### PR TITLE
[Bugfix] Bugfix of pass order for hopper

### DIFF
--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -203,14 +203,14 @@ def lower(
     mod = tl.transform.ThreadPartialSync("shared.dyn")(mod)
     mod = tir.transform.InferFragment()(mod)
     mod = tir.transform.LowerThreadAllreduce()(mod)
+    mod = tl.transform.LowerHopperIntrin()(mod)
+    mod = tl.transform.ThreadSync("shared")(mod)
+    mod = tl.transform.ThreadSync("shared.dyn")(mod)
+    mod = tir.transform.InjectPTXAsyncCopy()(mod)
 
     mod = tl.transform.AnnotateDeviceRegions()(mod)
     mod = tir.transform.SplitHostDevice()(mod)
     mod = tir.transform.MergeSharedMemoryAllocations()(mod)
-    mod = tl.transform.ThreadSync("shared")(mod)
-    mod = tl.transform.ThreadSync("shared.dyn")(mod)
-    mod = tl.transform.LowerHopperIntrin()(mod)
-    mod = tir.transform.InjectPTXAsyncCopy()(mod)
 
     mod = tl.transform.MakePackedAPI()(mod)
     mod = tir.transform.LowerDeviceKernelLaunch()(mod)


### PR DESCRIPTION
This PR fixes the pass order in [lower.py](https://github.com/tile-ai/tilelang/compare/main...chengyupku:tilelang:main#diff-e8395ac8f9a0848926b352900043a46a38d67a3c2762dc0f1267f5d296207a63). The previous pass order caused host functions on Hopper to not be filtered to the host side.