### PR TITLE
[Transform] Preserve bind scope when splitting if statements

### DIFF
--- a/src/transform/if_stmt_binding.cc
+++ b/src/transform/if_stmt_binding.cc
@@ -39,16 +39,35 @@ private:
     ICHECK(then_case.defined()) << "then_case must be defined";
     ICHECK(!else_case.defined()) << "else_case must be undefined";
 
-    auto bind_if_stmt = [](const Optional<Stmt> &body,
-                           const PrimExpr &condition) -> Stmt {
+    auto make_seq = [](Array<Stmt> seq) -> Stmt {
+      ICHECK(!seq.empty());
+      return seq.size() == 1 ? seq[0] : SeqStmt(std::move(seq));
+    };
+
+    auto bind_if_stmt = [&make_seq](const Optional<Stmt> &body,
+                                    const PrimExpr &condition) -> Stmt {
       if (body.defined()) {
         auto stmt = body.value();
         if (auto seq_stmt = stmt.as<SeqStmtNode>()) {
-          Array<Stmt> seq_;
-          for (auto s : seq_stmt->seq) {
-            seq_.push_back(IfThenElse(condition, s, Stmt()));
+          Array<Stmt> seq;
+          const size_t n = seq_stmt->seq.size();
+          size_t i = 0;
+          for (; i < n && !seq_stmt->seq[i].as<BindNode>(); ++i) {
+            seq.push_back(IfThenElse(condition, seq_stmt->seq[i], Stmt()));
           }
-          return SeqStmt(std::move(seq_));
+
+          // A direct Bind is emitted as a C/CUDA declaration. Keep it and the
+          // following statements in one lexical block, matching old LetStmt
+          // scope semantics.
+          if (i < n) {
+            Array<Stmt> bind_scope;
+            for (; i < n; ++i) {
+              bind_scope.push_back(seq_stmt->seq[i]);
+            }
+            seq.push_back(
+                IfThenElse(condition, make_seq(std::move(bind_scope)), Stmt()));
+          }
+          return make_seq(std::move(seq));
         } else {
           return IfThenElse(condition, stmt, Stmt());
         }

--- a/testing/python/transform/test_tilelang_transform_if_stmt_binding.py
+++ b/testing/python/transform/test_tilelang_transform_if_stmt_binding.py
@@ -1,0 +1,53 @@
+from tilelang import tvm as tvm
+import tilelang
+import tilelang.testing
+from tvm.script import tirx as T
+
+
+def _run_if_stmt_binding(func):
+    mod = tvm.IRModule({"main": func})
+    return tilelang.transform.IfStmtBinding()(mod)["main"]
+
+
+def test_if_stmt_binding_splits_plain_seq_stmt():
+    @T.prim_func
+    def before(A: T.Buffer((4,), "float32")):
+        if A[0] >= T.float32(0):
+            A[0] = T.float32(1)
+            A[1] = T.float32(2)
+
+    @T.prim_func
+    def expected(A: T.Buffer((4,), "float32")):
+        if A[0] >= T.float32(0):
+            A[0] = T.float32(1)
+        if A[0] >= T.float32(0):
+            A[1] = T.float32(2)
+
+    after = _run_if_stmt_binding(before)
+    tvm.ir.assert_structural_equal(after.body, expected.body, True)
+
+
+def test_if_stmt_binding_keeps_direct_bind_scope():
+    @T.prim_func
+    def before(A: T.Buffer((4,), "float32"), B: T.Buffer((4,), "float32")):
+        if A[0] >= T.float32(0):
+            A[0] = T.float32(1)
+            bound = T.bind(A[1] + T.float32(2))
+            B[0] = bound
+            B[1] = bound + T.float32(1)
+
+    @T.prim_func
+    def expected(A: T.Buffer((4,), "float32"), B: T.Buffer((4,), "float32")):
+        if A[0] >= T.float32(0):
+            A[0] = T.float32(1)
+        if A[0] >= T.float32(0):
+            bound = T.bind(A[1] + T.float32(2))
+            B[0] = bound
+            B[1] = bound + T.float32(1)
+
+    after = _run_if_stmt_binding(before)
+    tvm.ir.assert_structural_equal(after.body, expected.body, True)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

- Preserve lexical scope for direct `Bind` statements when `IfStmtBinding` distributes a guard over a `SeqStmt`.
- Prevent the pass from moving a direct binding into a separate guarded block from statements that use it.
- Add transform-level before/after tests for both the normal splitting behavior and the direct-bind lexical-scope case.

## Changes

- Split guarded sequences only up to the first direct `Bind`.
- Keep the first direct `Bind` and following statements under one `IfThenElse` to match the old `LetStmt` scope behavior.
- Add structural `IfStmtBinding` regression tests under `testing/python/transform` instead of relying on CUDA codegen failure.

## Validation

- `pre-commit run --all-files`
- `cmake --build build -j$(nproc)`
- `python -m pytest testing/python/transform/test_tilelang_transform_if_stmt_binding.py -q`
- `python -m pytest testing/python/language/test_tilelang_language_ptr.py -x`
- `python /nfs-df/prod/data/permanent/wanglei/tilelang/debug/0520_bug/fused_hc_multilayer_recompute.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve lexical scoping of declarations inside conditional bodies when sequences are split into separate conditional branches, ensuring bound variables remain in the intended scope.

* **Tests**
  * Added tests that verify sequence-splitting in conditionals and that direct-bind scopes are preserved after the transform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2232?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->