### PR TITLE
[CI] Add PyPI release publishing

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -16,6 +16,7 @@ on:
       - pyproject.toml
       - MANIFEST.in
       - CMakeLists.txt
+      - VERSION
       - version_provider.py
       - .github/workflows/dist.yml
       # Type aliases can affect package import/build behavior.
@@ -371,3 +372,40 @@ jobs:
           name: artifacts
           path: dist/*
           if-no-files-found: error
+
+  publish-pypi:
+    name: Publish to PyPI
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    needs: [list-artifacts]
+    timeout-minutes: 15
+    environment:
+      name: pypi
+      url: https://pypi.org/p/tilelang
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Validate release tag matches VERSION
+        run: |
+          VERSION="$(cat VERSION)"
+          TAG="${GITHUB_REF_NAME}"
+          if [ "${TAG}" != "v${VERSION}" ]; then
+            echo "Release tag ${TAG} does not match VERSION v${VERSION}"
+            exit 1
+          fi
+
+      - name: Download release artifacts
+        uses: actions/download-artifact@v8
+        with:
+          name: artifacts
+          path: dist
+
+      - name: List distributions
+        run: ls -lh dist/*
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary

- Add a release-only PyPI publishing job to the existing Dist workflow.
- Use PyPI Trusted Publishing through GitHub OIDC instead of long-lived PyPI tokens.
- Ensure version-only release PRs trigger Dist by including VERSION in the path filter.

## Changes

- Add a publish-pypi job that runs only for published GitHub Releases.
- Validate that the release tag matches the VERSION file before uploading distributions.
- Download the aggregated release artifacts and publish them with pypa/gh-action-pypi-publish.

## Validation

- `git diff --check`
- `./format.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated release pipeline with automatic PyPI package publishing on release events
  * Extended build workflow to trigger on `VERSION` file changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->