### PR TITLE
[ENV] Clean up compiler temp files by default

### DIFF
--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -310,8 +310,8 @@ class Environment:
     )  # disable kernel cache, usually for unit testing / debugging, high priority
     TILELANG_CLEAR_CACHE = EnvVar("TILELANG_CLEAR_CACHE", "0")  # DEPRECATED! clear cache automatically if set
     TILELANG_CLEANUP_TEMP_FILES = EnvVar(
-        "TILELANG_CLEANUP_TEMP_FILES", "0"
-    )  # cleanup temporary compiler files/dirs after compilation (default: keep for debugging)
+        "TILELANG_CLEANUP_TEMP_FILES", "1"
+    )  # cleanup temporary compiler files/dirs after compilation (set to 0 to keep for debugging)
     TILELANG_HIP_SAVE_TEMP_FILES = EnvVar("TILELANG_HIP_SAVE_TEMP_FILES", "0")  # save temporary files for HIP compilation
 
     # Auto-tuning settings


### PR DESCRIPTION
## Summary

- Enable cleanup of temporary compiler files by default.
- Reduce accumulation of temporary CUDA/HIP compiler directories during normal use.
- Keep the existing debug opt-out by allowing TILELANG_CLEANUP_TEMP_FILES=0.

## Changes

- Change TILELANG_CLEANUP_TEMP_FILES default from 0 to 1.
- Update the inline environment variable comment to document that setting the variable to 0 preserves temporary files for debugging.

## Validation

- ./format.sh
- env -u TILELANG_CLEANUP_TEMP_FILES python -c "from tilelang.env import env; print(env.TILELANG_CLEANUP_TEMP_FILES, env.should_cleanup_temp_files())"
- TILELANG_CLEANUP_TEMP_FILES=0 python -c "from tilelang.env import env; print(env.TILELANG_CLEANUP_TEMP_FILES, env.should_cleanup_temp_files())"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Temporary compiler files are now automatically cleaned up by default after compilation, reducing unnecessary disk space usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->