### PR TITLE
testing: prefer hipBLAS on ROCm in pytest setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,6 @@ jobs:
           fi
           export UV_INDEX="${PIP_EXTRA_INDEX_URL}"
           export CLANG_TIDY_CMAKE_OPTIONS="${CLANG_TIDY_CMAKE_OPTIONS} -DUSE_ROCM=ON"
-          export TORCH_BLAS_PREFER_HIPBLASLT=0
 
           echo "USE_ROCM=ON" | tee -a "${GITHUB_ENV}"
           echo "ROCM_VERSION=${ROCM_VERSION}" | tee -a "${GITHUB_ENV}"
@@ -205,7 +204,6 @@ jobs:
           echo "PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}" | tee -a "${GITHUB_ENV}"
           echo "UV_INDEX=${UV_INDEX}" | tee -a "${GITHUB_ENV}"
           echo "CLANG_TIDY_CMAKE_OPTIONS=${CLANG_TIDY_CMAKE_OPTIONS}" | tee -a "${GITHUB_ENV}"
-          echo "TORCH_BLAS_PREFER_HIPBLASLT=${TORCH_BLAS_PREFER_HIPBLASLT}" | tee -a "${GITHUB_ENV}"
 
           if [[ ! -x "$(command -v hipcc)" ]]; then
             export PATH="/opt/rocm/bin:${PATH}"

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -12,6 +12,9 @@ except ImportError:
     pass
 else:
     torch.manual_seed(0)
+    # Workaround: hipBLASLt on ROCm 7.1 nightly has a bug with certain matmul shapes
+    if hasattr(torch.version, "hip") and torch.version.hip:
+        torch.backends.cuda.preferred_blas_library("hipblas")
 
 try:
     import numpy as np


### PR DESCRIPTION
## Summary
Prefer hipBLAS in the pytest setup when running on ROCm to work around a hipBLASLt issue seen on ROCm 7.1 nightly for certain matmul shapes.

## Testing
python -m py_compile testing/conftest.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test environment configuration for systems with CUDA hip support to ensure proper library initialization and test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->