### PR TITLE
[Bugfix] Fix CopyNode Lower method to include disable_tma flag in GetCopyInst

### DIFF
--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -692,8 +692,8 @@ Stmt CopyNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
   PassContext pass_ctx = PassContext::Current();
   bool disable_tma_lower =
       pass_ctx->GetConfig<bool>(kDisableTMALower, false).value();
-  auto copy_inst =
-      GetCopyInst(target, disable_tma_lower || disable_tma, T.layout_map, analyzer);
+  auto copy_inst = GetCopyInst(target, disable_tma_lower || disable_tma,
+                               T.layout_map, analyzer);
   if (copy_inst == CopyInst::kBulkLoad1D ||
       copy_inst == CopyInst::kBulkStore1D) {
     auto bulk_copy = LowerBulkCopy1D(T, analyzer, copy_inst);

--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -693,7 +693,7 @@ Stmt CopyNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
   bool disable_tma_lower =
       pass_ctx->GetConfig<bool>(kDisableTMALower, false).value();
   auto copy_inst =
-      GetCopyInst(target, disable_tma_lower, T.layout_map, analyzer);
+      GetCopyInst(target, disable_tma_lower || disable_tma, T.layout_map, analyzer);
   if (copy_inst == CopyInst::kBulkLoad1D ||
       copy_inst == CopyInst::kBulkStore1D) {
     auto bulk_copy = LowerBulkCopy1D(T, analyzer, copy_inst);


### PR DESCRIPTION
This pull request makes a targeted change to the `CopyNode::Lower` function in `src/op/copy.cc` to enhance the logic for selecting the copy instruction. The update ensures that the `disable_tma` flag is now considered in addition to the configuration option when determining whether to disable TMA lowering.

Key change:

* Improved the call to `GetCopyInst` by combining the `disable_tma_lower` configuration and the `disable_tma` flag, ensuring TMA lowering is properly disabled when either is set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Per-operation and global disable flags now consistently prevent bulk-transfer fast-paths, fixing incorrect path selection and improving correctness.

* **Performance**
  * More predictable behavior when bulk transfers are disabled; slight performance variations where fast-paths are intentionally bypassed.

* **Examples**
  * Updated examples to use default lowering and enable per-copy SIMT fallbacks with clarifying comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->