### PR TITLE
[BugFix] Fix ROCm/HIP kernel launch using CUDA-only API

### DIFF
--- a/tilelang/jit/adapter/wrapper.py
+++ b/tilelang/jit/adapter/wrapper.py
@@ -702,7 +702,7 @@ class TLHIPSourceWrapper(TLCUDASourceWrapper):
 
     def get_kernel_launch_code(self, function_name, grid_str, block_str, smem_str, call_args, cluster_dims):
         # HIP does not support cudaLaunchKernelEx; use <<<>>> syntax (same as pre-cluster-launch behavior)
-        return f"\t{function_name}<<<{grid_str}, {block_str}, {smem_str}, stream>>>({call_args});\n" 
+        return f"\t{function_name}<<<{grid_str}, {block_str}, {smem_str}, stream>>>({call_args});\n"
 
     def get_init_func(self):
         # Initialize an empty string for the CUDA function call


### PR DESCRIPTION
Commit 2e854b06 introduced cluster launch support by refactoring the kernel dispatch in `create_dispatch_func` to use `KERNEL_LAUNCH_FUNC_CODE`, which calls `cudaLaunchKernelEx` — a CUDA-only API not available in HIP/ROCm. `TLHIPSourceWrapper` inherits this method and thus generates invalid code for HIP targets, breaking the ROCm CI.

Fix by:
- Adding `KERNEL_LAUNCH_FUNC_CODE_HIP` using the `<<<>>>` syntax supported by hipcc
- Extracting kernel launch code selection into a `get_kernel_launch_code` method
- Overriding `get_kernel_launch_code` in `TLHIPSourceWrapper` to use the HIP template

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HIP kernels now use native HIP launch syntax for GPU execution.

* **Improvements**
  * Consolidated and centralized kernel launch logic across CUDA and HIP.
  * More consistent selection of cluster-based kernel launches, improving cross-backend behavior and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->