### PR TITLE
[Bugfix] Support `T.clear` for let binding

### DIFF
--- a/src/op/elem.cc
+++ b/src/op/elem.cc
@@ -361,21 +361,20 @@ Fill::Fill(Array<PrimExpr> args, BufferMap vmap) {
 
   if (args[0]->IsInstance<BufferLoadNode>()) {
     auto buffer_load = Downcast<BufferLoad>(args[0]);
-    for (const auto& index : buffer_load->indices) {
-      if (const auto* ramp = index.as<RampNode>()) {
+    for (const auto &index : buffer_load->indices) {
+      if (const auto *ramp = index.as<RampNode>()) {
         CHECK(ramp->stride.as<IntImmNode>()->value == 1)
             << "Only stride 1 ramps are supported";
-        const auto* lanes = ramp->lanes.as<IntImmNode>();
-        CHECK(lanes) << "Scalable vectors not supported in BufferRegion conversion";
+        const auto *lanes = ramp->lanes.as<IntImmNode>();
+        CHECK(lanes)
+            << "Scalable vectors not supported in BufferRegion conversion";
         region.push_back(Range::FromMinExtent(ramp->base, ramp->lanes));
       } else {
         region.push_back(Range::FromMinExtent(index, 1));
       }
     }
     dst = buffer_load->buffer;
-  }
-  else
-  {
+  } else {
     dst = vmap[GetVarFromAccessPtr(args[0])];
     for (int i = 0; i < dst->shape.size(); i++) {
       region.push_back(Range(0, dst->shape[i]));
@@ -388,7 +387,8 @@ Fill::Fill(Array<PrimExpr> args, BufferMap vmap) {
     value = args[1];
   }
 
-  ICHECK(region.size() == dst->shape.size()) << "region size = " << region.size() << " != " << dst->shape.size();
+  ICHECK(region.size() == dst->shape.size())
+      << "region size = " << region.size() << " != " << dst->shape.size();
   for (int i = 0; i < region.size(); i++) {
     // bound check if region is static
     if (region[i]->min.as<IntImm>()) {

--- a/src/op/elem.cc
+++ b/src/op/elem.cc
@@ -358,11 +358,48 @@ LayoutMap Copy::InferLayout(const LayoutInferArgs &T, InferLevel level) {
 }
 
 Fill::Fill(Array<PrimExpr> args, BufferMap vmap) {
-  dst = vmap[GetVarFromAccessPtr(args[0])];
+
+  if (args[0]->IsInstance<BufferLoadNode>()) {
+    auto buffer_load = Downcast<BufferLoad>(args[0]);
+    for (const auto& index : buffer_load->indices) {
+      if (const auto* ramp = index.as<RampNode>()) {
+        CHECK(ramp->stride.as<IntImmNode>()->value == 1)
+            << "Only stride 1 ramps are supported";
+        const auto* lanes = ramp->lanes.as<IntImmNode>();
+        CHECK(lanes) << "Scalable vectors not supported in BufferRegion conversion";
+        region.push_back(Range::FromMinExtent(ramp->base, ramp->lanes));
+      } else {
+        region.push_back(Range::FromMinExtent(index, 1));
+      }
+    }
+    dst = buffer_load->buffer;
+  }
+  else
+  {
+    dst = vmap[GetVarFromAccessPtr(args[0])];
+    for (int i = 0; i < dst->shape.size(); i++) {
+      region.push_back(Range(0, dst->shape[i]));
+    }
+  }
+
   if (args[1]->dtype != dst->dtype) {
     value = Cast(dst->dtype, args[1]);
   } else {
     value = args[1];
+  }
+
+  ICHECK(region.size() == dst->shape.size()) << "region size = " << region.size() << " != " << dst->shape.size();
+  for (int i = 0; i < region.size(); i++) {
+    // bound check if region is static
+    if (region[i]->min.as<IntImm>()) {
+      int64_t min = Downcast<IntImm>(region[i]->min)->value;
+      ICHECK_GE(min, 0) << "region[" << i << "] = " << min << " < 0";
+    }
+    if (region[i]->extent.as<IntImm>()) {
+      int64_t extent = Downcast<IntImm>(region[i]->extent)->value;
+      ICHECK_LE(extent, Downcast<IntImm>(dst->shape[i])->value)
+          << "region[" << i << "] = " << extent << " > " << dst->shape[i];
+    }
   }
 }
 
@@ -372,7 +409,7 @@ For Fill::MakeSIMTLoop(arith::Analyzer *analyzer) const {
   Array<PrimExpr> dst_indices;
   for (int i = 0; i < ndim; i++) {
     Var var = Var(std::string{char('i' + i)});
-    loop_vars.push_back({Range(0, dst->shape[i]), var, IterVarType::kDataPar});
+    loop_vars.push_back({region[i], var, IterVarType::kDataPar});
     dst_indices.push_back(var);
   }
   Stmt body = BufferStore(dst, value, dst_indices);

--- a/src/op/elem.h
+++ b/src/op/elem.h
@@ -59,6 +59,7 @@ private:
   For MakeSIMTLoop(arith::Analyzer *analyzer) const;
   tir::Buffer dst;
   PrimExpr value;
+  Array<Range> region;
 };
 
 } // namespace tl

--- a/testing/python/language/test_tilelang_language_alias.py
+++ b/testing/python/language/test_tilelang_language_alias.py
@@ -4,6 +4,7 @@
 import tilelang
 import tilelang.language as T
 
+
 def matmul(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype="float"):
     # add decorator @tilelang.jit if you want to return a torch function
     @T.prim_func

--- a/testing/python/language/test_tilelang_language_alias.py
+++ b/testing/python/language/test_tilelang_language_alias.py
@@ -4,7 +4,6 @@
 import tilelang
 import tilelang.language as T
 
-
 def matmul(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype="float"):
     # add decorator @tilelang.jit if you want to return a torch function
     @T.prim_func
@@ -22,6 +21,8 @@ def matmul(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype="flo
             T.clear(C_local)
 
             X_shared = A_shared[:block_M, :block_K]
+            X_local = C_local[:block_M, :block_K]
+            T.clear(X_local)
 
             for ko in T.Pipelined(T.ceildiv(K, block_K), num_stages=0):
                 # Copy tile of A

--- a/testing/python/language/test_tilelang_language_clear.py
+++ b/testing/python/language/test_tilelang_language_clear.py
@@ -4,7 +4,6 @@
 import tilelang
 import tilelang.language as T
 
-tilelang.disable_cache()
 
 def matmul(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype="float"):
     # add decorator @tilelang.jit if you want to return a torch function
@@ -26,7 +25,7 @@ def matmul(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype="flo
                 # Copy tile of A
                 # This is a sugar syntax for parallelized copy
                 T.copy(A[by * block_M, ko * block_K], A_shared)
-                
+
                 T.clear(A_shared)
 
                 # Demonstrate parallelized copy from global to shared for B
@@ -44,7 +43,8 @@ def matmul(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype="flo
 
 def run_matmul(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype="float"):
     program = matmul(M, N, K, block_M, block_N, block_K, dtype, accum_dtype)
-    kernel = tilelang.compile(program, out_idx=[2], target="cuda", pass_configs={"tl.disable_tma_lower": True})
+    kernel = tilelang.compile(
+        program, out_idx=[2], target="cuda", pass_configs={"tl.disable_tma_lower": True})
     import torch
     from tilelang.utils import map_torch_type
     a = torch.randn((M, K), dtype=map_torch_type(dtype)).cuda()

--- a/testing/python/language/test_tilelang_language_clear.py
+++ b/testing/python/language/test_tilelang_language_clear.py
@@ -1,0 +1,61 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+
+import tilelang
+import tilelang.language as T
+
+tilelang.disable_cache()
+
+def matmul(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype="float"):
+    # add decorator @tilelang.jit if you want to return a torch function
+    @T.prim_func
+    def main(
+            A: T.Buffer((M, K), dtype),
+            B: T.Buffer((N, K), dtype),
+            C: T.Buffer((M, N), dtype),
+    ):
+        # Initialize Kernel Context
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), dtype)
+            B_shared = T.alloc_shared((block_N, block_K), dtype)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            T.clear(C_local)
+
+            for ko in T.Pipelined(T.ceildiv(K, block_K), num_stages=0):
+                # Copy tile of A
+                # This is a sugar syntax for parallelized copy
+                T.copy(A[by * block_M, ko * block_K], A_shared)
+                
+                T.clear(A_shared)
+
+                # Demonstrate parallelized copy from global to shared for B
+                T.copy(B[bx * block_N, ko * block_K], B_shared)
+
+                # Perform a tile-level GEMM on the shared buffers
+                # Currently we dispatch to the cute/hip on Nvidia/AMD GPUs
+                T.gemm(A_shared, B_shared, C_local, transpose_B=True)
+
+            # Copy result back to global memory
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def run_matmul(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype="float"):
+    program = matmul(M, N, K, block_M, block_N, block_K, dtype, accum_dtype)
+    kernel = tilelang.compile(program, out_idx=[2], target="cuda", pass_configs={"tl.disable_tma_lower": True})
+    import torch
+    from tilelang.utils import map_torch_type
+    a = torch.randn((M, K), dtype=map_torch_type(dtype)).cuda()
+    b = torch.randn((N, K), dtype=map_torch_type(dtype)).cuda()
+    c = kernel(a, b)
+    assert torch.allclose(c, torch.zeros_like(c))
+
+
+def test_matmul():
+    run_matmul(1024, 1024, 1024, 128, 128, 32)
+
+
+if __name__ == "__main__":
+    test_matmul()

--- a/tilelang/jit/adapter/wrapper.py
+++ b/tilelang/jit/adapter/wrapper.py
@@ -37,7 +37,7 @@ extern "C" int init() {{
 PREDEF_HOST_FUNC = """
 extern "C" int call({}) {{
 {}
-return 0;
+    return 0;
 }}
 """
 

--- a/tilelang/jit/adapter/wrapper.py
+++ b/tilelang/jit/adapter/wrapper.py
@@ -12,9 +12,9 @@ import logging
 import textwrap
 
 PREDEF_ARRTIBUTE_SET_DYNAMIC_MEMORY = """
-    cudaError_t result = cudaFuncSetAttribute({0}, cudaFuncAttributeMaxDynamicSharedMemorySize, {1});
-    if (result != CUDA_SUCCESS) {{
-        snprintf(error_buf, ERROR_BUF_SIZE, "Failed to set the allowed dynamic shared memory size to %d with error: %s", {1}, cudaGetErrorString(result));
+    cudaError_t result_{0} = cudaFuncSetAttribute({0}, cudaFuncAttributeMaxDynamicSharedMemorySize, {1});
+    if (result_{0} != CUDA_SUCCESS) {{
+        snprintf(error_buf, ERROR_BUF_SIZE, "Failed to set the allowed dynamic shared memory size to %d with error: %s", {1}, cudaGetErrorString(result_{0}));
         return -1;
     }}
 """

--- a/tilelang/language/fill.py
+++ b/tilelang/language/fill.py
@@ -6,6 +6,7 @@ from tvm import tir
 from typing import Union
 from tilelang.language import has_let_value, get_let_value
 
+
 def fill(buffer: Union[tir.Buffer, tir.BufferRegion], value: tir.PrimExpr):
     """Fill a buffer or buffer region with a specified value.
     

--- a/tilelang/language/fill.py
+++ b/tilelang/language/fill.py
@@ -3,12 +3,40 @@
 """The language interface for tl programs."""
 
 from tvm import tir
+from typing import Union
+from tilelang.language import has_let_value, get_let_value
 
-
-def fill(buffer: tir.Buffer, value: tir.PrimExpr):
-    buffer = buffer.access_ptr("w")
+def fill(buffer: Union[tir.Buffer, tir.BufferRegion], value: tir.PrimExpr):
+    """Fill a buffer or buffer region with a specified value.
+    
+    Args:
+        buffer: Either a TVM buffer or buffer region to be filled
+        value: The value to fill the buffer with
+    
+    Returns:
+        A TVM intrinsic call that performs the fill operation
+    """
+    if isinstance(buffer, tir.Buffer):
+        buffer = buffer.access_ptr("w")  # Get write pointer if input is a Buffer
     return tir.call_intrin("handle", tir.op.Op.get("tl.fill"), buffer, value)
 
 
-def clear(buffer: tir.Buffer):
+def clear(buffer: Union[tir.Buffer, tir.Var]):
+    """Clear a buffer by filling it with zeros.
+    
+    Args:
+        buffer: Either a TVM buffer or a variable that contains a buffer region
+    
+    Returns:
+        A fill operation that sets the buffer contents to zero
+        
+    Raises:
+        ValueError: If the buffer variable contains an invalid buffer region
+    """
+    if isinstance(buffer, tir.Var) and has_let_value(buffer):
+        buffer_region = get_let_value(buffer)  # Get the actual buffer region from variable
+        if isinstance(buffer_region, tir.BufferRegion):
+            return fill(buffer_region, 0)
+        else:
+            raise ValueError(f"Invalid buffer region: {buffer_region}")
     return fill(buffer, 0)

--- a/tilelang/utils/__init__.py
+++ b/tilelang/utils/__init__.py
@@ -3,7 +3,7 @@
 """The profiler and convert to torch utils"""
 
 from .target import determine_target  # noqa: F401
-from .tensor import TensorSupplyType, torch_assert_close  # noqa: F401
+from .tensor import TensorSupplyType, torch_assert_close, map_torch_type  # noqa: F401
 from .language import (
     is_global,  # noqa: F401
     is_shared,  # noqa: F401


### PR DESCRIPTION
Also a bug fix for issue #262 

This pull request includes several changes to enhance the handling of buffer regions, improve type annotations, and add new functionalities in the `fill` and `clear` functions. The most important changes are summarized below:

### Buffer Region Handling Enhancements:

* [`src/op/elem.cc`](diffhunk://#diff-b41ad92a37e3f104b615eb0ec61a1d7af1c21ef178a5acb708e3b7391450cfb2R361-R403): Added support for handling `BufferLoadNode` instances and performing bounds checks on buffer regions in the `Fill` function.
* [`src/op/elem.cc`](diffhunk://#diff-b41ad92a37e3f104b615eb0ec61a1d7af1c21ef178a5acb708e3b7391450cfb2L375-R412): Updated `MakeSIMTLoop` to use the `region` array for loop variable ranges instead of directly using buffer shapes.
* [`src/op/elem.h`](diffhunk://#diff-7b294229e1942294a4e7352608794f95e151ddd2a6de1b400defd5383a34d01aR62): Introduced a new `region` member in the `Fill` class to store buffer regions.

### Type Annotations and Function Enhancements:

* [`tilelang/language/fill.py`](diffhunk://#diff-0063cfc6b84a612f75f9870da8a264304b11e6782baac8d41c5b7250f13bbbd4R6-R42): Enhanced the `fill` function to accept both `tir.Buffer` and `tir.BufferRegion` types, and added detailed docstrings for better understanding.
* [`tilelang/language/fill.py`](diffhunk://#diff-0063cfc6b84a612f75f9870da8a264304b11e6782baac8d41c5b7250f13bbbd4R6-R42): Improved the `clear` function to handle `tir.Var` types that contain buffer regions, including error handling and detailed docstrings.

### Testing Enhancements:

* [`testing/python/language/test_tilelang_language_alias.py`](diffhunk://#diff-509ec67d6d492fb29d33f99d53d73dde46ae5481eda8320de645707e637d6e21R25-R26): Added a new local buffer `X_local` and cleared it in the test case to ensure proper functionality.