### PR TITLE
[BugFix] : Add missing __syncthreads() after AtomicAdd and replace address_ of with access_ptr

### DIFF
--- a/src/op/atomic_add.cc
+++ b/src/op/atomic_add.cc
@@ -273,7 +273,6 @@ For AtomicAddNode::MakeSIMTLoop(arith::Analyzer *analyzer) const {
     src_value = Cast(dst->dtype, src_value);
 
   // Build a pointer to destination element using tvm_access_ptr
-  BufferLoad dst_load = BufferLoad(dst, dst_indices);
   Array<Range> dst_ranges;
   for (const PrimExpr &index : dst_indices) {
     dst_ranges.push_back(Range::FromMinExtent(index, 1));

--- a/src/transform/atomicadd_vectorize.cc
+++ b/src/transform/atomicadd_vectorize.cc
@@ -285,14 +285,8 @@ private:
               MakeAccessPtrFromRegion(dst_region, 2); // 2 = write access
           new_args.push_back(dst_ptr);
         } else if (const auto *call = node->args[0].as<CallNode>()) {
-          // If it's already an address_of or access_ptr, forward it; otherwise,
-          // keep original.
-          if (call->op.same_as(builtin::address_of()) ||
-              call->op.same_as(builtin::tvm_access_ptr())) {
-            new_args.push_back(node->args[0]);
-          } else {
-            new_args.push_back(node->args[0]);
-          }
+          // Forward the call as-is (address_of, access_ptr, or other)
+          new_args.push_back(node->args[0]);
         } else {
           new_args.push_back(node->args[0]);
         }

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -506,7 +506,7 @@ public:
 
   Stmt VisitStmt_(const EvaluateNode *op) final {
     if (const auto *call = op->value.as<CallNode>()) {
-      if (call->op.same_as(builtin::call_extern()) && call->args.size() >= 1) {
+      if (call->op.same_as(builtin::call_extern()) && !call->args.empty()) {
         if (const auto *func_name = call->args[0].as<StringImmNode>()) {
           std::string name = func_name->value;
           // Check if this is an AtomicAdd call (AtomicAdd, AtomicAddx2,
@@ -536,7 +536,7 @@ public:
                     }
                   }
                 } else if (ptr_call->op.same_as(builtin::address_of()) &&
-                           ptr_call->args.size() >= 1) {
+                           !ptr_call->args.empty()) {
                   // Handle legacy address_of case (for backward compatibility)
                   if (const auto *load =
                           ptr_call->args[0].as<BufferLoadNode>()) {


### PR DESCRIPTION
This commit fixes two issues:

1. Issue #1257: Add missing __syncthreads() after AtomicAdd operations
   - Added ThreadSyncAfterAtomicInserter class in thread_storage_sync.cc
   - Automatically inserts __syncthreads() after AtomicAdd on shared memory
   - Integrated into TileLangThreadSync() pass
   - Fixes synchronization issue in generated CUDA kernels

2. Issue #1423: Replace address_of with access_ptr (tvm_access_ptr)
   - Updated atomic_add.cc to use MakeAccessPtrFromRegion
   - Updated atomicadd_vectorize.cc to use MakeAccessPtrFromRegion
   - Provides richer semantic information for analysis
   - Maintains backward compatibility

Changes:
- src/op/atomic_add.cc: Replace address_of with access_ptr in AtomicAdd operations
- src/transform/atomicadd_vectorize.cc: Replace address_of with access_ptr in vectorization
- src/transform/thread_storage_sync.cc: Add ThreadSyncAfterAtomicInserter for syncthreads insertion

Verification:
- Compilation: Success
- Runtime: Verified with test case
- Generated CUDA code: Confirmed __syncthreads() is present after AtomicAdd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically insert thread synchronization barriers after atomic operations targeting shared memory to ensure correct visibility and ordering.

* **Refactor**
  * Standardized buffer argument handling to use region-based access pointers across atomic, vectorized, and transfer paths, improving consistency while preserving public interfaces and remaining compatible with legacy pointer forms.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->