### PR TITLE
[Bugfix][Subtype] Fix scalar fp4 store/load codegen for non-packed buffers

### DIFF
--- a/src/target/codegen_cuda.cc
+++ b/src/target/codegen_cuda.cc
@@ -3826,8 +3826,18 @@ void CodeGenTileLangCUDA::VisitExpr_(const BufferLoadNode *op,
   int lanes = op->dtype.lanes();
   // declare type.
   if (value_dtype.lanes() == element_dtype.lanes()) {
-    std::string ref = GetBufferRef(op->dtype, op->buffer.get(), index);
-    HandleVolatileLoads(ref, op, os);
+    // For scalar fp4 loads from non-packed buffers, use tl_fp4_packed_load
+    // to correctly extract the nibble at the given index (the /2 in GetBufferRef
+    // maps two consecutive fp4 elements to the same byte, but reading that byte
+    // only returns the low nibble — the odd-indexed element is lost).
+    if (element_dtype.is_float4() && element_dtype.lanes() == 1) {
+      std::string idx_str = PrintExpr(index);
+      std::string vid = GetVarID(buffer_var.get());
+      os << "tl_fp4_packed_load((fp4_e2_2_t*)" << vid << ", " << idx_str << ")";
+    } else {
+      std::string ref = GetBufferRef(op->dtype, op->buffer.get(), index);
+      HandleVolatileLoads(ref, op, os);
+    }
   } else {
     bool can_vector_load = false;
     arith::PVar<PrimExpr> base;
@@ -3899,11 +3909,24 @@ void CodeGenTileLangCUDA::VisitStmt_(const BufferStoreNode *op) {
   }
 
   if (value_dtype.lanes() == element_dtype.lanes()) {
-    std::string value = this->PrintExpr(op->value);
-    std::string ref =
-        this->GetBufferRef(value_dtype, op->buffer.get(), index_expr);
-    this->PrintIndent();
-    stream << ref << " = " << value << ";\n";
+    // For scalar fp4 stores to non-packed buffers, use tl_fp4_packed_store
+    // to correctly handle nibble-level writes. The /2 in GetBufferRef maps two
+    // consecutive fp4 elements to the same byte, and a plain assignment overwrites
+    // the entire byte — destroying the neighboring nibble.
+    if (element_dtype.is_float4() && element_dtype.lanes() == 1) {
+      std::string idx_str = PrintExpr(index_expr);
+      std::string value = this->PrintExpr(op->value);
+      std::string vid = GetVarID(buffer_var.get());
+      this->PrintIndent();
+      stream << "tl_fp4_packed_store((fp4_e2_2_t*)" << vid << ", " << idx_str
+             << ", " << value << ");\n";
+    } else {
+      std::string value = this->PrintExpr(op->value);
+      std::string ref =
+          this->GetBufferRef(value_dtype, op->buffer.get(), index_expr);
+      this->PrintIndent();
+      stream << ref << " = " << value << ";\n";
+    }
   } else {
     arith::PVar<PrimExpr> base;
     int ramp_lanes = value_dtype.lanes() / element_dtype.lanes();

--- a/src/target/codegen_cuda.cc
+++ b/src/target/codegen_cuda.cc
@@ -3827,9 +3827,10 @@ void CodeGenTileLangCUDA::VisitExpr_(const BufferLoadNode *op,
   // declare type.
   if (value_dtype.lanes() == element_dtype.lanes()) {
     // For scalar fp4 loads from non-packed buffers, use tl_fp4_packed_load
-    // to correctly extract the nibble at the given index (the /2 in GetBufferRef
-    // maps two consecutive fp4 elements to the same byte, but reading that byte
-    // only returns the low nibble — the odd-indexed element is lost).
+    // to correctly extract the nibble at the given index (the /2 in
+    // GetBufferRef maps two consecutive fp4 elements to the same byte, but
+    // reading that byte only returns the low nibble — the odd-indexed element
+    // is lost).
     if (element_dtype.is_float4() && element_dtype.lanes() == 1) {
       std::string idx_str = PrintExpr(index);
       std::string vid = GetVarID(buffer_var.get());
@@ -3911,8 +3912,8 @@ void CodeGenTileLangCUDA::VisitStmt_(const BufferStoreNode *op) {
   if (value_dtype.lanes() == element_dtype.lanes()) {
     // For scalar fp4 stores to non-packed buffers, use tl_fp4_packed_store
     // to correctly handle nibble-level writes. The /2 in GetBufferRef maps two
-    // consecutive fp4 elements to the same byte, and a plain assignment overwrites
-    // the entire byte — destroying the neighboring nibble.
+    // consecutive fp4 elements to the same byte, and a plain assignment
+    // overwrites the entire byte — destroying the neighboring nibble.
     if (element_dtype.is_float4() && element_dtype.lanes() == 1) {
       std::string idx_str = PrintExpr(index_expr);
       std::string value = this->PrintExpr(op->value);

--- a/src/transform/inject_assumes.cc
+++ b/src/transform/inject_assumes.cc
@@ -71,6 +71,46 @@ private:
       }
     }
 
+    // --- Stride divisibility for sub-byte dtypes ---
+    struct StrideDivisibilityItem {
+      PrimExpr stride;
+      int pack_factor;
+      std::vector<Buffer> buffers;
+    };
+    std::vector<StrideDivisibilityItem> stride_div_items;
+    std::unordered_map<size_t, std::vector<size_t>> stride_div_buckets;
+
+    void addStrideExpr(PrimExpr stride, int pack_factor, Buffer buffer) {
+      size_t h = sh(stride);
+      auto &bucket = stride_div_buckets[h];
+      auto it = std::find_if(bucket.begin(), bucket.end(), [&](size_t y) {
+        return se(stride, stride_div_items[y].stride, true);
+      });
+      if (it == bucket.end()) {
+        auto index = stride_div_items.size();
+        stride_div_items.push_back({stride, pack_factor, {buffer}});
+        bucket.push_back(index);
+      } else {
+        auto &item = stride_div_items[*it];
+        item.buffers.push_back(buffer);
+        // Use the largest pack_factor (strongest constraint)
+        item.pack_factor = std::max(item.pack_factor, pack_factor);
+      }
+    }
+
+    void addBufferStrides(Buffer buf) {
+      int element_bits = buf->dtype.bits() * buf->dtype.lanes();
+      if (element_bits >= 8 || buf->strides.empty())
+        return;
+      int pack_factor = 8 / element_bits;
+      for (size_t k = 0; k + 1 < buf->strides.size(); ++k) {
+        auto stride = buf->strides[k];
+        if (stride->IsInstance<IntImmNode>())
+          continue;
+        addStrideExpr(stride, pack_factor, buf);
+      }
+    }
+
     Stmt build(Stmt body) {
       auto analyzer = arith::Analyzer{};
       for (const auto &e : items) {
@@ -87,6 +127,23 @@ private:
         body = AttrStmt(simplified, tir::attr::tilelang_assume,
                         StringImm(ss.str()), body);
       }
+      // Inject stride divisibility assumes for sub-byte dtypes.
+      // E.g. for fp4 (pack_factor=2), non-last-dim strides must be even.
+      for (const auto &e : stride_div_items) {
+        auto cond = EQ(
+            floormod(e.stride, make_const(e.stride.dtype(), e.pack_factor)),
+            make_zero(e.stride.dtype()));
+        std::stringstream ss;
+        ss << "Sub-byte buffer stride must be divisible by " << e.pack_factor
+           << ": stride `" << e.stride << "` from buffer ";
+        for (size_t i = 0; i < e.buffers.size(); i++) {
+          if (i)
+            ss << ", ";
+          ss << "`" << e.buffers[i]->name << "`";
+        }
+        body = AttrStmt(cond, tir::attr::tilelang_assume,
+                        StringImm(ss.str()), body);
+      }
       return body;
     }
   };
@@ -95,6 +152,7 @@ private:
     auto body = VisitStmt(op->body);
     AssumeCreator c;
     c.addBuffer(op->buffer);
+    c.addBufferStrides(op->buffer);
     return DeclBuffer(op->buffer, c.build(body), op->span);
   }
 
@@ -153,13 +211,16 @@ private:
     if (IsHostMainBlock(op)) {
       for (auto item : f->buffer_map) {
         c.addBuffer(item.second);
+        c.addBufferStrides(item.second);
       }
     }
     for (auto item : op->alloc_buffers) {
       c.addBuffer(item);
+      c.addBufferStrides(item);
     }
     for (auto item : op->match_buffers) {
       c.addBuffer(item->buffer);
+      c.addBufferStrides(item->buffer);
     }
 
     return Block(op->iter_vars, op->reads, op->writes, op->name_hint,

--- a/src/transform/inject_assumes.cc
+++ b/src/transform/inject_assumes.cc
@@ -130,9 +130,9 @@ private:
       // Inject stride divisibility assumes for sub-byte dtypes.
       // E.g. for fp4 (pack_factor=2), non-last-dim strides must be even.
       for (const auto &e : stride_div_items) {
-        auto cond = EQ(
-            floormod(e.stride, make_const(e.stride.dtype(), e.pack_factor)),
-            make_zero(e.stride.dtype()));
+        auto cond =
+            EQ(floormod(e.stride, make_const(e.stride.dtype(), e.pack_factor)),
+               make_zero(e.stride.dtype()));
         std::stringstream ss;
         ss << "Sub-byte buffer stride must be divisible by " << e.pack_factor
            << ": stride `" << e.stride << "` from buffer ";
@@ -141,8 +141,8 @@ private:
             ss << ", ";
           ss << "`" << e.buffers[i]->name << "`";
         }
-        body = AttrStmt(cond, tir::attr::tilelang_assume,
-                        StringImm(ss.str()), body);
+        body = AttrStmt(cond, tir::attr::tilelang_assume, StringImm(ss.str()),
+                        body);
       }
       return body;
     }

--- a/testing/python/language/test_tilelang_language_subtype.py
+++ b/testing/python/language/test_tilelang_language_subtype.py
@@ -300,6 +300,7 @@ def test_subtype_complex_expressions_various(m, n):
     y = torch.randint(0, 256, (m * 2, n // 2), dtype=torch.uint8, device="cuda")
     complex_expr_kernel(x, y)
 
+
 # ---------------------------------------------------------------------------
 # Scalar fp4 store to StridedTensor with dynamic strides.
 # Before the fix the codegen wrote full bytes instead of nibbles, so
@@ -313,13 +314,12 @@ def test_subtype_fp4_dynamic_stride_store(block_size):
     """fp4 store via StridedTensor: dynamic strides must match static strides."""
     num_blocks, n, padding = 10, 64, 4
     fp4_bytes = 64  # 128 fp4 elems packed into 64 bytes
-    jit_kw = dict(out_idx=None, target="cuda",
-                  pass_configs={"tl.disable_data_race_check": True})
+    jit_kw = dict(out_idx=None, target="cuda", pass_configs={"tl.disable_data_race_check": True})
 
     def make_buf():
         row = fp4_bytes + padding
         back = torch.zeros(num_blocks, block_size * row, dtype=torch.uint8, device="cuda")
-        fp4 = back[:, :block_size * fp4_bytes].view(num_blocks, block_size, fp4_bytes).view(torch.int8)
+        fp4 = back[:, : block_size * fp4_bytes].view(num_blocks, block_size, fp4_bytes).view(torch.int8)
         return back, fp4
 
     torch.manual_seed(0)
@@ -337,7 +337,7 @@ def test_subtype_fp4_dynamic_stride_store(block_size):
         nb = T.dynamic("num_blocks")
         src: T.Tensor[(nv, 128), T.float4_e2m1fn]
         dst: T.StridedTensor[(nb, block_size, 128), (s0, s1, 1), T.float4_e2m1fn]
-        slots: T.Tensor[(nv,), "int32"]
+        slots: T.Tensor[(nv,), T.int32]
         with T.Kernel(nv, threads=32) as i:
             for k in T.serial(128):
                 dst[slots[i] // block_size, slots[i] % block_size, k] = src[i, k]
@@ -353,7 +353,7 @@ def test_subtype_fp4_dynamic_stride_store(block_size):
         ds1 = T.dynamic("ds1")
         src: T.Tensor[(nv, 128), T.float4_e2m1fn]
         dst: T.StridedTensor[(nb, block_size, 128), (ds0, ds1, 1), T.float4_e2m1fn]
-        slots: T.Tensor[(nv,), "int32"]
+        slots: T.Tensor[(nv,), T.int32]
         with T.Kernel(nv, threads=32) as i:
             for k in T.serial(128):
                 dst[slots[i] // block_size, slots[i] % block_size, k] = src[i, k]
@@ -362,8 +362,7 @@ def test_subtype_fp4_dynamic_stride_store(block_size):
     dynamic_kern(src, fp4_d, slots)
 
     assert torch.equal(back_s, back_d), (
-        f"static vs dynamic stride mismatch: "
-        f"{(back_s != back_d).sum().item()}/{back_s.numel()} bytes differ"
+        f"static vs dynamic stride mismatch: {(back_s != back_d).sum().item()}/{back_s.numel()} bytes differ"
     )
 
 
@@ -377,7 +376,7 @@ def test_subtype_fp4_scalar_store_codegen(n):
         nv = T.dynamic("n")
         src: T.Tensor[(nv, 128), T.float4_e2m1fn]
         dst: T.Tensor[(nv, 128), T.float4_e2m1fn]
-        perm: T.Tensor[(nv,), "int32"]
+        perm: T.Tensor[(nv,), T.int32]
         with T.Kernel(nv, threads=32) as i:
             for k in T.serial(128):
                 dst[perm[i], k] = src[i, k]
@@ -394,9 +393,7 @@ def test_subtype_fp4_scalar_store_codegen(n):
     inv[perm] = torch.arange(n, dtype=torch.int32, device="cuda")
     expected = src.view(torch.uint8)[inv.long()]
     actual = dst.view(torch.uint8)
-    assert torch.equal(expected, actual), (
-        f"scatter fp4 mismatch: {(expected != actual).sum().item()}/{actual.numel()} bytes differ"
-    )
+    assert torch.equal(expected, actual), f"scatter fp4 mismatch: {(expected != actual).sum().item()}/{actual.numel()} bytes differ"
 
 
 if __name__ == "__main__":

--- a/testing/python/language/test_tilelang_language_subtype.py
+++ b/testing/python/language/test_tilelang_language_subtype.py
@@ -300,6 +300,84 @@ def test_subtype_complex_expressions_various(m, n):
     y = torch.randint(0, 256, (m * 2, n // 2), dtype=torch.uint8, device="cuda")
     complex_expr_kernel(x, y)
 
+# ---------------------------------------------------------------------------
+# Scalar fp4 store to StridedTensor with dynamic strides.
+# Before the fix the codegen wrote full bytes instead of nibbles, so
+# consecutive fp4 elements sharing a byte would overwrite each other.
+# ---------------------------------------------------------------------------
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("block_size", [8, 16])
+def test_subtype_fp4_dynamic_stride_store(block_size):
+    """fp4 store via StridedTensor: dynamic strides must match static strides."""
+    num_blocks, n, padding = 10, 64, 4
+    fp4_bytes = 64  # 128 fp4 elems packed into 64 bytes
+    jit_kw = dict(out_idx=None, target="cuda",
+                  pass_configs={"tl.disable_data_race_check": True})
+
+    # -- kernel with compile-time constant strides (reference) --
+    @tilelang.jit(**jit_kw)
+    def static_kern(block_size: int, s0: int, s1: int) -> object:
+        n = T.dynamic("n")
+        num_blocks = T.dynamic("num_blocks")
+
+        @T.prim_func
+        def f(src: T.Tensor((n, 128), T.float4_e2m1fn),
+              dst: T.StridedTensor((num_blocks, block_size, 128),
+                                   (s0, s1, 1), T.float4_e2m1fn),
+              slots: T.Tensor((n,), "int32")) -> None:
+            with T.Kernel(n, threads=32) as i:
+                for k in T.serial(128):
+                    dst[slots[i] // block_size,
+                        slots[i] % block_size, k] = src[i, k]
+        return f
+
+    # -- kernel with runtime-resolved strides --
+    @tilelang.jit(**jit_kw)
+    def dynamic_kern(block_size: int) -> object:
+        n = T.dynamic("n")
+        num_blocks = T.dynamic("num_blocks")
+        ds0 = T.dynamic("ds0")
+        ds1 = T.dynamic("ds1")
+
+        @T.prim_func
+        def f(src: T.Tensor((n, 128), T.float4_e2m1fn),
+              dst: T.StridedTensor((num_blocks, block_size, 128),
+                                   (ds0, ds1, 1), T.float4_e2m1fn),
+              slots: T.Tensor((n,), "int32")) -> None:
+            with T.Kernel(n, threads=32) as i:
+                for k in T.serial(128):
+                    dst[slots[i] // block_size,
+                        slots[i] % block_size, k] = src[i, k]
+        return f
+
+    # -- helpers --
+    def make_buf():
+        row = fp4_bytes + padding
+        back = torch.zeros(num_blocks, block_size * row, dtype=torch.uint8, device="cuda")
+        fp4 = back[:, :block_size * fp4_bytes].view(num_blocks, block_size, fp4_bytes).view(torch.int8)
+        return back, fp4
+
+    torch.manual_seed(0)
+    src = torch.randint(0, 256, (n, 64), dtype=torch.uint8, device="cuda").view(torch.int8)
+    slots = torch.randperm(num_blocks * block_size, dtype=torch.int32, device="cuda")[:n]
+
+    # static (reference)
+    back_s, fp4_s = make_buf()
+    s0 = fp4_s.stride(0) * 2  # byte stride → fp4-element stride
+    s1 = fp4_s.stride(1) * 2
+    static_kern(block_size, s0, s1)(src, fp4_s, slots)
+
+    # dynamic
+    back_d, fp4_d = make_buf()
+    dynamic_kern(block_size)(src, fp4_d, slots)
+
+    assert torch.equal(back_s, back_d), (
+        f"static vs dynamic stride mismatch: "
+        f"{(back_s != back_d).sum().item()}/{back_s.numel()} bytes differ"
+    )
+
 
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/language/test_tilelang_language_subtype.py
+++ b/testing/python/language/test_tilelang_language_subtype.py
@@ -316,43 +316,6 @@ def test_subtype_fp4_dynamic_stride_store(block_size):
     jit_kw = dict(out_idx=None, target="cuda",
                   pass_configs={"tl.disable_data_race_check": True})
 
-    # -- kernel with compile-time constant strides (reference) --
-    @tilelang.jit(**jit_kw)
-    def static_kern(block_size: int, s0: int, s1: int) -> object:
-        n = T.dynamic("n")
-        num_blocks = T.dynamic("num_blocks")
-
-        @T.prim_func
-        def f(src: T.Tensor((n, 128), T.float4_e2m1fn),
-              dst: T.StridedTensor((num_blocks, block_size, 128),
-                                   (s0, s1, 1), T.float4_e2m1fn),
-              slots: T.Tensor((n,), "int32")) -> None:
-            with T.Kernel(n, threads=32) as i:
-                for k in T.serial(128):
-                    dst[slots[i] // block_size,
-                        slots[i] % block_size, k] = src[i, k]
-        return f
-
-    # -- kernel with runtime-resolved strides --
-    @tilelang.jit(**jit_kw)
-    def dynamic_kern(block_size: int) -> object:
-        n = T.dynamic("n")
-        num_blocks = T.dynamic("num_blocks")
-        ds0 = T.dynamic("ds0")
-        ds1 = T.dynamic("ds1")
-
-        @T.prim_func
-        def f(src: T.Tensor((n, 128), T.float4_e2m1fn),
-              dst: T.StridedTensor((num_blocks, block_size, 128),
-                                   (ds0, ds1, 1), T.float4_e2m1fn),
-              slots: T.Tensor((n,), "int32")) -> None:
-            with T.Kernel(n, threads=32) as i:
-                for k in T.serial(128):
-                    dst[slots[i] // block_size,
-                        slots[i] % block_size, k] = src[i, k]
-        return f
-
-    # -- helpers --
     def make_buf():
         row = fp4_bytes + padding
         back = torch.zeros(num_blocks, block_size * row, dtype=torch.uint8, device="cuda")
@@ -363,19 +326,76 @@ def test_subtype_fp4_dynamic_stride_store(block_size):
     src = torch.randint(0, 256, (n, 64), dtype=torch.uint8, device="cuda").view(torch.int8)
     slots = torch.randperm(num_blocks * block_size, dtype=torch.int32, device="cuda")[:n]
 
-    # static (reference)
+    # static (reference) — strides known at compile time
     back_s, fp4_s = make_buf()
     s0 = fp4_s.stride(0) * 2  # byte stride → fp4-element stride
     s1 = fp4_s.stride(1) * 2
-    static_kern(block_size, s0, s1)(src, fp4_s, slots)
 
-    # dynamic
+    @tilelang.jit(**jit_kw)
+    def static_kern(src, dst, slots):
+        nv = T.dynamic("n")
+        nb = T.dynamic("num_blocks")
+        src: T.Tensor[(nv, 128), T.float4_e2m1fn]
+        dst: T.StridedTensor[(nb, block_size, 128), (s0, s1, 1), T.float4_e2m1fn]
+        slots: T.Tensor[(nv,), "int32"]
+        with T.Kernel(nv, threads=32) as i:
+            for k in T.serial(128):
+                dst[slots[i] // block_size, slots[i] % block_size, k] = src[i, k]
+
+    static_kern(src, fp4_s, slots)
+
+    # dynamic — strides resolved at runtime
+    @tilelang.jit(**jit_kw)
+    def dynamic_kern(src, dst, slots):
+        nv = T.dynamic("n")
+        nb = T.dynamic("num_blocks")
+        ds0 = T.dynamic("ds0")
+        ds1 = T.dynamic("ds1")
+        src: T.Tensor[(nv, 128), T.float4_e2m1fn]
+        dst: T.StridedTensor[(nb, block_size, 128), (ds0, ds1, 1), T.float4_e2m1fn]
+        slots: T.Tensor[(nv,), "int32"]
+        with T.Kernel(nv, threads=32) as i:
+            for k in T.serial(128):
+                dst[slots[i] // block_size, slots[i] % block_size, k] = src[i, k]
+
     back_d, fp4_d = make_buf()
-    dynamic_kern(block_size)(src, fp4_d, slots)
+    dynamic_kern(src, fp4_d, slots)
 
     assert torch.equal(back_s, back_d), (
         f"static vs dynamic stride mismatch: "
         f"{(back_s != back_d).sum().item()}/{back_s.numel()} bytes differ"
+    )
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("n", [64, 128])
+def test_subtype_fp4_scalar_store_codegen(n):
+    """Scatter fp4 elements via indirection — forces scalar (non-vectorized) stores."""
+
+    @tilelang.jit(out_idx=None, pass_configs={"tl.disable_data_race_check": True})
+    def scatter_kern(src, dst, perm):
+        nv = T.dynamic("n")
+        src: T.Tensor[(nv, 128), T.float4_e2m1fn]
+        dst: T.Tensor[(nv, 128), T.float4_e2m1fn]
+        perm: T.Tensor[(nv,), "int32"]
+        with T.Kernel(nv, threads=32) as i:
+            for k in T.serial(128):
+                dst[perm[i], k] = src[i, k]
+
+    torch.manual_seed(42)
+    src = torch.randint(0, 256, (n, 64), dtype=torch.uint8, device="cuda").view(torch.int8)
+    dst = torch.zeros(n, 64, dtype=torch.uint8, device="cuda").view(torch.int8)
+    perm = torch.randperm(n, dtype=torch.int32, device="cuda")
+
+    scatter_kern(src, dst, perm)
+
+    # Invert the permutation and check src[inv[j]] == dst[j] at byte level
+    inv = torch.empty_like(perm)
+    inv[perm] = torch.arange(n, dtype=torch.int32, device="cuda")
+    expected = src.view(torch.uint8)[inv.long()]
+    actual = dst.view(torch.uint8)
+    assert torch.equal(expected, actual), (
+        f"scatter fp4 mismatch: {(expected != actual).sum().item()}/{actual.numel()} bytes differ"
     )
 
 

--- a/tilelang/jit/adapter/cython/adapter.py
+++ b/tilelang/jit/adapter/cython/adapter.py
@@ -213,12 +213,14 @@ class CythonKernelAdapter(BaseKernelAdapter):
         adapter._post_init()
         return adapter
 
-    def _process_dynamic_symbolic(self) -> dict[tir.Var, tuple[int, int, int]]:
+    def _process_dynamic_symbolic(self) -> dict[tir.Var, tuple[int, int, int, int]]:
         """Extract information about dynamic shapes from the TIR function.
 
-        Maps symbolic variables to their corresponding (id, buffer_index, dimension)
+        Maps symbolic variables to their corresponding (id, buffer_index, dimension, stride_scale)
         for runtime shape resolution.
-        id represents shape or stride, 0 represents shape, 1 represents stride
+        id represents shape or stride, 0 represents shape, 1 represents stride.
+        stride_scale compensates for sub-byte dtypes (e.g. float4_e2m1fn) where torch strides
+        are in storage units but the kernel expects logical element strides.
         """
         func = self.prim_func
         params = func.params
@@ -229,13 +231,15 @@ class CythonKernelAdapter(BaseKernelAdapter):
                 buffer = buffer_map[param]
                 for j, shape in enumerate(buffer.shape):
                     if isinstance(shape, tir.Var) and (shape not in dynamic_symbolic_map) and (shape not in params):
-                        dynamic_symbolic_map[shape] = (0, i, j)
+                        dynamic_symbolic_map[shape] = (0, i, j, 1)
         for i, param in enumerate(params):
             if param in buffer_map:
                 buffer = buffer_map[param]
+                element_bits = buffer.dtype.bits * buffer.dtype.lanes
+                stride_scale = 8 // element_bits if element_bits < 8 else 1
                 for j, stride in enumerate(buffer.strides):
                     if isinstance(stride, tir.Var) and (stride not in dynamic_symbolic_map) and (stride not in params):
-                        dynamic_symbolic_map[stride] = (1, i, j)
+                        dynamic_symbolic_map[stride] = (1, i, j, stride_scale)
         return dynamic_symbolic_map
 
     def _process_buffer_dtype(self) -> dict[tir.Var, tuple[int, torch.dtype]]:

--- a/tilelang/jit/adapter/cython/cython_wrapper.pyx
+++ b/tilelang/jit/adapter/cython/cython_wrapper.pyx
@@ -199,7 +199,7 @@ cdef class CythonKernelWrapper:
                     if isinstance(s, tir.Var):
                         for key in self.dynamic_symbolic_map:
                             if(str(s) == str(key)):
-                                ref_id, ref_tensor_idx, ref_shape_idx = self.dynamic_symbolic_map[key]
+                                ref_id, ref_tensor_idx, ref_shape_idx, _stride_scale = self.dynamic_symbolic_map[key]
                                 shape.append(tensor_list[ref_tensor_idx].shape[ref_shape_idx])
                     else:  # Already converted to Python int during initialization
                         shape.append(s)

--- a/tilelang/jit/adapter/cython/cython_wrapper.pyx
+++ b/tilelang/jit/adapter/cython/cython_wrapper.pyx
@@ -266,11 +266,11 @@ cdef class CythonKernelWrapper:
             self._check_static_contiguous(tensor_list)
 
         # Add dynamic dimension values to kernel arguments
-        for _, (ref_id, buffer_idx, shape_idx) in self.dynamic_symbolic_map.items():
+        for _, (ref_id, buffer_idx, shape_idx, stride_scale) in self.dynamic_symbolic_map.items():
             if ref_id == 0:
                 call_args.append(ctypes.c_int64(tensor_list[buffer_idx].shape[shape_idx]))
             else:
-                call_args.append(ctypes.c_int64(tensor_list[buffer_idx].stride(shape_idx)))
+                call_args.append(ctypes.c_int64(tensor_list[buffer_idx].stride(shape_idx) * stride_scale))
 
         # Add CUDA stream to kernel arguments
         call_args.append(ctypes.c_void_p(stream))

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -110,12 +110,14 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
 
         self._post_init()
 
-    def _process_dynamic_symbolic(self) -> dict[tir.Var, tuple[int, int]]:
+    def _process_dynamic_symbolic(self) -> dict[tir.Var, tuple[int, int, int, int]]:
         """Extract information about dynamic shapes from the TIR function.
 
-        Maps symbolic variables to their corresponding (id, buffer_index, dimension)
+        Maps symbolic variables to their corresponding (id, buffer_index, dimension, stride_scale)
         for runtime shape resolution.
-        id represents shape or stride, 0 represents shape, 1 represents stride
+        id represents shape or stride, 0 represents shape, 1 represents stride, 2 represents scalar param.
+        stride_scale compensates for sub-byte dtypes (e.g. float4_e2m1fn) where torch strides
+        are in storage units but the kernel expects logical element strides.
         """
         func = self.prim_func
         params = func.params
@@ -123,19 +125,21 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
         dynamic_symbolic_map = {}
         for i, param in enumerate(params):
             if isinstance(param, tir.Var) and (param not in dynamic_symbolic_map):
-                dynamic_symbolic_map[param] = (2, i, -1)
+                dynamic_symbolic_map[param] = (2, i, -1, 1)
         for i, param in enumerate(params):
             if param in buffer_map:
                 buffer = buffer_map[param]
                 for j, shape in enumerate(buffer.shape):
                     if isinstance(shape, tir.Var) and (shape not in dynamic_symbolic_map) and (shape not in params):
-                        dynamic_symbolic_map[shape] = (0, i, j)
+                        dynamic_symbolic_map[shape] = (0, i, j, 1)
         for i, param in enumerate(params):
             if param in buffer_map:
                 buffer = buffer_map[param]
+                element_bits = buffer.dtype.bits * buffer.dtype.lanes
+                stride_scale = 8 // element_bits if element_bits < 8 else 1
                 for j, stride in enumerate(buffer.strides):
                     if isinstance(stride, tir.Var) and (stride not in dynamic_symbolic_map) and (stride not in params):
-                        dynamic_symbolic_map[stride] = (1, i, j)
+                        dynamic_symbolic_map[stride] = (1, i, j, stride_scale)
         return dynamic_symbolic_map
 
     def _convert_torch_func(self) -> Callable[..., Any]:
@@ -216,13 +220,13 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
                         if isinstance(s, tir.Var):
                             for key in dynamic_symbolic_map:
                                 if str(s) == str(key):
-                                    ref_id, ref_tensor_idx, ref_shape_idx = dynamic_symbolic_map[key]
+                                    ref_id, ref_tensor_idx, ref_shape_idx, stride_scale = dynamic_symbolic_map[key]
                                     if ref_id == 2:
                                         shape.append(inputs[ref_tensor_idx])
                                     elif ref_id == 0:
                                         shape.append(tensor_list[ref_tensor_idx].shape[ref_shape_idx])
                                     elif ref_id == 1:
-                                        shape.append(tensor_list[ref_tensor_idx].stride()[ref_shape_idx])
+                                        shape.append(tensor_list[ref_tensor_idx].stride()[ref_shape_idx] * stride_scale)
                         else:  # Already converted to Python int during initialization
                             shape.append(s)
 


### PR DESCRIPTION
## Problem

Two issues with `float4_e2m1fn` (`fp4`) when `T.StridedTensor` uses **dynamic** strides (`T.dynamic()`):

### 1. Frontend stride capture is wrong for dynamic strides

fp4 packs 2 elements per byte, so the logical element stride is **2x the byte stride** reported by PyTorch's DLTensor. When strides are dynamic (runtime-resolved), the Python adapters (`tvm_ffi.py`, `cython/adapter.py`) read the runtime stride but did not apply this scaling factor, passing incorrect (halved) strides to the kernel.

(When strides are static/compile-time constants, `MakePackedAPI` in `arg_binder.cc` already handles the `* pack_factor` scaling correctly — so this only affects dynamic strides.)

### 2. Codegen scalar fp4 store corrupts neighboring nibbles

When strides are dynamic, the compiler cannot vectorize the store and falls back to element-by-element writes. `GetBufferRef` in `codegen_cuda.cc` applies a `/2` index mapping for fp4 (since 2 elements share 1 byte), but the scalar write stores a full byte (`fp4_e2_t` = `uint8_t`), destroying the neighboring nibble:

```c
// i=0: cache_fp4[0] = 0x0L   ← low nibble written, high nibble zeroed
// i=1: cache_fp4[0] = 0x0H   ← overwrites! low nibble from i=0 is lost
```

The same kernel with static (compile-time constant) strides takes the vectorized path `*(fp4_e2_32_t*)ptr = ...` and produces correct results.

## Minimal reproduction

```python
@tilelang.jit(out_idx=None, target="cuda")
def dynamic_kern(block_size: int) -> object:
    ds0 = T.dynamic("ds0")
    ds1 = T.dynamic("ds1")

    @T.prim_func
    def f(src: T.Tensor((n, 128), T.float4_e2m1fn),
          dst: T.StridedTensor((num_blocks, block_size, 128),
                               (ds0, ds1, 1), T.float4_e2m1fn), ...) -> None:
        with T.Kernel(n, threads=32) as i:
            for k in T.serial(128):
                dst[slots[i] // block_size,
                    slots[i] % block_size, k] = src[i, k]
    return f
```

## Changes

* **codegen_cuda.cc**: Scalar fp4 load/store to non-packed buffers now uses `tl_fp4_packed_load` / `tl_fp4_packed_store` for nibble-safe read-modify-write
* **cython/adapter.py, cython_wrapper.pyx, tvm_ffi.py**: Add `stride_scale = 8 // element_bits` to `_process_dynamic_symbolic` so dynamic strides for sub-byte dtypes are correctly scaled from byte units to logical element units
* **inject_assumes.cc**: Extend `InjectAssumes` pass to emit `assume(stride % pack_factor == 0)` for non-last-dimension strides of sub-byte buffers, providing the TIR analyzer with divisibility information
* **test_tilelang_language_subtype.py**: Add two tests:
  - `test_subtype_fp4_dynamic_stride_store`: compares static vs dynamic stride fp4 scatter byte-for-byte
  - `test_subtype_fp4_scalar_store_codegen`: scatter via indirection forces scalar store path, verifies nibble correctness

## Test plan

- [x] `pytest testing/python/language/test_tilelang_language_subtype.py` → 34/34 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FP4 scalar buffer load/store correctness for non-packed buffers.
  * Added stride-divisibility assumptions for buffers with sub-byte element types to ensure runtime correctness.

* **New Features**
  * Enhanced CUDA code generation for NaN-aware max/min operations with explicit type conversions and fallback functions.
  * Improved lexical allocation scope statement handling.

* **Tests**
  * Added test coverage for FP4 dynamic stride store and scalar store codegen operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->