### PR TITLE
[Bugfix] Do not consider local.var as local buffer during LowerTileOP

### DIFF
--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -769,13 +769,11 @@ private:
     bool has_non_local = false;
     PostOrderVisit(for_node->body, [&](const ObjectRef &obj) {
       if (const auto *load = obj.as<BufferLoadNode>()) {
-        if (!IsLocalBuffer(load->buffer) &&
-            !IsFragmentBuffer(load->buffer)) {
+        if (!IsLocalBuffer(load->buffer) && !IsFragmentBuffer(load->buffer)) {
           has_non_local = true;
         }
       } else if (const auto *store = obj.as<BufferStoreNode>()) {
-        if (!IsLocalBuffer(store->buffer) &&
-            !IsFragmentBuffer(store->buffer)) {
+        if (!IsLocalBuffer(store->buffer) && !IsFragmentBuffer(store->buffer)) {
           has_non_local = true;
         }
       }

--- a/testing/python/issue/test_tilelang_issue_1549.py
+++ b/testing/python/issue/test_tilelang_issue_1549.py
@@ -3,6 +3,7 @@ import tilelang.testing
 import tilelang.language as T
 import torch
 
+
 def test_issue_1549_strange_var_vectorization():
     @tl.jit
     def get_wrong_kernel(M: int = 4096):
@@ -29,10 +30,13 @@ def test_issue_1549_strange_var_vectorization():
     kernel(data)
     code = kernel.get_kernel_source()
     print(code)
-    assert """for (int i = 0; i < 32; ++i) {
+    assert (
+        """for (int i = 0; i < 32; ++i) {
     idx = ((i * 64) + ((int)threadIdx.x));
     Data[((i * 64) + ((int)threadIdx.x))] = idx;
-  }""" in code
+  }"""
+        in code
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
as title, which may lead to significant performance regression when we assign value into var.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced local buffer detection in parallel loop optimization, enabling thread binding and vectorization in additional scenarios.

* **Tests**
  * Added runtime verification of generated kernel source code in test suite.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->