### PR TITLE
[Bugfix] Fix ROCm FP4 packed buffer map key

### DIFF
--- a/src/backend/rocm/codegen/codegen_hip.cc
+++ b/src/backend/rocm/codegen/codegen_hip.cc
@@ -1074,12 +1074,13 @@ void CodeGenTileLangHIP::PrintCallExtern(Type ret_type, String global_symbol,
 std::string CodeGenTileLangHIP::GetBufferRef(DataType t,
                                              const BufferNode *buffer,
                                              PrimExpr index) {
-  const VarNode *buffer_var = buffer->data.get();
+  Var buffer_var = buffer->data;
+  const VarNode *buffer_var_node = buffer_var.get();
   std::ostringstream os;
-  std::string vid = GetVarID(buffer_var);
+  std::string vid = GetVarID(buffer_var_node);
   std::string scope;
-  if (alloc_storage_scope_.count(buffer_var)) {
-    scope = alloc_storage_scope_.at(buffer_var);
+  if (alloc_storage_scope_.count(buffer_var_node)) {
+    scope = alloc_storage_scope_.at(buffer_var_node);
   }
 
   // FP4 scalar access on gfx950: redirect to tl_fp4_packed_load helper.
@@ -1120,7 +1121,7 @@ std::string CodeGenTileLangHIP::GetBufferRef(DataType t,
   DataType buffer_element_dtype = buffer->dtype;
 
   std::string buffer_str = vid;
-  if (!HandleTypeMatch(buffer_var, buffer_element_dtype) || is_vol) {
+  if (!HandleTypeMatch(buffer_var_node, buffer_element_dtype) || is_vol) {
     std::stringstream temp;
     temp << "(" << ptr_cast(buffer_element_dtype) << vid << ")";
     buffer_str = temp.str();
@@ -1767,7 +1768,7 @@ void CodeGenTileLangHIP::VisitStmt_(const AllocBufferNode *op) {
       auto vid_packed = vid + "_packed";
       stream << "fp4_e2_2_t " << vid_packed << '[' << (constant_size + 1) / 2
              << "];\n";
-      fp4_packed_buffers_[op->buffer->data.get()] = vid_packed;
+      fp4_packed_buffers_[op->buffer->data] = vid_packed;
     } else if (scope == "local.var") {
       // Single-element variable: emit an initializer so the value is defined.
       // Default to 0; respect the user-provided tl.local_var_init annotation.
@@ -1806,7 +1807,7 @@ void CodeGenTileLangHIP::VisitStmt_(const BufferStoreNode *op) {
     std::string idx_str = PrintExpr(op->indices[0]);
     std::string value = this->PrintExpr(op->value);
     this->PrintIndent();
-    auto packed_it = fp4_packed_buffers_.find(buffer_var.get());
+    auto packed_it = fp4_packed_buffers_.find(buffer_var);
     if (packed_it != fp4_packed_buffers_.end()) {
       stream << "tl_fp4_packed_store(" << packed_it->second << ", " << idx_str
              << ", " << value << ");\n";

--- a/src/backend/rocm/codegen/codegen_hip.h
+++ b/src/backend/rocm/codegen/codegen_hip.h
@@ -86,8 +86,8 @@ private:
   bool enable_fp8_{false};
   // whether need hip_fp4.h (gfx950 only)
   bool enable_fp4_{false};
-  // Map from FP4 buffer VarNode* to packed buffer variable name (gfx950)
-  std::unordered_map<const tir::VarNode *, std::string> fp4_packed_buffers_;
+  // Map from FP4 buffer Var to packed buffer variable name (gfx950)
+  std::unordered_map<Var, std::string> fp4_packed_buffers_;
   // The size of the barrier array in shared memory
   int barrier_count_ = -1;
   // whether need mma.h


### PR DESCRIPTION
## Summary

- Fixes ROCm HIP codegen compilation for FP4 packed buffer tracking.
- Replaces the invalid `tir::VarNode*` map key with the TIRX `Var` handle used by the surrounding code.

## Changes

- Stores FP4 packed buffer mappings by `Var` in `CodeGenTileLangHIP`.
- Keeps raw `VarNode*` only for existing CodeGenC helper calls such as variable naming and type matching.
- Updates FP4 load/store lookups to use the same handle key that is recorded at allocation time.

## Validation

- `./format.sh`
- `c++ -std=c++17 ... -c src/backend/rocm/codegen/codegen_hip.cc -o /tmp/tilelang-codegen_hip.o`
- `c++ -std=c++17 ... -c src/backend/rocm/codegen/rt_mod_hip.cc -o /tmp/tilelang-rt_mod_hip.o`
- `cmake --build build --target tilelang_objs -j$(nproc)`

## Notes

- The local CMake cache has `USE_ROCM=OFF`; direct HIP translation-unit compiles covered the two files from the reported ROCm failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal buffer reference handling in ROCM HIP code generation for better efficiency
  * Enhanced FP4 packed buffer management for gfx950 architecture support

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->