### PR TITLE
[Draft] Tilelang JITv2: Simpler Kernel Declaration, Smart Code Generation, More Syntax Sugar and Extremely Low Overhead

### DIFF
--- a/tilelang/language/v2/__init__.py
+++ b/tilelang/language/v2/__init__.py
@@ -1,0 +1,87 @@
+from tilelang.language.tir.ir import *  # noqa: F401
+from tilelang.layout import Layout, Fragment  # noqa: F401
+from tilelang.language.parallel import Parallel  # noqa: F401
+from tilelang.language.pipeline import Pipelined  # noqa: F401
+from tilelang.language.persistent import Persistent  # noqa: F401
+from tilelang.language.frame import has_let_value, get_let_value  # noqa: F401
+from tilelang.language.kernel import (
+    Kernel,  # noqa: F401
+    KernelLaunchFrame,  # noqa: F401
+    get_thread_binding,  # noqa: F401
+    get_thread_bindings,  # noqa: F401
+    get_block_binding,  # noqa: F401
+    get_block_bindings,  # noqa: F401
+)
+from tilelang.language.warpgroup import ws  # noqa: F401
+from tilelang.language.allocate import (
+    alloc_var,  # noqa: F401
+    alloc_local,  # noqa: F401
+    alloc_shared,  # noqa: F401
+    alloc_fragment,  # noqa: F401
+    alloc_barrier,  # noqa: F401
+    alloc_reducer,  # noqa: F401
+)
+from tilelang.language.copy import copy, c2d_im2col  # noqa: F401
+from tilelang.language.gemm import GemmWarpPolicy, gemm, gemm_v2  # noqa: F401
+from tilelang.language.experimental.gemm_sp import gemm_sp  # noqa: F401
+from tilelang.language.fill import fill, clear  # noqa: F401
+from tilelang.language.reduce import (
+    reduce,  # noqa: F401
+    reduce_max,  # noqa: F401
+    reduce_min,  # noqa: F401
+    reduce_sum,  # noqa: F401
+    reduce_abssum,  # noqa: F401
+    reduce_absmax,  # noqa: F401
+    cumsum,  # noqa: F401
+    finalize_reducer,  # noqa: F401
+)
+from tilelang.language.print import print  # noqa: F401
+from tilelang.language.customize import (
+    atomic_max,  # noqa: F401
+    atomic_min,  # noqa: F401
+    atomic_add,  # noqa: F401
+    atomic_addx2,  # noqa: F401
+    atomic_addx4,  # noqa: F401
+    dp4a,  # noqa: F401
+    clamp,  # noqa: F401
+    reshape,  # noqa: F401
+    view,  # noqa: F401
+    atomic_load,  # noqa: F401
+    atomic_store,  # noqa: F401
+)
+from tilelang.language.logical import any_of, all_of  # noqa: F401
+from tilelang.language.builtin import *  # noqa: F401
+from tilelang.language.utils import index_to_coordinates  # noqa: F401
+
+from .types import (
+    DynSchema,  # noqa: F401
+    ConstSchema,  # noqa: F401
+    TensorSchema,  # noqa: F401
+    StridedTensorSchema,  # noqa: F401
+    Schema,  # noqa: F401
+    tune,  # noqa: F401
+    Tune,  # noqa: F401
+    dyn,  # noqa: F401
+    const,  # noqa: F401
+    StridedTensor,  # noqa: F401
+    Tensor,  # noqa: F401
+    Buffer_,  # noqa: F401
+    empty,  # noqa: F401
+    MakeEmpty,  # noqa: F401
+    cvt_dtype,  # noqa: F401
+    cvt_tvm_dtype_to_torch,  # noqa: F401
+    get_ptr_type,  # noqa: F401
+)
+from .compile import (
+    current_builder,  # noqa: F401
+    set_pass_configs,  # noqa: F401
+    get_pass_configs,  # noqa: F401
+    set_compile_flags,  # noqa: F401
+    add_compile_flags,  # noqa: F401
+    get_compile_flags,  # noqa: F401
+    get_target_host,  # noqa: F401
+    get_target,  # noqa: F401
+    get_params,  # noqa: F401
+    get_global_allocs,  # noqa: F401
+)
+from .jit import jit, JITFunc, JITDispatcher, compile  # noqa: F401

--- a/tilelang/language/v2/ast_rewrite.py
+++ b/tilelang/language/v2/ast_rewrite.py
@@ -1,0 +1,198 @@
+import ast
+from typing import Dict, Optional, List, Any
+
+
+class QuoteVisitor(ast.NodeTransformer):
+    def __init__(self, names: Dict[str, ast.AST], passes: Optional[List[Any]] = None):
+        self.names = names
+        self.passes = passes or []
+
+    def visit_Name(self, node: ast.Name) -> Any:
+        if node.id in self.names:
+            return self.names[node.id]
+        else:
+            return node
+
+    def visit_Pass(self, node: ast.Pass) -> Any:
+        item = self.passes.pop(0)
+        return item if item else node
+
+
+def quote(
+    expr: str, *, passes: Optional[List[Any]] = None, span=None, **kws
+) -> List[ast.AST]:
+    tree = ast.parse(expr)
+    tree = QuoteVisitor(kws, passes).visit(tree)
+    return tree.body
+
+
+def quote1(
+    expr: str, *, passes: Optional[List[Any]] = None, span=None, **kws
+) -> ast.AST:
+    res = quote(expr, passes=passes, span=span, **kws)
+    assert len(res) == 1
+    return res[0]
+
+
+def quote_expr(expr: str, **kws) -> List[ast.AST]:
+    res = quote1(expr, **kws)
+    assert isinstance(res, ast.Expr)
+    return res.value
+
+
+class DSLMutator(ast.NodeTransformer):
+    def __init__(self):
+        self.tmp_counter = 0
+
+    def get_tmp(self) -> str:
+        name = f"__tmp_{self.tmp_counter}"
+        self.tmp_counter += 1
+        return name
+
+    def visit_If(self, node: ast.If):
+        node = self.generic_visit(node)
+        return quote(
+            "with __tl.ctx_if(cond):\n"
+            "  for _ in __tl.ctx_then():\n"
+            "    pass\n"
+            "  for _ in __tl.ctx_else():\n"
+            "    pass\n",
+            cond=node.test,
+            passes=[node.body, node.orelse],
+        )
+
+    def visit_Expr(self, node: ast.Expr):
+        node = self.generic_visit(node)
+        return quote("__tl.eval(value)", value=node.value)
+
+    def _parse_names(self, target: ast.expr):
+        if isinstance(target, ast.Name):
+            return f"'{target.id}'"
+        elif isinstance(target, ast.Tuple):
+            return (
+                "(" + ",".join([self._parse_names(elt) for elt in target.elts]) + ",)"
+            )
+        else:
+            raise SyntaxError("Unsupported for target")
+
+    def visit_For(self, node: ast.For):
+        node = self.generic_visit(node)
+        names = self._parse_names(node.target)
+        return quote(
+            f"for target in __tl.ctx_for({names}, range):\n  pass",
+            target=node.target,
+            range=node.iter,
+            passes=[node.body],
+        )
+
+    def _emit_assign_tuple(
+        self, targets: List[ast.expr], rval: ast.expr
+    ) -> List[ast.AST]:
+        tmp_names = [self.get_tmp() for _ in range(len(targets))]
+        unpack = quote1(",".join(tmp_names) + ", = value", value=rval)
+        stmts = [unpack]
+        for i, target in enumerate(targets):
+            stmts.extend(
+                self._emit_assign_target(
+                    target, ast.Name(id=tmp_names[i], ctx=ast.Load())
+                )
+            )
+        return stmts
+
+    def _emit_assign_target(self, target: ast.expr, rval: ast.expr) -> List[ast.AST]:
+        if isinstance(target, ast.Name):
+            return quote(
+                f"name = __tl.bind('{target.id}', value)", name=target, value=rval
+            )
+        elif isinstance(target, ast.Subscript):
+            return quote(
+                "__tl.assign(lval, slice, value)",
+                lval=target.value,
+                slice=target.slice,
+                value=rval,
+            )
+        elif isinstance(target, ast.Tuple):
+            return self._emit_assign_tuple(target.elts, rval)
+
+    def visit_Assign(self, node: ast.Assign) -> List[ast.AST]:
+        node = self.generic_visit(node)
+        rval = node.value
+        stmts = []
+        for target in reversed(node.targets):
+            stmts.extend(self._emit_assign_target(target, rval))
+            rval = target
+        return stmts
+
+    def visit_FunctionDef(self, node: ast.FunctionDef):
+        node = self.generic_visit(node)
+        all_args = node.args.posonlyargs + node.args.args
+        if node.args.vararg is not None:
+            all_args += node.args.vararg
+        all_args += node.args.kwonlyargs
+        stmts = []
+        for arg in all_args:
+            name = arg.arg
+            if arg.annotation is not None:
+                arg_stmt = quote1(
+                    f'{name} = __tl.arg("{name}", {name}, annot)', annot=arg.annotation
+                )
+            else:
+                arg_stmt = quote1(f'{name} = __tl.arg("{name}", {name})')
+            stmts.append(arg_stmt)
+        node.body = quote(
+            "with __tl.builder:\n"
+            "  with __tl.prim_func():\n"
+            f'    __tl.func_name("{node.name}")\n'
+            "    pass",
+            passes=[stmts + node.body],
+        )
+        node.decorator_list.pop()
+        return quote1(
+            f"def __closure(__tl):\n  pass\n  return {node.name}\n", passes=[node]
+        )
+
+    def visit_BoolOp(self, node: ast.BoolOp):
+        node = self.generic_visit(node)
+        if isinstance(node.op, ast.And):
+            last = node.values[-1]
+            for i in reversed(range(len(node.values) - 1)):
+                last = quote_expr(
+                    expr="__tl.logical_and(left, lambda: right)",
+                    left=node.values[i],
+                    right=last,
+                )
+            return last
+        elif isinstance(node.op, ast.Or):
+            last = node.values[-1]
+            for i in reversed(range(len(node.values) - 1)):
+                last = quote_expr(
+                    "__tl.logical_or(left, lambda: right)",
+                    left=node.values[i],
+                    right=last,
+                )
+            return last
+        else:
+            return node
+
+    def visit_Compare(self, node: ast.Compare) -> ast.expr:
+        node = self.generic_visit(node)
+        left = node.left
+        splited = []
+        for op, comp in zip(node.ops, node.comparators):
+            splited.append(ast.Compare(left=left, ops=[op], comparators=[comp]))
+            left = comp
+        last = splited[-1]
+        for i in reversed(range(len(splited) - 1)):
+            last = quote_expr(
+                "__tl.logical_and(left, lambda: right)", left=splited[i], right=last
+            )
+        return last
+
+    def visit_Return(self, node: ast.Return):
+        return quote("return __tl.ret(value)", value=node.value)
+
+    def visit_With(self, node: ast.With):
+        node = self.generic_visit(node)
+        for expr in node.items:
+            expr.context_expr = quote_expr("__tl.ctx(e)", e=expr.context_expr)
+        return node

--- a/tilelang/language/v2/compile.py
+++ b/tilelang/language/v2/compile.py
@@ -1,0 +1,580 @@
+from __future__ import annotations
+import inspect
+import torch
+from dataclasses import dataclass, field
+from tvm import tir
+import linecache
+import io
+from .ast_rewrite import DSLMutator
+from .types import (
+    DynSchema,
+    StridedTensorSchema,
+    ConstSchema,
+    MakeEmpty,
+    Buffer_,
+    cvt_dtype,
+    cvt_tvm_dtype_to_torch,
+    get_ptr_type,
+    cvt_tvm_dtype_to_cffi,
+    cvt_tvm_dtype_to_ctypes,
+)
+import threading
+import ctypes
+from typing import (
+    Callable,
+    Dict,
+    Tuple,
+    TypeVar,
+    Optional,
+    List,
+    get_type_hints,
+    ContextManager,
+    Any,
+    Set,
+    Generic,
+    ParamSpec,
+    Protocol,
+)
+from tvm.script.ir_builder import IRBuilder
+from tvm.script.ir_builder import tir as tb
+from tvm.target import Target
+from contextlib import contextmanager
+import ast
+
+_P = ParamSpec('_P')
+_T = TypeVar("_T")
+
+class JITPyFunc(Protocol[_P, _T]):
+    def __call__(self, *args: _P.args, **kws: _P.kwargs) -> _T: ...
+    __tl_code__: str
+
+
+def generate_arg_parser(fn_name: str, func: Callable[_P, _T]) -> JITPyFunc[_P, Tuple[Tuple, Tuple]]:
+    func_args = []
+    code_parse_arg = []
+    default_dict = {}
+    tup_dyn = []
+    tup_const = []
+    dyn_dict = {}
+
+    def add_dyn(var_name: str, data: str):
+        nonlocal code_parse_arg, tup_dyn, dyn_dict
+        if var_name in dyn_dict:
+            code_parse_arg.append(f"assert {data} == {dyn_dict[var_name]}, 'dyn argument {var_name} mismatch'")
+        else:
+            dyn_dict[var_name] = data
+            tup_dyn.append(data)
+
+    sig = inspect.signature(func)
+    type_hints = get_type_hints(func)
+
+    for param in sig.parameters.values():
+        name = param.name
+        schema = type_hints.get(name, ConstSchema())
+        default = param.default
+        if default is not inspect._empty:
+            default_name = f"__{name}_default__"
+            default_dict[default_name] = default
+            func_args.append(f"{name} = {default_name}")
+        else:
+            func_args.append(f"{name}")
+        if isinstance(schema, DynSchema):
+            add_dyn(schema.name or name, name)
+        elif isinstance(schema, StridedTensorSchema):
+            tup_dyn.append(f"{name}.data_ptr()")
+            tup_const.append(f"{name}.dtype")
+            code_parse_arg.append(
+                f'assert {name}.device != __device_cpu__, "Expected a non cpu tensor"'
+            )
+            if schema.shape is not None:
+                code_parse_arg.append(
+                    ", ".join([f"{name}__shape_{i}" for i in range(len(schema.stride))])
+                    + f" = {name}.shape"
+                )
+                # code_parse_arg.append(f'{name}__shape_ = {name}.shape')
+                for i, dim in enumerate(schema.shape):
+                    if isinstance(dim, DynSchema):
+                        var_name = dim.name or f"{name}__shape_{i}"
+                        add_dyn(var_name, f"{name}__shape_{i}")
+                    else:
+                        tup_const.append(f"{name}__shape_{i}")
+            else:
+                tup_const.append(f"{name}.shape")
+            if schema.stride is not None:
+                code_parse_arg.append(
+                    ", ".join(
+                        [f"{name}__stride_{i}" for i in range(len(schema.stride))]
+                    )
+                    + f" = {name}.stride()"
+                )
+                for i, dim in enumerate(schema.stride):
+                    if isinstance(dim, DynSchema):
+                        var_name = dim.name or f"{name}__stride_{i}"
+                        add_dyn(var_name, f"{name}__stride_{i}")
+                    else:
+                        tup_const.append(f"{name}__stride_{i}")
+            else:
+                tup_const.append(f"{name}.stride()")
+        else:
+            tup_const.append(name)
+
+    closure = {
+        "__device_cpu__": torch.device("cpu"),
+        **default_dict,
+    }
+
+    source = ""
+    source += "def parse_args(" + ", ".join(closure.keys()) + "):\n"
+    source += f"  def {fn_name}(" + ", ".join(func_args) + ", __stream__=None" + "):\n"
+    source += "    " + "\n    ".join(code_parse_arg) + "\n"
+    source += "    __const_args__ = (" + ", ".join(tup_const) + ")\n"
+    source += "    __dyn_args__ = (" + ", ".join(tup_dyn) + ", __stream__)\n"
+    source += "    return __const_args__, __dyn_args__\n"
+    source += f"  return {fn_name}\n"
+
+    locs = {}
+    line_cache_name = f"{fn_name}_{id(source)}"
+    linecache.updatecache(line_cache_name, io.StringIO(source))
+    code = compile(source, line_cache_name, "exec")
+    exec(code, {}, locs)
+    fn = locs["parse_args"](**closure)
+    fn.__tl_code__ = source
+    return fn
+
+
+def get_current_stream_functor():
+    if torch.cuda.is_available():
+        try:
+            torch.cuda._lazy_init()
+            current_device = torch._C._cuda_getDevice
+            get_stream = torch._C._cuda_getCurrentRawStream
+            return lambda: get_stream(current_device())
+        except ImportError:
+            get_stream = torch.cuda.current_stream
+            return lambda: get_stream().cuda_stream
+    else:
+        return lambda: 0
+
+@dataclass(slots=True)
+class JITFunc(Generic[_P, _T]):
+    target: Target
+    target_host: Target
+    global_allocs: List[Buffer_]
+    outs: List[Buffer_]
+    pass_configs: Dict[str, Any]
+    compile_flags: List[str]
+    prim_func: tir.PrimFunc
+    arg_parser: Callable[_P, Tuple[Tuple, Tuple]]
+    const_args: Tuple
+
+    @property
+    def out_idx(self) -> Tuple[int]:
+        return tuple(i.arg_idx for i in self.outs)
+
+    def find_arg(self, var: tir.Var) -> int:
+        for i, p in enumerate(self.prim_func.params):
+            if p.same_as(var):
+                return i
+        raise RuntimeError(f"Cannot find argument {var} in function parameters")
+
+    def out_idx_set(self) -> Set[int]:
+        out_idx_set = set()
+        for out in self.outs:
+            if out.arg_idx is not None:
+                out_idx_set.add(out.arg_idx)
+        return out_idx_set
+
+    def get_ctypes_sig(self) -> Tuple:
+        params = []
+        for x in self.prim_func.params:
+            if isinstance(x, tir.Var):
+                params.append(cvt_tvm_dtype_to_ctypes(x.dtype))
+            else:
+                raise RuntimeError(f"Unsupported argument type: {type(x)}")
+        params.append(ctypes.c_void_p)
+        return (ctypes.c_int, params)
+
+    def get_cffi_sig(self) -> str:
+        params = []
+        for x in self.prim_func.params:
+            if isinstance(x, tir.Var):
+                cffi_type = cvt_tvm_dtype_to_cffi(x.dtype)
+                params.append(f"{cffi_type} {x.name}")
+            else:
+                raise RuntimeError(f"Unsupported argument type: {type(x)}")
+        params.append("long __cudastream")
+        return "int call(" + ", ".join(params) + ");"
+
+    def generate_global_alloc_wrapper(self, func) -> JITPyFunc[Any, _T]:
+        params: List[tir.Var] = self.prim_func.params
+        call_args = []
+        for p in params:
+            call_args.append(p.name)
+        out_idx_set = self.out_idx_set()
+        func_args = [arg for i, arg in enumerate(call_args) if i not in out_idx_set]
+        closure = {}
+        stmts = []
+        closure["__tl_empty"] = torch.empty
+        closure["__tl_kernel"] = func
+        returns = []
+        for allocs in self.global_allocs:
+            shape_args = []
+            for i, expr in enumerate(allocs.shape):
+                name = f"__{allocs.buffer.name}_shape_{i}"
+                if isinstance(expr, tir.Var):
+                    idx = self.find_arg(expr)
+                    shape_args.append(call_args[idx])
+                elif isinstance(expr, (tir.IntImm, tir.FloatImm)):
+                    closure[name] = expr.value
+                    shape_args.append(name)
+                elif isinstance(expr, (int, float)):
+                    closure[name] = expr
+                    shape_args.append(name)
+                else:
+                    raise RuntimeError(
+                        f"Unsupported shape expression type: {type(expr)}"
+                    )
+            dtype_name = f"__{allocs.buffer.name}_dtype"
+            device_name = f"__{allocs.buffer.name}_device"
+            closure[dtype_name] = cvt_tvm_dtype_to_torch(allocs.dtype)
+            closure[device_name] = allocs.device or torch.device("cuda")
+            arg_name = call_args[allocs.arg_idx]
+            tensor_name = f"{arg_name}_tensor"
+            stmts.append(
+                f"{tensor_name} = __tl_empty("
+                + ",".join(shape_args)
+                + f", dtype={dtype_name}, device={device_name})"
+            )
+            stmts.append(f"{arg_name} = {tensor_name}.data_ptr()")
+        for out in self.outs:
+            arg_name = call_args[out.arg_idx]
+            returns.append(f"{arg_name}_tensor")
+        closure["__stream_functor__"] = get_current_stream_functor()
+        stmts.append("if __stream__ is None: __stream__ = __stream_functor__()")
+        stmts.append(
+            "assert __tl_kernel("
+            + ",".join(call_args)
+            + ", __stream__) == 0, 'Kernel call failed'"
+        )
+
+        source = ""
+        source += "def __closure(" + ", ".join(closure.keys()) + "):\n"
+        source += "  def wrapper(" + ", ".join(func_args) + ", __stream__):\n"
+        source += "    " + "\n    ".join(stmts) + "\n"
+        source += "    return " + ",".join(returns) + "\n"
+        source += "  return wrapper"
+
+        locs = {}
+        line_cache_name = f"<tl_torch_wrapper_{id(source)}>"
+        linecache.updatecache(line_cache_name, io.StringIO(source))
+        code = compile(source, line_cache_name, "exec")
+        exec(code, {}, locs)
+        fn = locs["__closure"](**closure)
+        fn.__tl_code__ = source
+        return fn
+
+    def parse_args(self, *args: _P.args, **kws: _P.kwargs) -> Tuple[Tuple, Tuple]:
+        return self.arg_parser(*args, **kws)
+
+
+@dataclass
+class DSLBuilder:
+    # base pass_config or compile_flags
+    target: Target
+    target_host: Target
+    arg_parser: Optional[Callable]
+    const_args: Tuple
+    pass_configs: Dict[str, Any] = field(default_factory=dict)
+    compile_flags: List[str] = field(default_factory=list)
+    default_device: Optional[torch.device] = None
+
+    global_allocs: List[Buffer_] = field(default_factory=list)
+    outs: List[Buffer_] = field(default_factory=list)
+
+    # used to store pending shape args, making handle arg first
+    pending_args: List[(str, tir.Var)] = field(default_factory=list)
+    arg_idx: int = 0
+
+    var_map: Dict[str, tir.Var] = field(default_factory=dict)
+    frames: List[Any] = field(default_factory=list)
+    builder: IRBuilder = field(default_factory=IRBuilder)
+    _params: List[tir.Var] = field(default_factory=list)
+
+    def get(self) -> JITFunc:
+        return JITFunc(
+            target=self.target,
+            target_host=self.target_host,
+            pass_configs=self.pass_configs,
+            compile_flags=self.compile_flags,
+            prim_func=self.builder.get(),
+            global_allocs=self.global_allocs,
+            arg_parser=self.arg_parser,
+            const_args=self.const_args,
+            outs=self.outs,
+        )
+
+    @contextmanager
+    def with_frame(self, frame: ContextManager):
+        n = len(self.frames)
+        self.frames.append(frame)
+        yield frame.__enter__()
+        while len(self.frames) > n:
+            self.frames.pop().__exit__(None, None, None)
+
+    def push_frame(self, frame: ContextManager):
+        self.frames.append(frame)
+        return frame.__enter__()
+
+    def prim_func(self):
+        return self.with_frame(tb.prim_func())
+
+    def func_name(self, name: str):
+        tb.func_name(name)
+
+    def get_param(self, name: str, ty: Any, new: bool = False) -> tir.Var:
+        if name not in self.var_map:
+            var = tir.Var(name, ty)
+            self.var_map[name] = var
+            if new:
+                self.new_arg(name, var)
+            else:
+                self.pending_args.append((name, var))
+        return self.var_map[name]
+
+    def flush_pending_vars(self):
+        for name, var in self.pending_args:
+            self.new_arg(name, var)
+        self.pending_args.clear()
+
+    def new_arg(self, name: str, arg: tir.Var | tir.Buffer) -> Tuple[int, Any]:
+        idx = self.arg_idx
+        self.arg_idx += 1
+        self._params.append(arg)
+        return idx, tb.arg(name, arg)
+
+    def _convert_shape(self, shape, shape_schema, name_hint) -> Tuple[Any, ...]:
+        if shape_schema is None:
+            return tuple(shape)
+        else:
+            shape = list(shape)
+            assert len(shape) == len(
+                shape_schema
+            ), "Expected a tensor with matching rank"
+            for i, dim in enumerate(shape_schema):
+                if isinstance(dim, DynSchema):
+                    var_name = dim.name or f"{name_hint}_{i}"
+                    shape[i] = self.get_param(var_name, cvt_dtype(int), new=False)
+            return tuple(shape)
+
+    def arg(self, name: str, expr: Any, annot: Any) -> Any:
+        if isinstance(annot, DynSchema):
+            return self.get_param(annot.name or name, ty=cvt_dtype(annot.ty))
+        elif isinstance(annot, StridedTensorSchema):
+            assert isinstance(expr, torch.Tensor), "Expected a tensor argument"
+            ptr = tir.Var(f"{name}_handle", get_ptr_type(expr.dtype))
+            if annot.shape is None:
+                shape = tuple(expr.shape)
+                stride = tuple(expr.stride())
+            else:
+                shape = self._convert_shape(
+                    expr.shape, annot.shape, name_hint=f"{name}_shape"
+                )
+                stride = self._convert_shape(
+                    expr.stride(), annot.stride, name_hint=f"{name}_stride"
+                )
+            buffer = tir.decl_buffer(
+                name=name,
+                shape=shape,
+                strides=stride,
+                dtype=cvt_dtype(expr.dtype),
+                data=ptr,
+                scope="global",
+            )
+            _, arg = self.new_arg(name, buffer)
+            self.flush_pending_vars()
+            if self.default_device is None:
+                self.default_device = expr.device
+            return Buffer_(
+                buffer=arg,
+                shape=shape,
+                stride=stride,
+                dtype=arg.dtype,
+                device=expr.device,
+            )
+        else:
+            assert not isinstance(
+                expr, torch.Tensor
+            ), "Tensor argument must be annotated"
+            return expr
+
+    def bind(self, name: str, expr: Any, annot: Any = None) -> Any:
+        if isinstance(expr, MakeEmpty):
+            ptr = tir.Var(f"{name}_handle", get_ptr_type(expr.dtype))
+            buffer = tir.decl_buffer(
+                name=name,
+                shape=expr.shape,
+                strides=expr.stride,
+                dtype=cvt_dtype(expr.dtype),
+                data=ptr,
+                scope="global",
+            )
+            arg_idx, arg = self.new_arg(name, buffer)
+            self.flush_pending_vars()
+            result = Buffer_(
+                buffer=arg,
+                shape=expr.shape,
+                stride=expr.stride,
+                dtype=arg.dtype,
+                arg_idx=arg_idx,
+                device=expr.device or self.default_device,
+            )
+            self.global_allocs.append(result)
+            return result
+        elif isinstance(expr, (tir.Var, tir.IntImm, tir.FloatImm)):  # fast shortcut
+            return expr
+        elif isinstance(expr, tir.PrimExpr):
+            var = tir.Var(name=name, dtype=expr.dtype)
+            self.push_frame(tb.let(var, expr))
+            return var
+        else:
+            return expr
+
+    def eval(self, expr: Any):
+        if isinstance(expr, tir.PrimExpr):
+            tb.evaluate(expr)
+
+    def ret(self, val: Any = None) -> Any:
+        if isinstance(val, Buffer_):
+            val = (val,)
+        for v in val:
+            assert isinstance(v, Buffer_), "Expected a buffer to return"
+            assert v.arg_idx is not None, "Expected a make_empty buffer to return"
+            self.outs.append(v)
+
+    def assign(self, lval: Any, slice: Any, rval: Any) -> Any:
+        if isinstance(slice, (tir.PrimExpr, int)):
+            if isinstance(lval, Buffer_):
+                lval = lval.buffer
+            tb.buffer_store(lval, rval, slice)
+        else:
+            raise NotImplementedError()
+
+    def ctx_if(self, cond: bool | tir.PrimExpr):
+        return self.with_frame(tb.If(cond))
+
+    def ctx_then(self):
+        with self.with_frame(tb.Then()):
+            yield
+
+    def ctx_else(self):
+        with self.with_frame(tb.Else()):
+            yield
+
+    def ctx_for(self, var_names, for_range):
+        if isinstance(for_range, tb.frame.ForFrame):
+            with self.with_frame(for_range):
+                if len(for_range.vars) > 1:
+                    results = []
+                    for name, var in zip(var_names, for_range.vars):
+                        v = tir.Var(name, var.dtype)
+                        self.push_frame(tb.let(v, var))
+                        results.append(v)
+                    yield tuple(results)
+                else:
+                    v = tir.Var(var_names, for_range.vars[0].dtype)
+                    self.push_frame(tb.let(v, for_range.vars[0]))
+                    yield v
+        else:
+            return for_range
+
+    def ctx(self, ctx):
+        return ctx
+
+    def logical_and(self, val, rclosure) -> bool:
+        return (
+            tir.And(val, rclosure())
+            if isinstance(val, tir.PrimExpr)
+            else (val or rclosure())
+        )
+
+    def logical_or(self, val, rclosure) -> bool:
+        return (
+            tir.Or(val, rclosure())
+            if isinstance(val, tir.PrimExpr)
+            else (val or rclosure())
+        )
+
+
+def _remove_leading_ident(source: str):
+    lines = source.splitlines()
+    if not lines:
+        return source
+    ident_size = len(lines[0]) - len(lines[0].lstrip())
+    return "\n".join(
+        [line[ident_size:] if len(line) >= ident_size else line for line in lines]
+    )
+
+
+def make_prim_func_generator(func):
+    source = inspect.getsource(func)
+    source = _remove_leading_ident(source)
+    tree = ast.parse(source)
+    tree = DSLMutator().visit(tree)
+    tree = ast.fix_missing_locations(tree)
+    source = ast.unparse(tree)
+    # print(source) to show the generated code
+    line_cache_name = f"<{func.__name__}_{id(source)}>"
+    linecache.updatecache(line_cache_name, io.StringIO(source))
+    compiled = compile(source, filename=line_cache_name, mode="exec")
+    locs = {}
+    exec(compiled, func.__globals__, locs)
+    fn = locs["__closure"]
+    fn.__tl_code__ = source
+    return fn
+
+
+_thread_local_storage = threading.local()
+
+
+def set_current_builder(builder=None):
+    _thread_local_storage.builder = builder
+
+
+def current_builder() -> DSLBuilder:
+    return _thread_local_storage.builder
+
+
+def set_pass_configs(configs: Dict[str, Any]):
+    current_builder().pass_configs.update(configs)
+
+
+def get_pass_configs() -> Dict[str, Any]:
+    return current_builder().pass_configs
+
+
+def set_compile_flags(flags: List[str]):
+    current_builder().compile_flags = flags
+
+
+def add_compile_flags(flags: List[str]):
+    current_builder().compile_flags.extend(flags)
+
+
+def get_compile_flags() -> List[str]:
+    return current_builder().compile_flags
+
+
+def get_target_host() -> Target:
+    return current_builder().target_host
+
+
+def get_target() -> Target:
+    return current_builder().target
+
+
+def get_params() -> List[tir.Var]:
+    return current_builder()._params
+
+
+def get_global_allocs() -> List[Buffer_]:
+    return current_builder().global_allocs

--- a/tilelang/language/v2/jit.py
+++ b/tilelang/language/v2/jit.py
@@ -1,0 +1,222 @@
+from .compile import (
+    make_prim_func_generator,
+    generate_arg_parser,
+    DSLBuilder,
+    JITFunc,
+    JITPyFunc,
+    set_current_builder,
+)
+from typing import (
+    Callable,
+    Protocol,
+    Union,
+    List,
+    Dict,
+    Any,
+    overload,
+    ParamSpec,
+    TypeVar,
+    Generic,
+)
+import cffi
+from tilelang.utils.target import AVALIABLE_TARGETS, determine_target
+from tilelang.jit.adapter.libgen import LibraryGenerator
+from tilelang.jit.adapter.wrapper import TLWrapper
+from dataclasses import dataclass
+import tilelang
+from tilelang import tvm
+from tvm.target import Target
+import logging
+import ctypes
+import inspect
+
+logger = logging.getLogger(__name__)
+
+
+class JITLib(Protocol):
+    def init(self) -> int: ...
+    def get_last_error(self) -> bytes: ...
+    def call(self, *args): ...
+
+
+_P = ParamSpec("_P")
+_T = TypeVar("_T")
+
+
+@dataclass(slots=True)
+class JITKernel(Generic[_P, _T]):
+    lib_path: str
+    lib: JITLib | ctypes.CDLL
+    lib_call: Callable
+    source: str
+    func: JITFunc[_P, _T]
+
+    def __call__(self, *args: _P.args, **kws: _P.kwargs) -> _T:
+        const_args, dyn_args = self.func.parse_args(*args, **kws)
+        assert const_args == self.func.const_args, "Const args do not match"
+        return self.lib_call(*dyn_args)
+
+    def get_source(self) -> str:
+        return self.source
+
+
+def compile(func: JITFunc[_P, _T], verbose=False) -> JITKernel[_P, _T]:
+    func.generate_global_alloc_wrapper(None)  # test the wrapper generation
+
+    mod = tvm.IRModule({func.prim_func.attrs["global_symbol"]: func.prim_func})
+
+    with tvm.transform.PassContext(opt_level=3, config=func.pass_configs), func.target:
+        artifact = tilelang.lower(mod, target=func.target, target_host=func.target_host)
+
+    lib_generator = LibraryGenerator(func.target, verbose)
+    lib_generator.assign_pass_configs(func.pass_configs)
+    lib_generator.assign_compile_flags(func.compile_flags)
+
+    wrapper = TLWrapper(func.target)
+    wrapper.assign_optimized_module(scheduled_ir_module=mod)
+    wrapper.assign_pass_configs(func.pass_configs)
+    wrapper.assign_host_module(artifact.host_mod)
+    wrapper.assign_device_module(artifact.device_mod)
+
+    wrapped_source = wrapper.wrap(artifact.kernel_source)
+
+    lib_generator.update_lib_code(wrapped_source)
+    lib_generator.compile_lib()
+
+    lib_path = lib_generator.get_lib_path()
+
+    ffi = cffi.FFI()
+    ffi.cdef(func.get_cffi_sig())
+    ffi.cdef("int init();")
+    ffi.cdef("const char * get_last_error();")
+    lib: JITLib = ffi.dlopen(lib_path)
+
+    result = lib.init()
+    if result != 0:
+        error_msg = lib.get_last_error().decode("utf-8")
+        error_msg += f"\n{wrapped_source}"
+        raise RuntimeError(f"Initialization failed: {error_msg}")
+
+    lib_call = func.generate_global_alloc_wrapper(lib.call)
+
+    return JITKernel(
+        func=func,
+        source=wrapped_source,
+        lib_call=lib_call,
+        lib_path=lib_path,
+        lib=lib,
+    )
+
+
+class JITDispatcher(Generic[_P, _T]):
+    def __init__(
+        self,
+        func: Callable[_P, _T],
+        target: Union[str, Target] = "auto",
+        target_host: Union[str, Target] = None,
+        verbose: bool = False,
+        pass_configs: Dict[str, Any] = None,
+        compile_flags: List[str] = None,
+    ):
+        self.func = func
+        self.target_host = target_host
+        if isinstance(target, str):
+            assert target in AVALIABLE_TARGETS, f"Invalid target: {target}"
+            target = determine_target(target)
+        self.target = Target(target)
+        self.verbose = verbose
+        self.pass_configs = pass_configs or {}
+        self.compile_flags = compile_flags or []
+        self.jit_funcs = {}
+        self.kernel_calls = {}
+        self.kernels = {}
+        self.parse_args = generate_arg_parser(func.__name__, func)
+        self._jit_func_gen_lazy = None
+
+    @property
+    def jit_func_gen(self) -> JITPyFunc[_P, None]:
+        if self._jit_func_gen_lazy is None:
+            self._jit_func_gen_lazy = make_prim_func_generator(self.func)
+        return self._jit_func_gen_lazy
+
+    def partial(self, *args: _P.args, **kws: _P.kwargs) -> JITFunc[_P, _T]:
+        const_args, _ = self.parse_args(*args, **kws)
+        if const_args in self.jit_funcs:
+            return self.jit_funcs[const_args]
+        builder = DSLBuilder(
+            target=self.target,
+            target_host=self.target_host,
+            arg_parser=self.parse_args,
+            const_args=const_args,
+            pass_configs=self.pass_configs,
+            compile_flags=self.compile_flags,
+        )
+        set_current_builder(builder)
+        self.jit_func_gen(builder)(*args, **kws)
+        set_current_builder()
+        self.jit_funcs[const_args] = builder.get()
+        return builder.get()
+
+    def compiled(self, *args: _P.args, **kws: _P.kwargs) -> JITKernel[_P, _T]:
+        const_args, _ = self.parse_args(*args, **kws)
+        kernel = self.kernels.get(const_args, None)
+        if kernel is not None:
+            return kernel
+        func = self.partial(*args, **kws)
+        kernel = compile(func)
+        self.kernels[const_args] = kernel
+        self.kernel_calls[const_args] = kernel.lib_call
+        return kernel
+
+    def __call__(self, *args: _P.args, **kws: _P.kwargs) -> _T:
+        const_args, dyn_args = self.parse_args(*args, **kws)
+        kernel = self.kernel_calls.get(const_args, None)
+        if kernel is not None:
+            return kernel(*dyn_args)
+        kernel = self.compiled(*args, **kws)
+        return kernel.lib_call(*dyn_args)
+
+    def __repr__(self):
+        return f"JITGen(func={self.func}, target={self.target}, target_host={self.target_host}, verbose={self.verbose}, pass_configs={self.pass_configs}, compile_flags={self.compile_flags})"
+
+
+@overload
+def jit(func: Callable[_P, _T]) -> JITDispatcher[_P, _T]: ...
+@overload
+def jit(
+    target: Union[str, Target] = "auto",
+    target_host: Union[str, Target] = None,
+    verbose: bool = False,
+    pass_configs: Dict[str, Any] = None,
+    compile_flags: List[str] = None,
+) -> Callable[[Callable[_P, _T]], JITDispatcher[_P, _T]]: ...
+
+
+def jit(
+    target: Union[str, Target] = "auto",
+    target_host: Union[str, Target] = None,
+    verbose: bool = False,
+    pass_configs: Dict[str, Any] = None,
+    compile_flags: List[str] = None,
+) -> Callable[[Callable[_P, _T]], JITDispatcher[_P, _T]]:
+    if inspect.isfunction(target):
+        return JITDispatcher(
+            target,
+            target="auto",
+            target_host=None,
+            verbose=False,
+            pass_configs=None,
+            compile_flags=None,
+        )
+
+    def wrapper(func):
+        return JITDispatcher(
+            func,
+            target=target,
+            target_host=target_host,
+            verbose=verbose,
+            pass_configs=pass_configs,
+            compile_flags=compile_flags,
+        )
+
+    return wrapper

--- a/tilelang/language/v2/types.py
+++ b/tilelang/language/v2/types.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from tilelang import tvm
+from tvm import tir, ir
+import torch
+import ctypes
+from typing import (
+    Any,
+    Tuple,
+    TypeVar,
+    Iterable,
+    Optional,
+    TypeVarTuple,
+    TYPE_CHECKING,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DynSchema:
+    ty: Optional[type] = int
+    name: Optional[str] = None
+
+    def __getitem__(self, params):
+        if isinstance(params, tuple):
+            ty, name = params
+            return DynSchema(ty=ty, name=name)
+        return DynSchema(ty=params, name=self.name)
+
+
+@dataclass(frozen=True, slots=True)
+class ConstSchema:
+    def __getitem__(self, params):
+        return self
+
+
+@dataclass(frozen=True, slots=True)
+class StridedTensorSchema:
+    shape: Optional[Tuple[type, ...]] = None
+    stride: Optional[Tuple[type, ...]] = None
+
+    def __getitem__(self, params):
+        if isinstance(params, tuple):
+            shape, stride = params
+            return StridedTensorSchema(shape=shape, stride=stride)
+        return StridedTensorSchema(shape=params, stride=self.stride)
+
+
+class TensorSchema(StridedTensorSchema):
+    def __getitem__(self, params):
+        if not isinstance(params, tuple):
+            params = (params,)
+        stride = [int for _ in range(len(params))]
+        dyn_flag = False
+        for i in reversed(range(len(params))):
+            if dyn_flag:
+                stride[i] = dyn[int]
+            if isinstance(params[i], DynSchema):
+                dyn_flag = True
+        return TensorSchema(shape=params, stride=stride)
+
+
+_T = TypeVar("_T")
+_Shapes = TypeVarTuple("_Shapes")
+
+Schema = StridedTensorSchema | TensorSchema | DynSchema | ConstSchema
+
+if TYPE_CHECKING:
+
+    class dyn[_T](tir.Var):
+        dtype: tvm.DataType
+
+    class StridedTensor[_Shape, _Stride]:
+        ptr: Any
+        shape: _Shape
+        stride: _Stride
+        dtype: tvm.DataType
+
+    class Tensor[*_Shapes](StridedTensor[Tuple[*_Shapes], Tuple[int | dyn[int], ...]]):
+        pass
+
+else:
+    dyn = DynSchema()
+    const = ConstSchema()
+    StridedTensor = StridedTensorSchema()
+    Tensor = TensorSchema()
+
+
+@dataclass(frozen=True, slots=True)
+class Buffer_:
+    buffer: tir.Buffer
+    shape: Tuple[int | tir.PrimExpr, ...]
+    stride: Tuple[int | tir.PrimExpr, ...]
+    dtype: tvm.DataType
+    arg_idx: Optional[int] = None
+    device: Optional[torch.device] = None
+
+    def offset_of(self, indices) -> tir.IntImm:
+        return self.buffer.offset_of(indices)
+
+    def __getitem__(self, indices):
+        return self.buffer.__getitem__(indices)
+
+
+@dataclass(frozen=True, slots=True)
+class Tune[_T]:
+    params: Tuple[_T]
+
+    def __hash__(self) -> int:
+        return id(self)
+
+    def __eq__(self, rhs) -> bool:
+        return self is rhs
+
+    def __ne__(self, rhs) -> bool:
+        return self is not rhs
+
+
+def tune(params: Iterable[_T]) -> Tune[_T]:
+    assert len(params) > 0, "Expected a non-empty parameter candidates"
+    return Tune(tuple(params))
+
+
+@dataclass(frozen=True, slots=True)
+class MakeEmpty:
+    shape: Tuple[int | tir.Var, ...]
+    stride: Tuple[int | tir.Var, ...]
+    dtype: torch.dtype | tvm.DataType
+    device: torch.device
+
+
+def empty(
+    shape: Tuple[*_Shapes],
+    dtype: torch.dtype | tvm.DataType,
+    device: torch.device = None,
+) -> Tensor[*_Shapes]:
+    prod = 1
+    stride = [0 for _ in range(len(shape))]
+    for i in reversed(range(len(shape))):
+        stride[i] = prod
+        prod = prod * shape[i]
+    return MakeEmpty(shape=shape, stride=stride, dtype=dtype, device=device)
+
+
+_dtype_torch2tvm = {
+    # special types should placed in the first
+    float: "float32",
+    int: "int32",
+    torch.long: "int64",
+    torch.half: "half",
+    # other dtypes
+    torch.bool: "bool",
+    torch.int8: "int8",
+    torch.int16: "int16",
+    torch.int32: "int32",
+    torch.int64: "int64",
+    torch.uint8: "uint8",
+    torch.uint16: "uint16",
+    torch.uint32: "uint32",
+    torch.uint64: "uint64",
+    torch.bfloat16: "bfloat16",
+    torch.float16: "float16",
+    torch.float32: "float32",
+    torch.float64: "float64",
+    torch.float8_e4m3fn: "float8_e4m3fn",
+    torch.float8_e4m3fnuz: "float8_e4m3fnuz",
+    torch.float8_e5m2: "float8_e5m2",
+    torch.float8_e5m2fnuz: "float8_e5m2fnuz",
+    torch.float8_e8m0fnu: "float8_e8m0fnu",
+}
+
+
+_dtype_tvm2torch = {tvm.DataType(v): k for k, v in _dtype_torch2tvm.items()}
+
+_dtype_tvm2ctype = {
+    tvm.DataType("bool"): ctypes.c_bool,
+    tvm.DataType("int8"): ctypes.c_int8,
+    tvm.DataType("int16"): ctypes.c_int16,
+    tvm.DataType("int32"): ctypes.c_int32,
+    tvm.DataType("int64"): ctypes.c_int64,
+    tvm.DataType("uint8"): ctypes.c_uint8,
+    tvm.DataType("uint16"): ctypes.c_uint16,
+    tvm.DataType("uint32"): ctypes.c_uint32,
+    tvm.DataType("uint64"): ctypes.c_uint64,
+    # tvm.DataType("float16"): ctypes.c_uint16,
+    # tvm.DataType("bfloat16"): ctypes.c_uint16,
+    tvm.DataType("float32"): ctypes.c_float,
+    tvm.DataType("float64"): ctypes.c_double,
+    # tvm.DataType("float8_e4m3fn"): ctypes.c_uint8,
+    # tvm.DataType("float8_e4m3fnuz"): ctypes.c_uint8,
+    # tvm.DataType("float8_e5m2"): ctypes.c_uint8,
+    # tvm.DataType("float8_e5m2fnuz"): ctypes.c_uint8,
+    # tvm.DataType("float8_e8m0fnu"): ctypes.c_uint8,
+    tvm.DataType("handle"): ctypes.c_void_p,
+}
+
+_dtype_tvm2cffi = {
+    tvm.DataType("bool"): "bool",
+    tvm.DataType("int8"): "char",
+    tvm.DataType("int16"): "short",
+    tvm.DataType("int32"): "int",
+    tvm.DataType("int64"): "long long",
+    tvm.DataType("uint8"): "unsigned char",
+    tvm.DataType("uint16"): "unsigned short",
+    tvm.DataType("uint32"): "unsigned int",
+    tvm.DataType("uint64"): "unsigned long long",
+    tvm.DataType("float32"): "float",
+    tvm.DataType("float64"): "double",
+    # tvm.DataType("float16"): 'uint16_t',
+    # tvm.DataType("bfloat16"): 'uint16_t',
+    # tvm.DataType("float8_e4m3fn"): 'uint8_t',
+    # tvm.DataType("float8_e4m3fnuz"): 'uint8_t',
+    # tvm.DataType("float8_e5m2"): ctypes.c_uint8,
+    # tvm.DataType("float8_e5m2fnuz"): ctypes.c_uint8,
+    # tvm.DataType("float8_e8m0fnu"): ctypes.c_uint8,
+    tvm.DataType("handle"): "long",
+}
+
+
+def cvt_dtype(ty: ir.Type | str | type | torch.dtype) -> tvm.DataType:
+    if isinstance(ty, ir.Type):
+        return ty
+    if isinstance(ty, str):
+        return tvm.DataType(ty)
+    return tvm.DataType(_dtype_torch2tvm[ty])
+
+
+def cvt_tvm_dtype_to_torch(ty: tvm.DataType | str) -> torch.dtype:
+    if isinstance(ty, str):
+        ty = tvm.DataType(ty)
+    return _dtype_tvm2torch[ty]
+
+
+def cvt_tvm_dtype_to_ctypes(ty: tvm.DataType | str) -> Any:
+    if isinstance(ty, str):
+        ty = tvm.DataType(ty)
+    return _dtype_tvm2ctype[ty]
+
+
+def cvt_tvm_dtype_to_cffi(ty: tvm.DataType | str) -> str:
+    if isinstance(ty, str):
+        ty = tvm.DataType(ty)
+    return _dtype_tvm2cffi[ty]
+
+
+def get_ptr_type(
+    ty: ir.Type | str | type | torch.dtype, scope: str = "global"
+) -> ir.PointerType:
+    ty = cvt_dtype(ty)
+    return ir.PointerType(ir.PrimType(ty), scope)


### PR DESCRIPTION
# Tilelang JITv2

In this PR we introduce **Tilelang JITv2**, a new frontend for Tilelang with modern and attractive features.

## Features

### Kernel Declaration

Function declaration has been simplified:

<img width="600" alt="image" src="https://github.com/user-attachments/assets/c12ba9ea-7a11-493a-a226-95368ddf4a83" />

### Kernel Call

When calling functions, tensor shapes, strides, and dtypes are automatically inferred:

```py
# before
ker_1 = matmul(1024, 1024, 1024, 'float32')
c1 = ker_1(a1, b1)
ker_2 = matmul(1024, 1024, 512, 'float32')
c2 = ker_2(a2, b2)

# after
gemm(a1, b1)
gemm(a2, b2)
```

### Auto Tuning

Auto tuning can be done via default arguments:

```py
@tl.jit
def add(
    A: tl.Tensor[int],
    B: tl.Tensor[int],
    block: int = tune([128, 256, 512])
):
    ...
```

Or on-the-fly:

```py
add(A, B, tune([64, 128]))
```

### Smarter Static Evaluation

JITv2 preserves as much Python code as possible, allowing calls to custom Python functions or conditional kernel generation:

```py
@tl.jit
def gemm(
    ...
    split_k: bool = False
):
    block_size = my_super_block_size_huristic(M, N, K)
    if split_k: # split_k is a constant value
        with tl.Kernel(...) as ...:
            ...
    else:
        with tl.Kernel(...) as ...:
            ...

    return C
```

### Smarter Type Hinting

JITv2 not only eliminates annoying type warnings, but also adds extensive type annotations. This helps you clearly see each Tensor’s dimensions, and marks whether a value is on the Python side or kernel side. Even generated functions and the JIT-compiled kernels have friendly type hints:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/980fccc1-0c1a-46aa-865e-b33041d6b6d5" />

### Extremely Low Overhead

**JITv2's Python overhead has been optimized to the extreme**. In the fast path, only dynamic parameters are checked, bringing overhead in line with calling a torch function (e.g., `torch.add`):

```py
A = torch.randn(128, dtype=torch.float16, device="cuda")
B = torch.randn(128, dtype=torch.float16, device="cuda")

# torch.add:  ~ 6.5us
C_1 = A + B
# jit kernel: ~ 7.5us (cached)
C_2 = add(A, B)
```

## Architecture

The **Tilelang JIT** workflow:

1. Py-to-Py generates two pieces of code: argument parser and JIT function generator  
2. **Fast path (~1.5 μs)**: Calls the kernel, argument parser separates static and dynamic parameters; static cache hit → directly calls C++ library functions  
3. **Slow path**: Static cache miss → kernel needs to be recompiled  

<img width="2233" height="1407" alt="whiteboard_exported_image (1)" src="https://github.com/user-attachments/assets/2fe6bfb4-e636-4bde-8fa3-bbe2c0e9ff63" />

### Static & Dynamic Arguments

JITv2 inspects function signatures to determine which parameters are **const** and which are **dyn**:
- **dyn** supports only `int`, `float`, and `ptr`; treated as `tir.Var`
- **const** can be any type (simple types preferred; prefer `Tuple` over `List`)
- **dyn** types must be explicitly annotated; `Tensor` must be explicitly annotated because its `data_ptr` is always dynamic
- **const** arguments can differ from annotation (e.g., annotate `int` but pass a `dict`) — note: validation is hard (like writing a `pydantic`)

<img width="1128" height="779" alt="whiteboard_exported_image (2)" src="https://github.com/user-attachments/assets/d2c939bd-5864-4fc0-8180-ba1562fead84" />

### Argument Parser

JITv2 generates Python code for the fast path, which unpacks const and dyn arguments and then invokes the kernel:  
- **Optimized Python statements**: Each statement in the fast path is carefully designed, using bytecode fast to execute — overhead is minimal, even slightly smaller than `torch.to_dlpack`  
- **Static check cache**: The fast path does not perform type checks for const variables; instead, these are checked at compile time (e.g., wrong tensor shape → cache miss → kernel compiled → value range check)  
- **Dynamic type checks**: Fast path performs simple dynamic checks, e.g., asserting equal values for `K`. More complex asserts may be compiled to host code (not yet supported)  

```py
_K = dyn[int, '_K']
def foo(
    a: Tensor[int, _K],
    b: Tensor[int, _K],
    c: int,
):
    pass
# generated code
def foo_fastpath(a, b, c):
    # 1. Unpack type info
    # 1.1 Unpacking a tensor ~600 ns; each of the following lines takes ~200 ns, heavily optimized
    assert a.device != __device_cpu__, "Expected a non CPU tensor"
    a__shape_0, a__shape_1 = a.shape
    a__stride_0, a__stride_1 = a.stride()
    assert b.device != __device_cpu__, "Expected a non CPU tensor"
    #                  ^- note: torch.device('cpu') costs 200+ ns; using closure trick, __device_cpu__ costs 5 ns
    b__shape_0, b__shape_1 = b.shape
    b__stride_0, b__stride_1 = b.stride()
    # 2. Construct argument lists ~20–50 ns
    __const_args__ = (
        a.dtype, a__shape_0, a__shape_1, a__stride_0, a__stride_1,
        b.dtype, b__shape_0, b__shape_1, b__stride_0, b__stride_1,
        c)
    __dyn_args__ = (a.data_ptr(), b.data_ptr())
    return __const_args, __dyn_args__
```

### Memory Allocation & Return Values

Inside functions, use `T.alloc_global` to create global buffers:
- `T.alloc_global` is friendlier for type linting — it’s translated into `torch.empty`
- `T.alloc_xxx` **must** be assigned to a variable (`x = T.alloc_xxx()`), not passed directly as a function parameter (e.g., `foo(T.alloc_shared(...))` is not allowed)
- Return objects **must** be global buffers; returning Python objects is not supported (e.g., returning `BLOCK_M + BLOCK_N` is not allowed):

```py
@T.prim_func
def gemm(
    A: T.Tensor[int, int],
    B: T.Tensor[int, int],
    out_ty  = torch.half,
    BLOCK_M = T.tune([64, 128, 256]),
    BLOCK_N = T.tune([64, 128, 256]),
):
    # Quickly get dimensions
    (N, K), (M, K2) = A.shape, B.shape
    assert K == K2, "Expect 2 matrices with identical K dimension"
    # Allocate memory for output
    out = T.alloc_global((N, M), dtype=out_ty)
    with T.Kernel((T.ceildiv(M, BLOCK_M), T.ceildiv(N, BLOCK_N)), threads=128) as (bx, by):
        pass
    return out
```

## TODOs

- [ ] Integrate with `tl.language`
- [ ] Add auto tuner
