### PR TITLE
[Bugfix] Add tf32 casting to GEMM templates

### DIFF
--- a/src/tl_templates/cuda/gemm_sm80.h
+++ b/src/tl_templates/cuda/gemm_sm80.h
@@ -301,10 +301,9 @@ public:
       gemm(tiled_mma, tCrA_view(_, _, k), tCrB_view(_, _, k), acc);
     }
   }
-  da
 
-      static CUTE_DEVICE void
-      body_rs(A_type_raw *pA, B_type_raw *pB, C_type_raw *pC) {
+  static CUTE_DEVICE void body_rs(A_type_raw *pA, B_type_raw *pB,
+                                  C_type_raw *pC) {
     const int tid = threadIdx.x;
     Tensor sB = make_tensor(make_smem_ptr(reinterpret_cast<B_type *>(pB)),
                             SmemLayoutB{});

--- a/src/tl_templates/cuda/gemm_sm80.h
+++ b/src/tl_templates/cuda/gemm_sm80.h
@@ -203,7 +203,9 @@ struct OperandTraits<64, N, K, false, num_warp_n,
 
 template <typename T> CUTE_HOST_DEVICE static void cast_float_to_tf32(T &a) {
   uint32_t x = reinterpret_cast<uint32_t const &>(a);
-  x += 0x1000u;
+  if (std::isfinite(a)) {
+    x += 0x1000u;
+  }
   a = tfloat32_t::bitcast(x);
 };
 
@@ -222,9 +224,9 @@ public:
 
   static constexpr bool need_tfloat32_cast =
       std::is_same<A_type_raw, float>::value &&
-      std::is_same<A_type, tfloat32_t>::value &&
-      std::is_same<B_type_raw, float>::value &&
-      std::is_same<B_type, tfloat32_t>::value;
+      // A_type will be tfloat32_t if A_type_raw is float
+      std::is_same<B_type_raw, float>::value;
+  // B_type will be tfloat32_t if B_type_raw is float
 
   using Instruction =
       DispatchInstruction<A_type, B_type, C_type, num_warp_m, num_warp_n, N>;

--- a/src/tl_templates/cuda/gemm_sm80.h
+++ b/src/tl_templates/cuda/gemm_sm80.h
@@ -201,6 +201,12 @@ struct OperandTraits<64, N, K, false, num_warp_n,
   using Copy = DefaultCopy;
 };
 
+template <typename T> CUTE_HOST_DEVICE static void cast_float_to_tf32(T &a) {
+  uint32_t x = reinterpret_cast<uint32_t const &>(a);
+  x += 0x1000u;
+  a = tfloat32_t::bitcast(x);
+};
+
 template <int M, int N, int K, int num_warp_m, int num_warp_n, bool trans_A,
           bool trans_B, bool clear_accum, typename A_type_raw,
           typename B_type_raw, typename C_type_raw>
@@ -213,6 +219,12 @@ public:
       typename std::conditional<std::is_same<B_type_raw, float>::value,
                                 tfloat32_t, A_type_raw>::type;
   using C_type = C_type_raw;
+
+
+  static constexpr bool is_tfloat32 =
+      std::is_same<A_type, tfloat32_t>::value &&
+      std::is_same<B_type, tfloat32_t>::value;
+  
   using Instruction =
       DispatchInstruction<A_type, B_type, C_type, num_warp_m, num_warp_n, N>;
 
@@ -281,6 +293,10 @@ public:
     for (int k = 0; k < size<2>(tCrA); ++k) {
       copy(tiled_copy_A, tCsA(_, _, k), tCrA_copy_view(_, _, k));
       copy(tiled_copy_B, tCsB(_, _, k), tCrB_copy_view(_, _, k));
+      if constexpr (is_tfloat32) {
+        cast_float_to_tf32(tCrA_view(_, _, k));
+        cast_float_to_tf32(tCrB_view(_, _, k));
+      }
       gemm(tiled_mma, tCrA_view(_, _, k), tCrB_view(_, _, k), acc);
     }
   }
@@ -306,7 +322,9 @@ public:
     Tensor tCrA =
         make_tensor(make_rmem_ptr(reinterpret_cast<A_type *>(pA)),
                     partition_shape_A(tiled_mma, Shape<Int<M>, Int<K>>{}));
-
+    if constexpr (is_tfloat32) {
+      cast_float_to_tf32(tCrA);
+    }
     if constexpr (clear_accum) {
       clear(acc);
     }
@@ -316,6 +334,9 @@ public:
     for (int k = 0; k < size<2>(tCrA); ++k) {
       if (k < size<2>(tCrA) - 1) {
         copy(tiled_copy_B, tCsB(_, _, k + 1), tCrB_copy_view(_, _, k + 1));
+      }
+      if constexpr (is_tfloat32) {
+        cast_float_to_tf32(tCrB_view(_, _, k));
       }
       gemm(tiled_mma, tCrA(_, _, k), tCrB_view(_, _, k), acc);
     }
@@ -342,7 +363,9 @@ public:
     Tensor tCrB =
         make_tensor(make_rmem_ptr(reinterpret_cast<B_type *>(pB)),
                     partition_shape_B(tiled_mma, Shape<Int<N>, Int<K>>{}));
-
+    if constexpr (is_tfloat32) {
+      cast_float_to_tf32(tCrB);
+    }
     if constexpr (clear_accum) {
       clear(acc);
     }
@@ -352,6 +375,9 @@ public:
     for (int k = 0; k < size<2>(tCrA); ++k) {
       if (k < size<2>(tCrA) - 1) {
         copy(tiled_copy_A, tCsA(_, _, k + 1), tCrA_copy_view(_, _, k + 1));
+      }
+      if constexpr (is_tfloat32) {
+        cast_float_to_tf32(tCrA_view(_, _, k));
       }
       gemm(tiled_mma, tCrA_view(_, _, k), tCrB(_, _, k), acc);
     }

--- a/src/tl_templates/cuda/gemm_sm80.h
+++ b/src/tl_templates/cuda/gemm_sm80.h
@@ -224,9 +224,7 @@ public:
 
   static constexpr bool need_tfloat32_cast =
       std::is_same<A_type_raw, float>::value &&
-      // A_type will be tfloat32_t if A_type_raw is float
       std::is_same<B_type_raw, float>::value;
-  // B_type will be tfloat32_t if B_type_raw is float
 
   using Instruction =
       DispatchInstruction<A_type, B_type, C_type, num_warp_m, num_warp_n, N>;

--- a/src/tl_templates/cuda/gemm_sm80.h
+++ b/src/tl_templates/cuda/gemm_sm80.h
@@ -220,11 +220,9 @@ public:
                                 tfloat32_t, A_type_raw>::type;
   using C_type = C_type_raw;
 
+  static constexpr bool is_tfloat32 = std::is_same<A_type, tfloat32_t>::value &&
+                                      std::is_same<B_type, tfloat32_t>::value;
 
-  static constexpr bool is_tfloat32 =
-      std::is_same<A_type, tfloat32_t>::value &&
-      std::is_same<B_type, tfloat32_t>::value;
-  
   using Instruction =
       DispatchInstruction<A_type, B_type, C_type, num_warp_m, num_warp_n, N>;
 

--- a/src/tl_templates/cuda/gemm_sm89.h
+++ b/src/tl_templates/cuda/gemm_sm89.h
@@ -324,9 +324,8 @@ public:
                                 tfloat32_t, A_type_raw>::type;
   using C_type = C_type_raw;
 
-  static constexpr bool is_tfloat32 =
-      std::is_same<A_type, tfloat32_t>::value &&
-      std::is_same<B_type, tfloat32_t>::value;
+  static constexpr bool is_tfloat32 = std::is_same<A_type, tfloat32_t>::value &&
+                                      std::is_same<B_type, tfloat32_t>::value;
 
   using Instruction =
       DispatchInstruction<A_type, B_type, C_type, num_warp_m, num_warp_n, N>;

--- a/src/tl_templates/cuda/gemm_sm89.h
+++ b/src/tl_templates/cuda/gemm_sm89.h
@@ -2,13 +2,14 @@
 // Licensed under the MIT License.
 #pragma once
 
-#include "common.h"
-#include "cuda_fp8.h"
 #include <cute/algorithm/clear.hpp>
 #include <cute/arch/mma_sm80.hpp>
 #include <cute/atom/mma_atom.hpp>
 #include <cute/atom/mma_traits.hpp>
 #include <cute/underscore.hpp>
+
+#include "common.h"
+#include "cuda_fp8.h"
 
 namespace cute {
 
@@ -304,6 +305,12 @@ struct OperandTraits<64, N, K, false, num_warp_n,
   using Copy = DefaultCopy;
 };
 
+template <typename T> CUTE_HOST_DEVICE static void cast_float_to_tf32(T &a) {
+  uint32_t x = reinterpret_cast<uint32_t const &>(a);
+  x += 0x1000u;
+  a = tfloat32_t::bitcast(x);
+};
+
 template <int M, int N, int K, int num_warp_m, int num_warp_n, bool trans_A,
           bool trans_B, bool clear_accum, typename A_type_raw,
           typename B_type_raw, typename C_type_raw>
@@ -316,6 +323,11 @@ public:
       typename std::conditional<std::is_same<B_type_raw, float>::value,
                                 tfloat32_t, A_type_raw>::type;
   using C_type = C_type_raw;
+
+  static constexpr bool is_tfloat32 =
+      std::is_same<A_type, tfloat32_t>::value &&
+      std::is_same<B_type, tfloat32_t>::value;
+
   using Instruction =
       DispatchInstruction<A_type, B_type, C_type, num_warp_m, num_warp_n, N>;
 
@@ -380,10 +392,19 @@ public:
     // workaround
     auto tCrA_view = make_tensor(tCrA.data(), remove_swizzle(tCrA.layout()));
     auto tCrB_view = make_tensor(tCrB.data(), remove_swizzle(tCrB.layout()));
+
     CUTE_UNROLL
     for (int k = 0; k < size<2>(tCrA); ++k) {
       copy(tiled_copy_A, tCsA(_, _, k), tCrA_copy_view(_, _, k));
       copy(tiled_copy_B, tCsB(_, _, k), tCrB_copy_view(_, _, k));
+
+      // Convert float32 to tfloat32 because tfloat32 mma cannot truncate
+      // float32 automatically
+      if constexpr (is_tfloat32) {
+        cute::for_each(tCrA, cast_float_to_tf32<A_type>);
+        cute::for_each(tCrB, cast_float_to_tf32<B_type>);
+      }
+
       gemm(tiled_mma, tCrA_view(_, _, k), tCrB_view(_, _, k), acc);
     }
   }
@@ -410,6 +431,10 @@ public:
         make_tensor(make_rmem_ptr(reinterpret_cast<A_type *>(pA)),
                     partition_shape_A(tiled_mma, Shape<Int<M>, Int<K>>{}));
 
+    if constexpr (is_tfloat32) {
+      cute::for_each(tCrA, cast_float_to_tf32<A_type>);
+    }
+
     if constexpr (clear_accum) {
       clear(acc);
     }
@@ -419,6 +444,11 @@ public:
     for (int k = 0; k < size<2>(tCrA); ++k) {
       if (k < size<2>(tCrA) - 1) {
         copy(tiled_copy_B, tCsB(_, _, k + 1), tCrB_copy_view(_, _, k + 1));
+      }
+      // Convert float32 to tfloat32 because tfloat32 mma cannot truncate
+      // float32 automatically
+      if constexpr (is_tfloat32) {
+        cute::for_each(tCrB, cast_float_to_tf32<B_type>);
       }
       gemm(tiled_mma, tCrA(_, _, k), tCrB_view(_, _, k), acc);
     }
@@ -445,7 +475,9 @@ public:
     Tensor tCrB =
         make_tensor(make_rmem_ptr(reinterpret_cast<B_type *>(pB)),
                     partition_shape_B(tiled_mma, Shape<Int<N>, Int<K>>{}));
-
+    if constexpr (is_tfloat32) {
+      cute::for_each(tCrB, cast_float_to_tf32<B_type>);
+    }
     if constexpr (clear_accum) {
       clear(acc);
     }
@@ -455,6 +487,11 @@ public:
     for (int k = 0; k < size<2>(tCrA); ++k) {
       if (k < size<2>(tCrA) - 1) {
         copy(tiled_copy_A, tCsA(_, _, k + 1), tCrA_copy_view(_, _, k + 1));
+      }
+      // Convert float32 to tfloat32 because tfloat32 mma cannot truncate
+      // float32 automatically
+      if constexpr (is_tfloat32) {
+        cute::for_each(tCrA, cast_float_to_tf32<A_type>);
       }
       gemm(tiled_mma, tCrA_view(_, _, k), tCrB(_, _, k), acc);
     }

--- a/src/tl_templates/cuda/gemm_sm89.h
+++ b/src/tl_templates/cuda/gemm_sm89.h
@@ -307,7 +307,9 @@ struct OperandTraits<64, N, K, false, num_warp_n,
 
 template <typename T> CUTE_HOST_DEVICE static void cast_float_to_tf32(T &a) {
   uint32_t x = reinterpret_cast<uint32_t const &>(a);
-  x += 0x1000u;
+  if (std::isfinite(a)) {
+    x += 0x1000u;
+  }
   a = tfloat32_t::bitcast(x);
 };
 
@@ -326,9 +328,7 @@ public:
 
   static constexpr bool need_tfloat32_cast =
       std::is_same<A_type_raw, float>::value &&
-      std::is_same<A_type, tfloat32_t>::value &&
-      std::is_same<B_type_raw, float>::value &&
-      std::is_same<B_type, tfloat32_t>::value;
+      std::is_same<B_type_raw, float>::value;
 
   using Instruction =
       DispatchInstruction<A_type, B_type, C_type, num_warp_m, num_warp_n, N>;

--- a/src/tl_templates/cuda/gemm_sm90.h
+++ b/src/tl_templates/cuda/gemm_sm90.h
@@ -36,9 +36,8 @@ public:
                                tfloat32_t, B_type_raw>;
   using C_type = C_type_raw;
 
-  static constexpr bool is_tfloat32 =
-      std::is_same<A_type, tfloat32_t>::value &&
-      std::is_same<B_type, tfloat32_t>::value;
+  static constexpr bool is_tfloat32 = std::is_same<A_type, tfloat32_t>::value &&
+                                      std::is_same<B_type, tfloat32_t>::value;
 
   static constexpr GMMA::Major GmmaMajorA =
       trans_A ? GMMA::Major::MN : GMMA::Major::K;
@@ -358,7 +357,6 @@ struct OperandTraits<64, N, K, false, num_warp_n,
   using Copy = DefaultCopy;
 };
 
-
 template <typename T> CUTE_HOST_DEVICE static void cast_float_to_tf32(T &a) {
   uint32_t x = reinterpret_cast<uint32_t const &>(a);
   x += 0x1000u;
@@ -378,10 +376,8 @@ public:
                                 tfloat32_t, A_type_raw>::type;
   using C_type = C_type_raw;
 
-  static constexpr bool is_tfloat32 =
-      std::is_same<A_type, tfloat32_t>::value &&
-      std::is_same<B_type, tfloat32_t>::value;
-
+  static constexpr bool is_tfloat32 = std::is_same<A_type, tfloat32_t>::value &&
+                                      std::is_same<B_type, tfloat32_t>::value;
 
   using Instruction =
       DispatchInstruction<A_type, B_type, C_type, num_warp_m, num_warp_n, N>;
@@ -493,51 +489,51 @@ public:
         copy(tiled_copy_B, tCsB(_, _, k + 1), tCrB_copy_view(_, _, k + 1));
       }
       if constexpr (is_tfloat32) {
-      gemm(tiled_mma, tCrA(_, _, k), tCrB_view(_, _, k), acc);
-    }
-  }
-
-  static CUTE_DEVICE void body_sr(A_type_raw *pA, B_type_raw *pB,
-                                  C_type_raw *pC) {
-    const int tid = threadIdx.x;
-    Tensor sA = make_tensor(make_smem_ptr(reinterpret_cast<A_type *>(pA)),
-                            SmemLayoutA{});
-    TileMma tiled_mma;
-    auto thr_mma = tiled_mma.get_thread_slice(tid);
-    auto tiled_copy_A = make_tiled_copy_A(SmemCopyA{}, tiled_mma);
-    auto thr_copy_A = tiled_copy_A.get_thread_slice(tid);
-
-    Tensor tCrA = thr_mma.partition_fragment_A(sA);
-    Tensor tCsA = thr_copy_A.partition_S(sA);
-
-    Tensor tCrA_copy_view = thr_copy_A.retile_D(tCrA);
-
-    Tensor acc =
-        make_tensor(make_rmem_ptr(reinterpret_cast<C_type *>(pC)),
-                    partition_shape_C(tiled_mma, Shape<Int<M>, Int<N>>{}));
-    Tensor tCrB =
-        make_tensor(make_rmem_ptr(reinterpret_cast<B_type *>(pB)),
-                    partition_shape_B(tiled_mma, Shape<Int<N>, Int<K>>{}));
-    if constexpr (is_tfloat32) {
-      cast_float_to_tf32(tCrB);
-    }
-    auto tCrA_view = make_tensor(tCrA.data(), remove_swizzle(tCrA.layout()));
-    if constexpr (clear_accum) {
-      tiled_mma.accumulate_ = GMMA::ScaleOut::Zero;
-    }
-    copy(tiled_copy_A, tCsA(_, _, 0), tCrA_copy_view(_, _, 0));
-    CUTE_UNROLL
-    for (int k = 0; k < size<2>(tCrA); ++k) {
-      if (k < size<2>(tCrA) - 1) {
-        copy(tiled_copy_A, tCsA(_, _, k + 1), tCrA_copy_view(_, _, k + 1));
+        gemm(tiled_mma, tCrA(_, _, k), tCrB_view(_, _, k), acc);
       }
+    }
+
+    static CUTE_DEVICE void body_sr(A_type_raw * pA, B_type_raw * pB,
+                                    C_type_raw * pC) {
+      const int tid = threadIdx.x;
+      Tensor sA = make_tensor(make_smem_ptr(reinterpret_cast<A_type *>(pA)),
+                              SmemLayoutA{});
+      TileMma tiled_mma;
+      auto thr_mma = tiled_mma.get_thread_slice(tid);
+      auto tiled_copy_A = make_tiled_copy_A(SmemCopyA{}, tiled_mma);
+      auto thr_copy_A = tiled_copy_A.get_thread_slice(tid);
+
+      Tensor tCrA = thr_mma.partition_fragment_A(sA);
+      Tensor tCsA = thr_copy_A.partition_S(sA);
+
+      Tensor tCrA_copy_view = thr_copy_A.retile_D(tCrA);
+
+      Tensor acc =
+          make_tensor(make_rmem_ptr(reinterpret_cast<C_type *>(pC)),
+                      partition_shape_C(tiled_mma, Shape<Int<M>, Int<N>>{}));
+      Tensor tCrB =
+          make_tensor(make_rmem_ptr(reinterpret_cast<B_type *>(pB)),
+                      partition_shape_B(tiled_mma, Shape<Int<N>, Int<K>>{}));
       if constexpr (is_tfloat32) {
-        cast_float_to_tf32(tCrA_view(_, _, k));
+        cast_float_to_tf32(tCrB);
       }
-      gemm(tiled_mma, tCrA_view(_, _, k), tCrB(_, _, k), acc);
+      auto tCrA_view = make_tensor(tCrA.data(), remove_swizzle(tCrA.layout()));
+      if constexpr (clear_accum) {
+        tiled_mma.accumulate_ = GMMA::ScaleOut::Zero;
+      }
+      copy(tiled_copy_A, tCsA(_, _, 0), tCrA_copy_view(_, _, 0));
+      CUTE_UNROLL
+      for (int k = 0; k < size<2>(tCrA); ++k) {
+        if (k < size<2>(tCrA) - 1) {
+          copy(tiled_copy_A, tCsA(_, _, k + 1), tCrA_copy_view(_, _, k + 1));
+        }
+        if constexpr (is_tfloat32) {
+          cast_float_to_tf32(tCrA_view(_, _, k));
+        }
+        gemm(tiled_mma, tCrA_view(_, _, k), tCrB(_, _, k), acc);
+      }
     }
-  }
-};
+  };
 
 } // namespace tl_mma
 

--- a/src/tl_templates/cuda/gemm_sm90.h
+++ b/src/tl_templates/cuda/gemm_sm90.h
@@ -19,6 +19,12 @@ namespace tl_wgmma {
 
 using namespace cutlass::gemm::collective::detail; // ss_smem_selector
 
+template <typename T> CUTE_HOST_DEVICE static void cast_float_to_tf32(T &a) {
+  uint32_t x = reinterpret_cast<uint32_t const &>(a);
+  x += 0x1000u;
+  a = tfloat32_t::bitcast(x);
+};
+
 template <int M, int N, int K, int num_warp_m, int num_warp_n, bool trans_A,
           bool trans_B, bool clear_accum, typename A_type_raw,
           typename B_type_raw, typename C_type_raw>
@@ -29,6 +35,10 @@ public:
   using B_type = conditional_t<std::is_same<B_type_raw, float>::value,
                                tfloat32_t, B_type_raw>;
   using C_type = C_type_raw;
+
+  static constexpr bool is_tfloat32 =
+      std::is_same<A_type, tfloat32_t>::value &&
+      std::is_same<B_type, tfloat32_t>::value;
 
   static constexpr GMMA::Major GmmaMajorA =
       trans_A ? GMMA::Major::MN : GMMA::Major::K;
@@ -81,6 +91,10 @@ public:
     if constexpr (clear_accum) {
       tiled_mma.accumulate_ = GMMA::ScaleOut::Zero;
     }
+    if constexpr (is_tfloat32) {
+      cast_float_to_tf32(tCrA);
+      cast_float_to_tf32(tCrB);
+    }
     CUTLASS_PRAGMA_UNROLL
     for (int k_block = 0; k_block < size<2>(tCrA); ++k_block) {
       // warpgroup_arrive();
@@ -122,7 +136,10 @@ public:
     Tensor acc =
         make_tensor(make_rmem_ptr(reinterpret_cast<C_type *>(pC)),
                     partition_shape_C(tiled_mma, Shape<Int<M>, Int<N>>{}));
-
+    if constexpr (is_tfloat32) {
+      cast_float_to_tf32(tCrA);
+      cast_float_to_tf32(tCrB);
+    }
     warpgroup_fence_operand(tCrA);
     warpgroup_fence_operand(acc);
     warpgroup_arrive();
@@ -142,16 +159,6 @@ public:
     }
     warpgroup_fence_operand(acc);
     warpgroup_fence_operand(tCrA);
-
-    // warpgroup_fence_operand(acc);
-    // warpgroup_arrive();
-
-    // gemm(tiled_mma, tCrA(_, _, _), tCrB(_, _, _), acc);
-
-    // warpgroup_commit_batch();
-
-    // if constexpr (wg_wait >= 0) { warpgroup_wait<wg_wait>(); }
-    // warpgroup_fence_operand(acc);
   }
 };
 
@@ -351,6 +358,13 @@ struct OperandTraits<64, N, K, false, num_warp_n,
   using Copy = DefaultCopy;
 };
 
+
+template <typename T> CUTE_HOST_DEVICE static void cast_float_to_tf32(T &a) {
+  uint32_t x = reinterpret_cast<uint32_t const &>(a);
+  x += 0x1000u;
+  a = tfloat32_t::bitcast(x);
+};
+
 template <int M, int N, int K, int num_warp_m, int num_warp_n, bool trans_A,
           bool trans_B, bool clear_accum, typename A_type_raw,
           typename B_type_raw, typename C_type_raw>
@@ -363,6 +377,12 @@ public:
       typename std::conditional<std::is_same<B_type_raw, float>::value,
                                 tfloat32_t, A_type_raw>::type;
   using C_type = C_type_raw;
+
+  static constexpr bool is_tfloat32 =
+      std::is_same<A_type, tfloat32_t>::value &&
+      std::is_same<B_type, tfloat32_t>::value;
+
+
   using Instruction =
       DispatchInstruction<A_type, B_type, C_type, num_warp_m, num_warp_n, N>;
 
@@ -430,6 +450,10 @@ public:
     for (int k = 0; k < size<2>(tCrA); ++k) {
       copy(tiled_copy_A, tCsA(_, _, k), tCrA_copy_view(_, _, k));
       copy(tiled_copy_B, tCsB(_, _, k), tCrB_copy_view(_, _, k));
+      if constexpr (is_tfloat32) {
+        cast_float_to_tf32(tCrA_view(_, _, k));
+        cast_float_to_tf32(tCrB_view(_, _, k));
+      }
       gemm(tiled_mma, tCrA_view(_, _, k), tCrB_view(_, _, k), acc);
     }
   }
@@ -455,7 +479,9 @@ public:
     Tensor tCrA =
         make_tensor(make_rmem_ptr(reinterpret_cast<A_type *>(pA)),
                     partition_shape_A(tiled_mma, Shape<Int<M>, Int<K>>{}));
-
+    if constexpr (is_tfloat32) {
+      cast_float_to_tf32(tCrA);
+    }
     auto tCrB_view = make_tensor(tCrB.data(), remove_swizzle(tCrB.layout()));
     if constexpr (clear_accum) {
       tiled_mma.accumulate_ = GMMA::ScaleOut::Zero;
@@ -466,6 +492,7 @@ public:
       if (k < size<2>(tCrA) - 1) {
         copy(tiled_copy_B, tCsB(_, _, k + 1), tCrB_copy_view(_, _, k + 1));
       }
+      if constexpr (is_tfloat32) {
       gemm(tiled_mma, tCrA(_, _, k), tCrB_view(_, _, k), acc);
     }
   }
@@ -491,7 +518,9 @@ public:
     Tensor tCrB =
         make_tensor(make_rmem_ptr(reinterpret_cast<B_type *>(pB)),
                     partition_shape_B(tiled_mma, Shape<Int<N>, Int<K>>{}));
-
+    if constexpr (is_tfloat32) {
+      cast_float_to_tf32(tCrB);
+    }
     auto tCrA_view = make_tensor(tCrA.data(), remove_swizzle(tCrA.layout()));
     if constexpr (clear_accum) {
       tiled_mma.accumulate_ = GMMA::ScaleOut::Zero;
@@ -501,6 +530,9 @@ public:
     for (int k = 0; k < size<2>(tCrA); ++k) {
       if (k < size<2>(tCrA) - 1) {
         copy(tiled_copy_A, tCsA(_, _, k + 1), tCrA_copy_view(_, _, k + 1));
+      }
+      if constexpr (is_tfloat32) {
+        cast_float_to_tf32(tCrA_view(_, _, k));
       }
       gemm(tiled_mma, tCrA_view(_, _, k), tCrB(_, _, k), acc);
     }

--- a/src/tl_templates/cuda/gemm_sm90.h
+++ b/src/tl_templates/cuda/gemm_sm90.h
@@ -17,7 +17,9 @@ using namespace SM90;
 
 template <typename T> CUTE_HOST_DEVICE static void cast_float_to_tf32(T &a) {
   uint32_t x = reinterpret_cast<uint32_t const &>(a);
-  x += 0x1000u;
+  if (std::isfinite(a)) {
+    x += 0x1000u;
+  }
   a = tfloat32_t::bitcast(x);
 };
 
@@ -38,9 +40,9 @@ public:
 
   static constexpr bool need_tfloat32_cast =
       std::is_same<A_type_raw, float>::value &&
-      std::is_same<A_type, tfloat32_t>::value &&
-      std::is_same<B_type_raw, float>::value &&
-      std::is_same<B_type, tfloat32_t>::value;
+      // A_type will be tfloat32_t if A_type_raw is float
+      std::is_same<B_type_raw, float>::value;
+  // B_type will be tfloat32_t if B_type_raw is float
 
   static constexpr GMMA::Major GmmaMajorA =
       trans_A ? GMMA::Major::MN : GMMA::Major::K;

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -494,9 +494,12 @@ private:
       buffer_data_to_buffer_.Set(buffer->data, buffer);
     }
     if (op->annotations.count(attr::kLayoutMap)) {
-      auto map =
-          op->annotations.Get(attr::kLayoutMap).as<Map<Var, Layout>>().value();
-      for (const auto &[var, layout] : map) {
+      // Check if the layout map is Map<Var, Layout>
+      auto map = op->annotations.Get(attr::kLayoutMap).as<Map<Var, Layout>>();
+      ICHECK(map.defined()) << "layout map is not defined";
+      ICHECK(map.value().defined()) << "layout map is not defined";
+
+      for (const auto &[var, layout] : map.value()) {
         ICHECK(buffer_data_to_buffer_.count(var))
             << "buffer " << var << " is not found in the block";
         auto buffer = buffer_data_to_buffer_[var];

--- a/tilelang/language/__init__.py
+++ b/tilelang/language/__init__.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 """The language interface for tl programs."""
 
-from typing import Optional
+from typing import Optional, Callable, Dict
 # from .parser import *
 # now is fully compatible with the upstream
 # tir script
@@ -111,8 +111,16 @@ def annotate_layout(layout_map: Dict):
         return main
     """
     # layout_map is a dictionary of buffer to layout
-    layout_map = {buffer.data: layout for buffer, layout in layout_map.items()}
-    return block_attr({"layout_map": layout_map})
+    _layout_map = {}
+    for buffer, layout in layout_map.items():
+        if isinstance(layout, Layout):
+            _layout_map[buffer.data] = layout
+        elif isinstance(layout, Callable):
+            _layout_map[buffer.data] = Layout(buffer.shape, layout)
+        else:
+            raise ValueError(f"Invalid layout: {layout}")
+
+    return block_attr({"layout_map": _layout_map})
 
 
 def annotate_padding(padding_map: Dict):


### PR DESCRIPTION
- Introduced a `cast_float_to_tf32` function to convert float32 values to tfloat32 format across gemm_sm80, gemm_sm89, and gemm_sm90 templates.
- Implemented conditional casting in relevant sections of the GEMM operations to ensure compatibility with tfloat32 types.
- Enhanced the handling of tensor views to support the new casting logic, improving performance and accuracy in matrix operations.