### PR TITLE
Fix atomic load access pointer lowering

### DIFF
--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -239,6 +239,20 @@ private:
       : arith::IRMutatorWithAnalyzer(analyzer) {}
   // Constructor initializing the base class with the analyzer
 
+  PrimExpr VisitExpr_(const CallNode *op) final {
+    if (!op->op.same_as(tl::access_ptr())) {
+      return IRMutatorWithAnalyzer::VisitExpr_(op);
+    }
+
+    // Arg0 is address metadata. Rewriting its BufferLoad into a safe-value
+    // expression destroys the pointer source needed by LowerAccessPtr.
+    ICHECK_EQ(op->args.size(), 3U)
+        << "tl.access_ptr expects 3 args: (BufferLoad, extent, rw_mask)";
+    Array<PrimExpr> args{op->args[0], VisitExpr(op->args[1]),
+                         VisitExpr(op->args[2])};
+    return Call(op->dtype, op->op, args, op->annotations, op->span);
+  }
+
   PrimExpr VisitExpr_(const BufferLoadNode *op) final {
     auto load = Downcast<BufferLoad>(IRMutatorWithAnalyzer::VisitExpr_(op));
 

--- a/src/transform/lower_access_ptr.cc
+++ b/src/transform/lower_access_ptr.cc
@@ -79,20 +79,22 @@ PrimExpr LinearOffsetFromLoad(const BufferLoad &load) {
 class AccessPtrLowerer : public StmtExprMutator {
 public:
   PrimExpr VisitExpr_(const CallNode *op) final {
-    Call call = Downcast<Call>(StmtExprMutator::VisitExpr_(op));
-    if (!call->op.same_as(tl::access_ptr())) {
-      return std::move(call);
+    if (!op->op.same_as(tl::access_ptr())) {
+      return StmtExprMutator::VisitExpr_(op);
     }
 
-    ICHECK_EQ(call->args.size(), 3U)
+    ICHECK_EQ(op->args.size(), 3U)
         << "tl.access_ptr expects 3 args: (BufferLoad, extent, rw_mask)";
 
-    BufferLoad base_load = Downcast<BufferLoad>(call->args[0]);
+    PrimExpr base = StmtExprMutator::VisitExpr(op->args[0]);
+    ICHECK(base.as<BufferLoadNode>())
+        << "tl.access_ptr arg0 must be BufferLoad, but got " << base;
+    BufferLoad base_load = Downcast<BufferLoad>(base);
     Buffer buffer = base_load->buffer;
     ICHECK(buffer.defined());
 
-    PrimExpr extent = call->args[1];
-    PrimExpr rw_mask = call->args[2];
+    PrimExpr extent = StmtExprMutator::VisitExpr(op->args[1]);
+    PrimExpr rw_mask = StmtExprMutator::VisitExpr(op->args[2]);
 
     PrimExpr ptype = tirx::TypeAnnotation(buffer->dtype);
     PrimExpr data = buffer->data;

--- a/testing/python/issue/test_tilelang_issue_2123.py
+++ b/testing/python/issue/test_tilelang_issue_2123.py
@@ -1,0 +1,54 @@
+import tilelang.language as T
+from tvm import tirx
+from tvm.tirx import op
+from tilelang.engine.lower import lower_to_host_device_ir
+
+
+def _atomic_load_dynamic_block_index(num_tiles=4, threads=128):
+    @T.prim_func
+    def kernel(
+        status: T.Tensor((num_tiles,), T.int32),
+        out: T.Tensor((1,), T.int32),
+    ):
+        with T.Kernel(num_tiles, threads=threads) as tile:
+            look = T.alloc_var(T.int32)
+            state = T.alloc_var(T.int32)
+            done = T.alloc_var(T.bool)
+            tx = T.get_thread_binding()
+
+            if tx == 0:
+                look = tile - 1
+                done = look < 0
+                state = 0
+                while not done:
+                    state = T.atomic_load(status[look], memory_order="acquire")
+                    if state != 0:
+                        done = True
+                    else:
+                        look -= 1
+                        done = look < 0
+
+                if tile == num_tiles - 1:
+                    out[0] = state
+
+    return kernel
+
+
+def test_issue_2123_atomic_load_block_derived_index_lowers():
+    func = _atomic_load_dynamic_block_index()
+    _, device_mod, *_ = lower_to_host_device_ir(func, target="cuda")
+
+    calls: list[tirx.Call] = []
+    for prim_func in device_mod.functions.values():
+        tirx.stmt_functor.post_order_visit(
+            prim_func.body,
+            lambda expr: calls.append(expr) if isinstance(expr, tirx.Call) else None,
+        )
+
+    assert not any(call.op.same_as(op.Op.get("tl.access_ptr")) for call in calls)
+    assert any(
+        call.op.same_as(op.Op.get("tl.atomic_load_elem_op"))
+        and isinstance(call.args[0], tirx.Call)
+        and call.args[0].op.same_as(op.Op.get("tirx.tvm_access_ptr"))
+        for call in calls
+    )


### PR DESCRIPTION
Fixes #2123.

Summary:
- Preserve `tl.access_ptr` arg0 as address metadata during safe-memory rewriting.
- Lower `tl.access_ptr` without recursively mutating the full call before reading its `BufferLoad` base.
- Add a regression for `T.atomic_load(status[look])` with a block-derived mutable loop index.

Validation:
- `cmake --build build -j14`
- `python -m pytest testing/python/issue/test_tilelang_issue_2123.py testing/python/language/test_tilelang_language_access_ptr.py -q`
- `pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced atomic load operation handling for dynamically-derived block indices during code generation.

* **Tests**
  * Added test coverage for atomic load operations with complex dynamic indexing patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->