### PR TITLE
[Bugfix][WS] Consider loop min extent when computing phase id

### DIFF
--- a/testing/python/dynamic/test_tilelang_dynamic_symbolic_bench.py
+++ b/testing/python/dynamic/test_tilelang_dynamic_symbolic_bench.py
@@ -550,10 +550,10 @@ def run_assert_tl_matmul_block_dynamic_mnk(M, N, K, block_M, block_N, block_K):
 
 
 def test_all():
-    run_assert_tl_matmul_block_static(16384, 16384, 16384, 128, 128, 32)
-    run_assert_tl_matmul_block_dynamic_m(16384, 16384, 16384, 128, 128, 32)
-    run_assert_tl_matmul_block_dynamic_mn(16384, 16384, 16384, 128, 128, 32)
-    run_assert_tl_matmul_block_dynamic_mnk(16384, 16384, 16384, 128, 128, 32)
+    run_assert_tl_matmul_block_static(1024, 1024, 1024, 128, 128, 32)
+    run_assert_tl_matmul_block_dynamic_m(1024, 1024, 1024, 128, 128, 32)
+    run_assert_tl_matmul_block_dynamic_mn(1024, 1024, 1024, 128, 128, 32)
+    run_assert_tl_matmul_block_dynamic_mnk(1024, 1024, 1024, 128, 128, 32)
 
 
 if __name__ == "__main__":

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -165,7 +165,6 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.MergeSharedMemoryAllocations(
         enable_aggressive_merge=enable_aggressive_merge)(
             mod)
-    print("mod \n", mod)
     mod = tilelang.transform.ThreadSync("shared")(mod)
     mod = tilelang.transform.ThreadSync("shared.dyn")(mod)
     # Inject PTX async copy must behind the thread sync pass


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined loop handling and index computation in warp specialization; no user-facing behavior or API changes.

- Tests
  - Reduced problem sizes in dynamic benchmarking tests to speed up execution without altering coverage or outcomes.

- Chores
  - Removed extraneous debug print during optimization, resulting in cleaner logs with no functional impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->