### PR TITLE
[Typo] Rename `TILELANG_PRINT_COMPILATION` to `TILELANG_PRINT_ON_COMPILATION`

### DIFF
--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -75,7 +75,7 @@ TILELANG_CACHE_DIR: str = os.environ.get("TILELANG_CACHE_DIR",
 TILELANG_TMP_DIR: str = os.path.join(TILELANG_CACHE_DIR, "tmp")
 
 # Print the kernel name on every compilation
-TILELANG_PRINT_ON_COMPILATION: str = os.environ.get("TILELANG_PRINT_COMPILATION", "0")
+TILELANG_PRINT_ON_COMPILATION: str = os.environ.get("TILELANG_PRINT_ON_COMPILATION", "0")
 
 # Auto-clear cache if environment variable is set
 TILELANG_CLEAR_CACHE = os.environ.get("TILELANG_CLEAR_CACHE", "0")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - The print-on-compilation setting now reads from the TILELANG_PRINT_ON_COMPILATION environment variable (default "0").
  - If you previously set TILELANG_PRINT_COMPILATION, switch to the new name for the behavior to take effect.
  - No other behavior changed, but existing workflows may need to update environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->