### PR TITLE
[Bugfix] Use shared::cta instead of shared::cluster for non-cluster T…

### DIFF
--- a/src/target/ptx.cc
+++ b/src/target/ptx.cc
@@ -1429,7 +1429,7 @@ std::string PrintCpAsyncBulkAsm(const std::string &shared_ptr,
     unsigned int smem_addr_int = cast_smem_ptr_to_int({smem_addr});
     unsigned int barrier_addr_int = cast_smem_ptr_to_int({barrier});
     __asm__ __volatile__(
-      "cp.async.bulk.shared::cluster.global.mbarrier::complete_tx::bytes [%0], [%1], %2, [%3];"
+      "cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes [%0], [%1], %2, [%3];"
       :: "r"(smem_addr_int), "l"({global_ptr}), "r"({bytes}), "r"(barrier_addr_int)
       : "memory"
     );

--- a/src/tl_templates/cuda/copy_sm90.h
+++ b/src/tl_templates/cuda/copy_sm90.h
@@ -20,7 +20,7 @@ TL_DEVICE void tma_load(void *smem_ptr, void const *gmem_ptr,
   uint32_t smem_int_mbar =
       smem_ptr_to_uint(reinterpret_cast<uint64_t *>(&smem_mbar));
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
-  asm volatile("cp.async.bulk.shared::cluster.global.mbarrier::complete_tx::"
+  asm volatile("cp.async.bulk.shared::cta.global.mbarrier::complete_tx::"
                "bytes [%0], [%1], %2, [%3]; \n" ::"r"(smem_int_ptr),
                "l"((void const *)gmem_ptr), "r"(size), "r"(smem_int_mbar)
                :);
@@ -50,7 +50,7 @@ TL_DEVICE void tma_load(const CUtensorMap &descriptor, BarrierType &smem_mbar,
     smem_int_mbar = smem_ptr_to_uint(reinterpret_cast<uint64_t *>(&smem_mbar));
   }
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
-  asm volatile("cp.async.bulk.tensor.1d.shared::cluster.global.mbarrier::"
+  asm volatile("cp.async.bulk.tensor.1d.shared::cta.global.mbarrier::"
                "complete_tx::bytes.L2::cache_hint"
                " [%0], [%1, {%3}], [%2], %4;"
                :
@@ -72,7 +72,7 @@ TL_DEVICE void tma_load(const CUtensorMap &descriptor, BarrierType &smem_mbar,
     smem_int_mbar = smem_ptr_to_uint(reinterpret_cast<uint64_t *>(&smem_mbar));
   }
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
-  asm volatile("cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::"
+  asm volatile("cp.async.bulk.tensor.2d.shared::cta.global.mbarrier::"
                "complete_tx::bytes.L2::cache_hint"
                " [%0], [%1, {%3, %4}], [%2], %5;"
                :
@@ -94,7 +94,7 @@ TL_DEVICE void tma_load(const CUtensorMap &descriptor, BarrierType &smem_mbar,
     smem_int_mbar = smem_ptr_to_uint(reinterpret_cast<uint64_t *>(&smem_mbar));
   }
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
-  asm volatile("cp.async.bulk.tensor.3d.shared::cluster.global.mbarrier::"
+  asm volatile("cp.async.bulk.tensor.3d.shared::cta.global.mbarrier::"
                "complete_tx::bytes.L2::cache_hint"
                " [%0], [%1, {%3, %4, %5}], [%2], %6;"
                :
@@ -116,7 +116,7 @@ TL_DEVICE void tma_load(const CUtensorMap &descriptor, BarrierType &smem_mbar,
     smem_int_mbar = smem_ptr_to_uint(reinterpret_cast<uint64_t *>(&smem_mbar));
   }
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
-  asm volatile("cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::"
+  asm volatile("cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::"
                "complete_tx::bytes.L2::cache_hint"
                " [%0], [%1, {%3, %4, %5, %6}], [%2], %7;"
                :
@@ -139,7 +139,7 @@ TL_DEVICE void tma_load(const CUtensorMap &descriptor, BarrierType &smem_mbar,
     smem_int_mbar = smem_ptr_to_uint(reinterpret_cast<uint64_t *>(&smem_mbar));
   }
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
-  asm volatile("cp.async.bulk.tensor.5d.shared::cluster.global.mbarrier::"
+  asm volatile("cp.async.bulk.tensor.5d.shared::cta.global.mbarrier::"
                "complete_tx::bytes.L2::cache_hint"
                " [%0], [%1, {%3, %4, %5, %6, %7}], [%2], %8;"
                :
@@ -161,7 +161,7 @@ tma_load_im2col(const CUtensorMap &descriptor, BarrierType &smem_mbar,
   uint32_t smem_int_mbar =
       smem_ptr_to_uint(reinterpret_cast<uint64_t *>(&smem_mbar));
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
-  asm volatile("cp.async.bulk.tensor.4d.shared::cluster.global.im2col.mbarrier:"
+  asm volatile("cp.async.bulk.tensor.4d.shared::cta.global.im2col.mbarrier:"
                ":complete_tx::bytes.L2::cache_hint"
                " [%0], [%1, {%3, %4, %5, %6}], [%2], {%7, %8}, %9;"
                :


### PR DESCRIPTION
## Summary

On SM120 (RTX 5090), using `shared::cluster` in `cp.async.bulk` PTX instructions
without an actual cluster launch causes the NVIDIA driver to allocate ~3.5 GB of
extra device memory that persists for the CUDA context lifetime.

**Changes:**
- `copy_sm90.h`: replace `shared::cluster` with `shared::cta` in all 8
  `tma_load` / `tma_load_im2col` overloads. `tma_load_multicast` is unchanged
  (it correctly needs `shared::cluster.multicast::cluster`).
- `ptx.cc`: change `PrintCpAsyncBulkAsm` from `shared::cluster` to `shared::cta`.

## Root Cause

The NVIDIA driver provisions internal data structures for cluster coordination
(DSMEM, cross-CTA barriers) when it encounters `shared::cluster` address space
qualifiers, even when `cluster_size=1`. On SM120 this costs ~3.5 GB.

Minimal repro (pure CUDA, no tilelang dependency):
https://gist.github.com/Harry-Chen/38c0f47ce3eff4469db4a310e763e949

## Why `shared::cta` is Correct

- `shared::cta` = "address targets the calling CTA's shared memory" — always valid
- `shared::cluster` = "address may target any CTA's shared memory in the cluster"
  — only needed for cross-CTA DSMEM or multicast

TileLang's `tma_load` always loads into the **local CTA's own shared memory**.
It never does remote DSMEM writes. Therefore `shared::cta` is semantically
correct on both SM90 (Hopper) and SM120 (Blackwell).

## TMA Codegen Pipeline Context

TileLang has two paths that emit `cp.async.bulk` PTX:

```
Path 1 (main):  T.copy → copy.cc LowerBulkCopy → tl.tma_load IR
                → codegen_cuda.cc emits tl::tma_load(...)
                → copy_sm90.h inline asm

Path 2 (rare):  tir.ptx_cp_async_bulk → codegen_cuda.cc
                → ptx.cc PrintCpAsyncBulkAsm → inline asm
```

Both paths previously hardcoded `shared::cluster`. This PR fixes both.

## Cluster Support Status

TileLang has nascent cluster support (`T.Kernel(cluster_dims=...)`,
`cluster_arrive/wait/sync`), but it only affects **launch config**, not TMA
address space selection. The codegen pipeline does not thread `cluster_dims`
through to `tma_load` instruction emission.

`tma_load_multicast` exists in `copy_sm90.h` as a C++ template but is **not
wired into the codegen** — there is no `tl::tma_load_multicast` IR op and
`codegen_cuda.cc` never emits calls to it.

When cluster-aware TMA (e.g., multicast for GEMM A-matrix broadcast) is
implemented in the future, it will need to:
1. Thread `cluster_dims` from kernel annotations through `copy.cc` lowering
2. Add a `tl::tma_load_multicast` IR op and codegen path
3. The existing `tma_load_multicast` C++ template is ready for that

This fix does not block any future cluster work.

## Results (RTX 5090, SM120)

| Metric | Before | After |
|--------|--------|-------|
| Memory overhead | 3506 MiB | **0 MiB** |
| FP8 GEMM TFLOPS (8192^3) | 404 | 405 |
| Correctness | cosine diff ~3e-6 | unchanged |
| SASS size | 7514 lines | 6722 lines (-10.5%) |
| SASS syscall | `__cuda_syscall_cp_async_bulk_tensor_2d_tile_unicast` | **eliminated** |

## Test plan

- [x] FP8 blockwise GEMM correctness (cosine diff ~3e-6 vs torch._scaled_mm)
- [x] Performance unchanged (405 TFLOPS)
- [x] SASS verified: unicast syscall eliminated, direct UTMALDG.2D instructions
- [x] Pure CUDA minimal repro: shared::cta = 0 overhead, shared::cluster = +3.5 GB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified GPU memory barrier synchronization scope in bulk copy operations for SM90 architecture, updating coordination behavior for asynchronous memory transfers between global and shared memory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->