### PR TITLE
[Pass][Simplify] Introduce symbolic level simplify for condition expression

### DIFF
--- a/examples/blocksparse_gemm/example_blocksparse_gemm.py
+++ b/examples/blocksparse_gemm/example_blocksparse_gemm.py
@@ -157,9 +157,16 @@ def main():
         print(f"Sparsity Ratio: {sparsity}")
         print(f"Best Kernel Latency: {best_latency:.6f} ms")
     else:
-        kernel = blocksparse_matmul(M, N, K, DEFAULT_BLOCK_M, DEFAULT_BLOCK_N, DEFAULT_BLOCK_K,
-                                    DEFAULT_NUM_STAGES, DEFAULT_THREAD_NUM,
-                                    DEFAULT_ENABLE_RASTERIZATION)
+        kernel = blocksparse_matmul(
+            M,
+            N,
+            K,
+            block_M=DEFAULT_BLOCK_M,
+            block_N=DEFAULT_BLOCK_N,
+            block_K=DEFAULT_BLOCK_K,
+            num_stages=DEFAULT_NUM_STAGES,
+            thread_num=DEFAULT_THREAD_NUM,
+            enable_rasteration=DEFAULT_ENABLE_RASTERIZATION)
         block_M, block_N, block_K = DEFAULT_BLOCK_M, DEFAULT_BLOCK_N, DEFAULT_BLOCK_K
         print(f"Using default kernel with block size ({block_M}, {block_N}, {block_K})")
 

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -68,6 +68,10 @@ std::pair<int, int> Gemm::ComputeWarpPartition(int num_warps, Target target,
   constexpr int kNPerWarp = 8;  // Columns processed by a single warp
   bool allow_wgmma = TargetIsHopper(target) && maybe_hopper_wgmma &&
                      (this->M >= 64) && (num_warps % 4 == 0);
+  ICHECK(this->M % kMPerWarp == 0)
+      << "M must be divisible by " << kMPerWarp << ", but got " << this->M;
+  ICHECK(this->N % kNPerWarp == 0)
+      << "N must be divisible by " << kNPerWarp << ", but got " << this->N;
   if (allow_wgmma) {
     ICHECK(num_warps % 4 == 0) << "Warp-Group MMA requires 128×k threads.";
 

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -200,19 +200,20 @@ LayoutMap ParallelOp::InferLayout(const LayoutInferArgs &T, InferLevel level) {
         }
       });
 
-      // check if loop body contains a "pure" buffer store (i.e., direct assignment, not compound update)
+      // check if loop body contains a "pure" buffer store (i.e., direct
+      // assignment, not compound update)
       bool has_pure_buffer_store = false;
       PostOrderVisit(root_, [&](const ObjectRef &obj) {
-        if (const auto* store = obj.as<BufferStoreNode>()) {
-          // Check if the value is a direct load from another buffer (i.e., b[i] = a[i])
-          if (const auto* load = store->value.as<BufferLoadNode>()) {
+        if (const auto *store = obj.as<BufferStoreNode>()) {
+          // Check if the value is a direct load from another buffer (i.e., b[i]
+          // = a[i])
+          if (const auto *load = store->value.as<BufferLoadNode>()) {
             has_pure_buffer_store = true;
           }
         }
       });
 
-      if (!is_one(loop_layout_->ReplicateExtent()) &&
-          has_cross_thread_access &&
+      if (!is_one(loop_layout_->ReplicateExtent()) && has_cross_thread_access &&
           !has_pure_buffer_store) {
         auto inv = loop_layout_->Inverse();
         Array<PrimExpr> fwd;

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -200,7 +200,20 @@ LayoutMap ParallelOp::InferLayout(const LayoutInferArgs &T, InferLevel level) {
         }
       });
 
-      if (!is_one(loop_layout_->ReplicateExtent()) && has_cross_thread_access) {
+      // check if loop body contains a "pure" buffer store (i.e., direct assignment, not compound update)
+      bool has_pure_buffer_store = false;
+      PostOrderVisit(root_, [&](const ObjectRef &obj) {
+        if (const auto* store = obj.as<BufferStoreNode>()) {
+          // Check if the value is a direct load from another buffer (i.e., b[i] = a[i])
+          if (const auto* load = store->value.as<BufferLoadNode>()) {
+            has_pure_buffer_store = true;
+          }
+        }
+      });
+
+      if (!is_one(loop_layout_->ReplicateExtent()) &&
+          has_cross_thread_access &&
+          !has_pure_buffer_store) {
         auto inv = loop_layout_->Inverse();
         Array<PrimExpr> fwd;
         for (size_t i = 0; i < loop_layout_->OutputDim(); i++)

--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -228,8 +228,9 @@ Stmt ReduceOp::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
 
       bool has_arch = T.target->attrs.count("arch") > 0;
       if (has_arch && Downcast<String>(T.target->attrs["arch"]) == "sm_90") {
+        auto all_threads = T.thread_bounds->extent;
         ss << "tl::AllReduce<" << this->MakeCodegenReducer() << ", "
-           << reducing_threads << ", " << (*scale) << ">::run_hopper";
+           << reducing_threads << ", " << (*scale) << ", " << all_threads << ">::run_hopper";
       } else {
         ss << "tl::AllReduce<" << this->MakeCodegenReducer() << ", "
            << reducing_threads << ", " << (*scale) << ">::run";

--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -230,7 +230,8 @@ Stmt ReduceOp::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
       if (has_arch && Downcast<String>(T.target->attrs["arch"]) == "sm_90") {
         auto all_threads = T.thread_bounds->extent;
         ss << "tl::AllReduce<" << this->MakeCodegenReducer() << ", "
-           << reducing_threads << ", " << (*scale) << ", " << all_threads << ">::run_hopper";
+           << reducing_threads << ", " << (*scale) << ", " << all_threads
+           << ">::run_hopper";
       } else {
         ss << "tl::AllReduce<" << this->MakeCodegenReducer() << ", "
            << reducing_threads << ", " << (*scale) << ">::run";

--- a/src/tl_templates/cuda/reduce.h
+++ b/src/tl_templates/cuda/reduce.h
@@ -53,6 +53,7 @@ struct AllReduce {
     if constexpr (offset >= 32) {
       asm volatile("bar.sync %0, %1;" : : "r"(1), "r"(all_threads));
       red_buf[threadIdx.x] = x;
+      // TODO(lei): maybe we can merge the two bar.sync into one?
       asm volatile("bar.sync %0, %1;" : : "r"(2), "r"(all_threads));
       x = Reducer()(x, red_buf[threadIdx.x ^ offset]);
     } else {

--- a/src/transform/simplify.cc
+++ b/src/transform/simplify.cc
@@ -443,7 +443,8 @@ private:
     } else {
       // May have symbolic, need kSymbolicBound level prover.
       if (analyzer_->CanProve(condition) ||
-        analyzer_->CanProve(condition, arith::ProofStrength::kSymbolicBound)) {
+          analyzer_->CanProve(condition,
+                              arith::ProofStrength::kSymbolicBound)) {
         return Bool(true);
       }
       return NullOpt;

--- a/src/transform/simplify.cc
+++ b/src/transform/simplify.cc
@@ -210,7 +210,8 @@ TVM_REGISTER_PASS_CONFIG_OPTION("tl.Simplify", SimplifyConfig);
 class StmtSimplifier : public IRMutatorWithAnalyzer {
 public:
   static PrimFunc Apply(PrimFunc func, Analyzer *analyzer,
-                        Optional<SimplifyConfig> config_opt = NullOpt) {
+                        Optional<SimplifyConfig> config_opt = NullOpt,
+                        bool simplify_arguments = false) {
     auto config = config_opt.value_or(AttrsWithDefaultValues<SimplifyConfig>());
     analyzer->rewrite_simplify.SetEnabledExtensions(
         config->GetEnabledExtensions());
@@ -246,8 +247,8 @@ public:
         }
       }
     }
-    // return func;
-    if (param_updated) {
+
+    if (simplify_arguments && param_updated) {
       return PrimFunc(new_params, func.CopyOnWrite()->body, func->ret_type,
                       new_buffer_map, func->attrs, func->span);
     } else {
@@ -440,6 +441,11 @@ private:
     if (const int64_t *as_int = as_const_int(condition)) {
       return Bool(*as_int);
     } else {
+      // May have symbolic, need kSymbolicBound level prover.
+      if (analyzer_->CanProve(condition) ||
+        analyzer_->CanProve(condition, arith::ProofStrength::kSymbolicBound)) {
+        return Bool(true);
+      }
       return NullOpt;
     }
   }
@@ -456,11 +462,11 @@ private:
 
 using namespace tir::transform;
 
-tvm::transform::Pass Simplify() {
+tvm::transform::Pass Simplify(bool simplify_arguments = true) {
   auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
     arith::Analyzer analyzer;
     auto cfg = ctx->GetConfig<SimplifyConfig>("tl.Simplify");
-    return StmtSimplifier::Apply(f, &analyzer, cfg);
+    return StmtSimplifier::Apply(f, &analyzer, cfg, simplify_arguments);
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.Simplify", {});
 }

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -91,7 +91,10 @@ def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
         mod = tilelang.transform.AlignDynamicSharedMemoryAllocations(16)(mod)
     # Simplify again to clean up any duplicated conditions
     # that may have been introduced by safety checks
-    mod = tir.transform.Simplify()(mod)
+    # use an enhanced pass to simplify the dynamic symbolics
+    # TODO(lei): return to tir pass when kSymbolicBound simplification
+    # is merged into tvm.
+    mod = tilelang.transform.Simplify()(mod)
     # Try to vectorize loop with dynamic shape
     mod = tilelang.transform.LoopVectorizeDynamic()(mod)
     return mod

--- a/tilelang/transform/simplify.py
+++ b/tilelang/transform/simplify.py
@@ -7,7 +7,7 @@ from typing import Union, Callable
 from . import _ffi_api
 
 
-def Simplify():
+def Simplify(simplify_arguments: bool = False):
     """Simplify
 
     Returns
@@ -15,16 +15,16 @@ def Simplify():
     fpass : tvm.transform.Pass
         The result pass
     """
-    return _ffi_api.Simplify()  # type: ignore
+    return _ffi_api.Simplify(simplify_arguments)  # type: ignore
 
 
 def _Simplify(stmt: Union[PrimFunc, IRModule]) -> Union[PrimFunc, IRModule]:
     if isinstance(stmt, PrimFunc):
-        mod = Simplify()(IRModule.from_expr(stmt))
+        mod = Simplify(simplify_arguments=True)(IRModule.from_expr(stmt))
         assert len(mod.functions) == 1, "Simplify should return a single function"
         return list(mod.functions.values()).pop()
     elif isinstance(stmt, IRModule):
-        return Simplify()(stmt)
+        return Simplify(simplify_arguments=True)(stmt)
     else:
         raise ValueError(f"Unsupported type: {type(stmt)}")
 


### PR DESCRIPTION
Simplify `(bx // 2 < seq_len)` to the compile-time constant `true` whenever `bx` is in the half-open interval `[0, seq_len * 2)`.

<img width="4544" height="1524" alt="image" src="https://github.com/user-attachments/assets/bafa9216-1339-4f71-97ad-f690de728aff" />
