### PR TITLE
[Enhancement] Remove redundant recursive rewrite rule for FloorDiv in RewriteSimplifier

### DIFF
--- a/src/transform/common/loop_fusion_utils.h
+++ b/src/transform/common/loop_fusion_utils.h
@@ -114,7 +114,6 @@ private:
     if (detector.HasFragmentAccess()) {
       return IRMutatorWithAnalyzer::VisitStmt_(op);
     }
-
     while (true) {
       if (current->kind != ForKind::kParallel)
         break;
@@ -132,6 +131,20 @@ private:
     // If only one loop found or loop chain size is 1, no fusion needed.
     if (loop_chain.size() <= 1) {
       return IRMutatorWithAnalyzer::VisitStmt_(op);
+    }
+
+    // If one of the loop has extent which is not 2^n, we do not fuse
+    for (auto l : loop_chain) {
+      PrimExpr extent = l->extent;
+      // If extent is not a constant integer, we cannot determine if it's power of 2
+      if (!extent.as<IntImmNode>()) {
+        return IRMutatorWithAnalyzer::VisitStmt_(op);
+      }
+      int64_t value = extent.as<IntImmNode>()->value;
+      // Check if value is power of 2: value > 0 and only has one bit set
+      if (value <= 0 || (value & (value - 1)) != 0) {
+        return IRMutatorWithAnalyzer::VisitStmt_(op);
+      }
     }
 
     // At this point we have multiple nested parallel loops starting at zero

--- a/src/transform/common/loop_fusion_utils.h
+++ b/src/transform/common/loop_fusion_utils.h
@@ -136,7 +136,8 @@ private:
     // If one of the loop has extent which is not 2^n, we do not fuse
     for (auto l : loop_chain) {
       PrimExpr extent = l->extent;
-      // If extent is not a constant integer, we cannot determine if it's power of 2
+      // If extent is not a constant integer, we cannot determine if it's power
+      // of 2
       if (!extent.as<IntImmNode>()) {
         return IRMutatorWithAnalyzer::VisitStmt_(op);
       }

--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -244,11 +244,10 @@ bool IndiceCanVectorize(PrimExpr expr, Var var, PrimExpr iter_var_size,
   PrimExpr expr_simplified = analyzer->Simplify(expr_transformed);
 
   Vectorizer vectorizer(v0, IntImm(v0->dtype, target_vectorized_size));
-  PrimExpr expr_vectorized = vectorizer.VisitExpr(expr_transformed);
+  PrimExpr expr_vectorized = analyzer->Simplify(vectorizer.VisitExpr(expr_transformed));
 
   auto ramp_node = expr_vectorized.as<RampNode>();
   if (!ramp_node) {
-    expr_vectorized = analyzer->Simplify(expr_vectorized);
     // Broadcast value
     if (expr_vectorized.dtype().lanes() == 1)
       return true;

--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -244,7 +244,8 @@ bool IndiceCanVectorize(PrimExpr expr, Var var, PrimExpr iter_var_size,
   PrimExpr expr_simplified = analyzer->Simplify(expr_transformed);
 
   Vectorizer vectorizer(v0, IntImm(v0->dtype, target_vectorized_size));
-  PrimExpr expr_vectorized = analyzer->Simplify(vectorizer.VisitExpr(expr_transformed));
+  PrimExpr expr_vectorized =
+      analyzer->Simplify(vectorizer.VisitExpr(expr_transformed));
 
   auto ramp_node = expr_vectorized.as<RampNode>();
   if (!ramp_node) {


### PR DESCRIPTION
This pull request includes updates to a submodule, enhancements to loop fusion logic, and improvements to vectorization handling. The most significant changes focus on ensuring correctness in loop fusion by checking loop extents and optimizing vectorization by simplifying expressions earlier in the process.

### Submodule Update:
* Updated the `tvm` submodule to a new commit (`b56a1df6f3e41c6b6da019786b88d73ee9a0d378`) to incorporate the latest changes.

### Loop Fusion Enhancements:
* In `src/transform/common/loop_fusion_utils.h`, added logic to check if the extent of loops in the fusion chain is a power of 2. If the extent is not a constant integer or not a power of 2, the fusion process is skipped to ensure correctness.

### Vectorization Improvements:
* In `src/transform/loop_vectorize.cc`, moved the simplification of vectorized expressions earlier in the process to optimize and streamline the handling of vectorized code.