### PR TITLE
[Testing] Add atomic add test 

### DIFF
--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -244,9 +244,7 @@ bool IndiceCanVectorize(PrimExpr expr, Var var, PrimExpr iter_var_size,
   PrimExpr expr_simplified = analyzer->Simplify(expr_transformed);
 
   Vectorizer vectorizer(v0, IntImm(v0->dtype, target_vectorized_size));
-  PrimExpr expr_vectorized =
-      analyzer->Simplify(vectorizer.VisitExpr(expr_transformed));
-
+  PrimExpr expr_vectorized = vectorizer.VisitExpr(expr_transformed);
   auto ramp_node = expr_vectorized.as<RampNode>();
   if (!ramp_node) {
     // Broadcast value

--- a/testing/python/language/test_tilelang_language_atomic_add.py
+++ b/testing/python/language/test_tilelang_language_atomic_add.py
@@ -1,0 +1,49 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+
+import tilelang.testing
+import tilelang.language as T
+
+
+def atomic_add_program(K, M, N, block_M, block_N, dtype="float"):
+
+    @T.prim_func
+    def atomic_add(A: T.Tensor((K, M, N), dtype), B: T.Tensor((M, N), dtype)):
+        with T.Kernel(T.ceildiv(M, block_M), T.ceildiv(N, block_N), K, threads=32) as (bx, by, bz):
+            A_shared = T.alloc_shared((block_M, block_N), dtype)
+
+            T.copy(A[bz, bx * block_M:(bx + 1) * block_M, by * block_N:(by + 1) * block_N],
+                   A_shared)
+
+            for i, j in T.Parallel(block_M, block_N):
+                T.atomic_add(B[bx * block_M + i, by * block_N + j], A_shared[i, j])
+
+    return atomic_add
+
+
+def run_atomic_add(K, M, N, block_M, block_N, dtype="float32"):
+    program = atomic_add_program(K, M, N, block_M, block_N, dtype=dtype)
+    kernel = tilelang.compile(program)
+    # print(kernel.get_kernel_source())
+    import torch
+
+    def ref_program(A, B):
+        for k in range(K):
+            for i in range(M):
+                for j in range(N):
+                    B[i, j] += A[k, i, j]
+
+    A = torch.randn(K, M, N, dtype=getattr(torch, dtype)).cuda()
+    B = torch.zeros(M, N, dtype=getattr(torch, dtype)).cuda()
+    ref_B = B.clone()
+    ref_program(A, ref_B)
+    kernel(A, B)
+    torch.testing.assert_close(B, ref_B)
+
+
+def test_atomic_add():
+    run_atomic_add(8, 128, 128, 32, 32)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
This pull request includes changes to improve vectorization in the `IndiceCanVectorize` function and adds a new test for atomic addition in the TileLang language. Below is a summary of the most important changes:

### Improvements to vectorization:

* [`src/transform/loop_vectorize.cc`](diffhunk://#diff-20d3812edb240aac433ab7465ddf602fc0dd6bf78b47d51ab32fe6524476b094L247-R247): Simplified the `IndiceCanVectorize` function by removing an unnecessary call to `analyzer->Simplify` after vectorizing the transformed expression. This reduces redundant computation.

### New test for atomic addition:

* `testing/python/language/test_tilelang_language_atomic_add.py`: Added a new test file to verify the correctness of atomic addition functionality in TileLang. This includes:
  - A `T.prim_func` implementation of an atomic addition kernel.
  - A reference implementation for validation.
  - A test case (`test_atomic_add`) to compare the results of the kernel against the reference implementation using PyTorch.