### PR TITLE
[BugFix] fix torch MPS  check

### DIFF
--- a/tilelang/utils/device.py
+++ b/tilelang/utils/device.py
@@ -1,7 +1,7 @@
 import torch
 
 IS_CUDA = torch.cuda.is_available()
-IS_MPS = torch.mps.is_available()
+IS_MPS = torch.backends.mps.is_available()
 
 
 def get_current_device():


### PR DESCRIPTION
I discovered that in PyTorch versions below 2.4, there's no torch.mps.is_available() interface, only torch.backends.mps.is_available(). To support older PyTorch versions, we need to modify this interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of Apple Metal (MPS) support on macOS, resulting in more reliable automatic device selection. This reduces incorrect CPU/GPU fallbacks and applies MPS-specific behavior only when supported, improving stability and reducing errors for users with compatible hardware. CUDA and CPU behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->