### PR TITLE
[Fix] Fix a type that make wrong T.macro backtrace

### DIFF
--- a/tilelang/__init__.py
+++ b/tilelang/__init__.py
@@ -22,7 +22,6 @@ def _compute_version() -> str:
         version_file = repo_root / "VERSION"
         if version_file.is_file():
             try:
-                import version_provider
                 from version_provider import dynamic_metadata  # type: ignore
                 return dynamic_metadata("version")
             except Exception:

--- a/tilelang/language/v2/ast.py
+++ b/tilelang/language/v2/ast.py
@@ -553,7 +553,7 @@ class DSLMutator(ast.NodeTransformer):
 
     def visit_Name(self, node: ast.Name):
         if isinstance(node.ctx, ast.Load):
-            return quote_expr(f"__tb.rval('{node.id}', {node.id})", span=node)
+            return quote_expr(f"__tb.rval('{node.id}', node)", node=node, span=node)
         return node
 
 


### PR DESCRIPTION
This pr fix a typo in ast rewrite process, and make the backtrace more readable in `T.macro`. Without this patch, tilelang generates a backtrace always at the Line 1 of the file when using an undefined variable.

```py
@T.macro
def foo():
    xxx
@T.prim_func
def tmp():
    foo()
```

