### PR TITLE
[Bugfix] Fix incorrect sync hoist for fragment buffer conditions in ThreadSync

### DIFF
--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -665,9 +665,13 @@ private:
 
   PrimExpr VisitExpr_(const BufferLoadNode *op) final {
     current_.depends_on_runtime = true;
-    if (IsThreadLocalScope(GetScope(op->buffer->data))) {
-      current_.is_block_uniform = false;
-    }
+    // Do not mark local-scope loads as non-block-uniform solely based on
+    // storage scope.  Thread-local buffers (fragments) commonly hold
+    // block-uniform data when populated from block-uniform global addresses
+    // (e.g., T.copy(BlockMask[blockIdx.y, :], fragment)).  If the load
+    // indices actually depend on threadIdx, the recursive visit of indices
+    // below (via IRMutatorWithAnalyzer::VisitExpr_) will correctly set
+    // is_block_uniform = false through VisitExpr_(VarNode*).
     return IRMutatorWithAnalyzer::VisitExpr_(op);
   }
 


### PR DESCRIPTION
## Summary

- Fix a bug in `ConditionThreadPropertyChecker` where conditions derived from fragment (local-scope) buffer loads were incorrectly classified as non-block-uniform based solely on storage scope
- This caused `ThreadSync` to hoist `__syncthreads()` out of an if-body, removing the write-before-read synchronization between shared memory writes and TMA store reads
- The fix removes the scope-based heuristic and relies on recursive index analysis to determine block-uniformity

## Problem

When a blocksparse copy kernel uses a fragment buffer for block mask indices (e.g., `a = block_mask_f[i]`), the condition `a >= 0` guarding the copy body is actually **block-uniform** — all threads in a block hold the same fragment data loaded from `BlockMask[blockIdx.y, :]`.

However, `ConditionThreadPropertyChecker::VisitExpr_(BufferLoadNode*)` marked **all** local-scope buffer loads as non-block-uniform. This triggered the sync hoist logic, which moved `__syncthreads()` from between the shared memory writes and TMA store to before the if-statement — breaking the synchronization guarantee.

**Before fix** (incorrect):
```cuda
__syncthreads();        // hoisted here (too early)
if (a >= 0) {
    write_to_shared();  // all threads
    tma_store();        // elected thread — no sync!
}
```

**After fix** (correct):
```cuda
__syncthreads();        // loop-carried sync
if (a >= 0) {
    write_to_shared();  // all threads
    __syncthreads();    // correctly placed intra-iteration sync
    tma_store();        // elected thread
}
```

## Root Cause

In `ConditionThreadPropertyChecker::VisitExpr_(BufferLoadNode*)`:
```cpp
if (IsThreadLocalScope(GetScope(op->buffer->data))) {
    current_.is_block_uniform = false;  // too conservative
}
```

This unconditionally marked fragment buffer loads as non-block-uniform. The fix removes this check and instead relies on the recursive visit of buffer load indices — if any index depends on `threadIdx`, `VisitExpr_(VarNode*)` will correctly set `is_block_uniform = false`.

## Test plan

- [x] `test_blocksparse_copy_tma` — previously failing, now passes
- [x] `test_blocksparse_copy_cp_async` — passes
- [x] All 20 existing `test_tilelang_transform_thread_sync` tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler analysis for GPU thread uniformity. The compiler now more accurately determines when operations can be safely executed uniformly across threads by analyzing actual memory access patterns rather than relying solely on storage scope, leading to better code generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->