### PR TITLE
[Minor] Remove `from __future__ import annotations` for python 3.8

### DIFF
--- a/tilelang/carver/arch/arch_base.py
+++ b/tilelang/carver/arch/arch_base.py
@@ -1,6 +1,3 @@
-from __future__ import annotations
-
-
 class TileDevice:
     """
     Represents the architecture of a computing device, capturing various hardware specifications.

--- a/tilelang/carver/common_schedules.py
+++ b/tilelang/carver/common_schedules.py
@@ -19,7 +19,6 @@
 # Modifications Copyright (c) Microsoft.
 # The code below is mostly copied from apache/tvm common_schedules.py in dlight.
 """Common schedule strategies for TIR."""
-from __future__ import annotations
 from typing import Callable
 
 from tvm import tir

--- a/tilelang/carver/roller/hint.py
+++ b/tilelang/carver/roller/hint.py
@@ -1,5 +1,4 @@
 """Hint definition for schedule"""
-from __future__ import annotations
 from tvm import DataType
 from . import PrimFuncNode
 import numpy as np
@@ -218,7 +217,7 @@ class Hint:
         return dic
 
     @classmethod
-    def from_dict(cls, dic: dict) -> Hint:
+    def from_dict(cls, dic: dict) -> 'Hint':
         hint = cls()
         for k, v in dic.items():
             setattr(hint, k, v)

--- a/tilelang/carver/roller/policy/common.py
+++ b/tilelang/carver/roller/policy/common.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import numpy as np
 
 

--- a/tilelang/carver/roller/rasterization.py
+++ b/tilelang/carver/roller/rasterization.py
@@ -1,5 +1,4 @@
 """Rasteration Plan For L2 Cache Locality"""
-from __future__ import annotations
 
 
 class Rasterization:

--- a/tilelang/carver/roller/shape_inference/common.py
+++ b/tilelang/carver/roller/shape_inference/common.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from collections import OrderedDict
 
 from tvm import arith

--- a/tilelang/carver/roller/shape_inference/tir.py
+++ b/tilelang/carver/roller/shape_inference/tir.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from collections.abc import Mapping
 from tvm.tir.schedule.schedule import BlockRV
 from tvm.ir import structural_equal

--- a/tilelang/carver/template/base.py
+++ b/tilelang/carver/template/base.py
@@ -1,5 +1,4 @@
 # Import necessary modules and classes
-from __future__ import annotations
 from abc import ABC, abstractmethod  # For defining abstract base classes
 from dataclasses import dataclass, field  # For defining data classes
 from ..arch import (  # Import architecture-related utilities and classes
@@ -42,7 +41,7 @@ class BaseTemplate(ABC):
         """
         pass
 
-    def with_arch(self, arch: TileDevice) -> BaseTemplate:
+    def with_arch(self, arch: TileDevice) -> 'BaseTemplate':
         """
         Sets the architecture for this template and returns itself.
 
@@ -110,7 +109,7 @@ class BaseTemplate(ABC):
         """
         raise NotImplementedError("initialize_function is not implemented")
 
-    def set_function(self, func: PrimFunc) -> BaseTemplate:
+    def set_function(self, func: PrimFunc) -> 'BaseTemplate':
         """
         Sets the function for this template and returns itself.
 
@@ -123,7 +122,7 @@ class BaseTemplate(ABC):
         self._func = func
         return self
 
-    def set_output_nodes(self, output_nodes: list[OutputNode]) -> BaseTemplate:
+    def set_output_nodes(self, output_nodes: list[OutputNode]) -> 'BaseTemplate':
         """
         Sets the output nodes for this template and returns itself.
 

--- a/tilelang/carver/template/conv.py
+++ b/tilelang/carver/template/conv.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from dataclasses import dataclass
 from .base import BaseTemplate
 from tvm import te, tir

--- a/tilelang/carver/template/elementwise.py
+++ b/tilelang/carver/template/elementwise.py
@@ -1,5 +1,4 @@
 # Import necessary modules
-from __future__ import annotations
 from dataclasses import dataclass  # Used for defining data classes
 from .base import BaseTemplate  # Importing the base class for templates
 from tvm import te  # Importing TVM's tensor expression module

--- a/tilelang/carver/template/flashattention.py
+++ b/tilelang/carver/template/flashattention.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from dataclasses import dataclass
 from .base import BaseTemplate
 from tvm import te

--- a/tilelang/carver/template/gemv.py
+++ b/tilelang/carver/template/gemv.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from dataclasses import dataclass
 from .base import BaseTemplate
 from tvm import te

--- a/tilelang/carver/template/matmul.py
+++ b/tilelang/carver/template/matmul.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from dataclasses import dataclass
 from .base import BaseTemplate
 from tvm import te

--- a/tilelang/contrib/cc.py
+++ b/tilelang/contrib/cc.py
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 """Util to invoke C/C++ compilers in the system."""
-from __future__ import annotations
 import functools
 import os
 import shutil

--- a/tilelang/contrib/nvcc.py
+++ b/tilelang/contrib/nvcc.py
@@ -1,7 +1,6 @@
 # pylint: disable=invalid-name
 # modified from apache tvm python/tvm/contrib/nvcc.py
 """Utility to invoke nvcc compiler in the system"""
-from __future__ import absolute_import as _abs
 from __future__ import annotations
 
 import os

--- a/tilelang/intrinsics/mma_sm70_layout.py
+++ b/tilelang/intrinsics/mma_sm70_layout.py
@@ -1,6 +1,3 @@
-from __future__ import annotations
-
-
 def shared_16x4_to_mma_a_32x4_layout(row, col, rep):
     tid = (row % 4) + 16 * ((row // 4) % 2) + 4 * (row // 8) + 8 * rep
     local_id = col

--- a/tilelang/jit/adapter/ctypes/adapter.py
+++ b/tilelang/jit/adapter/ctypes/adapter.py
@@ -1,6 +1,5 @@
 """The profiler and convert to torch utils"""
 from __future__ import annotations
-
 import torch
 from ..base import BaseKernelAdapter
 import ctypes

--- a/tilelang/jit/adapter/cython/adapter.py
+++ b/tilelang/jit/adapter/cython/adapter.py
@@ -1,6 +1,5 @@
 """The profiler and convert to torch utils"""
 from __future__ import annotations
-
 import ctypes
 import logging
 import torch

--- a/tilelang/jit/adapter/dlpack.py
+++ b/tilelang/jit/adapter/dlpack.py
@@ -1,6 +1,4 @@
 """The profiler and convert to torch utils"""
-from __future__ import annotations
-
 import torch
 from tilelang.contrib.dlpack import to_pytorch_func
 from .base import BaseKernelAdapter

--- a/tilelang/language/allocate.py
+++ b/tilelang/language/allocate.py
@@ -13,8 +13,8 @@ Available allocation functions:
 Each function takes shape and dtype parameters and returns a TVM buffer object
 with the appropriate memory scope.
 """
-
 from __future__ import annotations
+
 from typing import overload, Literal
 from tilelang import tvm as tvm
 from tvm.script import tir as T

--- a/tilelang/language/annotations.py
+++ b/tilelang/language/annotations.py
@@ -1,6 +1,4 @@
 """Annotation helpers exposed on the TileLang language surface."""
-from __future__ import annotations
-
 from typing import Callable
 
 from tilelang.layout import Layout

--- a/tilelang/language/copy.py
+++ b/tilelang/language/copy.py
@@ -1,6 +1,5 @@
 """The language interface for tl programs."""
 from __future__ import annotations
-
 from typing import Literal
 from tilelang import language as T
 from tilelang.utils.language import (

--- a/tilelang/language/customize.py
+++ b/tilelang/language/customize.py
@@ -1,6 +1,5 @@
 """The language interface for tl programs."""
 from __future__ import annotations
-
 import tilelang.language as T
 from tvm.tir import PrimExpr, Buffer, op
 from .atomic import atomic_max, atomic_min, atomic_add, atomic_addx2, atomic_addx4, atomic_load, atomic_store  # noqa: F401

--- a/tilelang/language/experimental/gemm_sp.py
+++ b/tilelang/language/experimental/gemm_sp.py
@@ -1,6 +1,5 @@
 """The language interface for tl programs."""
 from __future__ import annotations
-
 from tilelang.primitives.gemm.base import GemmWarpPolicy
 import tilelang.language as T
 from tvm import tir

--- a/tilelang/language/fill.py
+++ b/tilelang/language/fill.py
@@ -1,6 +1,5 @@
 """The language interface for tl programs."""
 from __future__ import annotations
-
 from tvm import tir
 from tilelang.language import has_let_value, get_let_value
 from tilelang.utils.language import get_buffer_region_from_load

--- a/tilelang/language/frame.py
+++ b/tilelang/language/frame.py
@@ -1,6 +1,5 @@
 """Override the LetFrame to print a message when entering the frame."""
 from __future__ import annotations
-
 from tvm.ffi import register_object as _register_object
 from tvm.tir import Var, PrimExpr, BufferLoad, BufferRegion
 from tvm.ir import Range

--- a/tilelang/language/gemm.py
+++ b/tilelang/language/gemm.py
@@ -1,6 +1,5 @@
 """The language interface for tl programs."""
 from __future__ import annotations
-
 from tilelang.primitives.gemm.base import GemmWarpPolicy
 import tilelang.language as T
 from tvm import tir

--- a/tilelang/language/kernel.py
+++ b/tilelang/language/kernel.py
@@ -1,6 +1,5 @@
 """The language interface for tl programs."""
 from __future__ import annotations
-
 from collections import deque
 from tvm import tir
 from tvm.tir import Var

--- a/tilelang/language/loop.py
+++ b/tilelang/language/loop.py
@@ -1,6 +1,5 @@
 """The language interface for tl programs."""
 from __future__ import annotations
-
 from typing import Any
 from tvm import tir
 from tvm.tir import IntImm

--- a/tilelang/language/overrides/parser.py
+++ b/tilelang/language/overrides/parser.py
@@ -1,6 +1,4 @@
 """TVMScript parser overrides tailored for TileLang."""
-from __future__ import annotations
-
 from functools import partial
 
 from tvm.script.ir_builder import tir as T

--- a/tilelang/language/parser/operation.py
+++ b/tilelang/language/parser/operation.py
@@ -17,8 +17,6 @@
 # This file is modified from the original version,
 # which is part of the TVM project (https://tvm.apache.org/).
 """The tir expression operation registration"""
-from __future__ import annotations
-
 from tvm import tir
 from tvm.ffi.runtime_ctypes import DataType, DataTypeCode
 from tvm.tir import IntImm

--- a/tilelang/language/proxy.py
+++ b/tilelang/language/proxy.py
@@ -1,6 +1,6 @@
 """The language interface for tl programs."""
-
 from __future__ import annotations
+
 from typing import Any, SupportsIndex, TYPE_CHECKING
 from collections.abc import Sequence
 from typing_extensions import Self

--- a/tilelang/language/reduce.py
+++ b/tilelang/language/reduce.py
@@ -1,6 +1,5 @@
 """The language interface for tl programs."""
 from __future__ import annotations
-
 from tvm import tir
 from tilelang.language import copy, macro, alloc_shared, alloc_fragment
 from tilelang.language.utils import buffer_to_tile_region

--- a/tilelang/language/tir/ir.py
+++ b/tilelang/language/tir/ir.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 import tvm.script.ir_builder.tir.ir as _ir
 from tvm.script.ir_builder.tir import frame
 from tvm.tir import PrimExpr

--- a/tilelang/language/utils.py
+++ b/tilelang/language/utils.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from tilelang import tvm as tvm
 from tvm import tir
 from tvm.tir import PrimExpr, Buffer, BufferLoad, op

--- a/tilelang/language/v2/builder.py
+++ b/tilelang/language/v2/builder.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-
 from contextlib import contextmanager, AbstractContextManager
 from dataclasses import dataclass
 import inspect

--- a/tilelang/language/warpgroup.py
+++ b/tilelang/language/warpgroup.py
@@ -1,6 +1,4 @@
 """The language interface for tl programs."""
-from __future__ import annotations
-
 from tvm.script.ir_builder.tir.frame import TIRFrame
 from tvm.ffi import register_object
 from tilelang import _ffi_api

--- a/tilelang/layout/fragment.py
+++ b/tilelang/layout/fragment.py
@@ -1,7 +1,5 @@
 """Wrapping Layouts."""
 # pylint: disable=invalid-name, unsupported-binary-operation
-from __future__ import annotations
-
 import tvm
 import tvm_ffi
 from tvm.ir import Range
@@ -124,7 +122,7 @@ class Fragment(Layout):
     def repeat(self,
                repeats,
                repeat_on_thread: bool = False,
-               lower_dim_first: bool = True) -> Fragment:
+               lower_dim_first: bool = True) -> 'Fragment':
         """
         Returns a new Fragment that repeats the iteration space a given number of times.
 
@@ -144,7 +142,7 @@ class Fragment(Layout):
         """
         return _ffi_api.Fragment_repeat(self, repeats, repeat_on_thread, lower_dim_first)
 
-    def replicate(self, replicate: int) -> Fragment:
+    def replicate(self, replicate: int) -> 'Fragment':
         """
         Replicate the Fragment across a new thread dimension.
 
@@ -160,7 +158,7 @@ class Fragment(Layout):
         """
         return _ffi_api.Fragment_replicate(self, replicate)
 
-    def condense_rep_var(self) -> Fragment:
+    def condense_rep_var(self) -> 'Fragment':
         """
         Condense or fold the replicate variable into the existing iteration space.
         This operation may be used to reduce dimensionality if the replicate variable
@@ -207,7 +205,7 @@ class Fragment(Layout):
         """
         return f"Fragment<{self.get_input_shape()}->{self.get_output_shape()}, thread={self.thread}, index={self.index}>"
 
-    def is_equal(self, other: Fragment) -> bool:
+    def is_equal(self, other: 'Fragment') -> bool:
         """
         Check if the current fragment is equal to another fragment.
         """

--- a/tilelang/layout/gemm_sp.py
+++ b/tilelang/layout/gemm_sp.py
@@ -1,7 +1,6 @@
 """Wrapping Layouts."""
 # pylint: disable=invalid-name, unsupported-binary-operation
 from __future__ import annotations
-
 import tvm
 import tilelang.language as T
 import warnings

--- a/tilelang/layout/layout.py
+++ b/tilelang/layout/layout.py
@@ -1,7 +1,5 @@
 """Wrapping Layouts."""
 # pylint: disable=invalid-name, unsupported-binary-operation
-from __future__ import annotations
-
 import tvm_ffi
 from tvm.ir import Node, Range
 from tvm.tir import IterVar, Var, PrimExpr, IndexMap
@@ -122,7 +120,7 @@ class Layout(Node):
         # Map the provided indices using the constructed index mapping
         return index_map.map_indices(indices)
 
-    def inverse(self) -> Layout:
+    def inverse(self) -> 'Layout':
         """
         Compute the inverse of the current layout transformation.
 
@@ -133,7 +131,7 @@ class Layout(Node):
         """
         return _ffi_api.Layout_inverse(self)
 
-    def is_equal(self, other: Layout) -> bool:
+    def is_equal(self, other: 'Layout') -> bool:
         """
         Check if the current layout is equal to another layout.
 

--- a/tilelang/layout/swizzle.py
+++ b/tilelang/layout/swizzle.py
@@ -1,7 +1,7 @@
 """Wrapping Layouts."""
 # pylint: disable=invalid-name, unsupported-binary-operation
-
 from __future__ import annotations
+
 import tvm
 from tvm.tir import Buffer, BufferLoad, BufferRegion
 from tilelang import _ffi_api

--- a/tilelang/primitives/gemm/__init__.py
+++ b/tilelang/primitives/gemm/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-
 from tvm import tir
 from tilelang.utils import is_local, is_fragment, is_shared
 from tilelang.primitives.gemm.base import GemmWarpPolicy

--- a/tilelang/profiler/__init__.py
+++ b/tilelang/profiler/__init__.py
@@ -1,6 +1,5 @@
 """The profiler and convert to torch utils"""
 from __future__ import annotations
-
 from typing import Callable, Any, Literal
 from functools import partial
 import torch

--- a/tilelang/quantize/lop3.py
+++ b/tilelang/quantize/lop3.py
@@ -1,6 +1,5 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
-from __future__ import annotations
 from typing import Literal
 
 decode_i4_to_f16 = """

--- a/tilelang/quantize/mxfp.py
+++ b/tilelang/quantize/mxfp.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import Literal
 
 # Implementation asm for fp4 to bf16, using twiddling

--- a/tilelang/transform/add_bufstore_wrapper.py
+++ b/tilelang/transform/add_bufstore_wrapper.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from tvm.tir import (BufferStore, For, AttrStmt, ForKind, Var, PrimFunc, BufferLoad, Buffer, IntImm)
 from tvm.tir.stmt_functor import ir_transform, post_order_visit
 from tvm.tir.transform import prim_func_pass

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 """The profiler and convert to torch utils"""
 from enum import Enum
 import torch


### PR DESCRIPTION
Since the V2 frontend (#1120) rely on `ast.unparse`, which has been introduced in python 3.9, our codebase no longer supports python 3.8. This PR removes `from __future__ import annotations` for [Generic Alias Type](https://docs.python.org/3/library/stdtypes.html#types-genericalias). The statement is still necessary for union type `A | B`, which can be fully removed for `python>=3.10`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched many modules to use string-based forward references for type annotations and removed legacy future-style annotation imports.
  * Cleaned up import lists and minor formatting across files.
  * No runtime behavior or public API changes introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->