### PR TITLE
[Enhancement] Support debug print for unsigned char datatype

### DIFF
--- a/src/tl_templates/cuda/debug.h
+++ b/src/tl_templates/cuda/debug.h
@@ -101,9 +101,9 @@ debug_print_buffer_value<signed char>(const char *msg, const char *buf_name,
 
 // Specialization for unsiged char type
 template <>
-__device__ void debug_print_buffer_value<unsigned char>(const char *msg,
-                                               const char *buf_name, int index,
-                                               unsigned char var) {
+__device__ void
+debug_print_buffer_value<unsigned char>(const char *msg, const char *buf_name,
+                                        int index, unsigned char var) {
   printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
          "index=%d, dtype=char value=%d\n",
          msg, blockIdx.x, blockIdx.y, blockIdx.z, threadIdx.x, threadIdx.y,

--- a/src/tl_templates/cuda/debug.h
+++ b/src/tl_templates/cuda/debug.h
@@ -101,9 +101,9 @@ debug_print_buffer_value<signed char>(const char *msg, const char *buf_name,
 
 // Specialization for unsiged char type
 template <>
-__device__ void debug_print_buffer_value<char>(const char *msg,
+__device__ void debug_print_buffer_value<unsigned char>(const char *msg,
                                                const char *buf_name, int index,
-                                               char var) {
+                                               unsigned char var) {
   printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
          "index=%d, dtype=char value=%d\n",
          msg, blockIdx.x, blockIdx.y, blockIdx.z, threadIdx.x, threadIdx.y,

--- a/testing/python/debug/test_tilelang_debug_print.py
+++ b/testing/python/debug/test_tilelang_debug_print.py
@@ -5,8 +5,7 @@ import tilelang.testing
 import tilelang.language as T
 
 
-def debug_print_buffer(M=16, N=16):
-    dtype = "float16"
+def debug_print_buffer(M=16, N=16, dtype="float16"):
 
     @T.prim_func
     def program(Q: T.Buffer((M, N), dtype)):
@@ -20,7 +19,9 @@ def debug_print_buffer(M=16, N=16):
 
 
 def test_debug_print_buffer():
-    debug_print_buffer(16, 16)
+    debug_print_buffer(16, 16, dtype="float")
+    debug_print_buffer(16, 16, dtype="float16")
+    debug_print_buffer(16, 16, dtype="uint8")
 
 
 def debug_print_buffer_conditional(M=16, N=16):


### PR DESCRIPTION
This pull request includes changes to improve the debugging functionality and enhance the flexibility of the `debug_print_buffer` function. The most important changes include modifying the specialization for the `unsigned char` type in the `debug_print_buffer_value` function and updating the `debug_print_buffer` function to accept a `dtype` parameter.

Enhancements to debugging functionality:

* [`src/tl_templates/cuda/debug.h`](diffhunk://#diff-8b2ee777d9ea055d033d8e9d82f889ec068f3e819dd95d851c5072d31605ef07L104-R106): Modified the `debug_print_buffer_value` function to specialize for `unsigned char` instead of `char`.

Flexibility improvements:

* [`testing/python/debug/test_tilelang_debug_print.py`](diffhunk://#diff-5e01c8bab19190d409a55df99cbf5fd119cfcb30849f9bc46d57164ad83c35aeL8-R8): Updated the `debug_print_buffer` function to accept a `dtype` parameter, allowing different data types to be specified.
* [`testing/python/debug/test_tilelang_debug_print.py`](diffhunk://#diff-5e01c8bab19190d409a55df99cbf5fd119cfcb30849f9bc46d57164ad83c35aeL23-R24): Added multiple calls to `debug_print_buffer` with different `dtype` values in the `test_debug_print_buffer` function to test the new functionality.

Fix for issue #142 