### PR TITLE
[Bugfix] Adjust Autotuner threadpool `max_workers` limit to available CPUs

### DIFF
--- a/examples/blocksparse_gemm/example_blocksparse_gemm.py
+++ b/examples/blocksparse_gemm/example_blocksparse_gemm.py
@@ -7,7 +7,7 @@ import tilelang
 import tilelang.language as T
 from tilelang.autotuner import AutoTuner
 from tilelang.engine.param import KernelParam
-from tilelang.utils.tensor import get_tensor_supply
+from tilelang.utils.tensor import get_tensor_supply, TensorSupplyType
 import torch
 from typing import List
 
@@ -30,7 +30,7 @@ args = parser.parse_args()
 M, N, K = args.m, args.n, args.k
 sparsity = args.sparsity
 use_autotune = args.use_autotune
-default_tensor_supply = get_tensor_supply()
+default_tensor_supply = get_tensor_supply(TensorSupplyType.Auto)
 
 print(f"Running BlockSparse MatMul Benchmark for M={M}, N={N}, K={K}")
 print(f"Target Block Sparsity: {sparsity}")

--- a/tilelang/autotuner/__init__.py
+++ b/tilelang/autotuner/__init__.py
@@ -271,7 +271,7 @@ class AutoTuner:
             new_args = tuple(new_args)
             config_args.append(new_args)
 
-        num_workers = max(1, int(os.cpu_count() * 0.9))
+        num_workers = max(1, int(get_available_cpu_count() * 0.9))
         pool = concurrent.futures.ThreadPoolExecutor(max_workers=num_workers)
         futures = []
         future_to_index = {}
@@ -455,3 +455,14 @@ def check_tensor_list_compatibility(
         return False
 
     return all(tensor1.shape == tensor2.shape for tensor1, tensor2 in zip(list1, list2))
+
+
+def get_available_cpu_count():
+    """Gets the number of CPU cores available to the current process.
+    """
+    try:
+        cpu_count = len(os.sched_getaffinity(0))
+    except AttributeError:
+        cpu_count = os.cpu_count()
+
+    return cpu_count


### PR DESCRIPTION
Currently the autotuner calculates the `max_workers` for its `ThreadPoolExecutor` (used for concurrent kernel compilation) based on `os.cpu_count()`.

However, `os.cpu_count()` reflects the total number of CPUs available on the *system*, which doesn't necessarily reflect the number of cores the *current process* is actually allowed to use. The mismatch is common in containerized environments or when CPU affinity is set using tools like `taskset`.

Attempting to use more worker threads than available CPUs can lead to system thrashing and slow down the compilation process rather than accelerating it.

I think a better approach is to use `len(os.sched_getaffinity(0))` to get the number of CPUs that the process is actually available to use ([reference](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.cpu_count)).