### PR TITLE
[Refactor] Treat `local.var` as `local` buffers when deciding vectorization for stable actions

### DIFF
--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -998,11 +998,13 @@ private:
     bool has_non_local = false;
     PostOrderVisit(for_node->body, [&](const ObjectRef &obj) {
       if (const auto *load = obj.as<BufferLoadNode>()) {
-        if (!IsLocalBuffer(load->buffer) && !IsFragmentBuffer(load->buffer)) {
+        if (!IsLocalBuffer(load->buffer, /*allow_var*/ true) &&
+            !IsFragmentBuffer(load->buffer)) {
           has_non_local = true;
         }
       } else if (const auto *store = obj.as<BufferStoreNode>()) {
-        if (!IsLocalBuffer(store->buffer) && !IsFragmentBuffer(store->buffer)) {
+        if (!IsLocalBuffer(store->buffer, /*allow_var*/ true) &&
+            !IsFragmentBuffer(store->buffer)) {
           has_non_local = true;
         }
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved buffer detection logic to better handle local memory optimization.

* **Tests**
  * Added test coverage for vectorization behavior with local variable handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->