### PR TITLE
[FIX] Fix flattened buffer elem_offset to avoid double-count in access_ptr

### DIFF
--- a/src/transform/flatten_buffer.cc
+++ b/src/transform/flatten_buffer.cc
@@ -241,6 +241,11 @@ private:
     for (size_t i = 0; i < flattened->shape.size(); ++i) {
       writer->shape.Set(i, analyzer_->canonical_simplify(flattened->shape[i]));
     }
+    // Flattened indices already include buf->elem_offset (see
+    // VisitBufferAccess). Zero elem_offset so later passes (e.g.
+    // Buffer::access_ptr) use index as the sole offset and do not add
+    // buffer->elem_offset again.
+    writer->elem_offset = make_const(flattened->DefaultIndexType(), 0);
 
     buffer_remap_[buf] = flattened;
     return flattened;


### PR DESCRIPTION
## Fix double elem_offset in FlattenBuffer

When flattening unified buffers (A/B/C sharing one storage),
`FlattenBuffer` encodes `elem_offset` into the flattened index,
but the flattened buffer still keeps its original non-zero
`elem_offset`.

Later `buffer.access_ptr(..., index, ...)` computes:

    elem_offset + index

Since `index` already includes the logical offset,
the offset is applied twice, leading to incorrect memory access.

### Fix

Reset `elem_offset` to zero in `GetFlattenedBuffer()`:

```cpp
writer->elem_offset = make_const(flattened->DefaultIndexType(), 0);

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect index-offset handling for flattened buffers that could cause offsets to be counted twice.
  * Ensures flattened buffer indices and subsequent operations consistently use the correct single offset, improving correctness when accessing flattened or canonicalized data and preventing misaligned reads/writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->