### PR TITLE
[Enhancement] Add atomicAdd for FLOAT16x2 and FLOAT16x4

### DIFF
--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -184,18 +184,15 @@ TL_DEVICE void AtomicAddx2(bfloat16_t *address, bfloat16_t *val) {
 #if (defined(__CUDA_ARCH_LIST__) && (__CUDA_ARCH_LIST__ >= 900))
 // AtomicAdd Functions for FLOAT16x2
 TL_DEVICE void AtomicAddx2(float *address, float *val) {
-  atomicAdd(
-      reinterpret_cast<float2 *>(address),
-      static_cast<float2>(*reinterpret_cast<float2 *>(val)));
+  atomicAdd(reinterpret_cast<float2 *>(address),
+            static_cast<float2>(*reinterpret_cast<float2 *>(val)));
 }
 // AtomicAdd Functions for FLOAT16x4
 TL_DEVICE void AtomicAddx4(float *address, float *val) {
-  atomicAdd(
-      reinterpret_cast<float4 *>(address),
-      static_cast<float4>(*reinterpret_cast<float4 *>(val)));
+  atomicAdd(reinterpret_cast<float4 *>(address),
+            static_cast<float4>(*reinterpret_cast<float4 *>(val)));
 }
 #endif
-
 
 // DP4A
 template <typename InDatatype, typename OutDatatype>

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -181,6 +181,22 @@ TL_DEVICE void AtomicAddx2(bfloat16_t *address, bfloat16_t *val) {
 }
 #endif
 
+#if (defined(__CUDA_ARCH_LIST__) && (__CUDA_ARCH_LIST__ >= 900))
+// AtomicAdd Functions for FLOAT16x2
+TL_DEVICE void AtomicAddx2(float *address, float *val) {
+  atomicAdd(
+      reinterpret_cast<float2 *>(address),
+      static_cast<float2>(*reinterpret_cast<float2 *>(val)));
+}
+// AtomicAdd Functions for FLOAT16x4
+TL_DEVICE void AtomicAddx4(float *address, float *val) {
+  atomicAdd(
+      reinterpret_cast<float4 *>(address),
+      static_cast<float4>(*reinterpret_cast<float4 *>(val)));
+}
+#endif
+
+
 // DP4A
 template <typename InDatatype, typename OutDatatype>
 TL_DEVICE void DP4A(InDatatype *a, InDatatype *b, OutDatatype *c) {

--- a/tilelang/language/__init__.py
+++ b/tilelang/language/__init__.py
@@ -57,6 +57,7 @@ from .print import print  # noqa: F401
 from .customize import (
     atomic_add,  # noqa: F401
     atomic_addx2,  # noqa: F401
+    atomic_addx4,  # noqa: F401
     dp4a,  # noqa: F401
     clamp,  # noqa: F401
     reshape,  # noqa: F401

--- a/tilelang/language/customize.py
+++ b/tilelang/language/customize.py
@@ -33,6 +33,19 @@ def atomic_addx2(dst: Buffer, value: PrimExpr) -> PrimExpr:
     return T.call_extern("handle", "AtomicAddx2", T.address_of(dst), T.address_of(value))
 
 
+def atomic_addx4(dst: Buffer, value: PrimExpr) -> PrimExpr:
+    """Perform an atomic addition operation with double-width operands.
+
+    Args:
+        dst (Buffer): Destination buffer where the atomic addition will be performed
+        value (PrimExpr): Value to be atomically added (double-width)
+
+    Returns:
+        PrimExpr: Handle to the double-width atomic addition operation
+    """
+    return T.call_extern("handle", "AtomicAddx4", T.address_of(dst), T.address_of(value))
+
+
 def dp4a(A: Buffer, B: Buffer, C: Buffer) -> PrimExpr:
     """Perform a 4-element dot product with accumulation (DP4A).
 


### PR DESCRIPTION
 * Introduced `AtomicAddx2` and `AtomicAddx4` functions for performing atomic addition operations on double-width float types in CUDA.
  * Updated `customize.py` to include the new `atomic_addx4` function for external calls.
  * Modified `__init__.py` to export the new atomic addition function, ensuring accessibility in the module.