### PR TITLE
[Bugfix] Remove mistaken coalesced_width parameter in regression test of fusedmoe kernel

### DIFF
--- a/examples/fusedmoe/example_fusedmoe_tilelang.py
+++ b/examples/fusedmoe/example_fusedmoe_tilelang.py
@@ -615,7 +615,7 @@ def run_regression_perf(
             moe.up_logits_routed,
             moe.expert_output_routed,
         )
-    
+
     shared_latency = do_bench(run_shared_kernel_only, backend="cupti")
     routed_latency = do_bench(run_routed_kernel_only, backend="cupti")
     return (shared_latency + routed_latency) / 2


### PR DESCRIPTION
For issue #1802 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated performance benchmarking methodology to report mean latency across multiple kernel execution paths instead of a single path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->