### PR TITLE
[CuTeDSL] Lower handle_add_byte_offset in Python codegen

### DIFF
--- a/src/backend/cuda/codegen/codegen_cutedsl.cc
+++ b/src/backend/cuda/codegen/codegen_cutedsl.cc
@@ -1218,6 +1218,10 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
     ICHECK_EQ(load->indices.size(), 1)
         << "CodeGenTileLangCuTeDSL only supports flat memory";
     os << GetBufferPtr_(load->buffer.get(), load->indices[0]);
+  } else if (op->op.same_as(builtin::handle_add_byte_offset())) {
+    ICHECK_EQ(op->args.size(), 2U);
+    os << "tl.handle_add_byte_offset(" << PrintExpr_(op->args[0]) << ", "
+       << PrintExpr_(op->args[1]) << ")";
   } else if (op->op.same_as(tl::atomic_add_elem_op())) {
     // atomic_add_elem_op(dst_ptr, src_value[, memory_order])
     std::string dst_ptr = PrintExpr_(op->args[0]);

--- a/tilelang/contrib/cutedsl/utils.py
+++ b/tilelang/contrib/cutedsl/utils.py
@@ -20,6 +20,7 @@ __all__ = [
     "bitcast",
     "make_filled_tensor",
     "make_tensor_at_offset",
+    "handle_add_byte_offset",
     "shuffle_elect",
     "sync_thread_partial",
     "pack_half2",
@@ -110,6 +111,12 @@ def make_tensor_at_offset(ptr: cute.Pointer, offset, shape, div_by=1):
     if div_by != 1:
         offset = cute.assume(cutlass.as_numeric(offset), divby=div_by)
     return cute.make_tensor(ptr + offset, shape)
+
+
+def handle_add_byte_offset(handle, byte_offset):
+    ptr = handle.iterator if hasattr(handle, "iterator") else handle
+    byte_ptr = cute.recast_ptr(ptr, dtype=cutlass.Uint8)
+    return make_tensor_at_offset(byte_ptr, byte_offset, (1,))
 
 
 def shuffle_elect(thread_extent):


### PR DESCRIPTION
Make the CuTeDSL Python codegen handle tirx.handle_add_byte_offset instead of falling back to CodeGenTileLangPY and failing with an unresolved call.

The helper preserves byte-offset semantics by recasting tensor or pointer handles to Uint8 before applying the offset. This is needed for dynamic shared-memory aliases generated by TileLang lowering, such as the CuTeDSL GEMM JIT path.

Verified with nvidia-cutlass-dsl-libs-base 4.5.0 on CUDA:

* testing/python/jit/test_tilelang_jit_cutedsl.py::test_gemm_jit_kernel

* testing/python/jit/test_tilelang_jit_cutedsl.py::test_cutedsl_kernel_multi_stream

* testing/python/jit/test_tilelang_jit_cutedsl.py::test_cutedsl_dynamic_shape

* testing/python/jit/test_tilelang_jit_cutedsl.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for `handle_add_byte_offset` utility function to enable byte-level pointer manipulation.
  * Enabled CuTeDSL codegen support for byte offset operations in intrinsic function handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->