### PR TITLE
Fix predicated cp.async pipeline scheduling

### DIFF
--- a/src/transform/pipeline_planning.cc
+++ b/src/transform/pipeline_planning.cc
@@ -357,6 +357,14 @@ private:
         }
       }
       if (args.size() == 4) {
+        // Predicated cp.async should not be treated as a proven full
+        // overwrite of the destination buffer at pipeline-planning
+        // granularity. Model a conservative dependence on the destination so
+        // required initialization or other producer-side writes are not moved
+        // across the async copy.
+        if (auto dst_buf = TryGetBufFromAccessPtr(args[0])) {
+          reads_.push_back(BufferRegion::FullRegion(dst_buf.value()));
+        }
         // Preserve dependence from a predicated guard expression.
         this->VisitExpr(args[3]);
       }
@@ -755,6 +763,9 @@ private:
       async_written_buffers.insert(group.written_buffers.begin(),
                                    group.written_buffers.end());
       for (int stmt_idx = 0; stmt_idx < pipeline_stmt_count; ++stmt_idx) {
+        if (pipeline_stage_infos[stmt_idx].is_first_stage()) {
+          continue;
+        }
         if (stmt_reads_buffer_set(stmt_idx, group.written_buffers)) {
           cp_async_group_first_consumer[group_id] = stmt_idx;
           break;
@@ -790,6 +801,9 @@ private:
       int consumer_stmt_idx = -1;
       for (int stmt_idx = search_start; stmt_idx < pipeline_stmt_count;
            ++stmt_idx) {
+        if (pipeline_stage_infos[stmt_idx].is_first_stage()) {
+          continue;
+        }
         if (stmt_reads_buffer_set(stmt_idx, async_written_buffers)) {
           consumer_stmt_idx = stmt_idx;
           break;
@@ -1188,6 +1202,9 @@ private:
         for (int stmt_idx = wait_dep.wait_stmt_index + 1;
              stmt_idx < static_cast<int>(pipeline_stage_infos.size());
              ++stmt_idx) {
+          if (pipeline_stage_infos[stmt_idx].is_first_stage()) {
+            continue;
+          }
           bool dependent_read = false;
           for (const BufferRegion &read :
                pipeline_stage_infos[stmt_idx].reads) {

--- a/testing/python/transform/test_tilelang_transform_pipeline_planning.py
+++ b/testing/python/transform/test_tilelang_transform_pipeline_planning.py
@@ -3,6 +3,7 @@ import tilelang as tl
 from tilelang.utils.target import determine_target
 import tilelang.language as T
 import tilelang.testing
+import torch
 from tvm.tir.stmt_functor import post_order_visit
 
 auto_target = tvm.target.Target(determine_target("auto"))
@@ -244,6 +245,45 @@ def test_pipeline_planning_prioritizes_groups_by_consumer_and_rebinds_wait0():
     assert orders[2] < orders[6] < orders[5] < orders[7], (
         f"Expected wait for B before consumeB, then second wait before consumeA, got stages={stages}, orders={orders}"
     )
+
+
+@tilelang.testing.requires_cuda
+def test_pipeline_predicated_copy_preserves_shared_fill_correctness():
+    @T.prim_func
+    def main(
+        A: T.Tensor((8,), T.float16),
+        B: T.Tensor((16,), T.float16),
+    ):
+        with T.Kernel(1, threads=32):
+            S = T.alloc_shared((16,), T.float16)
+            for _ in T.Pipelined(1, num_stages=2):
+                T.fill(S, 0)
+                T.ptx_cp_async(
+                    T.access_ptr(S[0], "w", 16),
+                    T.access_ptr(A[0], "r", 16),
+                    16,
+                    True,
+                )
+                T.ptx_cp_async(
+                    T.access_ptr(S[8], "w", 16),
+                    T.access_ptr(A[0], "r", 16),
+                    16,
+                    False,
+                )
+                T.ptx_commit_group()
+                T.ptx_wait_group(0)
+                T.copy(S, B[0:16])
+
+    kernel = tl.compile(main, out_idx=[1], target="cuda")
+    src = kernel.get_kernel_source()
+    assert "cp_async_gs_conditional<16>" in src, "Expected predicated cp.async in generated CUDA source"
+
+    a = torch.randn((8,), dtype=torch.float16, device="cuda")
+    b = kernel(a)
+
+    expected = torch.zeros((16,), dtype=torch.float16, device="cuda")
+    expected[:8] = a
+    torch.testing.assert_close(b, expected, rtol=0, atol=0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- treat predicated `cp.async` conservatively during pipeline planning instead of assuming it fully overwrites the destination shared buffer
- skip producer-side first-stage statements when binding `cp.async` consumers and wait stages so fill/copy/commit are not misclassified as downstream consumers
- add a CUDA regression test that exercises `fill + predicated cp.async + wait` inside a pipelined loop

## Testing
- `python -m pytest testing/python/transform/test_tilelang_transform_pipeline_planning.py`
- `python debug/0316_pipeline/bug.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced pipeline scheduling correctness for GPU async copy operations, improving dependency tracking and stage ordering to ensure proper execution of dependent operations across pipeline stages.

* **Tests**
  * Added CUDA-specific test validating predicated async copy behavior and runtime output correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->