### PR TITLE
[Bugfix] Fallback to a Linear Layout instead of raising errors

### DIFF
--- a/src/layout/gemm_layouts.cc
+++ b/src/layout/gemm_layouts.cc
@@ -768,9 +768,11 @@ Layout makeGemmABLayoutHopper(int mat_stride, int mat_continuous,
 
   if (mat_stride % 8 == 0) {
     if (mat_continuous % (vector_size * 8) == 0)
-      return makeFullBankSwizzleLayout(mat_stride, mat_continuous, element_size);
+      return makeFullBankSwizzleLayout(mat_stride, mat_continuous,
+                                       element_size);
     else if (mat_continuous % (vector_size * 4) == 0)
-      return makeHalfBankSwizzleLayout(mat_stride, mat_continuous, element_size);
+      return makeHalfBankSwizzleLayout(mat_stride, mat_continuous,
+                                       element_size);
     else if (mat_continuous % (vector_size * 2) == 0)
       return makeQuarterBankSwizzleLayout(mat_stride, mat_continuous,
                                           element_size);
@@ -794,9 +796,11 @@ Layout makeGemmABLayoutSm100(int mat_stride, int mat_continuous, int continuity,
 
   if (mat_stride % 8 == 0) {
     if (mat_continuous % (vector_size * 8) == 0)
-      return makeFullBankSwizzleLayout(mat_stride, mat_continuous, element_size);
+      return makeFullBankSwizzleLayout(mat_stride, mat_continuous,
+                                       element_size);
     else if (mat_continuous % (vector_size * 4) == 0)
-      return makeHalfBankSwizzleLayout(mat_stride, mat_continuous, element_size);
+      return makeHalfBankSwizzleLayout(mat_stride, mat_continuous,
+                                       element_size);
     else if (mat_continuous % (vector_size * 2) == 0)
       return makeQuarterBankSwizzleLayout(mat_stride, mat_continuous,
                                           element_size);


### PR DESCRIPTION
as title, previous pr introduced atomatically tma swizzle lowering, but some tma shape can not apply swizzling and then raise errors, we should fallback it into linear gemm layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined memory layout selection for 64-bit elements. Now uses linear layout fallback when stride alignment requirements are not met, preventing attempts to use bank swizzle layouts in incompatible configurations.
  * Enhanced stride alignment validation across supported GPU architectures for improved consistency and robustness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->