### PR TITLE
[Documentation] Fix Installation Documentation

### DIFF
--- a/docs/get_started/Installation.md
+++ b/docs/get_started/Installation.md
@@ -50,7 +50,7 @@ To build and install **tile-lang** directly from source, follow these steps. Thi
 
 ```bash
 apt-get update
-apt-get install -y python3 python3-dev python3-setuptools gcc libtinfo-dev zlib1g-dev build-essential cmake libedit-dev libxml2-dev
+apt-get install -y python3 python3-dev python3-setuptools gcc zlib1g-dev build-essential cmake libedit-dev
 ```
 
 After installing the prerequisites, you can clone the **tile-lang** repository and install it using pip:


### PR DESCRIPTION
# Fix Docker Build

There are some typos in the documentation that make the provided build instructions incorrect.

Changes:
* Removed sudo as the provided image does not have sudo
* Changed tileLang to tilelang

