### PR TITLE
[Bugfix] Passing correct nvcc to cmake

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -818,6 +818,8 @@ class TilelangExtensionBuild(build_ext):
             f"-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={extdir}", f"-DPYTHON_EXECUTABLE={sys.executable}",
             f"-DCMAKE_BUILD_TYPE={'Debug' if DEBUG_MODE else 'Release'}"
         ]
+        if not USE_ROCM:
+            cmake_args.append(f"-DCMAKE_CUDA_COMPILER={os.path.join(CUDA_HOME, 'bin', 'nvcc')}")
 
         # Create the temporary build directory (if it doesn't exist).
         build_temp = os.path.abspath(self.build_temp)


### PR DESCRIPTION
cmake doesn't take the nvcc specified by CUDA_HOME by default. Consequently, the follow command failed for me because cmake still used the nvcc from the default location (e.g. in my case /usr/local/cuda/bin/nvcc):

```
$ PATH=/home/yangche/cuda-12.8/bin:$PATH CUDA_HOME=/home/yangche/cuda-12.8 pip install -e . -v
```

This minor fix enforces cmake to use the nvcc specified by the CUDA_HOME env.