### PR TITLE
Fix serial loop phase dtype mismatch in LowerTileOp

### DIFF
--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -1130,11 +1130,13 @@ private:
         }
       }
       PrimExpr phase_expr;
+      DataType loop_dtype = op->loop_var.dtype();
+      PrimExpr two = make_const(loop_dtype, 2);
       if (num_stages > 1) {
-        phase_expr = FloorMod(FloorDiv(op->loop_var, num_stages),
-                              IntImm(DataType::Int(32), 2));
+        PrimExpr num_stages_expr = make_const(loop_dtype, num_stages);
+        phase_expr = FloorMod(FloorDiv(op->loop_var, num_stages_expr), two);
       } else {
-        phase_expr = FloorMod(op->loop_var, IntImm(DataType::Int(32), 2));
+        phase_expr = FloorMod(op->loop_var, two);
       }
       loop_mbar_phase_stack_.push_back(analyzer_->Simplify(phase_expr));
       pushed_loop_mbar_phase = true;


### PR DESCRIPTION
This fixes a dtype mismatch in `LowerTileOp` when a serial loop variable is `int64`.

`debug/normal.py` currently allocates several index vars as `int64`, which leads to an `int64` serial loop in the lowered TIR. The pass was still building the phase expression with `int32` literals, so `FloorDiv`/`FloorMod` could fail during lowering with a mixed `int64` vs `int32` error.

The change makes the phase constants follow `op->loop_var.dtype()`, so the pass handles both `int32` and `int64` serial loops consistently.

Testing:
- `cd build && make -j32`
- `python /weka-hg/prod/deepseek/permanent/wanglei/tilelang/debug/normal.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type consistency in tile operation phase expressions to properly use loop variable data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->