### PR TITLE
[Bugfix] make cuda driver api compat with cuda12/13, along with tests

### DIFF
--- a/testing/python/carver/test_tilelang_carver_cuda_driver_properties.py
+++ b/testing/python/carver/test_tilelang_carver_cuda_driver_properties.py
@@ -1,0 +1,76 @@
+import tilelang.testing
+from tilelang.carver.arch.driver.cuda_driver import (
+    get_cuda_device_properties,
+    get_device_name,
+    get_shared_memory_per_block,
+    get_device_attribute,
+    get_max_dynamic_shared_size_bytes,
+    get_persisting_l2_cache_max_size,
+    get_num_sms,
+    get_registers_per_block,
+)
+import torch
+
+
+class _cudaDeviceAttrNames:
+    r"""
+    This struct carries all properties that are of int32_t.
+    refer to https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g49e2f8c2c0bd6fe264f2fc970912e5cd
+    """
+
+    cudaDevAttrMaxThreadsPerBlock: int = 1
+    cudaDevAttrMaxSharedMemoryPerBlock: int = 8
+    cudaDevAttrMultiProcessorCount: int = 16
+    cudaDevAttrMaxSharedMemoryPerMultiprocessor: int = 81
+    cudaDevAttrMaxPersistingL2CacheSize: int = 108
+
+
+def test_driver_get_device_properties():
+    prop = get_cuda_device_properties()
+    assert prop is not None, "Failed to get CUDA device properties"
+    assert isinstance(
+        prop,
+        torch.cuda._CudaDeviceProperties), ("Returned object is not of type _CudaDeviceProperties")
+
+
+def test_device_get_device_name():
+    tl_device_name = get_device_name()
+    th_device_name = torch.cuda.get_device_name()
+    assert tl_device_name == th_device_name, "Device names do not match"
+
+
+def test_device_get_shared_memory_per_block():
+    tl_smem = get_shared_memory_per_block()
+    driver_smem = get_device_attribute(_cudaDeviceAttrNames.cudaDevAttrMaxSharedMemoryPerBlock)
+    assert tl_smem == driver_smem, "Shared memory per block values do not match"
+
+
+def test_device_get_persisting_l2_cache_size():
+    tl_cache_size = get_persisting_l2_cache_max_size()
+    driver_cache_size = get_device_attribute(
+        _cudaDeviceAttrNames.cudaDevAttrMaxPersistingL2CacheSize)
+    assert tl_cache_size == driver_cache_size, "Persisting L2 cache size values do not match"
+
+
+def test_device_get_num_sms():
+    tl_num_sms = get_num_sms()
+    driver_num_sms = get_device_attribute(_cudaDeviceAttrNames.cudaDevAttrMultiProcessorCount)
+    assert tl_num_sms == driver_num_sms, "Number of SMs do not match"
+
+
+def test_device_get_registers_per_block():
+    tl_regs_per_block = get_registers_per_block()
+    driver_regs_per_block = get_device_attribute(_cudaDeviceAttrNames.cudaDevAttrMaxThreadsPerBlock)
+    assert tl_regs_per_block == driver_regs_per_block, "Registers per block values do not match"
+
+
+def test_device_get_max_dynamic_shared_size_bytes():
+    tl_dynamic_smem = get_max_dynamic_shared_size_bytes()
+    driver_dynamic_smem = get_device_attribute(
+        _cudaDeviceAttrNames.cudaDevAttrMaxSharedMemoryPerMultiprocessor)
+    assert tl_dynamic_smem == driver_dynamic_smem, (
+        "Max dynamic shared size bytes values do not match")
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
Description:
I encountered an issue where `driver.get_num_sms` (and potentially other device property queries) returns `0` when running in a CUDA 13 environment.

Root Cause:
It appears that the `cudaDeviceProp` struct definition has changed in CUDA 13. The current implementation, which likely relies on raw `ctypes` bindings or hardcoded struct layouts to query driver information, fails to map correctly to the new struct layout, resulting in incorrect return values.

Fix:
Reuse torch.cuda API mostly. For certain other APIs, hardcode the cudaDevAttr. This should be safe as CUDA APIs are backward-compat. 

Comments: 
Could anyone run the pr on the Windows platform? I have tested it over a NVCR PyTorch container(Linux). 

```
➜  carver git:(yq/cuda13-driver-api) ✗ python test_tilelang_carver_cuda_driver_properties.py
2025-12-06 15:56:41  [TileLang:tilelang.env:WARNING]: Loading tilelang libs from dev root: /data/tilelang/build
/usr/local/lib/python3.12/dist-packages/torch/cuda/__init__.py:63: FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the main
tainers of the package that installed pynvml for you.
  import pynvml  # type: ignore[import]
===================================================================================================== test session starts =====================================================================================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0
rootdir: /data/tilelang
configfile: pyproject.toml
plugins: anyio-4.10.0, shard-0.1.2, xdoctest-1.0.2, flakefinder-1.1.0, hypothesis-6.130.8, xdist-3.8.0, rerunfailures-16.0.1, typeguard-4.3.0
collected 7 items                                                                                                                                                                                                             
Running 7 items in this shard

test_tilelang_carver_cuda_driver_properties.py .......                                                                                                                                                                  [100%]

====================================================================================================== 7 passed in 0.11s ======================================================================================================
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA device property retrieval with enhanced error handling and fallback mechanisms for robustness.

* **Tests**
  * Added comprehensive unit tests for CUDA device property accessors to verify correctness and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->