### PR TITLE
[BugFix] Add shuffle elect condition for ptx_arrive_barrier() in TMA barrier injection

### DIFF
--- a/src/transform/inject_tma_barrier.cc
+++ b/src/transform/inject_tma_barrier.cc
@@ -504,17 +504,18 @@ private:
     return IRMutatorWithAnalyzer::VisitStmt_(op);
   }
 
-  Stmt VisitStmt_(const EvaluateNode* op) final {
+  Stmt VisitStmt_(const EvaluateNode *op) final {
     // Check whether this is ptx_arrive_barrier()
-    if (const CallNode* call = op->value.as<CallNode>()) {
-        if (call->op.same_as(builtin::ptx_arrive_barrier())) {
-            // producer arrives → guard with tl_shuffle_elect()
-            if (has_warp_specialization_ && is_producer_) {
-              PrimExpr cond = Call(DataType::Bool(), tl_shuffle_elect(), {IntImm(DataType::Int(32), 128)});
-              Stmt arrive_stmt = StmtExprMutator::VisitStmt_(op);
-              return IfThenElse(cond, arrive_stmt, Stmt());
-            }
+    if (const CallNode *call = op->value.as<CallNode>()) {
+      if (call->op.same_as(builtin::ptx_arrive_barrier())) {
+        // producer arrives → guard with tl_shuffle_elect()
+        if (has_warp_specialization_ && is_producer_) {
+          PrimExpr cond = Call(DataType::Bool(), tl_shuffle_elect(),
+                               {IntImm(DataType::Int(32), 128)});
+          Stmt arrive_stmt = StmtExprMutator::VisitStmt_(op);
+          return IfThenElse(cond, arrive_stmt, Stmt());
         }
+      }
     }
 
     return StmtExprMutator::VisitStmt_(op);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved barrier arrival behavior in producer code when warp specialization is enabled. Barrier operations now conditionally execute based on warp-level election, enhancing synchronization correctness in specialized parallel execution scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->