### PR TITLE
Fix a 3.9 issue. add `_typing.py` to dist check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,18 +45,8 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Setup Python 3.8
-        id: setup-pylowest
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.8" # use lowest supported version for linting
-          update-environment: false
-
-      - name: Check AST with Python 3.8
-        run: |
-          "${{ steps.setup-pylowest.outputs.python-path }}" -m compileall -q -f tilelang
-
       - name: Setup Python 3.9
+        id: setup-pylowest
         uses: actions/setup-python@v6
         with:
           python-version: "3.9"
@@ -66,6 +56,10 @@ jobs:
             pyproject.toml
             requirements*.txt
             .pre-commit-config.yaml
+
+      - name: Check AST with Python 3.9
+        run: |
+          "${{ steps.setup-pylowest.outputs.python-path }}" -m compileall -q -f tilelang
 
       - name: Pre-commit Lint
         run: |

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -18,6 +18,9 @@ on:
       - CMakeLists.txt
       - version_provider.py
       - .github/workflows/dist.yml
+      # temporarily add to dist check
+      # until we have type checking in ci / move to python 3.10
+      - tilelang/_typing.py
   release:
     types:
       - published

--- a/tilelang/_typing.py
+++ b/tilelang/_typing.py
@@ -1,9 +1,7 @@
 """Type annotations for TileLang."""
 
-# Union compatibility for Python 3.9
-from __future__ import annotations
-
 # NOTE(chaofan): We should name it "_typing.py" to avoid module shadowing with standard library "typing"
+# NOTE: In python 3.9, `from __future__ import annotations` does not for value expression, e.g. to define type alias
 
 # Python 3.9 compatibility
 try:
@@ -38,4 +36,4 @@ ShapeType: TypeAlias = Union[list[Union[tir.PrimExpr, int]], tuple[Union[tir.Pri
 
 # PrimExpr with adaptation to Python basic data types
 # IntImm, FloatImm, Bool: IntImm, Integer: IntImm
-PyPrimExpr: TypeAlias = tir.PrimExpr | int | float | bool
+PyPrimExpr: TypeAlias = Union[tir.PrimExpr, int, float, bool]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Chores**
- Updated continuous integration workflows to prioritize Python 3.9 as the minimum supported version
- Extended distribution check triggers to cover additional project modules
- Improved type annotation compatibility with Python 3.9 standards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->