### PR TITLE
[Layout] Strict annotate completed replicated layout for fragment with constant index 

### DIFF
--- a/src/layout/layout.cc
+++ b/src/layout/layout.cc
@@ -326,6 +326,12 @@ Fragment::Fragment(Array<PrimExpr> input_size, Array<PrimExpr> forward_index,
   data_ = std::move(n);
 }
 
+// which means the forward_thread is rep_var -> lambda i, rep: rep
+bool FragmentNode::IsCompletedReplicated() const {
+  arith::Analyzer analyzer;
+  return ExprDeepEqual()(analyzer.Simplify(forward_thread_), ReplicationPlaceholder());
+}
+
 PrimExpr FragmentNode::ThreadExtent() const {
   Array<PrimExpr> ret(OutputDim(), 1);
   arith::Analyzer analyzer;

--- a/src/layout/layout.cc
+++ b/src/layout/layout.cc
@@ -329,7 +329,8 @@ Fragment::Fragment(Array<PrimExpr> input_size, Array<PrimExpr> forward_index,
 // which means the forward_thread is rep_var -> lambda i, rep: rep
 bool FragmentNode::IsCompletedReplicated() const {
   arith::Analyzer analyzer;
-  return ExprDeepEqual()(analyzer.Simplify(forward_thread_), ReplicationPlaceholder());
+  return ExprDeepEqual()(analyzer.Simplify(forward_thread_),
+                         ReplicationPlaceholder());
 }
 
 PrimExpr FragmentNode::ThreadExtent() const {

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -101,6 +101,8 @@ public:
 
   bool IsEqual(const FragmentNode *other, bool skip_index = false) const;
 
+  bool IsCompletedReplicated() const;
+
   static void RegisterReflection();
 
   bool SEqualReduce(const FragmentNode *other, SEqualReducer equal) const;

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -213,9 +213,57 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
                                       InferLevel level) const {
   if (loop_layout_.defined())
     return {};
-  if (level == InferLevel::kStrict)
-    return {};
+  if (level == InferLevel::kStrict){
+    LayoutMap results;
+    // Deduce buffers that shoule be complicated replicated.
+    // For example:
+    // for i in T.Parllel(m):
+    //   fragment[0] = x[i]
+    // then fragment[0] must be replicated on all threads.
+    for (const auto &[buffer, indices] : indice_map_) {
+      if (T.layout_map.count(buffer)) {
+        continue;
+      }
+      if (buffer.scope() != "local.fragment") continue;
+      for (const auto &index : indices) {
+        if (const auto *imm = index.as<IntImmNode>()) {
+          if (imm->value == 0){
+            Array<IterVar> forward_vars;
+            for (const auto &s : buffer->shape) {
+              forward_vars.push_back(IterVar(Range(0, s), Var(), IterVarType::kDataPar));
+            }
+            Array<PrimExpr> forward_index;
+            for (const auto &iv : forward_vars) {
+              forward_index.push_back(iv->var);
+            }
+            Var rep;
+            auto rep_iter = IterVar({0, T.thread_bounds->extent}, rep,
+                                    IterVarType::kDataPar);
 
+            PrimExpr forward_thread = rep;
+            results.Set(buffer, Fragment(forward_vars, forward_index, forward_thread, rep_iter));
+          } else {
+            LOG(FATAL) << "Fragment buffer access with non-zero index [" << imm->value << "] is not supported. "
+                       << "Only fragment[0] access is allowed within T.Parallel loop.";
+          }
+        }
+      }
+    }
+    return results;
+  }
+  auto buffer_is_completed_replicated = [&](const Buffer &buffer) {
+    if (buffer.scope() != "local.fragment") return false;
+    auto frag = T.layout_map[buffer].as<Fragment>().value();
+    // buffer indices should be IntImm
+    for (const auto &index : indice_map_[buffer]) {
+      if (!index.as<IntImmNode>()) {
+        return false;
+      } else if (index.as<IntImmNode>()->value != 0) {
+        LOG(FATAL) << "buffer " << buffer << " is not completed replicated";
+      }
+    }
+    return frag->IsCompletedReplicated();
+  };
   // Step 1: try to infer loop's partition from a source fragment
   Buffer source_buffer, read_source_buffer;
   for (const auto &[buffer, indices] : indice_map_) {
@@ -226,15 +274,18 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
         continue;
 
       auto frag = T.layout_map[buffer].as<Fragment>().value();
+
       if (buffer_is_write_.count(buffer)) {
         source_buffer = buffer;
       } else {
         // Keep the buffer with largest number of indices
         // (which means the inference based on that buffer is more accurate)
         // as read_source_buffer to get more accurate layout
-        if (!read_source_buffer.defined() ||
+        // if the buffer is completed replicated, we don't need to infer the layout from this buffer.
+        if ((!read_source_buffer.defined() ||
             indice_map_[buffer].size() >
-                indice_map_[read_source_buffer].size()) {
+                indice_map_[read_source_buffer].size()) &&
+            !buffer_is_completed_replicated(buffer)) {
           read_source_buffer = buffer;
         }
         // If the buffer is not replicated and shape is equal to the

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -213,7 +213,7 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
                                       InferLevel level) const {
   if (loop_layout_.defined())
     return {};
-  if (level == InferLevel::kStrict){
+  if (level == InferLevel::kStrict) {
     LayoutMap results;
     // Deduce buffers that shoule be complicated replicated.
     // For example:
@@ -224,13 +224,15 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
       if (T.layout_map.count(buffer)) {
         continue;
       }
-      if (buffer.scope() != "local.fragment") continue;
+      if (buffer.scope() != "local.fragment")
+        continue;
       for (const auto &index : indices) {
         if (const auto *imm = index.as<IntImmNode>()) {
-          if (imm->value == 0){
+          if (imm->value == 0) {
             Array<IterVar> forward_vars;
             for (const auto &s : buffer->shape) {
-              forward_vars.push_back(IterVar(Range(0, s), Var(), IterVarType::kDataPar));
+              forward_vars.push_back(
+                  IterVar(Range(0, s), Var(), IterVarType::kDataPar));
             }
             Array<PrimExpr> forward_index;
             for (const auto &iv : forward_vars) {
@@ -240,11 +242,14 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
             auto rep_iter = IterVar({0, T.thread_bounds->extent}, rep,
                                     IterVarType::kDataPar);
 
-            PrimExpr forward_thread = rep;
-            results.Set(buffer, Fragment(forward_vars, forward_index, forward_thread, rep_iter));
+            const PrimExpr &forward_thread = rep;
+            results.Set(buffer, Fragment(forward_vars, forward_index,
+                                         forward_thread, rep_iter));
           } else {
-            LOG(FATAL) << "Fragment buffer access with non-zero index [" << imm->value << "] is not supported. "
-                       << "Only fragment[0] access is allowed within T.Parallel loop.";
+            LOG(FATAL)
+                << "Fragment buffer access with non-zero index [" << imm->value
+                << "] is not supported. "
+                << "Only fragment[0] access is allowed within T.Parallel loop.";
           }
         }
       }
@@ -252,7 +257,8 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
     return results;
   }
   auto buffer_is_completed_replicated = [&](const Buffer &buffer) {
-    if (buffer.scope() != "local.fragment") return false;
+    if (buffer.scope() != "local.fragment")
+      return false;
     auto frag = T.layout_map[buffer].as<Fragment>().value();
     // buffer indices should be IntImm
     for (const auto &index : indice_map_[buffer]) {
@@ -281,10 +287,11 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
         // Keep the buffer with largest number of indices
         // (which means the inference based on that buffer is more accurate)
         // as read_source_buffer to get more accurate layout
-        // if the buffer is completed replicated, we don't need to infer the layout from this buffer.
+        // if the buffer is completed replicated, we don't need to infer the
+        // layout from this buffer.
         if ((!read_source_buffer.defined() ||
-            indice_map_[buffer].size() >
-                indice_map_[read_source_buffer].size()) &&
+             indice_map_[buffer].size() >
+                 indice_map_[read_source_buffer].size()) &&
             !buffer_is_completed_replicated(buffer)) {
           read_source_buffer = buffer;
         }

--- a/tilelang/transform/add_bufstore_wrapper.py
+++ b/tilelang/transform/add_bufstore_wrapper.py
@@ -134,12 +134,13 @@ def AddWrapperForSingleBufStore():
                     # Validate fragment buffer indices - only index 0 is supported
                     buffer_indices = collect_buffer_indices(statement)
                     for buffer, indices in buffer_indices.items():
-                        if buffer.scope() == "local.fragment":
-                            for index in indices:
-                                if isinstance(index, IntImm) and index != 0:
-                                    raise ValueError(
-                                        f"Fragment buffer access with non-zero index [{index}] is not supported. "
-                                        "Only fragment[0] access is allowed.")
+                        if buffer.scope() != "local.fragment":
+                            continue
+                        for index in indices:
+                            if isinstance(index, IntImm) and index != 0:
+                                raise ValueError(
+                                    f"Fragment buffer access with non-zero index [{index}] is not supported. "
+                                    "Only fragment[0] access is allowed.")
 
                     # Wrap fragment[0] access with T.Parallel loop
                     return For(Var("_", "int32"), 0, 1, ForKind.PARALLEL, statement)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Strict mode now auto-assigns replicated layouts to fragment-scoped buffers lacking layouts.
  * Tighter validation enforces replication at index 0 only.

* Bug Fixes
  * Completed replicated buffers are excluded from further inference and read-source selection, preventing incorrect layout propagation.

* Refactor
  * Streamlined fragment buffer validation flow in the wrapper insertion pass for clarity without changing behavior.

* Chores
  * Exposed a public query to check whether a fragment is fully replicated, enabling safer higher-level logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->