### PR TITLE
[Refactor] Disable Predicated LDG PTX Lowering by default

### DIFF
--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -39,7 +39,7 @@ TVM_REGISTER_PASS_CONFIG_OPTION(kLayoutVisualizationFormats, String);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDeviceCompileFlags, ffi::Array<ffi::String>);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableDataRaceCheck, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kEnableLowerLDGSTG, Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION(kDisableLowerLDGSTGPredicated, Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION(kEnableLowerLDGSTGPredicated, Bool);
 
 DataType cuTensorMapType() { return DataType::UInt(8, 128); }
 

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -68,17 +68,17 @@ static constexpr const char *kDisableShuffleElect = "tl.disable_shuffle_elect";
 static constexpr const char *kEnableLowerLDGSTG = "tl.enable_lower_ldgstg";
 
 /*!
- * \brief Disable lowering predicated global load/store to ldg/stg intrinsics
+ * \brief Enable lowering predicated global load/store to ldg/stg intrinsics
  *
  * When enabled (set to true), predicated loads (if_then_else with else=0) and
- * predicated stores (IfThenElse with store in then case) will NOT be lowered
+ * predicated stores (IfThenElse with store in then case) will be lowered
  * to predicated ldg/stg intrinsics.
- * Default: OFF (predicated lowering is enabled by default)
+ * Default: OFF (predicated lowering is disabled by default)
  *
- * kDisableLowerLDGSTGPredicated = "tl.disable_lower_ldgstg_predicated"
+ * kEnableLowerLDGSTGPredicated = "tl.enable_lower_ldgstg_predicated"
  */
-static constexpr const char *kDisableLowerLDGSTGPredicated =
-    "tl.disable_lower_ldgstg_predicated";
+static constexpr const char *kEnableLowerLDGSTGPredicated =
+    "tl.enable_lower_ldgstg_predicated";
 static constexpr const char *kStorageRewriteDetectInplace =
     "tl.storage_rewrite_detect_inplace";
 static constexpr const char *kASTPrintEnable = "tl.ast_print_enable";

--- a/src/transform/lower_ldg_stg.cc
+++ b/src/transform/lower_ldg_stg.cc
@@ -17,7 +17,7 @@
  * Pass configurations:
  * - tl.enable_lower_ldgstg: Enable non-predicated ldg/stg lowering (default:
  * OFF)
- * - tl.disable_lower_ldgstg_predicated: Disable predicated ldg/stg lowering
+ * - tl.enable_lower_ldgstg_predicated: Enable predicated ldg/stg lowering
  * (default: OFF)
  */
 
@@ -491,11 +491,9 @@ tvm::transform::Pass LowerLDGSTG() {
     // Non-predicated ldg/stg: default OFF
     bool enable_non_predicated =
         ctx->GetConfig<Bool>(kEnableLowerLDGSTG, Bool(false)).value();
-    // Predicated ldg/stg: default ON (so disable flag default is false)
-    bool disable_predicated =
-        ctx->GetConfig<Bool>(kDisableLowerLDGSTGPredicated, Bool(false))
-            .value();
-    bool enable_predicated = !disable_predicated;
+    // Predicated ldg/stg: default OFF
+    bool enable_predicated =
+        ctx->GetConfig<Bool>(kEnableLowerLDGSTGPredicated, Bool(false)).value();
 
     // If both are disabled, skip the pass entirely
     if (!enable_non_predicated && !enable_predicated) {

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -60,9 +60,9 @@ class PassConfigKey(str, Enum):
     When enabled, converts Ramp-based global buffer load/store to ldg/stg intrinsics.
     Default: False"""
 
-    TL_DISABLE_LOWER_LDGSTG_PREDICATED = "tl.disable_lower_ldgstg_predicated"
-    """Disable predicated LDG/STG lowering.
-    When False (default), predicated loads (if_then_else with else=0) and
+    TL_ENABLE_LOWER_LDGSTG_PREDICATED = "tl.enable_lower_ldgstg_predicated"
+    """Enable predicated LDG/STG lowering.
+    When True, predicated loads (if_then_else with else=0) and
     predicated stores (IfThenElse with empty then case) are lowered to
     ldg/stg intrinsics. Default: False"""
 


### PR DESCRIPTION
As our benchmark shows that the performance is not always better than the default nvcc optimiztaions.

- Changed the configuration option from `kDisableLowerLDGSTGPredicated` to `kEnableLowerLDGSTGPredicated` to enable predicated lowering of global load/store operations.
- Updated relevant comments and documentation to reflect the new configuration behavior.
- Adjusted tests to utilize the new configuration option for enabling predicated lowering, ensuring consistency across the codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed and inverted pass configuration option for LDGSTG predicated lowering: the flag now enables the feature when set to `True` rather than disabling it when `True`. Users with existing configurations using the old flag will need to update their settings accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->