### PR TITLE
[Fix] Allow autotuning kernels with scalar value parameters

### DIFF
--- a/testing/python/utils/test_tensor_supply_scalar.py
+++ b/testing/python/utils/test_tensor_supply_scalar.py
@@ -1,0 +1,66 @@
+"""Regression tests for scalar-parameter input generation.
+
+These tests cover `tilelang.utils.tensor.get_tensor_supply` for the
+scalar (empty-shape) parameter case. Previously, calling the supplier
+with a scalar `KernelParam` raised `ValueError`, which broke the
+autotuner for any kernel signature that included a scalar value
+parameter (e.g. `def kernel(A: T.Tensor(...), s: T.float32):`).
+
+See: https://github.com/tile-ai/tilelang/issues/2081
+"""
+
+import pytest
+
+import tilelang
+import tilelang.testing
+from tilelang import tvm
+from tilelang.engine.param import KernelParam
+from tilelang.utils.tensor import TensorSupplyType, get_tensor_supply
+
+
+# (dtype string, expected Python type for the supplied scalar)
+_SCALAR_DTYPE_CASES = [
+    ("float32", float),
+    ("float16", float),
+    ("bfloat16", float),
+    ("float64", float),
+    ("int32", int),
+    ("int64", int),
+    ("int8", int),
+    ("uint8", int),
+    ("bool", bool),
+]
+
+
+@pytest.mark.parametrize("dtype_str,expected_py_type", _SCALAR_DTYPE_CASES)
+@pytest.mark.parametrize("supply_type", list(TensorSupplyType))
+def test_scalar_param_returns_python_scalar(dtype_str, expected_py_type, supply_type):
+    """A scalar `KernelParam` should yield a Python scalar of the right
+    dtype family for every `TensorSupplyType`. This is the fallback
+    that allows the autotuner to invoke kernels that take scalar
+    value parameters; users can still supply explicit values via
+    `supply_prog`. Regression for #2081.
+    """
+    param = KernelParam(dtype=tvm.DataType(dtype_str), shape=[])
+    supply = get_tensor_supply(supply_type)
+
+    value = supply(param)
+
+    assert isinstance(value, expected_py_type), (
+        f"Expected a {expected_py_type.__name__} for {dtype_str} scalar under {supply_type}, got {type(value).__name__} ({value!r})"
+    )
+
+
+def test_scalar_supply_does_not_require_cuda():
+    """The scalar fast path must not depend on a CUDA device, so that
+    autotuner input generation works on CPU-only hosts as well as on
+    GPU machines."""
+    param = KernelParam(dtype=tvm.DataType("float32"), shape=[])
+    supply = get_tensor_supply(TensorSupplyType.Integer)
+    # Should not raise, and should not touch CUDA at all.
+    value = supply(param)
+    assert isinstance(value, float)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/utils/tensor.py
+++ b/tilelang/utils/tensor.py
@@ -46,13 +46,18 @@ def get_tensor_supply(supply_type: TensorSupplyType = TensorSupplyType.Integer):
     def get_tensor(param: KernelParam) -> torch.Tensor:
         # Convert tvm.DataType to torch.dtype for tensor creation
         dtype: torch.dtype = param.torch_dtype()
-        device = get_current_device()
 
+        # Scalar value parameter (empty shape), e.g. `s: T.float32` in the
+        # kernel signature. Return a Python scalar of the matching dtype
+        # family so the autotuner can invoke kernels with scalar arguments
+        # without crashing. Users that need a specific scalar value can
+        # still pass it explicitly via `supply_prog`. See #2081.
         if hasattr(param, "shape") and not param.shape:
-            raise ValueError(
-                f"TensorType must have a shape, but got {type(param)}, "
-                "likely you are trying to generate a random tensor with a dynamic symbolic shape."
-            )
+            if hasattr(param, "is_boolean") and param.is_boolean():
+                return False
+            return 0.0 if dtype.is_floating_point else 0
+
+        device = get_current_device()
 
         # Check if with dynamic symbolic shape
         for shape in param.shape:


### PR DESCRIPTION
## Summary

Fixes #2081. Any kernel signature that includes a scalar value parameter, e.g.

```python
@tilelang.autotune(configs=[{"threads": 128}, {"threads": 256}], ...)
@tilelang.jit
def test_fun(N=4096, BLOCK_N=512, threads=128):
    @T.prim_func
    def kernel(A: T.Tensor((N,), T.float32), s: T.float32):  # <- scalar value param
        ...
    return kernel

test_fun()(A, 0.1)  # crashes during autotune
```

cannot currently be autotuned.

## Root cause

The autotuner asks the profiler to generate inputs for every parameter via `Profiler._get_inputs`, which calls `get_tensor_supply(...)(param)` for each one. For the scalar `s`, that path landed in `tilelang/utils/tensor.py:get_tensor`, which unconditionally raised on empty-shape `KernelParam`s:

```python
if hasattr(param, "shape") and not param.shape:
    raise ValueError(
        f"TensorType must have a shape, but got {type(param)}, "
        "likely you are trying to generate a random tensor with a dynamic symbolic shape."
    )
```

The error message was also misleading — the actual cause is a scalar value parameter, not a dynamic shape (which is detected separately by the `tir.Var` check below).

## Fix

Teach `get_tensor` to recognize scalar params and return a Python scalar of the matching dtype family (`False` for bool, `0.0` for floats, `0` for ints) so the autotuner can invoke the kernel during benchmarking. Users that need a specific scalar value can still override per-kernel via `supply_prog`.

The scalar fast path runs *before* `get_current_device()`, so this also makes input generation work on CPU-only hosts when the kernel only takes scalar params.

## Test plan

- [x] Added `testing/python/utils/test_tensor_supply_scalar.py` — CUDA-free unit test parameterised over every `TensorSupplyType` and the common dtype families (`float32/16/64`, `bfloat16`, `int8/32/64`, `uint8`, `bool`). Locks in that scalar params yield Python scalars of the right type for every supply variant.
- [x] `ruff check` + `ruff format --check` clean on both files.
- [ ] Maintainer to confirm autotune now succeeds on the repro from #2081 (I do not have a CUDA box to run `do_bench` end-to-end).

## Tradeoffs / notes

- The default scalar value is `0` / `0.0` / `False`. This is a deliberate, deterministic choice — randomized scalars would surprise users whose kernels branch on the value. Anyone needing specific scalars should use `supply_prog`, which already takes precedence over `_get_inputs`.
- The previous error path is removed because it was unreachable for legitimate uses (scalar params now succeed) and its message was actively misleading. The dynamic-shape error path remains untouched.

Closes: #2081

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scalar (zero-dimensional) parameters are now properly handled, returning appropriate Python scalar values instead of errors. This enables the autotuner to work with scalar arguments.

* **Tests**
  * Added regression tests validating scalar parameter support across multiple data types and tensor supply modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->