### PR TITLE
[Bugfix] Fix compilation issues for amd cdna element size check

### DIFF
--- a/src/layout/gemm_layouts.cc
+++ b/src/layout/gemm_layouts.cc
@@ -173,7 +173,7 @@ Fragment makeGemmFragmentA(const int block_m, const int block_n,
 
 Fragment makeGemmFragmentACDNA(const int block_m, const int block_n,
                                const int block_k, const int warp_m,
-                               const int warp_n, bool transposed) {
+                               const int warp_n, const int element_size, bool transposed) {
   // assume not transposed
   ICHECK(block_m % warp_m == 0);
   ICHECK(block_n % warp_n == 0);

--- a/src/layout/gemm_layouts.cc
+++ b/src/layout/gemm_layouts.cc
@@ -173,7 +173,8 @@ Fragment makeGemmFragmentA(const int block_m, const int block_n,
 
 Fragment makeGemmFragmentACDNA(const int block_m, const int block_n,
                                const int block_k, const int warp_m,
-                               const int warp_n, const int element_size, bool transposed) {
+                               const int warp_n, const int element_size,
+                               bool transposed) {
   // assume not transposed
   ICHECK(block_m % warp_m == 0);
   ICHECK(block_n % warp_n == 0);

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -149,7 +149,8 @@ Fragment makeGemmFragmentB(const int block_m, const int block_n,
 
 Fragment makeGemmFragmentACDNA(const int block_m, const int block_n,
                                const int block_k, const int warp_m,
-                               const int warp_n, const int element_size, bool transposed = false);
+                               const int warp_n, const int element_size,
+                               bool transposed = false);
 
 // Default Memory Layout
 Layout makeGemmLayoutLinear(int stride, int continuous);

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -149,7 +149,7 @@ Fragment makeGemmFragmentB(const int block_m, const int block_n,
 
 Fragment makeGemmFragmentACDNA(const int block_m, const int block_n,
                                const int block_k, const int warp_m,
-                               const int warp_n, bool transposed = false);
+                               const int warp_n, const int element_size, bool transposed = false);
 
 // Default Memory Layout
 Layout makeGemmLayoutLinear(int stride, int continuous);

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -278,8 +278,8 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
                                                 A->dtype.bits(), kPack);
       results.Set(A, shared_layout);
     } else if (A.scope() == "local.fragment") {
-      results.Set(
-          A, makeGemmFragmentACDNA(M, N, K, M / warp_m, N / warp_n, A->dtype.bits(), trans_A));
+      results.Set(A, makeGemmFragmentACDNA(M, N, K, M / warp_m, N / warp_n,
+                                           A->dtype.bits(), trans_A));
     } else {
       ICHECK(0);
     }

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -279,7 +279,7 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
       results.Set(A, shared_layout);
     } else if (A.scope() == "local.fragment") {
       results.Set(
-          A, makeGemmFragmentACDNA(M, N, K, M / warp_m, N / warp_n, trans_A));
+          A, makeGemmFragmentACDNA(M, N, K, M / warp_m, N / warp_n, A->dtype.bits(), trans_A));
     } else {
       ICHECK(0);
     }

--- a/tilelang/autotuner/__init__.py
+++ b/tilelang/autotuner/__init__.py
@@ -174,7 +174,7 @@ class AutoTuner:
         self.jit_compile = _compile
         return self
 
-    def run(self, warmup: int = 25, rep: int = 100, timeout: int = 100):
+    def run(self, warmup: int = 25, rep: int = 100, timeout: int = 30):
         """Run the auto-tuning process.
 
         Args:
@@ -220,7 +220,7 @@ class AutoTuner:
 
                 return func
 
-            jit_input_tensors_supply = get_input_tensors_supply(with_output=(profiler == "tvm"))
+            jit_input_tensors_supply = get_input_tensors_supply(with_output=False)
             ref_input_tensors_supply = get_input_tensors_supply(with_output=False)
 
             if cache_input_tensors:
@@ -249,9 +249,7 @@ class AutoTuner:
                     rtol=rtol,
                     atol=atol,
                     max_mismatched_ratio=max_mismatched_ratio)
-
-            latency = profiler.do_bench(
-                profiler.func, n_warmup=warmup, n_repeat=rep, input_tensors=self.jit_input_tensors)
+            latency = profiler.do_bench(warmup=warmup, rep=rep, input_tensors=self.jit_input_tensors)
             if self.ref_latency_cache is None and ref_prog is not None:
                 self.ref_input_tensors = ref_input_tensors_supply()
                 self.ref_latency_cache = profiler.do_bench(
@@ -306,7 +304,15 @@ class AutoTuner:
             try:
                 # Cannot ThreadPoolExecutor to enforce timeout on target_fn execution
                 # Because tma init may behave strangely with one thread
-                latency, ref_latency = target_fn(jit_context)
+                # latency, ref_latency = target_fn(jit_context)
+                benchmark_executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+                future = benchmark_executor.submit(target_fn, jit_context)
+                latency, ref_latency = future.result(timeout=timeout)
+            except concurrent.futures.TimeoutError:
+                logger.info(
+                    f"A timeout occurred while testing config {config}, checkout autotuner.log for more details"
+                )
+                continue
             except Exception as e:
                 logger.info(
                     f"An error occurred while testing config {config}, checkout autotuner.log for more details"

--- a/tilelang/autotuner/__init__.py
+++ b/tilelang/autotuner/__init__.py
@@ -249,7 +249,8 @@ class AutoTuner:
                     rtol=rtol,
                     atol=atol,
                     max_mismatched_ratio=max_mismatched_ratio)
-            latency = profiler.do_bench(warmup=warmup, rep=rep, input_tensors=self.jit_input_tensors)
+            latency = profiler.do_bench(
+                warmup=warmup, rep=rep, input_tensors=self.jit_input_tensors)
             if self.ref_latency_cache is None and ref_prog is not None:
                 self.ref_input_tensors = ref_input_tensors_supply()
                 self.ref_latency_cache = profiler.do_bench(


### PR DESCRIPTION
This pull request includes changes to enhance the GEMM fragment creation functions and improve the auto-tuning process in the `tilelang` module. The most important changes include adding an `element_size` parameter to GEMM fragment functions and enhancing timeout handling in the auto-tuner.

Enhancements to GEMM fragment creation:

* [`src/layout/gemm_layouts.cc`](diffhunk://#diff-402e906ccbf0bec59a2db319e19a1525cc7d6efd11523bf1b6f2a1462b64e29cL176-R177): Added an `element_size` parameter to the `makeGemmFragmentACDNA` function to accommodate different element sizes.
* [`src/layout/layout.h`](diffhunk://#diff-6294e9e63d3b1b3abaab214671f414ccba47aab33c0c5373f51a87460cadcc98L152-R153): Updated the `makeGemmFragmentACDNA` function declaration to include the `element_size` parameter.
* [`src/op/gemm.cc`](diffhunk://#diff-5cbeefe6d2ab80fbd44350603133779b381d613ca2f5b4f4a6bf89dbe98b6d2cL281-R282): Modified the `InferLayout` function to pass the `element_size` parameter when creating GEMM fragments.

Improvements to auto-tuning:

* [`tilelang/autotuner/__init__.py`](diffhunk://#diff-97693b0284b022034f1372b32098a5c8665f29f882a79e3739f19a340ea7dd38L177-R177): Reduced the default `timeout` value in the `run` method from 100 to 30 seconds to prevent long-running operations.
* [`tilelang/autotuner/__init__.py`](diffhunk://#diff-97693b0284b022034f1372b32098a5c8665f29f882a79e3739f19a340ea7dd38L309-R316): Added handling for `concurrent.futures.TimeoutError` to log a message and continue when a timeout occurs during benchmarking.