### PR TITLE
[Feature] Introduce NoSetMaxNReg for warp specialization

### DIFF
--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -106,6 +106,11 @@ TIR_DEFINE_TL_BUILTIN(SetMaxNReg)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
+TIR_DEFINE_TL_BUILTIN(NoSetMaxNReg)
+    .set_num_inputs(0)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
 TIR_DEFINE_TL_BUILTIN(WaitWgmma).set_num_inputs(1).set_attr<TCallEffectKind>(
     "TCallEffectKind", Integer(CallEffectKind::kOpaque));
 

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -164,6 +164,14 @@ const Op &TMAStoreWait();
 const Op &SetMaxNReg();
 
 /*!
+ * \brief No set reg hint for warp-specialized branched
+ *
+ * NoSetMaxNReg()
+ *
+ */
+const Op &NoSetMaxNReg();
+
+/*!
  * \brief Wait the previous wgmma to finish
  *
  * WaitWgmma(num_mma)

--- a/tilelang/language/builtin.py
+++ b/tilelang/language/builtin.py
@@ -37,6 +37,10 @@ def SetMaxNReg(*args):
     return tir.call_intrin("handle", tir.op.Op.get("tl.SetMaxNReg"), *args)
 
 
+def NoSetMaxNReg(*args):
+    return tir.call_intrin("handle", tir.op.Op.get("tl.NoSetMaxNReg"), *args)
+
+
 def MBarrierWaitParity(*args):
     return tir.call_intrin("handle", tir.op.Op.get("tl.MBarrierWaitParity"), *args)
 


### PR DESCRIPTION
- Added NoSetMaxNReg as a new TIR built-in to indicate no register hint for warp-specialized branches.
- Updated the warp specialization rewriter to handle the new NoSetMaxNReg operation, allowing for improved register management.
- Enhanced the Python interface to include NoSetMaxNReg for consistency with TIR operations.