### PR TITLE
Add pytest-durations to requirements for ROCm

### DIFF
--- a/requirements-rocm.txt
+++ b/requirements-rocm.txt
@@ -12,6 +12,7 @@ dtlib
 numpy>=1.23.5
 pytest>=6.2.4
 pytest_xdist>=2.2.1
+pytest-durations
 packaging>=21.0
 PyYAML
 tqdm>=4.62.3


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test reporting for ROCm environments by introducing a duration-tracking plugin, enabling clearer visibility into slow tests and helping streamline CI feedback. This supports more efficient debugging and prioritization. No user-facing changes.

* **Chores**
  * Updated test-related dependencies to include duration tracking, with no impact on runtime behavior or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->