### PR TITLE
[Fix][Build] Disable Cython PEP-489 multi-phase init for the cython wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,6 +309,13 @@ endif()
 
 python_add_library(tilelang_cython_wrapper MODULE "${CMAKE_BINARY_DIR}/tilelang_cython_wrapper.cpp" ${USE_SABI} WITH_SOABI)
 
+# Disable Cython's PEP-489 multi-phase init for the wrapper. The generated
+# C++ depends on CPython's private `_xxsubinterpreters` module at import
+# time, which is stripped from some distributor-built Python 3.12 builds
+# (notably Red Hat's RHEL 9 system Python). Single-phase init avoids that
+# dependency and matches Cython's own suggested workaround. See #2125.
+target_compile_definitions(tilelang_cython_wrapper PRIVATE CYTHON_PEP489_MULTI_PHASE_INIT=0)
+
 # Ensure dev builds drop the extension into build/lib alongside other shared libs
 set_target_properties(tilelang_cython_wrapper PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"


### PR DESCRIPTION
## Summary

Fixes #2125. `import tilelang` crashes on Red Hat-built CPython 3.12 (RHEL 9 and downstream distros) with:

```
__Pyx_GetCurrentInterpreterId failed.
Try setting the C define CYTHON_PEP489_MULTI_PHASE_INIT=0
ModuleNotFoundError: No module named '_xxsubinterpreters'
```

raised from `tilelang_cython_wrapper`. Define `CYTHON_PEP489_MULTI_PHASE_INIT=0` for the wrapper target so Cython falls back to single-phase init.

## Root cause

The wrapper is generated with PEP-489 multi-phase init, whose runtime probe touches the private `_xxsubinterpreters` C extension. Red Hat strips that extension from their packaged Python 3.12 build, so the import fails before any tilelang code runs.

This is exactly the workaround Cython itself recommends in its own error message.

## Tradeoffs

The only loss is the ability to load the wrapper into Python subinterpreters. tilelang does not do that today — there are no `subinterpreter` references anywhere in the tree, and the wrapper is the only `.pyx` in the repo, so the change is fully local.

## Test plan

- [ ] Maintainer or someone with RHEL 9 / Red Hat Python 3.12 confirms `import tilelang` succeeds after this change (I do not have a Linux box to repro locally).
- [x] No regressions in CMake parse / static checks.
- [x] No other `.pyx` files in the tree.

Closes: #2125

Thanks to @mgoin for tracing the root cause in the issue discussion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python extension initialization stability by adjusting build configuration for the core wrapper module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->