### PR TITLE
[Refactor] Move target gating into InjectFenceProxy pass entry

### DIFF
--- a/src/transform/inject_fence_proxy.cc
+++ b/src/transform/inject_fence_proxy.cc
@@ -19,6 +19,7 @@
 #include "tir/transforms/ir_utils.h"
 
 #include "../op/builtin.h"
+#include "../target/utils.h"
 
 namespace tvm {
 namespace tl {
@@ -536,8 +537,15 @@ private:
 
 tvm::transform::Pass InjectFenceProxy() {
   auto pass_func = [](PrimFunc f, const IRModule &, const PassContext &) {
-    f = ProxyFenceRewriter::Apply(f);
-    return f;
+    // fence.proxy.async is only meaningful on CUDA targets that expose the
+    // TMA / async-proxy programming model (sm_90+). On anything else the
+    // rewriter has no work to do, so skip it to keep the pipeline target-
+    // agnostic at its call sites.
+    auto target_opt = f->GetAttr<Target>(tvm::attr::kTarget);
+    if (!target_opt.defined() || !TargetHasBulkCopy(target_opt.value())) {
+      return f;
+    }
+    return ProxyFenceRewriter::Apply(f);
   };
   return tir::transform::CreatePrimFuncPass(pass_func, 0, "tl.InjectFenceProxy",
                                             {});

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -28,10 +28,6 @@ def module_has_tma(mod: IRModule) -> bool:
     return any(func.attrs and func.attrs.get("tl.has_tma", False) for _, func in mod.functions.items())
 
 
-def allow_fence_proxy(target: Target | None = None) -> bool:
-    return have_tma(target)
-
-
 def allow_vectorize(pass_ctx: PassContext | None = None) -> bool:
     if pass_ctx is None:
         pass_ctx = tilelang.transform.get_pass_context()
@@ -286,13 +282,9 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
     # because the merged allocation site is at the beginning of each device function
     enable_aggressive_merge = should_enable_aggressive_merge(pass_ctx=pass_ctx, target=target)
     mod = tilelang.transform.MergeSharedMemoryAllocations(enable_aggressive_merge=enable_aggressive_merge)(mod)
-    if allow_warp_specialized(pass_ctx=pass_ctx, target=target):
-        mod = tilelang.transform.InjectFenceProxy()(mod)
-    else:
-        if allow_fence_proxy(target=target):
-            # in hopper device, wgmma is an async proxy
-            # so we need to inject a fence proxy before it
-            mod = tilelang.transform.InjectFenceProxy()(mod)
+    # InjectFenceProxy is a no-op on targets that lack the TMA / async-proxy
+    # programming model; the pass itself checks the PrimFunc's target.
+    mod = tilelang.transform.InjectFenceProxy()(mod)
     mod = tilelang.transform.ThreadSync("shared")(mod)
     mod = tilelang.transform.ThreadSync("shared.dyn")(mod)
     mod = tilelang.transform.MergeIfStmt()(mod)


### PR DESCRIPTION
## Summary
- `InjectFenceProxy` now reads the `PrimFunc`'s target at the pass entry and becomes a no-op when the hardware lacks the TMA / async-proxy programming model (non-CUDA or pre-sm_90). The hardware precondition is an intrinsic property of the pass, so it belongs with the pass rather than being duplicated at every call site.
- `tilelang/engine/phase.py` drops the redundant `allow_warp_specialized` / `allow_fence_proxy` branching around `InjectFenceProxy()`. Both branches previously invoked the same pass, so the whole if/else collapsed into a single unconditional call. The now-unused `allow_fence_proxy` helper is removed.

## Motivation
The former call site looked like this:

```python
if allow_warp_specialized(pass_ctx=pass_ctx, target=target):
    mod = tilelang.transform.InjectFenceProxy()(mod)
else:
    if allow_fence_proxy(target=target):
        mod = tilelang.transform.InjectFenceProxy()(mod)
```

Both predicates ultimately reduced to `have_tma(target)`, so the if/else encoded no real decision — it just made the intent harder to read and tied a hardware check to a warp-specialization flag that has no bearing on whether `fence.proxy.async` is required. Pushing the target check into the pass keeps the scheduling layer target-agnostic and mirrors how other Hopper-era passes (e.g. `LowerPTXAsyncCopy`) gate themselves.

## Test plan
- [ ] CI build + unit tests on CUDA sm_90 (Hopper) to confirm `fence.proxy.async` is still injected where required.
- [ ] CI build on a non-TMA target (e.g. Ampere) to confirm the pass is now a clean no-op and nothing else in the lowering pipeline regresses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal compilation pass logic to improve code maintainability and simplify conditional execution flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->