### PR TITLE
[Examples] Add examples for operators in DeepSeek-V4

### DIFF
--- a/examples/deepseek_v32/sparse_mla_fwd.py
+++ b/examples/deepseek_v32/sparse_mla_fwd.py
@@ -7,10 +7,7 @@ from utils import assert_tensors_similar
 
 @tilelang.jit(
     out_idx=[-2, -1],
-    pass_configs={
-        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
-        tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True
-    },
+    pass_configs={tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True, tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True},
 )
 def sparse_mla_fwd(
     heads,

--- a/examples/deepseek_v32/sparse_mla_fwd.py
+++ b/examples/deepseek_v32/sparse_mla_fwd.py
@@ -7,7 +7,10 @@ from utils import assert_tensors_similar
 
 @tilelang.jit(
     out_idx=[-2, -1],
-    pass_configs={tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True},
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True
+    },
 )
 def sparse_mla_fwd(
     heads,
@@ -143,7 +146,7 @@ def sparse_mla_fwd(
                     alpha[h_i] = T.exp2((m_i_prev[h_i] - m_i[h_i]) * sm_scale)
                 for h_i, bi_i in T.Parallel(H_per_block, BI):
                     acc_s[h_i, bi_i] = T.exp2(acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale)
-                T.reduce_sum(acc_s, sumexp_i, dim=1)  # is this a accumulate operator?
+                T.reduce_sum(acc_s, sumexp_i, dim=1)
                 for h_i in T.Parallel(H_per_block):
                     sumexp[h_i] = sumexp[h_i] * alpha[h_i] + sumexp_i[h_i]
                 for h_i, d_i in T.Parallel(H_per_block, D):
@@ -158,7 +161,8 @@ def sparse_mla_fwd(
             for h_i in T.Parallel(H_per_block):
                 sumexp[h_i] = T.log2(sumexp[h_i]) + m_i[h_i] * sm_scale
 
-            T.copy(acc_o, Output[b_i, s_i, H0:H1, :])
+            T.copy(acc_o, O_shared)
+            T.copy(O_shared, Output[b_i, s_i, H0:H1, :])
             T.copy(sumexp, Lse[b_i, s_i, H0:H1])
 
     return main

--- a/examples/deepseek_v4/act_quant.py
+++ b/examples/deepseek_v4/act_quant.py
@@ -2,6 +2,7 @@ import torch
 import tilelang
 import tilelang.language as T
 
+
 def fast_log2_ceil(x):
     """Compute ceil(log2(x)) via IEEE 754 bit manipulation. Avoids slow log/ceil intrinsics."""
     bits_x = T.reinterpret(x, "uint32")
@@ -74,9 +75,7 @@ def fp8_quant_kernel(
                 else:
                     s_local[i] = amax_local[i] * fp8_max_inv
             for i, j in T.Parallel(blk_m, group_size):
-                y_local[i, j] = T.clamp(
-                    x_local[i, j] / s_local[i], fp8_min, fp8_max
-                )
+                y_local[i, j] = T.clamp(x_local[i, j] / s_local[i], fp8_min, fp8_max)
 
             for i in T.Parallel(blk_m):
                 scale[bx * blk_m + i, by] = s_local[i]
@@ -151,12 +150,10 @@ def fp4_quant_kernel(
 
             T.reduce_absmax(x_local, amax_local, dim=1)
             for i in T.Parallel(blk_m):
-                amax_local[i] = T.max(amax_local[i], 6 * (2 ** -126))
+                amax_local[i] = T.max(amax_local[i], 6 * (2**-126))
                 s_local[i] = fast_round_scale(amax_local[i], fp4_max_inv)
             for i, j in T.Parallel(blk_m, group_size):
-                y_local[i, j] = T.clamp(
-                    x_local[i, j] / s_local[i], fp4_min, fp4_max
-                )
+                y_local[i, j] = T.clamp(x_local[i, j] / s_local[i], fp4_min, fp4_max)
 
             for i in T.Parallel(blk_m):
                 scale[bx * blk_m + i, by] = s_local[i]
@@ -189,6 +186,7 @@ def fp4_act_quant(x: torch.Tensor, block_size: int = 32):
 # ---------------------------------------------------------------------------
 # PyTorch reference implementations
 # ---------------------------------------------------------------------------
+
 
 def fp8_act_quant_ref(x: torch.Tensor, block_size: int = 128, round_scale: bool = False):
     """PyTorch reference for block-wise FP8 quantization.
@@ -225,7 +223,7 @@ def _nearest_fp4_nibble(x_clamped: torch.Tensor) -> torch.Tensor:
     """
     fp4_vals = _FP4_VALS.to(x_clamped.device)
     x_abs = x_clamped.abs().unsqueeze(-1)  # (..., 1)
-    dists = (x_abs - fp4_vals).abs()       # (..., 8)
+    dists = (x_abs - fp4_vals).abs()  # (..., 8)
     idx = dists.argmin(dim=-1).to(torch.uint8)
     # For negative values, add 8 (set the sign nibble bit)
     idx = torch.where(x_clamped < 0, idx + 8, idx)
@@ -259,7 +257,7 @@ def fp4_act_quant_ref(x: torch.Tensor, block_size: int = 32):
     fp4_max = 6.0
     num_blocks = N // block_size
     x_float = x.float().reshape(M, num_blocks, block_size)
-    amax = x_float.abs().amax(dim=-1).clamp(min=6.0 * (2.0 ** -126))
+    amax = x_float.abs().amax(dim=-1).clamp(min=6.0 * (2.0**-126))
     # Always round scale for FP4/E8M0
     scale = torch.pow(2.0, torch.ceil(torch.log2(amax / fp4_max)))
     x_scaled = x_float / scale.unsqueeze(-1)
@@ -288,9 +286,9 @@ def fp4_dequant_to_float(quant: torch.Tensor, scale: torch.Tensor, N_logical: in
     high = (quant_u8 >> 4) & 0xF
     # Map nibbles to float values
     fp4_val_map = torch.tensor(
-        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
-         -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
-        dtype=torch.float32, device=quant.device,
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+        dtype=torch.float32,
+        device=quant.device,
     )
     vals = torch.stack([fp4_val_map[low.long()], fp4_val_map[high.long()]], dim=-1)
     vals = vals.reshape(M, -1)  # (M, N_logical)
@@ -304,6 +302,7 @@ def fp4_dequant_to_float(quant: torch.Tensor, scale: torch.Tensor, N_logical: in
 # ---------------------------------------------------------------------------
 # Test functions
 # ---------------------------------------------------------------------------
+
 
 def test_fp8_act_quant(M: int = 256, N: int = 1024, block_size: int = 128):
     """Test FP8 act quant: tilelang vs PyTorch reference."""

--- a/examples/deepseek_v4/act_quant.py
+++ b/examples/deepseek_v4/act_quant.py
@@ -1,0 +1,386 @@
+import torch
+import tilelang
+import tilelang.language as T
+
+def fast_log2_ceil(x):
+    """Compute ceil(log2(x)) via IEEE 754 bit manipulation. Avoids slow log/ceil intrinsics."""
+    bits_x = T.reinterpret(x, "uint32")
+    exp_x = (bits_x >> 23) & 0xFF
+    man_bits = bits_x & ((1 << 23) - 1)
+    return T.Cast("int32", exp_x - 127 + T.if_then_else(man_bits != 0, 1, 0))
+
+
+def fast_pow2(x):
+    """Compute 2^x for integer x via IEEE 754 bit manipulation."""
+    bits_x = (x + 127) << 23
+    return T.reinterpret(bits_x, "float32")
+
+
+def fast_round_scale(amax, fp8_max_inv):
+    return fast_pow2(fast_log2_ceil(amax * fp8_max_inv))
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+    }
+)
+def fp8_quant_kernel(
+    x,
+    block_size=128,
+    round_scale=True,  # round scale to exponential of 2
+):
+    """Block-wise FP8 quantization."""
+
+    M = T.dynamic("M")
+    N = T.const("N")
+    fp8_min, fp8_max = -448.0, 448.0
+    in_dtype = T.bfloat16
+    out_dtype = T.float8_e4m3
+    scale_dtype = T.float32
+    compute_dtype = T.float32  # Internal computation in FP32;
+
+    x: T.Tensor[(M, N), in_dtype]
+
+    blk_m = 32
+    group_size = block_size
+
+    quant = T.empty((M, N), out_dtype)
+    scale = T.empty((M, T.ceildiv(N, group_size)), scale_dtype)
+
+    fp8_max_inv = 1 / fp8_max
+    num_stages = 0 if round_scale else 2
+
+    with T.Kernel(T.ceildiv(M, blk_m), T.ceildiv(N, group_size), threads=128) as (
+        bx,
+        by,
+    ):
+        x_shared = T.alloc_shared((blk_m, group_size), in_dtype)
+        x_local = T.alloc_fragment((blk_m, group_size), in_dtype)
+        amax_local = T.alloc_fragment((blk_m,), compute_dtype)
+        s_local = T.alloc_fragment((blk_m,), compute_dtype)
+        y_local = T.alloc_fragment((blk_m, group_size), out_dtype)
+        y_shared = T.alloc_shared((blk_m, group_size), out_dtype)
+
+        for _ in T.Pipelined(1, num_stages=num_stages):
+            T.copy(x[bx * blk_m, by * group_size], x_shared)
+            T.copy(x_shared, x_local)
+
+            T.reduce_absmax(x_local, amax_local, dim=1)
+            for i in T.Parallel(blk_m):
+                amax_local[i] = T.max(amax_local[i], 1e-4)
+                if round_scale:
+                    s_local[i] = fast_round_scale(amax_local[i], fp8_max_inv)
+                else:
+                    s_local[i] = amax_local[i] * fp8_max_inv
+            for i, j in T.Parallel(blk_m, group_size):
+                y_local[i, j] = T.clamp(
+                    x_local[i, j] / s_local[i], fp8_min, fp8_max
+                )
+
+            for i in T.Parallel(blk_m):
+                scale[bx * blk_m + i, by] = s_local[i]
+            T.copy(y_local, y_shared)
+            T.copy(y_shared, quant[bx * blk_m, by * group_size])
+
+    return quant, scale
+
+
+def fp8_act_quant(x: torch.Tensor, block_size: int = 128, round_scale: bool = False):
+    """Block-wise FP8 quantization (bf16 -> fp8_e4m3).
+
+    Args:
+        x: Input tensor, shape (..., N) with N divisible by block_size, dtype bfloat16.
+        block_size: Group size for block-wise scaling along the last dimension.
+        round_scale: If True, round scale to nearest power of 2 (MXFP style).
+
+    Returns:
+        quant: FP8 quantized tensor, same shape as x, dtype float8_e4m3fn.
+        scale: Per-block scales, shape (..., N // block_size), dtype float32.
+    """
+    N = x.size(-1)
+    assert N % block_size == 0, f"N={N} must be divisible by block_size={block_size}"
+    z = x.contiguous()
+    quant, scale = fp8_quant_kernel(z.view(-1, N), block_size=block_size, round_scale=round_scale)
+    return quant.view(x.shape), scale.view(*x.size()[:-1], -1)
+
+
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+    }
+)
+def fp4_quant_kernel(
+    x,
+    block_size=32,
+):
+    """Block-wise FP4 quantization: bf16 -> float4_e2m1fn, E8M0 power-of-2 scale."""
+
+    M = T.dynamic("M")
+    N = T.const("N")
+    fp4_min, fp4_max = -6.0, 6.0
+    in_dtype = T.bfloat16
+    out_dtype = T.float4_e2m1fn
+    scale_dtype = T.float32
+    compute_dtype = T.float32
+
+    x: T.Tensor[(M, N), in_dtype]
+
+    blk_m = 32
+    group_size = block_size
+
+    quant = T.empty((M, N), out_dtype)
+    scale = T.empty((M, T.ceildiv(N, group_size)), scale_dtype)
+
+    fp4_max_inv = 1.0 / fp4_max
+
+    with T.Kernel(T.ceildiv(M, blk_m), T.ceildiv(N, group_size), threads=128) as (
+        bx,
+        by,
+    ):
+        x_shared = T.alloc_shared((blk_m, group_size), in_dtype)
+        x_local = T.alloc_fragment((blk_m, group_size), in_dtype)
+        amax_local = T.alloc_fragment((blk_m,), compute_dtype)
+        s_local = T.alloc_fragment((blk_m,), compute_dtype)
+        y_local = T.alloc_fragment((blk_m, group_size), out_dtype)
+        y_shared = T.alloc_shared((blk_m, group_size), out_dtype)
+
+        for _ in T.Pipelined(1, num_stages=2):
+            T.copy(x[bx * blk_m, by * group_size], x_shared)
+            T.copy(x_shared, x_local)
+
+            T.reduce_absmax(x_local, amax_local, dim=1)
+            for i in T.Parallel(blk_m):
+                amax_local[i] = T.max(amax_local[i], 6 * (2 ** -126))
+                s_local[i] = fast_round_scale(amax_local[i], fp4_max_inv)
+            for i, j in T.Parallel(blk_m, group_size):
+                y_local[i, j] = T.clamp(
+                    x_local[i, j] / s_local[i], fp4_min, fp4_max
+                )
+
+            for i in T.Parallel(blk_m):
+                scale[bx * blk_m + i, by] = s_local[i]
+            T.copy(y_local, y_shared)
+            T.copy(y_shared, quant[bx * blk_m, by * group_size])
+
+    return quant, scale
+
+
+def fp4_act_quant(x: torch.Tensor, block_size: int = 32):
+    """Block-wise FP4 quantization (bf16 -> float4_e2m1fn, E8M0 scale).
+
+    Args:
+        x: Input tensor, shape (..., N) with N divisible by block_size, dtype bfloat16.
+        block_size: Group size for block-wise scaling (default 32, must be even).
+
+    Returns:
+        quant: FP4 quantized tensor, logical shape matching x,
+               physical dtype float4_e2m1fn_x2 with last dim halved.
+        scale: Per-block scales, shape (..., N // block_size), dtype float32.
+    """
+    N = x.size(-1)
+    assert N % block_size == 0, f"N={N} must be divisible by block_size={block_size}"
+    z = x.contiguous()
+    quant, scale = fp4_quant_kernel(z.view(-1, N), block_size=block_size)
+    # FP4 output has physical shape (M, N//2) with float4_e2m1fn_x2 dtype
+    return quant.view(*x.size()[:-1], -1), scale.view(*x.size()[:-1], -1)
+
+
+# ---------------------------------------------------------------------------
+# PyTorch reference implementations
+# ---------------------------------------------------------------------------
+
+def fp8_act_quant_ref(x: torch.Tensor, block_size: int = 128, round_scale: bool = False):
+    """PyTorch reference for block-wise FP8 quantization.
+
+    Returns:
+        quant: shape (M, N), dtype torch.float8_e4m3fn.
+        scale: shape (M, num_blocks), dtype torch.float32.
+    """
+    M, N = x.shape
+    fp8_max = 448.0
+    num_blocks = N // block_size
+    x_float = x.float().reshape(M, num_blocks, block_size)
+    amax = x_float.abs().amax(dim=-1).clamp(min=1e-4)
+    if round_scale:
+        scale = torch.pow(2.0, torch.ceil(torch.log2(amax / fp8_max)))
+    else:
+        scale = amax / fp8_max
+    x_scaled = x_float / scale.unsqueeze(-1)
+    x_clamped = x_scaled.clamp(-fp8_max, fp8_max)
+    quant = x_clamped.reshape(M, N).to(torch.float8_e4m3fn)
+    return quant, scale
+
+
+# FP4 E2M1 representable values (unsigned nibble 0-7; sign adds 8)
+_FP4_VALS = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0], dtype=torch.float32)
+
+
+def _nearest_fp4_nibble(x_clamped: torch.Tensor) -> torch.Tensor:
+    """Round each float in [-6, 6] to the nearest FP4 E2M1 nibble value (uint8 0-15).
+
+    Nibble encoding for float4_e2m1fn:
+      0-7: +{0, 0.5, 1, 1.5, 2, 3, 4, 6}
+      8-15: -{0, 0.5, 1, 1.5, 2, 3, 4, 6}  (sign bit set)
+    """
+    fp4_vals = _FP4_VALS.to(x_clamped.device)
+    x_abs = x_clamped.abs().unsqueeze(-1)  # (..., 1)
+    dists = (x_abs - fp4_vals).abs()       # (..., 8)
+    idx = dists.argmin(dim=-1).to(torch.uint8)
+    # For negative values, add 8 (set the sign nibble bit)
+    idx = torch.where(x_clamped < 0, idx + 8, idx)
+    return idx
+
+
+def _pack_fp4_nibbles(nibbles: torch.Tensor) -> torch.Tensor:
+    """Pack pairs of FP4 nibbles into uint8 bytes.
+
+    nibbles: (M, N) uint8 tensor, each element in 0-15.
+    Returns: (M, N//2) uint8 tensor.
+    Low nibble (bits 3:0) = even index, High nibble (bits 7:4) = odd index.
+    """
+    M, N = nibbles.shape
+    assert N % 2 == 0
+    nb2 = nibbles.reshape(M, N // 2, 2)
+    low = nb2[:, :, 0] & 0xF
+    high = nb2[:, :, 1] & 0xF
+    packed = ((high << 4) | low).to(torch.uint8)
+    return packed
+
+
+def fp4_act_quant_ref(x: torch.Tensor, block_size: int = 32):
+    """PyTorch reference for block-wise FP4 quantization with E8M0 scale.
+
+    Returns:
+        quant: shape (M, N//2), dtype torch.float4_e2m1fn_x2 (packed).
+        scale: shape (M, num_blocks), dtype torch.float32.
+    """
+    M, N = x.shape
+    fp4_max = 6.0
+    num_blocks = N // block_size
+    x_float = x.float().reshape(M, num_blocks, block_size)
+    amax = x_float.abs().amax(dim=-1).clamp(min=6.0 * (2.0 ** -126))
+    # Always round scale for FP4/E8M0
+    scale = torch.pow(2.0, torch.ceil(torch.log2(amax / fp4_max)))
+    x_scaled = x_float / scale.unsqueeze(-1)
+    x_clamped = x_scaled.clamp(-fp4_max, fp4_max)
+    nibbles = _nearest_fp4_nibble(x_clamped.reshape(M, N))
+    packed = _pack_fp4_nibbles(nibbles)
+    quant = packed.view(torch.float4_e2m1fn_x2)
+    return quant, scale
+
+
+def fp4_dequant_to_float(quant: torch.Tensor, scale: torch.Tensor, N_logical: int) -> torch.Tensor:
+    """Dequantize FP4 packed tensor back to float32 for verification.
+
+    quant: shape (M, N//2), dtype float4_e2m1fn_x2.
+    scale: shape (M, num_blocks), dtype float32.
+    N_logical: original logical last dimension.
+    Returns: shape (M, N_logical), dtype float32.
+    """
+    M = quant.size(0)
+    num_blocks = scale.size(1)
+    block_size = N_logical // num_blocks
+
+    # View as uint8 and unpack nibbles
+    quant_u8 = quant.view(torch.uint8)
+    low = quant_u8 & 0xF
+    high = (quant_u8 >> 4) & 0xF
+    # Map nibbles to float values
+    fp4_val_map = torch.tensor(
+        [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+         -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0],
+        dtype=torch.float32, device=quant.device,
+    )
+    vals = torch.stack([fp4_val_map[low.long()], fp4_val_map[high.long()]], dim=-1)
+    vals = vals.reshape(M, -1)  # (M, N_logical)
+
+    # Broadcast scale per block
+    vals_blocks = vals.reshape(M, num_blocks, block_size)
+    scaled = vals_blocks * scale.unsqueeze(-1)
+    return scaled.reshape(M, N_logical)
+
+
+# ---------------------------------------------------------------------------
+# Test functions
+# ---------------------------------------------------------------------------
+
+def test_fp8_act_quant(M: int = 256, N: int = 1024, block_size: int = 128):
+    """Test FP8 act quant: tilelang vs PyTorch reference."""
+    torch.random.manual_seed(42)
+    x = torch.randn((M, N), dtype=torch.bfloat16, device="cuda")
+
+    for round_scale in [False, True]:
+        quant_tl, scale_tl = fp8_act_quant(x, block_size=block_size, round_scale=round_scale)
+        quant_ref, scale_ref = fp8_act_quant_ref(x, block_size=block_size, round_scale=round_scale)
+
+        # Compare scales
+        torch.testing.assert_close(scale_tl.float(), scale_ref.float(), rtol=1e-5, atol=1e-5)
+        # Compare quantized values (both float8_e4m3fn, compare as float32)
+        torch.testing.assert_close(quant_tl.float(), quant_ref.float(), rtol=0, atol=0)
+
+    print(f"[PASS] test_fp8_act_quant M={M}, N={N}, block_size={block_size}")
+
+
+def test_fp4_act_quant(M: int = 256, N: int = 1024, block_size: int = 32):
+    """Test FP4 act quant: tilelang vs PyTorch reference via dequantized comparison."""
+    torch.random.manual_seed(42)
+    x = torch.randn((M, N), dtype=torch.bfloat16, device="cuda")
+
+    quant_tl, scale_tl = fp4_act_quant(x, block_size=block_size)
+    quant_ref, scale_ref = fp4_act_quant_ref(x, block_size=block_size)
+
+    # Both return (M, N//2) physical float4_e2m1fn_x2 dtype
+    assert quant_tl.shape == quant_ref.shape, f"Shape mismatch: {quant_tl.shape} vs {quant_ref.shape}"
+
+    # Compare scales
+    torch.testing.assert_close(scale_tl.float(), scale_ref.float(), rtol=1e-5, atol=1e-5)
+
+    # Compare raw bits (both should be identical uint8 storage under the hood)
+    tl_bits = quant_tl.view(torch.uint8)
+    ref_bits = quant_ref.view(torch.uint8)
+    mismatches = (tl_bits != ref_bits).sum().item()
+    total = tl_bits.numel()
+    if mismatches > 0:
+        # FP4 nibble rounding differs at exact midpoints (CUDA hardware vs argmin tie-breaking)
+        dequant_tl = fp4_dequant_to_float(quant_tl, scale_tl, N)
+        dequant_ref = fp4_dequant_to_float(quant_ref, scale_ref, N)
+        max_diff = (dequant_tl - dequant_ref).abs().max().item()
+        # Allow up to one FP4 step difference at exact midpoints (~0.5-1.0 in dequant space)
+        torch.testing.assert_close(dequant_tl, dequant_ref, rtol=0.05, atol=1.0)
+        print(f"  (FP4 nibble mismatch: {mismatches}/{total} bytes from tie-breaking, max dequant diff: {max_diff:.4f})")
+    else:
+        print(f"  (FP4 bit-exact match: {total} bytes)")
+
+    print(f"[PASS] test_fp4_act_quant M={M}, N={N}, block_size={block_size}")
+
+
+def test_round_trip_error():
+    """Round-trip sanity: quantize then dequantize, check MSE."""
+    torch.random.manual_seed(42)
+    x = torch.randn((128, 512), dtype=torch.bfloat16, device="cuda")
+    x_float = x.float()
+
+    # FP8 round-trip
+    quant_fp8, scale_fp8 = fp8_act_quant(x, block_size=128, round_scale=True)
+    recovered_fp8 = quant_fp8.float() * scale_fp8.float().repeat_interleave(128, dim=1)
+    fp8_mse = torch.nn.functional.mse_loss(recovered_fp8, x_float).item()
+    print(f"  FP8 round-trip MSE: {fp8_mse:.6f}")
+    assert fp8_mse < 1.0, f"FP8 round-trip MSE too high: {fp8_mse}"
+
+    # FP4 round-trip
+    quant_fp4, scale_fp4 = fp4_act_quant(x, block_size=32)
+    recovered_fp4 = fp4_dequant_to_float(quant_fp4, scale_fp4, 512)
+    fp4_mse = torch.nn.functional.mse_loss(recovered_fp4, x_float).item()
+    print(f"  FP4 round-trip MSE: {fp4_mse:.6f}")
+    assert fp4_mse < 10.0, f"FP4 round-trip MSE too high: {fp4_mse}"
+
+    print("[PASS] test_round_trip_error")
+
+
+if __name__ == "__main__":
+    test_fp8_act_quant()
+    test_fp4_act_quant()
+    test_round_trip_error()

--- a/examples/deepseek_v4/act_quant.py
+++ b/examples/deepseek_v4/act_quant.py
@@ -23,7 +23,6 @@ def fast_round_scale(amax, fp8_max_inv):
 @tilelang.jit(
     pass_configs={
         tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
-        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
     }
 )
 def fp8_quant_kernel(
@@ -64,7 +63,7 @@ def fp8_quant_kernel(
         y_shared = T.alloc_shared((blk_m, group_size), out_dtype)
 
         for _ in T.Pipelined(1, num_stages=num_stages):
-            T.copy(x[bx * blk_m, by * group_size], x_shared)
+            T.copy(x[bx * blk_m, by * group_size], x_shared, disable_tma=True)
             T.copy(x_shared, x_local)
 
             T.reduce_absmax(x_local, amax_local, dim=1)
@@ -82,7 +81,7 @@ def fp8_quant_kernel(
             for i in T.Parallel(blk_m):
                 scale[bx * blk_m + i, by] = s_local[i]
             T.copy(y_local, y_shared)
-            T.copy(y_shared, quant[bx * blk_m, by * group_size])
+            T.copy(y_shared, quant[bx * blk_m, by * group_size], disable_tma=True)
 
     return quant, scale
 
@@ -109,7 +108,6 @@ def fp8_act_quant(x: torch.Tensor, block_size: int = 128, round_scale: bool = Fa
 @tilelang.jit(
     pass_configs={
         tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
-        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
     }
 )
 def fp4_quant_kernel(
@@ -148,7 +146,7 @@ def fp4_quant_kernel(
         y_shared = T.alloc_shared((blk_m, group_size), out_dtype)
 
         for _ in T.Pipelined(1, num_stages=2):
-            T.copy(x[bx * blk_m, by * group_size], x_shared)
+            T.copy(x[bx * blk_m, by * group_size], x_shared, disable_tma=True)
             T.copy(x_shared, x_local)
 
             T.reduce_absmax(x_local, amax_local, dim=1)
@@ -163,7 +161,7 @@ def fp4_quant_kernel(
             for i in T.Parallel(blk_m):
                 scale[bx * blk_m + i, by] = s_local[i]
             T.copy(y_local, y_shared)
-            T.copy(y_shared, quant[bx * blk_m, by * group_size])
+            T.copy(y_shared, quant[bx * blk_m, by * group_size], disable_tma=True)
 
     return quant, scale
 

--- a/examples/deepseek_v4/sparse_attn_fwd_sm90.py
+++ b/examples/deepseek_v4/sparse_attn_fwd_sm90.py
@@ -8,8 +8,7 @@ NOTE: This impl is simply an illustration and maybe not optimal,
 or comparable to handwrite version
 """
 
-#TODO(wt): Support window size
-
+# TODO(wt): Support window size
 
 import math
 import torch
@@ -87,8 +86,8 @@ def sparse_attn_fwd(
             logsum = T.alloc_fragment([H_per_block], accum_dtype)
             mask = T.alloc_fragment([BI], T.bool)
 
-            T.copy(Q[by, seq_idx, h_start:h_start + H_per_block, :], Q_shared)
-            T.copy(Sinks[h_start:h_start + H_per_block], Sinks_shared)
+            T.copy(Q[by, seq_idx, h_start : h_start + H_per_block, :], Q_shared)
+            T.copy(Sinks[h_start : h_start + H_per_block], Sinks_shared)
             T.fill(acc_o, 0)
             T.fill(logsum, 0)
             T.fill(scores_max, -(2**30))  # avoid -inf - inf to cause nan
@@ -106,13 +105,14 @@ def sparse_attn_fwd(
 
                 # Initialize scores with mask
                 for h_i, bi_i in T.Parallel(H_per_block, BI):
-                    acc_s[h_i, bi_i] = T.if_then_else(
-                        mask[bi_i], 0, -T.infinity(acc_s.dtype)
-                    )
+                    acc_s[h_i, bi_i] = T.if_then_else(mask[bi_i], 0, -T.infinity(acc_s.dtype))
 
                 # QK^T GEMM: (H_per_block, dim) @ (dim, BI) -> (H_per_block, BI)
                 T.gemm(
-                    Q_shared, KV_shared, acc_s, transpose_B=True,
+                    Q_shared,
+                    KV_shared,
+                    acc_s,
+                    transpose_B=True,
                     policy=T.GemmWarpPolicy.FullRow,
                 )
 
@@ -122,13 +122,9 @@ def sparse_attn_fwd(
                 for h_i in T.Parallel(H_per_block):
                     scores_max[h_i] = T.max(scores_max[h_i], scores_max_prev[h_i])
                 for h_i in T.Parallel(H_per_block):
-                    scores_scale[h_i] = T.exp2(
-                        scores_max_prev[h_i] * scale - scores_max[h_i] * scale
-                    )
+                    scores_scale[h_i] = T.exp2(scores_max_prev[h_i] * scale - scores_max[h_i] * scale)
                 for h_i, bi_i in T.Parallel(H_per_block, BI):
-                    acc_s[h_i, bi_i] = T.exp2(
-                        acc_s[h_i, bi_i] * scale - scores_max[h_i] * scale
-                    )
+                    acc_s[h_i, bi_i] = T.exp2(acc_s[h_i, bi_i] * scale - scores_max[h_i] * scale)
                 T.reduce_sum(acc_s, scores_sum, dim=1)
 
                 # Rescale acc_o by correction factor
@@ -138,7 +134,9 @@ def sparse_attn_fwd(
                 # Accumulate: P @ V
                 T.copy(acc_s, S_shared)
                 T.gemm(
-                    S_shared, KV_shared, acc_o,
+                    S_shared,
+                    KV_shared,
+                    acc_o,
                     policy=T.GemmWarpPolicy.FullRow,
                 )
 
@@ -148,9 +146,7 @@ def sparse_attn_fwd(
 
             # Attention sink (per-head)
             for h_i in T.Parallel(H_per_block):
-                logsum[h_i] += T.exp2(
-                    Sinks_shared[h_i] * 1.44269504 - scores_max[h_i] * scale
-                )
+                logsum[h_i] += T.exp2(Sinks_shared[h_i] * 1.44269504 - scores_max[h_i] * scale)
 
             # Normalize
             for h_i, d_i in T.Parallel(H_per_block, dim):
@@ -158,14 +154,14 @@ def sparse_attn_fwd(
 
             # Store output
             T.copy(acc_o, acc_o_shared)
-            T.copy(acc_o_shared, Output[by, seq_idx, h_start:h_start + H_per_block, :])
+            T.copy(acc_o_shared, Output[by, seq_idx, h_start : h_start + H_per_block, :])
 
     return main
 
 
 def torch_sparse_attention(
-    q: torch.Tensor,       # [b, s, h, d]
-    kv: torch.Tensor,      # [b, skv, d]
+    q: torch.Tensor,  # [b, s, h, d]
+    kv: torch.Tensor,  # [b, skv, d]
     attn_sink: torch.Tensor,  # [h]
     topk_idxs: torch.Tensor,  # [b, s, topk] int32
     softmax_scale: float,
@@ -211,8 +207,10 @@ def test_correctness(
 
     scale = 1.0 / math.sqrt(D_HEAD)
 
-    # TileLang forward
     kernel = sparse_attn_fwd(BATCH, H, N_CTX, N_KV, D_HEAD, TOPK, dtype=T_dtype)
+    print(kernel.get_kernel_source())
+
+    # TileLang forward
     O_tl = kernel(Q, KV, topk_idxs, attn_sink)
 
     # PyTorch reference

--- a/examples/deepseek_v4/sparse_attn_fwd_sm90.py
+++ b/examples/deepseek_v4/sparse_attn_fwd_sm90.py
@@ -1,0 +1,278 @@
+"""DSV4-style MQA Sparse Attention Kernel (BSHD layout).
+
+- Partial RoPE, instead of extra 64-dim RoPE
+- Support for attention sink
+- Designed for sm90
+
+NOTE: This impl is simply an illustration and maybe not optimal,
+or comparable to handwrite version
+"""
+
+#TODO(wt): Support window size
+
+
+import math
+import torch
+import tilelang
+from tilelang.profiler import do_bench
+import tilelang.language as T
+import argparse
+
+
+@tilelang.jit(
+    out_idx=[3],
+    pass_configs={
+        tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+    },
+)
+def sparse_attn_fwd(
+    batch,
+    heads,
+    seq_len,
+    seq_len_kv,
+    dim,
+    topk,
+    sm_scale=None,
+    block_N=64,
+    num_stages=2,
+    threads=256,
+    dtype: T.dtype = T.bfloat16,
+):
+    assert topk % block_N == 0, "topk must be divisible by block_N for now"
+
+    if sm_scale is None:
+        sm_scale = (1.0 / dim) ** 0.5
+    scale = sm_scale * 1.44269504  # log2(e)
+
+    q_shape = [batch, seq_len, heads, dim]
+    kv_shape = [batch, seq_len_kv, dim]
+    idx_shape = [batch, seq_len, topk]
+    o_shape = [batch, seq_len, heads, dim]
+    accum_dtype = T.float32
+
+    BI = block_N
+    NI = T.ceildiv(topk, BI)
+
+    if heads > 64:
+        assert heads % 64 == 0, "head_kv should be a multiple of 64"
+        REPLICATE_H = heads // 64
+    else:
+        REPLICATE_H = 1
+
+    H_per_block = 64
+
+    @T.prim_func
+    def main(
+        Q: T.Tensor(q_shape, dtype),
+        KV: T.Tensor(kv_shape, dtype),
+        TopkIndices: T.Tensor(idx_shape, T.int32),
+        Output: T.Tensor(o_shape, dtype),
+        Sinks: T.Tensor([heads], dtype),
+    ):
+        with T.Kernel(REPLICATE_H, seq_len, batch, threads=threads) as (h_block, seq_idx, by):
+            h_start = h_block * H_per_block
+
+            Q_shared = T.alloc_shared([H_per_block, dim], dtype)
+            KV_shared = T.alloc_shared([BI, dim], dtype)
+            S_shared = T.alloc_shared([H_per_block, BI], dtype)
+            Sinks_shared = T.alloc_shared([H_per_block], dtype)
+
+            acc_s = T.alloc_fragment([H_per_block, BI], accum_dtype)
+            acc_o = T.alloc_fragment([H_per_block, dim], accum_dtype)
+            acc_o_shared = T.alloc_shared([H_per_block, dim], dtype)
+            scores_max = T.alloc_fragment([H_per_block], accum_dtype)
+            scores_max_prev = T.alloc_fragment([H_per_block], accum_dtype)
+            scores_scale = T.alloc_fragment([H_per_block], accum_dtype)
+            scores_sum = T.alloc_fragment([H_per_block], accum_dtype)
+            logsum = T.alloc_fragment([H_per_block], accum_dtype)
+            mask = T.alloc_fragment([BI], T.bool)
+
+            T.copy(Q[by, seq_idx, h_start:h_start + H_per_block, :], Q_shared)
+            T.copy(Sinks[h_start:h_start + H_per_block], Sinks_shared)
+            T.fill(acc_o, 0)
+            T.fill(logsum, 0)
+            T.fill(scores_max, -(2**30))  # avoid -inf - inf to cause nan
+
+            for i_i in T.Pipelined(NI, num_stages=num_stages):
+                # Valid mask: skip padding indices (-1)
+                for bi_i in T.Parallel(BI):
+                    idx = TopkIndices[by, seq_idx, i_i * BI + bi_i]
+                    mask[bi_i] = idx >= 0
+
+                # Gather KV block using indices
+                for bi_i, d_i in T.Parallel(BI, dim):
+                    idx = TopkIndices[by, seq_idx, i_i * BI + bi_i]
+                    KV_shared[bi_i, d_i] = KV[by, idx, d_i]
+
+                # Initialize scores with mask
+                for h_i, bi_i in T.Parallel(H_per_block, BI):
+                    acc_s[h_i, bi_i] = T.if_then_else(
+                        mask[bi_i], 0, -T.infinity(acc_s.dtype)
+                    )
+
+                # QK^T GEMM: (H_per_block, dim) @ (dim, BI) -> (H_per_block, BI)
+                T.gemm(
+                    Q_shared, KV_shared, acc_s, transpose_B=True,
+                    policy=T.GemmWarpPolicy.FullRow,
+                )
+
+                # Online softmax with exp2
+                T.copy(scores_max, scores_max_prev)
+                T.reduce_max(acc_s, scores_max, dim=1, clear=False)
+                for h_i in T.Parallel(H_per_block):
+                    scores_max[h_i] = T.max(scores_max[h_i], scores_max_prev[h_i])
+                for h_i in T.Parallel(H_per_block):
+                    scores_scale[h_i] = T.exp2(
+                        scores_max_prev[h_i] * scale - scores_max[h_i] * scale
+                    )
+                for h_i, bi_i in T.Parallel(H_per_block, BI):
+                    acc_s[h_i, bi_i] = T.exp2(
+                        acc_s[h_i, bi_i] * scale - scores_max[h_i] * scale
+                    )
+                T.reduce_sum(acc_s, scores_sum, dim=1)
+
+                # Rescale acc_o by correction factor
+                for h_i, d_i in T.Parallel(H_per_block, dim):
+                    acc_o[h_i, d_i] *= scores_scale[h_i]
+
+                # Accumulate: P @ V
+                T.copy(acc_s, S_shared)
+                T.gemm(
+                    S_shared, KV_shared, acc_o,
+                    policy=T.GemmWarpPolicy.FullRow,
+                )
+
+                # Update logsum
+                for h_i in T.Parallel(H_per_block):
+                    logsum[h_i] = logsum[h_i] * scores_scale[h_i] + scores_sum[h_i]
+
+            # Attention sink (per-head)
+            for h_i in T.Parallel(H_per_block):
+                logsum[h_i] += T.exp2(
+                    Sinks_shared[h_i] * 1.44269504 - scores_max[h_i] * scale
+                )
+
+            # Normalize
+            for h_i, d_i in T.Parallel(H_per_block, dim):
+                acc_o[h_i, d_i] /= logsum[h_i]
+
+            # Store output
+            T.copy(acc_o, acc_o_shared)
+            T.copy(acc_o_shared, Output[by, seq_idx, h_start:h_start + H_per_block, :])
+
+    return main
+
+
+def torch_sparse_attention(
+    q: torch.Tensor,       # [b, s, h, d]
+    kv: torch.Tensor,      # [b, skv, d]
+    attn_sink: torch.Tensor,  # [h]
+    topk_idxs: torch.Tensor,  # [b, s, topk] int32
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Reference: gather KV by indices, compute attention with sink."""
+    batch, seq_len, heads, dim = q.shape
+    topk = topk_idxs.shape[-1]
+
+    # Expand KV to [b, s, skv, d] and gather by indices -> [b, s, topk, d]
+    kv_expanded = kv[:, None, :, :].expand(batch, seq_len, -1, dim)
+    idx_expanded = topk_idxs[:, :, :, None].expand(batch, seq_len, topk, dim).long()
+    gathered_kv = torch.gather(kv_expanded, 2, idx_expanded)
+
+    # Scores: [b, s, h, topk]
+    scores = torch.einsum("bmhd,bmtd->bmht", q.float(), gathered_kv.float()) * softmax_scale
+
+    # Concatenate sink and softmax
+    sink = attn_sink[None, None, :, None].expand(batch, seq_len, heads, 1)
+    attn = torch.softmax(torch.cat([scores, sink], dim=-1), dim=-1)
+
+    # Output: [b, s, h, d]
+    out = torch.einsum("bmht,bmtd->bmhd", attn[:, :, :, :-1], gathered_kv.float())
+    return out.to(q.dtype)
+
+
+def test_correctness(
+    BATCH: int = 1,
+    H: int = 8,
+    N_CTX: int = 512,
+    N_KV: int = 1024,
+    D_HEAD: int = 128,
+    TOPK: int = 256,
+    dtype_str: str = "bfloat16",
+):
+    T_dtype = T.dtype(dtype_str)
+    torch_dtype = T_dtype.as_torch()
+
+    torch.manual_seed(42)
+    Q = torch.randn(BATCH, N_CTX, H, D_HEAD, dtype=torch_dtype, device="cuda")
+    KV = torch.randn(BATCH, N_KV, D_HEAD, dtype=torch_dtype, device="cuda")
+    attn_sink = torch.randn(H, dtype=torch_dtype, device="cuda")
+    topk_idxs = torch.randint(0, N_KV, (BATCH, N_CTX, TOPK), dtype=torch.int32, device="cuda")
+
+    scale = 1.0 / math.sqrt(D_HEAD)
+
+    # TileLang forward
+    kernel = sparse_attn_fwd(BATCH, H, N_CTX, N_KV, D_HEAD, TOPK, dtype=T_dtype)
+    O_tl = kernel(Q, KV, topk_idxs, attn_sink)
+
+    # PyTorch reference
+    O_ref = torch_sparse_attention(Q, KV, attn_sink, topk_idxs, scale)
+
+    rtol, atol = 1e-2, 1e-2
+    max_err = (O_tl - O_ref).abs().max().item()
+    assert torch.allclose(O_tl, O_ref, rtol=rtol, atol=atol), f"O max err: {max_err}"
+    print(f"[{dtype_str}] Correctness OK, max error: {max_err:.6f}")
+
+
+def benchmark_fwd(
+    BATCH: int = 1,
+    H: int = 8,
+    N_CTX: int = 512,
+    N_KV: int = 1024,
+    D_HEAD: int = 128,
+    TOPK: int = 256,
+    dtype_str: str = "bfloat16",
+):
+    torch_dtype = {"float16": torch.float16, "bfloat16": torch.bfloat16}[dtype_str]
+
+    with torch.no_grad():
+        torch.manual_seed(42)
+        Q = torch.randn(BATCH, N_CTX, H, D_HEAD, dtype=torch_dtype, device="cuda")
+        KV = torch.randn(BATCH, N_KV, D_HEAD, dtype=torch_dtype, device="cuda")
+        attn_sink = torch.randn(H, dtype=torch_dtype, device="cuda")
+        topk_idxs = torch.randint(0, N_KV, (BATCH, N_CTX, TOPK), dtype=torch.int32, device="cuda")
+
+        kernel = sparse_attn_fwd(BATCH, H, N_CTX, N_KV, D_HEAD, TOPK, dtype=dtype_str)
+        latency_tl = do_bench(lambda: kernel(Q, KV, topk_idxs, attn_sink))
+
+        flops = 4.0 * BATCH * N_CTX * H * TOPK * D_HEAD
+        print(f"[{dtype_str}] B={BATCH}, S={N_CTX}, SKV={N_KV}, H={H}, D={D_HEAD}, TOPK={TOPK}")
+        print(f"  tilelang: {latency_tl:.3f} ms  ({flops / latency_tl * 1e-9:.2f} TFlops)")
+
+        return latency_tl
+
+
+def main(
+    BATCH: int = 1,
+    H: int = 8,
+    N_CTX: int = 1024,
+    N_KV: int = 1024,
+    D_HEAD: int = 64,
+    TOPK: int = 256,
+    dtype_str: str = "bfloat16",
+):
+    test_correctness(BATCH, H, N_CTX, N_KV, D_HEAD, TOPK, dtype_str)
+    benchmark_fwd(BATCH, H, N_CTX, N_KV, D_HEAD, TOPK, dtype_str)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch", type=int, default=1)
+    parser.add_argument("--h", type=int, default=128)
+    parser.add_argument("--n_ctx", type=int, default=4096)
+    parser.add_argument("--n_kv", type=int, default=8192)
+    parser.add_argument("--d_head", type=int, default=512)
+    parser.add_argument("--topk", type=int, default=1024)
+    parser.add_argument("--dtype", type=str, default="bfloat16")
+    args = parser.parse_args()
+    main(args.batch, args.h, args.n_ctx, args.n_kv, args.d_head, args.topk, args.dtype)

--- a/examples/deepseek_v4/test_tilelang_example_deepseek_v4.py
+++ b/examples/deepseek_v4/test_tilelang_example_deepseek_v4.py
@@ -1,0 +1,22 @@
+import tilelang.testing
+
+import act_quant
+import sparse_attn_fwd_sm90
+
+
+@tilelang.testing.requires_cuda
+def test_example_act_quant():
+    act_quant.test_fp8_act_quant(M=64, N=256, block_size=128)
+    act_quant.test_fp4_act_quant(M=64, N=256, block_size=32)
+    act_quant.test_round_trip_error()
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
+def test_example_sparse_attn_fwd_sm90():
+    sparse_attn_fwd_sm90.test_correctness()
+
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/examples/deepseek_v4/test_tilelang_example_deepseek_v4.py
+++ b/examples/deepseek_v4/test_tilelang_example_deepseek_v4.py
@@ -17,6 +17,5 @@ def test_example_sparse_attn_fwd_sm90():
     sparse_attn_fwd_sm90.test_correctness()
 
 
-
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a DSV4-style sparse attention example with PyTorch reference, correctness tests, benchmarking, and CLI.
  * Added block-wise activation quantization (FP8 and packed FP4) with reference implementations and round-trip tests.

* **Improvements**
  * Adjusted a sparse kernel's numeric configuration (fast math) and changed its output write path for improved numeric robustness.

* **Tests**
  * Added CUDA-gated example tests to run quantization and sparse-attention correctness checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->