### PR TITLE
[BugFix] Fix import error in nsa examples when `fla.__version__ >=0.2.1`

### DIFF
--- a/examples/deepseek_nsa/example_tilelang_nsa_bwd.py
+++ b/examples/deepseek_nsa/example_tilelang_nsa_bwd.py
@@ -7,7 +7,11 @@ from typing import Optional, Union
 import torch
 import triton
 
-from fla.ops.common.utils import prepare_token_indices
+import fla
+if fla.__version__ < "0.2.1":
+    from fla.ops.common.utils import prepare_token_indices
+else:
+    from fla.ops.utils import prepare_token_indices
 from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
 from reference import naive_nsa
 from einops import rearrange

--- a/examples/deepseek_nsa/example_tilelang_nsa_bwd.py
+++ b/examples/deepseek_nsa/example_tilelang_nsa_bwd.py
@@ -3,12 +3,13 @@
 # ruff: noqa
 import torch
 from typing import Optional, Union
+from packaging.version import parse
 
 import torch
 import triton
 
 import fla
-if fla.__version__ < "0.2.1":
+if parse(fla.__version__) < parse("0.2.1"):
     from fla.ops.common.utils import prepare_token_indices
 else:
     from fla.ops.utils import prepare_token_indices

--- a/examples/deepseek_nsa/example_tilelang_nsa_fwd_varlen.py
+++ b/examples/deepseek_nsa/example_tilelang_nsa_fwd_varlen.py
@@ -3,12 +3,14 @@
 # ruff: noqa
 import torch
 from typing import Optional, Union
+from packaging.version import parse
+
 import tilelang
 from tilelang import language as T
 import tilelang.testing
 
 import fla
-if fla.__version__ < "0.2.1":
+if parse(fla.__version__) < parse("0.2.1"):
     from fla.ops.common.utils import prepare_token_indices
 else:
     from fla.ops.utils import prepare_token_indices

--- a/examples/deepseek_nsa/example_tilelang_nsa_fwd_varlen.py
+++ b/examples/deepseek_nsa/example_tilelang_nsa_fwd_varlen.py
@@ -7,7 +7,11 @@ import tilelang
 from tilelang import language as T
 import tilelang.testing
 
-from fla.ops.common.utils import prepare_token_indices
+import fla
+if fla.__version__ < "0.2.1":
+    from fla.ops.common.utils import prepare_token_indices
+else:
+    from fla.ops.utils import prepare_token_indices
 from reference import naive_nsa
 from einops import rearrange
 

--- a/examples/deepseek_nsa/example_triton_nsa_bwd.py
+++ b/examples/deepseek_nsa/example_triton_nsa_bwd.py
@@ -3,13 +3,14 @@
 # ruff: noqa
 import torch
 from typing import Optional, Union
+from packaging.version import parse
 
 import torch
 import triton
 import triton.language as tl
 
 import fla
-if fla.__version__ < "0.2.1":
+if parse(fla.__version__) < parse("0.2.1"):
     from fla.ops.common.utils import prepare_token_indices
 else:
     from fla.ops.utils import prepare_token_indices

--- a/examples/deepseek_nsa/example_triton_nsa_bwd.py
+++ b/examples/deepseek_nsa/example_triton_nsa_bwd.py
@@ -8,7 +8,11 @@ import torch
 import triton
 import triton.language as tl
 
-from fla.ops.common.utils import prepare_token_indices
+import fla
+if fla.__version__ < "0.2.1":
+    from fla.ops.common.utils import prepare_token_indices
+else:
+    from fla.ops.utils import prepare_token_indices
 from fla.utils import autocast_custom_bwd, autocast_custom_fwd, contiguous
 from reference import naive_nsa
 from einops import rearrange

--- a/examples/deepseek_nsa/example_triton_nsa_fwd.py
+++ b/examples/deepseek_nsa/example_triton_nsa_fwd.py
@@ -3,13 +3,14 @@
 # ruff: noqa
 import torch
 from typing import Optional, Union
+from packaging.version import parse
 
 import torch
 import triton
 import triton.language as tl
 
 import fla
-if fla.__version__ < "0.2.1":
+if parse(fla.__version__) < parse("0.2.1"):
     from fla.ops.common.utils import prepare_token_indices
 else:
     from fla.ops.utils import prepare_token_indices

--- a/examples/deepseek_nsa/example_triton_nsa_fwd.py
+++ b/examples/deepseek_nsa/example_triton_nsa_fwd.py
@@ -8,7 +8,10 @@ import torch
 import triton
 import triton.language as tl
 
-from fla.ops.common.utils import prepare_token_indices
+if fla.__version__ < "0.2.1":
+    from fla.ops.common.utils import prepare_token_indices
+else:
+    from fla.ops.utils import prepare_token_indices
 from fla.utils import autocast_custom_fwd, contiguous
 from reference import naive_nsa
 from einops import rearrange

--- a/examples/deepseek_nsa/example_triton_nsa_fwd.py
+++ b/examples/deepseek_nsa/example_triton_nsa_fwd.py
@@ -8,6 +8,7 @@ import torch
 import triton
 import triton.language as tl
 
+import fla
 if fla.__version__ < "0.2.1":
     from fla.ops.common.utils import prepare_token_indices
 else:

--- a/examples/deepseek_nsa/example_triton_nsa_fwd_varlen.py
+++ b/examples/deepseek_nsa/example_triton_nsa_fwd_varlen.py
@@ -3,13 +3,14 @@
 # ruff: noqa
 import torch
 from typing import Optional, Union
+from packaging.version import parse
 
 import torch
 import triton
 import triton.language as tl
 
 import fla
-if fla.__version__ < "0.2.1":
+if parse(fla.__version__) < parse("0.2.1"):
     from fla.ops.common.utils import prepare_token_indices
 else:
     from fla.ops.utils import prepare_token_indices

--- a/examples/deepseek_nsa/example_triton_nsa_fwd_varlen.py
+++ b/examples/deepseek_nsa/example_triton_nsa_fwd_varlen.py
@@ -8,7 +8,11 @@ import torch
 import triton
 import triton.language as tl
 
-from fla.ops.common.utils import prepare_token_indices
+import fla
+if fla.__version__ < "0.2.1":
+    from fla.ops.common.utils import prepare_token_indices
+else:
+    from fla.ops.utils import prepare_token_indices
 from fla.utils import autocast_custom_fwd, contiguous
 from reference import naive_nsa
 from einops import rearrange


### PR DESCRIPTION
As mentioned in #574, since [FLA](https://github.com/fla-org/flash-linear-attention) update nsa's api in v0.2.1, we should use `from fla.ops.utils import prepare_token_indices` instead of `from fla.ops.common.utils import prepare_token_indices` when `fla.__version__ >= '0.2.1'` to fix the import issue.