### PR TITLE
[Bugfix] Avoid considering `local.var` buffer as `local`

### DIFF
--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -193,8 +193,6 @@ void ParallelOpNode::ExpandLetBindings(
     PostOrderVisit(expr, [&](const ObjectRef &node) {
       if (auto bl = node.as<BufferLoadNode>()) {
         if (IsFragmentBuffer(bl->buffer) && !indice_map_.count(bl->buffer)) {
-          LOG(INFO) << "ExpandLetBindings: set buffer " << bl->buffer
-                    << " with indices " << bl->indices;
           indice_map_.Set(bl->buffer, bl->indices);
         }
       } else if (auto var_node = node.as<VarNode>()) {

--- a/src/op/utils.h
+++ b/src/op/utils.h
@@ -48,8 +48,7 @@ inline bool IsGlobalBuffer(const Buffer &buffer) {
 }
 
 inline bool IsLocalBuffer(const Buffer &buffer) {
-  return buffer.defined() &&
-         (buffer.scope() == "local" || buffer.scope() == "local.var");
+  return buffer.defined() && buffer.scope() == "local";
 }
 
 } // namespace tl


### PR DESCRIPTION
This pull request includes minor improvements to logging and buffer scope checks in the parallel operation utilities.

Buffer scope handling:

* Updated `IsLocalBuffer` in `src/op/utils.h` to only consider buffers with scope `"local"` as local buffers, removing support for `"local.var"` scope.

Logging cleanup:

* Removed an informational log statement from the `ExpandLetBindings` method in `src/op/parallel.cc` to reduce unnecessary output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved buffer scope detection accuracy.

* **Chores**
  * Removed verbose logging for buffer operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->