### PR TITLE
[Refactor] Set default log level from waning into info

### DIFF
--- a/examples/flash_attention/example_mha_fwd_varlen.py
+++ b/examples/flash_attention/example_mha_fwd_varlen.py
@@ -3,7 +3,6 @@
 # ruff: noqa
 import torch
 import tilelang
-from tilelang.autotuner import *
 import tilelang.language as T
 import tilelang.testing
 import argparse
@@ -220,7 +219,7 @@ def attention_ref(
     return output.to(dtype=dtype_og), attention.to(dtype=dtype_og)
 
 
-def flashattn(batch_size, UQ, UKV, heads, dim, is_causal, max_seqlen_q):
+def flashattn(batch_size, UQ, UKV, heads, dim, is_causal):
     scale = (1.0 / dim)**0.5 * 1.44269504  # log2(e)
     q_shape = [UQ, heads, dim]
     k_shape = [UKV, heads, dim]
@@ -243,6 +242,7 @@ def flashattn(batch_size, UQ, UKV, heads, dim, is_causal, max_seqlen_q):
                 V_unpad: T.Buffer(v_shape, dtype),
                 cu_seqlens_q: T.Buffer([batch_size + 1], "int32"),
                 cu_seqlens_k: T.Buffer([batch_size + 1], "int32"),
+                max_seqlen_q: T.int32,
                 Output_unpad: T.Buffer(o_shape, dtype),
         ):
             with T.Kernel(
@@ -382,15 +382,11 @@ if __name__ == "__main__":
     device = torch.device("cuda")
     window_size = (-1, -1)
 
-    # q = torch.randn(batch, seq_len, heads, dim, dtype=dtype, requires_grad=True).to(device)
-    # k = torch.randn(
-    #     batch, seq_len, heads, dim, dtype=dtype, requires_grad=True
-    # ).to(device)
+    q = torch.randn(batch, seq_len, heads, dim, dtype=dtype, requires_grad=True).to(device)
+    k = torch.randn(
+        batch, seq_len, heads, dim, dtype=dtype, requires_grad=True
+    ).to(device)
     v = torch.randn(batch, seq_len, heads, dim, dtype=dtype, requires_grad=True).to(device)
-
-    q = torch.ones(batch, seq_len, heads, dim, dtype=dtype, requires_grad=True).to(device)
-    k = torch.ones(batch, seq_len, heads, dim, dtype=dtype, requires_grad=True).to(device)
-    # v = torch.ones(batch, seq_len, heads, dim, dtype=dtype, requires_grad=True).to(device)
 
     query_padding_mask = generate_random_padding_mask(seq_len, batch, device, mode="random")
     key_padding_mask = generate_random_padding_mask(seq_len, batch, device, mode="random")
@@ -415,20 +411,11 @@ if __name__ == "__main__":
     UK = k_unpad.shape[0]  # unpadded key length
     UKV = k_unpad.shape[0]  # unpadded query key length
 
-    # TODO(lei): max_seqlen_q should be a dynamic argument.
-    program = flashattn(batch, UQ, UKV, heads, dim, causal, max_seqlen_q)
-    # print(program)
-    kernel = tilelang.compile(program, out_idx=-1)
-    # print(kernel.get_kernel_source())
+    program = flashattn(batch, UQ, UKV, heads, dim, causal)
+    kernel = tilelang.compile(program, out_idx=-1, execution_backend="cython")
+    print(kernel.get_kernel_source())
 
-    profiler = kernel.get_profiler()
-
-    tilelang_latency = profiler.do_bench()
-    print(f"Tilelang latency: {tilelang_latency} ms")
-    # tflops
-    tflops = total_flops / tilelang_latency / 1e9
-
-    out_unpad = kernel(q_unpad, k_unpad, v_unpad, cu_seqlens_q, cu_seqlens_k)
+    out_unpad = kernel(q_unpad, k_unpad, v_unpad, cu_seqlens_q, cu_seqlens_k, max_seqlen_q)
     out = output_pad_fn(out_unpad)
 
     out_ref, _ = attention_ref(
@@ -451,6 +438,6 @@ if __name__ == "__main__":
         0.0,
         causal=causal,
     )
-    # TODO: Benchmark flash_attn and tilelang
     fla_out = output_pad_fn(fla_out_unpad)
     torch.testing.assert_close(out, out_ref, rtol=1e-2, atol=1e-2)
+    print("Assert Equal Passed")

--- a/examples/flash_attention/example_mha_fwd_varlen.py
+++ b/examples/flash_attention/example_mha_fwd_varlen.py
@@ -383,9 +383,7 @@ if __name__ == "__main__":
     window_size = (-1, -1)
 
     q = torch.randn(batch, seq_len, heads, dim, dtype=dtype, requires_grad=True).to(device)
-    k = torch.randn(
-        batch, seq_len, heads, dim, dtype=dtype, requires_grad=True
-    ).to(device)
+    k = torch.randn(batch, seq_len, heads, dim, dtype=dtype, requires_grad=True).to(device)
     v = torch.randn(batch, seq_len, heads, dim, dtype=dtype, requires_grad=True).to(device)
 
     query_padding_mask = generate_random_padding_mask(seq_len, batch, device, mode="random")

--- a/tilelang/__init__.py
+++ b/tilelang/__init__.py
@@ -51,7 +51,7 @@ def _init_logger():
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     logger.propagate = False
-    set_log_level("WARNING")
+    set_log_level("INFO")
 
 
 _init_logger()

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -121,7 +121,8 @@ def extrac_params(func: tir.PrimFunc):
     tensor_types = []
     for var in func.params:
         if var in func.buffer_map:
-            tensor_types.append(relay.TensorType(func.buffer_map[var].shape, func.buffer_map[var].dtype))
+            tensor_types.append(
+                relay.TensorType(func.buffer_map[var].shape, func.buffer_map[var].dtype))
         else:
             tensor_types.append(relay.scalar_type(var.dtype))
     return tensor_types

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -118,8 +118,12 @@ def tilelang_callback_hip_compile(code, target):
 
 
 def extrac_params(func: tir.PrimFunc):
-    buffers = [func.buffer_map[var] for var in func.params]
-    tensor_types = [relay.TensorType(buffer.shape, buffer.dtype) for buffer in buffers]
+    tensor_types = []
+    for var in func.params:
+        if var in func.buffer_map:
+            tensor_types.append(relay.TensorType(func.buffer_map[var].shape, func.buffer_map[var].dtype))
+        else:
+            tensor_types.append(relay.scalar_type(var.dtype))
     return tensor_types
 
 

--- a/tilelang/jit/adapter/cython/adapter.py
+++ b/tilelang/jit/adapter/cython/adapter.py
@@ -22,7 +22,7 @@ import os
 from pathlib import Path
 import logging
 
-logger = logging.getLogger("tilelang")
+logger = logging.getLogger(__name__)
 
 
 def get_cython_compiler() -> Optional[str]:
@@ -198,10 +198,11 @@ class CythonKernelAdapter(BaseKernelAdapter):
         buffer_map = func.buffer_map
         dynamic_symbolic_map = {}
         for i, param in enumerate(params):
-            buffer = buffer_map[param]
-            for j, shape in enumerate(buffer.shape):
-                if isinstance(shape, tir.Var) and (shape not in dynamic_symbolic_map):
-                    dynamic_symbolic_map[shape] = (i, j)
+            if param in buffer_map:
+                buffer = buffer_map[param]
+                for j, shape in enumerate(buffer.shape):
+                    if isinstance(shape, tir.Var) and (shape not in dynamic_symbolic_map):
+                        dynamic_symbolic_map[shape] = (i, j)
         return dynamic_symbolic_map
 
     def _forward_from_prebuild_lib(self, *args, stream: Optional[int] = None):

--- a/tilelang/jit/adapter/cython/cython_wrapper.pyx
+++ b/tilelang/jit/adapter/cython/cython_wrapper.pyx
@@ -59,7 +59,15 @@ cdef class CythonKernelWrapper:
             tensor_list.append(tensor)
         
         # Convert tensor pointers to C void pointers for kernel call
-        call_args = [ctypes.c_void_p(tensor_list[i].data_ptr()) for i in range(len(tensor_list))]
+        call_args = []
+        for i in range(len(tensor_list)):
+            if isinstance(tensor_list[i], torch.Tensor):
+                call_args.append(ctypes.c_void_p(tensor_list[i].data_ptr()))
+            elif isinstance(tensor_list[i], int):
+                # Dynamic symbolics which are passed as integer arguments
+                call_args.append(tensor_list[i])
+            else:
+                raise ValueError(f"Unsupported tensor type: {type(tensor_list[i])}")
 
         # Add dynamic dimension values to kernel arguments
         for _, (buffer_idx, shape_idx) in self.dynamic_symbolic_map.items():

--- a/tilelang/jit/adapter/wrapper.py
+++ b/tilelang/jit/adapter/wrapper.py
@@ -111,7 +111,8 @@ class TLCUDASourceWrapper(object):
             elif isinstance(param, tvm.tir.Var):
                 function_args.append({"name": param.name, "type": self._TYPE_MAP[param.dtype]})
             else:
-                raise ValueError(f"Parameter {param} is not in the buffer map of the primary function.")
+                raise ValueError(
+                    f"Parameter {param} is not in the buffer map of the primary function.")
         # Add dynamic symbols as integer arguments
         for dyn_sym in dynamic_symbolic_set:
             function_args.append({"name": dyn_sym, "type": "int"})

--- a/tilelang/jit/adapter/wrapper.py
+++ b/tilelang/jit/adapter/wrapper.py
@@ -102,11 +102,16 @@ class TLCUDASourceWrapper(object):
         function_args = []
         # Collect function arguments based on primary function's parameters and buffer mappings
         for param in self.prim_func.params:
-            buffer = self.prim_func.buffer_map[param]
-            function_args.append({
-                "name": buffer.name,
-                "type": self._TYPE_MAP[buffer.dtype] + "* __restrict__",
-            })
+            if param in self.prim_func.buffer_map:
+                buffer = self.prim_func.buffer_map[param]
+                function_args.append({
+                    "name": buffer.name,
+                    "type": self._TYPE_MAP[buffer.dtype] + "* __restrict__",
+                })
+            elif isinstance(param, tvm.tir.Var):
+                function_args.append({"name": param.name, "type": self._TYPE_MAP[param.dtype]})
+            else:
+                raise ValueError(f"Parameter {param} is not in the buffer map of the primary function.")
         # Add dynamic symbols as integer arguments
         for dyn_sym in dynamic_symbolic_set:
             function_args.append({"name": dyn_sym, "type": "int"})
@@ -284,10 +289,11 @@ class TLCUDASourceWrapper(object):
         # Determine the set of dynamic symbols used in the function
         dynamic_symbolic_set: List[str] = []
         for param in prim_func.params:
-            buffer = prim_func.buffer_map[param]
-            for dim in buffer.shape:
-                if isinstance(dim, tvm.tir.Var) and (dim.name not in dynamic_symbolic_set):
-                    dynamic_symbolic_set.append(dim.name)
+            if param in prim_func.buffer_map:
+                buffer = prim_func.buffer_map[param]
+                for dim in buffer.shape:
+                    if isinstance(dim, tvm.tir.Var) and (dim.name not in dynamic_symbolic_set):
+                        dynamic_symbolic_set.append(dim.name)
         return dynamic_symbolic_set
 
     def get_cuda_init_func(self):

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -51,10 +51,11 @@ def get_tensor_supply(supply_type: TensorSupplyType):
     def get_tensor(tensor: TensorType) -> torch.Tensor:
         dtype = map_torch_type(str(tensor.dtype))
         device = torch.cuda.current_device()
-        
+
         if hasattr(tensor, "shape") and not tensor.shape:
-            raise ValueError(f"TensorType must have a shape, but got {type(tensor)}, "
-                             "likely you are trying to generate a random tensor with a dynamic symbolic shape.")
+            raise ValueError(
+                f"TensorType must have a shape, but got {type(tensor)}, "
+                "likely you are trying to generate a random tensor with a dynamic symbolic shape.")
 
         shape = list(map(int, tensor.shape))
         if supply_type == TensorSupplyType.Auto:

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -51,6 +51,10 @@ def get_tensor_supply(supply_type: TensorSupplyType):
     def get_tensor(tensor: TensorType) -> torch.Tensor:
         dtype = map_torch_type(str(tensor.dtype))
         device = torch.cuda.current_device()
+        
+        if hasattr(tensor, "shape") and not tensor.shape:
+            raise ValueError(f"TensorType must have a shape, but got {type(tensor)}, "
+                             "likely you are trying to generate a random tensor with a dynamic symbolic shape.")
 
         shape = list(map(int, tensor.shape))
         if supply_type == TensorSupplyType.Auto:


### PR DESCRIPTION
This pull request includes several changes to improve code clarity, fix bugs, and enhance logging across multiple files. The most important changes include removing unused imports, modifying function parameters, updating logging levels, and adding error handling for dynamic symbolic shapes.

Improvements to code clarity and functionality:

* [`examples/flash_attention/example_mha_fwd_varlen.py`](diffhunk://#diff-a2e3695585a1ea98bb68d1579d4cc8901ecbb0276366cecf0e5f536be497c03cL6): Removed unused import `tilelang.autotuner`, modified `flashattn` function to remove `max_seqlen_q` parameter, and added it to the `main` function instead. Cleaned up commented-out code and added print statements for better debugging. [[1]](diffhunk://#diff-a2e3695585a1ea98bb68d1579d4cc8901ecbb0276366cecf0e5f536be497c03cL6) [[2]](diffhunk://#diff-a2e3695585a1ea98bb68d1579d4cc8901ecbb0276366cecf0e5f536be497c03cL223-R222) [[3]](diffhunk://#diff-a2e3695585a1ea98bb68d1579d4cc8901ecbb0276366cecf0e5f536be497c03cR245) [[4]](diffhunk://#diff-a2e3695585a1ea98bb68d1579d4cc8901ecbb0276366cecf0e5f536be497c03cL385-L394) [[5]](diffhunk://#diff-a2e3695585a1ea98bb68d1579d4cc8901ecbb0276366cecf0e5f536be497c03cL418-R416) [[6]](diffhunk://#diff-a2e3695585a1ea98bb68d1579d4cc8901ecbb0276366cecf0e5f536be497c03cL454-R441)

Enhancements to logging:

* [`tilelang/__init__.py`](diffhunk://#diff-ffb9f6b71f5ba70056cd56dd1559cc2be74cbcb0f0b085831581ec50fa6b8b30L54-R54): Changed the default logging level from "WARNING" to "INFO" to provide more detailed logs.
* [`tilelang/jit/adapter/cython/adapter.py`](diffhunk://#diff-fb6f070e77115039cffa90aea9d733c451c961c1c517ad15f5f58487a4ab1548L25-R25): Updated logger to use `__name__` for better module-specific logging.

Bug fixes and error handling:

* [`tilelang/engine/lower.py`](diffhunk://#diff-e8395ac8f9a0848926b352900043a46a38d67a3c2762dc0f1267f5d296207a63L121-R127): Added handling for cases where function parameters are not in the buffer map, ensuring proper tensor type extraction.
* [`tilelang/jit/adapter/cython/cython_wrapper.pyx`](diffhunk://#diff-8101f033a370463f49a5f1a4fbdd6a1deb01bf215ffc15fa44cb751e2f4c043dL62-R70): Added error handling for unsupported tensor types and dynamic symbolic shapes passed as integer arguments.
* [`tilelang/utils/tensor.py`](diffhunk://#diff-d53bf1f2e3725debd8d792d8d799bcd17ea37dd3f2019146d6e93b3a3f19be58R55-R59): Added validation to ensure `TensorType` has a shape, preventing errors when generating random tensors with dynamic symbolic shapes.