### PR TITLE
[Bugfix] Fix mismatch of shared memory layout and mma atom on Hopper

### DIFF
--- a/src/layout/layout.cc
+++ b/src/layout/layout.cc
@@ -448,7 +448,7 @@ TVM_REGISTER_GLOBAL("tl.Fragment_condense_rep_var")
 
 TVM_REGISTER_GLOBAL("tl.make_swizzled_layout")
     .set_body_typed([](int stride, int continuous, int element_size) {
-      return makeGemmABLayout(stride, continuous, element_size, 0);
+      return makeGemmABLayout(stride, continuous, continuous, element_size, 0);
     });
 
 } // namespace tl

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -150,8 +150,8 @@ Fragment makeGemmFragmentACDNA(const int block_m, const int block_n,
 // Default Memory Layout
 Layout makeGemmLayoutLinear(int stride, int continuous);
 Layout makeGemmABLayoutPadded(int stride, int continuous, int element_size);
-Layout makeGemmABLayout(int stride, int continuous, int element_size,
-                        int kfactor);
+Layout makeGemmABLayout(int mat_stride, int mat_continuous, int continuity,
+                        int element_size, int kfactor);
 Layout makeGemmABLayoutCDNA(int stride, int continuous, int element_size,
                             int kfactor);
 

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -188,10 +188,9 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
     if (A.scope() == "shared" || A.scope() == "shared.dyn") {
       const int64_t mat_stride = *as_const_int(A->shape[0]);
       const int64_t mat_continuous = *as_const_int(A->shape[1]);
-      const int64_t continuity =
-          trans_A ? mat_continuous / warp_m : mat_continuous;
-      results.Set(A, makeGemmABLayout(mat_stride, mat_continuous, continuity,
-                                      A->dtype.bits(), trans_A ? 1 : 2));
+      results.Set(A,
+                  makeGemmABLayout(mat_stride, mat_continuous, mat_continuous,
+                                   A->dtype.bits(), trans_A ? 1 : 2));
     } else if (A.scope() == "local.fragment") {
       ICHECK(trans_A == false);
       results.Set(A, makeGemmFragmentA(M, N, K, M / warp_m, N / warp_n,
@@ -202,10 +201,9 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
     if (B.scope() == "shared" || B.scope() == "shared.dyn") {
       const int64_t mat_stride = *as_const_int(B->shape[0]);
       const int64_t mat_continuous = *as_const_int(B->shape[1]);
-      const int64_t continuity =
-          trans_B ? mat_continuous : mat_continuous / warp_n;
-      results.Set(B, makeGemmABLayout(mat_stride, mat_continuous, continuity,
-                                      B->dtype.bits(), trans_B ? 2 : 1));
+      results.Set(B,
+                  makeGemmABLayout(mat_stride, mat_continuous, mat_continuous,
+                                   B->dtype.bits(), trans_B ? 2 : 1));
     } else if (B.scope() == "local.fragment") {
       ICHECK(trans_B == false);
       results.Set(B, makeGemmFragmentB(M, N, K, M / warp_m, N / warp_n));

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -186,8 +186,11 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
     results.Set(C, fragment);
 
     if (A.scope() == "shared" || A.scope() == "shared.dyn") {
-      results.Set(A, makeGemmABLayout(*as_const_int(A->shape[0]),
-                                      *as_const_int(A->shape[1]),
+      const int64_t mat_stride = *as_const_int(A->shape[0]);
+      const int64_t mat_continuous = *as_const_int(A->shape[1]);
+      const int64_t continuity =
+          trans_A ? mat_continuous / warp_m : mat_continuous;
+      results.Set(A, makeGemmABLayout(mat_stride, mat_continuous, continuity,
                                       A->dtype.bits(), trans_A ? 1 : 2));
     } else if (A.scope() == "local.fragment") {
       ICHECK(trans_A == false);
@@ -197,8 +200,11 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
       ICHECK(0);
     }
     if (B.scope() == "shared" || B.scope() == "shared.dyn") {
-      results.Set(B, makeGemmABLayout(*as_const_int(B->shape[0]),
-                                      *as_const_int(B->shape[1]),
+      const int64_t mat_stride = *as_const_int(B->shape[0]);
+      const int64_t mat_continuous = *as_const_int(B->shape[1]);
+      const int64_t continuity =
+          trans_B ? mat_continuous : mat_continuous / warp_n;
+      results.Set(B, makeGemmABLayout(mat_stride, mat_continuous, continuity,
                                       B->dtype.bits(), trans_B ? 2 : 1));
     } else if (B.scope() == "local.fragment") {
       ICHECK(trans_B == false);
@@ -222,8 +228,11 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
             : makeGemmFragmentC(M, N, M / warp_m, N / warp_n, C->dtype.bits());
     results.Set(C, fragment);
     if (A.scope() == "shared" || A.scope() == "shared.dyn") {
-      results.Set(A, makeGemmABLayout(*as_const_int(A->shape[0]),
-                                      *as_const_int(A->shape[1]),
+      const int64_t mat_stride = *as_const_int(A->shape[0]);
+      const int64_t mat_continuous = *as_const_int(A->shape[1]);
+      const int64_t continuity =
+          trans_A ? mat_continuous / (warp_m / 4) : mat_continuous;
+      results.Set(A, makeGemmABLayout(mat_stride, mat_continuous, continuity,
                                       A->dtype.bits(), trans_A ? 1 : 2));
     } else {
       ICHECK(trans_A == false);
@@ -231,8 +240,11 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
                                        A->dtype.bits()));
     }
     if (B.scope() == "shared" || B.scope() == "shared.dyn") {
-      results.Set(B, makeGemmABLayout(*as_const_int(B->shape[0]),
-                                      *as_const_int(B->shape[1]),
+      const int64_t mat_stride = *as_const_int(B->shape[0]);
+      const int64_t mat_continuous = *as_const_int(B->shape[1]);
+      const int64_t continuity =
+          trans_B ? mat_continuous : mat_continuous / warp_n;
+      results.Set(B, makeGemmABLayout(mat_stride, mat_continuous, continuity,
                                       B->dtype.bits(), trans_B ? 2 : 1));
     } else {
       ICHECK(0) << "WGMMA only support B in shared.";

--- a/src/tl_templates/cuda/gemm_sm90.h
+++ b/src/tl_templates/cuda/gemm_sm90.h
@@ -7,6 +7,7 @@
 #include <cute/atom/mma_atom.hpp>
 #include <cutlass/arch/barrier.h>
 #include <cutlass/cutlass.h>
+#include <cutlass/gemm/collective/collective_builder.hpp>
 
 #include "common.h"
 
@@ -15,65 +16,8 @@ namespace cute {
 using namespace SM90;
 
 namespace tl_wgmma {
-template <GMMA::Major major, class ElementType, class BLK_MN, class BLK_K>
-CUTE_HOST_DEVICE constexpr auto ss_smem_selector() {
-  auto BLK_MN0 = size<0>(BLK_MN{});
-  auto BLK_K0 = size<0>(BLK_K{});
 
-  static_assert(BLK_MN0 % 8 == 0, "BLK_MN0 must be a multiple of 8.");
-  static_assert(BLK_K0 % 8 == 0, "BLK_K0 must be a multiple of 8.");
-
-  if constexpr (major == GMMA::Major::MN) {
-    if constexpr (BLK_MN0 %
-                      size<0>(GMMA::Layout_MN_SW128_Atom<ElementType>{}) ==
-                  0) {
-      return GMMA::Layout_MN_SW128_Atom<ElementType>{};
-    } else if constexpr (BLK_MN0 %
-                             size<0>(
-                                 GMMA::Layout_MN_SW64_Atom<ElementType>{}) ==
-                         0) {
-      return GMMA::Layout_MN_SW64_Atom<ElementType>{};
-    } else if constexpr (BLK_MN0 %
-                             size<0>(
-                                 GMMA::Layout_MN_SW32_Atom<ElementType>{}) ==
-                         0) {
-      return GMMA::Layout_MN_SW32_Atom<ElementType>{};
-    } else if constexpr (BLK_MN0 %
-                             size<0>(
-                                 GMMA::Layout_MN_INTER_Atom<ElementType>{}) ==
-                         0) {
-      return GMMA::Layout_MN_INTER_Atom<ElementType>{};
-    } else {
-      static_assert(
-          BLK_MN0 % size<0>(GMMA::Layout_MN_INTER_Atom<ElementType>{}) == 0,
-          "BLK_MN0 must be a multiple of "
-          "size<0>(GMMA::Layout_MN_INTER_Atom<ElementType>{})");
-    }
-  } else if constexpr (major == GMMA::Major::K) {
-    if constexpr (BLK_K0 % size<1>(GMMA::Layout_K_SW128_Atom<ElementType>{}) ==
-                  0) {
-      return GMMA::Layout_K_SW128_Atom<ElementType>{};
-    } else if constexpr (BLK_K0 %
-                             size<1>(GMMA::Layout_K_SW64_Atom<ElementType>{}) ==
-                         0) {
-      return GMMA::Layout_K_SW64_Atom<ElementType>{};
-    } else if constexpr (BLK_K0 %
-                             size<1>(GMMA::Layout_K_SW32_Atom<ElementType>{}) ==
-                         0) {
-      return GMMA::Layout_K_SW32_Atom<ElementType>{};
-    } else if constexpr (BLK_K0 %
-                             size<1>(
-                                 GMMA::Layout_K_INTER_Atom<ElementType>{}) ==
-                         0) {
-      return GMMA::Layout_K_INTER_Atom<ElementType>{};
-    } else {
-      static_assert(
-          BLK_K0 % size<1>(GMMA::Layout_K_INTER_Atom<ElementType>{}) == 0,
-          "BLK_K0 must be a multiple of "
-          "size<1>(GMMA::Layout_K_INTER_Atom<ElementType>{})");
-    }
-  }
-}
+using namespace cutlass::gemm::collective::detail; // ss_smem_selector
 
 template <int M, int N, int K, int num_warp_m, int num_warp_n, bool trans_A,
           bool trans_B, typename A_type_raw, typename B_type_raw,

--- a/testing/python/issue/test_tilelang_issue_101.py
+++ b/testing/python/issue/test_tilelang_issue_101.py
@@ -3,6 +3,7 @@
 
 import torch
 import tilelang
+import tilelang.testing
 import tilelang.language as T
 
 

--- a/testing/python/issue/test_tilelang_issue_101.py
+++ b/testing/python/issue/test_tilelang_issue_101.py
@@ -44,10 +44,12 @@ def run_gemm_threads_test(threads, M=1024, N=192, K=1024, block_M=64, block_N=19
 
     tilelang.testing.torch_assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
 
+
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version(9, 0)
 def test_gemm_threads_2wgs():
     run_gemm_threads_test(128 * 2)
+
 
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version(9, 0)

--- a/testing/python/issue/test_tilelang_issue_101.py
+++ b/testing/python/issue/test_tilelang_issue_101.py
@@ -1,0 +1,56 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+
+import torch
+import tilelang
+import tilelang.language as T
+
+
+def matmul(M, N, K, block_M, block_N, block_K, threads, dtype="float16", accum_dtype="float"):
+
+    @T.prim_func
+    def main(
+            A: T.Buffer((M, K), dtype),
+            B: T.Buffer((K, N), dtype),
+            C: T.Buffer((M, N), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), dtype)
+            B_shared = T.alloc_shared((block_K, block_N), dtype)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            T.clear(C_local)
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=3):
+                T.copy(A[by * block_M, k * block_K], A_shared)
+                T.copy(B[k * block_K, bx * block_N], B_shared)
+                T.gemm(A_shared, B_shared, C_local, policy=T.GemmWarpPolicy.FullCol)
+
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def run_gemm_threads_test(threads, M=1024, N=192, K=1024, block_M=64, block_N=192, block_K=32):
+    func = matmul(M, N, K, block_M, block_N, block_K, threads)
+    jit_kernel = tilelang.compile(func, out_idx=-1, target="cuda")
+
+    torch.manual_seed(0)
+    a = torch.randn(M, K, device="cuda", dtype=torch.float16)
+    b = torch.randn(K, N, device="cuda", dtype=torch.float16)
+
+    ref_c = a @ b
+    c = jit_kernel(a, b)
+
+    tilelang.testing.torch_assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
+
+
+def test_gemm_threads_2wgs():
+    run_gemm_threads_test(128 * 2)
+
+
+def test_gemm_threads_4wgs():
+    run_gemm_threads_test(128 * 4)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/issue/test_tilelang_issue_101.py
+++ b/testing/python/issue/test_tilelang_issue_101.py
@@ -44,11 +44,13 @@ def run_gemm_threads_test(threads, M=1024, N=192, K=1024, block_M=64, block_N=19
 
     tilelang.testing.torch_assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
 
-
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(9, 0)
 def test_gemm_threads_2wgs():
     run_gemm_threads_test(128 * 2)
 
-
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(9, 0)
 def test_gemm_threads_4wgs():
     run_gemm_threads_test(128 * 4)
 


### PR DESCRIPTION
This pull request fixes issue #101.

The issue comes from the mismatch between the smem layout and the mma atom layout in this example.
Since the user specifies `GemmWarpPolicy.FullCol`, `num_warp_n` now equals 2 because of the 2 warp groups in total (256 threads).
This results in the selected mma atom being `wgmma.mma_async.m64n96k16`. However, the selection of the shared memory layout is not aware of `num_warp_n`, producing a 128B (64 x fp16) swizzle mode. As 64 cannot be divided by 96 from the mma atom, the issue occurs.

To fix this, we should also select the shared memory's layout with regard to the warp policy (see comment below).
We also need to adjust the code of layout inference correspondingly. We add a `continuity` parameter in `makeGemmABLayout` because now the matrix shape cannot be directly used to determine the swizzle mode.

We only fix the issue for sm90 code to avoid causing other issues not considered. However, we suspect the same problem also exists in sm80/70 codes.