### PR TITLE
[BugFix] Fix bug of missing MBarrierExpectTX

### DIFF
--- a/src/transform/warp_specialized_rewriter.cc
+++ b/src/transform/warp_specialized_rewriter.cc
@@ -219,7 +219,7 @@ private:
 
   Stmt expect_tx_;
   bool contain_tma_load_;
-  bool insert_in_evaluate_;
+  bool insert_in_evaluate_ = true;
 };
 
 class ProducerTraitsCollector : public StmtExprVisitor {


### PR DESCRIPTION
This pull request includes a small but important change to the `TMAExpectTxRewriter` class in the file `src/transform/warp_specialized_rewriter.cc`. The change initializes the `insert_in_evaluate_` boolean member to `true`.

* [`src/transform/warp_specialized_rewriter.cc`](diffhunk://#diff-3b0121eb3bc9b60c4f1b2aacc64bc682935d62afed8217bfc96bfd58765d403cL222-R222): Initialized the `insert_in_evaluate_` boolean member to `true` in the `TMAExpectTxRewriter` class.