### PR TITLE
[Cache] raise errors for `tileang.clear_cache()`

### DIFF
--- a/tilelang/cache/__init__.py
+++ b/tilelang/cache/__init__.py
@@ -39,9 +39,15 @@ def cached(
 
 def clear_cache():
     """
-    Clears the entire kernel cache (using KernelCache class).
+    Disabled helper that previously removed the entire kernel cache.
+
+    Raises:
+        RuntimeError: Always raised to warn users to clear the cache manually.
     """
-    _kernel_cache_instance.clear_cache()
+    cache_dir = env.TILELANG_CACHE_DIR
+    raise RuntimeError("tilelang.clear_cache() is disabled because deleting the cache directory "
+                       "is dangerous. If you accept the risk, remove it manually with "
+                       f"`rm -rf '{cache_dir}'`.")
 
 
 if env.TILELANG_CLEAR_CACHE.lower() in ("1", "true", "yes", "on"):


### PR DESCRIPTION
This pull request makes a significant change to the cache management in the `tilelang` package by disabling the `clear_cache()` helper function. Instead of allowing programmatic cache clearing, the function now raises an error and instructs users to manually delete the cache directory if necessary. This change is intended to prevent accidental or unsafe deletion of cached data.

Cache management changes:

* Disabled the `clear_cache()` function in `tilelang/cache/__init__.py` by making it always raise a `RuntimeError` with a message instructing users to manually delete the cache directory if they accept the risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The cache clearing functionality is now disabled. Users must manually remove the cache directory instead. Guidance on performing manual cache deletion via shell command has been added to help users with this process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->