### PR TITLE
Add frontmatter for the build skill

### DIFF
--- a/.agents/skills/build/SKILL.md
+++ b/.agents/skills/build/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: build
+description: Repository-specific build, rebuild, install, and test instructions for tilelang. Use when working in the tilelang repository and the correct commands are needed for building from source, reinstalling after changes, or running project tests.
+---
+
 # Build & Install
 
 ## Installing / Rebuilding tilelang

--- a/.agents/skills/tilelang-build/SKILL.md
+++ b/.agents/skills/tilelang-build/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: build
+name: tilelang-build
 description: Repository-specific build, rebuild, install, and test instructions for tilelang. Use when working in the tilelang repository and the correct commands are needed for building from source, reinstalling after changes, or running project tests.
 ---
 


### PR DESCRIPTION
The Agent Skills spec requires SKILL.md to contain YAML frontmatter followed by Markdown content, with name and description as required fields.

Reference: https://agentskills.io/specification#skill-md-format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added metadata to skill documentation to better organize and categorize build and test instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->