### PR TITLE
[ThreadSync] Skip (tx1 != tx2) checking for loop carry analysis

### DIFF
--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -1546,8 +1546,10 @@ private:
           curr_sub.Set(old_curr_var, shared_var);
         } else {
           // For RAW/WAR: use different Var objects to model cross-thread access
-          Var prev_var(std::string(thread_names[idx]) + "1", old_prev_var.dtype());
-          Var curr_var(std::string(thread_names[idx]) + "2", old_curr_var.dtype());
+          Var prev_var(std::string(thread_names[idx]) + "1",
+                       old_prev_var.dtype());
+          Var curr_var(std::string(thread_names[idx]) + "2",
+                       old_curr_var.dtype());
           thread_condition =
               tir::Or(thread_condition, tir::NE(prev_var, curr_var));
           prev_sub.Set(old_prev_var, prev_var);


### PR DESCRIPTION
unnecessary and which may lead to performance regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of thread conflict detection by refining how different access patterns are handled.
  * Removed unnecessary warning messages from thread synchronization operations.

* **Performance**
  * Optimized thread variable management for more efficient computation in synchronization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->