### PR TITLE
[Feature] Add TILELANG_CHECK_LAST_ERROR macro for improved error handling in CUDA and HIP

### DIFF
--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -41,7 +41,7 @@ using int4_t = int4;
   do {                                                                         \
     cudaError_t __err = cudaGetLastError();                                    \
     if (__err != cudaSuccess) {                                                \
-      snprintf(error_buf, ERROR_BUF_SIZE, "kernel_name: %s - %s",   \
+      snprintf(error_buf, ERROR_BUF_SIZE, "kernel_name: %s - %s",              \
                cudaGetErrorName(__err), cudaGetErrorString(__err));            \
       return -1;                                                               \
     }                                                                          \

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -37,6 +37,16 @@ using int4_t = int4;
     }                                                                          \
   } while (0)
 
+#define TILELANG_CHECK_LAST_ERROR(kernel_name)                                 \
+  do {                                                                         \
+    cudaError_t __err = cudaGetLastError();                                    \
+    if (__err != cudaSuccess) {                                                \
+      snprintf(error_buf, ERROR_BUF_SIZE, "kernel_name: %s - %s",   \
+               cudaGetErrorName(__err), cudaGetErrorString(__err));            \
+      return -1;                                                               \
+    }                                                                          \
+  } while (0)
+
 // abs function for bfloat_t and half_t since there is no implicit convertion
 // method
 TL_PATCH TL_DEVICE half_t __habs(const half_t x) {

--- a/src/tl_templates/hip/common.h
+++ b/src/tl_templates/hip/common.h
@@ -38,6 +38,16 @@
     }                                                                          \
   } while (0)
 
+#define TILELANG_CHECK_LAST_ERROR(kernel_name)                                 \
+  do {                                                                         \
+    hipError_t __err = hipGetLastError();                                    \
+    if (__err != hipSuccess) {                                                \
+      snprintf(error_buf, ERROR_BUF_SIZE, "kernel_name: %s - %s",   \
+               hipGetErrorName(__err), hipGetErrorString(__err));            \
+      return -1;                                                               \
+    }                                                                          \
+  } while (0)
+
 #define half _Float16
 #define __float2half_rn(x) half(x)
 

--- a/src/tl_templates/hip/common.h
+++ b/src/tl_templates/hip/common.h
@@ -40,10 +40,10 @@
 
 #define TILELANG_CHECK_LAST_ERROR(kernel_name)                                 \
   do {                                                                         \
-    hipError_t __err = hipGetLastError();                                    \
-    if (__err != hipSuccess) {                                                \
-      snprintf(error_buf, ERROR_BUF_SIZE, "kernel_name: %s - %s",   \
-               hipGetErrorName(__err), hipGetErrorString(__err));            \
+    hipError_t __err = hipGetLastError();                                      \
+    if (__err != hipSuccess) {                                                 \
+      snprintf(error_buf, ERROR_BUF_SIZE, "kernel_name: %s - %s",              \
+               hipGetErrorName(__err), hipGetErrorString(__err));              \
       return -1;                                                               \
     }                                                                          \
   } while (0)

--- a/tilelang/jit/adapter/wrapper.py
+++ b/tilelang/jit/adapter/wrapper.py
@@ -223,11 +223,7 @@ class TLCUDASourceWrapper(object):
             smem_str = 0 if dynamic_smem_buf is None else dynamic_smem_buf
             kernel_launch_code += "\t{}<<<{}, {}, {}, stream>>>({});\n".format(
                 function_name, grid_str, block_str, smem_str, call_args)
-            kernel_launch_code += "\tcudaError_t err = cudaGetLastError();\n"
-            kernel_launch_code += "\tif (err != cudaSuccess) {{\n"
-            kernel_launch_code += f"\t\tsnprintf(error_buf, ERROR_BUF_SIZE, \"{function_name}: %s - %s\", cudaGetErrorName(err), cudaGetErrorString(err));\n"
-            kernel_launch_code += "\t\treturn -1;\n"
-            kernel_launch_code += "\t}}\n"
+            kernel_launch_code += "TILELANG_CHECK_LAST_ERROR(\"{}\");\n".format(function_name)
 
         kernel_launch_code = self.generate_tma_descriptor_args(desc_name_map) + kernel_launch_code
 


### PR DESCRIPTION
This pull request introduces a macro to simplify and standardize error handling for CUDA and HIP kernel launches. The macro is then applied to replace repetitive error-handling code in the `tilelang/jit/adapter/wrapper.py` file. Below is a summary of the most important changes:

### Error-handling macro definition:

* [`src/tl_templates/cuda/common.h`](diffhunk://#diff-a9affb584850fb57935aeb0a8450d96497f4534022304d408cb369a47d1e8130R40-R49): Added the `TILELANG_CHECK_LAST_ERROR` macro to check for CUDA kernel launch errors, format error messages, and return `-1` if an error occurs.
* [`src/tl_templates/hip/common.h`](diffhunk://#diff-688f4edb061910df1c04c5d483e0d7283b7bd5aadb4479bdff7f39fad1f6c0f9R41-R50): Added the `TILELANG_CHECK_LAST_ERROR` macro for HIP kernel launches, mirroring the functionality of the CUDA macro but using HIP-specific error-checking functions.

### Refactoring kernel launch error handling:

* [`tilelang/jit/adapter/wrapper.py`](diffhunk://#diff-11632097304818e018a5c33430f70f6e9c98af09b886c20cca8dc41051633298L226-R226): Replaced repetitive CUDA error-handling code with the newly defined `TILELANG_CHECK_LAST_ERROR` macro to simplify and standardize the logic.