### PR TITLE
[ASTPrinter] Fix IfThenElse printing and some format problems

### DIFF
--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -125,7 +125,6 @@ def PreLowerSemanticCheck(mod: IRModule) -> None:
     Note: This is a validation-only pipeline of passes and does not modify or return the module.
     """
 
-    print(mod)
     # Print AST for debugging purpose
     if should_enable_ast_print():
         tilelang.analysis.ASTPrinter()(mod)


### PR DESCRIPTION
Previous ASTPrinter doesn't correctly handle the IfThenElse's sub-stmt logic. And we disable "stmt brief script" since it's not accurate. For example, for BufferStore, it will choose it's first line as its brief, which is usually a buffer declaration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated AST printer output formatting to display class names and restructured tree prefixes with field names and indices, replacing previous script excerpt display.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->