### PR TITLE
[CuTeDSL] Fix CuTeDSL byte-offset handle codegen

### DIFF
--- a/src/backend/cuda/codegen/codegen_cutedsl.cc
+++ b/src/backend/cuda/codegen/codegen_cutedsl.cc
@@ -144,6 +144,11 @@ CodeGenTileLangCuTeDSL::CodeGenTileLangCuTeDSL() {
       pass_ctx->GetConfig<Bool>(tl::kEnableFastMath, Bool(false)).value();
 }
 
+void CodeGenTileLangCuTeDSL::InitFuncState_(const PrimFunc &f) {
+  CodeGenTileLangPY::InitFuncState_(f);
+  raw_pointer_vars_.clear();
+}
+
 std::string CodeGenTileLangCuTeDSL::CanonicalizeFastmathFunctionName_(
     const std::string &func_name) const {
   static const std::unordered_map<std::string, std::string> kFastMathMap = {
@@ -1218,6 +1223,10 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
     ICHECK_EQ(load->indices.size(), 1)
         << "CodeGenTileLangCuTeDSL only supports flat memory";
     os << GetBufferPtr_(load->buffer.get(), load->indices[0]);
+  } else if (op->op.same_as(builtin::handle_add_byte_offset())) {
+    ICHECK_EQ(op->args.size(), 2U);
+    os << "(" << GetHandleBytePtr_(op->args[0]) << " + "
+       << PrintExpr_(op->args[1]) << ")";
   } else if (op->op.same_as(tl::atomic_add_elem_op())) {
     // atomic_add_elem_op(dst_ptr, src_value[, memory_order])
     std::string dst_ptr = PrintExpr_(op->args[0]);
@@ -1725,6 +1734,14 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const BufferStoreNode *op) {
   }
 }
 
+void CodeGenTileLangCuTeDSL::VisitStmt_(const BindNode *op) {
+  if (op->var.dtype().is_handle() && op->value.dtype().is_handle() &&
+      op->var->type_annotation.as<PointerTypeNode>()) {
+    raw_pointer_vars_.insert(op->var.get());
+  }
+  CodeGenTileLangPY::VisitStmt_(op);
+}
+
 void CodeGenTileLangCuTeDSL::VisitStmt_(const AllocBufferNode *op) {
   DataType alloc_dtype = op->buffer->dtype;
   std::string vid = AllocVarID(op->buffer->data.get());
@@ -2217,6 +2234,7 @@ std::string CodeGenTileLangCuTeDSL::GetBufferPtr_(const BufferNode *buffer,
                                                   PrimExpr index) {
   const VarNode *buffer_var = buffer->data.get();
   const std::string vid = GetVarID(buffer_var);
+  const bool is_raw_pointer = raw_pointer_vars_.count(buffer_var) != 0;
 
   DataType buffer_element_dtype = buffer->dtype;
   // CuTeDSL only supports i1 (Boolean) in rmem; use Uint8 for gmem pointers.
@@ -2243,7 +2261,14 @@ std::string CodeGenTileLangCuTeDSL::GetBufferPtr_(const BufferNode *buffer,
     scope = GetPtrStorageScope(buffer->data);
 
   std::string ptr_str;
-  if (scope == "shared.barrier" || scope == "shared.cluster_barrier") {
+  if (is_raw_pointer) {
+    if (effective_dtype == DataType::UInt(8)) {
+      ptr_str = vid;
+    } else {
+      ptr_str = "tl.recast_ptr(" + vid +
+                ", dtype=" + DTypeToString(effective_dtype) + ")";
+    }
+  } else if (scope == "shared.barrier" || scope == "shared.cluster_barrier") {
     ptr_str = vid;
   } else {
     bool is_handle_type_match = HandleTypeMatch_(buffer_var, effective_dtype);
@@ -2259,10 +2284,43 @@ std::string CodeGenTileLangCuTeDSL::GetBufferPtr_(const BufferNode *buffer,
   return "(" + ptr_str + " + " + index_str + ")";
 }
 
+std::string CodeGenTileLangCuTeDSL::GetHandleBytePtr_(const PrimExpr &expr) {
+  std::string ptr_str;
+  if (const VarNode *var = expr.as<VarNode>()) {
+    const std::string vid = GetVarID(var);
+    if (raw_pointer_vars_.count(var) != 0) {
+      ptr_str = vid;
+    } else {
+      std::string scope;
+      const bool is_typed_pointer =
+          var->type_annotation.as<PointerTypeNode>() != nullptr;
+      if (is_typed_pointer && alloc_storage_scope_.count(var)) {
+        scope = alloc_storage_scope_.at(var);
+      }
+      if (is_typed_pointer && scope.empty()) {
+        scope = GetPtrStorageScope(GetRef<Var>(var));
+      }
+      if (!is_typed_pointer || scope == "shared.barrier" ||
+          scope == "shared.cluster_barrier") {
+        ptr_str = vid;
+      } else {
+        ptr_str = vid + ".iterator";
+      }
+    }
+  } else {
+    ptr_str = PrintExpr_(expr);
+  }
+  return "tl.recast_ptr(" + ptr_str +
+         ", dtype=" + DTypeToString(DataType::UInt(8)) + ")";
+}
+
 std::string CodeGenTileLangCuTeDSL::GetVarPtr_(const PrimExpr &expr) {
   // For local buffers (rmem tensors), we need to use .iterator to get the
   // pointer since local buffers in CuTeDSL are tensors, not raw pointers
   if (const VarNode *var = expr.as<VarNode>()) {
+    if (raw_pointer_vars_.count(var) != 0) {
+      return GetVarID(var);
+    }
     return GetVarID(var) + ".iterator";
   }
   return PrintExpr_(expr);
@@ -2292,6 +2350,7 @@ std::string CodeGenTileLangCuTeDSL::GetBufferRef_(DataType t,
   if (scope == "local.var" || scope.find("local.descriptor") == 0) {
     return vid;
   }
+  const bool is_raw_pointer = raw_pointer_vars_.count(buffer_var) != 0;
 
   DataType buffer_element_dtype = buffer->dtype;
   // CuTeDSL only supports i1 (Boolean) in rmem. For gmem/shared bool buffers,
@@ -2303,7 +2362,14 @@ std::string CodeGenTileLangCuTeDSL::GetBufferRef_(DataType t,
   }
   bool is_handle_type_match = HandleTypeMatch_(buffer_var, effective_dtype);
   std::string ptr_str;
-  if (is_handle_type_match) {
+  if (is_raw_pointer) {
+    if (effective_dtype == DataType::UInt(8)) {
+      ptr_str = vid;
+    } else {
+      ptr_str = "tl.recast_ptr(" + vid +
+                ", dtype=" + DTypeToString(effective_dtype) + ")";
+    }
+  } else if (is_handle_type_match) {
     ptr_str = vid + ".iterator";
   } else {
     ptr_str = "tl.recast_ptr(" + vid +

--- a/src/backend/cuda/codegen/codegen_cutedsl.h
+++ b/src/backend/cuda/codegen/codegen_cutedsl.h
@@ -12,6 +12,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "codegen_py.h"
@@ -24,6 +25,7 @@ public:
   CodeGenTileLangCuTeDSL();
 
 protected:
+  void InitFuncState_(const PrimFunc &f) override;
   void PrintFuncDecorator_(std::ostream &os) override; // NOLINT(*)
   void PreFunctionBody_(const PrimFunc &f) override;
 
@@ -45,6 +47,7 @@ protected:
                   std::ostream &os) override; // NOLINT(*)
 
   void VisitStmt_(const BufferStoreNode *op) override;
+  void VisitStmt_(const BindNode *op) override;
   void VisitStmt_(const AllocBufferNode *op) override;
   void VisitStmt_(const AttrStmtNode *op) override;
   void VisitStmt_(const ForNode *op) override;
@@ -76,6 +79,9 @@ protected:
   std::string GetBufferRef_(DataType t, const BufferNode *buffer,
                             PrimExpr index) override;
 
+  // Get a byte-addressed pointer expression for handle byte-offset arithmetic.
+  std::string GetHandleBytePtr_(const PrimExpr &expr);
+
   // Get pointer string from a Var expression (local buffer -> vid.iterator)
   std::string GetVarPtr_(const PrimExpr &expr);
 
@@ -101,6 +107,11 @@ private:
 
   // Fastmath configuration (read from PassContext)
   bool enable_fastmath_ = false;
+
+  // Vars bound to handle-valued expressions are raw CuTeDSL pointers, not
+  // tensors. Later buffer accesses must use the var directly instead of
+  // appending ".iterator".
+  std::unordered_set<const VarNode *> raw_pointer_vars_;
 
   // Loop-break guard transformation state
   // When a for-loop contains loop_break(), we replace `break` with a guard

--- a/src/backend/cuda/codegen/codegen_py.cc
+++ b/src/backend/cuda/codegen/codegen_py.cc
@@ -418,6 +418,13 @@ void CodeGenTileLangPY::VisitExpr_(const CallNode *op,
       os << "(";
       PrintExpr_(op->args[0], os);
       os << " is None)";
+    } else if (op->op.same_as(builtin::handle_add_byte_offset())) {
+      ICHECK_EQ(op->args.size(), 2U);
+      os << "(";
+      PrintExpr_(op->args[0], os);
+      os << " + ";
+      PrintExpr_(op->args[1], os);
+      os << ")";
     } else if (op->op.same_as(builtin::isnan())) {
       os << "(";
       PrintExpr_(op->args[0], os);

--- a/testing/python/target/test_tilelang_codegen_cutedsl_cp_async.py
+++ b/testing/python/target/test_tilelang_codegen_cutedsl_cp_async.py
@@ -58,5 +58,41 @@ def test_cutedsl_codegen_supports_tl_ptx_cp_async():
     assert "tl.cp_async_gs(" in artifact.kernel_source
 
 
+def test_cutedsl_codegen_supports_shared_alias_byte_offset():
+    if not tvm.runtime.enabled("cuda"):
+        pytest.skip("TileLang CuTeDSL codegen requires TVM built with CUDA support.")
+
+    build_cutedsl = tvm.ffi.get_global_func("target.build.tilelang_cutedsl_without_compile", allow_missing=True)
+    if build_cutedsl is None:
+        pytest.skip("TileLang CuTeDSL backend is not enabled in this build.")
+
+    target = normalize_cutedsl_target({"kind": "cutedsl", "arch": "sm_90"})
+    assert target is not None
+
+    @T.prim_func
+    def prog(
+        A: T.Tensor((32,), "float16"),
+        B: T.Tensor((32,), "float16"),
+        C: T.Tensor((32,), "float16"),
+    ):
+        with T.Kernel(1, threads=32):
+            A_shared = T.alloc_shared((32,), "float16")
+            B_shared = T.alloc_shared((32,), "float16")
+            A_shared[0] = A[0]
+            B_shared[0] = B[0]
+            T.tvm_storage_sync("shared")
+            C[0] = A_shared[0] + B_shared[0]
+
+    artifact = lower(prog.with_attr("global_symbol", "main"), target=target)
+    source = artifact.kernel_source
+
+    assert "handle_add_byte_offset" not in source
+    assert "tl.recast_ptr(buf_dyn_shmem.iterator, dtype=cutlass.Uint8)" in source
+    assert "tl.recast_ptr(A_shared.iterator" not in source
+    assert "tl.recast_ptr(B_shared.iterator" not in source
+    assert "tl.recast_ptr(A_shared, dtype=cutlass.Float16)" in source
+    assert "tl.recast_ptr(B_shared, dtype=cutlass.Float16)" in source
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Summary

- Add Python and CuTeDSL codegen support for `tirx.handle_add_byte_offset`.
- Fix shared-memory alias lowering for CuTeDSL so merged shared buffers are emitted as byte-offset raw pointers instead of unresolved calls.

## Changes

- Emit base Python `handle_add_byte_offset` calls as pointer addition.
- In CuTeDSL codegen, recast handle operands to `cutlass.Uint8` for byte-addressed pointer arithmetic.
- Track handle-valued `Bind` aliases as raw pointers so later buffer accesses avoid `.iterator` and recast to the requested element type.
- Add a CuTeDSL shared-alias codegen regression test.

## Validation

- `./format.sh`
- `cmake --build build -j$(nproc)`
- `python -m pytest testing/python/target/test_tilelang_codegen_cutedsl_cp_async.py -q`
- `python -m pytest testing/python/components/test_cuda_shared_memory_alias_codegen.py -q`
- `python -m pytest testing/python/jit/test_tilelang_jit_cutedsl.py::test_gemm_jit_kernel testing/python/jit/test_tilelang_jit_cutedsl.py::test_cutedsl_kernel_multi_stream testing/python/jit/test_tilelang_jit_cutedsl.py::test_cutedsl_dynamic_shape -q` (skipped in this environment)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced code generation for CuTeDSL CUDA kernels with improved pointer arithmetic and byte-offset handling in shared memory operations.
  * Extended support for handle byte offset operations in code generation.

* **Tests**
  * Added validation for shared memory pointer casting behavior in CuTeDSL code generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->