### PR TITLE
[Bugfix] Improves compatibility when checking for MPS availability in different PyTorch builds.

### DIFF
--- a/tilelang/utils/device.py
+++ b/tilelang/utils/device.py
@@ -1,7 +1,14 @@
 import torch
 
 IS_CUDA = torch.cuda.is_available()
-IS_MPS = torch.mps.is_available()
+
+IS_MPS = False
+try:
+    IS_MPS = torch.backends.mps.is_available()
+except AttributeError:
+    print("MPS backend is not available in this PyTorch build.")
+except Exception as e:
+    print(f"An unexpected error occurred while checking MPS availability: {e}")
 
 
 def get_current_device():


### PR DESCRIPTION
This pull request updates the logic for detecting MPS (Apple Silicon GPU) support in the `tilelang/utils/device.py` utility. The change improves compatibility and error handling when checking for MPS availability in different PyTorch builds.

Device detection improvements:

* Changed MPS availability check to use `torch.backends.mps.is_available()` instead of `torch.mps.is_available()`, and added error handling to gracefully handle missing attributes or other exceptions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device compatibility by adding robust error handling for MPS backend availability checks. The application now gracefully handles PyTorch builds without MPS support and provides informative messages when the backend is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->