### PR TITLE
[FFI] Remove upper version bound on apache-tvm-ffi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     # >=0.1.6 fixes a memory issue: tilelang#1502, but keep
     # requirement as wide as possible to be compatible with other libraries
     # pip will try to use latest version whenever possible.
-    "apache-tvm-ffi~=0.1.0,>=0.1.2,<0.1.10",
+    "apache-tvm-ffi~=0.1.0,>=0.1.2",
     # torch-c-dlpack-ext provides prebuilt torch extensions.
     # Without it, TVM FFI may require JIT compilation on first import.
     "torch-c-dlpack-ext; python_version < '3.14'",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Requirements to run local build with `--no-build-isolation` or other developments
 
-apache-tvm-ffi~=0.1.0,>=0.1.2,<0.1.10
+apache-tvm-ffi~=0.1.0,>=0.1.2
 build
 cmake>=3.26
 cython>=3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Runtime requirements
 
-apache-tvm-ffi~=0.1.0,>=0.1.2,<0.1.10
+apache-tvm-ffi~=0.1.0,>=0.1.2
 torch-c-dlpack-ext; python_version < '3.14'
 cloudpickle
 ml-dtypes

--- a/testing/python/language/test_tilelang_language_let.py
+++ b/testing/python/language/test_tilelang_language_let.py
@@ -3,20 +3,20 @@ from tilelang import tvm as tvm
 from tilelang import language as T
 
 
+@tilelang.jit
+def test_kernel(
+    A: T.Tensor((16, 16), dtype=T.float32),
+):
+    for _blockIdx in T.thread_binding(1, thread="blockIdx.x"):
+        for _threadIdx in T.thread_binding(128, thread="threadIdx.x"):
+            b = A[0, 0:4]
+            A[0, 4:8] = b
+
+
 @tilelang.testing.requires_cuda
 def test_let_vectorize_load():
-    @T.prim_func
-    def main(A_ptr: T.handle):
-        A = T.match_buffer(A_ptr, (16, 16), dtype=T.float32, align=16)
-
-        for _blockIdx in T.thread_binding(1, thread="blockIdx.x"):
-            for _threadIdx in T.thread_binding(128, thread="threadIdx.x"):
-                b = A[0, 0:4]
-                A[0, 4:8] = b
-
-    mod = tvm.IRModule({"main": main})
-    mod = tvm.compile(mod, target="cuda")
-    assert "float4 b" in mod.mod.imports[0].inspect_source()
+    kernel_source = test_kernel.get_kernel_source()
+    assert "float4 b" in kernel_source
 
 
 if __name__ == "__main__":

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -52,7 +52,7 @@ def test_no_sync_between_atomic_adds_to_shared():
 
     mod = tvm.IRModule({"main": func})
     mod = tilelang.transform.ThreadSync("shared")(mod)
-    s = str(mod)
+    s = str(mod.script())
     assert 'T.tvm_storage_sync("shared")' not in s, f"Unexpected sync inserted for atomic ops:\n{s}"
 
 
@@ -90,7 +90,7 @@ def test_thread_sync_handles_int64_tvm_access_ptr_offset():
 
     mod = tvm.IRModule({"main": func})
     mod = tilelang.transform.ThreadSync("shared.dyn")(mod)
-    s = str(mod)
+    s = str(mod.script())
     assert 'T.tvm_storage_sync("shared.dyn")' not in s, f"Unexpected sync inserted for single atomic op:\n{s}"
 
 
@@ -115,7 +115,7 @@ def test_sync_if_with_same_index():
         result_local[0] = result_local[0] + temp_shared[0]
 
     mod = run_passes(func)
-    assert "T.tvm_storage_sync" in str(mod)
+    assert "T.tvm_storage_sync" in str(mod.script())
 
 
 @tilelang.testing.requires_cuda
@@ -137,7 +137,7 @@ def test_sync_if_with_same_index_with_modulo_if():
         result_local[0] = temp_shared[threadIdx_x]
 
     mod = run_passes(func)
-    assert "T.tvm_storage_sync" in str(mod)
+    assert "T.tvm_storage_sync" in str(mod.script())
 
 
 @tilelang.testing.requires_cuda
@@ -162,7 +162,7 @@ def test_sync_read_thread_id_independent_location():
         result_local[0] = result_local[0] + temp_shared[0] * p1[1]
 
     mod = run_passes(func)
-    assert "T.tvm_storage_sync" in str(mod)
+    assert "T.tvm_storage_sync" in str(mod.script())
 
 
 @tilelang.testing.requires_cuda
@@ -326,7 +326,7 @@ def test_sync_shared_dyn_stmatrix_loop_hoist():
 
     mod = tvm.IRModule({"main": func})
     mod = tilelang.transform.ThreadSync("shared.dyn")(mod)
-    s = str(mod)
+    s = str(mod.script())
     assert 'T.tvm_storage_sync("shared.dyn")' in s
     # Ensure the sync appears before the unrolled loop
     assert s.index('T.tvm_storage_sync("shared.dyn")') < s.index("for i in T.unroll(8)")
@@ -359,7 +359,7 @@ def test_loop_carry_no_dependency_same_index():
 
     mod = tvm.IRModule({"main": func})
     mod = tilelang.transform.ThreadSync("shared")(mod)
-    s = str(mod)
+    s = str(mod.script())
     # Should NOT have sync inside the loop since A[tx] in iteration i
     # does not conflict with A[tx] in iteration i+1 (they're different threads' data)
     # The key insight: same thread writes and reads its own location
@@ -399,7 +399,7 @@ def test_loop_carry_with_cross_thread_dependency():
 
     mod = tvm.IRModule({"main": func})
     mod = tilelang.transform.ThreadSync("shared")(mod)
-    s = str(mod)
+    s = str(mod.script())
     # Should have sync because thread tx reads from thread (tx+127)%128's location
     # This is a WAR hazard across threads
     assert 'T.tvm_storage_sync("shared")' in s, f"Expected sync for cross-thread dependency:\n{s}"
@@ -433,7 +433,7 @@ def test_loop_carry_modulo_buffering():
 
     mod = tvm.IRModule({"main": func})
     mod = tilelang.transform.ThreadSync("shared")(mod)
-    s = str(mod)
+    s = str(mod.script())
     # Should NOT have sync inside loop due to modulo buffering analysis
     # Note: This test verifies the modulo analysis capability
     print(f"Modulo buffering result:\n{s}")
@@ -467,7 +467,7 @@ def test_loop_carry_different_indices():
 
     mod = tvm.IRModule({"main": func})
     mod = tilelang.transform.ThreadSync("shared")(mod)
-    s = str(mod)
+    s = str(mod.script())
     print(f"Different indices result:\n{s}")
 
 
@@ -505,7 +505,7 @@ def test_sync_hoist_non_uniform_if_with_threadidx():
 
     mod = tvm.IRModule({"main": func})
     mod = tilelang.transform.ThreadSync("shared")(mod)
-    s = str(mod)
+    s = str(mod.script())
     # Sync should appear before the if statement
     assert 'T.tvm_storage_sync("shared")' in s, f"Expected sync:\n{s}"
     # The sync should be before the if, not inside it
@@ -545,7 +545,7 @@ def test_sync_hoist_non_uniform_if_shared_memory_condition():
 
     mod = tvm.IRModule({"main": func})
     mod = tilelang.transform.ThreadSync("shared")(mod)
-    s = str(mod)
+    s = str(mod.script())
     # Sync should appear before the if statement
     assert 'T.tvm_storage_sync("shared")' in s, f"Expected sync:\n{s}"
     # The sync should be before the if that checks token_ids
@@ -581,7 +581,7 @@ def test_sync_inside_uniform_if_blockidx():
 
     mod = tvm.IRModule({"main": func})
     mod = tilelang.transform.ThreadSync("shared")(mod)
-    s = str(mod)
+    s = str(mod.script())
     # Should have sync (either inside or outside the if is fine for uniform condition)
     assert 'T.tvm_storage_sync("shared")' in s, f"Expected sync:\n{s}"
 
@@ -605,7 +605,7 @@ def test_sync_inside_uniform_if_runtime_block_uniform_condition():
 
     mod = tvm.IRModule({"main": func})
     mod = tilelang.transform.ThreadSync("shared")(mod)
-    s = str(mod)
+    s = str(mod.script())
     assert s.count('T.tvm_storage_sync("shared")') == 1, f"Expected exactly one sync:\n{s}"
     if_pos = s.index("if flags[bx] > 0")
     sync_pos = s.index('T.tvm_storage_sync("shared")')
@@ -636,7 +636,7 @@ def test_sync_hoist_nested_non_uniform_if():
 
     mod = tvm.IRModule({"main": func})
     mod = tilelang.transform.ThreadSync("shared")(mod)
-    s = str(mod)
+    s = str(mod.script())
     assert 'T.tvm_storage_sync("shared")' in s, f"Expected sync:\n{s}"
     # Sync should be before the outermost non-uniform if
     sync_pos = s.index('T.tvm_storage_sync("shared")')
@@ -667,7 +667,7 @@ def test_sync_hoist_non_uniform_if_in_loop():
 
     mod = tvm.IRModule({"main": func})
     mod = tilelang.transform.ThreadSync("shared")(mod)
-    s = str(mod)
+    s = str(mod.script())
     assert 'T.tvm_storage_sync("shared")' in s, f"Expected sync:\n{s}"
     # Sync should be before the if inside the loop, not inside the if
     # This ensures all threads can reach the sync point
@@ -697,7 +697,7 @@ def test_no_sync_needed_uniform_accesses():
 
     mod = tvm.IRModule({"main": func})
     mod = tilelang.transform.ThreadSync("shared")(mod)
-    s = str(mod)
+    s = str(mod.script())
     # No sync needed - only local memory is accessed
     assert 'T.tvm_storage_sync("shared")' not in s, f"Unexpected sync:\n{s}"
 
@@ -724,7 +724,7 @@ def test_sync_hoist_non_uniform_if_in_loop_with_shared_memory():
 
     mod = tvm.IRModule({"main": func})
     mod = tilelang.transform.ThreadSync("shared")(mod)
-    s = str(mod)
+    s = str(mod.script())
     assert 'T.tvm_storage_sync("shared")' in s, f"Expected sync:\n{s}"
     # Sync should be before the if inside the loop, not inside the if
     sync_pos = s.index('T.tvm_storage_sync("shared")')

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -112,6 +112,8 @@ def tilelang_callback_cuda_compile(code, target, pass_config=None):
     enable_fast_math = bool(cfg.get(PassConfigKey.TL_ENABLE_FAST_MATH, False))
 
     ptxas_usage_level = cfg.get(PassConfigKey.TL_PTXAS_REGISTER_USAGE_LEVEL, None)
+    if ptxas_usage_level is not None:
+        ptxas_usage_level = int(ptxas_usage_level)
     verbose_ptxas_output = bool(cfg.get(PassConfigKey.TL_ENABLE_PTXAS_VERBOSE_OUTPUT, False))
 
     options = [

--- a/tilelang/jit/adapter/cutedsl/wrapper.py
+++ b/tilelang/jit/adapter/cutedsl/wrapper.py
@@ -1287,11 +1287,8 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
 
         for desc_name in desc_names:
             info = self.tma_desc_info[desc_name]
-            # Extract the base buffer variable name (must be a Var, not arbitrary expression)
-            global_addr = info["globalAddress"]
-            if not isinstance(global_addr, tvm.tir.Var):
-                raise ValueError(f"TMA globalAddress must be a buffer Var, got {type(global_addr)}: {global_addr}")
-            tensor_name = global_addr.name
+            # Extract the base buffer variable name
+            tensor_name = info["globalAddress"]
 
             if tensor_name not in tensor_args:
                 tensor_args.append(tensor_name)

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -62,6 +62,8 @@ class LibraryGenerator:
             enable_fast_math = self.pass_configs.get(PassConfigKey.TL_ENABLE_FAST_MATH, False)
 
             ptxas_usage_level = self.pass_configs.get(PassConfigKey.TL_PTXAS_REGISTER_USAGE_LEVEL, None)
+            if ptxas_usage_level is not None:
+                ptxas_usage_level = int(ptxas_usage_level)
             verbose_ptxas_output = self.pass_configs.get(PassConfigKey.TL_ENABLE_PTXAS_VERBOSE_OUTPUT, False)
 
             command = [

--- a/tilelang/jit/adapter/utils.py
+++ b/tilelang/jit/adapter/utils.py
@@ -432,6 +432,7 @@ def parse_tma_descriptor_args(
         if not isinstance(tensor_rank, int) or tensor_rank <= 0:
             raise ValueError(f"Invalid tensor_rank: {tensor_rank}. Must be a positive integer")
 
+        global_address = pythonic_expr_func(global_address)
         params = TMADescriptorParams(handle_name, dtype, tensor_rank, global_address, is_img2col)
 
         if not is_img2col:

--- a/tilelang/jit/adapter/wrapper.py
+++ b/tilelang/jit/adapter/wrapper.py
@@ -513,7 +513,10 @@ class TLCUDASourceWrapper:
 
             host_code = str(func)
             for function_name in function_names:
-                index = host_code.index(f'T.call_packed("{function_name}"')
+                try:
+                    index = host_code.index(f'T.call_packed("{function_name}"')
+                except ValueError:
+                    index = host_code.index(f'value="{function_name}"')
                 function_names_index[function_name] = index
         # sort function_names
         function_names = sorted(function_names, key=lambda x: function_names_index[x])


### PR DESCRIPTION
## Summary
- Remove the `<0.1.10` version cap from `apache-tvm-ffi` in `pyproject.toml`, `requirements.txt`, and `requirements-dev.txt`
- The pin was originally added to work around a `derived_object` regression, which has since been resolved in newer releases

## Test plan
- [ ] Verify CI passes with the latest `apache-tvm-ffi` resolved by pip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the checked-in TVM dependency to a newer commit.
  * Relaxed apache-tvm-ffi version constraints across project configs to allow newer 0.1.x releases.

* **Bug Fixes**
  * Ensure CUDA compilation gets numeric register-usage level values.
  * Make device-function parsing more resilient to host-code variations.
  * Accept direct tensor/global-address identifiers in TMA descriptor handling.

* **Tests**
  * Updated tests to assert kernel/source output via generated kernel source and script representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->