### PR TITLE
[Enhancement] Enhance alloc_var function to handle _ptr_sentinel dtype

### DIFF
--- a/tilelang/language/allocate.py
+++ b/tilelang/language/allocate.py
@@ -27,7 +27,7 @@ from tvm.tir.expr import FloatImm, IntImm
 from . import dtypes as _dtypes
 from .dtypes import dtype as tl_dtype
 from .eager.builder import OutTensor
-from .proxy import Tensor
+from .proxy import Tensor, ptr as _ptr_sentinel
 
 
 def alloc_shared(shape: ShapeType, dtype: DType, scope="shared.dyn") -> Buffer:
@@ -131,6 +131,9 @@ def alloc_var(dtype: DType, *args, scope: str = "local.var", init: PrimExpr | in
 
     if not isinstance(parsed_scope, str):
         raise TypeError("Scope must be a string in alloc_var.")
+
+    if dtype is _ptr_sentinel:
+        dtype = _dtypes.int64
 
     buffer = T.alloc_buffer([1], dtype, scope=parsed_scope)
     if parsed_init is not None:


### PR DESCRIPTION
Updated the alloc_var function to check for the _ptr_sentinel dtype and default to int64 if encountered. This change improves type handling and ensures compatibility with new tensor allocation scenarios.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed buffer allocation handling for pointer-typed variables. Pointer types now correctly coerce to int64 during allocation, ensuring proper type resolution and preventing allocation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->