### PR TITLE
[Bugfix] Fix thread race in getPlaceholder during par_compile

### DIFF
--- a/src/layout/layout.cc
+++ b/src/layout/layout.cc
@@ -275,12 +275,25 @@ Fragment TryPackedSubtypeReshape(const FragmentNode *fragment_node,
 
 } // namespace
 
+static constexpr size_t kMaxPlaceholders = 16;
+
 static Var getPlaceholder(const std::string &s) {
-  static std::unordered_map<std::string, Var> map;
-  if (map.find(s) == map.end()) {
-    map[s] = Var(s);
-  }
-  return map[s];
+  // Pre-allocate all possible placeholders so the map is immutable after init.
+  // C++11 guarantees thread-safe initialization of function-local statics,
+  // so concurrent reads are safe without a mutex.
+  static const std::unordered_map<std::string, Var> map = []() {
+    std::unordered_map<std::string, Var> m;
+    m.reserve(kMaxPlaceholders + 1);
+    m["_rep"] = Var("_rep");
+    for (size_t i = 0; i < kMaxPlaceholders; ++i) {
+      std::string key{'_', char('i' + i)};
+      m[key] = Var(key);
+    }
+    return m;
+  }();
+  auto it = map.find(s);
+  ICHECK(it != map.end()) << "Unknown placeholder: " << s;
+  return it->second;
 }
 
 Var ReplicationPlaceholder() { return getPlaceholder("_rep"); }


### PR DESCRIPTION
## Summary

- Fix data race in `getPlaceholder()` (`src/layout/layout.cc`) that caused random segfaults during `par_compile`
- Pre-allocate all placeholder variables (`_rep`, `_i` through `_x`) at static init time so the map is immutable after initialization
- C++11 guarantees thread-safe initialization of function-local statics, so concurrent reads are safe without a mutex

Closes #1935

## Test plan

- [x] `pytest testing/python/language/test_tilelang_language_eager_jit.py::test_jit2_gemm_ptr -v -s` passes
- [x] Verified with standalone reproduce script (`work/issue/#1935.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal placeholder handling with stricter validation and enhanced thread-safety guarantees. The system now rejects invalid placeholder references earlier, promoting more robust behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->