### PR TITLE
[Bugfix] Correctly construct the argument list for atomic add based on the vector size

### DIFF
--- a/src/transform/atomicadd_vectorize.cc
+++ b/src/transform/atomicadd_vectorize.cc
@@ -231,11 +231,6 @@ private:
       // Ref: src/tl_templates/cuda/atomic.h::AtomicAdd
       const IntImm memory_order =
           node->args.size() >= 3 ? Downcast<IntImm>(node->args[2]) : IntImm(0);
-
-      Call address_of_dst =
-          Call(DataType::Handle(), builtin::address_of(), {dst_node});
-      Call address_of_value =
-          Call(DataType::Handle(), builtin::address_of(), {value_node});
       Array<PrimExpr> new_args;
       Call address_of_dst =
           Call(DataType::Handle(), builtin::address_of(), {dst_node});
@@ -254,6 +249,7 @@ private:
         new_args.push_back(dst_node);
         new_args.push_back(value_node);
       }
+
       new_args.push_back(memory_order);
 
       Call new_call =


### PR DESCRIPTION
This pull request updates the argument handling logic in the `AtomicAddVectorizeRewriter` class to correctly construct the argument list for atomic add operations based on the vector size. The main change ensures that the correct arguments are passed for vectorized and non-vectorized atomic add calls.

Atomic add argument handling improvements:

* The construction of `new_args` now pushes `address_of_dst` and `address_of_value` only for vector sizes 2 and 4, while for the scalar case, it pushes `dst_node` and `value_node` directly. This ensures that the argument list matches the expected function signature for each case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed atomic addition vectorization to prevent duplicate argument emissions during compilation, improving code generation accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->