### PR TITLE
[Bugfix] Precision fix for causal attention

### DIFF
--- a/examples/flash_attention/example_mha_fwd_varlen.py
+++ b/examples/flash_attention/example_mha_fwd_varlen.py
@@ -151,7 +151,7 @@ def flashattn(batch_size,
                         K_shared[i, d] = 0
                 if is_causal:
                     for i, j in T.Parallel(block_M, block_N):
-                        acc_s[i, j] = T.if_then_else((bx * block_M + i >= k * block_N + j) and
+                        acc_s[i, j] = T.if_then_else((bx * block_M + i < k * block_N + j) or
                                                      (bx * block_M + i >= q_current_seqlen or
                                                       k * block_N + j >= k_current_seqlen),
                                                      -T.infinity(acc_s.dtype), 0)
@@ -216,7 +216,7 @@ def main(batch: int = 8, heads: int = 64, seq_len: int = 2048, dim: int = 128):
 
     tilelang.testing.set_random_seed(0)
 
-    causal = False
+    causal = True
     if causal:
         total_flops *= 0.5
 

--- a/examples/flash_attention/test_example_flash_attention.py
+++ b/examples/flash_attention/test_example_flash_attention.py
@@ -99,5 +99,65 @@ def test_example_mha_fwd_varlen():
     example_mha_fwd_varlen.main(batch=4, heads=16, seq_len=512, dim=64)
 
 
+# Additional causal tests
+
+
+@tilelang.testing.requires_cuda
+def test_example_gqa_fwd_bshd_causal():
+    example_gqa_fwd_bshd.main(
+        batch=1, heads=16, seq_len=512, dim=128, is_causal=True, groups=16, tune=False)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_example_gqa_fwd_bshd_wgmma_pipelined_causal():
+    example_gqa_fwd_bshd_wgmma_pipelined.main(
+        batch=1, heads=16, seq_len=512, dim=128, is_causal=True, groups=16, tune=False)
+
+
+@tilelang.testing.requires_cuda
+def test_example_mha_fwd_bhsd_causal():
+    example_mha_fwd_bhsd.main(batch=1, heads=32, seq_q=256, seq_kv=256, dim=128, is_causal=True)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_example_mha_fwd_bshd_wgmma_pipelined_causal():
+    example_mha_fwd_bshd_wgmma_pipelined.main(batch=1, heads=32, seq_len=256, is_causal=True)
+
+
+@tilelang.testing.requires_cuda
+def test_example_mha_fwd_bshd_causal():
+    example_mha_fwd_bshd.main(batch=1, seq_len=256, is_causal=True)
+
+
+@tilelang.testing.requires_cuda
+def test_example_mha_bwd_causal():
+    example_mha_bwd_bshd.main(
+        BATCH=1,
+        H=16,
+        N_CTX=256,
+        D_HEAD=64,
+        causal=True,
+    )
+
+
+@tilelang.testing.requires_cuda
+def test_example_mha_bwd_bhsd_causal():
+    example_mha_bwd_bhsd.main(
+        BATCH=1,
+        H=16,
+        N_CTX=256,
+        D_HEAD=64,
+        causal=True,
+    )
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_example_mha_bwd_wgmma_pipelined_causal():
+    example_mha_bwd_bshd_wgmma_pipelined.main(BATCH=1, H=32, N_CTX=128, D_HEAD=64, causal=True)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
This pull request makes several important updates to the Flash Attention MHA example and its test suite, primarily to improve and expand causal attention support. The main changes include fixing the causal masking logic in the forward pass, enabling causal mode by default, and significantly expanding the test coverage for causal variants of both forward and backward attention implementations.

Key changes:

**Causal Attention Logic and Defaults**
* Fixed the causal masking condition in the `main` function of `example_mha_fwd_varlen.py` to correctly handle causal attention masking.
* Set the `causal` flag to `True` by default in `example_mha_fwd_varlen.py`, ensuring that the example now runs in causal mode unless otherwise specified.

**Test Suite Expansion for Causal Attention**
* Added multiple new tests in `test_example_flash_attention.py` to cover causal variants of MHA and GQA forward and backward passes, including tests for pipelined and WGMMA implementations. These tests ensure that causal attention is correctly implemented and works across a variety of configurations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Causal attention is now enabled by default in flash attention example scripts, optimizing default behavior for sequential data processing.

* **Tests**
  * Added comprehensive test coverage for causal attention scenarios, including multiple compute configurations and pipelined variants.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->