### PR TITLE
[Refactor] Use `has_simt_copy` to decide whether to insert `set_max_nreg`

### DIFF
--- a/examples/deepseek_v32/fp8_lighting_indexer.py
+++ b/examples/deepseek_v32/fp8_lighting_indexer.py
@@ -136,8 +136,6 @@ def mqa_attn_return_logits(
             cu_k_s_min = T.alloc_local([1], index_dtype)
             cu_k_e_max = T.alloc_local([1], index_dtype)
 
-            T.no_set_max_nreg()
-
             cu_k_s_min[0] = 2147483647
             cu_k_e_max[0] = -2147483648
 

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -135,7 +135,6 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
         mod = tilelang.transform.MultiVersionBuffer()(mod)
         mod = tilelang.transform.WarpSpecialized()(mod)
         mod = tilelang.transform.InjectTmaBarrier()(mod)
-        mod = tilelang.transform.AnnotateWarpGroupRegAlloc()(mod)
         # if tma is not enabled, we can also do pipeline planning
         # to get better performance with async copy
         mod = tilelang.transform.PipelinePlanning()(mod)
@@ -206,6 +205,8 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
     # Inject PTX async copy must behind the thread sync pass
     # as ptx async copy won't be recognized as a valid buffer load
     mod = tilelang.transform.InjectPTXAsyncCopy()(mod)
+    if allow_tma_and_warp_specialized(pass_ctx=pass_ctx, target=target):
+        mod = tilelang.transform.AnnotateWarpGroupRegAlloc()(mod)
     mod = tilelang.transform.MakePackedAPI()(mod)
     mod = tilelang.transform.LowerDeviceKernelLaunch()(mod)
 


### PR DESCRIPTION
This pull request introduces improvements to register allocation annotation and its integration with target-specific optimization passes. The main changes include adding SIMT copy detection to avoid incorrect register allocation and adjusting when the `AnnotateWarpGroupRegAlloc` pass is applied in the optimization pipeline.

**Enhancements to register allocation annotation:**

* Added a new `SimtCopyDetector` class in `annotate_warp_group_reg_alloc.cc` to detect the presence of SIMT copy operations and prevent register allocation annotation when such operations are present.
* Updated the injection logic in `SetMaxNRegInjector` to use the new SIMT copy detection, ensuring register allocation is only annotated when safe.

**Optimization pipeline adjustments:**

* Moved the application of `AnnotateWarpGroupRegAlloc` in `phase.py` to after `InjectPTXAsyncCopy`, and now only apply it if TMA and warp specialization are enabled for the target. [[1]](diffhunk://#diff-d0919e6c22b4d85ff6c5a0a9f34b53bc9415d8c61dc84e9993841b10d14e44a5L138) [[2]](diffhunk://#diff-d0919e6c22b4d85ff6c5a0a9f34b53bc9415d8c61dc84e9993841b10d14e44a5R207-R208)

**Code cleanup:**

* Removed a call to `T.no_set_max_nreg()` in `fp8_lighting_indexer.py` as part of simplifying the kernel setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented over-aggressive register annotations by applying them only when TMA and warp specialization are enabled, reducing risk of performance regressions.
  * Updated an example kernel to rely on default register handling, improving stability across environments.

* **Refactor**
  * Improved detection of specialized memory copies to more accurately gate register optimization hints, leading to more predictable performance without changing user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->