### PR TITLE
[BugFix] Fix JITKernel export_library bug

### DIFF
--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -637,8 +637,17 @@ class JITKernel(Generic[_P, _T]):
         # rt_module: use export_library to export
         # rt_params: use cloudpickle to serialize
 
-        # Export the compiled kernel function to a shared library file.
-        self.rt_module.export_library(kernel_file)
+        if self.artifact is None or self.artifact.rt_mod is None:
+            raise AttributeError(
+                'Runtime module is not available. Please compile the kernel with `execution_backend="tvm_ffi"` before exporting.'
+            )
+
+        dir_path = os.path.dirname(kernel_file)
+        if dir_path:
+            os.makedirs(dir_path, exist_ok=True)
+
+        self.artifact.rt_mod.export_library(kernel_file)
+        logger.info(f"Kernel library exported to {os.path.abspath(kernel_file)}")
 
     def _get_ptx(self, verbose: bool | None = None) -> str:
         """


### PR DESCRIPTION
This pull request improves the robustness and usability of the kernel export functionality in `tilelang/jit/kernel.py`. The main change is to add error handling and ensure the target directory exists before exporting the compiled kernel library.

Kernel export improvements:

* Added a check to raise an `AttributeError` if `self.artifact` or `self.artifact.rt_mod` is not available, with a clear error message instructing the user to compile the kernel with `execution_backend="tvm_ffi"` before exporting.
* Ensured the target directory for the kernel file exists by creating it if necessary before exporting the library.
* Added a log message to confirm successful export and show the absolute path of the exported kernel library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved kernel library export robustness with enhanced validation.
  * Automatically creates required output directories during export.
  * Enhanced logging for export operations with file path information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->