### PR TITLE
[Docs] Improve Installation Guide

### DIFF
--- a/docs/get_started/Installation.md
+++ b/docs/get_started/Installation.md
@@ -51,7 +51,7 @@ apt-get install -y python3 python3-dev python3-setuptools gcc zlib1g-dev build-e
 
 Then, clone the tilelang repository and install it using pip. The `-v` flag enables verbose output during the build process.
 
-> **Note**: Use the `--recursive` flag to include necessary submodules. Tilelang currently depends on a customized version of TVM, which is included as a submodule. if you prefer [Building with Existing TVM Installation](#use-existing-tvm), you can skip cloning the TVM submodule (but still need other dependencies).
+> **Note**: Use the `--recursive` flag to include necessary submodules. Tilelang currently depends on a customized version of TVM, which is included as a submodule. If you prefer [Building with Existing TVM Installation](#using-existing-tvm), you can skip cloning the TVM submodule (but still need other dependencies).
 
 ```bash
 git clone --recursive https://github.com/tile-ai/tilelang.git
@@ -204,17 +204,17 @@ TODO
 
 ### IDE Configs
 
-Building tilelang locally will automatically `compile_commands.json` file in `build` dir.
+Building tilelang locally will automatically generate a `compile_commands.json` file in `build` dir.
 VSCode with clangd and [clangd extension](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd) should be able to index that without extra configuration.
 
 ### Compile Cache
 
-The default path of the compile cache is `~/.tilelang/cache`.ﬁ `ccache` will be automatically used if found.
+The default path of the compile cache is `~/.tilelang/cache`. `ccache` will be automatically used if found.
 
 ### Repairing Wheels
 
 If you plan to use your wheel in other environment,
-it's recommend to use auditwheel (on Linux) or delocate (on Darwin)
+it's recommended to use auditwheel (on Linux) or delocate (on Darwin)
 to repair them.
 
 (faster-rebuild-for-developers)=


### PR DESCRIPTION
Current installation guide is confusing (especially, the Building from Source section). This PR improves it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized product naming in installation docs
  * Reorganized installation methods to emphasize native Linux source builds; clarified Docker instructions
  * Expanded build-from-source workflow with prerequisites, recursive submodule guidance, and verbose build options
  * Added PYTHONPATH "work from source" workflow and developer-focused faster rebuild/dev-mode instructions
  * Updated TVM integration notes, verification commands, toolchain/version guidance, and assorted wording polish
<!-- end of auto-generated comment: release notes by coderabbit.ai -->