### PR TITLE
[Revert] Revert modifications for pass FlattenBuffer

### DIFF
--- a/src/transform/flatten_buffer.cc
+++ b/src/transform/flatten_buffer.cc
@@ -209,7 +209,7 @@ private:
     return std::move(store);
   }
 
-  PrimExpr VisitExpr_(const BufferLoadNode* op) final {
+  PrimExpr VisitExpr_(const BufferLoadNode *op) final {
     bool load_returns_bool = (op->dtype == DataType::Bool());
     BufferLoad load = Downcast<BufferLoad>(StmtExprMutator::VisitExpr_(op));
     load = VisitBufferAccess(load);
@@ -226,7 +226,7 @@ private:
     }
   }
 
-  PrimExpr VisitExpr_(const CallNode* op) final {
+  PrimExpr VisitExpr_(const CallNode *op) final {
     if (op->op.same_as(builtin::address_of())) {
       under_address_of = true;
       auto result = StmtExprMutator::VisitExpr_(op);

--- a/src/transform/flatten_buffer.cc
+++ b/src/transform/flatten_buffer.cc
@@ -209,9 +209,31 @@ private:
     return std::move(store);
   }
 
-  PrimExpr VisitExpr_(const BufferLoadNode *op) final {
+  PrimExpr VisitExpr_(const BufferLoadNode* op) final {
+    bool load_returns_bool = (op->dtype == DataType::Bool());
     BufferLoad load = Downcast<BufferLoad>(StmtExprMutator::VisitExpr_(op));
-    return VisitBufferAccess(load);
+    load = VisitBufferAccess(load);
+    // Handle casts from dtype of the backing array to value's dtype.
+    // TODO(Lunderberg): Move the handling of boolean into a
+    // dedicated pass.
+    if (load_returns_bool && !under_address_of) {
+      ICHECK_EQ(load->buffer->dtype, DataType::Int(8))
+          << "Expected int8 backing array for boolean tensor";
+      load.CopyOnWrite()->dtype = DataType::Int(8);
+      return tvm::cast(DataType::Bool(), load);
+    } else {
+      return std::move(load);
+    }
+  }
+
+  PrimExpr VisitExpr_(const CallNode* op) final {
+    if (op->op.same_as(builtin::address_of())) {
+      under_address_of = true;
+      auto result = StmtExprMutator::VisitExpr_(op);
+      under_address_of = false;
+      return result;
+    }
+    return StmtExprMutator::VisitExpr_(op);
   }
 
   Array<PrimExpr> GetSimplifiedElemOffset(const Buffer &buffer,
@@ -260,6 +282,8 @@ private:
     return BufferRegion(flattened_buf, flattened_ranges);
   }
 
+  /*! \brief Whether the current buffer is under address_of */
+  bool under_address_of = false;
   /*! \brief Map of buffers being remapped. */
   std::unordered_map<Buffer, Buffer, ObjectPtrHash, ObjectPtrEqual>
       buffer_remap_;

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -54,7 +54,7 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
     # TODO(lei): may need a pass to fuse the if-then-else in the
     # pipeline loop when we meet dynamic branch.
     mod = tir.transform.LowerOpaqueBlock()(mod)
-    mod = tir.transform.FlattenBuffer()(mod)
+    mod = tilelang.transform.FlattenBuffer()(mod)
     mod = tir.transform.NarrowDataType(32)(mod)
     mod = tir.transform.Simplify()(mod)
     mod = tilelang.transform.VectorizeLoop()(mod)

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -54,7 +54,7 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
     # TODO(lei): may need a pass to fuse the if-then-else in the
     # pipeline loop when we meet dynamic branch.
     mod = tir.transform.LowerOpaqueBlock()(mod)
-    mod = tilelang.transform.FlattenBuffer()(mod)
+    mod = tir.transform.FlattenBuffer()(mod)
     mod = tir.transform.NarrowDataType(32)(mod)
     mod = tir.transform.Simplify()(mod)
     mod = tilelang.transform.VectorizeLoop()(mod)


### PR DESCRIPTION
This pull request includes updates to a submodule and a correction in a function within the `tilelang/engine/phase.py` file.

Submodule update:

* [`3rdparty/tvm`](diffhunk://#diff-fa909c93fe94e9aa04c9e7f19e5754a2bb274678ad5c6275ee4bf54c6f9b1066L1-R1): Updated the submodule commit reference to the latest commit.

Function correction:

* [`tilelang/engine/phase.py`](diffhunk://#diff-d0919e6c22b4d85ff6c5a0a9f34b53bc9415d8c61dc84e9993841b10d14e44a5L57-R57): Corrected the call to `FlattenBuffer` by changing its namespace from `tilelang.transform` to `tir.transform` in the `OptimizeForTarget` function.