### PR TITLE
[Enhancement] Update ReduceOp initialization values for integer types

### DIFF
--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -44,15 +44,27 @@ ReduceOp::ReduceOp(Array<PrimExpr> args, BufferMap vmap) {
 }
 
 PrimExpr ReduceOp::MakeInitValue() const {
+  auto dst_dtype = dst->dtype;
+  auto is_int = dst_dtype.is_int();
+  auto bits = dst_dtype.bits();
+
   switch (type) {
   case ReduceType::kSum:
     return make_zero(dst->dtype);
   case ReduceType::kAbsSum:
     return make_zero(dst->dtype);
   case ReduceType::kMax:
-    return make_const(dst->dtype, -INFINITY);
+    if (is_int) {
+      return make_const(dst->dtype, -(1 << (bits - 1)));
+    } else {
+      return make_const(dst->dtype, -INFINITY);
+    }
   case ReduceType::kMin:
-    return make_const(dst->dtype, INFINITY);
+    if (is_int) {
+      return make_const(dst->dtype, (1 << (bits - 1)) - 1);
+    } else {
+      return make_const(dst->dtype, INFINITY);
+    }
   case ReduceType::kAbsMax:
     return make_const(dst->dtype, 0);
   default:

--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -46,6 +46,7 @@ ReduceOp::ReduceOp(Array<PrimExpr> args, BufferMap vmap) {
 PrimExpr ReduceOp::MakeInitValue() const {
   auto dst_dtype = dst->dtype;
   auto is_int = dst_dtype.is_int();
+  bool is_uint = dst_dtype.is_uint();
   auto bits = dst_dtype.bits();
 
   switch (type) {
@@ -56,12 +57,16 @@ PrimExpr ReduceOp::MakeInitValue() const {
   case ReduceType::kMax:
     if (is_int) {
       return make_const(dst->dtype, -(1 << (bits - 1)));
+    } else if (is_uint) {
+      return make_const(dst->dtype, 0);
     } else {
       return make_const(dst->dtype, -INFINITY);
     }
   case ReduceType::kMin:
     if (is_int) {
       return make_const(dst->dtype, (1 << (bits - 1)) - 1);
+    } else if (is_uint) {
+      return make_const(dst->dtype, (1 << bits) - 1);
     } else {
       return make_const(dst->dtype, INFINITY);
     }


### PR DESCRIPTION
- Modified the `MakeInitValue` method in `ReduceOp` to handle integer data types correctly by returning appropriate minimum and maximum values based on the bit width.
- Added checks for integer types to ensure correct initialization for `kMax` and `kMin` reduction types, enhancing the robustness of the reduction operations.