### PR TITLE
[Version] Keep local commit id as it somehow help with debugging

### DIFF
--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -8,6 +8,8 @@ import tilelang.language as T
 from tilelang.intrinsics import (
     make_mma_swizzle_layout as make_swizzle_layout,)  # noqa: F401
 
+tilelang.disable_cache()
+
 
 # add decorator @tilelang.jit if you want to return a torch function
 # @tilelang.jit

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -8,8 +8,6 @@ import tilelang.language as T
 from tilelang.intrinsics import (
     make_mma_swizzle_layout as make_swizzle_layout,)  # noqa: F401
 
-tilelang.disable_cache()
-
 
 # add decorator @tilelang.jit if you want to return a torch function
 # @tilelang.jit

--- a/tilelang/version.py
+++ b/tilelang/version.py
@@ -24,5 +24,24 @@ else:
 with open(version_file_path, "r") as version_file:
     __version__ = version_file.read().strip()
 
+
+def get_git_commit_id() -> Union[str, None]:
+    """Get the current git commit hash by running git in the current file's directory."""
+    try:
+        return subprocess.check_output(['git', 'rev-parse', 'HEAD'],
+                                       cwd=os.path.dirname(os.path.abspath(__file__)),
+                                       stderr=subprocess.DEVNULL,
+                                       encoding='utf-8').strip()
+    except subprocess.SubprocessError:
+        return None
+
+
+# Append git commit hash to version if not already present
+# NOTE(lei): Although the local commit id cannot capture locally staged changes,
+# the local commit id can help mitigate issues caused by incorrect cache to some extent,
+# so it should still be kept.
+if "+" not in __version__ and (commit_id := get_git_commit_id()):
+    __version__ = f"{__version__}+{commit_id}"
+
 # Define the public API for the module
 __all__ = ["__version__"]


### PR DESCRIPTION
Although the local commit id cannot capture locally staged changes, the local commit id can help mitigate issues caused by incorrect cache to some extent, so it should still be kept.