### PR TITLE
[Bugfix] Skip stride check for subtype

### DIFF
--- a/testing/python/language/test_tilelang_language_vectorized_cast.py
+++ b/testing/python/language/test_tilelang_language_vectorized_cast.py
@@ -135,5 +135,4 @@ def test_vectorized_cast_fp4(src_dtype, dst_dtype, check_str, lanes):
 
 
 if __name__ == "__main__":
-    # tilelang.testing.main()
-    test_vectorized_cast_fp4(T.float4_e2m1fn, T.float32, "__tl_cvt_fp4x2_to_float2", 2)
+    tilelang.testing.main()


### PR DESCRIPTION
This pull request introduces a targeted fix for handling subbyte data types (such as those with fewer than 8 bits per element) in the argument binding process of DLTensors, and includes a minor change to the test invocation in the vectorized cast test script. The key changes are as follows:

### DLTensor Argument Binding Improvements

* Updated `ArgBinder::BindDLTensors` in `src/transform/arg_binder.cc` to skip stride checks and binding for subbyte types (bits < 8), as these use packed storage and stride semantics do not apply. This prevents incorrect or unnecessary stride logic for such types. [[1]](diffhunk://#diff-cf1ace031cae946b6c2976dc53c155094c3a5a335771938a55fede8eee679b75R716-R720) [[2]](diffhunk://#diff-cf1ace031cae946b6c2976dc53c155094c3a5a335771938a55fede8eee679b75R815)

### Test Script Adjustment

* In `testing/python/language/test_tilelang_language_vectorized_cast.py`, commented out the main test runner and replaced it with a direct call to `test_vectorized_cast_fp4` for a specific test case, likely for focused debugging or validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized stride validation for subbyte data types to improve tensor processing efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->