### PR TITLE
[AMD][gfx950] Add ds_read_tr16_b64 / ds_read_tr8_b64 support for gfx950  LDS transpose reads

### DIFF
--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -627,6 +627,20 @@ TIR_DEFINE_TL_BUILTIN(warp_reduce_bitor)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
+// ds_read_tr16_b64(smem_ptr) -> uint32x2
+// gfx950 LDS transpose read: 64-bit, 16-element transpose (FP16/BF16 MFMA)
+TIR_DEFINE_TL_BUILTIN(ds_read_tr16_b64)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
+// ds_read_tr8_b64(smem_ptr) -> uint32x2
+// gfx950 LDS transpose read: 64-bit, 8-element transpose (FP32 MFMA)
+TIR_DEFINE_TL_BUILTIN(ds_read_tr8_b64)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
 // __ldg(BufferLoad | Buffer, idx?) -> value
 // Treat as a pure call that returns the loaded value.
 TIR_DEFINE_TL_BUILTIN(__ldg).set_num_inputs(-1).set_attr<TCallEffectKind>(

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -825,6 +825,26 @@ TVM_DLL const Op &match_all_sync();
 TVM_DLL const Op &loop_break();
 
 /*!
+ * \brief tilelang intrinsic for gfx950 LDS transpose read, 64-bit, 16-element.
+ *
+ * Reads 8 bytes from LDS with a 16-element transpose (FP16/BF16 MFMA B-load).
+ * Only available on gfx950 (MI350/MI355X).
+ *
+ * uint32x2 ds_read_tr16_b64(smem_access_ptr)
+ */
+TVM_DLL const Op &ds_read_tr16_b64();
+
+/*!
+ * \brief tilelang intrinsic for gfx950 LDS transpose read, 64-bit, 8-element.
+ *
+ * Reads 8 bytes from LDS with an 8-element transpose (FP32 MFMA B-load).
+ * Only available on gfx950 (MI350/MI355X).
+ *
+ * uint32x2 ds_read_tr8_b64(smem_access_ptr)
+ */
+TVM_DLL const Op &ds_read_tr8_b64();
+
+/*!
  * \brief tvm intrinsic for amd matrix core mfma instructions.
  *
  *  void tvm_mfma(StringImm shape, StringImm A_layout, StringImm B_layout,

--- a/src/target/codegen_hip.cc
+++ b/src/target/codegen_hip.cc
@@ -1022,6 +1022,14 @@ void CodeGenTileLangHIP::VisitExpr_(const CallNode *op, std::ostream &os) {
       os << ", " << PrintExpr(op->args[i]);
     }
     os << ")";
+  } else if (op->op.same_as(tl::ds_read_tr16_b64())) {
+    ICHECK_EQ(op->args.size(), 1U)
+        << "tl.ds_read_tr16_b64 expects one argument (smem_access_ptr).";
+    os << "tl::ds_read_tr16_b64(" << PrintExpr(op->args[0]) << ")";
+  } else if (op->op.same_as(tl::ds_read_tr8_b64())) {
+    ICHECK_EQ(op->args.size(), 1U)
+        << "tl.ds_read_tr8_b64 expects one argument (smem_access_ptr).";
+    os << "tl::ds_read_tr8_b64(" << PrintExpr(op->args[0]) << ")";
   } else if (op->op.same_as(tl::__ldg())) {
     // HIP fallback: regular load
     const BufferLoadNode *bl = op->args[0].as<BufferLoadNode>();

--- a/src/tl_templates/hip/ldsm.h
+++ b/src/tl_templates/hip/ldsm.h
@@ -1,3 +1,45 @@
 #pragma once
 
 #include "common.h"
+
+namespace tl {
+
+#if defined(__gfx950__)
+
+// ds_read_tr16_b64: LDS transpose read, 64-bit, 16-element transpose.
+// Reads 8 bytes from LDS with a transpose across 16 elements.
+// Used for FP16/BF16 MFMA matrix B loads on gfx950 (MI350/MI355X).
+// smem_ptr must point into __shared__ memory.
+//
+// Uses __builtin_amdgcn_ds_read_tr16_b64_v4f16 (LLVM builtin) instead of
+// inline assembly because ROCm <= 7.2 assembler does not yet recognise the
+// ds_read_tr16_b64 mnemonic even though the hardware supports it.
+CK_TILE_DEVICE uint2 ds_read_tr16_b64(const void *smem_ptr) {
+  typedef __attribute__((__vector_size__(4 * sizeof(__fp16)))) __fp16 fp16x4_t;
+  // C-style cast: void* → LDS fp16x4_t* (required by the LLVM builtin signature)
+  fp16x4_t v = __builtin_amdgcn_ds_read_tr16_b64_v4f16(
+      (__attribute__((address_space(3))) fp16x4_t *)(smem_ptr));
+  uint2 result;
+  __builtin_memcpy(&result, &v, sizeof(result));
+  return result;
+}
+
+// ds_read_tr8_b64: LDS transpose read, 64-bit, 8-element transpose.
+// Reads 8 bytes from LDS with a transpose across 8 elements.
+// Used for FP32 MFMA matrix B loads on gfx950 (MI350/MI355X).
+// smem_ptr must point into __shared__ memory.
+//
+// Uses __builtin_amdgcn_ds_read_tr8_b64_v2i32 (LLVM builtin) for the same
+// reason as ds_read_tr16_b64 above.
+CK_TILE_DEVICE uint2 ds_read_tr8_b64(const void *smem_ptr) {
+  typedef __attribute__((__vector_size__(2 * sizeof(int)))) int i32x2_t;
+  i32x2_t v = __builtin_amdgcn_ds_read_tr8_b64_v2i32(
+      (__attribute__((address_space(3))) i32x2_t *)(smem_ptr));
+  uint2 result;
+  __builtin_memcpy(&result, &v, sizeof(result));
+  return result;
+}
+
+#endif // __gfx950__
+
+} // namespace tl

--- a/src/tl_templates/hip/ldsm.h
+++ b/src/tl_templates/hip/ldsm.h
@@ -16,7 +16,8 @@ namespace tl {
 // ds_read_tr16_b64 mnemonic even though the hardware supports it.
 CK_TILE_DEVICE uint2 ds_read_tr16_b64(const void *smem_ptr) {
   typedef __attribute__((__vector_size__(4 * sizeof(__fp16)))) __fp16 fp16x4_t;
-  // C-style cast: void* → LDS fp16x4_t* (required by the LLVM builtin signature)
+  // C-style cast: void* → LDS fp16x4_t* (required by the LLVM builtin
+  // signature)
   fp16x4_t v = __builtin_amdgcn_ds_read_tr16_b64_v4f16(
       (__attribute__((address_space(3))) fp16x4_t *)(smem_ptr));
   uint2 result;

--- a/testing/python/amd/test_tilelang_ds_read_tr.py
+++ b/testing/python/amd/test_tilelang_ds_read_tr.py
@@ -29,17 +29,18 @@ def requires_gfx950():
 # Kernels
 # ---------------------------------------------------------------------------
 
+
 # ds_read_tr16_b64: each thread reads 2 fp16 elements from LDS with a
 # 16-element transpose and stores the result (as float32x2) into a staging
 # shared buffer, which is then copied to global memory.
 @tilelang.jit(target="hip")
 def _kernel_tr16(X, Out):
     NV = T.const("NV")
-    X:   T.Tensor[[NV], T.float16]
+    X: T.Tensor[[NV], T.float16]
     Out: T.Tensor[[NV // 2], T.float32]
 
     with T.Kernel(1, threads=NV // 2) as _:
-        smem  = T.alloc_shared([NV],      T.float16)
+        smem = T.alloc_shared([NV], T.float16)
         smem2 = T.alloc_shared([NV // 2], T.float32)
         T.copy(X[:NV], smem[:NV])
         T.sync_threads()
@@ -47,18 +48,18 @@ def _kernel_tr16(X, Out):
             val = T.reinterpret(T.ds_read_tr16_b64(smem[i * 2]), T.float32x2)
             smem2[i * 2 : i * 2 + 2] = val
         T.sync_threads()
-        T.copy(smem2[:NV // 2], Out[:NV // 2])
+        T.copy(smem2[: NV // 2], Out[: NV // 2])
 
 
 # ds_read_tr8_b64: same pattern but reads float32 elements.
 @tilelang.jit(target="hip")
 def _kernel_tr8(X, Out):
     NV = T.const("NV")
-    X:   T.Tensor[[NV], T.float32]
+    X: T.Tensor[[NV], T.float32]
     Out: T.Tensor[[NV // 2], T.float32]
 
     with T.Kernel(1, threads=NV // 2) as _:
-        smem  = T.alloc_shared([NV],      T.float32)
+        smem = T.alloc_shared([NV], T.float32)
         smem2 = T.alloc_shared([NV // 2], T.float32)
         T.copy(X[:NV], smem[:NV])
         T.sync_threads()
@@ -66,7 +67,7 @@ def _kernel_tr8(X, Out):
             val = T.reinterpret(T.ds_read_tr8_b64(smem[i * 2]), T.float32x2)
             smem2[i * 2 : i * 2 + 2] = val
         T.sync_threads()
-        T.copy(smem2[:NV // 2], Out[:NV // 2])
+        T.copy(smem2[: NV // 2], Out[: NV // 2])
 
 
 # ---------------------------------------------------------------------------
@@ -84,9 +85,7 @@ def test_ds_read_tr16_b64_codegen():
     src = _kernel_tr16.get_kernel_source(NV=N)
     print("=== ds_read_tr16_b64 codegen ===")
     print(src)
-    assert "ds_read_tr16_b64" in src, (
-        "Expected tl::ds_read_tr16_b64 call in generated HIP source"
-    )
+    assert "ds_read_tr16_b64" in src, "Expected tl::ds_read_tr16_b64 call in generated HIP source"
 
 
 @tilelang.testing.requires_rocm
@@ -97,9 +96,7 @@ def test_ds_read_tr8_b64_codegen():
     src = _kernel_tr8.get_kernel_source(NV=N)
     print("=== ds_read_tr8_b64 codegen ===")
     print(src)
-    assert "ds_read_tr8_b64" in src, (
-        "Expected tl::ds_read_tr8_b64 call in generated HIP source"
-    )
+    assert "ds_read_tr8_b64" in src, "Expected tl::ds_read_tr8_b64 call in generated HIP source"
 
 
 @tilelang.testing.requires_rocm
@@ -107,7 +104,7 @@ def test_ds_read_tr16_b64_runtime():
     """ds_read_tr16_b64 kernel must execute without error on gfx950."""
     requires_gfx950()
 
-    X   = torch.randn(N,     dtype=torch.float16, device="cuda")
+    X = torch.randn(N, dtype=torch.float16, device="cuda")
     Out = torch.empty(N // 2, dtype=torch.float32, device="cuda")
     _kernel_tr16(X, Out)
     torch.cuda.synchronize()
@@ -118,7 +115,7 @@ def test_ds_read_tr8_b64_runtime():
     """ds_read_tr8_b64 kernel must execute without error on gfx950."""
     requires_gfx950()
 
-    X   = torch.randn(N,     dtype=torch.float32, device="cuda")
+    X = torch.randn(N, dtype=torch.float32, device="cuda")
     Out = torch.empty(N // 2, dtype=torch.float32, device="cuda")
     _kernel_tr8(X, Out)
     torch.cuda.synchronize()

--- a/testing/python/amd/test_tilelang_ds_read_tr.py
+++ b/testing/python/amd/test_tilelang_ds_read_tr.py
@@ -1,0 +1,128 @@
+"""Tests for ds_read_tr16_b64 and ds_read_tr8_b64 intrinsics on gfx950.
+
+Covers:
+  - Codegen: generated HIP source contains the correct tl:: call.
+  - Runtime: kernel compiles and executes on gfx950 without errors.
+
+ds_read_tr16_b64  – LDS transpose read, 64-bit, 16-element transpose.
+                    Used for FP16/BF16 MFMA B-loads on MI350/MI355X (gfx950).
+ds_read_tr8_b64   – LDS transpose read, 64-bit, 8-element transpose.
+                    Used for FP32 MFMA B-loads on MI350/MI355X (gfx950).
+"""
+
+import pytest
+import torch
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.utils.target import target_is_gfx950, determine_target
+
+
+def requires_gfx950():
+    """Skip the test when the current ROCm target is not gfx950."""
+    target = determine_target("auto", return_object=True)
+    if not target_is_gfx950(target):
+        pytest.skip("gfx950 (MI350/MI355X) not detected")
+
+
+# ---------------------------------------------------------------------------
+# Kernels
+# ---------------------------------------------------------------------------
+
+# ds_read_tr16_b64: each thread reads 2 fp16 elements from LDS with a
+# 16-element transpose and stores the result (as float32x2) into a staging
+# shared buffer, which is then copied to global memory.
+@tilelang.jit(target="hip")
+def _kernel_tr16(X, Out):
+    NV = T.const("NV")
+    X:   T.Tensor[[NV], T.float16]
+    Out: T.Tensor[[NV // 2], T.float32]
+
+    with T.Kernel(1, threads=NV // 2) as _:
+        smem  = T.alloc_shared([NV],      T.float16)
+        smem2 = T.alloc_shared([NV // 2], T.float32)
+        T.copy(X[:NV], smem[:NV])
+        T.sync_threads()
+        for i in T.Parallel(NV // 2):
+            val = T.reinterpret(T.ds_read_tr16_b64(smem[i * 2]), T.float32x2)
+            smem2[i * 2 : i * 2 + 2] = val
+        T.sync_threads()
+        T.copy(smem2[:NV // 2], Out[:NV // 2])
+
+
+# ds_read_tr8_b64: same pattern but reads float32 elements.
+@tilelang.jit(target="hip")
+def _kernel_tr8(X, Out):
+    NV = T.const("NV")
+    X:   T.Tensor[[NV], T.float32]
+    Out: T.Tensor[[NV // 2], T.float32]
+
+    with T.Kernel(1, threads=NV // 2) as _:
+        smem  = T.alloc_shared([NV],      T.float32)
+        smem2 = T.alloc_shared([NV // 2], T.float32)
+        T.copy(X[:NV], smem[:NV])
+        T.sync_threads()
+        for i in T.Parallel(NV // 2):
+            val = T.reinterpret(T.ds_read_tr8_b64(smem[i * 2]), T.float32x2)
+            smem2[i * 2 : i * 2 + 2] = val
+        T.sync_threads()
+        T.copy(smem2[:NV // 2], Out[:NV // 2])
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+N = 128  # number of fp16 elements in shared memory
+
+
+@tilelang.testing.requires_rocm
+def test_ds_read_tr16_b64_codegen():
+    """Generated HIP source must contain tl::ds_read_tr16_b64(...)."""
+    requires_gfx950()
+
+    src = _kernel_tr16.get_kernel_source(NV=N)
+    print("=== ds_read_tr16_b64 codegen ===")
+    print(src)
+    assert "ds_read_tr16_b64" in src, (
+        "Expected tl::ds_read_tr16_b64 call in generated HIP source"
+    )
+
+
+@tilelang.testing.requires_rocm
+def test_ds_read_tr8_b64_codegen():
+    """Generated HIP source must contain tl::ds_read_tr8_b64(...)."""
+    requires_gfx950()
+
+    src = _kernel_tr8.get_kernel_source(NV=N)
+    print("=== ds_read_tr8_b64 codegen ===")
+    print(src)
+    assert "ds_read_tr8_b64" in src, (
+        "Expected tl::ds_read_tr8_b64 call in generated HIP source"
+    )
+
+
+@tilelang.testing.requires_rocm
+def test_ds_read_tr16_b64_runtime():
+    """ds_read_tr16_b64 kernel must execute without error on gfx950."""
+    requires_gfx950()
+
+    X   = torch.randn(N,     dtype=torch.float16, device="cuda")
+    Out = torch.empty(N // 2, dtype=torch.float32, device="cuda")
+    _kernel_tr16(X, Out)
+    torch.cuda.synchronize()
+
+
+@tilelang.testing.requires_rocm
+def test_ds_read_tr8_b64_runtime():
+    """ds_read_tr8_b64 kernel must execute without error on gfx950."""
+    requires_gfx950()
+
+    X   = torch.randn(N,     dtype=torch.float32, device="cuda")
+    Out = torch.empty(N // 2, dtype=torch.float32, device="cuda")
+    _kernel_tr8(X, Out)
+    torch.cuda.synchronize()
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/language/__init__.py
+++ b/tilelang/language/__init__.py
@@ -96,6 +96,8 @@ from .customize import (
 from .logical import any_of, all_of  # noqa: F401
 from .builtin import *  # noqa: F401
 from .builtin import __ldg as __ldg  # noqa: F401
+from .builtin import ds_read_tr16_b64 as ds_read_tr16_b64  # noqa: F401
+from .builtin import ds_read_tr8_b64 as ds_read_tr8_b64  # noqa: F401
 from .builtin import ldg32 as ldg32  # noqa: F401
 from .builtin import ldg64 as ldg64  # noqa: F401
 from .builtin import ldg128 as ldg128  # noqa: F401

--- a/tilelang/language/builtin.py
+++ b/tilelang/language/builtin.py
@@ -1332,6 +1332,48 @@ def ptx_mma_sm70(
     )
 
 
+def ds_read_tr16_b64(src: BufferLikeType) -> PrimExpr:
+    """LDS transpose read, 64-bit, 16-element transpose (gfx950 only).
+
+    Reads 8 bytes from LDS (__shared__ memory) with a 16-element transpose.
+    Used for FP16/BF16 MFMA matrix B-loads on MI350/MI355X (gfx950).
+
+    Args:
+        src: A `Buffer`, `BufferRegion`, or `BufferLoad` in shared memory.
+
+    Returns:
+        PrimExpr: The loaded 64-bit value as uint32x2.
+
+    Example:
+        >>> val = T.ds_read_tr16_b64(smem[i])
+    """
+    if not isinstance(src, BufferLikeTypeTuple):
+        raise TypeError(f"T.ds_read_tr16_b64 expects Buffer, BufferRegion, or BufferLoad. Got {type(src)}: {src}")
+    ptr = retrieve_ptr(src, access_type="r")
+    return tir.call_intrin("uint32x2", tir.op.Op.get("tl.ds_read_tr16_b64"), ptr)
+
+
+def ds_read_tr8_b64(src: BufferLikeType) -> PrimExpr:
+    """LDS transpose read, 64-bit, 8-element transpose (gfx950 only).
+
+    Reads 8 bytes from LDS (__shared__ memory) with an 8-element transpose.
+    Used for FP32 MFMA matrix B-loads on MI350/MI355X (gfx950).
+
+    Args:
+        src: A `Buffer`, `BufferRegion`, or `BufferLoad` in shared memory.
+
+    Returns:
+        PrimExpr: The loaded 64-bit value as uint32x2.
+
+    Example:
+        >>> val = T.ds_read_tr8_b64(smem[i])
+    """
+    if not isinstance(src, BufferLikeTypeTuple):
+        raise TypeError(f"T.ds_read_tr8_b64 expects Buffer, BufferRegion, or BufferLoad. Got {type(src)}: {src}")
+    ptr = retrieve_ptr(src, access_type="r")
+    return tir.call_intrin("uint32x2", tir.op.Op.get("tl.ds_read_tr8_b64"), ptr)
+
+
 def ldg32(src: BufferLikeType, pred: PrimExpr = None) -> PrimExpr:
     """Load 32 bits (4 bytes) from global memory using explicit PTX instructions.
 


### PR DESCRIPTION
## Summary
This PR adds TileLang support for two gfx950-specific LDS transpose-read instructions, enabling MFMA-optimized matrix B-loads on MI350/MI355X hardware.

  - **`tl.ds_read_tr16_b64`** — 64-bit LDS transpose read across 16 elements,
    designed for FP16/BF16 MFMA B-loads.
  - **`tl.ds_read_tr8_b64`** — 64-bit LDS transpose read across 8 elements,
    designed for FP32 MFMA B-loads.

  Both instructions are backed by LLVM builtins (`__builtin_amdgcn_ds_read_tr16_b64_v4f16` and `__builtin_amdgcn_ds_read_tr8_b64_v2i32`) instead of inline assembly because ROCm ≤ 7.2 assembler does not yet recognise the `ds_read_tr16_b64` / `ds_read_tr8_b64` mnemonics even though gfx950 hardware fully supports them.

## Changes

  | File | Change |
  |---|---|
  | `src/op/builtin.h` / `builtin.cc` | Register `tl.ds_read_tr16_b64` and
  `tl.ds_read_tr8_b64` as pure TIR ops |
  | `src/target/codegen_hip.cc` | Emit `tl::ds_read_tr16_b64(...)` /
  `tl::ds_read_tr8_b64(...)` calls in generated HIP source |
  | `src/tl_templates/hip/ldsm.h` | Implement the two device functions inside
  `namespace tl`, guarded by `#if defined(__gfx950__)` |
  | `tilelang/language/builtin.py` | Python frontend wrappers
  (`ds_read_tr16_b64`, `ds_read_tr8_b64`) |
  | `tilelang/language/__init__.py` | Re-export both wrappers as
  `T.ds_read_tr16_b64` / `T.ds_read_tr8_b64` |
  | `testing/python/amd/test_tilelang_ds_read_tr.py` | Codegen and runtime tests
   (skipped automatically when gfx950 is not present) |

  ## Test plan
 kernel compiles and executes correctly on MI350/MI355X  (requires gfx950).

  ```bash
  pytest testing/python/amd/test_tilelang_ds_read_tr.py -v

  Notes

  - The device functions are compiled only when __gfx950__ is defined, so there is zero impact on other targets (CUDA, other AMD GPUs).
  - Return type is uint32x2; callers can T.reinterpret(...) to the desired element type (e.g. float16x2, float32x2).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new LDS transpose read operations for AMD MI350/MI355X GPUs, providing optimized memory access patterns for compute workloads.

* **Tests**
  * Added comprehensive test coverage including code generation validation and runtime execution tests for the new operations on gfx950 hardware targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->