### PR TITLE
[Refactor] Remove body from TIR LetStmt

### DIFF
--- a/docs/compiler_internals/letstmt_inline.md
+++ b/docs/compiler_internals/letstmt_inline.md
@@ -50,9 +50,15 @@ The mutator checks this before dropping the binding:
 bool used_in_buffer_def = used_in_buffer_def_.count(op->var.get());
 
 if (can_inline && !used_in_buffer_def) {
-    return body;  // Inline: remove LetStmt and return body directly
+    return Evaluate(0);  // Inline: drop standalone LetStmt binding
 }
 ```
+
+Since `LetStmt` is now a standalone binding statement, the later statements in
+the enclosing `SeqStmt` are rewritten using the analyzer/substitution state that
+was established when the binding was visited. Dropping the binding therefore
+means replacing that individual `LetStmt` with a no-op, not returning a nested
+body.
 
 ## Example: Why Buffer Definition Variables Are Protected
 

--- a/src/backend/cuda/codegen/codegen_py.cc
+++ b/src/backend/cuda/codegen/codegen_py.cc
@@ -480,7 +480,6 @@ void CodeGenTileLangPY::VisitStmt_(const LetStmtNode *op) {
   std::string value = PrintExpr_(op->value);
   PrintIndent();
   stream << AllocVarID(op->var.get()) << " = " << value << "\n";
-  PrintStmt_(op->body);
 }
 
 void CodeGenTileLangPY::VisitStmt_(const AllocateNode *op) {

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -199,10 +199,12 @@ ForFrame PersistentFor(const Array<PrimExpr> &domain, const PrimExpr &wave_size,
                      /*thread_binding=*/std::nullopt, /*annotations=*/anno,
                      /*step=*/step);
     for (int i = 0; i < vars.size() - 1; ++i) {
-      outer = tvm::tir::LetStmt(vars[i], idxs[i + 1], outer);
+      outer = tvm::tir::SeqStmt::Flatten(
+          tvm::tir::SeqStmt({tvm::tir::LetStmt(vars[i], idxs[i + 1]), outer}));
     }
-    outer = tvm::tir::LetStmt(vars[vars.size() - 1],
-                              idxs[0] * group_size + idxs[vars.size()], outer);
+    outer = tvm::tir::SeqStmt::Flatten(tvm::tir::SeqStmt(
+        {tvm::tir::LetStmt(vars[vars.size() - 1], idxs[0] * group_size + idxs[vars.size()]),
+         outer}));
     return outer;
   };
 

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -203,7 +203,8 @@ ForFrame PersistentFor(const Array<PrimExpr> &domain, const PrimExpr &wave_size,
           tvm::tir::SeqStmt({tvm::tir::LetStmt(vars[i], idxs[i + 1]), outer}));
     }
     outer = tvm::tir::SeqStmt::Flatten(tvm::tir::SeqStmt(
-        {tvm::tir::LetStmt(vars[vars.size() - 1], idxs[0] * group_size + idxs[vars.size()]),
+        {tvm::tir::LetStmt(vars[vars.size() - 1],
+                           idxs[0] * group_size + idxs[vars.size()]),
          outer}));
     return outer;
   };

--- a/src/transform/annotate_warp_group_reg_alloc.cc
+++ b/src/transform/annotate_warp_group_reg_alloc.cc
@@ -60,15 +60,6 @@ Stmt RewriteWarpSpecializationBody(const Stmt &stmt, F &&rewrite_if,
     return AttrStmt(attr->node, attr->attr_key, attr->value, new_body);
   }
 
-  if (const auto *let_node = stmt.as<LetStmtNode>()) {
-    Stmt new_body =
-        RewriteWarpSpecializationBody(let_node->body, rewrite_if, rewrote);
-    if (new_body.same_as(let_node->body)) {
-      return stmt;
-    }
-    return LetStmt(let_node->var, let_node->value, new_body);
-  }
-
   if (const auto *realize = stmt.as<BlockRealizeNode>()) {
     const Block &block = realize->block;
     Stmt new_body =

--- a/src/transform/arg_binder.cc
+++ b/src/transform/arg_binder.cc
@@ -127,7 +127,7 @@ bool ArgBinder::BindNullable(const PrimExpr &arg, const PrimExpr &value,
     defs_.emplace_back(v_arg);
     if (with_lets) {
       (*def_map_)[v] = value;
-      init_nest_.emplace_back(LetStmt(v_arg, value, Evaluate(0)));
+      init_nest_.emplace_back(LetStmt(v_arg, value));
     } else {
       (*def_map_)[v] = value;
     }
@@ -190,7 +190,7 @@ bool ArgBinder::Bind_(const PrimExpr &arg, const PrimExpr &value,
       defs_.emplace_back(v_arg);
       if (with_lets) {
         (*def_map_)[v] = arg;
-        init_nest_.emplace_back(LetStmt(v_arg, value, Evaluate(0)));
+        init_nest_.emplace_back(LetStmt(v_arg, value));
       } else {
         (*def_map_)[v] = value;
       }
@@ -401,7 +401,7 @@ void ArgBinder::BindDLTensors(
     Var is_null_var(arg_name + "_is_null", DataType::Bool());
     init_nest_.emplace_back(
         LetStmt(is_null_var,
-                Call(DataType::Bool(), builtin::isnullptr(), {handle}), nop));
+                Call(DataType::Bool(), builtin::isnullptr(), {handle})));
     const PrimExpr &is_null = is_used ? const_false() : is_null_var;
 
     is_null_map[arg_name] = is_null_var;
@@ -436,8 +436,7 @@ void ArgBinder::BindDLTensors(
                 tvm::if_then_else(
                     Not(is_null),
                     TVMArrayGet(DataType::Handle(), handle, builtin::kArrShape),
-                    make_zero(DataType::Handle())),
-                nop));
+                    make_zero(DataType::Handle()))));
     init_nest_.emplace_back(DeclBuffer(buf_shape, nop));
 
     // Save for later use in shape binding
@@ -799,7 +798,7 @@ void ArgBinder::BindDLTensors(
               defs_.emplace_back(v_arg);
               (*def_map_)[v] = cascaded_value;
               init_nest_.emplace_back(
-                  LetStmt(v_arg, cascaded_value, Evaluate(0)));
+                  LetStmt(v_arg, cascaded_value));
             } else {
               // Single source or no special handling needed, use nullable
               // binding. When the only source is NULL, bind m to 0 safely.
@@ -843,8 +842,7 @@ void ArgBinder::BindDLTensors(
                     tvm::if_then_else(Not(is_null),
                                       TVMArrayGet(DataType::Handle(), handle,
                                                   builtin::kArrStrides),
-                                      make_zero(DataType::Handle())),
-                    nop));
+                                      make_zero(DataType::Handle()))));
         init_nest_.emplace_back(DeclBuffer(buf_strides, nop));
         PrimExpr v_strides_is_null =
             Call(DataType::Bool(1), builtin::isnullptr(), {buf_strides->data});
@@ -890,8 +888,7 @@ void ArgBinder::BindDLTensors(
                   tvm::if_then_else(Not(is_null),
                                     TVMArrayGet(DataType::Handle(), handle,
                                                 builtin::kArrStrides),
-                                    make_zero(DataType::Handle())),
-                  nop));
+                                    make_zero(DataType::Handle()))));
       init_nest_.emplace_back(DeclBuffer(buf_strides, nop));
       PrimExpr v_strides_is_null =
           Call(DataType::Bool(1), builtin::isnullptr(), {buf_strides->data});

--- a/src/transform/arg_binder.cc
+++ b/src/transform/arg_binder.cc
@@ -399,9 +399,8 @@ void ArgBinder::BindDLTensors(
     std::string arg_name = func_name + "." + buffer->data->name_hint;
 
     Var is_null_var(arg_name + "_is_null", DataType::Bool());
-    init_nest_.emplace_back(
-        LetStmt(is_null_var,
-                Call(DataType::Bool(), builtin::isnullptr(), {handle})));
+    init_nest_.emplace_back(LetStmt(
+        is_null_var, Call(DataType::Bool(), builtin::isnullptr(), {handle})));
     const PrimExpr &is_null = is_used ? const_false() : is_null_var;
 
     is_null_map[arg_name] = is_null_var;
@@ -797,8 +796,7 @@ void ArgBinder::BindDLTensors(
               Var v_arg = ffi::GetRef<Var>(v);
               defs_.emplace_back(v_arg);
               (*def_map_)[v] = cascaded_value;
-              init_nest_.emplace_back(
-                  LetStmt(v_arg, cascaded_value));
+              init_nest_.emplace_back(LetStmt(v_arg, cascaded_value));
             } else {
               // Single source or no special handling needed, use nullable
               // binding. When the only source is NULL, bind m to 0 safely.

--- a/src/transform/common/constr_visitor.h
+++ b/src/transform/common/constr_visitor.h
@@ -183,8 +183,19 @@ public:
     }
   }
   void VisitStmt_(const tir::LetStmtNode *op) override {
-    auto guard = MakeGuard(op->var, op->value);
-    Base::VisitStmt_(op);
+    Base::VisitExpr(op->value);
+  }
+  void VisitStmt_(const tir::SeqStmtNode *op) override {
+    size_t old_size = constr_stack_.size();
+    for (const tir::Stmt &stmt : op->seq) {
+      if (const auto *let = stmt.as<tir::LetStmtNode>()) {
+        Base::VisitExpr(let->value);
+        constr_stack_.push_back(Constr(let->var, let->value));
+      } else {
+        Base::VisitStmt(stmt);
+      }
+    }
+    constr_stack_.resize(old_size);
   }
   void VisitStmt_(const tir::AttrStmtNode *op) override {
     if (op->attr_key == tir::attr::tilelang_assume) {

--- a/src/transform/common/loop_vectorization_utils.h
+++ b/src/transform/common/loop_vectorization_utils.h
@@ -629,14 +629,13 @@ public:
         op->value.dtype().get_lanes_or_vscale_factor()) {
       Var new_var(op->var->name_hint, value.dtype());
       let_binding_[op->var] = new_var;
-      return LetStmt(new_var, value, this->VisitStmt(op->body));
+      return LetStmt(new_var, value, op->span);
     } else {
       let_binding_[op->var] = op->var;
-      Stmt body = this->VisitStmt(op->body);
-      if (value.same_as(op->value) && body.same_as(op->body)) {
+      if (value.same_as(op->value)) {
         return tvm::ffi::GetRef<Stmt>(op);
       } else {
-        return LetStmt(op->var, value, body);
+        return LetStmt(op->var, value, op->span);
       }
     }
   }

--- a/src/transform/frontend_legalize.cc
+++ b/src/transform/frontend_legalize.cc
@@ -27,6 +27,8 @@
 #include <tvm/tir/stmt_functor.h>
 #include <tvm/tir/transform.h>
 
+#include <vector>
+
 #include "arith/ir_mutator_with_analyzer.h"
 
 namespace tvm {
@@ -67,8 +69,41 @@ private:
   }
 
   Stmt VisitStmt_(const LetStmtNode *node) final {
-    let_bindings_[node->var.get()] = node->value;
-    return arith::IRMutatorWithAnalyzer::VisitStmt(node->body);
+    VisitExpr(node->value);
+    return Evaluate(0);
+  }
+
+  Stmt VisitStmt_(const SeqStmtNode *node) final {
+    struct SavedBinding {
+      const VarNode *var;
+      bool had_prev;
+      PrimExpr prev_value;
+    };
+
+    std::vector<SavedBinding> saved_bindings;
+    ffi::Array<Stmt> seq;
+    for (const Stmt &stmt : node->seq) {
+      if (const auto *let = stmt.as<LetStmtNode>()) {
+        PrimExpr value = VisitExpr(let->value);
+        auto it = let_bindings_.find(let->var.get());
+        SavedBinding saved{let->var.get(), it != let_bindings_.end(), PrimExpr()};
+        if (saved.had_prev) {
+          saved.prev_value = it->second;
+        }
+        saved_bindings.push_back(saved);
+        let_bindings_[let->var.get()] = value;
+      } else {
+        seq.push_back(VisitStmt(stmt));
+      }
+    }
+    for (auto it = saved_bindings.rbegin(); it != saved_bindings.rend(); ++it) {
+      if (it->had_prev) {
+        let_bindings_[it->var] = it->prev_value;
+      } else {
+        let_bindings_.erase(it->var);
+      }
+    }
+    return SeqStmt::Flatten(seq);
   }
 
   PrimExpr VisitExpr_(const LetNode *node) final {

--- a/src/transform/frontend_legalize.cc
+++ b/src/transform/frontend_legalize.cc
@@ -86,7 +86,8 @@ private:
       if (const auto *let = stmt.as<LetStmtNode>()) {
         PrimExpr value = VisitExpr(let->value);
         auto it = let_bindings_.find(let->var.get());
-        SavedBinding saved{let->var.get(), it != let_bindings_.end(), PrimExpr()};
+        SavedBinding saved{let->var.get(), it != let_bindings_.end(),
+                           PrimExpr()};
         if (saved.had_prev) {
           saved.prev_value = it->second;
         }

--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -1020,8 +1020,8 @@ private:
         : rewriter_(rewriter) {}
 
     DeterministicNoWaitCommitEffect Analyze(const Stmt &stmt) const {
-      if (const auto *let = stmt.as<LetStmtNode>()) {
-        return Analyze(let->body);
+      if (stmt.as<LetStmtNode>()) {
+        return {};
       }
       if (const auto *attr = stmt.as<AttrStmtNode>()) {
         return AnalyzeAttr(attr);
@@ -1121,7 +1121,7 @@ private:
       const auto &lw = *it;
       PrimExpr substituted = Substitute(
           lw.value, {{pipeline_loop_->loop_var, normalized_access_index}});
-      stmt = LetStmt(lw.var, substituted, stmt);
+      stmt = SeqStmt::Flatten(SeqStmt({LetStmt(lw.var, substituted), stmt}));
     }
     return stmt;
   }
@@ -1233,8 +1233,8 @@ private:
 
   HeadAsyncSyncInfo AnalyzeHeadAsyncSync(const Stmt &stmt,
                                          HeadSeqMode seq_mode) const {
-    if (const auto *let = stmt.as<LetStmtNode>()) {
-      return AnalyzeHeadAsyncSync(let->body, seq_mode);
+    if (stmt.as<LetStmtNode>()) {
+      return {};
     }
     if (const auto *attr = stmt.as<AttrStmtNode>()) {
       if (IsAsyncWaitQueueScope(attr)) {
@@ -1372,12 +1372,7 @@ private:
         return MakeStaticAsyncWaitStmtLike(attr, new_wait_n);
       }
     }
-    if (const auto *let = stmt.as<LetStmtNode>()) {
-      Stmt new_body =
-          RewriteWaitStaticInSimpleWrapper(let->body, new_wait_n, changed);
-      if (*changed) {
-        return LetStmt(let->var, let->value, new_body, let->span);
-      }
+    if (stmt.as<LetStmtNode>()) {
       return stmt;
     }
     if (const auto *attr = stmt.as<AttrStmtNode>()) {
@@ -1435,8 +1430,8 @@ private:
   }
 
   std::optional<int> TryGetFirstStaticWaitCount(const Stmt &stmt) const {
-    if (const auto *let = stmt.as<LetStmtNode>()) {
-      return TryGetFirstStaticWaitCount(let->body);
+    if (stmt.as<LetStmtNode>()) {
+      return std::nullopt;
     }
     if (const auto *attr = stmt.as<AttrStmtNode>()) {
       HeadAsyncSyncInfo info =
@@ -1475,12 +1470,7 @@ private:
 
   Stmt RewriteHeadStaticWaitInWrapper(const Stmt &stmt, int new_wait_n,
                                       bool *changed) const {
-    if (const auto *let = stmt.as<LetStmtNode>()) {
-      Stmt new_body =
-          RewriteHeadStaticWaitInWrapper(let->body, new_wait_n, changed);
-      if (*changed) {
-        return LetStmt(let->var, let->value, new_body, let->span);
-      }
+    if (stmt.as<LetStmtNode>()) {
       return stmt;
     }
     if (const auto *attr = stmt.as<AttrStmtNode>()) {
@@ -1536,12 +1526,7 @@ private:
 
   Stmt RewriteFirstStaticWaitInWrapper(const Stmt &stmt, int new_wait_n,
                                        bool *changed) const {
-    if (const auto *let = stmt.as<LetStmtNode>()) {
-      Stmt new_body =
-          RewriteFirstStaticWaitInWrapper(let->body, new_wait_n, changed);
-      if (*changed) {
-        return LetStmt(let->var, let->value, new_body, let->span);
-      }
+    if (stmt.as<LetStmtNode>()) {
       return stmt;
     }
     if (const auto *attr = stmt.as<AttrStmtNode>()) {
@@ -1693,12 +1678,7 @@ private:
       *changed = !relaxed.same_as(stmt);
       return relaxed;
     }
-    if (const auto *let = stmt.as<LetStmtNode>()) {
-      Stmt new_body =
-          RelaxLoopWaitsInSimpleWrapper(let->body, pre_outstanding_lb, changed);
-      if (*changed) {
-        return LetStmt(let->var, let->value, new_body, let->span);
-      }
+    if (stmt.as<LetStmtNode>()) {
       return stmt;
     }
     if (const auto *attr = stmt.as<AttrStmtNode>()) {
@@ -2984,39 +2964,9 @@ private:
           current = if_then_else->then_case;
           continue;
         }
-        if (const auto *let_stmt = current.as<LetStmtNode>()) {
-          // If this Let value uses the pipeline loop var OR any variable
-          // defined by a previously recorded loop-var-dependent LetStmt,
-          // record it and push inside each rewritten block later so the
-          // loop var can be substituted with the correct per-iteration index.
-          // Otherwise, keep it as a normal wrapper.
-          // This handles transitive dependencies like:
-          //   id = ids[i]      # depends on loop var
-          //   id2 = ids2[id]   # depends on id, so transitively on loop var
-          std::unordered_set<const VarNode *> dependent_vars;
-          dependent_vars.insert(op->loop_var.get());
-          for (const auto &lw : loop_var_let_wrappers) {
-            dependent_vars.insert(lw.var.get());
-          }
-          bool depends_on_loop =
-              UsesVar(let_stmt->value, [&dependent_vars](const VarNode *vn) {
-                return dependent_vars.count(vn) > 0;
-              });
-          if (depends_on_loop) {
-            loop_var_let_wrappers.push_back({let_stmt->var, let_stmt->value});
-          } else {
-            Var var = let_stmt->var;
-            PrimExpr value = let_stmt->value;
-            Span span = let_stmt->span;
-            rewrap_fns.emplace_back([var = std::move(var),
-                                     value = std::move(value),
-                                     span](Stmt body) -> Stmt {
-              return LetStmt(var, value, body, span);
-            });
-          }
-          current = let_stmt->body;
-          continue;
-        }
+        ICHECK(!current.as<LetStmtNode>())
+            << "LetStmt no longer wraps a body; expected leading let bindings "
+            << "to appear in the surrounding SeqStmt";
         if (const auto *attr = current.as<AttrStmtNode>()) {
           append_attr_wrapper(attr);
           current = attr->body;

--- a/src/transform/loop_unswitching.cc
+++ b/src/transform/loop_unswitching.cc
@@ -316,7 +316,7 @@ bool IsSideEffectFreeStmt(const Stmt &stmt) {
     if (SideEffect(op->value) > CallEffectKind::kReadState) {
       return false;
     }
-    return IsSideEffectFreeStmt(op->body);
+    return true;
   }
 
   if (const auto *op = stmt.as<IfThenElseNode>()) {
@@ -428,7 +428,7 @@ public:
     // Remove LetStmts for hoisted variables (they are now bound outside the
     // loop)
     if (hoisted_vars.count(op->var.get())) {
-      return VisitStmt(op->body);
+      return Evaluate(0);
     }
     return StmtExprMutator::VisitStmt_(op);
   }
@@ -491,8 +491,6 @@ public:
     // conditions using such variables should not be hoisted.
     let_bindings_[op->var.get()] = op->value;
     StmtVisitor::VisitStmt_(op);
-    // Remove the binding when leaving scope
-    let_bindings_.erase(op->var.get());
   }
 
   void VisitStmt_(const IfThenElseNode *op) final {
@@ -619,7 +617,7 @@ public:
     // outermost)
     for (auto it = finder.hoisted_let_bindings.rbegin();
          it != finder.hoisted_let_bindings.rend(); ++it) {
-      result = LetStmt(it->first, it->second, result);
+      result = SeqStmt::Flatten(SeqStmt({LetStmt(it->first, it->second), result}));
     }
 
     if (pushed_thread_idx) {

--- a/src/transform/loop_unswitching.cc
+++ b/src/transform/loop_unswitching.cc
@@ -617,7 +617,8 @@ public:
     // outermost)
     for (auto it = finder.hoisted_let_bindings.rbegin();
          it != finder.hoisted_let_bindings.rend(); ++it) {
-      result = SeqStmt::Flatten(SeqStmt({LetStmt(it->first, it->second), result}));
+      result =
+          SeqStmt::Flatten(SeqStmt({LetStmt(it->first, it->second), result}));
     }
 
     if (pushed_thread_idx) {

--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -828,14 +828,11 @@ private:
       // Allow override to handle duplicated loop bodies in pipelined loops
       analyzer_->Bind(op->var, value, /*allow_override=*/true);
     }
-    // Continue visiting the body to collect vectorization info
-    Stmt body = this->VisitStmt(op->body);
-    if (value.same_as(op->value) && body.same_as(op->body)) {
+    if (value.same_as(op->value)) {
       return ffi::GetRef<Stmt>(op);
     } else {
       auto n = this->CopyOnWrite(op);
       n->value = std::move(value);
-      n->body = std::move(body);
       return Stmt(n);
     }
   }

--- a/src/transform/lower_device_storage_access_info.cc
+++ b/src/transform/lower_device_storage_access_info.cc
@@ -58,7 +58,8 @@ public:
       Stmt stmt = StmtExprMutator::VisitStmt_(op);
       op = stmt.as<AllocateNode>();
       if (info->head_address.defined()) {
-        return SeqStmt::Flatten(SeqStmt({LetStmt(op->buffer_var, info->head_address), op->body}));
+        return SeqStmt::Flatten(
+            SeqStmt({LetStmt(op->buffer_var, info->head_address), op->body}));
       } else {
         return op->body;
       }

--- a/src/transform/lower_device_storage_access_info.cc
+++ b/src/transform/lower_device_storage_access_info.cc
@@ -58,7 +58,7 @@ public:
       Stmt stmt = StmtExprMutator::VisitStmt_(op);
       op = stmt.as<AllocateNode>();
       if (info->head_address.defined()) {
-        return LetStmt(op->buffer_var, info->head_address, op->body);
+        return SeqStmt::Flatten(SeqStmt({LetStmt(op->buffer_var, info->head_address), op->body}));
       } else {
         return op->body;
       }

--- a/src/transform/lower_hopper_intrin.cc
+++ b/src/transform/lower_hopper_intrin.cc
@@ -222,7 +222,8 @@ private:
                            {StringImm("tvm_ffi_any"), 16});
     Call init_desc =
         Call(DataType::Handle(), builtin::tvm_call_packed(), init_desc_args);
-    return SeqStmt::Flatten(SeqStmt({LetStmt(var, alloc_desc), Evaluate(init_desc)}));
+    return SeqStmt::Flatten(
+        SeqStmt({LetStmt(var, alloc_desc), Evaluate(init_desc)}));
   }
 
   Array<Stmt> prefetch_calls_;

--- a/src/transform/lower_hopper_intrin.cc
+++ b/src/transform/lower_hopper_intrin.cc
@@ -222,7 +222,7 @@ private:
                            {StringImm("tvm_ffi_any"), 16});
     Call init_desc =
         Call(DataType::Handle(), builtin::tvm_call_packed(), init_desc_args);
-    return LetStmt(var, alloc_desc, Evaluate(init_desc));
+    return SeqStmt::Flatten(SeqStmt({LetStmt(var, alloc_desc), Evaluate(init_desc)}));
   }
 
   Array<Stmt> prefetch_calls_;

--- a/src/transform/lower_ptx_async_copy.cc
+++ b/src/transform/lower_ptx_async_copy.cc
@@ -628,8 +628,8 @@ private:
       out.is_pure_copy_region = false;
       return out;
     }
-    if (const auto *let = stmt.as<LetStmtNode>()) {
-      return AnalyzeCopyRegion(let->body);
+    if (stmt.as<LetStmtNode>()) {
+      return out;
     }
     if (const auto *attr = stmt.as<AttrStmtNode>()) {
       return AnalyzeCopyRegion(attr->body);

--- a/src/transform/lower_shared_tmem.cc
+++ b/src/transform/lower_shared_tmem.cc
@@ -39,8 +39,6 @@ static std::pair<VarSet, bool> CollectFallthroughDeallocs(const Stmt &stmt) {
     return {{}, true};
 
   // Unwrap transparent wrapper nodes
-  if (auto *n = stmt.as<LetStmtNode>())
-    return CollectFallthroughDeallocs(n->body);
   if (auto *n = stmt.as<AttrStmtNode>())
     return CollectFallthroughDeallocs(n->body);
   if (auto *n = stmt.as<BlockNode>())

--- a/src/transform/lower_thread_allreduce.cc
+++ b/src/transform/lower_thread_allreduce.cc
@@ -770,7 +770,7 @@ private:
 
         Stmt body = SeqStmt::Flatten(in_let_statement);
         for (size_t i = 0; i < size; i++) {
-          body = LetStmt(in_warp_local_vars[i], loads[i], body);
+          body = SeqStmt::Flatten(SeqStmt({LetStmt(in_warp_local_vars[i], loads[i]), body}));
         }
         in_warp_seq.push_back(body);
       }

--- a/src/transform/lower_thread_allreduce.cc
+++ b/src/transform/lower_thread_allreduce.cc
@@ -770,7 +770,8 @@ private:
 
         Stmt body = SeqStmt::Flatten(in_let_statement);
         for (size_t i = 0; i < size; i++) {
-          body = SeqStmt::Flatten(SeqStmt({LetStmt(in_warp_local_vars[i], loads[i]), body}));
+          body = SeqStmt::Flatten(
+              SeqStmt({LetStmt(in_warp_local_vars[i], loads[i]), body}));
         }
         in_warp_seq.push_back(body);
       }

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -979,24 +979,17 @@ private:
 
   Stmt VisitStmt_(const LetStmtNode *op) final {
     PrimExpr value = this->VisitExpr(op->value);
-    bool recorded = false;
     if (value->IsInstance<BufferLoadNode>()) {
       let_bindings_[op->var] = value;
-      recorded = true;
     }
     if (SideEffect(value) <= CallEffectKind::kPure) {
       analyzer_->Bind(op->var, value);
     }
-    Stmt body = this->VisitStmt(op->body);
-    if (recorded) {
-      let_bindings_.erase(op->var);
-    }
-    if (value.same_as(op->value) && body.same_as(op->body)) {
+    if (value.same_as(op->value)) {
       return tvm::ffi::GetRef<Stmt>(op);
     } else {
       auto n = this->CopyOnWrite(op);
       n->value = value;
-      n->body = body;
       return Stmt(n);
     }
   }

--- a/src/transform/make_packed_api.cc
+++ b/src/transform/make_packed_api.cc
@@ -421,8 +421,7 @@ PrimFunc MakePackedAPI(PrimFunc func) {
         type_index,
         tir::Call(DataType::Int(32), builtin::tvm_struct_get(),
                   {v_packed_args, IntImm(DataType::Int(32), i),
-                   IntImm(DataType::Int(32), builtin::kTVMFFIAnyTypeIndex)}),
-        nop));
+                   IntImm(DataType::Int(32), builtin::kTVMFFIAnyTypeIndex)})));
     DataType dtype = param.dtype();
     if (dtype.is_handle()) {
       std::ostringstream msg;

--- a/src/transform/merge_shared_memory_allocations.cc
+++ b/src/transform/merge_shared_memory_allocations.cc
@@ -343,7 +343,6 @@ private:
     }
     if (const auto *let_node = stmt.as<LetStmtNode>()) {
       this->VisitExpr(let_node->value);
-      VisitWarpSpecializationBody(let_node->body);
       return;
     }
     StmtExprVisitor::VisitStmt(stmt);

--- a/src/transform/multi_version_buffer_rewriter.cc
+++ b/src/transform/multi_version_buffer_rewriter.cc
@@ -197,7 +197,10 @@ public:
   }
 
   void VisitStmt_(const ForNode *op) final { HandleBodyStmt(op); }
-  void VisitStmt_(const LetStmtNode *op) final { HandleBodyStmt(op); }
+  void VisitStmt_(const LetStmtNode *op) final {
+    StmtVisitor::VisitStmt_(op);
+    SetRole(op, Role::kBoth);
+  }
   void VisitStmt_(const AttrStmtNode *op) final { HandleBodyStmt(op); }
   void VisitStmt_(const AssertStmtNode *op) final { HandleBodyStmt(op); }
   void VisitStmt_(const BlockNode *op) final { HandleBodyStmt(op); }
@@ -242,8 +245,7 @@ private:
         }
         return;
       }
-      if (const auto *let = stmt.as<LetStmtNode>()) {
-        collect_stmts(let->body);
+      if (stmt.as<LetStmtNode>()) {
         return;
       }
       if (const auto *attr = stmt.as<AttrStmtNode>()) {

--- a/src/transform/pipeline_planning.cc
+++ b/src/transform/pipeline_planning.cc
@@ -1048,13 +1048,9 @@ private:
             current = if_then_else->then_case;
             continue;
           }
-          if (const auto *let_stmt = current.as<LetStmtNode>()) {
-            current = let_stmt->body;
-            continue;
-          }
           LOG(FATAL) << "Pipeline_Planning: Can't handle the body of the loop "
                      << "because it is not a SeqStmt, IfThenElse without else, "
-                     << "or LetStmt wrapping them, but got "
+                     << "or a BlockRealize containing them, but got "
                      << current->GetTypeKey();
         }
       }
@@ -1119,13 +1115,9 @@ private:
           current = if_then_else->then_case;
           continue;
         }
-        if (const auto *let_stmt = current.as<LetStmtNode>()) {
-          current = let_stmt->body;
-          continue;
-        }
         LOG(FATAL) << "Pipeline_Planning: Can't handle the body of the loop "
                    << "because it is not a SeqStmt, IfThenElse without else, "
-                   << "or LetStmt wrapping them, but got "
+                   << "or a BlockRealize containing them, but got "
                    << current->GetTypeKey();
       }
     }
@@ -2055,7 +2047,7 @@ private:
     // Reconstruct the loop body with the flattened SeqStmt so that
     // InjectSoftwarePipeline sees the correct number of pipeline stages.
     Stmt new_body_seq = SeqStmt(flat_stmts);
-    // Rebuild any wrapper layers (IfThenElse, LetStmt, BlockRealize)
+    // Rebuild any wrapper layers (IfThenElse, BlockRealize)
     // between the loop body and the SeqStmt.
     Stmt new_loop_body;
     if (const auto *realize = loop->body.as<BlockRealizeNode>()) {
@@ -2091,7 +2083,7 @@ private:
   }
 
   /*!
-   * \brief Rebuild the chain of wrapper statements (IfThenElse, LetStmt)
+   * \brief Rebuild the chain of wrapper statements (IfThenElse)
    *        between the loop body root and the inner SeqStmt, replacing
    *        the old SeqStmt with the new (flattened) one.
    */
@@ -2105,10 +2097,6 @@ private:
           if_node->condition,
           RebuildBodyWrapper(if_node->then_case, old_seq, new_seq),
           if_node->else_case);
-    }
-    if (const auto *let_node = current.as<LetStmtNode>()) {
-      return LetStmt(let_node->var, let_node->value,
-                     RebuildBodyWrapper(let_node->body, old_seq, new_seq));
     }
     LOG(FATAL) << "RebuildBodyWrapper: unexpected node type "
                << current->GetTypeKey();

--- a/src/transform/producer_consumer_ws.cc
+++ b/src/transform/producer_consumer_ws.cc
@@ -337,8 +337,18 @@ static const CallNode *GetEvaluateCallInSimpleWrapper(const Stmt &stmt) {
   if (const auto *attr = stmt.as<AttrStmtNode>()) {
     return GetEvaluateCallInSimpleWrapper(attr->body);
   }
-  if (const auto *let = stmt.as<LetStmtNode>()) {
-    return GetEvaluateCallInSimpleWrapper(let->body);
+  if (const auto *seq = stmt.as<SeqStmtNode>()) {
+    ffi::Optional<Stmt> non_let_stmt;
+    for (const Stmt &child : seq->seq) {
+      if (child.as<LetStmtNode>()) {
+        continue;
+      }
+      if (non_let_stmt.defined()) {
+        return nullptr;
+      }
+      non_let_stmt = child;
+    }
+    return non_let_stmt.defined() ? GetEvaluateCallInSimpleWrapper(non_let_stmt.value()) : nullptr;
   }
   if (const auto *block = stmt.as<BlockNode>()) {
     return GetEvaluateCallInSimpleWrapper(block->body);
@@ -391,15 +401,13 @@ private:
       : buffer_data_to_buffer_(buffer_map) {}
 
   static bool IsBranchPrivateBuffer(const Buffer &buffer) {
-    return IsFragmentBuffer(buffer) || IsLocalBuffer(buffer, true);
+    return IsFragmentBuffer(buffer) || IsLocalBuffer(buffer);
   }
 
   void VisitStmt_(const LetStmtNode *op) final {
     VisitExpr(op->value);
     summary_.def_vars.insert(op->var);
     bound_vars_.insert(op->var);
-    VisitStmt(op->body);
-    bound_vars_.erase(op->var);
   }
 
   void VisitStmt_(const ForNode *op) final {
@@ -534,6 +542,10 @@ ClassifyPreludeStmt(const Stmt &stmt, const BufferDataToBufferMap &buffer_map,
                     const LocalLiveSet &consumer_live_seed) {
   LocalAccessSummary summary = LocalAccessCollector::Collect(stmt, buffer_map);
   if (!summary.HasTrackedDefs()) {
+    return PreludeStmtPlacement::kKeepSharedPrelude;
+  }
+  if (!summary.def_vars.empty() && summary.read_buffers.empty() &&
+      summary.write_buffers.empty()) {
     return PreludeStmtPlacement::kKeepSharedPrelude;
   }
 
@@ -986,9 +998,8 @@ static bool CollectPreludeStmtsToPipelineLoop(const Stmt &stmt,
     }
     return false;
   }
-  if (const auto *let = stmt.as<LetStmtNode>()) {
-    return CollectPreludeStmtsToPipelineLoop(let->body, pipeline_loop,
-                                             prelude_stmts);
+  if (stmt.as<LetStmtNode>()) {
+    return false;
   }
   if (const auto *realize = stmt.as<BlockRealizeNode>()) {
     return CollectPreludeStmtsToPipelineLoop(realize->block->body,
@@ -1144,11 +1155,22 @@ private:
     if (auto *realize = loop_body.as<BlockRealizeNode>()) {
       loop_body = realize->block->body;
     }
-    // Unwrap LetStmt chain that dominates the whole loop body.
+    // Peel leading LetStmt bindings that dominate the whole loop body.
     std::vector<std::pair<Var, PrimExpr>> outer_let_bindings;
-    while (const auto *let = loop_body.as<LetStmtNode>()) {
-      outer_let_bindings.emplace_back(let->var, let->value);
-      loop_body = let->body;
+    if (const auto *seq = loop_body.as<SeqStmtNode>()) {
+      Array<Stmt> rest;
+      bool peeling_lets = true;
+      for (const Stmt &stmt : seq->seq) {
+        if (peeling_lets) {
+          if (const auto *let = stmt.as<LetStmtNode>()) {
+            outer_let_bindings.emplace_back(let->var, let->value);
+            continue;
+          }
+        }
+        peeling_lets = false;
+        rest.push_back(stmt);
+      }
+      loop_body = SeqStmt::Flatten(rest);
     }
     // Unwrap a single IfThenElse wrapper (no else branch) so that
     // TMA producers inside conditional loop bodies can be classified.
@@ -1158,12 +1180,23 @@ private:
     std::vector<std::pair<Var, PrimExpr>> inner_let_bindings;
     if (const auto *if_stmt = loop_body.as<IfThenElseNode>()) {
       if (!if_stmt->else_case.defined()) {
-        // Peel LetStmt chain from inside the conditional body. These
+        // Peel leading LetStmt bindings from inside the conditional body. These
         // bindings must remain inside the guarded region.
         Stmt inner = if_stmt->then_case;
-        while (const auto *let = inner.as<LetStmtNode>()) {
-          inner_let_bindings.emplace_back(let->var, let->value);
-          inner = let->body;
+        if (const auto *seq = inner.as<SeqStmtNode>()) {
+          Array<Stmt> rest;
+          bool peeling_lets = true;
+          for (const Stmt &stmt : seq->seq) {
+            if (peeling_lets) {
+              if (const auto *let = stmt.as<LetStmtNode>()) {
+                inner_let_bindings.emplace_back(let->var, let->value);
+                continue;
+              }
+            }
+            peeling_lets = false;
+            rest.push_back(stmt);
+          }
+          inner = SeqStmt::Flatten(rest);
         }
         loop_body_condition = if_stmt->condition;
         loop_body = inner;
@@ -1635,7 +1668,7 @@ private:
         [&](Stmt body,
             const std::vector<std::pair<Var, PrimExpr>> &bindings) -> Stmt {
       for (auto it = bindings.rbegin(); it != bindings.rend(); ++it) {
-        body = LetStmt(it->first, it->second, body);
+        body = SeqStmt::Flatten(SeqStmt({LetStmt(it->first, it->second), body}));
       }
       return body;
     };
@@ -1891,8 +1924,8 @@ private:
         }
       }
     }
-    if (auto *let = stmt.as<LetStmtNode>()) {
-      return FindPipelineLoop(let->body);
+    if (stmt.as<LetStmtNode>()) {
+      return nullptr;
     }
     if (auto *realize = stmt.as<BlockRealizeNode>()) {
       return FindPipelineLoop(realize->block->body);
@@ -2095,6 +2128,10 @@ private:
       {
         LocalLiveSet producer_live = producer_prelude_live_seed_;
         LocalLiveSet consumer_live = consumer_prelude_live_seed_;
+        for (int i = loop_idx + 1; i < static_cast<int>(seq->seq.size()); ++i) {
+          consumer_live.AddUses(LocalAccessCollector::Collect(
+              seq->seq[i], buffer_data_to_buffer_));
+        }
         for (int i = loop_idx - 1; i >= 0; --i) {
           LocalAccessSummary summary = LocalAccessCollector::Collect(
               seq->seq[i], buffer_data_to_buffer_);
@@ -2161,12 +2198,7 @@ private:
             Evaluate(let->value), buffer_data_to_buffer_);
         shared_prelude_live_seed_.AddUses(val_summary);
       }
-      ReplaceResult result = ReplacePipelineLoopInStmt(
-          let->body, pipeline_loop, ws_body, consumer_extent);
-      if (!result.found) {
-        return {stmt, false};
-      }
-      return {LetStmt(let->var, let->value, result.stmt), true};
+      return {stmt, false};
     }
     if (auto *realize = stmt.as<BlockRealizeNode>()) {
       ReplaceResult result = ReplacePipelineLoopInStmt(

--- a/src/transform/producer_consumer_ws.cc
+++ b/src/transform/producer_consumer_ws.cc
@@ -348,7 +348,9 @@ static const CallNode *GetEvaluateCallInSimpleWrapper(const Stmt &stmt) {
       }
       non_let_stmt = child;
     }
-    return non_let_stmt.defined() ? GetEvaluateCallInSimpleWrapper(non_let_stmt.value()) : nullptr;
+    return non_let_stmt.defined()
+               ? GetEvaluateCallInSimpleWrapper(non_let_stmt.value())
+               : nullptr;
   }
   if (const auto *block = stmt.as<BlockNode>()) {
     return GetEvaluateCallInSimpleWrapper(block->body);
@@ -1668,7 +1670,8 @@ private:
         [&](Stmt body,
             const std::vector<std::pair<Var, PrimExpr>> &bindings) -> Stmt {
       for (auto it = bindings.rbegin(); it != bindings.rend(); ++it) {
-        body = SeqStmt::Flatten(SeqStmt({LetStmt(it->first, it->second), body}));
+        body =
+            SeqStmt::Flatten(SeqStmt({LetStmt(it->first, it->second), body}));
       }
       return body;
     };

--- a/src/transform/simplify.cc
+++ b/src/transform/simplify.cc
@@ -384,13 +384,7 @@ private:
       }
     }
     if (remove_buffer_alias) {
-      Stmt body = this->VisitStmt(op->body);
-      bool used = UsesVar(
-          body, [&](const VarNode *var) { return var == op->var.get(); });
-      ICHECK(!used) << "Let binding of BufferLoad is expected to be unused "
-                       "before removal "
-                    << op->var << " : " << op->value << " .";
-      return body;
+      return Evaluate(0);
     }
 
     bool can_inline = CanInlineLetStmt(op);
@@ -399,18 +393,15 @@ private:
     } else if (SideEffect(op->value) <= CallEffectKind::kPure) {
       non_inlined_bindings_.Set(op->var, value);
     }
-    Stmt body = this->VisitStmt(op->body);
-
     bool used_in_buffer_def = used_in_buffer_def_.count(op->var.get());
 
     if (can_inline && !used_in_buffer_def) {
-      return body;
-    } else if (value.same_as(op->value) && body.same_as(op->body)) {
+      return Evaluate(0);
+    } else if (value.same_as(op->value)) {
       return tvm::ffi::GetRef<Stmt>(op);
     } else {
       auto n = this->CopyOnWrite(op);
       n->value = std::move(value);
-      n->body = std::move(body);
       return Stmt(n);
     }
   }

--- a/src/transform/split_host_device.cc
+++ b/src/transform/split_host_device.cc
@@ -375,9 +375,8 @@ private:
       tir::AssertStmt assert_success(
           kernel_error_code == success,
           tir::StringImm("Error executing compute kernel"), tir::Evaluate(0));
-      tir::LetStmt let_check(kernel_error_code, kernel_call, assert_success);
-
-      return let_check;
+      return tir::SeqStmt::Flatten(
+          tir::SeqStmt({tir::LetStmt(kernel_error_code, kernel_call), assert_success}));
 
     } else {
       return tir::Evaluate(

--- a/src/transform/split_host_device.cc
+++ b/src/transform/split_host_device.cc
@@ -375,8 +375,8 @@ private:
       tir::AssertStmt assert_success(
           kernel_error_code == success,
           tir::StringImm("Error executing compute kernel"), tir::Evaluate(0));
-      return tir::SeqStmt::Flatten(
-          tir::SeqStmt({tir::LetStmt(kernel_error_code, kernel_call), assert_success}));
+      return tir::SeqStmt::Flatten(tir::SeqStmt(
+          {tir::LetStmt(kernel_error_code, kernel_call), assert_success}));
 
     } else {
       return tir::Evaluate(

--- a/src/transform/storage_rewrite.cc
+++ b/src/transform/storage_rewrite.cc
@@ -300,7 +300,16 @@ public:
 
   void VisitStmt_(const AssertStmtNode *op) final { VisitNewScope(op); }
 
-  void VisitStmt_(const LetStmtNode *op) final { VisitNewScope(op); }
+  void VisitStmt_(const LetStmtNode *op) final {
+    scope_.push_back(StmtEntry());
+    StmtExprVisitor::VisitStmt_(op);
+    StmtEntry e = scope_.back();
+    scope_.pop_back();
+    if (!e.touched.empty()) {
+      e.stmt = op;
+      linear_seq_.push_back(e);
+    }
+  }
 
   // linearized access sequence.
   std::vector<StmtEntry> linear_seq_;
@@ -1815,13 +1824,11 @@ public:
   Stmt VisitStmt_(const LetStmtNode *op) final {
     auto it = rewrite_map_.find(op->var.get());
     PrimExpr value = this->VisitExpr(op->value);
-    Stmt body = this->VisitStmt(op->body);
     Var var = (it == rewrite_map_.end()) ? op->var : it->second.new_buffer_var;
-    if (var.same_as(op->var) && value.same_as(op->value) &&
-        body.same_as(op->body)) {
+    if (var.same_as(op->var) && value.same_as(op->value)) {
       return tvm::ffi::GetRef<Stmt>(op);
     }
-    return LetStmt(var, value, body);
+    return LetStmt(var, value, op->span);
   }
 
   Buffer RemapBuffer(Buffer buf) {

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -117,17 +117,21 @@ private:
   }
 
   bool IsWaitGroupStmt(const Stmt &stmt) const {
-    if (const auto *let = stmt.as<LetStmtNode>()) {
-      return IsWaitGroupStmt(let->body);
-    }
     if (const auto *attr = stmt.as<AttrStmtNode>()) {
       return IsWaitGroupStmt(attr->body);
     }
     if (const auto *seq = stmt.as<SeqStmtNode>()) {
-      if (seq->seq.size() == 1) {
-        return IsWaitGroupStmt(seq->seq[0]);
+      ffi::Optional<Stmt> non_let_stmt;
+      for (const Stmt &child : seq->seq) {
+        if (child.as<LetStmtNode>()) {
+          continue;
+        }
+        if (non_let_stmt.defined()) {
+          return false;
+        }
+        non_let_stmt = child;
       }
-      return false;
+      return non_let_stmt.defined() && IsWaitGroupStmt(non_let_stmt.value());
     }
     if (const auto *block = stmt.as<BlockNode>()) {
       return IsWaitGroupStmt(block->body);
@@ -157,17 +161,21 @@ private:
   }
 
   bool IsStorageSyncStmt(const Stmt &stmt) const {
-    if (const auto *let = stmt.as<LetStmtNode>()) {
-      return IsStorageSyncStmt(let->body);
-    }
     if (const auto *attr = stmt.as<AttrStmtNode>()) {
       return IsStorageSyncStmt(attr->body);
     }
     if (const auto *seq = stmt.as<SeqStmtNode>()) {
-      if (seq->seq.size() == 1) {
-        return IsStorageSyncStmt(seq->seq[0]);
+      ffi::Optional<Stmt> non_let_stmt;
+      for (const Stmt &child : seq->seq) {
+        if (child.as<LetStmtNode>()) {
+          continue;
+        }
+        if (non_let_stmt.defined()) {
+          return false;
+        }
+        non_let_stmt = child;
       }
-      return false;
+      return non_let_stmt.defined() && IsStorageSyncStmt(non_let_stmt.value());
     }
     if (const auto *block = stmt.as<BlockNode>()) {
       return IsStorageSyncStmt(block->body);
@@ -855,24 +863,41 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     // clear access entry.
     curr_stmt_.access.clear();
     allow_append_ = false;
-    // traverse body block
-    {
-      auto let_prop = AnalyzeExprProperty(op->value);
-      auto it = let_var_properties_.find(op->var.get());
-      bool had_prev = it != let_var_properties_.end();
+  }
+  void VisitStmt_(const SeqStmtNode *op) final {
+    struct SavedLetProperty {
+      const VarNode *var;
+      bool had_prev;
       ConditionThreadProperty prev_prop;
-      if (had_prev) {
-        prev_prop = it->second;
-      }
-      let_var_properties_[op->var.get()] = let_prop;
-      auto guard = MakeGuard(op->var, op->value);
-      this->VisitStmt(op->body);
-      if (had_prev) {
-        let_var_properties_[op->var.get()] = prev_prop;
+    };
+
+    size_t old_constr_size = constr_stack_.size();
+    std::vector<SavedLetProperty> saved_properties;
+    for (const Stmt &stmt : op->seq) {
+      if (const auto *let = stmt.as<LetStmtNode>()) {
+        this->VisitStmt(stmt);
+
+        auto it = let_var_properties_.find(let->var.get());
+        SavedLetProperty saved{let->var.get(), it != let_var_properties_.end(),
+                               ConditionThreadProperty()};
+        if (saved.had_prev) {
+          saved.prev_prop = it->second;
+        }
+        saved_properties.push_back(saved);
+        let_var_properties_[let->var.get()] = AnalyzeExprProperty(let->value);
+        constr_stack_.push_back(Constr(let->var, let->value));
       } else {
-        let_var_properties_.erase(op->var.get());
+        this->VisitStmt(stmt);
       }
     }
+    for (auto it = saved_properties.rbegin(); it != saved_properties.rend(); ++it) {
+      if (it->had_prev) {
+        let_var_properties_[it->var] = it->prev_prop;
+      } else {
+        let_var_properties_.erase(it->var);
+      }
+    }
+    constr_stack_.resize(old_constr_size);
   }
   void VisitStmt_(const BlockNode *op) final {
     auto block = Downcast<Block>(op);

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -890,7 +890,8 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
         this->VisitStmt(stmt);
       }
     }
-    for (auto it = saved_properties.rbegin(); it != saved_properties.rend(); ++it) {
+    for (auto it = saved_properties.rbegin(); it != saved_properties.rend();
+         ++it) {
       if (it->had_prev) {
         let_var_properties_[it->var] = it->prev_prop;
       } else {

--- a/src/transform/vectorize_loop.cc
+++ b/src/transform/vectorize_loop.cc
@@ -996,15 +996,14 @@ public:
       // Record mapping from the new var to its bound value
       let_value_binding_[op->var] = op->value;
       let_value_binding_[new_var] = value;
-      return LetStmt(new_var, value, this->VisitStmt(op->body));
+      return LetStmt(new_var, value, op->span);
     } else {
       let_var_map_[op->var] = op->var;
       let_value_binding_[op->var] = value;
-      Stmt body = this->VisitStmt(op->body);
-      if (value.same_as(op->value) && body.same_as(op->body)) {
+      if (value.same_as(op->value)) {
         return tvm::ffi::GetRef<Stmt>(op);
       } else {
-        return LetStmt(op->var, value, body);
+        return LetStmt(op->var, value, op->span);
       }
     }
   }
@@ -1055,7 +1054,7 @@ public:
         }
         // Bind the existing var v to its value around the stmt scope
         auto new_value = Substitute(let_value_binding_.at(v), {{var_, idx}});
-        stmt = LetStmt(v, new_value, stmt);
+        stmt = SeqStmt::Flatten(SeqStmt({LetStmt(v, new_value), stmt}));
       }
     }
 

--- a/testing/python/transform/test_tilelang_transform_simplify.py
+++ b/testing/python/transform/test_tilelang_transform_simplify.py
@@ -33,7 +33,7 @@ def test_stmt_simplify():
     with ib.for_range(0, n, name="i") as i, ib.if_scope(i < 12):
         A[i] = C[i]
 
-    body = tvm.tir.LetStmt(n, 10, ib.get())
+    body = tvm.tir.SeqStmt([tvm.tir.LetStmt(n, 10), ib.get()])
     mod = tvm.IRModule.from_expr(tvm.tir.PrimFunc([A, C, n], body))
     body = tl.transform.Simplify()(mod)["main"].body
     assert isinstance(body.body, tvm.tir.BufferStore)
@@ -51,7 +51,7 @@ def test_thread_extent_simplify():
     ib.scope_attr(ty, "thread_extent", 1)
     with ib.if_scope(tx + ty < 12):
         A[tx] = C[tx + ty]
-    body = tvm.tir.LetStmt(n, 10, ib.get())
+    body = tvm.tir.SeqStmt([tvm.tir.LetStmt(n, 10), ib.get()])
     mod = tvm.IRModule.from_expr(tvm.tir.PrimFunc([A, C, n], body))
     body = tl.transform.Simplify()(mod)["main"].body
     assert isinstance(body.body.body.body, tvm.tir.BufferStore)

--- a/tilelang/transform/decouple_type_cast.py
+++ b/tilelang/transform/decouple_type_cast.py
@@ -214,8 +214,7 @@ def inline_let_stmts(stmt: Stmt) -> Stmt:
     values are visible to ``MemoryAccessCollector``.
     """
     if isinstance(stmt, LetStmt):
-        body = inline_let_stmts(stmt.body)
-        return substitute(body, {stmt.var: stmt.value})
+        return stmt
     elif isinstance(stmt, IfThenElse):
         then_case = inline_let_stmts(stmt.then_case)
         else_case = inline_let_stmts(stmt.else_case) if stmt.else_case else None
@@ -223,7 +222,16 @@ def inline_let_stmts(stmt: Stmt) -> Stmt:
             return IfThenElse(stmt.condition, then_case, else_case)
         return stmt
     elif isinstance(stmt, SeqStmt):
-        new_seq = [inline_let_stmts(s) for s in stmt.seq]
+        bindings = {}
+        new_seq = []
+        for s in stmt.seq:
+            if isinstance(s, LetStmt):
+                bindings[s.var] = substitute(s.value, bindings) if bindings else s.value
+                continue
+            new_stmt = inline_let_stmts(s)
+            if bindings:
+                new_stmt = substitute(new_stmt, bindings)
+            new_seq.append(new_stmt)
         return SeqStmt(new_seq)
     else:
         return stmt

--- a/tilelang/transform/hoist_broadcast_values.py
+++ b/tilelang/transform/hoist_broadcast_values.py
@@ -2,6 +2,7 @@ from tvm import tir
 from tvm.tir import (
     BufferStore,
     LetStmt,
+    SeqStmt,
     Broadcast,
     Var,
     PrimFunc,
@@ -52,11 +53,7 @@ class HoistBroadcastValuesMutator(PyStmtExprMutator):
 
         # 4. Check if there are variables waiting to be defined.
         if self.pending_defs:
-            # 5. Wrap the current statement with LetStmt.
-            # Order: Traverse in reverse to ensure the first definition wraps the outermost layer.
-            # Structure generated: Let my_var = val In BufferStore(...)
-            for var, val in reversed(self.pending_defs):
-                new_stmt = LetStmt(var, val, new_stmt)
+            new_stmt = SeqStmt([LetStmt(var, val) for var, val in self.pending_defs] + [new_stmt])
 
         # 6. Restore the saved state.
         self.hoist_enabled = saved_hoist_enabled
@@ -76,24 +73,15 @@ class HoistBroadcastValuesMutator(PyStmtExprMutator):
         # 3. Visit the value expression (this will trigger visit_broadcast_).
         new_value = self.visit_expr(op.value)
 
-        # 4. Capture the pending defs from the value expression before visiting body.
+        # 4. Capture the pending defs from the value expression.
         value_pending_defs = self.pending_defs
 
-        # 5. Disable hoist flag and clear pending defs before visiting body.
-        self.hoist_enabled = False
-        self.pending_defs = []
-
-        # 6. Recursively visit the body.
-        new_body = self.visit_stmt(op.body)
-
-        # 7. Create the new LetStmt.
-        new_stmt = LetStmt(op.var, new_value, new_body)
+        # 5. Create the new LetStmt.
+        new_stmt = LetStmt(op.var, new_value)
 
         # 8. Check if there are variables waiting to be defined from the value expression.
         if value_pending_defs:
-            # 9. Wrap the current statement with LetStmt.
-            for var, val in reversed(value_pending_defs):
-                new_stmt = LetStmt(var, val, new_stmt)
+            new_stmt = SeqStmt([LetStmt(var, val) for var, val in value_pending_defs] + [new_stmt])
 
         # 10. Restore the saved state.
         self.hoist_enabled = saved_hoist_enabled


### PR DESCRIPTION
## Summary

This PR removes the `body` field from TIR `LetStmtNode` and migrates TileLang/TVM usage to standalone sequential let bindings. A `LetStmt(var, value)` now binds the variable for later statements in the enclosing `SeqStmt`, while old wrapper-style usages are represented as `SeqStmt([LetStmt(var, value), body])`.

The paired TVM submodule change is pushed to `tile-ai/tvm:codex/remove-tir-letstmt-body` at commit `834ac83f9`.

## Details

- Update the TIR `LetStmt` C++/Python/FFI definitions to remove the nested body.
- Update visitors, mutators, analyzers, printers, codegen, SSA/use-def analysis, and storage/lifetime analysis for sequential let scope.
- Migrate TileLang transforms, including pipeline planning/injection, producer-consumer warp specialization, simplification, vectorization, and storage rewrite paths.
- Update Python tests and internal LetStmt inlining docs for the new standalone binding model.

## Validation

- `cmake --build build -j$(nproc)`
- `PYTHONPATH=$PWD:$PWD/3rdparty/tvm/python:${PYTHONPATH:-} TVM_LIBRARY_PATH=$PWD/build/lib python examples/quickstart.py`
- `PYTHONPATH=$PWD:$PWD/3rdparty/tvm/python:${PYTHONPATH:-} TVM_LIBRARY_PATH=$PWD/build/lib python -m pytest -q testing/python/transform/test_tilelang_transform_simplify.py 3rdparty/tvm/tests/python/tir-base/test_tir_constructor.py::test_stmt_constructor 3rdparty/tvm/tests/python/tir-base/test_tir_nodes.py::test_let 3rdparty/tvm/tests/python/tir-base/test_tir_nodes.py::test_prim_func 3rdparty/tvm/tests/python/tir-base/test_tir_structural_equal_hash.py::test_prim_func 3rdparty/tvm/tests/python/tvmscript/test_tvmscript_ir_builder_tir.py::test_ir_builder_tir_let 3rdparty/tvm/tests/python/tir-analysis/test_tir_analysis_verify_ssa.py 3rdparty/tvm/tests/python/tir-transform/test_tir_transform_common_subexpr_elim.py::test_no_normalization_without_commoning 3rdparty/tvm/tests/python/tir-transform/test_tir_transform_common_subexpr_elim.py::test_deterministic_cse`
- `PYTHONPATH=$PWD:$PWD/3rdparty/tvm/python:${PYTHONPATH:-} TVM_LIBRARY_PATH=$PWD/build/lib python -m pytest -q testing/python/transform/test_tilelang_transform_pipeline_planning.py testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py testing/python/transform/test_tilelang_transform_producer_consumer_ws.py::test_tiled_ws_stage1_dynamic_loop_start testing/python/transform/test_tilelang_transform_producer_consumer_ws.py::test_tiled_ws_keeps_shared_prelude_local_vars_for_grouped_gemm testing/python/transform/test_tilelang_transform_producer_consumer_ws.py::test_tiled_ws_does_not_clone_local_var_into_producer_branch`

Note: `3rdparty/tvm/tests/python/tir-transform/test_tir_transform_lower_tvm_builtin.py` mostly passed (`6 passed, 1 skipped`), but `test_lower_overflow_int32` could not complete in this environment because `target.build.llvm` is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated TVM submodule to latest commit.
  * Restructured how let-statement bindings are handled across compiler transformation passes, improving statement sequence composition and inlining behavior.
  * Updated documentation to reflect changes in let-statement inlining semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->