### PR TITLE
[Compat] Add CUDA version check for __nv_fp8_e8m0 type

### DIFF
--- a/src/tl_templates/cuda/cuda_fp8.h
+++ b/src/tl_templates/cuda/cuda_fp8.h
@@ -6,7 +6,19 @@
 
 using fp8_e4_t = tl::float_e4m3_t;
 using fp8_e5_t = tl::float_e5m2_t;
+
+// __nv_fp8_e8m0 is only available in CUDA 12.6+
+#if __CUDACC_VER_MAJOR__ > 12 ||                                               \
+    (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 6)
 using fp8_e8_t = __nv_fp8_e8m0;
+#define TL_HAS_FP8_E8M0 1
+#else
+// Placeholder for CUDA < 12.6
+struct fp8_e8_t {
+  unsigned char data;
+};
+#define TL_HAS_FP8_E8M0 0
+#endif
 
 struct __CUDA_ALIGN__(2) fp8_e4_2_t {
   fp8_e4_t x;


### PR DESCRIPTION
## Summary
- Add conditional compilation for `__nv_fp8_e8m0` type which is only available in CUDA 12.6+
- Provide a placeholder struct for older CUDA versions to maintain compatibility
- Define `TL_HAS_FP8_E8M0` macro to allow runtime feature detection

## Test plan
- [x] Compile with CUDA < 12.6 to verify no `__nv_fp8_e8m0` undefined error
- [x] Compile with CUDA >= 12.6 to verify native type is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for CUDA fp8_e8_t data type with conditional availability based on CUDA version (12.6+).
  * Introduced feature detection capability to identify fp8_e8m0 support availability.
  * Implemented backward compatibility for CUDA versions prior to 12.6 with appropriate fallback mechanisms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->