### PR TITLE
[Pipeline] Replay scalar binds in pipelined stages

### DIFF
--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -711,6 +711,7 @@ public:
     for (const auto &[block, anno] : pipeline_info_) {
       ordered_stmts_.Set(anno.order, block);
     }
+    CollectScalarBindings();
 
     // Step 2: Emit the pipeline prologue, body and epilogue.
     Optional<Integer> pipeline_num_stages =
@@ -770,6 +771,127 @@ public:
   const Map<Buffer, Buffer> &GetBufferRemap() const { return buffer_remap_; }
 
 private:
+  struct ScalarBinding {
+    Var var;
+    PrimExpr value;
+    Span span;
+  };
+
+  using ScalarBindingMap =
+      std::unordered_map<Var, size_t, ObjectPtrHash, ObjectPtrEqual>;
+
+  void CollectScalarBindings() {
+    scalar_bindings_.clear();
+    scalar_binding_map_.clear();
+    for (const SBlock &block : ordered_stmts_) {
+      if (const auto *bind = block->body.as<BindNode>()) {
+        if (!scalar_binding_map_.count(bind->var)) {
+          scalar_binding_map_.emplace(bind->var, scalar_bindings_.size());
+          scalar_bindings_.push_back({bind->var, bind->value, bind->span});
+        }
+      }
+    }
+  }
+
+  VarSet FindScalarBindingUses(const Array<Var> &undefined_vars) const {
+    VarSet uses;
+    for (const Var &var : undefined_vars) {
+      if (scalar_binding_map_.count(var)) {
+        uses.insert(var);
+      }
+    }
+    return uses;
+  }
+
+  VarSet FindScalarBindingUses(const Stmt &stmt) const {
+    return FindScalarBindingUses(UndefinedVars(stmt, Array<Var>{}));
+  }
+
+  VarSet FindScalarBindingUses(const PrimExpr &expr) const {
+    return FindScalarBindingUses(UndefinedVars(expr));
+  }
+
+  void AppendScalarBinding(size_t binding_index, VarSet *emitted,
+                           VarSet *visiting,
+                           std::vector<size_t> *binding_indices) const {
+    const ScalarBinding &binding = scalar_bindings_[binding_index];
+    if (emitted->count(binding.var)) {
+      return;
+    }
+    ICHECK(!visiting->count(binding.var))
+        << "InjectSoftwarePipeline: cyclic scalar Bind dependency involving "
+        << binding.var;
+
+    visiting->insert(binding.var);
+    VarSet deps = FindScalarBindingUses(binding.value);
+    for (const ScalarBinding &candidate : scalar_bindings_) {
+      if (!deps.count(candidate.var)) {
+        continue;
+      }
+      auto it = scalar_binding_map_.find(candidate.var);
+      ICHECK(it != scalar_binding_map_.end());
+      AppendScalarBinding(it->second, emitted, visiting, binding_indices);
+    }
+    visiting->erase(binding.var);
+
+    emitted->insert(binding.var);
+    binding_indices->push_back(binding_index);
+  }
+
+  std::vector<size_t> RequiredScalarBindings(const Stmt &stmt) const {
+    std::vector<size_t> binding_indices;
+    if (scalar_bindings_.empty()) {
+      return binding_indices;
+    }
+
+    VarSet uses = FindScalarBindingUses(stmt);
+    if (uses.empty()) {
+      return binding_indices;
+    }
+
+    VarSet emitted;
+    VarSet visiting;
+    for (const ScalarBinding &binding : scalar_bindings_) {
+      if (!uses.count(binding.var)) {
+        continue;
+      }
+      auto it = scalar_binding_map_.find(binding.var);
+      ICHECK(it != scalar_binding_map_.end());
+      AppendScalarBinding(it->second, &emitted, &visiting, &binding_indices);
+    }
+    return binding_indices;
+  }
+
+  Stmt RewriteScalarBindingForAccess(size_t binding_index,
+                                     const PrimExpr &access_index) {
+    const ScalarBinding &binding = scalar_bindings_[binding_index];
+    Stmt bind = Bind(binding.var, binding.value, binding.span);
+    bind = PipelineBodyRewriter(buffer_data_to_buffer_, buffer_remap_,
+                                pipeline_loop_, max_stage_ != 1)(bind);
+    bind = Substitute(bind, {{pipeline_loop_->loop_var, access_index}});
+    return bind;
+  }
+
+  SBlock ReplayScalarBindings(SBlock block, const PrimExpr &access_index) {
+    std::vector<size_t> binding_indices = RequiredScalarBindings(block->body);
+    if (binding_indices.empty()) {
+      return block;
+    }
+
+    Array<Stmt> seq;
+    for (size_t binding_index : binding_indices) {
+      seq.push_back(RewriteScalarBindingForAccess(binding_index, access_index));
+    }
+    for (const Stmt &stmt : FlattenTopLevelSeq(block->body)) {
+      seq.push_back(stmt);
+    }
+
+    SBlockNode *n = block.CopyOnWrite();
+    n->body = SeqStmt(seq);
+    return MakeBlock(SBlockRealize({}, Bool(true), block),
+                     buffer_data_to_buffer_);
+  }
+
   /*!
    * \brief Analyze accesses to the buffers in the software pipeline.
    *
@@ -2227,6 +2349,9 @@ private:
     BufferCommitGroupMap buffer_to_commit_group;
 
     for (const SBlock &block : ordered_stmts_) {
+      if (block->body.as<BindNode>()) {
+        continue;
+      }
       const auto &pipeline_anno = pipeline_info_.at(block);
       int stage = pipeline_anno.stage;
       PrimExpr inbound = Bool(true);
@@ -2259,6 +2384,7 @@ private:
       }
       new_block = Downcast<SBlock>(Substitute(
           new_block, {{pipeline_loop_->loop_var, normalized_access_index}}));
+      new_block = ReplayScalarBindings(new_block, normalized_access_index);
 
       Stmt rewritten_stmt = SBlockRealize({}, inbound, new_block);
       rewritten_stmt = WrapLoopDependentWrappers(std::move(rewritten_stmt),
@@ -2399,6 +2525,8 @@ private:
   Map<Buffer, Buffer> buffer_remap_;
   Optional<Target> target_;
   Array<SBlock> ordered_stmts_;
+  std::vector<ScalarBinding> scalar_bindings_;
+  ScalarBindingMap scalar_binding_map_;
   std::vector<IfWrapper> loop_var_if_wrappers_;
   std::map<int, AsyncStateGlobal> async_states_;
 };

--- a/testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py
+++ b/testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py
@@ -512,5 +512,52 @@ def test_inject_software_pipeline_expands_annotated_layout():
     assert layout_map[shared.data].is_equal(layout.expand([2]))
 
 
+def test_inject_software_pipeline_replays_scalar_bind_per_stage_use():
+    @T.prim_func
+    def before(A: T.Tensor((128,), T.float32), B: T.Tensor((128,), T.float32)):
+        shared = T.alloc_buffer((16,), dtype=T.float32, scope="shared")
+        for tx in T.thread_binding(0, 16, thread="threadIdx.x"):
+            for i in T.serial(
+                0,
+                4,
+                annotations={
+                    "software_pipeline_stage": [0, 0, 1],
+                    "software_pipeline_order": [1, 2, 0],
+                    "software_pipeline_async_stages": [0],
+                    "software_pipeline_async_producers": [0, 1, 0],
+                    "software_pipeline_async_producer_groups": [-1, 0, -1],
+                },
+            ):
+                base: T.int32 = i * 16
+                with T.sblock("copy"):
+                    T.reads(A[base + tx])
+                    T.writes(shared[tx])
+                    shared[tx] = A[base + tx]
+                with T.sblock("store"):
+                    T.reads(shared[tx])
+                    T.writes(B[base + tx])
+                    B[base + tx] = shared[tx]
+
+    mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
+    mod = tl.transform.InjectSoftwarePipeline()(mod)
+
+    leading_bind_blocks = {"copy": 0, "store": 0}
+
+    def _visit(node):
+        if not isinstance(node, tvm.tirx.SBlock) or str(node.name_hint) not in leading_bind_blocks:
+            return
+        body = node.body
+        assert isinstance(body, tvm.tirx.SeqStmt), f"{node.name_hint} body should start with scalar Bind"
+        assert isinstance(body.seq[0], tvm.tirx.Bind), f"{node.name_hint} body should start with scalar Bind"
+        assert str(body.seq[0].var.name).startswith("base")
+        leading_bind_blocks[str(node.name_hint)] += 1
+
+    post_order_visit(mod["main"].body, _visit)
+
+    assert leading_bind_blocks["copy"] > 0
+    assert leading_bind_blocks["store"] > 0
+    assert "base = T.int32()" not in mod["main"].script()
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Summary

- Fix software pipeline injection for flat scalar `Bind` statements that are used by multiple pipelined stages.
- Prevent generated CUDA from referencing scalar temporaries outside their lexical scope after pipeline prologue, body, and epilogue rewriting.
- Add a transform regression that checks scalar binds are replayed into each stage block that uses them.

## Changes

- Collect scalar `Bind` statements from the ordered pipeline body before emitting the rewritten pipeline.
- Skip standalone scalar `Bind` blocks as executable pipeline stages, and replay the required bindings at the start of each consumer block using that block's normalized access index.
- Preserve dependency ordering among scalar bindings so bindings that depend on earlier scalar bindings are replayed first.
- Cover the failure mode with a regression where a scalar index is consumed by both copy and store stages.

## Validation

- `pre-commit run --all-files`
- `cmake --build build -j$(nproc)`
- `python -m pytest testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py -q`
- `python /nfs-df/prod/data/permanent/wanglei/tilelang/debug/0520_bug/mqa_index_distill_mlp_dynamic.py > /tmp/tilelang_mqa_index_distill_dynamic_restore.log 2>&1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure scalar bindings are correctly replayed per pipeline stage so stage-local scalar values are preserved and emitted where used across software-pipelined loops.

* **Tests**
  * Added regression test verifying per-stage scalar binding replay in the software-pipeline transformation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->