### PR TITLE
[DOC] Add document for develop with PYTHONPATH

### DIFF
--- a/docs/get_started/Installation.md
+++ b/docs/get_started/Installation.md
@@ -65,6 +65,26 @@ If you want to install **tile-lang** in development mode, you can run the follow
 pip install -e . -v
 ```
 
+If you prefer to work directly from the source tree via `PYTHONPATH`, make sure the native extension is built first:
+
+```bash
+mkdir -p build
+cd build
+cmake .. -DUSE_CUDA=ON
+make -j
+```
+Then add the repository root to `PYTHONPATH` before importing `tilelang`, for example:
+
+```bash
+export PYTHONPATH=/path/to/tilelang:$PYTHONPATH
+python -c "import tilelang; print(tilelang.__version__)"
+```
+
+Some useful CMake options you can toggle while configuring:
+- `-DUSE_CUDA=ON|OFF` builds against NVIDIA CUDA (default ON when CUDA headers are found).
+- `-DUSE_ROCM=ON` selects ROCm support when building on AMD GPUs.
+- `-DNO_VERSION_LABEL=ON` disables the backend/git suffix in `tilelang.__version__`.
+
 We currently provide four methods to install **tile-lang**:
 
 1. [Install Using Docker](#install-method-1) (Recommended)


### PR DESCRIPTION
This pull request updates the installation documentation for `tile-lang` to clarify how to work directly from the source tree using `PYTHONPATH`, and provides detailed instructions for building the native extension manually. It also lists useful CMake configuration options for customizing the build.

Documentation improvements for development installation:

* Added instructions on building the native extension with `cmake` and `make` before using `PYTHONPATH` to work from the source tree.
* Documented several CMake options (`USE_CUDA`, `USE_ROCM`, `NO_VERSION_LABEL`) for customizing the build process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide with build-from-source instructions using PYTHONPATH and native extension building steps via cmake and make.
  * Documented CMake feature toggles for CUDA, ROCM, and version labeling support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->