### PR TITLE
[Bugfix] Update TIR registration for GemmSPPy to use tile operation

### DIFF
--- a/src/op/gemm_sp_py.cc
+++ b/src/op/gemm_sp_py.cc
@@ -279,7 +279,7 @@ LayoutMap GemmSPPyNode::InferLayout(const LayoutInferArgs &T,
   return results;
 }
 
-TIR_REGISTER_TL_OP(GemmSPPy, gemm_sp_py)
+TIR_REGISTER_TL_TILE_OP(GemmSPPy, gemm_sp_py)
     .set_num_inputs(5)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));


### PR DESCRIPTION
This pull request makes a minor update to the registration macro for the `GemmSPPy` operator in the `src/op/gemm_sp_py.cc` file. The change ensures the operator is registered using the correct macro for tile-level operations.

* Changed from using `TIR_REGISTER_TL_OP` to `TIR_REGISTER_TL_TILE_OP` for registering the `GemmSPPy` operator, which aligns with tile-level operator conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal operator registration mechanism for improved compile-time processing of matrix multiplication operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->