### PR TITLE
[Language] Enhance T.dtype.as_torch conversion for compatibility

### DIFF
--- a/tilelang/language/v2/dtypes.py
+++ b/tilelang/language/v2/dtypes.py
@@ -173,21 +173,21 @@ def __dtype_as_torch__(self: dtype) -> torch.dtype:
             )
             return torch.float8_e4m3fn
     elif dtype_str == "float8_e5m2":
-        assert hasattr(torch, "float8_e5m2"), "torch.float8_e5m2 is not supported in this version of torchPlease upgrade torch >= 2.1.0"
+        assert hasattr(torch, "float8_e5m2"), "torch.float8_e5m2 is not supported in this version of torch. Please upgrade torch >= 2.1.0"
         return torch.float8_e5m2
     elif dtype_str == "e4m3fnuz_float8":
         assert hasattr(torch, "float8_e4m3fnuz"), (
-            "torch.float8_e4m3fnuz is not supported in this version of torchPlease upgrade torch >= 2.2.0"
+            "torch.float8_e4m3fnuz is not supported in this version of torch. Please upgrade torch >= 2.2.0"
         )
         return torch.float8_e4m3fnuz
     elif dtype_str == "float8_e8m0fnu":
         assert hasattr(torch, "float8_e8m0fnu"), (
-            "torch.float8_e8m0fnu is not supported in this version of torchPlease upgrade torch >= 2.8.0"
+            "torch.float8_e8m0fnu is not supported in this version of torch. Please upgrade torch >= 2.8.0"
         )
         return torch.float8_e8m0fnu
     elif dtype_str == "float4_e2m1fnx2":
         assert hasattr(torch, "float4_e2m1fnx2"), (
-            "torch.float4_e2m1fnx2 is not supported in this version of torchPlease upgrade torch >= 2.8.0"
+            "torch.float4_e2m1fnx2 is not supported in this version of torch. Please upgrade torch >= 2.8.0"
         )
         return torch.float4_e2m1fnx2
     elif dtype_str in _STR_TO_TORCH_DTYPE:


### PR DESCRIPTION
- Added support for new float8 and float4 data types in the __dtype_as_torch__ method.
- Implemented backend-specific handling for float8_e4m3 based on HIP or CUDA.
- Included assertions to ensure compatibility with the required PyTorch versions for each dtype.
- Improved error handling for unsupported dtypes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for more extended float8/float4 numeric types (multiple variants) to broaden precision options.
  * Implemented backend-aware handling so AMD ROCm and CUDA platforms select appropriate runtime dtypes.
  * Added runtime checks with clear upgrade hints when a needed dtype is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->