### PR TITLE
[RISCV][CPU] Add tl.cpu_arch pass-config plumbing

### DIFF
--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -19,6 +19,7 @@ namespace tl {
 TVM_REGISTER_PASS_CONFIG_OPTION(kDebugMergeSharedMemoryAllocations, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableSafeMemoryLegalize, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableWarpSpecialized, Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION(kCPUArch, String);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableThreadStorageSync, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kConfigIndexBitwidth, Integer);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableTMALower, Bool);

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -86,6 +86,7 @@ static constexpr const char *kDisableSafeMemoryLegalize =
     "tl.disable_safe_memory_legalize";
 static constexpr const char *kDisableWarpSpecialized =
     "tl.disable_warp_specialized";
+static constexpr const char *kCPUArch = "tl.cpu_arch";
 static constexpr const char *kConfigIndexBitwidth = "tl.config_index_bitwidth";
 // Deprecated pass config, temporarily re-enabled. Prevents plain T.copy()
 // from auto-lowering to TMA store. Will be removed in v0.1.10.

--- a/src/target/utils.cc
+++ b/src/target/utils.cc
@@ -357,8 +357,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
            [](Target target) { return TargetIsRocm(target); })
       .def("tl.TargetIsMetal",
            [](Target target) { return TargetIsMetal(target); })
-      .def("tl.TargetIsCPU",
-           [](Target target) { return TargetIsCPU(target); })
+      .def("tl.TargetIsCPU", [](Target target) { return TargetIsCPU(target); })
       .def("tl.TargetGetCPUArch",
            [](Target target) { return TargetGetCPUArch(target); })
       .def("tl.TargetIsVolta",

--- a/src/target/utils.cc
+++ b/src/target/utils.cc
@@ -3,14 +3,63 @@
  * \brief helper functions for target attributes.
  */
 
+#include <dmlc/thread_local.h>
+
 #include "utils.h"
 
+#include "../op/builtin.h"
 #include "../support/ffi_aliases.h"
 #include "dlpack/dlpack.h"
 #include <tvm/node/node.h>
 
 namespace tvm {
 namespace tl {
+
+namespace {
+
+struct PassContextConfigOverrideScope {
+  transform::PassContext pass_ctx;
+  ffi::Map<ffi::String, ffi::Any> previous_config;
+};
+
+struct PassContextConfigOverrideThreadLocalEntry {
+  std::vector<PassContextConfigOverrideScope> stack;
+};
+
+using PassContextConfigOverrideStore =
+    dmlc::ThreadLocalStore<PassContextConfigOverrideThreadLocalEntry>;
+
+void PushPassContextConfigs(ffi::Map<ffi::String, ffi::Any> overrides) {
+  transform::PassContext pass_ctx = transform::PassContext::Current();
+  auto *entry = PassContextConfigOverrideStore::Get();
+  entry->stack.push_back({pass_ctx, pass_ctx->config});
+
+  ffi::Map<ffi::String, ffi::Any> merged_config;
+  if (pass_ctx->config.defined()) {
+    merged_config = pass_ctx->config;
+  }
+  for (const auto &[key, value] : overrides) {
+    merged_config.Set(key, value);
+  }
+  pass_ctx->config = merged_config;
+}
+
+void PopPassContextConfigs() {
+  auto *entry = PassContextConfigOverrideStore::Get();
+  ICHECK(!entry->stack.empty())
+      << "Pass-context config override stack underflow";
+
+  PassContextConfigOverrideScope scope = entry->stack.back();
+  entry->stack.pop_back();
+
+  transform::PassContext current_pass_ctx = transform::PassContext::Current();
+  ICHECK(current_pass_ctx.same_as(scope.pass_ctx))
+      << "Pass-context config override restored under a different active "
+         "PassContext";
+  current_pass_ctx->config = scope.previous_config;
+}
+
+} // namespace
 
 bool TargetIsCuda(Target target) {
   return target->GetTargetDeviceType() == kDLCUDA;
@@ -23,6 +72,15 @@ bool TargetIsMetal(Target target) {
 }
 bool TargetIsCPU(Target target) {
   return target->GetTargetDeviceType() == kDLCPU;
+}
+
+ffi::Optional<ffi::String> TargetGetCPUArch(Target target) {
+  if (!TargetIsCPU(target)) {
+    return ffi::Optional<ffi::String>(std::nullopt);
+  }
+
+  return tvm::transform::PassContext::Current()->GetConfig(
+      kCPUArch, ffi::Optional<ffi::String>());
 }
 
 int GetArchInt(Target target) {
@@ -291,12 +349,18 @@ bool IsCudaVectorizableCast(DataType from_ty, DataType target_ty) {
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   refl::GlobalDef()
+      .def("tl.PushPassContextConfigs", PushPassContextConfigs)
+      .def("tl.PopPassContextConfigs", PopPassContextConfigs)
       .def("tl.TargetIsCuda",
            [](Target target) { return TargetIsCuda(target); })
       .def("tl.TargetIsRocm",
            [](Target target) { return TargetIsRocm(target); })
       .def("tl.TargetIsMetal",
            [](Target target) { return TargetIsMetal(target); })
+      .def("tl.TargetIsCPU",
+           [](Target target) { return TargetIsCPU(target); })
+      .def("tl.TargetGetCPUArch",
+           [](Target target) { return TargetGetCPUArch(target); })
       .def("tl.TargetIsVolta",
            [](Target target) { return TargetIsVolta(target); })
       .def("tl.TargetIsTuring",

--- a/src/target/utils.h
+++ b/src/target/utils.h
@@ -7,6 +7,7 @@
 #ifndef TVM_TL_TARGET_UTILS_H_
 #define TVM_TL_TARGET_UTILS_H_
 
+#include <tvm/ir/transform.h>
 #include <tvm/target/target.h>
 
 namespace tvm {
@@ -16,6 +17,7 @@ bool TargetIsCuda(Target target);
 bool TargetIsRocm(Target target);
 bool TargetIsMetal(Target target);
 bool TargetIsCPU(Target target);
+ffi::Optional<ffi::String> TargetGetCPUArch(Target target);
 
 bool TargetIsVolta(Target target);
 bool TargetIsTuring(Target target);

--- a/testing/python/cpu/test_tilelang_cpu_arch_config.py
+++ b/testing/python/cpu/test_tilelang_cpu_arch_config.py
@@ -1,0 +1,272 @@
+import importlib
+from pathlib import Path
+
+import pytest
+import tilelang
+import tilelang.language as T
+from tilelang import tvm as tvm
+
+
+@T.prim_func
+def tiny_cpu_kernel(A: T.Tensor((16, 16), "float32"), B: T.Tensor((16, 16), "float32")):
+    with T.Kernel(1, 1, is_cpu=True) as (bx, by):
+        T.copy(A, B)
+
+
+@T.prim_func
+def annotated_cpu_kernel(A: T.Tensor((16, 16), "float32"), B: T.Tensor((16, 16), "float32")):
+    T.annotate_pass_configs(
+        {
+            tilelang.PassConfigKey.TL_CPU_ARCH: "riscv",
+            tilelang.PassConfigKey.TL_FORCE_LET_INLINE: True,
+        }
+    )
+    with T.Kernel(1, 1, is_cpu=True) as (bx, by):
+        T.copy(A, B)
+
+
+@T.prim_func
+def annotated_cpu_kernel_aarch64(A: T.Tensor((16, 16), "float32"), B: T.Tensor((16, 16), "float32")):
+    T.annotate_pass_configs(
+        {
+            tilelang.PassConfigKey.TL_CPU_ARCH: "aarch64",
+            tilelang.PassConfigKey.TL_FORCE_LET_INLINE: True,
+        }
+    )
+    with T.Kernel(1, 1, is_cpu=True) as (bx, by):
+        T.copy(A, B)
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _read_repo_file(relative_path: str) -> str:
+    return (_repo_root() / relative_path).read_text()
+
+
+def _capture_lower_context(monkeypatch, func=tiny_cpu_kernel, pass_configs=None, outer_config=None, instruments=None):
+    observed_configs = []
+    lower_module = importlib.import_module("tilelang.engine.lower")
+    original_lower_and_legalize = lower_module.LowerAndLegalize
+
+    def capture_pass_context(mod, target):
+        observed_configs.append(dict(tvm.transform.PassContext.current().config))
+        return original_lower_and_legalize(mod, target)
+
+    monkeypatch.setattr(lower_module, "LowerAndLegalize", capture_pass_context)
+
+    with tvm.transform.PassContext(config=outer_config or {}, instruments=instruments or []), tvm.target.Target("c"):
+        artifact = tilelang.lower(
+            func,
+            target="c",
+            target_host="c",
+            pass_configs=pass_configs,
+        )
+
+    return artifact, observed_configs
+
+
+def test_lower_accepts_cpu_arch_pass_config():
+    with tvm.target.Target("c"):
+        artifact = tilelang.lower(
+            tiny_cpu_kernel,
+            target="c",
+            target_host="c",
+            pass_configs={"tl.cpu_arch": "riscv"},
+        )
+
+    assert artifact.kernel_source is not None
+    assert artifact.kernel_source.strip()
+
+
+def test_lower_without_cpu_arch_still_works():
+    with tvm.target.Target("c"):
+        artifact = tilelang.lower(tiny_cpu_kernel, target="c", target_host="c")
+
+    assert artifact.kernel_source is not None
+    assert artifact.kernel_source.strip()
+
+
+def test_lower_keeps_runtime_only_positional_argument_compatibility():
+    with tvm.target.Target("c"):
+        artifact = tilelang.lower(tiny_cpu_kernel, "c", "c", True)
+
+    assert artifact.kernel_source is not None
+    assert artifact.kernel_source.strip()
+    assert artifact.params is None
+
+
+def test_cpu_arch_pass_config_does_not_change_scalar_cpu_codegen():
+    with tvm.target.Target("c"):
+        default_artifact = tilelang.lower(tiny_cpu_kernel, target="c", target_host="c")
+        configured_artifact = tilelang.lower(
+            tiny_cpu_kernel,
+            target="c",
+            target_host="c",
+            pass_configs={"tl.cpu_arch": "riscv"},
+        )
+
+    assert default_artifact.kernel_source == configured_artifact.kernel_source
+
+
+def test_lower_preserves_outer_pass_context_instruments_and_merges_config(monkeypatch):
+    trace = []
+
+    @tvm.instrument.pass_instrument
+    class Probe:
+        def enter_pass_ctx(self):
+            trace.append("enter")
+
+        def exit_pass_ctx(self):
+            trace.append("exit")
+
+        def run_before_pass(self, mod, info):
+            if info.name == "tl.LowerTileOp":
+                trace.append("before-lower")
+
+        def run_after_pass(self, mod, info):
+            if info.name == "tl.LowerTileOp":
+                trace.append("after-lower")
+
+    outer_config = {tilelang.PassConfigKey.TL_FORCE_LET_INLINE: True}
+    artifact, observed_configs = _capture_lower_context(
+        monkeypatch,
+        pass_configs={"tl.cpu_arch": "riscv"},
+        outer_config=outer_config,
+        instruments=[Probe()],
+    )
+
+    assert artifact.kernel_source is not None
+    assert observed_configs
+    assert trace == ["enter", "before-lower", "after-lower", "exit"]
+    seen_config = observed_configs[-1]
+    assert bool(seen_config["tl.force_let_inline"])
+    assert seen_config["tl.cpu_arch"] == "riscv"
+
+
+def test_target_get_cpu_arch_is_observable_during_lowering_and_cpu_only(monkeypatch):
+    lower_module = importlib.import_module("tilelang.engine.lower")
+    original_lower_and_legalize = lower_module.LowerAndLegalize
+    target_get_cpu_arch = tvm.ffi.get_global_func("tl.TargetGetCPUArch")
+    observed_arches = []
+
+    def capture_cpu_arch(mod, target):
+        observed_arches.append(target_get_cpu_arch(target))
+        return original_lower_and_legalize(mod, target)
+
+    monkeypatch.setattr(lower_module, "LowerAndLegalize", capture_cpu_arch)
+
+    with tvm.target.Target("c"):
+        tilelang.lower(
+            tiny_cpu_kernel,
+            target="c",
+            target_host="c",
+            pass_configs={"tl.cpu_arch": "riscv"},
+        )
+    assert observed_arches[-1] == "riscv"
+
+    with tvm.target.Target("c"):
+        tilelang.lower(tiny_cpu_kernel, target="c", target_host="c")
+    assert observed_arches[-1] is None
+
+    assert target_get_cpu_arch(tvm.target.Target("cuda")) is None
+
+
+def test_lower_honors_function_level_pass_configs_and_explicit_overrides(monkeypatch):
+    _, observed_configs = _capture_lower_context(monkeypatch, func=annotated_cpu_kernel)
+    assert observed_configs
+    assert observed_configs[-1]["tl.cpu_arch"] == "riscv"
+    assert bool(observed_configs[-1]["tl.force_let_inline"])
+
+    _, override_configs = _capture_lower_context(
+        monkeypatch,
+        func=annotated_cpu_kernel,
+        pass_configs={"tl.cpu_arch": "aarch64"},
+    )
+    assert override_configs
+    assert override_configs[-1]["tl.cpu_arch"] == "aarch64"
+    assert bool(override_configs[-1]["tl.force_let_inline"])
+
+
+def test_lower_honors_function_level_pass_configs_for_irmodule_input(monkeypatch):
+    mod = tvm.IRModule({"main": annotated_cpu_kernel})
+
+    _, observed_configs = _capture_lower_context(monkeypatch, func=mod)
+    assert observed_configs
+    assert observed_configs[-1]["tl.cpu_arch"] == "riscv"
+    assert bool(observed_configs[-1]["tl.force_let_inline"])
+
+    _, override_configs = _capture_lower_context(
+        monkeypatch,
+        func=mod,
+        pass_configs={"tl.cpu_arch": "aarch64"},
+    )
+    assert override_configs
+    assert override_configs[-1]["tl.cpu_arch"] == "aarch64"
+    assert bool(override_configs[-1]["tl.force_let_inline"])
+
+
+def test_lower_honors_function_level_pass_configs_for_irmodule_with_unannotated_helper(monkeypatch):
+    mod = tvm.IRModule(
+        {
+            "main": annotated_cpu_kernel,
+            "helper": tiny_cpu_kernel,
+        }
+    )
+
+    _, observed_configs = _capture_lower_context(monkeypatch, func=mod)
+    assert observed_configs
+    assert observed_configs[-1]["tl.cpu_arch"] == "riscv"
+    assert bool(observed_configs[-1]["tl.force_let_inline"])
+
+
+def test_lower_allows_explicit_override_for_conflicting_multifunc_irmodule(monkeypatch):
+    mod = tvm.IRModule(
+        {
+            "main": annotated_cpu_kernel,
+            "other": annotated_cpu_kernel_aarch64,
+        }
+    )
+
+    _, observed_configs = _capture_lower_context(
+        monkeypatch,
+        func=mod,
+        pass_configs={"tl.cpu_arch": "x86_64"},
+    )
+    assert observed_configs
+    assert observed_configs[-1]["tl.cpu_arch"] == "x86_64"
+    assert bool(observed_configs[-1]["tl.force_let_inline"])
+
+
+def test_lower_rejects_conflicting_function_level_pass_configs_for_multifunc_irmodule():
+    mod = tvm.IRModule(
+        {
+            "main": annotated_cpu_kernel,
+            "other": annotated_cpu_kernel_aarch64,
+        }
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="Conflicting function-level tilelang_pass_configs found in IRModule",
+    ):
+        with tvm.target.Target("c"):
+            tilelang.lower(mod, target="c", target_host="c")
+
+
+def test_lower_rejects_unregistered_pass_config_key():
+    with pytest.raises(Exception):
+        with tvm.target.Target("c"):
+            tilelang.lower(
+                tiny_cpu_kernel,
+                target="c",
+                target_host="c",
+                pass_configs={"tl.not_registered": "value"},
+            )
+
+
+def test_cpu_arch_plumbing_is_declared_and_registered():
+    assert 'TL_CPU_ARCH = "tl.cpu_arch"' in _read_repo_file("tilelang/transform/pass_config.py")
+    assert 'kCPUArch = "tl.cpu_arch"' in _read_repo_file("src/op/builtin.h")
+    assert "TVM_REGISTER_PASS_CONFIG_OPTION(kCPUArch, String);" in _read_repo_file("src/op/builtin.cc")

--- a/testing/python/cpu/test_tilelang_cpu_arch_config.py
+++ b/testing/python/cpu/test_tilelang_cpu_arch_config.py
@@ -247,23 +247,24 @@ def test_lower_rejects_conflicting_function_level_pass_configs_for_multifunc_irm
         }
     )
 
-    with pytest.raises(
-        ValueError,
-        match="Conflicting function-level tilelang_pass_configs found in IRModule",
+    with (
+        pytest.raises(
+            ValueError,
+            match="Conflicting function-level tilelang_pass_configs found in IRModule",
+        ),
+        tvm.target.Target("c"),
     ):
-        with tvm.target.Target("c"):
-            tilelang.lower(mod, target="c", target_host="c")
+        tilelang.lower(mod, target="c", target_host="c")
 
 
 def test_lower_rejects_unregistered_pass_config_key():
-    with pytest.raises(Exception):
-        with tvm.target.Target("c"):
-            tilelang.lower(
-                tiny_cpu_kernel,
-                target="c",
-                target_host="c",
-                pass_configs={"tl.not_registered": "value"},
-            )
+    with pytest.raises(AttributeError, match="Invalid config option 'tl.not_registered'"), tvm.target.Target("c"):
+        tilelang.lower(
+            tiny_cpu_kernel,
+            target="c",
+            target_host="c",
+            pass_configs={"tl.not_registered": "value"},
+        )
 
 
 def test_cpu_arch_plumbing_is_declared_and_registered():

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -292,12 +292,8 @@ def _resolve_lower_pass_configs(
                     continue
                 if len(key_values) != len(prim_func_configs):
                     owners = ", ".join(name for name, _ in key_values)
-                    missing = ", ".join(
-                        name for name, configs in prim_func_configs if key not in configs
-                    )
-                    conflict_details.append(
-                        f"{key} set on [{owners}] but missing on [{missing}]"
-                    )
+                    missing = ", ".join(name for name, configs in prim_func_configs if key not in configs)
+                    conflict_details.append(f"{key} set on [{owners}] but missing on [{missing}]")
                     continue
 
                 first_value = key_values[0][1]

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from contextlib import contextmanager
+from typing import Any, Callable
 import tilelang.transform
 from tilelang import tvm as tvm
 from tvm import tir
@@ -12,6 +13,7 @@ from tvm.target import Target
 from tilelang.contrib import hipcc, nvcc
 from tilelang.env import COMPOSABLE_KERNEL_INCLUDE_DIR, CUTLASS_INCLUDE_DIR, TILELANG_TEMPLATE_PATH
 from tilelang.transform import PassConfigKey
+from tilelang.transform.pass_config import normalize_pass_configs
 from tilelang.transform.metal import MarkHostMetalContext
 from tilelang.engine.param import KernelParam, CompiledArtifact
 from tilelang.utils.target import determine_target
@@ -221,7 +223,103 @@ def device_codegen_without_compile(device_mod: tvm.IRModule, target: Target) -> 
     return device_mod
 
 
-def lower(
+def _merged_pass_context(pass_configs: dict[str, Any] | None):
+    normalized_pass_configs = normalize_pass_configs(pass_configs)
+    if not normalized_pass_configs:
+        return _noop_context()
+
+    push_pass_context_configs = tvm.ffi.get_global_func("tl.PushPassContextConfigs")
+    pop_pass_context_configs = tvm.ffi.get_global_func("tl.PopPassContextConfigs")
+    merged_config = {}
+    for key, value in normalized_pass_configs.items():
+        merged_config[key.value if isinstance(key, PassConfigKey) else key] = value
+    # Reuse PassContext construction for config-key/type validation without
+    # entering a nested pass-context scope.
+    tvm.transform.PassContext(config=merged_config)
+
+    @contextmanager
+    def merged_pass_context_scope():
+        push_pass_context_configs(merged_config)
+        try:
+            yield
+        finally:
+            pop_pass_context_configs()
+
+    return merged_pass_context_scope()
+
+
+@contextmanager
+def _noop_context():
+    yield
+
+
+def _resolve_lower_pass_configs(
+    func_or_mod: tir.PrimFunc | tvm.IRModule,
+    pass_configs: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    def _canonicalize_pass_configs(raw_pass_configs: dict[str, Any] | None) -> dict[str, Any]:
+        canonicalized = {}
+        for key, value in normalize_pass_configs(raw_pass_configs).items():
+            canonicalized[key.value if isinstance(key, PassConfigKey) else key] = value
+        return canonicalized
+
+    def _get_func_pass_configs(func: tir.PrimFunc) -> dict[str, Any]:
+        func_attrs = func.attrs
+        if func_attrs and "tilelang_pass_configs" in func_attrs:
+            return _canonicalize_pass_configs(dict(func_attrs["tilelang_pass_configs"]))
+        return {}
+
+    explicit_pass_configs = _canonicalize_pass_configs(pass_configs)
+    merged_pass_configs = {}
+    if isinstance(func_or_mod, tir.PrimFunc):
+        merged_pass_configs.update(_get_func_pass_configs(func_or_mod))
+    elif isinstance(func_or_mod, tvm.IRModule):
+        prim_func_configs = []
+        for global_var, func in func_or_mod.functions.items():
+            if isinstance(func, tir.PrimFunc):
+                func_pass_configs = _get_func_pass_configs(func)
+                if func_pass_configs:
+                    prim_func_configs.append((global_var.name_hint, func_pass_configs))
+
+        if len(prim_func_configs) == 1:
+            merged_pass_configs.update(prim_func_configs[0][1])
+        elif len(prim_func_configs) > 1:
+            conflict_details = []
+            all_keys = sorted({key for _, configs in prim_func_configs for key in configs})
+            for key in all_keys:
+                key_values = [(name, configs[key]) for name, configs in prim_func_configs if key in configs]
+                if key in explicit_pass_configs:
+                    continue
+                if len(key_values) != len(prim_func_configs):
+                    owners = ", ".join(name for name, _ in key_values)
+                    missing = ", ".join(
+                        name for name, configs in prim_func_configs if key not in configs
+                    )
+                    conflict_details.append(
+                        f"{key} set on [{owners}] but missing on [{missing}]"
+                    )
+                    continue
+
+                first_value = key_values[0][1]
+                if all(value == first_value for _, value in key_values[1:]):
+                    merged_pass_configs[key] = first_value
+                else:
+                    value_details = ", ".join(f"{name}={value!r}" for name, value in key_values)
+                    conflict_details.append(f"{key} differs across [{value_details}]")
+
+            if conflict_details:
+                raise ValueError(
+                    "Conflicting function-level tilelang_pass_configs found in IRModule "
+                    f"({'; '.join(conflict_details)}). Lower functions separately, "
+                    "align their annotations, or pass an explicit module-wide "
+                    "`pass_configs=` override."
+                )
+    if explicit_pass_configs:
+        merged_pass_configs.update(explicit_pass_configs)
+    return merged_pass_configs or None
+
+
+def _lower_impl(
     func_or_mod: tir.PrimFunc | tvm.IRModule,
     target: str | Target = "auto",
     target_host: str | Target | None = None,
@@ -274,3 +372,26 @@ def lower(
         return CompiledArtifact(host_mod, device_mod, params, codegen_mod.inspect_source(), rt_mod=host_mod)
 
     return CompiledArtifact(host_mod, device_mod, params, codegen_mod.inspect_source())
+
+
+def lower(
+    func_or_mod: tir.PrimFunc | tvm.IRModule,
+    target: str | Target = "auto",
+    target_host: str | Target | None = None,
+    runtime_only=False,
+    pass_configs: dict[str, Any] | None = None,
+    enable_host_codegen=False,
+    enable_device_compile=False,
+) -> CompiledArtifact:
+
+    pass_configs = _resolve_lower_pass_configs(func_or_mod, pass_configs)
+
+    with _merged_pass_context(pass_configs):
+        return _lower_impl(
+            func_or_mod,
+            target=target,
+            target_host=target_host,
+            runtime_only=runtime_only,
+            enable_host_codegen=enable_host_codegen,
+            enable_device_compile=enable_device_compile,
+        )

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -55,6 +55,18 @@ class PassConfigKey(str, Enum):
     TL_DISABLE_WARP_SPECIALIZED = "tl.disable_warp_specialized"
     """Disable warp specialization optimization. Default: False"""
 
+    TL_CPU_ARCH = "tl.cpu_arch"
+    """CPU architecture-family selector.
+
+    Typical values include:
+    - "riscv"
+    - "x86_64"
+    - "aarch64"
+
+    This key identifies the CPU family only. It must not be used to encode
+    ISA extensions such as RVV or AME.
+    """
+
     TL_ENABLE_FAST_MATH = "tl.enable_fast_math"
     """
         Enable fast math optimization. Default: False


### PR DESCRIPTION
## Summary
  This PR adds `tl.cpu_arch` pass-config plumbing for CPU lowering.
  It makes `tl.cpu_arch`:
  - a registered pass-config key
  - available through `tilelang.lower(..., pass_configs=...)`
  - available through function-level `tilelang_pass_configs`
  - observable from CPU lowering via a C++ helper
  It also preserves ambient `PassContext` semantics by merging configs into the current active context instead of creating a nested
  pass-context scope.
  ## Notes
  This PR is plumbing only.
  It does not change existing CPU codegen behavior. In particular, scalar CPU codegen remains unchanged with or without `tl.cpu_arch`.
  ## Validation
  Covered by focused CPU tests for:
  - explicit `pass_configs` input
  - function-level pass-config attrs
  - `IRModule` inputs
  - multi-function conflict / override handling
  - `PassContext` instrument preservation
  - CPU-only C++ visibility of `tl.cpu_arch`
  - legacy `tilelang.lower(..., runtime_only)` positional compatibility
  Also verified against the existing CPU baseline:
  - `testing/python/cpu/test_tilelang_cpu_tgemm.py::test_codegen_basic`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Lowering accepts explicit pass_configs including a new CPU-architecture key to select a target CPU family; configs are normalized, merged with outer context, validated, and can be scoped for temporary overrides.
  * Runtime helpers let lowering detect CPU targets and observe the configured CPU arch.

* **Tests**
  * Added comprehensive tests for CPU-arch configs, merge/precedence rules, observability during lowering, annotated vs. explicit overrides, and related error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->