### PR TITLE
[Dev] Implement IfStmtBinding and MergeIfStmt transformations

### DIFF
--- a/src/transform/if_stmt_binding.cc
+++ b/src/transform/if_stmt_binding.cc
@@ -1,22 +1,5 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
 /*!
  * \file if_stmt_binding.cc
  * \brief Bind the If Stmt to each Stmt in SeqStmt

--- a/src/transform/if_stmt_binding.cc
+++ b/src/transform/if_stmt_binding.cc
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file if_stmt_binding.cc
+ * \brief Bind the If Stmt to each Stmt in SeqStmt
+ */
+
+#include <tvm/tir/analysis.h>
+#include <tvm/tir/builtin.h>
+#include <tvm/tir/op.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
+
+#include "../op/builtin.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tir;
+
+class IfStmtBindingRewriter : public StmtExprMutator {
+public:
+  static PrimFunc Substitute(PrimFunc &f) {
+    auto rewriter = IfStmtBindingRewriter();
+    f.CopyOnWrite()->body = rewriter(f->body);
+    return f;
+  }
+
+private:
+  IfStmtBindingRewriter() = default;
+
+  Stmt VisitStmt_(const IfThenElseNode *op) final {
+    auto condition = op->condition;
+    auto then_case = op->then_case;
+    auto else_case = op->else_case;
+
+    auto bind_if_stmt = [](Optional<Stmt> body,
+                           const PrimExpr condition) -> Stmt {
+      if (body.defined()) {
+        auto stmt = body.value();
+        if (auto seq_stmt = stmt.as<SeqStmtNode>()) {
+          Array<Stmt> seq_;
+          for (auto s : seq_stmt->seq) {
+            seq_.push_back(IfThenElse(condition, s, Stmt()));
+          }
+          return SeqStmt(std::move(seq_));
+        } else {
+          return IfThenElse(condition, stmt, Stmt());
+        }
+      } else {
+        return Stmt();
+      }
+    };
+
+    Array<Stmt> new_seq;
+
+    if (then_case.defined()) {
+      new_seq.push_back(bind_if_stmt(then_case, condition));
+    }
+    if (else_case.defined()) {
+      new_seq.push_back(bind_if_stmt(else_case, !condition));
+    }
+    return new_seq.size() == 1 ? new_seq[0] : SeqStmt(std::move(new_seq));
+  }
+
+  Stmt VisitStmt_(const SeqStmtNode *op) final {
+    Array<Stmt> seq;
+    for (auto stmt : op->seq) {
+      seq.push_back(VisitStmt(stmt));
+    }
+    return SeqStmt(std::move(seq));
+  }
+};
+
+using namespace tir::transform;
+tvm::transform::Pass IfStmtBinding() {
+  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+    return IfStmtBindingRewriter::Substitute(f);
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.IfStmtBinding", {});
+}
+
+TVM_REGISTER_GLOBAL("tl.transform.IfStmtBinding").set_body_typed(IfStmtBinding);
+
+} // namespace tl
+} // namespace tvm

--- a/src/transform/merge_if_stmt.cc
+++ b/src/transform/merge_if_stmt.cc
@@ -1,22 +1,5 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership. The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
 /*!
  * \file if_stmt_binding.cc
  * \brief Merge the If Stmt in SeqStmt

--- a/src/transform/merge_if_stmt.cc
+++ b/src/transform/merge_if_stmt.cc
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file if_stmt_binding.cc
+ * \brief Merge the If Stmt in SeqStmt
+ */
+
+#include <tvm/tir/analysis.h>
+#include <tvm/tir/builtin.h>
+#include <tvm/tir/op.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
+
+#include "../op/builtin.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tir;
+
+class MergeIfStmtRewriter : public StmtExprMutator {
+public:
+  static PrimFunc Substitute(PrimFunc &f) {
+    auto rewriter = MergeIfStmtRewriter();
+    f.CopyOnWrite()->body = rewriter(f->body);
+    return f;
+  }
+
+private:
+  MergeIfStmtRewriter() = default;
+
+  Stmt VisitStmt_(const SeqStmtNode *op) final {
+    Array<Stmt> new_seq;
+
+    PrimExpr current_condition;
+    Array<Stmt> current_if_bodies;
+
+    for (const Stmt &stmt : op->seq) {
+      Stmt new_stmt = this->VisitStmt(stmt);
+      if (const IfThenElseNode *if_node = new_stmt.as<IfThenElseNode>()) {
+        if (!if_node->else_case.defined()) {
+          if (current_condition.defined() &&
+              StructuralEqual()(current_condition, if_node->condition)) {
+            current_if_bodies.push_back(if_node->then_case);
+            continue;
+          } else {
+            if (!current_if_bodies.empty()) {
+              new_seq.push_back(IfThenElse(current_condition,
+                                           current_if_bodies.size() == 1
+                                               ? current_if_bodies[0]
+                                               : SeqStmt(current_if_bodies),
+                                           Stmt()));
+              current_if_bodies.clear();
+            }
+
+            current_condition = if_node->condition;
+            current_if_bodies.push_back(if_node->then_case);
+            continue;
+          }
+        }
+      }
+
+      if (!current_if_bodies.empty()) {
+        new_seq.push_back(IfThenElse(current_condition,
+                                     current_if_bodies.size() == 1
+                                         ? current_if_bodies[0]
+                                         : SeqStmt(current_if_bodies),
+                                     Stmt()));
+        current_condition = PrimExpr();
+        current_if_bodies.clear();
+      }
+
+      new_seq.push_back(new_stmt);
+    }
+
+    if (!current_if_bodies.empty()) {
+      new_seq.push_back(IfThenElse(current_condition,
+                                   current_if_bodies.size() == 1
+                                       ? current_if_bodies[0]
+                                       : SeqStmt(current_if_bodies),
+                                   Stmt()));
+    }
+
+    return new_seq.size() == 1 ? new_seq[0] : SeqStmt(new_seq);
+  }
+};
+
+using namespace tir::transform;
+tvm::transform::Pass MergeIfStmt() {
+  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+    return MergeIfStmtRewriter::Substitute(f);
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.MergeIfStmt", {});
+}
+
+TVM_REGISTER_GLOBAL("tl.transform.MergeIfStmt").set_body_typed(MergeIfStmt);
+
+} // namespace tl
+} // namespace tvm

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -32,10 +32,12 @@ def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
 def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
     # which may be introduced by the LegalizeSafeMemoryAccess
     if target.arch == "sm_90":
+        mod = tilelang.transform.IfStmtBinding()(mod)
         mod = tilelang.transform.MultiVersionBuffer()(mod)
         mod = tilelang.transform.WarpSpecialized()(mod)
         mod = tilelang.transform.InjectSoftwarePipeline()(mod)
         mod = tir.transform.LowerOpaqueBlock()(mod)
+        mod = tilelang.transform.MergeIfStmt()(mod)
         mod = tilelang.transform.RewriteWgmmaSync()(mod)
         # mod = tilelang.transform.WarpSpecializedPipeline()(mod)
         mod = tilelang.transform.InjectFenceProxy()(mod)

--- a/tilelang/transform/__init__.py
+++ b/tilelang/transform/__init__.py
@@ -139,6 +139,28 @@ def ThreadPartialSync(storage_scope: str):
     return _ffi_api.ThreadPartialSync(storage_scope)  # type: ignore
 
 
+def IfStmtBinding():
+    """IfStmtBinding
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    """
+    return _ffi_api.IfStmtBinding()  # type: ignore
+
+
+def MergeIfStmt():
+    """MergeIfStmt
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    """
+    return _ffi_api.MergeIfStmt()  # type: ignore
+
+
 def MultiVersionBuffer():
     """WarpSpecializedPipeline
 


### PR DESCRIPTION
- Add IfStmtBinding to bind If statements to each statement in SeqStmt, enhancing the handling of conditional statements.
- Introduce MergeIfStmt to merge consecutive If statements within SeqStmt, optimizing the structure of conditional logic.
- Update phase.py to apply IfStmtBinding and MergeIfStmt transformations for the "sm_90" target.
- Enhance __init__.py with new functions for IfStmtBinding and MergeIfStmt, providing a clear interface for these transformations.