### PR TITLE
Avoid cvt instruction in FP4 before cuda 13.0

### DIFF
--- a/src/tl_templates/cuda/cuda_fp4.h
+++ b/src/tl_templates/cuda/cuda_fp4.h
@@ -167,7 +167,7 @@ TL_DEVICE fp4_e2_32_t make_fp4_e2_32_t(
 // https://docs.nvidia.com/cuda/cuda-math-api/cuda_math_api/group__CUDA__MATH__FP4__MISC.html
 
 // Custom fp4_e2m1 -> half convertion for CUDA version < 13.0 to avoid using
-// `cvt.rn.relu.f16x2.e2m1x2` There are bugs in PTXAS related to
+// `cvt.rn.relu.f16x2.e2m1x2`, as there are bugs in PTXAS related to
 // `cvt.rn.relu.f16x2.e2m1x2` between CUDA 12.6 and 12.9
 __device__ __half_raw __tl_cvt_fp4_to_halfraw_naive(
     const __nv_fp4_storage_t x,
@@ -182,7 +182,7 @@ __device__ __half_raw __tl_cvt_fp4_to_halfraw_naive(
 }
 
 // Custom fp4_e2m1 -> half convertion for CUDA version < 13.0 to avoid using
-// `cvt.rn.relu.f16x2.e2m1x2` There are bugs in PTXAS related to
+// `cvt.rn.relu.f16x2.e2m1x2`, as there are bugs in PTXAS related to
 // `cvt.rn.relu.f16x2.e2m1x2` between CUDA 12.6 and 12.9
 __device__ __half2_raw __tl_cvt_fp4x2_to_halfraw2_naive(
     const __nv_fp4x2_storage_t x,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FP4→FP16 conversion reliability across CUDA toolchains by adding a safe fallback path for older toolchains and ensuring correct handling of paired FP4 values.

* **Chores**
  * Preserved existing public APIs while selecting the appropriate conversion implementation at build time based on the CUDA toolchain.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->