### PR TITLE
Fix SM70 buffer region indexing

### DIFF
--- a/tilelang/cuda/intrinsics/macro/mma_sm70_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/mma_sm70_macro_generator.py
@@ -206,6 +206,7 @@ class TensorCoreIntrinEmitter:
         A_buf = A_region.buffer
         A_base0 = A_region.region[-2].min
         A_base1 = A_region.region[-1].min
+        A_other = [r.min for r in A_region.region[:-2]]
 
         @T.macro
         def _warp_ldmatrix_a(
@@ -222,7 +223,7 @@ class TensorCoreIntrinEmitter:
                 wi, wk = warp_m * warp_row_tiles + i * micro_size_x, rk * chunk + ki * micro_size_k
                 for j in T.vectorized(local_size_a):
                     mi, mk = mma_load_layout(tx, j)
-                    A_local_buf[i * local_size_a + j] = A_buf[A_base0 + wi + mi, A_base1 + wk + mk]
+                    A_local_buf[i * local_size_a + j] = A_buf[tuple(A_other) + (A_base0 + wi + mi, A_base1 + wk + mk)]
 
         return _warp_ldmatrix_a(A_local_buf, A_region, ki, thread_binding, rk)
 
@@ -243,6 +244,7 @@ class TensorCoreIntrinEmitter:
         B_buf = B_region.buffer
         B_base0 = B_region.region[-2].min
         B_base1 = B_region.region[-1].min
+        B_other = [r.min for r in B_region.region[:-2]]
 
         @T.macro
         def _warp_ldmatrix_b(
@@ -265,10 +267,10 @@ class TensorCoreIntrinEmitter:
                 for j in T.vectorized(local_size_b):
                     if b_transposed:
                         mi, mk = mma_load_layout(tx, j)
-                        B_local_buf[i * local_size_b + j] = B_buf[B_base0 + wi + mi, B_base1 + wk + mk]
+                        B_local_buf[i * local_size_b + j] = B_buf[tuple(B_other) + (B_base0 + wi + mi, B_base1 + wk + mk)]
                     else:
                         mk, mi = mma_load_layout(tx, j)
-                        B_local_buf[i * local_size_b + j] = B_buf[B_base0 + wk + mk, B_base1 + wi + mi]
+                        B_local_buf[i * local_size_b + j] = B_buf[tuple(B_other) + (B_base0 + wk + mk, B_base1 + wi + mi)]
 
         return _warp_ldmatrix_b(B_local_buf, B_region, ki, thread_binding, rk)
 

--- a/tilelang/cuda/intrinsics/macro/mma_sm70_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/mma_sm70_macro_generator.py
@@ -187,6 +187,7 @@ class TensorCoreIntrinEmitter:
             return lane_id, warp_n, warp_m
 
     def ldmatrix_a(self, A_local_buf: Buffer, A_shared_buf: Buffer | BufferRegion, ki: PrimExpr, rk: PrimExpr | None = 0):
+        """Load matrix A fragments from shared memory into per-thread local storage."""
         warp_row_tiles = self.warp_row_tiles
         warp_rows = self.warp_rows
         chunk = self.chunk
@@ -228,6 +229,7 @@ class TensorCoreIntrinEmitter:
         return _warp_ldmatrix_a(A_local_buf, A_region, ki, thread_binding, rk)
 
     def ldmatrix_b(self, B_local_buf: Buffer, B_shared_buf: Buffer | BufferRegion, ki: PrimExpr, rk: PrimExpr | None = 0):
+        """Load matrix B fragments from shared memory into per-thread local storage."""
         warp_col_tiles = self.warp_col_tiles
         warp_cols = self.warp_cols
         chunk = self.chunk
@@ -275,6 +277,7 @@ class TensorCoreIntrinEmitter:
         return _warp_ldmatrix_b(B_local_buf, B_region, ki, thread_binding, rk)
 
     def mma(self, A_local_buf: Buffer, B_local_buf: Buffer, C_local_buf: Buffer, k_inner: PrimExpr | None = 0):
+        """Issue SM70 MMA operations using the loaded A/B fragments."""
         warp_rows = self.warp_rows
         warp_cols = self.warp_cols
         local_size_a = self.local_size_a


### PR DESCRIPTION
## Summary
- preserve leading buffer-region dimensions in the SM70 `ldmatrix` path
- fix lowering for replicated shared-memory regions such as 3D `A_shared` / `B_shared`
- resolve the Volta quickstart regression reported in #2190

## Test plan
- [x] run `examples/quickstart.py` on an SM70/Volta GPU
- [x] verify lowering no longer raises `IndexError` for 3D shared buffers

🤖 Generated with [Aiden x Claude Code]

Co-Authored-By: Aiden

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected shared-memory buffer indexing for CUDA matrix load intrinsics to handle multi-dimensional buffer regions, preventing misaligned or incorrect data access during matrix operations.
* **Documentation**
  * Added docstrings clarifying behavior and usage of the updated matrix load intrinsics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2191)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->