### PR TITLE
[Docker] Add libstdcxx-ng-12 to Dockerfiles for CUDA versions

### DIFF
--- a/docker/Dockerfile.cu118
+++ b/docker/Dockerfile.cu118
@@ -18,7 +18,7 @@ ENV PATH="/opt/conda/bin:${PATH}"
 
 ENV LIBGL_ALWAYS_INDIRECT=1
 
-RUN conda install pip cmake && conda clean --all
+RUN conda install pip cmake && conda install -c conda-forge libstdcxx-ng-12 && conda clean --all
 
 RUN apt-get install -y python3 python3-dev python3-setuptools gcc libtinfo-dev zlib1g-dev build-essential cmake libedit-dev libxml2-dev
 

--- a/docker/Dockerfile.cu120
+++ b/docker/Dockerfile.cu120
@@ -18,7 +18,7 @@ ENV PATH="/opt/conda/bin:${PATH}"
 
 ENV LIBGL_ALWAYS_INDIRECT=1
 
-RUN conda install pip cmake && conda clean --all
+RUN conda install pip cmake && conda install -c conda-forge libstdcxx-ng-12 && conda clean --all
 
 RUN apt-get install -y python3 python3-dev python3-setuptools gcc libtinfo-dev zlib1g-dev build-essential cmake libedit-dev libxml2-dev
 

--- a/docker/Dockerfile.cu121
+++ b/docker/Dockerfile.cu121
@@ -18,7 +18,7 @@ ENV PATH="/opt/conda/bin:${PATH}"
 
 ENV LIBGL_ALWAYS_INDIRECT=1
 
-RUN conda install pip cmake && conda clean --all
+RUN conda install pip cmake && conda install -c conda-forge libstdcxx-ng-12 && conda clean --all
 
 RUN apt-get install -y python3 python3-dev python3-setuptools gcc libtinfo-dev zlib1g-dev build-essential cmake libedit-dev libxml2-dev
 

--- a/docker/Dockerfile.cu123
+++ b/docker/Dockerfile.cu123
@@ -18,7 +18,7 @@ ENV PATH="/opt/conda/bin:${PATH}"
 
 ENV LIBGL_ALWAYS_INDIRECT=1
 
-RUN conda install pip cmake && conda clean --all
+RUN conda install pip cmake && conda install -c conda-forge libstdcxx-ng-12 && conda clean --all
 
 RUN apt-get install -y python3 python3-dev python3-setuptools gcc libtinfo-dev zlib1g-dev build-essential cmake libedit-dev libxml2-dev
 

--- a/docker/Dockerfile.cu124
+++ b/docker/Dockerfile.cu124
@@ -18,7 +18,7 @@ ENV PATH="/opt/conda/bin:${PATH}"
 
 ENV LIBGL_ALWAYS_INDIRECT=1
 
-RUN conda install pip cmake && conda clean --all
+RUN conda install pip cmake && conda install -c conda-forge libstdcxx-ng-12 && conda clean --all
 
 RUN apt-get install -y python3 python3-dev python3-setuptools gcc libtinfo-dev zlib1g-dev build-essential cmake libedit-dev libxml2-dev
 

--- a/docker/Dockerfile.cu125
+++ b/docker/Dockerfile.cu125
@@ -18,7 +18,7 @@ ENV PATH="/opt/conda/bin:${PATH}"
 
 ENV LIBGL_ALWAYS_INDIRECT=1
 
-RUN conda install pip cmake && conda clean --all
+RUN conda install pip cmake && conda install -c conda-forge libstdcxx-ng-12 && conda clean --all
 
 RUN apt-get install -y python3 python3-dev python3-setuptools gcc libtinfo-dev zlib1g-dev build-essential cmake libedit-dev libxml2-dev
 

--- a/docker/Dockerfile.cu126
+++ b/docker/Dockerfile.cu126
@@ -18,7 +18,7 @@ ENV PATH="/opt/conda/bin:${PATH}"
 
 ENV LIBGL_ALWAYS_INDIRECT=1
 
-RUN conda install pip cmake && conda clean --all
+RUN conda install pip cmake && conda install -c conda-forge libstdcxx-ng-12 && conda clean --all
 
 RUN apt-get install -y python3 python3-dev python3-setuptools gcc libtinfo-dev zlib1g-dev build-essential cmake libedit-dev libxml2-dev
 


### PR DESCRIPTION
Update Dockerfiles for CUDA 118, 120, 121, 123, 124, 125, and 126 to install libstdcxx-ng-12 from conda-forge, ensuring consistent standard library support across different CUDA versions