### PR TITLE
[Bugfix] Minor fix for warp specialized gemm swizzling

### DIFF
--- a/tilelang/layout/swizzle.py
+++ b/tilelang/layout/swizzle.py
@@ -109,19 +109,26 @@ def make_wgmma_swizzled_layout(buffer: BufferLikeType, continuity: int = None, k
 
 # for TCGEN05MMA Intrinsics
 def make_tcgen05mma_swizzled_layout(buffer: BufferLikeType, continuity: int = None, k_major: bool = True):
-    _, shape, _ = _get_buffer_info(buffer)
+    buf, shape, _ = _get_buffer_info(buffer)
     stride, continuous = _get_stride_continuous(buffer)
     element_size = _get_element_size(buffer)
     if continuity is None:
         continuity = continuous
-    base = _ffi_api.make_tcgen05mma_swizzled_layout(
-        stride,
-        continuous,
-        continuity,
-        element_size,
-        k_major,
-    )
-    return base.reshape(shape)
+    try:
+        base = _ffi_api.make_tcgen05mma_swizzled_layout(
+            stride,
+            continuous,
+            continuity,
+            element_size,
+            k_major,
+        )
+        return base.reshape(shape)
+    except TypeError as err:
+        # Keep Python sources compatible with older built libs that still expose
+        # the legacy FFI signature: (buffer, continuity, k_major).
+        if "Mismatched number of arguments" not in str(err):
+            raise
+        return _ffi_api.make_tcgen05mma_swizzled_layout(buf, continuity, k_major)
 
 
 # swizzle 128B

--- a/tilelang/tileop/gemm/gemm_tcgen05.py
+++ b/tilelang/tileop/gemm/gemm_tcgen05.py
@@ -1,6 +1,6 @@
 from .gemm_base import GemmBase
 from .inst import GemmInst
-from tilelang.layout import make_tcgen05mma_swizzled_layout
+from tilelang.layout import Layout, make_tcgen05mma_swizzled_layout
 from tilelang.intrinsics.tcgen05_macro_generator import (
     TensorCoreIntrinEmitter,
 )
@@ -11,6 +11,7 @@ from tvm import tir
 from tvm.target import Target
 from tvm.ir import Range
 from tvm.arith import Analyzer
+from typing import Callable
 
 
 _FLOAT8_DTYPES = {
@@ -30,6 +31,14 @@ class GemmTCGEN5(GemmBase):
     Layout inference and lowering are dispatched based on the memory scopes
     of operands A and B.
     """
+
+    def infer_shared_layout(self, continuity: int, k_major: bool) -> Callable[[tir.Buffer], Layout]:
+        """Build a shared-memory layout constructor for TCGEN05 operands."""
+
+        def _infer(buffer: tir.Buffer) -> Layout:
+            return make_tcgen05mma_swizzled_layout(buffer, continuity=continuity, k_major=k_major)
+
+        return _infer
 
     def infer_layout(self, target: Target, thread_nums: int):
         """Infer swizzled layouts for operands and accumulator.
@@ -60,15 +69,15 @@ class GemmTCGEN5(GemmBase):
             b_continuity = self.K if b_is_k_major else self.N // n_warp
 
             return {
-                self.A: make_tcgen05mma_swizzled_layout(self.A, continuity=a_continuity, k_major=a_is_k_major),
-                self.B: make_tcgen05mma_swizzled_layout(self.B, continuity=b_continuity, k_major=b_is_k_major),
+                self.A: self.infer_shared_layout(a_continuity, a_is_k_major)(self.A),
+                self.B: self.infer_shared_layout(b_continuity, b_is_k_major)(self.B),
                 self.C: mma_emitter.make_mma_store_layout(self.C),
             }
         if self.is_gemm_ts():
             b_continuity = self.K if b_is_k_major else self.N // n_warp
             layouts = {
                 self.A: mma_emitter.make_mma_store_layout(self.A),
-                self.B: make_tcgen05mma_swizzled_layout(self.B, continuity=b_continuity, k_major=b_is_k_major),
+                self.B: self.infer_shared_layout(b_continuity, b_is_k_major)(self.B),
                 self.C: mma_emitter.make_mma_store_layout(self.C),
             }
             return layouts


### PR DESCRIPTION
Thanks for @Hamerlate to provide the machine to reproduce and test, in this pr, we:
- Updated make_tcgen05mma_swizzled_layout to include error handling for argument mismatches, ensuring compatibility with older FFI signatures.
- Introduced infer_shared_layout method in GemmTCGEN5 to streamline layout inference for TCGEN05 operands, improving code clarity and maintainability.
- Refactored layout calls in infer_layout to utilize the new infer_shared_layout method, enhancing consistency across layout handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with different library versions by adding fallback handling for layout operations.

* **Refactor**
  * Restructured layout inference logic for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->