### PR TITLE
[Bugfix] Copy pass_configs dict to prevent mutation across multiple JIT compilations

### DIFF
--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -225,10 +225,9 @@ class JITKernel(Generic[_P, _T]):
         target_host = self.target_host
 
         execution_backend = self.execution_backend
-        pass_configs = self.pass_configs or {}
+        pass_configs = dict(self.pass_configs) if self.pass_configs else {}
 
         compile_flags = self.compile_flags
-
         if compile_flags is not None:
             compile_flags_cfg = pass_configs.get(PassConfigKey.TL_DEVICE_COMPILE_FLAGS)
             pass_configs[PassConfigKey.TL_DEVICE_COMPILE_FLAGS] = (


### PR DESCRIPTION
## Summary
- Fix a bug where `pass_configs` dictionary was shared and mutated across multiple JIT kernel compilations
- When calling a JIT-decorated function multiple times, the `compile_flags` would accumulate (e.g., `['-O3']` → `['-O3', '-O3']`)
- Solution: Create a copy of `pass_configs` before modifying it in `_compile_and_create_adapter`

## Root Cause Analysis

This is a classic Python **mutable object sharing** issue.

### How Python handles objects

In Python, variables store **references** (pointers) to objects, not the objects themselves:

```python
a = {"key": 1}
b = a          # b and a point to the same dict object
b["key"] = 2
print(a)       # {'key': 2} — a is also modified!
```

### What happened in this bug

When using the `@tilelang.jit` decorator:

```python
@tilelang.jit(
    pass_configs={...},   # This dict object is created only ONCE
    compile_flags=["-O3"],
)
def matmul(...):
    ...
```

The `pass_configs` dictionary is created **once** when the decorator is applied. Every subsequent call to `matmul()` reuses the **same** dictionary object.

When the code modifies this dictionary:
```python
pass_configs[key] = compile_flags  # Mutates the shared dict
```

All future calls see the accumulated modifications:
- 1st call: `compile_flags_cfg = None` → sets `['-O3']`
- 2nd call: `compile_flags_cfg = ['-O3']` → sets `['-O3', '-O3']`
- 3rd call: `compile_flags_cfg = ['-O3', '-O3']` → sets `['-O3', '-O3', '-O3']`

### The fix

Copy the dictionary before modifying:
```python
# Before (shared dict)
pass_configs = self.pass_configs or {}

# After (new copy each time)
pass_configs = dict(self.pass_configs) if self.pass_configs else {}
```

## Test plan
- [x] Run the reproduction script to verify flags no longer accumulate across multiple compilations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved object handling to prevent unintended mutations during configuration processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->