### PR TITLE
[docs] update tma description

### DIFF
--- a/docs/programming_guides/instructions.md
+++ b/docs/programming_guides/instructions.md
@@ -39,8 +39,7 @@ TileLang supports both synchronous and explicitly-asynchronous copies.
 
 `T.copy(src, dst, ...)` (synchronous semantics)
 - Intended default for most TileLang programs.
-- The compiler is free to lower it to different mechanisms (SIMT copy, `ldmatrix`,
-  TMA `cp.async.bulk`, `cp.async`, etc.) depending on target/hints, but the observable semantics
+- The compiler is free to lower it to different mechanisms (synchronous SIMT copy `ld.global`, warp-level copy `ldmatrix`, async copy via TMA `cp.async.bulk`, old async copy `cp.async`, etc.) depending on target/hints, but the observable semantics
   are *synchronous*: after the statement, it is safe to use `dst`.
 - If `T.copy` lowers to `cp.async`, TileLang will still preserve synchronous
   semantics by emitting the required `commit`/`wait` (and any required

--- a/docs/programming_guides/instructions.md
+++ b/docs/programming_guides/instructions.md
@@ -33,7 +33,7 @@ Semantics
 - Safety: the LegalizeSafeMemoryAccess pass inserts boundary guards when an
   access may be out‑of‑bounds and drops them when proven safe.
 
-### Lowering to `T.copy` to variants of copy machanisms
+### Lowering `T.copy` to variants of copy machanisms
 
 TileLang supports both synchronous and explicitly-asynchronous copies.
 

--- a/docs/programming_guides/instructions.md
+++ b/docs/programming_guides/instructions.md
@@ -39,7 +39,7 @@ TileLang supports both synchronous and explicitly-asynchronous copies.
 
 `T.copy(src, dst, ...)` (synchronous semantics)
 - Intended default for most TileLang programs.
-- The compiler is free to lower it to different mechanisms (synchronous SIMT copy `ld.global`, warp-level copy `ldmatrix`, async copy via TMA `cp.async.bulk`, old async copy `cp.async`, etc.) depending on target/hints, but the observable semantics
+- The compiler is free to lower it to different mechanisms (synchronous SIMT copy `ld.global`, warp-level copy     `ldmatrix`, async copy via TMA `cp.async.bulk`, old async copy `cp.async`, etc.) depending on target/hints, but the   observable semantics
   are *synchronous*: after the statement, it is safe to use `dst`.
 - If `T.copy` lowers to `cp.async`, TileLang will still preserve synchronous
   semantics by emitting the required `commit`/`wait` (and any required
@@ -144,6 +144,7 @@ signatures, behaviors, constraints, and examples, refer to API Reference
 Data movement
 - `T.copy(src, dst, ...)`: Move tiles between Global/Shared/Fragment.
 - `T.async_copy(src, dst, ...)`: Explicit async global→shared copy via `cp.async`.
+- `T.tma_copy(src, dst, ...)`: Explicit async global→shared copy via `cp.async.bulk`
 - `T.transpose(src, dst)`: Transpose a 2D shared buffer: `dst[j, i] = src[i, j]`.
 - `T.c2d_im2col(img, col, ...)`: 2D im2col transform for conv.
 

--- a/docs/programming_guides/instructions.md
+++ b/docs/programming_guides/instructions.md
@@ -33,7 +33,7 @@ Semantics
 - Safety: the LegalizeSafeMemoryAccess pass inserts boundary guards when an
   access may be out‑of‑bounds and drops them when proven safe.
 
-### Lowering `T.copy` to variants of copy machanisms
+### Lowering `T.copy` to variants of copy mechanisms
 
 TileLang supports both synchronous and explicitly-asynchronous copies.
 

--- a/docs/programming_guides/instructions.md
+++ b/docs/programming_guides/instructions.md
@@ -4,7 +4,7 @@ This page summarizes the core TileLang “instructions” available at the DSL
 level, how they map to hardware concepts, and how to use them correctly.
 
 ## Quick Categories
-- Data movement: `T.copy`, `T.async_copy`, `T.c2d_im2col`, staging Global ↔ Shared ↔ Fragment
+- Data movement: `T.copy`, `T.async_copy`, `T.tma_copy`, `T.c2d_im2col`, staging Global ↔ Shared ↔ Fragment
 - Compute primitives: `T.gemm`/`T.gemm_sp`, elementwise math (`T.exp`, `T.max`),
   reductions (`T.reduce_sum`, `T.cumsum`, warp reducers)
 - Control helpers: `T.clear`/`T.fill`, `T.reshape`/`T.view`
@@ -33,14 +33,14 @@ Semantics
 - Safety: the LegalizeSafeMemoryAccess pass inserts boundary guards when an
   access may be out‑of‑bounds and drops them when proven safe.
 
-### `T.copy` vs `T.async_copy`
+### Lowering to `T.copy` to variants of copy machanisms
 
 TileLang supports both synchronous and explicitly-asynchronous copies.
 
 `T.copy(src, dst, ...)` (synchronous semantics)
 - Intended default for most TileLang programs.
 - The compiler is free to lower it to different mechanisms (SIMT copy, `ldmatrix`,
-  TMA, `cp.async`, etc.) depending on target/hints, but the observable semantics
+  TMA `cp.async.bulk`, `cp.async`, etc.) depending on target/hints, but the observable semantics
   are *synchronous*: after the statement, it is safe to use `dst`.
 - If `T.copy` lowers to `cp.async`, TileLang will still preserve synchronous
   semantics by emitting the required `commit`/`wait` (and any required


### PR DESCRIPTION
See https://github.com/tile-ai/tilelang/issues/2150

and relevant PR related to tma:

- update tl.copy lowering backend https://github.com/tile-ai/tilelang/pull/2138, there [regression of performance](https://github.com/tile-ai/tilelang/pull/2138#issuecomment-4385442461)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added T.tma_copy to the data movement capabilities reference for easier discovery.
  * Reorganized and expanded guidance on lowering and copy mechanisms to cover additional targets, including cp.async.bulk variants.
  * Clarified observable semantics and behavioral differences for synchronous copy operations, with updated concise instruction reference entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->