### PR TITLE
[Pipeline] Support scalar bind-free pipeline annotations

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,6 +34,7 @@ programming_guides/overview
 programming_guides/language_basics
 programming_guides/instructions
 programming_guides/control_flow
+programming_guides/software_pipeline
 programming_guides/python_compatibility
 programming_guides/autotuning
 programming_guides/type_system

--- a/docs/programming_guides/control_flow.md
+++ b/docs/programming_guides/control_flow.md
@@ -99,6 +99,10 @@ for ko in T.Pipelined(T.ceildiv(K, BK), num_stages=3):
     T.gemm(A_s, B_s, C_f)             # stage: compute
 ```
 
+For manual `stage` / `order` annotations and the rule that scalar `Bind`
+statements do not consume annotation slots, see
+[Software Pipeline Annotations](software_pipeline.md).
+
 ### Persistent (advanced)
 
 `T.Persistent(domain, wave_size, index, group_size=...)` exposes persistent

--- a/docs/programming_guides/overview.md
+++ b/docs/programming_guides/overview.md
@@ -5,20 +5,23 @@ It mirrors the structure of a similar guide in another project and adapts it to 
 
 - Audience: Developers implementing custom GPU/CPU kernels with tile‑lang
 - Prereqs: Basic Python, NumPy/Tensor concepts, and familiarity with GPU programming notions
-- Scope: Language basics, control flow, instructions, autotuning, and type system
+- Scope: Language basics, control flow, instructions, software pipelining,
+  autotuning, and type system
 
 ## What You’ll Learn
 - How to structure kernels with TileLang’s core DSL constructs
 - How to move data across global/shared/fragment and pipeline compute
+- How to use manual software-pipeline annotations when inference is not enough
 - How to apply autotuning to tile sizes and schedules
 - How to specify and work with dtypes in kernels
 
 ## Suggested Reading Order
 1. Language Basics
 2. Control Flow
-3. Instructions
-4. Autotuning
-5. Type System
+3. Software Pipeline Annotations
+4. Instructions
+5. Autotuning
+6. Type System
 
 ## Related Docs
 - Tutorials: see existing guides in `tutorials/`

--- a/docs/programming_guides/software_pipeline.md
+++ b/docs/programming_guides/software_pipeline.md
@@ -54,7 +54,6 @@ copy statements in stage 0 and compute statements in stage 1:
 ```python
 for ko in T.Pipelined(
     T.ceildiv(K, BK),
-    num_stages=3,
     stage=[0, 0, 1],
     order=[0, 1, 2],
 ):
@@ -81,9 +80,10 @@ after the consumer. In practice:
 - If they are in different stages, producer stage must be less than or equal to
   consumer stage.
 
-`num_stages` controls the pipeline depth, namely the number of in-flight buffer
-versions retained by the rewritten loop. It is separate from the largest
-`stage` value, although common kernels use small stage numbers such as 0 and 1.
+When `stage` and `order` are provided manually, do not also set `num_stages` in
+normal code. The pipeline depth is inferred from the stage list as
+`max(stage) + 1`. Use `num_stages` by itself for compiler-inferred pipelines,
+and use `stage` / `order` by themselves for manually scheduled pipelines.
 
 ## Annotating a Reordered Pipeline
 
@@ -93,7 +93,6 @@ producer before a current-iteration consumer.
 ```python
 for ko in T.Pipelined(
     num_tiles,
-    num_stages=2,
     stage=[0, 1],
     order=[1, 0],
 ):
@@ -121,7 +120,6 @@ A scalar `Bind` may appear as a statement in the loop body:
 ```python
 for ko in T.Pipelined(
     num_tiles,
-    num_stages=2,
     stage=[0, 1],
     order=[1, 0],
 ):
@@ -143,7 +141,6 @@ For example:
 ```python
 for ko in T.Pipelined(
     num_tiles,
-    num_stages=2,
     stage=[0, 1],
     order=[1, 0],
 ):
@@ -196,7 +193,6 @@ Older code may include scalar `Bind` statements in the annotation arrays:
 ```python
 for ko in T.Pipelined(
     num_tiles,
-    num_stages=2,
     stage=[3, 0, 1],
     order=[1, 2, 0],
 ):

--- a/docs/programming_guides/software_pipeline.md
+++ b/docs/programming_guides/software_pipeline.md
@@ -13,8 +13,8 @@ for ko in T.Pipelined(T.ceildiv(K, BK), num_stages=3):
 
 For kernels whose loop body has unusual ordering, extra post-processing, or
 manual async-copy grouping, you can provide explicit pipeline annotations. This
-guide explains how to write those annotations and why scalar `Bind` statements
-are not part of the user-visible schedule.
+guide explains how to write those annotations and why replayable scalar `Bind`
+statements are not part of the user-visible schedule.
 
 ## The User Model
 
@@ -31,15 +31,15 @@ Annotate the statements that do work:
 - explicit waits, commits, or synchronization statements when they are part of
   the manual pipeline
 
-Do not annotate scalar aliases:
+Do not annotate replayable scalar aliases:
 
 ```python
 base: T.int32 = ko * BK
 offset: T.int32 = base + tx
 ```
 
-These scalar `Bind` statements are pure value definitions. The compiler places
-them automatically at each use.
+These `Bind` statements are value definitions, not materialized storage. The
+compiler places them automatically at each use.
 
 ## Stage and Order
 
@@ -113,9 +113,9 @@ order still determines which annotation entry belongs to which scheduled
 statement; `order` controls the emission order after the statements have been
 classified.
 
-## Scalar Bind Statements
+## Replayable Scalar Bind Statements
 
-A scalar `Bind` may appear as a statement in the loop body:
+A replayable scalar `Bind` may appear as a statement in the loop body:
 
 ```python
 for ko in T.Pipelined(
@@ -129,9 +129,9 @@ for ko in T.Pipelined(
 ```
 
 The `stage` and `order` arrays contain two entries, not three. They annotate the
-copy and the GEMM. The scalar `base` definition is intentionally omitted.
+copy and the GEMM. The `base` definition is intentionally omitted.
 
-This rule matters because a scalar `Bind` does not have a unique pipeline
+This rule matters because a replayable `Bind` does not have a unique pipeline
 position. It is closer to an SSA value or a local alias than to an executable
 operation. If the same scalar is used by statements in different stages, each
 consumer may need the value under a different logical pipeline iteration.
@@ -154,20 +154,62 @@ iteration while the store needs `base` for the current consumer iteration. A
 single user-selected stage/order for `base` would either be out of scope or
 would describe the wrong logical iteration for one of the uses.
 
-TileLang therefore treats scalar `Bind` as non-schedulable:
+TileLang therefore treats replayable scalar `Bind` as non-schedulable:
 
 ```text
 stage/order annotate only scheduled, effectful statements
-scalar Bind definitions are replayed at each consumer
+replayable Bind definitions are replayed at each consumer
 ```
 
 The replay is use-driven. If a consumer statement references a scalar bound in
 the pipeline body, the compiler recreates the needed `Bind` immediately before
 that consumer and substitutes the consumer's logical access index.
 
+A replayable scalar `Bind` may contain a read from a buffer that is not written
+inside the pipeline body:
+
+```python
+idx: T.int32 = Ids[ko]
+T.copy(A[idx], A_shared)
+B[idx] = A_shared[0]
+```
+
+Here `idx` is still a value alias. If both scheduled statements use it, TileLang
+replays `idx = Ids[logical_ko]` for each consumer. This may duplicate the load
+from `Ids`, but it preserves the alias semantics of `Bind`: the value is
+computed at the consumer's logical pipeline iteration.
+
+This is different from a materialized producer:
+
+```python
+idx_shared[tx] = Ids[ko]
+T.copy(A[idx_shared[tx]], A_shared)
+B[idx_shared[tx]] = A_shared[0]
+```
+
+The store to `idx_shared` creates storage and a real producer/consumer
+dependency. It should be counted as a scheduled statement and, when needed,
+versioned like other pipeline buffers.
+
+If a `Bind` reads a buffer that is written inside the same pipeline body, it is
+not treated as replayable:
+
+```python
+T.copy(A[ko * BK], A_shared)
+value: T.float32 = A_shared[tx]
+C[ko * BK + tx] = value
+```
+
+The load from `A_shared` depends on a pipeline producer. TileLang keeps this
+`Bind` in the scheduled statement list, so it needs a `stage` and `order` entry.
+Because a scalar `Bind` has no storage versioning, a scheduled `Bind` must be in
+the same stage as every consumer that uses its value. If the intended semantics
+are "load once and share across later stages", materialize the value explicitly
+with a buffer/register write instead of relying on `Bind` replay.
+
 ## Bind Dependencies
 
-Scalar binds can depend on earlier scalar binds:
+Replayable binds can depend on earlier replayable binds:
 
 ```python
 base: T.int32 = ko * BK
@@ -188,7 +230,8 @@ preserving the lexical scalar dependencies from the original loop body.
 
 ## Legacy Annotation Form
 
-Older code may include scalar `Bind` statements in the annotation arrays:
+Older code may include replayable scalar `Bind` statements in the annotation
+arrays:
 
 ```python
 for ko in T.Pipelined(
@@ -210,10 +253,10 @@ copy      -> stage 0, order 2
 store     -> stage 1, order 0
 ```
 
-When a legacy scalar `Bind` annotation is used by multiple scheduled statements,
-TileLang may warn that the scalar annotation is ignored and the bind is replayed
-at each use. New code should prefer the shorter annotation arrays that omit
-scalar binds entirely.
+When a legacy replayable scalar `Bind` annotation is used by multiple scheduled
+statements, TileLang may warn that the scalar annotation is ignored and the bind
+is replayed at each use. New code should prefer the shorter annotation arrays
+that omit replayable scalar binds entirely.
 
 ## Manual `T.serial` Annotations
 
@@ -236,8 +279,8 @@ for ko in T.serial(
 ```
 
 The same rule applies: `software_pipeline_stage` and
-`software_pipeline_order` describe only scheduled statements. Scalar `Bind`
-statements do not need entries.
+`software_pipeline_order` describe only scheduled statements. Replayable scalar
+`Bind` statements do not need entries.
 
 ## Design Rationale
 
@@ -245,7 +288,7 @@ The pipeline pass separates the loop body into two concepts:
 
 ```text
 scheduled statements: executable operations controlled by stage/order
-scalar bindings: pure local definitions placed by use-def analysis
+replayable scalar bindings: local value aliases placed by use-def analysis
 ```
 
 This split keeps the API stable for users and avoids ambiguous schedules. A
@@ -253,7 +296,7 @@ real pipeline operation has a clear execution point, can read or write buffers,
 and may require async-copy bookkeeping or synchronization. It is appropriate for
 the user to assign a stage and order to that operation.
 
-A scalar `Bind` has none of those properties:
+A replayable scalar `Bind` has none of those properties:
 
 - It has no side effect.
 - It owns no buffer storage.
@@ -262,7 +305,7 @@ A scalar `Bind` has none of those properties:
 
 Forcing users to annotate such a statement would require them to choose one
 stage/order even when there is no single correct answer. Replaying scalar binds
-at each consumer makes the intended semantics explicit in the generated IR and
+at each consumer makes the alias semantics explicit in the generated IR and
 keeps the user-facing schedule focused on real pipeline work.
 
 ## Checklist
@@ -270,11 +313,14 @@ keeps the user-facing schedule focused on real pipeline work.
 When writing manual pipeline annotations:
 
 - Count only scheduled statements when building `stage` and `order`.
-- Omit scalar aliases such as `base = ko * BK`.
+- Omit replayable scalar aliases such as `base = ko * BK` or
+  `idx = Ids[ko]` when `Ids` is not written in the pipeline.
+- Count a `Bind` as a scheduled statement if it reads a buffer written inside
+  the pipeline body.
 - Keep each scheduled statement's `order` unique.
 - Keep producers before consumers according to stage/order dependency rules.
 - Use `software_pipeline_async_producers` and
   `software_pipeline_async_producer_groups` with the same length as the
   scheduled statement list.
-- Prefer the bind-free form for new code; rely on legacy bind slots only when
-  maintaining old kernels.
+- Prefer the bind-free form for replayable aliases in new code; rely on legacy
+  bind slots only when maintaining old kernels.

--- a/docs/programming_guides/software_pipeline.md
+++ b/docs/programming_guides/software_pipeline.md
@@ -1,0 +1,284 @@
+# Software Pipeline Annotations
+
+TileLang can infer common producer/consumer pipelines from
+`T.Pipelined(..., num_stages=...)`. For regular GEMM-like kernels, this is the
+preferred entry point:
+
+```python
+for ko in T.Pipelined(T.ceildiv(K, BK), num_stages=3):
+    T.copy(A[by * BM, ko * BK], A_shared)
+    T.copy(B[ko * BK, bx * BN], B_shared)
+    T.gemm(A_shared, B_shared, C_local)
+```
+
+For kernels whose loop body has unusual ordering, extra post-processing, or
+manual async-copy grouping, you can provide explicit pipeline annotations. This
+guide explains how to write those annotations and why scalar `Bind` statements
+are not part of the user-visible schedule.
+
+## The User Model
+
+Pipeline annotations describe executable pipeline statements, not every IR node
+inside the loop body.
+
+Annotate the statements that do work:
+
+- copies, including global-to-shared and TMA copies
+- fills
+- GEMM or other tile operations
+- reductions
+- stores and atomics
+- explicit waits, commits, or synchronization statements when they are part of
+  the manual pipeline
+
+Do not annotate scalar aliases:
+
+```python
+base: T.int32 = ko * BK
+offset: T.int32 = base + tx
+```
+
+These scalar `Bind` statements are pure value definitions. The compiler places
+them automatically at each use.
+
+## Stage and Order
+
+Each scheduled statement has two numbers:
+
+- `stage`: the logical pipeline stage.
+- `order`: the order used when emitting scheduled statements.
+
+Lower stages run earlier in the pipeline. A typical copy/compute pipeline has
+copy statements in stage 0 and compute statements in stage 1:
+
+```python
+for ko in T.Pipelined(
+    T.ceildiv(K, BK),
+    num_stages=3,
+    stage=[0, 0, 1],
+    order=[0, 1, 2],
+):
+    T.copy(A[ko * BK], A_shared)
+    T.copy(B[ko * BK], B_shared)
+    T.gemm(A_shared, B_shared, C_local)
+```
+
+The two arrays are aligned to the scheduled statements in source order. In the
+example above:
+
+```text
+statement 0: copy A  -> stage 0, order 0
+statement 1: copy B  -> stage 0, order 1
+statement 2: gemm    -> stage 1, order 2
+```
+
+The compiler checks buffer dependencies after applying the annotations. If one
+scheduled statement produces data for another, the producer must not be placed
+after the consumer. In practice:
+
+- If producer and consumer are in the same stage, producer order must be smaller
+  than consumer order.
+- If they are in different stages, producer stage must be less than or equal to
+  consumer stage.
+
+`num_stages` controls the pipeline depth, namely the number of in-flight buffer
+versions retained by the rewritten loop. It is separate from the largest
+`stage` value, although common kernels use small stage numbers such as 0 and 1.
+
+## Annotating a Reordered Pipeline
+
+The `order` array is useful when the pipeline should issue a future-iteration
+producer before a current-iteration consumer.
+
+```python
+for ko in T.Pipelined(
+    num_tiles,
+    num_stages=2,
+    stage=[0, 1],
+    order=[1, 0],
+):
+    T.copy(A[ko * BK], A_shared)
+    T.gemm(A_shared, B_shared, C_local)
+```
+
+This says there are two scheduled statements:
+
+```text
+copy -> stage 0, order 1
+gemm -> stage 1, order 0
+```
+
+During pipeline rewriting, the compiler emits prologue, steady-state body, and
+epilogue pieces with the proper logical iteration for each stage. The source
+order still determines which annotation entry belongs to which scheduled
+statement; `order` controls the emission order after the statements have been
+classified.
+
+## Scalar Bind Statements
+
+A scalar `Bind` may appear as a statement in the loop body:
+
+```python
+for ko in T.Pipelined(
+    num_tiles,
+    num_stages=2,
+    stage=[0, 1],
+    order=[1, 0],
+):
+    base: T.int32 = ko * BK
+    T.copy(A[base + tx], A_shared[tx])
+    T.gemm(A_shared, B_shared, C_local)
+```
+
+The `stage` and `order` arrays contain two entries, not three. They annotate the
+copy and the GEMM. The scalar `base` definition is intentionally omitted.
+
+This rule matters because a scalar `Bind` does not have a unique pipeline
+position. It is closer to an SSA value or a local alias than to an executable
+operation. If the same scalar is used by statements in different stages, each
+consumer may need the value under a different logical pipeline iteration.
+
+For example:
+
+```python
+for ko in T.Pipelined(
+    num_tiles,
+    num_stages=2,
+    stage=[0, 1],
+    order=[1, 0],
+):
+    base: T.int32 = ko * BK
+    T.copy(A[base + tx], A_shared[tx])
+    B[base + tx] = A_shared[tx]
+```
+
+After pipeline rewriting, the copy may need `base` for a future producer
+iteration while the store needs `base` for the current consumer iteration. A
+single user-selected stage/order for `base` would either be out of scope or
+would describe the wrong logical iteration for one of the uses.
+
+TileLang therefore treats scalar `Bind` as non-schedulable:
+
+```text
+stage/order annotate only scheduled, effectful statements
+scalar Bind definitions are replayed at each consumer
+```
+
+The replay is use-driven. If a consumer statement references a scalar bound in
+the pipeline body, the compiler recreates the needed `Bind` immediately before
+that consumer and substitutes the consumer's logical access index.
+
+## Bind Dependencies
+
+Scalar binds can depend on earlier scalar binds:
+
+```python
+base: T.int32 = ko * BK
+offset: T.int32 = base + tx
+T.copy(A[offset], A_shared[tx])
+```
+
+The compiler replays dependencies before their users:
+
+```text
+base
+offset
+consumer statement
+```
+
+This keeps manual annotations focused on actual pipeline operations while still
+preserving the lexical scalar dependencies from the original loop body.
+
+## Legacy Annotation Form
+
+Older code may include scalar `Bind` statements in the annotation arrays:
+
+```python
+for ko in T.Pipelined(
+    num_tiles,
+    num_stages=2,
+    stage=[3, 0, 1],
+    order=[1, 2, 0],
+):
+    base: T.int32 = ko * BK
+    T.copy(A[base + tx], A_shared[tx])
+    B[base + tx] = A_shared[tx]
+```
+
+This form is accepted for compatibility. The scalar `Bind` entry is ignored,
+and the remaining entries are applied to the scheduled statements:
+
+```text
+base Bind -> ignored
+copy      -> stage 0, order 2
+store     -> stage 1, order 0
+```
+
+When a legacy scalar `Bind` annotation is used by multiple scheduled statements,
+TileLang may warn that the scalar annotation is ignored and the bind is replayed
+at each use. New code should prefer the shorter annotation arrays that omit
+scalar binds entirely.
+
+## Manual `T.serial` Annotations
+
+Most user code should use `T.Pipelined`. Lower-level tests or transform-level
+code may use the raw loop annotations directly:
+
+```python
+for ko in T.serial(
+    0,
+    num_tiles,
+    annotations={
+        "software_pipeline_stage": [0, 1],
+        "software_pipeline_order": [1, 0],
+        "software_pipeline_async_stages": [0],
+    },
+):
+    base: T.int32 = ko * BK
+    T.copy(A[base + tx], A_shared[tx])
+    B[base + tx] = A_shared[tx]
+```
+
+The same rule applies: `software_pipeline_stage` and
+`software_pipeline_order` describe only scheduled statements. Scalar `Bind`
+statements do not need entries.
+
+## Design Rationale
+
+The pipeline pass separates the loop body into two concepts:
+
+```text
+scheduled statements: executable operations controlled by stage/order
+scalar bindings: pure local definitions placed by use-def analysis
+```
+
+This split keeps the API stable for users and avoids ambiguous schedules. A
+real pipeline operation has a clear execution point, can read or write buffers,
+and may require async-copy bookkeeping or synchronization. It is appropriate for
+the user to assign a stage and order to that operation.
+
+A scalar `Bind` has none of those properties:
+
+- It has no side effect.
+- It owns no buffer storage.
+- It can be used by multiple scheduled statements.
+- Its correct value may depend on the consumer's logical pipeline iteration.
+
+Forcing users to annotate such a statement would require them to choose one
+stage/order even when there is no single correct answer. Replaying scalar binds
+at each consumer makes the intended semantics explicit in the generated IR and
+keeps the user-facing schedule focused on real pipeline work.
+
+## Checklist
+
+When writing manual pipeline annotations:
+
+- Count only scheduled statements when building `stage` and `order`.
+- Omit scalar aliases such as `base = ko * BK`.
+- Keep each scheduled statement's `order` unique.
+- Keep producers before consumers according to stage/order dependency rules.
+- Use `software_pipeline_async_producers` and
+  `software_pipeline_async_producer_groups` with the same length as the
+  scheduled statement list.
+- Prefer the bind-free form for new code; rely on legacy bind slots only when
+  maintaining old kernels.

--- a/src/transform/common/pipeline_utils.h
+++ b/src/transform/common/pipeline_utils.h
@@ -45,6 +45,9 @@ static constexpr const char *kPipelineAsyncProducers =
 /*! Per-statement async producer group id (-1 = not an async producer). */
 static constexpr const char *kPipelineAsyncProducerGroups =
     "software_pipeline_async_producer_groups";
+/*! Per-original-statement replayable scalar Bind flag (1 = replayable). */
+static constexpr const char *kPipelineReplayableScalarBinds =
+    "software_pipeline_replayable_scalar_binds";
 
 // ---------------------------------------------------------------------------
 // GetPipelineNumStages

--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -2518,7 +2518,9 @@ private:
             kv.first != s_tir::attr::software_pipeline_async_stages &&
             kv.first != kPipelineAsyncProducers &&
             kv.first != kPipelineAsyncProducerGroups &&
-            kv.first != kPipelineTmaCopies && kv.first != "num_stages") {
+            kv.first != kPipelineTmaCopies &&
+            kv.first != kPipelineReplayableScalarBinds &&
+            kv.first != "num_stages") {
           preserved_annotations.Set(key, kv.second);
         }
       }
@@ -3177,7 +3179,8 @@ private:
           key != s_tir::attr::software_pipeline_async_stages &&
           key != kPipelineAsyncProducers &&
           key != kPipelineAsyncProducerGroups && key != kPipelineTmaCopies &&
-          key != "num_stages" && key != "tl_pipelined_num_stages") {
+          key != kPipelineReplayableScalarBinds && key != "num_stages" &&
+          key != "tl_pipelined_num_stages") {
         preserved_annotations.Set(key, kv.second);
       }
     }
@@ -3423,15 +3426,38 @@ private:
     BufferUsageCollector collector(buffer_data_to_buffer_, allocated_buffers_);
     pipeline_allocs = collector.Collect(SeqStmt(pipeline_body_stmts));
 
-    BufferSet pipeline_write_buffers =
-        CollectPipelineWriteBuffers(original_order);
+    Optional<Array<Integer>> replayable_bind_mask;
+    if (auto replayable_bind_anno =
+            op->annotations.Get(kPipelineReplayableScalarBinds)) {
+      auto mask = Downcast<Array<Integer>>(replayable_bind_anno.value());
+      if (mask.size() == original_order.size()) {
+        bool valid_mask = true;
+        for (size_t i = 0; i < original_order.size(); ++i) {
+          if (mask[i]->value != 0 &&
+              original_order[i]->body.as<BindNode>() == nullptr) {
+            valid_mask = false;
+            break;
+          }
+        }
+        if (valid_mask) {
+          replayable_bind_mask = std::move(mask);
+        }
+      }
+    }
+    BufferSet pipeline_write_buffers;
+    if (!replayable_bind_mask.defined()) {
+      pipeline_write_buffers = CollectPipelineWriteBuffers(original_order);
+    }
     Array<SBlock> scalar_binding_blocks;
     Array<SBlock> scheduled_order;
     std::vector<char> is_replayable_bind;
     is_replayable_bind.reserve(original_order.size());
-    for (const SBlock &block : original_order) {
+    for (size_t i = 0; i < original_order.size(); ++i) {
+      const SBlock &block = original_order[i];
       bool replayable =
-          IsReplayableScalarBindBlock(block, pipeline_write_buffers);
+          replayable_bind_mask.defined()
+              ? replayable_bind_mask.value()[i]->value != 0
+              : IsReplayableScalarBindBlock(block, pipeline_write_buffers);
       is_replayable_bind.push_back(replayable ? 1 : 0);
       if (replayable) {
         scalar_binding_blocks.push_back(block);

--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -15,6 +15,7 @@
 #include <tvm/tirx/stmt.h>
 #include <tvm/tirx/transform.h>
 
+#include <algorithm>
 #include <functional>
 #include <map>
 #include <unordered_map>
@@ -61,6 +62,10 @@ bool GetBoolAnnotation(const CopyNode &op, const char *key) {
     }
   }
   return false;
+}
+
+bool IsScalarBindBlock(const SBlock &block) {
+  return block->body.as<BindNode>() != nullptr;
 }
 
 bool GetIsTmaCopy(const CopyNode &op) {
@@ -677,17 +682,21 @@ public:
    * blocks and should not be re-allocated.
    * \param pipeline_loop The original loop to be software pipelined.
    * \param pipeline_info The pipeline annotation information.
+   * \param scalar_binding_blocks Scalar Bind statements from the pipeline body.
    * \param loop_var_if_wrappers If wrappers with conditions that depend on
    * the loop var.
    */
   PipelineRewriter(Map<Var, Buffer> buffer_data_to_buffer,
                    const Array<Buffer> &pipeline_allocs,
                    const Array<Buffer> &local_allocs, const For &pipeline_loop,
-                   const PipelineInfo &pipeline_info, Optional<Target> target,
+                   const PipelineInfo &pipeline_info,
+                   const Array<SBlock> &scalar_binding_blocks,
+                   Optional<Target> target,
                    const std::vector<IfWrapper> &loop_var_if_wrappers)
       : buffer_data_to_buffer_(std::move(buffer_data_to_buffer)),
         pipeline_allocs_(pipeline_allocs), local_allocs_(local_allocs),
         pipeline_loop_(pipeline_loop), pipeline_info_(pipeline_info),
+        scalar_binding_blocks_(scalar_binding_blocks),
         target_(std::move(target)),
         loop_var_if_wrappers_(loop_var_if_wrappers) {}
 
@@ -707,9 +716,15 @@ public:
         buffer_remap_.Set(buffer, RewriteAllocBuffer(buffer, num_versions));
       }
     }
-    ordered_stmts_.resize(pipeline_info_.size());
+    std::vector<std::pair<int, SBlock>> ordered_blocks;
     for (const auto &[block, anno] : pipeline_info_) {
-      ordered_stmts_.Set(anno.order, block);
+      ordered_blocks.emplace_back(anno.order, block);
+    }
+    std::sort(
+        ordered_blocks.begin(), ordered_blocks.end(),
+        [](const auto &lhs, const auto &rhs) { return lhs.first < rhs.first; });
+    for (const auto &[_, block] : ordered_blocks) {
+      ordered_stmts_.push_back(block);
     }
     CollectScalarBindings();
 
@@ -783,7 +798,7 @@ private:
   void CollectScalarBindings() {
     scalar_bindings_.clear();
     scalar_binding_map_.clear();
-    for (const SBlock &block : ordered_stmts_) {
+    for (const SBlock &block : scalar_binding_blocks_) {
       if (const auto *bind = block->body.as<BindNode>()) {
         if (!scalar_binding_map_.count(bind->var)) {
           scalar_binding_map_.emplace(bind->var, scalar_bindings_.size());
@@ -2521,6 +2536,7 @@ private:
   Array<Buffer> local_allocs_;
   For pipeline_loop_;
   PipelineInfo pipeline_info_;
+  Array<SBlock> scalar_binding_blocks_;
   int max_stage_ = -1;
   Map<Buffer, Buffer> buffer_remap_;
   Optional<Target> target_;
@@ -3354,22 +3370,68 @@ private:
     BufferUsageCollector collector(buffer_data_to_buffer_, allocated_buffers_);
     pipeline_allocs = collector.Collect(SeqStmt(pipeline_body_stmts));
 
+    Array<SBlock> scalar_binding_blocks;
+    Array<SBlock> scheduled_order;
+    for (const SBlock &block : original_order) {
+      if (IsScalarBindBlock(block)) {
+        scalar_binding_blocks.push_back(block);
+      } else {
+        scheduled_order.push_back(block);
+      }
+    }
+    ICHECK(!scheduled_order.empty())
+        << "ValueError: The body of the software pipeline has no schedulable "
+           "statements after removing scalar Bind statements";
+
     auto pipeline_stages = Downcast<Array<Integer>>(
         op->annotations.at(s_tir::attr::software_pipeline_stage));
     auto pipeline_orders = Downcast<Array<Integer>>(
         op->annotations.at(s_tir::attr::software_pipeline_order));
-    ICHECK_EQ(pipeline_stages.size(), original_order.size())
-        << "PrimFunc " << global_symbol_ << " has original order "
-        << original_order.Map(
-               [](const auto &block) { return block->name_hint; })
-        << ", but pipeline annotation is " << pipeline_stages
-        << " with different size";
-    ICHECK_EQ(pipeline_orders.size(), original_order.size())
-        << "PrimFunc " << global_symbol_ << " has original order "
-        << original_order.Map(
-               [](const auto &block) { return block->name_hint; })
-        << ", but pipeline annotation is " << pipeline_orders
-        << " with different size";
+    ICHECK_EQ(pipeline_stages.size(), pipeline_orders.size())
+        << "PrimFunc " << global_symbol_
+        << " has software_pipeline_stage annotation " << pipeline_stages
+        << " and software_pipeline_order annotation " << pipeline_orders
+        << " with different sizes";
+
+    bool annotations_include_scalar_binds = false;
+    if (pipeline_stages.size() == scheduled_order.size()) {
+      annotations_include_scalar_binds = false;
+    } else if (pipeline_stages.size() == original_order.size()) {
+      annotations_include_scalar_binds = true;
+    } else {
+      LOG(FATAL) << "PrimFunc " << global_symbol_
+                 << " has schedulable pipeline order "
+                 << scheduled_order.Map(
+                        [](const auto &block) { return block->name_hint; })
+                 << " and original order "
+                 << original_order.Map(
+                        [](const auto &block) { return block->name_hint; })
+                 << ", but pipeline annotation is " << pipeline_stages
+                 << " with different size";
+    }
+
+    std::vector<size_t> scheduled_annotation_indices;
+    scheduled_annotation_indices.reserve(scheduled_order.size());
+    if (annotations_include_scalar_binds) {
+      size_t scheduled_index = 0;
+      for (size_t i = 0; i < original_order.size(); ++i) {
+        if (IsScalarBindBlock(original_order[i])) {
+          continue;
+        }
+        ICHECK(scheduled_index < scheduled_order.size());
+        ICHECK(scheduled_order[scheduled_index].same_as(original_order[i]));
+        scheduled_annotation_indices.push_back(i);
+        ++scheduled_index;
+      }
+    } else {
+      for (size_t i = 0; i < scheduled_order.size(); ++i) {
+        scheduled_annotation_indices.push_back(i);
+      }
+    }
+
+    auto expected_annotation_size = annotations_include_scalar_binds
+                                        ? original_order.size()
+                                        : scheduled_order.size();
 
     std::unordered_set<int> pipeline_async_stages;
     if (auto async_annot =
@@ -3383,9 +3445,9 @@ private:
     if (auto async_producers_anno =
             op->annotations.Get(kPipelineAsyncProducers)) {
       auto async_flags = Downcast<Array<Integer>>(async_producers_anno.value());
-      ICHECK_EQ(async_flags.size(), original_order.size())
-          << "PrimFunc " << global_symbol_ << " has original order "
-          << original_order.Map(
+      ICHECK_EQ(async_flags.size(), expected_annotation_size)
+          << "PrimFunc " << global_symbol_ << " has schedulable order "
+          << scheduled_order.Map(
                  [](const auto &block) { return block->name_hint; })
           << ", but async producer annotation is " << async_flags
           << " with different size";
@@ -3396,40 +3458,81 @@ private:
             op->annotations.Get(kPipelineAsyncProducerGroups)) {
       auto async_group_ids =
           Downcast<Array<Integer>>(async_groups_anno.value());
-      ICHECK_EQ(async_group_ids.size(), original_order.size())
-          << "PrimFunc " << global_symbol_ << " has original order "
-          << original_order.Map(
+      ICHECK_EQ(async_group_ids.size(), expected_annotation_size)
+          << "PrimFunc " << global_symbol_ << " has schedulable order "
+          << scheduled_order.Map(
                  [](const auto &block) { return block->name_hint; })
           << ", but async producer group annotation is " << async_group_ids
           << " with different size";
       pipeline_async_producer_groups = async_group_ids;
     }
 
-    for (size_t i = 0; i < pipeline_stages.size(); i++) {
-      int stage = static_cast<int>(pipeline_stages[i]->value);
+    for (size_t i = 0; i < scheduled_order.size(); i++) {
+      size_t annotation_index = scheduled_annotation_indices[i];
+      int stage = static_cast<int>(pipeline_stages[annotation_index]->value);
       bool is_async_candidate =
           pipeline_async_producers
-              ? (pipeline_async_producers.value()[i]->value != 0)
+              ? (pipeline_async_producers.value()[annotation_index]->value != 0)
               : (pipeline_async_stages.count(stage) > 0);
       // Stages that already spell out async behavior themselves keep that
       // ownership. The pipeline pass only injects async producer semantics for
       // "plain" producer stages that do not already contain cp.async / async
       // queue operations.
-      bool is_async = is_async_candidate &&
-                      !ContainsExplicitAsyncIntrinsics(original_order[i]->body);
+      bool is_async = is_async_candidate && !ContainsExplicitAsyncIntrinsics(
+                                                scheduled_order[i]->body);
       PipelineAnnotation stage_order{
           stage,
-          /*order=*/static_cast<int>(pipeline_orders[i]->value),
+          /*order=*/static_cast<int>(pipeline_orders[annotation_index]->value),
           /*async=*/is_async,
           /*async_group_id=*/
           pipeline_async_producer_groups
               ? static_cast<int>(
-                    pipeline_async_producer_groups.value()[i]->value)
+                    pipeline_async_producer_groups.value()[annotation_index]
+                        ->value)
               : -1};
-      pipeline_info.emplace(original_order[i], stage_order);
+      pipeline_info.emplace(scheduled_order[i], stage_order);
     }
 
-    ValidatePipelineBody(pipeline_info, original_order);
+    if (annotations_include_scalar_binds) {
+      for (const SBlock &binding_block : scalar_binding_blocks) {
+        const auto *bind = binding_block->body.as<BindNode>();
+        ICHECK(bind != nullptr);
+        bool seen_consumer = false;
+        bool multiple_consumers = false;
+        PipelineAnnotation first_consumer;
+        for (const SBlock &consumer : scheduled_order) {
+          Array<Var> undefined_vars =
+              UndefinedVars(consumer->body, Array<Var>{});
+          bool uses_binding = false;
+          for (const Var &var : undefined_vars) {
+            if (var.same_as(bind->var)) {
+              uses_binding = true;
+              break;
+            }
+          }
+          if (!uses_binding) {
+            continue;
+          }
+          const PipelineAnnotation &anno = pipeline_info.at(consumer);
+          if (!seen_consumer) {
+            first_consumer = anno;
+            seen_consumer = true;
+          } else if (first_consumer.stage != anno.stage ||
+                     first_consumer.order != anno.order) {
+            multiple_consumers = true;
+            break;
+          }
+        }
+        if (multiple_consumers) {
+          LOG(WARNING)
+              << "Scalar Bind '" << bind->var
+              << "' is used by multiple pipeline stages; its annotation is "
+                 "ignored and the bind is replayed at each use.";
+        }
+      }
+    }
+
+    ValidatePipelineBody(pipeline_info, scheduled_order);
 
     if (!HasOverlappableStages(pipeline_info)) {
       if (const auto *realize = for_node->body.as<SBlockRealizeNode>()) {
@@ -3475,15 +3578,24 @@ private:
       pipeline_depth = std::max(pipeline_depth, 1);
       if (max_stage > 0) {
         if (auto tma_copies_anno = op->annotations.Get(kPipelineTmaCopies)) {
-          auto tma_copies = Downcast<Array<Integer>>(tma_copies_anno.value());
-          if (tma_copies.size() == original_order.size()) {
-            for (const auto &tc : tma_copies) {
+          auto raw_tma_copies =
+              Downcast<Array<Integer>>(tma_copies_anno.value());
+          Array<Integer> tma_copies;
+          if (raw_tma_copies.size() == scheduled_order.size()) {
+            tma_copies = raw_tma_copies;
+          } else if (raw_tma_copies.size() == original_order.size()) {
+            for (size_t annotation_index : scheduled_annotation_indices) {
+              tma_copies.push_back(raw_tma_copies[annotation_index]);
+            }
+          }
+          if (tma_copies.size() == scheduled_order.size()) {
+            for (const Integer &tc : tma_copies) {
               if (tc->value != 0)
                 num_pipeline_tma_copies++;
             }
             if (num_pipeline_tma_copies > 0) {
               pipeline_barrier_buf = RewritePipelineTmaBarriers(
-                  original_order, pipeline_info, tma_copies,
+                  scheduled_order, pipeline_info, tma_copies,
                   buffer_data_to_buffer_, allocated_buffers_,
                   block_local_allocs, for_node->loop_var, for_node->min,
                   pipeline_depth);
@@ -3512,7 +3624,7 @@ private:
                 ->value);
       }
       Map<Buffer, Buffer> barrier_remap = ExpandPipelineBarriers(
-          original_order, pipeline_info, buffer_data_to_buffer_,
+          scheduled_order, pipeline_info, buffer_data_to_buffer_,
           allocated_buffers_, block_local_allocs, pipeline_allocs,
           for_node->loop_var, for_node->min, barrier_depth);
       // Register expanded barriers for outer block alloc_buffers update.
@@ -3535,9 +3647,9 @@ private:
       }
     }
 
-    PipelineRewriter rewriter(buffer_data_to_buffer_, pipeline_allocs,
-                              local_allocs, for_node, pipeline_info, target_,
-                              loop_var_if_wrappers);
+    PipelineRewriter rewriter(
+        buffer_data_to_buffer_, pipeline_allocs, local_allocs, for_node,
+        pipeline_info, scalar_binding_blocks, target_, loop_var_if_wrappers);
     Stmt pipeline = rewriter.BuildPipeline();
     subtree_modified_ = true;
 

--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -64,8 +64,27 @@ bool GetBoolAnnotation(const CopyNode &op, const char *key) {
   return false;
 }
 
-bool IsScalarBindBlock(const SBlock &block) {
-  return block->body.as<BindNode>() != nullptr;
+bool IsReplayableScalarBindBlock(const SBlock &block,
+                                 const BufferSet &pipeline_write_buffers) {
+  if (block->body.as<BindNode>() == nullptr) {
+    return false;
+  }
+  for (const BufferRegion &read : block->reads) {
+    if (pipeline_write_buffers.count(read->buffer)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+BufferSet CollectPipelineWriteBuffers(const Array<SBlock> &blocks) {
+  BufferSet write_buffers;
+  for (const SBlock &block : blocks) {
+    for (const BufferRegion &write : block->writes) {
+      write_buffers.insert(write->buffer);
+    }
+  }
+  return write_buffers;
 }
 
 bool GetIsTmaCopy(const CopyNode &op) {
@@ -682,7 +701,8 @@ public:
    * blocks and should not be re-allocated.
    * \param pipeline_loop The original loop to be software pipelined.
    * \param pipeline_info The pipeline annotation information.
-   * \param scalar_binding_blocks Scalar Bind statements from the pipeline body.
+   * \param scalar_binding_blocks Replayable scalar Bind statements from the
+   * pipeline body.
    * \param loop_var_if_wrappers If wrappers with conditions that depend on
    * the loop var.
    */
@@ -2364,9 +2384,6 @@ private:
     BufferCommitGroupMap buffer_to_commit_group;
 
     for (const SBlock &block : ordered_stmts_) {
-      if (block->body.as<BindNode>()) {
-        continue;
-      }
       const auto &pipeline_anno = pipeline_info_.at(block);
       int stage = pipeline_anno.stage;
       PrimExpr inbound = Bool(true);
@@ -3101,6 +3118,42 @@ private:
     }
   }
 
+  void ValidateScheduledBindDependencies(const PipelineInfo &pipeline_info,
+                                         const Array<SBlock> &scheduled_order) {
+    std::unordered_map<Var, SBlock, ObjectPtrHash, ObjectPtrEqual>
+        bind_producers;
+    for (const SBlock &block : scheduled_order) {
+      if (const auto *bind = block->body.as<BindNode>()) {
+        bind_producers.emplace(bind->var, block);
+      }
+    }
+    if (bind_producers.empty()) {
+      return;
+    }
+
+    for (const SBlock &consumer : scheduled_order) {
+      Array<Var> undefined_vars = UndefinedVars(consumer->body, Array<Var>{});
+      for (const Var &var : undefined_vars) {
+        auto it = bind_producers.find(var);
+        if (it == bind_producers.end() || it->second.same_as(consumer)) {
+          continue;
+        }
+
+        const PipelineAnnotation &producer_info = pipeline_info.at(it->second);
+        const PipelineAnnotation &consumer_info = pipeline_info.at(consumer);
+        ICHECK_EQ(producer_info.stage, consumer_info.stage)
+            << "ValueError: scheduled scalar Bind '" << var
+            << "' is used from a different pipeline stage. Scalar Bind "
+               "statements that cannot be replayed must be scheduled in the "
+               "same stage as their consumers.";
+        ICHECK_LT(producer_info.order, consumer_info.order)
+            << "ValueError: scheduled scalar Bind '" << var
+            << "' must be ordered before every consumer in the same pipeline "
+               "stage.";
+      }
+    }
+  }
+
   bool HasOverlappableStages(const PipelineInfo &pipeline_info) const {
     std::optional<int> first_stage;
     for (const auto &pair : pipeline_info) {
@@ -3370,10 +3423,17 @@ private:
     BufferUsageCollector collector(buffer_data_to_buffer_, allocated_buffers_);
     pipeline_allocs = collector.Collect(SeqStmt(pipeline_body_stmts));
 
+    BufferSet pipeline_write_buffers =
+        CollectPipelineWriteBuffers(original_order);
     Array<SBlock> scalar_binding_blocks;
     Array<SBlock> scheduled_order;
+    std::vector<char> is_replayable_bind;
+    is_replayable_bind.reserve(original_order.size());
     for (const SBlock &block : original_order) {
-      if (IsScalarBindBlock(block)) {
+      bool replayable =
+          IsReplayableScalarBindBlock(block, pipeline_write_buffers);
+      is_replayable_bind.push_back(replayable ? 1 : 0);
+      if (replayable) {
         scalar_binding_blocks.push_back(block);
       } else {
         scheduled_order.push_back(block);
@@ -3381,7 +3441,7 @@ private:
     }
     ICHECK(!scheduled_order.empty())
         << "ValueError: The body of the software pipeline has no schedulable "
-           "statements after removing scalar Bind statements";
+           "statements after removing replayable scalar Bind statements";
 
     auto pipeline_stages = Downcast<Array<Integer>>(
         op->annotations.at(s_tir::attr::software_pipeline_stage));
@@ -3393,11 +3453,11 @@ private:
         << " and software_pipeline_order annotation " << pipeline_orders
         << " with different sizes";
 
-    bool annotations_include_scalar_binds = false;
+    bool annotations_include_replayable_binds = false;
     if (pipeline_stages.size() == scheduled_order.size()) {
-      annotations_include_scalar_binds = false;
+      annotations_include_replayable_binds = false;
     } else if (pipeline_stages.size() == original_order.size()) {
-      annotations_include_scalar_binds = true;
+      annotations_include_replayable_binds = true;
     } else {
       LOG(FATAL) << "PrimFunc " << global_symbol_
                  << " has schedulable pipeline order "
@@ -3412,10 +3472,10 @@ private:
 
     std::vector<size_t> scheduled_annotation_indices;
     scheduled_annotation_indices.reserve(scheduled_order.size());
-    if (annotations_include_scalar_binds) {
+    if (annotations_include_replayable_binds) {
       size_t scheduled_index = 0;
       for (size_t i = 0; i < original_order.size(); ++i) {
-        if (IsScalarBindBlock(original_order[i])) {
+        if (is_replayable_bind[i]) {
           continue;
         }
         ICHECK(scheduled_index < scheduled_order.size());
@@ -3429,7 +3489,7 @@ private:
       }
     }
 
-    auto expected_annotation_size = annotations_include_scalar_binds
+    auto expected_annotation_size = annotations_include_replayable_binds
                                         ? original_order.size()
                                         : scheduled_order.size();
 
@@ -3493,7 +3553,7 @@ private:
       pipeline_info.emplace(scheduled_order[i], stage_order);
     }
 
-    if (annotations_include_scalar_binds) {
+    if (annotations_include_replayable_binds) {
       for (const SBlock &binding_block : scalar_binding_blocks) {
         const auto *bind = binding_block->body.as<BindNode>();
         ICHECK(bind != nullptr);
@@ -3532,6 +3592,7 @@ private:
       }
     }
 
+    ValidateScheduledBindDependencies(pipeline_info, scheduled_order);
     ValidatePipelineBody(pipeline_info, scheduled_order);
 
     if (!HasOverlappableStages(pipeline_info)) {

--- a/src/transform/pipeline_planning.cc
+++ b/src/transform/pipeline_planning.cc
@@ -1149,6 +1149,7 @@ private:
     size_t original_stmt_count{0};
     Array<Stmt> scheduled_stmts;
     std::vector<size_t> scheduled_indices;
+    Array<Integer> replayable_bind_mask;
   };
 
   ScheduledStmtAnalysis AnalyzeScheduledStmts(
@@ -1158,10 +1159,13 @@ private:
         CollectPipelineWriteBuffers(stmts, chain_builder);
     ScheduledStmtAnalysis analysis;
     analysis.original_stmt_count = stmts.size();
+    analysis.replayable_bind_mask.reserve(stmts.size());
     for (size_t i = 0; i < stmts.size(); ++i) {
       const Stmt &stmt = stmts[i];
-      if (IsReplayableScalarBindStmt(stmt, pipeline_write_buffers,
-                                     chain_builder)) {
+      bool replayable = IsReplayableScalarBindStmt(stmt, pipeline_write_buffers,
+                                                   chain_builder);
+      analysis.replayable_bind_mask.push_back(Integer(replayable ? 1 : 0));
+      if (replayable) {
         continue;
       }
       analysis.scheduled_indices.push_back(i);
@@ -1369,6 +1373,19 @@ private:
                       filtered_order_array);
       annotations.Set(s_tir::attr::software_pipeline_stage,
                       filtered_stage_array);
+      if (pipeline_stmts.size() == pipeline_body_seq->seq.size()) {
+        bool flatten_preserved_original_order = true;
+        for (size_t i = 0; i < pipeline_stmts.size(); ++i) {
+          if (!pipeline_stmts[i].same_as(pipeline_body_seq->seq[i])) {
+            flatten_preserved_original_order = false;
+            break;
+          }
+        }
+        if (flatten_preserved_original_order) {
+          annotations.Set(kPipelineReplayableScalarBinds,
+                          analysis.replayable_bind_mask);
+        }
+      }
       MaybeAnnotateLegacyAsyncPipelineLoop(
           pipeline_body_root, analysis.scheduled_stmts, filtered_order_array,
           filtered_stage_array, &annotations);
@@ -2265,6 +2282,8 @@ private:
                     Array<Integer>(stages));
     annotations.Set(s_tir::attr::software_pipeline_order,
                     Array<Integer>(orders));
+    annotations.Set(kPipelineReplayableScalarBinds,
+                    analysis.replayable_bind_mask);
 
     // Propagate per-statement TMA eligibility so InjectSoftwarePipeline can
     // rewrite TMA copies to use pipeline-level barrier management.

--- a/src/transform/pipeline_planning.cc
+++ b/src/transform/pipeline_planning.cc
@@ -61,6 +61,43 @@ bool MayConflict(const Region &region1, const Region &region2) {
   return true;
 }
 
+bool IsScalarBindStmt(const Stmt &stmt) {
+  return stmt.as<BindNode>() != nullptr;
+}
+
+Array<Stmt> FilterScalarBindStmts(const Array<Stmt> &stmts) {
+  Array<Stmt> scheduled_stmts;
+  for (const Stmt &stmt : stmts) {
+    if (IsScalarBindStmt(stmt)) {
+      continue;
+    }
+    scheduled_stmts.push_back(stmt);
+  }
+  return scheduled_stmts;
+}
+
+Array<Integer> FilterScalarBindAnnotations(const Array<Integer> &annotations,
+                                           const Array<Stmt> &original_stmts,
+                                           const Array<Stmt> &scheduled_stmts) {
+  if (annotations.size() == scheduled_stmts.size()) {
+    return annotations;
+  }
+
+  ICHECK_EQ(annotations.size(), original_stmts.size())
+      << "PipelinePlanning: expected pipeline annotation size to match either "
+         "the scheduled statement count or the original statement count";
+
+  Array<Integer> filtered;
+  for (size_t i = 0; i < original_stmts.size(); ++i) {
+    if (IsScalarBindStmt(original_stmts[i])) {
+      continue;
+    }
+    filtered.push_back(annotations[i]);
+  }
+  ICHECK_EQ(filtered.size(), scheduled_stmts.size());
+  return filtered;
+}
+
 class TmemLoadCollector : public StmtExprVisitor {
 public:
   TmemLoadCollector() {}
@@ -1278,9 +1315,23 @@ private:
       }
       SeqStmt pipeline_body_seq =
           PipelineBodySeqFinder::FindOrFatal(pipeline_body_root);
-      MaybeAnnotateLegacyAsyncPipelineLoop(pipeline_body_root,
-                                           pipeline_body_seq->seq, order_array,
-                                           stage_array, &annotations);
+      Array<Stmt> pipeline_stmts =
+          SeqStmtFlattener::Flatten(pipeline_body_seq->seq);
+      Array<Stmt> scheduled_stmts = FilterScalarBindStmts(pipeline_stmts);
+      ICHECK(!scheduled_stmts.empty())
+          << "PipelinePlanning: explicit pipeline annotations have no "
+             "schedulable statements after removing scalar Bind statements";
+      Array<Integer> filtered_order_array = FilterScalarBindAnnotations(
+          order_array, pipeline_stmts, scheduled_stmts);
+      Array<Integer> filtered_stage_array = FilterScalarBindAnnotations(
+          stage_array, pipeline_stmts, scheduled_stmts);
+      annotations.Set(s_tir::attr::software_pipeline_order,
+                      filtered_order_array);
+      annotations.Set(s_tir::attr::software_pipeline_stage,
+                      filtered_stage_array);
+      MaybeAnnotateLegacyAsyncPipelineLoop(pipeline_body_root, scheduled_stmts,
+                                           filtered_order_array,
+                                           filtered_stage_array, &annotations);
       auto for_node = GetRef<For>(loop);
       for_node.CopyOnWrite()->annotations = annotations;
       return for_node;
@@ -1334,13 +1385,17 @@ private:
     // inside the loop body. Flatten them so pipeline planning can assign
     // individual stages to the produce and wait statements.
     Array<Stmt> flat_stmts = SeqStmtFlattener::Flatten(pipeline_body_seq->seq);
+    Array<Stmt> scheduled_stmts = FilterScalarBindStmts(flat_stmts);
+    ICHECK(!scheduled_stmts.empty())
+        << "PipelinePlanning: loop has no schedulable statements after "
+           "removing scalar Bind statements";
 
     AsyncDependencyChainBuilder chain_builder(buffer_data_to_buffer_);
     chain_builder(pipeline_body_root);
 
     std::vector<PipelineStageInfo> pipeline_stage_infos;
-    for (size_t i = 0; i < flat_stmts.size(); i++) {
-      auto pinfo = MakePipelineStageInfo(flat_stmts[i], i, chain_builder);
+    for (size_t i = 0; i < scheduled_stmts.size(); i++) {
+      auto pinfo = MakePipelineStageInfo(scheduled_stmts[i], i, chain_builder);
       pipeline_stage_infos.push_back(std::move(pinfo));
     }
 

--- a/src/transform/pipeline_planning.cc
+++ b/src/transform/pipeline_planning.cc
@@ -37,10 +37,6 @@ using BufferSet = std::unordered_set<Buffer, ObjectPtrHash, ObjectPtrEqual>;
 using BufferRegionMap = std::unordered_map<Buffer, Array<BufferRegion>,
                                            ObjectPtrHash, ObjectPtrEqual>;
 
-using BufferSet = std::unordered_set<Buffer, ObjectPtrHash, ObjectPtrEqual>;
-using BufferRegionMap = std::unordered_map<Buffer, Array<BufferRegion>,
-                                           ObjectPtrHash, ObjectPtrEqual>;
-
 /*!
  * \brief Check whether two regions have intersections.
  * \param region1 The first region.
@@ -59,43 +55,6 @@ bool MayConflict(const Region &region1, const Region &region2) {
     }
   }
   return true;
-}
-
-bool IsScalarBindStmt(const Stmt &stmt) {
-  return stmt.as<BindNode>() != nullptr;
-}
-
-Array<Stmt> FilterScalarBindStmts(const Array<Stmt> &stmts) {
-  Array<Stmt> scheduled_stmts;
-  for (const Stmt &stmt : stmts) {
-    if (IsScalarBindStmt(stmt)) {
-      continue;
-    }
-    scheduled_stmts.push_back(stmt);
-  }
-  return scheduled_stmts;
-}
-
-Array<Integer> FilterScalarBindAnnotations(const Array<Integer> &annotations,
-                                           const Array<Stmt> &original_stmts,
-                                           const Array<Stmt> &scheduled_stmts) {
-  if (annotations.size() == scheduled_stmts.size()) {
-    return annotations;
-  }
-
-  ICHECK_EQ(annotations.size(), original_stmts.size())
-      << "PipelinePlanning: expected pipeline annotation size to match either "
-         "the scheduled statement count or the original statement count";
-
-  Array<Integer> filtered;
-  for (size_t i = 0; i < original_stmts.size(); ++i) {
-    if (IsScalarBindStmt(original_stmts[i])) {
-      continue;
-    }
-    filtered.push_back(annotations[i]);
-  }
-  ICHECK_EQ(filtered.size(), scheduled_stmts.size());
-  return filtered;
 }
 
 class TmemLoadCollector : public StmtExprVisitor {
@@ -978,11 +937,12 @@ private:
           continue;
         }
         const auto &producer = pipeline_stage_infos[it->second];
-        ICHECK_LE(producer.stage, consumer.stage)
+        ICHECK_EQ(producer.stage, consumer.stage)
             << "Pipeline planning error: scalar dependency from statement "
             << producer.original_stmt_index << " to statement "
             << consumer.original_stmt_index
-            << " crosses from a later stage to an earlier stage.";
+            << " crosses pipeline stages. Scheduled scalar Bind statements "
+               "must stay in the same stage as their consumers.";
         if (producer.stage == consumer.stage) {
           ICHECK_LT(producer.order, consumer.order)
               << "Pipeline planning error: scalar dependency from statement "
@@ -1143,7 +1103,91 @@ private:
     pinfo.cp_async_wait_min_inflight = async_info.cp_async_wait_min_inflight;
     pinfo.cp_async_wait_has_dynamic = async_info.cp_async_wait_has_dynamic;
     ClassifyCopyLikeStage(block->body, &pinfo);
-    return std::move(pinfo);
+    return pinfo;
+  }
+
+  std::pair<Array<BufferRegion>, Array<BufferRegion>> CollectStmtAccessRegions(
+      const Stmt &stmt,
+      const AsyncDependencyChainBuilder &chain_builder) const {
+    SBlock block(/*iter_vars=*/{}, /*reads=*/{}, /*writes=*/{},
+                 /*name_hint=*/"", /*body*/ stmt);
+    auto collector =
+        BufferRegionCollector(buffer_data_to_buffer_, chain_builder, target_);
+    collector(block);
+    return {collector.GetReads(), collector.GetWrites()};
+  }
+
+  BufferSet CollectPipelineWriteBuffers(
+      const Array<Stmt> &stmts,
+      const AsyncDependencyChainBuilder &chain_builder) const {
+    BufferSet write_buffers;
+    for (const Stmt &stmt : stmts) {
+      auto [_, writes] = CollectStmtAccessRegions(stmt, chain_builder);
+      for (const BufferRegion &write : writes) {
+        write_buffers.insert(write->buffer);
+      }
+    }
+    return write_buffers;
+  }
+
+  bool IsReplayableScalarBindStmt(
+      const Stmt &stmt, const BufferSet &pipeline_write_buffers,
+      const AsyncDependencyChainBuilder &chain_builder) const {
+    if (stmt.as<BindNode>() == nullptr) {
+      return false;
+    }
+    auto [reads, _] = CollectStmtAccessRegions(stmt, chain_builder);
+    for (const BufferRegion &read : reads) {
+      if (pipeline_write_buffers.count(read->buffer)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  struct ScheduledStmtAnalysis {
+    size_t original_stmt_count{0};
+    Array<Stmt> scheduled_stmts;
+    std::vector<size_t> scheduled_indices;
+  };
+
+  ScheduledStmtAnalysis AnalyzeScheduledStmts(
+      const Array<Stmt> &stmts,
+      const AsyncDependencyChainBuilder &chain_builder) const {
+    BufferSet pipeline_write_buffers =
+        CollectPipelineWriteBuffers(stmts, chain_builder);
+    ScheduledStmtAnalysis analysis;
+    analysis.original_stmt_count = stmts.size();
+    for (size_t i = 0; i < stmts.size(); ++i) {
+      const Stmt &stmt = stmts[i];
+      if (IsReplayableScalarBindStmt(stmt, pipeline_write_buffers,
+                                     chain_builder)) {
+        continue;
+      }
+      analysis.scheduled_indices.push_back(i);
+      analysis.scheduled_stmts.push_back(stmt);
+    }
+    return analysis;
+  }
+
+  Array<Integer> FilterAnnotationsForScheduledStmts(
+      const Array<Integer> &annotations,
+      const ScheduledStmtAnalysis &analysis) const {
+    if (annotations.size() == analysis.scheduled_stmts.size()) {
+      return annotations;
+    }
+
+    ICHECK_EQ(annotations.size(), analysis.original_stmt_count)
+        << "PipelinePlanning: expected pipeline annotation size to match "
+           "either the scheduled statement count or the original statement "
+           "count";
+
+    Array<Integer> filtered;
+    for (size_t index : analysis.scheduled_indices) {
+      filtered.push_back(annotations[index]);
+    }
+    ICHECK_EQ(filtered.size(), analysis.scheduled_stmts.size());
+    return filtered;
   }
 
   class PipelineBodySeqFinder
@@ -1283,18 +1327,10 @@ private:
 
       Map<String, Any> annotations;
       for (const auto &[key, value] : loop->annotations) {
-        if (key != "tl_pipeline_order") {
+        if (key != "tl_pipeline_order" && key != "tl_pipeline_stage") {
           annotations.Set(key, value);
         }
       }
-      annotations.Set(s_tir::attr::software_pipeline_order, order_anno.value());
-
-      for (const auto &[key, value] : loop->annotations) {
-        if (key != "tl_pipeline_stage") {
-          annotations.Set(key, value);
-        }
-      }
-      annotations.Set(s_tir::attr::software_pipeline_stage, stage_anno.value());
       if (TargetHasAsyncCopy(target_) && use_async_copy_) {
         // Legacy explicit stage/order annotations do not carry per-statement
         // async producer metadata yet, so keep the previous stage-level
@@ -1317,21 +1353,25 @@ private:
           PipelineBodySeqFinder::FindOrFatal(pipeline_body_root);
       Array<Stmt> pipeline_stmts =
           SeqStmtFlattener::Flatten(pipeline_body_seq->seq);
-      Array<Stmt> scheduled_stmts = FilterScalarBindStmts(pipeline_stmts);
-      ICHECK(!scheduled_stmts.empty())
+      AsyncDependencyChainBuilder chain_builder(buffer_data_to_buffer_);
+      chain_builder(pipeline_body_root);
+      ScheduledStmtAnalysis analysis =
+          AnalyzeScheduledStmts(pipeline_stmts, chain_builder);
+      ICHECK(!analysis.scheduled_stmts.empty())
           << "PipelinePlanning: explicit pipeline annotations have no "
-             "schedulable statements after removing scalar Bind statements";
-      Array<Integer> filtered_order_array = FilterScalarBindAnnotations(
-          order_array, pipeline_stmts, scheduled_stmts);
-      Array<Integer> filtered_stage_array = FilterScalarBindAnnotations(
-          stage_array, pipeline_stmts, scheduled_stmts);
+             "schedulable statements after removing replayable scalar Bind "
+             "statements";
+      Array<Integer> filtered_order_array =
+          FilterAnnotationsForScheduledStmts(order_array, analysis);
+      Array<Integer> filtered_stage_array =
+          FilterAnnotationsForScheduledStmts(stage_array, analysis);
       annotations.Set(s_tir::attr::software_pipeline_order,
                       filtered_order_array);
       annotations.Set(s_tir::attr::software_pipeline_stage,
                       filtered_stage_array);
-      MaybeAnnotateLegacyAsyncPipelineLoop(pipeline_body_root, scheduled_stmts,
-                                           filtered_order_array,
-                                           filtered_stage_array, &annotations);
+      MaybeAnnotateLegacyAsyncPipelineLoop(
+          pipeline_body_root, analysis.scheduled_stmts, filtered_order_array,
+          filtered_stage_array, &annotations);
       auto for_node = GetRef<For>(loop);
       for_node.CopyOnWrite()->annotations = annotations;
       return for_node;
@@ -1385,17 +1425,18 @@ private:
     // inside the loop body. Flatten them so pipeline planning can assign
     // individual stages to the produce and wait statements.
     Array<Stmt> flat_stmts = SeqStmtFlattener::Flatten(pipeline_body_seq->seq);
-    Array<Stmt> scheduled_stmts = FilterScalarBindStmts(flat_stmts);
-    ICHECK(!scheduled_stmts.empty())
-        << "PipelinePlanning: loop has no schedulable statements after "
-           "removing scalar Bind statements";
-
     AsyncDependencyChainBuilder chain_builder(buffer_data_to_buffer_);
     chain_builder(pipeline_body_root);
+    ScheduledStmtAnalysis analysis =
+        AnalyzeScheduledStmts(flat_stmts, chain_builder);
+    ICHECK(!analysis.scheduled_stmts.empty())
+        << "PipelinePlanning: loop has no schedulable statements after "
+           "removing replayable scalar Bind statements";
 
     std::vector<PipelineStageInfo> pipeline_stage_infos;
-    for (size_t i = 0; i < scheduled_stmts.size(); i++) {
-      auto pinfo = MakePipelineStageInfo(scheduled_stmts[i], i, chain_builder);
+    for (size_t i = 0; i < analysis.scheduled_stmts.size(); i++) {
+      auto pinfo =
+          MakePipelineStageInfo(analysis.scheduled_stmts[i], i, chain_builder);
       pipeline_stage_infos.push_back(std::move(pinfo));
     }
 
@@ -2347,7 +2388,7 @@ private:
     for (const auto &buffer : op->alloc_buffers) {
       buffer_data_to_buffer_.erase(buffer->data);
     }
-    return std::move(block);
+    return block;
   }
 
   Map<Var, Buffer> buffer_data_to_buffer_;

--- a/testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py
+++ b/testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py
@@ -512,7 +512,27 @@ def test_inject_software_pipeline_expands_annotated_layout():
     assert layout_map[shared.data].is_equal(layout.expand([2]))
 
 
-def test_inject_software_pipeline_replays_scalar_bind_per_stage_use():
+def _collect_leading_bind_names(mod, block_names):
+    leading_binds = {name: [] for name in block_names}
+
+    def _visit(node):
+        if not isinstance(node, tvm.tirx.SBlock) or str(node.name_hint) not in leading_binds:
+            return
+        body = node.body
+        assert isinstance(body, tvm.tirx.SeqStmt), f"{node.name_hint} body should start with scalar Bind"
+        names = []
+        for stmt in body.seq:
+            if not isinstance(stmt, tvm.tirx.Bind):
+                break
+            names.append(str(stmt.var.name))
+        assert names, f"{node.name_hint} body should start with scalar Bind"
+        leading_binds[str(node.name_hint)].append(names)
+
+    post_order_visit(mod["main"].body, _visit)
+    return leading_binds
+
+
+def test_inject_software_pipeline_replays_scalar_bind_without_annotation_slot():
     @T.prim_func
     def before(A: T.Tensor((128,), T.float32), B: T.Tensor((128,), T.float32)):
         shared = T.alloc_buffer((16,), dtype=T.float32, scope="shared")
@@ -521,7 +541,45 @@ def test_inject_software_pipeline_replays_scalar_bind_per_stage_use():
                 0,
                 4,
                 annotations={
-                    "software_pipeline_stage": [0, 0, 1],
+                    "software_pipeline_stage": [0, 1],
+                    "software_pipeline_order": [1, 0],
+                    "software_pipeline_async_stages": [0],
+                    "software_pipeline_async_producers": [1, 0],
+                    "software_pipeline_async_producer_groups": [0, -1],
+                },
+            ):
+                base: T.int32 = i * 16
+                with T.sblock("copy"):
+                    T.reads(A[base + tx])
+                    T.writes(shared[tx])
+                    shared[tx] = A[base + tx]
+                with T.sblock("store"):
+                    T.reads(shared[tx])
+                    T.writes(B[base + tx])
+                    B[base + tx] = shared[tx]
+
+    mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
+    mod = tl.transform.InjectSoftwarePipeline()(mod)
+
+    leading_binds = _collect_leading_bind_names(mod, {"copy", "store"})
+
+    assert leading_binds["copy"]
+    assert leading_binds["store"]
+    assert all(names[0].startswith("base") for names in leading_binds["copy"])
+    assert all(names[0].startswith("base") for names in leading_binds["store"])
+    assert "base = T.int32()" not in mod["main"].script()
+
+
+def test_inject_software_pipeline_ignores_legacy_scalar_bind_annotation_slot():
+    @T.prim_func
+    def before(A: T.Tensor((128,), T.float32), B: T.Tensor((128,), T.float32)):
+        shared = T.alloc_buffer((16,), dtype=T.float32, scope="shared")
+        for tx in T.thread_binding(0, 16, thread="threadIdx.x"):
+            for i in T.serial(
+                0,
+                4,
+                annotations={
+                    "software_pipeline_stage": [3, 0, 1],
                     "software_pipeline_order": [1, 2, 0],
                     "software_pipeline_async_stages": [0],
                     "software_pipeline_async_producers": [0, 1, 0],
@@ -541,22 +599,53 @@ def test_inject_software_pipeline_replays_scalar_bind_per_stage_use():
     mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
     mod = tl.transform.InjectSoftwarePipeline()(mod)
 
-    leading_bind_blocks = {"copy": 0, "store": 0}
+    leading_binds = _collect_leading_bind_names(mod, {"copy", "store"})
 
-    def _visit(node):
-        if not isinstance(node, tvm.tirx.SBlock) or str(node.name_hint) not in leading_bind_blocks:
-            return
-        body = node.body
-        assert isinstance(body, tvm.tirx.SeqStmt), f"{node.name_hint} body should start with scalar Bind"
-        assert isinstance(body.seq[0], tvm.tirx.Bind), f"{node.name_hint} body should start with scalar Bind"
-        assert str(body.seq[0].var.name).startswith("base")
-        leading_bind_blocks[str(node.name_hint)] += 1
-
-    post_order_visit(mod["main"].body, _visit)
-
-    assert leading_bind_blocks["copy"] > 0
-    assert leading_bind_blocks["store"] > 0
+    assert leading_binds["copy"]
+    assert leading_binds["store"]
+    assert all(names[0].startswith("base") for names in leading_binds["copy"])
+    assert all(names[0].startswith("base") for names in leading_binds["store"])
     assert "base = T.int32()" not in mod["main"].script()
+
+
+def test_inject_software_pipeline_replays_scalar_bind_dependencies():
+    @T.prim_func
+    def before(A: T.Tensor((128,), T.float32), B: T.Tensor((128,), T.float32)):
+        shared = T.alloc_buffer((16,), dtype=T.float32, scope="shared")
+        for tx in T.thread_binding(0, 16, thread="threadIdx.x"):
+            for i in T.serial(
+                0,
+                4,
+                annotations={
+                    "software_pipeline_stage": [0, 1],
+                    "software_pipeline_order": [0, 1],
+                },
+            ):
+                base: T.int32 = i * 16
+                offset: T.int32 = base + tx
+                with T.sblock("copy"):
+                    T.reads(A[offset])
+                    T.writes(shared[tx])
+                    shared[tx] = A[offset]
+                with T.sblock("store"):
+                    T.reads(shared[tx])
+                    T.writes(B[offset])
+                    B[offset] = shared[tx]
+
+    mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
+    mod = tl.transform.InjectSoftwarePipeline()(mod)
+
+    leading_binds = _collect_leading_bind_names(mod, {"copy", "store"})
+
+    assert leading_binds["copy"]
+    assert leading_binds["store"]
+    for names in leading_binds["copy"] + leading_binds["store"]:
+        assert len(names) >= 2
+        assert names[0].startswith("base")
+        assert names[1].startswith("offset")
+    script = mod["main"].script()
+    assert "base = T.int32()" not in script
+    assert "offset = T.int32()" not in script
 
 
 if __name__ == "__main__":

--- a/testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py
+++ b/testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py
@@ -601,6 +601,7 @@ def test_inject_software_pipeline_replays_readonly_bufferload_bind():
                     "software_pipeline_async_stages": [0],
                     "software_pipeline_async_producers": [1, 0],
                     "software_pipeline_async_producer_groups": [0, -1],
+                    "software_pipeline_replayable_scalar_binds": [1, 0, 0],
                 },
             ):
                 idx: T.int32 = Ids[i] * 16
@@ -639,6 +640,7 @@ def test_inject_software_pipeline_schedules_bind_that_reads_pipeline_buffer():
                     "software_pipeline_async_stages": [0],
                     "software_pipeline_async_producers": [1, 0, 0],
                     "software_pipeline_async_producer_groups": [0, -1, -1],
+                    "software_pipeline_replayable_scalar_binds": [1, 0, 0, 0],
                 },
             ):
                 base: T.int32 = i * 16

--- a/testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py
+++ b/testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py
@@ -532,6 +532,19 @@ def _collect_leading_bind_names(mod, block_names):
     return leading_binds
 
 
+def _collect_direct_bind_names(mod):
+    names = []
+
+    def _visit(node):
+        if not isinstance(node, tvm.tirx.SBlock):
+            return
+        if isinstance(node.body, tvm.tirx.Bind):
+            names.append(str(node.body.var.name))
+
+    post_order_visit(mod["main"].body, _visit)
+    return names
+
+
 def test_inject_software_pipeline_replays_scalar_bind_without_annotation_slot():
     @T.prim_func
     def before(A: T.Tensor((128,), T.float32), B: T.Tensor((128,), T.float32)):
@@ -568,6 +581,89 @@ def test_inject_software_pipeline_replays_scalar_bind_without_annotation_slot():
     assert all(names[0].startswith("base") for names in leading_binds["copy"])
     assert all(names[0].startswith("base") for names in leading_binds["store"])
     assert "base = T.int32()" not in mod["main"].script()
+
+
+def test_inject_software_pipeline_replays_readonly_bufferload_bind():
+    @T.prim_func
+    def before(
+        A: T.Tensor((128,), T.float32),
+        Ids: T.Tensor((4,), T.int32),
+        B: T.Tensor((128,), T.float32),
+    ):
+        shared = T.alloc_buffer((16,), dtype=T.float32, scope="shared")
+        for tx in T.thread_binding(0, 16, thread="threadIdx.x"):
+            for i in T.serial(
+                0,
+                4,
+                annotations={
+                    "software_pipeline_stage": [0, 1],
+                    "software_pipeline_order": [1, 0],
+                    "software_pipeline_async_stages": [0],
+                    "software_pipeline_async_producers": [1, 0],
+                    "software_pipeline_async_producer_groups": [0, -1],
+                },
+            ):
+                idx: T.int32 = Ids[i] * 16
+                with T.sblock("copy"):
+                    T.reads(A[idx + tx])
+                    T.writes(shared[tx])
+                    shared[tx] = A[idx + tx]
+                with T.sblock("store"):
+                    T.reads(shared[tx])
+                    T.writes(B[idx + tx])
+                    B[idx + tx] = shared[tx]
+
+    mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
+    mod = tl.transform.InjectSoftwarePipeline()(mod)
+
+    leading_binds = _collect_leading_bind_names(mod, {"copy", "store"})
+
+    assert leading_binds["copy"]
+    assert leading_binds["store"]
+    assert all(names[0].startswith("idx") for names in leading_binds["copy"])
+    assert all(names[0].startswith("idx") for names in leading_binds["store"])
+    assert "idx = T.int32()" not in mod["main"].script()
+
+
+def test_inject_software_pipeline_schedules_bind_that_reads_pipeline_buffer():
+    @T.prim_func
+    def before(A: T.Tensor((128,), T.float32), B: T.Tensor((128,), T.float32)):
+        shared = T.alloc_buffer((16,), dtype=T.float32, scope="shared")
+        for tx in T.thread_binding(0, 16, thread="threadIdx.x"):
+            for i in T.serial(
+                0,
+                4,
+                annotations={
+                    "software_pipeline_stage": [0, 1, 1],
+                    "software_pipeline_order": [0, 1, 2],
+                    "software_pipeline_async_stages": [0],
+                    "software_pipeline_async_producers": [1, 0, 0],
+                    "software_pipeline_async_producer_groups": [0, -1, -1],
+                },
+            ):
+                base: T.int32 = i * 16
+                with T.sblock("copy"):
+                    T.reads(A[base + tx])
+                    T.writes(shared[tx])
+                    shared[tx] = A[base + tx]
+                value: T.float32 = shared[tx]
+                with T.sblock("store"):
+                    T.reads()
+                    T.writes(B[base + tx])
+                    B[base + tx] = value
+
+    mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
+    mod = tl.transform.InjectSoftwarePipeline()(mod)
+
+    leading_binds = _collect_leading_bind_names(mod, {"copy", "store"})
+    direct_binds = _collect_direct_bind_names(mod)
+
+    assert leading_binds["copy"]
+    assert leading_binds["store"]
+    assert all(names[0].startswith("base") for names in leading_binds["copy"])
+    assert all(names[0].startswith("base") for names in leading_binds["store"])
+    assert any(name.startswith("value") for name in direct_binds)
+    assert all(not any(name.startswith("value") for name in names) for names in leading_binds["store"])
 
 
 def test_inject_software_pipeline_ignores_legacy_scalar_bind_annotation_slot():

--- a/testing/python/transform/test_tilelang_transform_pipeline_planning.py
+++ b/testing/python/transform/test_tilelang_transform_pipeline_planning.py
@@ -258,10 +258,39 @@ def test_pipeline_planning_stages_bind_with_dependent_copy():
     orders = [int(v) for v in annos[0]["software_pipeline_order"]]
     async_producers = [int(v) for v in annos[0]["software_pipeline_async_producers"]]
 
-    assert len(stages) == 3, f"Expected Bind, copy, and consumer stages, got {stages}"
-    assert stages == [0, 0, 1]
-    assert orders[0] < orders[1] < orders[2]
-    assert async_producers == [0, 1, 0]
+    assert len(stages) == 2, f"Expected copy and consumer stages, got {stages}"
+    assert stages == [0, 1]
+    assert orders == [0, 1]
+    assert async_producers == [1, 0]
+
+
+def test_pipeline_planning_accepts_explicit_bind_free_annotations():
+    @T.prim_func
+    def before(
+        A: T.Tensor((64,), T.float16),
+        B: T.Tensor((64,), T.float16),
+        C: T.Tensor((64,), T.float16),
+    ):
+        with T.Kernel(1, threads=16):
+            A_shared = T.alloc_shared((16,), T.float16)
+            for i in T.Pipelined(4, num_stages=2, order=[1, 0], stage=[0, 1]):
+                base: T.int32 = i * 16
+                T.copy(A[base], A_shared)
+                T.copy(A_shared, C[base])
+
+    mod = _run_pipeline_planning(before, sm80_target)
+    annos = _collect_pipeline_loop_annotations(mod["main"])
+    assert annos, "Expected at least one loop annotated by PipelinePlanning"
+    anno = annos[0]
+    stages = [int(v) for v in anno["software_pipeline_stage"]]
+    orders = [int(v) for v in anno["software_pipeline_order"]]
+    async_producers = [int(v) for v in anno["software_pipeline_async_producers"]]
+    async_groups = [int(v) for v in anno["software_pipeline_async_producer_groups"]]
+
+    assert stages == [0, 1]
+    assert orders == [1, 0]
+    assert async_producers == [1, 0]
+    assert async_groups == [0, -1]
 
 
 def test_pipeline_planning_binds_commit_to_cp_async_stage():

--- a/testing/python/transform/test_tilelang_transform_pipeline_planning.py
+++ b/testing/python/transform/test_tilelang_transform_pipeline_planning.py
@@ -273,7 +273,7 @@ def test_pipeline_planning_accepts_explicit_bind_free_annotations():
     ):
         with T.Kernel(1, threads=16):
             A_shared = T.alloc_shared((16,), T.float16)
-            for i in T.Pipelined(4, num_stages=2, order=[1, 0], stage=[0, 1]):
+            for i in T.Pipelined(4, order=[1, 0], stage=[0, 1]):
                 base: T.int32 = i * 16
                 T.copy(A[base], A_shared)
                 T.copy(A_shared, C[base])
@@ -291,6 +291,31 @@ def test_pipeline_planning_accepts_explicit_bind_free_annotations():
     assert orders == [1, 0]
     assert async_producers == [1, 0]
     assert async_groups == [0, -1]
+
+
+def test_pipeline_planning_keeps_bind_that_reads_pipeline_written_buffer():
+    @T.prim_func
+    def before(
+        A: T.Tensor((64,), T.float16),
+        C: T.Tensor((64,), T.float16),
+    ):
+        with T.Kernel(1, threads=16):
+            A_shared = T.alloc_shared((16,), T.float16)
+            for i in T.Pipelined(4, order=[0, 1, 2], stage=[0, 1, 1]):
+                base: T.int32 = i * 16
+                T.copy(A[base], A_shared)
+                value: T.float16 = A_shared[0]
+                C[base] = value
+
+    mod = _run_pipeline_planning(before, sm80_target)
+    annos = _collect_pipeline_loop_annotations(mod["main"])
+    assert annos, "Expected at least one loop annotated by PipelinePlanning"
+    anno = annos[0]
+    stages = [int(v) for v in anno["software_pipeline_stage"]]
+    orders = [int(v) for v in anno["software_pipeline_order"]]
+
+    assert stages == [0, 1, 1]
+    assert orders == [0, 1, 2]
 
 
 def test_pipeline_planning_binds_commit_to_cp_async_stage():

--- a/testing/python/transform/test_tilelang_transform_pipeline_planning.py
+++ b/testing/python/transform/test_tilelang_transform_pipeline_planning.py
@@ -257,11 +257,13 @@ def test_pipeline_planning_stages_bind_with_dependent_copy():
     stages = [int(v) for v in annos[0]["software_pipeline_stage"]]
     orders = [int(v) for v in annos[0]["software_pipeline_order"]]
     async_producers = [int(v) for v in annos[0]["software_pipeline_async_producers"]]
+    replayable_binds = [int(v) for v in annos[0]["software_pipeline_replayable_scalar_binds"]]
 
     assert len(stages) == 2, f"Expected copy and consumer stages, got {stages}"
     assert stages == [0, 1]
     assert orders == [0, 1]
     assert async_producers == [1, 0]
+    assert replayable_binds == [1, 0, 0]
 
 
 def test_pipeline_planning_accepts_explicit_bind_free_annotations():
@@ -286,11 +288,13 @@ def test_pipeline_planning_accepts_explicit_bind_free_annotations():
     orders = [int(v) for v in anno["software_pipeline_order"]]
     async_producers = [int(v) for v in anno["software_pipeline_async_producers"]]
     async_groups = [int(v) for v in anno["software_pipeline_async_producer_groups"]]
+    replayable_binds = [int(v) for v in anno["software_pipeline_replayable_scalar_binds"]]
 
     assert stages == [0, 1]
     assert orders == [1, 0]
     assert async_producers == [1, 0]
     assert async_groups == [0, -1]
+    assert replayable_binds == [1, 0, 0]
 
 
 def test_pipeline_planning_keeps_bind_that_reads_pipeline_written_buffer():
@@ -313,9 +317,11 @@ def test_pipeline_planning_keeps_bind_that_reads_pipeline_written_buffer():
     anno = annos[0]
     stages = [int(v) for v in anno["software_pipeline_stage"]]
     orders = [int(v) for v in anno["software_pipeline_order"]]
+    replayable_binds = [int(v) for v in anno["software_pipeline_replayable_scalar_binds"]]
 
     assert stages == [0, 1, 1]
     assert orders == [0, 1, 2]
+    assert replayable_binds == [1, 0, 0, 0]
 
 
 def test_pipeline_planning_binds_commit_to_cp_async_stage():

--- a/tilelang/language/loop.py
+++ b/tilelang/language/loop.py
@@ -147,9 +147,9 @@ def Pipelined(
 
     Notes
     -----
-    Scalar ``Bind`` statements created by local aliases are not scheduled
-    pipeline operations and should not consume entries in ``order`` or
-    ``stage``. For example, in the body below only the copy and store need
+    Replayable scalar ``Bind`` statements created by local aliases are not
+    scheduled pipeline operations and should not consume entries in ``order``
+    or ``stage``. For example, in the body below only the copy and store need
     annotation entries; ``base`` is replayed automatically at each use:
 
     .. code-block:: python
@@ -159,11 +159,18 @@ def Pipelined(
             T.copy(A[base], shared)
             T.copy(shared, B[base])
 
-    Older code that included scalar ``Bind`` entries in ``order``/``stage`` is
-    accepted for compatibility, but those entries are ignored by the pipeline
-    passes. New code should annotate only the scheduled statements. Avoid
-    setting ``num_stages`` together with manual ``order``/``stage`` unless you
-    intentionally need an explicit depth override.
+    A replayable ``Bind`` may also read a buffer that is not written by the
+    pipeline body, such as ``idx = Ids[i]``. If a ``Bind`` reads a buffer that
+    is written inside the same pipeline body, it is kept as a scheduled
+    statement because the load has a pipeline dependency and cannot be freely
+    replayed.
+
+    Older code that included replayable scalar ``Bind`` entries in
+    ``order``/``stage`` is accepted for compatibility, but those entries are
+    ignored by the pipeline passes. New code should annotate only the scheduled
+    statements. Avoid setting ``num_stages`` together with manual
+    ``order``/``stage`` unless you intentionally need an explicit depth
+    override.
     Returns
     -------
     res : frame.ForFrame

--- a/tilelang/language/loop.py
+++ b/tilelang/language/loop.py
@@ -129,6 +129,36 @@ def Pipelined(
     num_stages : int
         The max number of buffer used between pipeline producers and consumers.
         if num_stages is 0, pipeline will not be enabled.
+    order : Optional[List[int]]
+        Optional manual emission order for scheduled statements in the loop
+        body. This list should describe executable pipeline statements such as
+        copies, fills, GEMMs, reductions, stores, waits, or commits.
+    stage : Optional[List[int]]
+        Optional manual pipeline stage for each scheduled statement in the loop
+        body. The list is aligned with ``order`` and follows the same statement
+        counting rule.
+    sync : Optional[List[List[int]]]
+        Optional synchronization metadata for manual pipeline lowering.
+    group : Optional[List[List[int]]]
+        Optional producer grouping metadata for manual pipeline lowering.
+
+    Notes
+    -----
+    Scalar ``Bind`` statements created by local aliases are not scheduled
+    pipeline operations and should not consume entries in ``order`` or
+    ``stage``. For example, in the body below only the copy and store need
+    annotation entries; ``base`` is replayed automatically at each use:
+
+    .. code-block:: python
+
+        for i in T.Pipelined(n, num_stages=2, order=[1, 0], stage=[0, 1]):
+            base: T.int32 = i * block
+            T.copy(A[base], shared)
+            T.copy(shared, B[base])
+
+    Older code that included scalar ``Bind`` entries in ``order``/``stage`` is
+    accepted for compatibility, but those entries are ignored by the pipeline
+    passes. New code should annotate only the scheduled statements.
     Returns
     -------
     res : frame.ForFrame

--- a/tilelang/language/loop.py
+++ b/tilelang/language/loop.py
@@ -128,7 +128,10 @@ def Pipelined(
         The maximum value of iteration.
     num_stages : int
         The max number of buffer used between pipeline producers and consumers.
-        if num_stages is 0, pipeline will not be enabled.
+        For compiler-inferred pipelines, if ``num_stages`` is 0, pipeline will
+        not be enabled. For manually scheduled pipelines, prefer specifying
+        ``order`` and ``stage`` without ``num_stages``; the pipeline depth is
+        inferred as ``max(stage) + 1``.
     order : Optional[List[int]]
         Optional manual emission order for scheduled statements in the loop
         body. This list should describe executable pipeline statements such as
@@ -151,14 +154,16 @@ def Pipelined(
 
     .. code-block:: python
 
-        for i in T.Pipelined(n, num_stages=2, order=[1, 0], stage=[0, 1]):
+        for i in T.Pipelined(n, order=[1, 0], stage=[0, 1]):
             base: T.int32 = i * block
             T.copy(A[base], shared)
             T.copy(shared, B[base])
 
     Older code that included scalar ``Bind`` entries in ``order``/``stage`` is
     accepted for compatibility, but those entries are ignored by the pipeline
-    passes. New code should annotate only the scheduled statements.
+    passes. New code should annotate only the scheduled statements. Avoid
+    setting ``num_stages`` together with manual ``order``/``stage`` unless you
+    intentionally need an explicit depth override.
     Returns
     -------
     res : frame.ForFrame


### PR DESCRIPTION
## Summary

- Distinguish replayable scalar `Bind` aliases from `Bind` statements that represent pipeline-dependent loads.
- Keep bind-free pipeline annotations for value aliases, including read-only `BufferLoad` aliases such as `idx = Ids[i]`.
- Count `Bind` statements that read pipeline-written buffers as scheduled statements, because those loads have real producer/consumer dependencies.

## Changes

- Detect buffers written inside a pipeline body and only filter/replay scalar `Bind` statements whose reads do not touch those buffers.
- Preserve compatibility with legacy annotations that include replayable `Bind` slots by filtering those slots before scheduling.
- Validate scheduled `Bind` dependencies so scalar values without storage versioning stay in the same stage as their consumers and are ordered before them.
- Align `PipelinePlanning` and `InjectSoftwarePipeline` around the same replayable-bind model.
- Document the distinction between value aliases and materialized producers, including why `x = A[i]` can be replayed when `A` is not written by the pipeline, while `x = S[i]` must be scheduled when `S` is pipeline-written.
- Add regression coverage for read-only `BufferLoad` bind replay and pipeline-written-buffer bind scheduling.

## Validation

- `cmake --build build -j$(nproc)`
- `python -m pytest testing/python/transform/test_tilelang_transform_pipeline_planning.py -q`
- `python -m pytest testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py -q`
- `python /nfs-df/prod/data/permanent/wanglei/tilelang/debug/0520_bug/mqa_index_distill_mlp_dynamic.py > /tmp/tilelang_mqa_index_distill_dynamic_replayable_bind.log 2>&1`
- `pre-commit run --all-files`
