### PR TITLE
feat: Add TILELANG_DUMP_IR environment variable to dump IR between passes

### DIFF
--- a/testing/python/debug/test_dump_ir.py
+++ b/testing/python/debug/test_dump_ir.py
@@ -1,0 +1,19 @@
+import tilelang
+import tilelang.language as T
+
+
+@tilelang.jit(out_idx=[-1])
+def simple_kernel(M=128, N=128):
+    @T.prim_func
+    def kernel(A: T.Tensor((M, N), "float32"), B: T.Tensor((M, N), "float32")):
+        with T.Kernel(T.ceildiv(N, 32), T.ceildiv(M, 32), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((32, 32), "float32")
+            T.copy(A[by * 32 : (by + 1) * 32, bx * 32 : (bx + 1) * 32], A_shared)
+            T.copy(A_shared, B[by * 32 : (by + 1) * 32, bx * 32 : (bx + 1) * 32])
+
+    return kernel
+
+
+if __name__ == "__main__":
+    kernel = simple_kernel()
+    print("Kernel compiled!")

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -1,5 +1,14 @@
 from __future__ import annotations
 from tvm import tir, IRModule
+
+
+def should_dump_ir() -> bool:
+    import os
+
+    """Check if IR dump is enabled via environment variable."""
+    return os.environ.get("TILELANG_DUMP_IR", "0") == "1"
+
+
 from tvm.target import Target
 import tilelang
 from tilelang.transform import PassContext
@@ -172,47 +181,98 @@ def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
         IRModule: The transformed module, ready for target-specific optimization passes.
     """
     mod = tir.transform.BindTarget(target)(mod)
+    if should_dump_ir():
+        print("=== After BindTarget ===")
+        print(mod)
 
     if should_force_let_inline():
         # Force-let inline whenever the pass config requests it.
         mod = tilelang.transform.LetInline()(mod)
+        if should_dump_ir():
+            print("=== After LetInline ===")
+            print(mod)
     # Add wrapper for single buf store
     mod = tilelang.transform.AddWrapperForSingleBufStore()(mod)
+    if should_dump_ir():
+        print("=== After AddWrapperForSingleBufStore ===")
+        print(mod)
     # Normalize negative indices to canonical non-negative form
     mod = tilelang.transform.LegalizeNegativeIndex()(mod)
+    if should_dump_ir():
+        print("=== After LegalizeNegativeIndex ===")
+        print(mod)
     # Verify parallel loop correctness
     if should_enable_race_check():
         mod = tilelang.transform.VerifyParallelLoop()(mod)
+        if should_dump_ir():
+            print("=== After VerifyParallelLoop ===")
+            print(mod)
     # Inject assumes to speedup tvm prover
     mod = tilelang.transform.InjectAssumes()(mod)
+    if should_dump_ir():
+        print("=== After InjectAssumes ===")
+        print(mod)
     # Simplify the IR expressions
     mod = tilelang.transform.Simplify()(mod)
+    if should_dump_ir():
+        print("=== After Simplify ===")
+        print(mod)
     # Set layouts for reducers
     mod = tilelang.transform.LayoutReducer()(mod)
+    if should_dump_ir():
+        print("=== After LayoutReducer ===")
+        print(mod)
     # Infer memory layouts for fragments and shared memory
     mod = tilelang.transform.LayoutInference()(mod)
+    if should_dump_ir():
+        print("=== After LayoutInference ===")
+        print(mod)
     # Visualize the layout
     LayoutVisual(mod)
     # Lower high-level tile operations to low-level operations
     mod = tilelang.transform.LowerTileOp()(mod)
+    if should_dump_ir():
+        print("=== After LowerTileOp ===")
+        print(mod)
     # Lower l2 persistent map
     mod = tilelang.transform.LowerL2Persistent()(mod)
+    if should_dump_ir():
+        print("=== After LowerL2Persistent ===")
+        print(mod)
     # Decouple type cast vectorization constraints before vectorization
     mod = tilelang.transform.DecoupleTypeCast()(mod)
+    if should_dump_ir():
+        print("=== After DecoupleTypeCast ===")
+        print(mod)
     # Legalize vectorized loops to ensure they are valid
     mod = tilelang.transform.LegalizeVectorizedLoop()(mod)
+    if should_dump_ir():
+        print("=== After LegalizeVectorizedLoop ===")
+        print(mod)
     # Add safety checks for memory accesses
     mod = tilelang.transform.LegalizeSafeMemoryAccess()(mod)
+    if should_dump_ir():
+        print("=== After LegalizeSafeMemoryAccess ===")
+        print(mod)
     # Lower frontend pointer metadata op to standard tvm_access_ptr
     mod = tilelang.transform.LowerAccessPtr()(mod)
+    if should_dump_ir():
+        print("=== After LowerAccessPtr ===")
+        print(mod)
     # Simplify again to clean up any duplicated conditions
     # that may have been introduced by safety checks
     # use an enhanced pass to simplify the dynamic symbolics
     # TODO(lei): return to tir pass when kSymbolicBound simplification
     # is merged into tvm.
     mod = tilelang.transform.Simplify()(mod)
+    if should_dump_ir():
+        print("=== After Simplify ===")
+        print(mod)
     # Hoist any root-block annotations to PrimFunc attrs if pass is available
     mod = tilelang.transform.HoistNonRestrictParams()(mod)
+    if should_dump_ir():
+        print("=== After HoistNonRestrictParams ===")
+        print(mod)
     return mod
 
 


### PR DESCRIPTION
## Summary

Add TILELANG_DUMP_IR environment variable to dump IR between passes, similar to Triton's MLIR_ENABLE_DUMP feature.

## Changes

- Add `should_dump_ir()` function to check environment variable
- Dump IR after each pass in `LowerAndLegalize` function

## Usage

```bash
TILELANG_DUMP_IR=1 python your_script.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added IR dumping capability controlled via environment variable, allowing inspection of intermediate compilation states for debugging purposes.
* **Tests**
  * Added test module for IR dumping and kernel compilation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->