### PR TITLE
[Release] Fix scikit-build version provider scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,11 @@ wheel.py-api = "cp38"
 cmake.version = ">=3.26.1"
 build-dir = "build"
 
+# Include backend and git info in version
+metadata.version.provider = "version_provider"
+metadata.version.provider-path = "."
+experimental = true
+
 # On Windows, force the Ninja generator so the project's MSVC environment
 # activation path runs (it is guarded on `CMAKE_GENERATOR MATCHES "Ninja"`).
 # Linux and macOS keep the scikit-build-core default (Makefiles).
@@ -109,11 +114,6 @@ if.platform-system = "win32"
 cmake.args = ["-G", "Ninja"]
 
 # editable.rebuild = true
-
-# Include backend and git info in version
-metadata.version.provider = "version_provider"
-metadata.version.provider-path = "."
-experimental = true
 
 # build.verbose = true
 # logging.level = "DEBUG"


### PR DESCRIPTION
## Summary

This PR moves the scikit-build-core dynamic version provider configuration back into the global `[tool.scikit-build]` table.

## Root Cause

The Windows Ninja override was added before the version provider settings in `pyproject.toml`. In TOML, keys after `[[tool.scikit-build.overrides]]` remain scoped to that override table until a new table starts. As a result, `metadata.version.provider`, `metadata.version.provider-path`, and `experimental` only applied on Windows. Linux builds with `dynamic = ["version"]` did not see a global provider and fell back to the default `0.0.0` package version.

## Impact

Linux and macOS wheel builds will now use `version_provider.py` again and produce filenames with the expected backend, date, and git metadata, such as `0.1.9+cuda.dYYYYMMDD.gitxxxxxxx`, instead of `0.0.0`.

The Windows Ninja generator override is preserved unchanged.

## Validation

- Parsed `pyproject.toml` with `tomllib` and verified the provider settings are global while the Windows override only contains `cmake.args = ["-G", "Ninja"]`.
- Ran `TILELANG_BUILD_WHEEL_WITH_DATE=1 python - <<'PY' ...` and verified the provider returns `0.1.9+cuda.d20260508.git69086d8e`.

A full wheel build was not run to avoid triggering a C++/CUDA build for this TOML-only fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration and version metadata handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->