### PR TITLE
[BugFix] Relax loop wait and adjust trailing drain behavior in async pipeline tests

### DIFF
--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -1792,7 +1792,13 @@ private:
     for (size_t pos = 1; pos < suffix_wait_indices.size(); ++pos) {
       bool changed = false;
       int idx = suffix_wait_indices[pos];
-      seq.Set(idx, RewriteFirstStaticWaitInWrapper(seq[idx], retain, &changed));
+      // Tail consumers drain the final committed groups with no new commits in
+      // between. Relax them progressively from the end so the suffix becomes
+      // ..., wait<2>, wait<1>, wait<0> instead of rewriting every drain wait to
+      // the same retain count.
+      int new_wait_n = std::min(retain, static_cast<int>(pos));
+      seq.Set(idx,
+              RewriteFirstStaticWaitInWrapper(seq[idx], new_wait_n, &changed));
     }
     return seq;
   }

--- a/testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py
+++ b/testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py
@@ -390,15 +390,15 @@ def test_async_pipeline_does_not_mark_non_cp_async_compatible_copy():
     assert annotated == 0
 
 
-def test_async_pipeline_relaxes_loop_wait_and_splits_trailing_drain():
+def test_async_pipeline_relaxes_loop_wait_and_descends_trailing_drain():
     @T.prim_func
-    def before(A: T.Tensor((32,), T.uint8), B: T.Tensor((32,), T.uint8)):
+    def before(A: T.Tensor((40,), T.uint8), B: T.Tensor((40,), T.uint8)):
         S = T.alloc_buffer((4,), dtype=T.uint8, scope="shared")
         for i in T.serial(
             0,
-            4,
+            5,
             annotations={
-                "software_pipeline_stage": [0, 2],
+                "software_pipeline_stage": [0, 3],
                 "software_pipeline_order": [0, 1],
                 "software_pipeline_async_stages": [0],
                 "software_pipeline_async_producers": [1, 0],
@@ -424,8 +424,8 @@ def test_async_pipeline_relaxes_loop_wait_and_splits_trailing_drain():
     loop_waits = _collect_wait_args(loop.body)
     all_waits = _collect_wait_args(func)
 
-    assert loop_waits == [2], f"Expected relaxed loop wait to keep two groups in flight, got {loop_waits}"
-    assert all_waits == [2, 2, 0], f"Expected trailing waits to split into retain+drain, got {all_waits}"
+    assert loop_waits == [3], f"Expected relaxed loop wait to keep three groups in flight, got {loop_waits}"
+    assert all_waits == [3, 2, 1, 0], f"Expected trailing waits to descend through the drain suffix, got {all_waits}"
 
 
 def test_degenerate_pipeline_with_single_stage_is_not_expanded():


### PR DESCRIPTION
Updated the async pipeline logic to progressively relax loop waits and modify the trailing drain suffix. The test case was also adjusted to reflect changes in the expected behavior, ensuring that the pipeline maintains the correct number of groups in flight and descends through the drain suffix as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced software pipeline optimization for more efficient async operation wait sequencing. The refined approach now generates code with dynamically optimized wait patterns, producing better performance characteristics while maintaining full correctness.

* **Tests**
  * Updated test cases to validate the new pipeline optimization behavior and ensure proper handling of async operations in software pipeline generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->