### PR TITLE
[Cache] Introduce detailed target information for the disk kernel cache

### DIFF
--- a/.github/workflows/amd_ci.yml
+++ b/.github/workflows/amd_ci.yml
@@ -60,11 +60,6 @@ jobs:
           exit 1
         fi
         rm -rf build
-    
-    - name: Commit and Push Changes
-      uses: stefanzweifel/git-auto-commit-action@v5
-      with:
-        commit_message: "lint"
 
   build-test-amd:
     runs-on: [self-hosted, amd, gpu]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,6 @@ jobs:
           exit 1
         fi
         rm -rf build
-    
-    - name: Commit and Push Changes
-      uses: stefanzweifel/git-auto-commit-action@v5
-      with:
-        commit_message: "lint"
 
   build-test-nvidia:
     runs-on: [self-hosted, nvidia]

--- a/benchmark/matmul/benchmark_matmul.py
+++ b/benchmark/matmul/benchmark_matmul.py
@@ -243,4 +243,5 @@ if __name__ == "__main__":
     print(f"Best TFlops: {total_flops / best_latency * 1e-9:.3f}")
     print(f"Best config: {best_config}")
 
-    print(f"Reference TFlops: {total_flops / ref_latency * 1e-9:.3f}")
+    if ref_latency is not None:
+        print(f"Reference TFlops: {total_flops / ref_latency * 1e-9:.3f}")

--- a/src/target/codegen_cuda.cc
+++ b/src/target/codegen_cuda.cc
@@ -1960,13 +1960,17 @@ inline void PrintConst(const FloatImmNode *op, std::ostream &os,
   // Type code is kBFloat
   if (op->dtype.is_bfloat16()) {
     os << "bfloat16_t";
-    os << '(' << std::scientific << op->value << 'f' << ')';
+    os << '(' << std::hexfloat << op->value << 'f';
+    os << "/*" << std::scientific << op->value << "*/";
+    os << ')';
     return;
   }
   // Type code is kFloat8_e5m2 or kE4M4Float
   if (op->dtype.is_float8() || op->dtype.is_float4()) {
     p->PrintType(op->dtype, os);
-    os << '(' << std::scientific << op->value << 'f' << ')';
+    os << '(' << std::hexfloat << op->value << 'f';
+    os << "/*" << std::scientific << op->value << "*/";
+    os << ')';
     return;
   }
   // Type code is kFloat
@@ -1984,9 +1988,10 @@ inline void PrintConst(const FloatImmNode *op, std::ostream &os,
       temp << ((op->dtype.bits() == 32) ? "CUDART_NAN_F" : "CUDART_NAN");
       p->need_math_constants_h_ = true;
     } else {
-      temp << std::scientific << op->value;
+      temp << std::hexfloat << op->value;
       if (op->dtype.bits() == 32)
         temp << 'f';
+      temp << "/*" << std::scientific << op->value << "*/";
     }
     p->MarkConst(temp.str());
     os << temp.str();

--- a/src/target/codegen_cuda.cc
+++ b/src/target/codegen_cuda.cc
@@ -325,16 +325,12 @@ void CodeGenTileLangCUDA::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
     enable_fp6_ = true;
     if (t.lanes() <= 4) {
       os << GetFP6Type(t);
-    } else {
-      fail = true;
     }
     return;
   } else if (t.is_float4()) {
     enable_fp4_ = true;
     if (t.lanes() <= 4) {
       os << GetFP4Type(t);
-    } else {
-      fail = true;
     }
     return;
   } else if (t == DataType::Bool()) {

--- a/tilelang/autotuner/param.py
+++ b/tilelang/autotuner/param.py
@@ -68,7 +68,7 @@ class CompileArgs:
             "execution_backend":
                 self.execution_backend,
             "target":
-                self.target,
+                str(self.target),
             "target_host":
                 str(self.target_host) if self.target_host else None,
             "verbose":

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from tilelang import env
 from tilelang.autotuner.param import CompileArgs, ProfileArgs, AutotuneResult
 from tilelang.autotuner.capture import get_autotune_inputs
+from tilelang.utils.target import determine_target
 from tilelang.jit.param import _P, _RProg
 from tilelang.version import __version__
 
@@ -150,7 +151,7 @@ class AutoTuner:
         """
         self.compile_args = CompileArgs(
             out_idx=out_idx,
-            target=target,
+            target=Target(determine_target(target)),
             execution_backend=execution_backend,
             target_host=target_host,
             verbose=verbose,

--- a/tilelang/jit/__init__.py
+++ b/tilelang/jit/__init__.py
@@ -20,6 +20,7 @@ from tvm.tir import PrimFunc
 from tvm.target import Target
 
 from tilelang.jit.kernel import JITKernel
+from tilelang.utils.target import determine_target
 from tilelang.cache import cached
 from os import path, makedirs
 from logging import getLogger
@@ -71,7 +72,7 @@ def compile(
         compile_flags = [compile_flags]
 
     # This path is not a performance critical path, so we can afford to convert the target.
-    target, target_host = Target(target), Target(target_host) if target_host else None
+    target = Target(determine_target(target))
 
     return cached(
         func=func,

--- a/tilelang/jit/__init__.py
+++ b/tilelang/jit/__init__.py
@@ -34,7 +34,7 @@ def compile(
     out_idx: Union[List[int], int, None] = None,
     execution_backend: Literal["dlpack", "ctypes", "cython", "nvrtc"] = "cython",
     target: Union[str, Target] = "auto",
-    target_host: Union[str, Target] = None,
+    target_host: Union[str, Target, None] = None,
     verbose: bool = False,
     pass_configs: Optional[Dict[str, Any]] = None,
     compile_flags: Optional[Union[List[str], str]] = None,
@@ -69,6 +69,10 @@ def compile(
     assert isinstance(func, PrimFunc), f"target function must be a PrimFunc but got {type(func)}"
     if isinstance(compile_flags, str):
         compile_flags = [compile_flags]
+
+    # This path is not a performance critical path, so we can afford to convert the target.
+    target, target_host = Target(target), Target(target_host) if target_host else None
+
     return cached(
         func=func,
         out_idx=out_idx,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - JIT compile API accepts no host target (target_host may be omitted); target inputs are auto-normalized for simpler usage.

- Refactor
  - Target normalization moved earlier for consistent behavior across compilation and autotuning.
  - Autotuner now stores a stringified target representation when hashing.

- Bug Fixes / Behavior
  - Numeric literal emission switched to hexfloat (original scientific value preserved in comments).
  - Relaxed error signaling for some narrow floating types.
  - Benchmark prints reference performance only when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->