### PR TITLE
[Python] Drop Python 3.9 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,11 +44,11 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Setup Python 3.9
+      - name: Setup Python 3.10
         id: setup-pylowest
         uses: actions/setup-python@v6
         with:
-          python-version: "3.9"
+          python-version: "3.10"
           update-environment: true
           cache: pip
           cache-dependency-path: |
@@ -56,7 +56,7 @@ jobs:
             requirements*.txt
             .pre-commit-config.yaml
 
-      - name: Check AST with Python 3.9
+      - name: Check AST with Python 3.10
         run: |
           "${{ steps.setup-pylowest.outputs.python-path }}" -m compileall -q -f tilelang
 

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -18,8 +18,7 @@ on:
       - CMakeLists.txt
       - version_provider.py
       - .github/workflows/dist.yml
-      # temporarily add to dist check
-      # until we have type checking in ci / move to python 3.10
+      # Type aliases can affect package import/build behavior.
       - tilelang/_typing.py
   release:
     types:
@@ -115,12 +114,11 @@ jobs:
     strategy:
       matrix:
         target:
-          # Build wheels for different Python ABIs.
-          # Windows CUDA 13.0 uses cp310 because PyTorch cu130 does not publish cp39 wheels.
-          - { runner: ubuntu-latest, toolkit: "CUDA-12.8", test_backends: "cu118 cu130", python_version: "3.9" }
-          - { runner: ubuntu-24.04-arm, toolkit: "CUDA-12.8", test_backends: "cu126 cu130", python_version: "3.9" }
+          # Build wheels for the minimum supported Python ABI.
+          - { runner: ubuntu-latest, toolkit: "CUDA-12.8", test_backends: "cu118 cu130", python_version: "3.10" }
+          - { runner: ubuntu-24.04-arm, toolkit: "CUDA-12.8", test_backends: "cu126 cu130", python_version: "3.10" }
           - { runner: windows-latest, toolkit: "CUDA-13.0", test_backends: "cu130", python_version: "3.10" }
-          - { runner: macos-latest, toolkit: "Metal", python_version: "3.9" }
+          - { runner: macos-latest, toolkit: "Metal", python_version: "3.10" }
           # - "3.14t"  # let user to build from source for now
           # TODO: Add cp315-abi3.abi3t after PEP 803
       fail-fast: false

--- a/docs/get_started/Installation.md
+++ b/docs/get_started/Installation.md
@@ -5,7 +5,7 @@
 **Prerequisites for installation via wheel or PyPI:**
 
 - **glibc**: 2.28 (Ubuntu 20.04 or later)
-- **Python Version**: >= 3.9
+- **Python Version**: >= 3.10
 - **CUDA Version**: >= 10.0 (host installation), or pip-provided CUDA toolchain (>= 13.0)
 
 The easiest way to install tilelang is directly from PyPI using pip. To install the latest version, run the following command in your terminal:
@@ -37,7 +37,7 @@ python -c "import tilelang; print(tilelang.__version__)"
 **Prerequisites for building from source:**
 
 - **Operating System**: Linux or Windows
-- **Python Version**: >= 3.9
+- **Python Version**: >= 3.10
 - **CUDA Version**: >= 10.0 (host installation), or pip-provided CUDA toolchain (>= 13.0)
 
 If you prefer Docker, please skip to the [Install Using Docker](#install-using-docker) section. The commands below use Ubuntu/Debian as the Linux example; Windows-specific notes are called out where they differ.

--- a/maint/scripts/docker_local_distribute.sh
+++ b/maint/scripts/docker_local_distribute.sh
@@ -2,4 +2,4 @@
 set -euxo pipefail
 
 # Build for local architecture
-CIBW_BUILD='cp39-*' cibuildwheel . 2>&1 | tee cibuildwheel.log
+CIBW_BUILD='cp310-*' cibuildwheel . 2>&1 | tee cibuildwheel.log

--- a/maint/scripts/docker_pypi_distribute.sh
+++ b/maint/scripts/docker_pypi_distribute.sh
@@ -16,4 +16,4 @@ if docker buildx version >/dev/null 2>&1; then
   export CIBW_ARCHS='x86_64 aarch64'
 fi
 
-NO_VERSION_LABEL=ON CIBW_BUILD='cp39-*' cibuildwheel . 2>&1 | tee cibuildwheel.log
+NO_VERSION_LABEL=ON CIBW_BUILD='cp310-*' cibuildwheel . 2>&1 | tee cibuildwheel.log

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "tilelang"
 description = "A tile level programming language to generate high performance code."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 authors = [{ name = "TileLang Contributors" }, { name = "Tile-AI" }]
 maintainers = [{ name = "Lei Wang", email = "leiwang1999@outlook.com" }]
 license = "MIT"
@@ -15,7 +15,6 @@ classifiers = [
     "Operating System :: MacOS",
     "Programming Language :: C++",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -185,7 +184,7 @@ skip = [
 ]
 
 [tool.ruff]
-target-version = "py39"
+target-version = "py310"
 line-length = 140
 output-format = "full"
 

--- a/tilelang/_typing.py
+++ b/tilelang/_typing.py
@@ -1,15 +1,9 @@
 """Type annotations for TileLang."""
 
 # NOTE(chaofan): We should name it "_typing.py" to avoid module shadowing with standard library "typing"
-# NOTE: In python 3.9, `from __future__ import annotations` does not for value expression, e.g. to define type alias
+# NOTE: `from __future__ import annotations` does not affect value expressions used for type aliases.
 
-# Python 3.9 compatibility
-try:
-    from typing import TypeAlias
-except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
-
-from typing import Union
+from typing import TypeAlias
 
 from tvm import ir
 from tvm import tir
@@ -18,22 +12,21 @@ from tvm.tir import BufferLoad, BufferRegion
 from tilelang.dtypes import dtype
 
 # Barrier can only be a Buffer, a BufferLoad
-BarrierType: TypeAlias = Union[tir.Buffer, BufferLoad]
+BarrierType: TypeAlias = tir.Buffer | BufferLoad
 
 # BufferLikeType can be a Buffer, a BufferLoad, a BufferRegion
-BufferLikeType: TypeAlias = Union[tir.Buffer, BufferLoad, BufferRegion]
+BufferLikeType: TypeAlias = tir.Buffer | BufferLoad | BufferRegion
 
-# This is for Python 3.9 compatibility.
-# In Python 3.9, we can only use isinstance(a, (TypeA, TypeB, ...)) instead of isinstance(a, TypeA | TypeB | ...))
+# Runtime checks use tuple form for compatibility with isinstance().
 BufferLikeTypeTuple = (tir.Buffer, BufferLoad, BufferRegion)
 
 # Difference between "AnyDType" and "DType":
 # - AnyDType is a union of all possible types that can represent a data type, including torch.dtype
 # - DType is a more specific type alias that represents a data type in the context of TileLang, and must be
 #   adapted to string.
-DType: TypeAlias = Union[dtype, ir.Type, str, type]
-ShapeType: TypeAlias = Union[list[Union[tir.PrimExpr, int]], tuple[Union[tir.PrimExpr, int], ...]]
+DType: TypeAlias = dtype | ir.Type | str | type
+ShapeType: TypeAlias = list[tir.PrimExpr | int] | tuple[tir.PrimExpr | int, ...]
 
 # PrimExpr with adaptation to Python basic data types
 # IntImm, FloatImm, Bool: IntImm, Integer: IntImm
-PyPrimExpr: TypeAlias = Union[tir.PrimExpr, int, float, bool]
+PyPrimExpr: TypeAlias = tir.PrimExpr | int | float | bool

--- a/tilelang/autodd.py
+++ b/tilelang/autodd.py
@@ -6,7 +6,9 @@ from copy import copy, deepcopy
 from dataclasses import dataclass
 from pathlib import Path
 import shutil
-from typing import Callable, Literal, NamedTuple, override
+from typing import Literal, NamedTuple
+from collections.abc import Callable
+from typing_extensions import override
 from collections.abc import Sequence
 from collections.abc import Iterable
 import contextlib

--- a/tilelang/autotuner/grouped_compile.py
+++ b/tilelang/autotuner/grouped_compile.py
@@ -6,7 +6,8 @@ so tuner.py can stay focused on orchestration.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Optional
+from typing import Any
+from collections.abc import Callable
 
 from tilelang import tvm
 from tvm.tir import PrimFunc
@@ -18,7 +19,7 @@ from tilelang.jit.adapter import TVMFFIKernelAdapter
 from tilelang.jit.kernel import JITKernel
 from tilelang.transform import PassConfigKey
 
-CompileUnitResult = tuple[int, dict[str, Any], Optional[JITKernel], Optional[Exception]]
+CompileUnitResult = tuple[int, dict[str, Any], JITKernel | None, Exception | None]
 
 
 def compile_grouped_unit_tvm_ffi(

--- a/tilelang/autotuner/param.py
+++ b/tilelang/autotuner/param.py
@@ -6,7 +6,8 @@ import tilelang
 from tilelang import tvm as tvm
 from tvm.tir import PrimFunc
 from tvm.target import Target
-from typing import Callable, Literal, Any
+from typing import Literal, Any
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 import errno

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -16,13 +16,8 @@ from tvm.tir import PrimFunc, Var
 from tvm.target import Target
 import inspect
 from functools import partial
-from typing import Callable, Generic, Literal, Any, TypeVar
-
-# Python 3.9 compatibility for ParamSpec
-try:
-    from typing import ParamSpec
-except ImportError:  # Python < 3.10
-    from typing_extensions import ParamSpec
+from typing import Generic, Literal, Any, ParamSpec, TypeVar
+from collections.abc import Callable
 from tqdm.auto import tqdm
 import logging
 import concurrent.futures

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -12,7 +12,8 @@ import threading
 import uuid
 import sys
 from hashlib import sha256
-from typing import Callable, Literal
+from typing import Literal
+from collections.abc import Callable
 
 import cloudpickle
 from tvm.target import Target

--- a/tilelang/carver/analysis.py
+++ b/tilelang/carver/analysis.py
@@ -1,7 +1,7 @@
 """Analysis on TIR blocks, loops and functions."""
 
 from __future__ import annotations
-from typing_extensions import Literal
+from typing import Literal
 
 from tvm import ir, tir, DataType
 from tvm.ffi import get_global_func

--- a/tilelang/carver/common_schedules.py
+++ b/tilelang/carver/common_schedules.py
@@ -20,7 +20,7 @@
 # The code below is mostly copied from apache/tvm common_schedules.py in dlight.
 """Common schedule strategies for TIR."""
 
-from typing import Callable
+from collections.abc import Callable
 
 from tvm import tir
 from .utils import retrieve_func_from_module

--- a/tilelang/cuda/intrinsics/macro/mma_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/mma_macro_generator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import tilelang.language as T
-from typing import Literal, Callable
+from typing import Literal
+from collections.abc import Callable
 from tilelang.common import TransformKind
 from tvm import DataType
 from tvm import tir

--- a/tilelang/cuda/intrinsics/macro/mma_sm70_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/mma_sm70_macro_generator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import tilelang.language as T
-from typing import Literal, Callable
+from typing import Literal
+from collections.abc import Callable
 from tvm import DataType
 from tvm import tir
 from tvm.ir import Range

--- a/tilelang/cuda/intrinsics/macro/mma_sp_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/mma_sp_macro_generator.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import tilelang.language as T
-from typing import Literal, Callable
+from typing import Literal
+from collections.abc import Callable
 from tvm import DataType, tir
 from tvm.tir import PrimExpr, IndexMap, Buffer, Var, BufferRegion, BufferLoad
 from tvm.ir import Range

--- a/tilelang/cuda/intrinsics/macro/wgmma_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/wgmma_macro_generator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import tilelang.language as T
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import Callable
+from collections.abc import Callable
 from .mma_macro_generator import TensorCoreIntrinEmitter as MMAIntrinEmitter
 from tvm import DataType
 from tvm.tir import PrimExpr, Buffer, Var, IndexMap, BufferRegion

--- a/tilelang/cuda/op/gemm/gemm_tcgen05.py
+++ b/tilelang/cuda/op/gemm/gemm_tcgen05.py
@@ -18,7 +18,7 @@ from tvm import tir
 from tvm.target import Target
 from tvm.ir import Range
 from tvm.arith import Analyzer
-from typing import Callable
+from collections.abc import Callable
 
 
 _FLOAT8_DTYPES = {

--- a/tilelang/cuda/op/gemm/gemm_wgmma.py
+++ b/tilelang/cuda/op/gemm/gemm_wgmma.py
@@ -18,7 +18,7 @@ from tvm.ir import Range
 from tvm import tir
 from tilelang import language as T
 from tilelang.transform.simplify import _Simplify
-from typing import Callable
+from collections.abc import Callable
 
 
 GEMM_INST_WGMMA = "cuda.wgmma"

--- a/tilelang/engine/callback.py
+++ b/tilelang/engine/callback.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Callable
+from collections.abc import Callable
 import tvm_ffi
 from tvm.target import Target
 

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import Callable
+from collections.abc import Callable
 import tilelang.transform
 from tilelang import tvm as tvm
 from tvm import tir

--- a/tilelang/jit/__init__.py
+++ b/tilelang/jit/__init__.py
@@ -10,19 +10,15 @@ from dataclasses import dataclass
 import inspect
 from typing import (
     Any,
-    Callable,
     Generic,
     TypeVar,
     overload,
     Literal,
+    ParamSpec,
 )
+from collections.abc import Callable
 from collections.abc import Iterable
 
-# Python 3.9 compatibility for ParamSpec
-try:
-    from typing import ParamSpec
-except ImportError:  # Python < 3.10
-    from typing_extensions import ParamSpec
 from tilelang import tvm as tvm
 from tilelang.language.eager import PrimFunc, prim_func, JITFunc
 from tvm.target import Target

--- a/tilelang/jit/adapter/base.py
+++ b/tilelang/jit/adapter/base.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 from tilelang.engine.param import KernelParam
 import torch
 

--- a/tilelang/jit/adapter/cutedsl/adapter.py
+++ b/tilelang/jit/adapter/cutedsl/adapter.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 import logging
 import weakref
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 
 import torch
 from tvm import tir

--- a/tilelang/jit/adapter/cython/adapter.py
+++ b/tilelang/jit/adapter/cython/adapter.py
@@ -5,7 +5,8 @@ import ctypes
 import logging
 import torch
 
-from typing import Callable, Any
+from typing import Any
+from collections.abc import Callable
 from tilelang import tvm as tvm
 from tvm.target import Target
 from tilelang.engine.param import KernelParam

--- a/tilelang/jit/adapter/nvrtc/adapter.py
+++ b/tilelang/jit/adapter/nvrtc/adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import logging
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 
 import torch
 from tvm import tir

--- a/tilelang/jit/adapter/torch/metal.py
+++ b/tilelang/jit/adapter/torch/metal.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from functools import wraps
-from typing import Callable
+from collections.abc import Callable
 
 import torch
 from tvm import tir

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -8,7 +8,8 @@ On non-CUDA builds, the stream/device fall back to 0/CPU semantics.
 
 from __future__ import annotations
 
-from typing import Callable, Any
+from typing import Any
+from collections.abc import Callable
 import sys
 
 import torch

--- a/tilelang/jit/adapter/utils.py
+++ b/tilelang/jit/adapter/utils.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import re
-from typing import Literal, Callable, Any
+from typing import Literal, Any
+from collections.abc import Callable
 from tilelang import tvm as tvm
 from tvm import IRModule, tir
 from tvm.target import Target

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
-from typing import Any, Callable, Generic, Literal, TypeVar
-
-# Python 3.9 compatibility for ParamSpec
-try:
-    from typing import ParamSpec
-except ImportError:  # Python < 3.10
-    from typing_extensions import ParamSpec
+from typing import Any, Generic, Literal, ParamSpec, TypeVar
+from collections.abc import Callable
 
 from tilelang.jit.adapter.utils import is_cutedsl_target, is_metal_target, is_cuda_target
 from tvm.target import Target

--- a/tilelang/language/annotations.py
+++ b/tilelang/language/annotations.py
@@ -1,6 +1,6 @@
 """Annotation helpers exposed on the TileLang language surface."""
 
-from typing import Callable
+from collections.abc import Callable
 
 from tilelang.layout import Fragment, Layout
 from tilelang.utils.language import is_fragment

--- a/tilelang/language/dtypes.py
+++ b/tilelang/language/dtypes.py
@@ -1,7 +1,7 @@
 from tilelang import tvm
 from tvm import ir
 import torch
-from typing import Generic, TypeVar, Union, TYPE_CHECKING
+from typing import Generic, TypeVar, TYPE_CHECKING
 from tvm import tir
 import tvm.script.ir_builder.tir._ffi_api as tb_ffi
 import numpy as np
@@ -20,13 +20,13 @@ if TYPE_CHECKING:
 else:
     dtype = tvm.DataType
 
-# Python 3.9 compatibility: avoid PEP 604 unions at runtime
-AnyDType = Union[ir.Type, str, type, torch.dtype, dtype]
+# Keep a typing alias separate from the tuple used by runtime checks.
+AnyDType = ir.Type | str | type | torch.dtype | dtype
 
 
 def _is_any_dtype(obj: object) -> bool:
     """Check if obj is a dtype-like value. Use instead of isinstance(obj, AnyDType)
-    because Union types cannot be used with isinstance in Python 3.9."""
+    to keep the runtime check explicit."""
     return isinstance(obj, (ir.Type, str, type, torch.dtype, dtype))
 
 

--- a/tilelang/language/eager/ast.py
+++ b/tilelang/language/eager/ast.py
@@ -2,16 +2,11 @@ from __future__ import annotations
 import ast
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Generic, Any, Literal, TypeVar
+from typing import Generic, Any, Literal, ParamSpec, TypeVar
+from collections.abc import Callable
 from contextlib import AbstractContextManager
 from collections.abc import Iterable
 
-
-# Python 3.9 compatibility for ParamSpec
-try:
-    from typing import ParamSpec
-except ImportError:  # Python < 3.10
-    from typing_extensions import ParamSpec
 import inspect
 
 # from .utils import get_ast, get_compiled_object

--- a/tilelang/language/eager/builder.py
+++ b/tilelang/language/eager/builder.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 from contextlib import contextmanager, AbstractContextManager
 from dataclasses import dataclass
 import inspect
-import sys
 
 from tilelang.language.kernel import KernelLaunchFrame
 from tvm_ffi.container import Map
@@ -18,15 +17,12 @@ from tvm.tir import Buffer
 from tvm.script.ir_builder import tir, IRBuilder
 
 from tvm.tir.expr import BufferLoad, CallEffectKind, EqualOp, FloatImm, IntImm, NotEqualOp, PrimExpr, StringImm, Var
-from typing import TYPE_CHECKING, Callable, Any, Generic, TypeVar, ForwardRef, Union, Literal, get_origin
+from typing import TYPE_CHECKING, Any, Generic, TypeVar, ForwardRef, Literal, get_origin, ParamSpec
+from collections.abc import Callable
+from typing_extensions import Self
 from collections.abc import Hashable
 from collections.abc import Sequence
 
-# Python 3.9 compatibility for ParamSpec and Self
-try:
-    from typing import ParamSpec, Self
-except ImportError:  # Python < 3.11 for Self, < 3.10 for ParamSpec
-    from typing_extensions import ParamSpec, Self
 from .. import dtypes as dt
 from . import utils
 from tilelang.jit.exceptions import JITNoBuilderError, EagerJITBuildError
@@ -137,10 +133,9 @@ class Ref:
 class UnrollForWithStep(SerialForWithStep): ...
 
 
-# Python 3.9 compatibility: avoid PEP 604 unions at runtime
-# Use tuple for isinstance checks and typing.Union for annotations/aliases
+# Runtime frame checks use tuple form; AnyFrame is kept as an annotation alias.
 ContinueOrBreak = (ContinueFrame, BreakFrame)
-AnyFrame = Union[tir.frame.IRBuilderFrame, Frame]
+AnyFrame = tir.frame.IRBuilderFrame | Frame
 
 TIR_CONTROL_FRAME = (
     tir.frame.WhileFrame,
@@ -881,10 +876,7 @@ def get_type_hints(func):
                     continue
                 except Exception:
                     pass
-            if sys.version_info >= (3, 10):
-                value = ForwardRef(value, module=func.__module__)
-            else:
-                value = ForwardRef(value, is_argument=True)
+            value = ForwardRef(value, module=func.__module__)
             hints[name] = _eval_type(value, globalns=globalns, localns=localns)
         else:
             hints[name] = value

--- a/tilelang/language/eager/utils.py
+++ b/tilelang/language/eager/utils.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 import ast
 import inspect
-from typing import Any, Callable, Literal
+from typing import Any, Literal
+from collections.abc import Callable
 from tilelang import env
 from hashlib import sha256
 from tvm import tir

--- a/tilelang/language/tir/entry.py
+++ b/tilelang/language/tir/entry.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import inspect
-from typing import Callable
+from collections.abc import Callable
 
 import tvm.script.parser.tir.entry as _tir_entry
 from tvm.tir.function import PrimFunc

--- a/tilelang/profiler/__init__.py
+++ b/tilelang/profiler/__init__.py
@@ -1,7 +1,8 @@
 """The profiler and convert to torch utils"""
 
 from __future__ import annotations
-from typing import Callable, Any, Literal
+from typing import Any, Literal
+from collections.abc import Callable
 from functools import partial
 import torch
 from dataclasses import dataclass

--- a/tilelang/profiler/bench.py
+++ b/tilelang/profiler/bench.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import os
 import sys
-from typing import Callable, Literal
+from typing import Literal
+from collections.abc import Callable
 
 import torch
 

--- a/tilelang/rocm/intrinsics/mfma_macro_generator.py
+++ b/tilelang/rocm/intrinsics/mfma_macro_generator.py
@@ -8,7 +8,8 @@ from tvm.target import Target
 from tvm.tir import PrimExpr, IndexMap, Buffer, Var, BufferRegion, BufferLoad
 from tvm.runtime import convert
 from .utils import mfma_store_index_map
-from typing import Literal, Callable
+from typing import Literal
+from collections.abc import Callable
 import warnings
 
 from tilelang.utils.target import target_is_gfx950, determine_target

--- a/tilelang/testing/perf_regression.py
+++ b/tilelang/testing/perf_regression.py
@@ -6,7 +6,8 @@ import logging
 import os
 import time
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
+from collections.abc import Callable
 from collections.abc import Sequence
 import warnings
 

--- a/tilelang/tileop/gemm/registry.py
+++ b/tilelang/tileop/gemm/registry.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
+from collections.abc import Callable
 
 from tvm.target import Target
 

--- a/tilelang/tileop/gemm_sp/registry.py
+++ b/tilelang/tileop/gemm_sp/registry.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable
+from collections.abc import Callable
 
 from tvm.target import Target
 

--- a/tilelang/transform/simplify.py
+++ b/tilelang/transform/simplify.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from tilelang import tvm as tvm
 from tvm import IRModule
 from tvm.tir import PrimFunc
-from typing import Callable
+from collections.abc import Callable
 from . import _ffi_api
 
 


### PR DESCRIPTION
## Summary

- Drop Python 3.9 from the supported TileLang runtime matrix and set the minimum supported version to Python 3.10.
- Align package metadata, install docs, CI, and wheel build scripts with the new minimum version.

## Changes

- Update pyproject metadata, classifiers, and Ruff target to Python 3.10.
- Move CI compile checks and cibuildwheel jobs from Python 3.9/cp39 to Python 3.10/cp310.
- Remove Python 3.9 compatibility fallbacks for ParamSpec and TypeAlias, and apply the Ruff py310 cleanup required by the new target version.
- Use typing_extensions.override where needed so Python 3.10/3.11 can still import the affected module.

## Validation

- `./format.sh`
- `python -m ruff check tilelang`
- `python -m ruff format --check tilelang`
- `python -m compileall -q -f tilelang`

## Notes

- The remaining `3.9` text outside third-party code refers to ROCm versions or benchmark/example numeric values, not Python support.
- Existing `from __future__ import annotations` imports are mostly left in place to avoid changing annotation evaluation behavior beyond the support-version update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated minimum Python version requirement to 3.10.
  * Updated CI/CD workflows and build distribution scripts to target Python 3.10.
  * Modernized codebase to leverage Python 3.10+ features and removed compatibility workarounds for earlier versions.
  * Updated installation documentation to reflect new Python version requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2218?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->