### PR TITLE
[TMA] Fix TMA descriptor init placement

### DIFF
--- a/src/transform/lower_hopper_intrin.cc
+++ b/src/transform/lower_hopper_intrin.cc
@@ -10,6 +10,9 @@
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/tir/transform.h>
 
+#include <unordered_map>
+#include <vector>
+
 #include "../op/builtin.h"
 #include "../runtime/runtime.h"
 
@@ -25,33 +28,16 @@ public:
     PrimFuncNode *fptr = f.CopyOnWrite();
     LowerHopperIntrin substituter(disable_shuffle_elect);
     fptr->body = substituter.VisitStmt(f->body);
-    Map<Var, Array<PrimExpr>> init_desc_arg_map;
     // Collect prologue/epilogue statements for host-side setup/teardown
     Array<Stmt> prologue_stmts;
     Array<Stmt> epilogue_stmts;
-    for (const auto &[call, var] : substituter.desc_map_) {
-      // Should allocate 128 bytes for TensorMap on stack
-      Call alloc_desc = Call(DataType::Handle(), builtin::tvm_stack_alloca(),
-                             {StringImm("tvm_ffi_any"), 16});
-      Array<PrimExpr> init_desc_args;
-      if (call->op.same_as(create_tma_descriptor())) {
-        init_desc_args.push_back(StringImm(tvm_tensormap_create_tiled));
-      } else if (call->op.same_as(create_tma_im2col_descriptor())) {
-        init_desc_args.push_back(StringImm(tvm_tensormap_create_im2col));
-      } else {
-        CHECK(0) << call->op;
+    for (const auto &desc_init : substituter.desc_inits_) {
+      if (!desc_init.emitted) {
+        prologue_stmts.push_back(desc_init.stmt);
       }
-      init_desc_args.push_back(var);
-      init_desc_args.insert(init_desc_args.end(), call->args.begin(),
-                            call->args.end());
-      // add to function attribute
-      Call init_desc =
-          Call(DataType::Handle(), builtin::tvm_call_packed(), init_desc_args);
-      // Accumulate TMA descriptor init into prologue
-      prologue_stmts.push_back(LetStmt(var, alloc_desc, Evaluate(init_desc)));
-      init_desc_arg_map.Set(var, init_desc_args);
     }
-    f = WithAttr(std::move(f), "tma_descriptor_args", init_desc_arg_map);
+    f = WithAttr(std::move(f), "tma_descriptor_args",
+                 substituter.init_desc_arg_map_);
 
     // Additionally, if L2 persistent cache annotations were lowered earlier,
     // materialize TVM FFI calls to set the stream access policy window.
@@ -126,6 +112,31 @@ public:
     return f;
   }
 
+  Stmt VisitStmt_(const AllocateNode *op) final {
+    Stmt stmt = StmtExprMutator::VisitStmt_(op);
+    Array<Stmt> init_stmts;
+    for (auto &desc_init : desc_inits_) {
+      if (!desc_init.emitted && desc_init.base_var == op->buffer_var.get()) {
+        init_stmts.push_back(desc_init.stmt);
+        desc_init.emitted = true;
+      }
+    }
+    if (init_stmts.empty()) {
+      return stmt;
+    }
+
+    auto *alloc = stmt.as<AllocateNode>();
+    ICHECK(alloc != nullptr);
+    Array<Stmt> seq;
+    for (const auto &init_stmt : init_stmts) {
+      seq.push_back(init_stmt);
+    }
+    seq.push_back(alloc->body);
+    auto n = CopyOnWrite(alloc);
+    n->body = SeqStmt(seq);
+    return Stmt(n);
+  }
+
   Stmt VisitStmt_(const AttrStmtNode *op) final {
     if (op->attr_key == tir::attr::thread_extent) {
       IterVar iv = Downcast<IterVar>(op->node);
@@ -166,7 +177,12 @@ public:
         String name = call->args[2].as<Var>().value()->name_hint;
         var = Var(name + "_desc",
                   PointerType(PrimType(cuTensorMapType()), "grid_constant"));
-        desc_map_[tvm::ffi::GetRef<Call>(call)] = var;
+        Call call_ref = tvm::ffi::GetRef<Call>(call);
+        desc_map_[call_ref] = var;
+        Array<PrimExpr> init_desc_args = MakeInitDescArgs(call_ref, var);
+        init_desc_arg_map_.Set(var, init_desc_args);
+        desc_inits_.push_back({call->args[2].as<Var>().value().get(),
+                               MakeInitDescStmt(var, init_desc_args), false});
         prefetch_calls_.push_back(
             Evaluate(Call(DataType::Handle(), builtin::call_extern(),
                           {StringImm("tl::prefetch_tma_descriptor"), var})));
@@ -178,8 +194,41 @@ public:
   }
 
 private:
+  struct DescInit {
+    const VarNode *base_var;
+    Stmt stmt;
+    bool emitted;
+  };
+
+  static Array<PrimExpr> MakeInitDescArgs(const Call &call, const Var &var) {
+    Array<PrimExpr> init_desc_args;
+    if (call->op.same_as(create_tma_descriptor())) {
+      init_desc_args.push_back(StringImm(tvm_tensormap_create_tiled));
+    } else if (call->op.same_as(create_tma_im2col_descriptor())) {
+      init_desc_args.push_back(StringImm(tvm_tensormap_create_im2col));
+    } else {
+      CHECK(0) << call->op;
+    }
+    init_desc_args.push_back(var);
+    init_desc_args.insert(init_desc_args.end(), call->args.begin(),
+                          call->args.end());
+    return init_desc_args;
+  }
+
+  static Stmt MakeInitDescStmt(const Var &var,
+                               const Array<PrimExpr> &init_desc_args) {
+    // Should allocate 128 bytes for TensorMap on stack.
+    Call alloc_desc = Call(DataType::Handle(), builtin::tvm_stack_alloca(),
+                           {StringImm("tvm_ffi_any"), 16});
+    Call init_desc =
+        Call(DataType::Handle(), builtin::tvm_call_packed(), init_desc_args);
+    return LetStmt(var, alloc_desc, Evaluate(init_desc));
+  }
+
   Array<Stmt> prefetch_calls_;
   std::unordered_map<Call, Var, StructuralHash, ExprDeepEqual> desc_map_;
+  std::vector<DescInit> desc_inits_;
+  Map<Var, Array<PrimExpr>> init_desc_arg_map_;
   LowerHopperIntrin(bool disable_shuffle_elect)
       : disable_shuffle_elect_(disable_shuffle_elect) {}
   bool disable_shuffle_elect_;

--- a/testing/python/transform/test_tilelang_transform_lower_hopper_intrin.py
+++ b/testing/python/transform/test_tilelang_transform_lower_hopper_intrin.py
@@ -53,5 +53,50 @@ def test_lower_shared_barrier():
     assert "tvm_storage_sync" in body_text
 
 
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_tma_descriptor_init_after_alloc_global():
+    @T.prim_func
+    def before():
+        T.func_attr({"tir.is_entry_func": True, "tl.has_tma": T.bool(True)})
+        Output_partial = T.allocate([32], "float16", "global")
+        with T.launch_thread("threadIdx.x", 1):
+            T.evaluate(
+                T.create_tma_descriptor(
+                    6,
+                    4,
+                    Output_partial,
+                    8,
+                    2,
+                    2,
+                    1,
+                    2,
+                    16,
+                    32,
+                    64,
+                    8,
+                    1,
+                    2,
+                    1,
+                    1,
+                    1,
+                    1,
+                    1,
+                    0,
+                    0,
+                    2,
+                    0,
+                )
+            )
+
+    mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
+    mod = tvm.tir.transform.BindTarget(auto_target)(mod)
+    mod = tl.transform.LowerHopperIntrin()(mod)
+    func = mod["main"]
+
+    assert not tvm.tir.analysis.undefined_vars(func.body, func.params)
+    body_text = func.script()
+    assert body_text.index('T.allocate([32], "float16", "global")') < body_text.index('T.call_packed("__tvm_tensormap_create_tiled"')
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Summary
- Keep TMA descriptor initialization after the allocation that defines its base pointer when the descriptor targets an allocated workspace.
- Preserve the existing function-prologue initialization path for descriptors whose base pointer is not introduced by a local Allocate.
- Add a Hopper regression test that checks descriptor initialization no longer creates undefined variables for alloc_global-backed descriptors.

## Root Cause
LowerHopperIntrin previously hoisted every TMA descriptor initialization to the function prologue. When a descriptor referenced a workspace created by T.alloc_global, the hoisted call used the allocation variable before the Allocate statement defined it. MakePackedAPI later caught this malformed TIR as a use-before-definition error.

## Validation
- ./format.sh
- cmake --build build -j$(nproc)
- python -m pytest testing/python/transform/test_tilelang_transform_lower_hopper_intrin.py -x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for tensor memory access descriptor initialization in NVIDIA Hopper GPU operations, ensuring correct host-side setup and sequencing for tensor memory operations.

* **Tests**
  * Added test coverage for descriptor initialization workflows with global tensor allocations to validate proper initialization ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->