### PR TITLE
[Release] Build tilelang against CUDA 13.1 in CI

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -134,13 +134,10 @@ jobs:
           create-symlink: true
           evict-old-files: "7d"
           append-timestamp: false
-          key: wheel-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target.toolkit }}-${{ hashFiles('**/*.cc') }}
+          key: wheel-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.cc') }}
           restore-keys: |
-            wheel-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target.toolkit }}-${{ hashFiles('**/*.cc') }}
-            wheel-${{ runner.os }}-${{ runner.arch }}-${{ matrix.target.toolkit }}
+            wheel-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('**/*.cc') }}
             wheel-${{ runner.os }}-${{ runner.arch }}
-            ${{ runner.os }}-${{ runner.arch }}-${{ matrix.target.toolkit }}
-            ${{ runner.os }}-${{ runner.arch }}
 
       - name: Set CIBW_BUILD
         run: |


### PR DESCRIPTION
Related to: https://github.com/tile-ai/tilelang/issues/1504

Also remove toolchain version from Github Action cache key, it turns out that different cuda version can share same cache and get similar speedup: https://github.com/tile-ai/tilelang/actions/runs/20498276657/job/58901369419?pr=1532

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Expanded build matrix to produce binaries with CUDA 13.1 on additional platforms, including ARM64 systems running Ubuntu 24.04.
  * Simplified build caching/keying to improve cache consistency and reduce restore overhead during builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->