### PR TITLE
[Refactor] Phaseout torch>=2.2.0 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ typing_extensions>=4.10.0
 cloudpickle
 ml_dtypes
 psutil
-torch>=2.2.0
+torch


### PR DESCRIPTION
Previously, this was implemented to support float8. Now, the implementation has changed—float8-related calls are hidden and no longer explicitly invoked.