### PR TITLE
[Bugfix] Fix missing reg alloc in custom warp specialization

### DIFF
--- a/src/transform/annotate_warp_group_reg_alloc.cc
+++ b/src/transform/annotate_warp_group_reg_alloc.cc
@@ -95,8 +95,7 @@ public:
 private:
   Stmt VisitStmt_(const EvaluateNode *op) final {
     if (const CallNode *call = op->value.as<CallNode>()) {
-      if (call->op.same_as(set_max_nreg()) ||
-          call->op.same_as(no_set_max_nreg())) {
+      if (call->op.same_as(no_set_max_nreg())) {
         // Remove the original set_max_nreg calls as they will be re-inserted
         // at appropriate locations
         return Evaluate(0);
@@ -136,11 +135,9 @@ private:
       // Only inject if we have valid register hints and no SIMT copy
       bool has_simt_copy = SimtCopyDetector::Detect(producer_body);
 
-      if (dec_reg >= 0 && inc_reg >= 0 && !has_simt_copy) {
-        auto inc_reg_num =
-            IntImm(DataType::Int(32), inc_reg == 0 ? 240 : inc_reg);
-        auto dec_reg_num =
-            IntImm(DataType::Int(32), dec_reg == 0 ? 24 : dec_reg);
+      if (dec_reg == 0 && inc_reg == 0 && !has_simt_copy) {
+        auto inc_reg_num = IntImm(DataType::Int(32), 240);
+        auto dec_reg_num = IntImm(DataType::Int(32), 24);
         inc_reg_stmt = Evaluate(
             Call(DataType::Handle(), set_max_nreg(), {inc_reg_num, 1}));
         dec_reg_stmt = Evaluate(


### PR DESCRIPTION
This pull request makes targeted changes to the `SetMaxNRegInjector` logic in `annotate_warp_group_reg_alloc.cc`, refining how register allocation annotations are handled. The main focus is to adjust when and how `set_max_nreg` calls are injected and removed, specifically tightening the conditions under which register hints are applied.

**Refinements to register allocation annotation:**

* The check for removing `set_max_nreg` calls in `VisitStmt_` is now limited to only `no_set_max_nreg`, meaning original `set_max_nreg` calls are no longer removed at this stage.

* The logic for injecting register hints has changed: register hints are now only injected if both `dec_reg` and `inc_reg` are exactly zero and there is no SIMT copy detected, simplifying and restricting the conditions for annotation. The register numbers are now hardcoded to 240 and 24 for `inc_reg` and `dec_reg` respectively.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization adjustments to register allocation handling. No user-visible changes or new features introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->