### PR TITLE
[Refactor] Move dtypes.py from eager to language and add bits/bytes properties

### DIFF
--- a/testing/python/language/test_tilelang_language_frontend_v2.py
+++ b/testing/python/language/test_tilelang_language_frontend_v2.py
@@ -40,7 +40,7 @@ def test_argument():
 
 
 def test_expr():
-    from tilelang.language.eager.dtypes import _all_dtypes
+    from tilelang.language.dtypes import _all_dtypes
 
     errors = []
     for name in _all_dtypes:

--- a/tilelang/__init__.py
+++ b/tilelang/__init__.py
@@ -160,7 +160,7 @@ with _lazy_load_lib():
         engine,  # noqa: F401
         tools,  # noqa: F401
     )
-    from .language.eager import dtypes  # noqa: F401
+    from .language import dtypes  # noqa: F401
     from .autotuner import autotune  # noqa: F401
     from .transform import PassConfigKey  # noqa: F401
     from .engine import lower, register_cuda_postproc, register_hip_postproc, register_c_postproc  # noqa: F401

--- a/tilelang/dtypes.py
+++ b/tilelang/dtypes.py
@@ -1,0 +1,3 @@
+# Re-export from language.dtypes for convenient access via `from tilelang.dtypes import ...`
+from tilelang.language.dtypes import *  # noqa: F401, F403
+from tilelang.language.dtypes import dtype, AnyDType, get_tvm_dtype  # noqa: F401

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -19,7 +19,7 @@ from tilelang.utils.target import determine_target
 from tilelang.jit.adapter.base import BaseKernelAdapter
 from tilelang.utils.language import retrieve_func_from_module
 from tilelang.engine.param import KernelParam
-from tilelang.language.eager.dtypes import dtype
+from tilelang.language.dtypes import dtype
 
 
 class TVMFFIKernelAdapter(BaseKernelAdapter):

--- a/tilelang/language/allocate.py
+++ b/tilelang/language/allocate.py
@@ -28,8 +28,8 @@ from tvm.tir import PrimExpr
 from tvm.script.parser.tir import block_attr
 from tvm.tir.buffer import Buffer
 from tvm.tir.expr import FloatImm, IntImm
-from .eager import dtypes as _dtypes
-from .eager.dtypes import dtype as tl_dtype
+from . import dtypes as _dtypes
+from .dtypes import dtype as tl_dtype
 from .eager.builder import OutTensor
 
 _Shapes = TypeVarTuple("_Shapes")

--- a/tilelang/language/dtypes.py
+++ b/tilelang/language/dtypes.py
@@ -12,6 +12,10 @@ _T = TypeVar("_T")
 if TYPE_CHECKING:
 
     class dtype(Generic[_T]):
+        @property
+        def bits(self) -> int: ...
+        @property
+        def bytes(self) -> int: ...
         def as_torch(self) -> torch.dtype: ...
 else:
     dtype = tvm.DataType
@@ -218,9 +222,15 @@ def __dtype_new__(cls, value: AnyDType) -> dtype:
         raise TypeError(f"Invalid DataType {value}({type(value)}), expect one of {expected}")
 
 
+def __dtype_bytes__(self: dtype) -> int:
+    """Return the number of bytes for this dtype."""
+    return self.itemsize
+
+
 dtype.__call__ = __dtype_call__
 dtype.__new__ = __dtype_new__
 dtype.as_torch = __dtype_as_torch__
+dtype.bytes = property(__dtype_bytes__)
 
 
 def get_tvm_dtype(value: AnyDType) -> dtype:

--- a/tilelang/language/eager/__init__.py
+++ b/tilelang/language/eager/__init__.py
@@ -1,2 +1,2 @@
 from .builder import prim_func, macro, PrimFunc, JITFunc, Ref, const  # noqa: F401
-from .dtypes import *
+from ..dtypes import *

--- a/tilelang/language/eager/ast.py
+++ b/tilelang/language/eager/ast.py
@@ -15,7 +15,7 @@ import inspect
 
 # from .utils import get_ast, get_compiled_object
 from . import utils
-from . import dtypes
+from .. import dtypes
 
 _span_attrs = ["lineno", "col_offset", "end_lineno", "end_col_offset"]
 

--- a/tilelang/language/eager/builder.py
+++ b/tilelang/language/eager/builder.py
@@ -27,7 +27,7 @@ try:
     from typing import ParamSpec, Self
 except ImportError:  # Python < 3.11 for Self, < 3.10 for ParamSpec
     from typing_extensions import ParamSpec, Self
-from . import dtypes as dt
+from .. import dtypes as dt
 from . import utils
 from tilelang.jit.exceptions import JITNoBuilderError, EagerJITBuildError
 import threading


### PR DESCRIPTION
## Summary

- Move `dtypes.py` from `tilelang/language/eager/` to `tilelang/language/` since dtype definitions are general-purpose, not eager-specific
- Add `bytes` property to dtype as a convenient alias for `itemsize`
- Create `tilelang/dtypes.py` for direct import via `from tilelang.dtypes import ...`

## Changes

| File | Change |
|------|--------|
| `language/dtypes.py` | Moved from `language/eager/dtypes.py`, added `bytes` property and type hints |
| `tilelang/dtypes.py` | New re-export module for convenient access |
| `language/eager/*.py` | Updated imports from `.` to `..` |
| `language/allocate.py` | Updated imports |
| `jit/adapter/tvm_ffi.py` | Updated imports |
| `tilelang/__init__.py` | Updated imports |

## Test plan

- [x] Verified `from tilelang.dtypes import float32, int8, dtype` works
- [x] Verified `dtype.bits` and `dtype.bytes` properties work correctly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `bits` and `bytes` properties to dtype objects for convenient access to type size information.
  * Introduced a new accessible module for importing data type utilities directly.

* **Refactor**
  * Reorganized internal data type imports for improved code structure and accessibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->