### PR TITLE
[TMA] Support FP4 TensorMap TMA copies

### DIFF
--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -40,6 +40,32 @@ static PrimExpr MakeTmaLeaderCondition(PrimExpr thread_extent) {
   return Call(DataType::Bool(), tl_shuffle_elect(), {std::move(thread_extent)});
 }
 
+static int64_t TMABytesFromElements(int64_t elements, DataType dtype) {
+  return (elements * dtype.bits() + 7) / 8;
+}
+
+static PrimExpr TMABytesFromElements(PrimExpr elements, DataType dtype) {
+  PrimExpr elements_i64 = cast(DataType::Int(64), elements);
+  int bits = dtype.bits();
+  if (bits % 8 == 0) {
+    return elements_i64 * IntImm(DataType::Int(64), bits / 8);
+  }
+  return FloorDiv(elements_i64 * IntImm(DataType::Int(64), bits) +
+                      IntImm(DataType::Int(64), 7),
+                  IntImm(DataType::Int(64), 8));
+}
+
+static PrimExpr TMABitsFromElements(PrimExpr elements, DataType dtype) {
+  return cast(DataType::Int(64), elements) *
+         IntImm(DataType::Int(64), dtype.bits());
+}
+
+static int64_t TMAElementsForBytes(int64_t bytes, DataType dtype) {
+  ICHECK_EQ((bytes * 8) % dtype.bits(), 0)
+      << bytes << " bytes cannot be represented as whole elements of " << dtype;
+  return bytes * 8 / dtype.bits();
+}
+
 PrimExpr GetCopyMbarPhaseExpr(const Map<String, ObjectRef> &annotations,
                               const LowerArgs &T) {
   PrimExpr phase = T.mbar_phase_expr;
@@ -525,8 +551,7 @@ bool CopyNode::CheckGlobalStrides(const Buffer &buffer,
   }
 
   for (size_t i = 0; i + 1 < strides.size(); ++i) {
-    PrimExpr stride_bytes =
-        cast(DataType::Int(64), strides[i]) * buffer->dtype.bytes();
+    PrimExpr stride_bytes = TMABytesFromElements(strides[i], buffer->dtype);
     if (analyzer->CanProve(
             FloorMod(stride_bytes, IntImm(DataType::Int(64), 16)) != 0,
             arith::ProofStrength::kSymbolicBound)) {
@@ -565,13 +590,14 @@ bool CopyNode::CheckBulkLoad(Target target, arith::Analyzer *analyzer,
   // now we check src (gmem) as tma box dim is deduced from src
   if (check_last_dim &&
       analyzer->CanProve(
-          FloorMod(src_range[src_range.size() - 1]->extent * src->dtype.bytes(),
-                   16) != 0,
+          FloorMod(TMABitsFromElements(src_range[src_range.size() - 1]->extent,
+                                       src->dtype),
+                   IntImm(DataType::Int(64), 128)) != 0,
           arith::ProofStrength::kSymbolicBound)) {
     LOG(WARNING)
         << "src range must have last dim multiple of 16 for tma bulk load "
         << src->name << " range " << src_range[src_range.size() - 1]->extent
-        << " * " << src->dtype.bytes() << " % 16 != 0";
+        << " * " << src->dtype.bits() << " bits % 128 != 0";
     return false;
   }
 
@@ -679,13 +705,14 @@ bool CopyNode::CheckBulkStore(Target target, arith::Analyzer *analyzer,
   // now we check dst (gmem) as tma box dim is deduced from dst
   if (check_last_dim &&
       analyzer->CanProve(
-          FloorMod(dst_range[dst_range.size() - 1]->extent * dst->dtype.bytes(),
-                   16) != 0,
+          FloorMod(TMABitsFromElements(dst_range[dst_range.size() - 1]->extent,
+                                       dst->dtype),
+                   IntImm(DataType::Int(64), 128)) != 0,
           arith::ProofStrength::kSymbolicBound)) {
     LOG(WARNING)
         << "dst range must have last dim multiple of 16 for tma bulk store "
         << dst->name << " range " << dst_range[dst_range.size() - 1]->extent
-        << " * " << dst->dtype.bytes() << " % 16 != 0";
+        << " * " << dst->dtype.bits() << " bits % 128 != 0";
     return false;
   }
   // 4. src and dst must have the same dtype
@@ -1523,7 +1550,7 @@ Stmt CopyNode::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer,
   ICHECK(is_one(desc.global_stride[0])) << desc.global_stride;
   // Make global stride in bytes
   desc.global_stride = desc.global_stride.Map([&](PrimExpr e) {
-    return cast(DataType::Int(64), e) * global_tensor->dtype.bytes();
+    return TMABytesFromElements(e, global_tensor->dtype);
   });
   for (size_t i{1}; i < desc.global_stride.size(); i++) {
     auto stride = desc.global_stride[i].as<IntImmNode>();
@@ -1640,9 +1667,9 @@ Stmt CopyNode::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer,
   }
   int instruction_dim = *inner_box_dim;
   if (desc.swizzle == static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B)) {
-    instruction_dim = 64 / src->dtype.bytes();
+    instruction_dim = TMAElementsForBytes(64, src->dtype);
   } else if (desc.swizzle == static_cast<int>(CU_TENSOR_MAP_SWIZZLE_128B)) {
-    instruction_dim = 128 / src->dtype.bytes();
+    instruction_dim = TMAElementsForBytes(128, src->dtype);
   }
   if (instruction_dim > 256) {
     // smem_box dim must be in [0, 256]
@@ -1656,7 +1683,8 @@ Stmt CopyNode::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer,
       << " is not divisible by instruction_dim: " << instruction_dim;
   desc.smem_box.Set(0, PrimExpr(instruction_dim));
 
-  int inner_box_dim_ = instruction_dim * shared_tensor->dtype.bytes();
+  int inner_box_dim_ =
+      TMABytesFromElements(instruction_dim, shared_tensor->dtype);
 
   // Check inner_box_dim_ for each swizzle type in a cleaner way
   struct SwizzleCheck {
@@ -1787,9 +1815,10 @@ Stmt CopyNode::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer,
     PrimExpr total_bytes;
     if ((*inner_box_dim) != instruction_dim) {
       int loop_extent = (*inner_box_dim) / instruction_dim;
-      total_bytes = total_elements * loop_extent * shared_tensor->dtype.bytes();
+      total_bytes = TMABytesFromElements(total_elements * loop_extent,
+                                         shared_tensor->dtype);
     } else {
-      total_bytes = total_elements * shared_tensor->dtype.bytes();
+      total_bytes = TMABytesFromElements(total_elements, shared_tensor->dtype);
     }
 
     Stmt barrier_before_tma_stmt;
@@ -1947,7 +1976,7 @@ Stmt CopyNode::LowerBulkCopy1D(const LowerArgs &T, arith::Analyzer *analyzer,
   }
 
   Stmt tma_copy;
-  PrimExpr total_bytes = elements * shared_tensor->dtype.bytes();
+  PrimExpr total_bytes = TMABytesFromElements(elements, shared_tensor->dtype);
   if (is_load) {
     // 1D TMA load: args = {shared_addr, global_addr, mbarrier, bytes, eviction}
     PrimExpr mbar_arg = barrier_base_id >= 0 ? mbar_handle : PrimExpr(0);
@@ -2120,9 +2149,8 @@ Stmt Conv2DIm2ColOpNode::Lower(const LowerArgs &T,
   // The first stride element should be 1
   ICHECK(is_one(desc.global_stride[0])) << desc.global_stride;
   // Make global stride in bytes
-  desc.global_stride = desc.global_stride.Map([&](PrimExpr e) {
-    return cast(DataType::Int(64), e) * src_->dtype.bytes();
-  });
+  desc.global_stride = desc.global_stride.Map(
+      [&](PrimExpr e) { return TMABytesFromElements(e, src_->dtype); });
   desc.elem_stride = {1, stride_, stride_, 1};
   desc.lower_corner = {-padding_, -padding_};
   desc.upper_corner = {-padding_, -padding_};
@@ -2237,9 +2265,9 @@ Stmt Conv2DIm2ColOpNode::Lower(const LowerArgs &T,
   if (barrier_base_id >= 0) {
     bool ws_barrier = annotations_.Get("barrier").has_value();
     // Total bytes transferred by im2col TMA copy
-    PrimExpr total_bytes =
-        IntImm(DataType::Int(32), desc.smem_box_pixel * desc.smem_box_channel *
-                                      dst_->dtype.bytes());
+    PrimExpr total_bytes = TMABytesFromElements(
+        IntImm(DataType::Int(32), desc.smem_box_pixel * desc.smem_box_channel),
+        dst_->dtype);
 
     Stmt barrier_before_tma_stmt = Evaluate(Call(
         DataType::Handle(), mbarrier_expect_tx(), {mbar_handle, total_bytes}));

--- a/src/op/utils.cc
+++ b/src/op/utils.cc
@@ -147,6 +147,13 @@ PrimExpr MakeAccessPtrFromBufferLoad(const BufferLoad &load, int rw_mask) {
 
 // Maps TVM DataType to CUDA's CUtensorMapDataType enum value.
 int to_CUtensorMapDataType(DataType dtype) {
+  // CUDA 13 adds packed U4 TensorMap formats. The vendored CUDA stub may lag
+  // the installed toolkit, so keep the enum value by CUDA's documented order.
+  constexpr int kTensorMapDataType16U4Align8B = 13;
+  if (dtype.is_float4_e2m1fn()) {
+    return kTensorMapDataType16U4Align8B;
+  }
+
   CUtensorMapDataType tp;
   if (dtype.is_float()) {
     switch (dtype.bits()) {

--- a/src/runtime/runtime.cc
+++ b/src/runtime/runtime.cc
@@ -39,8 +39,19 @@ static uint64_t PtrModulo(const void *ptr, uint64_t align) {
   return reinterpret_cast<uintptr_t>(ptr) % align;
 }
 
+// The vendored CUDA stub may lag the installed toolkit. Keep the numeric
+// values from the CUDA Driver API enum order so runtime validation can accept
+// descriptors produced for newer drivers without requiring newer headers.
+static constexpr int kTensorMapDataType16U4Align8B = 13;
+static constexpr int kTensorMapDataType16U4Align16B = 14;
+static constexpr int kTensorMapDataType16U6Align16B = 15;
+
+static constexpr int kTensorMapSwizzle128BAtom32B = 4;
+static constexpr int kTensorMapSwizzle128BAtom32BFlip8B = 5;
+static constexpr int kTensorMapSwizzle128BAtom64B = 6;
+
 static const char *TensorMapDataTypeToString(CUtensorMapDataType type) {
-  switch (type) {
+  switch (static_cast<int>(type)) {
   case CU_TENSOR_MAP_DATA_TYPE_UINT8:
     return "CU_TENSOR_MAP_DATA_TYPE_UINT8";
   case CU_TENSOR_MAP_DATA_TYPE_UINT16:
@@ -67,6 +78,12 @@ static const char *TensorMapDataTypeToString(CUtensorMapDataType type) {
     return "CU_TENSOR_MAP_DATA_TYPE_TFLOAT32";
   case CU_TENSOR_MAP_DATA_TYPE_TFLOAT32_FTZ:
     return "CU_TENSOR_MAP_DATA_TYPE_TFLOAT32_FTZ";
+  case kTensorMapDataType16U4Align8B:
+    return "CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B";
+  case kTensorMapDataType16U4Align16B:
+    return "CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B";
+  case kTensorMapDataType16U6Align16B:
+    return "CU_TENSOR_MAP_DATA_TYPE_16U6_ALIGN16B";
   default:
     return "<unknown CUtensorMapDataType>";
   }
@@ -87,7 +104,7 @@ TensorMapInterleaveToString(CUtensorMapInterleave interleave) {
 }
 
 static const char *TensorMapSwizzleToString(CUtensorMapSwizzle swizzle) {
-  switch (swizzle) {
+  switch (static_cast<int>(swizzle)) {
   case CU_TENSOR_MAP_SWIZZLE_NONE:
     return "CU_TENSOR_MAP_SWIZZLE_NONE";
   case CU_TENSOR_MAP_SWIZZLE_32B:
@@ -96,6 +113,12 @@ static const char *TensorMapSwizzleToString(CUtensorMapSwizzle swizzle) {
     return "CU_TENSOR_MAP_SWIZZLE_64B";
   case CU_TENSOR_MAP_SWIZZLE_128B:
     return "CU_TENSOR_MAP_SWIZZLE_128B";
+  case kTensorMapSwizzle128BAtom32B:
+    return "CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B";
+  case kTensorMapSwizzle128BAtom32BFlip8B:
+    return "CU_TENSOR_MAP_SWIZZLE_128B_ATOM_32B_FLIP_8B";
+  case kTensorMapSwizzle128BAtom64B:
+    return "CU_TENSOR_MAP_SWIZZLE_128B_ATOM_64B";
   default:
     return "<unknown CUtensorMapSwizzle>";
   }
@@ -128,7 +151,7 @@ static const char *TensorMapOOBFillToString(CUtensorMapFloatOOBfill oob_fill) {
 }
 
 static uint64_t TensorMapDataTypeBits(CUtensorMapDataType type) {
-  switch (type) {
+  switch (static_cast<int>(type)) {
   case CU_TENSOR_MAP_DATA_TYPE_UINT8:
     return 8;
   case CU_TENSOR_MAP_DATA_TYPE_UINT16:
@@ -146,6 +169,11 @@ static uint64_t TensorMapDataTypeBits(CUtensorMapDataType type) {
   case CU_TENSOR_MAP_DATA_TYPE_INT64:
   case CU_TENSOR_MAP_DATA_TYPE_FLOAT64:
     return 64;
+  case kTensorMapDataType16U4Align8B:
+  case kTensorMapDataType16U4Align16B:
+    return 4;
+  case kTensorMapDataType16U6Align16B:
+    return 6;
   default:
     return 0;
   }
@@ -166,10 +194,57 @@ static bool IsFloatTensorMapType(CUtensorMapDataType type) {
   }
 }
 
+static bool IsTensorMapDataType16U4Align8B(CUtensorMapDataType type) {
+  return static_cast<int>(type) == kTensorMapDataType16U4Align8B;
+}
+
+static bool IsTensorMapDataType16U4Align16B(CUtensorMapDataType type) {
+  return static_cast<int>(type) == kTensorMapDataType16U4Align16B;
+}
+
+static bool IsTensorMapDataType16U6Align16B(CUtensorMapDataType type) {
+  return static_cast<int>(type) == kTensorMapDataType16U6Align16B;
+}
+
+static bool IsPackedAlign16TensorMapType(CUtensorMapDataType type) {
+  return IsTensorMapDataType16U4Align16B(type) ||
+         IsTensorMapDataType16U6Align16B(type);
+}
+
+static bool IsTensorMapSwizzle128BFamily(CUtensorMapSwizzle swizzle) {
+  switch (static_cast<int>(swizzle)) {
+  case CU_TENSOR_MAP_SWIZZLE_128B:
+  case kTensorMapSwizzle128BAtom32B:
+  case kTensorMapSwizzle128BAtom32BFlip8B:
+  case kTensorMapSwizzle128BAtom64B:
+    return true;
+  default:
+    return false;
+  }
+}
+
+static bool IsSupportedPackedTensorMapSwizzle(CUtensorMapDataType type,
+                                              CUtensorMapSwizzle swizzle) {
+  int swizzle_value = static_cast<int>(swizzle);
+  if (IsTensorMapDataType16U6Align16B(type)) {
+    return swizzle_value == CU_TENSOR_MAP_SWIZZLE_NONE ||
+           swizzle_value == CU_TENSOR_MAP_SWIZZLE_128B ||
+           swizzle_value == kTensorMapSwizzle128BAtom32B ||
+           swizzle_value == kTensorMapSwizzle128BAtom64B;
+  }
+  if (IsTensorMapDataType16U4Align16B(type)) {
+    return swizzle_value == CU_TENSOR_MAP_SWIZZLE_NONE ||
+           swizzle_value == CU_TENSOR_MAP_SWIZZLE_128B ||
+           swizzle_value == kTensorMapSwizzle128BAtom32B;
+  }
+  return true;
+}
+
 static uint64_t
 RequiredGlobalAddressAlignment(CUtensorMapDataType type,
                                CUtensorMapInterleave interleave) {
-  if (interleave == CU_TENSOR_MAP_INTERLEAVE_32B) {
+  if (interleave == CU_TENSOR_MAP_INTERLEAVE_32B ||
+      IsPackedAlign16TensorMapType(type)) {
     return 32;
   }
   return 16;
@@ -178,22 +253,24 @@ RequiredGlobalAddressAlignment(CUtensorMapDataType type,
 static uint64_t
 RequiredGlobalStrideAlignment(CUtensorMapDataType type,
                               CUtensorMapInterleave interleave) {
-  if (interleave == CU_TENSOR_MAP_INTERLEAVE_32B) {
+  if (interleave == CU_TENSOR_MAP_INTERLEAVE_32B ||
+      IsPackedAlign16TensorMapType(type)) {
     return 32;
   }
   return 16;
 }
 
 static uint64_t SwizzleSpanBytes(CUtensorMapSwizzle swizzle) {
-  switch (swizzle) {
+  if (IsTensorMapSwizzle128BFamily(swizzle)) {
+    return 128;
+  }
+  switch (static_cast<int>(swizzle)) {
   case CU_TENSOR_MAP_SWIZZLE_NONE:
     return 0;
   case CU_TENSOR_MAP_SWIZZLE_32B:
     return 32;
   case CU_TENSOR_MAP_SWIZZLE_64B:
     return 64;
-  case CU_TENSOR_MAP_SWIZZLE_128B:
-    return 128;
   default:
     return 0;
   }
@@ -348,6 +425,18 @@ static std::vector<std::string> ValidateTensorMapArgs(const TensorMapArgs &T) {
                        std::to_string(T.globalDim[i]));
     }
   }
+  if (T.tensorRank > 0) {
+    if (IsPackedAlign16TensorMapType(T.type) && T.globalDim[0] % 128 != 0) {
+      issues.push_back("globalDim[0] must be a multiple of 128 for " +
+                       std::string(TensorMapDataTypeToString(T.type)) +
+                       ", but got " + std::to_string(T.globalDim[0]));
+    }
+    if (IsTensorMapDataType16U4Align8B(T.type) && T.globalDim[0] % 2 != 0) {
+      issues.push_back("globalDim[0] must be a multiple of 2 for " +
+                       std::string(TensorMapDataTypeToString(T.type)) +
+                       ", but got " + std::to_string(T.globalDim[0]));
+    }
+  }
 
   for (size_t raw_i = 1; raw_i < T.tensorRank; ++raw_i) {
     cuuint64_t stride = T.globalStride[raw_i];
@@ -382,6 +471,12 @@ static std::vector<std::string> ValidateTensorMapArgs(const TensorMapArgs &T) {
                        std::to_string(T.boxDim[i]));
     }
   }
+  if (T.tensorRank > 0 && IsPackedAlign16TensorMapType(T.type) &&
+      T.boxDim[0] != 128) {
+    issues.push_back("boxDim[0] must be 128 for " +
+                     std::string(TensorMapDataTypeToString(T.type)) +
+                     ", but got " + std::to_string(T.boxDim[0]));
+  }
 
   if (T.tensorRank > 0 && T.interleave == CU_TENSOR_MAP_INTERLEAVE_NONE &&
       type_bits != 0 && ((uint64_t{T.boxDim[0]} * type_bits) % 128 != 0)) {
@@ -403,6 +498,16 @@ static std::vector<std::string> ValidateTensorMapArgs(const TensorMapArgs &T) {
       T.swizzle != CU_TENSOR_MAP_SWIZZLE_32B) {
     issues.push_back("swizzle must be CU_TENSOR_MAP_SWIZZLE_32B when "
                      "interleave is CU_TENSOR_MAP_INTERLEAVE_32B");
+  }
+  if (IsTensorMapDataType16U6Align16B(T.type) &&
+      T.interleave != CU_TENSOR_MAP_INTERLEAVE_NONE) {
+    issues.push_back("interleave must be CU_TENSOR_MAP_INTERLEAVE_NONE for " +
+                     std::string(TensorMapDataTypeToString(T.type)));
+  }
+  if (!IsSupportedPackedTensorMapSwizzle(T.type, T.swizzle)) {
+    issues.push_back(std::string(TensorMapSwizzleToString(T.swizzle)) +
+                     " is not supported for " +
+                     TensorMapDataTypeToString(T.type));
   }
 
   uint64_t swizzle_bytes = SwizzleSpanBytes(T.swizzle);
@@ -587,6 +692,18 @@ ValidateTensorMapIm2ColArgs(const TensorMapIm2ColArgs &T) {
                        std::to_string(T.elementStrides[i]));
     }
   }
+  if (T.tensorRank > 0) {
+    if (IsPackedAlign16TensorMapType(T.type) && T.globalDim[0] % 128 != 0) {
+      issues.push_back("globalDim[0] must be a multiple of 128 for " +
+                       std::string(TensorMapDataTypeToString(T.type)) +
+                       ", but got " + std::to_string(T.globalDim[0]));
+    }
+    if (IsTensorMapDataType16U4Align8B(T.type) && T.globalDim[0] % 2 != 0) {
+      issues.push_back("globalDim[0] must be a multiple of 2 for " +
+                       std::string(TensorMapDataTypeToString(T.type)) +
+                       ", but got " + std::to_string(T.globalDim[0]));
+    }
+  }
 
   for (size_t raw_i = 1; raw_i < T.tensorRank; ++raw_i) {
     cuuint64_t stride = T.globalStride[raw_i];
@@ -611,10 +728,34 @@ ValidateTensorMapIm2ColArgs(const TensorMapIm2ColArgs &T) {
     }
   }
 
+  if (T.smem_box_channel == 0 || T.smem_box_channel > 256) {
+    issues.push_back("channelsPerPixel must be in [1, 256], but got " +
+                     std::to_string(T.smem_box_channel));
+  }
+  if (IsPackedAlign16TensorMapType(T.type) && T.smem_box_channel != 128) {
+    issues.push_back("channelsPerPixel must be 128 for " +
+                     std::string(TensorMapDataTypeToString(T.type)) +
+                     ", but got " + std::to_string(T.smem_box_channel));
+  }
+  if (T.smem_box_pixel == 0 || T.smem_box_pixel > 1024) {
+    issues.push_back("pixelsPerColumn must be in [1, 1024], but got " +
+                     std::to_string(T.smem_box_pixel));
+  }
+
   if (T.interleave == CU_TENSOR_MAP_INTERLEAVE_32B &&
       T.swizzle != CU_TENSOR_MAP_SWIZZLE_32B) {
     issues.push_back("swizzle must be CU_TENSOR_MAP_SWIZZLE_32B when "
                      "interleave is CU_TENSOR_MAP_INTERLEAVE_32B");
+  }
+  if (IsTensorMapDataType16U6Align16B(T.type) &&
+      T.interleave != CU_TENSOR_MAP_INTERLEAVE_NONE) {
+    issues.push_back("interleave must be CU_TENSOR_MAP_INTERLEAVE_NONE for " +
+                     std::string(TensorMapDataTypeToString(T.type)));
+  }
+  if (!IsSupportedPackedTensorMapSwizzle(T.type, T.swizzle)) {
+    issues.push_back(std::string(TensorMapSwizzleToString(T.swizzle)) +
+                     " is not supported for " +
+                     TensorMapDataTypeToString(T.type));
   }
 
   if (T.oobFill == CU_TENSOR_MAP_FLOAT_OOB_FILL_NAN_REQUEST_ZERO_FMA &&

--- a/testing/python/language/test_tilelang_language_tma_copy.py
+++ b/testing/python/language/test_tilelang_language_tma_copy.py
@@ -195,6 +195,90 @@ def run_gemm_tma_copy_store(num_stages):
     profiler.assert_allclose(ref_program, atol=1e-2, rtol=1e-2)
 
 
+def fp4_tma_copy_roundtrip(M=128, N=256, block_M=64, block_N=128):
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), T.float4_e2m1fn),
+        B: T.Tensor((M, N), T.float4_e2m1fn),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_N), T.float4_e2m1fn)
+            mbar = T.alloc_barrier(128)
+            T.tma_copy(A[by * block_M, bx * block_N], A_shared, barrier=mbar)
+            T.barrier_arrive(mbar)
+            T.mbarrier_wait_parity(mbar, 0)
+            T.tma_copy(A_shared, B[by * block_M, bx * block_N])
+            T.tma_store_wait()
+
+    return main
+
+
+def run_fp4_tma_copy_roundtrip():
+    import re
+    import torch
+
+    M, N = 128, 256
+    program = fp4_tma_copy_roundtrip(M=M, N=N)
+    kernel = tilelang.compile(
+        program,
+        out_idx=[1],
+        pass_configs={tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True},
+    )
+    device_source = kernel.get_kernel_source()
+    host_source = kernel.get_host_source()
+    assert "CUtensorMap" in device_source
+    assert "tl::tma_load" in device_source
+    assert "tl::tma_store" in device_source
+    assert host_source.count("__tvm_tensormap_create_tiled") >= 2
+
+    def descriptor_init_block(desc_name):
+        marker = f"[0].v_ptr) = {desc_name};"
+        start = host_source.find(marker)
+        assert start >= 0, f"Missing {desc_name} TensorMap initialization"
+        end = host_source.find("TVMFFIFunctionCall(__tvm_tensormap_create_tiled_packed", start)
+        assert end >= 0, f"Missing {desc_name} TensorMap creation call"
+        return host_source[start:end]
+
+    def stack_int(block, index):
+        match = re.search(rf"\[{index}\]\.v_int64\)\s*=\s*\(\(int64_t\)(-?\d+)\);", block)
+        assert match, f"Missing stack[{index}] integer assignment in:\n{block}"
+        return int(match.group(1))
+
+    # create_tma_descriptor(data_type, rank, global_addr,
+    #   global_shape..., global_stride..., smem_box..., smem_stride...,
+    #   interleave, swizzle, l2_promotion, oob_fill)
+    expected_tma_args = {
+        1: 13,  # CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B
+        2: 2,  # rank
+        4: 256,  # global_shape[0], reversed innermost dimension
+        5: 128,  # global_shape[1]
+        6: 1,  # raw innermost stride, ignored by CUDA encode
+        7: 128,  # next global stride in bytes: 256 fp4 elements == 128 bytes
+        8: 128,  # smem_box[0]: 128 fp4 elements == 64 bytes
+        9: 64,  # smem_box[1]
+        10: 1,  # element stride[0]
+        11: 1,  # element stride[1]
+        12: 0,  # CU_TENSOR_MAP_INTERLEAVE_NONE
+        13: 2,  # CU_TENSOR_MAP_SWIZZLE_64B
+        14: 2,  # CU_TENSOR_MAP_L2_PROMOTION_L2_128B
+        15: 0,  # CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE
+    }
+    for desc_name in ("A_desc", "B_desc"):
+        block = descriptor_init_block(desc_name)
+        for index, expected in expected_tma_args.items():
+            assert stack_int(block, index) == expected
+
+    a = torch.randint(-128, 128, (M, N // 2), device="cuda", dtype=torch.int8)
+    b = kernel(a)
+    assert torch.equal(b.view(torch.int8), a)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(10, 0)
+def test_fp4_tma_copy_roundtrip():
+    run_fp4_tma_copy_roundtrip()
+
+
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_tma_copy_store_pipeline_2_stages():


### PR DESCRIPTION
## Summary

This PR adds FP4 TensorMap/TMA support for `float4_e2m1fn` copies and covers it with an explicit `T.tma_copy` roundtrip test.

## What changed

- Map `float4_e2m1fn` to CUDA TensorMap data type value `13`, corresponding to `CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B`.
- Update TMA byte and bit calculations to use `dtype.bits()` instead of `dtype.bytes()` so sub-byte packed dtypes such as FP4 use correct strides, box sizes, and mbarrier transaction byte counts.
- Extend TensorMap runtime validation/debug handling for packed U4/U6 TensorMap data types and 128B atom swizzle enum values, while staying compatible with the vendored CUDA stub headers.
- Add an FP4 `T.tma_copy` test that performs a global -> shared -> global roundtrip, checks device TMA codegen, and validates host-side TensorMap initialization parameters from `get_host_source()`.

## Why

FP4 is represented as a sub-byte logical dtype, while the existing TMA lowering assumed byte-addressable elements through `DataType::bytes()`. That made descriptor strides and transaction byte counts incorrect for packed FP4 TensorMap descriptors.

## Validation

- `cmake --build build -j$(nproc)`
- `PYTHONPATH=$(pwd):$PYTHONPATH python -m pytest testing/python/language/test_tilelang_language_tma_copy.py -q -k fp4_tma_copy_roundtrip`
- `PYTHONPATH=$(pwd):$PYTHONPATH python -m pytest testing/python/language/test_tilelang_language_tma_copy.py -q`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for FP4 (float4_e2m1fn) TMA operations and CUDA packed-U4 tensor map handling.

* **Bug Fixes**
  * Dtype-aware bit-based conversions for TMA size/stride calculations and swizzle sizing.
  * Stricter validation for packed tensor-map types, alignments, swizzles, and related warnings.
  * Recognize newer CUDA TMA enum values.

* **Tests**
  * Added an FP4 TMA load/store roundtrip test with host-side descriptor validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->