### PR TITLE
[BugFix] Adding extra parameters into autotune hashkey

### DIFF
--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -262,7 +262,7 @@ class AutoTuner:
         key_data = {
             "version": __version__,
             "op_parameters": tuple(op_parameters),
-            "extra_parameters": _normalize_param(extra_parameters),
+            "extra_parameters": extra_parameters,
             "func_source": func_source,
             "configs": self.configs,
             "compile_args": hash(self.compile_args),
@@ -308,6 +308,9 @@ class AutoTuner:
             for var_name, cell in zip(var_names, cells):
                 if var_name in parameters:
                     continue
+                # Cell content must be serializable
+                assert isinstance(cell.cell_contents, (int, float, str, bool, type(None))), \
+                    f"Cell contents {cell.cell_contents} is not serializable: {type(cell.cell_contents)}"
                 extra_parameters[var_name] = cell.cell_contents
 
         if isinstance(self.configs, Callable):


### PR DESCRIPTION
Fix https://github.com/tile-ai/tilelang/issues/1250 via capturing arguments in closure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autotuner cache key generation to include additional runtime parameters and values captured from function closures, with deterministic serialization to prevent incorrect cache hits or misses.
  * Updated tuning workflow and cache interactions so the autotuner more reliably recognizes unique tuning contexts; this may change caching behavior compared to prior runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->