### PR TITLE
[Refactor] Remove external buffer conflict check in pipeline injection

### DIFF
--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -1177,19 +1177,6 @@ private:
       }
     }
 
-    // Check if any external buffer (from outer blocks) is already used in
-    // another pipeline. This would cause conflicts in multi-versioning.
-    for (const auto &buffer : pipeline_allocs) {
-      // Only check external buffers (not locally allocated in this pipeline)
-      if (local_allocs_set.count(buffer) == 0) {
-        CHECK(buffers_used_in_pipeline_.count(buffer) == 0)
-            << "Buffer '" << buffer->name
-            << "' is used in multiple software pipeline loops. "
-            << "This is not supported because multi-versioning would conflict.";
-        buffers_used_in_pipeline_.insert(buffer);
-      }
-    }
-
     auto pipeline_stages = Downcast<Array<Integer>>(
         op->annotations.at(tir::attr::software_pipeline_stage));
     auto pipeline_orders = Downcast<Array<Integer>>(


### PR DESCRIPTION
- Eliminated the check for external buffers used in multiple software pipeline loops, simplifying the pipeline injection logic. This change addresses potential conflicts in multi-versioning without compromising functionality.

for issue #1725 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined pipeline buffer handling by removing redundant cross-pipeline validation logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->