### PR TITLE
[Refactor] Phaseout legacy util `map_torch_type` with `T.dtype.as_torch`

### DIFF
--- a/examples/deepseek_deepgemm/example_deepgemm_fp8_2xAcc.py
+++ b/examples/deepseek_deepgemm/example_deepgemm_fp8_2xAcc.py
@@ -4,7 +4,6 @@ import torch
 import tilelang.testing
 import tilelang
 import tilelang.language as T
-from tilelang.utils.tensor import map_torch_type
 
 tilelang.testing.set_random_seed(42)
 
@@ -148,9 +147,9 @@ def assert_tl_gemm_correctness(M, N, K, block_N, in_dtype, out_dtype, accum_dtyp
     # src_code is the generated cuda source
     assert src_code is not None
 
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
-    accum_dtype = map_torch_type(accum_dtype)
+    in_dtype = in_dtype.as_torch()
+    out_dtype = out_dtype.as_torch()
+    accum_dtype = accum_dtype.as_torch()
 
     A = torch.randn(M, K).to(torch.bfloat16).cuda()
     B = torch.randn(N, K).to(torch.bfloat16).cuda()

--- a/examples/gemm_fp8/example_tilelang_gemm_fp8_intrinsic.py
+++ b/examples/gemm_fp8/example_tilelang_gemm_fp8_intrinsic.py
@@ -6,7 +6,6 @@ import tilelang.language as T
 from tilelang.intrinsics import get_swizzle_layout
 from tilelang.intrinsics.mma_macro_generator import TensorCoreIntrinEmitter
 from tilelang.intrinsics.mfma_macro_generator import MatrixCoreIntrinEmitter
-from tilelang.utils.tensor import map_torch_type
 from tilelang.utils import determine_fp8_type
 
 tilelang.testing.set_random_seed(0)
@@ -195,9 +194,9 @@ def assert_tl_matmul_correctness(M, N, K, in_dtype, out_dtype, accum_dtype):
     # src_code is the generated cuda source
     assert src_code is not None
 
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
-    accum_dtype = map_torch_type(accum_dtype)
+    in_dtype = in_dtype.as_torch()
+    out_dtype = out_dtype.as_torch()
+    accum_dtype = accum_dtype.as_torch()
 
     if in_dtype in {torch.int8, torch.int32}:
         A = torch.randint(-128, 128, (M, K), dtype=torch.int8).to(in_dtype).cuda()

--- a/examples/gemm_fp8/example_tilelang_gemm_fp8_intrinsic.py
+++ b/examples/gemm_fp8/example_tilelang_gemm_fp8_intrinsic.py
@@ -233,7 +233,7 @@ def main():
 
 def run_regression_perf():
     M, N, K = 4096, 4096, 4096
-    out_dtype, accum_dtype = "float32", "float32"
+    out_dtype, accum_dtype = T.float32, T.float32
     in_dtype = determine_fp8_type()
     kernel_e4m3 = tl_matmul(M, N, K, in_dtype, out_dtype, accum_dtype)
     profiler_e4m3 = kernel_e4m3.get_profiler(tilelang.TensorSupplyType.Integer)

--- a/examples/gemm_fp8/example_tilelang_gemm_fp8_sm100.py
+++ b/examples/gemm_fp8/example_tilelang_gemm_fp8_sm100.py
@@ -1,7 +1,6 @@
 import torch
 import tilelang
 import tilelang.language as T
-from tilelang.utils.tensor import map_torch_type
 
 
 def matmul(
@@ -74,8 +73,8 @@ num_stages = 2
 threads = 256
 for tvm_fp8_dtype in [T.float8_e4m3fn, T.float8_e5m2]:
     for tvm_acc_dtype in [T.float16, T.float32]:  # , torch.float16]:
-        torch_fp8_dtype = map_torch_type(tvm_fp8_dtype)
-        torch_acc_dtype = map_torch_type(tvm_acc_dtype)
+        torch_fp8_dtype = tvm_fp8_dtype.as_torch()
+        torch_acc_dtype = tvm_acc_dtype.as_torch()
         print(f"running {tvm_fp8_dtype} -> {tvm_acc_dtype}")
         in_dtype, out_dtype, accum_dtype = tvm_fp8_dtype, tvm_acc_dtype, tvm_acc_dtype
 

--- a/testing/python/jit/test_tilelang_jit_cutedsl.py
+++ b/testing/python/jit/test_tilelang_jit_cutedsl.py
@@ -4,7 +4,6 @@ import tilelang.testing
 import tilelang
 import torch
 import pytest
-from tilelang.utils.tensor import map_torch_type
 
 
 def matmul(
@@ -180,8 +179,8 @@ def run_gemm_jit_kernel(
 
     matmul_kernel = tilelang.compile(program, out_idx=-1, target="cutedsl")
 
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
 
     A = torch.randn(M, K, dtype=in_dtype).cuda()
     B = torch.randn(K, N, dtype=in_dtype).cuda()
@@ -282,8 +281,8 @@ def run_cutedsl_kernel_multi_stream(
     )
 
     matmul_kernel = tilelang.compile(program, target="cutedsl")
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
     tensor_a = torch.randn(M, K, dtype=in_dtype).cuda()
     tensor_b = torch.randn(K, N, dtype=in_dtype).cuda()
 
@@ -332,8 +331,8 @@ def run_cutedsl_dynamic_shape(
     if isinstance(K, T.Var):
         K = 768
 
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
 
     tensor_a = torch.randn(M, K, dtype=in_dtype).cuda()
     tensor_b = torch.randn(K, N, dtype=in_dtype).cuda()

--- a/testing/python/jit/test_tilelang_jit_gemm_cython.py
+++ b/testing/python/jit/test_tilelang_jit_gemm_cython.py
@@ -4,7 +4,6 @@ import tilelang.testing
 import tilelang
 import torch
 import pytest
-from tilelang.utils.tensor import map_torch_type
 
 
 def matmul(
@@ -134,8 +133,8 @@ def run_gemm_jit_kernel(
 
     matmul_kernel = tilelang.compile(program, out_idx=-1, execution_backend="cython")
 
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
 
     A = torch.randn(M, K, dtype=in_dtype).cuda()
     B = torch.randn(K, N, dtype=in_dtype).cuda()
@@ -234,8 +233,8 @@ def run_cython_kernel_multi_stream(
 
     matmul_kernel = tilelang.compile(program, execution_backend="cython")
 
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
 
     tensor_a = torch.randn(M, K, dtype=in_dtype).cuda()
     tensor_b = torch.randn(K, N, dtype=in_dtype).cuda()
@@ -284,8 +283,8 @@ def run_cython_dynamic_shape(
     if isinstance(K, T.Var):
         K = 192
 
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
 
     tensor_a = torch.randn(M, K, dtype=in_dtype).cuda()
     tensor_b = torch.randn(K, N, dtype=in_dtype).cuda()
@@ -334,8 +333,8 @@ def run_cython_dynamic_shape_with_out_idx(
     if isinstance(K, T.Var):
         K = 192
 
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
 
     tensor_a = torch.randn(M, K, dtype=in_dtype).cuda()
     tensor_b = torch.randn(K, N, dtype=in_dtype).cuda()
@@ -411,8 +410,8 @@ def run_matmul_int_variable(M, N, K, block_M, block_N, block_K, trans_A, trans_B
     )
     matmul_kernel = tilelang.compile(program, execution_backend="cython", out_idx=2)
 
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
 
     tensor_a = torch.randn(M, K, dtype=in_dtype).cuda()
     tensor_b = torch.randn(K, N, dtype=in_dtype).cuda()
@@ -482,8 +481,8 @@ def run_matmul_float_variable(M, N, K, block_M, block_N, block_K, trans_A, trans
     )
     matmul_kernel = tilelang.compile(program, execution_backend="cython", out_idx=2)
 
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
 
     tensor_a = torch.randn(M, K, dtype=in_dtype).cuda()
     tensor_b = torch.randn(K, N, dtype=in_dtype).cuda()

--- a/testing/python/jit/test_tilelang_jit_nullptr.py
+++ b/testing/python/jit/test_tilelang_jit_nullptr.py
@@ -3,7 +3,6 @@ from tilelang import tvm as tvm
 import tilelang.testing
 import tilelang as tl
 import tilelang.language as T
-from tilelang.utils import map_torch_type
 
 
 @tl.jit
@@ -39,9 +38,9 @@ def tensor_null_test(M, N, K, block_M, block_N, block_K, dtype=T.float16, accum_
 
 
 def run_test(M, N, K, block_M, block_N, block_K, dtype=T.float16, accum_dtype=T.float32):
-    a = torch.randn(M, K, device="cuda", dtype=map_torch_type(dtype))
-    b = torch.randn(N, K, device="cuda", dtype=map_torch_type(dtype))
-    c = torch.zeros(M, N, device="cuda", dtype=map_torch_type(accum_dtype))
+    a = torch.randn(M, K, device="cuda", dtype=dtype.as_torch())
+    b = torch.randn(N, K, device="cuda", dtype=dtype.as_torch())
+    c = torch.zeros(M, N, device="cuda", dtype=accum_dtype.as_torch())
     kernel = tensor_null_test(M, N, K, block_M, block_N, block_K, dtype, accum_dtype, with_bias=False)
     kernel(a, b, c, None)
 

--- a/testing/python/jit/test_tilelang_jit_nvrtc.py
+++ b/testing/python/jit/test_tilelang_jit_nvrtc.py
@@ -4,7 +4,6 @@ import tilelang.testing
 import tilelang
 import torch
 import pytest
-from tilelang.utils.tensor import map_torch_type
 
 
 def matmul(
@@ -132,8 +131,8 @@ def run_gemm_jit_kernel(
 
     matmul_kernel = tilelang.compile(program, out_idx=-1, execution_backend="nvrtc")
 
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
 
     A = torch.randn(M, K, dtype=in_dtype).cuda()
     B = torch.randn(K, N, dtype=in_dtype).cuda()
@@ -234,8 +233,8 @@ def run_nvrtc_kernel_multi_stream(
     )
 
     matmul_kernel = tilelang.compile(program, execution_backend="nvrtc")
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
     tensor_a = torch.randn(M, K, dtype=in_dtype).cuda()
     tensor_b = torch.randn(K, N, dtype=in_dtype).cuda()
 
@@ -284,8 +283,8 @@ def run_nvrtc_dynamic_shape(
     if isinstance(K, T.Var):
         K = 768
 
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
 
     tensor_a = torch.randn(M, K, dtype=in_dtype).cuda()
     tensor_b = torch.randn(K, N, dtype=in_dtype).cuda()

--- a/testing/python/jit/test_tilelang_jit_tvm_ffi.py
+++ b/testing/python/jit/test_tilelang_jit_tvm_ffi.py
@@ -4,7 +4,6 @@ import tilelang.testing
 import tilelang
 import torch
 import pytest
-from tilelang.utils.tensor import map_torch_type
 
 
 def matmul(
@@ -132,8 +131,8 @@ def run_gemm_jit_kernel(
 
     matmul_kernel = tilelang.compile(program, out_idx=-1, execution_backend="tvm_ffi")
 
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
 
     A = torch.randn(M, K, dtype=in_dtype).cuda()
     B = torch.randn(K, N, dtype=in_dtype).cuda()
@@ -232,8 +231,8 @@ def run_tvm_ffi_kernel_multi_stream(
     )
 
     matmul_kernel = tilelang.compile(program, execution_backend="tvm_ffi")
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
     tensor_a = torch.randn(M, K, dtype=in_dtype).cuda()
     tensor_b = torch.randn(K, N, dtype=in_dtype).cuda()
 
@@ -281,8 +280,8 @@ def run_tvm_ffi_dynamic_shape(
     if isinstance(K, T.Var):
         K = 768
 
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
 
     tensor_a = torch.randn(M, K, dtype=in_dtype).cuda()
     tensor_b = torch.randn(K, N, dtype=in_dtype).cuda()

--- a/testing/python/kernel/test_tilelang_kernel_bf16_gemm_mma.py
+++ b/testing/python/kernel/test_tilelang_kernel_bf16_gemm_mma.py
@@ -9,7 +9,6 @@ from tilelang.intrinsics.mma_macro_generator import (
     TensorCoreIntrinEmitter,
 )
 from tilelang.transform import simplify_prim_func
-from tilelang.utils.tensor import map_torch_type
 
 tilelang.testing.set_random_seed(0)
 
@@ -190,9 +189,9 @@ def assert_tl_matmul_correctness(M, N, K, in_dtype, out_dtype, accum_dtype):
     # src_code is the generated cuda source
     assert src_code is not None
 
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
-    accum_dtype = map_torch_type(accum_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
+    accum_dtype = T.dtype(accum_dtype).as_torch()
 
     if in_dtype in {torch.int8, torch.int32}:
         A = torch.randint(-128, 128, (M, K), dtype=torch.int8).to(in_dtype).cuda()

--- a/testing/python/kernel/test_tilelang_kernel_fp8_gemm.py
+++ b/testing/python/kernel/test_tilelang_kernel_fp8_gemm.py
@@ -1,7 +1,6 @@
 import torch
 import tilelang.testing
 import tilelang.language as T
-from tilelang.utils.tensor import map_torch_type
 
 
 def calc_diff(x, y):
@@ -38,12 +37,12 @@ def assert_matmul_correctness(M, N, K, block_M, block_N, block_K, in_dtype, out_
     func = matmul_nt(M, N, K, block_M, block_N, block_K, in_dtype, out_dtype, accum_dtype)
     kernel = tilelang.compile(func, out_idx=-1)
 
-    A = torch.randn(M, K).to(map_torch_type(in_dtype)).cuda()
-    B = torch.randn(N, K).to(map_torch_type(in_dtype)).cuda()
+    A = torch.randn(M, K).to(T.dtype(in_dtype).as_torch()).cuda()
+    B = torch.randn(N, K).to(T.dtype(in_dtype).as_torch()).cuda()
 
     C = kernel(A, B)
 
-    ref_c = torch.matmul(A.to(map_torch_type(accum_dtype)), B.T.to(map_torch_type(accum_dtype))).to(map_torch_type(out_dtype))
+    ref_c = torch.matmul(A.to(T.dtype(accum_dtype).as_torch()), B.T.to(T.dtype(accum_dtype).as_torch())).to(T.dtype(out_dtype).as_torch())
     print(C)
     print(ref_c)
     diff = calc_diff(C, ref_c)

--- a/testing/python/kernel/test_tilelang_kernel_fp8_gemm_mma.py
+++ b/testing/python/kernel/test_tilelang_kernel_fp8_gemm_mma.py
@@ -9,7 +9,6 @@ from tilelang.intrinsics.mma_macro_generator import (
     TensorCoreIntrinEmitter,
 )
 from tilelang.transform import simplify_prim_func
-from tilelang.utils.tensor import map_torch_type
 
 tilelang.testing.set_random_seed(0)
 
@@ -190,9 +189,9 @@ def assert_tl_matmul_correctness(M, N, K, in_dtype, out_dtype, accum_dtype):
     # src_code is the generated cuda source
     assert src_code is not None
 
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
-    accum_dtype = map_torch_type(accum_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
+    accum_dtype = T.dtype(accum_dtype).as_torch()
 
     if in_dtype in {torch.int8, torch.int32}:
         A = torch.randint(-128, 128, (M, K), dtype=torch.int8).to(in_dtype).cuda()

--- a/testing/python/kernel/test_tilelang_kernel_fp8_gemv_simt.py
+++ b/testing/python/kernel/test_tilelang_kernel_fp8_gemv_simt.py
@@ -6,7 +6,6 @@ from tvm import DataType
 import tilelang.language as T
 from tilelang import JITKernel
 from tilelang.transform.simplify import apply_simplify
-from tilelang.utils.tensor import map_torch_type
 from typing import Optional
 
 tilelang.testing.set_random_seed(0)
@@ -128,9 +127,9 @@ def evaluate_gemv_simt(
 
     kernel = JITKernel(program, target="cuda")
 
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
-    accum_dtype = map_torch_type(accum_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
+    accum_dtype = T.dtype(accum_dtype).as_torch()
 
     if in_dtype in {torch.int8, torch.int32}:
         A = torch.randint(-128, 128, (M, K), dtype=torch.int8).to(in_dtype).cuda()

--- a/testing/python/kernel/test_tilelang_kernel_gemm_mma_intrinsic.py
+++ b/testing/python/kernel/test_tilelang_kernel_gemm_mma_intrinsic.py
@@ -9,7 +9,6 @@ from tilelang.intrinsics.mma_macro_generator import (
     TensorCoreIntrinEmitter,
 )
 from tilelang.transform import simplify_prim_func
-from tilelang.utils.tensor import map_torch_type
 
 tilelang.testing.set_random_seed(0)
 
@@ -190,9 +189,9 @@ def assert_tl_matmul_correctness(M, N, K, in_dtype, out_dtype, accum_dtype):
     # src_code is the generated cuda source
     assert src_code is not None
 
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
-    accum_dtype = map_torch_type(accum_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
+    accum_dtype = T.dtype(accum_dtype).as_torch()
 
     if in_dtype in {torch.int8, torch.int32}:
         A = torch.randint(-128, 128, (M, K), dtype=torch.int8).to(in_dtype).cuda()

--- a/testing/python/kernel/test_tilelang_kernel_gemv_simt.py
+++ b/testing/python/kernel/test_tilelang_kernel_gemv_simt.py
@@ -6,7 +6,6 @@ from tvm import DataType
 import tilelang.language as T
 from tilelang import JITKernel
 from tilelang.transform.simplify import apply_simplify
-from tilelang.utils.tensor import map_torch_type
 from typing import Optional
 
 tilelang.testing.set_random_seed(0)
@@ -128,9 +127,9 @@ def evaluate_gemv_simt(
 
     kernel = JITKernel(program, target="cuda")
 
-    in_dtype = map_torch_type(in_dtype)
-    out_dtype = map_torch_type(out_dtype)
-    accum_dtype = map_torch_type(accum_dtype)
+    in_dtype = T.dtype(in_dtype).as_torch()
+    out_dtype = T.dtype(out_dtype).as_torch()
+    accum_dtype = T.dtype(accum_dtype).as_torch()
 
     if in_dtype in {torch.int8, torch.int32}:
         A = torch.randint(-128, 128, (M, K), dtype=torch.int8).to(in_dtype).cuda()

--- a/testing/python/language/test_tilelang_language_clear.py
+++ b/testing/python/language/test_tilelang_language_clear.py
@@ -43,10 +43,9 @@ def run_matmul(M, N, K, block_M, block_N, block_K, dtype=T.float16, accum_dtype=
     program = matmul(M, N, K, block_M, block_N, block_K, dtype, accum_dtype)
     kernel = tilelang.compile(program, out_idx=[2])
     import torch
-    from tilelang.utils import map_torch_type
 
-    a = torch.randn((M, K), dtype=map_torch_type(dtype)).cuda()
-    b = torch.randn((N, K), dtype=map_torch_type(dtype)).cuda()
+    a = torch.randn((M, K), dtype=dtype.as_torch()).cuda()
+    b = torch.randn((N, K), dtype=dtype.as_torch()).cuda()
     c = kernel(a, b)
     assert torch.allclose(c, torch.zeros_like(c))
 

--- a/testing/python/language/test_tilelang_language_ptr.py
+++ b/testing/python/language/test_tilelang_language_ptr.py
@@ -4,7 +4,6 @@ from tilelang import tvm as tvm
 import tilelang.testing
 import tilelang as tl
 import tilelang.language as T
-from tilelang.utils import map_torch_type
 
 
 def matmul_test(M, N, K, block_M, block_N, block_K, dtype=T.float16, accum_dtype=T.float32):
@@ -118,10 +117,10 @@ def run_matmul(M, N, K, block_M, block_N, block_K, dtype=T.float16, accum_dtype=
     def ref_program(a, b):
         return (a @ b.T).to(torch.float32)
 
-    a = torch.randn(M, K, device="cuda", dtype=map_torch_type(dtype))
-    b = torch.randn(N, K, device="cuda", dtype=map_torch_type(dtype))
-    ffi_c = torch.zeros(M, N, device="cuda", dtype=map_torch_type(accum_dtype))
-    cython_c = torch.zeros(M, N, device="cuda", dtype=map_torch_type(accum_dtype))
+    a = torch.randn(M, K, device="cuda", dtype=dtype.as_torch())
+    b = torch.randn(N, K, device="cuda", dtype=dtype.as_torch())
+    ffi_c = torch.zeros(M, N, device="cuda", dtype=accum_dtype.as_torch())
+    cython_c = torch.zeros(M, N, device="cuda", dtype=accum_dtype.as_torch())
 
     ffi_jit_kernel(a, b, ffi_c, M, N, K)
     cython_jit_kernel(a.data_ptr(), b.data_ptr(), cython_c.data_ptr(), M, N, K)
@@ -133,10 +132,10 @@ def run_pointer_table_copy(N, dtype=T.float16):
     program = pointer_table_copy_test(N, dtype)
     cython_jit_kernel = tl.compile(program, execution_backend="cython")
     ffi_jit_kernel = tl.compile(program, execution_backend="tvm_ffi")
-    src = torch.randn(N, device="cuda", dtype=map_torch_type(dtype))
+    src = torch.randn(N, device="cuda", dtype=dtype.as_torch())
     src_ptrs = torch.tensor([src.data_ptr()], device="cuda", dtype=torch.int64)
-    ffi_out = torch.empty(N, device="cuda", dtype=map_torch_type(dtype))
-    cython_out = torch.empty(N, device="cuda", dtype=map_torch_type(dtype))
+    ffi_out = torch.empty(N, device="cuda", dtype=dtype.as_torch())
+    cython_out = torch.empty(N, device="cuda", dtype=dtype.as_torch())
 
     ffi_jit_kernel(src_ptrs, ffi_out)
     cython_jit_kernel(src_ptrs, cython_out)
@@ -150,11 +149,11 @@ def run_pointer_table_multi_copy(G, N, dtype=T.float16):
     program = pointer_table_multi_copy_test(G, N, dtype)
     cython_jit_kernel = tl.compile(program, execution_backend="cython")
     ffi_jit_kernel = tl.compile(program, execution_backend="tvm_ffi")
-    srcs = [torch.randn(N, device="cuda", dtype=map_torch_type(dtype)) for _ in range(G)]
+    srcs = [torch.randn(N, device="cuda", dtype=dtype.as_torch()) for _ in range(G)]
     src_ptrs = torch.tensor([src.data_ptr() for src in srcs], device="cuda", dtype=torch.int64)
     ref = torch.stack(srcs, dim=0)
-    ffi_out = torch.empty((G, N), device="cuda", dtype=map_torch_type(dtype))
-    cython_out = torch.empty((G, N), device="cuda", dtype=map_torch_type(dtype))
+    ffi_out = torch.empty((G, N), device="cuda", dtype=dtype.as_torch())
+    cython_out = torch.empty((G, N), device="cuda", dtype=dtype.as_torch())
 
     ffi_jit_kernel(src_ptrs, ffi_out)
     cython_jit_kernel(src_ptrs, cython_out)
@@ -171,8 +170,8 @@ def run_pointer_table_grouped_matmul(batch_sizes_list, N, K, block_M, block_N, b
     ffi_jit_kernel = tl.compile(program, execution_backend="tvm_ffi", **compile_kwargs)
 
     device = "cuda"
-    torch_dtype = map_torch_type(dtype)
-    torch_accum_dtype = map_torch_type(accum_dtype)
+    torch_dtype = dtype.as_torch()
+    torch_accum_dtype = accum_dtype.as_torch()
     max_M = max(batch_sizes_list)
     batch_tile_offsets = [0]
     for size in batch_sizes_list[:-1]:

--- a/testing/python/tilelibrary/test_tilelang_tilelibrary_gemm_sp.py
+++ b/testing/python/tilelibrary/test_tilelang_tilelibrary_gemm_sp.py
@@ -6,7 +6,7 @@ import tilelang.language as T
 
 from tilelang.utils.sparse import compress, randn_semi_sparse, randint_semi_sparse
 from tilelang.layout import make_cutlass_metadata_layout
-from tilelang.utils.tensor import torch_assert_close, map_torch_type
+from tilelang.utils.tensor import torch_assert_close
 from tilelang.intrinsics.mma_sp_macro_generator import SparseTensorCoreIntrinEmitter
 
 torch.backends.cuda.matmul.allow_tf32 = False
@@ -21,11 +21,11 @@ def generate_dense_input(M, N, K, trans_A, trans_B, in_dtype):
             low, high = (0, 4) if is_unsigned else (-2, 2)
         else:
             low, high = (0, 128) if is_unsigned else (-64, 64)
-        A = randint_semi_sparse(M, K, low=low, high=high, dtype=map_torch_type(in_dtype), device="cuda", transposed=trans_A)
-        B = torch.randint(size=(N, K) if trans_B else (K, N), low=low, high=high, dtype=map_torch_type(in_dtype), device="cuda")
+        A = randint_semi_sparse(M, K, low=low, high=high, dtype=T.dtype(in_dtype).as_torch(), device="cuda", transposed=trans_A)
+        B = torch.randint(size=(N, K) if trans_B else (K, N), low=low, high=high, dtype=T.dtype(in_dtype).as_torch(), device="cuda")
     else:
-        A = randn_semi_sparse(M, K, dtype=torch.float32, device="cuda", transposed=trans_A).to(map_torch_type(in_dtype))
-        B = torch.randn((N, K) if trans_B else (K, N), device="cuda", dtype=torch.float32).to(map_torch_type(in_dtype))
+        A = randn_semi_sparse(M, K, dtype=torch.float32, device="cuda", transposed=trans_A).to(T.dtype(in_dtype).as_torch())
+        B = torch.randn((N, K) if trans_B else (K, N), device="cuda", dtype=torch.float32).to(T.dtype(in_dtype).as_torch())
     return A, B
 
 

--- a/testing/python/tilelibrary/test_tilelang_tilelibrary_gemm_sp_v2.py
+++ b/testing/python/tilelibrary/test_tilelang_tilelibrary_gemm_sp_v2.py
@@ -1,7 +1,7 @@
 import pytest
 from tilelang import tvm as tvm
 from tilelang.utils.sparse import compress, randn_semi_sparse, randint_semi_sparse
-from tilelang.utils.tensor import torch_assert_close, map_torch_type
+from tilelang.utils.tensor import torch_assert_close
 from tilelang.layout import make_cutlass_metadata_layout
 from tilelang.intrinsics.mma_sp_macro_generator import SparseTensorCoreIntrinEmitter
 
@@ -123,8 +123,8 @@ def run_gemm_ss(
     C = _matmul(A, B)
 
     torch_assert_close(
-        C_sp.to(map_torch_type(out_dtype)).to(torch.float32),
-        C.to(map_torch_type(out_dtype)).to(torch.float32),
+        C_sp.to(T.dtype(out_dtype).as_torch()).to(torch.float32),
+        C.to(T.dtype(out_dtype).as_torch()).to(torch.float32),
         rtol=1e-3,
         atol=1e-3,
         base_name="tilelang_sp",
@@ -142,11 +142,11 @@ def generate_dense_input(M, N, K, trans_A, trans_B, in_dtype):
             low, high = (0, 4) if is_unsigned else (-2, 2)
         else:
             low, high = (0, 128) if is_unsigned else (-64, 64)
-        A = randint_semi_sparse(M, K, low=low, high=high, dtype=map_torch_type(in_dtype), device="cuda", transposed=trans_A)
-        B = torch.randint(size=(N, K) if trans_B else (K, N), low=low, high=high, dtype=map_torch_type(in_dtype), device="cuda")
+        A = randint_semi_sparse(M, K, low=low, high=high, dtype=T.dtype(in_dtype).as_torch(), device="cuda", transposed=trans_A)
+        B = torch.randint(size=(N, K) if trans_B else (K, N), low=low, high=high, dtype=T.dtype(in_dtype).as_torch(), device="cuda")
     else:
-        A = randn_semi_sparse(M, K, dtype=map_torch_type(in_dtype), device="cuda", transposed=trans_A)
-        B = torch.randn((N, K) if trans_B else (K, N), device="cuda", dtype=torch.float32).to(map_torch_type(in_dtype))
+        A = randn_semi_sparse(M, K, dtype=T.dtype(in_dtype).as_torch(), device="cuda", transposed=trans_A)
+        B = torch.randn((N, K) if trans_B else (K, N), device="cuda", dtype=torch.float32).to(T.dtype(in_dtype).as_torch())
     return A, B
 
 
@@ -288,8 +288,8 @@ def run_gemm_rs(
     C = _matmul(A, B)
 
     torch_assert_close(
-        C_sp.to(map_torch_type(out_dtype)).to(torch.float32),
-        C.to(map_torch_type(out_dtype)).to(torch.float32),
+        C_sp.to(T.dtype(out_dtype).as_torch()).to(torch.float32),
+        C.to(T.dtype(out_dtype).as_torch()).to(torch.float32),
         rtol=1e-3,
         atol=1e-3,
         base_name="tilelang_sp",
@@ -436,8 +436,8 @@ def run_gemm_sr(
     C = _matmul(A, B)
 
     torch_assert_close(
-        C_sp.to(map_torch_type(out_dtype)).to(torch.float32),
-        C.to(map_torch_type(out_dtype)).to(torch.float32),
+        C_sp.to(T.dtype(out_dtype).as_torch()).to(torch.float32),
+        C.to(T.dtype(out_dtype).as_torch()).to(torch.float32),
         rtol=1e-3,
         atol=1e-3,
         base_name="tilelang_sp",
@@ -588,8 +588,8 @@ def run_gemm_rr(
     C = _matmul(A, B)
 
     torch_assert_close(
-        C_sp.to(map_torch_type(out_dtype)).to(torch.float32),
-        C.to(map_torch_type(out_dtype)).to(torch.float32),
+        C_sp.to(T.dtype(out_dtype).as_torch()).to(torch.float32),
+        C.to(T.dtype(out_dtype).as_torch()).to(torch.float32),
         rtol=1e-3,
         atol=1e-3,
         base_name="tilelang_sp",

--- a/tilelang/jit/adapter/cython/adapter.py
+++ b/tilelang/jit/adapter/cython/adapter.py
@@ -18,7 +18,6 @@ from tilelang.jit.adapter.libgen import LibraryGenerator
 from tilelang.jit.adapter.utils import is_cuda_target, is_hip_target, is_cpu_target, is_metal_target
 from tilelang.utils.target import determine_target
 from tilelang.utils.language import retrieve_func_from_module
-from tilelang.utils.tensor import map_torch_type
 
 logger = logging.getLogger(__name__)
 
@@ -255,7 +254,7 @@ class CythonKernelAdapter(BaseKernelAdapter):
             if param in buffer_map:
                 buffer = buffer_map[param]
                 name, dtype = buffer.name, buffer.dtype
-                buffer_dtype_map[name] = (i, map_torch_type(dtype))
+                buffer_dtype_map[name] = (i, dtype.as_torch())
         return buffer_dtype_map
 
     def _process_ptr_map(self) -> dict[int, str]:

--- a/tilelang/jit/adapter/cython/cython_wrapper.pyx
+++ b/tilelang/jit/adapter/cython/cython_wrapper.pyx
@@ -6,7 +6,6 @@ import ctypes
 from libc.stdint cimport int64_t, uintptr_t
 from libc.stdlib cimport malloc, free
 from tvm import tir
-from tilelang.utils.tensor import map_torch_type
 
 cdef class CythonKernelWrapper:
     # Class attributes to store kernel configuration and library reference

--- a/tilelang/language/dtypes.py
+++ b/tilelang/language/dtypes.py
@@ -194,7 +194,7 @@ def __dtype_as_torch__(self: dtype) -> torch.dtype:
     elif dtype_str == "float8_e5m2":
         assert hasattr(torch, "float8_e5m2"), "torch.float8_e5m2 is not supported in this version of torch. Please upgrade torch >= 2.1.0"
         return torch.float8_e5m2
-    elif dtype_str == "float8_e4m3fnuz":
+    elif dtype_str in ("float8_e4m3fnuz", "e4m3fnuz_float8"):
         assert hasattr(torch, "float8_e4m3fnuz"), (
             "torch.float8_e4m3fnuz is not supported in this version of torch. Please upgrade torch >= 2.2.0"
         )
@@ -227,6 +227,8 @@ __orig_dtype_new = dtype.__new__
 
 
 def __dtype_new__(cls, value: AnyDType) -> dtype:
+    if isinstance(value, dtype):
+        return value
     if isinstance(value, str):
         return __orig_dtype_new(cls, _CANONICAL_TO_DISPLAY_STR.get(value, value))
     elif value in _DTYPE_TO_STR:

--- a/tilelang/utils/__init__.py
+++ b/tilelang/utils/__init__.py
@@ -5,7 +5,7 @@ from .target import (  # noqa: F401
     determine_fp8_type,
     determine_torch_fp8_type,
 )
-from .tensor import TensorSupplyType, torch_assert_close, map_torch_type  # noqa: F401
+from .tensor import TensorSupplyType, torch_assert_close  # noqa: F401
 from .language import (
     is_global,  # noqa: F401
     is_shared,  # noqa: F401

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -39,41 +39,6 @@ class TensorSupplyType(Enum):
     Auto = 7
 
 
-def map_torch_type(intype) -> torch.dtype:
-    # Convert to string if needed
-    if not isinstance(intype, str):
-        intype = str(intype)
-
-    if intype == "float8_e4m3":
-        assert hasattr(torch, "float8_e4m3fn"), "torch.float8_e4m3fn is not supported in this version of torchPlease upgrade torch >= 2.1.0"
-        return torch.float8_e4m3fn
-    elif intype == "float8_e5m2":
-        assert hasattr(torch, "float8_e5m2"), "torch.float8_e5m2 is not supported in this version of torchPlease upgrade torch >= 2.1.0"
-        return torch.float8_e5m2
-    elif intype == "e4m3fnuz_float8":
-        assert hasattr(torch, "float8_e4m3fnuz"), (
-            "torch.float8_e4m3fnuz is not supported in this version of torchPlease upgrade torch >= 2.2.0"
-        )
-        return torch.float8_e4m3fnuz
-    elif intype == "float8_e8m0fnu":
-        assert hasattr(torch, "float8_e8m0fnu"), (
-            "torch.float8_e8m0fnu is not supported in this version of torchPlease upgrade torch >= 2.8.0"
-        )
-        return torch.float8_e8m0fnu
-    elif intype == "float4_e2m1fnx2":
-        assert hasattr(torch, "float4_e2m1fnx2"), (
-            "torch.float4_e2m1fnx2 is not supported in this version of torchPlease upgrade torch >= 2.8.0"
-        )
-        return torch.float4_e2m1fnx2
-    elif intype == "int4":
-        return torch.int8
-    elif "float4" in intype:
-        # PyTorch doesn't support float4, use int8 as storage type
-        return torch.int8
-    else:
-        return getattr(torch, intype)
-
-
 def get_tensor_supply(supply_type: TensorSupplyType = TensorSupplyType.Integer):
     from tilelang.engine.param import KernelParam
     from .device import get_current_device


### PR DESCRIPTION
## Summary

`map_torch_type` was a standalone function that converted dtype strings or TVM `DataType` objects to `torch.dtype`. This was redundant since `T.dtype.as_torch()` (and `T.dtype(x).as_torch()`) already provides the same functionality with better handling (HIP/CUDA awareness, proper dtype lookup tables, etc.).

## Changes

- Remove `map_torch_type` from `tilelang/utils/tensor.py` and its re-export in `tilelang/utils/__init__.py`
- Make `T.dtype()` idempotent for existing dtype objects (add pass-through in `__dtype_new__`)
- Add backward-compat for `"e4m3fnuz_float8"` TVM internal name in `__dtype_as_torch__`
- Replace all usages across production code, tests, and examples
- Remove unused import from `cython_wrapper.pyx`
- Rebuild Cython extension

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified dtype handling across examples, tests, and runtime to use the language-provided dtype conversion, improving consistency while preserving behavior and public APIs.
  * Broadened recognition of a float8 dtype alias so that that format is accepted in more forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->