### PR TITLE
[CI] Use auditwheel to generate manylinux wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 debug/
 build/
 dist/
+wheelhouse/
 __pycache__
 nnfusion.tar.gz
 

--- a/maint/scripts/docker_local_distribute.sh
+++ b/maint/scripts/docker_local_distribute.sh
@@ -4,17 +4,10 @@
 # Licensed under the MIT License.
 
 # Get the CUDA version from the command line
-IMAGE=nvidia/cuda:12.1.0-devel-ubuntu18.04
+IMAGE="tilelang-builder:18.04"
+docker build . -f "$(dirname "${BASH_SOURCE[0]}")/pypi.Dockerfile" --tag ${IMAGE}
 
-docker pull ${IMAGE}
-
-apt_command="apt update && apt install -y software-properties-common && add-apt-repository -y ppa:deadsnakes/ppa && apt update && apt install -y wget curl libtinfo-dev zlib1g-dev libssl-dev build-essential libedit-dev libxml2-dev"
-
-install_python_env="curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda3 && export PATH=~/miniconda3/bin/:$PATH && conda create -n py38 python=3.8 -y && conda create -n py39 python=3.9 -y && conda create -n py310 python=3.10 -y && conda create -n py311 python=3.11 -y && conda create -n py312 python=3.12 -y && ln -s ~/miniconda3/envs/py38/bin/python3.8 /usr/bin/python3.8 && ln -s ~/miniconda3/envs/py39/bin/python3.9 /usr/bin/python3.9 && ln -s ~/miniconda3/envs/py310/bin/python3.10 /usr/bin/python3.10 && ln -s ~/miniconda3/envs/py311/bin/python3.11 /usr/bin/python3.11 && ln -s ~/miniconda3/envs/py312/bin/python3.12 /usr/bin/python3.12"
-
-install_cmake="wget https://github.com/Kitware/CMake/releases/download/v3.28.4/cmake-3.28.4-linux-x86_64.tar.gz && tar -xvzf cmake-*.tar.gz && rm cmake-*.tar.gz && cd cmake-* && cp bin/* /usr/local/bin/ && mv share/* /usr/local/share/ && mv man/* /usr/local/man/ && hash -r && cd /tilelang && export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH"
-
-install_pip="python3.8 -m pip install  --upgrade pip && python3.8 -m pip install -r requirements-build.txt"
+install_pip="python3.8 -m pip install --upgrade pip && python3.8 -m pip install -r requirements-build.txt"
 
 tox_command="python3.8 -m tox -e py38,py39,py310,py311,py312"
 

--- a/maint/scripts/docker_pypi_distribute.sh
+++ b/maint/scripts/docker_pypi_distribute.sh
@@ -16,6 +16,6 @@ install_cmake="wget https://github.com/Kitware/CMake/releases/download/v3.28.4/c
 
 install_pip="python3.8 -m pip install --upgrade pip && python3.8 -m pip install -r requirements-build.txt"
 
-tox_command="python3.8 -m tox -e py38-pypi,py39-pypi,py310-pypi,py311-pypi,py312-pypi"
+tox_command="python3.8 -m tox -e py38-pypi,py39-pypi,py310-pypi,py311-pypi,py312-pypi,audit_2_27"
 
 docker run --rm -v $(pwd):/tilelang ${IMAGE} /bin/bash -c "$apt_command && $install_python_env && $install_cmake && $install_pip && $tox_command"

--- a/maint/scripts/docker_pypi_distribute.sh
+++ b/maint/scripts/docker_pypi_distribute.sh
@@ -4,18 +4,11 @@
 # Licensed under the MIT License.
 
 # Get the CUDA version from the command line
-IMAGE=nvidia/cuda:12.1.0-devel-ubuntu18.04
-
-docker pull ${IMAGE}
-
-apt_command="apt update && apt install -y software-properties-common && add-apt-repository -y ppa:deadsnakes/ppa && apt update && apt install -y wget curl libtinfo-dev zlib1g-dev libssl-dev build-essential libedit-dev libxml2-dev"
-
-install_python_env="curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh && bash Miniconda3-latest-Linux-x86_64.sh -b -p ~/miniconda3 && export PATH=~/miniconda3/bin/:$PATH && conda create -n py38 python=3.8 -y && conda create -n py39 python=3.9 -y && conda create -n py310 python=3.10 -y && conda create -n py311 python=3.11 -y && conda create -n py312 python=3.12 -y && ln -s ~/miniconda3/envs/py38/bin/python3.8 /usr/bin/python3.8 && ln -s ~/miniconda3/envs/py39/bin/python3.9 /usr/bin/python3.9 && ln -s ~/miniconda3/envs/py310/bin/python3.10 /usr/bin/python3.10 && ln -s ~/miniconda3/envs/py311/bin/python3.11 /usr/bin/python3.11 && ln -s ~/miniconda3/envs/py312/bin/python3.12 /usr/bin/python3.12"
-
-install_cmake="wget https://github.com/Kitware/CMake/releases/download/v3.28.4/cmake-3.28.4-linux-x86_64.tar.gz && tar -xvzf cmake-*.tar.gz && rm cmake-*.tar.gz && cd cmake-* && cp bin/* /usr/local/bin/ && mv share/* /usr/local/share/ && mv man/* /usr/local/man/ && hash -r && cd /tilelang && export LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu/:$LD_LIBRARY_PATH"
+IMAGE="tilelang-builder:18.04"
+docker build . -f "$(dirname "${BASH_SOURCE[0]}")/pypi.Dockerfile" --tag ${IMAGE}
 
 install_pip="python3.8 -m pip install --upgrade pip && python3.8 -m pip install -r requirements-build.txt"
 
 tox_command="python3.8 -m tox -e py38-pypi,py39-pypi,py310-pypi,py311-pypi,py312-pypi,audit_2_27"
 
-docker run --rm -v $(pwd):/tilelang ${IMAGE} /bin/bash -c "$apt_command && $install_python_env && $install_cmake && $install_pip && $tox_command"
+docker run --rm -v $(pwd):/tilelang ${IMAGE} /bin/bash -c "$install_pip && $tox_command"

--- a/maint/scripts/pypi.Dockerfile
+++ b/maint/scripts/pypi.Dockerfile
@@ -1,0 +1,25 @@
+FROM nvidia/cuda:12.1.0-devel-ubuntu18.04
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y wget curl libtinfo-dev zlib1g-dev libssl-dev build-essential libedit-dev libxml2-dev; \
+    curl -O https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh; \
+    bash Miniconda3-latest-Linux-x86_64.sh -b -p /miniconda3; \
+    rm Miniconda3-latest-Linux-x86_64.sh
+
+ENV PATH=/miniconda3/bin/:$PATH
+
+RUN set -eux; \
+    conda create -n py38 python=3.8 -y; \
+    conda create -n py39 python=3.9 -y; \
+    conda create -n py310 python=3.10 -y; \
+    conda create -n py311 python=3.11 -y; \
+    conda create -n py312 python=3.12 -y; \
+    ln -s /miniconda3/envs/py38/bin/python3.8 /usr/bin/python3.8; \
+    ln -s /miniconda3/envs/py39/bin/python3.9 /usr/bin/python3.9; \
+    ln -s /miniconda3/envs/py310/bin/python3.10 /usr/bin/python3.10; \
+    ln -s /miniconda3/envs/py311/bin/python3.11 /usr/bin/python3.11; \
+    ln -s /miniconda3/envs/py312/bin/python3.12 /usr/bin/python3.12; \
+    conda install -y cmake patchelf
+
+WORKDIR /tilelang

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -6,3 +6,5 @@ setuptools>=61
 torch
 wheel
 tox
+auditwheel
+patchelf

--- a/tilelang/jit/adapter/utils.py
+++ b/tilelang/jit/adapter/utils.py
@@ -1,5 +1,8 @@
 # Copyright (c) Tile-AI Corporation.
 # Licensed under the MIT License.
+
+from __future__ import annotations
+
 import re
 from typing import Union, Optional, Literal
 from tilelang import tvm as tvm

--- a/tilelang/jit/adapter/utils.py
+++ b/tilelang/jit/adapter/utils.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import re
-from typing import Union, Optional, Literal
+from typing import Union, Optional, Literal, Tuple
 from tilelang import tvm as tvm
 from tvm import IRModule, tir
 from tvm.target import Target
@@ -68,7 +68,7 @@ def get_annotated_mod(
     target: Union[str, Target] = "auto",
     target_host: Optional[Union[str, Target]] = None,
     model_type: Literal["device", "host", "all"] = "all",
-) -> Union[IRModule, tuple[IRModule, IRModule]]:
+) -> Union[IRModule, Tuple[IRModule, IRModule]]:
 
     # Validate model_type early
     if model_type not in {"device", "host", "all"}:

--- a/tilelang/jit/adapter/utils.py
+++ b/tilelang/jit/adapter/utils.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import re
-from typing import Union, Optional, Literal, Tuple
+from typing import Union, Optional, Literal
 from tilelang import tvm as tvm
 from tvm import IRModule, tir
 from tvm.target import Target
@@ -68,7 +68,7 @@ def get_annotated_mod(
     target: Union[str, Target] = "auto",
     target_host: Optional[Union[str, Target]] = None,
     model_type: Literal["device", "host", "all"] = "all",
-) -> Union[IRModule, Tuple[IRModule, IRModule]]:
+) -> Union[IRModule, tuple[IRModule, IRModule]]:
 
     # Validate model_type early
     if model_type not in {"device", "host", "all"}:

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT License.
 
 from __future__ import annotations
-
 """The profiler and convert to torch utils"""
 from enum import Enum
 import torch

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -1,6 +1,5 @@
 # Copyright (c) Tile-AI Organization.
 # Licensed under the MIT License.
-
 """The profiler and convert to torch utils"""
 from enum import Enum
 import torch

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -1,14 +1,13 @@
 # Copyright (c) Tile-AI Organization.
 # Licensed under the MIT License.
 
-from __future__ import annotations
-
 """The profiler and convert to torch utils"""
 from enum import Enum
 import torch
 from tvm.runtime import ndarray
 from torch.utils.dlpack import to_dlpack
 import numpy as np
+from typing import Tuple
 
 
 class TensorSupplyType(Enum):
@@ -153,7 +152,7 @@ def _compare_attributes(
 
 
 def _equalize_attributes(actual: torch.Tensor,
-                         expected: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+                         expected: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
     """Equalizes some attributes of two tensors for value comparison.
     If ``actual`` and ``expected`` are ...
     - ... not on the same :attr:`~torch.Tensor.device`, they are moved CPU memory.

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -1,5 +1,8 @@
 # Copyright (c) Tile-AI Organization.
 # Licensed under the MIT License.
+
+from __future__ import annotations
+
 """The profiler and convert to torch utils"""
 from enum import Enum
 import torch

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -1,12 +1,14 @@
 # Copyright (c) Tile-AI Organization.
 # Licensed under the MIT License.
+
+from __future__ import annotations
+
 """The profiler and convert to torch utils"""
 from enum import Enum
 import torch
 from tvm.runtime import ndarray
 from torch.utils.dlpack import to_dlpack
 import numpy as np
-from typing import Tuple
 
 
 class TensorSupplyType(Enum):
@@ -151,7 +153,7 @@ def _compare_attributes(
 
 
 def _equalize_attributes(actual: torch.Tensor,
-                         expected: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+                         expected: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     """Equalizes some attributes of two tensors for value comparison.
     If ``actual`` and ``expected`` are ...
     - ... not on the same :attr:`~torch.Tensor.device`, they are moved CPU memory.

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,14 @@ commands =
 setenv =
     PYPI_BUILD = TRUE
 commands =
-    python setup.py bdist_wheel --plat-name=manylinux1_x86_64
+    python setup.py bdist_wheel
+
+[testenv:audit_2_27]
+deps =
+    auditwheel
+    patchelf
+commands =
+    auditwheel repair --plat=manylinux_2_27_x86_64 dist/*
 
 [testenv:py38]
 basepython = python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -17,11 +17,13 @@ commands =
     python setup.py bdist_wheel
 
 [testenv:audit_2_27]
+allowlist_externals =
+    bash
 deps =
     auditwheel
     patchelf
 commands =
-    auditwheel repair --plat=manylinux_2_27_x86_64 dist/*
+    bash -c 'auditwheel repair -L=/lib --exclude=/usr/local/cuda* --exclude=libcuda.so.1 --plat=manylinux_2_27_x86_64 dist/*'
 
 [testenv:py38]
 basepython = python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ commands =
     python setup.py bdist_wheel
 
 [testenv:audit_2_27]
+skip_install = true
 allowlist_externals =
     bash
 deps =


### PR DESCRIPTION
As title.

Currently pypi wheels do not provide libraries required by libtvm_runtime.so and stuffs. This causes troubles like https://github.com/tile-ai/tilelang/issues/172 and a so missing error mentioned in wechat group.

This PR shell fix it.
