### PR TITLE
Dynamic max-size for ccache based on OS

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
-          max-size: "200MB"
+          max-size: ${{ runner.os == 'Windows' && '1GB' || '200MB' }}
           create-symlink: ${{ runner.os != 'Windows' }}
           evict-old-files: "7d"
           append-timestamp: false

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
-          max-size: ${{ runner.os == 'Windows' && '1GB' || '200MB' }}
+          max-size: "200MB"
           create-symlink: ${{ runner.os != 'Windows' }}
           evict-old-files: "7d"
           append-timestamp: false
@@ -144,7 +144,7 @@ jobs:
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
-          max-size: "200MB"
+          max-size: ${{ runner.os == 'Windows' && '1GB' || '200MB' }}
           create-symlink: ${{ runner.os != 'Windows' }}
           evict-old-files: "7d"
           append-timestamp: false


### PR DESCRIPTION
This pull request updates the `ccache` configuration in the `.github/workflows/dist.yml` file to optimize cache usage for different operating systems.

Caching improvements:
* Increased the `ccache` maximum cache size to `1GB` on Windows runners, while keeping it at `200MB` for other operating systems, to better accommodate larger build artifacts on Windows.

https://github.com/tile-ai/tilelang/issues/2267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow cache settings for the build process: cache size now varies by runner OS (larger on Windows, smaller on other systems) to optimize build caching behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->