### PR TITLE
fix: suppress false positive conflict write warning when dst index depends on thread var

### DIFF
--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -18,6 +18,7 @@
 #include "utils.h"
 
 #include "builtin.h"
+#include <tvm/tir/analysis.h>
 #include <tvm/tir/builtin.h>
 #include <tvm/tir/op.h>
 #include <tvm/tir/op_attr_types.h>
@@ -1099,9 +1100,24 @@ Stmt CopyNode::LowerNormalCopy(const LowerArgs &T,
 
   if (is_cpu_target || IsLocalBuffer(src) || IsLocalBuffer(dst)) {
     if (IsLocalBuffer(src) && !IsLocalBuffer(dst)) {
-      LOG(WARNING) << "Copy from local buffer `" << src->name << "` to "
-                   << dst.scope() << " buffer `" << dst->name
-                   << "` may cause conflicted write.";
+      // A conflict write only occurs when multiple threads write to the same
+      // global address. If any dst_range dimension's min depends on the thread
+      // variable, each thread targets a distinct location and there is no
+      // conflict.
+      bool dst_depends_on_thread = false;
+      for (const auto &range : dst_range) {
+        if (tir::UsesVar(range->min, [&](const VarNode *v) {
+              return v == T.thread_var.get();
+            })) {
+          dst_depends_on_thread = true;
+          break;
+        }
+      }
+      if (!dst_depends_on_thread) {
+        LOG(WARNING) << "Copy from local buffer `" << src->name << "` to "
+                     << dst.scope() << " buffer `" << dst->name
+                     << "` may cause conflicted write.";
+      }
     }
     vectorized_thread_loop = VectorizeLoop(fused_loop, T.layout_map);
     return vectorized_thread_loop;


### PR DESCRIPTION
## Summary

Fix false positive "conflicted write" warning when copying from local to global buffers where each thread writes to a distinct memory location.

Fixes #2035.

## Bug Cause

In `CopyNode::LowerNormalCopy`, the warning was emitted unconditionally whenever the source is a local buffer and the destination is not:

```cpp
if (IsLocalBuffer(src) && !IsLocalBuffer(dst)) {
    LOG(WARNING) << "... may cause conflicted write.";  // always fires
}
```

It never checks whether threads actually write to the same address. A conflict write only occurs when **multiple threads write to the same global memory address**. If the destination index varies per thread (i.e., depends on `threadIdx.x`), each thread targets a distinct location and there is no conflict.

For example, in issue #2035:

```python
tid = T.get_thread_binding()           # threadIdx.x
token_idx = bs * blk_m + tid           # varies per thread
T.copy(output_local, output[bh, token_idx, :])
```

Each thread writes to a different `token_idx`, so no conflict exists.

## Fix

Before emitting the warning, check whether any dimension of `dst_range` depends on `threadIdx.x`. If so, each thread writes to a distinct location and the warning is suppressed.

## Known Limitation

The proper fix would be to prove that the mapping from thread ID to destination address is injective (i.e., different threads map to different addresses). However, performing injectivity checking via Z3 has prohibitive overhead in the compiler.

As a practical approximation, this PR checks whether the destination index contains `threadIdx.x` — if it does, the mapping is almost certainly injective (each thread writes to a different location). However, this is a syntactic check rather than a semantic one: if a user creates an IR-level `Var` (e.g., via `T.var("int32")`) bound to a thread-dependent expression, `tir::UsesVar` would not trace through the binding, potentially missing a non-conflict case. This edge case is rare in practice.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved warning accuracy for buffer copy operations by reducing false-positive warnings when thread-level write conflicts aren't actually possible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->