### PR TITLE
[Enhancement] Improve memory access condition checks in GlobalMemChecker

### DIFF
--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -116,12 +116,12 @@ struct GlobalMemChecker : public StmtExprVisitor {
       // If analyzer->CanProve(index < shape_dim) returns false,
       // it means we cannot prove the access is within bounds.
       PrimExpr upper_bound_cond = index < shape_dim;
-      if (!analyzer_->CanProve(upper_bound_cond)) {
+      if (!analyzer_->CanProve(upper_bound_cond, arith::ProofStrength::kSymbolicBound)) {
         _conditions.push_back(upper_bound_cond);
       }
       // Check if index >= 0 can be proven.
       PrimExpr lower_bound_cond = index >= 0;
-      if (!analyzer_->CanProve(lower_bound_cond)) {
+      if (!analyzer_->CanProve(lower_bound_cond, arith::ProofStrength::kSymbolicBound)) {
         _conditions.push_back(lower_bound_cond);
       }
     }

--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -116,12 +116,14 @@ struct GlobalMemChecker : public StmtExprVisitor {
       // If analyzer->CanProve(index < shape_dim) returns false,
       // it means we cannot prove the access is within bounds.
       PrimExpr upper_bound_cond = index < shape_dim;
-      if (!analyzer_->CanProve(upper_bound_cond, arith::ProofStrength::kSymbolicBound)) {
+      if (!analyzer_->CanProve(upper_bound_cond,
+                               arith::ProofStrength::kSymbolicBound)) {
         _conditions.push_back(upper_bound_cond);
       }
       // Check if index >= 0 can be proven.
       PrimExpr lower_bound_cond = index >= 0;
-      if (!analyzer_->CanProve(lower_bound_cond, arith::ProofStrength::kSymbolicBound)) {
+      if (!analyzer_->CanProve(lower_bound_cond,
+                               arith::ProofStrength::kSymbolicBound)) {
         _conditions.push_back(lower_bound_cond);
       }
     }


### PR DESCRIPTION
- Updated the condition checks in the GlobalMemChecker to utilize symbolic bounds in the CanProve method, enhancing the accuracy of memory access validations.
- This change ensures that both upper and lower bound conditions are evaluated with improved proof strength, contributing to more robust memory access analysis.