### PR TITLE
[BugFix] Fix type mismatch when lowering to AtomicAddx2 template

### DIFF
--- a/src/tl_templates/cuda/atomic.h
+++ b/src/tl_templates/cuda/atomic.h
@@ -437,15 +437,24 @@ AtomicAddx2Ret(half_t *ref, ValType val,
 }
 
 #if (defined(__CUDA_ARCH_LIST__) && (__CUDA_ARCH_LIST__ > 750))
-template <typename src_type>
-TL_DEVICE void AtomicAddx2(bfloat16_t *ref, src_type *val,
+template <typename T> TL_DEVICE __nv_bfloat162 ToBfloat162(T *val) {
+  return *reinterpret_cast<const __nv_bfloat162 *>(val);
+}
+
+template <typename T> TL_DEVICE __nv_bfloat162 ToBfloat162(T val) {
+  return static_cast<__nv_bfloat162>(
+      *reinterpret_cast<const __nv_bfloat162 *>(&val));
+}
+
+TL_DEVICE __nv_bfloat162 ToBfloat162(__nv_bfloat162 val) { return val; }
+
+template <typename ValType>
+TL_DEVICE void AtomicAddx2(bfloat16_t *ref, ValType val,
                            int memory_order = int(cuda::memory_order_relaxed)) {
+  __nv_bfloat162 add_val = ToBfloat162(val);
   if (memory_order == int(cuda::memory_order_relaxed)) {
-    atomicAdd(reinterpret_cast<__nv_bfloat162 *>(ref),
-              static_cast<__nv_bfloat162>(
-                  *reinterpret_cast<const __nv_bfloat162 *>(val)));
+    atomicAdd(reinterpret_cast<__nv_bfloat162 *>(ref), add_val);
   } else {
-    __nv_bfloat162 add_val = *reinterpret_cast<const __nv_bfloat162 *>(val);
     unsigned short add_val_x_cast =
         *reinterpret_cast<unsigned short *>(&add_val.x);
     unsigned short add_val_y_cast =

--- a/testing/python/language/test_tilelang_language_atomic.py
+++ b/testing/python/language/test_tilelang_language_atomic.py
@@ -88,7 +88,7 @@ def atomic_addx2_program(M, N, block_M, block_N, dtype=T.float16):
 
 def run_atomic_addx2(M, N, block_M, block_N, dtype=T.float16):
     kernel = atomic_addx2_program(M, N, block_M, block_N, dtype=dtype)
-    print(kernel.get_kernel_source())
+
     import torch
 
     A = torch.randn(M, N, dtype=torch.float32).cuda().to(getattr(torch, dtype))
@@ -232,8 +232,24 @@ def test_tma_atomic_add():
 def run_atomic_add_auto_vectorized(K, M, N, block_M, block_N, dtype=T.float32):
     tilelang.disable_cache()
     kernel = atomic_add_program(K, M, N, block_M, block_N, dtype=dtype)
-    print(kernel.get_kernel_source())
     assert "AtomicAddx4" in kernel.get_kernel_source()
+
+
+@tilelang.jit
+def atomic_add_auto_vectorized_unit_test(vec_size: int, dtype=T.float32):
+    @T.prim_func
+    def atomic_addx2(A: T.Tensor((vec_size,), dtype)):
+        with T.Kernel(threads=1):
+            A_local = T.alloc_fragment((vec_size,), dtype)
+            for i in T.Parallel(vec_size):
+                T.atomic_add(A[i], A_local[i])
+
+    return atomic_addx2
+
+
+def run_atomic_add_auto_vectorized_unit_test(vec_size: int, dtype=T.float32):
+    kernel = atomic_add_auto_vectorized_unit_test(vec_size, dtype)
+    assert f"AtomicAddx{vec_size}" in kernel.get_kernel_source()
 
 
 @tilelang.jit
@@ -279,6 +295,7 @@ def test_atomic_different_memory_orders():
     run_atomic_different_memory_orders(32, 32, 8, 8, dtype=T.bfloat16)
 
 
+# TODO: atomic_addx4 currently not support half
 def test_atomic_addx4():
     run_atomic_addx4(16, 64, 4, 4)
 
@@ -294,12 +311,21 @@ def test_atomic_add():
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_atomic_add_auto_vectorized():
-    run_atomic_add_auto_vectorized(8, 128, 128, 32, 32)
+    run_atomic_add_auto_vectorized(8, 128, 128, 32, 32, dtype=T.float32)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_atomic_add_auto_vectorized_unit_test():
+    run_atomic_add_auto_vectorized_unit_test(2, dtype=T.float32)
+    run_atomic_add_auto_vectorized_unit_test(4, dtype=T.float32)
+    run_atomic_add_auto_vectorized_unit_test(2, dtype=T.float16)
+    run_atomic_add_auto_vectorized_unit_test(2, dtype=T.bfloat16)
 
 
 @tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_atomic_add_complicated_parallel():
-    run_atomic_add_complicated_parallel(8, 128, 128, 32, 32)
+    run_atomic_add_complicated_parallel(8, 128, 128, 32, 32, dtype=T.float32)
 
 
 # ======================= Tile-level atomic add =======================


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added conversion utilities for flexible half2/bfloat16 vector handling.
  * Atomic add operations now accept both pointer and direct value inputs and support vectorized half2/bfloat16 adds.

* **Tests**
  * Added unit tests exercising auto-vectorized atomic add variants and updated existing atomic add tests to specify data types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->