### PR TITLE
Allow fill global buffer

### DIFF
--- a/src/op/elem.cc
+++ b/src/op/elem.cc
@@ -186,7 +186,8 @@ Stmt FillNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     auto init_loop = MakeSIMTLoop(analyzer);
     auto vectorized_thread_loop = VectorizeLoop(init_loop);
     return vectorized_thread_loop;
-  } else if (dst.scope() == "shared.dyn" || dst.scope() == "shared" || dst.scope() == "global") {
+  } else if (dst.scope() == "shared.dyn" || dst.scope() == "shared" ||
+             dst.scope() == "global") {
     auto par_op = ParallelOp(MakeSIMTLoop(analyzer));
     par_op->InferLayout({T.target, T.thread_bounds, T.layout_map},
                         InferLevel::kFree);

--- a/src/op/elem.cc
+++ b/src/op/elem.cc
@@ -186,7 +186,7 @@ Stmt FillNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     auto init_loop = MakeSIMTLoop(analyzer);
     auto vectorized_thread_loop = VectorizeLoop(init_loop);
     return vectorized_thread_loop;
-  } else if (dst.scope() == "shared.dyn" || dst.scope() == "shared") {
+  } else if (dst.scope() == "shared.dyn" || dst.scope() == "shared" || dst.scope() == "global") {
     auto par_op = ParallelOp(MakeSIMTLoop(analyzer));
     par_op->InferLayout({T.target, T.thread_bounds, T.layout_map},
                         InferLevel::kFree);


### PR DESCRIPTION
Allow fill, clear on global buffer.

Example code:

```py
@T.prim_func
def foo(
    A: T.Tensor((128,), dtype='float16'),
    B: T.Tensor((128,), dtype='float16')
):
    with T.Kernel(T.ceildiv(128, 16), threads=16) as bx:
        T.clear(B[bx*16:bx*16+16])
        T.fill(B[bx*16:bx*16+16], 1.0)
```

The generated cuda source:

```cu
extern "C" __global__ void foo_kernel(half_t* __restrict__ B);
extern "C" __global__ void __launch_bounds__(16, 1) foo_kernel(half_t* __restrict__ B) {
  #pragma unroll
  for (int i = 0; i < 1; ++i) {
    B[((int)threadIdx.x)] = half_t(0.000000e+00f);
  }
  #pragma unroll
  for (int i_1 = 0; i_1 < 1; ++i_1) {
    B[((int)threadIdx.x)] = half_t(1.000000e+00f);
  }
}
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for fill operations targeting global memory, enabling workloads that write results directly to global scope.
* **Improvements**
  * Ensures consistent behavior and performance with existing paths (parallel execution, vectorization, and predicate guarding where applicable) across memory scopes.
  * Increases compatibility by handling previously unsupported configurations without altering existing local or fragment behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->