### PR TITLE
[Ci] Adds pytest-durations for test timing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,11 +116,11 @@ jobs:
         source "${{ runner.tool_cache }}/${{ env.VENV_DIR }}/bin/activate"
         cd examples
         unset PYTHONPATH
-        python -m pytest -n 4 **/test*.py -v -r fE
+        python -m pytest -n 4 **/test*.py -v -r fE --durations=0
 
     - name: Run tests
       run: |
         source "${{ runner.tool_cache }}/${{ env.VENV_DIR }}/bin/activate"
         cd testing/python
         unset PYTHONPATH
-        python -m pytest -n 4 -v -r fE
+        python -m pytest -n 4 -v -r fE --durations=0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -12,6 +12,7 @@ dtlib
 numpy>=1.23.5
 pytest>=6.2.4
 pytest_xdist>=2.2.1
+pytest-durations
 packaging>=21.0
 PyYAML
 tqdm>=4.62.3


### PR DESCRIPTION
Adds `pytest-durations` to the test requirements and configures pytest to display test durations.

This helps in identifying slow-running tests and optimizing the test suite for faster feedback.