### PR TITLE
[Bugfix]Add CUDA availability check in CtypesKernelAdapter

### DIFF
--- a/tilelang/jit/adapter/ctypes/adapter.py
+++ b/tilelang/jit/adapter/ctypes/adapter.py
@@ -228,7 +228,10 @@ class CtypesKernelAdapter(BaseKernelAdapter):
 
         # if stream is not None, we need to pass the stream to the library
         if stream is None:
-            stream = torch.cuda.current_stream().cuda_stream
+            if str(self.target).startswith("cuda") and torch.cuda.is_available():
+                stream = torch.cuda.current_stream().cuda_stream
+            else:
+                stream = 0
 
         self._forward_from_prebuild_lib(*args, stream=stream)
 

--- a/tilelang/jit/adapter/cython/cython_wrapper.pyx
+++ b/tilelang/jit/adapter/cython/cython_wrapper.pyx
@@ -75,7 +75,10 @@ cdef class CythonKernelWrapper:
 
         # Use current CUDA stream if none specified
         if stream == -1: 
-            stream = torch.cuda.current_stream().cuda_stream
+            if torch.cuda.is_available():
+                stream = torch.cuda.current_stream().cuda_stream
+            else:
+                stream = 0
 
         cdef int ins_idx = 0
         cdef list tensor_list = []


### PR DESCRIPTION



## Fix Contents

 Modified the `_warp_forward_from_prebuild_lib` method to check before accessing CUDA streams:
   - Whether the current target platform is CUDA
   - Whether CUDA is available

## Testing

This fix has been tested in the following environments:
- Pure CPU environment (no NVIDIA driver)
```
(meson) yxc@yxc-MS-7B89:~/code/2503/tilelang_yxc$ python testing/python/cpu/test_tilelang_cpu_gemm.py
2025-03-24 01:21:55 [TileLang:INFO]: No cached version found for cython jit adapter, need to compile...
2025-03-24 01:21:55 [TileLang:INFO]: Compiling cython jit adapter...
======================================================================================= test session starts =======================================================================================
platform linux -- Python 3.12.3, pytest-8.3.5, pluggy-1.5.0
rootdir: /home/yxc/code/2503/tilelang_yxc
configfile: pyproject.toml
plugins: xdist-3.6.1, typeguard-4.3.0
collected 2 items

testing/python/cpu/test_tilelang_cpu_gemm.py ..                                                                                                                                             [100%]

======================================================================================== warnings summary =========================================================================================
testing/python/cpu/test_tilelang_cpu_gemm.py::test_matmul_codegen
testing/python/cpu/test_tilelang_cpu_gemm.py::test_matmul_codegen
testing/python/cpu/test_tilelang_cpu_gemm.py::test_matmul_compile
testing/python/cpu/test_tilelang_cpu_gemm.py::test_matmul_compile
testing/python/cpu/test_tilelang_cpu_gemm.py::test_matmul_compile
testing/python/cpu/test_tilelang_cpu_gemm.py::test_matmul_compile
  /home/yxc/code/2503/tilelang_yxc/tilelang/../3rdparty/tvm/python/tvm/script/parser/core/doc.py:296: DeprecationWarning: Attribute s is deprecated and will be removed in Python 3.14; use value instead
    kv = {attr: self.func(getattr(node, attr, None)) for attr in self.fields}

testing/python/cpu/test_tilelang_cpu_gemm.py::test_matmul_codegen
testing/python/cpu/test_tilelang_cpu_gemm.py::test_matmul_codegen
testing/python/cpu/test_tilelang_cpu_gemm.py::test_matmul_compile
testing/python/cpu/test_tilelang_cpu_gemm.py::test_matmul_compile
testing/python/cpu/test_tilelang_cpu_gemm.py::test_matmul_compile
testing/python/cpu/test_tilelang_cpu_gemm.py::test_matmul_compile
  /home/yxc/code/2503/tilelang_yxc/tilelang/../3rdparty/tvm/python/tvm/script/parser/core/doc.py:296: DeprecationWarning: Attribute n is deprecated and will be removed in Python 3.14; use value instead
    kv = {attr: self.func(getattr(node, attr, None)) for attr in self.fields}

testing/python/cpu/test_tilelang_cpu_gemm.py::test_matmul_codegen
testing/python/cpu/test_tilelang_cpu_gemm.py::test_matmul_compile
  /home/yxc/code/2503/tilelang_yxc/tilelang/../3rdparty/tvm/python/tvm/script/parser/core/doc.py:297: DeprecationWarning: Attribute s is deprecated and will be removed in Python 3.14; use value instead
    return self.doc_cls(**kv)

testing/python/cpu/test_tilelang_cpu_gemm.py::test_matmul_codegen
testing/python/cpu/test_tilelang_cpu_gemm.py::test_matmul_compile
  /home/yxc/code/2503/tilelang_yxc/tilelang/../3rdparty/tvm/python/tvm/script/parser/core/doc.py:297: DeprecationWarning: Attribute n is deprecated and will be removed in Python 3.14; use value instead
    return self.doc_cls(**kv)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================= 2 passed, 16 warnings in 7.20s ==================================================================================
(meson) yxc@yxc-MS-7B89:~/code/2503/tilelang_yxc$
```

Confirmed working in CPU mode by running `tilelang/testing/python/cpu/test_tilelang_cpu_gemm.py`.

## Related Issue

Fixes Issue #256 