### PR TITLE
[Refactor] Refactor for Better Layout Conflict Handling

### DIFF
--- a/examples/native_sparse_attention/benchmark/benchmark_nsa_fwd.py
+++ b/examples/native_sparse_attention/benchmark/benchmark_nsa_fwd.py
@@ -616,7 +616,7 @@ def benchmark_nsa(batch_size,
 
     profiler = kernel.get_profiler()
 
-    profiler_latency = profiler.do_bench(profiler.mod)
+    profiler_latency = profiler.do_bench()
     print(f"Profiler latency: {profiler_latency} ms")
 
     # Create input tensors

--- a/src/layout/layout.cc
+++ b/src/layout/layout.cc
@@ -366,8 +366,8 @@ Fragment FragmentNode::CondenseReplicateVar() const {
 
 std::string LayoutNode::DebugOutput() const {
   std::stringstream ss;
-  ss << "Layout Shape: " << InputShape() << " -> " << OutputShape()
-     << " -> " << GetForwardIndex();
+  ss << "Layout Shape: " << InputShape() << " -> " << OutputShape() << " -> "
+     << GetForwardIndex();
   return ss.str();
 }
 

--- a/src/layout/layout.cc
+++ b/src/layout/layout.cc
@@ -364,17 +364,21 @@ Fragment FragmentNode::CondenseReplicateVar() const {
                   new_thread_replicate->dom->extent, new_thread_replicate->var);
 }
 
-void LayoutNode::DebugOutput() const {
-  LOG_DEBUG << "Layout Shape: " << InputShape() << " -> " << OutputShape();
-  LOG_DEBUG << "Layout Index: " << forward_index_;
+std::string LayoutNode::DebugOutput() const {
+  std::stringstream ss;
+  ss << "Layout Shape: " << InputShape() << " -> " << OutputShape()
+     << " -> " << GetForwardIndex();
+  return ss.str();
 }
 
-void FragmentNode::DebugOutput() const {
-  LOG_DEBUG << "Fragment Shape: " << InputShape() << " -> " << OutputShape();
-  LOG_DEBUG << "Fragment Replicate: " << ReplicateExtent();
-  LOG_DEBUG << "Fragment ThreadExtent: " << ThreadExtent();
-  LOG_DEBUG << "Fragment Index: " << forward_index_;
-  LOG_DEBUG << "Fragment ThreadIndex: " << forward_thread_;
+std::string FragmentNode::DebugOutput() const {
+  std::stringstream ss;
+  ss << "Fragment Shape: " << InputShape() << " -> " << OutputShape();
+  ss << " -> replicate: " << ReplicateExtent();
+  ss << " -> thread: " << ThreadExtent();
+  ss << " -> forward_thread: " << forward_thread_;
+  ss << " -> forward_index: " << GetForwardIndex();
+  return ss.str();
 }
 
 bool LayoutNode::SEqualReduce(const LayoutNode *other,

--- a/src/layout/layout.cc
+++ b/src/layout/layout.cc
@@ -396,6 +396,30 @@ bool FragmentNode::SEqualReduce(const FragmentNode *other,
          equal(this->forward_thread_, other->forward_thread_);
 }
 
+bool LayoutNode::IsEqual(const LayoutNode *other, bool skip_index) const {
+  bool ret = StructuralEqual()(this->InputShape(), other->InputShape());
+  ret &= StructuralEqual()(this->OutputShape(), other->OutputShape());
+  if (!skip_index) {
+    ret &= StructuralEqual()(this->forward_index_, other->forward_index_);
+  }
+  return ret;
+}
+
+bool FragmentNode::IsEqual(const FragmentNode *other, bool skip_index) const {
+  // Fragment Layout Comparison can skip the index comparison
+  // when the output shape is the same, as we can do
+  // a[i, j] = b[j, i] in register level.
+
+  bool ret = StructuralEqual()(this->InputShape(), other->InputShape());
+  ret &= StructuralEqual()(this->OutputShape(), other->OutputShape());
+  ret &= StructuralEqual()(this->ReplicateExtent(), other->ReplicateExtent());
+  ret &= StructuralEqual()(this->ThreadExtent(), other->ThreadExtent());
+  if (!skip_index) {
+    ret &= StructuralEqual()(this->forward_index_, other->forward_index_);
+  }
+  return ret;
+}
+
 TVM_REGISTER_NODE_TYPE(LayoutNode);
 TVM_REGISTER_NODE_TYPE(FragmentNode);
 

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -40,7 +40,7 @@ public:
 
   virtual Layout Inverse() const;
 
-  virtual void DebugOutput() const;
+  virtual std::string DebugOutput() const;
 
   static constexpr bool _type_has_method_sequal_reduce = true;
   static constexpr const char *_type_key = "tl.Layout";
@@ -94,7 +94,7 @@ public:
 
   Fragment CondenseReplicateVar() const;
 
-  void DebugOutput() const final;
+  std::string DebugOutput() const final;
 
   void VisitAttrs(tvm::AttrVisitor *v);
   bool SEqualReduce(const FragmentNode *other, SEqualReducer equal) const;

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -42,6 +42,8 @@ public:
 
   virtual std::string DebugOutput() const;
 
+  virtual bool IsEqual(const LayoutNode *other, bool skip_index = false) const;
+
   static constexpr bool _type_has_method_sequal_reduce = true;
   static constexpr const char *_type_key = "tl.Layout";
   bool SEqualReduce(const LayoutNode *other, SEqualReducer equal) const;
@@ -95,6 +97,8 @@ public:
   Fragment CondenseReplicateVar() const;
 
   std::string DebugOutput() const final;
+
+  bool IsEqual(const FragmentNode *other, bool skip_index = false) const;
 
   void VisitAttrs(tvm::AttrVisitor *v);
   bool SEqualReduce(const FragmentNode *other, SEqualReducer equal) const;

--- a/src/layout/swizzle.cc
+++ b/src/layout/swizzle.cc
@@ -61,8 +61,8 @@ Array<PrimExpr> SwizzledLayoutNode::Forward(const Array<PrimExpr> &vars) const {
 std::string SwizzledLayoutNode::DebugOutput() const {
   std::stringstream ss;
   ss << LayoutNode::DebugOutput();
-  ss << "Layout Swizzle: " << pattern_.Base() << " " << pattern_.Bits()
-     << " " << pattern_.Shift();
+  ss << "Layout Swizzle: " << pattern_.Base() << " " << pattern_.Bits() << " "
+     << pattern_.Shift();
   return ss.str();
 }
 

--- a/src/layout/swizzle.cc
+++ b/src/layout/swizzle.cc
@@ -58,10 +58,12 @@ Array<PrimExpr> SwizzledLayoutNode::Forward(const Array<PrimExpr> &vars) const {
   return expr_list;
 }
 
-void SwizzledLayoutNode::DebugOutput() const {
-  LayoutNode::DebugOutput();
-  std::cout << "Layout Swizzle: " << pattern_.Base() << " " << pattern_.Bits()
-            << " " << pattern_.Shift();
+std::string SwizzledLayoutNode::DebugOutput() const {
+  std::stringstream ss;
+  ss << LayoutNode::DebugOutput();
+  ss << "Layout Swizzle: " << pattern_.Base() << " " << pattern_.Bits()
+     << " " << pattern_.Shift();
+  return ss.str();
 }
 
 Layout SwizzledLayoutNode::Inverse() const {

--- a/src/layout/swizzle.cc
+++ b/src/layout/swizzle.cc
@@ -71,6 +71,12 @@ Layout SwizzledLayoutNode::Inverse() const {
   return {};
 }
 
+bool SwizzledLayoutNode::IsEqual(const SwizzledLayoutNode *other,
+                                 bool skip_index) const {
+  return LayoutNode::IsEqual(other, skip_index) &&
+         pattern_ == other->pattern_;
+}
+
 SwizzledLayout::SwizzledLayout(Array<IterVar> forward_var,
                                Array<PrimExpr> forward_index,
                                SwizzlePattern pattern) {

--- a/src/layout/swizzle.cc
+++ b/src/layout/swizzle.cc
@@ -73,8 +73,7 @@ Layout SwizzledLayoutNode::Inverse() const {
 
 bool SwizzledLayoutNode::IsEqual(const SwizzledLayoutNode *other,
                                  bool skip_index) const {
-  return LayoutNode::IsEqual(other, skip_index) &&
-         pattern_ == other->pattern_;
+  return LayoutNode::IsEqual(other, skip_index) && pattern_ == other->pattern_;
 }
 
 SwizzledLayout::SwizzledLayout(Array<IterVar> forward_var,

--- a/src/layout/swizzle.h
+++ b/src/layout/swizzle.h
@@ -45,7 +45,7 @@ public:
 
   Array<PrimExpr> Forward(const Array<PrimExpr> &vars) const final;
   Layout Inverse() const final;
-  void DebugOutput() const final;
+  std::string DebugOutput() const final;
 
   static constexpr const char *_type_key = "tl.SwizzledLayout";
   bool SEqualReduce(const SwizzledLayoutNode *other, SEqualReducer equal) const;

--- a/src/layout/swizzle.h
+++ b/src/layout/swizzle.h
@@ -46,7 +46,7 @@ public:
   Array<PrimExpr> Forward(const Array<PrimExpr> &vars) const final;
   Layout Inverse() const final;
   std::string DebugOutput() const final;
-
+  bool IsEqual(const SwizzledLayoutNode *other, bool skip_index = false) const;
   static constexpr const char *_type_key = "tl.SwizzledLayout";
   bool SEqualReduce(const SwizzledLayoutNode *other, SEqualReducer equal) const;
   void VisitAttrs(tvm::AttrVisitor *v);

--- a/src/op/elem.cc
+++ b/src/op/elem.cc
@@ -343,8 +343,8 @@ LayoutMap Copy::InferLayout(const LayoutInferArgs &T, InferLevel level) {
   if (T.layout_map.count(src) && T.layout_map.count(dst)) {
     // Only compare fragment layout
     if (src.scope() == "local.fragment" && dst.scope() == "local.fragment") {
-      const FragmentNode* src_layout = T.layout_map[src].as<Fragment>().get();
-      const FragmentNode* dst_layout = T.layout_map[dst].as<Fragment>().get();
+      const FragmentNode *src_layout = T.layout_map[src].as<Fragment>().get();
+      const FragmentNode *dst_layout = T.layout_map[dst].as<Fragment>().get();
       if (src_layout && dst_layout) {
         ICHECK(src_layout->IsEqual(dst_layout, true))
             << "Get different layout for " << src << " and " << dst

--- a/src/op/elem.cc
+++ b/src/op/elem.cc
@@ -340,6 +340,12 @@ LayoutMap Copy::InferLayout(const LayoutInferArgs &T, InferLevel level) {
     arith::Analyzer analyzer;
     par_op_ = std::make_unique<ParallelOp>(MakeSIMTLoop(&analyzer));
   }
+  if (T.layout_map.count(src) && T.layout_map.count(dst)) {
+    ICHECK(StructuralEqual()(T.layout_map[src], T.layout_map[dst]))
+        << "Get different layout for " << src
+        << " src layout: " << T.layout_map[src]->DebugOutput()
+        << " dst layout: " << T.layout_map[dst]->DebugOutput();
+  }
   return par_op_->InferLayout(T, level);
 }
 

--- a/src/op/elem.cc
+++ b/src/op/elem.cc
@@ -343,8 +343,8 @@ LayoutMap Copy::InferLayout(const LayoutInferArgs &T, InferLevel level) {
   if (T.layout_map.count(src) && T.layout_map.count(dst)) {
     // Only compare fragment layout
     if (src.scope() == "local.fragment" && dst.scope() == "local.fragment") {
-      auto src_layout = T.layout_map[src].as<Fragment>().get();
-      auto dst_layout = T.layout_map[dst].as<Fragment>().get();
+      const FragmentNode* src_layout = T.layout_map[src].as<Fragment>().get();
+      const FragmentNode* dst_layout = T.layout_map[dst].as<Fragment>().get();
       if (src_layout && dst_layout) {
         ICHECK(src_layout->IsEqual(dst_layout, true))
             << "Get different layout for " << src << " and " << dst

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -235,15 +235,18 @@ LayoutMap ParallelOp::InferLayout(const LayoutInferArgs &T, InferLevel level) {
     if (buffer.scope() == "local.fragment" && source_buffer.defined() &&
         source_buffer.scope() == "local.fragment") {
       if (T.layout_map.count(buffer)) {
-        const FragmentNode* src_layout = T.layout_map[buffer].as<Fragment>().get();
+        const FragmentNode *src_layout =
+            T.layout_map[buffer].as<Fragment>().get();
         Fragment dst_layout_fragment = CompleteBufferFragment(buffer);
-        const FragmentNode* dst_layout = dst_layout_fragment.as<Fragment>().get();
+        const FragmentNode *dst_layout =
+            dst_layout_fragment.as<Fragment>().get();
         if (src_layout && dst_layout) {
           ICHECK(src_layout->IsEqual(dst_layout, true))
-              << "Layout may conflict with ParallelOp for buffer "
-              << buffer << "\nLHS = " << src_layout->DebugOutput()
+              << "Layout may conflict with ParallelOp for buffer " << buffer
+              << "\nLHS = " << src_layout->DebugOutput()
               << "\nRHS = " << dst_layout->DebugOutput()
-              << "\nYou may need to use a shared memory to transform the layout";
+              << "\nYou may need to use a shared memory to transform the "
+                 "layout";
         }
       }
     }

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -225,8 +225,16 @@ LayoutMap ParallelOp::InferLayout(const LayoutInferArgs &T, InferLevel level) {
   // Step 3: Infer other fragment's layout from the loop's partition
   LayoutMap results;
   for (const auto &[buffer, _] : indice_map_) {
-    if (!T.layout_map.count(buffer))
+    if (!T.layout_map.count(buffer)) {
       results.Set(buffer, CompleteBufferFragment(buffer));
+    } else {
+      auto src_layout = T.layout_map[buffer];
+      auto dst_layout = CompleteBufferFragment(buffer);
+      ICHECK(StructuralEqual()(src_layout, dst_layout))
+          << "Layout infer conflict for " << buffer << " " << source_buffer
+          << "\nLHS = " << src_layout->DebugOutput()
+          << "\nRHS = " << dst_layout->DebugOutput();
+    }
   }
   return results;
 }

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -235,14 +235,15 @@ LayoutMap ParallelOp::InferLayout(const LayoutInferArgs &T, InferLevel level) {
     if (buffer.scope() == "local.fragment" && source_buffer.defined() &&
         source_buffer.scope() == "local.fragment") {
       if (T.layout_map.count(buffer)) {
-        auto src_layout = T.layout_map[buffer].as<Fragment>().get();
-        auto dst_layout = CompleteBufferFragment(buffer).as<Fragment>().get();
+        const FragmentNode* src_layout = T.layout_map[buffer].as<Fragment>().get();
+        Fragment dst_layout_fragment = CompleteBufferFragment(buffer);
+        const FragmentNode* dst_layout = dst_layout_fragment.as<Fragment>().get();
         if (src_layout && dst_layout) {
           ICHECK(src_layout->IsEqual(dst_layout, true))
               << "Layout may conflict with ParallelOp for buffer "
               << buffer << "\nLHS = " << src_layout->DebugOutput()
-                         << "\nRHS = " << dst_layout->DebugOutput()
-                         << "\nYou may need to use a shared memory to transform the layout";
+              << "\nRHS = " << dst_layout->DebugOutput()
+              << "\nYou may need to use a shared memory to transform the layout";
         }
       }
     }

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -131,7 +131,6 @@ public:
           LayoutInferArgs{target_, static_cast<size_t>(*extent_ptr),
                           layout_map},
           level);
-
       // Process the returned updates
       for (const auto &[buffer, layout] : updates) {
         // Basic validity checks
@@ -142,7 +141,8 @@ public:
           // If already in map, ensure they are structurally equal
           ICHECK(StructuralEqual()(layout, layout_map[buffer]))
               << "Get different layout for " << buffer
-              << " in cur_infer_id = " << cur_infer_id;
+              << " current layout: " << layout->DebugOutput()
+              << " previous layout: " << layout_map[buffer]->DebugOutput();
         } else {
           // Otherwise, update map
           layout_map.Set(buffer, layout);
@@ -191,9 +191,10 @@ public:
     for (int i = 0; i < num_infer; i++) {
       run_infer_step(i, InferLevel::kStrict, false);
     }
-    // step 2: infer common layout with BFS
 
+    // step 2: infer common layout with BFS
     finish_infer_queue();
+
     // step 3: relax constraints to free and re-run
     for (int i = 0; i < num_infer; i++) {
       run_infer_step(i, InferLevel::kFree, true);

--- a/testing/python/language/test_tilelang_language_reduce_max.py
+++ b/testing/python/language/test_tilelang_language_reduce_max.py
@@ -17,7 +17,7 @@ def reduce_max_test(M, N, dtype="float16"):
         with T.Kernel(1) as _:
             A_local = T.alloc_fragment((M, N), dtype)
             B_local = T.alloc_fragment((M,), dtype)
-            
+
             # Copy input to local
             T.copy(A, A_local)
             # Perform reduce_max operation
@@ -44,7 +44,7 @@ def test_reduce_max():
     run_reduce_max(256, 256)
     run_reduce_max(512, 128)
     run_reduce_max(128, 512)
-    
+
     # Test different dtypes
     run_reduce_max(256, 256, "float32")
     run_reduce_max(256, 256, "float16")

--- a/testing/python/language/test_tilelang_language_reduce_max.py
+++ b/testing/python/language/test_tilelang_language_reduce_max.py
@@ -1,0 +1,54 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+
+from tilelang import tvm as tvm
+import tilelang.testing
+import tilelang as tl
+
+
+def reduce_max_test(M, N, dtype="float16"):
+    import tilelang.language as T
+
+    @T.prim_func
+    def main(
+            A: T.Buffer((M, N), dtype),
+            B: T.Buffer((M,), dtype),
+    ):
+        with T.Kernel(1) as _:
+            A_local = T.alloc_fragment((M, N), dtype)
+            B_local = T.alloc_fragment((M,), dtype)
+            
+            # Copy input to local
+            T.copy(A, A_local)
+            # Perform reduce_max operation
+            T.reduce_max(A_local, B_local, dim=1)
+            # Copy result back
+            T.copy(B_local, B)
+
+    return main
+
+
+def run_reduce_max(M, N, dtype="float16"):
+    program = reduce_max_test(M, N, dtype)
+    jit_kernel = tl.compile(program, out_idx=-1)
+    profiler = jit_kernel.get_profiler()
+
+    def ref_program(A):
+        return A.max(dim=1).values
+
+    profiler.assert_allclose(ref_program, atol=1e-2, rtol=1e-2)
+
+
+def test_reduce_max():
+    # Test different sizes
+    run_reduce_max(256, 256)
+    run_reduce_max(512, 128)
+    run_reduce_max(128, 512)
+    
+    # Test different dtypes
+    run_reduce_max(256, 256, "float32")
+    run_reduce_max(256, 256, "float16")
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/webgpu/test_webgpu_codegen.py
+++ b/testing/python/webgpu/test_webgpu_codegen.py
@@ -27,7 +27,7 @@ def matmul(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype="flo
                 T.copy(A[by * block_M, ko * block_K], A_shared, coalesced_width=2)
                 T.copy(B[ko * block_K, bx * block_N], B_shared, coalesced_width=2)
 
-                for i, j, k in T.Parallel(block_M, block_N, block_K):
+                for i, j, k in T.grid(block_M, block_N, block_K):
                     C_local[i, j] += A_shared[i, k] * B_shared[k, j]
 
             T.copy(C_local, C[by * block_M, bx * block_N], coalesced_width=2)


### PR DESCRIPTION
This pull request includes several changes to improve the `DebugOutput` methods in the layout-related classes and enhance layout inference checks. The most important changes include converting `DebugOutput` methods to return `std::string`, adding layout consistency checks, and minor code formatting improvements.

Improvements to `DebugOutput` methods:

* [`src/layout/layout.cc`](diffhunk://#diff-8e8b85e9396c3aaaf378020a15e4274510e97a4fb17c7c5ac7047596e1ca37c5L367-R381): The `DebugOutput` methods in `LayoutNode` and `FragmentNode` were modified to return `std::string` instead of printing directly to the console.
* [`src/layout/swizzle.cc`](diffhunk://#diff-345c4633d913e6c31c4b2137d9485fa0d4762dbd6efea08ac993c50acec15b0cL61-R66): The `DebugOutput` method in `SwizzledLayoutNode` was modified to return `std::string` instead of printing directly to the console.

Layout consistency checks:

* [`src/op/elem.cc`](diffhunk://#diff-b41ad92a37e3f104b615eb0ec61a1d7af1c21ef178a5acb708e3b7391450cfb2R343-R348): Added a check to ensure that the source and destination layouts are structurally equal in the `Copy::InferLayout` method.
* [`src/op/parallel.cc`](diffhunk://#diff-ef280fbd8aa7147455086fe8e3515b5a57544d0eee947850799f14812037b40eL228-R237): Added a check to ensure that the inferred layout matches the existing layout in the `ParallelOp::InferLayout` method.
* [`src/transform/layout_inference.cc`](diffhunk://#diff-199e49dddc4965b8946973e03a1c65fd646309c0417a766af0bcf77a1ff88c3dL145-R145): Enhanced the layout consistency check to include detailed debug output in the `BufferUseDefCollector` class.

Minor code formatting improvements:

* [`src/transform/layout_inference.cc`](diffhunk://#diff-199e49dddc4965b8946973e03a1c65fd646309c0417a766af0bcf77a1ff88c3dL134): Removed unnecessary blank lines and improved code formatting. [[1]](diffhunk://#diff-199e49dddc4965b8946973e03a1c65fd646309c0417a766af0bcf77a1ff88c3dL134) [[2]](diffhunk://#diff-199e49dddc4965b8946973e03a1c65fd646309c0417a766af0bcf77a1ff88c3dL194-R197)