### PR TITLE
[AMD] refactor MatrixCoreIntrinEmitter

### DIFF
--- a/testing/python/amd/test_tilelang_gemm_mfma_intrinsic.py
+++ b/testing/python/amd/test_tilelang_gemm_mfma_intrinsic.py
@@ -234,6 +234,10 @@ def test_assert_tl_matmul():
     assert_tl_matmul_correctness(128, 128, 128, "int8", "int32", accum_dtype="int32")
     assert_tl_matmul_correctness(128, 256, 256, "int8", "int32", accum_dtype="int32")
     assert_tl_matmul_correctness(128, 256, 256, "int8", "int32", accum_dtype="int32", k_pack=2)
+    assert_tl_matmul_correctness(
+        128, 256, 256, "int8", "int32", b_transposed=False, accum_dtype="int32")
+    assert_tl_matmul_correctness(
+        128, 256, 256, "int8", "int32", b_transposed=False, accum_dtype="int32", k_pack=2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* add a new emitter for weight preshuffle mfma.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced AMD MFMA preshuffle GEMM path with streamlined data flow for improved stability and potential performance gains.
  - Added an option to load matrix B directly from global memory in preshuffle scenarios.
  - Expanded supported data types by removing restrictive runtime checks.

- Tests
  - Added coverage for int8 GEMM configurations (e.g., 128x256x256) and k-pack variations.
  - Extended tests to validate the new B loading option and updated preshuffle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->