### PR TITLE
[Enhancement] Refine error messaging in LowerBulkCopy for global and shared range checks

### DIFF
--- a/src/op/bulk_copy.cc
+++ b/src/op/bulk_copy.cc
@@ -187,8 +187,8 @@ Stmt Copy::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer) const {
     }
     auto s_range = shared_range[s_range_idx++];
     ICHECK(StructuralEqual()(g_range->extent, s_range->extent))
-        << "global_range[" << i << "] is illegal, global_range[" << i
-        << "] = " << g_range->extent << ", shared_range[" << s_range_idx
+        << global_tensor->name << "[" << i << "] is illegal, " << global_tensor->name << "[" << i
+        << "] = " << g_range->extent << ", " << shared_tensor->name << "[" << s_range_idx
         << "] = " << s_range->extent;
   }
 

--- a/src/op/bulk_copy.cc
+++ b/src/op/bulk_copy.cc
@@ -187,8 +187,9 @@ Stmt Copy::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer) const {
     }
     auto s_range = shared_range[s_range_idx++];
     ICHECK(StructuralEqual()(g_range->extent, s_range->extent))
-        << global_tensor->name << "[" << i << "] is illegal, " << global_tensor->name << "[" << i
-        << "] = " << g_range->extent << ", " << shared_tensor->name << "[" << s_range_idx
+        << global_tensor->name << "[" << i << "] is illegal, "
+        << global_tensor->name << "[" << i << "] = " << g_range->extent << ", "
+        << shared_tensor->name << "[" << s_range_idx
         << "] = " << s_range->extent;
   }
 


### PR DESCRIPTION
- Improved the clarity of error messages in the LowerBulkCopy function by enhancing the output format.
- Included additional context in error messages to aid debugging when global and shared ranges are found to be illegal, ensuring better traceability during bulk copy operations.