### PR TITLE
[ROCm] Match CUDA path debug-info and temp-file plumbing

### DIFF
--- a/tilelang/contrib/hipcc.py
+++ b/tilelang/contrib/hipcc.py
@@ -7,13 +7,29 @@
 
 from __future__ import absolute_import as _abs
 
+import os
 import subprocess
+import tempfile
 
 import tvm_ffi
 
+from tilelang import tvm as tvm
+from tilelang.env import env
 from tvm.contrib import utils
 from tvm.base import py_str
 from tvm.contrib.rocm import get_rocm_arch, find_rocm_path
+
+
+def _resolve_artifact_paths(temp, file_name, target_format, kernels_output_dir=None):
+    if kernels_output_dir is None:
+        return temp.relpath(f"{file_name}.cc"), temp.relpath(f"{file_name}.{target_format}")
+
+    os.makedirs(kernels_output_dir, exist_ok=True)
+    fd, temp_code = tempfile.mkstemp(prefix=f"{file_name}_", suffix=".cc", dir=kernels_output_dir)
+    os.close(fd)
+    file_stem, _ = os.path.splitext(os.path.basename(temp_code))
+    temp_target = os.path.join(kernels_output_dir, f"{file_stem}.{target_format}")
+    return temp_code, temp_target
 
 
 def compile_hip(code, target_format="hsaco", arch=None, options=None, path_target=None, verbose=False):
@@ -45,11 +61,13 @@ def compile_hip(code, target_format="hsaco", arch=None, options=None, path_targe
         rocm_path = find_rocm_path()
         arch = get_rocm_arch(rocm_path)
 
-    temp = utils.tempdir()
+    temp = utils.tempdir(keep_for_debug=not env.should_cleanup_temp_files())
+    file_name = "my_kernel"
     if target_format not in ["hsaco"]:
         raise ValueError("target_format must be hsaco")
-    temp_code = temp.relpath("my_kernel.cc")
-    temp_target = temp.relpath(f"my_kernel.{target_format}")
+    pass_context = tvm.get_global_func("transform.GetCurrentPassContext")()
+    kernels_output_dir = pass_context.config.get("hip.kernels_output_dir", None)
+    temp_code, temp_target = _resolve_artifact_paths(temp, file_name, target_format, kernels_output_dir=kernels_output_dir)
 
     with open(temp_code, "w") as out_file:
         out_file.write(code)
@@ -57,6 +75,8 @@ def compile_hip(code, target_format="hsaco", arch=None, options=None, path_targe
     file_target = path_target if path_target else temp_target
     cmd = ["hipcc"]
     cmd += ["-O3", "-c"]
+    # Always include line info for better profiling and mapping
+    cmd += ["-gline-tables-only"]
     if isinstance(arch, str):
         cmd += [f"--offload-arch={arch}"]
     if target_format == "hsaco":


### PR DESCRIPTION
This PR brings the HIP backend (`tilelang/contrib/hipcc.py`) to feature parity with the CUDA backend (`tilelang/contrib/nvcc.py`) on three profile-mode points: `keep_for_debug` for the tempdir, the `hip.kernels_output_dir` `PassContext` config, and an always-on `-gline-tables-only` flag. The result is that AMD users get the same source-line attribution in profilers (e.g. rocprofv3 ATT) that NVIDIA users already get from `-lineinfo`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable output directory for HIP kernel artifacts via TVM context settings

* **Chores**
  * Improved temporary file cleanup behavior in HIP compiler integration
  * Enabled debug line table generation in HIP kernel compilation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->