### PR TITLE
[feat] Add Hexagon HMX backend support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,23 @@ set(TILELANG_HIP_INCLUDE_DIR "" CACHE PATH
     "Path to HIP headers when building with USE_ROCM=ON on a host without a ROCm runtime")
 # Configs end
 
+# --- LLVM Detection for Hexagon/CPU Backend ---
+if(NOT DEFINED USE_LLVM)
+  set(USE_LLVM OFF CACHE STRING "Build with LLVM support (required for Hexagon)")
+endif()
+
+if(USE_LLVM STREQUAL "ON")
+  find_program(LLVM_CONFIG_PATH NAMES llvm-config-18 llvm-config-17 llvm-config)
+  if(LLVM_CONFIG_PATH)
+    set(USE_LLVM ${LLVM_CONFIG_PATH} CACHE STRING "Path to llvm-config" FORCE)
+  else()
+    message(WARNING "USE_LLVM is ON but llvm-config was not found in PATH.")
+  endif()
+endif()
+
+set(_TILELANG_USE_LLVM_SAVED ${USE_LLVM})
+
+# Load TVM sources and base configs
 include(cmake/load_tvm.cmake)
 
 if(EXISTS ${TVM_SOURCE}/cmake/config.cmake)
@@ -338,6 +355,19 @@ if(EXISTS ${TVM_SOURCE}/cmake/config.cmake)
 else()
   message(FATAL_ERROR "Nor tvm provided or submodule checkout-ed.")
 endif()
+
+# Restore USE_LLVM — TVM's config.cmake may have reset it
+if(_TILELANG_USE_LLVM_SAVED AND NOT _TILELANG_USE_LLVM_SAVED STREQUAL "OFF")
+  set(USE_LLVM ${_TILELANG_USE_LLVM_SAVED} CACHE STRING "LLVM config path" FORCE)
+  message(STATUS "TileLang: restored USE_LLVM=${USE_LLVM}")
+endif()
+unset(_TILELANG_USE_LLVM_SAVED)
+
+if(USE_LLVM AND NOT USE_LLVM STREQUAL "OFF")
+  message(STATUS "TileLang Build with LLVM: ${USE_LLVM}")
+  add_definitions(-DTILELANG_HEXAGON_ENABLED)
+endif()
+
 # Re-apply TileLang's preferred backend settings after TVM's config may have
 # overridden the USE_* cache entries.
 foreach(BACKEND IN LISTS TILELANG_BACKENDS)
@@ -359,6 +389,11 @@ set(TILE_LANG_INCLUDES ${TVM_INCLUDES})
 # Add TileLang's own src/ to include path so cross-directory includes
 # can use paths relative to src/ (e.g. "target/utils.h", "op/builtin.h").
 list(INSERT TILE_LANG_INCLUDES 0 "${CMAKE_CURRENT_SOURCE_DIR}/src")
+
+# Include TVM 'src' directory to resolve "tvm/runtime/hexagon/hexagon_htp.h"
+list(APPEND TILE_LANG_INCLUDES
+  ${TVM_SOURCE}/src
+)
 
 # Collect source files
 file(GLOB TILE_LANG_SRCS
@@ -383,6 +418,7 @@ file(GLOB TILE_LANG_SRCS
 # Always include CPU-safe runtime helpers
 list(APPEND TILE_LANG_SRCS
   src/runtime/error_helpers.cc
+  src/runtime/hexagon_runtime.cc
 )
 
 # Track if the user explicitly selected a backend via cache options.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,11 +341,15 @@ if(USE_LLVM STREQUAL "ON")
   if(LLVM_CONFIG_PATH)
     set(USE_LLVM ${LLVM_CONFIG_PATH} CACHE STRING "Path to llvm-config" FORCE)
   else()
-    message(WARNING "USE_LLVM is ON but llvm-config was not found in PATH.")
+    message(FATAL_ERROR "USE_LLVM is ON but llvm-config was not found in PATH. "
+                        "Install LLVM (llvm-config must be on PATH) or set USE_LLVM=OFF.")
   endif()
 endif()
 
-set(_TILELANG_USE_LLVM_SAVED ${USE_LLVM})
+# Save user's USE_LLVM before TVM's config.cmake overwrites it.
+# TVM's config.cmake unconditionally sets USE_LLVM to OFF, so we
+# save the value here and restore it after the include.
+set(_TILELANG_USE_LLVM_SAVED "${USE_LLVM}")
 
 # Load TVM sources and base configs
 include(cmake/load_tvm.cmake)
@@ -356,16 +360,13 @@ else()
   message(FATAL_ERROR "Nor tvm provided or submodule checkout-ed.")
 endif()
 
-# Restore USE_LLVM — TVM's config.cmake may have reset it
-if(_TILELANG_USE_LLVM_SAVED AND NOT _TILELANG_USE_LLVM_SAVED STREQUAL "OFF")
-  set(USE_LLVM ${_TILELANG_USE_LLVM_SAVED} CACHE STRING "LLVM config path" FORCE)
-  message(STATUS "TileLang: restored USE_LLVM=${USE_LLVM}")
-endif()
+set(USE_LLVM "${_TILELANG_USE_LLVM_SAVED}" CACHE STRING "LLVM config path" FORCE)
+set(USE_LLVM "${_TILELANG_USE_LLVM_SAVED}")
+
 unset(_TILELANG_USE_LLVM_SAVED)
 
 if(USE_LLVM AND NOT USE_LLVM STREQUAL "OFF")
   message(STATUS "TileLang Build with LLVM: ${USE_LLVM}")
-  add_definitions(-DTILELANG_HEXAGON_ENABLED)
 endif()
 
 # Re-apply TileLang's preferred backend settings after TVM's config may have
@@ -390,9 +391,10 @@ set(TILE_LANG_INCLUDES ${TVM_INCLUDES})
 # can use paths relative to src/ (e.g. "target/utils.h", "op/builtin.h").
 list(INSERT TILE_LANG_INCLUDES 0 "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
-# Include TVM 'src' directory to resolve "tvm/runtime/hexagon/hexagon_htp.h"
+# Include TVM public 'include' and private 'src' directories using absolute paths
 list(APPEND TILE_LANG_INCLUDES
-  ${TVM_SOURCE}/src
+  "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tvm/include"
+  "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tvm/src"
 )
 
 # Collect source files

--- a/src/runtime/hexagon_runtime.cc
+++ b/src/runtime/hexagon_runtime.cc
@@ -1,0 +1,38 @@
+#include <tvm/ffi/function.h>
+#include <tvm/ffi/reflection/registry.h>
+
+#ifdef TILELANG_HEXAGON_ENABLED
+
+#include <runtime/hexagon/hexagon_htp.h>
+
+namespace tvm {
+namespace tilelang {
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+
+  refl::GlobalDef().def_packed(
+      "tilelang.hexagon.hmx_kernel_launch",
+      [](ffi::PackedArgs args, ffi::Any *rv) {
+        // args[0] is the kernel Function; remaining args are forwarded to it.
+        // AnyView supports .cast<T>() for type-safe extraction.
+        ffi::Function kernel = args[0].cast<ffi::Function>();
+
+        // PackedArgs(const AnyView* data, int32_t size) — slice past the first
+        // arg. args.data() returns const AnyView*, args.size() returns int32_t.
+        ffi::PackedArgs kernel_args(args.data() + 1, args.size() - 1);
+
+        // RAII: powers on HMX on construction, releases on scope exit.
+        tvm::runtime::hexagon::HexagonHtp htp;
+
+        kernel.CallPacked(kernel_args, rv);
+      });
+}
+
+} // namespace tilelang
+} // namespace tvm
+
+#else
+// Hexagon runtime support disabled.
+// Build with -DUSE_LLVM=ON to enable HMX kernel launch support.
+#endif // TILELANG_HEXAGON_ENABLED

--- a/src/transform/lower_hexagon_intrinsics.cc
+++ b/src/transform/lower_hexagon_intrinsics.cc
@@ -1,0 +1,99 @@
+#include <tvm/ffi/reflection/registry.h>
+#include <tvm/target/target_info.h>
+#include <tvm/tir/builtin.h>
+#include <tvm/tir/expr.h>
+#include <tvm/tir/op.h>
+#include <tvm/tir/stmt_functor.h>
+#include <tvm/tir/transform.h>
+
+namespace tvm {
+namespace tilelang {
+
+using namespace tir;
+using tvm::ffi::Array;
+
+class HexagonIntrinsicLowerer : public StmtExprMutator {
+public:
+  HexagonIntrinsicLowerer() {}
+
+  Stmt Run(Stmt stmt) { return this->VisitStmt(stmt); }
+
+  Stmt VisitStmt_(const EvaluateNode *op) override {
+    if (const CallNode *call = op->value.as<CallNode>()) {
+      if (call->op.same_as(builtin::call_extern())) {
+        if (const StringImmNode *func_name =
+                call->args[0].as<StringImmNode>()) {
+
+          // Lower HMX MMA placeholder
+          if (func_name->value == "hmx_mma_placeholder") {
+            Array<PrimExpr> new_args;
+            new_args.push_back(StringImm("HexKL_mma_i8acc32"));
+            new_args.push_back(
+                call->args[3]); // C_acc (accumulator — first arg to HexKL)
+            new_args.push_back(call->args[1]); // A_vtcm
+            new_args.push_back(call->args[2]); // B_vtcm
+            return Evaluate(
+                Call(DataType::Int(32), builtin::call_extern(), new_args));
+          }
+
+          // HexagonDmaCopy is not yet available in HexKL v73.
+          // to-do: LowerHexagonDMA pass.
+        }
+      }
+    }
+    return StmtExprMutator::VisitStmt_(op);
+  }
+};
+
+namespace transform {
+
+tvm::transform::Pass LowerHexagonIntrinsics() {
+  auto pass_func = [=](PrimFunc f, IRModule m,
+                       tvm::transform::PassContext ctx) {
+    auto *n = f.CopyOnWrite();
+    n->body = HexagonIntrinsicLowerer().Run(std::move(n->body));
+    return f;
+  };
+  return tvm::tir::transform::CreatePrimFuncPass(
+      pass_func, 0, "tilelang.transform.LowerHexagonIntrinsics", {});
+}
+
+// Memory scope descriptors
+// These are queried by TVM's storage analysis to understand capacity/alignment.
+// Fields confirmed from tvm/target/target_info.h:
+//   unit_bits     — addressable unit size in bits
+//   max_num_bits  — total memory capacity in bits
+//   max_simd_bits — widest SIMD operation in bits (HVX = 1024-bit)
+//   head_address  — base address PrimExpr (IntImm 0 = no fixed mapping)
+
+static MemoryInfo GetHmxAccMem() {
+  auto n = tvm::ffi::make_object<MemoryInfoNode>();
+  // HMX accumulator register file: 32×32 int32 = 32768 bits
+  n->unit_bits = 32;                // 32-bit int32 elements
+  n->max_num_bits = 32LL * 32 * 32; // 32768 bits total
+  n->max_simd_bits = 1024;          // HVX vector width
+  n->head_address = IntImm(DataType::Int(32), 0);
+  return MemoryInfo(n);
+}
+
+static MemoryInfo GetVtcmMem() {
+  auto n = tvm::ffi::make_object<MemoryInfoNode>();
+  // VTCM on Hexagon v73: 8 MB
+  n->unit_bits = 8;                        // byte-addressable
+  n->max_num_bits = 8LL * 1024 * 1024 * 8; // 8 MB in bits
+  n->max_simd_bits = 1024;                 // HVX vector width
+  n->head_address = IntImm(DataType::Int(32), 0);
+  return MemoryInfo(n);
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  refl::GlobalDef()
+      .def("tilelang.transform.LowerHexagonIntrinsics", LowerHexagonIntrinsics)
+      .def("tvm.info.mem.global.hmx.acc", GetHmxAccMem)
+      .def("tvm.info.mem.global.vtcm", GetVtcmMem);
+}
+
+} // namespace transform
+} // namespace tilelang
+} // namespace tvm

--- a/src/transform/lower_hexagon_intrinsics.cc
+++ b/src/transform/lower_hexagon_intrinsics.cc
@@ -1,15 +1,14 @@
 #include <tvm/ffi/reflection/registry.h>
-#include <tvm/target/target_info.h>
-#include <tvm/tir/builtin.h>
-#include <tvm/tir/expr.h>
-#include <tvm/tir/op.h>
-#include <tvm/tir/stmt_functor.h>
-#include <tvm/tir/transform.h>
+#include <tvm/tirx/builtin.h>
+#include <tvm/tirx/expr.h>
+#include <tvm/tirx/op.h>
+#include <tvm/tirx/stmt_functor.h>
+#include <tvm/tirx/transform.h>
 
 namespace tvm {
 namespace tilelang {
 
-using namespace tir;
+using namespace tirx;
 using tvm::ffi::Array;
 
 class HexagonIntrinsicLowerer : public StmtExprMutator {
@@ -54,44 +53,14 @@ tvm::transform::Pass LowerHexagonIntrinsics() {
     n->body = HexagonIntrinsicLowerer().Run(std::move(n->body));
     return f;
   };
-  return tvm::tir::transform::CreatePrimFuncPass(
+  return tvm::tirx::transform::CreatePrimFuncPass(
       pass_func, 0, "tilelang.transform.LowerHexagonIntrinsics", {});
-}
-
-// Memory scope descriptors
-// These are queried by TVM's storage analysis to understand capacity/alignment.
-// Fields confirmed from tvm/target/target_info.h:
-//   unit_bits     — addressable unit size in bits
-//   max_num_bits  — total memory capacity in bits
-//   max_simd_bits — widest SIMD operation in bits (HVX = 1024-bit)
-//   head_address  — base address PrimExpr (IntImm 0 = no fixed mapping)
-
-static MemoryInfo GetHmxAccMem() {
-  auto n = tvm::ffi::make_object<MemoryInfoNode>();
-  // HMX accumulator register file: 32×32 int32 = 32768 bits
-  n->unit_bits = 32;                // 32-bit int32 elements
-  n->max_num_bits = 32LL * 32 * 32; // 32768 bits total
-  n->max_simd_bits = 1024;          // HVX vector width
-  n->head_address = IntImm(DataType::Int(32), 0);
-  return MemoryInfo(n);
-}
-
-static MemoryInfo GetVtcmMem() {
-  auto n = tvm::ffi::make_object<MemoryInfoNode>();
-  // VTCM on Hexagon v73: 8 MB
-  n->unit_bits = 8;                        // byte-addressable
-  n->max_num_bits = 8LL * 1024 * 1024 * 8; // 8 MB in bits
-  n->max_simd_bits = 1024;                 // HVX vector width
-  n->head_address = IntImm(DataType::Int(32), 0);
-  return MemoryInfo(n);
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
-  refl::GlobalDef()
-      .def("tilelang.transform.LowerHexagonIntrinsics", LowerHexagonIntrinsics)
-      .def("tvm.info.mem.global.hmx.acc", GetHmxAccMem)
-      .def("tvm.info.mem.global.vtcm", GetVtcmMem);
+  refl::GlobalDef().def("tilelang.transform.LowerHexagonIntrinsics",
+                        LowerHexagonIntrinsics);
 }
 
 } // namespace transform

--- a/testing/python/hexagon/diagnose_hmx.py
+++ b/testing/python/hexagon/diagnose_hmx.py
@@ -24,7 +24,7 @@ def build_hmx_matmul(M, N, K):
     ):
         A_vtcm = T.alloc_fragment((M, K), "int8", scope="global.vtcm")
         B_vtcm = T.alloc_fragment((K, N), "int8", scope="global.vtcm")
-        C_acc  = T.alloc_fragment((M, N), "int32", scope="global.hmx.acc")
+        C_acc = T.alloc_fragment((M, N), "int32", scope="global.hmx.acc")
 
         for i, k in T.grid(M, K):
             A_vtcm[i, k] = A_host[i, k]
@@ -65,10 +65,10 @@ def test_000_environment():
 def test_001_ir_dump():
     """Dump the full kernel_source so we can see what was actually generated."""
     M, N, K = 32, 32, 32
-    func   = build_hmx_matmul(M, N, K)
+    func = build_hmx_matmul(M, N, K)
     target = tvm.target.Target("llvm -mtriple=hexagon -mcpu=hexagonv73")
     kernel = tl.compile(func, target=target)
-    ir     = kernel.kernel_source
+    ir = kernel.kernel_source
 
     print("\n")
     print("=" * 60)
@@ -79,49 +79,46 @@ def test_001_ir_dump():
 
     # Report which assertions would pass/fail without actually asserting
     checks = {
-        'target triple = "hexagon"'  : 'target triple',
-        "A_vtcm"                     : 'VTCM alloc A',
-        "B_vtcm"                     : 'VTCM alloc B',
-        "C_acc"                      : 'HMX accumulator',
-        "hmx_mma_placeholder"        : 'placeholder NOT lowered (bad)',
-        "HexKL_mma_i8acc32"          : 'HexKL intrinsic (good)',
-        "HexKL_mma_i8i32"            : 'HexKL alt spelling',
-        "call_extern"                : 'any call_extern',
-        "llvm.hexagon"               : 'LLVM hexagon intrinsic',
+        'target triple = "hexagon"': "target triple",
+        "A_vtcm": "VTCM alloc A",
+        "B_vtcm": "VTCM alloc B",
+        "C_acc": "HMX accumulator",
+        "hmx_mma_placeholder": "placeholder NOT lowered (bad)",
+        "HexKL_mma_i8acc32": "HexKL intrinsic (good)",
+        "HexKL_mma_i8i32": "HexKL alt spelling",
+        "call_extern": "any call_extern",
+        "llvm.hexagon": "LLVM hexagon intrinsic",
     }
 
     print("\nASSERTION PROBE RESULTS:")
-    all_good = True
     for needle, label in checks.items():
         found = needle in ir
         status = "✓ FOUND  " if found else "✗ MISSING"
         print(f"  {status}  [{label}]  '{needle}'")
-        if label == 'placeholder NOT lowered (bad)' and found:
-            all_good = False
-        if label in ('HexKL intrinsic (good)', 'HexKL alt spelling') and found:
-            pass  # at least one should be present
 
     print()
     # Only hard-assert on things we're sure about
-    assert 'target triple = "hexagon"' in ir, \
-        "Not even targeting Hexagon — target string is wrong or codegen didn't run"
+    assert 'target triple = "hexagon"' in ir, "Not even targeting Hexagon — target string is wrong or codegen didn't run"
 
 
-@pytest.mark.skipif(not has_hexagon_codegen(), reason="Hexagon LLVM not available")  
+@pytest.mark.skipif(not has_hexagon_codegen(), reason="Hexagon LLVM not available")
 def test_002_hmx_lowering_status():
     """Specifically check whether HMX intrinsics were lowered or are still placeholders."""
     M, N, K = 32, 32, 32
-    func   = build_hmx_matmul(M, N, K)
+    func = build_hmx_matmul(M, N, K)
     target = tvm.target.Target("llvm -mtriple=hexagon -mcpu=hexagonv73")
     kernel = tl.compile(func, target=target)
-    ir     = kernel.kernel_source
+    ir = kernel.kernel_source
 
     placeholder_present = "hmx_mma_placeholder" in ir
-    hexkl_present       = any(s in ir for s in [
-        "HexKL_mma_i8acc32",
-        "HexKL_mma_i8i32",
-        "HexKL_mma",
-    ])
+    hexkl_present = any(
+        s in ir
+        for s in [
+            "HexKL_mma_i8acc32",
+            "HexKL_mma_i8i32",
+            "HexKL_mma",
+        ]
+    )
     llvm_intrin_present = "llvm.hexagon" in ir
 
     print(f"\n  placeholder still in IR : {placeholder_present}")

--- a/testing/python/hexagon/diagnose_hmx.py
+++ b/testing/python/hexagon/diagnose_hmx.py
@@ -1,0 +1,144 @@
+import pytest
+from tilelang import tvm as tvm
+import tilelang as tl
+import tilelang.language as T
+from tilelang.intrinsics.hexagon import hmx
+
+
+def has_hexagon_codegen():
+    try:
+        if not tvm.runtime.enabled("llvm"):
+            return False
+        tvm.target.Target("llvm -mtriple=hexagon -mcpu=hexagonv73")
+        return True
+    except Exception:
+        return False
+
+
+def build_hmx_matmul(M, N, K):
+    @T.prim_func
+    def main(
+        A_host: T.Tensor((M, K), "int8"),
+        B_host: T.Tensor((K, N), "int8"),
+        C_host: T.Tensor((M, N), "int32"),
+    ):
+        A_vtcm = T.alloc_fragment((M, K), "int8", scope="global.vtcm")
+        B_vtcm = T.alloc_fragment((K, N), "int8", scope="global.vtcm")
+        C_acc  = T.alloc_fragment((M, N), "int32", scope="global.hmx.acc")
+
+        for i, k in T.grid(M, K):
+            A_vtcm[i, k] = A_host[i, k]
+        for k, j in T.grid(K, N):
+            B_vtcm[k, j] = B_host[k, j]
+        for i, j in T.grid(M, N):
+            C_acc[i, j] = T.cast(0, "int32")
+
+        hmx.mma(A_vtcm, B_vtcm, C_acc)
+
+        for i, j in T.grid(M, N):
+            C_host[i, j] = C_acc[i, j]
+
+    return main
+
+
+# Diagnostics (always run, no skipif)
+def test_000_environment():
+    """Report the full environment so we know exactly what we're working with."""
+    print("\n")
+    print("=" * 60)
+    print("ENVIRONMENT REPORT")
+    print("=" * 60)
+    print(f"  tvm.__file__         : {tvm.__file__}")
+    print(f"  tvm.__version__      : {tvm.__version__}")
+    print(f"  llvm enabled         : {tvm.runtime.enabled('llvm')}")
+    print(f"  has_hexagon_codegen(): {has_hexagon_codegen()}")
+
+    try:
+        t = tvm.target.Target("llvm -mtriple=hexagon -mcpu=hexagonv73")
+        print(f"  hexagon target       : OK → {t}")
+    except Exception as e:
+        print(f"  hexagon target       : FAILED → {e}")
+    print("=" * 60)
+
+
+@pytest.mark.skipif(not has_hexagon_codegen(), reason="Hexagon LLVM not available")
+def test_001_ir_dump():
+    """Dump the full kernel_source so we can see what was actually generated."""
+    M, N, K = 32, 32, 32
+    func   = build_hmx_matmul(M, N, K)
+    target = tvm.target.Target("llvm -mtriple=hexagon -mcpu=hexagonv73")
+    kernel = tl.compile(func, target=target)
+    ir     = kernel.kernel_source
+
+    print("\n")
+    print("=" * 60)
+    print("FULL KERNEL SOURCE")
+    print("=" * 60)
+    print(ir)
+    print("=" * 60)
+
+    # Report which assertions would pass/fail without actually asserting
+    checks = {
+        'target triple = "hexagon"'  : 'target triple',
+        "A_vtcm"                     : 'VTCM alloc A',
+        "B_vtcm"                     : 'VTCM alloc B',
+        "C_acc"                      : 'HMX accumulator',
+        "hmx_mma_placeholder"        : 'placeholder NOT lowered (bad)',
+        "HexKL_mma_i8acc32"          : 'HexKL intrinsic (good)',
+        "HexKL_mma_i8i32"            : 'HexKL alt spelling',
+        "call_extern"                : 'any call_extern',
+        "llvm.hexagon"               : 'LLVM hexagon intrinsic',
+    }
+
+    print("\nASSERTION PROBE RESULTS:")
+    all_good = True
+    for needle, label in checks.items():
+        found = needle in ir
+        status = "✓ FOUND  " if found else "✗ MISSING"
+        print(f"  {status}  [{label}]  '{needle}'")
+        if label == 'placeholder NOT lowered (bad)' and found:
+            all_good = False
+        if label in ('HexKL intrinsic (good)', 'HexKL alt spelling') and found:
+            pass  # at least one should be present
+
+    print()
+    # Only hard-assert on things we're sure about
+    assert 'target triple = "hexagon"' in ir, \
+        "Not even targeting Hexagon — target string is wrong or codegen didn't run"
+
+
+@pytest.mark.skipif(not has_hexagon_codegen(), reason="Hexagon LLVM not available")  
+def test_002_hmx_lowering_status():
+    """Specifically check whether HMX intrinsics were lowered or are still placeholders."""
+    M, N, K = 32, 32, 32
+    func   = build_hmx_matmul(M, N, K)
+    target = tvm.target.Target("llvm -mtriple=hexagon -mcpu=hexagonv73")
+    kernel = tl.compile(func, target=target)
+    ir     = kernel.kernel_source
+
+    placeholder_present = "hmx_mma_placeholder" in ir
+    hexkl_present       = any(s in ir for s in [
+        "HexKL_mma_i8acc32",
+        "HexKL_mma_i8i32",
+        "HexKL_mma",
+    ])
+    llvm_intrin_present = "llvm.hexagon" in ir
+
+    print(f"\n  placeholder still in IR : {placeholder_present}")
+    print(f"  HexKL intrinsic in IR   : {hexkl_present}")
+    print(f"  llvm.hexagon in IR      : {llvm_intrin_present}")
+
+    if placeholder_present:
+        pytest.fail(
+            "hmx_mma_placeholder was NOT lowered.\n"
+            "_lower_hexagon_intrinsics is not wired into the compile pipeline.\n"
+            "Check lower() in tilelang/engine/lower.py"
+        )
+    elif not hexkl_present and not llvm_intrin_present:
+        pytest.fail(
+            "HMX placeholder is gone but no HexKL/llvm.hexagon intrinsic was emitted.\n"
+            "The lowering pass may be silently dropping the MMA op.\n"
+            "Check LowerHMXIntrinsics implementation."
+        )
+    else:
+        print("  ✓ HMX intrinsics correctly lowered")

--- a/testing/python/hexagon/diagnose_hmx.py
+++ b/testing/python/hexagon/diagnose_hmx.py
@@ -9,7 +9,7 @@ def has_hexagon_codegen():
     try:
         if not tvm.runtime.enabled("llvm"):
             return False
-        tvm.target.Target("llvm -mtriple=hexagon -mcpu=hexagonv73")
+        tvm.target.Target({"kind": "llvm", "mtriple": "hexagon", "mcpu": "hexagonv73"})
         return True
     except Exception:
         return False
@@ -54,7 +54,7 @@ def test_000_environment():
     print(f"  has_hexagon_codegen(): {has_hexagon_codegen()}")
 
     try:
-        t = tvm.target.Target("llvm -mtriple=hexagon -mcpu=hexagonv73")
+        t = tvm.target.Target({"kind": "llvm", "mtriple": "hexagon", "mcpu": "hexagonv73"})
         print(f"  hexagon target       : OK → {t}")
     except Exception as e:
         print(f"  hexagon target       : FAILED → {e}")
@@ -66,7 +66,7 @@ def test_001_ir_dump():
     """Dump the full kernel_source so we can see what was actually generated."""
     M, N, K = 32, 32, 32
     func = build_hmx_matmul(M, N, K)
-    target = tvm.target.Target("llvm -mtriple=hexagon -mcpu=hexagonv73")
+    target = tvm.target.Target({"kind": "llvm", "mtriple": "hexagon", "mcpu": "hexagonv73"})
     kernel = tl.compile(func, target=target)
     ir = kernel.kernel_source
 
@@ -106,7 +106,7 @@ def test_002_hmx_lowering_status():
     """Specifically check whether HMX intrinsics were lowered or are still placeholders."""
     M, N, K = 32, 32, 32
     func = build_hmx_matmul(M, N, K)
-    target = tvm.target.Target("llvm -mtriple=hexagon -mcpu=hexagonv73")
+    target = tvm.target.Target({"kind": "llvm", "mtriple": "hexagon", "mcpu": "hexagonv73"})
     kernel = tl.compile(func, target=target)
     ir = kernel.kernel_source
 

--- a/testing/python/hexagon/test_hmx_mma.py
+++ b/testing/python/hexagon/test_hmx_mma.py
@@ -1,0 +1,100 @@
+"""Test for Hexagon HMX MMA compilation and lowering."""
+
+import pytest
+import tilelang as tl
+import tilelang.language as T
+import tilelang.testing
+from tilelang.intrinsics.hexagon import hmx
+from tilelang import tvm as tvm
+
+# Shapes to test: (M, N, K)
+# HMX v73 typically supports 32x32 tiles for int8 (32768 bits).
+TEST_SHAPES = [
+    (32, 32, 32),
+    # (64, 64, 32),
+    # to-do
+]
+
+
+def has_hexagon_codegen():
+    """Check if LLVM and Hexagon are available in the current TVM build."""
+    try:
+        if not tvm.runtime.enabled("llvm"):
+            return False
+        # Try to construct a Hexagon target object
+        tvm.target.Target("llvm -mtriple=hexagon -mcpu=hexagonv73")
+        return True
+    except Exception:
+        return False
+
+
+def build_hmx_matmul(M, N, K):
+    """Kernel factory for HMX Matmul."""
+
+    @T.prim_func
+    def main(
+        A_host: T.Tensor((M, K), "int8"),
+        B_host: T.Tensor((K, N), "int8"),
+        C_host: T.Tensor((M, N), "int32"),
+    ):
+        # Allocation in Hexagon Specific Scopes
+        A_vtcm = T.alloc_fragment((M, K), "int8", scope="global.vtcm")
+        B_vtcm = T.alloc_fragment((K, N), "int8", scope="global.vtcm")
+        C_acc = T.alloc_fragment((M, N), "int32", scope="global.hmx.acc")
+
+        # DDR -> VTCM
+        for i, k in T.grid(M, K):
+            A_vtcm[i, k] = A_host[i, k]
+        for k, j in T.grid(K, N):
+            B_vtcm[k, j] = B_host[k, j]
+
+        # Init Accumulator
+        for i, j in T.grid(M, N):
+            C_acc[i, j] = T.cast(0, "int32")
+
+        # Hardware MMA Intrinsic
+        hmx.mma(A_vtcm, B_vtcm, C_acc)
+
+        # HMX.acc -> DDR
+        for i, j in T.grid(M, N):
+            C_host[i, j] = C_acc[i, j]
+
+    return main
+
+
+@pytest.mark.skipif(not has_hexagon_codegen(), reason="Hexagon LLVM backend not available")
+@pytest.mark.parametrize("M, N, K", TEST_SHAPES, ids=[f"shape={m}x{n}x{k}" for m, n, k in TEST_SHAPES])
+def test_hmx_mma_compilation(M, N, K):
+    """Verify that HMX MMA kernels lower to the correct Hexagon hardware intrinsics."""
+    func = build_hmx_matmul(M, N, K)
+    target = tvm.target.Target("llvm -mtriple=hexagon -mcpu=hexagonv73")
+
+    # Compile the kernel
+    kernel = tl.compile(func, target=target)
+
+    # Validation Logic
+    ir = kernel.kernel_source
+
+    # Automated IR Checks
+    assert 'target triple = "hexagon"' in ir, "Missing Hexagon target triple in IR"
+    assert "A_vtcm" in ir, "VTCM allocation (A_vtcm) not found in IR"
+    assert "C_acc" in ir, "Accumulator allocation (C_acc) not found in IR"
+    assert "HexKL_mma_i8acc32" in ir, "Hexagon HMX hardware intrinsic call not found in IR"
+    assert "hmx_mma_placeholder" not in ir, "HMX placeholder was not lowered"
+
+
+@pytest.mark.skipif(not has_hexagon_codegen(), reason="Hexagon LLVM backend not available")
+def test_hmx_host_execution_guard():
+    """Verify that attempting to run Hexagon code on host raises a clear error."""
+    func = build_hmx_matmul(32, 32, 32)
+    target = tvm.target.Target("llvm -mtriple=hexagon -mcpu=hexagonv73")
+
+    kernel = tl.compile(func, target=target)
+
+    # This should raise the RuntimeError from base.py
+    with pytest.raises(RuntimeError, match="Hexagon kernels cannot be executed directly on the host"):
+        kernel(None, None, None)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/hexagon/test_hmx_mma.py
+++ b/testing/python/hexagon/test_hmx_mma.py
@@ -22,7 +22,7 @@ def has_hexagon_codegen():
         if not tvm.runtime.enabled("llvm"):
             return False
         # Try to construct a Hexagon target object
-        tvm.target.Target("llvm -mtriple=hexagon -mcpu=hexagonv73")
+        tvm.target.Target({"kind": "llvm", "mtriple": "hexagon", "mcpu": "hexagonv73"})
         return True
     except Exception:
         return False
@@ -67,7 +67,7 @@ def build_hmx_matmul(M, N, K):
 def test_hmx_mma_compilation(M, N, K):
     """Verify that HMX MMA kernels lower to the correct Hexagon hardware intrinsics."""
     func = build_hmx_matmul(M, N, K)
-    target = tvm.target.Target("llvm -mtriple=hexagon -mcpu=hexagonv73")
+    target = tvm.target.Target({"kind": "llvm", "mtriple": "hexagon", "mcpu": "hexagonv73"})
 
     # Compile the kernel
     kernel = tl.compile(func, target=target)
@@ -87,7 +87,7 @@ def test_hmx_mma_compilation(M, N, K):
 def test_hmx_host_execution_guard():
     """Verify that attempting to run Hexagon code on host raises a clear error."""
     func = build_hmx_matmul(32, 32, 32)
-    target = tvm.target.Target("llvm -mtriple=hexagon -mcpu=hexagonv73")
+    target = tvm.target.Target({"kind": "llvm", "mtriple": "hexagon", "mcpu": "hexagonv73"})
 
     kernel = tl.compile(func, target=target)
 

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -472,7 +472,10 @@ class KernelCache:
                 self.logger.debug(f"Saving kernel parameters to disk: {params_path}")
             KernelCache._safe_write_file(params_path, "wb", lambda file: cloudpickle.dump(kernel.params, file))
 
+            _is_ir_only = getattr(kernel.adapter, "libpath", None) is None
             missing_files = self._get_missing_complete_cache_files(staging_path)
+            if _is_ir_only:
+                missing_files = [f for f in missing_files if not f.endswith(self.kernel_lib_path)]
             if missing_files:
                 missing_names = ", ".join(os.path.basename(path) for path in missing_files)
                 raise RuntimeError(f"Incomplete cache staging directory is missing required file(s): {missing_names}")
@@ -590,6 +593,10 @@ class KernelCache:
     def _save_so_cubin_to_disk(self, kernel: JITKernel, cache_path: str, verbose: bool = False):
         kernel_lib_path = os.path.join(cache_path, self.kernel_lib_path)
         src_lib_path = kernel.adapter.libpath
+        if src_lib_path is None:
+            # Hexagon and other IR-only targets have no .so — skip binary cache
+            self.logger.debug("Skipping binary cache save: adapter.libpath is None (IR-only target)")
+            return
         if verbose:
             self.logger.debug(f"Saving kernel library to file: {kernel_lib_path}")
         KernelCache._safe_write_file(kernel_lib_path, "wb", lambda file: file.write(KernelCache._load_binary(src_lib_path)))

--- a/tilelang/carver/arch/__init__.py
+++ b/tilelang/carver/arch/__init__.py
@@ -56,6 +56,7 @@ __all__ = [
     "is_cdna_arch",
     "is_rdna_arch",
     "is_metal_arch",
+    "is_hexagon_target",
     "CUDA",
     "CDNA",
     "RDNA",

--- a/tilelang/carver/arch/hexagon.py
+++ b/tilelang/carver/arch/hexagon.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from tvm.target import Target
+from .arch_base import TileDevice
+from tilelang.utils.target import is_hexagon_target
+
+
+class HexagonMemoryScope:
+    """String constants for Hexagon-specific TVM memory scopes."""
+
+    DDR = "global"  # off-chip DRAM (host-side tensors)
+    VTCM = "global.vtcm"  # on-chip Versatile TCM  (~8 MB on v68+)
+    LOCAL_VTCM = "local.vtcm"  # VTCM viewed as thread-local scratch
+    HMX_ACC = "global.hmx.acc"  # HMX accumulator register file
+    L2_CACHE = "global.l2cache"  # L2 cache hint scope (informational)
+
+
+@dataclass
+class HMXTileShape:
+    """Describes one legal HMX MMA tile configuration."""
+
+    M: int  # output rows
+    N: int  # output cols
+    K: int  # reduction dimension
+    a_dtype: str  # input A element type  (e.g. "int8", "uint8", "float16")
+    b_dtype: str  # input B element type
+    c_dtype: str  # accumulator type       (e.g. "int32", "float32")
+
+
+# HMX shapes available on Hexagon v73+ (from Qualcomm HKL documentation)
+HMX_TILE_SHAPES: list[HMXTileShape] = [
+    # Int8 × Int8 → Int32
+    HMXTileShape(M=8, N=32, K=32, a_dtype="int8", b_dtype="int8", c_dtype="int32"),
+    HMXTileShape(M=16, N=32, K=32, a_dtype="int8", b_dtype="int8", c_dtype="int32"),
+    HMXTileShape(M=32, N=32, K=32, a_dtype="int8", b_dtype="int8", c_dtype="int32"),
+    # UInt8 × Int8 → Int32  (asymmetric quantisation)
+    HMXTileShape(M=8, N=32, K=32, a_dtype="uint8", b_dtype="int8", c_dtype="int32"),
+    HMXTileShape(M=32, N=32, K=32, a_dtype="uint8", b_dtype="int8", c_dtype="int32"),
+    # Float16 × Float16 → Float32  (v75+ HMX-FP)
+    HMXTileShape(M=16, N=16, K=16, a_dtype="float16", b_dtype="float16", c_dtype="float32"),
+    HMXTileShape(M=32, N=16, K=16, a_dtype="float16", b_dtype="float16", c_dtype="float32"),
+]
+
+
+@dataclass
+class HexagonArch(TileDevice):
+    """
+    Architecture descriptor for Qualcomm Hexagon DSPs with HMX support.
+
+    Attributes
+    ----------
+    target : tvm.target.Target
+        The TVM target object (must satisfy is_hexagon_target()).
+    cpu_version : str
+        Hexagon CPU version string, e.g. "hexagonv73", "hexagonv75".
+    hvx_vector_bytes : int
+        HVX vector width in bytes (128 on v66+).
+    vtcm_size_bytes : int
+        Total VTCM capacity in bytes (default 8 MB for v73).
+    hmx_acc_bits : int
+        Total HMX accumulator register file size in bits.
+    hmx_tile_shapes : list[HMXTileShape]
+        Supported HMX MMA tile configurations.
+    """
+
+    target: Target
+    cpu_version: str = "hexagonv73"
+    hvx_vector_bytes: int = 128  # 1024-bit HVX vectors
+    vtcm_size_bytes: int = 8 * 1024 * 1024  # 8 MB default
+    hmx_acc_bits: int = 32 * 32 * 32  # conservative accumulator file
+    hmx_tile_shapes: list[HMXTileShape] = field(default_factory=lambda: HMX_TILE_SHAPES)
+
+    @property
+    def arch(self) -> HexagonArch:  # self IS the arch
+        return self
+
+    @property
+    def device_name(self) -> str:
+        return f"hexagon-{self.cpu_version}"
+
+    @property
+    def sm_count(self) -> int:
+        # Hexagon has no SMs; return 1 so any code that queries this still works.
+        return 1
+
+    @property
+    def max_threads_per_block(self) -> int:
+        # HVX operates as SIMD over 1 HVX thread; expose 1 "thread"
+        return 1
+
+    @property
+    def max_shared_memory_per_block(self) -> int:
+        return self.vtcm_size_bytes
+
+    def get_hmx_tile(
+        self,
+        M: int,
+        N: int,
+        K: int,
+        a_dtype: str = "int8",
+        b_dtype: str = "int8",
+        c_dtype: str = "int32",
+    ) -> HMXTileShape | None:
+        """
+        Return the matching HMXTileShape or None if not natively supported.
+
+        Note: shapes like (64, 64, 32) are NOT native HMX tiles. The caller
+        is responsible for tiling into (32, 32, 32) blocks before calling hmx.mma().
+        Returns None for any M or N > 32 on int8.
+        """
+        for ts in self.hmx_tile_shapes:
+            if ts.M == M and ts.N == N and ts.K == K and ts.a_dtype == a_dtype and ts.b_dtype == b_dtype and ts.c_dtype == c_dtype:
+                return ts
+        return None
+
+    def supports_hmx_fp(self) -> bool:
+        """True when the target includes FP16 HMX (v75+)."""
+        return "v75" in self.cpu_version or "v79" in self.cpu_version
+
+
+def get_hexagon_arch(target: Target) -> HexagonArch:
+    """
+    Construct a HexagonArch from a TVM Target.
+
+    Raises
+    ------
+    ValueError
+        If *target* is not a Hexagon target.
+    """
+    if not is_hexagon_target(target):
+        raise ValueError(f"Expected a Hexagon target, got: {target}. Use e.g. tvm.target.Target('llvm -mtriple=hexagon -mcpu=hexagonv73')")
+
+    attrs = target.attrs if hasattr(target, "attrs") else {}
+    mcpu = str(attrs.get("mcpu", "hexagonv73")).lower()
+
+    # Derive VTCM size heuristic from version
+    vtcm = 8 * 1024 * 1024  # 8 MB baseline (v68/v69/v73)
+    if "v75" in mcpu or "v79" in mcpu:
+        vtcm = 16 * 1024 * 1024  # 16 MB on newer parts
+
+    return HexagonArch(
+        target=target,
+        cpu_version=mcpu,
+        vtcm_size_bytes=vtcm,
+    )

--- a/tilelang/carver/arch/hexagon.py
+++ b/tilelang/carver/arch/hexagon.py
@@ -129,7 +129,10 @@ def get_hexagon_arch(target: Target) -> HexagonArch:
         If *target* is not a Hexagon target.
     """
     if not is_hexagon_target(target):
-        raise ValueError(f"Expected a Hexagon target, got: {target}. Use e.g. tvm.target.Target('llvm -mtriple=hexagon -mcpu=hexagonv73')")
+        raise ValueError(
+            f"Expected a Hexagon target, got: {target}. "
+            'Use e.g. tvm.target.Target({"kind": "llvm", "mtriple": "hexagon", "mcpu": "hexagonv73"})'
+        )
 
     attrs = target.attrs if hasattr(target, "attrs") else {}
     mcpu = str(attrs.get("mcpu", "hexagonv73")).lower()

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -21,6 +21,7 @@ from tilelang.engine.phase import (
     LowerAndLegalize,
     OptimizeForTarget,
 )
+from tilelang.utils.target import is_hexagon_target
 
 
 def is_cpu_device_backend(target: Target):
@@ -248,9 +249,19 @@ def device_codegen(device_mod: tvm.IRModule, target: Target) -> tvm.IRModule:
 
 
 def device_codegen_without_compile(device_mod: tvm.IRModule, target: Target) -> tvm.IRModule:
+    _is_hex = is_hexagon_target(target)
+
     device_mod = tilelang.transform.LowerIntrin()(device_mod)
     device_mod = tirx.transform.Simplify()(device_mod)
-    device_mod = tilelang.transform.HoistBroadcastValues()(device_mod)
+
+    if not _is_hex:
+        device_mod = tilelang.transform.HoistBroadcastValues()(device_mod)
+
+    if _is_hex:
+        # Use SkipAssert (plural) and LowerTVMBuiltin to clean the IR for LLVM
+        device_mod = tvm.tir.transform.SkipAssert()(device_mod)
+        device_mod = tvm.tir.transform.LowerTVMBuiltin()(device_mod)
+        device_mod = tvm.tir.transform.Simplify()(device_mod)
 
     if target.kind.name == "cuda":
         global_func = "target.build.tilelang_" + ("cutedsl" if "cutedsl" in target.keys else "cuda") + "_without_compile"
@@ -279,6 +290,11 @@ def lower_to_host_device_ir(
 ) -> tuple[tvm.IRModule, tvm.IRModule, list[KernelParam] | None, Target, Target]:
     """Lower input TIR to split host/device IRModules without backend codegen."""
 
+    if isinstance(target, str):
+        target = determine_target(target)
+
+    _is_hex = is_hexagon_target(target)
+
     mod = func_or_mod
     params = None
     if isinstance(func_or_mod, tirx.PrimFunc):
@@ -300,14 +316,20 @@ def lower_to_host_device_ir(
     # Before lowering, do semantic check
     PreLowerSemanticCheck(mod)
 
-    # Phase 1: Lower and legalize the IR
-    mod = LowerAndLegalize(mod, target)
+    with target:
+        # Phase 1: Lower and legalize the IR
+        mod = LowerAndLegalize(mod, target)
 
-    # Phase 2: Optimize the IR for the target
-    mod = OptimizeForTarget(mod, target)
+        # Phase 2: Optimize the IR for the target
+        mod = OptimizeForTarget(mod, target)
 
     host_mod = tirx.transform.Filter(_is_host_call)(mod)
     device_mod = tirx.transform.Filter(_is_device_call)(mod)
+
+    if _is_hex and len(device_mod.functions) == 0:
+        # In LLVM/Hexagon, functions aren't always tagged as 'device_kernel'
+        # so treat the whole module as the device module.
+        device_mod = mod
 
     return host_mod, device_mod, params, target, target_host
 
@@ -335,6 +357,7 @@ def lower(
     )
 
     codegen_mod = device_codegen(device_mod, target) if enable_device_compile else device_codegen_without_compile(device_mod, target)
+
     kernel_source = codegen_mod.inspect_source()
 
     if enable_host_codegen:
@@ -343,3 +366,32 @@ def lower(
         return CompiledArtifact(host_mod, device_mod, params, kernel_source, rt_mod=host_mod)
 
     return CompiledArtifact(host_mod, device_mod, params, kernel_source)
+
+
+def _lower_hexagon_intrinsics(mod: tvm.IRModule) -> tvm.IRModule:
+    _lower_hmx = tvm.get_global_func(
+        "tilelang.hexagon.transform.LowerHMXIntrinsics",  # one consistent name
+        allow_missing=True,
+    )
+
+    if _lower_hmx is None:
+        import warnings
+
+        warnings.warn(
+            "tilelang.hexagon.transform.LowerHMXIntrinsics not found. "
+            "hmx_mma_placeholder calls will NOT be lowered. "
+            "Did you build with TILELANG_HEXAGON_ENABLED?",
+            stacklevel=3,
+        )
+        return mod
+
+    # Apply per-function; no ApplyPassToFunction API exists in TVM
+    new_funcs = {}
+    for gv, func in mod.functions.items():
+        name = gv.name_hint
+        if name.endswith("_kernel") or name.endswith("_device"):
+            new_funcs[gv] = _lower_hmx(func)
+        else:
+            new_funcs[gv] = func
+
+    return tvm.IRModule(new_funcs)

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -259,9 +259,9 @@ def device_codegen_without_compile(device_mod: tvm.IRModule, target: Target) -> 
 
     if _is_hex:
         # Use SkipAssert (plural) and LowerTVMBuiltin to clean the IR for LLVM
-        device_mod = tvm.tir.transform.SkipAssert()(device_mod)
-        device_mod = tvm.tir.transform.LowerTVMBuiltin()(device_mod)
-        device_mod = tvm.tir.transform.Simplify()(device_mod)
+        device_mod = tvm.tirx.transform.SkipAssert()(device_mod)
+        device_mod = tvm.tirx.transform.LowerTVMBuiltin()(device_mod)
+        device_mod = tvm.tirx.transform.Simplify()(device_mod)
 
     if target.kind.name == "cuda":
         global_func = "target.build.tilelang_" + ("cutedsl" if "cutedsl" in target.keys else "cuda") + "_without_compile"

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -4,6 +4,7 @@ from tvm.target import Target
 import tilelang
 from tilelang.transform import PassContext
 from tilelang.contrib.nvcc import have_tma, have_pdl
+import tvm
 
 
 def allow_warp_specialized(pass_ctx: PassContext | None = None, target: Target | None = None) -> bool:
@@ -234,7 +235,12 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.HoistGlobalBufferAllocations()(mod)
     mod = tilelang.transform.LowerOpaqueBlock()(mod)
     mod = tilelang.transform.Simplify()(mod)
+    
     mod = tirx.transform.NarrowDataType(32)(mod)
+    _lower_hex = tvm.get_global_func("tilelang.transform.LowerHexagonIntrinsics", True)
+    if _lower_hex is not None:
+        mod = _lower_hex()(mod)
+
     mod = tilelang.transform.FlattenBuffer()(mod)
     # ConfigIndexBitwidth must be applied after FlattenBuffer
     # as it will flatten index computing

--- a/tilelang/engine/phase.py
+++ b/tilelang/engine/phase.py
@@ -235,7 +235,7 @@ def OptimizeForTarget(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.HoistGlobalBufferAllocations()(mod)
     mod = tilelang.transform.LowerOpaqueBlock()(mod)
     mod = tilelang.transform.Simplify()(mod)
-    
+
     mod = tirx.transform.NarrowDataType(32)(mod)
     _lower_hex = tvm.get_global_func("tilelang.transform.LowerHexagonIntrinsics", True)
     if _lower_hex is not None:

--- a/tilelang/intrinsics/hexagon/__init__.py
+++ b/tilelang/intrinsics/hexagon/__init__.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from tvm import tir
+
+
+def mma(
+    A: tir.Buffer,
+    B: tir.Buffer,
+    C: tir.Buffer,
+    *,
+    extern_name: str = "hmx_mma_placeholder",
+) -> None:
+    """
+    Emit an HMX matrix-multiply-accumulate intrinsic: C += A × B.
+
+    The function emits a ``T.evaluate(tir.call_extern(...))`` that lowers
+    to an ``hmx_mma_*`` C/C++ extern call.  When targeting a real device
+    you can implement that extern using the Qualcomm Hexagon Kernel Library
+    (HKL) or inline assembly.
+
+    Parameters
+    ----------
+    A : tir.Buffer
+        Input buffer in VTCM (int8 / uint8 / float16).
+    B : tir.Buffer
+        Weight buffer in VTCM (int8 / uint8 / float16).
+    C : tir.Buffer
+        Accumulator buffer in HMX accumulator scope (int32 / float32).
+    extern_name : str
+        Name of the C extern to call.  Defaults to ``hmx_mma_i8i8i32``.
+        Override to ``hmx_mma_f16f16f32`` for FP16 HMX (v75+).
+    """
+    from tilelang import language as T
+
+    T.evaluate(
+        tir.call_extern(
+            "handle",
+            extern_name,
+            A.data,
+            B.data,
+            C.data,
+        )
+    )
+
+
+def mma_fp16(A: tir.Buffer, B: tir.Buffer, C: tir.Buffer) -> None:
+    """
+    FP16 × FP16 → FP32 HMX MMA (requires Hexagon v75+ with HMX-FP).
+    """
+    mma(A, B, C, extern_name="hmx_mma_f16f16f32")
+
+
+def vtcm_dma_copy(src: tir.Buffer, dst: tir.Buffer) -> None:
+    """
+    Emit an async DMA copy from DDR (*src*) to VTCM (*dst*).
+
+    In a real kernel this maps to a ``dma_move`` or similar HKL call.
+    The placeholder keeps the TIR graph well-formed during development.
+    """
+    tir.Evaluate(
+        tir.call_extern(
+            "handle",
+            "hexagon_dma_copy",
+            src.access_ptr("r"),
+            dst.access_ptr("w"),
+        )
+    )
+
+
+class HMXBuilder:
+    """
+    Namespace object that groups HMX intrinsics, analogous to tilelang's
+    existing MMABuilder for CUDA tensor-core operations.
+
+    Example
+    -------
+    ::
+
+        from tilelang.intrinsics.hexagon import hmx
+
+        hmx.mma(A_vtcm, B_vtcm, C_acc)          # int8 MMA
+        hmx.mma_fp16(A_vtcm, B_vtcm, C_acc)     # fp16 MMA (v75+)
+        hmx.vtcm_dma_copy(A_host, A_vtcm)        # async DMA
+    """
+
+    mma = staticmethod(mma)
+    mma_fp16 = staticmethod(mma_fp16)
+    vtcm_dma_copy = staticmethod(vtcm_dma_copy)
+
+
+hmx = HMXBuilder()
+
+
+__all__ = [
+    "hmx",
+    "HMXBuilder",
+    "register_hexagon_memory_info",
+    "mma",
+    "mma_fp16",
+    "vtcm_dma_copy",
+]

--- a/tilelang/intrinsics/hexagon/__init__.py
+++ b/tilelang/intrinsics/hexagon/__init__.py
@@ -1,30 +1,30 @@
 from __future__ import annotations
 
-from tvm import tir
+from tvm import tirx
 
 
 def mma(
-    A: tir.Buffer,
-    B: tir.Buffer,
-    C: tir.Buffer,
+    A: tirx.Buffer,
+    B: tirx.Buffer,
+    C: tirx.Buffer,
     *,
     extern_name: str = "hmx_mma_placeholder",
 ) -> None:
     """
     Emit an HMX matrix-multiply-accumulate intrinsic: C += A × B.
 
-    The function emits a ``T.evaluate(tir.call_extern(...))`` that lowers
+    The function emits a ``T.evaluate(tirx.call_extern(...))`` that lowers
     to an ``hmx_mma_*`` C/C++ extern call.  When targeting a real device
     you can implement that extern using the Qualcomm Hexagon Kernel Library
     (HKL) or inline assembly.
 
     Parameters
     ----------
-    A : tir.Buffer
+    A : tirx.Buffer
         Input buffer in VTCM (int8 / uint8 / float16).
-    B : tir.Buffer
+    B : tirx.Buffer
         Weight buffer in VTCM (int8 / uint8 / float16).
-    C : tir.Buffer
+    C : tirx.Buffer
         Accumulator buffer in HMX accumulator scope (int32 / float32).
     extern_name : str
         Name of the C extern to call.  Defaults to ``hmx_mma_i8i8i32``.
@@ -33,32 +33,32 @@ def mma(
     from tilelang import language as T
 
     T.evaluate(
-        tir.call_extern(
+        tirx.call_extern(
             "handle",
             extern_name,
-            A.data,
-            B.data,
-            C.data,
+            A.access_ptr("r"),
+            B.access_ptr("r"),
+            C.access_ptr("rw"),
         )
     )
 
 
-def mma_fp16(A: tir.Buffer, B: tir.Buffer, C: tir.Buffer) -> None:
+def mma_fp16(A: tirx.Buffer, B: tirx.Buffer, C: tirx.Buffer) -> None:
     """
     FP16 × FP16 → FP32 HMX MMA (requires Hexagon v75+ with HMX-FP).
     """
     mma(A, B, C, extern_name="hmx_mma_f16f16f32")
 
 
-def vtcm_dma_copy(src: tir.Buffer, dst: tir.Buffer) -> None:
+def vtcm_dma_copy(src: tirx.Buffer, dst: tirx.Buffer) -> None:
     """
     Emit an async DMA copy from DDR (*src*) to VTCM (*dst*).
 
     In a real kernel this maps to a ``dma_move`` or similar HKL call.
     The placeholder keeps the TIR graph well-formed during development.
     """
-    tir.Evaluate(
-        tir.call_extern(
+    tirx.evaluate(
+        tirx.call_extern(
             "handle",
             "hexagon_dma_copy",
             src.access_ptr("r"),

--- a/tilelang/jit/adapter/base.py
+++ b/tilelang/jit/adapter/base.py
@@ -85,6 +85,16 @@ class BaseKernelAdapter(ABC):
         return lambda: torch.device("cpu")
 
     def __call__(self, *args: Any, **kwds: Any) -> Any:
+        if self.func is None:
+            from tilelang.utils.target import is_hexagon_target
+
+            if is_hexagon_target(self.target):
+                raise RuntimeError(
+                    "Hexagon kernels cannot be executed directly on the host machine. "
+                    "To run this kernel, please use the Hexagon SDK Simulator or "
+                    "the HexagonLauncher on a supported Qualcomm device."
+                )
+            raise RuntimeError("The compiled function is not initialized.")
         return self.func(*args, **kwds)
 
     def get_kernel_source(self, kernel_only: bool = True) -> str:

--- a/tilelang/jit/adapter/cython/adapter.py
+++ b/tilelang/jit/adapter/cython/adapter.py
@@ -132,6 +132,16 @@ class CythonKernelAdapter(BaseKernelAdapter):
         self.lib_generator.compile_lib()
         self.lib = self.lib_generator.load_lib()
 
+        from tilelang.utils.target import is_hexagon_target
+
+        if is_hexagon_target(self.target):
+            # For Hexagon, we are cross-compiling.
+            # We cannot load symbols or execute this on the host machine.
+            # Returning early allows the JIT object to exist so we can
+            # inspect kernel.kernel_source.
+            self._compiled_func = None
+            return
+
         self.lib.get_last_error.restype = ctypes.c_char_p
         result = self.lib.init()
         if result != 0:
@@ -325,6 +335,8 @@ class CythonKernelAdapter(BaseKernelAdapter):
             device = torch.device("cpu")
         elif is_metal_target(self.target):
             device = torch.device("mps")
+        elif "hexagon" in self.target.keys or "hexagon" in str(self.target):
+            device = torch.device("cpu")
         else:
             raise ValueError(f"Unsupported target: {self.target}")
 

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -58,6 +58,15 @@ class LibraryGenerator:
 
     def compile_lib(self, timeout: float = None):
         target = self.target
+
+        from tilelang.utils.target import is_hexagon_target
+
+        if is_hexagon_target(self.target):
+            # We are cross-compiling for Hexagon.
+            # We cannot link or load this on the host machine.
+            self.lib = None
+            return
+
         verbose = self.verbose
         if is_cuda_target(target):
             from tilelang.env import CUTLASS_INCLUDE_DIR

--- a/tilelang/jit/adapter/utils.py
+++ b/tilelang/jit/adapter/utils.py
@@ -87,12 +87,22 @@ def extract_python_func_declaration(source: str, func_name: str) -> str:
 
 
 def match_declare_kernel_cpu(source: str, annotation: str = "int32_t") -> int:
-    pattern = r"int32_t\s+\w+"
+    # C-style signature
+    pattern_c = r"int32_t\s+\w+"
+    # LLVM-style signature
+    pattern_llvm = r"define\s+.*@(?!llvm\.)\w+"
+
     for line in source.split("\n"):
-        if annotation in line:
-            matched = re.findall(pattern, line)
-            if len(matched) >= 1:
-                return source.index(matched[0] + "(")
+        # C pattern
+        matched = re.findall(pattern_c, line)
+        if matched:
+            return source.index(matched[0])
+        # LLVM pattern
+        matched = re.findall(pattern_llvm, line)
+        if matched:
+            # Match the start of the 'define'
+            return source.index(matched[0])
+
     raise ValueError("No global kernel found in the source code")
 
 

--- a/tilelang/jit/adapter/wrapper.py
+++ b/tilelang/jit/adapter/wrapper.py
@@ -22,6 +22,8 @@ import re
 import logging
 import textwrap
 from tvm.tirx.stmt_functor import post_order_visit
+from tilelang.utils.target import is_hexagon_target
+
 
 PREDEF_ATTRIBUTE_SET_DYNAMIC_MEMORY = """
     cudaError_t result_{0} = cudaFuncSetAttribute({0}, cudaFuncAttributeMaxDynamicSharedMemorySize, {1});
@@ -452,7 +454,8 @@ class TLCUDASourceWrapper:
                 device_mod, host_mod = get_annotated_mod(self.mod, self.target)
             self.device_mod = device_mod
             self.host_mod = host_mod
-        assert len(self.device_mod.functions) >= 1, "Device module should have at least one function."
+        if not is_hexagon_target(self.target):
+            assert len(self.device_mod.functions) >= 1, "Device module should have at least one function."
         assert len(self.host_mod.functions) == 1, "Only support one function in host module."
 
         block_info_map = {}
@@ -950,6 +953,18 @@ class TLWrapper(BaseWrapper):
         self.target = target
         self.lib = None
 
+    @property
+    def arch(self):
+        if "_arch" in self.__dict__:
+            return self.__dict__["_arch"]
+        if is_hexagon_target(self.target):
+            from tilelang.carver.arch.hexagon import get_hexagon_arch
+
+            arch = get_hexagon_arch(self.target)
+            self.__dict__["_arch"] = arch
+            return arch
+        return None
+
     def assign_optimized_module(self, scheduled_ir_module: IRModule):
         self.scheduled_ir_module = scheduled_ir_module
 
@@ -965,16 +980,19 @@ class TLWrapper(BaseWrapper):
     # Get Scheduled Rt Module and return source to be compiled
     def wrap(self, c_source: str):
         assert self.scheduled_ir_module is not None, "Please assign optimized module first."
+
         if is_cuda_target(self.target):
             wrapper_class = TLCUDASourceWrapper
         elif is_hip_target(self.target):
             wrapper_class = TLHIPSourceWrapper
-        elif is_cpu_target(self.target):
-            wrapper_class = TLCPUSourceWrapper
         elif is_metal_target(self.target):
             wrapper_class = TLMetalSourceWrapper
+        elif is_cpu_target(self.target) or is_hexagon_target(self.target):
+            wrapper_class = TLCPUSourceWrapper
         else:
-            raise ValueError(f"Unsupported platform: {self.arch.platform}")
+            arch_name = self.arch.platform if self.arch else "unknown"
+            raise ValueError(f"Unsupported platform: {arch_name}")
+
         wrapper = wrapper_class(
             scheduled_ir_module=self.scheduled_ir_module,
             source=c_source,

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -198,6 +198,16 @@ class JITKernel(Generic[_P, _T]):
         Any
             The result of the function execution.
         """
+        if self.torch_function is None:
+            from tilelang.utils.target import is_hexagon_target
+
+            if is_hexagon_target(self.target):
+                raise RuntimeError(
+                    "Hexagon kernels cannot be executed directly on the host machine. "
+                    "To run this kernel, please use the Hexagon SDK Simulator or "
+                    "the HexagonLauncher on a supported Qualcomm device."
+                )
+
         return self.torch_function(*args, **kwds)
 
     def _compile_and_create_adapter(self, tilelang_func: PrimFunc, out_idx: list[int]) -> BaseKernelAdapter:

--- a/tilelang/utils/target.py
+++ b/tilelang/utils/target.py
@@ -21,6 +21,7 @@ SUPPORTED_TARGETS: dict[str, str] = {
     "cuda": "CUDA GPU target. Use dict options such as {'kind': 'cuda', 'arch': 'sm_90'}.",
     "hip": "ROCm HIP target. Use dict options such as {'kind': 'hip', 'mcpu': 'gfx942'}.",
     "metal": "Apple Metal target for arm64 Macs.",
+    "hexagon": "Qualcomm Hexagon DSP target.",
     "llvm": "LLVM CPU target. Use dict options such as {'kind': 'llvm', 'mcpu': 'native'}.",
     "webgpu": "WebGPU target for browser/WebGPU runtimes.",
     "c": "C source backend.",
@@ -134,6 +135,19 @@ def check_metal_availability() -> bool:
     return arch == "arm64"
 
 
+def check_hexagon_availability() -> bool:
+    """
+    Check if Hexagon support is available in the TVM build.
+    Returns:
+        bool: True if Hexagon is available, False otherwise.
+    """
+    try:
+        # Check if Hexagon runtime is enabled in TVM
+        return tvm.runtime.enabled("hexagon")
+    except Exception:
+        return False
+
+
 def determine_fp8_type(fp8_format: Literal["e4m3", "e5m2"] = "e4m3") -> str:
     """
     Select the correct FP8 dtype string for the current platform.
@@ -202,22 +216,38 @@ def normalize_cutedsl_target(target: TargetLike) -> Target | None:
     return None
 
 
+def is_hexagon_target(target) -> bool:
+    """Return True for LLVM targets cross-compiled to Hexagon."""
+    if target is None:
+        return False
+    # Check if it's a TVM Target object
+    if hasattr(target, "kind"):
+        if target.kind.name == "hexagon":
+            return True
+        if target.kind.name == "llvm":
+            return "hexagon" in str(target.attrs.get("mtriple", "")).lower()
+    # Check if it's a string
+    return "hexagon" in str(target).lower()
+
+
 def determine_target(target: TargetLike | Literal["auto"] = "auto", return_object: bool = False) -> str | TargetConfig | Target:
     """
-    Determine the appropriate target for compilation (CUDA, HIP, or manual selection).
+    Determine the appropriate target for compilation (CUDA, HIP, Hexagon, or manual selection).
 
     Args:
         target (Union[str, dict, Target, Literal["auto"]]): User-specified target.
-            - If "auto", the system will automatically detect whether CUDA or HIP is available.
+            - If "auto", the system will automatically detect available accelerators.
             - If a string, dict, or Target, it is directly validated.
 
     Returns:
         Union[str, dict, Target]: The selected target ("cuda", "hip", a config dict, or a Target object).
 
     Raises:
-        ValueError: If no CUDA or HIP is available and the target is "auto".
+        ValueError: If no compatible accelerator is found and the target is "auto".
         AssertionError: If the target is invalid.
     """
+
+    return_var: str | TargetConfig | Target = target
 
     return_var: str | TargetConfig | Target = target
 
@@ -245,60 +275,65 @@ def determine_target(target: TargetLike | Literal["auto"] = "auto", return_objec
                 return_var = _rocm_target_from_arch(_detect_torch_rocm_arch())
             elif check_metal_availability():
                 return_var = "metal"
+            elif check_hexagon_availability():
+                return_var = "llvm -mtriple=hexagon -mcpu=hexagonv73"
             else:
-                raise ValueError("No CUDA or HIP or MPS available on this system.")
-
+                raise ValueError("No CUDA, HIP, MPS, or Hexagon available on this system.")
     else:
-        possible_cutedsl_target = normalize_cutedsl_target(target)
-        if possible_cutedsl_target is not None:
+        return_var = target
+
+    # Handle Backend-Specific Normalization (Shorthands)
+    if isinstance(return_var, str) and "hexagon" in return_var.lower():
+        s = return_var.strip()
+        if s.lower() == "hexagon":
+            s = "llvm"
+        if "-mtriple" not in s:
+            s += " -mtriple=hexagon"
+        if "-mcpu" not in s:
+            s += " -mcpu=hexagonv73"
+        return_var = s.strip()
+
+    # Handle CuTeDSL special case
+    possible_cutedsl_target = normalize_cutedsl_target(return_var)
+    if possible_cutedsl_target is not None:
+        return_var = possible_cutedsl_target
+    else:
+        # Validate the target if it's not "auto"
+        if isinstance(target, Target):
+            return_var = with_rocm_target_attrs(target)
+        elif isinstance(target, dict):
             try:
-                from tilelang.jit.adapter.cutedsl.checks import check_cutedsl_available  # lazy
-
-                check_cutedsl_available()
-            except ImportError as e:
-                raise AssertionError(f"CuTeDSL backend is not available. Please install tilelang-cutedsl package. {str(e)}") from e
-
-            return_var = possible_cutedsl_target
-        else:
-            # Validate the target if it's not "auto"
-            if isinstance(target, Target):
-                return_var = with_rocm_target_attrs(target)
-            elif isinstance(target, dict):
-                try:
-                    parsed_target = Target(target)
-                except Exception as err:
-                    raise AssertionError(
-                        f"Target {target} is not supported. Pass a valid target config dict, e.g. `{{'kind': 'cuda', 'arch': 'sm_80'}}`."
-                    ) from err
-                if parsed_target.kind.name == "hip" and target_get_mcpu(parsed_target) is not None:
-                    return_var = with_rocm_target_attrs(parsed_target)
-                else:
-                    return_var = target
-            elif isinstance(target, str):
-                normalized_target = target.strip()
-                if not normalized_target:
-                    raise AssertionError(f"Target {target} is not supported")
-                try:
-                    parsed_target = Target(normalized_target)
-                except Exception as err:
-                    examples = ", ".join(f"`{name}`" for name in SUPPORTED_TARGETS)
-                    raise AssertionError(
-                        f"Target {target} is not supported. Supported targets include: {examples}. "
-                        "Pass target options as a dict, e.g. `{'kind': 'cuda', 'arch': 'sm_80'}`."
-                    ) from err
-                if parsed_target.kind.name == "hip" and target_get_mcpu(parsed_target) is not None:
-                    return_var = with_rocm_target_attrs(parsed_target)
-                else:
-                    return_var = normalized_target
+                parsed_target = Target(target)
+            except Exception as err:
+                raise AssertionError(
+                    f"Target {target} is not supported. Pass a valid target config dict, e.g. `{{'kind': 'cuda', 'arch': 'sm_80'}}`."
+                ) from err
+            if parsed_target.kind.name == "hip" and target_get_mcpu(parsed_target) is not None:
+                return_var = with_rocm_target_attrs(parsed_target)
             else:
+                return_var = target
+        elif isinstance(target, str):
+            normalized_target = target.strip()
+            if not normalized_target:
                 raise AssertionError(f"Target {target} is not supported")
+            try:
+                parsed_target = Target(normalized_target)
+            except Exception as err:
+                examples = ", ".join(f"`{name}`" for name in SUPPORTED_TARGETS)
+                raise AssertionError(
+                    f"Target {target} is not supported. Supported targets include: {examples}. "
+                    "Pass target options as a dict, e.g. `{'kind': 'cuda', 'arch': 'sm_80'}`."
+                ) from err
+            if parsed_target.kind.name == "hip" and target_get_mcpu(parsed_target) is not None:
+                return_var = with_rocm_target_attrs(parsed_target)
+            else:
+                return_var = normalized_target
+        else:
+            raise AssertionError(f"Target {target} is not supported")
 
-    if isinstance(return_var, Target):
-        return return_var
+    # Final Validation and conversion to object if requested
     if return_object:
-        if isinstance(return_var, Target):
-            return return_var
-        return Target(return_var)
+        return return_var if isinstance(return_var, Target) else Target(return_var)
     return return_var
 
 

--- a/tilelang/utils/target.py
+++ b/tilelang/utils/target.py
@@ -276,7 +276,7 @@ def determine_target(target: TargetLike | Literal["auto"] = "auto", return_objec
             elif check_metal_availability():
                 return_var = "metal"
             elif check_hexagon_availability():
-                return_var = "llvm -mtriple=hexagon -mcpu=hexagonv73"
+                return_var = {"kind": "llvm", "mtriple": "hexagon", "mcpu": "hexagonv73"}
             else:
                 raise ValueError("No CUDA, HIP, MPS, or Hexagon available on this system.")
     else:
@@ -284,14 +284,11 @@ def determine_target(target: TargetLike | Literal["auto"] = "auto", return_objec
 
     # Handle Backend-Specific Normalization (Shorthands)
     if isinstance(return_var, str) and "hexagon" in return_var.lower():
-        s = return_var.strip()
-        if s.lower() == "hexagon":
-            s = "llvm"
-        if "-mtriple" not in s:
-            s += " -mtriple=hexagon"
-        if "-mcpu" not in s:
-            s += " -mcpu=hexagonv73"
-        return_var = s.strip()
+        return_var = {"kind": "llvm", "mtriple": "hexagon", "mcpu": "hexagonv73"}
+
+    elif isinstance(return_var, dict) and return_var.get("mtriple") == "hexagon":
+        return_var.setdefault("kind", "llvm")
+        return_var.setdefault("mcpu", "hexagonv73")
 
     # Handle CuTeDSL special case
     possible_cutedsl_target = normalize_cutedsl_target(return_var)


### PR DESCRIPTION
## Title: Add Hexagon Backend with HMX Support for Matrix Multiplication

### Summary
Introduce a dedicated Hexagon backend for TileLang with support for Qualcomm HMX (Hexagon Matrix eXtensions). This integration enables the generation of high-performance LLVM IR specifically targeting Hexagon DSP hardware instructions for matrix multiplication.

### Why
Qualcomm's Hexagon DSPs power a vast number of edge devices. By leveraging the Hexagon Kernel Library (HexKL) interfaces through TileLang, we can achieve efficient CodeGen for specialized operators like sparse attention on mobile hardware. This keeps TileLang at the forefront of heterogeneous hardware support and enables localized, backend-specific optimizations for Qualcomm chips.

### Key Changes

#### Hardware Lowering
- New C++ pass `LowerHexagonIntrinsics` that translates TileLang MMA placeholders into the specialized `@HexKL_mma_i8acc32` hardware instructions.

#### Memory Architecture
- Native C++ registration of `global.vtcm` and `global.hmx.acc` memory scopes.
- Provides the compiler with correct alignment (128‑byte) and capacity constraints for Hexagon HTP.

#### Runtime Support
- Runtime power‑management wrapper `hmx_kernel_launch` utilizing the `HexagonHtp` RAII guard to enable the HMX hardware block during execution.

#### JIT Infrastructure
- Enhancements to the kernel cache to support IR‑only backends.
- Addition of execution guards to prevent cross‑compiled binaries from attempting to run on incompatible host CPUs.

### Validation

```bash
# Style and Linting
pre-commit run --all-files

# Build Verification (requires LLVM 17/18)
cd build
cmake .. -DUSE_LLVM=ON
make -j$(nproc)

# Symbol Verification
nm -D lib/libtilelang.so | grep "LowerHexagonIntrinsics"

# Functional Testing (IR Generation & Logic)
pytest testing/python/hexagon/test_hmx_mma.py
pytest testing/python/hexagon/diagnose_hmx.py
```

#### Additional Checks
- **IR Validation**: Verified correct target triple (`hexagon`), memory allocations (`A_vtcm`, `C_acc`), and hardware intrinsic calls (`HexKL_mma_i8acc32`).
- **Host Guard**: Verified that calling Hexagon kernels on x86/ARM hosts raises a descriptive `RuntimeError`.

### Compatibility
- Requires LLVM 17 or 18.
- Tested on Qualcomm HTP hardware (simulator and physical device).

### Related Issues
Closes: https://github.com/tile-ai/tilelang/issues/1293

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hexagon DSP target support with HMX acceleration, intrinsics (MMA, DMA), architecture descriptors, and runtime kernel launch integration.
  * Hexagon-aware JIT/adapters and target handling for cross-compilation workflows.

* **Tests**
  * New diagnostics and unit tests for Hexagon codegen, IR lowering, and HMX MMA behavior.

* **Chores**
  * Build-system enhancements for LLVM/Hexagon detection and IR-only caching; kernel-cache and target utilities updated for Hexagon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->