### PR TITLE
[Build] Explicitly add `libtvm` as a dep of `libtilelang`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,12 +169,8 @@ target_include_directories(tilelang_objs PRIVATE ${TILE_LANG_INCLUDES})
 
 add_library(tilelang SHARED $<TARGET_OBJECTS:tilelang_objs>)
 add_library(tilelang_module SHARED $<TARGET_OBJECTS:tilelang_objs>)
-target_link_libraries(tilelang PUBLIC tvm_runtime)
+target_link_libraries(tilelang PUBLIC tvm_runtime tvm)
 target_link_libraries(tilelang_module PUBLIC tvm)
-if(APPLE)
-  # FIXME: libtilelang should only link against tvm runtime
-  target_link_libraries(tilelang PUBLIC tvm)
-endif()
 # Build cython extension
 find_package(Python REQUIRED COMPONENTS Interpreter Development.Module ${SKBUILD_SABI_COMPONENT})
 


### PR DESCRIPTION
Closes #1028

After digging into #1028, it seems that `libtilelang` depends on `libtvm` anyway. Linux works because it enables lazy loading by default and the old behavior works fine. Darwin requires all symbols to be found when linking, causes the previous error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated library linking configuration to apply consistently across all platforms.
  * Enhanced runtime dependency linking for the build system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->