### PR TITLE
[Language] Support explicit programming for identified warp groups  

### DIFF
--- a/examples/deepseek_mla/experimental/example_mla_decode_kv_fp8.py
+++ b/examples/deepseek_mla/experimental/example_mla_decode_kv_fp8.py
@@ -53,7 +53,7 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
             T.fill(acc_o, 0)
             T.fill(logsum, 0)
             T.fill(scores_max, -T.infinity(accum_dtype))
-            T.NoSetMaxNReg()
+            T.no_set_max_nreg()
             loop_range = T.ceildiv(seqlen_kv, block_N)
             for k in T.Pipelined(loop_range, num_stages=2):
                 T.copy(KV[bx, k * block_N:(k + 1) * block_N, cur_kv_head, :], qKV_shared)

--- a/examples/warp_specialize/gemm_ws.py
+++ b/examples/warp_specialize/gemm_ws.py
@@ -3,6 +3,7 @@
 import tilelang
 import tilelang.language as T
 
+
 def matmul(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype="float"):
     # add decorator @tilelang.jit if you want to return a torch function
     @T.prim_func
@@ -44,10 +45,15 @@ func = matmul(128, 128, 64, 128, 128, 32)
 # out_idx specifies the index of the output buffer in the argument list
 # if out_idx is specified, the tensor will be created during runtime
 # target currently can be "cuda" or "hip" or "cpu".
-jit_kernel = tilelang.compile(func, out_idx=[2], target="cuda", execution_backend="cython", pass_configs={
-    "tl.disable_warp_specialized": True,
-    "tl.disable_tma_lower": True,
-})
+jit_kernel = tilelang.compile(
+    func,
+    out_idx=[2],
+    target="cuda",
+    execution_backend="cython",
+    pass_configs={
+        "tl.disable_warp_specialized": True,
+        "tl.disable_tma_lower": True,
+    })
 print(jit_kernel.get_kernel_source())
 # jit_kernel = tilelang.compile(func, out_idx=[2], target="cuda", execution_backend="dlpack")
 print(jit_kernel.get_kernel_source(), file=open("gemm_ws.cu", "w"))

--- a/examples/warp_specialize/gemm_ws.py
+++ b/examples/warp_specialize/gemm_ws.py
@@ -55,8 +55,6 @@ jit_kernel = tilelang.compile(
         "tl.disable_tma_lower": True,
     })
 print(jit_kernel.get_kernel_source())
-# jit_kernel = tilelang.compile(func, out_idx=[2], target="cuda", execution_backend="dlpack")
-print(jit_kernel.get_kernel_source(), file=open("gemm_ws.cu", "w"))
 # 3. Test the kernel in Python with PyTorch data
 import torch
 

--- a/examples/warp_specialize/gemm_ws.py
+++ b/examples/warp_specialize/gemm_ws.py
@@ -1,0 +1,81 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+import tilelang
+import tilelang.language as T
+
+def matmul(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype="float"):
+    # add decorator @tilelang.jit if you want to return a torch function
+    @T.prim_func
+    def main(
+            A: T.Tensor((M, K), dtype),
+            B: T.Tensor((K, N), dtype),
+            C: T.Tensor((M, N), dtype),
+    ):
+        # Initialize Kernel Context
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=256) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), dtype, "shared")
+            B_shared = T.alloc_shared((block_K, block_N), dtype, "shared")
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+            # create mbarrier for tma
+            T.create_list_of_mbarrier(128, 128)
+
+            with T.ws(1):
+                for ko in range(T.ceildiv(K, block_K)):
+                    T.mbarrier_wait_parity(T.get_mbarrier(1), ko ^ 1)
+                    T.copy(A[by * block_M, ko * block_K], A_shared)
+                    T.copy(B[ko * block_K, bx * block_N], B_shared)
+                    T.ptx_arrive_barrier(T.get_mbarrier(0))
+            with T.ws(0):
+                T.clear(C_local)
+                for ko in range(T.ceildiv(K, block_K)):
+                    T.mbarrier_wait_parity(T.get_mbarrier(0), ko)
+                    T.gemm(A_shared, B_shared, C_local)
+                    T.ptx_arrive_barrier(T.get_mbarrier(1))
+                T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+# 1. Define the kernel (matmul) and compile/lower it into an executable module
+func = matmul(128, 128, 64, 128, 128, 32)
+
+# 2. Compile the kernel into a torch function
+# out_idx specifies the index of the output buffer in the argument list
+# if out_idx is specified, the tensor will be created during runtime
+# target currently can be "cuda" or "hip" or "cpu".
+jit_kernel = tilelang.compile(func, out_idx=[2], target="cuda", execution_backend="cython", pass_configs={
+    "tl.disable_warp_specialized": True,
+    "tl.disable_tma_lower": True,
+})
+print(jit_kernel.get_kernel_source())
+# jit_kernel = tilelang.compile(func, out_idx=[2], target="cuda", execution_backend="dlpack")
+print(jit_kernel.get_kernel_source(), file=open("gemm_ws.cu", "w"))
+# 3. Test the kernel in Python with PyTorch data
+import torch
+
+# Create random input tensors on the GPU
+a = torch.randn(128, 64, device="cuda", dtype=torch.float16)
+b = torch.randn(64, 128, device="cuda", dtype=torch.float16)
+
+# Run the kernel through the Profiler
+c = jit_kernel(a, b)
+
+print(c)
+# Reference multiplication using PyTorch
+ref_c = a @ b
+
+# Validate correctness
+torch.testing.assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
+print("Kernel output matches PyTorch reference.")
+
+# 4. Retrieve and inspect the generated CUDA source (optional)
+# cuda_source = jit_kernel.get_kernel_source()
+# print("Generated CUDA kernel:\n", cuda_source)
+
+# 5.Profile latency with kernel
+profiler = jit_kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
+
+latency = profiler.do_bench()
+
+print(f"Latency: {latency} ms")

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -162,6 +162,7 @@ KernelLaunchFrame KernelLaunch(Array<PrimExpr> grid_size,
       attrs.defined() && attrs.count(tilelang_is_cpu_kernel_frame);
 
   if (is_cpu_kernel_frame) {
+    // Launch CPU Kernel
     ICHECK(grid_size.size() >= 0);
     ICHECK(block_size.size() == 0) << "CPU kernel cannot have block size";
     ICHECK(attrs.defined());
@@ -170,7 +171,6 @@ KernelLaunchFrame KernelLaunch(Array<PrimExpr> grid_size,
       n->frames.push_back(
           MakeIterVarFrame("block_var_" + std::to_string(i), grid_size[i]));
     }
-    // Launch CPU Kernel
   } else {
     // Launch GPU Kernel
     ICHECK(grid_size.size() <= 3);
@@ -203,17 +203,15 @@ KernelLaunchFrame KernelLaunch(Array<PrimExpr> grid_size,
             CreateEnvThread("tz", "threadIdx.z", block_size[2].dtype()),
             block_size[2]));
       }
-    } else {
-      n->frames.push_back(Block(""));
     }
   }
 
   if (attrs.defined()) {
-    auto empty_block = Block("");
+    auto empty_block = Block("root");
     empty_block->annotations = attrs;
     n->frames.push_back(empty_block);
   } else {
-    n->frames.push_back(Block(""));
+    n->frames.push_back(Block("root"));
   }
 
   return KernelLaunchFrame(n);

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -252,13 +252,16 @@ public:
 
 class WarpSpecializeFrame : public TIRFrame {
 public:
-  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(WarpSpecializeFrame, TIRFrame,
+  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(WarpSpecializeFrame,
+                                                    TIRFrame,
                                                     WarpSpecializeFrameNode);
 };
 
-WarpSpecializeFrame WarpSpecialize(int warp_group_idx, PrimExpr thread_idx, int warp_group_size = 128) {
+WarpSpecializeFrame WarpSpecialize(int warp_group_idx, PrimExpr thread_idx,
+                                   int warp_group_size = 128) {
   ObjectPtr<WarpSpecializeFrameNode> n = make_object<WarpSpecializeFrameNode>();
-  PrimExpr min_bound = max(0, IntImm(thread_idx.dtype(), warp_group_idx) * warp_group_size);
+  PrimExpr min_bound =
+      max(0, IntImm(thread_idx.dtype(), warp_group_idx) * warp_group_size);
   PrimExpr max_bound = min_bound + warp_group_size;
   PrimExpr condition = thread_idx >= min_bound && thread_idx < max_bound;
   IfFrame if_frame = If(condition);

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -223,5 +223,52 @@ TVM_REGISTER_GLOBAL("tl.Parallel").set_body_typed(ParallelFor);
 TVM_REGISTER_GLOBAL("tl.Pipelined").set_body_typed(PipelinedFor);
 TVM_REGISTER_GLOBAL("tl.KernelLaunch").set_body_typed(KernelLaunch);
 
+class WarpSpecializeFrameNode : public TIRFrameNode {
+public:
+  Array<TIRFrame> frames;
+
+  void VisitAttrs(tvm::AttrVisitor *v) {
+    TIRFrameNode::VisitAttrs(v);
+    v->Visit("frames", &frames);
+  }
+
+  static constexpr const char *_type_key = "tl.WarpSpecializeFrame";
+  TVM_DECLARE_FINAL_OBJECT_INFO(WarpSpecializeFrameNode, TIRFrameNode);
+
+public:
+  TVM_DLL void EnterWithScope() final {
+    for (auto frame = frames.begin(); frame != frames.end(); ++frame)
+      (*frame)->EnterWithScope();
+  }
+  /*!
+   * \brief The method called when exiting RAII scope.
+   * \sa tvm::support::With
+   */
+  TVM_DLL void ExitWithScope() final {
+    for (auto frame = frames.rbegin(); frame != frames.rend(); ++frame)
+      (*frame)->ExitWithScope();
+  }
+};
+
+class WarpSpecializeFrame : public TIRFrame {
+public:
+  TVM_DEFINE_MUTABLE_NOTNULLABLE_OBJECT_REF_METHODS(WarpSpecializeFrame, TIRFrame,
+                                                    WarpSpecializeFrameNode);
+};
+
+WarpSpecializeFrame WarpSpecialize(int warp_group_idx, PrimExpr thread_idx, int warp_group_size = 128) {
+  ObjectPtr<WarpSpecializeFrameNode> n = make_object<WarpSpecializeFrameNode>();
+  PrimExpr min_bound = max(0, IntImm(thread_idx.dtype(), warp_group_idx) * warp_group_size);
+  PrimExpr max_bound = min_bound + warp_group_size;
+  PrimExpr condition = thread_idx >= min_bound && thread_idx < max_bound;
+  IfFrame if_frame = If(condition);
+  n->frames.push_back(if_frame);
+  n->frames.push_back(Then());
+  return WarpSpecializeFrame(n);
+}
+
+TVM_REGISTER_NODE_TYPE(WarpSpecializeFrameNode);
+TVM_REGISTER_GLOBAL("tl.WarpSpecialize").set_body_typed(WarpSpecialize);
+
 } // namespace tl
 } // namespace tvm

--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -61,10 +61,8 @@ TIR_DEFINE_TL_BUILTIN(tma_load_im2col)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(tma_store)
-    .set_num_inputs(-1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
+TIR_DEFINE_TL_BUILTIN(tma_store).set_num_inputs(-1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
 
 TIR_DEFINE_TL_BUILTIN(mbarrier_wait_parity)
     .set_num_inputs(2)
@@ -115,8 +113,10 @@ TIR_DEFINE_TL_BUILTIN(no_set_max_nreg)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(wait_wgmma).set_num_inputs(1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+TIR_DEFINE_TL_BUILTIN(wait_wgmma)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
 
 TIR_DEFINE_TL_BUILTIN(pack_b16).set_num_inputs(2).set_attr<TCallEffectKind>(
     "TCallEffectKind", Integer(CallEffectKind::kPure));

--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -33,92 +33,92 @@ TVM_REGISTER_PASS_CONFIG_OPTION(kDynamicAlignment, Integer);
   TVM_REGISTER_OP("tl." #OpName)                                               \
       .set_attr<TScriptPrinterName>("TScriptPrinterName", #OpName)
 
-TIR_DEFINE_TL_BUILTIN(CreateListofMBarrierOp)
+TIR_DEFINE_TL_BUILTIN(create_list_of_mbarrier)
     .set_num_inputs(-1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(CreateTMADescriptorOp)
+TIR_DEFINE_TL_BUILTIN(create_tma_descriptor)
     .set_num_inputs(-1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kPure));
 
-TIR_DEFINE_TL_BUILTIN(CreateTMAIm2ColDescriptorOp)
+TIR_DEFINE_TL_BUILTIN(create_tma_im2col_descriptor)
     .set_num_inputs(-1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kPure));
 
-TIR_DEFINE_TL_BUILTIN(GetMBarrierOp)
+TIR_DEFINE_TL_BUILTIN(get_mbarrier)
     .set_num_inputs(1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kPure));
 
-TIR_DEFINE_TL_BUILTIN(TMALoadOp).set_num_inputs(-1).set_attr<TCallEffectKind>(
+TIR_DEFINE_TL_BUILTIN(tma_load).set_num_inputs(-1).set_attr<TCallEffectKind>(
     "TCallEffectKind", Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(TMALoadIm2ColOp)
+TIR_DEFINE_TL_BUILTIN(tma_load_im2col)
     .set_num_inputs(-1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(TMAStoreOp)
+TIR_DEFINE_TL_BUILTIN(tma_store)
     .set_num_inputs(-1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(MBarrierWaitParity)
+TIR_DEFINE_TL_BUILTIN(mbarrier_wait_parity)
     .set_num_inputs(2)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(MBarrierExpectTX)
+TIR_DEFINE_TL_BUILTIN(mbarrier_expect_tx)
     .set_num_inputs(2)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(LDMatrixOp)
+TIR_DEFINE_TL_BUILTIN(ptx_ldmatirx)
     .set_num_inputs(4)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(STMatrixOp)
+TIR_DEFINE_TL_BUILTIN(ptx_stmatirx)
     .set_num_inputs(-1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(SyncThreadsPartialOp)
+TIR_DEFINE_TL_BUILTIN(sync_thread_partial)
     .set_num_inputs(1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(FenceProxyAsyncOp)
+TIR_DEFINE_TL_BUILTIN(fence_proxy_async)
     .set_num_inputs(0)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(TMAStoreArrive)
+TIR_DEFINE_TL_BUILTIN(tma_store_arrive)
     .set_num_inputs(0)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(TMAStoreWait)
+TIR_DEFINE_TL_BUILTIN(tma_store_wait)
     .set_num_inputs(0)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
-TIR_DEFINE_TL_BUILTIN(SetMaxNReg)
+TIR_DEFINE_TL_BUILTIN(set_max_nreg)
     .set_num_inputs(2)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(NoSetMaxNReg)
+TIR_DEFINE_TL_BUILTIN(no_set_max_nreg)
     .set_num_inputs(0)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(WaitWgmma).set_num_inputs(1).set_attr<TCallEffectKind>(
+TIR_DEFINE_TL_BUILTIN(wait_wgmma).set_num_inputs(1).set_attr<TCallEffectKind>(
     "TCallEffectKind", Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(PackB16Op).set_num_inputs(2).set_attr<TCallEffectKind>(
+TIR_DEFINE_TL_BUILTIN(pack_b16).set_num_inputs(2).set_attr<TCallEffectKind>(
     "TCallEffectKind", Integer(CallEffectKind::kPure));
 } // namespace tl
 } // namespace tvm

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -45,31 +45,31 @@ static constexpr const char *kDynamicAlignment = "tl.dynamic_alignment";
 /*!
  * \brief tvm intrinsics for TMADescriptor creation for tiled load
  *
- * CuTensorMap* CreateTMADescriptorOp(data_type, rank, global_addr,
+ * CuTensorMap* create_tma_descriptor(data_type, rank, global_addr,
  * global_shape..., global_stride..., smem_box..., smem_stride..., interleave,
  * swizzle, l2_promotion, oob_fill)
  *
  */
-const Op &CreateTMADescriptorOp();
+const Op &create_tma_descriptor();
 
 /*!
  * \brief tvm intrinsics for TMADescriptor creation for image to column load
  *
- * CuTensorMap* CreateTMAIm2ColDescriptorOp(data_type, rank, global_addr,
+ * CuTensorMap* create_tma_im2col_descriptor(data_type, rank, global_addr,
  * global_shape..., global_stride..., elem_stride..., lower_corner...,
  * upper_corner..., smme_box_pixel, smem_box_channel, interleave, swizzle,
  * l2_promotion, oob_fill)
  *
  */
-const Op &CreateTMAIm2ColDescriptorOp();
+const Op &create_tma_im2col_descriptor();
 
 /*!
  * \brief Create a list of mbarrier with num_threads
  *
- * CreateListofMBarrierOp(num_threads0, num_threads1, ...)
+ * create_list_of_mbarrier(num_threads0, num_threads1, ...)
  *
  */
-const Op &CreateListofMBarrierOp();
+const Op &create_list_of_mbarrier();
 
 /*!
  * \brief Get the mbarrier with barrier_id
@@ -77,83 +77,83 @@ const Op &CreateListofMBarrierOp();
  * int64_t* GetMBarrier(barrier_id)
  *
  */
-const Op &GetMBarrierOp();
+const Op &get_mbarrier();
 
 /*!
  * \brief tvm intrinsics for loading data from global tensor descriptor to
  * shared memory
  *
- * TMALoadOp(descriptor, mbarrier, smem_data, coord_0, coord_1, ...)
+ * tma_load(descriptor, mbarrier, smem_data, coord_0, coord_1, ...)
  *
  */
-const Op &TMALoadOp();
+const Op &tma_load();
 
 /*!
  * \brief tvm intrinsics for loading image from global tensor to columns in
  * shared memory
  *
- * TMALoadOp(descriptor, mbarrier, smem_data, coord_0, coord_1, ...,
+ * tma_load(descriptor, mbarrier, smem_data, coord_0, coord_1, ...,
  * image_offset, ...)
  *
  */
-const Op &TMALoadIm2ColOp();
+const Op &tma_load_im2col();
 
 /*!
  * \brief tvm intrinsics for storing data from shared memory to global tensor
  * descriptor
  *
- * TMAStoreOp(descriptor, smem_data, coord_0, coord_1, ...)
+ * tma_store(descriptor, smem_data, coord_0, coord_1, ...)
  *
  */
-const Op &TMAStoreOp();
+const Op &tma_store();
 
 /*!
  * \brief tvm intrinsics for mbarrier wait with parity bit
  *
- * MBarrierWaitParity(mbarrier, parity)
+ * mbarrier_wait_parity(mbarrier, parity)
  *
  */
-const Op &MBarrierWaitParity();
+const Op &mbarrier_wait_parity();
 
 /*!
  * \brief tvm intrinsics for mbarrier expect tx
  *
- * MBarrierExpectTX(mbarrier, transaction_bytes)
+ * mbarrier_expect_tx(mbarrier, transaction_bytes)
  *
  */
-const Op &MBarrierExpectTX();
+const Op &mbarrier_expect_tx();
 
 /*!
  * \brief tvm intrinsics for ldmatrix
  *
- * LDMatrixOp(transposed, num, shared_addr, local_addr)
+ * ptx_ldmatirx(transposed, num, shared_addr, local_addr)
  *
  */
-const Op &LDMatrixOp();
+const Op &ptx_ldmatirx();
 
 /*!
  * \brief tvm intrinsics for stmatrix
  *
- * LDMatrixOp(transposed, num, shared_addr, int32_values...)
+ * ptx_ldmatirx(transposed, num, shared_addr, int32_values...)
  *
  */
-const Op &STMatrixOp();
+const Op &ptx_stmatirx();
 
 /*!
  * \brief Pack two b16 value into a b32 value
  *
- * int32 PackB16Op(b16_value, b16_value)
+ * int32 pack_b16(b16_value, b16_value)
  *
  */
-const Op &PackB16Op();
+const Op &pack_b16();
 
 /*!
  * \brief Similar to __syncthreads(), but can be used to sync partial threads
  *
- * SyncThreadsPartialOp(num_partial_threads or mbarrier)
+ * sync_thread_partial(num_partial_threads or mbarrier)
  *
  */
-const Op &SyncThreadsPartialOp();
+const Op &sync_thread_partial();
 
 /*!
  * \brief Issue a shared memory fence for async operations
@@ -161,23 +161,23 @@ const Op &SyncThreadsPartialOp();
  * FenceProxyAsync()
  *
  */
-const Op &FenceProxyAsyncOp();
+const Op &fence_proxy_async();
 
 /*!
  * \brief Indicate arrival of warp issuing TMA_STORE
  *
- * TMAStoreArrive()
+ * tma_store_arrive()
  *
  */
-const Op &TMAStoreArrive();
+const Op &tma_store_arrive();
 
 /*!
  * \brief Wait for TMA_STORE to finish
  *
- * TMAStoreWait()
+ * tma_store_wait()
  *
  */
-const Op &TMAStoreWait();
+const Op &tma_store_wait();
 
 /*!
  * \brief Set reg hint for warp-specialized branched
@@ -185,23 +185,23 @@ const Op &TMAStoreWait();
  * SetMaxNRegInc(num_reg, is_inc)
  *
  */
-const Op &SetMaxNReg();
+const Op &set_max_nreg();
 
 /*!
  * \brief No set reg hint for warp-specialized branched
  *
- * NoSetMaxNReg()
+ * no_set_max_nreg()
  *
  */
-const Op &NoSetMaxNReg();
+const Op &no_set_max_nreg();
 
 /*!
  * \brief Wait the previous wgmma to finish
  *
- * WaitWgmma(num_mma)
+ * wait_wgmma(num_mma)
  *
  */
-const Op &WaitWgmma();
+const Op &wait_wgmma();
 
 /*!
  * \brief tvm intrinsic for amd matrix core mfma instructions.

--- a/src/op/bulk_copy.cc
+++ b/src/op/bulk_copy.cc
@@ -210,14 +210,14 @@ Stmt Copy::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer) const {
   desc.smem_box.Set(0, PrimExpr(instruction_dim));
 
   Call create_descriptor =
-      Call(DataType::Handle(), CreateTMADescriptorOp(), desc.EncodeCallArgs());
+      Call(DataType::Handle(), create_tma_descriptor(), desc.EncodeCallArgs());
 
   Array<PrimExpr> args;
   args.reserve(desc.rank + 3);
   args.push_back(create_descriptor);
   if (is_load)
     args.push_back(0); // mbarrier id placeholder
-  auto op = is_load ? TMALoadOp() : TMAStoreOp();
+  auto op = is_load ? tma_load() : tma_store();
 
   Stmt tma_copy;
 
@@ -346,7 +346,7 @@ Stmt Conv2DIm2ColOp::Lower(const LowerArgs &T,
     }
   }
 
-  Call create_desc = Call(DataType::Handle(), CreateTMAIm2ColDescriptorOp(),
+  Call create_desc = Call(DataType::Handle(), create_tma_im2col_descriptor(),
                           desc.EncodeCallArgs());
 
   Array<PrimExpr> global_coords; // c, w, h, n
@@ -397,7 +397,7 @@ Stmt Conv2DIm2ColOp::Lower(const LowerArgs &T,
 
   Stmt tma_copy =
       IfThenElse(EQ(T.thread_var, 0),
-                 Evaluate(Call(DataType::Handle(), TMALoadIm2ColOp(), args)));
+                 Evaluate(Call(DataType::Handle(), tma_load_im2col(), args)));
   return tma_copy;
 }
 

--- a/src/op/elem.cc
+++ b/src/op/elem.cc
@@ -171,8 +171,8 @@ Stmt Copy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     }
     auto loop_layout = par_op->GetLoopLayout();
     auto thread_var = T.thread_var;
-    auto thread_loop = PartitionLoop(par_op->GetRoot(), T.thread_var, analyzer,
-                                     loop_layout);
+    auto thread_loop =
+        PartitionLoop(par_op->GetRoot(), T.thread_var, analyzer, loop_layout);
     vectorized_thread_loop = VectorizeLoop(thread_loop);
   }
 

--- a/src/op/elem.cc
+++ b/src/op/elem.cc
@@ -169,9 +169,10 @@ Stmt Copy::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
       par_op->InferLayout(
           {T.target, T.thread_bounds, T.layout_map, T.buffer_remap}, level);
     }
-
+    auto loop_layout = par_op->GetLoopLayout();
+    auto thread_var = T.thread_var;
     auto thread_loop = PartitionLoop(par_op->GetRoot(), T.thread_var, analyzer,
-                                     par_op->GetLoopLayout());
+                                     loop_layout);
     vectorized_thread_loop = VectorizeLoop(thread_loop);
   }
 
@@ -278,7 +279,7 @@ Stmt Copy::LowerLDSMCopy(const LowerArgs &T, arith::Analyzer *analyzer) const {
     num = 2;
 
   Array<PrimExpr> args;
-  const Op &op = is_ldmatrix ? tl::LDMatrixOp() : tl::STMatrixOp();
+  const Op &op = is_ldmatrix ? tl::ptx_ldmatirx() : tl::ptx_stmatirx();
   args.push_back(static_cast<int>(is_transposed));
   args.push_back(num);
 
@@ -327,7 +328,7 @@ Stmt Copy::LowerLDSMCopy(const LowerArgs &T, arith::Analyzer *analyzer) const {
         value1 = Cast(shared_tensor->dtype, value1);
       }
       PrimExpr value_packed =
-          Call(DataType::Int(32), PackB16Op(), {value0, value1});
+          Call(DataType::Int(32), pack_b16(), {value0, value1});
       args.push_back(value_packed);
     }
   }

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -164,8 +164,7 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
     return {};
   LayoutMap results;
   ICHECK(C.scope() == "local.fragment");
-  auto block_size = *as_const_int(T.thread_bounds->extent) -
-                    *as_const_int(T.thread_bounds->min);
+  auto block_size = *as_const_int(T.thread_bounds->extent);
   if (TargetIsVolta(T.target)) {
     const int warp_size = 32;
     auto [warp_m, warp_n] =

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -146,7 +146,7 @@ LayoutMap ParallelOp::InferLayout(const LayoutInferArgs &T, InferLevel level) {
   if (level == InferLevel::kStrict)
     return {};
 
-  auto block_size = T.thread_bounds->extent - T.thread_bounds->min;
+  auto block_size = T.thread_bounds->extent;
   // Step 1: try to infer loop's partition from a source fragment
   Buffer source_buffer, read_source_buffer;
   for (const auto &[buffer, indices] : indice_map_) {
@@ -228,7 +228,7 @@ LayoutMap ParallelOp::InferLayout(const LayoutInferArgs &T, InferLevel level) {
     }
     PrimExpr loop_thread_extent = loop_layout_->ThreadExtent();
     if (!analyzer_.CanProveEqual(loop_thread_extent, block_size))
-      AddPredicate(LT(InputPlaceholder(0), loop_thread_extent));
+      AddPredicate(LT(InputPlaceholder(0) - T.thread_bounds->min, loop_thread_extent));
   } else {
     return {};
   }

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -228,7 +228,8 @@ LayoutMap ParallelOp::InferLayout(const LayoutInferArgs &T, InferLevel level) {
     }
     PrimExpr loop_thread_extent = loop_layout_->ThreadExtent();
     if (!analyzer_.CanProveEqual(loop_thread_extent, block_size))
-      AddPredicate(LT(InputPlaceholder(0) - T.thread_bounds->min, loop_thread_extent));
+      AddPredicate(
+          LT(InputPlaceholder(0) - T.thread_bounds->min, loop_thread_extent));
   } else {
     return {};
   }

--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -12,10 +12,12 @@
 #include <tvm/tir/builtin.h>
 #include <tvm/tir/op.h>
 #include <tvm/tir/op_attr_types.h>
+#include <tvm/tir/stmt_functor.h>
 
 #include "../layout/utils.h"
 #include "../transform/loop_partition.h"
 #include "tir/transforms/ir_utils.h"
+
 
 namespace tvm {
 namespace tl {
@@ -310,7 +312,7 @@ Stmt CumSumOp::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
              this->src.scope() == "shared") {
     ICHECK(this->dst.scope() == "shared.dyn" || this->dst.scope() == "shared");
     std::stringstream ss;
-    auto threads = T.thread_bounds->extent - T.thread_bounds->min;
+    auto threads = T.thread_bounds->extent;
     ss << "tl::CumSum2D<" << threads << ", " << dim << ", "
        << (reverse ? "true" : "false") << ">::run";
     Array<PrimExpr> args = {StringImm(ss.str()), src.access_ptr(1),

--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -18,7 +18,6 @@
 #include "../transform/loop_partition.h"
 #include "tir/transforms/ir_utils.h"
 
-
 namespace tvm {
 namespace tl {
 

--- a/src/target/codegen_cuda.cc
+++ b/src/target/codegen_cuda.cc
@@ -810,7 +810,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     std::string barrier_name = "_mbarrier";
     this->stream << "__shared__ uint64_t " << barrier_name << "["
                  << barrier_count << "];\n";
-  } else if (op->op.same_as(tl::GetMBarrierOp())) {
+  } else if (op->op.same_as(tl::get_mbarrier())) {
     std::string barrier_name = "_mbarrier";
     std::string barrier_id = this->PrintExpr(op->args[0]);
     os << barrier_name + "[" + barrier_id + "]";
@@ -822,50 +822,50 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     print_extern_call_stmt("tl::mbarrier_arrive_expect_tx");
   } else if (op->op.same_as(builtin::ptx_cp_async_barrier())) {
     print_extern_call_stmt("tl::mbarrier_cp_async_arrive");
-  } else if (op->op.same_as(tl::MBarrierExpectTX())) {
+  } else if (op->op.same_as(tl::mbarrier_expect_tx())) {
     print_extern_call_stmt("tl::mbarrier_expect_tx");
-  } else if (op->op.same_as(tl::MBarrierWaitParity())) {
+  } else if (op->op.same_as(tl::mbarrier_wait_parity())) {
     print_extern_call_stmt("tl::mbarrier_wait");
-  } else if (op->op.same_as(tl::SyncThreadsPartialOp())) {
+  } else if (op->op.same_as(tl::sync_thread_partial())) {
     print_extern_call_stmt("tl::syncthreads_partial");
-  } else if (op->op.same_as(tl::TMALoadOp())) {
+  } else if (op->op.same_as(tl::tma_load())) {
     print_extern_call_stmt("tl::tma_load");
-  } else if (op->op.same_as(tl::TMALoadIm2ColOp())) {
+  } else if (op->op.same_as(tl::tma_load_im2col())) {
     print_extern_call_stmt("tl::tma_load_im2col");
-  } else if (op->op.same_as(tl::TMAStoreOp())) {
+  } else if (op->op.same_as(tl::tma_store())) {
     print_extern_call_stmt("tl::tma_store");
-  } else if (op->op.same_as(tl::LDMatrixOp())) {
+  } else if (op->op.same_as(tl::ptx_ldmatirx())) {
     int trans = Downcast<IntImm>(op->args[0])->value;
     int num = Downcast<IntImm>(op->args[1])->value;
     std::string func_name = "tl::ptx_ldmatrix_x" + std::to_string(num);
     if (trans == 1)
       func_name += "_trans";
     print_extern_call_stmt(func_name, 2);
-  } else if (op->op.same_as(tl::STMatrixOp())) {
+  } else if (op->op.same_as(tl::ptx_stmatirx())) {
     int trans = Downcast<IntImm>(op->args[0])->value;
     int num = Downcast<IntImm>(op->args[1])->value;
     std::string func_name = "tl::ptx_stmatrix_x" + std::to_string(num);
     if (trans == 1)
       func_name += "_trans";
     print_extern_call_stmt(func_name, 2);
-  } else if (op->op.same_as(tl::FenceProxyAsyncOp())) {
+  } else if (op->op.same_as(tl::fence_proxy_async())) {
     print_extern_call_stmt("tl::fence_proxy_async");
-  } else if (op->op.same_as(tl::TMAStoreArrive())) {
+  } else if (op->op.same_as(tl::tma_store_arrive())) {
     print_extern_call_stmt("tl::tma_store_arrive");
-  } else if (op->op.same_as(tl::TMAStoreWait())) {
+  } else if (op->op.same_as(tl::tma_store_wait())) {
     print_extern_call_stmt("tl::tma_store_wait<0>");
-  } else if (op->op.same_as(tl::SetMaxNReg())) {
+  } else if (op->op.same_as(tl::set_max_nreg())) {
     this->PrintIndent();
     int nreg = Downcast<IntImm>(op->args[0])->value;
     int is_inc = Downcast<IntImm>(op->args[1])->value;
     std::string func_name =
         is_inc ? "tl::warpgroup_reg_alloc" : "tl::warpgroup_reg_dealloc";
     this->stream << func_name << "<" << std::to_string(nreg) << ">();\n";
-  } else if (op->op.same_as(tl::WaitWgmma())) {
+  } else if (op->op.same_as(tl::wait_wgmma())) {
     this->PrintIndent();
     int num_mma = Downcast<IntImm>(op->args[0])->value;
     this->stream << "tl::wait_wgmma<" << std::to_string(num_mma) << ">();\n";
-  } else if (op->op.same_as(tl::PackB16Op())) {
+  } else if (op->op.same_as(tl::pack_b16())) {
     os << "__pack_half2(" << this->PrintExpr(op->args[0]) << ", "
        << this->PrintExpr(op->args[1]) << ")";
   } else if (op->op.same_as(builtin::tvm_fill_fragment())) {

--- a/src/target/codegen_hip.cc
+++ b/src/target/codegen_hip.cc
@@ -768,7 +768,7 @@ void CodeGenTileLangHIP::VisitExpr_(const CallNode *op, std::ostream &os) {
     std::string barrier_name = "_mbarrier";
     this->stream << "__shared__ uint64_t " << barrier_name << "["
                  << barrier_count << "];\n";
-  } else if (op->op.same_as(tl::GetMBarrierOp())) {
+  } else if (op->op.same_as(tl::get_mbarrier())) {
     std::string barrier_name = "_mbarrier";
     std::string barrier_id = this->PrintExpr(op->args[0]);
     os << barrier_name + "[" + barrier_id + "]";
@@ -780,46 +780,46 @@ void CodeGenTileLangHIP::VisitExpr_(const CallNode *op, std::ostream &os) {
     print_extern_call_stmt("tl::mbarrier_arrive_expect_tx");
   } else if (op->op.same_as(builtin::ptx_cp_async_barrier())) {
     print_extern_call_stmt("tl::mbarrier_cp_async_arrive");
-  } else if (op->op.same_as(tl::MBarrierExpectTX())) {
+  } else if (op->op.same_as(tl::mbarrier_expect_tx())) {
     print_extern_call_stmt("tl::mbarrier_expect_tx");
-  } else if (op->op.same_as(tl::MBarrierWaitParity())) {
+  } else if (op->op.same_as(tl::mbarrier_wait_parity())) {
     print_extern_call_stmt("tl::mbarrier_wait");
-  } else if (op->op.same_as(tl::SyncThreadsPartialOp())) {
+  } else if (op->op.same_as(tl::sync_thread_partial())) {
     print_extern_call_stmt("tl::syncthreads_partial");
-  } else if (op->op.same_as(tl::TMALoadOp())) {
+  } else if (op->op.same_as(tl::tma_load())) {
     print_extern_call_stmt("tl::tma_load");
-  } else if (op->op.same_as(tl::TMALoadIm2ColOp())) {
+  } else if (op->op.same_as(tl::tma_load_im2col())) {
     print_extern_call_stmt("tl::tma_load_im2col");
-  } else if (op->op.same_as(tl::TMAStoreOp())) {
+  } else if (op->op.same_as(tl::tma_store())) {
     print_extern_call_stmt("tl::tma_store");
-  } else if (op->op.same_as(tl::LDMatrixOp())) {
+  } else if (op->op.same_as(tl::ptx_ldmatirx())) {
     int trans = Downcast<IntImm>(op->args[0])->value;
     int num = Downcast<IntImm>(op->args[1])->value;
     std::string func_name = "tl::ptx_ldmatrix_x" + std::to_string(num);
     if (trans == 1)
       func_name += "_trans";
     print_extern_call_stmt(func_name, 2);
-  } else if (op->op.same_as(tl::STMatrixOp())) {
+  } else if (op->op.same_as(tl::ptx_stmatirx())) {
     int trans = Downcast<IntImm>(op->args[0])->value;
     int num = Downcast<IntImm>(op->args[1])->value;
     std::string func_name = "tl::ptx_stmatrix_x" + std::to_string(num);
     if (trans == 1)
       func_name += "_trans";
     print_extern_call_stmt(func_name, 2);
-  } else if (op->op.same_as(tl::FenceProxyAsyncOp())) {
+  } else if (op->op.same_as(tl::fence_proxy_async())) {
     print_extern_call_stmt("tl::fence_proxy_async");
-  } else if (op->op.same_as(tl::SetMaxNReg())) {
+  } else if (op->op.same_as(tl::set_max_nreg())) {
     this->PrintIndent();
     int nreg = Downcast<IntImm>(op->args[0])->value;
     int is_inc = Downcast<IntImm>(op->args[1])->value;
     std::string func_name =
         is_inc ? "tl::warpgroup_reg_alloc" : "tl::warpgroup_reg_dealloc";
     this->stream << func_name << "<" << std::to_string(nreg) << ">();\n";
-  } else if (op->op.same_as(tl::WaitWgmma())) {
+  } else if (op->op.same_as(tl::wait_wgmma())) {
     this->PrintIndent();
     int num_mma = Downcast<IntImm>(op->args[0])->value;
     this->stream << "tl::wait_wgmma<" << std::to_string(num_mma) << ">();\n";
-  } else if (op->op.same_as(tl::PackB16Op())) {
+  } else if (op->op.same_as(tl::pack_b16())) {
     os << "__pack_half2(" << this->PrintExpr(op->args[0]) << ", "
        << this->PrintExpr(op->args[1]) << ")";
   } else if (op->op.same_as(builtin::tvm_fill_fragment())) {

--- a/src/transform/eliminate_storage_sync_for_mbarrier.cc
+++ b/src/transform/eliminate_storage_sync_for_mbarrier.cc
@@ -1,0 +1,104 @@
+// Copyright (c) Tile-AI Corporation.
+// Licensed under the MIT License.
+/*!
+ * \file eliminate_storage_sync_for_mbarrier.cc
+ */
+#include <tvm/runtime/registry.h>
+#include <tvm/tir/analysis.h>
+#include <tvm/tir/builtin.h>
+#include <tvm/tir/expr.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
+#include "arith/ir_mutator_with_analyzer.h"
+#include "arith/ir_visitor_with_analyzer.h"
+#include "./storage_access.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tir;
+using arith::IRMutatorWithAnalyzer;
+using arith::IRVisitorWithAnalyzer;
+
+class Eliminator : public IRMutatorWithAnalyzer {
+public:
+    static Stmt Substitute(Stmt stmt, bool skip_thread_partition = false) {
+        arith::Analyzer analyzer;
+        Eliminator transformer(&analyzer);
+        return transformer.VisitStmt(stmt);
+    }
+    
+    Eliminator(arith::Analyzer *analyzer)
+        : IRMutatorWithAnalyzer(analyzer) {
+        in_mbarrier_region_ = false;
+    }
+
+    Stmt VisitStmt_(const AttrStmtNode *op) final {
+        if (op->attr_key == "thread_extent") {
+            const VarNode* var = nullptr;
+            if (op->node->IsInstance<VarNode>()) {
+                var = static_cast<const VarNode*>(op->node.get());
+                if (var->name_hint == "threadIdx.x") {
+                    thread_extent_ = op;
+                }
+            }
+        }
+        return IRMutatorWithAnalyzer::VisitStmt_(op);
+    }
+
+    Stmt VisitStmt_(const EvaluateNode* op) final {
+        const CallNode* call = nullptr;
+        if (op->value->IsInstance<CallNode>()) {
+            call = static_cast<const CallNode*>(op->value.get());
+            if (call->op.same_as(builtin::tvm_storage_sync())) {
+                // Skip storage sync if we're in a region with mbarrier operations
+                if (in_mbarrier_region_) {
+                    return Stmt();
+                }
+            } else if (call->op.same_as(builtin::ptx_arrive_barrier()) || 
+                      call->op.same_as(builtin::ptx_wait_barrier())) {
+                in_mbarrier_region_ = true;
+            }
+        }
+        return IRMutatorWithAnalyzer::VisitStmt_(op);
+    }
+
+    Stmt VisitStmt_(const IfThenElseNode* op) final {
+        bool old_in_mbarrier = in_mbarrier_region_;
+        Stmt then_case = VisitStmt(op->then_case);
+        
+        Stmt ret;
+        if (op->else_case.defined()) {
+            in_mbarrier_region_ = old_in_mbarrier;
+            Stmt else_case = VisitStmt(op->else_case.value());
+            in_mbarrier_region_ = old_in_mbarrier || in_mbarrier_region_;
+            ret = IfThenElse(VisitExpr(op->condition), then_case, else_case);
+        } else {
+            in_mbarrier_region_ = old_in_mbarrier || in_mbarrier_region_;
+            ret = IfThenElse(VisitExpr(op->condition), then_case, Stmt());
+        }
+        return ret;
+    }
+
+private:
+    bool in_mbarrier_region_;
+    const AttrStmtNode* thread_extent_{nullptr};
+};
+using namespace tir::transform;
+
+namespace transform {
+
+tvm::transform::Pass EliminateStorageSyncForMBarrier() {
+  auto pass_func = [](PrimFunc f, IRModule m, PassContext ctx) {
+    auto *n = f.CopyOnWrite();
+    n->body = Eliminator::Substitute(std::move(n->body));
+    return f;
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.EliminateStorageSyncForMBarrier", {});
+}
+
+TVM_REGISTER_GLOBAL("tl.transform.EliminateStorageSyncForMBarrier").set_body_typed(EliminateStorageSyncForMBarrier);
+
+} // namespace transform
+} // namespace tl
+} // namespace tvm

--- a/src/transform/eliminate_storage_sync_for_mbarrier.cc
+++ b/src/transform/eliminate_storage_sync_for_mbarrier.cc
@@ -3,15 +3,15 @@
 /*!
  * \file eliminate_storage_sync_for_mbarrier.cc
  */
+#include "./storage_access.h"
+#include "arith/ir_mutator_with_analyzer.h"
+#include "arith/ir_visitor_with_analyzer.h"
 #include <tvm/runtime/registry.h>
 #include <tvm/tir/analysis.h>
 #include <tvm/tir/builtin.h>
 #include <tvm/tir/expr.h>
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/tir/transform.h>
-#include "arith/ir_mutator_with_analyzer.h"
-#include "arith/ir_visitor_with_analyzer.h"
-#include "./storage_access.h"
 
 namespace tvm {
 namespace tl {
@@ -22,67 +22,66 @@ using arith::IRVisitorWithAnalyzer;
 
 class Eliminator : public IRMutatorWithAnalyzer {
 public:
-    static Stmt Substitute(Stmt stmt, bool skip_thread_partition = false) {
-        arith::Analyzer analyzer;
-        Eliminator transformer(&analyzer);
-        return transformer.VisitStmt(stmt);
-    }
-    
-    Eliminator(arith::Analyzer *analyzer)
-        : IRMutatorWithAnalyzer(analyzer) {
-        in_mbarrier_region_ = false;
-    }
+  static Stmt Substitute(Stmt stmt, bool skip_thread_partition = false) {
+    arith::Analyzer analyzer;
+    Eliminator transformer(&analyzer);
+    return transformer.VisitStmt(stmt);
+  }
 
-    Stmt VisitStmt_(const AttrStmtNode *op) final {
-        if (op->attr_key == "thread_extent") {
-            const VarNode* var = nullptr;
-            if (op->node->IsInstance<VarNode>()) {
-                var = static_cast<const VarNode*>(op->node.get());
-                if (var->name_hint == "threadIdx.x") {
-                    thread_extent_ = op;
-                }
-            }
-        }
-        return IRMutatorWithAnalyzer::VisitStmt_(op);
-    }
+  Eliminator(arith::Analyzer *analyzer) : IRMutatorWithAnalyzer(analyzer) {
+    in_mbarrier_region_ = false;
+  }
 
-    Stmt VisitStmt_(const EvaluateNode* op) final {
-        const CallNode* call = nullptr;
-        if (op->value->IsInstance<CallNode>()) {
-            call = static_cast<const CallNode*>(op->value.get());
-            if (call->op.same_as(builtin::tvm_storage_sync())) {
-                // Skip storage sync if we're in a region with mbarrier operations
-                if (in_mbarrier_region_) {
-                    return Stmt();
-                }
-            } else if (call->op.same_as(builtin::ptx_arrive_barrier()) || 
-                      call->op.same_as(builtin::ptx_wait_barrier())) {
-                in_mbarrier_region_ = true;
-            }
+  Stmt VisitStmt_(const AttrStmtNode *op) final {
+    if (op->attr_key == "thread_extent") {
+      const VarNode *var = nullptr;
+      if (op->node->IsInstance<VarNode>()) {
+        var = static_cast<const VarNode *>(op->node.get());
+        if (var->name_hint == "threadIdx.x") {
+          thread_extent_ = op;
         }
-        return IRMutatorWithAnalyzer::VisitStmt_(op);
+      }
     }
+    return IRMutatorWithAnalyzer::VisitStmt_(op);
+  }
 
-    Stmt VisitStmt_(const IfThenElseNode* op) final {
-        bool old_in_mbarrier = in_mbarrier_region_;
-        Stmt then_case = VisitStmt(op->then_case);
-        
-        Stmt ret;
-        if (op->else_case.defined()) {
-            in_mbarrier_region_ = old_in_mbarrier;
-            Stmt else_case = VisitStmt(op->else_case.value());
-            in_mbarrier_region_ = old_in_mbarrier || in_mbarrier_region_;
-            ret = IfThenElse(VisitExpr(op->condition), then_case, else_case);
-        } else {
-            in_mbarrier_region_ = old_in_mbarrier || in_mbarrier_region_;
-            ret = IfThenElse(VisitExpr(op->condition), then_case, Stmt());
+  Stmt VisitStmt_(const EvaluateNode *op) final {
+    const CallNode *call = nullptr;
+    if (op->value->IsInstance<CallNode>()) {
+      call = static_cast<const CallNode *>(op->value.get());
+      if (call->op.same_as(builtin::tvm_storage_sync())) {
+        // Skip storage sync if we're in a region with mbarrier operations
+        if (in_mbarrier_region_) {
+          return Stmt();
         }
-        return ret;
+      } else if (call->op.same_as(builtin::ptx_arrive_barrier()) ||
+                 call->op.same_as(builtin::ptx_wait_barrier())) {
+        in_mbarrier_region_ = true;
+      }
     }
+    return IRMutatorWithAnalyzer::VisitStmt_(op);
+  }
+
+  Stmt VisitStmt_(const IfThenElseNode *op) final {
+    bool old_in_mbarrier = in_mbarrier_region_;
+    Stmt then_case = VisitStmt(op->then_case);
+
+    Stmt ret;
+    if (op->else_case.defined()) {
+      in_mbarrier_region_ = old_in_mbarrier;
+      Stmt else_case = VisitStmt(op->else_case.value());
+      in_mbarrier_region_ = old_in_mbarrier || in_mbarrier_region_;
+      ret = IfThenElse(VisitExpr(op->condition), then_case, else_case);
+    } else {
+      in_mbarrier_region_ = old_in_mbarrier || in_mbarrier_region_;
+      ret = IfThenElse(VisitExpr(op->condition), then_case, Stmt());
+    }
+    return ret;
+  }
 
 private:
-    bool in_mbarrier_region_;
-    const AttrStmtNode* thread_extent_{nullptr};
+  bool in_mbarrier_region_;
+  const AttrStmtNode *thread_extent_{nullptr};
 };
 using namespace tir::transform;
 
@@ -94,10 +93,12 @@ tvm::transform::Pass EliminateStorageSyncForMBarrier() {
     n->body = Eliminator::Substitute(std::move(n->body));
     return f;
   };
-  return CreatePrimFuncPass(pass_func, 0, "tl.EliminateStorageSyncForMBarrier", {});
+  return CreatePrimFuncPass(pass_func, 0, "tl.EliminateStorageSyncForMBarrier",
+                            {});
 }
 
-TVM_REGISTER_GLOBAL("tl.transform.EliminateStorageSyncForMBarrier").set_body_typed(EliminateStorageSyncForMBarrier);
+TVM_REGISTER_GLOBAL("tl.transform.EliminateStorageSyncForMBarrier")
+    .set_body_typed(EliminateStorageSyncForMBarrier);
 
 } // namespace transform
 } // namespace tl

--- a/src/transform/inject_fence_proxy.cc
+++ b/src/transform/inject_fence_proxy.cc
@@ -56,7 +56,8 @@ public:
   void VisitStmt_(const EvaluateNode *op) final {
     Proxy proxy = Proxy::kAsync;
     if (auto call = op->value.as<CallNode>()) {
-      if (call->op.same_as(ptx_ldmatirx()) || call->op.same_as(ptx_stmatirx())) {
+      if (call->op.same_as(ptx_ldmatirx()) ||
+          call->op.same_as(ptx_stmatirx())) {
         proxy = Proxy::kGeneric;
       }
     }

--- a/src/transform/inject_fence_proxy.cc
+++ b/src/transform/inject_fence_proxy.cc
@@ -56,7 +56,7 @@ public:
   void VisitStmt_(const EvaluateNode *op) final {
     Proxy proxy = Proxy::kAsync;
     if (auto call = op->value.as<CallNode>()) {
-      if (call->op.same_as(LDMatrixOp()) || call->op.same_as(STMatrixOp())) {
+      if (call->op.same_as(ptx_ldmatirx()) || call->op.same_as(ptx_stmatirx())) {
         proxy = Proxy::kGeneric;
       }
     }
@@ -123,13 +123,13 @@ public:
 private:
   Stmt VisitStmt_(const EvaluateNode *op) final {
     if (auto call = op->value.as<CallNode>()) {
-      if (call->op.same_as(TMAStoreOp())) {
+      if (call->op.same_as(tma_store())) {
         Array<Stmt> new_body;
         new_body.push_back(GetRef<Evaluate>(op));
         new_body.push_back(
-            Evaluate(Call(DataType::Handle(), TMAStoreArrive(), {})));
+            Evaluate(Call(DataType::Handle(), tma_store_arrive(), {})));
         new_body.push_back(
-            Evaluate(Call(DataType::Handle(), TMAStoreWait(), {})));
+            Evaluate(Call(DataType::Handle(), tma_store_wait(), {})));
         return SeqStmt(std::move(new_body));
       }
     }
@@ -157,7 +157,7 @@ private:
     Array<Stmt> new_body;
     Proxy cur_proxy, prev_proxy;
     auto fence_stmt =
-        Evaluate(Call(DataType::Handle(), FenceProxyAsyncOp(), {}));
+        Evaluate(Call(DataType::Handle(), fence_proxy_async(), {}));
     prev_proxy = get_generic_proxy(op->seq[0]);
     new_body.push_back(VisitStmt(op->seq[0]));
     if (op->seq.size() > 1) {

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -461,10 +461,10 @@ private:
           analyzer_.const_int_bound.IsBound(thread_var_->var)) {
         auto const_int_bound = analyzer_.const_int_bound(thread_var_);
         auto dtype = thread_var_->var.dtype();
-        auto extent = const_int_bound->max_value - const_int_bound->min_value + 1;
+        auto extent =
+            const_int_bound->max_value - const_int_bound->min_value + 1;
         thread_bounds_vec_.push_back(Range::FromMinExtent(
-            IntImm(dtype, const_int_bound->min_value),
-            IntImm(dtype, extent)));
+            IntImm(dtype, const_int_bound->min_value), IntImm(dtype, extent)));
       } else {
         thread_bounds_vec_.push_back(Range::FromMinExtent(0, 1));
       }
@@ -571,7 +571,7 @@ private:
           }
         }
       });
-      
+
       auto loop_layout = result_.for_map[root];
       bool parallel_loop = !is_register_store && !skip_thread_partition_;
       if (parallel_loop) {

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -259,7 +259,6 @@ public:
       auto &next = infer_list_[cur_infer_id];
       auto iter_var = thread_var_vec_[cur_infer_id];
       auto thread_bounds = thread_bounds_vec_[cur_infer_id];
-
       // Double-check that 'next' is valid
       ICHECK(next != nullptr) << "infer_list_[" << cur_infer_id
                               << "] is null inside run_infer_step.";
@@ -423,9 +422,10 @@ private:
         auto const_int_bound = analyzer_.const_int_bound(thread_var_);
         auto min_value = const_int_bound->min_value;
         auto max_value = const_int_bound->max_value;
+        auto extent = max_value - min_value + 1;
         auto dtype = thread_var_->var.dtype();
         thread_bounds_vec_.push_back(Range::FromMinExtent(
-            IntImm(dtype, min_value), IntImm(dtype, max_value + 1)));
+            IntImm(dtype, min_value), IntImm(dtype, extent)));
       } else {
         thread_bounds_vec_.push_back(Range::FromMinExtent(0, 1));
       }
@@ -461,9 +461,10 @@ private:
           analyzer_.const_int_bound.IsBound(thread_var_->var)) {
         auto const_int_bound = analyzer_.const_int_bound(thread_var_);
         auto dtype = thread_var_->var.dtype();
+        auto extent = const_int_bound->max_value - const_int_bound->min_value + 1;
         thread_bounds_vec_.push_back(Range::FromMinExtent(
             IntImm(dtype, const_int_bound->min_value),
-            IntImm(dtype, const_int_bound->max_value + 1)));
+            IntImm(dtype, extent)));
       } else {
         thread_bounds_vec_.push_back(Range::FromMinExtent(0, 1));
       }
@@ -570,10 +571,10 @@ private:
           }
         }
       });
-
+      
+      auto loop_layout = result_.for_map[root];
       bool parallel_loop = !is_register_store && !skip_thread_partition_;
       if (parallel_loop) {
-        auto loop_layout = result_.for_map[root];
         for_node =
             PartitionLoop(for_node, thread_var_->var, analyzer_, loop_layout);
       }

--- a/src/transform/loop_partition.cc
+++ b/src/transform/loop_partition.cc
@@ -189,7 +189,7 @@ Fragment PlanLoopPartition(For op, size_t num_thread, int vectorize_size) {
 
 Fragment PlanLoopPartition(For op, int vectorize_size, Range thread_range) {
   size_t num_thread =
-      *as_const_int(thread_range->extent) - *as_const_int(thread_range->min);
+      *as_const_int(thread_range->extent);
   LoopPartitioner partitioner;
   Fragment fragment = partitioner.Partition(op, num_thread, vectorize_size);
   auto node = make_object<FragmentNode>(*fragment.get());

--- a/src/transform/loop_partition.cc
+++ b/src/transform/loop_partition.cc
@@ -188,8 +188,7 @@ Fragment PlanLoopPartition(For op, size_t num_thread, int vectorize_size) {
 }
 
 Fragment PlanLoopPartition(For op, int vectorize_size, Range thread_range) {
-  size_t num_thread =
-      *as_const_int(thread_range->extent);
+  size_t num_thread = *as_const_int(thread_range->extent);
   LoopPartitioner partitioner;
   Fragment fragment = partitioner.Partition(op, num_thread, vectorize_size);
   auto node = make_object<FragmentNode>(*fragment.get());

--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -242,9 +242,10 @@ bool IndiceCanVectorize(PrimExpr expr, Var var, PrimExpr iter_var_size,
                                   iter_var_size, target_vectorized_size))));
   PrimExpr expr_transformed = analyzer->Simplify(
       Substitute(expr, {{var, v0 + v1 * target_vectorized_size}}));
-  PrimExpr expr_simplified = analyzer->Simplify(expr_transformed);
   Vectorizer vectorizer(v0, IntImm(v0->dtype, target_vectorized_size));
   PrimExpr expr_vectorized = vectorizer.VisitExpr(expr_transformed);
+  // This simplify is necessary for thread region specifiled
+  // optimizations.
   expr_vectorized = analyzer->Simplify(expr_vectorized);
   auto ramp_node = expr_vectorized.as<RampNode>();
   if (!ramp_node) {

--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -64,6 +64,7 @@ private:
   void VisitStmt_(const ForNode *node) final {
     inner_for_ = node;
     iter_map_.Set(node->loop_var, Range(node->min, node->extent));
+
     arith::IRVisitorWithAnalyzer::VisitStmt_(node);
   }
 
@@ -138,7 +139,6 @@ private:
         max_vector_size = gcd_base;
       }
       vector_size_ = arith::ZeroAwareGCD(max_vector_size, vector_size_);
-
       PrimExpr elem_offset = 0;
       PrimExpr stride = 1;
       for (int i = indices.size() - 1; i >= 0; --i) {
@@ -232,6 +232,7 @@ bool IndiceCanVectorize(PrimExpr expr, Var var, PrimExpr iter_var_size,
   ICHECK(target_vectorized_size >= 1);
   if (target_vectorized_size == 1)
     return true;
+  // bind thread range
   if (!analyzer->CanProveEqual(FloorMod(iter_var_size, target_vectorized_size),
                                0))
     return false;
@@ -242,9 +243,9 @@ bool IndiceCanVectorize(PrimExpr expr, Var var, PrimExpr iter_var_size,
   PrimExpr expr_transformed = analyzer->Simplify(
       Substitute(expr, {{var, v0 + v1 * target_vectorized_size}}));
   PrimExpr expr_simplified = analyzer->Simplify(expr_transformed);
-
   Vectorizer vectorizer(v0, IntImm(v0->dtype, target_vectorized_size));
   PrimExpr expr_vectorized = vectorizer.VisitExpr(expr_transformed);
+  expr_vectorized = analyzer->Simplify(expr_vectorized);
   auto ramp_node = expr_vectorized.as<RampNode>();
   if (!ramp_node) {
     // Broadcast value

--- a/src/transform/loop_vectorize.h
+++ b/src/transform/loop_vectorize.h
@@ -36,6 +36,7 @@ namespace tl {
 using namespace tir;
 
 int GetVectorizeSize(const For &loop);
+
 For VectorizeLoop(const For &loop, int vectorize_hint = -1);
 
 bool IndiceCanVectorize(PrimExpr expr, Var var, PrimExpr iter_var_size,

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -298,9 +298,10 @@ private:
       auto const_int_bound = analyzer_->const_int_bound(thread_var_);
       auto min_value = const_int_bound->min_value;
       auto max_value = const_int_bound->max_value;
+      auto extent = max_value + 1 - min_value;
       thread_bounds =
           Range::FromMinExtent(IntImm(thread_var_->var.dtype(), min_value),
-                               IntImm(thread_var_->var.dtype(), max_value + 1));
+                               IntImm(thread_var_->var.dtype(), extent));
     } else {
       thread_bounds = Range::FromMinExtent(0, 1);
     }

--- a/src/transform/multi_version_buffer_rewriter.cc
+++ b/src/transform/multi_version_buffer_rewriter.cc
@@ -53,8 +53,7 @@ public:
   void VisitStmt_(const EvaluateNode *op) final {
     Role role = Role::kConsumer;
     if (auto call = op->value.as<CallNode>()) {
-      if (call->op.same_as(tma_load()) ||
-          call->op.same_as(tma_load_im2col())) {
+      if (call->op.same_as(tma_load()) || call->op.same_as(tma_load_im2col())) {
         role = Role::kProducer;
         has_bulk_copy_ = true;
       }

--- a/src/transform/multi_version_buffer_rewriter.cc
+++ b/src/transform/multi_version_buffer_rewriter.cc
@@ -53,8 +53,8 @@ public:
   void VisitStmt_(const EvaluateNode *op) final {
     Role role = Role::kConsumer;
     if (auto call = op->value.as<CallNode>()) {
-      if (call->op.same_as(TMALoadOp()) ||
-          call->op.same_as(TMALoadIm2ColOp())) {
+      if (call->op.same_as(tma_load()) ||
+          call->op.same_as(tma_load_im2col())) {
         role = Role::kProducer;
         has_bulk_copy_ = true;
       }

--- a/src/transform/thread_partial_sync.cc
+++ b/src/transform/thread_partial_sync.cc
@@ -331,8 +331,8 @@ public:
       if (partial_syncs_.count(stmt.get())) {
         auto iter = partial_syncs_.find(stmt.get());
         ICHECK(sync_scope_.rank == StorageRank::kShared);
-        barrier = Evaluate(Call(DataType::Int(32), tl::sync_thread_partial(),
-                                {iter->second}));
+        barrier = Evaluate(
+            Call(DataType::Int(32), tl::sync_thread_partial(), {iter->second}));
       } else {
         return StmtExprMutator::VisitStmt(stmt);
       }

--- a/src/transform/thread_partial_sync.cc
+++ b/src/transform/thread_partial_sync.cc
@@ -331,7 +331,7 @@ public:
       if (partial_syncs_.count(stmt.get())) {
         auto iter = partial_syncs_.find(stmt.get());
         ICHECK(sync_scope_.rank == StorageRank::kShared);
-        barrier = Evaluate(Call(DataType::Int(32), tl::SyncThreadsPartialOp(),
+        barrier = Evaluate(Call(DataType::Int(32), tl::sync_thread_partial(),
                                 {iter->second}));
       } else {
         return StmtExprMutator::VisitStmt(stmt);

--- a/src/transform/warp_specialized_rewriter.cc
+++ b/src/transform/warp_specialized_rewriter.cc
@@ -43,7 +43,7 @@ public:
   void clear() { has_tma_load_ = false; }
 
   void VisitExpr_(const CallNode *call) final {
-    if (call->op.same_as(TMALoadOp()) || call->op.same_as(TMALoadIm2ColOp())) {
+    if (call->op.same_as(tma_load()) || call->op.same_as(tma_load_im2col())) {
       has_tma_load_ = true;
     }
   }
@@ -116,8 +116,8 @@ public:
   void VisitStmt_(const EvaluateNode *op) final {
     Role role = Role::kConsumer;
     if (auto call = op->value.as<CallNode>()) {
-      if (call->op.same_as(TMALoadOp()) ||
-          call->op.same_as(TMALoadIm2ColOp())) {
+      if (call->op.same_as(tma_load()) ||
+          call->op.same_as(tma_load_im2col())) {
         role = Role::kProducer;
         has_bulk_copy_ = true;
       }
@@ -207,11 +207,11 @@ private:
 };
 
 static PrimExpr makeGetBarrier(PrimExpr barrier_id) {
-  return Call(DataType::Handle(), GetMBarrierOp(), {barrier_id});
+  return Call(DataType::Handle(), get_mbarrier(), {barrier_id});
 }
 
 static Stmt makeExpectTX(PrimExpr barrier_id, PrimExpr bytes) {
-  auto call = Call(DataType::Handle(), MBarrierExpectTX(),
+  auto call = Call(DataType::Handle(), mbarrier_expect_tx(),
                    {makeGetBarrier(barrier_id), bytes});
   return Evaluate(call);
 }
@@ -229,7 +229,7 @@ static Stmt makeCpAsyncBarrier(PrimExpr barrier_id) {
 }
 
 static Stmt makeParityWait(PrimExpr barrier_id, PrimExpr parity) {
-  auto call = Call(DataType::Handle(), MBarrierWaitParity(),
+  auto call = Call(DataType::Handle(), mbarrier_wait_parity(),
                    {makeGetBarrier(barrier_id), parity});
   return Evaluate(call);
 }
@@ -273,8 +273,8 @@ private:
 
   Stmt VisitStmt_(const EvaluateNode *op) final {
     if (const CallNode *call = op->value.as<CallNode>()) {
-      if (call->op.same_as(TMALoadOp()) ||
-          call->op.same_as(TMALoadIm2ColOp())) {
+      if (call->op.same_as(tma_load()) ||
+          call->op.same_as(tma_load_im2col())) {
         contain_tma_load_ = true;
         if (insert_in_evaluate_) {
           Array<Stmt> new_seq = {expect_tx_, GetRef<Evaluate>(op)};
@@ -308,7 +308,7 @@ public:
 
 private:
   void VisitExpr_(const CallNode *call) final {
-    if (call->op.same_as(TMALoadOp()) || call->op.same_as(TMALoadIm2ColOp())) {
+    if (call->op.same_as(tma_load()) || call->op.same_as(tma_load_im2col())) {
       Call access_ptr = Downcast<Call>(call->args[2]);
       ICHECK(access_ptr->op.same_as(builtin::tvm_access_ptr()));
       int type_bytes = access_ptr->args[0]->dtype.bytes();
@@ -361,7 +361,7 @@ public:
 private:
   PrimExpr VisitExpr_(const CallNode *op) final {
     auto call = Downcast<Call>(StmtExprMutator::VisitExpr_(op));
-    if (call->op.same_as(TMALoadOp()) || call->op.same_as(TMALoadIm2ColOp())) {
+    if (call->op.same_as(tma_load()) || call->op.same_as(tma_load_im2col())) {
       Call access_ptr = Downcast<Call>(call->args[2]);
       ICHECK(access_ptr->op.same_as(builtin::tvm_access_ptr()));
       call.CopyOnWrite()->args.Set(1, makeGetBarrier(producer_barrier_idx_));
@@ -1082,7 +1082,7 @@ public:
 private:
   void VisitStmt_(const EvaluateNode *op) final {
     if (const CallNode *call = op->value.as<CallNode>()) {
-      if (call->op.same_as(SetMaxNReg())) {
+      if (call->op.same_as(set_max_nreg())) {
         int reg_hint = call->args[0].as<IntImmNode>()->value;
         int is_inc = call->args[1].as<IntImmNode>()->value;
         ICHECK(reg_hint <= 240 && reg_hint >= 24)
@@ -1092,7 +1092,7 @@ private:
         // producer should decrease register hint while consumer should increase
         // register hint
         nreg_.Set(is_inc, IntImm(DataType::Int(32), reg_hint));
-      } else if (call->op.same_as(NoSetMaxNReg())) {
+      } else if (call->op.same_as(no_set_max_nreg())) {
         has_no_set_max_nreg_ = true;
       }
     }
@@ -1149,7 +1149,7 @@ private:
 
   Stmt VisitStmt_(const EvaluateNode *op) final {
     if (const CallNode *call = op->value.as<CallNode>()) {
-      if (call->op.same_as(SetMaxNReg()) || call->op.same_as(NoSetMaxNReg())) {
+      if (call->op.same_as(set_max_nreg()) || call->op.same_as(no_set_max_nreg())) {
         return Evaluate(0);
       }
     }
@@ -1202,7 +1202,7 @@ private:
         barrier_num_threads.push_back(arrive_thread_count);
       }
       Stmt init_barrier = Evaluate(Call(
-          DataType::Handle(), CreateListofMBarrierOp(), barrier_num_threads));
+          DataType::Handle(), create_list_of_mbarrier(), barrier_num_threads));
       block.CopyOnWrite()->body = SeqStmt({init_barrier, code});
       block_realize.CopyOnWrite()->block = block;
       return block_realize;
@@ -1224,9 +1224,9 @@ private:
     auto inc_reg_stmt = Evaluate(0);
     auto dec_reg_stmt = Evaluate(0);
     if (dec_reg >= 0 && inc_reg >= 0) {
-      inc_reg_stmt = Evaluate(Call(DataType::Handle(), SetMaxNReg(),
+      inc_reg_stmt = Evaluate(Call(DataType::Handle(), set_max_nreg(),
                                    {inc_reg == 0 ? 240 : inc_reg, 1}));
-      dec_reg_stmt = Evaluate(Call(DataType::Handle(), SetMaxNReg(),
+      dec_reg_stmt = Evaluate(Call(DataType::Handle(), set_max_nreg(),
                                    {dec_reg == 0 ? 24 : dec_reg, 0}));
     }
 
@@ -1252,7 +1252,7 @@ private:
     }
 
     Stmt init_barrier = Evaluate(Call(
-        DataType::Handle(), CreateListofMBarrierOp(), barrier_num_threads));
+        DataType::Handle(), create_list_of_mbarrier(), barrier_num_threads));
     Stmt body = IfThenElse(GE(thread_iv_->var, consumer_thread_extent),
                            producer_code, consumer_code);
     // Add an attr here to handle the partial thread count in ThreadSync pass.

--- a/src/transform/warp_specialized_rewriter.cc
+++ b/src/transform/warp_specialized_rewriter.cc
@@ -116,8 +116,7 @@ public:
   void VisitStmt_(const EvaluateNode *op) final {
     Role role = Role::kConsumer;
     if (auto call = op->value.as<CallNode>()) {
-      if (call->op.same_as(tma_load()) ||
-          call->op.same_as(tma_load_im2col())) {
+      if (call->op.same_as(tma_load()) || call->op.same_as(tma_load_im2col())) {
         role = Role::kProducer;
         has_bulk_copy_ = true;
       }
@@ -273,8 +272,7 @@ private:
 
   Stmt VisitStmt_(const EvaluateNode *op) final {
     if (const CallNode *call = op->value.as<CallNode>()) {
-      if (call->op.same_as(tma_load()) ||
-          call->op.same_as(tma_load_im2col())) {
+      if (call->op.same_as(tma_load()) || call->op.same_as(tma_load_im2col())) {
         contain_tma_load_ = true;
         if (insert_in_evaluate_) {
           Array<Stmt> new_seq = {expect_tx_, GetRef<Evaluate>(op)};
@@ -1149,7 +1147,8 @@ private:
 
   Stmt VisitStmt_(const EvaluateNode *op) final {
     if (const CallNode *call = op->value.as<CallNode>()) {
-      if (call->op.same_as(set_max_nreg()) || call->op.same_as(no_set_max_nreg())) {
+      if (call->op.same_as(set_max_nreg()) ||
+          call->op.same_as(no_set_max_nreg())) {
         return Evaluate(0);
       }
     }

--- a/testing/python/transform/test_tilelang_transform_inject_fence_proxy.py
+++ b/testing/python/transform/test_tilelang_transform_inject_fence_proxy.py
@@ -46,7 +46,7 @@ def test_lower_fence_proxy():
             C_local = T.decl_buffer((32,), scope="local")
             for i in T.unroll(16):
                 C_local[i * 2:i * 2 + 2] = T.Broadcast(T.float32(0), 2)
-            T.FenceProxyAsyncOp()
+            T.fence_proxy_async()
             T.call_extern("handle", "tl::gemm_ss<64, 64, 32, 4, 1, 0, 0>",
                           T.tvm_access_ptr(T.type_annotation("float16"), A_shared.data, 0, 2048, 1),
                           T.tvm_access_ptr(T.type_annotation("float16"), B_shared.data, 0, 2048, 1),

--- a/testing/python/transform/test_tilelang_transform_lower_hopper_intrin.py
+++ b/testing/python/transform/test_tilelang_transform_lower_hopper_intrin.py
@@ -31,7 +31,7 @@ def test_lower_hopper_intrin_barrier():
     def before():
         with T.Kernel(8):
             _ = T.launch_thread("threadIdx.x", 128)
-            T.CreateListofMBarrierOp(128, 128, 128, 128)
+            T.create_list_of_mbarrier(128, 128, 128, 128)
 
     @T.prim_func
     def after():
@@ -41,16 +41,16 @@ def test_lower_hopper_intrin_barrier():
             with T.If(v_1 == 0), T.Then():
                 T.evaluate(
                     tir.Call("handle", "tir.ptx_init_barrier_thread_count",
-                             [T.GetMBarrierOp(0), 128]))
+                             [T.get_mbarrier(0), 128]))
                 T.evaluate(
                     tir.Call("handle", "tir.ptx_init_barrier_thread_count",
-                             [T.GetMBarrierOp(1), 128]))
+                             [T.get_mbarrier(1), 128]))
                 T.evaluate(
                     tir.Call("handle", "tir.ptx_init_barrier_thread_count",
-                             [T.GetMBarrierOp(2), 128]))
+                             [T.get_mbarrier(2), 128]))
                 T.evaluate(
                     tir.Call("handle", "tir.ptx_init_barrier_thread_count",
-                             [T.GetMBarrierOp(3), 128]))
+                             [T.get_mbarrier(3), 128]))
             T.evaluate(tir.Call("handle", "tir.tvm_storage_sync", ["shared"]))
 
     _check(before, after)

--- a/testing/python/transform/test_tilelang_transform_multi_version_buffer.py
+++ b/testing/python/transform/test_tilelang_transform_multi_version_buffer.py
@@ -50,14 +50,14 @@ def test_multi_version_buffer():
                     C_local[i * 2 + vec] = T.float32(0)
             for k in T.serial(16, annotations={"num_stages": 3}):
                 if v == 0:
-                    T.TMALoadOp(
-                        T.CreateTMADescriptorOp(6, 2, A.data, 512, 512, 2, 1024, 32, 64, 1, 1, 0, 2,
+                    T.tma_load(
+                        T.create_tma_descriptor(6, 2, A.data, 512, 512, 2, 1024, 32, 64, 1, 1, 0, 2,
                                                 2, 0), 0,
                         T.tvm_access_ptr(T.type_annotation("float16"), A_shared.data, 0, 2048, 2),
                         k * 32, by * 64)
                 if v == 0:
-                    T.TMALoadOp(
-                        T.CreateTMADescriptorOp(6, 2, B.data, 512, 512, 2, 1024, 64, 32, 1, 1, 0, 3,
+                    T.tma_load(
+                        T.create_tma_descriptor(6, 2, B.data, 512, 512, 2, 1024, 64, 32, 1, 1, 0, 3,
                                                 2, 0), 0,
                         T.tvm_access_ptr(T.type_annotation("float16"), B_shared.data, 0, 2048, 2),
                         bx * 64, k * 32)
@@ -83,15 +83,15 @@ def test_multi_version_buffer():
                     C_local[i * 2 + vec] = T.float32(0)
             for k in T.serial(16, annotations={"num_stages": 3}):
                 if v == 0:
-                    T.TMALoadOp(
-                        T.CreateTMADescriptorOp(6, 2, A.data, 512, 512, 2, 1024, 32, 64, 1, 1, 0, 2,
+                    T.tma_load(
+                        T.create_tma_descriptor(6, 2, A.data, 512, 512, 2, 1024, 32, 64, 1, 1, 0, 2,
                                                 2, 0), 0,
                         T.tvm_access_ptr(
                             T.type_annotation("float16"), A_shared.data, k % 3 * 2048, 2048, 2),
                         k * 32, by * 64)
                 if v == 0:
-                    T.TMALoadOp(
-                        T.CreateTMADescriptorOp(6, 2, B.data, 512, 512, 2, 1024, 64, 32, 1, 1, 0, 3,
+                    T.tma_load(
+                        T.create_tma_descriptor(6, 2, B.data, 512, 512, 2, 1024, 64, 32, 1, 1, 0, 3,
                                                 2, 0), 0,
                         T.tvm_access_ptr(
                             T.type_annotation("float16"), B_shared.data, k % 3 * 2048, 2048, 2),

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -37,7 +37,6 @@ def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
     # Simplify the IR expressions
     mod = tir.transform.Simplify()(mod)
     # Infer memory layouts for fragments and shared memory
-    print(mod)
     mod = tilelang.transform.LayoutInference()(mod)
     # Lower high-level tile operations to low-level operations
     mod = tilelang.transform.LowerTileOp()(mod)
@@ -118,6 +117,7 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.ConfigIndexBitwidth()(mod)
     mod = tilelang.transform.ThreadSync("shared")(mod)
     mod = tilelang.transform.ThreadSync("shared.dyn")(mod)
+    mod = tilelang.transform.EliminateStorageSyncForMBarrier()(mod)
     mod = tilelang.transform.InjectPTXAsyncCopy()(mod)
 
     mod = tilelang.transform.AnnotateDeviceRegions()(mod)

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -18,8 +18,10 @@ def allow_tma_and_warp_specialized(pass_ctx: Optional[PassContext] = None,
     disable_warp_specialized = pass_ctx.config.get("tl.disable_warp_specialized", False)
     return not (disable_tma_lower and disable_warp_specialized)
 
+
 def allow_fence_proxy(target: Optional[Target] = None) -> bool:
     return target.arch in {"sm_90", "sm_90a"}
+
 
 def allow_vectorize(pass_ctx: Optional[PassContext] = None) -> bool:
     if pass_ctx is None:
@@ -76,7 +78,7 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
         mod = tilelang.transform.PipelinePlanning()(mod)
         mod = tilelang.transform.InjectSoftwarePipeline()(mod)
         mod = tilelang.transform.MergeIfStmt()(mod)
-    
+
     if allow_fence_proxy(target=target):
         # in hopper device, wgmma is an async proxy
         # so we need to inject a fence proxy before it
@@ -87,9 +89,7 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
     mod = tir.transform.NarrowDataType(32)(mod)
     mod = tir.transform.Simplify()(mod)
 
-    mod = tilelang.transform.VectorizeLoop(
-        enable_vectorize=allow_vectorize(pass_ctx=pass_ctx)
-    )(mod)
+    mod = tilelang.transform.VectorizeLoop(enable_vectorize=allow_vectorize(pass_ctx=pass_ctx))(mod)
 
     mod = tir.transform.StorageRewrite()(mod)
     mod = tir.transform.UnrollLoop()(mod)

--- a/tilelang/jit/adapter/cython/adapter.py
+++ b/tilelang/jit/adapter/cython/adapter.py
@@ -261,6 +261,7 @@ class CythonKernelAdapter(BaseKernelAdapter):
         result = self.lib.init()
         if result != 0:
             error_msg = self.lib.get_last_error().decode('utf-8')
+            error_msg += f"\n{self.lib_code}"
             raise RuntimeError(f"Initialization failed: {error_msg}")
 
         self.cython_wrapper = CythonKernelWrapper(self.result_idx, self.params, self.lib)

--- a/tilelang/language/__init__.py
+++ b/tilelang/language/__init__.py
@@ -34,6 +34,7 @@ from .kernel import (
     get_block_binding,  # noqa: F401
     get_block_bindings,  # noqa: F401
 )
+from .warpgroup import ws  # noqa: F401
 from .allocate import (
     alloc_local,  # noqa: F401
     alloc_shared,  # noqa: F401

--- a/tilelang/language/builtin.py
+++ b/tilelang/language/builtin.py
@@ -160,6 +160,7 @@ def mbarrier_wait_parity(mbarrier: Union[int, PrimExpr], parity: Union[int, Var]
         mbarrier = get_mbarrier(mbarrier)
     return tir.call_intrin("handle", tir.op.Op.get("tl.mbarrier_wait_parity"), mbarrier, parity)
 
+
 def mbarrier_arrive(mbarrier: Union[int, PrimExpr]):
     """Arrive at memory barrier.
 
@@ -170,6 +171,7 @@ def mbarrier_arrive(mbarrier: Union[int, PrimExpr]):
     if isinstance(mbarrier, int):
         mbarrier = get_mbarrier(mbarrier)
     return ptx_arrive_barrier(mbarrier)
+
 
 def mbarrier_expect_tx(*args):
     """Set expected transaction count for memory barrier.

--- a/tilelang/language/builtin.py
+++ b/tilelang/language/builtin.py
@@ -5,7 +5,7 @@
 from tvm import tir
 
 
-def CreateListofMBarrierOp(*args):
+def create_list_of_mbarrier(*args):
     """Create a list of memory barrier operations.
 
     Args:
@@ -14,10 +14,10 @@ def CreateListofMBarrierOp(*args):
     Returns:
         tir.Call: A handle to the created list of memory barriers
     """
-    return tir.call_intrin("handle", tir.op.Op.get("tl.CreateListofMBarrierOp"), *args)
+    return tir.call_intrin("handle", tir.op.Op.get("tl.create_list_of_mbarrier"), *args)
 
 
-def GetMBarrierOp(*args):
+def get_mbarrier(*args):
     """Retrieve a memory barrier operation.
 
     Args:
@@ -26,10 +26,10 @@ def GetMBarrierOp(*args):
     Returns:
         tir.Call: A handle to the requested memory barrier
     """
-    return tir.call_intrin("handle", tir.op.Op.get("tl.GetMBarrierOp"), *args)
+    return tir.call_intrin("handle", tir.op.Op.get("tl.get_mbarrier"), *args)
 
 
-def CreateTMADescriptorOp(*args):
+def create_tma_descriptor(*args):
     """Create a Tensor Memory Access (TMA) descriptor.
 
     Args:
@@ -38,10 +38,10 @@ def CreateTMADescriptorOp(*args):
     Returns:
         tir.Call: A handle to the created TMA descriptor
     """
-    return tir.call_intrin("handle", tir.op.Op.get("tl.CreateTMADescriptorOp"), *args)
+    return tir.call_intrin("handle", tir.op.Op.get("tl.create_tma_descriptor"), *args)
 
 
-def TMALoadOp(*args):
+def tma_load(*args):
     """Perform a Tensor Memory Access (TMA) load operation.
 
     Args:
@@ -50,10 +50,10 @@ def TMALoadOp(*args):
     Returns:
         tir.Call: A handle to the TMA load operation
     """
-    return tir.call_intrin("handle", tir.op.Op.get("tl.TMALoadOp"), *args)
+    return tir.call_intrin("handle", tir.op.Op.get("tl.tma_load"), *args)
 
 
-def FenceProxyAsyncOp(*args):
+def fence_proxy_async(*args):
     """Create a fence for asynchronous proxy operations.
 
     Args:
@@ -62,10 +62,10 @@ def FenceProxyAsyncOp(*args):
     Returns:
         tir.Call: A handle to the fence operation
     """
-    return tir.call_intrin("handle", tir.op.Op.get("tl.FenceProxyAsyncOp"), *args)
+    return tir.call_intrin("handle", tir.op.Op.get("tl.fence_proxy_async"), *args)
 
 
-def TMAStoreArrive(*args):
+def tma_store_arrive(*args):
     """Signal the arrival of a TMA store operation.
 
     Args:
@@ -74,10 +74,10 @@ def TMAStoreArrive(*args):
     Returns:
         tir.Call: A handle to the store arrive operation
     """
-    return tir.call_intrin("handle", tir.op.Op.get("tl.TMAStoreArrive"), *args)
+    return tir.call_intrin("handle", tir.op.Op.get("tl.tma_store_arrive"), *args)
 
 
-def TMAStoreWait(*args):
+def tma_store_wait(*args):
     """Wait for completion of TMA store operations.
 
     Args:
@@ -86,10 +86,10 @@ def TMAStoreWait(*args):
     Returns:
         tir.Call: A handle to the store wait operation
     """
-    return tir.call_intrin("handle", tir.op.Op.get("tl.TMAStoreWait"), *args)
+    return tir.call_intrin("handle", tir.op.Op.get("tl.tma_store_wait"), *args)
 
 
-def SetMaxNReg(*args):
+def set_max_nreg(*args):
     """Set the maximum number of registers to use.
 
     Args:
@@ -98,10 +98,10 @@ def SetMaxNReg(*args):
     Returns:
         tir.Call: A handle to the register setting operation
     """
-    return tir.call_intrin("handle", tir.op.Op.get("tl.SetMaxNReg"), *args)
+    return tir.call_intrin("handle", tir.op.Op.get("tl.set_max_nreg"), *args)
 
 
-def NoSetMaxNReg(*args):
+def no_set_max_nreg(*args):
     """Disable the maximum register limit setting.
 
     Args:
@@ -110,10 +110,10 @@ def NoSetMaxNReg(*args):
     Returns:
         tir.Call: A handle to the register limit disable operation
     """
-    return tir.call_intrin("handle", tir.op.Op.get("tl.NoSetMaxNReg"), *args)
+    return tir.call_intrin("handle", tir.op.Op.get("tl.no_set_max_nreg"), *args)
 
 
-def MBarrierWaitParity(*args):
+def mbarrier_wait_parity(*args):
     """Wait for memory barrier parity condition.
 
     Args:
@@ -122,10 +122,10 @@ def MBarrierWaitParity(*args):
     Returns:
         tir.Call: A handle to the barrier wait operation
     """
-    return tir.call_intrin("handle", tir.op.Op.get("tl.MBarrierWaitParity"), *args)
+    return tir.call_intrin("handle", tir.op.Op.get("tl.mbarrier_wait_parity"), *args)
 
 
-def MBarrierExpectTX(*args):
+def mbarrier_expect_tx(*args):
     """Set expected transaction count for memory barrier.
 
     Args:
@@ -134,10 +134,10 @@ def MBarrierExpectTX(*args):
     Returns:
         tir.Call: A handle to the barrier expectation operation
     """
-    return tir.call_intrin("handle", tir.op.Op.get("tl.MBarrierExpectTX"), *args)
+    return tir.call_intrin("handle", tir.op.Op.get("tl.mbarrier_expect_tx"), *args)
 
 
-def WaitWgmma(*args):
+def wait_wgmma(*args):
     """Wait for WGMMA (Warp Group Matrix Multiply-Accumulate) operations to complete.
 
     Args:
@@ -146,4 +146,4 @@ def WaitWgmma(*args):
     Returns:
         tir.Call: A handle to the WGMMA wait operation
     """
-    return tir.call_intrin("handle", tir.op.Op.get("tl.WaitWgmma"), *args)
+    return tir.call_intrin("handle", tir.op.Op.get("tl.wait_wgmma"), *args)

--- a/tilelang/language/kernel.py
+++ b/tilelang/language/kernel.py
@@ -283,20 +283,24 @@ def get_block_bindings() -> List[Var]:
     """
     return KernelLaunchFrame.Current().get_block_bindings()
 
+
 def get_thread_extent(dim: int = 0) -> int:
     """Returns the thread extent for the given dimension.
     """
     return KernelLaunchFrame.Current().get_thread_extent(dim)
+
 
 def get_thread_extents() -> List[int]:
     """Returns all three thread extents.
     """
     return KernelLaunchFrame.Current().get_thread_extents()
 
+
 def get_block_extent(dim: int = 0) -> int:
     """Returns the block extent for the given dimension.
     """
     return KernelLaunchFrame.Current().get_block_extent(dim)
+
 
 def get_block_extents() -> List[int]:
     """Returns all three block extents.

--- a/tilelang/language/kernel.py
+++ b/tilelang/language/kernel.py
@@ -130,6 +130,12 @@ class KernelLaunchFrame(TIRFrame):
         iter_var = self.frames[dim].iter_var
         return int(iter_var.dom.extent)
 
+    def get_block_extents(self) -> List[int]:
+        """
+        Returns the block extents for all three dimensions.
+        """
+        return [self.get_block_extent(dim) for dim in range(3)]
+
     def get_thread_extent(self, dim: int) -> int:
         """
         Returns the thread extent for the given dimension.
@@ -137,6 +143,12 @@ class KernelLaunchFrame(TIRFrame):
         """
         iter_var = self.frames[-4 + dim].iter_var
         return int(iter_var.dom.extent)
+
+    def get_thread_extents(self) -> List[int]:
+        """
+        Returns the thread extents for all three dimensions.
+        """
+        return [self.get_thread_extent(dim) for dim in range(3)]
 
     def get_thread_binding(self, dim: int = 0) -> Var:
         """
@@ -270,3 +282,23 @@ def get_block_bindings() -> List[Var]:
     """Returns all three block bindings.
     """
     return KernelLaunchFrame.Current().get_block_bindings()
+
+def get_thread_extent(dim: int = 0) -> int:
+    """Returns the thread extent for the given dimension.
+    """
+    return KernelLaunchFrame.Current().get_thread_extent(dim)
+
+def get_thread_extents() -> List[int]:
+    """Returns all three thread extents.
+    """
+    return KernelLaunchFrame.Current().get_thread_extents()
+
+def get_block_extent(dim: int = 0) -> int:
+    """Returns the block extent for the given dimension.
+    """
+    return KernelLaunchFrame.Current().get_block_extent(dim)
+
+def get_block_extents() -> List[int]:
+    """Returns all three block extents.
+    """
+    return KernelLaunchFrame.Current().get_block_extents()

--- a/tilelang/language/warpgroup.py
+++ b/tilelang/language/warpgroup.py
@@ -31,7 +31,6 @@ def WarpSpecialize(warp_group_idx: int,):
     res : Tuple[frame.LaunchThreadFrame]
         The result LaunchThreadFrame.
     """
-    attrs: dict = {}
     id_x, id_y, id_z = get_thread_bindings()
     ex_x, ex_y, ex_z = get_thread_extents()
     tid = id_z * (ex_y * ex_x) + id_y * ex_x + id_x

--- a/tilelang/language/warpgroup.py
+++ b/tilelang/language/warpgroup.py
@@ -32,7 +32,7 @@ def WarpSpecialize(warp_group_idx: int,):
         The result LaunchThreadFrame.
     """
     id_x, id_y, id_z = get_thread_bindings()
-    ex_x, ex_y, ex_z = get_thread_extents()
+    ex_x, ex_y, _ = get_thread_extents()
     tid = id_z * (ex_y * ex_x) + id_y * ex_x + id_x
     # only available for nvidia gpus.
     warp_group_size = 128

--- a/tilelang/language/warpgroup.py
+++ b/tilelang/language/warpgroup.py
@@ -1,0 +1,47 @@
+# Copyright (c) Tile-AI Corporation.
+# Licensed under the MIT License.
+"""The language interface for tl programs."""
+
+from tvm.script.ir_builder.tir.frame import TIRFrame
+from tvm._ffi import register_object
+from tilelang import _ffi_api
+from .kernel import get_thread_bindings, get_thread_extents
+
+
+@register_object("tl.WarpSpecializeFrame")
+class WarpSpecializeFrame(TIRFrame):
+    """
+    WarpSpecializeFrame is a custom TIRFrame that manages warp group indices
+    and handles the entry and exit of the kernel launch scope.
+    """
+
+
+def WarpSpecialize(
+    warp_group_idx: int,
+):
+    """Tools to construct a warp group frame.
+
+    Parameters
+    ----------
+    warp_group_idx : int
+        A integer representing warp group index
+        Or a list of integers representing blockDim.(x|y|z)
+        if the value is -1, we skip the threadIdx.x binding.
+
+    Returns
+    -------
+    res : Tuple[frame.LaunchThreadFrame]
+        The result LaunchThreadFrame.
+    """
+    attrs: dict = {}
+    id_x, id_y, id_z = get_thread_bindings()
+    ex_x, ex_y, ex_z = get_thread_extents()
+    tid = id_z * (ex_y * ex_x) + id_y * ex_x + id_x
+    # only suport nvidia target.
+    warp_group_size = 128
+
+
+    return _ffi_api.WarpSpecialize(warp_group_idx, tid, warp_group_size)
+
+# Alias for WarpSpecialize for more concise usage
+ws = WarpSpecialize

--- a/tilelang/language/warpgroup.py
+++ b/tilelang/language/warpgroup.py
@@ -16,9 +16,7 @@ class WarpSpecializeFrame(TIRFrame):
     """
 
 
-def WarpSpecialize(
-    warp_group_idx: int,
-):
+def WarpSpecialize(warp_group_idx: int,):
     """Tools to construct a warp group frame.
 
     Parameters
@@ -37,11 +35,11 @@ def WarpSpecialize(
     id_x, id_y, id_z = get_thread_bindings()
     ex_x, ex_y, ex_z = get_thread_extents()
     tid = id_z * (ex_y * ex_x) + id_y * ex_x + id_x
-    # only suport nvidia target.
+    # only available for nvidia gpus.
     warp_group_size = 128
 
-
     return _ffi_api.WarpSpecialize(warp_group_idx, tid, warp_group_size)
+
 
 # Alias for WarpSpecialize for more concise usage
 ws = WarpSpecialize

--- a/tilelang/transform/__init__.py
+++ b/tilelang/transform/__init__.py
@@ -316,3 +316,9 @@ def FlattenBuffer():
         The result pass
     """
     return _ffi_api.FlattenBuffer()  # type: ignore
+
+
+def EliminateStorageSyncForMBarrier():
+    """EliminateStorageSyncForMBarrier
+    """
+    return _ffi_api.EliminateStorageSyncForMBarrier()  # type: ignore


### PR DESCRIPTION
This pull request introduces several changes to the codebase, focusing on API renaming for consistency, adding new functionality for warp specialization, and minor improvements to layout inference and loop partitioning. Below is a breakdown of the most important changes:

### API Renaming for Consistency
* Renamed multiple TileLang API functions to use snake_case for consistency with Python naming conventions (e.g., `T.NoSetMaxNReg()` to `T.no_set_max_nreg()` and `T.WaitWgmma()` to `T.wait_wgmma()`) across various files. (`[[1]](diffhunk://#diff-7be972a85e81f6555dd498db2f2ffec8f2c3e8ab272bd2783db8b5c94e18393cL56-R56)`, `[[2]](diffhunk://#diff-81fa69a0f32d2eae21c82945f813a1d870c73abe1cdac5d083b2cf60cf733a1eL209-R209)`, `[[3]](diffhunk://#diff-81fa69a0f32d2eae21c82945f813a1d870c73abe1cdac5d083b2cf60cf733a1eL218-R218)`, `[[4]](diffhunk://#diff-81fa69a0f32d2eae21c82945f813a1d870c73abe1cdac5d083b2cf60cf733a1eL231-R231)`, `[[5]](diffhunk://#diff-39f3332b8026cdf6f2a0bcd6b507e46f4347e6e071b6a76668d4b7cec4b8f73eL36-R121)`, `[[6]](diffhunk://#diff-00c453d27cd8f89830f77e9a0cfdce35b878e41b4926ea9b23938732783e8e2aL213-R220)`, `[[7]](diffhunk://#diff-00c453d27cd8f89830f77e9a0cfdce35b878e41b4926ea9b23938732783e8e2aL349-R349)`, `[[8]](diffhunk://#diff-00c453d27cd8f89830f77e9a0cfdce35b878e41b4926ea9b23938732783e8e2aL400-R400)`, `[[9]](diffhunk://#diff-b41ad92a37e3f104b615eb0ec61a1d7af1c21ef178a5acb708e3b7391450cfb2L281-R282)`, `[[10]](diffhunk://#diff-b41ad92a37e3f104b615eb0ec61a1d7af1c21ef178a5acb708e3b7391450cfb2L330-R331)`)

### New Warp Specialization Feature
* Introduced a new `WarpSpecializeFrame` class and related functionality to support warp-specialized execution. This includes the `WarpSpecialize` function for defining warp-specific execution scopes. (`[src/ir.ccR226-R275](diffhunk://#diff-fd7749ba50b6074ced53829097c03ece00d7572477e24cf9dd416cd807dfe75fR226-R275)`)

### New Matrix Multiplication Example
* Added a new example for warp-specialized GEMM (general matrix multiplication) with CUDA backend in `examples/warp_specialize/gemm_ws.py`. This includes kernel definition, compilation, and testing with PyTorch. (`[examples/warp_specialize/gemm_ws.pyR1-R85](diffhunk://#diff-697be8466ce84f8cf4c15555a3562badb85ef048846badc8bdbd06e50de1d553R1-R85)`)

### Layout Inference and Loop Partitioning Improvements
* Refactored layout inference logic to simplify and improve handling of thread bounds by removing unnecessary subtraction of `min` from `extent`. (`[[1]](diffhunk://#diff-5cbeefe6d2ab80fbd44350603133779b381d613ca2f5b4f4a6bf89dbe98b6d2cL167-R167)`, `[[2]](diffhunk://#diff-ef280fbd8aa7147455086fe8e3515b5a57544d0eee947850799f14812037b40eL149-R149)`)
* Updated loop partitioning logic in `ParallelOp` to account for thread bounds offset in predicate generation. (`[src/op/parallel.ccL231-R232](diffhunk://#diff-ef280fbd8aa7147455086fe8e3515b5a57544d0eee947850799f14812037b40eL231-R232)`)

### Minor Enhancements
* Added a missing include for `tvm/tir/stmt_functor.h` in `src/op/reduce.cc` to ensure proper functionality. (`[src/op/reduce.ccR15](diffhunk://#diff-6db4f8a0f03dffeb4b8b493182b3754cc170d550bb6ea71ca472ced6320c8868R15)`)