### PR TITLE
Refactor producer-consumer WS access tracking for WGMMA-local state

### DIFF
--- a/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
+++ b/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
@@ -1,9 +1,5 @@
 # ruff: noqa
-import importlib.util
-from pathlib import Path
-
 from tilelang import tvm as tvm
-import tilelang
 import tilelang as tl
 import tilelang.language as T
 import tilelang.testing
@@ -34,13 +30,6 @@ def _collect_ifs(stmt):
 
     tvm.tir.stmt_functor.post_order_visit(stmt, visitor)
     return ifs
-
-
-def _find_if(stmt, predicate):
-    for if_stmt in _collect_ifs(stmt):
-        if predicate(if_stmt):
-            return if_stmt
-    return None
 
 
 def _stmt_contains_call(stmt, op_name: str) -> bool:
@@ -77,16 +66,6 @@ def _collect_buffer_loads(stmt, scope: str):
 
     tvm.tir.stmt_functor.post_order_visit(stmt, visitor)
     return loads
-
-
-def _load_debug_module(rel_path: str):
-    repo_root = Path(__file__).resolve().parents[3]
-    module_path = repo_root / rel_path
-    spec = importlib.util.spec_from_file_location(module_path.stem, module_path)
-    module = importlib.util.module_from_spec(spec)
-    assert spec.loader is not None
-    spec.loader.exec_module(module)
-    return module
 
 
 def test_producer_consumer_ws_pure_tma_does_not_reserve_unused_preloop_barrier():


### PR DESCRIPTION
## Summary
- split producer-consumer WS access summaries into all-buffer accesses vs branch-private accesses
- teach the access collector to recognize raw `buffer.data` operands used by `warpgroup_fence_operand`, `ptx_wgmma_ss`, and `ptx_wgmma_rs`
- make loop-prefix hoisting use branch-private liveness so consumer-private intermediates are not moved into the producer branch
- add a regression test that lowers the real `flashattn_bwd` kernel and checks that WGMMA stays in the consumer branch

## Motivation
The previous logic only tracked explicit buffer loads/stores and a narrow subset of pointer-style accesses. That was too weak for lowered Hopper WGMMA code, where local accumulator buffers are often passed through opaque calls as raw `buffer.data` vars.

As a result, consumer-private compute such as `qkT` and `dsT` could be misclassified as producer-safe prefix work and hoisted across the producer/consumer split, changing kernel semantics.

## Testing
- `python -m py_compile testing/python/transform/test_tilelang_transform_producer_consumer_ws.py`
- `python -m pytest testing/python/transform/test_tilelang_transform_producer_consumer_ws.py -k real_flash_bwd_wgmma -q`
- `PYTHONPATH=/weka-hg/prod/deepseek/permanent/wanglei/tilelang_ref python /weka-hg/prod/deepseek/permanent/wanglei/tilelang_ref/debug/0323_flex/test.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal buffer tracking and dependency-aware producer-consumer loop hoisting to improve correctness and performance for complex kernel transformations.
* **Tests**
  * Added test helpers for runtime introspection and dynamic module loading to enable more robust validation of producer-consumer optimization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->