### PR TITLE
[CI]Adds pytest timeout to CI

### DIFF
--- a/.github/workflows/amd_ci.yml
+++ b/.github/workflows/amd_ci.yml
@@ -115,4 +115,4 @@ jobs:
         source "${{ runner.tool_cache }}/${{ env.VENV_DIR }}/bin/activate"
         cd testing/python/amd
         unset PYTHONPATH
-        python -m pytest -v test_tilelang_test_amd.py --durations=0
+        python -m pytest -v test_tilelang_test_amd.py --durations=0 --timeout=200

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,4 +118,4 @@ jobs:
         source "${{ runner.tool_cache }}/${{ env.VENV_DIR }}/bin/activate"
         cd testing/python
         unset PYTHONPATH
-        python -m pytest -n 4 -v -r fE --durations=0
+        python -m pytest -n 4 -v -r fE --durations=0 --timeout=200

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -13,6 +13,7 @@ numpy>=1.23.5
 pytest>=6.2.4
 pytest_xdist>=2.2.1
 pytest-durations
+pytest-timeout
 packaging>=21.0
 PyYAML
 tqdm>=4.62.3


### PR DESCRIPTION
Adds a timeout to pytest runs in CI to prevent jobs from hanging indefinitely. This also adds `pytest-timeout` to the test requirements.