### PR TITLE
[codex] Fix 1D TMA store layout inference

### DIFF
--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -483,6 +483,13 @@ LayoutMap CopyNode::InferLayout(const LayoutInferArgs &T,
                              thread_extent, T.thread_bounds, result_map);
     }
 
+    if (is_tma_1d) {
+      // 1D TMA requires contiguous shared memory. Do not infer a swizzled
+      // shared layout here, otherwise the final instruction selection may fall
+      // back to descriptor-based multidimensional TMA.
+      return result_map;
+    }
+
     // check shared layout is non-swizzle
     // skip layout inference if shared layout is already annotated
     if (level == InferLevel::kFree && !T.layout_map.count(shared_tensor)) {

--- a/testing/python/language/test_tilelang_language_tma_store.py
+++ b/testing/python/language/test_tilelang_language_tma_store.py
@@ -114,6 +114,18 @@ def auto_tma_store_copy(M, N, block_M, block_N, dtype, threads):
     return main
 
 
+def full_shape_tma_store_1d(dtype, threads):
+    @T.prim_func
+    def main(
+        C: T.Tensor((128, 128), dtype),
+    ):
+        with T.Kernel(threads=threads):
+            C_shared = T.alloc_shared((128, 128), dtype)
+            T.copy(C_shared, C)
+
+    return main
+
+
 def run_auto_tma_store_copy():
     M = N = 256
     block_M = block_N = 128
@@ -138,6 +150,17 @@ def run_auto_tma_store_copy():
     profiler.assert_allclose(ref_program, atol=1e-2, rtol=1e-2)
 
 
+def run_full_shape_tma_store_1d_codegen():
+    program = full_shape_tma_store_1d(T.float32, 128)
+    kernel = tilelang.compile(
+        program,
+        pass_configs={tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True},
+    )
+    kernel_source = kernel.get_kernel_source()
+    assert "tl::tma_store" in kernel_source, "Expected TMA store in kernel source"
+    assert "CUtensorMap" not in kernel_source, "Expected pointer-based 1D TMA store"
+
+
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_tma_store_2_stages():
@@ -154,6 +177,12 @@ def test_tma_store_3_stages():
 @tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_plain_copy_auto_tma_store():
     run_auto_tma_store_copy()
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_plain_copy_full_shape_tma_store_uses_1d():
+    run_full_shape_tma_store_1d_codegen()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes a layout-inference regression that caused plain shared -> global copies to fall back from the pointer-based 1D TMA store path to descriptor-based multidimensional TMA.

Root cause: `CopyNode::InferLayout()` could still attach a swizzled shared-memory layout during free inference after the copy had already been selected as `kBulkStore1D`. That mutated the shared layout map and made later lowering reject the 1D path, which produced `CUtensorMap`-backed stores instead of `tl::tma_store(shared_ptr, global_ptr, bytes)`.

What changed:
- Skip shared-layout swizzle inference for copies that have already been classified as 1D TMA.
- Add a regression test that compiles a full-shape `(128, 128)` shared -> global store and checks that the generated kernel uses pointer-based `tma_store` without `CUtensorMap`.

Validation:
- `./format.sh`
- `cmake --build build -j$(nproc)`
- `python debug/0503_tma_store/test.py`
- `python -m pytest testing/python/language/test_tilelang_language_tma_store.py -x -k "full_shape_tma_store_uses_1d"`
- `python -m pytest testing/python/language/test_tilelang_language_tma_store.py -x -k "plain_copy_auto_tma_store"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized layout inference for 1D bulk transfer operations to improve performance by short-circuiting unnecessary validation logic.

* **Tests**
  * Updated test coverage for 1D TMA store codegen to validate kernel generation and improve test specificity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->