### PR TITLE
[BugFix] Add float4 definitions to cpp/common.h for CPU backend

### DIFF
--- a/src/tl_templates/cpp/common.h
+++ b/src/tl_templates/cpp/common.h
@@ -1,8 +1,43 @@
 #pragma once
 
 #include "half.hpp"
+
 #include <math.h>
 #include <stdbool.h>
 
 using half_float::half;
-// Not Implemented
+
+// ============================================================================
+// Vector types for CPU/C++ backend
+// ============================================================================
+
+#ifdef __cplusplus
+// C++ version with constructor
+struct float4 {
+  float x, y, z, w;
+
+  // Default constructor
+  float4() : x(0), y(0), z(0), w(0) {}
+
+  float4(float val) : x(val), y(val), z(val), w(val) {}
+
+  // Constructor for C++ (used in generated code)
+  float4(float x_val, float y_val, float z_val, float w_val)
+      : x(x_val), y(y_val), z(z_val), w(w_val) {}
+};
+#else
+// C version
+typedef struct {
+  float x, y, z, w;
+} float4;
+#endif
+
+// Constructor for float4 (C and C++)
+static inline float4 make_float4(float x, float y, float z, float w) {
+  float4 result;
+  result.x = x;
+  result.y = y;
+  result.z = z;
+  result.w = w;
+  return result;
+}


### PR DESCRIPTION
## Problem

When compiling CPU kernels that use `T.copy`, the generated code references `float4` type which is not defined, causing compilation errors:


## Root Cause

The CPU backend uses `tl_templates/cpp/common.h` which lacked float4 definitions. CUDA backend doesn't need this because float4 is built into CUDA SDK.

## Fix

- Add `float4` struct definition to `src/tl_templates/cpp/common.h`
- Add C++ constructors:
  - Default constructor
  - Single float constructor (for broadcast operations)
  - Four floats constructor
- Add `make_float4` helper function

## Testing

```bash
pytest testing/python/cpu/test_tilelang_cpu_gemm.py::test_matmul_with_copy_cython -v
# PASSED


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added vector type support in the backend for enhanced computational operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->