### PR TITLE
[codex] Bump apache-tvm-ffi to 0.1.11rc2

### DIFF
--- a/docs/get_started/Installation.md
+++ b/docs/get_started/Installation.md
@@ -268,7 +268,7 @@ pip install -e . -v --no-build-isolation --no-deps
 
 # Manually install required runtime deps when using --no-deps.
 # Note: skip torch-c-dlpack-ext on ROCm (its wheel expects CUDA libs).
-pip install "apache-tvm-ffi>=0.1.6" "z3-solver>=4.13.0"
+pip install "apache-tvm-ffi==0.1.11rc2" "z3-solver>=4.13.0"
 # If you already installed torch-c-dlpack-ext and hit `libtorch_cuda.so` errors:
 # pip uninstall -y torch-c-dlpack-ext
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    # >=0.1.6 fixes a memory issue: tilelang#1502, but keep
-    # requirement as wide as possible to be compatible with other libraries
-    # pip will try to use latest version whenever possible.
-    "apache-tvm-ffi~=0.1.0,>=0.1.2",
+    "apache-tvm-ffi==0.1.11rc2",
     # torch-c-dlpack-ext provides prebuilt torch extensions.
     # Without it, TVM FFI may require JIT compilation on first import.
     "torch-c-dlpack-ext; python_version < '3.14'",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Requirements to run local build with `--no-build-isolation` or other developments
 
-apache-tvm-ffi~=0.1.0,>=0.1.2
+apache-tvm-ffi==0.1.11rc2
 build
 cmake>=3.26
 cython>=3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Runtime requirements
 
-apache-tvm-ffi~=0.1.0,>=0.1.2
+apache-tvm-ffi==0.1.11rc2
 torch-c-dlpack-ext; python_version < '3.14'
 cloudpickle
 ml-dtypes


### PR DESCRIPTION
## Summary

Bump the TileLang TVM FFI dependency to `apache-tvm-ffi==0.1.11rc2` across the runtime and development requirement declarations.

Also update the ROCm manual `--no-deps` installation instructions so users install the same FFI version manually.

## Impact

This makes new installs resolve the requested Apache TVM FFI release candidate instead of the previous `<0.1.10` range.

## Validation

- `python -m pip install --dry-run --no-deps "apache-tvm-ffi==0.1.11rc2"`
- parsed dependency specs from `pyproject.toml`, `requirements.txt`, and `requirements-dev.txt`
- `git diff --check`
- `pre-commit run --files pyproject.toml requirements.txt requirements-dev.txt docs/get_started/Installation.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `apache-tvm-ffi` dependency to pinned pre-release version `0.1.11rc2` across all package requirements and installation documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->