### PR TITLE
[Enhancement] Add commit ID to versioning and improve logging initialization

### DIFF
--- a/src/transform/flatten_buffer.cc
+++ b/src/transform/flatten_buffer.cc
@@ -281,11 +281,12 @@ private:
       auto int_bound = analyzer_->const_int_bound(index);
       DataType dtype = index->dtype;
       if (dtype.is_int() && dtype.bits() < 64) {
-        int64_t max_value = int_bound->max_value + 1;
+        int64_t max_value = int_bound->max_value;
         int64_t min_value = int_bound->min_value;
         const int64_t type_max = (1LL << (dtype.bits() - 1));
         const int64_t type_min = -(1LL << (dtype.bits() - 1));
-        if (max_value >= type_max || min_value < type_min) {
+
+        if (max_value >= (type_max - 1) || min_value < type_min) {
           Int64Promoter promoter;
           for (auto &index : flattened_indices) {
             safe_indices.push_back(promoter(index));

--- a/tilelang/autotuner/__init__.py
+++ b/tilelang/autotuner/__init__.py
@@ -46,18 +46,24 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 logger.propagate = False
 
-formatter = logging.Formatter('%(asctime)s %(levelname)s:%(message)s')
+# Lazy handler initialization flag
+_logger_handlers_initialized = False
 
-file_handler = logging.FileHandler('autotuner.log', mode='w')
-file_handler.setLevel(logging.DEBUG)
-file_handler.setFormatter(formatter)
 
-console_handler = logging.StreamHandler(sys.stdout)
-console_handler.setLevel(logging.INFO)
-console_handler.setFormatter(formatter)
-
-logger.addHandler(file_handler)
-logger.addHandler(console_handler)
+def _init_logger_handlers():
+    global _logger_handlers_initialized
+    if _logger_handlers_initialized:
+        return
+    formatter = logging.Formatter('%(asctime)s %(levelname)s:%(message)s')
+    file_handler = logging.FileHandler('autotuner.log', mode='w')
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(formatter)
+    console_handler = logging.StreamHandler(sys.stdout)
+    console_handler.setLevel(logging.INFO)
+    console_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+    logger.addHandler(console_handler)
+    _logger_handlers_initialized = True
 
 
 @dataclass(frozen=True)
@@ -241,6 +247,7 @@ class AutoTuner:
         Returns:
             AutotuneResult: Results of the auto-tuning process.
         """
+        _init_logger_handlers()
         sig = inspect.signature(self.fn)
         keys = list(sig.parameters.keys())
         bound_args = sig.bind()

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -17,6 +17,7 @@ import cloudpickle
 import logging
 
 from tilelang.env import TILELANG_CACHE_DIR, is_cache_enabled
+from tilelang.version import __version__
 
 KERNEL_PATH = "kernel.cu"
 WRAPPED_KERNEL_PATH = "wrapped_kernel.cu"
@@ -89,6 +90,7 @@ class KernelCache:
         """
         func_binary = cloudpickle.dumps(func.script())
         key_data = {
+            "version": __version__,
             "func": sha256(func_binary).hexdigest(),  # Use SHA256 to generate hash key
             "out_idx": (tuple(out_idx) if isinstance(out_idx, (list, tuple)) else [out_idx]),
             "args_repr": tuple(
@@ -149,6 +151,8 @@ class KernelCache:
         with self._lock:
             # First check in-memory cache
             if key in self._memory_cache:
+                self.logger.warning("Found kernel in memory cache. For better performance," \
+                                    " consider using `@tilelang.jit` instead of direct kernel caching.")
                 return self._memory_cache[key]
 
             # Then check disk cache

--- a/tilelang/version.py
+++ b/tilelang/version.py
@@ -2,6 +2,8 @@
 # Licensed under the MIT License.
 
 import os
+import subprocess
+from typing import Union
 
 # Get the absolute path of the current Python script's directory
 current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -24,6 +26,25 @@ else:
 # Use 'strip()' to remove any leading/trailing whitespace or newline characters
 with open(version_file_path, "r") as version_file:
     __version__ = version_file.read().strip()
+
+
+def get_git_commit_id() -> Union[str, None]:
+    """Get the current git commit hash.
+    
+    Returns:
+        str | None: The git commit hash if available, None otherwise.
+    """
+    try:
+        return subprocess.check_output(['git', 'rev-parse', 'HEAD'],
+                                       stderr=subprocess.DEVNULL,
+                                       encoding='utf-8').strip()
+    except subprocess.SubprocessError:
+        return None
+
+
+# Append git commit hash to version if not already present
+if "+" not in __version__ and (commit_id := get_git_commit_id()):
+    __version__ = f"{__version__}+{commit_id}"
 
 # Define the public API for the module
 __all__ = ["__version__"]


### PR DESCRIPTION
* Updated `get_tilelang_version` to include an optional commit ID in the version string.
* Enhanced the `TileLangBuilPydCommand` to write the version with commit ID to the VERSION file during the build process.
* Introduced a new function `get_git_commit_id` in `version.py` to retrieve the current git commit hash.
* Refactored logger initialization in `autotuner/__init__.py` to ensure handlers are set up only once, improving performance and clarity.
* Minor fixes in `flatten_buffer.cc` and `kernel_cache.py` for better handling of versioning and logging.
