### PR TITLE
[Enhancement] Report Error Body in ParallelOp Layout Inference

### DIFF
--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -243,6 +243,8 @@ LayoutMap ParallelOp::InferLayout(const LayoutInferArgs &T, InferLevel level) {
         if (src_layout && dst_layout) {
           ICHECK(src_layout->IsEqual(dst_layout, true))
               << "Layout may conflict with ParallelOp for buffer " << buffer
+              << "\nError body begin:\n"
+              << GetRoot()->body << "\nError body end"
               << "\nLHS = " << src_layout->DebugOutput()
               << "\nRHS = " << dst_layout->DebugOutput()
               << "\nYou may need to use a shared memory to transform the "


### PR DESCRIPTION
Added detailed error messages in the InferLayout method to provide better context when layout conflicts occur. This includes the body of the operation that triggered the error, aiding in debugging and layout validation.