### PR TITLE
[BugFix] fix warning on deepseek_v32 topk_selector.py

### DIFF
--- a/examples/deepseek_v32/topk_selector.py
+++ b/examples/deepseek_v32/topk_selector.py
@@ -57,6 +57,8 @@ def tl_topk_impl(topk, in_dtype=T.float32, out_dtype=T.int32):
             l_end_idx = T.alloc_var(T.int32)
             l_out_pos = T.alloc_var(T.int32)
 
+            pos = T.alloc_var(T.int32)
+
             l_new_topk = topk
             l_start_idx = starts[bx]
             l_end_idx = ends[bx]


### PR DESCRIPTION
The previous implementation of `topk` will report an warning as
```
[datetime]  [TileLang:tilelang.env:WARNING]: Loading tilelang libs from dev root: <prefix>/tilelang/build
[datetime]   [TileLang:tilelang.language.v2.builder:WARNING]: Immutable value `pos` is re-bound. If you want to modify its value, please use T.alloc_var to make it a variable!
Stack (most recent call last):
  File "<prefix>/tilelang/examples/deepseek_v32/topk_selector.py", line 274, in <module>
    test_topk_selector()
  File "<prefix>/tilelang/examples/deepseek_v32/topk_selector.py", line 194, in test_topk_selector
    indexes = tl_topk(input, starts, ends, topk)
  File "<prefix>/tilelang/examples/deepseek_v32/topk_selector.py", line 180, in tl_topk
    kernel = tl_topk_impl(topk)
  File "<prefix>/tilelang/tilelang/jit/__init__.py", line 414, in __call__
    kernel = self.compile(*args, **kwargs, **tune_params)
  File "<prefix>/tilelang/tilelang/jit/__init__.py", line 348, in compile
    func = self.get_tir(*args, **kwargs)
  File "<prefix>/tilelang/tilelang/jit/__init__.py", line 296, in get_tir
    tir = self.func(*args, **kwargs)
  File "<prefix>/tilelang/examples/deepseek_v32/topk_selector.py", line 36, in tl_topk_impl
    def tl_topk_kernel(
  File "<prefix>/tilelang/tilelang/language/v2/builder.py", line 1006, in prim_func
    return impl(func) if func is not None else impl
  File "<prefix>/tilelang/tilelang/language/v2/builder.py", line 996, in impl
    ir_gen.gen(builder)(**annot)
  File "<prefix>/tilelang/examples/deepseek_v32/topk_selector.py", line 110, in tl_topk_kernel
    pos = T.atomic_add(s_num_input[0], 1, return_prev=True)
x  [TileLang:tilelang.language.v2.builder:WARNING]: Immutable value `pos` is re-bound. If you want to modify its value, please use T.alloc_var to make it a variable!
Stack (most recent call last):
  File "<prefix>/tilelang/examples/deepseek_v32/topk_selector.py", line 274, in <module>
    test_topk_selector()
  File "<prefix>/tilelang/examples/deepseek_v32/topk_selector.py", line 194, in test_topk_selector
    indexes = tl_topk(input, starts, ends, topk)
  File "<prefix>/tilelang/examples/deepseek_v32/topk_selector.py", line 180, in tl_topk
    kernel = tl_topk_impl(topk)
  File "<prefix>/tilelang/tilelang/jit/__init__.py", line 414, in __call__
    kernel = self.compile(*args, **kwargs, **tune_params)
  File "<prefix>/tilelang/tilelang/jit/__init__.py", line 348, in compile
    func = self.get_tir(*args, **kwargs)
  File "<prefix>/tilelang/tilelang/jit/__init__.py", line 296, in get_tir
    tir = self.func(*args, **kwargs)
  File "<prefix>/tilelang/examples/deepseek_v32/topk_selector.py", line 36, in tl_topk_impl
    def tl_topk_kernel(
  File "<prefix>/tilelang/tilelang/language/v2/builder.py", line 1006, in prim_func
    return impl(func) if func is not None else impl
  File "<prefix>/tilelang/tilelang/language/v2/builder.py", line 996, in impl
    ir_gen.gen(builder)(**annot)
  File "<prefix>/tilelang/examples/deepseek_v32/topk_selector.py", line 171, in tl_topk_kernel
    pos = T.atomic_add(s_num_input[r_idx ^ 1], 1, return_prev=True)
```

This PR allocates `pos` as a variable to avoid this warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Minor internal code cleanup: added an explicit local declaration with no behavioral or public API changes; no user-facing impact.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->