### PR TITLE
[CPU] Minor fix for cpu backend

### DIFF
--- a/tilelang/jit/adapter/wrapper.py
+++ b/tilelang/jit/adapter/wrapper.py
@@ -977,16 +977,19 @@ class TLCPUSourceWrapper:
         "float32": "float",
         "float16": "half",
         "int32": "int32_t",
+        "int8": "int8_t",
+        "uint8": "uint8_t",
+        "int16": "int16_t",
+        "uint16": "uint16_t",
+        "int64": "int64_t",
+        "uint64": "uint64_t",
+        "float64": "double",
+        "bool": "bool",
+        "uchar": "uchar",
     }
 
-    INIT_FUNC = textwrap.dedent('''
-        #ifdef __cplusplus
-        extern "C"
-        #endif
-        int32_t init() {
-            return 0;
-        }
-    ''')
+    # Use common init with error buffer and get_last_error for CPU backend as well
+    INIT_FUNC = PREDEF_INIT_FUNC.format("")
 
     CALL_PREFIX = textwrap.dedent("""
         #ifdef __cplusplus
@@ -1107,8 +1110,8 @@ class TLCPUSourceWrapper:
         return dynamic_symbolic_set
 
     def get_cpu_init_func(self):
-        init_funcs = self.INIT_FUNC
-        return init_funcs
+        # Provide init() and get_last_error() for CPU backend
+        return self.INIT_FUNC
 
     def update_lib_code(self, code: str):
         # Update the library code with the given code string


### PR DESCRIPTION
* Added new type mappings for int8, uint8, int16, uint16, int64, uint64, float64, bool, and uchar to the TLCPUSourceWrapper class.
* Updated the initialization function to use a common format for the CPU backend, ensuring consistency and improved error handling with the addition of get_last_error().
* Refactored the get_cpu_init_func method to return the updated initialization function, enhancing clarity and maintainability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactors**
  * Enhanced support for additional numeric and boolean data types (int8, uint8, int16, uint16, int64, uint64, float64, bool).
  * Improved initialization handling for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->