### PR TITLE
[Fix] Change ue8m0 default round mode to cudaRoundPosInf

### DIFF
--- a/src/tl_templates/cuda/cuda_fp8.h
+++ b/src/tl_templates/cuda/cuda_fp8.h
@@ -336,34 +336,34 @@ __tl_cvt_e8m0x2_to_bfloat162(const __nv_fp8x2_storage_t src) {
 TL_DEVICE
 __nv_fp8_storage_t __tl_cvt_bfloat16_to_e8m0(const __nv_bfloat16 src) {
   __nv_bfloat16_raw raw = *reinterpret_cast<const __nv_bfloat16_raw *>(&src);
-  return __nv_cvt_bfloat16raw_to_e8m0(raw, __NV_SATFINITE, cudaRoundNearest);
+  return __nv_cvt_bfloat16raw_to_e8m0(raw, __NV_SATFINITE, cudaRoundPosInf);
 }
 
 // bfloat162 -> fp8_e8m0x2
 TL_DEVICE __nv_fp8x2_storage_t
 __tl_cvt_bfloat162_to_e8m0x2(const __nv_bfloat162 src) {
   __nv_bfloat162_raw raw = *reinterpret_cast<const __nv_bfloat162_raw *>(&src);
-  return __nv_cvt_bfloat162raw_to_e8m0x2(raw, __NV_SATFINITE, cudaRoundNearest);
+  return __nv_cvt_bfloat162raw_to_e8m0x2(raw, __NV_SATFINITE, cudaRoundPosInf);
 }
 
 // float -> fp8_e8m0
 TL_DEVICE __nv_fp8_storage_t __tl_cvt_float_to_e8m0(const float src) {
-  return __nv_cvt_float_to_e8m0(src, __NV_SATFINITE, cudaRoundNearest);
+  return __nv_cvt_float_to_e8m0(src, __NV_SATFINITE, cudaRoundPosInf);
 }
 
 // float2 -> fp8_e8m0x2
 TL_DEVICE __nv_fp8x2_storage_t __tl_cvt_float2_to_e8m0x2(const float2 src) {
-  return __nv_cvt_float2_to_e8m0x2(src, __NV_SATFINITE, cudaRoundNearest);
+  return __nv_cvt_float2_to_e8m0x2(src, __NV_SATFINITE, cudaRoundPosInf);
 }
 
 // double -> fp8_e8m0
 TL_DEVICE __nv_fp8_storage_t __tl_cvt_double_to_e8m0(const double src) {
-  return __nv_cvt_double_to_e8m0(src, __NV_SATFINITE, cudaRoundNearest);
+  return __nv_cvt_double_to_e8m0(src, __NV_SATFINITE, cudaRoundPosInf);
 }
 
 // double2 -> fp8_e8m0x2
 TL_DEVICE __nv_fp8x2_storage_t __tl_cvt_double2_to_e8m0x2(const double2 src) {
-  return __nv_cvt_double2_to_e8m0x2(src, __NV_SATFINITE, cudaRoundNearest);
+  return __nv_cvt_double2_to_e8m0x2(src, __NV_SATFINITE, cudaRoundPosInf);
 }
 
 #endif


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified rounding behavior in conversion operations to round toward positive infinity instead of to nearest value, ensuring consistent rounding across floating-point type conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->