### PR TITLE
[Refactor] Phaseout python dependency `attrs` and `decorator`

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,6 @@ cmake>=3.26
 cffi
 cpplint
 Cython
-decorator
 docutils
 dtlib
 numpy>=1.23.5
@@ -17,7 +16,6 @@ PyYAML
 tqdm>=4.62.3
 typing_extensions>=4.10.0
 requests
-attrs
 cloudpickle
 ml_dtypes
 psutil

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,7 +6,6 @@ cmake>=3.26
 cffi
 cpplint
 Cython
-decorator
 docutils
 dtlib
 numpy>=1.23.5
@@ -17,7 +16,6 @@ PyYAML
 tqdm>=4.62.3
 typing_extensions>=4.10.0
 requests
-attrs
 cloudpickle
 ml_dtypes
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 # runtime requirements
 Cython
-decorator
 numpy>=1.23.5
 tqdm>=4.62.3
 typing_extensions>=4.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ decorator
 numpy>=1.23.5
 tqdm>=4.62.3
 typing_extensions>=4.10.0
-attrs
 cloudpickle
 ml_dtypes
 psutil


### PR DESCRIPTION
This pull request updates a submodule and removes unused dependencies from the development and testing requirements files. Below is a breakdown of the most important changes:

### Submodule Update:
* Updated the `tvm` submodule to a new commit (`17ab6489dfd6b219db6f72cf5bec5e2c1c5c8690`) from the previous one (`b56a1df6f3e41c6b6da019786b88d73ee9a0d378`).

### Dependency Cleanup:
* Removed the `decorator` and `attrs` packages from the `requirements-dev.txt` file, as they are no longer needed. [[1]](diffhunk://#diff-2b4945591edfeaa4cf4d3f155e66d4b43d1bda7a55d881d5cf3107f1b05abbbcL9) [[2]](diffhunk://#diff-2b4945591edfeaa4cf4d3f155e66d4b43d1bda7a55d881d5cf3107f1b05abbbcL20)
* Removed the `decorator` and `attrs` packages from the `requirements-test.txt` file, aligning the test dependencies with the updated requirements. [[1]](diffhunk://#diff-685da804fbcac569d75387e475e57d1de687a54c6c41b3aa4057694cfb5abc4bL9) [[2]](diffhunk://#diff-685da804fbcac569d75387e475e57d1de687a54c6c41b3aa4057694cfb5abc4bL20)