### PR TITLE
[Refactor] Optimize debug message for parallel inference

### DIFF
--- a/src/layout/utils.cc
+++ b/src/layout/utils.cc
@@ -93,7 +93,9 @@ Array<IterSplitExpr> get_unused_iters(const IterMark &mark,
     if (j == splits.size()) {
       ICHECK(lowest != splits.size());
       ICHECK(CanProveDivisible(splits[lowest]->lower_factor,
-                               expected_lower_factor));
+                               expected_lower_factor))
+          << " Cannot prove divisible for " << splits[lowest]->lower_factor
+          << " and " << expected_lower_factor;
       results.emplace_back(
           mark, expected_lower_factor,
           FloorDiv(splits[lowest]->lower_factor, expected_lower_factor), 1);


### PR DESCRIPTION
This pull request improves error handling and debugging in the layout inference logic, making it easier to diagnose issues when layout inference fails during parallel operations. The most important changes are:

**Error reporting improvements:**

* Enhanced the error message in `get_unused_iters` (in `utils.cc`) to include details about the operands when divisibility cannot be proven, aiding in debugging layout-related issues.

* Wrapped the layout inference logic in `ParallelOpNode::InferLayout` (in `parallel.cc`) with a try-catch block to catch TVM runtime errors. The new error message provides context about the failed buffer, the underlying TVM error, the problematic loop AST, and a hint for resolving the issue, before logging a fatal error.

Now:

```python
for i in T.Parallel(16):
     A_fragment[i, i] = A_fragment[i, i] + 1.0
```

will throw errs with it's for stmt:

```bash
InternalError: Check failed: (CanProveDivisible(splits[lowest]->lower_factor, expected_lower_factor)) is false:  Cannot prove divisible for 2 and 16

  Problematic loop AST:
 for i in T.parallel(16):
    A_fragment = T.Buffer((16, 16), "bfloat16", scope="local.fragment")
    A_fragment[i, i] = T.Cast("bfloat16", T.Cast("float32", A_fragment[i, i]) + T.float32(1.0))
Hint: ensure the loop extent divides the thread binding or adjust the fragment mapping.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting with more detailed diagnostic messages when parallel computation operations encounter issues, providing clearer information for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->