### PR TITLE
[Bugfix] Adjust role assignment in warp specialization based on read access

### DIFF
--- a/src/transform/warp_specialized_rewriter.cc
+++ b/src/transform/warp_specialized_rewriter.cc
@@ -129,7 +129,7 @@ public:
     auto access = GetBlockReadWriteRegion(block, buffer_data_to_buffer_);
     auto reads = access[0];
     Role role = Role::kProducer;
-    if (reads.size() == 0)
+    if (reads.empty())
       role = Role::kConsumer;
     for (auto read : reads) {
       if (read->buffer.scope() != "global") {


### PR DESCRIPTION
- Updated the role assignment logic in `warp_specialized_rewriter.cc` to set the role to `kConsumer` when no reads are detected, ensuring correct behavior in memory access scenarios.