### PR TITLE
Add preliminary support for bf16 for AMD

### DIFF
--- a/src/target/codegen_hip.cc
+++ b/src/target/codegen_hip.cc
@@ -509,8 +509,8 @@ void CodeGenTileLangHIP::PrintVecElemStore(const std::string &vec, DataType t,
     stream << "*((half_t*)(&(((half2*)(&(" << vec << "." << access[i / 2]
            << ")))->" << access[i % 2] << "))) = " << value << ";\n";
   } else if (t.is_bfloat16()) {
-    stream << "((bfloat16_t*)(&(" << vec << "." << access[i / 2]
-           << ")))[" << (i % 2) << "] = " << value << ";\n";
+    stream << "((bfloat16_t*)(&(" << vec << "." << access[i / 2] << ")))["
+           << (i % 2) << "] = " << value << ";\n";
   } else if (t.lanes() > 4 && t.lanes() <= 8) {
     std::string type_name;
     if (t.bits() == 16) {

--- a/src/target/codegen_hip.cc
+++ b/src/target/codegen_hip.cc
@@ -490,51 +490,51 @@ void CodeGenTileLangHIP::PrintVecElemStore(const std::string &vec, DataType t,
   this->PrintIndent();
   static const char access[] = {'x', 'y', 'z', 'w'};
   ICHECK(i >= 0 && i < (t.bits() == 8                        ? 16
-                        : (t.bits() == 16 || t.bits() == 32) ? 8
-                                                             : 4));
-  if (t.bits() == 8 && (t.is_int() || t.is_uint())) {
-    if (t.lanes() == 2 || t.lanes() == 3) {
-      stream << vec << '.' << access[i % t.lanes()] << "="
-             << "(" << value << ");\n";
-    } else {
-      std::string ac = t.lanes() == 4 ? vec : (vec + "." + access[i / 4]);
-      stream << ac << "=";
-      // Do not read the first undef lane.
-      if (i != 0) {
+  : (t.bits() == 16 || t.bits() == 32) ? 8
+                                       : 4));
+        if (t.bits() == 8 && (t.is_int() || t.is_uint())) {
+        if (t.lanes() == 2 || t.lanes() == 3) {
+        stream << vec << '.' << access[i % t.lanes()] << "="
+        << "(" << value << ");\n";
+        } else {
+        std::string ac = t.lanes() == 4 ? vec : (vec + "." + access[i / 4]);
+        stream << ac << "=";
+        if (i != 0) {
         stream << ac << " & ~(0x000000ff << " << i % 4 * 8 << ") |";
-      }
-      stream << "(" << value << " << " << i % 4 * 8 << ");\n";
-    }
-  } else if (t.is_float16()) {
-    stream << "*((half_t*)(&(((half2*)(&(" << vec << "." << access[i / 2]
-           << ")))->" << access[i % 2] << "))) = " << value << ";\n";
-  } else if (t.is_bfloat16()) {
-    stream << "*((bfloat16_t*)(&((half2*)(&(" << vec << "." << access[i / 2]
-           << ")))->" << access[i % 2] << "))) = " << value << ";\n";
-  } else if (t.lanes() > 4 && t.lanes() <= 8) {
-    std::string type_name;
-    if (t.bits() == 16) {
-      if (t.is_int()) {
+        }
+        stream << "(" << value << " << " << i % 4 * 8 << ");\n";
+        }
+        } else if (t.is_float16()) {
+          stream << "*((half_t*)(&(((half2*)(&(" << vec << "." << access[i / 2]
+          << ")))->" << access[i % 2] << "))) = " << value << ";\n";
+        } else if (t.is_bfloat16()) {
+          stream << "((bfloat16_t*)(&(" << vec << "." << access[i / 2]
+          << ")))[" << (i % 2) << "] = " << value << ";\n";
+        } else if (t.lanes() > 4 && t.lanes() <= 8) {
+        std::string type_name;
+        if (t.bits() == 16) {
+        if (t.is_int()) {
         type_name = "short";
-      } else if (t.is_uint()) {
+        } else if (t.is_uint()) {
         type_name = "ushort";
-      }
-    } else if (t.bits() == 32) {
-      if (t.is_int()) {
+        }
+        } else if (t.bits() == 32) {
+        if (t.is_int()) {
         type_name = "int";
-      } else if (t.is_uint()) {
+        } else if (t.is_uint()) {
         type_name = "uint";
-      } else if (t.is_float()) {
-        type_name = "float";
-      }
-    }
-    ICHECK(!type_name.empty());
-    stream << "((" << type_name << "2*)(&(" << vec << "." << access[i / 2]
-           << ")))->" << access[i % 2] << " = " << value << ";\n";
-  } else {
-    stream << vec << "." << access[i] << " = " << value << ";\n";
-  }
+              } else if (t.is_float()) {
+                              type_name = "float";
+                                    }
+        }
+        ICHECK(!type_name.empty());
+        stream << "((" << type_name << "2*)(&(" << vec << "." << access[i / 2]
+        << ")))->" << access[i % 2] << " = " << value << ";\n";
+        } else {
+        stream << vec << "." << access[i] << " = " << value << ";\n";
+        }
 }
+ 
 
 void CodeGenTileLangHIP::PrintStorageSync(const CallNode *op) {
   const std::string &sync = op->args[0].as<StringImmNode>()->value;

--- a/src/tl_templates/hip/common.h
+++ b/src/tl_templates/hip/common.h
@@ -63,7 +63,8 @@ struct bfloat16x16 {
   bfloat16_t data[16];
 };
 
-typedef __attribute__((__vector_size__(4 * sizeof(short)))) short bfloat16x4_vec;
+typedef
+    __attribute__((__vector_size__(4 * sizeof(short)))) short bfloat16x4_vec;
 
 using int32x4 = __attribute__((__vector_size__(4 * sizeof(int)))) int;
 using float32x4 = __attribute__((__vector_size__(4 * sizeof(float)))) float;

--- a/src/tl_templates/hip/common.h
+++ b/src/tl_templates/hip/common.h
@@ -63,6 +63,8 @@ struct bfloat16x16 {
   bfloat16_t data[16];
 };
 
+typedef __attribute__((__vector_size__(4 * sizeof(short)))) short bfloat16x4_vec;
+
 using int32x4 = __attribute__((__vector_size__(4 * sizeof(int)))) int;
 using float32x4 = __attribute__((__vector_size__(4 * sizeof(float)))) float;
 using float32x16 = __attribute__((__vector_size__(16 * sizeof(float)))) float;

--- a/src/tl_templates/hip/gemm.h
+++ b/src/tl_templates/hip/gemm.h
@@ -1,4 +1,4 @@
-// Copyright (c)// Copyright (c) Tile-AI Corporation.
+// Copyright (c) Tile-AI Corporation.
 // Licensed under the MIT License.
 #pragma once
 
@@ -28,10 +28,7 @@ struct MfmaTraits<__hip_bfloat16> {
     template <typename AccType>
     static TL_DEVICE void mfma_op(
         const __hip_bfloat16* b, const __hip_bfloat16* a, AccType* c) {
-        // Creating a data structure for the MFMA intrinsic
-        // This depends on how your intrinsic expects the BF16 data
-        typedef __attribute__((__vector_size__(4 * sizeof(short)))) short bf16_vec;
-        bf16_vec b_vec, a_vec;
+        bfloat16x4_vec b_vec, a_vec;
         
         // Reinterpret the pointers
         short* b_short = reinterpret_cast<short*>(const_cast<__hip_bfloat16*>(b));

--- a/src/tl_templates/hip/gemm.h
+++ b/src/tl_templates/hip/gemm.h
@@ -1,10 +1,52 @@
-// Copyright (c) Tile-AI Corporation.
+// Copyright (c)// Copyright (c) Tile-AI Corporation.
 // Licensed under the MIT License.
 #pragma once
 
 #include "common.h"
+#include <type_traits>
 
 namespace tl {
+
+// Trait to determine the MFMA instruction to use based on data type
+template <typename T>
+struct MfmaTraits;
+
+// Specialization for half/float16
+template <>
+struct MfmaTraits<half> {
+    template <typename AccType>
+    static TL_DEVICE void mfma_op(
+        const half* b, const half* a, AccType* c) {
+        *c = __builtin_amdgcn_mfma_f32_16x16x16f16(
+            *((float16x4*)b), *((float16x4*)a), *c, 0, 0, 0);
+    }
+};
+
+// Specialization for __hip_bfloat16
+template <>
+struct MfmaTraits<__hip_bfloat16> {
+    template <typename AccType>
+    static TL_DEVICE void mfma_op(
+        const __hip_bfloat16* b, const __hip_bfloat16* a, AccType* c) {
+        // Creating a data structure for the MFMA intrinsic
+        // This depends on how your intrinsic expects the BF16 data
+        typedef __attribute__((__vector_size__(4 * sizeof(short)))) short bf16_vec;
+        bf16_vec b_vec, a_vec;
+        
+        // Reinterpret the pointers
+        short* b_short = reinterpret_cast<short*>(const_cast<__hip_bfloat16*>(b));
+        short* a_short = reinterpret_cast<short*>(const_cast<__hip_bfloat16*>(a));
+        
+        // Copy the data
+        for (int i = 0; i < 4; ++i) {
+            b_vec[i] = b_short[i];
+            a_vec[i] = a_short[i];
+        }
+        
+        // Call the intrinsic and store the result directly to c
+        *c = __builtin_amdgcn_mfma_f32_16x16x16bf16_1k(b_vec, a_vec, *c, 0, 0, 0);
+    }
+};
 
 // ref to bitblas/tl/mfma_macro_generator.py::kPack
 template <int M, int N, int K, int num_warp_m, int num_warp_n, bool TransposeA,
@@ -167,11 +209,12 @@ public:
       for (int kp = 0; kp < kPack; kp++) {
         for (int i = 0; i < warp_rows; ++i) {
           for (int j = 0; j < warp_cols; ++j) {
-            *(((float32x4 *)C_local) + ((i * warp_cols) + j)) =
-                __builtin_amdgcn_mfma_f32_16x16x16f16(
-                    *(((float16x4 *)B_local) + j * kPack + kp),
-                    *(((float16x4 *)A_local) + i * kPack + kp),
-                    *(((float32x4 *)C_local) + ((i * warp_cols) + j)), 0, 0, 0);
+            auto acc_ptr = ((float32x4 *)C_local) + ((i * warp_cols) + j);
+            auto b_ptr = ((B_type *)B_local) + (j * kPack + kp) * 4;
+            auto a_ptr = ((A_type *)A_local) + (i * kPack + kp) * 4;
+            
+            // Use the trait to select the correct MFMA instruction, either fp16 or bf16 currently
+            MfmaTraits<A_type>::mfma_op(b_ptr, a_ptr, acc_ptr);
           }
         }
       }
@@ -223,12 +266,12 @@ public:
       for (int kp = 0; kp < kPack; kp++) {
         for (int i = 0; i < warp_rows; ++i) {
           for (int j = 0; j < warp_cols; ++j) {
-            *(((float32x4 *)C_local) + ((i * warp_cols) + j)) =
-                __builtin_amdgcn_mfma_f32_16x16x16f16(
-                    *(((float16x4 *)B_local) + j * kPack + kp),
-                    *(((float16x4 *)A_local) + ki * warp_rows * kPack +
-                      i * kPack + kp),
-                    *(((float32x4 *)C_local) + ((i * warp_cols) + j)), 0, 0, 0);
+            auto acc_ptr = ((float32x4 *)C_local) + ((i * warp_cols) + j);
+            auto b_ptr = ((B_type *)B_local) + (j * kPack + kp) * 4;
+            auto a_ptr = ((A_type *)A_local) + (ki * warp_rows * kPack + i * kPack + kp) * 4;
+            
+            // Use the trait to select the correct MFMA instruction, either fp16 or bf16 currently
+            MfmaTraits<A_type>::mfma_op(b_ptr, a_ptr, acc_ptr);
           }
         }
       }

--- a/src/tl_templates/hip/gemm.h
+++ b/src/tl_templates/hip/gemm.h
@@ -8,41 +8,37 @@
 namespace tl {
 
 // Trait to determine the MFMA instruction to use based on data type
-template <typename T>
-struct MfmaTraits;
+template <typename T> struct MfmaTraits;
 
 // Specialization for half/float16
-template <>
-struct MfmaTraits<half> {
-    template <typename AccType>
-    static TL_DEVICE void mfma_op(
-        const half* b, const half* a, AccType* c) {
-        *c = __builtin_amdgcn_mfma_f32_16x16x16f16(
-            *((float16x4*)b), *((float16x4*)a), *c, 0, 0, 0);
-    }
+template <> struct MfmaTraits<half> {
+  template <typename AccType>
+  static TL_DEVICE void mfma_op(const half *b, const half *a, AccType *c) {
+    *c = __builtin_amdgcn_mfma_f32_16x16x16f16(*((float16x4 *)b),
+                                               *((float16x4 *)a), *c, 0, 0, 0);
+  }
 };
 
 // Specialization for __hip_bfloat16
-template <>
-struct MfmaTraits<__hip_bfloat16> {
-    template <typename AccType>
-    static TL_DEVICE void mfma_op(
-        const __hip_bfloat16* b, const __hip_bfloat16* a, AccType* c) {
-        bfloat16x4_vec b_vec, a_vec;
-        
-        // Reinterpret the pointers
-        short* b_short = reinterpret_cast<short*>(const_cast<__hip_bfloat16*>(b));
-        short* a_short = reinterpret_cast<short*>(const_cast<__hip_bfloat16*>(a));
-        
-        // Copy the data
-        for (int i = 0; i < 4; ++i) {
-            b_vec[i] = b_short[i];
-            a_vec[i] = a_short[i];
-        }
-        
-        // Call the intrinsic and store the result directly to c
-        *c = __builtin_amdgcn_mfma_f32_16x16x16bf16_1k(b_vec, a_vec, *c, 0, 0, 0);
+template <> struct MfmaTraits<__hip_bfloat16> {
+  template <typename AccType>
+  static TL_DEVICE void mfma_op(const __hip_bfloat16 *b,
+                                const __hip_bfloat16 *a, AccType *c) {
+    bfloat16x4_vec b_vec, a_vec;
+
+    // Reinterpret the pointers
+    short *b_short = reinterpret_cast<short *>(const_cast<__hip_bfloat16 *>(b));
+    short *a_short = reinterpret_cast<short *>(const_cast<__hip_bfloat16 *>(a));
+
+    // Copy the data
+    for (int i = 0; i < 4; ++i) {
+      b_vec[i] = b_short[i];
+      a_vec[i] = a_short[i];
     }
+
+    // Call the intrinsic and store the result directly to c
+    *c = __builtin_amdgcn_mfma_f32_16x16x16bf16_1k(b_vec, a_vec, *c, 0, 0, 0);
+  }
 };
 
 // ref to bitblas/tl/mfma_macro_generator.py::kPack
@@ -209,8 +205,9 @@ public:
             auto acc_ptr = ((float32x4 *)C_local) + ((i * warp_cols) + j);
             auto b_ptr = ((B_type *)B_local) + (j * kPack + kp) * 4;
             auto a_ptr = ((A_type *)A_local) + (i * kPack + kp) * 4;
-            
-            // Use the trait to select the correct MFMA instruction, either fp16 or bf16 currently
+
+            // Use the trait to select the correct MFMA instruction, either fp16
+            // or bf16 currently
             MfmaTraits<A_type>::mfma_op(b_ptr, a_ptr, acc_ptr);
           }
         }
@@ -265,9 +262,11 @@ public:
           for (int j = 0; j < warp_cols; ++j) {
             auto acc_ptr = ((float32x4 *)C_local) + ((i * warp_cols) + j);
             auto b_ptr = ((B_type *)B_local) + (j * kPack + kp) * 4;
-            auto a_ptr = ((A_type *)A_local) + (ki * warp_rows * kPack + i * kPack + kp) * 4;
-            
-            // Use the trait to select the correct MFMA instruction, either fp16 or bf16 currently
+            auto a_ptr = ((A_type *)A_local) +
+                         (ki * warp_rows * kPack + i * kPack + kp) * 4;
+
+            // Use the trait to select the correct MFMA instruction, either fp16
+            // or bf16 currently
             MfmaTraits<A_type>::mfma_op(b_ptr, a_ptr, acc_ptr);
           }
         }

--- a/testing/python/amd/test_tilelang_test_amd.py
+++ b/testing/python/amd/test_tilelang_test_amd.py
@@ -107,6 +107,21 @@ def test_gemm_f16f32f32_nt():
     run_gemm(1024, 1024, 1024, True, False, "float16", "float32", "float32", 128, 128, 32)
     run_gemm(1024, 1024, 1024, False, True, "float16", "float32", "float32", 128, 128, 32, k_pack=2)
 
+@tilelang.testing.requires_rocm
+def test_gemm_bf16f32f32_nt():
+    run_gemm(1024, 1024, 1024, False, False, "bfloat16", "float32", "float32", 128, 128, 32)
+    run_gemm(1024, 1024, 1024, False, True, "bfloat16", "float32", "float32", 128, 128, 32)
+    run_gemm(1024, 1024, 1024, True, True, "bfloat16", "float32", "float32", 128, 128, 32)
+    run_gemm(1024, 1024, 1024, True, False, "bfloat16", "float32", "float32", 128, 128, 32)
+    run_gemm(1024, 1024, 1024, False, True, "bfloat16", "float32", "float32", 128, 128, 32, k_pack=2)
+
+@tilelang.testing.requires_rocm
+def test_gemm_bf16bf16f32():
+    run_gemm(1024, 1024, 1024, False, False, "bfloat16", "bfloat16", "float32", 128, 128, 32)
+    run_gemm(1024, 1024, 1024, False, True, "bfloat16", "bfloat16", "float32", 128, 128, 32)
+    run_gemm(1024, 1024, 1024, True, True, "bfloat16", "bfloat16", "float32", 128, 128, 32)
+    run_gemm(1024, 1024, 1024, True, False, "bfloat16", "bfloat16", "float32", 128, 128, 32)
+    run_gemm(1024, 1024, 1024, False, True, "bfloat16", "bfloat16", "float32", 128, 128, 32, k_pack=2)
 
 def matmul_rs(
     M,
@@ -213,6 +228,19 @@ def test_gemm_rs_f16f32f32_nt():
     run_gemm_rs(1024, 1024, 1024, True, True, "float16", "float32", "float32", 128, 128, 32)
     run_gemm_rs(1024, 1024, 1024, True, False, "float16", "float32", "float32", 128, 128, 32)
 
+@tilelang.testing.requires_rocm
+def test_gemm_rs_bf16f32f32_nt():
+    run_gemm_rs(1024, 1024, 1024, False, False, "bfloat16", "float32", "float32", 128, 128, 32)
+    run_gemm_rs(1024, 1024, 1024, False, True, "bfloat16", "float32", "float32", 128, 128, 32)
+    run_gemm_rs(1024, 1024, 1024, True, True, "bfloat16", "float32", "float32", 128, 128, 32)
+    run_gemm_rs(1024, 1024, 1024, True, False, "bfloat16", "float32", "float32", 128, 128, 32)
+
+@tilelang.testing.requires_rocm
+def test_gemm_rs_bf16bf16f32_nt():
+    run_gemm_rs(1024, 1024, 1024, False, False, "bfloat16", "bfloat16", "float32", 128, 128, 32)
+    run_gemm_rs(1024, 1024, 1024, False, True, "bfloat16", "bfloat16", "float32", 128, 128, 32)
+    run_gemm_rs(1024, 1024, 1024, True, True, "bfloat16", "bfloat16", "float32", 128, 128, 32)
+    run_gemm_rs(1024, 1024, 1024, True, False, "bfloat16", "bfloat16", "float32", 128, 128, 32)
 
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/amd/test_tilelang_test_amd.py
+++ b/testing/python/amd/test_tilelang_test_amd.py
@@ -107,13 +107,16 @@ def test_gemm_f16f32f32_nt():
     run_gemm(1024, 1024, 1024, True, False, "float16", "float32", "float32", 128, 128, 32)
     run_gemm(1024, 1024, 1024, False, True, "float16", "float32", "float32", 128, 128, 32, k_pack=2)
 
+
 @tilelang.testing.requires_rocm
 def test_gemm_bf16f32f32_nt():
     run_gemm(1024, 1024, 1024, False, False, "bfloat16", "float32", "float32", 128, 128, 32)
     run_gemm(1024, 1024, 1024, False, True, "bfloat16", "float32", "float32", 128, 128, 32)
     run_gemm(1024, 1024, 1024, True, True, "bfloat16", "float32", "float32", 128, 128, 32)
     run_gemm(1024, 1024, 1024, True, False, "bfloat16", "float32", "float32", 128, 128, 32)
-    run_gemm(1024, 1024, 1024, False, True, "bfloat16", "float32", "float32", 128, 128, 32, k_pack=2)
+    run_gemm(
+        1024, 1024, 1024, False, True, "bfloat16", "float32", "float32", 128, 128, 32, k_pack=2)
+
 
 @tilelang.testing.requires_rocm
 def test_gemm_bf16bf16f32():
@@ -121,7 +124,9 @@ def test_gemm_bf16bf16f32():
     run_gemm(1024, 1024, 1024, False, True, "bfloat16", "bfloat16", "float32", 128, 128, 32)
     run_gemm(1024, 1024, 1024, True, True, "bfloat16", "bfloat16", "float32", 128, 128, 32)
     run_gemm(1024, 1024, 1024, True, False, "bfloat16", "bfloat16", "float32", 128, 128, 32)
-    run_gemm(1024, 1024, 1024, False, True, "bfloat16", "bfloat16", "float32", 128, 128, 32, k_pack=2)
+    run_gemm(
+        1024, 1024, 1024, False, True, "bfloat16", "bfloat16", "float32", 128, 128, 32, k_pack=2)
+
 
 def matmul_rs(
     M,
@@ -228,6 +233,7 @@ def test_gemm_rs_f16f32f32_nt():
     run_gemm_rs(1024, 1024, 1024, True, True, "float16", "float32", "float32", 128, 128, 32)
     run_gemm_rs(1024, 1024, 1024, True, False, "float16", "float32", "float32", 128, 128, 32)
 
+
 @tilelang.testing.requires_rocm
 def test_gemm_rs_bf16f32f32_nt():
     run_gemm_rs(1024, 1024, 1024, False, False, "bfloat16", "float32", "float32", 128, 128, 32)
@@ -235,12 +241,14 @@ def test_gemm_rs_bf16f32f32_nt():
     run_gemm_rs(1024, 1024, 1024, True, True, "bfloat16", "float32", "float32", 128, 128, 32)
     run_gemm_rs(1024, 1024, 1024, True, False, "bfloat16", "float32", "float32", 128, 128, 32)
 
+
 @tilelang.testing.requires_rocm
 def test_gemm_rs_bf16bf16f32_nt():
     run_gemm_rs(1024, 1024, 1024, False, False, "bfloat16", "bfloat16", "float32", 128, 128, 32)
     run_gemm_rs(1024, 1024, 1024, False, True, "bfloat16", "bfloat16", "float32", 128, 128, 32)
     run_gemm_rs(1024, 1024, 1024, True, True, "bfloat16", "bfloat16", "float32", 128, 128, 32)
     run_gemm_rs(1024, 1024, 1024, True, False, "bfloat16", "bfloat16", "float32", 128, 128, 32)
+
 
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
This adds preliminary bfloat16 for AMD, tested on a MI250. 
We generalize the `tl:gemm_ss` operation for HIP to work for both fp16 and bf16.

This has only been tested on a version of the `examples/quickstart.py` script:
```python
# Copyright (c) Tile-AI Corporation.
# Licensed under the MIT License.
import tilelang
import tilelang.language as T
# `make_mma_swizzle_layout` is a python defined layout function
# specifically designed for MMA operations
# which ensures the consistency with the nvidia CUTLASS Library.
# to avoid bank conflicts and maximize the performance.
from tilelang.intrinsics import (
    make_mma_swizzle_layout as make_swizzle_layout,)  # noqa: F401

import torch

tl_dtype = "bfloat16"
torch_dtype = torch.bfloat16
# tl_dtype = "float16"
# torch_dtype = torch.float16

def matmul(M, N, K, block_M, block_N, block_K, dtype=tl_dtype, accum_dtype="float"):
    # add decorator @tilelang.jit if you want to return a torch function
    @T.prim_func
    def main(
            A: T.Tensor((M, K), dtype),
            B: T.Tensor((K, N), dtype),
            C: T.Tensor((M, N), dtype),
    ):
        # Initialize Kernel Context
        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
            A_shared = T.alloc_shared((block_M, block_K), dtype)
            B_shared = T.alloc_shared((block_K, block_N), dtype)
            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)

            # Apply layout optimizations or define your own layout (Optional)
            # If not specified, we will deduce the layout automatically
            # T.annotate_layout({
            #     A_shared: make_swizzle_layout(A_shared),
            #     B_shared: make_swizzle_layout(B_shared),
            # })

            # Enable rasterization for better L2 cache locality (Optional)
            # T.use_swizzle(panel_size=10, enable=True)

            # Clear local accumulation
            T.clear(C_local)

            for ko in T.Pipelined(T.ceildiv(K, block_K), num_stages=3):
                # Copy tile of A
                # This is a sugar syntax for parallelized copy
                # for i, k in T.Parallel(M, block_K):
                #     A_shared[i, k] = A[by * block_M + i, ko * block_K + k]
                T.copy(A[by * block_M, ko * block_K], A_shared)

                # Copy tile of B
                T.copy(B[ko * block_K, bx * block_N], B_shared)

                # Perform a tile-level GEMM on the shared buffers
                # Currently we dispatch to the cute/hip on Nvidia/AMD GPUs
                T.gemm(A_shared, B_shared, C_local)

            # Copy result back to global memory
            T.copy(C_local, C[by * block_M, bx * block_N])

    return main


# 1. Define the kernel (matmul) and compile/lower it into an executable module
func = matmul(1024, 1024, 1024, 128, 128, 32)

# 2. Compile the kernel into a torch function
# out_idx specifies the index of the output buffer in the argument list
# if out_idx is specified, the tensor will be created during runtime
# target currently can be "cuda" or "rocm" or "cpu".
jit_kernel = tilelang.compile(func, out_idx=[2], target="hip", execution_backend="cython")
# jit_kernel = tilelang.compile(func, out_idx=[2], target="cuda", execution_backend="dlpack")

# 3. Test the kernel in Python with PyTorch data

# Create random input tensors on the GPU
a = torch.randn(1024, 1024, device="cuda", dtype=torch_dtype)
b = torch.randn(1024, 1024, device="cuda", dtype=torch_dtype)

# Run the kernel through the Profiler
c = jit_kernel(a, b)

print(c)
# Reference multiplication using PyTorch
ref_c = a @ b

# Validate correctness
torch.testing.assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
print("Kernel output matches PyTorch reference.")

# 4. Retrieve and inspect the generated CUDA source (optional)
# cuda_source = jit_kernel.get_kernel_source()
# print("Generated CUDA kernel:\n", cuda_source)

# 5.Profile latency with kernel
profiler = jit_kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)

latency = profiler.do_bench()

print(f"Latency: {latency} ms")

```

At large values, the bf16 kernel does not match the torch implementation. I'm not sure if this is due to a mismatch in the `torch.bfloat16` and `__hip_bfloat16` implementations.

**Limits:**
This PR is missing tests and has not expanded the bf16 support beyond the quickstart example.