### PR TITLE
[Bugfix] Enable `.shared::cta` in TMA copy paths only on CUDA 12.8+

### DIFF
--- a/src/target/ptx.cc
+++ b/src/target/ptx.cc
@@ -1428,11 +1428,19 @@ std::string PrintCpAsyncBulkAsm(const std::string &shared_ptr,
   {
     unsigned int smem_addr_int = cast_smem_ptr_to_int({smem_addr});
     unsigned int barrier_addr_int = cast_smem_ptr_to_int({barrier});
+#if (__CUDACC_VER_MAJOR__ > 12) || (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 8)
     __asm__ __volatile__(
       "cp.async.bulk.shared::cta.global.mbarrier::complete_tx::bytes [%0], [%1], %2, [%3];"
       :: "r"(smem_addr_int), "l"({global_ptr}), "r"({bytes}), "r"(barrier_addr_int)
       : "memory"
     );
+#else
+    __asm__ __volatile__(
+      "cp.async.bulk.shared::cluster.global.mbarrier::complete_tx::bytes [%0], [%1], %2, [%3];"
+      :: "r"(smem_addr_int), "l"({global_ptr}), "r"({bytes}), "r"(barrier_addr_int)
+      : "memory"
+    );
+#endif
   }
 )";
 

--- a/src/tl_templates/cuda/copy_sm90.h
+++ b/src/tl_templates/cuda/copy_sm90.h
@@ -20,10 +20,18 @@ TL_DEVICE void tma_load(void *smem_ptr, void const *gmem_ptr,
   uint32_t smem_int_mbar =
       smem_ptr_to_uint(reinterpret_cast<uint64_t *>(&smem_mbar));
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
+#if (__CUDACC_VER_MAJOR__ > 12) ||                                             \
+    (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 8)
   asm volatile("cp.async.bulk.shared::cta.global.mbarrier::complete_tx::"
                "bytes [%0], [%1], %2, [%3]; \n" ::"r"(smem_int_ptr),
                "l"((void const *)gmem_ptr), "r"(size), "r"(smem_int_mbar)
                :);
+#else
+  asm volatile("cp.async.bulk.shared::cluster.global.mbarrier::complete_tx::"
+               "bytes [%0], [%1], %2, [%3]; \n" ::"r"(smem_int_ptr),
+               "l"((void const *)gmem_ptr), "r"(size), "r"(smem_int_mbar)
+               :);
+#endif
 }
 
 TL_DEVICE void tma_load_multicast(void *smem_ptr, void *gmem_ptr,
@@ -50,6 +58,8 @@ TL_DEVICE void tma_load(const CUtensorMap &descriptor, BarrierType &smem_mbar,
     smem_int_mbar = smem_ptr_to_uint(reinterpret_cast<uint64_t *>(&smem_mbar));
   }
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
+#if (__CUDACC_VER_MAJOR__ > 12) ||                                             \
+    (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 8)
   asm volatile("cp.async.bulk.tensor.1d.shared::cta.global.mbarrier::"
                "complete_tx::bytes.L2::cache_hint"
                " [%0], [%1, {%3}], [%2], %4;"
@@ -57,6 +67,15 @@ TL_DEVICE void tma_load(const CUtensorMap &descriptor, BarrierType &smem_mbar,
                : "r"(smem_int_ptr), "l"(gmem_int_desc), "r"(smem_int_mbar),
                  "r"(crd0), "l"(cache_hint)
                : "memory");
+#else
+  asm volatile("cp.async.bulk.tensor.1d.shared::cluster.global.mbarrier::"
+               "complete_tx::bytes.L2::cache_hint"
+               " [%0], [%1, {%3}], [%2], %4;"
+               :
+               : "r"(smem_int_ptr), "l"(gmem_int_desc), "r"(smem_int_mbar),
+                 "r"(crd0), "l"(cache_hint)
+               : "memory");
+#endif
 }
 
 template <CacheHintSm90 cache_hint = CacheHintSm90::EVICT_NORMAL,
@@ -72,6 +91,8 @@ TL_DEVICE void tma_load(const CUtensorMap &descriptor, BarrierType &smem_mbar,
     smem_int_mbar = smem_ptr_to_uint(reinterpret_cast<uint64_t *>(&smem_mbar));
   }
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
+#if (__CUDACC_VER_MAJOR__ > 12) ||                                             \
+    (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 8)
   asm volatile("cp.async.bulk.tensor.2d.shared::cta.global.mbarrier::"
                "complete_tx::bytes.L2::cache_hint"
                " [%0], [%1, {%3, %4}], [%2], %5;"
@@ -79,6 +100,15 @@ TL_DEVICE void tma_load(const CUtensorMap &descriptor, BarrierType &smem_mbar,
                : "r"(smem_int_ptr), "l"(gmem_int_desc), "r"(smem_int_mbar),
                  "r"(crd0), "r"(crd1), "l"(cache_hint)
                : "memory");
+#else
+  asm volatile("cp.async.bulk.tensor.2d.shared::cluster.global.mbarrier::"
+               "complete_tx::bytes.L2::cache_hint"
+               " [%0], [%1, {%3, %4}], [%2], %5;"
+               :
+               : "r"(smem_int_ptr), "l"(gmem_int_desc), "r"(smem_int_mbar),
+                 "r"(crd0), "r"(crd1), "l"(cache_hint)
+               : "memory");
+#endif
 }
 
 template <CacheHintSm90 cache_hint = CacheHintSm90::EVICT_NORMAL,
@@ -94,6 +124,8 @@ TL_DEVICE void tma_load(const CUtensorMap &descriptor, BarrierType &smem_mbar,
     smem_int_mbar = smem_ptr_to_uint(reinterpret_cast<uint64_t *>(&smem_mbar));
   }
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
+#if (__CUDACC_VER_MAJOR__ > 12) ||                                             \
+    (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 8)
   asm volatile("cp.async.bulk.tensor.3d.shared::cta.global.mbarrier::"
                "complete_tx::bytes.L2::cache_hint"
                " [%0], [%1, {%3, %4, %5}], [%2], %6;"
@@ -101,6 +133,15 @@ TL_DEVICE void tma_load(const CUtensorMap &descriptor, BarrierType &smem_mbar,
                : "r"(smem_int_ptr), "l"(gmem_int_desc), "r"(smem_int_mbar),
                  "r"(crd0), "r"(crd1), "r"(crd2), "l"(cache_hint)
                : "memory");
+#else
+  asm volatile("cp.async.bulk.tensor.3d.shared::cluster.global.mbarrier::"
+               "complete_tx::bytes.L2::cache_hint"
+               " [%0], [%1, {%3, %4, %5}], [%2], %6;"
+               :
+               : "r"(smem_int_ptr), "l"(gmem_int_desc), "r"(smem_int_mbar),
+                 "r"(crd0), "r"(crd1), "r"(crd2), "l"(cache_hint)
+               : "memory");
+#endif
 }
 template <CacheHintSm90 cache_hint = CacheHintSm90::EVICT_NORMAL,
           typename BarrierType = uint64_t>
@@ -116,6 +157,8 @@ TL_DEVICE void tma_load(const CUtensorMap &descriptor, BarrierType &smem_mbar,
     smem_int_mbar = smem_ptr_to_uint(reinterpret_cast<uint64_t *>(&smem_mbar));
   }
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
+#if (__CUDACC_VER_MAJOR__ > 12) ||                                             \
+    (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 8)
   asm volatile("cp.async.bulk.tensor.4d.shared::cta.global.mbarrier::"
                "complete_tx::bytes.L2::cache_hint"
                " [%0], [%1, {%3, %4, %5, %6}], [%2], %7;"
@@ -123,6 +166,15 @@ TL_DEVICE void tma_load(const CUtensorMap &descriptor, BarrierType &smem_mbar,
                : "r"(smem_int_ptr), "l"(gmem_int_desc), "r"(smem_int_mbar),
                  "r"(crd0), "r"(crd1), "r"(crd2), "r"(crd3), "l"(cache_hint)
                : "memory");
+#else
+  asm volatile("cp.async.bulk.tensor.4d.shared::cluster.global.mbarrier::"
+               "complete_tx::bytes.L2::cache_hint"
+               " [%0], [%1, {%3, %4, %5, %6}], [%2], %7;"
+               :
+               : "r"(smem_int_ptr), "l"(gmem_int_desc), "r"(smem_int_mbar),
+                 "r"(crd0), "r"(crd1), "r"(crd2), "r"(crd3), "l"(cache_hint)
+               : "memory");
+#endif
 }
 
 template <CacheHintSm90 cache_hint = CacheHintSm90::EVICT_NORMAL,
@@ -139,6 +191,8 @@ TL_DEVICE void tma_load(const CUtensorMap &descriptor, BarrierType &smem_mbar,
     smem_int_mbar = smem_ptr_to_uint(reinterpret_cast<uint64_t *>(&smem_mbar));
   }
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
+#if (__CUDACC_VER_MAJOR__ > 12) ||                                             \
+    (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 8)
   asm volatile("cp.async.bulk.tensor.5d.shared::cta.global.mbarrier::"
                "complete_tx::bytes.L2::cache_hint"
                " [%0], [%1, {%3, %4, %5, %6, %7}], [%2], %8;"
@@ -147,6 +201,16 @@ TL_DEVICE void tma_load(const CUtensorMap &descriptor, BarrierType &smem_mbar,
                  "r"(crd0), "r"(crd1), "r"(crd2), "r"(crd3), "r"(crd4),
                  "l"(cache_hint)
                : "memory");
+#else
+  asm volatile("cp.async.bulk.tensor.5d.shared::cluster.global.mbarrier::"
+               "complete_tx::bytes.L2::cache_hint"
+               " [%0], [%1, {%3, %4, %5, %6, %7}], [%2], %8;"
+               :
+               : "r"(smem_int_ptr), "l"(gmem_int_desc), "r"(smem_int_mbar),
+                 "r"(crd0), "r"(crd1), "r"(crd2), "r"(crd3), "r"(crd4),
+                 "l"(cache_hint)
+               : "memory");
+#endif
 }
 
 template <CacheHintSm90 cache_hint = CacheHintSm90::EVICT_NORMAL,
@@ -161,6 +225,8 @@ tma_load_im2col(const CUtensorMap &descriptor, BarrierType &smem_mbar,
   uint32_t smem_int_mbar =
       smem_ptr_to_uint(reinterpret_cast<uint64_t *>(&smem_mbar));
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
+#if (__CUDACC_VER_MAJOR__ > 12) ||                                             \
+    (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 8)
   asm volatile("cp.async.bulk.tensor.4d.shared::cta.global.im2col.mbarrier:"
                ":complete_tx::bytes.L2::cache_hint"
                " [%0], [%1, {%3, %4, %5, %6}], [%2], {%7, %8}, %9;"
@@ -169,6 +235,16 @@ tma_load_im2col(const CUtensorMap &descriptor, BarrierType &smem_mbar,
                  "r"(coord_c), "r"(coord_w), "r"(coord_h), "r"(coord_n),
                  "h"(offset_w), "h"(offset_h), "l"(cache_hint)
                : "memory");
+#else
+  asm volatile("cp.async.bulk.tensor.4d.shared::cluster.global.im2col.mbarrier:"
+               ":complete_tx::bytes.L2::cache_hint"
+               " [%0], [%1, {%3, %4, %5, %6}], [%2], {%7, %8}, %9;"
+               :
+               : "r"(smem_int_ptr), "l"(gmem_int_desc), "r"(smem_int_mbar),
+                 "r"(coord_c), "r"(coord_w), "r"(coord_h), "r"(coord_n),
+                 "h"(offset_w), "h"(offset_h), "l"(cache_hint)
+               : "memory");
+#endif
 }
 
 template <CacheHintSm90 cache_hint = CacheHintSm90::EVICT_NORMAL>


### PR DESCRIPTION
### Summary

This PR updates TileLang SM90 TMA copy paths to use `.shared::cta`
only when compiling with CUDA 12.8 or newer.

For older CUDA toolchains, these paths continue to use `shared::cluster`.

### Changes

- Update regular SM90 TMA load paths in `src/tl_templates/cuda/copy_sm90.h`
- Update `im2col` TMA load paths in `src/tl_templates/cuda/copy_sm90.h`
- Update bulk G2S `cp.async.bulk.shared...` emission in:
  - `src/tl_templates/cuda/copy_sm90.h`
  - `src/target/ptx.cc`

### Why

Using `.shared::cta` unconditionally can cause SM90 kernels to fail during
PTX assembly on older toolchains with errors like:

```text
State space incorrect for instruction 'cp.async.bulk.tensor'
```

Restricting `.shared::cta` to CUDA 12.8+ keeps the newer path available
where supported while preserving compatibility with older toolchains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility of memory operations across different CUDA compiler versions. Updated instructions to ensure correct execution with current and recent toolchains, enhancing stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->