### PR TITLE
[Nvidia][SM121] Add intrin.h include to gemm_mma.h for sm120+

### DIFF
--- a/src/tl_templates/cuda/gemm_mma.h
+++ b/src/tl_templates/cuda/gemm_mma.h
@@ -9,6 +9,7 @@
 
 #include "common.h"
 #include "cuda_fp8.h"
+#include "intrin.h"
 
 namespace cute {
 


### PR DESCRIPTION
`gemm_sm120.h` is based on `gemm_mma.h`.
However, `gemm_mma.h` did not include `intrin.h`, which is essential to compile tilelang code on sm120 hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CUDA GEMM template to include required intrinsics header for improved build compatibility across environments. No changes to functionality, performance, or public APIs.
  * Enhances maintainability and reduces potential compiler warnings, with no impact on user-facing behavior or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->