### PR TITLE
[Bugfix] Fix flops comp and softmax scale in mla 

### DIFF
--- a/examples/deepseek_mla/benchmark_mla.py
+++ b/examples/deepseek_mla/benchmark_mla.py
@@ -87,7 +87,7 @@ def run_flash_mla(q, block_table, blocked_k, max_seqlen_pad, block_size, b, s_q,
 
 
 @torch.inference_mode()
-def run_flash_infer(q, block_table, blocked_k, max_seqlen_pad, block_size, b, s_q, cache_seqlens,
+def run_flashinfer(q, block_table, blocked_k, max_seqlen_pad, block_size, b, s_q, cache_seqlens,
                     h_q, h_kv, d, dv, causal, dtype):
     # pip install flashinfer-python
     import flashinfer
@@ -128,7 +128,7 @@ def run_flash_infer(q, block_table, blocked_k, max_seqlen_pad, block_size, b, s_
         blocked_k.dtype,
     )
 
-    def flash_infer():
+    def flashinfer():
         output, lse = mla_wrapper.run(
             q_nope.view(-1, h_q, dv),
             q_pe.view(-1, h_q, d - dv),
@@ -137,8 +137,8 @@ def run_flash_infer(q, block_table, blocked_k, max_seqlen_pad, block_size, b, s_
             return_lse=True)
         return output.view(b, -1, h_q, dv), lse.view(b, h_q, 1)
 
-    out_flash, lse_flash = flash_infer()
-    t = triton.testing.do_bench(flash_infer)
+    out_flash, lse_flash = flashinfer()
+    t = triton.testing.do_bench(flashinfer)
     return out_flash, lse_flash, t
 
 
@@ -459,7 +459,7 @@ FUNC_TABLE = {
     "torch": run_torch_mla,
     "tilelang": run_flash_mla_tilelang,
     "flash_mla": run_flash_mla,
-    "flash_infer": run_flash_infer,
+    "flashinfer": run_flashinfer,
     "flash_mla_triton": run_flash_mla_triton,
 }
 
@@ -496,9 +496,9 @@ def compare_ab(baseline, target, b, s_q, cache_seqlens, h_q, h_kv, d, dv, causal
                                        s_q, cache_seqlens, h_q, h_kv, d, dv, causal, dtype)
 
     torch.testing.assert_close(out_b.float(), out_a.float(), atol=1e-2, rtol=1e-2), "out"
-    if target not in ["flash_infer", "flash_mla_triton", "tilelang"
-                     ] and baseline not in ["flash_infer", "flash_mla_triton", "tilelang"]:
-        # flash_infer has a different lse return value
+    if target not in ["flashinfer", "flash_mla_triton", "tilelang"
+                     ] and baseline not in ["flashinfer", "flash_mla_triton", "tilelang"]:
+        # flashinfer has a different lse return value
         # flash_mla_triton and flash_mla_tilelang doesn't return lse
         torch.testing.assert_close(lse_b.float(), lse_a.float(), atol=1e-2, rtol=1e-2), "lse"
 
@@ -554,7 +554,7 @@ available_targets = [
     "torch",
     "tilelang",
     "flash_mla",
-    "flash_infer",
+    "flashinfer",
     "flash_mla_triton",
 ]
 

--- a/examples/deepseek_mla/benchmark_mla.py
+++ b/examples/deepseek_mla/benchmark_mla.py
@@ -88,7 +88,7 @@ def run_flash_mla(q, block_table, blocked_k, max_seqlen_pad, block_size, b, s_q,
 
 @torch.inference_mode()
 def run_flashinfer(q, block_table, blocked_k, max_seqlen_pad, block_size, b, s_q, cache_seqlens,
-                    h_q, h_kv, d, dv, causal, dtype):
+                   h_q, h_kv, d, dv, causal, dtype):
     # pip install flashinfer-python
     import flashinfer
     assert d > dv, "mla with rope dim should be larger than no rope dim"

--- a/examples/deepseek_mla/example_mla_decode_paged.py
+++ b/examples/deepseek_mla/example_mla_decode_paged.py
@@ -12,7 +12,9 @@ import math
         tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
     })
 def mla_decode_tilelang(batch, h_q, h_kv, max_seqlen_pad, dv, dpe, block_N, block_H, num_split,
-                        block_size, softmax_scale):
+                        block_size, softmax_scale=None):
+    if softmax_scale is None:
+        softmax_scale = (dv + dpe)**-0.5
     scale = float(softmax_scale * 1.44269504)  # log2(e)
     dtype = "float16"
     accum_dtype = "float"
@@ -322,7 +324,7 @@ def run_tilelang_mla(q, block_table, blocked_k, max_seqlen_pad, block_size, b, s
     num_kv_splits = 1
     BLOCK_N = 64
     BLOCK_H = min(64, h_q // h_kv)
-    softmax_scale = (d + dv)**-0.5
+    softmax_scale = d**-0.5
 
     out_partial = torch.empty(b, h_q, num_kv_splits, dv, dtype=dtype, device=q.device)
     glse = torch.empty(b, h_q, num_kv_splits, dtype=dtype, device=q.device)
@@ -379,7 +381,7 @@ if __name__ == "__main__":
     max_seqlen = cache_seqlens.max().item()
     max_seqlen_pad = math.ceil(max_seqlen / 256) * 256
 
-    total_flops = s_q * total_seqlens * h_q * (d + dv) * 2
+    total_flops = s_q * total_seqlens * h_q * d * 2
 
     q = torch.randn(b, s_q, h_q, d, dtype=dtype, device=device)
     block_table = torch.arange(

--- a/examples/deepseek_mla/example_mla_decode_paged.py
+++ b/examples/deepseek_mla/example_mla_decode_paged.py
@@ -11,8 +11,17 @@ import math
     out_idx=[8], pass_configs={
         tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
     })
-def mla_decode_tilelang(batch, h_q, h_kv, max_seqlen_pad, dv, dpe, block_N, block_H, num_split,
-                        block_size, softmax_scale=None):
+def mla_decode_tilelang(batch,
+                        h_q,
+                        h_kv,
+                        max_seqlen_pad,
+                        dv,
+                        dpe,
+                        block_N,
+                        block_H,
+                        num_split,
+                        block_size,
+                        softmax_scale=None):
     if softmax_scale is None:
         softmax_scale = (dv + dpe)**-0.5
     scale = float(softmax_scale * 1.44269504)  # log2(e)


### PR DESCRIPTION
Fixes some issues.
1. The benchmark cannot run due to missing arg
<img width="662" height="202" alt="image" src="https://github.com/user-attachments/assets/51ba2aa3-a2de-4a66-9007-ee1bfdd4ab42" />

2. The FLOPs computation should use the full head dim `d = dpe + dv`. The softmax scale is adjusted accordingly. See  
https://github.com/flashinfer-ai/flashinfer/blob/0f8ecab1121ad52dd22b47317662cbbd7f0d343c/benchmarks/bench_deepseek_mla.py#L73

I ran the bench against Flashinfer main branch on H100, and looks like it has packed in more optimizations than when the last comparision was made. Looking forward to learning more Tilelang tricks to speed it up!
<img width="969" height="382" alt="image" src="https://github.com/user-attachments/assets/154a69ee-059a-48e6-aed6-dda4a3e167fc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - softmax_scale is now optional and auto-computed at runtime when omitted; callers remain backward compatible.

- Refactor
  - Renamed Flash Inference backend from "flash_infer" to "flashinfer" across targets and dispatch.

- Improvements
  - FLOPs reporting updated to use d only (was d + dv), aligning metrics with the new attention scaling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->