### PR TITLE
[Misc] Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,112 @@
+name: 🐛 Bug Report
+description: File an issue about a bug.
+title: "[BUG] "
+labels: [bug]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        Please do your best to make the issue as easy to act on as possible,
+        and only submit here if there is clearly a problem with TileLang.
+
+  - type: checkboxes
+    id: steps
+    attributes:
+      label: Required prerequisites
+      description: Make sure you've completed the following steps before submitting your issue -- thank you!
+      options:
+        - label: I have read the documentation <https://tilelang.com>.
+          required: true
+        - label: >-
+            I have searched the [Issue Tracker](https://github.com/tile-ai/tilelang/issues)
+            that this hasn't already been reported. (comment there if it has.)
+          required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: What version of TileLang are you using?
+      description: >-
+        Run command `python3 -c 'print(__import__("tilelang").__version__)'` in your shell
+        and paste the output here.
+      placeholder: E.g., 0.1.5
+    validations:
+      required: true
+
+  - type: textarea
+    id: system-info
+    attributes:
+      label: System information
+      description: |
+        Describe the characteristic of your environment:
+
+        - Describe how the library was installed (pip, conda, source, ...)
+        - Python version
+        - Versions of any other relevant libraries
+
+        ```python
+        import sys, tilelang, torch
+        print(sys.version, sys.platform)
+        print(tilelang.__version__)
+        print(torch.__version__)
+        ```
+
+        ```bash
+        python3 -m torch.utils.collect_env
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Problem description
+      description: >-
+        Provide a short description, state the expected behavior and what actually happens. Include
+        relevant information like what version of TileLang you are using, what system you are on, and
+        any useful commands / output.
+    validations:
+      required: true
+
+  - type: textarea
+    id: code
+    attributes:
+      label: Reproducible example code
+      description: >-
+        The code should be minimal, have minimal external dependencies, and isolate the functions
+        that cause breakage. Submit matched and complete snippets that can be easily run to diagnose
+        the issue.
+      value: |
+        The Python snippets:
+
+        ```python
+
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: traceback
+    attributes:
+      label: Traceback
+      description: Put the Python traceback information here.
+      placeholder: |
+        Traceback (most recent call last):
+          File ...
+      render: pytb
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Provide a clear and concise description of what you expected to happen.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: >-
+        Add any other context about the problem here. Screenshots may also be helpful.
+
+        If you know or suspect the reason for this bug, paste the code lines and suggest modifications.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,45 @@
+name: ✨ Feature Request
+description: Suggest an idea for this project.
+title: "[Feature Request] "
+labels: [enhancement]
+body:
+  - type: checkboxes
+    id: steps
+    attributes:
+      label: Required prerequisites
+      description: Make sure you've completed the following steps before submitting your issue -- thank you!
+      options:
+        - label: >-
+            I have searched the [Issue Tracker](https://github.com/tile-ai/tilelang/issues)
+            that this hasn't already been reported. (comment there if it has.)
+          required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Outline the motivation for the proposal.
+      value: |
+        <!-- Please outline the motivation for the proposal.
+        Is your feature request related to a problem? E.g., "I'm always frustrated when [...]".
+        If this is related to another issue, please link here too. -->
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Solution
+      description: Provide a clear and concise description of what you want to happen.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives
+      description: A clear and concise description of any alternative solutions or features you've considered.
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context about the problem here. Screenshots may also be helpful.

--- a/.github/ISSUE_TEMPLATE/questions.yml
+++ b/.github/ISSUE_TEMPLATE/questions.yml
@@ -1,0 +1,25 @@
+name: 🤔 Questions / Help / Support
+description: Do you need support?
+title: "[Question] "
+labels: [question]
+body:
+  - type: checkboxes
+    id: steps
+    attributes:
+      label: Required prerequisites
+      description: Make sure you've completed the following steps before submitting your issue -- thank you!
+      options:
+        - label: I have read the documentation <https://tilelang.com>.
+          required: true
+        - label: >-
+            I have searched the [Issue Tracker](https://github.com/tile-ai/tilelang/issues)
+            that this hasn't already been reported. (comment there if it has.)
+          required: true
+
+  - type: textarea
+    id: questions
+    attributes:
+      label: Questions
+      description: Describe your questions with relevant resources such as snippets, links, images, etc.
+    validations:
+      required: true


### PR DESCRIPTION
Add `bug-report`, `feature-request`, and `questions` issue template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added structured GitHub issue templates for bug reports, feature requests, and support questions to streamline issue submissions.
  * Disabled blank issue creation to encourage users to follow the provided templates and provide consistent information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->