### PR TITLE
[CUDA] Support packed fp8/fp4 pair reduction casts

### DIFF
--- a/examples/grouped_gemm/example_grouped_gemm_bwd.py
+++ b/examples/grouped_gemm/example_grouped_gemm_bwd.py
@@ -56,13 +56,8 @@ def grouped_gemm_fwd(
 
 class _GroupedGEMM(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, a, b, batch_sizes):
-        block_M = 64
-        block_N = 64
-        block_K = 64
+    def forward(ctx, a, b, batch_sizes, block_M, block_N, block_K, num_stages, threads):
         padding_M = block_M
-        num_stages = 2
-        threads = 128
         batch_sum = a.shape[0]
         batch_count = b.shape[0]
         K = a.shape[1]
@@ -85,15 +80,20 @@ class _GroupedGEMM(torch.autograd.Function):
         ctx.batch_sum = batch_sum
         ctx.batch_count = batch_count
         ctx.K = K
+        ctx.block_M = block_M
+        ctx.block_N = block_N
+        ctx.block_K = block_K
+        ctx.num_stages = num_stages
+        ctx.threads = threads
         return o
 
     @staticmethod
     def backward(ctx, grad_output):
-        block_M = 64
-        block_N = 64
-        block_K = 64
-        num_stages = 2
-        threads = 128
+        block_M = ctx.block_M
+        block_N = ctx.block_N
+        block_K = ctx.block_K
+        num_stages = ctx.num_stages
+        threads = ctx.threads
 
         A, B, batch_sizes, batch_offsets = ctx.saved_tensors
 
@@ -105,7 +105,7 @@ class _GroupedGEMM(torch.autograd.Function):
         A, B, batch_sizes = [maybe_contiguous(x) for x in (A, B, batch_sizes)]
 
         dB = grouped_gemm_bwd(A, grad_output, batch_sizes, batch_offsets, block_M, block_N, block_K, num_stages, threads)
-        return None, dB, None
+        return None, dB, None, None, None, None, None, None
 
 
 def ref_program(a, b, batch_sizes):
@@ -182,7 +182,21 @@ def grouped_gemm_bwd(A, B, batch_sizes, batch_offsets, block_M, block_N, block_K
     return C
 
 
-def run_tilelang_grouped_gemm(batch_sizes_list, K, M, block_M):
+def run_tilelang_grouped_gemm(
+    batch_sizes_list,
+    K,
+    M,
+    block_M,
+    block_N,
+    block_K,
+    trans_b=False,
+    num_stages=2,
+    threads=128,
+    profile=False,
+):
+    if trans_b:
+        raise NotImplementedError("grouped GEMM backward example does not support transposed B")
+
     padding_M = block_M
     device = torch.device("cuda")
     dtype = torch.float16
@@ -198,7 +212,7 @@ def run_tilelang_grouped_gemm(batch_sizes_list, K, M, block_M):
     dB_ref, B.grad = B.grad.clone(), None
 
     GroupedGEMM = _GroupedGEMM.apply
-    O = GroupedGEMM(A, B, batch_sizes)
+    O = GroupedGEMM(A, B, batch_sizes, block_M, block_N, block_K, num_stages, threads)
     O.backward(dO, retain_graph=True)
     dB, B.grad = B.grad.clone(), None
 
@@ -206,6 +220,12 @@ def run_tilelang_grouped_gemm(batch_sizes_list, K, M, block_M):
         print("✅ Tilelang and Torch match")
     else:
         print("❌ Tilelang and Torch mismatch")
+
+    if profile:
+        from tilelang.profiler import do_bench
+
+        latency = do_bench(lambda: GroupedGEMM(A, B, batch_sizes, block_M, block_N, block_K, num_stages, threads))
+        print(f"Latency: {latency} ms")
 
 
 if __name__ == "__main__":
@@ -219,5 +239,9 @@ if __name__ == "__main__":
     K, M = args.K, args.M
 
     block_M = 64
+    block_N = 128
+    block_K = 64
+    num_stages = 2
+    threads = 256
 
-    run_tilelang_grouped_gemm(batch_sizes_list, K, M, block_M)
+    run_tilelang_grouped_gemm(batch_sizes_list, K, M, block_M, block_N, block_K, False, num_stages, threads)

--- a/src/backend/cuda/codegen/codegen_cutedsl.cc
+++ b/src/backend/cuda/codegen/codegen_cutedsl.cc
@@ -192,6 +192,10 @@ std::string DTypeToString(DataType t) {
     if (bits == 16 || bits == 32 || bits == 64) {
       elem_type = "Float" + std::to_string(bits);
     }
+  } else if (t.is_tfloat32()) {
+    // CuTeDSL TF32 scalar arithmetic is only valid in MMA paths; use FP32 for
+    // storage and elementwise arithmetic since TF32 has the same memory layout.
+    elem_type = "Float32";
   } else if (t.is_bfloat16()) {
     elem_type = "BFloat16";
   } else if (t.is_float8()) {

--- a/src/backend/cuda/codegen/codegen_cutedsl.cc
+++ b/src/backend/cuda/codegen/codegen_cutedsl.cc
@@ -1218,6 +1218,10 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
     ICHECK_EQ(load->indices.size(), 1)
         << "CodeGenTileLangCuTeDSL only supports flat memory";
     os << GetBufferPtr_(load->buffer.get(), load->indices[0]);
+  } else if (op->op.same_as(builtin::handle_add_byte_offset())) {
+    ICHECK_EQ(op->args.size(), 2U);
+    os << "tl.handle_add_byte_offset(" << PrintExpr_(op->args[0]) << ", "
+       << PrintExpr_(op->args[1]) << ")";
   } else if (op->op.same_as(tl::atomic_add_elem_op())) {
     // atomic_add_elem_op(dst_ptr, src_value[, memory_order])
     std::string dst_ptr = PrintExpr_(op->args[0]);

--- a/src/runtime/metal/metal_module.h
+++ b/src/runtime/metal/metal_module.h
@@ -11,6 +11,8 @@
 #include <string>
 #include <utility>
 
+#include "target/metal/metal_fallback_module.h"
+
 namespace tvm {
 namespace codegen {
 
@@ -18,19 +20,9 @@ inline ffi::Module
 MetalModuleCreate(ffi::Map<ffi::String, ffi::Bytes> smap,
                   ffi::Map<ffi::String, runtime::FunctionInfo> fmap,
                   ffi::String fmt, ffi::String source) {
-  auto fcreate = ffi::Function::GetGlobal("ffi.Module.create.metal");
-  if (fcreate.has_value()) {
-    return (*fcreate)(smap, fmt, fmap,
-                      ffi::Map<ffi::String, ffi::String>{{"metal", source}})
-        .cast<ffi::Module>();
-  }
-  auto fallback = ffi::Function::GetGlobal("ffi.Module.create.metal_fallback");
-  if (fallback.has_value()) {
-    return (*fallback)(smap, fmt, fmap,
-                       ffi::Map<ffi::String, ffi::String>{{"metal", source}})
-        .cast<ffi::Module>();
-  }
-  LOG(FATAL) << "Metal module factory not available.";
+  return target::MetalModuleCreateWithFallback(
+      std::move(smap), std::move(fmt), std::move(fmap),
+      ffi::Map<ffi::String, ffi::String>{{"metal", std::move(source)}});
 }
 
 } // namespace codegen

--- a/src/tl_templates/cuda/cuda_fp4.h
+++ b/src/tl_templates/cuda/cuda_fp4.h
@@ -221,6 +221,15 @@ TL_DEVICE half2 __tl_cvt_fp4x2_to_half2(const __nv_fp4x2_storage_t src) {
   return result;
 }
 
+namespace tl {
+
+template <typename T> TL_DEVICE T from_uint1(fp4_e2_2_t v) {
+  __half2 result = __tl_cvt_fp4x2_to_half2(v.__x);
+  return *reinterpret_cast<T *>(&result);
+}
+
+} // namespace tl
+
 // half -> fp4_e2m1
 TL_DEVICE __nv_fp4_storage_t __tl_cvt_half_to_fp4(const __half src) {
   __half_raw raw = *reinterpret_cast<const __half_raw *>(&src);

--- a/src/tl_templates/cuda/cuda_fp8.h
+++ b/src/tl_templates/cuda/cuda_fp8.h
@@ -133,6 +133,17 @@ TL_DEVICE fp8_e4_2_t make_fp8_e4_2_t(fp8_e4_t x, fp8_e4_t y) {
   return result;
 }
 
+namespace tl {
+
+template <typename T> TL_DEVICE T from_uint1(fp8_e4_2_t v) {
+  __nv_fp8x2_storage_t storage;
+  memcpy(&storage, &v, sizeof(storage));
+  __half2 result = __nv_cvt_fp8x2_to_halfraw2(storage, __NV_E4M3);
+  return *reinterpret_cast<T *>(&result);
+}
+
+} // namespace tl
+
 // Pack four fp8_e4_t values.
 TL_DEVICE fp8_e4_4_t make_fp8_e4_4_t(fp8_e4_t x0, fp8_e4_t x1, fp8_e4_t x2,
                                      fp8_e4_t x3) {

--- a/tilelang/contrib/cutedsl/utils.py
+++ b/tilelang/contrib/cutedsl/utils.py
@@ -20,6 +20,7 @@ __all__ = [
     "bitcast",
     "make_filled_tensor",
     "make_tensor_at_offset",
+    "handle_add_byte_offset",
     "shuffle_elect",
     "sync_thread_partial",
     "pack_half2",
@@ -110,6 +111,12 @@ def make_tensor_at_offset(ptr: cute.Pointer, offset, shape, div_by=1):
     if div_by != 1:
         offset = cute.assume(cutlass.as_numeric(offset), divby=div_by)
     return cute.make_tensor(ptr + offset, shape)
+
+
+def handle_add_byte_offset(handle, byte_offset):
+    ptr = handle.iterator if hasattr(handle, "iterator") else handle
+    byte_ptr = cute.recast_ptr(ptr, dtype=cutlass.Uint8)
+    return make_tensor_at_offset(byte_ptr, byte_offset, (1,))
 
 
 def shuffle_elect(thread_extent):


### PR DESCRIPTION
Generated CUDA for per-token cast benchmarks can reduce pre-quantized FP8/FP4 values through half2 absmax operations. The generated loads cast packed fp8_e4_2_t/fp4_e2_2_t storage with from_uint1<__half2>, but common.h only exposes from_uint1 for uint1 storage, so NVCC rejects overload resolution for the packed FP8/FP4 arguments.

This is needed for TileKernels workloads that exercise the packed FP8/FP4 per-token cast path to compile and run on the H100 CUDA backend.

Previous compile errors looked like:

    <build-temp>/tvm_kernels.cu(45): error: no instance of function template "tl::from_uint1" matches the argument list
                argument types are: (fp8_e4_2_t)
            stage1_amax_fragment_pack[i_1] = tl::to_uint1(tl::max2(tl::from_uint1<__half2>(stage1_amax_fragment_pack[i_1]), tl::from_uint1<__half2>(tl::to_uint1(tl::abs2(tl::from_uint1<__half2>(*(fp8_e4_2_t*)(x_stage1_fragment_reshaped + ((i_1 * 16) + (rv * 2)))))))));
                                                                                                                                                                          ^
    <tilelang>/src/tl_templates/cuda/common.h(696): note #3326-D: function template "tl::from_uint1" does not match because argument #1 does not match parameter
      template <typename T> TL_DEVICE T from_uint1(uint1 v) {

and:

    <build-temp>/tvm_kernels.cu(46): error: no instance of function template "tl::from_uint1" matches the argument list
                argument types are: (fp4_e2_2_t)
            stage1_amax_fragment_pack[i_1] = tl::to_uint1(tl::max2(tl::from_uint1<__half2>(stage1_amax_fragment_pack[i_1]), tl::from_uint1<__half2>(tl::to_uint1(tl::abs2(tl::from_uint1<__half2>(*(fp4_e2_2_t*)(x_stage1_fragment_reshaped_packed + ((i_1 * 8) + rv))))))));
                                                                                                                                                                           ^
    <tilelang>/src/tl_templates/cuda/common.h(696): note #3326-D: function template "tl::from_uint1" does not match because argument #1 does not match parameter
      template <typename T> TL_DEVICE T from_uint1(uint1 v) {

Add dtype-local conversion overloads in the CUDA FP8 and FP4 template headers. The FP8 bridge converts fp8_e4_2_t through __nv_fp8x2_storage_t and __nv_cvt_fp8x2_to_halfraw2(..., __NV_E4M3), while the FP4 bridge converts fp4_e2_2_t through the existing __tl_cvt_fp4x2_to_half2 helper. Keeping these bridges next to the packed dtype definitions avoids making common.h depend on dtype-specific packed storage.

Verified on H100 (sm_90, 114 SMs) with CUDA 13.2 and PyTorch 2.12.0+cu132:

* representative packed/TMA FP8 and FP4 per_token_cast benchmark cases: 2 passed
* full per_token_cast benchmark: 448 passed
* representative functional validation for engram_grad_w_reduce and packed/TMA per_token_cast cases: 8 passed

The original NVCC errors for tl::from_uint1 with fp8_e4_2_t and fp4_e2_2_t arguments no longer appear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device-side support to convert packed 4-bit and 8-bit floating formats to half-precision on CUDA for using compressed FP4/FP8 values in half-precision computations.
  * Added a handle byte-offset utility to create tensors at byte offsets, plus compiler backend support to emit the corresponding call.
* **Refactor**
  * Metal module creation now delegates to a fallback-capable constructor to improve robustness.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->