### PR TITLE
Add sparse fine-tuning kernel for deepseek sparse attention to example

### DIFF
--- a/examples/dsa_sparse_finetune/index.py
+++ b/examples/dsa_sparse_finetune/index.py
@@ -2,13 +2,10 @@
 import torch
 import torch.nn.functional as F
 import functools
-import tilelang
-from typing import Callable, Union, Any
+from typing import Callable, Any
 
 
-def tensor_cache(
-    fn: Callable[..., torch.Tensor],
-) -> Callable[..., torch.Tensor]:
+def tensor_cache(fn: Callable[..., torch.Tensor],) -> Callable[..., torch.Tensor]:
     """
     A decorator that caches the most recent result of a function with tensor inputs.
 
@@ -32,11 +29,11 @@ def tensor_cache(
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         nonlocal last_args, last_kwargs, last_result
 
-        if last_args is not None and last_kwargs is not None:
-            if len(args) == len(last_args) and len(kwargs) == len(last_kwargs):
-                if all(a is b for a, b in zip(args, last_args, strict=False)) and \
-                        all(k in last_kwargs and v is last_kwargs[k] for k, v in kwargs.items()):
-                    return last_result
+        if (last_args is not None and last_kwargs is not None) and \
+            (len(args) == len(last_args) and len(kwargs) == len(last_kwargs)) and \
+                all(a is b for a, b in zip(args, last_args, strict=False)) and \
+                    all(k in last_kwargs and v is last_kwargs[k] for k, v in kwargs.items()):
+            return last_result
 
         result = fn(*args, **kwargs)
         last_args, last_kwargs, last_result = args, kwargs, result
@@ -59,9 +56,7 @@ def prepare_cu_seqlens_from_lens(
 
 
 @tensor_cache
-def prepare_lens_from_cu_seqlens(
-    cu_seqlens: torch.LongTensor,
-) -> torch.LongTensor:
+def prepare_lens_from_cu_seqlens(cu_seqlens: torch.LongTensor,) -> torch.LongTensor:
     return torch.diff(cu_seqlens)
 
 

--- a/examples/dsa_sparse_finetune/utils.py
+++ b/examples/dsa_sparse_finetune/utils.py
@@ -1,17 +1,19 @@
 import torch
 
+
 def get_abs_err(y, x):
     x = x.to(torch.float32)
     y = y.to(torch.float32)
-    return (x-y).flatten().abs().max().item()
+    return (x - y).flatten().abs().max().item()
 
 
 def get_err_ratio(y, x):
     x = x.to(torch.float32)
     y = y.to(torch.float32)
-    err = (x-y).flatten().square().mean().sqrt().item()
+    err = (x - y).flatten().square().mean().sqrt().item()
     base = (x).flatten().square().mean().sqrt().item()
     return err / base
+
 
 def calculate_tensor_similarity(x, y, name="tensor"):
     """


### PR DESCRIPTION
This PR integrates the kernel required for the sparse fine-tuning stage of deepseek sparse attention into the example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added sparse attention mechanism with optimized forward and backward kernel implementations for efficient fine-tuning workflows
  * Included reference implementations and comprehensive test harnesses for validation and benchmarking
  * Provided utility functions for sequence processing and tensor similarity measurement to support sparse attention operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->