### PR TITLE
[API] Default warp-lane mask to 0xFFFFFFFF for warp-sync builtins

### DIFF
--- a/docs/programming_guides/instructions.md
+++ b/docs/programming_guides/instructions.md
@@ -195,9 +195,9 @@ Synchronization helpers
 - `T.pdl_sync()`: Wait until kernel dependencies are satisfied.
 
 Warp-vote / warp-ballot (CUDA ≥ 9 / HIP)
-- `T.any_sync(mask, predicate)` → `int32`: Non-zero if ANY lane in `mask` has non-zero predicate  (`__any_sync`).
-- `T.all_sync(mask, predicate)` → `int32`: Non-zero if ALL lanes in `mask` have non-zero predicate  (`__all_sync`).
-- `T.ballot_sync(mask, predicate)` → `uint64`: Bitmask of lanes in `mask` with non-zero predicate. CUDA: `__ballot_sync` zero-extended to 64 bits; HIP: `__ballot` returns natively as `uint64`, covering all 64 wavefront lanes.
+- `T.any_sync(predicate[, mask])` → `int32`: Non-zero if ANY lane in `mask` has non-zero predicate (`__any_sync`). `mask` defaults to `0xFFFFFFFF`.
+- `T.all_sync(predicate[, mask])` → `int32`: Non-zero if ALL lanes in `mask` have non-zero predicate (`__all_sync`). `mask` defaults to `0xFFFFFFFF`.
+- `T.ballot_sync(predicate[, mask])` → `uint64`: Bitmask of lanes in `mask` with non-zero predicate. CUDA: `__ballot_sync` zero-extended to 64 bits; HIP: `__ballot` returns natively as `uint64`, covering all 64 wavefront lanes. `mask` defaults to `0xFFFFFFFF`.
 - `T.ballot(predicate)` → `uint64`: Full-warp/wavefront ballot (mask = `0xFFFFFFFF`). No truncation on HIP.
 - `T.activemask()` → `uint64`: Bitmask of currently active lanes. CUDA: `__activemask` zero-extended to 64 bits; HIP: `__ballot(1)` as `uint64`.
 
@@ -206,15 +206,15 @@ Block-wide predicated sync
 - `T.syncthreads_and(predicate)` → `int32`: Sync; non-zero iff ALL threads have non-zero predicate (`__syncthreads_and`).
 - `T.syncthreads_or(predicate)` → `int32`: Sync; non-zero iff ANY thread has non-zero predicate (`__syncthreads_or`).
 
-Warp-shuffle (intra-warp data exchange)
-- `T.shfl_sync(mask, value, src_lane[, width])`: Broadcast value from `src_lane` to all lanes (`__shfl_sync`).
-- `T.shfl_xor(value, offset[, mask, width])`: XOR-swap across lanes (`__shfl_xor_sync`).
-- `T.shfl_down(value, offset[, mask, width])`: Shift down by `offset` lanes (`__shfl_down_sync`).
-- `T.shfl_up(value, offset[, mask, width])`: Shift up by `offset` lanes (`__shfl_up_sync`).
+Warp-shuffle (intra-warp data exchange). All accept a trailing `mask` kwarg that defaults to `0xFFFFFFFF`.
+- `T.shfl_sync(value, src_lane[, width, mask])`: Broadcast value from `src_lane` to all lanes (`__shfl_sync`).
+- `T.shfl_xor(value, delta[, width, mask])`: XOR-swap across lanes (`__shfl_xor_sync`).
+- `T.shfl_down(value, delta[, width, mask])`: Shift down by `delta` lanes (`__shfl_down_sync`).
+- `T.shfl_up(value, delta[, width, mask])`: Shift up by `delta` lanes (`__shfl_up_sync`).
 
-Warp-match (CUDA sm_70+, not supported on HIP)
-- `T.match_any_sync(mask, value)` → `uint32`: Bitmask of lanes in `mask` whose `value` matches the calling lane's (`__match_any_sync`).
-- `T.match_all_sync(mask, value)` → `uint32`: Returns `mask` if all lanes in `mask` agree on `value`, else 0 (`__match_all_sync`). The C-level `int*` predicate output is hidden; reconstruct it as `result != 0`.
+Warp-match (CUDA sm_70+, not supported on HIP). `mask` defaults to `0xFFFFFFFF`.
+- `T.match_any_sync(value[, mask])` → `uint32`: Bitmask of lanes in `mask` whose `value` matches the calling lane's (`__match_any_sync`).
+- `T.match_all_sync(value[, mask])` → `uint32`: Returns `mask` if all lanes in `mask` agree on `value`, else 0 (`__match_all_sync`). The C-level `int*` predicate output is hidden; reconstruct it as `result != 0`.
 
 > **Note on HIP:** `any_sync`/`all_sync` ignore the mask and call `__any`/`__all` directly. `ballot_sync`, `ballot`, and `activemask` call `__ballot` which returns `uint64` natively on 64-thread wavefronts — no truncation occurs. Shuffle intrinsics lower to `__shfl`/`__shfl_xor`/`__shfl_down`/`__shfl_up` (mask ignored). `syncthreads_count/and/or` have identical signatures on both platforms. `match_any_sync` and `match_all_sync` have no HIP equivalent and will fail to codegen on HIP.
 

--- a/testing/python/language/test_tilelang_language_warp_sync.py
+++ b/testing/python/language/test_tilelang_language_warp_sync.py
@@ -43,7 +43,7 @@ def kernel_with_shfl_sync():
         with T.Kernel(1, threads=32):
             tx = T.get_thread_binding()
             val = tx * 10
-            broadcast = T.shfl_sync(0xFFFFFFFF, val, 31)
+            broadcast = T.shfl_sync(val, 31)
             A[tx] = broadcast
 
     return main

--- a/testing/python/language/test_tilelang_language_warp_vote.py
+++ b/testing/python/language/test_tilelang_language_warp_vote.py
@@ -33,7 +33,7 @@ def kernel_any_sync():
     ):
         with T.Kernel(1, threads=32):
             tx = T.get_thread_binding()
-            val = T.any_sync(0xFFFFFFFF, tx == 0)
+            val = T.any_sync(tx == 0)
             B[tx] = val
 
     return main
@@ -65,7 +65,7 @@ def kernel_all_sync():
     ):
         with T.Kernel(1, threads=32):
             tx = T.get_thread_binding()
-            val = T.all_sync(0xFFFFFFFF, 1)
+            val = T.all_sync(1)
             B[tx] = val
 
     return main
@@ -96,7 +96,7 @@ def kernel_ballot_sync():
     ):
         with T.Kernel(1, threads=32):
             tx = T.get_thread_binding()
-            mask = T.ballot_sync(0xFFFFFFFF, tx == 0)
+            mask = T.ballot_sync(tx == 0)
             B[tx] = T.cast(mask, "int64")
 
     return main
@@ -335,7 +335,7 @@ def kernel_match_any_sync():
         with T.Kernel(1, threads=32):
             tx = T.get_thread_binding()
             value = T.if_then_else(tx < 16, 1, 2)
-            peers = T.match_any_sync(0xFFFFFFFF, value)
+            peers = T.match_any_sync(value)
             B[tx] = T.cast(peers, "int32")
 
     return main
@@ -370,7 +370,7 @@ def kernel_match_all_sync_true():
     ):
         with T.Kernel(1, threads=32):
             tx = T.get_thread_binding()
-            result = T.match_all_sync(0xFFFFFFFF, 7)
+            result = T.match_all_sync(7)
             B[tx] = T.cast(result, "int32")
 
     return main
@@ -386,7 +386,7 @@ def kernel_match_all_sync_false():
     ):
         with T.Kernel(1, threads=32):
             tx = T.get_thread_binding()
-            result = T.match_all_sync(0xFFFFFFFF, tx)
+            result = T.match_all_sync(tx)
             B[tx] = T.cast(result, "int32")
 
     return main

--- a/tilelang/language/builtin.py
+++ b/tilelang/language/builtin.py
@@ -884,7 +884,10 @@ def _as_uint32_mask(mask: int | PrimExpr) -> PrimExpr:
 
 
 def shfl_xor(
-    mask: int | PrimExpr, value: int | PrimExpr | tir.Call, delta: int | PrimExpr | tir.Call, width: int | PrimExpr = _DEFAULT_SHFL_WIDTH
+    value: int | PrimExpr | tir.Call,
+    delta: int | PrimExpr | tir.Call,
+    width: int | PrimExpr = _DEFAULT_SHFL_WIDTH,
+    mask: int | PrimExpr = _FULL_WARP_MASK,
 ):
     """XOR-swap ``value`` across lanes (``__shfl_xor_sync`` on CUDA,
     ``__shfl_xor`` on HIP — mask ignored on HIP).
@@ -893,7 +896,10 @@ def shfl_xor(
 
 
 def shfl_down(
-    mask: int | PrimExpr, value: int | PrimExpr | tir.Call, delta: int | PrimExpr | tir.Call, width: int | PrimExpr = _DEFAULT_SHFL_WIDTH
+    value: int | PrimExpr | tir.Call,
+    delta: int | PrimExpr | tir.Call,
+    width: int | PrimExpr = _DEFAULT_SHFL_WIDTH,
+    mask: int | PrimExpr = _FULL_WARP_MASK,
 ):
     """Shift ``value`` down by ``delta`` lanes (``__shfl_down_sync`` on CUDA,
     ``__shfl_down`` on HIP).
@@ -902,7 +908,10 @@ def shfl_down(
 
 
 def shfl_up(
-    mask: int | PrimExpr, value: int | PrimExpr | tir.Call, delta: int | PrimExpr | tir.Call, width: int | PrimExpr = _DEFAULT_SHFL_WIDTH
+    value: int | PrimExpr | tir.Call,
+    delta: int | PrimExpr | tir.Call,
+    width: int | PrimExpr = _DEFAULT_SHFL_WIDTH,
+    mask: int | PrimExpr = _FULL_WARP_MASK,
 ):
     """Shift ``value`` up by ``delta`` lanes (``__shfl_up_sync`` on CUDA,
     ``__shfl_up`` on HIP).
@@ -927,7 +936,12 @@ def sync_warp(mask: int = None):
     return tir.call_intrin("void", tir.op.Op.get("tl.sync_warp"))
 
 
-def shfl_sync(mask: int | PrimExpr, value: int | PrimExpr, srcLane: int | PrimExpr, width: int | PrimExpr = _DEFAULT_SHFL_WIDTH):
+def shfl_sync(
+    value: int | PrimExpr,
+    srcLane: int | PrimExpr,
+    width: int | PrimExpr = _DEFAULT_SHFL_WIDTH,
+    mask: int | PrimExpr = _FULL_WARP_MASK,
+):
     """Broadcast ``value`` from ``srcLane`` to all lanes in the subgroup of
     ``width`` lanes (``__shfl_sync`` on CUDA, ``__shfl`` on HIP — mask ignored
     on HIP).
@@ -944,7 +958,10 @@ def shfl_sync(mask: int | PrimExpr, value: int | PrimExpr, srcLane: int | PrimEx
 # ---------------------------------------------------------------------------
 
 
-def any_sync(mask: int | PrimExpr, predicate: int | PrimExpr) -> PrimExpr:
+def any_sync(
+    predicate: int | PrimExpr,
+    mask: int | PrimExpr = _FULL_WARP_MASK,
+) -> PrimExpr:
     """Non-zero if ANY active lane in ``mask`` has a non-zero ``predicate``.
 
     Lowers to ``__any_sync(mask, predicate)`` on CUDA and ``__any(predicate)``
@@ -952,8 +969,8 @@ def any_sync(mask: int | PrimExpr, predicate: int | PrimExpr) -> PrimExpr:
     convergent).
 
     Args:
-        mask: Warp lane mask (e.g. ``0xFFFFFFFF`` for all 32 lanes).
         predicate: Integer condition to test.
+        mask: Warp lane mask (defaults to ``0xFFFFFFFF``, i.e. all 32 lanes).
 
     Returns:
         int32: Non-zero if any thread in the mask has a non-zero predicate.
@@ -961,15 +978,18 @@ def any_sync(mask: int | PrimExpr, predicate: int | PrimExpr) -> PrimExpr:
     return tir.call_intrin("int32", tir.op.Op.get("tl.any_sync"), _as_uint32_mask(mask), predicate)
 
 
-def all_sync(mask: int | PrimExpr, predicate: int | PrimExpr) -> PrimExpr:
+def all_sync(
+    predicate: int | PrimExpr,
+    mask: int | PrimExpr = _FULL_WARP_MASK,
+) -> PrimExpr:
     """Non-zero only if ALL active lanes in ``mask`` have a non-zero predicate.
 
     Lowers to ``__all_sync(mask, predicate)`` on CUDA and ``__all(predicate)``
     on HIP.
 
     Args:
-        mask: Warp lane mask (e.g. ``0xFFFFFFFF`` for all 32 lanes).
         predicate: Integer condition to test.
+        mask: Warp lane mask (defaults to ``0xFFFFFFFF``, i.e. all 32 lanes).
 
     Returns:
         int32: Non-zero if all threads in the mask have a non-zero predicate.
@@ -977,7 +997,10 @@ def all_sync(mask: int | PrimExpr, predicate: int | PrimExpr) -> PrimExpr:
     return tir.call_intrin("int32", tir.op.Op.get("tl.all_sync"), _as_uint32_mask(mask), predicate)
 
 
-def ballot_sync(mask: int | PrimExpr, predicate: int | PrimExpr) -> PrimExpr:
+def ballot_sync(
+    predicate: int | PrimExpr,
+    mask: int | PrimExpr = _FULL_WARP_MASK,
+) -> PrimExpr:
     """Return a ``uint64`` bitmask of lanes in ``mask`` whose predicate is set.
 
     CUDA: ``__ballot_sync(mask, predicate)`` returns ``unsigned int``; codegen
@@ -993,7 +1016,7 @@ def ballot_sync(mask: int | PrimExpr, predicate: int | PrimExpr) -> PrimExpr:
 
 def ballot(predicate: int | PrimExpr) -> PrimExpr:
     """Full-warp / full-wavefront ballot. Equivalent to
-    ``ballot_sync(0xFFFFFFFF, predicate)``.
+    ``ballot_sync(predicate)`` (i.e. with the default full warp mask).
 
     Returns:
         uint64: Bitmask with bit N set if lane N's predicate is non-zero.
@@ -1041,7 +1064,10 @@ def syncthreads_or(predicate: int | PrimExpr) -> PrimExpr:
 # ---------------------------------------------------------------------------
 
 
-def match_any_sync(mask: int | PrimExpr, value: int | PrimExpr) -> PrimExpr:
+def match_any_sync(
+    value: int | PrimExpr,
+    mask: int | PrimExpr = _FULL_WARP_MASK,
+) -> PrimExpr:
     """Return a ``uint32`` bitmask of lanes in ``mask`` whose ``value`` equals
     the calling lane's value. Lowers to ``__match_any_sync`` on CUDA
     (compute capability >= 7.0). Not supported on HIP.
@@ -1049,7 +1075,10 @@ def match_any_sync(mask: int | PrimExpr, value: int | PrimExpr) -> PrimExpr:
     return tir.call_intrin("uint32", tir.op.Op.get("tl.match_any_sync"), _as_uint32_mask(mask), value)
 
 
-def match_all_sync(mask: int | PrimExpr, value: int | PrimExpr) -> PrimExpr:
+def match_all_sync(
+    value: int | PrimExpr,
+    mask: int | PrimExpr = _FULL_WARP_MASK,
+) -> PrimExpr:
     """Return ``mask`` if all lanes in ``mask`` agree on ``value``, else 0.
 
     Lowers to ``__match_all_sync`` on CUDA (compute capability >= 7.0); the


### PR DESCRIPTION
## Summary

Follow-up to #1858. Reorder the `mask` parameter to the end (with a default of `0xFFFFFFFF` as a uint32 TIR const) for the warp-level sync builtins in `tilelang/language/builtin.py`:

- shfl family: `shfl_xor`, `shfl_down`, `shfl_up`, `shfl_sync` — new shape `(value, delta/srcLane, width=32, mask=0xFFFFFFFF)`
- warp-vote: `any_sync`, `all_sync`, `ballot_sync` — new shape `(predicate, mask=0xFFFFFFFF)`
- warp-match: `match_any_sync`, `match_all_sync` — new shape `(value, mask=0xFFFFFFFF)`

### Why

Full-warp is the overwhelmingly common case — nearly every caller just wants `0xFFFFFFFF`. Making mask an optional trailing kwarg:

1. Removes boilerplate at call sites (`T.any_sync(pred)` instead of `T.any_sync(0xFFFFFFFF, pred)`).
2. Keeps pre-#1858 `(value, delta)`-style `shfl_xor/down/up` calls working, avoiding a breaking change for external users.

The low-level TIR ops and codegen lowering (`src/op/builtin.*`, `codegen_{cuda,hip}.cc`) still take `(mask, value, ...)` in CUDA-native order — only the Python wrapper argument order changed.

### Changes

- `tilelang/language/builtin.py`: signatures updated for 9 wrappers.
- `testing/python/language/test_tilelang_language_warp_{sync,vote}.py`: 7 call sites simplified to rely on the default mask.
- `docs/programming_guides/instructions.md`: signature table refreshed, default mask noted.

## Test plan

- [ ] `pytest testing/python/language/test_tilelang_language_warp_vote.py`
- [ ] `pytest testing/python/language/test_tilelang_language_warp_sync.py`
- [ ] Verify generated CUDA source still prints `(uint)0xFFFFFFFF` for the mask (not `(int64_t)...`)
- [ ] Spot-check HIP codegen for shfl/vote/ballot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated warp synchronization instruction signatures across all shuffle and vote operations. The `mask` parameter is now optional, positioned as a trailing argument with a full-warp default. Changes affect ballot, any, all, match, and shuffle synchronization functions with new parameter ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->