### PR TITLE
[Bugfix] Fix saving kernel source code where JITKernel.artifact is None

### DIFF
--- a/tilelang/autotuner/param.py
+++ b/tilelang/autotuner/param.py
@@ -172,9 +172,9 @@ class AutotuneResult:
             kernel_path = os.path.join(cache_path, KERNEL_PATH)
             if verbose:
                 logger.debug(f"Saving kernel source code to file: {kernel_path}")
-            if kernel.artifact.kernel_source is not None:
+            if kernel.kernel_source is not None:
                 with open(kernel_path, "w") as f:
-                    f.write(kernel.artifact.kernel_source)
+                    f.write(kernel.kernel_source)
         except Exception as e:
             logger.error(f"Error saving kernel source code to disk: {e}")
 

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -262,9 +262,9 @@ class KernelCache:
             kernel_path = os.path.join(cache_path, KERNEL_PATH)
             if verbose:
                 self.logger.debug(f"Saving kernel source code to file: {kernel_path}")
-            if kernel.artifact.kernel_source is not None:
+            if kernel.kernel_source is not None:
                 KernelCache._safe_write_file(kernel_path, "w",
-                                             lambda file: file.write(kernel.artifact.kernel_source))
+                                             lambda file: file.write(kernel.kernel_source))
         except Exception as e:
             self.logger.error(f"Error saving kernel source code to disk: {e}")
 


### PR DESCRIPTION
In cases where JITKernel.artifact is None, it'll spit error -
```
2025-10-01 01:06:18  [TileLang:tilelang:ERROR]: Error saving kernel source
code to disk: 'NoneType' object has no attribute 'kernel_source'
```

Looking at properties of JITKernel, it seems that `JITKernel.kernel_source` is a better way to achieve this.
Ref:
https://github.com/tile-ai/tilelang/blob/main/tilelang/jit/kernel.py#L453-L455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures the correct kernel source is saved to disk so persisted kernel files reflect the actual, current source and avoid missing or outdated content.
* **Chores**
  * Internal alignment of kernel source handling across components to use a single, consistent source for persistence and reduce discrepancies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->