### PR TITLE
[Example] Add support for `bfloat16` and user-defined `sm_scale` in attention sink examples

### DIFF
--- a/examples/attention_sink/example_gqa_sink_bwd_bhsd.py
+++ b/examples/attention_sink/example_gqa_sink_bwd_bhsd.py
@@ -28,7 +28,8 @@ def flashattn_fwd(
         seq_len,
         dim,
         groups=1,
-        window_size=None,  # None for full attention,
+        window_size=None,  # None for full attention
+        sm_scale=None,
         block_M=128,
         block_N=128,
         num_stages=2,
@@ -37,7 +38,10 @@ def flashattn_fwd(
     if window_size is not None:
         assert window_size % block_N == 0, "window_size must be divisible by block_N"
 
-    scale = (1.0 / dim)**0.5 * 1.44269504  # log2(e)
+    if sm_scale is None:
+        sm_scale = (1.0 / dim)**0.5 
+    scale = sm_scale * 1.44269504  # log2(e)
+
     head_kv = heads // groups
     q_shape = [batch, heads, seq_len, dim]
     kv_shape = [batch, head_kv, seq_len, dim]
@@ -199,9 +203,11 @@ def flashattn_bwd_postprocess(batch, heads, seq_len, dim):
 @tilelang.jit(pass_configs={
     tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
 })
-def flashattn_bwd(batch, heads, seq_len, dim, groups, window_size=None):  # None for full attention
-    sm_scale = (1.0 / dim)**0.5
+def flashattn_bwd(batch, heads, seq_len, dim, groups, window_size=None, sm_scale=None):  # None for full attention
+    if sm_scale is None:
+        sm_scale = (1.0 / dim)**0.5
     scale = sm_scale * 1.44269504  # log2(e)
+
     head_kv = heads // groups
     q_shape = [batch, heads, seq_len, dim]
     kv_shape = [batch, head_kv, seq_len, dim]
@@ -338,6 +344,11 @@ class _attention(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, q, k, v, sinks, window_size, groups):
+        def maybe_contiguous(x):
+            if x.stride(-1) != 1:
+                return x.contiguous()
+            return x
+        q, k, v, sinks= [maybe_contiguous(x) for x in (q, k, v, sinks)]
         BATCH, H, N_CTX, D_HEAD = q.shape
         kernel = flashattn_fwd(BATCH, H, N_CTX, D_HEAD, groups, window_size)
         o, lse = kernel(q, k, v, sinks)
@@ -352,12 +363,6 @@ class _attention(torch.autograd.Function):
         BATCH, H, N_CTX, D_HEAD = q.shape
         groups = ctx.groups
 
-        def maybe_contiguous(x):
-            if x.stride(-1) != 1:
-                return x.contiguous()
-            return x
-
-        do, q, k, v, sinks, o = [maybe_contiguous(x) for x in (do, q, k, v, sinks, o)]
         kernel_prep = flashattn_bwd_preprocess(BATCH, H, N_CTX, D_HEAD)
         kernel_post = flashattn_bwd_postprocess(BATCH, H, N_CTX, D_HEAD)
         delta = kernel_prep(o, do)

--- a/examples/attention_sink/example_gqa_sink_bwd_bhsd.py
+++ b/examples/attention_sink/example_gqa_sink_bwd_bhsd.py
@@ -33,7 +33,8 @@ def flashattn_fwd(
         block_M=128,
         block_N=128,
         num_stages=2,
-        threads=256):
+        threads=256,
+        dtype: str = "float16"):
 
     if window_size is not None:
         assert window_size % block_N == 0, "window_size must be divisible by block_N"
@@ -45,7 +46,6 @@ def flashattn_fwd(
     head_kv = heads // groups
     q_shape = [batch, heads, seq_len, dim]
     kv_shape = [batch, head_kv, seq_len, dim]
-    dtype = "float16"
     accum_dtype = "float"
 
     @T.prim_func
@@ -140,8 +140,7 @@ def flashattn_fwd(
     out_idx=[2], pass_configs={
         tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
     })
-def flashattn_bwd_preprocess(batch, heads, seq_len, dim):
-    dtype = "float16"
+def flashattn_bwd_preprocess(batch, heads, seq_len, dim, dtype: str = "float16"):
     accum_dtype = "float"
     shape = [batch, heads, seq_len, dim]
     blk = 32
@@ -179,8 +178,7 @@ def make_dq_layout(dQ):
     out_idx=[1], pass_configs={
         tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
     })
-def flashattn_bwd_postprocess(batch, heads, seq_len, dim):
-    dtype = "float16"
+def flashattn_bwd_postprocess(batch, heads, seq_len, dim, dtype: str = "float16"):
     accum_dtype = "float"
     shape = [batch, heads, seq_len, dim]
     blk = 64
@@ -203,7 +201,7 @@ def flashattn_bwd_postprocess(batch, heads, seq_len, dim):
 @tilelang.jit(pass_configs={
     tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
 })
-def flashattn_bwd(batch, heads, seq_len, dim, groups, window_size=None, sm_scale=None):  # None for full attention
+def flashattn_bwd(batch, heads, seq_len, dim, groups, window_size=None, sm_scale=None, dtype="float16"):  # None for full attention
     if sm_scale is None:
         sm_scale = (1.0 / dim)**0.5
     scale = sm_scale * 1.44269504  # log2(e)
@@ -211,7 +209,6 @@ def flashattn_bwd(batch, heads, seq_len, dim, groups, window_size=None, sm_scale
     head_kv = heads // groups
     q_shape = [batch, heads, seq_len, dim]
     kv_shape = [batch, head_kv, seq_len, dim]
-    dtype = "float16"
     accum_dtype = "float"
 
     block_M, block_N, num_stages, threads = get_bwd_configs()
@@ -311,8 +308,7 @@ def flashattn_bwd(batch, heads, seq_len, dim, groups, window_size=None, sm_scale
 
 
 @tilelang.jit(out_idx=-1)
-def flashattn_bwd_dsink(batch, heads, seq_len, block=256):
-    dtype = "float16"
+def flashattn_bwd_dsink(batch, heads, seq_len, block=256, dtype: str = "float16"):
     accum_dtype = "float"
     shape = [batch, heads, seq_len]
 
@@ -350,7 +346,8 @@ class _attention(torch.autograd.Function):
             return x
         q, k, v, sinks= [maybe_contiguous(x) for x in (q, k, v, sinks)]
         BATCH, H, N_CTX, D_HEAD = q.shape
-        kernel = flashattn_fwd(BATCH, H, N_CTX, D_HEAD, groups, window_size)
+        dtype = "float16" if q.dtype == torch.float16 else "bfloat16"
+        kernel = flashattn_fwd(BATCH, H, N_CTX, D_HEAD, groups, window_size, dtype=dtype)
         o, lse = kernel(q, k, v, sinks)
         ctx.save_for_backward(q, k, v, sinks, o, lse)
         ctx.window_size = window_size
@@ -362,21 +359,22 @@ class _attention(torch.autograd.Function):
         q, k, v, sinks, o, lse = ctx.saved_tensors
         BATCH, H, N_CTX, D_HEAD = q.shape
         groups = ctx.groups
+        dtype = "float16" if q.dtype == torch.float16 else "bfloat16"
 
-        kernel_prep = flashattn_bwd_preprocess(BATCH, H, N_CTX, D_HEAD)
-        kernel_post = flashattn_bwd_postprocess(BATCH, H, N_CTX, D_HEAD)
+        kernel_prep = flashattn_bwd_preprocess(BATCH, H, N_CTX, D_HEAD, dtype=dtype)
+        kernel_post = flashattn_bwd_postprocess(BATCH, H, N_CTX, D_HEAD, dtype=dtype)
         delta = kernel_prep(o, do)
-        kernel = flashattn_bwd(BATCH, H, N_CTX, D_HEAD, groups, ctx.window_size)
+        kernel = flashattn_bwd(BATCH, H, N_CTX, D_HEAD, groups, ctx.window_size, dtype=dtype)
         q_shape = [BATCH, H, N_CTX, D_HEAD]
         head_kv = H // groups
         kv_shape = [BATCH, head_kv, N_CTX, D_HEAD]
         dq = torch.zeros(q_shape, dtype=torch.float32, device=q.device)  # acc for atomicAdd
-        dk = torch.zeros(kv_shape, dtype=torch.float16, device=q.device)
-        dv = torch.zeros(kv_shape, dtype=torch.float16, device=q.device)
+        dk = torch.zeros(kv_shape, dtype=q.dtype, device=q.device)
+        dv = torch.zeros(kv_shape, dtype=q.dtype, device=q.device)
         kernel(q, k, v, do, lse, delta, dq, dk, dv)
         dq = kernel_post(dq)
 
-        kernel_dsink = flashattn_bwd_dsink(BATCH, H, N_CTX)
+        kernel_dsink = flashattn_bwd_dsink(BATCH, H, N_CTX, dtype=dtype)
         dsinks = kernel_dsink(sinks, delta, lse).sum(0).sum(1)
         return dq, dk, dv, dsinks, None, None
 
@@ -390,7 +388,8 @@ def ref_program(query: torch.Tensor,
                 key: torch.Tensor,
                 value: torch.Tensor,
                 sinks: torch.Tensor,
-                sliding_window: int | None = None) -> torch.Tensor:
+                sliding_window: int | None = None,
+                dtype: torch.dtype = torch.float16) -> torch.Tensor:
 
     key = key.transpose(1, 2).contiguous()
     value = value.transpose(1, 2).contiguous()
@@ -428,7 +427,7 @@ def ref_program(query: torch.Tensor,
     output = torch.einsum("bhmqk,bkhmd->bqhmd", scores, value.float())
 
     output = output.reshape(batch_size, num_queries, num_key_value_heads * num_key_value_groups,
-                            head_dim).to(torch.float16)
+                            head_dim).to(dtype)
     return output.transpose(1, 2).contiguous()
 
 
@@ -437,7 +436,9 @@ def main(BATCH: int = 1,
          N_CTX: int = 512,
          D_HEAD: int = 64,
          groups: int = 2,
-         window_size: int | None = None):
+         window_size: int | None = None,
+         dtype: str = "float16"):
+    torch_dtype = {"float16": torch.float16, "bfloat16": torch.bfloat16}[dtype]
     if window_size is not None:
         print('Using sliding window attention.')
         assert window_size <= N_CTX
@@ -449,13 +450,13 @@ def main(BATCH: int = 1,
     total_flops = 5 * flops_per_matmul
 
     Q = (
-        torch.empty(BATCH, H, N_CTX, D_HEAD, dtype=torch.float16,
+        torch.empty(BATCH, H, N_CTX, D_HEAD, dtype=torch_dtype,
                     device="cuda").normal_().requires_grad_())
     K = torch.empty(
-        BATCH, H // groups, N_CTX, D_HEAD, dtype=torch.float16,
+        BATCH, H // groups, N_CTX, D_HEAD, dtype=torch_dtype,
         device="cuda").normal_().requires_grad_()
     V = torch.empty_like(K).normal_().requires_grad_()
-    sinks = torch.randn(H, dtype=torch.float16, device="cuda").requires_grad_()
+    sinks = torch.randn(H, dtype=torch_dtype, device="cuda").requires_grad_()
     dO = torch.randn_like(Q)
 
     O = attention(Q, K, V, sinks, window_size, groups)
@@ -465,7 +466,7 @@ def main(BATCH: int = 1,
     dV, V.grad = V.grad.clone(), None
     dsinks, sinks.grad = sinks.grad.clone(), None
 
-    O_ref = ref_program(Q, K, V, sinks, window_size)
+    O_ref = ref_program(Q, K, V, sinks, window_size, dtype=torch_dtype)
     O_ref.backward(dO, retain_graph=True)
     dQ_ref, Q.grad = Q.grad.clone(), None
     dK_ref, K.grad = K.grad.clone(), None
@@ -508,5 +509,6 @@ if __name__ == "__main__":
         type=int,
         default=None,
         help='window size (default: None, which means full attention)')
+    parser.add_argument('--dtype', type=str, default="float16", help="dtype, can be float16 or bfloat16")
     args = parser.parse_args()
-    main(args.batch, args.h, args.n_ctx, args.d_head, args.groups, args.window_size)
+    main(args.batch, args.h, args.n_ctx, args.d_head, args.groups, args.window_size, args.dtype)

--- a/examples/attention_sink/example_gqa_sink_fwd_bhsd_wgmma_pipelined.py
+++ b/examples/attention_sink/example_gqa_sink_fwd_bhsd_wgmma_pipelined.py
@@ -25,9 +25,10 @@ def get_configs():
     rep=100,
 )
 @tilelang.jit(
-    out_idx=[3], pass_configs={
-        tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
-    })
+    out_idx=[3], 
+    pass_configs={tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,}, 
+    compile_flags=["--use_fast_math", "-O3", "-DENABLE_BF16"]
+)
 def flashattn(
     batch,
     heads,
@@ -41,6 +42,7 @@ def flashattn(
     block_N=128,
     num_stages=2,
     threads=256,
+    dtype: str = "float16",
 ):
 
     if window_size is not None:
@@ -53,7 +55,6 @@ def flashattn(
     head_kv = heads // groups
     q_shape = [batch, heads, seq_q, dim]
     kv_shape = [batch, head_kv, seq_kv, dim]
-    dtype = "float16"
     accum_dtype = "float"
 
     past_len = seq_kv - seq_q
@@ -209,7 +210,8 @@ def ref_program(query: torch.Tensor,
                 key: torch.Tensor,
                 value: torch.Tensor,
                 sinks: torch.Tensor,
-                sliding_window: int | None = None) -> torch.Tensor:
+                sliding_window: int | None = None,
+                dtype: torch.dtype = torch.float16) -> torch.Tensor:
 
     key = key.transpose(1, 2).contiguous()
     value = value.transpose(1, 2).contiguous()
@@ -247,7 +249,7 @@ def ref_program(query: torch.Tensor,
     output = torch.einsum("bhmqk,bkhmd->bqhmd", scores, value.float())
 
     output = output.reshape(batch_size, num_queries, num_key_value_heads * num_key_value_groups,
-                            head_dim).to(torch.float16)
+                            head_dim).to(dtype)
     return output.transpose(1, 2).contiguous()
 
 
@@ -368,11 +370,12 @@ def triton_program(Q, K, V, Sinks, window_size: int | None = None) -> torch.Tens
 
 
 def gen_inputs(B, H, Sq, Skv, D,
-               groups) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    query = torch.randn([B, H, Sq, D], dtype=torch.float16, device='cuda')
-    key = torch.randn([B, H // groups, Skv, D], dtype=torch.float16, device='cuda')
-    value = torch.randn([B, H // groups, Skv, D], dtype=torch.float16, device='cuda')
-    sinks = torch.randn([H], dtype=torch.float16, device='cuda')
+               groups,
+               dtype=torch.float16) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    query = torch.randn([B, H, Sq, D], dtype=dtype, device='cuda')
+    key = torch.randn([B, H // groups, Skv, D], dtype=dtype, device='cuda')
+    value = torch.randn([B, H // groups, Skv, D], dtype=dtype, device='cuda')
+    sinks = torch.randn([H], dtype=dtype, device='cuda')
     return query, key, value, sinks
 
 
@@ -384,8 +387,10 @@ def main(
     dim: int = 128,
     groups: int = 8,
     window_size: int | None = None,
+    dtype: str = "float16",
     tune: bool = False,
 ):
+    torch_dtype = {"float16": torch.float16, "bfloat16": torch.bfloat16}[dtype]
     if window_size is not None:
         print('Using sliding window attention.')
         assert window_size <= seq_q
@@ -397,7 +402,7 @@ def main(
     total_flops = 2 * flops_per_matmul
 
     if tune:
-        kernel = flashattn(batch, heads, seq_q, seq_kv, dim, groups, window_size)
+        kernel = flashattn(batch, heads, seq_q, seq_kv, dim, groups, window_size, dtype=dtype)
         print(f"Best latency: {kernel.latency}")
         print(f"Best TFlops: {total_flops / kernel.latency * 1e-9}")
         print(f"Best config: {kernel.config}")
@@ -419,17 +424,21 @@ def main(
             block_M=block_M,
             block_N=block_N,
             num_stages=num_stages,
-            threads=threads)
+            threads=threads,
+            dtype=dtype)
 
-        Q, K, V, sinks = gen_inputs(batch, heads, seq_q, seq_kv, dim, groups)
+        Q, K, V, sinks = gen_inputs(batch, heads, seq_q, seq_kv, dim, groups, dtype=torch_dtype)
 
         torch.testing.assert_close(
-            kernel(Q, K, V, sinks), ref_program(Q, K, V, sinks, window_size), rtol=1e-2, atol=1e-2)
+            kernel(Q, K, V, sinks),
+            ref_program(Q, K, V, sinks, window_size, dtype=torch_dtype),
+            rtol=1e-2,
+            atol=1e-2)
         print("All checks passed.✅")
 
         if torch.allclose(
                 triton_program(Q, K, V, sinks, window_size),
-                ref_program(Q, K, V, sinks, window_size),
+                ref_program(Q, K, V, sinks, window_size, dtype=torch_dtype),
                 rtol=1e-2,
                 atol=1e-2):
             print("Checks for triton passed.✅")
@@ -462,7 +471,8 @@ if __name__ == "__main__":
         type=int,
         default=None,
         help='window size (default: None, which means full attention)')
+    parser.add_argument('--dtype', type=str, default="float16", help="dtype, can be float16 or bfloat16")
     parser.add_argument('--tune', action='store_true', help='tune configs')
     args = parser.parse_args()
     main(args.batch, args.heads, args.seq_q, args.seq_kv, args.dim, args.groups, args.window_size,
-         args.tune)
+         args.dtype, args.tune)

--- a/examples/attention_sink/example_gqa_sink_fwd_bhsd_wgmma_pipelined.py
+++ b/examples/attention_sink/example_gqa_sink_fwd_bhsd_wgmma_pipelined.py
@@ -36,6 +36,7 @@ def flashattn(
     dim,
     groups=1,
     window_size=None,  # None for full attention
+    sm_scale=None,
     block_M=128,
     block_N=128,
     num_stages=2,
@@ -45,7 +46,10 @@ def flashattn(
     if window_size is not None:
         assert window_size % block_N == 0, "window_size must be divisible by block_N"
 
-    scale = (1.0 / dim)**0.5 * 1.44269504  # log2(e)
+    if sm_scale is None:
+        sm_scale = (1.0 / dim)**0.5 
+    scale = sm_scale * 1.44269504  # log2(e)
+
     head_kv = heads // groups
     q_shape = [batch, heads, seq_q, dim]
     kv_shape = [batch, head_kv, seq_kv, dim]

--- a/examples/attention_sink/example_mha_sink_bwd_bhsd.py
+++ b/examples/attention_sink/example_mha_sink_bwd_bhsd.py
@@ -28,6 +28,7 @@ def flashattn_fwd(
         seq_len,
         dim,
         window_size=None,  # None for full attention,
+        sm_scale=None,
         block_M=64,
         block_N=64,
         num_stages=1,
@@ -36,7 +37,10 @@ def flashattn_fwd(
     if window_size is not None:
         assert window_size % block_N == 0, "window_size must be divisible by block_N"
 
-    scale = (1.0 / dim)**0.5 * 1.44269504  # log2(e)
+    if sm_scale is None:
+        sm_scale = (1.0 / dim)**0.5 
+    scale = sm_scale * 1.44269504  # log2(e)
+
     shape = [batch, heads, seq_len, dim]
     dtype = "float16"
     accum_dtype = "float"
@@ -52,7 +56,6 @@ def flashattn_fwd(
     ):
         with T.Kernel(T.ceildiv(seq_len, block_M), heads, batch, threads=threads) as (bx, by, bz):
             Q_shared = T.alloc_shared([block_M, dim], dtype)
-            # Q_local = T.alloc_fragment([block_M, dim], dtype)
             K_shared = T.alloc_shared([block_N, dim], dtype)
             V_shared = T.alloc_shared([block_N, dim], dtype)
             acc_s = T.alloc_fragment([block_M, block_N], accum_dtype)
@@ -72,9 +75,6 @@ def flashattn_fwd(
             T.fill(scores_max, -T.infinity(accum_dtype))
             for i in T.Parallel(block_M):
                 sinks[i] = Sinks[by]
-            # T.copy(Q_shared, Q_local)
-            # for i, j in T.Parallel(block_M, dim):
-            #     Q_local[i, j] *= scale
             end = T.min(T.ceildiv(seq_len, block_N), T.ceildiv((bx + 1) * block_M, block_N))
             start = T.alloc_local([1], 'int32')
             if window_size is not None:
@@ -204,13 +204,16 @@ def flashattn_bwd(
         heads,
         seq_len,
         dim,
-        window_size=None,  # None for full attention,
+        window_size=None,  # None for full attention
+        sm_scale=None,
 ):
 
     block_M, block_N, num_stages, threads = get_bwd_configs()
 
-    sm_scale = (1.0 / dim)**0.5
+    if sm_scale is None:
+        sm_scale = (1.0 / dim)**0.5 
     scale = sm_scale * 1.44269504  # log2(e)
+
     shape = [batch, heads, seq_len, dim]
     dtype = "float16"
     accum_dtype = "float"
@@ -349,7 +352,7 @@ class _attention(torch.autograd.Function):
         BATCH, H, N_CTX, D_HEAD = q.shape
         block_M = 64
         block_N = 64 if D_HEAD <= 128 else 32
-        kernel = flashattn_fwd(BATCH, H, N_CTX, D_HEAD, window_size, block_M, block_N)
+        kernel = flashattn_fwd(BATCH, H, N_CTX, D_HEAD, window_size, block_M=block_M, block_N=block_N)
         o, lse = kernel(q, k, v, sinks)
         ctx.save_for_backward(q, k, v, sinks, o, lse)
         ctx.window_size = window_size

--- a/examples/attention_sink/example_mha_sink_bwd_bhsd.py
+++ b/examples/attention_sink/example_mha_sink_bwd_bhsd.py
@@ -6,6 +6,8 @@ from tilelang.profiler import do_bench
 import tilelang.language as T
 import argparse
 
+tilelang.disable_cache()
+
 
 def get_bwd_configs():
     sm_major, sm_minor = torch.cuda.get_device_capability()
@@ -19,9 +21,10 @@ def get_bwd_configs():
 
 
 @tilelang.jit(
-    out_idx=[3, 4], pass_configs={
-        tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
-    })
+    out_idx=[3, 4],     
+    pass_configs={tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,}, 
+    compile_flags=["-DENABLE_BF16"]
+)
 def flashattn_fwd(
         batch,
         heads,
@@ -32,7 +35,8 @@ def flashattn_fwd(
         block_M=64,
         block_N=64,
         num_stages=1,
-        threads=128):
+        threads=128,
+        dtype: str = "float16"):
 
     if window_size is not None:
         assert window_size % block_N == 0, "window_size must be divisible by block_N"
@@ -42,7 +46,6 @@ def flashattn_fwd(
     scale = sm_scale * 1.44269504  # log2(e)
 
     shape = [batch, heads, seq_len, dim]
-    dtype = "float16"
     accum_dtype = "float"
 
     @T.prim_func
@@ -66,7 +69,7 @@ def flashattn_fwd(
             scores_scale = T.alloc_fragment([block_M], accum_dtype)
             scores_sum = T.alloc_fragment([block_M], accum_dtype)
             logsum = T.alloc_fragment([block_M], accum_dtype)
-            sinks = T.alloc_fragment([heads], dtype)
+            sinks = T.alloc_fragment([heads], accum_dtype)
 
             T.annotate_layout({Q_shared: tilelang.layout.make_swizzled_layout(Q_shared)})
             T.copy(Q[bz, by, bx * block_M:(bx + 1) * block_M, :], Q_shared)
@@ -133,11 +136,9 @@ def flashattn_fwd(
 
 
 @tilelang.jit(
-    out_idx=[2], pass_configs={
-        tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
-    })
-def flashattn_bwd_preprocess(batch, heads, seq_len, dim):
-    dtype = "float16"
+    out_idx=[2],     
+    pass_configs={tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,})
+def flashattn_bwd_preprocess(batch, heads, seq_len, dim, dtype: str = "float16"):
     accum_dtype = "float"
     shape = [batch, heads, seq_len, dim]
     blk = 32
@@ -172,11 +173,11 @@ def make_dq_layout(dQ):
 
 
 @tilelang.jit(
-    out_idx=[1], pass_configs={
-        tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
-    })
-def flashattn_bwd_postprocess(batch, heads, seq_len, dim):
-    dtype = "float16"
+    out_idx=[1],     
+    pass_configs={tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,}, 
+    compile_flags=["-DENABLE_BF16"]
+)
+def flashattn_bwd_postprocess(batch, heads, seq_len, dim, dtype: str = "float16"):
     accum_dtype = "float"
     shape = [batch, heads, seq_len, dim]
     blk = 64
@@ -196,9 +197,9 @@ def flashattn_bwd_postprocess(batch, heads, seq_len, dim):
     return flash_bwd_post
 
 
-@tilelang.jit(pass_configs={
-    tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
-})
+@tilelang.jit(    
+    pass_configs={tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,}, 
+    compile_flags=["-DENABLE_BF16"])
 def flashattn_bwd(
         batch,
         heads,
@@ -206,6 +207,7 @@ def flashattn_bwd(
         dim,
         window_size=None,  # None for full attention
         sm_scale=None,
+        dtype: str = "float16",
 ):
 
     block_M, block_N, num_stages, threads = get_bwd_configs()
@@ -215,7 +217,6 @@ def flashattn_bwd(
     scale = sm_scale * 1.44269504  # log2(e)
 
     shape = [batch, heads, seq_len, dim]
-    dtype = "float16"
     accum_dtype = "float"
 
     if window_size is not None:
@@ -298,7 +299,7 @@ def flashattn_bwd(
                 T.copy(Delta[bz, bx, k * block_N:(k + 1) * block_N], delta)
 
                 for i, j in T.Parallel(block_M, block_N):
-                    dsT_cast[i, j] = qkT[i, j] * (dsT[i, j] - delta[j]) * sm_scale
+                    dsT_cast[i, j] = qkT[i, j] * (dsT[i, j] - delta[j]) * scale
                 T.gemm(dsT_cast, q, dk, policy=T.GemmWarpPolicy.FullRow)
 
                 T.copy(dsT_cast, dsT_shared)
@@ -315,9 +316,12 @@ def flashattn_bwd(
     return flash_bwd
 
 
-@tilelang.jit(out_idx=-1)
-def flashattn_bwd_dsink(batch, heads, seq_len, block=128):
-    dtype = "float16"
+@tilelang.jit(
+    out_idx=-1,     
+    pass_configs={tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,}, 
+    compile_flags=["-DENABLE_BF16"]
+)
+def flashattn_bwd_dsink(batch, heads, seq_len, block=128, dtype: str = "float16"):
     accum_dtype = "float"
     shape = [batch, heads, seq_len]
 
@@ -352,7 +356,15 @@ class _attention(torch.autograd.Function):
         BATCH, H, N_CTX, D_HEAD = q.shape
         block_M = 64
         block_N = 64 if D_HEAD <= 128 else 32
-        kernel = flashattn_fwd(BATCH, H, N_CTX, D_HEAD, window_size, block_M=block_M, block_N=block_N)
+        dtype = "float16" if q.dtype == torch.float16 else "bfloat16"
+        kernel = flashattn_fwd(BATCH,
+                               H,
+                               N_CTX,
+                               D_HEAD,
+                               window_size,
+                               block_M=block_M,
+                               block_N=block_N,
+                               dtype=dtype)
         o, lse = kernel(q, k, v, sinks)
         ctx.save_for_backward(q, k, v, sinks, o, lse)
         ctx.window_size = window_size
@@ -369,18 +381,19 @@ class _attention(torch.autograd.Function):
             return x
 
         do, q, k, v, sinks, o = [maybe_contiguous(x) for x in (do, q, k, v, sinks, o)]
-        kernel_prep = flashattn_bwd_preprocess(BATCH, H, N_CTX, D_HEAD)
-        kernel_post = flashattn_bwd_postprocess(BATCH, H, N_CTX, D_HEAD)
+        dtype = "float16" if q.dtype == torch.float16 else "bfloat16"
+        kernel_prep = flashattn_bwd_preprocess(BATCH, H, N_CTX, D_HEAD, dtype=dtype)
+        kernel_post = flashattn_bwd_postprocess(BATCH, H, N_CTX, D_HEAD, dtype=dtype)
         delta = kernel_prep(o, do)
-        kernel = flashattn_bwd(BATCH, H, N_CTX, D_HEAD, ctx.window_size)
+        kernel = flashattn_bwd(BATCH, H, N_CTX, D_HEAD, ctx.window_size, dtype=dtype)
         shape = [BATCH, H, N_CTX, D_HEAD]
         dq = torch.zeros(shape, dtype=torch.float32, device=q.device)  # acc for atomicAdd
-        dk = torch.empty(shape, dtype=torch.float16, device=q.device)
-        dv = torch.empty(shape, dtype=torch.float16, device=q.device)
+        dk = torch.empty(shape, dtype=q.dtype, device=q.device)
+        dv = torch.empty(shape, dtype=q.dtype, device=q.device)
         kernel(q, k, v, do, lse, delta, dq, dk, dv)
         dq = kernel_post(dq)
 
-        kernel_dsink = flashattn_bwd_dsink(BATCH, H, N_CTX)
+        kernel_dsink = flashattn_bwd_dsink(BATCH, H, N_CTX, dtype=dtype)
         dsinks = kernel_dsink(sinks, delta, lse).sum(0).sum(1)
         return dq, dk, dv, dsinks, None
 
@@ -394,7 +407,8 @@ def ref_program(query: torch.Tensor,
                 key: torch.Tensor,
                 value: torch.Tensor,
                 sinks: torch.Tensor,
-                sliding_window: int | None = None) -> torch.Tensor:
+                sliding_window: int | None = None,
+                dtype: torch.dtype = torch.float16) -> torch.Tensor:
 
     query = query.transpose(1, 2).contiguous().unsqueeze(
         3)  # align with the original function's interface
@@ -433,7 +447,7 @@ def ref_program(query: torch.Tensor,
     output = torch.einsum("bhmqk,bkhmd->bqhmd", scores, value.float())
 
     output = output.reshape(batch_size, num_queries, num_key_value_heads * num_key_value_groups,
-                            head_dim).to(torch.float16)
+                            head_dim).to(dtype)
     return output.transpose(1, 2).contiguous()
 
 
@@ -441,7 +455,9 @@ def main(BATCH: int = 1,
          H: int = 1,
          N_CTX: int = 512,
          D_HEAD: int = 128,
-         window_size: int | None = None):
+         window_size: int | None = None,
+         dtype: str = "float16"):
+    torch_dtype = {"float16": torch.float16, "bfloat16": torch.bfloat16}[dtype]
     if window_size is not None:
         print('Using sliding window attention.')
         assert window_size <= N_CTX
@@ -453,11 +469,11 @@ def main(BATCH: int = 1,
     total_flops = 5 * flops_per_matmul
 
     Q = (
-        torch.empty(BATCH, H, N_CTX, D_HEAD, dtype=torch.half,
+        torch.empty(BATCH, H, N_CTX, D_HEAD, dtype=torch_dtype,
                     device="cuda").normal_().requires_grad_())
     K = torch.empty_like(Q).normal_().requires_grad_()
     V = torch.empty_like(Q).normal_().requires_grad_()
-    sinks = torch.randn(H, dtype=torch.float16, device=Q.device).requires_grad_()
+    sinks = torch.randn(H, dtype=torch_dtype, device=Q.device).requires_grad_()
     dO = torch.randn_like(Q)
 
     O = attention(Q, K, V, sinks, window_size)
@@ -467,7 +483,7 @@ def main(BATCH: int = 1,
     dV, V.grad = V.grad.clone(), None
     dsinks, sinks.grad = sinks.grad.clone(), None
 
-    O_ref = ref_program(Q, K, V, sinks, window_size)
+    O_ref = ref_program(Q, K, V, sinks, window_size, dtype=torch_dtype)
     O_ref.backward(dO, retain_graph=True)
     dQ_ref, Q.grad = Q.grad.clone(), None
     dK_ref, K.grad = K.grad.clone(), None
@@ -501,13 +517,14 @@ def main(BATCH: int = 1,
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--batch', type=int, default=1, help='Batch size')
-    parser.add_argument('--h', type=int, default=32, help='Number of heads')
-    parser.add_argument('--n_ctx', type=int, default=1024, help='Context size')
+    parser.add_argument('--h', type=int, default=64, help='Number of heads')
+    parser.add_argument('--n_ctx', type=int, default=4096, help='Context size')
     parser.add_argument('--d_head', type=int, default=128, help='Head dimension')
     parser.add_argument(
         '--window_size',
         type=int,
         default=None,
         help='window size (default: None, which means full attention)')
+    parser.add_argument('--dtype', type=str, default="float16", help="dtype, can be float16 or bfloat16")
     args = parser.parse_args()
-    main(args.batch, args.h, args.n_ctx, args.d_head, args.window_size)
+    main(args.batch, args.h, args.n_ctx, args.d_head, args.window_size, args.dtype)

--- a/examples/attention_sink/example_mha_sink_fwd_bhsd.py
+++ b/examples/attention_sink/example_mha_sink_fwd_bhsd.py
@@ -27,6 +27,7 @@ def flashattn(
         seq_kv,
         dim,
         window_size=None,  # None for full attention
+        sm_scale=None,
         block_M=64,
         block_N=64,
         num_stages=1,
@@ -34,7 +35,9 @@ def flashattn(
     if window_size is not None:
         assert window_size % block_N == 0, "window_size must be divisible by block_N"
 
-    scale = (1.0 / dim)**0.5 * 1.44269504  # log2(e)
+    if sm_scale is None:
+        sm_scale = (1.0 / dim)**0.5 
+    scale = sm_scale * 1.44269504  # log2(e)
     q_shape = [batch, heads, seq_q, dim]
     kv_shape = [batch, heads, seq_kv, dim]
     dtype = "float16"

--- a/examples/attention_sink/example_mha_sink_fwd_bhsd.py
+++ b/examples/attention_sink/example_mha_sink_fwd_bhsd.py
@@ -17,9 +17,9 @@ def get_configs():
 
 @autotune(configs=get_configs(), warmup=500, rep=100)
 @tilelang.jit(
-    out_idx=[3], pass_configs={
-        tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
-    })
+    out_idx=[3], 
+    pass_configs={tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,}, 
+    compile_flags=["--use_fast_math", "-O3", "-DENABLE_BF16"])
 def flashattn(
         batch,
         heads,
@@ -31,7 +31,8 @@ def flashattn(
         block_M=64,
         block_N=64,
         num_stages=1,
-        threads=128):
+        threads=128,
+        dtype: str = "float16"):
     if window_size is not None:
         assert window_size % block_N == 0, "window_size must be divisible by block_N"
 
@@ -40,7 +41,6 @@ def flashattn(
     scale = sm_scale * 1.44269504  # log2(e)
     q_shape = [batch, heads, seq_q, dim]
     kv_shape = [batch, heads, seq_kv, dim]
-    dtype = "float16"
     accum_dtype = "float"
 
     past_len = seq_kv - seq_q
@@ -189,7 +189,8 @@ def ref_program(query: torch.Tensor,
                 key: torch.Tensor,
                 value: torch.Tensor,
                 sinks: torch.Tensor,
-                sliding_window: int | None = None) -> torch.Tensor:
+                sliding_window: int | None = None,
+                dtype: torch.dtype = torch.float16) -> torch.Tensor:
 
     query = query.transpose(1, 2).contiguous().unsqueeze(
         3)  # align with the original function's interface
@@ -228,15 +229,16 @@ def ref_program(query: torch.Tensor,
     output = torch.einsum("bhmqk,bkhmd->bqhmd", scores, value.float())
 
     output = output.reshape(batch_size, num_queries, num_key_value_heads * num_key_value_groups,
-                            head_dim).to(torch.float16)
+                            head_dim).to(dtype)
     return output.transpose(1, 2).contiguous()
 
 
-def gen_inputs(B, H, Sq, Skv, D) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    query = torch.randn([B, H, Sq, D], dtype=torch.float16, device='cuda')
-    key = torch.randn([B, H, Skv, D], dtype=torch.float16, device='cuda')
-    value = torch.randn([B, H, Skv, D], dtype=torch.float16, device='cuda')
-    sinks = torch.zeros([H], dtype=torch.float16, device='cuda')
+def gen_inputs(B, H, Sq, Skv, D,
+               dtype=torch.float16) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    query = torch.randn([B, H, Sq, D], dtype=dtype, device='cuda')
+    key = torch.randn([B, H, Skv, D], dtype=dtype, device='cuda')
+    value = torch.randn([B, H, Skv, D], dtype=dtype, device='cuda')
+    sinks = torch.randn([H], dtype=dtype, device='cuda')
     return query, key, value, sinks
 
 
@@ -246,7 +248,9 @@ def main(batch: int = 1,
          seq_kv: int = 256,
          dim: int = 128,
          window_size: int | None = None,
+         dtype: str = "float16",
          tune: bool = False):
+    torch_dtype = {"float16": torch.float16, "bfloat16": torch.bfloat16}[dtype]
     if window_size is not None:
         print('Using sliding window attention.')
         assert window_size <= seq_q
@@ -258,7 +262,7 @@ def main(batch: int = 1,
     total_flops = 2 * flops_per_matmul
 
     if tune:
-        kernel = flashattn(batch, heads, seq_q, seq_kv, dim, window_size)
+        kernel = flashattn(batch, heads, seq_q, seq_kv, dim, window_size, dtype=dtype)
         print(f"Best latency: {kernel.latency}")
         print(f"Best TFlops: {total_flops / kernel.latency * 1e-9}")
         print(f"Best config: {kernel.config}")
@@ -279,15 +283,20 @@ def main(batch: int = 1,
             block_M=block_M,
             block_N=block_N,
             num_stages=num_stages,
-            threads=threads)
+            threads=threads,
+            dtype=dtype)
 
-        Q, K, V, sinks = gen_inputs(batch, heads, seq_q, seq_kv, dim)
+        Q, K, V, sinks = gen_inputs(batch, heads, seq_q, seq_kv, dim, dtype=torch_dtype)
 
         torch.testing.assert_close(
-            kernel(Q, K, V, sinks), ref_program(Q, K, V, sinks, window_size), rtol=1e-2, atol=1e-2)
+            kernel(Q, K, V, sinks),
+            ref_program(Q, K, V, sinks, window_size, dtype=torch_dtype),
+            rtol=1e-2,
+            atol=1e-2)
         print("All checks passed.✅")
 
-        latency = do_bench(lambda: ref_program(Q, K, V, sinks, window_size), warmup=500)
+        latency = do_bench(lambda: ref_program(Q, K, V, sinks, window_size, dtype=torch_dtype),
+                           warmup=500)
         print("Ref: {:.2f} ms".format(latency))
         print("Ref: {:.2f} TFlops".format(total_flops / latency * 1e-9))
         latency = do_bench(lambda: kernel(Q, K, V, sinks), warmup=500)
@@ -307,6 +316,9 @@ if __name__ == "__main__":
         type=int,
         default=None,
         help='window size (default: None, which means full attention)')
+    
+    parser.add_argument('--dtype', type=str, default="float16", help="dtype, can be float16 or bfloat16")
     parser.add_argument('--tune', action='store_true', help='tune')
     args = parser.parse_args()
-    main(args.batch, args.heads, args.seq_q, args.seq_kv, args.dim, args.window_size, args.tune)
+    main(args.batch, args.heads, args.seq_q, args.seq_kv, args.dim, args.window_size, args.dtype,
+         args.tune)

--- a/examples/attention_sink/example_mha_sink_fwd_bhsd_wgmma_pipelined.py
+++ b/examples/attention_sink/example_mha_sink_fwd_bhsd_wgmma_pipelined.py
@@ -21,9 +21,9 @@ def get_configs():
 
 @autotune(configs=get_configs(), warmup=500, rep=100)
 @tilelang.jit(
-    out_idx=[3], pass_configs={
-        tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
-    })
+    out_idx=[3], 
+    pass_configs={tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,}, 
+    compile_flags=["--use_fast_math", "-O3", "-DENABLE_BF16"])
 def flashattn(
         batch,
         heads,
@@ -35,7 +35,8 @@ def flashattn(
         block_M=128,
         block_N=128,
         num_stages=2,
-        threads=256):
+        threads=256,
+        dtype: str = "float16"):
 
     if window_size is not None:
         assert window_size % block_N == 0, "window_size must be divisible by block_N"
@@ -46,7 +47,6 @@ def flashattn(
 
     q_shape = [batch, heads, seq_q, dim]
     kv_shape = [batch, heads, seq_kv, dim]
-    dtype = "float16"
     accum_dtype = "float"
 
     past_len = seq_kv - seq_q
@@ -202,7 +202,8 @@ def ref_program(query: torch.Tensor,
                 key: torch.Tensor,
                 value: torch.Tensor,
                 sinks: torch.Tensor,
-                sliding_window: int | None = None) -> torch.Tensor:
+                sliding_window: int | None = None,
+                dtype: torch.dtype = torch.float16) -> torch.Tensor:
 
     query = query.transpose(1, 2).contiguous().unsqueeze(
         3)  # align with the original function'sinterface
@@ -241,7 +242,7 @@ def ref_program(query: torch.Tensor,
     output = torch.einsum("bhmqk,bkhmd->bqhmd", scores, value.float())
 
     output = output.reshape(batch_size, num_queries, num_key_value_heads * num_key_value_groups,
-                            head_dim).to(torch.float16)
+                            head_dim).to(dtype)
     return output.transpose(1, 2).contiguous()
 
 
@@ -358,11 +359,12 @@ def triton_program(Q, K, V, Sinks, window_size: int | None = None) -> torch.Tens
     return o
 
 
-def gen_inputs(B, H, Sq, Skv, D) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    query = torch.randn([B, H, Sq, D], dtype=torch.float16, device='cuda')
-    key = torch.randn([B, H, Skv, D], dtype=torch.float16, device='cuda')
-    value = torch.randn([B, H, Skv, D], dtype=torch.float16, device='cuda')
-    sinks = torch.randn([H], dtype=torch.float16, device='cuda')
+def gen_inputs(B, H, Sq, Skv, D,
+               dtype=torch.float16) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    query = torch.randn([B, H, Sq, D], dtype=dtype, device='cuda')
+    key = torch.randn([B, H, Skv, D], dtype=dtype, device='cuda')
+    value = torch.randn([B, H, Skv, D], dtype=dtype, device='cuda')
+    sinks = torch.randn([H], dtype=dtype, device='cuda')
     return query, key, value, sinks
 
 
@@ -372,7 +374,9 @@ def main(batch: int = 1,
          seq_kv: int = 256,
          dim: int = 128,
          window_size: int | None = None,
+         dtype: str = "float16",
          tune: bool = False):
+    torch_dtype = {"float16": torch.float16, "bfloat16": torch.bfloat16}[dtype]
     if window_size is not None:
         print('Using sliding window attention.')
         assert window_size <= seq_q
@@ -384,7 +388,7 @@ def main(batch: int = 1,
     total_flops = 2 * flops_per_matmul
 
     if tune:
-        kernel = flashattn(batch, heads, seq_q, seq_kv, dim, window_size)
+        kernel = flashattn(batch, heads, seq_q, seq_kv, dim, window_size, dtype=dtype)
         print(f"Best latency: {kernel.latency}")
         print(f"Best TFlops: {total_flops / kernel.latency * 1e-9}")
         print(f"Best config: {kernel.config}")
@@ -405,17 +409,21 @@ def main(batch: int = 1,
             block_M=block_M,
             block_N=block_N,
             num_stages=num_stages,
-            threads=threads)
+            threads=threads,
+            dtype=dtype)
 
-        Q, K, V, sinks = gen_inputs(batch, heads, seq_q, seq_kv, dim)
+        Q, K, V, sinks = gen_inputs(batch, heads, seq_q, seq_kv, dim, dtype=torch_dtype)
 
         torch.testing.assert_close(
-            kernel(Q, K, V, sinks), ref_program(Q, K, V, sinks, window_size), rtol=1e-2, atol=1e-2)
+            kernel(Q, K, V, sinks),
+            ref_program(Q, K, V, sinks, window_size, dtype=torch_dtype),
+            rtol=1e-2,
+            atol=1e-2)
         print("All checks passed.✅")
 
         if torch.allclose(
                 triton_program(Q, K, V, sinks, window_size),
-                ref_program(Q, K, V, sinks, window_size),
+                ref_program(Q, K, V, sinks, window_size, dtype=torch_dtype),
                 rtol=1e-2,
                 atol=1e-2):
             print("Checks for triton passed.✅")
@@ -442,6 +450,8 @@ if __name__ == "__main__":
         type=int,
         default=None,
         help='window size (default: None, which means full attention)')
+    parser.add_argument('--dtype', type=str, default="float16", help="dtype, can be float16 or bfloat16")
     parser.add_argument('--tune', action='store_true', help='tune')
     args = parser.parse_args()
-    main(args.batch, args.heads, args.seq_q, args.seq_kv, args.dim, args.window_size, args.tune)
+    main(args.batch, args.heads, args.seq_q, args.seq_kv, args.dim, args.window_size, args.dtype,
+         args.tune)

--- a/examples/attention_sink/example_mha_sink_fwd_bhsd_wgmma_pipelined.py
+++ b/examples/attention_sink/example_mha_sink_fwd_bhsd_wgmma_pipelined.py
@@ -31,6 +31,7 @@ def flashattn(
         seq_kv,
         dim,
         window_size=None,  # None for full attention
+        sm_scale=None,
         block_M=128,
         block_N=128,
         num_stages=2,
@@ -39,7 +40,10 @@ def flashattn(
     if window_size is not None:
         assert window_size % block_N == 0, "window_size must be divisible by block_N"
 
-    scale = (1.0 / dim)**0.5 * 1.44269504  # log2(e)
+    if sm_scale is None:
+        sm_scale = (1.0 / dim)**0.5 
+    scale = sm_scale * 1.44269504  # log2(e)
+
     q_shape = [batch, heads, seq_q, dim]
     kv_shape = [batch, heads, seq_kv, dim]
     dtype = "float16"


### PR DESCRIPTION
This pull request introduces support for configurable data types (float16 and bfloat16) for attention kernels in the example scripts, improving flexibility and compatibility for different hardware and precision requirements. It also refactors kernel functions and input generation to accept a `dtype` parameter, ensures reference implementations use the correct precision, and adds command-line options for specifying data type. Additionally, minor improvements to kernel configuration and memory allocation are included.

**Data type configurability and propagation:**

* All major attention kernel functions (`flashattn_fwd`, `flashattn_bwd`, preprocess/postprocess functions, and input generators) now accept a `dtype` argument, defaulting to `"float16"`, allowing easy switching between float16 and bfloat16. [[1]](diffhunk://#diff-db525776a256adb13f20db00dca58b2e11e06aa4cb05249d0169239eb7f88a40L31-L44) [[2]](diffhunk://#diff-27cb387baf0234f57b5fc703135012800d09d1fb107ae3bab1ad0ab7b48cf3ecR40-L52) [[3]](diffhunk://#diff-ac3c24de02cae297e53f37a4c540d9860b32e5bafdeb1e781fa7d1e5b71f614cL22-L41)
* The main entry points and CLI interfaces for each example script are updated to accept and propagate the `dtype` parameter, including correct mapping to PyTorch types. [[1]](diffhunk://#diff-db525776a256adb13f20db00dca58b2e11e06aa4cb05249d0169239eb7f88a40L435-R441) [[2]](diffhunk://#diff-27cb387baf0234f57b5fc703135012800d09d1fb107ae3bab1ad0ab7b48cf3ecR390-R393) [[3]](diffhunk://#diff-27cb387baf0234f57b5fc703135012800d09d1fb107ae3bab1ad0ab7b48cf3ecR474-R478)

**Reference and test improvements:**

* Reference implementations (`ref_program`) and test assertions now use the specified `dtype` for outputs and comparisons, ensuring consistency between kernel and reference results. [[1]](diffhunk://#diff-db525776a256adb13f20db00dca58b2e11e06aa4cb05249d0169239eb7f88a40L426-R430) [[2]](diffhunk://#diff-27cb387baf0234f57b5fc703135012800d09d1fb107ae3bab1ad0ab7b48cf3ecL246-R252) [[3]](diffhunk://#diff-27cb387baf0234f57b5fc703135012800d09d1fb107ae3bab1ad0ab7b48cf3ecL418-R441)

**Kernel and memory allocation fixes:**

* Memory allocations for intermediate tensors (such as gradients and sinks) now use the correct `dtype`, matching the input precision. [[1]](diffhunk://#diff-db525776a256adb13f20db00dca58b2e11e06aa4cb05249d0169239eb7f88a40L447-R459) [[2]](diffhunk://#diff-db525776a256adb13f20db00dca58b2e11e06aa4cb05249d0169239eb7f88a40R362-R377) [[3]](diffhunk://#diff-27cb387baf0234f57b5fc703135012800d09d1fb107ae3bab1ad0ab7b48cf3ecL367-R378)
* In `example_mha_sink_bwd_bhsd.py`, sinks are allocated with `accum_dtype` instead of `dtype` for improved numerical stability.

**Kernel configuration and compilation:**

* Kernel compilation flags now include support for bfloat16 (`-DENABLE_BF16`) and fast math optimizations, ensuring kernels are built with appropriate precision support. [[1]](diffhunk://#diff-27cb387baf0234f57b5fc703135012800d09d1fb107ae3bab1ad0ab7b48cf3ecL28-R31) [[2]](diffhunk://#diff-ac3c24de02cae297e53f37a4c540d9860b32e5bafdeb1e781fa7d1e5b71f614cL22-L41)

**Miscellaneous improvements:**

* Minor code cleanups, such as removing commented code and disabling cache in `example_mha_sink_bwd_bhsd.py` for reproducibility. [[1]](diffhunk://#diff-ac3c24de02cae297e53f37a4c540d9860b32e5bafdeb1e781fa7d1e5b71f614cR9-R10) [[2]](diffhunk://#diff-ac3c24de02cae297e53f37a4c540d9860b32e5bafdeb1e781fa7d1e5b71f614cL55)