### PR TITLE
[Enhancement]Support mixed-sign ramp indices in LegalizeNegativeIndex

### DIFF
--- a/src/transform/legalize_negative_index.cc
+++ b/src/transform/legalize_negative_index.cc
@@ -163,6 +163,38 @@ private:
                         const LoadStore2StateMap &states)
       : arith::IRMutatorWithAnalyzer(analyzer), states_(states) {}
 
+  PrimExpr TryRewriteMixedRamp(const PrimExpr &index,
+                               const PrimExpr &buffer_extent) {
+    PrimExpr value = analyzer_->Simplify(index);
+    const auto *ramp = value.as<RampNode>();
+    if (ramp == nullptr)
+      return PrimExpr();
+
+    int lanes = *as_const_int(ramp->lanes);
+    ffi::Array<PrimExpr> values;
+    ffi::Array<PrimExpr> shuffle_indices;
+    DataType dtype = value.dtype().element_of();
+    for (int lane_id = 0; lane_id < lanes; ++lane_id) {
+      PrimExpr lane = analyzer_->Simplify(
+          ramp->base + ramp->stride * IntImm(ramp->stride.dtype(), lane_id));
+      if (analyzer_->CanProve(lane < 0))
+        lane = analyzer_->Simplify(buffer_extent + lane);
+      else if (!analyzer_->CanProve(lane >= 0))
+        return PrimExpr();
+      values.push_back(lane.dtype() == dtype ? lane : Cast(dtype, lane));
+      shuffle_indices.push_back(IntImm(DataType::Int(32), lane_id));
+    }
+    return analyzer_->Simplify(Shuffle(values, shuffle_indices, value->span));
+  }
+
+  BufferRegion UpdateRegion(BufferRegion region) {
+    for (const Range &range : region->region) {
+      if (analyzer_->CanProve(analyzer_->Simplify(range->min) < 0))
+        return BufferRegion::FullRegion(region->buffer);
+    }
+    return region;
+  }
+
   ffi::Array<PrimExpr> UpdateIdx(const ffi::Array<PrimExpr> &indices,
                                  const ffi::Array<PrimExpr> &buffer_shape,
                                  const std::vector<IndexSignState> &state_vec) {
@@ -171,9 +203,13 @@ private:
         << indices << ")";
     ffi::Array<PrimExpr> new_indices = indices;
     for (size_t i = 0; i < indices.size(); ++i) {
-      if (state_vec[i] != IndexSignState::kNegative)
-        continue;
-      new_indices.Set(i, analyzer_->Simplify(buffer_shape[i] + indices[i]));
+      if (state_vec[i] == IndexSignState::kNegative) {
+        new_indices.Set(i, analyzer_->Simplify(buffer_shape[i] + indices[i]));
+      } else if (state_vec[i] == IndexSignState::kUnknown) {
+        PrimExpr rewritten = TryRewriteMixedRamp(indices[i], buffer_shape[i]);
+        if (rewritten.defined())
+          new_indices.Set(i, rewritten);
+      }
     }
     return new_indices;
   }
@@ -200,6 +236,16 @@ private:
 
     auto indices = UpdateIdx(store->indices, store->buffer->shape, it->second);
     return BufferStore(store->buffer, store->value, indices, store->predicate);
+  }
+
+  Stmt VisitStmt_(const BlockNode *op) final {
+    Block block = Downcast<Block>(arith::IRMutatorWithAnalyzer::VisitStmt_(op));
+    BlockNode *n = block.CopyOnWrite();
+    n->reads.MutateByApply(
+        [this](BufferRegion region) { return UpdateRegion(region); });
+    n->writes.MutateByApply(
+        [this](BufferRegion region) { return UpdateRegion(region); });
+    return block;
   }
 
 private:

--- a/testing/python/transform/test_tilelang_transform_legalize_negative_index.py
+++ b/testing/python/transform/test_tilelang_transform_legalize_negative_index.py
@@ -186,6 +186,50 @@ def test_buffer_load_vector_index_negative_ramp():
     _check(before, after)
 
 
+def test_buffer_load_vector_index_mixed_sign_ramp():
+    """
+    Test vectorized ramp indices that mix Python-negative and non-negative
+    lanes.
+    """
+
+    @T.prim_func
+    def before(A: T.Tensor((1024,), T.float32)):
+        vec = T.Ramp(-2, 1, 4)  # indices: [-2, -1, 0, 1]
+        value = A[vec]
+        B = T.alloc_buffer((4,), T.float32)
+        B[T.Ramp(0, 1, 4)] = value
+
+    @T.prim_func
+    def after(A: T.Tensor((1024,), T.float32)):
+        vec = T.Ramp(-2, 1, 4)  # noqa: F841
+        value = A[T.Shuffle([1022, 1023, 0, 1], [0, 1, 2, 3])]
+        B = T.alloc_buffer((4,), T.float32)
+        B[T.Ramp(0, 1, 4)] = value
+
+    _check(before, after)
+
+
+def test_buffer_load_vector_index_mixed_sign_ramp_in_kernel():
+    """
+    Test a sliding-window KV-cache style vector load that crosses a ring-buffer
+    boundary inside a kernel body.
+    """
+
+    @T.prim_func
+    def before(A: T.Tensor((1024,), T.float32), B: T.Tensor((4,), T.float32)):
+        with T.Kernel(1, threads=1) as _:
+            vec = T.Ramp(-2, 1, 4)  # indices: [-2, -1, 0, 1]
+            B[T.Ramp(0, 1, 4)] = A[vec]
+
+    @T.prim_func
+    def after(A: T.Tensor((1024,), T.float32), B: T.Tensor((4,), T.float32)):
+        with T.Kernel(1, threads=1) as _:
+            vec = T.Ramp(-2, 1, 4)  # noqa: F841
+            B[T.Ramp(0, 1, 4)] = A[T.Shuffle([1022, 1023, 0, 1], [0, 1, 2, 3])]
+
+    _check(before, after)
+
+
 def test_buffer_load_nested_buffer_loads():
     """
     Test legalization with nested buffer load expressions.
@@ -312,6 +356,27 @@ def test_buffer_store_vector_index_negative_ramp():
         vec = T.Ramp(-4, 1, 4)  # noqa: F841
         values = T.Ramp(0.0, 1.0, 4)
         A[T.Ramp(1020, 1, 4)] = values
+
+    _check(before, after)
+
+
+def test_buffer_store_vector_index_mixed_sign_ramp():
+    """
+    Test vectorized store ramp indices that mix Python-negative and
+    non-negative lanes.
+    """
+
+    @T.prim_func
+    def before(A: T.Tensor((1024,), T.float32)):
+        vec = T.Ramp(-2, 1, 4)  # indices: [-2, -1, 0, 1]
+        values = T.Ramp(0.0, 1.0, 4)
+        A[vec] = values
+
+    @T.prim_func
+    def after(A: T.Tensor((1024,), T.float32)):
+        vec = T.Ramp(-2, 1, 4)  # noqa: F841
+        values = T.Ramp(0.0, 1.0, 4)
+        A[T.Shuffle([1022, 1023, 0, 1], [0, 1, 2, 3])] = values
 
     _check(before, after)
 


### PR DESCRIPTION

## Summary

- Extend `LegalizeNegativeIndex` to handle constant `Ramp` indices whose lanes mix negative and non-negative values.
- Preserve existing negative-index semantics by rewriting only the lanes proven negative and keeping non-negative lanes unchanged.
- Widen affected block read/write regions conservatively when the original region starts below zero.

## Motivation

TileLang already legalizes Python-style negative indices in scalar and all-negative vector cases, for example:

```python
A[-1]
A[T.Ramp(-4, 1, 4)]
```

This PR extends the same behavior to the mixed-sign constant ramp case:

```python
A[T.Ramp(-2, 1, 4)]  # lanes: [-2, -1, 0, 1]
```

The existing pass classifies the whole ramp as unknown-sign, because the vector expression is neither fully negative nor fully non-negative. As a result, the negative lanes are left unlegalized even though each lane is constant and can be handled independently.

## Kernel Reproducer

Kernels often split a wrapped circular-buffer window into two contiguous accesses, which is usually the faster lowering shape. This example is not meant to prescribe a preferred kernel style; it is a compact reproducer for the existing negative-index semantics when a vectorized load crosses a circular-buffer boundary.

Complete reproducer:

```python
import torch
import tilelang
from tilelang import tvm as tvm
import tilelang.language as T


CACHE_LEN = 1024
WINDOW = 4
WRAP_LEFT = 2


@T.prim_func
def sliding_window_kv_cache_unwrap(
    K_cache: T.Tensor((CACHE_LEN,), T.float32),
    K_window: T.Tensor((WINDOW,), T.float32),
):
    """Gather a KV window that crosses the circular-cache boundary.

    Logical window:
      K_cache[-2], K_cache[-1], K_cache[0], K_cache[1]

    Expected physical slots:
      K_cache[1022], K_cache[1023], K_cache[0], K_cache[1]
    """
    with T.Kernel(1, threads=1) as _:
        logical_window = T.Ramp(-WRAP_LEFT, 1, WINDOW)
        K_window[T.Ramp(0, 1, WINDOW)] = K_cache[logical_window]


def show_lowered_ir():
    mod = tvm.IRModule.from_expr(
        sliding_window_kv_cache_unwrap.with_attr("global_symbol", "main")
    )
    lowered = tilelang.transform.LegalizeNegativeIndex()(mod)["main"]
    print(lowered.script())


def run_kernel():
    backing = torch.empty(CACHE_LEN + WRAP_LEFT, device="cuda", dtype=torch.float32)
    backing[0] = -2000.0
    backing[1] = -1000.0
    backing[WRAP_LEFT:] = torch.arange(CACHE_LEN, device="cuda", dtype=torch.float32)

    k_cache_view = backing[WRAP_LEFT:]
    k_window = torch.empty(WINDOW, device="cuda", dtype=torch.float32)
    expected = torch.tensor([1022.0, 1023.0, 0.0, 1.0], device="cuda")

    kernel = tilelang.compile(
        sliding_window_kv_cache_unwrap,
        target="cuda",
        execution_backend="nvrtc",
    )
    kernel(k_cache_view, k_window)
    torch.cuda.synchronize()

    print("actual  :", k_window.detach().cpu().tolist())
    print("expected:", expected.detach().cpu().tolist())
    assert torch.allclose(k_window, expected)


if __name__ == "__main__":
    show_lowered_ir()
    if torch.cuda.is_available():
        run_kernel()
```

Before this patch, the transform leaves the mixed-sign access as an unlegalized negative range/ramp:

```python
T.reads(K_cache[-2:2])
K_window[0:4] = K_cache[logical_window]
```

After this patch, the same transform produces the lane-wise legalized indices:

```python
T.reads(K_cache[0:1024])
K_window[0:4] = K_cache[T.Shuffle([1022, 1023, 0, 1], [0, 1, 2, 3])]
```

This keeps the transform behavior consistent across scalar negative indices, all-negative vector ramps, and constant mixed-sign vector ramps.

## Implementation

When the sign state is unknown, the rewriter now tries a narrow lane-wise rewrite for constant `Ramp` indices:

- If a lane is provably negative, rewrite it as `buffer_extent + lane`.
- If a lane is provably non-negative, keep it unchanged.
- If any lane remains unknown, leave the original expression unchanged.

The rewritten vector is represented as `T.Shuffle`, which preserves the per-lane indexing semantics without changing truly dynamic unknown-sign cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for legalization of mixed-sign vector indices in buffer load/store operations.

* **Bug Fixes**
  * Improved handling of negative lanes in vectorized buffer access and block-level region metadata.

* **Tests**
  * Added tests covering mixed-sign vector index scenarios for loads and stores (including kernel contexts).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->