### PR TITLE
[Bugfix] Fix missing host `cuTensorMapEncodeIm2col` call

### DIFF
--- a/examples/convolution/example_convolution.py
+++ b/examples/convolution/example_convolution.py
@@ -122,6 +122,7 @@ def main(argv=None):
     out_c = kernel(a, b)
     ref_c = ref_program(S, P, D)(a, b)
     torch.testing.assert_close(out_c, ref_c, rtol=1e-2, atol=1e-2)
+    print("All checks passed.✅")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request introduces support for TMA Im2Col descriptor initialization and ensures that all relevant code paths and IR transformations handle the new `tma_load_im2col` operation. Additionally, it improves user feedback in the convolution example.

Support for TMA Im2Col descriptors:

* Added the `TMA_IM2COL_DESC_INIT_FUNC` string template for initializing TMA Im2Col descriptors in `tilelang/jit/adapter/wrapper.py`.
* Updated the descriptor argument generation logic in `generate_tma_descriptor_args` to correctly parse and initialize Im2Col descriptors, including validation and extraction of Im2Col-specific parameters. [[1]](diffhunk://#diff-11632097304818e018a5c33430f70f6e9c98af09b886c20cca8dc41051633298L404-R444) [[2]](diffhunk://#diff-11632097304818e018a5c33430f70f6e9c98af09b886c20cca8dc41051633298L442-R518)

IR and transformation updates for Im2Col:

* Modified IR mutators and visitors in `src/transform/inject_tma_barrier.cc` to recognize and handle both `tma_load` and `tma_load_im2col` operations, ensuring correct barrier injection and rewriting. [[1]](diffhunk://#diff-fa1991af89fd329958133527bacae9cca5e17c126b7e9e8d0f994e0be64e3bddL166-R166) [[2]](diffhunk://#diff-fa1991af89fd329958133527bacae9cca5e17c126b7e9e8d0f994e0be64e3bddL206-R206) [[3]](diffhunk://#diff-fa1991af89fd329958133527bacae9cca5e17c126b7e9e8d0f994e0be64e3bddL454-R463)

User experience improvement:

* Added a print statement to the convolution example to notify users when all checks have passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for IM2COL tensor operations with enhanced TMA descriptor initialization for memory access patterns.

* **Improvements**
  * Example scripts now display clear success confirmation messages upon passing validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->