### PR TITLE
[Enhancement] Remove DeReplicate during parallel loop layout inference

### DIFF
--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -164,7 +164,7 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
     return {};
   LayoutMap results;
   ICHECK(C.scope() == "local.fragment");
-  auto block_size = *as_const_int(T.thread_bounds->extent);
+  auto block_size = *as_const_int(T.thread_bounds->extent) - *as_const_int(T.thread_bounds->min);
   if (TargetIsVolta(T.target)) {
     const int warp_size = 32;
     auto [warp_m, warp_n] =

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -223,10 +223,6 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
   } else if (TargetIsHopper(T.target)) {
     const int warp_size = 32;
     bool maybe_wgmma = (this->M >= 64) && (block_size / warp_size % 4 == 0);
-    if (!maybe_wgmma) {
-      LOG(WARNING)
-          << "WGMMA is not enabled because M < 64 or block_size % 128 != 0";
-    }
     auto [warp_m, warp_n] =
         ComputeWarpPartition(block_size / warp_size, T.target, maybe_wgmma);
     auto fragment =

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -164,7 +164,8 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
     return {};
   LayoutMap results;
   ICHECK(C.scope() == "local.fragment");
-  auto block_size = *as_const_int(T.thread_bounds->extent) - *as_const_int(T.thread_bounds->min);
+  auto block_size = *as_const_int(T.thread_bounds->extent) -
+                    *as_const_int(T.thread_bounds->min);
   if (TargetIsVolta(T.target)) {
     const int warp_size = 32;
     auto [warp_m, warp_n] =

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -184,19 +184,19 @@ LayoutMap ParallelOp::InferLayout(const LayoutInferArgs &T, InferLevel level) {
   } else if (level == InferLevel::kFree) {
     if (read_source_buffer.defined()) {
       loop_layout_ = compute_loop_layout_from_buffer(read_source_buffer);
-      // Loop don't need to be replicated.
-      if (!is_one(loop_layout_->ReplicateExtent()))
-        loop_layout_ = loop_layout_->DeReplicate();
-      // if still has replication, add a condition
-      if (!is_one(loop_layout_->ReplicateExtent())) {
-        auto inv = loop_layout_->Inverse();
-        Array<PrimExpr> fwd;
-        for (size_t i = 0; i < loop_layout_->OutputDim(); i++)
-          fwd.push_back(0);
-        fwd.push_back(InputPlaceholder(0));
-        auto rep = inv->Forward(fwd).back();
-        AddPredicate(EQ(rep, 0));
-      }
+      // // Loop don't need to be replicated.
+      // if (!is_one(loop_layout_->ReplicateExtent()))
+      //   loop_layout_ = loop_layout_->DeReplicate();
+      // // if still has replication, add a condition
+      // if (!is_one(loop_layout_->ReplicateExtent())) {
+      //   auto inv = loop_layout_->Inverse();
+      //   Array<PrimExpr> fwd;
+      //   for (size_t i = 0; i < loop_layout_->OutputDim(); i++)
+      //     fwd.push_back(0);
+      //   fwd.push_back(InputPlaceholder(0));
+      //   auto rep = inv->Forward(fwd).back();
+      //   AddPredicate(EQ(rep, 0));
+      // }
     } else {
       // Vectorize Size must be aware of the buffer_remap
       // As the pass will do post processing to the layout
@@ -227,6 +227,7 @@ LayoutMap ParallelOp::InferLayout(const LayoutInferArgs &T, InferLevel level) {
   } else {
     return {};
   }
+
   // Step 2: Check that the loop's partition can correctly align with all source
   // fragment
   for (const auto &[buffer, _] : indice_map_) {
@@ -270,8 +271,8 @@ LayoutMap ParallelOp::InferLayout(const LayoutInferArgs &T, InferLevel level) {
               << "Layout may conflict with ParallelOp for buffer " << buffer
               << "\nError body begin:\n"
               << GetRoot()->body << "\nError body end"
-              << "\nbuffer layout = " << src_layout->DebugOutput()
-              << "\nloop layout = " << dst_layout->DebugOutput()
+              << "\nLHS = " << src_layout->DebugOutput()
+              << "\nRHS = " << dst_layout->DebugOutput()
               << "\nYou may need to use a shared memory to transform the "
                  "layout";
         }

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -181,8 +181,6 @@ LayoutMap ParallelOp::InferLayout(const LayoutInferArgs &T, InferLevel level) {
   };
   if (source_buffer.defined()) {
     loop_layout_ = compute_loop_layout_from_buffer(source_buffer);
-  } else if (read_source_buffer.defined()) {
-    loop_layout_ = compute_loop_layout_from_buffer(read_source_buffer);
   } else if (level == InferLevel::kFree) {
     if (read_source_buffer.defined()) {
       loop_layout_ = compute_loop_layout_from_buffer(read_source_buffer);
@@ -272,8 +270,8 @@ LayoutMap ParallelOp::InferLayout(const LayoutInferArgs &T, InferLevel level) {
               << "Layout may conflict with ParallelOp for buffer " << buffer
               << "\nError body begin:\n"
               << GetRoot()->body << "\nError body end"
-              << "\nLHS = " << src_layout->DebugOutput()
-              << "\nRHS = " << dst_layout->DebugOutput()
+              << "\nbuffer layout = " << src_layout->DebugOutput()
+              << "\nloop layout = " << dst_layout->DebugOutput()
               << "\nYou may need to use a shared memory to transform the "
                  "layout";
         }


### PR DESCRIPTION
This pull request refines layout inference logic in the `Gemm` and `ParallelOp` operations by addressing block size calculations, simplifying conditions, and cleaning up unused or commented-out code. These changes aim to improve code clarity and maintainability while ensuring correctness in layout inference.

### Changes in `Gemm` layout inference:

* Adjusted block size calculation to account for the `min` value in `T.thread_bounds`, ensuring accurate computation of block size. (`src/op/gemm.cc`, [src/op/gemm.ccL167-R168](diffhunk://#diff-5cbeefe6d2ab80fbd44350603133779b381d613ca2f5b4f4a6bf89dbe98b6d2cL167-R168))
* Removed a warning log and the associated condition check for WGMMA when `M < 64` or `block_size % 128 != 0`, simplifying the logic. (`src/op/gemm.cc`, [src/op/gemm.ccL226-L229](diffhunk://#diff-5cbeefe6d2ab80fbd44350603133779b381d613ca2f5b4f4a6bf89dbe98b6d2cL226-L229))

### Changes in `ParallelOp` layout inference:

* Commented out the logic for handling replication in loop layouts, likely as part of a cleanup or temporary deprecation. (`src/op/parallel.cc`, [src/op/parallel.ccL184-R199](diffhunk://#diff-ef280fbd8aa7147455086fe8e3515b5a57544d0eee947850799f14812037b40eL184-R199))
* Removed an unnecessary blank line to improve code formatting. (`src/op/parallel.cc`, [src/op/parallel.ccR230](diffhunk://#diff-ef280fbd8aa7147455086fe8e3515b5a57544d0eee947850799f14812037b40eR230))