### PR TITLE
[CI] Modify test requirements and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,7 @@ jobs:
       run: |
         source tilelang_ci/bin/activate
         python -m pip install --upgrade pip
-        if [ -f requirements-test.txt ]; then python -m pip install -r requirements-test.txt; fi
-        python -m pip install --no-build-isolation flash-attn
+        if [ -f requirements-test.txt ]; then PIP_NO_BUILD_ISOLATION=1 python -m pip install -r requirements-test.txt; fi
 
     - name: Install project in wheel mode
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
         source tilelang_ci/bin/activate
         python -m pip install --upgrade pip
         if [ -f requirements-test.txt ]; then python -m pip install -r requirements-test.txt; fi
+        python -m pip install --no-build-isolation flash-attn
 
     - name: Install project in wheel mode
       run: |

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -27,7 +27,5 @@ setuptools
 einops
 attrs
 decorator
-packaging
-wheel
 scipy
 tornado

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -27,5 +27,6 @@ setuptools
 einops
 attrs
 decorator
+flash-attn
 scipy
 tornado

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -27,6 +27,7 @@ setuptools
 einops
 attrs
 decorator
-flash-attn
+packaging
+wheel
 scipy
 tornado


### PR DESCRIPTION
- Replaced `flash-attn` with `packaging` and `wheel` in `requirements-test.txt` to ensure proper package management.
- Updated the CI workflow to install `flash-attn` without build isolation, improving the installation process.