### PR TITLE
[Lint] Introduce clang-tidy into format.sh

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,10 +1,40 @@
 Checks: >
+  # 1. 保留的类别：更容易发现 bug/性能问题
   clang-analyzer-*,
-  cppcoreguidelines-*,
-  modernize-*,
+  cppcoreguidelines-pro-type-static-cast-downcast,
+  cppcoreguidelines-pro-type-member-init,
+  cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  cppcoreguidelines-slicing,
+  cppcoreguidelines-special-member-functions,
+  cppcoreguidelines-narrowing-conversions,
   performance-*,
-  readability-*,
-  -readability-identifier-length
+
+  # 2. 可读性：只保留实用的
+  readability-braces-around-statements,
+  readability-container-size-empty,
+  readability-delete-null-pointer,
+  readability-redundant-member-init,
+  readability-redundant-smartptr-get,
+  readability-redundant-string-cstr,
+
+  # 3. 禁用所有侵入式/风格大改的规则
+  -readability-identifier-length,
+  -readability-avoid-const-params-in-decls,
+  -readability-else-after-return,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -modernize-use-trailing-return-type,
+  -modernize-use-nodiscard,
+  -modernize-use-auto,
+  -modernize-pass-by-value,
+  -modernize-return-braced-init-list,
+  -modernize-use-default-member-init,
+  -modernize-loop-convert,
+  -modernize-concat-nested-namespaces,
+  -llvm-include-order,
+  -bugprone-unused-return-value,
+  -clang-diagnostic-unused-result
+
 WarningsAsErrors: '*'
 
 HeaderFilterRegex: '^(?!.*(3rdparty|build)).*$'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 Checks: >
-  # 1. 保留的类别：更容易发现 bug/性能问题
+  # 1. Retained categories: easier to find bugs/performance issues
   clang-analyzer-*,
   cppcoreguidelines-pro-type-static-cast-downcast,
   cppcoreguidelines-pro-type-member-init,
@@ -9,7 +9,7 @@ Checks: >
   cppcoreguidelines-narrowing-conversions,
   performance-*,
 
-  # 2. 可读性：只保留实用的
+  # 2. Readability: only keep useful rules
   readability-braces-around-statements,
   readability-container-size-empty,
   readability-delete-null-pointer,
@@ -17,7 +17,7 @@ Checks: >
   readability-redundant-smartptr-get,
   readability-redundant-string-cstr,
 
-  # 3. 禁用所有侵入式/风格大改的规则
+  # 3. Disable all intrusive/style-breaking rules
   -readability-identifier-length,
   -readability-avoid-const-params-in-decls,
   -readability-else-after-return,
@@ -38,6 +38,9 @@ Checks: >
   -cppcoreguidelines-narrowing-conversions,
   -clang-diagnostic-error,
   -cppcoreguidelines-pro-type-member-init,
+  -clang-analyzer-optin.cplusplus.UninitializedObject,
+  -cppcoreguidelines-pro-type-static-cast-downcast,
+  -performance-unnecessary-value-param,
 
 WarningsAsErrors: '*'
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,7 +6,6 @@ Checks: >
   cppcoreguidelines-pro-bounds-array-to-pointer-decay,
   cppcoreguidelines-pro-bounds-pointer-arithmetic,
   cppcoreguidelines-slicing,
-  cppcoreguidelines-special-member-functions,
   cppcoreguidelines-narrowing-conversions,
   performance-*,
 
@@ -33,7 +32,12 @@ Checks: >
   -modernize-concat-nested-namespaces,
   -llvm-include-order,
   -bugprone-unused-return-value,
-  -clang-diagnostic-unused-result
+  -clang-diagnostic-unused-result,
+  -cppcoreguidelines-special-member-functions,
+  -performance-noexcept-move-constructor,
+  -cppcoreguidelines-narrowing-conversions,
+  -clang-diagnostic-error,
+  -cppcoreguidelines-pro-type-member-init,
 
 WarningsAsErrors: '*'
 

--- a/.github/workflows/amd_ci.yml
+++ b/.github/workflows/amd_ci.yml
@@ -48,6 +48,8 @@ jobs:
     - name: Run format check
       run: |
         source "${{ runner.tool_cache }}/${{ env.VENV_DIR }}/bin/activate"
+        mkdir -p build
+        cd build; cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DUSE_ROCM=ON; cd ..
         if ! output=$(./format.sh 2>&1); then
           echo "------------------------------------"
           echo "message:"
@@ -56,6 +58,7 @@ jobs:
           echo "------------------------------------"
           exit 1
         fi
+        rm -rf build
     
     - name: Commit and Push Changes
       uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/amd_ci.yml
+++ b/.github/workflows/amd_ci.yml
@@ -48,6 +48,7 @@ jobs:
     - name: Run format check
       run: |
         source "${{ runner.tool_cache }}/${{ env.VENV_DIR }}/bin/activate"
+        git submodule update --init --recursive
         mkdir -p build
         cd build; cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DUSE_ROCM=ON; cd ..
         if ! output=$(./format.sh 2>&1); then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
     - name: Run format check
       run: |
         source "${{ runner.tool_cache }}/${{ env.VENV_DIR }}/bin/activate"
+        mkdir -p build
+        # run cmake to create the build directory with compile_commands.json
+        cd build; cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DUSE_CUDA=ON; cd ..
         if ! output=$(./format.sh 2>&1); then
           echo "------------------------------------"
           echo "message:"
@@ -55,6 +58,7 @@ jobs:
           echo "------------------------------------"
           exit 1
         fi
+        rm -rf build
     
     - name: Commit and Push Changes
       uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,7 @@ jobs:
     - name: Run format check
       run: |
         source "${{ runner.tool_cache }}/${{ env.VENV_DIR }}/bin/activate"
+        git submodule update --init --recursive
         mkdir -p build
         # run cmake to create the build directory with compile_commands.json
         cd build; cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DUSE_CUDA=ON; cd ..

--- a/format.sh
+++ b/format.sh
@@ -249,6 +249,73 @@ else
 fi
 echo 'tile-lang clang-format: Done'
 
+echo 'tile-lang clang-tidy: Check Start'
+# If clang-tidy is available, run it; otherwise, skip
+if command -v run-clang-tidy &>/dev/null; then
+    # Check if clang-tidy is available
+    if ! command -v clang-tidy &>/dev/null; then
+        echo "clang-tidy not found. Skipping clang-tidy checks."
+    else
+        # Get clang-tidy version
+        CLANG_TIDY_VERSION=$(clang-tidy --version | head -n1 | awk '{print $4}')
+        echo "Using clang-tidy version: $CLANG_TIDY_VERSION"
+
+        # Check if build directory exists
+        if [ ! -d "build" ]; then
+            echo "Build directory not found. Skipping clang-tidy checks."
+        else
+            # Run clang-tidy on specified files
+            clang_tidy_files() {
+                run-clang-tidy -j 64 "$@" -p build
+            }
+
+            # Run clang-tidy on all C/C++ source files
+            clang_tidy_all() {
+                run-clang-tidy -j 64 src/*.cc -p build
+            }
+
+            # Run clang-tidy on changed C/C++ files relative to main
+            clang_tidy_changed() {
+                if git show-ref --verify --quiet refs/remotes/origin/main; then
+                    BASE_BRANCH="origin/main"
+                else
+                    BASE_BRANCH="main"
+                fi
+
+                MERGEBASE="$(git merge-base $BASE_BRANCH HEAD)"
+
+                # Get changed C/C++ files
+                CHANGED_FILES=$(git diff --name-only --diff-filter=ACM "$MERGEBASE" -- '*.c' '*.cc' '*.cpp' '*.h' '*.hpp' 2>/dev/null || true)
+                
+                if [ -n "$CHANGED_FILES" ]; then
+                    echo "Running clang-tidy on changed files:"
+                    echo "$CHANGED_FILES"
+                    # Convert newline-separated files to space-separated and run clang-tidy once
+                    CHANGED_FILES_SPACE=$(echo "$CHANGED_FILES" | tr '\n' ' ')
+                    run-clang-tidy -j 64 $CHANGED_FILES_SPACE -p build
+                else
+                    echo "No C/C++ files changed. Skipping clang-tidy."
+                fi
+            }
+
+            if [[ "$1" == '--files' ]]; then
+               # If --files is given, run clang-tidy only on the provided files
+               clang_tidy_files "${@:2}"
+            elif [[ "$1" == '--all' ]]; then
+               # If --all is given, run clang-tidy on all source files
+               clang_tidy_all
+            else
+               # Otherwise, run clang-tidy only on changed C/C++ files
+               clang_tidy_changed
+            fi
+        fi
+    fi
+else
+    echo "run-clang-tidy not found. Skipping clang-tidy checks."
+    echo "To install clang-tidy tools, you may need to install clang-tidy and run-clang-tidy."
+fi
+echo 'tile-lang clang-tidy: Done'
+
 # Check if there are any uncommitted changes after all formatting steps.
 # If there are, ask the user to review and stage them.
 if ! git diff --quiet &>/dev/null; then

--- a/format.sh
+++ b/format.sh
@@ -292,7 +292,7 @@ if command -v run-clang-tidy &>/dev/null; then
                     echo "$CHANGED_FILES"
                     # Convert newline-separated files to space-separated and run clang-tidy once
                     CHANGED_FILES_SPACE=$(echo "$CHANGED_FILES" | tr '\n' ' ')
-                    run-clang-tidy -j 64 $CHANGED_FILES_SPACE -p build
+                    run-clang-tidy -j 64 $CHANGED_FILES_SPACE -p build -fix
                 else
                     echo "No C/C++ files changed. Skipping clang-tidy."
                 fi

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -5,3 +5,4 @@ tomli==2.0.1
 ruff==0.6.5
 codespell==2.3.0
 clang-format==15.0.7
+clang-tidy==18.1.8

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -33,7 +33,7 @@ static Var CreateEnvThread(String name, String thread_tag, DataType dtype) {
   return var;
 }
 
-static ForFrame MakeIterVarFrame(const std::string& name, const PrimExpr& dom) {
+static ForFrame MakeIterVarFrame(const std::string &name, const PrimExpr &dom) {
   using namespace tvm::tir;
   Var var = Var(name, dom->dtype);
   // Create a frame that represents a loop over the given domain.
@@ -49,8 +49,8 @@ static ForFrame MakeIterVarFrame(const std::string& name, const PrimExpr& dom) {
   return ForFrame(n);
 }
 
-ForFrame ParallelFor(const Array<PrimExpr>& extents,
-                     const Map<String, ObjectRef>& annotations) {
+ForFrame ParallelFor(const Array<PrimExpr> &extents,
+                     const Map<String, ObjectRef> &annotations) {
   using namespace tvm::tir;
   ObjectPtr<ForFrameNode> n = make_object<ForFrameNode>();
   n->vars.reserve(extents.size());
@@ -60,26 +60,27 @@ ForFrame ParallelFor(const Array<PrimExpr>& extents,
     n->vars.push_back(Var("v", extent.dtype()));
     n->doms.push_back(Range(make_const(dtype, 0), extent));
   }
-  n->f_make_for_loop = [annotations](const Array<Var> &vars, const Array<Range> &doms,
+  n->f_make_for_loop = [annotations](const Array<Var> &vars,
+                                     const Array<Range> &doms,
                                      Stmt body) -> Stmt {
     ICHECK_EQ(vars.size(), doms.size());
     int n = vars.size();
     for (int i = n - 1; i >= 0; --i) {
       Range dom = doms[i];
       Var var = vars[i];
-      body =
-          For(var, dom->min, dom->extent, ForKind::kParallel, body,
-              /*thread_binding=*/std::nullopt, /*annotations=*/annotations);
+      body = For(var, dom->min, dom->extent, ForKind::kParallel, body,
+                 /*thread_binding=*/std::nullopt, /*annotations=*/annotations);
     }
     return body;
   };
   return ForFrame(n);
 }
 
-ForFrame PipelinedFor(PrimExpr start, const PrimExpr& stop, int num_stages,
-                      const Array<PrimExpr>& order, const Array<PrimExpr>& stages,
-                      const Array<Array<PrimExpr>>& sync,
-                      const Array<Array<PrimExpr>>& groups) {
+ForFrame PipelinedFor(PrimExpr start, const PrimExpr &stop, int num_stages,
+                      const Array<PrimExpr> &order,
+                      const Array<PrimExpr> &stages,
+                      const Array<Array<PrimExpr>> &sync,
+                      const Array<Array<PrimExpr>> &groups) {
   using namespace tvm::tir;
   ObjectPtr<ForFrameNode> n = make_object<ForFrameNode>();
   DataType dtype = stop.dtype();
@@ -101,16 +102,15 @@ ForFrame PipelinedFor(PrimExpr start, const PrimExpr& stop, int num_stages,
       anno.Set("tl_pipeline_sync", sync);
     if (!groups.empty())
       anno.Set("tl_pipeline_group", groups);
-    body = For(vars[0], doms[0]->min, doms[0]->extent, ForKind::kSerial,
-               body,
+    body = For(vars[0], doms[0]->min, doms[0]->extent, ForKind::kSerial, body,
                /*thread_binding=*/std::nullopt, /*annotations=*/anno);
     return body;
   };
   return ForFrame(n);
 }
 
-ForFrame PersistentFor(const Array<PrimExpr>& domain, const PrimExpr& wave_size,
-                       const PrimExpr& index, PrimExpr group_size) {
+ForFrame PersistentFor(const Array<PrimExpr> &domain, const PrimExpr &wave_size,
+                       const PrimExpr &index, PrimExpr group_size) {
   using namespace tvm::tir;
   ICHECK(!domain.empty());
   ObjectPtr<ForFrameNode> n = make_object<ForFrameNode>();
@@ -222,9 +222,9 @@ public:
                                                     KernelLaunchFrameNode);
 };
 
-KernelLaunchFrame KernelLaunch(const Array<PrimExpr>& grid_size,
-                               const Optional<Array<PrimExpr>>& block_size_opt,
-                               const Map<String, ffi::Any>& attrs) {
+KernelLaunchFrame KernelLaunch(const Array<PrimExpr> &grid_size,
+                               const Optional<Array<PrimExpr>> &block_size_opt,
+                               const Map<String, ffi::Any> &attrs) {
   ObjectPtr<KernelLaunchFrameNode> n = make_object<KernelLaunchFrameNode>();
 
   // If the kernel is a CPU kernel, we don't need to launch any threads.
@@ -335,14 +335,14 @@ public:
                                                     WarpSpecializeFrameNode);
 };
 
-WarpSpecializeFrame WarpSpecialize(const Array<IntImm>& warp_group_ids,
-                                   const PrimExpr& thread_idx,
+WarpSpecializeFrame WarpSpecialize(const Array<IntImm> &warp_group_ids,
+                                   const PrimExpr &thread_idx,
                                    int warp_group_size = 128) {
   ObjectPtr<WarpSpecializeFrameNode> n = make_object<WarpSpecializeFrameNode>();
   PrimExpr condition;
   std::vector<int> warp_groups;
   warp_groups.reserve(warp_group_ids.size());
-for (int i = 0; i < warp_group_ids.size(); i++) {
+  for (int i = 0; i < warp_group_ids.size(); i++) {
     warp_groups.push_back(Downcast<IntImm>(warp_group_ids[i])->value);
   }
   std::sort(warp_groups.begin(), warp_groups.end());

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -11,6 +11,8 @@
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/script/ir_builder/tir/ir.h>
 
+#include <utility>
+
 namespace tvm {
 namespace tl {
 
@@ -19,8 +21,8 @@ using namespace script::ir_builder::tir;
 static Var CreateEnvThread(String name, String thread_tag, DataType dtype) {
   using namespace tvm::tir;
   using namespace tvm::script::ir_builder;
-  IterVar iter_var(Range{nullptr}, Var(name, dtype),
-                   tvm::tir::IterVarType::kThreadIndex, thread_tag);
+  IterVar iter_var(Range{nullptr}, Var(std::move(name), dtype),
+                   tvm::tir::IterVarType::kThreadIndex, std::move(thread_tag));
   Var var = iter_var->var;
   if (Optional<PrimFuncFrame> opt_frame =
           IRBuilder::Current()->FindFrame<PrimFuncFrame>()) {
@@ -31,15 +33,15 @@ static Var CreateEnvThread(String name, String thread_tag, DataType dtype) {
   return var;
 }
 
-static ForFrame MakeIterVarFrame(std::string name, PrimExpr dom) {
+static ForFrame MakeIterVarFrame(const std::string& name, const PrimExpr& dom) {
   using namespace tvm::tir;
   Var var = Var(name, dom->dtype);
   // Create a frame that represents a loop over the given domain.
   ObjectPtr<ForFrameNode> n = make_object<ForFrameNode>();
   n->vars.push_back(var);
   n->doms.push_back(Range(0, dom));
-  n->f_make_for_loop = [](Array<Var> vars, Array<Range> doms,
-                          Stmt body) -> Stmt {
+  n->f_make_for_loop = [](const Array<Var> &vars, const Array<Range> &doms,
+                          const Stmt &body) -> Stmt {
     ICHECK_EQ(vars.size(), 1);
     ICHECK_EQ(doms.size(), 1);
     return For(vars[0], doms[0]->min, doms[0]->extent, ForKind::kSerial, body);
@@ -47,8 +49,8 @@ static ForFrame MakeIterVarFrame(std::string name, PrimExpr dom) {
   return ForFrame(n);
 }
 
-ForFrame ParallelFor(Array<PrimExpr> extents,
-                     Map<String, ObjectRef> annotations) {
+ForFrame ParallelFor(const Array<PrimExpr>& extents,
+                     const Map<String, ObjectRef>& annotations) {
   using namespace tvm::tir;
   ObjectPtr<ForFrameNode> n = make_object<ForFrameNode>();
   n->vars.reserve(extents.size());
@@ -58,7 +60,7 @@ ForFrame ParallelFor(Array<PrimExpr> extents,
     n->vars.push_back(Var("v", extent.dtype()));
     n->doms.push_back(Range(make_const(dtype, 0), extent));
   }
-  n->f_make_for_loop = [annotations](Array<Var> vars, Array<Range> doms,
+  n->f_make_for_loop = [annotations](const Array<Var> &vars, const Array<Range> &doms,
                                      Stmt body) -> Stmt {
     ICHECK_EQ(vars.size(), doms.size());
     int n = vars.size();
@@ -66,7 +68,7 @@ ForFrame ParallelFor(Array<PrimExpr> extents,
       Range dom = doms[i];
       Var var = vars[i];
       body =
-          For(var, dom->min, dom->extent, ForKind::kParallel, std::move(body),
+          For(var, dom->min, dom->extent, ForKind::kParallel, body,
               /*thread_binding=*/std::nullopt, /*annotations=*/annotations);
     }
     return body;
@@ -74,16 +76,16 @@ ForFrame ParallelFor(Array<PrimExpr> extents,
   return ForFrame(n);
 }
 
-ForFrame PipelinedFor(PrimExpr start, PrimExpr stop, int num_stages,
-                      Array<PrimExpr> order, Array<PrimExpr> stages,
-                      Array<Array<PrimExpr>> sync,
-                      Array<Array<PrimExpr>> groups) {
+ForFrame PipelinedFor(PrimExpr start, const PrimExpr& stop, int num_stages,
+                      const Array<PrimExpr>& order, const Array<PrimExpr>& stages,
+                      const Array<Array<PrimExpr>>& sync,
+                      const Array<Array<PrimExpr>>& groups) {
   using namespace tvm::tir;
   ObjectPtr<ForFrameNode> n = make_object<ForFrameNode>();
   DataType dtype = stop.dtype();
   n->vars.push_back(Var("v", dtype));
-  n->doms.push_back(Range(start, stop));
-  n->f_make_for_loop = [=](Array<Var> vars, Array<Range> doms,
+  n->doms.push_back(Range(std::move(start), stop));
+  n->f_make_for_loop = [=](const Array<Var> &vars, const Array<Range> &doms,
                            Stmt body) -> Stmt {
     ICHECK_EQ(vars.size(), doms.size());
     int n = vars.size();
@@ -91,26 +93,26 @@ ForFrame PipelinedFor(PrimExpr start, PrimExpr stop, int num_stages,
     Map<String, ObjectRef> anno;
     if (num_stages > 0)
       anno.Set("num_stages", PrimExpr(num_stages));
-    if (order.size() > 0)
+    if (!order.empty())
       anno.Set("tl_pipeline_order", order);
-    if (stages.size() > 0)
+    if (!stages.empty())
       anno.Set("tl_pipeline_stage", stages);
-    if (sync.size() > 0)
+    if (!sync.empty())
       anno.Set("tl_pipeline_sync", sync);
-    if (groups.size() > 0)
+    if (!groups.empty())
       anno.Set("tl_pipeline_group", groups);
     body = For(vars[0], doms[0]->min, doms[0]->extent, ForKind::kSerial,
-               std::move(body),
+               body,
                /*thread_binding=*/std::nullopt, /*annotations=*/anno);
     return body;
   };
   return ForFrame(n);
 }
 
-ForFrame PersistentFor(Array<PrimExpr> domain, PrimExpr wave_size,
-                       PrimExpr index, PrimExpr group_size) {
+ForFrame PersistentFor(const Array<PrimExpr>& domain, const PrimExpr& wave_size,
+                       const PrimExpr& index, PrimExpr group_size) {
   using namespace tvm::tir;
-  ICHECK(domain.size() > 0);
+  ICHECK(!domain.empty());
   ObjectPtr<ForFrameNode> n = make_object<ForFrameNode>();
   n->vars.reserve(domain.size());
   n->doms.reserve(domain.size());
@@ -139,8 +141,8 @@ ForFrame PersistentFor(Array<PrimExpr> domain, PrimExpr wave_size,
   }
   grouped_domain.push_back(group_size);
 
-  n->f_make_for_loop = [=](Array<Var> vars, Array<Range> doms,
-                           Stmt body) -> Stmt {
+  n->f_make_for_loop = [=](const Array<Var> &vars, const Array<Range> &doms,
+                           const Stmt &body) -> Stmt {
     ICHECK_EQ(vars.size(), doms.size());
     Map<String, ObjectRef> anno;
     Array<PrimExpr> idxs(grouped_domain.size(), PrimExpr());
@@ -220,9 +222,9 @@ public:
                                                     KernelLaunchFrameNode);
 };
 
-KernelLaunchFrame KernelLaunch(Array<PrimExpr> grid_size,
-                               Optional<Array<PrimExpr>> block_size_opt,
-                               Map<String, ffi::Any> attrs) {
+KernelLaunchFrame KernelLaunch(const Array<PrimExpr>& grid_size,
+                               const Optional<Array<PrimExpr>>& block_size_opt,
+                               const Map<String, ffi::Any>& attrs) {
   ObjectPtr<KernelLaunchFrameNode> n = make_object<KernelLaunchFrameNode>();
 
   // If the kernel is a CPU kernel, we don't need to launch any threads.
@@ -234,7 +236,7 @@ KernelLaunchFrame KernelLaunch(Array<PrimExpr> grid_size,
   if (is_cpu_kernel_frame) {
     // Launch CPU Kernel
     ICHECK(grid_size.size() >= 0);
-    ICHECK(block_size.size() == 0) << "CPU kernel cannot have block size";
+    ICHECK(block_size.empty()) << "CPU kernel cannot have block size";
     ICHECK(attrs.defined());
     // create grid loop var
     for (int i = 0; i < grid_size.size(); i++) {
@@ -244,7 +246,7 @@ KernelLaunchFrame KernelLaunch(Array<PrimExpr> grid_size,
   } else {
     // Launch GPU Kernel
     ICHECK(grid_size.size() <= 3);
-    if (grid_size.size() > 0)
+    if (!grid_size.empty())
       n->frames.push_back(LaunchThread(
           CreateEnvThread("bx", "blockIdx.x", grid_size[0].dtype()),
           grid_size[0]));
@@ -258,7 +260,7 @@ KernelLaunchFrame KernelLaunch(Array<PrimExpr> grid_size,
           grid_size[2]));
     if (block_size.defined()) {
       ICHECK(block_size.size() <= 3);
-      if (block_size.size() > 0) {
+      if (!block_size.empty()) {
         n->frames.push_back(LaunchThread(
             CreateEnvThread("tx", "threadIdx.x", block_size[0].dtype()),
             block_size[0]));
@@ -333,13 +335,14 @@ public:
                                                     WarpSpecializeFrameNode);
 };
 
-WarpSpecializeFrame WarpSpecialize(Array<IntImm> warp_group_ids,
-                                   PrimExpr thread_idx,
+WarpSpecializeFrame WarpSpecialize(const Array<IntImm>& warp_group_ids,
+                                   const PrimExpr& thread_idx,
                                    int warp_group_size = 128) {
   ObjectPtr<WarpSpecializeFrameNode> n = make_object<WarpSpecializeFrameNode>();
   PrimExpr condition;
   std::vector<int> warp_groups;
-  for (int i = 0; i < warp_group_ids.size(); i++) {
+  warp_groups.reserve(warp_group_ids.size());
+for (int i = 0; i < warp_group_ids.size(); i++) {
     warp_groups.push_back(Downcast<IntImm>(warp_group_ids[i])->value);
   }
   std::sort(warp_groups.begin(), warp_groups.end());

--- a/src/op/atomic_add.h
+++ b/src/op/atomic_add.h
@@ -17,8 +17,6 @@ using namespace tir;
 
 class AtomicAddNode : public TileOperatorNode {
 public:
-  Array<PrimExpr> args_;
-
   Buffer src, dst;
   Array<Range> src_range, dst_range;
   IntImm coalesced_width;

--- a/src/op/copy.h
+++ b/src/op/copy.h
@@ -96,8 +96,6 @@ struct TMAIm2ColDesc {
  */
 class CopyNode : public TileOperatorNode {
 public:
-  Array<PrimExpr> args_; // Copy parameters (indices, sizes, etc.)
-
   Buffer src, dst;                   // Source and destination buffers
   Array<Range> src_range, dst_range; // Ranges for each dimension in src and dst
   IntImm coalesced_width; // Width (in elements) for coalesced memory access

--- a/src/op/copy.h
+++ b/src/op/copy.h
@@ -21,7 +21,7 @@ using namespace tir;
 /*!
  * \brief Copy instruction type.
  */
-enum class CopyInst {
+enum class CopyInst : uint8_t {
   kNormal = 0,    // utilize ldg/stg or cpasync or any buffer copy
   kLDSM = 1,      // ldmatrix memory copy
   kSTSM = 2,      // stmatrix memory copy
@@ -105,13 +105,13 @@ public:
 
   mutable ParallelOp par_op_; // Optional associated parallelization operator
 
-  enum class EvictionPolicy {
+  enum class EvictionPolicy : uint8_t {
     kEvictNormal = 0,
     kEvictFirst = 1,
     kEvictLast = 2,
   };
 
-  int eviction_policy; // Policy for cache eviction
+  uint8_t eviction_policy; // Policy for cache eviction
   static constexpr const char *_type_key = "tl.Copy";
   TVM_DECLARE_FINAL_OBJECT_INFO(CopyNode, TileOperatorNode);
 

--- a/src/op/gemm.h
+++ b/src/op/gemm.h
@@ -14,7 +14,7 @@ namespace tl {
 
 using namespace tir;
 
-enum class GemmWarpPolicy {
+enum class GemmWarpPolicy : uint8_t {
   kSquare = 0,
   kFullRow = 1,
   kFullCol = 2,
@@ -49,7 +49,7 @@ public:
 
 private:
   // Target GEMM instruction
-  enum class GemmInst { kMMA, kWGMMA, kUTCMMA, kMFMA };
+  enum class GemmInst : uint8_t { kMMA, kWGMMA, kUTCMMA, kMFMA };
   GemmInst GetGemmInst(int block_size, Target target) const;
 
   std::pair<int, int> ComputeWarpPartition(int num_warps, GemmInst gemm_inst,

--- a/src/op/gemm_sp.h
+++ b/src/op/gemm_sp.h
@@ -18,7 +18,7 @@ class GemmSPNode : public TileOperatorNode {
 public:
   Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const;
   LayoutMap InferLayout(const LayoutInferArgs &T, InferLevel level) const;
-  enum class GemmWarpPolicy {
+  enum class GemmWarpPolicy : uint8_t {
     kSquare = 0,
     kFullRow = 1,
     kFullCol = 2,

--- a/src/op/operator.h
+++ b/src/op/operator.h
@@ -11,8 +11,8 @@
 #include <tvm/ir/op.h>
 #include <tvm/target/target.h>
 #include <tvm/tir/buffer.h>
-#include <tvm/tir/stmt.h>
 #include <tvm/tir/op_attr_types.h>
+#include <tvm/tir/stmt.h>
 
 #include "../layout/layout.h"
 
@@ -51,32 +51,32 @@ struct LayoutInferArgs {
 class TileOperatorNode;
 class TileOperator;
 
-class TileOperatorNode: public Object {
- public:
+class TileOperatorNode : public Object {
+public:
   virtual Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const = 0;
 
-  virtual LayoutMap InferLayout(const LayoutInferArgs& T,
+  virtual LayoutMap InferLayout(const LayoutInferArgs &T,
                                 InferLevel level) const = 0;
 
   virtual TileOperator Clone() const = 0;
 
-  static constexpr const char* _type_key = "tl.TileOperator";
+  static constexpr const char *_type_key = "tl.TileOperator";
 
   TVM_DECLARE_BASE_OBJECT_INFO(TileOperatorNode, Object);
 };
 
 class TileOperator : public ObjectRef {
-  public:
-   TVM_DEFINE_OBJECT_REF_METHODS(TileOperator, ObjectRef, TileOperatorNode);
+public:
+  TVM_DEFINE_OBJECT_REF_METHODS(TileOperator, ObjectRef, TileOperatorNode);
 };
-
 
 Var GetVarFromAccessPtr(const PrimExpr &expr);
 
 TileOperator ParseOperator(Call call, BufferMap vmap);
 TileOperator ParseOperator(Stmt stmt, BufferMap vmap);
 
-using OpBuilderFunc = ffi::TypedFunction<TileOperator(Array<PrimExpr>, BufferMap)>;
+using OpBuilderFunc =
+    ffi::TypedFunction<TileOperator(Array<PrimExpr>, BufferMap)>;
 
 #define TIR_REGISTER_TL_OP(Entry, OpName)                                      \
   const Op &Entry::Get() {                                                     \
@@ -86,10 +86,9 @@ using OpBuilderFunc = ffi::TypedFunction<TileOperator(Array<PrimExpr>, BufferMap
   TVM_REGISTER_OP("tl." #OpName)                                               \
       .set_attr<TScriptPrinterName>("TScriptPrinterName", #OpName)             \
       .set_attr<OpBuilderFunc>("TLOpBuilder",                                  \
-                               [](Array<PrimExpr> args, BufferMap vmap) {            \
-                                 return Entry(args, vmap);                          \
+                               [](Array<PrimExpr> args, BufferMap vmap) {      \
+                                 return Entry(args, vmap);                     \
                                })
-
 
 } // namespace tl
 } // namespace tvm

--- a/src/op/operator.h
+++ b/src/op/operator.h
@@ -25,7 +25,7 @@ using AddWorkspaceCallback = std::function<PrimExpr(int, DataType)>;
 using LayoutMap = Map<Buffer, Layout>;
 using BufferMap = Map<Var, Buffer>;
 
-enum class InferLevel {
+enum class InferLevel : uint8_t {
   kFree = 0,
   kCommon = 1,
   kStrict = 2,

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -192,7 +192,7 @@ private:
   // Check if the buffer is accessed with common indices (i.e., loop variables).
   bool IsCommonAccessIndice(const Buffer &buffer) const;
   // Add a predicate to the current predicate expression.
-  void AddPredicate(const PrimExpr &&expr) const {
+  void AddPredicate(const PrimExpr &expr) const {
     predicate_ = predicate_.defined() ? And(expr, predicate_.value()) : expr;
   }
   // Allow ParallelLoopNestVisitor to access private members.
@@ -218,7 +218,7 @@ class ParallelOp : public TileOperator {
 public:
   TVM_DEFINE_OBJECT_REF_METHODS(ParallelOp, TileOperator, ParallelOpNode);
 
-  ParallelOp(const For &&root) {
+  ParallelOp(const For &root) {
     auto op = make_object<ParallelOpNode>(root);
     data_ = std::move(op);
   }

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -86,7 +86,7 @@ public:
   Optional<PrimExpr> GetPredicate(Var thread_var) const;
 
   // Clone this operator.
-  TileOperator Clone() const;
+  TileOperator Clone() const override;
 
 private:
   // Complete the fragment layout for a given buffer.

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -94,7 +94,7 @@ private:
   // Check if the buffer is accessed with common indices (i.e., loop variables).
   bool IsCommonAccessIndice(const Buffer &buffer) const;
   // Add a predicate to the current predicate expression.
-  void AddPredicate(const PrimExpr&& expr) const {
+  void AddPredicate(const PrimExpr &&expr) const {
     predicate_ = predicate_.defined() ? And(expr, predicate_.value()) : expr;
   }
   // Allow ParallelLoopNestVisitor to access private members.
@@ -118,7 +118,7 @@ class ParallelOp : public TileOperator {
 public:
   TVM_DEFINE_OBJECT_REF_METHODS(ParallelOp, TileOperator, ParallelOpNode);
 
-  ParallelOp(const For&& root) {
+  ParallelOp(const For &&root) {
     auto op = make_object<ParallelOpNode>(root);
     data_ = std::move(op);
   }

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -94,7 +94,7 @@ private:
   // Check if the buffer is accessed with common indices (i.e., loop variables).
   bool IsCommonAccessIndice(const Buffer &buffer) const;
   // Add a predicate to the current predicate expression.
-  void AddPredicate(PrimExpr expr) const {
+  void AddPredicate(const PrimExpr&& expr) const {
     predicate_ = predicate_.defined() ? And(expr, predicate_.value()) : expr;
   }
   // Allow ParallelLoopNestVisitor to access private members.
@@ -118,7 +118,7 @@ class ParallelOp : public TileOperator {
 public:
   TVM_DEFINE_OBJECT_REF_METHODS(ParallelOp, TileOperator, ParallelOpNode);
 
-  ParallelOp(For root) {
+  ParallelOp(const For&& root) {
     auto op = make_object<ParallelOpNode>(root);
     data_ = std::move(op);
   }

--- a/src/op/reduce.h
+++ b/src/op/reduce.h
@@ -14,7 +14,7 @@ namespace tl {
 
 using namespace tir;
 
-enum class ReduceType {
+enum class ReduceType : uint8_t {
   kSum,
   kAbsSum,
   kMax,

--- a/src/op/region.h
+++ b/src/op/region.h
@@ -36,7 +36,7 @@ public:
   int GetAccessMask() const { return access_mask_; }
   bool IsFullRegion() const;
 
-  TileOperator Clone() const;
+  TileOperator Clone() const override;
 };
 
 class RegionOp : public TileOperator {

--- a/src/transform/align_dynamic_shared_memory_allocations.cc
+++ b/src/transform/align_dynamic_shared_memory_allocations.cc
@@ -25,7 +25,7 @@ public:
   explicit TileLangAlignDynamicSharedMemoryAllocations(int align_bytes)
       : align_bytes_(align_bytes) {}
 
-  static Stmt Substitute(int align_bytes, Stmt stmt) {
+  static Stmt Substitute(int align_bytes, const Stmt& stmt) {
     TileLangAlignDynamicSharedMemoryAllocations smem_rewriter(align_bytes);
     return smem_rewriter.VisitStmt(stmt);
   }
@@ -138,7 +138,7 @@ private:
 
 tvm::transform::Pass AlignDynamicSharedMemoryAllocations(int align_bytes) {
   using namespace tir::transform;
-  auto pass_func = [align_bytes](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [align_bytes](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     auto *n = f.CopyOnWrite();
     n->body = TileLangAlignDynamicSharedMemoryAllocations::Substitute(
         align_bytes, n->body);

--- a/src/transform/align_dynamic_shared_memory_allocations.cc
+++ b/src/transform/align_dynamic_shared_memory_allocations.cc
@@ -25,7 +25,7 @@ public:
   explicit TileLangAlignDynamicSharedMemoryAllocations(int align_bytes)
       : align_bytes_(align_bytes) {}
 
-  static Stmt Substitute(int align_bytes, const Stmt& stmt) {
+  static Stmt Substitute(int align_bytes, const Stmt &stmt) {
     TileLangAlignDynamicSharedMemoryAllocations smem_rewriter(align_bytes);
     return smem_rewriter.VisitStmt(stmt);
   }
@@ -138,7 +138,8 @@ private:
 
 tvm::transform::Pass AlignDynamicSharedMemoryAllocations(int align_bytes) {
   using namespace tir::transform;
-  auto pass_func = [align_bytes](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [align_bytes](PrimFunc f, const IRModule &m,
+                                 const PassContext &ctx) {
     auto *n = f.CopyOnWrite();
     n->body = TileLangAlignDynamicSharedMemoryAllocations::Substitute(
         align_bytes, n->body);

--- a/src/transform/annotate_device_regions.cc
+++ b/src/transform/annotate_device_regions.cc
@@ -66,8 +66,8 @@ private:
 
 tvm::transform::Pass AnnotateDeviceRegions() {
   using namespace tir::transform;
-  auto pass_func = [](PrimFunc func, const IRModule& mod,
-                      const tvm::transform::PassContext& ctx) -> PrimFunc {
+  auto pass_func = [](PrimFunc func, const IRModule &mod,
+                      const tvm::transform::PassContext &ctx) -> PrimFunc {
     auto opt_target = func->GetAttr<Target>(tvm::attr::kTarget);
     ICHECK(opt_target) << "AnnotateDeviceRegions: Require the target attribute";
     Target target = opt_target.value();

--- a/src/transform/annotate_device_regions.cc
+++ b/src/transform/annotate_device_regions.cc
@@ -31,6 +31,8 @@
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/tir/transform.h>
 
+#include <utility>
+
 namespace tvm {
 namespace tl {
 
@@ -39,7 +41,7 @@ using namespace tir;
 class DeviceRegionAnnotater : public StmtMutator {
 public:
   explicit DeviceRegionAnnotater(Target device_target)
-      : device_target_(device_target) {}
+      : device_target_(std::move(device_target)) {}
 
   Stmt VisitStmt_(const AttrStmtNode *op) final {
     if (op->attr_key == tvm::attr::kTarget) {
@@ -64,8 +66,8 @@ private:
 
 tvm::transform::Pass AnnotateDeviceRegions() {
   using namespace tir::transform;
-  auto pass_func = [](PrimFunc func, IRModule mod,
-                      tvm::transform::PassContext ctx) -> PrimFunc {
+  auto pass_func = [](PrimFunc func, const IRModule& mod,
+                      const tvm::transform::PassContext& ctx) -> PrimFunc {
     auto opt_target = func->GetAttr<Target>(tvm::attr::kTarget);
     ICHECK(opt_target) << "AnnotateDeviceRegions: Require the target attribute";
     Target target = opt_target.value();

--- a/src/transform/annotate_warp_group_reg_alloc.cc
+++ b/src/transform/annotate_warp_group_reg_alloc.cc
@@ -110,12 +110,14 @@ private:
       bool has_simt_copy = false; // Placeholder
 
       if (dec_reg >= 0 && inc_reg >= 0 && !has_simt_copy) {
-        auto inc_reg_num = IntImm(DataType::Int(32), inc_reg == 0 ? 240 : inc_reg);
-        auto dec_reg_num = IntImm(DataType::Int(32), dec_reg == 0 ? 24 : dec_reg);
-        inc_reg_stmt = Evaluate(Call(DataType::Handle(), set_max_nreg(),
-                                     {inc_reg_num, 1}));
-        dec_reg_stmt = Evaluate(Call(DataType::Handle(), set_max_nreg(),
-                                     {dec_reg_num, 0}));
+        auto inc_reg_num =
+            IntImm(DataType::Int(32), inc_reg == 0 ? 240 : inc_reg);
+        auto dec_reg_num =
+            IntImm(DataType::Int(32), dec_reg == 0 ? 24 : dec_reg);
+        inc_reg_stmt = Evaluate(
+            Call(DataType::Handle(), set_max_nreg(), {inc_reg_num, 1}));
+        dec_reg_stmt = Evaluate(
+            Call(DataType::Handle(), set_max_nreg(), {dec_reg_num, 0}));
       }
 
       // Inject register setting statements
@@ -148,7 +150,8 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass AnnotateWarpGroupRegAlloc() {
-  auto pass_func = [](PrimFunc f, const IRModule& m, const PassContext& ctx) -> PrimFunc {
+  auto pass_func = [](PrimFunc f, const IRModule &m,
+                      const PassContext &ctx) -> PrimFunc {
     return SetMaxNRegInjector::Inject(std::move(f));
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.AnnotateWarpGroupRegAlloc", {});

--- a/src/transform/annotate_warp_group_reg_alloc.cc
+++ b/src/transform/annotate_warp_group_reg_alloc.cc
@@ -7,6 +7,7 @@
 #include <tvm/tir/transform.h>
 
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "../op/builtin.h"
@@ -145,8 +146,8 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass AnnotateWarpGroupRegAlloc() {
-  auto pass_func = [](PrimFunc f, IRModule m, PassContext ctx) -> PrimFunc {
-    return SetMaxNRegInjector::Inject(f);
+  auto pass_func = [](PrimFunc f, const IRModule& m, const PassContext& ctx) -> PrimFunc {
+    return SetMaxNRegInjector::Inject(std::move(f));
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.AnnotateWarpGroupRegAlloc", {});
 }

--- a/src/transform/annotate_warp_group_reg_alloc.cc
+++ b/src/transform/annotate_warp_group_reg_alloc.cc
@@ -33,8 +33,8 @@ private:
   void VisitStmt_(const EvaluateNode *op) final {
     if (const CallNode *call = op->value.as<CallNode>()) {
       if (call->op.same_as(set_max_nreg())) {
-        int reg_hint = call->args[0].as<IntImmNode>()->value;
-        int is_inc = call->args[1].as<IntImmNode>()->value;
+        auto reg_hint = call->args[0].as<IntImmNode>()->value;
+        auto is_inc = call->args[1].as<IntImmNode>()->value;
         ICHECK(reg_hint <= 240 && reg_hint >= 24)
             << "Invalid reg hint: " << reg_hint;
         ICHECK(is_inc == 0 || is_inc == 1) << "Invalid is_inc: " << is_inc;
@@ -98,8 +98,8 @@ private:
       Optional<Stmt> consumer_body = if_then_else->else_case;
       ICHECK(consumer_body.defined()) << "Consumer body is undefined";
 
-      int dec_reg = nreg_[0].as<IntImmNode>()->value;
-      int inc_reg = nreg_[1].as<IntImmNode>()->value;
+      auto dec_reg = nreg_[0].as<IntImmNode>()->value;
+      auto inc_reg = nreg_[1].as<IntImmNode>()->value;
 
       auto inc_reg_stmt = Evaluate(0);
       auto dec_reg_stmt = Evaluate(0);
@@ -110,10 +110,12 @@ private:
       bool has_simt_copy = false; // Placeholder
 
       if (dec_reg >= 0 && inc_reg >= 0 && !has_simt_copy) {
+        auto inc_reg_num = IntImm(DataType::Int(32), inc_reg == 0 ? 240 : inc_reg);
+        auto dec_reg_num = IntImm(DataType::Int(32), dec_reg == 0 ? 24 : dec_reg);
         inc_reg_stmt = Evaluate(Call(DataType::Handle(), set_max_nreg(),
-                                     {inc_reg == 0 ? 240 : inc_reg, 1}));
+                                     {inc_reg_num, 1}));
         dec_reg_stmt = Evaluate(Call(DataType::Handle(), set_max_nreg(),
-                                     {dec_reg == 0 ? 24 : dec_reg, 0}));
+                                     {dec_reg_num, 0}));
       }
 
       // Inject register setting statements

--- a/src/transform/atomicadd_vectorize.cc
+++ b/src/transform/atomicadd_vectorize.cc
@@ -80,7 +80,7 @@ private:
     return arith::IRVisitorWithAnalyzer::VisitExpr_(node);
   }
 
-  void UpdateVectorSize(const Array<PrimExpr>& indices, const Buffer &buffer) {
+  void UpdateVectorSize(const Array<PrimExpr> &indices, const Buffer &buffer) {
     if (!inner_for_)
       return;
     auto extent_ptr = inner_for_->extent.as<IntImmNode>();
@@ -126,7 +126,8 @@ private:
       // dynamic shape load: get the vectorization condition
       dynamic_ = true;
       PrimExpr offset = buffer.OffsetOf(indices).back();
-      condition_ = (FloorMod(offset, IntImm(DataType::Int(32), vector_size_)) == 0);
+      condition_ =
+          (FloorMod(offset, IntImm(DataType::Int(32), vector_size_)) == 0);
     }
   }
 
@@ -142,7 +143,7 @@ private:
 
 class AtomicAddVectorizeRewriter : public StmtExprMutator {
 public:
-  AtomicAddVectorizeRewriter(const AtomicAddVectorizePlanResult& plan)
+  AtomicAddVectorizeRewriter(const AtomicAddVectorizePlanResult &plan)
       : vector_size_(plan.vector_size), condition_(plan.condition),
         dynamic_(plan.dynamic) {}
 
@@ -291,7 +292,8 @@ For VectorizeAtomicAdd(const For &for_node, Var thread_var, Range thread_bounds,
     int vectorize_hint = vectorize_size_max;
     AtomicAddVectorizePlanResult res = {1, false, 0};
     AtomicAddVectorizePlanner planner;
-    res = planner.Plan(for_node, std::move(thread_var), std::move(thread_bounds), vectorize_hint);
+    res = planner.Plan(for_node, std::move(thread_var),
+                       std::move(thread_bounds), vectorize_hint);
     vectorize_hint = res.vector_size;
 
     if (vectorize_hint == 1)

--- a/src/transform/atomicadd_vectorize.h
+++ b/src/transform/atomicadd_vectorize.h
@@ -14,8 +14,8 @@ namespace tl {
 
 using namespace tir;
 
-For VectorizeAtomicAdd(const For &for_node, Var thread_var, Range thread_bounds,
-                       int compute_capability);
+For VectorizeAtomicAdd(const For &for_node, const Var &thread_var,
+                       const Range &thread_bounds, int compute_capability);
 
 } // namespace tl
 } // namespace tvm

--- a/src/transform/cluster_planning.cc
+++ b/src/transform/cluster_planning.cc
@@ -66,18 +66,18 @@ public:
     }
 
     if (mem_reuse_max > 0) {
-        std::string tag_str = cluster_tag; // Convert to std::string
-        if (tag_str.rfind("blockIdx", 0) == 0) {
-            // starts with "blockIdx"
-            tag_str = "clusterIdx" + tag_str.substr(strlen("blockIdx"));
-        } else {
-            // Unexpected format — maybe just prefix
-            tag_str = "clusterIdx" + tag_str;
-        }
-        cluster_tag = tvm::ffi::String(tag_str); // Convert back
-        return WithAttr(f, cluster_tag, Integer(cluster_size_));
+      std::string tag_str = cluster_tag; // Convert to std::string
+      if (tag_str.rfind("blockIdx", 0) == 0) {
+        // starts with "blockIdx"
+        tag_str = "clusterIdx" + tag_str.substr(strlen("blockIdx"));
+      } else {
+        // Unexpected format — maybe just prefix
+        tag_str = "clusterIdx" + tag_str;
+      }
+      cluster_tag = tvm::ffi::String(tag_str); // Convert back
+      return WithAttr(f, cluster_tag, Integer(cluster_size_));
     } else {
-        return f;
+      return f;
     }
   }
 
@@ -116,7 +116,7 @@ PrimFunc ClusterPlanning(PrimFunc f) { return ClusterPlanner::Substitute(f); }
 namespace transform {
 
 tvm::transform::Pass ClusterPlanning() {
-  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     return ClusterPlanning(std::move(f));
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.ClusterPlanning", {});

--- a/src/transform/cluster_planning.cc
+++ b/src/transform/cluster_planning.cc
@@ -66,11 +66,18 @@ public:
     }
 
     if (mem_reuse_max > 0) {
-      cluster_tag =
-          "clusterIdx" + String(cluster_tag.c_str() + strlen("blockIdx"));
-      return WithAttr(f, cluster_tag, Integer(cluster_size_));
+        std::string tag_str = cluster_tag; // Convert to std::string
+        if (tag_str.rfind("blockIdx", 0) == 0) {
+            // starts with "blockIdx"
+            tag_str = "clusterIdx" + tag_str.substr(strlen("blockIdx"));
+        } else {
+            // Unexpected format — maybe just prefix
+            tag_str = "clusterIdx" + tag_str;
+        }
+        cluster_tag = tvm::ffi::String(tag_str); // Convert back
+        return WithAttr(f, cluster_tag, Integer(cluster_size_));
     } else {
-      return f;
+        return f;
     }
   }
 

--- a/src/transform/cluster_planning.cc
+++ b/src/transform/cluster_planning.cc
@@ -109,7 +109,7 @@ PrimFunc ClusterPlanning(PrimFunc f) { return ClusterPlanner::Substitute(f); }
 namespace transform {
 
 tvm::transform::Pass ClusterPlanning() {
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     return ClusterPlanning(std::move(f));
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.ClusterPlanning", {});

--- a/src/transform/common/loop_fusion_utils.h
+++ b/src/transform/common/loop_fusion_utils.h
@@ -45,7 +45,7 @@ class FragmentAccessDetector : public StmtExprVisitor {
 public:
   FragmentAccessDetector() = default;
 
-  void Collect(Stmt stmt) { VisitStmt(stmt); }
+  void Collect(const Stmt& stmt) { VisitStmt(stmt); }
 
   bool HasFragmentAccess() { return has_fragment_access_; }
 
@@ -91,7 +91,7 @@ private:
  */
 class ParallelLoopFuser : public IRMutatorWithAnalyzer {
 public:
-  static Stmt Fuse(Stmt stmt) {
+  static Stmt Fuse(const Stmt& stmt) {
     arith::Analyzer analyzer;
     ParallelLoopFuser substituter(&analyzer);
     return substituter.VisitStmt(stmt);

--- a/src/transform/common/loop_fusion_utils.h
+++ b/src/transform/common/loop_fusion_utils.h
@@ -45,7 +45,7 @@ class FragmentAccessDetector : public StmtExprVisitor {
 public:
   FragmentAccessDetector() = default;
 
-  void Collect(const Stmt& stmt) { VisitStmt(stmt); }
+  void Collect(const Stmt &stmt) { VisitStmt(stmt); }
 
   bool HasFragmentAccess() { return has_fragment_access_; }
 
@@ -91,7 +91,7 @@ private:
  */
 class ParallelLoopFuser : public IRMutatorWithAnalyzer {
 public:
-  static Stmt Fuse(const Stmt& stmt) {
+  static Stmt Fuse(const Stmt &stmt) {
     arith::Analyzer analyzer;
     ParallelLoopFuser substituter(&analyzer);
     return substituter.VisitStmt(stmt);

--- a/src/transform/common/loop_parallel_transform_utils.h
+++ b/src/transform/common/loop_parallel_transform_utils.h
@@ -26,7 +26,7 @@ using arith::IRVisitorWithAnalyzer;
 
 class ParallelLoopTransformer : public IRMutatorWithAnalyzer {
 public:
-  static Stmt Substitute(Stmt stmt, bool skip_thread_partition = false) {
+  static Stmt Substitute(const Stmt& stmt, bool skip_thread_partition = false) {
     arith::Analyzer analyzer;
     ParallelLoopTransformer transformer(&analyzer);
     return transformer.VisitStmt(stmt);
@@ -86,7 +86,7 @@ public:
             used_vars.insert(GetRef<Var>(v));
           }
         });
-        if (used_vars.size() == 0) {
+        if (used_vars.empty()) {
           continue;
         }
 

--- a/src/transform/common/loop_parallel_transform_utils.h
+++ b/src/transform/common/loop_parallel_transform_utils.h
@@ -26,7 +26,7 @@ using arith::IRVisitorWithAnalyzer;
 
 class ParallelLoopTransformer : public IRMutatorWithAnalyzer {
 public:
-  static Stmt Substitute(const Stmt& stmt, bool skip_thread_partition = false) {
+  static Stmt Substitute(const Stmt &stmt, bool skip_thread_partition = false) {
     arith::Analyzer analyzer;
     ParallelLoopTransformer transformer(&analyzer);
     return transformer.VisitStmt(stmt);

--- a/src/transform/common/loop_parallel_transform_utils.h
+++ b/src/transform/common/loop_parallel_transform_utils.h
@@ -75,8 +75,6 @@ public:
       for (size_t i = 0; i < indices.size(); ++i) {
         auto index = indices[i];
         auto bound = analyzer_->const_int_bound(index);
-        int64_t upper_bound = bound->max_value + 1;
-        int64_t shape = Downcast<IntImm>(buffer->shape[i])->value;
 
         // Collect the variables that used in the index
         std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> used_vars;

--- a/src/transform/common/loop_vectorization_utils.h
+++ b/src/transform/common/loop_vectorization_utils.h
@@ -177,7 +177,8 @@ public:
   using ExprFunctor::VisitExpr;
   using StmtMutator::operator();
 
-  Vectorizer(const Var& var, const PrimExpr& var_lanes) : var_(var), var_lanes_(var_lanes) {
+  Vectorizer(const Var &var, const PrimExpr &var_lanes)
+      : var_(var), var_lanes_(var_lanes) {
     ramp_ = Ramp(IntImm(var->dtype, 0), IntImm(var->dtype, 1), var_lanes);
   }
 
@@ -197,11 +198,13 @@ public:
   }
 
   PrimExpr VisitExpr_(const AddNode *op) final {
-    return AddSubVec(op, [](PrimExpr a, PrimExpr b) { return std::move(a) + std::move(b); });
+    return AddSubVec(
+        op, [](PrimExpr a, PrimExpr b) { return std::move(a) + std::move(b); });
   }
 
   PrimExpr VisitExpr_(const SubNode *op) final {
-    return AddSubVec(op, [](PrimExpr a, PrimExpr b) { return std::move(a) - std::move(b); });
+    return AddSubVec(
+        op, [](PrimExpr a, PrimExpr b) { return std::move(a) - std::move(b); });
   }
 
   PrimExpr VisitExpr_(const MulNode *op) final {

--- a/src/transform/common/loop_vectorization_utils.h
+++ b/src/transform/common/loop_vectorization_utils.h
@@ -29,6 +29,7 @@
 #include <tvm/tir/utils.h>
 
 #include <queue>
+#include <utility>
 
 #include "../../op/parallel.h"
 #include "../loop_partition.h"
@@ -86,7 +87,7 @@ inline PrimExpr BroadcastTo(PrimExpr e, int lanes, bool is_scalable) {
 class VecAllocAccess : public StmtExprMutator {
 public:
   VecAllocAccess(const VarNode *buf, Var var, PrimExpr var_lanes)
-      : buf_(buf), var_(var), var_lanes_(var_lanes) {}
+      : buf_(buf), var_(std::move(var)), var_lanes_(std::move(var_lanes)) {}
 
   PrimExpr VisitExpr_(const BufferLoadNode *op) final {
     auto load = Downcast<BufferLoad>(StmtExprMutator::VisitExpr_(op));
@@ -176,7 +177,7 @@ public:
   using ExprFunctor::VisitExpr;
   using StmtMutator::operator();
 
-  Vectorizer(Var var, PrimExpr var_lanes) : var_(var), var_lanes_(var_lanes) {
+  Vectorizer(const Var& var, const PrimExpr& var_lanes) : var_(var), var_lanes_(var_lanes) {
     ramp_ = Ramp(IntImm(var->dtype, 0), IntImm(var->dtype, 1), var_lanes);
   }
 
@@ -196,11 +197,11 @@ public:
   }
 
   PrimExpr VisitExpr_(const AddNode *op) final {
-    return AddSubVec(op, [](PrimExpr a, PrimExpr b) { return a + b; });
+    return AddSubVec(op, [](PrimExpr a, PrimExpr b) { return std::move(a) + std::move(b); });
   }
 
   PrimExpr VisitExpr_(const SubNode *op) final {
-    return AddSubVec(op, [](PrimExpr a, PrimExpr b) { return a - b; });
+    return AddSubVec(op, [](PrimExpr a, PrimExpr b) { return std::move(a) - std::move(b); });
   }
 
   PrimExpr VisitExpr_(const MulNode *op) final {
@@ -704,7 +705,7 @@ private:
   // mutate array, with given lane requirement
   // when finished, p_lane updates the lane requirement.
   Array<PrimExpr> MutateArray(Array<PrimExpr> arr, int *p_lanes) {
-    if (arr.size() == 0)
+    if (arr.empty())
       return arr;
     int &lanes = *p_lanes;
     bool changed = false;

--- a/src/transform/common/thread_sync_types.h
+++ b/src/transform/common/thread_sync_types.h
@@ -24,7 +24,7 @@ struct ThreadBoundKey {
 // Number of threads syncing using the barrier must be a multiple of warp-size
 // ID 0 should not be used for safety, as other driver APIs (i.e. __syncthreads)
 // may use it and conflict with other uses.
-enum class ReservedNamedBarriers {
+enum class ReservedNamedBarriers : uint8_t {
   kSyncThreads = 0,
   kReduce_0 = 1,
   kReduce_1 = 2,

--- a/src/transform/config_index_bitwidth.cc
+++ b/src/transform/config_index_bitwidth.cc
@@ -18,7 +18,7 @@ public:
   ConfigIndexBitwidthRewriter(int index_bitwidth)
       : _index_bitwidth_(index_bitwidth) {}
 
-  Stmt operator()(const Stmt& s) { return VisitStmt(s); }
+  Stmt operator()(const Stmt &s) { return VisitStmt(s); }
 
 protected:
   using Parent::VisitExpr_;
@@ -73,7 +73,7 @@ protected:
 class IndexLegalizer : public IRMutatorWithAnalyzer {
 
 public:
-  static Stmt Rewrite(const Stmt& stmt) {
+  static Stmt Rewrite(const Stmt &stmt) {
     Analyzer ana;
     auto pass = IndexLegalizer(&ana);
     return pass.VisitStmt(stmt);
@@ -158,7 +158,7 @@ private:
 
 tvm::transform::Pass ConfigIndexBitwidth() {
   using namespace tir::transform;
-  auto pass_func = [](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     auto *n = f.CopyOnWrite();
     // Get pass config `tl.config_index_bitwidth`
     tvm::transform::PassContext ctxt = tvm::transform::PassContext::Current();
@@ -166,8 +166,7 @@ tvm::transform::Pass ConfigIndexBitwidth() {
         ctxt->GetConfig(kConfigIndexBitwidth, Optional<Integer>());
     if (opt_config_index_bitwidth.defined()) {
       int config_index_bitwidth = opt_config_index_bitwidth.value()->value;
-      n->body = ConfigIndexBitwidthRewriter(config_index_bitwidth)(
-          n->body);
+      n->body = ConfigIndexBitwidthRewriter(config_index_bitwidth)(n->body);
     }
     // Legalize out-of-bound indices to be int64
     n->body = IndexLegalizer::Rewrite(n->body);

--- a/src/transform/config_index_bitwidth.cc
+++ b/src/transform/config_index_bitwidth.cc
@@ -18,7 +18,7 @@ public:
   ConfigIndexBitwidthRewriter(int index_bitwidth)
       : _index_bitwidth_(index_bitwidth) {}
 
-  Stmt operator()(Stmt s) { return VisitStmt(s); }
+  Stmt operator()(const Stmt& s) { return VisitStmt(s); }
 
 protected:
   using Parent::VisitExpr_;
@@ -73,7 +73,7 @@ protected:
 class IndexLegalizer : public IRMutatorWithAnalyzer {
 
 public:
-  static Stmt Rewrite(Stmt stmt) {
+  static Stmt Rewrite(const Stmt& stmt) {
     Analyzer ana;
     auto pass = IndexLegalizer(&ana);
     return pass.VisitStmt(stmt);
@@ -158,7 +158,7 @@ private:
 
 tvm::transform::Pass ConfigIndexBitwidth() {
   using namespace tir::transform;
-  auto pass_func = [](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     auto *n = f.CopyOnWrite();
     // Get pass config `tl.config_index_bitwidth`
     tvm::transform::PassContext ctxt = tvm::transform::PassContext::Current();
@@ -167,10 +167,10 @@ tvm::transform::Pass ConfigIndexBitwidth() {
     if (opt_config_index_bitwidth.defined()) {
       int config_index_bitwidth = opt_config_index_bitwidth.value()->value;
       n->body = ConfigIndexBitwidthRewriter(config_index_bitwidth)(
-          std::move(n->body));
+          n->body);
     }
     // Legalize out-of-bound indices to be int64
-    n->body = IndexLegalizer::Rewrite(std::move(n->body));
+    n->body = IndexLegalizer::Rewrite(n->body);
     return f;
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.ConfigIndexBitwidth", {});

--- a/src/transform/eliminate_storage_sync_for_mbarrier.cc
+++ b/src/transform/eliminate_storage_sync_for_mbarrier.cc
@@ -22,7 +22,7 @@ using arith::IRVisitorWithAnalyzer;
 
 class Eliminator : public IRMutatorWithAnalyzer {
 public:
-  static Stmt Substitute(Stmt stmt, bool skip_thread_partition = false) {
+  static Stmt Substitute(const Stmt& stmt, bool skip_thread_partition = false) {
     arith::Analyzer analyzer;
     Eliminator transformer(&analyzer);
     return transformer.VisitStmt(stmt);
@@ -107,9 +107,9 @@ using namespace tir::transform;
 namespace transform {
 
 tvm::transform::Pass EliminateStorageSyncForMBarrier() {
-  auto pass_func = [](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     auto *n = f.CopyOnWrite();
-    n->body = Eliminator::Substitute(std::move(n->body));
+    n->body = Eliminator::Substitute(n->body);
     return f;
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.EliminateStorageSyncForMBarrier",

--- a/src/transform/eliminate_storage_sync_for_mbarrier.cc
+++ b/src/transform/eliminate_storage_sync_for_mbarrier.cc
@@ -22,7 +22,7 @@ using arith::IRVisitorWithAnalyzer;
 
 class Eliminator : public IRMutatorWithAnalyzer {
 public:
-  static Stmt Substitute(const Stmt& stmt, bool skip_thread_partition = false) {
+  static Stmt Substitute(const Stmt &stmt, bool skip_thread_partition = false) {
     arith::Analyzer analyzer;
     Eliminator transformer(&analyzer);
     return transformer.VisitStmt(stmt);
@@ -107,7 +107,7 @@ using namespace tir::transform;
 namespace transform {
 
 tvm::transform::Pass EliminateStorageSyncForMBarrier() {
-  auto pass_func = [](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     auto *n = f.CopyOnWrite();
     n->body = Eliminator::Substitute(n->body);
     return f;

--- a/src/transform/eliminate_storage_sync_for_mbarrier.cc
+++ b/src/transform/eliminate_storage_sync_for_mbarrier.cc
@@ -37,7 +37,7 @@ public:
     if (op->attr_key == "thread_extent") {
       const VarNode *var = nullptr;
       if (op->node->IsInstance<VarNode>()) {
-        var = static_cast<const VarNode *>(op->node.get());
+        var = op->node.as<VarNode>();
         if (var->name_hint == "threadIdx.x") {
           thread_extent_ = op;
         }
@@ -49,7 +49,7 @@ public:
   Stmt VisitStmt_(const EvaluateNode *op) final {
     const CallNode *call = nullptr;
     if (op->value->IsInstance<CallNode>()) {
-      call = static_cast<const CallNode *>(op->value.get());
+      call = op->value.as<CallNode>();
       if (call->op.same_as(builtin::tvm_storage_sync())) {
         // Skip storage sync if we're in a region with mbarrier operations
         // and we're not in a for loop with mbarrier operations

--- a/src/transform/flatten_buffer.cc
+++ b/src/transform/flatten_buffer.cc
@@ -75,21 +75,23 @@ private:
 
     Array<Buffer> alloc_buffers = op->alloc_buffers;
     alloc_buffers.MutateByApply(
-        [this](const Buffer& buf) { return GetFlattenedBuffer(buf); });
+        [this](const Buffer &buf) { return GetFlattenedBuffer(buf); });
     if (!alloc_buffers.same_as(op->alloc_buffers)) {
       block.CopyOnWrite()->alloc_buffers = alloc_buffers;
     }
 
     Array<BufferRegion> reads = op->reads;
-    reads.MutateByApply(
-        [this](BufferRegion region) { return MutateBufferRegion(std::move(region)); });
+    reads.MutateByApply([this](BufferRegion region) {
+      return MutateBufferRegion(std::move(region));
+    });
     if (!reads.same_as(op->reads)) {
       block.CopyOnWrite()->reads = reads;
     }
 
     Array<BufferRegion> writes = op->writes;
-    writes.MutateByApply(
-        [this](BufferRegion region) { return MutateBufferRegion(std::move(region)); });
+    writes.MutateByApply([this](BufferRegion region) {
+      return MutateBufferRegion(std::move(region));
+    });
     if (!writes.same_as(op->writes)) {
       block.CopyOnWrite()->writes = writes;
     }
@@ -171,7 +173,7 @@ private:
     return VisitStmt(op->body);
   }
 
-  Buffer GetFlattenedBuffer(const Buffer& buf) {
+  Buffer GetFlattenedBuffer(const Buffer &buf) {
     auto it = buffer_remap_.find(buf);
     if (it != buffer_remap_.end()) {
       return it->second;
@@ -301,7 +303,7 @@ PrimFunc FlattenBufferRewriter(PrimFunc f) {
 
 using namespace tir::transform;
 tvm::transform::Pass FlattenBuffer() {
-  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     return FlattenBufferRewriter(std::move(f));
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.FlattenBuffer", {});

--- a/src/transform/flatten_buffer.cc
+++ b/src/transform/flatten_buffer.cc
@@ -30,6 +30,8 @@
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/tir/transform.h>
 
+#include <utility>
+
 namespace tvm {
 namespace tl {
 
@@ -73,21 +75,21 @@ private:
 
     Array<Buffer> alloc_buffers = op->alloc_buffers;
     alloc_buffers.MutateByApply(
-        [this](Buffer buf) { return GetFlattenedBuffer(buf); });
+        [this](const Buffer& buf) { return GetFlattenedBuffer(buf); });
     if (!alloc_buffers.same_as(op->alloc_buffers)) {
       block.CopyOnWrite()->alloc_buffers = alloc_buffers;
     }
 
     Array<BufferRegion> reads = op->reads;
     reads.MutateByApply(
-        [this](BufferRegion region) { return MutateBufferRegion(region); });
+        [this](BufferRegion region) { return MutateBufferRegion(std::move(region)); });
     if (!reads.same_as(op->reads)) {
       block.CopyOnWrite()->reads = reads;
     }
 
     Array<BufferRegion> writes = op->writes;
     writes.MutateByApply(
-        [this](BufferRegion region) { return MutateBufferRegion(region); });
+        [this](BufferRegion region) { return MutateBufferRegion(std::move(region)); });
     if (!writes.same_as(op->writes)) {
       block.CopyOnWrite()->writes = writes;
     }
@@ -169,7 +171,7 @@ private:
     return VisitStmt(op->body);
   }
 
-  Buffer GetFlattenedBuffer(Buffer buf) {
+  Buffer GetFlattenedBuffer(const Buffer& buf) {
     auto it = buffer_remap_.find(buf);
     if (it != buffer_remap_.end()) {
       return it->second;
@@ -294,12 +296,12 @@ private:
 };
 
 PrimFunc FlattenBufferRewriter(PrimFunc f) {
-  return BufferFlattener::Flatten(f);
+  return BufferFlattener::Flatten(std::move(f));
 }
 
 using namespace tir::transform;
 tvm::transform::Pass FlattenBuffer() {
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     return FlattenBufferRewriter(std::move(f));
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.FlattenBuffer", {});

--- a/src/transform/frontend_legalize.cc
+++ b/src/transform/frontend_legalize.cc
@@ -83,7 +83,7 @@ private:
 using namespace tir::transform;
 
 Pass FrontendLegalize() {
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     return FrontendLegalizer::Substitute(std::move(f));
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.FrontendLegalize", {});

--- a/src/transform/frontend_legalize.cc
+++ b/src/transform/frontend_legalize.cc
@@ -83,7 +83,7 @@ private:
 using namespace tir::transform;
 
 Pass FrontendLegalize() {
-  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     return FrontendLegalizer::Substitute(std::move(f));
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.FrontendLegalize", {});

--- a/src/transform/if_stmt_binding.cc
+++ b/src/transform/if_stmt_binding.cc
@@ -38,8 +38,8 @@ private:
     ICHECK(then_case.defined()) << "then_case must be defined";
     ICHECK(!else_case.defined()) << "else_case must be undefined";
 
-    auto bind_if_stmt = [](Optional<Stmt> body,
-                           const PrimExpr condition) -> Stmt {
+    auto bind_if_stmt = [](const Optional<Stmt>& body,
+                           const PrimExpr& condition) -> Stmt {
       if (body.defined()) {
         auto stmt = body.value();
         if (auto seq_stmt = stmt.as<SeqStmtNode>()) {
@@ -75,7 +75,7 @@ private:
 
 using namespace tir::transform;
 tvm::transform::Pass IfStmtBinding() {
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     return IfStmtBindingRewriter::Substitute(f);
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.IfStmtBinding", {});

--- a/src/transform/if_stmt_binding.cc
+++ b/src/transform/if_stmt_binding.cc
@@ -38,8 +38,8 @@ private:
     ICHECK(then_case.defined()) << "then_case must be defined";
     ICHECK(!else_case.defined()) << "else_case must be undefined";
 
-    auto bind_if_stmt = [](const Optional<Stmt>& body,
-                           const PrimExpr& condition) -> Stmt {
+    auto bind_if_stmt = [](const Optional<Stmt> &body,
+                           const PrimExpr &condition) -> Stmt {
       if (body.defined()) {
         auto stmt = body.value();
         if (auto seq_stmt = stmt.as<SeqStmtNode>()) {
@@ -75,7 +75,7 @@ private:
 
 using namespace tir::transform;
 tvm::transform::Pass IfStmtBinding() {
-  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     return IfStmtBindingRewriter::Substitute(f);
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.IfStmtBinding", {});

--- a/src/transform/inject_fence_proxy.cc
+++ b/src/transform/inject_fence_proxy.cc
@@ -36,7 +36,7 @@ namespace tl {
 
 using namespace tir;
 
-enum class Proxy { kGeneric, kAsync, kBoth };
+enum class Proxy : uint8_t { kGeneric, kAsync, kBoth };
 
 class ProxyMarker : public StmtVisitor {
 public:

--- a/src/transform/inject_fence_proxy.cc
+++ b/src/transform/inject_fence_proxy.cc
@@ -155,7 +155,7 @@ private:
   }
 
   Stmt VisitStmt_(const SeqStmtNode *op) final {
-    ICHECK(op->seq.size() > 0);
+    ICHECK(!op->seq.empty());
     Array<Stmt> new_body;
     Proxy cur_proxy, prev_proxy;
     auto fence_stmt =
@@ -172,7 +172,7 @@ private:
         prev_proxy = cur_proxy;
       }
     }
-    ICHECK(new_body.size() > 0);
+    ICHECK(!new_body.empty());
     return new_body.size() == 1 ? new_body[0] : SeqStmt(std::move(new_body));
   }
 
@@ -187,7 +187,7 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass InjectFenceProxy() {
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     f = TMAStoreSyncInjector::Substitute(f);
     return InjectFenceProxy::Substitute(f);
   };

--- a/src/transform/inject_fence_proxy.cc
+++ b/src/transform/inject_fence_proxy.cc
@@ -187,7 +187,7 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass InjectFenceProxy() {
-  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     f = TMAStoreSyncInjector::Substitute(f);
     return InjectFenceProxy::Substitute(f);
   };

--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -131,10 +131,12 @@ private:
   }
 
   PrimExpr RewriteBufferAccess(const Call &call,
-                               const std::vector<int>& arg_indices) {
+                               const std::vector<int> &arg_indices) {
     auto product = [](const Array<PrimExpr> &input) {
       return foldl(
-          [](PrimExpr a, PrimExpr b, Span span) { return mul(std::move(a), std::move(b), std::move(span)); },
+          [](PrimExpr a, PrimExpr b, Span span) {
+            return mul(std::move(a), std::move(b), std::move(span));
+          },
           make_const(DataType::Int(32), 1), input);
     };
     Array<PrimExpr> new_args = call->args;
@@ -364,7 +366,7 @@ private:
    * \param region2 The second region.
    * \return Whether region1 and region2 have intersections.
    */
-  bool MayConflict(const Region& region1, const Region& region2) {
+  bool MayConflict(const Region &region1, const Region &region2) {
     ICHECK(region1.size() == region2.size());
     for (size_t i = 0; i < region1.size(); i++) {
       Range dim1 = region1[i];
@@ -481,7 +483,9 @@ private:
     PrimExpr producer_head;
     std::vector<std::vector<int>> commit_groups;
     std::unordered_map<const BufferNode *, int> buffer_to_commit_group_;
-    bool writes(const Buffer& buf) const { return dst_buffers.count(buf.get()) > 0; }
+    bool writes(const Buffer &buf) const {
+      return dst_buffers.count(buf.get()) > 0;
+    }
   };
 
   // Per-stage states that are local to each of pipeline prologue, body, and
@@ -617,7 +621,7 @@ private:
    * \param unroll_loop Whether the loop should be unrolled.
    * \return The result loop.
    */
-  Stmt EmitImpl(const PrimExpr& start, const PrimExpr& end, bool unroll_loop,
+  Stmt EmitImpl(const PrimExpr &start, const PrimExpr &end, bool unroll_loop,
                 bool need_bound_check) {
     PrimExpr new_loop_var;
     PrimExpr extent = end - start;
@@ -983,7 +987,7 @@ private:
  */
 tir::transform::Pass InjectSoftwarePipeline() {
   using namespace tir::transform;
-  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     auto *fptr = f.CopyOnWrite();
     fptr->body = software_pipeline::PipelineInjector::Inject(f);
     fptr->body = ConvertSSA(std::move(fptr->body));

--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -27,6 +27,7 @@
 #include <tvm/tir/transform.h>
 
 #include <unordered_set>
+#include <utility>
 
 #include "support/utils.h"
 #include "tir/schedule/utils.h"
@@ -104,7 +105,7 @@ public:
                        const Map<Buffer, Buffer> &buffer_remap,
                        For pipeline_loop, bool access_all_versions)
       : buffer_data_to_buffer_(buffer_data_to_buffer),
-        buffer_remap_(buffer_remap), pipeline_loop_(pipeline_loop),
+        buffer_remap_(buffer_remap), pipeline_loop_(std::move(pipeline_loop)),
         access_all_versions_(access_all_versions) {}
 
 private:
@@ -130,10 +131,10 @@ private:
   }
 
   PrimExpr RewriteBufferAccess(const Call &call,
-                               const std::vector<int> arg_indices) {
+                               const std::vector<int>& arg_indices) {
     auto product = [](const Array<PrimExpr> &input) {
       return foldl(
-          [](PrimExpr a, PrimExpr b, Span span) { return mul(a, b, span); },
+          [](PrimExpr a, PrimExpr b, Span span) { return mul(std::move(a), std::move(b), std::move(span)); },
           make_const(DataType::Int(32), 1), input);
     };
     Array<PrimExpr> new_args = call->args;
@@ -363,7 +364,7 @@ private:
    * \param region2 The second region.
    * \return Whether region1 and region2 have intersections.
    */
-  bool MayConflict(Region region1, Region region2) {
+  bool MayConflict(const Region& region1, const Region& region2) {
     ICHECK(region1.size() == region2.size());
     for (size_t i = 0; i < region1.size(); i++) {
       Range dim1 = region1[i];
@@ -458,7 +459,7 @@ private:
   Buffer RewriteAllocBuffer(const Buffer &buffer, int num_versions) {
     ObjectPtr<BufferNode> new_buffer = make_object<BufferNode>(*(buffer.get()));
     new_buffer->shape.insert(new_buffer->shape.begin(), PrimExpr(num_versions));
-    if (new_buffer->strides.size()) {
+    if (!new_buffer->strides.empty()) {
       ICHECK(new_buffer->strides.size() + 1 == new_buffer->shape.size());
       PrimExpr stride_0 = new_buffer->strides[0] * new_buffer->shape[1];
       new_buffer->strides.insert(new_buffer->strides.begin(), stride_0);
@@ -480,7 +481,7 @@ private:
     PrimExpr producer_head;
     std::vector<std::vector<int>> commit_groups;
     std::unordered_map<const BufferNode *, int> buffer_to_commit_group_;
-    bool writes(Buffer buf) const { return dst_buffers.count(buf.get()) > 0; }
+    bool writes(const Buffer& buf) const { return dst_buffers.count(buf.get()) > 0; }
   };
 
   // Per-stage states that are local to each of pipeline prologue, body, and
@@ -616,7 +617,7 @@ private:
    * \param unroll_loop Whether the loop should be unrolled.
    * \return The result loop.
    */
-  Stmt EmitImpl(PrimExpr start, PrimExpr end, bool unroll_loop,
+  Stmt EmitImpl(const PrimExpr& start, const PrimExpr& end, bool unroll_loop,
                 bool need_bound_check) {
     PrimExpr new_loop_var;
     PrimExpr extent = end - start;
@@ -719,7 +720,7 @@ private:
     }
 
     return BlockRealize({}, Bool(true),
-                        MakeBlock(std::move(new_loop), buffer_data_to_buffer_));
+                        MakeBlock(new_loop, buffer_data_to_buffer_));
   }
 
   arith::Analyzer analyzer_;
@@ -782,7 +783,7 @@ public:
 
 private:
   explicit PipelineInjector(Optional<String> global_symbol)
-      : global_symbol_(global_symbol) {}
+      : global_symbol_(std::move(global_symbol)) {}
 
   /*!
    * \brief Check the pipeline satisfies the following conditions:
@@ -982,7 +983,7 @@ private:
  */
 tir::transform::Pass InjectSoftwarePipeline() {
   using namespace tir::transform;
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     auto *fptr = f.CopyOnWrite();
     fptr->body = software_pipeline::PipelineInjector::Inject(f);
     fptr->body = ConvertSSA(std::move(fptr->body));

--- a/src/transform/inject_ptx_async_copy.cc
+++ b/src/transform/inject_ptx_async_copy.cc
@@ -53,7 +53,7 @@ public:
 
   Stmt InjectPTX(const BufferLoadNode *load, const BufferStoreNode *store,
                  bool predicated = false,
-                 PrimExpr predicate_value = PrimExpr()) {
+                 const PrimExpr& predicate_value = PrimExpr()) {
     if (load->buffer.scope() == "global") {
       ICHECK(load->indices.size() == 1 && store->indices.size() == 1);
       ICHECK(load->indices[0]->dtype.lanes() ==
@@ -224,7 +224,7 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass InjectPTXAsyncCopy() {
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     auto *n = f.CopyOnWrite();
     n->body = PTXAsyncCopyInjector()(n->body);
     return f;

--- a/src/transform/inject_ptx_async_copy.cc
+++ b/src/transform/inject_ptx_async_copy.cc
@@ -53,7 +53,7 @@ public:
 
   Stmt InjectPTX(const BufferLoadNode *load, const BufferStoreNode *store,
                  bool predicated = false,
-                 const PrimExpr& predicate_value = PrimExpr()) {
+                 const PrimExpr &predicate_value = PrimExpr()) {
     if (load->buffer.scope() == "global") {
       ICHECK(load->indices.size() == 1 && store->indices.size() == 1);
       ICHECK(load->indices[0]->dtype.lanes() ==
@@ -224,7 +224,7 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass InjectPTXAsyncCopy() {
-  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     auto *n = f.CopyOnWrite();
     n->body = PTXAsyncCopyInjector()(n->body);
     return f;

--- a/src/transform/inject_tma_barrier.cc
+++ b/src/transform/inject_tma_barrier.cc
@@ -57,7 +57,7 @@ public:
     loop_extents = 1;
   }
 
-  void Collect(const Stmt& stmt) { VisitStmt(stmt); }
+  void Collect(const Stmt &stmt) { VisitStmt(stmt); }
 
   PrimExpr BulkCopyBytes() { return bulk_copy_bytes; }
 
@@ -190,7 +190,7 @@ public:
   Map<PrimExpr, IntImm> barrier_id_to_range() { return barrier_id_to_range_; }
 
 private:
-  void UpdateBarrierRange(const PrimExpr& barrier_id, const IntImm& extent) {
+  void UpdateBarrierRange(const PrimExpr &barrier_id, const IntImm &extent) {
     if (barrier_id_to_range_.count(barrier_id)) {
       auto old_extent = barrier_id_to_range_[barrier_id];
       ICHECK_EQ(old_extent->value, extent->value)
@@ -209,7 +209,7 @@ private:
         pending_tma_ops_.push_back(GetRef<Call>(call));
       } else if (call->op.same_as(builtin::ptx_arrive_barrier())) {
         PrimExpr barrier_id = call->args[0];
-        for (const auto& tma_call : pending_tma_ops_) {
+        for (const auto &tma_call : pending_tma_ops_) {
           tma_op_to_barrier_id_.Set(tma_call, barrier_id);
         }
         auto const_int_bound = analyzer_.const_int_bound(thread_var_);
@@ -505,7 +505,7 @@ private:
 };
 
 tvm::transform::Pass InjectTmaBarrier() {
-  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     // Check if function only uses threadIdx.x before proceeding
     if (!ThreadTagChecker::HasOnlyThreadIdxX(f)) {
       LOG(WARNING) << "InjectTmaBarrier will be disabled because the program "

--- a/src/transform/inject_tma_barrier.cc
+++ b/src/transform/inject_tma_barrier.cc
@@ -32,6 +32,8 @@
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/tir/transform.h>
 
+#include <utility>
+
 #include "../op/builtin.h"
 #include "./common/attr.h"
 #include "./common/collector.h"
@@ -55,7 +57,7 @@ public:
     loop_extents = 1;
   }
 
-  void Collect(Stmt stmt) { VisitStmt(stmt); }
+  void Collect(const Stmt& stmt) { VisitStmt(stmt); }
 
   PrimExpr BulkCopyBytes() { return bulk_copy_bytes; }
 
@@ -103,12 +105,12 @@ private:
                                 IterVarType::kDataPar);
 
   PrimExpr makeGetBarrier(PrimExpr barrier_id) {
-    return Call(DataType::Handle(), get_mbarrier(), {barrier_id});
+    return Call(DataType::Handle(), get_mbarrier(), {std::move(barrier_id)});
   }
 
   Stmt makeExpectTX(PrimExpr barrier_id, PrimExpr bytes) {
     auto call = Call(DataType::Handle(), mbarrier_expect_tx(),
-                     {makeGetBarrier(barrier_id), bytes});
+                     {makeGetBarrier(std::move(barrier_id)), std::move(bytes)});
     return Evaluate(call);
   }
 
@@ -188,7 +190,7 @@ public:
   Map<PrimExpr, IntImm> barrier_id_to_range() { return barrier_id_to_range_; }
 
 private:
-  void UpdateBarrierRange(PrimExpr barrier_id, IntImm extent) {
+  void UpdateBarrierRange(const PrimExpr& barrier_id, const IntImm& extent) {
     if (barrier_id_to_range_.count(barrier_id)) {
       auto old_extent = barrier_id_to_range_[barrier_id];
       ICHECK_EQ(old_extent->value, extent->value)
@@ -207,7 +209,7 @@ private:
         pending_tma_ops_.push_back(GetRef<Call>(call));
       } else if (call->op.same_as(builtin::ptx_arrive_barrier())) {
         PrimExpr barrier_id = call->args[0];
-        for (auto tma_call : pending_tma_ops_) {
+        for (const auto& tma_call : pending_tma_ops_) {
           tma_op_to_barrier_id_.Set(tma_call, barrier_id);
         }
         auto const_int_bound = analyzer_.const_int_bound(thread_var_);
@@ -326,7 +328,7 @@ public:
   std::vector<int> restore_barrier_ids_;
   int if_depth_{0};
   Map<ObjectRef, PrimExpr> tma_op_to_barrier_id_;
-  arith::Analyzer *analyzer_;
+  arith::Analyzer *analyzer_{};
   Map<Var, arith::IntSet> var_int_set_;
   std::vector<arith::IntSet> int_sets_;
 };
@@ -336,7 +338,7 @@ public:
   BarrierCreationRewriter(std::vector<int> restore_barrier_ids,
                           PrimExpr producer_thread_extent)
       : restore_barrier_ids_(std::move(restore_barrier_ids)),
-        producer_thread_extent_(producer_thread_extent) {}
+        producer_thread_extent_(std::move(producer_thread_extent)) {}
 
   PrimExpr VisitExpr_(const CallNode *op) {
     if (op->op.same_as(create_list_of_mbarrier())) {
@@ -370,8 +372,8 @@ public:
                      Map<PrimExpr, IntImm> barrier_id_to_range,
                      bool has_create_list_of_mbarrier)
       : IRMutatorWithAnalyzer(analyzer),
-        tma_op_to_barrier_id_(tma_op_to_barrier_id),
-        barrier_id_to_range_(barrier_id_to_range),
+        tma_op_to_barrier_id_(std::move(tma_op_to_barrier_id)),
+        barrier_id_to_range_(std::move(barrier_id_to_range)),
         has_create_list_of_mbarrier_(has_create_list_of_mbarrier) {}
 
   static PrimFunc Rewrite(PrimFunc f, arith::Analyzer *analyzer) {
@@ -405,7 +407,7 @@ public:
 private:
   Stmt VisitStmt_(const BlockNode *op) {
     auto block = GetRef<Block>(op);
-    if (!has_create_list_of_mbarrier_ && barrier_id_to_range_.size() > 0 &&
+    if (!has_create_list_of_mbarrier_ && !barrier_id_to_range_.empty() &&
         op->name_hint == MainBlockName) {
       ICHECK(false) << "Please declare create_list_of_mbarrier.";
     }
@@ -503,7 +505,7 @@ private:
 };
 
 tvm::transform::Pass InjectTmaBarrier() {
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     // Check if function only uses threadIdx.x before proceeding
     if (!ThreadTagChecker::HasOnlyThreadIdxX(f)) {
       LOG(WARNING) << "InjectTmaBarrier will be disabled because the program "

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -550,7 +550,7 @@ public:
   }
 
 private:
-  LayoutInferencer(const LayoutInferenceResult result,
+  LayoutInferencer(const LayoutInferenceResult& result,
                    bool skip_thread_partition, arith::Analyzer *analyzer)
       : arith::IRMutatorWithAnalyzer(analyzer), result_(result),
         skip_thread_partition_(skip_thread_partition){};
@@ -648,11 +648,11 @@ private:
 
 tvm::transform::Pass LayoutInference() {
   using namespace tir::transform;
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     f.CopyOnWrite()->body = ParallelLoopTransformer::Substitute(f->body);
     ThreadBindingCollector collector;
     collector(f->body);
-    bool has_thread_binding = collector.thread_binding_.size() > 0;
+    bool has_thread_binding = !collector.thread_binding_.empty();
     bool skip_thread_partition = !has_thread_binding;
     return LayoutInferencer::Substitute(std::move(f), skip_thread_partition);
   };

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -550,7 +550,7 @@ public:
   }
 
 private:
-  LayoutInferencer(const LayoutInferenceResult& result,
+  LayoutInferencer(const LayoutInferenceResult &result,
                    bool skip_thread_partition, arith::Analyzer *analyzer)
       : arith::IRMutatorWithAnalyzer(analyzer), result_(result),
         skip_thread_partition_(skip_thread_partition){};
@@ -648,7 +648,7 @@ private:
 
 tvm::transform::Pass LayoutInference() {
   using namespace tir::transform;
-  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     f.CopyOnWrite()->body = ParallelLoopTransformer::Substitute(f->body);
     ThreadBindingCollector collector;
     collector(f->body);

--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -142,7 +142,8 @@ class SafeMemorysRewriter : public StmtExprMutator {
 public:
   explicit SafeMemorysRewriter(Map<Buffer, PrimExpr> annotated_padding_map,
                                arith::Analyzer *analyzer)
-      : annotated_padding_map_(std::move(annotated_padding_map)), analyzer_(analyzer) {}
+      : annotated_padding_map_(std::move(annotated_padding_map)),
+        analyzer_(analyzer) {}
 
 private:
   Stmt VisitStmt_(const BufferStoreNode *op) final {
@@ -343,7 +344,7 @@ private:
 tvm::transform::Pass LegalizeSafeMemoryAccess() {
   using namespace tir::transform;
   // Define the transformation function to be applied
-  auto pass_func = [=](PrimFunc f, const IRModule& m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, PassContext ctx) {
     bool disable_safe_memory_legalize =
         ctx->GetConfig<Bool>(kDisableSafeMemoryLegalize, Bool(false)).value();
     if (disable_safe_memory_legalize) {

--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -10,6 +10,8 @@
 #include <tvm/tir/transform.h>
 #include <tvm/tir/utils.h>
 
+#include <utility>
+
 #include "../op/builtin.h"
 #include "../op/parallel.h"
 #include "arith/ir_mutator_with_analyzer.h"
@@ -140,7 +142,7 @@ class SafeMemorysRewriter : public StmtExprMutator {
 public:
   explicit SafeMemorysRewriter(Map<Buffer, PrimExpr> annotated_padding_map,
                                arith::Analyzer *analyzer)
-      : annotated_padding_map_(annotated_padding_map), analyzer_(analyzer) {}
+      : annotated_padding_map_(std::move(annotated_padding_map)), analyzer_(analyzer) {}
 
 private:
   Stmt VisitStmt_(const BufferStoreNode *op) final {
@@ -153,7 +155,7 @@ private:
 
     // Skip boundary check if the store value is an IfThenElse
     if (const IfThenElseNode *if_node = store->value.as<IfThenElseNode>()) {
-      if (conditions.size() > 0) {
+      if (!conditions.empty()) {
         LOG(WARNING)
             << "Skipping boundary check for store with IfThenElse value: "
             << store->value
@@ -165,7 +167,7 @@ private:
       return store;
     }
 
-    if (conditions.size() == 0) {
+    if (conditions.empty()) {
       return store;
     }
 
@@ -215,7 +217,7 @@ private:
         checker(call);
         Array<PrimExpr> conditions = checker.GetConditions();
 
-        if (conditions.size() == 0) {
+        if (conditions.empty()) {
           return evaluate;
         }
 
@@ -330,7 +332,7 @@ private:
   static bool HasInnerLoop(const Stmt &stmt) {
     LeafForFinder finder;
     finder(stmt);
-    return finder.leaf_for_nodes.size() > 0;
+    return !finder.leaf_for_nodes.empty();
   }
 
   Map<Var, Buffer> buffer_data_to_buffer_;
@@ -341,7 +343,7 @@ private:
 tvm::transform::Pass LegalizeSafeMemoryAccess() {
   using namespace tir::transform;
   // Define the transformation function to be applied
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, PassContext ctx) {
     bool disable_safe_memory_legalize =
         ctx->GetConfig<Bool>(kDisableSafeMemoryLegalize, Bool(false)).value();
     if (disable_safe_memory_legalize) {

--- a/src/transform/legalize_vectorized_loop.cc
+++ b/src/transform/legalize_vectorized_loop.cc
@@ -73,7 +73,7 @@ private:
     // Change the loop kind from vectorized to serial
     for_node.CopyOnWrite()->kind = ForKind::kSerial;
     // Apply vectorization transformation to the loop
-    return VectorizeLoop(std::move(for_node));
+    return VectorizeLoop(for_node);
   }
 };
 
@@ -81,7 +81,7 @@ private:
 tvm::transform::Pass LegalizeVectorizedLoop() {
   using namespace tir::transform;
   // Define the transformation function to be applied
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     return LoopVectorizedLegalizer::Substitute(std::move(f));
   };
   // Create and return a PrimFunc pass with the transformation function

--- a/src/transform/legalize_vectorized_loop.cc
+++ b/src/transform/legalize_vectorized_loop.cc
@@ -81,7 +81,7 @@ private:
 tvm::transform::Pass LegalizeVectorizedLoop() {
   using namespace tir::transform;
   // Define the transformation function to be applied
-  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     return LoopVectorizedLegalizer::Substitute(std::move(f));
   };
   // Create and return a PrimFunc pass with the transformation function

--- a/src/transform/loop_partition.cc
+++ b/src/transform/loop_partition.cc
@@ -59,7 +59,7 @@ private:
 
 // Rewrite the parallel loop into a common loop, which is mapped to threads
 For PartitionLoop(For op, Var thread_var, arith::Analyzer *analyzer,
-                  const Fragment& loop_layout) {
+                  const Fragment &loop_layout) {
   ICHECK(loop_layout.defined());
   ICHECK(thread_var.defined());
   int old_loop_depth = loop_layout->InputDim();
@@ -125,7 +125,7 @@ class LoopPartitioner : public StmtExprVisitor {
 public:
   LoopPartitioner() = default;
 
-  Fragment Partition(const For& op, int num_thread, int vectorize_size) {
+  Fragment Partition(const For &op, int num_thread, int vectorize_size) {
     this->VisitStmt(op);
     int loop_size_full = 1;
     PrimExpr flattened = 0;
@@ -184,12 +184,14 @@ private:
   Array<IterVar> loop_vars_;
 };
 
-Fragment PlanLoopPartition(const For& op, size_t num_thread, int vectorize_size) {
+Fragment PlanLoopPartition(const For &op, size_t num_thread,
+                           int vectorize_size) {
   LoopPartitioner partitioner;
   return partitioner.Partition(op, num_thread, vectorize_size);
 }
 
-Fragment PlanLoopPartition(const For& op, int vectorize_size, const Range& thread_range) {
+Fragment PlanLoopPartition(const For &op, int vectorize_size,
+                           const Range &thread_range) {
   size_t num_thread = *as_const_int(thread_range->extent);
   LoopPartitioner partitioner;
   Fragment fragment = partitioner.Partition(op, num_thread, vectorize_size);

--- a/src/transform/loop_partition.cc
+++ b/src/transform/loop_partition.cc
@@ -26,6 +26,8 @@
 
 #include <tvm/tir/stmt_functor.h>
 
+#include <utility>
+
 namespace tvm {
 namespace tl {
 
@@ -57,7 +59,7 @@ private:
 
 // Rewrite the parallel loop into a common loop, which is mapped to threads
 For PartitionLoop(For op, Var thread_var, arith::Analyzer *analyzer,
-                  Fragment loop_layout) {
+                  const Fragment& loop_layout) {
   ICHECK(loop_layout.defined());
   ICHECK(thread_var.defined());
   int old_loop_depth = loop_layout->InputDim();
@@ -72,7 +74,7 @@ For PartitionLoop(For op, Var thread_var, arith::Analyzer *analyzer,
   vars.push_back(thread_var);
   // create the substitute map, and the loop body
   Map<Var, PrimExpr> vmap;
-  Stmt body = op;
+  Stmt body = std::move(op);
   auto inv_loop = loop_layout->Inverse();
   auto indices = inv_loop->Forward(Array<PrimExpr>(vars.begin(), vars.end()));
   for (int i = 0; i < old_loop_depth; i++) {
@@ -123,7 +125,7 @@ class LoopPartitioner : public StmtExprVisitor {
 public:
   LoopPartitioner() = default;
 
-  Fragment Partition(For op, int num_thread, int vectorize_size) {
+  Fragment Partition(const For& op, int num_thread, int vectorize_size) {
     this->VisitStmt(op);
     int loop_size_full = 1;
     PrimExpr flattened = 0;
@@ -182,12 +184,12 @@ private:
   Array<IterVar> loop_vars_;
 };
 
-Fragment PlanLoopPartition(For op, size_t num_thread, int vectorize_size) {
+Fragment PlanLoopPartition(const For& op, size_t num_thread, int vectorize_size) {
   LoopPartitioner partitioner;
   return partitioner.Partition(op, num_thread, vectorize_size);
 }
 
-Fragment PlanLoopPartition(For op, int vectorize_size, Range thread_range) {
+Fragment PlanLoopPartition(const For& op, int vectorize_size, const Range& thread_range) {
   size_t num_thread = *as_const_int(thread_range->extent);
   LoopPartitioner partitioner;
   Fragment fragment = partitioner.Partition(op, num_thread, vectorize_size);
@@ -196,7 +198,7 @@ Fragment PlanLoopPartition(For op, int vectorize_size, Range thread_range) {
 
 For LoopPragmaUnroll(For stmt) {
   LoopPramaUnroller unroller;
-  For unrolled = Downcast<For>(unroller(stmt));
+  For unrolled = Downcast<For>(unroller(std::move(stmt)));
   return unrolled;
 }
 

--- a/src/transform/loop_partition.h
+++ b/src/transform/loop_partition.h
@@ -35,11 +35,11 @@ namespace tl {
 using namespace tir;
 
 For PartitionLoop(For op, Var thread_var, arith::Analyzer *analyzer,
-                  Fragment loop_layout);
+                  const Fragment& loop_layout);
 
-Fragment PlanLoopPartition(For op, size_t num_thread, int vectorize_size);
+Fragment PlanLoopPartition(const For& op, size_t num_thread, int vectorize_size);
 
-Fragment PlanLoopPartition(For op, int vectorize_size, Range thread_range);
+Fragment PlanLoopPartition(const For& op, int vectorize_size, const Range& thread_range);
 
 For LoopPragmaUnroll(For stmt);
 

--- a/src/transform/loop_partition.h
+++ b/src/transform/loop_partition.h
@@ -35,11 +35,13 @@ namespace tl {
 using namespace tir;
 
 For PartitionLoop(For op, Var thread_var, arith::Analyzer *analyzer,
-                  const Fragment& loop_layout);
+                  const Fragment &loop_layout);
 
-Fragment PlanLoopPartition(const For& op, size_t num_thread, int vectorize_size);
+Fragment PlanLoopPartition(const For &op, size_t num_thread,
+                           int vectorize_size);
 
-Fragment PlanLoopPartition(const For& op, int vectorize_size, const Range& thread_range);
+Fragment PlanLoopPartition(const For &op, int vectorize_size,
+                           const Range &thread_range);
 
 For LoopPragmaUnroll(For stmt);
 

--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -110,7 +110,7 @@ private:
     // TODO: perform some checks here
   }
 
-  void UpdateVectorSize(const Array<PrimExpr>& indices, const Buffer &buffer) {
+  void UpdateVectorSize(const Array<PrimExpr> &indices, const Buffer &buffer) {
     if (!inner_for_)
       return;
     auto extent_ptr = inner_for_->extent.as<IntImmNode>();
@@ -180,7 +180,7 @@ private:
 
 class VectorizeRewriter : public StmtExprMutator {
 public:
-  VectorizeRewriter(const VectorizePlanResult& plan)
+  VectorizeRewriter(const VectorizePlanResult &plan)
       : vector_size_(plan.vector_size), condition_(plan.condition),
         dynamic_(plan.dynamic) {}
 
@@ -236,7 +236,8 @@ VectorizePlanResult GetVectorizePlanResult(const For &loop) {
   return {vector_size, dynamic, condition};
 }
 
-bool IndiceCanVectorize(const PrimExpr& expr, Var var, const PrimExpr& iter_var_size,
+bool IndiceCanVectorize(const PrimExpr &expr, Var var,
+                        const PrimExpr &iter_var_size,
                         int target_vectorized_size, arith::Analyzer *analyzer) {
   ICHECK(target_vectorized_size >= 1);
   if (target_vectorized_size == 1)

--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -110,7 +110,7 @@ private:
     // TODO: perform some checks here
   }
 
-  void UpdateVectorSize(const Array<PrimExpr> indices, const Buffer &buffer) {
+  void UpdateVectorSize(const Array<PrimExpr>& indices, const Buffer &buffer) {
     if (!inner_for_)
       return;
     auto extent_ptr = inner_for_->extent.as<IntImmNode>();
@@ -139,7 +139,7 @@ private:
 
       // Generate strides if not existed
       auto strides = buffer->strides;
-      if (buffer->strides.size() == 0) {
+      if (buffer->strides.empty()) {
         PrimExpr stride = 1;
         for (int i = indices.size() - 1; i >= 0; --i) {
           strides.push_back(stride);
@@ -169,7 +169,7 @@ private:
 
   const int vector_load_bits_max_ = 128;
 
-  const ForNode *inner_for_;
+  const ForNode *inner_for_{};
   Map<Var, Range> iter_map_;
   bool has_nonlocal_memory_access_ = false;
   int vector_size_ = 128;
@@ -180,7 +180,7 @@ private:
 
 class VectorizeRewriter : public StmtExprMutator {
 public:
-  VectorizeRewriter(VectorizePlanResult plan)
+  VectorizeRewriter(const VectorizePlanResult& plan)
       : vector_size_(plan.vector_size), condition_(plan.condition),
         dynamic_(plan.dynamic) {}
 
@@ -220,7 +220,7 @@ private:
     }
   }
 
-  const ForNode *inner_for_;
+  const ForNode *inner_for_{};
   const int vector_size_;
   const PrimExpr condition_;
   const bool dynamic_;
@@ -236,7 +236,7 @@ VectorizePlanResult GetVectorizePlanResult(const For &loop) {
   return {vector_size, dynamic, condition};
 }
 
-bool IndiceCanVectorize(PrimExpr expr, Var var, PrimExpr iter_var_size,
+bool IndiceCanVectorize(const PrimExpr& expr, Var var, const PrimExpr& iter_var_size,
                         int target_vectorized_size, arith::Analyzer *analyzer) {
   ICHECK(target_vectorized_size >= 1);
   if (target_vectorized_size == 1)

--- a/src/transform/loop_vectorize.h
+++ b/src/transform/loop_vectorize.h
@@ -37,7 +37,7 @@ int GetVectorizeSize(const For &loop);
 
 For VectorizeLoop(const For &loop, int vectorize_hint = -1);
 
-bool IndiceCanVectorize(PrimExpr expr, Var var, PrimExpr iter_var_size,
+bool IndiceCanVectorize(const PrimExpr& expr, Var var, const PrimExpr& iter_var_size,
                         int target_vectorized_size, arith::Analyzer *analyzer);
 
 } // namespace tl

--- a/src/transform/loop_vectorize.h
+++ b/src/transform/loop_vectorize.h
@@ -37,7 +37,8 @@ int GetVectorizeSize(const For &loop);
 
 For VectorizeLoop(const For &loop, int vectorize_hint = -1);
 
-bool IndiceCanVectorize(const PrimExpr& expr, Var var, const PrimExpr& iter_var_size,
+bool IndiceCanVectorize(const PrimExpr &expr, Var var,
+                        const PrimExpr &iter_var_size,
                         int target_vectorized_size, arith::Analyzer *analyzer);
 
 } // namespace tl

--- a/src/transform/loop_vectorize_dynamic.cc
+++ b/src/transform/loop_vectorize_dynamic.cc
@@ -33,7 +33,8 @@ struct VectorizePlanResult {
   PrimExpr condition;
 };
 
-bool IndiceCanVectorizeDynamic(const PrimExpr& expr, Var var, const PrimExpr& iter_var_size,
+bool IndiceCanVectorizeDynamic(const PrimExpr &expr, Var var,
+                               const PrimExpr &iter_var_size,
                                int target_vectorized_size,
                                arith::Analyzer *analyzer) {
   ICHECK(target_vectorized_size >= 1);
@@ -137,7 +138,7 @@ private:
     // TODO: may perform some checks here
   }
 
-  void UpdateVectorSize(const Array<PrimExpr>& indices, const Buffer &buffer) {
+  void UpdateVectorSize(const Array<PrimExpr> &indices, const Buffer &buffer) {
     if (!inner_for_)
       return;
     auto extent_ptr = inner_for_->extent.as<IntImmNode>();
@@ -245,7 +246,7 @@ private:
 class VectorizedConditionExtracter : public StmtExprVisitor {
 public:
   VectorizedConditionExtracter() = default;
-  std::vector<PrimExpr> GetConditions(const Stmt& body) {
+  std::vector<PrimExpr> GetConditions(const Stmt &body) {
     this->VisitStmt(body);
     return conditions_;
   }
@@ -270,7 +271,7 @@ private:
 class NestedLoopChecker : public StmtExprVisitor {
 public:
   NestedLoopChecker() : loop_num_(0) {}
-  int GetNestLoopNum(const Stmt& body) {
+  int GetNestLoopNum(const Stmt &body) {
     this->VisitStmt(body);
     return loop_num_;
   }
@@ -344,7 +345,7 @@ private:
 
 class VectorizeRewriterDynamic : public StmtExprMutator {
 public:
-  VectorizeRewriterDynamic(const VectorizePlanResult& plan,
+  VectorizeRewriterDynamic(const VectorizePlanResult &plan,
                            bool disable_dynamic_tail_split)
       : vector_size_(plan.vector_size), condition_(plan.condition),
         dynamic_(plan.dynamic),
@@ -509,7 +510,7 @@ public:
 
 tvm::transform::Pass LoopVectorizeDynamic() {
   using namespace tir::transform;
-  auto pass_func = [=](PrimFunc f, const IRModule& m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, PassContext ctx) {
     bool disable_dynamic_tail_split =
         ctx->GetConfig<Bool>(kDisableDynamicTailSplit, Bool(true)).value();
     int dynamic_alignment =

--- a/src/transform/loop_vectorize_dynamic.cc
+++ b/src/transform/loop_vectorize_dynamic.cc
@@ -12,6 +12,7 @@
 #include <tvm/tir/stmt_functor.h>
 
 #include <numeric>
+#include <utility>
 
 #include "../layout/layout.h"
 #include "../layout/utils.h"
@@ -32,7 +33,7 @@ struct VectorizePlanResult {
   PrimExpr condition;
 };
 
-bool IndiceCanVectorizeDynamic(PrimExpr expr, Var var, PrimExpr iter_var_size,
+bool IndiceCanVectorizeDynamic(const PrimExpr& expr, Var var, const PrimExpr& iter_var_size,
                                int target_vectorized_size,
                                arith::Analyzer *analyzer) {
   ICHECK(target_vectorized_size >= 1);
@@ -136,7 +137,7 @@ private:
     // TODO: may perform some checks here
   }
 
-  void UpdateVectorSize(const Array<PrimExpr> indices, const Buffer &buffer) {
+  void UpdateVectorSize(const Array<PrimExpr>& indices, const Buffer &buffer) {
     if (!inner_for_)
       return;
     auto extent_ptr = inner_for_->extent.as<IntImmNode>();
@@ -198,7 +199,7 @@ private:
 
   int vector_size_;
 
-  const ForNode *inner_for_;
+  const ForNode *inner_for_{};
   Map<Var, Range> iter_map_;
   bool has_nonlocal_memory_access_ = false;
   // conditionally vectorize
@@ -210,8 +211,8 @@ class VectorizedBodyMutator : public StmtExprMutator {
 public:
   VectorizedBodyMutator(Var inner_var, int vector_size,
                         std::vector<PrimExpr> conditions)
-      : inner_var_(inner_var), vector_size_(vector_size),
-        conditions_(conditions) {}
+      : inner_var_(std::move(inner_var)), vector_size_(vector_size),
+        conditions_(std::move(conditions)) {}
 
 private:
   PrimExpr VisitExpr_(const CallNode *op) final {
@@ -244,7 +245,7 @@ private:
 class VectorizedConditionExtracter : public StmtExprVisitor {
 public:
   VectorizedConditionExtracter() = default;
-  std::vector<PrimExpr> GetConditions(Stmt body) {
+  std::vector<PrimExpr> GetConditions(const Stmt& body) {
     this->VisitStmt(body);
     return conditions_;
   }
@@ -269,7 +270,7 @@ private:
 class NestedLoopChecker : public StmtExprVisitor {
 public:
   NestedLoopChecker() : loop_num_(0) {}
-  int GetNestLoopNum(Stmt body) {
+  int GetNestLoopNum(const Stmt& body) {
     this->VisitStmt(body);
     return loop_num_;
   }
@@ -286,7 +287,7 @@ private:
 class VectorizedConditionMutator : public StmtExprMutator {
 public:
   VectorizedConditionMutator(Var inner_var, int extent)
-      : inner_var_(inner_var), vector_size_(extent) {}
+      : inner_var_(std::move(inner_var)), vector_size_(extent) {}
 
 private:
   PrimExpr VisitExpr_(const GENode *node) final {
@@ -343,7 +344,7 @@ private:
 
 class VectorizeRewriterDynamic : public StmtExprMutator {
 public:
-  VectorizeRewriterDynamic(VectorizePlanResult plan,
+  VectorizeRewriterDynamic(const VectorizePlanResult& plan,
                            bool disable_dynamic_tail_split)
       : vector_size_(plan.vector_size), condition_(plan.condition),
         dynamic_(plan.dynamic),
@@ -396,7 +397,7 @@ private:
 
     // Adaptively set vectorized variable to the min/max value of the extent
     PrimExpr condition_bound;
-    if (conditions.size() > 0) {
+    if (!conditions.empty()) {
       condition_bound = condition_mutator(conditions[0]);
       for (int i = 1; i < conditions.size(); ++i) {
         condition_bound = condition_bound && condition_mutator(conditions[i]);
@@ -413,7 +414,7 @@ private:
       For vectorize_for =
           For(inner_var, 0, vector_size_, ForKind::kVectorized, vectorize_body);
       For serial_for = For(inner_var, 0, vector_size_, ForKind::kSerial, body);
-      if (conditions.size() > 0) {
+      if (!conditions.empty()) {
         body = IfThenElse(condition_bound, vectorize_for, serial_for);
       } else {
         body = vectorize_for;
@@ -436,7 +437,7 @@ private:
     }
   }
 
-  const ForNode *inner_for_;
+  const ForNode *inner_for_{};
   int vector_size_;
   const PrimExpr condition_;
   const bool dynamic_;
@@ -509,7 +510,7 @@ public:
 
 tvm::transform::Pass LoopVectorizeDynamic() {
   using namespace tir::transform;
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, PassContext ctx) {
     bool disable_dynamic_tail_split =
         ctx->GetConfig<Bool>(kDisableDynamicTailSplit, Bool(true)).value();
     int dynamic_alignment =

--- a/src/transform/loop_vectorize_dynamic.cc
+++ b/src/transform/loop_vectorize_dynamic.cc
@@ -485,7 +485,6 @@ private:
                                                   // non-vectorized loop
       return for_node;
     }
-    int vectorize_hint = res.vector_size;
     auto rewriter = VectorizeRewriterDynamic(res, disable_dynamic_tail_split_);
     return Downcast<For>(rewriter(for_node));
   }

--- a/src/transform/lower_device_kernel_launch.cc
+++ b/src/transform/lower_device_kernel_launch.cc
@@ -356,7 +356,7 @@ namespace transform {
 
 tvm::transform::Pass LowerDeviceKernelLaunch() {
   auto pass_func = [](IRModule mod,
-                      const tir::transform::PassContext& ctx) -> IRModule {
+                      const tir::transform::PassContext &ctx) -> IRModule {
     auto mutator = [&mod]() {
       std::unordered_map<const GlobalVarNode *, KernelInfo> device_info_map;
       for (const auto &[gvar, base_func] : mod->functions) {

--- a/src/transform/lower_device_kernel_launch.cc
+++ b/src/transform/lower_device_kernel_launch.cc
@@ -356,7 +356,7 @@ namespace transform {
 
 tvm::transform::Pass LowerDeviceKernelLaunch() {
   auto pass_func = [](IRModule mod,
-                      tir::transform::PassContext ctx) -> IRModule {
+                      const tir::transform::PassContext& ctx) -> IRModule {
     auto mutator = [&mod]() {
       std::unordered_map<const GlobalVarNode *, KernelInfo> device_info_map;
       for (const auto &[gvar, base_func] : mod->functions) {
@@ -380,7 +380,7 @@ tvm::transform::Pass LowerDeviceKernelLaunch() {
         }
       }
 
-      if (updates->functions.size()) {
+      if (!updates->functions.empty()) {
         mod.CopyOnWrite()->Update(updates);
       }
     }
@@ -396,7 +396,7 @@ tvm::transform::Pass LowerDeviceKernelLaunch() {
         }
       }
 
-      if (updates->functions.size()) {
+      if (!updates->functions.empty()) {
         mod.CopyOnWrite()->Update(updates);
       }
     }

--- a/src/transform/lower_device_storage_access_info.cc
+++ b/src/transform/lower_device_storage_access_info.cc
@@ -105,8 +105,8 @@ private:
     return AddressOffset(buffer_var, dtype, offset);
   }
 
-  PrimExpr MakeTaggedAccessPtr(DataType ptr_type, const Var& buffer_var,
-                               DataType dtype, const PrimExpr& offset,
+  PrimExpr MakeTaggedAccessPtr(DataType ptr_type, const Var &buffer_var,
+                               DataType dtype, const PrimExpr &offset,
                                const MemoryInfo &info) {
     if (ptr_type.is_handle()) {
       ICHECK(info->head_address.defined())
@@ -134,7 +134,7 @@ namespace transform {
 using namespace tir::transform;
 
 Pass LowerDeviceStorageAccessInfo() {
-  auto pass_func = [](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     auto *n = f.CopyOnWrite();
     n->body = StorageAccessInfoLower()(std::move(n->body));
     return f;

--- a/src/transform/lower_device_storage_access_info.cc
+++ b/src/transform/lower_device_storage_access_info.cc
@@ -44,7 +44,7 @@ class StorageAccessInfoLower : public StmtExprMutator {
 public:
   Stmt VisitStmt_(const AllocateNode *op) final {
     auto scope = StorageScope::Create(GetPtrStorageScope(op->buffer_var));
-    if (scope.tag.length() != 0 && scope.tag != ".dyn" && scope.tag != ".var" &&
+    if (!scope.tag.empty() && scope.tag != ".dyn" && scope.tag != ".var" &&
         scope.tag != ".barrier") {
       auto info = GetMemoryInfo(GetPtrStorageScope(op->buffer_var));
       ICHECK(info.defined())
@@ -105,8 +105,8 @@ private:
     return AddressOffset(buffer_var, dtype, offset);
   }
 
-  PrimExpr MakeTaggedAccessPtr(DataType ptr_type, Var buffer_var,
-                               DataType dtype, PrimExpr offset,
+  PrimExpr MakeTaggedAccessPtr(DataType ptr_type, const Var& buffer_var,
+                               DataType dtype, const PrimExpr& offset,
                                const MemoryInfo &info) {
     if (ptr_type.is_handle()) {
       ICHECK(info->head_address.defined())
@@ -134,7 +134,7 @@ namespace transform {
 using namespace tir::transform;
 
 Pass LowerDeviceStorageAccessInfo() {
-  auto pass_func = [](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     auto *n = f.CopyOnWrite();
     n->body = StorageAccessInfoLower()(std::move(n->body));
     return f;

--- a/src/transform/lower_hopper_intrin.cc
+++ b/src/transform/lower_hopper_intrin.cc
@@ -26,7 +26,7 @@ public:
     LowerHopperIntrin substituter(disable_shuffle_elect);
     fptr->body = substituter.VisitStmt(f->body);
     Map<String, Array<PrimExpr>> init_desc_arg_map;
-    for (auto [call, var] : substituter.desc_map_) {
+    for (const auto& [call, var] : substituter.desc_map_) {
       // Should allocate 128 bytes for TensorMap on stack
       Call alloc_desc = Call(DataType::Handle(), builtin::tvm_stack_alloca(),
                              {StringImm("arg_value"), 16});
@@ -117,7 +117,7 @@ public:
       }
       return var;
     } else if (call->op.same_as(create_list_of_mbarrier())) {
-      ICHECK(init_mbarrier_calls_.size() == 0);
+      ICHECK(init_mbarrier_calls_.empty());
       int num_barriers = static_cast<int>(call->args.size());
       for (int i = 0; i < num_barriers; i++) {
         PrimExpr mbarrier = Call(DataType::Handle(), get_mbarrier(), {i});
@@ -143,7 +143,7 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass LowerHopperIntrin() {
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, PassContext ctx) {
     bool disable_shuffle_elect =
         ctx->GetConfig<Bool>(kDisableShuffleElect, Bool(false)).value();
     return LowerHopperIntrin::Substitute(f, disable_shuffle_elect);

--- a/src/transform/lower_hopper_intrin.cc
+++ b/src/transform/lower_hopper_intrin.cc
@@ -26,7 +26,7 @@ public:
     LowerHopperIntrin substituter(disable_shuffle_elect);
     fptr->body = substituter.VisitStmt(f->body);
     Map<String, Array<PrimExpr>> init_desc_arg_map;
-    for (const auto& [call, var] : substituter.desc_map_) {
+    for (const auto &[call, var] : substituter.desc_map_) {
       // Should allocate 128 bytes for TensorMap on stack
       Call alloc_desc = Call(DataType::Handle(), builtin::tvm_stack_alloca(),
                              {StringImm("arg_value"), 16});
@@ -143,7 +143,7 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass LowerHopperIntrin() {
-  auto pass_func = [=](PrimFunc f, const IRModule& m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, PassContext ctx) {
     bool disable_shuffle_elect =
         ctx->GetConfig<Bool>(kDisableShuffleElect, Bool(false)).value();
     return LowerHopperIntrin::Substitute(f, disable_shuffle_elect);

--- a/src/transform/lower_l2_persistent_annotation.cc
+++ b/src/transform/lower_l2_persistent_annotation.cc
@@ -92,7 +92,7 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass LowerL2Persistent() {
-  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     return LowerL2Persistent::Substitute(f);
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.LowerL2Persistent", {});

--- a/src/transform/lower_l2_persistent_annotation.cc
+++ b/src/transform/lower_l2_persistent_annotation.cc
@@ -47,7 +47,7 @@ public:
       l2_persistent_arguments.push_back(size_in_bytes);
       init_l2_persistent_map.Set(buffer->name, l2_persistent_arguments);
     }
-    if (init_l2_persistent_map.size() > 0) {
+    if (!init_l2_persistent_map.empty()) {
       f = WithAttr(std::move(f), attr::kL2PersistentMap,
                    init_l2_persistent_map);
     }
@@ -92,7 +92,7 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass LowerL2Persistent() {
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     return LowerL2Persistent::Substitute(f);
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.LowerL2Persistent", {});

--- a/src/transform/lower_opaque_block.cc
+++ b/src/transform/lower_opaque_block.cc
@@ -146,7 +146,7 @@ private:
   }
 
   static Stmt MakeLaunchThread(PrimExpr min, PrimExpr extent, Var var,
-                               const String& thread_tag, Stmt body) {
+                               const String &thread_tag, Stmt body) {
     IterVar iter_var(/*dom=*/Range::FromMinExtent(std::move(min), extent),
                      /*var=*/std::move(var),
                      /*iter_type=*/IterVarType::kThreadIndex,
@@ -225,7 +225,7 @@ PrimFunc TLLowerOpaqueBlock(PrimFunc f) {
 
 tir::transform::Pass LowerOpaqueBlock() {
   using namespace tir::transform;
-  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     return TLLowerOpaqueBlock(std::move(f));
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.LowerOpaqueBlock", {});

--- a/src/transform/lower_opaque_block.cc
+++ b/src/transform/lower_opaque_block.cc
@@ -25,6 +25,8 @@
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/tir/transform.h>
 
+#include <utility>
+
 #include "tir/transforms/ir_utils.h"
 
 namespace tvm {
@@ -144,8 +146,8 @@ private:
   }
 
   static Stmt MakeLaunchThread(PrimExpr min, PrimExpr extent, Var var,
-                               String thread_tag, Stmt body) {
-    IterVar iter_var(/*dom=*/Range::FromMinExtent(min, extent),
+                               const String& thread_tag, Stmt body) {
+    IterVar iter_var(/*dom=*/Range::FromMinExtent(std::move(min), extent),
                      /*var=*/std::move(var),
                      /*iter_type=*/IterVarType::kThreadIndex,
                      /*thread_tag=*/thread_tag);
@@ -223,7 +225,7 @@ PrimFunc TLLowerOpaqueBlock(PrimFunc f) {
 
 tir::transform::Pass LowerOpaqueBlock() {
   using namespace tir::transform;
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     return TLLowerOpaqueBlock(std::move(f));
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.LowerOpaqueBlock", {});

--- a/src/transform/lower_shared_barrier.cc
+++ b/src/transform/lower_shared_barrier.cc
@@ -45,7 +45,7 @@ private:
 
     Array<Buffer> barrier_buffers;
 
-    for (const auto& [data, buffer] : buffer_map_) {
+    for (const auto &[data, buffer] : buffer_map_) {
       const auto *ptr_type =
           buffer->data->type_annotation.as<PointerTypeNode>();
       auto storage_scope = ptr_type->storage_scope;
@@ -191,7 +191,7 @@ namespace transform {
 using namespace tir::transform;
 
 tvm::transform::Pass LowerSharedBarrier() {
-  auto pass_func = [=](PrimFunc f, const IRModule& m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, PassContext ctx) {
     bool disable_shuffle_elect =
         ctx->GetConfig<Bool>(kDisableShuffleElect, Bool(false)).value();
     return tl::LowerSharedBarrier(std::move(f), disable_shuffle_elect);

--- a/src/transform/lower_shared_barrier.cc
+++ b/src/transform/lower_shared_barrier.cc
@@ -13,6 +13,8 @@
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/tir/transform.h>
 
+#include <utility>
+
 namespace tvm {
 namespace tl {
 
@@ -22,7 +24,7 @@ class SharedBarrierRewriter : public StmtExprMutator {
 public:
   static Stmt Rewrite(Stmt body, bool disable_shuffle_elect = false) {
     SharedBarrierRewriter rewriter(disable_shuffle_elect);
-    return rewriter(body);
+    return rewriter(std::move(body));
   }
 
 private:
@@ -43,7 +45,7 @@ private:
 
     Array<Buffer> barrier_buffers;
 
-    for (auto [data, buffer] : buffer_map_) {
+    for (const auto& [data, buffer] : buffer_map_) {
       const auto *ptr_type =
           buffer->data->type_annotation.as<PointerTypeNode>();
       auto storage_scope = ptr_type->storage_scope;
@@ -53,7 +55,7 @@ private:
       }
     }
 
-    if (barrier_buffers.size() == 0) {
+    if (barrier_buffers.empty()) {
       return StmtExprMutator::VisitStmt_(op);
     }
 
@@ -189,7 +191,7 @@ namespace transform {
 using namespace tir::transform;
 
 tvm::transform::Pass LowerSharedBarrier() {
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, PassContext ctx) {
     bool disable_shuffle_elect =
         ctx->GetConfig<Bool>(kDisableShuffleElect, Bool(false)).value();
     return tl::LowerSharedBarrier(std::move(f), disable_shuffle_elect);

--- a/src/transform/lower_thread_allreduce.cc
+++ b/src/transform/lower_thread_allreduce.cc
@@ -30,6 +30,7 @@
 #include <tvm/tir/transform.h>
 
 #include <unordered_set>
+#include <utility>
 
 #include "runtime/thread_storage_scope.h"
 #include "tir/transforms/ir_utils.h"
@@ -50,16 +51,16 @@ class AllocateCollector : public StmtExprVisitor {
 private:
   bool IsDynamicSharedMemory(Var buffer_var) {
     StorageScope storage_scope =
-        runtime::StorageScope::Create(GetPtrStorageScope(buffer_var));
+        runtime::StorageScope::Create(GetPtrStorageScope(std::move(buffer_var)));
     return storage_scope.rank == runtime::StorageRank::kShared &&
            storage_scope.tag == ".dyn";
   }
 
   bool IsStaticSharedMemory(Var buffer_var) {
     StorageScope storage_scope =
-        runtime::StorageScope::Create(GetPtrStorageScope(buffer_var));
+        runtime::StorageScope::Create(GetPtrStorageScope(std::move(buffer_var)));
     return storage_scope.rank == runtime::StorageRank::kShared &&
-           storage_scope.tag == "";
+           storage_scope.tag.empty();
   }
 
 public:
@@ -197,7 +198,7 @@ private:
   struct ThreadEntry {
     runtime::ThreadScope scope;
     IterVar iv;
-    int extent;
+    int extent{};
     // comparator
     bool operator<(const ThreadEntry &other) const {
       return scope.dim_index < other.scope.dim_index;
@@ -532,7 +533,7 @@ private:
 
     // Fix all local allocations as all statements are built.
     Stmt body = SeqStmt::Flatten(seq);
-    for (Buffer buf : new_alloc_bufs) {
+    for (const Buffer& buf : new_alloc_bufs) {
       body = DeclBuffer(buf, body);
       body = Allocate(buf->data, buf->dtype, buf->shape,
                       const_true(buf->dtype.lanes()), body);
@@ -545,9 +546,9 @@ private:
   MakeWarpAllreduce(std::vector<PrimExpr> src_values,            //
                     std::vector<DataType> dtypes,                //
                     const CommReducerNode *combiner,             //
-                    PrimExpr reduce_index, int reduce_extent,    //
-                    PrimExpr group_index,                        //
-                    PrimExpr mask, Optional<PrimExpr> predicate, //
+                    const PrimExpr& reduce_index, int reduce_extent,    //
+                    const PrimExpr& group_index,                        //
+                    const PrimExpr& mask, const Optional<PrimExpr>& predicate, //
                     std::vector<Stmt> *seq) {
     int n_buffers = src_values.size();
 
@@ -785,7 +786,7 @@ private:
                          int *out_total_extent) {
     int &total_extent = *out_total_extent;
     total_extent = 1;
-    if (tvec.size() == 0) {
+    if (tvec.empty()) {
       return make_zero(DataType::Int(32));
     }
 
@@ -802,7 +803,7 @@ private:
     return ret;
   }
   // The local buffer index.
-  PrimExpr BufIndex(PrimExpr reduce_index, PrimExpr group_index,
+  PrimExpr BufIndex(PrimExpr reduce_index, const PrimExpr& group_index,
                     int reduce_extent) {
     if (!is_zero(group_index)) {
       return analyzer_.Simplify(group_index * reduce_extent + reduce_index);
@@ -817,7 +818,7 @@ private:
   }
 
   // Emit warp shuffle  calls.
-  PrimExpr WarpShuffle(const Op &op, Optional<Buffer> mask_buffer, PrimExpr val,
+  PrimExpr WarpShuffle(const Op &op, const Optional<Buffer>& mask_buffer, const PrimExpr& val,
                        PrimExpr delta_or_lane) {
     Array<PrimExpr> indices = {0};
     PrimExpr mask;
@@ -827,7 +828,7 @@ private:
       mask = IntImm(DataType::Int(32), 0);
     }
     PrimExpr width = IntImm(DataType::Int(32), warp_size_);
-    Array<PrimExpr> args{mask, val, delta_or_lane, width, width};
+    Array<PrimExpr> args{mask, val, std::move(delta_or_lane), width, width};
     return Call(val.dtype(), op, args);
   }
 
@@ -904,7 +905,7 @@ private:
   // The maximum number of threads of the device. "-1" denotes unknown.
   int max_num_threads_{-1};
   // A boolean indicating if the target supports warp-level masking.
-  bool need_warp_shuffle_mask_;
+  bool need_warp_shuffle_mask_{};
 
   // surrounding scope of thread extent.
   std::vector<const AttrStmtNode *> thread_extents_;
@@ -925,7 +926,7 @@ namespace transform {
 using namespace tir::transform;
 
 tvm::transform::Pass LowerThreadAllreduce() {
-  auto pass_func = [](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     AllocateCollector collector;
     collector(f->body);
     bool is_dynamic = collector.dyn_shmem_allocs_.size() > 1;

--- a/src/transform/lower_thread_allreduce.cc
+++ b/src/transform/lower_thread_allreduce.cc
@@ -176,7 +176,6 @@ public:
     }
 
     BufferLoad load = Downcast<BufferLoad>(StmtExprMutator::VisitExpr_(op));
-    op = load.get();
 
     if (auto opt = GetRemappedBuffer(load->buffer)) {
       load.CopyOnWrite()->buffer = opt.value();

--- a/src/transform/lower_thread_allreduce.cc
+++ b/src/transform/lower_thread_allreduce.cc
@@ -50,15 +50,15 @@ class AllocateCollector : public StmtExprVisitor {
 
 private:
   bool IsDynamicSharedMemory(Var buffer_var) {
-    StorageScope storage_scope =
-        runtime::StorageScope::Create(GetPtrStorageScope(std::move(buffer_var)));
+    StorageScope storage_scope = runtime::StorageScope::Create(
+        GetPtrStorageScope(std::move(buffer_var)));
     return storage_scope.rank == runtime::StorageRank::kShared &&
            storage_scope.tag == ".dyn";
   }
 
   bool IsStaticSharedMemory(Var buffer_var) {
-    StorageScope storage_scope =
-        runtime::StorageScope::Create(GetPtrStorageScope(std::move(buffer_var)));
+    StorageScope storage_scope = runtime::StorageScope::Create(
+        GetPtrStorageScope(std::move(buffer_var)));
     return storage_scope.rank == runtime::StorageRank::kShared &&
            storage_scope.tag.empty();
   }
@@ -532,7 +532,7 @@ private:
 
     // Fix all local allocations as all statements are built.
     Stmt body = SeqStmt::Flatten(seq);
-    for (const Buffer& buf : new_alloc_bufs) {
+    for (const Buffer &buf : new_alloc_bufs) {
       body = DeclBuffer(buf, body);
       body = Allocate(buf->data, buf->dtype, buf->shape,
                       const_true(buf->dtype.lanes()), body);
@@ -542,12 +542,13 @@ private:
   }
 
   std::pair<std::vector<PrimExpr>, std::vector<Buffer>>
-  MakeWarpAllreduce(std::vector<PrimExpr> src_values,            //
-                    std::vector<DataType> dtypes,                //
-                    const CommReducerNode *combiner,             //
-                    const PrimExpr& reduce_index, int reduce_extent,    //
-                    const PrimExpr& group_index,                        //
-                    const PrimExpr& mask, const Optional<PrimExpr>& predicate, //
+  MakeWarpAllreduce(std::vector<PrimExpr> src_values,                //
+                    std::vector<DataType> dtypes,                    //
+                    const CommReducerNode *combiner,                 //
+                    const PrimExpr &reduce_index, int reduce_extent, //
+                    const PrimExpr &group_index,                     //
+                    const PrimExpr &mask,
+                    const Optional<PrimExpr> &predicate, //
                     std::vector<Stmt> *seq) {
     int n_buffers = src_values.size();
 
@@ -802,7 +803,7 @@ private:
     return ret;
   }
   // The local buffer index.
-  PrimExpr BufIndex(PrimExpr reduce_index, const PrimExpr& group_index,
+  PrimExpr BufIndex(PrimExpr reduce_index, const PrimExpr &group_index,
                     int reduce_extent) {
     if (!is_zero(group_index)) {
       return analyzer_.Simplify(group_index * reduce_extent + reduce_index);
@@ -817,8 +818,8 @@ private:
   }
 
   // Emit warp shuffle  calls.
-  PrimExpr WarpShuffle(const Op &op, const Optional<Buffer>& mask_buffer, const PrimExpr& val,
-                       PrimExpr delta_or_lane) {
+  PrimExpr WarpShuffle(const Op &op, const Optional<Buffer> &mask_buffer,
+                       const PrimExpr &val, PrimExpr delta_or_lane) {
     Array<PrimExpr> indices = {0};
     PrimExpr mask;
     if (mask_buffer.defined()) {
@@ -925,7 +926,7 @@ namespace transform {
 using namespace tir::transform;
 
 tvm::transform::Pass LowerThreadAllreduce() {
-  auto pass_func = [](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     AllocateCollector collector;
     collector(f->body);
     bool is_dynamic = collector.dyn_shmem_allocs_.size() > 1;

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -77,7 +77,7 @@ public:
 
   void Clear() { buffer_var_gemm_.clear(); }
 
-  void Collect(Stmt stmt) { VisitStmt(stmt); }
+  void Collect(const Stmt& stmt) { VisitStmt(stmt); }
 
   Array<Var> GetBufferVarGemm() { return buffer_var_gemm_; }
 
@@ -131,7 +131,7 @@ public:
    * remapping. \param stmt The statement to rewrite. \param buffer_remap A map
    * from old buffers to new buffers. \return The rewritten statement.
    */
-  static Stmt Substitute(Stmt stmt, Map<Buffer, Buffer> buffer_remap) {
+  static Stmt Substitute(const Stmt& stmt, Map<Buffer, Buffer> buffer_remap) {
     arith::Analyzer analyzer;
     RemapBufferRewriter substituter(&analyzer);
     substituter.buffer_remap_ = std::move(buffer_remap);
@@ -277,7 +277,7 @@ private:
     return block;
   }
 
-  int CheckAndGetBufferRowSize(Buffer buffer) {
+  int CheckAndGetBufferRowSize(const Buffer& buffer) {
     CHECK(buffer->shape.size() >= 2)
         << "The dimension of Buffer \"" << buffer->name << "\" with shape "
         << buffer->shape << " should be at least 2";
@@ -287,8 +287,8 @@ private:
     return buffer_row_size;
   }
 
-  PrimExpr HandleAccessPtrAndOffset(PrimExpr access_ptr,
-                                    Optional<PrimExpr> offset = std::nullopt,
+  PrimExpr HandleAccessPtrAndOffset(const PrimExpr& access_ptr,
+                                    const Optional<PrimExpr>& offset = std::nullopt,
                                     DataType dtype = DataType::Int(32)) {
     // The 2th arg of T.tvm_access_ptr call is offset, we set it to 0 and
     // accumulate it to smem_offset
@@ -541,7 +541,7 @@ namespace transform {
 using namespace tir::transform;
 
 tvm::transform::Pass LowerTileOp() {
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     return LowerTileOpPass::Substitute(std::move(f));
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.LowerTileOp", {});

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -77,7 +77,7 @@ public:
 
   void Clear() { buffer_var_gemm_.clear(); }
 
-  void Collect(const Stmt& stmt) { VisitStmt(stmt); }
+  void Collect(const Stmt &stmt) { VisitStmt(stmt); }
 
   Array<Var> GetBufferVarGemm() { return buffer_var_gemm_; }
 
@@ -131,7 +131,7 @@ public:
    * remapping. \param stmt The statement to rewrite. \param buffer_remap A map
    * from old buffers to new buffers. \return The rewritten statement.
    */
-  static Stmt Substitute(const Stmt& stmt, Map<Buffer, Buffer> buffer_remap) {
+  static Stmt Substitute(const Stmt &stmt, Map<Buffer, Buffer> buffer_remap) {
     arith::Analyzer analyzer;
     RemapBufferRewriter substituter(&analyzer);
     substituter.buffer_remap_ = std::move(buffer_remap);
@@ -277,7 +277,7 @@ private:
     return block;
   }
 
-  int CheckAndGetBufferRowSize(const Buffer& buffer) {
+  int CheckAndGetBufferRowSize(const Buffer &buffer) {
     CHECK(buffer->shape.size() >= 2)
         << "The dimension of Buffer \"" << buffer->name << "\" with shape "
         << buffer->shape << " should be at least 2";
@@ -287,9 +287,10 @@ private:
     return buffer_row_size;
   }
 
-  PrimExpr HandleAccessPtrAndOffset(const PrimExpr& access_ptr,
-                                    const Optional<PrimExpr>& offset = std::nullopt,
-                                    DataType dtype = DataType::Int(32)) {
+  PrimExpr
+  HandleAccessPtrAndOffset(const PrimExpr &access_ptr,
+                           const Optional<PrimExpr> &offset = std::nullopt,
+                           DataType dtype = DataType::Int(32)) {
     // The 2th arg of T.tvm_access_ptr call is offset, we set it to 0 and
     // accumulate it to smem_offset
     CHECK(access_ptr->IsInstance<CallNode>())
@@ -541,7 +542,7 @@ namespace transform {
 using namespace tir::transform;
 
 tvm::transform::Pass LowerTileOp() {
-  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     return LowerTileOpPass::Substitute(std::move(f));
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.LowerTileOp", {});

--- a/src/transform/make_packed_api.cc
+++ b/src/transform/make_packed_api.cc
@@ -48,7 +48,7 @@ namespace {
 class ReturnRewriter : public StmtMutator {
 public:
   explicit ReturnRewriter(Var ret_var, Var ret_tcode)
-      : ret_var_(ret_var), ret_tcode_(ret_tcode) {}
+      : ret_var_(std::move(ret_var)), ret_tcode_(std::move(ret_tcode)) {}
 
   Stmt VisitStmt_(const ForNode *node) override {
     if (node->kind == ForKind::kParallel)
@@ -82,7 +82,7 @@ private:
     Buffer dummy_tcode_buffer;
   };
 
-  ConvertedInfo ConvertForFFI(PrimExpr val) {
+  ConvertedInfo ConvertForFFI(const PrimExpr& val) {
     ConvertedInfo info;
 
     // convert val's data type to FFI data type, return type code
@@ -124,7 +124,7 @@ private:
     return info;
   }
 
-  Stmt WriteToOut(PrimExpr val) {
+  Stmt WriteToOut(const PrimExpr& val) {
     auto info = ConvertForFFI(val);
     Stmt store_val = BufferStore(info.dummy_val_buffer, info.expr, {0});
     Stmt store_tcode =
@@ -142,8 +142,8 @@ private:
 };
 
 Stmt RewriteReturn(Stmt body, Var ret_var, Var ret_tcode) {
-  ReturnRewriter rewriter(ret_var, ret_tcode);
-  return rewriter(body);
+  ReturnRewriter rewriter(std::move(ret_var), std::move(ret_tcode));
+  return rewriter(std::move(body));
 }
 
 class SubroutineCallRewriter : public StmtExprMutator {
@@ -151,7 +151,7 @@ public:
   static Optional<Stmt> Apply(const Map<GlobalVar, String> &packed_func_methods,
                               Stmt stmt) {
     SubroutineCallRewriter rewriter(packed_func_methods);
-    stmt = rewriter.VisitStmt(std::move(stmt));
+    stmt = rewriter.VisitStmt(stmt);
     if (rewriter.made_change_) {
       return stmt;
     } else {
@@ -192,12 +192,12 @@ private:
 
 } // namespace
 
-inline Stmt MakeAssertEQ(PrimExpr lhs, PrimExpr rhs, std::string msg) {
-  return AssertStmt(lhs == rhs, tvm::tir::StringImm(msg), Evaluate(0));
+inline Stmt MakeAssertEQ(PrimExpr lhs, PrimExpr rhs, const std::string& msg) {
+  return AssertStmt(std::move(lhs) == std::move(rhs), tvm::tir::StringImm(msg), Evaluate(0));
 }
 
-inline Stmt MakeAssertNotNull(PrimExpr ptr, std::string msg) {
-  Call isnull(DataType::Bool(), builtin::isnullptr(), {ptr});
+inline Stmt MakeAssertNotNull(PrimExpr ptr, const std::string& msg) {
+  Call isnull(DataType::Bool(), builtin::isnullptr(), {std::move(ptr)});
   return AssertStmt(!isnull, tvm::tir::StringImm(msg), Evaluate(0));
 }
 
@@ -472,7 +472,7 @@ PrimFunc MakePackedAPI(PrimFunc func) {
 
 tvm::transform::Pass MakePackedAPI() {
   using tvm::transform::Pass;
-  auto pass_func = [](IRModule mod, tvm::transform::PassContext ctx) {
+  auto pass_func = [](IRModule mod, const tvm::transform::PassContext& ctx) {
     Map<GlobalVar, String> packed_func_methods;
     for (const auto &[gvar, base_func] : mod->functions) {
       if (auto opt = base_func.as<PrimFunc>()) {
@@ -504,7 +504,7 @@ tvm::transform::Pass MakePackedAPI() {
       }
     }
 
-    if (updates->functions.size()) {
+    if (!updates->functions.empty()) {
       mod.CopyOnWrite()->Update(updates);
     }
     return mod;

--- a/src/transform/make_packed_api.cc
+++ b/src/transform/make_packed_api.cc
@@ -82,7 +82,7 @@ private:
     Buffer dummy_tcode_buffer;
   };
 
-  ConvertedInfo ConvertForFFI(const PrimExpr& val) {
+  ConvertedInfo ConvertForFFI(const PrimExpr &val) {
     ConvertedInfo info;
 
     // convert val's data type to FFI data type, return type code
@@ -124,7 +124,7 @@ private:
     return info;
   }
 
-  Stmt WriteToOut(const PrimExpr& val) {
+  Stmt WriteToOut(const PrimExpr &val) {
     auto info = ConvertForFFI(val);
     Stmt store_val = BufferStore(info.dummy_val_buffer, info.expr, {0});
     Stmt store_tcode =
@@ -192,11 +192,12 @@ private:
 
 } // namespace
 
-inline Stmt MakeAssertEQ(PrimExpr lhs, PrimExpr rhs, const std::string& msg) {
-  return AssertStmt(std::move(lhs) == std::move(rhs), tvm::tir::StringImm(msg), Evaluate(0));
+inline Stmt MakeAssertEQ(PrimExpr lhs, PrimExpr rhs, const std::string &msg) {
+  return AssertStmt(std::move(lhs) == std::move(rhs), tvm::tir::StringImm(msg),
+                    Evaluate(0));
 }
 
-inline Stmt MakeAssertNotNull(PrimExpr ptr, const std::string& msg) {
+inline Stmt MakeAssertNotNull(PrimExpr ptr, const std::string &msg) {
   Call isnull(DataType::Bool(), builtin::isnullptr(), {std::move(ptr)});
   return AssertStmt(!isnull, tvm::tir::StringImm(msg), Evaluate(0));
 }
@@ -472,7 +473,7 @@ PrimFunc MakePackedAPI(PrimFunc func) {
 
 tvm::transform::Pass MakePackedAPI() {
   using tvm::transform::Pass;
-  auto pass_func = [](IRModule mod, const tvm::transform::PassContext& ctx) {
+  auto pass_func = [](IRModule mod, const tvm::transform::PassContext &ctx) {
     Map<GlobalVar, String> packed_func_methods;
     for (const auto &[gvar, base_func] : mod->functions) {
       if (auto opt = base_func.as<PrimFunc>()) {

--- a/src/transform/merge_if_stmt.cc
+++ b/src/transform/merge_if_stmt.cc
@@ -92,7 +92,7 @@ private:
 
 using namespace tir::transform;
 tvm::transform::Pass MergeIfStmt() {
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     return MergeIfStmtRewriter::Substitute(f);
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.MergeIfStmt", {});

--- a/src/transform/merge_if_stmt.cc
+++ b/src/transform/merge_if_stmt.cc
@@ -92,7 +92,7 @@ private:
 
 using namespace tir::transform;
 tvm::transform::Pass MergeIfStmt() {
-  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     return MergeIfStmtRewriter::Substitute(f);
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.MergeIfStmt", {});

--- a/src/transform/merge_shared_memory_allocations.cc
+++ b/src/transform/merge_shared_memory_allocations.cc
@@ -33,6 +33,7 @@
 
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 #include "../op/builtin.h"
 #include "../target/utils.h"
@@ -51,16 +52,16 @@ using runtime::StorageScope;
 
 static bool IsDynamicSharedMemory(Var buffer_var) {
   StorageScope storage_scope =
-      runtime::StorageScope::Create(GetPtrStorageScope(buffer_var));
+      runtime::StorageScope::Create(GetPtrStorageScope(std::move(buffer_var)));
   return storage_scope.rank == runtime::StorageRank::kShared &&
          storage_scope.tag == ".dyn";
 }
 
 static bool IsStaticSharedMemory(Var buffer_var) {
   StorageScope storage_scope =
-      runtime::StorageScope::Create(GetPtrStorageScope(buffer_var));
+      runtime::StorageScope::Create(GetPtrStorageScope(std::move(buffer_var)));
   return storage_scope.rank == runtime::StorageRank::kShared &&
-         storage_scope.tag == "";
+         storage_scope.tag.empty();
 }
 
 /*!
@@ -106,7 +107,7 @@ public:
   /*! \brief record the touch list of statement. */
   struct StmtEntry {
     // The statement
-    const Object *stmt;
+    const Object *stmt{};
     // The index in the linear_seq_ to point to end of the nested scope.
     // This is only set to non-zero if stmt is a nested scope.
     // if offset > 0, means this is the begin, the end entry is current_index +
@@ -167,7 +168,7 @@ public:
 
     StmtEntry e = scope_.back();
     scope_.pop_back();
-    if (e.touched.size() != 0) {
+    if (!e.touched.empty()) {
       e.stmt = op;
       UpdateStmtAttr(op, scope_level_);
       linear_seq_.push_back(e);
@@ -180,7 +181,7 @@ public:
     StmtExprVisitor::VisitStmt_(op);
     StmtEntry e = scope_.back();
     scope_.pop_back();
-    if (e.touched.size() != 0) {
+    if (!e.touched.empty()) {
       e.stmt = op;
       UpdateStmtAttr(op, scope_level_);
       linear_seq_.push_back(e);
@@ -602,7 +603,7 @@ private:
     }
   }
 
-  PrimExpr GetBufferOffset(Var buffer_var, DataType dtype) {
+  PrimExpr GetBufferOffset(const Var& buffer_var, DataType dtype) {
     auto it = buffer_byte_offsets_.find(buffer_var.get());
     ICHECK(it != buffer_byte_offsets_.end())
         << "buffer_var = " << buffer_var->name_hint << ", dtype = " << dtype;
@@ -750,8 +751,8 @@ private:
     std::vector<StmtEntry> gen_kill_seq;
     for (const auto &stmt_entry : seq) {
       // if has gen and kill, add to gen_kill_seq
-      if (event_map_[stmt_entry.stmt].gen.size() > 0 ||
-          event_map_[stmt_entry.stmt].kill.size() > 0) {
+      if (!event_map_[stmt_entry.stmt].gen.empty() ||
+          !event_map_[stmt_entry.stmt].kill.empty()) {
         gen_kill_seq.push_back(stmt_entry);
       }
     }
@@ -1108,7 +1109,7 @@ namespace transform {
 Pass MergeSharedMemoryAllocations(bool enable_aggressive_merge = false,
                                   int align_bytes = 16) {
   auto pass_func = [enable_aggressive_merge,
-                    align_bytes](PrimFunc f, IRModule m, PassContext ctx) {
+                    align_bytes](PrimFunc f, const IRModule& m, PassContext ctx) {
     bool merge_static_smem =
         ctx->GetConfig<Bool>("tir.merge_static_smem", Bool(false)).value();
     bool debug_merge_shared_memory_allocations =

--- a/src/transform/merge_shared_memory_allocations.cc
+++ b/src/transform/merge_shared_memory_allocations.cc
@@ -603,7 +603,7 @@ private:
     }
   }
 
-  PrimExpr GetBufferOffset(const Var& buffer_var, DataType dtype) {
+  PrimExpr GetBufferOffset(const Var &buffer_var, DataType dtype) {
     auto it = buffer_byte_offsets_.find(buffer_var.get());
     ICHECK(it != buffer_byte_offsets_.end())
         << "buffer_var = " << buffer_var->name_hint << ", dtype = " << dtype;
@@ -1108,8 +1108,8 @@ namespace transform {
 
 Pass MergeSharedMemoryAllocations(bool enable_aggressive_merge = false,
                                   int align_bytes = 16) {
-  auto pass_func = [enable_aggressive_merge,
-                    align_bytes](PrimFunc f, const IRModule& m, PassContext ctx) {
+  auto pass_func = [enable_aggressive_merge, align_bytes](
+                       PrimFunc f, const IRModule &m, PassContext ctx) {
     bool merge_static_smem =
         ctx->GetConfig<Bool>("tir.merge_static_smem", Bool(false)).value();
     bool debug_merge_shared_memory_allocations =

--- a/src/transform/multi_version_buffer_rewriter.cc
+++ b/src/transform/multi_version_buffer_rewriter.cc
@@ -137,8 +137,8 @@ public:
 private:
   MultiVersionBufferRewriter() = default;
 
-  Array<Buffer> GetVersionedBuffers(const Array<Stmt>& seq_stmt,
-                                    const Array<Buffer>& scoped_buffers) {
+  Array<Buffer> GetVersionedBuffers(const Array<Stmt> &seq_stmt,
+                                    const Array<Buffer> &scoped_buffers) {
     std::vector<Role> roles;
     Array<Array<BufferRegion>> reads, writes;
     auto marker = WarpSpecializedRoleMarker_(buffer_data_to_buffer_);
@@ -279,10 +279,12 @@ private:
   }
 
   PrimExpr RewriteBufferAccess(const Call &call,
-                               const std::vector<int>& arg_indices) {
+                               const std::vector<int> &arg_indices) {
     auto product = [](const Array<PrimExpr> &input) {
       return foldl(
-          [](PrimExpr a, PrimExpr b, Span span) { return mul(std::move(a), std::move(b), std::move(span)); },
+          [](PrimExpr a, PrimExpr b, Span span) {
+            return mul(std::move(a), std::move(b), std::move(span));
+          },
           make_const(DataType::Int(32), 1), input);
     };
     Array<PrimExpr> new_args = call->args;
@@ -318,7 +320,7 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass MultiVersionBuffer() {
-  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     return MultiVersionBufferRewriter::Substitute(f);
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.MultiVersionBuffer", {});

--- a/src/transform/multi_version_buffer_rewriter.cc
+++ b/src/transform/multi_version_buffer_rewriter.cc
@@ -10,6 +10,8 @@
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/tir/transform.h>
 
+#include <utility>
+
 #include "../op/builtin.h"
 
 namespace tvm {
@@ -22,7 +24,7 @@ enum class Role { kConsumer, kProducer, kBoth };
 class WarpSpecializedRoleMarker_ : public StmtVisitor {
 public:
   WarpSpecializedRoleMarker_(Map<Var, Buffer> buffer_data_to_buffer)
-      : buffer_data_to_buffer_(buffer_data_to_buffer) {}
+      : buffer_data_to_buffer_(std::move(buffer_data_to_buffer)) {}
 
   Role GetRole(const StmtNode *stmt) const {
     auto it = map_.find(stmt);
@@ -135,8 +137,8 @@ public:
 private:
   MultiVersionBufferRewriter() = default;
 
-  Array<Buffer> GetVersionedBuffers(Array<Stmt> seq_stmt,
-                                    Array<Buffer> scoped_buffers) {
+  Array<Buffer> GetVersionedBuffers(const Array<Stmt>& seq_stmt,
+                                    const Array<Buffer>& scoped_buffers) {
     std::vector<Role> roles;
     Array<Array<BufferRegion>> reads, writes;
     auto marker = WarpSpecializedRoleMarker_(buffer_data_to_buffer_);
@@ -145,8 +147,8 @@ private:
       Block block(/*iter_vars=*/{}, /*reads=*/{}, /*writes=*/{},
                   /*name_hint=*/"", /*body*/ stmt);
       auto access = GetBlockAccessRegion(block, buffer_data_to_buffer_);
-      reads.push_back(std::move(access[0]));
-      writes.push_back(std::move(access[1]));
+      reads.push_back(access[0]);
+      writes.push_back(access[1]);
       roles.push_back(marker.GetRole(stmt));
     }
 
@@ -173,7 +175,7 @@ private:
   static Buffer RewriteAllocBuffer(const Buffer &buffer, int num_versions) {
     ObjectPtr<BufferNode> new_buffer = make_object<BufferNode>(*(buffer.get()));
     new_buffer->shape.insert(new_buffer->shape.begin(), PrimExpr(num_versions));
-    if (new_buffer->strides.size()) {
+    if (!new_buffer->strides.empty()) {
       ICHECK(new_buffer->strides.size() + 1 == new_buffer->shape.size());
       PrimExpr stride_0 = new_buffer->strides[0] * new_buffer->shape[1];
       new_buffer->strides.insert(new_buffer->strides.begin(), stride_0);
@@ -277,10 +279,10 @@ private:
   }
 
   PrimExpr RewriteBufferAccess(const Call &call,
-                               const std::vector<int> arg_indices) {
+                               const std::vector<int>& arg_indices) {
     auto product = [](const Array<PrimExpr> &input) {
       return foldl(
-          [](PrimExpr a, PrimExpr b, Span span) { return mul(a, b, span); },
+          [](PrimExpr a, PrimExpr b, Span span) { return mul(std::move(a), std::move(b), std::move(span)); },
           make_const(DataType::Int(32), 1), input);
     };
     Array<PrimExpr> new_args = call->args;
@@ -316,7 +318,7 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass MultiVersionBuffer() {
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     return MultiVersionBufferRewriter::Substitute(f);
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.MultiVersionBuffer", {});

--- a/src/transform/multi_version_buffer_rewriter.cc
+++ b/src/transform/multi_version_buffer_rewriter.cc
@@ -19,7 +19,7 @@ namespace tl {
 
 using namespace tir;
 
-enum class Role { kConsumer, kProducer, kBoth };
+enum class Role : uint8_t { kConsumer, kProducer, kBoth };
 
 class WarpSpecializedRoleMarker_ : public StmtVisitor {
 public:

--- a/src/transform/persist_threadblock.cc
+++ b/src/transform/persist_threadblock.cc
@@ -53,7 +53,7 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass PersistThreadblock() {
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     return PersistThreadblock::Substitute(f);
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.PersistThreadblock", {});

--- a/src/transform/persist_threadblock.cc
+++ b/src/transform/persist_threadblock.cc
@@ -53,7 +53,7 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass PersistThreadblock() {
-  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     return PersistThreadblock::Substitute(f);
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.PersistThreadblock", {});

--- a/src/transform/pipeline_planning.cc
+++ b/src/transform/pipeline_planning.cc
@@ -5,6 +5,8 @@
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/tir/transform.h>
 
+#include <utility>
+
 #include "../target/utils.h"
 #include "tvm/ir/expr.h"
 
@@ -19,7 +21,7 @@ using namespace tir;
  * \param region2 The second region.
  * \return Whether region1 and region2 have intersections.
  */
-bool MayConflict(Region region1, Region region2) {
+bool MayConflict(const Region& region1, const Region& region2) {
   ICHECK(region1.size() == region2.size());
   for (size_t i = 0; i < region1.size(); i++) {
     Range dim1 = region1[i];
@@ -42,7 +44,7 @@ bool MayConflict(Region region1, Region region2) {
 class BufferRegionCollector : public StmtExprVisitor {
 public:
   BufferRegionCollector(Map<Var, Buffer> buffer_data_to_buffer)
-      : buffer_data_to_buffer_(buffer_data_to_buffer) {}
+      : buffer_data_to_buffer_(std::move(buffer_data_to_buffer)) {}
 
   Array<BufferRegion> GetReads() const { return reads_; }
 
@@ -182,7 +184,7 @@ private:
    */
   struct PipelineStageInfo {
     Array<BufferRegion> reads, writes;
-    int original_stmt_index;
+    int original_stmt_index{};
     int order = -1, stage = -1;
     bool copy_stage = false;
     bool producer_for_copy = false;
@@ -200,7 +202,7 @@ private:
 
   PipelineStageInfo MakePipelineStageInfo(Stmt stmt, int idx) {
     Block block(/*iter_vars=*/{}, /*reads=*/{}, /*writes=*/{}, /*name_hint=*/"",
-                /*body*/ stmt);
+                /*body*/ std::move(stmt));
     Array<Array<BufferRegion>> access =
         GetBlockReadWriteRegion(block, buffer_data_to_buffer_);
     auto collector = BufferRegionCollector(buffer_data_to_buffer_);
@@ -555,12 +557,12 @@ private:
 
   Map<Var, Buffer> buffer_data_to_buffer_;
   Target target_;
-  bool use_async_copy_;
+  bool use_async_copy_{};
 };
 
 tvm::transform::Pass PipelinePlanning() {
   using namespace tir::transform;
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, PassContext ctx) {
     bool use_async_copy =
         ctx->GetConfig<Bool>("tir.use_async_copy", Bool(true)).value();
     PrimFuncNode *fptr = f.CopyOnWrite();

--- a/src/transform/pipeline_planning.cc
+++ b/src/transform/pipeline_planning.cc
@@ -21,7 +21,7 @@ using namespace tir;
  * \param region2 The second region.
  * \return Whether region1 and region2 have intersections.
  */
-bool MayConflict(const Region& region1, const Region& region2) {
+bool MayConflict(const Region &region1, const Region &region2) {
   ICHECK(region1.size() == region2.size());
   for (size_t i = 0; i < region1.size(); i++) {
     Range dim1 = region1[i];
@@ -562,7 +562,7 @@ private:
 
 tvm::transform::Pass PipelinePlanning() {
   using namespace tir::transform;
-  auto pass_func = [=](PrimFunc f, const IRModule& m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, PassContext ctx) {
     bool use_async_copy =
         ctx->GetConfig<Bool>("tir.use_async_copy", Bool(true)).value();
     PrimFuncNode *fptr = f.CopyOnWrite();

--- a/src/transform/simplify.cc
+++ b/src/transform/simplify.cc
@@ -217,9 +217,10 @@ TVM_REGISTER_PASS_CONFIG_OPTION("tl.Simplify", SimplifyConfig);
 
 class StmtSimplifier : public IRMutatorWithAnalyzer {
 public:
-  static PrimFunc Apply(PrimFunc func, Analyzer *analyzer,
-                        const Optional<SimplifyConfig>& config_opt = std::nullopt,
-                        bool simplify_arguments = false) {
+  static PrimFunc
+  Apply(PrimFunc func, Analyzer *analyzer,
+        const Optional<SimplifyConfig> &config_opt = std::nullopt,
+        bool simplify_arguments = false) {
     auto config = config_opt.value_or(AttrsWithDefaultValues<SimplifyConfig>());
     analyzer->rewrite_simplify.SetEnabledExtensions(
         config->GetEnabledExtensions());
@@ -276,8 +277,8 @@ private:
       std::optional<ControlFlowGraph> touch_pattern,
       std::unordered_set<const VarNode *> used_in_buffer_def)
       : IRMutatorWithAnalyzer(analyzer), config_(std::move(config)),
-        touch_pattern_(std::move(touch_pattern)), used_in_buffer_def_(std::move(used_in_buffer_def)) {
-  }
+        touch_pattern_(std::move(touch_pattern)),
+        used_in_buffer_def_(std::move(used_in_buffer_def)) {}
 
   using Parent = IRMutatorWithAnalyzer;
   using Parent::VisitExpr_;
@@ -478,10 +479,11 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass Simplify(bool simplify_arguments = true) {
-  auto pass_func = [=](PrimFunc f, const IRModule& m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, PassContext ctx) {
     arith::Analyzer analyzer;
     auto cfg = ctx->GetConfig<SimplifyConfig>("tl.Simplify");
-    return StmtSimplifier::Apply(std::move(f), &analyzer, cfg, simplify_arguments);
+    return StmtSimplifier::Apply(std::move(f), &analyzer, cfg,
+                                 simplify_arguments);
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.Simplify", {});
 }

--- a/src/transform/simplify.cc
+++ b/src/transform/simplify.cc
@@ -11,6 +11,8 @@
 #include <tvm/tir/transform.h>
 #include <tvm/tir/utils.h>
 
+#include <utility>
+
 #include "arith/ir_mutator_with_analyzer.h"
 #include "tir/analysis/control_flow_graph.h"
 #include "tir/analysis/var_use_def_analysis.h"
@@ -22,11 +24,11 @@ using namespace tir;
 using namespace arith;
 
 struct SimplifyConfigNode : public AttrsNodeReflAdapter<SimplifyConfigNode> {
-  bool transitively_prove_inequalities;
-  bool propagate_knowns_to_prove_conditional;
-  bool propagate_knowns_to_simplify_expressions;
-  bool convert_boolean_to_and_of_ors;
-  bool apply_constraints_to_boolean_branches;
+  bool transitively_prove_inequalities{};
+  bool propagate_knowns_to_prove_conditional{};
+  bool propagate_knowns_to_simplify_expressions{};
+  bool convert_boolean_to_and_of_ors{};
+  bool apply_constraints_to_boolean_branches{};
 
   static void RegisterReflection() {
     namespace refl = tvm::ffi::reflection;
@@ -85,7 +87,7 @@ CollectUsedBuffers(const PrimFunc &func) {
     using StmtExprVisitor::VisitExpr_;
     using StmtExprVisitor::VisitStmt_;
 
-    Visitor(PrimFunc func) : func(func) {}
+    Visitor(PrimFunc func) : func(std::move(func)) {}
 
     void VisitExpr_(const CallNode *op) override {
       for (const auto &arg : op->args) {
@@ -216,7 +218,7 @@ TVM_REGISTER_PASS_CONFIG_OPTION("tl.Simplify", SimplifyConfig);
 class StmtSimplifier : public IRMutatorWithAnalyzer {
 public:
   static PrimFunc Apply(PrimFunc func, Analyzer *analyzer,
-                        Optional<SimplifyConfig> config_opt = std::nullopt,
+                        const Optional<SimplifyConfig>& config_opt = std::nullopt,
                         bool simplify_arguments = false) {
     auto config = config_opt.value_or(AttrsWithDefaultValues<SimplifyConfig>());
     analyzer->rewrite_simplify.SetEnabledExtensions(
@@ -273,8 +275,8 @@ private:
       Analyzer *analyzer, SimplifyConfig config,
       std::optional<ControlFlowGraph> touch_pattern,
       std::unordered_set<const VarNode *> used_in_buffer_def)
-      : IRMutatorWithAnalyzer(analyzer), config_(config),
-        touch_pattern_(touch_pattern), used_in_buffer_def_(used_in_buffer_def) {
+      : IRMutatorWithAnalyzer(analyzer), config_(std::move(config)),
+        touch_pattern_(std::move(touch_pattern)), used_in_buffer_def_(std::move(used_in_buffer_def)) {
   }
 
   using Parent = IRMutatorWithAnalyzer;
@@ -476,10 +478,10 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass Simplify(bool simplify_arguments = true) {
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, PassContext ctx) {
     arith::Analyzer analyzer;
     auto cfg = ctx->GetConfig<SimplifyConfig>("tl.Simplify");
-    return StmtSimplifier::Apply(f, &analyzer, cfg, simplify_arguments);
+    return StmtSimplifier::Apply(std::move(f), &analyzer, cfg, simplify_arguments);
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.Simplify", {});
 }

--- a/src/transform/storage_access.cc
+++ b/src/transform/storage_access.cc
@@ -287,7 +287,8 @@ void TileLangStorageAccessVisitor::VisitExpr_(const CallNode *op) {
       Array<Range> buffer_ranges;
       // from indices to buffer indices
       ICHECK(buffer->shape.size() == load->indices.size());
-      // Use buffer shape and indices to compute the buffer_ranges for each dimension.
+      // Use buffer shape and indices to compute the buffer_ranges for each
+      // dimension.
       for (size_t i = 0; i < buffer->shape.size(); ++i) {
         PrimExpr min = load->indices[i];
         PrimExpr extent = make_const(buffer->shape[i].dtype(), 1);
@@ -394,8 +395,8 @@ void TileLangStorageAccessVisitor::VisitExpr_(const CallNode *op) {
   }
 }
 
-Map<Var, Range>
-TileLangStorageAccessVisitor::ComputeThreadRange(const Array<IterVar>& threads) {
+Map<Var, Range> TileLangStorageAccessVisitor::ComputeThreadRange(
+    const Array<IterVar> &threads) {
   Map<Var, Range> thread_range;
   for (const auto &th : threads) {
     auto thread_tag = th->thread_tag;
@@ -413,7 +414,8 @@ TileLangStorageAccessVisitor::ComputeThreadRange(const Array<IterVar>& threads) 
   return thread_range;
 }
 
-StorageScope TileLangStorageAccessVisitor::GetScope(const Var& buffer_var) const {
+StorageScope
+TileLangStorageAccessVisitor::GetScope(const Var &buffer_var) const {
   if (buffer_var->type_annotation.as<PointerTypeNode>()) {
     return StorageScope::Create(GetPtrStorageScope(buffer_var));
   }

--- a/src/transform/storage_access.h
+++ b/src/transform/storage_access.h
@@ -144,13 +144,13 @@ protected:
    * \param threads The threads to compute the range for.
    * \return The thread range.
    */
-  Map<Var, Range> ComputeThreadRange(const Array<IterVar>& threads);
+  Map<Var, Range> ComputeThreadRange(const Array<IterVar> &threads);
 
   /*!
    * \brief Get the scope of the buffer array.
    * \return The scope of the final buffer array.
    */
-  StorageScope GetScope(const Var& buffer_var) const;
+  StorageScope GetScope(const Var &buffer_var) const;
   // access scope
   std::vector<std::vector<StmtEntry>> scope_;
 

--- a/src/transform/storage_access.h
+++ b/src/transform/storage_access.h
@@ -88,7 +88,7 @@ public:
   /*! \brief Access pattern about a single statement */
   struct StmtEntry {
     /*! \brief The statement */
-    const Object *stmt;
+    const Object *stmt{};;{};
     /*! \brief access patterns in the statement */
     std::vector<AccessEntry> access;
   };
@@ -144,13 +144,13 @@ protected:
    * \param threads The threads to compute the range for.
    * \return The thread range.
    */
-  Map<Var, Range> ComputeThreadRange(Array<IterVar> threads);
+  Map<Var, Range> ComputeThreadRange(const Array<IterVar>& threads);
 
   /*!
    * \brief Get the scope of the buffer array.
    * \return The scope of the final buffer array.
    */
-  StorageScope GetScope(Var buffer_var) const;
+  StorageScope GetScope(const Var& buffer_var) const;
   // access scope
   std::vector<std::vector<StmtEntry>> scope_;
 

--- a/src/transform/storage_access.h
+++ b/src/transform/storage_access.h
@@ -49,7 +49,7 @@ using runtime::StorageScope;
 class TileLangStorageAccessVisitor : public IRVisitorWithAnalyzer {
 public:
   /*! \brief Storage access type */
-  enum AccessType {
+  enum AccessType : uint8_t {
     kRead,
     kWrite,
     kSync,
@@ -88,7 +88,7 @@ public:
   /*! \brief Access pattern about a single statement */
   struct StmtEntry {
     /*! \brief The statement */
-    const Object *stmt{};;{};
+    const Object *stmt{};
     /*! \brief access patterns in the statement */
     std::vector<AccessEntry> access;
   };

--- a/src/transform/storage_rewrite.cc
+++ b/src/transform/storage_rewrite.cc
@@ -346,15 +346,15 @@ public:
     src_ = src;
     result_ = true;
     if (stmt->IsInstance<AttrStmtNode>()) {
-      VisitStmt_(static_cast<const AttrStmtNode *>(stmt));
+      VisitStmt_(reinterpret_cast<const AttrStmtNode *>(stmt));
     } else if (stmt->IsInstance<ForNode>()) {
-      VisitStmt_(static_cast<const ForNode *>(stmt));
+      VisitStmt_(reinterpret_cast<const ForNode *>(stmt));
     } else if (stmt->IsInstance<IfThenElseNode>()) {
-      VisitStmt_(static_cast<const IfThenElseNode *>(stmt));
+      VisitStmt_(reinterpret_cast<const IfThenElseNode *>(stmt));
     } else if (stmt->IsInstance<WhileNode>()) {
-      VisitStmt_(static_cast<const WhileNode *>(stmt));
+      VisitStmt_(reinterpret_cast<const WhileNode *>(stmt));
     } else if (stmt->IsInstance<BufferStoreNode>()) {
-      VisitStmt_(static_cast<const BufferStoreNode *>(stmt));
+      VisitStmt_(reinterpret_cast<const BufferStoreNode *>(stmt));
     } else {
       return false;
     }
@@ -994,7 +994,7 @@ private:
       }
       // enter/exit new scope
       if (s.stmt->IsInstance<AttrStmtNode>()) {
-        const auto *op = static_cast<const AttrStmtNode *>(s.stmt);
+        const auto *op = reinterpret_cast<const AttrStmtNode *>(s.stmt);
         if (op->attr_key == tir::attr::thread_extent ||
             op->attr_key == tir::attr::virtual_thread ||
             tir::attr::IsPragmaKey(op->attr_key)) {
@@ -1003,7 +1003,7 @@ private:
           ICHECK(op->attr_key == tir::attr::extern_scope);
         }
       } else if (s.stmt->IsInstance<ForNode>()) {
-        const auto *op = static_cast<const ForNode *>(s.stmt);
+        const auto *op = reinterpret_cast<const ForNode *>(s.stmt);
         if (op->kind == ForKind::kParallel) {
           if (thread_scope_ == nullptr || thread_scope_ == op) {
             PlanNewScope(op);
@@ -1183,7 +1183,7 @@ private:
  *
  */
 struct BufferVarInfo {
-  enum DeclarationLocation {
+  enum DeclarationLocation : uint8_t {
     kPrimFuncParam = (1 << 0),
     kPrimFuncBufferMap = (1 << 1),
     kAllocateNode = (1 << 2),

--- a/src/transform/storage_rewrite.cc
+++ b/src/transform/storage_rewrite.cc
@@ -96,15 +96,15 @@ static void LegalizeBufferLoadDType(BufferLoadNode *n) {
 class AllocateCollector : public StmtExprVisitor {
 private:
   bool IsDynamicSharedMemory(Var buffer_var) {
-    StorageScope storage_scope =
-        runtime::StorageScope::Create(GetPtrStorageScope(std::move(buffer_var)));
+    StorageScope storage_scope = runtime::StorageScope::Create(
+        GetPtrStorageScope(std::move(buffer_var)));
     return storage_scope.rank == runtime::StorageRank::kShared &&
            storage_scope.tag == ".dyn";
   }
 
   bool IsStaticSharedMemory(Var buffer_var) {
-    StorageScope storage_scope =
-        runtime::StorageScope::Create(GetPtrStorageScope(std::move(buffer_var)));
+    StorageScope storage_scope = runtime::StorageScope::Create(
+        GetPtrStorageScope(std::move(buffer_var)));
     return storage_scope.rank == runtime::StorageRank::kShared &&
            storage_scope.tag.empty();
   }
@@ -502,7 +502,7 @@ public:
     return node;
   }
 
-  Buffer RemapBuffer(const Buffer& buf, const Var& new_backing_array) {
+  Buffer RemapBuffer(const Buffer &buf, const Var &new_backing_array) {
     auto key = buf.get();
     auto it = buffer_remap_.find(key);
     if (it != buffer_remap_.end()) {
@@ -1368,7 +1368,7 @@ public:
     StmtExprVisitor::VisitStmt_(op);
   }
 
-  void HandleLetNode(const Var& let_var) {
+  void HandleLetNode(const Var &let_var) {
     if (let_var->dtype.is_handle()) {
       auto pointer_type = GetPointerType(let_var->type_annotation);
       if (pointer_type.has_value()) {
@@ -1398,7 +1398,7 @@ public:
    * some locations can be rewritten without others.
    */
   void
-  OnArrayDeclaration(const Var& buffer, DataType element_dtype, PrimExpr extent,
+  OnArrayDeclaration(const Var &buffer, DataType element_dtype, PrimExpr extent,
                      BufferVarInfo::DeclarationLocation declaration_location) {
     ICHECK(info_map_.find(buffer.get()) == info_map_.end())
         << "Array declaration of " << buffer->name_hint
@@ -1407,8 +1407,8 @@ public:
     if (element_dtype == DataType::Bool()) {
       element_dtype = DataType::Int(8).with_lanes(element_dtype.lanes());
     }
-    info_map_[buffer.get()] =
-        BufferVarInfo{buffer, element_dtype, std::move(extent), declaration_location};
+    info_map_[buffer.get()] = BufferVarInfo{
+        buffer, element_dtype, std::move(extent), declaration_location};
   }
 
   /* Update the type map for a buffer based on its usage
@@ -1911,7 +1911,7 @@ PrimFunc PointerValueTypeRewrite(
 using namespace tir::transform;
 namespace transform {
 Pass StorageRewrite() {
-  auto pass_func = [](PrimFunc f, const IRModule& m, PassContext ctx) {
+  auto pass_func = [](PrimFunc f, const IRModule &m, PassContext ctx) {
     bool enable_reuse = true;
     bool reuse_require_exact_matched_dtype = false;
     bool merge_static_smem =
@@ -1958,7 +1958,7 @@ TVM_FFI_STATIC_INIT_BLOCK({
 });
 
 Pass PointerValueTypeRewrite() {
-  auto pass_func = [](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     return tl::PointerValueTypeRewrite(std::move(f));
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.PointerValueTypeRewrite", {});

--- a/src/transform/storage_rewrite.cc
+++ b/src/transform/storage_rewrite.cc
@@ -36,6 +36,7 @@
 #include <map>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 #include "arith/int_operator.h"
 #include "runtime/thread_storage_scope.h"
@@ -96,16 +97,16 @@ class AllocateCollector : public StmtExprVisitor {
 private:
   bool IsDynamicSharedMemory(Var buffer_var) {
     StorageScope storage_scope =
-        runtime::StorageScope::Create(GetPtrStorageScope(buffer_var));
+        runtime::StorageScope::Create(GetPtrStorageScope(std::move(buffer_var)));
     return storage_scope.rank == runtime::StorageRank::kShared &&
            storage_scope.tag == ".dyn";
   }
 
   bool IsStaticSharedMemory(Var buffer_var) {
     StorageScope storage_scope =
-        runtime::StorageScope::Create(GetPtrStorageScope(buffer_var));
+        runtime::StorageScope::Create(GetPtrStorageScope(std::move(buffer_var)));
     return storage_scope.rank == runtime::StorageRank::kShared &&
-           storage_scope.tag == "";
+           storage_scope.tag.empty();
   }
 
 public:
@@ -143,7 +144,7 @@ public:
   /*! \brief record the touch hist of statement. */
   struct StmtEntry {
     // The statement
-    const Object *stmt;
+    const Object *stmt{};
     // The index in the linear_seq_ to point to end of the nested scope.
     // This is only set to non-zero if stmt is a nested scope.
     // if offset > 0, means this is the begin, the end entry is current_index +
@@ -198,11 +199,11 @@ public:
           << it->second.num_physical_dimensions
           << " physical dimensions, but is accessed as having "
           << op->buffer->axis_separators.size() + 1 << " physical dimensions"
-          << std::endl;
+          << '\n';
     }
     StmtEntry e = scope_.back();
     scope_.pop_back();
-    if (e.touched.size() != 0) {
+    if (!e.touched.empty()) {
       e.stmt = op;
       linear_seq_.push_back(e);
     }
@@ -227,7 +228,7 @@ public:
           << it->second.num_physical_dimensions
           << " physical dimensions, but is accessed as having "
           << op->buffer->axis_separators.size() + 1 << " physical dimensions"
-          << std::endl;
+          << '\n';
     }
   }
 
@@ -237,7 +238,7 @@ public:
     StmtExprVisitor::VisitStmt_(op);
     StmtEntry e = scope_.back();
     scope_.pop_back();
-    if (e.touched.size() != 0) {
+    if (!e.touched.empty()) {
       e.stmt = op;
       linear_seq_.push_back(e);
     }
@@ -442,9 +443,9 @@ private:
   // result of the check
   bool result_{true};
   // destination memory
-  const VarNode *dst_;
+  const VarNode *dst_{};
   // source variable
-  const VarNode *src_;
+  const VarNode *src_{};
   // counter of load,
   // it is not safe to inplace when there is nested load like A[B[i]]
   int mem_nest_{0};
@@ -501,7 +502,7 @@ public:
     return node;
   }
 
-  Buffer RemapBuffer(Buffer buf, Var new_backing_array) {
+  Buffer RemapBuffer(const Buffer& buf, const Var& new_backing_array) {
     auto key = buf.get();
     auto it = buffer_remap_.find(key);
     if (it != buffer_remap_.end()) {
@@ -641,7 +642,7 @@ private:
     // The physical dimensionality of the allocations.  Since
     // StorageRewrite is applied after StorageFlatten/FlattenBuffer,
     // this is size of `AllocateNode::extents`.  If moved
-    size_t ndim;
+    size_t ndim{};
     // Allocs that shares this entry.
     std::vector<const AllocateNode *> allocs;
     // The children of this entry, not including itself.
@@ -671,7 +672,7 @@ private:
   // Checks whether the storage_scope is especially tagged for a specific
   // memory. Special memory is all combined into a single allocation.
   bool IsSpecialTaggedMemory(const StorageScope &scope) {
-    return scope.tag.length() != 0 && scope.tag != ".dyn" &&
+    return !scope.tag.empty() && scope.tag != ".dyn" &&
            scope.tag != ".barrier" && scope.tag != ".workspace" &&
            scope.tag != ".vtcm";
   }
@@ -729,7 +730,7 @@ private:
         // already merged
         if (e->bits_offset != 0)
           continue;
-        if (e->merged_children.size() != 0) {
+        if (!e->merged_children.empty()) {
           NewAllocTagMerged(e);
           continue;
         }
@@ -1062,7 +1063,7 @@ private:
     // disable reuse of small arrays, they will be lowered to registers in LLVM
     // This rules only apply if we are using non special memory
     bool is_small_array =
-        (scope.tag.length() == 0) &&
+        (scope.tag.empty()) &&
         (scope.rank >= StorageRank::kWarp || op->dtype.is_handle() ||
          (is_known_size && const_nbits <= 32));
 
@@ -1134,7 +1135,7 @@ private:
 
     // disable reuse of small arrays, they will be lowered to registers in LLVM
     // This rules only apply if we are using non special memory
-    if (e->scope.tag.length() == 0) {
+    if (e->scope.tag.empty()) {
       // Disable sharing of local memory.
       if (e->scope.rank >= StorageRank::kWarp ||
           e->allocs[0]->dtype.is_handle())
@@ -1293,7 +1294,7 @@ public:
       Var buffer_var = buffer->data;
       DataType dtype = buffer->dtype;
       PrimExpr extent =
-          buffer->shape.size() ? buffer->shape[buffer->shape.size() - 1] : 0;
+          !buffer->shape.empty() ? buffer->shape[buffer->shape.size() - 1] : 0;
       OnArrayDeclaration(buffer_var, dtype, extent,
                          BufferVarInfo::kPrimFuncParam);
     }
@@ -1350,7 +1351,7 @@ public:
   void VisitStmt_(const AllocateConstNode *op) final {
     const Array<PrimExpr> &extents = op->extents;
     PrimExpr extent =
-        extents.size() ? extents[extents.size() - 1] : NullValue<PrimExpr>();
+        !extents.empty() ? extents[extents.size() - 1] : NullValue<PrimExpr>();
     OnArrayDeclaration(op->buffer_var, op->dtype, extent,
                        BufferVarInfo::kAllocateConstNode);
 
@@ -1367,7 +1368,7 @@ public:
     StmtExprVisitor::VisitStmt_(op);
   }
 
-  void HandleLetNode(Var let_var) {
+  void HandleLetNode(const Var& let_var) {
     if (let_var->dtype.is_handle()) {
       auto pointer_type = GetPointerType(let_var->type_annotation);
       if (pointer_type.has_value()) {
@@ -1397,7 +1398,7 @@ public:
    * some locations can be rewritten without others.
    */
   void
-  OnArrayDeclaration(Var buffer, DataType element_dtype, PrimExpr extent,
+  OnArrayDeclaration(const Var& buffer, DataType element_dtype, PrimExpr extent,
                      BufferVarInfo::DeclarationLocation declaration_location) {
     ICHECK(info_map_.find(buffer.get()) == info_map_.end())
         << "Array declaration of " << buffer->name_hint
@@ -1407,7 +1408,7 @@ public:
       element_dtype = DataType::Int(8).with_lanes(element_dtype.lanes());
     }
     info_map_[buffer.get()] =
-        BufferVarInfo{buffer, element_dtype, extent, declaration_location};
+        BufferVarInfo{buffer, element_dtype, std::move(extent), declaration_location};
   }
 
   /* Update the type map for a buffer based on its usage
@@ -1452,7 +1453,7 @@ public:
       ICHECK(indices[i].dtype().is_scalar())
           << "Only the last index of a buffer access may be a vector type.";
     }
-    int index_lanes = indices.size() ? indices.back().dtype().lanes() : 1;
+    int index_lanes = !indices.empty() ? indices.back().dtype().lanes() : 1;
 
     DataType access_dtype = value_dtype;
 
@@ -1488,7 +1489,7 @@ public:
     // divisible by the number of number of lanes, and the predicate
     // does not apply any masking, then this array access could be
     // vectorized.
-    if (indices.size()) {
+    if (!indices.empty()) {
       const RampNode *ramp_index = indices[indices.size() - 1].as<RampNode>();
       if (ramp_index && is_one(ramp_index->stride)) {
         if (ramp_index->lanes->IsInstance<IntImmNode>()) {
@@ -1502,7 +1503,7 @@ public:
       }
     }
 
-    if (detect_scalar_read_patterns_ && is_buffer_load && indices.size()) {
+    if (detect_scalar_read_patterns_ && is_buffer_load && !indices.empty()) {
       const PrimExpr last_dim_index = indices[indices.size() - 1];
       if (last_dim_index.dtype().lanes() == 1) {
         arith::ModularSet me = analyzer_.modular_set(last_dim_index);
@@ -1910,7 +1911,7 @@ PrimFunc PointerValueTypeRewrite(
 using namespace tir::transform;
 namespace transform {
 Pass StorageRewrite() {
-  auto pass_func = [](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [](PrimFunc f, const IRModule& m, PassContext ctx) {
     bool enable_reuse = true;
     bool reuse_require_exact_matched_dtype = false;
     bool merge_static_smem =
@@ -1957,7 +1958,7 @@ TVM_FFI_STATIC_INIT_BLOCK({
 });
 
 Pass PointerValueTypeRewrite() {
-  auto pass_func = [](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     return tl::PointerValueTypeRewrite(std::move(f));
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.PointerValueTypeRewrite", {});

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -613,7 +613,7 @@ private:
   Stmt VisitStmt_(const EvaluateNode *op) final {
     const CallNode *call = nullptr;
     if (op->value->IsInstance<CallNode>()) {
-      call = static_cast<const CallNode *>(op->value.get());
+      call = op->value.as<CallNode>();
       if (call->op.same_as(builtin::tvm_storage_sync())) {
         const auto &args = call->args;
         ICHECK(!args.empty());

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -742,7 +742,7 @@ private:
   std::unordered_map<ThreadBoundKey, size_t> thread_count_map_;
 };
 
-PrimFunc TileLangThreadSync(PrimFunc func, const std::string& storage_scope) {
+PrimFunc TileLangThreadSync(PrimFunc func, const std::string &storage_scope) {
   StorageScope sync_scope = StorageScope::Create(storage_scope);
   auto *n = func.CopyOnWrite();
   auto stmt = n->body;
@@ -765,8 +765,9 @@ using namespace tir::transform;
 
 namespace transform {
 
-tvm::transform::Pass ThreadSync(const String& storage_scope) {
-  auto pass_func = [storage_scope](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+tvm::transform::Pass ThreadSync(const String &storage_scope) {
+  auto pass_func = [storage_scope](PrimFunc f, const IRModule &m,
+                                   const PassContext &ctx) {
     auto *n = f.CopyOnWrite();
     return tl::TileLangThreadSync(std::move(f), storage_scope);
     ;

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -30,6 +30,7 @@
 
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 
 #include "./common/thread_sync_types.h"
 #include "./storage_access.h"
@@ -46,7 +47,7 @@ using arith::IRMutatorWithAnalyzer;
 class TileLangThreadSyncPlanner : public TileLangStorageAccessVisitor {
 public:
   explicit TileLangThreadSyncPlanner(StorageScope sync_scope)
-      : sync_scope_(sync_scope) {}
+      : sync_scope_(std::move(sync_scope)) {}
 
   // The syncs inserted before each statement
   std::unordered_set<const Object *> syncs_inserted_;
@@ -404,7 +405,7 @@ private:
 class ThreadSyncAfterWaitQueueInserter : public StmtExprMutator {
 public:
   explicit ThreadSyncAfterWaitQueueInserter(StorageScope sync_scope)
-      : sync_scope_(sync_scope) {}
+      : sync_scope_(std::move(sync_scope)) {}
 
   Stmt VisitStmt_(const AttrStmtNode *op) final {
     if (op->attr_key == tvm::tir::attr::async_wait_queue_scope) {
@@ -430,10 +431,10 @@ class ThreadSyncInserter : public StmtExprMutator {
 public:
   ThreadSyncInserter(StorageScope sync_scope,
                      const std::unordered_set<const Object *> &syncs)
-      : sync_scope_(sync_scope), syncs_(syncs) {}
+      : sync_scope_(std::move(sync_scope)), syncs_(syncs) {}
 
   Stmt VisitStmt(const Stmt &stmt) final {
-    if (syncs_.size() == 0)
+    if (syncs_.empty())
       return stmt;
     if (syncs_.count(stmt.get())) {
       Stmt barrier;
@@ -535,7 +536,7 @@ private:
 
   // Get current storage scope.
   StorageScope GetScope(Var buffer_var) const {
-    return StorageScope::Create(GetPtrStorageScope(buffer_var));
+    return StorageScope::Create(GetPtrStorageScope(std::move(buffer_var)));
   }
 
   // private functions.
@@ -615,7 +616,7 @@ private:
       call = static_cast<const CallNode *>(op->value.get());
       if (call->op.same_as(builtin::tvm_storage_sync())) {
         const auto &args = call->args;
-        ICHECK(args.size() > 0);
+        ICHECK(!args.empty());
         const auto *scope_node = args[0].as<StringImmNode>();
         ICHECK(scope_node != nullptr);
         const std::string &scope = scope_node->value;
@@ -741,11 +742,11 @@ private:
   std::unordered_map<ThreadBoundKey, size_t> thread_count_map_;
 };
 
-PrimFunc TileLangThreadSync(PrimFunc func, std::string storage_scope) {
+PrimFunc TileLangThreadSync(PrimFunc func, const std::string& storage_scope) {
   StorageScope sync_scope = StorageScope::Create(storage_scope);
   auto *n = func.CopyOnWrite();
   auto stmt = n->body;
-  if (sync_scope.rank == StorageRank::kShared && sync_scope.tag == "") {
+  if (sync_scope.rank == StorageRank::kShared && sync_scope.tag.empty()) {
     stmt = ThreadSyncAfterWaitQueueInserter(sync_scope)(stmt);
   }
   TileLangThreadSyncPlanner planner(sync_scope);
@@ -764,8 +765,8 @@ using namespace tir::transform;
 
 namespace transform {
 
-tvm::transform::Pass ThreadSync(String storage_scope) {
-  auto pass_func = [storage_scope](PrimFunc f, IRModule m, PassContext ctx) {
+tvm::transform::Pass ThreadSync(const String& storage_scope) {
+  auto pass_func = [storage_scope](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     auto *n = f.CopyOnWrite();
     return tl::TileLangThreadSync(std::move(f), storage_scope);
     ;

--- a/src/transform/vectorize_loop.cc
+++ b/src/transform/vectorize_loop.cc
@@ -33,6 +33,7 @@
 #include <tvm/tir/transform.h>
 
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "arith/scalable_expression.h"
@@ -127,7 +128,7 @@ inline PrimExpr BroadcastTo(PrimExpr e, int lanes, bool is_scalable) {
 class TLVecAllocAccess : public StmtExprMutator {
 public:
   TLVecAllocAccess(const VarNode *buf, Var var, PrimExpr var_lanes)
-      : buf_(buf), var_(var), var_lanes_(var_lanes) {}
+      : buf_(buf), var_(std::move(var)), var_lanes_(std::move(var_lanes)) {}
 
   PrimExpr VisitExpr_(const BufferLoadNode *op) final {
     auto load = Downcast<BufferLoad>(StmtExprMutator::VisitExpr_(op));
@@ -207,7 +208,7 @@ public:
   using ExprFunctor::VisitExpr;
   using StmtMutator::operator();
 
-  TLVectorizer(Var var, PrimExpr var_lanes) : var_(var), var_lanes_(var_lanes) {
+  TLVectorizer(const Var& var, const PrimExpr& var_lanes) : var_(var), var_lanes_(var_lanes) {
     ramp_ = Ramp(IntImm(var->dtype, 0), IntImm(var->dtype, 1), var_lanes);
   }
 
@@ -227,11 +228,11 @@ public:
   }
 
   PrimExpr VisitExpr_(const AddNode *op) final {
-    return AddSubVec(op, [](PrimExpr a, PrimExpr b) { return a + b; });
+    return AddSubVec(op, [](PrimExpr a, PrimExpr b) { return std::move(a) + std::move(b); });
   }
 
   PrimExpr VisitExpr_(const SubNode *op) final {
-    return AddSubVec(op, [](PrimExpr a, PrimExpr b) { return a - b; });
+    return AddSubVec(op, [](PrimExpr a, PrimExpr b) { return std::move(a) - std::move(b); });
   }
 
   PrimExpr VisitExpr_(const MulNode *op) final {
@@ -712,7 +713,7 @@ private:
   // mutate array, with given lane requirement
   // when finished, p_lane updates the lane requirement.
   Array<PrimExpr> MutateArray(Array<PrimExpr> arr, int *p_lanes) {
-    if (arr.size() == 0)
+    if (arr.empty())
       return arr;
     int &lanes = *p_lanes;
     bool changed = false;
@@ -826,7 +827,7 @@ Stmt SkipVectorize(Stmt stmt) { return VectorizeSkipper()(std::move(stmt)); }
 
 tvm::transform::Pass VectorizeLoop(bool enable_vectorize = true) {
   using namespace tir::transform;
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
     auto *n = f.CopyOnWrite();
     if (enable_vectorize) {
       n->body = tvm::tl::LoopVectorizer()(std::move(n->body));

--- a/src/transform/vectorize_loop.cc
+++ b/src/transform/vectorize_loop.cc
@@ -208,7 +208,8 @@ public:
   using ExprFunctor::VisitExpr;
   using StmtMutator::operator();
 
-  TLVectorizer(const Var& var, const PrimExpr& var_lanes) : var_(var), var_lanes_(var_lanes) {
+  TLVectorizer(const Var &var, const PrimExpr &var_lanes)
+      : var_(var), var_lanes_(var_lanes) {
     ramp_ = Ramp(IntImm(var->dtype, 0), IntImm(var->dtype, 1), var_lanes);
   }
 
@@ -228,11 +229,13 @@ public:
   }
 
   PrimExpr VisitExpr_(const AddNode *op) final {
-    return AddSubVec(op, [](PrimExpr a, PrimExpr b) { return std::move(a) + std::move(b); });
+    return AddSubVec(
+        op, [](PrimExpr a, PrimExpr b) { return std::move(a) + std::move(b); });
   }
 
   PrimExpr VisitExpr_(const SubNode *op) final {
-    return AddSubVec(op, [](PrimExpr a, PrimExpr b) { return std::move(a) - std::move(b); });
+    return AddSubVec(
+        op, [](PrimExpr a, PrimExpr b) { return std::move(a) - std::move(b); });
   }
 
   PrimExpr VisitExpr_(const MulNode *op) final {
@@ -827,7 +830,7 @@ Stmt SkipVectorize(Stmt stmt) { return VectorizeSkipper()(std::move(stmt)); }
 
 tvm::transform::Pass VectorizeLoop(bool enable_vectorize = true) {
   using namespace tir::transform;
-  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     auto *n = f.CopyOnWrite();
     if (enable_vectorize) {
       n->body = tvm::tl::LoopVectorizer()(std::move(n->body));

--- a/src/transform/warp_specialized_rewriter.cc
+++ b/src/transform/warp_specialized_rewriter.cc
@@ -32,7 +32,7 @@ struct LoopInfo {
   PrimExpr min;
 };
 
-enum class Role { kConsumer, kProducer, kBoth };
+enum class Role : uint8_t { kConsumer, kProducer, kBoth };
 
 class ProducerBufferDetector : public StmtExprVisitor {
 public:

--- a/src/transform/warp_specialized_rewriter.cc
+++ b/src/transform/warp_specialized_rewriter.cc
@@ -12,6 +12,8 @@
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/tir/transform.h>
 
+#include <utility>
+
 #include "../op/builtin.h"
 #include "./common/collector.h"
 #include "runtime/thread_storage_scope.h"
@@ -36,7 +38,7 @@ class ProducerBufferDetector : public StmtExprVisitor {
 public:
   ProducerBufferDetector(
       std::unordered_set<const BufferNode *> cur_producer_buffers)
-      : cur_producer_buffers_(cur_producer_buffers) {}
+      : cur_producer_buffers_(std::move(cur_producer_buffers)) {}
 
   void clear() { has_producer_buffer_ = false; }
 
@@ -60,7 +62,7 @@ public:
 
 class ProducerUsedBufferFinder : public StmtExprVisitor {
 public:
-  auto FindProducerusedBuffer(Stmt stmt) {
+  auto FindProducerusedBuffer(const Stmt& stmt) {
     producer_buffers_.clear();
     std::unordered_set<const BufferNode *> last_producer_buffers_;
     for (;;) {
@@ -128,7 +130,7 @@ private:
 class WarpSpecializedRoleMarker : public StmtVisitor {
 public:
   WarpSpecializedRoleMarker(Map<Var, Buffer> buffer_data_to_buffer)
-      : buffer_data_to_buffer_(buffer_data_to_buffer) {}
+      : buffer_data_to_buffer_(std::move(buffer_data_to_buffer)) {}
 
   void Prepare(const Stmt &stmt) {
     ProducerUsedBufferFinder finder;
@@ -248,12 +250,12 @@ private:
 };
 
 static PrimExpr makeGetBarrier(PrimExpr barrier_id) {
-  return Call(DataType::Handle(), get_mbarrier(), {barrier_id});
+  return Call(DataType::Handle(), get_mbarrier(), {std::move(barrier_id)});
 }
 
 static Stmt makeArriveBarrier(PrimExpr barrier_id, int cta_id = -1,
-                              PrimExpr pred = 1) {
-  Array<PrimExpr> args = {makeGetBarrier(barrier_id)};
+                              const PrimExpr& pred = 1) {
+  Array<PrimExpr> args = {makeGetBarrier(std::move(barrier_id))};
   if (cta_id != -1) {
     args.push_back(cta_id);
     args.push_back(pred);
@@ -264,13 +266,13 @@ static Stmt makeArriveBarrier(PrimExpr barrier_id, int cta_id = -1,
 
 static Stmt makeCpAsyncBarrier(PrimExpr barrier_id) {
   auto call = Call(DataType::Handle(), builtin::ptx_cp_async_barrier(),
-                   {makeGetBarrier(barrier_id)});
+                   {makeGetBarrier(std::move(barrier_id))});
   return Evaluate(call);
 }
 
 static Stmt makeParityWait(PrimExpr barrier_id, PrimExpr parity) {
   auto call = Call(DataType::Handle(), mbarrier_wait_parity(),
-                   {makeGetBarrier(barrier_id), parity});
+                   {makeGetBarrier(std::move(barrier_id)), std::move(parity)});
   return Evaluate(call);
 }
 
@@ -280,7 +282,7 @@ public:
 
   void Clear() { has_simt_copy = false; }
 
-  void Collect(Stmt stmt) { VisitStmt(stmt); }
+  void Collect(const Stmt& stmt) { VisitStmt(stmt); }
 
   bool HasSimtCopy() { return has_simt_copy; }
 
@@ -304,7 +306,7 @@ private:
     StmtExprVisitor::VisitExpr_(op);
   }
 
-  bool has_simt_copy;
+  bool has_simt_copy{};
   bool in_if_cond_ = false;
 };
 
@@ -313,8 +315,8 @@ class MbarrierRewriter : public StmtExprMutator {
 public:
   static Stmt Rewrite(Stmt stmt, PrimExpr barrier_id) {
     MbarrierRewriter rewriter;
-    rewriter.producer_barrier_idx_ = barrier_id;
-    return rewriter(stmt);
+    rewriter.producer_barrier_idx_ = std::move(barrier_id);
+    return rewriter(std::move(stmt));
   }
 
 private:
@@ -345,15 +347,15 @@ public:
   static Stmt Rewrite(Stmt stmt, Var thread_var, PrimExpr replaced,
                       PrimExpr thread_extent, bool do_shuffle = false) {
     auto rewriter =
-        ThreadIdxRewriter(thread_var, replaced, thread_extent, do_shuffle);
-    return rewriter(stmt);
+        ThreadIdxRewriter(std::move(thread_var), std::move(replaced), std::move(thread_extent), do_shuffle);
+    return rewriter(std::move(stmt));
   }
 
 private:
   ThreadIdxRewriter(Var thread_var, PrimExpr replaced, PrimExpr thread_extent,
                     bool do_shuffle)
-      : thread_var_(thread_var), replaced_(replaced),
-        thread_extent_(thread_extent), do_shuffle_(do_shuffle) {}
+      : thread_var_(std::move(thread_var)), replaced_(std::move(replaced)),
+        thread_extent_(std::move(thread_extent)), do_shuffle_(do_shuffle) {}
 
   PrimExpr VisitExpr_(const VarNode *var) final {
     if (var == thread_var_.get()) {
@@ -415,15 +417,15 @@ Block MakeGroupBlock(const Stmt &stmt,
 }
 
 struct OpInfo {
-  int group_size, order, stage;
+  int group_size{}, order{}, stage{};
   std::vector<int> group;
 };
 struct PipelineInfo {
   std::vector<OpInfo> op_infos;
 
   PipelineInfo() = default;
-  PipelineInfo(Array<Array<Integer>> group_info, Array<Integer> order_info,
-               Array<Integer> stage_info) {
+  PipelineInfo(const Array<Array<Integer>>& group_info, const Array<Integer>& order_info,
+               const Array<Integer>& stage_info) {
     int n = static_cast<int>(group_info.size());
     ICHECK(n == static_cast<int>(order_info.size()));
     ICHECK(n == static_cast<int>(stage_info.size()));
@@ -441,7 +443,7 @@ struct PipelineInfo {
   }
 
   PipelineInfo(const PipelineInfo &other) {
-    for (auto op_info : other.op_infos) {
+    for (const auto& op_info : other.op_infos) {
       op_infos.push_back(op_info);
     }
   }
@@ -501,18 +503,18 @@ struct PipelineInfo {
   }
 
   void PrintPipelineInfo() {
-    std::cout << "Print op_infos:" << std::endl;
+    std::cout << "Print op_infos:" << '\n';
     for (size_t i = 0; i < op_infos.size(); i++) {
       std::cout << i << " " << op_infos[i].group_size << " "
-                << op_infos[i].order << " " << op_infos[i].stage << std::endl;
+                << op_infos[i].order << " " << op_infos[i].stage << '\n';
     }
-    std::cout << "End of print" << std::endl;
+    std::cout << "End of print" << '\n';
   }
 };
 
 class GroupOpRewriter : public StmtExprMutator {
 public:
-  GroupOpRewriter(PipelineInfo pipeline_info) : pipeline_info_(pipeline_info) {}
+  GroupOpRewriter(const PipelineInfo& pipeline_info) : pipeline_info_(pipeline_info) {}
 
 private:
   Stmt VisitStmt_(const ForNode *op) final {
@@ -546,7 +548,7 @@ private:
     }
     Array<Integer> order_anno;
     Array<Integer> stage_anno;
-    for (auto op_info : pipeline_info_.op_infos) {
+    for (const auto& op_info : pipeline_info_.op_infos) {
       order_anno.push_back(Integer(op_info.order));
       stage_anno.push_back(Integer(op_info.stage));
     }
@@ -588,7 +590,7 @@ public:
     in_if_scope_ = false;
   }
 
-  static bool HasWgMMA(Stmt stmt) {
+  static bool HasWgMMA(const Stmt& stmt) {
     auto collector = WgMMACollector();
     collector(stmt);
     return collector.has_wgmma_;
@@ -629,12 +631,12 @@ public:
    * @param only_has_wgmma If true, adjust emission and barrier-thread-count
    * logic for blocks that contain WgMMA operations.
    */
-  WSCodeEmitter(bool is_emitting_producer, IterVar thread_iv,
+  WSCodeEmitter(bool is_emitting_producer, const IterVar& thread_iv,
                 Map<Var, Buffer> buffer_data_to_buffer,
                 const WarpSpecializedRoleMarker &marker,
                 bool mbarrier_only = false, bool only_has_wgmma = false)
       : is_emitting_producer_(is_emitting_producer),
-        buffer_data_to_buffer_(buffer_data_to_buffer), marker_(marker),
+        buffer_data_to_buffer_(std::move(buffer_data_to_buffer)), marker_(marker),
         thread_var_(thread_iv->var), mbarrier_only_(mbarrier_only),
         only_has_wgmma_(only_has_wgmma) {}
 
@@ -721,7 +723,7 @@ private:
       return FilterByRole(op);
 
     auto seq_transformed =
-        op->seq.Map([&](Stmt stmt) { return VisitStmt(stmt); });
+        op->seq.Map([&](const Stmt& stmt) { return VisitStmt(stmt); });
 
     auto map = ExtractSyncPattern(op->seq);
 
@@ -768,7 +770,7 @@ private:
                                 : parity_;
           block_stmt.push_back(makeParityWait(acquire_barrier_id, parity));
         }
-        ICHECK(map.release[i].size() > 0);
+        ICHECK(!map.release[i].empty());
         for (size_t j = 0; j < map.release[i].size(); j++) {
           int pattern_idx = map.release[i][j];
           PrimExpr release_barrier_id =
@@ -854,7 +856,7 @@ private:
 
     num_barriers_ += map.patterns.size() * num_stages_;
 
-    ICHECK(new_body.size() > 0);
+    ICHECK(!new_body.empty());
     return new_body.size() == 1 ? new_body[0] : SeqStmt(std::move(new_body));
   }
 
@@ -887,8 +889,8 @@ private:
 
     PipelineInfo pipeline_info(group_info_array, order_info_array,
                                stage_info_array);
-    if (pipeline_info.op_infos.size() > 0) {
-      ICHECK(pipeline_info_.op_infos.size() == 0)
+    if (!pipeline_info.op_infos.empty()) {
+      ICHECK(pipeline_info_.op_infos.empty())
           << "Nested pipeline not supported.";
     }
 
@@ -910,7 +912,7 @@ private:
     auto result = FilterByRole(op);
 
     Stmt grouped_for_node;
-    if (result.as<ForNode>() && group_anno && group_info_array.size() > 0 &&
+    if (result.as<ForNode>() && group_anno && !group_info_array.empty() &&
         !is_emitting_producer_) {
       GroupOpRewriter group_op_rewriter(pipeline_info_);
       auto for_node = Downcast<For>(result);
@@ -927,12 +929,12 @@ private:
     if (result.as<ForNode>()) {
       auto for_node = Downcast<For>(result);
       for_node.CopyOnWrite()->annotations.erase("num_stages");
-      if (is_emitting_producer_ || group_info_array.size() == 0) {
+      if (is_emitting_producer_ || group_info_array.empty()) {
         for_node.CopyOnWrite()->annotations.erase("tl_pipeline_order");
         for_node.CopyOnWrite()->annotations.erase("tl_pipeline_stage");
       }
       if (is_emitting_producer_ || !group_anno ||
-          group_info_array.size() == 0) {
+          group_info_array.empty()) {
         loop_stack_.pop_back();
         return for_node;
       }
@@ -981,7 +983,7 @@ private:
   };
 
   std::vector<SyncPattern>
-  CreateBaseSyncPairs(Array<Stmt> seq_stmt,
+  CreateBaseSyncPairs(const Array<Stmt>& seq_stmt,
                       const std::vector<bool> &is_producer) {
     const int n = seq_stmt.size();
     std::vector<std::set<const BufferNode *>> reads, writes;
@@ -1096,7 +1098,7 @@ private:
     return sync_pattern_cleaned;
   }
 
-  SyncPatternMap ExtractSyncPattern(Array<Stmt> seq_stmt) {
+  SyncPatternMap ExtractSyncPattern(const Array<Stmt>& seq_stmt) {
     size_t num_stmts = seq_stmt.size();
     std::vector<bool> is_producer;
     is_producer.reserve(num_stmts);
@@ -1129,7 +1131,7 @@ private:
     std::vector<int> cur_consumer_barrier, cur_producer_barrier;
     for (int i = num_stmts - 1; i >= 0; i--) {
       if (is_producer[i]) {
-        if (map.release[i].size() == 0) {
+        if (map.release[i].empty()) {
           for (auto pattern_idx : cur_producer_barrier) {
             map.release[i].push_back(pattern_idx);
             map.release_after[i].push_back(false);
@@ -1140,7 +1142,7 @@ private:
           }
         }
       } else {
-        if (map.release[i].size() == 0) {
+        if (map.release[i].empty()) {
           for (auto pattern_idx : cur_consumer_barrier) {
             map.release[i].push_back(pattern_idx);
             map.release_after[i].push_back(false);
@@ -1369,7 +1371,7 @@ private:
 class WarpSpecializedDetector : public IRVisitorWithAnalyzer {
 public:
   // return true means this aws will be disabled
-  static bool Detect(Stmt stmt, bool skip_thread_partition = false) {
+  static bool Detect(const Stmt& stmt, bool skip_thread_partition = false) {
     WarpSpecializedDetector detector;
     detector.VisitStmt(stmt);
     if (detector.has_warp_specialization_) {
@@ -1436,7 +1438,7 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass WarpSpecialized() {
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule& m, PassContext ctx) {
     bool disable_warp_specialized =
         ctx->GetConfig<Bool>(kDisableWarpSpecialized, Bool(false)).value();
     bool disable_shuffle_elect =

--- a/src/transform/warp_specialized_rewriter.cc
+++ b/src/transform/warp_specialized_rewriter.cc
@@ -62,7 +62,7 @@ public:
 
 class ProducerUsedBufferFinder : public StmtExprVisitor {
 public:
-  auto FindProducerusedBuffer(const Stmt& stmt) {
+  auto FindProducerusedBuffer(const Stmt &stmt) {
     producer_buffers_.clear();
     std::unordered_set<const BufferNode *> last_producer_buffers_;
     for (;;) {
@@ -254,7 +254,7 @@ static PrimExpr makeGetBarrier(PrimExpr barrier_id) {
 }
 
 static Stmt makeArriveBarrier(PrimExpr barrier_id, int cta_id = -1,
-                              const PrimExpr& pred = 1) {
+                              const PrimExpr &pred = 1) {
   Array<PrimExpr> args = {makeGetBarrier(std::move(barrier_id))};
   if (cta_id != -1) {
     args.push_back(cta_id);
@@ -282,7 +282,7 @@ public:
 
   void Clear() { has_simt_copy = false; }
 
-  void Collect(const Stmt& stmt) { VisitStmt(stmt); }
+  void Collect(const Stmt &stmt) { VisitStmt(stmt); }
 
   bool HasSimtCopy() { return has_simt_copy; }
 
@@ -347,7 +347,8 @@ public:
   static Stmt Rewrite(Stmt stmt, Var thread_var, PrimExpr replaced,
                       PrimExpr thread_extent, bool do_shuffle = false) {
     auto rewriter =
-        ThreadIdxRewriter(std::move(thread_var), std::move(replaced), std::move(thread_extent), do_shuffle);
+        ThreadIdxRewriter(std::move(thread_var), std::move(replaced),
+                          std::move(thread_extent), do_shuffle);
     return rewriter(std::move(stmt));
   }
 
@@ -424,8 +425,9 @@ struct PipelineInfo {
   std::vector<OpInfo> op_infos;
 
   PipelineInfo() = default;
-  PipelineInfo(const Array<Array<Integer>>& group_info, const Array<Integer>& order_info,
-               const Array<Integer>& stage_info) {
+  PipelineInfo(const Array<Array<Integer>> &group_info,
+               const Array<Integer> &order_info,
+               const Array<Integer> &stage_info) {
     int n = static_cast<int>(group_info.size());
     ICHECK(n == static_cast<int>(order_info.size()));
     ICHECK(n == static_cast<int>(stage_info.size()));
@@ -443,7 +445,7 @@ struct PipelineInfo {
   }
 
   PipelineInfo(const PipelineInfo &other) {
-    for (const auto& op_info : other.op_infos) {
+    for (const auto &op_info : other.op_infos) {
       op_infos.push_back(op_info);
     }
   }
@@ -514,7 +516,8 @@ struct PipelineInfo {
 
 class GroupOpRewriter : public StmtExprMutator {
 public:
-  GroupOpRewriter(const PipelineInfo& pipeline_info) : pipeline_info_(pipeline_info) {}
+  GroupOpRewriter(const PipelineInfo &pipeline_info)
+      : pipeline_info_(pipeline_info) {}
 
 private:
   Stmt VisitStmt_(const ForNode *op) final {
@@ -548,7 +551,7 @@ private:
     }
     Array<Integer> order_anno;
     Array<Integer> stage_anno;
-    for (const auto& op_info : pipeline_info_.op_infos) {
+    for (const auto &op_info : pipeline_info_.op_infos) {
       order_anno.push_back(Integer(op_info.order));
       stage_anno.push_back(Integer(op_info.stage));
     }
@@ -590,7 +593,7 @@ public:
     in_if_scope_ = false;
   }
 
-  static bool HasWgMMA(const Stmt& stmt) {
+  static bool HasWgMMA(const Stmt &stmt) {
     auto collector = WgMMACollector();
     collector(stmt);
     return collector.has_wgmma_;
@@ -631,14 +634,14 @@ public:
    * @param only_has_wgmma If true, adjust emission and barrier-thread-count
    * logic for blocks that contain WgMMA operations.
    */
-  WSCodeEmitter(bool is_emitting_producer, const IterVar& thread_iv,
+  WSCodeEmitter(bool is_emitting_producer, const IterVar &thread_iv,
                 Map<Var, Buffer> buffer_data_to_buffer,
                 const WarpSpecializedRoleMarker &marker,
                 bool mbarrier_only = false, bool only_has_wgmma = false)
       : is_emitting_producer_(is_emitting_producer),
-        buffer_data_to_buffer_(std::move(buffer_data_to_buffer)), marker_(marker),
-        thread_var_(thread_iv->var), mbarrier_only_(mbarrier_only),
-        only_has_wgmma_(only_has_wgmma) {}
+        buffer_data_to_buffer_(std::move(buffer_data_to_buffer)),
+        marker_(marker), thread_var_(thread_iv->var),
+        mbarrier_only_(mbarrier_only), only_has_wgmma_(only_has_wgmma) {}
 
   /**
    * @brief Whether a SIMT-style bulk copy was detected.
@@ -723,7 +726,7 @@ private:
       return FilterByRole(op);
 
     auto seq_transformed =
-        op->seq.Map([&](const Stmt& stmt) { return VisitStmt(stmt); });
+        op->seq.Map([&](const Stmt &stmt) { return VisitStmt(stmt); });
 
     auto map = ExtractSyncPattern(op->seq);
 
@@ -933,8 +936,7 @@ private:
         for_node.CopyOnWrite()->annotations.erase("tl_pipeline_order");
         for_node.CopyOnWrite()->annotations.erase("tl_pipeline_stage");
       }
-      if (is_emitting_producer_ || !group_anno ||
-          group_info_array.empty()) {
+      if (is_emitting_producer_ || !group_anno || group_info_array.empty()) {
         loop_stack_.pop_back();
         return for_node;
       }
@@ -983,7 +985,7 @@ private:
   };
 
   std::vector<SyncPattern>
-  CreateBaseSyncPairs(const Array<Stmt>& seq_stmt,
+  CreateBaseSyncPairs(const Array<Stmt> &seq_stmt,
                       const std::vector<bool> &is_producer) {
     const int n = seq_stmt.size();
     std::vector<std::set<const BufferNode *>> reads, writes;
@@ -1098,7 +1100,7 @@ private:
     return sync_pattern_cleaned;
   }
 
-  SyncPatternMap ExtractSyncPattern(const Array<Stmt>& seq_stmt) {
+  SyncPatternMap ExtractSyncPattern(const Array<Stmt> &seq_stmt) {
     size_t num_stmts = seq_stmt.size();
     std::vector<bool> is_producer;
     is_producer.reserve(num_stmts);
@@ -1371,7 +1373,7 @@ private:
 class WarpSpecializedDetector : public IRVisitorWithAnalyzer {
 public:
   // return true means this aws will be disabled
-  static bool Detect(const Stmt& stmt, bool skip_thread_partition = false) {
+  static bool Detect(const Stmt &stmt, bool skip_thread_partition = false) {
     WarpSpecializedDetector detector;
     detector.VisitStmt(stmt);
     if (detector.has_warp_specialization_) {
@@ -1438,7 +1440,7 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass WarpSpecialized() {
-  auto pass_func = [=](PrimFunc f, const IRModule& m, PassContext ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, PassContext ctx) {
     bool disable_warp_specialized =
         ctx->GetConfig<Bool>(kDisableWarpSpecialized, Bool(false)).value();
     bool disable_shuffle_elect =

--- a/src/transform/wgmma_sync_rewriter.cc
+++ b/src/transform/wgmma_sync_rewriter.cc
@@ -19,7 +19,7 @@ namespace tl {
 
 using namespace tir;
 
-bool isGemm(const Stmt& stmt) {
+bool isGemm(const Stmt &stmt) {
   bool is_gemm = false;
   if (stmt.as<EvaluateNode>()) {
     auto call = Downcast<Evaluate>(stmt)->value.as<CallNode>();
@@ -35,7 +35,7 @@ bool isGemm(const Stmt& stmt) {
   return is_gemm;
 }
 
-bool isGemmSync(const Stmt& stmt) {
+bool isGemmSync(const Stmt &stmt) {
   bool is_gemm_sync = false;
   if (stmt.as<EvaluateNode>()) {
     auto call = Downcast<Evaluate>(stmt)->value.as<CallNode>();
@@ -51,7 +51,7 @@ bool isGemmSync(const Stmt& stmt) {
   return is_gemm_sync;
 }
 
-bool isArriveBarrier(const Stmt& stmt) {
+bool isArriveBarrier(const Stmt &stmt) {
   bool is_arrive_barrier = false;
   if (stmt.as<EvaluateNode>()) {
     auto call = Downcast<Evaluate>(stmt)->value.as<CallNode>();
@@ -218,7 +218,8 @@ private:
         gemm_count++;
       } else if (isGemmSync(new_seq[i])) {
         auto call = Downcast<Evaluate>(new_seq[i])->value.as<CallNode>();
-        auto sync_index = static_cast<int>(Downcast<IntImm>(call->args[1])->value);
+        auto sync_index =
+            static_cast<int>(Downcast<IntImm>(call->args[1])->value);
         auto wait_count = gemm_count - sync_index - 1;
         if (sync_index > max_sync_index)
           max_sync_index = sync_index;
@@ -259,7 +260,7 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass RewriteWgmmaSync() {
-  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     return WgmmaSyncRewriter::Substitute(std::move(f));
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.RewriteWgmmaSync", {});

--- a/src/transform/wgmma_sync_rewriter.cc
+++ b/src/transform/wgmma_sync_rewriter.cc
@@ -218,7 +218,7 @@ private:
         gemm_count++;
       } else if (isGemmSync(new_seq[i])) {
         auto call = Downcast<Evaluate>(new_seq[i])->value.as<CallNode>();
-        auto sync_index = Downcast<IntImm>(call->args[1])->value;
+        auto sync_index = static_cast<int>(Downcast<IntImm>(call->args[1])->value);
         auto wait_count = gemm_count - sync_index - 1;
         if (sync_index > max_sync_index)
           max_sync_index = sync_index;

--- a/src/transform/wgmma_sync_rewriter.cc
+++ b/src/transform/wgmma_sync_rewriter.cc
@@ -10,6 +10,8 @@
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/tir/transform.h>
 
+#include <utility>
+
 #include "../op/builtin.h"
 
 namespace tvm {
@@ -17,7 +19,7 @@ namespace tl {
 
 using namespace tir;
 
-bool isGemm(Stmt stmt) {
+bool isGemm(const Stmt& stmt) {
   bool is_gemm = false;
   if (stmt.as<EvaluateNode>()) {
     auto call = Downcast<Evaluate>(stmt)->value.as<CallNode>();
@@ -33,7 +35,7 @@ bool isGemm(Stmt stmt) {
   return is_gemm;
 }
 
-bool isGemmSync(Stmt stmt) {
+bool isGemmSync(const Stmt& stmt) {
   bool is_gemm_sync = false;
   if (stmt.as<EvaluateNode>()) {
     auto call = Downcast<Evaluate>(stmt)->value.as<CallNode>();
@@ -49,7 +51,7 @@ bool isGemmSync(Stmt stmt) {
   return is_gemm_sync;
 }
 
-bool isArriveBarrier(Stmt stmt) {
+bool isArriveBarrier(const Stmt& stmt) {
   bool is_arrive_barrier = false;
   if (stmt.as<EvaluateNode>()) {
     auto call = Downcast<Evaluate>(stmt)->value.as<CallNode>();
@@ -257,8 +259,8 @@ private:
 using namespace tir::transform;
 
 tvm::transform::Pass RewriteWgmmaSync() {
-  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
-    return WgmmaSyncRewriter::Substitute(f);
+  auto pass_func = [=](PrimFunc f, const IRModule& m, const PassContext& ctx) {
+    return WgmmaSyncRewriter::Substitute(std::move(f));
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.RewriteWgmmaSync", {});
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * clang-tidy integrated into formatting checks with selectable run modes (--files/--all/changed).

* **Chores**
  * CI/AMD workflows run temporary build steps to generate compile commands and clean up; added clang-tidy to lint deps.

* **Refactor**
  * Widespread const-correctness, move-semantics, emptiness checks, and safer initializations to reduce copies.

* **Style**
  * Lint rules narrowed to a targeted, less-intrusive subset.

* **Breaking Changes**
  * Multiple public signatures, enum storage types, and a small helper/field were changed or removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->