### PR TITLE
[CMake] Add CUDA Major Version Detection for Conditional Compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,10 @@ if(USE_CUDA)
   endif()
 
   message(STATUS "CUDA Toolkit includes: ${CUDAToolkit_INCLUDE_DIRS}")
+  set(CUDA_MAJOR_VERSION ${CUDAToolkit_VERSION_MAJOR})
+  message(STATUS "Setting CUDA_MAJOR_VERSION=${CUDA_MAJOR_VERSION}")
+  add_compile_definitions(CUDA_MAJOR_VERSION=${CUDA_MAJOR_VERSION})
+  
   list(APPEND TILE_LANG_INCLUDES ${CUDAToolkit_INCLUDE_DIRS})
 endif(USE_CUDA)
 

--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -92,6 +92,15 @@ TIR_DEFINE_TL_BUILTIN(FenceProxyAsyncOp)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
+TIR_DEFINE_TL_BUILTIN(TMAStoreArrive)
+    .set_num_inputs(0)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(TMAStoreWait)
+    .set_num_inputs(0)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
 TIR_DEFINE_TL_BUILTIN(SetMaxNReg)
     .set_num_inputs(2)
     .set_attr<TCallEffectKind>("TCallEffectKind",

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -140,6 +140,22 @@ const Op &SyncThreadsPartialOp();
 const Op &FenceProxyAsyncOp();
 
 /*!
+ * \brief Indicate arrival of warp issuing TMA_STORE
+ *
+ * TMAStoreArrive()
+ *
+ */
+const Op &TMAStoreArrive();
+
+/*!
+ * \brief Wait for TMA_STORE to finish
+ *
+ * TMAStoreWait()
+ *
+ */
+const Op &TMAStoreWait();
+
+/*!
  * \brief Set reg hint for warp-specialized branched
  *
  * SetMaxNRegInc(num_reg, is_inc)

--- a/src/runtime/runtime.cc
+++ b/src/runtime/runtime.cc
@@ -17,7 +17,7 @@ namespace tl {
 
 using namespace runtime;
 
-#if (__CUDACC_VER_MAJOR__ >= 12)
+#if (CUDA_MAJOR_VERSION >= 12)
 template <typename T> static std::string ArrayToStr(const T *ptr, size_t n) {
   std::stringstream ss;
   ss << "[";
@@ -203,7 +203,7 @@ TVM_REGISTER_GLOBAL(tvm_tensormap_create_im2col)
       }
       *ret = static_cast<int>(result);
     });
-#endif // (__CUDACC_VER_MAJOR__ >= 12)
+#endif // (CUDA_MAJOR_VERSION >= 12)
 
 } // namespace tl
 } // namespace tvm

--- a/src/runtime/runtime.h
+++ b/src/runtime/runtime.h
@@ -13,12 +13,12 @@
 namespace tvm {
 namespace tl {
 
-#if (__CUDACC_VER_MAJOR__ >= 12)
+#if (CUDA_MAJOR_VERSION >= 12)
 constexpr const char *tvm_tensormap_create_tiled =
     "__tvm_tensormap_create_tiled";
 constexpr const char *tvm_tensormap_create_im2col =
     "__tvm_tensormap_create_im2col";
-#endif // (__CUDACC_VER_MAJOR__ >= 12)
+#endif // (CUDA_MAJOR_VERSION >= 12)
 } // namespace tl
 } // namespace tvm
 

--- a/src/target/codegen_cuda.cc
+++ b/src/target/codegen_cuda.cc
@@ -843,6 +843,10 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     print_extern_call_stmt(func_name, 2);
   } else if (op->op.same_as(tl::FenceProxyAsyncOp())) {
     print_extern_call_stmt("tl::fence_proxy_async");
+  } else if (op->op.same_as(tl::TMAStoreArrive())) {
+    print_extern_call_stmt("tl::tma_store_arrive");
+  } else if (op->op.same_as(tl::TMAStoreWait())) {
+    print_extern_call_stmt("tl::tma_store_wait<0>");
   } else if (op->op.same_as(tl::SetMaxNReg())) {
     this->PrintIndent();
     int nreg = Downcast<IntImm>(op->args[0])->value;

--- a/src/tl_templates/cuda/copy_sm90.h
+++ b/src/tl_templates/cuda/copy_sm90.h
@@ -227,6 +227,15 @@ TL_DEVICE void fence_proxy_async() {
   asm volatile("fence.proxy.async.shared::cta;" : :);
 }
 
+// Indicate arrival of warp issuing TMA_STORE
+TL_DEVICE void tma_store_arrive() {
+  asm volatile("cp.async.bulk.commit_group;");
+}
+
+template <int Count> TL_DEVICE void tma_store_wait() {
+  asm volatile("cp.async.bulk.wait_group.read %0;" : : "n"(Count) : "memory");
+}
+
 TL_DEVICE void syncthreads_partial(uint64_t &smem_barrier) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(&smem_barrier);
   uint64_t state = 0;

--- a/src/transform/lower_hopper_intrin.cc
+++ b/src/transform/lower_hopper_intrin.cc
@@ -36,7 +36,7 @@ namespace tl {
 
 using namespace tir;
 
-#if (__CUDACC_VER_MAJOR__ >= 12)
+#if (CUDA_MAJOR_VERSION >= 12)
 class LowerHopperIntrin : public StmtExprMutator {
 public:
   static PrimFunc Substitute(PrimFunc &f) {
@@ -169,7 +169,7 @@ tvm::transform::Pass LowerHopperIntrin() {
 
 TVM_REGISTER_GLOBAL("tl.transform.LowerHopperIntrin")
     .set_body_typed(LowerHopperIntrin);
-#endif // (__CUDACC_VER_MAJOR__ >= 12)
+#endif // (CUDA_MAJOR_VERSION >= 12)
 
 } // namespace tl
 } // namespace tvm

--- a/testing/python/transform/test_tilelang_transform_lower_hopper_intrin.py
+++ b/testing/python/transform/test_tilelang_transform_lower_hopper_intrin.py
@@ -57,5 +57,4 @@ def test_lower_hopper_intrin_barrier():
 
 
 if __name__ == "__main__":
-    # tilelang.testing.main()
-    test_lower_hopper_intrin_barrier()
+    tilelang.testing.main()

--- a/tilelang/language/builtin.py
+++ b/tilelang/language/builtin.py
@@ -25,6 +25,14 @@ def FenceProxyAsyncOp(*args):
     return tir.call_intrin("handle", tir.op.Op.get("tl.FenceProxyAsyncOp"), *args)
 
 
+def TMAStoreArrive(*args):
+    return tir.call_intrin("handle", tir.op.Op.get("tl.TMAStoreArrive"), *args)
+
+
+def TMAStoreWait(*args):
+    return tir.call_intrin("handle", tir.op.Op.get("tl.TMAStoreWait"), *args)
+
+
 def SetMaxNReg(*args):
     return tir.call_intrin("handle", tir.op.Op.get("tl.SetMaxNReg"), *args)
 


### PR DESCRIPTION
This pull request introduces several new features and updates to the CUDA integration. The most important changes include setting the CUDA major version and updating conditional compilation directives.

### CUDA Integration:
* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR159-R162): Set the `CUDA_MAJOR_VERSION` based on `CUDAToolkit_VERSION_MAJOR` and add it as a compile definition.

### Conditional Compilation:
* `src/runtime/runtime.cc`, `src/runtime/runtime.h`, `src/transform/lower_hopper_intrin.cc`: Updated conditional compilation directives to use `CUDA_MAJOR_VERSION` instead of `__CUDACC_VER_MAJOR__`. [[1]](diffhunk://#diff-84c611d7ef14082f87606bacea92867b1e8fa0086e7daed922b3b2825b588080L20-R20) [[2]](diffhunk://#diff-84c611d7ef14082f87606bacea92867b1e8fa0086e7daed922b3b2825b588080L206-R206) [[3]](diffhunk://#diff-0dcc5d2b18fd9a0382ef28203b9a5e77aaba4d742b4cb325879bfa15defee24dL16-R21) [[4]](diffhunk://#diff-757eac85159ad8e43df80adaf49de8390991a65240e6661ee978b6a60a9a87ebL39-R39) [[5]](diffhunk://#diff-757eac85159ad8e43df80adaf49de8390991a65240e6661ee978b6a60a9a87ebL172-R172)
