### PR TITLE
[Enhancement] Improve error handling in layout inference

### DIFF
--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -215,7 +215,8 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
                   makeGemmABLayout(mat_stride, mat_continuous, mat_continuous,
                                    B->dtype.bits(), trans_B ? 2 : 1));
     } else if (B.scope() == "local.fragment") {
-      ICHECK(trans_B == false) << "B is local.fragment, trans_B must be false, please raise an issue if you see this";
+      ICHECK(trans_B == false) << "B is local.fragment, trans_B must be false, "
+                                  "please raise an issue if you see this";
       results.Set(B, makeGemmFragmentB(M, N, K, M / warp_m, N / warp_n));
     } else {
       ICHECK(0);

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -215,7 +215,7 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
                   makeGemmABLayout(mat_stride, mat_continuous, mat_continuous,
                                    B->dtype.bits(), trans_B ? 2 : 1));
     } else if (B.scope() == "local.fragment") {
-      ICHECK(trans_B == false);
+      ICHECK(trans_B == false) << "B is local.fragment, trans_B must be false, please raise an issue if you see this";
       results.Set(B, makeGemmFragmentB(M, N, K, M / warp_m, N / warp_n));
     } else {
       ICHECK(0);

--- a/testing/python/language/test_tilelang_language_cumsum.py
+++ b/testing/python/language/test_tilelang_language_cumsum.py
@@ -53,7 +53,7 @@ def run_cumsum(M, N, block_M, block_N, dim=0, reverse=False, dtype="float16", sc
     elif scope == "fragment":
         program = cumsum_fragment_test(M, N, block_M, block_N, dim, reverse, dtype)
     jit_kernel = tl.compile(program, out_idx=-1)
-    profiler = jit_kernel.get_profiler(tensor_supply_type=tl.TensorSupplyType.One)
+    profiler = jit_kernel.get_profiler(tensor_supply_type=tl.TensorDistributionType.Randn)
 
     def ref_program(A):
         ref_b = torch.empty_like(A)
@@ -64,8 +64,8 @@ def run_cumsum(M, N, block_M, block_N, dim=0, reverse=False, dtype="float16", sc
                                                          block_N:(j + 1) * block_N].cumsum(dim=dim)
                 if reverse:
                     ref_b[i * block_M:(i + 1) * block_M, j * block_N:(j + 1) *
-                          block_N] = ref_b[i * block_M:(i + 1) * block_M,
-                                           j * block_N:(j + 1) * block_N].flip(dims=[dim])
+                          block_N] = A[i * block_M:(i + 1) * block_M, j * block_N:(j + 1) *
+                                       block_N].flip(dims=[dim]).cumsum(dim=dim).flip(dims=[dim])
         return ref_b
 
     profiler.assert_allclose(ref_program)


### PR DESCRIPTION
This pull request includes changes to improve error messaging, update a test utility, and fix a bug in a test reference implementation. Below is a summary of the most important changes:

### Error Messaging Improvements:
* Updated the `ICHECK` statement in `src/op/gemm.cc` to include a detailed error message when `trans_B` is not false for `B` in the `"local.fragment"` scope. This helps users identify and report issues more effectively.

### Test Utility Updates:
* Modified the `get_profiler` method in `testing/python/language/test_tilelang_language_cumsum.py` to use `tl.TensorDistributionType.Randn` instead of `tl.TensorSupplyType.One`, ensuring better randomization during testing.

### Bug Fixes in Test Reference Implementation:
* Fixed the logic in the `ref_program` function in `testing/python/language/test_tilelang_language_cumsum.py` to correctly apply `cumsum` and `flip` operations in reverse mode, ensuring the reference output matches expected behavior.