### PR TITLE
[ROCm] Expose HIP kernel n_regs / n_spills / n_max_threads on JITKernel

### DIFF
--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -461,9 +461,7 @@ class KernelCache:
                 self.logger.debug(f"Saving kernel parameters to disk: {params_path}")
             KernelCache._safe_write_file(params_path, "wb", lambda file: cloudpickle.dump(kernel.params, file))
 
-            # Persist parsed kernel-resource-usage remarks (HIP only;
-            # empty dict on other targets) so cache hits don't lose
-            # kernel.n_regs / n_spills / resource_usage.
+            # Persist HIP kernel-resource-usage remarks
             usage = getattr(kernel, "_resource_usage", None) or {}
             if usage:
                 dump_to_file(usage, os.path.join(staging_path, self.resource_usage_path))

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -22,6 +22,7 @@ from tilelang.engine.param import KernelParam
 from tilelang.utils.language import get_prim_func_name
 from tilelang import env
 from tilelang.jit import JITKernel
+from tilelang.contrib.hip_resource_info import dump_to_file, load_from_file
 from tilelang import __version__
 import platform
 
@@ -46,6 +47,7 @@ class KernelCache:
     host_kernel_path = "host_kernel.cu"
     kernel_lib_path = "kernel_lib.so"
     params_path = "params.pkl"
+    resource_usage_path = "resource_usage.json"
     cache_root_dir = "kernels"
     staging_root_dir = ".staging"
 
@@ -459,6 +461,13 @@ class KernelCache:
                 self.logger.debug(f"Saving kernel parameters to disk: {params_path}")
             KernelCache._safe_write_file(params_path, "wb", lambda file: cloudpickle.dump(kernel.params, file))
 
+            # Persist parsed kernel-resource-usage remarks (HIP only;
+            # empty dict on other targets) so cache hits don't lose
+            # kernel.n_regs / n_spills / resource_usage.
+            usage = getattr(kernel, "_resource_usage", None) or {}
+            if usage:
+                dump_to_file(usage, os.path.join(staging_path, self.resource_usage_path))
+
             missing_files = self._get_missing_complete_cache_files(staging_path)
             if missing_files:
                 missing_names = ", ".join(os.path.basename(path) for path in missing_files)
@@ -531,7 +540,7 @@ class KernelCache:
         except Exception:
             self.logger.exception("Error loading kernel parameters from disk")
 
-        return self._build_kernel(
+        kernel = self._build_kernel(
             func=func,
             host_kernel_source=host_kernel_source,
             device_kernel_source=device_kernel_source,
@@ -544,6 +553,17 @@ class KernelCache:
             pass_configs=pass_configs,
             compile_flags=compile_flags,
         )
+
+        # Restore parsed kernel-resource-usage if a previous compile
+        # persisted it; absent file is fine (older caches, non-HIP).
+        ru_path = os.path.join(cache_path, self.resource_usage_path)
+        if kernel is not None and os.path.exists(ru_path):
+            try:
+                kernel._resource_usage = load_from_file(ru_path)
+            except Exception:
+                self.logger.exception("Error loading kernel resource_usage from disk")
+
+        return kernel
 
     def _clear_disk_cache(self):
         """

--- a/tilelang/contrib/hip_resource_info.py
+++ b/tilelang/contrib/hip_resource_info.py
@@ -1,0 +1,145 @@
+"""Parse AMD GPU per-kernel resource usage out of clang's
+``-Rpass-analysis=kernel-resource-usage`` remarks and expose them on
+JITKernel.
+
+clang emits a block like::
+
+    remark: src.cc:9:0: Function Name: main_kernel [-Rpass-analysis=kernel-resource-usage]
+    remark: src.cc:9:0:     TotalSGPRs: 16 [-Rpass-analysis=kernel-resource-usage]
+    remark: src.cc:9:0:     VGPRs: 5 [-Rpass-analysis=kernel-resource-usage]
+    remark: src.cc:9:0:     ScratchSize [bytes/lane]: 0 [-Rpass-analysis=kernel-resource-usage]
+    remark: src.cc:9:0:     SGPRs Spill: 0 [-Rpass-analysis=kernel-resource-usage]
+    remark: src.cc:9:0:     VGPRs Spill: 0 [-Rpass-analysis=kernel-resource-usage]
+    ...
+
+right alongside any real warnings/errors. We *parse and strip* those
+lines before printing or raising, so autotune logs don't drown in
+hundreds of remark blocks while real diagnostics still surface.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import re
+import threading
+from dataclasses import asdict, dataclass, field
+
+# A line is a kernel-resource-usage remark iff it carries this exact tag.
+# clang appends the option name as ``[-Rpass-analysis=kernel-resource-usage]``.
+_REMARK_TAG = "[-Rpass-analysis=kernel-resource-usage]"
+# clang prints `<path>:<line>:<col>: remark:     <key>: <value> [-Rpass-...]`
+_REMARK_LINE_RE = re.compile(r"\bremark:\s*(?P<key>[^:]+?):\s*(?P<value>.*?)\s*" + re.escape(_REMARK_TAG) + r"\s*$")
+
+
+@dataclass
+class KernelResourceUsage:
+    """Resource counts as reported by clang's kernel-resource-usage pass.
+
+    Field names mirror the remark labels (lower-cased, normalized) so we
+    can extend without breaking callers.
+    """
+
+    n_regs: int = 0  # VGPRs
+    # Total VGPR-equivalent spill pressure: the explicit `VGPRs Spill` count
+    # plus scratch memory in dwords (`ScratchSize [bytes/lane]` / 4). Matches
+    # how triton accounts for spills (its n_spills is scratch_bytes / 4) but
+    # also folds in clang's explicit spill count when present.
+    n_spills: int = 0
+    scratch_bytes: int = 0  # raw `ScratchSize [bytes/lane]`
+    n_max_threads: int | None = None  # not in remarks; kept for API symmetry
+    extra: dict[str, str] = field(default_factory=dict)  # raw remark key→value
+
+
+_FLAG = "-Rpass-analysis=kernel-resource-usage"
+
+_RECORDER = threading.local()
+
+
+def hipcc_remark_flag() -> str:
+    """The clang flag callers should pass to hipcc to enable the remark
+    output we parse here."""
+    return _FLAG
+
+
+def reset_recorder() -> None:
+    """Begin a fresh recording window on this thread."""
+    _RECORDER.items = {}
+
+
+def pop_recorded() -> dict[str, KernelResourceUsage]:
+    """Return everything recorded since the last ``reset_recorder`` and
+    clear the buffer."""
+    items = getattr(_RECORDER, "items", {})
+    _RECORDER.items = {}
+    return dict(items)
+
+
+def filter_and_record(output: str) -> str:
+    """Strip kernel-resource-usage remarks from ``output``, parse them,
+    and append the parsed entries to the active recorder (if any).
+    Returns the filtered output with the remark lines removed."""
+    if _REMARK_TAG not in output:
+        return output
+
+    kept_lines: list[str] = []
+    current_name: str | None = None
+    current: KernelResourceUsage | None = None
+    items = getattr(_RECORDER, "items", None)
+
+    for line in output.splitlines(keepends=True):
+        m = _REMARK_LINE_RE.search(line.rstrip("\n").rstrip("\r"))
+        if m is None:
+            kept_lines.append(line)
+            continue
+        key = m.group("key").strip()
+        value = m.group("value").strip()
+        if key == "Function Name":
+            # finalize previous block
+            if items is not None and current_name and current is not None:
+                items[current_name] = current
+            current_name = value
+            current = KernelResourceUsage()
+        elif current is not None:
+            current.extra[key] = value
+            if key == "VGPRs":
+                with contextlib.suppress(ValueError):
+                    current.n_regs = int(value)
+            elif key == "VGPRs Spill":
+                with contextlib.suppress(ValueError):
+                    current.n_spills += int(value)
+            elif key.startswith("ScratchSize"):
+                # ScratchSize [bytes/lane] — fold scratch dwords into n_spills.
+                with contextlib.suppress(ValueError):
+                    current.scratch_bytes = int(value)
+                    current.n_spills += int(value) // 4
+        # remark line is dropped (not added to kept_lines)
+
+    if items is not None and current_name and current is not None:
+        items[current_name] = current
+
+    return "".join(kept_lines)
+
+
+def dump_to_file(usage: dict[str, KernelResourceUsage], path: str) -> None:
+    """Persist parsed resource usage so it survives kernel-cache hits."""
+    data = {name: asdict(u) for name, u in usage.items()}
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+
+
+def load_from_file(path: str) -> dict[str, KernelResourceUsage]:
+    """Inverse of ``dump_to_file``. Tolerant of missing / unknown fields
+    so older cache entries keep working when the dataclass evolves."""
+    with open(path) as f:
+        data = json.load(f)
+    out: dict[str, KernelResourceUsage] = {}
+    for name, entry in data.items():
+        out[name] = KernelResourceUsage(
+            n_regs=int(entry.get("n_regs", 0)),
+            n_spills=int(entry.get("n_spills", 0)),
+            scratch_bytes=int(entry.get("scratch_bytes", 0)),
+            n_max_threads=entry.get("n_max_threads"),
+            extra=dict(entry.get("extra", {})),
+        )
+    return out

--- a/tilelang/contrib/hip_resource_info.py
+++ b/tilelang/contrib/hip_resource_info.py
@@ -3,7 +3,6 @@
 JITKernel.
 
 clang emits a block like::
-
     remark: src.cc:9:0: Function Name: main_kernel [-Rpass-analysis=kernel-resource-usage]
     remark: src.cc:9:0:     TotalSGPRs: 16 [-Rpass-analysis=kernel-resource-usage]
     remark: src.cc:9:0:     VGPRs: 5 [-Rpass-analysis=kernel-resource-usage]

--- a/tilelang/contrib/hipcc.py
+++ b/tilelang/contrib/hipcc.py
@@ -15,6 +15,8 @@ from tvm.contrib import utils
 from tvm.base import py_str
 from tvm.contrib.rocm import get_rocm_arch, find_rocm_path
 
+from .hip_resource_info import filter_and_record, hipcc_remark_flag
+
 
 def compile_hip(code, target_format="hsaco", arch=None, options=None, path_target=None, verbose=False):
     """Compile HIP code with hipcc.
@@ -69,19 +71,25 @@ def compile_hip(code, target_format="hsaco", arch=None, options=None, path_targe
         else:
             raise ValueError("options must be str or list of str")
 
+    # -Rpass-analysis=kernel-resource-usage prints per-kernel VGPR /
+    # scratch / spill counts as clang remarks; tilelang parses + strips
+    # them in `filter_and_record` so they don't drown autotune logs.
+    cmd += [hipcc_remark_flag()]
+
     cmd += ["-o", file_target]
     cmd += [temp_code]
 
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
 
     (out, _) = proc.communicate()
+    out_text = filter_and_record(py_str(out))
     if verbose:
-        print(py_str(out))
+        print(out_text)
 
     if proc.returncode != 0:
         msg = code
         msg += "\nCompilation error:\n"
-        msg += py_str(out)
+        msg += out_text
         raise RuntimeError(msg)
 
     with open(file_target, "rb") as f:

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -312,6 +312,7 @@ class Environment:
     TILELANG_CLEANUP_TEMP_FILES = EnvVar(
         "TILELANG_CLEANUP_TEMP_FILES", "0"
     )  # cleanup temporary compiler files/dirs after compilation (default: keep for debugging)
+    TILELANG_HIP_SAVE_TEMP_FILES = EnvVar("TILELANG_HIP_SAVE_TEMP_FILES", "0")  # save temporary files for HIP compilation
 
     # Auto-tuning settings
     TILELANG_AUTO_TUNING_DISABLE_CACHE = EnvVar("TILELANG_AUTO_TUNING_DISABLE_CACHE", "0")
@@ -502,3 +503,4 @@ if os.environ.get("TL_TEMPLATE_PATH", None) is None:
 CUTLASS_INCLUDE_DIR = env.CUTLASS_INCLUDE_DIR
 COMPOSABLE_KERNEL_INCLUDE_DIR = env.COMPOSABLE_KERNEL_INCLUDE_DIR
 TILELANG_TEMPLATE_PATH = env.TILELANG_TEMPLATE_PATH
+TILELANG_HIP_SAVE_TEMP_FILES = env.TILELANG_HIP_SAVE_TEMP_FILES

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -21,7 +21,7 @@ from tilelang.contrib.rocm import find_rocm_path, get_rocm_arch
 from tilelang.env import TILELANG_TEMPLATE_PATH
 from tilelang.utils.target import target_get_mcpu
 
-from tilelang.contrib.hip_resource_info import filter_and_record, hipcc_remark_flag
+from tilelang.contrib.hip_resource_info import filter_and_record
 
 from .utils import is_cpu_target, is_cuda_target, is_hip_target
 
@@ -128,10 +128,7 @@ class LibraryGenerator:
                 f"--offload-arch={arch}",
                 "--shared",
                 src.name,
-                # Emit per-kernel resource-usage remarks; tilelang parses
-                # and strips them below before printing/raising so they
-                # don't pollute autotune logs.
-                hipcc_remark_flag(),
+                "-Rpass-analysis=kernel-resource-usage",
             ]
             command += [
                 "-I" + COMPOSABLE_KERNEL_INCLUDE_DIR,
@@ -178,9 +175,6 @@ class LibraryGenerator:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
             )
-        # On HIP we always capture stdio so the kernel-resource-usage
-        # remarks can be parsed + stripped before anything reaches the
-        # terminal; the filtered output still surfaces on error.
         if is_hip_target(target):
             run_kwargs.setdefault("stdout", subprocess.PIPE)
             run_kwargs.setdefault("stderr", subprocess.STDOUT)
@@ -192,20 +186,14 @@ class LibraryGenerator:
         except Exception as e:
             raise RuntimeError(f"Compile kernel failed because of {e}") from e
 
-        captured = ""
-        if ret.stdout is not None:
-            captured = ret.stdout.decode("utf-8", errors="replace")
-            if is_hip_target(target):
-                captured = filter_and_record(captured)
-
         if ret.returncode != 0:
+            captured = ret.stdout.decode("utf-8", errors="replace") if ret.stdout else ""
             raise RuntimeError(f"Compilation Failed! {command}\n{captured}\n{self.lib_code}")
 
-        # On HIP success, surface any real (non-remark) warnings only when
-        # the caller asked for verbose output, matching `compile_hip`'s
-        # behavior. Quiet by default so autotune logs stay clean.
-        if is_hip_target(target) and verbose and captured.strip():
-            print(captured)
+        if is_hip_target(target) and ret.stdout is not None:
+            captured = filter_and_record(ret.stdout.decode("utf-8", errors="replace"))
+            if verbose and captured.strip():
+                print(captured)
 
         self.srcpath = src.name
         self.libpath = libpath

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -21,6 +21,8 @@ from tilelang.contrib.rocm import find_rocm_path, get_rocm_arch
 from tilelang.env import TILELANG_TEMPLATE_PATH
 from tilelang.utils.target import target_get_mcpu
 
+from tilelang.contrib.hip_resource_info import filter_and_record, hipcc_remark_flag
+
 from .utils import is_cpu_target, is_cuda_target, is_hip_target
 
 logger = logging.getLogger(__name__)
@@ -126,6 +128,10 @@ class LibraryGenerator:
                 f"--offload-arch={arch}",
                 "--shared",
                 src.name,
+                # Emit per-kernel resource-usage remarks; tilelang parses
+                # and strips them below before printing/raising so they
+                # don't pollute autotune logs.
+                hipcc_remark_flag(),
             ]
             command += [
                 "-I" + COMPOSABLE_KERNEL_INCLUDE_DIR,
@@ -172,6 +178,12 @@ class LibraryGenerator:
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
             )
+        # On HIP we always capture stdio so the kernel-resource-usage
+        # remarks can be parsed + stripped before anything reaches the
+        # terminal; the filtered output still surfaces on error.
+        if is_hip_target(target):
+            run_kwargs.setdefault("stdout", subprocess.PIPE)
+            run_kwargs.setdefault("stderr", subprocess.STDOUT)
 
         try:
             if verbose:
@@ -180,9 +192,20 @@ class LibraryGenerator:
         except Exception as e:
             raise RuntimeError(f"Compile kernel failed because of {e}") from e
 
+        captured = ""
+        if ret.stdout is not None:
+            captured = ret.stdout.decode("utf-8", errors="replace")
+            if is_hip_target(target):
+                captured = filter_and_record(captured)
+
         if ret.returncode != 0:
-            captured = ret.stdout.decode("utf-8", errors="replace") if ret.stdout else ""
             raise RuntimeError(f"Compilation Failed! {command}\n{captured}\n{self.lib_code}")
+
+        # On HIP success, surface any real (non-remark) warnings only when
+        # the caller asked for verbose output, matching `compile_hip`'s
+        # behavior. Quiet by default so autotune logs stay clean.
+        if is_hip_target(target) and verbose and captured.strip():
+            print(captured)
 
         self.srcpath = src.name
         self.libpath = libpath

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -114,7 +114,7 @@ class LibraryGenerator:
             ]
 
         elif is_hip_target(target):
-            from tilelang.env import COMPOSABLE_KERNEL_INCLUDE_DIR
+            from tilelang.env import COMPOSABLE_KERNEL_INCLUDE_DIR, TILELANG_HIP_SAVE_TEMP_FILES
 
             src = tempfile.NamedTemporaryFile(mode="w", suffix=".cpp", delete=False)  # noqa: SIM115
             libpath = src.name.replace(".cpp", ".so")
@@ -132,6 +132,8 @@ class LibraryGenerator:
             command += [
                 "-I" + COMPOSABLE_KERNEL_INCLUDE_DIR,
             ]
+            if TILELANG_HIP_SAVE_TEMP_FILES != "0":
+                command += ["--save-temps", "-g"]
         elif is_cpu_target(target):
             from tilelang.contrib.cc import get_cplus_compiler
 

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -20,7 +20,6 @@ from tilelang.contrib.nvcc import (
 from tilelang.contrib.rocm import find_rocm_path, get_rocm_arch
 from tilelang.env import TILELANG_TEMPLATE_PATH
 from tilelang.utils.target import target_get_mcpu
-
 from tilelang.contrib.hip_resource_info import filter_and_record
 
 from .utils import is_cpu_target, is_cuda_target, is_hip_target

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -244,12 +244,7 @@ class JITKernel(Generic[_P, _T]):
             dump_ir_path = pass_configs.get(PassConfigKey.TL_DUMP_IR_DIR, "./dump_ir")  # Default dump path
             pass_instruments.append(tvm.ir.instrument.DumpIR(dump_dir=dump_ir_path))
 
-        # On HIP, open a recorder window so the kernel-resource-usage
-        # remarks emitted by hipcc get parsed into self._resource_usage
-        # (consumed by kernel.n_regs etc.). The window has to stay open
-        # past adapter construction: tvm_ffi runs hipcc inside lower()
-        # (enable_device_compile=True), but cython invokes it later from
-        # the adapter constructor.
+        # open a recorder window for kernel-resource-usage remarks
         capture_resources = is_hip_target(target)
         if capture_resources:
             reset_recorder()
@@ -641,10 +636,7 @@ class JITKernel(Generic[_P, _T]):
 
     @property
     def resource_usage(self) -> dict[str, Any]:
-        """{kernel_name: KernelResourceUsage} parsed from clang's
-        kernel-resource-usage remarks. HIP only; empty for other
-        targets and for kernels loaded from cache (no compile happened).
-        """
+        """HIP only now"""
         return getattr(self, "_resource_usage", {}) or {}
 
     def _primary_resource_usage(self):

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -7,7 +7,8 @@ try:
 except ImportError:  # Python < 3.10
     from typing_extensions import ParamSpec
 
-from tilelang.jit.adapter.utils import is_cutedsl_target, is_metal_target, is_cuda_target
+from tilelang.contrib.hip_resource_info import pop_recorded, reset_recorder
+from tilelang.jit.adapter.utils import is_cutedsl_target, is_metal_target, is_cuda_target, is_hip_target
 from tvm.target import Target
 from tvm.tir import PrimFunc
 
@@ -243,6 +244,15 @@ class JITKernel(Generic[_P, _T]):
             dump_ir_path = pass_configs.get(PassConfigKey.TL_DUMP_IR_DIR, "./dump_ir")  # Default dump path
             pass_instruments.append(tvm.ir.instrument.DumpIR(dump_dir=dump_ir_path))
 
+        # On HIP, open a recorder window so the kernel-resource-usage
+        # remarks emitted by hipcc get parsed into self._resource_usage
+        # (consumed by kernel.n_regs etc.). The window has to stay open
+        # past adapter construction: tvm_ffi runs hipcc inside lower()
+        # (enable_device_compile=True), but cython invokes it later from
+        # the adapter constructor.
+        capture_resources = is_hip_target(target)
+        if capture_resources:
+            reset_recorder()
         with tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=pass_instruments), self.target:
             artifact = tilelang.lower(
                 tilelang_func,
@@ -331,6 +341,9 @@ class JITKernel(Generic[_P, _T]):
         else:
             # Handle invalid backend.
             raise ValueError(f"Invalid execution backend: {execution_backend}")
+
+        if capture_resources:
+            self._resource_usage = pop_recorded()
 
         return adapter
 
@@ -625,6 +638,40 @@ class JITKernel(Generic[_P, _T]):
     @property
     def host_source(self) -> str:
         return str(self.artifact.host_mod) if self.artifact else ""
+
+    @property
+    def resource_usage(self) -> dict[str, Any]:
+        """{kernel_name: KernelResourceUsage} parsed from clang's
+        kernel-resource-usage remarks. HIP only; empty for other
+        targets and for kernels loaded from cache (no compile happened).
+        """
+        return getattr(self, "_resource_usage", {}) or {}
+
+    def _primary_resource_usage(self):
+        usage = self.resource_usage
+        if not usage:
+            return None
+        gsym = None
+        if self.prim_func is not None and self.prim_func.attrs is not None:
+            gsym = self.prim_func.attrs.get("global_symbol")
+        if gsym is not None and str(gsym) in usage:
+            return usage[str(gsym)]
+        return next(iter(usage.values()))
+
+    @property
+    def n_regs(self) -> int | None:
+        info = self._primary_resource_usage()
+        return info.n_regs if info is not None else None
+
+    @property
+    def n_spills(self) -> int | None:
+        info = self._primary_resource_usage()
+        return info.n_spills if info is not None else None
+
+    @property
+    def n_max_threads(self) -> int | None:
+        info = self._primary_resource_usage()
+        return info.n_max_threads if info is not None else None
 
     def export_library(self, kernel_file: str) -> None:
         """

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -7,7 +7,6 @@ try:
 except ImportError:  # Python < 3.10
     from typing_extensions import ParamSpec
 
-from tilelang.contrib.hip_resource_info import pop_recorded, reset_recorder
 from tilelang.jit.adapter.utils import is_cutedsl_target, is_metal_target, is_cuda_target, is_hip_target
 from tvm.target import Target
 from tvm.tir import PrimFunc
@@ -26,6 +25,7 @@ from tilelang.jit.adapter import (
 from tilelang.profiler import Profiler, TensorSupplyType
 from tilelang.utils.target import determine_target
 from tilelang.contrib import nvcc as tl_nvcc
+from tilelang.contrib.hip_resource_info import pop_recorded, reset_recorder
 from tilelang.transform import PassConfigKey
 from tilelang.transform.pass_config import normalize_pass_configs
 import logging


### PR DESCRIPTION
## Problem
- In project https://github.com/sgl-project/sglang/blob/amd/deepseek_v4/python/sglang/srt/layers/attention/nsa/tilelang_kernel.py#L1574-L1582, uses a tilelang kernel for attention.  And it will spills in some BLOCK configs with no warning.
- So add a spills information to tilelang kernels like what triton do will make it more convenient to debug these problems.

## Summary
- New **`JITKernel.n_regs / n_spills / n_max_threads`** (plus a richer `resource_usage: dict[name, KernelResourceUsage]`) that report per-kernel AMD GPU resource counts. **Mirrors triton's `kernel.n_regs / n_spills`**.
- Implementation parses clang's `-Rpass-analysis=kernel-resource-usage` remarks rather than going through the HIP runtime, which keeps the diff small (no ctypes / `libamdhip64` wiring, no HSACO bytes shuffled through `lower()`) like what triton doing.
- Remarks are **filtered out of hipcc's stdio before anything reaches the terminal**, so autotune logs don't drown in resource blocks. Real warnings + errors flow through unchanged.
- Cache-aware: parsed values are written as `resource_usage.json` next to `kernel_lib.so` and reloaded on cache hits, so subsequent runs don't lose the resource view to the cache. Older cache entries (no JSON file) silently degrade to `None`.


`n_spills` accounting: \`VGPRs Spill + ScratchSize[bytes/lane] / 4\` — explicit spill count plus scratch dwords, treating one scratch dword the same as one spilled VGPR for accounting (both end up in main memory, similar access cost). Triton uses scratch/4 only; this also folds in clang's explicit spill count when present. Raw \`scratch_bytes\` is exposed as its own field on \`KernelResourceUsage\`.

## Verification on MI355X (gfx950)
Small elementwise add. First run (cache miss → compile) and second run (cache hit → no compile) both report \`n_regs=5, n_spills=0, usage_keys=['main_kernel']\`. Zero remark lines leak to stdout/stderr — verified by grepping the captured output for \`Rpass-analysis|VGPRs|TotalSGPRs|Occupancy|remark:\`. Both \`tvm_ffi\` and \`cython\` execution backends populate \`resource_usage\` correctly.

## Test plan
- [x] Build + run a tilelang HIP kernel; read \`kernel.n_regs / n_spills / n_max_threads\`
- [x] Confirm clang remarks do **not** appear on terminal during compile
- [x] Cache miss → \`resource_usage.json\` written
- [x] Cache hit → values restored from JSON
- [x] Both \`tvm_ffi\` and \`cython\` backends populate \`resource_usage\`
- [ ] CI on a CUDA-only target (smoke check that HIP-only paths stay dormant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HIP kernels now capture and persist resource usage (registers, spills, scratch, thread limits) to disk as part of the cache.
  * Kernel objects expose resource-usage properties (for inspection and analysis).
  * Compiler remarks for HIP are filtered and recorded to present cleaner, annotated output.
  * New environment flag to optionally preserve temporary HIP compilation files for debugging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->