### PR TITLE
Change disable_out_of_bound_warning default to True

### DIFF
--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -39,7 +39,7 @@ struct SafeMemChecker : public StmtExprVisitor {
     disableOOBWarning =
         tvm::transform::PassContext::Current()
             ->GetConfig(kDisableOutOfBoundWarning, Optional<Bool>())
-            .value_or(false);
+            .value_or(true);
   }
   void VisitExpr_(const BufferLoadNode *op) final {
     // If the buffer is in global scope, we will check its indices and add

--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -147,7 +147,8 @@ struct SafeMemChecker : public StmtExprVisitor {
           LOG(WARNING) << "Index access may exceed buffer bounds: " << index
                        << " >= " << shape_dim
                        << "; Buffer name: " << buffer->name;
-        } else {
+        }
+        if (IsGlobalBuffer(buffer)) {
           _conditions.push_back(upper_bound_cond);
         }
       }
@@ -173,7 +174,8 @@ struct SafeMemChecker : public StmtExprVisitor {
         if (throw_warning) {
           LOG(WARNING) << "Index access may be negative: " << index << " < 0"
                        << "; Buffer name: " << buffer->name;
-        } else {
+        }
+        if (IsGlobalBuffer(buffer)) {
           _conditions.push_back(lower_bound_cond);
         }
       }

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -264,7 +264,7 @@ class PassConfigKey(str, Enum):
     """Output directory for generated CUDA kernels. Default: empty string"""
 
     TL_DISABLE_OUT_OF_BOUND_WARNING = "tl.disable_out_of_bound_warning"
-    """Disable out-of-bound access warnings in safe memory access legalization. Default: False"""
+    """Disable out-of-bound access warnings in safe memory access legalization. Default: True"""
 
     TL_ENABLE_DUMP_IR = "tl.enable_dump_ir"
     """Enable dumping IR during lowering between passes. Default: False"""


### PR DESCRIPTION
- `src/transform/legalize_safe_memory_access.cc`: .value_or(false) → .value_or(true)
- `tilelang/transform/pass_config.py`: update docstring accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Out-of-bounds warnings are now disabled by default.
  * Warnings continue to be emitted in cases that remain local/non-global.

* **Documentation**
  * Updated configuration docs to reflect the new default for out-of-bounds warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->