### PR TITLE
[example] use T.dynamic instead of tvm.te.var

### DIFF
--- a/examples/dynamic_shape/example_dynamic.py
+++ b/examples/dynamic_shape/example_dynamic.py
@@ -1,7 +1,6 @@
 import tilelang
 import tilelang.language as T
 import tilelang.testing
-from tilelang import tvm as tvm
 
 
 @tilelang.jit
@@ -17,9 +16,9 @@ def matmul_dynamic_mnk(
     num_stages,
     threads,
 ):
-    M = tvm.te.var("m")
-    N = tvm.te.var("n")
-    K = tvm.te.var("k")
+    M = T.dynamic("m")
+    N = T.dynamic("n")
+    K = T.dynamic("k")
 
     A_shape = (K, M) if trans_A else (M, K)
     B_shape = (N, K) if trans_B else (K, N)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated example code to use modern dynamic variable construction methods.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->