### PR TITLE
[BugFix] Fix IntrinInfo repr

### DIFF
--- a/testing/python/carver/test_tilelang_carver_hint.py
+++ b/testing/python/carver/test_tilelang_carver_hint.py
@@ -1,0 +1,17 @@
+from tilelang.carver.roller.hint import IntrinInfo
+
+
+def test_intrin_info_repr():
+    info = IntrinInfo(
+        in_dtype="float16",
+        out_dtype="float32",
+        trans_b=True,
+        input_transform_kind=1,
+        weight_transform_kind=2,
+    )
+
+    text = repr(info)
+    assert "float16" in text
+    assert "float32" in text
+    assert "input_transform_kind=1" in text
+    assert "weight_transform_kind=2" in text

--- a/tilelang/carver/roller/hint.py
+++ b/tilelang/carver/roller/hint.py
@@ -125,7 +125,11 @@ class IntrinInfo:
         self.weight_transform_kind = weight_transform_kind
 
     def __repr__(self) -> str:
-        return f"<IntrinInfo, {self.in_dtype}, {self.out_dtype}, {self.trans_b}, {self.propagate_b}>"
+        return (
+            f"<IntrinInfo, in_dtype={self.in_dtype}, out_dtype={self.out_dtype}, "
+            f"trans_b={self.trans_b}, input_transform_kind={self.input_transform_kind}, "
+            f"weight_transform_kind={self.weight_transform_kind}>"
+        )
 
     def is_input_8bit(self) -> bool:
         return DataType(self.in_dtype).bits == 8


### PR DESCRIPTION
  ## Summary

  Fix `IntrinInfo.__repr__` to avoid referencing the undefined `propagate_b` attribute.

  The previous implementation raised `AttributeError` when an `IntrinInfo` object was printed or formatted through `repr()`. This updates
  the repr output to use existing fields and adds a focused regression test.

  ## Changes

  - Replace the invalid `self.propagate_b` reference in `IntrinInfo.__repr__`.
  - Include existing fields in the repr output:
    - `in_dtype`
    - `out_dtype`
    - `trans_b`
    - `input_transform_kind`
    - `weight_transform_kind`
  - Add a unit test for `repr(IntrinInfo)`.

  ## Validation

  ```bash
  pytest -q testing/python/carver/test_tilelang_carver_hint.py


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test verification for internal representation formatting.

* **Chores**
  * Updated internal object representation to display additional transformation kind information.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2175)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->