### PR TITLE
[NFC] Align stale fallback comment with CUDA 12.8 guard

### DIFF
--- a/src/tl_templates/cuda/cuda_fp8.h
+++ b/src/tl_templates/cuda/cuda_fp8.h
@@ -13,7 +13,7 @@ using fp8_e5_t = tl::float_e5m2_t;
 using fp8_e8_t = __nv_fp8_e8m0;
 #define TL_HAS_FP8_E8M0 1
 #else
-// Placeholder for CUDA < 12.6
+// Placeholder for CUDA < 12.8
 struct fp8_e8_t {
   unsigned char data;
 };


### PR DESCRIPTION
## Summary
NFC: align the stale fallback-branch comment in `cuda_fp8.h` with the
CUDA 12.8 guard introduced in #2212.

## Background
In #2212 the `__nv_fp8_e8m0` compile-time guard was bumped from
CUDA 12.6 to 12.8, but the `#else` branch comment was left as
`// Placeholder for CUDA < 12.6`. CodeRabbit flagged this as an
Outside-diff stale comment during review of #2212.

This PR finishes that cleanup.

Note: supersedes #2214, which was closed because its branch was based on
pre-#2212 main and would have inadvertently reverted the guard change.
This PR is properly rebased on top of #2212.

## Test plan
Comment-only change; no code semantics, no build / behavior impact.

Related: #1564, #2212.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation for CUDA version compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->