### PR TITLE
[BugFix] Fix T.gemm() on SM75 (Turing) GPUs (#1992)

### DIFF
--- a/src/backend/cuda/op/gemm.cc
+++ b/src/backend/cuda/op/gemm.cc
@@ -297,7 +297,8 @@ struct Gemm {
     if (gemm_inst == kCudaWGMMA) {
       return ComputeWgmmaWarpPartition(policy, M, N, num_warps);
     }
-    int k_n_per_warp = TargetIsVolta(target) ? 16 : 8;
+    int k_n_per_warp =
+        (TargetIsVolta(target) || TargetIsTuring(target)) ? 16 : 8;
     return ComputeDefaultWarpPartition(policy, M, N, num_warps, k_n_per_warp);
   }
 

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -790,7 +790,11 @@ TL_DEVICE __nv_bfloat162 fma2(__nv_bfloat162 a, __nv_bfloat162 b,
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
   return __hfma2(a, b, c);
 #else
-  return __nv_bfloat162{__hfma(a.x, b.x, c.x), __hfma(a.y, b.y, c.y)};
+  float a_x = __bfloat162float(a.x), a_y = __bfloat162float(a.y);
+  float b_x = __bfloat162float(b.x), b_y = __bfloat162float(b.y);
+  float c_x = __bfloat162float(c.x), c_y = __bfloat162float(c.y);
+  return __nv_bfloat162{__float2bfloat16(a_x * b_x + c_x),
+                        __float2bfloat16(a_y * b_y + c_y)};
 #endif
 }
 

--- a/src/tl_templates/cuda/gemm_mma.h
+++ b/src/tl_templates/cuda/gemm_mma.h
@@ -105,7 +105,6 @@ TL_DISPATCH_MMA(int8_t, int8_t, int, SM80_16x8x32_S32S8S8S32_TN)
 TL_DISPATCH_MMA(double, double, double, SM80_8x8x4_F64F64F64F64_TN)
 #elif __CUDA_ARCH_LIST__ >= 750
 #include <cute/arch/mma_sm75.hpp>
-TL_DISPATCH_MMA(half_t, half_t, half_t, SM75_16x8x8_F16F16F16F16_TN)
 TL_DISPATCH_MMA(half_t, half_t, float, SM75_16x8x8_F32F16F16F32_TN)
 #endif
 #endif

--- a/tilelang/cuda/op/gemm/__init__.py
+++ b/tilelang/cuda/op/gemm/__init__.py
@@ -7,15 +7,15 @@ from .gemm_mma import GEMM_INST_MMA, GemmMMA
 from .gemm_mma_sm70 import GemmMMASm70
 from .gemm_tcgen05 import GEMM_INST_TCGEN05, GemmTCGEN5
 from .gemm_wgmma import GEMM_INST_WGMMA, GemmWGMMA
-from tilelang.utils.target import target_is_cuda, target_is_volta
+from tilelang.utils.target import target_is_cuda, target_is_turing, target_is_volta
 
 
 def _match_mma(target) -> bool:
-    return target_is_cuda(target) and not target_is_volta(target)
+    return target_is_cuda(target) and not (target_is_volta(target) or target_is_turing(target))
 
 
 def _match_mma_sm70(target) -> bool:
-    return target_is_volta(target)
+    return target_is_volta(target) or target_is_turing(target)
 
 
 def _match_wgmma(target) -> bool:


### PR DESCRIPTION
## Summary
- Route SM75 to the Volta MMA path (GemmMMASm70) instead of selecting SM80 MMA instructions (tilelang/cuda/op/gemm/__init__.py)
- Set kNPerWarp=16 for Turing to match the Volta warp partition (src/backend/cuda/op/gemm.cc)
- Remove invalid SM75_16x8x8_F16F16F16F16_TN reference from src/tl_templates/cuda/gemm_mma.h
- Fix bf16 fma2 fallback for SM < 80 (incidentally found while investigating SM75 compilation errors)
## Why
- SM75 was not handled in the dispatch logic and fell through to GemmMMA, which emits SM80-only m16n8k16 MMA instructions unsupported on Turing hardware
- The current vendored CuTe SM75 wrapper does not define SM75_16x8x8_F16F16F16F16_TN, causing compilation failure
## Tested
- Verified on NVIDIA TITAN RTX (SM75)
- test_gemm_f16f16f32_nn passes after the fix
- test_assert_tl_matmul passes after the fix
## Future work
- A dedicated GemmMMASm75 using native Turing m16n8k8 MMA instructions could be added for improved performance on SM75 GPUs
Closes #1992

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Optimizations**
  * Improved matrix multiplication performance on Turing architecture GPUs
  * Enhanced floating-point precision for bfloat16 data type operations

* **Refactoring**
  * Refined GPU architecture detection and operation targeting logic
  * Streamlined compute capability matching across GPU architectures

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2173)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->