### PR TITLE
Fix reduce layout

### DIFF
--- a/src/layout/utils.cc
+++ b/src/layout/utils.cc
@@ -325,8 +325,8 @@ std::pair<PrimExpr, IterVar> CompressIterator(const PrimExpr &expr,
   collector.Collect({iter_sum});
   IterMark mark;
   for (const IterMark &m : collector.visited_) {
-    ICHECK(m->source.as<Var>()) << "Not a normalized iterator: " << mark;
-    if (m->source.as<Var>().value().same_as(var)) {
+    auto v = m->source.as<Var>();
+    if (v && v.value().same_as(var)) {
       mark = m;
       break;
     }

--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -403,7 +403,8 @@ Stmt ReduceOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
         arith::NormalizeToIterSum(src_thread, ToVMap(src_vars), analyzer);
     for (const auto &iter_split : iter_sum->args) {
       auto mark = iter_split->source->source.as<Var>();
-      ICHECK(mark) << "Not a normalized iterator: " << iter_split->source;
+      if (!mark)
+        continue;
       if (mark.value().same_as(src_vars[this->dim]->var)) {
         // `scale` is the stride of participating threads in the thread index
         // space.  When the thread-to-data mapping for the reduce dimension is

--- a/testing/python/language/test_tilelang_language_reshape.py
+++ b/testing/python/language/test_tilelang_language_reshape.py
@@ -260,5 +260,31 @@ def test_reshape_shape_mismatch():
         reshape_shape_mismatch_test(1024, 32, T.float32)
 
 
+def test_reduce_absmax_after_reshape_3d():
+    M, N, num_groups, num_per_channels = 2, 384, 3, 128
+    threads = 128
+    dtype = "int64"
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, num_groups), dtype),
+    ):
+        with T.Kernel(1, threads=threads) as _:
+            A_local = T.alloc_fragment((M, N), dtype)
+            A_reshaped = T.reshape(A_local, [M, num_groups, num_per_channels])
+            B_local = T.alloc_fragment((M, num_groups), dtype)
+            T.copy(A, A_local)
+            T.reduce_absmax(A_reshaped, B_local, dim=2)
+            T.copy(B_local, B)
+
+    jit_kernel = tl.compile(main, out_idx=-1)
+    A_torch = torch.randint(-100, 100, (M, N), dtype=getattr(torch, dtype)).cuda()
+    B_torch = jit_kernel(A_torch)
+
+    ref = A_torch.abs().reshape(M, num_groups, num_per_channels).max(dim=2).values
+    torch.testing.assert_close(B_torch, ref)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
The specific shape in the added test fails in the previous version of TileLang. Here is a short fix and a minimal test that fails on the previous TileLang but succeeds after the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for edge cases in iteration and reduction operations to prevent crashes when encountering invalid iterator states.

* **Tests**
  * Added test coverage for absolute maximum reduction operations on reshaped tensors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->