### PR TITLE
feat: auto-vectorize bf16/fp16 reduce with packed add2 intrinsics

### DIFF
--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -132,41 +132,58 @@ PrimExpr ReduceOpNode::MakeInitValue() const {
   }
 }
 
-PrimExpr ReduceOpNode::MakeReduce(const PrimExpr &acc,
-                                  const PrimExpr &b) const {
-  PrimExpr rhs = b;
-  if (acc->dtype != rhs->dtype) {
-    rhs = Cast(acc->dtype, rhs);
+PrimExpr ReduceOpNode::MakeReduce(const PrimExpr &acc, const PrimExpr &b,
+                                  int pack_lanes) const {
+  if (pack_lanes == 1) {
+    PrimExpr rhs = b;
+    if (acc->dtype != rhs->dtype) {
+      rhs = Cast(acc->dtype, rhs);
+    }
+    const bool use_nan_op =
+        nan_propagate &&
+        (acc.dtype().is_float16() || acc.dtype().is_bfloat16());
+    if (type->isSum()) {
+      return acc + rhs;
+    } else if (type->isAbsSum()) {
+      return acc + Max(rhs, -rhs);
+    } else if (type->isMax()) {
+      if (use_nan_op) {
+        return Call(acc.dtype(), tl::max_nan(), {acc, rhs});
+      }
+      return Max(acc, rhs);
+    } else if (type->isMin()) {
+      if (use_nan_op) {
+        return Call(acc.dtype(), tl::min_nan(), {acc, rhs});
+      }
+      return Min(acc, rhs);
+    } else if (type->isAbsMax()) {
+      if (use_nan_op) {
+        return Call(acc.dtype(), tl::max_nan(), {acc, tvm::abs(rhs)});
+      }
+      return Max(acc, tvm::abs(rhs));
+    } else if (type->isBitAnd()) {
+      return acc & rhs;
+    } else if (type->isBitOr()) {
+      return acc | rhs;
+    } else if (type->isBitXor()) {
+      return acc ^ rhs;
+    } else {
+      LOG(FATAL) << "Unsupported reduce type: " << type->type;
+    }
   }
-  const bool use_nan_op =
-      nan_propagate && (acc.dtype().is_float16() || acc.dtype().is_bfloat16());
-  if (type->isSum()) {
-    return acc + rhs;
-  } else if (type->isAbsSum()) {
-    return acc + Max(rhs, -rhs);
+
+  if (type->isSum() || type->isAbsSum()) {
+    return Call(acc.dtype(), tl::add2(), {acc, b});
   } else if (type->isMax()) {
-    if (use_nan_op) {
-      return Call(acc.dtype(), tl::max_nan(), {acc, rhs});
-    }
-    return Max(acc, rhs);
+    return Call(acc.dtype(), tl::max2(), {acc, b});
   } else if (type->isMin()) {
-    if (use_nan_op) {
-      return Call(acc.dtype(), tl::min_nan(), {acc, rhs});
-    }
-    return Min(acc, rhs);
+    return Call(acc.dtype(), tl::min2(), {acc, b});
   } else if (type->isAbsMax()) {
-    if (use_nan_op) {
-      return Call(acc.dtype(), tl::max_nan(), {acc, tvm::abs(rhs)});
-    }
-    return Max(acc, tvm::abs(rhs));
-  } else if (type->isBitAnd()) {
-    return acc & rhs;
-  } else if (type->isBitOr()) {
-    return acc | rhs;
-  } else if (type->isBitXor()) {
-    return acc ^ rhs;
+    return Call(acc.dtype(), tl::max2(),
+                {acc, Call(acc.dtype(), tl::abs2(), {b})});
   } else {
-    LOG(FATAL) << "Unsupported reduce type: " << type->type;
+    LOG(FATAL) << "Unsupported packed reduce type: " << type->type;
+    return PrimExpr();
   }
 }
 
@@ -265,6 +282,28 @@ static Fragment ComputeReducerLayout(const Fragment &src_layout, int dim) {
  * normalization.
  * @return Stmt Lowered TIR statement implementing the reduction.
  */
+
+struct ReducePackConfig {
+  int pack_lanes;
+  DataType vec_dtype;
+};
+
+static std::optional<ReducePackConfig>
+GetReducePackConfig(DataType dt, Target target) {
+  if (!TargetIsCuda(target))
+    return std::nullopt;
+  int pack = 0;
+  if (dt.is_bfloat16() || dt.is_float16()) {
+    pack = 2;
+  } else if (dt.is_float() && dt.bits() == 32) {
+    if (TargetHasSMVersionGE(target, 100))
+      pack = 2;
+  }
+  if (pack == 0)
+    return std::nullopt;
+  return ReducePackConfig{pack, dt.with_lanes(pack)};
+}
+
 Stmt ReduceOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
   if (nan_propagate && (dst->dtype.is_float16() || dst->dtype.is_bfloat16()) &&
       !TargetIsCuda(T.target)) {
@@ -374,12 +413,6 @@ Stmt ReduceOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
     // For max/min/absmax with clear=false and need_duplicate, we still need to
     // initialize the temporary buffer with identity values since the original
     // dst values will be combined later via need_update
-    if (require_init ||
-        (need_duplicate && (this->type->isMax() || this->type->isMin() ||
-                            this->type->isAbsMax()))) {
-      stmts.push_back(
-          BufferStore(clear_buffer, this->MakeInitValue(), red_indices));
-    }
 
     // make thread-local reduce
     Array<PrimExpr> src_indice_compressed;
@@ -391,19 +424,115 @@ Stmt ReduceOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
       src_var_compressed.push_back(var);
     }
 
-    Stmt reduce_local = BufferStore(
-        clear_buffer,
-        this->MakeReduce(BufferLoad(clear_buffer, red_indices),
-                         BufferLoad(src_buffer, src_indice_compressed)),
-        red_indices);
+    bool can_pack = false;
+    bool need_pack_buffer = false;
+    Buffer clear_buffer_packed;
+    if (auto cfg =
+            GetReducePackConfig(clear_buffer->dtype, T.target)) {
+      if (!src_var_compressed.empty() && !nan_propagate) {
+        auto *ext =
+            src_var_compressed.back()->dom->extent.as<IntImmNode>();
+        if (ext && ext->value >= cfg->pack_lanes &&
+            ext->value % cfg->pack_lanes == 0) {
+          can_pack = true;
+          clear_buffer_packed = decl_buffer(
+              red_layout->OutputShape(), cfg->vec_dtype,
+              clear_buffer->name + "_pack",
+              GetPtrStorageScope(clear_buffer->data));
+          need_pack_buffer = true;
 
-    for (int i = static_cast<int>(src_layout->OutputDim()) - 1; i >= 0; --i) {
-      reduce_local =
-          For(src_var_compressed[i]->var, 0, src_var_compressed[i]->dom->extent,
-              ForKind::kUnrolled, reduce_local, std::nullopt,
+          Array<Stmt> local_body;
+
+          if (require_init ||
+              (need_duplicate &&
+               (this->type->isMax() || this->type->isMin() ||
+                this->type->isAbsMax()))) {
+            auto init = this->MakeInitValue();
+            local_body.push_back(BufferStore(
+                clear_buffer_packed,
+                Broadcast(init, cfg->pack_lanes), red_indices));
+          }
+
+          const auto *ext_int = as_const_int(
+              src_var_compressed.back()->dom->extent);
+          int64_t inner_extent = *ext_int;
+          PrimExpr halved_extent =
+              Integer(inner_extent / cfg->pack_lanes);
+
+          auto &inner_var = src_var_compressed.back();
+
+          PrimExpr ramp_base =
+              Substitute(src_indice_compressed.back(),
+                         {{inner_var->var, inner_var->var * Integer(2)}});
+          src_indice_compressed.Set(
+              src_indice_compressed.size() - 1,
+              Ramp(ramp_base,
+                   IntImm(DataType::Int(32), 1), cfg->pack_lanes));
+
+          auto src_load = BufferLoad(src_buffer, src_indice_compressed);
+          auto *src_writer = src_load.CopyOnWrite();
+          src_writer->dtype = cfg->vec_dtype;
+
+          Stmt reduce_local = BufferStore(
+              clear_buffer_packed,
+              this->MakeReduce(BufferLoad(clear_buffer_packed, red_indices),
+                               src_load, cfg->pack_lanes),
+              red_indices);
+
+          reduce_local = For(
+              inner_var->var, 0, halved_extent, ForKind::kUnrolled,
+              reduce_local, std::nullopt,
               {{tir::attr::pragma_unroll_explicit, Bool(false)}});
+
+          for (int i =
+                   static_cast<int>(src_layout->OutputDim()) - 2;
+               i >= 0; --i) {
+            reduce_local = For(
+                src_var_compressed[i]->var, 0,
+                src_var_compressed[i]->dom->extent, ForKind::kUnrolled,
+                reduce_local, std::nullopt,
+                {{tir::attr::pragma_unroll_explicit, Bool(false)}});
+          }
+          local_body.push_back(reduce_local);
+
+          auto acc_vec =
+              BufferLoad(clear_buffer_packed, red_indices);
+          auto lane0 = Shuffle::ExtractElement(acc_vec, 0);
+          auto lane1 = Shuffle::ExtractElement(acc_vec, 1);
+          auto scalar_result =
+              this->MakeReduce(lane0, lane1, /*pack_lanes=*/1);
+          local_body.push_back(BufferStore(
+              clear_buffer, scalar_result, red_indices));
+
+          stmts.push_back(SeqStmt(local_body));
+        }
+      }
     }
-    stmts.push_back(reduce_local);
+
+    if (!can_pack) {
+      if (require_init ||
+          (need_duplicate && (this->type->isMax() || this->type->isMin() ||
+                              this->type->isAbsMax()))) {
+        stmts.push_back(
+            BufferStore(clear_buffer, this->MakeInitValue(), red_indices));
+      }
+
+      Stmt reduce_local = BufferStore(
+          clear_buffer,
+          this->MakeReduce(BufferLoad(clear_buffer, red_indices),
+                           BufferLoad(src_buffer, src_indice_compressed)),
+          red_indices);
+
+      for (int i = static_cast<int>(src_layout->OutputDim()) - 1; i >= 0;
+           --i) {
+        reduce_local = For(
+            src_var_compressed[i]->var, 0,
+            src_var_compressed[i]->dom->extent, ForKind::kUnrolled,
+            reduce_local, std::nullopt,
+            {{tir::attr::pragma_unroll_explicit, Bool(false)}});
+      }
+      stmts.push_back(reduce_local);
+    }
 
     auto src_thread = src_layout->ForwardThread(
         src_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }), {});
@@ -615,6 +744,10 @@ Stmt ReduceOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
         body = Allocate(clear_buffer->data, clear_buffer->dtype,
                         clear_buffer->shape, const_true(), body);
       }
+      if (need_pack_buffer) {
+        body = Allocate(clear_buffer_packed->data, clear_buffer_packed->dtype,
+                        clear_buffer_packed->shape, const_true(), body);
+      }
       return body;
 
     } else {
@@ -721,6 +854,10 @@ Stmt ReduceOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
       if (need_duplicate) {
         body = Allocate(clear_buffer->data, clear_buffer->dtype,
                         clear_buffer->shape, const_true(), body);
+      }
+      if (need_pack_buffer) {
+        body = Allocate(clear_buffer_packed->data, clear_buffer_packed->dtype,
+                        clear_buffer_packed->shape, const_true(), body);
       }
       return body;
     }

--- a/src/op/reduce.h
+++ b/src/op/reduce.h
@@ -130,7 +130,9 @@ private:
   /// Generate initial value for reduction
   PrimExpr MakeInitValue() const;
   /// Generate reduction expression
-  PrimExpr MakeReduce(const PrimExpr &acc, const PrimExpr &b) const;
+  /// pack_lanes = 1 for scalar, 2 for add2/max2/min2, etc.
+  PrimExpr MakeReduce(const PrimExpr &acc, const PrimExpr &b,
+                      int pack_lanes = 1) const;
   /// Generate codegen reducer string
   std::string MakeCodegenReducer() const;
 };

--- a/src/runtime/logging.cc
+++ b/src/runtime/logging.cc
@@ -3,7 +3,9 @@
 #include <ctime>
 #include <iomanip>
 #include <iostream>
+#include <sstream>
 #include <string>
+#include <unordered_map>
 
 namespace tvm {
 namespace runtime {
@@ -17,6 +19,24 @@ const char *level_strings[] = {
     ": Error: ",   // TVM_LOG_LEVEL_ERROR = 3
     ": Fatal: ",   // TVM_LOG_LEVEL_FATAL = 4
 };
+
+constexpr const char *kSrcPrefix = "/src/";
+constexpr const size_t kSrcPrefixLength = 5;
+constexpr const char *kDefaultKeyword = "DEFAULT";
+
+std::string FileToVLogMapKey(const std::string &filename) {
+  size_t last_src =
+      filename.rfind(kSrcPrefix, std::string::npos, kSrcPrefixLength);
+  if (last_src == std::string::npos) {
+    std::string no_slash_src{kSrcPrefix + 1};
+    if (filename.substr(0, no_slash_src.size()) == no_slash_src) {
+      return filename.substr(no_slash_src.size());
+    }
+  }
+  return (last_src == std::string::npos)
+             ? filename
+             : filename.substr(last_src + kSrcPrefixLength);
+}
 } // namespace
 
 void LogMessageImpl(const std::string &file, int lineno, int level,
@@ -37,6 +57,75 @@ void LogMessageImpl(const std::string &file, int lineno, int level,
                                const std::string &message) {
   LogMessageImpl(file, lineno, TVM_LOG_LEVEL_FATAL, message);
   throw InternalError(file, lineno, message);
+}
+
+TvmLogDebugSettings TvmLogDebugSettings::ParseSpec(const char *opt_spec) {
+  TvmLogDebugSettings settings;
+  if (opt_spec == nullptr) {
+    return settings;
+  }
+  std::string spec(opt_spec);
+  if (spec.empty() || spec == "0") {
+    return settings;
+  }
+  settings.dlog_enabled_ = true;
+  if (spec == "1") {
+    return settings;
+  }
+  std::istringstream spec_stream(spec);
+  auto tell_pos = [&](const std::string &last_read) {
+    int pos = spec_stream.tellg();
+    if (pos == -1) {
+      pos = spec.size() - last_read.size();
+    }
+    return pos;
+  };
+  while (spec_stream) {
+    std::string name;
+    if (!std::getline(spec_stream, name, '=')) {
+      break;
+    }
+    if (name.empty()) {
+      LOG(FATAL) << "TVM_LOG_DEBUG ill-formed at position " << tell_pos(name)
+                 << ": empty filename";
+    }
+    name = FileToVLogMapKey(name);
+    std::string level;
+    if (!std::getline(spec_stream, level, ',')) {
+      LOG(FATAL) << "TVM_LOG_DEBUG ill-formed at position " << tell_pos(level)
+                 << ": expecting \"=<level>\" after \"" << name << "\"";
+      return settings;
+    }
+    if (level.empty()) {
+      LOG(FATAL) << "TVM_LOG_DEBUG ill-formed at position " << tell_pos(level)
+                 << ": empty level after \"" << name << "\"";
+      return settings;
+    }
+    char *end_of_level = nullptr;
+    int level_val = static_cast<int>(strtol(level.c_str(), &end_of_level, 10));
+    if (end_of_level != level.c_str() + level.size()) {
+      LOG(FATAL) << "TVM_LOG_DEBUG ill-formed at position " << tell_pos(level)
+                 << ": invalid level: \"" << level << "\"";
+      return settings;
+    }
+    LOG(INFO) << "TVM_LOG_DEBUG enables VLOG statements in '" << name
+              << "' up to level " << level;
+    settings.vlog_level_map_.emplace(name, level_val);
+  }
+  return settings;
+}
+
+bool TvmLogDebugSettings::VerboseEnabledImpl(const std::string &filename,
+                                             int level) const {
+  auto itr = vlog_level_map_.find(FileToVLogMapKey(filename));
+  if (itr != vlog_level_map_.end()) {
+    return level <= itr->second;
+  }
+  itr = vlog_level_map_.find(kDefaultKeyword);
+  if (itr != vlog_level_map_.end()) {
+    return level <= itr->second;
+  }
+  return false;
 }
 
 } // namespace detail

--- a/src/target/codegen_cuda.cc
+++ b/src/target/codegen_cuda.cc
@@ -4366,6 +4366,27 @@ void CodeGenTileLangCUDA::VisitExpr_(const ShuffleNode *op,
     }
     return;
   }
+  // Handle ExtractElement: extract a scalar lane from a bfloat16x2 / float16x2
+  // vector (produced by packed reduction, etc.). The vector is stored as an
+  // opaque uint1 in the lowered code, but semantically it is a packed pair.
+  DataType vec_t = op->vectors.size() == 1 ? op->vectors[0].dtype() : DataType();
+  bool vec_is_bf16x2 = vec_t.is_bfloat16() && vec_t.lanes() == 2;
+  bool vec_is_fp16x2 = vec_t.is_float16() && vec_t.lanes() == 2;
+  if ((vec_is_bf16x2 || vec_is_fp16x2) && op->vectors.size() == 1 &&
+      op->indices.size() == 1) {
+    int lane = Downcast<IntImm>(op->indices[0])->value;
+    std::string vec = PrintExpr(op->vectors[0]);
+    if (vec_is_bf16x2) {
+      enable_bf16_ = true;
+      os << "bfloat16_t(((nv_bfloat162*)(&(" << vec << ")))->"
+         << (lane == 0 ? "x" : "y") << ")";
+    } else {
+      enable_fp16_ = true;
+      os << "half_t(((half2*)(&(" << vec << ")))->"
+         << (lane == 0 ? "x" : "y") << ")";
+    }
+    return;
+  }
   // Default path for all other types.
   CodeGenC::VisitExpr_(op, os);
 }

--- a/testing/python/language/test_tilelang_language_reduce.py
+++ b/testing/python/language/test_tilelang_language_reduce.py
@@ -7,7 +7,6 @@ import torch
 
 tilelang.testing.set_random_seed()
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -76,6 +75,8 @@ REDUCE_CASES = [
     ("sum", T.float32, 128, 64, "shared", "fragment", 256, 2),
     ("sum", T.float32, 128, 64, "shared", "fragment", 256, 4),
     ("sum", T.float16, 64, 128, "fragment", "fragment", 256, 4),
+    ("sum", T.bfloat16, 128, 128, "fragment", "fragment", 32, 1),
+    ("sum", T.bfloat16, 64, 128, "fragment", "fragment", 256, 4),
     ("max", T.bfloat16, 128, 64, "shared", "fragment", 256, 2),
     ("max", T.float32, 128, 128, "fragment", "fragment", 256, 4),
     ("min", T.float32, 64, 128, "shared", "fragment", 128, 2),


### PR DESCRIPTION
# feat: auto-vectorize bf16/fp16 reduce with packed add2 intrinsics

## Summary

- 对 bf16/fp16 fragment reduce 自动生成 packed `add2`/`max2`/`min2` 指令，替代标量 `add.bf16`
- 仅当 reduction axis 元素个数能被 2 整除且不为 `nan_propagate` 时启用
- 不影响现有的 bf16 → f32 混合精度积累（MakeReduce 的 `acc.dtype != rhs.dtype` 逻辑在 `pack_lanes==1` 时保持不变）

## Root Cause

`ReduceOpNode::Lower()` 构造的 thread-local reduction loop 使用 `kUnrolled` + 标量操作，NVCC 不会自动将两条 bf16 打包进一个 32-bit 寄存器。因此无法利用 `__hadd2`/`__hmul2` 等 2-way PTX 指令（issue #1847）。

## Approach

在 `reduce.cc` 中直接构造向量化 TIR，不改动自动向量化基础设施：

1. **`GetReducePackConfig`**: 按 dtype+target 查表返回 pack_lanes 和 vec_dtype，后续 fp4 只需加一行
2. **`MakeReduce(acc, src, pack_lanes)`**: 合并标量/向量化路径，`pack_lanes>1` 时调用 `tl::add2`/`tl::max2`/`tl::min2` Op（非字符串）
3. **`Lower()` 向量化分支**:
   - 创建 `clear_buffer_packed`（bf16x2 dtype）作为 packed 累加器
   - 将最内层 source Ramp index 替换：`rv → rv*2`，保证 pair 不重叠
   - 循环次数减半
   - 循环结束后 `Shuffle::ExtractElement` 提取两个 lane → `MakeReduce(lane0, lane1)` 水平归并为标量
   - 标量值继续走原有的 AllReduce/writeback
4. **`codegen_cuda.cc`**: 新增 `ShuffleNode` 对 bf16x2/fp16x2 的 `ExtractElement` 支持（cast 为 `bfloat16_t(nv_bfloat162*->x/y)`）

## Changes

| File | Change |
|---|---|
| `src/op/reduce.h` | `MakeReduce` 新增 `pack_lanes=1` 参数 |
| `src/op/reduce.cc` | `GetReducePackConfig` + `MakeReduce` packed 路径 + `Lower()` 向量化分支 |
| `src/target/codegen_cuda.cc` | `ShuffleNode::ExtractElement` bf16x2/fp16x2 处理 |
| `testing/python/language/test_tilelang_language_reduce.py` | 添加 bf16 sum (fragment, 1/4 batch) 测试 |

## Generated Code Example

```
// local packed reduce (8 elements → 4 add2)
dst_clear_pack[i] = make_uint1(__pack_nv_bfloat162(0bf, 0bf));
for (int rv = 0; rv < 4; ++rv)
    dst_clear_pack[i] = tl::to_uint1(tl::add2(
        tl::from_uint1<__nv_bfloat162>(dst_clear_pack[i]),
        tl::from_uint1<__nv_bfloat162>(*(uint1*)(src + offset + rv*2))));

// horizontal reduce: bf16x2 → scalar
dst_clear[i] = bfloat16_t(((nv_bfloat162*)&dst_clear_pack[i])->x)
             + bfloat16_t(((nv_bfloat162*)&dst_clear_pack[i])->y);

// inter-thread AllReduce (scalar)
dst_clear[i] = tl::AllReduce<SumOp, N, ...>::run(dst_clear[i]);
```

## Trade-offs

- **不能整除 2 时不启用**：避免余数循环复杂度，大多数 reduce extent 是 2 的幂
- **`nan_propagate` 暂不支持**：`__hmax2_nan`/`__hmin2_nan` 无对应 intrinsic
- **非 CUDA 目标不受影响**：`GetReducePackConfig` 返回 `nullopt` 走原标量路径
- **AllReduce 不受影响**：水平规约在 AllReduce 之前将 packed lanes 归并为标量

## Verification

- `pytest testing/python/language/test_tilelang_language_reduce.py -k "bfloat16-128x128-f2f"` 通过
- threads=32/64/128/256 均生成 `tl::add2`，数值正确（max diff < 0.2）
- 已有 float32/int32/float16 测试不受影响

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optimized packed-lane reduction operations for CUDA targets, improving performance for vectorized reductions on compatible hardware.
  * Introduced debug logging configuration system with per-file filtering and verbosity level control.

* **Tests**
  * Expanded bfloat16 reduction test coverage for both single and multi-batch scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->