### PR TITLE
Making version parser more robust against missing or unavailable metadata

### DIFF
--- a/tilelang/__init__.py
+++ b/tilelang/__init__.py
@@ -3,11 +3,25 @@ import os
 import ctypes
 
 import logging
+import warnings
 from tqdm import tqdm
 
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
-__version__ = version('tilelang')
+try:
+    __version__ = version('tilelang')
+except PackageNotFoundError:
+    try:
+        from version_provider import dynamic_metadata
+
+        __version__ = dynamic_metadata('version')
+    except Exception as exc:
+        warnings.warn(
+            f"tilelang version metadata unavailable ({exc!r}); using development version.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        __version__ = "0.0.dev0"
 
 
 class TqdmLoggingHandler(logging.Handler):


### PR DESCRIPTION
This pull request updates the way the `tilelang` package determines its version, making it more robust against missing or unavailable metadata. The main change is the addition of a fallback mechanism that attempts to retrieve version information from an alternative provider, and if that fails, sets a default development version while issuing a warning.

Version handling improvements:

* Added a fallback to retrieve the package version using `dynamic_metadata` from `version_provider` if the standard metadata is not found, and emits a warning with a default value if all attempts fail. (`tilelang/__init__.py`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced version detection with improved error handling for cases where package metadata is unavailable. Users will receive a warning and the application will continue operating with a development version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->