### PR TITLE
[Bugfix][Language V2] Capture closure variables from program

### DIFF
--- a/tilelang/language/v2/builder.py
+++ b/tilelang/language/v2/builder.py
@@ -584,9 +584,7 @@ def get_type_hints(func):
         freevars = getattr(func.__code__, 'co_freevars', ())
         cells = getattr(func, '__closure__', ()) or ()
         closure_bindings = {
-            name: cell.cell_contents
-            for name, cell in zip(freevars, cells)
-            if name not in localns
+            name: cell.cell_contents for name, cell in zip(freevars, cells) if name not in localns
         }
         if closure_bindings:
             localns.update(closure_bindings)


### PR DESCRIPTION
This pull request improves the robustness and flexibility of type hint evaluation for functions in `tilelang/language/v2/builder.py`. The main changes ensure that type annotations referencing variables from outer scopes (such as closure variables) are properly resolved, and that string-based dtype annotations are handled more reliably.

Enhancements to type hint resolution:

* Updated the namespace construction in `get_type_hints` to include closure variables from nested functions, allowing type annotations to reference symbols defined in enclosing scopes.
* Improved the handling of string-based dtype annotations by safely splitting and evaluating them only if they match known dtypes, with better error handling for unexpected formats.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type hint resolution for nested functions and complex annotation scenarios, reducing misinterpretation of forward/referenced types.
  * Enhanced resilience and error handling when evaluating annotations (including string aliases), preventing crashes and allowing graceful fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->