### PR TITLE
Fixed mha_bwd shape inconsistency error

### DIFF
--- a/examples/flash_attention/example_mha_bwd.py
+++ b/examples/flash_attention/example_mha_bwd.py
@@ -179,8 +179,8 @@ def flashattn_bwd(batch, heads, seq_len, dim, is_causal, block_M, block_N):
             dv = T.alloc_fragment([block_M, dim], accum_dtype)
             dk = T.alloc_fragment([block_M, dim], accum_dtype)
             dq = T.alloc_fragment([block_N, dim], accum_dtype)
-            dv_shared = T.alloc_shared([block_N, dim], dtype)
-            dk_shared = T.alloc_shared([block_N, dim], dtype)
+            dv_shared = T.alloc_shared([block_M, dim], dtype)
+            dk_shared = T.alloc_shared([block_M, dim], dtype)
 
             T.annotate_layout({
                 dQ: make_dq_layout(dQ),


### PR DESCRIPTION
dv and dk both have shapes [block_M, dim], but the current dv_shared and dk_shared have shapes [block_N, dim]. This commit fixed their shape inconsistency.

In the previous version, the reason this file still works is because block_N and block_M are the same (64), but this file will run into issue once you change their sizes.