### PR TITLE
Fix: treat kParallel as serial when vectorizing

### DIFF
--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -934,7 +934,7 @@ Stmt CopyNode::LowerLDSMCopy(const LowerArgs &T, arith::Analyzer *analyzer,
   auto body = Evaluate(Call(DataType::Handle(), op, args));
   For for_node =
       For(local_iter, 0, FloorDiv(extent, 2 * num), ForKind::kSerial, body);
-  for_node = LoopPragmaUnroll(for_node);
+  for_node = PragmaUnrollLoop(for_node);
   auto range = T.thread_bounds;
   if (range.defined()) {
     auto thread_var = T.thread_var;

--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -448,6 +448,7 @@ Stmt ReduceOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     if (dst_layout->InputDim() > 0) {
       body = PartitionLoop(Downcast<For>(body), T.thread_var, analyzer,
                            red_layout);
+      body = PragmaUnrollLoop(Downcast<For>(body));
     } else {
       auto guard = (T.thread_var == T.thread_bounds->min);
       body = IfThenElse(guard, body);

--- a/src/transform/loop_partition.h
+++ b/src/transform/loop_partition.h
@@ -45,7 +45,7 @@ Fragment PlanLoopPartition(const For &op, size_t num_thread,
 Fragment PlanLoopPartition(const For &op, int vectorize_size,
                            const Range &thread_range);
 
-For LoopPragmaUnroll(For stmt);
+For PragmaUnrollLoop(For stmt);
 
 /*!
  * \brief Lower a parallel loop by partitioning and vectorizing it.


### PR DESCRIPTION
TileLang uses `ForKind::kParallel` as a frontend "SIMT loop" marker in a few places.
When vectorization resolves to size=1 (a no-op) or when `VectorizeRewriter` splits
loops, leaving loops as `kParallel` can block downstream serial-only transforms
(e.g. pragma-unroll rewriting).

This change:
- Rewrites `kParallel` -> `kSerial` when `VectorizeLoop` resolves to vector size 1.
- Ensures `VectorizeRewriter` output also downgrades `kParallel` loops to `kSerial`
  (including the generated outer loop after splitting).
- Renames `LoopPragmaUnroll` to `PragmaUnrollLoop` and applies unrolling
  consistently after partition/vectorize in loop lowering and ops.

Validated with:
- `debug/0209_issues/local_parallel.py`
- `TILELANG_CACHE_DIR=/tmp/tilelang-cache python testing/python/cpu/test_tilelang_cpu_gemm.py`
