### PR TITLE
pin apache-tvm-ffi<0.1.10 (derived_object regression)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # >=0.1.6 fixes a memory issue: tilelang#1502, but keep
     # requirement as wide as possible to be compatible with other libraries
     # pip will try to use latest version whenever possible.
-    "apache-tvm-ffi~=0.1.0,>=0.1.2",
+    "apache-tvm-ffi~=0.1.0,>=0.1.2,<0.1.10",
     # torch-c-dlpack-ext provides prebuilt torch extensions.
     # Without it, TVM FFI may require JIT compilation on first import.
     "torch-c-dlpack-ext; python_version < '3.14'",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Requirements to run local build with `--no-build-isolation` or other developments
 
-apache-tvm-ffi~=0.1.0,>=0.1.2
+apache-tvm-ffi~=0.1.0,>=0.1.2,<0.1.10
 build
 cmake>=3.26
 cython>=3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Runtime requirements
 
-apache-tvm-ffi~=0.1.0,>=0.1.2
+apache-tvm-ffi~=0.1.0,>=0.1.2,<0.1.10
 torch-c-dlpack-ext; python_version < '3.14'
 cloudpickle
 ml-dtypes


### PR DESCRIPTION
Fix: https://github.com/tile-ai/tilelang/actions/runs/24116705653/job/70362222104

This could be reverted after we cherry-picked https://github.com/apache/tvm/commit/44dbd138d51314309955fba8c3d1294e4a89da35 cc @junrushao

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency constraints across configuration files to restrict available versions and ensure compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->