### PR TITLE
[AMD] Support FlashMLA with num split template for AMD gpus

### DIFF
--- a/tilelang/jit/adapter/utils.py
+++ b/tilelang/jit/adapter/utils.py
@@ -32,7 +32,7 @@ def match_global_kernel(source: str, annotation: str = "__global__") -> int:
 
 
 def match_declare_kernel(source: str, annotation: str = "__global__") -> int:
-    pattern = r"__global__\s+void\s+\w+"
+    pattern = r"__global__\s+void\s+(?:__launch_bounds__\(\d+\)\s+)?\w+"
     for line in source.split("\n"):
         if annotation in line:
             matched = re.findall(pattern, line)


### PR DESCRIPTION

This pull request includes a modification to the `match_declare_kernel` function in the `tilelang/jit/adapter/utils.py` file to improve the pattern matching for kernel declarations.

Pattern matching improvement:

* [`tilelang/jit/adapter/utils.py`](diffhunk://#diff-6f11c60f8bb9fa7b730d84353f032c859f799a0b1399cabb6f0939c370b8abe1L35-R35): Updated the regular expression pattern in the `match_declare_kernel` function to account for optional `__launch_bounds__` annotations in kernel declarations.