### PR TITLE
[tilelang] Fix CUPTI cache flush filtering

### DIFF
--- a/testing/python/profiler/test_bench_cupti.py
+++ b/testing/python/profiler/test_bench_cupti.py
@@ -22,5 +22,23 @@ def test_cupti_counts_torch_zeros_kernel_time():
         assert _bench_with_cupti(fn, cache, n_repeat=3) > 0
 
 
+@tilelang.testing.requires_cuda
+def test_cupti_empty_function_excludes_cache_flush_time():
+    import torch
+
+    cache = torch.empty(1024 * 1024, dtype=torch.int, device="cuda")
+
+    def fn():
+        pass
+
+    cache.zero_()
+    torch.cuda.synchronize()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+
+        assert _bench_with_cupti(fn, cache, n_repeat=3) == 0.0
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/profiler/test_bench_cupti.py
+++ b/testing/python/profiler/test_bench_cupti.py
@@ -1,0 +1,26 @@
+import warnings
+from tilelang.profiler.bench import _bench_with_cupti
+import tilelang.testing
+
+
+@tilelang.testing.requires_cuda
+def test_cupti_counts_torch_zeros_kernel_time():
+    import torch
+
+    cache = torch.empty(1024 * 1024, dtype=torch.int, device="cuda")
+
+    def fn():
+        return torch.zeros(cache.numel(), dtype=cache.dtype, device=cache.device)
+
+    cache.zero_()
+    fn()
+    torch.cuda.synchronize()
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+
+        assert _bench_with_cupti(fn, cache, n_repeat=3) > 0
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/profiler/bench.py
+++ b/tilelang/profiler/bench.py
@@ -60,6 +60,7 @@ class suppress_stdout_stderr:
 IS_CUDA = torch.cuda.is_available()
 device = "cuda:0" if IS_CUDA else "mps:0"
 Event = torch.cuda.Event if IS_CUDA else torch.mps.Event
+_CACHE_ZERO_PROFILE_KEY = "tilelang_cache_zero"
 
 
 def do_bench(
@@ -182,26 +183,38 @@ def _bench_with_cupti(
     with suppress_stdout_stderr():
         schedule = torch.profiler.schedule(wait=1, warmup=0, active=1, repeat=1)
         profiler = torch.profiler.profile(
-            activities=[torch.profiler.ProfilerActivity.CUDA],
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
             schedule=schedule,
         )
 
         with profiler:
             for _ in range(2):
                 for _ in range(n_repeat):
-                    cache.zero_()
+                    with torch.profiler.record_function(_CACHE_ZERO_PROFILE_KEY):
+                        cache.zero_()
                     fn()
                 profiler.step()
 
-    # Calculate average kernel time, excluding cache-clearing overhead
+    # `cache.zero_()` and user code such as `torch.zeros` can share the same
+    # generated kernel name, so exclude only the annotated cache-zero range.
+    def is_cuda_event(event):
+        return getattr(getattr(event, "device_type", None), "name", "") == "CUDA"
+
     total_cuda_time = 0.0
     excluded_time = 0.0
-    excluded_kernels = "at::native::vectorized_elementwise"
 
-    for event in profiler.key_averages():
+    for event in profiler.events():
+        if not is_cuda_event(event):
+            continue
+        if getattr(event, "is_user_annotation", False):
+            if event.key == _CACHE_ZERO_PROFILE_KEY:
+                excluded_time += event.self_device_time_total
+            continue
+
         total_cuda_time += event.self_device_time_total
-        if excluded_kernels in event.key:
-            excluded_time += event.self_device_time_total
 
     kernel_time_us = (total_cuda_time - excluded_time) / n_repeat
     return kernel_time_us * 1e-3  # Convert microseconds to milliseconds

--- a/tilelang/profiler/bench.py
+++ b/tilelang/profiler/bench.py
@@ -60,7 +60,7 @@ class suppress_stdout_stderr:
 IS_CUDA = torch.cuda.is_available()
 device = "cuda:0" if IS_CUDA else "mps:0"
 Event = torch.cuda.Event if IS_CUDA else torch.mps.Event
-_CACHE_FLUSH_PROFILE_NAME = "tilelang::cache_flush"
+_CACHE_FLUSH_ID = "tilelang::cache_flush"
 
 
 def do_bench(
@@ -193,7 +193,7 @@ def _bench_with_cupti(
         with profiler:
             for _ in range(2):
                 for _ in range(n_repeat):
-                    with torch.profiler.record_function(_CACHE_FLUSH_PROFILE_NAME):
+                    with torch.profiler.record_function(_CACHE_FLUSH_ID):
                         cache.zero_()
                     fn()
                 profiler.step()
@@ -210,7 +210,7 @@ def _bench_with_cupti(
         if not is_cuda_event(event):
             continue
         if getattr(event, "is_user_annotation", False):
-            if event.key == _CACHE_FLUSH_PROFILE_NAME:
+            if event.key == _CACHE_FLUSH_ID:
                 excluded_time += event.self_device_time_total
             continue
 

--- a/tilelang/profiler/bench.py
+++ b/tilelang/profiler/bench.py
@@ -60,7 +60,7 @@ class suppress_stdout_stderr:
 IS_CUDA = torch.cuda.is_available()
 device = "cuda:0" if IS_CUDA else "mps:0"
 Event = torch.cuda.Event if IS_CUDA else torch.mps.Event
-_CACHE_ZERO_PROFILE_KEY = "tilelang_cache_zero"
+_CACHE_FLUSH_PROFILE_NAME = "tilelang::cache_flush"
 
 
 def do_bench(
@@ -193,13 +193,13 @@ def _bench_with_cupti(
         with profiler:
             for _ in range(2):
                 for _ in range(n_repeat):
-                    with torch.profiler.record_function(_CACHE_ZERO_PROFILE_KEY):
+                    with torch.profiler.record_function(_CACHE_FLUSH_PROFILE_NAME):
                         cache.zero_()
                     fn()
                 profiler.step()
 
     # `cache.zero_()` and user code such as `torch.zeros` can share the same
-    # generated kernel name, so exclude only the annotated cache-zero range.
+    # generated kernel name, so exclude only the annotated cache flush range.
     def is_cuda_event(event):
         return getattr(getattr(event, "device_type", None), "name", "") == "CUDA"
 
@@ -210,7 +210,7 @@ def _bench_with_cupti(
         if not is_cuda_event(event):
             continue
         if getattr(event, "is_user_annotation", False):
-            if event.key == _CACHE_ZERO_PROFILE_KEY:
+            if event.key == _CACHE_FLUSH_PROFILE_NAME:
                 excluded_time += event.self_device_time_total
             continue
 

--- a/tilelang/profiler/bench.py
+++ b/tilelang/profiler/bench.py
@@ -209,12 +209,12 @@ def _bench_with_cupti(
     for event in profiler.events():
         if not is_cuda_event(event):
             continue
-        if getattr(event, "is_user_annotation", False):
+
+        if event.is_user_annotation:
             if event.key == _CACHE_FLUSH_ID:
                 excluded_time += event.self_device_time_total
-            continue
-
-        total_cuda_time += event.self_device_time_total
+        else:
+            total_cuda_time += event.self_device_time_total
 
     kernel_time_us = (total_cuda_time - excluded_time) / n_repeat
     return kernel_time_us * 1e-3  # Convert microseconds to milliseconds

--- a/tilelang/profiler/bench.py
+++ b/tilelang/profiler/bench.py
@@ -210,11 +210,10 @@ def _bench_with_cupti(
         if not is_cuda_event(event):
             continue
 
-        if event.is_user_annotation:
-            if event.key == _CACHE_FLUSH_ID:
-                excluded_time += event.self_device_time_total
-        else:
+        if not event.is_user_annotation:
             total_cuda_time += event.self_device_time_total
+        elif event.key == _CACHE_FLUSH_ID:
+            excluded_time += event.self_device_time_total
 
     kernel_time_us = (total_cuda_time - excluded_time) / n_repeat
     return kernel_time_us * 1e-3  # Convert microseconds to milliseconds


### PR DESCRIPTION
## Summary

- Fix CUPTI benchmark timing so cache flush kernels are excluded without dropping user kernels with the same generated CUDA name.
- Add a CUDA regression test that benchmarks `torch.zeros` and verifies its kernel time remains counted.

## Changes

- Annotate the internal cache flush with `torch.profiler.record_function`.
- Collect CUDA profiler events directly and subtract only the cache-zero annotation time, instead of filtering all `at::native::vectorized_elementwise` kernels by name.
- Add a focused profiler test for the `torch.zeros` case.

## Validation

- `./format.sh`
- `python -m pytest testing/python/profiler/test_bench_cupti.py -q`
- `python -m pytest testing/python/profiler/test_tilelang_profiler.py -q --run-perf`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added CUDA-gated tests: one verifies GPU kernel time is captured; another ensures an empty workload reports zero kernel time.

* **Bug Fixes**
  * Improved profiler accuracy by accounting for both CPU and GPU activities and excluding internal cache-clear work from reported kernel timings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->