### PR TITLE
[Feat] Add fast sine and cosine definitions in CUDA templates

### DIFF
--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -18,6 +18,8 @@ using int4_t = int4;
 #define hexp cutlass::fast_exp
 #define hlog cutlass::fast_log
 #define hsqrt cutlass::fast_sqrt
+#define hsin cutlass::fast_sin
+#define hcos cutlass::fast_cos
 #define htanh cutlass::fast_tanh
 #define hpow powf
 


### PR DESCRIPTION
This pull request adds new mathematical function macros to the CUDA common header to support fast sine and cosine operations, improving performance and consistency for trigonometric calculations.

Math function enhancements:

* Added macros for fast sine (`hsin`) and fast cosine (`hcos`) using `cutlass::fast_sin` and `cutlass::fast_cos` in `src/tl_templates/cuda/common.h`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fast sine and cosine operations to GPU-accelerated math helpers, enabling optimized trigonometric computations.
  * Complements existing fast math utilities and can reduce latency for workloads relying on trig calculations.
  * No breaking changes: existing functionality remains unaffected, with seamless integration for current users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->