### PR TITLE
[BugFix] Add vector type definitions to common.h for CPU codegen

### DIFF
--- a/src/tl_templates/cpp/common.h
+++ b/src/tl_templates/cpp/common.h
@@ -3,6 +3,40 @@
 #include "half.hpp"
 #include <math.h>
 #include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
 
 using half_float::half;
-// Not Implemented
+
+// Vector types for CPU codegen.
+// The C codegen emits vector pointer casts like *(float4*)(ptr + offset)
+// and broadcast expressions like ((float4)(v, v, v, v)) where the comma
+// expression evaluates to a single value, requiring a one-arg constructor.
+template <typename T, int N> struct vec_type {
+  T data[N];
+  vec_type() = default;
+  explicit vec_type(T v) {
+    for (int i = 0; i < N; i++)
+      data[i] = v;
+  }
+};
+
+#define TL_DEFINE_VEC(T)                                                       \
+  using T##2 = vec_type<T, 2>;                                                 \
+  using T##4 = vec_type<T, 4>;                                                 \
+  using T##8 = vec_type<T, 8>;                                                 \
+  using T##16 = vec_type<T, 16>;
+
+TL_DEFINE_VEC(float)
+TL_DEFINE_VEC(double)
+TL_DEFINE_VEC(half)
+TL_DEFINE_VEC(int8_t)
+TL_DEFINE_VEC(int16_t)
+TL_DEFINE_VEC(int32_t)
+TL_DEFINE_VEC(int64_t)
+TL_DEFINE_VEC(uint8_t)
+TL_DEFINE_VEC(uint16_t)
+TL_DEFINE_VEC(uint32_t)
+TL_DEFINE_VEC(uint64_t)
+
+#undef TL_DEFINE_VEC

--- a/testing/python/cpu/test_tilelang_cpu_gemm.py
+++ b/testing/python/cpu/test_tilelang_cpu_gemm.py
@@ -116,12 +116,9 @@ def test_matmul_compile():
 def test_matmul_with_copy_cython():
     """CPU kernel using T.copy with cython backend.
 
-    Verifies that TLCPUSourceWrapper.parse_source_information() does not
-    crash with 'Target context required' when device_mod/host_mod are
-    already provided by tilelang.lower().
-
-    Note: The full compile may fail due to missing vector type definitions
-    (float4 etc.) in common.h — that is a separate known issue.
+    Verifies that T.copy works end-to-end on CPU: the vectorized copy
+    uses vector types (e.g. float4) defined in common.h, and the
+    wrapper correctly skips redundant re-lowering.
     """
     M, N, K = 128, 128, 128
     block_M, block_N, block_K = 32, 32, 32
@@ -145,11 +142,13 @@ def test_matmul_with_copy_cython():
                     C_local[i, j] += A_local[i, k] * B_local[k, j]
             T.copy(C_local, C[by * block_M, bx * block_N])
 
-    try:
-        tilelang.compile(matmul, target="c", out_idx=-1, execution_backend="cython")
-    except Exception as e:
-        # Must not be the target context error (the bug we fixed)
-        assert "Target context required" not in str(e), f"parse_source_information still crashes without target context: {e}"
+    compiled = tilelang.compile(matmul, target="c", out_idx=-1, execution_backend="cython")
+
+    a = torch.randn(M, K, dtype=torch.float32)
+    b = torch.randn(K, N, dtype=torch.float32)
+    c = compiled(a, b)
+    ref = a @ b
+    torch.testing.assert_close(c, ref, rtol=1e-5, atol=1e-5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

This is the follow-up fix mentioned in #1899 for the remaining `float4` compilation issue.

When a CPU kernel uses `T.copy`, the VectorizeLoop pass vectorizes the copy into 128-bit vector operations. The C codegen (`CodeGenTileLangCPP::PrintType`) then emits vector type names like `float4`, `int32_t4`, etc. However, common.h had no definitions for these types, causing g++ to fail:

**error: 'float4' was not declared in this scope**

Minimal reproducer:
```python
@T.prim_func
def matmul(A: T.Tensor((128, 128), "float32"), B: T.Tensor((128, 128), "float32"), C: T.Tensor((128, 128), "float32")):
    with T.Kernel(4, 4, is_cpu=True) as (bx, by):
        A_local = T.alloc_local((32, 32), "float32")
        T.copy(A[by * 32, 0], A_local)  # triggers vectorization → float4
        ...

tilelang.compile(matmul, target="c", execution_backend="cython")
# g++ error: 'float4' was not declared in this scope
```

## Root Cause

The VectorizeLoop pass is target-agnostic — it vectorizes to 128-bit for all targets. On CUDA/HIP/Metal, `float4` is a built-in type
provided by the runtime. On CPU (plain C++), there is no such type, and `common.h` only had `// Not Implemented`.

The generated C code uses vector types in two patterns:
- Pointer cast load/store: `*(float4*)(ptr + offset)`
- Broadcast:` ((float4)(v, v, v, v)) `(comma expression evaluates to single value → needs one-arg constructor)

## Fix

Add a generic `vec_type<T, N>` template to `common.h` with type aliases for all combinations that `PrintType()` can emit:

```cpp
template <typename T, int N>
struct vec_type {
  T data[N];
  vec_type() = default;
  explicit vec_type(T v) { for (int i = 0; i < N; i++) data[i] = v; }
};

#define TL_DEFINE_VEC(T) \
  using T##2 = vec_type<T, 2>; using T##4 = vec_type<T, 4>; \
  using T##8 = vec_type<T, 8>; using T##16 = vec_type<T, 16>;

TL_DEFINE_VEC(float)  TL_DEFINE_VEC(double)  TL_DEFINE_VEC(half)
TL_DEFINE_VEC(int8_t) TL_DEFINE_VEC(int16_t) TL_DEFINE_VEC(int32_t) ...
```

## Test

Updated test_matmul_with_copy_cython to verify end-to-end correctness (compile + execute + torch.testing.assert_close) instead of just
checking for crash. This test exercises both this fix and #1899.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added broad vector-type support for CPU codegen: 2/4/8/16-element vector variants for float, double, half, and signed/unsigned integer types to enable more efficient vectorized operations.

* **Tests**
  * Upgraded matrix-multiplication test to perform end-to-end verification, exercising copy usage and validating runtime results rather than previous error-path checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->