### PR TITLE
[Enhancement] Automatically build and install cython into packages 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -414,6 +414,7 @@ class TileLangBuilPydCommand(build_py):
         # copy cython files
         CYTHON_SRC = [
             "tilelang/jit/adapter/cython/cython_wrapper.pyx",
+            "tilelang/jit/adapter/cython/.cycache",
         ]
         for item in CYTHON_SRC:
             source_dir = os.path.join(ROOT_DIR, item)


### PR DESCRIPTION
- Included the Cython cache directory in the list of source files for the TileLang build process, ensuring proper handling of cached Cython files during the build.