### PR TITLE
[Feature][Fix] Extend TCGEN5 F8F6F4 dtype plumbing

### DIFF
--- a/src/op/tcgen5_meta.h
+++ b/src/op/tcgen5_meta.h
@@ -178,6 +178,12 @@ inline uint32_t GetTCGEN5InstrDesc(int atom_m, int atom_n, int atom_k,
       return static_cast<uint32_t>(0);
     } else if (dtype.is_float8_e5m2fnuz() || dtype.is_float8_e5m2()) {
       return static_cast<uint32_t>(1);
+    } else if (dtype.is_float6_e2m3fn()) {
+      return static_cast<uint32_t>(3);
+    } else if (dtype.is_float6_e3m2fn()) {
+      return static_cast<uint32_t>(4);
+    } else if (dtype.is_float4_e2m1fn()) {
+      return static_cast<uint32_t>(5);
     } else if (dtype.is_int() && dtype.bits() == 8) {
       return static_cast<uint32_t>(1);
     } else if (dtype.is_uint() && dtype.bits() == 8) {
@@ -259,6 +265,12 @@ inline uint32_t GetTCGEN5BlockScaledInstrDesc(int atom_m, int atom_n,
       return 0u; // E4M3
     } else if (dtype.is_float8_e5m2fnuz() || dtype.is_float8_e5m2()) {
       return 1u; // E5M2
+    } else if (dtype.is_float6_e2m3fn()) {
+      return 3u; // E2M3
+    } else if (dtype.is_float6_e3m2fn()) {
+      return 4u; // E3M2
+    } else if (dtype.is_float4_e2m1fn()) {
+      return 5u; // E2M1
     }
     LOG(FATAL) << "Unsupported dtype for block-scaled descriptor: " << dtype;
     return 0u;

--- a/src/target/ptx.cc
+++ b/src/target/ptx.cc
@@ -36,19 +36,22 @@ namespace codegen {
 namespace ptx {
 
 static const char *enum_to_str[] = {
-    "kInt4",        "kUInt4",         "kInt8",    "kUInt8",    "kInt16",
-    "kUInt16",      "kInt32",         "kUInt32",  "kInt64",    "kUInt64",
-    "kFloat8_e4m3", "kFloat8_e5m2",   "kFloat16", "kBFloat16", "kFloat16x2",
-    "kFloat32",     "kTensorFloat32", "kFloat64", "kBit1",     "kBit8",
-    "kBit16",       "kBit32",         "kBit64"};
+    "kInt4",          "kUInt4",    "kInt8",        "kUInt8",
+    "kInt16",         "kUInt16",   "kInt32",       "kUInt32",
+    "kInt64",         "kUInt64",   "kFloat8_e4m3", "kFloat8_e5m2",
+    "kFloat16",       "kBFloat16", "kFloat16x2",   "kFloat32",
+    "kTensorFloat32", "kFloat64",  "kBit1",        "kBit8",
+    "kBit16",         "kBit32",    "kBit64",       "kFloat6_e2m3fn",
+    "kFloat6_e3m2fn"};
 
-static const char *dtype_str[] = {
-    ".s4",   ".u4",  ".s8",   ".u8",   ".s16", ".u16",  ".s32",   ".u32",
-    ".s64",  ".u64", ".e4m3", ".e5m2", ".f16", ".bf16", ".f16x2", ".f32",
-    ".tf32", ".f64", ".b1",   ".b8",   ".b16", ".b32",  ".b64"};
-static const uint32_t num_bits[] = {4,  4,  8, 8, 16, 16, 32, 32,
-                                    64, 64, 8, 8, 16, 16, 32, 32,
-                                    32, 64, 1, 8, 16, 32, 64};
+static const char *dtype_str[] = {".s4",   ".u4",   ".s8",  ".u8",   ".s16",
+                                  ".u16",  ".s32",  ".u32", ".s64",  ".u64",
+                                  ".e4m3", ".e5m2", ".f16", ".bf16", ".f16x2",
+                                  ".f32",  ".tf32", ".f64", ".b1",   ".b8",
+                                  ".b16",  ".b32",  ".b64", ".e2m3", ".e3m2"};
+static const uint32_t num_bits[] = {4,  4, 8,  8,  16, 16, 32, 32, 64,
+                                    64, 8, 8,  16, 16, 32, 32, 32, 64,
+                                    1,  8, 16, 32, 64, 6,  6};
 
 /*!
  * \brief Create PTX data type from string.
@@ -80,6 +83,10 @@ DataType DTypeFromString(const std::string str) {
   } else if (str == "float8_e5m2" || str == "float8_e5m2fn" || str == "e5m2" ||
              str == ".e5m2") {
     return DataType::kFloat8_e5m2;
+  } else if (str == "float6_e2m3fn" || str == "e2m3" || str == ".e2m3") {
+    return DataType::kFloat6_e2m3fn;
+  } else if (str == "float6_e3m2fn" || str == "e3m2" || str == ".e3m2") {
+    return DataType::kFloat6_e3m2fn;
   } else if (str == "float16" || str == "fp16" || str == ".f16") {
     return DataType::kFloat16;
   } else if (str == "bfloat16" || str == "bf16") {

--- a/src/target/ptx.cc
+++ b/src/target/ptx.cc
@@ -42,17 +42,17 @@ static const char *enum_to_str[] = {
     "kFloat8_e4m3", "kFloat8_e5m2",   "kFloat16", "kBFloat16", "kFloat16x2",
     "kFloat32",     "kTensorFloat32", "kFloat64", "kBit1",     "kBit8",
     "kBit16",       "kBit32",         "kBit64",   "kFloat6_e2m3fn",
-    "kFloat6_e3m2fn"};
+    "kFloat6_e3m2fn", "kFloat4_e2m1fn"};
 
 static const char *dtype_str[] = {
     ".s4",   ".u4",  ".s8",   ".u8",   ".s16", ".u16",  ".s32",   ".u32",
     ".s64",  ".u64", ".e4m3", ".e5m2", ".f16", ".bf16", ".f16x2", ".f32",
     ".tf32", ".f64", ".b1",   ".b8",   ".b16", ".b32",  ".b64",
-    ".e2m3", ".e3m2"};
+    ".e2m3", ".e3m2", ".e2m1"};
 static const uint32_t num_bits[] = {4,  4,  8, 8, 16, 16, 32, 32,
                                     64, 64, 8, 8, 16, 16, 32, 32,
                                     32, 64, 1, 8, 16, 32, 64,
-                                    6,  6};
+                                    6,  6,  4};
 // clang-format on
 
 /*!
@@ -89,6 +89,8 @@ DataType DTypeFromString(const std::string str) {
     return DataType::kFloat6_e2m3fn;
   } else if (str == "float6_e3m2fn" || str == "e3m2" || str == ".e3m2") {
     return DataType::kFloat6_e3m2fn;
+  } else if (str == "float4_e2m1fn" || str == "e2m1" || str == ".e2m1") {
+    return DataType::kFloat4_e2m1fn;
   } else if (str == "float16" || str == "fp16" || str == ".f16") {
     return DataType::kFloat16;
   } else if (str == "bfloat16" || str == "bf16") {

--- a/src/target/ptx.cc
+++ b/src/target/ptx.cc
@@ -35,23 +35,25 @@ namespace codegen {
 // PTX related data structures and functions.
 namespace ptx {
 
+// clang-format off
 static const char *enum_to_str[] = {
-    "kInt4",          "kUInt4",    "kInt8",        "kUInt8",
-    "kInt16",         "kUInt16",   "kInt32",       "kUInt32",
-    "kInt64",         "kUInt64",   "kFloat8_e4m3", "kFloat8_e5m2",
-    "kFloat16",       "kBFloat16", "kFloat16x2",   "kFloat32",
-    "kTensorFloat32", "kFloat64",  "kBit1",        "kBit8",
-    "kBit16",         "kBit32",    "kBit64",       "kFloat6_e2m3fn",
+    "kInt4",        "kUInt4",         "kInt8",    "kUInt8",    "kInt16",
+    "kUInt16",      "kInt32",         "kUInt32",  "kInt64",    "kUInt64",
+    "kFloat8_e4m3", "kFloat8_e5m2",   "kFloat16", "kBFloat16", "kFloat16x2",
+    "kFloat32",     "kTensorFloat32", "kFloat64", "kBit1",     "kBit8",
+    "kBit16",       "kBit32",         "kBit64",   "kFloat6_e2m3fn",
     "kFloat6_e3m2fn"};
 
-static const char *dtype_str[] = {".s4",   ".u4",   ".s8",  ".u8",   ".s16",
-                                  ".u16",  ".s32",  ".u32", ".s64",  ".u64",
-                                  ".e4m3", ".e5m2", ".f16", ".bf16", ".f16x2",
-                                  ".f32",  ".tf32", ".f64", ".b1",   ".b8",
-                                  ".b16",  ".b32",  ".b64", ".e2m3", ".e3m2"};
-static const uint32_t num_bits[] = {4,  4, 8,  8,  16, 16, 32, 32, 64,
-                                    64, 8, 8,  16, 16, 32, 32, 32, 64,
-                                    1,  8, 16, 32, 64, 6,  6};
+static const char *dtype_str[] = {
+    ".s4",   ".u4",  ".s8",   ".u8",   ".s16", ".u16",  ".s32",   ".u32",
+    ".s64",  ".u64", ".e4m3", ".e5m2", ".f16", ".bf16", ".f16x2", ".f32",
+    ".tf32", ".f64", ".b1",   ".b8",   ".b16", ".b32",  ".b64",
+    ".e2m3", ".e3m2"};
+static const uint32_t num_bits[] = {4,  4,  8, 8, 16, 16, 32, 32,
+                                    64, 64, 8, 8, 16, 16, 32, 32,
+                                    32, 64, 1, 8, 16, 32, 64,
+                                    6,  6};
+// clang-format on
 
 /*!
  * \brief Create PTX data type from string.

--- a/src/target/ptx.h
+++ b/src/target/ptx.h
@@ -65,7 +65,9 @@ enum class DataType : int {
   kBit8 = 19,
   kBit16 = 20,
   kBit32 = 21,
-  kBit64 = 22
+  kBit64 = 22,
+  kFloat6_e2m3fn = 23,
+  kFloat6_e3m2fn = 24
 };
 
 /*!

--- a/src/target/ptx.h
+++ b/src/target/ptx.h
@@ -67,7 +67,8 @@ enum class DataType : int {
   kBit32 = 21,
   kBit64 = 22,
   kFloat6_e2m3fn = 23,
-  kFloat6_e3m2fn = 24
+  kFloat6_e3m2fn = 24,
+  kFloat4_e2m1fn = 25
 };
 
 /*!

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -342,7 +342,8 @@ enum class DataType : int {
   kBit32 = 21,
   kBit64 = 22,
   kFloat6_e2m3fn = 23,
-  kFloat6_e3m2fn = 24
+  kFloat6_e3m2fn = 24,
+  kFloat4_e2m1fn = 25
 };
 
 union GmmaDescriptor {

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -340,7 +340,9 @@ enum class DataType : int {
   kBit8 = 19,
   kBit16 = 20,
   kBit32 = 21,
-  kBit64 = 22
+  kBit64 = 22,
+  kFloat6_e2m3fn = 23,
+  kFloat6_e3m2fn = 24
 };
 
 union GmmaDescriptor {

--- a/src/tl_templates/cuda/instruction/tcgen05mma.h
+++ b/src/tl_templates/cuda/instruction/tcgen05mma.h
@@ -247,7 +247,7 @@ TL_DEVICE void tcgen05mma_ts<DataType::kFloat6_e3m2fn, false>(
     uint32_t const &tmem_a, uint64_t const &desc_b, uint32_t const &tmem_c,
     uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
     int const &mask1, int const &mask2, int const &mask3) {
-  tcgen05mma_ts<DataType::kFloat6_e2m3fn, false>(
+  tcgen05mma_ts<DataType::kFloat8_e4m3, false>(
       tmem_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
 }
 
@@ -256,7 +256,26 @@ TL_DEVICE void tcgen05mma_ts<DataType::kFloat6_e3m2fn, true>(
     uint32_t const &tmem_a, uint64_t const &desc_b, uint32_t const &tmem_c,
     uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
     int const &mask1, int const &mask2, int const &mask3) {
-  tcgen05mma_ts<DataType::kFloat6_e2m3fn, true>(
+  tcgen05mma_ts<DataType::kFloat8_e4m3, true>(
+      tmem_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
+}
+
+// FP4 family instruction kind (maps to kind::f8f6f4)
+template <>
+TL_DEVICE void tcgen05mma_ts<DataType::kFloat4_e2m1fn, false>(
+    uint32_t const &tmem_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
+    int const &mask1, int const &mask2, int const &mask3) {
+  tcgen05mma_ts<DataType::kFloat8_e4m3, false>(
+      tmem_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
+}
+
+template <>
+TL_DEVICE void tcgen05mma_ts<DataType::kFloat4_e2m1fn, true>(
+    uint32_t const &tmem_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
+    int const &mask1, int const &mask2, int const &mask3) {
+  tcgen05mma_ts<DataType::kFloat8_e4m3, true>(
       tmem_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
 }
 
@@ -473,7 +492,7 @@ TL_DEVICE void tcgen05mma_ss<DataType::kFloat6_e3m2fn, false>(
     uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
     uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
     int const &mask1, int const &mask2, int const &mask3) {
-  tcgen05mma_ss<DataType::kFloat6_e2m3fn, false>(
+  tcgen05mma_ss<DataType::kFloat8_e4m3, false>(
       desc_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
 }
 
@@ -482,7 +501,26 @@ TL_DEVICE void tcgen05mma_ss<DataType::kFloat6_e3m2fn, true>(
     uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
     uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
     int const &mask1, int const &mask2, int const &mask3) {
-  tcgen05mma_ss<DataType::kFloat6_e2m3fn, true>(
+  tcgen05mma_ss<DataType::kFloat8_e4m3, true>(
+      desc_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
+}
+
+// FP4 family instruction kind (maps to kind::f8f6f4)
+template <>
+TL_DEVICE void tcgen05mma_ss<DataType::kFloat4_e2m1fn, false>(
+    uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
+    int const &mask1, int const &mask2, int const &mask3) {
+  tcgen05mma_ss<DataType::kFloat8_e4m3, false>(
+      desc_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
+}
+
+template <>
+TL_DEVICE void tcgen05mma_ss<DataType::kFloat4_e2m1fn, true>(
+    uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
+    int const &mask1, int const &mask2, int const &mask3) {
+  tcgen05mma_ss<DataType::kFloat8_e4m3, true>(
       desc_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
 }
 
@@ -615,7 +653,17 @@ TL_DEVICE void tcgen05mma_ws_ss<DataType::kFloat6_e3m2fn>(
     uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
     uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
     int const &mask1, int const &mask2, int const &mask3) {
-  tcgen05mma_ws_ss<DataType::kFloat6_e2m3fn>(
+  tcgen05mma_ws_ss<DataType::kFloat8_e4m3>(
+      desc_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
+}
+
+// FP4 ws (maps to kind::f8f6f4)
+template <>
+TL_DEVICE void tcgen05mma_ws_ss<DataType::kFloat4_e2m1fn>(
+    uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
+    int const &mask1, int const &mask2, int const &mask3) {
+  tcgen05mma_ws_ss<DataType::kFloat8_e4m3>(
       desc_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
 }
 
@@ -721,7 +769,7 @@ TL_DEVICE void tcgen05mma_blockscaled_ss<DataType::kFloat6_e3m2fn, false>(
     uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
     uint32_t const &scalec, uint32_t const &desc_val, uint32_t const &tmem_sfa,
     uint32_t const &tmem_sfb) {
-  tcgen05mma_blockscaled_ss<DataType::kFloat6_e2m3fn, false>(
+  tcgen05mma_blockscaled_ss<DataType::kFloat8_e4m3, false>(
       desc_a, desc_b, tmem_c, scalec, desc_val, tmem_sfa, tmem_sfb);
 }
 
@@ -730,7 +778,26 @@ TL_DEVICE void tcgen05mma_blockscaled_ss<DataType::kFloat6_e3m2fn, true>(
     uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
     uint32_t const &scalec, uint32_t const &desc_val, uint32_t const &tmem_sfa,
     uint32_t const &tmem_sfb) {
-  tcgen05mma_blockscaled_ss<DataType::kFloat6_e2m3fn, true>(
+  tcgen05mma_blockscaled_ss<DataType::kFloat8_e4m3, true>(
+      desc_a, desc_b, tmem_c, scalec, desc_val, tmem_sfa, tmem_sfb);
+}
+
+// FP4 block-scaled
+template <>
+TL_DEVICE void tcgen05mma_blockscaled_ss<DataType::kFloat4_e2m1fn, false>(
+    uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, uint32_t const &tmem_sfa,
+    uint32_t const &tmem_sfb) {
+  tcgen05mma_blockscaled_ss<DataType::kFloat8_e4m3, false>(
+      desc_a, desc_b, tmem_c, scalec, desc_val, tmem_sfa, tmem_sfb);
+}
+
+template <>
+TL_DEVICE void tcgen05mma_blockscaled_ss<DataType::kFloat4_e2m1fn, true>(
+    uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, uint32_t const &tmem_sfa,
+    uint32_t const &tmem_sfb) {
+  tcgen05mma_blockscaled_ss<DataType::kFloat8_e4m3, true>(
       desc_a, desc_b, tmem_c, scalec, desc_val, tmem_sfa, tmem_sfb);
 }
 

--- a/src/tl_templates/cuda/instruction/tcgen05mma.h
+++ b/src/tl_templates/cuda/instruction/tcgen05mma.h
@@ -697,4 +697,41 @@ TL_DEVICE void tcgen05mma_blockscaled_ss<DataType::kFloat8_e5m2, true>(
       desc_a, desc_b, tmem_c, scalec, desc_val, tmem_sfa, tmem_sfb);
 }
 
+// FP6 block-scaled
+template <>
+TL_DEVICE void tcgen05mma_blockscaled_ss<DataType::kFloat6_e2m3fn, false>(
+    uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, uint32_t const &tmem_sfa,
+    uint32_t const &tmem_sfb) {
+  tcgen05mma_blockscaled_ss<DataType::kFloat8_e4m3, false>(
+      desc_a, desc_b, tmem_c, scalec, desc_val, tmem_sfa, tmem_sfb);
+}
+
+template <>
+TL_DEVICE void tcgen05mma_blockscaled_ss<DataType::kFloat6_e2m3fn, true>(
+    uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, uint32_t const &tmem_sfa,
+    uint32_t const &tmem_sfb) {
+  tcgen05mma_blockscaled_ss<DataType::kFloat8_e4m3, true>(
+      desc_a, desc_b, tmem_c, scalec, desc_val, tmem_sfa, tmem_sfb);
+}
+
+template <>
+TL_DEVICE void tcgen05mma_blockscaled_ss<DataType::kFloat6_e3m2fn, false>(
+    uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, uint32_t const &tmem_sfa,
+    uint32_t const &tmem_sfb) {
+  tcgen05mma_blockscaled_ss<DataType::kFloat6_e2m3fn, false>(
+      desc_a, desc_b, tmem_c, scalec, desc_val, tmem_sfa, tmem_sfb);
+}
+
+template <>
+TL_DEVICE void tcgen05mma_blockscaled_ss<DataType::kFloat6_e3m2fn, true>(
+    uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, uint32_t const &tmem_sfa,
+    uint32_t const &tmem_sfb) {
+  tcgen05mma_blockscaled_ss<DataType::kFloat6_e2m3fn, true>(
+      desc_a, desc_b, tmem_c, scalec, desc_val, tmem_sfa, tmem_sfb);
+}
+
 } // namespace tl

--- a/src/tl_templates/cuda/instruction/tcgen05mma.h
+++ b/src/tl_templates/cuda/instruction/tcgen05mma.h
@@ -169,7 +169,7 @@ TL_DEVICE void tcgen05mma_ts<DataType::kUInt8, true>(
                                        mask0, mask1, mask2, mask3);
 }
 
-// FP8 family instruction kind (maps to f8f6f4)
+// FP8 family instruction kind (maps to kind::f8f6f4)
 template <>
 TL_DEVICE void tcgen05mma_ts<DataType::kFloat8_e4m3, false>(
     uint32_t const &tmem_a, uint64_t const &desc_b, uint32_t const &tmem_c,
@@ -220,6 +220,43 @@ TL_DEVICE void tcgen05mma_ts<DataType::kFloat8_e5m2, true>(
     uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
     int const &mask1, int const &mask2, int const &mask3) {
   tcgen05mma_ts<DataType::kFloat8_e4m3, true>(
+      tmem_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
+}
+
+// FP6 family instruction kind (maps to kind::f8f6f4)
+template <>
+TL_DEVICE void tcgen05mma_ts<DataType::kFloat6_e2m3fn, false>(
+    uint32_t const &tmem_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
+    int const &mask1, int const &mask2, int const &mask3) {
+  tcgen05mma_ts<DataType::kFloat8_e4m3, false>(
+      tmem_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
+}
+
+template <>
+TL_DEVICE void tcgen05mma_ts<DataType::kFloat6_e2m3fn, true>(
+    uint32_t const &tmem_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
+    int const &mask1, int const &mask2, int const &mask3) {
+  tcgen05mma_ts<DataType::kFloat8_e4m3, true>(
+      tmem_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
+}
+
+template <>
+TL_DEVICE void tcgen05mma_ts<DataType::kFloat6_e3m2fn, false>(
+    uint32_t const &tmem_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
+    int const &mask1, int const &mask2, int const &mask3) {
+  tcgen05mma_ts<DataType::kFloat6_e2m3fn, false>(
+      tmem_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
+}
+
+template <>
+TL_DEVICE void tcgen05mma_ts<DataType::kFloat6_e3m2fn, true>(
+    uint32_t const &tmem_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
+    int const &mask1, int const &mask2, int const &mask3) {
+  tcgen05mma_ts<DataType::kFloat6_e2m3fn, true>(
       tmem_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
 }
 
@@ -358,7 +395,7 @@ TL_DEVICE void tcgen05mma_ss<DataType::kUInt8, true>(
                                        mask0, mask1, mask2, mask3);
 }
 
-// FP8 family instruction kind (maps to f8f6f4)
+// FP8 family instruction kind (maps to kind::f8f6f4)
 template <>
 TL_DEVICE void tcgen05mma_ss<DataType::kFloat8_e4m3, false>(
     uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
@@ -409,6 +446,43 @@ TL_DEVICE void tcgen05mma_ss<DataType::kFloat8_e5m2, true>(
     uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
     int const &mask1, int const &mask2, int const &mask3) {
   tcgen05mma_ss<DataType::kFloat8_e4m3, true>(
+      desc_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
+}
+
+// FP6 family instruction kind (maps to kind::f8f6f4)
+template <>
+TL_DEVICE void tcgen05mma_ss<DataType::kFloat6_e2m3fn, false>(
+    uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
+    int const &mask1, int const &mask2, int const &mask3) {
+  tcgen05mma_ss<DataType::kFloat8_e4m3, false>(
+      desc_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
+}
+
+template <>
+TL_DEVICE void tcgen05mma_ss<DataType::kFloat6_e2m3fn, true>(
+    uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
+    int const &mask1, int const &mask2, int const &mask3) {
+  tcgen05mma_ss<DataType::kFloat8_e4m3, true>(
+      desc_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
+}
+
+template <>
+TL_DEVICE void tcgen05mma_ss<DataType::kFloat6_e3m2fn, false>(
+    uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
+    int const &mask1, int const &mask2, int const &mask3) {
+  tcgen05mma_ss<DataType::kFloat6_e2m3fn, false>(
+      desc_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
+}
+
+template <>
+TL_DEVICE void tcgen05mma_ss<DataType::kFloat6_e3m2fn, true>(
+    uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
+    int const &mask1, int const &mask2, int const &mask3) {
+  tcgen05mma_ss<DataType::kFloat6_e2m3fn, true>(
       desc_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
 }
 
@@ -499,7 +573,7 @@ TL_DEVICE void tcgen05mma_ws_ss<DataType::kUInt8>(
                                     mask0, mask1, mask2, mask3);
 }
 
-// FP8 ws (maps to f8f6f4)
+// FP8 ws (maps to kind::f8f6f4)
 template <>
 TL_DEVICE void tcgen05mma_ws_ss<DataType::kFloat8_e4m3>(
     uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
@@ -523,6 +597,25 @@ TL_DEVICE void tcgen05mma_ws_ss<DataType::kFloat8_e5m2>(
     uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
     int const &mask1, int const &mask2, int const &mask3) {
   tcgen05mma_ws_ss<DataType::kFloat8_e4m3>(
+      desc_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
+}
+
+// FP6 ws (maps to kind::f8f6f4)
+template <>
+TL_DEVICE void tcgen05mma_ws_ss<DataType::kFloat6_e2m3fn>(
+    uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
+    int const &mask1, int const &mask2, int const &mask3) {
+  tcgen05mma_ws_ss<DataType::kFloat8_e4m3>(
+      desc_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
+}
+
+template <>
+TL_DEVICE void tcgen05mma_ws_ss<DataType::kFloat6_e3m2fn>(
+    uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,
+    uint32_t const &scalec, uint32_t const &desc_val, int const &mask0,
+    int const &mask1, int const &mask2, int const &mask3) {
+  tcgen05mma_ws_ss<DataType::kFloat6_e2m3fn>(
       desc_a, desc_b, tmem_c, scalec, desc_val, mask0, mask1, mask2, mask3);
 }
 
@@ -585,7 +678,7 @@ TL_DEVICE void tcgen05mma_blockscaled_ss<DataType::kFloat8_e4m3, true>(
   }
 }
 
-// FP8 E5M2 maps to same instruction
+// FP8 E5M2 maps to the same instruction
 template <>
 TL_DEVICE void tcgen05mma_blockscaled_ss<DataType::kFloat8_e5m2, false>(
     uint64_t const &desc_a, uint64_t const &desc_b, uint32_t const &tmem_c,

--- a/tilelang/intrinsics/mma_macro_generator.py
+++ b/tilelang/intrinsics/mma_macro_generator.py
@@ -57,6 +57,7 @@ class TensorCoreIntrinEmitter:
         "float8_e5m2fnuz": "e5m2",
         "float6_e2m3fn": "e2m3",
         "float6_e3m2fn": "e3m2",
+        "float4_e2m1fn": "e2m1",
     }
 
     # Represent the thread binding in the form of (tx, warp_n, warp_m)

--- a/tilelang/intrinsics/mma_macro_generator.py
+++ b/tilelang/intrinsics/mma_macro_generator.py
@@ -55,6 +55,8 @@ class TensorCoreIntrinEmitter:
         "float8_e4m3fnuz": "e4m3",
         "float8_e5m2": "e5m2",
         "float8_e5m2fnuz": "e5m2",
+        "float6_e2m3fn": "e2m3",
+        "float6_e3m2fn": "e3m2",
     }
 
     # Represent the thread binding in the form of (tx, warp_n, warp_m)

--- a/tilelang/intrinsics/tcgen05_macro_generator.py
+++ b/tilelang/intrinsics/tcgen05_macro_generator.py
@@ -125,6 +125,8 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         if isinstance(a_dtype, str):
             a_dtype = DataType(a_dtype)
         if a_dtype.bits == 6:
+            if self.chunk % 32 != 0:
+                raise ValueError(f"TCGEN5MMA FP6 requires chunk to be a multiple of 32, got {self.chunk}")
             self.k_dim = 32
             return
         super()._initialize_k_dim(a_dtype)
@@ -605,7 +607,7 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         b_swizzle_mode = self._determinate_swizzle_mode(B_buf, self.b_shared_layout)
 
         elems_in_bits = DataType(self.a_dtype).bits
-        elems_in_bytes = elems_in_bits // 8
+        elems_in_bytes = (elems_in_bits + 7) // 8
         accum_dtype_in_bits = DataType(accum_dtype).bits
 
         if len(self.meta) != 5:

--- a/tilelang/intrinsics/tcgen05_macro_generator.py
+++ b/tilelang/intrinsics/tcgen05_macro_generator.py
@@ -121,6 +121,14 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         self.micro_size_x = m_dim
         self.micro_size_k = k_dim
 
+    def _initialize_k_dim(self, a_dtype=T.float16):
+        if isinstance(a_dtype, str):
+            a_dtype = DataType(a_dtype)
+        if a_dtype.bits == 6:
+            self.k_dim = 32
+            return
+        super()._initialize_k_dim(a_dtype)
+
     def _determinate_swizzle_mode(self, buffer: Buffer, layout: Layout) -> SwizzleMode:
         # same behavior to src/layout/gemm_layouts.cc::makeGemmABLayoutHopper
         if layout is None or layout.is_equal(make_linear_layout(buffer)):
@@ -199,7 +207,7 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         b_swizzle_mode = self._determinate_swizzle_mode(B_buf, self.b_shared_layout)
 
         elems_in_bits = DataType(self.a_dtype).bits
-        elems_in_bytes = elems_in_bits // 8
+        elems_in_bytes = (elems_in_bits + 7) // 8
         a_swizzle_atom_elems = a_swizzle_mode.swizzle_byte_size() // elems_in_bytes
         b_swizzle_atom_elems = n_dim_per_cta if b_swizzle_mode.is_none() else b_swizzle_mode.swizzle_byte_size() // elems_in_bytes
         accum_dtype_in_bits = DataType(accum_dtype).bits
@@ -423,7 +431,7 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
 
         a_dtype_in_bits = DataType(self.a_dtype).bits
         elems_in_bits = a_dtype_in_bits
-        elems_in_bytes = elems_in_bits // 8
+        elems_in_bytes = (elems_in_bits + 7) // 8
         b_swizzle_atom_elems = n_dim_per_cta if b_swizzle_mode.is_none() else b_swizzle_mode.swizzle_byte_size() // elems_in_bytes
         accum_dtype_in_bits = DataType(accum_dtype).bits
 

--- a/tilelang/intrinsics/tcgen05_macro_generator.py
+++ b/tilelang/intrinsics/tcgen05_macro_generator.py
@@ -124,9 +124,9 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
     def _initialize_k_dim(self, a_dtype=T.float16):
         if isinstance(a_dtype, str):
             a_dtype = DataType(a_dtype)
-        if a_dtype.bits == 6:
+        if a_dtype.bits == 6 or str(a_dtype) == "float4_e2m1fn":
             if self.chunk % 32 != 0:
-                raise ValueError(f"TCGEN5MMA FP6 requires chunk to be a multiple of 32, got {self.chunk}")
+                raise ValueError(f"TCGEN5MMA FP{a_dtype.bits} requires chunk to be a multiple of 32, got {self.chunk}")
             self.k_dim = 32
             return
         super()._initialize_k_dim(a_dtype)


### PR DESCRIPTION
### Summary

Extend the TCGEN5 low-bit codegen path for FP6 and FP4 inputs.

### Feature

- add descriptor encoding for FP6 E2M3/E3M2 and FP4 E2M1
- add FP6 PTX/CUDA dtype mappings
- route FP6 TCGEN5 lowering through the existing `kind::f8f6f4` instruction path

### Bugfix

- fix FP6 byte-width handling in TCGEN5 swizzle/offset calculations
- Add FP6 block-scaled TCGEN5 MMA dispatch specializations so FP6 E2M3/E3M2 block-scaled lowering does not fall through to the unsupported generic template. The specializations reuse the existing `mxf8f6f4.block_scale` asm body, with the concrete FP6 format carried by the instruction descriptor.

For FP6 TCGEN5 GEMM lowering, byte width should use the minimum byte-addressable width. This avoids zero-byte descriptor math for 6-bit dtypes and lets the FP6 TCGEN5 codegen path reach CUDA source generation.

### Cleanup
- Report invalid FP6 TCGEN5 `chunk` values early with a clear `ValueError`, instead of letting them fail later in lower-level MMA shape checks.
- Clarify TCGEN5 MMA comments to consistently reference the actual PTX instruction kind, e.g. `kind::f8f6f4`.
- Keep PTX dtype lookup tables stable under formatting by guarding the compact table layout with `clang-format off/on`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added FP6 (float6) support: compiler and PTX now recognize float6 variants and emit matching instruction encodings.
  * Enabled block-scaled mxf8f6f4.block_scale descriptors for new FP6/FP4 inputs.
  * Instruction templates and intrinsic generation updated to handle FP6 dtypes, including adjusted element/byte sizing and k-dimension for 6-bit types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->