### PR TITLE
[Example][BugFix] Fix arguements override in deepseek_v32 topk_selector

### DIFF
--- a/examples/deepseek_v32/topk_selector.py
+++ b/examples/deepseek_v32/topk_selector.py
@@ -185,9 +185,6 @@ def tl_topk(input, starts, ends, topk):
 
 
 def test_topk_selector(batch=64, seq_len=32 * 1024, topk=2048):
-    batch = 64
-    seq_len = 32 * 1024
-    topk = 2048
     torch.manual_seed(1)
     input = torch.randn(batch, seq_len, dtype=torch.float32).cuda()
     starts = torch.zeros(batch, dtype=torch.int32).cuda()
@@ -243,9 +240,6 @@ def test_topk_selector(batch=64, seq_len=32 * 1024, topk=2048):
 
 
 def run_regression_perf(batch=64, seq_len=32 * 1024, topk=2048):
-    batch = 64
-    seq_len = 32 * 1024
-    topk = 2048
     torch.manual_seed(1)
     input = torch.randn(batch, seq_len, dtype=torch.float32).cuda()
     starts = torch.zeros(batch, dtype=torch.int32).cuda()


### PR DESCRIPTION
Removed unnecessary reassignments of `batch`, `seq_len`, and `topk` inside the `test_topk_selector` and `run_regression_perf` functions, as these values are already provided by the function parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved parameter handling in internal functions to respect externally provided values rather than applying fixed overrides, enhancing code flexibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->