### PR TITLE
[Enhancement] Add DISABLE_CACHE environment variables

### DIFF
--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -325,7 +325,7 @@ class AutoTuner:
         key = self.generate_cache_key(parameters, extra_parameters)
 
         with self._lock:
-            if env.is_cache_enabled():
+            if env.is_cache_enabled() and not env.is_autotune_cache_disabled():
                 # First check in-memory cache
                 if key in self._memory_cache:
                     logger.warning("Found kernel in memory cache. For better performance," \
@@ -601,7 +601,7 @@ class AutoTuner:
             logger.warning("DLPack backend does not support cache saving to disk.")
         else:
             with self._lock:
-                if env.is_cache_enabled():
+                if env.is_cache_enabled() and not env.is_autotune_cache_disabled():
                     self._save_result_to_disk(key, autotuner_result)
 
         self._memory_cache[key] = autotuner_result


### PR DESCRIPTION
This PR adds two environment variables: `TILELANG_DISABLE_CACHE` and `TILELANG_AUTO_TUNING_DISABLE_CACHE`, which globally disable all kernel cache/autotuner cache behaviours once they are set. The default value is "0", meaning enabling the cache. This is only for conveniently testing & debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new environment variables for granular cache control: `TILELANG_DISABLE_CACHE` (global kernel cache control) and `TILELANG_AUTO_TUNING_DISABLE_CACHE` (auto-tuning specific cache management).
  * Enhanced cache validation in auto-tuner to respect cache control settings during tuning operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->