### PR TITLE
[Refactor] Remove debug message in pass legalize_safe_memory_access

### DIFF
--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -170,15 +170,11 @@ private:
     if (IsGlobalBuffer(store->buffer)) {
       Stmt store_with_conditions = store;
       for (auto cond : conditions) {
-        LOG(INFO) << "condition: " << cond;
-        LOG(INFO) << "store: " << store;
         store_with_conditions = IfThenElse(cond, store_with_conditions);
       }
       return store_with_conditions;
     } else if (isSharedBuffer(store->buffer)) {
       PrimExpr value = store->value;
-      LOG(INFO) << "value: " << value;
-      LOG(INFO) << "conditions: " << conditions;
       for (auto cond : conditions) {
         ICHECK(cond.dtype() == DataType::Bool(1))
             << "condition is not a boolean: " << cond;

--- a/tilelang/jit/adapter/cython/adapter.py
+++ b/tilelang/jit/adapter/cython/adapter.py
@@ -92,6 +92,7 @@ with open(cython_wrapper_path, "r") as f:
     library_path = cache_dir / "cython_wrapper.so"
     md5_path = cache_dir / "md5.txt"
     code_hash = hashlib.sha256(cython_wrapper_code.encode()).hexdigest()
+    cache_path = cache_dir / f"{code_hash}.so"
 
     # Check if cached version exists and is valid
     need_compile = True
@@ -112,7 +113,7 @@ with open(cython_wrapper_path, "r") as f:
         try:
             with open(md5_path, "w") as f:
                 f.write(code_hash)
-
+            
             # compile the cython_wrapper.pyx file into .cpp
             cython = get_cython_compiler()
             if cython is None:
@@ -122,7 +123,7 @@ with open(cython_wrapper_path, "r") as f:
             cc = get_cplus_compiler()
             command = f"{cc} -shared -pthread -fPIC -fwrapv -O2 -Wall -fno-strict-aliasing -I{python_include_path} {source_path} -o {temp_path}"
             os.system(command)
-
+            
             # rename the temp file to the library file
             temp_path.rename(library_path)
         except Exception as e:
@@ -130,6 +131,7 @@ with open(cython_wrapper_path, "r") as f:
                 temp_path.unlink()
             raise Exception(f"Failed to compile cython jit adapter: {e}") from e
         finally:
+            lock_file = cache_path.with_suffix('.lock')
             if lock_file.exists():
                 lock_file.unlink()
 

--- a/tilelang/jit/adapter/cython/adapter.py
+++ b/tilelang/jit/adapter/cython/adapter.py
@@ -113,7 +113,7 @@ with open(cython_wrapper_path, "r") as f:
         try:
             with open(md5_path, "w") as f:
                 f.write(code_hash)
-            
+
             # compile the cython_wrapper.pyx file into .cpp
             cython = get_cython_compiler()
             if cython is None:
@@ -123,7 +123,7 @@ with open(cython_wrapper_path, "r") as f:
             cc = get_cplus_compiler()
             command = f"{cc} -shared -pthread -fPIC -fwrapv -O2 -Wall -fno-strict-aliasing -I{python_include_path} {source_path} -o {temp_path}"
             os.system(command)
-            
+
             # rename the temp file to the library file
             temp_path.rename(library_path)
         except Exception as e:


### PR DESCRIPTION
This pull request includes changes to the `src/transform/legalize_safe_memory_access.cc` file to clean up the code by removing unnecessary logging statements.

Codebase cleanup:

* [`src/transform/legalize_safe_memory_access.cc`](diffhunk://#diff-d9e675b8eb6e382847a1b542e623ee7ebe4afe1ad470f6cf983e6330e795fcb0L173-L181): Removed `LOG(INFO)` statements that output conditions, store, and value information within the `SafeMemorysRewriter` class.