### PR TITLE
[Layout] Enhance layout inference pass

### DIFF
--- a/src/op/elem.cc
+++ b/src/op/elem.cc
@@ -163,9 +163,13 @@ Stmt Copy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
   if (is_cpu_target) {
     vectorized_thread_loop = VectorizeLoop(fused_loop);
   } else {
-    par_op->InferLayout(
-        {T.target, T.thread_bounds, T.layout_map, T.buffer_remap},
-        InferLevel::kFree);
+    std::vector<InferLevel> levels = {InferLevel::kCommon, InferLevel::kStrict, InferLevel::kFree};
+    for (auto level : levels) {
+      par_op->InferLayout(
+          {T.target, T.thread_bounds, T.layout_map, T.buffer_remap},
+          level);
+    }
+
     auto thread_loop = PartitionLoop(par_op->GetRoot(), T.thread_var, analyzer,
                                      par_op->GetLoopLayout());
     vectorized_thread_loop = VectorizeLoop(thread_loop);

--- a/src/op/elem.cc
+++ b/src/op/elem.cc
@@ -163,11 +163,11 @@ Stmt Copy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
   if (is_cpu_target) {
     vectorized_thread_loop = VectorizeLoop(fused_loop);
   } else {
-    std::vector<InferLevel> levels = {InferLevel::kCommon, InferLevel::kStrict, InferLevel::kFree};
+    std::vector<InferLevel> levels = {InferLevel::kCommon, InferLevel::kStrict,
+                                      InferLevel::kFree};
     for (auto level : levels) {
       par_op->InferLayout(
-          {T.target, T.thread_bounds, T.layout_map, T.buffer_remap},
-          level);
+          {T.target, T.thread_bounds, T.layout_map, T.buffer_remap}, level);
     }
 
     auto thread_loop = PartitionLoop(par_op->GetRoot(), T.thread_var, analyzer,

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -122,6 +122,21 @@ bool ParallelOp::IsCommonAccessIndice(const Buffer &buffer) const {
   return StructuralEqual()(indice_map_[buffer], common_indice);
 }
 
+/*! \brief Infer the layout for parallel operations based on different inference levels
+ * 
+ * The inference level controls how aggressively we try to infer and optimize layouts:
+ * - kStrict (2): Most conservative level. Only allows explicitly defined layouts.
+ *                Returns empty layout map if loop_layout_ is not already defined.
+ *                Used when exact layout control is required.
+ * 
+ * - kCommon (1): Intermediate level between strict and free.
+ *                Allows common layout patterns while maintaining some constraints.
+ * 
+ * - kFree (0):   Most permissive level. Allows maximum optimization freedom.
+ *                Will attempt layout inference even without source buffers.
+ *                Can generate new layouts based on vectorization and thread bounds.
+ *                Used when maximum performance optimization is desired.
+ */
 LayoutMap ParallelOp::InferLayout(const LayoutInferArgs &T, InferLevel level) {
   if (loop_layout_.defined())
     return {};
@@ -163,6 +178,8 @@ LayoutMap ParallelOp::InferLayout(const LayoutInferArgs &T, InferLevel level) {
   };
   if (source_buffer.defined()) {
     loop_layout_ = compute_loop_layout_from_buffer(source_buffer);
+  } else if (read_source_buffer.defined()){
+    loop_layout_ = compute_loop_layout_from_buffer(read_source_buffer);
   } else if (level == InferLevel::kFree) {
     if (read_source_buffer.defined()) {
       loop_layout_ = compute_loop_layout_from_buffer(read_source_buffer);

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -122,20 +122,23 @@ bool ParallelOp::IsCommonAccessIndice(const Buffer &buffer) const {
   return StructuralEqual()(indice_map_[buffer], common_indice);
 }
 
-/*! \brief Infer the layout for parallel operations based on different inference levels
- * 
- * The inference level controls how aggressively we try to infer and optimize layouts:
- * - kStrict (2): Most conservative level. Only allows explicitly defined layouts.
- *                Returns empty layout map if loop_layout_ is not already defined.
+/*! \brief Infer the layout for parallel operations based on different inference
+ * levels
+ *
+ * The inference level controls how aggressively we try to infer and optimize
+ * layouts:
+ * - kStrict (2): Most conservative level. Only allows explicitly defined
+ * layouts. Returns empty layout map if loop_layout_ is not already defined.
  *                Used when exact layout control is required.
- * 
+ *
  * - kCommon (1): Intermediate level between strict and free.
- *                Allows common layout patterns while maintaining some constraints.
- * 
+ *                Allows common layout patterns while maintaining some
+ * constraints.
+ *
  * - kFree (0):   Most permissive level. Allows maximum optimization freedom.
  *                Will attempt layout inference even without source buffers.
- *                Can generate new layouts based on vectorization and thread bounds.
- *                Used when maximum performance optimization is desired.
+ *                Can generate new layouts based on vectorization and thread
+ * bounds. Used when maximum performance optimization is desired.
  */
 LayoutMap ParallelOp::InferLayout(const LayoutInferArgs &T, InferLevel level) {
   if (loop_layout_.defined())
@@ -178,7 +181,7 @@ LayoutMap ParallelOp::InferLayout(const LayoutInferArgs &T, InferLevel level) {
   };
   if (source_buffer.defined()) {
     loop_layout_ = compute_loop_layout_from_buffer(source_buffer);
-  } else if (read_source_buffer.defined()){
+  } else if (read_source_buffer.defined()) {
     loop_layout_ = compute_loop_layout_from_buffer(read_source_buffer);
   } else if (level == InferLevel::kFree) {
     if (read_source_buffer.defined()) {

--- a/tilelang/jit/adapter/wrapper.py
+++ b/tilelang/jit/adapter/wrapper.py
@@ -38,6 +38,7 @@ extern "C" const char* get_last_error() {{
 extern "C" int init() {{
     error_buf[0] = '\\0';
     {0}
+    return 0;
 }}
 """
 


### PR DESCRIPTION
This pull request introduces enhancements to layout inference and optimization for parallel operations, along with a minor change in a Python wrapper file. The most significant updates involve adding support for multiple inference levels and improving layout computation logic.

### Enhancements to layout inference and optimization:

* **Added multiple inference levels for layout optimization**: Introduced `InferLevel` with three levels (`kStrict`, `kCommon`, `kFree`) to control the aggressiveness of layout inference and optimization. Each level has distinct behavior, ranging from conservative to highly permissive. This change is documented in `ParallelOp::InferLayout`.

* **Updated layout inference logic in `ParallelOp::InferLayout`**: Enhanced the method to handle cases where `read_source_buffer` is defined, improving layout computation flexibility and accuracy.

* **Iterative layout inference in `Stmt Copy::Lower`**: Modified the `Lower` method to iterate over all inference levels (`kCommon`, `kStrict`, `kFree`) for layout inference, providing more robust layout optimization.

### Miscellaneous:

* **Minor update in `tilelang/jit/adapter/wrapper.py`**: Added a `return 0;` statement to the `init` function, ensuring proper function termination.