### PR TITLE
[Bugfix] Tolerate size-1 dim strides in RelaxedStrideCheck for DLPack compatibility

### DIFF
--- a/src/transform/arg_binder.cc
+++ b/src/transform/arg_binder.cc
@@ -326,8 +326,8 @@ void ArgBinder::RelaxedStrideCheck(const int dim_idx, const PrimExpr &stride,
       }
       // Tolerate any stride value when dim size is 1 (torch 2.1 DLPack bug:
       // forces stride=1 for size-1 dims regardless of logical stride).
-      PrimExpr cond =
-          (expected == logical_stride_val) || (expected == 0) || (dim_shape == 1);
+      PrimExpr cond = (expected == logical_stride_val) || (expected == 0) ||
+                      (dim_shape == 1);
       BinderAddAssert(&analyzer_, cond, stride_element_name, &asserts_,
                       is_null);
     } else {

--- a/src/transform/arg_binder.h
+++ b/src/transform/arg_binder.h
@@ -166,8 +166,7 @@ public:
 
   void RelaxedStrideCheck(const int dim_idx, const PrimExpr &stride,
                           const PrimExpr &logical_stride_val,
-                          const PrimExpr &dim_shape,
-                          const PrimExpr &is_null,
+                          const PrimExpr &dim_shape, const PrimExpr &is_null,
                           const std::string &stride_element_name);
 
 private:


### PR DESCRIPTION
Torch 2.1's DLPack implementation forces stride=1 for any dimension with size 1, regardless of the logical stride. For example, a tensor of shape (1, 1024) gets strides (1, 1) instead of the correct (1024, 1).

The compact buffer path in BindDLTensors already handled this via `buffer->shape[k] == 1`. This commit extends the same tolerance to RelaxedStrideCheck (used for explicit-stride buffers) by adding a `dim_shape` parameter and relaxing the condition to also pass when `dim_shape == 1`.

Since a size-1 dimension is never indexed, its stride value is semantically irrelevant — this fix requires no contiguous assumption.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined tensor stride validation to treat dimensions of size one as flexible, preventing false stride mismatches for singleton dimensions.
  * Applied the improved stride validation across all tensor binding scenarios, including small-bit subtypes and both auto-broadcast and non-auto-broadcast paths, improving layout recognition and robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->