### PR TITLE
[Example] Optimize online_softmax example

### DIFF
--- a/examples/online_softmax/online_softmax.py
+++ b/examples/online_softmax/online_softmax.py
@@ -38,8 +38,7 @@ def softmax_kernel(
                 T.reduce_max(x, max_x, dim=0, clear=True)
 
                 for j in T.Parallel(BN):
-                    exp_x[j] = T.if_then_else(j + i_n * BN < N,
-                                              T.exp2(x[j] * scale - max_x[0] * scale), 0)
+                    exp_x[j] = T.exp2(x[j] * scale - max_x[0] * scale)
 
                 T.reduce_sum(exp_x, sum_exp_x, dim=0, clear=True)
 
@@ -49,9 +48,7 @@ def softmax_kernel(
                 T.copy(X[i_m, i_n * BN:(i_n + 1) * BN], x)
 
                 for j in T.Parallel(BN):
-
-                    if j + i_n * BN < N:
-                        y[j] = T.exp2(x[j] * scale - lse[0])
+                    y[j] = T.exp2(x[j] * scale - lse[0])
 
                 T.copy(y, Y[i_m, i_n * BN:(i_n + 1) * BN])
 


### PR DESCRIPTION
- Y should be output in float16.
- BN needs to be equal to N to be really online.
- On my H100 machine, this increase speedup from 1.424x to 2.788x.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Softmax now supports much larger input sizes (improved performance and stability on big tensors).
  * Simplified internal computation yields more consistent behavior across inputs.

* **Bug Fixes**
  * Softmax outputs now honor the configured dtype by default, removing the need for manual casting.
  * Improved numerical consistency for edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->