### PR TITLE
[CuTeDSL] Represent tfloat32 storage as Float32

### DIFF
--- a/src/backend/cuda/codegen/codegen_cutedsl.cc
+++ b/src/backend/cuda/codegen/codegen_cutedsl.cc
@@ -192,6 +192,10 @@ std::string DTypeToString(DataType t) {
     if (bits == 16 || bits == 32 || bits == 64) {
       elem_type = "Float" + std::to_string(bits);
     }
+  } else if (t.is_tfloat32()) {
+    // CuTeDSL TF32 scalar arithmetic is only valid in MMA paths; use FP32 for
+    // storage and elementwise arithmetic since TF32 has the same memory layout.
+    elem_type = "Float32";
   } else if (t.is_bfloat16()) {
     elem_type = "BFloat16";
   } else if (t.is_float8()) {


### PR DESCRIPTION
CuTeDSL examples that allocate T.tfloat32 buffers originally failed because custom[tfloat32] had no dtype mapping in DTypeToString. Mapping it directly to cutlass.TFloat32 allowed codegen to proceed, but ordinary elementwise expressions such as x_frag * x_frag then produced invalid MLIR arith.muli operations on tf32 values.

Represent custom[tfloat32] as cutlass.Float32 for CuTeDSL storage, recasts, and elementwise arithmetic. TileLang tfloat32 has the same memory layout as float32, and CuTeDSL MMA helpers still select TF32 instructions through the PTX/WGMMA dtype strings, so the tensor-core path keeps TF32 semantics without using the TF32 scalar type for general arithmetic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TensorFloat32 (TF32) handling for CUDA codegen: TF32 is mapped to float32 for storage and elementwise arithmetic, while TF32 arithmetic is enabled for tensor-core/MMA execution paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->