### PR TITLE
Add an example: mHC residual projection backward

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,4 +1,5 @@
 cancelled
+dout
 hsa
 ist
 LOD

--- a/examples/deepseek_mhc/example_mhc_bwd.py
+++ b/examples/deepseek_mhc/example_mhc_bwd.py
@@ -1,6 +1,5 @@
 # NOTE: This bwd script is not an official upstream script; it is community-written and provided for reference only.
 # checkout pr: https://github.com/tile-ai/tilelang/pull/1758
-
 import torch
 
 import tilelang
@@ -175,9 +174,7 @@ def sinkhorn_bwd_implicit_cg(n_stream: int, tilesize: int = 32, threads: int = 1
             # Conjugate gradient: iteration ends
 
             for i_tile, i_nx, i_ny in T.Parallel(tilesize, n_stream, n_stream):
-                res_tile[i_tile, i_nx, i_ny] = (
-                    dR[i_tile, i_nx, i_ny] - x1[i_tile, i_nx] - x2[i_tile, i_ny]
-                ) * R[i_tile, i_nx, i_ny]
+                res_tile[i_tile, i_nx, i_ny] = (dR[i_tile, i_nx, i_ny] - x1[i_tile, i_nx] - x2[i_tile, i_ny]) * R[i_tile, i_nx, i_ny]
 
             T.copy(res_tile, res[i_seq * tilesize : (i_seq + 1) * tilesize, :, :])
 


### PR DESCRIPTION
I’d like to add an example for the mHC backward pass, but I’m running into some bugs that I haven’t been able to resolve on my own. I would really appreciate it if someone could take a look.

The algorithm is described [here in my blog](https://da1sypetals.netlify.app/posts/sinkhorn-bwd/). More importantly, there is a Triton implementation available [here](https://gist.github.com/Da1sypetals/e5cc3a9ec27f1d569e0d47adc609f023).

I attempted to translate the Triton code into TileLang more or less word-for-word, but I couldn’t get correct results. The current implementation always produces `NaN`s. Interestingly, if I add a `print` inside the `T.serial` loop, the results become correct (or at least very close).

I’d really appreciate it if someone could review the code and point out whether there is a bug in my implementation or if something else is going wrong 🌹


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new example demonstrating backward pass computation for Sinkhorn operations with autotuning and performance optimization.

* **Chores**
  * Updated spelling wordlist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->