### PR TITLE
[BugFix] cpu with while loop compile error

### DIFF
--- a/src/transform/split_host_device.cc
+++ b/src/transform/split_host_device.cc
@@ -51,14 +51,14 @@ namespace tir = tvm::tir;
 namespace {
 
 class CPUFallbackThreadVarCanonicalizer : public tir::StmtExprMutator {
- public:
+public:
   static tir::Stmt Rewrite(tir::Stmt stmt) {
     CPUFallbackThreadVarCanonicalizer canonicalizer;
     return canonicalizer(std::move(stmt));
   }
 
- private:
-  PrimExpr VisitExpr_(const tir::VarNode* op) final {
+private:
+  PrimExpr VisitExpr_(const tir::VarNode *op) final {
     if (op != nullptr && op->name_hint == "v_thread") {
       return tir::make_zero(op->dtype);
     }
@@ -66,7 +66,7 @@ class CPUFallbackThreadVarCanonicalizer : public tir::StmtExprMutator {
   }
 };
 
-}  // namespace
+} // namespace
 
 // This pass traverses the AST, split the target function into host part and
 // device part and copies all assume attribute statements to the device side.

--- a/src/transform/split_host_device.cc
+++ b/src/transform/split_host_device.cc
@@ -50,8 +50,21 @@ namespace tir = tvm::tir;
 
 namespace {
 
+/*! \brief Rewrite the synthetic CPU fallback thread variable to a constant.
+ *
+ * Some CPU lowering paths materialize a degenerate `v_thread` variable to
+ * reuse thread-oriented transformations even though the generated CPU kernel
+ * has no real thread binding.  If that synthetic variable survives until
+ * host/device splitting, undefined-variable analysis may incorrectly treat it
+ * as a device-kernel parameter.
+ *
+ * This mutator canonicalizes that CPU-only fallback variable to `0` before
+ * device parameter inference so the generated `c` target kernel signature does
+ * not accidentally expose `v_thread`.
+ */
 class CPUFallbackThreadVarCanonicalizer : public tir::StmtExprMutator {
 public:
+  /*! \brief Apply the canonicalization to a statement tree. */
   static tir::Stmt Rewrite(tir::Stmt stmt) {
     CPUFallbackThreadVarCanonicalizer canonicalizer;
     return canonicalizer(std::move(stmt));
@@ -270,6 +283,10 @@ private:
     body = SourceKernelAttrExtractor::Extract(
         std::move(body), &code_block_source_, &code_block_entry_name_);
 
+    // CPU `c` kernels may still contain the synthetic fallback `v_thread`
+    // introduced by earlier lowering.  Canonicalize it before use-def analysis
+    // so split-device parameter inference does not promote it into the device
+    // kernel ABI.
     if (device_target->kind->name == "c") {
       body = CPUFallbackThreadVarCanonicalizer::Rewrite(std::move(body));
     }

--- a/src/transform/split_host_device.cc
+++ b/src/transform/split_host_device.cc
@@ -48,6 +48,26 @@ namespace tl {
 using namespace ffi;
 namespace tir = tvm::tir;
 
+namespace {
+
+class CPUFallbackThreadVarCanonicalizer : public tir::StmtExprMutator {
+ public:
+  static tir::Stmt Rewrite(tir::Stmt stmt) {
+    CPUFallbackThreadVarCanonicalizer canonicalizer;
+    return canonicalizer(std::move(stmt));
+  }
+
+ private:
+  PrimExpr VisitExpr_(const tir::VarNode* op) final {
+    if (op != nullptr && op->name_hint == "v_thread") {
+      return tir::make_zero(op->dtype);
+    }
+    return tir::StmtExprMutator::VisitExpr_(op);
+  }
+};
+
+}  // namespace
+
 // This pass traverses the AST, split the target function into host part and
 // device part and copies all assume attribute statements to the device side.
 
@@ -249,6 +269,10 @@ private:
     code_block_entry_name_ = std::nullopt;
     body = SourceKernelAttrExtractor::Extract(
         std::move(body), &code_block_source_, &code_block_entry_name_);
+
+    if (device_target->kind->name == "c") {
+      body = CPUFallbackThreadVarCanonicalizer::Rewrite(std::move(body));
+    }
 
     // Normal kernels infer device parameters from use-def of the device body.
     // Source kernels have no meaningful DSL body, so their device signature

--- a/testing/python/cpu/test_tilelang_cpu_while_repro.py
+++ b/testing/python/cpu/test_tilelang_cpu_while_repro.py
@@ -1,0 +1,32 @@
+import tilelang
+import tilelang.language as T
+
+
+def test_cpu_kernel_source_generation_with_while() -> None:
+    """Regression test: CPU `T.While` kernels should compile without errors.
+
+    See: https://github.com/tile-ai/tilelang/issues/2202
+
+    Historically, a CPU kernel containing `T.While(...)` inside
+    `T.Kernel(..., is_cpu=True)` could leak the synthetic fallback thread
+    variable `v_thread` into host/device splitting. That in turn caused CPU
+    compilation to fail during packed-API generation or later C wrapper
+    generation.
+
+    This test follows the existing compile-only regression style used in the
+    repository: success is defined by `tilelang.compile(..., target="c")`
+    completing without raising an exception.
+    """
+    @T.prim_func
+    def main(flag: T.Buffer((1,), "int32"), out: T.Buffer((1,), "int32")):
+        with T.Kernel(1, is_cpu=True):
+            state = T.alloc_fragment((1,), "int32")
+            state[0] = 0
+
+            with T.While(state[0] == 0):
+                state[0] = flag[0]
+
+            out[0] = state[0]
+
+    compiled = tilelang.compile(main, target="c")
+    assert compiled is not None

--- a/testing/python/cpu/test_tilelang_cpu_while_repro.py
+++ b/testing/python/cpu/test_tilelang_cpu_while_repro.py
@@ -17,6 +17,7 @@ def test_cpu_kernel_source_generation_with_while() -> None:
     repository: success is defined by `tilelang.compile(..., target="c")`
     completing without raising an exception.
     """
+
     @T.prim_func
     def main(flag: T.Buffer((1,), "int32"), out: T.Buffer((1,), "int32")):
         with T.Kernel(1, is_cpu=True):


### PR DESCRIPTION
Original issue reported at: https://github.com/tile-ai/tilelang/issues/2202

## Summary
This PR fixes a CPU lowering bug where `T.While(...)` inside `T.Kernel(..., is_cpu=True)` could leak the synthetic fallback thread variable `v_thread` into host/device splitting.

Previously, the CPU `c` target could incorrectly treat `v_thread` as an undefined device parameter, which caused compilation failures during packed API generation or later C wrapper generation.

The fix canonicalizes the synthetic CPU fallback `v_thread` to `0` in the CPU split-device path before device parameter collection, preventing it from becoming part of the generated CPU kernel ABI.

## What changed
### `src/transform/split_host_device.cc`
- Added a small CPU-only canonicalization pass:
  - `CPUFallbackThreadVarCanonicalizer`
- Applied it only when:
  - `device_target->kind->name == "c"`
- This ensures the synthetic fallback `v_thread` is rewritten to a constant before undefined-var analysis collects device function parameters.

### `testing/python/cpu/test_tilelang_cpu_while_repro.py`
- Added a dedicated regression test for CPU `T.While` lowering
- Improved the test docstring to explain:
  - the historical failure mode
  - the role of synthetic `v_thread`
  - the expected success condition
- Made the success condition explicit by asserting that:
  - `tilelang.compile(main, target="c")` returns a non-`None` compiled object

## Root cause
For CPU kernels, earlier lowering may introduce a synthetic degenerate thread variable `v_thread` to model thread-like structure even when no real thread binding exists.

When a kernel body contained `T.While(...)`, that synthetic variable could survive into `SplitHostDevice`. Since device parameters are inferred from undefined variable analysis there, `v_thread` was incorrectly promoted into the generated CPU device-kernel signature.

That led to failures such as:
- packed API free-variable errors
- generated C wrapper/device signature mismatch

## Why this fix is low risk
- The change is explicitly gated to the CPU `c` backend:
  - `if (device_target->kind->name == "c")`
- It does not alter CUDA / ROCm / Metal / WebGPU / LLVM device lowering paths
- The final fix is localized to host/device splitting, where the incorrect parameter promotion actually occurred
- A temporary broader workaround in `MakePackedAPI` was removed, so the final patch stays narrowly scoped

## Validation
### Repro test
```bash
python -m pytest testing/python/cpu/test_tilelang_cpu_while_repro.py -q
```
Result:
- `1 passed`

### CPU regression suite
```bash
python -m pytest testing/python/cpu -q
```
Result:
- `15 passed, 15 warnings`

## Behavior before vs after
### Before
Lowered CPU IR could produce a kernel like:
```python
def main_kernel(flag, out, v_thread):
```
and the host wrapper would call it with a synthetic `v_thread`.

### After
The lowered CPU kernel signature is:
```python
def main_kernel(flag, out):
```
with no leaked synthetic thread parameter.

## AI Acknowledgement
While the bug was found in our experiments in our dev environments.
AI models were used to subsequently isolate, replicate, and fix the issue, and generate the PR summary above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CPU kernel compilation failures when using while loops in CPU-targeted kernels, improving reliability for complex CPU kernel code.

* **Tests**
  * Added a regression test to ensure CPU kernel compilation succeeds for kernels containing while loops.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2203)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->