### PR TITLE
Fix deepgemm exmaple 

### DIFF
--- a/examples/deepseek_deepgemm/example_deepgemm_fp8_2xAcc.py
+++ b/examples/deepseek_deepgemm/example_deepgemm_fp8_2xAcc.py
@@ -9,7 +9,7 @@ import tilelang as TL
 import tilelang.language as T
 from tilelang.utils.tensor import map_torch_type
 
-tilelang.testing.set_random_seed(0)
+tilelang.testing.set_random_seed(42)
 
 
 def tl_gemm(
@@ -154,9 +154,6 @@ def assert_tl_gemm_correctness(M, N, K, block_N, in_dtype, out_dtype, accum_dtyp
     # src_code is the generated cuda source
     assert src_code is not None
 
-    print(
-        f"M={M}, N={N}, K={K}, block_N={block_N}, in_dtype={in_dtype}, out_dtype={out_dtype}, accum_dtype={accum_dtype}"
-    )
     in_dtype = map_torch_type(in_dtype)
     out_dtype = map_torch_type(out_dtype)
     accum_dtype = map_torch_type(accum_dtype)
@@ -181,7 +178,7 @@ def assert_tl_gemm_correctness(M, N, K, block_N, in_dtype, out_dtype, accum_dtyp
     assert latency is not None
     print(f"latency: {latency} ms")
     tflops = 2 * M * N * K / latency / 1e9
-    print(f"tflops: {tflops}\n")
+    print(f"tflops: {tflops}")
 
 
 if __name__ == "__main__":

--- a/examples/deepseek_deepgemm/example_deepgemm_fp8_2xAcc.py
+++ b/examples/deepseek_deepgemm/example_deepgemm_fp8_2xAcc.py
@@ -154,6 +154,7 @@ def assert_tl_gemm_correctness(M, N, K, block_N, in_dtype, out_dtype, accum_dtyp
     # src_code is the generated cuda source
     assert src_code is not None
 
+    print(f"M={M}, N={N}, K={K}, block_N={block_N}, in_dtype={in_dtype}, out_dtype={out_dtype}, accum_dtype={accum_dtype}")
     in_dtype = map_torch_type(in_dtype)
     out_dtype = map_torch_type(out_dtype)
     accum_dtype = map_torch_type(accum_dtype)
@@ -169,7 +170,6 @@ def assert_tl_gemm_correctness(M, N, K, block_N, in_dtype, out_dtype, accum_dtyp
     # Get Reference Result
     ref_c = ref_deepgemm_fp8(A_fp8, B_fp8, A_scale, B_scale, out_dtype)
     diff = calc_diff(C, ref_c)
-    print(f"Running deepgemm Benchmark for M={M}, N={N}, K={K}, block_N={block_N}, in_dtype={in_dtype}, out_dtype={out_dtype}, accum_dtype={accum_dtype}")
     print(f"diff: {diff}")
     assert diff < 1e-3
 

--- a/examples/deepseek_deepgemm/example_deepgemm_fp8_2xAcc.py
+++ b/examples/deepseek_deepgemm/example_deepgemm_fp8_2xAcc.py
@@ -146,8 +146,8 @@ def calc_diff(x, y):
     return 1 - sim
 
 
-def assert_tl_gemm_correctness(M, N, K, in_dtype, out_dtype, accum_dtype):
-    gemm = tl_gemm(M, N, K, in_dtype, out_dtype, accum_dtype)
+def assert_tl_gemm_correctness(M, N, K, block_N, in_dtype, out_dtype, accum_dtype):
+    gemm = tl_gemm(M, N, K, block_N, in_dtype, out_dtype, accum_dtype)
     kernel = TL.compile(gemm, out_idx=[])
     src_code = kernel.get_kernel_source()
 
@@ -169,6 +169,7 @@ def assert_tl_gemm_correctness(M, N, K, in_dtype, out_dtype, accum_dtype):
     # Get Reference Result
     ref_c = ref_deepgemm_fp8(A_fp8, B_fp8, A_scale, B_scale, out_dtype)
     diff = calc_diff(C, ref_c)
+    print(f"Running deepgemm Benchmark for M={M}, N={N}, K={K}, block_N={block_N}, in_dtype={in_dtype}, out_dtype={out_dtype}, accum_dtype={accum_dtype}")
     print(f"diff: {diff}")
     assert diff < 1e-3
 
@@ -178,7 +179,7 @@ def assert_tl_gemm_correctness(M, N, K, in_dtype, out_dtype, accum_dtype):
     assert latency is not None
     print(f"latency: {latency} ms")
     tflops = 2 * M * N * K / latency / 1e9
-    print(f"tflops: {tflops}")
+    print(f"tflops: {tflops}\n")
 
 
 if __name__ == "__main__":

--- a/examples/deepseek_deepgemm/example_deepgemm_fp8_2xAcc.py
+++ b/examples/deepseek_deepgemm/example_deepgemm_fp8_2xAcc.py
@@ -154,7 +154,9 @@ def assert_tl_gemm_correctness(M, N, K, block_N, in_dtype, out_dtype, accum_dtyp
     # src_code is the generated cuda source
     assert src_code is not None
 
-    print(f"M={M}, N={N}, K={K}, block_N={block_N}, in_dtype={in_dtype}, out_dtype={out_dtype}, accum_dtype={accum_dtype}")
+    print(
+        f"M={M}, N={N}, K={K}, block_N={block_N}, in_dtype={in_dtype}, out_dtype={out_dtype}, accum_dtype={accum_dtype}"
+    )
     in_dtype = map_torch_type(in_dtype)
     out_dtype = map_torch_type(out_dtype)
     accum_dtype = map_torch_type(accum_dtype)


### PR DESCRIPTION
The origin example miss blockK, so have wrong logs: 
```
Traceback (most recent call last):
  File "/A/tilelang/examples/deepseek_deepgemm/example_deepgemm_fp8_2xAcc.py", line 188, in <module>
    assert_tl_gemm_correctness(1024, 1024, 8192, block_N, dtype, out_dtype, "float32")
TypeError: assert_tl_gemm_correctness() takes 6 positional arguments but 7 were given
```

Also add a line to print the running config, the result looks now: 
```
M=1024, N=1024, K=8192, block_N=16, in_dtype=e4m3_float8, out_dtype=bfloat16, accum_dtype=float32
diff: 3.2641305429681466e-06
latency: 0.17004799842834473 ms
tflops: 101.02952897289937

M=1024, N=1024, K=8192, block_N=32, in_dtype=e4m3_float8, out_dtype=bfloat16, accum_dtype=float32
diff: 3.2780839122059646e-06
latency: 0.1316480040550232 ms
tflops: 130.49851615539538

M=1024, N=1024, K=8192, block_N=64, in_dtype=e4m3_float8, out_dtype=bfloat16, accum_dtype=float32
diff: 3.2598711143805303e-06
latency: 0.10572800040245056 ms
tflops: 162.49119550739

M=1024, N=1024, K=8192, block_N=128, in_dtype=e4m3_float8, out_dtype=bfloat16, accum_dtype=float32
diff: 3.2763182604700347e-06
latency: 0.11388800293207169 ms
.....
```