### PR TITLE
[Bugfix] Support `T.Parallel` with local register assignment 

### DIFF
--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -532,16 +532,36 @@ private:
   Stmt VisitStmt_(const ForNode *op) final {
     For for_node = Downcast<For>(IRMutatorWithAnalyzer::VisitStmt_(op));
     if (result_.for_map.count(GetRef<For>(op))) {
-      auto loop_layout = result_.for_map[GetRef<For>(op)];
-      if (!skip_thread_partition_) {
-        // If none thread bindings are provided, partition the loop
+      auto root = GetRef<For>(op);
+      // This check is a workaround to support T.Parallel for local buffers.
+      // For example:
+      //   for i in T.Parallel(1024):
+      //     A_local[i] = A_global[i]
+      // Here, A_local is a register-local buffer held independently by each thread,
+      // so explicit thread binding is not required.
+      //
+      // We use PostOrderVisit to detect whether the buffer store targets a "local" buffer,
+      // which indicates register usage and justifies skipping thread binding.
+      bool is_register_store = false;
+      PostOrderVisit(root, [&](const ObjectRef &obj) {
+          if (const auto *store = obj.as<BufferStoreNode>()) {
+            if (store->buffer.scope() == "local") {
+              is_register_store = true;
+            }
+          }
+      });
+
+      bool parallel_loop = !is_register_store && !skip_thread_partition_;
+      if (parallel_loop) {
+        auto loop_layout = result_.for_map[root];
         for_node =
             PartitionLoop(for_node, thread_var_->var, analyzer_, loop_layout);
       }
+      // If none thread bindings are provided, partition the loop
       for_node = VectorizeLoop(for_node);
 
-      if (result_.predicate_map.count(GetRef<For>(op))) {
-        return IfThenElse(result_.predicate_map[GetRef<For>(op)], for_node);
+      if (result_.predicate_map.count(root) && parallel_loop) {
+        return IfThenElse(result_.predicate_map[root], for_node);
       } else {
         return for_node;
       }

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -537,18 +537,19 @@ private:
       // For example:
       //   for i in T.Parallel(1024):
       //     A_local[i] = A_global[i]
-      // Here, A_local is a register-local buffer held independently by each thread,
-      // so explicit thread binding is not required.
+      // Here, A_local is a register-local buffer held independently by each
+      // thread, so explicit thread binding is not required.
       //
-      // We use PostOrderVisit to detect whether the buffer store targets a "local" buffer,
-      // which indicates register usage and justifies skipping thread binding.
+      // We use PostOrderVisit to detect whether the buffer store targets a
+      // "local" buffer, which indicates register usage and justifies skipping
+      // thread binding.
       bool is_register_store = false;
       PostOrderVisit(root, [&](const ObjectRef &obj) {
-          if (const auto *store = obj.as<BufferStoreNode>()) {
-            if (store->buffer.scope() == "local") {
-              is_register_store = true;
-            }
+        if (const auto *store = obj.as<BufferStoreNode>()) {
+          if (store->buffer.scope() == "local") {
+            is_register_store = true;
           }
+        }
       });
 
       bool parallel_loop = !is_register_store && !skip_thread_partition_;

--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -53,8 +53,6 @@ public:
 
   int Plan(const For &node) {
     this->operator()(node);
-    // Always Enable vectorization
-    // if (!has_nonlocal_memory_access_) return 1;
     return vector_size_;
   }
 
@@ -127,14 +125,12 @@ private:
     }
     // so we should disable this GCD optimization
     max_vector_size = arith::ZeroAwareGCD(max_vector_size, extent_ptr->value);
-
     auto last_dim = buffer->shape.back();
     auto mod_set = analyzer_.modular_set(last_dim);
     // when dynamic shape like [m, k]: coeff=1, base=0, GCD will block
     // conditionally tail vectorize
     if (buffer->shape.back().as<IntImmNode>()) {
       max_vector_size = arith::ZeroAwareGCD(max_vector_size, mod_set->coeff);
-
       auto gcd_base = arith::ZeroAwareGCD(max_vector_size, mod_set->base);
       // If gcd_base is equal to the last dimension,
       // we should analyze the second-to-last dimension
@@ -142,7 +138,6 @@ private:
       if (gcd_base < Downcast<IntImm>(last_dim)->value) {
         max_vector_size = gcd_base;
       }
-
       vector_size_ = arith::ZeroAwareGCD(max_vector_size, vector_size_);
 
       PrimExpr elem_offset = 0;
@@ -243,12 +238,11 @@ bool IndiceCanVectorize(PrimExpr expr, Var var, PrimExpr iter_var_size,
     return false;
   Var v0("v0"), v1("v1");
   analyzer->Bind(v0, Range(0, target_vectorized_size));
-  analyzer->Bind(v1, Range(0, FloorDiv(iter_var_size, target_vectorized_size)));
+  analyzer->Bind(v1, Range(0, analyzer->Simplify(FloorDiv(iter_var_size, target_vectorized_size))));
   PrimExpr expr_transformed = analyzer->Simplify(
       Substitute(expr, {{var, v0 + v1 * target_vectorized_size}}));
-
   Vectorizer vectorizer(v0, IntImm(v0->dtype, target_vectorized_size));
-  PrimExpr expr_vectorized = vectorizer.VisitExpr(expr_transformed);
+  PrimExpr expr_vectorized = analyzer->Simplify(vectorizer.VisitExpr(expr_transformed));
   auto ramp_node = expr_vectorized.as<RampNode>();
   if (!ramp_node) {
     // Broadcast value

--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -238,11 +238,13 @@ bool IndiceCanVectorize(PrimExpr expr, Var var, PrimExpr iter_var_size,
     return false;
   Var v0("v0"), v1("v1");
   analyzer->Bind(v0, Range(0, target_vectorized_size));
-  analyzer->Bind(v1, Range(0, analyzer->Simplify(FloorDiv(iter_var_size, target_vectorized_size))));
+  analyzer->Bind(v1, Range(0, analyzer->Simplify(FloorDiv(
+                                  iter_var_size, target_vectorized_size))));
   PrimExpr expr_transformed = analyzer->Simplify(
       Substitute(expr, {{var, v0 + v1 * target_vectorized_size}}));
   Vectorizer vectorizer(v0, IntImm(v0->dtype, target_vectorized_size));
-  PrimExpr expr_vectorized = analyzer->Simplify(vectorizer.VisitExpr(expr_transformed));
+  PrimExpr expr_vectorized =
+      analyzer->Simplify(vectorizer.VisitExpr(expr_transformed));
   auto ramp_node = expr_vectorized.as<RampNode>();
   if (!ramp_node) {
     // Broadcast value

--- a/tilelang/engine/param.py
+++ b/tilelang/engine/param.py
@@ -77,9 +77,7 @@ class KernelParam:
         dtype_str = str(self.dtype)
         if dtype_str.startswith("torch."):
             dtype_str = dtype_str[6:]
-        if dtype_str.startswith("uint"):
-            return True
-        return False
+        return dtype_str.startswith("uint")
 
     def is_float8(self) -> bool:
         """
@@ -91,9 +89,7 @@ class KernelParam:
         dtype_str = str(self.dtype)
         if dtype_str.startswith("torch."):
             dtype_str = dtype_str[6:]
-        if dtype_str.startswith("float8"):
-            return True
-        return False
+        return dtype_str.startswith("float8")
 
     def is_boolean(self) -> bool:
         """

--- a/tilelang/engine/param.py
+++ b/tilelang/engine/param.py
@@ -74,7 +74,12 @@ class KernelParam:
         Returns:
             bool: True if parameter is an unsigned integer type, False otherwise
         """
-        return str(self.dtype).removeprefix("torch.").startswith("uint")
+        dtype_str = str(self.dtype)
+        if dtype_str.startswith("torch."):
+            dtype_str = dtype_str[6:]
+        if dtype_str.startswith("uint"):
+            return True
+        return False
 
     def is_float8(self) -> bool:
         """
@@ -83,7 +88,12 @@ class KernelParam:
         Returns:
             bool: True if parameter is a float8 type, False otherwise
         """
-        return str(self.dtype).removeprefix("torch.").startswith("float8")
+        dtype_str = str(self.dtype)
+        if dtype_str.startswith("torch."):
+            dtype_str = dtype_str[6:]
+        if dtype_str.startswith("float8"):
+            return True
+        return False
 
     def is_boolean(self) -> bool:
         """
@@ -92,7 +102,8 @@ class KernelParam:
         Returns:
             bool: True if parameter is a boolean type, False otherwise
         """
-        return str(self.dtype).removeprefix("torch.").startswith("bool")
+        dtype_str = str(self.dtype)
+        return dtype_str[6:] if dtype_str.startswith("torch.") else dtype_str.startswith("bool")
 
 
 @dataclass


### PR DESCRIPTION
This pull request includes several changes to improve the layout inference and loop vectorization processes, as well as updates to type-checking methods in the `tilelang` engine. The most important changes are detailed below:

### Layout Inference Enhancements:
* Added a check to detect whether a buffer store targets a "local" buffer, which justifies skipping thread binding for register-local buffers in parallel loops. (`src/transform/layout_inference.cc`)

### Loop Vectorization Improvements:
* Removed unnecessary comments and simplified logic in the `Plan` method to always enable vectorization. (`src/transform/loop_vectorize.cc`)
* Simplified the binding and transformation of expressions in the `IndiceCanVectorize` function to improve readability and maintainability. (`src/transform/loop_vectorize.cc`)

### Type-Checking Method Updates:
* Refactored the `is_unsigned`, `is_float8`, and `is_boolean` methods to handle type strings more consistently and avoid using the `removeprefix` method. (`tilelang/engine/param.py`) [[1]](diffhunk://#diff-c1fc6e0b4fb889c28f5247206dbdd5fab78f5f7165a7deb24bf5113285c298a3L77-R80) [[2]](diffhunk://#diff-c1fc6e0b4fb889c28f5247206dbdd5fab78f5f7165a7deb24bf5113285c298a3L86-R92) [[3]](diffhunk://#diff-c1fc6e0b4fb889c28f5247206dbdd5fab78f5f7165a7deb24bf5113285c298a3L95-R102)