### PR TITLE
[Enhancement] Add exp fallback for bf16

### DIFF
--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -241,3 +241,8 @@ TL_DEVICE void __sync_thread_partial() {
   asm volatile("bar.sync %0, %1;" : : "r"(barrier_id), "r"(thread_count));
 }
 } // namespace tl
+
+namespace cutlass {
+TL_DEVICE
+bfloat16_t fast_exp(bfloat16_t x) { return ::hexp(x); }
+} // namespace cutlass


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added device-side exponential support for bfloat16 in the CUDA backend, enabling fast math operations on BF16 data in kernels and improving compatibility with BF16 workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->