### PR TITLE
[Bugfix]:Fix atomic add auto vectorize memory access out of bound error

### DIFF
--- a/src/transform/atomicadd_vectorize.cc
+++ b/src/transform/atomicadd_vectorize.cc
@@ -170,7 +170,8 @@ private:
         ICHECK(tx_var.defined()) << "Failed to find tx var";
         Var outer_var = Var(old_var->name_hint + "_outer");
         Map<Var, PrimExpr> vmap;
-        // Scale thread index (tx) and loop variable by vector_size to map each new iteration to a vectorized chunk
+        // Scale thread index (tx) and loop variable by vector_size to map each
+        // new iteration to a vectorized chunk
         vmap.Set(tx_var, tx_var * vector_size_);
         vmap.Set(fnode->loop_var, outer_var * vector_size_);
         Stmt body = Substitute(fnode->body, vmap);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified innermost loop vectorization mapping by replacing complex alignment math with a direct scaling approach; internal substitutions updated while public APIs remain unchanged.

* **Performance**
  * Potential runtime improvements in vectorized kernels due to reduced index-computation overhead.

* **Bug Fixes**
  * Eliminates edge-case misalignments that could occur under the previous alignment logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->