### PR TITLE
[Bugfix] Expose `alloc_reducer` definition to the python side

### DIFF
--- a/tilelang/language/__init__.py
+++ b/tilelang/language/__init__.py
@@ -41,6 +41,7 @@ from .allocate import (
     alloc_shared,  # noqa: F401
     alloc_fragment,  # noqa: F401
     alloc_barrier,  # noqa: F401
+    alloc_reducer,  # noqa: F401
 )
 from .copy import copy, c2d_im2col  # noqa: F401
 from .gemm import GemmWarpPolicy, gemm, gemm_v2  # noqa: F401


### PR DESCRIPTION
- Introduced a new function `alloc_reducer` to allocate a reducer buffer with specified shape, data type, and reduction operation (sum, max, min).
- Added detailed documentation for the function, including usage instructions and parameter descriptions.
- Ensured that the function supports replication strategies and includes assertions for valid operation types and replication options.

This enhancement improves the functionality of buffer management in TileLang, facilitating efficient reduction operations in parallel loops.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added alloc_reducer API for creating reducer buffers with configurable operation (sum, max, min) and optional replication; now accessible from the top-level language package.
  * Includes input validation with sensible defaults to prevent invalid configurations.

* Documentation
  * Expanded docstrings describing reducer usage, operation semantics, and initial values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->