### PR TITLE
[Refactor] Disable unhelpful warning print

### DIFF
--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -257,8 +257,8 @@ public:
           const Layout &existing = layout_map[buffer];
           if (!layout.as<Fragment>() && !existing.as<Fragment>()) {
             if (auto merged = MergeSwizzleLayouts(existing, layout, buffer)) {
-              LOG(WARNING) << "Swizzle layout conflict for buffer " << buffer
-                           << ", merging to smaller granularity";
+              DLOG(WARNING) << "Swizzle layout conflict for buffer " << buffer
+                            << ", merging to smaller granularity";
               layout_map.Set(buffer, merged.value());
               propagate_alias(buffer, merged.value());
               continue;


### PR DESCRIPTION
as title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted logging verbosity for internal layout conflict resolution to reduce unnecessary warning messages during normal operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->