### PR TITLE
[Refactor] Moving `NormalizeToBufferRegion` and `MakeAccessPtrFromRegion` to utils

### DIFF
--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -13,8 +13,8 @@
 
 #include "../target/utils.h"
 #include "region.h"
-#include "utils.h"
 #include "tcgen5_meta.h"
+#include "utils.h"
 
 namespace tvm {
 namespace tl {
@@ -453,9 +453,12 @@ Stmt GemmNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
       policy_->computeWarpPartition(m_, n_, block_size, T.target, gemm_inst);
 
   // Build access pointers from regions locally
-  PrimExpr Aptr = MakeAccessPtrFromRegion(aRegion_, /*r*/ 1, /*require_2d*/ true);
-  PrimExpr Bptr = MakeAccessPtrFromRegion(bRegion_, /*r*/ 1, /*require_2d*/ true);
-  PrimExpr Cptr = MakeAccessPtrFromRegion(cRegion_, /*rw*/ 3, /*require_2d*/ true);
+  PrimExpr Aptr =
+      MakeAccessPtrFromRegion(aRegion_, /*r*/ 1, /*require_2d*/ true);
+  PrimExpr Bptr =
+      MakeAccessPtrFromRegion(bRegion_, /*r*/ 1, /*require_2d*/ true);
+  PrimExpr Cptr =
+      MakeAccessPtrFromRegion(cRegion_, /*rw*/ 3, /*require_2d*/ true);
 
   std::stringstream ss;
   std::string op_name;

--- a/src/op/gemm_py.cc
+++ b/src/op/gemm_py.cc
@@ -13,8 +13,8 @@
 
 #include "../target/utils.h"
 #include "region.h"
-#include "utils.h"
 #include "tcgen5_meta.h"
+#include "utils.h"
 
 namespace tvm {
 namespace tl {

--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -15,9 +15,9 @@
 #include "../target/utils.h"
 #include "../transform/loop_partition.h"
 #include "region.h"
-#include "utils.h"
 #include "tir/transforms/ir_utils.h"
 #include "tvm/tir/stmt.h"
+#include "utils.h"
 
 namespace tvm {
 namespace tl {

--- a/src/op/utils.cc
+++ b/src/op/utils.cc
@@ -19,7 +19,8 @@ BufferRegion NormalizeToBufferRegion(const PrimExpr &arg,
     return Downcast<BufferRegion>(arg);
   }
 
-  // Case 2: BufferLoad — convert indices to ranges (Ramp -> lanes, else extent=1)
+  // Case 2: BufferLoad — convert indices to ranges (Ramp -> lanes, else
+  // extent=1)
   if (const auto *load = arg.as<BufferLoadNode>()) {
     Array<Range> ranges;
     for (const PrimExpr &index : load->indices) {
@@ -89,7 +90,8 @@ PrimExpr MakeAccessPtrFromRegion(const BufferRegion &region, int rw_mask,
       offset = offset + region->region[i]->min * strides[i];
     }
     // Extent: last two extents product (elements)
-    extent = region->region[ndim - 2]->extent * region->region[ndim - 1]->extent;
+    extent =
+        region->region[ndim - 2]->extent * region->region[ndim - 1]->extent;
   }
 
   // ptype and return handle

--- a/src/op/utils.h
+++ b/src/op/utils.h
@@ -19,15 +19,15 @@ using namespace tir;
 // Normalize an argument (BufferRegion/BufferLoad/tl.region/tvm_access_ptr)
 // to BufferRegion so ops can uniformly consume regions.
 TVM_DLL BufferRegion NormalizeToBufferRegion(const PrimExpr &arg,
-                                            const BufferMap &vmap);
+                                             const BufferMap &vmap);
 
 // Build a tvm_access_ptr(handle) from a BufferRegion.
 // - If `require_2d` is true, checks buffer ndim >= 2.
 // - For 1D regions (when allowed), offset=min, extent=extent.
 // - For ndim >= 2, offset sums all but last two dims using row-major strides,
 //   extent is product of the last two extents.
-TVM_DLL PrimExpr MakeAccessPtrFromRegion(const BufferRegion &region, int rw_mask,
-                                         bool require_2d = false);
+TVM_DLL PrimExpr MakeAccessPtrFromRegion(const BufferRegion &region,
+                                         int rw_mask, bool require_2d = false);
 
 } // namespace tl
 } // namespace tvm


### PR DESCRIPTION
This pull request refactors utility logic for TL operators by moving shared functions into new utility files, improving code reuse and maintainability. The duplicated implementations of `NormalizeToBufferRegion` and `MakeAccessPtrFromRegion` have been removed from individual operator files and consolidated into `src/op/utils.h` and `src/op/utils.cc`. Additionally, minor interface adjustments were made to some calls for consistency.

**Utility code refactoring and consolidation:**

* Added new files `src/op/utils.h` and `src/op/utils.cc` containing shared implementations for `NormalizeToBufferRegion` and `MakeAccessPtrFromRegion`, which handle conversion of various region argument types and construction of access pointers for buffer regions. [[1]](diffhunk://#diff-35171efecb7210b7acd62e86bb98f7bc9f1f3dbbf41081d30ad567996f5473e0R1-R105) [[2]](diffhunk://#diff-5ae3e310d9bd4d852257d4cb30177407da036130af0951b73e45c452d635e55fR1-R35)
* Removed duplicated implementations of `NormalizeToBufferRegion` and `MakeAccessPtrFromRegion` from `src/op/gemm.cc`, `src/op/gemm_py.cc`, and `src/op/reduce.cc`, replacing them with calls to the new utility functions. [[1]](diffhunk://#diff-5cbeefe6d2ab80fbd44350603133779b381d613ca2f5b4f4a6bf89dbe98b6d2cL51-R54) [[2]](diffhunk://#diff-62ea4f98c360d6b119553e16338f6bcc380c9c8e894236fd7da8ad52dcffbd7bR17-R26) [[3]](diffhunk://#diff-6db4f8a0f03dffeb4b8b493182b3754cc170d550bb6ea71ca472ced6320c8868R20-R29)
* Updated includes in operator files (`src/op/gemm.cc`, `src/op/gemm_py.cc`, `src/op/reduce.cc`) to reference the new `utils.h` header. [[1]](diffhunk://#diff-5cbeefe6d2ab80fbd44350603133779b381d613ca2f5b4f4a6bf89dbe98b6d2cR17) [[2]](diffhunk://#diff-62ea4f98c360d6b119553e16338f6bcc380c9c8e894236fd7da8ad52dcffbd7bR17-R26) [[3]](diffhunk://#diff-6db4f8a0f03dffeb4b8b493182b3754cc170d550bb6ea71ca472ced6320c8868R20-R29)

**Interface improvement:**

* Modified calls to `MakeAccessPtrFromRegion` in `src/op/gemm.cc` to add a `require_2d` argument for stricter dimension checks.

These changes centralize common logic, reduce code duplication, and make future maintenance easier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated internal utility functions into a shared module to improve code organization and reduce duplication across operations. Updated related operation modules to reference the centralized utilities with enhanced parameters for stricter dimension requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->