### PR TITLE
Add conversion from cutlass::float_e4m3/e5m2 to tl::float_e4m3/e5m2

### DIFF
--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -556,7 +556,7 @@ struct float_e4m3_t : public cute::float_e4m3_t {
 
   CUTLASS_HOST_DEVICE
   float_e4m3_t(cutlass::float_e4m3_t x)
-      : cute::float_e4m3_t(*reinterpret_cast<cute::float_e4m3_t*>(&x)) {}
+      : cute::float_e4m3_t(*reinterpret_cast<cute::float_e4m3_t *>(&x)) {}
 };
 
 struct float_e5m2_t : public cute::float_e5m2_t {
@@ -570,7 +570,7 @@ struct float_e5m2_t : public cute::float_e5m2_t {
 
   CUTLASS_HOST_DEVICE
   float_e5m2_t(cutlass::float_e5m2_t x)
-      : cute::float_e5m2_t(*reinterpret_cast<cute::float_e5m2_t*>(&x)) {}
+      : cute::float_e5m2_t(*reinterpret_cast<cute::float_e5m2_t *>(&x)) {}
 };
 
 template <typename T> struct to_cute_type {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved interoperability between CUDA floating-point types by adding conversion constructors for the new compact float formats (enhanced automatic conversion between compatible float representations), reducing manual casting and easing integration in CUDA workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->