### PR TITLE
[Bugfix] Correct method call for block reduction check when analyzing memory footprint

### DIFF
--- a/tilelang/carver/roller/node.py
+++ b/tilelang/carver/roller/node.py
@@ -495,7 +495,7 @@ class PrimFuncNode(Node):
             for buffer in self.block_analyzer.get_input_buffers(block):
                 cache = buffer.name not in cached_tensor and (
                     is_broadcast_pattern(buffer, output_buffer) or
-                    self.block_analyzer.get_block_info(block).is_reduction)
+                    self.block_analyzer.get_block_info(block).is_reduction())
                 if not cache:
                     continue
                 cached_tensor.append(buffer.name)


### PR DESCRIPTION
The `is_reduction` method was not correctly invoked, resulting in the buffer cache eligibility check always passing, which may lead to unnecessary cache statistics.