### PR TITLE
[Feat] Introduce an offset option in threadblock swizzle

### DIFF
--- a/src/tl_templates/cuda/threadblock_swizzle.h
+++ b/src/tl_templates/cuda/threadblock_swizzle.h
@@ -4,7 +4,7 @@
 
 namespace tl {
 
-template <int panel_width> TL_DEVICE dim3 rasterization2DRow() {
+template <int panel_width, int offset> TL_DEVICE dim3 rasterization2DRow() {
   const unsigned int block_idx = blockIdx.x + blockIdx.y * gridDim.x;
   const unsigned int grid_size = gridDim.x * gridDim.y;
   const unsigned int panel_size = panel_width * gridDim.x;
@@ -18,11 +18,11 @@ template <int panel_width> TL_DEVICE dim3 rasterization2DRow() {
   const unsigned int col_idx = (panel_idx & 1)
                                    ? gridDim.x - 1 - panel_offset / stride
                                    : panel_offset / stride;
-  const unsigned int row_idx = panel_offset % stride + panel_idx * panel_width;
+  const unsigned int row_idx = (panel_offset % stride + panel_idx * panel_width + offset) % gridDim.y;
   return {col_idx, row_idx, blockIdx.z};
 }
 
-template <int panel_width> TL_DEVICE dim3 rasterization2DColumn() {
+template <int panel_width, int offset> TL_DEVICE dim3 rasterization2DColumn() {
   const unsigned int block_idx = blockIdx.x + blockIdx.y * gridDim.x;
   const unsigned int grid_size = gridDim.x * gridDim.y;
   const unsigned int panel_size = panel_width * gridDim.y;
@@ -36,7 +36,7 @@ template <int panel_width> TL_DEVICE dim3 rasterization2DColumn() {
   const unsigned int row_idx = (panel_idx & 1)
                                    ? gridDim.y - 1 - panel_offset / stride
                                    : panel_offset / stride;
-  const unsigned int col_idx = panel_offset % stride + panel_idx * panel_width;
+  const unsigned int col_idx = (panel_offset % stride + panel_idx * panel_width + offset) % gridDim.x;
   return {col_idx, row_idx, blockIdx.z};
 }
 

--- a/tilelang/language/__init__.py
+++ b/tilelang/language/__init__.py
@@ -76,13 +76,13 @@ def symbolic(name: str, dtype: str = "int32"):
     return tir.Var(name, dtype)
 
 
-def use_swizzle(panel_size: int, order: str = "row", enable: bool = True):
+def use_swizzle(panel_size: int, order: str = "row", offset: int = 0, enable: bool = True):
     # If order is row, use rasterization2DRow, otherwise use rasterization2DColumn
     # The panel size is the number of threads in a warp
     # Use to improve the L2 Cache Locality
     device_func = ("rasterization2DRow" if order == "row" else "rasterization2DColumn")
     return attr(None, "threadblock_swizzle_pattern",
-                f"tl::{device_func}<{panel_size}>") if enable else None
+                f"tl::{device_func}<{panel_size}, {offset}>") if enable else None
 
 
 def annotate_layout(layout_map: Dict):


### PR DESCRIPTION
Add an `offset` option in threadblock swizzle API. 

This is useful in some distributed scenarios, e.g. overlapped AllGather+GEMM, where an offset could be applied so that SMs can be dispatched to compute blocks of **local** data first, alleviating the overhead of waiting.