### PR TITLE
[TMA] Bugfix when a shared buffer is both issued with tma store and tma load

### DIFF
--- a/src/transform/lower_hopper_intrin.cc
+++ b/src/transform/lower_hopper_intrin.cc
@@ -25,7 +25,7 @@ public:
     PrimFuncNode *fptr = f.CopyOnWrite();
     LowerHopperIntrin substituter(disable_shuffle_elect);
     fptr->body = substituter.VisitStmt(f->body);
-    Map<String, Array<PrimExpr>> init_desc_arg_map;
+    Map<Var, Array<PrimExpr>> init_desc_arg_map;
     for (const auto &[call, var] : substituter.desc_map_) {
       // Should allocate 128 bytes for TensorMap on stack
       Call alloc_desc = Call(DataType::Handle(), builtin::tvm_stack_alloca(),
@@ -46,7 +46,7 @@ public:
           Call(DataType::Handle(), builtin::tvm_call_packed(), init_desc_args);
       fptr->body =
           LetStmt(var, alloc_desc, SeqStmt({Evaluate(init_desc), fptr->body}));
-      init_desc_arg_map.Set(var->name_hint, init_desc_args);
+      init_desc_arg_map.Set(var, init_desc_args);
     }
     f = WithAttr(std::move(f), "tma_descriptor_args", init_desc_arg_map);
     return f;


### PR DESCRIPTION
- Updated `init_desc_arg_map` to use `Var` as the key instead of `String` in `lower_hopper_intrin.cc`.
- Enhanced `func_call_args` method in `TLCUDASourceWrapper` to accept additional parameters for better argument mapping.
- Added assertions to ensure consistency between function parameters and arguments during kernel launches.
- Modified `generate_tma_descriptor_args` to utilize a mapping of variable names for TMA descriptor initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Exposes the primary host function via a public property in CUDA/NVRTC wrappers for easier access.
* Bug Fixes
  * Ensures descriptor arguments are correctly mapped to device function parameters with validation to prevent mismatches at runtime.
* Refactor
  * Streamlines propagation of function parameters through dispatch and kernel launch paths for more reliable code generation.
  * Improves descriptor handling with variable-based mappings, enabling safer and more consistent initialization across kernels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->