### PR TITLE
[Bugfix] Fix multiple cg defination when using T.sync_grid

### DIFF
--- a/src/target/codegen_cuda.cc
+++ b/src/target/codegen_cuda.cc
@@ -1645,10 +1645,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
   } else if (op->op.same_as(tl::sync_grid())) {
     this->need_cooperative_groups_ = true;
     this->PrintIndent();
-    this->stream << "cooperative_groups::grid_group grid = "
-                    "cooperative_groups::this_grid();\n";
-    this->PrintIndent();
-    this->stream << "grid.sync();\n";
+    this->stream << "cooperative_groups::this_grid().sync();\n";
   } else if (op->op.same_as(tl::loop_break())) {
     this->PrintIndent();
     this->stream << "break;\n";


### PR DESCRIPTION
This pull request makes a small change to the CUDA code generation logic for grid synchronization. The code now directly calls `cooperative_groups::this_grid().sync();` instead of creating a `grid_group` variable before calling `sync()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized CUDA grid synchronization implementation to use a more direct approach while maintaining existing synchronization behavior and ensuring cooperative groups functionality continues to operate as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->