### PR TITLE
Refactor TileLang backend ownership and registry dispatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,25 +170,21 @@ set(USE_GTEST OFF)
 # Include directories for TileLang
 set(TILE_LANG_INCLUDES ${TVM_INCLUDES})
 
-# Collect source files
-file(GLOB TILE_LANG_SRCS
-  src/*.cc
-  src/layout/*.cc
-  src/transform/*.cc
-  src/transform/common/*.cc
-  src/op/*.cc
-  src/target/utils.cc
-  src/target/codegen_c_host.cc
-  src/target/codegen_c.cc
-  src/target/rt_mod_c.cc
-  # intrin_rule doesn't have system dependency
-  src/target/intrin_rule*.cc
-)
+# Backend-local CMake files own native source lists, stubs, include paths, and
+# compile definitions. Top-level CMake only selects and delegates.
+include("${CMAKE_CURRENT_SOURCE_DIR}/src/backend/common/CMakeLists.txt")
+include("${CMAKE_CURRENT_SOURCE_DIR}/src/backend/nvidia/CMakeLists.txt")
+include("${CMAKE_CURRENT_SOURCE_DIR}/src/backend/amd/CMakeLists.txt")
+include("${CMAKE_CURRENT_SOURCE_DIR}/src/backend/apple/CMakeLists.txt")
+include("${CMAKE_CURRENT_SOURCE_DIR}/src/backend/cpu/CMakeLists.txt")
+include("${CMAKE_CURRENT_SOURCE_DIR}/src/backend/webgpu/CMakeLists.txt")
 
-# Always include CPU-safe runtime helpers
-list(APPEND TILE_LANG_SRCS
-  src/runtime/error_helpers.cc
-)
+tilelang_collect_common_backend(TILE_LANG_SRCS TILELANG_COMMON_INCLUDES)
+list(APPEND TILE_LANG_INCLUDES ${TILELANG_COMMON_INCLUDES})
+tilelang_configure_cpu_backend(TILELANG_CPU_SRCS TILELANG_CPU_INCLUDES)
+tilelang_configure_webgpu_backend(TILELANG_WEBGPU_SRCS TILELANG_WEBGPU_INCLUDES)
+list(APPEND TILE_LANG_SRCS ${TILELANG_CPU_SRCS} ${TILELANG_WEBGPU_SRCS})
+list(APPEND TILE_LANG_INCLUDES ${TILELANG_CPU_INCLUDES} ${TILELANG_WEBGPU_INCLUDES})
 
 # Track if the user explicitly selected a backend via cache options.
 set(TILELANG_BACKEND_USER_SELECTED OFF)
@@ -223,199 +219,21 @@ if(NOT TILELANG_BACKEND_USER_SELECTED)
 endif()
 
 if(USE_METAL)
-  if(NOT APPLE)
-    # On non-Apple platforms USE_METAL=ON enables only codegen (Metal source
-    # generation) without requiring the Metal/Foundation frameworks.
-    message(STATUS "Metal backend on non-Apple: enabling codegen-only mode (no Metal runtime)")
-    set(USE_METAL OFF)
-  endif()
-  file(GLOB TILE_LANG_METAL_SRCS
-    src/target/rt_mod_metal.cc
-  )
-  list(APPEND TILE_LANG_SRCS ${TILE_LANG_METAL_SRCS})
-  # FIXME: CIBW failed with backtrace, why???
-  set(TVM_FFI_USE_LIBBACKTRACE OFF)
-elseif(USE_ROCM)
-  set(CMAKE_HIP_STANDARD 17)
-  include(${TVM_SOURCE}/cmake/utils/FindROCM.cmake)
-  find_rocm(${USE_ROCM})
-  add_compile_definitions(__HIP_PLATFORM_AMD__ __HIP_PLATFORM_HCC__=1)
+  tilelang_configure_apple_backend(TILELANG_APPLE_SRCS TILELANG_APPLE_INCLUDES)
+  list(APPEND TILE_LANG_SRCS ${TILELANG_APPLE_SRCS})
+  list(APPEND TILE_LANG_INCLUDES ${TILELANG_APPLE_INCLUDES})
+endif()
 
-  if(TILELANG_USE_HIP_STUBS)
-    if(WIN32 AND NOT CYGWIN)
-      message(FATAL_ERROR "TILELANG_USE_HIP_STUBS=ON is not supported on Windows. "
-                          "Please configure with -DTILELANG_USE_HIP_STUBS=OFF.")
-    endif()
+if(USE_ROCM)
+  tilelang_configure_amd_backend(TILELANG_AMD_SRCS TILELANG_AMD_INCLUDES)
+  list(APPEND TILE_LANG_SRCS ${TILELANG_AMD_SRCS})
+  list(APPEND TILE_LANG_INCLUDES ${TILELANG_AMD_INCLUDES})
+endif()
 
-    # ============================================================================
-    # HIP Stub Library (libhip_stub.so)
-    # ============================================================================
-    # This library provides drop-in replacements for HIP runtime/module APIs by
-    # lazily loading libamdhip64.so at runtime.
-    #
-    # It also provides minimal HSA wrappers (hsa_init / hsa_shut_down) to avoid a
-    # hard DT_NEEDED dependency on libhsa-runtime64 in ROCm-enabled wheels.
-    # ============================================================================
-    add_library(hip_stub SHARED src/target/stubs/hip.cc)
-    target_include_directories(hip_stub PRIVATE ${ROCM_INCLUDE_DIRS})
-    target_compile_definitions(hip_stub PRIVATE TILELANG_HIP_STUB_EXPORTS)
-    target_link_libraries(hip_stub PRIVATE ${CMAKE_DL_LIBS})
-    set_target_properties(hip_stub PROPERTIES
-      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-      ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-      OUTPUT_NAME "hip_stub"
-    )
-
-    # ============================================================================
-    # HIPRTC Stub Library (libhiprtc_stub.so)
-    # ============================================================================
-    # This library provides a minimal HIPRTC API surface and lazily loads
-    # libhiprtc.so at runtime.
-    # ============================================================================
-    add_library(hiprtc_stub SHARED src/target/stubs/hiprtc.cc)
-    target_include_directories(hiprtc_stub PRIVATE ${ROCM_INCLUDE_DIRS})
-    target_compile_definitions(hiprtc_stub PRIVATE TILELANG_HIPRTC_STUB_EXPORTS)
-    target_link_libraries(hiprtc_stub PRIVATE ${CMAKE_DL_LIBS})
-    set_target_properties(hiprtc_stub PROPERTIES
-      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-      ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-      OUTPUT_NAME "hiprtc_stub"
-    )
-
-    # Make TVM link against our HIP stub instead of the real libamdhip64.so.
-    #
-    # NOTE: TVM's `find_rocm()` calls `find_library(ROCM_HIPHCC_LIBRARY amdhip64 ...)`.
-    # `find_library()` will not override an already-cached variable, so setting it
-    # here ensures TVM doesn't record a DT_NEEDED on libamdhip64.
-    set(ROCM_HIPHCC_LIBRARY hip_stub CACHE STRING "HIP runtime library to link against" FORCE)
-
-    # Prevent TVM from recording a DT_NEEDED on libhsa-runtime64.
-    # The few HSA entrypoints used by TVM are stubbed by hip_stub and resolved
-    # lazily when available.
-    set(ROCM_HSA_LIBRARY ROCM_HSA_LIBRARY-NOTFOUND CACHE STRING
-        "HSA runtime library to link against" FORCE)
-  endif()
-
-  file(GLOB TILE_LANG_HIP_SRCS
-    src/target/codegen_hip.cc
-    src/target/rt_mod_hip.cc
-  )
-  list(APPEND TILE_LANG_SRCS ${TILE_LANG_HIP_SRCS})
-  list(APPEND TILE_LANG_INCLUDES ${ROCM_INCLUDE_DIRS})
-elseif(USE_CUDA)
-  set(CMAKE_CUDA_STANDARD 17)
-  find_package(CUDAToolkit REQUIRED)
-  set(CMAKE_CUDA_COMPILER "${CUDAToolkit_BIN_DIR}/nvcc")
-  add_compile_definitions("CUDA_MAJOR_VERSION=${CUDAToolkit_VERSION_MAJOR}")
-
-  # Set `USE_CUDA=/usr/local/cuda-x.y`
-  cmake_path(GET CUDAToolkit_BIN_DIR PARENT_PATH USE_CUDA)
-
-  if(TILELANG_USE_CUDA_STUBS)
-    if(WIN32 AND NOT CYGWIN)
-      message(FATAL_ERROR "TILELANG_USE_CUDA_STUBS=ON is not supported on Windows. "
-                          "Please configure with -DTILELANG_USE_CUDA_STUBS=OFF.")
-    endif()
-
-    # ============================================================================
-    # CUDA Driver Stub Library (libcuda_stub.so)
-    # ============================================================================
-    # This library provides drop-in replacements for CUDA driver API functions.
-    # Instead of linking directly against libcuda.so (which would fail on
-    # CPU-only machines), we link against this stub which loads libcuda.so
-    # lazily at runtime on first API call.
-    #
-    # The stub exports global C functions matching the CUDA driver API:
-    #   - cuModuleLoadData, cuLaunchKernel, cuMemsetD32_v2, etc.
-    # These can be called directly without any wrapper macros.
-    # ============================================================================
-    add_library(cuda_stub SHARED src/target/stubs/cuda.cc)
-    target_include_directories(cuda_stub PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
-    # Export symbols with visibility="default" when building
-    target_compile_definitions(cuda_stub PRIVATE TILELANG_CUDA_STUB_EXPORTS)
-    # Use dlopen/dlsym for runtime library loading
-    target_link_libraries(cuda_stub PRIVATE ${CMAKE_DL_LIBS})
-    set_target_properties(cuda_stub PROPERTIES
-      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-      ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-      # Use consistent naming
-      OUTPUT_NAME "cuda_stub"
-    )
-
-    # ============================================================================
-    # CUDA Runtime Stub Library (libcudart_stub.so)
-    # ============================================================================
-    # libcudart's SONAME includes its major version (e.g. libcudart.so.11.0 / .12 / .13).
-    # Link against this stub instead of the real libcudart so a single wheel can
-    # run in environments that provide different libcudart major versions.
-    #
-    # The stub exports a minimal set of CUDA Runtime API entrypoints used by TVM
-    # and lazily loads libcudart at runtime on first API call.
-    # ============================================================================
-    add_library(cudart_stub SHARED src/target/stubs/cudart.cc)
-    target_include_directories(cudart_stub PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
-    target_compile_definitions(cudart_stub PRIVATE TILELANG_CUDART_STUB_EXPORTS)
-    target_link_libraries(cudart_stub PRIVATE ${CMAKE_DL_LIBS})
-    set_target_properties(cudart_stub PROPERTIES
-      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-      ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-      OUTPUT_NAME "cudart_stub"
-    )
-
-    # Make TVM link against our CUDA Runtime stub instead of the real libcudart.
-    #
-    # NOTE: TVM's `find_cuda()` calls `find_library(CUDA_CUDART_LIBRARY cudart ...)`.
-    # `find_library()` will not override an already-cached variable, so setting it
-    # here ensures TVM doesn't record a DT_NEEDED on `libcudart.so.<major>`.
-    set(CUDA_CUDART_LIBRARY cudart_stub CACHE STRING "CUDART library to link against" FORCE)
-
-    # ============================================================================
-    # NVRTC Stub Library (libnvrtc_stub.so)
-    # ============================================================================
-    # NVRTC's SONAME includes its major version (e.g. libnvrtc.so.11.2 / .12 / .13).
-    # Link against this stub instead of the real NVRTC library so a single wheel
-    # can run in environments that provide different NVRTC major versions.
-    #
-    # The stub exports a minimal set of NVRTC C API entrypoints used by TVM and
-    # lazily loads libnvrtc at runtime on first API call.
-    # ============================================================================
-    add_library(nvrtc_stub SHARED src/target/stubs/nvrtc.cc)
-    target_include_directories(nvrtc_stub PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
-    target_compile_definitions(nvrtc_stub PRIVATE TILELANG_NVRTC_STUB_EXPORTS)
-    target_link_libraries(nvrtc_stub PRIVATE ${CMAKE_DL_LIBS})
-    set_target_properties(nvrtc_stub PROPERTIES
-      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-      ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-      OUTPUT_NAME "nvrtc_stub"
-    )
-
-    # Make TVM link against our NVRTC stub instead of the real libnvrtc.
-    #
-    # NOTE: TVM's `find_cuda()` calls `find_library(CUDA_NVRTC_LIBRARY nvrtc ...)`.
-    # `find_library()` will not override an already-cached variable, so setting it
-    # here ensures TVM doesn't record a DT_NEEDED on `libnvrtc.so.<major>`.
-    set(CUDA_NVRTC_LIBRARY nvrtc_stub CACHE STRING "NVRTC library to link against" FORCE)
-  endif()
-
-  file(GLOB TILE_LANG_CUDA_SRCS
-    src/runtime/runtime.cc
-    src/target/ptx.cc
-    src/target/codegen_cuda.cc
-    src/target/codegen_py.cc
-    src/target/codegen_utils.cc
-    src/target/codegen_cutedsl.cc
-    src/target/rt_mod_cuda.cc
-    src/target/rt_mod_cutedsl.cc
-  )
-  list(APPEND TILE_LANG_SRCS ${TILE_LANG_CUDA_SRCS})
-
-  list(APPEND TILE_LANG_INCLUDES ${CUDAToolkit_INCLUDE_DIRS})
-  link_directories(${CUDAToolkit_LIBRARY_DIR} ${CUDAToolkit_LIBRARY_DIR}/stubs)
+if(USE_CUDA)
+  tilelang_configure_nvidia_backend(TILELANG_NVIDIA_SRCS TILELANG_NVIDIA_INCLUDES)
+  list(APPEND TILE_LANG_SRCS ${TILELANG_NVIDIA_SRCS})
+  list(APPEND TILE_LANG_INCLUDES ${TILELANG_NVIDIA_INCLUDES})
 endif()
 
 set(USE_Z3      ON CACHE STRING "Use Z3 SMT solver for TileLang optimizations")

--- a/src/backend/README.md
+++ b/src/backend/README.md
@@ -1,0 +1,10 @@
+# TileLang Native Backend Ownership
+
+This tree is the native backend ownership surface used by CMake. Backend CMake
+files own source lists, stub libraries, include paths, and compile definitions
+for their backend even when some implementation files still live in transitional
+locations such as `src/target` or `src/transform`.
+
+Public FFI registration names are intentionally preserved during this staged
+move. Physical file relocation should be mechanical once the CMake ownership and
+Python backend metadata are covered by tests.

--- a/src/backend/amd/CMakeLists.txt
+++ b/src/backend/amd/CMakeLists.txt
@@ -1,0 +1,48 @@
+function(tilelang_configure_amd_backend OUT_SRCS OUT_INCLUDES)
+  set(CMAKE_HIP_STANDARD 17 PARENT_SCOPE)
+  include("${TVM_SOURCE}/cmake/utils/FindROCM.cmake")
+  find_rocm(${USE_ROCM})
+  add_compile_definitions(__HIP_PLATFORM_AMD__ __HIP_PLATFORM_HCC__=1)
+
+  if(TILELANG_USE_HIP_STUBS)
+    if(WIN32 AND NOT CYGWIN)
+      message(FATAL_ERROR "TILELANG_USE_HIP_STUBS=ON is not supported on Windows. "
+                          "Please configure with -DTILELANG_USE_HIP_STUBS=OFF.")
+    endif()
+
+    add_library(hip_stub SHARED "${CMAKE_CURRENT_SOURCE_DIR}/src/target/stubs/hip.cc")
+    target_include_directories(hip_stub PRIVATE ${ROCM_INCLUDE_DIRS})
+    target_compile_definitions(hip_stub PRIVATE TILELANG_HIP_STUB_EXPORTS)
+    target_link_libraries(hip_stub PRIVATE ${CMAKE_DL_LIBS})
+    set_target_properties(hip_stub PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      OUTPUT_NAME "hip_stub"
+    )
+
+    add_library(hiprtc_stub SHARED "${CMAKE_CURRENT_SOURCE_DIR}/src/target/stubs/hiprtc.cc")
+    target_include_directories(hiprtc_stub PRIVATE ${ROCM_INCLUDE_DIRS})
+    target_compile_definitions(hiprtc_stub PRIVATE TILELANG_HIPRTC_STUB_EXPORTS)
+    target_link_libraries(hiprtc_stub PRIVATE ${CMAKE_DL_LIBS})
+    set_target_properties(hiprtc_stub PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      OUTPUT_NAME "hiprtc_stub"
+    )
+
+    set(ROCM_HIPHCC_LIBRARY hip_stub CACHE STRING "HIP runtime library to link against" FORCE)
+    set(ROCM_HSA_LIBRARY ROCM_HSA_LIBRARY-NOTFOUND CACHE STRING
+        "HSA runtime library to link against" FORCE)
+  endif()
+
+  set(_amd_srcs
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/target/codegen_hip.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/target/rt_mod_hip.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/target/intrin_rule_hip.cc"
+  )
+
+  set(${OUT_SRCS} ${_amd_srcs} PARENT_SCOPE)
+  set(${OUT_INCLUDES} ${ROCM_INCLUDE_DIRS} PARENT_SCOPE)
+endfunction()

--- a/src/backend/apple/CMakeLists.txt
+++ b/src/backend/apple/CMakeLists.txt
@@ -1,0 +1,17 @@
+function(tilelang_configure_apple_backend OUT_SRCS OUT_INCLUDES)
+  if(NOT APPLE)
+    message(STATUS "Metal backend on non-Apple: enabling codegen-only mode (no Metal runtime)")
+    set(USE_METAL OFF PARENT_SCOPE)
+    set(${OUT_SRCS} "" PARENT_SCOPE)
+    set(${OUT_INCLUDES} "" PARENT_SCOPE)
+    return()
+  endif()
+
+  set(_apple_srcs
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/target/rt_mod_metal.cc"
+  )
+
+  set(TVM_FFI_USE_LIBBACKTRACE OFF PARENT_SCOPE)
+  set(${OUT_SRCS} ${_apple_srcs} PARENT_SCOPE)
+  set(${OUT_INCLUDES} "" PARENT_SCOPE)
+endfunction()

--- a/src/backend/common/CMakeLists.txt
+++ b/src/backend/common/CMakeLists.txt
@@ -1,0 +1,38 @@
+function(tilelang_collect_common_backend OUT_SRCS OUT_INCLUDES)
+  file(GLOB _common_srcs
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/layout/*.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/*.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/common/*.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/op/*.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/target/utils.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/target/codegen_c_host.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/target/codegen_c.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/target/rt_mod_c.cc"
+  )
+
+  set(_nvidia_transform_srcs
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/annotate_warp_group_reg_alloc.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/fuse_mbarrier_arrive_expect_tx.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/inject_fence_proxy.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/inject_tcgen05_fence.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/lower_blackwell_2sm.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/lower_hopper_intrin.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/lower_l2_persistent_annotation.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/lower_ldg_stg.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/lower_pdl.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/lower_ptx_async_copy.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/lower_shared_barrier.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/lower_shared_tmem.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/persist_threadblock.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/producer_consumer_ws.cc"
+  )
+  list(REMOVE_ITEM _common_srcs ${_nvidia_transform_srcs})
+
+  list(APPEND _common_srcs
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/runtime/error_helpers.cc"
+  )
+
+  set(${OUT_SRCS} ${_common_srcs} PARENT_SCOPE)
+  set(${OUT_INCLUDES} "" PARENT_SCOPE)
+endfunction()

--- a/src/backend/cpu/CMakeLists.txt
+++ b/src/backend/cpu/CMakeLists.txt
@@ -1,0 +1,4 @@
+function(tilelang_configure_cpu_backend OUT_SRCS OUT_INCLUDES)
+  set(${OUT_SRCS} "" PARENT_SCOPE)
+  set(${OUT_INCLUDES} "" PARENT_SCOPE)
+endfunction()

--- a/src/backend/nvidia/CMakeLists.txt
+++ b/src/backend/nvidia/CMakeLists.txt
@@ -1,0 +1,81 @@
+function(tilelang_configure_nvidia_backend OUT_SRCS OUT_INCLUDES)
+  set(CMAKE_CUDA_STANDARD 17 PARENT_SCOPE)
+  find_package(CUDAToolkit REQUIRED)
+  set(CMAKE_CUDA_COMPILER "${CUDAToolkit_BIN_DIR}/nvcc" PARENT_SCOPE)
+  add_compile_definitions("CUDA_MAJOR_VERSION=${CUDAToolkit_VERSION_MAJOR}")
+
+  cmake_path(GET CUDAToolkit_BIN_DIR PARENT_PATH _tilelang_use_cuda)
+  set(USE_CUDA "${_tilelang_use_cuda}" PARENT_SCOPE)
+
+  if(TILELANG_USE_CUDA_STUBS)
+    if(WIN32 AND NOT CYGWIN)
+      message(FATAL_ERROR "TILELANG_USE_CUDA_STUBS=ON is not supported on Windows. "
+                          "Please configure with -DTILELANG_USE_CUDA_STUBS=OFF.")
+    endif()
+
+    add_library(cuda_stub SHARED "${CMAKE_CURRENT_SOURCE_DIR}/src/target/stubs/cuda.cc")
+    target_include_directories(cuda_stub PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+    target_compile_definitions(cuda_stub PRIVATE TILELANG_CUDA_STUB_EXPORTS)
+    target_link_libraries(cuda_stub PRIVATE ${CMAKE_DL_LIBS})
+    set_target_properties(cuda_stub PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      OUTPUT_NAME "cuda_stub"
+    )
+
+    add_library(cudart_stub SHARED "${CMAKE_CURRENT_SOURCE_DIR}/src/target/stubs/cudart.cc")
+    target_include_directories(cudart_stub PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+    target_compile_definitions(cudart_stub PRIVATE TILELANG_CUDART_STUB_EXPORTS)
+    target_link_libraries(cudart_stub PRIVATE ${CMAKE_DL_LIBS})
+    set_target_properties(cudart_stub PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      OUTPUT_NAME "cudart_stub"
+    )
+    set(CUDA_CUDART_LIBRARY cudart_stub CACHE STRING "CUDART library to link against" FORCE)
+
+    add_library(nvrtc_stub SHARED "${CMAKE_CURRENT_SOURCE_DIR}/src/target/stubs/nvrtc.cc")
+    target_include_directories(nvrtc_stub PRIVATE ${CUDAToolkit_INCLUDE_DIRS})
+    target_compile_definitions(nvrtc_stub PRIVATE TILELANG_NVRTC_STUB_EXPORTS)
+    target_link_libraries(nvrtc_stub PRIVATE ${CMAKE_DL_LIBS})
+    set_target_properties(nvrtc_stub PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+      OUTPUT_NAME "nvrtc_stub"
+    )
+    set(CUDA_NVRTC_LIBRARY nvrtc_stub CACHE STRING "NVRTC library to link against" FORCE)
+  endif()
+
+  set(_nvidia_srcs
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/backend/nvidia/runtime/runtime.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/target/ptx.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/target/codegen_cuda.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/target/codegen_py.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/target/codegen_utils.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/target/codegen_cutedsl.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/target/rt_mod_cuda.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/target/rt_mod_cutedsl.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/target/intrin_rule_cuda.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/annotate_warp_group_reg_alloc.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/fuse_mbarrier_arrive_expect_tx.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/inject_fence_proxy.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/inject_tcgen05_fence.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/lower_blackwell_2sm.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/lower_hopper_intrin.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/lower_l2_persistent_annotation.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/lower_ldg_stg.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/lower_pdl.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/lower_ptx_async_copy.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/lower_shared_barrier.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/lower_shared_tmem.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/persist_threadblock.cc"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform/producer_consumer_ws.cc"
+  )
+
+  set(${OUT_SRCS} ${_nvidia_srcs} PARENT_SCOPE)
+  set(${OUT_INCLUDES} ${CUDAToolkit_INCLUDE_DIRS} PARENT_SCOPE)
+  link_directories(${CUDAToolkit_LIBRARY_DIR} ${CUDAToolkit_LIBRARY_DIR}/stubs)
+endfunction()

--- a/src/backend/nvidia/runtime/runtime.cc
+++ b/src/backend/nvidia/runtime/runtime.cc
@@ -4,9 +4,9 @@
  *
  */
 
-#include "runtime.h"
+#include "../../../runtime/runtime.h"
 
-#include "../target/stubs/cuda.h"
+#include "../../../target/stubs/cuda.h"
 #include <cstdint>
 #include <sstream>
 #include <tvm/ffi/function.h>

--- a/src/backend/webgpu/CMakeLists.txt
+++ b/src/backend/webgpu/CMakeLists.txt
@@ -1,0 +1,4 @@
+function(tilelang_configure_webgpu_backend OUT_SRCS OUT_INCLUDES)
+  set(${OUT_SRCS} "" PARENT_SCOPE)
+  set(${OUT_INCLUDES} "" PARENT_SCOPE)
+endfunction()

--- a/testing/python/backend/test_backend_registry.py
+++ b/testing/python/backend/test_backend_registry.py
@@ -70,6 +70,8 @@ def test_unknown_target_reports_backend_resolution_error():
 
 
 def test_execution_specs_own_adapter_codegen_and_cache_metadata():
+    from tilelang.cache import _dispatch_map
+
     cuda_backend = get_device_backend(Target("cuda"))
     cutedsl_backend = get_device_backend(Target("cuda -keys=cutedsl"))
 
@@ -78,6 +80,7 @@ def test_execution_specs_own_adapter_codegen_and_cache_metadata():
     assert tvm_ffi.requires_device_compile is True
     assert tvm_ffi.cache_artifact.kernel_lib_path == "executable.so"
     assert get_kernel_cache(Target("cuda"), "tvm_ffi").kernel_lib_path == "executable.so"
+    assert _dispatch_map["tvm_ffi"].kernel_lib_path == "executable.so"
 
     nvrtc = cuda_backend.execution_spec("nvrtc")
     assert nvrtc.requires_host_codegen is False
@@ -86,12 +89,15 @@ def test_execution_specs_own_adapter_codegen_and_cache_metadata():
     assert nvrtc.cache_artifact.kernel_lib_path == "kernel.cubin"
     assert "kernel.py" in nvrtc.cache_artifact.extra_required_paths
     assert nvrtc.cache_factory().kernel_lib_path == "kernel.cubin"
+    assert _dispatch_map["nvrtc"].kernel_lib_path == "kernel.cubin"
 
     cutedsl = cutedsl_backend.execution_spec("cutedsl")
     assert cutedsl.python_source_wrapper_factory is not None
     assert cutedsl.cache_artifact.kernel_lib_path == "kernel.py"
     assert cutedsl.cache_artifact.device_kernel_path == "kernel.py"
     assert "launcher_lib.so" in cutedsl.cache_artifact.extra_required_paths
+    assert _dispatch_map["cutedsl"].kernel_lib_path == "kernel.py"
+    assert sorted(_dispatch_map) == ["cutedsl", "cython", "nvrtc", "torch", "tvm_ffi"]
 
     assert get_execution_spec(Target("hip"), "cython").c_source_wrapper_factory is not None
     assert get_execution_spec(Target("c"), "cython").c_source_wrapper_factory is not None

--- a/testing/python/backend/test_backend_registry.py
+++ b/testing/python/backend/test_backend_registry.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+
+import tilelang  # noqa: F401
+from tvm.target import Target
+
+from tilelang.backend.errors import BackendResolutionError
+from tilelang.backend.registry import (
+    allowed_execution_backends_for_target,
+    get_device_backend,
+    resolve_execution_backend,
+)
+
+
+def test_device_backend_registry_resolves_current_targets():
+    cases = [
+        ("cuda", "nvidia", "cuda", "target.build.tilelang_cuda_without_compile"),
+        ("cuda -keys=cutedsl", "cutedsl", "cutedsl_py", "target.build.tilelang_cutedsl_without_compile"),
+        ("hip", "amd", "hip", "target.build.tilelang_hip_without_compile"),
+        ("metal", "apple", "metal", "target.build.metal"),
+        ("c", "cpu-c", "c", "target.build.tilelang_c"),
+        ("llvm", "cpu-llvm", "llvm", "target.build.llvm"),
+        ("webgpu", "webgpu", "webgpu", "target.build.webgpu"),
+    ]
+
+    for target_spec, backend_name, source_kind, source_symbol in cases:
+        backend = get_device_backend(Target(target_spec))
+        assert backend.name == backend_name
+        assert backend.source_kind == source_kind
+        assert backend.source_builder is not None
+        assert backend.source_builder.ffi_symbol == source_symbol
+
+
+def test_execution_backend_compatibility_matrix_is_backend_owned():
+    assert allowed_execution_backends_for_target(Target("cuda")) == ["tvm_ffi", "nvrtc", "cython"]
+    assert allowed_execution_backends_for_target(Target("cuda -keys=cutedsl")) == ["cutedsl"]
+    assert allowed_execution_backends_for_target(Target("hip")) == ["tvm_ffi", "cython"]
+    assert allowed_execution_backends_for_target(Target("metal")) == ["tvm_ffi", "torch"]
+    assert allowed_execution_backends_for_target(Target("c")) == ["cython", "tvm_ffi"]
+    assert allowed_execution_backends_for_target(Target("llvm")) == ["cython", "tvm_ffi"]
+    assert allowed_execution_backends_for_target(Target("webgpu")) == ["cython", "tvm_ffi"]
+
+
+def test_execution_backend_resolution_preserves_defaults_and_aliases():
+    assert resolve_execution_backend("auto", Target("cuda")) == "tvm_ffi"
+    assert resolve_execution_backend(None, Target("hip")) == "tvm_ffi"
+    assert resolve_execution_backend("auto", Target("cuda -keys=cutedsl")) == "cutedsl"
+    assert resolve_execution_backend("auto", Target("c")) == "cython"
+    assert resolve_execution_backend("dlpack", Target("cuda")) == "tvm_ffi"
+
+
+def test_execution_backend_resolution_rejects_invalid_pairs():
+    with pytest.raises(ValueError, match="Invalid execution backend"):
+        resolve_execution_backend("torch", Target("cuda"))
+
+
+def test_unknown_target_reports_backend_resolution_error():
+    with pytest.raises(BackendResolutionError, match="No TileLang device backend"):
+        get_device_backend(Target("vulkan"))
+

--- a/testing/python/backend/test_backend_registry.py
+++ b/testing/python/backend/test_backend_registry.py
@@ -1,16 +1,25 @@
 from __future__ import annotations
 
+import inspect
+from pathlib import Path
+
 import pytest
 
 import tilelang  # noqa: F401
 from tvm.target import Target
 
+from tilelang.backend.execution import get_execution_spec, get_kernel_cache, get_library_compile_spec
 from tilelang.backend.errors import BackendResolutionError
+from tilelang.backend.nvidia.passes import NvidiaPassHooks
 from tilelang.backend.registry import (
     allowed_execution_backends_for_target,
     get_device_backend,
     resolve_execution_backend,
 )
+from tilelang.engine import phase
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def test_device_backend_registry_resolves_current_targets():
@@ -59,3 +68,83 @@ def test_unknown_target_reports_backend_resolution_error():
     with pytest.raises(BackendResolutionError, match="No TileLang device backend"):
         get_device_backend(Target("vulkan"))
 
+
+def test_execution_specs_own_adapter_codegen_and_cache_metadata():
+    cuda_backend = get_device_backend(Target("cuda"))
+    cutedsl_backend = get_device_backend(Target("cuda -keys=cutedsl"))
+
+    tvm_ffi = get_execution_spec(Target("cuda"), "tvm_ffi")
+    assert tvm_ffi.requires_host_codegen is True
+    assert tvm_ffi.requires_device_compile is True
+    assert tvm_ffi.cache_artifact.kernel_lib_path == "executable.so"
+    assert get_kernel_cache(Target("cuda"), "tvm_ffi").kernel_lib_path == "executable.so"
+
+    nvrtc = cuda_backend.execution_spec("nvrtc")
+    assert nvrtc.requires_host_codegen is False
+    assert nvrtc.requires_device_compile is False
+    assert nvrtc.python_source_wrapper_factory is not None
+    assert nvrtc.cache_artifact.kernel_lib_path == "kernel.cubin"
+    assert "kernel.py" in nvrtc.cache_artifact.extra_required_paths
+    assert nvrtc.cache_factory().kernel_lib_path == "kernel.cubin"
+
+    cutedsl = cutedsl_backend.execution_spec("cutedsl")
+    assert cutedsl.python_source_wrapper_factory is not None
+    assert cutedsl.cache_artifact.kernel_lib_path == "kernel.py"
+    assert cutedsl.cache_artifact.device_kernel_path == "kernel.py"
+    assert "launcher_lib.so" in cutedsl.cache_artifact.extra_required_paths
+
+    assert get_execution_spec(Target("hip"), "cython").c_source_wrapper_factory is not None
+    assert get_execution_spec(Target("c"), "cython").c_source_wrapper_factory is not None
+    assert get_library_compile_spec(Target("cuda")).source_suffix == ".cu"
+    assert get_library_compile_spec(Target("hip")).source_suffix == ".cpp"
+    assert get_library_compile_spec(Target("c")).source_suffix == ".cpp"
+
+
+def test_backend_pass_hooks_are_wired_into_shared_pipeline():
+    lower_source = inspect.getsource(phase.LowerAndLegalize)
+    optimize_source = inspect.getsource(phase.OptimizeForTarget)
+    nvidia_hook_source = inspect.getsource(NvidiaPassHooks)
+
+    assert "backend.pass_hooks.pre_layout" in lower_source
+    assert lower_source.index("backend.pass_hooks.pre_layout") < lower_source.index("PipelinePlanning")
+    assert "backend.pass_hooks.post_tile_lowering" in lower_source
+    assert "backend.pass_hooks.before_split_host_device" in optimize_source
+    assert "backend.pass_hooks.after_split_host_device" in optimize_source
+    assert "backend.pass_hooks.before_device_codegen" in optimize_source
+
+    assert "ProducerConsumerWarpSpecialized" in nvidia_hook_source
+    assert "LowerBlackwell2SM" in nvidia_hook_source
+    assert "MarkCudaSyncCalls" in nvidia_hook_source
+    assert "PersistThreadblock" in nvidia_hook_source
+
+
+def test_native_backend_cmake_ownership_points_are_staged():
+    top_level_cmake = (REPO_ROOT / "CMakeLists.txt").read_text()
+    nvidia_cmake = (REPO_ROOT / "src/backend/nvidia/CMakeLists.txt").read_text()
+    amd_cmake = (REPO_ROOT / "src/backend/amd/CMakeLists.txt").read_text()
+    common_cmake = (REPO_ROOT / "src/backend/common/CMakeLists.txt").read_text()
+
+    assert "tilelang_configure_nvidia_backend" in top_level_cmake
+    assert "tilelang_configure_amd_backend" in top_level_cmake
+    assert "elseif(USE_ROCM)" not in top_level_cmake
+    assert "elseif(USE_CUDA)" not in top_level_cmake
+    assert "src/backend/nvidia/runtime/runtime.cc" in nvidia_cmake
+    assert "src/target/codegen_cuda.cc" in nvidia_cmake
+    assert "src/target/stubs/cuda.cc" in nvidia_cmake
+    assert "src/target/codegen_hip.cc" in amd_cmake
+    assert "src/target/stubs/hip.cc" in amd_cmake
+    assert "lower_hopper_intrin.cc" in common_cmake
+    assert "list(REMOVE_ITEM _common_srcs" in common_cmake
+
+
+def test_backend_imports_do_not_eagerly_require_optional_sdk_adapters():
+    import importlib
+
+    for module_name in [
+        "tilelang",
+        "tilelang.backend",
+        "tilelang.cache",
+        "tilelang.jit.execution_backend",
+        "tilelang.jit.kernel",
+    ]:
+        importlib.import_module(module_name)

--- a/testing/python/cache/test_tilelang_kernel_cache.py
+++ b/testing/python/cache/test_tilelang_kernel_cache.py
@@ -26,6 +26,7 @@ import tilelang.language as T
 import tvm_ffi
 import torch
 import uuid
+from functools import cache
 from pathlib import Path
 from tilelang.env import env
 from tilelang.cache import _dispatch_map
@@ -38,12 +39,61 @@ BACKENDS = [
 ]
 
 
+def test_dispatch_map_compatibility_export():
+    """The legacy cache singleton table remains importable and metadata-backed."""
+    expected_backends = {"tvm_ffi", "cython", "nvrtc", "cutedsl", "torch"}
+    assert expected_backends.issubset(_dispatch_map)
+    assert _dispatch_map["tvm_ffi"].kernel_lib_path == "executable.so"
+    assert _dispatch_map["cython"].kernel_lib_path == "kernel_lib.so"
+    assert _dispatch_map["nvrtc"].kernel_lib_path == "kernel.cubin"
+    assert _dispatch_map["cutedsl"].kernel_lib_path == "kernel.py"
+
+
 def _get_target_from_backend(backend: str):
     """Map backend to target string."""
     return "cutedsl" if backend == "cutedsl" else "auto"
 
 
+@cache
+def _nvrtc_unavailable_reason() -> str | None:
+    try:
+        from tilelang.jit.adapter.nvrtc import check_nvrtc_available
+        from tilelang.jit.adapter.nvrtc.libgen import NVRTCLibraryGenerator
+        from tvm.target import Target
+
+        check_nvrtc_available()
+        generator = NVRTCLibraryGenerator(Target("cuda"), verbose=True)
+        generator.update_lib_code("""
+#include <tl_templates/cuda/gemm.h>
+#include <tl_templates/cuda/copy.h>
+#include <tl_templates/cuda/reduce.h>
+#include <tl_templates/cuda/ldsm.h>
+#include <tl_templates/cuda/threadblock_swizzle.h>
+#include <tl_templates/cuda/debug.h>
+extern "C" __global__ void __tilelang_nvrtc_probe(const float* A, float* B) {
+    B[((int)blockIdx.x)] = A[((int)blockIdx.x)];
+}
+""")
+        generator.update_host_func("def call(*args, **kwargs):\n    pass\n")
+        generator.compile_lib()
+    except Exception as e:
+        message = [line.strip() for line in str(e).splitlines() if line.strip()]
+        for line in message:
+            if line == "Compilation error:":
+                continue
+            if "error:" in line or "catastrophic error" in line or "errors detected" in line:
+                return line[:240]
+        return message[-1][:240] if message else e.__class__.__name__
+    return None
+
+
 def _require_backend_available(backend: str) -> None:
+    if backend == "nvrtc":
+        reason = _nvrtc_unavailable_reason()
+        if reason is not None:
+            pytest.skip(f"NVRTC backend unavailable for current target: {reason}")
+        return
+
     if backend != "cutedsl":
         return
     try:

--- a/tilelang/backend/__init__.py
+++ b/tilelang/backend/__init__.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from tilelang.backend.base import BackendPassHooks, DeviceBackend, FFIBuilderRef
+from tilelang.backend.registry import (
+    allowed_execution_backends_for_target,
+    build_device_module,
+    get_device_backend,
+    registered_device_backends,
+    resolve_execution_backend,
+)
+
+__all__ = [
+    "BackendPassHooks",
+    "DeviceBackend",
+    "FFIBuilderRef",
+    "allowed_execution_backends_for_target",
+    "build_device_module",
+    "get_device_backend",
+    "registered_device_backends",
+    "resolve_execution_backend",
+]

--- a/tilelang/backend/amd/__init__.py
+++ b/tilelang/backend/amd/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from tilelang.backend.base import DeviceBackend
 
-from .execution import HIP_DEFAULT_EXECUTION_BACKEND, HIP_EXECUTION_BACKENDS
+from .execution import HIP_DEFAULT_EXECUTION_BACKEND, HIP_EXECUTION_BACKENDS, HIP_EXECUTION_SPECS
 from .ffi import HIP_COMPILED_BUILDER, HIP_SOURCE_BUILDER
 from .passes import AmdPassHooks
 from .target import is_hip_target
@@ -19,8 +19,8 @@ def get_backends() -> tuple[DeviceBackend, ...]:
             execution_backends=HIP_EXECUTION_BACKENDS,
             default_execution_backend=HIP_DEFAULT_EXECUTION_BACKEND,
             source_kind="hip",
+            execution_specs=HIP_EXECUTION_SPECS,
             pass_hooks=AmdPassHooks(),
             metadata={"dialect": "hip"},
         ),
     )
-

--- a/tilelang/backend/amd/__init__.py
+++ b/tilelang/backend/amd/__init__.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from tilelang.backend.base import DeviceBackend
+
+from .execution import HIP_DEFAULT_EXECUTION_BACKEND, HIP_EXECUTION_BACKENDS
+from .ffi import HIP_COMPILED_BUILDER, HIP_SOURCE_BUILDER
+from .passes import AmdPassHooks
+from .target import is_hip_target
+
+
+def get_backends() -> tuple[DeviceBackend, ...]:
+    return (
+        DeviceBackend(
+            name="amd",
+            family="amd",
+            match_target=is_hip_target,
+            source_builder=HIP_SOURCE_BUILDER,
+            compiled_builder=HIP_COMPILED_BUILDER,
+            execution_backends=HIP_EXECUTION_BACKENDS,
+            default_execution_backend=HIP_DEFAULT_EXECUTION_BACKEND,
+            source_kind="hip",
+            pass_hooks=AmdPassHooks(),
+            metadata={"dialect": "hip"},
+        ),
+    )
+

--- a/tilelang/backend/amd/execution.py
+++ b/tilelang/backend/amd/execution.py
@@ -1,6 +1,53 @@
 from __future__ import annotations
 
+from typing import Any
 
-HIP_EXECUTION_BACKENDS = ("tvm_ffi", "cython")
+from tvm.target import Target
+
+from tilelang.backend.base import LibraryCompileSpec
+from tilelang.backend.common.execution import make_cython_execution_spec, make_tvm_ffi_execution_spec
+
+
 HIP_DEFAULT_EXECUTION_BACKEND = "tvm_ffi"
 
+
+def _hip_source_wrapper(**kwargs):
+    from tilelang.jit.adapter.wrapper import TLHIPSourceWrapper
+
+    return TLHIPSourceWrapper(**kwargs)
+
+
+def _hip_library_command(target: Target, source_path: str, library_path: str, pass_configs: dict[str, Any]) -> list[str]:
+    from tilelang.contrib.rocm import find_rocm_path, get_rocm_arch
+    from tilelang.env import COMPOSABLE_KERNEL_INCLUDE_DIR, TILELANG_TEMPLATE_PATH
+
+    rocm_path = find_rocm_path()
+    arch = get_rocm_arch(rocm_path)
+    return [
+        "hipcc",
+        "-std=c++17",
+        "-fPIC",
+        f"--offload-arch={arch}",
+        "--shared",
+        source_path,
+        "-I" + COMPOSABLE_KERNEL_INCLUDE_DIR,
+        "-I" + TILELANG_TEMPLATE_PATH,
+        "-o",
+        library_path,
+    ]
+
+
+HIP_LIBRARY_COMPILE_SPEC = LibraryCompileSpec(
+    source_suffix=".cpp",
+    library_suffix=".so",
+    command_factory=_hip_library_command,
+)
+
+HIP_EXECUTION_SPECS = (
+    make_tvm_ffi_execution_spec(),
+    make_cython_execution_spec(
+        c_source_wrapper_factory=_hip_source_wrapper,
+        library_compile_spec=HIP_LIBRARY_COMPILE_SPEC,
+    ),
+)
+HIP_EXECUTION_BACKENDS = tuple(spec.name for spec in HIP_EXECUTION_SPECS)

--- a/tilelang/backend/amd/execution.py
+++ b/tilelang/backend/amd/execution.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+
+HIP_EXECUTION_BACKENDS = ("tvm_ffi", "cython")
+HIP_DEFAULT_EXECUTION_BACKEND = "tvm_ffi"
+

--- a/tilelang/backend/amd/ffi.py
+++ b/tilelang/backend/amd/ffi.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from tilelang.backend.base import FFIBuilderRef
+
+
+HIP_SOURCE_BUILDER = FFIBuilderRef("target.build.tilelang_hip_without_compile", "source")
+HIP_COMPILED_BUILDER = FFIBuilderRef("target.build.tilelang_hip", "compiled")
+

--- a/tilelang/backend/amd/ffi.py
+++ b/tilelang/backend/amd/ffi.py
@@ -5,4 +5,3 @@ from tilelang.backend.base import FFIBuilderRef
 
 HIP_SOURCE_BUILDER = FFIBuilderRef("target.build.tilelang_hip_without_compile", "source")
 HIP_COMPILED_BUILDER = FFIBuilderRef("target.build.tilelang_hip", "compiled")
-

--- a/tilelang/backend/amd/passes.py
+++ b/tilelang/backend/amd/passes.py
@@ -5,4 +5,3 @@ from tilelang.backend.base import BackendPassHooks
 
 class AmdPassHooks(BackendPassHooks):
     pass
-

--- a/tilelang/backend/amd/passes.py
+++ b/tilelang/backend/amd/passes.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from tilelang.backend.base import BackendPassHooks
+
+
+class AmdPassHooks(BackendPassHooks):
+    pass
+

--- a/tilelang/backend/amd/target.py
+++ b/tilelang/backend/amd/target.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from tilelang.backend.common.target import is_hip_target
+
+__all__ = ["is_hip_target"]

--- a/tilelang/backend/apple/__init__.py
+++ b/tilelang/backend/apple/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from tilelang.backend.base import DeviceBackend
 
-from .execution import METAL_DEFAULT_EXECUTION_BACKEND, METAL_EXECUTION_BACKENDS
+from .execution import METAL_DEFAULT_EXECUTION_BACKEND, METAL_EXECUTION_BACKENDS, METAL_EXECUTION_SPECS
 from .ffi import METAL_COMPILED_BUILDER, METAL_SOURCE_BUILDER
 from .passes import ApplePassHooks
 from .target import is_metal_target
@@ -19,8 +19,8 @@ def get_backends() -> tuple[DeviceBackend, ...]:
             execution_backends=METAL_EXECUTION_BACKENDS,
             default_execution_backend=METAL_DEFAULT_EXECUTION_BACKEND,
             source_kind="metal",
+            execution_specs=METAL_EXECUTION_SPECS,
             pass_hooks=ApplePassHooks(),
             metadata={"dialect": "metal"},
         ),
     )
-

--- a/tilelang/backend/apple/__init__.py
+++ b/tilelang/backend/apple/__init__.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from tilelang.backend.base import DeviceBackend
+
+from .execution import METAL_DEFAULT_EXECUTION_BACKEND, METAL_EXECUTION_BACKENDS
+from .ffi import METAL_COMPILED_BUILDER, METAL_SOURCE_BUILDER
+from .passes import ApplePassHooks
+from .target import is_metal_target
+
+
+def get_backends() -> tuple[DeviceBackend, ...]:
+    return (
+        DeviceBackend(
+            name="apple",
+            family="apple",
+            match_target=is_metal_target,
+            source_builder=METAL_SOURCE_BUILDER,
+            compiled_builder=METAL_COMPILED_BUILDER,
+            execution_backends=METAL_EXECUTION_BACKENDS,
+            default_execution_backend=METAL_DEFAULT_EXECUTION_BACKEND,
+            source_kind="metal",
+            pass_hooks=ApplePassHooks(),
+            metadata={"dialect": "metal"},
+        ),
+    )
+

--- a/tilelang/backend/apple/execution.py
+++ b/tilelang/backend/apple/execution.py
@@ -1,6 +1,52 @@
 from __future__ import annotations
 
+from dataclasses import replace
 
-METAL_EXECUTION_BACKENDS = ("tvm_ffi", "torch")
+from tilelang.backend.base import ExecutionBackendSpec
+from tilelang.backend.common.execution import make_tvm_ffi_execution_spec
+
+
 METAL_DEFAULT_EXECUTION_BACKEND = "tvm_ffi"
 
+
+def _metal_source_wrapper(**kwargs):
+    from tilelang.jit.adapter.wrapper import TLMetalSourceWrapper
+
+    return TLMetalSourceWrapper(**kwargs)
+
+
+def _create_torch_metal_adapter(**kwargs):
+    from tilelang.jit.adapter.torch import MetalKernelAdapter
+
+    artifact = kwargs.pop("artifact")
+    return MetalKernelAdapter(
+        params=kwargs["params"],
+        result_idx=kwargs["result_idx"],
+        func_or_mod=kwargs["func_or_mod"],
+        device_mod=artifact.device_mod,
+        kernel_global_source=artifact.kernel_source,
+        verbose=kwargs["verbose"],
+    )
+
+
+def _create_torch_cache():
+    from tilelang.jit.adapter.torch.kernel_cache import TorchKernelCache
+
+    return TorchKernelCache()
+
+
+METAL_TVM_FFI_SPEC = make_tvm_ffi_execution_spec()
+METAL_TVM_FFI_SPEC = replace(METAL_TVM_FFI_SPEC, c_source_wrapper_factory=_metal_source_wrapper)
+
+METAL_EXECUTION_SPECS = (
+    METAL_TVM_FFI_SPEC,
+    ExecutionBackendSpec(
+        name="torch",
+        adapter_factory=_create_torch_metal_adapter,
+        database_adapter_factory=None,
+        cache_factory=_create_torch_cache,
+        kernel_source_from_adapter=False,
+        host_source_from_adapter=False,
+    ),
+)
+METAL_EXECUTION_BACKENDS = tuple(spec.name for spec in METAL_EXECUTION_SPECS)

--- a/tilelang/backend/apple/execution.py
+++ b/tilelang/backend/apple/execution.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+
+METAL_EXECUTION_BACKENDS = ("tvm_ffi", "torch")
+METAL_DEFAULT_EXECUTION_BACKEND = "tvm_ffi"
+

--- a/tilelang/backend/apple/ffi.py
+++ b/tilelang/backend/apple/ffi.py
@@ -5,4 +5,3 @@ from tilelang.backend.base import FFIBuilderRef
 
 METAL_SOURCE_BUILDER = FFIBuilderRef("target.build.metal", "source")
 METAL_COMPILED_BUILDER = FFIBuilderRef("target.build.metal", "compiled")
-

--- a/tilelang/backend/apple/ffi.py
+++ b/tilelang/backend/apple/ffi.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from tilelang.backend.base import FFIBuilderRef
+
+
+METAL_SOURCE_BUILDER = FFIBuilderRef("target.build.metal", "source")
+METAL_COMPILED_BUILDER = FFIBuilderRef("target.build.metal", "compiled")
+

--- a/tilelang/backend/apple/passes.py
+++ b/tilelang/backend/apple/passes.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from tilelang.backend.base import BackendPassHooks
+
+
+class ApplePassHooks(BackendPassHooks):
+    pass
+

--- a/tilelang/backend/apple/passes.py
+++ b/tilelang/backend/apple/passes.py
@@ -5,4 +5,3 @@ from tilelang.backend.base import BackendPassHooks
 
 class ApplePassHooks(BackendPassHooks):
     pass
-

--- a/tilelang/backend/apple/target.py
+++ b/tilelang/backend/apple/target.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from tilelang.backend.common.target import is_metal_target
+
+__all__ = ["is_metal_target"]

--- a/tilelang/backend/base.py
+++ b/tilelang/backend/base.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from tilelang import tvm
+from tvm.target import Target
+
+
+BuilderMode = Literal["source", "compiled"]
+
+
+@dataclass(frozen=True)
+class FFIBuilderRef:
+    """Lazy reference to a Python-accessible C++ FFI builder."""
+
+    ffi_symbol: str
+    mode: BuilderMode
+
+    def build(self, mod: tvm.IRModule, target: Target) -> tvm.runtime.Module:
+        return tvm.ffi.get_global_func(self.ffi_symbol)(mod, target)
+
+
+class BackendPassHooks:
+    """No-op backend pass hooks for shared pipeline integration."""
+
+    def pre_layout(self, mod: tvm.IRModule, target: Target) -> tvm.IRModule:
+        return mod
+
+    def post_layout(self, mod: tvm.IRModule, target: Target) -> tvm.IRModule:
+        return mod
+
+    def post_tile_lowering(self, mod: tvm.IRModule, target: Target) -> tvm.IRModule:
+        return mod
+
+    def pre_storage_rewrite(self, mod: tvm.IRModule, target: Target) -> tvm.IRModule:
+        return mod
+
+    def post_storage_rewrite(self, mod: tvm.IRModule, target: Target) -> tvm.IRModule:
+        return mod
+
+    def before_split_host_device(self, mod: tvm.IRModule, target: Target) -> tvm.IRModule:
+        return mod
+
+    def after_split_host_device(self, mod: tvm.IRModule, target: Target) -> tvm.IRModule:
+        return mod
+
+    def before_device_codegen(self, mod: tvm.IRModule, target: Target) -> tvm.IRModule:
+        return mod
+
+
+UnavailableExecutionBackends = Callable[[], tuple[str, ...]]
+
+
+@dataclass(frozen=True)
+class DeviceBackend:
+    name: str
+    family: str
+    match_target: Callable[[Target], bool]
+    source_builder: FFIBuilderRef | None
+    compiled_builder: FFIBuilderRef | None
+    execution_backends: tuple[str, ...]
+    default_execution_backend: str
+    source_kind: str
+    pass_hooks: BackendPassHooks = field(default_factory=BackendPassHooks)
+    unavailable_execution_backends: UnavailableExecutionBackends | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def builder_for(self, *, compile: bool) -> FFIBuilderRef:
+        builder = self.compiled_builder if compile else self.source_builder
+        if builder is None:
+            mode = "compiled" if compile else "source"
+            raise ValueError(f"Backend '{self.name}' does not support {mode} device codegen")
+        return builder
+
+    def allowed_execution_backends(self, *, include_unavailable: bool = True) -> list[str]:
+        allowed = list(self.execution_backends)
+        if include_unavailable or self.unavailable_execution_backends is None:
+            return allowed
+
+        unavailable = set(self.unavailable_execution_backends())
+        return [backend for backend in allowed if backend not in unavailable]
+

--- a/tilelang/backend/base.py
+++ b/tilelang/backend/base.py
@@ -9,6 +9,10 @@ from tvm.target import Target
 
 
 BuilderMode = Literal["source", "compiled"]
+AdapterFactory = Callable[..., Any]
+CacheFactory = Callable[[], Any]
+SourceWrapperFactory = Callable[..., Any]
+LibraryCommandFactory = Callable[[Target, str, str, dict[str, Any]], list[str]]
 
 
 @dataclass(frozen=True)
@@ -25,6 +29,9 @@ class FFIBuilderRef:
 class BackendPassHooks:
     """No-op backend pass hooks for shared pipeline integration."""
 
+    def adjust_aggressive_shared_memory_merge(self, enabled: bool, target: Target) -> bool:
+        return enabled
+
     def pre_layout(self, mod: tvm.IRModule, target: Target) -> tvm.IRModule:
         return mod
 
@@ -32,6 +39,15 @@ class BackendPassHooks:
         return mod
 
     def post_tile_lowering(self, mod: tvm.IRModule, target: Target) -> tvm.IRModule:
+        return mod
+
+    def optimize_entry(self, mod: tvm.IRModule, target: Target) -> tvm.IRModule:
+        return mod
+
+    def lower_shared_barrier(self, mod: tvm.IRModule, target: Target) -> tvm.IRModule:
+        return mod
+
+    def after_shared_barrier_lowering(self, mod: tvm.IRModule, target: Target, *, has_tma: bool) -> tvm.IRModule:
         return mod
 
     def pre_storage_rewrite(self, mod: tvm.IRModule, target: Target) -> tvm.IRModule:
@@ -46,11 +62,49 @@ class BackendPassHooks:
     def after_split_host_device(self, mod: tvm.IRModule, target: Target) -> tvm.IRModule:
         return mod
 
+    def after_shared_memory_planning(self, mod: tvm.IRModule, target: Target) -> tvm.IRModule:
+        return mod
+
+    def after_shared_sync(self, mod: tvm.IRModule, target: Target) -> tvm.IRModule:
+        return mod
+
     def before_device_codegen(self, mod: tvm.IRModule, target: Target) -> tvm.IRModule:
         return mod
 
 
 UnavailableExecutionBackends = Callable[[], tuple[str, ...]]
+
+
+@dataclass(frozen=True)
+class CacheArtifactSpec:
+    kernel_lib_path: str = "kernel_lib.so"
+    device_kernel_path: str = "device_kernel.cu"
+    host_kernel_path: str = "host_kernel.cu"
+    extra_required_paths: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class LibraryCompileSpec:
+    source_suffix: str
+    library_suffix: str
+    command_factory: LibraryCommandFactory
+
+
+@dataclass(frozen=True)
+class ExecutionBackendSpec:
+    name: str
+    adapter_factory: AdapterFactory
+    database_adapter_factory: AdapterFactory | None
+    cache_factory: CacheFactory
+    cache_artifact: CacheArtifactSpec = field(default_factory=CacheArtifactSpec)
+    c_source_wrapper_factory: SourceWrapperFactory | None = None
+    python_source_wrapper_factory: SourceWrapperFactory | None = None
+    library_compile_spec: LibraryCompileSpec | None = None
+    requires_host_codegen: bool = False
+    requires_device_compile: bool = False
+    kernel_source_from_adapter: bool = True
+    host_source_from_adapter: bool = True
+    requires_cxx_compiler: bool = False
 
 
 @dataclass(frozen=True)
@@ -63,9 +117,24 @@ class DeviceBackend:
     execution_backends: tuple[str, ...]
     default_execution_backend: str
     source_kind: str
+    execution_specs: tuple[ExecutionBackendSpec, ...] = ()
     pass_hooks: BackendPassHooks = field(default_factory=BackendPassHooks)
     unavailable_execution_backends: UnavailableExecutionBackends | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self):
+        if self.execution_specs:
+            spec_names = tuple(spec.name for spec in self.execution_specs)
+            if self.execution_backends and self.execution_backends != spec_names:
+                raise ValueError(
+                    f"Backend '{self.name}' execution_backends must match execution_specs order: "
+                    f"{self.execution_backends} != {spec_names}"
+                )
+            if self.default_execution_backend not in spec_names:
+                raise ValueError(
+                    f"Backend '{self.name}' default execution backend "
+                    f"'{self.default_execution_backend}' is not registered"
+                )
 
     def builder_for(self, *, compile: bool) -> FFIBuilderRef:
         builder = self.compiled_builder if compile else self.source_builder
@@ -82,3 +151,8 @@ class DeviceBackend:
         unavailable = set(self.unavailable_execution_backends())
         return [backend for backend in allowed if backend not in unavailable]
 
+    def execution_spec(self, name: str) -> ExecutionBackendSpec:
+        for spec in self.execution_specs:
+            if spec.name == name:
+                return spec
+        raise ValueError(f"Execution backend '{name}' is not registered for device backend '{self.name}'")

--- a/tilelang/backend/common/__init__.py
+++ b/tilelang/backend/common/__init__.py
@@ -1,2 +1,1 @@
 from __future__ import annotations
-

--- a/tilelang/backend/common/__init__.py
+++ b/tilelang/backend/common/__init__.py
@@ -1,0 +1,2 @@
+from __future__ import annotations
+

--- a/tilelang/backend/common/execution.py
+++ b/tilelang/backend/common/execution.py
@@ -1,6 +1,144 @@
 from __future__ import annotations
 
+from typing import Any
+
+from tvm.target import Target
+
+from tilelang.backend.base import (
+    CacheArtifactSpec,
+    ExecutionBackendSpec,
+    LibraryCompileSpec,
+    SourceWrapperFactory,
+)
+
 
 CPU_EXECUTION_BACKENDS = ("cython", "tvm_ffi")
 CPU_DEFAULT_EXECUTION_BACKEND = "cython"
 
+
+def _create_tvm_ffi_adapter(**kwargs):
+    from tilelang.jit.adapter.tvm_ffi import TVMFFIKernelAdapter
+
+    artifact = kwargs.pop("artifact")
+    assert artifact.rt_mod is not None, "tvm_ffi backend requires a runtime module."
+    return TVMFFIKernelAdapter(
+        params=kwargs["params"],
+        result_idx=kwargs["result_idx"],
+        target=kwargs["target"],
+        func_or_mod=kwargs["func_or_mod"],
+        host_mod=artifact.host_mod,
+        device_mod=artifact.device_mod,
+        rt_mod=artifact.rt_mod,
+        device_kernel_source=artifact.kernel_source,
+        verbose=kwargs["verbose"],
+        pass_configs=kwargs["pass_configs"],
+        compile_flags=kwargs["compile_flags"],
+    )
+
+
+def _create_tvm_ffi_adapter_from_database(**kwargs):
+    from tilelang.jit.adapter.tvm_ffi import TVMFFIKernelAdapter
+
+    return TVMFFIKernelAdapter.from_database(**kwargs)
+
+
+def _create_tvm_ffi_cache():
+    from tilelang.jit.adapter.kernel_cache import TVMFFIKernelCache
+
+    return TVMFFIKernelCache()
+
+
+def _create_cython_adapter(**kwargs):
+    from tilelang.jit.adapter.cython import CythonKernelAdapter
+
+    artifact = kwargs.pop("artifact")
+    return CythonKernelAdapter(
+        params=kwargs["params"],
+        result_idx=kwargs["result_idx"],
+        target=kwargs["target"],
+        func_or_mod=kwargs["func_or_mod"],
+        host_mod=artifact.host_mod,
+        device_mod=artifact.device_mod,
+        device_kernel_source=artifact.kernel_source,
+        verbose=kwargs["verbose"],
+        pass_configs=kwargs["pass_configs"],
+        compile_flags=kwargs["compile_flags"],
+    )
+
+
+def _create_cython_adapter_from_database(**kwargs):
+    from tilelang.jit.adapter.cython import CythonKernelAdapter
+
+    return CythonKernelAdapter.from_database(**kwargs)
+
+
+def _create_cython_cache():
+    from tilelang.jit.adapter.cython.kernel_cache import CythonKernelCache
+
+    return CythonKernelCache()
+
+
+def _cpu_source_wrapper(**kwargs):
+    from tilelang.jit.adapter.wrapper import TLCPUSourceWrapper
+
+    return TLCPUSourceWrapper(**kwargs)
+
+
+def _cpu_library_command(target: Target, source_path: str, library_path: str, pass_configs: dict[str, Any]) -> list[str]:
+    from tilelang.contrib.cc import get_cplus_compiler
+    from tilelang.env import TILELANG_TEMPLATE_PATH
+
+    return [
+        get_cplus_compiler(),
+        "-std=c++17",
+        "-fPIC",
+        "-shared",
+        source_path,
+        "-I" + TILELANG_TEMPLATE_PATH,
+        "-o",
+        library_path,
+    ]
+
+
+CPU_LIBRARY_COMPILE_SPEC = LibraryCompileSpec(
+    source_suffix=".cpp",
+    library_suffix=".so",
+    command_factory=_cpu_library_command,
+)
+
+
+def make_tvm_ffi_execution_spec() -> ExecutionBackendSpec:
+    return ExecutionBackendSpec(
+        name="tvm_ffi",
+        adapter_factory=_create_tvm_ffi_adapter,
+        database_adapter_factory=_create_tvm_ffi_adapter_from_database,
+        cache_factory=_create_tvm_ffi_cache,
+        cache_artifact=CacheArtifactSpec(kernel_lib_path="executable.so"),
+        requires_host_codegen=True,
+        requires_device_compile=True,
+    )
+
+
+def make_cython_execution_spec(
+    *,
+    c_source_wrapper_factory: SourceWrapperFactory | None,
+    library_compile_spec: LibraryCompileSpec | None,
+) -> ExecutionBackendSpec:
+    return ExecutionBackendSpec(
+        name="cython",
+        adapter_factory=_create_cython_adapter,
+        database_adapter_factory=_create_cython_adapter_from_database,
+        cache_factory=_create_cython_cache,
+        c_source_wrapper_factory=c_source_wrapper_factory,
+        library_compile_spec=library_compile_spec,
+        requires_cxx_compiler=True,
+    )
+
+
+CPU_EXECUTION_SPECS = (
+    make_cython_execution_spec(
+        c_source_wrapper_factory=_cpu_source_wrapper,
+        library_compile_spec=CPU_LIBRARY_COMPILE_SPEC,
+    ),
+    make_tvm_ffi_execution_spec(),
+)

--- a/tilelang/backend/common/execution.py
+++ b/tilelang/backend/common/execution.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+
+CPU_EXECUTION_BACKENDS = ("cython", "tvm_ffi")
+CPU_DEFAULT_EXECUTION_BACKEND = "cython"
+

--- a/tilelang/backend/common/ffi.py
+++ b/tilelang/backend/common/ffi.py
@@ -5,4 +5,3 @@ from tilelang.backend.base import FFIBuilderRef
 
 C_SOURCE_BUILDER = FFIBuilderRef("target.build.tilelang_c", "source")
 LLVM_SOURCE_BUILDER = FFIBuilderRef("target.build.llvm", "source")
-

--- a/tilelang/backend/common/ffi.py
+++ b/tilelang/backend/common/ffi.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from tilelang.backend.base import FFIBuilderRef
+
+
+C_SOURCE_BUILDER = FFIBuilderRef("target.build.tilelang_c", "source")
+LLVM_SOURCE_BUILDER = FFIBuilderRef("target.build.llvm", "source")
+

--- a/tilelang/backend/common/target.py
+++ b/tilelang/backend/common/target.py
@@ -37,4 +37,3 @@ def is_llvm_target(target: Target) -> bool:
 
 def is_webgpu_target(target: Target) -> bool:
     return target_kind(target) == "webgpu"
-

--- a/tilelang/backend/common/target.py
+++ b/tilelang/backend/common/target.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from tvm.target import Target
+
+
+def target_kind(target: Target) -> str:
+    return target.kind.name
+
+
+def target_keys(target: Target) -> set[str]:
+    return {str(key) for key in target.keys}
+
+
+def is_cuda_target(target: Target) -> bool:
+    return target_kind(target) == "cuda"
+
+
+def is_cutedsl_target(target: Target) -> bool:
+    return is_cuda_target(target) and "cutedsl" in target_keys(target)
+
+
+def is_hip_target(target: Target) -> bool:
+    return target_kind(target) == "hip"
+
+
+def is_metal_target(target: Target) -> bool:
+    return target_kind(target) == "metal"
+
+
+def is_c_target(target: Target) -> bool:
+    return target_kind(target) == "c"
+
+
+def is_llvm_target(target: Target) -> bool:
+    return target_kind(target) == "llvm"
+
+
+def is_webgpu_target(target: Target) -> bool:
+    return target_kind(target) == "webgpu"
+

--- a/tilelang/backend/cpu/__init__.py
+++ b/tilelang/backend/cpu/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from tilelang.backend.base import DeviceBackend
 
-from .execution import CPU_DEFAULT_EXECUTION_BACKEND, CPU_EXECUTION_BACKENDS
+from .execution import CPU_DEFAULT_EXECUTION_BACKEND, CPU_EXECUTION_BACKENDS, CPU_EXECUTION_SPECS
 from .ffi import C_SOURCE_BUILDER, LLVM_SOURCE_BUILDER
 from .passes import CpuPassHooks
 from .target import is_c_target, is_llvm_target
@@ -20,6 +20,7 @@ def get_backends() -> tuple[DeviceBackend, ...]:
             execution_backends=CPU_EXECUTION_BACKENDS,
             default_execution_backend=CPU_DEFAULT_EXECUTION_BACKEND,
             source_kind="c",
+            execution_specs=CPU_EXECUTION_SPECS,
             pass_hooks=hooks,
             metadata={"dialect": "c"},
         ),
@@ -32,8 +33,8 @@ def get_backends() -> tuple[DeviceBackend, ...]:
             execution_backends=CPU_EXECUTION_BACKENDS,
             default_execution_backend=CPU_DEFAULT_EXECUTION_BACKEND,
             source_kind="llvm",
+            execution_specs=CPU_EXECUTION_SPECS,
             pass_hooks=hooks,
             metadata={"dialect": "llvm"},
         ),
     )
-

--- a/tilelang/backend/cpu/__init__.py
+++ b/tilelang/backend/cpu/__init__.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from tilelang.backend.base import DeviceBackend
+
+from .execution import CPU_DEFAULT_EXECUTION_BACKEND, CPU_EXECUTION_BACKENDS
+from .ffi import C_SOURCE_BUILDER, LLVM_SOURCE_BUILDER
+from .passes import CpuPassHooks
+from .target import is_c_target, is_llvm_target
+
+
+def get_backends() -> tuple[DeviceBackend, ...]:
+    hooks = CpuPassHooks()
+    return (
+        DeviceBackend(
+            name="cpu-c",
+            family="cpu",
+            match_target=is_c_target,
+            source_builder=C_SOURCE_BUILDER,
+            compiled_builder=None,
+            execution_backends=CPU_EXECUTION_BACKENDS,
+            default_execution_backend=CPU_DEFAULT_EXECUTION_BACKEND,
+            source_kind="c",
+            pass_hooks=hooks,
+            metadata={"dialect": "c"},
+        ),
+        DeviceBackend(
+            name="cpu-llvm",
+            family="cpu",
+            match_target=is_llvm_target,
+            source_builder=LLVM_SOURCE_BUILDER,
+            compiled_builder=None,
+            execution_backends=CPU_EXECUTION_BACKENDS,
+            default_execution_backend=CPU_DEFAULT_EXECUTION_BACKEND,
+            source_kind="llvm",
+            pass_hooks=hooks,
+            metadata={"dialect": "llvm"},
+        ),
+    )
+

--- a/tilelang/backend/cpu/execution.py
+++ b/tilelang/backend/cpu/execution.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from tilelang.backend.common.execution import CPU_DEFAULT_EXECUTION_BACKEND, CPU_EXECUTION_BACKENDS
+
+__all__ = ["CPU_DEFAULT_EXECUTION_BACKEND", "CPU_EXECUTION_BACKENDS"]
+

--- a/tilelang/backend/cpu/execution.py
+++ b/tilelang/backend/cpu/execution.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from tilelang.backend.common.execution import CPU_DEFAULT_EXECUTION_BACKEND, CPU_EXECUTION_BACKENDS
+from tilelang.backend.common.execution import (
+    CPU_DEFAULT_EXECUTION_BACKEND,
+    CPU_EXECUTION_BACKENDS,
+    CPU_EXECUTION_SPECS,
+)
 
-__all__ = ["CPU_DEFAULT_EXECUTION_BACKEND", "CPU_EXECUTION_BACKENDS"]
-
+__all__ = ["CPU_DEFAULT_EXECUTION_BACKEND", "CPU_EXECUTION_BACKENDS", "CPU_EXECUTION_SPECS"]

--- a/tilelang/backend/cpu/ffi.py
+++ b/tilelang/backend/cpu/ffi.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+from tilelang.backend.common.ffi import C_SOURCE_BUILDER, LLVM_SOURCE_BUILDER
+
+__all__ = ["C_SOURCE_BUILDER", "LLVM_SOURCE_BUILDER"]
+

--- a/tilelang/backend/cpu/ffi.py
+++ b/tilelang/backend/cpu/ffi.py
@@ -3,4 +3,3 @@ from __future__ import annotations
 from tilelang.backend.common.ffi import C_SOURCE_BUILDER, LLVM_SOURCE_BUILDER
 
 __all__ = ["C_SOURCE_BUILDER", "LLVM_SOURCE_BUILDER"]
-

--- a/tilelang/backend/cpu/passes.py
+++ b/tilelang/backend/cpu/passes.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from tilelang.backend.base import BackendPassHooks
+
+
+class CpuPassHooks(BackendPassHooks):
+    pass
+

--- a/tilelang/backend/cpu/passes.py
+++ b/tilelang/backend/cpu/passes.py
@@ -5,4 +5,3 @@ from tilelang.backend.base import BackendPassHooks
 
 class CpuPassHooks(BackendPassHooks):
     pass
-

--- a/tilelang/backend/cpu/target.py
+++ b/tilelang/backend/cpu/target.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from tilelang.backend.common.target import is_c_target, is_llvm_target
+
+__all__ = ["is_c_target", "is_llvm_target"]

--- a/tilelang/backend/errors.py
+++ b/tilelang/backend/errors.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+
+class BackendResolutionError(ValueError):
+    """Raised when no TileLang backend metadata can resolve a target."""
+
+
+class BackendCodegenError(ValueError):
+    """Raised when resolved backend metadata cannot perform requested codegen."""
+

--- a/tilelang/backend/errors.py
+++ b/tilelang/backend/errors.py
@@ -7,4 +7,3 @@ class BackendResolutionError(ValueError):
 
 class BackendCodegenError(ValueError):
     """Raised when resolved backend metadata cannot perform requested codegen."""
-

--- a/tilelang/backend/execution.py
+++ b/tilelang/backend/execution.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from typing import Any
+
+from tilelang.backend.common.target import is_cutedsl_target, is_metal_target
+
+
+def create_execution_adapter(
+    execution_backend: str,
+    *,
+    artifact,
+    params,
+    result_idx,
+    target,
+    func_or_mod,
+    verbose: bool,
+    pass_configs: dict[str, Any] | None,
+    compile_flags: list[str] | None,
+):
+    if execution_backend == "tvm_ffi":
+        from tilelang.jit.adapter.tvm_ffi import TVMFFIKernelAdapter
+
+        assert artifact.rt_mod is not None, "tvm_ffi backend requires a runtime module."
+        return TVMFFIKernelAdapter(
+            params=params,
+            result_idx=result_idx,
+            target=target,
+            func_or_mod=func_or_mod,
+            host_mod=artifact.host_mod,
+            device_mod=artifact.device_mod,
+            rt_mod=artifact.rt_mod,
+            device_kernel_source=artifact.kernel_source,
+            verbose=verbose,
+            pass_configs=pass_configs,
+            compile_flags=compile_flags,
+        )
+
+    if execution_backend == "cython":
+        from tilelang.jit.adapter.cython import CythonKernelAdapter
+
+        return CythonKernelAdapter(
+            params=params,
+            result_idx=result_idx,
+            target=target,
+            func_or_mod=func_or_mod,
+            host_mod=artifact.host_mod,
+            device_mod=artifact.device_mod,
+            device_kernel_source=artifact.kernel_source,
+            verbose=verbose,
+            pass_configs=pass_configs,
+            compile_flags=compile_flags,
+        )
+
+    if execution_backend == "nvrtc":
+        from tilelang.jit.adapter.nvrtc import NVRTCKernelAdapter
+
+        return NVRTCKernelAdapter(
+            params=params,
+            result_idx=result_idx,
+            target=target,
+            func_or_mod=func_or_mod,
+            host_mod=artifact.host_mod,
+            device_mod=artifact.device_mod,
+            device_kernel_source=artifact.kernel_source,
+            verbose=verbose,
+            pass_configs=pass_configs,
+            compile_flags=compile_flags,
+        )
+
+    if execution_backend == "torch":
+        from tilelang.jit.adapter.torch import MetalKernelAdapter
+
+        assert is_metal_target(target)
+        return MetalKernelAdapter(
+            params=params,
+            result_idx=result_idx,
+            func_or_mod=func_or_mod,
+            device_mod=artifact.device_mod,
+            kernel_global_source=artifact.kernel_source,
+            verbose=verbose,
+        )
+
+    if execution_backend == "cutedsl":
+        from tilelang.jit.adapter.cutedsl import CuTeDSLKernelAdapter
+
+        assert is_cutedsl_target(target)
+        return CuTeDSLKernelAdapter(
+            params=params,
+            result_idx=result_idx,
+            target=target,
+            func_or_mod=func_or_mod,
+            host_mod=artifact.host_mod,
+            device_mod=artifact.device_mod,
+            device_kernel_source=artifact.kernel_source,
+            verbose=verbose,
+            pass_configs=pass_configs,
+            compile_flags=compile_flags,
+        )
+
+    raise ValueError(f"Invalid execution backend: {execution_backend}")
+
+
+def create_execution_adapter_from_database(
+    execution_backend: str,
+    *,
+    params,
+    result_idx,
+    target,
+    func_or_mod,
+    host_kernel_source: str,
+    device_kernel_source: str,
+    kernel_lib_path: str,
+    pass_configs: dict[str, Any] | None = None,
+    compile_flags: list[str] | None = None,
+):
+    if execution_backend == "tvm_ffi":
+        from tilelang.jit.adapter.tvm_ffi import TVMFFIKernelAdapter
+
+        return TVMFFIKernelAdapter.from_database(
+            params=params,
+            result_idx=result_idx,
+            target=target,
+            func_or_mod=func_or_mod,
+            host_kernel_source=host_kernel_source,
+            device_kernel_source=device_kernel_source,
+            kernel_lib_path=kernel_lib_path,
+            pass_configs=pass_configs,
+            compile_flags=compile_flags,
+        )
+
+    if execution_backend == "cython":
+        from tilelang.jit.adapter.cython import CythonKernelAdapter
+
+        return CythonKernelAdapter.from_database(
+            params=params,
+            result_idx=result_idx,
+            target=target,
+            func_or_mod=func_or_mod,
+            host_kernel_source=host_kernel_source,
+            device_kernel_source=device_kernel_source,
+            kernel_lib_path=kernel_lib_path,
+            pass_configs=pass_configs,
+        )
+
+    if execution_backend == "nvrtc":
+        from tilelang.jit.adapter.nvrtc import NVRTCKernelAdapter
+
+        return NVRTCKernelAdapter.from_database(
+            params=params,
+            result_idx=result_idx,
+            target=target,
+            func_or_mod=func_or_mod,
+            host_kernel_source=host_kernel_source,
+            device_kernel_source=device_kernel_source,
+            kernel_lib_path=kernel_lib_path,
+            pass_configs=pass_configs,
+            compile_flags=compile_flags,
+        )
+
+    if execution_backend == "cutedsl":
+        from tilelang.jit.adapter.cutedsl import CuTeDSLKernelAdapter
+
+        return CuTeDSLKernelAdapter.from_database(
+            params=params,
+            result_idx=result_idx,
+            target=target,
+            func_or_mod=func_or_mod,
+            host_kernel_source=host_kernel_source,
+            device_kernel_source=device_kernel_source,
+            kernel_lib_path=kernel_lib_path,
+            pass_configs=pass_configs,
+            compile_flags=compile_flags,
+        )
+
+    raise ValueError(f"Invalid execution backend: {execution_backend}")

--- a/tilelang/backend/execution.py
+++ b/tilelang/backend/execution.py
@@ -2,7 +2,23 @@ from __future__ import annotations
 
 from typing import Any
 
-from tilelang.backend.common.target import is_cutedsl_target, is_metal_target
+from tvm.target import Target
+
+from tilelang.backend.base import ExecutionBackendSpec, LibraryCompileSpec
+from tilelang.backend.registry import get_device_backend, resolve_execution_backend
+
+
+def get_execution_spec(target: Target, execution_backend: str | None) -> ExecutionBackendSpec:
+    resolved = resolve_execution_backend(execution_backend, target)
+    return get_device_backend(target).execution_spec(resolved)
+
+
+def _first_execution_spec_with(target: Target, attr_name: str) -> ExecutionBackendSpec:
+    backend = get_device_backend(target)
+    for spec in backend.execution_specs:
+        if getattr(spec, attr_name) is not None:
+            return spec
+    raise ValueError(f"Backend '{backend.name}' does not provide execution metadata '{attr_name}'")
 
 
 def create_execution_adapter(
@@ -17,87 +33,17 @@ def create_execution_adapter(
     pass_configs: dict[str, Any] | None,
     compile_flags: list[str] | None,
 ):
-    if execution_backend == "tvm_ffi":
-        from tilelang.jit.adapter.tvm_ffi import TVMFFIKernelAdapter
-
-        assert artifact.rt_mod is not None, "tvm_ffi backend requires a runtime module."
-        return TVMFFIKernelAdapter(
-            params=params,
-            result_idx=result_idx,
-            target=target,
-            func_or_mod=func_or_mod,
-            host_mod=artifact.host_mod,
-            device_mod=artifact.device_mod,
-            rt_mod=artifact.rt_mod,
-            device_kernel_source=artifact.kernel_source,
-            verbose=verbose,
-            pass_configs=pass_configs,
-            compile_flags=compile_flags,
-        )
-
-    if execution_backend == "cython":
-        from tilelang.jit.adapter.cython import CythonKernelAdapter
-
-        return CythonKernelAdapter(
-            params=params,
-            result_idx=result_idx,
-            target=target,
-            func_or_mod=func_or_mod,
-            host_mod=artifact.host_mod,
-            device_mod=artifact.device_mod,
-            device_kernel_source=artifact.kernel_source,
-            verbose=verbose,
-            pass_configs=pass_configs,
-            compile_flags=compile_flags,
-        )
-
-    if execution_backend == "nvrtc":
-        from tilelang.jit.adapter.nvrtc import NVRTCKernelAdapter
-
-        return NVRTCKernelAdapter(
-            params=params,
-            result_idx=result_idx,
-            target=target,
-            func_or_mod=func_or_mod,
-            host_mod=artifact.host_mod,
-            device_mod=artifact.device_mod,
-            device_kernel_source=artifact.kernel_source,
-            verbose=verbose,
-            pass_configs=pass_configs,
-            compile_flags=compile_flags,
-        )
-
-    if execution_backend == "torch":
-        from tilelang.jit.adapter.torch import MetalKernelAdapter
-
-        assert is_metal_target(target)
-        return MetalKernelAdapter(
-            params=params,
-            result_idx=result_idx,
-            func_or_mod=func_or_mod,
-            device_mod=artifact.device_mod,
-            kernel_global_source=artifact.kernel_source,
-            verbose=verbose,
-        )
-
-    if execution_backend == "cutedsl":
-        from tilelang.jit.adapter.cutedsl import CuTeDSLKernelAdapter
-
-        assert is_cutedsl_target(target)
-        return CuTeDSLKernelAdapter(
-            params=params,
-            result_idx=result_idx,
-            target=target,
-            func_or_mod=func_or_mod,
-            host_mod=artifact.host_mod,
-            device_mod=artifact.device_mod,
-            device_kernel_source=artifact.kernel_source,
-            verbose=verbose,
-            pass_configs=pass_configs,
-            compile_flags=compile_flags,
-        )
-
-    raise ValueError(f"Invalid execution backend: {execution_backend}")
+    spec = get_execution_spec(target, execution_backend)
+    return spec.adapter_factory(
+        artifact=artifact,
+        params=params,
+        result_idx=result_idx,
+        target=target,
+        func_or_mod=func_or_mod,
+        verbose=verbose,
+        pass_configs=pass_configs,
+        compile_flags=compile_flags,
+    )
 
 
 def create_execution_adapter_from_database(
@@ -113,63 +59,37 @@ def create_execution_adapter_from_database(
     pass_configs: dict[str, Any] | None = None,
     compile_flags: list[str] | None = None,
 ):
-    if execution_backend == "tvm_ffi":
-        from tilelang.jit.adapter.tvm_ffi import TVMFFIKernelAdapter
+    spec = get_execution_spec(target, execution_backend)
+    if spec.database_adapter_factory is None:
+        raise ValueError(f"Execution backend '{execution_backend}' does not support database cache loading")
+    return spec.database_adapter_factory(
+        params=params,
+        result_idx=result_idx,
+        target=target,
+        func_or_mod=func_or_mod,
+        host_kernel_source=host_kernel_source,
+        device_kernel_source=device_kernel_source,
+        kernel_lib_path=kernel_lib_path,
+        pass_configs=pass_configs,
+        compile_flags=compile_flags,
+    )
 
-        return TVMFFIKernelAdapter.from_database(
-            params=params,
-            result_idx=result_idx,
-            target=target,
-            func_or_mod=func_or_mod,
-            host_kernel_source=host_kernel_source,
-            device_kernel_source=device_kernel_source,
-            kernel_lib_path=kernel_lib_path,
-            pass_configs=pass_configs,
-            compile_flags=compile_flags,
-        )
 
-    if execution_backend == "cython":
-        from tilelang.jit.adapter.cython import CythonKernelAdapter
+def create_c_source_wrapper(device_target: Target, **kwargs):
+    spec = _first_execution_spec_with(device_target, "c_source_wrapper_factory")
+    return spec.c_source_wrapper_factory(**kwargs)
 
-        return CythonKernelAdapter.from_database(
-            params=params,
-            result_idx=result_idx,
-            target=target,
-            func_or_mod=func_or_mod,
-            host_kernel_source=host_kernel_source,
-            device_kernel_source=device_kernel_source,
-            kernel_lib_path=kernel_lib_path,
-            pass_configs=pass_configs,
-        )
 
-    if execution_backend == "nvrtc":
-        from tilelang.jit.adapter.nvrtc import NVRTCKernelAdapter
+def create_python_source_wrapper(device_target: Target, **kwargs):
+    spec = _first_execution_spec_with(device_target, "python_source_wrapper_factory")
+    return spec.python_source_wrapper_factory(**kwargs)
 
-        return NVRTCKernelAdapter.from_database(
-            params=params,
-            result_idx=result_idx,
-            target=target,
-            func_or_mod=func_or_mod,
-            host_kernel_source=host_kernel_source,
-            device_kernel_source=device_kernel_source,
-            kernel_lib_path=kernel_lib_path,
-            pass_configs=pass_configs,
-            compile_flags=compile_flags,
-        )
 
-    if execution_backend == "cutedsl":
-        from tilelang.jit.adapter.cutedsl import CuTeDSLKernelAdapter
+def get_library_compile_spec(target: Target) -> LibraryCompileSpec:
+    spec = _first_execution_spec_with(target, "library_compile_spec")
+    return spec.library_compile_spec
 
-        return CuTeDSLKernelAdapter.from_database(
-            params=params,
-            result_idx=result_idx,
-            target=target,
-            func_or_mod=func_or_mod,
-            host_kernel_source=host_kernel_source,
-            device_kernel_source=device_kernel_source,
-            kernel_lib_path=kernel_lib_path,
-            pass_configs=pass_configs,
-            compile_flags=compile_flags,
-        )
 
-    raise ValueError(f"Invalid execution backend: {execution_backend}")
+def get_kernel_cache(target: Target, execution_backend: str):
+    spec = get_execution_spec(target, execution_backend)
+    return spec.cache_factory()

--- a/tilelang/backend/nvidia/__init__.py
+++ b/tilelang/backend/nvidia/__init__.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from tilelang.backend.base import DeviceBackend
+
+from .execution import (
+    CUDA_DEFAULT_EXECUTION_BACKEND,
+    CUDA_EXECUTION_BACKENDS,
+    CUTEDSL_DEFAULT_EXECUTION_BACKEND,
+    CUTEDSL_EXECUTION_BACKENDS,
+    unavailable_cuda_execution_backends,
+)
+from .ffi import CUDA_COMPILED_BUILDER, CUDA_SOURCE_BUILDER, CUTEDSL_SOURCE_BUILDER
+from .passes import NvidiaPassHooks
+from .target import is_cutedsl_target, is_tilelang_cuda_target
+
+
+def get_backends() -> tuple[DeviceBackend, ...]:
+    hooks = NvidiaPassHooks()
+    return (
+        DeviceBackend(
+            name="cutedsl",
+            family="nvidia",
+            match_target=is_cutedsl_target,
+            source_builder=CUTEDSL_SOURCE_BUILDER,
+            compiled_builder=None,
+            execution_backends=CUTEDSL_EXECUTION_BACKENDS,
+            default_execution_backend=CUTEDSL_DEFAULT_EXECUTION_BACKEND,
+            source_kind="cutedsl_py",
+            pass_hooks=hooks,
+            metadata={"dialect": "cutedsl"},
+        ),
+        DeviceBackend(
+            name="nvidia",
+            family="nvidia",
+            match_target=is_tilelang_cuda_target,
+            source_builder=CUDA_SOURCE_BUILDER,
+            compiled_builder=CUDA_COMPILED_BUILDER,
+            execution_backends=CUDA_EXECUTION_BACKENDS,
+            default_execution_backend=CUDA_DEFAULT_EXECUTION_BACKEND,
+            source_kind="cuda",
+            pass_hooks=hooks,
+            unavailable_execution_backends=unavailable_cuda_execution_backends,
+            metadata={"dialect": "cuda"},
+        ),
+    )
+

--- a/tilelang/backend/nvidia/__init__.py
+++ b/tilelang/backend/nvidia/__init__.py
@@ -5,8 +5,10 @@ from tilelang.backend.base import DeviceBackend
 from .execution import (
     CUDA_DEFAULT_EXECUTION_BACKEND,
     CUDA_EXECUTION_BACKENDS,
+    CUDA_EXECUTION_SPECS,
     CUTEDSL_DEFAULT_EXECUTION_BACKEND,
     CUTEDSL_EXECUTION_BACKENDS,
+    CUTEDSL_EXECUTION_SPECS,
     unavailable_cuda_execution_backends,
 )
 from .ffi import CUDA_COMPILED_BUILDER, CUDA_SOURCE_BUILDER, CUTEDSL_SOURCE_BUILDER
@@ -26,6 +28,7 @@ def get_backends() -> tuple[DeviceBackend, ...]:
             execution_backends=CUTEDSL_EXECUTION_BACKENDS,
             default_execution_backend=CUTEDSL_DEFAULT_EXECUTION_BACKEND,
             source_kind="cutedsl_py",
+            execution_specs=CUTEDSL_EXECUTION_SPECS,
             pass_hooks=hooks,
             metadata={"dialect": "cutedsl"},
         ),
@@ -38,9 +41,9 @@ def get_backends() -> tuple[DeviceBackend, ...]:
             execution_backends=CUDA_EXECUTION_BACKENDS,
             default_execution_backend=CUDA_DEFAULT_EXECUTION_BACKEND,
             source_kind="cuda",
+            execution_specs=CUDA_EXECUTION_SPECS,
             pass_hooks=hooks,
             unavailable_execution_backends=unavailable_cuda_execution_backends,
             metadata={"dialect": "cuda"},
         ),
     )
-

--- a/tilelang/backend/nvidia/execution.py
+++ b/tilelang/backend/nvidia/execution.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+
+CUDA_EXECUTION_BACKENDS = ("tvm_ffi", "nvrtc", "cython")
+CUDA_DEFAULT_EXECUTION_BACKEND = "tvm_ffi"
+CUTEDSL_EXECUTION_BACKENDS = ("cutedsl",)
+CUTEDSL_DEFAULT_EXECUTION_BACKEND = "cutedsl"
+
+
+def unavailable_cuda_execution_backends() -> tuple[str, ...]:
+    try:
+        from tilelang.jit.adapter.nvrtc import is_nvrtc_available
+    except Exception:
+        return ()
+
+    return () if is_nvrtc_available else ("nvrtc",)
+

--- a/tilelang/backend/nvidia/execution.py
+++ b/tilelang/backend/nvidia/execution.py
@@ -1,10 +1,176 @@
 from __future__ import annotations
 
+from typing import Any
 
-CUDA_EXECUTION_BACKENDS = ("tvm_ffi", "nvrtc", "cython")
+from tvm.target import Target
+
+from tilelang.backend.base import CacheArtifactSpec, ExecutionBackendSpec, LibraryCompileSpec
+from tilelang.backend.common.execution import make_cython_execution_spec, make_tvm_ffi_execution_spec
+from tilelang.transform import PassConfigKey
+
+
 CUDA_DEFAULT_EXECUTION_BACKEND = "tvm_ffi"
-CUTEDSL_EXECUTION_BACKENDS = ("cutedsl",)
 CUTEDSL_DEFAULT_EXECUTION_BACKEND = "cutedsl"
+
+
+def _cuda_source_wrapper(**kwargs):
+    from tilelang.jit.adapter.wrapper import TLCUDASourceWrapper
+
+    return TLCUDASourceWrapper(**kwargs)
+
+
+def _cuda_nvrtc_source_wrapper(**kwargs):
+    from tilelang.jit.adapter.nvrtc import TLNVRTCSourceWrapper
+
+    return TLNVRTCSourceWrapper(**kwargs)
+
+
+def _cutedsl_source_wrapper(**kwargs):
+    from tilelang.jit.adapter.cutedsl import TLCuTeDSLSourceWrapper
+
+    return TLCuTeDSLSourceWrapper(**kwargs)
+
+
+def _cuda_library_command(target: Target, source_path: str, library_path: str, pass_configs: dict[str, Any]) -> list[str]:
+    from tilelang.contrib.nvcc import get_nvcc_compiler, get_target_arch, get_target_compute_version
+    from tilelang.env import CUTLASS_INCLUDE_DIR, TILELANG_TEMPLATE_PATH
+
+    target_arch = get_target_arch(get_target_compute_version(target))
+    command = [
+        get_nvcc_compiler(),
+        "-std=c++17",
+        "-w",
+        "-Xcudafe",
+        "--diag_suppress=177",
+        "--compiler-options",
+        "-fPIC",
+        "-lineinfo",
+        "--shared",
+        source_path,
+        "-lcuda",
+        "-gencode",
+        f"arch=compute_{target_arch},code=sm_{target_arch}",
+    ]
+
+    if pass_configs.get(PassConfigKey.TL_ENABLE_FAST_MATH, False):
+        command += ["--use_fast_math"]
+
+    ptxas_usage_level = pass_configs.get(PassConfigKey.TL_PTXAS_REGISTER_USAGE_LEVEL, None)
+    if ptxas_usage_level is not None:
+        command += [f"--ptxas-options=--register-usage-level={int(ptxas_usage_level)}"]
+
+    if pass_configs.get(PassConfigKey.TL_ENABLE_PTXAS_VERBOSE_OUTPUT, False):
+        command += ["--ptxas-options=--verbose"]
+
+    command += [
+        "-I" + CUTLASS_INCLUDE_DIR,
+        "-I" + TILELANG_TEMPLATE_PATH,
+        "-o",
+        library_path,
+    ]
+    return command
+
+
+CUDA_LIBRARY_COMPILE_SPEC = LibraryCompileSpec(
+    source_suffix=".cu",
+    library_suffix=".so",
+    command_factory=_cuda_library_command,
+)
+
+
+def _create_nvrtc_adapter(**kwargs):
+    from tilelang.jit.adapter.nvrtc import NVRTCKernelAdapter
+
+    artifact = kwargs.pop("artifact")
+    return NVRTCKernelAdapter(
+        params=kwargs["params"],
+        result_idx=kwargs["result_idx"],
+        target=kwargs["target"],
+        func_or_mod=kwargs["func_or_mod"],
+        host_mod=artifact.host_mod,
+        device_mod=artifact.device_mod,
+        device_kernel_source=artifact.kernel_source,
+        verbose=kwargs["verbose"],
+        pass_configs=kwargs["pass_configs"],
+        compile_flags=kwargs["compile_flags"],
+    )
+
+
+def _create_nvrtc_adapter_from_database(**kwargs):
+    from tilelang.jit.adapter.nvrtc import NVRTCKernelAdapter
+
+    return NVRTCKernelAdapter.from_database(**kwargs)
+
+
+def _create_nvrtc_cache():
+    from tilelang.jit.adapter.nvrtc.kernel_cache import NVRTCKernelCache
+
+    return NVRTCKernelCache()
+
+
+def _create_cutedsl_adapter(**kwargs):
+    from tilelang.jit.adapter.cutedsl import CuTeDSLKernelAdapter
+
+    artifact = kwargs.pop("artifact")
+    return CuTeDSLKernelAdapter(
+        params=kwargs["params"],
+        result_idx=kwargs["result_idx"],
+        target=kwargs["target"],
+        func_or_mod=kwargs["func_or_mod"],
+        host_mod=artifact.host_mod,
+        device_mod=artifact.device_mod,
+        device_kernel_source=artifact.kernel_source,
+        verbose=kwargs["verbose"],
+        pass_configs=kwargs["pass_configs"],
+        compile_flags=kwargs["compile_flags"],
+    )
+
+
+def _create_cutedsl_adapter_from_database(**kwargs):
+    from tilelang.jit.adapter.cutedsl import CuTeDSLKernelAdapter
+
+    return CuTeDSLKernelAdapter.from_database(**kwargs)
+
+
+def _create_cutedsl_cache():
+    from tilelang.jit.adapter.cutedsl.kernel_cache import CuTeDSLKernelCache
+
+    return CuTeDSLKernelCache()
+
+
+CUDA_EXECUTION_SPECS = (
+    make_tvm_ffi_execution_spec(),
+    ExecutionBackendSpec(
+        name="nvrtc",
+        adapter_factory=_create_nvrtc_adapter,
+        database_adapter_factory=_create_nvrtc_adapter_from_database,
+        cache_factory=_create_nvrtc_cache,
+        cache_artifact=CacheArtifactSpec(kernel_lib_path="kernel.cubin", extra_required_paths=("kernel.py",)),
+        python_source_wrapper_factory=_cuda_nvrtc_source_wrapper,
+    ),
+    make_cython_execution_spec(
+        c_source_wrapper_factory=_cuda_source_wrapper,
+        library_compile_spec=CUDA_LIBRARY_COMPILE_SPEC,
+    ),
+)
+CUDA_EXECUTION_BACKENDS = tuple(spec.name for spec in CUDA_EXECUTION_SPECS)
+
+CUTEDSL_EXECUTION_SPECS = (
+    ExecutionBackendSpec(
+        name="cutedsl",
+        adapter_factory=_create_cutedsl_adapter,
+        database_adapter_factory=_create_cutedsl_adapter_from_database,
+        cache_factory=_create_cutedsl_cache,
+        cache_artifact=CacheArtifactSpec(
+            kernel_lib_path="kernel.py",
+            device_kernel_path="kernel.py",
+            host_kernel_path="kernel.py",
+            extra_required_paths=("launcher_lib.so",),
+        ),
+        python_source_wrapper_factory=_cutedsl_source_wrapper,
+    ),
+)
+CUTEDSL_EXECUTION_BACKENDS = tuple(spec.name for spec in CUTEDSL_EXECUTION_SPECS)
 
 
 def unavailable_cuda_execution_backends() -> tuple[str, ...]:
@@ -14,4 +180,3 @@ def unavailable_cuda_execution_backends() -> tuple[str, ...]:
         return ()
 
     return () if is_nvrtc_available else ("nvrtc",)
-

--- a/tilelang/backend/nvidia/ffi.py
+++ b/tilelang/backend/nvidia/ffi.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from tilelang.backend.base import FFIBuilderRef
+
+
+CUDA_SOURCE_BUILDER = FFIBuilderRef("target.build.tilelang_cuda_without_compile", "source")
+CUDA_COMPILED_BUILDER = FFIBuilderRef("target.build.tilelang_cuda", "compiled")
+CUTEDSL_SOURCE_BUILDER = FFIBuilderRef("target.build.tilelang_cutedsl_without_compile", "source")
+

--- a/tilelang/backend/nvidia/ffi.py
+++ b/tilelang/backend/nvidia/ffi.py
@@ -6,4 +6,3 @@ from tilelang.backend.base import FFIBuilderRef
 CUDA_SOURCE_BUILDER = FFIBuilderRef("target.build.tilelang_cuda_without_compile", "source")
 CUDA_COMPILED_BUILDER = FFIBuilderRef("target.build.tilelang_cuda", "compiled")
 CUTEDSL_SOURCE_BUILDER = FFIBuilderRef("target.build.tilelang_cutedsl_without_compile", "source")
-

--- a/tilelang/backend/nvidia/passes.py
+++ b/tilelang/backend/nvidia/passes.py
@@ -1,8 +1,62 @@
 from __future__ import annotations
 
+import tilelang
 from tilelang.backend.base import BackendPassHooks
+from tilelang.contrib.nvcc import have_pdl, have_tma
+from tilelang.transform import PassContext
+from tvm import IRModule
+from tvm.target import Target
+
+
+def allow_warp_specialized(pass_ctx: PassContext | None = None, target: Target | None = None) -> bool:
+    if pass_ctx is None:
+        pass_ctx = tilelang.transform.get_pass_context()
+    if target is None or (not have_tma(target)):
+        return False
+    disable_warp_specialized = pass_ctx.config.get("tl.disable_warp_specialized", False)
+    return not disable_warp_specialized
 
 
 class NvidiaPassHooks(BackendPassHooks):
-    pass
+    def adjust_aggressive_shared_memory_merge(self, enabled: bool, target: Target) -> bool:
+        if allow_warp_specialized(target=target):
+            return False
+        return enabled
 
+    def pre_layout(self, mod: IRModule, target: Target) -> IRModule:
+        if allow_warp_specialized(target=target):
+            mod = tilelang.transform.ProducerConsumerWarpSpecialized()(mod)
+        return tilelang.transform.LowerBlackwell2SM()(mod)
+
+    def post_tile_lowering(self, mod: IRModule, target: Target) -> IRModule:
+        return tilelang.transform.LowerL2Persistent()(mod)
+
+    def optimize_entry(self, mod: IRModule, target: Target) -> IRModule:
+        return tilelang.transform.LowerSharedTmem()(mod)
+
+    def lower_shared_barrier(self, mod: IRModule, target: Target) -> IRModule:
+        return tilelang.transform.LowerSharedBarrier()(mod)
+
+    def after_shared_barrier_lowering(self, mod: IRModule, target: Target, *, has_tma: bool) -> IRModule:
+        if has_tma:
+            mod = tilelang.transform.FuseMBarrierArriveExpectTx()(mod)
+        return mod
+
+    def before_split_host_device(self, mod: IRModule, target: Target) -> IRModule:
+        mod = tilelang.transform.LowerLDGSTG()(mod)
+        return tilelang.transform.LowerHopperIntrin()(mod)
+
+    def after_split_host_device(self, mod: IRModule, target: Target) -> IRModule:
+        return tilelang.transform.MarkCudaSyncCalls(have_pdl(target))(mod)
+
+    def after_shared_memory_planning(self, mod: IRModule, target: Target) -> IRModule:
+        return tilelang.transform.InjectFenceProxy()(mod)
+
+    def after_shared_sync(self, mod: IRModule, target: Target) -> IRModule:
+        mod = tilelang.transform.InjectTcgen05Fence()(mod)
+        if allow_warp_specialized(target=target):
+            mod = tilelang.transform.AnnotateWarpGroupRegAlloc()(mod)
+        return mod
+
+    def before_device_codegen(self, mod: IRModule, target: Target) -> IRModule:
+        return tilelang.transform.PersistThreadblock()(mod)

--- a/tilelang/backend/nvidia/passes.py
+++ b/tilelang/backend/nvidia/passes.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from tilelang.backend.base import BackendPassHooks
+
+
+class NvidiaPassHooks(BackendPassHooks):
+    pass
+

--- a/tilelang/backend/nvidia/target.py
+++ b/tilelang/backend/nvidia/target.py
@@ -7,4 +7,3 @@ from tilelang.backend.common.target import is_cuda_target, is_cutedsl_target
 
 def is_tilelang_cuda_target(target: Target) -> bool:
     return is_cuda_target(target) and not is_cutedsl_target(target)
-

--- a/tilelang/backend/nvidia/target.py
+++ b/tilelang/backend/nvidia/target.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from tvm.target import Target
+
+from tilelang.backend.common.target import is_cuda_target, is_cutedsl_target
+
+
+def is_tilelang_cuda_target(target: Target) -> bool:
+    return is_cuda_target(target) and not is_cutedsl_target(target)
+

--- a/tilelang/backend/registry.py
+++ b/tilelang/backend/registry.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from tvm.target import Target
+
+from tilelang.backend import amd, apple, cpu, nvidia, webgpu
+from tilelang.backend.base import DeviceBackend
+from tilelang.backend.common.target import target_kind
+from tilelang.backend.errors import BackendResolutionError
+
+
+_CANONICAL_EXECUTION_BACKEND_MAP = {
+    "dlpack": "tvm_ffi",
+}
+
+_DEVICE_BACKENDS: tuple[DeviceBackend, ...] = (
+    *nvidia.get_backends(),
+    *amd.get_backends(),
+    *apple.get_backends(),
+    *cpu.get_backends(),
+    *webgpu.get_backends(),
+)
+
+
+def _canon_execution_backend(name: str | None) -> str | None:
+    if name is None:
+        return None
+    key = str(name).lower()
+    return _CANONICAL_EXECUTION_BACKEND_MAP.get(key, key)
+
+
+def _format_options(options: Iterable[str]) -> str:
+    return ", ".join(sorted(options))
+
+
+def registered_device_backends() -> tuple[DeviceBackend, ...]:
+    return _DEVICE_BACKENDS
+
+
+def get_device_backend(target: Target) -> DeviceBackend:
+    for backend in _DEVICE_BACKENDS:
+        if backend.match_target(target):
+            return backend
+
+    supported = _format_options(backend.name for backend in _DEVICE_BACKENDS)
+    raise BackendResolutionError(
+        f"No TileLang device backend is registered for target '{target_kind(target)}'. "
+        f"Registered backends: {supported}."
+    )
+
+
+def build_device_module(device_mod, target: Target, *, compile: bool):
+    backend = get_device_backend(target)
+    builder = backend.builder_for(compile=compile)
+    return builder.build(device_mod, target)
+
+
+def allowed_execution_backends_for_target(target: Target, *, include_unavailable: bool = True) -> list[str]:
+    return get_device_backend(target).allowed_execution_backends(include_unavailable=include_unavailable)
+
+
+def resolve_execution_backend(requested: str | None, target: Target) -> str:
+    req = _canon_execution_backend(requested)
+    backend = get_device_backend(target)
+    allowed_all = backend.allowed_execution_backends(include_unavailable=True)
+    allowed_available = backend.allowed_execution_backends(include_unavailable=False)
+
+    if req in (None, "auto"):
+        choice = backend.default_execution_backend
+        if choice not in allowed_available and allowed_available:
+            choice = allowed_available[0]
+        return choice
+
+    if req not in allowed_all:
+        raise ValueError(
+            f"Invalid execution backend '{requested}' for target '{target_kind(target)}'. "
+            f"Allowed: {_format_options(allowed_all)}. Tip: use execution_backend='auto'."
+        )
+
+    if req not in allowed_available:
+        raise ValueError(
+            f"Execution backend '{requested}' requires extra dependencies and is not available now. "
+            f"Try one of: {_format_options(allowed_available)}."
+        )
+
+    return req
+

--- a/tilelang/backend/registry.py
+++ b/tilelang/backend/registry.py
@@ -85,4 +85,3 @@ def resolve_execution_backend(requested: str | None, target: Target) -> str:
         )
 
     return req
-

--- a/tilelang/backend/webgpu/__init__.py
+++ b/tilelang/backend/webgpu/__init__.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from tilelang.backend.base import DeviceBackend
+
+from .execution import WEBGPU_DEFAULT_EXECUTION_BACKEND, WEBGPU_EXECUTION_BACKENDS
+from .ffi import WEBGPU_SOURCE_BUILDER
+from .passes import WebGPUPassHooks
+from .target import is_webgpu_target
+
+
+def get_backends() -> tuple[DeviceBackend, ...]:
+    return (
+        DeviceBackend(
+            name="webgpu",
+            family="webgpu",
+            match_target=is_webgpu_target,
+            source_builder=WEBGPU_SOURCE_BUILDER,
+            compiled_builder=None,
+            execution_backends=WEBGPU_EXECUTION_BACKENDS,
+            default_execution_backend=WEBGPU_DEFAULT_EXECUTION_BACKEND,
+            source_kind="webgpu",
+            pass_hooks=WebGPUPassHooks(),
+            metadata={"dialect": "webgpu"},
+        ),
+    )
+

--- a/tilelang/backend/webgpu/__init__.py
+++ b/tilelang/backend/webgpu/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from tilelang.backend.base import DeviceBackend
 
-from .execution import WEBGPU_DEFAULT_EXECUTION_BACKEND, WEBGPU_EXECUTION_BACKENDS
+from .execution import WEBGPU_DEFAULT_EXECUTION_BACKEND, WEBGPU_EXECUTION_BACKENDS, WEBGPU_EXECUTION_SPECS
 from .ffi import WEBGPU_SOURCE_BUILDER
 from .passes import WebGPUPassHooks
 from .target import is_webgpu_target
@@ -19,8 +19,8 @@ def get_backends() -> tuple[DeviceBackend, ...]:
             execution_backends=WEBGPU_EXECUTION_BACKENDS,
             default_execution_backend=WEBGPU_DEFAULT_EXECUTION_BACKEND,
             source_kind="webgpu",
+            execution_specs=WEBGPU_EXECUTION_SPECS,
             pass_hooks=WebGPUPassHooks(),
             metadata={"dialect": "webgpu"},
         ),
     )
-

--- a/tilelang/backend/webgpu/execution.py
+++ b/tilelang/backend/webgpu/execution.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+
+WEBGPU_EXECUTION_BACKENDS = ("cython", "tvm_ffi")
+WEBGPU_DEFAULT_EXECUTION_BACKEND = "cython"
+

--- a/tilelang/backend/webgpu/execution.py
+++ b/tilelang/backend/webgpu/execution.py
@@ -1,6 +1,15 @@
 from __future__ import annotations
 
+from tilelang.backend.common.execution import make_cython_execution_spec, make_tvm_ffi_execution_spec
 
-WEBGPU_EXECUTION_BACKENDS = ("cython", "tvm_ffi")
+
 WEBGPU_DEFAULT_EXECUTION_BACKEND = "cython"
 
+WEBGPU_EXECUTION_SPECS = (
+    make_cython_execution_spec(
+        c_source_wrapper_factory=None,
+        library_compile_spec=None,
+    ),
+    make_tvm_ffi_execution_spec(),
+)
+WEBGPU_EXECUTION_BACKENDS = tuple(spec.name for spec in WEBGPU_EXECUTION_SPECS)

--- a/tilelang/backend/webgpu/ffi.py
+++ b/tilelang/backend/webgpu/ffi.py
@@ -4,4 +4,3 @@ from tilelang.backend.base import FFIBuilderRef
 
 
 WEBGPU_SOURCE_BUILDER = FFIBuilderRef("target.build.webgpu", "source")
-

--- a/tilelang/backend/webgpu/ffi.py
+++ b/tilelang/backend/webgpu/ffi.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from tilelang.backend.base import FFIBuilderRef
+
+
+WEBGPU_SOURCE_BUILDER = FFIBuilderRef("target.build.webgpu", "source")
+

--- a/tilelang/backend/webgpu/passes.py
+++ b/tilelang/backend/webgpu/passes.py
@@ -5,4 +5,3 @@ from tilelang.backend.base import BackendPassHooks
 
 class WebGPUPassHooks(BackendPassHooks):
     pass
-

--- a/tilelang/backend/webgpu/passes.py
+++ b/tilelang/backend/webgpu/passes.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from tilelang.backend.base import BackendPassHooks
+
+
+class WebGPUPassHooks(BackendPassHooks):
+    pass
+

--- a/tilelang/backend/webgpu/target.py
+++ b/tilelang/backend/webgpu/target.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from tilelang.backend.common.target import is_webgpu_target
+
+__all__ = ["is_webgpu_target"]

--- a/tilelang/cache/__init__.py
+++ b/tilelang/cache/__init__.py
@@ -10,6 +10,21 @@ from tilelang.jit import JITKernel
 from tilelang import env
 
 
+def _build_dispatch_map():
+    from tilelang.backend.registry import registered_device_backends
+
+    dispatch = {}
+    for backend in registered_device_backends():
+        for spec in backend.execution_specs:
+            if spec.name in dispatch:
+                continue
+            dispatch[spec.name] = spec.cache_factory()
+    return dispatch
+
+
+_dispatch_map = _build_dispatch_map()
+
+
 def cached(
     func: PrimFunc = None,
     out_idx: list[int] = None,
@@ -36,7 +51,6 @@ def cached(
     # Normalize target and resolve execution backend before proceeding
     from tilelang.utils.target import determine_target as _determine_target
     from tilelang.jit.execution_backend import resolve_execution_backend, allowed_backends_for_target
-    from tilelang.backend.execution import get_kernel_cache
 
     norm_target = Target(_determine_target(target)) if isinstance(target, str) else target
     requested_backend = execution_backend
@@ -54,7 +68,10 @@ def cached(
                 norm_target.kind.name,
                 ", ".join(sorted(allowed_now)),
             )
-    kernel_cache = get_kernel_cache(norm_target, execution_backend)
+    if execution_backend not in _dispatch_map:
+        raise ValueError(f'Cannot find support for execution backend "{execution_backend}"')
+
+    kernel_cache = _dispatch_map[execution_backend]
     return kernel_cache.cached(
         func,
         out_idx,

--- a/tilelang/cache/__init__.py
+++ b/tilelang/cache/__init__.py
@@ -3,28 +3,11 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Literal
+from typing import Literal
 from tvm.target import Target
 from tvm.tir import PrimFunc
 from tilelang.jit import JITKernel
 from tilelang import env
-from tilelang.jit.adapter.cutedsl.kernel_cache import CuTeDSLKernelCache
-from tilelang.jit.adapter.cython.kernel_cache import CythonKernelCache
-from tilelang.jit.adapter.nvrtc.kernel_cache import NVRTCKernelCache
-from tilelang.jit.adapter.torch.kernel_cache import TorchKernelCache
-from tilelang.jit.adapter.kernel_cache import TVMFFIKernelCache
-
-if TYPE_CHECKING:
-    from .kernel_cache import KernelCache
-
-# Create a map of singleton instance of KernelCaches
-_dispatch_map: dict[str, KernelCache] = {
-    "tvm_ffi": TVMFFIKernelCache(),
-    "cython": CythonKernelCache(),
-    "nvrtc": NVRTCKernelCache(),
-    "cutedsl": CuTeDSLKernelCache(),
-    "torch": TorchKernelCache(),
-}
 
 
 def cached(
@@ -53,6 +36,7 @@ def cached(
     # Normalize target and resolve execution backend before proceeding
     from tilelang.utils.target import determine_target as _determine_target
     from tilelang.jit.execution_backend import resolve_execution_backend, allowed_backends_for_target
+    from tilelang.backend.execution import get_kernel_cache
 
     norm_target = Target(_determine_target(target)) if isinstance(target, str) else target
     requested_backend = execution_backend
@@ -70,20 +54,18 @@ def cached(
                 norm_target.kind.name,
                 ", ".join(sorted(allowed_now)),
             )
-    if execution_backend in _dispatch_map:
-        return _dispatch_map[execution_backend].cached(
-            func,
-            out_idx,
-            *args,
-            target=norm_target,
-            target_host=target_host,
-            execution_backend=execution_backend,
-            verbose=verbose,
-            pass_configs=pass_configs,
-            compile_flags=compile_flags,
-        )
-    else:
-        raise ValueError(f'Cannot find support for execution backend "{execution_backend}"')
+    kernel_cache = get_kernel_cache(norm_target, execution_backend)
+    return kernel_cache.cached(
+        func,
+        out_idx,
+        *args,
+        target=norm_target,
+        target_host=target_host,
+        execution_backend=execution_backend,
+        verbose=verbose,
+        pass_configs=pass_configs,
+        compile_flags=compile_flags,
+    )
 
 
 def clear_cache():

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -383,6 +383,28 @@ class KernelCache:
         """
         return os.path.join(self._get_cache_root(), key)
 
+    def _validate_backend_cache_artifact(self, target: str | Target, execution_backend: str) -> None:
+        from tilelang.backend.execution import get_execution_spec
+        from tilelang.utils.target import determine_target
+
+        norm_target = Target(determine_target(target)) if isinstance(target, str) else target
+        artifact = get_execution_spec(norm_target, execution_backend).cache_artifact
+        expected = {
+            "device_kernel_path": artifact.device_kernel_path,
+            "host_kernel_path": artifact.host_kernel_path,
+            "kernel_lib_path": artifact.kernel_lib_path,
+        }
+        actual = {
+            "device_kernel_path": self.device_kernel_path,
+            "host_kernel_path": self.host_kernel_path,
+            "kernel_lib_path": self.kernel_lib_path,
+        }
+        if expected != actual:
+            raise RuntimeError(
+                f"Kernel cache artifact metadata mismatch for execution backend '{execution_backend}': "
+                f"expected {expected}, got {actual}"
+            )
+
     @staticmethod
     def _load_binary(path: str):
         with open(path, "rb") as file:
@@ -423,6 +445,7 @@ class KernelCache:
         # Env-backed cache roots may change across tests or at runtime; recreate the
         # namespace-specific directories lazily here so direct save helpers keep working
         # even when the singleton instance is reused.
+        self._validate_backend_cache_artifact(kernel.target, kernel.execution_backend)
         KernelCache._create_dirs()
         cache_path = self._get_cache_path(key)
 
@@ -502,6 +525,7 @@ class KernelCache:
         Returns:
             JITKernel: The loaded kernel if found, None otherwise.
         """
+        self._validate_backend_cache_artifact(target, execution_backend)
         cache_path = self._get_cache_path(key)
         device_kernel_path = os.path.join(cache_path, self.device_kernel_path)
         host_kernel_path = os.path.join(cache_path, self.host_kernel_path)

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -10,6 +10,7 @@ from tvm import tir
 import tvm_ffi
 from tvm.ir import CallingConv
 from tvm.target import Target
+from tilelang.backend.registry import build_device_module
 from tilelang.contrib import hipcc, nvcc
 from tilelang.env import COMPOSABLE_KERNEL_INCLUDE_DIR, CUTLASS_INCLUDE_DIR, TILELANG_TEMPLATE_PATH
 from tilelang.transform import PassConfigKey
@@ -230,15 +231,7 @@ def device_codegen(device_mod: tvm.IRModule, target: Target) -> tvm.IRModule:
     device_mod = tir.transform.Simplify()(device_mod)
     device_mod = tilelang.transform.HoistBroadcastValues()(device_mod)
 
-    if target.kind.name == "cuda":
-        global_func = "target.build.tilelang_" + ("cutedsl" if "cutedsl" in target.keys else "cuda")
-        device_mod = tvm.ffi.get_global_func(global_func)(device_mod, target)
-    elif target.kind.name == "hip":
-        device_mod = tvm.ffi.get_global_func("target.build.tilelang_hip")(device_mod, target)
-    elif target.kind.name == "metal":
-        device_mod = tvm.ffi.get_global_func("target.build.metal")(device_mod, target)
-    else:
-        raise ValueError(f"Target {target.kind.name} is not supported")
+    device_mod = build_device_module(device_mod, target, compile=True)
 
     return device_mod
 
@@ -249,21 +242,7 @@ def device_codegen_without_compile(device_mod: tvm.IRModule, target: Target) -> 
     device_mod = tir.transform.Simplify()(device_mod)
     device_mod = tilelang.transform.HoistBroadcastValues()(device_mod)
 
-    if target.kind.name == "cuda":
-        global_func = "target.build.tilelang_" + ("cutedsl" if "cutedsl" in target.keys else "cuda") + "_without_compile"
-        device_mod = tvm.ffi.get_global_func(global_func)(device_mod, target)
-    elif target.kind.name == "hip":
-        device_mod = tvm.ffi.get_global_func("target.build.tilelang_hip_without_compile")(device_mod, target)
-    elif target.kind.name == "c":
-        device_mod = tvm.ffi.get_global_func("target.build.tilelang_c")(device_mod, target)
-    elif target.kind.name == "llvm":
-        device_mod = tvm.ffi.get_global_func("target.build.llvm")(device_mod, target)
-    elif target.kind.name == "webgpu":
-        device_mod = tvm.ffi.get_global_func("target.build.webgpu")(device_mod, target)
-    elif target.kind.name == "metal":
-        device_mod = tvm.ffi.get_global_func("target.build.metal")(device_mod, target)
-    else:
-        raise ValueError(f"Target {target.kind.name} is not supported")
+    device_mod = build_device_module(device_mod, target, compile=False)
 
     return device_mod
 

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -2,20 +2,9 @@ from __future__ import annotations
 from tvm import tir, IRModule
 from tvm.target import Target
 import tilelang
+from tilelang.backend.base import DeviceBackend
+from tilelang.backend.registry import get_device_backend
 from tilelang.transform import PassContext
-from tilelang.contrib.nvcc import have_tma, have_pdl
-
-
-def allow_warp_specialized(pass_ctx: PassContext | None = None, target: Target | None = None) -> bool:
-    # avoid circular import
-    from tilelang.jit.adapter.utils import is_cuda_target
-
-    if pass_ctx is None:
-        pass_ctx = tilelang.transform.get_pass_context()
-    if (not is_cuda_target(target)) or (not have_tma(target)):
-        return False
-    disable_warp_specialized = pass_ctx.config.get("tl.disable_warp_specialized", False)
-    return not disable_warp_specialized
 
 
 def module_has_tma(mod: IRModule) -> bool:
@@ -42,15 +31,18 @@ def allow_global_thread_synchronization(pass_ctx: PassContext | None = None) -> 
     return enable_global_thread_sync
 
 
-def should_enable_aggressive_merge(pass_ctx: PassContext | None = None, target: Target | None = None) -> bool:
+def should_enable_aggressive_merge(
+    pass_ctx: PassContext | None = None,
+    target: Target | None = None,
+    backend: DeviceBackend | None = None,
+) -> bool:
     if pass_ctx is None:
         pass_ctx = tilelang.transform.get_pass_context()
     enable_aggressive_merge = bool(pass_ctx.config.get(tilelang.PassConfigKey.TL_ENABLE_AGGRESSIVE_SHARED_MEMORY_MERGE, False))
-    if allow_warp_specialized(pass_ctx=pass_ctx, target=target):
-        # This is a workaround to avoid the bug in the MergeSharedMemoryAllocations pass
-        # when warp specialization is enabled, as different warp threads may access different
-        # buffers, but the liveness analysis is hard because we need to do pipeline.
-        enable_aggressive_merge = False
+    if backend is None and target is not None:
+        backend = get_device_backend(target)
+    if backend is not None and target is not None:
+        enable_aggressive_merge = backend.pass_hooks.adjust_aggressive_shared_memory_merge(enable_aggressive_merge, target)
     return enable_aggressive_merge
 
 
@@ -142,7 +134,6 @@ def PreLowerSemanticCheck(mod: IRModule) -> None:
 
 
 def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
-    # Bind the target device information to the module
     """
     Bind target information and progressively legalize and lower frontend Tile IR into a form suitable for downstream optimization and codegen.
 
@@ -163,6 +154,8 @@ def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
     Returns:
         IRModule: The transformed module, ready for target-specific optimization passes.
     """
+    backend = get_device_backend(target)
+    # Bind the target device information to the module
     mod = tir.transform.BindTarget(target)(mod)
 
     if should_force_let_inline():
@@ -181,17 +174,7 @@ def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.Simplify()(mod)
     # Set layouts for reducers
     mod = tilelang.transform.LayoutReducer()(mod)
-    # Tile-level warp specialization: runs before layout inference so that
-    # producer/consumer split happens at the high-level tile-op IR.
-    # The pass classifies copy ops as TMA/cp.async/sync inline (no prior
-    # InstructionAnnotation pass needed). Shared buffers are multi-versioned
-    # internally only for functions where the WS transformation actually
-    # applies.
-    if allow_warp_specialized(target=target):
-        mod = tilelang.transform.ProducerConsumerWarpSpecialized()(mod)
-    # Lower 2SM TCGEN5MMA and related on Blackwell target (must run before
-    # LayoutInference so that the use_2cta annotation is visible to infer_layout)
-    mod = tilelang.transform.LowerBlackwell2SM()(mod)
+    mod = backend.pass_hooks.pre_layout(mod, target)
     # Run pipeline planning and software-pipeline rewriting before layout
     # inference so inferred layouts see the final pipelined structure directly.
     mod = tilelang.transform.PipelinePlanning()(mod)
@@ -203,8 +186,7 @@ def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
     LayoutVisual(mod)
     # Lower high-level tile operations to low-level operations
     mod = tilelang.transform.LowerTileOp()(mod)
-    # Lower l2 persistent map
-    mod = tilelang.transform.LowerL2Persistent()(mod)
+    mod = backend.pass_hooks.post_tile_lowering(mod, target)
     # Decouple type cast vectorization constraints before vectorization
     mod = tilelang.transform.DecoupleTypeCast()(mod)
     # Legalize vectorized loops to ensure they are valid
@@ -225,9 +207,9 @@ def LowerAndLegalize(mod: IRModule, target: Target) -> IRModule:
 
 
 def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
+    backend = get_device_backend(target)
     pass_ctx = tilelang.transform.get_pass_context()
-    # Lower the shared.tmem into specific initialization slot
-    mod = tilelang.transform.LowerSharedTmem()(mod)
+    mod = backend.pass_hooks.optimize_entry(mod, target)
     # which may be introduced by the LegalizeSafeMemoryAccess
     mod = tilelang.transform.IfStmtBinding()(mod)
     has_tma = module_has_tma(mod)
@@ -235,9 +217,8 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
     # InjectSoftwarePipeline, so no late MVB barrier fixup is needed.
     # Buffer allocation placement is handled uniformly for both paths.
     mod = tilelang.transform.PlanAndUpdateBufferAllocationLocation()(mod)
-    mod = tilelang.transform.LowerSharedBarrier()(mod)
-    if has_tma:
-        mod = tilelang.transform.FuseMBarrierArriveExpectTx()(mod)
+    mod = backend.pass_hooks.lower_shared_barrier(mod, target)
+    mod = backend.pass_hooks.after_shared_barrier_lowering(mod, target, has_tma=has_tma)
     mod = tilelang.transform.HoistGlobalBufferAllocations()(mod)
     mod = tilelang.transform.LowerOpaqueBlock()(mod)
     mod = tilelang.transform.Simplify()(mod)
@@ -269,8 +250,7 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
     # the Legalization.
     mod = tir.transform.InferFragment()(mod)
     mod = tilelang.transform.LowerThreadAllreduce()(mod)
-    mod = tilelang.transform.LowerLDGSTG()(mod)
-    mod = tilelang.transform.LowerHopperIntrin()(mod)
+    mod = backend.pass_hooks.before_split_host_device(mod, target)
     # Global Barrier Synchronization must be applied before
     # SplitHostDevice pass, as the global barrier
     if allow_global_thread_synchronization():
@@ -278,33 +258,22 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.AnnotateDeviceRegions()(mod)
     mod = tilelang.transform.SplitHostDevice()(mod)
 
-    # Mark the function contains pdl_sync or pdl_trigger
-    mod = tilelang.transform.MarkCudaSyncCalls(have_pdl(target))(mod)
+    mod = backend.pass_hooks.after_split_host_device(mod, target)
 
     mod = tilelang.transform.AnnotateReadOnlyParams()(mod)
     # MergeSharedMemoryAllocations must be applied after SplitHostDevice
     # because the merged allocation site is at the beginning of each device function
-    enable_aggressive_merge = should_enable_aggressive_merge(pass_ctx=pass_ctx, target=target)
+    enable_aggressive_merge = should_enable_aggressive_merge(pass_ctx=pass_ctx, target=target, backend=backend)
     mod = tilelang.transform.MergeSharedMemoryAllocations(enable_aggressive_merge=enable_aggressive_merge)(mod)
-    # InjectFenceProxy is a no-op on targets that lack the TMA / async-proxy
-    # programming model; the pass itself checks the PrimFunc's target.
-    mod = tilelang.transform.InjectFenceProxy()(mod)
+    mod = backend.pass_hooks.after_shared_memory_planning(mod, target)
     mod = tilelang.transform.ThreadSync("shared")(mod)
     mod = tilelang.transform.ThreadSync("shared.dyn")(mod)
-    # Inject conservative tcgen05 fences on Blackwell (SM100+).
-    # Must run after ThreadSync so that tvm_storage_sync calls are present.
-    # The pass handles shared syncs and simple linear wait/use, use/arrive
-    # handoffs, and is a no-op on non-SM100 targets or functions without TMEM.
-    mod = tilelang.transform.InjectTcgen05Fence()(mod)
+    mod = backend.pass_hooks.after_shared_sync(mod, target)
     mod = tilelang.transform.MergeIfStmt()(mod)
-    # NOTE: LowerPTXAsyncCopy is applied earlier (before PipelinePlanning).
-    if allow_warp_specialized(pass_ctx=pass_ctx, target=target):
-        mod = tilelang.transform.AnnotateWarpGroupRegAlloc()(mod)
     mod = tilelang.transform.MakePackedAPI()(mod)
     mod = tilelang.transform.Simplify()(mod)
     mod = tilelang.transform.LowerDeviceKernelLaunch()(mod)
 
-    # Transform threadblock to persistent threadblock
-    mod = tilelang.transform.PersistThreadblock()(mod)
+    mod = backend.pass_hooks.before_device_codegen(mod, target)
 
     return mod

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -8,13 +8,7 @@ from typing import Any
 
 from tvm.target import Target
 
-from tilelang import tvm as tvm
-from tilelang.transform import PassConfigKey
-from tilelang.contrib.nvcc import get_nvcc_compiler, get_target_arch, get_target_compute_version
-from tilelang.contrib.rocm import find_rocm_path, get_rocm_arch
-from tilelang.env import TILELANG_TEMPLATE_PATH
-
-from .utils import is_cpu_target, is_cuda_target, is_hip_target
+from tilelang.backend.execution import get_library_compile_spec
 
 logger = logging.getLogger(__name__)
 
@@ -52,84 +46,13 @@ class LibraryGenerator:
     def compile_lib(self, timeout: float = None):
         target = self.target
         verbose = self.verbose
-        if is_cuda_target(target):
-            from tilelang.env import CUTLASS_INCLUDE_DIR
-
-            src = tempfile.NamedTemporaryFile(mode="w", suffix=".cu", delete=False)  # noqa: SIM115
-            target_arch = get_target_arch(get_target_compute_version(target))
-            libpath = src.name.replace(".cu", ".so")
-
-            enable_fast_math = self.pass_configs.get(PassConfigKey.TL_ENABLE_FAST_MATH, False)
-
-            ptxas_usage_level = self.pass_configs.get(PassConfigKey.TL_PTXAS_REGISTER_USAGE_LEVEL, None)
-            if ptxas_usage_level is not None:
-                ptxas_usage_level = int(ptxas_usage_level)
-            verbose_ptxas_output = self.pass_configs.get(PassConfigKey.TL_ENABLE_PTXAS_VERBOSE_OUTPUT, False)
-
-            command = [
-                get_nvcc_compiler(),
-                "-std=c++17",
-                "-w",  # Disable all warning messages
-                "-Xcudafe",
-                "--diag_suppress=177",
-                "--compiler-options",
-                "-fPIC",
-                "-lineinfo",
-                "--shared",
-                src.name,
-                "-lcuda",
-                "-gencode",
-                f"arch=compute_{target_arch},code=sm_{target_arch}",
-            ]
-            if enable_fast_math:
-                command += ["--use_fast_math"]
-            if ptxas_usage_level is not None:
-                command += [f"--ptxas-options=--register-usage-level={ptxas_usage_level}"]
-            if verbose_ptxas_output:
-                command += ["--ptxas-options=--verbose"]
-            command += [
-                "-I" + CUTLASS_INCLUDE_DIR,
-            ]
-
-        elif is_hip_target(target):
-            from tilelang.env import COMPOSABLE_KERNEL_INCLUDE_DIR
-
-            src = tempfile.NamedTemporaryFile(mode="w", suffix=".cpp", delete=False)  # noqa: SIM115
-            libpath = src.name.replace(".cpp", ".so")
-            rocm_path = find_rocm_path()
-            arch = get_rocm_arch(rocm_path)
-            command = [
-                "hipcc",
-                "-std=c++17",
-                "-fPIC",
-                f"--offload-arch={arch}",
-                "--shared",
-                src.name,
-            ]
-            command += [
-                "-I" + COMPOSABLE_KERNEL_INCLUDE_DIR,
-            ]
-        elif is_cpu_target(target):
-            from tilelang.contrib.cc import get_cplus_compiler
-
-            src = tempfile.NamedTemporaryFile(mode="w", suffix=".cpp", delete=False)  # noqa: SIM115
-            libpath = src.name.replace(".cpp", ".so")
-
-            command = [get_cplus_compiler(), "-std=c++17", "-fPIC", "-shared", src.name]
-            command += [
-                "-I" + TILELANG_TEMPLATE_PATH,
-            ]
-        else:
-            raise ValueError(f"Unsupported target: {target}")
-
-        command += [
-            "-I" + TILELANG_TEMPLATE_PATH,
-        ]
+        compile_spec = get_library_compile_spec(target)
+        src = tempfile.NamedTemporaryFile(mode="w", suffix=compile_spec.source_suffix, delete=False)  # noqa: SIM115
+        libpath = src.name[: -len(compile_spec.source_suffix)] + compile_spec.library_suffix
+        command = compile_spec.command_factory(target, src.name, libpath, self.pass_configs or {})
 
         if self.compile_flags:
             command += [item for flag in self.compile_flags for item in flag.split() if item not in command]
-
-        command += ["-o", libpath]
 
         src.write(self.lib_code)
         src.flush()

--- a/tilelang/jit/adapter/wrapper.py
+++ b/tilelang/jit/adapter/wrapper.py
@@ -5,14 +5,11 @@ from typing import Any
 from tvm import IRModule
 from tvm.target import Target
 
+from tilelang.backend.execution import create_c_source_wrapper, create_python_source_wrapper
+
 from .utils import (
-    is_metal_target,
-    is_cutedsl_target,
     match_declare_kernel,
     match_declare_kernel_cpu,
-    is_cuda_target,
-    is_hip_target,
-    is_cpu_target,
     get_annotated_mod,
     pythonic_expr,
     parse_function_call_args,
@@ -963,17 +960,8 @@ class TLWrapper(BaseWrapper):
     # Get Scheduled Rt Module and return source to be compiled
     def wrap(self, c_source: str):
         assert self.scheduled_ir_module is not None, "Please assign optimized module first."
-        if is_cuda_target(self.target):
-            wrapper_class = TLCUDASourceWrapper
-        elif is_hip_target(self.target):
-            wrapper_class = TLHIPSourceWrapper
-        elif is_cpu_target(self.target):
-            wrapper_class = TLCPUSourceWrapper
-        elif is_metal_target(self.target):
-            wrapper_class = TLMetalSourceWrapper
-        else:
-            raise ValueError(f"Unsupported platform: {self.arch.platform}")
-        wrapper = wrapper_class(
+        wrapper = create_c_source_wrapper(
+            self.target,
             scheduled_ir_module=self.scheduled_ir_module,
             source=c_source,
             target=self.target,
@@ -990,17 +978,8 @@ class TLPyWrapper(TLWrapper):
 
     def wrap(self, py_source: str):
         # assert self.scheduled_ir_module is not None, "Please assign optimized module first."
-        if is_cutedsl_target(self.target):
-            from tilelang.jit.adapter.cutedsl import TLCuTeDSLSourceWrapper
-
-            wrapper_class = TLCuTeDSLSourceWrapper
-        elif is_cuda_target(self.target):
-            from tilelang.jit.adapter.nvrtc import TLNVRTCSourceWrapper
-
-            wrapper_class = TLNVRTCSourceWrapper
-        else:
-            raise ValueError(f"Unsupported target for NVRTC backend: {self.target}")
-        wrapper = wrapper_class(
+        wrapper = create_python_source_wrapper(
+            self.target,
             scheduled_ir_module=self.scheduled_ir_module,
             source=py_source,
             target=self.target,

--- a/tilelang/jit/execution_backend.py
+++ b/tilelang/jit/execution_backend.py
@@ -1,66 +1,19 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
-
 from tvm.target import Target
-from tilelang.jit.adapter.utils import is_cutedsl_target
-
-# Canonical names for execution backends used internally
-_CANONICAL_MAP = {
-    "dlpack": "tvm_ffi",  # historical alias
-}
-
-
-def _canon_backend(name: str | None) -> str | None:
-    if name is None:
-        return None
-    key = str(name).lower()
-    return _CANONICAL_MAP.get(key, key)
-
-
-def _target_kind(target: Target) -> str:
-    # tvm.target.Target always has kind.name
-    return target.kind.name
+from tilelang.backend.registry import (
+    allowed_execution_backends_for_target,
+    resolve_execution_backend as _resolve_execution_backend,
+)
 
 
 def allowed_backends_for_target(target: Target, *, include_unavailable: bool = True) -> list[str]:
-    """Return allowed execution backends for a given TVM target kind.
+    """Return allowed execution backends for a given TVM target.
 
     include_unavailable: if False, this will filter out backends that are known
     to be unavailable at runtime (e.g., NVRTC without cuda-python installed).
     """
-    kind = _target_kind(target)
-
-    if is_cutedsl_target(target):
-        return ["cutedsl"]
-    elif kind == "cuda":
-        allowed = ["tvm_ffi", "nvrtc", "cython"]
-    elif kind == "hip":
-        allowed = ["tvm_ffi", "cython"]
-    elif kind == "metal":
-        allowed = ["tvm_ffi", "torch"]
-    elif kind == "c":  # CPU C backend
-        allowed = ["cython", "tvm_ffi"]
-    else:
-        # Fallback: prefer portable hosts
-        allowed = ["cython", "tvm_ffi"]
-
-    if not include_unavailable:
-        # Drop NVRTC if not importable
-        try:
-            from tilelang.jit.adapter.nvrtc import is_nvrtc_available  # lazy
-
-            if not is_nvrtc_available and "nvrtc" in allowed:
-                allowed = [b for b in allowed if b != "nvrtc"]
-        except Exception:
-            # Be conservative and keep nvrtc if detection itself fails
-            pass
-
-    return allowed
-
-
-def _format_options(options: Iterable[str]) -> str:
-    return ", ".join(sorted(options))
+    return allowed_execution_backends_for_target(target, include_unavailable=include_unavailable)
 
 
 def resolve_execution_backend(requested: str | None, target: Target) -> str:
@@ -71,36 +24,4 @@ def resolve_execution_backend(requested: str | None, target: Target) -> str:
     - Validates the combination (target, backend) and raises with helpful
       alternatives when invalid.
     """
-    req = _canon_backend(requested)
-    allowed_all = allowed_backends_for_target(target, include_unavailable=True)
-    allowed_avail = allowed_backends_for_target(target, include_unavailable=False)
-
-    # Default selection for auto/None
-    if req in (None, "auto"):
-        if is_cutedsl_target(target):
-            return "cutedsl"
-        kind = _target_kind(target)
-        if kind == "cuda" or kind == "metal" or kind == "hip":
-            choice = "tvm_ffi"
-        else:
-            choice = "cython"
-        # If the chosen default is not available (very rare), fall back to first available
-        if choice not in allowed_avail and allowed_avail:
-            choice = allowed_avail[0]
-        return choice
-
-    # Validate against allowed
-    if req not in allowed_all:
-        raise ValueError(
-            f"Invalid execution backend '{requested}' for target '{_target_kind(target)}'. "
-            f"Allowed: {_format_options(allowed_all)}. Tip: use execution_backend='auto'."
-        )
-
-    # Promote to availability-aware set for nicer errors (e.g., nvrtc not installed)
-    if req not in allowed_avail:
-        raise ValueError(
-            f"Execution backend '{requested}' requires extra dependencies and is not available now. "
-            f"Try one of: {_format_options(allowed_avail)}."
-        )
-
-    return req
+    return _resolve_execution_backend(requested, target)

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -7,8 +7,13 @@ try:
 except ImportError:  # Python < 3.10
     from typing_extensions import ParamSpec
 
+from tilelang.backend.execution import (
+    create_execution_adapter,
+    create_execution_adapter_from_database,
+    get_execution_spec,
+)
 from tilelang.backend.common.target import is_cuda_target
-from tilelang.backend.execution import create_execution_adapter, create_execution_adapter_from_database
+from tilelang.backend.registry import resolve_execution_backend
 from tvm.target import Target
 from tvm.tir import PrimFunc
 
@@ -59,7 +64,7 @@ class JITKernel(Generic[_P, _T]):
         self,
         func: PrimFunc = None,
         out_idx: list[int] | int = None,
-        execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"] = "tvm_ffi",
+        execution_backend: Literal["auto", "tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"] | None = "tvm_ffi",
         target: str | Target = "auto",
         target_host: str | Target = None,
         verbose: bool = False,
@@ -91,7 +96,6 @@ class JITKernel(Generic[_P, _T]):
             Whether to create a TorchFunction from a database.
         """
         self.prim_func = func
-        self.execution_backend = execution_backend
         self.target_host = target_host
         self.verbose = verbose
 
@@ -101,16 +105,10 @@ class JITKernel(Generic[_P, _T]):
 
         # Ensure the target is always a valid TVM Target object.
         self.target = determine_target(target, return_object=True)
+        self.execution_backend = resolve_execution_backend(execution_backend, self.target)
+        self.execution_spec = get_execution_spec(self.target, self.execution_backend)
 
-        # Validate the execution backend.
-        assert execution_backend in [
-            "tvm_ffi",
-            "cython",
-            "nvrtc",
-            "torch",
-            "cutedsl",
-        ], f"Invalid execution backend. {execution_backend}"
-        if execution_backend == "cython":
+        if self.execution_spec.requires_cxx_compiler:
             from tilelang.contrib.cc import get_cplus_compiler
 
             assert get_cplus_compiler() is not None, "Cython backend requires a C++ compiler, please install or use other backends."
@@ -229,8 +227,8 @@ class JITKernel(Generic[_P, _T]):
             )
 
         # Compile the function with TVM, optimizing with shared memory lowering.
-        enable_host_codegen = execution_backend == "tvm_ffi"
-        enable_device_compile = execution_backend == "tvm_ffi"
+        enable_host_codegen = self.execution_spec.requires_host_codegen
+        enable_device_compile = self.execution_spec.requires_device_compile
 
         # Additional pass instruments
         pass_instruments = []
@@ -333,7 +331,7 @@ class JITKernel(Generic[_P, _T]):
         str
             The source code of the compiled kernel function.
         """
-        if self.execution_backend in {"cython", "nvrtc", "tvm_ffi", "cutedsl"}:
+        if self.execution_spec.kernel_source_from_adapter:
             return self.adapter.get_kernel_source(kernel_only=kernel_only)
         return self.artifact.kernel_source
 
@@ -341,7 +339,7 @@ class JITKernel(Generic[_P, _T]):
         """
         Returns the source code of the host function.
         """
-        if self.execution_backend in {"cython", "nvrtc", "tvm_ffi", "cutedsl"}:
+        if self.execution_spec.host_source_from_adapter:
             return self.adapter.get_host_source()
         assert self.artifact.host_mod is not None, "host_mod is not available"
         return str(self.artifact.host_mod)

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -7,7 +7,8 @@ try:
 except ImportError:  # Python < 3.10
     from typing_extensions import ParamSpec
 
-from tilelang.jit.adapter.utils import is_cutedsl_target, is_metal_target, is_cuda_target
+from tilelang.backend.common.target import is_cuda_target
+from tilelang.backend.execution import create_execution_adapter, create_execution_adapter_from_database
 from tvm.target import Target
 from tvm.tir import PrimFunc
 
@@ -15,13 +16,7 @@ import tilelang
 from tilelang import tvm
 from tilelang import env
 from tilelang.engine.param import CompiledArtifact, KernelParam
-from tilelang.jit.adapter import (
-    BaseKernelAdapter,
-    CythonKernelAdapter,
-    CuTeDSLKernelAdapter,
-    TVMFFIKernelAdapter,
-    MetalKernelAdapter,
-)
+from tilelang.jit.adapter.base import BaseKernelAdapter
 from tilelang.profiler import Profiler, TensorSupplyType
 from tilelang.utils.target import determine_target
 from tilelang.contrib import nvcc as tl_nvcc
@@ -254,85 +249,17 @@ class JITKernel(Generic[_P, _T]):
 
         self.artifact = artifact
 
-        # Create an adapter based on the specified execution backend.
-        if execution_backend == "tvm_ffi":
-            # Use TVMFFIKernelAdapter for interoperability with PyTorch via DLPack.
-            # But we need to ensure that the runtime is enabled and the runtime module is not None.
-            assert artifact.rt_mod is not None, "tvm_ffi backend requires a runtime module."
-            adapter = TVMFFIKernelAdapter(
-                params=artifact.params,
-                result_idx=out_idx,
-                target=target,
-                func_or_mod=tilelang_func,
-                host_mod=artifact.host_mod,
-                device_mod=artifact.device_mod,
-                rt_mod=artifact.rt_mod,
-                device_kernel_source=artifact.kernel_source,
-                verbose=verbose,
-                pass_configs=pass_configs,
-                compile_flags=compile_flags,
-            )
-        elif execution_backend == "cython":
-            adapter = CythonKernelAdapter(
-                params=artifact.params,
-                result_idx=out_idx,
-                target=target,
-                func_or_mod=tilelang_func,
-                host_mod=artifact.host_mod,
-                device_mod=artifact.device_mod,
-                device_kernel_source=artifact.kernel_source,
-                verbose=verbose,
-                pass_configs=pass_configs,
-                compile_flags=compile_flags,
-            )
-        elif execution_backend == "nvrtc":
-            from tilelang.jit.adapter import NVRTCKernelAdapter
-
-            adapter = NVRTCKernelAdapter(
-                params=artifact.params,
-                result_idx=out_idx,
-                target=target,
-                func_or_mod=tilelang_func,
-                host_mod=artifact.host_mod,
-                device_mod=artifact.device_mod,
-                device_kernel_source=artifact.kernel_source,
-                verbose=verbose,
-                pass_configs=pass_configs,
-                compile_flags=compile_flags,
-            )
-        elif execution_backend == "torch":
-            assert is_metal_target(target)
-            adapter = MetalKernelAdapter(
-                params=artifact.params,
-                result_idx=out_idx,
-                # target=target,
-                func_or_mod=tilelang_func,
-                # host_mod=artifact.host_mod,
-                device_mod=artifact.device_mod,
-                kernel_global_source=artifact.kernel_source,
-                verbose=verbose,
-                # pass_configs=pass_configs,
-                # compile_flags=compile_flags,
-            )
-        elif execution_backend == "cutedsl":
-            assert is_cutedsl_target(target)
-            adapter = CuTeDSLKernelAdapter(
-                params=artifact.params,
-                result_idx=out_idx,
-                target=target,
-                func_or_mod=tilelang_func,
-                host_mod=artifact.host_mod,
-                device_mod=artifact.device_mod,
-                device_kernel_source=artifact.kernel_source,
-                verbose=verbose,
-                pass_configs=pass_configs,
-                compile_flags=compile_flags,
-            )
-        else:
-            # Handle invalid backend.
-            raise ValueError(f"Invalid execution backend: {execution_backend}")
-
-        return adapter
+        return create_execution_adapter(
+            execution_backend,
+            artifact=artifact,
+            params=artifact.params,
+            result_idx=out_idx,
+            target=target,
+            func_or_mod=tilelang_func,
+            verbose=verbose,
+            pass_configs=pass_configs,
+            compile_flags=compile_flags,
+        )
 
     def _create_adapter_from_database(
         self,
@@ -349,61 +276,18 @@ class JITKernel(Generic[_P, _T]):
         target = self.target
         execution_backend = self.execution_backend
 
-        # Create an adapter based on the specified execution backend.
-        if execution_backend == "tvm_ffi":
-            adapter = TVMFFIKernelAdapter.from_database(
-                params=params,
-                result_idx=result_idx,
-                target=target,
-                func_or_mod=func_or_mod,
-                host_kernel_source=host_kernel_source,
-                device_kernel_source=device_kernel_source,
-                kernel_lib_path=kernel_lib_path,
-                pass_configs=pass_configs,
-                compile_flags=compile_flags,
-            )
-        elif execution_backend == "cython":
-            adapter = CythonKernelAdapter.from_database(
-                params=params,
-                result_idx=result_idx,
-                target=target,
-                func_or_mod=func_or_mod,
-                host_kernel_source=host_kernel_source,
-                device_kernel_source=device_kernel_source,
-                kernel_lib_path=kernel_lib_path,
-                pass_configs=pass_configs,
-            )
-        elif execution_backend == "nvrtc":
-            from tilelang.jit.adapter import NVRTCKernelAdapter
-
-            adapter = NVRTCKernelAdapter.from_database(
-                params=params,
-                result_idx=result_idx,
-                target=target,
-                func_or_mod=func_or_mod,
-                host_kernel_source=host_kernel_source,
-                device_kernel_source=device_kernel_source,
-                kernel_lib_path=kernel_lib_path,
-                pass_configs=pass_configs,
-                compile_flags=compile_flags,
-            )
-        elif execution_backend == "cutedsl":
-            adapter = CuTeDSLKernelAdapter.from_database(
-                params=params,
-                result_idx=result_idx,
-                target=target,
-                func_or_mod=func_or_mod,
-                host_kernel_source=host_kernel_source,
-                device_kernel_source=device_kernel_source,
-                kernel_lib_path=kernel_lib_path,
-                pass_configs=pass_configs,
-                compile_flags=compile_flags,
-            )
-        else:
-            # Handle invalid backend.
-            raise ValueError(f"Invalid execution backend: {execution_backend}")
-
-        return adapter
+        return create_execution_adapter_from_database(
+            execution_backend,
+            params=params,
+            result_idx=result_idx,
+            target=target,
+            func_or_mod=func_or_mod,
+            host_kernel_source=host_kernel_source,
+            device_kernel_source=device_kernel_source,
+            kernel_lib_path=kernel_lib_path,
+            pass_configs=pass_configs,
+            compile_flags=compile_flags,
+        )
 
     @classmethod
     def from_tilelang_function(cls, tilelang_func: PrimFunc, **kwargs):


### PR DESCRIPTION
## Summary

This draft PR starts the backend ownership split needed for TileLang's growing backend matrix. The main direction is to make backend-specific behavior explicit instead of spreading NVIDIA/CUDA assumptions across lowering, JIT, cache, wrapper generation, CMake, and runtime code.

The PR separates two layers that are easy to conflate:

- `src/backend/*` is the native build/runtime layer for CMake and C++ sources.
- `tilelang/backend/*` is the Python backend layer for registry metadata, dispatch decisions, pass hooks, FFI builder references, target classification, and execution backend mapping.

That means `tilelang/backend` is intentionally not treated as a C-only location. Backend-specific Python code now has a first-class home next to the native backend layout.

## Backend layout

Native backend layout added under `src/backend`:

- `src/backend/common`
- `src/backend/nvidia`
- `src/backend/amd`
- `src/backend/apple`
- `src/backend/cpu`
- `src/backend/webgpu`

Python backend layout added under `tilelang/backend`:

- `tilelang/backend/common`
- `tilelang/backend/nvidia`
- `tilelang/backend/amd`
- `tilelang/backend/apple`
- `tilelang/backend/cpu`
- `tilelang/backend/webgpu`

Each Python backend package can own its target helpers, execution mapping, pass hooks, and FFI builder references. This gives future backend work a clear place to add Python-side behavior without adding more special cases to central JIT/lowering modules.

## Main changes

- Introduces backend specs and a registry in `tilelang/backend/base.py` and `tilelang/backend/registry.py`.
- Adds explicit concepts for backend metadata, including device backend, host target, execution backend support, FFI builders, adapter settings, cache metadata, and lowering pass hooks.
- Moves target and execution-backend resolution behind backend-owned helpers instead of keeping CUDA/HIP/CPU/Metal/WebGPU logic directly in the JIT entry points.
- Routes JIT wrapper/libgen/cache metadata through backend specs so backend-specific output names, adapters, and cache validation are centralized.
- Keeps optional SDK/runtime imports lazy so unsupported backends do not fail import-time checks on machines without that SDK installed.
- Adds backend pass hook support and moves NVIDIA-specific pass insertion into `tilelang/backend/nvidia/passes.py`.
- Adds native backend CMake subdirectories and moves the CUDA runtime source into `src/backend/nvidia/runtime/runtime.cc`.
- Keeps public FFI registration names stable while changing the source ownership layout.
- Restores the legacy cache `_dispatch_map` compatibility surface as a registry-backed singleton table.
- Adds cache artifact metadata validation for backend and execution backend mismatches.
- Removes trailing blank lines from new backend modules so `git diff --check` passes for the full PR range.

## Commit scope

The PR branch is intentionally limited to backend architecture and cache/JIT dispatch compatibility:

- `Introduce Python backend registry`
- `Complete backend ownership registry staging`
- `Restore cache dispatch compatibility`
- `Remove backend module trailing blank lines`

Language-level correctness fixes found during review are not included in this PR so this draft can stay focused on the backend architecture boundary.

## Design direction

This PR currently introduces a shared lowering pipeline with backend pass hooks. That is a staging step, not necessarily the final architecture.

A stronger long-term direction is to let each backend own its lowering and pass pipeline explicitly:

- Keep `tilelang/engine/lower.py` as the high-level orchestration entry point.
- Move shared pipeline building blocks into `tilelang/backend/common/pipeline.py` or an equivalent common module.
- Add backend-owned pipeline implementations such as `tilelang/backend/nvidia/pipeline.py`, `tilelang/backend/amd/pipeline.py`, `tilelang/backend/apple/pipeline.py`, and so on.
- Let each `DeviceBackend` provide its own pipeline object or factory, instead of only providing hook methods into one global shared pipeline.
- Use the common pipeline as the default implementation for simple backends, while NVIDIA/AMD or other specialized backends can override larger pipeline sections when needed.

TileOP ownership should follow the same direction:

- Keep a common TileOP contract/base layer for frontend IR compatibility and shared behavior.
- Let each backend explicitly register which TileOP implementations it supports.
- Allow a backend to implement an op, inherit the common fallback, or reject the op with a clear unsupported-backend error.
- Move backend-specific TileOP selection logic, such as GEMM instruction selection, toward backend-owned registries instead of keeping all backend choices in one shared TileOP implementation.
- Keep the native C++ `TileOperatorNode` contract as the IR/lowering boundary, while Python-side TileOP implementation choice can become backend-owned.

The current PR creates the backend registry shape needed for this next step, but does not fully migrate pipeline or TileOP ownership yet.

## Testing

Latest checks run on the cleaned PR branch:

- `cmake --build build -j$(nproc)` -> passed
- `pytest -q testing/python/backend/test_backend_registry.py` -> `9 passed`
- `pytest -q testing/python/cache/test_tilelang_kernel_cache.py -rs --tb=short` -> `10 passed, 3 skipped`
- Import-only check for `tilelang`, `tilelang.backend`, `tilelang.cache`, and `tilelang.jit.kernel` -> `import-ok`
- `git diff --check origin/main..HEAD` -> passed

The three cache-suite skips are the existing NVRTC platform gate on this host.

## Known limitations and follow-ups

This PR is intentionally a draft because it defines the first backend ownership boundary rather than completing every backend migration.

Items that still need review or follow-up:

- Decide how much backend-specific C++ code should move under each `src/backend/<name>` directory in later PRs.
- Promote `LowerAndLegalize` / `OptimizeForTarget` from a shared pipeline with hooks into backend-owned pipeline implementations.
- Decide whether backend-specific Python FFI bindings should stay in `tilelang/backend/<name>/ffi.py` long term, or whether they should be split further once each backend grows more runtime-specific code.
- Expand backend-owned pass hooks beyond the current NVIDIA-focused path as AMD, Apple, CPU, and WebGPU passes become more complete.
- Introduce a common TileOP base/contract and backend-owned TileOP implementation registry, so each backend can choose to implement, inherit, or reject each TileOP explicitly.
- Add real execution coverage for ROCm, Metal, CPU, and WebGPU environments. This branch keeps their imports and registry metadata safe, but local runtime coverage was not available in this environment.
- Consider documenting the backend taxonomy in developer docs once the registry shape has been reviewed.

## Review focus

I would especially like review on:

- Whether the split between `src/backend/*` and `tilelang/backend/*` is the right long-term ownership model.
- Whether the registry fields are too broad, too narrow, or missing important backend concepts.
- Whether pass hooks are enough for the first step, and how soon we should move to fully backend-owned lowering/pass pipelines.
- Whether TileOP implementation ownership should become part of `DeviceBackend`, a separate TileOP registry, or a separate backend capability registry.
- Whether cache metadata validation should be stricter before this becomes non-draft.
