### PR TITLE
  [CuTeDSL] Integrate host codegen call sites

### DIFF
--- a/testing/python/autotune/test_tilelang_autotune_cutedsl_cache.py
+++ b/testing/python/autotune/test_tilelang_autotune_cutedsl_cache.py
@@ -22,16 +22,27 @@ def test_cutedsl_save_creates_kernel_py(tmp_path):
         (src_dir / "kernel.cubin").write_bytes(b"fake_cubin")
 
         class FakeLibGen:
+            """Minimal CuTeDSL library generator stub for cache-save tests."""
+
             launcher_libpath = None
 
         class FakeAdapter:
+            """Minimal CuTeDSL adapter stub exposing source accessors."""
+
             libpath = str(src_dir / "kernel.py")
             lib_generator = FakeLibGen()
 
             def get_kernel_source(self, kernel_only=True):
-                return "# src"
+                """Return a fake device source."""
+                return "# device src"
+
+            def get_host_source(self):
+                """Return a fake host wrapper source."""
+                return "# host src"
 
         class FakeKernel:
+            """Minimal JITKernel stub for CuTeDSL autotune cache saving."""
+
             execution_backend = "cutedsl"
             adapter = FakeAdapter()
             kernel_source = "# src"
@@ -49,26 +60,30 @@ def test_cutedsl_save_creates_kernel_py(tmp_path):
 
 
 def _is_cutedsl_available():
+    """Return whether the CuTeDSL stack is usable in the current environment."""
     try:
         from tilelang.jit.adapter.cutedsl.checks import check_cutedsl_available
 
         check_cutedsl_available()
         return True
-    except (ImportError, AssertionError):
+    except (ImportError, ModuleNotFoundError, RuntimeError, AssertionError):
         return False
 
 
 # Define autotune kernel at module level so closures don't capture module objects
 def _make_vec_add_autotuned():
+    """Create a tiny CuTeDSL autotuned vector-add kernel."""
     from tilelang.autotuner import autotune
 
     @autotune(configs=[{"threads": t} for t in (128, 256)], warmup=3, rep=5)
     @tilelang.jit(out_idx=[-1], target="cutedsl")
     def vec_add(n: int, dtype: str = "float32", threads: int = 128):
+        """Build one vector-add candidate for the autotuner."""
         num_blocks = n // threads
 
         @T.prim_func
         def kernel(a: T.Tensor((n,), dtype), b: T.Tensor((n,), dtype), c: T.Tensor((n,), dtype)):
+            """Add two vectors using one TileLang kernel."""
             with T.Kernel(num_blocks, threads=threads) as bx:
                 for i in T.Parallel(threads):
                     c[bx * threads + i] = a[bx * threads + i] + b[bx * threads + i]

--- a/testing/python/jit/test_tilelang_jit_cutedsl_host_codegen.py
+++ b/testing/python/jit/test_tilelang_jit_cutedsl_host_codegen.py
@@ -1,0 +1,255 @@
+"""Tests for CuTeDSL host codegen integration."""
+
+import pytest
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+CUTEDSL_SM90_TARGET = {"kind": "cutedsl", "arch": "sm_90"}
+
+
+def _require_cutedsl():
+    """Skip when the CuTeDSL Python stack is unavailable."""
+    try:
+        from tilelang.jit.adapter.cutedsl.checks import check_cutedsl_available
+
+        check_cutedsl_available()
+    except (ImportError, ModuleNotFoundError, RuntimeError, AssertionError) as err:
+        pytest.skip(f"CuTeDSL is not available: {err}")
+
+
+def _lower_cutedsl(program):
+    """Lower a TileLang program and build its CuTeDSL host wrapper."""
+    _require_cutedsl()
+
+    from tilelang.jit.adapter.cutedsl.wrapper import TLCuTeDSLSourceWrapper
+    from tilelang.utils.target import determine_target
+
+    target = determine_target(CUTEDSL_SM90_TARGET)
+    with target:
+        artifact = tilelang.lower(program, target=target)
+    mod = tilelang.tvm.IRModule({program.attrs["global_symbol"]: program})
+    wrapper = TLCuTeDSLSourceWrapper(mod, artifact.kernel_source, target, artifact.device_mod, artifact.host_mod)
+    return artifact, wrapper
+
+
+def _host_entry_gvar_and_func(wrapper):
+    """Return the GlobalVar and PrimFunc selected as the wrapper host entry."""
+    entry_func = wrapper._host_entry_func()
+    for gvar, host_func in wrapper.host_mod.functions.items():
+        if host_func.same_as(entry_func):
+            return gvar, host_func
+    raise AssertionError("Unable to locate wrapper host entry function in host_mod")
+
+
+def single_kernel_program(N, block_size=64, dtype=T.float32):
+    """Create a single-kernel CuTeDSL program."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), dtype),
+        B: T.Tensor((N,), dtype),
+    ):
+        """Write one output tensor from one device kernel."""
+
+        with T.Kernel(T.ceildiv(N, block_size), threads=block_size) as (bx,):
+            for i in T.Parallel(block_size):
+                idx = bx * block_size + i
+                if idx < N:
+                    B[idx] = A[idx] + 1.0
+
+    return main
+
+
+def two_kernel_program(N, block_size=64, dtype=T.float32):
+    """Create a program with two lowered host kernel call sites."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), dtype),
+        B: T.Tensor((N,), dtype),
+        C: T.Tensor((N,), dtype),
+    ):
+        """Launch two device kernels from one host wrapper."""
+
+        with T.Kernel(T.ceildiv(N, block_size), threads=block_size) as (bx,):
+            for i in T.Parallel(block_size):
+                idx = bx * block_size + i
+                if idx < N:
+                    B[idx] = A[idx] + 1.0
+
+        with T.Kernel(T.ceildiv(N, block_size), threads=block_size) as (bx2,):
+            for j in T.Parallel(block_size):
+                idx = bx2 * block_size + j
+                if idx < N:
+                    C[idx] = B[idx] * 2.0
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+def test_cutedsl_host_wrapper_follows_lowered_host_call_sites():
+    """Verify generated CuTeDSL launchers use lowered host call-site order."""
+
+    _, wrapper = _lower_cutedsl(two_kernel_program(64))
+
+    call_sites = wrapper._collect_host_kernel_call_sites()
+    call_names = [call_site["function_name"] for call_site in call_sites]
+    assert len(call_names) == 2
+    assert call_names == wrapper.function_names
+
+    launcher_cpp = wrapper.get_launcher_cpp_code()
+    first_launch = launcher_cpp.index(f"Launch kernel 0: {call_names[0]}")
+    second_launch = launcher_cpp.index(f"Launch kernel 1: {call_names[1]}")
+    assert first_launch < second_launch
+
+    host_source = wrapper.host_func
+    first_cubin_launch = host_source.index(f"{call_names[0]}(")
+    second_cubin_launch = host_source.index(f"{call_names[1]}(")
+    assert first_cubin_launch < second_cubin_launch
+
+
+@tilelang.testing.requires_cuda
+def test_cutedsl_host_wrapper_preserves_repeated_same_kernel_call_sites():
+    """Verify repeated host launches of the same device kernel remain distinct."""
+
+    _, wrapper = _lower_cutedsl(single_kernel_program(64))
+    original_call_site = wrapper._collect_host_kernel_call_sites()[0]
+    function_name = original_call_site["function_name"]
+    repeated_body = tilelang.tvm.tirx.SeqStmt(
+        [
+            tilelang.tvm.tirx.Evaluate(tilelang.tvm.tirx.call_packed(function_name, *original_call_site["function_params"])),
+            tilelang.tvm.tirx.Evaluate(tilelang.tvm.tirx.call_packed(function_name, *original_call_site["function_params"])),
+        ]
+    )
+
+    entry_gvar, entry_func = _host_entry_gvar_and_func(wrapper)
+    wrapper.host_mod = tilelang.tvm.IRModule({entry_gvar.name_hint: entry_func.with_body(repeated_body)})
+
+    call_sites = wrapper._collect_host_kernel_call_sites()
+    call_names = [call_site["function_name"] for call_site in call_sites]
+    assert call_names == [function_name, function_name]
+    assert call_sites[0] is not call_sites[1]
+
+    wrapper.update_lib_code(wrapper.source)
+    launcher_cpp = wrapper.get_launcher_cpp_code()
+    first_launch = launcher_cpp.index(f"Launch kernel 0: {function_name}")
+    second_launch = launcher_cpp.index(f"Launch kernel 1: {function_name}")
+    assert first_launch < second_launch
+
+    host_source = wrapper.host_func
+    kernel_wrapper_source = host_source[host_source.index("def kernel_wrapper") :]
+    first_cubin_launch = kernel_wrapper_source.index(f"{function_name}(")
+    second_cubin_launch = kernel_wrapper_source.index(f"{function_name}(", first_cubin_launch + 1)
+    assert first_cubin_launch < second_cubin_launch
+
+
+@tilelang.testing.requires_cuda
+def test_cutedsl_host_call_sites_ignore_dead_helper_funcs():
+    """Verify CuTeDSL launch collection only scans the host entry function."""
+
+    _, wrapper = _lower_cutedsl(single_kernel_program(64))
+    call_sites = wrapper._collect_host_kernel_call_sites()
+    function_name = call_sites[0]["function_name"]
+
+    entry_gvar, entry_func = _host_entry_gvar_and_func(wrapper)
+    dead_helper = tilelang.tvm.tirx.PrimFunc(
+        [],
+        tilelang.tvm.tirx.Evaluate(tilelang.tvm.tirx.call_packed(function_name)),
+    ).with_attr("global_symbol", "dead_helper")
+    wrapper.host_mod = tilelang.tvm.IRModule(
+        {
+            entry_gvar.name_hint: entry_func,
+            "dead_helper": dead_helper,
+        }
+    )
+
+    assert wrapper._collect_host_kernel_call_sites() == call_sites
+
+
+@tilelang.testing.requires_cuda
+def test_cutedsl_host_call_sites_require_launch_metadata():
+    """Verify missing launch metadata for a real host call site fails fast."""
+
+    _, wrapper = _lower_cutedsl(single_kernel_program(64))
+    function_name = wrapper._collect_host_kernel_call_sites()[0]["function_name"]
+
+    for metadata_name in ("block_info", "grid_info", "dynamic_smem_buf"):
+        original_metadata = getattr(wrapper, metadata_name)
+        metadata = dict(original_metadata)
+        metadata.pop(function_name)
+        try:
+            setattr(wrapper, metadata_name, metadata)
+            with pytest.raises(AssertionError, match=f".*{function_name}.*{metadata_name}.*"):
+                wrapper.update_lib_code(wrapper.source)
+        finally:
+            setattr(wrapper, metadata_name, original_metadata)
+
+
+@tilelang.testing.requires_cuda
+def test_cutedsl_adapter_exposes_device_and_host_sources():
+    """Verify CuTeDSL adapter exposes device, host, and combined sources."""
+
+    _require_cutedsl()
+
+    kernel = tilelang.compile(
+        single_kernel_program(64),
+        target=CUTEDSL_SM90_TARGET,
+        execution_backend="cutedsl",
+    )
+
+    device_source = kernel.get_kernel_source(kernel_only=True)
+    host_source = kernel.get_host_source()
+    combined_source = kernel.get_kernel_source(kernel_only=False)
+
+    assert "@cute.kernel" in device_source
+    assert "def call(" in host_source
+    assert "--gpu-arch=sm_90" in host_source
+    assert "_generate_cubin_if_needed" in host_source
+    assert device_source in combined_source
+    assert host_source in combined_source
+
+
+def test_cutedsl_cache_restore_does_not_fallback_to_host_source(monkeypatch, tmp_path):
+    """Verify missing cached generated modules stay distinct from host wrappers."""
+
+    from tilelang.jit.adapter.cutedsl.adapter import CuTeDSLKernelAdapter
+    from tilelang.jit.adapter.cutedsl import adapter as cutedsl_adapter
+
+    class FakeLibraryGenerator:
+        """Minimal CuTeDSL library generator stub for cache restore tests."""
+
+        def __init__(self, target, verbose):
+            self.target = target
+            self.verbose = verbose
+            self.pymodule = object()
+
+        def assign_compile_flags(self, compile_flags):
+            """Accept compile flags without invoking the real generator."""
+            self.compile_flags = compile_flags
+
+        def load_lib(self, lib_path):
+            """Pretend to load a cached Python module from disk."""
+            self.libpath = lib_path
+
+    monkeypatch.setattr(cutedsl_adapter, "CuTeDSLLibraryGenerator", FakeLibraryGenerator)
+
+    prim_func = tilelang.tvm.tirx.PrimFunc([], tilelang.tvm.tirx.Evaluate(0)).with_attr("global_symbol", "main")
+    missing_kernel_py = tmp_path / "missing_kernel.py"
+    restored = CuTeDSLKernelAdapter.from_database(
+        params=[],
+        result_idx=[],
+        target=CUTEDSL_SM90_TARGET,
+        func_or_mod=prim_func,
+        host_kernel_source="# host wrapper",
+        device_kernel_source="# device kernel",
+        kernel_lib_path=str(missing_kernel_py),
+    )
+
+    assert restored.get_generated_module_source() is None
+    assert restored.get_host_source() == "# host wrapper"
+    assert restored.get_kernel_source(kernel_only=False) == "# device kernel\n\n# host wrapper"
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/target/test_tilelang_codegen_cutedsl_cp_async.py
+++ b/testing/python/target/test_tilelang_codegen_cutedsl_cp_async.py
@@ -1,4 +1,5 @@
 import pytest
+import torch
 
 import tilelang
 import tilelang.testing
@@ -16,6 +17,22 @@ def test_cutedsl_dict_target_normalizes_to_cuda_marker(monkeypatch):
 
     assert target.kind.name == "cuda"
     assert target.attrs["arch"] == "sm_80"
+    assert {"cuda", "gpu", "cutedsl"}.issubset(set(target.keys))
+
+
+def test_cutedsl_string_target_uses_detected_cuda_arch(monkeypatch):
+    """Verify bare CuTeDSL targets use TileLang's CUDA arch normalization."""
+
+    from tilelang.jit.adapter.cutedsl import checks
+
+    monkeypatch.setattr(checks, "check_cutedsl_available", lambda: None)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda _: (9, 0))
+
+    target = determine_target("cutedsl", return_object=True)
+
+    assert target.kind.name == "cuda"
+    assert target.attrs["arch"] == "sm_90a"
     assert {"cuda", "gpu", "cutedsl"}.issubset(set(target.keys))
 
 

--- a/tilelang/autotuner/param.py
+++ b/tilelang/autotuner/param.py
@@ -60,6 +60,7 @@ class CompileArgs:
     pass_configs: dict[str, Any] | None = None
 
     def compile_program(self, program: PrimFunc):
+        """Compile one candidate program using this compile configuration."""
         return tilelang.compile(
             program,
             out_idx=self.out_idx,
@@ -71,6 +72,7 @@ class CompileArgs:
         )
 
     def __hash__(self):
+        """Return a stable hash for cache key construction."""
         data = {
             "execution_backend": self.execution_backend,
             "target": str(self.target),
@@ -122,6 +124,7 @@ class ProfileArgs:
     cache_input_tensors: bool = True
 
     def __hash__(self):
+        """Return a stable hash for profiling configuration reuse."""
         data = {
             "warmup": self.warmup,
             "rep": self.rep,
@@ -158,12 +161,14 @@ class AutotuneResult:
 
     @staticmethod
     def _load_binary(path: str):
+        """Load binary content from a cache artifact."""
         with open(path, "rb") as file:
             binary = file.read()
         return binary
 
     @staticmethod
     def _safe_write_file(path: str, mode: str, operation: Callable[[Any], None]):
+        """Atomically write one cache file through a temporary sibling file."""
         # Random a temporary file within the same FS as the cache directory
         tmp_dir = env.TILELANG_TMP_DIR
         os.makedirs(tmp_dir, exist_ok=True)
@@ -175,6 +180,7 @@ class AutotuneResult:
 
     @staticmethod
     def _safe_write_executable(executable: Executable, path: str):
+        """Atomically export one runtime executable to disk."""
         tmp_dir = env.TILELANG_TMP_DIR
         os.makedirs(tmp_dir, exist_ok=True)
         temp_path = os.path.join(tmp_dir, f"{os.getpid()}_{uuid.uuid4()}.so")
@@ -203,15 +209,18 @@ class AutotuneResult:
         device_kernel_path = os.path.join(cache_path, DEVICE_KERNEL_PATH)
         if verbose:
             logger.debug(f"Saving kernel source code to file: {device_kernel_path}")
-        if kernel.kernel_source is not None:
-            self._safe_write_file(device_kernel_path, "w", lambda f: f.write(kernel.kernel_source))
+        device_kernel_source = kernel.kernel_source
+        if kernel.execution_backend == "cutedsl":
+            device_kernel_source = kernel.adapter.get_kernel_source(kernel_only=True)
+        if device_kernel_source is not None:
+            self._safe_write_file(device_kernel_path, "w", lambda f: f.write(device_kernel_source))
 
         # Save host kernel source code (wrapped)
         host_kernel_path = os.path.join(cache_path, HOST_KERNEL_PATH)
         if verbose:
             logger.debug(f"Saving wrapped kernel source code to file: {host_kernel_path}")
         # Match kernel_cache behavior: use host source for tvm_ffi, otherwise wrapped kernel
-        if kernel.execution_backend == "tvm_ffi":
+        if kernel.execution_backend == "tvm_ffi" or kernel.execution_backend == "cutedsl":
             self._safe_write_file(host_kernel_path, "w", lambda f: f.write(kernel.adapter.get_host_source()))
         else:
             self._safe_write_file(host_kernel_path, "w", lambda f: f.write(kernel.adapter.get_kernel_source()))
@@ -458,6 +467,7 @@ class AutotuneResult:
 
     @classmethod
     def load_from_disk(cls, path: Path, compile_args: CompileArgs) -> AutotuneResult:
+        """Load a complete autotune result and its compiled kernel from disk."""
         if not os.path.exists(path):
             return None
 
@@ -527,6 +537,7 @@ class AutotuneResult:
 
     @staticmethod
     def _get_kernel_lib_file(execution_backend: str) -> str:
+        """Return the cache filename for one backend's executable artifact."""
         if execution_backend == "nvrtc":
             return KERNEL_CUBIN_PATH
         if execution_backend == "tvm_ffi":
@@ -537,6 +548,7 @@ class AutotuneResult:
 
     @classmethod
     def _get_required_kernel_files(cls, path: Path, execution_backend: str) -> list[Path]:
+        """Return backend-specific files required to reload a kernel."""
         files = [path / cls._get_kernel_lib_file(execution_backend)]
         if execution_backend == "nvrtc":
             files.append(path / KERNEL_PY_PATH)
@@ -544,6 +556,7 @@ class AutotuneResult:
 
     @classmethod
     def _get_complete_result_files(cls, path: Path, execution_backend: str) -> list[Path]:
+        """Return the full file set that marks an autotune result complete."""
         return list(
             dict.fromkeys(
                 [
@@ -560,14 +573,17 @@ class AutotuneResult:
 
     @classmethod
     def _get_missing_complete_result_files(cls, path: Path, execution_backend: str) -> list[Path]:
+        """Return complete-result files missing from a candidate cache path."""
         return [file for file in cls._get_complete_result_files(path, execution_backend) if not file.exists()]
 
     @classmethod
     def _is_complete_result_dir(cls, path: Path, execution_backend: str) -> bool:
+        """Return whether a cache directory contains all required files."""
         return path.is_dir() and not cls._get_missing_complete_result_files(path, execution_backend)
 
     @classmethod
     def _remove_incomplete_result_dir(cls, path: Path, execution_backend: str) -> bool:
+        """Remove a stale incomplete result directory when present."""
         if not path.is_dir() or cls._is_complete_result_dir(path, execution_backend):
             return False
         shutil.rmtree(path)
@@ -575,4 +591,5 @@ class AutotuneResult:
 
     @staticmethod
     def _is_rename_collision(exc: OSError) -> bool:
+        """Return whether a rename failure came from a benign race."""
         return exc.errno in {errno.EEXIST, errno.ENOTEMPTY}

--- a/tilelang/jit/adapter/cutedsl/adapter.py
+++ b/tilelang/jit/adapter/cutedsl/adapter.py
@@ -21,13 +21,15 @@ logger = logging.getLogger(__name__)
 
 
 class CuTeDSLKernelAdapter(BaseKernelAdapter):
+    """Runtime adapter for generated CuTeDSL Python modules."""
+
     pymodule = None
 
     def __init__(
         self,
         params: list[KernelParam],
         result_idx: list[int],
-        target: str | Target,
+        target: str | dict[str, object] | Target,
         func_or_mod: tirx.PrimFunc | tvm.IRModule,
         host_mod: tvm.IRModule | None = None,
         device_mod: tvm.IRModule | None = None,
@@ -37,12 +39,15 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
         pass_configs: dict[str, Any] | None = None,
         compile_flags: list[str] | None = None,
     ):
+        """Build a CuTeDSL adapter from freshly lowered TileLang artifacts."""
         check_cutedsl_available()
 
         self.params = params
         self.result_idx = self._legalize_result_idx(result_idx)
         self.host_kernel_source = host_kernel_source
         self.device_kernel_source = device_kernel_source
+        self.kernel_global_source = device_kernel_source
+        self.generated_module_source: str | None = None
 
         if isinstance(func_or_mod, tirx.PrimFunc):
             gsym = func_or_mod.attrs.get("global_symbol")
@@ -78,6 +83,7 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
         self.wrapper.assign_device_module(device_mod)
         wrapper_result = self.wrapper.wrap(device_kernel_source)
         self.host_func = wrapper_result["host_func"]
+        self.host_kernel_source = self.host_func
         self.function_names = wrapper_result["function_names"]
         self.launcher_cpp_code = wrapper_result.get("launcher_cpp_code", None)
         self.launcher_lib_name = wrapper_result.get("launcher_lib_name", None)
@@ -92,8 +98,9 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
         self.lib_generator.load_lib()
         self.libpath = self.lib_generator.libpath
         with open(self.libpath) as f:
-            self.device_kernel_source = f.read()
-        self.kernel_global_source = self.device_kernel_source
+            self.generated_module_source = f.read()
+        if self.kernel_global_source is None:
+            self.kernel_global_source = self.device_kernel_source
         self.pymodule = self.lib_generator.pymodule
 
         self._post_init()
@@ -103,7 +110,7 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
         cls,
         params: list[KernelParam],
         result_idx: list[int],
-        target: str,
+        target: str | dict[str, object] | Target,
         func_or_mod: tirx.PrimFunc | tvm.IRModule,
         host_kernel_source: str,
         device_kernel_source: str,
@@ -112,11 +119,13 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
         pass_configs: dict[str, Any] | None = None,
         compile_flags: list[str] | None = None,
     ):
+        """Rebuild a CuTeDSL adapter from persisted cache artifacts."""
         adapter = cls.__new__(cls)
         adapter.params = params
         adapter.result_idx = adapter._legalize_result_idx(result_idx)
         adapter.host_kernel_source = host_kernel_source
         adapter.device_kernel_source = device_kernel_source
+        adapter.generated_module_source = None
 
         if isinstance(func_or_mod, tirx.PrimFunc):
             gsym = func_or_mod.attrs.get("global_symbol")
@@ -150,6 +159,11 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
         adapter.lib_generator.load_lib(lib_path=kernel_lib_path)
         adapter.libpath = kernel_lib_path
         adapter.kernel_global_source = device_kernel_source
+        try:
+            with open(kernel_lib_path) as f:
+                adapter.generated_module_source = f.read()
+        except OSError:
+            adapter.generated_module_source = None
         adapter.pymodule = adapter.lib_generator.pymodule
 
         adapter._post_init()
@@ -180,6 +194,7 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
         self._dynamic_symbolic_name_map: dict[str, tuple[int, int, int]] = {}
 
         def unique_push_back(v: tirx.Var, entry: tuple[int, int, int]):
+            """Append one symbolic variable unless it has already been seen."""
             if v in dynamic_symbolic_map:
                 return
             dynamic_symbolic_map[v] = entry
@@ -221,15 +236,30 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
             return self._dynamic_symbolic_name_map[v.name]
         raise KeyError(f"Dynamic symbolic variable '{v.name}' not found in symbolic map")
 
+    def get_host_source(self) -> str | None:
+        """Get the generated Python host wrapper source."""
+        return self.host_kernel_source
+
+    def get_generated_module_source(self) -> str | None:
+        """Get the importable generated CuTeDSL Python module source."""
+        return self.generated_module_source
+
     def get_kernel_source(self, kernel_only: bool = True) -> str | None:
-        """Get the CUDA kernel source code.
+        """Get the CuTeDSL device source, optionally with host wrapper source.
 
         Returns
         -------
         str | None
             The kernel source code, or None if not available
         """
-        return self.device_kernel_source
+        device_source = self.kernel_global_source or self.device_kernel_source
+        if kernel_only:
+            return device_source
+
+        sources = [source for source in (device_source, self.host_kernel_source) if source]
+        if sources:
+            return "\n\n".join(sources)
+        return self.generated_module_source
 
     def _forward_from_prebuild_lib(self, *args, stream: int | None = None, device_id: int = 0):
         """Low-level function to call the compiled CUDA kernel.

--- a/tilelang/jit/adapter/cutedsl/kernel_cache.py
+++ b/tilelang/jit/adapter/cutedsl/kernel_cache.py
@@ -8,19 +8,46 @@ from tilelang.jit import JITKernel
 
 
 class CuTeDSLKernelCache(KernelCache):
+    """Persist CuTeDSL kernels as Python modules plus launcher artifacts."""
+
     # CuTeDSL C++ launcher specific
     kernel_lib_path = "kernel.py"
-    device_kernel_path = "kernel.py"
-    host_kernel_path = "kernel.py"
+    device_kernel_path = "device_kernel.py"
+    host_kernel_path = "host_kernel.py"
     launcher_lib_path = "launcher_lib.so"
     launcher_cpp_path = "launcher.cpp"
 
     @override
     def _save_kernel_source_code_to_disk(self, kernel: JITKernel, cache_path: str, verbose: bool = False):
-        return
+        """Save the original CuTeDSL device source for source inspection."""
+        device_kernel_path = os.path.join(cache_path, self.device_kernel_path)
+        if verbose:
+            self.logger.debug(f"Saving CuTeDSL device source to file: {device_kernel_path}")
+        device_source = kernel.adapter.get_kernel_source(kernel_only=True)
+        if device_source is not None:
+            KernelCache._safe_write_file(device_kernel_path, "w", lambda file: file.write(device_source))
+
+    @override
+    def _save_wrapper_kernel_code_to_disk(self, kernel: JITKernel, cache_path: str, verbose: bool = False):
+        """Save both the generated host wrapper and importable kernel module."""
+        host_kernel_path = os.path.join(cache_path, self.host_kernel_path)
+        if verbose:
+            self.logger.debug(f"Saving CuTeDSL host source to file: {host_kernel_path}")
+        host_source = kernel.adapter.get_host_source()
+        if host_source is not None:
+            KernelCache._safe_write_file(host_kernel_path, "w", lambda file: file.write(host_source))
+
+        kernel_lib_path = os.path.join(cache_path, self.kernel_lib_path)
+        if verbose:
+            self.logger.debug(f"Saving CuTeDSL generated module to file: {kernel_lib_path}")
+        generated_module_source = kernel.adapter.get_generated_module_source()
+        if generated_module_source is None:
+            generated_module_source = KernelCache._load_binary(kernel.adapter.libpath).decode()
+        KernelCache._safe_write_file(kernel_lib_path, "w", lambda file: file.write(generated_module_source))
 
     @override
     def _save_so_cubin_to_disk(self, kernel: JITKernel, cache_path: str, verbose: bool = False):
+        """Save launcher shared objects and optional debugging artifacts."""
         # Save C++ launcher library if it exists
         lib_gen = getattr(kernel.adapter, "lib_generator", None)
         if lib_gen and hasattr(lib_gen, "launcher_libpath") and lib_gen.launcher_libpath:
@@ -39,9 +66,11 @@ class CuTeDSLKernelCache(KernelCache):
 
     @override
     def _get_required_files(self, cache_path: str) -> list[str]:
+        """Return the CuTeDSL cache files required for a runnable reload."""
         return super()._get_required_files(cache_path) + [os.path.join(cache_path, self.launcher_lib_path)]
 
     @override
     def _set_adapter_cache_path(self, kernel: JITKernel, cache_path: str):
+        """Record the cache path so first execution can persist generated cubin."""
         if hasattr(kernel, "adapter"):
             kernel.adapter._cache_path = cache_path

--- a/tilelang/jit/adapter/cutedsl/wrapper.py
+++ b/tilelang/jit/adapter/cutedsl/wrapper.py
@@ -793,6 +793,7 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
         host_mod: IRModule | None = None,
         pass_configs: dict[str, Any] | None = None,
     ):
+        """Initialize CuTeDSL wrapper state and generated launcher code."""
         super().__init__(scheduled_ir_module, source, target, device_mod, host_mod, pass_configs)
 
     # =========================================================================
@@ -830,7 +831,66 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
 
     @staticmethod
     def _cxx_cast(ctype: str, expr_str: str) -> str:
+        """Render a C++ static_cast expression."""
         return f"static_cast<{ctype}>({expr_str})"
+
+    @staticmethod
+    def _call_packed_name(arg: Any) -> str | None:
+        """Return the packed function name when a TIR argument names one."""
+        if isinstance(arg, str):
+            return arg
+        if isinstance(arg, tvm.tirx.StringImm):
+            return arg.value
+        return None
+
+    def _host_entry_func(self) -> tvm.tirx.PrimFunc:
+        """Return the lowered host entry PrimFunc, not the generated Python wrapper."""
+        return TLCUDASourceWrapper.host_func.fget(self)
+
+    def _collect_host_kernel_call_sites(self) -> list[dict[str, Any]]:
+        """Collect CuTeDSL kernel calls from the lowered host entry in order."""
+        if self.host_mod is None:
+            raise AssertionError("host_mod is required for CuTeDSL host codegen")
+        if self.device_mod is None:
+            raise AssertionError("device_mod is required for CuTeDSL host codegen")
+
+        device_function_names = set(self.function_names or [])
+        kernel_call_sites: list[dict[str, Any]] = []
+
+        def visitor(node):
+            """Record CuTeDSL kernel calls from one host TIR node."""
+            if not isinstance(node, tvm.tirx.Call):
+                return
+            if not (hasattr(node, "op") and node.op == tvm.ir.Op.get("tirx.tvm_call_packed")):
+                return
+            args = node.args
+            if not args:
+                return
+
+            function_name = self._call_packed_name(args[0])
+            if function_name not in device_function_names:
+                return
+            if function_name not in self.device_mod:
+                raise AssertionError(f"Function {function_name} not found in device module")
+
+            device_func = self.device_mod[function_name]
+            kernel_params_cnt = len(device_func.params)
+            if len(args) < 1 + kernel_params_cnt:
+                raise AssertionError("tvm_call_packed should have at least 1 argument and match device function parameters")
+
+            kernel_call_sites.append(
+                {
+                    "function_name": function_name,
+                    "function_params": args[1 : 1 + kernel_params_cnt],
+                }
+            )
+
+        post_order_visit(self._host_entry_func().body, visitor)
+
+        if not kernel_call_sites:
+            raise AssertionError("No CuTeDSL kernel call sites found in host entry function")
+
+        return kernel_call_sites
 
     def _collect_function_args(self) -> tuple[list[dict], list[str]]:
         """Collect all function arguments from primary function.
@@ -872,6 +932,7 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
         """Extract function call arguments from Python function declaration."""
 
         def maybe_desc(name: str | tuple[str, str], param_names: list[str], i: int):
+            """Record descriptor aliases while matching declaration parameters."""
             name_str = name if isinstance(name, str) else name[0]
             param = param_names[i]
             if not (param == name_str + "_desc" or param.startswith(name_str + "_desc_")):
@@ -1439,6 +1500,18 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
         """Create dispatch function - always use C++ launcher."""
         return self.create_dispatch_func_cpp_launcher(code, function_informations)
 
+    @staticmethod
+    def _normalize_function_informations(function_informations) -> list[dict]:
+        """Normalize legacy function metadata maps into ordered call-site metadata."""
+        if isinstance(function_informations, dict):
+            ordered_infos = []
+            for function_name, function_info in function_informations.items():
+                info = dict(function_info)
+                info.setdefault("function_name", function_name)
+                ordered_infos.append(info)
+            return ordered_infos
+        return list(function_informations)
+
     def create_dispatch_func_cpp_launcher(self, code, function_informations):
         """Create dispatch function using C++ launcher."""
         function_args, buffer_args = self._collect_function_args()
@@ -1447,8 +1520,10 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
         kernel_metadata = []
         all_desc_names_union = []
         all_tma_tensors_union = []
+        function_information_list = self._normalize_function_informations(function_informations)
 
-        for function_name, function_info in function_informations.items():
+        for function_info in function_information_list:
+            function_name = function_info["function_name"]
             declaration = extract_python_func_declaration(code, function_name)
             desc_name_map: dict[str, str] = {}
             desc_name_var_map: dict[str, tvm.tirx.Var] = {}
@@ -1523,38 +1598,33 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
         """Update the library code with the given code string."""
         self.lib_code = code
 
-        function_informations = {}
-        for function_name in self.function_names:
-            if (function_name not in self.block_info) or (function_name not in self.grid_info):
-                continue
+        function_informations = []
+        for call_site in self._collect_host_kernel_call_sites():
+            function_name = call_site["function_name"]
+            missing_metadata = [
+                metadata_name
+                for metadata_name, metadata in (
+                    ("block_info", self.block_info),
+                    ("grid_info", self.grid_info),
+                    ("dynamic_smem_buf", self.dynamic_smem_buf),
+                )
+                if not isinstance(metadata, dict) or function_name not in metadata
+            ]
+            if missing_metadata:
+                raise AssertionError(f"Missing CuTeDSL launch metadata for host call site {function_name}: {', '.join(missing_metadata)}")
 
-            assert function_name in self.device_mod, f"Function {function_name} not found in device module"
-            device_func = self.device_mod[function_name]
-            kernel_params_cnt = len(device_func.params)
-            function_params: list[str] = None
+            function_informations.append(
+                {
+                    "function_name": function_name,
+                    "block_info": self.block_info[function_name],
+                    "grid_info": self.grid_info[function_name],
+                    "dynamic_smem_buf": self.dynamic_smem_buf[function_name],
+                    "function_params": call_site["function_params"],
+                }
+            )
 
-            def visitor(node, fn=function_name, param_cnt=kernel_params_cnt):
-                nonlocal function_params
-                if isinstance(node, tvm.tirx.Call):
-                    if not (hasattr(node, "op") and node.op == tvm.ir.Op.get("tirx.tvm_call_packed")):
-                        return
-                    args = node.args
-                    if not args or args[0] != fn:
-                        return
-                    if len(args) < 1 + param_cnt:
-                        raise AssertionError("tvm_call_packed should have at least 1 argument and match device function parameters")
-                    function_params = args[1 : 1 + param_cnt]
-
-            post_order_visit(self.host_func.body, visitor)
-            assert function_params is not None, "function_params should not be None"
-
-            function_informations[function_name] = {
-                "function_name": function_name,
-                "block_info": self.block_info[function_name],
-                "grid_info": self.grid_info[function_name],
-                "dynamic_smem_buf": self.dynamic_smem_buf[function_name],
-                "function_params": function_params,
-            }
+        if not function_informations:
+            raise AssertionError("No CuTeDSL kernel call sites have launch metadata")
 
         self.host_func = self.create_dispatch_func(code, function_informations)
         return self.lib_code

--- a/tilelang/utils/target.py
+++ b/tilelang/utils/target.py
@@ -93,6 +93,21 @@ def _rocm_target_from_arch(arch: str | None) -> Target | str:
     return Target(target_dict)
 
 
+def _detect_torch_cuda_arch() -> str | None:
+    """Return the CUDA SM architecture detected from PyTorch, if available."""
+    if not torch.cuda.is_available():
+        return None
+    cap = torch.cuda.get_device_capability(0)
+    return f"sm_{nvcc.get_target_arch(cap)}" if cap else None
+
+
+def _cuda_target_from_arch(arch: str | None) -> Target | str:
+    """Build a CUDA target while preserving the legacy bare string fallback."""
+    if arch is None:
+        return "cuda"
+    return Target({"kind": "cuda", "arch": arch})
+
+
 def describe_supported_targets() -> dict[str, str]:
     """
     Return a mapping of supported target names to usage descriptions.
@@ -165,7 +180,9 @@ def determine_torch_fp8_type(fp8_format: Literal["e4m3", "e5m2"] = "e4m3") -> to
     return torch_dtype
 
 
-def _with_cutedsl_key(target: Target) -> Target:
+def _with_cutedsl_key(target: Target | str) -> Target:
+    if not isinstance(target, Target):
+        target = Target(target)
     target_dict = dict(target.export())
     target_dict["keys"] = list(dict.fromkeys([*target_dict.get("keys", ()), "cutedsl"]))
     return Target(target_dict)
@@ -195,7 +212,7 @@ def normalize_cutedsl_target(target: TargetLike) -> Target | None:
 
     if target.strip() == "cutedsl":
         try:
-            return _with_cutedsl_key(Target("cuda"))
+            return _with_cutedsl_key(_cuda_target_from_arch(_detect_torch_cuda_arch()))
         except Exception:
             return None
 
@@ -237,10 +254,7 @@ def determine_target(target: TargetLike | Literal["auto"] = "auto", return_objec
 
             # Determine the target based on availability
             if is_cuda_available:
-                if torch.cuda.is_available() and (cap := torch.cuda.get_device_capability(0)):
-                    return_var = Target({"kind": "cuda", "arch": f"sm_{nvcc.get_target_arch(cap)}"})
-                else:
-                    return_var = "cuda"
+                return_var = _cuda_target_from_arch(_detect_torch_cuda_arch())
             elif is_hip_available:
                 return_var = _rocm_target_from_arch(_detect_torch_rocm_arch())
             elif check_metal_availability():


### PR DESCRIPTION
 ## Summary

  This PR completes the CuTeDSL host codegen integration path by driving CuTeDSL launcher generation from the lowered host IR call sites instead of
  rebuilding launch order from device function metadata alone.

  The generated CuTeDSL Python host wrapper and C++ launcher now follow the actual `tir.tvm_call_packed` calls emitted in `host_mod`, preserving
  multi-kernel launch order and allowing repeated launches of the same device kernel to be represented as distinct host call sites.

  This PR also separates CuTeDSL source visibility and cache persistence into device source, generated host wrapper source, and the final importable
  `kernel.py` module.

  ## Changes

  - Collect CuTeDSL kernel call sites from lowered `host_mod` in host IR order.
  - Generate CuTeDSL C++ launcher metadata from ordered host call sites.
  - Preserve separate CuTeDSL source surfaces:
    - `get_kernel_source(kernel_only=True)` returns device CuTeDSL kernel source.
    - `get_host_source()` returns generated Python host wrapper source.
    - `get_kernel_source(kernel_only=False)` returns device + host source.
    - `get_generated_module_source()` returns the importable generated `kernel.py`.
  - Persist CuTeDSL cache artifacts separately:
    - `device_kernel.py`
    - `host_kernel.py`
    - `kernel.py`
    - `launcher_lib.so`
  - Update autotune cache persistence to save the real CuTeDSL host wrapper source.
  - Add host-codegen integration tests covering:
    - lowered host call-site ordering
    - generated launcher ordering
    - device/host/combined source accessors
    - CuTeDSL disk cache roundtrip
    - CuTeDSL autotune cache roundtrip

  ## Notes

  This branch is based on the CuTeDSL 4.5 setup compatibility patch because the current CuTeDSL 4.5 runtime requires the `Constexpr` import
  compatibility fix in `threadblock_swizzle.py`. The host-codegen change itself is independent from the PDL support patch.

  ## Testing

  ```bash
  python -m pytest -q testing/python/jit/test_tilelang_jit_cutedsl_host_codegen.py --tb=short

  python -m pytest -q 'testing/python/cache/test_tilelang_kernel_cache.py::test_disk_cache_with_postproc[cutedsl]' --tb=short

  python -m pytest -q testing/python/autotune/test_tilelang_autotune_cutedsl_cache.py --tb=short

  pre-commit run --all-files

  Locally verified:

  testing/python/jit/test_tilelang_jit_cutedsl_host_codegen.py: 2 passed
  cutedsl cache + autotune cache targeted tests: 5 passed
  pre-commit run --all-files: Passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expose and persist distinct device, host, and generated module sources; richer host-launcher metadata discovery and validation.

* **Bug Fixes**
  * Save device/host artifacts to separate cache files and improve fallback/loading; fail-fast on missing per-call-site launch metadata; broaden availability probing for CUDA adapter.

* **Tests**
  * New CUDA-gated integration and autotuning tests covering host codegen, source exposure, launch-metadata, and richer test stubs.

* **Documentation**
  * Added docstrings for swizzle utilities and several helper methods.

* **Chores**
  * Updated CUDA test dependency pin to align with CI wheels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->