### PR TITLE
[CI] Disable buggy(maybe) warp specialized kernel ci test for H20

### DIFF
--- a/examples/warp_specialize/test_example_warp_specialize.py
+++ b/examples/warp_specialize/test_example_warp_specialize.py
@@ -1,16 +1,17 @@
 import tilelang.testing
 
-import example_warp_specialize_flashmla
 import example_warp_specialize_gemm_barrierpipe_stage2
 import example_warp_specialize_gemm_copy_0_gemm_1
 import example_warp_specialize_gemm_copy_1_gemm_0
 import example_warp_specialize_gemm_softpipe_stage2
 
-
-@tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
-def test_example_warp_specialize_flashmla():
-    example_warp_specialize_flashmla.main()
+# TODO: skip for now as non-deterministic on H20
+# CC @cunxiao
+# @tilelang.testing.requires_cuda
+# @tilelang.testing.requires_cuda_compute_version_eq(9, 0)
+# def test_example_warp_specialize_flashmla():
+#     import example_warp_specialize_flashmla
+#     example_warp_specialize_flashmla.main()
 
 
 @tilelang.testing.requires_cuda


### PR DESCRIPTION
@Cunxiao2002 will take a look for this case on H20.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Temporarily disabled one example test pending follow-up, retaining the structure as commented code with a TODO for future re-enablement.
  * All other example tests remain active and unchanged, including existing version guards.
  * Improves test suite stability without affecting runtime features or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->