### PR TITLE
[Bugfix] Replace profiler.mod with profiler.adapter to fix AttributeError

### DIFF
--- a/examples/elementwise/elementwise_add.py
+++ b/examples/elementwise/elementwise_add.py
@@ -44,5 +44,5 @@ if __name__ == "__main__":
     print("All checks pass.")
     latency = profiler.do_bench(ref_program, warmup=500)
     print("Ref: {:.2f} ms".format(latency))
-    latency = profiler.do_bench(profiler.mod, warmup=500)
+    latency = profiler.do_bench(profiler.adapter, warmup=500)
     print("Tile-lang: {:.2f} ms".format(latency))

--- a/examples/elementwise/elementwise_add.py
+++ b/examples/elementwise/elementwise_add.py
@@ -44,5 +44,5 @@ if __name__ == "__main__":
     print("All checks pass.")
     latency = profiler.do_bench(ref_program, warmup=500)
     print("Ref: {:.2f} ms".format(latency))
-    latency = profiler.do_bench(profiler.adapter, warmup=500)
+    latency = profiler.do_bench(warmup=500)
     print("Tile-lang: {:.2f} ms".format(latency))

--- a/examples/norm/rms_norm.py
+++ b/examples/norm/rms_norm.py
@@ -73,5 +73,5 @@ if __name__ == "__main__":
 
     latency = profiler.do_bench(ref_program, warmup=500)
     print("Ref: {:.2f} ms".format(latency))
-    latency = profiler.do_bench(profiler.mod, warmup=500)
+    latency = profiler.do_bench(profiler.adapter, warmup=500)
     print("Tile-lang: {:.2f} ms".format(latency))

--- a/examples/norm/rms_norm.py
+++ b/examples/norm/rms_norm.py
@@ -73,5 +73,5 @@ if __name__ == "__main__":
 
     latency = profiler.do_bench(ref_program, warmup=500)
     print("Ref: {:.2f} ms".format(latency))
-    latency = profiler.do_bench(profiler.adapter, warmup=500)
+    latency = profiler.do_bench(warmup=500)
     print("Tile-lang: {:.2f} ms".format(latency))


### PR DESCRIPTION
The use of profiler.mod in the example scripts elementwise_add.py and rms_norm.py causes an error when passed to profiler.do_bench(): `AttributeError: 'Profiler' object has no attribute 'mod'`

Replaced profiler.mod with profiler.adapter, which correctly references the backend module for benchmarking. This change resolves the error and allows the examples to run as expected.