### PR TITLE
[Feature] Support T.clone_buffer and preliminary T.load_buffer macros (#1567)

### DIFF
--- a/docs/programming_guides/language_basics.md
+++ b/docs/programming_guides/language_basics.md
@@ -148,7 +148,24 @@ T.copy(C_local, C[by * BM, bx * BN])
 
 `T.copy` performs coalescing and scope‑specific lowering during compilation.
 
-## 6. A Minimal End‑to‑End Example (Vector Add)
+## 6. Buffer Cloning and Loading
+
+TileLang provides a sugar macro `T.clone_buffer` to simplify the pattern of duplicating data within the same or different memory scopes.
+
+```python
+# Manually allocate and then copy
+A_shared = T.alloc_shared((128, 128), "float16")
+# ... some operations on A_shared ...
+A_backup = T.alloc_buffer(A_shared.shape, dtype=A_shared.dtype, scope=A_shared.scope())
+T.copy(A_shared, A_backup)
+
+# One-liner using T.clone_buffer
+A_shared = T.alloc_shared((128, 128), "float16")
+# ... some operations on A_shared ...
+A_backup = T.clone_buffer(A_shared)
+```
+
+## 7. A Minimal End‑to‑End Example (Vector Add)
 
 ```python
 import tilelang
@@ -189,7 +206,7 @@ Notes
 - You can pass compile‑time tunables (tile sizes, dtypes) through the outer
   Python function and bake them into the generated TIR.
 
-## 7. Tiled GEMM Skeleton
+## 8. Tiled GEMM Skeleton
 
 Below is a minimal pattern for a tiled GEMM using shared memory staging and a
 fragment accumulator. It mirrors the quickstart style found in the repository.
@@ -215,7 +232,7 @@ def gemm(
         T.copy(C_f, C[by * BM, bx * BN])
 ```
 
-## 8. Debugging and Printing
+## 9. Debugging and Printing
 
 Use `T.print` inside a kernel for quick introspection. TileLang emits printing
 from a single thread for shared/fragment scopes to avoid floods.

--- a/src/transform/unroll_loop.cc
+++ b/src/transform/unroll_loop.cc
@@ -118,6 +118,7 @@ public:
       return ret;
     } else if (op->attr_key == "pragma_unroll_explicit") {
       bool explicit_unroll = Downcast<Integer>(op->value)->value;
+      LOG(INFO) << "explicit_unroll: " << explicit_unroll;
       std::swap(explicit_unroll, explicit_unroll_);
       Stmt ret = this->VisitStmt(op->body);
       std::swap(explicit_unroll, explicit_unroll_);

--- a/testing/python/language/test_tilelang_clone.py
+++ b/testing/python/language/test_tilelang_clone.py
@@ -1,0 +1,45 @@
+import torch
+import tilelang as tl
+import tilelang.language as T
+
+
+def test_clone_buffer():
+    for scope in ["shared", "local"]:
+        M, N = 64, 64
+        @tl.jit
+        def kernel(A: T.Tensor((M, N), "float16"), B: T.Tensor((M, N), "float16")):
+            with T.Kernel(1, 1):
+                buf_source = T.alloc_buffer((M, N), dtype="float16", scope=scope)
+                T.copy(A, buf_source)
+                buf_cloned = T.clone_buffer(buf_source)
+                T.copy(buf_cloned, B)
+
+        a = torch.randn(M, N).cuda().half()
+        b = torch.empty(M, N).cuda().half()
+        kernel(a, b)
+        torch.testing.assert_close(a, b, rtol=1e-3, atol=1e-3)
+        print("Test clone_buffer: Passed")
+
+
+def test_load_buffer():
+    K = 32
+    @tl.jit
+    def kernel(A: T.Tensor((K, K), "float16"), B: T.Tensor((K, K), "float16")):
+        with T.Kernel(1, 1, threads=K * K):
+            A_shared = T.load_buffer(A, offsets=(0, 0), shape=(K, K), target="shared")
+            for i, j in T.Parallel(K, K):
+                A_shared[i, j] = A[i, j]
+            T.sync_threads()
+            for i, j in T.Parallel(K, K):
+                B[i, j] = A_shared[i, j]
+
+    a = torch.randn(K, K).cuda().half()
+    b = torch.zeros(K, K).cuda().half()
+    kernel(a, b)
+    torch.testing.assert_close(b, a, rtol=1e-3, atol=1e-3)
+    print("Test load_buffer: Passed ")
+
+
+if __name__ == "__main__":
+    test_clone_buffer()
+    test_load_buffer()

--- a/tilelang/language/__init__.py
+++ b/tilelang/language/__init__.py
@@ -24,7 +24,7 @@ from .loop import (
     Serial,  # noqa: F401
     Unroll,  # noqa: F401
 )
-from .frame import has_let_value, get_let_value  # noqa: F401
+from .frame import has_let_value, get_let_value, clone_buffer, load_buffer  # noqa: F401
 from .math_intrinsics import *  # noqa: F401
 from .kernel import (
     Kernel,  # noqa: F401


### PR DESCRIPTION
Introduce T.clone_buffer macro to automatically allocate and copy bufferswith identical shape and dtype, reducing boilerplate code.
Add test and doc.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced buffer cloning functionality for duplicating data across memory scopes
  * Added buffer region loading capabilities for copying sub-regions into target scopes

* **Documentation**
  * Added new programming guide section covering buffer cloning and loading with practical examples

* **Tests**
  * Added comprehensive tests for buffer cloning and loading operations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->