### PR TITLE
[Example] Remove redundant T.copy in `examples/deepseek_v32/sparse_mla_fwd.py`

### DIFF
--- a/examples/deepseek_v32/sparse_mla_fwd.py
+++ b/examples/deepseek_v32/sparse_mla_fwd.py
@@ -161,9 +161,7 @@ def sparse_mla_fwd(
             for h_i in T.Parallel(H_per_block):
                 sumexp[h_i] = T.log2(sumexp[h_i]) + m_i[h_i] * sm_scale
 
-            T.copy(acc_o, O_shared)
             T.copy(acc_o, Output[b_i, s_i, H0:H1, :])
-            T.copy(sumexp, Lse_shared)
             T.copy(sumexp, Lse[b_i, s_i, H0:H1])
 
     return main


### PR DESCRIPTION
The `T.copy()` operations I removed seem to be redundant, after removing it, I observed Slight performance improvement on L20.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Sparse MLA kernel forward pass efficiency by streamlining memory management. Removed intermediate buffer stages and now directs final computation results directly to output buffers, reducing memory overhead and enhancing kernel performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->