### PR TITLE
add gfx950 new feature, 160K LDS and copy async support 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,13 +33,10 @@ dependencies = [
     "apache-tvm-ffi~=0.1.0,>=0.1.2,<0.1.10",
     # torch-c-dlpack-ext provides prebuilt torch extensions.
     # Without it, TVM FFI may require JIT compilation on first import.
-    "torch-c-dlpack-ext; python_version < '3.14'",
     "cloudpickle",
     "ml-dtypes",
     "numpy>=1.23.5",
     "psutil",
-    "torch",
-    "torch>=2.4; platform_system == 'Darwin'",
     # jit-compiling a torch extension needs setuptools
     "setuptools; platform_system == 'Darwin'",
     "tqdm>=4.62.3",

--- a/src/tl_templates/hip/copy.h
+++ b/src/tl_templates/hip/copy.h
@@ -80,12 +80,13 @@ CK_TILE_DEVICE void async_buffer_load_dwordx4_v(void *smem, int32x4_t rsrc,
                                                 index_t voffset) {
   auto const lds_ptr_sgpr =
       __builtin_amdgcn_readfirstlane((reinterpret_cast<uintptr_t>(smem)));
-  asm volatile("s_mov_b32 m0, %0; \n\t"
-               "buffer_load_dwordx4 %1, %2, 0 offen lds;\n\t" ::"s"(lds_ptr_sgpr),
-               "v"(voffset), "s"(rsrc)
-               : "memory");
+  asm volatile(
+      "s_mov_b32 m0, %0; \n\t"
+      "buffer_load_dwordx4 %1, %2, 0 offen lds;\n\t" ::"s"(lds_ptr_sgpr),
+      "v"(voffset), "s"(rsrc)
+      : "memory");
 }
-#endif  // __gfx950__
+#endif // __gfx950__
 
 template <int N>
 TL_DEVICE void cp_async_gs(void *lds_base_ptr, void const *global_base_ptr) {

--- a/src/tl_templates/hip/copy.h
+++ b/src/tl_templates/hip/copy.h
@@ -72,10 +72,34 @@ CK_TILE_DEVICE void async_buffer_load_dword_v(void *smem, int32x4_t rsrc,
                : "memory");
 }
 
+// gfx950 (CDNA4 / MI350): 128-bit direct-to-LDS async load.
+// buffer_load_dwordx4 ... lds bypasses VGPRs entirely, giving 4x the
+// bandwidth of the 32-bit path and overlapping with MFMA computation.
+#if defined(__gfx950__)
+CK_TILE_DEVICE void async_buffer_load_dwordx4_v(void *smem, int32x4_t rsrc,
+                                                index_t voffset) {
+  auto const lds_ptr_sgpr =
+      __builtin_amdgcn_readfirstlane((reinterpret_cast<uintptr_t>(smem)));
+  asm volatile("s_mov_b32 m0, %0; \n\t"
+               "buffer_load_dwordx4 %1, %2, 0 offen lds;\n\t" ::"s"(lds_ptr_sgpr),
+               "v"(voffset), "s"(rsrc)
+               : "memory");
+}
+#endif  // __gfx950__
+
 template <int N>
 TL_DEVICE void cp_async_gs(void *lds_base_ptr, void const *global_base_ptr) {
   if constexpr (N == 16) {
+#if defined(__gfx950__)
+    // gfx950: use 128-bit direct-to-LDS async copy (buffer_load_dwordx4 lds)
+    async_buffer_load_dwordx4_v(
+        lds_base_ptr,
+        make_wave_buffer_resource(((const int32_t *)global_base_ptr) -
+                                  threadIdx.x),
+        threadIdx.x * N /*16 bytes*/);
+#else
     *(uint4 *)lds_base_ptr = *(const uint4 *)global_base_ptr;
+#endif
   } else if constexpr (N == 8) {
     *(uint2 *)lds_base_ptr = *(const uint2 *)global_base_ptr;
   } else if constexpr (N == 4) {
@@ -91,8 +115,21 @@ template <int N>
 TL_DEVICE void cp_async_gs_conditional(void *lds_base_ptr,
                                        void const *global_base_ptr, bool cond) {
   if constexpr (N == 16) {
+#if defined(__gfx950__)
+    // gfx950: use 128-bit direct-to-LDS async copy (buffer_load_dwordx4 lds)
+    if (cond) {
+      async_buffer_load_dwordx4_v(
+          lds_base_ptr,
+          make_wave_buffer_resource(((const int32_t *)global_base_ptr) -
+                                    threadIdx.x),
+          threadIdx.x * N /*16 bytes*/);
+    } else {
+      *(uint4 *)lds_base_ptr = make_uint4(0, 0, 0, 0);
+    }
+#else
     *(uint4 *)lds_base_ptr =
         cond ? *(const uint4 *)global_base_ptr : make_uint4(0, 0, 0, 0);
+#endif
   } else if constexpr (N == 8) {
     *(uint2 *)lds_base_ptr =
         cond ? *(const uint2 *)global_base_ptr : make_uint2(0, 0);

--- a/tilelang/carver/arch/cdna.py
+++ b/tilelang/carver/arch/cdna.py
@@ -23,7 +23,7 @@ class CDNA(TileDevice):
         self.device: tvm.runtime.Device = device
         self.platform: str = "CDNA"
 
-        # TVM runtime hould orrectly report 160 KB (163840 B) for gfx950; the
+        # TVM runtime should orrectly report 160 KB (163840 B) for gfx950; the
         # override is kept as a safety net in case an older driver reports the
         # conservative 64 KB default.
         mcpu = str(target.attrs.get("mcpu", ""))

--- a/tilelang/carver/arch/cdna.py
+++ b/tilelang/carver/arch/cdna.py
@@ -3,6 +3,10 @@ import tvm
 from tvm.target import Target
 from .arch_base import TileDevice
 
+# LDS size per CU for specific AMD GPU architectures (in bytes).
+# gfx950 (CDNA4 / MI350): 160 KB — larger than the 64 KB default for gfx942.
+_GFX950_LDS_SIZE = 160 * 1024  # 163840 bytes
+
 
 def is_cdna_arch(arch: TileDevice) -> bool:
     return isinstance(arch, CDNA)
@@ -18,7 +22,17 @@ class CDNA(TileDevice):
             raise RuntimeError("Cannot find HIP device 0.")
         self.device: tvm.runtime.Device = device
         self.platform: str = "CDNA"
-        self.smem_cap = device.max_shared_memory_per_block
+
+        # TVM runtime hould orrectly report 160 KB (163840 B) for gfx950; the
+        # override is kept as a safety net in case an older driver reports the
+        # conservative 64 KB default.
+        mcpu = str(target.attrs.get("mcpu", ""))
+        reported = device.max_shared_memory_per_block
+        if "gfx950" in mcpu and reported < _GFX950_LDS_SIZE:
+            self.smem_cap = _GFX950_LDS_SIZE
+        else:
+            self.smem_cap = reported
+
         self.compute_max_core = device.multi_processor_count
         self.warp_size = device.warp_size
         self.compute_capability = device.compute_version.replace(".", "")


### PR DESCRIPTION
HI TileLang Team

This PR includes two gfx950/mi350 related feature, 160K shared memory and copy.async support. 
please check it.

Thanks 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed automatic installation of certain PyTorch-related packages and conditional pins, reducing automatic runtime dependencies during install.

* **Performance**
  * Improved shared memory handling for GFX950 GPUs to better respect device limits.
  * Added a direct async buffer load path for GFX950 hardware to improve data transfer efficiency and conditional zeroing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->