### PR TITLE
[Feature] Implement Swizzle 32B

### DIFF
--- a/src/layout/gemm_layouts.cc
+++ b/src/layout/gemm_layouts.cc
@@ -318,6 +318,26 @@ PrimExpr xor8x8(const PrimExpr &i, const PrimExpr j) {
   return 2 * xor4x4(i1, j1) + xor2x2(i0, j0);
 }
 
+// Layout swizzling for 32 bytes
+Layout makeQuarterBankSwizzleLayout(int stride, int continuous, int element_size) {
+  // Swizzle 1 bit
+  Var i = InputPlaceholder(0);
+  Var j = InputPlaceholder(1);
+  int vector_size = 128 / element_size;
+  ICHECK(stride % 8 == 0) << "stride=" << stride;
+  ICHECK(continuous % (vector_size * 2) == 0)
+      << "continuous=" << continuous << ", vector_size=" << vector_size;
+  PrimExpr ts = FloorDiv(i, 8);
+  PrimExpr s = FloorMod(i, 8);
+  PrimExpr tc = FloorDiv(FloorDiv(j, vector_size), 2);
+  PrimExpr c = FloorMod(FloorDiv(j, vector_size), 2);
+  PrimExpr vec = FloorMod(j, vector_size);
+  PrimExpr c_swizzle = xor2x2(c, FloorDiv(s, 4));
+  PrimExpr index = vec + (c_swizzle + s * 2) * vector_size;
+  return Layout(Array<PrimExpr>{stride, continuous}, {tc, ts, index});
+}
+
+// Layout swizzling for 64 bytes
 Layout makeHalfBankSwizzleLayout(int stride, int continuous, int element_size) {
   // Swizzle 2 bit
   Var i = InputPlaceholder(0);
@@ -336,6 +356,7 @@ Layout makeHalfBankSwizzleLayout(int stride, int continuous, int element_size) {
   return Layout(Array<PrimExpr>{stride, continuous}, {tc, ts, index});
 }
 
+// Layout swizzling for 128 bytes
 Layout makeFullBankSwizzleLayout(int stride, int continuous, int element_size) {
   // Swizzle 3 bit
   Var i = InputPlaceholder(0);
@@ -535,7 +556,7 @@ Layout makeGemmVoltaABLayout(int stride, int continuous, bool is_a,
  * \return A Layout object representing the chosen memory layout.
  */
 Layout makeGemmABLayout(int mat_stride, int mat_continuous, int continuity,
-                        int element_size, int kfactor) {
+                        int element_size, int kfactor, bool enable_padding) {
   if (element_size == 64) {
     if (kfactor == 1 && continuity % 16 == 0) // float64 KxN
       return makeGemmABLayoutF64_Kouter(mat_stride, mat_continuous);
@@ -545,13 +566,19 @@ Layout makeGemmABLayout(int mat_stride, int mat_continuous, int continuity,
   }
   int vector_size = 128 / element_size;
   if (kfactor == 1 && element_size == 8) // int8 KxN
-    return makeGemmABLayoutPadded(mat_stride, mat_continuous, element_size);
+    if (enable_padding)
+      return makeGemmABLayoutPadded(mat_stride, mat_continuous, element_size);
+    else
+      return makeQuarterBankSwizzleLayout(mat_stride, mat_continuous, element_size);
   else if (mat_continuous % (vector_size * 8) == 0)
     return makeFullBankSwizzleLayout(mat_stride, mat_continuous, element_size);
   else if (mat_continuous % (vector_size * 4) == 0)
     return makeHalfBankSwizzleLayout(mat_stride, mat_continuous, element_size);
   else {
-    return makeGemmABLayoutPadded(mat_stride, mat_continuous, element_size);
+    if (enable_padding)
+      return makeGemmABLayoutPadded(mat_stride, mat_continuous, element_size);
+    else
+      return makeQuarterBankSwizzleLayout(mat_stride, mat_continuous, element_size);
   }
 }
 

--- a/src/layout/gemm_layouts.cc
+++ b/src/layout/gemm_layouts.cc
@@ -557,7 +557,7 @@ Layout makeGemmVoltaABLayout(int stride, int continuous, bool is_a,
  * \return A Layout object representing the chosen memory layout.
  */
 Layout makeGemmABLayout(int mat_stride, int mat_continuous, int continuity,
-                        int element_size, int kfactor, bool enable_padding) {
+                        int element_size, int kfactor) {
   if (element_size == 64) {
     if (kfactor == 1 && continuity % 16 == 0) // float64 KxN
       return makeGemmABLayoutF64_Kouter(mat_stride, mat_continuous);
@@ -567,22 +567,37 @@ Layout makeGemmABLayout(int mat_stride, int mat_continuous, int continuity,
   }
   int vector_size = 128 / element_size;
   if (kfactor == 1 && element_size == 8) // int8 KxN
-    if (enable_padding)
-      return makeGemmABLayoutPadded(mat_stride, mat_continuous, element_size);
-    else
-      return makeQuarterBankSwizzleLayout(mat_stride, mat_continuous,
-                                          element_size);
+    return makeGemmABLayoutPadded(mat_stride, mat_continuous, element_size);
   else if (mat_continuous % (vector_size * 8) == 0)
     return makeFullBankSwizzleLayout(mat_stride, mat_continuous, element_size);
   else if (mat_continuous % (vector_size * 4) == 0)
     return makeHalfBankSwizzleLayout(mat_stride, mat_continuous, element_size);
   else {
-    if (enable_padding)
-      return makeGemmABLayoutPadded(mat_stride, mat_continuous, element_size);
-    else
-      return makeQuarterBankSwizzleLayout(mat_stride, mat_continuous,
-                                          element_size);
+    return makeGemmABLayoutPadded(mat_stride, mat_continuous, element_size);
   }
+}
+
+Layout makeGemmABLayoutHopper(int mat_stride, int mat_continuous,
+                              int continuity, int element_size, int kfactor) {
+  if (element_size == 64) {
+    if (kfactor == 1 && continuity % 16 == 0) // float64 KxN
+      return makeGemmABLayoutF64_Kouter(mat_stride, mat_continuous);
+    if (kfactor == 2 && continuity % 16 == 0) // float64 NxK
+      return makeGemmABLayoutF64_Kinner(mat_stride, mat_continuous);
+    return makeQuarterBankSwizzleLayout(mat_stride, mat_continuous,
+                                        element_size);
+  }
+  int vector_size = 128 / element_size;
+  if (kfactor == 1 && element_size == 8) // int8 KxN
+    return makeQuarterBankSwizzleLayout(mat_stride, mat_continuous,
+                                        element_size);
+  else if (mat_continuous % (vector_size * 8) == 0)
+    return makeFullBankSwizzleLayout(mat_stride, mat_continuous, element_size);
+  else if (mat_continuous % (vector_size * 4) == 0)
+    return makeHalfBankSwizzleLayout(mat_stride, mat_continuous, element_size);
+  else
+    return makeQuarterBankSwizzleLayout(mat_stride, mat_continuous,
+                                        element_size);
 }
 
 Layout makeGemmABLayoutCDNA(int stride, int continuous, int element_size,

--- a/src/layout/gemm_layouts.cc
+++ b/src/layout/gemm_layouts.cc
@@ -319,7 +319,8 @@ PrimExpr xor8x8(const PrimExpr &i, const PrimExpr j) {
 }
 
 // Layout swizzling for 32 bytes
-Layout makeQuarterBankSwizzleLayout(int stride, int continuous, int element_size) {
+Layout makeQuarterBankSwizzleLayout(int stride, int continuous,
+                                    int element_size) {
   // Swizzle 1 bit
   Var i = InputPlaceholder(0);
   Var j = InputPlaceholder(1);
@@ -569,7 +570,8 @@ Layout makeGemmABLayout(int mat_stride, int mat_continuous, int continuity,
     if (enable_padding)
       return makeGemmABLayoutPadded(mat_stride, mat_continuous, element_size);
     else
-      return makeQuarterBankSwizzleLayout(mat_stride, mat_continuous, element_size);
+      return makeQuarterBankSwizzleLayout(mat_stride, mat_continuous,
+                                          element_size);
   else if (mat_continuous % (vector_size * 8) == 0)
     return makeFullBankSwizzleLayout(mat_stride, mat_continuous, element_size);
   else if (mat_continuous % (vector_size * 4) == 0)
@@ -578,7 +580,8 @@ Layout makeGemmABLayout(int mat_stride, int mat_continuous, int continuity,
     if (enable_padding)
       return makeGemmABLayoutPadded(mat_stride, mat_continuous, element_size);
     else
-      return makeQuarterBankSwizzleLayout(mat_stride, mat_continuous, element_size);
+      return makeQuarterBankSwizzleLayout(mat_stride, mat_continuous,
+                                          element_size);
   }
 }
 

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -163,7 +163,8 @@ Fragment makeGemmFragmentACDNA(const int block_m, const int block_n,
 Layout makeGemmLayoutLinear(int stride, int continuous);
 Layout makeGemmABLayoutPadded(int stride, int continuous, int element_size);
 Layout makeGemmABLayout(int mat_stride, int mat_continuous, int continuity,
-                        int element_size, int kfactor, bool enable_padding = true);
+                        int element_size, int kfactor,
+                        bool enable_padding = true);
 Layout makeGemmABLayoutCDNA(int stride, int continuous, int element_size,
                             int kfactor);
 
@@ -178,7 +179,8 @@ Layout makeGemmVoltaABLayout(int stride, int continuous, bool is_a,
 
 Layout makeFullBankSwizzleLayout(int stride, int continuous, int element_size);
 Layout makeHalfBankSwizzleLayout(int stride, int continuous, int element_size);
-Layout makeQuarterBankSwizzleLayout(int stride, int continuous, int element_size);
+Layout makeQuarterBankSwizzleLayout(int stride, int continuous,
+                                    int element_size);
 
 namespace attr {
 // BlockAttr, Containing the layout for all the buffers in the block

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -163,7 +163,7 @@ Fragment makeGemmFragmentACDNA(const int block_m, const int block_n,
 Layout makeGemmLayoutLinear(int stride, int continuous);
 Layout makeGemmABLayoutPadded(int stride, int continuous, int element_size);
 Layout makeGemmABLayout(int mat_stride, int mat_continuous, int continuity,
-                        int element_size, int kfactor);
+                        int element_size, int kfactor, bool enable_padding = true);
 Layout makeGemmABLayoutCDNA(int stride, int continuous, int element_size,
                             int kfactor);
 
@@ -178,6 +178,7 @@ Layout makeGemmVoltaABLayout(int stride, int continuous, bool is_a,
 
 Layout makeFullBankSwizzleLayout(int stride, int continuous, int element_size);
 Layout makeHalfBankSwizzleLayout(int stride, int continuous, int element_size);
+Layout makeQuarterBankSwizzleLayout(int stride, int continuous, int element_size);
 
 namespace attr {
 // BlockAttr, Containing the layout for all the buffers in the block

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -163,8 +163,9 @@ Fragment makeGemmFragmentACDNA(const int block_m, const int block_n,
 Layout makeGemmLayoutLinear(int stride, int continuous);
 Layout makeGemmABLayoutPadded(int stride, int continuous, int element_size);
 Layout makeGemmABLayout(int mat_stride, int mat_continuous, int continuity,
-                        int element_size, int kfactor,
-                        bool enable_padding = true);
+                        int element_size, int kfactor);
+Layout makeGemmABLayoutHopper(int mat_stride, int mat_continuous,
+                              int continuity, int element_size, int kfactor);
 Layout makeGemmABLayoutCDNA(int stride, int continuous, int element_size,
                             int kfactor);
 

--- a/src/op/bulk_copy.cc
+++ b/src/op/bulk_copy.cc
@@ -202,7 +202,7 @@ Stmt Copy::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer) const {
     } else if (StructuralEqual()(
                    shared_layout,
                    makeQuarterBankSwizzleLayout(*stride, *continuous,
-                                             shared_tensor->dtype.bits()))) {
+                                                shared_tensor->dtype.bits()))) {
       desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B);
     } else if (StructuralEqual()(
                    shared_layout,
@@ -367,11 +367,11 @@ Stmt Conv2DIm2ColOp::Lower(const LowerArgs &T,
     LOG(INFO) << "shared_layout: " << shared_layout->DebugOutput();
     if (StructuralEqual()(shared_layout,
                           makeQuarterBankSwizzleLayout(*stride, *continuous,
-                                                    dst->dtype.bits()))) {
+                                                       dst->dtype.bits()))) {
       LOG(INFO) << "Use quarter bank swizzle layout";
       desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B);
-    } else if (StructuralEqual()(shared_layout,
-                          makeHalfBankSwizzleLayout(*stride, *continuous,
+    } else if (StructuralEqual()(shared_layout, makeHalfBankSwizzleLayout(
+                                                    *stride, *continuous,
                                                     dst->dtype.bits()))) {
       desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B);
     } else if (StructuralEqual()(shared_layout, makeFullBankSwizzleLayout(

--- a/src/op/bulk_copy.cc
+++ b/src/op/bulk_copy.cc
@@ -201,6 +201,11 @@ Stmt Copy::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer) const {
       desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_NONE);
     } else if (StructuralEqual()(
                    shared_layout,
+                   makeQuarterBankSwizzleLayout(*stride, *continuous,
+                                             shared_tensor->dtype.bits()))) {
+      desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B);
+    } else if (StructuralEqual()(
+                   shared_layout,
                    makeHalfBankSwizzleLayout(*stride, *continuous,
                                              shared_tensor->dtype.bits()))) {
       desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B);
@@ -359,7 +364,13 @@ Stmt Conv2DIm2ColOp::Lower(const LowerArgs &T,
     auto stride = as_const_int(shared_layout->InputShape()[0]);
     auto continuous = as_const_int(shared_layout->InputShape()[1]);
     ICHECK(stride != nullptr && continuous != nullptr);
+    LOG(INFO) << "shared_layout: " << shared_layout->DebugOutput();
     if (StructuralEqual()(shared_layout,
+                          makeQuarterBankSwizzleLayout(*stride, *continuous,
+                                                    dst->dtype.bits()))) {
+      LOG(INFO) << "Use quarter bank swizzle layout";
+      desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B);
+    } else if (StructuralEqual()(shared_layout,
                           makeHalfBankSwizzleLayout(*stride, *continuous,
                                                     dst->dtype.bits()))) {
       desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B);

--- a/src/op/bulk_copy.cc
+++ b/src/op/bulk_copy.cc
@@ -364,11 +364,9 @@ Stmt Conv2DIm2ColOp::Lower(const LowerArgs &T,
     auto stride = as_const_int(shared_layout->InputShape()[0]);
     auto continuous = as_const_int(shared_layout->InputShape()[1]);
     ICHECK(stride != nullptr && continuous != nullptr);
-    LOG(INFO) << "shared_layout: " << shared_layout->DebugOutput();
     if (StructuralEqual()(shared_layout,
                           makeQuarterBankSwizzleLayout(*stride, *continuous,
                                                        dst->dtype.bits()))) {
-      LOG(INFO) << "Use quarter bank swizzle layout";
       desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B);
     } else if (StructuralEqual()(shared_layout, makeHalfBankSwizzleLayout(
                                                     *stride, *continuous,

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -352,7 +352,7 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
           trans_A ? 4 * mat_continuous / warp_m : mat_continuous;
       results.Set(A,
                   makeGemmABLayout(mat_stride, mat_continuous, mat_continuous,
-                                   A->dtype.bits(), trans_A ? 1 : 2));
+                                   A->dtype.bits(), trans_A ? 1 : 2, false));
     } else {
       auto fragment = makeGemmFragmentA(M, N, K, M / warp_m, N / warp_n,
                                         A->dtype.bits(), trans_A);
@@ -365,7 +365,7 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
       const int64_t continuity =
           trans_B ? mat_continuous : mat_continuous / warp_n;
       results.Set(B, makeGemmABLayout(mat_stride, mat_continuous, continuity,
-                                      B->dtype.bits(), trans_B ? 2 : 1));
+                                      B->dtype.bits(), trans_B ? 2 : 1, false));
     } else {
       ICHECK(0) << "WGMMA only support B in shared.";
     }

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -350,9 +350,9 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
       const int64_t mat_continuous = *as_const_int(A->shape[dim_A - 1]);
       const int64_t continuity =
           trans_A ? 4 * mat_continuous / warp_m : mat_continuous;
-      results.Set(A,
-                  makeGemmABLayout(mat_stride, mat_continuous, mat_continuous,
-                                   A->dtype.bits(), trans_A ? 1 : 2, false));
+      results.Set(A, makeGemmABLayoutHopper(mat_stride, mat_continuous,
+                                            mat_continuous, A->dtype.bits(),
+                                            trans_A ? 1 : 2));
     } else {
       auto fragment = makeGemmFragmentA(M, N, K, M / warp_m, N / warp_n,
                                         A->dtype.bits(), trans_A);
@@ -364,8 +364,9 @@ LayoutMap Gemm::InferLayout(const LayoutInferArgs &T, InferLevel level) {
       const int64_t mat_continuous = *as_const_int(B->shape[dim_B - 1]);
       const int64_t continuity =
           trans_B ? mat_continuous : mat_continuous / warp_n;
-      results.Set(B, makeGemmABLayout(mat_stride, mat_continuous, continuity,
-                                      B->dtype.bits(), trans_B ? 2 : 1, false));
+      results.Set(B,
+                  makeGemmABLayoutHopper(mat_stride, mat_continuous, continuity,
+                                         B->dtype.bits(), trans_B ? 2 : 1));
     } else {
       ICHECK(0) << "WGMMA only support B in shared.";
     }

--- a/tilelang/autotuner/__init__.py
+++ b/tilelang/autotuner/__init__.py
@@ -426,8 +426,6 @@ class AutoTuner:
                 logger.debug(f"Error: {e}")
                 continue
 
-            logging.debug(f"Config {config} latency: {latency} at index {i}")
-
             if latency < best_latency:
                 best_latency = latency
                 best_config = config

--- a/tilelang/autotuner/__init__.py
+++ b/tilelang/autotuner/__init__.py
@@ -37,7 +37,7 @@ class TimeoutException(Exception):
 
 
 def timeout_handler(signum, frame):
-    raise TimeoutException()
+    raise TimeoutException("Operation timed out")
 
 
 def run_with_timeout(func, timeout, *args, **kwargs):
@@ -45,6 +45,8 @@ def run_with_timeout(func, timeout, *args, **kwargs):
     signal.alarm(timeout)
     try:
         result = func(*args, **kwargs)
+    except Exception as e:
+        raise e
     finally:
         signal.alarm(0)
     return result
@@ -103,7 +105,7 @@ class AutoTuner:
     _kernel_parameters: Optional[Tuple[str, ...]] = None
     _lock = threading.Lock()  # For thread safety
     _memory_cache = {}  # In-memory cache dictionary
-    cache_dir: Path = Path(TILELANG_CACHE_DIR) / "autotuner"
+    cache_dir: Path = Path(TILELANG_CACHE_DIR)
 
     def __init__(self, fn: Callable, configs):
         self.fn = fn
@@ -352,7 +354,6 @@ class AutoTuner:
                         max_mismatched_ratio=max_mismatched_ratio)
             latency = profiler.do_bench(
                 warmup=warmup, rep=rep, input_tensors=self.jit_input_tensors)
-
             if self.ref_latency_cache is None and ref_prog is not None:
                 self.ref_input_tensors = ref_input_tensors_supply()
                 self.ref_latency_cache = profiler.do_bench(
@@ -424,6 +425,8 @@ class AutoTuner:
                 )
                 logger.debug(f"Error: {e}")
                 continue
+
+            logging.debug(f"Config {config} latency: {latency} at index {i}")
 
             if latency < best_latency:
                 best_latency = latency


### PR DESCRIPTION
- Introduced a new `makeQuarterBankSwizzleLayout` function for layout swizzling of 32 bytes.
- Updated `makeGemmABLayout` to include an `enable_padding` parameter, allowing for conditional layout selection between padded and quarter bank swizzle layouts.
- Adjusted layout inference in GEMM operations to utilize the new quarter bank swizzle layout when appropriate.
- Enhanced bulk copy operations to recognize and handle the new layout type, improving memory access patterns.

TODO Items:

- [x] Check if we can have better performance on 4090 if we replace padding with swizzl 32b.
- [x] If so, phase out padding layout.