### PR TITLE
[Bugfix] add a patch to fix T.abs on float16

### DIFF
--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -27,7 +27,8 @@ using int4_t = int4;
 #define TL_DEVICE_NOINLINE __noinline__ __device__
 #define TL_PATCH
 
-// abs function for bfloat_t and half_t since there is no implicit convertion method
+// abs function for bfloat_t and half_t since there is no implicit convertion
+// method
 TL_PATCH TL_DEVICE half_t __habs(const half_t x) {
   return half_t(__habs(x.to_half()));
 }

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -25,6 +25,12 @@ using int4_t = int4;
 
 #define TL_DEVICE __forceinline__ __device__
 #define TL_DEVICE_NOINLINE __noinline__ __device__
+#define TL_PATCH
+
+// abs function for bfloat_t and half_t since there is no implicit convertion method
+TL_PATCH TL_DEVICE half_t __habs(const half_t x) {
+  return half_t(__habs(x.to_half()));
+}
 
 // Pack two half values.
 TL_DEVICE unsigned __pack_half2(const half x, const half y) {


### PR DESCRIPTION
# Description

Without the patch, calling `T.abs` on `cutlass:half_t` will trigger:

```
/tmp/tmpu264lyg1.cu(12): error: no instance of overloaded function "__habs" matches the argument list
            argument types are: (cutlass::half_t)
    val[0] = __habs(val[0]);

/usr/local/cuda-12.4/bin/../targets/x86_64-linux/include/cuda_bf16.hpp(3509): note #3326-D: function "__habs(__nv_bfloat16)" does not match because argument #1 does not match parameter
  static __attribute__((host)) __attribute__((device)) __inline__ __nv_bfloat16 __habs(const __nv_bfloat16 a)
                                                                                ^
/usr/local/cuda-12.4/bin/../targets/x86_64-linux/include/cuda_fp16.hpp(3252): note #3326-D: function "__habs(__half)" does not match because argument #1 does not match parameter
  static __attribute__((host)) __attribute__((device)) __inline__ __half __habs(const __half a)
```

as there is no (and cannot be) constructor defined for `cutlass:half_t` in `half` to do an implicit conversion.

# Solution

`cutlass:half_t` provided a conversion method `to_half` to do an explicit conversion and we can simply overload the function to bypass this.

# Reproduction

```python
import torch
import tilelang
import tilelang.language as T
from tilelang.utils.tensor import map_torch_type

tilelang.disable_cache()
dtype = "float16"

SIZE = 256
BLK_SIZE = 32

def test_kernel():
    @T.prim_func
    def kernel(
        X: T.Tensor((SIZE, SIZE), dtype),
        Y: T.Tensor((SIZE, SIZE), dtype),
    ):
        with T.Kernel(
            T.ceildiv(SIZE, BLK_SIZE),
            T.ceildiv(SIZE, BLK_SIZE),
            threads=(BLK_SIZE, BLK_SIZE),
        ) as (bi, bj):
            ti = T.get_thread_binding(0)
            tj = T.get_thread_binding(1)
            val = T.alloc_local((1, ), dtype)
            val[0] = X[bi * BLK_SIZE + ti, bj * BLK_SIZE + tj]
            val[0] = T.abs(val[0])
            Y[bi * BLK_SIZE + ti, bj * BLK_SIZE + tj] = val[0]
    return kernel



def main():
    X = torch.randn(SIZE, SIZE, device='cuda').to(map_torch_type(dtype))

    def ref_progam(x):
        return x.abs()

    kernel = test_kernel()
    kernel = tilelang.compile(kernel, out_idx=[-1])

    Y_ref = ref_progam(X)
    Y = kernel(X)

    torch.testing.assert_close(Y, Y_ref)


if __name__ == "__main__":
    main()
```