### PR TITLE
[Bugfix][TMA] Drop buffer_oob gate from 1D bulk-copy eligibility

### DIFF
--- a/src/backend/cuda/op/copy_analysis.cc
+++ b/src/backend/cuda/op/copy_analysis.cc
@@ -227,6 +227,16 @@ bool CheckBulkCopy1D(const Buffer &global_tensor, const Buffer &shared_tensor,
                                   global_range[i]->min == 0,
                               arith::ProofStrength::kSymbolicBound)) {
         global_not_full_dim_encounter = true;
+        bool single_row = analyzer->CanProve(
+            global_range[i]->extent == 1, arith::ProofStrength::kSymbolicBound);
+        bool provably_in_bounds =
+            analyzer->CanProve(global_range[i]->min + global_range[i]->extent <=
+                                   global_tensor->shape[i],
+                               arith::ProofStrength::kSymbolicBound);
+        if (!single_row && !provably_in_bounds) {
+          global_is_contiguous = false;
+          break;
+        }
       }
     } else {
       if (!analyzer->CanProve(global_range[i]->extent == 1,
@@ -493,12 +503,6 @@ CopyFacts AnalyzeCopyFacts(const CopyNode &op, const CopyAnalysisContext &ctx) {
   const LayoutMap &layout_map =
       ctx.layout_map != nullptr ? *ctx.layout_map : empty_layout_map;
   bool is_cutedsl = TargetIsCuTeDSL(ctx.target);
-  // Issue #2180: only the descriptor-based 2D TMA path needs the OOB gate.
-  // The 1D bulk-copy path emits `cp.async.bulk`, which has the same OOB
-  // semantics as plain T.copy(); gating it on `buffer_oob` causes
-  // InferLayout to fall through to the 2D path for dynamic-outer-shape
-  // tensors and install a swizzle-shaped shared layout, which then forces
-  // Lower() into LowerBulk and triggers the 256-element splitting.
   facts.layout_dependent_tma_available = facts.has_layout_map && !is_cutedsl;
 
   if (facts.layout_dependent_tma_available) {

--- a/src/backend/cuda/op/copy_analysis.cc
+++ b/src/backend/cuda/op/copy_analysis.cc
@@ -493,8 +493,13 @@ CopyFacts AnalyzeCopyFacts(const CopyNode &op, const CopyAnalysisContext &ctx) {
   const LayoutMap &layout_map =
       ctx.layout_map != nullptr ? *ctx.layout_map : empty_layout_map;
   bool is_cutedsl = TargetIsCuTeDSL(ctx.target);
-  facts.layout_dependent_tma_available =
-      facts.has_layout_map && !is_cutedsl && !ctx.buffer_oob;
+  // Issue #2180: only the descriptor-based 2D TMA path needs the OOB gate.
+  // The 1D bulk-copy path emits `cp.async.bulk`, which has the same OOB
+  // semantics as plain T.copy(); gating it on `buffer_oob` causes
+  // InferLayout to fall through to the 2D path for dynamic-outer-shape
+  // tensors and install a swizzle-shaped shared layout, which then forces
+  // Lower() into LowerBulk and triggers the 256-element splitting.
+  facts.layout_dependent_tma_available = facts.has_layout_map && !is_cutedsl;
 
   if (facts.layout_dependent_tma_available) {
     facts.can_bulk_load_1d =

--- a/testing/python/language/test_tilelang_language_tma_1d.py
+++ b/testing/python/language/test_tilelang_language_tma_1d.py
@@ -46,10 +46,47 @@ def run_elementwise_add(M, N):
         assert "tma_load" in code and "CUtensorMap" in code
 
 
+def _lower_issue_2180_kernel(K, dtype):
+    M = T.dynamic("M")
+
+    @T.prim_func
+    def gemm(A: T.Tensor([M, K], dtype)):
+        with T.Kernel(M, threads=256):
+            var = T.alloc_var(T.int32, init=0)
+            a_shared = T.alloc_shared(K, dtype=dtype)
+            mbar = T.alloc_barrier(256)
+            T.tma_copy(A[var, 0:K], a_shared, barrier=mbar)
+
+    artifact = tilelang.lower(gemm, target={"kind": "cuda", "arch": "sm_90a"})
+    return artifact.kernel_source
+
+
+def _check_single_1d_tma(code):
+    n_tma_load = code.count("tl::tma_load(")
+    has_desc = "CUtensorMap" in code
+    assert n_tma_load == 1, f"Issue #2180: expected exactly 1 tl::tma_load, got {n_tma_load}.\nGenerated source:\n{code}"
+    assert not has_desc, f"Issue #2180: expected 1D bulk-copy without CUtensorMap descriptor.\nGenerated source:\n{code}"
+
+
+def test_issue_2180_full_row_fp32_k1024():
+    _check_single_1d_tma(_lower_issue_2180_kernel(K=1024, dtype=T.float32))
+
+
+def test_issue_2180_full_row_fp32_k512():
+    _check_single_1d_tma(_lower_issue_2180_kernel(K=512, dtype=T.float32))
+
+
+def test_issue_2180_full_row_fp16_k1024():
+    _check_single_1d_tma(_lower_issue_2180_kernel(K=1024, dtype=T.float16))
+
+
 def main():
     run_elementwise_add(128, 128)
     run_elementwise_add(256, 128)
     run_elementwise_add(256, 256)
+    test_issue_2180_full_row_fp32_k1024()
+    test_issue_2180_full_row_fp32_k512()
+    test_issue_2180_full_row_fp16_k1024()
 
 
 if __name__ == "__main__":

--- a/testing/python/language/test_tilelang_language_tma_1d.py
+++ b/testing/python/language/test_tilelang_language_tma_1d.py
@@ -80,6 +80,30 @@ def test_issue_2180_full_row_fp16_k1024():
     _check_single_1d_tma(_lower_issue_2180_kernel(K=1024, dtype=T.float16))
 
 
+def _lower_oob_outer_slice_kernel():
+    H_full = 8
+    H_block = 64
+    K = 128
+
+    @T.prim_func
+    def gemm(A: T.Tensor([H_full, K], T.bfloat16)):
+        with T.Kernel(1, threads=128):
+            a_shared = T.alloc_shared((H_block, K), dtype=T.bfloat16)
+            mbar = T.alloc_barrier(128)
+            T.tma_copy(A[0:H_block, 0:K], a_shared, barrier=mbar)
+
+    artifact = tilelang.lower(gemm, target={"kind": "cuda", "arch": "sm_90a"})
+    return artifact.kernel_source
+
+
+def test_oob_outer_slice_falls_back_to_2d():
+    code = _lower_oob_outer_slice_kernel()
+    assert "CUtensorMap" in code, (
+        f"Provably-OOB outer slice must fall back to the 2D descriptor path so the HW clamp "
+        f"applies; got 1D bulk copy instead.\nGenerated source:\n{code}"
+    )
+
+
 def main():
     run_elementwise_add(128, 128)
     run_elementwise_add(256, 128)
@@ -87,6 +111,7 @@ def main():
     test_issue_2180_full_row_fp32_k1024()
     test_issue_2180_full_row_fp32_k512()
     test_issue_2180_full_row_fp16_k1024()
+    test_oob_outer_slice_falls_back_to_2d()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #2180.

When i was looking at the issue, the 4-way split came from the 1D bulk-copy eligibility being gated on the same flag the descriptor-based 2D path uses, even though the 1D path doesn't actually need that gate. I narrowed it to a single safety check that only matters for the descriptor variant. While testing that on H100, i realised the gate was also catching legitimately out-of-bounds outer slices for free, so the second commit tightens the 1D eligibility check to keep those on the 2D descriptor path where the hardware clamp can do its job. Together with 4 regression tests (3 positive, 1 negative).

## Verification

Pre-patch generated source for the issue's repro (extracted from the codegen string):

```cpp
extern "C" __global__ void __launch_bounds__(256, 1)
gemm_kernel(__grid_constant__ const CUtensorMap A_desc, int M) {
  ...
  if (tl::tl_shuffle_elect<256>()) {
    mbar[0].expect_transaction(4096);
    tl::tma_load(A_desc, mbar[0], (&(a_shared[  0])),   0, var);
    tl::tma_load(A_desc, mbar[0], (&(a_shared[256])), 256, var);
    tl::tma_load(A_desc, mbar[0], (&(a_shared[512])), 512, var);
    tl::tma_load(A_desc, mbar[0], (&(a_shared[768])), 768, var);
  }
}
```

Post-patch:

```cpp
extern "C" __global__ void __launch_bounds__(256, 1)
gemm_kernel(float* __restrict__ A, int M) {
  ...
  mbar[0].expect_transaction(4096);
  tl::tma_load((&(a_shared[0])), (&(A[(((int64_t)var) * (int64_t)1024)])), mbar[0], 4096);
}
```

A single 1D `cp.async.bulk` issue, no `CUtensorMap` descriptor — matches the expected behavior in the issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined bulk-copy contiguity checks so certain 1D copy cases are correctly treated as contiguous.
  * Relaxed gating for layout-dependent TMA so descriptor-based TMA considerations occur in more valid layout cases.

* **Tests**
  * Added TileLang CUDA tests covering 1D TMA lowering for full-row variants and an out-of-bounds fallback that verifies use of the 2D descriptor path.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->