### PR TITLE
[Bugfix] Fix logic error in ReduceOp when handling CUDA architecture

### DIFF
--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -161,7 +161,9 @@ Stmt ReduceOp::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
         continue;
       int reducing_threads = (*extent) * (*scale);
       std::stringstream ss;
-      if (Downcast<String>(T.target->attrs["arch"]) == "sm_90") {
+
+      bool has_arch = T.target->attrs.count("arch") > 0;
+      if (has_arch && Downcast<String>(T.target->attrs["arch"]) == "sm_90") {
         ss << "tl::AllReduce<" << this->MakeCodegenReducer() << ", "
            << reducing_threads << ", " << (*scale) << ">::run_hopper";
       } else {

--- a/src/transform/if_stmt_binding.cc
+++ b/src/transform/if_stmt_binding.cc
@@ -31,8 +31,11 @@ private:
 
   Stmt VisitStmt_(const IfThenElseNode *op) final {
     auto condition = op->condition;
-    auto then_case = op->then_case;
-    auto else_case = op->else_case;
+    auto then_case = VisitStmt(op->then_case);
+    Optional<Stmt> else_case = op->else_case;
+    if (else_case.defined()) {
+      else_case = VisitStmt(else_case.value());
+    }
 
     auto bind_if_stmt = [](Optional<Stmt> body,
                            const PrimExpr condition) -> Stmt {


### PR DESCRIPTION
Improvements to target architecture handling:

* [`src/op/reduce.cc`](diffhunk://#diff-6db4f8a0f03dffeb4b8b493182b3754cc170d550bb6ea71ca472ced6320c8868L164-R166): Added a check to ensure the "arch" attribute is present before comparing it to "sm_90".