### PR TITLE
remove unused duplicated type check

### DIFF
--- a/src/target/codegen_cuda.cc
+++ b/src/target/codegen_cuda.cc
@@ -131,8 +131,7 @@ static std::string GetTileLangFP8Type(DataType type) {
   if (type.is_float8_e4m3fn() || type.is_float8_e4m3fnuz() ||
       type.is_float8_e4m3()) {
     stream << "fp8_e4" << vec << "_t";
-  } else if (type.is_float8_e5m2() || type.is_float8_e5m2fnuz() ||
-             type.is_float8_e5m2()) {
+  } else if (type.is_float8_e5m2() || type.is_float8_e5m2fnuz()) {
     stream << "fp8_e5" << vec << "_t";
   } else if (type.is_float8_e8m0fnu()) {
     stream << "fp8_e8" << vec << "_t";


### PR DESCRIPTION
The second `type.is_float8_e5m2()` is duplicated in the `if` statement, so I removed it here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal code generation logic for improved clarity and maintainability with no impact on functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->