### PR TITLE
[Autotune] Add autotune coverage for symbolic M and normalize cache key

### DIFF
--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -231,6 +231,16 @@ class AutoTuner:
     def generate_cache_key(self, parameters: Dict[str, Any]) -> Optional[AutotuneResult]:
         """Generate a cache key for the auto-tuning process.
         """
+
+        def _normalize_param(value):
+            if isinstance(value, Var):
+                return str(value)
+            if isinstance(value, (list, tuple)):
+                return [_normalize_param(v) for v in value]
+            if isinstance(value, dict):
+                return {str(k): _normalize_param(v) for k, v in value.items()}
+            return value
+
         # extract parameters from the function signature
         op_parameters = []
         for _, default_value in parameters.items():
@@ -238,7 +248,7 @@ class AutoTuner:
                 op_parameters.append(default_value.default)
 
         if self._kernel_parameters is not None:
-            op_parameters += self._kernel_parameters
+            op_parameters += _normalize_param(self._kernel_parameters)
 
         func_source = inspect.getsource(self.fn)
         key_data = {


### PR DESCRIPTION
This pull request adds better support for symbolic (dynamic) dimensions in the autotuning tests and improves the handling of symbolic parameters when generating cache keys for autotuning. The main changes include updating the test harness to allow passing concrete values for symbolic dimensions and normalizing symbolic variables in cache key generation to ensure correct behavior.

**Testing improvements:**
* Updated `run_autotune` in `test_tilelang_autotune_with_inputs.py` to accept optional concrete values for symbolic dimensions and resolve them at runtime. This allows tests to specify actual sizes for symbolic variables.
* Added a new test, `test_autotune_matmul_symbolic_m`, to verify autotuning works with a symbolic `M` dimension by providing a concrete value.

**Autotuner robustness:**
* In `tuner.py`, added normalization of symbolic variables (`Var`) and nested structures when generating the autotune cache key, ensuring that symbolic parameters are consistently and correctly represented in the cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for symbolic tensor dimensions in autotuning tests, enabling tests with parameterized matrix shapes alongside fixed dimensions.

* **Tests**
  * New test case for autotuning with symbolic tensor dimensions.

* **Improvements**
  * Enhanced autotune cache key generation with normalized parameter handling for consistent, deterministic caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->