### PR TITLE
[Bugfix] Disable force inline for ldmatrix

### DIFF
--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -24,6 +24,7 @@ using int4_t = int4;
 #define ushort unsigned short
 
 #define TL_DEVICE __forceinline__ __device__
+#define TL_DEVICE_NOINLINE __noinline__ __device__
 
 // Pack two half values.
 TL_DEVICE unsigned __pack_half2(const half x, const half y) {

--- a/src/tl_templates/cuda/ldsm.h
+++ b/src/tl_templates/cuda/ldsm.h
@@ -7,7 +7,7 @@
 namespace tl {
 
 TL_DEVICE_NOINLINE void ptx_ldmatrix_x1(void const *const smem_ptr,
-                               void *const local_ptr) {
+                                        void *const local_ptr) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   int32_t *value = reinterpret_cast<int32_t *>(local_ptr);
   asm volatile("ldmatrix.sync.aligned.x1.m8n8.shared.b16 {%0}, [%1];\n"
@@ -16,7 +16,7 @@ TL_DEVICE_NOINLINE void ptx_ldmatrix_x1(void const *const smem_ptr,
 }
 
 TL_DEVICE_NOINLINE void ptx_ldmatrix_x2(void const *const smem_ptr,
-                               void *const local_ptr) {
+                                        void *const local_ptr) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   int32_t *value = reinterpret_cast<int32_t *>(local_ptr);
   asm volatile("ldmatrix.sync.aligned.x2.m8n8.shared.b16 {%0, %1}, [%2];\n"
@@ -25,7 +25,7 @@ TL_DEVICE_NOINLINE void ptx_ldmatrix_x2(void const *const smem_ptr,
 }
 
 TL_DEVICE_NOINLINE void ptx_ldmatrix_x4(void const *const smem_ptr,
-                               void *const __restrict__ local_ptr) {
+                                        void *const local_ptr) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   int32_t *value = reinterpret_cast<int32_t *>(local_ptr);
   asm volatile(
@@ -35,7 +35,7 @@ TL_DEVICE_NOINLINE void ptx_ldmatrix_x4(void const *const smem_ptr,
 }
 
 TL_DEVICE_NOINLINE void ptx_ldmatrix_x1_trans(void const *const smem_ptr,
-                                     void *const local_ptr) {
+                                              void *const local_ptr) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   int32_t *value = reinterpret_cast<int32_t *>(local_ptr);
   asm volatile("ldmatrix.sync.aligned.x1.trans.m8n8.shared.b16 {%0}, [%1];\n"
@@ -44,7 +44,7 @@ TL_DEVICE_NOINLINE void ptx_ldmatrix_x1_trans(void const *const smem_ptr,
 }
 
 TL_DEVICE_NOINLINE void ptx_ldmatrix_x2_trans(void const *const smem_ptr,
-                                     void *const local_ptr) {
+                                              void *const local_ptr) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   int32_t *value = reinterpret_cast<int32_t *>(local_ptr);
   asm volatile(
@@ -54,7 +54,7 @@ TL_DEVICE_NOINLINE void ptx_ldmatrix_x2_trans(void const *const smem_ptr,
 }
 
 TL_DEVICE_NOINLINE void ptx_ldmatrix_x4_trans(void const *const smem_ptr,
-                                     void *const local_ptr) {
+                                              void *const local_ptr) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   int32_t *value = reinterpret_cast<int32_t *>(local_ptr);
   asm volatile(

--- a/src/tl_templates/cuda/ldsm.h
+++ b/src/tl_templates/cuda/ldsm.h
@@ -6,7 +6,7 @@
 
 namespace tl {
 
-TL_DEVICE void ptx_ldmatrix_x1(void const *const smem_ptr,
+TL_DEVICE_NOINLINE void ptx_ldmatrix_x1(void const *const smem_ptr,
                                void *const local_ptr) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   int32_t *value = reinterpret_cast<int32_t *>(local_ptr);
@@ -15,7 +15,7 @@ TL_DEVICE void ptx_ldmatrix_x1(void const *const smem_ptr,
                : "r"(smem_int_ptr));
 }
 
-TL_DEVICE void ptx_ldmatrix_x2(void const *const smem_ptr,
+TL_DEVICE_NOINLINE void ptx_ldmatrix_x2(void const *const smem_ptr,
                                void *const local_ptr) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   int32_t *value = reinterpret_cast<int32_t *>(local_ptr);
@@ -24,8 +24,8 @@ TL_DEVICE void ptx_ldmatrix_x2(void const *const smem_ptr,
                : "r"(smem_int_ptr));
 }
 
-TL_DEVICE void ptx_ldmatrix_x4(void const *const smem_ptr,
-                               void *const local_ptr) {
+TL_DEVICE_NOINLINE void ptx_ldmatrix_x4(void const *const smem_ptr,
+                               void *const __restrict__ local_ptr) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   int32_t *value = reinterpret_cast<int32_t *>(local_ptr);
   asm volatile(
@@ -34,7 +34,7 @@ TL_DEVICE void ptx_ldmatrix_x4(void const *const smem_ptr,
       : "r"(smem_int_ptr));
 }
 
-TL_DEVICE void ptx_ldmatrix_x1_trans(void const *const smem_ptr,
+TL_DEVICE_NOINLINE void ptx_ldmatrix_x1_trans(void const *const smem_ptr,
                                      void *const local_ptr) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   int32_t *value = reinterpret_cast<int32_t *>(local_ptr);
@@ -43,7 +43,7 @@ TL_DEVICE void ptx_ldmatrix_x1_trans(void const *const smem_ptr,
                : "r"(smem_int_ptr));
 }
 
-TL_DEVICE void ptx_ldmatrix_x2_trans(void const *const smem_ptr,
+TL_DEVICE_NOINLINE void ptx_ldmatrix_x2_trans(void const *const smem_ptr,
                                      void *const local_ptr) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   int32_t *value = reinterpret_cast<int32_t *>(local_ptr);
@@ -53,7 +53,7 @@ TL_DEVICE void ptx_ldmatrix_x2_trans(void const *const smem_ptr,
       : "r"(smem_int_ptr));
 }
 
-TL_DEVICE void ptx_ldmatrix_x4_trans(void const *const smem_ptr,
+TL_DEVICE_NOINLINE void ptx_ldmatrix_x4_trans(void const *const smem_ptr,
                                      void *const local_ptr) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   int32_t *value = reinterpret_cast<int32_t *>(local_ptr);

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -150,9 +150,12 @@ public:
             continue;
 
           // Check if buffer exists in use_list_
-          ICHECK(use_list_.count(buffer))
-              << "Buffer " << buffer << " not found in use_list_. "
-              << "Potential mismatch between inference updates and use_list_.";
+          if (!use_list_.count(buffer)) {
+            LOG(WARNING) << "Buffer " << buffer << " not found in use_list_. "
+                         << "Potential mismatch between inference updates and "
+                         << "use_list_.";
+            continue;
+          }
 
           // Push back into BFS queue
           for (int idx : use_list_[buffer]) {

--- a/tilelang/engine/param.py
+++ b/tilelang/engine/param.py
@@ -66,3 +66,21 @@ class KernelParam:
             bool: True if parameter has no dimensions (empty shape), False otherwise
         """
         return len(self.shape) == 0
+
+    def is_unsigned(self) -> bool:
+        """
+        Checks if the parameter represents an unsigned integer type.
+        
+        Returns:
+            bool: True if parameter is an unsigned integer type, False otherwise
+        """
+        return str(self.dtype).removeprefix("torch.").startswith("uint")
+
+    def is_float8(self) -> bool:
+        """
+        Checks if the parameter represents a float8 type.
+        
+        Returns:
+            bool: True if parameter is a float8 type, False otherwise
+        """
+        return str(self.dtype).removeprefix("torch.").startswith("float8")

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -1,6 +1,5 @@
-# Copyright (c) Microsoft Corporation.
+# Copyright (c) Tile-AI Organization.
 # Licensed under the MIT License.
-
 from tvm import tir, IRModule
 from tvm.target import Target
 import tilelang
@@ -39,7 +38,6 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
         mod = tir.transform.LowerOpaqueBlock()(mod)
         mod = tilelang.transform.MergeIfStmt()(mod)
         mod = tilelang.transform.RewriteWgmmaSync()(mod)
-        # mod = tilelang.transform.WarpSpecializedPipeline()(mod)
         mod = tilelang.transform.InjectFenceProxy()(mod)
     else:
         mod = tir.transform.PlanAndUpdateBufferAllocationLocation()(mod)

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -195,14 +195,14 @@ class JITKernel(object):
         return cls(func=tilelang_func, **kwargs)
 
     def get_profiler(self,
-                     tensor_supply_type: TensorSupplyType = TensorSupplyType.Integer) -> Profiler:
+                     tensor_supply_type: TensorSupplyType = TensorSupplyType.Auto) -> Profiler:
         """
         Creates a profiler to benchmark the compiled runtime module.
 
         Parameters
         ----------
         tensor_supply_type : TensorSupplyType, optional
-            The type of input tensors to supply for profiling (default: TensorSupplyType.Integer).
+            The type of input tensors to supply for profiling (default: TensorSupplyType.Auto).
 
         Returns
         -------

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -60,8 +60,8 @@ def get_tensor_supply(supply_type: TensorSupplyType):
 
         shape = list(map(int, param.shape))
         if supply_type == TensorSupplyType.Auto:
-            is_unsigned = param.dtype.startswith("uint")
-            is_float8 = param.dtype.endswith("float8")
+            is_unsigned = str(dtype).removeprefix("torch.").startswith("uint")
+            is_float8 = str(dtype).removeprefix("torch.").startswith("float8")
             if is_unsigned:
                 return torch.randint(low=0, high=3, size=shape, device=device, dtype=dtype)
             elif is_float8:

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -98,6 +98,7 @@ def get_tensor_supply(supply_type: TensorSupplyType):
 
     return get_tensor
 
+
 # TODO: Align with torch.testing.assert_close
 def torch_assert_close(
     tensor_a,

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -60,8 +60,8 @@ def get_tensor_supply(supply_type: TensorSupplyType):
 
         shape = list(map(int, param.shape))
         if supply_type == TensorSupplyType.Auto:
-            is_unsigned = tensor.dtype.startswith("uint")
-            is_float8 = tensor.dtype.endswith("float8")
+            is_unsigned = param.dtype.startswith("uint")
+            is_float8 = param.dtype.endswith("float8")
             if is_unsigned:
                 return torch.randint(low=0, high=3, size=shape, device=device, dtype=dtype)
             elif is_float8:

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -60,8 +60,8 @@ def get_tensor_supply(supply_type: TensorSupplyType):
 
         shape = list(map(int, param.shape))
         if supply_type == TensorSupplyType.Auto:
-            is_unsigned = str(dtype).removeprefix("torch.").startswith("uint")
-            is_float8 = str(dtype).removeprefix("torch.").startswith("float8")
+            is_unsigned = param.is_unsigned()
+            is_float8 = param.is_float8()
             if is_unsigned:
                 return torch.randint(low=0, high=3, size=shape, device=device, dtype=dtype)
             elif is_float8:
@@ -79,8 +79,8 @@ def get_tensor_supply(supply_type: TensorSupplyType):
             return torch.ones(*shape, device=device, dtype=dtype)
 
         if supply_type == TensorSupplyType.Integer:
-            is_unsigned = str(dtype).removeprefix("torch.").startswith("uint")
-            is_float8 = str(dtype).removeprefix("torch.").startswith("float8")
+            is_unsigned = param.is_unsigned()
+            is_float8 = param.is_float8()
             if is_unsigned:
                 return torch.randint(low=0, high=3, size=shape, device=device, dtype=dtype)
             elif is_float8:

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -60,12 +60,17 @@ def get_tensor_supply(supply_type: TensorSupplyType):
 
         shape = list(map(int, param.shape))
         if supply_type == TensorSupplyType.Auto:
-            if dtype == torch.float16 or dtype == torch.float32:
+            is_unsigned = tensor.dtype.startswith("uint")
+            is_float8 = tensor.dtype.endswith("float8")
+            if is_unsigned:
+                return torch.randint(low=0, high=3, size=shape, device=device, dtype=dtype)
+            elif is_float8:
+                return torch.randint(
+                    low=-128, high=128, size=shape, device=device, dtype=torch.int8).to(dtype)
+            elif dtype in {torch.float16, torch.float32, torch.bfloat16}:
                 return torch.empty(*shape, device=device, dtype=dtype).normal_(-1.0, 1.0)
-            elif dtype == torch.uint8:
-                return torch.randint(0, 2, size=shape, device=device, dtype=dtype)
             else:
-                raise NotImplementedError(dtype)
+                return torch.randint(low=-2, high=3, size=shape, device=device, dtype=dtype)
 
         if dtype == torch.int8 and supply_type in [
                 TensorSupplyType.Uniform,

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -98,7 +98,7 @@ def get_tensor_supply(supply_type: TensorSupplyType):
 
     return get_tensor
 
-
+# TODO: Align with torch.testing.assert_close
 def torch_assert_close(
     tensor_a,
     tensor_b,


### PR DESCRIPTION
This pull request includes several changes to improve the CUDA codebase and update the logging mechanism. The most important changes include adding a new macro definition, updating function attributes to use the new macro, changing the logging mechanism for buffer checks, and updating licensing information.

Improvements to CUDA codebase:

* [`src/tl_templates/cuda/common.h`](diffhunk://#diff-a9affb584850fb57935aeb0a8450d96497f4534022304d408cb369a47d1e8130R27): Added a new macro definition `TL_DEVICE_NOINLINE` to specify noinline device functions.
* [`src/tl_templates/cuda/ldsm.h`](diffhunk://#diff-62f8dd53fd99d691f74a1dba673a393154130ad3cc3f7e7e0d8b3dbbc6b96ec2L9-R9): Updated multiple functions to use `TL_DEVICE_NOINLINE` instead of `TL_DEVICE` to prevent inlining of these functions. [[1]](diffhunk://#diff-62f8dd53fd99d691f74a1dba673a393154130ad3cc3f7e7e0d8b3dbbc6b96ec2L9-R9) [[2]](diffhunk://#diff-62f8dd53fd99d691f74a1dba673a393154130ad3cc3f7e7e0d8b3dbbc6b96ec2L18-R18) [[3]](diffhunk://#diff-62f8dd53fd99d691f74a1dba673a393154130ad3cc3f7e7e0d8b3dbbc6b96ec2L27-R28) [[4]](diffhunk://#diff-62f8dd53fd99d691f74a1dba673a393154130ad3cc3f7e7e0d8b3dbbc6b96ec2L37-R37) [[5]](diffhunk://#diff-62f8dd53fd99d691f74a1dba673a393154130ad3cc3f7e7e0d8b3dbbc6b96ec2L46-R46) [[6]](diffhunk://#diff-62f8dd53fd99d691f74a1dba673a393154130ad3cc3f7e7e0d8b3dbbc6b96ec2L56-R56)

Logging mechanism update:

* [`src/transform/layout_inference.cc`](diffhunk://#diff-199e49dddc4965b8946973e03a1c65fd646309c0417a766af0bcf77a1ff88c3dL153-R158): Changed the logging mechanism for buffer checks from `ICHECK` to `LOG(WARNING)` to provide a warning message and continue execution instead of terminating the program.

Licensing update:

* [`tilelang/engine/phase.py`](diffhunk://#diff-d0919e6c22b4d85ff6c5a0a9f34b53bc9415d8c61dc84e9993841b10d14e44a5L1-L3): Updated the copyright notice to reflect the new organization, Tile-AI Organization.

Other updates:

* [`tilelang/jit/kernel.py`](diffhunk://#diff-0eaba9f3529de6197aa7e13ba09aadf2253971a3571cf805678f4816e764e194L197-R204): Changed the default value of `tensor_supply_type` in the `get_profiler` method to `TensorSupplyType.Auto`.