### PR TITLE
[Enhancement] Support to find Cython path more automatically

### DIFF
--- a/tilelang/jit/adapter/cython/adapter.py
+++ b/tilelang/jit/adapter/cython/adapter.py
@@ -25,6 +25,7 @@ import os
 import fcntl
 from pathlib import Path
 import logging
+import site
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +40,23 @@ def get_cython_compiler() -> Optional[str]:
     """
 
     cython_names = ["cython", "cython3"]
-    dirs_in_path = os.get_exec_path()
+    
+    # Check system PATH
+    dirs_in_path = list(os.get_exec_path())
+    
+    # Add user site-packages bin directory
+    user_base = site.getuserbase()
+    if user_base:
+        user_bin = os.path.join(user_base, "bin")
+        if os.path.exists(user_bin):
+            dirs_in_path = [user_bin] + dirs_in_path
+    
+    # If in a virtual environment, add its bin directory
+    if sys.prefix != sys.base_prefix:
+        venv_bin = os.path.join(sys.prefix, "bin")
+        if os.path.exists(venv_bin):
+            dirs_in_path = [venv_bin] + dirs_in_path
+
     for cython_name in cython_names:
         for d in dirs_in_path:
             cython_path = os.path.join(d, cython_name)

--- a/tilelang/jit/adapter/cython/adapter.py
+++ b/tilelang/jit/adapter/cython/adapter.py
@@ -40,17 +40,17 @@ def get_cython_compiler() -> Optional[str]:
     """
 
     cython_names = ["cython", "cython3"]
-    
+
     # Check system PATH
     dirs_in_path = list(os.get_exec_path())
-    
+
     # Add user site-packages bin directory
     user_base = site.getuserbase()
     if user_base:
         user_bin = os.path.join(user_base, "bin")
         if os.path.exists(user_bin):
             dirs_in_path = [user_bin] + dirs_in_path
-    
+
     # If in a virtual environment, add its bin directory
     if sys.prefix != sys.base_prefix:
         venv_bin = os.path.join(sys.prefix, "bin")


### PR DESCRIPTION
Many users install Cython into their local site package or venv, without this, they have to use `export PATH=/path/to/Cython/` to contain Cython executable, we want to do this automatically as like `pip install Cython` will install the directory like `~/.local/bin`. 

The order will be `venv`, then `user site directory` then `system directory`, this is also a reasonable directory order to search.