### PR TITLE
[Bugfix] Improve Thread Variable Handling in Layout Inference

### DIFF
--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation.
+// Copyright (c) Tile-AI Corporation.
 // Licensed under the MIT License.
 
 /*!

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -1,21 +1,5 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 /*!
  * \file layout_inference.cc
@@ -431,8 +415,7 @@ tvm::transform::Pass LayoutInference() {
     collector(f->body);
     bool has_thread_binding = collector.thread_binding_.size() > 0;
     bool skip_thread_partition = !has_thread_binding;
-    auto _f = LayoutInferencer::Substitute(std::move(f), skip_thread_partition);
-    return _f;
+    return LayoutInferencer::Substitute(std::move(f), skip_thread_partition);
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.LayoutInference", {});
 }


### PR DESCRIPTION
- Update layout inference to handle thread variables more robustly
- Add explicit size check between infer_list_ and thread_var_vec_
- Modify thread variable access to use per-iteration thread variable
- Simplify thread predicate retrieval logic
- Add minor code cleanup and return variable assignment

Code to reproduce this bug:

```python
# type: ignore
# ruff: noqa
import tilelang
import tilelang.language as T

def test(
    batch_size: int,
    head_dim: int,
):
    dtype = "float16"

    @T.macro
    def kernel1(
        A: T.Buffer([batch_size, head_dim], dtype),
    ):
        with T.Kernel(
            batch_size, threads=128
        ) as by:
            cur_batch = by
            for j in T.Parallel(head_dim):
                A[cur_batch, j] = 0.0
    

    @T.macro
    def kernel2(
        B: T.Buffer([batch_size, head_dim], dtype),
    ):
        with T.Kernel(
            batch_size, threads=128
        ) as by:
            cur_batch = by
            for j in T.Parallel(head_dim):
                B[cur_batch, j] = 0.0

    @T.prim_func
    def main(
        A: T.Buffer([batch_size, head_dim], dtype),
        B: T.Buffer([batch_size, head_dim], dtype),
    ):
        kernel1(
            A,
        )
        kernel2(
            B,
        )

    return main

 

if __name__ == "__main__":
    
    batch_size = 10
    head_dim = 32

    program = test(
        # T.symbolic("batch_size"),
        batch_size,
        head_dim,
    )
    kernel = tilelang.compile(program, execution_backend="cython", target="cuda")
    print(kernel.get_kernel_source())
    
```