### PR TITLE
[Typo] Fix typos in comments and example README

### DIFF
--- a/examples/deepseek_v32/inference/README.md
+++ b/examples/deepseek_v32/inference/README.md
@@ -1,6 +1,6 @@
 # DeepSeek V3.2
 
-First convert huggingface model weights to the the format required by our inference demo. Set `MP` to match your available GPU count:
+First convert huggingface model weights to the format required by our inference demo. Set `MP` to match your available GPU count:
 ```bash
 cd inference
 export EXPERTS=256

--- a/src/transform/unroll_loop.cc
+++ b/src/transform/unroll_loop.cc
@@ -271,7 +271,7 @@ private:
   // this does not count the total steps, only count the number of loops
   int auto_max_extent_;
   bool explicit_unroll_;
-  // Wether to unroll loops to local access.
+  // Whether to unroll loops to local access.
   bool unroll_local_access_{false};
   // Number of normal loops in scope
   int normal_loop_depth_{0};

--- a/tilelang/analysis/fragment_loop_checker.py
+++ b/tilelang/analysis/fragment_loop_checker.py
@@ -62,7 +62,7 @@ class _FragmentLoopCheckVisitor(PyStmtExprVisitor):
         self.loop_stack.append(op)
         child = op.body
 
-        # Reach the the innermost loop
+        # Reach the innermost loop
         # This may cause repeated check for cases like: For1{Stmt1; For2{}; For3{};};
         # But it's OK since the check is idempotent.
         if not isinstance(child, For):

--- a/tilelang/analysis/fragment_loop_checker.py
+++ b/tilelang/analysis/fragment_loop_checker.py
@@ -62,8 +62,12 @@ class _FragmentLoopCheckVisitor(PyStmtExprVisitor):
         self.loop_stack.append(op)
         child = op.body
 
-        # Reach the innermost loop
-        # This may cause repeated check for cases like: For1{Stmt1; For2{}; For3{};};
+        # Reach the innermost loop -- This may cause repeated checks for cases like:
+        #   For1{
+        #       Stmt1;
+        #       For2{};
+        #       For3{};
+        #   };
         # But it's OK since the check is idempotent.
         if not isinstance(child, For):
             buffer_accesses = collect_fragment_accesses(child)

--- a/tilelang/language/eager/builder.py
+++ b/tilelang/language/eager/builder.py
@@ -849,7 +849,7 @@ def get_type_hints(func):
     # ```
     #
     # This is incomplete and buggy
-    #   the only bug scenario the function body doesn't use the the parameters
+    #   the only bug scenario the function body doesn't use the parameters
     #   but such define-no-use scenario is very rare in writing kernels
     #
     # ```py


### PR DESCRIPTION
## Summary

Four single-character / duplicate-word typos in non-runtime text. No behavior change.

- `src/transform/unroll_loop.cc:274` — `Wether` → `Whether`
- `tilelang/analysis/fragment_loop_checker.py:65` — `Reach the the innermost loop` → `Reach the innermost loop`
- `tilelang/language/eager/builder.py:852` — `doesn't use the the parameters` → `doesn't use the parameters`
- `examples/deepseek_v32/inference/README.md:3` — `to the the format required` → `to the format required`

The duplicate-word ones aren't caught by the configured `codespell` hook; the C++ one isn't checked because `codespell` excludes `*.cc` per `.pre-commit-config.yaml`.

## Test plan

Comments and docs only — no test changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected a duplicated word in the example README instructions.

* **Chores**
  * Fixed spelling and grammar in several code comments and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->