### PR TITLE
[Bugfix] Support loop-dependent conditions in IfThenElse within T.Pipelined

### DIFF
--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -877,8 +877,9 @@ private:
         for (auto it = loop_var_if_wrappers_.rbegin();
              it != loop_var_if_wrappers_.rend(); ++it) {
           const auto &iw = *it;
-          PrimExpr substituted_condition = Substitute(
-              iw.condition, {{pipeline_loop_->loop_var, normalized_access_index}});
+          PrimExpr substituted_condition =
+              Substitute(iw.condition,
+                         {{pipeline_loop_->loop_var, normalized_access_index}});
           inner = IfThenElse(substituted_condition, inner, Stmt(), iw.span);
         }
         n->body = inner;
@@ -1111,15 +1112,16 @@ private:
           for (const auto &lw : loop_var_let_wrappers) {
             dependent_vars.insert(lw.var.get());
           }
-          bool condition_depends_on_loop =
-              UsesVar(if_then_else->condition, [&dependent_vars](const VarNode *vn) {
+          bool condition_depends_on_loop = UsesVar(
+              if_then_else->condition, [&dependent_vars](const VarNode *vn) {
                 return dependent_vars.count(vn) > 0;
               });
 
           if (condition_depends_on_loop) {
             // If condition depends on loop variable, we need to push it inside
             // each pipeline stage with proper substitution
-            loop_var_if_wrappers.push_back({if_then_else->condition, if_then_else->span});
+            loop_var_if_wrappers.push_back(
+                {if_then_else->condition, if_then_else->span});
           } else {
             // Otherwise, safe to wrap outside the pipeline
             PrimExpr condition = if_then_else->condition;

--- a/testing/python/issue/test_tilelang_issue_1210.py
+++ b/testing/python/issue/test_tilelang_issue_1210.py
@@ -38,6 +38,7 @@ def _make_kernel_if_cond(M, N):
                     _id = ids[i]
                     T.copy(KV[_id, :], A)
                     T.clear(B)
+
     return fwd_main
 
 

--- a/testing/python/issue/test_tilelang_issue_1263.py
+++ b/testing/python/issue/test_tilelang_issue_1263.py
@@ -1,6 +1,7 @@
 import tilelang.testing
 import tilelang.language as T
 
+
 def _test_kernel(M, N):
     dtype = "bfloat16"
 
@@ -19,6 +20,7 @@ def _test_kernel(M, N):
                 id2 = ids2[id]
                 T.copy(KV[id2, :], A)
                 T.clear(B)
+
     return fwd_main
 
 
@@ -39,9 +41,9 @@ def _test_kernel_if_cond(M, N):
                 id = ids[i]
                 id2 = ids2[id]
                 if id2 > 1:
-                    if id < 3:
-                        T.copy(KV[id2, :], A)
-                        T.clear(B)
+                    T.copy(KV[id2, :], A)
+                    T.clear(B)
+
     return fwd_main
 
 


### PR DESCRIPTION
This PR extends the pipeline injection transform to handle `IfThenElse` statements whose conditions depend on the pipeline loop variable, fixing a regression similar to #1210 but for conditional statements.

## Problem

When an `if` statement with a condition depending on the pipeline loop variable (e.g., `if i > 1:`) was placed inside a `T.Pipelined` block, the condition may be incorrectly hoisted outside the pipeline loop, causing the loop variable to become undefined and resulting in the error:

```
InternalError: variables [i] are used, but are not passed in as API arguments
```
The `IfThenElse` handling in `inject_pipeline.cc` always added conditions to `rewrap_fns` (wrapping them outside the pipeline), without checking if the condition uses the loop variable. This is the same bug that was fixed for `LetStmt` in PR #1212, but was not addressed for conditional statements

### Example:
```python
def _make_kernel_if_cond(M, N):
    dtype = T.bfloat16

    @T.prim_func
    def fwd_main(KV: T.Tensor((M, N), dtype), ids: T.Tensor((4,), T.int32)):
        with T.Kernel(4, threads=1):
            A = T.alloc_shared([N], dtype)
            B = T.alloc_shared([N], dtype)

            for i in T.Pipelined(4, num_stages=1):
                if i > 1: # <-this line!!!
                    _id = ids[i]
                    T.copy(KV[_id, :], A)
                    T.clear(B)
    return fwd_main
```
Before this PR, above code would be transformed as:
```
// WRONG: Condition evaluated outside, i is undefined
if (i > 1)
  pipeline_loop:
    for i in [0, 1, 2, 3]:
      body
```
## Solution
This PR applies the same strategy used for `LetStmt` to `IfThenElse` conditions:

1. Introduced `IfWrapper` struct to track if conditions that depend on the loop variable
2. Added dependency detection that checks if an if condition uses:
- The pipeline loop variable directly, OR
- Any variable transitively dependent on the loop variable
3. Per-iteration substitution: Loop-dependent conditions are pushed inside each pipeline stage with the loop variable substituted for that iteration
## Key Changes
`inject_pipeline.cc`:
- Added `IfWrapper` struct to store if conditions and spans
- Extended `PipelineRewriter` to accept and process `loop_var_if_wrappers`
- Updated `IfThenElse` detection logic to check for loop variable dependencies
- Apply if wrappers inside each rewritten pipeline block with proper substitution

## Related Issues/PRs:
#1210 
#1212 
#1263 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pipeline loop compilation now wraps and stages conditional branches that depend on the pipeline loop variable, preserving correct per-stage semantics and enabling conditional control flow inside pipelined regions.

* **Tests**
  * Added and expanded tests exercising conditional execution inside pipelined loops across multiple compilation configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->