### PR TITLE
[Bugfix] Skip fp4 dtype binding when using older versions of ml_dtypes

### DIFF
--- a/tilelang/version.py
+++ b/tilelang/version.py
@@ -32,7 +32,8 @@ def get_git_commit_id() -> Union[str, None]:
                                        cwd=os.path.dirname(os.path.abspath(__file__)),
                                        stderr=subprocess.DEVNULL,
                                        encoding='utf-8').strip()
-    except subprocess.SubprocessError:
+    # FileNotFoundError is raised when git is not installed
+    except (subprocess.SubprocessError, FileNotFoundError):
         return None
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Prevented errors during version retrieval when Git is unavailable, ensuring the app runs smoothly in environments without Git. Version still includes the commit ID when available.

- Chores
  - Updated third-party TVM dependency to a newer revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->