### PR TITLE
[Bugfix] Fix layout conflict issue for gqa decoding examples

### DIFF
--- a/examples/flash_decoding/example_gqa_decode.py
+++ b/examples/flash_decoding/example_gqa_decode.py
@@ -209,8 +209,7 @@ def flashattn(batch, heads, groups, seqlen_kv, dim, tune=False):
                 scale_local = T.alloc_local([1], accum_dtype)
 
                 T.annotate_layout({
-                    lse_max_local:
-                        T.Fragment(lse_max_local.shape, forward_thread_fn=lambda i: i),
+                    lse_max_local: T.Fragment(lse_max_local.shape, forward_thread_fn=lambda i: i),
                 })
 
                 # T.clear(lse_logsum_local)
@@ -423,7 +422,7 @@ if __name__ == "__main__":
     total_flops = qk_flops + pv_flops
 
     if (not args.tune):
-        
+
         def get_heuristic_config() -> dict:
             # Get CUDA device properties
             if not torch.cuda.is_available():
@@ -434,7 +433,7 @@ if __name__ == "__main__":
             print(f"CUDA device capability: {sm_version}")
             if sm_version == 89:
                 return {
-                    "block_N": 128, 
+                    "block_N": 128,
                     "block_H": 64,
                     "num_split": 8,
                     "num_stages": 0,
@@ -442,15 +441,15 @@ if __name__ == "__main__":
                 }
             else:
                 return {
-                    "block_N": 128, 
+                    "block_N": 128,
                     "block_H": 64,
                     "num_split": 8,
                     "num_stages": 2,
                     "threads": 128
                 }
+
         config = get_heuristic_config()
-        program = flashattn(
-            batch, heads, groups, kv_seqlen, dim, tune=args.tune)(**config)
+        program = flashattn(batch, heads, groups, kv_seqlen, dim, tune=args.tune)(**config)
         kernel = tilelang.compile(program, out_idx=[6])
         profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Auto)
         profiler.assert_allclose(ref_program, rtol=0.01, atol=0.01)

--- a/examples/flash_decoding/example_gqa_decode.py
+++ b/examples/flash_decoding/example_gqa_decode.py
@@ -203,34 +203,30 @@ def flashattn(batch, heads, groups, seqlen_kv, dim, tune=False):
                 po_local = T.alloc_fragment([dim], dtype)
                 o_accum_local = T.alloc_fragment([dim], accum_dtype)
                 lse_local = T.alloc_fragment([num_split, 128], dtype)
-                lse_local_split = T.alloc_local([1], accum_dtype)
+                lse_local_split = T.alloc_var(accum_dtype)
                 lse_logsum_local = T.alloc_local([1], accum_dtype)
                 lse_max_local = T.alloc_fragment([128], accum_dtype)
                 scale_local = T.alloc_local([1], accum_dtype)
 
                 T.annotate_layout({
-                    lse_logsum_local:
-                        T.Fragment(lse_logsum_local.shape, forward_thread_fn=lambda i: i),
                     lse_max_local:
                         T.Fragment(lse_max_local.shape, forward_thread_fn=lambda i: i),
-                    lse_local:
-                        T.Fragment(lse_local.shape, forward_thread_fn=lambda i, j: j),
                 })
 
-                T.clear(lse_logsum_local)
+                # T.clear(lse_logsum_local)
                 T.clear(o_accum_local)
                 for k in T.Parallel(num_split):
                     lse_local[k, 0] = glse[bz, by, k]
                 T.reduce_max(lse_local, lse_max_local, dim=0, clear=True)
                 for k in T.Pipelined(num_split, num_stages=1):
-                    lse_local_split[0] = glse[bz, by, k]
-                    lse_logsum_local[0] += T.exp2(lse_local_split[0] - lse_max_local[0])
+                    lse_local_split = glse[bz, by, k]
+                    lse_logsum_local[0] += T.exp2(lse_local_split - lse_max_local[0])
                 lse_logsum_local[0] = T.log2(lse_logsum_local[0]) + lse_max_local[0]
                 for k in T.serial(num_split):
                     for i in T.Parallel(dim):
                         po_local[i] = Output_partial[bz, by, k, i]
-                    lse_local_split[0] = glse[bz, by, k]
-                    scale_local[0] = T.exp2(lse_local_split[0] - lse_logsum_local[0])
+                    lse_local_split = glse[bz, by, k]
+                    scale_local[0] = T.exp2(lse_local_split - lse_logsum_local[0])
                     for i in T.Parallel(dim):
                         o_accum_local[i] += po_local[i] * scale_local[0]
                 for i in T.Parallel(dim):
@@ -427,9 +423,34 @@ if __name__ == "__main__":
     total_flops = qk_flops + pv_flops
 
     if (not args.tune):
+        
+        def get_heuristic_config() -> dict:
+            # Get CUDA device properties
+            if not torch.cuda.is_available():
+                raise RuntimeError("CUDA is not available")
+            device = torch.cuda.current_device()
+            sm_major, sm_minor = torch.cuda.get_device_capability(device)
+            sm_version = sm_major * 10 + sm_minor
+            print(f"CUDA device capability: {sm_version}")
+            if sm_version == 89:
+                return {
+                    "block_N": 128, 
+                    "block_H": 64,
+                    "num_split": 8,
+                    "num_stages": 0,
+                    "threads": 128
+                }
+            else:
+                return {
+                    "block_N": 128, 
+                    "block_H": 64,
+                    "num_split": 8,
+                    "num_stages": 2,
+                    "threads": 128
+                }
+        config = get_heuristic_config()
         program = flashattn(
-            batch, heads, groups, kv_seqlen, dim, tune=args.tune)(
-                block_N=128, block_H=64, num_split=8, num_stages=2, threads=128)
+            batch, heads, groups, kv_seqlen, dim, tune=args.tune)(**config)
         kernel = tilelang.compile(program, out_idx=[6])
         profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Auto)
         profiler.assert_allclose(ref_program, rtol=0.01, atol=0.01)
@@ -437,7 +458,7 @@ if __name__ == "__main__":
         latency = profiler.do_bench(ref_program, warmup=500)
         print("Ref: {:.2f} ms".format(latency))
         print("Ref: {:.2f} TFlops".format(total_flops / latency * 1e-9))
-        latency = profiler.do_bench(kernel.rt_module, warmup=500, profiler="auto")
+        latency = profiler.do_bench(warmup=500)
         print("Tile-lang: {:.2f} ms".format(latency))
         print("Tile-lang: {:.2f} TFlops".format(total_flops / latency * 1e-9))
     else:

--- a/src/transform/loop_vectorize_dynamic.cc
+++ b/src/transform/loop_vectorize_dynamic.cc
@@ -343,7 +343,6 @@ class LoopVectorizerDynamic : public IRMutatorWithAnalyzer {
 public:
   static Stmt Substitute(Stmt stmt) {
     arith::Analyzer analyzer;
-    LOG(INFO) << "LoopVectorizerDynamic Substitute";
     LoopVectorizerDynamic substituter(&analyzer);
     stmt = substituter.VisitStmt(stmt);
     return stmt;


### PR DESCRIPTION
This pull request includes changes to improve the memory allocation and performance tuning in `examples/flash_decoding/example_gqa_decode.py`, as well as a minor cleanup in `src/transform/loop_vectorize_dynamic.cc`.

Memory allocation improvements:

* Changed `lse_local_split` to use `T.alloc_var` instead of `T.alloc_local` to improve memory allocation efficiency.
* Simplified the update of `lse_local_split` and `lse_logsum_local` to reduce redundant assignments.

Performance tuning:

* Added a new function `get_heuristic_config` to dynamically determine CUDA device properties and set configuration parameters accordingly. This change ensures optimal performance based on the device's capabilities.
* Updated the `flashattn` function call to use the configuration dictionary returned by `get_heuristic_config`.

Code cleanup:

* Removed an unnecessary logging statement in the `LoopVectorizerDynamic` class to clean up the code.