### PR TITLE
Fix float4 storage dtype torch mapping

### DIFF
--- a/testing/python/language/test_tilelang_language_dtype_as_torch.py
+++ b/testing/python/language/test_tilelang_language_dtype_as_torch.py
@@ -1,0 +1,13 @@
+import pytest
+import torch
+
+import tilelang.language as T
+
+
+@pytest.mark.skipif(
+    not hasattr(torch, "float4_e2m1fn_x2"),
+    reason="PyTorch float4_e2m1fn_x2 dtype is unavailable",
+)
+def test_float4_e2m1fnx2_as_torch_uses_storage_dtype_name():
+    assert T.float4_e2m1fnx2.as_torch() is torch.float4_e2m1fn_x2
+    assert T.float4_e2m1fn.as_torch() is torch.float4_e2m1fn_x2

--- a/tilelang/language/dtypes.py
+++ b/tilelang/language/dtypes.py
@@ -205,8 +205,8 @@ def __dtype_as_torch__(self: dtype) -> torch.dtype:
         )
         return torch.float8_e8m0fnu
     elif dtype_str == "float4_e2m1fnx2":
-        assert hasattr(torch, "float4_e2m1fnx2"), (
-            "torch.float4_e2m1fnx2 is not supported in this version of torch. Please upgrade torch >= 2.8.0"
+        assert hasattr(torch, "float4_e2m1fn_x2"), (
+            "torch.float4_e2m1fn_x2 is not supported in this version of torch. Please upgrade torch >= 2.8.0"
         )
         return torch.float4_e2m1fn_x2
     elif dtype_str == "float4_e2m1fn":


### PR DESCRIPTION
Fix `T.float4_e2m1fnx2.as_torch()` to check the correct PyTorch dtype name, `torch.float4_e2m1fn_x2`

Torch does not have `float4_e2m1fnx2` the correct attribute is `float4_e2m1fn_x2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed float4_e2m1fnx2 dtype conversion to use the correct PyTorch dtype name.

* **Tests**
  * Added test coverage for dtype-to-PyTorch conversions with conditional skipping when required dtypes are unavailable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2174)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->