### PR TITLE
[Refactor] Strip build machine paths from LOG messages in wheel releases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,8 +426,29 @@ if(USE_Z3 AND USE_PYPI_Z3)
   find_package(Z3 REQUIRED)
 endif()
 
+# Enable custom logging so we control the output format (e.g. strip build paths
+# from __FILE__ so wheel users don't see CI machine paths in warnings).
+set(USE_CUSTOM_LOGGING ON CACHE BOOL "Use custom logging implementation" FORCE)
+
+# Detect release (wheel) builds: in CI (cibuildwheel) or scikit-build-core wheel builds,
+# we strip source paths from LOG(WARNING) etc. for a cleaner user experience.
+# Local dev builds keep full paths for debugging.
+if(DEFINED ENV{CIBUILDWHEEL} OR "$ENV{SKBUILD_STATE}" STREQUAL "wheel")
+  set(TILELANG_RELEASE_BUILD_DEFAULT ON)
+else()
+  set(TILELANG_RELEASE_BUILD_DEFAULT OFF)
+endif()
+option(TILELANG_RELEASE_BUILD "Strip source paths from log messages (for wheel releases)" ${TILELANG_RELEASE_BUILD_DEFAULT})
+
 # Include tvm after configs have been populated
 add_subdirectory(${TVM_SOURCE} tvm EXCLUDE_FROM_ALL)
+
+# Provide the custom LogMessageImpl / LogFatalImpl implementation to TVM,
+# since TVM_LOG_CUSTOMIZE=1 requires them to be supplied by the user.
+target_sources(tvm_objs PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/src/runtime/logging.cc")
+if(TILELANG_RELEASE_BUILD)
+  target_compile_definitions(tvm_objs PRIVATE TILELANG_RELEASE_BUILD=1)
+endif()
 
 # Resolve compile warnings in tvm
 add_compile_definitions(DMLC_USE_LOGGING_LIBRARY=<tvm/runtime/logging.h>)
@@ -442,6 +463,10 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif()
 
 target_include_directories(tilelang_objs PRIVATE ${TILE_LANG_INCLUDES})
+target_compile_definitions(tilelang_objs PRIVATE TVM_LOG_CUSTOMIZE=1)
+if(TILELANG_RELEASE_BUILD)
+  target_compile_definitions(tilelang_objs PRIVATE TILELANG_RELEASE_BUILD=1)
+endif()
 
 add_library(tilelang SHARED $<TARGET_OBJECTS:tilelang_objs>)
 target_link_libraries(tilelang PUBLIC tvm)

--- a/src/op/atomic_add.cc
+++ b/src/op/atomic_add.cc
@@ -456,12 +456,15 @@ Stmt AtomicAddNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
                      shared_layout,
                      makeGemmABLayoutPadded(*stride, *continuous,
                                             shared_tensor->dtype.bits()))) {
-        DLOG(WARNING) << "AtomicAdd TMA cannot support a padded layout for src: "
-                     << src->name << ", dst: " << dst->name << " fallback to none swizzle";
+        DLOG(WARNING)
+            << "AtomicAdd TMA cannot support a padded layout for src: "
+            << src->name << ", dst: " << dst->name
+            << " fallback to none swizzle";
         desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_NONE);
       } else {
         DLOG(WARNING) << "AtomicAdd TMA unsupported swizzle layout for src: "
-                     << src->name << ", dst: " << dst->name << " fallback to none swizzle";
+                      << src->name << ", dst: " << dst->name
+                      << " fallback to none swizzle";
         desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_NONE);
       }
     }
@@ -500,8 +503,8 @@ Stmt AtomicAddNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     for (const auto &check : swizzle_checks) {
       if (desc.swizzle == check.swizzle && inner_box_dim_ > check.max_dim) {
         DLOG(WARNING) << "AtomicAdd TMA cannot support swizzled layout with "
-                        "inner_box_dim_ > "
-                     << check.max_dim;
+                         "inner_box_dim_ > "
+                      << check.max_dim;
       }
     }
 

--- a/src/op/atomic_add.cc
+++ b/src/op/atomic_add.cc
@@ -456,12 +456,12 @@ Stmt AtomicAddNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
                      shared_layout,
                      makeGemmABLayoutPadded(*stride, *continuous,
                                             shared_tensor->dtype.bits()))) {
-        LOG(WARNING) << "AtomicAdd TMA cannot support a padded layout for src: "
-                     << src->name << ", dst: " << dst->name;
+        DLOG(WARNING) << "AtomicAdd TMA cannot support a padded layout for src: "
+                     << src->name << ", dst: " << dst->name << " fallback to none swizzle";
         desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_NONE);
       } else {
-        LOG(WARNING) << "AtomicAdd TMA unsupported swizzle layout for src: "
-                     << src->name << ", dst: " << dst->name;
+        DLOG(WARNING) << "AtomicAdd TMA unsupported swizzle layout for src: "
+                     << src->name << ", dst: " << dst->name << " fallback to none swizzle";
         desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_NONE);
       }
     }
@@ -499,7 +499,7 @@ Stmt AtomicAddNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     };
     for (const auto &check : swizzle_checks) {
       if (desc.swizzle == check.swizzle && inner_box_dim_ > check.max_dim) {
-        LOG(WARNING) << "AtomicAdd TMA cannot support swizzled layout with "
+        DLOG(WARNING) << "AtomicAdd TMA cannot support swizzled layout with "
                         "inner_box_dim_ > "
                      << check.max_dim;
       }

--- a/src/runtime/logging.cc
+++ b/src/runtime/logging.cc
@@ -10,17 +10,17 @@ namespace runtime {
 namespace detail {
 
 namespace {
-const char* level_strings[] = {
-    ": Debug: ",    // TVM_LOG_LEVEL_DEBUG = 0
-    ": ",           // TVM_LOG_LEVEL_INFO  = 1
-    ": Warning: ",  // TVM_LOG_LEVEL_WARNING = 2
-    ": Error: ",    // TVM_LOG_LEVEL_ERROR = 3
-    ": Fatal: ",    // TVM_LOG_LEVEL_FATAL = 4
+const char *level_strings[] = {
+    ": Debug: ",   // TVM_LOG_LEVEL_DEBUG = 0
+    ": ",          // TVM_LOG_LEVEL_INFO  = 1
+    ": Warning: ", // TVM_LOG_LEVEL_WARNING = 2
+    ": Error: ",   // TVM_LOG_LEVEL_ERROR = 3
+    ": Fatal: ",   // TVM_LOG_LEVEL_FATAL = 4
 };
-}  // namespace
+} // namespace
 
-void LogMessageImpl(const std::string& file, int lineno, int level,
-                    const std::string& message) {
+void LogMessageImpl(const std::string &file, int lineno, int level,
+                    const std::string &message) {
   std::time_t t = std::time(nullptr);
   std::cerr << "[" << std::put_time(std::localtime(&t), "%H:%M:%S") << "] ";
 #ifdef TILELANG_RELEASE_BUILD
@@ -33,12 +33,12 @@ void LogMessageImpl(const std::string& file, int lineno, int level,
 #endif
 }
 
-[[noreturn]] void LogFatalImpl(const std::string& file, int lineno,
-                                const std::string& message) {
+[[noreturn]] void LogFatalImpl(const std::string &file, int lineno,
+                               const std::string &message) {
   LogMessageImpl(file, lineno, TVM_LOG_LEVEL_FATAL, message);
   throw InternalError(file, lineno, message);
 }
 
-}  // namespace detail
-}  // namespace runtime
-}  // namespace tvm
+} // namespace detail
+} // namespace runtime
+} // namespace tvm

--- a/src/runtime/logging.cc
+++ b/src/runtime/logging.cc
@@ -1,0 +1,44 @@
+#include <tvm/runtime/logging.h>
+
+#include <ctime>
+#include <iomanip>
+#include <iostream>
+#include <string>
+
+namespace tvm {
+namespace runtime {
+namespace detail {
+
+namespace {
+const char* level_strings[] = {
+    ": Debug: ",    // TVM_LOG_LEVEL_DEBUG = 0
+    ": ",           // TVM_LOG_LEVEL_INFO  = 1
+    ": Warning: ",  // TVM_LOG_LEVEL_WARNING = 2
+    ": Error: ",    // TVM_LOG_LEVEL_ERROR = 3
+    ": Fatal: ",    // TVM_LOG_LEVEL_FATAL = 4
+};
+}  // namespace
+
+void LogMessageImpl(const std::string& file, int lineno, int level,
+                    const std::string& message) {
+  std::time_t t = std::time(nullptr);
+  std::cerr << "[" << std::put_time(std::localtime(&t), "%H:%M:%S") << "] ";
+#ifdef TILELANG_RELEASE_BUILD
+  // Release (wheel) builds: omit file path for a cleaner user experience.
+  std::cerr << level_strings[level] << message << std::endl;
+#else
+  // Dev builds: include file path for debugging.
+  std::cerr << file << ":" << lineno << level_strings[level] << message
+            << std::endl;
+#endif
+}
+
+[[noreturn]] void LogFatalImpl(const std::string& file, int lineno,
+                                const std::string& message) {
+  LogMessageImpl(file, lineno, TVM_LOG_LEVEL_FATAL, message);
+  throw InternalError(file, lineno, message);
+}
+
+}  // namespace detail
+}  // namespace runtime
+}  // namespace tvm

--- a/src/transform/producer_consumer_ws.cc
+++ b/src/transform/producer_consumer_ws.cc
@@ -2394,10 +2394,10 @@ tvm::transform::Pass ProducerConsumerWarpSpecialized() {
     }
     // Only apply MVB + WS if the function is a tiled WS candidate.
     if (!TiledWSCandidate::Check(f->body, target.value())) {
-      LOG(WARNING) << "[WS] skipped: no TMA copies in pipeline loop";
+      DLOG(WARNING) << "[WS] skipped: no TMA copies in pipeline loop";
       return f;
     }
-    LOG(WARNING) << "[WS] candidate found, applying MVB + WS";
+    DLOG(WARNING) << "[WS] candidate found, applying MVB + WS";
     // Expand shared buffers for pipelining before the WS split.
     // Keep the original so we can fall back if the WS rewriter doesn't fire
     // (e.g. non-tile-op consumers in the loop body).
@@ -2405,7 +2405,7 @@ tvm::transform::Pass ProducerConsumerWarpSpecialized() {
     f = ApplyMultiVersionBufferRewriter(std::move(f));
     PrimFunc result = ProducerConsumerWSRewriter::Substitute(std::move(f));
     if (!result->HasNonzeroAttr(kTiledWSApplied)) {
-      LOG(WARNING) << "[WS] rewriter did not fire, falling back";
+      DLOG(WARNING) << "[WS] rewriter did not fire, falling back";
       // The TMA kernel needs warp specialization for correct pipelined
       // execution.  Since the tiled rewriter could not apply WS (e.g.
       // conditional loop body), strip pipeline annotations so that
@@ -2432,7 +2432,7 @@ tvm::transform::Pass ProducerConsumerWarpSpecialized() {
       fn->body = stripped;
       return original_f;
     }
-    LOG(WARNING) << "[WS] transformation applied successfully";
+    DLOG(WARNING) << "[WS] transformation applied successfully";
     return result;
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.ProducerConsumerWarpSpecialized",


### PR DESCRIPTION
## Summary

When tilelang is installed from a PyPI wheel, `LOG(WARNING)` messages currently leak the build machine's absolute file paths (e.g. `/home/runner/work/tilelang/tilelang/src/op/copy.cc:520`) because `__FILE__` is baked in at compile time. This is a poor user experience and exposes CI infrastructure details.

This PR enables TVM's `TVM_LOG_CUSTOMIZE` hook to take control of log output formatting, and conditionally strips source paths in release builds.

## Changes

- **Enable `TVM_LOG_CUSTOMIZE`** and provide custom `LogMessageImpl` / `LogFatalImpl` in `src/runtime/logging.cc`
- **Auto-detect release builds** via `CIBUILDWHEEL` and `SKBUILD_STATE` environment variables, exposed as the CMake option `TILELANG_RELEASE_BUILD`
- **Downgrade noisy diagnostics** from `LOG(WARNING)` to `DLOG(WARNING)` in `atomic_add.cc` and `producer_consumer_ws.cc` (these are development diagnostics, not actionable for end users)

### Behavior

| Build | `TILELANG_RELEASE_BUILD` | LOG(WARNING) output |
|---|---|---|
| Local dev (`pip install -e .`, `cmake .. && make`) | OFF | `[HH:MM:SS] /path/to/file.cc:123: Warning: msg` |
| Wheel (`cibuildwheel`, `python -m build`) | ON | `[HH:MM:SS] Warning: msg` |

No 3rdparty files are modified — the custom logging implementation lives entirely in tilelang-owned source.

## Test plan

- [x] Local build compiles and links successfully (`cmake --build . --target tilelang`)
- [x] `./format.sh` (pre-commit hooks) passes
- [ ] CI wheel build smoke test (`python -c "import tilelang; print(tilelang.__version__)"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced logging system with release-optimized message formatting and improved source path handling.
* **Improvements**
  * Release builds now display cleaner, more concise logs with source file paths hidden for improved readability.
  * Debug builds retain detailed source location information for development and troubleshooting purposes.
  * Reduced overall log verbosity in production/release-mode builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->