### PR TITLE
[Typo] Rename `power_of_int` with `pow_of_int` for consistency

### DIFF
--- a/src/op/math.cc
+++ b/src/op/math.cc
@@ -24,7 +24,7 @@ PrimExpr power_of_int_op(PrimExpr args) {
   PrimExpr base = arg[0];
   PrimExpr exp = arg[1];
   String power_of_int_name =
-      "tl::power_of_int<" + std::to_string(exp.as<IntImmNode>()->value) + ">";
+      "tl::pow_of_int<" + std::to_string(exp.as<IntImmNode>()->value) + ">";
   return tir::Call(base.dtype(), tir::builtin::call_extern(),
                    {StringImm(power_of_int_name), base});
 }

--- a/src/op/math.cc
+++ b/src/op/math.cc
@@ -16,25 +16,25 @@ namespace tvm {
 namespace tl {
 using namespace tir;
 
-PrimExpr power_of_int_op(PrimExpr args) {
+PrimExpr pow_of_int_op(PrimExpr args) {
   const CallNode *call = args.as<CallNode>();
   CHECK(call != nullptr);
   const Array<PrimExpr> &arg = call->args;
   ICHECK_EQ(arg.size(), 2);
   PrimExpr base = arg[0];
   PrimExpr exp = arg[1];
-  String power_of_int_name =
+  String pow_of_int_name =
       "tl::pow_of_int<" + std::to_string(exp.as<IntImmNode>()->value) + ">";
   return tir::Call(base.dtype(), tir::builtin::call_extern(),
-                   {StringImm(power_of_int_name), base});
+                   {StringImm(pow_of_int_name), base});
 }
 
-TVM_REGISTER_OP("tl.power_of_int")
+TVM_REGISTER_OP("tl.pow_of_int")
     .set_num_inputs(2)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kPure))
-    .set_attr<TScriptPrinterName>("TScriptPrinterName", "power_of_int")
-    .set_attr<FLowerIntrinsic>("cuda.FLowerIntrinsic", power_of_int_op);
+    .set_attr<TScriptPrinterName>("TScriptPrinterName", "pow_of_int")
+    .set_attr<FLowerIntrinsic>("cuda.FLowerIntrinsic", pow_of_int_op);
 
 } // namespace tl
 } // namespace tvm

--- a/tilelang/language/tir/op.py
+++ b/tilelang/language/tir/op.py
@@ -2612,7 +2612,7 @@ def pow_of_int(x: PrimExpr, y: int) -> PrimExpr:
     """
     return call_intrin(
         x.dtype,
-        tvm.tir.op.Op.get("tl.power_of_int"),
+        tvm.tir.op.Op.get("tl.pow_of_int"),
         x,
         y,
     )


### PR DESCRIPTION
This pull request updates the naming convention for a mathematical operation in both C++ and Python code to ensure consistency and clarity. The changes primarily involve renaming the operation from `power_of_int` to `pow_of_int` across relevant files.

### Naming convention updates:

* In `src/op/math.cc`, the function `power_of_int_op` was renamed to `pow_of_int_op`, and associated strings and attributes were updated to reflect the new name. This includes changes to the operation name in `TVM_REGISTER_OP` and string literals used in the function.

* In `tilelang/language/tir/op.py`, the operation name passed to `tvm.tir.op.Op.get` was updated from `"tl.power_of_int"` to `"tl.pow_of_int"`.