### PR TITLE
[BugFix] Keep shared-prelude local vars in producer-consumer WS

### DIFF
--- a/examples/grouped_gemm/test_example_grouped_gemm.py
+++ b/examples/grouped_gemm/test_example_grouped_gemm.py
@@ -1,0 +1,60 @@
+import tilelang.testing
+
+import example_grouped_gemm_bwd
+import example_grouped_gemm_fwd
+import example_grouped_gemm_fwd_ptr
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(9, 0)
+def test_example_grouped_gemm_fwd_small():
+    example_grouped_gemm_fwd.run_tilelang_grouped_gemm(
+        [5, 9, 13],
+        K=64,
+        M=96,
+        block_M=64,
+        block_N=64,
+        block_K=32,
+        trans_b=False,
+        num_stages=2,
+        threads=256,
+        profile=False,
+    )
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(9, 0)
+def test_example_grouped_gemm_fwd_ptr_small():
+    example_grouped_gemm_fwd_ptr.run_tilelang_grouped_gemm_ptr(
+        [5, 9, 13],
+        K=64,
+        N=96,
+        block_M=64,
+        block_N=64,
+        block_K=32,
+        num_stages=1,
+        threads=256,
+        backend="tvm_ffi",
+        profile=False,
+    )
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(9, 0)
+def test_example_grouped_gemm_bwd_small():
+    example_grouped_gemm_bwd.run_tilelang_grouped_gemm(
+        [5, 9, 13],
+        K=64,
+        M=96,
+        block_M=64,
+        block_N=64,
+        block_K=32,
+        trans_b=False,
+        num_stages=2,
+        threads=256,
+        profile=False,
+    )
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/src/transform/producer_consumer_ws.cc
+++ b/src/transform/producer_consumer_ws.cc
@@ -2087,7 +2087,8 @@ private:
         for (int i = loop_idx - 1; i >= 0; --i) {
           LocalAccessSummary summary = LocalAccessCollector::Collect(
               seq->seq[i], buffer_data_to_buffer_);
-          if (!summary.HasTrackedDefs()) continue;
+          if (!summary.HasTrackedDefs())
+            continue;
           if (producer_live.NeedsAnyDef(summary)) {
             producer_live.AddUses(summary);
           }
@@ -2103,10 +2104,9 @@ private:
       // move next to the branch that consumes them, or are duplicated when
       // both producer and consumer need the same definition.
       for (int i = 0; i < loop_idx; ++i) {
-        switch (ClassifyPreludeStmt(seq->seq[i], buffer_data_to_buffer_,
-                                    shared_prelude_live_seed_,
-                                    producer_prelude_live_seed_,
-                                    consumer_prelude_live_seed_)) {
+        switch (ClassifyPreludeStmt(
+            seq->seq[i], buffer_data_to_buffer_, shared_prelude_live_seed_,
+            producer_prelude_live_seed_, consumer_prelude_live_seed_)) {
         case PreludeStmtPlacement::kProducerOnly:
           extracted_producer_init_.push_back(seq->seq[i]);
           break;

--- a/src/transform/producer_consumer_ws.cc
+++ b/src/transform/producer_consumer_ws.cc
@@ -527,10 +527,15 @@ enum class PreludeStmtPlacement : uint8_t {
 
 static PreludeStmtPlacement
 ClassifyPreludeStmt(const Stmt &stmt, const BufferDataToBufferMap &buffer_map,
+                    const LocalLiveSet &shared_live_seed,
                     const LocalLiveSet &producer_live_seed,
                     const LocalLiveSet &consumer_live_seed) {
   LocalAccessSummary summary = LocalAccessCollector::Collect(stmt, buffer_map);
   if (!summary.HasTrackedDefs()) {
+    return PreludeStmtPlacement::kKeepSharedPrelude;
+  }
+
+  if (shared_live_seed.NeedsAnyDef(summary)) {
     return PreludeStmtPlacement::kKeepSharedPrelude;
   }
 
@@ -1687,6 +1692,7 @@ private:
     // Consumer: threadIdx.x stays, but extent is consumer_extent
     Stmt rewritten_consumer = final_consumer_loop;
 
+    shared_prelude_live_seed_ = {};
     producer_prelude_live_seed_ = {};
     consumer_prelude_live_seed_ = {};
     producer_prelude_live_seed_.AddUses(LocalAccessCollector::Collect(
@@ -1735,7 +1741,7 @@ private:
       }
       auto maybe_clone = [&](const Buffer &buffer) {
         if (!buffer.defined() ||
-            !(IsFragmentBuffer(buffer) || IsLocalBuffer(buffer, true)) ||
+            !(IsFragmentBuffer(buffer) || IsLocalBuffer(buffer)) ||
             !block_alloc_buffers.count(buffer.get()) ||
             producer_buffer_remap.count(buffer.get())) {
           return;
@@ -2070,12 +2076,35 @@ private:
       if (loop_idx < 0) {
         return {stmt, false};
       }
+      // Propagate liveness backwards through prelude statements so that
+      // transitive dependencies are captured.  For example, if consumer
+      // needs `m_start` and `m_start` is defined by a prelude statement
+      // that reads `cur_batch_idx`, the loop defining `cur_batch_idx`
+      // must also be visible to the consumer.
+      {
+        LocalLiveSet producer_live = producer_prelude_live_seed_;
+        LocalLiveSet consumer_live = consumer_prelude_live_seed_;
+        for (int i = loop_idx - 1; i >= 0; --i) {
+          LocalAccessSummary summary = LocalAccessCollector::Collect(
+              seq->seq[i], buffer_data_to_buffer_);
+          if (!summary.HasTrackedDefs()) continue;
+          if (producer_live.NeedsAnyDef(summary)) {
+            producer_live.AddUses(summary);
+          }
+          if (consumer_live.NeedsAnyDef(summary)) {
+            consumer_live.AddUses(summary);
+          }
+        }
+        producer_prelude_live_seed_ = producer_live;
+        consumer_prelude_live_seed_ = consumer_live;
+      }
       // Classify pre-loop statements using branch-private def/use sets.
       // Shared-prelude statements stay in place; branch-private definitions
       // move next to the branch that consumes them, or are duplicated when
       // both producer and consumer need the same definition.
       for (int i = 0; i < loop_idx; ++i) {
         switch (ClassifyPreludeStmt(seq->seq[i], buffer_data_to_buffer_,
+                                    shared_prelude_live_seed_,
                                     producer_prelude_live_seed_,
                                     consumer_prelude_live_seed_)) {
         case PreludeStmtPlacement::kProducerOnly:
@@ -2109,6 +2138,18 @@ private:
       return {new_seq.size() == 1 ? new_seq[0] : SeqStmt(new_seq), true};
     }
     if (auto *let = stmt.as<LetStmtNode>()) {
+      // The LetStmt value is evaluated in the shared prelude (outside
+      // both producer and consumer branches).  If it reads branch-private
+      // buffers or vars defined by a prelude statement, that definition
+      // must remain available in the shared scope.  Propagate such uses
+      // into both live seeds before visiting the body so the upstream
+      // prelude-statement classifier sees them when classifying the
+      // surrounding SeqStmt.
+      {
+        LocalAccessSummary val_summary = LocalAccessCollector::Collect(
+            Evaluate(let->value), buffer_data_to_buffer_);
+        shared_prelude_live_seed_.AddUses(val_summary);
+      }
       ReplaceResult result = ReplacePipelineLoopInStmt(
           let->body, pipeline_loop, ws_body, consumer_extent);
       if (!result.found) {
@@ -2186,6 +2227,7 @@ private:
   bool ws_transformed_{false};
   BufferDataToBufferMap buffer_data_to_buffer_;
   std::unordered_map<const StmtNode *, Stmt> common_prelude_rewrites_;
+  LocalLiveSet shared_prelude_live_seed_;
   LocalLiveSet producer_prelude_live_seed_;
   LocalLiveSet consumer_prelude_live_seed_;
   Array<Stmt> extracted_producer_init_;

--- a/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
+++ b/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
@@ -114,6 +114,122 @@ def prelude_tma_wait_sink(block=64, iters=2, dtype="float16", threads=128):
     return main
 
 
+def grouped_gemm_padded_pipelined(
+    batch_sizes,
+    K,
+    N,
+    block_M=64,
+    block_N=64,
+    block_K=32,
+    num_stages=2,
+    threads=256,
+    dtype="float16",
+):
+    """Grouped GEMM with padded M tiles to exercise WS shared-prelude local vars."""
+
+    batch_sizes = tuple(batch_sizes)
+    batch_count = len(batch_sizes)
+    batch_sum = sum(batch_sizes)
+    total_m_blocks = sum((size + block_M - 1) // block_M for size in batch_sizes)
+
+    @T.prim_func
+    def main(
+        A: T.Buffer((batch_sum, K), dtype),
+        B: T.Buffer((batch_count, K, N), dtype),
+        C: T.Buffer((batch_sum, N), dtype),
+        batch_sizes_buf: T.Buffer((batch_count,), "int32"),
+        batch_offsets: T.Buffer((batch_count,), "int32"),
+        batch_padded_offsets: T.Buffer((batch_count,), "int32"),
+    ):
+        with T.Kernel(total_m_blocks, T.ceildiv(N, block_N), threads=threads) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), dtype)
+            B_shared = T.alloc_shared((block_K, block_N), dtype)
+            C_local = T.alloc_fragment((block_M, block_N), "float32")
+            cur_batch_idx = T.alloc_var("int32")
+            cur_batch_size = T.alloc_var("int32")
+
+            m_start_padded = bx * block_M
+            for i in range(batch_count):
+                in_cur_batch_idx = m_start_padded >= batch_padded_offsets[i]
+                cur_batch_idx = T.if_then_else(in_cur_batch_idx, i, cur_batch_idx)
+
+            cur_batch_size = batch_sizes_buf[cur_batch_idx]
+            m_start = m_start_padded - batch_padded_offsets[cur_batch_idx] + batch_offsets[cur_batch_idx]
+            actual_rows = T.max(
+                0,
+                T.min(block_M, cur_batch_size + batch_padded_offsets[cur_batch_idx] - m_start_padded),
+            )
+
+            T.clear(C_local)
+            for ko in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
+                T.copy(A[m_start, ko * block_K], A_shared)
+                T.copy(B[cur_batch_idx, ko * block_K, by * block_N], B_shared)
+                T.gemm(A_shared, B_shared, C_local)
+
+            for i, j in T.Parallel(block_M, block_N):
+                if i < actual_rows:
+                    C[m_start + i, by * block_N + j] = C_local[i, j]
+
+    return main
+
+
+def grouped_gemm_reference(A, B, batch_sizes):
+    import torch
+
+    outputs = []
+    start = 0
+    for idx, size in enumerate(batch_sizes):
+        end = start + size
+        outputs.append(torch.mm(A[start:end], B[idx]))
+        start = end
+    return torch.cat(outputs, dim=0)
+
+
+def grouped_gemm_inputs(batch_sizes, K, N, block_M, dtype="float16"):
+    import math
+    import torch
+
+    batch_sizes = list(batch_sizes)
+    batch_offsets = [0]
+    batch_padded_offsets = [0]
+    for i in range(len(batch_sizes) - 1):
+        batch_offsets.append(batch_offsets[-1] + batch_sizes[i])
+        batch_padded_offsets.append(
+            batch_padded_offsets[-1] + math.ceil(batch_sizes[i] / block_M) * block_M
+        )
+
+    A = torch.randn(sum(batch_sizes), K, dtype=getattr(torch, dtype), device="cuda")
+    B = torch.randn(len(batch_sizes), K, N, dtype=getattr(torch, dtype), device="cuda")
+    batch_sizes_t = torch.tensor(batch_sizes, dtype=torch.int32, device="cuda")
+    batch_offsets_t = torch.tensor(batch_offsets, dtype=torch.int32, device="cuda")
+    batch_padded_offsets_t = torch.tensor(batch_padded_offsets, dtype=torch.int32, device="cuda")
+    return A, B, batch_sizes_t, batch_offsets_t, batch_padded_offsets_t
+
+
+def _find_after(src, needle, start=0):
+    pos = src.find(needle, start)
+    assert pos >= 0, f"missing substring: {needle}"
+    return pos
+
+
+def _compile_grouped_gemm_ws(batch_sizes=(63, 77), K=128, N=128, block_M=64, block_N=64, block_K=32):
+    pass_configs = {tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: False}
+    func = grouped_gemm_padded_pipelined(batch_sizes, K, N, block_M, block_N, block_K)
+    kernel = _compile_tvm_ffi(func, pass_configs, out_idx=[2])
+    return kernel, batch_sizes
+
+
+def _run_grouped_gemm_ws(kernel, batch_sizes, K=128, N=128, block_M=64, dtype="float16"):
+    import torch
+
+    A, B, batch_sizes_t, batch_offsets_t, batch_padded_offsets_t = grouped_gemm_inputs(
+        batch_sizes, K, N, block_M, dtype
+    )
+    out = kernel(A, B, batch_sizes_t, batch_offsets_t, batch_padded_offsets_t)
+    ref = grouped_gemm_reference(A.float(), B.float(), batch_sizes)
+    torch.testing.assert_close(out.float(), ref, rtol=1e-2, atol=1e-2)
+    return out
+
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version(9, 0)
 def test_tiled_ws_stage1_dynamic_loop_start():
@@ -318,6 +434,36 @@ def test_tiled_ws_sinks_preloop_tma_waits_into_consumer():
     assert k_load < v_load < branch < first_wait
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(9, 0)
+def test_tiled_ws_keeps_shared_prelude_local_vars_for_grouped_gemm():
+    """Shared-prelude grouped-gemm indices must stay outside WS branches."""
+    kernel, batch_sizes = _compile_grouped_gemm_ws()
+    src = kernel.get_kernel_source()
+
+    branch = _find_after(src, "if (256 <= ((int)threadIdx.x))")
+    cur_batch_idx_loop = _find_after(src, "for (int i = 0; i < 2; ++i)")
+    m_start = _find_after(src, "int m_start =")
+    actual_rows = _find_after(src, "int actual_rows =")
+
+    assert cur_batch_idx_loop < m_start < actual_rows < branch
+    _run_grouped_gemm_ws(kernel, batch_sizes)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(9, 0)
+def test_tiled_ws_does_not_clone_local_var_into_producer_branch():
+    """Producer branch should reuse shared local.var state instead of cloning it."""
+    kernel, batch_sizes = _compile_grouped_gemm_ws()
+    src = kernel.get_kernel_source()
+
+    assert "cur_batch_idx_producer_ws" not in src
+    assert "cur_batch_size_producer_ws" not in src
+    assert "tl::tma_load(B_desc" in src
+    assert "cur_batch_idx);" in src
+    _run_grouped_gemm_ws(kernel, batch_sizes)
+
+
 if __name__ == "__main__":
     test_tiled_ws_stage1_dynamic_loop_start()
     test_tiled_ws_correctness()
@@ -325,3 +471,5 @@ if __name__ == "__main__":
     test_tiled_ws_swizzled_layout_allows_ws()
     test_tiled_ws_incompatible_layout_blocks_ws()
     test_tiled_ws_sinks_preloop_tma_waits_into_consumer()
+    test_tiled_ws_keeps_shared_prelude_local_vars_for_grouped_gemm()
+    test_tiled_ws_does_not_clone_local_var_into_producer_branch()

--- a/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
+++ b/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
@@ -194,9 +194,7 @@ def grouped_gemm_inputs(batch_sizes, K, N, block_M, dtype="float16"):
     batch_padded_offsets = [0]
     for i in range(len(batch_sizes) - 1):
         batch_offsets.append(batch_offsets[-1] + batch_sizes[i])
-        batch_padded_offsets.append(
-            batch_padded_offsets[-1] + math.ceil(batch_sizes[i] / block_M) * block_M
-        )
+        batch_padded_offsets.append(batch_padded_offsets[-1] + math.ceil(batch_sizes[i] / block_M) * block_M)
 
     A = torch.randn(sum(batch_sizes), K, dtype=getattr(torch, dtype), device="cuda")
     B = torch.randn(len(batch_sizes), K, N, dtype=getattr(torch, dtype), device="cuda")
@@ -222,13 +220,12 @@ def _compile_grouped_gemm_ws(batch_sizes=(63, 77), K=128, N=128, block_M=64, blo
 def _run_grouped_gemm_ws(kernel, batch_sizes, K=128, N=128, block_M=64, dtype="float16"):
     import torch
 
-    A, B, batch_sizes_t, batch_offsets_t, batch_padded_offsets_t = grouped_gemm_inputs(
-        batch_sizes, K, N, block_M, dtype
-    )
+    A, B, batch_sizes_t, batch_offsets_t, batch_padded_offsets_t = grouped_gemm_inputs(batch_sizes, K, N, block_M, dtype)
     out = kernel(A, B, batch_sizes_t, batch_offsets_t, batch_padded_offsets_t)
     ref = grouped_gemm_reference(A.float(), B.float(), batch_sizes)
     torch.testing.assert_close(out.float(), ref, rtol=1e-2, atol=1e-2)
     return out
+
 
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version(9, 0)


### PR DESCRIPTION
#2054 

- Preserve prelude definitions needed by shared LetStmt values during warp-specialized pipeline rewriting
- Avoid cloning local.var buffers into the producer branch. This keeps grouped GEMM batch index calculations shared and fixes incorrect TMA batch selection.

This fixes the previously failed grouped gemm fwd example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pipeline prelude liveness so shared prelude variables are preserved when needed and branch-local buffers are less aggressively cloned.

* **Tests**
  * Added CUDA-gated grouped-GEMM tests validating correctness, shared-prelude ordering, and that producer-branch cloning does not occur.
  * Added transform tests that compile/run workloads with workspace optimizations to assert placement and behavior of shared prelude variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->