### PR TITLE
[CUDA][IR] Preserve dynamic shared memory aliases

### DIFF
--- a/src/transform/merge_shared_memory_allocations.cc
+++ b/src/transform/merge_shared_memory_allocations.cc
@@ -472,6 +472,44 @@ public:
   }
 
 private:
+  std::vector<Stmt> MakeAliasBindings() const {
+    struct AliasInfo {
+      const VarNode *var{nullptr};
+      PrimExpr byte_offset;
+    };
+
+    std::vector<AliasInfo> aliases;
+    aliases.reserve(buffer_byte_offsets_.size());
+    for (const auto &pair : buffer_byte_offsets_) {
+      if (shmem_allocs_.count(pair.first) == 0) {
+        continue;
+      }
+      aliases.push_back(AliasInfo{pair.first, pair.second});
+    }
+
+    std::sort(aliases.begin(), aliases.end(),
+              [](const AliasInfo &lhs, const AliasInfo &rhs) {
+                const auto *lhs_offset = lhs.byte_offset.as<IntImmNode>();
+                const auto *rhs_offset = rhs.byte_offset.as<IntImmNode>();
+                if (lhs_offset != nullptr && rhs_offset != nullptr &&
+                    lhs_offset->value != rhs_offset->value) {
+                  return lhs_offset->value < rhs_offset->value;
+                }
+                return lhs.var->name_hint < rhs.var->name_hint;
+              });
+
+    std::vector<Stmt> bindings;
+    bindings.reserve(aliases.size());
+    for (const AliasInfo &alias : aliases) {
+      Var buffer_var = GetRef<Var>(alias.var);
+      PrimExpr alias_ptr =
+          Call(DataType::Handle(), builtin::handle_add_byte_offset(),
+               {merged_buf_var_, alias.byte_offset});
+      bindings.push_back(tirx::Bind(buffer_var, alias_ptr));
+    }
+    return bindings;
+  }
+
   Stmt VisitStmt_(const AttrStmtNode *op) final {
     if (op->attr_key == tirx::attr::thread_extent && !allocated_) {
       // Allocate one dynamic shared memory allocation at the beginning of
@@ -512,8 +550,13 @@ private:
       Buffer merged_buf(merged_buf_var_, DataType::UInt(8),
                         {merged_alloc_size_}, {}, PrimExpr(),
                         merged_buf_var_->name_hint, 0, 0, kDefault);
-      Stmt new_body = SeqStmt(
-          {AllocBuffer(merged_buf), StmtExprMutator::VisitStmt(op->body)});
+      Array<Stmt> seq;
+      seq.push_back(AllocBuffer(merged_buf));
+      for (const Stmt &alias_binding : MakeAliasBindings()) {
+        seq.push_back(alias_binding);
+      }
+      seq.push_back(StmtExprMutator::VisitStmt(op->body));
+      Stmt new_body = SeqStmt(seq);
       return AttrStmt(op->node, op->attr_key, op->value, new_body, op->span);
     }
     return StmtMutator::VisitStmt_(op);
@@ -530,12 +573,7 @@ private:
   }
 
   Stmt VisitStmt_(const DeclBufferNode *op) final {
-    auto node = Downcast<DeclBuffer>(StmtExprMutator::VisitStmt_(op));
-    auto new_buf = GetUpdatedBuffer(node->buffer);
-    if (!new_buf.same_as(node->buffer)) {
-      node.CopyOnWrite()->buffer = new_buf;
-    }
-    return std::move(node);
+    return StmtExprMutator::VisitStmt_(op);
   }
 
   PrimExpr VisitExpr_(const BufferLoadNode *op) final {
@@ -554,124 +592,13 @@ private:
           << "MergeSharedMemoryAllocations expects flat memory buffers, "
           << "and is to be run after "
           << "StorageFlatten (TE schedules) or FlattenBuffer (TIR schedules)";
-      Array<PrimExpr> indices = {
-          node->indices[0] +
-          this->GetBufferOffset(node->buffer->data, node->buffer->dtype)};
-
-      auto writer = node.CopyOnWrite();
-      writer->buffer = GetUpdatedBuffer(node->buffer);
-      writer->indices = indices;
     }
 
     return node;
   }
 
-  Buffer GetUpdatedBuffer(Buffer buffer) {
-    auto key = buffer.get();
-    auto it = buffer_remap_.find(key);
-    if (it != buffer_remap_.end()) {
-      return it->second;
-    }
-
-    if (IsAppropriateSharedMemory(buffer->data)) {
-      ICHECK_EQ(buffer->shape.size(), 1)
-          << "Buffer " << buffer << " has shape " << buffer->shape << ".  "
-          << "MergeSharedMemoryAllocations expects flat memory buffers, "
-          << "and is to be run after "
-          << "StorageFlatten (TE schedules) or FlattenBuffer (TIR schedules)";
-      auto writer = buffer.CopyOnWrite();
-      writer->data = merged_buf_var_;
-    }
-
-    buffer_remap_[key] = buffer;
-    return buffer;
-  }
-
   PrimExpr VisitExpr_(const CallNode *op) final {
-    if (op->op.same_as(builtin::tvm_access_ptr())) {
-      ICHECK_EQ(op->args.size(), 5U);
-      DataType dtype = op->args[0].dtype();
-      Var buffer = Downcast<Var>(op->args[1]);
-      if (!IsAppropriateSharedMemory(buffer)) {
-        return StmtExprMutator::VisitExpr_(op);
-      }
-      if (!IsManagedAllocation(buffer)) {
-        return StmtExprMutator::VisitExpr_(op);
-      }
-      ICHECK(HasBufferOffset(buffer))
-          << "Shared memory allocation " << buffer->name_hint
-          << " was collected for merging but was not assigned an offset.";
-      PrimExpr extra_offset = GetBufferOffset(buffer, dtype);
-
-      PrimExpr offset = this->VisitExpr(op->args[2]);
-      PrimExpr extent = this->VisitExpr(op->args[3]);
-      return Call(op->dtype, op->op,
-                  {op->args[0], merged_buf_var_, extra_offset + offset, extent,
-                   op->args[4]});
-    } else if (op->op.same_as(builtin::ptx_cp_async()) ||
-               op->op.same_as(tl::ptx_cp_async())) {
-      ICHECK(op->args.size() == 3U || op->args.size() == 4U)
-          << "ptx_cp_async expects 3 or 4 arguments (dst_access_ptr, "
-             "src_access_ptr, count[, predicate])";
-
-      // Extract dst_access_ptr and check if it needs merging
-      Call dst_access_ptr = Downcast<Call>(op->args[0]);
-      ICHECK(dst_access_ptr->op.same_as(builtin::tvm_access_ptr()))
-          << "First argument must be tvm_access_ptr";
-
-      // tvm_access_ptr(ptype, data, offset, extent, rw_mask)
-      Var buffer = Downcast<Var>(dst_access_ptr->args[1]);
-      if (!IsAppropriateSharedMemory(buffer)) {
-        return StmtExprMutator::VisitExpr_(op);
-      }
-      if (!IsManagedAllocation(buffer)) {
-        return StmtExprMutator::VisitExpr_(op);
-      }
-      ICHECK(HasBufferOffset(buffer))
-          << "Shared memory allocation " << buffer->name_hint
-          << " was collected for merging but was not assigned an offset.";
-
-      DataType dtype = op->dtype;
-      DataType ptr_dtype = dst_access_ptr->args[0].dtype();
-      PrimExpr extra_offset = GetBufferOffset(buffer, ptr_dtype);
-      PrimExpr offset = this->VisitExpr(dst_access_ptr->args[2]);
-
-      // Create new dst_access_ptr with merged buffer and adjusted offset
-      auto new_dst_access_ptr =
-          Call(DataType::Handle(), builtin::tvm_access_ptr(),
-               {
-                   dst_access_ptr->args[0], // ptype
-                   merged_buf_var_,         // merged buffer
-                   extra_offset + offset,   // adjusted offset
-                   dst_access_ptr->args[3], // extent
-                   dst_access_ptr->args[4]  // rw_mask
-               });
-
-      Array<PrimExpr> cp_async_args = {new_dst_access_ptr, op->args[1],
-                                       op->args[2]};
-      if (op->args.size() == 4U) {
-        cp_async_args.push_back(op->args[3]);
-      }
-      return Call(dtype, op->op, cp_async_args);
-    } else {
-      return StmtExprMutator::VisitExpr_(op);
-    }
-  }
-
-  PrimExpr GetBufferOffset(const Var &buffer_var, DataType dtype) {
-    auto it = buffer_byte_offsets_.find(buffer_var.get());
-    ICHECK(it != buffer_byte_offsets_.end())
-        << "buffer_var = " << buffer_var->name_hint << ", dtype = " << dtype;
-    return indexdiv(it->second, dtype.bytes() * dtype.lanes());
-  }
-
-  bool HasBufferOffset(const Var &buffer_var) {
-    return buffer_byte_offsets_.find(buffer_var.get()) !=
-           buffer_byte_offsets_.end();
-  }
-
-  bool IsManagedAllocation(const Var &buffer_var) {
-    return shmem_allocs_.find(buffer_var.get()) != shmem_allocs_.end();
+    return StmtExprMutator::VisitExpr_(op);
   }
 
   // Wrapper function to determine if the shared memory allocation for a
@@ -1482,9 +1409,6 @@ private:
   PrimExpr merged_alloc_size_{0};
   // The mapping from the original buffer var to its offset in the merged buffer
   std::unordered_map<const VarNode *, PrimExpr> buffer_byte_offsets_;
-  // The mapping from the original buffer objects to their location in the
-  // merged buffer.
-  std::unordered_map<const BufferNode *, Buffer> buffer_remap_;
   // The flag indicating whether the merged buffer has been allocated
   bool allocated_{false};
   // Locations of free ops.

--- a/src/transform/merge_shared_memory_allocations.cc
+++ b/src/transform/merge_shared_memory_allocations.cc
@@ -27,6 +27,7 @@
 #include <tvm/ir/cast.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/s_tir/stmt.h>
+#include <tvm/target/target.h>
 #include <tvm/tirx/expr.h>
 #include <tvm/tirx/op.h>
 #include <tvm/tirx/stmt_functor.h>
@@ -446,9 +447,10 @@ public:
   explicit SharedMemoryRewriter(
       const std::unordered_map<const VarNode *, const AllocBufferNode *>
           &shmem_allocs,
-      bool is_dynamic = true, bool verbose = false, int align_bytes = 0)
+      bool is_dynamic = true, bool verbose = false, int align_bytes = 0,
+      bool preserve_aliases = true)
       : is_dynamic_{is_dynamic}, shmem_allocs_{shmem_allocs}, verbose_{verbose},
-        align_bytes_{align_bytes} {
+        align_bytes_{align_bytes}, preserve_aliases_{preserve_aliases} {
     if (!is_dynamic) {
       merged_buf_var_ =
           Var("buf_shmem", PointerType(PrimType(DataType::UInt(8)), "shared"));
@@ -552,8 +554,10 @@ private:
                         merged_buf_var_->name_hint, 0, 0, kDefault);
       Array<Stmt> seq;
       seq.push_back(AllocBuffer(merged_buf));
-      for (const Stmt &alias_binding : MakeAliasBindings()) {
-        seq.push_back(alias_binding);
+      if (preserve_aliases_) {
+        for (const Stmt &alias_binding : MakeAliasBindings()) {
+          seq.push_back(alias_binding);
+        }
       }
       seq.push_back(StmtExprMutator::VisitStmt(op->body));
       Stmt new_body = SeqStmt(seq);
@@ -573,7 +577,14 @@ private:
   }
 
   Stmt VisitStmt_(const DeclBufferNode *op) final {
-    return StmtExprMutator::VisitStmt_(op);
+    auto node = Downcast<DeclBuffer>(StmtExprMutator::VisitStmt_(op));
+    if (!preserve_aliases_) {
+      auto new_buf = GetUpdatedBuffer(node->buffer);
+      if (!new_buf.same_as(node->buffer)) {
+        node.CopyOnWrite()->buffer = new_buf;
+      }
+    }
+    return std::move(node);
   }
 
   PrimExpr VisitExpr_(const BufferLoadNode *op) final {
@@ -592,13 +603,128 @@ private:
           << "MergeSharedMemoryAllocations expects flat memory buffers, "
           << "and is to be run after "
           << "StorageFlatten (TE schedules) or FlattenBuffer (TIR schedules)";
+      if (!preserve_aliases_) {
+        Array<PrimExpr> indices = {
+            node->indices[0] +
+            this->GetBufferOffset(node->buffer->data, node->buffer->dtype)};
+
+        auto writer = node.CopyOnWrite();
+        writer->buffer = GetUpdatedBuffer(node->buffer);
+        writer->indices = indices;
+      }
     }
 
     return node;
   }
 
+  Buffer GetUpdatedBuffer(Buffer buffer) {
+    auto key = buffer.get();
+    auto it = buffer_remap_.find(key);
+    if (it != buffer_remap_.end()) {
+      return it->second;
+    }
+
+    if (IsAppropriateSharedMemory(buffer->data)) {
+      ICHECK_EQ(buffer->shape.size(), 1)
+          << "Buffer " << buffer << " has shape " << buffer->shape << ".  "
+          << "MergeSharedMemoryAllocations expects flat memory buffers, "
+          << "and is to be run after "
+          << "StorageFlatten (TE schedules) or FlattenBuffer (TIR schedules)";
+      auto writer = buffer.CopyOnWrite();
+      writer->data = merged_buf_var_;
+    }
+
+    buffer_remap_[key] = buffer;
+    return buffer;
+  }
+
   PrimExpr VisitExpr_(const CallNode *op) final {
+    if (preserve_aliases_) {
+      return StmtExprMutator::VisitExpr_(op);
+    }
+    if (op->op.same_as(builtin::tvm_access_ptr())) {
+      ICHECK_EQ(op->args.size(), 5U);
+      DataType dtype = op->args[0].dtype();
+      Var buffer = Downcast<Var>(op->args[1]);
+      if (!IsAppropriateSharedMemory(buffer)) {
+        return StmtExprMutator::VisitExpr_(op);
+      }
+      if (!IsManagedAllocation(buffer)) {
+        return StmtExprMutator::VisitExpr_(op);
+      }
+      ICHECK(HasBufferOffset(buffer))
+          << "Shared memory allocation " << buffer->name_hint
+          << " was collected for merging but was not assigned an offset.";
+      PrimExpr extra_offset = GetBufferOffset(buffer, dtype);
+
+      PrimExpr offset = this->VisitExpr(op->args[2]);
+      PrimExpr extent = this->VisitExpr(op->args[3]);
+      return Call(op->dtype, op->op,
+                  {op->args[0], merged_buf_var_, extra_offset + offset, extent,
+                   op->args[4]});
+    } else if (op->op.same_as(builtin::ptx_cp_async()) ||
+               op->op.same_as(tl::ptx_cp_async())) {
+      ICHECK(op->args.size() == 3U || op->args.size() == 4U)
+          << "ptx_cp_async expects 3 or 4 arguments (dst_access_ptr, "
+             "src_access_ptr, count[, predicate])";
+
+      // Extract dst_access_ptr and check if it needs merging
+      Call dst_access_ptr = Downcast<Call>(op->args[0]);
+      ICHECK(dst_access_ptr->op.same_as(builtin::tvm_access_ptr()))
+          << "First argument must be tvm_access_ptr";
+
+      // tvm_access_ptr(ptype, data, offset, extent, rw_mask)
+      Var buffer = Downcast<Var>(dst_access_ptr->args[1]);
+      if (!IsAppropriateSharedMemory(buffer)) {
+        return StmtExprMutator::VisitExpr_(op);
+      }
+      if (!IsManagedAllocation(buffer)) {
+        return StmtExprMutator::VisitExpr_(op);
+      }
+      ICHECK(HasBufferOffset(buffer))
+          << "Shared memory allocation " << buffer->name_hint
+          << " was collected for merging but was not assigned an offset.";
+
+      DataType dtype = op->dtype;
+      DataType ptr_dtype = dst_access_ptr->args[0].dtype();
+      PrimExpr extra_offset = GetBufferOffset(buffer, ptr_dtype);
+      PrimExpr offset = this->VisitExpr(dst_access_ptr->args[2]);
+
+      // Create new dst_access_ptr with merged buffer and adjusted offset
+      auto new_dst_access_ptr =
+          Call(DataType::Handle(), builtin::tvm_access_ptr(),
+               {
+                   dst_access_ptr->args[0], // ptype
+                   merged_buf_var_,         // merged buffer
+                   extra_offset + offset,   // adjusted offset
+                   dst_access_ptr->args[3], // extent
+                   dst_access_ptr->args[4]  // rw_mask
+               });
+
+      Array<PrimExpr> cp_async_args = {new_dst_access_ptr, op->args[1],
+                                       op->args[2]};
+      if (op->args.size() == 4U) {
+        cp_async_args.push_back(op->args[3]);
+      }
+      return Call(dtype, op->op, cp_async_args);
+    }
     return StmtExprMutator::VisitExpr_(op);
+  }
+
+  PrimExpr GetBufferOffset(const Var &buffer_var, DataType dtype) {
+    auto it = buffer_byte_offsets_.find(buffer_var.get());
+    ICHECK(it != buffer_byte_offsets_.end())
+        << "buffer_var = " << buffer_var->name_hint << ", dtype = " << dtype;
+    return indexdiv(it->second, dtype.bytes() * dtype.lanes());
+  }
+
+  bool HasBufferOffset(const Var &buffer_var) {
+    return buffer_byte_offsets_.find(buffer_var.get()) !=
+           buffer_byte_offsets_.end();
+  }
+
+  bool IsManagedAllocation(const Var &buffer_var) {
+    return shmem_allocs_.find(buffer_var.get()) != shmem_allocs_.end();
   }
 
   // Wrapper function to determine if the shared memory allocation for a
@@ -1409,28 +1535,36 @@ private:
   PrimExpr merged_alloc_size_{0};
   // The mapping from the original buffer var to its offset in the merged buffer
   std::unordered_map<const VarNode *, PrimExpr> buffer_byte_offsets_;
+  // The mapping from the original buffer objects to their location in the
+  // merged buffer.
+  std::unordered_map<const BufferNode *, Buffer> buffer_remap_;
   // The flag indicating whether the merged buffer has been allocated
   bool allocated_{false};
   // Locations of free ops.
   std::unordered_map<const Object *, EventEntry> event_map_;
   // The mapping of buffer bytes alignment
   std::unordered_map<const VarNode *, int> shmem_alignment_map_;
+  // Whether to preserve original buffer vars as handle aliases of the merged
+  // allocation. Some backends, such as WebGPU, cannot print handle-valued Bind
+  // nodes and use the direct merged-buffer rewrite path instead.
+  bool preserve_aliases_{true};
 };
 
 Stmt MergeSharedMemoryAllocations(Stmt stmt, bool merge_static_smem,
                                   bool enable_aggressive_merge,
-                                  int align_bytes = 16, bool verbose = false) {
+                                  int align_bytes = 16, bool verbose = false,
+                                  bool preserve_aliases = true) {
   AllocateCollector collector;
   collector(stmt);
   if (collector.dyn_shmem_allocs_.size() > 1) {
     SharedMemoryRewriter rewriter(collector.dyn_shmem_allocs_, true, verbose,
-                                  align_bytes);
+                                  align_bytes, preserve_aliases);
     rewriter.PlanReuse(stmt, true, enable_aggressive_merge);
     stmt = rewriter(std::move(stmt));
   }
   if (merge_static_smem && collector.static_shmem_allocs_.size() > 1) {
     SharedMemoryRewriter rewriter(collector.static_shmem_allocs_, false,
-                                  verbose, align_bytes);
+                                  verbose, align_bytes, preserve_aliases);
     rewriter.PlanReuse(stmt, false, enable_aggressive_merge);
     stmt = rewriter(std::move(stmt));
   }
@@ -1450,10 +1584,14 @@ Pass MergeSharedMemoryAllocations(bool enable_aggressive_merge = false,
     bool debug_merge_shared_memory_allocations =
         ctx->GetConfig<Bool>(kDebugMergeSharedMemoryAllocations, Bool(false))
             .value();
+    bool preserve_aliases = true;
+    if (auto target = f->GetAttr<Target>(tvm::attr::kTarget)) {
+      preserve_aliases = target.value()->kind->name != "webgpu";
+    }
     auto *n = f.CopyOnWrite();
     n->body = tl::MergeSharedMemoryAllocations(
         std::move(n->body), merge_static_smem, enable_aggressive_merge,
-        align_bytes, debug_merge_shared_memory_allocations);
+        align_bytes, debug_merge_shared_memory_allocations, preserve_aliases);
     return f;
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.MergeSharedMemoryAllocations",

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -630,6 +630,10 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
   StorageScope GetScope(Var buffer_var) const {
     return StorageScope::Create(GetPtrStorageScope(std::move(buffer_var)));
   }
+  bool IsSharedDynPointer(const Var &buffer_var) const {
+    return buffer_var->type_annotation.as<PointerTypeNode>() &&
+           GetPtrStorageScope(buffer_var) == "shared.dyn";
+  }
   PrimExpr AliasElemOffset(Var buffer_var, DataType dtype,
                            DataType index_dtype) const {
     auto it = shared_memory_alias_byte_offsets_.find(buffer_var.get());
@@ -661,14 +665,13 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     return index + elem_offset;
   }
   void RecordSharedMemoryAlias(const Var &alias_var, const PrimExpr &value) {
-    StorageScope alias_scope = GetScope(alias_var);
-    if (alias_scope.rank != StorageRank::kShared || alias_scope.tag != ".dyn") {
-      return;
-    }
     const auto *call = value.as<CallNode>();
     if (call == nullptr ||
         !call->op.same_as(builtin::handle_add_byte_offset()) ||
         call->args.size() != 2U) {
+      return;
+    }
+    if (!IsSharedDynPointer(alias_var)) {
       return;
     }
     const auto *base = call->args[0].as<VarNode>();

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -625,8 +625,62 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
   };
   // access scope
   std::vector<std::vector<StmtEntry>> scope_;
+  std::unordered_map<const VarNode *, PrimExpr>
+      shared_memory_alias_byte_offsets_;
   StorageScope GetScope(Var buffer_var) const {
     return StorageScope::Create(GetPtrStorageScope(std::move(buffer_var)));
+  }
+  PrimExpr AliasElemOffset(Var buffer_var, DataType dtype,
+                           DataType index_dtype) const {
+    auto it = shared_memory_alias_byte_offsets_.find(buffer_var.get());
+    if (it == shared_memory_alias_byte_offsets_.end()) {
+      return make_const(index_dtype, 0);
+    }
+    int elem_bytes = dtype.bytes() * dtype.lanes();
+    ICHECK_GT(elem_bytes, 0);
+    PrimExpr byte_offset = it->second;
+    if (byte_offset.dtype() != index_dtype) {
+      byte_offset = Cast(index_dtype, byte_offset);
+    }
+    return indexdiv(byte_offset, make_const(index_dtype, elem_bytes));
+  }
+  PrimExpr AddAliasElemOffset(Var buffer_var, DataType dtype,
+                              PrimExpr index) const {
+    DataType index_dtype = index.dtype();
+    DataType scalar_index_dtype =
+        index_dtype.is_scalar() ? index_dtype : index_dtype.element_of();
+    PrimExpr elem_offset =
+        AliasElemOffset(std::move(buffer_var), dtype, scalar_index_dtype);
+    if (is_zero(elem_offset)) {
+      return index;
+    }
+    if (!index_dtype.is_scalar()) {
+      elem_offset = Broadcast(elem_offset,
+                              IntImm(DataType::Int(32), index_dtype.lanes()));
+    }
+    return index + elem_offset;
+  }
+  void RecordSharedMemoryAlias(const Var &alias_var, const PrimExpr &value) {
+    StorageScope alias_scope = GetScope(alias_var);
+    if (alias_scope.rank != StorageRank::kShared || alias_scope.tag != ".dyn") {
+      return;
+    }
+    const auto *call = value.as<CallNode>();
+    if (call == nullptr ||
+        !call->op.same_as(builtin::handle_add_byte_offset()) ||
+        call->args.size() != 2U) {
+      return;
+    }
+    const auto *base = call->args[0].as<VarNode>();
+    if (base == nullptr) {
+      return;
+    }
+    PrimExpr byte_offset = call->args[1];
+    auto base_it = shared_memory_alias_byte_offsets_.find(base);
+    if (base_it != shared_memory_alias_byte_offsets_.end()) {
+      byte_offset = byte_offset + base_it->second;
+    }
+    shared_memory_alias_byte_offsets_[alias_var.get()] = byte_offset;
   }
   IterVar GetThreadVar(const std::string &tag) const {
     for (const auto &iv : env_threads_) {
@@ -649,10 +703,12 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       e.threads = env_threads();
       e.buffer = buf;
       e.buffer_name = op->buffer;
-      e.buffer_indices = op->indices;
       e.dtype = op->dtype.element_of();
       for (const auto &index : op->indices) {
-        e.touched.push_back(arith::IntSet::Vector(index));
+        PrimExpr physical_index =
+            AddAliasElemOffset(buf, op->buffer->dtype, index);
+        e.buffer_indices.push_back(physical_index);
+        e.touched.push_back(arith::IntSet::Vector(physical_index));
       }
       e.type = kRead;
       e.scope = scope;
@@ -674,10 +730,12 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       e.threads = env_threads();
       e.buffer = buf;
       e.buffer_name = op->buffer;
-      e.buffer_indices = op->indices;
       e.dtype = op->value.dtype().element_of();
       for (const auto &index : op->indices) {
-        e.touched.push_back(arith::IntSet::Vector(index));
+        PrimExpr physical_index =
+            AddAliasElemOffset(buf, op->buffer->dtype, index);
+        e.buffer_indices.push_back(physical_index);
+        e.touched.push_back(arith::IntSet::Vector(physical_index));
       }
       e.type = kWrite;
       e.scope = scope;
@@ -708,6 +766,7 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     allow_append_ = true;
     ICHECK_EQ(curr_stmt_.access.size(), 0U);
     curr_stmt_.stmt = op;
+    RecordSharedMemoryAlias(op->var, op->value);
     this->VisitExpr(op->value);
     // push to the scope
     scope_.back().push_back(curr_stmt_);
@@ -1009,7 +1068,8 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
         // Use buffer shape and indices to compute the buffer_ranges for each
         // dimension.
         for (size_t i = 0; i < buffer->shape.size(); ++i) {
-          PrimExpr min = load->indices[i];
+          PrimExpr min = AddAliasElemOffset(GetRef<Var>(buffer_var),
+                                            buffer->dtype, load->indices[i]);
           PrimExpr extent = make_const(buffer->shape[i].dtype(), 1);
           buffer_ranges.push_back(Range::FromMinExtent(min, extent));
         }
@@ -1022,7 +1082,9 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
           e.buffer_name = buffer;
           e.buffer_ranges = buffer_ranges;
           for (const auto &index : load->indices) {
-            e.touched.push_back(arith::IntSet::Vector(index));
+            PrimExpr physical_index = AddAliasElemOffset(
+                GetRef<Var>(buffer_var), buffer->dtype, index);
+            e.touched.push_back(arith::IntSet::Vector(physical_index));
           }
           e.is_pointer_access = true;
           e.is_atomic = (atomic_dst_ptr_depth_ > 0);
@@ -1038,7 +1100,8 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       ICHECK_EQ(op->args.size(), 5U);
       DataType dtype = op->args[0].dtype();
       const VarNode *buffer_var = op->args[1].as<VarNode>();
-      PrimExpr offset = op->args[2];
+      PrimExpr offset =
+          AddAliasElemOffset(GetRef<Var>(buffer_var), dtype, op->args[2]);
       PrimExpr extent = op->args[3];
       const IntImmNode *flag = op->args[4].as<IntImmNode>();
       StorageScope scope = GetScope(GetRef<Var>(buffer_var));

--- a/testing/python/components/test_cuda_shared_memory_alias_codegen.py
+++ b/testing/python/components/test_cuda_shared_memory_alias_codegen.py
@@ -1,0 +1,34 @@
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+@tilelang.testing.requires_cuda
+def test_dynamic_shared_memory_merge_emits_named_aliases():
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((32,), T.float16),
+        B: T.Tensor((32,), T.float16),
+        C: T.Tensor((32,), T.float16),
+    ):
+        with T.Kernel(1, threads=32):
+            A_shared = T.alloc_shared((32,), T.float16)
+            B_shared = T.alloc_shared((32,), T.float16)
+            A_shared[0] = A[0]
+            B_shared[0] = B[0]
+            T.tvm_storage_sync("shared")
+            C[0] = A_shared[0] + B_shared[0]
+
+    artifact = tilelang.lower(kernel, target="cuda")
+    source = artifact.kernel_source
+
+    assert "extern __shared__ __align__(1024) uchar buf_dyn_shmem[];" in source
+    assert "void* A_shared = ((void*)((char*)buf_dyn_shmem + 0));" in source
+    assert "void* B_shared = ((void*)((char*)buf_dyn_shmem + 64));" in source
+    assert "A_shared" in source
+    assert "B_shared" in source
+    assert "((half_t*)buf_dyn_shmem)" not in source
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_disable_memory_reuse.py
+++ b/testing/python/transform/test_tilelang_transform_disable_memory_reuse.py
@@ -128,9 +128,7 @@ def test_disable_reuse_no_overlap():
         """Extract merged shared-memory offsets from generated code."""
         # Alias-preserving lowering emits:
         #   void* a_shared = ((void*)((char*)buf_dyn_shmem + 0));
-        alias_pattern = (
-            r"void\*\s+\w+\s*=\s*\(\(void\*\)\(\(char\*\)buf_dyn_shmem\s*\+\s*(\d+)\)\);"
-        )
+        alias_pattern = r"void\*\s+\w+\s*=\s*\(\(void\*\)\(\(char\*\)buf_dyn_shmem\s*\+\s*(\d+)\)\);"
         # Direct merged-buffer lowering emits access patterns such as:
         #   buf_dyn_shmem)[1024])
         direct_pattern = r"buf_dyn_shmem\)\[(\d+)\]"


### PR DESCRIPTION
## Summary

- Preserve named shared-memory aliases when dynamic shared allocations are merged instead of rewriting every access to the merged allocation.
- Keep thread sync analysis aware of alias byte offsets so disjoint aliases do not create false shared-memory conflicts.

## Changes

- Emit `Bind` statements that define each original shared allocation as a `handle_add_byte_offset` alias of `buf_dyn_shmem`.
- Track `shared.dyn` alias offsets in the thread sync planner and include the corresponding element offset in load, store, and pointer-access conflict ranges.
- Add a CUDA codegen test covering named aliases and avoiding repeated direct casts from `buf_dyn_shmem`.

## Example

Before this change, accesses after dynamic shared-memory merging were printed directly against the merged allocation:

```cpp
*(uint4*)(((half_t*)buf_dyn_shmem) + a_offset) = ...;
*(uint4*)(((half_t*)buf_dyn_shmem) + b_offset) = ...;
```

After this change, the original shared buffers are preserved as aliases of the merged dynamic allocation, and later accesses use those alias names:

```cpp
extern __shared__ __align__(1024) uchar buf_dyn_shmem[];
void* A_shared = ((void*)((char*)buf_dyn_shmem + 0));
void* B_shared = ((void*)((char*)buf_dyn_shmem + 8192));

*(uint4*)(((half_t*)A_shared) + a_index) = ...;
*(uint4*)(((half_t*)B_shared) + b_index) = ...;
```

The sync planner still reasons about physical shared-memory locations by folding alias byte offsets into element indices. For example:

```text
A_shared[tx] -> tx + 0
B_shared[tx] -> tx + 4096  // 8192 bytes / sizeof(half_t)
```

This keeps `A_shared` and `B_shared` in the same `shared.dyn` allocation for dependency analysis while avoiding false conflicts between disjoint regions.

## Validation

- `./format.sh`
- `cmake --build build -j$(nproc)`
- `PYTHONPATH=$(pwd):$PYTHONPATH python -m pytest testing/python/components/test_cuda_shared_memory_alias_codegen.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared-memory merging adds an alias-preservation mode with a public option to emit per-buffer handle aliases (enabled by default for non-WebGPU targets).

* **Bug Fixes**
  * Thread-storage sync and access planning now account for shared-memory handle aliases so memory accesses and offsets are correct.

* **Tests**
  * Added/updated tests to verify CUDA codegen emits named pointer aliases and to robustly extract shared-memory offsets in both alias-preserving and merged-buffer outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->