### PR TITLE
[Bugfix] Fix vectorize planner ignoring cast source type bit width

### DIFF
--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -653,8 +653,7 @@ private:
       int source_lanes = vector_load_bits_max_ / source_bits;
       max_lanes = std::min(target_lanes, source_lanes);
     }
-    int cast_vector_size =
-        arith::ZeroAwareGCD(max_lanes, initial_vector_size_);
+    int cast_vector_size = arith::ZeroAwareGCD(max_lanes, initial_vector_size_);
     // Record cast constraint (use empty buffer to indicate cast)
     buffer_vector_infos_.push_back({Buffer(), cast_vector_size, false, {}});
     return arith::IRMutatorWithAnalyzer::VisitExpr_(node);


### PR DESCRIPTION
## Summary

- Fix `VectorizePlanner::VisitExpr_(CastNode*)` to consider **both** source and target type bit widths when computing vectorization lane constraints
- Previously only the target type was considered, causing over-vectorization when casting from wider to narrower types (e.g., `int32` → `float8_e4m3fn`)
- This produced `int32x16` vector types that CUDA codegen cannot represent (int32 supports at most 8 lanes via `longlong4`), resulting in `Cannot convert type int32x16 to CUDA type`

## Reproducer

```python
@tilelang.jit
def get_kernel():
    n, m = 2048, 2048
    block_n = 4

    @T.prim_func
    def test_kernel(
        a: T.Tensor[(n, m), T.float8_e4m3fn],
    ):
        with T.Kernel(T.ceildiv(n, block_n), threads=256) as (block_idx,):
            for i, j in T.Parallel(block_n, m):
                a[block_idx + i, j] = j

    return test_kernel
```

## Root Cause

In `VectorizePlanner::VisitExpr_(CastNode*)`, the cast vectorization constraint was:

```cpp
int cast_vector_size = arith::ZeroAwareGCD(
    vector_load_bits_max_ / node->dtype.bits(),  // only target type
    initial_vector_size_);
```

For `Cast(float8_e4m3fn, int32_var)`: `128 / 8 = 16` lanes — but `int32` can only support `128 / 32 = 4` lanes (max 8 via `longlong4`).

## Fix

Take `min(target_lanes, source_lanes)` so both sides of the cast produce representable CUDA vector types.

## Test plan

- [x] Original reproducer now compiles and generates correct CUDA kernel
- [x] `testing/python/transform/` — 205 passed
- [x] `testing/python/kernel/` (excl. tcgen5) — 32 passed
- [x] `testing/python/language/` — 463 passed
- [x] `testing/python/issue/` — 45 passed


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved vector-size computation for type casts by considering both source and target data types. This yields more accurate, safer vectorization decisions, may reduce vector sizes for some casts, and helps avoid incorrect or overly-large vectorization that could affect performance consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->