### PR TITLE
[Bugfix] Update Dockerfile.cu120

### DIFF
--- a/docker/Dockerfile.cu120
+++ b/docker/Dockerfile.cu120
@@ -23,6 +23,6 @@ RUN conda install pip cmake && conda clean --all
 RUN apt-get install -y python3 python3-dev python3-setuptools gcc libtinfo-dev zlib1g-dev build-essential cmake libedit-dev libxml2-dev
 
 RUN git clone https://github.com/tile-ai/tilelang.git --recursive -b main TileLang \
-  && cd TileLang && ./install.sh
+  && cd TileLang && ./install_cuda.sh
 
 CMD bash


### PR DESCRIPTION
This pull request includes a change to the `docker/Dockerfile.cu120` file to modify the installation script for TileLang when using CUDA.

* [`docker/Dockerfile.cu120`](diffhunk://#diff-7027d45bf5040cb2634c81f28d0d6254e6078151464848ddda11adcff937adbbL26-R26): Changed the TileLang installation script from `install.sh` to `install_cuda.sh` to ensure proper setup for CUDA environments.