### PR TITLE
[BugFix] Add int64_t support for AtomicAdd

### DIFF
--- a/src/tl_templates/cuda/atomic.h
+++ b/src/tl_templates/cuda/atomic.h
@@ -31,6 +31,10 @@ template <> struct normalize_atomic_type<bfloat16_t> {
 };
 #endif
 
+template <> struct normalize_atomic_type<int64_t> {
+  using type = unsigned long long;
+};
+
 template <typename T1, typename T2> TL_DEVICE T1 cuda_cast(T2 val) {
   return T1(val);
 }


### PR DESCRIPTION
## Summary
- Add `normalize_atomic_type` specialization for `int64_t` to map it to `unsigned long long`
- Fixes compilation error when using `atomic_add` with int64 tensors

## Problem
CUDA's `atomicAdd` doesn't have an `int64_t` overload - it only supports `unsigned long long` for 64-bit integers. This caused compilation errors like:
```
error: no instance of overloaded function "atomicAdd" matches the argument list
            argument types are: (NT1 *, int64_t)
```

## Solution
Since `int64_t` and `unsigned long long` have the same bit representation, we can safely map `int64_t` to `unsigned long long` via the `normalize_atomic_type` trait, which is already used for `half_t` and `bfloat16_t`.

## Test plan
- [x] Verified compilation succeeds with int64 atomic_add kernel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved atomic operation handling for 64-bit signed integers in CUDA, ensuring correct type normalization and consistent behavior across operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->