### PR TITLE
[Bugfix] Address PassContext contamination from CI and fix incorrect rewrites in warp specialized pass

### DIFF
--- a/src/transform/warp_specialized_rewriter.cc
+++ b/src/transform/warp_specialized_rewriter.cc
@@ -376,14 +376,24 @@ private:
           eq_op->b.as<VarNode>() == thread_var_.get()) {
         maybe_thread_opt_ = true;
       }
-      maybe_thread_opt_ = do_shuffle_ && maybe_thread_opt_;
+      auto then_case = StmtExprMutator::VisitStmt(op->then_case);
+      maybe_thread_opt_ = do_shuffle_ && maybe_thread_opt_ && has_tma_op_;
+      if (maybe_thread_opt_) {
+        return IfThenElse(
+            Call(DataType::Bool(), tl_shuffle_elect(), {thread_extent_}),
+            StmtExprMutator::VisitStmt(op->then_case), std::nullopt);
+      }
     }
-    if (maybe_thread_opt_)
-      return IfThenElse(
-          Call(DataType::Bool(), tl_shuffle_elect(), {thread_extent_}),
-          StmtExprMutator::VisitStmt(op->then_case), std::nullopt);
-    else
-      return StmtExprMutator::VisitStmt_(op);
+    return StmtExprMutator::VisitStmt_(op);
+  }
+
+  PrimExpr VisitExpr_(const CallNode *op) final {
+    if (op->op.same_as(tl::tma_load()) ||
+        op->op.same_as(tl::tma_load_im2col()) ||
+        op->op.same_as(tl::tma_store())) {
+      has_tma_op_ = true;
+    }
+    return StmtExprMutator::VisitExpr_(op);
   }
 
   Var thread_var_;
@@ -391,6 +401,7 @@ private:
   PrimExpr thread_extent_;
   bool maybe_thread_opt_ = false;
   bool do_shuffle_;
+  bool has_tma_op_ = false;
 };
 
 Block MakeGroupBlock(const Stmt &stmt,

--- a/src/transform/warp_specialized_rewriter.cc
+++ b/src/transform/warp_specialized_rewriter.cc
@@ -378,6 +378,7 @@ private:
       }
       auto then_case = StmtExprMutator::VisitStmt(op->then_case);
       maybe_thread_opt_ = do_shuffle_ && maybe_thread_opt_ && has_tma_op_;
+      has_tma_op_ = false;
       if (maybe_thread_opt_) {
         return IfThenElse(
             Call(DataType::Bool(), tl_shuffle_elect(), {thread_extent_}),

--- a/testing/python/transform/test_tilelang_transform_lower_tile_op.py
+++ b/testing/python/transform/test_tilelang_transform_lower_tile_op.py
@@ -63,10 +63,10 @@ def test_loop_tail_split(block_M, block_N, block_K, threads, vec_load_b, dtype):
                                                t // (block_N // vec_load_b),
                                                bx * block_N + t % (block_N // vec_load_b) *
                                                (block_N // vec_load_b) + vec], T.float16(0))
-
-    mod = tvm.tir.transform.BindTarget(auto_target)(Before)
-    mod = tl.transform.LowerTileOp()(mod)
-    mod = tvm.tir.transform.Simplify()(mod)
+    with tvm.transform.PassContext():
+        mod = tvm.tir.transform.BindTarget(auto_target)(Before)
+        mod = tl.transform.LowerTileOp()(mod)
+        mod = tvm.tir.transform.Simplify()(mod)
     ref_mod = tvm.tir.transform.BindTarget(auto_target)(After)
     ref_mod = tvm.tir.transform.Simplify()(ref_mod)
     # Note(tzj): The structures are equal except the argument in "T.reads" function.

--- a/testing/python/transform/test_tilelang_transform_lower_tile_op.py
+++ b/testing/python/transform/test_tilelang_transform_lower_tile_op.py
@@ -63,6 +63,7 @@ def test_loop_tail_split(block_M, block_N, block_K, threads, vec_load_b, dtype):
                                                t // (block_N // vec_load_b),
                                                bx * block_N + t % (block_N // vec_load_b) *
                                                (block_N // vec_load_b) + vec], T.float16(0))
+
     with tvm.transform.PassContext():
         mod = tvm.tir.transform.BindTarget(auto_target)(Before)
         mod = tl.transform.LowerTileOp()(mod)

--- a/testing/python/webgpu/test_webgpu_codegen.py
+++ b/testing/python/webgpu/test_webgpu_codegen.py
@@ -43,8 +43,9 @@ def assert_gemm_codegen(
     accum_dtype="float",
 ):
     func = matmul(M, N, K, block_M, block_N, block_K, dtype=dtype, accum_dtype=accum_dtype)
-
-    artifact = tilelang.lower(func, target="webgpu")
+    # Because the current pass context have been polluted by previous testing.
+    with tvm.transform.PassContext():
+        artifact = tilelang.lower(func, target="webgpu")
 
     src_code = artifact.kernel_source
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improves warp-level optimization for kernels that use TMA operations, potentially boosting execution speed in relevant workloads.

* **Reliability**
  * Applies warp-shuffle optimization only when TMA usage is detected and ensures internal state is reset between mutation steps, reducing incorrect transformations and improving predictability.

* **Tests**
  * WebGPU and tile transformation tests now run within an isolated compiler pass context to reduce cross-test interference and improve stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->