### PR TITLE
[Refactor] Implement thread-local storage for FrameStack in frame.py and kernel.py

### DIFF
--- a/tilelang/language/frame.py
+++ b/tilelang/language/frame.py
@@ -9,6 +9,7 @@ from tvm import DataType
 from tvm.script.ir_builder.tir.frame import TIRFrame
 from collections import deque
 from typing import Optional
+import threading
 
 
 class FrameStack:
@@ -97,8 +98,14 @@ class FrameStack:
         return bool(self._stack)
 
 
-# Global stack for LetFrame instances
-_let_frame_stack = FrameStack()
+# Use thread local to store the stack
+# This is to avoid the cross-thread interference
+_local_let = threading.local()
+
+def _get_let_stack() -> FrameStack:
+    if not hasattr(_local_let, "let_frame_stack"):
+        _local_let.let_frame_stack = FrameStack()
+    return _local_let.let_frame_stack
 
 
 @_register_object("script.ir_builder.tir.LetFrame")
@@ -127,7 +134,7 @@ class LetFrame(TIRFrame):
                 self.value = BufferRegion(self.value.buffer,
                                           [Range(x.base, x.lanes) for x in indices])
 
-        _let_frame_stack.push(self)
+        _get_let_stack().push(self)
         return self.var
 
     def __exit__(self, ptype, value, trace):
@@ -138,8 +145,9 @@ class LetFrame(TIRFrame):
             value: Exception value if an exception occurred
             trace: Exception traceback if an exception occurred
         """
-        if _let_frame_stack.top() is self:
-            _let_frame_stack.pop()
+        stack = _get_let_stack()
+        if stack.top() is self:
+            stack.pop()
         super().__exit__(ptype, value, trace)
 
     @classmethod
@@ -152,7 +160,7 @@ class LetFrame(TIRFrame):
         Raises:
             IndexError: If there are no active let frames
         """
-        return _let_frame_stack.top()
+        return _get_let_stack().top()
 
     @staticmethod
     def get_value(var: Var):
@@ -164,7 +172,7 @@ class LetFrame(TIRFrame):
         Returns:
             The value bound to the variable, or None if not found
         """
-        return _let_frame_stack.get_value(var)
+        return _get_let_stack().get_value(var)
 
     @staticmethod
     def has_value(var: Var) -> bool:
@@ -176,7 +184,7 @@ class LetFrame(TIRFrame):
         Returns:
             bool: True if the variable has a binding, False otherwise
         """
-        return _let_frame_stack.has_value(var)
+        return _get_let_stack().has_value(var)
 
 
 def has_let_value(var: Var) -> bool:
@@ -188,7 +196,7 @@ def has_let_value(var: Var) -> bool:
     Returns:
         bool: True if the variable has a binding, False otherwise
     """
-    return _let_frame_stack.has_value(var)
+    return _get_let_stack().has_value(var)
 
 
 def get_let_value(var: Var) -> Optional[PrimExpr]:
@@ -200,4 +208,4 @@ def get_let_value(var: Var) -> Optional[PrimExpr]:
     Returns:
         Optional[PrimExpr]: The bound value if found, None otherwise
     """
-    return _let_frame_stack.get_value(var)
+    return _get_let_stack().get_value(var)

--- a/tilelang/language/frame.py
+++ b/tilelang/language/frame.py
@@ -102,6 +102,7 @@ class FrameStack:
 # This is to avoid the cross-thread interference
 _local_let = threading.local()
 
+
 def _get_let_stack() -> FrameStack:
     if not hasattr(_local_let, "let_frame_stack"):
         _local_let.let_frame_stack = FrameStack()

--- a/tilelang/language/kernel.py
+++ b/tilelang/language/kernel.py
@@ -9,6 +9,7 @@ from tvm.tir import Var
 from tvm.script.ir_builder.tir.frame import TIRFrame, BlockFrame
 from tvm._ffi import register_object
 from tilelang import _ffi_api
+import threading
 
 
 class FrameStack:
@@ -42,6 +43,10 @@ class FrameStack:
             return self._stack[-1]
         raise IndexError(f"{self.__class__.__name__} is empty")
 
+    def size(self):
+        """Returns the number of items in the stack."""
+        return len(self._stack)
+
     def __len__(self):
         """Returns the number of items in the stack."""
         return len(self._stack)
@@ -53,9 +58,14 @@ class FrameStack:
         """
         return bool(self._stack)
 
+# Use thread local to store the stack
+# This is to avoid the cross-thread interference
+_local = threading.local()
 
-# Use our new FrameStack instead of a plain list or deque
-_kernel_launch_frame_stack = FrameStack()
+def _get_current_stack() -> FrameStack:
+    if not hasattr(_local, "kernel_launch_frame_stack"):
+        _local.kernel_launch_frame_stack = FrameStack()
+    return _local.kernel_launch_frame_stack
 
 
 @register_object("tl.KernelLaunchFrame")
@@ -72,7 +82,7 @@ class KernelLaunchFrame(TIRFrame):
         block dimension), or a list of Vars otherwise.
         """
         super().__enter__()
-        _kernel_launch_frame_stack.push(self)
+        _get_current_stack().push(self)
         # If we have exactly 5 frames, return the single iter_var.var.
         if len(self.frames) == 5:
             return self.frames[0].iter_var.var
@@ -96,9 +106,9 @@ class KernelLaunchFrame(TIRFrame):
         Exits the KernelLaunchFrame scope and pops this frame from the stack,
         but only if it's indeed the topmost frame.
         """
-        # Check if this frame is the current top before popping.
-        if _kernel_launch_frame_stack.top() is self:
-            _kernel_launch_frame_stack.pop()
+        stack = _get_current_stack()
+        if stack.top() is self:
+            stack.pop()
         super().__exit__(ptype, value, trace)
 
     @classmethod
@@ -107,7 +117,8 @@ class KernelLaunchFrame(TIRFrame):
         Returns the topmost (current) KernelLaunchFrame from the stack if it exists,
         or None if the stack is empty.
         """
-        return _kernel_launch_frame_stack.top()
+        stack = _get_current_stack()
+        return stack.top() if stack else None
 
     def get_block_extent(self, dim: int) -> int:
         """

--- a/tilelang/language/kernel.py
+++ b/tilelang/language/kernel.py
@@ -58,9 +58,11 @@ class FrameStack:
         """
         return bool(self._stack)
 
+
 # Use thread local to store the stack
 # This is to avoid the cross-thread interference
 _local = threading.local()
+
 
 def _get_current_stack() -> FrameStack:
     if not hasattr(_local, "kernel_launch_frame_stack"):


### PR DESCRIPTION
This pull request introduces changes to `tilelang/language/frame.py` and `tilelang/language/kernel.py` to ensure thread safety by using thread-local storage for frame stacks. Additionally, a new method is added to the `FrameStack` class in `tilelang/language/kernel.py`.

Thread safety improvements:

* [`tilelang/language/frame.py`](diffhunk://#diff-389cd48e2e02bc14e6545fd1832a7a0658defbe037acca12cb035e2644892d56R12): Replaced the global `_let_frame_stack` with a thread-local `_local_let` to store the stack, and updated methods to use `_get_let_stack()` for accessing the stack. [[1]](diffhunk://#diff-389cd48e2e02bc14e6545fd1832a7a0658defbe037acca12cb035e2644892d56R12) [[2]](diffhunk://#diff-389cd48e2e02bc14e6545fd1832a7a0658defbe037acca12cb035e2644892d56L100-R109) [[3]](diffhunk://#diff-389cd48e2e02bc14e6545fd1832a7a0658defbe037acca12cb035e2644892d56L130-R138) [[4]](diffhunk://#diff-389cd48e2e02bc14e6545fd1832a7a0658defbe037acca12cb035e2644892d56L141-R151) [[5]](diffhunk://#diff-389cd48e2e02bc14e6545fd1832a7a0658defbe037acca12cb035e2644892d56L155-R164) [[6]](diffhunk://#diff-389cd48e2e02bc14e6545fd1832a7a0658defbe037acca12cb035e2644892d56L167-R176) [[7]](diffhunk://#diff-389cd48e2e02bc14e6545fd1832a7a0658defbe037acca12cb035e2644892d56L179-R188) [[8]](diffhunk://#diff-389cd48e2e02bc14e6545fd1832a7a0658defbe037acca12cb035e2644892d56L191-R200) [[9]](diffhunk://#diff-389cd48e2e02bc14e6545fd1832a7a0658defbe037acca12cb035e2644892d56L203-R212)
* [`tilelang/language/kernel.py`](diffhunk://#diff-aeb3d6121993c4b243a5acf2f61e2c222624c316b997783e4f7b55b16e63a7a5R12): Replaced the global `_kernel_launch_frame_stack` with a thread-local `_local` to store the stack, and updated methods to use `_get_current_stack()` for accessing the stack. [[1]](diffhunk://#diff-aeb3d6121993c4b243a5acf2f61e2c222624c316b997783e4f7b55b16e63a7a5R12) [[2]](diffhunk://#diff-aeb3d6121993c4b243a5acf2f61e2c222624c316b997783e4f7b55b16e63a7a5L57-R70) [[3]](diffhunk://#diff-aeb3d6121993c4b243a5acf2f61e2c222624c316b997783e4f7b55b16e63a7a5L75-R87) [[4]](diffhunk://#diff-aeb3d6121993c4b243a5acf2f61e2c222624c316b997783e4f7b55b16e63a7a5L99-R113) [[5]](diffhunk://#diff-aeb3d6121993c4b243a5acf2f61e2c222624c316b997783e4f7b55b16e63a7a5L110-R123)

New method addition:

* [`tilelang/language/kernel.py`](diffhunk://#diff-aeb3d6121993c4b243a5acf2f61e2c222624c316b997783e4f7b55b16e63a7a5R46-R49): Added a `size` method to the `FrameStack` class to return the number of items in the stack.