### PR TITLE
Add opt-out for prelower semantic checks for DeepSeek V4 Flash on ARM64 

### DIFF
--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -83,7 +83,8 @@ def should_enable_race_check(pass_ctx: PassContext | None = None) -> bool:
 def should_enable_prelower_semantic_check(pass_ctx: PassContext | None = None) -> bool:
     if pass_ctx is None:
         pass_ctx = tilelang.transform.get_pass_context()
-    return not bool(pass_ctx and pass_ctx.config.get(tilelang.PassConfigKey.TL_DISABLE_PRELOWER_SEMANTIC_CHECK, False))
+    enabled = not pass_ctx.config.get(tilelang.PassConfigKey.TL_DISABLE_PRELOWER_SEMANTIC_CHECK, False)
+    return enabled
 
 
 def get_layout_visual_formats(pass_ctx: PassContext | None = None) -> list[str]:

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -80,6 +80,12 @@ def should_enable_race_check(pass_ctx: PassContext | None = None) -> bool:
     return enabled
 
 
+def should_enable_prelower_semantic_check(pass_ctx: PassContext | None = None) -> bool:
+    if pass_ctx is None:
+        pass_ctx = tilelang.transform.get_pass_context()
+    return not bool(pass_ctx and pass_ctx.config.get(tilelang.PassConfigKey.TL_DISABLE_PRELOWER_SEMANTIC_CHECK, False))
+
+
 def get_layout_visual_formats(pass_ctx: PassContext | None = None) -> list[str]:
     if pass_ctx is None:
         pass_ctx = tilelang.transform.get_pass_context()
@@ -121,6 +127,9 @@ def PreLowerSemanticCheck(mod: IRModule) -> None:
     in Python side instead of letting the error dive into the complicated TVM/C++ stack.
     Note: This is a validation-only pipeline of passes and does not modify or return the module.
     """
+
+    if not should_enable_prelower_semantic_check():
+        return
 
     # Print AST for debugging purpose
     if should_enable_ast_print():

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -52,6 +52,9 @@ class PassConfigKey(str, Enum):
     TL_DISABLE_DATA_RACE_CHECK = "tl.disable_data_race_check"
     """Disable data race check in TileLang. Default: False"""
 
+    TL_DISABLE_PRELOWER_SEMANTIC_CHECK = "tl.disable_prelower_semantic_check"
+    """Disable Python-side pre-lower semantic checks. Default: False"""
+
     TL_DISABLE_WARP_SPECIALIZED = "tl.disable_warp_specialized"
     """Disable warp specialization optimization. Default: False"""
 


### PR DESCRIPTION
 # TileLang / TVM Patch Investigation for DeepSeek V4 Flash on ARM64 Python 3.12

## Summary

    Exactly three TileLang wheel files were changed after install:

    1. `tilelang/3rdparty/tvm/python/tvm/runtime/support.py`
    2. `tilelang/analysis/nested_loop_checker.py`
    3. `tilelang/engine/phase.py`

## Findings

    - The `support.py` edit fixes a vendored TVM `derived_object`/`@tir.functor.visitor` initialization failure on
    Python 3.12/aarch64 by ensuring `_inst` can be assigned before attribute forwarding starts.
    - Current TileLang upstream already has a cleaner version of that fix in its `3rdparty/tvm` submodule:
    `TVMDerivedObject.__slots__` includes `_inst` conditionally.
    - The `nested_loop_checker.py` and `phase.py` edits are a broad local workaround: they disable TileLang
    pre-lower semantic checks entirely.
    - Disabling semantic checks globally is probably not upstreamable as-is because it removes useful validation
    for normal TileLang users.

    - The modified package is TileLang, not `apache-tvm-ffi`.
    - The user-visible DeepSeek V4 Flash unblock is caused by TileLang semantic-check behavior.
    - TileLang owns `NestedLoopChecker`, `PreLowerSemanticCheck`, and its vendored TVM submodule version.
    - `tvm-ffi` has no local modifications and no matching runtime `support.py` file for this fix.

## PR Rationale

Propose an opt-out pass config for pre-lower semantic validation:

```python
    PassConfigKey.TL_DISABLE_PRELOWER_SEMANTIC_CHECK = "tl.disable_prelower_semantic_check"
```

This makes the DeepSeek V4 Flash workaround explicit and scoped while preserving default validation. It is safer than the local patch because existing users keep current behavior, and model integrations can opt out only when they intentionally accept responsibility for generated TileLang IR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pass configuration option to toggle pre-lower semantic validation. When disabled, the pre-lower validation step and its related outputs are skipped, giving finer-grained control over the validation pipeline during passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->