### PR TITLE
[Enhancement][CUDA] Avoid C7508 for CUDA backend via assigning default value to `minBlocksPerMultiprocesor `

### DIFF
--- a/src/target/codegen_cuda.cc
+++ b/src/target/codegen_cuda.cc
@@ -98,7 +98,7 @@ void CodeGenTileLangCUDA::PrintExtraAttrs(const PrimFunc &f) {
       // return
       return;
     }
-    stream << " __launch_bounds__(" << threadIdx_ext_int->value << ")";
+    stream << " __launch_bounds__(" << threadIdx_ext_int->value << ", 1)";
   }
 }
 


### PR DESCRIPTION
We should set the second parametr minBlockperSM for __launch_bounds__ to avoid C7508, just set it to 1 to make compiler happy.