### PR TITLE
[Bugfix] Avoid reusing local.var allocations (#1678)

### DIFF
--- a/src/transform/storage_rewrite.cc
+++ b/src/transform/storage_rewrite.cc
@@ -1094,6 +1094,10 @@ private:
       return NewAlloc(op, attach_scope, scope, const_nbits);
     }
 
+    if (scope.tag == ".var") {
+      return NewAlloc(op, attach_scope, scope, const_nbits);
+    }
+
     if (is_known_size) {
       // constant allocation.
       auto begin = const_free_map_.lower_bound(const_nbits / match_range);

--- a/testing/python/issue/test_tilelang_issue_1678.py
+++ b/testing/python/issue/test_tilelang_issue_1678.py
@@ -1,0 +1,30 @@
+import tilelang
+import tilelang.testing
+from tilelang import language as T
+
+
+@tilelang.jit
+def _alloc_var_mixed_dtype_kernel():
+    @T.prim_func
+    def kernel():
+        with T.Kernel(1, 1, threads=1) as (_, _):
+            i = T.alloc_var(T.int32)
+            i = 1
+            tmp_row = T.alloc_local((4,), T.float32)
+            amax_local = T.alloc_var(T.float32)
+            j = i
+            amax_local = T.max(amax_local, tmp_row[j])
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_alloc_var_mixed_dtype_codegen():
+    kernel = _alloc_var_mixed_dtype_kernel()
+    source = kernel.get_kernel_source()
+    assert "int i" in source
+    assert "float amax_local" in source
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
Summary

This PR fixes incorrect local variable reuse in StorageRewrite that caused
multiple T.alloc_var() declarations to be merged into a single local variable,
leading to unexpected overwrites in generated CUDA code.

Root Cause

StorageRewrite previously allowed reuse of local.var allocations.
However, T.alloc_var() is semantically closer to a distinct scalar declaration
rather than a reusable buffer.

When multiple alloc_var are present in the same scope, reuse breaks
declaration and initialization ordering, producing invalid code such as:

```cpp
int i = 0;
float tmp_row[4];
i = 1;
i = max(i, tmp_row[0]);  // overwrites previous alloc_var
```

Fix

* Disable reuse for local.var in StorageRewrite (storage_rewrite.cc)
* Ensure each T.alloc_var() results in a unique local variable
* Preserve correct declaration and initialization semantics

This change only affects local.var and does not impact buffer or shared memory reuse.

Tests

* test_tilelang_issue_1678.py

Related Issue

Fixes [#1678](https://github.com/tile-ai/tilelang/issues/1678) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved allocation handling for specific scope scenarios.

* **Tests**
  * Added test coverage for allocation with mixed data type scenarios in CUDA environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->