### PR TITLE
[BugFix] Add pre-commit to requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ cmake>=3.26
 cython>=3.0.0
 ninja
 packaging
-pre-commit
+pre-commit>=4.0.0
 scikit-build-core
 setuptools>=61
 torch


### PR DESCRIPTION
As reported in [#1609](https://github.com/tile-ai/tilelang/issues/1609), adding pre-commit to the requirements-dev.txt would simplify local development setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added pre-commit (>=4.0.0) to development dependencies to enable additional pre-commit tooling and checks.
  * This change affects developer workflows only; there are no runtime or build behavior changes visible to end users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->