### PR TITLE
[Bugfix] Add dynamic shape support with out_idx in Cython JIT kernel compilation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -212,7 +212,8 @@ def build_csrc(llvm_config_path):
     # Run CMake and make
     try:
         subprocess.check_call(["cmake", ".."])
-        num_jobs = multiprocessing.cpu_count()
+        # 90% utilization
+        num_jobs = max(1, int(os.cpu_count() * 0.9))
         subprocess.check_call(["make", f"-j{num_jobs}"])
     except subprocess.CalledProcessError as error:
         raise RuntimeError("Failed to build TileLang C Source") from error

--- a/setup.py
+++ b/setup.py
@@ -212,8 +212,7 @@ def build_csrc(llvm_config_path):
     # Run CMake and make
     try:
         subprocess.check_call(["cmake", ".."])
-        # 90% utilization
-        num_jobs = max(1, int(os.cpu_count() * 0.9))
+        num_jobs = max(1, int(multiprocessing.cpu_count() * 0.9))
         subprocess.check_call(["make", f"-j{num_jobs}"])
     except subprocess.CalledProcessError as error:
         raise RuntimeError("Failed to build TileLang C Source") from error

--- a/tilelang/jit/adapter/cython/cython_wrapper.pyx
+++ b/tilelang/jit/adapter/cython/cython_wrapper.pyx
@@ -67,7 +67,8 @@ cdef class CythonKernelWrapper:
                 for s in self.params[i].shape:
                     if isinstance(s, tir.Var):
                         # find the corresponding input tensor and shape dimension
-                        assert s in self.dynamic_symbolic_map
+                        assert s in self.dynamic_symbolic_map, f"Dynamic symbolic dimension \
+                                                                    {s} not found in dynamic_symbolic_map"
                         ref_tensor_idx, ref_shape_idx = self.dynamic_symbolic_map[s]
                         shape.append(tensor_list[ref_tensor_idx].shape[ref_shape_idx])
                     elif isinstance(s, (tir.IntImm, int)):

--- a/tilelang/jit/adapter/cython/cython_wrapper.pyx
+++ b/tilelang/jit/adapter/cython/cython_wrapper.pyx
@@ -7,6 +7,7 @@ cimport cython
 import ctypes
 from libc.stdint cimport int64_t, uintptr_t
 from libc.stdlib cimport malloc, free
+from tvm import tir
 
 cdef class CythonKernelWrapper:
     # Class attributes to store kernel configuration and library reference
@@ -62,7 +63,17 @@ cdef class CythonKernelWrapper:
             if i in self.result_idx:
                 # Create empty output tensor with specified dtype and shape
                 dtype = torch.__getattribute__(str(self.params[i].dtype))
-                shape = list(map(int, self.params[i].shape))
+                shape = []
+                for s in self.params[i].shape:
+                    if isinstance(s, tir.Var):
+                        # find the corresponding input tensor and shape dimension
+                        assert s in self.dynamic_symbolic_map
+                        ref_tensor_idx, ref_shape_idx = self.dynamic_symbolic_map[s]
+                        shape.append(tensor_list[ref_tensor_idx].shape[ref_shape_idx])
+                    elif isinstance(s, (tir.IntImm, int)):
+                        shape.append(int(s))
+                    else:
+                        raise ValueError(f"Unsupported shape type: {type(s)}")
                 device = inputs[0].device if len(inputs) > 0 else torch.cuda.current_device()
                 tensor = torch.empty(*shape, dtype=dtype, device=device)
             else:


### PR DESCRIPTION
This pull request introduces new functionality for handling dynamic shapes in Cython kernels and includes changes to both the test suite and the Cython wrapper implementation. The most important changes are summarized below:

### New Functionality for Dynamic Shapes:

* [`testing/python/jit/test_tilelang_jit_gemm_cython.py`](diffhunk://#diff-9b73e1ab167c1a34e01a085b75e3b49b447a0d8f373293d3e6a12248cf8dc328R410-R466): Added the `run_cython_dynamic_shape_with_out_idx` function to test dynamic shapes with Cython kernels and a corresponding test case `test_cython_dynamic_shape_with_out_idx`.

### Modifications to Cython Wrapper:

* [`tilelang/jit/adapter/cython/cython_wrapper.pyx`](diffhunk://#diff-8101f033a370463f49a5f1a4fbdd6a1deb01bf215ffc15fa44cb751e2f4c043dR10): Imported `tir` from `tvm` to handle dynamic shapes.
* [`tilelang/jit/adapter/cython/cython_wrapper.pyx`](diffhunk://#diff-8101f033a370463f49a5f1a4fbdd6a1deb01bf215ffc15fa44cb751e2f4c043dL65-R76): Updated the `CythonKernelWrapper` class to support dynamic shapes by mapping symbolic variables to actual tensor dimensions.