### PR TITLE
[Transform] Preserve WS prelude liveness ordering

### DIFF
--- a/src/transform/producer_consumer_ws.cc
+++ b/src/transform/producer_consumer_ws.cc
@@ -2349,12 +2349,18 @@ private:
         return Optional<Stmt>();
       }
 
-      PropagatePreludeLiveness(op, loop_idx);
-      AppendClassifiedPrelude(op, loop_idx, &new_seq);
-
       Optional<Stmt> rewritten_loop = VisitStmt(op->seq[loop_idx]);
       ICHECK(rewritten_loop.defined())
           << "ProducerConsumerWS: failed to replace pipeline loop child";
+
+      // Rewrite the child containing the pipeline loop before classifying this
+      // level's prelude.  The recursive rewrite propagates liveness from
+      // nested post-loop consumers, which outer prelude BindNodes need in
+      // order to stay shared when they feed both pre-loop shared work and the
+      // producer/consumer branches.
+      PropagatePreludeLiveness(op, loop_idx);
+      AppendClassifiedPrelude(op, loop_idx, &new_seq);
+
       new_seq.push_back(rewritten_loop.value());
 
       for (int i = loop_idx + 1; i < static_cast<int>(op->seq.size()); ++i) {

--- a/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
+++ b/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
@@ -145,6 +145,37 @@ def prelude_tma_bound_index(block=64, iters=2, dtype="float16", threads=128):
     return main
 
 
+def guarded_prelude_tma_postloop_scalar(block=64, iters=2, dtype="float16", threads=128):
+    """Nested guarded pipeline whose post-loop consumer uses a prelude scalar."""
+
+    @T.prim_func
+    def main(
+        Q: T.Buffer((iters * block * 2, block), dtype),
+        K: T.Buffer((iters * block * 2, block), dtype),
+        LSE: T.Buffer((block * 2, block), dtype),
+        idx: T.Buffer((1,), "int32"),
+        O: T.Buffer((block, block), dtype),
+    ):
+        with T.Kernel(1, threads=threads) as _:
+            Q_shared = T.alloc_shared((block, block), dtype)
+            K_shared = T.alloc_shared((block, block), dtype)
+            LSE_shared = T.alloc_shared((block, block), dtype)
+            acc = T.alloc_fragment((block, block), "float32")
+
+            base = idx[0]
+            T.clear(acc)
+            if base < block:
+                T.copy(LSE[base, 0], LSE_shared)
+                for ko in T.Pipelined(iters, num_stages=2):
+                    T.copy(Q[ko * block + base, 0], Q_shared)
+                    T.copy(K[ko * block + base, 0], K_shared)
+                    T.gemm(Q_shared, K_shared, acc, transpose_B=True, policy=T.GemmWarpPolicy.FullRow)
+                for i, j in T.Parallel(block, block):
+                    O[i, j] = acc[i, j] + LSE_shared[i, j] + T.cast(base, "float32")
+
+    return main
+
+
 def explicit_cp_async_wait_position(iters=4, block=16, cp_elems=8, dtype="float16", threads=128):
     """A mixed TMA + explicit cp.async pipeline with cp.async consumed first."""
 
@@ -526,6 +557,26 @@ def test_tiled_ws_keeps_preloop_tma_scalar_bind_shared():
     branch = _find_after(src, "if (128 <= ((int)threadIdx.x))")
 
     assert start_bind < k_load < branch
+
+
+def test_tiled_ws_propagates_nested_postloop_liveness_to_outer_prelude():
+    """Outer scalar binds used by nested post-loop consumers must stay shared."""
+
+    func = guarded_prelude_tma_postloop_scalar().with_attr("global_symbol", "main")
+    mod = tvm.IRModule.from_expr(func)
+    target = determine_target({"kind": "cuda", "arch": "sm_90"}, return_object=True)
+    mod = tvm.tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.ProducerConsumerWarpSpecialized()(mod)
+    script = mod["main"].script()
+
+    assert "tl_tiled_ws_applied" in script
+    shared_base = _find_after(script, "base: T.int32 = idx[0]")
+    guard = _find_after(script, "if base < 64:")
+    branch = _find_after(script, 'T.attr([128, 128], "kWarpSpecializationScope", 0)')
+    producer_base = script.find("base = idx[0]", branch)
+
+    assert shared_base < guard < branch
+    assert producer_base < 0
 
 
 @tilelang.testing.requires_cuda


### PR DESCRIPTION
## Summary

- Fix tiled producer/consumer WS prelude classification so nested post-loop consumer liveness is available before outer prelude statements are moved.
- Prevent shared scalar binds used by guarded TMA prelude work and consumer post-loop stores from being sunk into producer-only branches.

## Changes

- Reorder `PipelineLoopInStmtReplacer` to recursively rewrite the child containing the pipeline loop before classifying the current `SeqStmt` prelude.
- Add a regression test covering guarded prelude TMA work with a nested pipelined loop and post-loop consumer scalar use.

## Validation

- `cmake --build build -j$(nproc)`
- `python /nfs-df/prod/data/permanent/wanglei/tilelang/debug/0520_bug/softmax_sum.py`
- `pre-commit run --all-files`
- `python -m pytest testing/python/transform/test_tilelang_transform_producer_consumer_ws.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed control flow ordering in producer-consumer warp specialization transformation to correctly handle nested pipeline loops and post-loop consumer liveness tracking.

* **Tests**
  * Added test case for nested pipelined producer loops with post-loop consumer scenarios in warp specialization, ensuring proper liveness propagation and guard ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2233?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->