### PR TITLE
[Cache] Rename sparse compress cache directory

### DIFF
--- a/tilelang/utils/sparse.py
+++ b/tilelang/utils/sparse.py
@@ -9,6 +9,7 @@ from tilelang import env
 
 # Include version information to ensure different versions use separate caches
 from tilelang import __version__
+
 # Define paths
 compress_util = os.path.join(env.TILELANG_TEMPLATE_PATH, "tl_templates/cuda/compress_sm90.cu")
 # Cache directory for compiled extensions


### PR DESCRIPTION
This pull request makes a targeted improvement to the caching mechanism for compiled CUDA extensions in the `tilelang/utils/sparse.py` module. The main change is to ensure that different versions of the package use separate cache directories, which helps prevent conflicts and compatibility issues when switching between versions.

Cache management improvement:

* Updated the cache directory path for compiled CUDA extensions to include the current package version (`__version__`), ensuring that each version uses its own cache and avoiding cross-version conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sparse cache now maintains version-specific cache directories, preventing potential conflicts across different package versions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->