### PR TITLE
[Dependency] Update apache-tvm-ffi to >=0.1.6 for memory safety when gc is not enabled

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     # Extra constraint to tvm-ffi for abi issue,
     # should be removed after our tvm's update.
     # See discussion in tilelang#1373 and apache/tvm-ffi#307
-    "apache-tvm-ffi>=0.1.3",
+    "apache-tvm-ffi>=0.1.6",
     # torch-c-dlpack-ext provides prebuilt torch extensions.
     # Without it, TVM FFI may require JIT compilation on first import.
     "torch-c-dlpack-ext",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Requirements to run local build with `--no-build-isolation` or other developments
 
-apache-tvm-ffi>=0.1.3
+apache-tvm-ffi>=0.1.6
 build
 cmake>=3.26
 cython>=3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Runtime requirements
-apache-tvm-ffi>=0.1.3
+apache-tvm-ffi>=0.1.6
 torch-c-dlpack-ext
 cloudpickle
 ml-dtypes


### PR DESCRIPTION
As title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated apache-tvm-ffi dependency to version 0.1.6 or higher across development and runtime environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->