### PR TITLE
Re-enable deprecated `TL_DISABLE_TMA_LOWER` pass config for TMA store

### DIFF
--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -79,8 +79,8 @@ static constexpr const char *kDisableSafeMemoryLegalize =
 static constexpr const char *kDisableWarpSpecialized =
     "tl.disable_warp_specialized";
 static constexpr const char *kConfigIndexBitwidth = "tl.config_index_bitwidth";
-// Deprecated compatibility-only pass config. It is no longer consumed by the
-// lowering pipeline, but remains registered so legacy kernels keep working.
+// Deprecated pass config, temporarily re-enabled. Prevents plain T.copy()
+// from auto-lowering to TMA store. Will be removed in v0.1.10.
 static constexpr const char *kDisableTMALower = "tl.disable_tma_lower";
 static constexpr const char *kEnableAggressiveSharedMemoryMerge =
     "tl.enable_aggressive_shared_memory_merge";

--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -948,10 +948,9 @@ CopyInst CopyNode::GetCopyInst(Target target, const LayoutMap &layout_map,
   // remains allowed because it is self-synchronized locally and does not
   // participate in pipeline producer scheduling.
   // Also honour the (deprecated) global pass config for backward compat.
-  if (!GetDisableTMA() &&
-      !tvm::transform::PassContext::Current()
-           ->GetConfig<Bool>(kDisableTMALower, Bool(false))
-           .value()) {
+  if (!GetDisableTMA() && !tvm::transform::PassContext::Current()
+                               ->GetConfig<Bool>(kDisableTMALower, Bool(false))
+                               .value()) {
     bool is_cutedsl = TargetIsCuTeDSL(target);
     if (!is_cutedsl && !buffer_oob &&
         CheckBulkStore1D(target, layout_map, analyzer)) {

--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -947,7 +947,11 @@ CopyInst CopyNode::GetCopyInst(Target target, const LayoutMap &layout_map,
   // Plain T.copy does not auto-upgrade to TMA loads anymore. Store-side TMA
   // remains allowed because it is self-synchronized locally and does not
   // participate in pipeline producer scheduling.
-  if (!GetDisableTMA()) {
+  // Also honour the (deprecated) global pass config for backward compat.
+  if (!GetDisableTMA() &&
+      !tvm::transform::PassContext::Current()
+           ->GetConfig<Bool>(kDisableTMALower, Bool(false))
+           .value()) {
     bool is_cutedsl = TargetIsCuTeDSL(target);
     if (!is_cutedsl && !buffer_oob &&
         CheckBulkStore1D(target, layout_map, analyzer)) {

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -272,8 +272,7 @@ class PassConfigKey(str, Enum):
 
 _DEPRECATED_PASS_CONFIG_MESSAGES = {
     PassConfigKey.TL_DISABLE_TMA_LOWER.value: (
-        "`tl.disable_tma_lower` is deprecated and will be removed in v0.1.10. "
-        "Use `T.copy(..., disable_tma=True)` per-copy instead."
+        "`tl.disable_tma_lower` is deprecated and will be removed in v0.1.10. Use `T.copy(..., disable_tma=True)` per-copy instead."
     ),
 }
 

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -86,11 +86,10 @@ class PassConfigKey(str, Enum):
     """Bitwidth for configuration indices. Default: 32"""
 
     TL_DISABLE_TMA_LOWER = "tl.disable_tma_lower"
-    """Deprecated compatibility-only flag for legacy kernels.
+    """Deprecated flag — prevents plain T.copy() from auto-lowering to TMA store.
 
-    This flag no longer has any effect in the current lowering pipeline and is
-    kept only so older kernels do not fail pass-config validation. It will be
-    removed in v0.1.10.
+    Temporarily re-enabled for backward compatibility. Will be removed in
+    v0.1.10.
     """
 
     TL_DISABLE_SAFE_MEMORY_ACCESS = "tl.disable_safe_memory_legalize"
@@ -273,9 +272,8 @@ class PassConfigKey(str, Enum):
 
 _DEPRECATED_PASS_CONFIG_MESSAGES = {
     PassConfigKey.TL_DISABLE_TMA_LOWER.value: (
-        "`tl.disable_tma_lower` is deprecated, kept only for backward "
-        "compatibility, has no effect in the current lowering pipeline, and "
-        "will be removed in v0.1.10."
+        "`tl.disable_tma_lower` is deprecated and will be removed in v0.1.10. "
+        "Use `T.copy(..., disable_tma=True)` per-copy instead."
     ),
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Temporarily re-enabled the global disable-TMA option so it again prevents auto-lowering of T.copy to TMA stores.

* **Documentation**
  * Clarified deprecation messaging and added an explicit removal target (v0.1.10); advises using per-copy disable_tma=True instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->