### PR TITLE
[Layout] Utilizing IsEqual instead of StructuralEqual

### DIFF
--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -159,7 +159,7 @@ public:
           }
         }
         // If already in map, ensure they are structurally equal
-        ICHECK(StructuralEqual()(layout, layout_map[buffer]))
+        ICHECK(layout->IsEqual(layout_map[buffer].get()))
             << "Get different layout for " << buffer
             << "\n current layout: " << layout->DebugOutput()
             << "\n previous layout: " << layout_map[buffer]->DebugOutput();


### PR DESCRIPTION
This pull request updates the way buffer layout equality is checked in the `BufferUseDefCollector` class within `src/transform/layout_inference.cc`. The change replaces the use of the general `StructuralEqual` function with the more specific `IsEqual` method for layout comparison.

Improvement to layout comparison logic:

* Changed buffer layout equality check from using `StructuralEqual()` to the more precise `layout->IsEqual()` method in the `BufferUseDefCollector` class, ensuring that layout objects are compared using their specialized equality logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved buffer layout validation accuracy during runtime checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->