### PR TITLE
improve build skill description for AI agent discoverability

### DIFF
--- a/.agents/skills/tilelang-build/SKILL.md
+++ b/.agents/skills/tilelang-build/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: tilelang-build
-description: Repository-specific build, rebuild, install, and test instructions for tilelang. Use when working in the tilelang repository and the correct commands are needed for building from source, reinstalling after changes, or running project tests.
+name: build
+description: "MUST load before any build, install, cmake, pip, or test operation in tilelang. Defines canonical build methods (pip install, cmake dev, editable-install ban) and test commands. ALWAYS re-read after rebase, merge, or dependency changes."
 ---
 
 # Build & Install


### PR DESCRIPTION
## Summary

Make the build skill description directive so AI agents always load it before build operations.

**Before:** `Repository-specific build, rebuild, install, and test instructions for tilelang. Use when working in the tilelang repository and the correct commands are needed...`

**After:** `MUST load before any build, install, cmake, pip, or test operation in tilelang. Defines canonical build methods (pip install, cmake dev, editable-install ban) and test commands. ALWAYS re-read after rebase, merge, or dependency changes.`

## Why

AI agents see skill descriptions as one-line summaries in a long list. The passive phrasing ("Use when...commands are needed") reads as optional documentation — agents skip it when they already have cached knowledge of cmake commands from prior context. This causes them to miss project-specific constraints (e.g., the editable-install ban, or the need to re-configure after rebase).

The directive phrasing ("MUST load before...") and explicit triggers ("after rebase, merge, or dependency changes") ensure agents treat the skill as mandatory rather than informational.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated skill documentation to clarify build process requirements and loading order constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->