### PR TITLE
[Wheel] Provide a bare docker scripts to help build wheels for manylinux

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,7 @@ include CMakeLists.txt
 include requirements.txt
 include requirements-test.txt
 include requirements-dev.txt
+include tilelang/jit/adapter/cython/cython_wrapper.pyx
 recursive-include src *
 recursive-include 3rdparty *
 recursive-exclude 3rdparty/clang* * 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,7 +3,6 @@ include CMakeLists.txt
 include requirements.txt
 include requirements-test.txt
 include requirements-dev.txt
-include tilelang/jit/adapter/cython/cython_wrapper.pyx
 recursive-include src *
 recursive-include 3rdparty *
 recursive-exclude 3rdparty/clang* * 

--- a/format.sh
+++ b/format.sh
@@ -35,9 +35,9 @@ tool_version_check() {
     fi
 }
 
-tool_version_check "yapf" $YAPF_VERSION "$(grep yapf requirements-dev.txt | cut -d'=' -f3)"
-tool_version_check "ruff" $RUFF_VERSION "$(grep "ruff==" requirements-dev.txt | cut -d'=' -f3)"
-tool_version_check "codespell" "$CODESPELL_VERSION" "$(grep codespell requirements-dev.txt | cut -d'=' -f3)"
+tool_version_check "yapf" $YAPF_VERSION "$(grep yapf requirements-lint.txt | cut -d'=' -f3)"
+tool_version_check "ruff" $RUFF_VERSION "$(grep "ruff==" requirements-lint.txt | cut -d'=' -f3)"
+tool_version_check "codespell" "$CODESPELL_VERSION" "$(grep codespell requirements-lint.txt | cut -d'=' -f3)"
 
 echo 'tile-lang yapf: Check Start'
 
@@ -196,7 +196,7 @@ echo 'tile-lang clang-format: Check Start'
 # If clang-format is available, run it; otherwise, skip
 if command -v clang-format &>/dev/null; then
     CLANG_FORMAT_VERSION=$(clang-format --version | awk '{print $3}')
-    tool_version_check "clang-format" "$CLANG_FORMAT_VERSION" "$(grep clang-format requirements-dev.txt | cut -d'=' -f3)"
+    tool_version_check "clang-format" "$CLANG_FORMAT_VERSION" "$(grep clang-format requirements-lint.txt | cut -d'=' -f3)"
 
     CLANG_FORMAT_FLAGS=("-i")
 

--- a/maint/scripts/build_docs.sh
+++ b/maint/scripts/build_docs.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 cd docs
 
 pip install -r requirements.txt
@@ -7,5 +10,3 @@ pip install -r requirements.txt
 make html
 
 cp CNAME _build/html/
-
-

--- a/maint/scripts/docker_local_distribute.sh
+++ b/maint/scripts/docker_local_distribute.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Get the CUDA version from the command line
+IMAGE=nvidia/cuda:12.1.0-devel-ubuntu18.04
+
+docker pull ${IMAGE}
+
+# Run the docker container with the command directly
+# docker run --rm -v $(pwd):/tilelang ${IMAGE} /bin/bash -c "cd /tilelang && export PATH=/usr/local/bin:$PATH export CC=/opt/rh/devtoolset-9/root/usr/bin/gcc && export CXX=/opt/rh/devtoolset-9/root/usr/bin/gcc && expprt CUDAHOSTCXX=/usr/bin/g++ && /opt/python/cp38-cp38/bin/python -m pip install -r requirements-build.txt && /opt/python/cp38-cp38/bin/python -m tox -e py38,py39,py310,py311,py312"
+
+
+# docker run --rm -v $(pwd):/tilelang ${IMAGE} /bin/bash -it
+
+command="apt update && apt install -y software-properties-common && add-apt-repository -y ppa:deadsnakes/ppa && apt update && apt install -y wget python3.8 python3.8-dev python3-pip python3-setuptools libtinfo-dev zlib1g-dev libssl-dev build-essential libedit-dev libxml2-dev && ln -s /usr/bin/python3.8 /usr/bin/python && wget https://github.com/Kitware/CMake/releases/download/v3.28.4/cmake-3.28.4-linux-x86_64.tar.gz && tar -xvzf cmake-*.tar.gz && rm cmake-*.tar.gz && cd cmake-* && cp bin/* /usr/local/bin/ && mv share/* /usr/local/share/ && mv man/* /usr/local/man/ && hash -r && cd /tilelang && export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH && python3.8 -m pip install  --upgrade pip && python3.8 -m pip install -r requirements-build.txt && python3.8 -m tox -e py38,py39,py310,py311,py312" 
+
+
+docker run --rm -v $(pwd):/tilelang ${IMAGE} /bin/bash -c "$command"

--- a/maint/scripts/docker_local_distribute.sh
+++ b/maint/scripts/docker_local_distribute.sh
@@ -8,13 +8,14 @@ IMAGE=nvidia/cuda:12.1.0-devel-ubuntu18.04
 
 docker pull ${IMAGE}
 
-# Run the docker container with the command directly
-# docker run --rm -v $(pwd):/tilelang ${IMAGE} /bin/bash -c "cd /tilelang && export PATH=/usr/local/bin:$PATH export CC=/opt/rh/devtoolset-9/root/usr/bin/gcc && export CXX=/opt/rh/devtoolset-9/root/usr/bin/gcc && expprt CUDAHOSTCXX=/usr/bin/g++ && /opt/python/cp38-cp38/bin/python -m pip install -r requirements-build.txt && /opt/python/cp38-cp38/bin/python -m tox -e py38,py39,py310,py311,py312"
+apt_command="apt update && apt install -y software-properties-common && add-apt-repository -y ppa:deadsnakes/ppa && apt update && apt install -y wget curl libtinfo-dev zlib1g-dev libssl-dev build-essential libedit-dev libxml2-dev"
 
+install_python_env="curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda3 && export PATH=~/miniconda3/bin/:$PATH && conda create -n py38 python=3.8 -y && conda create -n py39 python=3.9 -y && conda create -n py310 python=3.10 -y && conda create -n py311 python=3.11 -y && conda create -n py312 python=3.12 -y && ln -s ~/miniconda3/envs/py38/bin/python3.8 /usr/bin/python3.8 && ln -s ~/miniconda3/envs/py39/bin/python3.9 /usr/bin/python3.9 && ln -s ~/miniconda3/envs/py310/bin/python3.10 /usr/bin/python3.10 && ln -s ~/miniconda3/envs/py311/bin/python3.11 /usr/bin/python3.11 && ln -s ~/miniconda3/envs/py312/bin/python3.12 /usr/bin/python3.12"
 
-# docker run --rm -v $(pwd):/tilelang ${IMAGE} /bin/bash -it
+install_cmake="wget https://github.com/Kitware/CMake/releases/download/v3.28.4/cmake-3.28.4-linux-x86_64.tar.gz && tar -xvzf cmake-*.tar.gz && rm cmake-*.tar.gz && cd cmake-* && cp bin/* /usr/local/bin/ && mv share/* /usr/local/share/ && mv man/* /usr/local/man/ && hash -r && cd /tilelang && export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH"
 
-command="apt update && apt install -y software-properties-common && add-apt-repository -y ppa:deadsnakes/ppa && apt update && apt install -y wget python3.8 python3.8-dev python3-pip python3-setuptools libtinfo-dev zlib1g-dev libssl-dev build-essential libedit-dev libxml2-dev && ln -s /usr/bin/python3.8 /usr/bin/python && wget https://github.com/Kitware/CMake/releases/download/v3.28.4/cmake-3.28.4-linux-x86_64.tar.gz && tar -xvzf cmake-*.tar.gz && rm cmake-*.tar.gz && cd cmake-* && cp bin/* /usr/local/bin/ && mv share/* /usr/local/share/ && mv man/* /usr/local/man/ && hash -r && cd /tilelang && export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH && python3.8 -m pip install  --upgrade pip && python3.8 -m pip install -r requirements-build.txt && python3.8 -m tox -e py38,py39,py310,py311,py312" 
+install_pip="python3.8 -m pip install  --upgrade pip && python3.8 -m pip install -r requirements-build.txt"
 
+tox_command="python3.8 -m tox -e py38,py39,py310,py311,py312"
 
-docker run --rm -v $(pwd):/tilelang ${IMAGE} /bin/bash -c "$command"
+docker run --rm -v $(pwd):/tilelang ${IMAGE} /bin/bash -c "$apt_command && $install_python_env && $install_cmake && $install_pip && $tox_command"

--- a/maint/scripts/docker_pypi_distribute.sh
+++ b/maint/scripts/docker_pypi_distribute.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# Get the CUDA version from the command line
+CUDA_VERSION=$1
+if [ -z "${CUDA_VERSION}" ]; then
+    echo "No CUDA version provided, using default 124"
+    CUDA_VERSION=124
+fi
+
+IMAGE=pytorch/manylinux-cuda${CUDA_VERSION}
+
+docker pull ${IMAGE}
+
+# Run the docker container with the command directly
+docker run --rm -v $(pwd):/tilelang ${IMAGE} /bin/bash -c "cd /tilelang && export PATH=/usr/local/bin:$PATH && yum install -y python3.8 python3.9 python3.10 python3.11 python3.12 && pip install -r requirements-build.txt && tox -e py38-pypi,py39-pypi,py310-pypi,py311-pypi,py312-pypi"

--- a/maint/scripts/docker_pypi_distribute.sh
+++ b/maint/scripts/docker_pypi_distribute.sh
@@ -4,15 +4,18 @@
 # Licensed under the MIT License.
 
 # Get the CUDA version from the command line
-CUDA_VERSION=$1
-if [ -z "${CUDA_VERSION}" ]; then
-    echo "No CUDA version provided, using default 124"
-    CUDA_VERSION=124
-fi
-
-IMAGE=pytorch/manylinux-cuda${CUDA_VERSION}
+IMAGE=nvidia/cuda:12.1.0-devel-ubuntu18.04
 
 docker pull ${IMAGE}
 
-# Run the docker container with the command directly
-docker run --rm -v $(pwd):/tilelang ${IMAGE} /bin/bash -c "cd /tilelang && export PATH=/usr/local/bin:$PATH && yum install -y python3.8 python3.9 python3.10 python3.11 python3.12 && pip install -r requirements-build.txt && tox -e py38-pypi,py39-pypi,py310-pypi,py311-pypi,py312-pypi"
+apt_command="apt update && apt install -y software-properties-common && add-apt-repository -y ppa:deadsnakes/ppa && apt update && apt install -y wget curl libtinfo-dev zlib1g-dev libssl-dev build-essential libedit-dev libxml2-dev"
+
+install_python_env="curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda3 && export PATH=~/miniconda3/bin/:$PATH && conda create -n py38 python=3.8 -y && conda create -n py39 python=3.9 -y && conda create -n py310 python=3.10 -y && conda create -n py311 python=3.11 -y && conda create -n py312 python=3.12 -y && ln -s ~/miniconda3/envs/py38/bin/python3.8 /usr/bin/python3.8 && ln -s ~/miniconda3/envs/py39/bin/python3.9 /usr/bin/python3.9 && ln -s ~/miniconda3/envs/py310/bin/python3.10 /usr/bin/python3.10 && ln -s ~/miniconda3/envs/py311/bin/python3.11 /usr/bin/python3.11 && ln -s ~/miniconda3/envs/py312/bin/python3.12 /usr/bin/python3.12"
+
+install_cmake="wget https://github.com/Kitware/CMake/releases/download/v3.28.4/cmake-3.28.4-linux-x86_64.tar.gz && tar -xvzf cmake-*.tar.gz && rm cmake-*.tar.gz && cd cmake-* && cp bin/* /usr/local/bin/ && mv share/* /usr/local/share/ && mv man/* /usr/local/man/ && hash -r && cd /tilelang && export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH"
+
+install_pip="python3.8 -m pip install --upgrade pip && python3.8 -m pip install -r requirements-build.txt"
+
+tox_command="python3.8 -m tox -e py38-pypi,py39-pypi,py310-pypi,py311-pypi,py312-pypi"
+
+docker run --rm -v $(pwd):/tilelang ${IMAGE} /bin/bash -c "$apt_command && $install_python_env && $install_cmake && $install_pip && $tox_command"

--- a/maint/scripts/local_distribution_tox.sh
+++ b/maint/scripts/local_distribution_tox.sh
@@ -3,7 +3,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-multi_python_version=("3.8","3.9","3.10" "3.11", "3.12")
+multi_python_version=("3.8" "3.9" "3.10" "3.11" "3.12")
 for python_version in "${multi_python_version[@]}"; do
     echo "Installing Python ${python_version}..."
     apt-get install -y python${python_version}

--- a/maint/scripts/pypi_distribution_tox.sh
+++ b/maint/scripts/pypi_distribution_tox.sh
@@ -3,7 +3,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-multi_python_version=("3.8","3.9","3.10" "3.11", "3.12")
+multi_python_version=("3.8" "3.9" "3.10" "3.11" "3.12")
 for python_version in "${multi_python_version[@]}"; do
     echo "Installing Python ${python_version}..."
     apt-get install -y python${python_version}

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,4 +1,5 @@
 # Should be mirrored in pyproject.toml
+build
 cmake>=3.26
 packaging
 setuptools>=61

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,5 @@
-# formatting
-yapf==0.40.2
-toml==0.10.2
-tomli==2.0.1
-ruff==0.6.5
-codespell==2.3.0
-clang-format==15.0.7
-
+# lint requirements
+-r requirements-lint.txt
 # build requirements
 cmake>=3.26
 # runtime requirements

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,0 +1,7 @@
+# formatting
+yapf==0.40.2
+toml==0.10.2
+tomli==2.0.1
+ruff==0.6.5
+codespell==2.3.0
+clang-format==15.0.7

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,11 +1,5 @@
-# formatting
-yapf==0.40.2
-toml==0.10.2
-tomli==2.0.1
-ruff==0.6.5
-codespell==2.3.0
-clang-format==15.0.7
-
+# lint requirements
+-r requirements-lint.txt
 # build requirements
 cmake>=3.26
 # runtime requirements

--- a/setup.py
+++ b/setup.py
@@ -236,31 +236,31 @@ class TileLangBuilPydCommand(build_py):
         ]
 
         # copy cython files
-        CYTHON_SRC = [
-            "tilelang/jit/adapter/cython/cython_wrapper.pyx",
-        ]
-        for item in CYTHON_SRC:
-            print(f"Copying {item} to {self.build_lib}")
-            source_cython_file = None
-            for dir in potential_dirs:
-                candidate = os.path.join(dir, item)
-                if os.path.exists(candidate):
-                    source_cython_file = candidate
-                    break
+        # CYTHON_SRC = [
+        #     "tilelang/jit/adapter/cython/cython_wrapper.pyx",
+        # ]
+        # for item in CYTHON_SRC:
+        #     print(f"Copying {item} to {self.build_lib}")
+        #     source_cython_file = None
+        #     for dir in potential_dirs:
+        #         candidate = os.path.join(dir, item)
+        #         if os.path.exists(candidate):
+        #             source_cython_file = candidate
+        #             break
 
-            if source_cython_file:
-                source_dir = os.path.dirname(source_cython_file)
-                target_dir = os.path.join(self.build_lib, item)
-                if os.path.isdir(source_dir):
-                    self.mkpath(target_dir)
-                    distutils.dir_util.copy_tree(source_dir, target_dir)
-                else:
-                    target_dir = os.path.dirname(target_dir)
-                    if not os.path.exists(target_dir):
-                        os.makedirs(target_dir)
-                    shutil.copy2(source_cython_file, target_dir)
-            else:
-                print(f"WARNING: {item} not found in any expected directories!")
+        #     if source_cython_file:
+        #         source_dir = os.path.dirname(source_cython_file)
+        #         target_dir = os.path.join(self.build_lib, item)
+        #         if os.path.isdir(source_dir):
+        #             self.mkpath(target_dir)
+        #             distutils.dir_util.copy_tree(source_dir, target_dir)
+        #         else:
+        #             target_dir = os.path.dirname(target_dir)
+        #             if not os.path.exists(target_dir):
+        #                 os.makedirs(target_dir)
+        #             shutil.copy2(source_cython_file, target_dir)
+        #     else:
+        #         print(f"WARNING: {item} not found in any expected directories!")
 
         # copy the tl_templates
         TILELANG_SRC = [

--- a/setup.py
+++ b/setup.py
@@ -242,7 +242,7 @@ class TileLangBuilPydCommand(build_py):
                 target_dir = os.path.dirname(target_dir)
                 if not os.path.exists(target_dir):
                     os.makedirs(target_dir)
-                if not os.path.exists(target_dir):
+                if not os.path.exists(os.path.join(target_dir, os.path.basename(source_dir))):
                     # if not exists, copy the file
                     # as tox will copy the file to the build
                     # directory based on manifest file

--- a/setup.py
+++ b/setup.py
@@ -254,6 +254,11 @@ class TileLangBuilPydCommand(build_py):
                 if os.path.isdir(source_dir):
                     self.mkpath(target_dir)
                     distutils.dir_util.copy_tree(source_dir, target_dir)
+                else:
+                    target_dir = os.path.dirname(target_dir)
+                    if not os.path.exists(target_dir):
+                        os.makedirs(target_dir)
+                    shutil.copy2(source_cython_file, target_dir)
             else:
                 print(f"WARNING: {item} not found in any expected directories!")
 

--- a/setup.py
+++ b/setup.py
@@ -228,40 +228,6 @@ class TileLangBuilPydCommand(build_py):
         print(f"Extension output directory (parent): {ext_output_dir}")
         print(f"Build temp directory: {build_temp_dir}")
 
-        potential_dirs = [
-            ext_output_dir,
-            self.build_lib,
-            build_temp_dir,
-            os.path.join(ROOT_DIR, "build"),
-        ]
-
-        # copy cython files
-        # CYTHON_SRC = [
-        #     "tilelang/jit/adapter/cython/cython_wrapper.pyx",
-        # ]
-        # for item in CYTHON_SRC:
-        #     print(f"Copying {item} to {self.build_lib}")
-        #     source_cython_file = None
-        #     for dir in potential_dirs:
-        #         candidate = os.path.join(dir, item)
-        #         if os.path.exists(candidate):
-        #             source_cython_file = candidate
-        #             break
-
-        #     if source_cython_file:
-        #         source_dir = os.path.dirname(source_cython_file)
-        #         target_dir = os.path.join(self.build_lib, item)
-        #         if os.path.isdir(source_dir):
-        #             self.mkpath(target_dir)
-        #             distutils.dir_util.copy_tree(source_dir, target_dir)
-        #         else:
-        #             target_dir = os.path.dirname(target_dir)
-        #             if not os.path.exists(target_dir):
-        #                 os.makedirs(target_dir)
-        #             shutil.copy2(source_cython_file, target_dir)
-        #     else:
-        #         print(f"WARNING: {item} not found in any expected directories!")
-
         # copy the tl_templates
         TILELANG_SRC = [
             "src/tl_templates",
@@ -283,6 +249,13 @@ class TileLangBuilPydCommand(build_py):
             "libtvm.so",
             "libtilelang.so",
             "libtilelang_module.so",
+        ]
+
+        potential_dirs = [
+            ext_output_dir,
+            self.build_lib,
+            build_temp_dir,
+            os.path.join(ROOT_DIR, "build"),
         ]
 
         for item in TVM_PREBUILD_ITEMS:

--- a/setup.py
+++ b/setup.py
@@ -228,33 +228,25 @@ class TileLangBuilPydCommand(build_py):
         print(f"Extension output directory (parent): {ext_output_dir}")
         print(f"Build temp directory: {build_temp_dir}")
 
-        potential_dirs = [
-            ext_output_dir,
-            self.build_lib,
-            build_temp_dir,
-            os.path.join(ROOT_DIR, "build"),
-        ]
-
         # copy cython files
         CYTHON_SRC = [
             "tilelang/jit/adapter/cython/cython_wrapper.pyx",
         ]
         for item in CYTHON_SRC:
-            print(f"Copying {item} to {self.build_lib}")
-            source_cython_file = None
-            for dir in potential_dirs:
-                candidate = os.path.join(dir, item)
-                if os.path.exists(candidate):
-                    source_cython_file = candidate
-                    break
-
-            if source_cython_file:
-                source_dir = os.path.dirname(source_cython_file)
-                target_file = os.path.join(self.build_lib, item)
-                if not os.path.exists(target_file):
-                    shutil.copy2(source_cython_file, target_file)
+            source_dir = os.path.join(ROOT_DIR, item)
+            target_dir = os.path.join(self.build_lib, item)
+            if os.path.isdir(source_dir):
+                self.mkpath(target_dir)
+                distutils.dir_util.copy_tree(source_dir, target_dir)
             else:
-                print(f"WARNING: {item} not found in any expected directories!")
+                target_dir = os.path.dirname(target_dir)
+                if not os.path.exists(target_dir):
+                    os.makedirs(target_dir)
+                if not os.path.exists(target_dir):
+                    # if not exists, copy the file
+                    # as tox will copy the file to the build
+                    # directory based on manifest file
+                    shutil.copy2(source_dir, target_dir)
 
         # copy the tl_templates
         TILELANG_SRC = [
@@ -277,6 +269,13 @@ class TileLangBuilPydCommand(build_py):
             "libtvm.so",
             "libtilelang.so",
             "libtilelang_module.so",
+        ]
+
+        potential_dirs = [
+            ext_output_dir,
+            self.build_lib,
+            build_temp_dir,
+            os.path.join(ROOT_DIR, "build"),
         ]
 
         for item in TVM_PREBUILD_ITEMS:

--- a/setup.py
+++ b/setup.py
@@ -228,6 +228,34 @@ class TileLangBuilPydCommand(build_py):
         print(f"Extension output directory (parent): {ext_output_dir}")
         print(f"Build temp directory: {build_temp_dir}")
 
+        potential_dirs = [
+            ext_output_dir,
+            self.build_lib,
+            build_temp_dir,
+            os.path.join(ROOT_DIR, "build"),
+        ]
+
+        # copy cython files
+        CYTHON_SRC = [
+            "tilelang/jit/adapter/cython/cython_wrapper.pyx",
+        ]
+        for item in CYTHON_SRC:
+            print(f"Copying {item} to {self.build_lib}")
+            source_cython_file = None
+            for dir in potential_dirs:
+                candidate = os.path.join(dir, item)
+                if os.path.exists(candidate):
+                    source_cython_file = candidate
+                    break
+
+            if source_cython_file:
+                source_dir = os.path.dirname(source_cython_file)
+                target_file = os.path.join(self.build_lib, item)
+                if not os.path.exists(target_file):
+                    shutil.copy2(source_cython_file, target_file)
+            else:
+                print(f"WARNING: {item} not found in any expected directories!")
+
         # copy the tl_templates
         TILELANG_SRC = [
             "src/tl_templates",
@@ -249,13 +277,6 @@ class TileLangBuilPydCommand(build_py):
             "libtvm.so",
             "libtilelang.so",
             "libtilelang_module.so",
-        ]
-
-        potential_dirs = [
-            ext_output_dir,
-            self.build_lib,
-            build_temp_dir,
-            os.path.join(ROOT_DIR, "build"),
         ]
 
         for item in TVM_PREBUILD_ITEMS:

--- a/setup.py
+++ b/setup.py
@@ -227,21 +227,36 @@ class TileLangBuilPydCommand(build_py):
         ext_output_dir = os.path.dirname(extdir)
         print(f"Extension output directory (parent): {ext_output_dir}")
         print(f"Build temp directory: {build_temp_dir}")
+
+        potential_dirs = [
+            ext_output_dir,
+            self.build_lib,
+            build_temp_dir,
+            os.path.join(ROOT_DIR, "build"),
+        ]
+
         # copy cython files
         CYTHON_SRC = [
             "tilelang/jit/adapter/cython/cython_wrapper.pyx",
         ]
         for item in CYTHON_SRC:
-            source_dir = os.path.join(ROOT_DIR, item)
-            target_dir = os.path.join(self.build_lib, item)
-            if os.path.isdir(source_dir):
-                self.mkpath(target_dir)
-                distutils.dir_util.copy_tree(source_dir, target_dir)
+            print(f"Copying {item} to {self.build_lib}")
+            source_cython_file = None
+            for dir in potential_dirs:
+                candidate = os.path.join(dir, item)
+                if os.path.exists(candidate):
+                    source_cython_file = candidate
+                    break
+
+            if source_cython_file:
+                source_dir = os.path.dirname(source_cython_file)
+                target_dir = os.path.join(self.build_lib, item)
+                if os.path.isdir(source_dir):
+                    self.mkpath(target_dir)
+                    distutils.dir_util.copy_tree(source_dir, target_dir)
             else:
-                target_dir = os.path.dirname(target_dir)
-                if not os.path.exists(target_dir):
-                    os.makedirs(target_dir)
-                shutil.copy2(source_dir, target_dir)
+                print(f"WARNING: {item} not found in any expected directories!")
+
         # copy the tl_templates
         TILELANG_SRC = [
             "src/tl_templates",
@@ -257,13 +272,6 @@ class TileLangBuilPydCommand(build_py):
                 if not os.path.exists(target_dir):
                     os.makedirs(target_dir)
                 shutil.copy2(source_dir, target_dir)
-
-        potential_dirs = [
-            ext_output_dir,
-            self.build_lib,
-            build_temp_dir,
-            os.path.join(ROOT_DIR, "build"),
-        ]
 
         TVM_PREBUILD_ITEMS = [
             "libtvm_runtime.so",


### PR DESCRIPTION
This pull request includes several changes to improve the organization and functionality of the build and linting scripts, as well as some licensing updates. The most important changes include moving linting requirements to a separate file, adding new scripts for Docker-based distribution, and removing unnecessary code from `setup.py`.

### Organization and Licensing Updates:

* `maint/scripts/build_docs.sh`: Added copyright and licensing information. (F1de9305L1)
* [`maint/scripts/docker_local_distribute.sh`](diffhunk://#diff-15110692f1414c07d8e9a1db498e3fce45a1435aa6553154ea9816165580afe9R1-R21): Added new script for local Docker-based distribution with necessary environment setup and commands.
* [`maint/scripts/docker_pypi_distribute.sh`](diffhunk://#diff-61d1811c43ee3a7a99754d36cbd32699d7f7a7f27e9f4da98fa023cd2c3e05b4R1-R21): Added new script for PyPI Docker-based distribution with necessary environment setup and commands.

### Linting and Formatting:

* [`format.sh`](diffhunk://#diff-ef87df35455e8abccb373a278caa1c24262425cff2cb2da5fff1d34775702ec2L38-R40): Updated `tool_version_check` function to reference `requirements-lint.txt` instead of `requirements-dev.txt` for linting tools. [[1]](diffhunk://#diff-ef87df35455e8abccb373a278caa1c24262425cff2cb2da5fff1d34775702ec2L38-R40) [[2]](diffhunk://#diff-ef87df35455e8abccb373a278caa1c24262425cff2cb2da5fff1d34775702ec2L199-R199)
* `requirements-dev.txt` and `requirements-test.txt`: Moved linting requirements to `requirements-lint.txt` and included a reference to the new file. [[1]](diffhunk://#diff-2b4945591edfeaa4cf4d3f155e66d4b43d1bda7a55d881d5cf3107f1b05abbbcL1-R2) [[2]](diffhunk://#diff-685da804fbcac569d75387e475e57d1de687a54c6c41b3aa4057694cfb5abc4bL1-R2)
* [`requirements-lint.txt`](diffhunk://#diff-e8c1fa419c48663db59ce9f738071365a505d5f533226940879b0202e024651cR1-R7): Created new file for linting requirements.

### Code Cleanup:

* [`setup.py`](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L230-R230): Removed unnecessary code for copying Cython files and reorganized the potential directories list. [[1]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L230-R230) [[2]](diffhunk://#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L261-R260)