### PR TITLE
[example] fix unused param in mhs example

### DIFF
--- a/examples/flash_attention/example_mha_fwd_bshd.py
+++ b/examples/flash_attention/example_mha_fwd_bshd.py
@@ -193,7 +193,7 @@ def main(
         print("Tile-lang: {:.2f} ms".format(latency))
         print("Tile-lang: {:.2f} TFlops".format(total_flops / latency * 1e-9))
     else:
-        best_result = flashattn(batch, heads, seq_len, dim, is_causal, tune=tune)
+        best_result = flashattn(batch, heads, seq_len, dim, is_causal)
         best_latency = best_result.latency
         best_config = best_result.config
         ref_latency = best_result.ref_latency


### PR DESCRIPTION
`flashattn` is already wrapped with `autotune`, `tune` is not used and reports unknown param error.

https://github.com/tile-ai/tilelang/blob/d3e75b701b23014072f0edc9565fd8e6023be71c/examples/flash_attention/example_mha_fwd_bshd.py#L16-L18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a parameter mismatch in the Flash Attention example to align with the current call signature, preventing runtime errors.
  * Tuning now relies on the built-in mechanism automatically; no manual flag is needed.
  * Preserves existing behavior and results without requiring user changes.
  * No public APIs were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->