### PR TITLE
[Refactor] Refactor cross vars handling logic to a copy-remap strategy in SplitHostDevice

### DIFF
--- a/testing/python/transform/test_tilelang_transform_split_host_device.py
+++ b/testing/python/transform/test_tilelang_transform_split_host_device.py
@@ -1,0 +1,36 @@
+from tilelang import tvm as tvm
+import tilelang as tl
+import tilelang.language as T
+import tilelang.testing
+
+
+def split_host_device_with_user_assume():
+    n = T.dynamic("n")
+
+    @T.prim_func
+    def main(a: T.Tensor[(n,), T.int32]):
+        T.assume(n >= 233 and n <= 1000)
+        with T.Kernel(1, threads=128):
+            for i in T.serial(T.ceildiv(n - 233, 123)):
+                a[i] = 1
+
+    return main
+
+
+def test_split_host_device_with_user_assume(with_B=False, with_bias=False):
+    tester = split_host_device_with_user_assume()
+    mod = tvm.IRModule({tester.attrs["global_symbol"]: tester})
+    # There are some dependent pass that need to be run before SplitHostDevice
+    mod = tvm.tir.transform.BindTarget(tvm.target.Target("cuda", "c"))(mod)
+    mod = tl.transform.InjectAssumes()(mod)
+    tilelang.analysis.ASTPrinter()(mod)
+    mod = tilelang.transform.AnnotateDeviceRegions()(mod)
+    tilelang.analysis.ASTPrinter()(mod)
+
+    mod2 = tl.transform.SplitHostDevice()(mod)
+
+    assert len(mod2.functions) == 2
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -263,12 +263,7 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
     if allow_global_thread_synchronization():
         mod = tilelang.transform.ThreadSync("global")(mod)
     mod = tilelang.transform.AnnotateDeviceRegions()(mod)
-
-    tilelang.analysis.ASTPrinter()(mod)
-    print(mod)
     mod = tilelang.transform.SplitHostDevice()(mod)
-    tilelang.analysis.ASTPrinter()(mod)
-    print(mod)
 
     # Mark the function contains pdl_sync or pdl_trigger
     mod = tilelang.transform.MarkCudaSyncCalls(have_pdl(target))(mod)


### PR DESCRIPTION
Prior to this PR, after SplitHostDevice, TIR vars which are "defined in host-side and used in device-side" (we call them "cross vars") are directly appended to the parameter list of new generated device function (e.g. main_kernel). This causes the device function body will not uses vars in parameter list, but uses a new renamed var. The root cause is complex. But I believe an important reason is that the old logic will let two "identical TIR vars" present in two different PrimFuncs, which is a dangerous case and may cause strange use-def analysis bug.

This PR refactors the logic of cross vars part, first copying them and doing remap. This makes the function form more reasonable and solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced host-device code splitting logic with improved cross-variable identification and buffer management on the device side.

* **Tests**
  * Added comprehensive tests for host-device transformation with user-supplied constraints.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->