### PR TITLE
[Docs] Update nightly build installation instructions in README and Installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ We currently provide three ways to install **tile-lang** from source:
 For users who want access to the latest features and improvements before official releases, we provide nightly builds of **tile-lang**.
 
 ```bash
-pip install tilelang -f https://tile-ai.github.io/whl/nightly/cu121/
-# or pip install tilelang --find-links https://tile-ai.github.io/whl/nightly/cu121/
+pip install tilelang -f https://tile-ai.github.io/whl/nightly
+# or pip install tilelang --find-links https://tile-ai.github.io/whl/nightly
 ```
 
 > **Note:** Nightly builds contain the most recent code changes but may be less stable than official releases. They're ideal for testing new features or if you need a specific bugfix that hasn't been released yet.

--- a/docs/get_started/Installation.md
+++ b/docs/get_started/Installation.md
@@ -264,8 +264,8 @@ If you still want to use `pip install -e . -v --no-build-isolation` without `--n
 For users who want access to the latest features and improvements before official releases, we provide nightly builds of tilelang.
 
 ```bash
-pip install tilelang -f https://tile-ai.github.io/whl/nightly/cu121/
-# or pip install tilelang --find-links https://tile-ai.github.io/whl/nightly/cu121/
+pip install tilelang -f https://tile-ai.github.io/whl/nightly
+# or pip install tilelang --find-links https://tile-ai.github.io/whl/nightly
 ```
 
 > **Note:** Nightly builds contain the most recent code changes but may be less stable than official releases. They're ideal for testing new features or if you need a specific bugfix that hasn't been released yet.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated nightly build installation instructions in documentation. Installation commands now reference generic nightly wheel repositories instead of CUDA version-specific paths. This simplifies the setup process for development builds and provides greater flexibility for users seeking to install the latest development versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->