### PR TITLE
[bug] fix type object is not subscriptable in py38

### DIFF
--- a/tilelang/jit/adapter/torch/metal.py
+++ b/tilelang/jit/adapter/torch/metal.py
@@ -1,5 +1,5 @@
 from functools import wraps
-from typing import Callable, Optional, Union
+from typing import Callable, Optional, Union, List
 
 import torch
 from tvm import tir
@@ -14,8 +14,8 @@ class MetalKernelAdapter(BaseKernelAdapter):
 
     def __init__(
         self,
-        params: list[KernelParam],
-        result_idx: list[int],
+        params: List[KernelParam],
+        result_idx: List[int],
         #  target: Union[str, Target],
         func_or_mod: Union[tir.PrimFunc, tvm.IRModule],
         #  host_mod: Optional[tvm.IRModule] = None,


### PR DESCRIPTION


```shell
docker run --gpus all -v /home/bbuf:/home/bbuf -it --rm --ipc=host nvcr.io/nvidia/pytorch:
23.01-py3

python3 /home/bbuf/tilelang/examples/elementwise/test_example_elementwise.py
Traceback (most recent call last):
  File "/home/bbuf/tilelang/examples/elementwise/test_example_elementwise.py", line 1, in <module>
    import tilelang.testing
  File "/home/bbuf/tilelang/tilelang/__init__.py", line 82, in <module>
    from .jit import jit, JITKernel, compile  # noqa: F401
  File "/home/bbuf/tilelang/tilelang/jit/__init__.py", line 19, in <module>
    from tilelang.jit.adapter.utils import is_metal_target
  File "/home/bbuf/tilelang/tilelang/jit/adapter/__init__.py", line 6, in <module>
    from .torch import MetalKernelAdapter  # noqa: F401
  File "/home/bbuf/tilelang/tilelang/jit/adapter/torch/__init__.py", line 1, in <module>
    from .metal import MetalKernelAdapter
  File "/home/bbuf/tilelang/tilelang/jit/adapter/torch/metal.py", line 13, in <module>
    class MetalKernelAdapter(BaseKernelAdapter):
  File "/home/bbuf/tilelang/tilelang/jit/adapter/torch/metal.py", line 17, in MetalKernelAdapter
    params: list[KernelParam],
TypeError: 'type' object is not subscriptable
root@5cf8a7876e56:/home/bbuf/tilelang# python3
Python 3.8.10 (default, Nov 14 2022, 12:59:47) 
[GCC 9.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> exit()
```

Py3.9+ support `list[KernelParam]` .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized public type annotations to use consistent generic types.
  * No changes to runtime behavior or performance.
  * No user-facing impact; functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->