### PR TITLE
[Refactor] Update cache key generation in KernelCache

### DIFF
--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -53,7 +53,7 @@ class KernelCache:
         """
         Generates a unique cache key.
         """
-        func_binary = cloudpickle.dumps(func)
+        func_binary = cloudpickle.dumps(func.script())
         key_data = {
             "func": sha256(func_binary).hexdigest(),  # Use SHA256 to generate hash key
             "out_idx": tuple(out_idx) if isinstance(out_idx, (list, tuple)) else [out_idx],


### PR DESCRIPTION
- Changed the cache key generation to use the serialized script of the function instead of the function object itself, improving the uniqueness of cache keys.

Also a fix for issue #271 