### PR TITLE
[Bugfix] Fix safe memory guard reuse for issue 2119

### DIFF
--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -4,6 +4,7 @@
  */
 
 #include <tvm/ffi/reflection/registry.h>
+#include <tvm/node/structural_equal.h>
 #include <tvm/tir/builtin.h>
 #include <tvm/tir/op.h>
 #include <tvm/tir/stmt_functor.h>
@@ -11,6 +12,7 @@
 #include <tvm/tir/utils.h>
 
 #include <utility>
+#include <vector>
 
 #include "../op/builtin.h"
 #include "../op/parallel.h"
@@ -33,9 +35,11 @@ struct SafeMemChecker : public StmtExprVisitor {
 
   bool disableOOBWarning = false;
 
-  SafeMemChecker(arith::Analyzer *analyzer, bool recursively_collect_conds)
+  SafeMemChecker(arith::Analyzer *analyzer, bool recursively_collect_conds,
+                 Array<PrimExpr> active_predicates = {})
       : analyzer_(analyzer),
-        recursively_collect_conds_(recursively_collect_conds) {
+        recursively_collect_conds_(recursively_collect_conds),
+        active_predicates_(std::move(active_predicates)) {
     disableOOBWarning =
         tvm::transform::PassContext::Current()
             ->GetConfig(kDisableOutOfBoundWarning, Optional<Bool>())
@@ -116,16 +120,21 @@ struct SafeMemChecker : public StmtExprVisitor {
       // If analyzer->CanProve(index < shape_dim) returns false,
       // it means we cannot prove the access is within bounds.
       PrimExpr upper_bound_cond = index < shape_dim;
-      bool can_prove_upper = false;
-      try {
-        can_prove_upper = analyzer_->CanProve(
-            upper_bound_cond, arith::ProofStrength::kSymbolicBound);
-      } catch (const Error &e) {
-        // Some layout-lowered sparse/global indices contain arithmetic that
-        // defeats interval reasoning.  Safe-memory legalization should remain
-        // conservative in that case and emit an explicit runtime guard instead
-        // of hard-failing compilation.
-        can_prove_upper = false;
+      bool can_prove_upper = IsKnownActivePredicate(upper_bound_cond);
+      if (!can_prove_upper) {
+        try {
+          can_prove_upper = analyzer_->CanProve(
+              upper_bound_cond, arith::ProofStrength::kSymbolicBound);
+        } catch (const Error &e) {
+          // Some layout-lowered sparse/global indices contain arithmetic that
+          // defeats interval reasoning.  Safe-memory legalization should remain
+          // conservative in that case and emit an explicit runtime guard
+          // instead of hard-failing compilation.
+          can_prove_upper = false;
+        }
+        if (!can_prove_upper) {
+          can_prove_upper = CanProveWithActivePredicates(upper_bound_cond);
+        }
       }
       if (!can_prove_upper) {
         if (throw_warning) {
@@ -138,12 +147,17 @@ struct SafeMemChecker : public StmtExprVisitor {
       }
       // Check if index >= 0 can be proven.
       PrimExpr lower_bound_cond = index >= 0;
-      bool can_prove_lower = false;
-      try {
-        can_prove_lower = analyzer_->CanProve(
-            lower_bound_cond, arith::ProofStrength::kSymbolicBound);
-      } catch (const Error &e) {
-        can_prove_lower = false;
+      bool can_prove_lower = IsKnownActivePredicate(lower_bound_cond);
+      if (!can_prove_lower) {
+        try {
+          can_prove_lower = analyzer_->CanProve(
+              lower_bound_cond, arith::ProofStrength::kSymbolicBound);
+        } catch (const Error &e) {
+          can_prove_lower = false;
+        }
+        if (!can_prove_lower) {
+          can_prove_lower = CanProveWithActivePredicates(lower_bound_cond);
+        }
       }
       if (!can_prove_lower) {
         if (throw_warning) {
@@ -178,12 +192,69 @@ struct SafeMemChecker : public StmtExprVisitor {
     return fragile;
   }
 
+  bool IsKnownActivePredicate(const PrimExpr &cond) {
+    PrimExpr target = analyzer_->Simplify(cond);
+    for (const PrimExpr &predicate : active_predicates_) {
+      std::vector<PrimExpr> conjuncts;
+      CollectConjuncts(predicate, &conjuncts);
+      for (const PrimExpr &conjunct : conjuncts) {
+        if (StructuralEqual()(analyzer_->Simplify(conjunct), target)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  bool CanProveWithActivePredicates(const PrimExpr &cond) {
+    if (active_predicates_.empty()) {
+      return false;
+    }
+
+    // Analyzer::ConstraintContext is not mutation-aware for BufferLoad-based
+    // guards. Use Z3 only as a local implication query over predicates that the
+    // rewriter has kept valid.
+    PrimExpr assumptions = active_predicates_[0];
+    for (size_t i = 1; i < active_predicates_.size(); ++i) {
+      assumptions = tir::And(assumptions, active_predicates_[i]);
+    }
+    PrimExpr implication =
+        analyzer_->rewrite_simplify(tir::Or(Not(assumptions), cond));
+    try {
+      return analyzer_->z3_prover.CanProve(implication);
+    } catch (const Error &e) {
+      return false;
+    }
+  }
+
+  static PrimExpr StripLikely(const PrimExpr &expr) {
+    static auto op_likely = Op::Get("tir.likely");
+    if (const auto *call = expr.as<CallNode>()) {
+      if (call->op.same_as(op_likely)) {
+        return call->args[0];
+      }
+    }
+    return expr;
+  }
+
+  static void CollectConjuncts(const PrimExpr &expr,
+                               std::vector<PrimExpr> *conjuncts) {
+    PrimExpr stripped = StripLikely(expr);
+    if (const auto *and_node = stripped.as<AndNode>()) {
+      CollectConjuncts(and_node->a, conjuncts);
+      CollectConjuncts(and_node->b, conjuncts);
+    } else {
+      conjuncts->push_back(stripped);
+    }
+  }
+
   Array<PrimExpr> GetConditions() { return _conditions; }
 
 private:
   Array<PrimExpr> _conditions;
   arith::Analyzer *analyzer_;
   bool recursively_collect_conds_;
+  Array<PrimExpr> active_predicates_;
 };
 
 class SafeMemorysRewriter : public IRMutatorWithAnalyzer {
@@ -204,17 +275,105 @@ public:
   }
 
 private:
+  struct ActivePredicate {
+    PrimExpr predicate;
+    std::vector<Buffer> deps;
+    bool valid{true};
+  };
+
   // Constructor initializing the base class with the analyzer
   SafeMemorysRewriter(arith::Analyzer *analyzer)
       : arith::IRMutatorWithAnalyzer(analyzer) {}
   // Constructor initializing the base class with the analyzer
+
+  Array<PrimExpr> ActivePredicates() const {
+    Array<PrimExpr> predicates;
+    for (const ActivePredicate &predicate : active_predicates_) {
+      if (predicate.valid) {
+        predicates.push_back(predicate.predicate);
+      }
+    }
+    return predicates;
+  }
+
+  static bool ContainsBuffer(const std::vector<Buffer> &buffers,
+                             const Buffer &buffer) {
+    for (const Buffer &candidate : buffers) {
+      if (candidate.same_as(buffer)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  static std::vector<Buffer> CollectPredicateDeps(const PrimExpr &predicate) {
+    std::vector<Buffer> deps;
+    PostOrderVisit(predicate, [&](const ObjectRef &obj) {
+      if (const auto *load = obj.as<BufferLoadNode>()) {
+        Buffer buffer = load->buffer;
+        if (!ContainsBuffer(deps, buffer)) {
+          deps.push_back(buffer);
+        }
+      }
+    });
+    return deps;
+  }
+
+  void PushActivePredicate(const PrimExpr &predicate) {
+    active_predicates_.push_back(
+        ActivePredicate{predicate, CollectPredicateDeps(predicate), true});
+  }
+
+  std::vector<bool> PrefixValidity(size_t size) const {
+    std::vector<bool> validity;
+    validity.reserve(size);
+    for (size_t i = 0; i < size; ++i) {
+      validity.push_back(active_predicates_[i].valid);
+    }
+    return validity;
+  }
+
+  void RestorePrefixValidity(const std::vector<ActivePredicate> &base,
+                             const std::vector<bool> &validity) {
+    active_predicates_ = base;
+    ICHECK_LE(validity.size(), active_predicates_.size());
+    for (size_t i = 0; i < validity.size(); ++i) {
+      active_predicates_[i].valid = validity[i];
+    }
+  }
+
+  void MergeBranchValidity(const std::vector<ActivePredicate> &base,
+                           const std::vector<bool> &then_validity,
+                           const std::vector<bool> &else_validity) {
+    active_predicates_ = base;
+    ICHECK_EQ(then_validity.size(), else_validity.size());
+    ICHECK_LE(then_validity.size(), active_predicates_.size());
+    for (size_t i = 0; i < then_validity.size(); ++i) {
+      active_predicates_[i].valid = then_validity[i] && else_validity[i];
+    }
+  }
+
+  void InvalidatePredicatesDependingOn(const Buffer &buffer) {
+    for (ActivePredicate &predicate : active_predicates_) {
+      if (predicate.valid && ContainsBuffer(predicate.deps, buffer)) {
+        predicate.valid = false;
+      }
+    }
+  }
+
+  void InvalidateAllActivePredicates() {
+    for (ActivePredicate &predicate : active_predicates_) {
+      predicate.valid = false;
+    }
+  }
 
   PrimExpr VisitExpr_(const BufferLoadNode *op) final {
     auto load = Downcast<BufferLoad>(IRMutatorWithAnalyzer::VisitExpr_(op));
 
     // For Load/Store, we only check the current node, not its children.
     // Since rewriter will recursively visit children.
-    SafeMemChecker checker(analyzer_, /*recursively_collect_conds=*/false);
+    SafeMemChecker checker(analyzer_, /*recursively_collect_conds=*/false,
+                           ActivePredicates());
     checker(load);
     Array<PrimExpr> conditions = checker.GetConditions();
 
@@ -237,7 +396,8 @@ private:
     // Check if the buffer is in global scope
     auto store = Downcast<BufferStore>(IRMutatorWithAnalyzer::VisitStmt_(op));
 
-    SafeMemChecker checker(analyzer_, /*recursively_collect_conds=*/false);
+    SafeMemChecker checker(analyzer_, /*recursively_collect_conds=*/false,
+                           ActivePredicates());
     checker(store);
     Array<PrimExpr> conditions = checker.GetConditions();
 
@@ -250,12 +410,15 @@ private:
             << "\nAs manual boundary check detected, potential out-of-bounds "
                "access may occur."
             << "\nAuto detect boundaries are " << conditions;
+        InvalidatePredicatesDependingOn(store->buffer);
         return store;
       }
+      InvalidatePredicatesDependingOn(store->buffer);
       return store;
     }
 
     if (conditions.empty()) {
+      InvalidatePredicatesDependingOn(store->buffer);
       return store;
     }
 
@@ -264,6 +427,7 @@ private:
     for (auto cond : conditions) {
       store_with_conditions = IfThenElse(cond, store_with_conditions);
     }
+    InvalidatePredicatesDependingOn(store->buffer);
     return store_with_conditions;
   }
 
@@ -337,7 +501,8 @@ private:
     BufferLoad src_base_load =
         GetBaseLoadFromAccessPtrExpr(call->args[kCPAsyncSrcPtrArg]);
 
-    SafeMemChecker checker(analyzer_, /*recursively_collect_conds=*/false);
+    SafeMemChecker checker(analyzer_, /*recursively_collect_conds=*/false,
+                           ActivePredicates());
     checker.CheckBufferIndices(src_base_load->buffer, src_base_load->indices,
                                /*is_load=*/true, /*throw_warning=*/false);
     return checker.GetConditions();
@@ -431,25 +596,98 @@ private:
         if (conditions.empty()) {
           // Fallback when we cannot recover the underlying buffer access
           // directly from the access_ptr arguments.
-          SafeMemChecker checker(analyzer_, /*recursively_collect_conds=*/true);
+          SafeMemChecker checker(analyzer_, /*recursively_collect_conds=*/true,
+                                 ActivePredicates());
           checker(call);
           conditions = checker.GetConditions();
         }
-        return RewriteCPAsync(evaluate, call, conditions);
+        Stmt rewritten = RewriteCPAsync(evaluate, call, conditions);
+        InvalidateAllActivePredicates();
+        return rewritten;
       }
 
       if (NeedsEvaluateBoundaryCheck(call)) {
         // For side-effect calls (extern/atomic), recursively collect
         // conditions from all children. We avoid rewriting BufferLoad in call
         // arguments directly to prevent nullptr issues in downstream lowering.
-        SafeMemChecker checker(analyzer_, /*recursively_collect_conds=*/true);
+        SafeMemChecker checker(analyzer_, /*recursively_collect_conds=*/true,
+                               ActivePredicates());
         checker(call);
         Array<PrimExpr> conditions = checker.GetConditions();
-        return WrapEvaluateWithConditions(evaluate, conditions);
+        Stmt rewritten = WrapEvaluateWithConditions(evaluate, conditions);
+        InvalidateAllActivePredicates();
+        return rewritten;
       }
     }
 
     return evaluate;
+  }
+
+  Stmt VisitStmt_(const IfThenElseNode *op) final {
+    PrimExpr condition = this->VisitExpr(op->condition);
+    PrimExpr real_condition = SafeMemChecker::StripLikely(condition);
+    bool condition_has_buffer_load =
+        !CollectPredicateDeps(real_condition).empty();
+    std::vector<ActivePredicate> base_predicates = active_predicates_;
+    size_t base_size = base_predicates.size();
+
+    Stmt then_case;
+    Optional<Stmt> else_case;
+    {
+      active_predicates_ = base_predicates;
+      PushActivePredicate(real_condition);
+      if (condition_has_buffer_load) {
+        // Do not enter Analyzer::ConstraintContext for BufferLoad conditions:
+        // a BufferStore in this branch can change the loaded value while the
+        // analyzer would still keep the old condition in scope.
+        then_case = this->VisitStmt(op->then_case);
+      } else {
+        With<arith::ConstraintContext> ctx(analyzer_, real_condition);
+        WithRecordIterPredicate(real_condition, [&] {
+          then_case = this->VisitStmt(op->then_case);
+        });
+      }
+    }
+    std::vector<bool> then_validity = PrefixValidity(base_size);
+
+    std::vector<bool> else_validity;
+    if (op->else_case) {
+      PrimExpr not_condition = analyzer_->rewrite_simplify(Not(real_condition));
+      active_predicates_ = base_predicates;
+      PushActivePredicate(not_condition);
+      if (condition_has_buffer_load) {
+        else_case = this->VisitStmt(op->else_case.value());
+      } else {
+        With<arith::ConstraintContext> ctx(analyzer_, not_condition);
+        else_case = this->VisitStmt(op->else_case.value());
+      }
+      else_validity = PrefixValidity(base_size);
+    } else {
+      active_predicates_ = base_predicates;
+      else_validity = PrefixValidity(base_size);
+    }
+
+    if (is_one(real_condition)) {
+      RestorePrefixValidity(base_predicates, then_validity);
+      return then_case;
+    }
+    if (is_zero(real_condition)) {
+      RestorePrefixValidity(base_predicates, else_validity);
+      return else_case.value_or(Evaluate(0));
+    }
+
+    MergeBranchValidity(base_predicates, then_validity, else_validity);
+
+    if (condition.same_as(op->condition) && then_case.same_as(op->then_case) &&
+        else_case.same_as(op->else_case)) {
+      return ffi::GetRef<Stmt>(op);
+    }
+
+    auto n = this->CopyOnWrite(op);
+    n->condition = std::move(condition);
+    n->then_case = std::move(then_case);
+    n->else_case = std::move(else_case);
+    return Stmt(n);
   }
 
   Stmt VisitStmt_(const BlockNode *op) final {
@@ -486,6 +724,7 @@ private:
   Map<Var, Buffer> buffer_data_to_buffer_;
   Map<Buffer, PrimExpr> annotated_safe_value_map_;
   Map<Var, PrimExpr> annotated_safe_value_by_data_;
+  std::vector<ActivePredicate> active_predicates_;
 };
 
 // Create a pass that legalizes vectorized loops in the IRModule

--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -311,7 +311,7 @@ public:
 private:
   struct ActivePredicate {
     PrimExpr predicate;
-    std::vector<Buffer> deps;
+    std::vector<Var> deps;
     bool valid{true};
   };
 
@@ -330,23 +330,39 @@ private:
     return predicates;
   }
 
-  static bool ContainsBuffer(const std::vector<Buffer> &buffers,
-                             const Buffer &buffer) {
-    for (const Buffer &candidate : buffers) {
-      if (candidate.same_as(buffer)) {
+  static bool ContainsStorage(const std::vector<Var> &storages,
+                              const Var &storage) {
+    for (const Var &candidate : storages) {
+      if (candidate.same_as(storage)) {
         return true;
       }
     }
     return false;
   }
 
-  static std::vector<Buffer> CollectPredicateDeps(const PrimExpr &predicate) {
-    std::vector<Buffer> deps;
+  Var CanonicalStorage(Var storage) const {
+    for (int depth = 0; depth < 16 && storage_aliases_.count(storage);
+         ++depth) {
+      Var next = storage_aliases_[storage];
+      if (next.same_as(storage)) {
+        break;
+      }
+      storage = next;
+    }
+    return storage;
+  }
+
+  Var StorageKey(const Buffer &buffer) const {
+    return CanonicalStorage(buffer->data);
+  }
+
+  std::vector<Var> CollectPredicateDeps(const PrimExpr &predicate) {
+    std::vector<Var> deps;
     PostOrderVisit(predicate, [&](const ObjectRef &obj) {
       if (const auto *load = obj.as<BufferLoadNode>()) {
-        Buffer buffer = load->buffer;
-        if (!ContainsBuffer(deps, buffer)) {
-          deps.push_back(buffer);
+        Var storage = StorageKey(load->buffer);
+        if (!ContainsStorage(deps, storage)) {
+          deps.push_back(storage);
         }
       }
     });
@@ -387,9 +403,43 @@ private:
     }
   }
 
+  std::vector<PrimExpr> ValidPredicatesFrom(size_t begin) const {
+    std::vector<PrimExpr> predicates;
+    for (size_t i = begin; i < active_predicates_.size(); ++i) {
+      if (active_predicates_[i].valid) {
+        predicates.push_back(active_predicates_[i].predicate);
+      }
+    }
+    return predicates;
+  }
+
+  PrimExpr Conjunction(const std::vector<PrimExpr> &predicates) {
+    if (predicates.empty()) {
+      return Bool(true);
+    }
+    PrimExpr result = predicates[0];
+    for (size_t i = 1; i < predicates.size(); ++i) {
+      result = tir::And(result, predicates[i]);
+    }
+    return analyzer_->rewrite_simplify(result);
+  }
+
+  void PushBranchSummary(const std::vector<PrimExpr> &then_predicates,
+                         const std::vector<PrimExpr> &else_predicates) {
+    if (then_predicates.empty() && else_predicates.empty()) {
+      return;
+    }
+    PrimExpr summary = analyzer_->rewrite_simplify(
+        tir::Or(Conjunction(then_predicates), Conjunction(else_predicates)));
+    if (!is_one(summary)) {
+      PushActivePredicate(summary);
+    }
+  }
+
   void InvalidatePredicatesDependingOn(const Buffer &buffer) {
+    Var storage = StorageKey(buffer);
     for (ActivePredicate &predicate : active_predicates_) {
-      if (predicate.valid && ContainsBuffer(predicate.deps, buffer)) {
+      if (predicate.valid && ContainsStorage(predicate.deps, storage)) {
         predicate.valid = false;
       }
     }
@@ -409,14 +459,15 @@ private:
     }
   }
 
-  static bool ExprDependsOnBuffer(const PrimExpr &expr, const Buffer &buffer) {
+  bool ExprDependsOnBuffer(const PrimExpr &expr, const Buffer &buffer) {
     bool depends = false;
+    Var storage = StorageKey(buffer);
     PostOrderVisit(expr, [&](const ObjectRef &obj) {
       if (depends) {
         return;
       }
       if (const auto *load = obj.as<BufferLoadNode>()) {
-        depends = load->buffer.same_as(buffer);
+        depends = StorageKey(load->buffer).same_as(storage);
       }
     });
     return depends;
@@ -494,9 +545,6 @@ private:
     if (!IsTrackableScalarLocalStore(store)) {
       return;
     }
-    if (ExprDependsOnBuffer(store->value, store->buffer)) {
-      return;
-    }
     if (!ValueLoadsOnlyTrackableScalarLocals(store->value)) {
       return;
     }
@@ -506,9 +554,19 @@ private:
 
     // A scalar local.var store defines the value read by later BufferLoad
     // nodes.
-    PrimExpr value = analyzer_->Simplify(store->value);
+    if (ExprDependsOnBuffer(store->value, store->buffer)) {
+      return;
+    }
+
+    PrimExpr value = store->value;
+    value = analyzer_->Simplify(value);
     PrimExpr load = BufferLoad(store->buffer, store->indices);
     PushActivePredicate(analyzer_->rewrite_simplify(EQ(load, value)));
+  }
+
+  void UpdatePredicatesForStore(const BufferStore &store) {
+    InvalidatePredicatesDependingOn(store->buffer);
+    TryPushStoreValuePredicate(store);
   }
 
   PrimExpr VisitExpr_(const BufferLoadNode *op) final {
@@ -554,18 +612,15 @@ private:
             << "\nAs manual boundary check detected, potential out-of-bounds "
                "access may occur."
             << "\nAuto detect boundaries are " << conditions;
-        InvalidatePredicatesDependingOn(store->buffer);
-        TryPushStoreValuePredicate(store);
+        UpdatePredicatesForStore(store);
         return store;
       }
-      InvalidatePredicatesDependingOn(store->buffer);
-      TryPushStoreValuePredicate(store);
+      UpdatePredicatesForStore(store);
       return store;
     }
 
     if (conditions.empty()) {
-      InvalidatePredicatesDependingOn(store->buffer);
-      TryPushStoreValuePredicate(store);
+      UpdatePredicatesForStore(store);
       return store;
     }
 
@@ -796,8 +851,10 @@ private:
       }
     }
     std::vector<bool> then_validity = PrefixValidity(base_size);
+    std::vector<PrimExpr> then_predicates = ValidPredicatesFrom(base_size);
 
     std::vector<bool> else_validity;
+    std::vector<PrimExpr> else_predicates;
     if (op->else_case) {
       PrimExpr not_condition = analyzer_->rewrite_simplify(Not(real_condition));
       active_predicates_ = base_predicates;
@@ -809,6 +866,7 @@ private:
         else_case = this->VisitStmt(op->else_case.value());
       }
       else_validity = PrefixValidity(base_size);
+      else_predicates = ValidPredicatesFrom(base_size);
     } else {
       active_predicates_ = base_predicates;
       else_validity = PrefixValidity(base_size);
@@ -824,6 +882,9 @@ private:
     }
 
     MergeBranchValidity(base_predicates, then_validity, else_validity);
+    if (op->else_case) {
+      PushBranchSummary(then_predicates, else_predicates);
+    }
 
     if (condition.same_as(op->condition) && then_case.same_as(op->then_case) &&
         else_case.same_as(op->else_case)) {
@@ -847,8 +908,13 @@ private:
   }
 
   Stmt VisitStmt_(const BlockNode *op) final {
+    Map<Var, Var> base_storage_aliases = storage_aliases_;
     for (auto buffer : op->alloc_buffers) {
       buffer_data_to_buffer_.Set(buffer->data, buffer);
+    }
+    for (const MatchBufferRegion &match_buffer : op->match_buffers) {
+      storage_aliases_.Set(match_buffer->buffer->data,
+                           StorageKey(match_buffer->source->buffer));
     }
     if (op->annotations.count(attr::kSafeValueMap)) {
       auto map = op->annotations.Get(attr::kSafeValueMap)
@@ -863,7 +929,9 @@ private:
         annotated_safe_value_by_data_.Set(var, safe_value);
       }
     }
-    return IRMutatorWithAnalyzer::VisitStmt_(op);
+    Stmt stmt = IRMutatorWithAnalyzer::VisitStmt_(op);
+    storage_aliases_ = base_storage_aliases;
+    return stmt;
   }
 
   // Get the safe value of the buffer
@@ -880,6 +948,7 @@ private:
   Map<Var, Buffer> buffer_data_to_buffer_;
   Map<Buffer, PrimExpr> annotated_safe_value_map_;
   Map<Var, PrimExpr> annotated_safe_value_by_data_;
+  Map<Var, Var> storage_aliases_;
   std::vector<ActivePredicate> active_predicates_;
 };
 

--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -11,6 +11,8 @@
 #include <tvm/tir/transform.h>
 #include <tvm/tir/utils.h>
 
+#include <functional>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -211,18 +213,50 @@ struct SafeMemChecker : public StmtExprVisitor {
       return false;
     }
 
-    // Analyzer::ConstraintContext is not mutation-aware for BufferLoad-based
-    // guards. Use Z3 only as a local implication query over predicates that the
-    // rewriter has kept valid.
+    // Mirror the existing implication check used by thread_storage_sync:
+    // active_predicates => cond is proved as !active_predicates || cond. This
+    // keeps BufferLoad facts local to this query, while still letting Z3 reason
+    // across algebraic expressions over those facts.
     PrimExpr assumptions = active_predicates_[0];
     for (size_t i = 1; i < active_predicates_.size(); ++i) {
       assumptions = tir::And(assumptions, active_predicates_[i]);
     }
-    PrimExpr implication =
-        analyzer_->rewrite_simplify(tir::Or(Not(assumptions), cond));
     try {
-      return analyzer_->z3_prover.CanProve(implication);
+      PrimExpr implication =
+          analyzer_->rewrite_simplify(tir::Or(tir::Not(assumptions), cond));
+      if (analyzer_->z3_prover.CanProve(implication)) {
+        return true;
+      }
     } catch (const Error &e) {
+      // Fall through to the generic analyzer path below.
+    }
+
+    // Analyzer::ConstraintContext is not mutation-aware for BufferLoad-based
+    // guards. Enter only predicates that the rewriter has kept valid, and do so
+    // in a temporary scope so the existing analyzer machinery can still prove
+    // cases handled by const_int_bound, int_set, and rewrite_simplify.
+    std::vector<std::function<void()>> exits;
+    try {
+      exits.reserve(active_predicates_.size());
+      for (const PrimExpr &predicate : active_predicates_) {
+        exits.push_back(analyzer_->EnterConstraint(predicate));
+      }
+      bool proved =
+          analyzer_->CanProve(cond, arith::ProofStrength::kSymbolicBound);
+      while (!exits.empty()) {
+        if (exits.back()) {
+          exits.back()();
+        }
+        exits.pop_back();
+      }
+      return proved;
+    } catch (const Error &e) {
+      while (!exits.empty()) {
+        if (exits.back()) {
+          exits.back()();
+        }
+        exits.pop_back();
+      }
       return false;
     }
   }
@@ -367,6 +401,116 @@ private:
     }
   }
 
+  bool CanProveEqual(const PrimExpr &lhs, const PrimExpr &rhs) {
+    try {
+      return analyzer_->CanProveEqual(lhs, rhs);
+    } catch (const Error &e) {
+      return false;
+    }
+  }
+
+  static bool ExprDependsOnBuffer(const PrimExpr &expr, const Buffer &buffer) {
+    bool depends = false;
+    PostOrderVisit(expr, [&](const ObjectRef &obj) {
+      if (depends) {
+        return;
+      }
+      if (const auto *load = obj.as<BufferLoadNode>()) {
+        depends = load->buffer.same_as(buffer);
+      }
+    });
+    return depends;
+  }
+
+  static bool IsZ3SupportedCall(const CallNode *call) {
+    return call->op.same_as(builtin::bitwise_and()) ||
+           call->op.same_as(builtin::bitwise_or()) ||
+           call->op.same_as(builtin::bitwise_xor()) ||
+           call->op.same_as(builtin::bitwise_not()) ||
+           call->op.same_as(builtin::shift_left()) ||
+           call->op.same_as(builtin::shift_right());
+  }
+
+  static bool ContainsUnsupportedCall(const PrimExpr &expr) {
+    bool unsupported = false;
+    PostOrderVisit(expr, [&](const ObjectRef &obj) {
+      if (unsupported) {
+        return;
+      }
+      if (const auto *call = obj.as<CallNode>()) {
+        unsupported = !IsZ3SupportedCall(call);
+      }
+    });
+    return unsupported;
+  }
+
+  bool IsTrackableScalarLocalBufferAccess(const Buffer &buffer,
+                                          const Array<PrimExpr> &indices) {
+    std::string scope = buffer.scope();
+    if (scope.find("local.var") == std::string::npos) {
+      return false;
+    }
+    if (!buffer->dtype.is_int() && !buffer->dtype.is_uint()) {
+      return false;
+    }
+    if (buffer->shape.size() != 1 || indices.size() != 1) {
+      return false;
+    }
+    if (!CanProveEqual(buffer->shape[0], IntImm(buffer->shape[0].dtype(), 1))) {
+      return false;
+    }
+    if (!CanProveEqual(indices[0], IntImm(indices[0].dtype(), 0))) {
+      return false;
+    }
+    return true;
+  }
+
+  bool IsTrackableScalarLocalStore(const BufferStore &store) {
+    if (!IsTrackableScalarLocalBufferAccess(store->buffer, store->indices)) {
+      return false;
+    }
+    if (store->predicate.defined() &&
+        !is_one(analyzer_->Simplify(store->predicate.value()))) {
+      return false;
+    }
+    return true;
+  }
+
+  bool ValueLoadsOnlyTrackableScalarLocals(const PrimExpr &value) {
+    bool supported = true;
+    PostOrderVisit(value, [&](const ObjectRef &obj) {
+      if (!supported) {
+        return;
+      }
+      if (const auto *load = obj.as<BufferLoadNode>()) {
+        supported =
+            IsTrackableScalarLocalBufferAccess(load->buffer, load->indices);
+      }
+    });
+    return supported;
+  }
+
+  void TryPushStoreValuePredicate(const BufferStore &store) {
+    if (!IsTrackableScalarLocalStore(store)) {
+      return;
+    }
+    if (ExprDependsOnBuffer(store->value, store->buffer)) {
+      return;
+    }
+    if (!ValueLoadsOnlyTrackableScalarLocals(store->value)) {
+      return;
+    }
+    if (ContainsUnsupportedCall(store->value)) {
+      return;
+    }
+
+    // A scalar local.var store defines the value read by later BufferLoad
+    // nodes.
+    PrimExpr value = analyzer_->Simplify(store->value);
+    PrimExpr load = BufferLoad(store->buffer, store->indices);
+    PushActivePredicate(analyzer_->rewrite_simplify(EQ(load, value)));
+  }
+
   PrimExpr VisitExpr_(const BufferLoadNode *op) final {
     auto load = Downcast<BufferLoad>(IRMutatorWithAnalyzer::VisitExpr_(op));
 
@@ -411,14 +555,17 @@ private:
                "access may occur."
             << "\nAuto detect boundaries are " << conditions;
         InvalidatePredicatesDependingOn(store->buffer);
+        TryPushStoreValuePredicate(store);
         return store;
       }
       InvalidatePredicatesDependingOn(store->buffer);
+      TryPushStoreValuePredicate(store);
       return store;
     }
 
     if (conditions.empty()) {
       InvalidatePredicatesDependingOn(store->buffer);
+      TryPushStoreValuePredicate(store);
       return store;
     }
 
@@ -688,6 +835,15 @@ private:
     n->then_case = std::move(then_case);
     n->else_case = std::move(else_case);
     return Stmt(n);
+  }
+
+  Stmt VisitStmt_(const ForNode *op) final {
+    std::vector<ActivePredicate> base_predicates = active_predicates_;
+    size_t base_size = base_predicates.size();
+    Stmt stmt = IRMutatorWithAnalyzer::VisitStmt_(op);
+    std::vector<bool> body_validity = PrefixValidity(base_size);
+    RestorePrefixValidity(base_predicates, body_validity);
+    return stmt;
   }
 
   Stmt VisitStmt_(const BlockNode *op) final {

--- a/testing/python/issue/test_tilelang_issue_2119.py
+++ b/testing/python/issue/test_tilelang_issue_2119.py
@@ -1,0 +1,94 @@
+import tilelang as tl
+import tilelang.language as T
+import tilelang.testing
+import tvm
+from tvm.tir import stmt_functor
+from tvm.tir.stmt import IfThenElse
+
+
+def _count_if_then_else(stmt):
+    count = 0
+
+    def visit(node):
+        nonlocal count
+        if isinstance(node, IfThenElse):
+            count += 1
+
+    stmt_functor.post_order_visit(stmt, visit)
+    return count
+
+
+def _guarded_global_atomic(num_bins: int = 16, num_threads: int = 128):
+    @T.prim_func
+    def main(
+        keys: T.Tensor((num_threads,), dtype=T.int32),
+        counts: T.Tensor((num_bins,), dtype=T.int32),
+    ):
+        with T.Kernel(1, 1, threads=num_threads) as (bx, by):
+            bin_id = T.alloc_var(T.int32)
+            tid = T.get_thread_binding()
+
+            bin_id = keys[tid]
+            if bin_id >= 0 and bin_id < num_bins:
+                T.atomic_add(counts[bin_id], 1)
+
+    return main
+
+
+def _guarded_global_atomic_algebraic(num_bins: int = 16, num_threads: int = 128):
+    @T.prim_func
+    def main(
+        keys: T.Tensor((num_threads,), dtype=T.int32),
+        counts: T.Tensor((num_bins,), dtype=T.int32),
+    ):
+        with T.Kernel(1, 1, threads=num_threads) as (bx, by):
+            bin_id = T.alloc_var(T.int32)
+            tid = T.get_thread_binding()
+
+            bin_id = keys[tid]
+            if bin_id >= 0 and bin_id + 1 <= num_bins:
+                T.atomic_add(counts[bin_id], 1)
+
+    return main
+
+
+def _guarded_global_atomic_reassigned(num_bins: int = 16, num_threads: int = 128):
+    @T.prim_func
+    def main(
+        keys: T.Tensor((num_threads * 2,), dtype=T.int32),
+        counts: T.Tensor((num_bins,), dtype=T.int32),
+    ):
+        with T.Kernel(1, 1, threads=num_threads) as (bx, by):
+            bin_id = T.alloc_var(T.int32)
+            tid = T.get_thread_binding()
+
+            bin_id = keys[tid]
+            if bin_id >= 0 and bin_id < num_bins:
+                bin_id = keys[tid + num_threads]
+                T.atomic_add(counts[bin_id], 1)
+
+    return main
+
+
+def _legalize(func):
+    mod = tvm.IRModule({func.attrs["global_symbol"]: func})
+    return tl.transform.LegalizeSafeMemoryAccess()(mod)
+
+
+def test_guarded_global_atomic_reuses_active_guard():
+    transformed = _legalize(_guarded_global_atomic())
+    assert _count_if_then_else(transformed["main"].body) == 1
+
+
+def test_guarded_global_atomic_uses_active_guard_implication():
+    transformed = _legalize(_guarded_global_atomic_algebraic())
+    assert _count_if_then_else(transformed["main"].body) == 1
+
+
+def test_guarded_global_atomic_reassigned_gets_new_guard():
+    transformed = _legalize(_guarded_global_atomic_reassigned())
+    assert _count_if_then_else(transformed["main"].body) > 1
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/issue/test_tilelang_issue_2119.py
+++ b/testing/python/issue/test_tilelang_issue_2119.py
@@ -70,6 +70,79 @@ def _guarded_global_atomic_reassigned(num_bins: int = 16, num_threads: int = 128
     return main
 
 
+def _guarded_global_atomic_reassigned_static(num_bins: int = 16, num_threads: int = 128):
+    @T.prim_func
+    def main(
+        keys: T.Tensor((num_threads,), dtype=T.int32),
+        counts: T.Tensor((num_bins,), dtype=T.int32),
+    ):
+        with T.Kernel(1, 1, threads=num_threads) as (bx, by):
+            bin_id = T.alloc_var(T.int32)
+            tid = T.get_thread_binding()
+
+            bin_id = keys[tid]
+            if bin_id >= 0 and bin_id < num_bins:
+                bin_id = 3
+                T.atomic_add(counts[bin_id], 1)
+
+    return main
+
+
+def _guarded_global_atomic_reassigned_algebraic(num_bins: int = 16, num_threads: int = 128):
+    @T.prim_func
+    def main(
+        keys: T.Tensor((num_threads,), dtype=T.int32),
+        counts: T.Tensor((num_bins,), dtype=T.int32),
+    ):
+        with T.Kernel(1, 1, threads=num_threads) as (bx, by):
+            bin_id = T.alloc_var(T.int32)
+            shifted = T.alloc_var(T.int32)
+            tid = T.get_thread_binding()
+
+            bin_id = keys[tid]
+            if bin_id > 0 and bin_id < num_bins:
+                shifted = bin_id - 1
+                T.atomic_add(counts[shifted], 1)
+
+    return main
+
+
+def _guarded_global_atomic_reassigned_self_dependent(num_bins: int = 16, num_threads: int = 128):
+    @T.prim_func
+    def main(
+        keys: T.Tensor((num_threads,), dtype=T.int32),
+        counts: T.Tensor((num_bins,), dtype=T.int32),
+    ):
+        with T.Kernel(1, 1, threads=num_threads) as (bx, by):
+            bin_id = T.alloc_var(T.int32)
+            tid = T.get_thread_binding()
+
+            bin_id = keys[tid]
+            if bin_id >= 0 and bin_id < num_bins:
+                bin_id = bin_id + 1
+                T.atomic_add(counts[bin_id], 1)
+
+    return main
+
+
+def _guarded_global_atomic_store_bitwise(num_bins: int = 16, num_threads: int = 128):
+    @T.prim_func
+    def main(
+        keys: T.Tensor((num_threads,), dtype=T.int32),
+        counts: T.Tensor((num_bins,), dtype=T.int32),
+    ):
+        with T.Kernel(1, 1, threads=num_threads) as (bx, by):
+            bin_id = T.alloc_var(T.int32)
+            masked = T.alloc_var(T.int32)
+            tid = T.get_thread_binding()
+
+            bin_id = keys[tid]
+            masked = T.bitwise_and(bin_id, 15)
+            T.atomic_add(counts[masked], 1)
+
+    return main
+
+
 def _legalize(func):
     mod = tvm.IRModule({func.attrs["global_symbol"]: func})
     return tl.transform.LegalizeSafeMemoryAccess()(mod)
@@ -88,6 +161,26 @@ def test_guarded_global_atomic_uses_active_guard_implication():
 def test_guarded_global_atomic_reassigned_gets_new_guard():
     transformed = _legalize(_guarded_global_atomic_reassigned())
     assert _count_if_then_else(transformed["main"].body) > 1
+
+
+def test_guarded_global_atomic_reassigned_static_reuses_store_predicate():
+    transformed = _legalize(_guarded_global_atomic_reassigned_static())
+    assert _count_if_then_else(transformed["main"].body) == 1
+
+
+def test_guarded_global_atomic_reassigned_algebraic_uses_z3_store_predicate():
+    transformed = _legalize(_guarded_global_atomic_reassigned_algebraic())
+    assert _count_if_then_else(transformed["main"].body) == 1
+
+
+def test_guarded_global_atomic_reassigned_self_dependent_gets_new_guard():
+    transformed = _legalize(_guarded_global_atomic_reassigned_self_dependent())
+    assert _count_if_then_else(transformed["main"].body) > 1
+
+
+def test_guarded_global_atomic_store_bitwise_uses_z3_store_predicate():
+    transformed = _legalize(_guarded_global_atomic_store_bitwise())
+    assert _count_if_then_else(transformed["main"].body) == 0
 
 
 if __name__ == "__main__":

--- a/testing/python/issue/test_tilelang_issue_2119.py
+++ b/testing/python/issue/test_tilelang_issue_2119.py
@@ -125,6 +125,129 @@ def _guarded_global_atomic_reassigned_self_dependent(num_bins: int = 16, num_thr
     return main
 
 
+def _guarded_global_atomic_reassigned_self_dependent_safe(num_bins: int = 16, num_threads: int = 128):
+    @T.prim_func
+    def main(
+        keys: T.Tensor((num_threads,), dtype=T.int32),
+        counts: T.Tensor((num_bins,), dtype=T.int32),
+    ):
+        with T.Kernel(1, 1, threads=num_threads) as (bx, by):
+            bin_id = T.alloc_var(T.int32)
+            tid = T.get_thread_binding()
+
+            bin_id = keys[tid]
+            if bin_id >= 0 and bin_id < num_bins - 1:
+                bin_id = bin_id + 1
+                T.atomic_add(counts[bin_id], 1)
+
+    return main
+
+
+def _guarded_global_atomic_nested_self_dependent_join(num_bins: int = 16, num_threads: int = 128):
+    @T.prim_func
+    def main(
+        keys: T.Tensor((num_threads,), dtype=T.int32),
+        counts: T.Tensor((num_bins,), dtype=T.int32),
+    ):
+        with T.Kernel(1, 1, threads=num_threads) as (bx, by):
+            bin_id = T.alloc_var(T.int32)
+            tid = T.get_thread_binding()
+
+            bin_id = keys[tid]
+            if bin_id > 0 and bin_id < 13:
+                if bin_id > 8:
+                    bin_id = bin_id + 1
+                else:
+                    bin_id = bin_id // 2
+                bin_id = bin_id + 1
+                T.atomic_add(counts[bin_id], 1)
+
+    return main
+
+
+def _guarded_global_atomic_nested_self_dependent_outside_guard(num_bins: int = 16, num_threads: int = 128):
+    @T.prim_func
+    def main(
+        keys: T.Tensor((num_threads,), dtype=T.int32),
+        counts: T.Tensor((num_bins,), dtype=T.int32),
+    ):
+        with T.Kernel(1, 1, threads=num_threads) as (bx, by):
+            bin_id = T.alloc_var(T.int32)
+            tid = T.get_thread_binding()
+
+            bin_id = keys[tid]
+            if bin_id > 0 and bin_id < 13:
+                if bin_id > 8:
+                    bin_id = bin_id + 1
+                else:
+                    bin_id = bin_id // 2
+            bin_id = bin_id + 1
+            T.atomic_add(counts[bin_id], 1)
+
+    return main
+
+
+def _guarded_global_atomic_nested_unknown_branch(num_bins: int = 16, num_threads: int = 128):
+    @T.prim_func
+    def main(
+        keys: T.Tensor((num_threads * 2,), dtype=T.int32),
+        counts: T.Tensor((num_bins,), dtype=T.int32),
+    ):
+        with T.Kernel(1, 1, threads=num_threads) as (bx, by):
+            bin_id = T.alloc_var(T.int32)
+            tid = T.get_thread_binding()
+
+            bin_id = keys[tid]
+            if bin_id >= 0 and bin_id < num_bins:
+                if bin_id > 8:
+                    bin_id = keys[tid + num_threads]
+                else:
+                    bin_id = bin_id // 2
+                T.atomic_add(counts[bin_id], 1)
+
+    return main
+
+
+def _guarded_global_atomic_nested_unsafe_branch(num_bins: int = 16, num_threads: int = 128):
+    @T.prim_func
+    def main(
+        keys: T.Tensor((num_threads,), dtype=T.int32),
+        counts: T.Tensor((num_bins,), dtype=T.int32),
+    ):
+        with T.Kernel(1, 1, threads=num_threads) as (bx, by):
+            bin_id = T.alloc_var(T.int32)
+            tid = T.get_thread_binding()
+
+            bin_id = keys[tid]
+            if bin_id >= 0 and bin_id < num_bins:
+                if bin_id > 8:
+                    bin_id = bin_id + 10
+                else:
+                    bin_id = bin_id // 2
+                T.atomic_add(counts[bin_id], 1)
+
+    return main
+
+
+def _guarded_global_atomic_loop_self_dependent_no_leak(num_bins: int = 16, num_threads: int = 128):
+    @T.prim_func
+    def main(
+        keys: T.Tensor((num_threads,), dtype=T.int32),
+        counts: T.Tensor((num_bins,), dtype=T.int32),
+    ):
+        with T.Kernel(1, 1, threads=num_threads) as (bx, by):
+            bin_id = T.alloc_var(T.int32)
+            tid = T.get_thread_binding()
+
+            bin_id = keys[tid]
+            if bin_id >= 0 and bin_id < num_bins - 1:
+                for _ in T.serial(1):
+                    bin_id = bin_id + 1
+                T.atomic_add(counts[bin_id], 1)
+
+    return main
+
+
 def _guarded_global_atomic_store_bitwise(num_bins: int = 16, num_threads: int = 128):
     @T.prim_func
     def main(
@@ -141,6 +264,100 @@ def _guarded_global_atomic_store_bitwise(num_bins: int = 16, num_threads: int = 
             T.atomic_add(counts[masked], 1)
 
     return main
+
+
+def _alias_local_var_reassigned():
+    keys = tvm.tir.decl_buffer((128,), "int32", name="keys")
+    counts = tvm.tir.decl_buffer((16,), "int32", name="counts")
+    bin_id = tvm.tir.decl_buffer((1,), "int32", name="bin_id", scope="local.var")
+    alias = tvm.tir.decl_buffer((1,), "int32", name="bin_id_alias", data=bin_id.data, scope="local.var")
+    zero = tvm.tir.IntImm("int32", 0)
+    one = tvm.tir.IntImm("int32", 1)
+    load = tvm.tir.BufferLoad(bin_id, [zero])
+    condition = tvm.tir.And(load >= zero, load < tvm.tir.IntImm("int32", 16))
+    body = tvm.tir.SeqStmt(
+        [
+            tvm.tir.BufferStore(bin_id, tvm.tir.BufferLoad(keys, [zero]), [zero]),
+            tvm.tir.IfThenElse(
+                condition,
+                tvm.tir.SeqStmt(
+                    [
+                        tvm.tir.BufferStore(alias, tvm.tir.BufferLoad(keys, [one]), [zero]),
+                        tvm.tir.BufferStore(counts, one, [tvm.tir.BufferLoad(bin_id, [zero])]),
+                    ]
+                ),
+                None,
+            ),
+        ]
+    )
+    return tvm.tir.PrimFunc(
+        [keys.data, counts.data],
+        body,
+        buffer_map={keys.data: keys, counts.data: counts},
+    )
+
+
+def _alias_local_var_self_dependent_safe():
+    keys = tvm.tir.decl_buffer((128,), "int32", name="keys")
+    counts = tvm.tir.decl_buffer((16,), "int32", name="counts")
+    bin_id = tvm.tir.decl_buffer((1,), "int32", name="bin_id", scope="local.var")
+    alias = tvm.tir.decl_buffer((1,), "int32", name="bin_id_alias", data=bin_id.data, scope="local.var")
+    zero = tvm.tir.IntImm("int32", 0)
+    one = tvm.tir.IntImm("int32", 1)
+    load = tvm.tir.BufferLoad(bin_id, [zero])
+    condition = tvm.tir.And(load >= zero, load < tvm.tir.IntImm("int32", 15))
+    body = tvm.tir.SeqStmt(
+        [
+            tvm.tir.BufferStore(bin_id, tvm.tir.BufferLoad(keys, [zero]), [zero]),
+            tvm.tir.IfThenElse(
+                condition,
+                tvm.tir.SeqStmt(
+                    [
+                        tvm.tir.BufferStore(alias, tvm.tir.BufferLoad(bin_id, [zero]) + one, [zero]),
+                        tvm.tir.BufferStore(counts, one, [tvm.tir.BufferLoad(bin_id, [zero])]),
+                    ]
+                ),
+                None,
+            ),
+        ]
+    )
+    return tvm.tir.PrimFunc(
+        [keys.data, counts.data],
+        body,
+        buffer_map={keys.data: keys, counts.data: counts},
+    )
+
+
+def _alias_local_var_invalidates_tracked_self_dependent():
+    keys = tvm.tir.decl_buffer((128,), "int32", name="keys")
+    counts = tvm.tir.decl_buffer((16,), "int32", name="counts")
+    bin_id = tvm.tir.decl_buffer((1,), "int32", name="bin_id", scope="local.var")
+    alias = tvm.tir.decl_buffer((1,), "int32", name="bin_id_alias", data=bin_id.data, scope="local.var")
+    zero = tvm.tir.IntImm("int32", 0)
+    one = tvm.tir.IntImm("int32", 1)
+    load = tvm.tir.BufferLoad(bin_id, [zero])
+    condition = tvm.tir.And(load >= zero, load < tvm.tir.IntImm("int32", 15))
+    body = tvm.tir.SeqStmt(
+        [
+            tvm.tir.BufferStore(bin_id, tvm.tir.BufferLoad(keys, [zero]), [zero]),
+            tvm.tir.IfThenElse(
+                condition,
+                tvm.tir.SeqStmt(
+                    [
+                        tvm.tir.BufferStore(alias, tvm.tir.BufferLoad(bin_id, [zero]) + one, [zero]),
+                        tvm.tir.BufferStore(alias, tvm.tir.BufferLoad(keys, [one]), [zero]),
+                        tvm.tir.BufferStore(counts, one, [tvm.tir.BufferLoad(bin_id, [zero])]),
+                    ]
+                ),
+                None,
+            ),
+        ]
+    )
+    return tvm.tir.PrimFunc(
+        [keys.data, counts.data],
+        body,
+        buffer_map={keys.data: keys, counts.data: counts},
+    )
 
 
 def _legalize(func):
@@ -178,9 +395,57 @@ def test_guarded_global_atomic_reassigned_self_dependent_gets_new_guard():
     assert _count_if_then_else(transformed["main"].body) > 1
 
 
+def test_guarded_global_atomic_reassigned_self_dependent_safe_gets_conservative_guard():
+    transformed = _legalize(_guarded_global_atomic_reassigned_self_dependent_safe())
+    assert _count_if_then_else(transformed["main"].body) > 1
+
+
+def test_guarded_global_atomic_nested_self_dependent_join_gets_conservative_guard():
+    transformed = _legalize(_guarded_global_atomic_nested_self_dependent_join())
+    assert _count_if_then_else(transformed["main"].body) > 2
+
+
+def test_guarded_global_atomic_nested_self_dependent_outside_guard_gets_new_guard():
+    transformed = _legalize(_guarded_global_atomic_nested_self_dependent_outside_guard())
+    assert _count_if_then_else(transformed["main"].body) > 2
+
+
+def test_guarded_global_atomic_nested_unknown_branch_gets_new_guard():
+    transformed = _legalize(_guarded_global_atomic_nested_unknown_branch())
+    assert _count_if_then_else(transformed["main"].body) > 2
+
+
+def test_guarded_global_atomic_nested_unsafe_branch_gets_new_guard():
+    transformed = _legalize(_guarded_global_atomic_nested_unsafe_branch())
+    assert _count_if_then_else(transformed["main"].body) > 2
+
+
+def test_guarded_global_atomic_loop_self_dependent_no_leak_gets_new_guard():
+    transformed = _legalize(_guarded_global_atomic_loop_self_dependent_no_leak())
+    assert _count_if_then_else(transformed["main"].body) > 1
+
+
 def test_guarded_global_atomic_store_bitwise_uses_z3_store_predicate():
     transformed = _legalize(_guarded_global_atomic_store_bitwise())
     assert _count_if_then_else(transformed["main"].body) == 0
+
+
+def test_alias_local_var_reassigned_invalidates_by_storage():
+    mod = tvm.IRModule({"main": _alias_local_var_reassigned()})
+    transformed = tl.transform.LegalizeSafeMemoryAccess()(mod)
+    assert _count_if_then_else(transformed["main"].body) > 1
+
+
+def test_alias_local_var_self_dependent_safe_gets_conservative_guard():
+    mod = tvm.IRModule({"main": _alias_local_var_self_dependent_safe()})
+    transformed = tl.transform.LegalizeSafeMemoryAccess()(mod)
+    assert _count_if_then_else(transformed["main"].body) > 1
+
+
+def test_alias_local_var_invalidates_tracked_self_dependent_by_storage():
+    mod = tvm.IRModule({"main": _alias_local_var_invalidates_tracked_self_dependent()})
+    transformed = tl.transform.LegalizeSafeMemoryAccess()(mod)
+    assert _count_if_then_else(transformed["main"].body) > 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #2119

## Summary

This PR fixes redundant bounds guards emitted by `LegalizeSafeMemoryAccess` when an access is already dominated by an enclosing guard, but the guarded index is represented as a `BufferLoad` after lowering from `T.alloc_var`.

For example, the pass should not add another bounds check around:

```python
if bin_id >= 0 and bin_id < num_bins:
    T.atomic_add(counts[bin_id], 1)
```

The fix also handles new scalar `local.var` definitions inside the guarded region, such as:

```python
if bin_id > 0 and bin_id < num_bins:
    shifted = bin_id - 1
    T.atomic_add(counts[shifted], 1)
```

## Changes

- Track active `if` predicates inside `LegalizeSafeMemoryAccess`.
- Reuse still-valid active predicates when checking buffer access bounds.
- Invalidate active predicates when their dependent buffer is written.
- Avoid treating `BufferLoad`-based predicates as ordinary analyzer constraints, since they may become stale after mutation.
- Add a Z3 fallback for proving implications from still-valid active predicates.
- Track conservative scalar `local.var` store predicates for simple reassignment cases.
- Reject self-dependent or unsupported scalar store predicates conservatively.
- Add issue regression coverage in `testing/python/issue/test_tilelang_issue_2119.py`.

## Limitations

Scalar store-value tracking is intentionally conservative. It only tracks unconditional scalar integer `local.var` stores whose value is independent of the destination buffer and whose RHS uses supported expressions / trackable scalar locals. Predicated stores, self-dependent updates such as `x = x + 1`, and unsupported calls still fall back to emitting runtime guards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened safe-memory bounds checking by tracking and applying active predicates across control flow, improving precision and reducing incorrect conservatism during legalization.

* **Tests**
  * Added comprehensive tests covering diverse guard patterns, reassigned/index-dependent indices, loop-carried cases, masking, and aliasing to validate legalization outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->