### PR TITLE
[Code Style] Refine nvrtc compile related check style

### DIFF
--- a/tilelang/contrib/nvcc.py
+++ b/tilelang/contrib/nvcc.py
@@ -4,6 +4,7 @@
 from __future__ import absolute_import as _abs
 
 import os
+import shutil
 import subprocess
 import warnings
 from typing import Tuple
@@ -14,6 +15,18 @@ from tvm.target import Target
 
 from tvm.base import py_str
 from tvm.contrib import utils
+
+
+def find_cuda_home():
+    """Find the CUDA install path."""
+    cuda_home = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")
+    if cuda_home is None:
+        nvcc_path = shutil.which("nvcc")
+        if nvcc_path is not None:
+            cuda_home = os.path.dirname(os.path.dirname(nvcc_path))
+        else:
+            cuda_home = "/usr/local/cuda"
+    return cuda_home
 
 
 def compile_cuda(code,

--- a/tilelang/contrib/nvcc.py
+++ b/tilelang/contrib/nvcc.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import as _abs
 
 import os
-import shutil
 import subprocess
 import warnings
 from typing import Tuple
@@ -15,18 +14,6 @@ from tvm.target import Target
 
 from tvm.base import py_str
 from tvm.contrib import utils
-
-
-def find_cuda_home():
-    """Find the CUDA install path."""
-    cuda_home = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH")
-    if cuda_home is None:
-        nvcc_path = shutil.which("nvcc")
-        if nvcc_path is not None:
-            cuda_home = os.path.dirname(os.path.dirname(nvcc_path))
-        else:
-            cuda_home = "/usr/local/cuda"
-    return cuda_home
 
 
 def compile_cuda(code,

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -20,7 +20,6 @@ from .utils import is_cpu_target, is_cuda_target, is_hip_target
 
 logger = logging.getLogger(__name__)
 
-# Import NVRTC availability check from centralized location
 try:
     from tilelang.jit.adapter.nvrtc import is_nvrtc_available
     if is_nvrtc_available:

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -11,7 +11,7 @@ from tvm.target import Target
 
 from tilelang import tvm as tvm
 from tilelang.transform import PassConfigKey
-from tilelang.contrib.nvcc import get_nvcc_compiler, get_target_arch, get_target_compute_version
+from tilelang.contrib.nvcc import find_cuda_home, get_nvcc_compiler, get_target_arch, get_target_compute_version
 from tilelang.contrib.rocm import find_rocm_path, get_rocm_arch
 from tilelang.env import TILELANG_TEMPLATE_PATH
 from tilelang.utils.deprecated import deprecated_warning
@@ -20,16 +20,14 @@ from .utils import is_cpu_target, is_cuda_target, is_hip_target
 
 logger = logging.getLogger(__name__)
 
-is_nvrtc_available = False
-NVRTC_UNAVAILABLE_WARNING = "cuda-python is not available, nvrtc backend cannot be used. " \
-                            "Please install cuda-python via `pip install cuda-python` " \
-                            "if you want to use the nvrtc backend."
+# Import NVRTC availability check from centralized location
 try:
-    import cuda.bindings.driver as cuda
-    from tilelang.contrib.nvrtc import compile_cuda
-    is_nvrtc_available = True
+    from tilelang.jit.adapter.nvrtc import is_nvrtc_available
+    if is_nvrtc_available:
+        import cuda.bindings.driver as cuda
+        from tilelang.contrib.nvrtc import compile_cuda
 except ImportError:
-    pass
+    is_nvrtc_available = False
 
 
 class LibraryGenerator(object):
@@ -194,7 +192,9 @@ class PyLibraryGenerator(LibraryGenerator):
 
     def __init__(self, target: Target, verbose: bool = False):
         if not is_nvrtc_available:
-            raise ImportError(NVRTC_UNAVAILABLE_WARNING)
+            raise ImportError("cuda-python is not available, nvrtc backend cannot be used. "
+                              "Please install cuda-python via `pip install cuda-python` "
+                              "if you want to use the nvrtc backend.")
         super().__init__(target, verbose)
 
     @staticmethod
@@ -243,7 +243,7 @@ class PyLibraryGenerator(LibraryGenerator):
             else:
                 tl_template_path = TILELANG_TEMPLATE_PATH
 
-            cuda_home = "/usr/local/cuda" if CUDA_HOME is None else CUDA_HOME
+            cuda_home = CUDA_HOME if CUDA_HOME is not None else find_cuda_home()
 
             options = [f"-I{tl_template_path}", f"-I{cutlass_path}", f"-I{cuda_home}/include"]
             if self.compile_flags:

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -11,7 +11,7 @@ from tvm.target import Target
 
 from tilelang import tvm as tvm
 from tilelang.transform import PassConfigKey
-from tilelang.contrib.nvcc import find_cuda_home, get_nvcc_compiler, get_target_arch, get_target_compute_version
+from tilelang.contrib.nvcc import get_nvcc_compiler, get_target_arch, get_target_compute_version
 from tilelang.contrib.rocm import find_rocm_path, get_rocm_arch
 from tilelang.env import TILELANG_TEMPLATE_PATH
 from tilelang.utils.deprecated import deprecated_warning
@@ -243,7 +243,7 @@ class PyLibraryGenerator(LibraryGenerator):
             else:
                 tl_template_path = TILELANG_TEMPLATE_PATH
 
-            cuda_home = CUDA_HOME if CUDA_HOME is not None else find_cuda_home()
+            cuda_home = CUDA_HOME if CUDA_HOME else "/usr/local/cuda"
 
             options = [f"-I{tl_template_path}", f"-I{cutlass_path}", f"-I{cuda_home}/include"]
             if self.compile_flags:

--- a/tilelang/jit/adapter/nvrtc/__init__.py
+++ b/tilelang/jit/adapter/nvrtc/__init__.py
@@ -1,1 +1,47 @@
-from .adapter import NVRTCKernelAdapter  # noqa: F401
+"""NVRTC Backend for TileLang.
+
+This module provides runtime compilation support using NVIDIA's NVRTC API.
+"""
+
+import logging
+
+__all__ = ['NVRTCKernelAdapter', 'is_nvrtc_available', 'check_nvrtc_available']
+
+logger = logging.getLogger(__name__)
+
+# Check if cuda-python is available
+is_nvrtc_available = False
+NVRTC_UNAVAILABLE_MESSAGE = ("cuda-python is not available, NVRTC backend cannot be used. "
+                             "Please install cuda-python via `pip install cuda-python` "
+                             "if you want to use the NVRTC backend.")
+
+try:
+    import cuda.bindings.driver as cuda  # noqa: F401
+    import cuda.bindings.nvrtc as nvrtc  # noqa: F401
+    is_nvrtc_available = True
+except ImportError as e:
+    logger.debug(f"cuda-python import failed: {e}")
+
+
+def check_nvrtc_available():
+    """Check if NVRTC backend is available.
+
+    Raises
+    ------
+    ImportError
+        If cuda-python is not installed or cannot be imported
+    """
+    if not is_nvrtc_available:
+        raise ImportError(NVRTC_UNAVAILABLE_MESSAGE)
+
+
+# Conditionally import the adapter
+if is_nvrtc_available:
+    from .adapter import NVRTCKernelAdapter  # noqa: F401
+else:
+    # Provide a dummy class that raises error on instantiation
+    class NVRTCKernelAdapter:
+        """Dummy NVRTCKernelAdapter that raises ImportError on instantiation."""
+
+        def __init__(self, *args, **kwargs):
+            raise ImportError(NVRTC_UNAVAILABLE_MESSAGE)


### PR DESCRIPTION
- [x] Centralized NVRTC availability checking into `tilelang/jit/adapter/nvrtc/__init__.py` to eliminate code duplication across multiple files and provide consistent error messaging
- [x] Replaced relative imports with absolute imports (e.g., `from tilelang.jit.adapter.base import` instead of `from ..base import`) for better code clarity and maintainability
-  [x] Added comprehensive type hints to key methods (`_process_dynamic_symbolic`, `get_kernel_source`, `_convert_torch_func`).