### PR TITLE
[BugFix] Try to fix ROCm CI by disable tvm-ffi C DLPack exchange on ROCm

### DIFF
--- a/testing/python/components/test_tilelang_env.py
+++ b/testing/python/components/test_tilelang_env.py
@@ -1,5 +1,8 @@
-import tilelang
 import os
+from types import SimpleNamespace
+
+import tilelang
+from tilelang.env import configure_rocm_tvm_ffi_dlpack_env
 
 
 def test_env_var():
@@ -11,6 +14,39 @@ def test_env_var():
     # test forced value with class method
     tilelang.env.TILELANG_PRINT_ON_COMPILATION = "1"
     assert tilelang.env.TILELANG_PRINT_ON_COMPILATION == "1"
+
+
+def test_configure_rocm_tvm_ffi_dlpack_env_sets_rocm_flags(monkeypatch):
+    monkeypatch.delenv("TVM_FFI_SKIP_C_DLPACK_EXCHANGE_API", raising=False)
+    monkeypatch.delenv("TVM_FFI_DISABLE_TORCH_C_DLPACK", raising=False)
+
+    fake_torch = SimpleNamespace(version=SimpleNamespace(hip="7.2"))
+
+    assert configure_rocm_tvm_ffi_dlpack_env(fake_torch)
+    assert os.environ["TVM_FFI_SKIP_C_DLPACK_EXCHANGE_API"] == "1"
+    assert os.environ["TVM_FFI_DISABLE_TORCH_C_DLPACK"] == "1"
+
+
+def test_configure_rocm_tvm_ffi_dlpack_env_skips_non_rocm(monkeypatch):
+    monkeypatch.delenv("TVM_FFI_SKIP_C_DLPACK_EXCHANGE_API", raising=False)
+    monkeypatch.delenv("TVM_FFI_DISABLE_TORCH_C_DLPACK", raising=False)
+
+    fake_torch = SimpleNamespace(version=SimpleNamespace(hip=None))
+
+    assert not configure_rocm_tvm_ffi_dlpack_env(fake_torch)
+    assert "TVM_FFI_SKIP_C_DLPACK_EXCHANGE_API" not in os.environ
+    assert "TVM_FFI_DISABLE_TORCH_C_DLPACK" not in os.environ
+
+
+def test_configure_rocm_tvm_ffi_dlpack_env_preserves_user_overrides(monkeypatch):
+    monkeypatch.setenv("TVM_FFI_SKIP_C_DLPACK_EXCHANGE_API", "0")
+    monkeypatch.setenv("TVM_FFI_DISABLE_TORCH_C_DLPACK", "0")
+
+    fake_torch = SimpleNamespace(version=SimpleNamespace(hip="7.2"))
+
+    assert configure_rocm_tvm_ffi_dlpack_env(fake_torch)
+    assert os.environ["TVM_FFI_SKIP_C_DLPACK_EXCHANGE_API"] == "0"
+    assert os.environ["TVM_FFI_DISABLE_TORCH_C_DLPACK"] == "0"
 
 
 if __name__ == "__main__":

--- a/tilelang/__init__.py
+++ b/tilelang/__init__.py
@@ -108,7 +108,10 @@ del _init_logger
 
 @contextlib.contextmanager
 def _lazy_load_lib():
-    import torch  # noqa: F401 # preload torch to avoid dlopen errors
+    import torch  # preload torch to avoid dlopen errors
+    from .env import configure_rocm_tvm_ffi_dlpack_env
+
+    configure_rocm_tvm_ffi_dlpack_env(torch)
 
     if sys.platform.startswith("win32"):
         yield

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -62,6 +62,28 @@ def prepend_dll_search_path(paths: list[str]) -> None:
 
 prepend_dll_search_path(TL_LIBS)
 
+
+def configure_rocm_tvm_ffi_dlpack_env(torch_module: object | None = None) -> bool:
+    """Disable tvm-ffi's C DLPack fast path for ROCm PyTorch builds.
+
+    The C exchange path can corrupt DLTensor metadata with ROCm nightly stacks,
+    surfacing as shape[0] being read as ``ndim`` by generated packed APIs.
+    """
+    if torch_module is None:
+        try:
+            import torch as torch_module  # type: ignore[import-not-found]
+        except Exception:
+            return False
+
+    torch_version = getattr(torch_module, "version", None)
+    if getattr(torch_version, "hip", None) is None:
+        return False
+
+    os.environ.setdefault("TVM_FFI_SKIP_C_DLPACK_EXCHANGE_API", "1")
+    os.environ.setdefault("TVM_FFI_DISABLE_TORCH_C_DLPACK", "1")
+    return True
+
+
 # TVM's Python loader (3rdparty/tvm/python/tvm/base.py) ORs ``os.RTLD_LAZY``
 # into ``ctypes.CDLL`` mode unconditionally. Windows has no lazy dlopen mode,
 # so we expose a 0 sentinel to keep ``LoadLibrary``'s default behavior.


### PR DESCRIPTION
## Motivation

Try to fix fail of ROCm 7.2 CI.

ROCm 7.2 CI can fail across unrelated TileLang tests with errors like `ndim expected 2, but got 512`. The reported value matches the first tensor dimension, which indicates DLTensor metadata is being read through a bad C DLPack exchange path rather than a kernel-specific failure.

The first CI run still failed with the same errors, so this revision also sets the fallback switches at ROCm job setup time, before install/import/test Python processes can import `tvm_ffi`.

## Changes

- Add a TileLang import-time ROCm guard that sets `TVM_FFI_SKIP_C_DLPACK_EXCHANGE_API=1`.
- Also set `TVM_FFI_DISABLE_TORCH_C_DLPACK=1` before importing TVM so `tvm_ffi` does not load the optional torch C DLPack extension on ROCm.
- Export the same two switches from the ROCm GitHub Actions environment setup step.
- Preserve explicit user overrides through `os.environ.setdefault`.
- Add unit coverage for ROCm, non-ROCm, and user override behavior.

## Testing

- `python` source compile check passed for the modified files.
- `git diff --check` passed.
- Local pytest could not run in this checkout because `build/lib` and `build/tvm` are absent, so importing `tilelang` fails on the pre-existing `TL_LIBS` assertion before test collection.
- CI rerun is pending for commit `5ce534a1`.
