### PR TITLE
[Enhancement][CUDA][SM100] Report unsupported FP6 vector types earlier

### DIFF
--- a/src/target/codegen_cuda.cc
+++ b/src/target/codegen_cuda.cc
@@ -771,8 +771,9 @@ void CodeGenTileLangCUDA::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
     enable_fp6_ = true;
     if (t.lanes() <= 4) {
       os << GetTileLangFP6Type(t);
+      return;
     }
-    return;
+    fail = true;
   } else if (t.is_float4()) {
     enable_fp4_ = true;
     if (t.lanes() <= 64) {


### PR DESCRIPTION
## Summary

Improve CUDA codegen diagnostics for unsupported FP6 vector types (`lanes > 4`). Previously this path could return without emitting a type, producing malformed CUDA and confusing downstream NVCC errors. This change lets it reach TileLang’s existing unsupported-type error path instead.

## Why

FP6 tensors may be lowered through layout transform, reindex, or tiled staging paths that introduce vectorized element types in the IR. When such a path produces an FP6 type with wider lanes, e.g. `float6x8` or `float6x16`, CUDA codegen currently has no corresponding emitted type. Reporting the unsupported type at TileLang codegen time gives a clearer failure mode than generating malformed CUDA and deferring the error to NVCC.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA code generation handling for specific vector type compilation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->