### PR TITLE
[CUDA][SM100] Include cuda_fp6.h when emitting FP6 types

### DIFF
--- a/src/target/codegen_cuda.cc
+++ b/src/target/codegen_cuda.cc
@@ -592,6 +592,9 @@ std::string CodeGenTileLangCUDA::Finish() {
   if (enable_fp8_) {
     decl_stream << "#include <tl_templates/cuda/cuda_fp8.h>\n";
   }
+  if (enable_fp6_) {
+    decl_stream << "#include <cuda_fp6.h>\n";
+  }
   if (enable_fp4_) {
     decl_stream << "#include <tl_templates/cuda/cuda_fp4.h>\n";
   }


### PR DESCRIPTION
## Summary

Add `#include <cuda_fp6.h>` when CUDA codegen emits FP6 types.

## Why

On Blackwell, FP6 can be used as a storage dtype in kernel parameters, for example in copy, staging, or layout-transform kernels. Since codegen already emits native CUDA FP6 types like `__nv_fp6_e2m3` / `__nv_fp6_e3m2`, the generated source needs `<cuda_fp6.h>` to be self-contained.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for FP6 data type in CUDA code generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->