### PR TITLE
[Bugfix] Fix tvm import path for editable build

### DIFF
--- a/testing/python/language/test_tilelang_language_let.py
+++ b/testing/python/language/test_tilelang_language_let.py
@@ -16,7 +16,7 @@ def test_let_vectorize_load():
 
     mod = tvm.IRModule({"main": main})
     mod = tvm.compile(mod, target="cuda")
-    assert "float4 b" in mod.mod.imported_modules[0].get_source()
+    assert "float4 b" in mod.mod.imports[0].inspect_source()
 
 
 if __name__ == "__main__":

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -297,12 +297,11 @@ def prepend_pythonpath(path):
 if env.TVM_IMPORT_PYTHON_PATH is not None:
     prepend_pythonpath(env.TVM_IMPORT_PYTHON_PATH)
 else:
-    tvm_path = os.path.join(THIRD_PARTY_ROOT, "tvm")
+    tvm_path = os.path.join(THIRD_PARTY_ROOT, 'tvm', 'python')
     assert os.path.exists(tvm_path), tvm_path
     if tvm_path not in sys.path:
-        tvm_python_binding = os.path.join(tvm_path, 'python')
-        prepend_pythonpath(tvm_python_binding)
-        env.TVM_IMPORT_PYTHON_PATH = tvm_python_binding
+        prepend_pythonpath(tvm_path)
+        env.TVM_IMPORT_PYTHON_PATH = tvm_path
 
     if os.environ.get("TVM_LIBRARY_PATH") is None:
         os.environ['TVM_LIBRARY_PATH'] = env.TVM_LIBRARY_PATH = os.pathsep.join(TL_LIBS)


### PR DESCRIPTION
This pull request makes two targeted updates to improve compatibility with recent changes in the TVM library and its Python bindings. The most important changes are:

**TVM Python binding path update:**

* Changed the logic in `tilelang/env.py` to set the TVM Python binding path to `third_party/tvm/python` instead of just `third_party/tvm`, ensuring the correct directory is used for imports.

**API usage update for TVM module inspection:**

* Updated the test in `testing/python/language/test_tilelang_language_let.py` to use `mod.mod.imports[0].inspect_source()` instead of `mod.mod.imported_modules[0].get_source()`, reflecting changes in the TVM API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal test inspection method for imported module source
  * Refined Python path handling in environment configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->