### PR TITLE
[Fix][AMD] Fix Roller autotuner for RDNA3 WMMA targets

### DIFF
--- a/benchmark/matmul/benchmark_matmul.py
+++ b/benchmark/matmul/benchmark_matmul.py
@@ -30,7 +30,7 @@ def ref_program(A, B):
     return A @ B.T
 
 
-def get_configs(args, kwargs):
+def get_configs(*args, **kwargs):
     """
     Generate a list of configuration dictionaries that will be used for tuning.
 
@@ -45,7 +45,14 @@ def get_configs(args, kwargs):
         Each configuration dict includes various block sizes, pipeline stages,
         thread numbers, and other parameters to explore during autotuning.
     """
-    M, N, K, with_roller = args[:4]
+    # Support both the current autotuner calling convention
+    #   get_configs(M, N, K, with_roller, ...)
+    # and the historical/manual helper style
+    #   get_configs((M, N, K, with_roller), kwargs)
+    if len(args) == 2 and isinstance(args[0], (tuple, list)) and isinstance(args[1], dict):
+        M, N, K, with_roller = args[0][:4]
+    else:
+        M, N, K, with_roller = args[:4]
 
     if with_roller:
         from tilelang.carver.template import MatmulTemplate

--- a/benchmark/matmul/benchmark_matmul.py
+++ b/benchmark/matmul/benchmark_matmul.py
@@ -49,12 +49,11 @@ def get_configs(args, kwargs):
 
     if with_roller:
         from tilelang.carver.template import MatmulTemplate
-        from tilelang.carver.arch import CUDA
-        from tilelang.carver.arch import CDNA
+        from tilelang.carver.arch import CUDA, auto_infer_current_arch
         from tilelang.carver.roller.rasterization import NoRasterization
         import torch
 
-        arch = CUDA("cuda") if torch.version.hip is None else CDNA("hip")
+        arch = CUDA("cuda") if torch.version.hip is None else auto_infer_current_arch()
         topk = 10
 
         carve_template = MatmulTemplate(
@@ -78,15 +77,26 @@ def get_configs(args, kwargs):
         for hint in roller_hints:
             config = {}
             block_m, block_n = hint.block
-            warp_m, warp_n = hint.warp
-            # block_rows, block_cols represents warp partitioning
-            block_rows, block_cols = block_m // warp_m, block_n // warp_n
             config["block_M"] = block_m
             config["block_N"] = block_n
             config["block_K"] = hint.rstep[0]
             config["num_stages"] = hint.pipeline_stage
-            config["thread_num"] = block_rows * block_cols * 32
-            config["policy"] = T.GemmWarpPolicy.from_warp_partition(block_rows, block_cols)
+            if hint.warp:
+                warp_m, warp_n = hint.warp
+                # block_rows, block_cols represents warp partitioning
+                block_rows, block_cols = block_m // warp_m, block_n // warp_n
+                config["thread_num"] = block_rows * block_cols * arch.warp_size
+                config["policy"] = T.GemmWarpPolicy.from_warp_partition(block_rows, block_cols)
+            else:
+                # Some HIP/RDNA targets currently fall back to non-tensorcore Roller
+                # hints.  Keep these usable for benchmarking by deriving the thread
+                # count from the thread tiling and letting TileLang choose a square
+                # WMMA warp partition at T.gemm lowering time.
+                thread_num = 1
+                for extent in hint.thread:
+                    thread_num *= extent
+                config["thread_num"] = thread_num
+                config["policy"] = T.GemmWarpPolicy.Square
             config["enable_rasteration"] = hint.rasterization_plan is not NoRasterization
             configs.append(config)
         for config in configs:

--- a/testing/python/target/test_tilelang_rocm_target.py
+++ b/testing/python/target/test_tilelang_rocm_target.py
@@ -112,3 +112,17 @@ def test_rdna_tensor_instruction_lookup_is_generation_aware():
     arch.rdna_generation = 12
     with pytest.raises(ValueError, match="Unsupported RDNA generation"):
         arch.get_avaliable_tensorintrin_shapes()
+
+
+def test_rdna_internal_tuning_config_allows_mcpu_overrides():
+    from tilelang.carver.arch.rdna import _get_rdna_tuning_config
+
+    default = _get_rdna_tuning_config("gfx1100")
+    gfx1151 = _get_rdna_tuning_config("gfx1151:sramecc+:xnack-")
+
+    assert default.preferred_warps_per_block == 4
+    assert default.pipeline_stage == 1
+    assert default.reduction_step_for_dtype_bits(16) == 32
+    assert gfx1151.preferred_warps_per_block == 4
+    assert gfx1151.pipeline_stage == 2
+    assert gfx1151.reduction_step_for_dtype_bits(16) == 32

--- a/tilelang/carver/arch/rdna.py
+++ b/tilelang/carver/arch/rdna.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from dataclasses import dataclass
 import tvm
 from tvm.target import Target
 from .arch_base import TileDevice
@@ -9,6 +10,40 @@ _RDNA_DEFAULT_LDS_SIZE = 64 * 1024
 _RDNA_TENSOR_INSTRUCTIONS = {
     11: (TensorInstruction("wmma", [16, 16]),),
 }
+
+
+@dataclass(frozen=True)
+class _RDNATuningConfig:
+    """Internal Roller tuning heuristics for RDNA WMMA targets.
+
+    Keep this deliberately small and table-driven so exact mcpu overrides stay
+    localized here as gfx1100/gfx1151 measurements diverge. These values are
+    scheduling defaults, not architectural correctness constraints.
+    """
+
+    preferred_warps_per_block: int = 4
+    pipeline_stage: int = 1
+    reduction_step_by_dtype_bits: tuple[tuple[int, int], ...] = ((16, 32),)
+
+    def reduction_step_for_dtype_bits(self, bits: int) -> int | None:
+        return dict(self.reduction_step_by_dtype_bits).get(bits)
+
+
+_RDNA_DEFAULT_TUNING = _RDNATuningConfig()
+_RDNA_TUNING_OVERRIDES: dict[str, _RDNATuningConfig] = {
+    # Strix Halo / Radeon 8060S: measured best large FP16 GEMM configs use
+    # 128-thread blocks, K tiles starting at 32, and two software pipeline stages.
+    "gfx1151": _RDNATuningConfig(
+        preferred_warps_per_block=4,
+        pipeline_stage=2,
+        reduction_step_by_dtype_bits=((16, 32),),
+    ),
+}
+
+
+def _get_rdna_tuning_config(mcpu: str | None) -> _RDNATuningConfig:
+    normalized = str(mcpu).strip().split(":", maxsplit=1)[0] if mcpu else None
+    return _RDNA_TUNING_OVERRIDES.get(normalized, _RDNA_DEFAULT_TUNING)
 
 
 def _get_tensor_instructions_for_generation(rdna_generation: int) -> tuple[TensorInstruction, ...]:
@@ -27,9 +62,11 @@ class RDNA(TileDevice):
         if isinstance(target, str):
             target = tvm.target.Target(target)
         self.target = target
+        self.mcpu = target_get_mcpu(target)
         self.rdna_generation = target_get_rdna_generation(target)
+        self.tuning = _get_rdna_tuning_config(self.mcpu)
         if self.rdna_generation != 11:
-            arch = target_get_mcpu(target) or str(target)
+            arch = self.mcpu or str(target)
             raise ValueError(f"RDNA device model currently supports gfx11 targets only, got {arch}.")
         device = tvm.runtime.rocm(0)
         if not device.exist:

--- a/tilelang/carver/matmul_analysis.py
+++ b/tilelang/carver/matmul_analysis.py
@@ -17,6 +17,8 @@ from .analysis import (
 from tvm.target.target import Target
 from tvm.tir.stmt_functor import pre_order_visit
 from .arch import get_arch, is_tensorcore_supported_precision
+from .arch.rdna import _get_rdna_tuning_config
+from tilelang.utils.target import target_get_mcpu, target_is_rdna
 import logging
 
 logger = logging.getLogger(__name__)
@@ -540,13 +542,20 @@ def get_tensorized_func_and_tags(
         sm_version = arch.replace("sm_", "")
         return int(sm_version) if sm_version.isdigit() else -1
 
+    def is_cuda_tensorcore_target(target: Target) -> bool:
+        return target.kind.name == "cuda" and check_sm_version(target.arch) >= 70
+
+    def is_rdna_wmma_target(target: Target) -> bool:
+        return target.kind.name == "hip" and target_is_rdna(target)
+
     def analysis_tensorcore_tags(sch: tir.Schedule, block: BlockRV, target: Target) -> bool | dict:
         tags: dict[str, list[int] | int] = {}
         block_stmt = sch.get(block)
 
-        # Nvidia Only Support Tensor Core for
-        # devices greater than 70.
-        if check_sm_version(target.arch) < 70:
+        # Tensorized schedules are supported by NVIDIA Tensor Cores and by RDNA
+        # WMMA on HIP/gfx11+ targets.  Other targets fall back to the default
+        # Roller policy.
+        if not is_cuda_tensorcore_target(target) and not is_rdna_wmma_target(target):
             return False
         # analysis tensorcore axis
         # todo(lei): maybe we can remove this in the future
@@ -560,11 +569,13 @@ def get_tensorized_func_and_tags(
         if target.kind.name == "cuda" and check_sm_version(target.arch) in {80, 90}:
             # enable pipeline stage only for sm_80 devices
             tags["pipeline_stage"] = 2
+        elif is_rdna_wmma_target(target):
+            tags["pipeline_stage"] = _get_rdna_tuning_config(target_get_mcpu(target)).pipeline_stage
 
         # analysis async copy
         # todo(lei): maybe we can integrate this into policy in the future
         tags["use_async_copy"] = False
-        if tags["pipeline_stage"] == 2 and check_sm_version(target.arch) in {80, 90}:
+        if target.kind.name == "cuda" and tags["pipeline_stage"] == 2 and check_sm_version(target.arch) in {80, 90}:
             # async copy only works in software pipeline.
             tags["use_async_copy"] = True
 
@@ -593,7 +604,7 @@ def get_tensorized_func_and_tags(
         intrin_info["in_dtype"] = in_dtype
         intrin_info["out_dtype"] = out_dtype
 
-        if 70 <= check_sm_version(target.arch) < 80 and out_dtype == "int32":
+        if target.kind.name == "cuda" and 70 <= check_sm_version(target.arch) < 80 and out_dtype == "int32":
             # INT32 Accum TensorCore only supports SM Version > 32.
             return False
 
@@ -616,7 +627,7 @@ def get_tensorized_func_and_tags(
                 if isinstance(M, tir.IntImm) and M <= 128:
                     require_block_reduce = True
                 break
-        if require_block_reduce and check_sm_version(target.arch) == 80:
+        if target.kind.name == "cuda" and require_block_reduce and check_sm_version(target.arch) == 80:
             tags["block_reduction_depth"] = 2
         return tags
 
@@ -625,11 +636,16 @@ def get_tensorized_func_and_tags(
         return func, None
 
     block_stmt = sch.get(main_block)
-    if target.kind.name == "cuda" and check_sm_version(target.arch) >= 70:
+    if is_cuda_tensorcore_target(target) or is_rdna_wmma_target(target):
         in_dtype, out_dtype = get_in_out_dtypes(block_stmt)
-        if not is_tensorcore_supported_precision(in_dtype, out_dtype, arch=get_arch(target)):
-            logger.debug(f"The input and output dtype ({in_dtype}, {out_dtype})is not supported by tensorcore")
-            return func, None
+        if is_cuda_tensorcore_target(target):
+            if not is_tensorcore_supported_precision(in_dtype, out_dtype, arch=get_arch(target)):
+                logger.debug(f"The input and output dtype ({in_dtype}, {out_dtype})is not supported by tensorcore")
+                return func, None
+        elif is_rdna_wmma_target(target):
+            if (str(in_dtype), str(out_dtype)) not in {("float16", "float32")}:
+                logger.debug(f"The input and output dtype ({in_dtype}, {out_dtype})is not supported by RDNA WMMA")
+                return func, None
 
         # reindex and transform functions
         # Normalize tensor functions to C[S, I, J] += A[S, I, K] * B[S, J, K]

--- a/tilelang/carver/matmul_analysis.py
+++ b/tilelang/carver/matmul_analysis.py
@@ -642,10 +642,9 @@ def get_tensorized_func_and_tags(
             if not is_tensorcore_supported_precision(in_dtype, out_dtype, arch=get_arch(target)):
                 logger.debug(f"The input and output dtype ({in_dtype}, {out_dtype})is not supported by tensorcore")
                 return func, None
-        elif is_rdna_wmma_target(target):
-            if (str(in_dtype), str(out_dtype)) not in {("float16", "float32")}:
-                logger.debug(f"The input and output dtype ({in_dtype}, {out_dtype})is not supported by RDNA WMMA")
-                return func, None
+        elif is_rdna_wmma_target(target) and (str(in_dtype), str(out_dtype)) not in {("float16", "float32")}:
+            logger.debug(f"The input and output dtype ({in_dtype}, {out_dtype})is not supported by RDNA WMMA")
+            return func, None
 
         # reindex and transform functions
         # Normalize tensor functions to C[S, I, J] += A[S, I, K] * B[S, J, K]

--- a/tilelang/carver/roller/policy/tensorcore.py
+++ b/tilelang/carver/roller/policy/tensorcore.py
@@ -32,7 +32,9 @@ class TensorCorePolicy(DefaultPolicy):
         if pipleline_stage:
             self.pipeline_stage = pipleline_stage
         else:
-            if self.arch.compute_capability in {"sm_80", "sm_90", "sm_90a"}:
+            if is_rdna_arch(self.arch):
+                self.pipeline_stage = self.arch.tuning.pipeline_stage
+            elif self.arch.compute_capability in {"sm_80", "sm_90", "sm_90a"}:
                 self.pipeline_stage = 2
             else:
                 self.pipeline_stage = 1
@@ -89,6 +91,10 @@ class TensorCorePolicy(DefaultPolicy):
         # 512 bytes // type bits
         reduce_input_dtype = node.get_buffer_dtype(node.block_analyzer.get_input_buffers(node.reduction_block)[0])
         basic = (target_transaction * 8) // reduce_input_dtype.bits
+        if is_rdna_arch(self.arch):
+            rdna_basic = self.arch.tuning.reduction_step_for_dtype_bits(reduce_input_dtype.bits)
+            if rdna_basic is not None:
+                basic = rdna_basic
 
         result = {}
         for iter_info in node.raxis:
@@ -103,6 +109,13 @@ class TensorCorePolicy(DefaultPolicy):
         return result
 
     def _expand_reduce_axis(self, td: TileDict):
+        if is_rdna_arch(self.arch):
+            # RDNA WMMA benefits from considering wide output tiles such as
+            # 64x256 that only fit with smaller K tiles.  Start from the RDNA
+            # tuning default and then use the generic expansion pass to grow K
+            # only when shared-memory/occupancy limits allow it.
+            return super()._expand_reduce_axis(td)
+
         # For tensorcore program, if we got a small tilesize, we should consider expand the reduce axis
         # to improve compute efficiency.
         def _check_small_tile(td: TileDict):
@@ -216,8 +229,9 @@ class TensorCorePolicy(DefaultPolicy):
     def score_block_size(self, n):
         base_score = super().score_block_size(n)
         if is_rdna_arch(self.arch):
+            preferred_warps = self.arch.tuning.preferred_warps_per_block
             warps = (n + self.arch.warp_size - 1) // self.arch.warp_size
-            return (0 if warps == 8 else 1, abs(warps - 8), *base_score)
+            return (0 if warps == preferred_warps else 1, abs(warps - preferred_warps), *base_score)
         return base_score
 
     def _can_implement_layout(self, node: PrimFuncNode, td: TileDict):


### PR DESCRIPTION
# Fix Roller autotuner for RDNA3 WMMA targets

The ROCm Roller autotuner currently cannot generate tile configurations for RDNA3 / gfx11 HIP targets.

Two issues prevent it from working:

1. `matmul_analysis.py` gates tensorcore scheduling on NVIDIA `sm_` version checks, so RDNA WMMA targets fall through to the default non-tensorcore Roller policy. In that path `hint.warp` is empty, and downstream code that expects `warp_m, warp_n = hint.warp` cannot construct a tensorcore GEMM config.
2. `benchmark_matmul.py` hardcodes `CDNA("hip")` for all HIP targets, which selects the wrong architecture model for RDNA GPUs. Its callback signature, `get_configs(args, kwargs)`, also does not match the autotuner's current calling convention, `get_configs(M, N, K, with_roller)`, so `--with_roller` crashes immediately with:

```text
TypeError: get_configs() takes 2 positional arguments but 4 were given
```

As a result, `benchmark/matmul/benchmark_matmul.py --with_roller` is broken on RDNA3 today.

## Changes

- `tilelang/carver/matmul_analysis.py`
  - Recognize RDNA WMMA targets alongside NVIDIA tensorcore targets in the tensorized scheduling path.
  - Guard NVIDIA-specific `sm_` version checks so they do not reject HIP/RDNA targets.
  - Wire in per-`mcpu` pipeline-stage defaults for RDNA.

- `tilelang/carver/roller/policy/tensorcore.py`
  - Use per-`mcpu` tuning config for RDNA pipeline stages, reduction step sizes, warp-per-block scoring, and K-axis expansion instead of applying CDNA/NVIDIA defaults.

- `tilelang/carver/arch/rdna.py`
  - Add an internal table-driven `_RDNATuningConfig` with per-`mcpu` overrides.
  - Add a `gfx1151` override; `gfx1100` uses the default RDNA tuning config.
  - Expose `mcpu` and `tuning` on the `RDNA` arch object.

- `benchmark/matmul/benchmark_matmul.py`
  - Fix the autotuner callback signature with `*args, **kwargs` compatibility.
  - Use `auto_infer_current_arch()` instead of hardcoded `CDNA("hip")` for HIP targets.
  - Handle empty `hint.warp` fallback.
  - Use `arch.warp_size` instead of hardcoded `32`.

- `testing/python/target/test_tilelang_rocm_target.py`
  - Add test coverage for per-`mcpu` RDNA tuning config lookup.

## Benchmark results

Command:

```bash
benchmark/matmul/benchmark_matmul.py --m 4096 --n 4096 --k 4096 --with_roller
```

| GPU | Main | This PR |
|---|---:|---:|
| gfx1100 / RX 7900 XTX / 96 CUs | ❌ `TypeError` | ✅ 75.1 TFLOPS / 1.83 ms |
| gfx1151 / Radeon 8060S / 20 CUs | ❌ `TypeError` | ✅ 18.8 TFLOPS / 7.30 ms |

This PR is about making the RDNA Roller/autotuner path work and generate RDNA WMMA candidates. Fixed-kernel performance is largely unchanged when the same explicit config is passed to both branches (and are typically lower than PyTorch (hipBLASLt) and rocWMMA for structural reasons...

## Validation

```bash
python -m pytest testing/python/target/test_tilelang_rocm_target.py -q
python -m py_compile \
  tilelang/carver/arch/rdna.py \
  tilelang/carver/matmul_analysis.py \
  tilelang/carver/roller/policy/tensorcore.py \
  benchmark/matmul/benchmark_matmul.py \
  testing/python/target/test_tilelang_rocm_target.py
git diff --check
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added RDNA/AMD WMMA tensorcore support for matrix multiplication and tensorization.
  * Per-target RDNA tuning applied at scheduling and block-size selection.

* **Improvements**
  * More flexible autotuning configuration interface and more robust target/architecture detection.
  * Tensorcore analysis broadened to handle both CUDA and RDNA precision rules; CUDA-specific logic now properly gated.

* **Tests**
  * Added unit test validating RDNA tuning configuration overrides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2208)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->