### PR TITLE
[JIT] Support Cython jit and make cython a default execution backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,6 @@ tilelang/lib
 
 # tox
 .tox/
+
+# cython
+tilelang/jit/adapter/cython/.cycache

--- a/examples/gemm/README.md
+++ b/examples/gemm/README.md
@@ -339,8 +339,6 @@ def tl_matmul(
             B_local = T.alloc_local((warp_cols * local_size_b), in_dtype)
             C_local = T.alloc_local((warp_rows * warp_cols * local_size_c), accum_dtype)
 
-            thread_binding = T.thread_binding(0, threads, "threadIdx.x")
-
             T.annotate_layout({
                 A_shared: make_swizzle_layout(A_shared),
                 B_shared: make_swizzle_layout(B_shared),

--- a/setup.py
+++ b/setup.py
@@ -151,7 +151,7 @@ def download_and_extract_llvm(version, is_aarch64=False, extract_path="3rdparty"
 
 
 package_data = {
-    "tilelang": ["py.typed"],
+    "tilelang": ["py.typed", "*pyx"],
 }
 
 LLVM_VERSION = "10.0.1"

--- a/testing/python/jit/test_tilelang_jit_gemm_cython.py
+++ b/testing/python/jit/test_tilelang_jit_gemm_cython.py
@@ -269,7 +269,6 @@ def run_cython_kernel_do_bench(M,
     cython_profiler = cython_matmul_kernel.get_profiler()
     ctypes_profiler = ctypes_matmul_kernel.get_profiler()
 
-
     cython_latency = cython_profiler.do_bench(func=cython_matmul_kernel, profiler="torch")
     print(f"cython Latency: {cython_latency} ms")
 
@@ -278,9 +277,7 @@ def run_cython_kernel_do_bench(M,
     tvm_latency = cython_profiler.do_bench()
     print(f"TVM Latency: {tvm_latency} ms")
 
-
     assert tvm_latency is not None
-
 
     ctypes_latency = ctypes_profiler.do_bench(func=ctypes_matmul_kernel, profiler="torch")
     print(f"ctypes Latency: {ctypes_latency} ms")

--- a/testing/python/jit/test_tilelang_jit_gemm_cython.py
+++ b/testing/python/jit/test_tilelang_jit_gemm_cython.py
@@ -1,0 +1,414 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from tilelang import tvm as tvm
+import tilelang.language as T
+import tilelang.testing
+import tilelang
+import torch
+
+
+def matmul(
+    M,
+    N,
+    K,
+    block_M,
+    block_N,
+    block_K,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+    accum_dtype,
+    num_stages,
+    threads,
+):
+    A_shape = (K, M) if trans_A else (M, K)
+    B_shape = (N, K) if trans_B else (K, N)
+    A_shared_shape = (block_K, block_M) if trans_A else (block_M, block_K)
+    B_shared_shape = (block_N, block_K) if trans_B else (block_K, block_N)
+
+    @T.prim_func
+    def main(
+            A: T.Buffer(A_shape, in_dtype),
+            B: T.Buffer(B_shape, in_dtype),
+            C: T.Buffer((M, N), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads) as (bx, by):
+            A_shared = T.alloc_shared(A_shared_shape, in_dtype)
+            B_shared = T.alloc_shared(B_shared_shape, in_dtype)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+            T.clear(C_local)
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
+                if trans_A:
+                    T.copy(A[k * block_K, by * block_M], A_shared)
+                else:
+                    T.copy(A[by * block_M, k * block_K], A_shared)
+                if trans_B:
+                    T.copy(B[bx * block_N, k * block_K], B_shared)
+                else:
+                    T.copy(B[k * block_K, bx * block_N], B_shared)
+                T.gemm(A_shared, B_shared, C_local, trans_A, trans_B)
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def run_gemm(
+    M,
+    N,
+    K,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+    dtypeAccum,
+    block_M,
+    block_N,
+    block_K,
+    num_stages=3,
+    num_threads=128,
+):
+    program = matmul(
+        M,
+        N,
+        K,
+        block_M,
+        block_N,
+        block_K,
+        trans_A,
+        trans_B,
+        in_dtype,
+        out_dtype,
+        dtypeAccum,
+        num_stages,
+        num_threads,
+    )
+
+    stramp = "&*(XS)"
+
+    @tvm.register_func("tilelang_callback_cuda_postproc", override=True)
+    def tilelang_callback_cuda_postproc(code, _):
+        code = f"// {stramp}\n" + code
+        return code
+
+    matmul_kernel = tilelang.JITKernel(program, out_idx=-1, execution_backend="cython")
+
+    kernel_source = matmul_kernel.get_kernel_source()
+
+    assert stramp in kernel_source, f"Expected {stramp} in the kernel source"
+
+
+def test_gemm_f16f16f16_nn():
+    run_gemm(
+        512,
+        1024,
+        768,
+        False,
+        False,
+        "float16",
+        "float16",
+        "float16",
+        128,
+        256,
+        32,
+        2,
+    )
+
+
+def matmu_jit_kernel(
+    M,
+    N,
+    K,
+    block_M,
+    block_N,
+    block_K,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+    accum_dtype,
+    num_stages,
+    threads,
+):
+    A_shape = (K, M) if trans_A else (M, K)
+    B_shape = (N, K) if trans_B else (K, N)
+    A_shared_shape = (block_K, block_M) if trans_A else (block_M, block_K)
+    B_shared_shape = (block_N, block_K) if trans_B else (block_K, block_N)
+
+    import tilelang.language as T
+
+    @T.prim_func
+    def main(
+            A: T.Buffer(A_shape, in_dtype),
+            B: T.Buffer(B_shape, in_dtype),
+            C: T.Buffer((M, N), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads) as (bx, by):
+            A_shared = T.alloc_shared(A_shared_shape, in_dtype)
+            B_shared = T.alloc_shared(B_shared_shape, in_dtype)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+            T.clear(C_local)
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
+                if trans_A:
+                    T.copy(A[k * block_K, by * block_M], A_shared)
+                else:
+                    T.copy(A[by * block_M, k * block_K], A_shared)
+                if trans_B:
+                    T.copy(B[bx * block_N, k * block_K], B_shared)
+                else:
+                    T.copy(B[k * block_K, bx * block_N], B_shared)
+                T.gemm(A_shared, B_shared, C_local, trans_A, trans_B)
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def run_gemm_jit_kernel(
+    M,
+    N,
+    K,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+    dtypeAccum,
+    block_M,
+    block_N,
+    block_K,
+    num_stages=3,
+    num_threads=128,
+):
+    program = matmu_jit_kernel(
+        M,
+        N,
+        K,
+        block_M,
+        block_N,
+        block_K,
+        trans_A,
+        trans_B,
+        in_dtype,
+        out_dtype,
+        dtypeAccum,
+        num_stages,
+        num_threads,
+    )
+
+    matmul_kernel = tilelang.JITKernel(program, out_idx=-1, execution_backend="cython")
+
+    A = torch.randn(M, K, dtype=torch.__getattribute__(in_dtype)).cuda()
+    B = torch.randn(K, N, dtype=torch.__getattribute__(in_dtype)).cuda()
+
+    if trans_A:
+        A = A.T
+    if trans_B:
+        B = B.T
+
+    def ref_program(A, B):
+        import torch
+        C = torch.matmul(A.to(torch.float), B.to(torch.float))
+        C = C.to(torch.__getattribute__(out_dtype))
+        return C
+
+    ref_C = ref_program(A, B)
+    C = matmul_kernel(A, B)
+
+    tilelang.testing.torch_assert_close(C, ref_C, atol=1e-2, rtol=1e-2, max_mismatched_ratio=0.05)
+
+
+def test_gemm_jit_kernel():
+    run_gemm_jit_kernel(
+        512,
+        1024,
+        768,
+        False,
+        False,
+        "float16",
+        "float16",
+        "float16",
+        128,
+        256,
+        32,
+        2,
+    )
+
+
+def run_cython_kernel_do_bench(M,
+                               N,
+                               K,
+                               trans_A,
+                               trans_B,
+                               in_dtype,
+                               out_dtype,
+                               dtypeAccum,
+                               block_M,
+                               block_N,
+                               block_K,
+                               num_stages=3,
+                               num_threads=128):
+    program = matmul(
+        M,
+        N,
+        K,
+        block_M,
+        block_N,
+        block_K,
+        trans_A,
+        trans_B,
+        in_dtype,
+        out_dtype,
+        dtypeAccum,
+        num_stages,
+        num_threads,
+    )
+
+    cython_matmul_kernel = tilelang.JITKernel(program, execution_backend="cython")
+    ctypes_matmul_kernel = tilelang.JITKernel(program, execution_backend="ctypes")
+
+    cython_profiler = cython_matmul_kernel.get_profiler()
+    ctypes_profiler = ctypes_matmul_kernel.get_profiler()
+
+
+    cython_latency = cython_profiler.do_bench(func=cython_matmul_kernel, profiler="torch")
+    print(f"cython Latency: {cython_latency} ms")
+
+    # assert ctypes_latency is not None
+
+    tvm_latency = cython_profiler.do_bench()
+    print(f"TVM Latency: {tvm_latency} ms")
+
+
+    assert tvm_latency is not None
+
+
+    ctypes_latency = ctypes_profiler.do_bench(func=ctypes_matmul_kernel, profiler="torch")
+    print(f"ctypes Latency: {ctypes_latency} ms")
+
+    assert cython_latency is not None
+
+
+def test_cython_kernel_do_bench():
+    run_cython_kernel_do_bench(512, 1024, 768, False, False, "float16", "float16", "float16", 128,
+                               256, 32, 2)
+
+
+def run_cython_kernel_multi_stream(M,
+                                   N,
+                                   K,
+                                   trans_A,
+                                   trans_B,
+                                   in_dtype,
+                                   out_dtype,
+                                   dtypeAccum,
+                                   block_M,
+                                   block_N,
+                                   block_K,
+                                   num_stages=3,
+                                   num_threads=128):
+    program = matmul(
+        M,
+        N,
+        K,
+        block_M,
+        block_N,
+        block_K,
+        trans_A,
+        trans_B,
+        in_dtype,
+        out_dtype,
+        dtypeAccum,
+        num_stages,
+        num_threads,
+    )
+
+    matmul_kernel = tilelang.JITKernel(program, execution_backend="cython")
+
+    tensor_a = torch.randn(M, K, dtype=torch.__getattribute__(in_dtype)).cuda()
+    tensor_b = torch.randn(K, N, dtype=torch.__getattribute__(in_dtype)).cuda()
+
+    if trans_A:
+        tensor_a = tensor_a.T
+    if trans_B:
+        tensor_b = tensor_b.T
+    tensor_c = torch.randn(M, N, dtype=torch.__getattribute__(out_dtype)).cuda()
+
+    num_streams = 4
+    for _ in range(num_streams):
+        stream = torch.cuda.Stream()
+        with torch.cuda.stream(stream):
+            matmul_kernel(tensor_a, tensor_b, tensor_c)
+
+
+def test_cython_kernel_multi_stream():
+    run_cython_kernel_multi_stream(512, 1024, 768, False, False, "float16", "float16", "float16",
+                                   128, 256, 32, 2)
+
+
+def run_cython_dynamic_shape(M,
+                             N,
+                             K,
+                             trans_A,
+                             trans_B,
+                             in_dtype,
+                             out_dtype,
+                             dtypeAccum,
+                             block_M,
+                             block_N,
+                             block_K,
+                             num_stages=3,
+                             num_threads=128):
+    program = matmul(
+        M,
+        N,
+        K,
+        block_M,
+        block_N,
+        block_K,
+        trans_A,
+        trans_B,
+        in_dtype,
+        out_dtype,
+        dtypeAccum,
+        num_stages,
+        num_threads,
+    )
+
+    matmul_kernel = tilelang.JITKernel(program, execution_backend="cython")
+    if isinstance(M, T.Var):
+        M = 1024
+    if isinstance(N, T.Var):
+        N = 1024
+    if isinstance(K, T.Var):
+        K = 768
+    tensor_a = torch.randn(M, K, dtype=torch.__getattribute__(in_dtype)).cuda()
+    tensor_b = torch.randn(K, N, dtype=torch.__getattribute__(in_dtype)).cuda()
+
+    if trans_A:
+        tensor_a = tensor_a.T
+    if trans_B:
+        tensor_b = tensor_b.T
+    tensor_c = torch.randn(M, N, dtype=torch.__getattribute__(out_dtype)).cuda()
+
+    matmul_kernel(tensor_a, tensor_b, tensor_c)
+
+    tensor_ref_c = torch.matmul(tensor_a.to(torch.float), tensor_b.to(torch.float))
+    tilelang.testing.torch_assert_close(
+        tensor_c, tensor_ref_c, atol=1e-2, rtol=1e-2, max_mismatched_ratio=0.05)
+
+
+def test_cython_dynamic_shape():
+    run_cython_dynamic_shape(
+        T.symbolic("m"), 1024, 768, False, False, "float16", "float16", "float16", 128, 256, 32, 2)
+
+    run_cython_dynamic_shape(
+        T.symbolic("m"), T.symbolic("n"), 768, False, False, "float16", "float16", "float16", 128,
+        256, 32, 2)
+
+    run_cython_dynamic_shape(
+        T.symbolic("m"), T.symbolic("n"), T.symbolic("k"), False, False, "float16", "float16",
+        "float16", 128, 256, 32, 2)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/kernel/test_tilelang_kernel_int4_gemm_mma.py
+++ b/testing/python/kernel/test_tilelang_kernel_int4_gemm_mma.py
@@ -136,14 +136,14 @@ def tl_matmul(
                         A_local,
                         A_shared,
                         ki,
-                        )
+                    )
 
                     # Load B into fragment
                     mma_emitter.ldmatrix_b(
                         B_local,
                         B_shared,
                         ki,
-                        )
+                    )
 
                     # Perform Matrix Multiplication
                     mma_emitter.mma(A_local, B_local, C_local)
@@ -321,14 +321,14 @@ def tl_matmul_weight_only_transform(
                         A_local,
                         A_shared,
                         ki,
-                        )
+                    )
 
                     # Load B into fragment
                     mma_emitter.ldmatrix_b(
                         B_local,
                         B_shared,
                         ki,
-                        )
+                    )
 
                     # Perform Matrix Multiplication
                     mma_emitter.mma(A_local, B_local, C_local)

--- a/testing/python/kernel/test_tilelang_kernel_int4_gemm_mma.py
+++ b/testing/python/kernel/test_tilelang_kernel_int4_gemm_mma.py
@@ -109,8 +109,6 @@ def tl_matmul(
             B_local = T.alloc_local((warp_cols * local_size_b), in_dtype)
             C_local = T.alloc_local((warp_rows * warp_cols * local_size_c), accum_dtype)
 
-            thread_binding = T.thread_binding(0, threads, "threadIdx.x")
-
             T.annotate_layout({
                 A_shared: make_swizzle_layout(A_shared),
                 B_shared: make_swizzle_layout(B_shared),
@@ -293,8 +291,6 @@ def tl_matmul_weight_only_transform(
             A_local = T.alloc_local((warp_rows * local_size_a), in_dtype)
             B_local = T.alloc_local((warp_cols * local_size_b), in_dtype)
             C_local = T.alloc_local((warp_rows * warp_cols * local_size_c), accum_dtype)
-
-            thread_binding = T.thread_binding(0, threads, "threadIdx.x")
 
             T.annotate_layout({
                 A_shared: make_swizzle_layout(A_shared),

--- a/tilelang/jit/adapter/__init__.py
+++ b/tilelang/jit/adapter/__init__.py
@@ -5,3 +5,4 @@ from .base import BaseKernelAdapter  # noqa: F401
 from .dlpack import TorchDLPackKernelAdapter  # noqa: F401
 from .torchcpp import TorchCPPKernelAdapter  # noqa: F401
 from .ctypes import CtypesKernelAdapter  # noqa: F401
+from .cython import CythonKernelAdapter  # noqa: F401

--- a/tilelang/jit/adapter/ctypes/wrapper.py
+++ b/tilelang/jit/adapter/ctypes/wrapper.py
@@ -89,12 +89,12 @@ class TLCUDASourceWrapper(object):
 
     def get_dynamic_symbolic_set(self, prim_func):
         # Determine the set of dynamic symbols used in the function
-        dynamic_symbolic_set = set()
+        dynamic_symbolic_set: List[str] = []
         for param in prim_func.params:
             buffer = prim_func.buffer_map[param]
             for dim in buffer.shape:
-                if isinstance(dim, tvm.tir.Var):
-                    dynamic_symbolic_set.add(dim.name)
+                if isinstance(dim, tvm.tir.Var) and (dim.name not in dynamic_symbolic_set):
+                    dynamic_symbolic_set.append(dim.name)
         return dynamic_symbolic_set
 
     def get_cuda_init_func(self):
@@ -201,203 +201,6 @@ class TLCUDASourceWrapper(object):
             raise ValueError("Cannot find primary function in the module.")
 
 
-class TLCUDASourceWrapperWithDynamic(TLCUDASourceWrapper):
-
-    def __init__(self, scheduled_ir_module: IRModule, source: str, target: Target):
-        super().__init__(scheduled_ir_module, source, target)
-
-    def get_cuda_init_func(self):
-        # Initialize an empty string to accumulate CUDA function calls for setting dynamic shared memory
-        call_str = """"""
-        # Iterate over functions and their dynamic shared memory requirements
-        for function_name, dynamic_smem_buf in self.dynamic_smem_buf.items():
-            if dynamic_smem_buf is not None:
-                # Format the cudaFuncSetAttribute call for dynamic shared memory
-                call_str += PREDEF_ARRTIBUTE_SET_DYNAMIC_MEMORY.format(
-                    function_name, dynamic_smem_buf)
-        # Define the init function that will set the attributes for each kernel
-        init_funcs = PREDEF_INIT_FUNC.format(call_str)
-        return init_funcs
-
-    def create_dispatch_func(self, code, function_informations):
-        # Extract the set of dynamic symbolic names used in the primary function
-        dynamic_symbolic_set = self.get_dynamic_symbolic_set(self.prim_func)
-
-        # Find the location of the global kernel function in the code
-        index = match_global_kernel(code)
-
-        # Analyze the function declaration to prepare for argument extraction
-        dummy_declaration = code[index:].split(";")[0]
-
-        function_name = self.function_name
-
-        # Identify the start of the function body to insert arguments
-        index = code.index("{", index)
-        function_args = []
-        # Collect function arguments based on primary function's parameters and buffer mappings
-        for param in self.prim_func.params:
-            buffer = self.prim_func.buffer_map[param]
-            function_args.append({
-                "name": buffer.name,
-                "type": self._TYPE_MAP[buffer.dtype] + "* __restrict__",
-            })
-        # Add dynamic symbols as integer arguments
-        for dyn_sym in dynamic_symbolic_set:
-            function_args.append({"name": dyn_sym, "type": "int"})
-
-        function_args.append({"name": "stream=cudaStreamDefault", "type": "cudaStream_t"},)
-
-        # Format the argument definitions for function declaration
-        def_args = ", ".join([f"{arg['type']} {arg['name']}" for arg in function_args])
-
-        def func_call_args(s: str, function_args):
-            # Extract and clean the function call arguments to match the declaration
-            pattern = r"[,\s]*(?:\w+\s*\*+\s*__restrict__\s+)?(\w+)"
-            matches = re.findall(pattern, s)
-            call_args = []
-            for match in matches:
-                match = re.sub(r"\d+", "", match)  # Remove numbers
-                match = re.sub(r"_", "", match)  # Remove underscores
-                for arg in function_args:
-                    if arg["name"] == match:
-                        call_args.append(match)
-            return call_args
-
-        call_args = ", ".join(func_call_args(dummy_declaration, function_args))
-
-        def legalize_c(p):
-            # Convert TIR expressions to legal C expressions
-            # Directly convert to string since the special case handling
-            # does not alter the string representation for `tvm.tir.Var` and `IntImm`.
-            # Replace Python's floor division operator with C's division operator
-            if isinstance(p, tvm.tir.IntImm):
-                p = int(p)
-            return str(p).replace("//", "/")
-
-        last_range = 0
-        num_items = len(function_informations)
-        _call_str = """"""
-        for last_range, (function_name, info) in enumerate(function_informations.items()):
-            # Prepare block and grid configurations for kernel launches
-            block_info, grid_info = info["block_info"], info["grid_info"]
-            block_str = "dim3({}, {}, {})".format(
-                legalize_c(block_info[0]),
-                legalize_c(block_info[1]),
-                legalize_c(block_info[2]),
-            )
-            grid_str = "dim3({}, {}, {})".format(
-                legalize_c(grid_info[0]),
-                legalize_c(grid_info[1]),
-                legalize_c(grid_info[2]),
-            )
-            # Handle dynamic shared memory specification
-            smem_str = (0 if info["dynamic_smem_buf"] is None else info["dynamic_smem_buf"])
-            opt_shapes = info["opt_shapes"]
-            # Generate conditional kernel launch code based on dynamic symbolic ranges
-            (symbolic,) = list(dynamic_symbolic_set)
-            range_str = opt_shapes[symbolic]
-            if last_range == 0:
-                call_str = "  if ({} == 0) return; \n".format(symbolic,)
-                call_str += "  if ({} <= {}) {{\n    {}<<<{}, {}, {}, stream>>>({}); \n  }}\n".format(
-                    symbolic,
-                    range_str,
-                    function_name,
-                    grid_str,
-                    block_str,
-                    smem_str,
-                    call_args,
-                )
-            else:
-                call_str = "  else if ({} <= {}) {{\n    {}<<<{}, {}, {}, stream>>>({}); \n  }}\n".format(
-                    symbolic,
-                    range_str,
-                    function_name,
-                    grid_str,
-                    block_str,
-                    smem_str,
-                    call_args,
-                )
-            if last_range == num_items - 1:
-                call_str += "  else {{\n    {}<<<{}, {}, {}, stream>>>({}); \n  }}\n".format(
-                    function_name, grid_str, block_str, smem_str, call_args)
-            _call_str += call_str
-
-        # Wrap the kernel dispatch logic in an external C function
-        host_func = PREDEF_HOST_FUNC.format(def_args, _call_str)
-        return host_func
-
-    def parse_source_information(self):
-        # Parse device module to extract execution configurations for each function
-        device_mod = get_annotated_device_mod(self.mod, self.target, backend=self.backend)
-        block_info_map = {}
-        grid_info_map = {}
-        dynamic_smem_buf_map = {}
-        for g_var, func in device_mod.functions.items():
-            # Default block and grid configurations
-            block_info = [1, 1, 1]
-            grid_info = [1, 1, 1]
-            function_name = g_var.name_hint
-            attrs = func.attrs
-            dynamic_smem_buf = None
-            if "dyn_shared_memory_buf" in attrs:
-                dynamic_smem_buf = int(attrs["dyn_shared_memory_buf"])
-            if "thread_extent" in attrs:
-                # Extract block and grid sizes from thread extents
-                thread_extent = attrs["thread_extent"]
-                for tag, extent in thread_extent.items():
-                    if "threadIdx" in tag:
-                        block_info["xyz".index(tag[-1])] = extent
-                    elif "blockIdx" in tag:
-                        grid_info["xyz".index(tag[-1])] = extent
-            # Map the extracted configurations to each function
-            block_info_map[function_name] = block_info
-            grid_info_map[function_name] = grid_info
-            dynamic_smem_buf_map[function_name] = dynamic_smem_buf
-        # Store the mappings for use in code generation
-        self.block_info = block_info_map
-        self.grid_info = grid_info_map
-        self.dynamic_smem_buf = dynamic_smem_buf_map
-
-    def update_lib_code(self, code: str):
-        # Organize function information for code generation
-        function_informations = {}
-        for g_var, func in self.mod.functions.items():
-            function_name = g_var.name_hint
-            # Do not update function with dispatch host function
-            if (function_name not in self.block_info) or (function_name not in self.grid_info):
-                continue
-
-            attrs = func.attrs
-            assert "opt_shapes" in attrs
-            opt_shapes = attrs["opt_shapes"]
-            function_informations[function_name] = {
-                "function_name": function_name,
-                "opt_shapes": opt_shapes,
-                "block_info": self.block_info[function_name],
-                "grid_info": self.grid_info[function_name],
-                "dynamic_smem_buf": self.dynamic_smem_buf[function_name],
-            }
-
-        def compare_map_objects(map_obj):
-            comparable_representation = list(map_obj.values())
-            return comparable_representation
-
-        function_informations = dict(
-            sorted(
-                function_informations.items(),
-                key=lambda item: compare_map_objects(item[1]["opt_shapes"]),
-            ))
-
-        self.lib_code = code
-
-        # Generate the initialization and dispatch functions
-        init_func = self.get_cuda_init_func()
-        host_func = self.create_dispatch_func(code, function_informations)
-        # Concatenate source code with generated code segments
-        lib_code = self.source + init_func + host_func
-        return lib_code
-
-
 class TLHIPSourceWrapper(TLCUDASourceWrapper):
 
     def __init__(self, scheduled_ir_module: IRModule, source: str, target: Target):
@@ -430,11 +233,10 @@ class TLWrapper(BaseWrapper):
         self.scheduled_ir_module = scheduled_ir_module
 
     # Get Scheduled Rt Module and return source to be compiled
-    def wrap(self, c_source: str, is_dynamic: bool = False):
+    def wrap(self, c_source: str):
         assert self.scheduled_ir_module is not None, "Please assign optimized module first."
         if is_cuda_target(self.target):
-            wrapper_class = (
-                TLCUDASourceWrapper if not is_dynamic else TLCUDASourceWrapperWithDynamic)
+            wrapper_class = TLCUDASourceWrapper
         elif is_hip_target(self.target):
             wrapper_class = TLHIPSourceWrapper
         else:

--- a/tilelang/jit/adapter/cython/__init__.py
+++ b/tilelang/jit/adapter/cython/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from .adapter import CythonKernelAdapter  # noqa: F401

--- a/tilelang/jit/adapter/cython/adapter.py
+++ b/tilelang/jit/adapter/cython/adapter.py
@@ -1,0 +1,212 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+"""The profiler and convert to torch utils"""
+
+from ..base import BaseKernelAdapter
+import ctypes
+from typing import List, Optional, Union, Callable, Dict, Tuple
+from tilelang import tvm as tvm
+from tvm.target import Target
+from tvm.relay import TensorType
+from tvm import tir
+from .wrapper import TLWrapper
+from .libgen import LibraryGenerator
+from tilelang.utils.target import determine_target
+from tilelang.utils.language import retrieve_func_from_module
+
+import sys
+import sysconfig
+import hashlib
+import os
+from pathlib import Path
+import logging
+
+logger = logging.getLogger("tilelang")
+
+# Add cache management functions at module level
+def get_cache_dir() -> Path:
+    """Get the cache directory for the current Python version."""
+    py_version = f"py{sys.version_info.major}{sys.version_info.minor}"
+    # current directory
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    cache_dir = Path(current_dir) / ".cycache" / py_version
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir
+
+def get_cached_lib(source_code: str) -> Tuple[Optional[ctypes.CDLL], Path]:
+    """Try to load cached library or return None if not found."""
+    code_hash = hashlib.sha256(source_code.encode()).hexdigest()
+    cache_path = get_cache_dir() / f"{code_hash}.so"
+    if cache_path.exists():
+        try:
+            return ctypes.CDLL(str(cache_path)), cache_path
+        except:
+            return None, cache_path
+    return None, cache_path
+
+# read the cython_wrapper.pyx file
+current_dir = os.path.dirname(os.path.abspath(__file__))
+cython_wrapper_path = os.path.join(current_dir, "cython_wrapper.pyx")
+
+with open(cython_wrapper_path, "r") as f:
+    cython_wrapper_code = f.read()
+    cache_dir = get_cache_dir()
+    source_path = cache_dir / "cython_wrapper.cpp"
+    library_path = cache_dir / "cython_wrapper.so"
+    md5_path = cache_dir / "md5.txt"
+    code_hash = hashlib.sha256(cython_wrapper_code.encode()).hexdigest()
+    
+    # Check if cached version exists and is valid
+    need_compile = True
+    if md5_path.exists() and library_path.exists():
+        with open(md5_path, "r") as f:
+            cached_hash = f.read().strip()
+            if cached_hash == code_hash:
+                logger.debug(f"Cython jit adapter is up to date, no need to compile...")
+                need_compile = False
+            else:
+                logger.info(f"Cython jit adapter is out of date, need to compile...")
+    else:
+        logger.info(f"No cached version found for cython jit adapter, need to compile...")
+    
+    if need_compile:
+        logger.info(f"Compiling cython jit adapter...")
+        with open(md5_path, "w") as f:
+            f.write(code_hash)
+        # compile the cython_wrapper.pyx file into .cpp
+        os.system(f"cython {cython_wrapper_path} --cplus -o {source_path}")
+        # compile the .cpp file into .so
+        python_include_path = sysconfig.get_path("include")
+        command = f"g++ -shared -pthread -fPIC -fwrapv -O2 -Wall -fno-strict-aliasing -I{python_include_path} {source_path} -o {library_path}"
+        try:
+            os.system(command)
+        except Exception as e:
+            raise f"Failed to compile cython jit adapter" from e
+    
+    # add the .so file to the sys.path
+    cache_dir_str = str(cache_dir)
+    if cache_dir_str not in sys.path:
+        sys.path.append(cache_dir_str)
+
+from cython_wrapper import CythonKernelWrapper
+
+class CythonKernelAdapter(BaseKernelAdapter):
+    """Adapter class that converts TVM/TIR functions to callable CUDA kernels using ctypes.
+    
+    This adapter handles:
+    1. Converting TIR functions to compiled CUDA libraries
+    2. Managing dynamic shapes in tensor operations
+    3. Wrapping C++ kernels for Python/PyTorch usage
+    """
+
+    # Class attributes to store compiled kernel information
+    target: str = "cuda"
+    ir_module: Optional[tvm.IRModule] = None
+    lib: Optional[ctypes.CDLL] = None  # Compiled library handle
+    wrapped_source: Optional[str] = None  # Generated C++ wrapper code
+    # Maps symbolic variables to their corresponding buffer and shape indices
+    dynamic_symbolic_map: Optional[Dict[tir.Var, Tuple[int, int]]] = None
+
+    def __init__(self,
+                 rt_mod,
+                 params: List[TensorType],
+                 result_idx: List[int],
+                 target,
+                 func_or_mod: Union[tir.PrimFunc, tvm.IRModule],
+                 verbose: bool = False):
+        """Initialize the adapter with the given TIR function or module.
+        
+        Args:
+            rt_mod: Runtime module
+            params: List of tensor types for inputs/outputs
+            result_idx: Indices of output tensors
+            target: Target platform (e.g., 'cuda')
+            func_or_mod: TIR function or module to be compiled
+            verbose: Enable verbose logging
+        """
+        self.mod = rt_mod
+        self.params = params
+        self.result_idx = self._legalize_result_idx(result_idx)
+
+        if isinstance(func_or_mod, tir.PrimFunc):
+            self.ir_module = tvm.IRModule({func_or_mod.attrs["global_symbol"]: func_or_mod})
+        else:
+            self.ir_module = func_or_mod
+
+        self.dynamic_symbolic_map = self._process_dynamic_symbolic()
+
+        self.target = Target.canon_target(determine_target(target))
+        self.verbose = verbose
+        self.wrapper = TLWrapper(self.target)
+        self.lib_generator = LibraryGenerator(self.target)
+
+        self.wrapper.assign_optimized_module(self.ir_module)
+        self.wrapped_source = self.wrapper.wrap(self.get_kernel_source())
+
+        self.lib_generator.update_lib_code(self.wrapped_source)
+        self.lib_generator.compile_lib()
+        self.lib = self.lib_generator.load_lib()
+        self.lib.init()
+
+        self.cython_wrapper = CythonKernelWrapper(self.dynamic_symbolic_map, self.result_idx, self.params, self.lib)
+
+        self._post_init()
+
+    def _process_dynamic_symbolic(self):
+        """Extract information about dynamic shapes from the TIR function.
+        
+        Maps symbolic variables to their corresponding (buffer_index, shape_dimension)
+        for runtime shape resolution.
+        """
+        func = self.prim_func
+        params = func.params
+        buffer_map = func.buffer_map
+        dynamic_symbolic_map = {}
+        for i, param in enumerate(params):
+            buffer = buffer_map[param]
+            for j, shape in enumerate(buffer.shape):
+                if isinstance(shape, tir.Var) and (shape not in dynamic_symbolic_map):
+                    dynamic_symbolic_map[shape] = (i, j)
+        return dynamic_symbolic_map
+
+    def _forward_from_prebuild_lib(self, *args, stream: Optional[int] = None):
+        """Low-level function to call the compiled CUDA kernel.
+        
+        Converts PyTorch tensor pointers to C void pointers for ctypes interface.
+        """
+        ctypes_args = [
+            ctypes.c_void_p(arr.data_ptr()) if not isinstance(arr, int) else arr for arr in args
+        ]
+        ctypes_args.append(ctypes.c_void_p(stream))
+        self.lib.call(*ctypes_args)
+
+    def _convert_torch_func(self) -> Callable:
+        """Returns a PyTorch-compatible function wrapper for the kernel."""
+        def lambda_forward(*args, stream: int = -1):
+            return self.cython_wrapper.forward([*args], stream=stream)
+        return lambda_forward
+
+    @property
+    def prim_func(self) -> tir.PrimFunc:
+        """Returns the primary TIR function from the IR module."""
+        return retrieve_func_from_module(self.ir_module)
+
+    @property
+    def srcpath(self):
+        """Returns the source path of the compiled library."""
+        return self.lib_generator.srcpath
+
+    @property
+    def libpath(self):
+        """Returns the path to the compiled library."""
+        return self.lib_generator.libpath
+
+    @property
+    def lib_code(self):
+        """Returns the code of the compiled library."""
+        return self.lib_generator.lib_code
+
+    @property
+    def is_dynamic(self):
+        """Indicates whether the kernel handles dynamic shapes."""
+        return (self.dynamic_symbolic_map is not None and len(self.dynamic_symbolic_map) > 0)

--- a/tilelang/jit/adapter/cython/cython_wrapper.pyx
+++ b/tilelang/jit/adapter/cython/cython_wrapper.pyx
@@ -1,0 +1,79 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+# cython: language_level=3
+
+import torch
+cimport cython
+import ctypes
+from libc.stdint cimport int64_t, uintptr_t
+from libc.stdlib cimport malloc, free
+
+cdef class CythonKernelWrapper:
+    # Class attributes to store kernel configuration and library reference
+    cdef:
+        object dynamic_symbolic_map  # Maps dynamic dimensions to their corresponding tensor indices
+        list result_idx             # Indices of output tensors in the params list
+        list params                 # List of parameter specifications (includes both inputs and outputs)
+        object lib                  # Reference to the compiled library containing the kernel
+
+    def __cinit__(self, dynamic_symbolic_map, result_idx, params, lib):
+        # Initialize wrapper with kernel configuration
+        self.dynamic_symbolic_map = dynamic_symbolic_map
+        self.result_idx = result_idx
+        self.params = params
+        self.lib = lib
+
+    cpdef forward(self, list inputs, int stream = -1):
+        # Validate input dimensions and prepare for kernel execution
+        cdef int total_params = len(self.params)
+        cdef int total_inputs = len(inputs)
+        cdef int total_result_idx = len(self.result_idx)
+        cdef int total_dynamic_symbolics = len(self.dynamic_symbolic_map)
+
+        # Ensure the number of inputs matches expected parameter count
+        if total_params != total_inputs + total_result_idx:
+            raise ValueError(
+                f"Expected {len(self.params)} inputs, got {len(inputs) + len(self.result_idx)} with {len(inputs)} inputs and {len(self.result_idx)} outputs"
+            )
+
+        # Use current CUDA stream if none specified
+        if stream == -1:
+            stream = <uintptr_t>torch.cuda.current_stream().cuda_stream
+
+        cdef int ins_idx = 0
+        cdef list tensor_list = []
+        cdef list call_args = []
+
+        # Prepare input and output tensors
+        for i in range(len(self.params)):
+            if i in self.result_idx:
+                # Create empty output tensor with specified dtype and shape
+                dtype = torch.__getattribute__(str(self.params[i].dtype))
+                shape = list(map(int, self.params[i].shape))
+                device = inputs[0].device if len(inputs) > 0 else torch.cuda.current_device()
+                tensor = torch.empty(*shape, dtype=dtype, device=device)
+            else:
+                # Use provided input tensor
+                tensor = inputs[ins_idx]
+                ins_idx += 1
+            tensor_list.append(tensor)
+        
+        # Convert tensor pointers to C void pointers for kernel call
+        call_args = [ctypes.c_void_p(tensor_list[i].data_ptr()) for i in range(len(tensor_list))]
+
+        # Add dynamic dimension values to kernel arguments
+        for _, (buffer_idx, shape_idx) in self.dynamic_symbolic_map.items():
+            call_args.append(tensor_list[buffer_idx].shape[shape_idx])
+        
+        # Add CUDA stream to kernel arguments
+        call_args.append(ctypes.c_void_p(stream))
+
+        # Execute the kernel
+        self.lib.call(*call_args)
+
+        # Return output tensor(s)
+        if len(self.result_idx) == 1:
+            return tensor_list[self.result_idx[0]]
+        else:
+            return [tensor_list[i] for i in self.result_idx]
+    

--- a/tilelang/jit/adapter/cython/libgen.py
+++ b/tilelang/jit/adapter/cython/libgen.py
@@ -1,0 +1,106 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+from typing import Optional
+from .utils import is_cuda_target, is_hip_target
+from tilelang import tvm as tvm
+from tilelang.contrib.nvcc import get_target_compute_version
+from tvm.target import Target
+import ctypes
+import os
+import tempfile
+import subprocess
+import logging
+from tilelang.env import TILELANG_TEMPLATE_PATH, CUTLASS_INCLUDE_DIR
+
+logger = logging.getLogger(__name__)
+
+
+class LibraryGenerator(object):
+    srcpath: Optional[str] = None
+    libpath: Optional[str] = None
+    lib_code: Optional[str] = None
+
+    def __init__(self, target: Target):
+        self.target = target
+
+    def update_lib_code(self, lib_code: str):
+        self.lib_code = lib_code
+
+    # Assume currently we only support CUDA compilation
+    def load_lib(self):
+        return ctypes.CDLL(self.libpath)
+
+    def compile_lib(self, timeout: float = None, with_tl: bool = True):
+        target = self.target
+        if is_cuda_target(target):
+            src = tempfile.NamedTemporaryFile(mode="w", suffix=".cu", delete=False)
+            compute_version = "".join(get_target_compute_version(target).split("."))
+            libpath = src.name.replace(".cu", ".so")
+
+            command = [
+                "nvcc",
+                "-std=c++17",
+                "-Xcudafe",
+                "--diag_suppress=177",
+                "--compiler-options",
+                "'-fPIC'",
+                "-lineinfo",
+                "--shared",
+                src.name,
+                "-lcuda",
+                "-gencode",
+                f"arch=compute_{compute_version},code=sm_{compute_version}",
+            ]
+
+        elif is_hip_target(target):
+            src = tempfile.NamedTemporaryFile(mode="w", suffix=".cpp", delete=False)
+            libpath = src.name.replace(".cpp", ".so")
+
+            command = [
+                "hipcc",
+                "-std=c++17",
+                "-fPIC",
+                "--shared",
+                src.name,
+            ]
+
+        else:
+            raise ValueError(f"Unsupported target: {target}")
+
+        if with_tl:
+            command += [
+                "-I" + TILELANG_TEMPLATE_PATH,
+                "-I" + CUTLASS_INCLUDE_DIR,
+            ]
+            command += ["-diag-suppress=20013"]
+        command += ["-o", libpath]
+
+        src.write(self.lib_code)
+        src.flush()
+        try:
+            ret = subprocess.run(command, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            logger.warning(f"Compilation Timeout! {command}")
+            return None
+        if ret.returncode != 0:
+            logger.warning(f"Compilation Failed! {command}")
+            return None
+        self.srcpath = src.name
+        self.libpath = libpath
+
+    def remove_lib(self):
+        if self.libpath:
+            os.remove(self.libpath)
+        self.libpath = None
+
+    def get_source_path(self):
+        return self.srcpath
+
+    def get_lib_path(self):
+        return self.libpath
+
+    def set_lib_path(self, libpath):
+        self.libpath = libpath
+
+    def set_src_path(self, srcpath):
+        self.srcpath = srcpath

--- a/tilelang/jit/adapter/cython/utils.py
+++ b/tilelang/jit/adapter/cython/utils.py
@@ -1,0 +1,104 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+import re
+from typing import Union, Optional
+from tilelang import tvm as tvm
+from tvm import IRModule, tir
+from tvm.target import Target
+import tilelang.transform
+from tilelang.engine.lower import (
+    is_device_call,
+    determine_target,
+    canon_target_host,
+)
+
+
+def match_global_kernel(source: str) -> int:
+    pattern = r"__global__\s+void\s+[__launch_bounds__\(\d+\)\s+]\w+"
+    matched = re.findall(pattern, source)
+    assert len(matched) >= 1  # may have statement before kernel
+    return source.index(matched[0])
+
+
+def is_cuda_target(target: Target) -> bool:
+    return target.kind.name == "cuda"
+
+
+def is_hip_target(target: Target) -> bool:
+    return target.kind.name == "hip"
+
+
+def get_annotated_device_mod(
+    func_or_mod: Union[tir.PrimFunc, tvm.IRModule],
+    target: Union[str, Target] = "auto",
+    target_host: Optional[Union[str, Target]] = None,
+) -> "IRModule":
+
+    mod = func_or_mod
+    if isinstance(func_or_mod, tir.PrimFunc):
+        func = func_or_mod
+        mod = tvm.IRModule({func.attrs["global_symbol"]: func})
+
+    if isinstance(target, str):
+        target = determine_target(target)
+
+    target_host = canon_target_host(target, target_host)
+
+    target_host = tvm.target.Target.canon_target(target_host)
+    target = tvm.target.Target(target, target_host)
+
+    mod = tir.transform.BindTarget(target)(mod)
+
+    mod = tilelang.transform.FrontendLegalize()(mod)
+    mod = tir.transform.Simplify()(mod)
+    mod = tilelang.transform.LayoutInference()(mod)
+    mod = tilelang.transform.LowerTileOp()(mod)
+    mod = tir.transform.Simplify()(mod)
+
+    if target.arch == "sm_90":
+        mod = tilelang.transform.WarpSpecializedPipeline()(mod)
+    else:
+        mod = tir.transform.PlanAndUpdateBufferAllocationLocation()(mod)
+        mod = tilelang.transform.PipelinePlanning()(mod)
+        mod = tilelang.transform.InjectSoftwarePipeline()(mod)
+
+    mod = tir.transform.LowerOpaqueBlock()(mod)
+    mod = tir.transform.FlattenBuffer()(mod)
+    mod = tir.transform.NarrowDataType(32)(mod)
+    mod = tir.transform.Simplify()(mod)
+
+    mod = tir.transform.VectorizeLoop()(mod)
+    mod = tir.transform.StorageRewrite()(mod)
+    mod = tir.transform.UnrollLoop()(mod)
+    mod = tir.transform.RenormalizeSplitPattern()(mod)
+    mod = tir.transform.Simplify()(mod)
+    mod = tir.transform.RemoveNoOp()(mod)
+    mod = tir.transform.RewriteUnsafeSelect()(mod)
+    mod = tir.transform.HoistIfThenElse()(mod)
+
+    mod = tir.transform.VerifyMemory()(mod)
+    mod = tir.transform.AnnotateEntryFunc()(mod)
+    mod = tir.transform.ThreadSync("shared")(mod)
+    # TODO(lei): This is a hack to make sure the
+    # thread level allreduce pass can be applied
+    # in TL. As Tl only use one thread dimension
+    # the var binding information will be lost
+    # in the lowering process with Legalization
+    # and Simplify pass.
+    # We can find a way better to create var instead
+    # of putting the LowerThreadAllreduce before
+    # the Legalization.
+    mod = tir.transform.LowerThreadAllreduce()(mod)
+    mod = tir.transform.ThreadSync("shared.dyn")(mod)
+    mod = tilelang.transform.LowerHopperIntrin()(mod)
+    mod = tir.transform.InjectPTXAsyncCopy()(mod)
+
+    mod = tir.transform.AnnotateDeviceRegions()(mod)
+    mod = tir.transform.SplitHostDevice()(mod)
+    mod = tir.transform.MergeSharedMemoryAllocations()(mod)
+    mod = tir.transform.MakePackedAPI()(mod)
+    mod = tir.transform.LowerDeviceKernelLaunch()(mod)
+
+    device_mod = tir.transform.Filter(is_device_call)(mod)
+
+    return device_mod

--- a/tilelang/jit/adapter/cython/wrapper.py
+++ b/tilelang/jit/adapter/cython/wrapper.py
@@ -243,4 +243,5 @@ class TLWrapper(BaseWrapper):
         else:
             raise ValueError(f"Unsupported platform: {self.arch.platform}")
         wrapper = wrapper_class(self.scheduled_ir_module, c_source, self.target)
+        print(wrapper.lib_code)
         return wrapper.lib_code

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -7,7 +7,7 @@ import tilelang
 from tilelang import tvm as tvm
 from tvm.tir import PrimFunc
 
-from tilelang.jit.adapter import TorchCPPKernelAdapter, TorchDLPackKernelAdapter, BaseKernelAdapter, CtypesKernelAdapter
+from tilelang.jit.adapter import TorchCPPKernelAdapter, TorchDLPackKernelAdapter, BaseKernelAdapter, CtypesKernelAdapter, CythonKernelAdapter
 from tilelang.utils.target import determine_target, AVALIABLE_TARGETS
 from tilelang.profiler import Profiler, TensorSupplyType
 
@@ -34,7 +34,7 @@ class JITKernel(object):
         self,
         func: PrimFunc = None,
         out_idx: Union[List[int], int] = None,
-        execution_backend: Literal["dlpack", "torch_cpp", "ctypes"] = "dlpack",
+        execution_backend: Literal["dlpack", "torch_cpp", "ctypes", "cython"] = "cython",
         target: Union[str, Target] = "auto",
         target_host: Union[str, Target] = None,
         verbose: bool = False,
@@ -73,8 +73,8 @@ class JITKernel(object):
         target = Target(target)
 
         # Validate the execution backend.
-        assert execution_backend in ["dlpack", "torch_cpp",
-                                     "ctypes"], f"Invalid execution backend. {execution_backend}"
+        assert execution_backend in ["dlpack", "torch_cpp", "ctypes",
+                                     "cython"], f"Invalid execution backend. {execution_backend}"
 
         # Compile the TileLang function and create a kernel adapter for execution.
         adapter = self._compile_and_create_adapter(func)
@@ -145,8 +145,16 @@ class JITKernel(object):
             )
             raise NotImplementedError("Torch CPP backend is not fully implemented.")
         elif execution_backend == "ctypes":
-            # CTYPES backend (not fully tested yet).
             adapter = CtypesKernelAdapter(
+                rt_mod,
+                params=params,
+                result_idx=out_idx,
+                target=target,
+                func_or_mod=tilelang_func,
+                verbose=verbose,
+            )
+        elif execution_backend == "cython":
+            adapter = CythonKernelAdapter(
                 rt_mod,
                 params=params,
                 result_idx=out_idx,

--- a/tilelang/language/__init__.py
+++ b/tilelang/language/__init__.py
@@ -35,6 +35,10 @@ from .customize import (
 from .builtin import *  # noqa: F401
 
 
+def symbolic(name: str, dtype: str = "int32"):
+    return tir.Var(name, dtype)
+
+
 def use_swizzle(panel_size: int, order: str = "row", enable: bool = True):
     # If order is row, use rasterization2DRow, otherwise use rasterization2DColumn
     # The panel size is the number of threads in a warp

--- a/tilelang/utils/language.py
+++ b/tilelang/utils/language.py
@@ -4,6 +4,8 @@
 from tvm.tir import Buffer
 from typing import List
 from functools import reduce
+from tvm import IRModule
+from tvm.tir import PrimFunc
 
 # Scope Checkers for TVM Buffers
 # These utility functions check the memory scope of a given TVM buffer.
@@ -89,3 +91,26 @@ def array_reduce(array: List[int]) -> int:
         int: The reduced integer.
     """
     return reduce(lambda x, y: x * y, array)
+
+
+def retrieve_func_from_module(ir_module: IRModule) -> PrimFunc:
+    """
+    Retrieve the single PrimFunc from an IRModule.
+
+    Args:
+        ir_module (IRModule): The TVM IRModule to extract the function from.
+            The module should contain exactly one global function.
+
+    Returns:
+        PrimFunc: The single function contained in the module.
+
+    Raises:
+        ValueError: If ir_module is not an IRModule.
+        AssertionError: If the module contains more than one global function.
+    """
+    if not isinstance(ir_module, IRModule):
+        raise ValueError("Not supported type: ", type(ir_module))
+    assert len(ir_module.get_global_vars()) == 1, (
+        "The optimized module should only have one global variable for default schedule.")
+    func = list(ir_module.functions.values())[0]
+    return func


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and structure of the `tilelang` project. The most important changes include the addition of new test cases for the ctypes kernel, the introduction of a new kernel adapter, and enhancements to the ctypes adapter functionality.

### Enhancements to testing:

* Added new test cases for the ctypes kernel, including `run_ctypes_kernel_do_bench`, `run_ctypes_kernel_multi_stream`, and `run_ctypes_dynamic_shape` in `testing/python/jit/test_tilelang_jit_gemm_ctypes.py`. These tests ensure that the ctypes kernel performs correctly under various conditions and configurations.

### New kernel adapter:

* Introduced the `CythonKernelAdapter` in `tilelang/jit/adapter/__init__.py`, expanding the project's capability to handle different types of kernel adapters.

### Enhancements to ctypes adapter:

* Enhanced the `CtypesKernelAdapter` in `tilelang/jit/adapter/ctypes/adapter.py` by adding detailed class-level documentation, handling dynamic shapes, and improving the initialization process. These changes make the adapter more robust and easier to use. [[1]](diffhunk://#diff-2234f838318e2a6bc276679648d8f0baf10ededce1bf0a6443538fe96449ce74L8-R52) [[2]](diffhunk://#diff-2234f838318e2a6bc276679648d8f0baf10ededce1bf0a6443538fe96449ce74R62-R187)
* Modified the `get_dynamic_symbolic_set` method in `tilelang/jit/adapter/ctypes/wrapper.py` to use a list instead of a set for dynamic symbols, ensuring the order is preserved.
* Improved the `legalize_c` method in `tilelang/jit/adapter/ctypes/wrapper.py` to correctly handle the CUDA kernel launch string.

### Minor fixes and improvements:

* Updated the `package_data` in `setup.py` to include `*pyx` files, ensuring all necessary files are packaged.
* Removed unused imports and reorganized the import statements in `testing/python/jit/test_tilelang_jit_gemm_ctypes.py` for better readability and maintainability. [[1]](diffhunk://#diff-c3bfb0dc0b52cf7594e30f2461199baebd15ddb9ba96f2c62ea3f402f894d202R5) [[2]](diffhunk://#diff-c3bfb0dc0b52cf7594e30f2461199baebd15ddb9ba96f2c62ea3f402f894d202L30-L31)