### PR TITLE
[BugFix] add target context and avoid redundant re-lowering in TLCPUSourceWrapper

### DIFF
--- a/testing/python/cpu/test_tilelang_cpu_gemm.py
+++ b/testing/python/cpu/test_tilelang_cpu_gemm.py
@@ -113,5 +113,44 @@ def test_matmul_compile():
     tilelang.testing.torch_assert_close(C, C_torch, atol=1e-2, rtol=1e-2, max_mismatched_ratio=0.05)
 
 
+def test_matmul_with_copy_cython():
+    """CPU kernel using T.copy with cython backend.
+
+    Verifies that TLCPUSourceWrapper.parse_source_information() does not
+    crash with 'Target context required' when device_mod/host_mod are
+    already provided by tilelang.lower().
+
+    Note: The full compile may fail due to missing vector type definitions
+    (float4 etc.) in common.h — that is a separate known issue.
+    """
+    M, N, K = 128, 128, 128
+    block_M, block_N, block_K = 32, 32, 32
+
+    @T.prim_func
+    def matmul(
+        A: T.Tensor((M, K), "float32"),
+        B: T.Tensor((K, N), "float32"),
+        C: T.Tensor((M, N), "float32"),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), is_cpu=True) as (bx, by):
+            A_local = T.alloc_local((block_M, block_K), "float32")
+            B_local = T.alloc_local((block_K, block_N), "float32")
+            C_local = T.alloc_local((block_M, block_N), "float32")
+
+            T.clear(C_local)
+            for ko in T.serial(K // block_K):
+                T.copy(A[by * block_M, ko * block_K], A_local)
+                T.copy(B[ko * block_K, bx * block_N], B_local)
+                for i, j, k in T.grid(block_M, block_N, block_K):
+                    C_local[i, j] += A_local[i, k] * B_local[k, j]
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    try:
+        tilelang.compile(matmul, target="c", out_idx=-1, execution_backend="cython")
+    except Exception as e:
+        # Must not be the target context error (the bug we fixed)
+        assert "Target context required" not in str(e), f"parse_source_information still crashes without target context: {e}"
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/tilelang/jit/adapter/wrapper.py
+++ b/tilelang/jit/adapter/wrapper.py
@@ -835,13 +835,16 @@ class TLCPUSourceWrapper:
         return host_func
 
     def parse_source_information(self):
-        with tvm.transform.PassContext(opt_level=3, config=self.pass_configs):
-            device_mod, host_mod = get_annotated_mod(self.mod, self.target)
-        assert len(device_mod.functions) >= 1, "Device module should have at least one function."
-        assert len(host_mod.functions) == 1, "Only support one function in host module."
+        if self.device_mod is None or self.host_mod is None:
+            with tvm.transform.PassContext(opt_level=3, config=self.pass_configs), self.target:
+                device_mod, host_mod = get_annotated_mod(self.mod, self.target)
+            self.device_mod = device_mod
+            self.host_mod = host_mod
+        assert len(self.device_mod.functions) >= 1, "Device module should have at least one function."
+        assert len(self.host_mod.functions) == 1, "Only support one function in host module."
 
         function_names = []
-        for g_var, _ in device_mod.functions.items():
+        for g_var, _ in self.device_mod.functions.items():
             function_name = g_var.name_hint
             function_names.append(function_name)
 


### PR DESCRIPTION
## Problem
When compiling CPU kernels that utilize `T.copy` via `tilelang.compile(target="c", execution_backend="cpython")`, the compiler crashes with a `tvm.error.InternalError: Target context required`.

## Minimal Reproducer:
```python
import tilelang as tl
import tilelang.language as T

@T.prim_func
def matmul(A: T.Tensor((128, 128), "float32"), B: T.Tensor((128, 128), "float32"), C: T.Tensor((128, 128), "float32")):
    # triggers crash when is_cpu=True and T.copy is used
    with T.Kernel(128, 128, is_cpu=True) as (bx, by):
        A_local = T.alloc_local((32, 32), "float32")
        T.copy(A[by * 32, 0], A_local) 
        ...

tl.compile(matmul, target="c", out_idx=-1, execution_backend="cython")
```

## Root Cause Analysis

The issue stems from `TLCPUSourceWrapper.parse_source_information()` which unconditionally invokes `get_annotated_mod()` to re-lower the IR. This leads to two problems:

1. The re-lowering triggers VectorizePlanner (via `T.copy` -> `T.Parallel` -> `ParallelOpNode`), which calls `Target::Current(false)`. But the with block only sets PassContext, not the target — causing the crash.
2. In standard flows, `tilelang.lower()` already generated `device_mod` and `host_mod`. Re-lowering them here is unnecessary.

## Fix

Check if `device_mod/host_mod` already exist before re-lowering. Also add `self.target` to the context manager for the fallback path.

## Testing
- New Test Case: `test_matmul_with_copy_cpython` added to verify the compilation flow.
- Verfication: Confirmed that `tilelang.compile` new successfully generated source code without context-related crashes.
- But: Complete end-to-end execution of the generated code is currently limited by missing `float4` definitions in `common.h`, which will be a addressed in subsequent PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for CPU matrix-multiplication compilation targeting the C/Cython backend to improve compilation stability.

* **Improvements**
  * Made module initialization lazy during compilation to improve reliability and reduce unnecessary work, aligning discovered function metadata with runtime state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->