### PR TITLE
[AMD] [gfx950]Fix multiple HIP codegen bugs to support TileKernel  

### DIFF
--- a/src/target/codegen_hip.cc
+++ b/src/target/codegen_hip.cc
@@ -723,7 +723,7 @@ void CodeGenTileLangHIP::VisitExpr_(const ShuffleNode *op,
   // as HIP_vector_type<unsigned int, 1> which has a single .x member.
   DataType t = op->dtype;
   bool is_bf16x2 = t.is_bfloat16() && t.lanes() == 2;
-  bool is_fp16x2  = t.is_float16()  && t.lanes() == 2;
+  bool is_fp16x2 = t.is_float16() && t.lanes() == 2;
   if ((is_bf16x2 || is_fp16x2) && op->vectors.size() == 2 &&
       op->vectors[0].dtype().lanes() == 1 &&
       op->vectors[1].dtype().lanes() == 1) {

--- a/src/target/codegen_hip.cc
+++ b/src/target/codegen_hip.cc
@@ -210,6 +210,10 @@ std::string CodeGenTileLangHIP::Finish() {
     decl_stream << "#include <tl_templates/hip/hip_fp8.h>\n";
   }
 
+  if (need_cooperative_groups_) {
+    decl_stream << "#include <hip/hip_cooperative_groups.h>\n";
+  }
+
   decl_stream << "#include <tl_templates/hip/gemm.h>\n";
   decl_stream << "#include <tl_templates/hip/copy.h>\n";
   decl_stream << "#include <tl_templates/hip/reduce.h>\n";
@@ -836,6 +840,15 @@ std::string CodeGenTileLangHIP::GetBufferRef(DataType t,
     buffer_str = temp.str();
   }
 
+  if (scope.empty()) {
+    scope = GetPtrStorageScope(buffer->data);
+  }
+  // local.var is a scalar — no indexing needed.
+  if (scope == "local.var") {
+    os << vid;
+    return os.str();
+  }
+
   std::string index_str = PrintExpr(index);
   if (t.bits() == 4 || (t.bits() == 1 && t.is_int())) {
     // This is a special case, because CodegenCUDA::PrintType()
@@ -940,6 +953,14 @@ void CodeGenTileLangHIP::VisitExpr_(const CallNode *op, std::ostream &os) {
   } else if (op->op.same_as(tl::pack_b16())) {
     os << "__pack_half2(" << this->PrintExpr(op->args[0]) << ", "
        << this->PrintExpr(op->args[1]) << ")";
+  } else if (op->op.same_as(tl::sync_grid())) {
+    this->need_cooperative_groups_ = true;
+    this->PrintIndent();
+    this->stream << "cooperative_groups::this_grid().sync();\n";
+  } else if (op->op.same_as(tl::sync_warp())) {
+    // AMD wavefronts execute in lockstep, so intra-wavefront convergence is
+    // guaranteed by the hardware. __syncwarp() has no HIP equivalent and is a
+    // no-op here. The mask argument (if present) is intentionally ignored.
   } else if (op->op.same_as(tl::any_sync())) {
     ICHECK_EQ(op->args.size(), 2U) << "tl.any_sync expects <mask, predicate>.";
     // HIP __any takes only the predicate; the mask is ignored because
@@ -1435,7 +1456,23 @@ void CodeGenTileLangHIP::VisitStmt_(const AllocateNode *op) {
         scope == "shared") {
       constant_size = constant_size / (32 / op->dtype.bits());
     }
-    stream << ' ' << vid << '[' << constant_size << "];\n";
+
+    if (scope == "local.var") {
+      // Single-element variable: emit an initializer so the value is defined.
+      // Default to 0; respect the user-provided tl.local_var_init annotation.
+      PrimExpr init = tir::make_const(op->dtype, 0);
+      auto init_it = op->annotations.find(tl::attr::kLocalVarInit);
+      if (init_it != op->annotations.end()) {
+        PrimExpr user_init = Downcast<PrimExpr>((*init_it).second);
+        if (!user_init.dtype().is_void() && user_init.dtype() != op->dtype) {
+          user_init = tir::Cast(op->dtype, user_init);
+        }
+        init = user_init;
+      }
+      stream << ' ' << vid << " = " << PrintExpr(init) << ";\n";
+    } else {
+      stream << ' ' << vid << '[' << constant_size << "];\n";
+    }
   }
 
   RegisterHandleType(op->buffer_var.get(), op->dtype);

--- a/src/target/codegen_hip.cc
+++ b/src/target/codegen_hip.cc
@@ -714,6 +714,32 @@ std::string CodeGenTileLangHIP::CastFromTo(std::string value, DataType from,
   return os.str();
 }
 
+void CodeGenTileLangHIP::VisitExpr_(const ShuffleNode *op,
+                                    std::ostream &os) { // NOLINT(*)
+  // For bfloat16x2 / float16x2 construction from two scalar lanes, emit the
+  // HIP pack intrinsic instead of the invalid `uint1(a, b)` that CodeGenC
+  // would generate (HIP's uint1 has no two-argument constructor).
+  // `uint1{value}` aggregate initialisation is valid: uint1 is defined by ROCm
+  // as HIP_vector_type<unsigned int, 1> which has a single .x member.
+  DataType t = op->dtype;
+  bool is_bf16x2 = t.is_bfloat16() && t.lanes() == 2;
+  bool is_fp16x2  = t.is_float16()  && t.lanes() == 2;
+  if ((is_bf16x2 || is_fp16x2) && op->vectors.size() == 2 &&
+      op->vectors[0].dtype().lanes() == 1 &&
+      op->vectors[1].dtype().lanes() == 1) {
+    std::string e0 = PrintExpr(op->vectors[0]);
+    std::string e1 = PrintExpr(op->vectors[1]);
+    if (is_bf16x2) {
+      os << "uint1{__pack_bfloat162(" << e0 << ", " << e1 << ")}";
+    } else {
+      os << "uint1{__pack_half2(" << e0 << ", " << e1 << ")}";
+    }
+    return;
+  }
+  // Default path for all other shuffle patterns.
+  CodeGenC::VisitExpr_(op, os);
+}
+
 void CodeGenTileLangHIP::VisitExpr_(const CastNode *op, std::ostream &os) {
   DataType from_ty = op->value.dtype();
   DataType target_ty = op->dtype;

--- a/src/target/codegen_hip.h
+++ b/src/target/codegen_hip.h
@@ -49,6 +49,7 @@ public:
   void VisitExpr_(const FloatImmNode *op, std::ostream &os) final;
   void VisitExpr_(const CallNode *op, std::ostream &os) final;
   void VisitExpr_(const CastNode *op, std::ostream &os) final;
+  void VisitExpr_(const ShuffleNode *op, std::ostream &os) final;   // NOLINT(*)
   void VisitStmt_(const AllocateNode *op) final;
   void VisitStmt_(const AttrStmtNode *op) final;
 

--- a/src/target/codegen_hip.h
+++ b/src/target/codegen_hip.h
@@ -49,7 +49,7 @@ public:
   void VisitExpr_(const FloatImmNode *op, std::ostream &os) final;
   void VisitExpr_(const CallNode *op, std::ostream &os) final;
   void VisitExpr_(const CastNode *op, std::ostream &os) final;
-  void VisitExpr_(const ShuffleNode *op, std::ostream &os) final;   // NOLINT(*)
+  void VisitExpr_(const ShuffleNode *op, std::ostream &os) final; // NOLINT(*)
   void VisitStmt_(const AllocateNode *op) final;
   void VisitStmt_(const AttrStmtNode *op) final;
 

--- a/src/target/codegen_hip.h
+++ b/src/target/codegen_hip.h
@@ -73,6 +73,8 @@ private:
   friend void PrintConst(const FloatImmNode *op, std::ostream &os,
                          CodeGenTileLangHIP *p);
 
+  // whether need hip_cooperative_groups.h
+  bool need_cooperative_groups_{false};
   // whether need math_constants.h
   bool need_math_constants_h_{false};
   // whether need mfma.h

--- a/src/target/rt_mod_hip.cc
+++ b/src/target/rt_mod_hip.cc
@@ -41,6 +41,10 @@ ExtractFuncInfo(const IRModule &mod) {
         dtype = DataType::Int(32);
       info.arg_types.push_back(dtype);
     }
+    if (f->HasNonzeroAttr("use_cooperative_groups")) {
+      info.launch_param_tags.push_back(
+          runtime::launch_param::kUseCooperativeLaunch);
+    }
     if (auto opt = f->GetAttr<ffi::Array<ffi::String>>(
             tir::attr::kKernelLaunchParams)) {
       for (const auto &tag : opt.value()) {

--- a/src/target/stubs/hip.cc
+++ b/src/target/stubs/hip.cc
@@ -139,6 +139,7 @@ HIPDriverAPI CreateHIPDriverAPI() {
   LOOKUP(hipModuleGetFunction_, "hipModuleGetFunction")
   LOOKUP(hipModuleGetGlobal_, "hipModuleGetGlobal")
   LOOKUP(hipModuleLaunchKernel_, "hipModuleLaunchKernel")
+  LOOKUP(hipModuleLaunchCooperativeKernel_, "hipModuleLaunchCooperativeKernel")
 #undef LOOKUP
 
   return api;
@@ -395,6 +396,17 @@ hipError_t hipModuleLaunchKernel(hipFunction_t f, unsigned int gridDimX,
   return HIPDriverAPI::get()->hipModuleLaunchKernel_(
       f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ,
       sharedMemBytes, stream, kernelParams, extra);
+}
+
+hipError_t hipModuleLaunchCooperativeKernel(
+    hipFunction_t f, unsigned int gridDimX, unsigned int gridDimY,
+    unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY,
+    unsigned int blockDimZ, unsigned int sharedMemBytes, hipStream_t stream,
+    void **kernelParams) {
+  // NOLINTNEXTLINE(clang-analyzer-core.CallAndMessage)
+  return HIPDriverAPI::get()->hipModuleLaunchCooperativeKernel_(
+      f, gridDimX, gridDimY, gridDimZ, blockDimX, blockDimY, blockDimZ,
+      sharedMemBytes, stream, kernelParams);
 }
 
 // --- Minimal HSA wrappers

--- a/src/target/stubs/hip.h
+++ b/src/target/stubs/hip.h
@@ -80,7 +80,8 @@
   _(hipModuleUnload)                                                           \
   _(hipModuleGetFunction)                                                      \
   _(hipModuleGetGlobal)                                                        \
-  _(hipModuleLaunchKernel)
+  _(hipModuleLaunchKernel)                                                     \
+  _(hipModuleLaunchCooperativeKernel)
 
 namespace tvm::tl::hip {
 
@@ -132,6 +133,11 @@ struct TILELANG_HIP_STUB_API HIPDriverAPI {
                                        unsigned int, unsigned int, unsigned int,
                                        unsigned int, unsigned int, unsigned int,
                                        hipStream_t, void **, void **);
+  hipError_t (*hipModuleLaunchCooperativeKernel_)(hipFunction_t, unsigned int,
+                                                  unsigned int, unsigned int,
+                                                  unsigned int, unsigned int,
+                                                  unsigned int, unsigned int,
+                                                  hipStream_t, void **);
 
   static HIPDriverAPI *get();
   static bool is_available();
@@ -210,5 +216,11 @@ TILELANG_HIP_STUB_API hipError_t hipModuleLaunchKernel(
     unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY,
     unsigned int blockDimZ, unsigned int sharedMemBytes, hipStream_t stream,
     void **kernelParams, void **extra);
+
+TILELANG_HIP_STUB_API hipError_t hipModuleLaunchCooperativeKernel(
+    hipFunction_t f, unsigned int gridDimX, unsigned int gridDimY,
+    unsigned int gridDimZ, unsigned int blockDimX, unsigned int blockDimY,
+    unsigned int blockDimZ, unsigned int sharedMemBytes, hipStream_t stream,
+    void **kernelParams);
 
 } // extern "C"

--- a/src/tl_templates/hip/common.h
+++ b/src/tl_templates/hip/common.h
@@ -201,40 +201,40 @@ TL_DEVICE uint1 abs2(uint1 val) {
 }
 TL_DEVICE uint1 max2(uint1 a, uint1 b) {
   bfloat16_t a0, a1, b0, b1;
-  __builtin_memcpy(&a0, &a.x,       sizeof(a0));
-  __builtin_memcpy(&a1, (char*)&a.x + 2, sizeof(a1));
-  __builtin_memcpy(&b0, &b.x,       sizeof(b0));
-  __builtin_memcpy(&b1, (char*)&b.x + 2, sizeof(b1));
+  __builtin_memcpy(&a0, &a.x, sizeof(a0));
+  __builtin_memcpy(&a1, (char *)&a.x + 2, sizeof(a1));
+  __builtin_memcpy(&b0, &b.x, sizeof(b0));
+  __builtin_memcpy(&b1, (char *)&b.x + 2, sizeof(b1));
   bfloat16_t r0 = (float)a0 > (float)b0 ? a0 : b0;
   bfloat16_t r1 = (float)a1 > (float)b1 ? a1 : b1;
   return uint1{__pack_bfloat162(r0, r1)};
 }
 TL_DEVICE uint1 min2(uint1 a, uint1 b) {
   bfloat16_t a0, a1, b0, b1;
-  __builtin_memcpy(&a0, &a.x,       sizeof(a0));
-  __builtin_memcpy(&a1, (char*)&a.x + 2, sizeof(a1));
-  __builtin_memcpy(&b0, &b.x,       sizeof(b0));
-  __builtin_memcpy(&b1, (char*)&b.x + 2, sizeof(b1));
+  __builtin_memcpy(&a0, &a.x, sizeof(a0));
+  __builtin_memcpy(&a1, (char *)&a.x + 2, sizeof(a1));
+  __builtin_memcpy(&b0, &b.x, sizeof(b0));
+  __builtin_memcpy(&b1, (char *)&b.x + 2, sizeof(b1));
   bfloat16_t r0 = (float)a0 < (float)b0 ? a0 : b0;
   bfloat16_t r1 = (float)a1 < (float)b1 ? a1 : b1;
   return uint1{__pack_bfloat162(r0, r1)};
 }
 TL_DEVICE uint1 add2(uint1 a, uint1 b) {
   bfloat16_t a0, a1, b0, b1;
-  __builtin_memcpy(&a0, &a.x,       sizeof(a0));
-  __builtin_memcpy(&a1, (char*)&a.x + 2, sizeof(a1));
-  __builtin_memcpy(&b0, &b.x,       sizeof(b0));
-  __builtin_memcpy(&b1, (char*)&b.x + 2, sizeof(b1));
+  __builtin_memcpy(&a0, &a.x, sizeof(a0));
+  __builtin_memcpy(&a1, (char *)&a.x + 2, sizeof(a1));
+  __builtin_memcpy(&b0, &b.x, sizeof(b0));
+  __builtin_memcpy(&b1, (char *)&b.x + 2, sizeof(b1));
   bfloat16_t r0 = (bfloat16_t)((float)a0 + (float)b0);
   bfloat16_t r1 = (bfloat16_t)((float)a1 + (float)b1);
   return uint1{__pack_bfloat162(r0, r1)};
 }
 TL_DEVICE uint1 mul2(uint1 a, uint1 b) {
   bfloat16_t a0, a1, b0, b1;
-  __builtin_memcpy(&a0, &a.x,       sizeof(a0));
-  __builtin_memcpy(&a1, (char*)&a.x + 2, sizeof(a1));
-  __builtin_memcpy(&b0, &b.x,       sizeof(b0));
-  __builtin_memcpy(&b1, (char*)&b.x + 2, sizeof(b1));
+  __builtin_memcpy(&a0, &a.x, sizeof(a0));
+  __builtin_memcpy(&a1, (char *)&a.x + 2, sizeof(a1));
+  __builtin_memcpy(&b0, &b.x, sizeof(b0));
+  __builtin_memcpy(&b1, (char *)&b.x + 2, sizeof(b1));
   bfloat16_t r0 = (bfloat16_t)((float)a0 * (float)b0);
   bfloat16_t r1 = (bfloat16_t)((float)a1 * (float)b1);
   return uint1{__pack_bfloat162(r0, r1)};

--- a/src/tl_templates/hip/common.h
+++ b/src/tl_templates/hip/common.h
@@ -110,6 +110,20 @@ TL_DEVICE unsigned __pack_bfloat162(const bfloat16_t x, const bfloat16_t y) {
   return (v1 << 16) | v0;
 }
 
+// __habs overloads for hip_bfloat16 and float16_t to resolve ambiguity on ROCm.
+// hip_bfloat16 != __hip_bfloat16, and float16_t != __half, so the standard
+// __habs overloads don't match exactly, causing ambiguous overload errors.
+__device__ __forceinline__ hip_bfloat16 __habs(hip_bfloat16 a) {
+  unsigned short bits = *reinterpret_cast<unsigned short *>(&a);
+  bits &= 0x7FFFu;
+  return *reinterpret_cast<hip_bfloat16 *>(&bits);
+}
+__device__ __forceinline__ float16_t __habs(float16_t a) {
+  unsigned short bits = *reinterpret_cast<unsigned short *>(&a);
+  bits &= 0x7FFFu;
+  return *reinterpret_cast<float16_t *>(&bits);
+}
+
 namespace tl {
 
 // Packed x2 element-wise math helpers (HIP scalar fallbacks)

--- a/src/tl_templates/hip/common.h
+++ b/src/tl_templates/hip/common.h
@@ -113,15 +113,22 @@ TL_DEVICE unsigned __pack_bfloat162(const bfloat16_t x, const bfloat16_t y) {
 // __habs overloads for hip_bfloat16 and float16_t to resolve ambiguity on ROCm.
 // hip_bfloat16 != __hip_bfloat16, and float16_t != __half, so the standard
 // __habs overloads don't match exactly, causing ambiguous overload errors.
+// Use __builtin_memcpy instead of reinterpret_cast to avoid strict-aliasing UB.
 __device__ __forceinline__ hip_bfloat16 __habs(hip_bfloat16 a) {
-  unsigned short bits = *reinterpret_cast<unsigned short *>(&a);
+  uint16_t bits;
+  __builtin_memcpy(&bits, &a, sizeof(bits));
   bits &= 0x7FFFu;
-  return *reinterpret_cast<hip_bfloat16 *>(&bits);
+  hip_bfloat16 result;
+  __builtin_memcpy(&result, &bits, sizeof(result));
+  return result;
 }
 __device__ __forceinline__ float16_t __habs(float16_t a) {
-  unsigned short bits = *reinterpret_cast<unsigned short *>(&a);
+  uint16_t bits;
+  __builtin_memcpy(&bits, &a, sizeof(bits));
   bits &= 0x7FFFu;
-  return *reinterpret_cast<float16_t *>(&bits);
+  float16_t result;
+  __builtin_memcpy(&result, &bits, sizeof(result));
+  return result;
 }
 
 namespace tl {
@@ -178,6 +185,59 @@ TL_DEVICE float2 abs2(float2 a) {
   out.x = (a.x >= 0.0f) ? a.x : -a.x;
   out.y = (a.y >= 0.0f) ? a.y : -a.y;
   return out;
+}
+
+// Packed bfloat16x2 overloads for uint1 carrier.
+// On HIP, uint1 = HIP_vector_type<unsigned int, 1> (32-bit), already defined
+// by ROCm via amd_hip_vector_types.h — no additional typedef needed.
+// A packed bfloat16x2 word layout:
+//   bits [15: 0] = first  bfloat16 (sign at bit 15)
+//   bits [31:16] = second bfloat16 (sign at bit 31)
+// These overloads are required by the HIP codegen's ShuffleNode packing path
+// (VisitExpr_ ShuffleNode emits uint1{__pack_bfloat162(a, b)}).
+TL_DEVICE uint1 abs2(uint1 val) {
+  // Clear both sign bits simultaneously.
+  return uint1{val.x & 0x7FFF7FFFu};
+}
+TL_DEVICE uint1 max2(uint1 a, uint1 b) {
+  bfloat16_t a0, a1, b0, b1;
+  __builtin_memcpy(&a0, &a.x,       sizeof(a0));
+  __builtin_memcpy(&a1, (char*)&a.x + 2, sizeof(a1));
+  __builtin_memcpy(&b0, &b.x,       sizeof(b0));
+  __builtin_memcpy(&b1, (char*)&b.x + 2, sizeof(b1));
+  bfloat16_t r0 = (float)a0 > (float)b0 ? a0 : b0;
+  bfloat16_t r1 = (float)a1 > (float)b1 ? a1 : b1;
+  return uint1{__pack_bfloat162(r0, r1)};
+}
+TL_DEVICE uint1 min2(uint1 a, uint1 b) {
+  bfloat16_t a0, a1, b0, b1;
+  __builtin_memcpy(&a0, &a.x,       sizeof(a0));
+  __builtin_memcpy(&a1, (char*)&a.x + 2, sizeof(a1));
+  __builtin_memcpy(&b0, &b.x,       sizeof(b0));
+  __builtin_memcpy(&b1, (char*)&b.x + 2, sizeof(b1));
+  bfloat16_t r0 = (float)a0 < (float)b0 ? a0 : b0;
+  bfloat16_t r1 = (float)a1 < (float)b1 ? a1 : b1;
+  return uint1{__pack_bfloat162(r0, r1)};
+}
+TL_DEVICE uint1 add2(uint1 a, uint1 b) {
+  bfloat16_t a0, a1, b0, b1;
+  __builtin_memcpy(&a0, &a.x,       sizeof(a0));
+  __builtin_memcpy(&a1, (char*)&a.x + 2, sizeof(a1));
+  __builtin_memcpy(&b0, &b.x,       sizeof(b0));
+  __builtin_memcpy(&b1, (char*)&b.x + 2, sizeof(b1));
+  bfloat16_t r0 = (bfloat16_t)((float)a0 + (float)b0);
+  bfloat16_t r1 = (bfloat16_t)((float)a1 + (float)b1);
+  return uint1{__pack_bfloat162(r0, r1)};
+}
+TL_DEVICE uint1 mul2(uint1 a, uint1 b) {
+  bfloat16_t a0, a1, b0, b1;
+  __builtin_memcpy(&a0, &a.x,       sizeof(a0));
+  __builtin_memcpy(&a1, (char*)&a.x + 2, sizeof(a1));
+  __builtin_memcpy(&b0, &b.x,       sizeof(b0));
+  __builtin_memcpy(&b1, (char*)&b.x + 2, sizeof(b1));
+  bfloat16_t r0 = (bfloat16_t)((float)a0 * (float)b0);
+  bfloat16_t r1 = (bfloat16_t)((float)a1 * (float)b1);
+  return uint1{__pack_bfloat162(r0, r1)};
 }
 
 // Any

--- a/src/tl_templates/hip/hip_fp8.h
+++ b/src/tl_templates/hip/hip_fp8.h
@@ -199,28 +199,33 @@ struct __align__(16) fp8_e8_16_t {
 
 __device__ fp8_e4_4_t make_fp8_e4_4_t(fp8_e4_t x, fp8_e4_t y, fp8_e4_t z,
                                       fp8_e4_t w) {
-  // reinterpret the 4 fp8_e4_t values to signed char value and shift
-  signed char x_char = *reinterpret_cast<signed char *>(&x);
-  signed char y_char = *reinterpret_cast<signed char *>(&y);
-  signed char z_char = *reinterpret_cast<signed char *>(&z);
-  signed char w_char = *reinterpret_cast<signed char *>(&w);
-  int res = (w_char << 24) | (z_char << 16) | (y_char << 8) | x_char;
+  // reinterpret the 4 fp8_e4_t values to unsigned char to avoid sign extension
+  // on shift
+  unsigned char x_char = *reinterpret_cast<unsigned char *>(&x);
+  unsigned char y_char = *reinterpret_cast<unsigned char *>(&y);
+  unsigned char z_char = *reinterpret_cast<unsigned char *>(&z);
+  unsigned char w_char = *reinterpret_cast<unsigned char *>(&w);
+  unsigned int res = ((unsigned int)w_char << 24) |
+                     ((unsigned int)z_char << 16) |
+                     ((unsigned int)y_char << 8) | (unsigned int)x_char;
   return *reinterpret_cast<fp8_e4_4_t *>(&res);
 }
 
 __device__ fp8_e4_8_t make_fp8_e4_8_t(fp8_e4_t x, fp8_e4_t y, fp8_e4_t z,
                                       fp8_e4_t w, fp8_e4_t v, fp8_e4_t u,
                                       fp8_e4_t t, fp8_e4_t s) {
-  signed char x_char = *reinterpret_cast<signed char *>(&x);
-  signed char y_char = *reinterpret_cast<signed char *>(&y);
-  signed char z_char = *reinterpret_cast<signed char *>(&z);
-  signed char w_char = *reinterpret_cast<signed char *>(&w);
-  signed char v_char = *reinterpret_cast<signed char *>(&v);
-  signed char u_char = *reinterpret_cast<signed char *>(&u);
-  signed char t_char = *reinterpret_cast<signed char *>(&t);
-  signed char s_char = *reinterpret_cast<signed char *>(&s);
-  int a = (w_char << 24) | (z_char << 16) | (y_char << 8) | x_char;
-  int b = (s_char << 24) | (t_char << 16) | (u_char << 8) | v_char;
+  unsigned char x_char = *reinterpret_cast<unsigned char *>(&x);
+  unsigned char y_char = *reinterpret_cast<unsigned char *>(&y);
+  unsigned char z_char = *reinterpret_cast<unsigned char *>(&z);
+  unsigned char w_char = *reinterpret_cast<unsigned char *>(&w);
+  unsigned char v_char = *reinterpret_cast<unsigned char *>(&v);
+  unsigned char u_char = *reinterpret_cast<unsigned char *>(&u);
+  unsigned char t_char = *reinterpret_cast<unsigned char *>(&t);
+  unsigned char s_char = *reinterpret_cast<unsigned char *>(&s);
+  unsigned int a = ((unsigned int)w_char << 24) | ((unsigned int)z_char << 16) |
+                   ((unsigned int)y_char << 8) | (unsigned int)x_char;
+  unsigned int b = ((unsigned int)s_char << 24) | ((unsigned int)t_char << 16) |
+                   ((unsigned int)u_char << 8) | (unsigned int)v_char;
   fp8_e4_8_t res;
   res.x = *reinterpret_cast<fp8_e4_4_t *>(&a);
   res.y = *reinterpret_cast<fp8_e4_4_t *>(&b);
@@ -233,26 +238,34 @@ __device__ fp8_e4_16_t make_fp8_e4_16_t(fp8_e4_t x0, fp8_e4_t x1, fp8_e4_t x2,
                                         fp8_e4_t y1, fp8_e4_t y2, fp8_e4_t y3,
                                         fp8_e4_t y4, fp8_e4_t y5, fp8_e4_t y6,
                                         fp8_e4_t y7) {
-  signed char x0_char = *reinterpret_cast<signed char *>(&x0);
-  signed char x1_char = *reinterpret_cast<signed char *>(&x1);
-  signed char x2_char = *reinterpret_cast<signed char *>(&x2);
-  signed char x3_char = *reinterpret_cast<signed char *>(&x3);
-  signed char x4_char = *reinterpret_cast<signed char *>(&x4);
-  signed char x5_char = *reinterpret_cast<signed char *>(&x5);
-  signed char x6_char = *reinterpret_cast<signed char *>(&x6);
-  signed char x7_char = *reinterpret_cast<signed char *>(&x7);
-  signed char y0_char = *reinterpret_cast<signed char *>(&y0);
-  signed char y1_char = *reinterpret_cast<signed char *>(&y1);
-  signed char y2_char = *reinterpret_cast<signed char *>(&y2);
-  signed char y3_char = *reinterpret_cast<signed char *>(&y3);
-  signed char y4_char = *reinterpret_cast<signed char *>(&y4);
-  signed char y5_char = *reinterpret_cast<signed char *>(&y5);
-  signed char y6_char = *reinterpret_cast<signed char *>(&y6);
-  signed char y7_char = *reinterpret_cast<signed char *>(&y7);
-  int a = (x3_char << 24) | (x2_char << 16) | (x1_char << 8) | x0_char;
-  int b = (x7_char << 24) | (x6_char << 16) | (x5_char << 8) | x4_char;
-  int c = (y3_char << 24) | (y2_char << 16) | (y1_char << 8) | y0_char;
-  int d = (y7_char << 24) | (y6_char << 16) | (y5_char << 8) | y4_char;
+  unsigned char x0_char = *reinterpret_cast<unsigned char *>(&x0);
+  unsigned char x1_char = *reinterpret_cast<unsigned char *>(&x1);
+  unsigned char x2_char = *reinterpret_cast<unsigned char *>(&x2);
+  unsigned char x3_char = *reinterpret_cast<unsigned char *>(&x3);
+  unsigned char x4_char = *reinterpret_cast<unsigned char *>(&x4);
+  unsigned char x5_char = *reinterpret_cast<unsigned char *>(&x5);
+  unsigned char x6_char = *reinterpret_cast<unsigned char *>(&x6);
+  unsigned char x7_char = *reinterpret_cast<unsigned char *>(&x7);
+  unsigned char y0_char = *reinterpret_cast<unsigned char *>(&y0);
+  unsigned char y1_char = *reinterpret_cast<unsigned char *>(&y1);
+  unsigned char y2_char = *reinterpret_cast<unsigned char *>(&y2);
+  unsigned char y3_char = *reinterpret_cast<unsigned char *>(&y3);
+  unsigned char y4_char = *reinterpret_cast<unsigned char *>(&y4);
+  unsigned char y5_char = *reinterpret_cast<unsigned char *>(&y5);
+  unsigned char y6_char = *reinterpret_cast<unsigned char *>(&y6);
+  unsigned char y7_char = *reinterpret_cast<unsigned char *>(&y7);
+  unsigned int a = ((unsigned int)x3_char << 24) |
+                   ((unsigned int)x2_char << 16) |
+                   ((unsigned int)x1_char << 8) | (unsigned int)x0_char;
+  unsigned int b = ((unsigned int)x7_char << 24) |
+                   ((unsigned int)x6_char << 16) |
+                   ((unsigned int)x5_char << 8) | (unsigned int)x4_char;
+  unsigned int c = ((unsigned int)y3_char << 24) |
+                   ((unsigned int)y2_char << 16) |
+                   ((unsigned int)y1_char << 8) | (unsigned int)y0_char;
+  unsigned int d = ((unsigned int)y7_char << 24) |
+                   ((unsigned int)y6_char << 16) |
+                   ((unsigned int)y5_char << 8) | (unsigned int)y4_char;
   fp8_e4_8_t res_x;
   res_x.x = *reinterpret_cast<fp8_e4_4_t *>(&a);
   res_x.y = *reinterpret_cast<fp8_e4_4_t *>(&b);

--- a/src/tl_templates/hip/reduce.h
+++ b/src/tl_templates/hip/reduce.h
@@ -261,12 +261,34 @@ template <int threads, int Axis = 0, bool reverse = false> struct CumSum2D {
 
 template <typename T, typename ReduceOp>
 TL_DEVICE T warp_reduce(T value, ReduceOp op) {
-  value = op(value, __shfl_xor(value, 32));
-  value = op(value, __shfl_xor(value, 16));
-  value = op(value, __shfl_xor(value, 8));
-  value = op(value, __shfl_xor(value, 4));
-  value = op(value, __shfl_xor(value, 2));
-  value = op(value, __shfl_xor(value, 1));
+  // 5-step butterfly reduction with width=32, matching CUDA's 32-lane warp
+  // semantics on CDNA (wave64) and RDNA (wave32) targets.
+  //
+  // On CDNA (wave64, 64-lane wavefronts) with threads=32 per block:
+  //   Only lanes 0-31 are active; lanes 32-63 hold uninitialised VGPRs.
+  //   The old step `__shfl_xor(value, 32)` without a width argument read
+  //   from those uninitialised lanes, producing NaN or garbage.
+  //   width=32 confines every shuffle to the [0,31] group, preventing this.
+  //
+  // On CDNA with threads=64 (one full wave64):
+  //   width=32 splits the wavefront into two independent 32-lane groups.
+  //   Lane 0 of each group holds the group partial sum, which is exactly what
+  //   kernels that assume logical warp_size=32 expect for their inter-warp
+  //   shared-memory reductions.
+  //
+  // On RDNA (wave32, 32-lane wavefronts):
+  //   width=32 equals the wavefront size, so behaviour is identical to
+  //   omitting the width argument.
+  //
+  // Note: this intentionally preserves 32-lane logical-warp semantics for
+  // backward compatibility.  Full wave64 utilisation (6-step, width=64) would
+  // require restructuring inter-warp shared-memory communication in all
+  // kernels and is deferred to a separate optimisation pass.
+  value = op(value, __shfl_xor(value, 16, 32));
+  value = op(value, __shfl_xor(value, 8,  32));
+  value = op(value, __shfl_xor(value, 4,  32));
+  value = op(value, __shfl_xor(value, 2,  32));
+  value = op(value, __shfl_xor(value, 1,  32));
   return value;
 }
 

--- a/src/tl_templates/hip/reduce.h
+++ b/src/tl_templates/hip/reduce.h
@@ -285,10 +285,10 @@ TL_DEVICE T warp_reduce(T value, ReduceOp op) {
   // require restructuring inter-warp shared-memory communication in all
   // kernels and is deferred to a separate optimisation pass.
   value = op(value, __shfl_xor(value, 16, 32));
-  value = op(value, __shfl_xor(value, 8,  32));
-  value = op(value, __shfl_xor(value, 4,  32));
-  value = op(value, __shfl_xor(value, 2,  32));
-  value = op(value, __shfl_xor(value, 1,  32));
+  value = op(value, __shfl_xor(value, 8, 32));
+  value = op(value, __shfl_xor(value, 4, 32));
+  value = op(value, __shfl_xor(value, 2, 32));
+  value = op(value, __shfl_xor(value, 1, 32));
   return value;
 }
 

--- a/src/transform/pipeline_planning.cc
+++ b/src/transform/pipeline_planning.cc
@@ -1075,14 +1075,19 @@ private:
       return StmtExprMutator::VisitStmt_(loop);
     int num_stages = num_stages_anno->as<IntImmNode>()->value;
     // On HIP/ROCM, skip software pipelining for multi-stage loops.
-    // Double-buffering (num_stages > 1) doubles the shared-memory (LDS)
-    // allocation for every buffer declared inside the loop body.  CDNA
-    // devices have at most 128 KB of LDS per workgroup; exceeding that limit
-    // causes hipModuleLaunchKernel to return HIPERRORINVALIDVALUE.
-    // Setting num_stages = 1 in the planner generates incorrect copy loops
-    // (only one async-copy issued instead of the full multi-row preload), so
-    // the safest fallback is a plain sequential loop where T.copy executes
-    // synchronously without any async-copy or double-buffering infrastructure.
+    // Double-buffering (num_stages > 1) doubles the LDS allocation for every
+    // shared buffer declared inside the loop body, which easily exhausts the
+    // per-workgroup LDS limit and causes hipModuleLaunchKernel to return
+    // HIPERRORINVALIDVALUE.  LDS limits by generation:
+    //   gfx942 (CDNA3 / MI300X): 64 KB per workgroup
+    //   gfx950 (CDNA4 / MI350):  160 KB per workgroup (see PR #2058)
+    // Even with the larger gfx950 budget, double-buffering a pair of large
+    // shared tiles (e.g. bM×bK + bK×bN in bf16) can exceed 160 KB, and the
+    // HIP async-copy infrastructure used by the CUDA pipeline planner has no
+    // equivalent on ROCM today.  Setting num_stages = 1 inside the planner
+    // generates incorrect copy loops, so the safest fallback is a plain
+    // sequential loop where T.copy executes synchronously without any
+    // async-copy or double-buffering infrastructure.
     if (TargetIsRocm(target_) && num_stages > 1) {
       return StmtExprMutator::VisitStmt_(loop);
     }

--- a/src/transform/pipeline_planning.cc
+++ b/src/transform/pipeline_planning.cc
@@ -1074,6 +1074,18 @@ private:
     if (!num_stages_anno)
       return StmtExprMutator::VisitStmt_(loop);
     int num_stages = num_stages_anno->as<IntImmNode>()->value;
+    // On HIP/ROCM, skip software pipelining for multi-stage loops.
+    // Double-buffering (num_stages > 1) doubles the shared-memory (LDS)
+    // allocation for every buffer declared inside the loop body.  CDNA
+    // devices have at most 128 KB of LDS per workgroup; exceeding that limit
+    // causes hipModuleLaunchKernel to return HIPERRORINVALIDVALUE.
+    // Setting num_stages = 1 in the planner generates incorrect copy loops
+    // (only one async-copy issued instead of the full multi-row preload), so
+    // the safest fallback is a plain sequential loop where T.copy executes
+    // synchronously without any async-copy or double-buffering infrastructure.
+    if (TargetIsRocm(target_) && num_stages > 1) {
+      return StmtExprMutator::VisitStmt_(loop);
+    }
     Stmt pipeline_body_root{nullptr};
     if (const auto *realize = loop->body.as<BlockRealizeNode>()) {
       const auto &block = realize->block;

--- a/testing/python/amd/test_tilelang_hip_codegen.py
+++ b/testing/python/amd/test_tilelang_hip_codegen.py
@@ -1,13 +1,20 @@
 """
-Tests for HIP/AMD codegen fixes in TileLang.
+Regression tests for HIP/AMD codegen fixes in TileLang.
 
-Covers three fixes made to src/target/codegen_hip.cc:
-  1. T.sync_warp() is lowered to a no-op on HIP (AMD wavefronts execute in
-     lockstep so no explicit reconvergence barrier is needed).
-  2. T.alloc_var(dtype, init=value) emits a properly initialised scalar
-     declaration on HIP (previously the init value was silently dropped).
-  3. local.var buffers are accessed as plain scalars in GetBufferRef (no [0]
-     subscript), consistent with the scalar declaration emitted for them.
+Covers six bug fixes across five source files:
+
+  Fix 1 (reduce.h)            warp_reduce 5-step butterfly with width=32
+  Fix 2 (codegen_hip.cc,      ShuffleNode bfloat16x2/float16x2 packing;
+          common.h)            uint1 bf16x2 math overloads
+  Fix 3 (allocate.py,         T.alloc_var(init=<literal>) emits a correctly
+          codegen_hip.cc)      initialised scalar on HIP
+  Fix 4 (codegen_hip.cc)      T.sync_warp() lowered to no-op on HIP
+  Fix 5 (codegen_hip.cc,      T.sync_grid() lowered to cooperative groups
+          rt_mod_hip.cc,       grid barrier; runtime launch infrastructure
+          stubs/)              added
+  Fix 6 (pipeline_planning.cc) T.Pipelined(num_stages>1) falls back to a
+                               plain sequential loop on ROCM to avoid LDS
+                               overflow (hipModuleLaunchKernel EINVAL)
 """
 
 import pytest
@@ -18,244 +25,19 @@ import tilelang.language as T
 
 
 # ---------------------------------------------------------------------------
-# Fix 1: T.sync_warp() → no-op on HIP
-# ---------------------------------------------------------------------------
-
-
-@tilelang.jit(
-    pass_configs={
-        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
-        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
-    }
-)
-def _kernel_sync_warp_codegen():
-    """Minimal kernel that exercises T.sync_warp()."""
-
-    @T.prim_func
-    def main(A: T.Tensor((32,), "float32"), B: T.Tensor((32,), "float32")):
-        with T.Kernel(1, threads=32):
-            tx = T.get_thread_binding()
-            A_shared = T.alloc_shared((32,), "float32")
-            A_shared[tx] = A[tx]
-            T.sync_warp()
-            B[tx] = A_shared[tx] * 2.0
-
-    return main
-
-
-@tilelang.testing.requires_rocm
-def test_sync_warp_no_syncwarp_in_hip_source():
-    """__syncwarp must NOT appear in the HIP-generated kernel source."""
-    kernel = _kernel_sync_warp_codegen()
-    src = kernel.get_kernel_source()
-    assert "__syncwarp" not in src, (
-        "T.sync_warp() should be a no-op on HIP (AMD wavefronts are lockstep), "
-        f"but __syncwarp was found in the generated source:\n{src}"
-    )
-
-
-@tilelang.testing.requires_rocm
-def test_sync_warp_correctness():
-    """Kernel using T.sync_warp() should produce correct results on HIP."""
-    kernel = _kernel_sync_warp_codegen()
-    A = torch.arange(32, dtype=torch.float32, device="cuda")
-    B = torch.zeros(32, dtype=torch.float32, device="cuda")
-    kernel(A, B)
-    torch.testing.assert_close(B, A * 2.0)
-
-
-# ---------------------------------------------------------------------------
-# Fix 2: T.alloc_var(init=...) initialisation on HIP
-# ---------------------------------------------------------------------------
-
-
-@tilelang.jit(
-    pass_configs={
-        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
-        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
-    }
-)
-def _kernel_alloc_var_init():
-    """Kernel that initialises a local int32 variable and writes it to output."""
-
-    @T.prim_func
-    def main(Out: T.Tensor((64,), "int32")):
-        with T.Kernel(1, threads=64):
-            tx = T.get_thread_binding()
-            counter = T.alloc_var(T.int32, init=7)
-            Out[tx] = counter
-
-    return main
-
-
-@tilelang.testing.requires_rocm
-def test_alloc_var_init_in_hip_source():
-    """Init value must appear in the generated HIP source for T.alloc_var."""
-    kernel = _kernel_alloc_var_init()
-    src = kernel.get_kernel_source()
-    assert "= 7;" in src, (
-        "T.alloc_var(T.int32, init=7) should generate '= 7;' in HIP source, "
-        f"but it was not found.\nGenerated source:\n{src}"
-    )
-
-
-@tilelang.testing.requires_rocm
-def test_alloc_var_init_no_array_subscript_in_hip_source():
-    """local.var should be declared as a scalar, not as an array (no [0])."""
-    kernel = _kernel_alloc_var_init()
-    src = kernel.get_kernel_source()
-    # The kernel source should contain 'counter = 7' not 'counter[1]' or 'counter[0]'
-    assert "counter[" not in src, (
-        "local.var should be emitted as a scalar (e.g. 'int counter = 7'), "
-        f"but array-style access was found in the HIP source:\n{src}"
-    )
-
-
-@tilelang.testing.requires_rocm
-def test_alloc_var_init_correctness():
-    """Kernel should read back the initialised value correctly on HIP."""
-    kernel = _kernel_alloc_var_init()
-    out = torch.zeros(64, dtype=torch.int32, device="cuda")
-    kernel(out)
-    assert torch.all(out == 7), (
-        f"Expected all 7, got: {out}"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Fix 2b: multiple T.alloc_var with distinct init values
-# ---------------------------------------------------------------------------
-
-
-@tilelang.jit(
-    pass_configs={
-        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
-        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
-    }
-)
-def _kernel_multi_alloc_var_init():
-    """Two local variables with different init values, summed into output."""
-
-    @T.prim_func
-    def main(Out: T.Tensor((32,), "int32")):
-        with T.Kernel(1, threads=32):
-            tx = T.get_thread_binding()
-            a = T.alloc_var(T.int32, init=3)
-            b = T.alloc_var(T.int32, init=4)
-            Out[tx] = a + b
-
-    return main
-
-
-@tilelang.testing.requires_rocm
-def test_multi_alloc_var_init_in_hip_source():
-    """Both init values must appear in the HIP source."""
-    kernel = _kernel_multi_alloc_var_init()
-    src = kernel.get_kernel_source()
-    assert src.count("= 3;") >= 1, f"Init value 3 not found in HIP source:\n{src}"
-    assert src.count("= 4;") >= 1, f"Init value 4 not found in HIP source:\n{src}"
-
-
-@tilelang.testing.requires_rocm
-def test_multi_alloc_var_init_correctness():
-    """Sum of two initialised local variables should equal 7 on HIP."""
-    kernel = _kernel_multi_alloc_var_init()
-    out = torch.zeros(32, dtype=torch.int32, device="cuda")
-    kernel(out)
-    assert torch.all(out == 7), f"Expected all 7 (3+4), got: {out}"
-
-
-# ---------------------------------------------------------------------------
-# Fix 2c: T.alloc_var(init=0) — the default zero-init case
-# ---------------------------------------------------------------------------
-
-
-@tilelang.jit(
-    pass_configs={
-        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
-        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
-    }
-)
-def _kernel_alloc_var_count():
-    """
-    Accumulates a count by incrementing a local variable in a loop.
-    Relies on the variable being zero-initialised (init=0 default).
-    """
-
-    @T.prim_func
-    def main(Out: T.Tensor((32,), "int32")):
-        with T.Kernel(1, threads=32):
-            tx = T.get_thread_binding()
-            count = T.alloc_var(T.int32, init=0)
-            for _ in T.unroll(5):
-                count += 1
-            Out[tx] = count
-
-    return main
-
-
-@tilelang.testing.requires_rocm
-def test_alloc_var_zero_init_correctness():
-    """Variable initialised to 0, incremented 5 times, should equal 5."""
-    kernel = _kernel_alloc_var_count()
-    out = torch.zeros(32, dtype=torch.int32, device="cuda")
-    kernel(out)
-    assert torch.all(out == 5), f"Expected all 5, got: {out}"
-
-
-# ---------------------------------------------------------------------------
-# Fix 3: T.sync_grid() codegen on HIP (codegen only; runtime not yet complete)
-# ---------------------------------------------------------------------------
-
-
-@tilelang.jit(
-    pass_configs={
-        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
-        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
-    }
-)
-def _kernel_sync_grid_codegen():
-    """Kernel that calls T.sync_grid() to trigger cooperative groups codegen."""
-
-    @T.prim_func
-    def main(A: T.Tensor((32,), "float32")):
-        with T.Kernel(1, threads=32):
-            tx = T.get_thread_binding()
-            T.sync_grid()
-            A[tx] = T.float32(tx)
-
-    return main
-
-
-@tilelang.testing.requires_rocm
-def test_sync_grid_cooperative_groups_in_hip_source():
-    """
-    T.sync_grid() should generate cooperative_groups::this_grid().sync()
-    and include <hip/hip_cooperative_groups.h> in the HIP source.
-
-    Note: runtime execution of this kernel is not yet supported because
-    rocm_module.cc does not yet call hipModuleLaunchCooperativeKernel.
-    This test validates codegen only.
-    """
-    kernel = _kernel_sync_grid_codegen()
-    src = kernel.get_kernel_source()
-    assert "this_grid().sync()" in src, (
-        "T.sync_grid() should generate 'this_grid().sync()' in HIP source, "
-        f"but it was not found:\n{src}"
-    )
-    assert "cooperative_groups" in src, (
-        "T.sync_grid() should include cooperative_groups in HIP source, "
-        f"but it was not found:\n{src}"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Fix 4: warp_reduce — 5-step butterfly with width=32 (reduce.h)
+# Fix 1 — src/tl_templates/hip/reduce.h
+#   warp_reduce: 5-step butterfly with explicit width=32
 #
-# On CDNA (wave64) the old 6-step butterfly called __shfl_xor(value, 32)
-# without a width argument, reading uninitialised VGPRs in lanes 32-63 when
-# only 32 threads were active → NaN / garbage in reduce_max / reduce_sum.
-# Fix: remove step-32 shuffle; add width=32 to all remaining 5 steps.
+# Symptom: On CDNA (wave64) with 32 active threads the old 6-step butterfly
+#   called __shfl_xor(value, 32) without a width argument, reading uninitialised
+#   VGPRs in lanes 32-63.  This produced NaN or garbage in every reduction that
+#   went through warp_reduce (reduce_max, reduce_sum, AllReduce).
+#
+# Fix: remove the step-32 shuffle; add width=32 to every remaining step.
+#   __shfl_xor(v, N, 32) restricts the butterfly to the lower 32-lane group,
+#   matching CUDA warp semantics on CDNA wave64 and RDNA wave32 alike.
+#   With 64 threads and width=32 the wavefront splits into two independent
+#   32-lane groups — correct for kernels that assume logical warp_size=32.
 # ---------------------------------------------------------------------------
 
 
@@ -266,7 +48,7 @@ def test_warp_reduce_no_nan(n_tokens, n_experts):
     32-thread-per-block reduce_max / reduce_sum must not produce NaN on CDNA.
 
     Old: __shfl_xor(v, 32) with 32 active threads reads uninit VGPRs → NaN.
-    New: 5-step with width=32 stays in-group → correct result, no NaN.
+    New: 5-step with width=32 stays in [0,31] group → correct, no NaN.
     """
     assert n_experts <= 32
 
@@ -308,9 +90,8 @@ def test_warp_reduce_correctness_32_threads():
     """
     32-thread reduce_sum over 32 elements must return the exact sum on CDNA.
 
-    warp_reduce is exercised when T.reduce_sum falls through to the warp-level
-    shuffle path.  With the old __shfl_xor(v, 32) bug, reading uninitialised
-    lanes 32-63 on CDNA produced garbage.  With width=32 the result is exact.
+    Exercises the warp-level shuffle path directly.  With the old step-32
+    shuffle, uninitialised VGPR reads on CDNA produced garbage.
     """
     N = 32
 
@@ -335,26 +116,64 @@ def test_warp_reduce_correctness_32_threads():
     reduce_kernel()(x, out)
     torch.cuda.synchronize()
 
-    expected = x.sum()
     assert not out[0].isnan(), "reduce_sum NaN — warp_reduce VGPR bug on CDNA"
-    torch.testing.assert_close(out[0], expected, atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(out[0], x.sum(), atol=1e-4, rtol=1e-4)
+
+
+@tilelang.testing.requires_rocm
+def test_warp_reduce_with_64_threads_two_groups():
+    """
+    With 64 threads and width=32 the wavefront splits into two independent
+    32-lane groups — each group's lane 0 holds its partial sum.
+
+    Old: __shfl_xor(v, 32) without width mixed the groups → wrong result.
+    New: width=32 confines each shuffle to its own 32-lane group → correct.
+    """
+    N, n_exp = 64, 4
+
+    @tilelang.jit
+    def two_warp_reduce():
+        @T.prim_func
+        def kernel(
+            x:   T.Tensor((N, n_exp), T.float32),
+            out: T.Tensor((N,), T.float32),
+        ) -> None:
+            with T.Kernel(1, threads=N) as _:
+                tx = T.get_thread_binding()
+                frag = T.alloc_fragment(n_exp, T.float32)
+                T.copy(x[tx, 0], frag)
+                s = T.alloc_fragment(1, T.float32)
+                T.reduce_sum(frag, s, dim=0)
+                out[tx] = s[0]
+        return kernel
+
+    x   = torch.ones(N, n_exp, dtype=torch.float32, device="cuda")
+    out = torch.zeros(N, dtype=torch.float32, device="cuda")
+    two_warp_reduce()(x, out)
+    torch.cuda.synchronize()
+
+    assert not out.isnan().any(), "NaN in two-warp reduce — width=32 fix not applied"
 
 
 # ---------------------------------------------------------------------------
-# Fix 5: ShuffleNode bfloat16x2 / float16x2 packing (codegen_hip.cc)
-#         uint1 bf16x2 math overloads (common.h)
+# Fix 2 — src/target/codegen_hip.cc (VisitExpr_ ShuffleNode)
+#         src/tl_templates/hip/common.h (uint1 bfloat16x2 math overloads)
 #
-# Old: CodeGenC emitted `uint1(a, b)` — invalid HIP constructor → compile error.
-# Fix: Override VisitExpr_(ShuffleNode) to emit `uint1{__pack_bfloat162(a,b)}`.
-#      Add abs2/max2/min2/add2/mul2 overloads for uint1 in common.h.
+# Symptom: Packing two bfloat16 scalars into a bfloat16x2 ShuffleNode caused
+#   CodeGenC to emit `uint1(a, b)` — invalid HIP constructor → compile error.
+#
+# Fix (codegen_hip.cc): Override VisitExpr_(ShuffleNode) to emit
+#   `uint1{__pack_bfloat162(a, b)}` / `uint1{__pack_half2(a, b)}`.
+# Fix (common.h): Add abs2/max2/min2/add2/mul2 overloads for uint1 as a
+#   packed bfloat16x2 carrier.
 # ---------------------------------------------------------------------------
 
 
 @tilelang.testing.requires_rocm
-def test_bfloat16_shuffle_emits_pack_intrinsic():
+def test_bfloat16_shuffle_codegen_and_correctness():
     """
-    A bfloat16 fragment reduction triggers ShuffleNode bfloat16x2 packing.
-    The generated HIP source must use __pack_bfloat162 (not `uint1(a,b)`).
+    bfloat16 fragment warp-reduction: source must use __pack_bfloat162
+    (not invalid `uint1(a,b)`) and the result must be numerically correct.
     """
     n_tok, n_exp = 16, 8
 
@@ -377,27 +196,479 @@ def test_bfloat16_shuffle_emits_pack_intrinsic():
                     out[pid] = s[0]
         return kernel
 
-    src = bf16_reduce(n_tok, n_exp).get_kernel_source()
-    # Must use the pack intrinsic, not the invalid two-argument constructor
-    assert "uint1(a" not in src and "uint1(b" not in src, \
+    kernel = bf16_reduce(n_tok, n_exp)
+
+    # Source check: no invalid two-argument constructor
+    src = kernel.get_kernel_source()
+    assert "uint1(a" not in src and "uint1(b" not in src, (
         "Old `uint1(a, b)` constructor found — ShuffleNode fix not applied"
+    )
 
     # Runtime correctness
     x   = torch.randn(n_tok, n_exp, dtype=torch.bfloat16, device="cuda")
     out = torch.zeros(n_tok,        dtype=torch.float32,  device="cuda")
-    bf16_reduce(n_tok, n_exp)(x, out)
+    kernel(x, out)
     torch.cuda.synchronize()
-    assert not out.isnan().any(), "bf16 ShuffleNode reduction produced NaN"
+    assert not out.isnan().any(), "bf16 ShuffleNode reduction NaN"
     torch.testing.assert_close(out, x.float().sum(dim=1), atol=5e-2, rtol=1e-2)
 
 
+@tilelang.testing.requires_rocm
+def test_float16_shuffle_correctness():
+    """
+    float16 fragment warp-reduction exercises the __pack_half2 path.
+    Analogous to the bfloat16 test but for float16x2 packing.
+    """
+    n_tok, n_exp = 64, 8
+
+    @tilelang.jit
+    def f16_reduce(n_t: int, n_e: int):
+        @T.prim_func
+        def kernel(
+            x:   T.Tensor((n_t, n_e), T.float16),
+            out: T.Tensor((n_t,), T.float32),
+        ) -> None:
+            with T.Kernel(n_t, threads=32) as pid:
+                frag = T.alloc_fragment(n_e, T.float16)
+                T.copy(x[pid, 0], frag)
+                frag_f32 = T.alloc_fragment(n_e, T.float32)
+                for i in T.Parallel(n_e):
+                    frag_f32[i] = T.cast(frag[i], T.float32)
+                s = T.alloc_fragment(1, T.float32)
+                T.reduce_sum(frag_f32, s, dim=0)
+                if T.get_thread_binding() == 0:
+                    out[pid] = s[0]
+        return kernel
+
+    x   = torch.randn(n_tok, n_exp, dtype=torch.float16, device="cuda")
+    out = torch.zeros(n_tok,        dtype=torch.float32, device="cuda")
+    f16_reduce(n_tok, n_exp)(x, out)
+    torch.cuda.synchronize()
+    assert not out.isnan().any(), "float16 ShuffleNode reduction NaN"
+    torch.testing.assert_close(out, x.float().sum(dim=1), atol=1e-1, rtol=1e-2)
+
+
 # ---------------------------------------------------------------------------
-# Fix 6: T.Pipelined(num_stages>1) on ROCM — skip pipeline planning
-#         (pipeline_planning.cc)
+# Fix 3 — tilelang/language/allocate.py + src/target/codegen_hip.cc
+#   T.alloc_var(init=<literal>) initialisation on HIP;
+#   local.var scalar declaration and GetBufferRef bare-name return
 #
-# Old: double-buffering doubled LDS per loop body → hipModuleLaunchKernel
-#      EINVAL on CDNA (≤128 KB LDS/workgroup).
-# Fix: TargetIsRocm() && num_stages>1 → fall back to plain sequential loop.
+# Symptom (allocate.py): int/float literals used block_attr("tl.local_var_init")
+#   which the HIP backend silently ignored → variable uninitialised at runtime.
+# Symptom (codegen_hip.cc): AllocateNode emitted `type vid[1];` for local.var;
+#   alloc_storage_scope_ was not updated → GetBufferRef fell through to an
+#   invalid pointer-cast path → compile failure.
+#
+# Fix (allocate.py): always route init through T.buffer_store → explicit
+#   BufferStore TIR node → assignment statement in every backend.
+# Fix (codegen_hip.cc): emit `type vid = init;`; register alloc_storage_scope_
+#   so GetBufferRef returns the bare name `vid`.
+# ---------------------------------------------------------------------------
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+    }
+)
+def _kernel_alloc_var_init():
+    """Kernel that initialises a local int32 variable to 7 and writes it out."""
+
+    @T.prim_func
+    def main(Out: T.Tensor((64,), "int32")):
+        with T.Kernel(1, threads=64):
+            tx = T.get_thread_binding()
+            counter = T.alloc_var(T.int32, init=7)
+            Out[tx] = counter
+
+    return main
+
+
+@tilelang.testing.requires_rocm
+def test_alloc_var_init_in_hip_source():
+    """Init value must appear as `= 7;` in the generated HIP source."""
+    src = _kernel_alloc_var_init().get_kernel_source()
+    assert "= 7;" in src, (
+        "T.alloc_var(T.int32, init=7) should generate '= 7;' in HIP source, "
+        f"but it was not found.\nGenerated source:\n{src}"
+    )
+
+
+@tilelang.testing.requires_rocm
+def test_alloc_var_init_no_array_subscript_in_hip_source():
+    """local.var must be declared as a scalar (no `counter[` array syntax)."""
+    src = _kernel_alloc_var_init().get_kernel_source()
+    assert "counter[" not in src, (
+        "local.var should be emitted as a scalar (e.g. 'int counter = 7'), "
+        f"but array-style access was found:\n{src}"
+    )
+
+
+@tilelang.testing.requires_rocm
+def test_alloc_var_init_correctness():
+    """All output elements must equal 7 — the initialised value."""
+    out = torch.zeros(64, dtype=torch.int32, device="cuda")
+    _kernel_alloc_var_init()(out)
+    assert torch.all(out == 7), f"Expected all 7, got: {out}"
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+    }
+)
+def _kernel_multi_alloc_var_init():
+    """Two local variables with different init values, summed into output."""
+
+    @T.prim_func
+    def main(Out: T.Tensor((32,), "int32")):
+        with T.Kernel(1, threads=32):
+            tx = T.get_thread_binding()
+            a = T.alloc_var(T.int32, init=3)
+            b = T.alloc_var(T.int32, init=4)
+            Out[tx] = a + b
+
+    return main
+
+
+@tilelang.testing.requires_rocm
+def test_multi_alloc_var_init_in_hip_source():
+    """Both init values must appear in the HIP source."""
+    src = _kernel_multi_alloc_var_init().get_kernel_source()
+    assert src.count("= 3;") >= 1, f"Init value 3 not found in HIP source:\n{src}"
+    assert src.count("= 4;") >= 1, f"Init value 4 not found in HIP source:\n{src}"
+
+
+@tilelang.testing.requires_rocm
+def test_multi_alloc_var_init_correctness():
+    """Sum of two initialised local variables must equal 7 (3+4)."""
+    out = torch.zeros(32, dtype=torch.int32, device="cuda")
+    _kernel_multi_alloc_var_init()(out)
+    assert torch.all(out == 7), f"Expected all 7 (3+4), got: {out}"
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+    }
+)
+def _kernel_alloc_var_count():
+    """Counter initialised to 0, incremented 5 times in a loop."""
+
+    @T.prim_func
+    def main(Out: T.Tensor((32,), "int32")):
+        with T.Kernel(1, threads=32):
+            tx = T.get_thread_binding()
+            count = T.alloc_var(T.int32, init=0)
+            for _ in T.unroll(5):
+                count += 1
+            Out[tx] = count
+
+    return main
+
+
+@tilelang.testing.requires_rocm
+def test_alloc_var_zero_init_correctness():
+    """Variable initialised to 0 and incremented 5 times must equal 5."""
+    out = torch.zeros(32, dtype=torch.int32, device="cuda")
+    _kernel_alloc_var_count()(out)
+    assert torch.all(out == 5), f"Expected all 5, got: {out}"
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("init_val,dtype_str", [
+    (0,    "int32"),
+    (7,    "int32"),
+    (-3,   "int32"),
+    (0.0,  "float32"),
+    (1.0,  "float32"),
+    (-0.5, "float32"),
+])
+def test_alloc_var_literal_init_is_reliable(init_val, dtype_str):
+    """
+    alloc_var with any literal init must produce that exact value on HIP.
+
+    Old: int/float literals → block_attr (silently ignored) → uninit.
+    New: always T.buffer_store → `vid = init_val;` in generated HIP C.
+    """
+    tl_dtype    = T.int32   if dtype_str == "int32"   else T.float32
+    torch_dtype = torch.int32 if dtype_str == "int32" else torch.float32
+    N = 32
+
+    @tilelang.jit
+    def var_init_kernel(iv, tld):
+        @T.prim_func
+        def kernel(out: T.Tensor((N,), tld)) -> None:
+            with T.Kernel(1, threads=N) as _:
+                v = T.alloc_var(tld, init=iv)
+                for i in T.Parallel(N):
+                    out[i] = v
+        return kernel
+
+    out = torch.zeros(N, dtype=torch_dtype, device="cuda")
+    var_init_kernel(init_val, tl_dtype)(out)
+    torch.cuda.synchronize()
+
+    expected = torch.full((N,), init_val, dtype=torch_dtype, device="cuda")
+    if dtype_str == "int32":
+        assert torch.equal(out, expected), (
+            f"alloc_var(init={init_val}) got {out[0].item()}, expected {init_val}"
+        )
+    else:
+        torch.testing.assert_close(out, expected, atol=0, rtol=0)
+
+
+@tilelang.testing.requires_rocm
+def test_alloc_var_inf_init():
+    """
+    alloc_var(init=-T.infinity(T.float32)) — the pattern used for top1_var /
+    top2_var in MoE topk gate kernels — must produce -inf on HIP.
+    """
+    N = 32
+
+    @tilelang.jit
+    def inf_init_kernel():
+        @T.prim_func
+        def kernel(out: T.Tensor((N,), T.float32)) -> None:
+            with T.Kernel(1, threads=N) as _:
+                v = T.alloc_var(T.float32, init=-T.infinity(T.float32))
+                for i in T.Parallel(N):
+                    out[i] = v
+        return kernel
+
+    out = torch.zeros(N, dtype=torch.float32, device="cuda")
+    inf_init_kernel()(out)
+    torch.cuda.synchronize()
+    assert out.isinf().all() and (out < 0).all(), (
+        f"alloc_var(init=-inf) got {out[0].item()}, expected -inf"
+    )
+
+
+@tilelang.testing.requires_rocm
+def test_alloc_var_init_zero_persists_across_serial_loop():
+    """
+    count_var = T.alloc_var(T.int32, init=0) must start at 0 and accumulate
+    correctly.  This is the exact pattern used by count_var in MoE kernels.
+    """
+    N = 8
+
+    @tilelang.jit
+    def serial_count_kernel():
+        @T.prim_func
+        def kernel(out: T.Tensor((1,), T.int32)) -> None:
+            with T.Kernel(1, threads=1) as _:
+                count_var = T.alloc_var(T.int32, init=0)
+                for _ in T.serial(N):
+                    count_var = count_var + 1
+                out[0] = count_var
+        return kernel
+
+    out = torch.zeros(1, dtype=torch.int32, device="cuda")
+    serial_count_kernel()(out)
+    torch.cuda.synchronize()
+    assert out[0].item() == N, (
+        f"count_var: got {out[0].item()}, expected {N} — init=0 not applied (block_attr bug)"
+    )
+
+
+@tilelang.testing.requires_rocm
+def test_local_var_scalar_codegen():
+    """
+    local.var must be emitted and accessed as a plain scalar on HIP.
+
+    Before: alloc_storage_scope_ not registered → GetBufferRef fell through to
+            an invalid pointer-cast path → compile failure.
+    After:  `type vid = init;` emitted; GetBufferRef returns bare `vid`.
+    """
+    N = 32
+
+    @tilelang.jit
+    def local_var_scalar():
+        @T.prim_func
+        def kernel(out: T.Tensor((N,), T.int32)) -> None:
+            with T.Kernel(1, threads=N) as _:
+                v = T.alloc_var(T.int32, init=5)
+                if T.get_thread_binding() == 0:
+                    v = v + 1
+                for i in T.Parallel(N):
+                    out[i] = v
+        return kernel
+
+    out = torch.zeros(N, dtype=torch.int32, device="cuda")
+    local_var_scalar()(out)
+    torch.cuda.synchronize()
+    assert out[0].item() == 6, (
+        f"local.var scalar: got {out[0].item()}, expected 6 (5+1)"
+    )
+
+
+@tilelang.testing.requires_rocm
+def test_local_var_float_init_readable():
+    """
+    local.var with float32 literal init must be readable on HIP.
+    Before the alloc_storage_scope_ fix, GetBufferRef emitted invalid code.
+    """
+    @tilelang.jit
+    def float_init_readback():
+        @T.prim_func
+        def kernel(out: T.Tensor((1,), T.float32)) -> None:
+            with T.Kernel(1, threads=32) as _:
+                v = T.alloc_var(T.float32, init=3.14)
+                if T.get_thread_binding() == 0:
+                    out[0] = v
+        return kernel
+
+    out = torch.zeros(1, dtype=torch.float32, device="cuda")
+    float_init_readback()(out)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out[0].item(), 3.14, atol=1e-5, rtol=0)
+
+
+# ---------------------------------------------------------------------------
+# Fix 4 — src/target/codegen_hip.cc
+#   T.sync_warp() → no-op on HIP
+#
+# Symptom: tl::sync_warp() had no handler → codegen assertion failure or
+#   undefined symbol at link time.
+# Fix: emit an empty statement; AMD wavefronts execute in lockstep so
+#   intra-wavefront convergence is guaranteed by hardware.
+# ---------------------------------------------------------------------------
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+    }
+)
+def _kernel_sync_warp_codegen():
+    """Minimal kernel that exercises T.sync_warp()."""
+
+    @T.prim_func
+    def main(A: T.Tensor((32,), "float32"), B: T.Tensor((32,), "float32")):
+        with T.Kernel(1, threads=32):
+            tx = T.get_thread_binding()
+            A_shared = T.alloc_shared((32,), "float32")
+            A_shared[tx] = A[tx]
+            T.sync_warp()
+            B[tx] = A_shared[tx] * 2.0
+
+    return main
+
+
+@tilelang.testing.requires_rocm
+def test_sync_warp_no_syncwarp_in_hip_source():
+    """__syncwarp must NOT appear in the generated HIP source."""
+    src = _kernel_sync_warp_codegen().get_kernel_source()
+    assert "__syncwarp" not in src, (
+        "T.sync_warp() should be a no-op on HIP, "
+        f"but __syncwarp was found in the generated source:\n{src}"
+    )
+
+
+@tilelang.testing.requires_rocm
+def test_sync_warp_correctness():
+    """Kernel using T.sync_warp() must produce correct results on HIP."""
+    A = torch.arange(32, dtype=torch.float32, device="cuda")
+    B = torch.zeros(32, dtype=torch.float32, device="cuda")
+    _kernel_sync_warp_codegen()(A, B)
+    torch.testing.assert_close(B, A * 2.0)
+
+
+@tilelang.testing.requires_rocm
+def test_sync_warp_inside_conditional():
+    """
+    T.sync_warp() inside a conditional branch (pattern from moe/common.py
+    get_topk_group_idx).  Verifies compilation and deterministic output.
+    """
+    N, M = 32, 8
+
+    @tilelang.jit
+    def sync_warp_cond_kernel():
+        @T.prim_func
+        def kernel(
+            x:   T.Tensor((N,), T.float32),
+            out: T.Tensor((M,), T.float32),
+        ) -> None:
+            with T.Kernel(1, threads=N) as _:
+                shmem = T.alloc_shared((M,), T.float32)
+                tx = T.get_thread_binding()
+                if tx < M:
+                    shmem[tx] = x[tx]
+                T.sync_warp()
+                for i in T.Parallel(M):
+                    out[i] = shmem[i]
+        return kernel
+
+    x   = torch.randn(N, dtype=torch.float32, device="cuda")
+    out = torch.zeros(M, dtype=torch.float32, device="cuda")
+    sync_warp_cond_kernel()(x, out)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, x[:M])
+
+
+# ---------------------------------------------------------------------------
+# Fix 5 — src/target/codegen_hip.cc, src/target/rt_mod_hip.cc,
+#          src/target/stubs/hip.cc, src/target/stubs/hip.h
+#   T.sync_grid() → cooperative_groups::this_grid().sync()
+#
+# Symptom: tl::sync_grid() had no handler → same assertion / link failure.
+# Fix: emit cooperative_groups call; add need_cooperative_groups_ flag to
+#   conditionally include hip_cooperative_groups.h; add runtime launch
+#   infrastructure (hipModuleLaunchCooperativeKernel stubs).
+# ---------------------------------------------------------------------------
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+    }
+)
+def _kernel_sync_grid_codegen():
+    """Kernel that calls T.sync_grid() to trigger cooperative groups codegen."""
+
+    @T.prim_func
+    def main(A: T.Tensor((32,), "float32")):
+        with T.Kernel(1, threads=32):
+            tx = T.get_thread_binding()
+            T.sync_grid()
+            A[tx] = T.float32(tx)
+
+    return main
+
+
+@tilelang.testing.requires_rocm
+def test_sync_grid_cooperative_groups_in_hip_source():
+    """
+    T.sync_grid() must emit cooperative_groups::this_grid().sync() and
+    include <hip/hip_cooperative_groups.h> in the generated HIP source.
+
+    Note: runtime execution requires hipModuleLaunchCooperativeKernel which
+    is added via the stub infrastructure; this test validates codegen only.
+    """
+    src = _kernel_sync_grid_codegen().get_kernel_source()
+    assert "this_grid().sync()" in src, (
+        f"T.sync_grid() should generate 'this_grid().sync()' but not found:\n{src}"
+    )
+    assert "cooperative_groups" in src, (
+        f"T.sync_grid() should include cooperative_groups but not found:\n{src}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fix 6 — src/transform/pipeline_planning.cc
+#   Skip T.Pipelined(num_stages>1) pipeline planning on ROCM
+#
+# Symptom: Double-buffering doubled the LDS allocation for every shared buffer
+#   inside the loop body.  On CDNA (≤128 KB LDS per workgroup), this caused
+#   hipModuleLaunchKernel to return HIPERRORINVALIDVALUE at runtime.
+#
+# Fix: when TargetIsRocm() && num_stages > 1, skip pipeline planning and fall
+#   back to a plain sequential loop with synchronous T.copy — always LDS-safe.
 # ---------------------------------------------------------------------------
 
 
@@ -405,10 +676,10 @@ def test_bfloat16_shuffle_emits_pack_intrinsic():
 @pytest.mark.parametrize("num_stages", [1, 2, 3])
 def test_pipelined_no_lds_overflow(num_stages):
     """
-    T.Pipelined(num_stages=N) must not raise hipModuleLaunchKernel EINVAL on
-    ROCM and must produce the correct result regardless of N.
+    T.Pipelined(num_stages=N) must not raise hipModuleLaunchKernel EINVAL and
+    must produce the correct result regardless of N.
 
-    Old: num_stages=2 doubled LDS allocation → EINVAL on CDNA.
+    Old: num_stages=2 doubled LDS → EINVAL on CDNA.
     New: multi-stage loops fall back to plain sequential on ROCM.
     """
     M, K, blk = 32, 256, 64
@@ -446,7 +717,8 @@ def test_pipelined_no_lds_overflow(num_stages):
 def test_pipelined_multi_stage_fp16_gemm(num_stages):
     """
     FP16 GEMM with T.Pipelined(num_stages>1) must launch and produce correct
-    results on ROCM — the most common pattern that triggered the LDS overflow.
+    results on ROCM — the most common pattern that triggered the LDS overflow
+    (A_s bM×bK + B_s bK×bN doubled per pipeline stage).
     """
     M, N, K = 128, 128, 128
     bM, bN, bK = 64, 64, 32

--- a/testing/python/amd/test_tilelang_hip_codegen.py
+++ b/testing/python/amd/test_tilelang_hip_codegen.py
@@ -10,6 +10,7 @@ Covers three fixes made to src/target/codegen_hip.cc:
      subscript), consistent with the scalar declaration emitted for them.
 """
 
+import pytest
 import torch
 import tilelang
 import tilelang.testing
@@ -246,6 +247,236 @@ def test_sync_grid_cooperative_groups_in_hip_source():
         "T.sync_grid() should include cooperative_groups in HIP source, "
         f"but it was not found:\n{src}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Fix 4: warp_reduce — 5-step butterfly with width=32 (reduce.h)
+#
+# On CDNA (wave64) the old 6-step butterfly called __shfl_xor(value, 32)
+# without a width argument, reading uninitialised VGPRs in lanes 32-63 when
+# only 32 threads were active → NaN / garbage in reduce_max / reduce_sum.
+# Fix: remove step-32 shuffle; add width=32 to all remaining 5 steps.
+# ---------------------------------------------------------------------------
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("n_tokens,n_experts", [(64, 8), (128, 16), (512, 32)])
+def test_warp_reduce_no_nan(n_tokens, n_experts):
+    """
+    32-thread-per-block reduce_max / reduce_sum must not produce NaN on CDNA.
+
+    Old: __shfl_xor(v, 32) with 32 active threads reads uninit VGPRs → NaN.
+    New: 5-step with width=32 stays in-group → correct result, no NaN.
+    """
+    assert n_experts <= 32
+
+    @tilelang.jit
+    def gate_reduce(n_tok: int, n_exp: int):
+        @T.prim_func
+        def kernel(
+            logits:  T.Tensor((n_tok, n_exp), T.float32),
+            out_max: T.Tensor((n_tok,), T.float32),
+            out_sum: T.Tensor((n_tok,), T.float32),
+        ) -> None:
+            with T.Kernel(n_tok, threads=32) as pid:
+                lf = T.alloc_fragment(n_exp, T.float32)
+                T.copy(logits[pid, 0], lf)
+                mx = T.alloc_fragment(1, T.float32)
+                T.reduce_max(lf, mx, dim=0)
+                sm = T.alloc_fragment(1, T.float32)
+                T.reduce_sum(lf, sm, dim=0)
+                if T.get_thread_binding() == 0:
+                    out_max[pid] = mx[0]
+                    out_sum[pid] = sm[0]
+        return kernel
+
+    logits  = torch.randn(n_tokens, n_experts, dtype=torch.float32, device="cuda")
+    out_max = torch.zeros(n_tokens, dtype=torch.float32, device="cuda")
+    out_sum = torch.zeros(n_tokens, dtype=torch.float32, device="cuda")
+
+    gate_reduce(n_tokens, n_experts)(logits, out_max, out_sum)
+    torch.cuda.synchronize()
+
+    assert not out_max.isnan().any(), "reduce_max NaN — __shfl_xor(v,32) uninit VGPR bug"
+    assert not out_sum.isnan().any(), "reduce_sum NaN — __shfl_xor(v,32) uninit VGPR bug"
+    torch.testing.assert_close(out_max, logits.max(dim=1).values, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(out_sum, logits.sum(dim=1),        atol=1e-4, rtol=1e-4)
+
+
+@tilelang.testing.requires_rocm
+def test_warp_reduce_correctness_32_threads():
+    """
+    32-thread reduce_sum over 32 elements must return the exact sum on CDNA.
+
+    warp_reduce is exercised when T.reduce_sum falls through to the warp-level
+    shuffle path.  With the old __shfl_xor(v, 32) bug, reading uninitialised
+    lanes 32-63 on CDNA produced garbage.  With width=32 the result is exact.
+    """
+    N = 32
+
+    @tilelang.jit
+    def reduce_kernel():
+        @T.prim_func
+        def kernel(
+            x:   T.Tensor((N,), T.float32),
+            out: T.Tensor((1,), T.float32),
+        ) -> None:
+            with T.Kernel(1, threads=N) as _:
+                frag = T.alloc_fragment((N,), T.float32)
+                T.copy(x, frag)
+                s = T.alloc_fragment((1,), T.float32)
+                T.reduce_sum(frag, s, dim=0)
+                if T.get_thread_binding() == 0:
+                    out[0] = s[0]
+        return kernel
+
+    x   = torch.arange(1, N + 1, dtype=torch.float32, device="cuda")
+    out = torch.zeros(1, dtype=torch.float32, device="cuda")
+    reduce_kernel()(x, out)
+    torch.cuda.synchronize()
+
+    expected = x.sum()
+    assert not out[0].isnan(), "reduce_sum NaN — warp_reduce VGPR bug on CDNA"
+    torch.testing.assert_close(out[0], expected, atol=1e-4, rtol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Fix 5: ShuffleNode bfloat16x2 / float16x2 packing (codegen_hip.cc)
+#         uint1 bf16x2 math overloads (common.h)
+#
+# Old: CodeGenC emitted `uint1(a, b)` — invalid HIP constructor → compile error.
+# Fix: Override VisitExpr_(ShuffleNode) to emit `uint1{__pack_bfloat162(a,b)}`.
+#      Add abs2/max2/min2/add2/mul2 overloads for uint1 in common.h.
+# ---------------------------------------------------------------------------
+
+
+@tilelang.testing.requires_rocm
+def test_bfloat16_shuffle_emits_pack_intrinsic():
+    """
+    A bfloat16 fragment reduction triggers ShuffleNode bfloat16x2 packing.
+    The generated HIP source must use __pack_bfloat162 (not `uint1(a,b)`).
+    """
+    n_tok, n_exp = 16, 8
+
+    @tilelang.jit
+    def bf16_reduce(n_t: int, n_e: int):
+        @T.prim_func
+        def kernel(
+            x:   T.Tensor((n_t, n_e), T.bfloat16),
+            out: T.Tensor((n_t,), T.float32),
+        ) -> None:
+            with T.Kernel(n_t, threads=32) as pid:
+                frag = T.alloc_fragment(n_e, T.bfloat16)
+                T.copy(x[pid, 0], frag)
+                frag_f32 = T.alloc_fragment(n_e, T.float32)
+                for i in T.Parallel(n_e):
+                    frag_f32[i] = T.cast(frag[i], T.float32)
+                s = T.alloc_fragment(1, T.float32)
+                T.reduce_sum(frag_f32, s, dim=0)
+                if T.get_thread_binding() == 0:
+                    out[pid] = s[0]
+        return kernel
+
+    src = bf16_reduce(n_tok, n_exp).get_kernel_source()
+    # Must use the pack intrinsic, not the invalid two-argument constructor
+    assert "uint1(a" not in src and "uint1(b" not in src, \
+        "Old `uint1(a, b)` constructor found — ShuffleNode fix not applied"
+
+    # Runtime correctness
+    x   = torch.randn(n_tok, n_exp, dtype=torch.bfloat16, device="cuda")
+    out = torch.zeros(n_tok,        dtype=torch.float32,  device="cuda")
+    bf16_reduce(n_tok, n_exp)(x, out)
+    torch.cuda.synchronize()
+    assert not out.isnan().any(), "bf16 ShuffleNode reduction produced NaN"
+    torch.testing.assert_close(out, x.float().sum(dim=1), atol=5e-2, rtol=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# Fix 6: T.Pipelined(num_stages>1) on ROCM — skip pipeline planning
+#         (pipeline_planning.cc)
+#
+# Old: double-buffering doubled LDS per loop body → hipModuleLaunchKernel
+#      EINVAL on CDNA (≤128 KB LDS/workgroup).
+# Fix: TargetIsRocm() && num_stages>1 → fall back to plain sequential loop.
+# ---------------------------------------------------------------------------
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("num_stages", [1, 2, 3])
+def test_pipelined_no_lds_overflow(num_stages):
+    """
+    T.Pipelined(num_stages=N) must not raise hipModuleLaunchKernel EINVAL on
+    ROCM and must produce the correct result regardless of N.
+
+    Old: num_stages=2 doubled LDS allocation → EINVAL on CDNA.
+    New: multi-stage loops fall back to plain sequential on ROCM.
+    """
+    M, K, blk = 32, 256, 64
+
+    @tilelang.jit
+    def pipelined_rowsum(n_stages: int):
+        @T.prim_func
+        def kernel(
+            x:   T.Tensor((M, K), T.float32),
+            out: T.Tensor((M,),   T.float32),
+        ) -> None:
+            with T.Kernel(M, threads=64) as pid:
+                acc = T.alloc_fragment((1,), T.float32)
+                T.clear(acc)
+                for k in T.Pipelined(K // blk, num_stages=n_stages):
+                    xs = T.alloc_shared((blk,), T.float32)
+                    xl = T.alloc_fragment((blk,), T.float32)
+                    T.copy(x[pid, k * blk], xs, disable_tma=True)
+                    T.copy(xs, xl, disable_tma=True)
+                    s = T.alloc_fragment((1,), T.float32)
+                    T.reduce_sum(xl, s, dim=0)
+                    acc[0] = acc[0] + s[0]
+                out[pid] = acc[0]
+        return kernel
+
+    x   = torch.ones(M, K, dtype=torch.float32, device="cuda")
+    out = torch.zeros(M,   dtype=torch.float32, device="cuda")
+    pipelined_rowsum(num_stages)(x, out)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, torch.full((M,), float(K), device="cuda"), atol=1e-4, rtol=0)
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("num_stages", [2, 3])
+def test_pipelined_multi_stage_fp16_gemm(num_stages):
+    """
+    FP16 GEMM with T.Pipelined(num_stages>1) must launch and produce correct
+    results on ROCM — the most common pattern that triggered the LDS overflow.
+    """
+    M, N, K = 128, 128, 128
+    bM, bN, bK = 64, 64, 32
+
+    @tilelang.jit
+    def fp16_gemm(n_stages: int):
+        @T.prim_func
+        def kernel(
+            A: T.Tensor((M, K), T.float16),
+            B: T.Tensor((K, N), T.float16),
+            C: T.Tensor((M, N), T.float32),
+        ) -> None:
+            with T.Kernel(T.ceildiv(N, bN), T.ceildiv(M, bM), threads=128) as (bx, by):
+                A_s = T.alloc_shared((bM, bK), T.float16)
+                B_s = T.alloc_shared((bK, bN), T.float16)
+                C_l = T.alloc_fragment((bM, bN), T.float32)
+                T.clear(C_l)
+                for k in T.Pipelined(K // bK, num_stages=n_stages):
+                    T.copy(A[by * bM, k * bK], A_s)
+                    T.copy(B[k * bK, bx * bN], B_s)
+                    T.gemm(A_s, B_s, C_l)
+                T.copy(C_l, C[by * bM, bx * bN])
+        return kernel
+
+    A = torch.randn(M, K, dtype=torch.float16, device="cuda")
+    B = torch.randn(K, N, dtype=torch.float16, device="cuda")
+    C = torch.zeros(M, N, dtype=torch.float32, device="cuda")
+    fp16_gemm(num_stages)(A, B, C)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(C, A.float() @ B.float(), atol=1.0, rtol=5e-2)
 
 
 if __name__ == "__main__":

--- a/testing/python/amd/test_tilelang_hip_codegen.py
+++ b/testing/python/amd/test_tilelang_hip_codegen.py
@@ -56,7 +56,7 @@ def test_warp_reduce_no_nan(n_tokens, n_experts):
     def gate_reduce(n_tok: int, n_exp: int):
         @T.prim_func
         def kernel(
-            logits:  T.Tensor((n_tok, n_exp), T.float32),
+            logits: T.Tensor((n_tok, n_exp), T.float32),
             out_max: T.Tensor((n_tok,), T.float32),
             out_sum: T.Tensor((n_tok,), T.float32),
         ) -> None:
@@ -70,9 +70,10 @@ def test_warp_reduce_no_nan(n_tokens, n_experts):
                 if T.get_thread_binding() == 0:
                     out_max[pid] = mx[0]
                     out_sum[pid] = sm[0]
+
         return kernel
 
-    logits  = torch.randn(n_tokens, n_experts, dtype=torch.float32, device="cuda")
+    logits = torch.randn(n_tokens, n_experts, dtype=torch.float32, device="cuda")
     out_max = torch.zeros(n_tokens, dtype=torch.float32, device="cuda")
     out_sum = torch.zeros(n_tokens, dtype=torch.float32, device="cuda")
 
@@ -82,7 +83,7 @@ def test_warp_reduce_no_nan(n_tokens, n_experts):
     assert not out_max.isnan().any(), "reduce_max NaN — __shfl_xor(v,32) uninit VGPR bug"
     assert not out_sum.isnan().any(), "reduce_sum NaN — __shfl_xor(v,32) uninit VGPR bug"
     torch.testing.assert_close(out_max, logits.max(dim=1).values, atol=1e-5, rtol=1e-5)
-    torch.testing.assert_close(out_sum, logits.sum(dim=1),        atol=1e-4, rtol=1e-4)
+    torch.testing.assert_close(out_sum, logits.sum(dim=1), atol=1e-4, rtol=1e-4)
 
 
 @tilelang.testing.requires_rocm
@@ -99,7 +100,7 @@ def test_warp_reduce_correctness_32_threads():
     def reduce_kernel():
         @T.prim_func
         def kernel(
-            x:   T.Tensor((N,), T.float32),
+            x: T.Tensor((N,), T.float32),
             out: T.Tensor((1,), T.float32),
         ) -> None:
             with T.Kernel(1, threads=N) as _:
@@ -109,9 +110,10 @@ def test_warp_reduce_correctness_32_threads():
                 T.reduce_sum(frag, s, dim=0)
                 if T.get_thread_binding() == 0:
                     out[0] = s[0]
+
         return kernel
 
-    x   = torch.arange(1, N + 1, dtype=torch.float32, device="cuda")
+    x = torch.arange(1, N + 1, dtype=torch.float32, device="cuda")
     out = torch.zeros(1, dtype=torch.float32, device="cuda")
     reduce_kernel()(x, out)
     torch.cuda.synchronize()
@@ -135,7 +137,7 @@ def test_warp_reduce_with_64_threads_two_groups():
     def two_warp_reduce():
         @T.prim_func
         def kernel(
-            x:   T.Tensor((N, n_exp), T.float32),
+            x: T.Tensor((N, n_exp), T.float32),
             out: T.Tensor((N,), T.float32),
         ) -> None:
             with T.Kernel(1, threads=N) as _:
@@ -145,9 +147,10 @@ def test_warp_reduce_with_64_threads_two_groups():
                 s = T.alloc_fragment(1, T.float32)
                 T.reduce_sum(frag, s, dim=0)
                 out[tx] = s[0]
+
         return kernel
 
-    x   = torch.ones(N, n_exp, dtype=torch.float32, device="cuda")
+    x = torch.ones(N, n_exp, dtype=torch.float32, device="cuda")
     out = torch.zeros(N, dtype=torch.float32, device="cuda")
     two_warp_reduce()(x, out)
     torch.cuda.synchronize()
@@ -181,7 +184,7 @@ def test_bfloat16_shuffle_codegen_and_correctness():
     def bf16_reduce(n_t: int, n_e: int):
         @T.prim_func
         def kernel(
-            x:   T.Tensor((n_t, n_e), T.bfloat16),
+            x: T.Tensor((n_t, n_e), T.bfloat16),
             out: T.Tensor((n_t,), T.float32),
         ) -> None:
             with T.Kernel(n_t, threads=32) as pid:
@@ -194,19 +197,18 @@ def test_bfloat16_shuffle_codegen_and_correctness():
                 T.reduce_sum(frag_f32, s, dim=0)
                 if T.get_thread_binding() == 0:
                     out[pid] = s[0]
+
         return kernel
 
     kernel = bf16_reduce(n_tok, n_exp)
 
     # Source check: no invalid two-argument constructor
     src = kernel.get_kernel_source()
-    assert "uint1(a" not in src and "uint1(b" not in src, (
-        "Old `uint1(a, b)` constructor found — ShuffleNode fix not applied"
-    )
+    assert "uint1(a" not in src and "uint1(b" not in src, "Old `uint1(a, b)` constructor found — ShuffleNode fix not applied"
 
     # Runtime correctness
-    x   = torch.randn(n_tok, n_exp, dtype=torch.bfloat16, device="cuda")
-    out = torch.zeros(n_tok,        dtype=torch.float32,  device="cuda")
+    x = torch.randn(n_tok, n_exp, dtype=torch.bfloat16, device="cuda")
+    out = torch.zeros(n_tok, dtype=torch.float32, device="cuda")
     kernel(x, out)
     torch.cuda.synchronize()
     assert not out.isnan().any(), "bf16 ShuffleNode reduction NaN"
@@ -225,7 +227,7 @@ def test_float16_shuffle_correctness():
     def f16_reduce(n_t: int, n_e: int):
         @T.prim_func
         def kernel(
-            x:   T.Tensor((n_t, n_e), T.float16),
+            x: T.Tensor((n_t, n_e), T.float16),
             out: T.Tensor((n_t,), T.float32),
         ) -> None:
             with T.Kernel(n_t, threads=32) as pid:
@@ -238,10 +240,11 @@ def test_float16_shuffle_correctness():
                 T.reduce_sum(frag_f32, s, dim=0)
                 if T.get_thread_binding() == 0:
                     out[pid] = s[0]
+
         return kernel
 
-    x   = torch.randn(n_tok, n_exp, dtype=torch.float16, device="cuda")
-    out = torch.zeros(n_tok,        dtype=torch.float32, device="cuda")
+    x = torch.randn(n_tok, n_exp, dtype=torch.float16, device="cuda")
+    out = torch.zeros(n_tok, dtype=torch.float32, device="cuda")
     f16_reduce(n_tok, n_exp)(x, out)
     torch.cuda.synchronize()
     assert not out.isnan().any(), "float16 ShuffleNode reduction NaN"
@@ -290,8 +293,7 @@ def test_alloc_var_init_in_hip_source():
     """Init value must appear as `= 7;` in the generated HIP source."""
     src = _kernel_alloc_var_init().get_kernel_source()
     assert "= 7;" in src, (
-        "T.alloc_var(T.int32, init=7) should generate '= 7;' in HIP source, "
-        f"but it was not found.\nGenerated source:\n{src}"
+        f"T.alloc_var(T.int32, init=7) should generate '= 7;' in HIP source, but it was not found.\nGenerated source:\n{src}"
     )
 
 
@@ -300,8 +302,7 @@ def test_alloc_var_init_no_array_subscript_in_hip_source():
     """local.var must be declared as a scalar (no `counter[` array syntax)."""
     src = _kernel_alloc_var_init().get_kernel_source()
     assert "counter[" not in src, (
-        "local.var should be emitted as a scalar (e.g. 'int counter = 7'), "
-        f"but array-style access was found:\n{src}"
+        f"local.var should be emitted as a scalar (e.g. 'int counter = 7'), but array-style access was found:\n{src}"
     )
 
 
@@ -379,14 +380,17 @@ def test_alloc_var_zero_init_correctness():
 
 
 @tilelang.testing.requires_rocm
-@pytest.mark.parametrize("init_val,dtype_str", [
-    (0,    "int32"),
-    (7,    "int32"),
-    (-3,   "int32"),
-    (0.0,  "float32"),
-    (1.0,  "float32"),
-    (-0.5, "float32"),
-])
+@pytest.mark.parametrize(
+    "init_val,dtype_str",
+    [
+        (0, "int32"),
+        (7, "int32"),
+        (-3, "int32"),
+        (0.0, "float32"),
+        (1.0, "float32"),
+        (-0.5, "float32"),
+    ],
+)
 def test_alloc_var_literal_init_is_reliable(init_val, dtype_str):
     """
     alloc_var with any literal init must produce that exact value on HIP.
@@ -394,7 +398,7 @@ def test_alloc_var_literal_init_is_reliable(init_val, dtype_str):
     Old: int/float literals → block_attr (silently ignored) → uninit.
     New: always T.buffer_store → `vid = init_val;` in generated HIP C.
     """
-    tl_dtype    = T.int32   if dtype_str == "int32"   else T.float32
+    tl_dtype = T.int32 if dtype_str == "int32" else T.float32
     torch_dtype = torch.int32 if dtype_str == "int32" else torch.float32
     N = 32
 
@@ -406,6 +410,7 @@ def test_alloc_var_literal_init_is_reliable(init_val, dtype_str):
                 v = T.alloc_var(tld, init=iv)
                 for i in T.Parallel(N):
                     out[i] = v
+
         return kernel
 
     out = torch.zeros(N, dtype=torch_dtype, device="cuda")
@@ -414,9 +419,7 @@ def test_alloc_var_literal_init_is_reliable(init_val, dtype_str):
 
     expected = torch.full((N,), init_val, dtype=torch_dtype, device="cuda")
     if dtype_str == "int32":
-        assert torch.equal(out, expected), (
-            f"alloc_var(init={init_val}) got {out[0].item()}, expected {init_val}"
-        )
+        assert torch.equal(out, expected), f"alloc_var(init={init_val}) got {out[0].item()}, expected {init_val}"
     else:
         torch.testing.assert_close(out, expected, atol=0, rtol=0)
 
@@ -437,14 +440,13 @@ def test_alloc_var_inf_init():
                 v = T.alloc_var(T.float32, init=-T.infinity(T.float32))
                 for i in T.Parallel(N):
                     out[i] = v
+
         return kernel
 
     out = torch.zeros(N, dtype=torch.float32, device="cuda")
     inf_init_kernel()(out)
     torch.cuda.synchronize()
-    assert out.isinf().all() and (out < 0).all(), (
-        f"alloc_var(init=-inf) got {out[0].item()}, expected -inf"
-    )
+    assert out.isinf().all() and (out < 0).all(), f"alloc_var(init=-inf) got {out[0].item()}, expected -inf"
 
 
 @tilelang.testing.requires_rocm
@@ -464,14 +466,13 @@ def test_alloc_var_init_zero_persists_across_serial_loop():
                 for _ in T.serial(N):
                     count_var = count_var + 1
                 out[0] = count_var
+
         return kernel
 
     out = torch.zeros(1, dtype=torch.int32, device="cuda")
     serial_count_kernel()(out)
     torch.cuda.synchronize()
-    assert out[0].item() == N, (
-        f"count_var: got {out[0].item()}, expected {N} — init=0 not applied (block_attr bug)"
-    )
+    assert out[0].item() == N, f"count_var: got {out[0].item()}, expected {N} — init=0 not applied (block_attr bug)"
 
 
 @tilelang.testing.requires_rocm
@@ -495,14 +496,13 @@ def test_local_var_scalar_codegen():
                     v = v + 1
                 for i in T.Parallel(N):
                     out[i] = v
+
         return kernel
 
     out = torch.zeros(N, dtype=torch.int32, device="cuda")
     local_var_scalar()(out)
     torch.cuda.synchronize()
-    assert out[0].item() == 6, (
-        f"local.var scalar: got {out[0].item()}, expected 6 (5+1)"
-    )
+    assert out[0].item() == 6, f"local.var scalar: got {out[0].item()}, expected 6 (5+1)"
 
 
 @tilelang.testing.requires_rocm
@@ -511,6 +511,7 @@ def test_local_var_float_init_readable():
     local.var with float32 literal init must be readable on HIP.
     Before the alloc_storage_scope_ fix, GetBufferRef emitted invalid code.
     """
+
     @tilelang.jit
     def float_init_readback():
         @T.prim_func
@@ -519,6 +520,7 @@ def test_local_var_float_init_readable():
                 v = T.alloc_var(T.float32, init=3.14)
                 if T.get_thread_binding() == 0:
                     out[0] = v
+
         return kernel
 
     out = torch.zeros(1, dtype=torch.float32, device="cuda")
@@ -563,10 +565,7 @@ def _kernel_sync_warp_codegen():
 def test_sync_warp_no_syncwarp_in_hip_source():
     """__syncwarp must NOT appear in the generated HIP source."""
     src = _kernel_sync_warp_codegen().get_kernel_source()
-    assert "__syncwarp" not in src, (
-        "T.sync_warp() should be a no-op on HIP, "
-        f"but __syncwarp was found in the generated source:\n{src}"
-    )
+    assert "__syncwarp" not in src, f"T.sync_warp() should be a no-op on HIP, but __syncwarp was found in the generated source:\n{src}"
 
 
 @tilelang.testing.requires_rocm
@@ -590,7 +589,7 @@ def test_sync_warp_inside_conditional():
     def sync_warp_cond_kernel():
         @T.prim_func
         def kernel(
-            x:   T.Tensor((N,), T.float32),
+            x: T.Tensor((N,), T.float32),
             out: T.Tensor((M,), T.float32),
         ) -> None:
             with T.Kernel(1, threads=N) as _:
@@ -601,9 +600,10 @@ def test_sync_warp_inside_conditional():
                 T.sync_warp()
                 for i in T.Parallel(M):
                     out[i] = shmem[i]
+
         return kernel
 
-    x   = torch.randn(N, dtype=torch.float32, device="cuda")
+    x = torch.randn(N, dtype=torch.float32, device="cuda")
     out = torch.zeros(M, dtype=torch.float32, device="cuda")
     sync_warp_cond_kernel()(x, out)
     torch.cuda.synchronize()
@@ -651,12 +651,8 @@ def test_sync_grid_cooperative_groups_in_hip_source():
     is added via the stub infrastructure; this test validates codegen only.
     """
     src = _kernel_sync_grid_codegen().get_kernel_source()
-    assert "this_grid().sync()" in src, (
-        f"T.sync_grid() should generate 'this_grid().sync()' but not found:\n{src}"
-    )
-    assert "cooperative_groups" in src, (
-        f"T.sync_grid() should include cooperative_groups but not found:\n{src}"
-    )
+    assert "this_grid().sync()" in src, f"T.sync_grid() should generate 'this_grid().sync()' but not found:\n{src}"
+    assert "cooperative_groups" in src, f"T.sync_grid() should include cooperative_groups but not found:\n{src}"
 
 
 # ---------------------------------------------------------------------------
@@ -692,8 +688,8 @@ def test_pipelined_no_lds_overflow(num_stages):
     def pipelined_rowsum(n_stages: int):
         @T.prim_func
         def kernel(
-            x:   T.Tensor((M, K), T.float32),
-            out: T.Tensor((M,),   T.float32),
+            x: T.Tensor((M, K), T.float32),
+            out: T.Tensor((M,), T.float32),
         ) -> None:
             with T.Kernel(M, threads=64) as pid:
                 acc = T.alloc_fragment((1,), T.float32)
@@ -707,10 +703,11 @@ def test_pipelined_no_lds_overflow(num_stages):
                     T.reduce_sum(xl, s, dim=0)
                     acc[0] = acc[0] + s[0]
                 out[pid] = acc[0]
+
         return kernel
 
-    x   = torch.ones(M, K, dtype=torch.float32, device="cuda")
-    out = torch.zeros(M,   dtype=torch.float32, device="cuda")
+    x = torch.ones(M, K, dtype=torch.float32, device="cuda")
+    out = torch.zeros(M, dtype=torch.float32, device="cuda")
     pipelined_rowsum(num_stages)(x, out)
     torch.cuda.synchronize()
     torch.testing.assert_close(out, torch.full((M,), float(K), device="cuda"), atol=1e-4, rtol=0)
@@ -745,6 +742,7 @@ def test_pipelined_multi_stage_fp16_gemm(num_stages):
                     T.copy(B[k * bK, bx * bN], B_s)
                     T.gemm(A_s, B_s, C_l)
                 T.copy(C_l, C[by * bM, bx * bN])
+
         return kernel
 
     A = torch.randn(M, K, dtype=torch.float16, device="cuda")

--- a/testing/python/amd/test_tilelang_hip_codegen.py
+++ b/testing/python/amd/test_tilelang_hip_codegen.py
@@ -664,8 +664,12 @@ def test_sync_grid_cooperative_groups_in_hip_source():
 #   Skip T.Pipelined(num_stages>1) pipeline planning on ROCM
 #
 # Symptom: Double-buffering doubled the LDS allocation for every shared buffer
-#   inside the loop body.  On CDNA (≤128 KB LDS per workgroup), this caused
-#   hipModuleLaunchKernel to return HIPERRORINVALIDVALUE at runtime.
+#   inside the loop body, exhausting the per-workgroup LDS budget and causing
+#   hipModuleLaunchKernel to return HIPERRORINVALIDVALUE.  LDS limits:
+#     gfx942 (CDNA3 / MI300X): 64 KB;  gfx950 (CDNA4 / MI350): 160 KB (#2058)
+#   Even with gfx950's larger budget, double-buffering large shared tiles can
+#   still exceed 160 KB, and the HIP async-copy infrastructure has no ROCM
+#   equivalent, so the planner cannot safely pipeline on any ROCM target.
 #
 # Fix: when TargetIsRocm() && num_stages > 1, skip pipeline planning and fall
 #   back to a plain sequential loop with synchronous T.copy — always LDS-safe.
@@ -679,7 +683,7 @@ def test_pipelined_no_lds_overflow(num_stages):
     T.Pipelined(num_stages=N) must not raise hipModuleLaunchKernel EINVAL and
     must produce the correct result regardless of N.
 
-    Old: num_stages=2 doubled LDS → EINVAL on CDNA.
+    Old: num_stages=2 doubled LDS → EINVAL (64 KB on gfx942, 160 KB on gfx950).
     New: multi-stage loops fall back to plain sequential on ROCM.
     """
     M, K, blk = 32, 256, 64

--- a/testing/python/amd/test_tilelang_hip_codegen.py
+++ b/testing/python/amd/test_tilelang_hip_codegen.py
@@ -1,0 +1,252 @@
+"""
+Tests for HIP/AMD codegen fixes in TileLang.
+
+Covers three fixes made to src/target/codegen_hip.cc:
+  1. T.sync_warp() is lowered to a no-op on HIP (AMD wavefronts execute in
+     lockstep so no explicit reconvergence barrier is needed).
+  2. T.alloc_var(dtype, init=value) emits a properly initialised scalar
+     declaration on HIP (previously the init value was silently dropped).
+  3. local.var buffers are accessed as plain scalars in GetBufferRef (no [0]
+     subscript), consistent with the scalar declaration emitted for them.
+"""
+
+import torch
+import tilelang
+import tilelang.testing
+import tilelang.language as T
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: T.sync_warp() → no-op on HIP
+# ---------------------------------------------------------------------------
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+    }
+)
+def _kernel_sync_warp_codegen():
+    """Minimal kernel that exercises T.sync_warp()."""
+
+    @T.prim_func
+    def main(A: T.Tensor((32,), "float32"), B: T.Tensor((32,), "float32")):
+        with T.Kernel(1, threads=32):
+            tx = T.get_thread_binding()
+            A_shared = T.alloc_shared((32,), "float32")
+            A_shared[tx] = A[tx]
+            T.sync_warp()
+            B[tx] = A_shared[tx] * 2.0
+
+    return main
+
+
+@tilelang.testing.requires_rocm
+def test_sync_warp_no_syncwarp_in_hip_source():
+    """__syncwarp must NOT appear in the HIP-generated kernel source."""
+    kernel = _kernel_sync_warp_codegen()
+    src = kernel.get_kernel_source()
+    assert "__syncwarp" not in src, (
+        "T.sync_warp() should be a no-op on HIP (AMD wavefronts are lockstep), "
+        f"but __syncwarp was found in the generated source:\n{src}"
+    )
+
+
+@tilelang.testing.requires_rocm
+def test_sync_warp_correctness():
+    """Kernel using T.sync_warp() should produce correct results on HIP."""
+    kernel = _kernel_sync_warp_codegen()
+    A = torch.arange(32, dtype=torch.float32, device="cuda")
+    B = torch.zeros(32, dtype=torch.float32, device="cuda")
+    kernel(A, B)
+    torch.testing.assert_close(B, A * 2.0)
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: T.alloc_var(init=...) initialisation on HIP
+# ---------------------------------------------------------------------------
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+    }
+)
+def _kernel_alloc_var_init():
+    """Kernel that initialises a local int32 variable and writes it to output."""
+
+    @T.prim_func
+    def main(Out: T.Tensor((64,), "int32")):
+        with T.Kernel(1, threads=64):
+            tx = T.get_thread_binding()
+            counter = T.alloc_var(T.int32, init=7)
+            Out[tx] = counter
+
+    return main
+
+
+@tilelang.testing.requires_rocm
+def test_alloc_var_init_in_hip_source():
+    """Init value must appear in the generated HIP source for T.alloc_var."""
+    kernel = _kernel_alloc_var_init()
+    src = kernel.get_kernel_source()
+    assert "= 7;" in src, (
+        "T.alloc_var(T.int32, init=7) should generate '= 7;' in HIP source, "
+        f"but it was not found.\nGenerated source:\n{src}"
+    )
+
+
+@tilelang.testing.requires_rocm
+def test_alloc_var_init_no_array_subscript_in_hip_source():
+    """local.var should be declared as a scalar, not as an array (no [0])."""
+    kernel = _kernel_alloc_var_init()
+    src = kernel.get_kernel_source()
+    # The kernel source should contain 'counter = 7' not 'counter[1]' or 'counter[0]'
+    assert "counter[" not in src, (
+        "local.var should be emitted as a scalar (e.g. 'int counter = 7'), "
+        f"but array-style access was found in the HIP source:\n{src}"
+    )
+
+
+@tilelang.testing.requires_rocm
+def test_alloc_var_init_correctness():
+    """Kernel should read back the initialised value correctly on HIP."""
+    kernel = _kernel_alloc_var_init()
+    out = torch.zeros(64, dtype=torch.int32, device="cuda")
+    kernel(out)
+    assert torch.all(out == 7), (
+        f"Expected all 7, got: {out}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fix 2b: multiple T.alloc_var with distinct init values
+# ---------------------------------------------------------------------------
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+    }
+)
+def _kernel_multi_alloc_var_init():
+    """Two local variables with different init values, summed into output."""
+
+    @T.prim_func
+    def main(Out: T.Tensor((32,), "int32")):
+        with T.Kernel(1, threads=32):
+            tx = T.get_thread_binding()
+            a = T.alloc_var(T.int32, init=3)
+            b = T.alloc_var(T.int32, init=4)
+            Out[tx] = a + b
+
+    return main
+
+
+@tilelang.testing.requires_rocm
+def test_multi_alloc_var_init_in_hip_source():
+    """Both init values must appear in the HIP source."""
+    kernel = _kernel_multi_alloc_var_init()
+    src = kernel.get_kernel_source()
+    assert src.count("= 3;") >= 1, f"Init value 3 not found in HIP source:\n{src}"
+    assert src.count("= 4;") >= 1, f"Init value 4 not found in HIP source:\n{src}"
+
+
+@tilelang.testing.requires_rocm
+def test_multi_alloc_var_init_correctness():
+    """Sum of two initialised local variables should equal 7 on HIP."""
+    kernel = _kernel_multi_alloc_var_init()
+    out = torch.zeros(32, dtype=torch.int32, device="cuda")
+    kernel(out)
+    assert torch.all(out == 7), f"Expected all 7 (3+4), got: {out}"
+
+
+# ---------------------------------------------------------------------------
+# Fix 2c: T.alloc_var(init=0) — the default zero-init case
+# ---------------------------------------------------------------------------
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+    }
+)
+def _kernel_alloc_var_count():
+    """
+    Accumulates a count by incrementing a local variable in a loop.
+    Relies on the variable being zero-initialised (init=0 default).
+    """
+
+    @T.prim_func
+    def main(Out: T.Tensor((32,), "int32")):
+        with T.Kernel(1, threads=32):
+            tx = T.get_thread_binding()
+            count = T.alloc_var(T.int32, init=0)
+            for _ in T.unroll(5):
+                count += 1
+            Out[tx] = count
+
+    return main
+
+
+@tilelang.testing.requires_rocm
+def test_alloc_var_zero_init_correctness():
+    """Variable initialised to 0, incremented 5 times, should equal 5."""
+    kernel = _kernel_alloc_var_count()
+    out = torch.zeros(32, dtype=torch.int32, device="cuda")
+    kernel(out)
+    assert torch.all(out == 5), f"Expected all 5, got: {out}"
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: T.sync_grid() codegen on HIP (codegen only; runtime not yet complete)
+# ---------------------------------------------------------------------------
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+    }
+)
+def _kernel_sync_grid_codegen():
+    """Kernel that calls T.sync_grid() to trigger cooperative groups codegen."""
+
+    @T.prim_func
+    def main(A: T.Tensor((32,), "float32")):
+        with T.Kernel(1, threads=32):
+            tx = T.get_thread_binding()
+            T.sync_grid()
+            A[tx] = T.float32(tx)
+
+    return main
+
+
+@tilelang.testing.requires_rocm
+def test_sync_grid_cooperative_groups_in_hip_source():
+    """
+    T.sync_grid() should generate cooperative_groups::this_grid().sync()
+    and include <hip/hip_cooperative_groups.h> in the HIP source.
+
+    Note: runtime execution of this kernel is not yet supported because
+    rocm_module.cc does not yet call hipModuleLaunchCooperativeKernel.
+    This test validates codegen only.
+    """
+    kernel = _kernel_sync_grid_codegen()
+    src = kernel.get_kernel_source()
+    assert "this_grid().sync()" in src, (
+        "T.sync_grid() should generate 'this_grid().sync()' in HIP source, "
+        f"but it was not found:\n{src}"
+    )
+    assert "cooperative_groups" in src, (
+        "T.sync_grid() should include cooperative_groups in HIP source, "
+        f"but it was not found:\n{src}"
+    )
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/language/allocate.py
+++ b/tilelang/language/allocate.py
@@ -137,10 +137,16 @@ def alloc_var(dtype: DType, *args, scope: str = "local.var", init: PrimExpr | in
 
     buffer = T.alloc_buffer([1], dtype, scope=parsed_scope)
     if parsed_init is not None:
+        # Always use T.buffer_store for reliable initialisation across all
+        # backends.  The block_attr("tl.local_var_init") path feeds into the
+        # flatten_buffer transform which does not reliably emit initialiser
+        # code on some backends (e.g. HIP codegen silently drops the
+        # annotation for integer/float literals, leaving the scalar
+        # uninitialised).  T.buffer_store emits an explicit BufferStore TIR
+        # node that every backend lowers to an assignment statement.
         if isinstance(parsed_init, (int, float, IntImm, FloatImm)):
-            block_attr({"tl.local_var_init": {buffer.data: tl_dtype(dtype)(parsed_init)}})
-        else:
-            T.buffer_store(buffer, parsed_init, 0)
+            parsed_init = tl_dtype(dtype)(parsed_init)
+        T.buffer_store(buffer, parsed_init, 0)
     return buffer
 
 


### PR DESCRIPTION
To support Tilekernel on AMD GPU, This PR fixes 6 bugs in TileLang's AMD ROCm/HIP backend, covering code generation correctness, runtime launch, LDS overflow, and reduction accuracy.

1)  Fix 1 — warp_reduce reads uninitialized VGPRs (reduce.h)

 Symptom: On CDNA (wave64) with 32 active threads, the old 6-step butterfly called __shfl_xor(value, 32) without a width argument, reading uninitialized VGPRs from lanes 32–63 and producing NaN or garbage in every reduction (reduce_max, reduce_sum, AllReduce).

Fix: Drop the step-32 shuffle; add width=32 to the remaining 5 steps. __shfl_xor(v, N, 32) confines the butterfly to the [0, 31] lane group, matching CUDA warp semantics on both CDNA wave64 and RDNA wave32.

This fix is just to have TileKernel run smoothly, not for performance. We will consider performance in other PRs  

2) Fix 2 — ShuffleNode bfloat16x2/float16x2 packing (codegen_hip.cc, common.h)

Symptom: HIP's uint1 has no two-argument constructor, so CodeGenC's emitted uint1(a, b) fails to compile.
Fix: Add a VisitExpr_(ShuffleNode) override that emits uint1{__pack_bfloat162(a, b)} / uint1{__pack_half2(a, b)} for bf16x2/fp16x2 packing. Add abs2, max2, min2, add2, mul2 overloads for the uint1 carrier type in common.h.

3) Fix 3 — T.alloc_var(init=...) leaves scalar uninitialized (allocate.py, codegen_hip.cc)

Symptom: For integer/float literal initializers, the old block_attr("tl.local_var_init") annotation path was silently dropped by the
  flatten-buffer transform on some backends, leaving the scalar uninitialized on HIP.
Fix: Always use T.buffer_store to emit an explicit BufferStore TIR node. The HIP codegen now emits T val = <init>; for local.var scope allocations, with a fallback of 0.

4) Fix 4 — T.sync_warp() has no HIP equivalent (codegen_hip.cc)

Symptom: HIP has no __syncwarp(), causing a compilation error.
  
Fix: AMD wavefronts execute in lockstep, so intra-wavefront convergence is hardware-guaranteed. sync_warp is now lowered to a no-op on HIP (the mask argument is intentionally ignored).

5) Fix 5 — T.sync_grid() missing cooperative groups support (codegen_hip.cc, rt_mod_hip.cc, stubs/)

Symptom: sync_grid had no HIP lowering path.
Fix: Emit cooperative_groups::this_grid().sync() and include hip/hip_cooperative_groups.h. The runtime detects the use_cooperative_groups function attribute and launches via hipModuleLaunchCooperativeKernel. Stub declarations and implementations are added for the new launch API.

 6)  Fix 6 — T.Pipelined(num_stages > 1) causes LDS overflow (pipeline_planning.cc)

 Symptom: Double-buffering doubles the LDS allocation for every shared buffer inside the loop body, easily exceeding the per-workgroup LDS limit (gfx942: 64 KB; gfx950: 160 KB), causing hipModuleLaunchKernel to return HIPERRORINVALIDVALUE.

Fix: When targeting ROCm and num_stages > 1, the pipeline planner falls back to a plain sequential loop. The HIP async-copy infrastructure required by the CUDA pipeline planner has no ROCm equivalent today; full pipelining support is  deferred.

 7) Fix 7 — sign-extension in FP8 packing (hip_fp8.h)

  Cast fp8 bytes through unsigned char before shifting to prevent sign-extension corrupting the packed bit pattern.

 8) Fix 8 — __habs overload ambiguity (common.h)

  Add __habs overloads for hip_bfloat16 and float16_t to resolve ambiguous-overload compile errors caused by ROCm type-alias mismatches. Uses __builtin_memcpy instead of reinterpret_cast to avoid strict-aliasing UB.

Test codes: testing/python/amd/test_tilelang_hip_codegen.py 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cooperative-groups synchronization support for HIP kernels
  * Improved local variable initialization with dtype-aware casting
  * Enabled software pipelining for multi-stage operations on ROCm targets

* **Bug Fixes**
  * Fixed warp reduction correctness with explicit 32-lane shuffle semantics
  * Improved shuffle operation code generation for packed data types
  * Corrected local variable storage representation in HIP code generation

* **Tests**
  * Added comprehensive HIP codegen regression test suite covering synchronization, reductions, and kernel execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->