### PR TITLE
[Fix] Fix tvm_ffi torch tensor handoff

### DIFF
--- a/testing/python/jit/test_tilelang_jit_tvm_ffi.py
+++ b/testing/python/jit/test_tilelang_jit_tvm_ffi.py
@@ -4,6 +4,8 @@ import tilelang.testing
 import tilelang
 import torch
 import pytest
+from tilelang.engine.param import KernelParam
+from tilelang.jit.adapter.tvm_ffi import TVMFFIKernelAdapter
 
 
 def matmul(
@@ -251,6 +253,41 @@ def run_tvm_ffi_kernel_multi_stream(
 
 def test_tvm_ffi_kernel_multi_stream():
     run_tvm_ffi_kernel_multi_stream(512, 1024, 768, False, False, T.float16, T.float16, T.float32, 128, 256, 32, 2)
+
+
+def test_tvm_ffi_adapter_converts_torch_tensors_before_executable_call():
+    seen_args = None
+
+    class FakeExecutable:
+        def __call__(self, *args):
+            nonlocal seen_args
+            seen_args = args
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((16,), T.int32),
+        B: T.Tensor((16,), T.int32),
+    ):
+        with T.Kernel(1, threads=1) as _:
+            for i in range(16):
+                B[i] = A[i]
+
+    adapter = TVMFFIKernelAdapter.__new__(TVMFFIKernelAdapter)
+    adapter.params = [KernelParam.from_buffer(main.buffer_map[p]) for p in main.params]
+    adapter.result_idx = [1]
+    adapter.ir_module = tvm.IRModule({"main": main.with_attr("global_symbol", "main")})
+    adapter.executable = FakeExecutable()
+    adapter.rt_mod = None
+
+    func = adapter._convert_torch_func()
+    inp = torch.arange(16, dtype=torch.int32)
+    out = func(inp)
+
+    assert isinstance(out, torch.Tensor)
+    assert seen_args is not None
+    assert len(seen_args) == 2
+    assert all(not isinstance(arg, torch.Tensor) for arg in seen_args)
+    assert all(isinstance(arg, tvm.runtime.Tensor) for arg in seen_args)
 
 
 def run_tvm_ffi_dynamic_shape(

--- a/testing/python/jit/test_tilelang_jit_tvm_ffi.py
+++ b/testing/python/jit/test_tilelang_jit_tvm_ffi.py
@@ -290,6 +290,42 @@ def test_tvm_ffi_adapter_converts_torch_tensors_before_executable_call():
     assert all(isinstance(arg, tvm.runtime.Tensor) for arg in seen_args)
 
 
+def test_tvm_ffi_adapter_accepts_non_contiguous_torch_tensors():
+    seen_args = None
+
+    class FakeExecutable:
+        def __call__(self, *args):
+            nonlocal seen_args
+            seen_args = args
+
+    @T.prim_func
+    def main(
+        A: T.StridedTensor((16, 16), (32, 1), T.float32),
+        B: T.Tensor((16, 16), T.float32),
+    ):
+        with T.Kernel(1, threads=1) as _:
+            for i, j in T.grid(16, 16):
+                B[i, j] = A[i, j]
+
+    adapter = TVMFFIKernelAdapter.__new__(TVMFFIKernelAdapter)
+    adapter.params = [KernelParam.from_buffer(main.buffer_map[p]) for p in main.params]
+    adapter.result_idx = [1]
+    adapter.ir_module = tvm.IRModule({"main": main.with_attr("global_symbol", "main")})
+    adapter.executable = FakeExecutable()
+    adapter.rt_mod = None
+
+    func = adapter._convert_torch_func()
+    base = torch.arange(16 * 32, dtype=torch.float32).reshape(16, 32)
+    inp = base[:, :16]
+    assert not inp.is_contiguous()
+    out = func(inp)
+
+    assert isinstance(out, torch.Tensor)
+    assert seen_args is not None
+    assert len(seen_args) == 2
+    assert all(isinstance(arg, tvm.runtime.Tensor) for arg in seen_args)
+
+
 def run_tvm_ffi_dynamic_shape(
     M, N, K, trans_A, trans_B, in_dtype, out_dtype, dtypeAccum, block_M, block_N, block_K, num_stages=3, num_threads=128
 ):

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -13,6 +13,7 @@ import sys
 
 import torch
 import torch.utils.dlpack
+import tvm_ffi
 from tilelang import tvm
 from tvm import runtime, tir
 from tvm.target import Target
@@ -247,7 +248,16 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
                 tensor_list.append(tensor)
 
             executable_args = tuple(
-                runtime.from_dlpack(torch.utils.dlpack.to_dlpack(tensor)) if isinstance(tensor, torch.Tensor) else tensor
+                # Use the legacy DLPack capsule explicitly so we bypass platform-specific
+                # torch.Tensor argument setters in tvm_ffi, while still accepting
+                # valid non-contiguous tensors/strided views.
+                tvm_ffi.from_dlpack(
+                    torch.utils.dlpack.to_dlpack(tensor),
+                    require_alignment=64,
+                    require_contiguous=False,
+                )
+                if isinstance(tensor, torch.Tensor)
+                else tensor
                 for tensor in tensor_list
             )
             executable(*executable_args)

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -12,6 +12,7 @@ from typing import Callable, Any
 import sys
 
 import torch
+import torch.utils.dlpack
 from tilelang import tvm
 from tvm import runtime, tir
 from tvm.target import Target
@@ -245,7 +246,11 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
                     ins_idx += 1
                 tensor_list.append(tensor)
 
-            executable(*tensor_list)
+            executable_args = tuple(
+                runtime.from_dlpack(torch.utils.dlpack.to_dlpack(tensor)) if isinstance(tensor, torch.Tensor) else tensor
+                for tensor in tensor_list
+            )
+            executable(*executable_args)
 
             # Return outputs in the requested form
             if len(self.result_idx) == 1:

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -12,7 +12,6 @@ from typing import Callable, Any
 import sys
 
 import torch
-import torch.utils.dlpack
 import tvm_ffi
 from tilelang import tvm
 from tvm import runtime, tir
@@ -248,12 +247,8 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
                 tensor_list.append(tensor)
 
             executable_args = tuple(
-                # Use the legacy DLPack capsule explicitly so we bypass platform-specific
-                # torch.Tensor argument setters in tvm_ffi, while still accepting
-                # valid non-contiguous tensors/strided views.
                 tvm_ffi.from_dlpack(
-                    torch.utils.dlpack.to_dlpack(tensor),
-                    require_alignment=64,
+                    tensor,
                     require_contiguous=False,
                 )
                 if isinstance(tensor, torch.Tensor)


### PR DESCRIPTION
## Summary
- convert Torch tensor arguments to tvm.runtime.Tensor before calling runtime.Executable
- add a regression test that checks the adapter does not pass raw torch.Tensor objects into the executable boundary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying that wrappers bridging PyTorch and the runtime convert tensor inputs as needed and still return PyTorch tensors.

* **Bug Fixes**
  * Improved runtime interoperability by converting PyTorch tensors into the runtime's compatible tensor form before invocation, including correct handling of contiguous and non-contiguous inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->