### PR TITLE
[BugFix] Fix type annotations for T.reshape and T.view (#1768)Fix type annotations for T.reshape and T.view

### DIFF
--- a/tilelang/language/customize.py
+++ b/tilelang/language/customize.py
@@ -37,7 +37,7 @@ def clamp(dst: PrimExpr, min_val: PrimExpr, max_val: PrimExpr) -> PrimExpr:
     return dst
 
 
-def reshape(src: Buffer, shape: list[PrimExpr]) -> Buffer:
+def reshape(src: Buffer, shape: list[PrimExpr] | tuple[PrimExpr, ...]) -> Buffer:
     """Reshapes the input buffer to the specified shape.
 
     Args:
@@ -53,7 +53,7 @@ def reshape(src: Buffer, shape: list[PrimExpr]) -> Buffer:
     return T.Tensor(shape, src.dtype, src.data)
 
 
-def view(src: Buffer, shape: list[PrimExpr] | None = None, dtype: str | None = None) -> Buffer:
+def view(src: Buffer, shape: list[PrimExpr] | tuple[PrimExpr, ...] | None = None, dtype: str | object | None = None) -> Buffer:
     """Return a Tensor view of the input buffer with an optional new shape and dtype.
 
     If `shape` is None the source buffer's shape is used; if `dtype` is None the source buffer's dtype is used. The returned buffer shares the same underlying data as `src` (no copy).


### PR DESCRIPTION
Fixes #1768

**Problem:**
The type annotations for `T.reshape` and `T.view` were too strict, causing type checkers (like mypy/Pylance) to incorrectly flag valid code:

```python
T.reshape(x, (32, 2))  # tuple is valid but type checker complained
T.view(x, (32, 2), T.float)  # tuple and T.dtype are valid but flagged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * `reshape` and `view` operations now accept both list and tuple formats for shape parameters.
  * `view` operations now support expanded dtype parameter options including string and object types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->