### PR TITLE
[BugFix] Add missing quarter swizzle and disallow `T.tma_copy` SIMT fallback

### DIFF
--- a/src/backend/cuda/op/copy.cc
+++ b/src/backend/cuda/op/copy.cc
@@ -1492,7 +1492,8 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
       DLOG(WARNING) << "TMA bulk copy cannot support a swizzled global layout "
                        "with inner_box_dim_ > "
                     << check.max_dim << ", will be fallback to normal copy";
-      return fallback_to_normal("swizzled shared box exceeds swizzle byte width");
+      return fallback_to_normal(
+          "swizzled shared box exceeds swizzle byte width");
     }
   }
 

--- a/src/backend/cuda/op/copy.cc
+++ b/src/backend/cuda/op/copy.cc
@@ -1283,10 +1283,19 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
   Array<Range> global_range = is_load ? src_range : dst_range;
   Array<Range> shared_range = is_load ? dst_range : src_range;
 
+  auto fallback_to_normal = [&](const char *reason) -> Stmt {
+    if (GetIsTmaCopy(op)) {
+      LOG(FATAL) << "T.tma_copy() cannot fall back to normal copy in "
+                 << "LowerBulk: " << reason << ", src=" << src->name
+                 << ", dst=" << dst->name;
+    }
+    return LowerNormal(op, T, analyzer);
+  };
+
   if (T.layout_map.count(global_tensor)) {
     DLOG(WARNING) << "TMA bulk copy cannot support a non-swizzled global "
                      "layout, fallback to normal copy.";
-    return LowerNormal(op, T, analyzer);
+    return fallback_to_normal("non-swizzled global layout");
   }
 
   auto linear_layout = ComputeLinearLayout(shared_tensor);
@@ -1360,7 +1369,7 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
       if (stride->value % 16 != 0 || stride->value >= (1ULL << 40)) {
         DLOG(WARNING) << "TMA bulk copy cannot support a global stride of "
                       << desc.global_stride[i] << ", fallback to normal copy.";
-        return LowerNormal(op, T, analyzer);
+        return fallback_to_normal("unsupported global stride");
       }
     }
   }
@@ -1413,7 +1422,7 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
       DLOG(WARNING) << "TMA bulk copy cannot support shared layout with input "
                     << "dimension " << shared_layout->InputDim()
                     << ", fallback to normal copy.";
-      return LowerNormal(op, T, analyzer);
+      return fallback_to_normal("shared layout input dimension is less than 2");
     }
     const int ndim = static_cast<int>(shared_layout->InputDim());
     auto stride = as_const_int(shared_layout->InputShape()[ndim - 2]);
@@ -1434,12 +1443,12 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
       DLOG(WARNING) << "Bulk copy cannot support a padded layout for src: "
                     << src->name << ", dst: " << dst->name
                     << ", fallback to normal copy";
-      return LowerNormal(op, T, analyzer);
+      return fallback_to_normal("padded shared layout");
     } else {
       DLOG(WARNING) << "Came across unsupported swizzle layout for src: "
                     << src->name << ", dst: " << dst->name
                     << ", fallback to normal copy";
-      return LowerNormal(op, T, analyzer);
+      return fallback_to_normal("unsupported shared swizzle layout");
     }
   }
 
@@ -1448,7 +1457,7 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
     DLOG(WARNING) << "inner_box_dim " << desc.smem_box[0]
                   << " can only be a constant integer for TMA bulk copy, "
                      "fallback to normal copy";
-    return LowerNormal(op, T, analyzer);
+    return fallback_to_normal("non-constant inner box dimension");
   }
   int instruction_dim = *inner_box_dim;
   if (desc.swizzle == static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B)) {
@@ -1483,7 +1492,7 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
       DLOG(WARNING) << "TMA bulk copy cannot support a swizzled global layout "
                        "with inner_box_dim_ > "
                     << check.max_dim << ", will be fallback to normal copy";
-      return LowerNormal(op, T, analyzer);
+      return fallback_to_normal("swizzled shared box exceeds swizzle byte width");
     }
   }
 

--- a/src/layout/gemm_layouts.cc
+++ b/src/layout/gemm_layouts.cc
@@ -837,6 +837,9 @@ Layout makeGemmABLayout(int mat_stride, int mat_continuous, int continuity,
   else if (mat_continuous % (vector_size * 4) == 0)
     return MakeHalfBankSwizzleLayout2D(mat_stride, mat_continuous,
                                        element_size);
+  else if (mat_continuous % (vector_size * 2) == 0)
+    return MakeQuarterBankSwizzleLayout2D(mat_stride, mat_continuous,
+                                          element_size);
   else {
     return makeGemmABLayoutPadded(mat_stride, mat_continuous, element_size);
   }


### PR DESCRIPTION
fixes #2200 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of edge cases during bulk memory copies, yielding clearer failure messages and more reliable fallback behavior.

* **Refactor**
  * Added an additional matrix layout selection path to enable a higher-performance layout in more scenarios, improving memory access efficiency for certain matrix multiplications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->