### PR TITLE
[Doc] Install docs add docker install method

### DIFF
--- a/docs/get_started/Installation.md
+++ b/docs/get_started/Installation.md
@@ -68,15 +68,95 @@ If you want to install **tile-lang** in development mode, you can run the follow
 pip install -e .
 ```
 
-We currently provide three methods to install **tile-lang**:
+We currently provide four methods to install **tile-lang**:
 
-1. [Install from Source (using your own TVM installation)](#install-method-1)
-2. [Install from Source (using the bundled TVM submodule)](#install-method-2)
-3. [Install Using the Provided Script](#install-method-3)
+1. [Install Using Docker](#install-method-1) (Recommended)
+2. [Install from Source (using your own TVM installation)](#install-method-2)
+3. [Install from Source (using the bundled TVM submodule)](#install-method-3)
+4. [Install Using the Provided Script](#install-method-4)
 
 (install-method-1)=
 
-### Method 1: Install from Source (Using Your Own TVM Installation)
+### Method 1: Install Using Docker (Recommended)
+
+For users who prefer a containerized environment with all dependencies pre-configured, **tile-lang** provides Docker images for different CUDA versions. This method is particularly useful for ensuring consistent environments across different systems and is the **recommended approach** for most users.
+
+**Prerequisites:**
+- Docker installed on your system
+- NVIDIA Docker runtime (nvidia-docker2) for GPU support
+- Compatible NVIDIA GPU (e.g., B200, H100, etc.)
+
+1. **Clone the Repository**:
+
+```bash
+git clone --recursive https://github.com/tile-ai/tilelang
+cd tilelang
+```
+
+2. **Build Docker Image**:
+
+Navigate to the docker directory and build the image for your desired CUDA version:
+
+```bash
+cd docker
+docker build -f Dockerfile.cu120 -t tilelang-cu120 .
+```
+
+Available Dockerfiles:
+- `Dockerfile.cu120` - For CUDA 12.0
+- Other CUDA versions may be available in the docker directory
+
+3. **Run Docker Container**:
+
+Start the container with GPU access and volume mounting:
+
+```bash
+docker run -itd \
+  --shm-size 32g \
+  --gpus all \
+  -v /home/tilelang:/home/tilelang \
+  --name tilelang_b200 \
+  tilelang-cu120 \
+  /bin/zsh
+```
+
+**Command Parameters Explanation:**
+- `--shm-size 32g`: Increases shared memory size for better performance
+- `--gpus all`: Enables access to all available GPUs
+- `-v /home/tilelang:/home/tilelang`: Mounts host directory to container (adjust path as needed)
+- `--name tilelang_b200`: Assigns a name to the container for easy management
+- `/bin/zsh`: Uses zsh as the default shell
+
+4. **Access the Container**:
+
+```bash
+docker exec -it tilelang_b200 /bin/zsh
+```
+
+5. **Verify Installation**:
+
+Once inside the container, verify that **tile-lang** is working correctly:
+
+```bash
+python -c "import tilelang; print(tilelang.__version__)"
+```
+
+You can now run TileLang examples and develop your applications within the containerized environment. The Docker image comes with all necessary dependencies pre-installed, including CUDA toolkit, TVM, and TileLang itself.
+
+**Example Usage:**
+
+After accessing the container, you can run TileLang examples:
+
+```bash
+cd /home/tilelang/examples
+python elementwise/test_example_elementwise.py
+```
+
+This Docker-based installation method provides a complete, isolated environment that works seamlessly on systems with compatible NVIDIA GPUs like the B200, ensuring optimal performance for TileLang applications.
+
+(install-method-2)=
+
+### Method 2: Install from Source (Using Your Own TVM Installation)
 
 If you already have a compatible TVM installation, follow these steps:
 
@@ -110,9 +190,9 @@ export PYTHONPATH=/your/path/to/tilelang/:$PYTHONPATH
 export TVM_IMPORT_PYTHON_PATH=/your/path/to/tvm/python
 ```
 
-(install-method-2)=
+(install-method-3)=
 
-### Method 2: Install from Source (Using the Bundled TVM Submodule)
+### Method 3: Install from Source (Using the Bundled TVM Submodule)
 
 If you prefer to use the built-in TVM version, follow these instructions:
 
@@ -150,9 +230,9 @@ Ensure the `tile-lang` Python package is in your `PYTHONPATH`:
 export PYTHONPATH=/your/path/to/tilelang/:$PYTHONPATH
 ```
 
-(install-method-3)=
+(install-method-4)=
 
-### Method 3: Install Using the Provided Script
+### Method 4: Install Using the Provided Script
 
 For a simplified installation, use the provided script:
 


### PR DESCRIPTION
I encountered multiple issues when building TileLang from source on B200 using the tutorial. For instance, the PyTorch version in the default Docker environment doesn't support the sm100 architecture, requiring manual creation of a miniconda environment to upgrade PyTorch and install all dependencies before compiling TVM/TileLang. This process essentially equals building Docker using TileLang's provided Dockerfile. The Docker build approach is much more convenient and streamlined, completing the entire environment setup without any extra compilation overhead. Therefore, I've added a new installation method that allows users to easily set up a clean TileLang development environment on any GPU.

<img width="1005" height="601" alt="图片" src="https://github.com/user-attachments/assets/a4b5a48e-2567-4b07-9868-e4e878a864bb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a recommended Docker-based installation path with prerequisites, step-by-step build/run/verify instructions and command examples.
  * Renumbered installation methods: Source install is now Method 2, Bundled TVM Submodule is Method 3, and Provided Script is Method 4.
  * Updated headings, anchors, and cross-references to reflect the new order.
  * Expanded and clarified instructions across methods to streamline setup and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->