### PR TITLE
[BugFix] Use content hash instead of mtime for libtilelang cache key

### DIFF
--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -57,13 +57,17 @@ class KernelCache:
     @staticmethod
     @functools.cache
     def _get_tilelang_lib_stamp() -> str | None:
-        """Return a cheap build-stamp for the TileLang runtime library.
+        """Return a content-based build-stamp for the TileLang runtime library.
 
         The kernel cache key historically only depended on `tilelang.__version__`
         and the TIR script. During development, C++ pass changes can change the
         generated kernel *without* changing the input TIR, leading to stale cache
-        hits. Including a library stamp (mtime+size) avoids this class of bugs
-        while keeping the cost low (computed once per process).
+        hits. Including a library stamp avoids this class of bugs.
+
+        We use a SHA-256 content hash of the library file instead of mtime so that
+        the cache key is stable across machines and fresh installs — two identical
+        builds of libtilelang.so will produce the same stamp regardless of when or
+        where they were installed.
         """
         import importlib
 
@@ -85,8 +89,11 @@ class KernelCache:
             for name in lib_names:
                 path = os.path.join(lib_dir, name)
                 if os.path.exists(path):
-                    st = os.stat(path)
-                    return f"{name}:{st.st_size}:{st.st_mtime_ns}"
+                    file_hash = sha256()
+                    with open(path, "rb") as f:
+                        for chunk in iter(lambda: f.read(1 << 20), b""):
+                            file_hash.update(chunk)
+                    return f"{name}:{file_hash.hexdigest()}"
         return None
 
     @staticmethod


### PR DESCRIPTION
## Problem

The kernel cache key includes a "library stamp" for `libtilelang.so` to detect C++ pass changes during development. Currently this stamp uses **mtime + file size** (`st.st_mtime_ns`), which causes cache misses when:

- The same tilelang version is installed on different machines at different times
- A container installs tilelang at startup (`pip install`) rather than baking it into the image
- Pre-compiled kernel caches are shared across machines

Even though the binary is byte-for-byte identical, the mtime differs, so the cache key changes and all cached kernels become invalid.

## Fix

Replace the mtime+size stamp with a **SHA-256 content hash** of the library file. Two identical builds of `libtilelang.so` now produce the same cache key regardless of installation time or machine.

- Uses chunked reads (1 MB) to keep memory usage low for large libraries
- Still computed once per process via `functools.cache`, so the overhead is negligible
- The stamp format changes from `libtilelang.so:<size>:<mtime_ns>` to `libtilelang.so:<sha256hex>`

## Impact

- **Fixes** cross-machine kernel cache sharing for containerized deployments
- **Preserves** the original intent: development builds with different C++ passes still invalidate the cache (different binary → different hash)
- **Note**: Existing caches will be invalidated once after upgrading (stamp format change), then stable going forward

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated runtime library cache verification mechanism for improved consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->