### PR TITLE
[Compat] Bump __nv_fp8_e8m0 guard from CUDA 12.6 to 12.8

### DIFF
--- a/src/tl_templates/cuda/cuda_fp8.h
+++ b/src/tl_templates/cuda/cuda_fp8.h
@@ -7,9 +7,9 @@
 using fp8_e4_t = tl::float_e4m3_t;
 using fp8_e5_t = tl::float_e5m2_t;
 
-// __nv_fp8_e8m0 is only available in CUDA 12.6+
+// __nv_fp8_e8m0 is only available in CUDA 12.8+
 #if __CUDACC_VER_MAJOR__ > 12 ||                                               \
-    (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 6)
+    (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 8)
 using fp8_e8_t = __nv_fp8_e8m0;
 #define TL_HAS_FP8_E8M0 1
 #else


### PR DESCRIPTION
## Summary
Bump `__nv_fp8_e8m0` compile-time guard from CUDA 12.6 to 12.8.

## Background
PR #1537 gated `__nv_fp8_e8m0` with `__CUDACC_VER >= 12.6`, but the symbol
was not actually shipped publicly until CUDA 12.8 — it is absent in the
12.6.x / 12.7.x headers and the corresponding CUDA Math API archive pages,
and first appears in the 12.8.0 docs.

Because `debug.h` unconditionally `#include`s `cuda_fp8.h` whenever
`__CUDA_ARCH_LIST__ >= 890`, every kernel targeting sm_89+ on CUDA 12.6 / 12.7
still fails with `identifier "__nv_fp8_e8m0" is undefined`, even when the
kernel itself does not use FP8 — see follow-up reports in #1564 from
@DB-Guo, @Imke7, @Puiching-Memory.

## Fix
Move the guard threshold from 12.6 to 12.8. CUDA 12.6 / 12.7 now falls back
to the existing 1-byte placeholder `struct fp8_e8_t { unsigned char data; }`,
which has the same size/alignment as native `__nv_fp8_e8m0` and is sufficient
for allocate / copy / pack / unpack code paths. E8M0 cast intrinsics remain
gated behind `#if TL_HAS_FP8_E8M0` and are unaffected.

## Test plan
- [x] CUDA 12.6 + sm_89+: kernels that previously failed to compile (e.g.
  vector_add, float16 RMSNorm) now compile and run.
- [x] CUDA 12.8+: behavior unchanged; existing E8M0 tests pass.

Closes #1564.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CUDA toolchain version requirement for FP8 type support from CUDA 12.6 to CUDA 12.8.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->