### PR TITLE
[Bugfix] Fix Transposed Fragment Layout for amd GEMM_RS matrix core 

### DIFF
--- a/src/layout/gemm_layouts.cc
+++ b/src/layout/gemm_layouts.cc
@@ -182,8 +182,8 @@ Fragment makeGemmFragmentACDNA(const int block_m, const int block_n,
     auto base_layout =
         makeGemmFragmentAB16x16CDNATransposed()->Repeat({1, 1}, false, false);
     auto warp_layout =
-        base_layout->Repeat({warp_m / 16, block_k / 16}, false, false);
-    auto block_layout = warp_layout->Repeat({block_m / warp_m, 1}, true, true)
+        base_layout->Repeat({block_k / 16, warp_m / 16}, false, true);
+    auto block_layout = warp_layout->Repeat({1, block_m / warp_m}, true, true)
                             ->Replicate(block_n / warp_n);
     return block_layout;
   } else {

--- a/testing/python/amd/test_tilelang_test_amd.py
+++ b/testing/python/amd/test_tilelang_test_amd.py
@@ -215,5 +215,4 @@ def test_gemm_rs_f16f32f32_nt():
 
 
 if __name__ == "__main__":
-    # tilelang.testing.main()
-    test_gemm_rs_f16f32f32_nt()
+    tilelang.testing.main()

--- a/testing/python/amd/test_tilelang_test_amd.py
+++ b/testing/python/amd/test_tilelang_test_amd.py
@@ -132,13 +132,11 @@ def matmul_rs(
 
     @T.prim_func
     def main(
-        A: T.Tensor(A_shape, in_dtype),
-        B: T.Tensor(B_shape, in_dtype),
-        C: T.Tensor((M, N), out_dtype),
+            A: T.Tensor(A_shape, in_dtype),
+            B: T.Tensor(B_shape, in_dtype),
+            C: T.Tensor((M, N), out_dtype),
     ):
-        with T.Kernel(
-            T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads
-        ) as (bx, by):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads) as (bx, by):
             A_shared = T.alloc_shared(A_shared_shape, in_dtype)
             A_local = T.alloc_fragment(A_shared_shape, in_dtype)
             B_shared = T.alloc_shared(B_shared_shape, in_dtype)


### PR DESCRIPTION
This pull request includes changes to the `src/layout/gemm_layouts.cc` and `testing/python/amd/test_tilelang_test_amd.py` files, focusing on improving the layout and functionality of GEMM operations and enhancing the testing framework for AMD.

### GEMM Layout Improvements:

* [`src/layout/gemm_layouts.cc`](diffhunk://#diff-402e906ccbf0bec59a2db319e19a1525cc7d6efd11523bf1b6f2a1462b64e29cL185-R186): Adjusted the `makeGemmFragmentACDNA` function to correct the layout repetition parameters, ensuring proper alignment and replication of GEMM fragments.

### Testing Enhancements:

* [`testing/python/amd/test_tilelang_test_amd.py`](diffhunk://#diff-8a9a2a591137c8e849559bda1e5ac8de88f871c10a6d3b6ab31e0d4eb9fbb812L134-R138): Reformatted the `main` function in `matmul_rs` for better readability and consistency.
* [`testing/python/amd/test_tilelang_test_amd.py`](diffhunk://#diff-8a9a2a591137c8e849559bda1e5ac8de88f871c10a6d3b6ab31e0d4eb9fbb812R151): Added a missing copy operation for `A_shared` to `A_local` within the `main` function to ensure data is correctly transferred.
* [`testing/python/amd/test_tilelang_test_amd.py`](diffhunk://#diff-8a9a2a591137c8e849559bda1e5ac8de88f871c10a6d3b6ab31e0d4eb9fbb812L174-R178): Updated the `run_gemm_rs` function to call `matmul_rs` instead of `matmul`, aligning with the new function naming.
* [`testing/python/amd/test_tilelang_test_amd.py`](diffhunk://#diff-8a9a2a591137c8e849559bda1e5ac8de88f871c10a6d3b6ab31e0d4eb9fbb812L214-R219): Modified the main execution block to directly call `test_gemm_rs_f16f32f32_nt` for testing purposes, bypassing the previous testing framework.