### PR TITLE
[Feat] Add missing support to pass reference by `T.Var` annotation

### DIFF
--- a/testing/python/language/test_tilelang_language_frontend_v2.py
+++ b/testing/python/language/test_tilelang_language_frontend_v2.py
@@ -361,5 +361,39 @@ def test_while_loop():
     assert A[0].item() == sum(range(10)), f"Expected {sum(range(10))}, but got {A[0].item()}"
 
 
+def test_var_macro():
+    try:
+
+        @T.macro
+        def macro_with_var(x: T.Var):
+            x = 1  # noqa: F841
+
+        @T.prim_func
+        def prim_call_macro():
+            with T.Kernel(1):
+                x = T.alloc_var(T.int32)
+                macro_with_var(x)
+
+        assert 'x[0] = 1' in prim_call_macro.script()
+    finally:
+        pass
+
+    try:
+
+        @T.macro
+        def macro_with_var(x: T.Var):
+            x = 1  # noqa: F841
+
+        @T.prim_func
+        def prim_call_macro():
+            with T.Kernel(1):
+                x = 1
+                macro_with_var(x)
+
+        raise RuntimeError("Expect to report an error, x should not be passed as T.Var")
+    except ValueError:
+        pass
+
+
 if __name__ == '__main__':
     tilelang.testing.main()


### PR DESCRIPTION
This pr add the missing support to pass reference by `T.Var` annotations.
When passing `macro_with_var(x)`, frontend-v2 mutates it into `macro_with_var(x[0])`
And when the macro is annotated with `T.Var`, like `macro_with_var(a: T.Var)`, it convert back the BufferLoad `x[0]` into its buffer x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced type annotation support for macro parameters, enabling strict argument type validation during macro invocation.

* **Improvements**
  * Enhanced error messaging when macros receive incorrect argument types, making debugging easier and faster.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->