### PR TITLE
[Refactor] Update KernelLaunch to clarify block name

### DIFF
--- a/src/ir.cc
+++ b/src/ir.cc
@@ -162,6 +162,7 @@ KernelLaunchFrame KernelLaunch(Array<PrimExpr> grid_size,
       attrs.defined() && attrs.count(tilelang_is_cpu_kernel_frame);
 
   if (is_cpu_kernel_frame) {
+    // Launch CPU Kernel
     ICHECK(grid_size.size() >= 0);
     ICHECK(block_size.size() == 0) << "CPU kernel cannot have block size";
     ICHECK(attrs.defined());
@@ -170,7 +171,6 @@ KernelLaunchFrame KernelLaunch(Array<PrimExpr> grid_size,
       n->frames.push_back(
           MakeIterVarFrame("block_var_" + std::to_string(i), grid_size[i]));
     }
-    // Launch CPU Kernel
   } else {
     // Launch GPU Kernel
     ICHECK(grid_size.size() <= 3);
@@ -203,17 +203,15 @@ KernelLaunchFrame KernelLaunch(Array<PrimExpr> grid_size,
             CreateEnvThread("tz", "threadIdx.z", block_size[2].dtype()),
             block_size[2]));
       }
-    } else {
-      n->frames.push_back(Block(""));
     }
   }
 
   if (attrs.defined()) {
-    auto empty_block = Block("");
+    auto empty_block = Block("root");
     empty_block->annotations = attrs;
     n->frames.push_back(empty_block);
   } else {
-    n->frames.push_back(Block(""));
+    n->frames.push_back(Block("root"));
   }
 
   return KernelLaunchFrame(n);


### PR DESCRIPTION
This pull request refactors the `KernelLaunch` function in `src/ir.cc` to improve clarity and consistency in handling CPU and GPU kernel launches. The most significant changes include reorganizing comments, ensuring proper annotations for blocks, and replacing empty block names with a more descriptive default.

### Improvements to code clarity:

* Reorganized the comment for launching the CPU kernel to align with the relevant code block, improving readability. [[1]](diffhunk://#diff-fd7749ba50b6074ced53829097c03ece00d7572477e24cf9dd416cd807dfe75fR165) [[2]](diffhunk://#diff-fd7749ba50b6074ced53829097c03ece00d7572477e24cf9dd416cd807dfe75fL173)

### Consistency in block handling:

* Replaced empty block names (`Block("")`) with a more descriptive default (`Block("root")`) to enhance code clarity and maintain consistency. This change applies both when attributes are defined and in the fallback case.