### PR TITLE
Allow mma gemm for all cuda arch

### DIFF
--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -194,9 +194,7 @@ GemmInst GemmNode::GetGemmInst(int block_size, Target target) const {
     return GemmInst::kWGMMA;
   } else if (TargetIsCDNA(target)) {
     return GemmInst::kMFMA;
-  } else if (TargetIsVolta(target) || TargetIsAmpere(target) ||
-             TargetIsTuring(target) || TargetIsHopper(target) ||
-             TargetIsSm100(target)) {
+  } else if (TargetIsCuda(target)) {
     return GemmInst::kMMA;
   } else {
     ICHECK(0) << "Unsupported target for gemm: " << target->str();


### PR DESCRIPTION
Closes #985 (hopefully, not tested)

Add back sm120 support for mma gemm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified GPU backend selection, unifying handling of CUDA targets. This ensures the optimized compute path is chosen more consistently when advanced options are not applicable.
* **Bug Fixes**
  * Resolved inconsistent behavior across CUDA architectures that could prevent the optimized path from being used, improving reliability.
* **Notes**
  * No changes to public interfaces.
  * Users may see improved performance and compatibility on a wider range of CUDA-enabled GPUs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->