### PR TITLE
[Bugfix] Legalize Datatype for mma intrinisc codegen 

### DIFF
--- a/src/target/codegen_cuda.cc
+++ b/src/target/codegen_cuda.cc
@@ -1749,6 +1749,9 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
         "reinterpret_cast<const (ARegType)*>((A_ptr) + (A_offset)), "
         "reinterpret_cast<const (BRegType)*>((B_ptr) + (B_offset)));\n";
     tl::codegen::Replacer replacer;
+
+    // TODO(lei): Type Workaround for TF32, should be removed when
+    // we introduced tfloat32_t in the frontend.
     std::string AType = tl::codegen::ptx::DTypeEnumToString(dtype_a_enum);
     if (AType == "tl::DataType::kFloat32") {
       AType = "tl::DataType::kTensorFloat32";
@@ -1756,6 +1759,14 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     std::string BType = tl::codegen::ptx::DTypeEnumToString(dtype_b_enum);
     if (BType == "tl::DataType::kFloat32") {
       BType = "tl::DataType::kTensorFloat32";
+    }
+    std::string ARegType = tl::codegen::GetMMARegisterType(dtype_a_enum);
+    if (ARegType == "float") {
+      ARegType = "uint32_t";
+    }
+    std::string BRegType = tl::codegen::GetMMARegisterType(dtype_b_enum);
+    if (BRegType == "float") {
+      BRegType = "uint32_t";
     }
 
     replacer.register_rule("(AType)", AType);
@@ -1767,10 +1778,8 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     replacer.register_rule("(K)", std::to_string(k));
     replacer.register_rule("(TransA)", A_layout == "row" ? "false" : "true");
     replacer.register_rule("(TransB)", B_layout == "row" ? "false" : "true");
-    replacer.register_rule("(ARegType)",
-                           tl::codegen::GetMMARegisterType(dtype_a_enum));
-    replacer.register_rule("(BRegType)",
-                           tl::codegen::GetMMARegisterType(dtype_b_enum));
+    replacer.register_rule("(ARegType)", ARegType);
+    replacer.register_rule("(BRegType)", BRegType);
     replacer.register_rule("(CRegType)",
                            tl::codegen::GetMMARegisterType(dtype_c_enum));
     replacer.register_rule("(A_ptr)", a_ref);


### PR DESCRIPTION
This pull request introduces a workaround in the CUDA code generation logic to handle TensorFloat32 (TF32) types and their register representations more robustly. The main goal is to ensure correct type handling for TF32 until native support is added in the frontend. The most important changes are:

**TF32 Type Handling Workaround:**

* Added a temporary workaround to map `"tl::DataType::kFloat32"` to `"tl::DataType::kTensorFloat32"` for TF32 support in both `AType` and `BType` variables, with a comment clarifying this is a temporary solution until proper TF32 support is introduced in the frontend.

**Register Type Mapping Adjustments:**

* Updated the logic for register type mapping so that if the MMA register type for either input is `"float"`, it is replaced with `"uint32_t"`, ensuring correct register usage for TF32 operations.

**Code Generation Rule Registration:**

* Simplified and corrected the registration of code generation replacement rules for `(AType)`, `(BType)`, `(ARegType)`, and `(BRegType)` to use the newly computed values, rather than calling the type conversion functions again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized CUDA matrix multiply code generation with improved type substitution and register handling during compilation for enhanced performance and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->