### PR TITLE
[Refactor] Adapt Caver to benchmark

### DIFF
--- a/tilelang/carver/roller/policy/default.py
+++ b/tilelang/carver/roller/policy/default.py
@@ -94,7 +94,10 @@ class DefaultPolicy:
 
             self._expand_reduce_axis(td)
             for codegen_dicts in self.assign_block_size(td):
-                results.append(codegen_dicts)
+                if isinstance(codegen_dicts, dict) and len(codegen_dicts) == 1:
+                    results.append(list(codegen_dicts.values())[0])
+                else:
+                    results.append(codegen_dicts)
                 if len(results) >= topk:
                     break
             if len(results) >= topk:

--- a/tilelang/carver/utils.py
+++ b/tilelang/carver/utils.py
@@ -44,6 +44,7 @@ def get_roller_hints_from_func(func_or_module: Union[tir.PrimFunc, IRModule],
 
     assert func is not None, "The function should not be None"
 
+    roller_hints = None
     if tensorcore_only:
         try:
             tensorized_func, tags = get_tensorized_func_and_tags(
@@ -53,9 +54,9 @@ def get_roller_hints_from_func(func_or_module: Union[tir.PrimFunc, IRModule],
             tags = None
         if tags and tensorized_func:
             policy = TensorCorePolicy(func=tensorized_func, arch=arch, tags=tags)
-            return policy.emit_config(topk)
+            roller_hints = policy.emit_config(topk)
         else:
-            return None
+            roller_hints = None
     else:
         policy = DefaultPolicy.from_prim_func(func=func, arch=arch)
         tensorized_func = None
@@ -67,7 +68,10 @@ def get_roller_hints_from_func(func_or_module: Union[tir.PrimFunc, IRModule],
             tags = None
         if tags and tensorized_func:
             policy = TensorCorePolicy.from_prim_func(func=tensorized_func, arch=arch, tags=tags)
-        return policy.emit_config(topk)
+            roller_hints = policy.emit_config(topk)
+        else:
+            roller_hints = None
+    return roller_hints
 
 
 def get_roller_hints_from_output_nodes(


### PR DESCRIPTION
…Roller Hints Generation

- Replace BitBLAS imports with TileLang Carver imports in benchmark_matmul.py
- Modify roller hints generation using new TileLang Carver template and utility functions
- Update get_roller_hints_from_func to handle None cases and improve return logic
- Adjust DefaultPolicy to handle different codegen dictionary formats