### PR TITLE
[Feature] Support mutable TMA descriptor and canonicalize usage in examples

### DIFF
--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -646,6 +646,12 @@ TIR_DEFINE_TL_BUILTIN(tensormap_fence_acquire)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
+// tma_desc_slot(workspace_ptr, sm_idx)
+TIR_DEFINE_TL_BUILTIN(tma_desc_slot)
+    .set_num_inputs(2)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
 TIR_DEFINE_TL_BUILTIN(warp_reduce_max)
     .set_num_inputs(1)
     .set_attr<TCallEffectKind>("TCallEffectKind",

--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -622,6 +622,30 @@ TIR_DEFINE_TL_BUILTIN(warp_reduce_sum)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
+// tensormap_copy_to_smem(smem_desc_ptr, gmem_desc_ptr)
+TIR_DEFINE_TL_BUILTIN(tensormap_copy_to_smem)
+    .set_num_inputs(2)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+// tensormap.replace.box_dim(smem_desc_ptr, dim_idx, new_box_dim)
+TIR_DEFINE_TL_BUILTIN(tensormap_replace_box_dim)
+    .set_num_inputs(3)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+// tensormap_cp_fence_release(gmem_desc_ptr, smem_desc_ptr)
+TIR_DEFINE_TL_BUILTIN(tensormap_cp_fence_release)
+    .set_num_inputs(2)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+// tensormap_fence_acquire(gmem_desc_ptr)
+TIR_DEFINE_TL_BUILTIN(tensormap_fence_acquire)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
 TIR_DEFINE_TL_BUILTIN(warp_reduce_max)
     .set_num_inputs(1)
     .set_attr<TCallEffectKind>("TCallEffectKind",

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -1095,6 +1095,38 @@ TVM_DLL const Op &device_assert_with_msg();
 TVM_DLL const Op &warp_reduce_sum();
 
 /*!
+ * \brief Copy TMA descriptor (128 bytes) from global memory to shared memory.
+ *
+ * tensormap_copy_to_smem(smem_desc_ptr, gmem_desc_ptr)
+ *
+ */
+TVM_DLL const Op &tensormap_copy_to_smem();
+
+/*!
+ * \brief Replace box_dim field in SMEM TMA descriptor.
+ *
+ * tensormap_replace_box_dim(smem_desc_ptr, dim_idx, new_box_dim)
+ *
+ */
+TVM_DLL const Op &tensormap_replace_box_dim();
+
+/*!
+ * \brief Copy SMEM descriptor back to GMEM + tensormap release fence.
+ *
+ * tensormap_cp_fence_release(gmem_desc_ptr, smem_desc_ptr)
+ *
+ */
+TVM_DLL const Op &tensormap_cp_fence_release();
+
+/*!
+ * \brief Acquire fence on GMEM TMA descriptor.
+ *
+ * tensormap_fence_acquire(gmem_desc_ptr)
+ *
+ */
+TVM_DLL const Op &tensormap_fence_acquire();
+
+/*!
  * \brief tilelang intrinsic for warp reduction max.
  */
 TVM_DLL const Op &warp_reduce_max();

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -1127,6 +1127,15 @@ TVM_DLL const Op &tensormap_cp_fence_release();
 TVM_DLL const Op &tensormap_fence_acquire();
 
 /*!
+ * \brief Access a per-block GMEM TMA descriptor slot.
+ *
+ * tma_desc_slot(workspace_ptr, sm_idx)
+ *
+ * codegen emits: workspace_ptr[sm_idx]
+ */
+TVM_DLL const Op &tma_desc_slot();
+
+/*!
  * \brief tilelang intrinsic for warp reduction max.
  */
 TVM_DLL const Op &warp_reduce_max();

--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -1719,11 +1719,19 @@ Stmt CopyNode::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer,
   // Bind descriptor to a variable so multiple references share the same object
   Var desc_handle("tma_desc", DataType::Handle());
 
-  // When dynamic box dims exist, allocate SMEM workspace for the descriptor
-  // copy (128 bytes, 128B-aligned) so tensormap.replace can modify it there.
+  // When dynamic box dims exist, allocate:
+  // 1) SMEM workspace for the descriptor copy (128 bytes, 128B-aligned)
+  //    so tensormap.replace can modify it there.
+  // 2) Per-block GMEM mutable descriptor workspace (via host-side allocation,
+  //    passed as CUtensorMap* kernel param).
   PrimExpr smem_desc_ptr;
+  PrimExpr mutable_handle;
   if (!dynamic_box_dims.empty()) {
     smem_desc_ptr = T.AddWorkspace(128, DataType::UInt(8));
+    PrimExpr mutable_ws = T.AllocMutableTmaWorkspace(
+        global_tensor->name + "_mutable");
+    mutable_handle = Call(DataType::Handle(), tma_desc_slot(),
+                          {mutable_ws, IntImm(DataType::Int(32), 0)});
   }
 
   // For TMA loads, allocate mbarrier(s) for synchronous semantics.
@@ -1756,7 +1764,7 @@ Stmt CopyNode::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer,
 
   Array<PrimExpr> args;
   args.reserve(desc.rank + 4);
-  args.push_back(desc_handle);
+  args.push_back(mutable_handle.defined() ? mutable_handle : desc_handle);
   if (is_load)
     args.push_back(barrier_base_id >= 0 ? mbar_handle : PrimExpr(0));
   auto op = is_load ? tma_load() : tma_store();
@@ -1806,34 +1814,44 @@ Stmt CopyNode::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer,
     tma_copy = Evaluate(Call(DataType::Handle(), op, args, ann));
   }
 
-  // When dynamic box dims exist, prepend the tensormap.replace + fence
-  // sequence to modify the descriptor at runtime before the TMA operation.
-  // Sequence: copy GMEM→SMEM, replace box_dim(s), cp_fence_release,
-  // fence_acquire.
+  // When dynamic box dims exist, build a two-part sequence:
+  //   Leader:  copy_to_smem + replace_box_dim (modify SMEM)
+  //   __syncthreads
+  //   All:     cp_fence_release + fence_acquire (publish to GMEM workspace)
+  //   Leader:  tma_load / tma_store (use workspace descriptor)
+  //
+  // The fence ops must run on ALL threads (CUTLASS requirement for
+  // tensormap.cp_fenceproxy with CTA sharing).
+  Stmt leader_smem_seq;
+  Array<Stmt> fence_stmts;
   if (!dynamic_box_dims.empty()) {
-    Array<Stmt> replace_prefix;
-    // 1) Copy GMEM descriptor to SMEM workspace (128 bytes)
-    replace_prefix.push_back(Evaluate(Call(
+    // Part 1: Leader modifies SMEM descriptor
+    Array<Stmt> smem_stmts;
+    smem_stmts.push_back(Evaluate(Call(
         DataType::Handle(), tensormap_copy_to_smem(),
         {smem_desc_ptr, desc_handle})));
-    // 2) Replace each dynamic box dim in the SMEM copy
     for (const auto &kv : dynamic_box_dims) {
-      replace_prefix.push_back(Evaluate(Call(
+      smem_stmts.push_back(Evaluate(Call(
           DataType::Handle(), tensormap_replace_box_dim(),
           {smem_desc_ptr, Integer(static_cast<int>(kv.first)),
            kv.second})));
     }
-    // 3) Fence release: copy modified SMEM descriptor back to GMEM
-    replace_prefix.push_back(Evaluate(Call(
+    leader_smem_seq = SeqStmt(smem_stmts);
+
+    // Part 2: All threads get SMEM fence + copy descriptor to workspace
+    fence_stmts.push_back(Evaluate(Call(
+        DataType::Int(32), builtin::tvm_storage_sync(),
+        {StringImm("shared")})));
+    fence_stmts.push_back(Evaluate(Call(
         DataType::Handle(), tensormap_cp_fence_release(),
-        {desc_handle, smem_desc_ptr})));
-    // 4) Fence acquire on the GMEM descriptor
-    replace_prefix.push_back(Evaluate(Call(
-        DataType::Handle(), tensormap_fence_acquire(), {desc_handle})));
-    // 5) Prefix the TMA operation with the replace+fence sequence
-    replace_prefix.push_back(tma_copy);
-    tma_copy = SeqStmt(replace_prefix);
+        {mutable_handle, smem_desc_ptr})));
+    fence_stmts.push_back(Evaluate(Call(
+        DataType::Handle(), tensormap_fence_acquire(), {mutable_handle})));
+
+    // Part 3: Leader uses workspace descriptor for TMA op
+    // (tma_copy already contains the tma_load/tma_store call)
   }
+
 
   // Bulk TMA stores participate in the cp.async.bulk group mechanism, so we
   // must commit and wait to ensure completion before the store buffer is
@@ -1920,34 +1938,61 @@ Stmt CopyNode::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer,
           DataType::Handle(), builtin::ptx_arrive_barrier(), {mbar_handle}));
     }
 
-    Array<Stmt> producer_seq{barrier_before_tma_stmt, tma_copy};
-    if (barrier_after_tma_stmt.defined()) {
-      producer_seq.push_back(barrier_after_tma_stmt.value());
+    auto LeaderGate = [&](const Stmt &s) {
+      return IfThenElse(MakeTmaLeaderCondition(T.thread_bounds->extent), s);
+    };
+
+    Stmt tma_load_block;
+    if (!fence_stmts.empty()) {
+      // Dynamic extents: split into leader(smem) + all(fence) + leader(tma)
+      Array<Stmt> tma_seq{barrier_before_tma_stmt, tma_copy};
+      if (barrier_after_tma_stmt.defined())
+        tma_seq.push_back(barrier_after_tma_stmt.value());
+      Stmt tma_gated = LeaderGate(SeqStmt(tma_seq));
+
+      Array<Stmt> full_seq;
+      full_seq.push_back(LeaderGate(leader_smem_seq));
+      for (const auto &s : fence_stmts)
+        full_seq.push_back(s);
+      full_seq.push_back(tma_gated);
+      tma_load_block = SeqStmt(full_seq);
+    } else {
+      Array<Stmt> producer_seq{barrier_before_tma_stmt, tma_copy};
+      if (barrier_after_tma_stmt.defined())
+        producer_seq.push_back(barrier_after_tma_stmt.value());
+      tma_load_block = LeaderGate(SeqStmt(producer_seq));
     }
 
-    // Thread-gated block: expect_tx + tma_load (+ optional arrive)
-    Stmt producer = IfThenElse(MakeTmaLeaderCondition(T.thread_bounds->extent),
-                               SeqStmt(producer_seq));
-
-    // tma_copy (from T.tma_copy()) is fire-and-forget: only emit the
-    // producer (expect_tx + tma_load). The user manages synchronization
-    // (arrive + wait) explicitly.
     if (GetIsTmaCopy()) {
-      return LetStmt(desc_handle, create_descriptor, producer);
+      return LetStmt(desc_handle, create_descriptor, tma_load_block);
     }
 
-    // For T.copy() with TMA: emit producer + wait pair so the pipeline/WS
-    // passes can split them into different stages.
     Stmt wait_stmt =
         Evaluate(Call(DataType::Handle(), mbarrier_wait_parity(),
                       {mbar_handle, GetCopyMbarPhaseExpr(annotations, T)}));
 
     return LetStmt(desc_handle, create_descriptor,
-                   SeqStmt({producer, wait_stmt}));
+                   SeqStmt({tma_load_block, wait_stmt}));
   }
 
-  tma_copy =
-      IfThenElse(MakeTmaLeaderCondition(T.thread_bounds->extent), tma_copy);
+  // Leader gate for SMEM ops and TMA ops (separated by all-threads fence).
+  auto LeaderGate = [&](const Stmt &s) {
+    return IfThenElse(MakeTmaLeaderCondition(T.thread_bounds->extent), s);
+  };
+
+  if (!fence_stmts.empty()) {
+    Array<Stmt> full_seq;
+    // Part 1: Leader modifies SMEM descriptor
+    full_seq.push_back(LeaderGate(leader_smem_seq));
+    // Part 2: All threads: __syncthreads + cp_fence_release + fence_acquire
+    for (const auto &s : fence_stmts)
+      full_seq.push_back(s);
+    // Part 3: Leader uses workspace descriptor for TMA op
+    full_seq.push_back(LeaderGate(tma_copy));
+    tma_copy = SeqStmt(full_seq);
+  } else {
+    tma_copy = LeaderGate(tma_copy);
+  }
 
   return LetStmt(desc_handle, create_descriptor, tma_copy);
 }

--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -812,17 +812,22 @@ CopyInst CopyNode::GetCopyInst(Target target, const LayoutMap &layout_map,
     return CopyInst::kCPAsync;
   }
 
-  // Plain T.copy does not auto-upgrade to TMA loads anymore. Store-side TMA
-  // remains allowed because it is self-synchronized locally and does not
-  // participate in pipeline producer scheduling.
+  // Plain T.copy auto-upgrades to TMA for both loads and stores when
+  // conditions are satisfied. Store-side TMA is self-synchronized locally;
+  // load-side TMA is auto-equipped with an internal mbarrier.
   // Also honour the (deprecated) global pass config for backward compat.
   if (!GetDisableTMA() && !tvm::transform::PassContext::Current()
                                ->GetConfig<Bool>(kDisableTMALower, Bool(false))
                                .value()) {
     bool is_cutedsl = TargetIsCuTeDSL(target);
     if (!is_cutedsl && !buffer_oob &&
-        CheckBulkStore1D(target, layout_map, analyzer)) {
+        CheckBulkLoad1D(target, layout_map, analyzer)) {
+      return CopyInst::kBulkLoad1D;
+    } else if (!is_cutedsl && !buffer_oob &&
+               CheckBulkStore1D(target, layout_map, analyzer)) {
       return CopyInst::kBulkStore1D;
+    } else if (CheckBulkLoad(target, analyzer)) {
+      return CopyInst::kBulkLoad;
     } else if (CheckBulkStore(target, analyzer)) {
       return CopyInst::kBulkStore;
     }
@@ -1631,6 +1636,37 @@ Stmt CopyNode::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer,
     }
   }
 
+  // Detect dynamic box dimensions; substitute buffer-shape maxima into the
+  // descriptor so create_tma_descriptor receives compile-time constants.
+  // The actual runtime extents are applied later via tensormap.replace.
+  // smem_box is in reverse order (innermost dim first at index 0).
+  std::vector<std::pair<size_t, PrimExpr>> dynamic_box_dims;
+  for (size_t i = 0; i < desc.smem_box.size(); i++) {
+    if (as_const_int(desc.smem_box[i]) != nullptr)
+      continue;
+    int buf_dim = static_cast<int>(shared_tensor_unmapped->shape.size()) - 1 -
+                  static_cast<int>(i);
+    if (buf_dim < 0 ||
+        buf_dim >= static_cast<int>(shared_tensor_unmapped->shape.size())) {
+      LOG(FATAL) << "Dynamic box dim " << i << " (" << desc.smem_box[i]
+                 << ") cannot be mapped to buffer shape (rank="
+                 << shared_tensor_unmapped->shape.size() << "). "
+                 << "Use a compile-time constant in the copy region.";
+    }
+    PrimExpr max_val =
+        analyzer->Simplify(shared_tensor_unmapped->shape[buf_dim]);
+    auto max_val_int = as_const_int(max_val);
+    if (max_val_int == nullptr) {
+      LOG(FATAL) << "Buffer shape dim " << buf_dim << " (" << max_val
+                 << ") must be a compile-time constant to serve as "
+                    "the upper bound for dynamic TMA box dim "
+                 << i << ".";
+    }
+    dynamic_box_dims.push_back(
+        {i, analyzer->Simplify(desc.smem_box[i])});
+    desc.smem_box.Set(i, Integer(*max_val_int));
+  }
+
   auto inner_box_dim = as_const_int(desc.smem_box[0]);
   if (inner_box_dim == nullptr) {
     LOG(WARNING) << "inner_box_dim " << desc.smem_box[0]
@@ -1680,6 +1716,16 @@ Stmt CopyNode::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer,
   Call create_descriptor =
       Call(DataType::Handle(), create_tma_descriptor(), desc.EncodeCallArgs());
 
+  // Bind descriptor to a variable so multiple references share the same object
+  Var desc_handle("tma_desc", DataType::Handle());
+
+  // When dynamic box dims exist, allocate SMEM workspace for the descriptor
+  // copy (128 bytes, 128B-aligned) so tensormap.replace can modify it there.
+  PrimExpr smem_desc_ptr;
+  if (!dynamic_box_dims.empty()) {
+    smem_desc_ptr = T.AddWorkspace(128, DataType::UInt(8));
+  }
+
   // For TMA loads, allocate mbarrier(s) for synchronous semantics.
   // Determine the mbarrier handle for TMA loads.
   // T.tma_copy(): requires user-provided barrier
@@ -1710,7 +1756,7 @@ Stmt CopyNode::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer,
 
   Array<PrimExpr> args;
   args.reserve(desc.rank + 4);
-  args.push_back(create_descriptor);
+  args.push_back(desc_handle);
   if (is_load)
     args.push_back(barrier_base_id >= 0 ? mbar_handle : PrimExpr(0));
   auto op = is_load ? tma_load() : tma_store();
@@ -1760,6 +1806,35 @@ Stmt CopyNode::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer,
     tma_copy = Evaluate(Call(DataType::Handle(), op, args, ann));
   }
 
+  // When dynamic box dims exist, prepend the tensormap.replace + fence
+  // sequence to modify the descriptor at runtime before the TMA operation.
+  // Sequence: copy GMEM→SMEM, replace box_dim(s), cp_fence_release,
+  // fence_acquire.
+  if (!dynamic_box_dims.empty()) {
+    Array<Stmt> replace_prefix;
+    // 1) Copy GMEM descriptor to SMEM workspace (128 bytes)
+    replace_prefix.push_back(Evaluate(Call(
+        DataType::Handle(), tensormap_copy_to_smem(),
+        {smem_desc_ptr, desc_handle})));
+    // 2) Replace each dynamic box dim in the SMEM copy
+    for (const auto &kv : dynamic_box_dims) {
+      replace_prefix.push_back(Evaluate(Call(
+          DataType::Handle(), tensormap_replace_box_dim(),
+          {smem_desc_ptr, Integer(static_cast<int>(kv.first)),
+           kv.second})));
+    }
+    // 3) Fence release: copy modified SMEM descriptor back to GMEM
+    replace_prefix.push_back(Evaluate(Call(
+        DataType::Handle(), tensormap_cp_fence_release(),
+        {desc_handle, smem_desc_ptr})));
+    // 4) Fence acquire on the GMEM descriptor
+    replace_prefix.push_back(Evaluate(Call(
+        DataType::Handle(), tensormap_fence_acquire(), {desc_handle})));
+    // 5) Prefix the TMA operation with the replace+fence sequence
+    replace_prefix.push_back(tma_copy);
+    tma_copy = SeqStmt(replace_prefix);
+  }
+
   // Bulk TMA stores participate in the cp.async.bulk group mechanism, so we
   // must commit and wait to ensure completion before the store buffer is
   // reused or the kernel exits.
@@ -1783,13 +1858,23 @@ Stmt CopyNode::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer,
   // The producer is annotated with the shared buffer so PipelinePlanning can
   // detect it as a copy stage and schedule it at pipeline stage 0.
   if (is_load && barrier_base_id >= 0) {
-    // Compute total bytes for all TMA sub-copies in this operation
-    PrimExpr total_bytes;
-    if ((*inner_box_dim) != instruction_dim) {
-      int loop_extent = (*inner_box_dim) / instruction_dim;
-      total_bytes = total_elements * loop_extent * shared_tensor->dtype.bytes();
-    } else {
-      total_bytes = total_elements * shared_tensor->dtype.bytes();
+    // Compute total bytes accounting for dynamic box dims that will be
+    // replaced at runtime.  total_elements is the product of the static
+    // (max) smem_box entries; we replace each dynamic dim with its runtime
+    // extent so expect_tx only accounts for the bytes actually transferred.
+    PrimExpr dyn_total_bytes;
+    {
+      PrimExpr dyn_elements = total_elements;
+      for (const auto &kv : dynamic_box_dims)
+        dyn_elements =
+            analyzer->Simplify(dyn_elements / desc.smem_box[kv.first] * kv.second);
+      if ((*inner_box_dim) != instruction_dim) {
+        int loop_extent = (*inner_box_dim) / instruction_dim;
+        dyn_total_bytes =
+            dyn_elements * loop_extent * shared_tensor->dtype.bytes();
+      } else {
+        dyn_total_bytes = dyn_elements * shared_tensor->dtype.bytes();
+      }
     }
 
     Stmt barrier_before_tma_stmt;
@@ -1803,7 +1888,7 @@ Stmt CopyNode::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer,
         // CTA 0's barrier (via tma_load_2sm peer-bit clearing). So expect_tx
         // must account for ALL CTAs' bytes and only execute on CTA 0.
         PrimExpr cluster_total_bytes =
-            total_bytes * IntImm(DataType::Int(32), T.cluster_size);
+            dyn_total_bytes * IntImm(DataType::Int(32), T.cluster_size);
         Stmt expect_stmt =
             Evaluate(Call(DataType::Handle(), mbarrier_expect_tx(),
                           {mbar_handle, cluster_total_bytes}));
@@ -1813,7 +1898,7 @@ Stmt CopyNode::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer,
       } else {
         barrier_before_tma_stmt =
             Evaluate(Call(DataType::Handle(), mbarrier_expect_tx(),
-                          {mbar_handle, total_bytes}));
+                          {mbar_handle, dyn_total_bytes}));
       }
       // When emit_arrive is set (by InjectSoftwarePipeline for pipeline-level
       // barrier management), also emit arrive inside the thread-0 guard.
@@ -1830,7 +1915,7 @@ Stmt CopyNode::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer,
       // domain explicitly when TMA shares a stage barrier with cp.async.
       barrier_before_tma_stmt =
           Evaluate(Call(DataType::Handle(), mbarrier_expect_tx(),
-                        {mbar_handle, total_bytes}));
+                        {mbar_handle, dyn_total_bytes}));
       barrier_after_tma_stmt = Evaluate(Call(
           DataType::Handle(), builtin::ptx_arrive_barrier(), {mbar_handle}));
     }
@@ -1848,7 +1933,7 @@ Stmt CopyNode::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer,
     // producer (expect_tx + tma_load). The user manages synchronization
     // (arrive + wait) explicitly.
     if (GetIsTmaCopy()) {
-      return producer;
+      return LetStmt(desc_handle, create_descriptor, producer);
     }
 
     // For T.copy() with TMA: emit producer + wait pair so the pipeline/WS
@@ -1857,13 +1942,14 @@ Stmt CopyNode::LowerBulkCopy(const LowerArgs &T, arith::Analyzer *analyzer,
         Evaluate(Call(DataType::Handle(), mbarrier_wait_parity(),
                       {mbar_handle, GetCopyMbarPhaseExpr(annotations, T)}));
 
-    return SeqStmt({producer, wait_stmt});
+    return LetStmt(desc_handle, create_descriptor,
+                   SeqStmt({producer, wait_stmt}));
   }
 
   tma_copy =
       IfThenElse(MakeTmaLeaderCondition(T.thread_bounds->extent), tma_copy);
 
-  return tma_copy;
+  return LetStmt(desc_handle, create_descriptor, tma_copy);
 }
 
 Stmt CopyNode::LowerBulkCopy1D(const LowerArgs &T, arith::Analyzer *analyzer,

--- a/src/op/operator.h
+++ b/src/op/operator.h
@@ -26,6 +26,9 @@ using namespace tir;
 
 using AddWorkspaceCallback = std::function<PrimExpr(int, DataType)>;
 using AllocMBarrierCallback = std::function<int(int arrive_count)>;
+// Create a per-block GMEM workspace pointer for a mutable TMA descriptor.
+// Returns a Var (type Handle) that will be lowered to a CUtensorMap * param.
+using AllocMutableTmaWorkspaceCallback = std::function<PrimExpr(const String &desc_name)>;
 using LayoutMap = Map<Buffer, Layout>;
 using BufferMap = Map<Var, Buffer>;
 
@@ -85,6 +88,7 @@ struct LowerArgs {
   Var thread_var;
   AddWorkspaceCallback AddWorkspace;
   AllocMBarrierCallback AllocMBarrier;
+  AllocMutableTmaWorkspaceCallback AllocMutableTmaWorkspace;
   LayoutMap layout_map;
   Map<Buffer, Buffer> buffer_remap;
   // Map from LetStmt variable to its bound expression, for resolving

--- a/src/target/codegen_cuda.cc
+++ b/src/target/codegen_cuda.cc
@@ -2261,6 +2261,18 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     print_extern_call_stmt(func_name, 2);
   } else if (op->op.same_as(tl::fence_proxy_async())) {
     print_extern_call_stmt("tl::fence_proxy_async");
+  } else if (op->op.same_as(tl::tensormap_copy_to_smem())) {
+    print_extern_call_stmt("tl::tensormap_copy_to_smem");
+  } else if (op->op.same_as(tl::tensormap_replace_box_dim())) {
+    int dim_idx = Downcast<IntImm>(op->args[1])->value;
+    this->PrintIndent();
+    this->stream << "tl::tensormap_replace_box_dim<" << dim_idx << ">("
+                 << this->PrintExpr(op->args[0]) << ", "
+                 << this->PrintExpr(op->args[2]) << ");\n";
+  } else if (op->op.same_as(tl::tensormap_cp_fence_release())) {
+    print_extern_call_stmt("tl::tensormap_cp_fence_release");
+  } else if (op->op.same_as(tl::tensormap_fence_acquire())) {
+    print_extern_call_stmt("tl::tensormap_fence_acquire");
   } else if (op->op.same_as(tl::tma_store_arrive())) {
     print_extern_call_stmt("tl::tma_store_arrive");
   } else if (op->op.same_as(tl::tma_store_wait())) {

--- a/src/target/codegen_cuda.cc
+++ b/src/target/codegen_cuda.cc
@@ -2208,7 +2208,10 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
       ss << "tl::tma_load(";
     }
     auto desc = op->args[0];
-    ss << this->PrintExpr(desc) << ", ";
+    ss << ([&](const PrimExpr &e) { auto v=e.as<VarNode>(); \
+     if(v){auto p=v->type_annotation.as<PointerTypeNode>(); \
+     if(p&&p->storage_scope!="grid_constant"&&p->element_type.as<PrimTypeNode>())return"*"+this->PrintExpr(e);} \
+     return this->PrintExpr(e); })(desc) << ", ";
     ss << this->PrintExpr(op->args[1]) << ", ";
     for (size_t i = 2; i < op->args.size() - 1; i++) {
       if (i > 2)
@@ -2230,7 +2233,6 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     }
     print_extern_call_stmt(ss.str(), 0, 1);
   } else if (op->op.same_as(tl::tma_store())) {
-    std::stringstream ss;
     auto need_reduce = op->args[op->args.size() - 2].as<IntImmNode>()->value;
     if (need_reduce) {
       print_extern_call_stmt("tl::tma_store_add", 0, 2);
@@ -2239,12 +2241,23 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     auto eviction_policy =
         this->eviction_policy_names_
             [op->args[op->args.size() - 1].as<IntImmNode>()->value];
+    std::ostringstream ss;
     if (eviction_policy != "EVICT_NORMAL") {
-      ss << "tl::tma_store<tl::CacheHintSm90::" << eviction_policy << ">";
+      ss << "tl::tma_store<tl::CacheHintSm90::" << eviction_policy << ">(";
     } else {
-      ss << "tl::tma_store";
+      ss << "tl::tma_store(";
     }
-    print_extern_call_stmt(ss.str(), 0, 2);
+    ss << ([&](const PrimExpr &e) { auto v=e.as<VarNode>(); \
+     if(v){auto p=v->type_annotation.as<PointerTypeNode>(); \
+     if(p&&p->storage_scope!="grid_constant"&&p->element_type.as<PrimTypeNode>())return"*"+this->PrintExpr(e);} \
+     return this->PrintExpr(e); })(op->args[0]) << ", ";
+    ss << this->PrintExpr(op->args[1]);
+    for (size_t i = 2; i < op->args.size() - 2; i++) {
+      ss << ", " << this->PrintExpr(op->args[i]);
+    }
+    ss << ");\n";
+    this->PrintIndent();
+    this->stream << ss.str();
   } else if (op->op.same_as(tl::ptx_ldmatrix())) {
     int trans = Downcast<IntImm>(op->args[0])->value;
     int num = Downcast<IntImm>(op->args[1])->value;
@@ -2262,7 +2275,13 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
   } else if (op->op.same_as(tl::fence_proxy_async())) {
     print_extern_call_stmt("tl::fence_proxy_async");
   } else if (op->op.same_as(tl::tensormap_copy_to_smem())) {
-    print_extern_call_stmt("tl::tensormap_copy_to_smem");
+    this->PrintIndent();
+    this->stream << "tl::tensormap_copy_to_smem("
+                 << this->PrintExpr(op->args[0]) << ", "
+                 << ([&](const PrimExpr &e) { auto v=e.as<VarNode>(); \
+     if(v){auto p=v->type_annotation.as<PointerTypeNode>(); \
+     if(p&&p->storage_scope!="grid_constant"&&p->element_type.as<PrimTypeNode>())return"*"+this->PrintExpr(e);} \
+     return this->PrintExpr(e); })(op->args[1]) << ");\n";
   } else if (op->op.same_as(tl::tensormap_replace_box_dim())) {
     int dim_idx = Downcast<IntImm>(op->args[1])->value;
     this->PrintIndent();
@@ -2270,9 +2289,24 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
                  << this->PrintExpr(op->args[0]) << ", "
                  << this->PrintExpr(op->args[2]) << ");\n";
   } else if (op->op.same_as(tl::tensormap_cp_fence_release())) {
-    print_extern_call_stmt("tl::tensormap_cp_fence_release");
+    this->PrintIndent();
+    this->stream << "tl::tensormap_cp_fence_release("
+                 << ([&](const PrimExpr &e) { auto v=e.as<VarNode>(); \
+     if(v){auto p=v->type_annotation.as<PointerTypeNode>(); \
+     if(p&&p->storage_scope!="grid_constant"&&p->element_type.as<PrimTypeNode>())return"*"+this->PrintExpr(e);} \
+     return this->PrintExpr(e); })(op->args[0]) << ", "
+                 << this->PrintExpr(op->args[1]) << ");\n";
   } else if (op->op.same_as(tl::tensormap_fence_acquire())) {
-    print_extern_call_stmt("tl::tensormap_fence_acquire");
+    this->PrintIndent();
+    this->stream << "tl::tensormap_fence_acquire("
+                 << ([&](const PrimExpr &e) { auto v=e.as<VarNode>(); \
+     if(v){auto p=v->type_annotation.as<PointerTypeNode>(); \
+     if(p&&p->storage_scope!="grid_constant"&&p->element_type.as<PrimTypeNode>())return"*"+this->PrintExpr(e);} \
+     return this->PrintExpr(e); })(op->args[0]) << ");\n";
+  } else if (op->op.same_as(tl::tma_desc_slot())) {
+    // Emit as: workspace_ptr[0]
+    // FIXME: use tl::smid() for multi-block kernels
+    os << this->PrintExpr(op->args[0]) << "[0]";
   } else if (op->op.same_as(tl::tma_store_arrive())) {
     print_extern_call_stmt("tl::tma_store_arrive");
   } else if (op->op.same_as(tl::tma_store_wait())) {
@@ -4838,6 +4872,14 @@ void CodeGenTileLangCUDA::PrintFunctionSignature(const String &function_name,
           os << ' ' << vid;
           continue;
         }
+        // Mutable TMA descriptors: global scope, CUtensorMap element type.
+        // Emitted as CUtensorMap* (writable GMEM pointer) instead of
+        // __grid_constant__ const CUtensorMap.
+        if (ptr->storage_scope == "global" &&
+            ptr->element_type.as<PrimTypeNode>()) {
+          os << "CUtensorMap *" << vid;
+          continue;
+        }
       }
 
       auto it = alloc_storage_scope_.find(v.get());
@@ -4946,6 +4988,11 @@ void CodeGenTileLangCUDA::AddFunction(const GlobalVar &gvar,
           stream << "__grid_constant__ const ";
           CodeGenC::PrintType(ptr->element_type, stream);
           stream << ' ' << vid;
+          continue;
+        }
+        if (ptr->storage_scope == "global" &&
+            ptr->element_type.as<PrimTypeNode>()) {
+          stream << "CUtensorMap *" << vid;
           continue;
         }
       }

--- a/src/target/rt_mod_cuda.cc
+++ b/src/target/rt_mod_cuda.cc
@@ -56,6 +56,12 @@ ExtractFuncInfo(const IRModule &mod) {
           info.arg_types.push_back(DataType(runtime::kDLGridConstant, 64, 1));
           continue;
         }
+        // Mutable TMA descriptor workspace: passed as CUtensorMap *.
+        if (ptr && ptr->storage_scope == "global" &&
+            ptr->element_type.as<PrimTypeNode>()) {
+          info.arg_types.push_back(DataType::Handle(64));
+          continue;
+        }
       }
       DataType dtype = f->params[i].dtype();
       // Device runtime cannot directly take bool arguments, map to int32.

--- a/src/tl_templates/cuda/copy_sm90.h
+++ b/src/tl_templates/cuda/copy_sm90.h
@@ -411,20 +411,34 @@ TL_DEVICE void prefetch_tma_descriptor(const CUtensorMap &descriptor) {
   asm volatile("prefetch.tensormap [%0];" : : "l"(gmem_int_desc) : "memory");
 }
 
+/*! \brief Read the SM (streaming multiprocessor) ID via PTX %smid. */
+TL_DEVICE unsigned smid() {
+  unsigned id;
+  asm volatile("mov.u32 %0, %%smid;" : "=r"(id));
+  return id;
+}
+
+/* Utility functions for tensormap, requires CUDA >= 12.3 */
+
 #if (__CUDACC_VER_MAJOR__ > 12) ||                                             \
     (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 3)
 
 TL_DEVICE void tensormap_copy_to_smem(void *smem_desc,
                                       const CUtensorMap &gmem_desc) {
+  // Copy the full 128-byte descriptor (sizeof CUtensorMap = 128).
+  // uint4 is 16 bytes, so we need 8 copies.
   uint4 *dst = reinterpret_cast<uint4 *>(smem_desc);
   const uint4 *src = reinterpret_cast<const uint4 *>(&gmem_desc);
-  dst[0] = src[0];
-  dst[1] = src[1];
+  #pragma unroll
+  for (int i = 0; i < 8; ++i) {
+    dst[i] = src[i];
+  }
 }
 
 template <int32_t DimIdx>
 TL_DEVICE void tensormap_replace_box_dim(void *smem_desc,
                                          int32_t new_box_dim) {
+  static_assert(DimIdx >= 0 && DimIdx < 5, "Invalid dimension index");
   uint32_t smem_int_desc = smem_ptr_to_uint(smem_desc);
   if constexpr (DimIdx == 0) {
     asm volatile(

--- a/src/tl_templates/cuda/copy_sm90.h
+++ b/src/tl_templates/cuda/copy_sm90.h
@@ -411,4 +411,73 @@ TL_DEVICE void prefetch_tma_descriptor(const CUtensorMap &descriptor) {
   asm volatile("prefetch.tensormap [%0];" : : "l"(gmem_int_desc) : "memory");
 }
 
+#if (__CUDACC_VER_MAJOR__ > 12) ||                                             \
+    (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 3)
+
+TL_DEVICE void tensormap_copy_to_smem(void *smem_desc,
+                                      const CUtensorMap &gmem_desc) {
+  uint4 *dst = reinterpret_cast<uint4 *>(smem_desc);
+  const uint4 *src = reinterpret_cast<const uint4 *>(&gmem_desc);
+  dst[0] = src[0];
+  dst[1] = src[1];
+}
+
+template <int32_t DimIdx>
+TL_DEVICE void tensormap_replace_box_dim(void *smem_desc,
+                                         int32_t new_box_dim) {
+  uint32_t smem_int_desc = smem_ptr_to_uint(smem_desc);
+  if constexpr (DimIdx == 0) {
+    asm volatile(
+        "tensormap.replace.tile.box_dim.shared::cta.b1024.b32 [%0], 0, %1;"
+        :
+        : "r"(smem_int_desc), "r"(new_box_dim)
+        : "memory");
+  } else if constexpr (DimIdx == 1) {
+    asm volatile(
+        "tensormap.replace.tile.box_dim.shared::cta.b1024.b32 [%0], 1, %1;"
+        :
+        : "r"(smem_int_desc), "r"(new_box_dim)
+        : "memory");
+  } else if constexpr (DimIdx == 2) {
+    asm volatile(
+        "tensormap.replace.tile.box_dim.shared::cta.b1024.b32 [%0], 2, %1;"
+        :
+        : "r"(smem_int_desc), "r"(new_box_dim)
+        : "memory");
+  } else if constexpr (DimIdx == 3) {
+    asm volatile(
+        "tensormap.replace.tile.box_dim.shared::cta.b1024.b32 [%0], 3, %1;"
+        :
+        : "r"(smem_int_desc), "r"(new_box_dim)
+        : "memory");
+  } else if constexpr (DimIdx == 4) {
+    asm volatile(
+        "tensormap.replace.tile.box_dim.shared::cta.b1024.b32 [%0], 4, %1;"
+        :
+        : "r"(smem_int_desc), "r"(new_box_dim)
+        : "memory");
+  }
+}
+
+TL_DEVICE void tensormap_cp_fence_release(const CUtensorMap &gmem_desc,
+                                          void *smem_desc) {
+  uint64_t gmem_int_desc = reinterpret_cast<uint64_t>(&gmem_desc);
+  uint32_t smem_int_desc = smem_ptr_to_uint(smem_desc);
+  asm volatile(
+      "tensormap.cp_fenceproxy.global.shared::cta.tensormap::generic.release."
+      "gpu.sync.aligned [%0], [%1], 128;"
+      :
+      : "l"(gmem_int_desc), "r"(smem_int_desc)
+      : "memory");
+}
+
+TL_DEVICE void tensormap_fence_acquire(const CUtensorMap &gmem_desc) {
+  uint64_t gmem_int_desc = reinterpret_cast<uint64_t>(&gmem_desc);
+  asm volatile("fence.proxy.tensormap::generic.acquire.gpu [%0], 128;"
+               :
+               : "l"(gmem_int_desc)
+               : "memory");
+}
+#endif // CUDA >= 12.3
+
 } // namespace tl

--- a/src/transform/detect_mutable_descriptors.cc
+++ b/src/transform/detect_mutable_descriptors.cc
@@ -1,0 +1,81 @@
+/*!
+ * \file detect_mutable_descriptors.cc
+ * \brief Detect TMA descriptors that are mutated via tensormap.replace + cp_fence_release.
+ *
+ * Runs before LowerHopperIntrin.  Scans the PrimFunc body for
+ * tensormap_cp_fence_release calls; each such call's first argument names a
+ * descriptor that will be written back to global memory at runtime and must
+ * therefore use a per-block GMEM workspace slot instead of the read-only
+ * __grid_constant__ parameter.
+ *
+ * Sets PrimFunc attributes:
+ *   "mutable_tma_descriptor_count" (Integer) – total mutable descriptors
+ *   "mutable_tma_descriptor_names"  (Array<StringImm>) – Var name_hints
+ */
+
+#include <string>
+#include <tvm/ffi/reflection/registry.h>
+#include <tvm/ir/transform.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
+#include <unordered_set>
+#include <vector>
+
+#include "../op/builtin.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tir;
+using namespace tir::transform;
+
+class MutableDescDetector : public StmtExprVisitor {
+public:
+  void VisitExpr_(const CallNode *op) final {
+    if (op->op.same_as(tensormap_cp_fence_release()) && op->args.size() >= 1) {
+      if (auto var = op->args[0].as<VarNode>()) {
+        mutable_desc_names_.insert(var->name_hint);
+      }
+    }
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
+  std::vector<std::string> GetSortedNames() const {
+    std::vector<std::string> names(mutable_desc_names_.begin(),
+                                   mutable_desc_names_.end());
+    std::sort(names.begin(), names.end());
+    return names;
+  }
+
+private:
+  std::unordered_set<std::string> mutable_desc_names_;
+};
+
+tvm::transform::Pass DetectMutableDescriptors() {
+  auto pass_func = [=](PrimFunc f, const IRModule &m, PassContext ctx) {
+    MutableDescDetector detector;
+    detector(f->body);
+    auto names = detector.GetSortedNames();
+
+    if (!names.empty()) {
+      Array<StringImm> name_arr;
+      for (const auto &n : names) {
+        name_arr.push_back(StringImm(n));
+      }
+      f = WithAttr(std::move(f), "mutable_tma_descriptor_names", name_arr);
+      f = WithAttr(std::move(f), "mutable_tma_descriptor_count",
+                   Integer(static_cast<int>(names.size())));
+    }
+    return f;
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.DetectMutableDescriptors", {});
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  refl::GlobalDef().def("tl.transform.DetectMutableDescriptors",
+                        DetectMutableDescriptors);
+}
+
+} // namespace tl
+} // namespace tvm

--- a/src/transform/fuse_mbarrier_arrive_expect_tx.cc
+++ b/src/transform/fuse_mbarrier_arrive_expect_tx.cc
@@ -102,6 +102,17 @@ private:
       return true;
     }
 
+    // tensormap_replace machinery: these are descriptor-manipulation PTX
+    // intrinsics that don't perform async memory transfers and don't interact
+    // with the mbarrier. Treat them as transparent so that the expect_tx /
+    // arrive pair can be fused into arrive_and_expect_tx.
+    if (call.value()->op.same_as(tl::tensormap_copy_to_smem()) ||
+        call.value()->op.same_as(tl::tensormap_replace_box_dim()) ||
+        call.value()->op.same_as(tl::tensormap_cp_fence_release()) ||
+        call.value()->op.same_as(tl::tensormap_fence_acquire())) {
+      return true;
+    }
+
     if (call.value()->op.same_as(builtin::tvm_storage_sync())) {
       if (call.value()->args.size() == 1) {
         if (const auto *scope = call.value()->args[0].as<StringImmNode>()) {

--- a/src/transform/inject_fence_proxy.cc
+++ b/src/transform/inject_fence_proxy.cc
@@ -213,6 +213,25 @@ ProxyEvent ClassifyCallProxyEvent(const CallNode *call) {
   if (IsFenceProxyAsyncCall(call)) {
     return ProxyEvent::kNeutral;
   }
+
+  // tensormap_replace machinery: these ops manipulate TMA descriptors through
+  // opaque PTX intrinsics.  Although their arguments may contain SMEM pointers,
+  // the SMEM accesses are inside leader-gated blocks and do not interact with
+  // the async/generic proxy that IsAsyncIntrinsic / CallMayWriteSharedMemory
+  // track.  Return kNone to avoid injecting a spurious fence.proxy.async
+  // before the subsequent TMA load/store.
+  if (call->op.same_as(tensormap_copy_to_smem()) ||
+      call->op.same_as(tensormap_replace_box_dim()) ||
+      call->op.same_as(tensormap_cp_fence_release())) {
+    return ProxyEvent::kNone;
+  }
+  // tensormap_fence_acquire is an acquire fence on the TMA generic proxy;
+  // treat it as a proxy-state reset (kNeutral) so the proxy state machine
+  // does not accumulate stale generic state.
+  if (call->op.same_as(tensormap_fence_acquire())) {
+    return ProxyEvent::kNeutral;
+  }
+
   if (IsAsyncIntrinsic(call)) {
     return ProxyEvent::kAsync;
   }

--- a/src/transform/lower_hopper_intrin.cc
+++ b/src/transform/lower_hopper_intrin.cc
@@ -1,6 +1,19 @@
 /*!
  * \file lower hopper intrin.cc
  * \brief Lower Hopper intrinsics cuda GPU(sm90+)
+ *
+ * Processes create_tma_descriptor / create_tma_im2col_descriptor calls:
+ *   - Replaces each call with a typed __grid_constant__ descriptor Var.
+ *   - Emits prefetch_tma_descriptor in the thread-leader prologue.
+ *
+ * Also handles tma_desc_slot calls:
+ *   - Converts the raw workspace_ptr Var into a typed CUtensorMap* "global"
+ *     scope Var so codegen emits it as a CUtensorMap* kernel parameter.
+ *   - Leaves the tma_desc_slot Call in place (codegen emits ptr[idx]).
+ *
+ * Grid_constant descriptors are never replaced in-place because they are
+ * read-only.  Mutable descriptor workspace is allocated on the host side
+ * (CUtensorMap * kernel param) and written by tensormap_cp_fence_release.
  */
 
 #include <tvm/ffi/reflection/registry.h>
@@ -9,6 +22,10 @@
 #include <tvm/tir/op.h>
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/tir/transform.h>
+
+#include <set>
+#include <string>
+#include <unordered_map>
 
 #include "../op/builtin.h"
 #include "../runtime/runtime.h"
@@ -19,18 +36,51 @@ namespace tl {
 using namespace tir;
 
 #if (CUDA_MAJOR_VERSION >= 12)
+
+namespace {
+
+/*!
+ * \brief Scan for tma_desc_slot calls and collect workspace pointer Var names.
+ */
+class WorkSpacePtrCollector : public StmtExprVisitor {
+public:
+  void VisitExpr_(const CallNode *op) final {
+    if (op->op.same_as(tma_desc_slot()) && !op->args.empty()) {
+      if (auto var = op->args[0].as<VarNode>()) {
+        workspace_ptr_names_.insert(var->name_hint);
+      }
+    }
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
+  const std::set<std::string> &workspace_ptr_names() const {
+    return workspace_ptr_names_;
+  }
+
+private:
+  std::set<std::string> workspace_ptr_names_;
+};
+
+} // namespace
+
 class LowerHopperIntrin : public StmtExprMutator {
 public:
   static PrimFunc Substitute(PrimFunc &f, bool disable_shuffle_elect) {
     PrimFuncNode *fptr = f.CopyOnWrite();
-    LowerHopperIntrin substituter(disable_shuffle_elect);
+
+    // Scan for tma_desc_slot workspace pointer names.
+    WorkSpacePtrCollector ws_collector;
+    ws_collector(f->body);
+    std::set<std::string> ws_ptr_names = ws_collector.workspace_ptr_names();
+
+    LowerHopperIntrin substituter(disable_shuffle_elect, ws_ptr_names);
     fptr->body = substituter.VisitStmt(f->body);
+
     Map<Var, Array<PrimExpr>> init_desc_arg_map;
-    // Collect prologue/epilogue statements for host-side setup/teardown
     Array<Stmt> prologue_stmts;
     Array<Stmt> epilogue_stmts;
+
     for (const auto &[call, var] : substituter.desc_map_) {
-      // Should allocate 128 bytes for TensorMap on stack
       Call alloc_desc = Call(DataType::Handle(), builtin::tvm_stack_alloca(),
                              {StringImm("tvm_ffi_any"), 16});
       Array<PrimExpr> init_desc_args;
@@ -44,22 +94,18 @@ public:
       init_desc_args.push_back(var);
       init_desc_args.insert(init_desc_args.end(), call->args.begin(),
                             call->args.end());
-      // add to function attribute
       Call init_desc =
           Call(DataType::Handle(), builtin::tvm_call_packed(), init_desc_args);
-      // Accumulate TMA descriptor init into prologue
       prologue_stmts.push_back(LetStmt(var, alloc_desc, Evaluate(init_desc)));
       init_desc_arg_map.Set(var, init_desc_args);
     }
     f = WithAttr(std::move(f), "tma_descriptor_args", init_desc_arg_map);
 
-    // Additionally, if L2 persistent cache annotations were lowered earlier,
-    // materialize TVM FFI calls to set the stream access policy window.
+    // L2 persistent cache handling (unchanged).
     if (f->attrs.defined() && f->attrs->dict.count("l2_persistent_map")) {
       auto l2_map =
           f->GetAttr<Map<String, Array<PrimExpr>>>("l2_persistent_map");
       if (l2_map.defined()) {
-        // Build a lookup from buffer name to Buffer object
         std::unordered_map<std::string, Buffer> name2buf;
         for (const auto &kv : f->buffer_map) {
           name2buf.emplace(kv.second->name, kv.second);
@@ -67,19 +113,8 @@ public:
         for (const auto &kv : l2_map.value()) {
           const std::string buf_name = kv.first;
           const Array<PrimExpr> &args = kv.second;
-          if (name2buf.count(buf_name) == 0) {
-            continue;
-          }
+          if (name2buf.count(buf_name) == 0) continue;
           const Buffer &buf = name2buf.at(buf_name);
-          // Build base pointer expression.
-          //
-          // We only need the base address for CUDA stream access policy window
-          // configuration. Using `Buffer::access_ptr` would materialize a
-          // typed pointer cast based on `buf->dtype` (e.g. float16 -> `half*`)
-          // in the generated C host stubs, which then requires a `half`
-          // definition during host compilation. Since the runtime API treats
-          // the pointer as opaque, keep it as `void*`/handle and adjust by
-          // `elem_offset` in bytes when needed.
           PrimExpr base_ptr = buf->data;
           if (buf->elem_offset.defined() && !is_zero(buf->elem_offset)) {
             PrimExpr byte_offset =
@@ -89,20 +124,16 @@ public:
                 Call(DataType::Handle(), builtin::handle_add_byte_offset(),
                      {base_ptr, byte_offset});
           }
-          // Args packed: func_name, base_ptr, num_bytes, hit_ratio
           Array<PrimExpr> packed_args;
           packed_args.push_back(
               StringImm(tvm_cuda_stream_set_access_policy_window));
           packed_args.push_back(base_ptr);
-          // size_in_bytes (args[1]) then hit_ratio (args[0])
           ICHECK_GE(args.size(), 2);
           packed_args.push_back(args[1]);
           packed_args.push_back(args[0]);
           prologue_stmts.push_back(Evaluate(Call(
               DataType::Int(32), builtin::tvm_call_packed(), packed_args)));
         }
-        // Add a single epilogue call to reset the access policy window and
-        // restore L2 limit
         Array<PrimExpr> reset_args;
         reset_args.push_back(
             StringImm(tvm_cuda_stream_reset_access_policy_window));
@@ -111,9 +142,24 @@ public:
       }
     }
 
-    // Stitch prologue statements before the original body
+    // Add typed workspace vars to f->params and buffer_map so MakePackedAPI
+    // includes them as API arguments with the correct handle type.
+    if (!substituter.ws_ptr_var_map_.empty()) {
+      for (const auto &kv : substituter.ws_ptr_var_map_) {
+        Var ws_ptr = kv.second;
+        // Add to function params
+        fptr->params.push_back(ws_ptr);
+        // One CUtensorMap workspace slot (128 bytes).
+        Buffer ws_buf = decl_buffer({IntImm(DataType::Int(32), 128)},
+                                    DataType::UInt(8), ws_ptr->name_hint,
+                                    "global");
+        ws_buf.CopyOnWrite()->data = ws_ptr;
+        fptr->buffer_map.Set(ws_ptr, ws_buf);
+      }
+    }
+
+    // Stitch prologue statements before the original body.
     if (!prologue_stmts.empty()) {
-      // Chain the Let/Evaluate statements sequentially
       Stmt seq = prologue_stmts.size() == 1 ? prologue_stmts[0]
                                             : SeqStmt(prologue_stmts);
       fptr->body = SeqStmt({seq, fptr->body});
@@ -158,6 +204,7 @@ public:
   PrimExpr VisitExpr_(const CallNode *call) final {
     if (call->op.same_as(create_tma_descriptor()) ||
         call->op.same_as(create_tma_im2col_descriptor())) {
+      // All descriptors are grid_constant (read-only) with prefetch.
       Var var;
       auto iter = desc_map_.find(tvm::ffi::GetRef<Call>(call));
       if (iter != desc_map_.end()) {
@@ -172,6 +219,27 @@ public:
                           {StringImm("tl::prefetch_tma_descriptor"), var})));
       }
       return var;
+    } else if (call->op.same_as(tma_desc_slot())) {
+      // Convert raw workspace_ptr Var to typed CUtensorMap* parameter.
+      // The first arg is workspace_ptr, second is slot index.
+      auto args = call->args;
+      if (auto var = args[0].as<VarNode>()) {
+        if (ws_ptr_names_.count(var->name_hint) > 0) {
+          auto it = ws_ptr_var_map_.find(var->name_hint);
+          if (it != ws_ptr_var_map_.end()) {
+            args.Set(0, it->second);
+          } else {
+            Var typed = Var(var->name_hint,
+                            PointerType(PrimType(cuTensorMapType()), "global"));
+            ws_ptr_var_map_[var->name_hint] = typed;
+            args.Set(0, typed);
+          }
+        }
+      }
+      if (args.same_as(call->args)) {
+        return tvm::ffi::GetRef<PrimExpr>(call);
+      }
+      return Call(call->dtype, call->op, args);
     } else {
       return StmtExprMutator::VisitExpr_(call);
     }
@@ -180,8 +248,12 @@ public:
 private:
   Array<Stmt> prefetch_calls_;
   std::unordered_map<Call, Var, StructuralHash, ExprDeepEqual> desc_map_;
-  LowerHopperIntrin(bool disable_shuffle_elect)
-      : disable_shuffle_elect_(disable_shuffle_elect) {}
+  std::set<std::string> ws_ptr_names_;
+  std::unordered_map<std::string, Var> ws_ptr_var_map_;
+  LowerHopperIntrin(bool disable_shuffle_elect,
+                    const std::set<std::string> &ws_ptr_names)
+      : disable_shuffle_elect_(disable_shuffle_elect),
+        ws_ptr_names_(ws_ptr_names) {}
   bool disable_shuffle_elect_;
 };
 

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -227,6 +227,17 @@ public:
     // later phases (OptimizeForTarget) can choose the right pass pipeline
     // without relying on pass-context side-channel mutation.
     f = WithAttr(std::move(f), kHasTMA, Bool(substituter.has_tma_));
+
+    // Record mutable TMA workspace var names for host-side allocation.
+    if (!substituter.mutable_workspace_vars_.empty()) {
+      Array<StringImm> ws_names;
+      for (const auto &v : substituter.mutable_workspace_vars_) {
+        ws_names.push_back(StringImm(v->name_hint));
+      }
+      f = WithAttr(std::move(f), "mutable_tma_workspace_names", ws_names);
+      f = WithAttr(std::move(f), "mutable_tma_descriptor_count",
+                   Integer(static_cast<int>(ws_names.size())));
+    }
     fptr = f.CopyOnWrite();
 
     // If any TMA copies allocated mbarriers, inject the barrier buffer
@@ -1068,9 +1079,22 @@ private:
       return id;
     };
 
+    AllocMutableTmaWorkspaceCallback mutable_ws_callback =
+        [this](const String &desc_name) -> PrimExpr {
+      auto it = mutable_workspace_map_.find(desc_name);
+      if (it != mutable_workspace_map_.end()) {
+        return (*it).second;
+      }
+      Var ws_ptr("tma_workspace_" + desc_name, DataType::Handle());
+      mutable_workspace_map_.Set(desc_name, ws_ptr);
+      mutable_workspace_vars_.push_back(ws_ptr);
+      return ws_ptr;
+    };
+
     auto lowered =
         tile_op->Lower(LowerArgs{target_, thread_bounds, thread_var_->var,
-                                 callback, mbarrier_callback, layout_map_,
+                                 callback, mbarrier_callback,
+                                 mutable_ws_callback, layout_map_,
                                  buffer_remap_, let_var_to_expr,
                                  loop_mbar_phase_stack_.empty()
                                      ? PrimExpr(IntImm(DataType::Int(32), 0))
@@ -1362,6 +1386,11 @@ private:
   // barrier_init annotation into the root block after all tile ops are lowered.
   int mbarrier_count_{0};
   std::vector<int> mbarrier_arrive_counts_;
+  // Counter and name->Var map for per-block mutable TMA descriptor workspace
+  // pointers, created by the AllocMutableTmaWorkspace callback and later
+  // converted to CUtensorMap * kernel params by LowerHopperIntrin.
+  std::vector<Var> mutable_workspace_vars_;
+  Map<String, Var> mutable_workspace_map_;
   // The shared.barrier scope buffer created lazily by AllocMBarrier callback.
   Optional<Buffer> mbarrier_buffer_;
   // Fallback mbarrier parity derived from the nearest enclosing serial loop.

--- a/src/transform/make_packed_api.cc
+++ b/src/transform/make_packed_api.cc
@@ -529,6 +529,9 @@ PrimFunc MakePackedAPI(PrimFunc func) {
     arg_buffer_declarations.push_back(DeclBuffer(buffer, nop));
   }
 
+  // Save mutable TMA descriptor count before WithAttrs replaces it.
+  auto mutable_tma_count = func->GetAttr<Integer>("mutable_tma_descriptor_count");
+
   // reset global symbol to attach prefix
   func = WithAttrs(
       std::move(func),
@@ -536,6 +539,12 @@ PrimFunc MakePackedAPI(PrimFunc func) {
        {tvm::attr::kTarget, target_host},
        {tvm::attr::kGlobalSymbol,
         ffi::symbol::tvm_ffi_symbol_prefix + global_symbol.value()}});
+
+  // Re-attach mutable TMA count that WithAttrs stripped.
+  if (mutable_tma_count.defined()) {
+    func = WithAttr(std::move(func), "mutable_tma_descriptor_count",
+                    mutable_tma_count.value());
+  }
 
   Stmt body = ReturnRewriter(v_result)(func_ptr->body);
   body = AttrStmt(make_zero(DataType::Int(32)), tir::attr::compute_scope,

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -1144,6 +1144,29 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       }
       return;
     }
+    // tensormap.replace machinery: these ops take SMEM workspace pointers
+    // but must not trigger tvm_storage_sync barriers because all the work
+    // is single-threaded (inside tl_shuffle_elect).  Visiting the args
+    // without marking shared memory accesses prevents the sync planner from
+    // inserting __syncthreads() inside the leader-gated block.
+    auto is_tensormap_replace_op = [&]() {
+      if (auto opt = op->op.as<Op>()) {
+        const Op &call_op = opt.value();
+        return call_op.same_as(tl::tensormap_copy_to_smem()) ||
+               call_op.same_as(tl::tensormap_replace_box_dim()) ||
+               call_op.same_as(tl::tensormap_cp_fence_release()) ||
+               call_op.same_as(tl::tensormap_fence_acquire());
+      }
+      return false;
+    }();
+    if (is_tensormap_replace_op) {
+      tensormap_depth_++;
+      for (const auto &a : op->args) {
+        this->VisitExpr(a);
+      }
+      tensormap_depth_--;
+      return;
+    }
     if (op->op.same_as(builtin::address_of())) {
       ICHECK_EQ(op->args.size(), 1U);
       if (auto load = op->args[0].as<BufferLoadNode>()) {
@@ -1248,12 +1271,14 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
         e.scope = scope;
         if (flag->value & 1) {
           e.type = kRead;
-          e.is_async_copy = (tma_depth_ > 0 || cp_async_depth_ > 0);
+          e.is_async_copy =
+              (tma_depth_ > 0 || cp_async_depth_ > 0 || tensormap_depth_ > 0);
           curr_stmt_.access.emplace_back(e);
         }
         if (flag->value & 2) {
           e.type = kWrite;
-          e.is_async_copy = (tma_depth_ > 0 || cp_async_depth_ > 0);
+          e.is_async_copy =
+              (tma_depth_ > 0 || cp_async_depth_ > 0 || tensormap_depth_ > 0);
           curr_stmt_.access.emplace_back(e);
         }
       }
@@ -1492,6 +1517,10 @@ private:
   int tma_depth_{0};
   // Nesting depth of cp.async calls (ptx_cp_async)
   int cp_async_depth_{0};
+  // Nesting depth of tensormap.replace machinery calls
+  // (tensormap_copy_to_smem / replace_box_dim / cp_fence_release /
+  // fence_acquire)
+  int tensormap_depth_{0};
   // Whether we're visiting the pointer argument expression of an atomic call
   // (e.g., atomic_add/atomic_max/atomic_load). When > 0, accesses produced by
   // the pointer metadata ops are tagged as atomic.

--- a/testing/python/language/test_tilelang_language_tma_dynamic.py
+++ b/testing/python/language/test_tilelang_language_tma_dynamic.py
@@ -1,0 +1,77 @@
+import tilelang
+import tilelang.testing
+from tilelang import language as T
+import pytest
+import torch
+
+
+@tilelang.jit
+def make_dynamic_copy_kernel():
+    @T.prim_func
+    def kernel(
+        A: T.Tensor([128, 128], T.float16),
+        B: T.Tensor([128, 128], T.float16),
+        actual_rows: T.int32,
+    ):
+        with T.Kernel(1, threads=128) as bx:
+            shared = T.alloc_shared([128, 128], T.float16)
+            # Dynamic M-dim extent: should trigger tensormap.replace
+            T.copy(A[:actual_rows, :], shared[:actual_rows, :])
+            T.copy(shared[:actual_rows, :], B[:actual_rows, :])
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_dynamic_tma_copy_emits_tensormap_replace():
+    """T.copy with dynamic extents emits tensormap.replace + fence sequence."""
+    kernel = make_dynamic_copy_kernel()
+
+    A = torch.randn((128, 128), dtype=torch.float16, device='cuda')
+    B = torch.zeros_like(A)
+    kernel(A, B, 127)
+    print(kernel.get_kernel_source())
+    assert torch.allclose(B[:127, :], A[:127, :])
+    assert torch.allclose(B[127:, :], torch.zeros_like(A[127:, :]))
+
+    src = kernel.get_kernel_source()
+    assert "tensormap_copy_to_smem" in src, (
+        "Expected tensormap_copy_to_smem for dynamic extents:\n" + src
+    )
+    assert "tensormap_replace_box_dim" in src, (
+        "Expected tensormap_replace_box_dim for dynamic extents:\n" + src
+    )
+    assert "tensormap_cp_fence_release" in src, (
+        "Expected tensormap_cp_fence_release for dynamic extents:\n" + src
+    )
+    assert "tensormap_fence_acquire" in src, (
+        "Expected tensormap_fence_acquire for dynamic extents:\n" + src
+    )
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_dynamic_copy_with_load_requires_barrier():
+    """T.tma_copy load with dynamic extent requires barrier (unchanged)."""
+    @T.prim_func
+    def kernel(
+        A: T.Tensor([4096, block_K], T.float16),
+        actual_rows: T.int32,
+    ):
+        with T.Kernel(1, threads=128) as bx:
+            A_shared = T.alloc_shared([block_M, block_K], T.float16)
+            mbar = T.alloc_barrier(1)
+            T.tma_copy(A[:actual_rows, :], A_shared[:actual_rows, :],
+                       barrier=mbar[0])
+    src = tilelang.compile(kernel).get_kernel_source()
+    assert "tensormap_replace_box_dim" in src, (
+        "TMA load with dynamic extent should also emit tensormap.replace:\n" + src
+    )
+
+
+if __name__ == "__main__":
+    test_dynamic_tma_copy_emits_tensormap_replace()
+    # test_static_tma_copy_no_tensormap_replace()
+    # test_dynamic_copy_with_load_requires_barrier()
+    # print("All tests passed!")

--- a/testing/python/language/test_tilelang_language_tma_dynamic.py
+++ b/testing/python/language/test_tilelang_language_tma_dynamic.py
@@ -1,11 +1,8 @@
 import tilelang
-import tilelang.testing
 from tilelang import language as T
-import pytest
 import torch
 
 
-@tilelang.jit
 def make_dynamic_copy_kernel():
     @T.prim_func
     def kernel(
@@ -15,27 +12,18 @@ def make_dynamic_copy_kernel():
     ):
         with T.Kernel(1, threads=128) as bx:
             shared = T.alloc_shared([128, 128], T.float16)
-            # Dynamic M-dim extent: should trigger tensormap.replace
             T.copy(A[:actual_rows, :], shared[:actual_rows, :])
             T.copy(shared[:actual_rows, :], B[:actual_rows, :])
 
     return kernel
 
 
-@tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_dynamic_tma_copy_emits_tensormap_replace():
     """T.copy with dynamic extents emits tensormap.replace + fence sequence."""
-    kernel = make_dynamic_copy_kernel()
-
-    A = torch.randn((128, 128), dtype=torch.float16, device='cuda')
-    B = torch.zeros_like(A)
-    kernel(A, B, 127)
-    print(kernel.get_kernel_source())
-    assert torch.allclose(B[:127, :], A[:127, :])
-    assert torch.allclose(B[127:, :], torch.zeros_like(A[127:, :]))
-
+    kernel = tilelang.compile(make_dynamic_copy_kernel())
     src = kernel.get_kernel_source()
+    print(src)
+
     assert "tensormap_copy_to_smem" in src, (
         "Expected tensormap_copy_to_smem for dynamic extents:\n" + src
     )
@@ -48,30 +36,17 @@ def test_dynamic_tma_copy_emits_tensormap_replace():
     assert "tensormap_fence_acquire" in src, (
         "Expected tensormap_fence_acquire for dynamic extents:\n" + src
     )
+    assert "prefetch_tma_descriptor" in src
+    assert "CUtensorMap *tma_workspace" in src
 
-
-@tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
-def test_dynamic_copy_with_load_requires_barrier():
-    """T.tma_copy load with dynamic extent requires barrier (unchanged)."""
-    @T.prim_func
-    def kernel(
-        A: T.Tensor([4096, block_K], T.float16),
-        actual_rows: T.int32,
-    ):
-        with T.Kernel(1, threads=128) as bx:
-            A_shared = T.alloc_shared([block_M, block_K], T.float16)
-            mbar = T.alloc_barrier(1)
-            T.tma_copy(A[:actual_rows, :], A_shared[:actual_rows, :],
-                       barrier=mbar[0])
-    src = tilelang.compile(kernel).get_kernel_source()
-    assert "tensormap_replace_box_dim" in src, (
-        "TMA load with dynamic extent should also emit tensormap.replace:\n" + src
-    )
+    A = torch.randn((128, 128), dtype=torch.float16, device='cuda')
+    B = torch.zeros_like(A)
+    kernel(A, B, 127)
+    torch.cuda.synchronize()
+   
+    assert torch.allclose(B[:127, :], A[:127, :])
+    assert torch.allclose(B[127:, :], torch.zeros_like(A[127:, :]))
 
 
 if __name__ == "__main__":
     test_dynamic_tma_copy_emits_tensormap_replace()
-    # test_static_tma_copy_no_tensormap_replace()
-    # test_dynamic_copy_with_load_requires_barrier()
-    # print("All tests passed!")

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -210,6 +210,21 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
             ins_idx: int = 0
             tensor_list: list[torch.Tensor] = []
 
+            # Count workspace pointers from CUDA kernel source.
+            # Match "CUtensorMap *name" where name contains "workspace".
+            workspace_tensors = []
+            import re
+            ws_names = set()
+            for m in re.finditer(r'CUtensorMap\s+\*\s*(\w+)',
+                                 self.device_kernel_source):
+                if 'workspace' in m.group(1):
+                    ws_names.add(m.group(1))
+            if ws_names:
+                for _ in ws_names:
+                    workspace_tensors.append(
+                        torch.empty(128, dtype=torch.uint8, device='cuda')
+                    )
+
             # Prepare input and output tensors
             for i in range(len(self.params)):
                 if i in self.result_idx:
@@ -245,6 +260,7 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
                     ins_idx += 1
                 tensor_list.append(tensor)
 
+            tensor_list.extend(workspace_tensors)
             executable(*tensor_list)
 
             # Return outputs in the requested form

--- a/tilelang/transform/__init__.py
+++ b/tilelang/transform/__init__.py
@@ -132,6 +132,20 @@ def LowerHopperIntrin():
     return _ffi_api.LowerHopperIntrin() if hasattr(_ffi_api, "LowerHopperIntrin") else lambda f: f  # type: ignore
 
 
+def DetectMutableDescriptors():
+    """DetectMutableDescriptors
+
+    Detects TMA descriptors that are mutated via tensormap.replace +
+    cp_fence_release.  Runs before LowerHopperIntrin.
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    """
+    return _ffi_api.DetectMutableDescriptors() if hasattr(_ffi_api, "DetectMutableDescriptors") else lambda f: f  # type: ignore
+
+
 def ThreadSync(storage_scope: str):
     """Insert sync between parallel read/write of shared buffers.
 


### PR DESCRIPTION
- Introduced new built-in functions: `tensormap_copy_to_smem`, `tensormap_replace_box_dim`, `tensormap_cp_fence_release`, and `tensormap_fence_acquire` to facilitate dynamic memory operations.
- Updated `LowerBulkCopy` to handle dynamic box dimensions, ensuring proper descriptor management and memory synchronization.
- Enhanced CUDA code generation to include new TMA operations.
- Added tests to verify the correct emission of TMA operations for dynamic extents in TileLang kernels.