### PR TITLE
[WIP] Handle CuTeDSL FP4 torch dtype

### DIFF
--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -33,6 +33,8 @@ CUTEDSL_KNOWN_FAILURES = {
     "gemm_sp/test_example_gemm_sp.py::test_example_gemm_sp",
     # Flaky — passes when run in isolation, fails under parallel execution
     "minference/test_vs_sparse_attn.py::test_vs_sparse_attn",
+    # CuTeDSL does not yet lower DeepSeek V4 FP4 act quant conversions.
+    "deepseek_v4/test_tilelang_example_deepseek_v4.py::test_example_act_quant",
 }
 
 

--- a/tilelang/jit/adapter/cutedsl/wrapper.py
+++ b/tilelang/jit/adapter/cutedsl/wrapper.py
@@ -612,6 +612,7 @@ def _generate_cubin_if_needed({cubin_gen_params}):
       "torch.float8_e4m3fnuz": cutlass.Float8E4M3FN,
       "torch.float8_e4m3fn": cutlass.Float8E4M3FN,
       "torch.float8_e5m2": cutlass.Float8E5M2,
+      "torch.float4_e2m1fn_x2": cutlass.Float4E2M1FN,
       "torch.float64": cutlass.Float64,
       "torch.int64": cutlass.Int64,
       "torch.int32": cutlass.Int32,


### PR DESCRIPTION
 Fix CuTeDSL handling for PyTorch FP4 storage dtype.

  PyTorch exposes packed FP4 as `torch.float4_e2m1fn_x2` which was introduced by [pr2174](https://github.com/tile-ai/tilelang/pull/2174), while CuTeDSL expects the logical scalar type `cutlass.Float4E2M1FN`. This PR adds
  the missing dtype mapping so CuTeDSL can recognize FP4 tensors instead of failing with a dtype lookup error.

  The DeepSeek V4 FP4 act-quant example is also marked as a CuTeDSL known limitation because current CuTeDSL lowering still cannot compile
  the FP4 conversion path. The remaining failure is not a dtype-dispatch issue; it requires proper FP4 conversion/store lowering in CuTeDSL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended data type support to include FP4 (float4_e2m1fn_x2) for CUTLASS kernel code generation, enabling compilation of models utilizing lower-precision quantized weights

* **Tests**
  * Updated test configuration to mark DeepSeek V4 activation quantization test as a known limitation when using the CuTeDSL compilation target

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2187)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->