### PR TITLE
[BugFix] ArgBinder: relax shared-shape binding for unused nullable buffers

### DIFF
--- a/src/transform/arg_binder.h
+++ b/src/transform/arg_binder.h
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace tvm {
@@ -109,7 +110,8 @@ public:
   BindDLTensors(const std::vector<std::pair<Var, Buffer>> &buffer_def,
                 const PrimExpr &device_type, const PrimExpr &device_id,
                 const std::string &func_name,
-                const std::unordered_set<const VarNode *> &used_param_buffers);
+                const std::unordered_set<const VarNode *> &used_param_buffers,
+                const std::unordered_set<const VarNode *> &used_shape_vars);
 
   /*! \return The defs generated in binding. */
   const std::vector<Var> &defs() const { return defs_; }

--- a/src/transform/make_packed_api.cc
+++ b/src/transform/make_packed_api.cc
@@ -514,7 +514,7 @@ PrimFunc MakePackedAPI(PrimFunc func) {
   }
 
   binder.BindDLTensors(buffer_def, device_type, device_id, name_hint,
-                       used_param_buffers);
+                       used_param_buffers, detector.used_shape_vars);
   for (const auto &[var, buffer] : buffer_def) {
     // Prefer buffer data var name in diagnostics to avoid exposing low-level
     // handle vars


### PR DESCRIPTION
### Problem
In the generated Packed API binder (`ArgBinder::BindDLTensors`), a symbolic shape var (e.g. `m`) can appear in multiple *nullable* input buffers.

If all of those buffers are passed as `None`, binding currently fails with an "at least one non-null buffer" assertion, even when the buffers are truly unused by the kernel body and another non-null tensor argument exists.

### Fix
- Move the handling into codegen (`ArgBinder::BindDLTensors` / `make_packed_api`).
- For shared symbolic vars that appear in multiple buffers:
  - If the var is used by the PrimFunc body, keep the existing behavior and require at least one non-null carrier buffer.
  - Otherwise, allow all carriers to be NULL and bind the var to 0 via the existing cascaded `if_then_else` expression (no Python-side dummy tensors / allocations).

### Tests
- Add `test_nullable_shared_shape_with_no_source_buffers_but_other_tensor_present`.