### PR TITLE
[Refactor] Improve dtype handling in KernelParam class

### DIFF
--- a/tilelang/engine/param.py
+++ b/tilelang/engine/param.py
@@ -99,7 +99,9 @@ class KernelParam:
             bool: True if parameter is a boolean type, False otherwise
         """
         dtype_str = str(self.dtype)
-        return dtype_str[6:] if dtype_str.startswith("torch.") else dtype_str.startswith("bool")
+        if dtype_str.startswith("torch."):
+            dtype_str = dtype_str[6:]
+        return dtype_str.startswith("bool")
 
 
 @dataclass


### PR DESCRIPTION
- Updated the dtype handling logic in the KernelParam class to enhance clarity and maintainability. The dtype string is now modified only if it starts with "torch.", simplifying the return statement for boolean type checks.