### PR TITLE
[BugFix] Reset cur_expect_idx_ correctly for multi-kernel TMA barrier injection

### DIFF
--- a/src/transform/inject_tma_barrier.cc
+++ b/src/transform/inject_tma_barrier.cc
@@ -497,6 +497,7 @@ private:
     if (op->attr_key == "kWarpSpecializationScope") {
       has_warp_specialization_ = true;
       first_if = true;
+      cur_expect_idx_ = 0;
     } else if (op->attr_key == tir::attr::thread_extent &&
                Downcast<IterVar>(op->node)->thread_tag == "threadIdx.x") {
       thread_var_ = Downcast<IterVar>(op->node);


### PR DESCRIPTION
This pr fixes an error mentioned in issue #1393.

### Problem

When a T.prim_func contains multiple kernels with TMA enabled, the second kernel uses stale indices from the first kernel, leading to incorrect mbarrier intrinsic generation.

### Reproduction

```py
@tilelang.jit(
    pass_configs={
        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: False,
        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: False,
    },
)
def multi_kernel_example():
    dtype = T.bfloat16
    accum_dtype = T.float32

    @T.prim_func
    def kernel(A: T.Tensor((512, 512), dtype), B: T.Tensor((512, 512), dtype)):
        with T.Kernel(1, 1, threads=128):
            A_shared = T.alloc_shared((64, 32), dtype=dtype)
            T.copy(A[0, 0], A_shared)
        with T.Kernel(1, 1, threads=128):
            X_shared = T.alloc_shared((32, 64), dtype=dtype)
            B_shared = T.alloc_shared((32, 64), dtype=dtype)
            O_local = T.alloc_fragment((32, 32), dtype=accum_dtype)
            T.copy(B[0, 0], B_shared)
            T.gemm(X_shared, B_shared, O_local, transpose_B=True)
    return kernel
```

Before this pr, the generated kernel source code of the second kernel contains:

```cu
if (tl::tl_shuffle_elect<128>()) {
  mbarrier[0].expect_transaction(4096);
  tl::fence_proxy_async();
  tl::tma_load(B_desc, mbarrier[0], (&(((bfloat16_t*)buf_dyn_shmem)[0])), 0, 0);
}
mbarrier[0].arrive();
```

while it should be:

```cu
if (tl::tl_shuffle_elect<128>()) {
  mbarrier[0].arrive_and_expect_tx(4096);
  tl::fence_proxy_async();
  tl::tma_load(B_desc, mbarrier[0], (&(((bfloat16_t*)buf_dyn_shmem)[0])), 0, 0);
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed initialization logic for barrier operations in specialized execution contexts to ensure correct operation sequencing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->