### PR TITLE
[Enhancement] Optimize CMake build process with dynamic job count calculation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -212,7 +212,8 @@ def build_csrc(llvm_config_path):
     # Run CMake and make
     try:
         subprocess.check_call(["cmake", ".."])
-        num_jobs = multiprocessing.cpu_count()
+        # 90% utilization
+        num_jobs = max(1, int(os.cpu_count() * 0.9))
         subprocess.check_call(["make", f"-j{num_jobs}"])
     except subprocess.CalledProcessError as error:
         raise RuntimeError("Failed to build TileLang C Source") from error

--- a/setup.py
+++ b/setup.py
@@ -212,8 +212,7 @@ def build_csrc(llvm_config_path):
     # Run CMake and make
     try:
         subprocess.check_call(["cmake", ".."])
-        # 90% utilization
-        num_jobs = max(1, int(os.cpu_count() * 0.9))
+        num_jobs = max(1, int(multiprocessing.cpu_count() * 0.9))
         subprocess.check_call(["make", f"-j{num_jobs}"])
     except subprocess.CalledProcessError as error:
         raise RuntimeError("Failed to build TileLang C Source") from error


### PR DESCRIPTION
- Modify build_csrc function to use 90% of available CPU cores
- Ensure at least one job is used during compilation
- Improve build performance by dynamically adjusting parallel job count