### PR TITLE
[Bugfix] Fix incorrect alignment of vectorized subtype

### DIFF
--- a/src/tl_templates/cuda/cuda_fp4.h
+++ b/src/tl_templates/cuda/cuda_fp4.h
@@ -71,7 +71,7 @@ public:
   }
 };
 
-struct __CUDA_ALIGN__(4) fp4_e2_4_t {
+struct __CUDA_ALIGN__(2) fp4_e2_4_t {
   fp4_e2_2_t x;
   fp4_e2_2_t y;
 };


### PR DESCRIPTION
This pull request makes a minor change to the memory alignment of the `fp4_e2_4_t` struct in `cuda_fp4.h`, reducing its alignment from 4 bytes to 2 bytes. This may improve memory efficiency or compatibility with certain data layouts.

* Reduced the alignment of the `fp4_e2_4_t` struct from 4 bytes to 2 bytes in `cuda_fp4.h`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized memory alignment for 4-bit floating-point data types to improve performance and memory efficiency in CUDA operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->