### PR TITLE
[Bugfix] Align stride index validation with torch in CythonKernelWrapper

### DIFF
--- a/tilelang/jit/adapter/cython/cython_wrapper.pyx
+++ b/tilelang/jit/adapter/cython/cython_wrapper.pyx
@@ -123,6 +123,11 @@ cdef class CythonKernelWrapper:
                 # otherwise, maybe torch.data_ptr() for T.ptr inputs
                 continue
             for stride_idx, expected_stride in strides_list:
+                # Ensure the stride index is within the valid range of tensor dimensions
+                # (stride_idx should be less than the number of dimensions of the tensor)
+                assert stride_idx < tensor.dim(), f"Stride index {stride_idx} out of bounds for tensor with {tensor.dim()} dimensions"
+                if tensor.shape[stride_idx] == 1:
+                    continue
                 actual_stride = tensor.stride(stride_idx)
                 if actual_stride != expected_stride:
                     raise ValueError(


### PR DESCRIPTION
* Introduced an assertion to ensure that the stride index is within the valid range of tensor dimensions in `cython_wrapper.pyx`.
* This change prevents potential out-of-bounds errors when accessing tensor dimensions, enhancing the robustness of the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected stride validation to skip singleton dimensions, reducing false-positive errors during execution.
  * Added defensive bounds checks to prevent rare crashes.
  * Improves reliability when working with arrays/tensors that include size-1 axes, avoiding unnecessary failures in shape/stride checks common in broadcasting-like scenarios.
  * No changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->