### PR TITLE
[BugFix] Fix redundant runtime bounds checks for BufferLoad indices in LegalizeSafeMemoryAccess

### DIFF
--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -127,6 +127,21 @@ struct SafeMemChecker : public StmtExprVisitor {
         // of hard-failing compilation.
         can_prove_upper = false;
       }
+
+      if (!can_prove_upper) {
+        // Fallback: use const_int_bound directly.
+        // CanProve's kSymbolicBound strategy uses int_set, which only tracks
+        // Var-keyed constraints. const_int_bound tracks PrimExpr-keyed
+        // constraints (including BufferLoad), so it can leverage bounds
+        // from an enclosing if-condition like `if bin_id < N`.
+        arith::ConstIntBound index_bound = analyzer_->const_int_bound(index);
+        arith::ConstIntBound shape_bound =
+            analyzer_->const_int_bound(shape_dim);
+        if (index_bound->max_value < shape_bound->min_value) {
+          can_prove_upper = true;
+        }
+      }
+
       if (!can_prove_upper) {
         if (throw_warning) {
           LOG(WARNING) << "Index access may exceed buffer bounds: " << index
@@ -145,6 +160,15 @@ struct SafeMemChecker : public StmtExprVisitor {
       } catch (const Error &e) {
         can_prove_lower = false;
       }
+
+      if (!can_prove_lower) {
+        // Same fallback as above for the lower bound.
+        arith::ConstIntBound index_bound = analyzer_->const_int_bound(index);
+        if (index_bound->min_value >= 0) {
+          can_prove_lower = true;
+        }
+      }
+
       if (!can_prove_lower) {
         if (throw_warning) {
           LOG(WARNING) << "Index access may be negative: " << index << " < 0"


### PR DESCRIPTION
As titled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safe memory bounds checking with a fallback mechanism to reduce unnecessary runtime guards and warnings in cases where symbolic interval analysis is inconclusive but constant bounds can be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->