### PR TITLE
[Enhancement] Introduce pass_configs parameter for kernel Caching

### DIFF
--- a/examples/flash_decoding/example_mha_inference.py
+++ b/examples/flash_decoding/example_mha_inference.py
@@ -304,7 +304,8 @@ if __name__ == "__main__":
     BLOCK_N = 64  # if D_HEAD <= 128 else 32
     program = flashattn(BATCH, H, Q_CTX, KV_CTX, D_HEAD, causal, BLOCK_M, BLOCK_N)
     ref_program = partial(ref_program, causal=causal)
-    kernel = tilelang.compile(program, out_idx=[5], pass_configs={tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True})
+    kernel = tilelang.compile(
+        program, out_idx=[5], pass_configs={tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True})
     print(kernel.get_kernel_source())
     profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
     profiler.assert_allclose(ref_program, rtol=0.01, atol=0.01)

--- a/examples/flash_decoding/example_mha_inference.py
+++ b/examples/flash_decoding/example_mha_inference.py
@@ -191,7 +191,6 @@ def flashattn(batch, heads, seqlen_q, seqlen_kv, dim, is_causal, block_M, block_
                 T.copy(po_shared, po_local)
                 for i in T.Parallel(block_M):
                     lse_local_split[i] = lse_local[k, i]
-                # T.copy(lse_local[k, :], lse_local_split)
                 for i in T.Parallel(block_M):
                     scale_local[i] = T.exp2(lse_local_split[i] - lse_logsum_local[i])
                 for i, j in T.Parallel(block_M, dim):
@@ -305,7 +304,7 @@ if __name__ == "__main__":
     BLOCK_N = 64  # if D_HEAD <= 128 else 32
     program = flashattn(BATCH, H, Q_CTX, KV_CTX, D_HEAD, causal, BLOCK_M, BLOCK_N)
     ref_program = partial(ref_program, causal=causal)
-    kernel = tilelang.compile(program, out_idx=[5], target="cuda", execution_backend="dlpack")
+    kernel = tilelang.compile(program, out_idx=[5], pass_configs={tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True})
     print(kernel.get_kernel_source())
     profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
     profiler.assert_allclose(ref_program, rtol=0.01, atol=0.01)

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -68,6 +68,7 @@ class KernelCache:
         args=None,
         target: Union[str, Target] = "auto",
         target_host: Union[str, Target] = None,
+        pass_configs: dict = None,
     ) -> str:
         """
         Generates a unique hash key for caching compiled kernels.
@@ -93,6 +94,7 @@ class KernelCache:
             "target": str(target),
             "target_host": str(target_host) if target_host else None,
             "execution_backend": execution_backend,
+            "pass_configs": pass_configs,
         }
         key_string = json.dumps(key_data, sort_keys=True)  # Sort keys to ensure consistency
         return sha256(key_string.encode()).hexdigest()  # Use SHA256 to generate hash key
@@ -138,7 +140,9 @@ class KernelCache:
             execution_backend=execution_backend,
             args=args,
             target=target,
-            target_host=target_host)
+            target_host=target_host,
+            pass_configs=pass_configs,
+        )
         with self._lock:
             # First check in-memory cache
             if key in self._memory_cache:

--- a/tilelang/jit/adapter/ctypes/adapter.py
+++ b/tilelang/jit/adapter/ctypes/adapter.py
@@ -119,6 +119,7 @@ class CtypesKernelAdapter(BaseKernelAdapter):
         adapter.result_idx = adapter._legalize_result_idx(result_idx)
         adapter.kernel_global_source = kernel_global_source
         adapter.wrapped_source = kernel_global_source
+        adapter.pass_configs = pass_configs
 
         if isinstance(func_or_mod, tir.PrimFunc):
             adapter.ir_module = tvm.IRModule({func_or_mod.attrs["global_symbol"]: func_or_mod})

--- a/tilelang/jit/adapter/cython/adapter.py
+++ b/tilelang/jit/adapter/cython/adapter.py
@@ -287,6 +287,7 @@ class CythonKernelAdapter(BaseKernelAdapter):
         adapter.result_idx = adapter._legalize_result_idx(result_idx)
         adapter.kernel_global_source = kernel_global_source
         adapter.wrapped_source = kernel_global_source
+        adapter.pass_configs = pass_configs
 
         if isinstance(func_or_mod, tir.PrimFunc):
             adapter.ir_module = tvm.IRModule({func_or_mod.attrs["global_symbol"]: func_or_mod})

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -147,6 +147,7 @@ class JITKernel(object):
             target=target,
             kernel_global_source=kernel_global_source,
             kernel_lib_path=kernel_lib_path,
+            pass_configs=pass_configs,
         )
         instance.torch_function = instance.adapter.func
         return instance
@@ -250,6 +251,7 @@ class JITKernel(object):
         func_or_mod: Union[PrimFunc, tvm.runtime.Module],
         kernel_global_source: str,
         kernel_lib_path: str,
+        pass_configs: Optional[Dict[str, Any]] = None,
     ) -> BaseKernelAdapter:
         target = self.target
         execution_backend = self.execution_backend
@@ -265,6 +267,7 @@ class JITKernel(object):
                 func_or_mod=func_or_mod,
                 kernel_global_source=kernel_global_source,
                 kernel_lib_path=kernel_lib_path,
+                pass_configs=pass_configs,
             )
         elif execution_backend == "cython":
             adapter = CythonKernelAdapter.from_database(
@@ -274,6 +277,7 @@ class JITKernel(object):
                 func_or_mod=func_or_mod,
                 kernel_global_source=kernel_global_source,
                 kernel_lib_path=kernel_lib_path,
+                pass_configs=pass_configs,
             )
         else:
             # Handle invalid backend.

--- a/tilelang/profiler/__init__.py
+++ b/tilelang/profiler/__init__.py
@@ -119,6 +119,8 @@ class Profiler:
                 rtol=rtol,
                 atol=atol,
                 max_mismatched_ratio=max_mismatched_ratio,
+                base_name="tilelang",
+                ref_name="ref",
             )
 
     def assert_consistent(self, repeat=10):

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -221,6 +221,8 @@ def torch_assert_close(
     check_dtype: bool = True,
     check_layout: bool = True,
     check_stride: bool = False,
+    base_name: str = "LHS",
+    ref_name: str = "RHS",
 ):
     """
     Custom function to assert that two tensors are "close enough," allowing a specified
@@ -296,7 +298,7 @@ def torch_assert_close(
             f"{mismatch_info}"
             f"\nGreatest absolute difference: {diff.max().item()}, "
             f"Greatest relative difference: {(diff / (torch.abs(tensor_b) + 1e-12)).max().item()}"
-            f"\nLHS: {tensor_a}"
-            f"\nRHS: {tensor_b}")
+            f"\n{base_name}: {tensor_a}"
+            f"\n{ref_name}: {tensor_b}")
     else:
         return True


### PR DESCRIPTION
This pull request introduces several updates across multiple files to enhance kernel compilation, improve configurability, and refine tensor comparison utilities. The most significant changes include adding support for `pass_configs` in kernel compilation, simplifying input generation in profiling, and improving tensor comparison error messages.

### Kernel Compilation Enhancements:
* Added a `pass_configs` parameter to several functions and methods, including `_generate_key`, `cached`, and various adapter-related methods, to allow more granular control over kernel compilation. This includes updates in `tilelang/cache/kernel_cache.py`, `tilelang/jit/adapter/ctypes/adapter.py`, `tilelang/jit/adapter/cython/adapter.py`, and `tilelang/jit/kernel.py`. (`[[1]](diffhunk://#diff-9c43640a625dd7e0bc001b30e8d6d253d4d910ad3e83058ee5ff6014b6989d93R71)`, `[[2]](diffhunk://#diff-9c43640a625dd7e0bc001b30e8d6d253d4d910ad3e83058ee5ff6014b6989d93R97)`, `[[3]](diffhunk://#diff-9c43640a625dd7e0bc001b30e8d6d253d4d910ad3e83058ee5ff6014b6989d93L141-R145)`, `[[4]](diffhunk://#diff-2234f838318e2a6bc276679648d8f0baf10ededce1bf0a6443538fe96449ce74R122)`, `[[5]](diffhunk://#diff-fb6f070e77115039cffa90aea9d733c451c961c1c517ad15f5f58487a4ab1548R290)`, `[[6]](diffhunk://#diff-0eaba9f3529de6197aa7e13ba09aadf2253971a3571cf805678f4816e764e194R150)`, `[[7]](diffhunk://#diff-0eaba9f3529de6197aa7e13ba09aadf2253971a3571cf805678f4816e764e194R254)`, `[[8]](diffhunk://#diff-0eaba9f3529de6197aa7e13ba09aadf2253971a3571cf805678f4816e764e194R270)`, `[[9]](diffhunk://#diff-0eaba9f3529de6197aa7e13ba09aadf2253971a3571cf805678f4816e764e194R280)`)

* Modified the kernel compilation call in `examples/flash_decoding/example_mha_inference.py` to include `pass_configs` for disabling TMA lowering, providing more flexibility in kernel behavior. (`[examples/flash_decoding/example_mha_inference.pyL308-R308](diffhunk://#diff-7263a27918434e2d64c23d90c8339d397aebc1090f2a6814742f4627f0c7b084L308-R308)`)

### Profiling and Input Simplification:
* Simplified input generation in `examples/linear_attention/example_retnet.py` by replacing manual tensor initialization with the profiler's `_get_inputs` method, streamlining the code. (`[examples/linear_attention/example_retnet.pyL186-L211](diffhunk://#diff-8f0f916b8916e34b1e6f7274b64e6ee123a2a4afe3dc90eca8fc4948a3056394L186-L211)`)

### Tensor Comparison Improvements:
* Enhanced `torch_assert_close` in `tilelang/utils/tensor.py` to include customizable base and reference tensor names (`base_name` and `ref_name`) in error messages, improving clarity during debugging. (`[[1]](diffhunk://#diff-d53bf1f2e3725debd8d792d8d799bcd17ea37dd3f2019146d6e93b3a3f19be58R224-R225)`, `[[2]](diffhunk://#diff-d53bf1f2e3725debd8d792d8d799bcd17ea37dd3f2019146d6e93b3a3f19be58L299-R302)`)

* Updated `assert_allclose` in `tilelang/profiler/__init__.py` to pass `base_name` and `ref_name` parameters to `torch_assert_close`, ensuring consistent naming conventions in tensor comparison. (`[tilelang/profiler/__init__.pyR122-R123](diffhunk://#diff-b3f17db8492573c451e8c620fb20ac43fee3e885f97135d7710ebd0512a9df70R122-R123)`)