### PR TITLE
[AMD] Adapt rocm and support `T.gemm` with transpose_b=False for amd backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ column_limit = 100
 indent_width = 4
 
 [tool.codespell]
-ignore-words-list = "nd, te, ist, LOD, offen, NotIn"
+ignore-words-list = "nd, te, ist, LOD, offen, NotIn, HSA"
 skip = [
     "build",
     "3rdparty",
@@ -35,7 +35,6 @@ select = [
     "SIM",
     # isort
     # "I",
-    "HSA,
 ]
 ignore = [
     # Module level import not at top of file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ select = [
     "SIM",
     # isort
     # "I",
+    "HSA,
 ]
 ignore = [
     # Module level import not at top of file

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -256,8 +256,6 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
       ICHECK(0) << "WGMMA only support B in shared.";
     }
   } else if (TargetIsCDNA(T.target)) {
-    ICHECK(trans_B == true) << "Currently only support Transpose B for CDNA";
-
     const int warp_size = 64;
     auto [warp_m, warp_n] =
         ComputeWarpPartition(T.block_size / warp_size, T.target);

--- a/src/target/codegen_hip.cc
+++ b/src/target/codegen_hip.cc
@@ -112,6 +112,7 @@ std::string CodeGenTileLangHIP::Finish() {
   decl_stream << "#include <tl_templates/hip/reduce.h>\n";
   decl_stream << "#include <tl_templates/hip/ldsm.h>\n";
   decl_stream << "#include <tl_templates/hip/threadblock_swizzle.h>\n";
+  decl_stream << "#include <tl_templates/hip/debug.h>\n";
   decl_stream << "\n";
   return CodeGenC::Finish();
 }
@@ -505,11 +506,11 @@ void CodeGenTileLangHIP::PrintVecElemStore(const std::string &vec, DataType t,
       stream << "(" << value << " << " << i % 4 * 8 << ");\n";
     }
   } else if (t.is_float16()) {
-    stream << "((half2*)(&(" << vec << "." << access[i / 2] << ")))->"
-           << access[i % 2] << " = " << value << ";\n";
+    stream << "*((half_t*)(&(((half2*)(&(" << vec << "." << access[i / 2] << ")))->"
+           << access[i % 2] << "))) = " << value << ";\n";
   } else if (t.is_bfloat16()) {
-    stream << "((nv_bfloat162*)(&(" << vec << "." << access[i / 2] << ")))->"
-           << access[i % 2] << " = " << value << ";\n";
+    stream << "*((bfloat16_t*)(&((half2*)(&(" << vec << "." << access[i / 2] << ")))->"
+           << access[i % 2] << "))) = " << value << ";\n";
   } else if (t.lanes() > 4 && t.lanes() <= 8) {
     std::string type_name;
     if (t.bits() == 16) {

--- a/src/target/codegen_hip.cc
+++ b/src/target/codegen_hip.cc
@@ -506,11 +506,11 @@ void CodeGenTileLangHIP::PrintVecElemStore(const std::string &vec, DataType t,
       stream << "(" << value << " << " << i % 4 * 8 << ");\n";
     }
   } else if (t.is_float16()) {
-    stream << "*((half_t*)(&(((half2*)(&(" << vec << "." << access[i / 2] << ")))->"
-           << access[i % 2] << "))) = " << value << ";\n";
+    stream << "*((half_t*)(&(((half2*)(&(" << vec << "." << access[i / 2]
+           << ")))->" << access[i % 2] << "))) = " << value << ";\n";
   } else if (t.is_bfloat16()) {
-    stream << "*((bfloat16_t*)(&((half2*)(&(" << vec << "." << access[i / 2] << ")))->"
-           << access[i % 2] << "))) = " << value << ";\n";
+    stream << "*((bfloat16_t*)(&((half2*)(&(" << vec << "." << access[i / 2]
+           << ")))->" << access[i % 2] << "))) = " << value << ";\n";
   } else if (t.lanes() > 4 && t.lanes() <= 8) {
     std::string type_name;
     if (t.bits() == 16) {

--- a/src/target/rt_mod_hip.cc
+++ b/src/target/rt_mod_hip.cc
@@ -95,7 +95,8 @@ runtime::Module BuildTileLangHIPWithoutCompile(IRModule mod, Target target) {
   if (const auto *f = Registry::Get("tilelang_callback_hip_postproc")) {
     code = (*f)(code, target).operator std::string();
   }
-  return ROCMModuleCreate("ptx", "fmt", ExtractFuncInfo(mod), code, std::string());
+  return ROCMModuleCreate("ptx", "fmt", ExtractFuncInfo(mod), code,
+                          std::string());
 }
 TVM_REGISTER_GLOBAL("target.build.tilelang_hip")
     .set_body_typed(BuildTileLangHIP);

--- a/src/target/rt_mod_hip.cc
+++ b/src/target/rt_mod_hip.cc
@@ -76,7 +76,7 @@ runtime::Module BuildTileLangHIP(IRModule mod, Target target) {
   return ROCMModuleCreate(ptx, fmt, ExtractFuncInfo(mod), code, std::string());
 }
 
-String BuildTileLangHIPWithoutCompile(IRModule mod, Target target) {
+runtime::Module BuildTileLangHIPWithoutCompile(IRModule mod, Target target) {
   using tvm::runtime::Registry;
   bool output_ssa = false;
   CodeGenTileLangHIP cg;
@@ -95,7 +95,7 @@ String BuildTileLangHIPWithoutCompile(IRModule mod, Target target) {
   if (const auto *f = Registry::Get("tilelang_callback_hip_postproc")) {
     code = (*f)(code, target).operator std::string();
   }
-  return String(code);
+  return ROCMModuleCreate("ptx", "fmt", ExtractFuncInfo(mod), code, std::string());
 }
 TVM_REGISTER_GLOBAL("target.build.tilelang_hip")
     .set_body_typed(BuildTileLangHIP);

--- a/src/tl_templates/hip/common.h
+++ b/src/tl_templates/hip/common.h
@@ -4,10 +4,9 @@
 
 #include <ck_tile/core.hpp>
 #include <hip/hip_fp16.h>
+#include <hip/hip_bf16.h>
 #include <hip/hip_runtime.h>
 #include <rocwmma/rocwmma.hpp>
-
-using ck_tile::half_t;
 
 #define HIPRT_INF_F __int_as_float(0x7f800000)
 #define HIPRT_NEGINF_F __int_as_float(0xff800000)
@@ -35,7 +34,6 @@ using ck_tile::half_t;
 #define hsqrt __ocml_sqrt_f16
 
 using float16_t = _Float16;
-
 using float16x2 =
     __attribute__((__vector_size__(2 * sizeof(float16_t)))) float16_t;
 using float16x4 =
@@ -44,6 +42,26 @@ using float16x8 =
     __attribute__((__vector_size__(8 * sizeof(float16_t)))) float16_t;
 using float16x16 =
     __attribute__((__vector_size__(16 * sizeof(float16_t)))) float16_t;
+
+using half_t = float16_t;
+
+using bfloat16_t = __hip_bfloat16;
+
+struct bfloat16x2 {
+    bfloat16_t data[2];
+};
+
+struct bfloat16x4 {
+    bfloat16_t data[4];
+};
+
+struct bfloat16x8 {
+    bfloat16_t data[8];
+};
+
+struct bfloat16x16 {
+    bfloat16_t data[16];
+};
 
 using int32x4 = __attribute__((__vector_size__(4 * sizeof(int)))) int;
 using float32x4 = __attribute__((__vector_size__(4 * sizeof(float)))) float;

--- a/src/tl_templates/hip/common.h
+++ b/src/tl_templates/hip/common.h
@@ -3,8 +3,8 @@
 #pragma once
 
 #include <ck_tile/core.hpp>
-#include <hip/hip_fp16.h>
 #include <hip/hip_bf16.h>
+#include <hip/hip_fp16.h>
 #include <hip/hip_runtime.h>
 #include <rocwmma/rocwmma.hpp>
 
@@ -48,19 +48,19 @@ using half_t = float16_t;
 using bfloat16_t = __hip_bfloat16;
 
 struct bfloat16x2 {
-    bfloat16_t data[2];
+  bfloat16_t data[2];
 };
 
 struct bfloat16x4 {
-    bfloat16_t data[4];
+  bfloat16_t data[4];
 };
 
 struct bfloat16x8 {
-    bfloat16_t data[8];
+  bfloat16_t data[8];
 };
 
 struct bfloat16x16 {
-    bfloat16_t data[16];
+  bfloat16_t data[16];
 };
 
 using int32x4 = __attribute__((__vector_size__(4 * sizeof(int)))) int;

--- a/src/tl_templates/hip/debug.h
+++ b/src/tl_templates/hip/debug.h
@@ -4,200 +4,190 @@
 #include <hip/hip_runtime.h>
 
 // Base template declaration
-template <typename T>
-__device__ void debug_print_var(const char* msg, T var);
+template <typename T> __device__ void debug_print_var(const char *msg, T var);
 
 // Specialization for signed char type
 template <>
-__device__ void debug_print_var<signed char>(const char* msg, signed char var) {
-    const char* safe_msg = msg;
-    int value = static_cast<int>(var);
-    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=signed char value=%d\n",
-           safe_msg, 
-           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
-           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
-           value);
+__device__ void debug_print_var<signed char>(const char *msg, signed char var) {
+  const char *safe_msg = msg;
+  int value = static_cast<int>(var);
+  printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=signed "
+         "char value=%d\n",
+         safe_msg, (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+         (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z, value);
 }
 
 // Specialization for unsigned char type
 template <>
-__device__ void debug_print_var<unsigned char>(const char* msg, unsigned char var) {
-    const char* safe_msg = msg;
-    unsigned int value = static_cast<unsigned int>(var);
-    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=unsigned char value=%u\n",
-           safe_msg, 
-           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
-           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
-           value);
+__device__ void debug_print_var<unsigned char>(const char *msg,
+                                               unsigned char var) {
+  const char *safe_msg = msg;
+  unsigned int value = static_cast<unsigned int>(var);
+  printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): "
+         "dtype=unsigned char value=%u\n",
+         safe_msg, (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+         (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z, value);
 }
 
 // Specialization for int type
-template <>
-__device__ void debug_print_var<int>(const char* msg, int var) {
-    const char* safe_msg = msg;
-    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=int value=%d\n",
-           safe_msg, 
-           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
-           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
-           var);
+template <> __device__ void debug_print_var<int>(const char *msg, int var) {
+  const char *safe_msg = msg;
+  printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=int "
+         "value=%d\n",
+         safe_msg, (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+         (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z, var);
 }
 
 // Specialization for unsigned int type
 template <>
-__device__ void debug_print_var<unsigned int>(const char* msg, unsigned int var) {
-    const char* safe_msg = msg;
-    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=unsigned int value=%u\n",
-           safe_msg, 
-           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
-           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
-           var);
+__device__ void debug_print_var<unsigned int>(const char *msg,
+                                              unsigned int var) {
+  const char *safe_msg = msg;
+  printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): "
+         "dtype=unsigned int value=%u\n",
+         safe_msg, (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+         (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z, var);
 }
 
 // Specialization for float type
-template <>
-__device__ void debug_print_var<float>(const char* msg, float var) {
-    const char* safe_msg = msg;
-    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=float value=%f\n",
-           safe_msg, 
-           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
-           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
-           var);
+template <> __device__ void debug_print_var<float>(const char *msg, float var) {
+  const char *safe_msg = msg;
+  printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=float "
+         "value=%f\n",
+         safe_msg, (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+         (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z, var);
 }
 
 // Specialization for double type
 template <>
-__device__ void debug_print_var<double>(const char* msg, double var) {
-    const char* safe_msg = msg;
-    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=double value=%lf\n",
-           safe_msg, 
-           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
-           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
-           var);
+__device__ void debug_print_var<double>(const char *msg, double var) {
+  const char *safe_msg = msg;
+  printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=double "
+         "value=%lf\n",
+         safe_msg, (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+         (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z, var);
 }
 
 // Specialization for bool type
-template <>
-__device__ void debug_print_var<bool>(const char* msg, bool var) {
-    const char* safe_msg = msg;
-    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=bool value=%s\n",
-           safe_msg, 
-           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
-           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
-           var ? "true" : "false");
+template <> __device__ void debug_print_var<bool>(const char *msg, bool var) {
+  const char *safe_msg = msg;
+  printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=bool "
+         "value=%s\n",
+         safe_msg, (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+         (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
+         var ? "true" : "false");
 }
 
 // Specialization for short type
-template <>
-__device__ void debug_print_var<short>(const char* msg, short var) {
-    const char* safe_msg = msg;
-    int value = static_cast<int>(var);
-    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=short value=%d\n",
-           safe_msg, 
-           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
-           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
-           value);
+template <> __device__ void debug_print_var<short>(const char *msg, short var) {
+  const char *safe_msg = msg;
+  int value = static_cast<int>(var);
+  printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=short "
+         "value=%d\n",
+         safe_msg, (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+         (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z, value);
 }
 
 // Specialization for unsigned short type
 template <>
-__device__ void debug_print_var<unsigned short>(const char* msg, unsigned short var) {
-    const char* safe_msg = msg;
-    unsigned int value = static_cast<unsigned int>(var);
-    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=unsigned short value=%u\n",
-           safe_msg, 
-           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
-           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
-           value);
+__device__ void debug_print_var<unsigned short>(const char *msg,
+                                                unsigned short var) {
+  const char *safe_msg = msg;
+  unsigned int value = static_cast<unsigned int>(var);
+  printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): "
+         "dtype=unsigned short value=%u\n",
+         safe_msg, (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+         (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z, value);
 }
 
 // Template declaration for device-side debug printing (buffer only)
 template <typename T>
-__device__ void debug_print_buffer_value(const char* msg, const char* buf_name,
-                                       int index, T var);
+__device__ void debug_print_buffer_value(const char *msg, const char *buf_name,
+                                         int index, T var);
 
 // Specialization for signed char type
 template <>
-__device__ void debug_print_buffer_value<signed char>(const char* msg, const char* buf_name,
-                                                     int index, signed char var) {
-    const char* safe_msg = msg;
-    const char* safe_buf_name = buf_name;
-    int value = static_cast<int>(var);
-    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
-           "index=%d, dtype=signed char value=%d\n",
-           safe_msg, 
-           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
-           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
-           safe_buf_name, index, value);
+__device__ void
+debug_print_buffer_value<signed char>(const char *msg, const char *buf_name,
+                                      int index, signed char var) {
+  const char *safe_msg = msg;
+  const char *safe_buf_name = buf_name;
+  int value = static_cast<int>(var);
+  printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
+         "index=%d, dtype=signed char value=%d\n",
+         safe_msg, (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+         (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z, safe_buf_name,
+         index, value);
 }
 
 // Specialization for unsigned char type
 template <>
-__device__ void debug_print_buffer_value<unsigned char>(const char* msg, const char* buf_name,
-                                                       int index, unsigned char var) {
-    const char* safe_msg = msg;
-    const char* safe_buf_name = buf_name;
-    unsigned int value = static_cast<unsigned int>(var);
-    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
-           "index=%d, dtype=unsigned char value=%u\n",
-           safe_msg, 
-           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
-           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
-           safe_buf_name, index, value);
+__device__ void
+debug_print_buffer_value<unsigned char>(const char *msg, const char *buf_name,
+                                        int index, unsigned char var) {
+  const char *safe_msg = msg;
+  const char *safe_buf_name = buf_name;
+  unsigned int value = static_cast<unsigned int>(var);
+  printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
+         "index=%d, dtype=unsigned char value=%u\n",
+         safe_msg, (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+         (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z, safe_buf_name,
+         index, value);
 }
 
 // Specialization for integer type
 template <>
-__device__ void debug_print_buffer_value<int>(const char* msg, const char* buf_name,
-                                             int index, int var) {
-    const char* safe_msg = msg;
-    const char* safe_buf_name = buf_name;
-    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
-           "index=%d, dtype=int value=%d\n",
-           safe_msg, 
-           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
-           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
-           safe_buf_name, index, var);
+__device__ void debug_print_buffer_value<int>(const char *msg,
+                                              const char *buf_name, int index,
+                                              int var) {
+  const char *safe_msg = msg;
+  const char *safe_buf_name = buf_name;
+  printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
+         "index=%d, dtype=int value=%d\n",
+         safe_msg, (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+         (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z, safe_buf_name,
+         index, var);
 }
 
 // Specialization for float type
 template <>
-__device__ void debug_print_buffer_value<float>(const char* msg, const char* buf_name,
-                                               int index, float var) {
-    const char* safe_msg = msg;
-    const char* safe_buf_name = buf_name;
-    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
-           "index=%d, dtype=float value=%f\n",
-           safe_msg, 
-           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
-           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
-           safe_buf_name, index, var);
+__device__ void debug_print_buffer_value<float>(const char *msg,
+                                                const char *buf_name, int index,
+                                                float var) {
+  const char *safe_msg = msg;
+  const char *safe_buf_name = buf_name;
+  printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
+         "index=%d, dtype=float value=%f\n",
+         safe_msg, (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+         (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z, safe_buf_name,
+         index, var);
 }
 
 // Specialization for half_t type
 template <>
-__device__ void debug_print_buffer_value<half_t>(const char* msg, const char* buf_name,
-                                                int index, half_t var) {
-    const char* safe_msg = msg;
-    const char* safe_buf_name = buf_name;
-    float value = static_cast<float>(var);
-    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
-           "index=%d, dtype=half_t value=%f\n",
-           safe_msg, 
-           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
-           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
-           safe_buf_name, index, value);
+__device__ void debug_print_buffer_value<half_t>(const char *msg,
+                                                 const char *buf_name,
+                                                 int index, half_t var) {
+  const char *safe_msg = msg;
+  const char *safe_buf_name = buf_name;
+  float value = static_cast<float>(var);
+  printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
+         "index=%d, dtype=half_t value=%f\n",
+         safe_msg, (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+         (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z, safe_buf_name,
+         index, value);
 }
 
 // Specialization for double type
 template <>
-__device__ void debug_print_buffer_value<double>(const char* msg, const char* buf_name,
-                                                int index, double var) {
-    const char* safe_msg = msg;
-    const char* safe_buf_name = buf_name;
-    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
-           "index=%d, dtype=double value=%lf\n",
-           safe_msg, 
-           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
-           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
-           safe_buf_name, index, var);
+__device__ void debug_print_buffer_value<double>(const char *msg,
+                                                 const char *buf_name,
+                                                 int index, double var) {
+  const char *safe_msg = msg;
+  const char *safe_buf_name = buf_name;
+  printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
+         "index=%d, dtype=double value=%lf\n",
+         safe_msg, (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+         (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z, safe_buf_name,
+         index, var);
 }

--- a/src/tl_templates/hip/debug.h
+++ b/src/tl_templates/hip/debug.h
@@ -1,0 +1,203 @@
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
+#pragma once
+#include <hip/hip_runtime.h>
+
+// Base template declaration
+template <typename T>
+__device__ void debug_print_var(const char* msg, T var);
+
+// Specialization for signed char type
+template <>
+__device__ void debug_print_var<signed char>(const char* msg, signed char var) {
+    const char* safe_msg = msg;
+    int value = static_cast<int>(var);
+    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=signed char value=%d\n",
+           safe_msg, 
+           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
+           value);
+}
+
+// Specialization for unsigned char type
+template <>
+__device__ void debug_print_var<unsigned char>(const char* msg, unsigned char var) {
+    const char* safe_msg = msg;
+    unsigned int value = static_cast<unsigned int>(var);
+    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=unsigned char value=%u\n",
+           safe_msg, 
+           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
+           value);
+}
+
+// Specialization for int type
+template <>
+__device__ void debug_print_var<int>(const char* msg, int var) {
+    const char* safe_msg = msg;
+    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=int value=%d\n",
+           safe_msg, 
+           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
+           var);
+}
+
+// Specialization for unsigned int type
+template <>
+__device__ void debug_print_var<unsigned int>(const char* msg, unsigned int var) {
+    const char* safe_msg = msg;
+    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=unsigned int value=%u\n",
+           safe_msg, 
+           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
+           var);
+}
+
+// Specialization for float type
+template <>
+__device__ void debug_print_var<float>(const char* msg, float var) {
+    const char* safe_msg = msg;
+    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=float value=%f\n",
+           safe_msg, 
+           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
+           var);
+}
+
+// Specialization for double type
+template <>
+__device__ void debug_print_var<double>(const char* msg, double var) {
+    const char* safe_msg = msg;
+    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=double value=%lf\n",
+           safe_msg, 
+           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
+           var);
+}
+
+// Specialization for bool type
+template <>
+__device__ void debug_print_var<bool>(const char* msg, bool var) {
+    const char* safe_msg = msg;
+    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=bool value=%s\n",
+           safe_msg, 
+           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
+           var ? "true" : "false");
+}
+
+// Specialization for short type
+template <>
+__device__ void debug_print_var<short>(const char* msg, short var) {
+    const char* safe_msg = msg;
+    int value = static_cast<int>(var);
+    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=short value=%d\n",
+           safe_msg, 
+           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
+           value);
+}
+
+// Specialization for unsigned short type
+template <>
+__device__ void debug_print_var<unsigned short>(const char* msg, unsigned short var) {
+    const char* safe_msg = msg;
+    unsigned int value = static_cast<unsigned int>(var);
+    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): dtype=unsigned short value=%u\n",
+           safe_msg, 
+           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
+           value);
+}
+
+// Template declaration for device-side debug printing (buffer only)
+template <typename T>
+__device__ void debug_print_buffer_value(const char* msg, const char* buf_name,
+                                       int index, T var);
+
+// Specialization for signed char type
+template <>
+__device__ void debug_print_buffer_value<signed char>(const char* msg, const char* buf_name,
+                                                     int index, signed char var) {
+    const char* safe_msg = msg;
+    const char* safe_buf_name = buf_name;
+    int value = static_cast<int>(var);
+    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
+           "index=%d, dtype=signed char value=%d\n",
+           safe_msg, 
+           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
+           safe_buf_name, index, value);
+}
+
+// Specialization for unsigned char type
+template <>
+__device__ void debug_print_buffer_value<unsigned char>(const char* msg, const char* buf_name,
+                                                       int index, unsigned char var) {
+    const char* safe_msg = msg;
+    const char* safe_buf_name = buf_name;
+    unsigned int value = static_cast<unsigned int>(var);
+    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
+           "index=%d, dtype=unsigned char value=%u\n",
+           safe_msg, 
+           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
+           safe_buf_name, index, value);
+}
+
+// Specialization for integer type
+template <>
+__device__ void debug_print_buffer_value<int>(const char* msg, const char* buf_name,
+                                             int index, int var) {
+    const char* safe_msg = msg;
+    const char* safe_buf_name = buf_name;
+    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
+           "index=%d, dtype=int value=%d\n",
+           safe_msg, 
+           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
+           safe_buf_name, index, var);
+}
+
+// Specialization for float type
+template <>
+__device__ void debug_print_buffer_value<float>(const char* msg, const char* buf_name,
+                                               int index, float var) {
+    const char* safe_msg = msg;
+    const char* safe_buf_name = buf_name;
+    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
+           "index=%d, dtype=float value=%f\n",
+           safe_msg, 
+           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
+           safe_buf_name, index, var);
+}
+
+// Specialization for half_t type
+template <>
+__device__ void debug_print_buffer_value<half_t>(const char* msg, const char* buf_name,
+                                                int index, half_t var) {
+    const char* safe_msg = msg;
+    const char* safe_buf_name = buf_name;
+    float value = static_cast<float>(var);
+    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
+           "index=%d, dtype=half_t value=%f\n",
+           safe_msg, 
+           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
+           safe_buf_name, index, value);
+}
+
+// Specialization for double type
+template <>
+__device__ void debug_print_buffer_value<double>(const char* msg, const char* buf_name,
+                                                int index, double var) {
+    const char* safe_msg = msg;
+    const char* safe_buf_name = buf_name;
+    printf("msg='%s' BlockIdx=(%d, %d, %d), ThreadIdx=(%d, %d, %d): buffer=%s, "
+           "index=%d, dtype=double value=%lf\n",
+           safe_msg, 
+           (int)blockIdx.x, (int)blockIdx.y, (int)blockIdx.z,
+           (int)threadIdx.x, (int)threadIdx.y, (int)threadIdx.z,
+           safe_buf_name, index, var);
+}

--- a/src/tl_templates/hip/gemm.h
+++ b/src/tl_templates/hip/gemm.h
@@ -244,9 +244,9 @@ template <int M, int N, int K, int num_warp_m, int num_warp_n, bool trans_A,
           bool trans_B, bool clear_accum, int kPack, typename A_type,
           typename B_type, typename C_type>
 TL_DEVICE void gemm_ss(A_type *pA, B_type *pB, C_type *accum) {
-  using Compute = GemmTensorOp<M, N, K, num_warp_m, num_warp_n, trans_A,
-                               trans_B, clear_accum, kPack, A_type, B_type,
-                               C_type>;
+  using Compute =
+      GemmTensorOp<M, N, K, num_warp_m, num_warp_n, trans_A, trans_B,
+                   clear_accum, kPack, A_type, B_type, C_type>;
   Compute::body(pA, pB, accum);
 }
 
@@ -254,9 +254,9 @@ template <int M, int N, int K, int num_warp_m, int num_warp_n, bool trans_A,
           bool trans_B, bool clear_accum, int kPack, typename A_type,
           typename B_type, typename C_type>
 TL_DEVICE void gemm_rs(A_type *pA, B_type *pB, C_type *accum) {
-  using Compute = GemmTensorOp<M, N, K, num_warp_m, num_warp_n, trans_A,
-                               trans_B, clear_accum, kPack, A_type, B_type,
-                               C_type>;
+  using Compute =
+      GemmTensorOp<M, N, K, num_warp_m, num_warp_n, trans_A, trans_B,
+                   clear_accum, kPack, A_type, B_type, C_type>;
   Compute::body_rs(pA, pB, accum);
 }
 

--- a/src/tl_templates/hip/gemm.h
+++ b/src/tl_templates/hip/gemm.h
@@ -8,10 +8,12 @@ namespace tl {
 
 // ref to bitblas/tl/mfma_macro_generator.py::kPack
 template <int M, int N, int K, int num_warp_m, int num_warp_n, bool TransposeA,
-          bool TransposeB, int kPack, typename A_type, typename B_type,
-          typename C_type, typename AccDataType = float>
+          bool TransposeB, bool clear_accum, int kPack, typename A_type,
+          typename B_type, typename C_type, typename AccDataType = float>
 class GemmTensorOp {
 public:
+  static_assert(!clear_accum, "clear_accum=true is not supported yet");
+
   static constexpr int micro_size_x = 16;
   static constexpr int micro_size_y = 16;
   static constexpr int micro_size_k = 16;
@@ -130,25 +132,37 @@ public:
         const auto l = warp_m * warp_row_tiles + i * micro_size_x;
         const auto r = ki * (kPack * micro_size_k);
         for (int local_id = 0; local_id < (kPack * local_size_a); local_id++) {
-          auto [row, col] = reverse_index_map(lane_id, local_id);
-          A_local[i * kPack * local_size_a + local_id] =
-              A_shared[make_swizzle_layout<last_dim_a, sizeof(A_type)>(
-                  l + row, r + col)];
+          if constexpr (TransposeA) {
+            auto [row, col] = reverse_index_map_transposed(lane_id, local_id);
+            A_local[i * kPack * local_size_a + local_id] =
+                A_shared[make_swizzle_layout<last_dim_a, sizeof(A_type)>(
+                    l + col, r + row)];
+          } else {
+            auto [row, col] = reverse_index_map(lane_id, local_id);
+            A_local[i * kPack * local_size_a + local_id] =
+                A_shared[make_swizzle_layout<last_dim_a, sizeof(A_type)>(
+                    l + row, r + col)];
+          }
         }
       }
-
       // Fetch B into register
       for (int j = 0; j < warp_cols; j++) {
         const auto l = warp_n * warp_col_tiles + j * micro_size_y;
         const auto r = ki * (kPack * micro_size_k);
         for (int local_id = 0; local_id < (kPack * local_size_b); local_id++) {
-          auto [row, col] = reverse_index_map(lane_id, local_id);
-          B_local[j * kPack * local_size_b + local_id] =
-              B_shared[make_swizzle_layout<last_dim_b, sizeof(B_type)>(
-                  l + row, r + col)];
+          if constexpr (TransposeB) {
+            auto [row, col] = reverse_index_map(lane_id, local_id);
+            B_local[j * kPack * local_size_b + local_id] =
+                B_shared[make_swizzle_layout<last_dim_b, sizeof(B_type)>(
+                    l + row, r + col)];
+          } else {
+            auto [row, col] = reverse_index_map_transposed(lane_id, local_id);
+            B_local[j * kPack * local_size_b + local_id] =
+                B_shared[make_swizzle_layout<last_dim_b, sizeof(B_type)>(
+                    r + row, l + col)];
+          }
         }
       }
-
       // Compute
       for (int kp = 0; kp < kPack; kp++) {
         for (int i = 0; i < warp_rows; ++i) {
@@ -191,10 +205,17 @@ public:
         const auto l = warp_n * warp_col_tiles + j * micro_size_y;
         const auto r = ki * kPack * micro_size_k;
         for (int local_id = 0; local_id < kPack * local_size_b; local_id++) {
-          auto [row, col] = reverse_index_map(lane_id, local_id);
-          B_local[j * local_size_b + local_id] =
-              B_shared[make_swizzle_layout<last_dim_b, sizeof(B_type)>(
-                  l + row, r + col)];
+          if constexpr (TransposeB) {
+            auto [row, col] = reverse_index_map(lane_id, local_id);
+            B_local[j * local_size_b + local_id] =
+                B_shared[make_swizzle_layout<last_dim_b, sizeof(B_type)>(
+                    l + row, r + col)];
+          } else {
+            auto [row, col] = reverse_index_map_transposed(lane_id, local_id);
+            B_local[j * local_size_b + local_id] =
+                B_shared[make_swizzle_layout<last_dim_b, sizeof(B_type)>(
+                    r + row, l + col)];
+          }
         }
       }
 
@@ -220,20 +241,22 @@ public:
 namespace tl {
 
 template <int M, int N, int K, int num_warp_m, int num_warp_n, bool trans_A,
-          bool trans_B, int kPack, typename A_type, typename B_type,
-          typename C_type>
+          bool trans_B, bool clear_accum, int kPack, typename A_type,
+          typename B_type, typename C_type>
 TL_DEVICE void gemm_ss(A_type *pA, B_type *pB, C_type *accum) {
   using Compute = GemmTensorOp<M, N, K, num_warp_m, num_warp_n, trans_A,
-                               trans_B, kPack, A_type, B_type, C_type>;
+                               trans_B, clear_accum, kPack, A_type, B_type,
+                               C_type>;
   Compute::body(pA, pB, accum);
 }
 
 template <int M, int N, int K, int num_warp_m, int num_warp_n, bool trans_A,
-          bool trans_B, int kPack, typename A_type, typename B_type,
-          typename C_type>
+          bool trans_B, bool clear_accum, int kPack, typename A_type,
+          typename B_type, typename C_type>
 TL_DEVICE void gemm_rs(A_type *pA, B_type *pB, C_type *accum) {
   using Compute = GemmTensorOp<M, N, K, num_warp_m, num_warp_n, trans_A,
-                               trans_B, kPack, A_type, B_type, C_type>;
+                               trans_B, clear_accum, kPack, A_type, B_type,
+                               C_type>;
   Compute::body_rs(pA, pB, accum);
 }
 

--- a/testing/python/amd/test_tilelang_test_amd.py
+++ b/testing/python/amd/test_tilelang_test_amd.py
@@ -64,7 +64,7 @@ def run_gemm(
     block_M,
     block_N,
     block_K,
-    num_stages=3,
+    num_stages=0,
     num_threads=128,
     k_pack=1,
 ):
@@ -94,15 +94,14 @@ def run_gemm(
             A = A.T
         if trans_B:
             B = B.T
-        C = torch.matmul(A.to(torch.float), B.to(torch.float))
-        C = C.to(torch.__getattribute__(out_dtype))
-        return C
+        return (A @ B).to(torch.__getattribute__(out_dtype))
 
     profiler.assert_allclose(ref_program, atol=1e-2, rtol=1e-2)
 
 
 @tilelang.testing.requires_rocm
 def test_gemm_f16f32f32_nt():
+    run_gemm(1024, 1024, 1024, False, False, "float16", "float32", "float32", 128, 128, 32)
     run_gemm(1024, 1024, 1024, False, True, "float16", "float32", "float32", 128, 128, 32)
     run_gemm(1024, 1024, 1024, False, True, "float16", "float32", "float32", 128, 128, 32, k_pack=2)
 

--- a/tilelang/__init__.py
+++ b/tilelang/__init__.py
@@ -100,7 +100,7 @@ from . import (
     engine,  # noqa: F401
 )
 
-from .engine import lower  # noqa: F401
+from .engine import lower, register_cuda_postproc, register_hip_postproc  # noqa: F401
 
 from .version import __version__  # noqa: F401
 

--- a/tilelang/contrib/rocm.py
+++ b/tilelang/contrib/rocm.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 """Utility for ROCm backend"""
+# ruff: noqa
 import re
 import subprocess
 import os

--- a/tilelang/contrib/rocm.py
+++ b/tilelang/contrib/rocm.py
@@ -1,0 +1,284 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Utility for ROCm backend"""
+import re
+import subprocess
+import os
+from os.path import join, exists
+
+import tvm._ffi
+from tvm._ffi.base import py_str
+import tvm.runtime
+import tvm.target
+
+from tvm.contrib import utils
+
+
+def find_lld(required=True):
+    """Find ld.lld in system.
+
+    Parameters
+    ----------
+    required : bool
+        Whether it is required,
+        runtime error will be raised if the compiler is required.
+
+    Returns
+    -------
+    valid_list : list of str
+        List of possible paths.
+
+    Note
+    ----
+    This function will first search ld.lld that
+    matches the major llvm version that built with tvm
+    """
+    lld_list = []
+    major = tvm.target.codegen.llvm_version_major(allow_none=True)
+    if major is not None:
+        lld_list += [f"ld.lld-{major}.0"]
+        lld_list += [f"ld.lld-{major}"]
+    lld_list += ["ld.lld"]
+    lld_list += [f"/opt/rocm/llvm/bin/{x}" for x in lld_list]
+    valid_list = [utils.which(x) for x in lld_list]
+    valid_list = [x for x in valid_list if x]
+    if not valid_list and required:
+        raise RuntimeError("cannot find ld.lld, candidates are: " + str(lld_list))
+    return valid_list
+
+
+def rocm_link(in_file, out_file, lld=None):
+    """Link relocatable ELF object to shared ELF object using lld
+
+    Parameters
+    ----------
+    in_file : str
+        Input file name (relocatable ELF object file)
+
+    out_file : str
+        Output file name (shared ELF object file)
+
+    lld : str, optional
+        The lld linker, if not specified,
+        we will try to guess the matched clang version.
+    """
+
+    # if our result has undefined symbols, it will fail to load
+    # (hipModuleLoad/hipModuleLoadData), but with a somewhat opaque message
+    # so we have ld.lld check this here.
+    # If you get a complaint about missing symbols you might want to check the
+    # list of bitcode files below.
+    args = [
+        lld if lld is not None else find_lld()[0],
+        "--no-undefined",
+        "-shared",
+        in_file,
+        "-o",
+        out_file,
+    ]
+    proc = subprocess.Popen(args, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    (out, _) = proc.communicate()
+
+    if proc.returncode != 0:
+        msg = "Linking error using ld.lld:\n"
+        msg += py_str(out)
+        raise RuntimeError(msg)
+
+
+@tvm._ffi.register_func("tvm_callback_rocm_link", override=True)
+def callback_rocm_link(obj_bin):
+    """Links object file generated from LLVM to HSA Code Object
+
+    Parameters
+    ----------
+    obj_bin : bytearray
+        The object file
+
+    Return
+    ------
+    cobj_bin : bytearray
+        The HSA Code Object
+    """
+    tmp_dir = utils.tempdir()
+    tmp_obj = tmp_dir.relpath("rocm_kernel.o")
+    tmp_cobj = tmp_dir.relpath("rocm_kernel.co")
+    with open(tmp_obj, "wb") as out_file:
+        out_file.write(bytes(obj_bin))
+    rocm_link(tmp_obj, tmp_cobj)
+    cobj_bin = bytearray(open(tmp_cobj, "rb").read())
+    return cobj_bin
+
+
+@tvm._ffi.register_func("tvm_callback_rocm_bitcode_path", override=True)
+def callback_rocm_bitcode_path(rocdl_dir=None):
+    """Utility function to find ROCm device library bitcodes
+
+    Parameters
+    ----------
+    rocdl_dir : str
+        The path to rocm library directory
+        The default value is the standard location
+    """
+    # seems link order matters.
+
+    if rocdl_dir is None:
+        if exists("/opt/rocm/amdgcn/bitcode/"):
+            rocdl_dir = "/opt/rocm/amdgcn/bitcode/"  # starting with rocm 3.9
+        else:
+            rocdl_dir = "/opt/rocm/lib/"  # until rocm 3.8
+
+    bitcode_names = [
+        "oclc_daz_opt_on",
+        "ocml",
+        "irif",  # this does not exist in rocm 3.9, drop eventually
+        "oclc_correctly_rounded_sqrt_off",
+        "oclc_correctly_rounded_sqrt_on",
+        "oclc_daz_opt_off",
+        "oclc_finite_only_off",
+        "oclc_finite_only_on",
+        # todo (t-vi): an alternative might be to scan for the
+        "oclc_isa_version_803",
+        "oclc_isa_version_900",  # isa version files (if the linker throws out
+        "oclc_isa_version_906",  # the unneeded ones or we filter for the arch we need)
+        "oclc_isa_version_1030",
+        "oclc_unsafe_math_off",
+        "oclc_unsafe_math_on",
+        "oclc_wavefrontsize64_on",
+        "oclc_abi_version_500",
+    ]
+
+    bitcode_files = []
+    for n in bitcode_names:
+        p = join(rocdl_dir, n + ".bc")  # rocm >= 3.9
+        if not exists(p):  # rocm <= 3.8
+            p = join(rocdl_dir, n + ".amdgcn.bc")
+        if exists(p):
+            bitcode_files.append(p)
+        elif "isa_version" not in n and n not in {"irif"}:
+            raise RuntimeError("could not find bitcode " + n)
+
+    return tvm.runtime.convert(bitcode_files)
+
+
+def parse_compute_version(compute_version):
+    """Parse compute capability string to divide major and minor version
+
+    Parameters
+    ----------
+    compute_version : str
+        compute capability of a GPU (e.g. "6.0")
+
+    Returns
+    -------
+    major : int
+        major version number
+    minor : int
+        minor version number
+    """
+    split_ver = compute_version.split(".")
+    try:
+        major = int(split_ver[0])
+        minor = int(split_ver[1])
+        return major, minor
+    except (IndexError, ValueError) as err:
+        # pylint: disable=raise-missing-from
+        raise RuntimeError("Compute version parsing error: " + str(err))
+
+
+def have_matrixcore(compute_version=None):
+    """Either MatrixCore support is provided in the compute capability or not
+
+    Parameters
+    ----------
+    compute_version : str, optional
+        compute capability of a GPU (e.g. "7.0").
+
+    Returns
+    -------
+    have_matrixcore : bool
+        True if MatrixCore support is provided, False otherwise
+    """
+    if compute_version is None:
+        if tvm.rocm(0).exist:
+            compute_version = tvm.rocm(0).compute_version
+        else:
+            raise RuntimeError("No ROCm runtime found")
+    major, _ = parse_compute_version(compute_version)
+    # matrix core first introduced in 8.0
+    if major >= 8:
+        return True
+
+    return False
+
+
+@tvm._ffi.register_func("tvm_callback_rocm_get_arch", override=True)
+def get_rocm_arch(rocm_path="/opt/rocm"):
+    """Utility function to get the AMD GPU architecture
+
+    Parameters
+    ----------
+    rocm_path : str
+        The path to rocm installation directory
+
+    Returns
+    -------
+    gpu_arch : str
+        The AMD GPU architecture
+    """
+    gpu_arch = "gfx900"
+    # check if rocm is installed
+    if not os.path.exists(rocm_path):
+        print("ROCm not detected, using default gfx900")
+        return gpu_arch
+    try:
+        # Execute rocminfo command
+        rocminfo_output = subprocess.check_output([f"{rocm_path}/bin/rocminfo"]).decode("utf-8")
+
+        # Use regex to match the "Name" field
+        match = re.search(r"Name:\s+(gfx\d+[a-zA-Z]*)", rocminfo_output)
+        if match:
+            gpu_arch = match.group(1)
+        return gpu_arch
+    except subprocess.CalledProcessError:
+        print(
+            f"Unable to execute rocminfo command, \
+                please ensure ROCm is installed and you have an AMD GPU on your system.\
+                    using default {gpu_arch}."
+        )
+        return gpu_arch
+
+
+def find_rocm_path():
+    """Utility function to find ROCm path
+
+    Returns
+    -------
+    path : str
+        Path to ROCm root.
+    """
+    if "ROCM_PATH" in os.environ:
+        return os.environ["ROCM_PATH"]
+    cmd = ["which", "hipcc"]
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    (out, _) = proc.communicate()
+    out = out.decode("utf-8").strip()
+    if proc.returncode == 0:
+        return os.path.realpath(os.path.join(out, "../.."))
+    rocm_path = "/opt/rocm"
+    if os.path.exists(os.path.join(rocm_path, "bin/hipcc")):
+        return rocm_path
+    raise RuntimeError("Cannot find ROCm path")

--- a/tilelang/contrib/rocm.py
+++ b/tilelang/contrib/rocm.py
@@ -254,11 +254,9 @@ def get_rocm_arch(rocm_path="/opt/rocm"):
             gpu_arch = match.group(1)
         return gpu_arch
     except subprocess.CalledProcessError:
-        print(
-            f"Unable to execute rocminfo command, \
+        print(f"Unable to execute rocminfo command, \
                 please ensure ROCm is installed and you have an AMD GPU on your system.\
-                    using default {gpu_arch}."
-        )
+                    using default {gpu_arch}.")
         return gpu_arch
 
 

--- a/tilelang/engine/__init__.py
+++ b/tilelang/engine/__init__.py
@@ -3,3 +3,4 @@
 
 from .lower import lower, is_device_call  # noqa: F401
 from .param import KernelParam  # noqa: F401
+from .callback import register_cuda_postproc, register_hip_postproc  # noqa: F401

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -11,6 +11,7 @@ import tempfile
 import subprocess
 import logging
 from tilelang.env import TILELANG_TEMPLATE_PATH, CUTLASS_INCLUDE_DIR
+from tilelang.contrib.rocm import find_rocm_path, get_rocm_arch
 
 logger = logging.getLogger(__name__)
 
@@ -60,11 +61,13 @@ class LibraryGenerator(object):
         elif is_hip_target(target):
             src = tempfile.NamedTemporaryFile(mode="w", suffix=".cpp", delete=False)
             libpath = src.name.replace(".cpp", ".so")
-
+            rocm_path = find_rocm_path()
+            arch = get_rocm_arch(rocm_path)
             command = [
                 "hipcc",
                 "-std=c++17",
                 "-fPIC",
+                f"--offload-arch={arch}",
                 "--shared",
                 src.name,
             ]
@@ -86,7 +89,6 @@ class LibraryGenerator(object):
                 "-I" + TILELANG_TEMPLATE_PATH,
                 "-I" + CUTLASS_INCLUDE_DIR,
             ]
-            command += ["-diag-suppress=20013"]
         command += ["-o", libpath]
 
         src.write(self.lib_code)

--- a/tilelang/jit/adapter/wrapper.py
+++ b/tilelang/jit/adapter/wrapper.py
@@ -11,7 +11,7 @@ import re
 import logging
 import textwrap
 
-PREDEF_ARRTIBUTE_SET_DYNAMIC_MEMORY = """
+PREDEF_ATTRIBUTE_SET_DYNAMIC_MEMORY = """
     cudaError_t result_{0} = cudaFuncSetAttribute({0}, cudaFuncAttributeMaxDynamicSharedMemorySize, {1});
     if (result_{0} != CUDA_SUCCESS) {{
         snprintf(error_buf, ERROR_BUF_SIZE, "Failed to set the allowed dynamic shared memory size to %d with error: %s", {1}, cudaGetErrorString(result_{0}));
@@ -369,7 +369,7 @@ class TLCUDASourceWrapper(object):
         for function_name, dynamic_smem_buf in self.dynamic_smem_buf.items():
             if dynamic_smem_buf is not None:
                 # Format the cudaFuncSetAttribute call for dynamic shared memory
-                call_str += PREDEF_ARRTIBUTE_SET_DYNAMIC_MEMORY.format(
+                call_str += PREDEF_ATTRIBUTE_SET_DYNAMIC_MEMORY.format(
                     function_name, dynamic_smem_buf)
         # Format the initialization function using the call_str
         init_funcs = PREDEF_INIT_FUNC.format(call_str)
@@ -441,7 +441,7 @@ class TLHIPSourceWrapper(TLCUDASourceWrapper):
         for function_name, dynamic_smem_buf in self.dynamic_smem_buf.items():
             if dynamic_smem_buf is not None:
                 # Format the cudaFuncSetAttribute call for dynamic shared memory
-                call_str += PREDEF_ARRTIBUTE_SET_DYNAMIC_MEMORY_HIP.format(
+                call_str += PREDEF_ATTRIBUTE_SET_DYNAMIC_MEMORY_HIP.format(
                     function_name, dynamic_smem_buf)
         # Format the initialization function using the call_str
         init_funcs = PREDEF_INIT_FUNC.format(call_str)

--- a/tilelang/jit/adapter/wrapper.py
+++ b/tilelang/jit/adapter/wrapper.py
@@ -19,6 +19,14 @@ PREDEF_ARRTIBUTE_SET_DYNAMIC_MEMORY = """
     }}
 """
 
+PREDEF_ARRTIBUTE_SET_DYNAMIC_MEMORY_HIP = """
+    hipError_t result_{0} = hipFuncSetAttribute((const void *){0}, hipFuncAttributeMaxDynamicSharedMemorySize, {1});
+    if (result_{0} != HIP_SUCCESS) {{
+        snprintf(error_buf, ERROR_BUF_SIZE, "Failed to set the allowed dynamic shared memory size to %d with error: %s", {1}, hipGetErrorString(result_{0}));
+        return -1;
+    }}
+"""
+
 PREDEF_INIT_FUNC = """
 #define ERROR_BUF_SIZE 1024
 static char error_buf[ERROR_BUF_SIZE];
@@ -162,7 +170,7 @@ class TLCUDASourceWrapper(object):
             if dyn_sym not in [arg["name"] for arg in function_args]:
                 function_args.append({"name": dyn_sym, "type": "int"})
 
-        function_args.append({"name": "stream=cudaStreamDefault", "type": "cudaStream_t"},)
+        function_args.append(self.get_stream_type())
 
         # Format the function arguments for declaration
         def_args = ", ".join([f"{arg['type']} {arg['name']}" for arg in function_args])
@@ -354,7 +362,7 @@ class TLCUDASourceWrapper(object):
                         dynamic_symbolic_set.append(dim.name)
         return dynamic_symbolic_set
 
-    def get_cuda_init_func(self):
+    def get_init_func(self):
         # Initialize an empty string for the CUDA function call
         call_str = """"""
         # If dynamic shared memory buffer is specified, prepare the cudaFuncSetAttribute call
@@ -373,7 +381,7 @@ class TLCUDASourceWrapper(object):
         # Get the function names
         function_names = self.function_names
         # Get the CUDA initialization function
-        init_func = self.get_cuda_init_func()
+        init_func = self.get_init_func()
 
         # Organize function information for code generation
         function_informations = {}
@@ -394,6 +402,9 @@ class TLCUDASourceWrapper(object):
         # Combine the source, initialization function, and host function to form the complete library code
         lib_code = self.source + init_func + host_func
         return lib_code
+
+    def get_stream_type(self) -> Dict[str, str]:
+        return {"name": "stream=cudaStreamDefault", "type": "cudaStream_t"}
 
     @property
     def prim_func(self):
@@ -423,19 +434,21 @@ class TLHIPSourceWrapper(TLCUDASourceWrapper):
                  pass_configs: Optional[Dict[str, Any]] = None):
         super().__init__(scheduled_ir_module, source, target, device_mod, host_mod, pass_configs)
 
-    def get_hip_init_func(self):
+    def get_init_func(self):
         # Initialize an empty string for the CUDA function call
         call_str = """"""
         # If dynamic shared memory buffer is specified, prepare the cudaFuncSetAttribute call
-        if self.dynamic_smem_buf is not None:
-            call_str = PREDEF_ARRTIBUTE_SET_DYNAMIC_MEMORY.format(self.function_name,
-                                                                  self.dynamic_smem_buf)
+        for function_name, dynamic_smem_buf in self.dynamic_smem_buf.items():
+            if dynamic_smem_buf is not None:
+                # Format the cudaFuncSetAttribute call for dynamic shared memory
+                call_str += PREDEF_ARRTIBUTE_SET_DYNAMIC_MEMORY_HIP.format(
+                    function_name, dynamic_smem_buf)
         # Format the initialization function using the call_str
         init_funcs = PREDEF_INIT_FUNC.format(call_str)
         return init_funcs
 
-    def get_stream_type(self, function_args):
-        function_args.append({"name": "stream=hipStreamDefault", "type": "hipStream_t"},)
+    def get_stream_type(self) -> Dict[str, str]:
+        return {"name": "stream=hipStreamDefault", "type": "hipStream_t"}
 
 
 class TLCPUSourceWrapper(object):

--- a/tilelang/jit/adapter/wrapper.py
+++ b/tilelang/jit/adapter/wrapper.py
@@ -19,7 +19,7 @@ PREDEF_ARRTIBUTE_SET_DYNAMIC_MEMORY = """
     }}
 """
 
-PREDEF_ARRTIBUTE_SET_DYNAMIC_MEMORY_HIP = """
+PREDEF_ATTRIBUTE_SET_DYNAMIC_MEMORY_HIP = """
     hipError_t result_{0} = hipFuncSetAttribute((const void *){0}, hipFuncAttributeMaxDynamicSharedMemorySize, {1});
     if (result_{0} != HIP_SUCCESS) {{
         snprintf(error_buf, ERROR_BUF_SIZE, "Failed to set the allowed dynamic shared memory size to %d with error: %s", {1}, hipGetErrorString(result_{0}));


### PR DESCRIPTION
This pull request includes various changes to improve the functionality and compatibility of the Tile-AI project, particularly focusing on the HIP (Heterogeneous-Compute Interface for Portability) backend. The most important changes include adding support for new data types, enhancing debug capabilities, and refining matrix operations.

### Enhancements to data types and operations:

* [`src/tl_templates/hip/common.h`](diffhunk://#diff-688f4edb061910df1c04c5d483e0d7283b7bd5aadb4479bdff7f39fad1f6c0f9R46-R65): Added definitions for `bfloat16_t` and related vector types, and redefined `half_t` to `float16_t` for better compatibility. [[1]](diffhunk://#diff-688f4edb061910df1c04c5d483e0d7283b7bd5aadb4479bdff7f39fad1f6c0f9R46-R65) [[2]](diffhunk://#diff-688f4edb061910df1c04c5d483e0d7283b7bd5aadb4479bdff7f39fad1f6c0f9L38)
* [`src/tl_templates/hip/gemm.h`](diffhunk://#diff-de5bef720ae59c0163609df96b69ac39be37dae79fa90f565527045b68ea0b7dR135-L151): Introduced support for `TransposeA` and `TransposeB` in the `GemmTensorOp` class and added a `clear_accum` parameter to control accumulation clearing. [[1]](diffhunk://#diff-de5bef720ae59c0163609df96b69ac39be37dae79fa90f565527045b68ea0b7dR135-L151) [[2]](diffhunk://#diff-de5bef720ae59c0163609df96b69ac39be37dae79fa90f565527045b68ea0b7dR208-R218) [[3]](diffhunk://#diff-de5bef720ae59c0163609df96b69ac39be37dae79fa90f565527045b68ea0b7dL223-R259)

### Debugging improvements:

* [`src/tl_templates/hip/debug.h`](diffhunk://#diff-4bf542a76fa1ee569d0cd105728d97b245eef069bd766052a4660ca337232adcR1-R193): Added a new header file with device-side debug printing templates for various data types, enhancing the ability to debug GPU code.
* [`src/target/codegen_hip.cc`](diffhunk://#diff-f2cab786e0ee1b4f99e4395774057d43c88aa50e7714f57e67e5df8417b84dd5R115): Included the new debug header in the HIP code generator.

### Code refactoring and fixes:

* [`src/target/rt_mod_hip.cc`](diffhunk://#diff-603ee08642837fff04320a2cf770e6d462636d3ecde6fde553a1adbc25c65580L79-R79): Fixed the return type of `BuildTileLangHIPWithoutCompile` to `runtime::Module` and updated the function to use `ROCMModuleCreate`. [[1]](diffhunk://#diff-603ee08642837fff04320a2cf770e6d462636d3ecde6fde553a1adbc25c65580L79-R79) [[2]](diffhunk://#diff-603ee08642837fff04320a2cf770e6d462636d3ecde6fde553a1adbc25c65580L98-R99)
* [`src/op/gemm.cc`](diffhunk://#diff-5cbeefe6d2ab80fbd44350603133779b381d613ca2f5b4f4a6bf89dbe98b6d2cL259-L260): Removed an unnecessary check for `trans_B` in the `InferLayout` function for CDNA targets.

### Testing and configuration updates:

* [`testing/python/amd/test_tilelang_test_amd.py`](diffhunk://#diff-8a9a2a591137c8e849559bda1e5ac8de88f871c10a6d3b6ab31e0d4eb9fbb812L67-R67): Updated the `run_gemm` function to use `num_stages=0` and simplified the reference program for matrix multiplication. [[1]](diffhunk://#diff-8a9a2a591137c8e849559bda1e5ac8de88f871c10a6d3b6ab31e0d4eb9fbb812L67-R67) [[2]](diffhunk://#diff-8a9a2a591137c8e849559bda1e5ac8de88f871c10a6d3b6ab31e0d4eb9fbb812L97-R104)
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L16-R16): Added "HSA" to the `ignore-words-list` for the `codespell` tool.
* [`tilelang/__init__.py`](diffhunk://#diff-ffb9f6b71f5ba70056cd56dd1559cc2be74cbcb0f0b085831581ec50fa6b8b30L103-R103): Added imports for `register_cuda_postproc` and `register_hip_postproc` to the TileLang initialization file.