### PR TITLE
[AMD] Fix HIP codegen for sync_warp, sync_grid, and local.var initialisation

### DIFF
--- a/src/target/codegen_hip.cc
+++ b/src/target/codegen_hip.cc
@@ -210,6 +210,10 @@ std::string CodeGenTileLangHIP::Finish() {
     decl_stream << "#include <tl_templates/hip/hip_fp8.h>\n";
   }
 
+  if (need_cooperative_groups_) {
+    decl_stream << "#include <hip/hip_cooperative_groups.h>\n";
+  }
+
   decl_stream << "#include <tl_templates/hip/gemm.h>\n";
   decl_stream << "#include <tl_templates/hip/copy.h>\n";
   decl_stream << "#include <tl_templates/hip/reduce.h>\n";
@@ -836,6 +840,15 @@ std::string CodeGenTileLangHIP::GetBufferRef(DataType t,
     buffer_str = temp.str();
   }
 
+  if (scope.empty()) {
+    scope = GetPtrStorageScope(buffer->data);
+  }
+  // local.var is a scalar — no indexing needed.
+  if (scope == "local.var") {
+    os << vid;
+    return os.str();
+  }
+
   std::string index_str = PrintExpr(index);
   if (t.bits() == 4 || (t.bits() == 1 && t.is_int())) {
     // This is a special case, because CodegenCUDA::PrintType()
@@ -940,6 +953,14 @@ void CodeGenTileLangHIP::VisitExpr_(const CallNode *op, std::ostream &os) {
   } else if (op->op.same_as(tl::pack_b16())) {
     os << "__pack_half2(" << this->PrintExpr(op->args[0]) << ", "
        << this->PrintExpr(op->args[1]) << ")";
+  } else if (op->op.same_as(tl::sync_grid())) {
+    this->need_cooperative_groups_ = true;
+    this->PrintIndent();
+    this->stream << "cooperative_groups::this_grid().sync();\n";
+  } else if (op->op.same_as(tl::sync_warp())) {
+    // AMD wavefronts execute in lockstep, so intra-wavefront convergence is
+    // guaranteed by the hardware. __syncwarp() has no HIP equivalent and is a
+    // no-op here. The mask argument (if present) is intentionally ignored.
   } else if (op->op.same_as(tl::any_sync())) {
     ICHECK_EQ(op->args.size(), 2U) << "tl.any_sync expects <mask, predicate>.";
     // HIP __any takes only the predicate; the mask is ignored because
@@ -1435,7 +1456,23 @@ void CodeGenTileLangHIP::VisitStmt_(const AllocateNode *op) {
         scope == "shared") {
       constant_size = constant_size / (32 / op->dtype.bits());
     }
-    stream << ' ' << vid << '[' << constant_size << "];\n";
+
+    if (scope == "local.var") {
+      // Single-element variable: emit an initializer so the value is defined.
+      // Default to 0; respect the user-provided tl.local_var_init annotation.
+      PrimExpr init = tir::make_const(op->dtype, 0);
+      auto init_it = op->annotations.find(tl::attr::kLocalVarInit);
+      if (init_it != op->annotations.end()) {
+        PrimExpr user_init = Downcast<PrimExpr>((*init_it).second);
+        if (!user_init.dtype().is_void() && user_init.dtype() != op->dtype) {
+          user_init = tir::Cast(op->dtype, user_init);
+        }
+        init = user_init;
+      }
+      stream << ' ' << vid << " = " << PrintExpr(init) << ";\n";
+    } else {
+      stream << ' ' << vid << '[' << constant_size << "];\n";
+    }
   }
 
   RegisterHandleType(op->buffer_var.get(), op->dtype);

--- a/src/target/codegen_hip.h
+++ b/src/target/codegen_hip.h
@@ -73,6 +73,8 @@ private:
   friend void PrintConst(const FloatImmNode *op, std::ostream &os,
                          CodeGenTileLangHIP *p);
 
+  // whether need hip_cooperative_groups.h
+  bool need_cooperative_groups_{false};
   // whether need math_constants.h
   bool need_math_constants_h_{false};
   // whether need mfma.h

--- a/src/target/rt_mod_hip.cc
+++ b/src/target/rt_mod_hip.cc
@@ -41,6 +41,10 @@ ExtractFuncInfo(const IRModule &mod) {
         dtype = DataType::Int(32);
       info.arg_types.push_back(dtype);
     }
+    if (f->HasNonzeroAttr("use_cooperative_groups")) {
+      info.launch_param_tags.push_back(
+          runtime::launch_param::kUseCooperativeLaunch);
+    }
     if (auto opt = f->GetAttr<ffi::Array<ffi::String>>(
             tir::attr::kKernelLaunchParams)) {
       for (const auto &tag : opt.value()) {

--- a/src/target/stubs/hip.cc
+++ b/src/target/stubs/hip.cc
@@ -139,6 +139,7 @@ HIPDriverAPI CreateHIPDriverAPI() {
   LOOKUP(hipModuleGetFunction_, "hipModuleGetFunction")
   LOOKUP(hipModuleGetGlobal_, "hipModuleGetGlobal")
   LOOKUP(hipModuleLaunchKernel_, "hipModuleLaunchKernel")
+  LOOKUP(hipModuleLaunchCooperativeKernel_, "hipModuleLaunchCooperativeKernel")
 #undef LOOKUP
 
   return api;
@@ -395,6 +396,17 @@ hipError_t hipModuleLaunchKernel(hipFunction_t f, unsigned int gridDimX,
   return HIPDriverAPI::get()->hipModuleLaunchKernel_(
       f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ,
       sharedMemBytes, stream, kernelParams, extra);
+}
+
+hipError_t hipModuleLaunchCooperativeKernel(
+    hipFunction_t f, unsigned int gridDimX, unsigned int gridDimY,
+    unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY,
+    unsigned int blockDimZ, unsigned int sharedMemBytes, hipStream_t stream,
+    void **kernelParams) {
+  // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
+  return HIPDriverAPI::get()->hipModuleLaunchCooperativeKernel_(
+      f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ,
+      sharedMemBytes, stream, kernelParams);
 }
 
 // --- Minimal HSA wrappers

--- a/src/target/stubs/hip.h
+++ b/src/target/stubs/hip.h
@@ -80,7 +80,8 @@
   _(hipModuleUnload)                                                           \
   _(hipModuleGetFunction)                                                      \
   _(hipModuleGetGlobal)                                                        \
-  _(hipModuleLaunchKernel)
+  _(hipModuleLaunchKernel)                                                     \
+  _(hipModuleLaunchCooperativeKernel)
 
 namespace tvm::tl::hip {
 
@@ -132,6 +133,11 @@ struct TILELANG_HIP_STUB_API HIPDriverAPI {
                                        unsigned int, unsigned int, unsigned int,
                                        unsigned int, unsigned int, unsigned int,
                                        hipStream_t, void **, void **);
+  hipError_t (*hipModuleLaunchCooperativeKernel_)(hipFunction_t, unsigned int,
+                                                  unsigned int, unsigned int,
+                                                  unsigned int, unsigned int,
+                                                  unsigned int, unsigned int,
+                                                  hipStream_t, void **);
 
   static HIPDriverAPI *get();
   static bool is_available();
@@ -210,5 +216,11 @@ TILELANG_HIP_STUB_API hipError_t hipModuleLaunchKernel(
     unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY,
     unsigned int blockDimZ, unsigned int sharedMemBytes, hipStream_t stream,
     void **kernelParams, void **extra);
+
+TILELANG_HIP_STUB_API hipError_t hipModuleLaunchCooperativeKernel(
+    hipFunction_t f, unsigned int gridDimX, unsigned int gridDimY,
+    unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY,
+    unsigned int blockDimZ, unsigned int sharedMemBytes, hipStream_t stream,
+    void **kernelParams);
 
 } // extern "C"

--- a/src/tl_templates/hip/common.h
+++ b/src/tl_templates/hip/common.h
@@ -110,6 +110,20 @@ TL_DEVICE unsigned __pack_bfloat162(const bfloat16_t x, const bfloat16_t y) {
   return (v1 << 16) | v0;
 }
 
+// __habs overloads for hip_bfloat16 and float16_t to resolve ambiguity on ROCm.
+// hip_bfloat16 != __hip_bfloat16, and float16_t != __half, so the standard
+// __habs overloads don't match exactly, causing ambiguous overload errors.
+__device__ __forceinline__ hip_bfloat16 __habs(hip_bfloat16 a) {
+  unsigned short bits = *reinterpret_cast<unsigned short *>(&a);
+  bits &= 0x7FFFu;
+  return *reinterpret_cast<hip_bfloat16 *>(&bits);
+}
+__device__ __forceinline__ float16_t __habs(float16_t a) {
+  unsigned short bits = *reinterpret_cast<unsigned short *>(&a);
+  bits &= 0x7FFFu;
+  return *reinterpret_cast<float16_t *>(&bits);
+}
+
 namespace tl {
 
 // Packed x2 element-wise math helpers (HIP scalar fallbacks)

--- a/src/tl_templates/hip/hip_fp8.h
+++ b/src/tl_templates/hip/hip_fp8.h
@@ -199,28 +199,33 @@ struct __align__(16) fp8_e8_16_t {
 
 __device__ fp8_e4_4_t make_fp8_e4_4_t(fp8_e4_t x, fp8_e4_t y, fp8_e4_t z,
                                       fp8_e4_t w) {
-  // reinterpret the 4 fp8_e4_t values to signed char value and shift
-  signed char x_char = *reinterpret_cast<signed char *>(&x);
-  signed char y_char = *reinterpret_cast<signed char *>(&y);
-  signed char z_char = *reinterpret_cast<signed char *>(&z);
-  signed char w_char = *reinterpret_cast<signed char *>(&w);
-  int res = (w_char << 24) | (z_char << 16) | (y_char << 8) | x_char;
+  // reinterpret the 4 fp8_e4_t values to unsigned char to avoid sign extension
+  // on shift
+  unsigned char x_char = *reinterpret_cast<unsigned char *>(&x);
+  unsigned char y_char = *reinterpret_cast<unsigned char *>(&y);
+  unsigned char z_char = *reinterpret_cast<unsigned char *>(&z);
+  unsigned char w_char = *reinterpret_cast<unsigned char *>(&w);
+  unsigned int res = ((unsigned int)w_char << 24) |
+                     ((unsigned int)z_char << 16) |
+                     ((unsigned int)y_char << 8) | (unsigned int)x_char;
   return *reinterpret_cast<fp8_e4_4_t *>(&res);
 }
 
 __device__ fp8_e4_8_t make_fp8_e4_8_t(fp8_e4_t x, fp8_e4_t y, fp8_e4_t z,
                                       fp8_e4_t w, fp8_e4_t v, fp8_e4_t u,
                                       fp8_e4_t t, fp8_e4_t s) {
-  signed char x_char = *reinterpret_cast<signed char *>(&x);
-  signed char y_char = *reinterpret_cast<signed char *>(&y);
-  signed char z_char = *reinterpret_cast<signed char *>(&z);
-  signed char w_char = *reinterpret_cast<signed char *>(&w);
-  signed char v_char = *reinterpret_cast<signed char *>(&v);
-  signed char u_char = *reinterpret_cast<signed char *>(&u);
-  signed char t_char = *reinterpret_cast<signed char *>(&t);
-  signed char s_char = *reinterpret_cast<signed char *>(&s);
-  int a = (w_char << 24) | (z_char << 16) | (y_char << 8) | x_char;
-  int b = (s_char << 24) | (t_char << 16) | (u_char << 8) | v_char;
+  unsigned char x_char = *reinterpret_cast<unsigned char *>(&x);
+  unsigned char y_char = *reinterpret_cast<unsigned char *>(&y);
+  unsigned char z_char = *reinterpret_cast<unsigned char *>(&z);
+  unsigned char w_char = *reinterpret_cast<unsigned char *>(&w);
+  unsigned char v_char = *reinterpret_cast<unsigned char *>(&v);
+  unsigned char u_char = *reinterpret_cast<unsigned char *>(&u);
+  unsigned char t_char = *reinterpret_cast<unsigned char *>(&t);
+  unsigned char s_char = *reinterpret_cast<unsigned char *>(&s);
+  unsigned int a = ((unsigned int)w_char << 24) | ((unsigned int)z_char << 16) |
+                   ((unsigned int)y_char << 8) | (unsigned int)x_char;
+  unsigned int b = ((unsigned int)s_char << 24) | ((unsigned int)t_char << 16) |
+                   ((unsigned int)u_char << 8) | (unsigned int)v_char;
   fp8_e4_8_t res;
   res.x = *reinterpret_cast<fp8_e4_4_t *>(&a);
   res.y = *reinterpret_cast<fp8_e4_4_t *>(&b);
@@ -233,26 +238,34 @@ __device__ fp8_e4_16_t make_fp8_e4_16_t(fp8_e4_t x0, fp8_e4_t x1, fp8_e4_t x2,
                                         fp8_e4_t y1, fp8_e4_t y2, fp8_e4_t y3,
                                         fp8_e4_t y4, fp8_e4_t y5, fp8_e4_t y6,
                                         fp8_e4_t y7) {
-  signed char x0_char = *reinterpret_cast<signed char *>(&x0);
-  signed char x1_char = *reinterpret_cast<signed char *>(&x1);
-  signed char x2_char = *reinterpret_cast<signed char *>(&x2);
-  signed char x3_char = *reinterpret_cast<signed char *>(&x3);
-  signed char x4_char = *reinterpret_cast<signed char *>(&x4);
-  signed char x5_char = *reinterpret_cast<signed char *>(&x5);
-  signed char x6_char = *reinterpret_cast<signed char *>(&x6);
-  signed char x7_char = *reinterpret_cast<signed char *>(&x7);
-  signed char y0_char = *reinterpret_cast<signed char *>(&y0);
-  signed char y1_char = *reinterpret_cast<signed char *>(&y1);
-  signed char y2_char = *reinterpret_cast<signed char *>(&y2);
-  signed char y3_char = *reinterpret_cast<signed char *>(&y3);
-  signed char y4_char = *reinterpret_cast<signed char *>(&y4);
-  signed char y5_char = *reinterpret_cast<signed char *>(&y5);
-  signed char y6_char = *reinterpret_cast<signed char *>(&y6);
-  signed char y7_char = *reinterpret_cast<signed char *>(&y7);
-  int a = (x3_char << 24) | (x2_char << 16) | (x1_char << 8) | x0_char;
-  int b = (x7_char << 24) | (x6_char << 16) | (x5_char << 8) | x4_char;
-  int c = (y3_char << 24) | (y2_char << 16) | (y1_char << 8) | y0_char;
-  int d = (y7_char << 24) | (y6_char << 16) | (y5_char << 8) | y4_char;
+  unsigned char x0_char = *reinterpret_cast<unsigned char *>(&x0);
+  unsigned char x1_char = *reinterpret_cast<unsigned char *>(&x1);
+  unsigned char x2_char = *reinterpret_cast<unsigned char *>(&x2);
+  unsigned char x3_char = *reinterpret_cast<unsigned char *>(&x3);
+  unsigned char x4_char = *reinterpret_cast<unsigned char *>(&x4);
+  unsigned char x5_char = *reinterpret_cast<unsigned char *>(&x5);
+  unsigned char x6_char = *reinterpret_cast<unsigned char *>(&x6);
+  unsigned char x7_char = *reinterpret_cast<unsigned char *>(&x7);
+  unsigned char y0_char = *reinterpret_cast<unsigned char *>(&y0);
+  unsigned char y1_char = *reinterpret_cast<unsigned char *>(&y1);
+  unsigned char y2_char = *reinterpret_cast<unsigned char *>(&y2);
+  unsigned char y3_char = *reinterpret_cast<unsigned char *>(&y3);
+  unsigned char y4_char = *reinterpret_cast<unsigned char *>(&y4);
+  unsigned char y5_char = *reinterpret_cast<unsigned char *>(&y5);
+  unsigned char y6_char = *reinterpret_cast<unsigned char *>(&y6);
+  unsigned char y7_char = *reinterpret_cast<unsigned char *>(&y7);
+  unsigned int a = ((unsigned int)x3_char << 24) |
+                   ((unsigned int)x2_char << 16) |
+                   ((unsigned int)x1_char << 8) | (unsigned int)x0_char;
+  unsigned int b = ((unsigned int)x7_char << 24) |
+                   ((unsigned int)x6_char << 16) |
+                   ((unsigned int)x5_char << 8) | (unsigned int)x4_char;
+  unsigned int c = ((unsigned int)y3_char << 24) |
+                   ((unsigned int)y2_char << 16) |
+                   ((unsigned int)y1_char << 8) | (unsigned int)y0_char;
+  unsigned int d = ((unsigned int)y7_char << 24) |
+                   ((unsigned int)y6_char << 16) |
+                   ((unsigned int)y5_char << 8) | (unsigned int)y4_char;
   fp8_e4_8_t res_x;
   res_x.x = *reinterpret_cast<fp8_e4_4_t *>(&a);
   res_x.y = *reinterpret_cast<fp8_e4_4_t *>(&b);

--- a/testing/python/amd/test_tilelang_hip_codegen.py
+++ b/testing/python/amd/test_tilelang_hip_codegen.py
@@ -1,0 +1,252 @@
+"""
+Tests for HIP/AMD codegen fixes in TileLang.
+
+Covers three fixes made to src/target/codegen_hip.cc:
+  1. T.sync_warp() is lowered to a no-op on HIP (AMD wavefronts execute in
+     lockstep so no explicit reconvergence barrier is needed).
+  2. T.alloc_var(dtype, init=value) emits a properly initialised scalar
+     declaration on HIP (previously the init value was silently dropped).
+  3. local.var buffers are accessed as plain scalars in GetBufferRef (no [0]
+     subscript), consistent with the scalar declaration emitted for them.
+"""
+
+import torch
+import tilelang
+import tilelang.testing
+import tilelang.language as T
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: T.sync_warp() → no-op on HIP
+# ---------------------------------------------------------------------------
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+    }
+)
+def _kernel_sync_warp_codegen():
+    """Minimal kernel that exercises T.sync_warp()."""
+
+    @T.prim_func
+    def main(A: T.Tensor((32,), "float32"), B: T.Tensor((32,), "float32")):
+        with T.Kernel(1, threads=32):
+            tx = T.get_thread_binding()
+            A_shared = T.alloc_shared((32,), "float32")
+            A_shared[tx] = A[tx]
+            T.sync_warp()
+            B[tx] = A_shared[tx] * 2.0
+
+    return main
+
+
+@tilelang.testing.requires_rocm
+def test_sync_warp_no_syncwarp_in_hip_source():
+    """__syncwarp must NOT appear in the HIP-generated kernel source."""
+    kernel = _kernel_sync_warp_codegen()
+    src = kernel.get_kernel_source()
+    assert "__syncwarp" not in src, (
+        "T.sync_warp() should be a no-op on HIP (AMD wavefronts are lockstep), "
+        f"but __syncwarp was found in the generated source:\n{src}"
+    )
+
+
+@tilelang.testing.requires_rocm
+def test_sync_warp_correctness():
+    """Kernel using T.sync_warp() should produce correct results on HIP."""
+    kernel = _kernel_sync_warp_codegen()
+    A = torch.arange(32, dtype=torch.float32, device="cuda")
+    B = torch.zeros(32, dtype=torch.float32, device="cuda")
+    kernel(A, B)
+    torch.testing.assert_close(B, A * 2.0)
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: T.alloc_var(init=...) initialisation on HIP
+# ---------------------------------------------------------------------------
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+    }
+)
+def _kernel_alloc_var_init():
+    """Kernel that initialises a local int32 variable and writes it to output."""
+
+    @T.prim_func
+    def main(Out: T.Tensor((64,), "int32")):
+        with T.Kernel(1, threads=64):
+            tx = T.get_thread_binding()
+            counter = T.alloc_var(T.int32, init=7)
+            Out[tx] = counter
+
+    return main
+
+
+@tilelang.testing.requires_rocm
+def test_alloc_var_init_in_hip_source():
+    """Init value must appear in the generated HIP source for T.alloc_var."""
+    kernel = _kernel_alloc_var_init()
+    src = kernel.get_kernel_source()
+    assert "= 7;" in src, (
+        "T.alloc_var(T.int32, init=7) should generate '= 7;' in HIP source, "
+        f"but it was not found.\nGenerated source:\n{src}"
+    )
+
+
+@tilelang.testing.requires_rocm
+def test_alloc_var_init_no_array_subscript_in_hip_source():
+    """local.var should be declared as a scalar, not as an array (no [0])."""
+    kernel = _kernel_alloc_var_init()
+    src = kernel.get_kernel_source()
+    # The kernel source should contain 'counter = 7' not 'counter[1]' or 'counter[0]'
+    assert "counter[" not in src, (
+        "local.var should be emitted as a scalar (e.g. 'int counter = 7'), "
+        f"but array-style access was found in the HIP source:\n{src}"
+    )
+
+
+@tilelang.testing.requires_rocm
+def test_alloc_var_init_correctness():
+    """Kernel should read back the initialised value correctly on HIP."""
+    kernel = _kernel_alloc_var_init()
+    out = torch.zeros(64, dtype=torch.int32, device="cuda")
+    kernel(out)
+    assert torch.all(out == 7), (
+        f"Expected all 7, got: {out}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fix 2b: multiple T.alloc_var with distinct init values
+# ---------------------------------------------------------------------------
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+    }
+)
+def _kernel_multi_alloc_var_init():
+    """Two local variables with different init values, summed into output."""
+
+    @T.prim_func
+    def main(Out: T.Tensor((32,), "int32")):
+        with T.Kernel(1, threads=32):
+            tx = T.get_thread_binding()
+            a = T.alloc_var(T.int32, init=3)
+            b = T.alloc_var(T.int32, init=4)
+            Out[tx] = a + b
+
+    return main
+
+
+@tilelang.testing.requires_rocm
+def test_multi_alloc_var_init_in_hip_source():
+    """Both init values must appear in the HIP source."""
+    kernel = _kernel_multi_alloc_var_init()
+    src = kernel.get_kernel_source()
+    assert src.count("= 3;") >= 1, f"Init value 3 not found in HIP source:\n{src}"
+    assert src.count("= 4;") >= 1, f"Init value 4 not found in HIP source:\n{src}"
+
+
+@tilelang.testing.requires_rocm
+def test_multi_alloc_var_init_correctness():
+    """Sum of two initialised local variables should equal 7 on HIP."""
+    kernel = _kernel_multi_alloc_var_init()
+    out = torch.zeros(32, dtype=torch.int32, device="cuda")
+    kernel(out)
+    assert torch.all(out == 7), f"Expected all 7 (3+4), got: {out}"
+
+
+# ---------------------------------------------------------------------------
+# Fix 2c: T.alloc_var(init=0) — the default zero-init case
+# ---------------------------------------------------------------------------
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+    }
+)
+def _kernel_alloc_var_count():
+    """
+    Accumulates a count by incrementing a local variable in a loop.
+    Relies on the variable being zero-initialised (init=0 default).
+    """
+
+    @T.prim_func
+    def main(Out: T.Tensor((32,), "int32")):
+        with T.Kernel(1, threads=32):
+            tx = T.get_thread_binding()
+            count = T.alloc_var(T.int32, init=0)
+            for _ in T.unroll(5):
+                count += 1
+            Out[tx] = count
+
+    return main
+
+
+@tilelang.testing.requires_rocm
+def test_alloc_var_zero_init_correctness():
+    """Variable initialised to 0, incremented 5 times, should equal 5."""
+    kernel = _kernel_alloc_var_count()
+    out = torch.zeros(32, dtype=torch.int32, device="cuda")
+    kernel(out)
+    assert torch.all(out == 5), f"Expected all 5, got: {out}"
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: T.sync_grid() codegen on HIP (codegen only; runtime not yet complete)
+# ---------------------------------------------------------------------------
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+    }
+)
+def _kernel_sync_grid_codegen():
+    """Kernel that calls T.sync_grid() to trigger cooperative groups codegen."""
+
+    @T.prim_func
+    def main(A: T.Tensor((32,), "float32")):
+        with T.Kernel(1, threads=32):
+            tx = T.get_thread_binding()
+            T.sync_grid()
+            A[tx] = T.float32(tx)
+
+    return main
+
+
+@tilelang.testing.requires_rocm
+def test_sync_grid_cooperative_groups_in_hip_source():
+    """
+    T.sync_grid() should generate cooperative_groups::this_grid().sync()
+    and include <hip/hip_cooperative_groups.h> in the HIP source.
+
+    Note: runtime execution of this kernel is not yet supported because
+    rocm_module.cc does not yet call hipModuleLaunchCooperativeKernel.
+    This test validates codegen only.
+    """
+    kernel = _kernel_sync_grid_codegen()
+    src = kernel.get_kernel_source()
+    assert "this_grid().sync()" in src, (
+        "T.sync_grid() should generate 'this_grid().sync()' in HIP source, "
+        f"but it was not found:\n{src}"
+    )
+    assert "cooperative_groups" in src, (
+        "T.sync_grid() should include cooperative_groups in HIP source, "
+        f"but it was not found:\n{src}"
+    )
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
when support Tilekernel on AMD GPU, we found TileKerle used some unsupported operation for AMD GPUs, which caused test case to fail. Three fixes to the HIP code generator, plus the cooperative-kernel launch infrastructure needed for T.sync_grid().

1. T.sync_warp() → no-op on HIP (codegen_hip.cc)

NVIDIA Volta introduced Independent Thread Scheduling, making __syncwarp() necessary to re-converge diverged warp threads. AMD wavefronts always execute in lockstep, so the hardware guarantees convergence without any explicit barrier. HIP provides no __syncwarp() equivalent. Previously TileLang hit a LOG(FATAL) "Unresolved call" on any kernel that used T.sync_warp(). Now it is lowered to a no-op (no code emitted), matching the behaviour of the existing "warp" sync path in PrintStorageSync().

2. T.sync_grid() → cooperative_groups::this_grid().sync() on HIP (codegen_hip.cc, codegen_hip.h, stubs/hip.h, stubs/hip.cc, rt_mod_hip.cc)

 T.sync_grid() previously had no HIP handler and caused a fatal codegen error. It is now lowered to cooperative_groups::this_grid().sync(), matching the CUDA path. Supporting infrastructure added:
  - need_cooperative_groups_ flag in CodeGenTileLangHIP that gates inclusion of <hip/hip_cooperative_groups.h>.
  - hipModuleLaunchCooperativeKernel lazy-load stub in the HIP driver shim, so the symbol is available without linking directly against libamdhip64.
  - ExtractFuncInfo in rt_mod_hip.cc now propagates the use_cooperative_groups PrimFunc attr as a kUseCooperativeLaunch launch-param tag, mirroring the CUDA path in rt_mod_cuda.cc.

3. T.alloc_var(init=...) emits initialized scalar on HIP (codegen_hip.cc)

local.var-scoped allocations are single-element variables. The CUDA codegen emits them as `type name = init_value;` and looks up the tl.local_var_init annotation to find the user-supplied initializer. The HIP codegen emitted `type name[1];` unconditionally, silently dropping the init value and leaving the variable undefined. This caused incorrect results on AMD (e.g. unrolled accumulation loops starting from garbage).
Fix: VisitStmt_(AllocateNode) now mirrors the CUDA path for local.var:
  - Emits `type name = 0;` by default.
  - Uses the tl.local_var_init annotation value when present.
  GetBufferRef is also updated to return `vid` directly (no [index] subscript) for local.var, consistent with the scalar declaration.

 New Test Case for this commit:
 testing/python/amd/test_tilelang_hip_codegen.py covers:
  - Absence of __syncwarp in HIP source for T.sync_warp() kernels.
  - Correctness of T.sync_warp() kernels at runtime on AMD.
  - Presence of init value in HIP source for T.alloc_var(init=N).
  - Absence of array subscript (e.g. counter[0]) for local.var scalars.
  - Runtime correctness of T.alloc_var(init=N) on AMD.
  - Codegen correctness of T.sync_grid() (cooperative_groups present i

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for grid-wide synchronization via `sync_grid()` on HIP
  * Added cooperative kernel launch API support for HIP
  * Added device `__habs` overloads for 16-bit floating-point types

* **Bug Fixes**
  * Fixed FP8-E4 packing helpers to correctly handle sign bits

* **Tests**
  * Added comprehensive HIP codegen validation test suite

<!-- end of auto-generated comment: release notes by coderabbit.ai -->