### PR TITLE
Use split TVM DLLs on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -495,6 +495,20 @@ if(MSVC)
       endif()
     endif()
   endforeach()
+
+  # TVM links against tvm_ffi_shared on Windows. Do not also export tvm-ffi
+  # inline class members from TileLang-built TVM DLLs, or lld-link reports
+  # duplicate symbols for tvm::ffi types already exported by tvm_ffi.dll.
+  foreach(_tilelang_tvm_obj_tgt IN ITEMS tvm_objs tvm_runtime_objs)
+    if(TARGET ${_tilelang_tvm_obj_tgt})
+      get_target_property(_tilelang_tvm_defs ${_tilelang_tvm_obj_tgt} COMPILE_DEFINITIONS)
+      if(_tilelang_tvm_defs)
+        list(REMOVE_ITEM _tilelang_tvm_defs TVM_FFI_EXPORTS -DTVM_FFI_EXPORTS)
+        set_target_properties(${_tilelang_tvm_obj_tgt}
+          PROPERTIES COMPILE_DEFINITIONS "${_tilelang_tvm_defs}")
+      endif()
+    endif()
+  endforeach()
 endif()
 
 # Provide the custom LogMessageImpl / LogFatalImpl implementation to TVM,
@@ -533,32 +547,16 @@ if(TILELANG_RELEASE_BUILD)
   target_compile_definitions(tilelang_objs PRIVATE TILELANG_RELEASE_BUILD=1)
 endif()
 
+set(TILELANG_OUTPUT_TARGETS tvm_runtime tvm_compiler)
 if(WIN32)
-  set(TILELANG_OUTPUT_TARGETS tvm)
-  # On Windows, TileLang subclasses a large number of non-exported TVM C++
-  # classes. Building those objects into tvm.dll avoids an otherwise fragile
-  # cross-DLL ABI boundary while keeping Python-side registration semantics.
-  #
-  # MSVC can still discard translation-unit-local static init triggers from
-  # object-library inputs when those TUs are otherwise only referenced for
-  # side effects (for example TVM_FFI_STATIC_INIT_BLOCK() registrations).
-  # Archive the TileLang objects first, then force-include that archive into
-  # tvm.dll so tl.* object/global registrations survive the final link.
-  add_library(tilelang_archive STATIC $<TARGET_OBJECTS:tilelang_objs>)
-  set_target_properties(tilelang_archive PROPERTIES
-    ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    LINKER_LANGUAGE CXX
-  )
-  target_link_libraries(tvm PRIVATE tilelang_archive)
-  target_link_options(tvm PRIVATE
-    "/WHOLEARCHIVE:$<TARGET_FILE:tilelang_archive>"
-  )
-  # TVM is added with EXCLUDE_FROM_ALL above, but on Windows we install
-  # tvm.dll as the only native artifact that ships TileLang symbols, so make
-  # sure `ninja` (and `cmake --build`) actually builds it by default.
-  set_property(TARGET tvm PROPERTY EXCLUDE_FROM_ALL FALSE)
+  # Windows ships tvm_runtime.dll and tvm_compiler.dll. The compiler DLL also
+  # carries TileLang's native registration/object code: TileLang uses TVM
+  # compiler-side C++ internals that are not consistently exported from a
+  # separate tilelang.dll, while exporting every TVM compiler object would exceed
+  # Windows' 65535-symbol DLL limit. This keeps Windows on explicit split TVM
+  # DLL names without falling back to the old unified tvm.dll.
+  target_sources(tvm_compiler PRIVATE $<TARGET_OBJECTS:tilelang_objs>)
 else()
-  set(TILELANG_OUTPUT_TARGETS tvm_runtime tvm_compiler)
   add_library(tilelang SHARED $<TARGET_OBJECTS:tilelang_objs>)
   target_link_libraries(tilelang PUBLIC tvm_compiler)
 
@@ -569,6 +567,15 @@ else()
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
   )
   list(PREPEND TILELANG_OUTPUT_TARGETS tilelang)
+endif()
+
+if(WIN32)
+  # TVM is added with EXCLUDE_FROM_ALL above. The split Windows build ships the
+  # same native target set as POSIX, so make sure default builds materialize all
+  # DLLs needed by Python import and wheel installation.
+  foreach(_tilelang_win_target IN LISTS TILELANG_OUTPUT_TARGETS)
+    set_property(TARGET ${_tilelang_win_target} PROPERTY EXCLUDE_FROM_ALL FALSE)
+  endforeach()
 endif()
 # Build cython extension
 find_package(Python REQUIRED COMPONENTS Interpreter Development.Module ${SKBUILD_SABI_COMPONENT})

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -90,7 +90,7 @@ class KernelCache:
             pass
 
         if sys.platform == "win32":
-            lib_names = ["tilelang.dll", "libtilelang.dll", "tvm.dll", "tvm_ffi.dll"]
+            lib_names = ["tvm_runtime.dll", "tvm_compiler.dll", "tvm_ffi.dll"]
         elif sys.platform == "darwin":
             lib_names = [
                 "libtilelang.dylib",

--- a/tilelang/contrib/msvc.py
+++ b/tilelang/contrib/msvc.py
@@ -305,9 +305,15 @@ def _find_import_libs() -> tuple[list[str], list[str]]:
     for lib_dir in TL_LIBS:
         if not os.path.isdir(lib_dir):
             continue
-        for lib_name in ("tvm.lib", "tvm_ffi.lib"):
-            lib_path = os.path.join(lib_dir, lib_name)
-            add_import_lib(lib_path)
+        # JIT-generated host libraries call TVM runtime C API symbols such as
+        # TVMBackendGetFuncFromEnv. Split Windows builds export those from
+        # tvm_runtime.dll, while older unified builds exported them from tvm.dll.
+        runtime_lib = os.path.join(lib_dir, "tvm_runtime.lib")
+        if os.path.exists(runtime_lib):
+            add_import_lib(runtime_lib)
+        else:
+            add_import_lib(os.path.join(lib_dir, "tvm.lib"))
+        add_import_lib(os.path.join(lib_dir, "tvm_ffi.lib"))
 
     try:
         from tvm_ffi import libinfo as tvm_ffi_libinfo

--- a/tilelang/libinfo.py
+++ b/tilelang/libinfo.py
@@ -26,9 +26,12 @@ def find_lib_path(name: str, py_ext=False):
     elif sys.platform.startswith("linux") or sys.platform.startswith("freebsd"):
         lib_names = [f"lib{name}.so"]
     elif sys.platform.startswith("win32"):
-        lib_names = [f"{name}.dll"]
         if name == "tilelang":
-            lib_names.append("tvm.dll")
+            # Windows links TileLang native registration objects into
+            # tvm_compiler.dll instead of a separate tilelang.dll.
+            lib_names = ["tvm_compiler.dll"]
+        else:
+            lib_names = [f"{name}.dll"]
     elif sys.platform.startswith("darwin"):
         lib_names = [f"lib{name}.dylib"]
     else:


### PR DESCRIPTION
## Summary

Use `tvm_runtime.dll` and `tvm_compiler.dll` as the Windows native artifacts instead of relying on the legacy unified `tvm.dll`.

On Windows, TileLang native registration/object code is linked into `tvm_compiler.dll`. This keeps Windows aligned with explicit split TVM library names while avoiding a separate `tilelang.dll` boundary for TVM compiler-side C++ internals.

This also updates the Windows cache stamp and TileLang native loader to use `tvm_compiler.dll`.

## Notes

https://github.com/tile-ai/tvm/pull/43

## Testing

- `uv sync --extra nvcc -vv --reinstall-package tilelang`
- Python import check for `tilelang`, `tvm_runtime.dll`, and `tvm_compiler.dll`
- `python -m compileall -q tilelang`
- `uvx pre-commit run --files CMakeLists.txt tilelang/cache/kernel_cache.py tilelang/libinfo.py`
- `python -m pytest testing/python/cache/test_tilelang_kernel_cache_atomic_save.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved duplicate symbol/export issues on Windows by preventing unintended symbol propagation from TileLang-built binaries.
  * Switched Windows outputs to separate runtime and compiler libraries so native integrations load the correct components.
  * Improved detection and selection of native import libraries on Windows and ensured required split libraries are built by default.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->