### PR TITLE
[Debug] Always include line info in NVCC command for improved profiling

### DIFF
--- a/tilelang/contrib/nvcc.py
+++ b/tilelang/contrib/nvcc.py
@@ -80,8 +80,8 @@ def compile_cuda(code,
     file_target = path_target if path_target else temp_target
     cmd = [get_nvcc_compiler()]
     cmd += [f"--{target_format}", "-O3"]
-    if kernels_output_dir is not None:
-        cmd += ["-lineinfo"]
+    # Always include line info for better profiling and mapping
+    cmd += ["-lineinfo"]
     if isinstance(arch, list):
         cmd += arch
     elif isinstance(arch, str):


### PR DESCRIPTION
This pull request introduces a minor but important change to the CUDA compilation process in `tilelang/contrib/nvcc.py`. The update ensures that line information is always included during compilation, which improves profiling and debugging capabilities.

* Compiler flags: The `-lineinfo` flag is now always added to the `nvcc` command in the `compile_cuda` function, ensuring better profiling and source mapping for generated CUDA code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Compilation**
  * CUDA compilation now always includes line information by default for all builds. Previously only applied when kernel output directories were specified. This enables enhanced debugging and profiling capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->