### PR TITLE
docs: add llvm version info to installation.md.

### DIFF
--- a/docs/get_started/Installation.md
+++ b/docs/get_started/Installation.md
@@ -39,6 +39,7 @@ python -c "import tilelang; print(tilelang.__version__)"
 - **Operating System**: Linux
 - **Python Version**: >= 3.7
 - **CUDA Version**: >= 10.0
+- **LLVM**: < 20 if you are using the bundled TVM submodule
 
 We recommend using a Docker container with the necessary dependencies to build **tile-lang** from source. You can use the following command to run a Docker container with the required dependencies:
 


### PR DESCRIPTION
When I built tile-lang from source, I found that compiling issues will raise if I use LLVM-20 due to the version of tvm submodule. Finally I fixed it by using lower version LLVM, therefore I'm adding a small hint to the doc in this PR.


Below is one of the errors:

```
/mnt/<user>/code/community/tilelang/3rdparty/tvm/src/target/llvm/codegen_amdgpu.cc:274:9: error: invalid use of incomplete type 'class llvm::Module'
  274 |     mlib->setTargetTriple(llvm_target->GetTargetTriple());
```