### PR TITLE
[Bugfix] Correct index calculation in Software Pipeline pass

### DIFF
--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -526,7 +526,9 @@ private:
         }
         PrimExpr new_index =
             old_index +
-            floormod(pipeline_loop_->loop_var, new_buffer->shape[0]) * offset;
+            floormod((pipeline_loop_->loop_var - pipeline_loop_->min),
+                     new_buffer->shape[0]) *
+                offset;
         new_args.Set(i + 1, new_index);
       }
     }


### PR DESCRIPTION
Adjusted the index calculation in the inject_pipeline.cc file to account for the minimum value of the pipeline loop variable. This change ensures that the floormod operation correctly reflects the intended behavior when computing new indices for buffer access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized buffer indexing calculation in pipeline processing to improve multi-version buffer selection efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->