### PR TITLE
[Release] Fix race condition when publishing

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -152,7 +152,7 @@ jobs:
             echo "CUDA_VERSION=${CUDA_VERSION}" | tee -a "${GITHUB_ENV}"
           fi
 
-          if [[ "${{ matrix.target.toolkit }}" == "Nightly-"* ]]; then
+          if [[ "${{ matrix.target.toolkit }}" == "Nightly-"* ]] && [[ "${{ github.event_name }}" == "release" ]]; then
             # Avoid using same file name for different toolkit.
             echo "NO_VERSION_LABEL=OFF" | tee -a "${GITHUB_ENV}"
             echo "NO_GIT_VERSION=ON" | tee -a "${GITHUB_ENV}"


### PR DESCRIPTION
File names after this PR:

```
$ ls ~/Downloads/artifacts\ \(1\)                         
tilelang-0.1.7.post2-cp38-abi3-macosx_11_0_arm64.whl
tilelang-0.1.7.post2-cp38-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
tilelang-0.1.7.post2-cp38-abi3-manylinux_2_34_aarch64.whl
tilelang-0.1.7.post2.tar.gz
tilelang-0.1.7.post2+cu131-cp38-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
tilelang-0.1.7.post2+cu131-cp38-abi3-manylinux_2_34_aarch64.whl
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Marked CUDA-13.1 targets as nightly builds in the wheel build matrix.
  * Improved CUDA-version parsing to extract the version from the last dash-delimited segment.
  * Added Nightly-* handling so nightly builds suppress normal version labels on release to avoid duplicate labeling; change applied across wheel build and setup logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->