### PR TITLE
[Bugfix] Improve autotune from elementwise_add function in examples

### DIFF
--- a/examples/elementwise/test_example_elementwise.py
+++ b/examples/elementwise/test_example_elementwise.py
@@ -6,7 +6,7 @@ def test_example_elementwise_add():
     example_elementwise_add.main()
 
 
-def test_example_elementwise_add_with_autotune():
+def test_example_elementwise_add_autotune():
     example_elementwise_add.main(use_autotune=True)
 
 


### PR DESCRIPTION
This pull request updates the `example_elementwise_add.py` example to improve the compilation and execution of the element-wise addition kernel. The main change is the removal of the `@tilelang.jit` decorator, which caused `autotuner.run` to fail when autotune was enabled in this example.

Kernel compilation and execution improvements:

* Removed the `@tilelang.jit(out_idx=[-1])` decorator from the `elementwise_add` function, so it now returns a program instead of a compiled kernel.
* Updated the main function to first generate the program using `elementwise_add`, then compile it with `tilelang.compile`, specifying `out_idx` and `target`. This makes the compilation step explicit and configurable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the elementwise example to expose size and autotune flags, add an autotuning configuration generator, and switch the build flow to support runtime autotune or a default config; removed legacy autotune helper utilities.
* **Tests**
  * Added a test exercising the autotune execution path for the elementwise example.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->