### PR TITLE
[AMD] Fix 3 bugs when build docker on amd mi3x gpu

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -22,10 +22,12 @@ RUN conda run -n py_3.10 conda install pip cmake -y && \
 RUN apt-get install -y python3 python3-dev python3-setuptools gcc libtinfo-dev zlib1g-dev build-essential cmake libedit-dev libxml2-dev
 
 RUN git clone https://github.com/tile-ai/tilelang.git --recursive -b main tilelang && \
-    conda run -n py_3.10 bash -c "cd tilelang && USE_ROCM=1 pip install -e . -v"
+    mv /opt/conda/envs/py_3.10/compiler_compat /opt/conda/envs/py_3.10/compiler_compat.bak || true && \
+    conda run -n py_3.10 bash -c "pip install 'numpy<2.0' --force-reinstall && cd tilelang && USE_ROCM=1 pip install -e . -v"
 
-RUN conda init bash
+RUN conda init bash && \
+    echo "conda activate py_3.10" >> /root/.bashrc
 
 SHELL ["/bin/bash", "-l", "-c"]
 
-CMD ["bash", "-c", "source ~/.bashrc && conda activate py_3.10 && exec bash"]
+ENTRYPOINT ["/bin/bash", "--login", "-i"]


### PR DESCRIPTION
## issue desc
I found below 3 issues when I install tilelang using docker on mi300/mi355 gpu following https://github.com/tile-ai/tilelang/blob/main/docs/get_started/Installation.md, after this pr, it works on mi300/mi355 like below
```
(py_3.10) root@mi355:~# python -c "import tilelang; print(tilelang.__version__)"
2025-12-10 13:15:50  [TileLang:tilelang.env:WARNING]: Loading tilelang libs from dev root: /root/tilelang/build
0.1.7+cuda.gitbc084aa4
(py_3.10) root@mi355:~#
```
### issue 1
1st issue I met is when I built using dockerfile.rocm
```
34.80   -- Check for working C compiler: /usr/bin/gcc - broken
34.80   CMake Error at /opt/conda/envs/py_3.10/share/cmake-4.1/Modules/CMakeTestCCompiler.cmake:67 (message):
34.80     The C compiler
34.80
34.80       "/usr/bin/gcc"
34.80
34.80     is not able to compile a simple test program.
34.80
34.80     It fails with the following output:
34.80
34.80       Change Dir: '/root/tilelang/build/CMakeFiles/CMakeScratch/TryCompile-rddpmJ'
34.80
34.80       Run Build Command(s): /usr/local/bin/ninja -v cmTC_1d0ca
34.80       [1/2] /usr/bin/gcc  -pthread -B /opt/conda/envs/py_3.10/compiler_compat    -o CMakeFiles/cmTC_1d0ca.dir/testCCompiler.c.o -c /root/tilelang/build/CMakeFiles/CMakeScratch/TryCompile-rddpmJ/testCCompiler.c
34.80       [2/2] : && /usr/bin/gcc  -pthread -B /opt/conda/envs/py_3.10/compiler_compat   CMakeFiles/cmTC_1d0ca.dir/testCCompiler.c.o -o cmTC_1d0ca   && :
34.80       FAILED: cmTC_1d0ca
34.80       : && /usr/bin/gcc  -pthread -B /opt/conda/envs/py_3.10/compiler_compat   CMakeFiles/cmTC_1d0ca.dir/testCCompiler.c.o -o cmTC_1d0ca   && :
34.80       /opt/conda/envs/py_3.10/compiler_compat/ld: /lib/x86_64-linux-gnu/libc.so.6: undefined reference to `_dl_audit_symbind_alt@GLIBC_PRIVATE'
34.80       /opt/conda/envs/py_3.10/compiler_compat/ld: /lib/x86_64-linux-gnu/libc.so.6: undefined reference to `__nptl_change_stack_perm@GLIBC_PRIVATE'
34.80       /opt/conda/envs/py_3.10/compiler_compat/ld: /lib/x86_64-linux-gnu/libc.so.6: undefined reference to `_dl_find_dso_for_object@GLIBC_PRIVATE'
34.80       /opt/conda/envs/py_3.10/compiler_compat/ld: /lib/x86_64-linux-gnu/libc.so.6: undefined reference to `_dl_fatal_printf@GLIBC_PRIVATE'
34.80       /opt/conda/envs/py_3.10/compiler_compat/ld: /lib/x86_64-linux-gnu/libc.so.6: undefined reference to `_dl_exception_create@GLIBC_PRIVATE'
34.80       /opt/conda/envs/py_3.10/compiler_compat/ld: /lib/x86_64-linux-gnu/libc.so.6: undefined reference to `__tunable_get_val@GLIBC_PRIVATE'
34.80       /opt/conda/envs/py_3.10/compiler_compat/ld: /lib/x86_64-linux-gnu/libc.so.6: undefined reference to `_dl_audit_preinit@GLIBC_PRIVATE'
34.80       collect2: error: ld returned 1 exit status
34.80       ninja: build stopped: subcommand failed.
```
which is caused by mismatch between glib version and conda linker, and would be fixed by L25

### issue 2
 after 1, the image is successfully built then I start the container, the second issue I met is 
```
CondaError: Run 'conda init' before 'conda activate'
```
which would be fixed by L28 29 33

### issue 3
after 2, I successfully started the container, then I wanna test by `python -c "import tilelang; print(tilelang.__version__)"`, but reported below, which is caused by incompatiable numpy version, and fixed by L26
```
A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.2.6 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.

Traceback (most recent call last):  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/tvm_ffi/utils/_build_optional_torch_c_dlpack.py", line 30, in <module>
    import torch
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/__init__.py", line 2120, in <module>
    from torch._higher_order_ops import cond
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/_higher_order_ops/__init__.py", line 1, in <module>
    from .cond import cond
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/_higher_order_ops/cond.py", line 5, in <module>
    import torch._subclasses.functional_tensor
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/_subclasses/functional_tensor.py", line 42, in <module>
    class FunctionalTensor(torch.Tensor):
  File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/_subclasses/functional_tensor.py", line 258, in FunctionalTensor
    cpu = _conversion_method_template(device=torch.device("cpu"))
/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/_subclasses/functional_tensor.py:258: UserWarning: Failed to initialize NumPy: _ARRAY_API not found (Triggered internally at /var/lib/jenkins/pytorch/torch/csrc/utils/tensor_numpy.cpp:84.)
  cpu = _conversion_method_template(device=torch.device("cpu"))
0.1.7+cuda.gitbc084aa4
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container startup behavior with enhanced shell initialization for better interactivity.
  * Updated environment preparation flow to ensure more reliable setup during container initialization.
  * Optimized conda environment auto-activation for streamlined developer experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->