### PR TITLE
fix: improve warning output in eager frontend

### DIFF
--- a/tilelang/__init__.py
+++ b/tilelang/__init__.py
@@ -88,7 +88,7 @@ def _init_logger():
 
     handler = TqdmLoggingHandler()
     formatter = logging.Formatter(
-        fmt="%(asctime)s  [TileLang:%(name)s:%(levelname)s]: %(message)s",
+        fmt="%(asctime)s  [TileLang:%(name)s:%(levelname)s] (%(filename)s:%(lineno)d): %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
     handler.setFormatter(formatter)

--- a/tilelang/language/eager/builder.py
+++ b/tilelang/language/eager/builder.py
@@ -66,7 +66,7 @@ def unwrap_cond(expr):
         return bool(expr)
     else:
         logger.warning(
-            f"Python expression `{expr}` is used as condition in TileLang, \nthis is treated as a constant expression. ",
+            f"Python expression `{expr}` is used as condition in TileLang, this is treated as a constant expression.",
             stacklevel=3,
         )
         return bool(expr)
@@ -251,7 +251,7 @@ class Builder(BaseBuilder):
     def check_continue_break(self):
         idx = self.find_frame_idx(ContinueOrBreak)
         if idx is not None:
-            logger.warning("Writing code after continue/break may cause undefined behavior in tilelang.", stacklevel=3)
+            logger.warning("Statements after continue/break have no effect and will be ignored.", stacklevel=3)
 
     @contextmanager
     def with_frame(self, frame: AbstractContextManager[Any] | None):
@@ -293,7 +293,10 @@ class Builder(BaseBuilder):
             pass
         elif isinstance(val, tir.frame.IRBuilderFrame):
             if isinstance(val, tir.frame.ForFrame):
-                logger.warning("Evaluating a for frame may cause undefined behavior in tilelang.", stacklevel=1)
+                logger.warning(
+                    "A for-loop frame is being evaluated as a standalone expression. Did you mean to use it in a `for` statement?",
+                    stacklevel=1,
+                )
             self.enter_frame(val)
         elif isinstance(val, PrimExpr):
             tir.evaluate(val)
@@ -306,7 +309,7 @@ class Builder(BaseBuilder):
         elif isinstance(val, (Buffer, Var)):
             pass
         else:
-            logger.warning(f"Unused return value: {val}({type(val)})", stacklevel=2)
+            logger.warning(f"Return value `{val}` ({type(val)}) is unused and will be discarded.", stacklevel=2)
 
     def ctx_for(self, it):
         self.check_continue_break()
@@ -322,7 +325,9 @@ class Builder(BaseBuilder):
                 else:
                     real_stop = tir.ceildiv(it.start - it.stop, -step_value)
             else:
-                logger.warning(f"Using a non-constant step `{it.step}` in stepped serial may lead to undefined behavior in tilelang")
+                logger.warning(
+                    f"Non-constant step `{it.step}` in serial range may produce unexpected results. Consider using a constant step if possible."
+                )
                 real_stop = tir.ceildiv(it.stop - it.start, it.step)
             if isinstance(it, UnrollForWithStep):
                 real_frame = tir.unroll(real_stop, annotations=it.annotations)
@@ -369,8 +374,8 @@ class Builder(BaseBuilder):
                 )
             else:
                 logger.warning(
-                    "While loop with constant false condition detected in Tilelang, the loop body will never be executed.\n"
-                    f"Condition: {cond_v}({type(cond_v)}) => {cond_v_unwrap}({type(cond_v_unwrap)})\n",
+                    "While loop condition is always false; the loop body will be skipped.\n"
+                    f"Condition: {cond_v} ({type(cond_v)}) => {cond_v_unwrap} ({type(cond_v_unwrap)})\n",
                     stacklevel=2,
                 )
         with self.with_frame(tir.While(cond_v_unwrap)):
@@ -465,7 +470,7 @@ class Builder(BaseBuilder):
             assert frame is not None, f"Variable `{name}` is not defined inside any control flow."
             if name in self.name_inside_frame and self.name_inside_frame[name] in self.frames:
                 logger.warning(
-                    f"Immutable value `{name}` is re-bound. If you want to modify its value, please use T.alloc_var to make it a variable!",
+                    f"`{name}` is an immutable binding and is being re-assigned. Use T.alloc_var to create a mutable variable.",
                     stacklevel=2,
                 )
             self.name_inside_frame[name] = self.frames[frame]
@@ -520,7 +525,7 @@ class Builder(BaseBuilder):
     def assign_slice(self, lval: Any, sl: slice, value: Any, annot=BaseBuilder.empty):
         self.check_continue_break()
         if annot is not self.empty:
-            logger.warning("Type annotation in slice assignment has no effect", stacklevel=2)
+            logger.warning("Type annotation on slice assignment is not supported and will be ignored.", stacklevel=2)
         if isinstance(lval, Buffer):
             tir.buffer_store(lval, value, sl)
         else:
@@ -564,7 +569,7 @@ class Builder(BaseBuilder):
                 assert frame is not None, f"Variable `{name}` is not defined inside any control flow."
                 if name in self.name_inside_frame and self.name_inside_frame[name] in self.frames:
                     logger.warning(
-                        f"Immutable value `{name}` is re-bound. If you want to modify its value, please use T.alloc_var to make it a variable!",
+                        f"`{name}` is an immutable binding and is being re-assigned. Use T.alloc_var to create a mutable variable.",
                         stacklevel=2,
                     )
                 self.name_inside_frame[name] = self.frames[frame]

--- a/tilelang/language/eager/builder.py
+++ b/tilelang/language/eager/builder.py
@@ -67,7 +67,6 @@ def unwrap_cond(expr):
     else:
         logger.warning(
             f"Python expression `{expr}` is used as condition in TileLang, \nthis is treated as a constant expression. ",
-            stack_info=True,
             stacklevel=3,
         )
         return bool(expr)
@@ -252,7 +251,7 @@ class Builder(BaseBuilder):
     def check_continue_break(self):
         idx = self.find_frame_idx(ContinueOrBreak)
         if idx is not None:
-            logger.warning("Writing code after continue/break may cause undefined behavior in tilelang.", stack_info=True, stacklevel=3)
+            logger.warning("Writing code after continue/break may cause undefined behavior in tilelang.", stacklevel=3)
 
     @contextmanager
     def with_frame(self, frame: AbstractContextManager[Any] | None):
@@ -294,11 +293,7 @@ class Builder(BaseBuilder):
             pass
         elif isinstance(val, tir.frame.IRBuilderFrame):
             if isinstance(val, tir.frame.ForFrame):
-                logger.warning(
-                    "Evaluating a for frame may cause undefined behavior in tilelang.",
-                    stack_info=True,
-                    stacklevel=1,
-                )
+                logger.warning("Evaluating a for frame may cause undefined behavior in tilelang.", stacklevel=1)
             self.enter_frame(val)
         elif isinstance(val, PrimExpr):
             tir.evaluate(val)
@@ -311,7 +306,7 @@ class Builder(BaseBuilder):
         elif isinstance(val, (Buffer, Var)):
             pass
         else:
-            logger.warning(f"Unused return value: {val}({type(val)})", stack_info=True, stacklevel=2)
+            logger.warning(f"Unused return value: {val}({type(val)})", stacklevel=2)
 
     def ctx_for(self, it):
         self.check_continue_break()
@@ -374,9 +369,8 @@ class Builder(BaseBuilder):
                 )
             else:
                 logger.warning(
-                    "While loop with constant false condition detected in Tilelang, the loop body will never be executed.\n",
+                    "While loop with constant false condition detected in Tilelang, the loop body will never be executed.\n"
                     f"Condition: {cond_v}({type(cond_v)}) => {cond_v_unwrap}({type(cond_v_unwrap)})\n",
-                    stack_info=True,
                     stacklevel=2,
                 )
         with self.with_frame(tir.While(cond_v_unwrap)):
@@ -472,7 +466,6 @@ class Builder(BaseBuilder):
             if name in self.name_inside_frame and self.name_inside_frame[name] in self.frames:
                 logger.warning(
                     f"Immutable value `{name}` is re-bound. If you want to modify its value, please use T.alloc_var to make it a variable!",
-                    stack_info=True,
                     stacklevel=2,
                 )
             self.name_inside_frame[name] = self.frames[frame]
@@ -527,7 +520,7 @@ class Builder(BaseBuilder):
     def assign_slice(self, lval: Any, sl: slice, value: Any, annot=BaseBuilder.empty):
         self.check_continue_break()
         if annot is not self.empty:
-            logger.warning("Type annotation in slice assignment has no effect", stack_info=True, stacklevel=2)
+            logger.warning("Type annotation in slice assignment has no effect", stacklevel=2)
         if isinstance(lval, Buffer):
             tir.buffer_store(lval, value, sl)
         else:
@@ -572,7 +565,6 @@ class Builder(BaseBuilder):
                 if name in self.name_inside_frame and self.name_inside_frame[name] in self.frames:
                     logger.warning(
                         f"Immutable value `{name}` is re-bound. If you want to modify its value, please use T.alloc_var to make it a variable!",
-                        stack_info=True,
                         stacklevel=2,
                     )
                 self.name_inside_frame[name] = self.frames[frame]

--- a/tilelang/language/eager/builder.py
+++ b/tilelang/language/eager/builder.py
@@ -295,7 +295,7 @@ class Builder(BaseBuilder):
             if isinstance(val, tir.frame.ForFrame):
                 logger.warning(
                     "A for-loop frame is being evaluated as a standalone expression. Did you mean to use it in a `for` statement?",
-                    stacklevel=1,
+                    stacklevel=2,
                 )
             self.enter_frame(val)
         elif isinstance(val, PrimExpr):
@@ -326,7 +326,8 @@ class Builder(BaseBuilder):
                     real_stop = tir.ceildiv(it.start - it.stop, -step_value)
             else:
                 logger.warning(
-                    f"Non-constant step `{it.step}` in serial range may produce unexpected results. Consider using a constant step if possible."
+                    f"Non-constant step `{it.step}` in serial range may produce unexpected results. Consider using a constant step if possible.",
+                    stacklevel=2,
                 )
                 real_stop = tir.ceildiv(it.stop - it.start, it.step)
             if isinstance(it, UnrollForWithStep):
@@ -470,7 +471,7 @@ class Builder(BaseBuilder):
             assert frame is not None, f"Variable `{name}` is not defined inside any control flow."
             if name in self.name_inside_frame and self.name_inside_frame[name] in self.frames:
                 logger.warning(
-                    f"`{name}` is an immutable binding and is being re-assigned. Use T.alloc_var to create a mutable variable.",
+                    f"Immutable value `{name}` is re-bound; use T.alloc_var to create a mutable variable.",
                     stacklevel=2,
                 )
             self.name_inside_frame[name] = self.frames[frame]
@@ -569,7 +570,7 @@ class Builder(BaseBuilder):
                 assert frame is not None, f"Variable `{name}` is not defined inside any control flow."
                 if name in self.name_inside_frame and self.name_inside_frame[name] in self.frames:
                     logger.warning(
-                        f"`{name}` is an immutable binding and is being re-assigned. Use T.alloc_var to create a mutable variable.",
+                        f"Immutable value `{name}` is re-bound; use T.alloc_var to create a mutable variable.",
                         stacklevel=2,
                     )
                 self.name_inside_frame[name] = self.frames[frame]


### PR DESCRIPTION
## Root Cause

Multiple `logger.warning` calls in `tilelang/language/eager/builder.py` pass `stack_info=True`, causing every warning to append a full Python call stack. The stack frames are all internal tilelang builder/AST paths and provide no useful information to users.

At the same time, the tilelang logger formatter omits the source file and line number, so users cannot locate which line in their own code triggered the warning. Several warning messages also used imprecise or overly terse phrasing.

## Before / After

**Before** (example: immutable re-bind warning):
```
2026-04-19 01:27:29  [TileLang:tilelang.language.eager.builder:WARNING]: Immutable value `v` is re-bound. If you want to modify its value, please use T.alloc_var to make it a variable!
Stack (most recent call last):
  File ".../tilelang/jit/__init__.py", line 315, in get_tir
    ...
  File ".../tilelang/language/eager/builder.py", line 466, in bind
    ...
  (dozens of internal stack frames)
```

**After**:
```
2026-04-19 01:28:06  [TileLang:tilelang.language.eager.builder:WARNING] (user_kernel.py:21): `v` is an immutable binding and is being re-assigned. Use T.alloc_var to create a mutable variable.
```

## Changes

1. Remove `stack_info=True` from all 8 `logger.warning` calls in `builder.py`, keeping the existing `stacklevel` parameter.
2. Add `%(filename)s:%(lineno)d` to the tilelang logger formatter in `tilelang/__init__.py`. Since the logger has `propagate = False`, this only affects tilelang's own log output.
3. Reword warning messages in `builder.py` for clarity and consistent tone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced logging to include source file and line number for clearer diagnostics.
  * Reworded and clarified builder warnings to be more actionable and user-friendly.
  * Reduced noisy stack-trace output for non-critical warnings to lower log verbosity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->