### PR TITLE
[CUDA] Support packed fp8/fp4 pair reduction casts

### DIFF
--- a/src/tl_templates/cuda/cuda_fp4.h
+++ b/src/tl_templates/cuda/cuda_fp4.h
@@ -221,6 +221,16 @@ TL_DEVICE half2 __tl_cvt_fp4x2_to_half2(const __nv_fp4x2_storage_t src) {
   return result;
 }
 
+namespace tl {
+
+template <typename T>
+TL_DEVICE T from_uint1(fp4_e2_2_t v) {
+  __half2 result = __tl_cvt_fp4x2_to_half2(v.__x);
+  return *reinterpret_cast<T *>(&result);
+}
+
+} // namespace tl
+
 // half -> fp4_e2m1
 TL_DEVICE __nv_fp4_storage_t __tl_cvt_half_to_fp4(const __half src) {
   __half_raw raw = *reinterpret_cast<const __half_raw *>(&src);

--- a/src/tl_templates/cuda/cuda_fp8.h
+++ b/src/tl_templates/cuda/cuda_fp8.h
@@ -133,6 +133,18 @@ TL_DEVICE fp8_e4_2_t make_fp8_e4_2_t(fp8_e4_t x, fp8_e4_t y) {
   return result;
 }
 
+namespace tl {
+
+template <typename T>
+TL_DEVICE T from_uint1(fp8_e4_2_t v) {
+  __nv_fp8x2_storage_t storage;
+  memcpy(&storage, &v, sizeof(storage));
+  __half2 result = __nv_cvt_fp8x2_to_halfraw2(storage, __NV_E4M3);
+  return *reinterpret_cast<T *>(&result);
+}
+
+} // namespace tl
+
 // Pack four fp8_e4_t values.
 TL_DEVICE fp8_e4_4_t make_fp8_e4_4_t(fp8_e4_t x0, fp8_e4_t x1, fp8_e4_t x2,
                                      fp8_e4_t x3) {


### PR DESCRIPTION
Generated CUDA for per-token cast benchmarks can reduce pre-quantized FP8/FP4 values through half2 absmax operations.  The generated loads cast packed fp8_e4_2_t/fp4_e2_2_t storage with from_uint1<__half2>, but common.h only exposes from_uint1 for uint1 storage, so NVCC rejects overload resolution for the packed FP8/FP4 arguments.

This is needed for TileKernels workloads that exercise the packed FP8/FP4 per-token cast path to compile and run on the H100 CUDA backend.

Add dtype-local conversion overloads in the CUDA FP8 and FP4 template headers.  The FP8 bridge converts fp8_e4_2_t through __nv_fp8x2_storage_t and __nv_cvt_fp8x2_to_halfraw2(..., __NV_E4M3), while the FP4 bridge converts fp4_e2_2_t through the existing __tl_cvt_fp4x2_to_half2 helper.  Keeping these bridges next to the packed dtype definitions avoids making common.h depend on dtype-specific packed storage.

Verified on H100 (sm_90, 114 SMs) with CUDA 13.2 and PyTorch 2.12.0+cu132:

* representative packed/TMA FP8 and FP4 per_token_cast benchmark cases: 2 passed
* full per_token_cast benchmark: 448 passed
* representative functional validation for engram_grad_w_reduce and packed/TMA per_token_cast cases: 8 passed

The original NVCC errors for tl::from_uint1 with fp8_e4_2_t and fp4_e2_2_t arguments no longer appear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added conversion utilities for lower-precision floating-point formats, enabling seamless type conversion between specialized numeric formats and other destination types for improved data handling flexibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->