### PR TITLE
[Refactor] Enhance TMA barrier validation and support for additional architectures

### DIFF
--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -6,12 +6,14 @@ import tilelang
 from tilelang.transform import PassContext
 from typing import Optional
 
+SUPPORTED_TMA_ARCHS = {"sm_90", "sm_90a", "sm_100"}
+
 
 def allow_tma_and_warp_specialized(pass_ctx: Optional[PassContext] = None,
                                    target: Optional[Target] = None) -> bool:
     if pass_ctx is None:
         pass_ctx = tilelang.transform.get_pass_context()
-    if target.arch not in {"sm_90", "sm_90a"}:
+    if target.arch not in SUPPORTED_TMA_ARCHS:
         return False
     disable_tma_lower = pass_ctx.config.get("tl.disable_tma_lower", False)
     disable_tma_lower = pass_ctx.config.get("tl.disable_tma_lower", False)
@@ -20,7 +22,7 @@ def allow_tma_and_warp_specialized(pass_ctx: Optional[PassContext] = None,
 
 
 def allow_fence_proxy(target: Optional[Target] = None) -> bool:
-    return target.arch in {"sm_90", "sm_90a"}
+    return target.arch in SUPPORTED_TMA_ARCHS
 
 
 def allow_vectorize(pass_ctx: Optional[PassContext] = None) -> bool:


### PR DESCRIPTION

* Updated the TMA barrier validation in `inject_tma_barrier.cc` to check for non-empty `barrier_id_to_range_` before raising an error for missing `create_list_of_mbarrier`.
* Refactored architecture checks in `phase.py` to utilize a new constant `SUPPORTED_TMA_ARCHS`, allowing for easier updates and improved readability in the target architecture validation logic.