### PR TITLE
[Feature] Add CUDA __ffs intrinsic for bit manipulation

### DIFF
--- a/src/backend/cuda/codegen/codegen_cuda.cc
+++ b/src/backend/cuda/codegen/codegen_cuda.cc
@@ -3505,6 +3505,16 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     // Emit __ldg(&buffer_ref)
     auto buffer_ref = this->GetBufferRef(op->dtype, buffer, base);
     os << "__ldg(&(" << buffer_ref << "))";
+  } else if (op->op.same_as(tl::__ffs())) {
+    ICHECK_EQ(op->args.size(), 1U) << "T.__ffs expects one argument.";
+    DataType arg_dtype = op->args[0].dtype();
+    ICHECK(arg_dtype.is_int() || arg_dtype.is_uint())
+        << "T.__ffs expects an integer argument, but got " << arg_dtype;
+    ICHECK(arg_dtype.bits() == 32 || arg_dtype.bits() == 64)
+        << "T.__ffs expects a 32-bit or 64-bit integer argument, but got "
+        << arg_dtype;
+    os << (arg_dtype.bits() == 64 ? "__ffsll(" : "__ffs(")
+       << PrintExpr(op->args[0]) << ")";
   } else if (op->op.same_as(tl::ldg32())) {
     // Explicit 32-bit global memory load: load_global_32(ptr) or
     // load_global_32_conditional(ptr, pred)

--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -704,6 +704,10 @@ TIR_DEFINE_TL_BUILTIN(ds_read_tr8_b64)
 TIR_DEFINE_TL_BUILTIN(__ldg).set_num_inputs(-1).set_attr<TCallEffectKind>(
     "TCallEffectKind", Integer(CallEffectKind::kPure));
 
+// __ffs(value) -> one-based least-significant set-bit position, or 0.
+TIR_DEFINE_TL_BUILTIN(__ffs).set_num_inputs(1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
 // ldg32(address, predicate(optional)) -> 32-bit value
 // Global memory load with 32-bit vector width
 TIR_DEFINE_TL_BUILTIN(ldg32).set_num_inputs(-1).set_attr<TCallEffectKind>(

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -1199,6 +1199,18 @@ TVM_DLL const Op &warp_reduce_bitor();
 TVM_DLL const Op &__ldg();
 
 /*!
+ * \brief tilelang intrinsic for CUDA find-first-set bit (__ffs / __ffsll).
+ *
+ *  Returns the one-based position of the least significant set bit, or 0 when
+ *  the input is zero. CUDA codegen emits `__ffs` for 32-bit integer inputs and
+ *  `__ffsll` for 64-bit integer inputs.
+ *
+ *  Usage from TVMScript:
+ *    lane = T.__ffs(mask) - 1
+ */
+TVM_DLL const Op &__ffs();
+
+/*!
  * \brief tilelang intrinsic for global memory load with 32-bit vector width.
  *
  *  This op loads 32 bits (4 bytes) from global memory using explicit

--- a/testing/python/language/test_tilelang_language_warp_vote.py
+++ b/testing/python/language/test_tilelang_language_warp_vote.py
@@ -7,6 +7,7 @@ T.all_sync          – __all_sync  / __all  (HIP)
 T.ballot_sync       – __ballot_sync→uint64 (CUDA, zero-ext) / __ballot uint64 (HIP, all lanes)
 T.ballot            – full-warp ballot_sync / __ballot uint64 (HIP, all lanes)
 T.activemask        – __activemask→uint64 (CUDA, zero-ext) / __ballot(1) uint64 (HIP, all lanes)
+T.__ffs             – __ffs / __ffsll (CUDA)
 T.syncthreads_count – __syncthreads_count
 T.syncthreads_and   – __syncthreads_and
 T.syncthreads_or    – __syncthreads_or
@@ -147,6 +148,38 @@ def test_ballot():
     # upper 32 bits are 0 on CUDA (32-wide warp).
     assert (int(b[0]) & 0xFFFFFFFF) == 0xFFFFFFFF, f"Expected lower 32 bits all set, got {int(b[0]):#018x}"
     assert (int(b[0]) >> 32) == 0, f"Expected upper 32 bits zero on CUDA, got {int(b[0]):#018x}"
+
+
+# ---------------------------------------------------------------------------
+# __ffs
+# ---------------------------------------------------------------------------
+
+
+@tilelang.jit
+def kernel_ffs_ballot_sync():
+    """Find the first lane whose ballot predicate is true."""
+
+    @T.prim_func
+    def main(
+        B: T.Tensor((32,), "int32"),
+    ):
+        with T.Kernel(1, threads=32):
+            tx = T.get_thread_binding()
+            mask = T.ballot_sync(tx >= 7)
+            B[tx] = T.__ffs(mask) - 1
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+def test_ffs_ballot_sync():
+    b = torch.zeros((32,), device="cuda", dtype=torch.int32)
+    kernel = kernel_ffs_ballot_sync()
+    src = kernel.get_kernel_source()
+    assert "__ballot_sync" in src, f"Expected __ballot_sync in source:\n{src}"
+    assert "__ffsll" in src, f"Expected __ffsll for uint64 ballot mask in source:\n{src}"
+    kernel(b)
+    assert torch.all(b == 7), f"Expected all lanes to find lane 7, got {b}"
 
 
 # ---------------------------------------------------------------------------

--- a/tilelang/language/__init__.py
+++ b/tilelang/language/__init__.py
@@ -117,6 +117,7 @@ from .customize import (
 from .logical import any_of, all_of  # noqa: F401
 from .builtin import *  # noqa: F401
 from .builtin import __ldg as __ldg  # noqa: F401
+from .builtin import __ffs as __ffs  # noqa: F401
 from .builtin import ds_read_tr16_b64 as ds_read_tr16_b64  # noqa: F401
 from .builtin import ds_read_tr8_b64 as ds_read_tr8_b64  # noqa: F401
 from .builtin import ldg32 as ldg32  # noqa: F401

--- a/tilelang/language/builtin.py
+++ b/tilelang/language/builtin.py
@@ -79,6 +79,17 @@ def __ldg(load_or_buf: BufferLoad | tirx.Buffer, index: PrimExpr | int | None = 
     raise TypeError("T.__ldg expects a BufferLoad or a Buffer.")
 
 
+def __ffs(value: int | PrimExpr) -> PrimExpr:
+    """Find the position of the least significant set bit.
+
+    Lowers to CUDA ``__ffs`` for 32-bit integer inputs and ``__ffsll`` for
+    64-bit integer inputs. The return value follows CUDA semantics: one-based
+    bit position, or 0 when ``value`` is zero.
+    """
+    value = tirx.convert(value)
+    return tirx.call_intrin("int32", tirx.op.Op.get("tl.__ffs"), value)
+
+
 def access_ptr(
     base: BufferLikeType,
     access_type: str | int = "r",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `__ffs()` builtin function to find the position of the least-significant set bit in 32-bit or 64-bit integer values. Returns a one-based index or 0 if the input is zero.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->