### PR TITLE
[Refactor] Reopen #794 Fix lower bug when buffer store is not guarded by any tile op

### DIFF
--- a/tilelang/transform/add_bufstore_wrapper.py
+++ b/tilelang/transform/add_bufstore_wrapper.py
@@ -11,9 +11,11 @@ def AddWrapperForSingleBufStore():
 
         def get_used_var(op):
             used_var = set()
+
             def visit_fn(x):
                 if isinstance(x, Var):
                     used_var.add(x)
+
             post_order_visit(op, visit_fn)
             return used_var
 


### PR DESCRIPTION
- **[Refactor] Rewrite AddWrapper pass by ir_transform, PyStmtExprVisitor and PyStmtExprMutator seem buggy**

This is re-open of #794 , the implementation is buggy. This is because `PyStmtExprVisitor` and `PyStmtExprMutator` are buggy, sometime causes segment fault. I re-implement the pass using `ir_transform`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal transformation rewritten to a stateful pre/post-visit traversal, improving reliability and maintainability for buffer-store handling in parallel/tiling scenarios; no change to observable behavior.

* **Chores**
  * Preserved public API and function signatures; internal implementation changes only.

* **Notes**
  * Focused on robustness and easier future maintenance; users should see no functional differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->