### PR TITLE
[Fix] Fix TL_ENABLE_PTXAS_VERBOSE_OUTPUT has no effect in tvm-ffi

### DIFF
--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -107,19 +107,22 @@ def tilelang_callback_cuda_compile(code, target, pass_config=None):
                     tokens.append(str(flag))
         options += tokens
 
+    verbose = False
     if enable_fast_math:
         options.append("--use_fast_math")
     if ptxas_usage_level is not None:
         options.append(f"--ptxas-options=--register-usage-level={ptxas_usage_level}")
     if verbose_ptxas_output:
         options.append("--ptxas-options=--verbose")
+        options.append("-w")  # Suppress warnings to make ptxas output more readable
+        verbose = True
 
     ptx = nvcc.compile_cuda(
         code,
         compile_format,
         arch,
         options=options,
-        verbose=False,
+        verbose=verbose,
     )
 
     return ptx


### PR DESCRIPTION
As title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA compilation to properly respect verbosity settings and warning suppression flags during the build process, ensuring more accurate control over compiler output and diagnostic messages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->