### PR TITLE
[Bugfix] Fixed the handling logic of IfThenElseNode in if_stmt_binding

### DIFF
--- a/src/transform/if_stmt_binding.cc
+++ b/src/transform/if_stmt_binding.cc
@@ -31,8 +31,11 @@ private:
 
   Stmt VisitStmt_(const IfThenElseNode *op) final {
     auto condition = op->condition;
-    auto then_case = op->then_case;
-    auto else_case = op->else_case;
+    auto then_case = VisitStmt(op->then_case);
+    Optional<Stmt> else_case = op->else_case;
+    if (else_case.defined()) {
+      else_case = VisitStmt(else_case.value());
+    }
 
     auto bind_if_stmt = [](Optional<Stmt> body,
                            const PrimExpr condition) -> Stmt {


### PR DESCRIPTION
This pull request includes a change to the `IfStmtBindingRewriter` class in the `src/transform/if_stmt_binding.cc` file. The change modifies how `then_case` and `else_case` are handled within the `VisitStmt_` method.

Handling of `then_case` and `else_case`:

* [`src/transform/if_stmt_binding.cc`](diffhunk://#diff-6600052496f40bdbba24c6390a66006fd2eef3b013e0fe7eee13aceead0f398bL34-R38): Updated the `VisitStmt_` method to use `VisitStmt` for `then_case` and conditionally apply `VisitStmt` to `else_case` if it is defined.