### PR TITLE
[Language] Fix gemm syntax highlight

### DIFF
--- a/tilelang/language/loop.py
+++ b/tilelang/language/loop.py
@@ -98,6 +98,28 @@ def Pipelined(
 def serial(
     start: tir.PrimExpr, stop: tir.PrimExpr | None = None, step: tir.PrimExpr | None = None, *, annotations: dict[str, Any] | None = None
 ) -> frame.ForFrame:
+    """The serial For statement.
+
+    Parameters
+    ----------
+    start : PrimExpr
+        The minimum value of iteration.
+
+    stop : PrimExpr
+        The maximum value of iteration.
+
+    step : PrimExpr
+        The step size of the iteration.
+
+    annotations : Dict[str, Any]
+        The optional annotations of the For statement.
+
+    Returns
+    -------
+    res : frame.ForFrame
+        The ForFrame.
+    """
+
     step_is_one = False
     step_is_one |= isinstance(step, int) and step == 1
     step_is_one |= isinstance(step, IntImm) and step.value == 1
@@ -179,8 +201,14 @@ def unroll(
 
 
 def Serial(
-    start: tir.PrimExpr, stop: tir.PrimExpr | None = None, step: tir.PrimExpr | None = None, *, annotations: dict[str, Any] | None = None
+    start: tir.PrimExpr,
+    stop: tir.PrimExpr | None = None,
+    step: tir.PrimExpr | None = None,
+    *,
+    annotations: dict[str, Any] | None = None,
 ):
+    """Alias of T.serial."""
+
     return serial(start, stop, step, annotations=annotations)
 
 
@@ -193,4 +221,6 @@ def Unroll(
     unroll_factor: int | None = None,
     annotations: dict[str, Any] | None = None,
 ):
+    """Alias of T.unroll."""
+
     return unroll(start, stop, step, explicit=explicit, unroll_factor=unroll_factor, annotations=annotations)


### PR DESCRIPTION
Following https://github.com/tile-ai/tilelang/pull/1466, this PR fixes the highlight problem of `T.gemm`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * GEMM entry now uses a runtime-dispatching callable wrapper instead of a static alias, preserving behavior while enabling runtime selection.
  * Loop helpers Serial and Unroll now expose explicit, typed function signatures for clearer argument handling while forwarding to the same underlying implementations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->