### PR TITLE
[Dist] Add lazy-loading stubs for CUDART + NVRTC (CUDA 11/12/13 compatible wheels)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,21 @@ foreach(BACKEND IN LISTS TILELANG_BACKENDS)
 endforeach()
 
 set(PREBUILD_CYTHON ON)
+
+# CUDA stub libraries (cuda/cudart/nvrtc) are used to build wheels that can run
+# across different CUDA Toolkit major versions and/or on CPU-only machines by
+# avoiding hard DT_NEEDED dependencies on versioned CUDA SONAMEs.
+#
+# These stubs are currently POSIX-only (dlopen/dlsym via <dlfcn.h>).
+if(WIN32 AND NOT CYGWIN)
+  set(_TILELANG_USE_CUDA_STUBS_DEFAULT OFF)
+else()
+  set(_TILELANG_USE_CUDA_STUBS_DEFAULT ON)
+endif()
+option(TILELANG_USE_CUDA_STUBS
+       "Use POSIX dlopen-based CUDA stub libraries (cuda/cudart/nvrtc) for portable wheels"
+       ${_TILELANG_USE_CUDA_STUBS_DEFAULT})
+unset(_TILELANG_USE_CUDA_STUBS_DEFAULT)
 # Configs end
 
 include(cmake/load_tvm.cmake)
@@ -211,87 +226,94 @@ elseif(USE_CUDA)
   # Set `USE_CUDA=/usr/local/cuda-x.y`
   cmake_path(GET CUDAToolkit_BIN_DIR PARENT_PATH USE_CUDA)
 
-  # ============================================================================
-  # CUDA Driver Stub Library (libcuda_stub.so)
-  # ============================================================================
-  # This library provides drop-in replacements for CUDA driver API functions.
-  # Instead of linking directly against libcuda.so (which would fail on
-  # CPU-only machines), we link against this stub which loads libcuda.so
-  # lazily at runtime on first API call.
-  #
-  # The stub exports global C functions matching the CUDA driver API:
-  #   - cuModuleLoadData, cuLaunchKernel, cuMemsetD32_v2, etc.
-  # These can be called directly without any wrapper macros.
-  # ============================================================================
-  add_library(cuda_stub SHARED src/target/stubs/cuda.cc)
-  target_include_directories(cuda_stub PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
-  # Export symbols with visibility="default" when building
-  target_compile_definitions(cuda_stub PRIVATE TILELANG_CUDA_STUB_EXPORTS)
-  # Use dlopen/dlsym for runtime library loading
-  target_link_libraries(cuda_stub PRIVATE ${CMAKE_DL_LIBS})
-  set_target_properties(cuda_stub PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    # Use consistent naming
-    OUTPUT_NAME "cuda_stub"
-  )
+  if(TILELANG_USE_CUDA_STUBS)
+    if(WIN32 AND NOT CYGWIN)
+      message(FATAL_ERROR "TILELANG_USE_CUDA_STUBS=ON is not supported on Windows. "
+                          "Please configure with -DTILELANG_USE_CUDA_STUBS=OFF.")
+    endif()
 
-  # ============================================================================
-  # CUDA Runtime Stub Library (libcudart_stub.so)
-  # ============================================================================
-  # libcudart's SONAME includes its major version (e.g. libcudart.so.11.0 / .12 / .13).
-  # Link against this stub instead of the real libcudart so a single wheel can
-  # run in environments that provide different libcudart major versions.
-  #
-  # The stub exports a minimal set of CUDA Runtime API entrypoints used by TVM
-  # and lazily loads libcudart at runtime on first API call.
-  # ============================================================================
-  add_library(cudart_stub SHARED src/target/stubs/cudart.cc)
-  target_include_directories(cudart_stub PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
-  target_compile_definitions(cudart_stub PRIVATE TILELANG_CUDART_STUB_EXPORTS)
-  target_link_libraries(cudart_stub PRIVATE ${CMAKE_DL_LIBS})
-  set_target_properties(cudart_stub PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    OUTPUT_NAME "cudart_stub"
-  )
+    # ============================================================================
+    # CUDA Driver Stub Library (libcuda_stub.so)
+    # ============================================================================
+    # This library provides drop-in replacements for CUDA driver API functions.
+    # Instead of linking directly against libcuda.so (which would fail on
+    # CPU-only machines), we link against this stub which loads libcuda.so
+    # lazily at runtime on first API call.
+    #
+    # The stub exports global C functions matching the CUDA driver API:
+    #   - cuModuleLoadData, cuLaunchKernel, cuMemsetD32_v2, etc.
+    # These can be called directly without any wrapper macros.
+    # ============================================================================
+    add_library(cuda_stub SHARED src/target/stubs/cuda.cc)
+    target_include_directories(cuda_stub PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+    # Export symbols with visibility="default" when building
+    target_compile_definitions(cuda_stub PRIVATE TILELANG_CUDA_STUB_EXPORTS)
+    # Use dlopen/dlsym for runtime library loading
+    target_link_libraries(cuda_stub PRIVATE ${CMAKE_DL_LIBS})
+    set_target_properties(cuda_stub PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      # Use consistent naming
+      OUTPUT_NAME "cuda_stub"
+    )
 
-  # Make TVM link against our CUDA Runtime stub instead of the real libcudart.
-  #
-  # NOTE: TVM's `find_cuda()` calls `find_library(CUDA_CUDART_LIBRARY cudart ...)`.
-  # `find_library()` will not override an already-cached variable, so setting it
-  # here ensures TVM doesn't record a DT_NEEDED on `libcudart.so.<major>`.
-  set(CUDA_CUDART_LIBRARY cudart_stub CACHE STRING "CUDART library to link against" FORCE)
+    # ============================================================================
+    # CUDA Runtime Stub Library (libcudart_stub.so)
+    # ============================================================================
+    # libcudart's SONAME includes its major version (e.g. libcudart.so.11.0 / .12 / .13).
+    # Link against this stub instead of the real libcudart so a single wheel can
+    # run in environments that provide different libcudart major versions.
+    #
+    # The stub exports a minimal set of CUDA Runtime API entrypoints used by TVM
+    # and lazily loads libcudart at runtime on first API call.
+    # ============================================================================
+    add_library(cudart_stub SHARED src/target/stubs/cudart.cc)
+    target_include_directories(cudart_stub PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+    target_compile_definitions(cudart_stub PRIVATE TILELANG_CUDART_STUB_EXPORTS)
+    target_link_libraries(cudart_stub PRIVATE ${CMAKE_DL_LIBS})
+    set_target_properties(cudart_stub PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      OUTPUT_NAME "cudart_stub"
+    )
 
-  # ============================================================================
-  # NVRTC Stub Library (libnvrtc_stub.so)
-  # ============================================================================
-  # NVRTC's SONAME includes its major version (e.g. libnvrtc.so.11.2 / .12 / .13).
-  # Link against this stub instead of the real NVRTC library so a single wheel
-  # can run in environments that provide different NVRTC major versions.
-  #
-  # The stub exports a minimal set of NVRTC C API entrypoints used by TVM and
-  # lazily loads libnvrtc at runtime on first API call.
-  # ============================================================================
-  add_library(nvrtc_stub SHARED src/target/stubs/nvrtc.cc)
-  target_include_directories(nvrtc_stub PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
-  target_compile_definitions(nvrtc_stub PRIVATE TILELANG_NVRTC_STUB_EXPORTS)
-  target_link_libraries(nvrtc_stub PRIVATE ${CMAKE_DL_LIBS})
-  set_target_properties(nvrtc_stub PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    OUTPUT_NAME "nvrtc_stub"
-  )
+    # Make TVM link against our CUDA Runtime stub instead of the real libcudart.
+    #
+    # NOTE: TVM's `find_cuda()` calls `find_library(CUDA_CUDART_LIBRARY cudart ...)`.
+    # `find_library()` will not override an already-cached variable, so setting it
+    # here ensures TVM doesn't record a DT_NEEDED on `libcudart.so.<major>`.
+    set(CUDA_CUDART_LIBRARY cudart_stub CACHE STRING "CUDART library to link against" FORCE)
 
-  # Make TVM link against our NVRTC stub instead of the real libnvrtc.
-  #
-  # NOTE: TVM's `find_cuda()` calls `find_library(CUDA_NVRTC_LIBRARY nvrtc ...)`.
-  # `find_library()` will not override an already-cached variable, so setting it
-  # here ensures TVM doesn't record a DT_NEEDED on `libnvrtc.so.<major>`.
-  set(CUDA_NVRTC_LIBRARY nvrtc_stub CACHE STRING "NVRTC library to link against" FORCE)
+    # ============================================================================
+    # NVRTC Stub Library (libnvrtc_stub.so)
+    # ============================================================================
+    # NVRTC's SONAME includes its major version (e.g. libnvrtc.so.11.2 / .12 / .13).
+    # Link against this stub instead of the real NVRTC library so a single wheel
+    # can run in environments that provide different NVRTC major versions.
+    #
+    # The stub exports a minimal set of NVRTC C API entrypoints used by TVM and
+    # lazily loads libnvrtc at runtime on first API call.
+    # ============================================================================
+    add_library(nvrtc_stub SHARED src/target/stubs/nvrtc.cc)
+    target_include_directories(nvrtc_stub PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+    target_compile_definitions(nvrtc_stub PRIVATE TILELANG_NVRTC_STUB_EXPORTS)
+    target_link_libraries(nvrtc_stub PRIVATE ${CMAKE_DL_LIBS})
+    set_target_properties(nvrtc_stub PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      OUTPUT_NAME "nvrtc_stub"
+    )
+
+    # Make TVM link against our NVRTC stub instead of the real libnvrtc.
+    #
+    # NOTE: TVM's `find_cuda()` calls `find_library(CUDA_NVRTC_LIBRARY nvrtc ...)`.
+    # `find_library()` will not override an already-cached variable, so setting it
+    # here ensures TVM doesn't record a DT_NEEDED on `libnvrtc.so.<major>`.
+    set(CUDA_NVRTC_LIBRARY nvrtc_stub CACHE STRING "NVRTC library to link against" FORCE)
+  endif()
 
   file(GLOB TILE_LANG_CUDA_SRCS
     src/runtime/runtime.cc
@@ -400,14 +422,14 @@ set(TILELANG_OUTPUT_TARGETS
   tvm_runtime
 )
 
-if(USE_CUDA)
+if(USE_CUDA AND TILELANG_USE_CUDA_STUBS)
   # Link against CUDA stub library instead of libcuda.so
   # This enables lazy loading of libcuda.so at runtime, allowing
   # `import tilelang` to succeed on CPU-only machines.
   foreach(target IN LISTS TILELANG_OUTPUT_TARGETS)
     target_link_libraries(${target} PUBLIC cuda_stub)
   endforeach()
-  # Include CUDA stub in output targets for RPATH configuration
+  # Include CUDA stubs in output targets for RPATH configuration
   list(APPEND TILELANG_OUTPUT_TARGETS cuda_stub cudart_stub nvrtc_stub)
 endif()
 
@@ -444,7 +466,7 @@ foreach(target IN LISTS TILELANG_OUTPUT_TARGETS)
 endforeach()
 
 # Exclude libcuda.so to allow importing on a CPU-only machine
-if(USE_CUDA AND PATCHELF_EXECUTABLE)
+if(USE_CUDA AND TILELANG_USE_CUDA_STUBS AND PATCHELF_EXECUTABLE)
   # Run `patchelf` on built libraries to remove libcuda.so dependency.
   # Use `install(CODE ...)` instead of `add_custom_command(... POST_BUILD ...)`
   # to avoid race conditions during linking.

--- a/src/target/stubs/cuda.cc
+++ b/src/target/stubs/cuda.cc
@@ -12,6 +12,12 @@
 
 #include "cuda.h"
 
+#if defined(_WIN32) && !defined(__CYGWIN__)
+#error "cuda_stub is currently POSIX-only (requires <dlfcn.h> / dlopen). "         \
+    "On Windows, build TileLang from source with -DTILELANG_USE_CUDA_STUBS=OFF " \
+    "to link against the real CUDA libraries."
+#endif
+
 #include <dlfcn.h>
 #include <stdexcept>
 #include <string>

--- a/src/target/stubs/cudart.cc
+++ b/src/target/stubs/cudart.cc
@@ -18,6 +18,12 @@
 
 #include <cuda_runtime_api.h>
 
+#if defined(_WIN32) && !defined(__CYGWIN__)
+#error "cudart_stub is currently POSIX-only (requires <dlfcn.h> / dlopen). "       \
+    "On Windows, build TileLang from source with -DTILELANG_USE_CUDA_STUBS=OFF " \
+    "to link against the real CUDA libraries."
+#endif
+
 #include <dlfcn.h>
 #include <stddef.h>
 #include <string.h>
@@ -39,15 +45,7 @@ static_assert(CUDART_VERSION >= 11000,
               "(CUDART_VERSION >= 11000).");
 
 // Export symbols with default visibility for the shared stub library.
-#if defined(_WIN32) || defined(__CYGWIN__)
-#ifdef TILELANG_CUDART_STUB_EXPORTS
-#define TILELANG_CUDART_STUB_API __declspec(dllexport)
-#else
-#define TILELANG_CUDART_STUB_API __declspec(dllimport)
-#endif
-#else
 #define TILELANG_CUDART_STUB_API __attribute__((visibility("default")))
-#endif
 
 namespace {
 

--- a/src/target/stubs/nvrtc.cc
+++ b/src/target/stubs/nvrtc.cc
@@ -19,19 +19,17 @@
 
 #include <nvrtc.h>
 
+#if defined(_WIN32) && !defined(__CYGWIN__)
+#error "nvrtc_stub is currently POSIX-only (requires <dlfcn.h> / dlopen). "        \
+    "On Windows, build TileLang from source with -DTILELANG_USE_CUDA_STUBS=OFF " \
+    "to link against the real CUDA libraries."
+#endif
+
 #include <dlfcn.h>
 #include <stddef.h>
 
 // Export symbols with default visibility for the shared stub library.
-#if defined(_WIN32) || defined(__CYGWIN__)
-#ifdef TILELANG_NVRTC_STUB_EXPORTS
-#define TILELANG_NVRTC_STUB_API __declspec(dllexport)
-#else
-#define TILELANG_NVRTC_STUB_API __declspec(dllimport)
-#endif
-#else
 #define TILELANG_NVRTC_STUB_API __attribute__((visibility("default")))
-#endif
 
 namespace {
 


### PR DESCRIPTION
 - Wheels that link directly against versioned CUDA libraries (libcudart.so.<major>, libnvrtc.so.<major>) often break when run in an environment with a different CUDA
    Toolkit major (e.g. build with 12.x, run with 13.x).
    versioned SONAMEs.
  What’s in this PR

  - Add src/target/stubs/cudart.cc: a cudart_stub shared library that exports the CUDA Runtime API subset used by TVM/TileLang and lazily loads the real libcudart via
      - Tries multiple SONAMEs for compatibility: libcudart.so.13, .12, .11.0, .11, then libcudart.so.
  - Add src/target/stubs/nvrtc.cc: an nvrtc_stub shared library that exports the NVRTC C API subset used by TVM/TileLang and lazily loads the real libnvrtc at runtime.
      - Tries multiple SONAMEs: libnvrtc.so.13, .12, .11.2, .11.1, .11.0, .11, then libnvrtc.so.
      - Provides stable fallback error strings/return codes when NVRTC is unavailable.
  - Update CMakeLists.txt to build cudart_stub and nvrtc_stub when USE_CUDA is enabled, and force TVM’s cached CUDA_CUDART_LIBRARY / CUDA_NVRTC_LIBRARY variables to
    point to these stub targets before add_subdirectory(tvm).
      - This prevents TVM from caching and linking against a specific libcudart.so.<major> / libnvrtc.so.<major> and avoids version-locked DT_NEEDED entries.
  - Add cudart_stub / nvrtc_stub to TILELANG_OUTPUT_TARGETS so existing install/RPATH/patchelf handling is applied consistently.

  CUDA 11/12 API compatibility

  - cudart_stub handles the cudaGraphInstantiate signature change between CUDA 11 (legacy 5-arg) and CUDA 12+ (3-arg + flags) safely:
      - Runtime dispatch prefers cudaGraphInstantiateWithFlags when present, otherwise falls back to legacy cudaGraphInstantiate.
      - Exported wrapper signature is selected with #if CUDART_VERSION >= 12000 to match the build-time headers.

  Testing

  - Built stub targets with cmake -S . -B build and cmake --build build --target cudart_stub nvrtc_stub.
  - Verified via ldd that libcudart_stub.so / libnvrtc_stub.so do not hard-link to libcudart.so.* / libnvrtc.so.* (resolved dynamically at runtime).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds dynamic, runtime-loading stubs for CUDA runtime and NVRTC with graceful fallbacks when system libraries are absent; improves compatibility across CUDA versions and allows operation without a fixed SONAME.
  * Adds a build-time option to enable/disable CUDA stub usage and a Windows guard that prevents POSIX-only stubs on unsupported platforms.

* **Chores**
  * Updated build and packaging to expose stub artifacts, adjust install-time rpath handling, and refine post-install library cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->