### PR TITLE
Allow variable barrier id in `T.sync_threads()`

### DIFF
--- a/src/backend/cuda/codegen/codegen_cuda.cc
+++ b/src/backend/cuda/codegen/codegen_cuda.cc
@@ -1399,13 +1399,20 @@ void CodeGenTileLangCUDA::PrintStorageSync(const CallNode *op) {
     if (args.size() == 1) {
       this->stream << "__syncthreads();\n";
     } else if (args.size() == 2) {
-      auto barrier_id = args[1].as<IntImmNode>()->value;
-      this->stream << "tl::__sync_thread_partial<" << barrier_id << ">();\n";
+      ICHECK(args[1].dtype().is_int())
+          << "storage_sync barrier_id must be integer type, got "
+          << args[1].dtype();
+      this->stream << "tl::__sync_thread_partial(" << PrintExpr(args[1])
+                   << ");\n";
     } else if (args.size() == 3) {
-      auto barrier_id = args[1].as<IntImmNode>()->value;
-      auto thread_count = args[2].as<IntImmNode>()->value;
-      this->stream << "tl::__sync_thread_partial<" << barrier_id << ", "
-                   << thread_count << ">();\n";
+      ICHECK(args[1].dtype().is_int())
+          << "storage_sync barrier_id must be integer type, got "
+          << args[1].dtype();
+      ICHECK(args[2].dtype().is_int())
+          << "storage_sync thread_count must be integer type, got "
+          << args[2].dtype();
+      this->stream << "tl::__sync_thread_partial(" << PrintExpr(args[1]) << ", "
+                   << PrintExpr(args[2]) << ");\n";
     } else {
       LOG(FATAL) << "Invalid number of arguments for storage sync: "
                  << args.size();

--- a/src/backend/cuda/codegen/codegen_cutedsl.cc
+++ b/src/backend/cuda/codegen/codegen_cutedsl.cc
@@ -2383,25 +2383,19 @@ void CodeGenTileLangCuTeDSL::PrintStorageSync_(const CallNode *op) {
     if (args.size() == 1) {
       stream << "tl.sync_threads()\n";
     } else if (args.size() == 2) {
-      auto barrier_id_ptr = args[1].as<IntImmNode>();
-      ICHECK(barrier_id_ptr)
-          << "storage_sync barrier_id (args[1]) must be IntImm, got "
-          << args[1]->GetTypeKey();
-      auto barrier_id = barrier_id_ptr->value;
-      stream << "tl.sync_thread_partial(" << barrier_id << ")\n";
+      ICHECK(args[1].dtype().is_int())
+          << "storage_sync barrier_id must be integer type, got "
+          << args[1].dtype();
+      stream << "tl.sync_thread_partial(" << PrintExpr_(args[1]) << ")\n";
     } else if (args.size() == 3) {
-      auto barrier_id_ptr = args[1].as<IntImmNode>();
-      ICHECK(barrier_id_ptr)
-          << "storage_sync barrier_id (args[1]) must be IntImm, got "
-          << args[1]->GetTypeKey();
-      auto thread_count_ptr = args[2].as<IntImmNode>();
-      ICHECK(thread_count_ptr)
-          << "storage_sync thread_count (args[2]) must be IntImm, got "
-          << args[2]->GetTypeKey();
-      auto barrier_id = barrier_id_ptr->value;
-      auto thread_count = thread_count_ptr->value;
-      stream << "tl.sync_thread_partial(" << barrier_id << ", " << thread_count
-             << ")\n";
+      ICHECK(args[1].dtype().is_int())
+          << "storage_sync barrier_id must be integer type, got "
+          << args[1].dtype();
+      ICHECK(args[2].dtype().is_int())
+          << "storage_sync thread_count must be integer type, got "
+          << args[2].dtype();
+      stream << "tl.sync_thread_partial(" << PrintExpr_(args[1]) << ", "
+             << PrintExpr_(args[2]) << ")\n";
     } else {
       LOG(FATAL) << "Invalid number of arguments for storage sync: "
                  << args.size();

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -582,8 +582,7 @@ template <int y = 1, typename T> TL_DEVICE T pow_of_int(T x) {
 
 // Thread partial barrier synchronization
 // https://docs.nvidia.com/cuda/parallel-thread-execution/#memory-consistency-model
-template <int barrier_id = 0, int thread_count = 0>
-TL_DEVICE void __sync_thread_partial() {
+TL_DEVICE void __sync_thread_partial(int barrier_id = 0, int thread_count = 0) {
   asm volatile("bar.sync %0, %1;" : : "r"(barrier_id), "r"(thread_count));
 }
 

--- a/testing/python/issue/test_tilelang_issue_ws_simt_copy_full_producer_extent.py
+++ b/testing/python/issue/test_tilelang_issue_ws_simt_copy_full_producer_extent.py
@@ -67,7 +67,7 @@ def test_ws_keeps_full_producer_extent_for_lowered_simt_copy():
     assert "__launch_bounds__(512, 1)" in src
     assert "if (256 <= ((int)threadIdx.x)) {" in flat_src
     assert "tl::tl_shuffle_elect<256>()" in src or "if (((int)threadIdx.x) == 256) {" in src
-    assert re.search(r"tl::__sync_thread_partial<\d+, 256>\(\);", src), src
+    assert re.search(r"tl::__sync_thread_partial\(\d+, 256\);", src), src
 
 
 if __name__ == "__main__":

--- a/testing/python/language/test_tilelang_language_sync_threads.py
+++ b/testing/python/language/test_tilelang_language_sync_threads.py
@@ -1,5 +1,3 @@
-import re
-
 import tilelang
 import tilelang.testing
 from tilelang import language as T

--- a/testing/python/language/test_tilelang_language_sync_threads.py
+++ b/testing/python/language/test_tilelang_language_sync_threads.py
@@ -1,0 +1,45 @@
+import re
+
+import tilelang
+import tilelang.testing
+from tilelang import language as T
+
+
+def _compile_cuda(func):
+    tilelang.disable_cache()
+    try:
+        return tilelang.compile(func, target="cuda", execution_backend="tvm_ffi")
+    finally:
+        tilelang.enable_cache()
+
+
+@tilelang.testing.requires_cuda
+def test_sync_threads_with_variable_barrier_id():
+    @T.prim_func
+    def kernel():
+        with T.Kernel(1, threads=256) as (bx,):
+            barrier_id = T.int32(1)
+            T.sync_threads(barrier_id)
+            T.sync_threads(barrier_id, 128)
+
+    kernel = _compile_cuda(kernel)
+    src = kernel.get_kernel_source()
+    assert "tl::__sync_thread_partial(" in src, src
+
+
+@tilelang.testing.requires_cuda
+def test_sync_threads_with_computed_barrier_id():
+    @T.prim_func
+    def kernel():
+        with T.Kernel(1, threads=256) as (bx,):
+            tx = T.launch_thread("threadIdx.x", 256)
+            barrier_id = tx % 4
+            T.sync_threads(barrier_id, 256)
+
+    kernel = _compile_cuda(kernel)
+    src = kernel.get_kernel_source()
+    assert "tl::__sync_thread_partial(" in src, src
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thread synchronization now accepts runtime-specified barrier IDs and thread counts and validates integer arguments, allowing dynamic synchronization instead of requiring compile-time constants.

* **Tests**
  * Updated and added CUDA tests to cover dynamic barrier ID and thread-count scenarios and adjusted source assertions to match the new runtime synchronization form.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->