### PR TITLE
[Dev] Support FP8 Codegen for cuda backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,11 @@ jobs:
         python-version: '3.9'
 
     - name: Create virtual environment
-      run: python -m venv bitblas_ci
+      run: python -m venv tilelang_ci
 
     - name: Activate virtual environment and install dependencies
       run: |
-        source bitblas_ci/bin/activate
+        source tilelang_ci/bin/activate
         python -m pip install --upgrade pip
         if [ -f requirements-dev.txt ]; then python -m pip install -r requirements-dev.txt; fi
 
@@ -31,7 +31,7 @@ jobs:
 
     - name: Run format check
       run: |
-        source bitblas_ci/bin/activate
+        source tilelang_ci/bin/activate
         ./format.sh
 
   build-test:
@@ -50,21 +50,21 @@ jobs:
         python-version: '3.9'
 
     - name: Create virtual environment
-      run: python -m venv bitblas_ci
+      run: python -m venv tilelang_ci
 
     - name: Activate virtual environment and install dependencies
       run: |
-        source bitblas_ci/bin/activate
+        source tilelang_ci/bin/activate
         python -m pip install --upgrade pip
         if [ -f requirements-test.txt ]; then python -m pip install -r requirements-test.txt; fi
 
     - name: Install project in wheel mode
       run: |
-        source bitblas_ci/bin/activate
+        source tilelang_ci/bin/activate
         python -m pip install .
 
     - name: Run tests
       run: |
-        source bitblas_ci/bin/activate
+        source tilelang_ci/bin/activate
         cd testing/python
         python -m pytest

--- a/src/target/codegen_cuda.cc
+++ b/src/target/codegen_cuda.cc
@@ -114,19 +114,6 @@ std::string CodeGenTileLangCUDA::Finish() {
     decl_stream << "#include <math_constants.h>\n";
   }
 
-  if (need_cast_smem_ptr_to_int_) {
-    decl_stream << "__forceinline__ __device__ unsigned int\n";
-    decl_stream << "cast_smem_ptr_to_int(const void* const smem_ptr)\n";
-    decl_stream << "{\n";
-    decl_stream << "  unsigned int smem_int;\n";
-    decl_stream << "  asm volatile (\"{ .reg .u64 smem_int; cvta.to.shared.u64 "
-                   "smem_int, %1; "
-                   "cvt.u32.u64 %0, smem_int; }\"\n";
-    decl_stream << "    : \"=r\"(smem_int) : \"l\"(smem_ptr));\n";
-    decl_stream << "  return smem_int;\n";
-    decl_stream << "}\n";
-  }
-
   decl_stream << "#include <tl_templates/cuda/gemm.h>\n";
   decl_stream << "#include <tl_templates/cuda/copy.h>\n";
   decl_stream << "#include <tl_templates/cuda/reduce.h>\n";

--- a/src/target/codegen_cuda.h
+++ b/src/target/codegen_cuda.h
@@ -73,14 +73,37 @@ private:
 
   friend void PrintConst(const FloatImmNode *op, std::ostream &os,
                          CodeGenTileLangCUDA *p);
-  // The size of the barrier array in shared memory
-  int barrier_count_ = -1;
+
+  // Whether global barrier is needed.
+  bool need_global_barrier_{false};
+  // Global barrier state
+  std::string vid_global_barrier_state_;
+  // Global barrier expected node.
+  std::string vid_global_barrier_expect_;
+  // whether enable fp16
+  bool enable_fp16_{false};
+  // whether enable bf16
+  bool enable_bf16_{false};
+  // whether enable fp8
+  bool enable_fp8_{false};
+  // whether enable int8
+  bool enable_int8_{false};
+  // whether enable warp shuffle intrinsics
+  bool enable_warp_shuffle_{false};
+  // whether need math_constants.h
+  bool need_math_constants_h_{false};
   // whether need mma.h
   bool need_mma_h_{false};
   // whether need cast_smem_ptr_to_int helper function
   bool need_cast_smem_ptr_to_int_{false};
+  // Op attribute map
+  OpAttrMap<bool> op_need_warp_shuffle_ =
+      Op::GetAttrMap<bool>("cuda.need_warp_shuffle");
+
   // The name of the barrier array in shared memory
   const std::string barrier_name_ = "barrier";
+  // The size of the barrier array in shared memory
+  int barrier_count_ = -1;
   // The alignment of the barrier array in shared memory
   // Set to 16 to maintain minimum alignment requirements for async bulk copy
   const int barrier_alignment_bytes_ = 16;

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -44,9 +44,19 @@ TL_DEVICE unsigned __pack_half2(const bfloat16_t x, const bfloat16_t y) {
   return (v1 << 16) | v0;
 }
 
-/// Helper to cast SMEM pointer to unsigned
+// Helper to cast SMEM pointer to unsigned
 TL_DEVICE uint32_t smem_ptr_to_uint(void const *const ptr) {
   return static_cast<uint32_t>(__cvta_generic_to_shared(ptr));
+}
+
+// Helper to cast SMEM pointer to unsigned
+TL_DEVICE unsigned int
+cast_smem_ptr_to_int(const void* const smem_ptr)
+{
+  unsigned int smem_int;
+  asm volatile ("{ .reg .u64 smem_int; cvta.to.shared.u64 smem_int, %1; cvt.u32.u64 %0, smem_int; }"
+    : "=r"(smem_int) : "l"(smem_ptr));
+  return smem_int;
 }
 
 // AtomicAdd Functions for FP16

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -50,12 +50,12 @@ TL_DEVICE uint32_t smem_ptr_to_uint(void const *const ptr) {
 }
 
 // Helper to cast SMEM pointer to unsigned
-TL_DEVICE unsigned int
-cast_smem_ptr_to_int(const void* const smem_ptr)
-{
+TL_DEVICE unsigned int cast_smem_ptr_to_int(const void *const smem_ptr) {
   unsigned int smem_int;
-  asm volatile ("{ .reg .u64 smem_int; cvta.to.shared.u64 smem_int, %1; cvt.u32.u64 %0, smem_int; }"
-    : "=r"(smem_int) : "l"(smem_ptr));
+  asm volatile("{ .reg .u64 smem_int; cvta.to.shared.u64 smem_int, %1; "
+               "cvt.u32.u64 %0, smem_int; }"
+               : "=r"(smem_int)
+               : "l"(smem_ptr));
   return smem_int;
 }
 

--- a/src/tl_templates/cuda/cuda_fp8.h
+++ b/src/tl_templates/cuda/cuda_fp8.h
@@ -7,17 +7,17 @@ using fp8_e4_t = __nv_fp8_e4m3;
 using fp8_e4_2_t = __nv_fp8x2_e4m3;
 using fp8_e4_4_t = __nv_fp8x4_e4m3;
 struct fp8_e4_8_t {
- fp8_e4_t data[8]; 
+  fp8_e4_t data[8];
 };
 struct fp8_e4_16_t {
- fp8_e4_t data[16]; 
+  fp8_e4_t data[16];
 };
 using fp8_e5_t = __nv_fp8_e5m2;
 using fp8_e5_2_t = __nv_fp8x2_e5m2;
 using fp8_e5_4_t = __nv_fp8x4_e5m2;
 struct fp8_e5_8_t {
- fp8_e5_t data[8]; 
+  fp8_e5_t data[8];
 };
 struct fp8_e5_16_t {
- fp8_e5_t data[16]; 
+  fp8_e5_t data[16];
 };

--- a/src/tl_templates/cuda/cuda_fp8.h
+++ b/src/tl_templates/cuda/cuda_fp8.h
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+#pragma once
+
+#include <cuda_fp8.h>
+using fp8_e4_t = __nv_fp8_e4m3;
+using fp8_e4_2_t = __nv_fp8x2_e4m3;
+using fp8_e4_4_t = __nv_fp8x4_e4m3;
+struct fp8_e4_8_t {
+ fp8_e4_t data[8]; 
+};
+struct fp8_e4_16_t {
+ fp8_e4_t data[16]; 
+};
+using fp8_e5_t = __nv_fp8_e5m2;
+using fp8_e5_2_t = __nv_fp8x2_e5m2;
+using fp8_e5_4_t = __nv_fp8x4_e5m2;
+struct fp8_e5_8_t {
+ fp8_e5_t data[8]; 
+};
+struct fp8_e5_16_t {
+ fp8_e5_t data[16]; 
+};

--- a/src/transform/vectorize_loop.cc
+++ b/src/transform/vectorize_loop.cc
@@ -1,0 +1,825 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file vectorize_loop.cc
+ */
+// Loop vectorizer as in Halide pipeline.
+#include <tvm/arith/analyzer.h>
+#include <tvm/runtime/registry.h>
+#include <tvm/tir/analysis.h>
+#include <tvm/tir/builtin.h>
+#include <tvm/tir/expr.h>
+#include <tvm/tir/op.h>
+#include <tvm/tir/op_attr_types.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
+
+#include <unordered_map>
+#include <vector>
+
+#include "arith/scalable_expression.h"
+#include "tir/analysis/check_contains.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tir;
+
+/*!
+ * \brief Perform data type legalization on the given BufferLoadNode pointer.
+ * Equal to BufferLoadNode::LegalizeDType, but operates on a pointer.
+ * \param n A pointer to a writable BufferLoadNode.
+ */
+static void LegalizeBufferLoadDType(BufferLoadNode* n) {
+  // Check that all indices except the last one have a scalar dtype
+  for (int i = 0; i < static_cast<int>(n->indices.size()) - 1; i++) {
+    ICHECK(n->indices[i].dtype().is_scalar())
+        << "Only the last index of a buffer access may be a vector type.";
+  }
+
+  // If there are no indices, set the dtype to the buffer's dtype
+  if (n->indices.empty()) {
+    n->dtype = n->buffer->dtype;
+  } else {
+    auto index_dtype = n->indices.back().dtype();
+    bool is_buffer_dtype_scalable = n->buffer->dtype.is_scalable_vector();
+    bool is_index_scalable        = index_dtype.is_scalable_vector();
+
+    // Do not allow both index dtype and buffer dtype to be scalable vectors
+    ICHECK(!(is_index_scalable && is_buffer_dtype_scalable))
+        << "Index dtype and buffer dtype cannot both be scalable.";
+
+    if (is_index_scalable) {
+      // Index is a scalable vector, while the buffer is not
+      n->dtype = n->buffer->dtype.with_scalable_vscale_factor(
+          index_dtype.vscale_factor() * n->buffer->dtype.lanes());
+    } else if (is_buffer_dtype_scalable) {
+      // The buffer is a scalable vector, while the index is not
+      n->dtype = n->buffer->dtype.with_scalable_vscale_factor(
+          n->buffer->dtype.vscale_factor() * index_dtype.lanes());
+    } else {
+      // Neither side is a scalable vector, multiply lanes
+      n->dtype = n->buffer->dtype.with_lanes(
+          index_dtype.lanes() * n->buffer->dtype.lanes());
+    }
+  }
+}
+
+inline PrimExpr CreateNewLanes(bool is_scalable, int lanes_or_vscale_factor) {
+  if (is_scalable) {
+    return Mul(Call(DataType::Int(32), builtin::vscale(), {}), lanes_or_vscale_factor);
+  } else {
+    return lanes_or_vscale_factor;
+  }
+}
+
+inline PrimExpr BroadcastTo(PrimExpr e, int lanes, bool is_scalable) {
+  // Check if e is already in the expected form
+  if (e.dtype().get_lanes_or_vscale_factor() == lanes &&
+      e.dtype().is_scalable_vector() == is_scalable)
+    return e;
+
+  if (const BroadcastNode* op = e.as<BroadcastNode>()) {
+    ICHECK(op->dtype.is_scalable_vector() == is_scalable)
+        << "Can't broadcast between scalable and fixed length vectors.";
+    int e_lanes = op->dtype.get_lanes_or_vscale_factor();
+
+    if (lanes % e_lanes == 0) {
+      return Broadcast(op->value, CreateNewLanes(is_scalable, lanes));
+    }
+  }
+
+  ICHECK(e.dtype().is_scalar()) << "Cannot broadcast lanes="
+                                << e.dtype().get_lanes_or_vscale_factor()
+                                << " is_scalable=" << e.dtype().is_scalable_vector() << " to "
+                                << lanes;
+
+  return Broadcast(e, CreateNewLanes(is_scalable, lanes));
+}
+
+// Rewrite vectorized allocation access
+// This is necessary for making each vector component containing its own workspace.
+// Originates from Halide's loop vectorizer
+//
+// s[i] = s[i * lanes + var]
+//
+// The same principle applies when using one thread to simulate multiple context.
+//
+class VecAllocAccess : public StmtExprMutator {
+ public:
+  VecAllocAccess(const VarNode* buf, Var var, PrimExpr var_lanes)
+      : buf_(buf), var_(var), var_lanes_(var_lanes) {}
+
+  PrimExpr VisitExpr_(const BufferLoadNode* op) final {
+    auto load = Downcast<BufferLoad>(StmtExprMutator::VisitExpr_(op));
+    return UpdateBufferAccess(load);
+  }
+
+  Stmt VisitStmt_(const BufferStoreNode* op) final {
+    auto store = Downcast<BufferStore>(StmtExprMutator::VisitStmt_(op));
+    return UpdateBufferAccess(store);
+  }
+
+ private:
+  template <typename Node>
+  Node UpdateBufferAccess(Node node) {
+    // Only update the buffer that's being replaced.
+    if (node->buffer->data.get() != buf_) {
+      return node;
+    }
+
+    // Find/make a Buffer object with the correct updated shape.
+    Buffer buf;
+    auto it = buffer_map_.find(node->buffer.get());
+    if (it != buffer_map_.end()) {
+      buf = it->second;
+    } else {
+      // Extend the least significant dimension by a factor of
+      // var_lanes_.  Typically, this will be a 1-d index into a flat
+      // memory space.
+      Array<PrimExpr> shape = node->buffer->shape;
+      shape.Set(shape.size() - 1, analyzer_.Simplify(shape[shape.size() - 1] * var_lanes_));
+
+      // TODO(Lunderberg): Move this pass to be prior to
+      // StorageFlatten/FlattenBuffer, implement by appending a
+      // dimension to the buffer.  Since it is currently after the
+      // flattening, the strides are not technically necessary, but
+      // are updated for consistency.
+
+      // Update strides if defined.
+      Array<PrimExpr> strides;
+      for (size_t i = 0; i < strides.size(); i++) {
+        PrimExpr stride = strides[i];
+        if (i != strides.size() - 1) {
+          stride *= var_lanes_;
+        }
+        strides.push_back(analyzer_.Simplify(stride));
+      }
+
+      // Copy everything into the new buffer.
+      buf = node->buffer;
+      auto buf_writer = buf.CopyOnWrite();
+      buf_writer->shape = shape;
+      buf_writer->strides = strides;
+      buffer_map_[buf.get()] = buf;
+    }
+
+    // Extend the last index by the number of lanes in the vectorized
+    // variable.
+    Array<PrimExpr> indices = node->indices;
+    indices.Set(indices.size() - 1,
+                analyzer_.Simplify(indices[indices.size() - 1] * var_lanes_ + var_));
+
+    auto writer = node.CopyOnWrite();
+    writer->buffer = buf;
+    writer->indices = indices;
+    return node;
+  }
+
+  // buffer var
+  const VarNode* buf_;
+  // Updated buffer objects.
+  std::unordered_map<const BufferNode*, Buffer> buffer_map_;
+  // variable to be replaced
+  Var var_;
+  // the lanes.
+  PrimExpr var_lanes_;
+  // Analyzer for simplifications
+  arith::Analyzer analyzer_;
+};
+
+// We use ExprFunctor directly instead of StmtExprMutator
+// This is because the transformation can change the dtype of the Expr
+// The existing ExprMutator transformation rules may not be well defined.
+class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimExpr&)> {
+ public:
+  using ExprFunctor::VisitExpr;
+  using StmtMutator::operator();
+
+  TLVectorizer(Var var, PrimExpr var_lanes) : var_(var), var_lanes_(var_lanes) {
+    ramp_ = Ramp(IntImm(var->dtype, 0), IntImm(var->dtype, 1), var_lanes);
+  }
+
+  Stmt VisitStmt(const Stmt& stmt) final {
+    ICHECK(!need_scalarize_);
+    Stmt ret = StmtMutator::VisitStmt(stmt);
+    if (need_scalarize_) {
+      need_scalarize_ = false;
+      return Scalarize(stmt);
+    } else {
+      return ret;
+    }
+  }
+
+  PrimExpr VisitExpr(const PrimExpr& e) final { return ExprFunctor::VisitExpr(e); }
+
+  PrimExpr VisitExpr_(const AddNode* op) final {
+    return AddSubVec(op, [](PrimExpr a, PrimExpr b) { return a + b; });
+  }
+
+  PrimExpr VisitExpr_(const SubNode* op) final {
+    return AddSubVec(op, [](PrimExpr a, PrimExpr b) { return a - b; });
+  }
+
+  PrimExpr VisitExpr_(const MulNode* op) final {
+    PrimExpr a = this->VisitExpr(op->a);
+    PrimExpr b = this->VisitExpr(op->b);
+    if (a.same_as(op->a) && b.same_as(op->b)) {
+      return GetRef<PrimExpr>(op);
+    } else {
+      bool is_vec_a = a.dtype().is_scalable_or_fixed_length_vector();
+      bool is_vec_b = b.dtype().is_scalable_or_fixed_length_vector();
+      if (is_vec_a && is_vec_b) {
+        // Let's not multiply scalable and fixed length vectors
+        ICHECK(a.dtype().is_scalable_vector() == b.dtype().is_scalable_vector())
+            << "Fixed length and scalable vectors can't be mixed in multiplication.";
+      }
+      if (is_vec_a || is_vec_b) {
+        const RampNode* b_ramp = b.as<RampNode>();
+        const RampNode* a_ramp = a.as<RampNode>();
+        if (a_ramp && b.dtype().is_scalar() && analyzer_.CanProve(b > 0)) {
+          PrimExpr lanes = a_ramp->lanes;
+          return Ramp(a_ramp->base * b, a_ramp->stride * b, lanes);
+        }
+        if (b_ramp && a.dtype().is_scalar() && analyzer_.CanProve(a > 0)) {
+          PrimExpr lanes = b_ramp->lanes;
+          return Ramp(b_ramp->base * a, b_ramp->stride * a, lanes);
+        }
+        int a_lanes = a.dtype().get_lanes_or_vscale_factor();
+        int b_lanes = b.dtype().get_lanes_or_vscale_factor();
+        int max_lanes = std::max(a_lanes, b_lanes);
+        bool is_scalable = a.dtype().is_scalable_vector() || b.dtype().is_scalable_vector();
+        return Mul(BroadcastTo(a, max_lanes, is_scalable), BroadcastTo(b, max_lanes, is_scalable));
+      }
+    }
+    return BinaryVec<Mul>(op);
+  }
+  PrimExpr VisitExpr_(const DivNode* op) final { return BinaryVec<Div>(op); }
+  PrimExpr VisitExpr_(const ModNode* op) final { return BinaryVec<Mod>(op); }
+  PrimExpr VisitExpr_(const FloorDivNode* op) final { return BinaryVec<FloorDiv>(op); }
+  PrimExpr VisitExpr_(const FloorModNode* op) final { return BinaryVec<FloorMod>(op); }
+  PrimExpr VisitExpr_(const MinNode* op) final { return BinaryVec<Min>(op); }
+  PrimExpr VisitExpr_(const MaxNode* op) final { return BinaryVec<Max>(op); }
+  PrimExpr VisitExpr_(const EQNode* op) final { return BinaryVec<EQ>(op); }
+  PrimExpr VisitExpr_(const NENode* op) final { return BinaryVec<NE>(op); }
+  PrimExpr VisitExpr_(const LTNode* op) final { return BinaryVec<LT>(op); }
+  PrimExpr VisitExpr_(const LENode* op) final { return BinaryVec<LE>(op); }
+  PrimExpr VisitExpr_(const GTNode* op) final { return BinaryVec<GT>(op); }
+  PrimExpr VisitExpr_(const GENode* op) final { return BinaryVec<GE>(op); }
+  PrimExpr VisitExpr_(const AndNode* op) final { return BinaryVec<And>(op); }
+  PrimExpr VisitExpr_(const OrNode* op) final { return BinaryVec<Or>(op); }
+
+  PrimExpr VisitExpr_(const NotNode* op) final {
+    PrimExpr a = this->VisitExpr(op->a);
+    if (a.same_as(op->a)) {
+      return GetRef<PrimExpr>(op);
+    } else {
+      return !(a);
+    }
+  }
+
+  PrimExpr VisitExpr_(const RampNode* op) final {
+    PrimExpr base = this->VisitExpr(op->base);
+    PrimExpr stride = this->VisitExpr(op->stride);
+    ICHECK(!base.dtype().is_scalable_vector())
+        << "Creating scalable vectors from existing vectors is not supported.";
+    ICHECK(!stride.dtype().is_scalable_vector())
+        << "Ramp stride with scalable dtype is not supported";
+    if (base.dtype().is_fixed_length_vector() && stride.dtype().is_scalar()) {
+      ICHECK(op->lanes->IsInstance<IntImmNode>())
+          << "Vectorizing over existing scalable vectors is not supported.";
+      const RampNode* base_ramp = base.as<RampNode>();
+      int op_lanes = static_cast<int>(Downcast<IntImm>(op->lanes)->value);
+      int base_ramp_lanes = static_cast<int>(Downcast<IntImm>(base_ramp->lanes)->value);
+      if (analyzer_.CanProve(base_ramp->stride ==
+                             stride * make_const(stride.dtype(), base_ramp_lanes))) {
+        return Ramp(base_ramp->base, stride, op_lanes * base_ramp_lanes);
+      }
+    }
+    int lanes = std::max(base.dtype().lanes(), stride.dtype().lanes());
+    base = BroadcastTo(base, lanes, false);
+    stride = BroadcastTo(stride, lanes, false);
+    Array<PrimExpr> elems;
+    for (int i = 0; i < lanes; ++i) {
+      elems.push_back(
+          Ramp(Shuffle::ExtractElement(base, i), Shuffle::ExtractElement(stride, i), op->lanes));
+    }
+    return Shuffle::Concat(elems);
+  }
+
+  PrimExpr VisitExpr_(const BroadcastNode* op) final {
+    PrimExpr value = this->VisitExpr(op->value);
+    if (value.dtype().is_scalable_or_fixed_length_vector()) {
+      need_scalarize_ = true;
+      return GetRef<PrimExpr>(op);
+    }
+    if (value.same_as(op->value)) {
+      return GetRef<PrimExpr>(op);
+    } else {
+      return Broadcast(op->value, op->lanes);
+    }
+  }
+
+  PrimExpr VisitExpr_(const SelectNode* op) final {
+    PrimExpr cond = this->VisitExpr(op->condition);
+    PrimExpr t = this->VisitExpr(op->true_value);
+    PrimExpr f = this->VisitExpr(op->false_value);
+    if (cond.same_as(op->condition) && t.same_as(op->true_value) && f.same_as(op->false_value)) {
+      return GetRef<PrimExpr>(op);
+    } else {
+      int cond_lanes = cond.dtype().get_lanes_or_vscale_factor();
+      int t_lanes = t.dtype().get_lanes_or_vscale_factor();
+      int f_lanes = f.dtype().get_lanes_or_vscale_factor();
+      int lanes = std::max(std::max(cond_lanes, t_lanes), f_lanes);
+      bool is_scalable = cond.dtype().is_scalable_vector() || t.dtype().is_scalable_vector() ||
+                         f.dtype().is_scalable_vector();
+      return Select(BroadcastTo(cond, lanes, is_scalable), BroadcastTo(t, lanes, is_scalable),
+                    BroadcastTo(f, lanes, is_scalable));
+    }
+  }
+
+  PrimExpr VisitExpr_(const CastNode* op) final {
+    PrimExpr value = this->VisitExpr(op->value);
+    if (value.same_as(op->value)) {
+      return GetRef<PrimExpr>(op);
+    } else {
+      if (value.dtype().is_scalable_vector()) {
+        return Cast(op->dtype.with_scalable_vscale_factor(value.dtype().vscale_factor()), value);
+      } else {
+        return Cast(op->dtype.with_lanes(value.dtype().lanes()), value);
+      }
+    }
+  }
+
+  PrimExpr VisitExpr_(const FloatImmNode* op) final { return GetRef<PrimExpr>(op); }
+
+  PrimExpr VisitExpr_(const IntImmNode* op) final { return GetRef<PrimExpr>(op); }
+
+  PrimExpr VisitExpr_(const StringImmNode* op) final { return GetRef<PrimExpr>(op); }
+
+  // Variable
+  PrimExpr VisitExpr_(const VarNode* op) final {
+    Var var = GetRef<Var>(op);
+
+    if (var.same_as(var_)) {
+      return ramp_;
+    }
+    auto it = let_binding_.find(var);
+    if (it != let_binding_.end()) {
+      return it->second;
+    } else {
+      return std::move(var);
+    }
+  }
+  // IfThenElse expr
+  PrimExpr MutateIfThenElseExpr_(const CallNode* op) {
+    PrimExpr cond = this->VisitExpr(op->args[0]);
+    if (cond.dtype().is_scalable_or_fixed_length_vector()) {
+      need_scalarize_ = true;
+      return GetRef<PrimExpr>(op);
+    }
+    PrimExpr t = this->VisitExpr(op->args[1]);
+    PrimExpr f = this->VisitExpr(op->args[2]);
+    if (cond.same_as(op->args[0]) && t.same_as(op->args[1]) && f.same_as(op->args[2])) {
+      return GetRef<PrimExpr>(op);
+    } else {
+      int t_lanes = t.dtype().get_lanes_or_vscale_factor();
+      int f_lanes = f.dtype().get_lanes_or_vscale_factor();
+      int lanes = std::max(t_lanes, f_lanes);
+      bool is_scalable = t.dtype().is_scalable_vector() || f.dtype().is_scalable_vector();
+      t = BroadcastTo(t, lanes, is_scalable);
+      f = BroadcastTo(f, lanes, is_scalable);
+      if (is_scalable) {
+        return Call(op->dtype.with_scalable_vscale_factor(lanes), op->op, {cond, t, f});
+      } else {
+        return Call(op->dtype.with_lanes(lanes), op->op, {cond, t, f});
+      }
+    }
+  }
+  // Reinterpret expr
+  PrimExpr MutateReinterpretExpr_(const CallNode* op) {
+    ICHECK(op->op.same_as(builtin::reinterpret()));
+    PrimExpr value = this->VisitExpr(op->args[0]);
+    if (value.same_as(op->args[0])) {
+      return GetRef<PrimExpr>(op);
+    } else {
+      int lanes = value.dtype().get_lanes_or_vscale_factor();
+      if (value.dtype().is_scalable_vector()) {
+        return Call(op->dtype.with_scalable_vscale_factor(lanes), op->op, {value});
+      } else {
+        return Call(op->dtype.with_lanes(lanes), op->op, {value});
+      }
+    }
+  }
+  // Call
+  PrimExpr VisitExpr_(const CallNode* op) final {
+    if (op->op.same_as(builtin::if_then_else())) {
+      return MutateIfThenElseExpr_(op);
+    } else if (op->op.same_as(builtin::texture2d_load())) {
+      int lane = 0;
+      Array<PrimExpr> fcd = MutateArray({op->args.back()}, &lane);
+      auto new_args = op->args;
+      new_args.pop_back();
+      new_args.push_back(fcd[0]);
+      return Call(op->dtype.with_lanes(4), op->op, new_args);
+    } else if (op->op.same_as(builtin::texture2d_store())) {
+      int lane = 0;
+      // Vectorize the value to store
+      Array<PrimExpr> value{op->args.back()};
+      Array<PrimExpr> mutated_value = MutateArray(value, &lane);
+      Array<PrimExpr> new_args{op->args[0], op->args[1], op->args[2], mutated_value[0]};
+      return Call(op->dtype.with_lanes(lane), op->op, new_args);
+    } else if (op->op.same_as(builtin::reinterpret())) {
+      return MutateReinterpretExpr_(op);
+    }
+    auto optional_op = op->op.as<Op>();
+    bool vectorizable = optional_op && op_vectorizable_.get(optional_op.value(), false) &&
+                        !op->dtype.is_scalable_vector();
+
+    if (!vectorizable) {
+      // Cannot vectorize this op
+      Array<PrimExpr> new_args;
+      for (auto arg : op->args) {
+        auto new_arg = this->VisitExpr(arg);
+        if (new_arg.dtype().is_scalable_or_fixed_length_vector()) {
+          need_scalarize_ = true;
+          return GetRef<PrimExpr>(op);
+        }
+        new_args.push_back(new_arg);
+      }
+      if (op->args.same_as(new_args)) {
+        return GetRef<PrimExpr>(op);
+      } else {
+        return Call(op->dtype, op->op, new_args);
+      }
+    } else {
+      int lane = 0;
+      Array<PrimExpr> new_args = MutateArray(op->args, &lane);
+      // normal code path.
+      if (op->args.same_as(new_args)) {
+        return GetRef<PrimExpr>(op);
+      } else {
+        return Call(op->dtype.with_lanes(lane), op->op, new_args);
+      }
+    }
+  }
+  // BufferLoad
+  PrimExpr VisitExpr_(const BufferLoadNode* op) final {
+    auto load = GetRef<BufferLoad>(op);
+
+    auto fmutate = [this](const PrimExpr& index) { return this->VisitExpr(index); };
+    Array<PrimExpr> indices = op->indices.Map(fmutate);
+
+    if (!indices.same_as(op->indices)) {
+      BufferLoadNode* writer = load.CopyOnWrite();
+      writer->indices = indices;
+      // writer->LegalizeDType();
+      LegalizeBufferLoadDType(writer);
+    }
+
+    return std::move(load);
+  }
+  // Let
+  PrimExpr VisitExpr_(const LetNode* op) final {
+    PrimExpr value = this->VisitExpr(op->value);
+    // Weaker SSA condition
+    // A single var can be binded in multiple lets
+    // but they have to bind to the same value.
+    // This is used to allow cases when we reuse a single let
+    // expression to cosntruct a nested expr.
+    // (let x = 1 in x + 1) * (let x = 1 in x + 1)
+    auto it = let_binding_.find(op->var);
+    if (it != let_binding_.end()) {
+      ICHECK(deep_equal_(it->second, value))
+          << "Let cannot bind the same var to two different values";
+    }
+    if (value.dtype().get_lanes_or_vscale_factor() !=
+        op->value.dtype().get_lanes_or_vscale_factor()) {
+      Var new_var(op->var->name_hint, value.dtype());
+      let_binding_[op->var] = new_var;
+      return Let(new_var, value, this->VisitExpr(op->body));
+    } else {
+      let_binding_[op->var] = op->var;
+      PrimExpr body = this->VisitExpr(op->body);
+      if (value.same_as(op->value) && body.same_as(op->body)) {
+        return GetRef<PrimExpr>(op);
+      } else {
+        return Let(op->var, value, body);
+      }
+    }
+  }
+  // BufferStore
+  Stmt VisitStmt_(const BufferStoreNode* op) final {
+    auto store = GetRef<BufferStore>(op);
+
+    auto fmutate = [this](const PrimExpr& index) { return this->VisitExpr(index); };
+    Array<PrimExpr> indices = op->indices.Map(fmutate);
+
+    PrimExpr value = this->VisitExpr(op->value);
+
+    if (!indices.same_as(op->indices) || !value.same_as(op->value)) {
+      ICHECK(!op->buffer->dtype.is_scalable_vector())
+          << "Vectorizing over scalable buffer elements is not supported in vectorizer.";
+      // How many lanes of indexing are present in the index and
+      // buffer element type, excluding the last index.
+      int other_index_lanes = op->buffer->dtype.lanes();
+      for (size_t i = 0; i < indices.size() - 1; i++) {
+        other_index_lanes *= indices[i].dtype().lanes();
+        // Only allow the last index to be scalable
+        ICHECK(!indices[i].dtype().is_scalable_vector()) << "Only the last index can be scalable.";
+      }
+
+      // The total number of lanes of indexing, including the last index.
+      auto last_index_dtype = indices[indices.size() - 1].dtype();
+      int lanes_in_last_index = last_index_dtype.get_lanes_or_vscale_factor();
+      int index_lanes = other_index_lanes * lanes_in_last_index;
+
+      // The total number of lanes in this store operation.  Either
+      // the index or the value will be broadcast out to this number
+      // of lanes, depending on which has more lanes.
+      int value_dtype_lanes = value.dtype().get_lanes_or_vscale_factor();
+      bool is_last_index_scalable = last_index_dtype.is_scalable_vector();
+      int total_lanes = std::max(index_lanes, value_dtype_lanes);
+
+      ICHECK_EQ(total_lanes % other_index_lanes, 0)
+          << "When storing to buffer " << op->buffer->name << ", cannot produce " << total_lanes
+          << " lanes of storage location by changing the last index.";
+      int last_index_lanes = total_lanes / other_index_lanes;
+
+      // Broadcast the last index such that the total number of index
+      // lanes matches the desired number.
+      indices.Set(indices.size() - 1, BroadcastTo(indices[indices.size() - 1], last_index_lanes,
+                                                  is_last_index_scalable));
+
+      auto writer = store.CopyOnWrite();
+      writer->indices = indices;
+      writer->value = BroadcastTo(value, total_lanes, is_last_index_scalable);
+    }
+
+    return std::move(store);
+  }
+  // For
+  Stmt VisitStmt_(const ForNode* op) final {
+    if (op->kind == ForKind::kVectorized) {
+      LOG(WARNING) << "Detect vectorize inside vectorized loop, ignoring...";
+    }
+    ICHECK(is_zero(op->min));
+    ICHECK(!op->extent.dtype().is_scalable_or_fixed_length_vector());
+    PrimExpr extent = this->VisitExpr(op->extent);
+    if (extent.dtype().is_scalable_or_fixed_length_vector()) {
+      return Scalarize(GetRef<Stmt>(op));
+    }
+    Stmt body = this->VisitStmt(op->body);
+    if (extent.same_as(op->extent) && body.same_as(op->body)) {
+      return GetRef<Stmt>(op);
+    } else {
+      return For(op->loop_var, op->min, extent, op->kind, body, op->thread_binding,
+                 op->annotations);
+    }
+  }
+  // IfThenElse
+  Stmt VisitStmt_(const IfThenElseNode* op) final {
+    ICHECK(!op->condition.dtype().is_scalable_or_fixed_length_vector());
+    PrimExpr condition = this->VisitExpr(op->condition);
+    if (condition.dtype().is_scalable_or_fixed_length_vector()) {
+      return Scalarize(GetRef<Stmt>(op));
+    }
+    Stmt then_case = this->VisitStmt(op->then_case);
+    Optional<Stmt> else_case = NullOpt;
+    if (op->else_case) {
+      else_case = this->VisitStmt(op->else_case.value());
+    }
+    if (condition.same_as(op->condition) && then_case.same_as(op->then_case) &&
+        else_case.same_as(op->else_case)) {
+      return GetRef<Stmt>(op);
+    } else {
+      return IfThenElse(condition, then_case, else_case);
+    }
+  }
+  // While
+  Stmt VisitStmt_(const WhileNode* op) final {
+    LOG(FATAL) << "A while loop inside a vectorized loop not supported.";
+  }
+  // LetStmt
+  Stmt VisitStmt_(const LetStmtNode* op) final {
+    PrimExpr value = this->VisitExpr(op->value);
+    ICHECK(!let_binding_.count(op->var)) << "SSA violation, a single var is binded twice";
+    let_binding_[op->var] = value;
+
+    if (value.dtype().get_lanes_or_vscale_factor() !=
+        op->value.dtype().get_lanes_or_vscale_factor()) {
+      Var new_var(op->var->name_hint, value.dtype());
+      let_binding_[op->var] = new_var;
+      return LetStmt(new_var, value, this->VisitStmt(op->body));
+    } else {
+      let_binding_[op->var] = op->var;
+      Stmt body = this->VisitStmt(op->body);
+      if (value.same_as(op->value) && body.same_as(op->body)) {
+        return GetRef<Stmt>(op);
+      } else {
+        return LetStmt(op->var, value, body);
+      }
+    }
+  }
+  // Allocate
+  Stmt VisitStmt_(const AllocateNode* op) final {
+    // Mutate the condition
+    PrimExpr condition = this->VisitExpr(op->condition);
+    if (condition.dtype().is_scalable_or_fixed_length_vector()) {
+      LOG(WARNING) << "Cannot handle vector extent in alloc of " << op->buffer_var->name_hint;
+      return Scalarize(GetRef<Stmt>(op));
+    }
+
+    // Mutate the extents
+    Array<PrimExpr> extents;
+    for (const auto& extent : op->extents) {
+      PrimExpr new_ext = this->VisitExpr(extent);
+      if (new_ext.dtype().is_scalable_or_fixed_length_vector()) {
+        LOG(WARNING) << "Cannot handle vector extent in alloc of " << op->buffer_var->name_hint;
+        return Scalarize(GetRef<Stmt>(op));
+      }
+      extents.push_back(new_ext);
+    }
+
+    // TODO(Lunderberg): Move this pass to be prior to
+    // StorageFlatten/FlattenBuffer.  That will allow this pass to be
+    // implemented as adding a new buffer dimension, which is later
+    // flattened.
+
+    // Extend the least significant dimension by a factor of
+    // var_lanes_.  Typically, this will be a 1-d index into a flat
+    // memory space.
+    extents.Set(extents.size() - 1, extents[extents.size() - 1] * var_lanes_);
+
+    // Rewrite access to the buffer in the body.
+    Stmt body = VecAllocAccess(op->buffer_var.get(), var_, var_lanes_)(op->body);
+    body = this->VisitStmt(body);
+    return Allocate(op->buffer_var, op->dtype, extents, condition, body);
+  }
+
+  // scalarize the statment
+  Stmt Scalarize(Stmt stmt) {
+    Var idx(var_->name_hint + ".s", var_->dtype);
+    stmt = Substitute(stmt, {{var_, idx}});
+    return For(idx, IntImm(var_->dtype, 0), var_lanes_, ForKind::kSerial, stmt);
+  }
+  // ProducerStore
+  Stmt VisitStmt_(const ProducerStoreNode* op) final {
+    LOG(FATAL) << "ProducerProvide cannot appear in a TIR PrimFunc";
+  }
+
+ private:
+  // analyzer
+  arith::Analyzer analyzer_;
+  // deep equal
+  ExprDeepEqual deep_equal_;
+  // variable to be replaced
+  Var var_;
+  // the lanes.
+  PrimExpr var_lanes_;
+  // ramp representing the var.
+  PrimExpr ramp_;
+  // flag to mark requirment of scalarization.
+  bool need_scalarize_{false};
+  // Let binding
+  std::unordered_map<Var, PrimExpr, ObjectPtrHash, ObjectPtrEqual> let_binding_;
+  // vectorizable property
+  OpAttrMap<TVectorizable> op_vectorizable_ = Op::GetAttrMap<TVectorizable>("TVectorizable");
+
+  // mutate array, with given lane requirement
+  // when finished, p_lane updates the lane requirement.
+  Array<PrimExpr> MutateArray(Array<PrimExpr> arr, int* p_lanes) {
+    if (arr.size() == 0) return arr;
+    int& lanes = *p_lanes;
+    bool changed = false;
+    std::vector<PrimExpr> new_arr(arr.size());
+    for (size_t i = 0; i < arr.size(); i++) {
+      PrimExpr old_elem = arr[i];
+      PrimExpr new_elem = this->VisitExpr(old_elem);
+      if (!new_elem.same_as(old_elem)) changed = true;
+      new_arr[i] = new_elem;
+      lanes = std::max(lanes, new_elem.dtype().lanes());
+    }
+
+    for (size_t i = 0; i < arr.size(); ++i) {
+      if (new_arr[i].dtype().lanes() != lanes) {
+        new_arr[i] = BroadcastTo(new_arr[i], lanes, false);
+        changed = true;
+      }
+    }
+    if (!changed) return arr;
+    return Array<PrimExpr>(new_arr);
+  }
+  template <typename TOp, typename T>
+  PrimExpr BinaryVec(const T* op) {
+    static_assert(std::is_same<typename TOp::ContainerType, T>::value, "constraint");
+    PrimExpr a = this->VisitExpr(op->a);
+    PrimExpr b = this->VisitExpr(op->b);
+    if (a.same_as(op->a) && b.same_as(op->b)) {
+      return GetRef<PrimExpr>(op);
+    } else {
+      int a_lanes = a.dtype().get_lanes_or_vscale_factor();
+      int b_lanes = b.dtype().get_lanes_or_vscale_factor();
+      int lanes = std::max(a_lanes, b_lanes);
+      bool is_scalable = a.dtype().is_scalable_vector() || b.dtype().is_scalable_vector();
+      return TOp(BroadcastTo(a, lanes, is_scalable), BroadcastTo(b, lanes, is_scalable));
+    }
+  }
+  template <typename T, typename FCompute>
+  PrimExpr AddSubVec(const T* op, FCompute fcompute) {
+    PrimExpr a = this->VisitExpr(op->a);
+    PrimExpr b = this->VisitExpr(op->b);
+    if (a.same_as(op->a) && b.same_as(op->b)) {
+      return GetRef<PrimExpr>(op);
+    } else {
+      int a_lanes = a.dtype().get_lanes_or_vscale_factor();
+      int b_lanes = b.dtype().get_lanes_or_vscale_factor();
+      int lanes = std::max(a_lanes, b_lanes);
+      if (lanes != 1) {
+        const RampNode* b_ramp = b.as<RampNode>();
+        const RampNode* a_ramp = a.as<RampNode>();
+        if (a.dtype().is_scalar() && b_ramp) {
+          return Ramp(fcompute(a, b_ramp->base),
+                      fcompute(make_zero(b_ramp->stride.dtype()), b_ramp->stride), b_ramp->lanes);
+        }
+        if (b.dtype().is_scalar() && a_ramp) {
+          return Ramp(fcompute(a_ramp->base, b), a_ramp->stride, a_ramp->lanes);
+        }
+      }
+      bool is_scalable = a.dtype().is_scalable_vector() || b.dtype().is_scalable_vector();
+      return fcompute(BroadcastTo(a, lanes, is_scalable), BroadcastTo(b, lanes, is_scalable));
+    }
+  }
+};
+
+class LoopVectorizer : public StmtMutator {
+ public:
+  Stmt VisitStmt_(const ForNode* op) final {
+    if (op->kind == ForKind::kVectorized) {
+      auto* extent_as_int = op->extent.as<IntImmNode>();
+
+      if (!extent_as_int || extent_as_int->value < 1) {
+        bool is_scalable_expr = CheckContains::ExprContains(op->extent, arith::IsVScaleCall);
+        ICHECK(is_scalable_expr && arith::TargetHasSVE())
+            << "Failed to vectorize loop with extent " << op->extent << " for target "
+            << Target::Current();
+      }
+      ICHECK(is_zero(op->min));
+      return TLVectorizer(op->loop_var, op->extent)(op->body);
+    } else {
+      return StmtMutator::VisitStmt_(op);
+    }
+  }
+};
+
+class VectorizeSkipper : public StmtMutator {
+ public:
+  Stmt VisitStmt_(const ForNode* op) final {
+    Stmt stmt = StmtMutator::VisitStmt_(op);
+    op = stmt.as<ForNode>();
+    if (op->kind == ForKind::kVectorized) {
+      return For(op->loop_var, op->min, op->extent, ForKind::kSerial, op->body);
+    } else {
+      return stmt;
+    }
+  }
+};
+
+Stmt SkipVectorize(Stmt stmt) { return VectorizeSkipper()(std::move(stmt)); }
+
+
+tvm::transform::Pass VectorizeLoop(bool enable_vectorize = true) {
+  using namespace tir::transform;
+  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+    auto* n = f.CopyOnWrite();
+    if (enable_vectorize) {
+      n->body = tvm::tl::LoopVectorizer()(std::move(n->body));
+    } else {
+      n->body = tvm::tl::VectorizeSkipper()(std::move(n->body));
+    }
+    return f;
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.VectorizeLoop", {});
+}
+
+TVM_REGISTER_GLOBAL("tl.transform.VectorizeLoop").set_body_typed(VectorizeLoop);
+
+}  // namespace tl
+}  // namespace tvm

--- a/src/transform/vectorize_loop.cc
+++ b/src/transform/vectorize_loop.cc
@@ -47,7 +47,7 @@ using namespace tir;
  * Equal to BufferLoadNode::LegalizeDType, but operates on a pointer.
  * \param n A pointer to a writable BufferLoadNode.
  */
-static void LegalizeBufferLoadDType(BufferLoadNode* n) {
+static void LegalizeBufferLoadDType(BufferLoadNode *n) {
   // Check that all indices except the last one have a scalar dtype
   for (int i = 0; i < static_cast<int>(n->indices.size()) - 1; i++) {
     ICHECK(n->indices[i].dtype().is_scalar())
@@ -60,7 +60,7 @@ static void LegalizeBufferLoadDType(BufferLoadNode* n) {
   } else {
     auto index_dtype = n->indices.back().dtype();
     bool is_buffer_dtype_scalable = n->buffer->dtype.is_scalable_vector();
-    bool is_index_scalable        = index_dtype.is_scalable_vector();
+    bool is_index_scalable = index_dtype.is_scalable_vector();
 
     // Do not allow both index dtype and buffer dtype to be scalable vectors
     ICHECK(!(is_index_scalable && is_buffer_dtype_scalable))
@@ -76,15 +76,16 @@ static void LegalizeBufferLoadDType(BufferLoadNode* n) {
           n->buffer->dtype.vscale_factor() * index_dtype.lanes());
     } else {
       // Neither side is a scalable vector, multiply lanes
-      n->dtype = n->buffer->dtype.with_lanes(
-          index_dtype.lanes() * n->buffer->dtype.lanes());
+      n->dtype = n->buffer->dtype.with_lanes(index_dtype.lanes() *
+                                             n->buffer->dtype.lanes());
     }
   }
 }
 
 inline PrimExpr CreateNewLanes(bool is_scalable, int lanes_or_vscale_factor) {
   if (is_scalable) {
-    return Mul(Call(DataType::Int(32), builtin::vscale(), {}), lanes_or_vscale_factor);
+    return Mul(Call(DataType::Int(32), builtin::vscale(), {}),
+               lanes_or_vscale_factor);
   } else {
     return lanes_or_vscale_factor;
   }
@@ -96,7 +97,7 @@ inline PrimExpr BroadcastTo(PrimExpr e, int lanes, bool is_scalable) {
       e.dtype().is_scalable_vector() == is_scalable)
     return e;
 
-  if (const BroadcastNode* op = e.as<BroadcastNode>()) {
+  if (const BroadcastNode *op = e.as<BroadcastNode>()) {
     ICHECK(op->dtype.is_scalable_vector() == is_scalable)
         << "Can't broadcast between scalable and fixed length vectors.";
     int e_lanes = op->dtype.get_lanes_or_vscale_factor();
@@ -106,40 +107,39 @@ inline PrimExpr BroadcastTo(PrimExpr e, int lanes, bool is_scalable) {
     }
   }
 
-  ICHECK(e.dtype().is_scalar()) << "Cannot broadcast lanes="
-                                << e.dtype().get_lanes_or_vscale_factor()
-                                << " is_scalable=" << e.dtype().is_scalable_vector() << " to "
-                                << lanes;
+  ICHECK(e.dtype().is_scalar())
+      << "Cannot broadcast lanes=" << e.dtype().get_lanes_or_vscale_factor()
+      << " is_scalable=" << e.dtype().is_scalable_vector() << " to " << lanes;
 
   return Broadcast(e, CreateNewLanes(is_scalable, lanes));
 }
 
 // Rewrite vectorized allocation access
-// This is necessary for making each vector component containing its own workspace.
-// Originates from Halide's loop vectorizer
+// This is necessary for making each vector component containing its own
+// workspace. Originates from Halide's loop vectorizer
 //
 // s[i] = s[i * lanes + var]
 //
-// The same principle applies when using one thread to simulate multiple context.
+// The same principle applies when using one thread to simulate multiple
+// context.
 //
 class VecAllocAccess : public StmtExprMutator {
- public:
-  VecAllocAccess(const VarNode* buf, Var var, PrimExpr var_lanes)
+public:
+  VecAllocAccess(const VarNode *buf, Var var, PrimExpr var_lanes)
       : buf_(buf), var_(var), var_lanes_(var_lanes) {}
 
-  PrimExpr VisitExpr_(const BufferLoadNode* op) final {
+  PrimExpr VisitExpr_(const BufferLoadNode *op) final {
     auto load = Downcast<BufferLoad>(StmtExprMutator::VisitExpr_(op));
     return UpdateBufferAccess(load);
   }
 
-  Stmt VisitStmt_(const BufferStoreNode* op) final {
+  Stmt VisitStmt_(const BufferStoreNode *op) final {
     auto store = Downcast<BufferStore>(StmtExprMutator::VisitStmt_(op));
     return UpdateBufferAccess(store);
   }
 
- private:
-  template <typename Node>
-  Node UpdateBufferAccess(Node node) {
+private:
+  template <typename Node> Node UpdateBufferAccess(Node node) {
     // Only update the buffer that's being replaced.
     if (node->buffer->data.get() != buf_) {
       return node;
@@ -155,7 +155,8 @@ class VecAllocAccess : public StmtExprMutator {
       // var_lanes_.  Typically, this will be a 1-d index into a flat
       // memory space.
       Array<PrimExpr> shape = node->buffer->shape;
-      shape.Set(shape.size() - 1, analyzer_.Simplify(shape[shape.size() - 1] * var_lanes_));
+      shape.Set(shape.size() - 1,
+                analyzer_.Simplify(shape[shape.size() - 1] * var_lanes_));
 
       // TODO(Lunderberg): Move this pass to be prior to
       // StorageFlatten/FlattenBuffer, implement by appending a
@@ -184,8 +185,9 @@ class VecAllocAccess : public StmtExprMutator {
     // Extend the last index by the number of lanes in the vectorized
     // variable.
     Array<PrimExpr> indices = node->indices;
-    indices.Set(indices.size() - 1,
-                analyzer_.Simplify(indices[indices.size() - 1] * var_lanes_ + var_));
+    indices.Set(
+        indices.size() - 1,
+        analyzer_.Simplify(indices[indices.size() - 1] * var_lanes_ + var_));
 
     auto writer = node.CopyOnWrite();
     writer->buffer = buf;
@@ -194,9 +196,9 @@ class VecAllocAccess : public StmtExprMutator {
   }
 
   // buffer var
-  const VarNode* buf_;
+  const VarNode *buf_;
   // Updated buffer objects.
-  std::unordered_map<const BufferNode*, Buffer> buffer_map_;
+  std::unordered_map<const BufferNode *, Buffer> buffer_map_;
   // variable to be replaced
   Var var_;
   // the lanes.
@@ -208,8 +210,9 @@ class VecAllocAccess : public StmtExprMutator {
 // We use ExprFunctor directly instead of StmtExprMutator
 // This is because the transformation can change the dtype of the Expr
 // The existing ExprMutator transformation rules may not be well defined.
-class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimExpr&)> {
- public:
+class TLVectorizer : public StmtMutator,
+                     public ExprFunctor<PrimExpr(const PrimExpr &)> {
+public:
   using ExprFunctor::VisitExpr;
   using StmtMutator::operator();
 
@@ -217,7 +220,7 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
     ramp_ = Ramp(IntImm(var->dtype, 0), IntImm(var->dtype, 1), var_lanes);
   }
 
-  Stmt VisitStmt(const Stmt& stmt) final {
+  Stmt VisitStmt(const Stmt &stmt) final {
     ICHECK(!need_scalarize_);
     Stmt ret = StmtMutator::VisitStmt(stmt);
     if (need_scalarize_) {
@@ -228,17 +231,19 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
     }
   }
 
-  PrimExpr VisitExpr(const PrimExpr& e) final { return ExprFunctor::VisitExpr(e); }
+  PrimExpr VisitExpr(const PrimExpr &e) final {
+    return ExprFunctor::VisitExpr(e);
+  }
 
-  PrimExpr VisitExpr_(const AddNode* op) final {
+  PrimExpr VisitExpr_(const AddNode *op) final {
     return AddSubVec(op, [](PrimExpr a, PrimExpr b) { return a + b; });
   }
 
-  PrimExpr VisitExpr_(const SubNode* op) final {
+  PrimExpr VisitExpr_(const SubNode *op) final {
     return AddSubVec(op, [](PrimExpr a, PrimExpr b) { return a - b; });
   }
 
-  PrimExpr VisitExpr_(const MulNode* op) final {
+  PrimExpr VisitExpr_(const MulNode *op) final {
     PrimExpr a = this->VisitExpr(op->a);
     PrimExpr b = this->VisitExpr(op->b);
     if (a.same_as(op->a) && b.same_as(op->b)) {
@@ -249,11 +254,12 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
       if (is_vec_a && is_vec_b) {
         // Let's not multiply scalable and fixed length vectors
         ICHECK(a.dtype().is_scalable_vector() == b.dtype().is_scalable_vector())
-            << "Fixed length and scalable vectors can't be mixed in multiplication.";
+            << "Fixed length and scalable vectors can't be mixed in "
+               "multiplication.";
       }
       if (is_vec_a || is_vec_b) {
-        const RampNode* b_ramp = b.as<RampNode>();
-        const RampNode* a_ramp = a.as<RampNode>();
+        const RampNode *b_ramp = b.as<RampNode>();
+        const RampNode *a_ramp = a.as<RampNode>();
         if (a_ramp && b.dtype().is_scalar() && analyzer_.CanProve(b > 0)) {
           PrimExpr lanes = a_ramp->lanes;
           return Ramp(a_ramp->base * b, a_ramp->stride * b, lanes);
@@ -265,28 +271,34 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
         int a_lanes = a.dtype().get_lanes_or_vscale_factor();
         int b_lanes = b.dtype().get_lanes_or_vscale_factor();
         int max_lanes = std::max(a_lanes, b_lanes);
-        bool is_scalable = a.dtype().is_scalable_vector() || b.dtype().is_scalable_vector();
-        return Mul(BroadcastTo(a, max_lanes, is_scalable), BroadcastTo(b, max_lanes, is_scalable));
+        bool is_scalable =
+            a.dtype().is_scalable_vector() || b.dtype().is_scalable_vector();
+        return Mul(BroadcastTo(a, max_lanes, is_scalable),
+                   BroadcastTo(b, max_lanes, is_scalable));
       }
     }
     return BinaryVec<Mul>(op);
   }
-  PrimExpr VisitExpr_(const DivNode* op) final { return BinaryVec<Div>(op); }
-  PrimExpr VisitExpr_(const ModNode* op) final { return BinaryVec<Mod>(op); }
-  PrimExpr VisitExpr_(const FloorDivNode* op) final { return BinaryVec<FloorDiv>(op); }
-  PrimExpr VisitExpr_(const FloorModNode* op) final { return BinaryVec<FloorMod>(op); }
-  PrimExpr VisitExpr_(const MinNode* op) final { return BinaryVec<Min>(op); }
-  PrimExpr VisitExpr_(const MaxNode* op) final { return BinaryVec<Max>(op); }
-  PrimExpr VisitExpr_(const EQNode* op) final { return BinaryVec<EQ>(op); }
-  PrimExpr VisitExpr_(const NENode* op) final { return BinaryVec<NE>(op); }
-  PrimExpr VisitExpr_(const LTNode* op) final { return BinaryVec<LT>(op); }
-  PrimExpr VisitExpr_(const LENode* op) final { return BinaryVec<LE>(op); }
-  PrimExpr VisitExpr_(const GTNode* op) final { return BinaryVec<GT>(op); }
-  PrimExpr VisitExpr_(const GENode* op) final { return BinaryVec<GE>(op); }
-  PrimExpr VisitExpr_(const AndNode* op) final { return BinaryVec<And>(op); }
-  PrimExpr VisitExpr_(const OrNode* op) final { return BinaryVec<Or>(op); }
+  PrimExpr VisitExpr_(const DivNode *op) final { return BinaryVec<Div>(op); }
+  PrimExpr VisitExpr_(const ModNode *op) final { return BinaryVec<Mod>(op); }
+  PrimExpr VisitExpr_(const FloorDivNode *op) final {
+    return BinaryVec<FloorDiv>(op);
+  }
+  PrimExpr VisitExpr_(const FloorModNode *op) final {
+    return BinaryVec<FloorMod>(op);
+  }
+  PrimExpr VisitExpr_(const MinNode *op) final { return BinaryVec<Min>(op); }
+  PrimExpr VisitExpr_(const MaxNode *op) final { return BinaryVec<Max>(op); }
+  PrimExpr VisitExpr_(const EQNode *op) final { return BinaryVec<EQ>(op); }
+  PrimExpr VisitExpr_(const NENode *op) final { return BinaryVec<NE>(op); }
+  PrimExpr VisitExpr_(const LTNode *op) final { return BinaryVec<LT>(op); }
+  PrimExpr VisitExpr_(const LENode *op) final { return BinaryVec<LE>(op); }
+  PrimExpr VisitExpr_(const GTNode *op) final { return BinaryVec<GT>(op); }
+  PrimExpr VisitExpr_(const GENode *op) final { return BinaryVec<GE>(op); }
+  PrimExpr VisitExpr_(const AndNode *op) final { return BinaryVec<And>(op); }
+  PrimExpr VisitExpr_(const OrNode *op) final { return BinaryVec<Or>(op); }
 
-  PrimExpr VisitExpr_(const NotNode* op) final {
+  PrimExpr VisitExpr_(const NotNode *op) final {
     PrimExpr a = this->VisitExpr(op->a);
     if (a.same_as(op->a)) {
       return GetRef<PrimExpr>(op);
@@ -295,7 +307,7 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
     }
   }
 
-  PrimExpr VisitExpr_(const RampNode* op) final {
+  PrimExpr VisitExpr_(const RampNode *op) final {
     PrimExpr base = this->VisitExpr(op->base);
     PrimExpr stride = this->VisitExpr(op->stride);
     ICHECK(!base.dtype().is_scalable_vector())
@@ -305,11 +317,13 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
     if (base.dtype().is_fixed_length_vector() && stride.dtype().is_scalar()) {
       ICHECK(op->lanes->IsInstance<IntImmNode>())
           << "Vectorizing over existing scalable vectors is not supported.";
-      const RampNode* base_ramp = base.as<RampNode>();
+      const RampNode *base_ramp = base.as<RampNode>();
       int op_lanes = static_cast<int>(Downcast<IntImm>(op->lanes)->value);
-      int base_ramp_lanes = static_cast<int>(Downcast<IntImm>(base_ramp->lanes)->value);
+      int base_ramp_lanes =
+          static_cast<int>(Downcast<IntImm>(base_ramp->lanes)->value);
       if (analyzer_.CanProve(base_ramp->stride ==
-                             stride * make_const(stride.dtype(), base_ramp_lanes))) {
+                             stride *
+                                 make_const(stride.dtype(), base_ramp_lanes))) {
         return Ramp(base_ramp->base, stride, op_lanes * base_ramp_lanes);
       }
     }
@@ -318,13 +332,13 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
     stride = BroadcastTo(stride, lanes, false);
     Array<PrimExpr> elems;
     for (int i = 0; i < lanes; ++i) {
-      elems.push_back(
-          Ramp(Shuffle::ExtractElement(base, i), Shuffle::ExtractElement(stride, i), op->lanes));
+      elems.push_back(Ramp(Shuffle::ExtractElement(base, i),
+                           Shuffle::ExtractElement(stride, i), op->lanes));
     }
     return Shuffle::Concat(elems);
   }
 
-  PrimExpr VisitExpr_(const BroadcastNode* op) final {
+  PrimExpr VisitExpr_(const BroadcastNode *op) final {
     PrimExpr value = this->VisitExpr(op->value);
     if (value.dtype().is_scalable_or_fixed_length_vector()) {
       need_scalarize_ = true;
@@ -337,45 +351,56 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
     }
   }
 
-  PrimExpr VisitExpr_(const SelectNode* op) final {
+  PrimExpr VisitExpr_(const SelectNode *op) final {
     PrimExpr cond = this->VisitExpr(op->condition);
     PrimExpr t = this->VisitExpr(op->true_value);
     PrimExpr f = this->VisitExpr(op->false_value);
-    if (cond.same_as(op->condition) && t.same_as(op->true_value) && f.same_as(op->false_value)) {
+    if (cond.same_as(op->condition) && t.same_as(op->true_value) &&
+        f.same_as(op->false_value)) {
       return GetRef<PrimExpr>(op);
     } else {
       int cond_lanes = cond.dtype().get_lanes_or_vscale_factor();
       int t_lanes = t.dtype().get_lanes_or_vscale_factor();
       int f_lanes = f.dtype().get_lanes_or_vscale_factor();
       int lanes = std::max(std::max(cond_lanes, t_lanes), f_lanes);
-      bool is_scalable = cond.dtype().is_scalable_vector() || t.dtype().is_scalable_vector() ||
+      bool is_scalable = cond.dtype().is_scalable_vector() ||
+                         t.dtype().is_scalable_vector() ||
                          f.dtype().is_scalable_vector();
-      return Select(BroadcastTo(cond, lanes, is_scalable), BroadcastTo(t, lanes, is_scalable),
+      return Select(BroadcastTo(cond, lanes, is_scalable),
+                    BroadcastTo(t, lanes, is_scalable),
                     BroadcastTo(f, lanes, is_scalable));
     }
   }
 
-  PrimExpr VisitExpr_(const CastNode* op) final {
+  PrimExpr VisitExpr_(const CastNode *op) final {
     PrimExpr value = this->VisitExpr(op->value);
     if (value.same_as(op->value)) {
       return GetRef<PrimExpr>(op);
     } else {
       if (value.dtype().is_scalable_vector()) {
-        return Cast(op->dtype.with_scalable_vscale_factor(value.dtype().vscale_factor()), value);
+        return Cast(op->dtype.with_scalable_vscale_factor(
+                        value.dtype().vscale_factor()),
+                    value);
       } else {
         return Cast(op->dtype.with_lanes(value.dtype().lanes()), value);
       }
     }
   }
 
-  PrimExpr VisitExpr_(const FloatImmNode* op) final { return GetRef<PrimExpr>(op); }
+  PrimExpr VisitExpr_(const FloatImmNode *op) final {
+    return GetRef<PrimExpr>(op);
+  }
 
-  PrimExpr VisitExpr_(const IntImmNode* op) final { return GetRef<PrimExpr>(op); }
+  PrimExpr VisitExpr_(const IntImmNode *op) final {
+    return GetRef<PrimExpr>(op);
+  }
 
-  PrimExpr VisitExpr_(const StringImmNode* op) final { return GetRef<PrimExpr>(op); }
+  PrimExpr VisitExpr_(const StringImmNode *op) final {
+    return GetRef<PrimExpr>(op);
+  }
 
   // Variable
-  PrimExpr VisitExpr_(const VarNode* op) final {
+  PrimExpr VisitExpr_(const VarNode *op) final {
     Var var = GetRef<Var>(op);
 
     if (var.same_as(var_)) {
@@ -389,7 +414,7 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
     }
   }
   // IfThenElse expr
-  PrimExpr MutateIfThenElseExpr_(const CallNode* op) {
+  PrimExpr MutateIfThenElseExpr_(const CallNode *op) {
     PrimExpr cond = this->VisitExpr(op->args[0]);
     if (cond.dtype().is_scalable_or_fixed_length_vector()) {
       need_scalarize_ = true;
@@ -397,24 +422,27 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
     }
     PrimExpr t = this->VisitExpr(op->args[1]);
     PrimExpr f = this->VisitExpr(op->args[2]);
-    if (cond.same_as(op->args[0]) && t.same_as(op->args[1]) && f.same_as(op->args[2])) {
+    if (cond.same_as(op->args[0]) && t.same_as(op->args[1]) &&
+        f.same_as(op->args[2])) {
       return GetRef<PrimExpr>(op);
     } else {
       int t_lanes = t.dtype().get_lanes_or_vscale_factor();
       int f_lanes = f.dtype().get_lanes_or_vscale_factor();
       int lanes = std::max(t_lanes, f_lanes);
-      bool is_scalable = t.dtype().is_scalable_vector() || f.dtype().is_scalable_vector();
+      bool is_scalable =
+          t.dtype().is_scalable_vector() || f.dtype().is_scalable_vector();
       t = BroadcastTo(t, lanes, is_scalable);
       f = BroadcastTo(f, lanes, is_scalable);
       if (is_scalable) {
-        return Call(op->dtype.with_scalable_vscale_factor(lanes), op->op, {cond, t, f});
+        return Call(op->dtype.with_scalable_vscale_factor(lanes), op->op,
+                    {cond, t, f});
       } else {
         return Call(op->dtype.with_lanes(lanes), op->op, {cond, t, f});
       }
     }
   }
   // Reinterpret expr
-  PrimExpr MutateReinterpretExpr_(const CallNode* op) {
+  PrimExpr MutateReinterpretExpr_(const CallNode *op) {
     ICHECK(op->op.same_as(builtin::reinterpret()));
     PrimExpr value = this->VisitExpr(op->args[0]);
     if (value.same_as(op->args[0])) {
@@ -422,14 +450,15 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
     } else {
       int lanes = value.dtype().get_lanes_or_vscale_factor();
       if (value.dtype().is_scalable_vector()) {
-        return Call(op->dtype.with_scalable_vscale_factor(lanes), op->op, {value});
+        return Call(op->dtype.with_scalable_vscale_factor(lanes), op->op,
+                    {value});
       } else {
         return Call(op->dtype.with_lanes(lanes), op->op, {value});
       }
     }
   }
   // Call
-  PrimExpr VisitExpr_(const CallNode* op) final {
+  PrimExpr VisitExpr_(const CallNode *op) final {
     if (op->op.same_as(builtin::if_then_else())) {
       return MutateIfThenElseExpr_(op);
     } else if (op->op.same_as(builtin::texture2d_load())) {
@@ -444,13 +473,15 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
       // Vectorize the value to store
       Array<PrimExpr> value{op->args.back()};
       Array<PrimExpr> mutated_value = MutateArray(value, &lane);
-      Array<PrimExpr> new_args{op->args[0], op->args[1], op->args[2], mutated_value[0]};
+      Array<PrimExpr> new_args{op->args[0], op->args[1], op->args[2],
+                               mutated_value[0]};
       return Call(op->dtype.with_lanes(lane), op->op, new_args);
     } else if (op->op.same_as(builtin::reinterpret())) {
       return MutateReinterpretExpr_(op);
     }
     auto optional_op = op->op.as<Op>();
-    bool vectorizable = optional_op && op_vectorizable_.get(optional_op.value(), false) &&
+    bool vectorizable = optional_op &&
+                        op_vectorizable_.get(optional_op.value(), false) &&
                         !op->dtype.is_scalable_vector();
 
     if (!vectorizable) {
@@ -481,14 +512,16 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
     }
   }
   // BufferLoad
-  PrimExpr VisitExpr_(const BufferLoadNode* op) final {
+  PrimExpr VisitExpr_(const BufferLoadNode *op) final {
     auto load = GetRef<BufferLoad>(op);
 
-    auto fmutate = [this](const PrimExpr& index) { return this->VisitExpr(index); };
+    auto fmutate = [this](const PrimExpr &index) {
+      return this->VisitExpr(index);
+    };
     Array<PrimExpr> indices = op->indices.Map(fmutate);
 
     if (!indices.same_as(op->indices)) {
-      BufferLoadNode* writer = load.CopyOnWrite();
+      BufferLoadNode *writer = load.CopyOnWrite();
       writer->indices = indices;
       // writer->LegalizeDType();
       LegalizeBufferLoadDType(writer);
@@ -497,7 +530,7 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
     return std::move(load);
   }
   // Let
-  PrimExpr VisitExpr_(const LetNode* op) final {
+  PrimExpr VisitExpr_(const LetNode *op) final {
     PrimExpr value = this->VisitExpr(op->value);
     // Weaker SSA condition
     // A single var can be binded in multiple lets
@@ -526,24 +559,28 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
     }
   }
   // BufferStore
-  Stmt VisitStmt_(const BufferStoreNode* op) final {
+  Stmt VisitStmt_(const BufferStoreNode *op) final {
     auto store = GetRef<BufferStore>(op);
 
-    auto fmutate = [this](const PrimExpr& index) { return this->VisitExpr(index); };
+    auto fmutate = [this](const PrimExpr &index) {
+      return this->VisitExpr(index);
+    };
     Array<PrimExpr> indices = op->indices.Map(fmutate);
 
     PrimExpr value = this->VisitExpr(op->value);
 
     if (!indices.same_as(op->indices) || !value.same_as(op->value)) {
       ICHECK(!op->buffer->dtype.is_scalable_vector())
-          << "Vectorizing over scalable buffer elements is not supported in vectorizer.";
+          << "Vectorizing over scalable buffer elements is not supported in "
+             "vectorizer.";
       // How many lanes of indexing are present in the index and
       // buffer element type, excluding the last index.
       int other_index_lanes = op->buffer->dtype.lanes();
       for (size_t i = 0; i < indices.size() - 1; i++) {
         other_index_lanes *= indices[i].dtype().lanes();
         // Only allow the last index to be scalable
-        ICHECK(!indices[i].dtype().is_scalable_vector()) << "Only the last index can be scalable.";
+        ICHECK(!indices[i].dtype().is_scalable_vector())
+            << "Only the last index can be scalable.";
       }
 
       // The total number of lanes of indexing, including the last index.
@@ -559,14 +596,16 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
       int total_lanes = std::max(index_lanes, value_dtype_lanes);
 
       ICHECK_EQ(total_lanes % other_index_lanes, 0)
-          << "When storing to buffer " << op->buffer->name << ", cannot produce " << total_lanes
+          << "When storing to buffer " << op->buffer->name
+          << ", cannot produce " << total_lanes
           << " lanes of storage location by changing the last index.";
       int last_index_lanes = total_lanes / other_index_lanes;
 
       // Broadcast the last index such that the total number of index
       // lanes matches the desired number.
-      indices.Set(indices.size() - 1, BroadcastTo(indices[indices.size() - 1], last_index_lanes,
-                                                  is_last_index_scalable));
+      indices.Set(indices.size() - 1,
+                  BroadcastTo(indices[indices.size() - 1], last_index_lanes,
+                              is_last_index_scalable));
 
       auto writer = store.CopyOnWrite();
       writer->indices = indices;
@@ -576,7 +615,7 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
     return std::move(store);
   }
   // For
-  Stmt VisitStmt_(const ForNode* op) final {
+  Stmt VisitStmt_(const ForNode *op) final {
     if (op->kind == ForKind::kVectorized) {
       LOG(WARNING) << "Detect vectorize inside vectorized loop, ignoring...";
     }
@@ -590,12 +629,12 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
     if (extent.same_as(op->extent) && body.same_as(op->body)) {
       return GetRef<Stmt>(op);
     } else {
-      return For(op->loop_var, op->min, extent, op->kind, body, op->thread_binding,
-                 op->annotations);
+      return For(op->loop_var, op->min, extent, op->kind, body,
+                 op->thread_binding, op->annotations);
     }
   }
   // IfThenElse
-  Stmt VisitStmt_(const IfThenElseNode* op) final {
+  Stmt VisitStmt_(const IfThenElseNode *op) final {
     ICHECK(!op->condition.dtype().is_scalable_or_fixed_length_vector());
     PrimExpr condition = this->VisitExpr(op->condition);
     if (condition.dtype().is_scalable_or_fixed_length_vector()) {
@@ -614,13 +653,14 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
     }
   }
   // While
-  Stmt VisitStmt_(const WhileNode* op) final {
+  Stmt VisitStmt_(const WhileNode *op) final {
     LOG(FATAL) << "A while loop inside a vectorized loop not supported.";
   }
   // LetStmt
-  Stmt VisitStmt_(const LetStmtNode* op) final {
+  Stmt VisitStmt_(const LetStmtNode *op) final {
     PrimExpr value = this->VisitExpr(op->value);
-    ICHECK(!let_binding_.count(op->var)) << "SSA violation, a single var is binded twice";
+    ICHECK(!let_binding_.count(op->var))
+        << "SSA violation, a single var is binded twice";
     let_binding_[op->var] = value;
 
     if (value.dtype().get_lanes_or_vscale_factor() !=
@@ -639,20 +679,22 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
     }
   }
   // Allocate
-  Stmt VisitStmt_(const AllocateNode* op) final {
+  Stmt VisitStmt_(const AllocateNode *op) final {
     // Mutate the condition
     PrimExpr condition = this->VisitExpr(op->condition);
     if (condition.dtype().is_scalable_or_fixed_length_vector()) {
-      LOG(WARNING) << "Cannot handle vector extent in alloc of " << op->buffer_var->name_hint;
+      LOG(WARNING) << "Cannot handle vector extent in alloc of "
+                   << op->buffer_var->name_hint;
       return Scalarize(GetRef<Stmt>(op));
     }
 
     // Mutate the extents
     Array<PrimExpr> extents;
-    for (const auto& extent : op->extents) {
+    for (const auto &extent : op->extents) {
       PrimExpr new_ext = this->VisitExpr(extent);
       if (new_ext.dtype().is_scalable_or_fixed_length_vector()) {
-        LOG(WARNING) << "Cannot handle vector extent in alloc of " << op->buffer_var->name_hint;
+        LOG(WARNING) << "Cannot handle vector extent in alloc of "
+                     << op->buffer_var->name_hint;
         return Scalarize(GetRef<Stmt>(op));
       }
       extents.push_back(new_ext);
@@ -669,7 +711,8 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
     extents.Set(extents.size() - 1, extents[extents.size() - 1] * var_lanes_);
 
     // Rewrite access to the buffer in the body.
-    Stmt body = VecAllocAccess(op->buffer_var.get(), var_, var_lanes_)(op->body);
+    Stmt body =
+        VecAllocAccess(op->buffer_var.get(), var_, var_lanes_)(op->body);
     body = this->VisitStmt(body);
     return Allocate(op->buffer_var, op->dtype, extents, condition, body);
   }
@@ -681,11 +724,11 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
     return For(idx, IntImm(var_->dtype, 0), var_lanes_, ForKind::kSerial, stmt);
   }
   // ProducerStore
-  Stmt VisitStmt_(const ProducerStoreNode* op) final {
+  Stmt VisitStmt_(const ProducerStoreNode *op) final {
     LOG(FATAL) << "ProducerProvide cannot appear in a TIR PrimFunc";
   }
 
- private:
+private:
   // analyzer
   arith::Analyzer analyzer_;
   // deep equal
@@ -701,19 +744,22 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
   // Let binding
   std::unordered_map<Var, PrimExpr, ObjectPtrHash, ObjectPtrEqual> let_binding_;
   // vectorizable property
-  OpAttrMap<TVectorizable> op_vectorizable_ = Op::GetAttrMap<TVectorizable>("TVectorizable");
+  OpAttrMap<TVectorizable> op_vectorizable_ =
+      Op::GetAttrMap<TVectorizable>("TVectorizable");
 
   // mutate array, with given lane requirement
   // when finished, p_lane updates the lane requirement.
-  Array<PrimExpr> MutateArray(Array<PrimExpr> arr, int* p_lanes) {
-    if (arr.size() == 0) return arr;
-    int& lanes = *p_lanes;
+  Array<PrimExpr> MutateArray(Array<PrimExpr> arr, int *p_lanes) {
+    if (arr.size() == 0)
+      return arr;
+    int &lanes = *p_lanes;
     bool changed = false;
     std::vector<PrimExpr> new_arr(arr.size());
     for (size_t i = 0; i < arr.size(); i++) {
       PrimExpr old_elem = arr[i];
       PrimExpr new_elem = this->VisitExpr(old_elem);
-      if (!new_elem.same_as(old_elem)) changed = true;
+      if (!new_elem.same_as(old_elem))
+        changed = true;
       new_arr[i] = new_elem;
       lanes = std::max(lanes, new_elem.dtype().lanes());
     }
@@ -724,12 +770,13 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
         changed = true;
       }
     }
-    if (!changed) return arr;
+    if (!changed)
+      return arr;
     return Array<PrimExpr>(new_arr);
   }
-  template <typename TOp, typename T>
-  PrimExpr BinaryVec(const T* op) {
-    static_assert(std::is_same<typename TOp::ContainerType, T>::value, "constraint");
+  template <typename TOp, typename T> PrimExpr BinaryVec(const T *op) {
+    static_assert(std::is_same<typename TOp::ContainerType, T>::value,
+                  "constraint");
     PrimExpr a = this->VisitExpr(op->a);
     PrimExpr b = this->VisitExpr(op->b);
     if (a.same_as(op->a) && b.same_as(op->b)) {
@@ -738,12 +785,14 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
       int a_lanes = a.dtype().get_lanes_or_vscale_factor();
       int b_lanes = b.dtype().get_lanes_or_vscale_factor();
       int lanes = std::max(a_lanes, b_lanes);
-      bool is_scalable = a.dtype().is_scalable_vector() || b.dtype().is_scalable_vector();
-      return TOp(BroadcastTo(a, lanes, is_scalable), BroadcastTo(b, lanes, is_scalable));
+      bool is_scalable =
+          a.dtype().is_scalable_vector() || b.dtype().is_scalable_vector();
+      return TOp(BroadcastTo(a, lanes, is_scalable),
+                 BroadcastTo(b, lanes, is_scalable));
     }
   }
   template <typename T, typename FCompute>
-  PrimExpr AddSubVec(const T* op, FCompute fcompute) {
+  PrimExpr AddSubVec(const T *op, FCompute fcompute) {
     PrimExpr a = this->VisitExpr(op->a);
     PrimExpr b = this->VisitExpr(op->b);
     if (a.same_as(op->a) && b.same_as(op->b)) {
@@ -753,33 +802,38 @@ class TLVectorizer : public StmtMutator, public ExprFunctor<PrimExpr(const PrimE
       int b_lanes = b.dtype().get_lanes_or_vscale_factor();
       int lanes = std::max(a_lanes, b_lanes);
       if (lanes != 1) {
-        const RampNode* b_ramp = b.as<RampNode>();
-        const RampNode* a_ramp = a.as<RampNode>();
+        const RampNode *b_ramp = b.as<RampNode>();
+        const RampNode *a_ramp = a.as<RampNode>();
         if (a.dtype().is_scalar() && b_ramp) {
-          return Ramp(fcompute(a, b_ramp->base),
-                      fcompute(make_zero(b_ramp->stride.dtype()), b_ramp->stride), b_ramp->lanes);
+          return Ramp(
+              fcompute(a, b_ramp->base),
+              fcompute(make_zero(b_ramp->stride.dtype()), b_ramp->stride),
+              b_ramp->lanes);
         }
         if (b.dtype().is_scalar() && a_ramp) {
           return Ramp(fcompute(a_ramp->base, b), a_ramp->stride, a_ramp->lanes);
         }
       }
-      bool is_scalable = a.dtype().is_scalable_vector() || b.dtype().is_scalable_vector();
-      return fcompute(BroadcastTo(a, lanes, is_scalable), BroadcastTo(b, lanes, is_scalable));
+      bool is_scalable =
+          a.dtype().is_scalable_vector() || b.dtype().is_scalable_vector();
+      return fcompute(BroadcastTo(a, lanes, is_scalable),
+                      BroadcastTo(b, lanes, is_scalable));
     }
   }
 };
 
 class LoopVectorizer : public StmtMutator {
- public:
-  Stmt VisitStmt_(const ForNode* op) final {
+public:
+  Stmt VisitStmt_(const ForNode *op) final {
     if (op->kind == ForKind::kVectorized) {
-      auto* extent_as_int = op->extent.as<IntImmNode>();
+      auto *extent_as_int = op->extent.as<IntImmNode>();
 
       if (!extent_as_int || extent_as_int->value < 1) {
-        bool is_scalable_expr = CheckContains::ExprContains(op->extent, arith::IsVScaleCall);
+        bool is_scalable_expr =
+            CheckContains::ExprContains(op->extent, arith::IsVScaleCall);
         ICHECK(is_scalable_expr && arith::TargetHasSVE())
-            << "Failed to vectorize loop with extent " << op->extent << " for target "
-            << Target::Current();
+            << "Failed to vectorize loop with extent " << op->extent
+            << " for target " << Target::Current();
       }
       ICHECK(is_zero(op->min));
       return TLVectorizer(op->loop_var, op->extent)(op->body);
@@ -790,8 +844,8 @@ class LoopVectorizer : public StmtMutator {
 };
 
 class VectorizeSkipper : public StmtMutator {
- public:
-  Stmt VisitStmt_(const ForNode* op) final {
+public:
+  Stmt VisitStmt_(const ForNode *op) final {
     Stmt stmt = StmtMutator::VisitStmt_(op);
     op = stmt.as<ForNode>();
     if (op->kind == ForKind::kVectorized) {
@@ -804,11 +858,10 @@ class VectorizeSkipper : public StmtMutator {
 
 Stmt SkipVectorize(Stmt stmt) { return VectorizeSkipper()(std::move(stmt)); }
 
-
 tvm::transform::Pass VectorizeLoop(bool enable_vectorize = true) {
   using namespace tir::transform;
   auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
-    auto* n = f.CopyOnWrite();
+    auto *n = f.CopyOnWrite();
     if (enable_vectorize) {
       n->body = tvm::tl::LoopVectorizer()(std::move(n->body));
     } else {
@@ -821,5 +874,5 @@ tvm::transform::Pass VectorizeLoop(bool enable_vectorize = true) {
 
 TVM_REGISTER_GLOBAL("tl.transform.VectorizeLoop").set_body_typed(VectorizeLoop);
 
-}  // namespace tl
-}  // namespace tvm
+} // namespace tl
+} // namespace tvm

--- a/testing/python/jit/test_tilelang_jit_callback.py
+++ b/testing/python/jit/test_tilelang_jit_callback.py
@@ -93,7 +93,7 @@ def run_gemm(
         code = f"// {stramp}\n" + code
         return code
 
-    matmul_kernel = tilelang.JITKernel(program, out_idx=-1, execution_backend="dl_pack")
+    matmul_kernel = tilelang.JITKernel(program, out_idx=-1, execution_backend="dlpack")
 
     kernel_source = matmul_kernel.get_kernel_source()
 
@@ -196,7 +196,7 @@ def run_gemm_jit_kernel(
         num_threads,
     )
 
-    matmul_kernel = tilelang.JITKernel(program, out_idx=-1, execution_backend="dl_pack")
+    matmul_kernel = tilelang.JITKernel(program, out_idx=-1, execution_backend="dlpack")
 
     A = torch.randn(M, K, dtype=torch.__getattribute__(in_dtype)).cuda()
     B = torch.randn(K, N, dtype=torch.__getattribute__(in_dtype)).cuda()

--- a/testing/python/jit/test_tilelang_jit_gemm.py
+++ b/testing/python/jit/test_tilelang_jit_gemm.py
@@ -31,7 +31,7 @@ def matmul(
 
     @tilelang.jit(
         out_idx=-1,  # create the output tensor during runtime
-        execution_backend="dl_pack",
+        execution_backend="dlpack",
     )
     @T.prim_func
     def main(
@@ -206,7 +206,7 @@ def run_gemm_jit_kernel(
         num_threads,
     )
 
-    matmul_kernel = tilelang.JITKernel(program, out_idx=-1, execution_backend="dl_pack")
+    matmul_kernel = tilelang.JITKernel(program, out_idx=-1, execution_backend="dlpack")
 
     A = torch.randn(M, K, dtype=torch.__getattribute__(in_dtype)).cuda()
     B = torch.randn(K, N, dtype=torch.__getattribute__(in_dtype)).cuda()

--- a/testing/python/kernel/test_tilelang_kernel_dequantize_gemm.py
+++ b/testing/python/kernel/test_tilelang_kernel_dequantize_gemm.py
@@ -239,7 +239,7 @@ def matmul(
     local_size = MAX_TRANSACTION_SIZE_IN_BITS // DataType(in_dtype).bits
     local_size_compressed = local_size // num_elems_per_byte
 
-    import tvm.tl.language as T
+    import tilelang.language as T
 
     @T.prim_func
     def main(

--- a/testing/python/kernel/test_tilelang_kernel_fp8_gemm_mma.py
+++ b/testing/python/kernel/test_tilelang_kernel_fp8_gemm_mma.py
@@ -227,6 +227,7 @@ def assert_tl_matmul_correctness(M, N, K, in_dtype, out_dtype, accum_dtype):
     print(ref_c)
     torch.testing.assert_close(C, ref_c, rtol=1e-2, atol=1e-2)
 
+
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version(8, 9)
 def test_assert_tl_matmul():

--- a/testing/python/kernel/test_tilelang_kernel_fp8_gemm_mma.py
+++ b/testing/python/kernel/test_tilelang_kernel_fp8_gemm_mma.py
@@ -199,8 +199,7 @@ def assert_tl_matmul_correctness(M, N, K, in_dtype, out_dtype, accum_dtype):
     in_dtype = map_torch_type(in_dtype)
     out_dtype = map_torch_type(out_dtype)
     accum_dtype = map_torch_type(accum_dtype)
-    
-    
+
     if in_dtype in {torch.int8, torch.int32}:
         A = torch.randint(-128, 128, (M, K), dtype=torch.int8).to(in_dtype).cuda()
         B = torch.randint(-128, 128, (N, K), dtype=torch.int8).to(in_dtype).cuda()

--- a/testing/python/kernel/test_tilelang_kernel_fp8_gemm_mma.py
+++ b/testing/python/kernel/test_tilelang_kernel_fp8_gemm_mma.py
@@ -227,7 +227,8 @@ def assert_tl_matmul_correctness(M, N, K, in_dtype, out_dtype, accum_dtype):
     print(ref_c)
     torch.testing.assert_close(C, ref_c, rtol=1e-2, atol=1e-2)
 
-
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(8, 9)
 def test_assert_tl_matmul():
     assert_tl_matmul_correctness(128, 128, 128, "e4m3_float8", "float32", "float32")
     assert_tl_matmul_correctness(128, 128, 128, "e5m2_float8", "float32", "float32")

--- a/testing/python/kernel/test_tilelang_kernel_fp8_gemm_mma.py
+++ b/testing/python/kernel/test_tilelang_kernel_fp8_gemm_mma.py
@@ -230,9 +230,6 @@ def assert_tl_matmul_correctness(M, N, K, in_dtype, out_dtype, accum_dtype):
 
 
 def test_assert_tl_matmul():
-    assert_tl_matmul_correctness(128, 128, 128, "float16", "float16", "float16")
-    assert_tl_matmul_correctness(128, 256, 256, "float16", "float32", "float32")
-    assert_tl_matmul_correctness(128, 256, 256, "int8", "int32", "int32")
     assert_tl_matmul_correctness(128, 128, 128, "e4m3_float8", "float32", "float32")
     assert_tl_matmul_correctness(128, 128, 128, "e5m2_float8", "float32", "float32")
 

--- a/testing/python/kernel/test_tilelang_kernel_fp8_gemv_simt.py
+++ b/testing/python/kernel/test_tilelang_kernel_fp8_gemv_simt.py
@@ -174,6 +174,8 @@ def evaluate_gemv_simt(
     tilelang.testing.torch_assert_close(C, ref_c, rtol=1e-2, atol=1e-2)
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(8, 9)
 def test_gemv_simt():
     evaluate_gemv_simt(1, 1024, 1024, "e4m3_float8", "float32", "float32", with_bias=False)
     evaluate_gemv_simt(1, 1024, 1024, "e5m2_float8", "float32", "float32", with_bias=False)

--- a/testing/python/kernel/test_tilelang_kernel_fp8_gemv_simt.py
+++ b/testing/python/kernel/test_tilelang_kernel_fp8_gemv_simt.py
@@ -4,10 +4,9 @@ import torch
 import torch.backends
 import tilelang.testing
 from tilelang import tvm as tvm
-from tvm import DataType, tir
-import tilelang as TL
+from tvm import DataType
 import tilelang.language as T
-from tilelang import JITKernel, Profiler
+from tilelang import JITKernel
 from tilelang.transform.simplify import apply_simplify
 from typing import Optional
 
@@ -109,12 +108,13 @@ def gemv_simt(
                     ))
             if kr == 0:
                 if with_bias:
-                    C[by, bx * n_partition +
-                        ni] = reduced_accum_res[0] + Bias[bx * n_partition + ni]
+                    C[by,
+                      bx * n_partition + ni] = reduced_accum_res[0] + Bias[bx * n_partition + ni]
                 else:
                     C[by, bx * n_partition + ni] = reduced_accum_res[0]
 
     return apply_simplify(main)
+
 
 def evaluate_gemv_simt(
     M: int,
@@ -127,11 +127,10 @@ def evaluate_gemv_simt(
     trans_B: bool = True,
     with_bias: bool = False,
 ):
-    program = gemv_simt(M, N, K, in_dtype, out_dtype, accum_dtype,
-                        trans_A, trans_B, with_bias)
+    program = gemv_simt(M, N, K, in_dtype, out_dtype, accum_dtype, trans_A, trans_B, with_bias)
 
     kernel = JITKernel(program, target="cuda")
-    
+
     def map_torch_type(intype):
         typemap = {
             'e4m3_float8': torch.float8_e4m3fn,
@@ -145,8 +144,7 @@ def evaluate_gemv_simt(
     in_dtype = map_torch_type(in_dtype)
     out_dtype = map_torch_type(out_dtype)
     accum_dtype = map_torch_type(accum_dtype)
-    
-    
+
     if in_dtype in {torch.int8, torch.int32}:
         A = torch.randint(-128, 128, (M, K), dtype=torch.int8).to(in_dtype).cuda()
         B = torch.randint(-128, 128, (N, K), dtype=torch.int8).to(in_dtype).cuda()
@@ -161,23 +159,25 @@ def evaluate_gemv_simt(
         Bias = torch.randn(N).to(accum_dtype).cuda() - 0.5
 
     C = torch.zeros(M, N).to(out_dtype).cuda()
-    
+
     if with_bias:
         kernel(A, B, Bias, C)
     else:
         kernel(A, B, C)
-    
+
     ref_c = torch.mm(A.to(torch.float32), B.T.to(torch.float32))
     if with_bias:
         ref_c += Bias.to(torch.float32)
-    
+
     print(C)
     print(ref_c)
     tilelang.testing.torch_assert_close(C, ref_c, rtol=1e-2, atol=1e-2)
 
+
 def test_gemv_simt():
     evaluate_gemv_simt(1, 1024, 1024, "e4m3_float8", "float32", "float32", with_bias=False)
     evaluate_gemv_simt(1, 1024, 1024, "e5m2_float8", "float32", "float32", with_bias=False)
+
 
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/kernel/test_tilelang_kernel_fp8_gemv_simt.py
+++ b/testing/python/kernel/test_tilelang_kernel_fp8_gemv_simt.py
@@ -1,0 +1,183 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+import torch
+import torch.backends
+import tilelang.testing
+from tilelang import tvm as tvm
+from tvm import DataType, tir
+import tilelang as TL
+import tilelang.language as T
+from tilelang import JITKernel, Profiler
+from tilelang.transform.simplify import apply_simplify
+from typing import Optional
+
+tilelang.testing.set_random_seed(0)
+
+
+def gemv_simt(
+    M: int,
+    N: int,
+    K: int,
+    in_dtype: str,
+    out_dtype: str,
+    accum_dtype: str,
+    trans_A: bool,
+    trans_B: bool,
+    with_bias: bool = False,
+    n_partition: Optional[int] = 4,
+    reduce_thread: Optional[int] = 32,
+):
+    assert n_partition is not None, "n_partition must be provided"
+    assert reduce_thread is not None, (
+        "reduce_thread must be provided currently, as related bitblas.gpu.gemv.GEMV"
+        "sch_outer_reduction_with_config is not implemented")
+
+    assert isinstance(N, int) and isinstance(K, int), "Do not support dynamic N and K Currently"
+
+    assert trans_A is False, "Dequantize only implement for trans_A=False currently"
+    assert trans_B is True, "Dequantize only implement for trans_B=TRue currently"
+
+    MAX_TRANSACTION_SIZE_IN_BITS = 128
+    micro_size_k = MAX_TRANSACTION_SIZE_IN_BITS // DataType(in_dtype).bits
+
+    block_K = reduce_thread * micro_size_k
+
+    A_shape = (M, K)
+    B_shape = (N, K)
+    Bias_shape = (N,)
+    C_shape = (M, N)
+
+    dp4a_size = 4
+    use_dp4a = in_dtype == "int8" and accum_dtype == "int32"
+
+    @T.prim_func
+    def main(
+            A: T.Buffer(A_shape, in_dtype),
+            B: T.Buffer(B_shape, in_dtype),
+            Bias: T.Buffer(Bias_shape, out_dtype),
+            C: T.Buffer(C_shape, out_dtype),
+    ):
+        with T.Kernel(
+                T.ceildiv(N, n_partition), M, threads=(reduce_thread, n_partition)) as (
+                    bx,
+                    by,
+                ):
+            A_local = T.alloc_local((micro_size_k,), in_dtype)
+            B_local = T.alloc_local((micro_size_k,), in_dtype)
+            accum_res = T.alloc_local((1,), accum_dtype)
+            reduced_accum_res = T.alloc_local((1,), accum_dtype)
+
+            kr = T.thread_binding(0, reduce_thread, thread="threadIdx.x")
+            ni = T.thread_binding(0, n_partition, thread="threadIdx.y")
+
+            T.clear(accum_res)
+            for ko in T.serial(T.ceildiv(K, block_K)):
+                for v in T.vectorized(micro_size_k):
+                    A_local[v] = A[by, ko * block_K + kr * micro_size_k + v]
+
+                for v in T.vectorized(micro_size_k):
+                    B_local[v] = B[
+                        bx * n_partition + ni,
+                        ko * block_K + kr * micro_size_k + v,
+                    ]
+
+                if use_dp4a:
+                    for ki in T.serial(micro_size_k // dp4a_size):
+                        T.dp4a(
+                            A_local[ki * dp4a_size],
+                            B_local[ki * dp4a_size],
+                            accum_res[0],
+                        )
+                else:
+                    for ki in T.serial(micro_size_k):
+                        accum_res[0] += A_local[ki].astype(accum_dtype) * B_local[ki].astype(
+                            accum_dtype)
+
+            with T.attr(
+                    T.comm_reducer(lambda x, y: x + y, [T.Cast(accum_dtype, 0)]),
+                    "reduce_scope",
+                    T.reinterpret(T.uint64(0), dtype="handle"),
+            ):
+                T.evaluate(
+                    T.tvm_thread_allreduce(
+                        T.uint32(1),
+                        accum_res[0],
+                        True,
+                        reduced_accum_res[0],
+                        kr,
+                        dtype="handle",
+                    ))
+            if kr == 0:
+                if with_bias:
+                    C[by, bx * n_partition +
+                        ni] = reduced_accum_res[0] + Bias[bx * n_partition + ni]
+                else:
+                    C[by, bx * n_partition + ni] = reduced_accum_res[0]
+
+    return apply_simplify(main)
+
+def evaluate_gemv_simt(
+    M: int,
+    N: int,
+    K: int,
+    in_dtype: str,
+    out_dtype: str,
+    accum_dtype: str,
+    trans_A: bool = False,
+    trans_B: bool = True,
+    with_bias: bool = False,
+):
+    program = gemv_simt(M, N, K, in_dtype, out_dtype, accum_dtype,
+                        trans_A, trans_B, with_bias)
+
+    kernel = JITKernel(program, target="cuda")
+    
+    def map_torch_type(intype):
+        typemap = {
+            'e4m3_float8': torch.float8_e4m3fn,
+            'e5m2_float8': torch.float8_e5m2,
+        }
+        if intype in typemap:
+            return typemap[intype]
+        else:
+            return getattr(torch, intype)
+
+    in_dtype = map_torch_type(in_dtype)
+    out_dtype = map_torch_type(out_dtype)
+    accum_dtype = map_torch_type(accum_dtype)
+    
+    
+    if in_dtype in {torch.int8, torch.int32}:
+        A = torch.randint(-128, 128, (M, K), dtype=torch.int8).to(in_dtype).cuda()
+        B = torch.randint(-128, 128, (N, K), dtype=torch.int8).to(in_dtype).cuda()
+        Bias = torch.randint(-128, 128, (N,), dtype=torch.int32).to(accum_dtype).cuda()
+    elif in_dtype in {torch.float8_e4m3fn, torch.float8_e5m2}:
+        A = torch.randn(M, K).to(in_dtype).cuda()
+        B = torch.randn(N, K).to(in_dtype).cuda()
+        Bias = torch.randn(N).to(accum_dtype).cuda()
+    else:
+        A = torch.randn(M, K).to(in_dtype).cuda() - 0.5
+        B = torch.randn(N, K).to(in_dtype).cuda() - 0.5
+        Bias = torch.randn(N).to(accum_dtype).cuda() - 0.5
+
+    C = torch.zeros(M, N).to(out_dtype).cuda()
+    
+    if with_bias:
+        kernel(A, B, Bias, C)
+    else:
+        kernel(A, B, C)
+    
+    ref_c = torch.mm(A.to(torch.float32), B.T.to(torch.float32))
+    if with_bias:
+        ref_c += Bias.to(torch.float32)
+    
+    print(C)
+    print(ref_c)
+    tilelang.testing.torch_assert_close(C, ref_c, rtol=1e-2, atol=1e-2)
+
+def test_gemv_simt():
+    evaluate_gemv_simt(1, 1024, 1024, "e4m3_float8", "float32", "float32", with_bias=False)
+    evaluate_gemv_simt(1, 1024, 1024, "e5m2_float8", "float32", "float32", with_bias=False)
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/kernel/test_tilelang_kernel_gemm_mma_intrinsic.py
+++ b/testing/python/kernel/test_tilelang_kernel_gemm_mma_intrinsic.py
@@ -182,7 +182,6 @@ def assert_tl_matmul_correctness(M, N, K, in_dtype, out_dtype, accum_dtype):
     matmul = tl_matmul(M, N, K, in_dtype, out_dtype, accum_dtype)
     mod, params = TL.lower(matmul)
     src_code = mod.imported_modules[0].get_source()
-    print(src_code)
     # src_code is the generated cuda source
     assert src_code is not None
 
@@ -223,9 +222,7 @@ def assert_tl_matmul_correctness(M, N, K, in_dtype, out_dtype, accum_dtype):
 
     # Get Reference Result
     ref_c = torch.matmul(A.to(torch.float32), B.T.to(torch.float32)).to(out_dtype)
-    print(C)
-    print(ref_c)
-    torch.testing.assert_close(C, ref_c, rtol=1e-2, atol=1e-2)
+    tilelang.testing.torch_assert_close(C, ref_c, rtol=1e-2, atol=1e-2)
 
 
 @tilelang.testing.requires_cuda

--- a/testing/python/kernel/test_tilelang_kernel_gemm_mma_intrinsic.py
+++ b/testing/python/kernel/test_tilelang_kernel_gemm_mma_intrinsic.py
@@ -199,8 +199,7 @@ def assert_tl_matmul_correctness(M, N, K, in_dtype, out_dtype, accum_dtype):
     in_dtype = map_torch_type(in_dtype)
     out_dtype = map_torch_type(out_dtype)
     accum_dtype = map_torch_type(accum_dtype)
-    
-    
+
     if in_dtype in {torch.int8, torch.int32}:
         A = torch.randint(-128, 128, (M, K), dtype=torch.int8).to(in_dtype).cuda()
         B = torch.randint(-128, 128, (N, K), dtype=torch.int8).to(in_dtype).cuda()

--- a/testing/python/kernel/test_tilelang_kernel_gemm_mma_intrinsic.py
+++ b/testing/python/kernel/test_tilelang_kernel_gemm_mma_intrinsic.py
@@ -222,7 +222,7 @@ def assert_tl_matmul_correctness(M, N, K, in_dtype, out_dtype, accum_dtype):
     assert latency is not None
 
     # Get Reference Result
-    ref_c = torch.matmul(A.to(accum_dtype), B.T.to(accum_dtype)).to(out_dtype)
+    ref_c = torch.matmul(A.to(torch.float32), B.T.to(torch.float32)).to(out_dtype)
     print(C)
     print(ref_c)
     torch.testing.assert_close(C, ref_c, rtol=1e-2, atol=1e-2)

--- a/testing/python/kernel/test_tilelang_kernel_gemm_mma_intrinsic.py
+++ b/testing/python/kernel/test_tilelang_kernel_gemm_mma_intrinsic.py
@@ -232,8 +232,7 @@ def test_assert_tl_matmul():
     assert_tl_matmul_correctness(128, 128, 128, "float16", "float16", "float16")
     assert_tl_matmul_correctness(128, 256, 256, "float16", "float32", "float32")
     assert_tl_matmul_correctness(128, 256, 256, "int8", "int32", "int32")
-    assert_tl_matmul_correctness(128, 128, 128, "e4m3_float8", "float32", "float32")
-    assert_tl_matmul_correctness(128, 128, 128, "e5m2_float8", "float32", "float32")
+    # fp8 test please checkout testing/python/kernel/test_tilelang_kernel_fp8_gemm_mma.py
 
 
 if __name__ == "__main__":

--- a/testing/python/kernel/test_tilelang_kernel_gemm_mma_intrinsic.py
+++ b/testing/python/kernel/test_tilelang_kernel_gemm_mma_intrinsic.py
@@ -228,11 +228,19 @@ def assert_tl_matmul_correctness(M, N, K, in_dtype, out_dtype, accum_dtype):
     torch.testing.assert_close(C, ref_c, rtol=1e-2, atol=1e-2)
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(8, 0)
 def test_assert_tl_matmul():
     assert_tl_matmul_correctness(128, 128, 128, "float16", "float16", "float16")
     assert_tl_matmul_correctness(128, 256, 256, "float16", "float32", "float32")
     assert_tl_matmul_correctness(128, 256, 256, "int8", "int32", "int32")
-    # fp8 test please checkout testing/python/kernel/test_tilelang_kernel_fp8_gemm_mma.py
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(8, 9)
+def test_assert_tl_matmul_fp8():
+    assert_tl_matmul_correctness(128, 128, 128, "e4m3_float8", "float32", "float32")
+    assert_tl_matmul_correctness(128, 128, 128, "e5m2_float8", "float32", "float32")
 
 
 if __name__ == "__main__":

--- a/testing/python/kernel/test_tilelang_kernel_gemv_simt.py
+++ b/testing/python/kernel/test_tilelang_kernel_gemv_simt.py
@@ -177,8 +177,7 @@ def evaluate_gemv_simt(
 def test_gemv_simt():
     evaluate_gemv_simt(1, 1024, 1024, "float16", "float16", "float16", with_bias=False)
     evaluate_gemv_simt(1, 1024, 1024, "int8", "int32", "int32", with_bias=False)
-    evaluate_gemv_simt(1, 1024, 1024, "e4m3_float8", "float32", "float32", with_bias=False)
-    evaluate_gemv_simt(1, 1024, 1024, "e5m2_float8", "float32", "float32", with_bias=False)
+    # fp8 test please checkout testing/python/kernel/test_tilelang_kernel_fp8_gemv_simt.py
 
 
 if __name__ == "__main__":

--- a/testing/python/kernel/test_tilelang_kernel_gemv_simt.py
+++ b/testing/python/kernel/test_tilelang_kernel_gemv_simt.py
@@ -179,7 +179,6 @@ def evaluate_gemv_simt(
 def test_gemv_simt():
     evaluate_gemv_simt(1, 1024, 1024, "float16", "float16", "float16", with_bias=False)
     evaluate_gemv_simt(1, 1024, 1024, "int8", "int32", "int32", with_bias=False)
-    # fp8 test please checkout testing/python/kernel/test_tilelang_kernel_fp8_gemv_simt.py
 
 
 @tilelang.testing.requires_cuda

--- a/testing/python/kernel/test_tilelang_kernel_gemv_simt.py
+++ b/testing/python/kernel/test_tilelang_kernel_gemv_simt.py
@@ -1,0 +1,185 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+import torch
+import torch.backends
+import tilelang.testing
+from tilelang import tvm as tvm
+from tvm import DataType, tir
+import tilelang as TL
+import tilelang.language as T
+from tilelang import JITKernel, Profiler
+from tilelang.transform.simplify import apply_simplify
+from typing import Optional
+
+tilelang.testing.set_random_seed(0)
+
+
+def gemv_simt(
+    M: int,
+    N: int,
+    K: int,
+    in_dtype: str,
+    out_dtype: str,
+    accum_dtype: str,
+    trans_A: bool,
+    trans_B: bool,
+    with_bias: bool = False,
+    n_partition: Optional[int] = 4,
+    reduce_thread: Optional[int] = 32,
+):
+    assert n_partition is not None, "n_partition must be provided"
+    assert reduce_thread is not None, (
+        "reduce_thread must be provided currently, as related bitblas.gpu.gemv.GEMV"
+        "sch_outer_reduction_with_config is not implemented")
+
+    assert isinstance(N, int) and isinstance(K, int), "Do not support dynamic N and K Currently"
+
+    assert trans_A is False, "Dequantize only implement for trans_A=False currently"
+    assert trans_B is True, "Dequantize only implement for trans_B=TRue currently"
+
+    MAX_TRANSACTION_SIZE_IN_BITS = 128
+    micro_size_k = MAX_TRANSACTION_SIZE_IN_BITS // DataType(in_dtype).bits
+
+    block_K = reduce_thread * micro_size_k
+
+    A_shape = (M, K)
+    B_shape = (N, K)
+    Bias_shape = (N,)
+    C_shape = (M, N)
+
+    dp4a_size = 4
+    use_dp4a = in_dtype == "int8" and accum_dtype == "int32"
+
+    @T.prim_func
+    def main(
+            A: T.Buffer(A_shape, in_dtype),
+            B: T.Buffer(B_shape, in_dtype),
+            Bias: T.Buffer(Bias_shape, out_dtype),
+            C: T.Buffer(C_shape, out_dtype),
+    ):
+        with T.Kernel(
+                T.ceildiv(N, n_partition), M, threads=(reduce_thread, n_partition)) as (
+                    bx,
+                    by,
+                ):
+            A_local = T.alloc_local((micro_size_k,), in_dtype)
+            B_local = T.alloc_local((micro_size_k,), in_dtype)
+            accum_res = T.alloc_local((1,), accum_dtype)
+            reduced_accum_res = T.alloc_local((1,), accum_dtype)
+
+            kr = T.thread_binding(0, reduce_thread, thread="threadIdx.x")
+            ni = T.thread_binding(0, n_partition, thread="threadIdx.y")
+
+            T.clear(accum_res)
+            for ko in T.serial(T.ceildiv(K, block_K)):
+                for v in T.vectorized(micro_size_k):
+                    A_local[v] = A[by, ko * block_K + kr * micro_size_k + v]
+
+                for v in T.vectorized(micro_size_k):
+                    B_local[v] = B[
+                        bx * n_partition + ni,
+                        ko * block_K + kr * micro_size_k + v,
+                    ]
+
+                if use_dp4a:
+                    for ki in T.serial(micro_size_k // dp4a_size):
+                        T.dp4a(
+                            A_local[ki * dp4a_size],
+                            B_local[ki * dp4a_size],
+                            accum_res[0],
+                        )
+                else:
+                    for ki in T.serial(micro_size_k):
+                        accum_res[0] += A_local[ki].astype(accum_dtype) * B_local[ki].astype(
+                            accum_dtype)
+
+            with T.attr(
+                    T.comm_reducer(lambda x, y: x + y, [T.Cast(accum_dtype, 0)]),
+                    "reduce_scope",
+                    T.reinterpret(T.uint64(0), dtype="handle"),
+            ):
+                T.evaluate(
+                    T.tvm_thread_allreduce(
+                        T.uint32(1),
+                        accum_res[0],
+                        True,
+                        reduced_accum_res[0],
+                        kr,
+                        dtype="handle",
+                    ))
+            if kr == 0:
+                if with_bias:
+                    C[by, bx * n_partition +
+                        ni] = reduced_accum_res[0] + Bias[bx * n_partition + ni]
+                else:
+                    C[by, bx * n_partition + ni] = reduced_accum_res[0]
+
+    return apply_simplify(main)
+
+def evaluate_gemv_simt(
+    M: int,
+    N: int,
+    K: int,
+    in_dtype: str,
+    out_dtype: str,
+    accum_dtype: str,
+    trans_A: bool = False,
+    trans_B: bool = True,
+    with_bias: bool = False,
+):
+    program = gemv_simt(M, N, K, in_dtype, out_dtype, accum_dtype,
+                        trans_A, trans_B, with_bias)
+
+    kernel = JITKernel(program, target="cuda")
+    
+    def map_torch_type(intype):
+        typemap = {
+            'e4m3_float8': torch.float8_e4m3fn,
+            'e5m2_float8': torch.float8_e5m2,
+        }
+        if intype in typemap:
+            return typemap[intype]
+        else:
+            return getattr(torch, intype)
+
+    in_dtype = map_torch_type(in_dtype)
+    out_dtype = map_torch_type(out_dtype)
+    accum_dtype = map_torch_type(accum_dtype)
+    
+    
+    if in_dtype in {torch.int8, torch.int32}:
+        A = torch.randint(-128, 128, (M, K), dtype=torch.int8).to(in_dtype).cuda()
+        B = torch.randint(-128, 128, (N, K), dtype=torch.int8).to(in_dtype).cuda()
+        Bias = torch.randint(-128, 128, (N,), dtype=torch.int32).to(accum_dtype).cuda()
+    elif in_dtype in {torch.float8_e4m3fn, torch.float8_e5m2}:
+        A = torch.randn(M, K).to(in_dtype).cuda()
+        B = torch.randn(N, K).to(in_dtype).cuda()
+        Bias = torch.randn(N).to(accum_dtype).cuda()
+    else:
+        A = torch.randn(M, K).to(in_dtype).cuda() - 0.5
+        B = torch.randn(N, K).to(in_dtype).cuda() - 0.5
+        Bias = torch.randn(N).to(accum_dtype).cuda() - 0.5
+
+    C = torch.zeros(M, N).to(out_dtype).cuda()
+    
+    if with_bias:
+        kernel(A, B, Bias, C)
+    else:
+        kernel(A, B, C)
+    
+    ref_c = torch.mm(A.to(torch.float32), B.T.to(torch.float32))
+    if with_bias:
+        ref_c += Bias.to(torch.float32)
+    
+    print(C)
+    print(ref_c)
+    tilelang.testing.torch_assert_close(C, ref_c, rtol=1e-2, atol=1e-2)
+
+def test_gemv_simt():
+    evaluate_gemv_simt(1, 1024, 1024, "float16", "float16", "float16", with_bias=False)
+    evaluate_gemv_simt(1, 1024, 1024, "int8", "int32", "int32", with_bias=False)
+    evaluate_gemv_simt(1, 1024, 1024, "e4m3_float8", "float32", "float32", with_bias=False)
+    evaluate_gemv_simt(1, 1024, 1024, "e5m2_float8", "float32", "float32", with_bias=False)
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/kernel/test_tilelang_kernel_gemv_simt.py
+++ b/testing/python/kernel/test_tilelang_kernel_gemv_simt.py
@@ -174,10 +174,19 @@ def evaluate_gemv_simt(
     tilelang.testing.torch_assert_close(C, ref_c, rtol=1e-2, atol=1e-2)
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(8, 0)
 def test_gemv_simt():
     evaluate_gemv_simt(1, 1024, 1024, "float16", "float16", "float16", with_bias=False)
     evaluate_gemv_simt(1, 1024, 1024, "int8", "int32", "int32", with_bias=False)
     # fp8 test please checkout testing/python/kernel/test_tilelang_kernel_fp8_gemv_simt.py
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(8, 9)
+def test_gemv_simt_fp8():
+    evaluate_gemv_simt(1, 1024, 1024, "e4m3_float8", "float32", "float32", with_bias=False)
+    evaluate_gemv_simt(1, 1024, 1024, "e5m2_float8", "float32", "float32", with_bias=False)
 
 
 if __name__ == "__main__":

--- a/testing/python/transform/test_tilelang_transform_vectorize_loop.py
+++ b/testing/python/transform/test_tilelang_transform_vectorize_loop.py
@@ -1,0 +1,480 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+import bitblas
+import tilelang
+from tilelang import tvm as tvm
+import tilelang.testing
+from tvm import te
+from tvm.script import ir as I
+from tilelang import language as T
+import pytest
+
+
+simple_target = tvm.target.Target("llvm -mtriple=x86_64-linux-gnu")
+sve_target = tvm.target.Target("llvm -device=arm_cpu -mtriple=aarch64-linux-gnu -mattr=+v8.2a,+sve")
+
+
+@pytest.mark.parametrize("extent, target", [(4, simple_target), (T.vscale() * 4, sve_target)])
+def test_vectorize_loop(extent, target):
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def main(A: T.Buffer((16,), "float32")):
+            for j in T.vectorized(0, extent):
+                A[j] = 1
+
+    @I.ir_module
+    class After:
+        @T.prim_func
+        def main(A: T.Buffer((16,), "float32")):
+            A[T.Ramp(0, 1, extent)] = T.Broadcast(1, extent)
+
+    with tvm.target.Target(target):
+        mod = tilelang.transform.VectorizeLoop()(Before)
+        tvm.ir.assert_structural_equal(mod, After)
+
+
+def test_vectorize_vector():
+    n = te.var("n")
+    ib = tvm.tir.ir_builder.create()
+    A = ib.pointer("float32x4", name="A")
+    with ib.for_range(0, n) as i:
+        with ib.for_range(0, 4, kind="vectorize") as j:
+            A[j] = tvm.tir.const(1, A.dtype)
+    stmt = ib.get()
+    assert isinstance(stmt.body, tvm.tir.For)
+
+    mod = tvm.IRModule.from_expr(tvm.tir.PrimFunc([A, n], stmt))
+    stmt = tilelang.transform.VectorizeLoop()(mod)["main"].body
+
+    assert isinstance(stmt, tvm.tir.For)
+    assert not isinstance(stmt.body, tvm.tir.For)
+    assert len(stmt.body.indices) == 1
+    assert isinstance(stmt.body.indices[0], tvm.tir.Ramp)
+    assert isinstance(stmt.body.value, tvm.tir.Broadcast)
+
+
+def test_vectorize_vector_scalable_error():
+    @I.ir_module
+    class Module:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "float32")):
+            for j in T.vectorized(T.vscale() * 4):
+                A[j * 4 : j * 4 + 4] = T.Broadcast(T.float32(1), 4)
+
+    error_msg = f"Creating scalable vectors from existing vectors is not supported."
+    with tvm.target.Target(sve_target):
+        with pytest.raises(tvm.error.InternalError, match=error_msg):
+            tilelang.transform.VectorizeLoop()(Module)
+
+
+def test_vectorize_vector_scalable_error2():
+    @I.ir_module
+    class Module:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "float32xvscalex4")):
+            for j in T.vectorized(4):
+                A[j] = T.Broadcast(T.float32(1), T.vscale() * 4)
+
+    error_msg = f"Vectorizing over scalable buffer elements is not supported in vectorizer."
+    with pytest.raises(tvm.error.InternalError, match=error_msg):
+        tilelang.transform.VectorizeLoop()(Module)
+
+
+def test_vectorize_vector_scalable_error3():
+    @I.ir_module
+    class Module:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "float32")):
+            for j in T.vectorized(4):
+                A[j * T.vscale() * 4 : j * T.vscale() * 4 + T.vscale() * 4] = T.Broadcast(
+                    T.float32(1), T.vscale() * 4
+                )
+
+    error_msg = f"Vectorizing over existing scalable vectors is not supported."
+    with pytest.raises(tvm.error.InternalError, match=error_msg):
+        with tvm.target.Target(sve_target):
+            tilelang.transform.VectorizeLoop()(Module)
+
+
+def test_vectorize_vector_scalable_error4():
+    @I.ir_module
+    class Module:
+        @T.prim_func(private=True)
+        def main(A: T.Buffer((25,), "float32")):
+            for j in T.vectorized(T.vscale() * 4):
+                A[j * T.vscale() * 4 : j * T.vscale() * 4 + T.vscale() * 4] = T.Broadcast(
+                    T.float32(1), T.vscale() * 4
+                )
+
+    error_msg = f"Creating scalable vectors from existing vectors is not supported."
+    with pytest.raises(tvm.error.InternalError, match=error_msg):
+        with tvm.target.Target(sve_target):
+            tilelang.transform.VectorizeLoop()(Module)
+
+
+@pytest.mark.parametrize("extent, target", [(4, simple_target), (T.vscale() * 4, sve_target)])
+def test_vectorize_with_if(extent, target):
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "float32"), n: T.int32, x: T.int32):
+            for i in T.vectorized(extent):
+                if x < n:
+                    A[i] = A[i] + T.float32(1)
+                else:
+                    if i < n:
+                        A[i] = T.float32(2)
+
+    @I.ir_module
+    class After:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "float32"), n: T.int32, x: T.int32):
+            if x < n:
+                A[T.Ramp(0, 1, extent)] = A[T.Ramp(0, 1, extent)] + T.Broadcast(
+                    T.float32(1), extent
+                )
+            else:
+                for i_s in range(extent):
+                    if i_s < n:
+                        A[i_s] = T.float32(2)
+
+    with tvm.target.Target(target):
+        mod = tilelang.transform.VectorizeLoop()(Before)
+        tvm.ir.assert_structural_equal(mod, After)
+
+
+def test_vectorize_with_if_cond_int64():
+    m = te.size_var("m", dtype="int64")
+    A = te.placeholder((m,), name="A", dtype="float32")
+    B = te.compute((m,), lambda i: te.if_then_else(i < 2, A[i], A[i] * 2), name="B")
+    s = te.create_schedule(B.op)
+    x, y = s[B].split(B.op.axis[0], factor=4)
+    s[B].vectorize(y)
+    f = tvm.build(s, [A, B], "llvm")
+
+
+@pytest.mark.parametrize("extent, target", [(4, simple_target), (T.vscale() * 4, sve_target)])
+def test_vectorize_let(extent, target):
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "float32")):
+            for i in T.vectorized(extent):
+                v = A[i] + T.float32(1)
+                A[i] = v + T.float32(2)
+
+    @I.ir_module
+    class After:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "float32")):
+            v = A[T.Ramp(0, 1, extent)] + T.Broadcast(T.float32(1), extent)
+            A[T.Ramp(0, 1, extent)] = v + T.Broadcast(T.float32(2), extent)
+
+    with tvm.target.Target(target):
+        mod = tilelang.transform.VectorizeLoop()(Before)
+        tvm.ir.assert_structural_equal(mod, After)
+
+
+@pytest.mark.parametrize("extent, target", [(4, simple_target), (tvm.tir.vscale() * 4, sve_target)])
+def test_vectorize_with_le_cond(extent, target):
+    n = te.var("n")
+    ib = tvm.tir.ir_builder.create()
+    A = ib.pointer("float32", name="A")
+    with ib.for_range(0, extent, kind="vectorize") as i:
+        with ib.if_scope(i <= n):
+            A[i] = A[i] + 1
+    stmt = ib.get()
+
+    mod = tvm.IRModule.from_expr(tvm.tir.PrimFunc([A, n], stmt))
+
+    with tvm.target.Target(target):
+        stmt = tilelang.transform.VectorizeLoop()(mod)["main"].body
+
+        # Check that the loop was't vectorised
+        assert isinstance(stmt, tvm.tir.For)
+
+
+@pytest.mark.parametrize("extent, target", [(4, simple_target), (tvm.tir.vscale() * 4, sve_target)])
+def test_vectorize_with_ge_cond(extent, target):
+    n = te.var("n")
+    ib = tvm.tir.ir_builder.create()
+    A = ib.pointer("float32", name="A")
+    with ib.for_range(0, extent, kind="vectorize") as i:
+        with ib.if_scope(i >= n):
+            A[i] = A[i] + 1
+    stmt = ib.get()
+
+    mod = tvm.IRModule.from_expr(tvm.tir.PrimFunc([A, n], stmt))
+
+    with tvm.target.Target(target):
+        stmt = tilelang.transform.VectorizeLoop()(mod)["main"].body
+
+        # Check that the loop wasn't vectorised
+        assert isinstance(stmt, tvm.tir.For)
+
+
+@pytest.mark.parametrize("extent, target", [(4, simple_target), (T.vscale() * 4, sve_target)])
+def test_vectorize_if_then_else_scalarize(extent, target):
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "float32")):
+            for i in T.vectorized(extent):
+                A[i] = T.if_then_else(i > 0, A[i] + T.float32(1), A[i])
+
+    @I.ir_module
+    class After:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "float32")):
+            for i_s in range(extent):
+                A[i_s] = T.if_then_else(i_s > 0, A[i_s] + T.float32(1), A[i_s])
+
+    with tvm.target.Target(target):
+        mod = tilelang.transform.VectorizeLoop()(Before)
+        tvm.ir.assert_structural_equal(mod, After)
+
+
+@pytest.mark.parametrize("extent, target", [(4, simple_target), (T.vscale() * 4, sve_target)])
+def test_vectorize_if_then_else_vector(extent, target):
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "float32"), n: T.int32):
+            for i in range(n):
+                for j in T.vectorized(extent):
+                    A[i * extent + j] = T.if_then_else(i > 0, A[i * extent + j], 0)
+
+    @I.ir_module
+    class After:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "float32"), n: T.int32):
+            for i in range(n):
+                A[T.Ramp(i * extent, 1, extent)] = T.if_then_else(
+                    i > 0, A[T.Ramp(i * extent, 1, extent)], T.Broadcast(0, extent)
+                )
+
+    with tvm.target.Target(target):
+        mod = tilelang.transform.VectorizeLoop()(Before)
+        tvm.ir.assert_structural_equal(mod, After)
+
+
+def test_vectorize_while_fail():
+    """A while loop inside a vectorized loop should fail."""
+
+    n = 64
+    num_iter = 10
+
+    def test_ir(A, B, C):
+        ib = tvm.tir.ir_builder.create()
+        n = C.shape[0]
+        A = ib.buffer_ptr(A)
+        B = ib.buffer_ptr(B)
+        C = ib.buffer_ptr(C)
+        i = ib.allocate("int32", (1,), name="i", scope="local")
+        i[0] = 0
+
+        with ib.for_range(0, n) as j:
+            C[j] = 0.0
+
+        with ib.for_range(0, n, kind="vectorize") as j:
+            with ib.while_loop(i[0] < num_iter):
+                C[j] += A[j] + B[j]
+                i[0] += 1
+
+        return ib.get()
+
+    dtype = "float32"
+    A = te.placeholder((n,), name="A", dtype=dtype)
+    B = te.placeholder((n,), name="B", dtype=dtype)
+
+    C = te.extern(
+        (n,),
+        [A, B],
+        lambda ins, outs: test_ir(ins[0], ins[1], outs[0]),
+        name="while_vectorize",
+        dtype=dtype,
+    )
+    s = te.create_schedule(C.op)
+
+    try:
+        tvm.lower(s, [A, B, C], "llvm")
+        assert False
+    except tvm.error.TVMError as e:
+        error_msg = str(e).split("\n")[-1]
+        expected = "A while loop inside a vectorized loop not supported"
+        assert expected in error_msg
+
+
+def test_vectorize_dtype_mismatch():
+    n = tvm.tir.IntImm("int64", 4)
+    A = te.compute((n,), lambda i: tvm.tir.IntImm("int64", 2**31 - 1) + i, name="A")
+    s = te.create_schedule(A.op)
+    s[A].vectorize(A.op.axis[0])
+    tvm.lower(s, [A], "llvm", simple_mode=True)
+
+
+@pytest.mark.parametrize(
+    "extent, vec_str, target",
+    [(16, "float32x16", simple_target), (T.vscale() * 8, "float32xvscalex8", sve_target)],
+)
+def test_vectorize_with_reinterpret(extent, vec_str, target):
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def main(A: T.Buffer((16,), "int32"), B: T.Buffer((16,), "float32")):
+            for i in T.vectorized(0, extent):
+                B[i] = T.reinterpret("float32", A[i])
+
+    @I.ir_module
+    class After:
+        @T.prim_func
+        def main(A: T.Buffer((16,), "int32"), B: T.Buffer((16,), "float32")):
+            B[T.Ramp(0, 1, extent)] = T.reinterpret(vec_str, A[T.Ramp(0, 1, extent)])
+
+    with tvm.target.Target(target):
+        mod = tilelang.transform.VectorizeLoop()(Before)
+        tvm.ir.assert_structural_equal(mod, After)
+
+
+@pytest.mark.parametrize("extent, target", [(4, simple_target), (T.vscale() * 4, sve_target)])
+@pytest.mark.parametrize(
+    "op",
+    (
+        T.Mul,
+        T.Add,
+        T.Sub,
+        T.Div,
+        T.Mod,
+        T.FloorDiv,
+        T.FloorMod,
+        T.Min,
+        T.Max,
+        T.EQ,
+        T.LT,
+        T.LE,
+        T.GE,
+        T.GT,
+        T.NE,
+    ),
+)
+def test_vectorize_binary(op, extent, target):
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "float32"), B: T.Buffer((25,), "float32")):
+            for j in T.vectorized(extent):
+                A[j] = op(T.float32(3), B[j])
+
+    @I.ir_module
+    class After:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "float32"), B: T.Buffer((25,), "float32")):
+            A[T.Ramp(0, 1, extent)] = op(T.Broadcast(T.float32(3), extent), B[T.Ramp(0, 1, extent)])
+
+    with tvm.target.Target(target):
+        mod = tilelang.transform.VectorizeLoop()(Before)
+        tvm.ir.assert_structural_equal(mod, After)
+
+
+@pytest.mark.parametrize("extent, target", [(4, simple_target), (T.vscale() * 4, sve_target)])
+@pytest.mark.parametrize("op", (T.And, T.Or))
+def test_vectorize_logical(op, extent, target):
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "bool"), B: T.Buffer((25,), "bool")):
+            for j in T.vectorized(extent):
+                A[j] = op(T.bool(1), B[j])
+
+    @I.ir_module
+    class After:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "bool"), B: T.Buffer((25,), "bool")):
+            A[T.Ramp(0, 1, extent)] = op(T.Broadcast(T.bool(1), extent), B[T.Ramp(0, 1, extent)])
+
+    with tvm.target.Target(target):
+        mod = tilelang.transform.VectorizeLoop()(Before)
+        tvm.ir.assert_structural_equal(mod, After)
+
+
+@pytest.mark.parametrize("extent, target", [(4, simple_target), (T.vscale() * 4, sve_target)])
+def test_vectorize_select(extent, target):
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "float32"), B: T.Buffer((25,), "float32")):
+            for j in T.vectorized(extent):
+                A[j] = T.Select(T.bool(True), A[j], B[j])
+
+    @I.ir_module
+    class After:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "float32"), B: T.Buffer((25,), "float32")):
+            A[T.Ramp(0, 1, extent)] = T.Select(
+                T.Broadcast(T.bool(True), extent),
+                A[T.Ramp(0, 1, extent)],
+                B[T.Ramp(0, 1, extent)],
+            )
+
+    with tvm.target.Target(target):
+        mod = tilelang.transform.VectorizeLoop()(Before)
+        tvm.ir.assert_structural_equal(mod, After)
+
+
+@pytest.mark.parametrize(
+    "extent, vec_str, target",
+    [(4, "int32x4", simple_target), (T.vscale() * 4, "int32xvscalex4", sve_target)],
+)
+def test_vectorize_cast(extent, vec_str, target):
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "int32"), B: T.Buffer((25,), "float32")):
+            for j in T.vectorized(extent):
+                A[j] = T.Cast("int32", B[j])
+
+    @I.ir_module
+    class After:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "int32"), B: T.Buffer((25,), "float32")):
+            A[T.Ramp(0, 1, extent)] = T.Cast(vec_str, B[T.Ramp(0, 1, extent)])
+
+    with tvm.target.Target(target):
+        mod = tilelang.transform.VectorizeLoop()(Before)        
+        tvm.ir.assert_structural_equal(mod, After)
+
+
+def test_illegal_extent():
+    @I.ir_module(check_well_formed=False)
+    class Mod:
+        @T.prim_func
+        def main(A: T.Buffer((25,), "int32")):
+            n = T.Var("n", dtype="int32")
+            for j in T.vectorized(n):
+                A[j] = 3
+
+    error_msg = f"Failed to vectorize loop with extent n for target \\(nullptr\\)"
+    with pytest.raises(tvm.error.InternalError, match=error_msg):
+        tilelang.transform.VectorizeLoop()(Mod)
+
+
+def test_illegal_vscale_in_non_sve_compilation():
+    @I.ir_module
+    class Mod:
+        @T.prim_func
+        def main(A: T.Buffer((16,), "float32")):
+            for j in T.vectorized(0, 4 * T.vscale()):
+                A[j] = 13
+
+    msg = (
+        f"Failed to vectorize loop with extent T.vscale\\(\\) \\* 4 for target "
+        f"llvm -keys=cpu -mtriple=x86_64-linux-gnu"
+    )
+    with tvm.target.Target(simple_target):
+        with pytest.raises(tvm.error.InternalError, match=msg):
+            tilelang.transform.VectorizeLoop()(Mod)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_vectorize_loop.py
+++ b/testing/python/transform/test_tilelang_transform_vectorize_loop.py
@@ -1,6 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-import bitblas
+# ruff: noqa
 import tilelang
 from tilelang import tvm as tvm
 import tilelang.testing

--- a/tilelang/contrib/dlpack.py
+++ b/tilelang/contrib/dlpack.py
@@ -35,27 +35,27 @@ def convert_func(tvm_func, tensor_type, to_dlpack_func):
     """
     assert callable(tvm_func)
     import torch
-    
+
     float8_dtype_map = {
         torch.float8_e4m3fn: "e4m3_float8",
         torch.float8_e4m3fnuz: "e4m3_float8",
         torch.float8_e5m2: "e5m2_float8",
         torch.float8_e5m2fnuz: "e5m2_float8",
     }
+
     def adapt_tensor(arg):
         if isinstance(arg, tensor_type):
-            if arg.dtype in {torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2, torch.float8_e5m2fnuz}:
-                return ndarray.from_dlpack(
-                    to_dlpack_func(arg.view(torch.int8))
-                )._create_view(arg.shape, dtype=float8_dtype_map[arg.dtype])
+            if arg.dtype in {
+                    torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2,
+                    torch.float8_e5m2fnuz
+            }:
+                return ndarray.from_dlpack(to_dlpack_func(arg.view(torch.int8)))._create_view(
+                    arg.shape, dtype=float8_dtype_map[arg.dtype])
             return ndarray.from_dlpack(to_dlpack_func(arg))
         return arg
 
     def _wrapper(*args):
-        args = tuple(
-            adapt_tensor(arg)
-            for arg in args
-        )
+        args = tuple(adapt_tensor(arg) for arg in args)
         return tvm_func(*args)
 
     return _wrapper

--- a/tilelang/contrib/dlpack.py
+++ b/tilelang/contrib/dlpack.py
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Wrapping functions to bridge frameworks with DLPack support to TVM"""
+from tvm.runtime import ndarray
+
+
+def convert_func(tvm_func, tensor_type, to_dlpack_func):
+    """Convert a tvm function into one that accepts a tensor from another
+       framework, provided the other framework supports DLPACK
+
+    Parameters
+    ----------
+    tvm_func: Function
+        Built tvm function operating on arrays
+
+    tensor_type: Type
+        Type of the tensors of the target framework
+
+    to_dlpack_func: Function
+        Function to convert the source tensors to DLPACK
+    """
+    assert callable(tvm_func)
+    import torch
+    
+    float8_dtype_map = {
+        torch.float8_e4m3fn: "e4m3_float8",
+        torch.float8_e4m3fnuz: "e4m3_float8",
+        torch.float8_e5m2: "e5m2_float8",
+        torch.float8_e5m2fnuz: "e5m2_float8",
+    }
+    def adapt_tensor(arg):
+        if isinstance(arg, tensor_type):
+            if arg.dtype in {torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2, torch.float8_e5m2fnuz}:
+                return ndarray.from_dlpack(
+                    to_dlpack_func(arg.view(torch.int8))
+                )._create_view(arg.shape, dtype=float8_dtype_map[arg.dtype])
+            return ndarray.from_dlpack(to_dlpack_func(arg))
+        return arg
+
+    def _wrapper(*args):
+        args = tuple(
+            adapt_tensor(arg)
+            for arg in args
+        )
+        return tvm_func(*args)
+
+    return _wrapper
+
+
+def to_pytorch_func(tvm_func):
+    """Convert a tvm function into one that accepts PyTorch tensors
+
+    Parameters
+    ----------
+    tvm_func: Function
+        Built tvm function operating on arrays
+
+    Returns
+    -------
+    wrapped_func: Function
+        Wrapped tvm function that operates on PyTorch tensors
+    """
+    # pylint: disable=import-outside-toplevel
+    import torch
+    import torch.utils.dlpack
+
+    return convert_func(tvm_func, torch.Tensor, torch.utils.dlpack.to_dlpack)

--- a/tilelang/engine/__init__.py
+++ b/tilelang/engine/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-from .lower import lower  # noqa: F401
+from .lower import lower, is_device_call  # noqa: F401

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -144,7 +144,6 @@ def lower(
     mod = tl.transform.LegalizeSafeMemoryAccess()(mod)
     # Inject Simplify to remove the duplicated conditions
     mod = tir.transform.Simplify()(mod)
-    mod = tir.transform.VectorizeLoop()(mod)
 
     # which may be introduced by the LegalizeSafeMemoryAccess
     if target.arch == "sm_90":
@@ -163,6 +162,7 @@ def lower(
     mod = tir.transform.FlattenBuffer()(mod)
     mod = tir.transform.NarrowDataType(32)(mod)
     mod = tir.transform.Simplify()(mod)
+    mod = tir.transform.VectorizeLoop()(mod)
     mod = tir.transform.StorageRewrite()(mod)
     mod = tir.transform.UnrollLoop()(mod)
     mod = tir.transform.RenormalizeSplitPattern()(mod)

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -162,7 +162,7 @@ def lower(
     mod = tir.transform.FlattenBuffer()(mod)
     mod = tir.transform.NarrowDataType(32)(mod)
     mod = tir.transform.Simplify()(mod)
-    mod = tir.transform.VectorizeLoop()(mod)
+    mod = tl.transform.VectorizeLoop()(mod)
     mod = tir.transform.StorageRewrite()(mod)
     mod = tir.transform.UnrollLoop()(mod)
     mod = tir.transform.RenormalizeSplitPattern()(mod)

--- a/tilelang/intrinsics/utils.py
+++ b/tilelang/intrinsics/utils.py
@@ -81,7 +81,7 @@ def get_mma_micro_size(dtype: Literal["float16", "int8"]):
     # Basic Tensor Core Matrix Multiply operation Unit
     micro_size_x = micro_size_y = 16
     micro_size_k = 16
-    if dtype == "int8":
+    if dtype in {"e4m3_float8", "e5m2_float8", "int8"}:
         micro_size_k = 32
     return micro_size_x, micro_size_y, micro_size_k
 

--- a/tilelang/jit/__init__.py
+++ b/tilelang/jit/__init__.py
@@ -24,7 +24,7 @@ def jit(
     func: Callable = None,
     *,  # Enforce keyword-only arguments from here on
     out_idx: Union[List[int], int] = None,
-    execution_backend: Literal["dl_pack", "torch_cpp", "ctypes"] = "dl_pack",
+    execution_backend: Literal["dlpack", "torch_cpp", "ctypes"] = "dlpack",
     target: Union[str, Target] = "auto",
     verbose: bool = False,
 ) -> BaseKernelAdapter:
@@ -42,8 +42,8 @@ def jit(
     out_idx : Union[List[int], int], optional
         The index (or list of indices) of the function outputs. This can be used
         to specify which outputs from the compiled function will be returned.
-    execution_backend : Literal["dl_pack", "torch_cpp", "ctypes"], optional
-        The wrapper type to use for the kernel adapter. Currently, only "dl_pack"
+    execution_backend : Literal["dlpack", "torch_cpp", "ctypes"], optional
+        The wrapper type to use for the kernel adapter. Currently, only "dlpack"
         and "torch_cpp" are supported.
     target : Union[str, Target], optional
         The compilation target for TVM. If set to "auto", an appropriate target
@@ -69,7 +69,7 @@ def jit(
 
     target = Target(target)
 
-    assert execution_backend in ["dl_pack", "torch_cpp", "ctypes"], "Invalid execution backend."
+    assert execution_backend in ["dlpack", "torch_cpp", "ctypes"], "Invalid execution backend."
 
     def _compile_and_create_adapter(tilelang_func: PrimFunc) -> BaseKernelAdapter:
         """

--- a/tilelang/jit/adapter/__init__.py
+++ b/tilelang/jit/adapter/__init__.py
@@ -2,5 +2,5 @@
 # Licensed under the MIT License.
 
 from .base import BaseKernelAdapter  # noqa: F401
-from .dl_pack import TorchDLPackKernelAdapter  # noqa: F401
+from .dlpack import TorchDLPackKernelAdapter  # noqa: F401
 from .torch_cpp import TorchCPPKernelAdapter  # noqa: F401

--- a/tilelang/jit/adapter/dlpack.py
+++ b/tilelang/jit/adapter/dlpack.py
@@ -4,7 +4,7 @@
 
 import torch
 from typing import List
-from tvm.contrib.dlpack import to_pytorch_func
+from tilelang.contrib.dlpack import to_pytorch_func
 from .base import BaseKernelAdapter
 
 

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -34,7 +34,7 @@ class JITKernel(object):
         self,
         func: PrimFunc = None,
         out_idx: Union[List[int], int] = None,
-        execution_backend: Literal["dl_pack", "torch_cpp", "ctypes"] = "dl_pack",
+        execution_backend: Literal["dlpack", "torch_cpp", "ctypes"] = "dlpack",
         target: Union[str, Target] = "auto",
         verbose: bool = False,
     ):
@@ -47,8 +47,8 @@ class JITKernel(object):
             The TileLang TIR function to compile and wrap.
         out_idx : Union[List[int], int], optional
             Index(es) of the output tensors to return (default: None).
-        execution_backend : Literal["dl_pack", "torch_cpp", "ctypes"], optional
-            Execution backend to use for kernel execution (default: "dl_pack").
+        execution_backend : Literal["dlpack", "torch_cpp", "ctypes"], optional
+            Execution backend to use for kernel execution (default: "dlpack").
         target : Union[str, Target], optional
             Compilation target, either as a string or a TVM Target object (default: "auto").
         verbose : bool, optional
@@ -69,7 +69,7 @@ class JITKernel(object):
         target = Target(target)
 
         # Validate the execution backend.
-        assert execution_backend in ["dl_pack", "torch_cpp",
+        assert execution_backend in ["dlpack", "torch_cpp",
                                      "ctypes"], f"Invalid execution backend. {execution_backend}"
 
         # Compile the TileLang function and create a kernel adapter for execution.
@@ -125,7 +125,7 @@ class JITKernel(object):
         self.rt_params = params
 
         # Create an adapter based on the specified execution backend.
-        if execution_backend == "dl_pack":
+        if execution_backend == "dlpack":
             # Use TorchDLPackKernelAdapter for interoperability with PyTorch via DLPack.
             adapter = TorchDLPackKernelAdapter(rt_mod, params=params, result_idx=out_idx)
         elif execution_backend == "torch_cpp":

--- a/tilelang/language/__init__.py
+++ b/tilelang/language/__init__.py
@@ -3,8 +3,10 @@
 """The language interface for tl programs."""
 
 from typing import Optional
-from .parser import *
-# from tvm.script.parser.tir import *
+# from .parser import *
+# now is fully compatible with the upstream
+# tir script
+from tvm.script.parser.tir import *
 from tilelang.layout import Layout, Fragment  # noqa: F401
 from .parallel import Parallel  # noqa: F401
 from .pipeline import Pipelined  # noqa: F401

--- a/tilelang/language/parser/parser.py
+++ b/tilelang/language/parser/parser.py
@@ -31,7 +31,7 @@ from tvm.script.ir_builder import ir as I
 from tvm.script.ir_builder import tir as T
 
 # May rewrite some register functions
-# if we use our own registeration
+# if we use our own registration
 # from .. import ast as T
 
 from tvm.script.ir_builder.base import IRBuilder

--- a/tilelang/language/parser/parser.py
+++ b/tilelang/language/parser/parser.py
@@ -28,7 +28,12 @@ from tvm.ir import GlobalVar, PrimType
 from tvm.tir import Buffer, IterVar, PrimExpr, Var
 
 from tvm.script.ir_builder import ir as I
-from .. import ast as T
+from tvm.script.ir_builder import tir as T
+
+# May rewrite some register functions
+# if we use our own registeration
+# from .. import ast as T
+
 from tvm.script.ir_builder.base import IRBuilder
 from tvm.script.ir_builder.base import IRBuilderFrame as Frame
 from tvm.script.parser._core import Parser, dispatch, doc

--- a/tilelang/profiler/__init__.py
+++ b/tilelang/profiler/__init__.py
@@ -17,6 +17,7 @@ from tilelang.utils.tensor import (
     get_tensor_supply,
     TensorSupplyType,
     torch_assert_close,
+    adapt_torch2tvm,
 )
 
 
@@ -130,7 +131,7 @@ class Profiler(TorchDLPackKernelAdapter):
             device = tvm.cuda(0) if target == "cuda" else tvm.rocm(0)
             time_evaluator = self.mod.time_evaluator(
                 self.mod.entry_name, device, number=rep, repeat=n_repeat)
-            tvm_inputs = [ndarray.from_dlpack(to_dlpack(inp)) for inp in ins]
+            tvm_inputs = [adapt_torch2tvm(inp) for inp in ins]
             # Transform Latency to ms
             return time_evaluator(*tvm_inputs).mean * 1e3
         elif profiler == "auto":
@@ -149,7 +150,7 @@ class Profiler(TorchDLPackKernelAdapter):
             ins = self._get_inputs(with_output=True)
             time_evaluator = self.mod.time_evaluator(
                 self.mod.entry_name, tvm.cuda(0), number=rep, repeat=n_repeat)
-            tvm_inputs = [ndarray.from_dlpack(to_dlpack(inp)) for inp in ins]
+            tvm_inputs = [adapt_torch2tvm(inp) for inp in ins]
             tvm_res = time_evaluator(*tvm_inputs).mean * 1e3
             return min(torch_res, tvm_res)
         else:

--- a/tilelang/profiler/__init__.py
+++ b/tilelang/profiler/__init__.py
@@ -8,8 +8,6 @@ import torch
 from contextlib import suppress
 
 import tvm
-from torch.utils.dlpack import to_dlpack
-from tvm.runtime import ndarray
 from tvm.relay import TensorType
 
 from tilelang.jit.adapter import TorchDLPackKernelAdapter

--- a/tilelang/transform/__init__.py
+++ b/tilelang/transform/__init__.py
@@ -186,3 +186,14 @@ def AnnotateDeviceRegions():
         The result pass
     """
     return _ffi_api.AnnotateDeviceRegions()  # type: ignore
+
+
+def VectorizeLoop(enable_vectorize: bool = True):
+    """VectorizeLoop
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    """
+    return _ffi_api.VectorizeLoop(enable_vectorize)  # type: ignore

--- a/tilelang/transform/simplify.py
+++ b/tilelang/transform/simplify.py
@@ -37,3 +37,8 @@ def simplify_prim_func(func: Callable) -> Callable:
         return _Simplify(stmt)
 
     return wrapper
+
+
+def apply_simplify(stmt: Union[PrimFunc, IRModule]) -> Union[PrimFunc, IRModule]:
+    """Apply Simplify pass to a PrimFunc or IRModule."""
+    return _Simplify(stmt)

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -4,8 +4,8 @@
 from enum import Enum
 import torch
 from tvm.relay import TensorType
-
-
+from tvm.runtime import ndarray
+from torch.utils.dlpack import to_dlpack
 class TensorSupplyType(Enum):
     Integer = 1
     Uniform = 2
@@ -15,10 +15,36 @@ class TensorSupplyType(Enum):
     One = 6
 
 
+
+def map_torch_type(intype):
+    typemap = {
+        'e4m3_float8': torch.float8_e4m3fn,
+        'e5m2_float8': torch.float8_e5m2,
+    }
+    if intype in typemap:
+        return typemap[intype]
+    else:
+        return getattr(torch, intype)
+
+float8_dtype_map = {
+    torch.float8_e4m3fn: "e4m3_float8",
+    torch.float8_e4m3fnuz: "e4m3_float8",
+    torch.float8_e5m2: "e5m2_float8",
+    torch.float8_e5m2fnuz: "e5m2_float8",
+}
+def adapt_torch2tvm(arg):
+    if isinstance(arg, torch.Tensor):
+        if arg.dtype in {torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2, torch.float8_e5m2fnuz}:
+            return ndarray.from_dlpack(
+                to_dlpack(arg.view(torch.int8))
+            )._create_view(shape=arg.shape, dtype=float8_dtype_map[arg.dtype])
+        return ndarray.from_dlpack(to_dlpack(arg))
+    return arg
+
 def get_tensor_supply(supply_type: TensorSupplyType):
 
     def get_tensor(tensor: TensorType) -> torch.Tensor:
-        dtype = torch.__getattribute__(str(tensor.dtype))
+        dtype = map_torch_type(str(tensor.dtype))
         device = torch.cuda.current_device()
 
         shape = list(map(int, tensor.shape))
@@ -30,8 +56,11 @@ def get_tensor_supply(supply_type: TensorSupplyType):
 
         if supply_type == TensorSupplyType.Integer:
             is_unsigned = tensor.dtype.startswith("uint")
+            is_float8 = tensor.dtype.endswith("float8")
             if is_unsigned:
                 return torch.randint(low=0, high=3, size=shape, device=device, dtype=dtype)
+            elif is_float8:
+                return torch.randint(low=-128, high=128, size=shape, device=device, dtype=torch.int8).to(dtype)
             else:
                 return torch.randint(low=-2, high=3, size=shape, device=device, dtype=dtype)
         elif supply_type == TensorSupplyType.Uniform:

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -6,6 +6,8 @@ import torch
 from tvm.relay import TensorType
 from tvm.runtime import ndarray
 from torch.utils.dlpack import to_dlpack
+
+
 class TensorSupplyType(Enum):
     Integer = 1
     Uniform = 2
@@ -13,7 +15,6 @@ class TensorSupplyType(Enum):
     Randn = 4
     Zero = 5
     One = 6
-
 
 
 def map_torch_type(intype):
@@ -26,20 +27,25 @@ def map_torch_type(intype):
     else:
         return getattr(torch, intype)
 
+
 float8_dtype_map = {
     torch.float8_e4m3fn: "e4m3_float8",
     torch.float8_e4m3fnuz: "e4m3_float8",
     torch.float8_e5m2: "e5m2_float8",
     torch.float8_e5m2fnuz: "e5m2_float8",
 }
+
+
 def adapt_torch2tvm(arg):
     if isinstance(arg, torch.Tensor):
-        if arg.dtype in {torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2, torch.float8_e5m2fnuz}:
-            return ndarray.from_dlpack(
-                to_dlpack(arg.view(torch.int8))
-            )._create_view(shape=arg.shape, dtype=float8_dtype_map[arg.dtype])
+        if arg.dtype in {
+                torch.float8_e4m3fn, torch.float8_e4m3fnuz, torch.float8_e5m2, torch.float8_e5m2fnuz
+        }:
+            return ndarray.from_dlpack(to_dlpack(arg.view(torch.int8)))._create_view(
+                shape=arg.shape, dtype=float8_dtype_map[arg.dtype])
         return ndarray.from_dlpack(to_dlpack(arg))
     return arg
+
 
 def get_tensor_supply(supply_type: TensorSupplyType):
 
@@ -60,7 +66,8 @@ def get_tensor_supply(supply_type: TensorSupplyType):
             if is_unsigned:
                 return torch.randint(low=0, high=3, size=shape, device=device, dtype=dtype)
             elif is_float8:
-                return torch.randint(low=-128, high=128, size=shape, device=device, dtype=torch.int8).to(dtype)
+                return torch.randint(
+                    low=-128, high=128, size=shape, device=device, dtype=torch.int8).to(dtype)
             else:
                 return torch.randint(low=-2, high=3, size=shape, device=device, dtype=dtype)
         elif supply_type == TensorSupplyType.Uniform:


### PR DESCRIPTION
This pull request includes several changes to enhance the CUDA code generation and improve the overall functionality of the TileLang engine. The most important changes include the addition of support for FP8 types, the introduction of a global barrier synchronization mechanism, and updates to various data type handling and vectorization processes.

### Enhancements to CUDA code generation:

* Added support for FP8 types, including the `GetFP8Type` function and necessary includes in the `Finish` method. (`src/target/codegen_cuda.cc`, `src/tl_templates/cuda/cuda_fp8.h`) [[1]](diffhunk://#diff-c3ab436cd4bc043109e6e9bcc9d813a4bc89311efd35f19203970bf10f7596d6R26-R53) [[2]](diffhunk://#diff-c3ab436cd4bc043109e6e9bcc9d813a4bc89311efd35f19203970bf10f7596d6R109-R129) [[3]](diffhunk://#diff-4e56e8e78cc0b762cf12de8b7eef9c43b9708e23e1beece1e1f770fa05fcb495R1-R23)
* Introduced a global barrier synchronization mechanism with related state variables and synchronization code. (`src/target/codegen_cuda.cc`, `src/target/codegen_cuda.h`) [[1]](diffhunk://#diff-c3ab436cd4bc043109e6e9bcc9d813a4bc89311efd35f19203970bf10f7596d6R553-R584) [[2]](diffhunk://#diff-995ec2e4e06ac204b1e4eb0a35250de02ab248fbcdae7b9b802a74a9c99b458cL76-R106)

### Updates to data type handling:

* Modified `PrintType` method to enable FP16, BF16, FP8, and INT8 types and updated the respective type printing logic. (`src/target/codegen_cuda.cc`) [[1]](diffhunk://#diff-c3ab436cd4bc043109e6e9bcc9d813a4bc89311efd35f19203970bf10f7596d6L131-R194) [[2]](diffhunk://#diff-c3ab436cd4bc043109e6e9bcc9d813a4bc89311efd35f19203970bf10f7596d6R233-R235) [[3]](diffhunk://#diff-c3ab436cd4bc043109e6e9bcc9d813a4bc89311efd35f19203970bf10f7596d6L203-R246) [[4]](diffhunk://#diff-c3ab436cd4bc043109e6e9bcc9d813a4bc89311efd35f19203970bf10f7596d6R308-R320)

### Improvements to TileLang engine:

* Reorganized the import statements in `tilelang/engine/__init__.py` and `tilelang/language/__init__.py` to improve compatibility and maintainability. (`tilelang/engine/__init__.py`, `tilelang/language/__init__.py`) [[1]](diffhunk://#diff-7c6f75bcdf3c9723e9e80d4d47ed18bbc7310ad464c9209aa22989b7b8658860L4-R4) [[2]](diffhunk://#diff-154d65bdd2298cc46b3f9719ce3627a35ec79f3a20c759f4c3211b67f9221564L6-R9)
* Added the `VectorizeLoop` transformation to the TileLang engine and adjusted the order of transformations in the `lower` function. (`tilelang/engine/lower.py`, `tilelang/transform/__init__.py`) [[1]](diffhunk://#diff-e8395ac8f9a0848926b352900043a46a38d67a3c2762dc0f1267f5d296207a63L147) [[2]](diffhunk://#diff-e8395ac8f9a0848926b352900043a46a38d67a3c2762dc0f1267f5d296207a63R165) [[3]](diffhunk://#diff-12f525dbd0b5c96c2bf0085e9347f5af4d777a9ebb8d615b0a4a3a28ee4055d4R189-R199)