### PR TITLE
[Bugfix] Enable swizzle 32B and fix the misalign bug in fp8 gemm when block_K = 32.

### DIFF
--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -181,8 +181,9 @@ Fragment makeGemmVoltaFragmentA(const int block_m, const int block_n,
 Layout makeGemmVoltaABLayout(int stride, int continuous, bool is_a,
                              int kfactor);
 
-Layout makeFullBankSwizzleLayout(int stride, int continuous, int element_size);
-Layout makeHalfBankSwizzleLayout(int stride, int continuous, int element_size);
+Layout makeSwizzle32BLayout(int stride, int continuous, int element_size);
+Layout makeSwizzle64BLayout(int stride, int continuous, int element_size);
+Layout makeSwizzle128BLayout(int stride, int continuous, int element_size);
 
 namespace attr {
 // BlockAttr, Containing the layout for all the buffers in the block

--- a/src/op/bulk_copy.cc
+++ b/src/op/bulk_copy.cc
@@ -198,14 +198,15 @@ Stmt Copy::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer) const {
                                              *stride, *continuous,
                                              shared_tensor->dtype.bits()))) {
       desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_NONE);
-    } else if (StructuralEqual()(
-                   shared_layout,
-                   makeHalfBankSwizzleLayout(*stride, *continuous,
+    } else if (StructuralEqual()(shared_layout, makeSwizzle32BLayout(
+                                             *stride, *continuous,
+                                             shared_tensor->dtype.bits()))) {
+      desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B);
+    } else if (StructuralEqual()(shared_layout, makeSwizzle64BLayout(
+                                             *stride, *continuous,
                                              shared_tensor->dtype.bits()))) {
       desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B);
-    } else if (StructuralEqual()(
-                   shared_layout,
-                   makeFullBankSwizzleLayout(*stride, *continuous,
+    } else if (StructuralEqual()(shared_layout, makeSwizzle128BLayout(*stride, *continuous,
                                              shared_tensor->dtype.bits()))) {
       desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_128B);
     } else {
@@ -356,11 +357,15 @@ Stmt Conv2DIm2ColOp::Lower(const LowerArgs &T,
     auto stride = as_const_int(shared_layout->InputShape()[0]);
     auto continuous = as_const_int(shared_layout->InputShape()[1]);
     ICHECK(stride != nullptr && continuous != nullptr);
-    if (StructuralEqual()(shared_layout,
-                          makeHalfBankSwizzleLayout(*stride, *continuous,
+    if (StructuralEqual()(shared_layout, makeSwizzle32BLayout(
+                                                    *stride, *continuous,
+                                                    dst->dtype.bits()))) {
+      desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B);
+    } else if (StructuralEqual()(shared_layout, makeSwizzle64BLayout(
+                                                    *stride, *continuous,
                                                     dst->dtype.bits()))) {
       desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B);
-    } else if (StructuralEqual()(shared_layout, makeFullBankSwizzleLayout(
+    } else if (StructuralEqual()(shared_layout, makeSwizzle128BLayout(
                                                     *stride, *continuous,
                                                     dst->dtype.bits()))) {
       desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_128B);

--- a/testing/python/kernel/test_tilelang_kernel_fp8_gemm.py
+++ b/testing/python/kernel/test_tilelang_kernel_fp8_gemm.py
@@ -59,7 +59,9 @@ def assert_matmul_correctness(M, N, K, block_M, block_N, block_K, in_dtype, out_
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version(9)
 def test_assert_matmul():
+    assert_matmul_correctness(1024, 1024, 1024, 128, 128, 32, "e4m3_float8", "float32", "float32")
     assert_matmul_correctness(1024, 1024, 1024, 128, 128, 64, "e4m3_float8", "float32", "float32")
+    assert_matmul_correctness(1024, 1024, 1024, 128, 128, 32, "e5m2_float8", "float32", "float32")
     assert_matmul_correctness(1024, 1024, 1024, 128, 128, 64, "e5m2_float8", "float32", "float32")
 
 

--- a/tilelang/intrinsics/mma_layout.py
+++ b/tilelang/intrinsics/mma_layout.py
@@ -91,6 +91,22 @@ def shared_16x32_to_mma_32x16_smoothlayout(i, j):
 def shared_32x16_to_mma_32x16_smoothlayout(i, j):
     return (i * 2 + j // 16, j % 16)
 
+def xor2x2(i,j):
+    return (i+j)%2
+
+def xor4x4(i,j):
+    i0 = i%2
+    j0 = j%2
+    i1 = i//2
+    j1 = j//2
+    return 2*xor2x2(i1,j1)+xor2x2(i0,j0)
+    
+def xor8x8(i,j):
+    i0 = i%2
+    j0 = j%2
+    i1 = i//2
+    j1 = j//2
+    return 2*xor4x4(i1,j1)+xor2x2(i0,j0)
 
 def get_swizzle_layout(row_idx, col_idx, row_size, dtype: Union[DataType, str], swizzle_bytes=None):
     ana = arith.Analyzer()

--- a/tilelang/intrinsics/mma_layout.py
+++ b/tilelang/intrinsics/mma_layout.py
@@ -92,25 +92,17 @@ def shared_32x16_to_mma_32x16_smoothlayout(i, j):
     return (i * 2 + j // 16, j % 16)
 
 
-def get_swizzle_layout(row_idx, col_idx, row_size, dtype: Union[DataType, str]):
+def get_swizzle_layout(row_idx, col_idx, row_size, dtype: Union[DataType, str], swizzle_bytes = None):
     ana = arith.Analyzer()
-    BANK_SIZE_BYTES = 128
     if isinstance(dtype, str):
         dtype = DataType(dtype)
-    col_idx_outer, col_idx_inner = col_idx // (BANK_SIZE_BYTES // dtype.bits), col_idx % (
-        BANK_SIZE_BYTES // dtype.bits)
-    #  use transaction bits to support diverse dtype.
-    #  for fp16, 64 elems * 16 bits = 1024 bits, 32 elems * 32 bits = 512 bits
-    #  for int8, 128 elems * 8 bits = 1024 bits, 64 elems * 8 bits = 512 bits
-    coalescent_bits = dtype.bits * row_size
-    # permutation on 4 banks, each bank has 32 bits
-    bank_elems = BANK_SIZE_BYTES // dtype.bits
-    new_col_idx_outer = None
-
-    if coalescent_bits % 1024 == 0:
+    row_bytes = dtype.bits * row_size // 8
+    assert row_bytes % 32 == 0, f"Row size must be multiple of 32B."
+    if swizzle_bytes is None:
+        swizzle_bytes = min(128, row_bytes)
+    # 128B swizzle
         #   Use 8 * 8 permuted layout
-        #   Every number below corresponds to 8 consecutive fp16 number in shared mem, i.e. one read
-        #   Every row below corresponds to 32 banks
+        #   Every number below corresponds to 16B
         #   0  1  2  3  4  5  6  7    ==>    0  1  2  3  4  5  6  7
         #   0  1  2  3  4  5  6  7    ==>    1  0  3  2  5  4  7  6
         #   0  1  2  3  4  5  6  7    ==>    2  3  0  1  6  7  4  5
@@ -119,33 +111,23 @@ def get_swizzle_layout(row_idx, col_idx, row_size, dtype: Union[DataType, str]):
         #   0  1  2  3  4  5  6  7    ==>    5  4  7  6  1  0  3  2
         #   0  1  2  3  4  5  6  7    ==>    6  7  4  5  2  3  0  1
         #   0  1  2  3  4  5  6  7    ==>    7  6  5  4  3  2  1  0
-        row_idx_sub = row_idx % bank_elems
-        new_col_idx_outer = col_idx_outer ^ row_idx_sub
-    else:
-        assert coalescent_bits % 512 == 0
+    # 64B swizzle
         #  Use 8 * 4 permuted layout
-        #  Every number below corresponds to 8 consecutive fp16 number in shared mem, i.e. one read
-        #  Every row below corresponds to 16 banks
-        #  0  1  2  3    ==>    0  1  2  3
-        #  0  1  2  3    ==>    0  1  2  3
-        #  0  1  2  3    ==>    1  0  3  2
-        #  0  1  2  3    ==>    1  0  3  2
-        #  0  1  2  3    ==>    2  3  0  1
-        #  0  1  2  3    ==>    2  3  0  1
-        #  0  1  2  3    ==>    3  2  1  0
-        #  0  1  2  3    ==>    3  2  1  0
-        #  View with 8 elements per row:
+        #  Every number below corresponds to 16B
         #  0  1  2  3  4  0  1  2  3    ==>    0  1  2  3  0  1  2  3
         #  0  1  2  3  4  0  1  2  3    ==>    1  0  3  2  1  0  3  2
         #  0  1  2  3  4  0  1  2  3    ==>    2  3  0  1  2  3  0  1
         #  0  1  2  3  4  0  1  2  3    ==>    3  2  1  0  3  2  1  0
-        row_idx_sub = row_idx % bank_elems
-        #  Interleave elems per byte
-        interleave_elems = 32 // dtype.bits
-        new_col_idx_outer = col_idx_outer ^ (row_idx_sub // interleave_elems)
-
-    assert (new_col_idx_outer is not None), f"Unsupported dtype {dtype} with {coalescent_bits} bits"
-    return row_idx, ana.simplify(new_col_idx_outer * bank_elems + col_idx_inner)
+    # 32B swizzle
+        #  Use 8 * 2 permuted layout
+        #  Every number below corresponds to 16B
+        #  0  1  2  3  4  5  6  7    ==>    0  1  2  3  4  5  6  7
+        #  0  1  2  3  4  5  6  7    ==>    1  0  3  2  5  4  7  6
+    elem_per_16B = 128 // dtype.bits
+    col_idx_16B = col_idx // elem_per_16B
+    col_idx_in_16B = col_idx % elem_per_16B
+    new_col_idx_16B = col_idx_16B ^ (row_idx % (swizzle_bytes // 16))
+    return row_idx, ana.simplify(new_col_idx_16B * elem_per_16B + col_idx_in_16B)
 
 
 def make_mma_swizzle_layout(shared_buf, is_smooth: bool = False):

--- a/tilelang/intrinsics/mma_layout.py
+++ b/tilelang/intrinsics/mma_layout.py
@@ -91,22 +91,26 @@ def shared_16x32_to_mma_32x16_smoothlayout(i, j):
 def shared_32x16_to_mma_32x16_smoothlayout(i, j):
     return (i * 2 + j // 16, j % 16)
 
-def xor2x2(i,j):
-    return (i+j)%2
 
-def xor4x4(i,j):
-    i0 = i%2
-    j0 = j%2
-    i1 = i//2
-    j1 = j//2
-    return 2*xor2x2(i1,j1)+xor2x2(i0,j0)
-    
-def xor8x8(i,j):
-    i0 = i%2
-    j0 = j%2
-    i1 = i//2
-    j1 = j//2
-    return 2*xor4x4(i1,j1)+xor2x2(i0,j0)
+def xor2x2(i, j):
+    return (i + j) % 2
+
+
+def xor4x4(i, j):
+    i0 = i % 2
+    j0 = j % 2
+    i1 = i // 2
+    j1 = j // 2
+    return 2 * xor2x2(i1, j1) + xor2x2(i0, j0)
+
+
+def xor8x8(i, j):
+    i0 = i % 2
+    j0 = j % 2
+    i1 = i // 2
+    j1 = j // 2
+    return 2 * xor4x4(i1, j1) + xor2x2(i0, j0)
+
 
 def get_swizzle_layout(row_idx, col_idx, row_size, dtype: Union[DataType, str], swizzle_bytes=None):
     ana = arith.Analyzer()

--- a/tilelang/intrinsics/mma_layout.py
+++ b/tilelang/intrinsics/mma_layout.py
@@ -92,37 +92,37 @@ def shared_32x16_to_mma_32x16_smoothlayout(i, j):
     return (i * 2 + j // 16, j % 16)
 
 
-def get_swizzle_layout(row_idx, col_idx, row_size, dtype: Union[DataType, str], swizzle_bytes = None):
+def get_swizzle_layout(row_idx, col_idx, row_size, dtype: Union[DataType, str], swizzle_bytes=None):
     ana = arith.Analyzer()
     if isinstance(dtype, str):
         dtype = DataType(dtype)
     row_bytes = dtype.bits * row_size // 8
-    assert row_bytes % 32 == 0, f"Row size must be multiple of 32B."
+    assert row_bytes % 32 == 0, "Row size must be multiple of 32B."
     if swizzle_bytes is None:
         swizzle_bytes = min(128, row_bytes)
     # 128B swizzle
-        #   Use 8 * 8 permuted layout
-        #   Every number below corresponds to 16B
-        #   0  1  2  3  4  5  6  7    ==>    0  1  2  3  4  5  6  7
-        #   0  1  2  3  4  5  6  7    ==>    1  0  3  2  5  4  7  6
-        #   0  1  2  3  4  5  6  7    ==>    2  3  0  1  6  7  4  5
-        #   0  1  2  3  4  5  6  7    ==>    3  2  1  0  7  6  5  4
-        #   0  1  2  3  4  5  6  7    ==>    4  5  6  7  0  1  2  3
-        #   0  1  2  3  4  5  6  7    ==>    5  4  7  6  1  0  3  2
-        #   0  1  2  3  4  5  6  7    ==>    6  7  4  5  2  3  0  1
-        #   0  1  2  3  4  5  6  7    ==>    7  6  5  4  3  2  1  0
+    #   Use 8 * 8 permuted layout
+    #   Every number below corresponds to 16B
+    #   0  1  2  3  4  5  6  7    ==>    0  1  2  3  4  5  6  7
+    #   0  1  2  3  4  5  6  7    ==>    1  0  3  2  5  4  7  6
+    #   0  1  2  3  4  5  6  7    ==>    2  3  0  1  6  7  4  5
+    #   0  1  2  3  4  5  6  7    ==>    3  2  1  0  7  6  5  4
+    #   0  1  2  3  4  5  6  7    ==>    4  5  6  7  0  1  2  3
+    #   0  1  2  3  4  5  6  7    ==>    5  4  7  6  1  0  3  2
+    #   0  1  2  3  4  5  6  7    ==>    6  7  4  5  2  3  0  1
+    #   0  1  2  3  4  5  6  7    ==>    7  6  5  4  3  2  1  0
     # 64B swizzle
-        #  Use 8 * 4 permuted layout
-        #  Every number below corresponds to 16B
-        #  0  1  2  3  4  0  1  2  3    ==>    0  1  2  3  0  1  2  3
-        #  0  1  2  3  4  0  1  2  3    ==>    1  0  3  2  1  0  3  2
-        #  0  1  2  3  4  0  1  2  3    ==>    2  3  0  1  2  3  0  1
-        #  0  1  2  3  4  0  1  2  3    ==>    3  2  1  0  3  2  1  0
+    #  Use 8 * 4 permuted layout
+    #  Every number below corresponds to 16B
+    #  0  1  2  3  4  0  1  2  3    ==>    0  1  2  3  0  1  2  3
+    #  0  1  2  3  4  0  1  2  3    ==>    1  0  3  2  1  0  3  2
+    #  0  1  2  3  4  0  1  2  3    ==>    2  3  0  1  2  3  0  1
+    #  0  1  2  3  4  0  1  2  3    ==>    3  2  1  0  3  2  1  0
     # 32B swizzle
-        #  Use 8 * 2 permuted layout
-        #  Every number below corresponds to 16B
-        #  0  1  2  3  4  5  6  7    ==>    0  1  2  3  4  5  6  7
-        #  0  1  2  3  4  5  6  7    ==>    1  0  3  2  5  4  7  6
+    #  Use 8 * 2 permuted layout
+    #  Every number below corresponds to 16B
+    #  0  1  2  3  4  5  6  7    ==>    0  1  2  3  4  5  6  7
+    #  0  1  2  3  4  5  6  7    ==>    1  0  3  2  5  4  7  6
     elem_per_16B = 128 // dtype.bits
     col_idx_16B = col_idx // elem_per_16B
     col_idx_in_16B = col_idx % elem_per_16B


### PR DESCRIPTION
When K_tile = 32B, we need to use swizzle 32B instead of padding to next 16B.
This PR added the support of swizzle 32B.