### PR TITLE
[EagerJIT] Add Syntax Sugar for Kernel Source Retrieval

### DIFF
--- a/tilelang/language/eager/builder.py
+++ b/tilelang/language/eager/builder.py
@@ -1054,7 +1054,9 @@ class JITFunc(Generic[_P, _T]):
     def parse_args(self, *args, **kwargs):
         """Parse arguments and return cache key and tensor args."""
         p1_key, tensor_args, kwargs = self._parse_phase1_key(*args, **kwargs)
-        if not tensor_args:
+        if self.mode == "auto":
+            self.mode = "lazy" if self._is_lazy_style(*args, **kwargs) else "eager"
+        if self.mode == "lazy":
             return (p1_key, None), kwargs
         tir_temp = self.p1_cache.get(p1_key, None)
         if tir_temp is None:


### PR DESCRIPTION
This pr add `kernel.get_kernel_source(N=1)` to allow kernel source retrieval

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added kernel caching to optimize compilation performance for repeated function calls with identical arguments.
  * Introduced `get_kernel_source()` method to inspect and debug compiled kernel code.

* **Performance**
  * Enhanced execution mode auto-detection for more efficient optimization selection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->