### PR TITLE
[Fix] Fix missing `not` operator in frontend (#1347)

### DIFF
--- a/testing/python/language/test_tilelang_language_frontend_v2.py
+++ b/testing/python/language/test_tilelang_language_frontend_v2.py
@@ -466,5 +466,18 @@ def test_buffer_slice_step():
         pass
 
 
+def test_boolop():
+    a = Var('a', 'int32')
+    b = Var('b', 'int32')
+    c = Var('c', 'int32')
+    d = Var('d', 'int32')
+
+    @T.macro
+    def cond():
+        return not (a < b and b < c and a * d < b * d) or b * d < c * d
+
+    cond()
+
+
 if __name__ == '__main__':
     tilelang.testing.main()


### PR DESCRIPTION
This pr adds the missing implementation of `not` in frontend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for logical NOT operations in boolean expressions.

* **Tests**
  * Extended test coverage to validate boolean and mixed-operation macro evaluation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->