### PR TITLE
[EagerJIT] Add Support for Parameter Only Kernel Compilation

### DIFF
--- a/tilelang/language/eager/ast.py
+++ b/tilelang/language/eager/ast.py
@@ -472,6 +472,7 @@ class DSLMutator(ast.NodeTransformer):
         node.body = stmts + node.body
         node.decorator_list.clear()
         name = node.name
+        node.args.kwarg = ast.arg(arg="__kwargs")
         node = SpanAttacher("__tb_fl", "__tb_fn").visit(node)
         return quote1(
             f"def make_closure({', '.join(self.nonlocals.keys())}):\n"


### PR DESCRIPTION
This pr add support for the grammar to compile kernel with only constexpr parameters.

```py
@tilelang.jit
def transpose(X, Y, block_M, block_N):
    M, N = T.const("M N")
    X: T.Tensor[[M, N], T.float32]
    Y: T.Tensor[[N, M], T.float32]
    ...

transpose.compile(M=1024, N=1024, block_M=64, block_N=64)
transpose.par_compile(
    [
        {'M': M, 'N': N, 'block_M': 128, 'block_N': 128}
        for M, N in [(256, 256), (512, 512), (1024, 1024)]
    ]
)
```