### PR TITLE
[Bugfix] Handle int64 offsets in ThreadSync for tvm_access_ptr

### DIFF
--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -26,6 +26,7 @@
 #include "arith/ir_mutator_with_analyzer.h"
 #include "runtime/thread_storage_scope.h"
 #include "tir/transforms/ir_utils.h"
+#include <algorithm>
 #include <string>
 #include <tvm/arith/analyzer.h>
 #include <tvm/arith/int_set.h>
@@ -1199,14 +1200,22 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
               buffer_data_to_buffer_.at(tvm::ffi::GetRef<Var>(buffer_var));
           auto buffer_shape = buffer->shape;
           // convert 1d offset to multi-dimensional index
-          auto linear_to_indices = [this](PrimExpr offset,
-                                          const Array<PrimExpr> &shape) {
+          auto linear_to_indices = [](PrimExpr offset,
+                                      const Array<PrimExpr> &shape) {
             Array<PrimExpr> indices;
+            DataType index_dtype = offset.dtype();
+            ICHECK(index_dtype.is_int() || index_dtype.is_uint())
+                << "Expected integer offset dtype in tvm_access_ptr, but got "
+                << index_dtype;
             PrimExpr remaining = std::move(offset);
             for (size_t i = 0; i < shape.size(); ++i) {
-              PrimExpr stride = make_const(DataType::Int(32), 1);
+              PrimExpr stride = make_const(index_dtype, 1);
               for (size_t j = i + 1; j < shape.size(); ++j) {
-                stride = stride * shape[j];
+                PrimExpr dim = shape[j];
+                if (dim.dtype() != index_dtype) {
+                  dim = tir::Cast(index_dtype, dim);
+                }
+                stride = stride * dim;
               }
               PrimExpr idx = FloorDiv(remaining, stride);
               remaining = FloorMod(remaining, stride);
@@ -1846,13 +1855,16 @@ private:
 
       // Handle Ramp expressions by creating a new index variable
       if (const RampNode *prev_ramp = prev_indice_bytes.as<RampNode>()) {
-        Var prev_idx("prev_idx", DataType::Int(32));
+        DataType prev_index_dtype = prev_ramp->base.dtype();
+        Var prev_idx("prev_idx", prev_index_dtype);
         analyzer.Bind(prev_idx, Range::FromMinExtent(0, prev_ramp->lanes));
+
         prev_indice_bytes = prev_ramp->base + prev_idx * prev_ramp->stride;
       }
 
       if (const RampNode *curr_ramp = curr_indice_bytes.as<RampNode>()) {
-        Var curr_idx("curr_idx", DataType::Int(32));
+        DataType curr_index_dtype = curr_ramp->base.dtype();
+        Var curr_idx("curr_idx", curr_index_dtype);
         analyzer.Bind(curr_idx, Range::FromMinExtent(0, curr_ramp->lanes));
         curr_indice_bytes = curr_ramp->base + curr_idx * curr_ramp->stride;
       }

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -57,6 +57,44 @@ def test_no_sync_between_atomic_adds_to_shared():
 
 
 @tilelang.testing.requires_cuda
+def test_thread_sync_handles_int64_tvm_access_ptr_offset():
+    """Regression: shared/shared.dyn pointer offsets may be int64.
+
+    ThreadSync used to reconstruct multidimensional indices with hardcoded
+    int32 temporaries, which crashed on expressions like FloorDiv(int64, int32)
+    while analyzing tvm_access_ptr from lowered atomic ops.
+    """
+
+    @T.prim_func(private=True)
+    def func():
+        A_shared = T.alloc_buffer((128,), dtype="float32", scope="shared.dyn")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        T.evaluate(
+            T.call_intrin(
+                "float32",
+                tvm.tir.op.Op.get("tl.atomic_add_elem_op"),
+                T.tvm_access_ptr(
+                    T.type_annotation("float32"),
+                    A_shared.data,
+                    T.Cast("int64", tx),
+                    1,
+                    3,
+                ),
+                T.float32(1),
+                T.int32(0),
+            )
+        )
+
+    mod = tvm.IRModule({"main": func})
+    mod = tilelang.transform.ThreadSync("shared.dyn")(mod)
+    s = str(mod)
+    assert 'T.tvm_storage_sync("shared.dyn")' not in s, f"Unexpected sync inserted for single atomic op:\n{s}"
+
+
+@tilelang.testing.requires_cuda
 def test_sync_if_with_same_index():
     @T.prim_func(check_well_formed=False)
     def func(p0_arg: T.Buffer((1, 2, 1, 1), "float32"), p1: T.Buffer(2, "float32")) -> None:


### PR DESCRIPTION
Updated the ThreadSync implementation to support int64 offsets in tvm_access_ptr, preventing crashes during index reconstruction. Added a regression test to ensure correct behavior with shared/shared.dyn pointers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced integer offset data type handling in thread synchronization operations.
  * Improved dtype consistency for multi-dimensional index calculations.
  * Added support for 64-bit integer offsets in memory access pointers.

* **Tests**
  * Added regression test for 64-bit integer offset handling in thread synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->