### PR TITLE
[CI] Disable autofix for pre-commit CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 ci:
-  autofix_prs: true
+  autofix_prs: false
   autofix_commit_msg: "[Lint]: [pre-commit.ci] auto fixes [...]"
   autoupdate_commit_msg: "[CI] [pre-commit.ci] autoupdate"
   autoupdate_schedule: monthly


### PR DESCRIPTION
This pull request makes a minor configuration update to the `.pre-commit-config.yaml` file, disabling automatic creation of autofix pull requests by the pre-commit CI system.

* Disabled automatic autofix pull requests by setting `autofix_prs` to `false` in `.pre-commit-config.yaml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic PR autofixes from pre-commit configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->