### PR TITLE
[Typo] Fix backend name for Huawei Ascend

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Tile Language (**tile-lang**) is a concise domain-specific language designed to 
 <img src=./images/MatmulExample.png />
 
 ## Latest News
-- 09/29/2025  🎉: Thrilled to announce that ​​AscendC​​ and ​​NPU IR​​ backends targeting Huawei Ascend chips are now supported!
+- 09/29/2025  🎉: Thrilled to announce that ​​AscendC​​ and ​Ascend​NPU IR​​ backends targeting Huawei Ascend chips are now supported!
 Check out the preview here:
 🔗 [link](https://github.com/tile-ai/tilelang-ascend).
 This includes implementations across two branches:
 [ascendc_pto](https://github.com/tile-ai/tilelang-ascend) and
-[npuir](https://github.com/tile-ai/tilelang-ascend/tree/npuir).
+[ascendnpu_ir](https://github.com/tile-ai/tilelang-ascend/tree/ascend_npuir).
 Feel free to explore and share your feedback! 
 - 07/04/2025 🚀: Introduced `T.gemm_sp` for 2:4 sparse tensor core support, check out [Pull Request #526](https://github.com/tile-ai/tilelang/pull/526) for details.
 - 06/05/2025 ✨: Added [NVRTC Backend](https://github.com/tile-ai/tilelang/pull/461) to significantly reduce compilation time for cute templates!

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Check out the preview here:
 🔗 [link](https://github.com/tile-ai/tilelang-ascend).
 This includes implementations across two branches:
 [ascendc_pto](https://github.com/tile-ai/tilelang-ascend) and
-[ascendnpu_ir](https://github.com/tile-ai/tilelang-ascend/tree/ascend_npuir).
+[ascendnpu_ir](https://github.com/tile-ai/tilelang-ascend/tree/ascendnpu_ir).
 Feel free to explore and share your feedback! 
 - 07/04/2025 🚀: Introduced `T.gemm_sp` for 2:4 sparse tensor core support, check out [Pull Request #526](https://github.com/tile-ai/tilelang/pull/526) for details.
 - 06/05/2025 ✨: Added [NVRTC Backend](https://github.com/tile-ai/tilelang/pull/461) to significantly reduce compilation time for cute templates!


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected branding in Latest News from “NPU IR” to “AscendNPU IR” to align with current naming.
  * Updated related hyperlinks to point to the new branch location, ensuring readers reach the correct resources.
  * Clarified the news entry to improve accuracy and reduce confusion.
  * No functional, UI, or API changes; this update is limited to text and URLs in documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->