### PR TITLE
[Refactor] Rename `TensorSupplyType` into `TensorDistribution`

### DIFF
--- a/benchmark/matmul/benchmark_matmul.py
+++ b/benchmark/matmul/benchmark_matmul.py
@@ -165,7 +165,7 @@ def matmul(M, N, K, with_roller):
     )
     @jit(
         out_idx=[2],
-        supply_type=tl.TensorSupplyType.Integer,
+        distribution=tl.TensorDistribution.Integer,
         ref_prog=ref_program,
         skip_check=True,
         target="auto",

--- a/benchmark/matmul/benchmark_matmul_intrinsic.py
+++ b/benchmark/matmul/benchmark_matmul_intrinsic.py
@@ -269,7 +269,7 @@ def matmul(M,
     )
     @jit(
         out_idx=[2],
-        supply_type=tl.TensorSupplyType.Integer,
+        distribution=tl.TensorDistribution.Integer,
         ref_prog=ref_program,
         skip_check=True,
         target="auto",

--- a/benchmark/matmul_fp8/benchmark_matmul.py
+++ b/benchmark/matmul_fp8/benchmark_matmul.py
@@ -165,7 +165,7 @@ def matmul(M, N, K, with_roller):
     )
     @jit(
         out_idx=[2],
-        supply_type=tl.TensorSupplyType.Integer,
+        distribution=tl.TensorDistribution.Integer,
         ref_prog=ref_program,
         skip_check=True,
         target="auto",

--- a/docs/deeplearning_operators/gemv.md
+++ b/docs/deeplearning_operators/gemv.md
@@ -346,7 +346,7 @@ def get_best_config(N, K):
     )
     @jit(
         out_idx=[-1],
-        supply_type=tl.TensorSupplyType.Integer,
+        distribution=tl.TensorDistribution.Integer,
         ref_prog=ref_program,
         skip_check=False,
         target="auto",

--- a/docs/tutorials/auto_tuning.md
+++ b/docs/tutorials/auto_tuning.md
@@ -102,7 +102,7 @@ Configure JIT compilation and benchmarking settings:
 autotuner = AutoTuner.from_kernel(
     kernel=kernel, configs=get_configs(M, N, K, with_roller)).set_compile_args(
         out_idx=[-1],
-        supply_type=tl.TensorSupplyType.Integer,
+        distribution=tl.TensorDistribution.Integer,
         ref_prog=ref_program,
         skip_check=False,
         target="auto",

--- a/examples/bitnet-1.58b/kernel_benchmark/tl_int8xint8.py
+++ b/examples/bitnet-1.58b/kernel_benchmark/tl_int8xint8.py
@@ -195,7 +195,7 @@ def assert_tl_matmul_correctness(M, N, K, in_dtype, out_dtype, accum_dtype):
 
     C = torch.zeros(M, N, device="cuda", dtype=getattr(torch, accum_dtype))
 
-    mod = TL.Profiler(mod, params, [], TL.TensorSupplyType.Integer)
+    mod = TL.Profiler(mod, params, [], TL.TensorDistribution.Integer)
 
     mod(A, B, C)
 

--- a/examples/blocksparse_gemm/example_blocksparse_gemm.py
+++ b/examples/blocksparse_gemm/example_blocksparse_gemm.py
@@ -7,7 +7,7 @@ import tilelang
 import tilelang.language as T
 from tilelang.autotuner import AutoTuner
 from tilelang.engine.param import KernelParam
-from tilelang.utils.tensor import get_tensor_supply, TensorSupplyType
+from tilelang.utils.tensor import get_tensor_supply, TensorDistribution
 import torch
 from typing import List
 
@@ -30,7 +30,7 @@ args = parser.parse_args()
 M, N, K = args.m, args.n, args.k
 sparsity = args.sparsity
 use_autotune = args.use_autotune
-default_tensor_supply = get_tensor_supply(TensorSupplyType.Auto)
+default_tensor_supply = get_tensor_supply(TensorDistribution.Auto)
 
 print(f"Running BlockSparse MatMul Benchmark for M={M}, N={N}, K={K}")
 print(f"Target Block Sparsity: {sparsity}")
@@ -111,8 +111,8 @@ def get_best_config(M, N, K):
     ).set_compile_args(
         out_idx=[-1],  # Index of the output tensor
 
-        # supply_type should not set here because we provide a custom supply
-        # function `supply_prog` and `supply_type` will be ignored.
+        # distribution should not set here because we provide a custom supply
+        # function `supply_prog` and `distribution` will be ignored.
 
         # supply_prog: Provide the custom function to generate input tensors
         # (A, B, BlockMask) for the kernel, allowing controlling sparsity via

--- a/examples/cast/example_group_per_split_token_cast_to_fp8.py
+++ b/examples/cast/example_group_per_split_token_cast_to_fp8.py
@@ -187,7 +187,7 @@ if __name__ == "__main__":
         execution_backend="cython",
         pass_configs={"tl.disable_tma_lower": True})
     print(kernel.get_kernel_source())
-    profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Randn)
+    profiler = kernel.get_profiler(tensor_distribution=tilelang.TensorDistribution.Randn)
 
     x_fp8, x_amax = kernel(x, batch_sizes)
     x_fp8_ref, x_amax_ref = ref_program(x, batch_sizes)

--- a/examples/cast/example_per_token_cast_to_fp8.py
+++ b/examples/cast/example_per_token_cast_to_fp8.py
@@ -91,7 +91,7 @@ if __name__ == "__main__":
         execution_backend="cython",
         pass_configs={"tl.disable_tma_lower": True})
     print(kernel.get_kernel_source())
-    profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Randn)
+    profiler = kernel.get_profiler(tensor_distribution=tilelang.TensorDistribution.Randn)
 
     x = torch.randn(M, N, device="cuda", dtype=torch.float32)
 

--- a/examples/convolution/example_convolution.py
+++ b/examples/convolution/example_convolution.py
@@ -155,7 +155,7 @@ def get_best_config(N, C, H, W, F, K, S, D, P, with_roller):
         kernel=kernel, configs=get_configs(N, C, H, W, F, K, S, D, P,
                                            with_roller)).set_compile_args(
                                                out_idx=[2],
-                                               supply_type=tilelang.TensorSupplyType.Integer,
+                                               distribution=tilelang.TensorDistribution.Integer,
                                                ref_prog=ref_program(S, P, D),
                                                skip_check=False,
                                                target="auto",

--- a/examples/deepseek_mla/amd/benchmark_mla_decode_amd_tilelang.py
+++ b/examples/deepseek_mla/amd/benchmark_mla_decode_amd_tilelang.py
@@ -293,7 +293,7 @@ if __name__ == "__main__":
     program = flashmla_decode(batch, heads, kv_heads, kv_ctx, dim, pe_dim, BLOCK_N, BLOCK_H,
                               num_split)
     kernel = tilelang.compile(program, out_idx=[6])
-    profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Randn)
+    profiler = kernel.get_profiler(tensor_distribution=tilelang.TensorDistribution.Randn)
     input_tensors = profiler._get_inputs()
     tilelang_output = kernel(*input_tensors)
     ref_output = ref_program(*input_tensors)
@@ -330,7 +330,7 @@ if __name__ == "__main__":
     if enable_autotune:
         autotuner = AutoTuner.from_kernel(
             kernel=wrapped_kernel, configs=get_configs()).set_compile_args(
-                supply_type=tilelang.TensorSupplyType.Integer,
+                distribution=tilelang.TensorDistribution.Integer,
                 target="auto",
             )
         tune_result = autotuner.run(warmup=3, rep=20)

--- a/examples/deepseek_mla/example_mla_decode.py
+++ b/examples/deepseek_mla/example_mla_decode.py
@@ -291,7 +291,7 @@ if __name__ == "__main__":
 
     program = flashattn(batch, heads, kv_heads, kv_ctx, dim, pe_dim, BLOCK_N, BLOCK_H, num_split)
     kernel = tilelang.compile(program, out_idx=[6])
-    profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Randn)
+    profiler = kernel.get_profiler(tensor_distribution=tilelang.TensorDistribution.Randn)
     profiler.assert_allclose(ref_program, rtol=0.01, atol=0.01)
     latency = profiler.do_bench(warmup=500)
     print(f"Latency: {latency} ms")

--- a/examples/deepseek_mla/example_mla_decode_paged.py
+++ b/examples/deepseek_mla/example_mla_decode_paged.py
@@ -326,7 +326,7 @@ def run_tilelang_mla(q, block_table, blocked_k, max_seqlen_pad, block_size, b, s
     program = mla_decode_tilelang(b, h_q, h_kv, max_seqlen_pad, dv, dpe, BLOCK_N, BLOCK_H,
                                   num_kv_splits, block_size)
     kernel = tilelang.compile(program, out_idx=[8])
-    profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Randn)
+    profiler = kernel.get_profiler(tensor_distribution=tilelang.TensorDistribution.Randn)
 
     def flash_mla_tilelang():
         out = profiler.func(

--- a/examples/deepseek_mla/experimental/example_mla_decode_kv_fp8.py
+++ b/examples/deepseek_mla/experimental/example_mla_decode_kv_fp8.py
@@ -151,7 +151,7 @@ if __name__ == "__main__":
     program = flashattn(batch, heads, kv_heads, kv_ctx, dim, pe_dim, BLOCK_N, BLOCK_H)
     print(program)
     kernel = tilelang.compile(program, out_idx=-1)
-    profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Randn)
+    profiler = kernel.get_profiler(tensor_distribution=tilelang.TensorDistribution.Randn)
     latency = profiler.do_bench(warmup=500)
     print(f"Latency: {latency} ms")
     print(f"TFlops: {total_flops / latency * 1e-9} TFlops")

--- a/examples/dequantize_gemm/example_dequant_gemm_fine_grained.py
+++ b/examples/dequantize_gemm/example_dequant_gemm_fine_grained.py
@@ -115,7 +115,7 @@ def run_gemm(
     )
 
     kernel = tilelang.compile(program, out_idx=[2])
-    profiler = kernel.get_profiler(tilelang.TensorSupplyType.Integer)
+    profiler = kernel.get_profiler(tilelang.TensorDistribution.Integer)
 
     out = profiler.run_once()
     assert out is not None
@@ -364,7 +364,7 @@ def assert_tl_matmul_with_ladder_weight_only_transform_block_reduce_int4_correct
 
     kernel = tilelang.compile(matmul, out_idx=[2])
     src_code = kernel.get_kernel_source()
-    profiler = kernel.get_profiler(tilelang.TensorSupplyType.Integer)
+    profiler = kernel.get_profiler(tilelang.TensorDistribution.Integer)
 
     # src_code is the generated cuda source
     assert src_code is not None

--- a/examples/dequantize_gemm/example_dequant_gemm_fp4_hopper.py
+++ b/examples/dequantize_gemm/example_dequant_gemm_fp4_hopper.py
@@ -243,7 +243,7 @@ def matmul(M, N, K, in_dtype, out_dtype, accum_dtype, num_bits=4, tune=False):
             keys=["block_M", "block_N", "block_K", "num_stages", "threads", "split"],
             warmup=10,
             rep=10)
-        @jit(out_idx=[2], supply_type=tilelang.TensorSupplyType.Integer, ref_prog=None)
+        @jit(out_idx=[2], distribution=tilelang.TensorDistribution.Integer, ref_prog=None)
         def kernel(block_M=None,
                    block_N=None,
                    block_K=None,
@@ -284,7 +284,7 @@ if __name__ == "__main__":
             M, N, K, "float16", "float16", "float32", num_bits=4, tune=args.tune)(
                 block_M=128, block_N=128, block_K=128, num_stages=2, threads=256, split=1)
         kernel = tilelang.compile(program, out_idx=[2])
-        profiler = kernel.get_profiler(tilelang.TensorSupplyType.Integer)
+        profiler = kernel.get_profiler(tilelang.TensorDistribution.Integer)
         profiler.assert_allclose(ref_program, rtol=0.01, atol=0.01)
         print("All checks pass.")
         latency = profiler.do_bench(ref_program, warmup=500)

--- a/examples/dynamic/example_dynamic.py
+++ b/examples/dynamic/example_dynamic.py
@@ -102,7 +102,7 @@ def test_matmul_dynamic(M, N, K, block_M, block_N, block_K, trans_A, trans_B, in
     torch.testing.assert_close(C, ref_c, rtol=1e-2, atol=1e-2)
     print("Kernel output matches PyTorch reference.")
 
-    profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
+    profiler = kernel.get_profiler(tensor_distribution=tilelang.TensorDistribution.Normal)
     latency = profiler.do_bench(input_tensors=[A, B, C])
     print(f"Latency: {latency} ms")
 

--- a/examples/flash_attention/example_gqa_fwd_bshd.py
+++ b/examples/flash_attention/example_gqa_fwd_bshd.py
@@ -192,7 +192,7 @@ def flashattn(batch, heads, seq_len, dim, is_causal, tune=False, groups=1):
             keys=["block_M", "block_N", "num_stages", "threads"],
             warmup=10,
             rep=10)
-        @jit(out_idx=[3], supply_type=tilelang.TensorSupplyType.Integer, ref_prog=None)
+        @jit(out_idx=[3], distribution=tilelang.TensorDistribution.Integer, ref_prog=None)
         def kernel(block_M=None, block_N=None, num_stages=None, threads=None):
             return kernel_func(block_M, block_N, num_stages, threads)
 
@@ -252,7 +252,7 @@ if __name__ == "__main__":
                 block_M=128, block_N=128, num_stages=2, threads=128)
         ref_program = partial(ref_program, is_causal=is_causal, groups=groups)
         kernel = tilelang.compile(program, out_idx=[3])
-        profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
+        profiler = kernel.get_profiler(tensor_distribution=tilelang.TensorDistribution.Normal)
         profiler.assert_allclose(ref_program, rtol=0.01, atol=0.01)
         print("All checks pass.")
         latency = profiler.do_bench(ref_program, warmup=500)

--- a/examples/flash_attention/example_gqa_fwd_bshd_wgmma_pipelined.py
+++ b/examples/flash_attention/example_gqa_fwd_bshd_wgmma_pipelined.py
@@ -164,7 +164,7 @@ def flashattn(batch, heads, seq_len, dim, is_causal, tune=False, groups=1):
             keys=["block_M", "block_N", "num_stages", "threads"],
             warmup=10,
             rep=10)
-        @jit(out_idx=[3], supply_type=tilelang.TensorSupplyType.Integer, ref_prog=None)
+        @jit(out_idx=[3], distribution=tilelang.TensorDistribution.Integer, ref_prog=None)
         def kernel(block_M=None, block_N=None, num_stages=None, threads=None):
             return kernel_func(block_M, block_N, num_stages, threads)
 
@@ -224,7 +224,7 @@ if __name__ == "__main__":
                 block_M=128, block_N=128, num_stages=2, threads=256)
         ref_program = partial(ref_program, is_causal=is_causal, groups=groups)
         kernel = tilelang.compile(program, out_idx=[3])
-        profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
+        profiler = kernel.get_profiler(tensor_distribution=tilelang.TensorDistribution.Normal)
         profiler.assert_allclose(ref_program, rtol=0.01, atol=0.01)
         print("All checks pass.")
         latency = profiler.do_bench(ref_program, warmup=500)

--- a/examples/flash_attention/example_mha_fwd_bhsd.py
+++ b/examples/flash_attention/example_mha_fwd_bhsd.py
@@ -160,7 +160,7 @@ def flashattn(batch, heads, seq_q, seq_kv, dim, is_causal, tune=False):
             keys=["block_M", "block_N", "num_stages", "threads"],
             warmup=10,
             rep=10)
-        @jit(out_idx=[3], supply_type=tilelang.TensorSupplyType.Integer, ref_prog=None)
+        @jit(out_idx=[3], distribution=tilelang.TensorDistribution.Integer, ref_prog=None)
         def kernel(block_M=None, block_N=None, num_stages=None, threads=None):
             return kernel_func(block_M, block_N, num_stages, threads)
 

--- a/examples/flash_attention/example_mha_fwd_bshd.py
+++ b/examples/flash_attention/example_mha_fwd_bshd.py
@@ -157,7 +157,7 @@ def flashattn(batch, heads, seq_len, dim, is_causal, tune=False):
             keys=["block_M", "block_N", "num_stages", "threads"],
             warmup=10,
             rep=10)
-        @jit(out_idx=[3], supply_type=tilelang.TensorSupplyType.Integer, ref_prog=None)
+        @jit(out_idx=[3], distribution=tilelang.TensorDistribution.Integer, ref_prog=None)
         def kernel(block_M=None, block_N=None, num_stages=None, threads=None):
             return kernel_func(block_M, block_N, num_stages, threads)
 

--- a/examples/flash_attention/example_mha_fwd_bshd_wgmma_pipelined.py
+++ b/examples/flash_attention/example_mha_fwd_bshd_wgmma_pipelined.py
@@ -162,7 +162,7 @@ def flashattn(batch, heads, seq_len, dim, is_causal, tune=False):
             keys=["block_M", "block_N", "num_stages", "threads"],
             warmup=10,
             rep=10)
-        @jit(out_idx=[3], supply_type=tilelang.TensorSupplyType.Integer, ref_prog=None)
+        @jit(out_idx=[3], distribution=tilelang.TensorDistribution.Integer, ref_prog=None)
         def kernel(block_M=None, block_N=None, num_stages=None, threads=None):
             return kernel_func(block_M, block_N, num_stages, threads)
 
@@ -210,7 +210,7 @@ if __name__ == "__main__":
                 block_M=128, block_N=128, num_stages=2, threads=256)
         ref_program = partial(ref_program, is_causal=is_causal)
         kernel = tilelang.compile(program, out_idx=[3])
-        profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
+        profiler = kernel.get_profiler(tensor_distribution=tilelang.TensorDistribution.Normal)
         profiler.assert_allclose(ref_program, rtol=0.01, atol=0.01)
         print("All checks pass.")
         latency = profiler.do_bench(ref_program, warmup=500)

--- a/examples/flash_attention/example_mha_inference.py
+++ b/examples/flash_attention/example_mha_inference.py
@@ -306,7 +306,7 @@ if __name__ == "__main__":
     program = flashattn(BATCH, H, Q_CTX, KV_CTX, D_HEAD, causal, BLOCK_M, BLOCK_N)
     ref_program = partial(ref_program, causal=causal)
     kernel = tilelang.compile(program, out_idx=[5])
-    profiler = kernel.get_profiler(tilelang.TensorSupplyType.Normal)
+    profiler = kernel.get_profiler(tilelang.TensorDistribution.Normal)
     profiler.assert_allclose(ref_program, rtol=0.01, atol=0.01)
     print("All checks passed!")
 

--- a/examples/flash_decoding/example_gqa_decode.py
+++ b/examples/flash_decoding/example_gqa_decode.py
@@ -278,7 +278,7 @@ def flashattn(batch, heads, groups, seqlen_kv, dim, tune=False):
             rep=10)
         @jit(
             out_idx=[6],
-            supply_type=tilelang.TensorSupplyType.Auto,
+            distribution=tilelang.TensorDistribution.Auto,
             ref_prog=ref_program,
             max_mismatched_ratio=0.05)
         def kernel(block_N=None, block_H=None, num_split=None, num_stages=None, threads=None):
@@ -459,7 +459,7 @@ if __name__ == "__main__":
         config = get_heuristic_config()
         program = flashattn(batch, heads, groups, kv_seqlen, dim, tune=args.tune)(**config)
         kernel = tilelang.compile(program, out_idx=[6])
-        profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Auto)
+        profiler = kernel.get_profiler(tensor_distribution=tilelang.TensorDistribution.Auto)
         profiler.assert_allclose(ref_program, rtol=0.01, atol=0.01)
         print("All checks pass.")
         latency = profiler.do_bench(ref_program, warmup=500)

--- a/examples/flash_decoding/example_mha_inference.py
+++ b/examples/flash_decoding/example_mha_inference.py
@@ -307,7 +307,7 @@ if __name__ == "__main__":
     ref_program = partial(ref_program, causal=causal)
     kernel = tilelang.compile(program, out_idx=[5], target="cuda", execution_backend="dlpack")
     print(kernel.get_kernel_source())
-    profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
+    profiler = kernel.get_profiler(tensor_distribution=tilelang.TensorDistribution.Normal)
     profiler.assert_allclose(ref_program, rtol=0.01, atol=0.01)
     print("All checks passed!")
 

--- a/examples/gemm/example_gemm_autotune.py
+++ b/examples/gemm/example_gemm_autotune.py
@@ -122,7 +122,7 @@ def get_best_config(M, N, K, with_roller=False):
     autotuner = AutoTuner.from_kernel(
         kernel=kernel, configs=get_configs(M, N, K, with_roller)).set_compile_args(
             out_idx=[-1],
-            supply_type=tl.TensorSupplyType.Integer,
+            distribution=tl.TensorDistribution.Integer,
             ref_prog=ref_program,
             skip_check=False,
             target="auto",
@@ -238,7 +238,7 @@ if __name__ == "__main__":
         kernel = tl.compile(matmul(M, N, K, **config), out_idx=-1)
 
     # benchmark
-    profiler = kernel.get_profiler(tensor_supply_type=tl.TensorSupplyType.Auto)
+    profiler = kernel.get_profiler(tensor_distribution=tl.TensorDistribution.Auto)
     tilelang_latency = profiler.do_bench()
     ref_latency = profiler.do_bench(ref_program)
     profiler.assert_allclose(ref_program, atol=1e-2, rtol=1e-2)

--- a/examples/gemm_fp8/example_tilelang_gemm_fp8_intrinsic.py
+++ b/examples/gemm_fp8/example_tilelang_gemm_fp8_intrinsic.py
@@ -202,7 +202,7 @@ def assert_tl_matmul_correctness(M, N, K, in_dtype, out_dtype, accum_dtype):
 
     C = torch.zeros(M, N, device="cuda", dtype=accum_dtype)
 
-    profiler = kernel.get_profiler(tilelang.TensorSupplyType.Integer)
+    profiler = kernel.get_profiler(tilelang.TensorDistribution.Integer)
 
     profiler(A, B, C)
 

--- a/examples/gemv/example_gemv.py
+++ b/examples/gemv/example_gemv.py
@@ -234,7 +234,7 @@ def get_best_config(N, K):
     )
     @jit(
         out_idx=[-1],
-        supply_type=tl.TensorSupplyType.Integer,
+        distribution=tl.TensorDistribution.Integer,
         ref_prog=ref_program,
         skip_check=False,
         target="auto",

--- a/examples/linear_attention/example_mamba_chunk_scan.py
+++ b/examples/linear_attention/example_mamba_chunk_scan.py
@@ -203,7 +203,7 @@ def chunk_scan_fwd(batch, seqlen, chunk_size, ngroups, nheads, headdim, dstate, 
             keys=["block_M", "block_N", "block_K", "block_Dstate", "num_stages", "threads"],
             warmup=10,
             rep=10)
-        @jit(out_idx=[7], supply_type=tilelang.TensorSupplyType.Normal, ref_prog=None)
+        @jit(out_idx=[7], distribution=tilelang.TensorDistribution.Normal, ref_prog=None)
         def kernel(block_M=None,
                    block_N=None,
                    block_K=None,
@@ -240,7 +240,7 @@ if __name__ == "__main__":
             batch, seq_len, chunk_size, groups, heads, dim, dstate, tune=args.tune)(
                 block_M=64, block_N=64, block_K=64, block_Dstate=128, num_stages=2, threads=128)
         kernel = tilelang.compile(program, out_idx=[7])
-        profiler = kernel.get_profiler(tilelang.TensorSupplyType.Normal)
+        profiler = kernel.get_profiler(tilelang.TensorDistribution.Normal)
         profiler.assert_allclose(ref_program, rtol=0.01, atol=0.01)
         print("All checks pass.")
         latency = profiler.do_bench(ref_program, warmup=500)

--- a/examples/linear_attention/example_mamba_chunk_state.py
+++ b/examples/linear_attention/example_mamba_chunk_state.py
@@ -145,7 +145,7 @@ def chunk_state_fwd(batch, seqlen, chunk_size, ngroups, nheads, headdim, dstate,
             keys=["block_M", "block_N", "block_K", "num_stages", "threads"],
             warmup=10,
             rep=10)
-        @jit(out_idx=[4], supply_type=tilelang.TensorSupplyType.Normal, ref_prog=None)
+        @jit(out_idx=[4], distribution=tilelang.TensorDistribution.Normal, ref_prog=None)
         def kernel(block_M=None, block_N=None, block_K=None, num_stages=None, threads=None):
             return kernel_func(block_M, block_N, block_K, num_stages, threads)
 
@@ -177,7 +177,7 @@ if __name__ == "__main__":
             batch, seq_len, chunk_size, groups, heads, dim, dstate, tune=args.tune)(
                 block_M=64, block_N=128, block_K=64, num_stages=4, threads=128)
         kernel = tilelang.compile(program, out_idx=[4])
-        profiler = kernel.get_profiler(tilelang.TensorSupplyType.Normal)
+        profiler = kernel.get_profiler(tilelang.TensorDistribution.Normal)
         profiler.assert_allclose(ref_program, rtol=0.01, atol=0.01)
         print("All checks pass.")
         latency = profiler.do_bench(ref_program, warmup=500)

--- a/examples/linear_attention/example_retnet.py
+++ b/examples/linear_attention/example_retnet.py
@@ -181,7 +181,7 @@ if __name__ == "__main__":
     BLOCK_N = 64
     program = retnet(BATCH, H, N_CTX, dim_qk, dim_v, BLOCK_M, BLOCK_N)
     kernel = tilelang.compile(program, out_idx=[4])
-    profiler = kernel.get_profiler(tilelang.TensorSupplyType.Normal)
+    profiler = kernel.get_profiler(tilelang.TensorDistribution.Normal)
 
     ins = []
     for i in range(len(kernel.params)):

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -97,7 +97,7 @@ print("Kernel output matches PyTorch reference.")
 # print("Generated CUDA kernel:\n", cuda_source)
 
 # 5.Profile latency with kernel
-profiler = jit_kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
+profiler = jit_kernel.get_profiler(tensor_distribution=tilelang.TensorDistribution.Normal)
 
 latency = profiler.do_bench()
 

--- a/maint/scripts/performance.py
+++ b/maint/scripts/performance.py
@@ -64,7 +64,7 @@ def run(M, N, K):
     autotuner = AutoTuner.from_kernel(
         kernel=kernel, configs=get_configs()).set_compile_args(
             out_idx=[-1],
-            supply_type=tl.TensorSupplyType.Integer,
+            distribution=tl.TensorDistribution.Integer,
             ref_prog=ref_program,
             skip_check=False,
             target="auto",

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -215,7 +215,8 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
                   makeGemmABLayout(mat_stride, mat_continuous, mat_continuous,
                                    B->dtype.bits(), trans_B ? 2 : 1));
     } else if (B.scope() == "local.fragment") {
-      ICHECK(trans_B == false);
+      ICHECK(trans_B == false) << "B is local.fragment, trans_B must be false, please raise an issue" 
+      << " if you want to use this feature";
       results.Set(B, makeGemmFragmentB(M, N, K, M / warp_m, N / warp_n));
     } else {
       ICHECK(0);

--- a/testing/python/autotune/test_tilelang_autotune.py
+++ b/testing/python/autotune/test_tilelang_autotune.py
@@ -254,7 +254,7 @@ def matmul(M, N, K, with_roller):
     autotuner = AutoTuner.from_kernel(
         kernel=kernel, configs=get_configs(M, N, K, with_roller)).set_compile_args(
             out_idx=[-1],
-            supply_type=tl.TensorSupplyType.Integer,
+            distribution=tl.TensorDistribution.Integer,
             ref_prog=ref_program,
             skip_check=False,
             target="auto",

--- a/testing/python/autotune/test_tilelang_autotune_decorator.py
+++ b/testing/python/autotune/test_tilelang_autotune_decorator.py
@@ -153,7 +153,7 @@ def matmul(M, N, K, with_roller):
     )
     @jit(
         out_idx=[-1],
-        supply_type=tl.TensorSupplyType.Integer,
+        distribution=tl.TensorDistribution.Integer,
         ref_prog=ref_program,
         skip_check=True,
         target="auto",

--- a/testing/python/dynamic/test_tilelang_dynamic_symbolic_bench.py
+++ b/testing/python/dynamic/test_tilelang_dynamic_symbolic_bench.py
@@ -118,7 +118,7 @@ def assert_tl_matmul_block_static(
 
     torch.testing.assert_close(C, ref_c, rtol=1e-2, atol=1e-2)
 
-    profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
+    profiler = kernel.get_profiler(tensor_distribution=tilelang.TensorDistribution.Normal)
     latency = profiler.do_bench()
     print(f"Static Latency: {latency} ms")
 
@@ -228,7 +228,7 @@ def assert_tl_matmul_block_dynamic_m(
 
     torch.testing.assert_close(C, ref_c, rtol=1e-2, atol=1e-2)
 
-    profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
+    profiler = kernel.get_profiler(tensor_distribution=tilelang.TensorDistribution.Normal)
     latency = profiler.do_bench(input_tensors=[A, B, C])
     print(f"Dynamic M Latency with pass_configs: {pass_configs} is {latency} ms")
 
@@ -337,7 +337,7 @@ def assert_tl_matmul_block_dynamic_mn(
 
     torch.testing.assert_close(C, ref_c, rtol=1e-2, atol=1e-2)
 
-    profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
+    profiler = kernel.get_profiler(tensor_distribution=tilelang.TensorDistribution.Normal)
     latency = profiler.do_bench(input_tensors=[A, B, C])
     print(f"Dynamic MN Latency with pass_configs: {pass_configs} is {latency} ms")
 
@@ -446,7 +446,7 @@ def assert_tl_matmul_block_dynamic_mnk(
 
     torch.testing.assert_close(C, ref_c, rtol=1e-2, atol=1e-2)
 
-    profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
+    profiler = kernel.get_profiler(tensor_distribution=tilelang.TensorDistribution.Normal)
     latency = profiler.do_bench(input_tensors=[A, B, C])
     print(f"Dynamic MNK Latency with pass_configs: {pass_configs} is {latency} ms")
 

--- a/testing/python/language/test_tilelang_language_cumsum.py
+++ b/testing/python/language/test_tilelang_language_cumsum.py
@@ -53,7 +53,7 @@ def run_cumsum(M, N, block_M, block_N, dim=0, reverse=False, dtype="float16", sc
     elif scope == "fragment":
         program = cumsum_fragment_test(M, N, block_M, block_N, dim, reverse, dtype)
     jit_kernel = tl.compile(program, out_idx=-1)
-    profiler = jit_kernel.get_profiler(tensor_supply_type=tl.TensorSupplyType.One)
+    profiler = jit_kernel.get_profiler(tensor_distribution=tl.TensorDistribution.Randn)
 
     def ref_program(A):
         ref_b = torch.empty_like(A)
@@ -64,8 +64,8 @@ def run_cumsum(M, N, block_M, block_N, dim=0, reverse=False, dtype="float16", sc
                                                          block_N:(j + 1) * block_N].cumsum(dim=dim)
                 if reverse:
                     ref_b[i * block_M:(i + 1) * block_M, j * block_N:(j + 1) *
-                          block_N] = ref_b[i * block_M:(i + 1) * block_M,
-                                           j * block_N:(j + 1) * block_N].flip(dims=[dim])
+                          block_N] = A[i * block_M:(i + 1) * block_M, j *
+                                                         block_N:(j + 1) * block_N].flip(dims=[dim]).cumsum(dim=dim).flip(dims=[dim])
         return ref_b
 
     profiler.assert_allclose(ref_program)

--- a/tilelang/__init__.py
+++ b/tilelang/__init__.py
@@ -86,7 +86,7 @@ from .profiler import Profiler  # noqa: F401
 from .cache import cached  # noqa: F401
 
 from .utils import (
-    TensorSupplyType,  # noqa: F401
+    TensorDistribution,  # noqa: F401
     deprecated,  # noqa: F401
 )
 from .layout import (

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -14,7 +14,7 @@ from tilelang.jit.adapter import (
     CythonKernelAdapter,
 )
 from tilelang.utils.target import determine_target, AVALIABLE_TARGETS
-from tilelang.profiler import Profiler, TensorSupplyType
+from tilelang.profiler import Profiler, TensorDistribution
 from tilelang.engine.param import KernelParam, CompiledArtifact
 
 
@@ -301,14 +301,14 @@ class JITKernel(object):
         return cls(func=tilelang_func, **kwargs)
 
     def get_profiler(self,
-                     tensor_supply_type: TensorSupplyType = TensorSupplyType.Auto) -> Profiler:
+                     tensor_distribution: TensorDistribution = TensorDistribution.Auto) -> Profiler:
         """
         Creates a profiler to benchmark the compiled runtime module.
 
         Parameters
         ----------
-        tensor_supply_type : TensorSupplyType, optional
-            The type of input tensors to supply for profiling (default: TensorSupplyType.Auto).
+        tensor_distribution : TensorDistribution, optional
+            The type of input tensors to supply for profiling (default: TensorDistribution.Auto).
 
         Returns
         -------
@@ -316,7 +316,7 @@ class JITKernel(object):
             A Profiler instance for benchmarking the runtime module.
         """
         return Profiler(self.params, self.out_idx,
-                        tensor_supply_type).with_default_adapter(self.adapter)
+                        tensor_distribution).with_default_adapter(self.adapter)
 
     def get_kernel_source(self) -> str:
         """

--- a/tilelang/profiler/__init__.py
+++ b/tilelang/profiler/__init__.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 import tvm
 from tilelang.utils.tensor import (
     get_tensor_supply,
-    TensorSupplyType,
+    TensorDistribution,
     torch_assert_close,
     adapt_torch2tvm,
 )
@@ -26,19 +26,19 @@ class Profiler:
     Attributes:
         params: List of kernel parameters defining the input/output specifications
         result_idx: Indices indicating which parameters are output tensors
-        supply_type: Type of tensor supply to use (e.g., random, zeros, etc.)
+        distribution: Type of tensor supply to use (e.g., random, zeros, etc.)
         adapter: Optional kernel adapter for interfacing with different backends
     """
 
     params: List[KernelParam]
     result_idx: List[int]
-    supply_type: TensorSupplyType
+    distribution: TensorDistribution
     adapter: Optional[BaseKernelAdapter] = None
 
     def __post_init__(self):
         """Initialize tensor supply after dataclass initialization"""
         self.result_idx = self._legalize_result_idx(self.result_idx)
-        self.supply = get_tensor_supply(self.supply_type)
+        self.supply = get_tensor_supply(self.distribution)
 
     def _legalize_result_idx(self, result_idx: Optional[List[int]] = None) -> List[int]:
         params = self.params

--- a/tilelang/utils/__init__.py
+++ b/tilelang/utils/__init__.py
@@ -3,7 +3,7 @@
 """The profiler and convert to torch utils"""
 
 from .target import determine_target  # noqa: F401
-from .tensor import TensorSupplyType, torch_assert_close, map_torch_type  # noqa: F401
+from .tensor import TensorDistribution, torch_assert_close, map_torch_type  # noqa: F401
 from .language import (
     is_global,  # noqa: F401
     is_shared,  # noqa: F401

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -11,7 +11,7 @@ from torch.utils.dlpack import to_dlpack
 import numpy as np
 
 
-class TensorSupplyType(Enum):
+class TensorDistribution(Enum):
     Integer = 1
     Uniform = 2
     Normal = 3
@@ -49,7 +49,7 @@ def adapt_torch2tvm(arg):
     return arg
 
 
-def get_tensor_supply(supply_type: TensorSupplyType = TensorSupplyType.Integer):
+def get_tensor_supply(distribution: TensorDistribution = TensorDistribution.Integer):
 
     from tilelang.engine.param import KernelParam
 
@@ -71,7 +71,7 @@ def get_tensor_supply(supply_type: TensorSupplyType = TensorSupplyType.Integer):
                 )
 
         shape = list(map(int, param.shape))
-        if supply_type == TensorSupplyType.Auto:
+        if distribution == TensorDistribution.Auto:
             is_unsigned = param.is_unsigned()
             is_float8 = param.is_float8()
             is_boolean = param.is_boolean()
@@ -87,13 +87,13 @@ def get_tensor_supply(supply_type: TensorSupplyType = TensorSupplyType.Integer):
             else:
                 return torch.randint(low=-2, high=3, size=shape, device=device, dtype=dtype)
 
-        if dtype == torch.int8 and supply_type in [
-                TensorSupplyType.Uniform,
-                TensorSupplyType.Normal,
+        if dtype == torch.int8 and distribution in [
+                TensorDistribution.Uniform,
+                TensorDistribution.Normal,
         ]:
             return torch.ones(*shape, device=device, dtype=dtype)
 
-        if supply_type == TensorSupplyType.Integer:
+        if distribution == TensorDistribution.Integer:
             is_unsigned = param.is_unsigned()
             is_float8 = param.is_float8()
             is_boolean = param.is_boolean()
@@ -106,18 +106,18 @@ def get_tensor_supply(supply_type: TensorSupplyType = TensorSupplyType.Integer):
                 return torch.randint(low=0, high=2, size=shape, device=device, dtype=dtype)
             else:
                 return torch.randint(low=-2, high=3, size=shape, device=device, dtype=dtype)
-        elif supply_type == TensorSupplyType.Uniform:
+        elif distribution == TensorDistribution.Uniform:
             return torch.empty(*shape, device=device, dtype=dtype).uniform_(-1.0, 1.0)
-        elif supply_type == TensorSupplyType.Normal:
+        elif distribution == TensorDistribution.Normal:
             return torch.empty(*shape, device=device, dtype=dtype).normal_(-1.0, 1.0)
-        elif supply_type == TensorSupplyType.Randn:
+        elif distribution == TensorDistribution.Randn:
             return torch.randn(*shape, device=device).to(dtype)
-        elif supply_type == TensorSupplyType.Zero:
+        elif distribution == TensorDistribution.Zero:
             return torch.zeros(*shape, device=device, dtype=dtype)
-        elif supply_type == TensorSupplyType.One:
+        elif distribution == TensorDistribution.One:
             return torch.ones(*shape, device=device, dtype=dtype)
         else:
-            raise NotImplementedError(supply_type)
+            raise NotImplementedError(distribution)
 
     return get_tensor
 


### PR DESCRIPTION
This pull request updates the codebase to replace the usage of `TensorSupplyType` with `TensorDistribution` across multiple files for consistency and clarity. The changes affect benchmarking, tutorials, and example scripts. 

### Refactoring TensorSupplyType to TensorDistribution:

* Updated the `@jit` decorator to use `distribution` instead of `supply_type` in various benchmark files, including `benchmark_matmul.py`, `benchmark_matmul_intrinsic.py`, and `benchmark_matmul_fp8.py`. [[1]](diffhunk://#diff-f6569b098c377678a1b3e4ce25ca3245ba53e3d91f4a98a48d38b6818b4e5b51L168-R168) [[2]](diffhunk://#diff-f9ace778cdfa13c4c40ce56cd048035b0aa6b208634c6a580897ba28bb0f2d47L272-R272) [[3]](diffhunk://#diff-fb3fe00f14bbd5edf99d9c2e30332de0e390dd670e4bb0c871acbfb2ee82aedeL168-R168)
* Modified example scripts such as `example_blocksparse_gemm.py`, `example_dequant_gemm_fine_grained.py`, and `example_mha_fwd_bhsd.py` to replace `TensorSupplyType` with `TensorDistribution` in profiler and kernel configurations. [[1]](diffhunk://#diff-920d8f2266d3bb6cce1880f0044672b536814ef91c47ffca750e98f4808629aeL33-R33) [[2]](diffhunk://#diff-55667d15be9756f40cf45a72ba6d7cd78f37acc3038795332e9c0bb09eef85b6L118-R118) [[3]](diffhunk://#diff-ec5c3d1df18abc6ea3baa2f59b596139f627da95c14c363851cdfc28802d64b0L163-R163)

### Documentation Updates:

* Updated the documentation in `gemv.md` and `auto_tuning.md` to reflect the change from `supply_type` to `distribution`. [[1]](diffhunk://#diff-207e7ab476e79a79dc5c889c8c7828290e6b43ee42a29c76683c8a4dfe1764bfL349-R349) [[2]](diffhunk://#diff-1c8b05b53f0bda85875e48caf7a21bf7236cbcd83d02597d0c636e2c8b1b633aL105-R105)

### Example Script Enhancements:

* Replaced `tensor_supply_type` with `tensor_distribution` in example scripts such as `example_dynamic.py`, `example_gqa_fwd_bshd.py`, and `example_mla_decode.py` to align with the updated terminology. [[1]](diffhunk://#diff-1c51f8fe9a51ea2f982062db92b373ff413f232271d1f3403fc00c3d464081f3L105-R105) [[2]](diffhunk://#diff-b320af9abbbf8d8b155faa2f85fdc6a5e48580c4877fb668a87adde236bbb76cL255-R255) [[3]](diffhunk://#diff-6302172cbe25b3718361777e9ae5ba94edbbfc17db93f0c9ebe147e4801a8a1fL294-R294)
* Updated comments in `example_blocksparse_gemm.py` to clarify the use of `distribution` in custom supply functions.

These changes ensure consistency in terminology and improve code readability across the project.