### PR TITLE
[Bugfix][Doc] Add astroid version constraint to requirements.txt

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,4 +10,4 @@ furo
 uvicorn
 myst-parser
 sphinx-autoapi == 3.6.0
-astroid
+astroid < 4


### PR DESCRIPTION
This pull request makes a minor update to the `docs/requirements.txt` file to restrict the version of the `astroid` dependency to versions less than 4 to avoid compatibility issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation build dependencies to add an upper version cap for a linting/parsing library, reducing the risk of future incompatibilities and ensuring more reliable documentation builds across environments.
  * No functional or API changes to the application; this is a maintenance update focused on stability of the docs toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->