### PR TITLE
[CI] optimize CI time

### DIFF
--- a/testing/python/tilelibrary/test_tilelang_tilelibrary_gemm_sp.py
+++ b/testing/python/tilelibrary/test_tilelang_tilelibrary_gemm_sp.py
@@ -2,7 +2,7 @@ import torch
 import tilelang
 import tilelang.testing
 
-from tilelang.utils.sparse import compress
+from tilelang.utils.sparse import compress, randn_semi_sparse
 from tilelang.layout import make_metadata_layout
 
 tilelang.disable_cache()
@@ -152,39 +152,6 @@ def matmul_sp_sm80(
 
     return main
 
-
-def generate_sparse_tensor_float32(M: int, K: int, dtype: torch.dtype, device='cpu', trans_A=False):
-    elem, group = SPARSITY_MAP[dtype]
-    if K % group != 0:
-        raise ValueError(
-            f"Last dimension must be divisible by {group} for {elem}:{group} sparsity.")
-
-    if trans_A:
-        full_tensor = torch.randn(K * M, dtype=torch.float32, device=device).view(K, M)
-        mask = torch.zeros_like(full_tensor, dtype=torch.bool)
-        for j in range(M):
-            for i in range(0, K, group):
-                flat_idx = torch.randint(0, group, (elem,), dtype=torch.int64)
-                for k in range(1, len(flat_idx)):
-                    while flat_idx[k] in flat_idx[:k]:
-                        flat_idx[k] = torch.randint(0, group, (1,), dtype=torch.int64)
-                for idx in flat_idx:
-                    mask[i + idx, j] = True
-    else:
-        full_tensor = torch.randn((M, K), dtype=torch.float32, device=device).view(M, K)
-        mask = torch.zeros_like(full_tensor, dtype=torch.bool)
-        for i in range(M):
-            for j in range(0, K, group):
-                flat_idx = torch.randint(0, group, (elem,), dtype=torch.int64)
-                for k in range(1, len(flat_idx)):
-                    while flat_idx[k] in flat_idx[:k]:
-                        flat_idx[k] = torch.randint(0, group, (1,), dtype=torch.int64)
-                for idx in flat_idx:
-                    mask[i, j + idx] = True
-
-    return full_tensor * mask
-
-
 def normalize(tensor, max_range=100.0):
     assert max_range <= 448.0
     max_v = tensor.abs().max().clamp(1e-4)
@@ -214,8 +181,8 @@ def run_gemm_sp(
         kernel,
         out_idx=[-1],
     )
-    A = generate_sparse_tensor_float32(
-        M, K, dtype=STR_TO_TYPE[in_dtype], device='cuda', trans_A=trans_A)
+    A = randn_semi_sparse(
+        M, K, dtype=STR_TO_TYPE[in_dtype], device='cuda', transposed=trans_A)
     if trans_B:
         B = torch.randn((N, K), device='cuda', dtype=torch.float32)
     else:

--- a/testing/python/tilelibrary/test_tilelang_tilelibrary_gemm_sp.py
+++ b/testing/python/tilelibrary/test_tilelang_tilelibrary_gemm_sp.py
@@ -152,6 +152,7 @@ def matmul_sp_sm80(
 
     return main
 
+
 def normalize(tensor, max_range=100.0):
     assert max_range <= 448.0
     max_v = tensor.abs().max().clamp(1e-4)
@@ -181,16 +182,15 @@ def run_gemm_sp(
         kernel,
         out_idx=[-1],
     )
-    A = randn_semi_sparse(
-        M, K, dtype=STR_TO_TYPE[in_dtype], device='cuda', transposed=trans_A)
+    A = randn_semi_sparse(M, K, dtype=STR_TO_TYPE[in_dtype], device='cuda', transposed=trans_A)
     if trans_B:
         B = torch.randn((N, K), device='cuda', dtype=torch.float32)
     else:
         B = torch.randn((K, N), device='cuda', dtype=torch.float32)
 
     if "float8" in in_dtype or "int8" in in_dtype:
-        A = normalize(A)
-        B = normalize(B)
+        A = normalize(A.float())
+        B = normalize(B.float())
 
     A = A.to(STR_TO_TYPE[in_dtype])
     B = B.to(STR_TO_TYPE[in_dtype])

--- a/testing/python/utils/test_compress_utils.py
+++ b/testing/python/utils/test_compress_utils.py
@@ -1,35 +1,13 @@
 import torch
 import tilelang
-from tilelang.utils.sparse import compress_sm90
+import tilelang.testing
 
+from tilelang.utils.sparse import compress_sm90, randn_semi_sparse
 
-def generate_2_to_4_sparse_tensor(shape, dtype=torch.float32, device='cpu'):
-    if shape[-1] % 4 != 0:
-        raise ValueError("Last dimension must be divisible by 4 for 2:4 sparsity.")
-
-    full_tensor = torch.randn(shape, dtype=torch.float32, device=device)
-    mask = torch.zeros_like(full_tensor, dtype=torch.bool)
-
-    group_count = shape[-1] // 4
-    group_shape = shape[:-1] + (group_count, 4)
-
-    reshaped = full_tensor.view(*group_shape)
-
-    for idx in range(reshaped.numel() // 4):
-        flat_idx = torch.randint(0, 4, (2,), dtype=torch.int64)
-        while flat_idx[0] == flat_idx[1]:
-            flat_idx[1] = torch.randint(0, 4, (1,), dtype=torch.int64)
-        i = idx // group_count
-        j = idx % group_count
-        mask.view(*group_shape)[i, j, flat_idx[0]] = True
-        mask.view(*group_shape)[i, j, flat_idx[1]] = True
-
-    sparse_tensor = full_tensor * mask
-    return sparse_tensor.to(dtype)
 
 
 def _test_compress_sm90(M, K, block_k, dtype):
-    A = generate_2_to_4_sparse_tensor((M, K), dtype=dtype, device='cuda')
+    A = randn_semi_sparse(M, K, dtype=dtype, device='cuda')
     A_sparse, E = compress_sm90(A, block_k, False)
 
 

--- a/testing/python/utils/test_compress_utils.py
+++ b/testing/python/utils/test_compress_utils.py
@@ -5,7 +5,6 @@ import tilelang.testing
 from tilelang.utils.sparse import compress_sm90, randn_semi_sparse
 
 
-
 def _test_compress_sm90(M, K, block_k, dtype):
     A = randn_semi_sparse(M, K, dtype=dtype, device='cuda')
     A_sparse, E = compress_sm90(A, block_k, False)

--- a/tilelang/utils/sparse.py
+++ b/tilelang/utils/sparse.py
@@ -94,7 +94,7 @@ def compress(A: torch.Tensor,
                          "Supported versions are sm_80 and sm_90.")
 
 
-def randn_semi_sparse(M: int, K: int, dtype=torch.float16, device='cuda', transposed: bool=False):
+def randn_semi_sparse(M: int, K: int, dtype=torch.float16, device='cuda', transposed: bool = False):
     """
     Generate a random semi-sparse tensor. The generated tensor will have 2:4 sparsity along the K dimension.
     Args:
@@ -105,20 +105,20 @@ def randn_semi_sparse(M: int, K: int, dtype=torch.float16, device='cuda', transp
         transpose (bool): If True, returns a transposed tensor of shape (K, M)
     """
     elem, group = 2, 4
+    tensor = torch.randn((M, K), dtype=torch.float, device=device).view(M, -1, group)
+    indice = tensor.topk(elem, dim=-1).indices
+    tensor.scatter_(-1, indice, 0)
+    tensor = tensor.view(M, K)
     if transposed:
-        tensor = torch.randn((K, M), dtype=torch.float, device=device).view(group, -1, M)
-        indice = tensor.topk(elem, dim=0).indices
-        tensor.scatter_(0, indice, 0)
-        tensor = tensor.view(K, M)
-    else:
-        tensor = torch.randn((M, K), dtype=torch.float, device=device).view(M, -1, group)
-        indice = tensor.topk(elem, dim=-1).indices
-        tensor.scatter_(-1, indice, 0)
-        tensor = tensor.view(M, K)
+        tensor = tensor.t().contiguous()
     return tensor.to(dtype)  # dtype like float8 might not have randn kernel
 
 
-def arange_semi_sparse(M: int, K: int, dtype=torch.float16, device='cuda', transposed: bool=False):
+def arange_semi_sparse(M: int,
+                       K: int,
+                       dtype=torch.float16,
+                       device='cuda',
+                       transposed: bool = False):
     """
     Generate a semi-sparse tensor with values from 0 to M*K-1. The generated tensor will have 2:4 sparsity along the K dimension.
     Args:
@@ -129,14 +129,10 @@ def arange_semi_sparse(M: int, K: int, dtype=torch.float16, device='cuda', trans
         transpose (bool): If True, returns a transposed tensor of shape (K, M)
     """
     elem, group = 2, 4
+    tensor = torch.arange(M * K, dtype=dtype, device=device).view(group, -1, M)
+    indice = tensor.topk(elem, dim=0).indices
+    tensor.scatter_(0, indice, 0)
+    tensor = tensor.view(K, M)
     if transposed:
-        tensor = torch.arange(M * K, dtype=dtype, device=device).view(group, -1, M)
-        indice = tensor.topk(elem, dim=0).indices
-        tensor.scatter_(0, indice, 0)
-        tensor = tensor.view(K, M)
-    else:
-        tensor = torch.arange(M * K, dtype=dtype, device=device).view(M, -1, group)
-        indice = tensor.topk(elem, dim=-1).indices
-        tensor.scatter_(-1, indice, 0)
-        tensor = tensor.view(M, K)
+        tensor = tensor.t().contiguous()
     return tensor

--- a/tilelang/utils/sparse.py
+++ b/tilelang/utils/sparse.py
@@ -92,3 +92,51 @@ def compress(A: torch.Tensor,
     else:
         raise ValueError(f"Unsupported CUDA compute version: {compute_version}. "
                          "Supported versions are sm_80 and sm_90.")
+
+
+def randn_semi_sparse(M: int, K: int, dtype=torch.float16, device='cuda', transposed: bool=False):
+    """
+    Generate a random semi-sparse tensor. The generated tensor will have 2:4 sparsity along the K dimension.
+    Args:
+        M (int): Number of rows
+        K (int): Number of columns
+        dtype: Data type of the tensor
+        device: Device to create the tensor on
+        transpose (bool): If True, returns a transposed tensor of shape (K, M)
+    """
+    elem, group = 2, 4
+    if transposed:
+        tensor = torch.randn((K, M), dtype=torch.float, device=device).view(group, -1, M)
+        indice = tensor.topk(elem, dim=0).indices
+        tensor.scatter_(0, indice, 0)
+        tensor = tensor.view(K, M)
+    else:
+        tensor = torch.randn((M, K), dtype=torch.float, device=device).view(M, -1, group)
+        indice = tensor.topk(elem, dim=-1).indices
+        tensor.scatter_(-1, indice, 0)
+        tensor = tensor.view(M, K)
+    return tensor.to(dtype)  # dtype like float8 might not have randn kernel
+
+
+def arange_semi_sparse(M: int, K: int, dtype=torch.float16, device='cuda', transposed: bool=False):
+    """
+    Generate a semi-sparse tensor with values from 0 to M*K-1. The generated tensor will have 2:4 sparsity along the K dimension.
+    Args:
+        M (int): Number of rows
+        K (int): Number of columns
+        dtype: Data type of the tensor
+        device: Device to create the tensor on
+        transpose (bool): If True, returns a transposed tensor of shape (K, M)
+    """
+    elem, group = 2, 4
+    if transposed:
+        tensor = torch.arange(M * K, dtype=dtype, device=device).view(group, -1, M)
+        indice = tensor.topk(elem, dim=0).indices
+        tensor.scatter_(0, indice, 0)
+        tensor = tensor.view(K, M)
+    else:
+        tensor = torch.arange(M * K, dtype=dtype, device=device).view(M, -1, group)
+        indice = tensor.topk(elem, dim=-1).indices
+        tensor.scatter_(-1, indice, 0)
+        tensor = tensor.view(M, K)
+    return tensor


### PR DESCRIPTION
The previous loop-based sparse tensor generator took too long time.

After this PR:

Compiling `compress_sm90` takes 134.0 seconds.

`testing/python/utils/test_compress_utils.py` takes 8.3 seconds.

`testing/python/tilelibrary/test_tilelang_tilelibrary_gemm_sp.py` takes 209.6s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added utilities to generate semi-sparse tensors (random and sequential), with optional transposition and CUDA support.
- Bug Fixes
  - Improved normalization for 8-bit inputs by casting to float before normalization.
- Refactor
  - Replaced custom sparse tensor generators in examples and tests with shared utilities to reduce inline logic.
- Tests
  - Updated tests to use the new utilities and aligned environment requirements for CUDA execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->