### PR TITLE
[Enhancement] Support cute mma tile mxn8ky

### DIFF
--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -215,7 +215,8 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
                   makeGemmABLayout(mat_stride, mat_continuous, mat_continuous,
                                    B->dtype.bits(), trans_B ? 2 : 1));
     } else if (B.scope() == "local.fragment") {
-      ICHECK(trans_B == false) << "B is local.fragment, trans_B must be false, please raise an issue if you see this";
+      ICHECK(trans_B == false) << "B is local.fragment, trans_B must be false, "
+                                  "please raise an issue if you see this";
       results.Set(B, makeGemmFragmentB(M, N, K, M / warp_m, N / warp_n));
     } else {
       ICHECK(0);

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -215,7 +215,7 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
                   makeGemmABLayout(mat_stride, mat_continuous, mat_continuous,
                                    B->dtype.bits(), trans_B ? 2 : 1));
     } else if (B.scope() == "local.fragment") {
-      ICHECK(trans_B == false);
+      ICHECK(trans_B == false) << "B is local.fragment, trans_B must be false, please raise an issue if you see this";
       results.Set(B, makeGemmFragmentB(M, N, K, M / warp_m, N / warp_n));
     } else {
       ICHECK(0);

--- a/src/tl_templates/cuda/gemm_sm80.h
+++ b/src/tl_templates/cuda/gemm_sm80.h
@@ -58,7 +58,8 @@ struct DispatchInstruction<half_t, half_t, float, num_warp_m, num_warp_n> {
 };
 #endif
 
-template <int Bits, int N, int K, bool K_inner, int num_warp_n, typename Enable = void>
+template <int Bits, int N, int K, bool K_inner, int num_warp_n,
+          typename Enable = void>
 struct OperandTraits {
   // Primary template, use padded layout and default copy
   static constexpr int stride = K_inner ? K : N;
@@ -76,7 +77,8 @@ struct OperandTraits<16, N, K, true, num_warp_n,
   using LayoutAtom = decltype(composition(
       Swizzle<2, 3, 3>{}, Layout<Shape<_8, _32>, Stride<_32, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N,
+                                         SM75_U32x4_LDSM_N>::type;
 };
 
 template <int N, int K, int num_warp_n>
@@ -85,7 +87,8 @@ struct OperandTraits<16, N, K, true, num_warp_n,
   using LayoutAtom = decltype(composition(
       Swizzle<3, 3, 3>{}, Layout<Shape<_8, _64>, Stride<_64, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N,
+                                         SM75_U32x4_LDSM_N>::type;
 };
 
 template <int N, int K, int num_warp_n>
@@ -114,7 +117,8 @@ struct OperandTraits<32, N, K, true, num_warp_n,
   using LayoutAtom = decltype(composition(
       Swizzle<3, 2, 3>{}, Layout<Shape<_8, _32>, Stride<_32, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N,
+                                         SM75_U32x4_LDSM_N>::type;
 };
 
 template <int N, int K, int num_warp_n>
@@ -123,7 +127,8 @@ struct OperandTraits<32, N, K, true, num_warp_n,
   using LayoutAtom = decltype(composition(
       Swizzle<2, 2, 3>{}, Layout<Shape<_8, _16>, Stride<_16, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N,
+                                         SM75_U32x4_LDSM_N>::type;
 };
 
 template <int N, int K, int num_warp_n>
@@ -161,7 +166,8 @@ struct OperandTraits<8, N, K, true, num_warp_n,
   using LayoutAtom = decltype(composition(
       Swizzle<3, 4, 3>{}, Layout<Shape<_8, _128>, Stride<_128, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N,
+                                         SM75_U32x4_LDSM_N>::type;
 };
 
 template <int N, int K, int num_warp_n>

--- a/src/tl_templates/cuda/gemm_sm89.h
+++ b/src/tl_templates/cuda/gemm_sm89.h
@@ -159,7 +159,7 @@ struct DispatchInstruction<half_t, half_t, float, num_warp_m, num_warp_n> {
 };
 #endif
 
-template <int Bits, int N, int K, bool K_inner, typename Enable = void>
+template <int Bits, int N, int K, bool K_inner, int num_warp_n, typename Enable = void>
 struct OperandTraits {
   // Primary template, use padded layout and default copy
   static constexpr int stride = K_inner ? K : N;
@@ -171,26 +171,26 @@ struct OperandTraits {
   using Copy = DefaultCopy;
 };
 
-template <int N, int K>
-struct OperandTraits<16, N, K, true,
+template <int N, int K, int num_warp_n>
+struct OperandTraits<16, N, K, true, num_warp_n,
                      typename std::enable_if<K % 64 == 32>::type> {
   using LayoutAtom = decltype(composition(
       Swizzle<2, 3, 3>{}, Layout<Shape<_8, _32>, Stride<_32, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = SM75_U32x4_LDSM_N;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
 };
 
-template <int N, int K>
-struct OperandTraits<16, N, K, true,
+template <int N, int K, int num_warp_n>
+struct OperandTraits<16, N, K, true, num_warp_n,
                      typename std::enable_if<K % 64 == 0>::type> {
   using LayoutAtom = decltype(composition(
       Swizzle<3, 3, 3>{}, Layout<Shape<_8, _64>, Stride<_64, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = SM75_U32x4_LDSM_N;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
 };
 
-template <int N, int K>
-struct OperandTraits<16, N, K, false,
+template <int N, int K, int num_warp_n>
+struct OperandTraits<16, N, K, false, num_warp_n,
                      typename std::enable_if<N % 64 == 32>::type> {
   using LayoutAtom = decltype(composition(
       Swizzle<2, 3, 3>{}, Layout<Shape<_32, _8>, Stride<_1, _32>>{}));
@@ -199,8 +199,8 @@ struct OperandTraits<16, N, K, false,
   using Copy = SM75_U16x8_LDSM_T;
 };
 
-template <int N, int K>
-struct OperandTraits<16, N, K, false,
+template <int N, int K, int num_warp_n>
+struct OperandTraits<16, N, K, false, num_warp_n,
                      typename std::enable_if<N % 64 == 0>::type> {
   using LayoutAtom = decltype(composition(
       Swizzle<3, 3, 3>{}, Layout<Shape<_64, _8>, Stride<_1, _64>>{}));
@@ -209,26 +209,26 @@ struct OperandTraits<16, N, K, false,
   using Copy = SM75_U16x8_LDSM_T;
 };
 
-template <int N, int K>
-struct OperandTraits<32, N, K, true,
+template <int N, int K, int num_warp_n>
+struct OperandTraits<32, N, K, true, num_warp_n,
                      typename std::enable_if<K % 32 == 0>::type> {
   using LayoutAtom = decltype(composition(
       Swizzle<3, 2, 3>{}, Layout<Shape<_8, _32>, Stride<_32, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = SM75_U32x4_LDSM_N;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
 };
 
-template <int N, int K>
-struct OperandTraits<32, N, K, true,
+template <int N, int K, int num_warp_n>
+struct OperandTraits<32, N, K, true, num_warp_n,
                      typename std::enable_if<K % 32 == 16>::type> {
   using LayoutAtom = decltype(composition(
       Swizzle<2, 2, 3>{}, Layout<Shape<_8, _16>, Stride<_16, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = SM75_U32x4_LDSM_N;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
 };
 
-template <int N, int K>
-struct OperandTraits<32, N, K, false,
+template <int N, int K, int num_warp_n>
+struct OperandTraits<32, N, K, false, num_warp_n,
                      typename std::enable_if<N % 32 == 0>::type> {
   using LayoutAtom = decltype(composition(
       Swizzle<3, 2, 3>{}, Layout<Shape<_32, _8>, Stride<_1, _32>>{}));
@@ -237,8 +237,8 @@ struct OperandTraits<32, N, K, false,
   using Copy = UniversalCopy<tfloat32_t>;
 };
 
-template <int N, int K>
-struct OperandTraits<32, N, K, false,
+template <int N, int K, int num_warp_n>
+struct OperandTraits<32, N, K, false, num_warp_n,
                      typename std::enable_if<N % 32 == 16>::type> {
   using LayoutAtom = decltype(composition(
       Swizzle<2, 2, 3>{}, Layout<Shape<_16, _8>, Stride<_1, _16>>{}));
@@ -247,26 +247,26 @@ struct OperandTraits<32, N, K, false,
   using Copy = UniversalCopy<tfloat32_t>;
 };
 
-template <int N, int K>
-struct OperandTraits<8, N, K, true,
+template <int N, int K, int num_warp_n>
+struct OperandTraits<8, N, K, true, num_warp_n,
                      typename std::enable_if<K % 128 == 64>::type> {
   using LayoutAtom = decltype(composition(
       Swizzle<2, 4, 3>{}, Layout<Shape<_8, _64>, Stride<_64, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = SM75_U32x4_LDSM_N;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
 };
 
-template <int N, int K>
-struct OperandTraits<8, N, K, true,
+template <int N, int K, int num_warp_n>
+struct OperandTraits<8, N, K, true, num_warp_n,
                      typename std::enable_if<K % 128 == 0>::type> {
   using LayoutAtom = decltype(composition(
       Swizzle<3, 4, 3>{}, Layout<Shape<_8, _128>, Stride<_128, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = SM75_U32x4_LDSM_N;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
 };
 
-template <int N, int K>
-struct OperandTraits<64, N, K, true,
+template <int N, int K, int num_warp_n>
+struct OperandTraits<64, N, K, true, num_warp_n,
                      typename std::enable_if<K % 16 == 0>::type> {
   using LayoutAtom = decltype(composition(
       Swizzle<2, 0, 4>{}, Layout<Shape<_4, _16>, Stride<_16, _1>>{}));
@@ -274,8 +274,8 @@ struct OperandTraits<64, N, K, true,
   using Copy = DefaultCopy;
 };
 
-template <int N, int K>
-struct OperandTraits<64, N, K, false,
+template <int N, int K, int num_warp_n>
+struct OperandTraits<64, N, K, false, num_warp_n,
                      typename std::enable_if<N % 16 == 0>::type> {
   using LayoutAtom = decltype(composition(
       Swizzle<2, 2, 2>{}, Layout<Shape<_16, _4>, Stride<_1, _16>>{}));
@@ -300,9 +300,9 @@ public:
       DispatchInstruction<A_type, B_type, C_type, num_warp_m, num_warp_n>;
 
   using OperandATraits =
-      OperandTraits<sizeof_bits<A_type>::value, M, K, !trans_A>;
+      OperandTraits<sizeof_bits<A_type>::value, M, K, !trans_A, num_warp_m>;
   using OperandBTraits =
-      OperandTraits<sizeof_bits<B_type>::value, N, K, trans_B>;
+      OperandTraits<sizeof_bits<B_type>::value, N, K, trans_B, num_warp_n>;
   using SmemLayoutA = typename OperandATraits::Layout;
   using SmemLayoutB = typename OperandBTraits::Layout;
   using SmemCopyA = Copy_Atom<typename OperandATraits::Copy, A_type>;

--- a/src/tl_templates/cuda/gemm_sm89.h
+++ b/src/tl_templates/cuda/gemm_sm89.h
@@ -13,7 +13,7 @@
 namespace cute {
 
 template <typename A_type, typename B_type, typename C_type, int num_warp_m,
-          int num_warp_n>
+          int num_warp_n, int N>
 struct DispatchInstruction;
 
 using _X = Underscore;
@@ -108,54 +108,56 @@ template <> struct MMA_Traits<SM89_16x8x32_F32F8F8F32_E5M2_TN> {
   using CLayout = SM80_16x8_Row;
 };
 
-template <int num_warp_m, int num_warp_n>
-struct DispatchInstruction<fp8_e4_t, fp8_e4_t, float, num_warp_m, num_warp_n> {
+template <int num_warp_m, int num_warp_n, int N>
+struct DispatchInstruction<fp8_e4_t, fp8_e4_t, float, num_warp_m, num_warp_n,
+                           N> {
   using MMA = MMA_Atom<SM89_16x8x32_F32F8F8F32_E4M3_TN>;
-  using MMA_Group = Tile<_X, Int<num_warp_n * 16>, _X>;
+  using MMA_Group = Tile<_X, Int<std::min(num_warp_n * 16, N)>, _X>;
 };
-template <int num_warp_m, int num_warp_n>
-struct DispatchInstruction<fp8_e5_t, fp8_e5_t, float, num_warp_m, num_warp_n> {
+template <int num_warp_m, int num_warp_n, int N>
+struct DispatchInstruction<fp8_e5_t, fp8_e5_t, float, num_warp_m, num_warp_n,
+                           N> {
   using MMA = MMA_Atom<SM89_16x8x32_F32F8F8F32_E5M2_TN>;
-  using MMA_Group = Tile<_X, Int<num_warp_n * 16>, _X>;
+  using MMA_Group = Tile<_X, Int<std::min(num_warp_n * 16, N)>, _X>;
 };
 
-template <int num_warp_m, int num_warp_n>
-struct DispatchInstruction<half_t, half_t, half_t, num_warp_m, num_warp_n> {
+template <int num_warp_m, int num_warp_n, int N>
+struct DispatchInstruction<half_t, half_t, half_t, num_warp_m, num_warp_n, N> {
   using MMA = MMA_Atom<SM80_16x8x16_F16F16F16F16_TN>;
-  using MMA_Group = Tile<_X, Int<num_warp_n * 16>, _X>;
+  using MMA_Group = Tile<_X, Int<std::min(num_warp_n * 16, N)>, _X>;
 };
-template <int num_warp_m, int num_warp_n>
-struct DispatchInstruction<half_t, half_t, float, num_warp_m, num_warp_n> {
+template <int num_warp_m, int num_warp_n, int N>
+struct DispatchInstruction<half_t, half_t, float, num_warp_m, num_warp_n, N> {
   using MMA = MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>;
-  using MMA_Group = Tile<_X, Int<num_warp_n * 16>, _X>;
+  using MMA_Group = Tile<_X, Int<std::min(num_warp_n * 16, N)>, _X>;
 };
-template <int num_warp_m, int num_warp_n>
+template <int num_warp_m, int num_warp_n, int N>
 struct DispatchInstruction<bfloat16_t, bfloat16_t, float, num_warp_m,
-                           num_warp_n> {
+                           num_warp_n, N> {
   using MMA = MMA_Atom<SM80_16x8x16_F32BF16BF16F32_TN>;
-  using MMA_Group = Tile<_X, Int<num_warp_n * 16>, _X>;
+  using MMA_Group = Tile<_X, Int<std::min(num_warp_n * 16, N)>, _X>;
 };
-template <int num_warp_m, int num_warp_n>
+template <int num_warp_m, int num_warp_n, int N>
 struct DispatchInstruction<tfloat32_t, tfloat32_t, float, num_warp_m,
-                           num_warp_n> {
+                           num_warp_n, N> {
   using MMA = MMA_Atom<SM80_16x8x8_F32TF32TF32F32_TN>;
-  using MMA_Group = Tile<_X, Int<num_warp_n * 16>, _X>;
+  using MMA_Group = Tile<_X, Int<std::min(num_warp_n * 16, N)>, _X>;
 };
-template <int num_warp_m, int num_warp_n>
-struct DispatchInstruction<int8_t, int8_t, int, num_warp_m, num_warp_n> {
+template <int num_warp_m, int num_warp_n, int N>
+struct DispatchInstruction<int8_t, int8_t, int, num_warp_m, num_warp_n, N> {
   using MMA = MMA_Atom<SM80_16x8x32_S32S8S8S32_TN>;
-  using MMA_Group = Tile<_X, Int<num_warp_n * 16>, _X>;
+  using MMA_Group = Tile<_X, Int<std::min(num_warp_n * 16, N)>, _X>;
 };
-template <int num_warp_m, int num_warp_n>
-struct DispatchInstruction<double, double, double, num_warp_m, num_warp_n> {
+template <int num_warp_m, int num_warp_n, int N>
+struct DispatchInstruction<double, double, double, num_warp_m, num_warp_n, N> {
   using MMA = MMA_Atom<SM80_8x8x4_F64F64F64F64_TN>;
   using MMA_Group = Tile<Int<num_warp_m * 16>, Int<num_warp_n * 16>, _X>;
 };
 #elif (defined(__CUDA_ARCH_LIST__) && (__CUDA_ARCH_LIST__ >= 750))
-template <int num_warp_m, int num_warp_n>
-struct DispatchInstruction<half_t, half_t, float, num_warp_m, num_warp_n> {
+template <int num_warp_m, int num_warp_n, int N>
+struct DispatchInstruction<half_t, half_t, float, num_warp_m, num_warp_n, N> {
   using MMA = MMA_Atom<SM75_16x8x8_F32F16F16F32_TN>;
-  using MMA_Group = Tile<_X, Int<num_warp_n * 16>, _16>;
+  using MMA_Group = Tile<_X, Int<std::min(num_warp_n * 16, N)>, _16>;
 };
 #endif
 
@@ -304,12 +306,13 @@ public:
                                 tfloat32_t, A_type_raw>::type;
   using C_type = C_type_raw;
   using Instruction =
-      DispatchInstruction<A_type, B_type, C_type, num_warp_m, num_warp_n>;
+      DispatchInstruction<A_type, B_type, C_type, num_warp_m, num_warp_n, N>;
 
   using OperandATraits =
       OperandTraits<sizeof_bits<A_type>::value, M, K, !trans_A, num_warp_m>;
   using OperandBTraits =
       OperandTraits<sizeof_bits<B_type>::value, N, K, trans_B, num_warp_n>;
+
   using SmemLayoutA = typename OperandATraits::Layout;
   using SmemLayoutB = typename OperandBTraits::Layout;
   using SmemCopyA = Copy_Atom<typename OperandATraits::Copy, A_type>;

--- a/src/tl_templates/cuda/gemm_sm89.h
+++ b/src/tl_templates/cuda/gemm_sm89.h
@@ -159,7 +159,8 @@ struct DispatchInstruction<half_t, half_t, float, num_warp_m, num_warp_n> {
 };
 #endif
 
-template <int Bits, int N, int K, bool K_inner, int num_warp_n, typename Enable = void>
+template <int Bits, int N, int K, bool K_inner, int num_warp_n,
+          typename Enable = void>
 struct OperandTraits {
   // Primary template, use padded layout and default copy
   static constexpr int stride = K_inner ? K : N;
@@ -177,7 +178,8 @@ struct OperandTraits<16, N, K, true, num_warp_n,
   using LayoutAtom = decltype(composition(
       Swizzle<2, 3, 3>{}, Layout<Shape<_8, _32>, Stride<_32, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N,
+                                         SM75_U32x4_LDSM_N>::type;
 };
 
 template <int N, int K, int num_warp_n>
@@ -186,7 +188,8 @@ struct OperandTraits<16, N, K, true, num_warp_n,
   using LayoutAtom = decltype(composition(
       Swizzle<3, 3, 3>{}, Layout<Shape<_8, _64>, Stride<_64, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N,
+                                         SM75_U32x4_LDSM_N>::type;
 };
 
 template <int N, int K, int num_warp_n>
@@ -215,7 +218,8 @@ struct OperandTraits<32, N, K, true, num_warp_n,
   using LayoutAtom = decltype(composition(
       Swizzle<3, 2, 3>{}, Layout<Shape<_8, _32>, Stride<_32, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N,
+                                         SM75_U32x4_LDSM_N>::type;
 };
 
 template <int N, int K, int num_warp_n>
@@ -224,7 +228,8 @@ struct OperandTraits<32, N, K, true, num_warp_n,
   using LayoutAtom = decltype(composition(
       Swizzle<2, 2, 3>{}, Layout<Shape<_8, _16>, Stride<_16, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N,
+                                         SM75_U32x4_LDSM_N>::type;
 };
 
 template <int N, int K, int num_warp_n>
@@ -253,7 +258,8 @@ struct OperandTraits<8, N, K, true, num_warp_n,
   using LayoutAtom = decltype(composition(
       Swizzle<2, 4, 3>{}, Layout<Shape<_8, _64>, Stride<_64, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N,
+                                         SM75_U32x4_LDSM_N>::type;
 };
 
 template <int N, int K, int num_warp_n>
@@ -262,7 +268,8 @@ struct OperandTraits<8, N, K, true, num_warp_n,
   using LayoutAtom = decltype(composition(
       Swizzle<3, 4, 3>{}, Layout<Shape<_8, _128>, Stride<_128, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N,
+                                         SM75_U32x4_LDSM_N>::type;
 };
 
 template <int N, int K, int num_warp_n>

--- a/src/tl_templates/cuda/gemm_sm90.h
+++ b/src/tl_templates/cuda/gemm_sm90.h
@@ -169,49 +169,49 @@ public:
 namespace tl_mma {
 
 template <typename A_type, typename B_type, typename C_type, int num_warp_m,
-          int num_warp_n>
+          int num_warp_n, int N>
 struct DispatchInstruction;
 
 using _X = Underscore;
 
 #if (defined(__CUDA_ARCH_LIST__) && (__CUDA_ARCH_LIST__ >= 800))
-template <int num_warp_m, int num_warp_n>
-struct DispatchInstruction<half_t, half_t, half_t, num_warp_m, num_warp_n> {
+template <int num_warp_m, int num_warp_n, int N>
+struct DispatchInstruction<half_t, half_t, half_t, num_warp_m, num_warp_n, N> {
   using MMA = MMA_Atom<SM80_16x8x16_F16F16F16F16_TN>;
-  using MMA_Group = Tile<_X, Int<num_warp_n * 16>, _X>;
+  using MMA_Group = Tile<_X, Int<std::min(num_warp_n * 16, N)>, _X>;
 };
-template <int num_warp_m, int num_warp_n>
-struct DispatchInstruction<half_t, half_t, float, num_warp_m, num_warp_n> {
+template <int num_warp_m, int num_warp_n, int N>
+struct DispatchInstruction<half_t, half_t, float, num_warp_m, num_warp_n, N> {
   using MMA = MMA_Atom<SM80_16x8x16_F32F16F16F32_TN>;
-  using MMA_Group = Tile<_X, Int<num_warp_n * 16>, _X>;
+  using MMA_Group = Tile<_X, Int<std::min(num_warp_n * 16, N)>, _X>;
 };
-template <int num_warp_m, int num_warp_n>
+template <int num_warp_m, int num_warp_n, int N>
 struct DispatchInstruction<bfloat16_t, bfloat16_t, float, num_warp_m,
-                           num_warp_n> {
+                           num_warp_n, N> {
   using MMA = MMA_Atom<SM80_16x8x16_F32BF16BF16F32_TN>;
-  using MMA_Group = Tile<_X, Int<num_warp_n * 16>, _X>;
+  using MMA_Group = Tile<_X, Int<std::min(num_warp_n * 16, N)>, _X>;
 };
-template <int num_warp_m, int num_warp_n>
+template <int num_warp_m, int num_warp_n, int N>
 struct DispatchInstruction<tfloat32_t, tfloat32_t, float, num_warp_m,
-                           num_warp_n> {
+                           num_warp_n, N> {
   using MMA = MMA_Atom<SM80_16x8x8_F32TF32TF32F32_TN>;
-  using MMA_Group = Tile<_X, Int<num_warp_n * 16>, _X>;
+  using MMA_Group = Tile<_X, Int<std::min(num_warp_n * 16, N)>, _X>;
 };
-template <int num_warp_m, int num_warp_n>
-struct DispatchInstruction<int8_t, int8_t, int, num_warp_m, num_warp_n> {
+template <int num_warp_m, int num_warp_n, int N>
+struct DispatchInstruction<int8_t, int8_t, int, num_warp_m, num_warp_n, N> {
   using MMA = MMA_Atom<SM80_16x8x32_S32S8S8S32_TN>;
-  using MMA_Group = Tile<_X, Int<num_warp_n * 16>, _X>;
+  using MMA_Group = Tile<_X, Int<std::min(num_warp_n * 16, N)>, _X>;
 };
-template <int num_warp_m, int num_warp_n>
-struct DispatchInstruction<double, double, double, num_warp_m, num_warp_n> {
+template <int num_warp_m, int num_warp_n, int N>
+struct DispatchInstruction<double, double, double, num_warp_m, num_warp_n, N> {
   using MMA = MMA_Atom<SM80_8x8x4_F64F64F64F64_TN>;
   using MMA_Group = Tile<Int<num_warp_m * 16>, Int<num_warp_n * 16>, _X>;
 };
 #elif (defined(__CUDA_ARCH_LIST__) && (__CUDA_ARCH_LIST__ >= 750))
-template <int num_warp_m, int num_warp_n>
-struct DispatchInstruction<half_t, half_t, float, num_warp_m, num_warp_n> {
+template <int num_warp_m, int num_warp_n, int N>
+struct DispatchInstruction<half_t, half_t, float, num_warp_m, num_warp_n, N> {
   using MMA = MMA_Atom<SM75_16x8x8_F32F16F16F32_TN>;
-  using MMA_Group = Tile<_X, Int<num_warp_n * 16>, _16>;
+  using MMA_Group = Tile<_X, Int<std::min(num_warp_n * 16, N)>, _16>;
 };
 #endif
 
@@ -360,7 +360,7 @@ public:
                                 tfloat32_t, A_type_raw>::type;
   using C_type = C_type_raw;
   using Instruction =
-      DispatchInstruction<A_type, B_type, C_type, num_warp_m, num_warp_n>;
+      DispatchInstruction<A_type, B_type, C_type, num_warp_m, num_warp_n, N>;
 
   using OperandATraits =
       OperandTraits<sizeof_bits<A_type>::value, M, K, !trans_A, num_warp_m>;

--- a/src/tl_templates/cuda/gemm_sm90.h
+++ b/src/tl_templates/cuda/gemm_sm90.h
@@ -215,7 +215,8 @@ struct DispatchInstruction<half_t, half_t, float, num_warp_m, num_warp_n> {
 };
 #endif
 
-template <int Bits, int N, int K, bool K_inner, int num_warp_n, typename Enable = void>
+template <int Bits, int N, int K, bool K_inner, int num_warp_n,
+          typename Enable = void>
 struct OperandTraits {
   // Primary template, use padded layout and default copy
   static constexpr int stride = K_inner ? K : N;
@@ -233,7 +234,8 @@ struct OperandTraits<16, N, K, true, num_warp_n,
   using LayoutAtom = decltype(composition(
       Swizzle<2, 3, 3>{}, Layout<Shape<_8, _32>, Stride<_32, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N,
+                                         SM75_U32x4_LDSM_N>::type;
 };
 
 template <int N, int K, int num_warp_n>
@@ -242,7 +244,8 @@ struct OperandTraits<16, N, K, true, num_warp_n,
   using LayoutAtom = decltype(composition(
       Swizzle<3, 3, 3>{}, Layout<Shape<_8, _64>, Stride<_64, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N,
+                                         SM75_U32x4_LDSM_N>::type;
 };
 
 template <int N, int K, int num_warp_n>
@@ -271,7 +274,8 @@ struct OperandTraits<32, N, K, true, num_warp_n,
   using LayoutAtom = decltype(composition(
       Swizzle<3, 2, 3>{}, Layout<Shape<_8, _32>, Stride<_32, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N,
+                                         SM75_U32x4_LDSM_N>::type;
 };
 
 template <int N, int K, int num_warp_n>
@@ -280,7 +284,8 @@ struct OperandTraits<32, N, K, true, num_warp_n,
   using LayoutAtom = decltype(composition(
       Swizzle<2, 2, 3>{}, Layout<Shape<_8, _16>, Stride<_16, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N,
+                                         SM75_U32x4_LDSM_N>::type;
 };
 
 template <int N, int K, int num_warp_n>
@@ -309,7 +314,8 @@ struct OperandTraits<8, N, K, true, num_warp_n,
   using LayoutAtom = decltype(composition(
       Swizzle<2, 4, 3>{}, Layout<Shape<_8, _64>, Stride<_64, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N,
+                                         SM75_U32x4_LDSM_N>::type;
 };
 
 template <int N, int K, int num_warp_n>
@@ -318,7 +324,8 @@ struct OperandTraits<8, N, K, true, num_warp_n,
   using LayoutAtom = decltype(composition(
       Swizzle<3, 4, 3>{}, Layout<Shape<_8, _128>, Stride<_128, _1>>{}));
   using Layout = decltype(tile_to_shape(LayoutAtom{}, Shape<Int<N>, Int<K>>{}));
-  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N, SM75_U32x4_LDSM_N>::type;
+  using Copy = typename std::conditional<N == 8 * num_warp_n, SM75_U32x2_LDSM_N,
+                                         SM75_U32x4_LDSM_N>::type;
 };
 
 template <int N, int K, int num_warp_n>

--- a/testing/python/language/test_tilelang_language_cumsum.py
+++ b/testing/python/language/test_tilelang_language_cumsum.py
@@ -53,7 +53,7 @@ def run_cumsum(M, N, block_M, block_N, dim=0, reverse=False, dtype="float16", sc
     elif scope == "fragment":
         program = cumsum_fragment_test(M, N, block_M, block_N, dim, reverse, dtype)
     jit_kernel = tl.compile(program, out_idx=-1)
-    profiler = jit_kernel.get_profiler(tensor_supply_type=tl.TensorSupplyType.One)
+    profiler = jit_kernel.get_profiler(tensor_supply_type=tl.TensorDistributionType.Randn)
 
     def ref_program(A):
         ref_b = torch.empty_like(A)
@@ -64,8 +64,8 @@ def run_cumsum(M, N, block_M, block_N, dim=0, reverse=False, dtype="float16", sc
                                                          block_N:(j + 1) * block_N].cumsum(dim=dim)
                 if reverse:
                     ref_b[i * block_M:(i + 1) * block_M, j * block_N:(j + 1) *
-                          block_N] = ref_b[i * block_M:(i + 1) * block_M,
-                                           j * block_N:(j + 1) * block_N].flip(dims=[dim])
+                          block_N] = A[i * block_M:(i + 1) * block_M, j * block_N:(j + 1) *
+                                       block_N].flip(dims=[dim]).cumsum(dim=dim).flip(dims=[dim])
         return ref_b
 
     profiler.assert_allclose(ref_program)


### PR DESCRIPTION
This pull request introduces significant updates to the GEMM (General Matrix Multiplication) implementation across multiple files, focusing on improving flexibility and correctness in operand handling and memory layout. The changes include additional template parameters for warp-level configurations, conditional logic for memory copy optimizations, and enhanced error checking for specific cases.

### Error Handling Improvements:
* Added a descriptive error message to the `ICHECK` condition in `Gemm::InferLayout` to clarify the requirement that `trans_B` must be `false` when `B` is a `local.fragment`.

### Template Enhancements for GEMM Operations:
* Introduced a new `num_warp_n` template parameter to `OperandTraits` in `gemm_sm80.h`, `gemm_sm89.h`, and `gemm_sm90.h`. This allows for more flexible configurations of warp-level memory layouts. [[1]](diffhunk://#diff-3574d9f9ad86e7f09a85627cd9ccd6fe5610def4b28ab218015df45f8995dc1cL61-R62) [[2]](diffhunk://#diff-ad04ba7f25634279353fa4e23cae2735273630685939cf92fd849ae4001db652L162-R163) [[3]](diffhunk://#diff-e643206d884073ffebc2e1157a72c72de5ae2d2aa96e4793bb8038d888885224L218-R219)
* Updated `OperandTraits` across multiple files to use `std::conditional` for selecting appropriate memory copy strategies (`SM75_U32x2_LDSM_N` or `SM75_U32x4_LDSM_N`) based on warp-level configurations. [[1]](diffhunk://#diff-3574d9f9ad86e7f09a85627cd9ccd6fe5610def4b28ab218015df45f8995dc1cL73-R95) [[2]](diffhunk://#diff-ad04ba7f25634279353fa4e23cae2735273630685939cf92fd849ae4001db652L174-R196) [[3]](diffhunk://#diff-e643206d884073ffebc2e1157a72c72de5ae2d2aa96e4793bb8038d888885224L230-R252)

### Memory Layout and Copy Logic:
* Adjusted the `OperandTraits` structures to include the new `num_warp_n` parameter, ensuring compatibility with various matrix shapes and strides for both row-major and column-major layouts. [[1]](diffhunk://#diff-3574d9f9ad86e7f09a85627cd9ccd6fe5610def4b28ab218015df45f8995dc1cL101-R105) [[2]](diffhunk://#diff-ad04ba7f25634279353fa4e23cae2735273630685939cf92fd849ae4001db652L202-R206) [[3]](diffhunk://#diff-e643206d884073ffebc2e1157a72c72de5ae2d2aa96e4793bb8038d888885224L258-R262)
* Enhanced memory layout definitions (`LayoutAtom` and `Layout`) for different operand configurations, ensuring that the tiling and swizzling logic aligns with the updated warp-level parameters. [[1]](diffhunk://#diff-3574d9f9ad86e7f09a85627cd9ccd6fe5610def4b28ab218015df45f8995dc1cL111-R135) [[2]](diffhunk://#diff-ad04ba7f25634279353fa4e23cae2735273630685939cf92fd849ae4001db652L212-R236) [[3]](diffhunk://#diff-e643206d884073ffebc2e1157a72c72de5ae2d2aa96e4793bb8038d888885224L268-R292)

### GEMM Tensor Operation Updates:
* Updated `GemmTensorOp` in `gemm_sm89.h` to use the new `num_warp_m` and `num_warp_n` parameters in `OperandTraits` for both operand A and B. This ensures that shared memory layouts and copy operations are consistent with the updated template logic.