### PR TITLE
[Refactor] Enhance deterministic ordering in shared memory allocation merge.

### DIFF
--- a/src/transform/merge_shared_memory_allocations.cc
+++ b/src/transform/merge_shared_memory_allocations.cc
@@ -751,7 +751,8 @@ private:
                 if (lhs.size_bytes != rhs.size_bytes) {
                   return lhs.size_bytes > rhs.size_bytes;
                 }
-                // Use name comparison for deterministic ordering instead of pointer comparison
+                // Use name comparison for deterministic ordering instead of
+                // pointer comparison
                 return lhs.var->name_hint < rhs.var->name_hint;
               });
 
@@ -1101,7 +1102,8 @@ private:
       }
     }
 
-    // Create a sorted vector of keys from shmem_allocs_ for deterministic iteration
+    // Create a sorted vector of keys from shmem_allocs_ for deterministic
+    // iteration
     std::vector<const VarNode *> sorted_vars;
     sorted_vars.reserve(shmem_allocs_.size());
     for (const auto &kv : shmem_allocs_) {


### PR DESCRIPTION
* Updated comparison logic in merge_shared_memory_allocations.cc to use name hints for deterministic ordering of variables instead of pointer comparisons.
* Introduced a sorted vector of keys for shmem_allocs_ to ensure consistent iteration order when processing allocations.

This refactor aims to improve the predictability of shared memory allocation handling in the transformation process. Otherwise, a same input program may lead to different smem allocate result and may lead to nondeterministic kernel performance.

Before:

First Run:
```
 S_shared -> offset=221184
 K_tail_shared_1 -> offset=212992
 K_tail_shared_0 -> offset=204800
 KV_shared_1_r -> offset=139264
 KV_shared_1_l -> offset=73728
 Q_tail_shared -> offset=65536
 sum_exp_shared -> offset=229376
 KV_shared_0_r -> offset=172032
 KV_shared_0_l -> offset=106496
 O_shared_l -> offset=32768
 O_shared_r -> offset=0
```

Second Run:

```
 sum_exp_shared -> offset=229376
 K_tail_shared_1 -> offset=212992
 K_tail_shared_0 -> offset=221184
 S_shared -> offset=204800
 KV_shared_1_l -> offset=172032
 KV_shared_1_r -> offset=73728
 Q_tail_shared -> offset=65536
 KV_shared_0_l -> offset=139264
 O_shared_l -> offset=32768
 KV_shared_0_r -> offset=106496
 O_shared_r -> offset=0
```

After this pass, they'll be the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed non-deterministic behavior in shared memory allocation scheduling: allocation ordering and offsets are now computed consistently by using a stable, name-based ordering of variables. This produces reproducible memory layout and scheduling across runs, reducing variability in builds and executions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->