### PR TITLE
layout: add Layout.repeat for tiling atom layouts

### DIFF
--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -60,6 +60,15 @@ public:
 
   virtual Array<PrimExpr> Forward(const Array<PrimExpr> &vars) const;
 
+  // Repeat the layout along a single input dimension and prepend a new output
+  // dimension that indicates the repeat-group index.
+  //
+  // For a layout L with input shape S and forward index F, repeating along
+  // dimension `dim` with `factor` constructs a new layout L' where:
+  //   - New input shape: S'[dim] = S[dim] * factor
+  //   - New forward index: [i_dim // S[dim]] + F(..., i_dim % S[dim], ...)
+  virtual Layout Repeat(int dim, int factor) const;
+
   virtual Layout Inverse() const;
 
   // Reshape the layout to a new logical shape. When aliasing buffers of

--- a/testing/python/layout/test_tilelang_layout_repeat.py
+++ b/testing/python/layout/test_tilelang_layout_repeat.py
@@ -1,0 +1,61 @@
+import pytest
+
+import tilelang
+import tilelang.testing
+from tilelang.layout import Layout
+
+tilelang.testing.set_random_seed()
+
+
+def test_layout_repeat_dim0_linear():
+    atom = Layout([8, 64], lambda i, j: i * 64 + j)
+    repeated = atom.repeat(dim=0, factor=2)
+
+    expected = Layout([16, 64], lambda i, j: [i // 8, (i % 8) * 64 + j])
+    assert repeated.is_equal(expected)
+
+    assert list(repeated.get_input_shape()) == [16, 64]
+    assert list(repeated.get_output_shape()) == [2, 512]
+
+
+def test_layout_repeat_dim1_linear():
+    atom = Layout([8, 64], lambda i, j: i * 64 + j)
+    repeated = atom.repeat(dim=1, factor=3)
+
+    expected = Layout([8, 192], lambda i, j: [j // 64, i * 64 + (j % 64)])
+    assert repeated.is_equal(expected)
+
+    assert list(repeated.get_input_shape()) == [8, 192]
+    assert list(repeated.get_output_shape()) == [3, 512]
+
+
+def test_layout_repeat_multi_output():
+    atom = Layout([8, 64], lambda i, j: [i, j])
+    repeated = atom.repeat(dim=0, factor=2)
+
+    expected = Layout([16, 64], lambda i, j: [i // 8, i % 8, j])
+    assert repeated.is_equal(expected)
+
+    assert list(repeated.get_output_shape()) == [2, 8, 64]
+
+
+def test_layout_repeat_factor_one_is_noop():
+    atom = Layout([8, 64], lambda i, j: i * 64 + j)
+    assert atom.repeat(dim=0, factor=1) is atom
+
+
+def test_layout_repeat_invalid_args():
+    atom = Layout([8, 64], lambda i, j: i * 64 + j)
+
+    with pytest.raises(ValueError):
+        _ = atom.repeat(dim=0, factor=0)
+    with pytest.raises(ValueError):
+        _ = atom.repeat(dim=0, factor=-1)
+    with pytest.raises(ValueError):
+        _ = atom.repeat(dim=2, factor=2)
+    with pytest.raises(ValueError):
+        _ = atom.repeat(dim=-3, factor=2)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
This PR adds `Layout.repeat(dim, factor)` to make it easy to tile/compose an atom layout into a larger logical layout.

Changes:
- Implement `LayoutNode::Repeat(int dim, int factor)` in C++ and expose it via FFI (`tl.Layout_repeat`).
- Wire up the Python API `Layout.repeat(...)` to call the FFI implementation (with Python-side argument validation).
- Add unit tests covering repeat on different dims, multi-output layouts, and invalid arguments.

Example: repeating an 8x64 atom on dim=0 with factor=2 produces a 16x64 layout with a leading repeat-group output dimension.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now repeat layouts along a specified dimension using a multiplication factor, with automatic adjustment of input dimensions and index transformations.

* **Tests**
  * Comprehensive test coverage added for the new layout repetition functionality, including multi-dimensional cases, edge cases, and input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->