### PR TITLE
[Cache] Refactor cache namespace layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,7 @@ jobs:
             pytest --verbose --color=yes --durations=0 --showlocals --cache-clear
           )
           "${PYTEST[@]}" --maxfail=3 --numprocesses=4 \
+            --ignore=../examples/grouped_gemm/test_example_grouped_gemm.py \
             ../examples
 
       # NVIDIA CUDA tests

--- a/examples/grouped_gemm/example_grouped_gemm_fwd_ptr.py
+++ b/examples/grouped_gemm/example_grouped_gemm_fwd_ptr.py
@@ -125,7 +125,7 @@ def run_tilelang_grouped_gemm_ptr(
     block_K,
     num_stages=2,
     threads=128,
-    backend="tvm_ffi",
+    backend="auto",
     profile=False,
 ):
     device = torch.device("cuda")
@@ -159,7 +159,13 @@ if __name__ == "__main__":
     parser.add_argument("--batch_sizes", type=str, default="64,128,256", help="comma-separated per-group M sizes")
     parser.add_argument("--K", type=int, default=4096, help="reduce dim")
     parser.add_argument("--N", type=int, default=4096, help="output dim")
-    parser.add_argument("--backend", type=str, default="tvm_ffi", choices=["tvm_ffi", "cython"], help="execution backend")
+    parser.add_argument(
+        "--backend",
+        type=str,
+        default="auto",
+        choices=["auto", "tvm_ffi", "cython", "nvrtc", "cutedsl"],
+        help="execution backend",
+    )
     parser.add_argument("--profile", action="store_true", help="benchmark the kernel")
     args = parser.parse_args()
 

--- a/examples/grouped_gemm/example_grouped_gemm_fwd_ptr.py
+++ b/examples/grouped_gemm/example_grouped_gemm_fwd_ptr.py
@@ -131,8 +131,11 @@ def run_tilelang_grouped_gemm_ptr(
     device = torch.device("cuda")
     dtype = torch.float16
     program = grouped_gemm_ptr(batch_sizes_list, K, N, block_M, block_N, block_K, num_stages, threads)
+    # The ptr-backed grouped GEMM example is intended to exercise the regular CUDA
+    # execution path; CuTeDSL does not support these handle tensors.
     kernel = tl.compile(
         program,
+        target="cuda",
         execution_backend=backend,
         pass_configs={"tl.disable_warp_specialized": True},
     )
@@ -163,7 +166,7 @@ if __name__ == "__main__":
         "--backend",
         type=str,
         default="auto",
-        choices=["auto", "tvm_ffi", "cython", "nvrtc", "cutedsl"],
+        choices=["auto", "tvm_ffi", "cython", "nvrtc"],
         help="execution backend",
     )
     parser.add_argument("--profile", action="store_true", help="benchmark the kernel")

--- a/examples/grouped_gemm/example_grouped_gemm_fwd_ptr.py
+++ b/examples/grouped_gemm/example_grouped_gemm_fwd_ptr.py
@@ -125,7 +125,6 @@ def run_tilelang_grouped_gemm_ptr(
     block_K,
     num_stages=2,
     threads=128,
-    backend="auto",
     profile=False,
 ):
     device = torch.device("cuda")
@@ -136,7 +135,7 @@ def run_tilelang_grouped_gemm_ptr(
     kernel = tl.compile(
         program,
         target="cuda",
-        execution_backend=backend,
+        execution_backend="auto",
         pass_configs={"tl.disable_warp_specialized": True},
     )
     a_list, b_list, c_list, a_ptrs, b_ptrs, c_ptrs, batch_tile_offsets = construct_inputs(batch_sizes_list, K, N, block_M, device, dtype)
@@ -162,13 +161,6 @@ if __name__ == "__main__":
     parser.add_argument("--batch_sizes", type=str, default="64,128,256", help="comma-separated per-group M sizes")
     parser.add_argument("--K", type=int, default=4096, help="reduce dim")
     parser.add_argument("--N", type=int, default=4096, help="output dim")
-    parser.add_argument(
-        "--backend",
-        type=str,
-        default="auto",
-        choices=["auto", "tvm_ffi", "cython", "nvrtc"],
-        help="execution backend",
-    )
     parser.add_argument("--profile", action="store_true", help="benchmark the kernel")
     args = parser.parse_args()
 
@@ -189,7 +181,6 @@ if __name__ == "__main__":
         block_K,
         num_stages=num_stages,
         threads=threads,
-        backend=args.backend,
         profile=args.profile,
     )
     print(f"End-to-end: {time.time() - t0:.3f} s")

--- a/examples/grouped_gemm/test_example_grouped_gemm.py
+++ b/examples/grouped_gemm/test_example_grouped_gemm.py
@@ -1,13 +1,8 @@
-import os
-import pytest
 import tilelang.testing
 
 import example_grouped_gemm_bwd
 import example_grouped_gemm_fwd
 import example_grouped_gemm_fwd_ptr
-
-_is_cutedsl = os.environ.get("TILELANG_TARGET", "").lower() == "cutedsl"
-pytestmark = pytest.mark.skipif(_is_cutedsl, reason="Grouped GEMM examples are not part of CuTeDSL coverage")
 
 
 @tilelang.testing.requires_cuda

--- a/examples/grouped_gemm/test_example_grouped_gemm.py
+++ b/examples/grouped_gemm/test_example_grouped_gemm.py
@@ -1,8 +1,13 @@
+import os
+import pytest
 import tilelang.testing
 
 import example_grouped_gemm_bwd
 import example_grouped_gemm_fwd
 import example_grouped_gemm_fwd_ptr
+
+_is_cutedsl = os.environ.get("TILELANG_TARGET", "").lower() == "cutedsl"
+pytestmark = pytest.mark.skipif(_is_cutedsl, reason="Grouped GEMM examples are not part of CuTeDSL coverage")
 
 
 @tilelang.testing.requires_cuda

--- a/examples/grouped_gemm/test_example_grouped_gemm.py
+++ b/examples/grouped_gemm/test_example_grouped_gemm.py
@@ -34,7 +34,6 @@ def test_example_grouped_gemm_fwd_ptr_small():
         block_K=32,
         num_stages=1,
         threads=256,
-        backend="auto",
         profile=False,
     )
 

--- a/examples/grouped_gemm/test_example_grouped_gemm.py
+++ b/examples/grouped_gemm/test_example_grouped_gemm.py
@@ -34,7 +34,7 @@ def test_example_grouped_gemm_fwd_ptr_small():
         block_K=32,
         num_stages=1,
         threads=256,
-        backend="tvm_ffi",
+        backend="auto",
         profile=False,
     )
 

--- a/testing/python/autotune/test_tilelang_autotune_atomic_save.py
+++ b/testing/python/autotune/test_tilelang_autotune_atomic_save.py
@@ -73,8 +73,8 @@ def _make_result(tmp_path, execution_backend: str = "cython"):
 
 def test_autotune_save_rewrites_incomplete_cache_dir(cache_dirs, tmp_path):
     result = _make_result(tmp_path)
-    path = cache_dirs / "autotune-entry"
-    path.mkdir()
+    path = cache_dirs / "test-namespace" / "autotuner" / "autotune-entry"
+    path.mkdir(parents=True)
     (path / "stale.txt").write_text("partial")
 
     result.save_to_disk(path)
@@ -94,8 +94,9 @@ def test_autotune_save_rewrites_incomplete_cache_dir(cache_dirs, tmp_path):
 
 def test_autotune_save_logs_write_oserror_instead_of_treating_it_as_race(cache_dirs, tmp_path, monkeypatch):
     result = _make_result(tmp_path)
-    path = cache_dirs / "autotune-error"
+    path = cache_dirs / "test-namespace" / "autotuner" / "autotune-error"
     logged = []
+    staging_root = path.parent.parent / ".staging"
 
     def raise_write_error(self, *args, **kwargs):
         raise OSError(errno.ENOSPC, "No space left on device")
@@ -110,14 +111,15 @@ def test_autotune_save_logs_write_oserror_instead_of_treating_it_as_race(cache_d
 
     assert not path.exists()
     assert "Error during atomic autotune result save" in logged
-    assert not any(child.name.startswith(".staging_") for child in cache_dirs.iterdir())
+    assert not staging_root.exists() or not any(staging_root.iterdir())
 
 
 def test_autotune_save_does_not_publish_incomplete_dir_when_device_source_is_missing(cache_dirs, tmp_path, monkeypatch):
     result = _make_result(tmp_path)
     result.kernel.kernel_source = None
-    path = cache_dirs / "autotune-missing-device-source"
+    path = cache_dirs / "test-namespace" / "autotuner" / "autotune-missing-device-source"
     logged = []
+    staging_root = path.parent.parent / ".staging"
 
     def record_exception(message, *args, **kwargs):
         logged.append(message)
@@ -128,13 +130,13 @@ def test_autotune_save_does_not_publish_incomplete_dir_when_device_source_is_mis
 
     assert not path.exists()
     assert "Error during atomic autotune result save" in logged
-    assert not any(child.name.startswith(".staging_") for child in cache_dirs.iterdir())
+    assert not staging_root.exists() or not any(staging_root.iterdir())
 
 
 def test_autotune_save_rewrites_nvrtc_dir_missing_launcher(cache_dirs, tmp_path):
     result = _make_result(tmp_path, execution_backend="nvrtc")
-    path = cache_dirs / "autotune-nvrtc-entry"
-    path.mkdir()
+    path = cache_dirs / "test-namespace" / "autotuner" / "autotune-nvrtc-entry"
+    path.mkdir(parents=True)
     (path / BEST_CONFIG_PATH).write_text("{}")
     (path / FUNCTION_PATH).write_bytes(b"old-func")
     (path / LATENCY_PATH).write_text('{"latency": 1.0, "ref_latency": 2.0}')

--- a/testing/python/cache/test_tilelang_kernel_cache_atomic_save.py
+++ b/testing/python/cache/test_tilelang_kernel_cache_atomic_save.py
@@ -1,4 +1,5 @@
 import errno
+from pathlib import Path
 import pytest
 
 from tilelang.cache.kernel_cache import KernelCache
@@ -48,8 +49,8 @@ def _make_fake_nvrtc_kernel(tmp_path):
 def test_kernel_cache_rewrites_incomplete_cache_dir(cache_dirs, tmp_path):
     cache = KernelCache()
     key = "atomic-repair"
-    cache_path = cache_dirs / key
-    cache_path.mkdir()
+    cache_path = Path(cache._get_cache_path(key))
+    cache_path.mkdir(parents=True)
     (cache_path / "stale.txt").write_text("partial")
 
     cache._save_kernel_to_disk(key, _make_fake_kernel(tmp_path))
@@ -65,6 +66,8 @@ def test_kernel_cache_logs_write_oserror_instead_of_treating_it_as_race(cache_di
     cache = KernelCache()
     key = "atomic-write-error"
     logged = []
+    cache_path = Path(cache._get_cache_path(key))
+    staging_root = Path(cache._get_staging_root())
 
     def raise_write_error(*args, **kwargs):
         raise OSError(errno.ENOSPC, "No space left on device")
@@ -77,9 +80,9 @@ def test_kernel_cache_logs_write_oserror_instead_of_treating_it_as_race(cache_di
 
     cache._save_kernel_to_disk(key, _make_fake_kernel(tmp_path))
 
-    assert f"{key}" not in {path.name for path in cache_dirs.iterdir()}
+    assert not cache_path.exists()
     assert "Error during atomic cache save" in logged
-    assert not any(path.name.startswith(".staging_") for path in cache_dirs.iterdir())
+    assert not staging_root.exists() or not any(staging_root.iterdir())
 
 
 def test_kernel_cache_does_not_publish_incomplete_dir_when_device_source_is_missing(cache_dirs, tmp_path, monkeypatch):
@@ -88,6 +91,8 @@ def test_kernel_cache_does_not_publish_incomplete_dir_when_device_source_is_miss
     kernel = _make_fake_kernel(tmp_path)
     kernel.kernel_source = None
     logged = []
+    cache_path = Path(cache._get_cache_path(key))
+    staging_root = Path(cache._get_staging_root())
 
     def record_exception(message, *args, **kwargs):
         logged.append(message)
@@ -96,16 +101,16 @@ def test_kernel_cache_does_not_publish_incomplete_dir_when_device_source_is_miss
 
     cache._save_kernel_to_disk(key, kernel)
 
-    assert f"{key}" not in {path.name for path in cache_dirs.iterdir()}
+    assert not cache_path.exists()
     assert "Error during atomic cache save" in logged
-    assert not any(path.name.startswith(".staging_") for path in cache_dirs.iterdir())
+    assert not staging_root.exists() or not any(staging_root.iterdir())
 
 
 def test_nvrtc_kernel_cache_rewrites_dir_missing_launcher(cache_dirs, tmp_path):
     cache = NVRTCKernelCache()
     key = "nvrtc-atomic-repair"
-    cache_path = cache_dirs / key
-    cache_path.mkdir()
+    cache_path = Path(cache._get_cache_path(key))
+    cache_path.mkdir(parents=True)
     (cache_path / cache.device_kernel_path).write_text("// device kernel")
     (cache_path / cache.host_kernel_path).write_text("// host kernel")
     (cache_path / cache.kernel_lib_path).write_bytes(b"old-cubin")

--- a/tilelang/autotuner/param.py
+++ b/tilelang/autotuner/param.py
@@ -373,20 +373,20 @@ class AutotuneResult:
     def save_to_disk(self, path: Path, verbose: bool = False):
         """Persist autotune result to disk using atomic directory rename.
 
-        All files are written into a temporary staging directory next to the
-        final *path*.  Once complete, the staging directory is atomically
-        renamed to *path* so that concurrent readers never see a half-written
-        result.
+        All files are written into a temporary staging directory under the
+        shared namespace staging root. Once complete, the staging directory is
+        atomically renamed to *path* so that concurrent readers never see a
+        half-written result.
         """
         # Already saved (e.g. another process won the race with a complete entry).
         if self._is_complete_result_dir(path, self.kernel.execution_backend):
             return
 
-        # Staging dir lives under TILELANG_CACHE_DIR (not the autotuner subdir) so that
-        # KernelCache._cleanup_stale_staging_dirs() can find and clean up stale entries.
-        staging_path = Path(env.TILELANG_CACHE_DIR) / f".staging_{Path(path).name}_{os.getpid()}_{uuid.uuid4().hex[:8]}"
+        # Keep autotuner staging under the shared namespace staging root so stale cleanup
+        # never needs to scan the full cache directory.
+        staging_path = path.parent.parent / ".staging" / f"{Path(path).name}_{os.getpid()}_{uuid.uuid4().hex[:8]}"
         os.makedirs(staging_path)
-        # Ensure the parent of the final path exists (e.g. ~/.tilelang/cache/autotuner/)
+        # Ensure the parent of the final path exists (e.g. ~/.tilelang/cache/<namespace>/autotuner/)
         os.makedirs(Path(path).parent, exist_ok=True)
 
         try:

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -132,7 +132,6 @@ class AutoTuner:
     _function_parameters: dict[str, Any] | None = None
     _lock = threading.Lock()  # For thread safety
     _memory_cache = {}  # In-memory cache dictionary
-    cache_dir: Path = Path(env.TILELANG_CACHE_DIR) / "autotuner"
 
     def __init__(self, fn: Callable, configs):
         self.fn = fn
@@ -141,6 +140,16 @@ class AutoTuner:
         self.jit_input_tensors = None
         self.ref_input_tensors = None
         self.jit_compile = None
+
+    @classmethod
+    def _get_cache_dir(cls) -> Path:
+        from tilelang.cache.kernel_cache import KernelCache
+
+        return Path(KernelCache._get_namespace_root()) / "autotuner"
+
+    @property
+    def cache_dir(self) -> Path:
+        return self._get_cache_dir()
 
     @classmethod
     def from_kernel(cls, kernel: Callable, configs):

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -420,6 +420,10 @@ class KernelCache:
             func (Callable, optional): The original function.
             verbose (bool): Enable verbose log messages.
         """
+        # Env-backed cache roots may change across tests or at runtime; recreate the
+        # namespace-specific directories lazily here so direct save helpers keep working
+        # even when the singleton instance is reused.
+        KernelCache._create_dirs()
         cache_path = self._get_cache_path(key)
 
         # Another process already wrote a complete entry — nothing to do.

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -39,11 +39,15 @@ class KernelCache:
     _instance = None  # For implementing singleton pattern
     _lock = threading.Lock()  # For thread safety
     _memory_cache = {}  # In-memory cache dictionary
+    _staging_cleanup_lock = threading.Lock()
+    _last_cleaned_staging_root: str | None = None
     execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"] = "tvm_ffi"
     device_kernel_path = "device_kernel.cu"
     host_kernel_path = "host_kernel.cu"
     kernel_lib_path = "kernel_lib.so"
     params_path = "params.pkl"
+    cache_root_dir = "kernels"
+    staging_root_dir = ".staging"
 
     @staticmethod
     @functools.cache
@@ -110,6 +114,29 @@ class KernelCache:
             base["torch"] = torch.__version__
         return base
 
+    @staticmethod
+    def _sanitize_path_component(component: str) -> str:
+        sanitized = "".join(ch if ch.isalnum() or ch in "._-" else "_" for ch in component)
+        sanitized = sanitized.strip("._-")
+        return sanitized or "unknown"
+
+    @staticmethod
+    def _format_version_namespace(version: str) -> str:
+        public, sep, local = version.partition("+")
+        public = KernelCache._sanitize_path_component(public)
+        if not sep:
+            return public
+        local = "".join(ch if ch.isalnum() else "_" for ch in local).strip("_")
+        return f"{public}_{local}" if local else public
+
+    @staticmethod
+    @functools.cache
+    def _get_cache_namespace() -> str:
+        base_key = KernelCache._get_base_key()
+        version = KernelCache._format_version_namespace(str(base_key.get("version", "unknown")))
+        platform_name = KernelCache._sanitize_path_component(str(base_key.get("platform", "unknown")))
+        return f"{version}-{platform_name}"
+
     def __new__(cls):
         """
         Implements singleton pattern for KernelCache class.
@@ -132,11 +159,31 @@ class KernelCache:
     def _create_dirs():
         os.makedirs(env.TILELANG_CACHE_DIR, exist_ok=True)
         os.makedirs(env.TILELANG_TMP_DIR, exist_ok=True)
-        KernelCache._cleanup_stale_staging_dirs()
+        os.makedirs(KernelCache._get_namespace_root(), exist_ok=True)
+        os.makedirs(KernelCache._get_cache_root(), exist_ok=True)
+        os.makedirs(KernelCache._get_staging_root(), exist_ok=True)
+
+        staging_root = KernelCache._get_staging_root()
+        with KernelCache._staging_cleanup_lock:
+            if KernelCache._last_cleaned_staging_root != staging_root:
+                KernelCache._cleanup_stale_staging_dirs()
+                KernelCache._last_cleaned_staging_root = staging_root
+
+    @staticmethod
+    def _get_namespace_root() -> str:
+        return os.path.join(env.TILELANG_CACHE_DIR, KernelCache._get_cache_namespace())
+
+    @staticmethod
+    def _get_cache_root() -> str:
+        return os.path.join(KernelCache._get_namespace_root(), KernelCache.cache_root_dir)
+
+    @staticmethod
+    def _get_staging_root() -> str:
+        return os.path.join(KernelCache._get_namespace_root(), KernelCache.staging_root_dir)
 
     @staticmethod
     def _cleanup_stale_staging_dirs(max_age_seconds: int = 3600):
-        """Remove staging directories older than *max_age_seconds* (default 1 h).
+        """Remove stale entries from the dedicated staging root.
 
         These are left behind when a process crashes mid-save.
         """
@@ -144,8 +191,12 @@ class KernelCache:
 
         try:
             now = time.time()
-            for entry in os.scandir(env.TILELANG_CACHE_DIR):
-                if entry.name.startswith(".staging_") and entry.is_dir(follow_symlinks=False):
+            staging_root = KernelCache._get_staging_root()
+            if not os.path.isdir(staging_root):
+                return
+
+            for entry in os.scandir(staging_root):
+                if entry.is_dir(follow_symlinks=False):
                     try:
                         if now - entry.stat().st_mtime > max_age_seconds:
                             shutil.rmtree(entry.path, ignore_errors=True)
@@ -330,7 +381,7 @@ class KernelCache:
         Returns:
             str: Absolute path to the cache directory for this kernel.
         """
-        return os.path.join(env.TILELANG_CACHE_DIR, key)
+        return os.path.join(self._get_cache_root(), key)
 
     @staticmethod
     def _load_binary(path: str):
@@ -358,10 +409,10 @@ class KernelCache:
         """
         Persists a compiled kernel to disk cache using atomic directory rename.
 
-        All files are first written into a temporary staging directory under
-        TILELANG_CACHE_DIR.  Once every file is in place, the staging directory
-        is atomically renamed to the final cache path so that other processes
-        never observe an incomplete cache entry.
+        All files are first written into a temporary staging directory under the
+        namespace staging root. Once every file is in place, the staging directory
+        is atomically renamed to the final cache path so that other processes never
+        observe an incomplete cache entry.
 
         Args:
             key (str): The hash key identifying the kernel.
@@ -375,10 +426,11 @@ class KernelCache:
         if self._is_complete_cache_dir(cache_path):
             return
 
-        # Staging dir lives under CACHE_DIR (same filesystem) so os.rename works.
+        # Staging dir lives under CACHE_DIR/<namespace>/.staging (same filesystem) so
+        # os.rename works without scanning the full cache root during stale cleanup.
         staging_path = os.path.join(
-            env.TILELANG_CACHE_DIR,
-            f".staging_{key}_{os.getpid()}_{uuid.uuid4().hex[:8]}",
+            self._get_staging_root(),
+            f"{key}_{os.getpid()}_{uuid.uuid4().hex[:8]}",
         )
         os.makedirs(staging_path)
 
@@ -489,14 +541,13 @@ class KernelCache:
         Removes all cached kernels from disk.
 
         Note:
-            This operation will delete the entire cache directory and recreate it empty.
+            This operation will delete the current kernel-cache namespace and recreate it empty.
             Use with caution as this operation cannot be undone.
         """
         try:
-            # Delete the entire cache directory
-            shutil.rmtree(env.TILELANG_CACHE_DIR)
+            shutil.rmtree(self._get_cache_root(), ignore_errors=True)
+            shutil.rmtree(self._get_staging_root(), ignore_errors=True)
 
-            # Re-create the cache directory
             KernelCache._create_dirs()
         except Exception:
             self.logger.exception("Error clearing disk cache")


### PR DESCRIPTION
## Summary
- move kernel and autotuner artifacts under a shared namespace root derived from the TileLang version and platform
- keep staging directories inside the same namespace so stale staging cleanup only scans a small local directory
- align autotuner cache and staging paths with the kernel cache layout

## Testing
- python -m py_compile tilelang/cache/kernel_cache.py tilelang/autotuner/tuner.py tilelang/autotuner/param.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Introduced namespace-aware on-disk cache layout for safer, isolated storage.
  * Staging/temp files now live under a namespace staging root, limiting cleanup scope.
  * Atomic save behavior preserved while adapting to the namespaced layout.

* **Tests**
  * Updated tests to expect namespaced cache and staging locations; adjusted directory-creation and cleanup assertions.

* **Examples**
  * Removed CLI backend option; example now relies on automatic backend selection ("auto").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->