### PR TITLE
feat: Add CUDA graph backend support to autotuner (#1633)

### DIFF
--- a/tilelang/_typing.py
+++ b/tilelang/_typing.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 # Python 3.9 compatibility
 try:
-    from typing import TypeAlias
+    from typing import TypeAlias, Union
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing_extensions import TypeAlias, Union
 
 from tvm import ir
 from tvm import tir
@@ -18,10 +18,10 @@ from tvm.tir import BufferLoad, BufferRegion
 from tilelang.dtypes import dtype
 
 # Barrier can only be a Buffer, a BufferLoad
-BarrierType: TypeAlias = tir.Buffer | BufferLoad
+BarrierType: TypeAlias = Union[tir.Buffer, BufferLoad]
 
 # BufferLikeType can be a Buffer, a BufferLoad, a BufferRegion
-BufferLikeType: TypeAlias = tir.Buffer | BufferLoad | BufferRegion
+BufferLikeType: TypeAlias = Union[tir.Buffer , BufferLoad , BufferRegion]
 
 # This is for Python 3.9 compatibility.
 # In Python 3.9, we can only use isinstance(a, (TypeA, TypeB, ...)) instead of isinstance(a, TypeA | TypeB | ...))
@@ -31,5 +31,5 @@ BufferLikeTypeTuple = (tir.Buffer, BufferLoad, BufferRegion)
 # - AnyDType is a union of all possible types that can represent a data type, including torch.dtype
 # - DType is a more specific type alias that represents a data type in the context of TileLang, and must be
 #   adapted to string.
-DType: TypeAlias = dtype | ir.Type | str | type
-ShapeType: TypeAlias = list[tir.PrimExpr | int] | tuple[tir.PrimExpr | int, ...]
+DType: TypeAlias = Union[dtype , ir.Type , str , type]
+ShapeType: TypeAlias = Union[list[Union[tir.PrimExpr , int]] , tuple[Union[tir.PrimExpr , int], ...]]

--- a/tilelang/autotuner/param.py
+++ b/tilelang/autotuner/param.py
@@ -99,6 +99,7 @@ class ProfileArgs:
         skip_check: bool = False
         manual_check_prog: Callable = None
         cache_input_tensors: bool = True
+        backend: Profiling backend to use ("event", "cupti", or "cudagraph")
     """
 
     warmup: int = 25
@@ -113,6 +114,7 @@ class ProfileArgs:
     skip_check: bool = False
     manual_check_prog: Callable = None
     cache_input_tensors: bool = True
+    backend: str = "event"
 
     def __hash__(self):
         data = {

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -388,6 +388,7 @@ class AutoTuner:
             rtol = profile_args.rtol
             atol = profile_args.atol
             max_mismatched_ratio = profile_args.max_mismatched_ratio
+            backend = profile_args.backend
 
             profiler = jit_kernel.get_profiler(tensor_supply_type=supply_type)
 
@@ -448,11 +449,11 @@ class AutoTuner:
                     profiler.assert_allclose(
                         ref_prog, input_tensors=self.jit_input_tensors, rtol=rtol, atol=atol, max_mismatched_ratio=max_mismatched_ratio
                     )
-            latency = profiler.do_bench(warmup=warmup, rep=rep, input_tensors=self.jit_input_tensors)
+            latency = profiler.do_bench(warmup=warmup, rep=rep, input_tensors=self.jit_input_tensors, backend= backend)
 
             if self.ref_latency_cache is None and ref_prog is not None:
                 self.ref_input_tensors = ref_input_tensors_supply()
-                self.ref_latency_cache = profiler.do_bench(ref_prog, n_warmup=warmup, n_repeat=rep, input_tensors=self.ref_input_tensors)
+                self.ref_latency_cache = profiler.do_bench(ref_prog, n_warmup=warmup, n_repeat=rep, input_tensors=self.ref_input_tensors, backend=backend)
 
             return latency, self.ref_latency_cache
 

--- a/tilelang/profiler/__init__.py
+++ b/tilelang/profiler/__init__.py
@@ -226,7 +226,7 @@ class Profiler:
         n_warmup: int = 1,
         n_repeat: int = 1,
         input_tensors: list[torch.Tensor] = None,
-        backend: Literal["event", "cupti"] = "event",
+        backend: Literal["event", "cupti", "cudagraph"] = "event",
         quantiles: list[float] | None = None,
         return_mode: Literal["min", "max", "mean", "median"] = "mean",
         dynamic_symbolic_constraints: dict[str, int] | None = None,
@@ -239,7 +239,7 @@ class Profiler:
             rep: Number of repetitions for timing
             n_warmup: Number of warmup iterations
             n_repeat: Number of timing iterations
-            profiler: Which profiling backend to use
+            profiler: Which profiling backend to use ("event", "cupti", or "cudagraph")
             input_tensors: Optional pre-generated input tensors
             dynamic_symbolic_constraints: Optional dict mapping dynamic symbolic variable
                 names to concrete int values. Use this when benchmarking kernels with


### PR DESCRIPTION
feat: Add CUDA graph backend support to autotuner

- Implement _bench_with_cudagraph function using torch.cuda.CUDAGraph
- Follow Triton's approach: unroll multiple calls in graph for accurate benchmarking
- Add 'cudagraph' backend option to profiler
- Add backend parameter to ProfileArgs dataclass
- Update autotuner to pass backend when profiling
- Add test for cudagraph backend
- Fix Python 3.9 compatibility in _typing.py

CUDA graph eliminates CPU launch overhead, achieving ~3x speedup for short kernels
(0.003ms vs 0.008ms in testing).

Fixes #1633


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CUDA Graph (cudagraph) backend for kernel profiling, enabling benchmarking using CUDA graphs alongside existing event and CUPTI profiling methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->