### PR TITLE
[BugFix] Fix SM90 WGMMA B_type typo and update SM75 kNPerWarp

### DIFF
--- a/src/backend/cuda/op/gemm.cc
+++ b/src/backend/cuda/op/gemm.cc
@@ -299,8 +299,7 @@ struct Gemm {
     if (gemm_inst == kCudaWGMMA) {
       return ComputeWgmmaWarpPartition(policy, M, N, num_warps);
     }
-    int k_n_per_warp =
-        (TargetIsVolta(target) || TargetIsTuring(target)) ? 16 : 8;
+    int k_n_per_warp = TargetIsVolta(target) ? 16 : 8;
     return ComputeDefaultWarpPartition(policy, M, N, num_warps, k_n_per_warp);
   }
 

--- a/src/tl_templates/cuda/gemm_sm90.h
+++ b/src/tl_templates/cuda/gemm_sm90.h
@@ -26,7 +26,7 @@ public:
   using A_type = conditional_t<std::is_same<A_type_cute, float>::value,
                                tfloat32_t, A_type_cute>;
   using B_type = conditional_t<std::is_same<B_type_cute, float>::value,
-                               tfloat32_t, A_type_cute>;
+                               tfloat32_t, B_type_cute>;
   using C_type = C_type_raw;
 
   static constexpr GMMA::Major GmmaMajorA =


### PR DESCRIPTION
## Summary

* Fix SM90 WGMMA `B_type` alias copy-paste typo in `src/tl_templates/cuda/gemm_sm90.h`
* Update SM75 `kNPerWarp` from 16 to 8 in `src/backend/cuda/op/gemm.cc` (follow-up to #2198)

## Why

* `gemm_sm90.h`: `B_type` fallback incorrectly used `A_type_cute` instead of `B_type_cute`, which could produce incorrect types for mixed-precision GEMM (e.g., A=fp8, B=fp16) on SM90.

* `gemm.cc`: In my previous PR #2173, I set `kNPerWarp=16` for Turing because SM75 was routed through the Volta MMA path (`m16n16k4`, `n_dim=16`). After #2198 introduced a native SM75 MMA path (`m16n8k8`, `n_dim=8`) via `GemmMMASm75`, `kNPerWarp` should now be updated to 8 to match the actual instruction shape.

## Tested

* SM75 GEMM tests pass (`test_tilelang_kernel_gemm_sm75.py`: fp16, int8, int4)
* Verified on NVIDIA TITAN RTX (SM75)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type handling in GPU tensor operation template for improved correctness.

* **Performance**
  * Optimized GPU warp scheduling for Volta architecture to enhance computational efficiency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->