### PR TITLE
[Refactor] Update set_compile_args to allow None for out_idx parameter

### DIFF
--- a/tilelang/autotuner/__init__.py
+++ b/tilelang/autotuner/__init__.py
@@ -156,7 +156,7 @@ class AutoTuner:
         return cls(kernel, configs)
 
     def set_compile_args(self,
-                         out_idx: Union[List[int], int] = -1,
+                         out_idx: Union[List[int], int, None] = None,
                          supply_type: tilelang.TensorSupplyType = tilelang.TensorSupplyType.Auto,
                          ref_prog: Callable = None,
                          supply_prog: Callable = None,

--- a/tilelang/jit/__init__.py
+++ b/tilelang/jit/__init__.py
@@ -28,7 +28,7 @@ def jit(
     execution_backend: Literal["dlpack", "ctypes", "cython"] = "cython",
     target: Union[str, Target] = "auto",
     verbose: bool = False,
-    **pass_config_kwargs: Optional[Dict[str, Any]],
+    pass_configs: Optional[Dict[str, Any]] = None,
 ) -> BaseKernelAdapter:
     """
     A decorator (or decorator factory) that JIT-compiles a given TileLang PrimFunc 
@@ -95,7 +95,7 @@ def jit(
             verbose=verbose,
             execution_backend=execution_backend,
             out_idx=out_idx,
-            **pass_config_kwargs,
+            pass_configs=pass_configs,
         ).adapter
 
     # If `func` was given, compile it immediately and return the adapter.


### PR DESCRIPTION
* Modified the `set_compile_args` method in `AutoTuner` to accept `None` as a valid input for the `out_idx` parameter, enhancing flexibility in argument handling.