### PR TITLE
[Enhancement] Enhance the conditions for async proxy in `InjectFenceProxy`

### DIFF
--- a/src/transform/inject_fence_proxy.cc
+++ b/src/transform/inject_fence_proxy.cc
@@ -80,7 +80,7 @@ bool IsAsyncIntrinsic(const CallNode *call) {
 
   // TileLang async intrinsics
   // Although tma_load is also an async intrinsic, it has no dependency on data
-  // from generic proxy. Hence, we doesn't take it into account.
+  // from generic proxy. Hence, we don't take it into account.
   if (call->op.same_as(tma_store()) || call->op.same_as(tma_store_arrive()) ||
       call->op.same_as(tma_store_wait()) || call->op.same_as(ptx_wgmma_ss()) ||
       call->op.same_as(ptx_wgmma_rs()) ||


### PR DESCRIPTION
#1849
- Remove CpAsync intrins as they belong to generic proxy, according to NV doc.
- DOES NOT inject fence before TmaLoad, as it has no dependency on previous data from generic proxy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Refined internal handling of asynchronous intrinsics to a smaller, focused set for more predictable compilation.
  * Removed explicit special-casing of certain async copy operations and clarified proxy ownership in documentation.
  * Minor doc updates and comments to explain behavior.
  * No changes to public APIs or user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->