### PR TITLE
[Bugfix] Add kernel_global_source property to TVMFFIKernelAdapter

### DIFF
--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -97,6 +97,7 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
         self.pass_configs = pass_configs
         self.compile_flags = compile_flags
         self.dynamic_symbolic_map = self._process_dynamic_symbolic()
+        self.kernel_global_source = self.device_kernel_source
 
         self._post_init()
 


### PR DESCRIPTION
fix #1576 

JITKernel.kernel_source falls back to self.adapter.kernel_global_source when artifact is None:

https://github.com/tile-ai/tilelang/blob/dcacc5a23d62d95d1c4bd4964a007dec26aeff8e/tilelang/jit/kernel.py#L616-L618

which causes the following error,

```
Error saving kernel source code to disk: 'TVMFFIKernelAdapter' object has no attribute 'kernel_global_source'
```

TVMFFIKernelAdapter was missing this attribute.

Add kernel_global_source assignment in __init__, consistent with CuTeDSLKernelAdapter:

https://github.com/tile-ai/tilelang/blob/dcacc5a23d62d95d1c4bd4964a007dec26aeff8e/tilelang/jit/adapter/cutedsl/adapter.py#L95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal improvements to kernel source code handling for enhanced consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->