### PR TITLE
[Transform] Refactor TIR statement traversal helpers

### DIFF
--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -1230,45 +1230,66 @@ private:
                     attr->span);
   }
 
-  HeadAsyncSyncInfo AnalyzeHeadAsyncSync(const Stmt &stmt,
-                                         HeadSeqMode seq_mode) const {
-    if (stmt.as<BindNode>()) {
-      return {};
+  class HeadAsyncSyncAnalyzer
+      : public StmtFunctor<HeadAsyncSyncInfo(const Stmt &)> {
+  public:
+    static HeadAsyncSyncInfo Analyze(const PipelineRewriter *rewriter,
+                                     const Stmt &stmt, HeadSeqMode seq_mode) {
+      HeadAsyncSyncAnalyzer analyzer(rewriter, seq_mode);
+      return analyzer(stmt);
     }
-    if (const auto *attr = stmt.as<AttrStmtNode>()) {
-      if (IsAsyncWaitQueueScope(attr)) {
-        if (auto wait_n = TryGetStaticAsyncWaitCount(attr)) {
+
+    HeadAsyncSyncAnalyzer(const PipelineRewriter *rewriter,
+                          HeadSeqMode seq_mode)
+        : rewriter_(rewriter), seq_mode_(seq_mode) {}
+
+    HeadAsyncSyncInfo VisitStmt_(const AttrStmtNode *op) final {
+      if (IsAsyncWaitQueueScope(op)) {
+        if (auto wait_n = rewriter_->TryGetStaticAsyncWaitCount(op)) {
           return {HeadAsyncSyncKind::kWaitStatic, *wait_n};
         }
         return {HeadAsyncSyncKind::kWaitDynamic, 0};
       }
-      if (IsAsyncCommitQueueScope(attr)) {
+      if (IsAsyncCommitQueueScope(op)) {
         return {HeadAsyncSyncKind::kCommit, 0};
       }
-      if (IsAsyncWaitInflightCount(attr)) {
+      if (IsAsyncWaitInflightCount(op)) {
         return {HeadAsyncSyncKind::kBlocked, 0};
       }
-      return AnalyzeHeadAsyncSync(attr->body, seq_mode);
+      return VisitStmt(op->body);
     }
-    if (const auto *seq = stmt.as<SeqStmtNode>()) {
-      if (seq->seq.empty()) {
+
+    HeadAsyncSyncInfo VisitStmt_(const SeqStmtNode *op) final {
+      if (op->seq.empty()) {
         return {};
       }
-      if (seq_mode == HeadSeqMode::kSingletonOnly && seq->seq.size() != 1) {
+      if (seq_mode_ == HeadSeqMode::kSingletonOnly && op->seq.size() != 1) {
         return {HeadAsyncSyncKind::kBlocked, 0};
       }
-      return AnalyzeHeadAsyncSync(seq->seq[0], seq_mode);
+      return VisitStmt(op->seq[0]);
     }
-    if (const auto *block = stmt.as<SBlockNode>()) {
-      return AnalyzeHeadAsyncSync(block->body, seq_mode);
+
+    HeadAsyncSyncInfo VisitStmt_(const SBlockNode *op) final {
+      return VisitStmt(op->body);
     }
-    if (const auto *realize = stmt.as<SBlockRealizeNode>()) {
-      if (is_one(realize->predicate)) {
-        return AnalyzeHeadAsyncSync(realize->block->body, seq_mode);
+
+    HeadAsyncSyncInfo VisitStmt_(const SBlockRealizeNode *op) final {
+      if (is_one(op->predicate)) {
+        return VisitStmt(op->block->body);
       }
       return {HeadAsyncSyncKind::kBlocked, 0};
     }
-    return {};
+
+    HeadAsyncSyncInfo VisitStmtDefault_(const Object *) final { return {}; }
+
+  private:
+    const PipelineRewriter *rewriter_;
+    HeadSeqMode seq_mode_;
+  };
+
+  HeadAsyncSyncInfo AnalyzeHeadAsyncSync(const Stmt &stmt,
+                                         HeadSeqMode seq_mode) const {
+    return HeadAsyncSyncAnalyzer::Analyze(this, stmt, seq_mode);
   }
 
   ClassifiedAsyncSyncStmt ClassifySimpleAsyncSyncStmt(const Stmt &stmt) const {
@@ -1359,64 +1380,81 @@ private:
     return guaranteed_groups;
   }
 
-  Stmt RewriteWaitStaticInSimpleWrapper(const Stmt &stmt, int new_wait_n,
-                                        bool *changed) const {
-    ClassifiedAsyncSyncStmt cls = ClassifySimpleAsyncSyncStmt(stmt);
-    if (cls.kind != AsyncSyncStmtKind::kWaitStatic) {
-      return stmt;
-    }
-    if (const auto *attr = stmt.as<AttrStmtNode>()) {
-      if (IsAsyncWaitQueueScope(attr)) {
-        *changed = true;
-        return MakeStaticAsyncWaitStmtLike(attr, new_wait_n);
+  class WaitStaticInSimpleWrapperRewriter
+      : public StmtFunctor<Optional<Stmt>(const Stmt &)> {
+  public:
+    static Optional<Stmt> Rewrite(const PipelineRewriter *rewriter,
+                                  const Stmt &stmt, int new_wait_n) {
+      if (rewriter->ClassifySimpleAsyncSyncStmt(stmt).kind !=
+          AsyncSyncStmtKind::kWaitStatic) {
+        return Optional<Stmt>();
       }
+      WaitStaticInSimpleWrapperRewriter rewrite(rewriter, new_wait_n);
+      return rewrite(stmt);
     }
-    if (stmt.as<BindNode>()) {
-      return stmt;
-    }
-    if (const auto *attr = stmt.as<AttrStmtNode>()) {
-      Stmt new_body =
-          RewriteWaitStaticInSimpleWrapper(attr->body, new_wait_n, changed);
-      if (*changed) {
-        return AttrStmt(attr->node, attr->attr_key, attr->value, new_body,
-                        attr->span);
+
+    WaitStaticInSimpleWrapperRewriter(const PipelineRewriter *rewriter,
+                                      int new_wait_n)
+        : rewriter_(rewriter), new_wait_n_(new_wait_n) {}
+
+    Optional<Stmt> VisitStmt_(const AttrStmtNode *op) final {
+      if (IsAsyncWaitQueueScope(op)) {
+        return rewriter_->MakeStaticAsyncWaitStmtLike(op, new_wait_n_);
       }
-      return stmt;
-    }
-    if (const auto *seq = stmt.as<SeqStmtNode>()) {
-      if (seq->seq.size() == 1) {
-        Stmt inner =
-            RewriteWaitStaticInSimpleWrapper(seq->seq[0], new_wait_n, changed);
-        if (*changed) {
-          return SeqStmt({inner});
-        }
+      Optional<Stmt> body = VisitStmt(op->body);
+      if (!body.defined()) {
+        return Optional<Stmt>();
       }
-      return stmt;
+      return AttrStmt(op->node, op->attr_key, op->value, body.value(),
+                      op->span);
     }
-    if (const auto *block = stmt.as<SBlockNode>()) {
-      Stmt inner =
-          RewriteWaitStaticInSimpleWrapper(block->body, new_wait_n, changed);
-      if (*changed) {
-        SBlock new_block = Downcast<SBlock>(stmt);
-        new_block.CopyOnWrite()->body = inner;
-        return new_block;
+
+    Optional<Stmt> VisitStmt_(const SeqStmtNode *op) final {
+      if (op->seq.size() != 1) {
+        return Optional<Stmt>();
       }
-      return stmt;
-    }
-    if (const auto *realize = stmt.as<SBlockRealizeNode>()) {
-      if (is_one(realize->predicate)) {
-        Stmt inner = RewriteWaitStaticInSimpleWrapper(realize->block->body,
-                                                      new_wait_n, changed);
-        if (*changed) {
-          SBlock new_block = realize->block;
-          new_block.CopyOnWrite()->body = inner;
-          return SBlockRealize(realize->iter_values, realize->predicate,
-                               new_block, realize->span);
-        }
+      Optional<Stmt> inner = VisitStmt(op->seq[0]);
+      if (!inner.defined()) {
+        return Optional<Stmt>();
       }
-      return stmt;
+      return SeqStmt({inner.value()});
     }
-    return stmt;
+
+    Optional<Stmt> VisitStmt_(const SBlockNode *op) final {
+      Optional<Stmt> body = VisitStmt(op->body);
+      if (!body.defined()) {
+        return Optional<Stmt>();
+      }
+      SBlock new_block = GetRef<SBlock>(op);
+      new_block.CopyOnWrite()->body = body.value();
+      return new_block;
+    }
+
+    Optional<Stmt> VisitStmt_(const SBlockRealizeNode *op) final {
+      if (!is_one(op->predicate)) {
+        return Optional<Stmt>();
+      }
+      Optional<Stmt> body = VisitStmt(op->block->body);
+      if (!body.defined()) {
+        return Optional<Stmt>();
+      }
+      SBlock new_block = op->block;
+      new_block.CopyOnWrite()->body = body.value();
+      return SBlockRealize(op->iter_values, op->predicate, new_block, op->span);
+    }
+
+    Optional<Stmt> VisitStmtDefault_(const Object *) final {
+      return Optional<Stmt>();
+    }
+
+  private:
+    const PipelineRewriter *rewriter_;
+    int new_wait_n_;
+  };
+
+  Optional<Stmt> RewriteWaitStaticInSimpleWrapper(const Stmt &stmt,
+                                                  int new_wait_n) const {
+    return WaitStaticInSimpleWrapperRewriter::Rewrite(this, stmt, new_wait_n);
   }
 
   std::optional<int> TryGetHeadStaticWaitCount(const Stmt &stmt) const {
@@ -1428,161 +1466,220 @@ private:
     return std::nullopt;
   }
 
-  std::optional<int> TryGetFirstStaticWaitCount(const Stmt &stmt) const {
-    if (stmt.as<BindNode>()) {
-      return std::nullopt;
+  class FirstStaticWaitCounter
+      : public StmtFunctor<std::optional<int>(const Stmt &)> {
+  public:
+    static std::optional<int> Find(const PipelineRewriter *rewriter,
+                                   const Stmt &stmt) {
+      FirstStaticWaitCounter finder(rewriter);
+      return finder(stmt);
     }
-    if (const auto *attr = stmt.as<AttrStmtNode>()) {
-      HeadAsyncSyncInfo info =
-          AnalyzeHeadAsyncSync(stmt, HeadSeqMode::kTakeFirstElement);
+
+    explicit FirstStaticWaitCounter(const PipelineRewriter *rewriter)
+        : rewriter_(rewriter) {}
+
+    std::optional<int> VisitStmt_(const AttrStmtNode *op) final {
+      HeadAsyncSyncInfo info = rewriter_->AnalyzeHeadAsyncSync(
+          GetRef<Stmt>(op), HeadSeqMode::kTakeFirstElement);
       if (info.kind == HeadAsyncSyncKind::kWaitStatic) {
         return info.wait_n;
       }
       if (info.IsBoundary()) {
         return std::nullopt;
       }
-      return TryGetFirstStaticWaitCount(attr->body);
+      return VisitStmt(op->body);
     }
-    if (const auto *seq = stmt.as<SeqStmtNode>()) {
-      for (const Stmt &elem : seq->seq) {
-        HeadAsyncSyncInfo info =
-            AnalyzeHeadAsyncSync(elem, HeadSeqMode::kTakeFirstElement);
+
+    std::optional<int> VisitStmt_(const SeqStmtNode *op) final {
+      for (const Stmt &elem : op->seq) {
+        HeadAsyncSyncInfo info = rewriter_->AnalyzeHeadAsyncSync(
+            elem, HeadSeqMode::kTakeFirstElement);
         if (info.kind == HeadAsyncSyncKind::kWaitStatic) {
           return info.wait_n;
         }
-        if (info.IsBoundary() || ContainsAsyncSyncScopes(elem)) {
+        if (info.IsBoundary() || rewriter_->ContainsAsyncSyncScopes(elem)) {
           return std::nullopt;
         }
       }
       return std::nullopt;
     }
-    if (const auto *block = stmt.as<SBlockNode>()) {
-      return TryGetFirstStaticWaitCount(block->body);
+
+    std::optional<int> VisitStmt_(const SBlockNode *op) final {
+      return VisitStmt(op->body);
     }
-    if (const auto *realize = stmt.as<SBlockRealizeNode>()) {
-      if (is_one(realize->predicate)) {
-        return TryGetFirstStaticWaitCount(realize->block->body);
+
+    std::optional<int> VisitStmt_(const SBlockRealizeNode *op) final {
+      if (is_one(op->predicate)) {
+        return VisitStmt(op->block->body);
       }
+      return std::nullopt;
     }
-    return std::nullopt;
+
+    std::optional<int> VisitStmtDefault_(const Object *) final {
+      return std::nullopt;
+    }
+
+  private:
+    const PipelineRewriter *rewriter_;
+  };
+
+  std::optional<int> TryGetFirstStaticWaitCount(const Stmt &stmt) const {
+    return FirstStaticWaitCounter::Find(this, stmt);
   }
 
-  Stmt RewriteHeadStaticWaitInWrapper(const Stmt &stmt, int new_wait_n,
-                                      bool *changed) const {
-    if (stmt.as<BindNode>()) {
-      return stmt;
+  class HeadStaticWaitInWrapperRewriter
+      : public StmtFunctor<Optional<Stmt>(const Stmt &)> {
+  public:
+    static Optional<Stmt> Rewrite(const PipelineRewriter *rewriter,
+                                  const Stmt &stmt, int new_wait_n) {
+      HeadStaticWaitInWrapperRewriter rewrite(rewriter, new_wait_n);
+      return rewrite(stmt);
     }
-    if (const auto *attr = stmt.as<AttrStmtNode>()) {
-      if (IsAsyncWaitQueueScope(attr)) {
-        *changed = true;
-        return MakeStaticAsyncWaitStmtLike(attr, new_wait_n);
+
+    HeadStaticWaitInWrapperRewriter(const PipelineRewriter *rewriter,
+                                    int new_wait_n)
+        : rewriter_(rewriter), new_wait_n_(new_wait_n) {}
+
+    Optional<Stmt> VisitStmt_(const AttrStmtNode *op) final {
+      if (IsAsyncWaitQueueScope(op)) {
+        return rewriter_->MakeStaticAsyncWaitStmtLike(op, new_wait_n_);
       }
-      Stmt new_body =
-          RewriteHeadStaticWaitInWrapper(attr->body, new_wait_n, changed);
-      if (*changed) {
-        return AttrStmt(attr->node, attr->attr_key, attr->value, new_body,
-                        attr->span);
+      Optional<Stmt> body = VisitStmt(op->body);
+      if (!body.defined()) {
+        return Optional<Stmt>();
       }
-      return stmt;
+      return AttrStmt(op->node, op->attr_key, op->value, body.value(),
+                      op->span);
     }
-    if (const auto *seq = stmt.as<SeqStmtNode>()) {
-      if (seq->seq.empty()) {
-        return stmt;
+
+    Optional<Stmt> VisitStmt_(const SeqStmtNode *op) final {
+      if (op->seq.empty()) {
+        return Optional<Stmt>();
       }
-      Array<Stmt> new_seq = seq->seq;
-      new_seq.Set(
-          0, RewriteHeadStaticWaitInWrapper(seq->seq[0], new_wait_n, changed));
-      if (*changed) {
-        return SeqStmt(new_seq);
+      Optional<Stmt> first = VisitStmt(op->seq[0]);
+      if (!first.defined()) {
+        return Optional<Stmt>();
       }
-      return stmt;
+      Array<Stmt> new_seq = op->seq;
+      new_seq.Set(0, first.value());
+      return SeqStmt(new_seq);
     }
-    if (const auto *block = stmt.as<SBlockNode>()) {
-      Stmt new_body =
-          RewriteHeadStaticWaitInWrapper(block->body, new_wait_n, changed);
-      if (*changed) {
-        SBlock new_block = Downcast<SBlock>(stmt);
-        new_block.CopyOnWrite()->body = new_body;
-        return new_block;
+
+    Optional<Stmt> VisitStmt_(const SBlockNode *op) final {
+      Optional<Stmt> body = VisitStmt(op->body);
+      if (!body.defined()) {
+        return Optional<Stmt>();
       }
-      return stmt;
+      SBlock new_block = GetRef<SBlock>(op);
+      new_block.CopyOnWrite()->body = body.value();
+      return new_block;
     }
-    if (const auto *realize = stmt.as<SBlockRealizeNode>()) {
-      if (is_one(realize->predicate)) {
-        Stmt new_body = RewriteHeadStaticWaitInWrapper(realize->block->body,
-                                                       new_wait_n, changed);
-        if (*changed) {
-          SBlock new_block = realize->block;
-          new_block.CopyOnWrite()->body = new_body;
-          return SBlockRealize(realize->iter_values, realize->predicate,
-                               new_block, realize->span);
-        }
+
+    Optional<Stmt> VisitStmt_(const SBlockRealizeNode *op) final {
+      if (!is_one(op->predicate)) {
+        return Optional<Stmt>();
       }
-      return stmt;
+      Optional<Stmt> body = VisitStmt(op->block->body);
+      if (!body.defined()) {
+        return Optional<Stmt>();
+      }
+      SBlock new_block = op->block;
+      new_block.CopyOnWrite()->body = body.value();
+      return SBlockRealize(op->iter_values, op->predicate, new_block, op->span);
     }
-    return stmt;
+
+    Optional<Stmt> VisitStmtDefault_(const Object *) final {
+      return Optional<Stmt>();
+    }
+
+  private:
+    const PipelineRewriter *rewriter_;
+    int new_wait_n_;
+  };
+
+  Optional<Stmt> RewriteHeadStaticWaitInWrapper(const Stmt &stmt,
+                                                int new_wait_n) const {
+    return HeadStaticWaitInWrapperRewriter::Rewrite(this, stmt, new_wait_n);
   }
 
-  Stmt RewriteFirstStaticWaitInWrapper(const Stmt &stmt, int new_wait_n,
-                                       bool *changed) const {
-    if (stmt.as<BindNode>()) {
-      return stmt;
+  class FirstStaticWaitInWrapperRewriter
+      : public StmtFunctor<Optional<Stmt>(const Stmt &)> {
+  public:
+    static Optional<Stmt> Rewrite(const PipelineRewriter *rewriter,
+                                  const Stmt &stmt, int new_wait_n) {
+      FirstStaticWaitInWrapperRewriter rewrite(rewriter, new_wait_n);
+      return rewrite(stmt);
     }
-    if (const auto *attr = stmt.as<AttrStmtNode>()) {
-      if (IsAsyncWaitQueueScope(attr)) {
-        *changed = true;
-        return MakeStaticAsyncWaitStmtLike(attr, new_wait_n);
+
+    FirstStaticWaitInWrapperRewriter(const PipelineRewriter *rewriter,
+                                     int new_wait_n)
+        : rewriter_(rewriter), new_wait_n_(new_wait_n) {}
+
+    Optional<Stmt> VisitStmt_(const AttrStmtNode *op) final {
+      if (IsAsyncWaitQueueScope(op)) {
+        return rewriter_->MakeStaticAsyncWaitStmtLike(op, new_wait_n_);
       }
-      if (IsAsyncCommitQueueScope(attr) || IsAsyncWaitInflightCount(attr)) {
-        return stmt;
+      if (IsAsyncCommitQueueScope(op) || IsAsyncWaitInflightCount(op)) {
+        return Optional<Stmt>();
       }
-      Stmt new_body =
-          RewriteFirstStaticWaitInWrapper(attr->body, new_wait_n, changed);
-      if (*changed) {
-        return AttrStmt(attr->node, attr->attr_key, attr->value, new_body,
-                        attr->span);
+      Optional<Stmt> body = VisitStmt(op->body);
+      if (!body.defined()) {
+        return Optional<Stmt>();
       }
-      return stmt;
+      return AttrStmt(op->node, op->attr_key, op->value, body.value(),
+                      op->span);
     }
-    if (const auto *seq = stmt.as<SeqStmtNode>()) {
-      Array<Stmt> new_seq = seq->seq;
+
+    Optional<Stmt> VisitStmt_(const SeqStmtNode *op) final {
+      Array<Stmt> new_seq = op->seq;
       for (int i = 0, n = static_cast<int>(new_seq.size()); i < n; ++i) {
-        Stmt updated =
-            RewriteFirstStaticWaitInWrapper(new_seq[i], new_wait_n, changed);
-        if (*changed) {
-          new_seq.Set(i, updated);
+        Optional<Stmt> updated = VisitStmt(new_seq[i]);
+        if (updated.defined()) {
+          new_seq.Set(i, updated.value());
           return SeqStmt(new_seq);
         }
-        if (ContainsAsyncSyncScopes(new_seq[i])) {
-          return stmt;
+        if (rewriter_->ContainsAsyncSyncScopes(new_seq[i])) {
+          return Optional<Stmt>();
         }
       }
-      return stmt;
+      return Optional<Stmt>();
     }
-    if (const auto *block = stmt.as<SBlockNode>()) {
-      Stmt new_body =
-          RewriteFirstStaticWaitInWrapper(block->body, new_wait_n, changed);
-      if (*changed) {
-        SBlock new_block = Downcast<SBlock>(stmt);
-        new_block.CopyOnWrite()->body = new_body;
-        return new_block;
+
+    Optional<Stmt> VisitStmt_(const SBlockNode *op) final {
+      Optional<Stmt> body = VisitStmt(op->body);
+      if (!body.defined()) {
+        return Optional<Stmt>();
       }
-      return stmt;
+      SBlock new_block = GetRef<SBlock>(op);
+      new_block.CopyOnWrite()->body = body.value();
+      return new_block;
     }
-    if (const auto *realize = stmt.as<SBlockRealizeNode>()) {
-      if (is_one(realize->predicate)) {
-        Stmt new_body = RewriteFirstStaticWaitInWrapper(realize->block->body,
-                                                        new_wait_n, changed);
-        if (*changed) {
-          SBlock new_block = realize->block;
-          new_block.CopyOnWrite()->body = new_body;
-          return SBlockRealize(realize->iter_values, realize->predicate,
-                               new_block, realize->span);
-        }
+
+    Optional<Stmt> VisitStmt_(const SBlockRealizeNode *op) final {
+      if (!is_one(op->predicate)) {
+        return Optional<Stmt>();
       }
-      return stmt;
+      Optional<Stmt> body = VisitStmt(op->block->body);
+      if (!body.defined()) {
+        return Optional<Stmt>();
+      }
+      SBlock new_block = op->block;
+      new_block.CopyOnWrite()->body = body.value();
+      return SBlockRealize(op->iter_values, op->predicate, new_block, op->span);
     }
-    return stmt;
+
+    Optional<Stmt> VisitStmtDefault_(const Object *) final {
+      return Optional<Stmt>();
+    }
+
+  private:
+    const PipelineRewriter *rewriter_;
+    int new_wait_n_;
+  };
+
+  Optional<Stmt> RewriteFirstStaticWaitInWrapper(const Stmt &stmt,
+                                                 int new_wait_n) const {
+    return FirstStaticWaitInWrapperRewriter::Rewrite(this, stmt, new_wait_n);
   }
 
   Stmt MaybeRelaxLoopWaits(const For &loop, int pre_outstanding_lb) const {
@@ -1631,10 +1728,10 @@ private:
               !uses_head_fallback || outstanding_lb >= (candidate_wait_n + 1);
           if (candidate_wait_n > 0 && enough_pre_outstanding &&
               (!uses_head_fallback || groups_after_wait_lb > 0)) {
-            bool changed_wait = false;
-            body.Set(i, RewriteWaitStaticInSimpleWrapper(
-                            body[i], candidate_wait_n, &changed_wait));
-            if (changed_wait) {
+            Optional<Stmt> rewritten_wait =
+                RewriteWaitStaticInSimpleWrapper(body[i], candidate_wait_n);
+            if (rewritten_wait.defined()) {
+              body.Set(i, rewritten_wait.value());
               changed = true;
               effective_wait_n = candidate_wait_n;
             }
@@ -1669,60 +1766,84 @@ private:
     return new_loop;
   }
 
-  Stmt RelaxLoopWaitsInSimpleWrapper(const Stmt &stmt, int pre_outstanding_lb,
-                                     bool *changed) const {
-    if (const auto *loop = stmt.as<ForNode>()) {
-      Stmt relaxed =
-          MaybeRelaxLoopWaits(Downcast<For>(stmt), pre_outstanding_lb);
-      *changed = !relaxed.same_as(stmt);
+  class LoopWaitsInSimpleWrapperRelaxer
+      : public StmtFunctor<Optional<Stmt>(const Stmt &)> {
+  public:
+    static Optional<Stmt> Rewrite(const PipelineRewriter *rewriter,
+                                  const Stmt &stmt, int pre_outstanding_lb) {
+      LoopWaitsInSimpleWrapperRelaxer relaxer(rewriter, pre_outstanding_lb);
+      return relaxer(stmt);
+    }
+
+    LoopWaitsInSimpleWrapperRelaxer(const PipelineRewriter *rewriter,
+                                    int pre_outstanding_lb)
+        : rewriter_(rewriter), pre_outstanding_lb_(pre_outstanding_lb) {}
+
+    Optional<Stmt> VisitStmt_(const ForNode *op) final {
+      For loop = GetRef<For>(op);
+      Stmt relaxed = rewriter_->MaybeRelaxLoopWaits(loop, pre_outstanding_lb_);
+      if (relaxed.same_as(loop)) {
+        return Optional<Stmt>();
+      }
       return relaxed;
     }
-    if (stmt.as<BindNode>()) {
-      return stmt;
-    }
-    if (const auto *attr = stmt.as<AttrStmtNode>()) {
-      Stmt new_body = RelaxLoopWaitsInSimpleWrapper(
-          attr->body, pre_outstanding_lb, changed);
-      if (*changed) {
-        return AttrStmt(attr->node, attr->attr_key, attr->value, new_body,
-                        attr->span);
+
+    Optional<Stmt> VisitStmt_(const AttrStmtNode *op) final {
+      Optional<Stmt> body = VisitStmt(op->body);
+      if (!body.defined()) {
+        return Optional<Stmt>();
       }
-      return stmt;
+      return AttrStmt(op->node, op->attr_key, op->value, body.value(),
+                      op->span);
     }
-    if (const auto *seq = stmt.as<SeqStmtNode>()) {
-      if (seq->seq.size() == 1) {
-        Stmt inner = RelaxLoopWaitsInSimpleWrapper(seq->seq[0],
-                                                   pre_outstanding_lb, changed);
-        if (*changed) {
-          return SeqStmt({inner});
-        }
+
+    Optional<Stmt> VisitStmt_(const SeqStmtNode *op) final {
+      if (op->seq.size() != 1) {
+        return Optional<Stmt>();
       }
-      return stmt;
-    }
-    if (const auto *block = stmt.as<SBlockNode>()) {
-      Stmt new_body = RelaxLoopWaitsInSimpleWrapper(
-          block->body, pre_outstanding_lb, changed);
-      if (*changed) {
-        SBlock new_block = Downcast<SBlock>(stmt);
-        new_block.CopyOnWrite()->body = new_body;
-        return new_block;
+      Optional<Stmt> inner = VisitStmt(op->seq[0]);
+      if (!inner.defined()) {
+        return Optional<Stmt>();
       }
-      return stmt;
+      return SeqStmt({inner.value()});
     }
-    if (const auto *realize = stmt.as<SBlockRealizeNode>()) {
-      if (is_one(realize->predicate)) {
-        Stmt new_body = RelaxLoopWaitsInSimpleWrapper(
-            realize->block->body, pre_outstanding_lb, changed);
-        if (*changed) {
-          SBlock new_block = realize->block;
-          new_block.CopyOnWrite()->body = new_body;
-          return SBlockRealize(realize->iter_values, realize->predicate,
-                               new_block, realize->span);
-        }
+
+    Optional<Stmt> VisitStmt_(const SBlockNode *op) final {
+      Optional<Stmt> body = VisitStmt(op->body);
+      if (!body.defined()) {
+        return Optional<Stmt>();
       }
-      return stmt;
+      SBlock new_block = GetRef<SBlock>(op);
+      new_block.CopyOnWrite()->body = body.value();
+      return new_block;
     }
-    return stmt;
+
+    Optional<Stmt> VisitStmt_(const SBlockRealizeNode *op) final {
+      if (!is_one(op->predicate)) {
+        return Optional<Stmt>();
+      }
+      Optional<Stmt> body = VisitStmt(op->block->body);
+      if (!body.defined()) {
+        return Optional<Stmt>();
+      }
+      SBlock new_block = op->block;
+      new_block.CopyOnWrite()->body = body.value();
+      return SBlockRealize(op->iter_values, op->predicate, new_block, op->span);
+    }
+
+    Optional<Stmt> VisitStmtDefault_(const Object *) final {
+      return Optional<Stmt>();
+    }
+
+  private:
+    const PipelineRewriter *rewriter_;
+    int pre_outstanding_lb_;
+  };
+
+  Optional<Stmt> RelaxLoopWaitsInSimpleWrapper(const Stmt &stmt,
+                                               int pre_outstanding_lb) const {
+    return LoopWaitsInSimpleWrapperRelaxer::Rewrite(this, stmt,
+                                                    pre_outstanding_lb);
   }
 
   class AsyncPipelineLoopWaitRelaxer : public StmtExprMutator {
@@ -1740,10 +1861,10 @@ private:
       int outstanding_lb = 0;
       for (int i = 0, n = static_cast<int>(visited.size()); i < n; ++i) {
         Stmt current = visited[i];
-        bool changed_loop = false;
-        current = rewriter_->RelaxLoopWaitsInSimpleWrapper(
-            current, outstanding_lb, &changed_loop);
-        if (changed_loop) {
+        Optional<Stmt> relaxed =
+            rewriter_->RelaxLoopWaitsInSimpleWrapper(current, outstanding_lb);
+        if (relaxed.defined()) {
+          current = relaxed.value();
           visited.Set(i, current);
         }
         ClassifiedAsyncSyncStmt cls =
@@ -1805,15 +1926,17 @@ private:
       return seq;
     }
     for (size_t pos = 1; pos < suffix_wait_indices.size(); ++pos) {
-      bool changed = false;
       int idx = suffix_wait_indices[pos];
       // Tail consumers drain the final committed groups with no new commits in
       // between. Relax them progressively from the end so the suffix becomes
       // ..., wait<2>, wait<1>, wait<0> instead of rewriting every drain wait to
       // the same retain count.
       int new_wait_n = std::min(retain, static_cast<int>(pos));
-      seq.Set(idx,
-              RewriteFirstStaticWaitInWrapper(seq[idx], new_wait_n, &changed));
+      Optional<Stmt> rewritten =
+          RewriteFirstStaticWaitInWrapper(seq[idx], new_wait_n);
+      if (rewritten.defined()) {
+        seq.Set(idx, rewritten.value());
+      }
     }
     return seq;
   }

--- a/src/transform/pipeline_planning.cc
+++ b/src/transform/pipeline_planning.cc
@@ -16,7 +16,6 @@
 #include "../op/utils.h"
 #include "common/pipeline_utils.h"
 #include <algorithm>
-#include <functional>
 #include <limits>
 #include <map>
 #include <numeric>
@@ -1110,6 +1109,112 @@ private:
     return std::move(pinfo);
   }
 
+  class PipelineBodySeqFinder
+      : public StmtFunctor<Optional<SeqStmt>(const Stmt &)> {
+  public:
+    static SeqStmt FindOrFatal(const Stmt &stmt) {
+      PipelineBodySeqFinder finder;
+      Optional<SeqStmt> seq = finder(stmt);
+      ICHECK(seq.defined());
+      return seq.value();
+    }
+
+    Optional<SeqStmt> VisitStmt_(const SeqStmtNode *op) final {
+      return GetRef<SeqStmt>(op);
+    }
+
+    Optional<SeqStmt> VisitStmt_(const IfThenElseNode *op) final {
+      ICHECK(!op->else_case.defined())
+          << "Pipeline_Planning: Can't handle the body of the loop because "
+             "the IfThenElse node has an else branch";
+      return VisitStmt(op->then_case);
+    }
+
+    Optional<SeqStmt> VisitStmtDefault_(const Object *op) final {
+      LOG(FATAL) << "Pipeline_Planning: Can't handle the body of the loop "
+                 << "because it is not a SeqStmt, IfThenElse without else, "
+                 << "but got " << op->GetTypeKey();
+      return Optional<SeqStmt>();
+    }
+  };
+
+  class SeqStmtFlattener : public StmtFunctor<Array<Stmt>(const Stmt &)> {
+  public:
+    using Base = StmtFunctor<Array<Stmt>(const Stmt &)>;
+
+    static Array<Stmt> Flatten(const Array<Stmt> &stmts) {
+      SeqStmtFlattener flattener;
+      Array<Stmt> flattened;
+      for (const Stmt &stmt : stmts) {
+        Array<Stmt> nested = flattener(stmt);
+        flattened.insert(flattened.end(), nested.begin(), nested.end());
+      }
+      return flattened;
+    }
+
+    Array<Stmt> VisitStmt(const Stmt &stmt) final {
+      if (!stmt.as<SeqStmtNode>()) {
+        return Array<Stmt>{stmt};
+      }
+      return Base::VisitStmt(stmt);
+    }
+
+    Array<Stmt> VisitStmt_(const SeqStmtNode *op) final {
+      Array<Stmt> flattened;
+      for (const Stmt &stmt : op->seq) {
+        Array<Stmt> nested = VisitStmt(stmt);
+        flattened.insert(flattened.end(), nested.begin(), nested.end());
+      }
+      return flattened;
+    }
+
+    Array<Stmt> VisitStmtDefault_(const Object *) final {
+      return Array<Stmt>();
+    }
+  };
+
+  class BodyWrapperRebuilder
+      : public StmtFunctor<Optional<Stmt>(const Stmt &)> {
+  public:
+    using Base = StmtFunctor<Optional<Stmt>(const Stmt &)>;
+
+    static Stmt ReplaceOrFatal(const Stmt &stmt, SeqStmt old_seq,
+                               Stmt new_seq) {
+      BodyWrapperRebuilder rebuilder(std::move(old_seq), std::move(new_seq));
+      Optional<Stmt> rebuilt = rebuilder(stmt);
+      ICHECK(rebuilt.defined());
+      return rebuilt.value();
+    }
+
+    BodyWrapperRebuilder(SeqStmt old_seq, Stmt new_seq)
+        : old_seq_(std::move(old_seq)), new_seq_(std::move(new_seq)) {}
+
+    Optional<Stmt> VisitStmt(const Stmt &stmt) final {
+      if (stmt.same_as(old_seq_)) {
+        return new_seq_;
+      }
+      return Base::VisitStmt(stmt);
+    }
+
+    Optional<Stmt> VisitStmt_(const IfThenElseNode *op) final {
+      Optional<Stmt> then_case = VisitStmt(op->then_case);
+      if (!then_case.defined()) {
+        return Optional<Stmt>();
+      }
+      return IfThenElse(op->condition, then_case.value(), op->else_case);
+    }
+
+    Optional<Stmt> VisitStmtDefault_(const Object *op) final {
+      LOG(FATAL) << "BodyWrapperRebuilder: unexpected node type "
+                 << op->GetTypeKey();
+      return Optional<Stmt>();
+    }
+
+  private:
+    SeqStmt old_seq_;
+    Stmt new_seq_;
+  };
+
   Stmt VisitStmt_(const ForNode *loop) final {
     auto order_anno = loop->annotations.Get("tl_pipeline_order");
     auto stage_anno = loop->annotations.Get("tl_pipeline_stage");
@@ -1161,7 +1266,6 @@ private:
                         Array<Integer>{0});
       }
       Stmt pipeline_body_root{nullptr};
-      Optional<SeqStmt> pipeline_body_seq;
       if (const auto *realize = loop->body.as<SBlockRealizeNode>()) {
         const auto &block = realize->block;
         for (const auto &buffer : block->alloc_buffers) {
@@ -1172,29 +1276,11 @@ private:
       } else {
         pipeline_body_root = loop->body;
       }
-      {
-        Stmt current = pipeline_body_root;
-        while (true) {
-          if (const auto *seq_stmt = current.as<SeqStmtNode>()) {
-            pipeline_body_seq = tvm::ffi::GetRef<SeqStmt>(seq_stmt);
-            break;
-          }
-          if (const auto *if_then_else = current.as<IfThenElseNode>()) {
-            ICHECK(!if_then_else->else_case.defined())
-                << "Pipeline_Planning: Can't handle the body of the loop "
-                   "because the IfThenElse node has an else branch";
-            current = if_then_else->then_case;
-            continue;
-          }
-          LOG(FATAL) << "Pipeline_Planning: Can't handle the body of the loop "
-                     << "because it is not a SeqStmt, IfThenElse without else, "
-                     << "but got " << current->GetTypeKey();
-        }
-      }
-      ICHECK(pipeline_body_seq.defined());
-      MaybeAnnotateLegacyAsyncPipelineLoop(
-          pipeline_body_root, pipeline_body_seq.value()->seq, order_array,
-          stage_array, &annotations);
+      SeqStmt pipeline_body_seq =
+          PipelineBodySeqFinder::FindOrFatal(pipeline_body_root);
+      MaybeAnnotateLegacyAsyncPipelineLoop(pipeline_body_root,
+                                           pipeline_body_seq->seq, order_array,
+                                           stage_array, &annotations);
       auto for_node = GetRef<For>(loop);
       for_node.CopyOnWrite()->annotations = annotations;
       return for_node;
@@ -1237,27 +1323,8 @@ private:
     } else {
       pipeline_body_root = loop->body;
     }
-    Optional<SeqStmt> pipeline_body_seq;
-    {
-      Stmt current = pipeline_body_root;
-      while (true) {
-        if (const auto *seq_stmt = current.as<SeqStmtNode>()) {
-          pipeline_body_seq = tvm::ffi::GetRef<SeqStmt>(seq_stmt);
-          break;
-        }
-        if (const auto *if_then_else = current.as<IfThenElseNode>()) {
-          ICHECK(!if_then_else->else_case.defined())
-              << "Pipeline_Planning: Can't handle the body of the loop because "
-                 "the IfThenElse node has an else branch";
-          current = if_then_else->then_case;
-          continue;
-        }
-        LOG(FATAL) << "Pipeline_Planning: Can't handle the body of the loop "
-                   << "because it is not a SeqStmt, IfThenElse without else, "
-                   << "but got " << current->GetTypeKey();
-      }
-    }
-    ICHECK(pipeline_body_seq.defined());
+    SeqStmt pipeline_body_seq =
+        PipelineBodySeqFinder::FindOrFatal(pipeline_body_root);
 
     ICHECK(num_stages >= 1);
     ICHECK(loop->kind == ForKind::kSerial);
@@ -1266,19 +1333,7 @@ private:
     // SeqStmt({produce, wait}) which creates nested SeqStmts when placed
     // inside the loop body. Flatten them so pipeline planning can assign
     // individual stages to the produce and wait statements.
-    Array<Stmt> flat_stmts;
-    std::function<void(const Stmt &)> flatten_seq = [&](const Stmt &s) {
-      if (auto *seq = s.as<SeqStmtNode>()) {
-        for (const auto &sub : seq->seq) {
-          flatten_seq(sub);
-        }
-      } else {
-        flat_stmts.push_back(s);
-      }
-    };
-    for (size_t i = 0; i < pipeline_body_seq.value()->size(); i++) {
-      flatten_seq(pipeline_body_seq.value()->seq[i]);
-    }
+    Array<Stmt> flat_stmts = SeqStmtFlattener::Flatten(pipeline_body_seq->seq);
 
     AsyncDependencyChainBuilder chain_builder(buffer_data_to_buffer_);
     chain_builder(pipeline_body_root);
@@ -2212,8 +2267,8 @@ private:
       const auto &block = realize->block;
       // Rebuild: body_root → ... → new_body_seq
       // We need to reconstruct the chain from block->body to the SeqStmt.
-      Stmt rebuilt_inner = RebuildBodyWrapper(
-          block->body, pipeline_body_seq.value(), new_body_seq);
+      Stmt rebuilt_inner = BodyWrapperRebuilder::ReplaceOrFatal(
+          block->body, pipeline_body_seq, new_body_seq);
       SBlock new_block(block->iter_vars, block->reads, block->writes,
                        block->name_hint, rebuilt_inner, block->init,
                        block->alloc_buffers, block->match_buffers,
@@ -2221,8 +2276,8 @@ private:
       new_loop_body =
           SBlockRealize(realize->iter_values, realize->predicate, new_block);
     } else {
-      new_loop_body = RebuildBodyWrapper(loop->body, pipeline_body_seq.value(),
-                                         new_body_seq);
+      new_loop_body = BodyWrapperRebuilder::ReplaceOrFatal(
+          loop->body, pipeline_body_seq, new_body_seq);
     }
 
     return For(loop->loop_var, loop->min, loop->extent, loop->kind,
@@ -2238,27 +2293,6 @@ private:
       buffer_data_to_buffer_.erase(buffer->data);
     }
     return std::move(block);
-  }
-
-  /*!
-   * \brief Rebuild the chain of wrapper statements (IfThenElse)
-   *        between the loop body root and the inner SeqStmt, replacing
-   *        the old SeqStmt with the new (flattened) one.
-   */
-  Stmt RebuildBodyWrapper(const Stmt &current, const SeqStmt &old_seq,
-                          const Stmt &new_seq) {
-    if (current.same_as(old_seq)) {
-      return new_seq;
-    }
-    if (const auto *if_node = current.as<IfThenElseNode>()) {
-      return IfThenElse(
-          if_node->condition,
-          RebuildBodyWrapper(if_node->then_case, old_seq, new_seq),
-          if_node->else_case);
-    }
-    LOG(FATAL) << "RebuildBodyWrapper: unexpected node type "
-               << current->GetTypeKey();
-    return current;
   }
 
   Map<Var, Buffer> buffer_data_to_buffer_;

--- a/src/transform/producer_consumer_ws.cc
+++ b/src/transform/producer_consumer_ws.cc
@@ -333,26 +333,40 @@ private:
   bool reads_shared_local_{false};
 };
 
-static const CallNode *GetEvaluateCallInSimpleWrapper(const Stmt &stmt) {
-  if (const auto *eval = stmt.as<EvaluateNode>()) {
-    return eval->value.as<CallNode>();
+class EvaluateCallInSimpleWrapperExtractor
+    : public StmtFunctor<Optional<Call>(const Stmt &)> {
+public:
+  Optional<Call> VisitStmt_(const EvaluateNode *op) final {
+    return op->value.as<Call>();
   }
-  if (const auto *if_stmt = stmt.as<IfThenElseNode>()) {
-    if (!if_stmt->else_case.defined()) {
-      return GetEvaluateCallInSimpleWrapper(if_stmt->then_case);
+
+  Optional<Call> VisitStmt_(const IfThenElseNode *op) final {
+    if (op->else_case.defined()) {
+      return Optional<Call>();
     }
-    return nullptr;
+    return VisitStmt(op->then_case);
   }
-  if (const auto *attr = stmt.as<AttrStmtNode>()) {
-    return GetEvaluateCallInSimpleWrapper(attr->body);
+
+  Optional<Call> VisitStmt_(const AttrStmtNode *op) final {
+    return VisitStmt(op->body);
   }
-  if (const auto *block = stmt.as<SBlockNode>()) {
-    return GetEvaluateCallInSimpleWrapper(block->body);
+
+  Optional<Call> VisitStmt_(const SBlockNode *op) final {
+    return VisitStmt(op->body);
   }
-  if (const auto *realize = stmt.as<SBlockRealizeNode>()) {
-    return GetEvaluateCallInSimpleWrapper(realize->block->body);
+
+  Optional<Call> VisitStmt_(const SBlockRealizeNode *op) final {
+    return VisitStmt(op->block->body);
   }
-  return nullptr;
+
+  Optional<Call> VisitStmtDefault_(const Object *) final {
+    return Optional<Call>();
+  }
+};
+
+static Optional<Call> GetEvaluateCallInSimpleWrapper(const Stmt &stmt) {
+  EvaluateCallInSimpleWrapperExtractor extractor;
+  return extractor(stmt);
 }
 
 class BufferDataToBufferCollector : public StmtExprVisitor {
@@ -575,13 +589,14 @@ static bool ContainsPtxCpAsync(const Stmt &stmt) {
 }
 
 static bool IsPtxCommitGroup(const Stmt &stmt) {
-  const auto *call = GetEvaluateCallInSimpleWrapper(stmt);
-  return call && call->op.same_as(builtin::ptx_commit_group());
+  Optional<Call> call = GetEvaluateCallInSimpleWrapper(stmt);
+  return call.defined() &&
+         call.value()->op.same_as(builtin::ptx_commit_group());
 }
 
 static bool IsPtxWaitGroup(const Stmt &stmt) {
-  const auto *call = GetEvaluateCallInSimpleWrapper(stmt);
-  return call && call->op.same_as(builtin::ptx_wait_group());
+  Optional<Call> call = GetEvaluateCallInSimpleWrapper(stmt);
+  return call.defined() && call.value()->op.same_as(builtin::ptx_wait_group());
 }
 
 static bool IsBarrierOrTmaControlCall(const CallNode *call) {
@@ -621,11 +636,11 @@ static bool CheckPipelineManagedCPAsyncCopy(const CopyNode *copy,
 }
 
 static bool IsSyncGlobalToSharedCopyLikeStmt(const Stmt &stmt, Target target) {
-  const auto *call = GetEvaluateCallInSimpleWrapper(stmt);
-  if (!call) {
+  Optional<Call> call = GetEvaluateCallInSimpleWrapper(stmt);
+  if (!call.defined()) {
     return false;
   }
-  auto tile_op = ParseOperator(GetRef<Call>(call));
+  auto tile_op = ParseOperator(call.value());
   if (!tile_op.defined()) {
     return false;
   }
@@ -967,66 +982,83 @@ AnalyzeBufferDataAccess(const Stmt &stmt, const Var &buffer_data,
   return detector.Result();
 }
 
-static bool CollectPreludeStmtsToPipelineLoop(const Stmt &stmt,
-                                              const For &pipeline_loop,
-                                              Array<Stmt> *prelude_stmts) {
-  if (stmt.same_as(pipeline_loop)) {
-    return true;
+class PreludeStmtsToPipelineLoopCollector
+    : public StmtFunctor<Optional<Array<Stmt>>(const Stmt &)> {
+public:
+  using Base = StmtFunctor<Optional<Array<Stmt>>(const Stmt &)>;
+
+  explicit PreludeStmtsToPipelineLoopCollector(For pipeline_loop)
+      : pipeline_loop_(std::move(pipeline_loop)) {}
+
+  Optional<Array<Stmt>> VisitStmt(const Stmt &stmt) final {
+    if (stmt.same_as(pipeline_loop_)) {
+      return Array<Stmt>();
+    }
+    return Base::VisitStmt(stmt);
   }
-  if (const auto *seq = stmt.as<SeqStmtNode>()) {
-    for (int i = 0; i < static_cast<int>(seq->seq.size()); ++i) {
-      Array<Stmt> nested_prelude;
-      if (CollectPreludeStmtsToPipelineLoop(seq->seq[i], pipeline_loop,
-                                            &nested_prelude)) {
-        for (int j = 0; j < i; ++j) {
-          prelude_stmts->push_back(seq->seq[j]);
-        }
-        prelude_stmts->insert(prelude_stmts->end(), nested_prelude.begin(),
-                              nested_prelude.end());
-        return true;
+
+  Optional<Array<Stmt>> VisitStmt_(const SeqStmtNode *op) final {
+    for (int i = 0; i < static_cast<int>(op->seq.size()); ++i) {
+      Optional<Array<Stmt>> nested_prelude = VisitStmt(op->seq[i]);
+      if (!nested_prelude.defined()) {
+        continue;
       }
-    }
-    return false;
-  }
-  if (const auto *realize = stmt.as<SBlockRealizeNode>()) {
-    return CollectPreludeStmtsToPipelineLoop(realize->block->body,
-                                             pipeline_loop, prelude_stmts);
-  }
-  if (const auto *block = stmt.as<SBlockNode>()) {
-    return CollectPreludeStmtsToPipelineLoop(block->body, pipeline_loop,
-                                             prelude_stmts);
-  }
-  if (const auto *attr = stmt.as<AttrStmtNode>()) {
-    return CollectPreludeStmtsToPipelineLoop(attr->body, pipeline_loop,
-                                             prelude_stmts);
-  }
-  if (const auto *if_stmt = stmt.as<IfThenElseNode>()) {
-    Array<Stmt> nested_prelude;
-    if (CollectPreludeStmtsToPipelineLoop(if_stmt->then_case, pipeline_loop,
-                                          &nested_prelude)) {
-      prelude_stmts->insert(prelude_stmts->end(), nested_prelude.begin(),
-                            nested_prelude.end());
-      return true;
-    }
-    if (if_stmt->else_case.defined()) {
-      nested_prelude.clear();
-      if (CollectPreludeStmtsToPipelineLoop(if_stmt->else_case.value(),
-                                            pipeline_loop, &nested_prelude)) {
-        prelude_stmts->insert(prelude_stmts->end(), nested_prelude.begin(),
-                              nested_prelude.end());
-        return true;
+
+      Array<Stmt> prelude_stmts;
+      for (int j = 0; j < i; ++j) {
+        prelude_stmts.push_back(op->seq[j]);
       }
+      prelude_stmts.insert(prelude_stmts.end(), nested_prelude.value().begin(),
+                           nested_prelude.value().end());
+      return prelude_stmts;
     }
+    return Optional<Array<Stmt>>();
   }
-  return false;
+
+  Optional<Array<Stmt>> VisitStmt_(const SBlockRealizeNode *op) final {
+    return VisitStmt(op->block->body);
+  }
+
+  Optional<Array<Stmt>> VisitStmt_(const SBlockNode *op) final {
+    return VisitStmt(op->body);
+  }
+
+  Optional<Array<Stmt>> VisitStmt_(const AttrStmtNode *op) final {
+    return VisitStmt(op->body);
+  }
+
+  Optional<Array<Stmt>> VisitStmt_(const IfThenElseNode *op) final {
+    Optional<Array<Stmt>> then_prelude = VisitStmt(op->then_case);
+    if (then_prelude.defined()) {
+      return then_prelude;
+    }
+    if (op->else_case.defined()) {
+      return VisitStmt(op->else_case.value());
+    }
+    return Optional<Array<Stmt>>();
+  }
+
+  Optional<Array<Stmt>> VisitStmtDefault_(const Object *) final {
+    return Optional<Array<Stmt>>();
+  }
+
+private:
+  For pipeline_loop_;
+};
+
+static Array<Stmt> CollectPreludeStmtsToPipelineLoop(const Stmt &stmt,
+                                                     const For &pipeline_loop) {
+  PreludeStmtsToPipelineLoopCollector collector(pipeline_loop);
+  Optional<Array<Stmt>> prelude_stmts = collector(stmt);
+  return prelude_stmts.defined() ? prelude_stmts.value() : Array<Stmt>();
 }
 
 static Optional<Var> ExtractProducerWriteBufferData(const Stmt &stmt) {
-  const auto *call = GetEvaluateCallInSimpleWrapper(stmt);
-  if (!call) {
+  Optional<Call> call = GetEvaluateCallInSimpleWrapper(stmt);
+  if (!call.defined()) {
     return Optional<Var>();
   }
-  auto tile_op = ParseOperator(GetRef<Call>(call));
+  auto tile_op = ParseOperator(call.value());
   if (!tile_op.defined()) {
     return Optional<Var>();
   }
@@ -1369,9 +1401,8 @@ private:
       }
     }
 
-    Array<Stmt> prelude_stmts;
-    CollectPreludeStmtsToPipelineLoop(orig_block->body, pipeline_loop,
-                                      &prelude_stmts);
+    Array<Stmt> prelude_stmts =
+        CollectPreludeStmtsToPipelineLoop(orig_block->body, pipeline_loop);
     std::vector<PreludeTmaLoadPlan> prelude_tma_plans;
     for (const Stmt &stmt : prelude_stmts) {
       if (ClassifyStmt(stmt, target_) != TileStmtKind::kTmaProducer) {
@@ -1905,8 +1936,11 @@ private:
                                dummy_producer, dummy_consumer);
     dummy_ws =
         AttrStmt(ws_partition, attr::kWarpSpecializationScope, 0, dummy_ws);
-    ReplaceResult replaced = ReplacePipelineLoopInStmt(
+    Optional<Stmt> replaced = ReplacePipelineLoopInStmt(
         orig_block->body, pipeline_loop, dummy_ws, consumer_extent);
+    ICHECK(replaced.defined())
+        << "ProducerConsumerWS: failed to replace pipeline loop";
+    Stmt replaced_stmt = replaced.value();
 
     // Producer and consumer partitions cannot safely share the same block-level
     // local/fragment buffers after tiled WS is introduced before
@@ -2009,12 +2043,10 @@ private:
         Stmt old_, new_;
       };
       SubstWsBody subst(dummy_ws, ws_body);
-      replaced.stmt = subst(replaced.stmt);
+      replaced_stmt = subst(replaced_stmt);
     }
-    ICHECK(replaced.found)
-        << "ProducerConsumerWS: failed to replace pipeline loop";
     Stmt new_block_body = SinkGuardedConsumerPostlude::Rewrite(
-        replaced.stmt, thread_iv_->var, consumer_extent);
+        replaced_stmt, thread_iv_->var, consumer_extent);
 
     // --- Update block ---
     SBlock new_block = orig_block;
@@ -2052,7 +2084,7 @@ private:
     return new_realize;
   }
 
-  class PipelineLoopFinder : public StmtExprVisitor {
+  class PipelineLoopFinder : public StmtVisitor {
   public:
     static Optional<For> Find(const Stmt &stmt) {
       PipelineLoopFinder finder;
@@ -2061,15 +2093,19 @@ private:
     }
 
   private:
-    void VisitStmt_(const ForNode *op) final {
+    void VisitStmt(const Stmt &stmt) final {
       if (pipeline_loop_.defined()) {
         return;
       }
+      StmtVisitor::VisitStmt(stmt);
+    }
+
+    void VisitStmt_(const ForNode *op) final {
       if (op->annotations.Get("num_stages")) {
         pipeline_loop_ = ffi::GetRef<For>(op);
         return;
       }
-      StmtExprVisitor::VisitStmt_(op);
+      StmtVisitor::VisitStmt_(op);
     }
 
     Optional<For> pipeline_loop_;
@@ -2078,11 +2114,6 @@ private:
   Optional<For> FindPipelineLoop(const Stmt &stmt) {
     return PipelineLoopFinder::Find(stmt);
   }
-
-  struct ReplaceResult {
-    Stmt stmt;
-    bool found{false};
-  };
 
   class SinkGuardedConsumerPostlude : public StmtExprMutator {
   public:
@@ -2233,177 +2264,254 @@ private:
     PrimExpr consumer_extent_;
   };
 
-  Stmt GuardConsumerOnly(const Stmt &stmt, PrimExpr consumer_extent) {
-    return IfThenElse(LT(thread_iv_->var, consumer_extent), stmt);
-  }
+  class PipelineLoopContainmentChecker
+      : public StmtFunctor<bool(const Stmt &)> {
+  public:
+    using Base = StmtFunctor<bool(const Stmt &)>;
 
-  ReplaceResult ReplacePipelineLoopInStmt(const Stmt &stmt,
-                                          const For &pipeline_loop,
-                                          const Stmt &ws_body,
-                                          PrimExpr consumer_extent) {
-    if (stmt.same_as(pipeline_loop)) {
-      return {ws_body, true};
+    static bool Contains(const Stmt &stmt, const For &pipeline_loop) {
+      PipelineLoopContainmentChecker checker(pipeline_loop);
+      return checker(stmt);
     }
-    if (auto *seq = stmt.as<SeqStmtNode>()) {
+
+    explicit PipelineLoopContainmentChecker(For pipeline_loop)
+        : pipeline_loop_(std::move(pipeline_loop)) {}
+
+    bool VisitStmt(const Stmt &stmt) final {
+      if (stmt.same_as(pipeline_loop_)) {
+        return true;
+      }
+      return Base::VisitStmt(stmt);
+    }
+
+    bool VisitStmt_(const SeqStmtNode *op) final {
+      for (const Stmt &stmt : op->seq) {
+        if (VisitStmt(stmt)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    bool VisitStmt_(const SBlockRealizeNode *op) final {
+      return VisitStmt(op->block->body);
+    }
+
+    bool VisitStmt_(const SBlockNode *op) final { return VisitStmt(op->body); }
+
+    bool VisitStmt_(const AttrStmtNode *op) final {
+      return VisitStmt(op->body);
+    }
+
+    bool VisitStmt_(const IfThenElseNode *op) final {
+      if (VisitStmt(op->then_case)) {
+        return true;
+      }
+      return op->else_case.defined() && VisitStmt(op->else_case.value());
+    }
+
+    bool VisitStmtDefault_(const Object *) final { return false; }
+
+  private:
+    For pipeline_loop_;
+  };
+
+  class PipelineLoopInStmtReplacer
+      : public StmtFunctor<Optional<Stmt>(const Stmt &)> {
+  public:
+    using Base = StmtFunctor<Optional<Stmt>(const Stmt &)>;
+
+    PipelineLoopInStmtReplacer(ProducerConsumerWSRewriter *rewriter,
+                               For pipeline_loop, Stmt ws_body,
+                               PrimExpr consumer_extent)
+        : rewriter_(rewriter), pipeline_loop_(std::move(pipeline_loop)),
+          ws_body_(std::move(ws_body)),
+          consumer_extent_(std::move(consumer_extent)) {}
+
+    Optional<Stmt> VisitStmt(const Stmt &stmt) final {
+      if (stmt.same_as(pipeline_loop_)) {
+        return ws_body_;
+      }
+      return Base::VisitStmt(stmt);
+    }
+
+    Optional<Stmt> VisitStmt_(const SeqStmtNode *op) final {
       Array<Stmt> new_seq;
-      bool found = false;
-      // First pass: find which child contains the pipeline loop.
       int loop_idx = -1;
-      for (int i = 0; i < static_cast<int>(seq->seq.size()); ++i) {
-        ReplaceResult probe = ReplacePipelineLoopInStmt(
-            seq->seq[i], pipeline_loop, ws_body, consumer_extent);
-        if (probe.found) {
+      for (int i = 0; i < static_cast<int>(op->seq.size()); ++i) {
+        if (PipelineLoopContainmentChecker::Contains(op->seq[i],
+                                                     pipeline_loop_)) {
           loop_idx = i;
           break;
         }
       }
       if (loop_idx < 0) {
-        return {stmt, false};
+        return Optional<Stmt>();
       }
-      // Propagate liveness backwards through prelude statements so that
-      // transitive dependencies are captured.  For example, if consumer
-      // needs `m_start` and `m_start` is defined by a prelude statement
-      // that reads `cur_batch_idx`, the loop defining `cur_batch_idx`
-      // must also be visible to the consumer.
-      //
-      // The same rule applies to common prelude statements that stay before
-      // the WS branch.  A pre-loop TMA copy can read a scalar BindNode that is
-      // also used by the consumer.  Without tracking common-prelude uses, that
-      // binding may be sunk into the consumer branch and leave the common TMA
-      // copy with a free var.
-      {
-        LocalLiveSet shared_live = shared_prelude_live_seed_;
-        LocalLiveSet producer_live = producer_prelude_live_seed_;
-        LocalLiveSet consumer_live = consumer_prelude_live_seed_;
-        for (int i = loop_idx + 1; i < static_cast<int>(seq->seq.size()); ++i) {
-          // Post-loop siblings are later sunk into the consumer branch by
-          // SinkGuardedConsumerPostlude.  Keep scalar/index dependencies in
-          // the enclosing prelude so existing shared-prelude index math stays
-          // common, but treat branch-private buffer uses as consumer-only so
-          // their local/fragment initialization does not leak into producer.
-          LocalAccessSummary summary = LocalAccessCollector::Collect(
-              seq->seq[i], buffer_data_to_buffer_);
-          shared_live.vars.insert(summary.read_vars.begin(),
-                                  summary.read_vars.end());
-          consumer_live.buffers.insert(summary.read_buffers.begin(),
-                                       summary.read_buffers.end());
-        }
-        for (int i = loop_idx - 1; i >= 0; --i) {
-          LocalAccessSummary summary = LocalAccessCollector::Collect(
-              seq->seq[i], buffer_data_to_buffer_);
-          if (!summary.HasTrackedDefs()) {
-            shared_live.AddUses(summary);
-            continue;
-          }
-          bool shared_needs = shared_live.NeedsAnyDef(summary);
-          bool producer_needs = producer_live.NeedsAnyDef(summary);
-          bool consumer_needs = consumer_live.NeedsAnyDef(summary);
-          if (shared_needs || (!producer_needs && !consumer_needs)) {
-            shared_live.AddUses(summary);
-          }
-          if (producer_needs) {
-            producer_live.AddUses(summary);
-          }
-          if (consumer_needs) {
-            consumer_live.AddUses(summary);
-          }
-        }
-        shared_prelude_live_seed_ = shared_live;
-        producer_prelude_live_seed_ = producer_live;
-        consumer_prelude_live_seed_ = consumer_live;
+
+      PropagatePreludeLiveness(op, loop_idx);
+      AppendClassifiedPrelude(op, loop_idx, &new_seq);
+
+      Optional<Stmt> rewritten_loop = VisitStmt(op->seq[loop_idx]);
+      ICHECK(rewritten_loop.defined())
+          << "ProducerConsumerWS: failed to replace pipeline loop child";
+      new_seq.push_back(rewritten_loop.value());
+
+      for (int i = loop_idx + 1; i < static_cast<int>(op->seq.size()); ++i) {
+        new_seq.push_back(GuardConsumerOnly(op->seq[i]));
       }
+      return new_seq.size() == 1 ? new_seq[0] : SeqStmt(new_seq);
+    }
+
+    Optional<Stmt> VisitStmt_(const SBlockRealizeNode *op) final {
+      Optional<Stmt> body = VisitStmt(op->block->body);
+      if (!body.defined()) {
+        return Optional<Stmt>();
+      }
+      SBlock block = op->block;
+      block.CopyOnWrite()->body = body.value();
+      SBlockRealize new_realize = GetRef<SBlockRealize>(op);
+      new_realize.CopyOnWrite()->block = block;
+      return new_realize;
+    }
+
+    Optional<Stmt> VisitStmt_(const SBlockNode *op) final {
+      Optional<Stmt> body = VisitStmt(op->body);
+      if (!body.defined()) {
+        return Optional<Stmt>();
+      }
+      SBlock new_block = GetRef<SBlock>(op);
+      new_block.CopyOnWrite()->body = body.value();
+      return new_block;
+    }
+
+    Optional<Stmt> VisitStmt_(const AttrStmtNode *op) final {
+      Optional<Stmt> body = VisitStmt(op->body);
+      if (!body.defined()) {
+        return Optional<Stmt>();
+      }
+      AttrStmt new_attr = GetRef<AttrStmt>(op);
+      new_attr.CopyOnWrite()->body = body.value();
+      return new_attr;
+    }
+
+    Optional<Stmt> VisitStmt_(const IfThenElseNode *op) final {
+      Optional<Stmt> then_result = VisitStmt(op->then_case);
+      Optional<Stmt> new_else = op->else_case;
+      bool found = then_result.defined();
+      if (!found && op->else_case.defined()) {
+        Optional<Stmt> else_result = VisitStmt(op->else_case.value());
+        if (else_result.defined()) {
+          new_else = else_result.value();
+          found = true;
+        }
+      }
+      if (!found) {
+        return Optional<Stmt>();
+      }
+      Stmt new_then =
+          then_result.defined() ? then_result.value() : op->then_case;
+      return IfThenElse(op->condition, new_then, new_else, op->span);
+    }
+
+    Optional<Stmt> VisitStmtDefault_(const Object *) final {
+      return Optional<Stmt>();
+    }
+
+  private:
+    Stmt GuardConsumerOnly(const Stmt &stmt) const {
+      return IfThenElse(LT(rewriter_->thread_iv_->var, consumer_extent_), stmt);
+    }
+
+    void PropagatePreludeLiveness(const SeqStmtNode *op, int loop_idx) {
+      LocalLiveSet shared_live = rewriter_->shared_prelude_live_seed_;
+      LocalLiveSet producer_live = rewriter_->producer_prelude_live_seed_;
+      LocalLiveSet consumer_live = rewriter_->consumer_prelude_live_seed_;
+      for (int i = loop_idx + 1; i < static_cast<int>(op->seq.size()); ++i) {
+        // Post-loop siblings are later sunk into the consumer branch by
+        // SinkGuardedConsumerPostlude.  Keep scalar/index dependencies in
+        // the enclosing prelude so existing shared-prelude index math stays
+        // common, but treat branch-private buffer uses as consumer-only so
+        // their local/fragment initialization does not leak into producer.
+        LocalAccessSummary summary = LocalAccessCollector::Collect(
+            op->seq[i], rewriter_->buffer_data_to_buffer_);
+        shared_live.vars.insert(summary.read_vars.begin(),
+                                summary.read_vars.end());
+        consumer_live.buffers.insert(summary.read_buffers.begin(),
+                                     summary.read_buffers.end());
+      }
+      for (int i = loop_idx - 1; i >= 0; --i) {
+        LocalAccessSummary summary = LocalAccessCollector::Collect(
+            op->seq[i], rewriter_->buffer_data_to_buffer_);
+        if (!summary.HasTrackedDefs()) {
+          shared_live.AddUses(summary);
+          continue;
+        }
+        bool shared_needs = shared_live.NeedsAnyDef(summary);
+        bool producer_needs = producer_live.NeedsAnyDef(summary);
+        bool consumer_needs = consumer_live.NeedsAnyDef(summary);
+        if (shared_needs || (!producer_needs && !consumer_needs)) {
+          shared_live.AddUses(summary);
+        }
+        if (producer_needs) {
+          producer_live.AddUses(summary);
+        }
+        if (consumer_needs) {
+          consumer_live.AddUses(summary);
+        }
+      }
+      rewriter_->shared_prelude_live_seed_ = shared_live;
+      rewriter_->producer_prelude_live_seed_ = producer_live;
+      rewriter_->consumer_prelude_live_seed_ = consumer_live;
+    }
+
+    void AppendClassifiedPrelude(const SeqStmtNode *op, int loop_idx,
+                                 Array<Stmt> *new_seq) {
       // Classify pre-loop statements using branch-private def/use sets.
       // Shared-prelude statements stay in place; branch-private definitions
       // move next to the branch that consumes them, or are duplicated when
       // both producer and consumer need the same definition.
       for (int i = 0; i < loop_idx; ++i) {
-        switch (ClassifyPreludeStmt(
-            seq->seq[i], buffer_data_to_buffer_, shared_prelude_live_seed_,
-            producer_prelude_live_seed_, consumer_prelude_live_seed_)) {
+        switch (ClassifyPreludeStmt(op->seq[i],
+                                    rewriter_->buffer_data_to_buffer_,
+                                    rewriter_->shared_prelude_live_seed_,
+                                    rewriter_->producer_prelude_live_seed_,
+                                    rewriter_->consumer_prelude_live_seed_)) {
         case PreludeStmtPlacement::kProducerOnly:
-          extracted_producer_init_.push_back(seq->seq[i]);
+          rewriter_->extracted_producer_init_.push_back(op->seq[i]);
           break;
         case PreludeStmtPlacement::kConsumerOnly:
-          extracted_consumer_init_.push_back(seq->seq[i]);
+          rewriter_->extracted_consumer_init_.push_back(op->seq[i]);
           break;
         case PreludeStmtPlacement::kDuplicateToBoth:
-          extracted_producer_init_.push_back(seq->seq[i]);
-          extracted_consumer_init_.push_back(seq->seq[i]);
+          rewriter_->extracted_producer_init_.push_back(op->seq[i]);
+          rewriter_->extracted_consumer_init_.push_back(op->seq[i]);
           break;
         case PreludeStmtPlacement::kKeepSharedPrelude:
-          if (auto it = common_prelude_rewrites_.find(seq->seq[i]);
-              it != common_prelude_rewrites_.end()) {
-            new_seq.push_back(it->second);
+          if (auto it = rewriter_->common_prelude_rewrites_.find(op->seq[i]);
+              it != rewriter_->common_prelude_rewrites_.end()) {
+            new_seq->push_back(it->second);
           } else {
-            new_seq.push_back(seq->seq[i]);
+            new_seq->push_back(op->seq[i]);
           }
           break;
         }
       }
-      // Replace the pipeline loop itself.
-      ReplaceResult result = ReplacePipelineLoopInStmt(
-          seq->seq[loop_idx], pipeline_loop, ws_body, consumer_extent);
-      new_seq.push_back(result.stmt);
-      // Guard post-loop siblings.
-      for (int i = loop_idx + 1; i < static_cast<int>(seq->seq.size()); ++i) {
-        new_seq.push_back(GuardConsumerOnly(seq->seq[i], consumer_extent));
-      }
-      return {new_seq.size() == 1 ? new_seq[0] : SeqStmt(new_seq), true};
     }
-    if (auto *realize = stmt.as<SBlockRealizeNode>()) {
-      ReplaceResult result = ReplacePipelineLoopInStmt(
-          realize->block->body, pipeline_loop, ws_body, consumer_extent);
-      if (!result.found) {
-        return {stmt, false};
-      }
-      SBlock block = realize->block;
-      block.CopyOnWrite()->body = result.stmt;
-      SBlockRealize new_realize = GetRef<SBlockRealize>(realize);
-      new_realize.CopyOnWrite()->block = block;
-      return {new_realize, true};
-    }
-    if (auto *block = stmt.as<SBlockNode>()) {
-      ReplaceResult result = ReplacePipelineLoopInStmt(
-          block->body, pipeline_loop, ws_body, consumer_extent);
-      if (!result.found) {
-        return {stmt, false};
-      }
-      SBlock new_block = GetRef<SBlock>(block);
-      new_block.CopyOnWrite()->body = result.stmt;
-      return {new_block, true};
-    }
-    if (auto *attr = stmt.as<AttrStmtNode>()) {
-      ReplaceResult result = ReplacePipelineLoopInStmt(
-          attr->body, pipeline_loop, ws_body, consumer_extent);
-      if (!result.found) {
-        return {stmt, false};
-      }
-      AttrStmt new_attr = GetRef<AttrStmt>(attr);
-      new_attr.CopyOnWrite()->body = result.stmt;
-      return {new_attr, true};
-    }
-    if (auto *if_stmt = stmt.as<IfThenElseNode>()) {
-      ReplaceResult then_result = ReplacePipelineLoopInStmt(
-          if_stmt->then_case, pipeline_loop, ws_body, consumer_extent);
-      Optional<Stmt> new_else = if_stmt->else_case;
-      bool found = then_result.found;
-      if (!found && if_stmt->else_case.defined()) {
-        ReplaceResult else_result =
-            ReplacePipelineLoopInStmt(if_stmt->else_case.value(), pipeline_loop,
-                                      ws_body, consumer_extent);
-        if (else_result.found) {
-          new_else = else_result.stmt;
-          found = true;
-        }
-      }
-      if (!found) {
-        return {stmt, false};
-      }
-      Stmt new_then = then_result.found ? then_result.stmt : if_stmt->then_case;
-      return {IfThenElse(if_stmt->condition, new_then, new_else, if_stmt->span),
-              true};
-    }
-    return {stmt, false};
+
+    ProducerConsumerWSRewriter *rewriter_;
+    For pipeline_loop_;
+    Stmt ws_body_;
+    PrimExpr consumer_extent_;
+  };
+
+  Optional<Stmt> ReplacePipelineLoopInStmt(const Stmt &stmt,
+                                           const For &pipeline_loop,
+                                           const Stmt &ws_body,
+                                           PrimExpr consumer_extent) {
+    PipelineLoopInStmtReplacer replacer(this, pipeline_loop, ws_body,
+                                        consumer_extent);
+    return replacer(stmt);
   }
 
   // --- PCThreadIdxRewriter (simplified for tile-op level) ---


### PR DESCRIPTION
## Summary

- Replace several hand-written recursive `as<Node>()` / if-dispatch helpers with typed `StmtFunctor` traversal helpers.
- Make pipeline and producer-consumer transform utilities use more direct returned-result patterns instead of out-params and `{stmt, found}` structs.
- Keep traversal scope explicit for wrapper-only searches while improving maintainability of the transform code.

## Changes

- Refactor prelude collection, simple wrapper call extraction, pipeline loop replacement, and pipeline loop lookup in `producer_consumer_ws.cc`.
- Refactor pipeline body SeqStmt lookup, SeqStmt flattening, and body wrapper rebuilding in `pipeline_planning.cc`.
- Refactor wait/commit wrapper analysis and rewrite helpers in `inject_pipeline.cc` to use `StmtFunctor` and `Optional<Stmt>` results.

## Validation

- `clang-format -i src/transform/producer_consumer_ws.cc src/transform/pipeline_planning.cc src/transform/inject_pipeline.cc`
- `git diff --check`
- `cmake --build build -j16`
- `./format.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal software-pipeline wait synchronization logic for improved clarity in boundary detection and rewrite operations.
  * Refactored loop-body handling in pipeline planning with simplified traversal and reconstruction patterns.
  * Updated producer/consumer warp-specialization transformation with consistent statement extraction and containment checking mechanisms.
  * All changes maintain existing compilation behavior with improved code organization and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2231?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->