### PR TITLE
[Feature][Blackwell] Add SM120 T.float4_e2m1fn FP4 GEMM support.

### DIFF
--- a/examples/gemm_fp4/example_gemm_a8w4.py
+++ b/examples/gemm_fp4/example_gemm_a8w4.py
@@ -1,0 +1,94 @@
+import torch
+import tilelang
+import tilelang.language as T
+
+
+FP4_E2M1_TO_FLOAT = [
+    0.0,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    4.0,
+    6.0,
+    -0.0,
+    -0.5,
+    -1.0,
+    -1.5,
+    -2.0,
+    -3.0,
+    -4.0,
+    -6.0,
+]
+
+
+def calc_diff(x, y):
+    x, y = x.double(), y.double()
+    denominator = (x * x + y * y).sum()
+    sim = 2 * (x * y).sum() / denominator
+    return 1 - sim
+
+
+def fp4_uint8_to_float(tensor):
+    lut = torch.tensor(FP4_E2M1_TO_FLOAT, dtype=torch.float32, device=tensor.device)
+    return lut[(tensor.to(torch.uint8) & 0x0F).to(torch.int64)]
+
+
+@tilelang.jit(
+    target="cuda",
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+    },
+)
+def matmul(A, B, block_M, block_N, block_K, out_dtype=T.float32, accum_dtype=T.float32):
+    M, N, K = T.const("M, N, K")
+
+    A: T.Tensor((M, K), T.float8_e4m3fn)
+    B: T.Tensor((N, K), T.float4_e2m1fn)
+    C = T.empty((M, N), out_dtype)
+
+    with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+        A_shared = T.alloc_shared((block_M, block_K), T.float8_e4m3fn)
+        B_shared = T.alloc_shared((block_N, block_K), T.float4_e2m1fn)
+        C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+        T.clear(C_local)
+        for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=3):
+            T.copy(A[by * block_M, k * block_K], A_shared)
+            T.copy(B[bx * block_N, k * block_K], B_shared)
+            T.gemm(A_shared, B_shared, C_local, transpose_B=True)
+
+        T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return C
+
+
+def test_gemm_a8w4(M, N, K):
+    a = torch.randn(M, K, dtype=torch.float16, device="cuda").to(torch.float8_e4m3fn)
+    b = torch.randint(0, 16, (N, K), dtype=torch.uint8, device="cuda")
+
+    c = matmul(a, b, 128, 128, 128)
+    ref_c = a.to(torch.float32) @ fp4_uint8_to_float(b).T
+
+    diff = calc_diff(c, ref_c)
+    print(f"diff: {diff}")
+    assert diff < 1e-3
+
+
+def main():
+    test_gemm_a8w4(1024, 1024, 1024)
+
+
+def run_regression_perf():
+    M, N, K = 4096, 4096, 4096
+    kernel = matmul.compile(M=M, N=N, K=K, block_M=128, block_N=128, block_K=128)
+    profiler = kernel.get_profiler(tilelang.TensorSupplyType.Integer)
+    if torch.version.hip is None:
+        return profiler.do_bench(backend="cupti")
+    return profiler.do_bench()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/gemm_fp4/example_gemm_fp4.py
+++ b/examples/gemm_fp4/example_gemm_fp4.py
@@ -1,0 +1,94 @@
+import torch
+import tilelang
+import tilelang.language as T
+
+
+FP4_E2M1_TO_FLOAT = [
+    0.0,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    4.0,
+    6.0,
+    -0.0,
+    -0.5,
+    -1.0,
+    -1.5,
+    -2.0,
+    -3.0,
+    -4.0,
+    -6.0,
+]
+
+
+def calc_diff(x, y):
+    x, y = x.double(), y.double()
+    denominator = (x * x + y * y).sum()
+    sim = 2 * (x * y).sum() / denominator
+    return 1 - sim
+
+
+def fp4_uint8_to_float(tensor):
+    lut = torch.tensor(FP4_E2M1_TO_FLOAT, dtype=torch.float32, device=tensor.device)
+    return lut[(tensor.to(torch.uint8) & 0x0F).to(torch.int64)]
+
+
+@tilelang.jit(
+    target="cuda",
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+    },
+)
+def matmul(A, B, block_M, block_N, block_K, out_dtype=T.float32, accum_dtype=T.float32):
+    M, N, K = T.const("M, N, K")
+
+    A: T.Tensor((M, K), T.float4_e2m1fn)
+    B: T.Tensor((N, K), T.float4_e2m1fn)
+    C = T.empty((M, N), out_dtype)
+
+    with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+        A_shared = T.alloc_shared((block_M, block_K), T.float4_e2m1fn)
+        B_shared = T.alloc_shared((block_N, block_K), T.float4_e2m1fn)
+        C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+
+        T.clear(C_local)
+        for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=3):
+            T.copy(A[by * block_M, k * block_K], A_shared)
+            T.copy(B[bx * block_N, k * block_K], B_shared)
+            T.gemm(A_shared, B_shared, C_local, transpose_B=True)
+
+        T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return C
+
+
+def test_gemm_fp4(M, N, K):
+    a = torch.randint(0, 16, (M, K), dtype=torch.uint8, device="cuda")
+    b = torch.randint(0, 16, (N, K), dtype=torch.uint8, device="cuda")
+
+    c = matmul(a, b, 128, 128, 128)
+    ref_c = fp4_uint8_to_float(a) @ fp4_uint8_to_float(b).T
+
+    diff = calc_diff(c, ref_c)
+    print(f"diff: {diff}")
+    assert diff < 1e-3
+
+
+def main():
+    test_gemm_fp4(1024, 1024, 1024)
+
+
+def run_regression_perf():
+    M, N, K = 4096, 4096, 4096
+    kernel = matmul.compile(M=M, N=N, K=K, block_M=128, block_N=128, block_K=128)
+    profiler = kernel.get_profiler(tilelang.TensorSupplyType.Integer)
+    if torch.version.hip is None:
+        return profiler.do_bench(backend="cupti")
+    return profiler.do_bench()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -265,11 +265,6 @@ std::string GetTileLangFP6Type(DataType type) {
 }
 
 std::string GetTileLangFP4Type(DataType type) {
-  if (type.is_float4_e2m1_unpacked()) {
-    LOG(FATAL) << "float4_e2m1_unpacked is a SMEM/TMA storage tag and has no "
-                  "CUDA register type";
-  }
-
   std::stringstream stream;
   int32_t lanes = type.lanes();
   std::string vec;
@@ -293,7 +288,7 @@ std::string GetTileLangFP4Type(DataType type) {
   }
 
   std::string suffix;
-  if (type.is_float4_e2m1fn()) {
+  if (type.is_float4_e2m1fn() || type.is_float4_e2m1_unpacked()) {
     suffix = "_e2";
   } else {
     LOG(FATAL) << "Unsupported FP4 type in CUDA codegen";
@@ -800,11 +795,7 @@ void CodeGenTileLangCUDA::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
       return;
     }
     fail = true;
-  } else if (t.is_float4_e2m1_unpacked()) {
-    LOG(FATAL) << "float4_e2m1_unpacked is a SMEM/TMA storage tag and must be "
-                  "lowered through shared-memory allocation";
-    return;
-  } else if (t.is_float4_e2m1fn()) {
+  } else if (t.is_float4_e2m1fn() || t.is_float4_e2m1_unpacked()) {
     enable_fp4_ = true;
     if (t.lanes() <= 64) {
       os << GetTileLangFP4Type(t);
@@ -1270,7 +1261,7 @@ void CodeGenTileLangCUDA::PrintVecElemLoad(const std::string &vec, DataType t,
       os << "." << access[(i % 8) / 4];
     // fp8_e5_4_t or fp8_e5_2_t
     os << "." << access[i % 4];
-  } else if (t.is_float4_e2m1fn()) {
+  } else if (t.is_float4()) {
     os << vec;
     // fp4_e2_64_t
     if (t.lanes() >= 64)
@@ -1372,6 +1363,25 @@ void CodeGenTileLangCUDA::PrintVecElemStore(const std::string &vec, DataType t,
       stream << "." << access[(i % 8) / 4];
     // fp8_e5_4_t or fp8_e5_2_t
     stream << "." << access[i % 4] << " = " << value << ";\n";
+  } else if (t.is_float4()) {
+    stream << vec;
+    // fp4_e2_64_t
+    if (t.lanes() >= 64)
+      stream << "." << access[i / 32];
+    // fp4_e2_32_t
+    if (t.lanes() >= 32)
+      stream << "." << access[(i % 32) / 16];
+    // fp4_e2_16_t
+    if (t.lanes() >= 16)
+      stream << "." << access[(i % 16) / 8];
+    // fp4_e2_8_t
+    if (t.lanes() >= 8)
+      stream << "." << access[(i % 8) / 4];
+    // fp4_e2_4_t -> fp4_e2_2_t member
+    if (t.lanes() >= 4)
+      stream << "." << access[(i % 4) / 2];
+    // fp4_e2_2_t -> set_x() or set_y()
+    stream << ".set_" << access[i % 2] << "(" << value << ");\n";
   } else if (t.lanes() > 4 && t.lanes() <= 8) {
     std::string type_name;
     if (t.bits() == 16) {
@@ -1392,25 +1402,6 @@ void CodeGenTileLangCUDA::PrintVecElemStore(const std::string &vec, DataType t,
     ICHECK(!type_name.empty());
     stream << "((" << type_name << "2*)(&(" << vec << "." << access[i / 2]
            << ")))->" << access[i % 2] << " = " << value << ";\n";
-  } else if (t.is_float4_e2m1fn()) {
-    stream << vec;
-    // fp4_e2_64_t
-    if (t.lanes() >= 64)
-      stream << "." << access[i / 32];
-    // fp4_e2_32_t
-    if (t.lanes() >= 32)
-      stream << "." << access[(i % 32) / 16];
-    // fp4_e2_16_t
-    if (t.lanes() >= 16)
-      stream << "." << access[(i % 16) / 8];
-    // fp4_e2_8_t
-    if (t.lanes() >= 8)
-      stream << "." << access[(i % 8) / 4];
-    // fp4_e2_4_t -> fp4_e2_2_t member
-    if (t.lanes() >= 4)
-      stream << "." << access[(i % 4) / 2];
-    // fp4_e2_2_t -> set_x() or set_y()
-    stream << ".set_" << access[i % 2] << "(" << value << ");\n";
   } else {
     stream << vec << "." << access[i] << " = " << value << ";\n";
   }
@@ -1738,7 +1729,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const CastNode *op, std::ostream &os) {
   }
 
   // Handle conversion from float16 to float4 (E2M1)
-  if (from_ty.is_float16() && target_ty.is_float4_e2m1fn()) {
+  if (from_ty.is_float16() && target_ty.is_float4()) {
     // Use __tl_cvt_half2_to_fp4x2 for vectorized conversion (half2 -> fp4x2)
     if (lanes == 2 || lanes == 4 || lanes == 8) {
       PrintVectorizedCast("__tl_cvt_half2_to_fp4x2", "half2", "uint8_t", "",
@@ -1748,8 +1739,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const CastNode *op, std::ostream &os) {
   }
 
   // Handle conversion from float32 to float4 (E2M1)
-  if (from_ty.is_float() && from_ty.bits() == 32 &&
-      target_ty.is_float4_e2m1fn()) {
+  if (from_ty.is_float() && from_ty.bits() == 32 && target_ty.is_float4()) {
     bool has_rbits = cast_rbits.defined();
 
     if (cast_round == "rs" && has_rbits) {
@@ -1809,7 +1799,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const CastNode *op, std::ostream &os) {
   }
 
   // Handle conversion from float4 (E2M1) to float16
-  if (from_ty.is_float4_e2m1fn() && target_ty.is_float16()) {
+  if (from_ty.is_float4() && target_ty.is_float16()) {
     // Use __tl_cvt_fp4x2_to_half2 for vectorized conversion (fp4x2 -> half2)
     if (lanes == 2 || lanes == 4 || lanes == 8) {
       PrintVectorizedCast("__tl_cvt_fp4x2_to_half2", "uint8_t", "half2", "",
@@ -1819,8 +1809,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const CastNode *op, std::ostream &os) {
   }
 
   // Handle conversion from float4 (E2M1) to float32
-  if (from_ty.is_float4_e2m1fn() && target_ty.is_float() &&
-      target_ty.bits() == 32) {
+  if (from_ty.is_float4() && target_ty.is_float() && target_ty.bits() == 32) {
     // Use __tl_cvt_fp4x2_to_float2 for vectorized conversion (fp4x2 -> float2)
     if (lanes == 2 || lanes == 4 || lanes == 8) {
       PrintVectorizedCast("__tl_cvt_fp4x2_to_float2", "uint8_t", "float2", "",
@@ -1830,8 +1819,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const CastNode *op, std::ostream &os) {
   }
 
   // Handle conversion from double to float4 (E2M1)
-  if (from_ty.is_float() && from_ty.bits() == 64 &&
-      target_ty.is_float4_e2m1fn()) {
+  if (from_ty.is_float() && from_ty.bits() == 64 && target_ty.is_float4()) {
     // Use __tl_cvt_double2_to_fp4x2 for vectorized conversion (double2 ->
     // fp4x2)
     if (lanes == 2 || lanes == 4 || lanes == 8) {
@@ -1842,8 +1830,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const CastNode *op, std::ostream &os) {
   }
 
   // Handle conversion from float4 (E2M1) to double
-  if (from_ty.is_float4_e2m1fn() && target_ty.is_float() &&
-      target_ty.bits() == 64) {
+  if (from_ty.is_float4() && target_ty.is_float() && target_ty.bits() == 64) {
     // Use __tl_cvt_fp4x2_to_double2 for vectorized conversion (fp4x2 ->
     // double2)
     if (lanes == 2 || lanes == 4 || lanes == 8) {
@@ -1854,7 +1841,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const CastNode *op, std::ostream &os) {
   }
 
   // Handle conversion from bfloat16 to float4 (E2M1)
-  if (from_ty.is_bfloat16() && target_ty.is_float4_e2m1fn()) {
+  if (from_ty.is_bfloat16() && target_ty.is_float4()) {
     // Use __tl_cvt_bfloat162_to_fp4x2 for vectorized conversion (bfloat162 ->
     // fp4x2)
     if (lanes == 2 || lanes == 4 || lanes == 8) {
@@ -1865,7 +1852,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const CastNode *op, std::ostream &os) {
   }
 
   // Handle conversion from float4 (E2M1) to bfloat16
-  if (from_ty.is_float4_e2m1fn() && target_ty.is_bfloat16()) {
+  if (from_ty.is_float4() && target_ty.is_bfloat16()) {
     // Use __tl_cvt_fp4x2_to_bfloat162 for vectorized conversion (fp4x2 ->
     // bfloat162)
     if (lanes == 2 || lanes == 4 || lanes == 8) {
@@ -2033,18 +2020,10 @@ std::string CodeGenTileLangCUDA::GetBufferRef(DataType t,
   const VarNode *buffer_var = buffer->data.get();
   std::ostringstream os;
   std::string vid = GetVarID(buffer_var);
-  // For fp4 packed buffers, use the packed buffer name for vector accesses
-  auto it = fp4_packed_buffers_.find(buffer_var);
-  if (it != fp4_packed_buffers_.end() && !t.is_scalar()) {
-    vid = it->second;
-  }
-  std::string scope;
-  if (alloc_storage_scope_.count(buffer_var)) {
-    scope = alloc_storage_scope_.at(buffer_var);
-  }
-  if (scope.empty()) {
-    scope = GetPtrStorageScope(buffer->data);
-  }
+  // FP4 storage is selected by scope, not by renaming the buffer. Shared
+  // scopes use packed byte addresses, while local fragments keep the declared
+  // name so generated MMA operands match the fragment allocation.
+  std::string scope = GetBufferStorageScope(buffer_var);
   // bool is_vol = IsVolatile(buffer_var);
   // always false for tl cutlass backend.
   bool is_vol = false;
@@ -2096,19 +2075,21 @@ std::string CodeGenTileLangCUDA::GetBufferRef(DataType t,
        << " + " << index_str << ")";
   } else if (t == buffer_element_dtype) {
     int div_factor = 1;
-    if (buffer_element_dtype.is_float4_e2m1fn() &&
-        buffer_element_dtype.lanes() == 1) {
+    if (IsFp4PackedStorage(buffer_var, buffer_element_dtype)) {
+      // Packed FP4 buffers are byte-addressed. Dividing by two maps two
+      // neighboring logical FP4 elements to one backing byte; scalar helpers
+      // still receive the original logical index for nibble selection.
       div_factor = 2;
     }
     index_str =
         PrintExpr(arith::Analyzer().Simplify(truncdiv(index, div_factor)));
     os << buffer_str << "[" << index_str << "]";
   } else {
-    // Fix fp4 pointer arithmetic: fp4 elements are 4-bit packed 2 per byte.
-    // fp4* + n incorrectly advances n bytes (skipping 2n elements).
     int div_factor = 1;
-    if (buffer_element_dtype.is_float4_e2m1fn() &&
-        buffer_element_dtype.lanes() == 1) {
+    if (IsFp4PackedStorage(buffer_var, buffer_element_dtype)) {
+      // Reinterpreted FP4 references start from the backing byte offset. C
+      // pointer arithmetic on fp4_e2_t would advance by whole storage objects
+      // and skip the neighboring nibble.
       div_factor = 2;
     }
     index_str =
@@ -2123,10 +2104,45 @@ std::string CodeGenTileLangCUDA::GetVecLoad(DataType t,
                                             const BufferNode *buffer,
                                             PrimExpr base) {
   const VarNode *buffer_var = buffer->data.get();
-  std::string scope;
-  if (alloc_storage_scope_.count(buffer_var)) {
-    scope = alloc_storage_scope_.at(buffer_var);
+  auto make_fp4_vec = [&](const auto &lane) {
+    std::ostringstream os;
+    os << "make_fp4_e2_" << t.lanes() << "_t(";
+    for (int i = 0; i < t.lanes(); ++i) {
+      if (i != 0)
+        os << ", ";
+      os << lane(i);
+    }
+    os << ")";
+    return os.str();
+  };
+  if (IsFp4SemanticLocalStorage(buffer_var, buffer->dtype) &&
+      t.is_float4_e2m1fn() && t.lanes() > 1) {
+    // Local FP4 vectors are logical element arrays, not packed byte arrays.
+    return make_fp4_vec([&](int i) {
+      PrimExpr index = arith::Analyzer().Simplify(
+          base + IntImm(base.dtype(), static_cast<int64_t>(i)));
+      return GetBufferRef(t.element_of(), buffer, index);
+    });
   }
+
+  if (IsFp4PackedStorage(buffer_var, buffer->dtype) && t.is_float4_e2m1fn() &&
+      t.lanes() > 1) {
+    arith::Analyzer analyzer;
+    bool base_aligned = is_zero(analyzer.Simplify(truncmod(base, 2)));
+    if (!base_aligned) {
+      // Packed FP4 vector reinterpret is only nibble-aligned for even logical
+      // bases. Odd or symbolic bases need per-lane nibble selection.
+      std::string vid = GetVarID(buffer_var);
+      return make_fp4_vec([&](int i) {
+        PrimExpr index = analyzer.Simplify(
+            base + IntImm(base.dtype(), static_cast<int64_t>(i)));
+        return "tl_fp4_packed_load((fp4_e2_2_t*)" + vid + ", " +
+               PrintExpr(index) + ")";
+      });
+    }
+  }
+
+  std::string scope = GetBufferStorageScope(buffer_var);
   if (scope.empty()) {
     scope = GetPtrStorageScope(buffer->data);
   }
@@ -2146,10 +2162,48 @@ void CodeGenTileLangCUDA::PrintVecStore(const BufferNode *buffer, DataType t,
                                         PrimExpr base,
                                         const std::string &value) {
   const VarNode *buffer_var = buffer->data.get();
-  std::string scope;
-  if (alloc_storage_scope_.count(buffer_var)) {
-    scope = alloc_storage_scope_.at(buffer_var);
+  auto emit_fp4_vec_scope = [&](const auto &emit_lane) {
+    std::ostringstream vec_type;
+    PrintType(t, vec_type);
+    this->PrintIndent();
+    this->stream << "{ " << vec_type.str() << " __tl_fp4_vec = " << value
+                 << "; ";
+    for (int i = 0; i < t.lanes(); ++i) {
+      std::ostringstream elem;
+      PrintVecElemLoad("__tl_fp4_vec", t, i, elem);
+      emit_lane(i, elem.str());
+    }
+    this->stream << "}\n";
+  };
+  if (IsFp4SemanticLocalStorage(buffer_var, buffer->dtype) &&
+      t.is_float4_e2m1fn() && t.lanes() > 1) {
+    // Store each FP4 lane so vector casts fill every semantic local element.
+    std::string vid = GetVarID(buffer_var);
+    emit_fp4_vec_scope([&](int i, const std::string &elem) {
+      PrimExpr index = arith::Analyzer().Simplify(
+          base + IntImm(base.dtype(), static_cast<int64_t>(i)));
+      this->stream << vid << "[" << PrintExpr(index) << "] = " << elem << "; ";
+    });
+    return;
   }
+
+  if (IsFp4PackedStorage(buffer_var, buffer->dtype) && t.is_float4_e2m1fn() &&
+      t.lanes() > 1) {
+    arith::Analyzer analyzer;
+    bool base_aligned = is_zero(analyzer.Simplify(truncmod(base, 2)));
+    if (!base_aligned) {
+      std::string vid = GetVarID(buffer_var);
+      emit_fp4_vec_scope([&](int i, const std::string &elem) {
+        PrimExpr index = analyzer.Simplify(
+            base + IntImm(base.dtype(), static_cast<int64_t>(i)));
+        this->stream << "tl_fp4_packed_store((fp4_e2_2_t*)" << vid << ", "
+                     << PrintExpr(index) << ", " << elem << "); ";
+      });
+      return;
+    }
+  }
+
+  std::string scope = GetBufferStorageScope(buffer_var);
   if (scope.empty()) {
     scope = GetPtrStorageScope(buffer->data);
   }
@@ -2164,6 +2218,53 @@ void CodeGenTileLangCUDA::PrintVecStore(const BufferNode *buffer, DataType t,
   this->PrintIndent();
   this->stream << "tl::store_global_256(&(" << buffer_ref << "), " << value
                << ");\n";
+}
+
+// FP4 storage follows the buffer role:
+// - Global FP4 storage keeps the public packed ABI.
+// - Shared FP4 storage may be lowered through remapped unpacked carriers.
+// - Local/local.fragment buffers use semantic FP4 elements for MMA operands.
+std::string
+CodeGenTileLangCUDA::GetBufferStorageScope(const VarNode *buffer_var) const {
+  auto it = alloc_storage_scope_.find(buffer_var);
+  if (it != alloc_storage_scope_.end())
+    return it->second;
+  if (const auto *ptr = buffer_var->type_annotation.as<PointerTypeNode>())
+    return ptr->storage_scope;
+  return "";
+}
+
+bool CodeGenTileLangCUDA::IsFp4PackedStorage(const VarNode *buffer_var,
+                                             DataType element_dtype) const {
+  if (!element_dtype.is_float4_e2m1fn() || !element_dtype.is_scalar()) {
+    return false;
+  }
+
+  Target cur_target = Target::Current(/*allow_not_defined=*/true);
+  std::string scope = GetBufferStorageScope(buffer_var);
+  if (scope.empty()) {
+    return true;
+  }
+  if (scope == "global") {
+    return true;
+  }
+  if (scope == "shared" || scope == "shared.dyn") {
+    // Shared FP4 keeps the packed-byte convention when it is not lowered
+    // through an unpacked carrier buffer.
+    return cur_target.defined() && tl::TargetHasSMVersionGE(cur_target, 100) &&
+           !tl::TargetHasSMVersionGE(cur_target, 120);
+  }
+  return scope != "local" && scope != "local.var" && scope != "local.fragment";
+}
+
+bool CodeGenTileLangCUDA::IsFp4SemanticLocalStorage(
+    const VarNode *buffer_var, DataType element_dtype) const {
+  if (!element_dtype.is_float4_e2m1fn() || !element_dtype.is_scalar()) {
+    return false;
+  }
+
+  std::string scope = GetBufferStorageScope(buffer_var);
+  return scope == "local" || scope == "local.fragment";
 }
 
 /**
@@ -2239,6 +2340,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
        << PrintExpr(op->args[1]) << ")";
     return;
   }
+
   if (op->op.same_as(builtin::ptx_cp_async())) {
     // args[0] = dst_access_ptr, args[1] = src_access_ptr, args[2] = bytes,
     // args[3] = predicate (optional)
@@ -2266,8 +2368,28 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     // args[2] = num_elems, args[3] = predicate (optional)
     int total_bytes = GetTileLangCPAsyncTransferBytes(op);
 
-    std::string dst = this->PrintExpr(op->args[0]);
-    std::string src = this->PrintExpr(op->args[1]);
+    auto print_access_ptr = [&](const PrimExpr &access_ptr) {
+      auto elem_type = GetAccessPtrElementType(access_ptr);
+      const auto *ptr_call = access_ptr.as<CallNode>();
+      if (elem_type.has_value() && elem_type->is_float4_e2m1fn() &&
+          ptr_call != nullptr &&
+          ptr_call->op.same_as(builtin::tvm_access_ptr())) {
+        ICHECK_GE(ptr_call->args.size(), 5U);
+        std::string base = this->PrintExpr(ptr_call->args[1]);
+        PrimExpr offset_expr = ptr_call->args[2];
+        if (const auto *base_var = ptr_call->args[1].as<VarNode>()) {
+          if (IsFp4PackedStorage(base_var, elem_type.value())) {
+            // Generic FP4 cp.async operands keep packed-byte addressing.
+            offset_expr = arith::Analyzer().Simplify(truncdiv(offset_expr, 2));
+          }
+        }
+        return base + " + " + this->PrintExpr(offset_expr);
+      }
+      return this->PrintExpr(access_ptr);
+    };
+
+    std::string dst = print_access_ptr(op->args[0]);
+    std::string src = print_access_ptr(op->args[1]);
     std::string size = std::to_string(total_bytes);
 
     this->PrintIndent();
@@ -4539,13 +4661,18 @@ void CodeGenTileLangCUDA::VisitStmt_(const AllocBufferNode *op) {
     bool is_float4_unpacked_shared =
         alloc_dtype.is_float4_e2m1_unpacked() &&
         (scope == "shared" || scope == "shared.dyn");
-    bool is_fp4_scalar_local = alloc_dtype.is_float4_e2m1fn() &&
-                               alloc_dtype.is_scalar() && scope == "local";
     bool is_int4_scalar_local =
         (alloc_dtype == DataType::Int(4) || alloc_dtype == DataType::UInt(4)) &&
-        alloc_dtype.is_scalar() && scope == "local";
-    if (!is_fp4_scalar_local && !is_int4_scalar_local) {
+        alloc_dtype.is_scalar() &&
+        (scope == "local" || scope == "local.fragment");
+    if (!is_int4_scalar_local) {
       PrintStorageScope(scope, stream);
+      if (alloc_dtype.is_float4_e2m1fn() && alloc_dtype.is_scalar() &&
+          (scope == "local" || scope == "local.fragment")) {
+        // Vectorized FP4 fragments reinterpret groups such as fp4_e2_16_t and
+        // fp4_e2_32_t from this local backing.
+        stream << "alignas(16) ";
+      }
       if (is_float4_unpacked_shared) {
         stream << "uint8_t";
       } else {
@@ -4580,20 +4707,16 @@ void CodeGenTileLangCUDA::VisitStmt_(const AllocBufferNode *op) {
       PrintIndent();
       stream << "auto " << vid << " = reinterpret_cast<" << mbarrier_dtype_
              << "*>(" << v_id_mem << ");\n";
-    } else if (scope == "local") {
+    } else if (scope == "local" || scope == "local.fragment") {
       if (alloc_dtype == DataType::Int(4) || alloc_dtype == DataType::UInt(4)) {
         stream << "alignas(16) ";
         PrintType(alloc_dtype, stream);
         stream << ' ' << vid << '[' << (constant_size + 1) / 2 << "];\n";
       } else {
-        if (alloc_dtype.is_float4_e2m1fn() && alloc_dtype.is_scalar()) {
-          auto vid_packed = vid + "_packed";
-          stream << "fp4_e2_2_t " << vid_packed << '['
-                 << (constant_size + 1) / 2 << "];\n";
-          fp4_packed_buffers_[op->buffer->data.get()] = vid_packed;
-        } else {
-          stream << ' ' << vid << '[' << constant_size << "];\n";
-        }
+        // Local FP4 is not byte-packed. Global/shared scopes own packing
+        // through GetBufferRef and the packed helpers; local arrays model the
+        // fragment elements consumed by ldmatrix and MMA.
+        stream << ' ' << vid << '[' << constant_size << "];\n";
       }
     } else if (scope == "local.var") {
       PrimExpr init = tirx::make_const(alloc_dtype, 0);
@@ -4682,22 +4805,13 @@ void CodeGenTileLangCUDA::VisitExpr_(const BufferLoadNode *op,
     return;
   }
 
-  // Check if this is a fp4 packed buffer access
-  auto packed_it = fp4_packed_buffers_.find(buffer_var.get());
-  if (packed_it != fp4_packed_buffers_.end() && value_dtype.is_scalar()) {
-    std::string idx_str = PrintExpr(index);
-    os << "tl_fp4_packed_load(" << packed_it->second << ", " << idx_str << ")";
-    return;
-  }
   int lanes = op->dtype.lanes();
   // declare type.
   if (value_dtype.lanes() == element_dtype.lanes()) {
-    // For scalar fp4 loads from non-packed buffers, use tl_fp4_packed_load
-    // to correctly extract the nibble at the given index (the /2 in
-    // GetBufferRef maps two consecutive fp4 elements to the same byte, but
-    // reading that byte only returns the low nibble — the odd-indexed element
-    // is lost).
-    if (element_dtype.is_float4_e2m1fn() && element_dtype.lanes() == 1) {
+    // Scalar FP4 packed buffers need nibble selection even when the backing
+    // storage is byte-indexed. Without the helper, two logical FP4 elements
+    // map to one byte and odd-indexed loads would read the low nibble.
+    if (IsFp4PackedStorage(buffer_var.get(), element_dtype)) {
       std::string idx_str = PrintExpr(index);
       std::string vid = GetVarID(buffer_var.get());
       os << "tl_fp4_packed_load((fp4_e2_2_t*)" << vid << ", " << idx_str << ")";
@@ -4781,22 +4895,11 @@ void CodeGenTileLangCUDA::VisitStmt_(const BufferStoreNode *op) {
     return;
   }
 
-  // Check if this is a fp4 packed buffer access
-  auto packed_it = fp4_packed_buffers_.find(buffer_var.get());
-  if (packed_it != fp4_packed_buffers_.end() && value_dtype.is_scalar()) {
-    std::string idx_str = PrintExpr(index_expr);
-    std::string value = this->PrintExpr(op->value);
-    this->PrintIndent();
-    stream << "tl_fp4_packed_store(" << packed_it->second << ", " << idx_str
-           << ", " << value << ");\n";
-    return;
-  }
   if (value_dtype.lanes() == element_dtype.lanes()) {
-    // For scalar fp4 stores to non-packed buffers, use tl_fp4_packed_store
-    // to correctly handle nibble-level writes. The /2 in GetBufferRef maps two
-    // consecutive fp4 elements to the same byte, and a plain assignment
-    // overwrites the entire byte — destroying the neighboring nibble.
-    if (element_dtype.is_float4_e2m1fn() && element_dtype.lanes() == 1) {
+    // Scalar FP4 packed stores update one nibble at the logical index.
+    // A plain assignment to the backing byte would overwrite the neighboring
+    // element.
+    if (IsFp4PackedStorage(buffer_var.get(), element_dtype)) {
       std::string idx_str = PrintExpr(index_expr);
       std::string value = this->PrintExpr(op->value);
       std::string vid = GetVarID(buffer_var.get());

--- a/src/cuda/codegen/codegen_cuda.h
+++ b/src/cuda/codegen/codegen_cuda.h
@@ -81,6 +81,13 @@ private:
   void HandleVolatileLoads(const std::string &value, const BufferLoadNode *op,
                            std::ostream &os) final;
   bool HandleLateIntrinsicCall(const CallNode *op, std::ostream &os);
+  // FP4 address helpers preserve public packed storage while allowing internal
+  // unpacked carrier buffers for shared-memory lowering.
+  std::string GetBufferStorageScope(const VarNode *buffer_var) const;
+  bool IsFp4PackedStorage(const VarNode *buffer_var,
+                          DataType element_dtype) const;
+  bool IsFp4SemanticLocalStorage(const VarNode *buffer_var,
+                                 DataType element_dtype) const;
 
   // Whether scope such as "__shared__" or "__constant__"  is part of type.
   bool IsScopePartOfType() const final { return false; }
@@ -155,8 +162,6 @@ private:
   std::unordered_map<const VarNode *, std::string> fragment_layouts;
   std::unordered_map<const VarNode *, IntImm> unroll_factor;
   std::optional<std::tuple<int64_t, int64_t, int64_t>> cluster_dims;
-  // ffi::Map from VarNode to packed buffer variable name for fp4 packed storage
-  std::unordered_map<const VarNode *, std::string> fp4_packed_buffers_;
   friend void PrintConst(const FloatImmNode *op, std::ostream &os,
                          CodeGenTileLangCUDA *p);
   void PrintWmmaScope(const std::string &scope, DataType t,

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -291,6 +291,8 @@ std::string DTypeToString(DataType t) {
   } else if (t.is_float4()) {
     if (t.is_float4_e2m1fn()) {
       elem_type = "Float4E2M1FN";
+    } else if (t.is_float4_e2m1_unpacked()) {
+      elem_type = "Uint8";
     }
   } else if (t.is_bool()) {
     elem_type = "Boolean";
@@ -2544,6 +2546,25 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const BindNode *op) {
         PrintType(prim_type->dtype, stream);
         stream << ", " << PrintExpr_(call->args[0]) << ", " << address_space
                << ")\n";
+        return;
+      }
+
+      if (const CallNode *call = op->value.as<CallNode>();
+          call && call->op.same_as(builtin::handle_add_byte_offset()) &&
+          call->args.size() == 2U) {
+        const auto *base_var = call->args[0].as<VarNode>();
+        ICHECK(base_var == nullptr ||
+               HandleTypeMatch_(base_var, DataType::UInt(8)))
+            << "CuTeDSL byte-offset aliases must be based on a uint8 arena";
+
+        PrintIndent();
+        stream << AllocVarID(op->var.get())
+               << " = tl.make_tensor(tl.recast_ptr("
+               << GetVarPtr_(call->args[0]) << " + "
+               << PrintExpr_(call->args[1]) << ", dtype=";
+        PrintType(prim_type->dtype, stream);
+        stream << "), (1,))\n";
+        RegisterHandleType_(op->var.get(), prim_type->dtype);
         return;
       }
     }

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -1045,6 +1045,12 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
 
   Buffer shared_tensor = is_ldmatrix ? src : dst;
   Buffer local_tensor = is_ldmatrix ? dst : src;
+  bool is_fp4_ldmatrix = is_ldmatrix &&
+                         shared_tensor->dtype.is_float4_e2m1_unpacked() &&
+                         local_tensor->dtype.is_float4_e2m1_unpacked();
+  if (is_fp4_ldmatrix && !TargetSupportsFp4Ldmatrix(T.target)) {
+    return LowerNormal(op, T, analyzer);
+  }
   Array<Range> local_region = is_ldmatrix ? src_range : dst_range;
   bool is_full_range = true;
   for (size_t i = 0; i < local_region.size(); i++) {
@@ -1094,27 +1100,34 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
   } else {
     return LowerNormal(op, T, analyzer);
   }
-  if (shared_tensor->dtype.bytes() != 2) {
+  if (!is_fp4_ldmatrix && shared_tensor->dtype.bytes() != 2) {
     return LowerNormal(op, T, analyzer);
   }
+
+  PrimExpr extent = local_tensor->shape[0];
+  int num = 1;
+  // FP4 unpacked byte carrier returns four logical elements per register; b16
+  // returns two.
+  int elems_per_reg = is_fp4_ldmatrix ? 4 : 2;
+  int max_elems_per_inst = elems_per_reg * 4;
+  int mid_elems_per_inst = elems_per_reg * 2;
   PrimExpr flattened_indice = shared_tensor.OffsetOf(shared_indices).back();
   if (!IndicesCanVectorize(flattened_indice, loop_vars.back()->var,
-                           loop_vars.back()->dom->extent, 8, analyzer)) {
+                           loop_vars.back()->dom->extent, max_elems_per_inst,
+                           analyzer)) {
     return LowerNormal(op, T, analyzer);
   }
+  if (analyzer->CanProveEqual(FloorMod(extent, max_elems_per_inst), 0))
+    num = 4;
+  else if (analyzer->CanProveEqual(FloorMod(extent, mid_elems_per_inst), 0))
+    num = 2;
+  int elems_per_inst = elems_per_reg * num;
 
   for (size_t i = 0; i < dst_range.size(); i++) {
     if (!is_zero(dst_range[i]->min) ||
         !analyzer->CanProveEqual(dst_range[i]->extent, dst->shape[i]))
       return LowerNormal(op, T, analyzer);
   }
-
-  PrimExpr extent = local_tensor->shape[0];
-  int num = 1;
-  if (analyzer->CanProveEqual(FloorMod(extent, 8), 0))
-    num = 4;
-  else if (analyzer->CanProveEqual(FloorMod(extent, 4), 0))
-    num = 2;
 
   Array<PrimExpr> args;
   const Op &copy_op = is_ldmatrix ? tl::ptx_ldmatrix() : tl::ptx_stmatrix();
@@ -1127,7 +1140,8 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
   PrimExpr warp = FloorDiv(T.thread_var, 32) * 32;
   if (!is_transposed) {
     auto local_index = analyzer->Simplify(
-        local_iter * 2 * num + 2 * FloorMod(FloorDiv(T.thread_var, 8), num));
+        local_iter * elems_per_inst +
+        elems_per_reg * FloorMod(FloorDiv(T.thread_var, 8), num));
     auto thread_index =
         analyzer->Simplify(warp + FloorMod(T.thread_var, 8) * 4);
     shared_coords = inv->Forward({local_index, thread_index});
@@ -1142,18 +1156,19 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
   shared_coords.pop_back();
   PrimExpr shared_addr =
       Call(DataType::Handle(), tl::access_ptr(),
-           {BufferLoad(shared_tensor, shared_coords), PrimExpr(2 * num),
+           {BufferLoad(shared_tensor, shared_coords), PrimExpr(elems_per_inst),
             make_const(DataType::Int(32), is_ldmatrix ? 1 : 2)});
   args.push_back(shared_addr);
 
   if (is_ldmatrix) {
-    if (local_tensor->dtype != shared_tensor->dtype) {
+    if (local_tensor->dtype != shared_tensor->dtype &&
+        !(is_fp4_ldmatrix && local_tensor->dtype.is_float4_e2m1_unpacked())) {
       return LowerNormal(op, T, analyzer);
     }
     PrimExpr local_addr =
         Call(DataType::Handle(), tl::access_ptr(),
-             {BufferLoad(local_tensor, {local_iter * 2 * num}),
-              PrimExpr(2 * num), make_const(DataType::Int(32), 2)});
+             {BufferLoad(local_tensor, {local_iter * elems_per_inst}),
+              PrimExpr(elems_per_inst), make_const(DataType::Int(32), 2)});
     args.push_back(local_addr);
   } else {
     for (int i = 0; i < num; i++) {
@@ -1172,8 +1187,8 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
   }
 
   auto body = Evaluate(Call(DataType::Handle(), copy_op, args));
-  For for_node =
-      For(local_iter, 0, FloorDiv(extent, 2 * num), ForKind::kSerial, body);
+  For for_node = For(local_iter, 0, FloorDiv(extent, elems_per_inst),
+                     ForKind::kSerial, body);
   for_node = PragmaUnrollLoop(for_node);
   auto range = T.thread_bounds;
   if (range.defined()) {
@@ -1595,7 +1610,7 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
   desc.smem_box.Set(0, PrimExpr(instruction_dim));
 
   int inner_box_dim_ =
-      TMABytesFromElements(instruction_dim, shared_tensor->dtype);
+      TMABytesFromElements(instruction_dim, shared_tensor_unmapped->dtype);
 
   struct SwizzleCheck {
     int swizzle;

--- a/src/cuda/op/copy.h
+++ b/src/cuda/op/copy.h
@@ -39,6 +39,7 @@ enum class CopyInst : uint8_t {
 const char *CopyInstToString(CopyInst inst);
 bool CopyInstIsTMA(CopyInst inst);
 bool CopyInstIsCPAsync(CopyInst inst);
+bool TargetSupportsFp4Ldmatrix(Target target);
 
 struct TMADesc {
   size_t rank;

--- a/src/cuda/op/copy_analysis.cc
+++ b/src/cuda/op/copy_analysis.cc
@@ -137,6 +137,17 @@ PreferredCopyInstruction GetPreferredInstruction(const CopyNode &op) {
   return PreferredCopyInstruction::kAuto;
 }
 
+bool IsFp4E2M1CarrierDType(DataType dtype) {
+  return dtype.is_float4_e2m1fn() || dtype.is_float4_e2m1_unpacked();
+}
+
+bool IsGlobalSharedFp4CarrierCopy(const CopyNode &op) {
+  bool global_shared = (IsGlobalBuffer(op.src) && IsSharedBuffer(op.dst)) ||
+                       (IsSharedBuffer(op.src) && IsGlobalBuffer(op.dst));
+  return global_shared && IsFp4E2M1CarrierDType(op.src->dtype) &&
+         IsFp4E2M1CarrierDType(op.dst->dtype);
+}
+
 bool CheckGlobalStrides(const Buffer &buffer, arith::Analyzer *analyzer,
                         bool emit_diagnostics) {
   Array<PrimExpr> strides = buffer->strides;
@@ -198,6 +209,14 @@ bool CheckBulkLoad(const CopyNode &op, Target target, arith::Analyzer *analyzer,
       (op.dst.scope() != "shared.dyn" && op.dst.scope() != "shared")) {
     return false;
   }
+  if (!GetIsTmaCopy(op) && IsGlobalSharedFp4CarrierCopy(op)) {
+    if (emit_diagnostics) {
+      DLOG(WARNING)
+          << "TMA bulk load is disabled for implicit FP4 carrier copies, "
+             "fallback to normal copy.";
+    }
+    return false;
+  }
   if (check_last_dim &&
       analyzer->CanProve(
           FloorMod(
@@ -235,6 +254,14 @@ bool CheckBulkStore(const CopyNode &op, Target target,
   }
   if ((op.src.scope() != "shared.dyn" && op.src.scope() != "shared") ||
       op.dst.scope() != "global") {
+    return false;
+  }
+  if (!GetIsTmaCopy(op) && IsGlobalSharedFp4CarrierCopy(op)) {
+    if (emit_diagnostics) {
+      DLOG(WARNING)
+          << "TMA bulk store is disabled for implicit FP4 carrier copies, "
+             "fallback to normal copy.";
+    }
     return false;
   }
   if (check_last_dim &&
@@ -330,13 +357,27 @@ bool CheckBulkStore1D(const CopyNode &op, Target target,
 }
 
 bool CheckLDSMCopy(const CopyNode &op, Target target) {
-  return TargetHasLdmatrix(target) && IsSharedBuffer(op.src) &&
-         IsFragmentBuffer(op.dst);
+  if (!TargetHasLdmatrix(target) || !IsSharedBuffer(op.src) ||
+      !IsFragmentBuffer(op.dst)) {
+    return false;
+  }
+  bool uses_fp4 = IsFp4E2M1CarrierDType(op.src->dtype) ||
+                  IsFp4E2M1CarrierDType(op.dst->dtype);
+  if (!uses_fp4) {
+    return true;
+  }
+  if (!TargetSupportsFp4Ldmatrix(target)) {
+    return false;
+  }
+  return op.src->dtype == op.dst->dtype ||
+         (op.src->dtype.is_float4_e2m1fn() &&
+          op.dst->dtype.is_float4_e2m1_unpacked());
 }
 
 bool CheckSTSMCopy(const CopyNode &op, Target target) {
-  return TargetHasStmatrix(target) && IsFragmentBuffer(op.src) &&
-         IsSharedBuffer(op.dst);
+  return !IsFp4E2M1CarrierDType(op.src->dtype) &&
+         !IsFp4E2M1CarrierDType(op.dst->dtype) && TargetHasStmatrix(target) &&
+         IsFragmentBuffer(op.src) && IsSharedBuffer(op.dst);
 }
 
 bool CheckTMemLoad(const CopyNode &op, Target target) {
@@ -408,6 +449,10 @@ bool CopyInstIsTMA(CopyInst inst) {
 }
 
 bool CopyInstIsCPAsync(CopyInst inst) { return inst == CopyInst::kCPAsync; }
+
+bool TargetSupportsFp4Ldmatrix(Target target) {
+  return TargetHasSMVersionGE(target, 120);
+}
 
 namespace {
 

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -237,8 +237,11 @@ LayoutMap GemmNode::InferLayout(const LayoutInferArgs &T,
     for (auto kv : inferred_layouts) {
       const Buffer &buf = kv.first;
       const Layout &layout = kv.second;
-      if (reuse_existing_shared_layout && IsSharedBuffer(buf) &&
-          T.layout_map.count(buf)) {
+      bool is_shared_buffer = IsSharedBuffer(buf);
+      bool replace_fp4_shared_layout =
+          is_shared_buffer && buf->dtype.is_float4_e2m1fn();
+      if (reuse_existing_shared_layout && is_shared_buffer &&
+          T.layout_map.count(buf) && !replace_fp4_shared_layout) {
         continue;
       }
       if (auto frag = layout.as<Fragment>()) {

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -46,7 +46,10 @@ private:
     auto load = Downcast<BufferLoad>(StmtExprMutator::VisitExpr_(op));
 
     if (buffer_remap_.count(load->buffer)) {
-      auto new_indices = layout_map_[load->buffer]->Forward(load->indices);
+      Array<PrimExpr> new_indices = load->indices;
+      if (layout_map_.count(load->buffer)) {
+        new_indices = layout_map_[load->buffer]->Forward(load->indices);
+      }
       auto new_buffer = buffer_remap_[load->buffer];
 
       return BufferLoad(new_buffer, new_indices);
@@ -57,9 +60,14 @@ private:
   Stmt VisitStmt_(const BufferStoreNode *op) final {
     auto store = Downcast<BufferStore>(StmtExprMutator::VisitStmt_(op));
     if (buffer_remap_.count(store->buffer)) {
-      auto new_indices = layout_map_[store->buffer]->Forward(store->indices);
+      Array<PrimExpr> new_indices = store->indices;
+      if (layout_map_.count(store->buffer)) {
+        new_indices = layout_map_[store->buffer]->Forward(store->indices);
+      }
       auto new_buffer = buffer_remap_[store->buffer];
-      return BufferStore(new_buffer, store->value, new_indices);
+      return BufferStore(new_buffer,
+                         CastFp4StorageValue(store->value, new_buffer->dtype),
+                         new_indices);
     }
     return store;
   }

--- a/src/op/utils.cc
+++ b/src/op/utils.cc
@@ -148,6 +148,20 @@ PrimExpr MakeAccessPtrFromBufferLoad(const BufferLoad &load, int rw_mask) {
   return Call(DataType::Handle(), builtin::tvm_access_ptr(), acc_args);
 }
 
+bool IsFp4E2M1StoragePair(DataType lhs, DataType rhs) {
+  auto is_e2m1 = [](DataType dtype) {
+    return dtype.is_float4_e2m1fn() || dtype.is_float4_e2m1_unpacked();
+  };
+  return is_e2m1(lhs) && is_e2m1(rhs) && lhs.lanes() == rhs.lanes();
+}
+
+PrimExpr CastFp4StorageValue(PrimExpr value, DataType dtype) {
+  if (value.dtype() != dtype && IsFp4E2M1StoragePair(value.dtype(), dtype)) {
+    return Cast(dtype, value);
+  }
+  return value;
+}
+
 // Maps TVM DataType to CUDA's CUtensorMapDataType enum value.
 int to_CUtensorMapDataType(DataType dtype) {
   // CUDA 13 adds packed U4 TensorMap formats. The vendored CUDA stub may lag

--- a/src/op/utils.h
+++ b/src/op/utils.h
@@ -54,6 +54,10 @@ TVM_DLL PrimExpr MakeAccessPtrFromRegion(const BufferRegion &region,
 TVM_DLL PrimExpr MakeAccessPtrFromBufferLoad(const BufferLoad &load,
                                              int rw_mask);
 
+TVM_DLL bool IsFp4E2M1StoragePair(DataType lhs, DataType rhs);
+
+TVM_DLL PrimExpr CastFp4StorageValue(PrimExpr value, DataType dtype);
+
 inline bool IsFragmentBuffer(const Buffer &buffer) {
   return buffer.defined() && buffer.scope() == "local.fragment";
 }

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -34,6 +34,8 @@ using cute::cast_smem_ptr_to_uint;
 
 using int4_t = int4;
 
+struct fp4_e2_t;
+
 #define hexp cutlass::fast_exp
 #define hlog cutlass::fast_log
 #define hsqrt cutlass::fast_sqrt
@@ -687,6 +689,9 @@ template <> struct to_cute_type<tl::float_e5m2_t> {
 };
 template <> struct to_cute_type<tl::tfloat32_t> {
   using type = cute::tfloat32_t;
+};
+template <> struct to_cute_type<::fp4_e2_t> {
+  using type = cute::float_e2m1_t;
 };
 
 // =========================================================================

--- a/src/tl_templates/cuda/cuda_fp4.h
+++ b/src/tl_templates/cuda/cuda_fp4.h
@@ -2,7 +2,8 @@
 
 #include "common.h"
 
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)) ||                      \
+    (defined(__CUDA_ARCH_LIST__) && (__CUDA_ARCH_LIST__ >= 1200))
 #include <cuda_fp4.h>
 
 // Wrapper for __nv_fp4_e2m1 with implicit conversions
@@ -166,6 +167,31 @@ TL_DEVICE fp4_e2_32_t make_fp4_e2_32_t(
                               x12, x13, x14, x15);
   result.y = make_fp4_e2_16_t(y0, y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11,
                               y12, y13, y14, y15);
+  return result;
+}
+
+// Pack sixty-four fp4_e2_t values.
+TL_DEVICE fp4_e2_64_t make_fp4_e2_64_t(
+    fp4_e2_t x0, fp4_e2_t x1, fp4_e2_t x2, fp4_e2_t x3, fp4_e2_t x4,
+    fp4_e2_t x5, fp4_e2_t x6, fp4_e2_t x7, fp4_e2_t x8, fp4_e2_t x9,
+    fp4_e2_t x10, fp4_e2_t x11, fp4_e2_t x12, fp4_e2_t x13, fp4_e2_t x14,
+    fp4_e2_t x15, fp4_e2_t x16, fp4_e2_t x17, fp4_e2_t x18, fp4_e2_t x19,
+    fp4_e2_t x20, fp4_e2_t x21, fp4_e2_t x22, fp4_e2_t x23, fp4_e2_t x24,
+    fp4_e2_t x25, fp4_e2_t x26, fp4_e2_t x27, fp4_e2_t x28, fp4_e2_t x29,
+    fp4_e2_t x30, fp4_e2_t x31, fp4_e2_t y0, fp4_e2_t y1, fp4_e2_t y2,
+    fp4_e2_t y3, fp4_e2_t y4, fp4_e2_t y5, fp4_e2_t y6, fp4_e2_t y7,
+    fp4_e2_t y8, fp4_e2_t y9, fp4_e2_t y10, fp4_e2_t y11, fp4_e2_t y12,
+    fp4_e2_t y13, fp4_e2_t y14, fp4_e2_t y15, fp4_e2_t y16, fp4_e2_t y17,
+    fp4_e2_t y18, fp4_e2_t y19, fp4_e2_t y20, fp4_e2_t y21, fp4_e2_t y22,
+    fp4_e2_t y23, fp4_e2_t y24, fp4_e2_t y25, fp4_e2_t y26, fp4_e2_t y27,
+    fp4_e2_t y28, fp4_e2_t y29, fp4_e2_t y30, fp4_e2_t y31) {
+  fp4_e2_64_t result;
+  result.x = make_fp4_e2_32_t(x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11,
+                              x12, x13, x14, x15, x16, x17, x18, x19, x20, x21,
+                              x22, x23, x24, x25, x26, x27, x28, x29, x30, x31);
+  result.y = make_fp4_e2_32_t(y0, y1, y2, y3, y4, y5, y6, y7, y8, y9, y10, y11,
+                              y12, y13, y14, y15, y16, y17, y18, y19, y20, y21,
+                              y22, y23, y24, y25, y26, y27, y28, y29, y30, y31);
   return result;
 }
 

--- a/src/tl_templates/cuda/gemm_mma.h
+++ b/src/tl_templates/cuda/gemm_mma.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cute/algorithm/clear.hpp>
-#include <cute/arch/mma_sm120.hpp>
 #include <cute/arch/mma_sm75.hpp>
 #include <cute/arch/mma_sm80.hpp>
 #include <cute/arch/mma_sm89.hpp>
@@ -42,9 +41,13 @@ using _X = Underscore;
 
 #ifdef __CUDA_ARCH_LIST__
 #if __CUDA_ARCH_LIST__ >= 1200
+#include "cuda_fp4.h"
 #include "cuda_fp8.h"
 #include <cute/arch/mma_sm120.hpp>
 #include <cute/arch/mma_sm80.hpp>
+TL_DISPATCH_MMA_TEMPLATE(fp4_e2_t, fp4_e2_t, float, SM120_16x8x32_TN)
+TL_DISPATCH_MMA_TEMPLATE(fp8_e4_t, fp4_e2_t, float, SM120_16x8x32_TN)
+TL_DISPATCH_MMA_TEMPLATE(fp4_e2_t, fp8_e4_t, float, SM120_16x8x32_TN)
 TL_DISPATCH_MMA_TEMPLATE(fp8_e4_t, fp8_e4_t, float, SM120_16x8x32_TN)
 TL_DISPATCH_MMA_TEMPLATE(fp8_e5_t, fp8_e5_t, float, SM120_16x8x32_TN)
 TL_DISPATCH_MMA(half_t, half_t, half_t, SM80_16x8x16_F16F16F16F16_TN)

--- a/src/tl_templates/cuda/instruction/mma.h
+++ b/src/tl_templates/cuda/instruction/mma.h
@@ -4,6 +4,15 @@
 #include <cute/arch/mma_sm75.hpp>
 #include <cute/arch/mma_sm80.hpp>
 #include <cute/arch/mma_sm89.hpp>
+
+#if (defined(__CUDA_ARCH_LIST__) && (__CUDA_ARCH_LIST__ >= 1200)) ||           \
+    (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1200))
+#define TL_HAS_F8F6F4_MMA_DISPATCHER 1
+#include <cute/arch/mma_sm120.hpp>
+#else
+#define TL_HAS_F8F6F4_MMA_DISPATCHER 0
+#endif
+
 #ifndef __CUDACC_RTC__
 #include <type_traits>
 #include <utility>
@@ -155,6 +164,49 @@ struct SM75_8x8x16_S32U8U8S32_TN {
   }
 };
 
+#if TL_HAS_F8F6F4_MMA_DISPATCHER
+template <class Impl, bool ShiftA, bool ShiftB> struct F8F6F4_16x8x32_TN {
+  using DRegisters = typename Impl::DRegisters;
+  using ARegisters = typename Impl::ARegisters;
+  using BRegisters = typename Impl::BRegisters;
+  using CRegisters = typename Impl::CRegisters;
+
+  template <bool Shift>
+  CUTE_HOST_DEVICE static uint32_t shift_fp4_mma_operand(uint32_t value) {
+    if constexpr (Shift) {
+      return value << 2;
+    } else {
+      return value;
+    }
+  }
+
+  CUTE_HOST_DEVICE static void fma(float &d0, float &d1, float &d2, float &d3,
+                                   uint32_t const &a0, uint32_t const &a1,
+                                   uint32_t const &a2, uint32_t const &a3,
+                                   uint32_t const &b0, uint32_t const &b1,
+                                   float const &c0, float const &c1,
+                                   float const &c2, float const &c3) {
+    // F8F6F4 MMA consumes the e2m1 payload from bits 2..5 of each
+    // byte-carrier lane, so FP4 operands are shifted immediately before fma.
+    Impl::fma(
+        d0, d1, d2, d3, shift_fp4_mma_operand<ShiftA>(a0),
+        shift_fp4_mma_operand<ShiftA>(a1), shift_fp4_mma_operand<ShiftA>(a2),
+        shift_fp4_mma_operand<ShiftA>(a3), shift_fp4_mma_operand<ShiftB>(b0),
+        shift_fp4_mma_operand<ShiftB>(b1), c0, c1, c2, c3);
+  }
+};
+
+using F8F6F4_FP4_FP4_F32_TN = F8F6F4_16x8x32_TN<
+    cute::SM120_16x8x32_TN<cute::float_e2m1_t, cute::float_e2m1_t, float>, true,
+    true>;
+using F8F6F4_FP8_FP4_F32_TN = F8F6F4_16x8x32_TN<
+    cute::SM120_16x8x32_TN<cute::float_e4m3_t, cute::float_e2m1_t, float>,
+    false, true>;
+using F8F6F4_FP4_FP8_F32_TN = F8F6F4_16x8x32_TN<
+    cute::SM120_16x8x32_TN<cute::float_e2m1_t, cute::float_e4m3_t, float>, true,
+    false>;
+#endif
+
 template <DataType AType, DataType BType, DataType CType, int M, int N, int K,
           bool TransA, bool TransB, bool Saturate>
 struct MmaDispatcher {
@@ -233,6 +285,16 @@ TL_DEFINE_MMA_DISPATCHER(kUInt4, kUInt4, kInt32, 16, 8, 32, false, true, false,
 TL_DEFINE_MMA_DISPATCHER(kUInt4, kUInt4, kInt32, 16, 8, 64, false, true, false,
                          cute::SM80_16x8x64_S32U4U4S32_TN)
 
+#if TL_HAS_F8F6F4_MMA_DISPATCHER
+// FP4/F8F6F4 inputs (k32)
+TL_DEFINE_MMA_DISPATCHER(kFloat4_e2m1fn, kFloat4_e2m1fn, kFloat32, 16, 8, 32,
+                         false, true, false, tl::detail::F8F6F4_FP4_FP4_F32_TN)
+TL_DEFINE_MMA_DISPATCHER(kFloat8_e4m3, kFloat4_e2m1fn, kFloat32, 16, 8, 32,
+                         false, true, false, tl::detail::F8F6F4_FP8_FP4_F32_TN)
+TL_DEFINE_MMA_DISPATCHER(kFloat4_e2m1fn, kFloat8_e4m3, kFloat32, 16, 8, 32,
+                         false, true, false, tl::detail::F8F6F4_FP4_FP8_F32_TN)
+#endif
+
 // FP8 inputs (k32)
 TL_DEFINE_MMA_DISPATCHER(kFloat8_e4m3, kFloat8_e4m3, kFloat16, 16, 8, 32, false,
                          true, false, cute::SM89_16x8x32_F16E4M3E4M3F16_TN)
@@ -265,6 +327,7 @@ TL_DEFINE_MMA_DISPATCHER(kFloat64, kFloat64, kFloat64, 8, 8, 4, false, true,
                          false, cute::SM80_8x8x4_F64F64F64F64_TN)
 
 #undef TL_DEFINE_MMA_DISPATCHER
+#undef TL_HAS_F8F6F4_MMA_DISPATCHER
 
 } // namespace detail
 

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -19,6 +19,7 @@
 #include "../layout/layout.h"
 #include "../layout/utils.h"
 #include "../op/builtin.h"
+#include "../op/copy.h"
 #include "../op/gemm.h"
 #include "../op/gemm_sp.h"
 #include "../op/operator.h"
@@ -39,14 +40,38 @@ namespace tl {
 using namespace tirx;
 using namespace ffi;
 
+static bool IsScalarFp4E2M1(const Buffer &buffer) {
+  return buffer->dtype.is_float4_e2m1fn() && buffer->dtype.is_scalar();
+}
+
+static bool IsScalarUnpackedFp4E2M1(const Buffer &buffer) {
+  return buffer->dtype.is_float4_e2m1_unpacked() && buffer->dtype.is_scalar();
+}
+
+static DataType GetLayoutStorageDType(const Buffer &buffer) {
+  if (IsSharedBuffer(buffer) && IsScalarFp4E2M1(buffer)) {
+    return DataType::Float4E2M1Unpacked(buffer->dtype.lanes());
+  }
+  return buffer->dtype;
+}
+
+static Buffer makeBufferWithDType(const Buffer &buffer, DataType dtype) {
+  return Buffer(buffer->data, dtype, buffer->shape, buffer->strides,
+                buffer->elem_offset, buffer->name, buffer->data_alignment,
+                buffer->offset_factor, buffer->buffer_type);
+}
+
 static Buffer makeBufferWithLayout(const Buffer &buffer, const Layout &layout,
                                    Map<Var, Var> &var_remap) {
   const auto *ptr_type =
       TVM_TYPE_AS(buffer->data->type_annotation, PointerTypeNode);
+  DataType storage_dtype = GetLayoutStorageDType(buffer);
   Type new_type;
   // convert fragments to normal local buffer
   if (IsFragmentBuffer(buffer)) {
-    new_type = PointerType(ptr_type->element_type, "local");
+    new_type = PointerType(PrimType(storage_dtype), "local");
+  } else if (storage_dtype != buffer->dtype) {
+    new_type = PointerType(PrimType(storage_dtype), ptr_type->storage_scope);
   } else {
     new_type = buffer->data->type_annotation;
   }
@@ -83,7 +108,7 @@ static Buffer makeBufferWithLayout(const Buffer &buffer, const Layout &layout,
       output_shape.insert(output_shape.begin(), replicate_extent);
     }
   }
-  return Buffer(new_var, buffer->dtype, output_shape, {}, buffer->elem_offset,
+  return Buffer(new_var, storage_dtype, output_shape, {}, buffer->elem_offset,
                 buffer->name, buffer->data_alignment, buffer->offset_factor,
                 buffer->buffer_type);
 }
@@ -332,6 +357,22 @@ public:
 
 private:
   using arith::IRMutatorWithAnalyzer::IRMutatorWithAnalyzer;
+
+  void MaybeRemapFp4CopySource(const CopyNode *copy) {
+    if (!IsGlobalBuffer(copy->src) || !IsScalarFp4E2M1(copy->src) ||
+        !IsSharedBuffer(copy->dst) || !buffer_remap_.count(copy->dst)) {
+      return;
+    }
+    Buffer remapped_dst = buffer_remap_[copy->dst];
+    if (!IsScalarUnpackedFp4E2M1(remapped_dst)) {
+      return;
+    }
+    if (!buffer_remap_.count(copy->src)) {
+      buffer_remap_.Set(
+          copy->src,
+          makeBufferWithDType(copy->src, DataType::Float4E2M1Unpacked()));
+    }
+  }
 
   Stmt VisitStmt_(const SBlockNode *op) final {
     // Record the mapping from buffer data var to buffer for later lookup
@@ -1023,9 +1064,14 @@ private:
     }
     auto buffer = load->buffer;
     if (buffer_remap_.count(buffer)) {
-      auto new_indices = layout_map_[buffer]->Forward(load->indices);
+      Array<PrimExpr> new_indices = load->indices;
+      if (layout_map_.count(buffer)) {
+        new_indices = layout_map_[buffer]->Forward(load->indices);
+      }
       auto new_buffer = buffer_remap_[load->buffer];
-      layout_remap_.Set(new_buffer, layout_map_[load->buffer]);
+      if (layout_map_.count(load->buffer)) {
+        layout_remap_.Set(new_buffer, layout_map_[load->buffer]);
+      }
       return BufferLoad(new_buffer, new_indices);
     } else if (var_remap_.count(buffer->data)) {
       auto new_buffer = Buffer(
@@ -1041,10 +1087,17 @@ private:
     auto store = Downcast<BufferStore>(IRMutatorWithAnalyzer::VisitStmt_(op));
     auto buffer = store->buffer;
     if (buffer_remap_.count(buffer)) {
-      auto new_indices = layout_map_[buffer]->Forward(store->indices);
+      Array<PrimExpr> new_indices = store->indices;
+      if (layout_map_.count(buffer)) {
+        new_indices = layout_map_[buffer]->Forward(store->indices);
+      }
       auto new_buffer = buffer_remap_[store->buffer];
-      layout_remap_.Set(new_buffer, layout_map_[store->buffer]);
-      return BufferStore(new_buffer, store->value, new_indices);
+      if (layout_map_.count(store->buffer)) {
+        layout_remap_.Set(new_buffer, layout_map_[store->buffer]);
+      }
+      return BufferStore(new_buffer,
+                         CastFp4StorageValue(store->value, new_buffer->dtype),
+                         new_indices);
     } else if (var_remap_.count(buffer->data)) {
       auto new_buffer = Buffer(
           var_remap_[buffer->data], buffer->dtype, buffer->shape,
@@ -1148,6 +1201,9 @@ private:
     auto tile_op = ParseOperator(GetRef<Stmt>(op));
     if (!tile_op.defined())
       return IRMutatorWithAnalyzer::VisitStmt_(op);
+    if (auto *copy = tile_op.as<CopyNode>()) {
+      MaybeRemapFp4CopySource(copy);
+    }
 
     Range thread_bounds = CurrentThreadBounds();
 

--- a/src/transform/tvm_ffi_binder.cc
+++ b/src/transform/tvm_ffi_binder.cc
@@ -96,6 +96,10 @@ TVMFFIABIBuilder::getUndefVars(const std::vector<PrimExpr> &args) {
   return res;
 }
 
+bool TVMFFIABIBuilder::UseFp4UnpackedABI(const Buffer &buffer) const {
+  return buffer->dtype.is_float4_e2m1_unpacked() && buffer->dtype.is_scalar();
+}
+
 bool TVMFFIABIBuilder::BindNullable(const PrimExpr &arg, const PrimExpr &value,
                                     const std::string &arg_name, bool with_lets,
                                     const PrimExpr &nullable_guard) {
@@ -350,7 +354,7 @@ void TVMFFIABIBuilder::BindDLTensors(
 
     // Scan buffer shape for symbolic variables
     for (size_t k = 0; k < buffer->shape.size(); ++k) {
-      if (buffer->dtype.bits() < 8) {
+      if (buffer->dtype.bits() < 8 && !UseFp4UnpackedABI(buffer)) {
         break;
       }
 
@@ -518,6 +522,19 @@ void TVMFFIABIBuilder::BindDLTensors(
            v_type_lanes == expect_lanes);
       cond = cond || float32_ok;
     }
+    if (UseFp4UnpackedABI(buffer)) {
+      PrimExpr code_int = IntImm(DataType::UInt(8), DataType::kInt);
+      PrimExpr code_uint = IntImm(DataType::UInt(8), DataType::kUInt);
+      PrimExpr code_unpacked =
+          IntImm(DataType::UInt(8), DataType::kFloat4_e2m1_unpacked);
+      PrimExpr bits8 = IntImm(DataType::UInt(8), 8);
+      PrimExpr lanes_ok = (v_type_lanes == expect_lanes);
+      PrimExpr byte_carrier_ok =
+          (v_type_bits == bits8 && lanes_ok &&
+           (v_type_code == code_int || v_type_code == code_uint ||
+            v_type_code == code_unpacked));
+      cond = cond || byte_carrier_ok;
+    }
     // Allow bool to match int8/uint8 at runtime, and also kDLBool(code=6).
     if (buffer->dtype.is_bool()) {
       PrimExpr code_int = IntImm(DataType::UInt(8), DataType::kInt);
@@ -544,7 +561,8 @@ void TVMFFIABIBuilder::BindDLTensors(
     }
     // Allow with bits < 8 to match any type with the same total bit count at
     // runtime (PyTorch uses int8 as storage for FP4).
-    bool data_is_subtype = buffer->dtype.bits() < 8;
+    bool data_is_subtype =
+        buffer->dtype.bits() < 8 && !UseFp4UnpackedABI(buffer);
     if (data_is_subtype) {
       // Get the pre-created shape buffer for reading runtime shape
       Buffer buf_shape = shape_buffer_map[arg_name];

--- a/src/transform/tvm_ffi_binder.h
+++ b/src/transform/tvm_ffi_binder.h
@@ -188,6 +188,7 @@ private:
   // Internal bind function
   bool Bind_(const PrimExpr &arg, const PrimExpr &value,
              const std::string &arg_name, bool with_lets);
+  bool UseFp4UnpackedABI(const Buffer &buffer) const;
   /*! \brief The definition map, can be uses to substitute */
   std::unordered_map<const VarNode *, PrimExpr> *def_map_;
   /*! \brief defs generated in the current binder */

--- a/testing/python/language/test_tilelang_language_float4_e2m1_unpacked_gemm.py
+++ b/testing/python/language/test_tilelang_language_float4_e2m1_unpacked_gemm.py
@@ -1,0 +1,89 @@
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm as tvm
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(12, 0)
+def test_semantic_fp4_gemm_uses_unpacked_carrier_fragments():
+    def assert_unpacked_shared_carrier(tir, name):
+        assert f'{name}: T.handle("custom[float4_e2m1_unpacked]", "shared.dyn")' in tir
+
+    cases = [
+        (T.float4_e2m1fn, T.float4_e2m1fn, "A", "B", "e2m1", "e2m1"),
+        (T.float8_e4m3fn, T.float4_e2m1fn, None, "B", "e4m3", "e2m1"),
+        (T.float4_e2m1fn, T.float8_e4m3fn, "A", None, "e2m1", "e4m3"),
+    ]
+
+    def lower_gemm(a_dtype, b_dtype):
+        @T.prim_func
+        def main(
+            A: T.Tensor((128, 128), a_dtype),
+            B: T.Tensor((128, 128), b_dtype),
+            C: T.Tensor((128, 128), T.float32),
+        ):
+            with T.Kernel(1, 1, threads=128):
+                A_shared = T.alloc_shared((128, 128), a_dtype)
+                B_shared = T.alloc_shared((128, 128), b_dtype)
+                C_local = T.alloc_fragment((128, 128), T.float32)
+
+                T.clear(C_local)
+                T.copy(A[0, 0], A_shared)
+                T.copy(B[0, 0], B_shared)
+                T.gemm(A_shared, B_shared, C_local, transpose_B=True)
+                T.copy(C_local, C[0, 0])
+
+        with tvm.target.Target("cuda"):
+            artifact = tilelang.lower(main, target="cuda")
+        return str(artifact.device_mod), artifact.kernel_source
+
+    for a_dtype, b_dtype, a_carrier, b_carrier, a_mma, b_mma in cases:
+        tir, src = lower_gemm(a_dtype, b_dtype)
+        if a_carrier:
+            assert 'A: T.handle("float4_e2m1fn", "global")' in tir
+            assert_unpacked_shared_carrier(tir, "A_shared")
+            assert 'A_local = T.alloc_buffer((64,), "custom[float4_e2m1_unpacked]", scope="local")' in tir
+        if b_carrier:
+            assert 'B: T.handle("float4_e2m1fn", "global")' in tir
+            assert_unpacked_shared_carrier(tir, "B_shared")
+            assert 'B_local = T.alloc_buffer((64,), "custom[float4_e2m1_unpacked]", scope="local")' in tir
+        assert f'T.ptx_mma("float32", "m16n8k32", "row", "col", "{a_mma}", "{b_mma}", "fp32"' in tir
+        assert "tl::ptx_ldmatrix_x4" in src
+        assert "tl::ptx_ldmatrix_b4x16" not in src
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(12, 0)
+def test_semantic_fp4_gemm_pipeline_uses_unpacked_carrier_cp_async():
+    @T.prim_func
+    def main(
+        A: T.Tensor((256, 256), T.float4_e2m1fn),
+        B: T.Tensor((256, 256), T.float4_e2m1fn),
+        C: T.Tensor((256, 256), T.float32),
+    ):
+        with T.Kernel(2, 2, threads=128) as (bx, by):
+            A_shared = T.alloc_shared((128, 64), T.float4_e2m1fn)
+            B_shared = T.alloc_shared((128, 64), T.float4_e2m1fn)
+            C_local = T.alloc_fragment((128, 128), T.float32)
+
+            T.clear(C_local)
+            for ko in T.Pipelined(4, num_stages=2):
+                T.copy(A[by * 128, ko * 64], A_shared)
+                T.copy(B[bx * 128, ko * 64], B_shared)
+                T.gemm(A_shared, B_shared, C_local, transpose_B=True)
+            T.copy(C_local, C[by * 128, bx * 128])
+
+    with tvm.target.Target("cuda"):
+        artifact = tilelang.lower(main, target="cuda")
+
+    tir = str(artifact.device_mod)
+    src = artifact.kernel_source
+    assert 'A: T.handle("float4_e2m1fn", "global")' in tir
+    assert 'B: T.handle("float4_e2m1fn", "global")' in tir
+    assert "custom[float4_e2m1_unpacked]" in tir
+    assert "tl::cp_async_gs" in src
+    assert "tl::ptx_ldmatrix_x4" in src
+    assert "tl::ptx_ldmatrix_b4x16" not in src
+    compact_src = src.replace(" ", "")
+    assert "((((((int)threadIdx.x)&15)>>3)+((((int)threadIdx.x)&3)>>1))&1)*16" in compact_src

--- a/tilelang/cuda/intrinsics/layout/utils.py
+++ b/tilelang/cuda/intrinsics/layout/utils.py
@@ -22,11 +22,13 @@ def get_ldmatrix_offset(
     row_idx,
     col_idx,
     stride,
-    dtype: Literal["float16", "int8", "int4"] = "float16",
+    dtype: Literal["float16", "int8", "int4", "float4_e2m1fn"] = "float16",
     transposed: bool = False,
 ):
     assert matrix in ["A", "B"], "matrix should be either A or B"
-    dtype_bits = DataType(dtype).bits
+    dtype_obj = DataType(dtype)
+    dtype_bits = dtype_obj.bits
+    is_fp4_e2m1fn = dtype_bits == 4 and str(dtype_obj) == "float4_e2m1fn"
     if dtype_bits == 32:
         if matrix == "B" and transposed:
             transform_func = ldmatrix_32x4_to_shared_16x8_layout_b
@@ -47,21 +49,22 @@ def get_ldmatrix_offset(
         else:
             new_row_idx, new_col_idx = transform_func(row_idx, col_idx)
             return new_row_idx, new_col_idx
-    elif dtype_bits <= 8:
+    elif is_fp4_e2m1fn or dtype_bits <= 8:
+        # FP4 shared operands use one unpacked carrier byte per logical value,
+        # so they keep the 8-bit ldmatrix coordinates. Packed int4/uint4
+        # still scale those coordinates to byte offsets.
         if matrix == "B" and transposed:
             transform_func = ldmatrix_32x16_to_shared_16x32_layout_b
-            new_row_idx, new_col_idx = transform_func(row_idx, col_idx)
-            pack_factor = 8 // dtype_bits
-            return new_row_idx, new_col_idx * pack_factor
         elif matrix == "A" and not transposed:
             transform_func = ldmatrix_32x16_to_shared_16x32_layout_a
-            new_row_idx, new_col_idx = transform_func(row_idx, col_idx)
-            pack_factor = 8 // dtype_bits
-            return new_row_idx, new_col_idx * pack_factor
         else:
-            raise ValueError("ldmatrix only supports B transposed and A non-transposed for int8")
+            raise ValueError(f"ldmatrix only supports B transposed and A non-transposed for {dtype_obj}")
+        new_row_idx, new_col_idx = transform_func(row_idx, col_idx)
+        if not is_fp4_e2m1fn:
+            new_col_idx *= 8 // dtype_bits
+        return new_row_idx, new_col_idx
     else:
-        raise ValueError(f"Unsupported dtype {dtype}")
+        raise ValueError(f"Unsupported dtype {dtype_obj}")
 
 
 def shared_16x16_to_mma_32x8_layout(i, j):

--- a/tilelang/cuda/intrinsics/macro/mma_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/mma_macro_generator.py
@@ -118,7 +118,13 @@ class TensorCoreIntrinEmitter:
     def _initialize_k_dim(self, a_dtype=T.float16):
         if isinstance(a_dtype, str):
             a_dtype = DataType(a_dtype)
-        self.k_dim = min(256 // a_dtype.bits, self.chunk)
+        a_dtype_str = str(a_dtype)
+        if a_dtype_str == "float4_e2m1fn":
+            if self.chunk < 32:
+                raise ValueError(f"float4_e2m1fn MMA requires chunk >= 32, got chunk={self.chunk}")
+            self.k_dim = 32
+        else:
+            self.k_dim = min(256 // a_dtype.bits, self.chunk)
 
     def _initialize_m_dim(self, a_dtype=T.float16):
         if isinstance(a_dtype, str):
@@ -314,18 +320,21 @@ class TensorCoreIntrinEmitter:
         micro_size_k = self.micro_size_k
         local_size_a = self.local_size_a
         a_transposed = self.a_transposed
+        a_dtype_obj = DataType(a_dtype)
+        a_dtype_bits = a_dtype_obj.bits
+        is_fp4_a = str(a_dtype_obj) == "float4_e2m1fn"
         # ldmatrix cannot be used for int8 + trans case.
-        ldmatrix_available = not (DataType(a_dtype).bits != 16 and a_transposed)
+        ldmatrix_available = not (a_dtype_bits != 16 and a_transposed)
 
         def mma_load_layout(i, j):
             return i, j
 
         if not ldmatrix_available:
-            if DataType(a_dtype).bits == 8:
+            if a_dtype_bits == 8 or is_fp4_a:
                 mma_load_layout = mma_load_a_32x16_to_shared_16x32_layout
-            elif DataType(a_dtype).bits == 16:
+            elif a_dtype_bits == 16:
                 mma_load_layout = mma_load_a_32x8_to_shared_16x16_layout
-            elif DataType(a_dtype).bits == 32:
+            elif a_dtype_bits == 32:
                 mma_load_layout = mma_load_a_32x4_to_shared_16x8_layout
             else:
                 raise ValueError(f"Unsupported dtype: {a_dtype}")
@@ -356,6 +365,8 @@ class TensorCoreIntrinEmitter:
                 wi, wk = warp_m * warp_row_tiles + i * micro_size_x, rk * chunk + ki * micro_size_k
 
                 if ldmatrix_available:
+                    num = 4
+                    access_extent = 4 * num if is_fp4_a else 2 * num
                     row_off, col_off = get_ldmatrix_offset("A", tx, 0, stride, a_dtype, a_transposed)
                     src_indices = (
                         tuple(A_other) + (A_base0 + wk + row_off, A_base1 + wi + col_off)
@@ -364,9 +375,9 @@ class TensorCoreIntrinEmitter:
                     )
                     T.ptx_ldmatrix(
                         T.bool(trans),
-                        4,
-                        T.access_ptr(A_buf[src_indices], "r", extent=8),
-                        T.access_ptr(A_local_buf[i * local_size_a], "w", extent=8),
+                        num,
+                        T.access_ptr(A_buf[src_indices], "r", extent=access_extent),
+                        T.access_ptr(A_local_buf[i * local_size_a], "w", extent=access_extent),
                     )
                 else:
                     for j in T.serial(local_size_a):
@@ -426,6 +437,9 @@ class TensorCoreIntrinEmitter:
         micro_size_k = self.micro_size_k
         local_size_b = self.local_size_b
         b_transposed = self.b_transposed
+        b_dtype_obj = DataType(b_dtype)
+        b_dtype_bits = b_dtype_obj.bits
+        is_fp4_b = str(b_dtype_obj) == "float4_e2m1fn"
         thread_binding = self.get_thread_binding()
 
         # legalize shared buffer to region
@@ -437,17 +451,17 @@ class TensorCoreIntrinEmitter:
         B_stride_last = B_buf.shape[-1]
         replicate_b = self.n_dim == 16
         # ldmatrix cannot be used for int8 + trans case.
-        ldmatrix_available = not (DataType(b_dtype).bits != 16 and not b_transposed)
+        ldmatrix_available = not (b_dtype_bits != 16 and not b_transposed)
 
         def mma_load_layout(i, j):
             return i, j
 
         if not ldmatrix_available:
-            if DataType(b_dtype).bits == 8:
+            if b_dtype_bits == 8 or is_fp4_b:
                 mma_load_layout = mma_load_b_32x16_to_shared_16x32_layout
-            elif DataType(b_dtype).bits == 16:
+            elif b_dtype_bits == 16:
                 mma_load_layout = mma_load_b_32x8_to_shared_16x16_layout
-            elif DataType(b_dtype).bits == 32:
+            elif b_dtype_bits == 32:
                 mma_load_layout = mma_load_b_32x4_to_shared_16x8_layout
             else:
                 raise ValueError(f"Unsupported dtype: {b_dtype}")
@@ -473,6 +487,7 @@ class TensorCoreIntrinEmitter:
 
                 if ldmatrix_available:
                     num = 4 if replicate_b else 2
+                    access_extent = 4 * num if is_fp4_b else 2 * num
                     row_off, col_off = get_ldmatrix_offset("B", tx, 0, stride, b_dtype, b_transposed)
                     src_indices = (
                         tuple(B_other) + (B_base0 + wi + row_off, B_base1 + wk + col_off)
@@ -482,8 +497,8 @@ class TensorCoreIntrinEmitter:
                     T.ptx_ldmatrix(
                         T.bool(trans),
                         num,
-                        T.access_ptr(B_buf[src_indices], "r", extent=2 * num),
-                        T.access_ptr(B_local_buf[i * local_size_b], "w", extent=2 * num),
+                        T.access_ptr(B_buf[src_indices], "r", extent=access_extent),
+                        T.access_ptr(B_local_buf[i * local_size_b], "w", extent=access_extent),
                     )
 
                 else:
@@ -695,7 +710,9 @@ class TensorCoreIntrinEmitter:
         matrix_is_a: bool = matrix == "A"
         matrix_is_b: bool = matrix == "B"
         dtype = self.a_dtype if matrix_is_a else self.b_dtype
-        dtype_bits = DataType(dtype).bits
+        dtype_obj = DataType(dtype)
+        dtype_bits = dtype_obj.bits
+        is_fp4_e2m1fn = str(dtype_obj) == "float4_e2m1fn"
         transposed = self.a_transposed if matrix_is_a else self.b_transposed
 
         # s represents spatial axis
@@ -712,7 +729,7 @@ class TensorCoreIntrinEmitter:
         elif dtype_bits == 16:
             transform_func_sr_a = shared_16x16_to_mma_32x8_layout_sr_a
             transform_func_sr_b = shared_16x16_to_mma_32x8_layout_sr_b
-        elif dtype_bits == 8:
+        elif dtype_bits == 8 or is_fp4_e2m1fn:
             transform_func_sr_a = shared_16x32_to_mma_32x16_layout_sr_a
             transform_func_sr_b = shared_16x32_to_mma_32x16_layout_sr_b
         else:
@@ -936,7 +953,11 @@ class TensorCoreIntrinEmitterWithLadderTransform(TensorCoreIntrinEmitter):
         self._initialize_transform_kind(transform_kind_a, transform_kind_b)
 
     def _initialize_k_dim(self, a_dtype=T.float16):
-        self.k_dim = 256 // DataType(a_dtype).bits
+        a_dtype_obj = DataType(a_dtype)
+        if str(a_dtype_obj) == "float4_e2m1fn":
+            self.k_dim = 32
+        else:
+            self.k_dim = 256 // a_dtype_obj.bits
 
     def _initialize_local_size(self, m_dim=16, n_dim=16, k_dim=16, warp_size=32):
         self.local_size_a = (m_dim * k_dim) // warp_size

--- a/tilelang/cuda/op/gemm/gemm_mma.py
+++ b/tilelang/cuda/op/gemm/gemm_mma.py
@@ -20,7 +20,52 @@ GEMM_INST_MMA = "cuda.mma"
 class GemmMMA(GemmBase):
     intrin_emitter_cls = TensorCoreIntrinEmitter
 
+    @property
+    def allow_f8f6f4_mixed_dtypes(self) -> bool:
+        # Let the MMA implementation accept its A8W4 FP8/FP4 path while keeping
+        # the exact supported pairs checked in _validate_mma_dtypes().
+        return True
+
+    @staticmethod
+    def _is_fp8_e4m3(dtype: str) -> bool:
+        return str(dtype) in {"float8_e4m3", "float8_e4m3fn", "float8_e4m3fnuz"}
+
+    @staticmethod
+    def _is_fp4_e2m1(dtype: str) -> bool:
+        return str(dtype) == "float4_e2m1fn"
+
+    @staticmethod
+    def _fragment_carrier_dtype(dtype):
+        if GemmMMA._is_fp4_e2m1(dtype):
+            return T.float4_e2m1_unpacked
+        return dtype
+
+    @staticmethod
+    def _layout_carrier_buffer(buffer):
+        if GemmMMA._is_fp4_e2m1(buffer.dtype):
+            return tirx.decl_buffer(
+                buffer.shape,
+                dtype=T.float4_e2m1_unpacked,
+                name=buffer.name,
+                scope=buffer.scope(),
+            )
+        return buffer
+
+    def _validate_mma_dtypes(self):
+        a_dtype = str(self.A.dtype)
+        b_dtype = str(self.B.dtype)
+        if a_dtype == b_dtype:
+            return
+        # Mixed A8W4 paths are selected only from semantic dtypes. Packed host
+        # storage such as uint8 is not treated as an FP4 GEMM dtype.
+        mixed_fp8_fp4 = (self._is_fp8_e4m3(a_dtype) and self._is_fp4_e2m1(b_dtype)) or (
+            self._is_fp4_e2m1(a_dtype) and self._is_fp8_e4m3(b_dtype)
+        )
+        if not mixed_fp8_fp4:
+            raise AssertionError(f"Unsupported mixed MMA dtypes: A={a_dtype}, B={b_dtype}")
+
     def _make_mma_emitter(self, target: Target, thread_nums: int, thread_var: tirx.Var | None = None):
+        self._validate_mma_dtypes()
         m_warp, n_warp = self.policy.compute_warp_partition(self.M, self.N, thread_nums, target, GEMM_INST_MMA)
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
@@ -37,26 +82,34 @@ class GemmMMA(GemmBase):
             chunk=self.chunk,
             thread_var=thread_var,
         )
+        if self.chunk % emitter.micro_size_k != 0:
+            raise ValueError(
+                f"T.gemm K tile ({self.chunk}) must be divisible by MMA instruction K tile "
+                f"({emitter.micro_size_k}) for A={self.A.dtype}, B={self.B.dtype}"
+            )
         return emitter
 
     def infer_layout(self, target: Target, thread_nums: int):
         mma_emitter = self._make_mma_emitter(target, thread_nums)
+        use_fp4_unpacked_layout = self._is_fp4_e2m1(self.A.dtype) or self._is_fp4_e2m1(self.B.dtype)
+        A_layout_buf = self._layout_carrier_buffer(self.A) if use_fp4_unpacked_layout else self.A
+        B_layout_buf = self._layout_carrier_buffer(self.B) if use_fp4_unpacked_layout else self.B
         if self.is_gemm_ss():
             return {
-                self.A: make_swizzled_layout(self.A),
-                self.B: make_swizzled_layout(self.B),
+                self.A: make_swizzled_layout(A_layout_buf),
+                self.B: make_swizzled_layout(B_layout_buf),
                 self.C: mma_emitter.make_mma_store_layout(self.C),
             }
         elif self.is_gemm_sr():
             return {
-                self.A: make_swizzled_layout(self.A),
+                self.A: make_swizzled_layout(A_layout_buf),
                 self.B: mma_emitter.make_mma_load_layout(self.B, matrix="B"),
                 self.C: mma_emitter.make_mma_store_layout(self.C),
             }
         elif self.is_gemm_rs():
             return {
                 self.A: mma_emitter.make_mma_load_layout(self.A, matrix="A"),
-                self.B: make_swizzled_layout(self.B),
+                self.B: make_swizzled_layout(B_layout_buf),
                 self.C: mma_emitter.make_mma_store_layout(self.C),
             }
         elif self.is_gemm_rr():
@@ -83,6 +136,8 @@ class GemmMMA(GemmBase):
 
         a_dtype = self.a_dtype
         b_dtype = self.b_dtype
+        a_fragment_dtype = self._fragment_carrier_dtype(a_dtype)
+        b_fragment_dtype = self._fragment_carrier_dtype(b_dtype)
         warp_rows = mma_emitter.warp_rows
         warp_cols = mma_emitter.warp_cols
         local_size_a = mma_emitter.local_size_a
@@ -115,8 +170,8 @@ class GemmMMA(GemmBase):
                 B_shared into local fragments, then issues Tensor Core mma ops,
                 accumulating into C_local.
                 """
-                A_local = T.alloc_local((warp_rows * local_size_a), a_dtype)
-                B_local = T.alloc_local((warp_cols * local_size_b), b_dtype)
+                A_local = T.alloc_local((warp_rows * local_size_a), a_fragment_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b), b_fragment_dtype)
                 if clear_accum:
                     T.clear(C_buf)
                 for ki in T.serial(0, (block_K // micro_size_k)):
@@ -150,7 +205,7 @@ class GemmMMA(GemmBase):
                 B_shared into local fragments, then issues Tensor Core mma ops,
                 accumulating into C_local.
                 """
-                A_local = T.alloc_local((warp_rows * local_size_a), a_dtype)
+                A_local = T.alloc_local((warp_rows * local_size_a), a_fragment_dtype)
 
                 if clear_accum:
                     T.clear(C_buf)
@@ -180,7 +235,7 @@ class GemmMMA(GemmBase):
                 B_shared into local fragments, then issues Tensor Core mma ops,
                 accumulating into C_local.
                 """
-                B_local = T.alloc_local((warp_cols * local_size_b), b_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b), b_fragment_dtype)
                 if clear_accum:
                     T.clear(C_buf)
                 for ki in T.serial(0, (block_K // micro_size_k)):


### PR DESCRIPTION
## Summary

This PR adds SM120 fragment-MMA GEMM support for semantic `T.float4_e2m1fn`
operands.

TileLang programs continue to declare FP4 operands as `T.float4_e2m1fn`.
For the SM120 performance path, lowering maps those semantic operands onto the
hidden `T.float4_e2m1_unpacked` byte carrier internally. Users do not need to
write FP4 GEMM operands as `uint8` tensors in TileLang programs.

Supported SM120 GEMM combinations:

| A dtype | B dtype | Accumulator | SM120 path |
| --- | --- | --- | --- |
| `T.float4_e2m1fn` | `T.float4_e2m1fn` | `T.float32` | FP4 x FP4 fragment MMA |
| `T.float8_e4m3fn` | `T.float4_e2m1fn` | `T.float32` | A8W4 fragment MMA |
| `T.float4_e2m1fn` | `T.float8_e4m3fn` | `T.float32` | W4A8 fragment MMA |

## Design Goals

- Preserve semantic TileLang signatures: FP4 tensors stay `T.float4_e2m1fn` at
  the language level.
- Use `T.float4_e2m1_unpacked` as the hidden physical carrier for the SM120 FP4
  GEMM path.
- Align the SM120 FP4 performance path with the byte-carrier / ordinary
  `ldmatrix` model used by #2182.
- Add SM120 FP4/A8W4/W4A8 support without changing existing int4/uint4
  `ldmatrix` behavior.
- Reject unsupported FP4 MMA K tile shapes early instead of generating kernels
  that silently skip a K tail.

## Design

The key separation is between the public dtype and the physical carrier:

- TileLang program signatures use `T.float4_e2m1fn`.
- SM120 GEMM lowering uses hidden `custom[float4_e2m1_unpacked]8` shared/local
  carrier buffers where the hardware path needs byte slots.
- Runtime tensors for this SM120 path may use byte-compatible storage with
  logical `(M, K)` / `(N, K)` shapes.
- The FFI binder accepts byte-compatible runtime tensors for semantic SM120 FP4
  operands while preserving the public `T.float4_e2m1fn` handle dtype.
- The SM120 MMA path shifts FP4 payload bits only for FP4 operands before
  calling the CuTe SM120 F8/F6/F4 atom.

## Main Changes

### CUDA Templates

- Add SM120 `cute::SM120_16x8x32_TN` dispatch for FP4xFP4, FP8xFP4, and
  FP4xFP8 into FP32.
- Apply the FP4 operand register shift only to operands that are actually FP4.
- Bridge TileLang FP4 template types to CuTe FP4 types while keeping existing
  packed helper types.

### CUDA Lowering

- Lower semantic SM120 FP4 GEMM operands through hidden
  `float4_e2m1_unpacked` carrier buffers where required by the performance path.
- Emit ordinary `tl::ptx_ldmatrix_x*` for the hidden unpacked-carrier path.
- Keep packed FP4 fallback vector load/store safe for odd or not-proven-even
  logical offsets by lowering those cases through per-lane nibble helpers.
- Preserve shared-memory alias information for CuTeDSL codegen.
- Preserve FP4 storage casts when layout lowering changes the physical carrier
  dtype.

### Python Lowering

- Use `T.float4_e2m1_unpacked` as the hidden local/shared carrier for semantic
  SM120 FP4 operands.
- Build SM120 FP4 shared layouts through an unpacked-carrier view while keeping
  public buffer dtypes semantic.
- Validate mixed A/B dtypes explicitly for A8W4 and W4A8.
- Reject `T.gemm` block K values that are not divisible by the selected
  instruction K tile.

### Examples

- Add mainline-style SM120 examples for FP4xFP4 and A8W4:
  - `examples/gemm_fp4/example_gemm_fp4_sm120.py`
  - `examples/gemm_fp4/example_gemm_a8w4_sm120.py`
- The examples keep semantic `T.float4_e2m1fn` kernel signatures and use
  byte-compatible host tensors only as an interoperability detail.

### Tests

- Add focused SM120 lowering coverage in
  `testing/python/language/test_tilelang_language_float4_e2m1_unpacked_gemm.py`.
- The tests check that semantic FP4 GEMM uses hidden unpacked shared/local
  carriers, ordinary `tl::ptx_ldmatrix_x*`, and no `tl::ptx_ldmatrix_b4x16` on
  the main performance path.

## Why The Review Fixes Matter

FP4 storage has two concerns that should not be conflated: the user-facing dtype
and the physical carrier used by the hardware path. The hidden
`float4_e2m1_unpacked` carrier lets SM120 GEMM keep the semantic
`T.float4_e2m1fn` API while matching the ordinary-ldmatrix byte-carrier
performance model used by #2182.

For packed fallback cases, FP4 byte storage is byte-addressed while logical FP4
elements are nibble-addressed. A vector reinterpret load/store is safe only when
the logical base offset is known to be even. If the offset is odd, or if codegen
cannot prove it is even, vectorized byte reinterpretation can read or write the
wrong nibble without producing a compilation error. This PR routes those cases
through per-lane nibble helpers.

SM120 FP4/A8W4/W4A8 MMA consumes K in fixed `m16n8k32` instruction chunks.
Allowing a `block_K` such as 48 would execute only the representable K=32
portion and miss the K tail. This PR turns that silent numerical error into an
explicit unsupported-shape error.

## Validation

Local SM120 validation used an RTX PRO 6000 / compute capability 12.0
environment.

Build and focused examples:

```bash
cmake --build build -j$(nproc)
PYTHONPATH=$PWD${PYTHONPATH:+:$PYTHONPATH} python examples/gemm_fp4/example_gemm_fp4_sm120.py
PYTHONPATH=$PWD${PYTHONPATH:+:$PYTHONPATH} python examples/gemm_fp4/example_gemm_a8w4_sm120.py
```

Generated CUDA and TIR were inspected for the expected SM120 FP4 markers:

```text
public TIR handles: float4_e2m1fn
internal carrier: custom[float4_e2m1_unpacked]8
ordinary ldmatrix: tl::ptx_ldmatrix_x*
not present on the main performance path: tl::ptx_ldmatrix_b4x16
SM120 m16n8k32 FP4/A8W4/W4A8 dtype dispatch
```

Focused tests:

```bash
PYTHONPATH=$PWD${PYTHONPATH:+:$PYTHONPATH} python -m pytest \
  testing/python/language/test_tilelang_language_float4_e2m1_unpacked_dtype.py \
  testing/python/language/test_tilelang_language_float4_e2m1_unpacked_gemm.py -q
```

Observed focused-test results:

```text
testing/python/language/test_tilelang_language_float4_e2m1_unpacked_dtype.py: 5 passed
testing/python/language/test_tilelang_language_float4_e2m1_unpacked_gemm.py: 2 passed
```

Performance comparison against #2182 used the same SM120 GEMM shapes for
FP4xFP4, A8W4, and W4A8, with 6 shapes, 2 `block_K` settings, and 9 repeats per
point. No block-scale cases were included.

Latency delta is this PR divided by #2182 minus 1:

```text
mean geomean:
FP4xFP4  +0.41%
A8W4     +0.55%
W4A8     +0.75%
all      +0.57%

median geomean:
FP4xFP4  +1.37%
A8W4     -1.25%
W4A8     +0.23%
all      +0.11%
```

Equivalent TOPS delta is #2182 latency divided by this PR latency minus 1:

```text
mean geomean:
FP4xFP4  -0.41%
A8W4     -0.55%
W4A8     -0.74%
all      -0.57%

median geomean:
FP4xFP4  -1.35%
A8W4     +1.27%
W4A8     -0.23%
all      -0.11%
```

The overall result is effectively performance-neutral versus #2182: mean TOPS
is about 0.57% lower, while median TOPS is about 0.11% lower.

## Notes And Non-Goals

- Mixed A8W4/W4A8 dispatch is selected from explicit FP8/FP4 dtype pairs.
- `float4_e2m1_unpacked` is a hidden physical carrier for the SM120 path, not
  the public GEMM dtype users are expected to write.
- `uint8` remains a runtime storage/interoperability detail for byte-compatible
  host tensors, not the public TileLang FP4 GEMM dtype.
- Existing int4/uint4 `ldmatrix` offset behavior stays on the existing path.
