### PR TITLE
[EXAMPLE] In the flash attention example keep the max of all blocks seen in scores_max numerical stability

### DIFF
--- a/examples/flash_attention/example_mha_fwd_bhsd.py
+++ b/examples/flash_attention/example_mha_fwd_bhsd.py
@@ -87,7 +87,7 @@ def flashattn(batch,
 
         for i in T.Parallel(block_M):
             scores_max[i] = T.max(scores_max[i], scores_max_prev[i])
-        
+
         # To do causal softmax, we need to set the scores_max to 0 if it is -inf
         # This process is called Check_inf in FlashAttention3 code, and it only need to be done
         # in the first ceil_div(kBlockM, kBlockN) steps.


### PR DESCRIPTION
In the flash attention example, keep the max of previous scores_max and max(acc_s) in scores_max for numerical stability

From [Flash Attention 2 paper](https://arxiv.org/pdf/2205.14135), Algorithm 1

$$m_i^{\text{new}} = \max(m_i, \tilde{m}_{ij})$$

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Adjusted per-row maximum tracking in the Flash Attention example's Softmax flow to incorporate previous-row maxima when computing each row's max.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->