### PR TITLE
[BugFix] Consider non-local store in external call and SIMT producer for warp specialize

### DIFF
--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -1247,6 +1247,20 @@ private:
               has_non_local_store = true;
             }
           }
+        } else if (call->op.same_as(builtin::call_extern())) {
+          // call_extern may pass address_of(non-local-buffer) pointers
+          for (const auto &arg : call->args) {
+            if (auto ic = arg.as<CallNode>()) {
+              if (ic->op.same_as(builtin::address_of()) &&
+                  !ic->args.empty()) {
+                if (auto bl = ic->args[0].as<BufferLoadNode>()) {
+                  if (!IsLocalBuffer(bl->buffer)) {
+                    has_non_local_store = true;
+                  }
+                }
+              }
+            }
+          }
         }
       }
     });

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -1251,8 +1251,7 @@ private:
           // call_extern may pass address_of(non-local-buffer) pointers
           for (const auto &arg : call->args) {
             if (auto ic = arg.as<CallNode>()) {
-              if (ic->op.same_as(builtin::address_of()) &&
-                  !ic->args.empty()) {
+              if (ic->op.same_as(builtin::address_of()) && !ic->args.empty()) {
                 if (auto bl = ic->args[0].as<BufferLoadNode>()) {
                   if (!IsLocalBuffer(bl->buffer)) {
                     has_non_local_store = true;

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -1247,17 +1247,12 @@ private:
               has_non_local_store = true;
             }
           }
-        } else if (call->op.same_as(builtin::call_extern())) {
-          // call_extern may pass address_of(non-local-buffer) pointers
-          for (const auto &arg : call->args) {
-            if (auto ic = arg.as<CallNode>()) {
-              if (ic->op.same_as(builtin::address_of()) && !ic->args.empty()) {
-                if (auto bl = ic->args[0].as<BufferLoadNode>()) {
-                  if (!IsLocalBuffer(bl->buffer)) {
-                    has_non_local_store = true;
-                  }
-                }
-              }
+        } else if (call->op.same_as(builtin::address_of())) {
+          // call_extern may pass address_of(non-local-buffer) pointers, and
+          // PostOrderVisit reaches the address_of call directly.
+          if (const auto *load = call->args[0].as<BufferLoadNode>()) {
+            if (!IsLocalBuffer(load->buffer)) {
+              has_non_local_store = true;
             }
           }
         }

--- a/src/transform/producer_consumer_ws.cc
+++ b/src/transform/producer_consumer_ws.cc
@@ -1330,6 +1330,52 @@ private:
       ++access_group_idx;
     }
 
+    // --- Adjust wait positions for SIMT/cp.async producers ---
+    // SIMT producers (global→shared via cp.async) tie their completion to ALL
+    // forward barriers.  The consumer must therefore wait on a forward barrier
+    // BEFORE it reads any SIMT-produced shared buffer.  If the current
+    // wait_insert_pos is too late (i.e. the consumer reads the SIMT-produced
+    // buffer before the earliest TMA wait), we must pull ALL waits earlier.
+    if (has_simt_producer || has_cp_async_producer) {
+      int earliest_simt_read = static_cast<int>(consumer_compute_stmts.size());
+      for (size_t i = 0; i < flat_stmts.size(); ++i) {
+        if (kinds[i] != TileStmtKind::kSimtProducer &&
+            kinds[i] != TileStmtKind::kCpAsyncProducer) {
+          continue;
+        }
+        // Collect shared buffers written by this SIMT/cp.async producer.
+        std::unordered_set<const VarNode *> written_vars;
+        PostOrderVisit(flat_stmts[i], [&](const ObjectRef &obj) {
+          if (const auto *store = obj.as<BufferStoreNode>()) {
+            if (IsSharedBuffer(store->buffer)) {
+              written_vars.insert(store->buffer->data.get());
+            }
+          }
+        });
+        // Find first consumer read of any of these buffers.
+        for (size_t ci = 0; ci < consumer_compute_stmts.size(); ++ci) {
+          bool found = false;
+          PostOrderVisit(consumer_compute_stmts[ci], [&](const ObjectRef &obj) {
+            if (found) return;
+            if (const auto *load = obj.as<BufferLoadNode>()) {
+              if (written_vars.count(load->buffer->data.get())) {
+                found = true;
+              }
+            }
+          });
+          if (found) {
+            earliest_simt_read =
+                std::min(earliest_simt_read, static_cast<int>(ci));
+            break;
+          }
+        }
+      }
+      // Pull all wait positions earlier if needed.
+      for (int g = 0; g < num_producer_groups; ++g) {
+        wait_insert_pos[g] = std::min(wait_insert_pos[g], earliest_simt_read);
+      }
+    }
+
     // --- Determine if TMA barriers can be merged ---
     // When all pure-TMA producers wait at the same consumer position and
     // release at the same position, forward and back-pressure barriers can

--- a/src/transform/producer_consumer_ws.cc
+++ b/src/transform/producer_consumer_ws.cc
@@ -1027,6 +1027,67 @@ static Optional<Var> ExtractProducerWriteBufferData(const Stmt &stmt) {
   return Optional<Var>();
 }
 
+static int
+FindFirstAsyncProducerConsumerRead(const Stmt &producer_stmt,
+                                   const Array<Stmt> &consumer_compute_stmts,
+                                   const BufferDataToBufferMap &buffer_map) {
+  int earliest_read = static_cast<int>(consumer_compute_stmts.size());
+  auto update_earliest_read = [&](const Var &buffer_data) {
+    for (size_t ci = 0; ci < static_cast<size_t>(earliest_read); ++ci) {
+      BufferDataAccessInfo access = AnalyzeBufferDataAccess(
+          consumer_compute_stmts[ci], buffer_data, buffer_map);
+      if (access.read) {
+        earliest_read = static_cast<int>(ci);
+        return;
+      }
+    }
+  };
+  if (Optional<Var> write_buffer_data =
+          ExtractProducerWriteBufferData(producer_stmt)) {
+    update_earliest_read(write_buffer_data.value());
+  }
+  PostOrderVisit(producer_stmt, [&](const ObjectRef &obj) {
+    if (earliest_read == 0) {
+      return;
+    }
+    if (const auto *store = obj.as<BufferStoreNode>()) {
+      if (IsSharedBuffer(store->buffer)) {
+        update_earliest_read(store->buffer->data);
+      }
+      return;
+    }
+    const auto *call = obj.as<CallNode>();
+    if (!call || !(call->op.same_as(builtin::ptx_cp_async()) ||
+                   call->op.same_as(tl::ptx_cp_async()))) {
+      return;
+    }
+    PostOrderVisit(call->args[0], [&](const ObjectRef &ptr_obj) {
+      if (earliest_read == 0) {
+        return;
+      }
+      if (const auto *load = ptr_obj.as<BufferLoadNode>()) {
+        if (IsSharedBuffer(load->buffer)) {
+          update_earliest_read(load->buffer->data);
+        }
+        return;
+      }
+      const auto *ptr_call = ptr_obj.as<CallNode>();
+      if (!ptr_call || !ptr_call->op.same_as(builtin::tvm_access_ptr())) {
+        return;
+      }
+      const auto *var = ptr_call->args[1].as<VarNode>();
+      if (!var) {
+        return;
+      }
+      auto it = buffer_map.find(ffi::GetRef<Var>(var));
+      if (it != buffer_map.end() && IsSharedBuffer(it->second)) {
+        update_earliest_read(it->second->data);
+      }
+    });
+  });
+  return earliest_read;
+}
+
 static Stmt RewritePreludeTmaProducerStmt(const Stmt &stmt,
                                           const Buffer &barrier_buf,
                                           PrimExpr barrier_id) {
@@ -1331,49 +1392,23 @@ private:
     }
 
     // --- Adjust wait positions for SIMT/cp.async producers ---
-    // SIMT producers (global→shared via cp.async) tie their completion to ALL
-    // forward barriers.  The consumer must therefore wait on a forward barrier
-    // BEFORE it reads any SIMT-produced shared buffer.  If the current
-    // wait_insert_pos is too late (i.e. the consumer reads the SIMT-produced
-    // buffer before the earliest TMA wait), we must pull ALL waits earlier.
+    // SIMT and cp.async producers tie their completion to all forward barriers.
+    // If a consumer reads any such shared destination before the first TMA
+    // read, pull all waits earlier so the async producer is also covered.
     if (has_simt_producer || has_cp_async_producer) {
-      int earliest_simt_read = static_cast<int>(consumer_compute_stmts.size());
+      int earliest_async_read = static_cast<int>(consumer_compute_stmts.size());
       for (size_t i = 0; i < flat_stmts.size(); ++i) {
         if (kinds[i] != TileStmtKind::kSimtProducer &&
             kinds[i] != TileStmtKind::kCpAsyncProducer) {
           continue;
         }
-        // Collect shared buffers written by this SIMT/cp.async producer.
-        std::unordered_set<const VarNode *> written_vars;
-        PostOrderVisit(flat_stmts[i], [&](const ObjectRef &obj) {
-          if (const auto *store = obj.as<BufferStoreNode>()) {
-            if (IsSharedBuffer(store->buffer)) {
-              written_vars.insert(store->buffer->data.get());
-            }
-          }
-        });
-        // Find first consumer read of any of these buffers.
-        for (size_t ci = 0; ci < consumer_compute_stmts.size(); ++ci) {
-          bool found = false;
-          PostOrderVisit(consumer_compute_stmts[ci], [&](const ObjectRef &obj) {
-            if (found)
-              return;
-            if (const auto *load = obj.as<BufferLoadNode>()) {
-              if (written_vars.count(load->buffer->data.get())) {
-                found = true;
-              }
-            }
-          });
-          if (found) {
-            earliest_simt_read =
-                std::min(earliest_simt_read, static_cast<int>(ci));
-            break;
-          }
-        }
+        int first_read = FindFirstAsyncProducerConsumerRead(
+            flat_stmts[i], consumer_compute_stmts, buffer_data_to_buffer_);
+        earliest_async_read = std::min(earliest_async_read, first_read);
       }
       // Pull all wait positions earlier if needed.
       for (int g = 0; g < num_producer_groups; ++g) {
-        wait_insert_pos[g] = std::min(wait_insert_pos[g], earliest_simt_read);
+        wait_insert_pos[g] = std::min(wait_insert_pos[g], earliest_async_read);
       }
     }
 

--- a/src/transform/producer_consumer_ws.cc
+++ b/src/transform/producer_consumer_ws.cc
@@ -1356,7 +1356,8 @@ private:
         for (size_t ci = 0; ci < consumer_compute_stmts.size(); ++ci) {
           bool found = false;
           PostOrderVisit(consumer_compute_stmts[ci], [&](const ObjectRef &obj) {
-            if (found) return;
+            if (found)
+              return;
             if (const auto *load = obj.as<BufferLoadNode>()) {
               if (written_vars.count(load->buffer->data.get())) {
                 found = true;

--- a/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
+++ b/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
@@ -114,6 +114,34 @@ def prelude_tma_wait_sink(block=64, iters=2, dtype="float16", threads=128):
     return main
 
 
+def explicit_cp_async_wait_position(iters=4, block=16, cp_elems=8, dtype="float16", threads=128):
+    """A mixed TMA + explicit cp.async pipeline with cp.async consumed first."""
+
+    @T.prim_func
+    def main(
+        A: T.Buffer((iters, block), dtype),
+        B: T.Buffer((iters, cp_elems), dtype),
+        B_out: T.Buffer((iters,), dtype),
+        A_out: T.Buffer((iters, block), dtype),
+    ):
+        with T.Kernel(1, threads=threads) as _:
+            A_shared = T.alloc_shared((block,), dtype)
+            B_shared = T.alloc_shared((cp_elems,), dtype)
+
+            for ko in T.Pipelined(iters, num_stages=2):
+                T.ptx_cp_async(
+                    T.access_ptr(B_shared[0], "w", cp_elems),
+                    T.access_ptr(B[ko, 0], "r", cp_elems),
+                    cp_elems,
+                )
+                T.copy(A[ko, 0], A_shared)
+                B_out[ko] = B_shared[0]
+                for i in T.Parallel(block):
+                    A_out[ko, i] = A_shared[i]
+
+    return main
+
+
 def grouped_gemm_padded_pipelined(
     batch_sizes,
     K,
@@ -431,6 +459,27 @@ def test_tiled_ws_sinks_preloop_tma_waits_into_consumer():
     assert k_load < v_load < branch < first_wait
 
 
+def test_tiled_ws_explicit_cp_async_wait_precedes_first_consumer_read():
+    """Explicit cp.async destinations must pull the consumer wait earlier."""
+
+    func = explicit_cp_async_wait_position().with_attr("global_symbol", "main")
+    mod = tvm.IRModule.from_expr(func)
+    mod = tvm.tir.transform.BindTarget(tvm.target.Target("cuda -arch=sm_90"))(mod)
+    mod = tilelang.transform.ProducerConsumerWarpSpecialized()(mod)
+    script = mod["main"].script()
+
+    assert "tl_tiled_ws_applied" in script
+    assert "T.ptx_cp_async" in script
+    assert "T.tma_copy" in script
+
+    consumer_branch = _find_after(script, "else:")
+    wait = _find_after(script, "T.mbarrier_wait_parity", consumer_branch)
+    cp_async_read = _find_after(script, "B_out[ko] = B_shared[0]", consumer_branch)
+    tma_read = _find_after(script, "A_out[ko, i] = A_shared", consumer_branch)
+
+    assert wait < cp_async_read < tma_read
+
+
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version(9, 0)
 def test_tiled_ws_keeps_shared_prelude_local_vars_for_grouped_gemm():
@@ -468,5 +517,6 @@ if __name__ == "__main__":
     test_tiled_ws_swizzled_layout_allows_ws()
     test_tiled_ws_incompatible_layout_blocks_ws()
     test_tiled_ws_sinks_preloop_tma_waits_into_consumer()
+    test_tiled_ws_explicit_cp_async_wait_precedes_first_consumer_read()
     test_tiled_ws_keeps_shared_prelude_local_vars_for_grouped_gemm()
     test_tiled_ws_does_not_clone_local_var_into_producer_branch()


### PR DESCRIPTION
Two bugs caused incorrect results when T.Parallel loops use T.call_extern with T.address_of(shared_buffer) inside pipelined, warp-specialized kernels:

Bug 1 (lower_tile_op.cc): has_non_local_store did not recognize address_of(shared_buffer) inside call_extern as a non-local access, so parallel_loop was set to false and thread partitioning was skipped entirely — every thread ran the full serial loop.

Reproduction:
```python
"""
Minimal reproducer for Bug 1 (fixed in 0dba22aa):

  lower_tile_op.cc: has_non_local_store did not recognize
  address_of(shared_buffer) inside call_extern as a non-local access,
  so parallel_loop was set to false and thread partitioning was skipped
  entirely - every thread ran the full serial loop.

Trigger conditions:
  1. T.Parallel loop inside a warp-specialized pipeline (T.Pipelined
     with num_stages > 0, auto-WS triggered by T.copy/TMA).
  2. The parallel loop body uses T.call_extern with
     T.address_of(shared_buffer_element).
  3. No other non-local BufferStore inside the parallel loop body.

Without fix: all consumer threads execute every iteration.
With fix:    iterations are partitioned across consumer threads.

Observable effect:
  The external function `atomic_inc` does atomicAdd(ptr, 1).  With
  correct partitioning each shared element is bumped once per stage.
  With the bug, each element is bumped N times (N = consumer threads).
"""

import tilelang
from tilelang import language as T
import torch


@tilelang.jit
def bug1_kernel(
    M: int = 16,
    K: int = 32,
    block_M: int = 16,
    block_K: int = 16,
    dtype: str = "float16",
):
    @T.prim_func
    def main(
        A: T.Tensor((M, K), dtype),
        Counts: T.Tensor((M, block_K), "int32"),
    ):
        with T.Kernel(T.ceildiv(M, block_M), threads=128) as by:
            A_shared = T.alloc_shared((block_M, block_K), dtype)
            counters = T.alloc_shared((block_K,), "int32")

            T.import_source(
                'extern "C" __device__ void atomic_inc(int* ptr) { atomicAdd(ptr, 1); }\n'
            )

            T.clear(counters)

            for ko in T.Pipelined(T.ceildiv(K, block_K), num_stages=2):
                # TMA copy triggers auto warp-specialization (2 warp groups)
                T.copy(A[by * block_M, ko * block_K], A_shared)

                # Bug 1 trigger: T.Parallel + call_extern + address_of(shared).
                # Without the fix, has_non_local_store stays false because
                # address_of(BufferLoad(shared)) inside call_extern is not
                # recognized as a non-local access.  Thread partitioning
                # is skipped - all consumer threads run the full loop.
                for i in T.Parallel(block_K):
                    T.call_extern("void", "atomic_inc", T.address_of(counters[i]))

            # Write counters to output for inspection
            for i in T.Parallel(block_K):
                Counts[by * block_M, i] = counters[i]

    return main


if __name__ == "__main__":
    M, K = 16, 32
    block_M, block_K = 16, 16

    kernel = bug1_kernel(M, K, block_M, block_K)

    A = torch.randn((M, K), device="cuda", dtype=torch.float16)
    Counts = torch.zeros((M, block_K), device="cuda", dtype=torch.int32)

    kernel(A, Counts)
    torch.cuda.synchronize()

    num_stages = T.ceildiv(K, block_K).value
    actual = Counts.cpu()

    print(f"Pipeline stages: {num_stages}")
    print(f"Counters (should all == {num_stages}):")
    print(actual.int())
    # Only first block row (by=0) was written; check that row
    written = actual[0]
    print(f"  first row: {written.int().tolist()}")

    if written.min().item() == num_stages and written.max().item() == num_stages:
        print("PASS: Partitioning correct - each element bumped once per stage.")
    elif written.min().item() > num_stages:
        print("FAIL (BUG PRESENT): counters > expected!")
        print("  Each element was bumped by EVERY consumer thread,")
        print("  proving thread partitioning was skipped.")
    else:
        print(f"UNEXPECTED: range [{written.min().item()}, {written.max().item()}]")
```

Bug 2(producer_consumer_ws.cc): wait_insert_pos was only computed for kTmaProducer statements. SIMT/cp.async producers (e.g. T.Parallel global→shared copies) were skipped, so the consumer read from SIMT-produced shared buffers before the barrier wait — a data race.

Reproduction:
```python
"""
Minimal reproducer for Bug 2 (fixed in 0dba22aa):

  producer_consumer_ws.cc: wait_insert_pos was only computed for
  kTmaProducer statements.  SIMT/cp.async producers were skipped, so
  the consumer read from SIMT-produced shared buffers before the
  barrier wait - a data race.

Trigger conditions:
  1. Warp-specialized pipeline (num_stages > 0, auto-WS via TMA).
  2. At least one SIMT producer writes to a shared buffer.
  3. Consumer reads the SIMT-produced buffer at an EARLIER statement
     than the first TMA-produced buffer read.  (If both are consumed
     in the same gemm/tile-op, the TMA-derived wait position covers
     both and the bug is masked.)

What the generated CUDA looks like WITHOUT the fix:
  // Consumer warp group (T.ws(0)):
  stmt_0:  read B_shared[SIMT-produced]  // NO barrier wait yet!
  mbarrier_wait(...)                      // wait_insert_pos = 1 (from TMA)
  stmt_1:  read A_shared[TMA-produced]

  -> B_shared is read before the producer signalled "done".
  -> Consumer may see stale/partially-written data (data race).

WITH the fix:
  // Consumer warp group (T.ws(0)):
  mbarrier_wait(...)                      // wait_insert_pos = 0 (pulled back)
  stmt_0:  read B_shared[SIMT-produced]  // safe
  stmt_1:  read A_shared[TMA-produced]

Observable effect:
  Each pipeline stage the SIMT producer copies a distinct row of
  B values to B_shared.  The consumer reads B_shared at stmt 0.
  Without the fix, the consumer may read stale/wrong B_shared data
  because it races ahead of the SIMT producer's forward barrier.
"""

import tilelang
from tilelang import language as T
import torch


@tilelang.jit
def bug2_kernel(
    num_stages: int = 4,
    block_N: int = 64,
):
    @T.prim_func
    def main(
        A_in: T.Tensor((num_stages, block_N), "float16"),
        B_in: T.Tensor((num_stages, block_N), "float16"),
        B_out: T.Tensor((num_stages, block_N), "float16"),
        A_out: T.Tensor((num_stages, block_N), "float16"),
    ):
        with T.Kernel(1, threads=128) as _bx:
            A_shared = T.alloc_shared((block_N,), "float16")
            B_shared = T.alloc_shared((block_N,), "float16")

            for ko in T.Pipelined(num_stages, num_stages=2):
                # ---- Producer side (auto-assigned to T.ws(1)) ----
                # SIMT producer: global->shared copy of B_in.
                # Classified as kSimtProducer (writes_shared+reads_global).
                for i in T.Parallel(block_N):
                    B_shared[i] = B_in[ko, i]

                # TMA producer: global->shared copy of A_in.
                # Classified as kTmaProducer (triggers auto-WS on Hopper).
                T.copy(A_in[ko, :], A_shared)

                # ---- Consumer side (auto-assigned to T.ws(0)) ----
                # CRITICAL ORDERING: stmt 0 reads SIMT buffer BEFORE
                # stmt 1 reads TMA buffer.  Without the fix, the
                # compiler places the forward-barrier wait at stmt 1
                # (derived from TMA buffer's first read), so stmt 0
                # executes without waiting — a data race on B_shared.
                #
                # Use a single-element read (not T.Parallel) so the
                # compiler doesn't merge stmt 0 and stmt 1 into one
                # consumer statement.
                #
                # Stmt 0: read SIMT-produced B_shared (barrier-skipped w/o fix).
                B_out[ko, 0] = B_shared[0]

                # Stmt 1: read TMA-produced A_shared (barrier placed here w/o fix).
                for i in T.Parallel(block_N):
                    A_out[ko, i] = A_shared[i]

    return main


if __name__ == '__main__':
    num_stages = 4
    block_N = 64

    kernel = bug2_kernel(num_stages, block_N)

    A_in = torch.arange(num_stages * block_N, device="cuda", dtype=torch.float16).reshape(
        num_stages, block_N
    )
    # B_in: each stage has a distinct first-element value
    B_in = torch.zeros((num_stages, block_N), device="cuda", dtype=torch.float16)
    for k in range(num_stages):
        B_in[k, 0] = float(k * 100)  # stage 0=0, stage 1=100, stage 2=200, ...

    B_out = torch.zeros((num_stages, block_N), device="cuda", dtype=torch.float16)
    A_out = torch.zeros((num_stages, block_N), device="cuda", dtype=torch.float16)

    kernel(A_in, B_in, B_out, A_out)
    torch.cuda.synchronize()

    b_in_cpu = B_in.cpu()
    b_out_cpu = B_out.cpu()
    a_out_cpu = A_out.cpu()
    a_in_cpu = A_in.cpu()

    print("=== Bug 2 reproducer: SIMT producer barrier wait position ===")
    print()
    print("Each stage: SIMT producer copies B to B_shared [global->shared],")
    print("TMA copies A to A_shared.")
    print("Consumer reads B_shared[0] at stmt 0, A_shared at stmt 1.")
    print()

    b_ok = torch.allclose(b_out_cpu[:, 0], b_in_cpu[:, 0])
    a_ok = torch.allclose(a_out_cpu, a_in_cpu)

    print(f"B_out first-elem matches B_in: {b_ok}")
    print(f"A_out matches A_in: {a_ok}")

    if b_ok and a_ok:
        print()
        print("PASS: Both outputs match. Bug is fixed.")
    elif not b_ok:
        print()
        print("FAIL (BUG PRESENT): B_out first element does not match B_in!")
        print("  The consumer read B_shared[0] before the SIMT producer's")
        print("  forward-barrier arrive was waited on, getting a stale value.")
        for k in range(num_stages):
            expected = b_in_cpu[k, 0].item()
            actual = b_out_cpu[k, 0].item()
            print(f"  Stage {k}: got {actual:.0f} expected {expected:.0f}")
    else:
        print()
        print(f"UNEXPECTED: A mismatch (A_out)")
```
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Better detection of non-local memory accesses inside parallel loops to avoid missed non-local writes.
  * Refined producer/consumer synchronization for SIMT and cp.async producers so producer waits are advanced to match consumer reads, reducing stalls.

* **Tests**
  * Added a test validating that producer-side waits occur before the first consumer read in pipelined cp.async scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2166)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->