### PR TITLE
[CMake] Added support for statically linked system libc library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@
 cmake_minimum_required(VERSION 3.18)
 project(TILE_LANG C CXX)
 
+option(TILE_LANG_STATIC_STDCPP "Statically link libstdc++ for TileLang libraries" ON)
+
 # Set default build type to Release if not provided
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type")
@@ -59,6 +61,18 @@ include(CheckCXXCompilerFlag)
 # Enable static runtime build if required
 if(TILE_LANG_INSTALL_STATIC_LIB)
   set(BUILD_STATIC_RUNTIME ON)
+endif()
+
+if(TILE_LANG_STATIC_STDCPP)
+  message(STATUS "Enabling static linking of C++ standard library")
+  # Set compile flags for static linking of the C++ standard library
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++")
+  # For some compilers, additional flags may be required
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -static-libstdc++")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -static-libstdc++")
+  endif()
 endif()
 
 # Enforce CUDA standard


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a build option to statically link the C++ standard library for TileLang libraries, enabled by default. This improves portability and reduces runtime dependencies for produced binaries.
  - When enabled, builds on GNU toolchains apply static linking across executables, shared libraries, and modules. A status message confirms activation.
  - The option can be turned off if dynamic linking is preferred for smaller binaries or specific deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->