### PR TITLE
[Enhancement] Update LetStmtNode handling in loop vectorization to support variable binding overrides

### DIFF
--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -214,11 +214,12 @@ private:
     }
   }
 
-  // NOTE(wt): The base class IRMutatorWithAnalyzer::VisitStmt_(LetStmtNode*) binds
-  // let variables, but this causes issues when the same variable name appears
-  // multiple times with different values (e.g., in pipelined loops where the
-  // body is duplicated). For this case, we allow the analyzer to override the binding.
-  // Check the impl of IRMutatorWithAnalyzer::VisitStmt_(LetStmtNode*) in:
+  // NOTE(wt): The base class IRMutatorWithAnalyzer::VisitStmt_(LetStmtNode*)
+  // binds let variables, but this causes issues when the same variable name
+  // appears multiple times with different values (e.g., in pipelined loops
+  // where the body is duplicated). For this case, we allow the analyzer to
+  // override the binding. Check the impl of
+  // IRMutatorWithAnalyzer::VisitStmt_(LetStmtNode*) in:
   // tvm/src/arith/ir_mutator_with_analyzer.cc
   Stmt VisitStmt_(const LetStmtNode *op) final {
     PrimExpr value = this->VisitExpr(op->value);


### PR DESCRIPTION
fix #1472 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loop vectorization to better handle certain let-variable bindings, yielding more reliable optimized code generation and preserving correctness in compiled loops. No changes to public APIs or exported interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->