### PR TITLE
Fix ramp_lanes calculation in CUDA codegen

### DIFF
--- a/src/target/codegen_cuda.cc
+++ b/src/target/codegen_cuda.cc
@@ -2808,11 +2808,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const BufferLoadNode *op,
   } else {
     bool can_vector_load = false;
     arith::PVar<PrimExpr> base;
-    // For sub-byte types with lanes > 1 in element_dtype, adjust the ramp
-    // pattern
-    int ramp_lanes = (element_dtype.lanes() > 1 && element_dtype.bits() < 8)
-                         ? value_dtype.lanes() / element_dtype.lanes()
-                         : value_dtype.lanes();
+    int ramp_lanes = value_dtype.lanes() / element_dtype.lanes();
     if (arith::ramp(base, 1, ramp_lanes).Match(index)) {
       const RampNode *ramp = index.as<RampNode>();
       ICHECK(ramp);
@@ -2876,12 +2872,7 @@ void CodeGenTileLangCUDA::VisitStmt_(const BufferStoreNode *op) {
     stream << ref << " = " << value << ";\n";
   } else {
     arith::PVar<PrimExpr> base;
-    // For sub-byte types with lanes > 1 in element_dtype, adjust the ramp
-    // pattern
-    int ramp_lanes = (element_dtype.lanes() > 1 && element_dtype.bits() < 8)
-                         ? value_dtype.lanes() / element_dtype.lanes()
-                         : value_dtype.lanes();
-
+    int ramp_lanes = value_dtype.lanes() / element_dtype.lanes();
     if (arith::ramp(base, 1, ramp_lanes).Match(index_expr)) {
       std::string value = this->PrintExpr(op->value);
       this->PrintVecStore(op->buffer.get(), value_dtype, base.Eval(), value);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced CUDA code generation efficiency by simplifying vector operation calculations. Removed special-case handling that previously applied different rules for certain data types. Now uses a unified approach for computing vector operation widths across all buffer operations, ensuring more consistent behavior and improving code maintainability. Includes minor formatting improvements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->