### PR TITLE
[Refactor] Refactor blockscaled TCGEN5, support .f8f6f4/.mxf8f6f4 and restore maint scripts

### DIFF
--- a/examples/blockscaled_gemm_sm100/gemm_mxfp8_blockscaled_1d1d.py
+++ b/examples/blockscaled_gemm_sm100/gemm_mxfp8_blockscaled_1d1d.py
@@ -126,8 +126,6 @@ def mxfp8_blockscaled_gemm(
                 if k % sf_load_period == 0:
                     T.tcgen05_cp_warpx4(SFA_shared[stage, :], SFA_tmem)
                     T.tcgen05_cp_warpx4(SFB_shared[stage, :], SFB_tmem)
-
-                # sf_id selects which of the 4 packed E8M0 values to use
                 T.tcgen05_gemm_blockscaled(
                     A_shared[stage, :, :],
                     B_shared[stage, :, :],
@@ -137,8 +135,9 @@ def mxfp8_blockscaled_gemm(
                     transpose_B=transpose_B,
                     mbar=consumed[stage],
                     clear_accum=k == 0,
-                    sf_a_id=k % sf_load_period,
-                    sf_b_id=k % sf_load_period,
+                    k_start=k * block_K,
+                    sf_a_granularity_k=sf_granularity_k,
+                    sf_b_granularity_k=sf_granularity_k,
                 )
 
             T.tcgen05_mma_arrive(tmem_full)
@@ -290,8 +289,9 @@ def mxfp8_blockscaled_gemm_2cta(
                     transpose_B=transpose_B,
                     mbar=consumed[stage],
                     clear_accum=k == 0,
-                    sf_a_id=k % sf_load_period,
-                    sf_b_id=k % sf_load_period,
+                    k_start=k * block_K,
+                    sf_a_granularity_k=sf_granularity_k,
+                    sf_b_granularity_k=sf_granularity_k,
                     use_2cta=True,
                 )
             T.tcgen05_mma_arrive(tmem_full, arrive_2cta=True)
@@ -463,8 +463,9 @@ def mxfp8_blockscaled_gemm_2cta_persistent(
                             transpose_B=transpose_B,
                             mbar=consumed[stage],
                             clear_accum=k == 0,
-                            sf_a_id=k % sf_load_period,
-                            sf_b_id=k % sf_load_period,
+                            k_start=k * block_K,
+                            sf_a_granularity_k=sf_granularity_k,
+                            sf_b_granularity_k=sf_granularity_k,
                             use_2cta=True,
                         )
                     T.tcgen05_mma_arrive(tmem_full, arrive_2cta=True)

--- a/examples/blockscaled_gemm_sm100/grouped_gemm_mxfp8_blockscaled_1d1d.py
+++ b/examples/blockscaled_gemm_sm100/grouped_gemm_mxfp8_blockscaled_1d1d.py
@@ -158,8 +158,9 @@ def grouped_mxfp8_blockscaled_gemm_2cta(
                     transpose_B=transpose_B,
                     mbar=consumed[stage],
                     clear_accum=k == 0,
-                    sf_a_id=k % sf_load_period,
-                    sf_b_id=k % sf_load_period,
+                    k_start=k * block_K,
+                    sf_a_granularity_k=sf_granularity_k,
+                    sf_b_granularity_k=sf_granularity_k,
                     use_2cta=True,
                 )
             T.tcgen05_mma_arrive(tmem_full, arrive_2cta=True)
@@ -364,8 +365,9 @@ def grouped_mxfp8_blockscaled_gemm_2cta_persistent(
                             transpose_B=transpose_B,
                             mbar=consumed[stage],
                             clear_accum=k == 0,
-                            sf_a_id=k % sf_load_period,
-                            sf_b_id=k % sf_load_period,
+                            k_start=k * block_K,
+                            sf_a_granularity_k=sf_granularity_k,
+                            sf_b_granularity_k=sf_granularity_k,
                             use_2cta=True,
                         )
                     T.tcgen05_mma_arrive(tmem_full, arrive_2cta=True)

--- a/examples/blockscaled_gemm_sm100/mxfp8_illustrated.md
+++ b/examples/blockscaled_gemm_sm100/mxfp8_illustrated.md
@@ -104,7 +104,9 @@ SFA_tmem: [128 lanes, 4 columns]
 SFB_tmem: [128 lanes, 8 columns]  # two 128-column N chunks
 ```
 
-During MMA issue, `sf_a_id = k % 4` and `sf_b_id = k % 4` select the active
+During MMA issue, the kernel passes `k_start = k * block_K` plus
+`sf_a_granularity_k = sf_b_granularity_k = 128`. The lowering derives the PTX
+scale-factor IDs as `(k_start / sf_granularity_k) % 4`, selecting the active
 byte sub-column from the packed `uint32` cell. This is why one SF TMA load
 serves four adjacent `block_K=128` MMA iterations.
 

--- a/examples/deepseek_v4/fp8_fp4_gemm_1d1d_sm100.py
+++ b/examples/deepseek_v4/fp8_fp4_gemm_1d1d_sm100.py
@@ -1,0 +1,425 @@
+# Schedule adapted from DeepGEMM.
+
+import argparse
+from typing import Tuple
+from functools import lru_cache
+import torch
+import tilelang
+import tilelang.language as T
+from tilelang.carver.arch import driver
+from tilelang.profiler import do_bench
+
+
+def _ceil_div(x: int, y: int) -> int:
+    return (x + y - 1) // y
+
+
+def _make_fp8_fp4_gemm_1d1d_prim_func(
+    M: int,
+    N: int,
+    K: int,
+    block_M: int,
+    block_N: int,
+    block_K: int,
+    out_dtype,
+    accum_dtype,
+    num_stages: int,
+    sf_granularity_k: int = 128,
+    store_block_N: int = 64,
+):
+    assert block_M == 128
+    assert block_N == 256
+    assert block_K == 128
+    assert sf_granularity_k == 128
+
+    half_N = block_N // 2
+    sf_k_groups = _ceil_div(_ceil_div(K, sf_granularity_k), 4)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), T.float4_e2m1fn),
+        B: T.Tensor((N, K), T.float8_e4m3fn),
+        SFA: T.Tensor((sf_k_groups * M,), T.uint32),
+        SFB: T.Tensor((sf_k_groups * N,), T.uint32),
+        D: T.Tensor((M, N), out_dtype),
+    ):
+        sm_num = driver.get_num_sms()
+        num_clusters = sm_num // 2
+        m_blocks = T.ceildiv(M, block_M)
+        m_clusters = m_blocks // 2
+        n_blocks = T.ceildiv(N, block_N)
+        k_iters = T.ceildiv(K, block_K)
+        sf_load_period = sf_granularity_k * 4 // block_K
+        waves = T.ceildiv(m_blocks * n_blocks, sm_num)
+        group_size = 16
+
+        with T.Kernel(sm_num, threads=256, cluster_dims=2) as (block_id):
+            cta_id = T.block_rank_in_cluster()
+            T.assume(cta_id < 2)
+
+            A_shared = T.alloc_shared((num_stages, block_M, block_K), T.float4_e2m1_unpacked)
+            B_shared = T.alloc_shared((num_stages, half_N, block_K), T.float8_e4m3fn)
+            SFA_shared = T.alloc_shared((num_stages, block_M), "uint32")
+            SFB_shared = T.alloc_shared((num_stages, block_N), "uint32")
+
+            C_tmem = T.alloc_tmem([block_M, block_N], accum_dtype)
+            SFA_tmem = T.alloc_tmem([block_M, 4], "uint32")
+            SFB_tmem = T.alloc_tmem([block_M, 8], "uint32")
+
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+            C_shared = T.alloc_shared((block_M, store_block_N), out_dtype)
+
+            loaded = T.alloc_barrier([32] * num_stages)
+            with_sf_full = T.alloc_cluster_barrier([32 * 2] * num_stages)
+            consumed = T.alloc_cluster_barrier([1] * num_stages)
+            tmem_full = T.alloc_cluster_barrier([1])
+            tmem_empty = T.alloc_cluster_barrier([128 * 2])
+
+            tx = T.get_thread_binding()
+
+            if tx < 32:  # issue TMA, load operands and SFs
+                for w in T.unroll(waves):
+                    cluster_id = block_id // 2
+                    tile_id = num_clusters * w + cluster_id
+                    bx_cluster = (tile_id // group_size) % m_clusters
+                    bx = bx_cluster * 2 + cta_id
+                    by = (tile_id % group_size) + (tile_id // group_size) // m_clusters * group_size
+
+                    if bx * block_M < M and by * block_N < N:
+                        for k in T.serial(k_iters):
+                            phase = w * k_iters + k
+                            stage = phase % num_stages
+                            parity = (phase // num_stages) & 1
+                            T.mbarrier_wait_parity(consumed[stage], parity ^ 1)
+                            T.tma_copy(
+                                A[bx * block_M : (bx + 1) * block_M, k * block_K : (k + 1) * block_K],
+                                A_shared[stage, :, :],
+                                barrier=loaded[stage],
+                            )
+                            T.tma_copy(
+                                B[
+                                    by * block_N + cta_id * half_N : by * block_N + (cta_id + 1) * half_N,
+                                    k * block_K : (k + 1) * block_K,
+                                ],
+                                B_shared[stage, :, :],
+                                barrier=loaded[stage],
+                            )
+                            if k % sf_load_period == 0:
+                                sf_group_idx = k // sf_load_period
+                                T.tma_copy(
+                                    SFA[sf_group_idx * M + bx * block_M : sf_group_idx * M + (bx + 1) * block_M],
+                                    SFA_shared[stage, :],
+                                    barrier=loaded[stage],
+                                )
+                                T.tma_copy(
+                                    SFB[sf_group_idx * N + by * block_N : sf_group_idx * N + (by + 1) * block_N],
+                                    SFB_shared[stage, :],
+                                    barrier=loaded[stage],
+                                )
+                            T.mbarrier_arrive(loaded[stage])
+
+            elif 32 <= tx < 64 and cta_id == 0:  # issue tcgen5
+                for w in T.unroll(waves):
+                    cluster_id = block_id // 2
+                    tile_id = num_clusters * w + cluster_id
+
+                    if tile_id < m_clusters * n_blocks:
+                        T.mbarrier_wait_parity(tmem_empty, (w & 1) ^ 1)
+                        for k in T.serial(k_iters):
+                            phase = w * k_iters + k
+                            stage = phase % num_stages
+                            parity = (phase // num_stages) & 1
+                            T.mbarrier_wait_parity(with_sf_full[stage], parity)
+                            if k % sf_load_period == 0:
+                                T.tcgen05_cp_warpx4(SFA_shared[stage, :], SFA_tmem, use_2cta=True)
+                                T.tcgen05_cp_warpx4(SFB_shared[stage, :], SFB_tmem, use_2cta=True)
+                            T.tcgen05_gemm_blockscaled(
+                                A_shared[stage, :, :],
+                                B_shared[stage, :, :],
+                                C_tmem,
+                                SFA_tmem,
+                                SFB_tmem,
+                                transpose_B=True,
+                                mbar=consumed[stage],
+                                clear_accum=k == 0,
+                                k_start=k * block_K,
+                                sf_a_granularity_k=sf_granularity_k,
+                                sf_b_granularity_k=sf_granularity_k,
+                                use_2cta=True,
+                            )
+                        T.tcgen05_mma_arrive(tmem_full, arrive_2cta=True)
+
+            elif 64 <= tx < 96:  # transpose SFs
+                for w in T.unroll(waves):
+                    cluster_id = block_id // 2
+                    tile_id = num_clusters * w + cluster_id
+
+                    if tile_id < m_clusters * n_blocks:
+                        for k in T.serial(k_iters):
+                            phase = w * k_iters + k
+                            stage = phase % num_stages
+                            parity = (phase // num_stages) & 1
+                            T.mbarrier_wait_parity(loaded[stage], parity)
+                            if k % sf_load_period == 0:
+                                T.tcgen05_sf_warp_transpose(SFA_shared[stage, :])
+                                T.tcgen05_sf_warp_transpose(SFB_shared[stage, :])
+                                T.fence_proxy_async()
+                            T.mbarrier_arrive(with_sf_full[stage], 0)
+
+            elif 128 <= tx < 256:  # epilogue
+                for w in T.unroll(waves):
+                    cluster_id = block_id // 2
+                    tile_id = num_clusters * w + cluster_id
+                    bx_cluster = (tile_id // group_size) % m_clusters
+                    bx = bx_cluster * 2 + cta_id
+                    by = (tile_id % group_size) + (tile_id // group_size) // m_clusters * group_size
+
+                    if bx * block_M < M and by * block_N < N:
+                        T.mbarrier_wait_parity(tmem_full, w & 1)
+                        T.copy(C_tmem, C_local)
+                        T.mbarrier_arrive(tmem_empty, 0)
+
+                        for i in T.unroll(T.ceildiv(block_N, store_block_N)):
+                            T.copy(C_local[:, i * store_block_N : (i + 1) * store_block_N], C_shared)
+                            T.copy(C_shared, D[bx * block_M, by * block_N + i * store_block_N])
+
+    return main
+
+
+@lru_cache(maxsize=None)
+def _compile_fp8_fp4_gemm_1d1d(
+    M: int,
+    N: int,
+    K: int,
+    out_dtype,
+):
+    program = _make_fp8_fp4_gemm_1d1d_prim_func(
+        M,
+        N,
+        K,
+        128,
+        256,
+        128,
+        out_dtype,
+        T.float32,
+        6,
+        128,
+    )
+    # NOTE(wt): Work around the @tilelang.jit wrapper's current packed-FP4 ABI check:
+    # T.float4_e2m1fn logical [M, K] inputs are passed as int8 [M, K / 2].
+    # See https://github.com/tile-ai/tilelang/issues/2292.
+
+    return tilelang.compile(program, out_idx=[4])
+
+
+def _align_up(x: int, y: int) -> int:
+    return _ceil_div(x, y) * y
+
+
+def _ceil_to_ue8m0(x: torch.Tensor) -> torch.Tensor:
+    bits = x.abs().float().view(torch.int32)
+    exp = ((bits >> 23) & 0xFF) + (bits & 0x7FFFFF).ne(0).to(torch.int32)
+    return (exp.clamp(1, 254) << 23).view(torch.float32)
+
+
+def pack_sf_u8_to_u32_1d(sf_u8: torch.Tensor) -> torch.Tensor:
+    assert sf_u8.dtype == torch.uint8
+    assert sf_u8.dim() == 2
+    mn, sf_k_padded = sf_u8.shape
+    assert sf_k_padded % 4 == 0
+    words = sf_u8.to(torch.int64)
+    packed = (words[:, 0::4] | (words[:, 1::4] << 8) | (words[:, 2::4] << 16) | (words[:, 3::4] << 24)).to(torch.uint32)
+    return packed.T.contiguous().reshape(-1)
+
+
+def unpack_sf_u32_1d(packed_sf: torch.Tensor, mn: int, sf_k_blocks: int) -> torch.Tensor:
+    sf_k_groups = _ceil_div(sf_k_blocks, 4)
+    packed_2d = packed_sf.view(sf_k_groups, mn).T.contiguous().to(torch.int64)
+    unpacked = torch.empty((mn, sf_k_groups * 4), device=packed_sf.device, dtype=torch.uint8)
+    for i in range(4):
+        unpacked[:, i::4] = ((packed_2d >> (8 * i)) & 0xFF).to(torch.uint8)
+    return unpacked[:, :sf_k_blocks].contiguous()
+
+
+_FP4_E2M1_VALUES = (
+    0.0,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    4.0,
+    6.0,
+    -0.0,
+    -0.5,
+    -1.0,
+    -1.5,
+    -2.0,
+    -3.0,
+    -4.0,
+    -6.0,
+)
+
+
+def _fp4_lut(device: torch.device) -> torch.Tensor:
+    return torch.tensor(_FP4_E2M1_VALUES, device=device, dtype=torch.float32)
+
+
+def _packed_fp4_to_float(packed: torch.Tensor, logical_k: int) -> torch.Tensor:
+    u = packed.contiguous().view(torch.uint8)
+    if u.shape[1] != logical_k // 2:
+        u = u[:, : logical_k // 2]
+    lut = _fp4_lut(u.device)
+    lo = lut[(u & 0x0F).long()]
+    hi = lut[((u >> 4) & 0x0F).long()]
+    out = torch.empty((u.shape[0], logical_k), device=u.device, dtype=torch.float32)
+    out[:, 0::2] = lo
+    out[:, 1::2] = hi
+    return out
+
+
+def _quantize_float_to_fp4_packed(x: torch.Tensor) -> torch.Tensor:
+    m, k = x.shape
+    assert k % 2 == 0
+    lut = _fp4_lut(x.device)
+    idx = (x.reshape(-1, 1) - lut.reshape(1, -1)).abs().argmin(dim=1).reshape(m, k)
+    lo = idx[:, 0::2].to(torch.uint8)
+    hi = idx[:, 1::2].to(torch.uint8)
+    return (lo | (hi << 4)).to(torch.int8)
+
+
+def quantize_mxfp4_with_packed_ue8m0(x: torch.Tensor, gran_k: int = 128) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    assert x.dim() == 2
+    assert x.size(1) % 2 == 0
+    mn, k = x.shape
+    padded_k = _align_up(k, gran_k)
+    x_padded = torch.zeros((mn, padded_k), device=x.device, dtype=x.dtype)
+    x_padded[:, :k] = x
+    x_view = x_padded.view(mn, padded_k // gran_k, gran_k)
+    amax = x_view.abs().float().amax(dim=2).clamp_min(6.0 * (2.0**-126))
+    sf = _ceil_to_ue8m0(amax / 6.0)
+    x_fp4 = _quantize_float_to_fp4_packed((x_view * (1.0 / sf.unsqueeze(2))).reshape(mn, padded_k))[:, : k // 2].contiguous()
+    sf_u8 = (sf.contiguous().view(torch.int32) >> 23).to(torch.uint8)
+    sf_k_padded = _align_up(sf_u8.shape[1], 4)
+    if sf_k_padded != sf_u8.shape[1]:
+        sf_padded = torch.full((mn, sf_k_padded), 127, device=x.device, dtype=torch.uint8)
+        sf_padded[:, : sf_u8.shape[1]] = sf_u8
+    else:
+        sf_padded = sf_u8
+    return x_fp4, pack_sf_u8_to_u32_1d(sf_padded), sf_u8
+
+
+def quantize_mxfp8_with_packed_ue8m0(x: torch.Tensor, gran_k: int = 128) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    assert x.dim() == 2
+    mn, k = x.shape
+    padded_k = _align_up(k, gran_k)
+    x_padded = torch.zeros((mn, padded_k), device=x.device, dtype=x.dtype)
+    x_padded[:, :k] = x
+    x_view = x_padded.view(mn, padded_k // gran_k, gran_k)
+    amax = x_view.abs().float().amax(dim=2).clamp_min(1e-4)
+    sf = _ceil_to_ue8m0(amax / 448.0)
+    x_fp8 = (x_view * (1.0 / sf.unsqueeze(2))).to(torch.float8_e4m3fn)
+    x_fp8 = x_fp8.view(mn, padded_k)[:, :k].contiguous()
+    sf_u8 = (sf.contiguous().view(torch.int32) >> 23).to(torch.uint8)
+    sf_k_padded = _align_up(sf_u8.shape[1], 4)
+    if sf_k_padded != sf_u8.shape[1]:
+        sf_padded = torch.full((mn, sf_k_padded), 127, device=x.device, dtype=torch.uint8)
+        sf_padded[:, : sf_u8.shape[1]] = sf_u8
+    else:
+        sf_padded = sf_u8
+    return x_fp8, pack_sf_u8_to_u32_1d(sf_padded), sf_u8
+
+
+def fp8_fp4_gemm_ref(a_fp4, b_fp8, sfa_packed, sfb_packed, sf_granularity_k=128):
+    m, k_packed = a_fp4.shape
+    k = k_packed * 2
+    n, k2 = b_fp8.shape
+    assert k == k2
+    sf_k_blocks = _ceil_div(k, sf_granularity_k)
+    sfa = unpack_sf_u32_1d(sfa_packed, m, sf_k_blocks)
+    sfb = unpack_sf_u32_1d(sfb_packed, n, sf_k_blocks)
+    a_f32 = _packed_fp4_to_float(a_fp4, k)
+    b_f32 = b_fp8.to(torch.float32)
+    sfa_scales = torch.pow(2.0, sfa.to(torch.float32) - 127.0)
+    sfb_scales = torch.pow(2.0, sfb.to(torch.float32) - 127.0)
+
+    c = torch.zeros((m, n), device=a_fp4.device, dtype=torch.float32)
+    for bi in range(sf_k_blocks):
+        k_start = bi * sf_granularity_k
+        k_end = min(k_start + sf_granularity_k, k)
+        a_block = a_f32[:, k_start:k_end] * sfa_scales[:, bi : bi + 1]
+        b_block = b_f32[:, k_start:k_end] * sfb_scales[:, bi : bi + 1]
+        c += a_block @ b_block.T
+    return c
+
+
+def cosine_diff(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    x = x.double().flatten()
+    y = y.double().flatten()
+    return 1.0 - 2.0 * (x * y).sum() / ((x * x + y * y).sum())
+
+
+def run_fp8_fp4_gemm_1d1d(
+    a_fp4,
+    b_fp8,
+    sfa,
+    sfb,
+    out_dtype=T.bfloat16,
+):
+    block_M, block_N, block_K = 128, 256, 128
+    m, k_packed = a_fp4.shape
+    n, k = b_fp8.shape
+    assert k_packed * 2 == k
+    assert m % (2 * block_M) == 0, f"M={m} must be divisible by {2 * block_M}"
+    assert n % (32 * block_N) == 0, f"N={n} must be divisible by {32 * block_N}"
+    assert k % (2 * block_K) == 0, f"K={k} must be divisible by {2 * block_K}"
+    kernel = _compile_fp8_fp4_gemm_1d1d(m, n, k, out_dtype)
+    return kernel(a_fp4, b_fp8, sfa, sfb)
+
+
+def check_correctness(M=256, N=8192, K=1024, seed=0):
+    torch.manual_seed(seed)
+    a = torch.randn((M, K), device="cuda", dtype=torch.float32)
+    b = torch.randn((N, K), device="cuda", dtype=torch.float32)
+    a_fp4, sfa, _ = quantize_mxfp4_with_packed_ue8m0(a)
+    b_fp8, sfb, _ = quantize_mxfp8_with_packed_ue8m0(b)
+
+    c = run_fp8_fp4_gemm_1d1d(a_fp4, b_fp8, sfa, sfb)
+    ref = fp8_fp4_gemm_ref(a_fp4, b_fp8, sfa, sfb).to(torch.bfloat16)
+    diff = cosine_diff(c, ref)
+    max_abs_diff = (c.float() - ref.float()).abs().max()
+    print(f"cosine diff={float(diff):.6g}, max abs diff={float(max_abs_diff):.6g}")
+    assert diff < 1e-3
+    return c
+
+
+def benchmark(M=512, N=8192, K=8192, seed=0, warmup=25, rep=100):
+    torch.manual_seed(seed)
+    a = torch.randn((M, K), device="cuda", dtype=torch.float32)
+    b = torch.randn((N, K), device="cuda", dtype=torch.float32)
+    a_fp4, sfa, _ = quantize_mxfp4_with_packed_ue8m0(a)
+    b_fp8, sfb, _ = quantize_mxfp8_with_packed_ue8m0(b)
+
+    torch.cuda.synchronize()
+    latency = do_bench(lambda: run_fp8_fp4_gemm_1d1d(a_fp4, b_fp8, sfa, sfb), warmup=warmup, rep=rep)
+    tflops = 2 * M * N * K / latency / 1e9
+    print(f"M={M} N={N} K={K}: {latency:.4f} ms, {tflops:.2f} TFLOP/s")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--M", type=int, default=1024)
+    parser.add_argument("--N", type=int, default=8192)
+    parser.add_argument("--K", type=int, default=8192)
+    parser.add_argument("--seed", type=int, default=0)
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    check_correctness(args.M, args.N, args.K, args.seed)
+    benchmark(args.M, args.N, args.K, args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/deepseek_v4/test_tilelang_example_deepseek_v4.py
+++ b/examples/deepseek_v4/test_tilelang_example_deepseek_v4.py
@@ -1,6 +1,7 @@
 import tilelang.testing
 
 import act_quant
+import fp8_fp4_gemm_1d1d_sm100
 import sparse_attn_fwd_sm90
 
 
@@ -9,6 +10,12 @@ def test_example_act_quant():
     act_quant.test_fp8_act_quant(M=64, N=256, block_size=128)
     act_quant.test_fp4_act_quant(M=64, N=256, block_size=32)
     act_quant.test_round_trip_error()
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(10, 0)
+def test_example_fp8_fp4_gemm_1d1d():
+    fp8_fp4_gemm_1d1d_sm100.check_correctness(M=256, N=8192, K=512)
 
 
 @tilelang.testing.requires_cuda

--- a/examples/gemm_sm100/gemm_tcgen5mma_ws.py
+++ b/examples/gemm_sm100/gemm_tcgen5mma_ws.py
@@ -1,4 +1,3 @@
-
 # Non-persistent
 
 import torch

--- a/examples/gemm_sm100/gemm_tcgen5mma_ws.py
+++ b/examples/gemm_sm100/gemm_tcgen5mma_ws.py
@@ -1,3 +1,4 @@
+
 # Non-persistent
 
 import torch

--- a/examples/gemm_sm100/gemm_tcgen5mma_ws_persistent.py
+++ b/examples/gemm_sm100/gemm_tcgen5mma_ws_persistent.py
@@ -5,7 +5,9 @@ import tilelang
 import tilelang.language as T
 from tilelang.carver.arch import driver
 from tilelang.profiler import do_bench
+
 tilelang.disable_cache()
+
 
 @tilelang.jit
 def gemm_persistent(

--- a/examples/gemm_sm100/gemm_tcgen5mma_ws_persistent.py
+++ b/examples/gemm_sm100/gemm_tcgen5mma_ws_persistent.py
@@ -6,8 +6,6 @@ import tilelang.language as T
 from tilelang.carver.arch import driver
 from tilelang.profiler import do_bench
 
-tilelang.disable_cache()
-
 
 @tilelang.jit
 def gemm_persistent(

--- a/examples/gemm_sm100/gemm_tcgen5mma_ws_persistent.py
+++ b/examples/gemm_sm100/gemm_tcgen5mma_ws_persistent.py
@@ -5,7 +5,7 @@ import tilelang
 import tilelang.language as T
 from tilelang.carver.arch import driver
 from tilelang.profiler import do_bench
-
+tilelang.disable_cache()
 
 @tilelang.jit
 def gemm_persistent(

--- a/maint/gemm/correctness_evaluation.py
+++ b/maint/gemm/correctness_evaluation.py
@@ -1,0 +1,807 @@
+# pytest correctness_evaluation.py -n 32
+import pytest
+from tilelang import tvm as tvm
+import tilelang.testing
+from tilelang import language as T
+import torch
+
+
+def matmul(
+    M,
+    N,
+    K,
+    block_M,
+    block_N,
+    block_K,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+    accum_dtype,
+    num_stages,
+    threads,
+):
+    A_shape = (K, M) if trans_A else (M, K)
+    B_shape = (N, K) if trans_B else (K, N)
+    A_shared_shape = (block_K, block_M) if trans_A else (block_M, block_K)
+    B_shared_shape = (block_N, block_K) if trans_B else (block_K, block_N)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor(A_shape, in_dtype),
+        B: T.Tensor(B_shape, in_dtype),
+        C: T.Tensor((M, N), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads) as (bx, by):
+            A_shared = T.alloc_shared(A_shared_shape, in_dtype, scope="shared.dyn")
+            B_shared = T.alloc_shared(B_shared_shape, in_dtype, scope="shared.dyn")
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+            T.clear(C_local)
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
+                if trans_A:
+                    T.copy(A[k * block_K, by * block_M], A_shared)
+                else:
+                    T.copy(A[by * block_M, k * block_K], A_shared)
+                if trans_B:
+                    T.copy(B[bx * block_N, k * block_K], B_shared)
+                else:
+                    T.copy(B[k * block_K, bx * block_N], B_shared)
+                T.gemm(A_shared, B_shared, C_local, trans_A, trans_B)
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def _compile_and_check(
+    program,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+):
+    kernel = tilelang.compile(
+        program,
+        out_idx=[2],
+        pass_configs={
+            tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+            tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+            # tilelang.PassConfigKey.TIR_USE_ASYNC_COPY: False,
+        },
+    )
+
+    print(kernel.get_kernel_source())
+
+    profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
+
+    def ref_program(A, B):
+        if trans_A:
+            A = A.T
+        if trans_B:
+            B = B.T
+        if in_dtype == T.float32:
+            A = (A.view(torch.int32) - 0x1000).view(torch.float32)
+            B = (B.view(torch.int32) - 0x1000).view(torch.float32)
+        C = torch.matmul(A.to(torch.float), B.to(torch.float))
+        C = C.to(torch.__getattribute__(out_dtype))
+        return C
+
+    profiler.assert_allclose(ref_program, atol=1e-2, rtol=1e-2)
+    print("assert_allclose")
+
+
+def run_gemm(
+    M,
+    N,
+    K,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+    dtypeAccum,
+    block_M,
+    block_N,
+    block_K,
+    num_stages=2,
+    num_threads=128,
+):
+    if block_N >= 256 or block_M >= 256 or block_K >= 256:
+        num_stages = 0
+    program = matmul(
+        M,
+        N,
+        K,
+        block_M,
+        block_N,
+        block_K,
+        trans_A,
+        trans_B,
+        in_dtype,
+        out_dtype,
+        dtypeAccum,
+        num_stages,
+        num_threads,
+    )
+
+    _compile_and_check(program, trans_A, trans_B, in_dtype, out_dtype)
+
+
+def matmul_rs(
+    M,
+    N,
+    K,
+    block_M,
+    block_N,
+    block_K,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+    accum_dtype,
+    num_stages,
+    threads,
+):
+    A_shape = (K, M) if trans_A else (M, K)
+    B_shape = (N, K) if trans_B else (K, N)
+    A_shared_shape = (block_K, block_M) if trans_A else (block_M, block_K)
+    B_shared_shape = (block_N, block_K) if trans_B else (block_K, block_N)
+    A_frag_shape = A_shared_shape
+
+    @T.prim_func
+    def main(
+        A: T.Tensor(A_shape, in_dtype),
+        B: T.Tensor(B_shape, in_dtype),
+        C: T.Tensor((M, N), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads) as (bx, by):
+            A_shared = T.alloc_shared(A_shared_shape, in_dtype, scope="shared.dyn")
+            B_shared = T.alloc_shared(B_shared_shape, in_dtype, scope="shared.dyn")
+            A_frag = T.alloc_fragment(A_frag_shape, in_dtype)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+            T.clear(C_local)
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
+                if trans_A:
+                    T.copy(A[k * block_K, by * block_M], A_shared)
+                else:
+                    T.copy(A[by * block_M, k * block_K], A_shared)
+                if trans_B:
+                    T.copy(B[bx * block_N, k * block_K], B_shared)
+                else:
+                    T.copy(B[k * block_K, bx * block_N], B_shared)
+                T.copy(A_shared, A_frag)
+                T.gemm(A_frag, B_shared, C_local, trans_A, trans_B)
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def run_gemm_rs(
+    M,
+    N,
+    K,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+    dtypeAccum,
+    block_M,
+    block_N,
+    block_K,
+    num_stages=2,
+    num_threads=128,
+):
+    if block_N >= 256 or block_M >= 256 or block_K >= 256:
+        num_stages = 0
+    program = matmul_rs(
+        M,
+        N,
+        K,
+        block_M,
+        block_N,
+        block_K,
+        trans_A,
+        trans_B,
+        in_dtype,
+        out_dtype,
+        dtypeAccum,
+        num_stages,
+        num_threads,
+    )
+    _compile_and_check(program, trans_A, trans_B, in_dtype, out_dtype)
+
+
+def matmul_sr(
+    M,
+    N,
+    K,
+    block_M,
+    block_N,
+    block_K,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+    accum_dtype,
+    num_stages,
+    threads,
+):
+    A_shape = (K, M) if trans_A else (M, K)
+    B_shape = (N, K) if trans_B else (K, N)
+    A_shared_shape = (block_K, block_M) if trans_A else (block_M, block_K)
+    B_shared_shape = (block_N, block_K) if trans_B else (block_K, block_N)
+    B_frag_shape = B_shared_shape
+
+    @T.prim_func
+    def main(
+        A: T.Tensor(A_shape, in_dtype),
+        B: T.Tensor(B_shape, in_dtype),
+        C: T.Tensor((M, N), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads) as (bx, by):
+            A_shared = T.alloc_shared(A_shared_shape, in_dtype, scope="shared.dyn")
+            B_shared = T.alloc_shared(B_shared_shape, in_dtype, scope="shared.dyn")
+            B_frag = T.alloc_fragment(B_frag_shape, in_dtype)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+            T.clear(C_local)
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
+                if trans_A:
+                    T.copy(A[k * block_K, by * block_M], A_shared)
+                else:
+                    T.copy(A[by * block_M, k * block_K], A_shared)
+                if trans_B:
+                    T.copy(B[bx * block_N, k * block_K], B_shared)
+                else:
+                    T.copy(B[k * block_K, bx * block_N], B_shared)
+                T.copy(B_shared, B_frag)
+                T.gemm(A_shared, B_frag, C_local, trans_A, trans_B)
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def run_gemm_sr(
+    M,
+    N,
+    K,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+    dtypeAccum,
+    block_M,
+    block_N,
+    block_K,
+    num_stages=2,
+    num_threads=128,
+):
+    if block_N >= 256 or block_M >= 256 or block_K >= 256:
+        num_stages = 0
+    program = matmul_sr(
+        M,
+        N,
+        K,
+        block_M,
+        block_N,
+        block_K,
+        trans_A,
+        trans_B,
+        in_dtype,
+        out_dtype,
+        dtypeAccum,
+        num_stages,
+        num_threads,
+    )
+
+    _compile_and_check(program, trans_A, trans_B, in_dtype, out_dtype)
+
+
+def matmul_rr(
+    M,
+    N,
+    K,
+    block_M,
+    block_N,
+    block_K,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+    accum_dtype,
+    num_stages,
+    threads,
+):
+    A_shape = (K, M) if trans_A else (M, K)
+    B_shape = (N, K) if trans_B else (K, N)
+    A_shared_shape = (block_K, block_M) if trans_A else (block_M, block_K)
+    B_shared_shape = (block_N, block_K) if trans_B else (block_K, block_N)
+    A_frag_shape = A_shared_shape
+    B_frag_shape = B_shared_shape
+
+    @T.prim_func
+    def main(
+        A: T.Tensor(A_shape, in_dtype),
+        B: T.Tensor(B_shape, in_dtype),
+        C: T.Tensor((M, N), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads) as (bx, by):
+            A_shared = T.alloc_shared(A_shared_shape, in_dtype, scope="shared.dyn")
+            B_shared = T.alloc_shared(B_shared_shape, in_dtype, scope="shared.dyn")
+            A_frag = T.alloc_fragment(A_frag_shape, in_dtype)
+            B_frag = T.alloc_fragment(B_frag_shape, in_dtype)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+            T.clear(C_local)
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
+                if trans_A:
+                    T.copy(A[k * block_K, by * block_M], A_shared)
+                else:
+                    T.copy(A[by * block_M, k * block_K], A_shared)
+                if trans_B:
+                    T.copy(B[bx * block_N, k * block_K], B_shared)
+                else:
+                    T.copy(B[k * block_K, bx * block_N], B_shared)
+                T.copy(A_shared, A_frag)
+                T.copy(B_shared, B_frag)
+                T.gemm(A_frag, B_frag, C_local, trans_A, trans_B)
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def run_gemm_rr(
+    M,
+    N,
+    K,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+    dtypeAccum,
+    block_M,
+    block_N,
+    block_K,
+    num_stages=2,
+    num_threads=128,
+):
+    if block_N >= 256 or block_M >= 256 or block_K >= 256:
+        num_stages = 0
+    program = matmul_rr(
+        M,
+        N,
+        K,
+        block_M,
+        block_N,
+        block_K,
+        trans_A,
+        trans_B,
+        in_dtype,
+        out_dtype,
+        dtypeAccum,
+        num_stages,
+        num_threads,
+    )
+
+    _compile_and_check(program, trans_A, trans_B, in_dtype, out_dtype)
+
+
+M_VALUES = [64, 128, 256]
+N_VALUES = [16, 32, 64, 128, 256, 512]
+K_VALUES = [16, 32, 64, 128]
+K_VALUES_8Bit = [32, 64, 128]
+NUM_THREADS_VALUES = [128, 256]
+
+
+def _generate_dtype_cases(k_values, num_threads):
+    """Generate dtype test cases for given K values and num_threads."""
+    return (
+        [
+            pytest.param(
+                k,
+                T.float16,
+                T.float16,
+                T.float16,
+                num_threads,
+                id=f"K{k}-float16-float16-float16-threads{num_threads}",
+            )
+            for k in k_values
+        ]
+        + [
+            pytest.param(
+                k,
+                T.int8,
+                T.int32,
+                T.int32,
+                num_threads,
+                id=f"K{k}-int8-int32-int32-threads{num_threads}",
+            )
+            for k in K_VALUES_8Bit
+        ]
+        + [
+            pytest.param(
+                k,
+                T.float8_e5m2,
+                T.float32,
+                T.float32,
+                num_threads,
+                id=f"K{k}-float8_e5m2-float32-float32-threads{num_threads}",
+            )
+            for k in K_VALUES_8Bit
+        ]
+        + [
+            pytest.param(
+                k,
+                T.float8_e4m3fn,
+                T.float32,
+                T.float32,
+                num_threads,
+                id=f"K{k}-float8_e4m3fn-float32-float32-threads{num_threads}",
+            )
+            for k in K_VALUES_8Bit
+        ]
+    )
+
+
+# num_threads=128 can work with any N
+FALSE_TRUE_CASES_128 = _generate_dtype_cases(K_VALUES, 128)
+# num_threads=256 requires N >= 32
+FALSE_TRUE_CASES_256 = _generate_dtype_cases(K_VALUES, 256)
+FALSE_TRUE_CASES = FALSE_TRUE_CASES_128 + FALSE_TRUE_CASES_256
+
+
+def _ensure_torch_dtypes(*dtype_names):
+    import torch
+
+    for name in set(dtype_names):
+        if not hasattr(torch, name):
+            pytest.skip(f"Torch does not expose dtype {name}")
+
+
+def _skip_if_threads_exceed_n(num_threads, n):
+    """Skip test if num_threads=256 and N < 32."""
+    if num_threads == 256 and n < 32:
+        pytest.skip(f"num_threads=256 requires N >= 32, but N={n}")
+
+
+def run_gemm_rs_false_true(m, n, k, in_dtype, out_dtype, accum_dtype, num_threads=128):
+    run_gemm_rs(m, n, k * 3, False, True, in_dtype, out_dtype, accum_dtype, m, n, k, num_threads=num_threads)
+
+
+def run_gemm_rs_false_false(m, n, k, num_threads=128):
+    run_gemm_rs(m, n, k * 3, False, False, T.float16, T.float16, T.float16, m, n, k, num_threads=num_threads)
+
+
+def run_gemm_rs_true_false(m, n, k, num_threads=128):
+    run_gemm_rs(m, n, k * 3, True, False, T.float16, T.float16, T.float16, m, n, k, num_threads=num_threads)
+
+
+def run_gemm_rs_true_true(m, n, k, num_threads=128):
+    run_gemm_rs(m, n, k * 3, True, True, T.float16, T.float16, T.float16, m, n, k, num_threads=num_threads)
+
+
+def run_gemm_sr_false_true(m, n, k, in_dtype, out_dtype, accum_dtype, num_threads=128):
+    run_gemm_sr(m, n, k * 3, False, True, in_dtype, out_dtype, accum_dtype, m, n, k, num_threads=num_threads)
+
+
+def run_gemm_sr_false_false(m, n, k, num_threads=128):
+    run_gemm_sr(m, n, k * 3, False, False, T.float16, T.float16, T.float16, m, n, k, num_threads=num_threads)
+
+
+def run_gemm_sr_true_false(m, n, k, num_threads=128):
+    run_gemm_sr(m, n, k * 3, True, False, T.float16, T.float16, T.float16, m, n, k, num_threads=num_threads)
+
+
+def run_gemm_sr_true_true(m, n, k, num_threads=128):
+    run_gemm_sr(m, n, k * 3, True, True, T.float16, T.float16, T.float16, m, n, k, num_threads=num_threads)
+
+
+def run_gemm_rr_false_true(m, n, k, in_dtype, out_dtype, accum_dtype, num_threads=128):
+    run_gemm_rr(m, n, k * 3, False, True, in_dtype, out_dtype, accum_dtype, m, n, k, num_threads=num_threads)
+
+
+def run_gemm_rr_false_false(m, n, k, num_threads=128):
+    run_gemm_rr(m, n, k * 3, False, False, T.float16, T.float16, T.float16, m, n, k, num_threads=num_threads)
+
+
+def run_gemm_rr_true_false(m, n, k, num_threads=128):
+    run_gemm_rr(m, n, k * 3, True, False, T.float16, T.float16, T.float16, m, n, k, num_threads=num_threads)
+
+
+def run_gemm_rr_true_true(m, n, k, num_threads=128):
+    run_gemm_rr(m, n, k * 3, True, True, T.float16, T.float16, T.float16, m, n, k, num_threads=num_threads)
+
+
+TRANS_CASES = [
+    pytest.param(False, False, id="nn"),
+    pytest.param(False, True, id="nt"),
+    pytest.param(True, False, id="tn"),
+    pytest.param(True, True, id="tt"),
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _setup_tilelang_environment():
+    tilelang.disable_cache()
+    tilelang.testing.set_random_seed(42)
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k,in_dtype,out_dtype,accum_dtype,num_threads", FALSE_TRUE_CASES)
+def test_gemm_false_true(m, n, k, in_dtype, out_dtype, accum_dtype, num_threads):
+    import torch
+
+    _skip_if_threads_exceed_n(num_threads, n)
+
+    required_torch_attrs = {
+        in_dtype,
+        out_dtype,
+        accum_dtype,
+    }
+    for attr in required_torch_attrs:
+        if not hasattr(torch, attr):
+            pytest.skip(f"Torch does not expose dtype {attr}")
+    run_gemm(
+        m,
+        n,
+        k * 3,
+        False,
+        True,
+        in_dtype,
+        out_dtype,
+        accum_dtype,
+        m,
+        n,
+        k,
+        num_threads=num_threads,
+    )
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k", K_VALUES, ids=lambda v: f"K{v}")
+@pytest.mark.parametrize("num_threads", NUM_THREADS_VALUES, ids=lambda v: f"threads{v}")
+def test_gemm_false_false(m, n, k, num_threads):
+    _skip_if_threads_exceed_n(num_threads, n)
+    run_gemm(
+        m,
+        n,
+        k * 3,
+        False,
+        False,
+        T.float16,
+        T.float16,
+        T.float16,
+        m,
+        n,
+        k,
+        num_threads=num_threads,
+    )
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k", K_VALUES, ids=lambda v: f"K{v}")
+@pytest.mark.parametrize("num_threads", NUM_THREADS_VALUES, ids=lambda v: f"threads{v}")
+def test_gemm_true_false(m, n, k, num_threads):
+    _skip_if_threads_exceed_n(num_threads, n)
+    run_gemm(
+        m,
+        n,
+        k * 3,
+        True,
+        False,
+        T.float16,
+        T.float16,
+        T.float16,
+        m,
+        n,
+        k,
+        num_threads=num_threads,
+    )
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k", K_VALUES, ids=lambda v: f"K{v}")
+@pytest.mark.parametrize("num_threads", NUM_THREADS_VALUES, ids=lambda v: f"threads{v}")
+def test_gemm_true_true(m, n, k, num_threads):
+    _skip_if_threads_exceed_n(num_threads, n)
+    run_gemm(
+        m,
+        n,
+        k * 3,
+        True,
+        True,
+        T.float16,
+        T.float16,
+        T.float16,
+        m,
+        n,
+        k,
+        num_threads=num_threads,
+    )
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k,in_dtype,out_dtype,accum_dtype,num_threads", FALSE_TRUE_CASES)
+def test_gemm_rs_false_true(m, n, k, in_dtype, out_dtype, accum_dtype, num_threads):
+    _skip_if_threads_exceed_n(num_threads, n)
+    _ensure_torch_dtypes(in_dtype, out_dtype, accum_dtype)
+    run_gemm_rs_false_true(m, n, k, in_dtype, out_dtype, accum_dtype, num_threads)
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k", K_VALUES, ids=lambda v: f"K{v}")
+@pytest.mark.parametrize("num_threads", NUM_THREADS_VALUES, ids=lambda v: f"threads{v}")
+def test_gemm_rs_false_false(m, n, k, num_threads):
+    _skip_if_threads_exceed_n(num_threads, n)
+    _ensure_torch_dtypes(T.float16)
+    run_gemm_rs_false_false(m, n, k, num_threads)
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k", K_VALUES, ids=lambda v: f"K{v}")
+@pytest.mark.parametrize("num_threads", NUM_THREADS_VALUES, ids=lambda v: f"threads{v}")
+def test_gemm_rs_true_false(m, n, k, num_threads):
+    _skip_if_threads_exceed_n(num_threads, n)
+    _ensure_torch_dtypes(T.float16)
+    run_gemm_rs_true_false(m, n, k, num_threads)
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k", K_VALUES, ids=lambda v: f"K{v}")
+@pytest.mark.parametrize("num_threads", NUM_THREADS_VALUES, ids=lambda v: f"threads{v}")
+def test_gemm_rs_true_true(m, n, k, num_threads):
+    _skip_if_threads_exceed_n(num_threads, n)
+    _ensure_torch_dtypes(T.float16)
+    run_gemm_rs_true_true(m, n, k, num_threads)
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k,in_dtype,out_dtype,accum_dtype,num_threads", FALSE_TRUE_CASES)
+def test_gemm_sr_false_true(m, n, k, in_dtype, out_dtype, accum_dtype, num_threads):
+    _skip_if_threads_exceed_n(num_threads, n)
+    _ensure_torch_dtypes(in_dtype, out_dtype, accum_dtype)
+    run_gemm_sr_false_true(m, n, k, in_dtype, out_dtype, accum_dtype, num_threads)
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k", K_VALUES, ids=lambda v: f"K{v}")
+@pytest.mark.parametrize("num_threads", NUM_THREADS_VALUES, ids=lambda v: f"threads{v}")
+def test_gemm_sr_false_false(m, n, k, num_threads):
+    _skip_if_threads_exceed_n(num_threads, n)
+    _ensure_torch_dtypes(T.float16)
+    run_gemm_sr_false_false(m, n, k, num_threads)
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k", K_VALUES, ids=lambda v: f"K{v}")
+@pytest.mark.parametrize("num_threads", NUM_THREADS_VALUES, ids=lambda v: f"threads{v}")
+def test_gemm_sr_true_false(m, n, k, num_threads):
+    _skip_if_threads_exceed_n(num_threads, n)
+    _ensure_torch_dtypes(T.float16)
+    run_gemm_sr_true_false(m, n, k, num_threads)
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k", K_VALUES, ids=lambda v: f"K{v}")
+@pytest.mark.parametrize("num_threads", NUM_THREADS_VALUES, ids=lambda v: f"threads{v}")
+def test_gemm_sr_true_true(m, n, k, num_threads):
+    _skip_if_threads_exceed_n(num_threads, n)
+    _ensure_torch_dtypes(T.float16)
+    run_gemm_sr_true_true(m, n, k, num_threads)
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k,in_dtype,out_dtype,accum_dtype,num_threads", FALSE_TRUE_CASES)
+def test_gemm_rr_false_true(m, n, k, in_dtype, out_dtype, accum_dtype, num_threads):
+    _skip_if_threads_exceed_n(num_threads, n)
+    _ensure_torch_dtypes(in_dtype, out_dtype, accum_dtype)
+    run_gemm_rr_false_true(m, n, k, in_dtype, out_dtype, accum_dtype, num_threads)
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k", K_VALUES, ids=lambda v: f"K{v}")
+@pytest.mark.parametrize("num_threads", NUM_THREADS_VALUES, ids=lambda v: f"threads{v}")
+def test_gemm_rr_false_false(m, n, k, num_threads):
+    _skip_if_threads_exceed_n(num_threads, n)
+    _ensure_torch_dtypes(T.float16)
+    run_gemm_rr_false_false(m, n, k, num_threads)
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k", K_VALUES, ids=lambda v: f"K{v}")
+@pytest.mark.parametrize("num_threads", NUM_THREADS_VALUES, ids=lambda v: f"threads{v}")
+def test_gemm_rr_true_false(m, n, k, num_threads):
+    _skip_if_threads_exceed_n(num_threads, n)
+    _ensure_torch_dtypes(T.float16)
+    run_gemm_rr_true_false(m, n, k, num_threads)
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k", K_VALUES, ids=lambda v: f"K{v}")
+@pytest.mark.parametrize("num_threads", NUM_THREADS_VALUES, ids=lambda v: f"threads{v}")
+def test_gemm_rr_true_true(m, n, k, num_threads):
+    _skip_if_threads_exceed_n(num_threads, n)
+    _ensure_torch_dtypes(T.float16)
+    run_gemm_rr_true_true(m, n, k, num_threads)
+
+
+if __name__ == "__main__":
+    run_gemm(
+        M=64,
+        N=192,
+        K=64,
+        trans_A=False,
+        trans_B=False,
+        in_dtype=T.bfloat16,
+        out_dtype=T.bfloat16,
+        dtypeAccum=T.float32,
+        block_M=64,
+        block_N=192,
+        block_K=64,
+        num_stages=0,
+        num_threads=256,
+    )
+
+    # # Test Pass
+    # for m in [64, 128, 256]:
+    #     for n in [16, 32, 64, 128]:
+    #         for k in [16, 32, 64, 128]:
+    #             print(f"======================= Test {m} {n} {k} False True =============================")
+    #             run_gemm(m, n, k * 3, False, True, T.float16, T.float16, T.float16, m, n, k, 2, 128)
+    #             print(f"Test {m} {n} {k} Pass")
+
+    # # Test Pass
+    # for m in [64, 128, 256]:
+    #     for n in [16, 32, 64, 128]:
+    #         for k in [16, 32, 64, 128]:
+    #             print(f"======================= Test {m} {n} {k} False False =============================")
+    #             run_gemm(m, n, k * 3, False, False, T.float16, T.float16, T.float16, m, n, k, 2, 128)
+    #             print(f"Test {m} {n} {k} Pass")
+
+    # # Test Pass
+    # for m in [64, 128, 256]:
+    #     for n in [16, 32, 64, 128]:
+    #         for k in [16, 32, 64, 128]:
+    #             print(f"======================= Test {m} {n} {k} True False =============================")
+    #             run_gemm(m, n, k * 3, True, False, T.float16, T.float16, T.float16, m, n, k, 2, 128)
+    #             print(f"Test {m}, {n} {k} Pass")
+    #         print(f"Test {n} Pass")
+
+    # # Test Pass
+    # for m in [64, 128, 256]:
+    #     for n in [16, 32, 64, 128]:
+    #         for k in [16, 32, 64, 128]:
+    #             print(f"======================= Test {m} {n} {k} True True =============================")
+    #             run_gemm(m, n, k * 3, True, True, T.float16, T.float16, T.float16, m, n, k, 2, 128)
+    #             print(f"Test {m}, {n} {k} Pass")
+    #         print(f"Test {n} Pass")
+
+    # Test Pass
+    # for m in [64, 128, 256]:
+    #     for n in [16, 32, 64, 128]:
+    #         for k in [16, 32, 64, 128]:
+    #             print(f"======================= Test {m} {n} {k} False True =============================")
+    #             run_gemm_rs(m, n, k * 3, False, True, T.float16, T.float16, T.float16, m, n, k, 2, 128)
+    #             print(f"Test {m} {n} {k} Pass")
+
+    # for n in [16, 32, 64, 128]:
+    #     for k in [16, 32, 64, 128]:
+    #         run_gemm_rs(64, n, k, False, False, T.float16, T.float16, T.float16, 64, n, k, 0, 256)
+    #         print(f"Test {64} {n} {k} Pass")
+
+    # for n in [16, 32, 64, 128]:
+    #     for k in [16, 32, 64, 128]:
+    #         run_gemm(64, n, k, False, False, T.float16, T.float16, T.float16, 64, n, k, 0, 256)
+    #         print(f"Test {64} {n} {k} Pass")

--- a/maint/gemm/correctness_evaluation_sm70.py
+++ b/maint/gemm/correctness_evaluation_sm70.py
@@ -1,0 +1,348 @@
+# pytest maint/gemm/correctness_evaluation_sm70.py -n 32
+import pytest
+from tilelang import tvm as tvm
+import tilelang.testing
+from tilelang import language as T
+
+
+def matmul(
+    M,
+    N,
+    K,
+    block_M,
+    block_N,
+    block_K,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+    accum_dtype,
+    num_stages,
+    threads,
+):
+    A_shape = (K, M) if trans_A else (M, K)
+    B_shape = (N, K) if trans_B else (K, N)
+    A_shared_shape = (block_K, block_M) if trans_A else (block_M, block_K)
+    B_shared_shape = (block_N, block_K) if trans_B else (block_K, block_N)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor(A_shape, in_dtype),
+        B: T.Tensor(B_shape, in_dtype),
+        C: T.Tensor((M, N), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads) as (bx, by):
+            A_shared = T.alloc_shared(A_shared_shape, in_dtype, scope="shared.dyn")
+            B_shared = T.alloc_shared(B_shared_shape, in_dtype, scope="shared.dyn")
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+            T.clear(C_local)
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
+                if trans_A:
+                    T.copy(A[k * block_K, by * block_M], A_shared)
+                else:
+                    T.copy(A[by * block_M, k * block_K], A_shared)
+                if trans_B:
+                    T.copy(B[bx * block_N, k * block_K], B_shared)
+                else:
+                    T.copy(B[k * block_K, bx * block_N], B_shared)
+                T.gemm(A_shared, B_shared, C_local, trans_A, trans_B)
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def _compile_and_check(
+    program,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+):
+    kernel = tilelang.compile(
+        program,
+        out_idx=[2],
+        pass_configs={
+            tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+            tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+            # tilelang.PassConfigKey.TIR_USE_ASYNC_COPY: False,
+        },
+    )
+
+    print(kernel.get_kernel_source())
+
+    profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
+
+    def ref_program(A, B):
+        import torch
+
+        if trans_A:
+            A = A.T
+        if trans_B:
+            B = B.T
+        if in_dtype == T.float32:
+            A = (A.view(torch.int32) - 0x1000).view(torch.float32)
+            B = (B.view(torch.int32) - 0x1000).view(torch.float32)
+        C = torch.matmul(A.to(torch.float), B.to(torch.float))
+        C = C.to(torch.__getattribute__(out_dtype))
+        return C
+
+    profiler.assert_allclose(ref_program, atol=1e-2, rtol=1e-2)
+    print("assert_allclose")
+
+
+def run_gemm(
+    M,
+    N,
+    K,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+    dtypeAccum,
+    block_M,
+    block_N,
+    block_K,
+    num_stages=3,
+    num_threads=128,
+):
+    program = matmul(
+        M,
+        N,
+        K,
+        block_M,
+        block_N,
+        block_K,
+        trans_A,
+        trans_B,
+        in_dtype,
+        out_dtype,
+        dtypeAccum,
+        num_stages,
+        num_threads,
+    )
+
+    _compile_and_check(program, trans_A, trans_B, in_dtype, out_dtype)
+
+
+def matmul_rs(
+    M,
+    N,
+    K,
+    block_M,
+    block_N,
+    block_K,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+    accum_dtype,
+    num_stages,
+    threads,
+):
+    A_shape = (K, M) if trans_A else (M, K)
+    B_shape = (N, K) if trans_B else (K, N)
+    A_shared_shape = (block_K, block_M) if trans_A else (block_M, block_K)
+    B_shared_shape = (block_N, block_K) if trans_B else (block_K, block_N)
+    A_frag_shape = A_shared_shape
+
+    @T.prim_func
+    def main(
+        A: T.Tensor(A_shape, in_dtype),
+        B: T.Tensor(B_shape, in_dtype),
+        C: T.Tensor((M, N), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads) as (bx, by):
+            A_shared = T.alloc_shared(A_shared_shape, in_dtype, scope="shared.dyn")
+            B_shared = T.alloc_shared(B_shared_shape, in_dtype, scope="shared.dyn")
+            A_frag = T.alloc_fragment(A_frag_shape, in_dtype)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+            T.clear(C_local)
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
+                if trans_A:
+                    T.copy(A[k * block_K, by * block_M], A_shared)
+                else:
+                    T.copy(A[by * block_M, k * block_K], A_shared)
+                if trans_B:
+                    T.copy(B[bx * block_N, k * block_K], B_shared)
+                else:
+                    T.copy(B[k * block_K, bx * block_N], B_shared)
+                T.copy(A_shared, A_frag)
+                T.gemm(A_frag, B_shared, C_local, trans_A, trans_B)
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def run_gemm_rs(
+    M,
+    N,
+    K,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+    dtypeAccum,
+    block_M,
+    block_N,
+    block_K,
+    num_stages=3,
+    num_threads=128,
+):
+    program = matmul_rs(
+        M,
+        N,
+        K,
+        block_M,
+        block_N,
+        block_K,
+        trans_A,
+        trans_B,
+        in_dtype,
+        out_dtype,
+        dtypeAccum,
+        num_stages,
+        num_threads,
+    )
+    _compile_and_check(program, trans_A, trans_B, in_dtype, out_dtype)
+
+
+M_VALUES = [64, 128]
+N_VALUES = [32, 64, 128]
+K_VALUES = [16, 32, 64]
+FALSE_TRUE_CASES = [
+    pytest.param(
+        k,
+        T.float16,
+        T.float16,
+        T.float16,
+        id=f"K{k}-float16-float16-float16",
+    )
+    for k in K_VALUES
+] + [
+    pytest.param(
+        k,
+        T.float16,
+        T.float16,
+        T.float32,
+        id=f"K{k}-float16-float16-float32",
+    )
+    for k in K_VALUES
+]
+
+
+def _ensure_torch_dtypes(*dtype_names):
+    import torch
+
+    for name in set(dtype_names):
+        if not hasattr(torch, name):
+            pytest.skip(f"Torch does not expose dtype {name}")
+
+
+def run_gemm_rs_false_true(m, n, k, in_dtype, out_dtype, accum_dtype):
+    run_gemm_rs(m, n, k * 3, False, True, in_dtype, out_dtype, accum_dtype, m, n, k, 2, 128)
+
+
+def run_gemm_rs_false_false(m, n, k):
+    run_gemm_rs(m, n, k * 3, False, False, T.float16, T.float16, T.float16, m, n, k, 2, 128)
+
+
+TRANS_CASES = [
+    pytest.param(False, False, id="nn"),
+    pytest.param(False, True, id="nt"),
+    pytest.param(True, False, id="tn"),
+    pytest.param(True, True, id="tt"),
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _setup_tilelang_environment():
+    tilelang.disable_cache()
+    tilelang.testing.set_random_seed(42)
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k,in_dtype,out_dtype,accum_dtype", FALSE_TRUE_CASES)
+def test_gemm_false_true(m, n, k, in_dtype, out_dtype, accum_dtype):
+    import torch
+
+    required_torch_attrs = {
+        in_dtype,
+        out_dtype,
+        accum_dtype,
+    }
+    for attr in required_torch_attrs:
+        if not hasattr(torch, attr):
+            pytest.skip(f"Torch does not expose dtype {attr}")
+    run_gemm(
+        m,
+        n,
+        k * 3,
+        False,
+        True,
+        in_dtype,
+        out_dtype,
+        accum_dtype,
+        m,
+        n,
+        k,
+        2,
+        128,
+    )
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k", K_VALUES, ids=lambda v: f"K{v}")
+def test_gemm_false_false(m, n, k):
+    run_gemm(
+        m,
+        n,
+        k * 3,
+        False,
+        False,
+        T.float16,
+        T.float16,
+        T.float16,
+        m,
+        n,
+        k,
+        2,
+        128,
+    )
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k,in_dtype,out_dtype,accum_dtype", FALSE_TRUE_CASES)
+def test_gemm_rs_false_true(m, n, k, in_dtype, out_dtype, accum_dtype):
+    _ensure_torch_dtypes(in_dtype, out_dtype, accum_dtype)
+    run_gemm_rs_false_true(m, n, k, in_dtype, out_dtype, accum_dtype)
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k", K_VALUES, ids=lambda v: f"K{v}")
+def test_gemm_rs_false_false(m, n, k):
+    _ensure_torch_dtypes(T.float16)
+    run_gemm_rs_false_false(m, n, k)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()
+
+    # # Test Pass
+    # for m in [64, 128]:
+    #     for n in [16, 32, 64, 128]:
+    #         for k in [16, 32, 64]:
+    #             print(f"======================= Test {m} {n} {k} False True =============================")
+    #             run_gemm(m, n, k * 3, False, True, T.float16, T.float16, T.float16, m, n, k, 2, 128)
+    #             print(f"Test {m} {n} {k} Pass")
+
+    # # Test Pass
+    # for m in [64, 128]:
+    #     for n in [16, 32, 64, 128]:
+    #         for k in [16, 32, 64]:
+    #             print(f"======================= Test {m} {n} {k} False False =============================")
+    #             run_gemm(m, n, k * 3, False, False, T.float16, T.float16, T.float16, m, n, k, 2, 128)
+    #             print(f"Test {m} {n} {k} Pass")

--- a/maint/gemm/correctness_evaluation_tcgen05.py
+++ b/maint/gemm/correctness_evaluation_tcgen05.py
@@ -1,0 +1,231 @@
+# pytest correctness_evaluation.py -n 32
+import pytest
+from tilelang import tvm as tvm
+import tilelang.testing
+import tilelang.language as T
+
+
+def matmul(
+    M,
+    N,
+    K,
+    block_M,
+    block_N,
+    block_K,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+    accum_dtype,
+    num_stages,
+    threads,
+):
+    A_shape = (K, M) if trans_A else (M, K)
+    B_shape = (N, K) if trans_B else (K, N)
+    A_shared_shape = (block_K, block_M) if trans_A else (block_M, block_K)
+    B_shared_shape = (block_N, block_K) if trans_B else (block_K, block_N)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor(A_shape, in_dtype),
+        B: T.Tensor(B_shape, in_dtype),
+        C: T.Tensor((M, N), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads) as (bx, by):
+            A_shared = T.alloc_shared(A_shared_shape, in_dtype)
+            B_shared = T.alloc_shared(B_shared_shape, in_dtype)
+            C_tmem = T.alloc_tmem([block_M, block_N], accum_dtype)
+            mbar = T.alloc_barrier(1)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+            C_shared = T.alloc_shared((block_M, block_N), out_dtype)
+
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
+                T.copy(A[by * block_M, k * block_K], A_shared)
+                T.copy(B[bx * block_N, k * block_K], B_shared)
+                T.tcgen05_gemm(A_shared, B_shared, C_tmem, trans_A, trans_B, mbar=mbar, clear_accum=k == 0)
+                T.mbarrier_wait_parity(mbar, k % 2)
+
+            T.copy(C_tmem, C_local)
+            T.copy(C_local, C_shared)
+
+            T.copy(C_shared, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def _compile_and_check(
+    program,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+):
+    kernel = tilelang.compile(
+        program,
+        out_idx=[2],
+        pass_configs={
+            tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+            tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        },
+    )
+
+    print(kernel.get_kernel_source())
+
+    profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
+
+    def ref_program(A, B):
+        import torch
+
+        if trans_A:
+            A = A.T
+        if trans_B:
+            B = B.T
+        if in_dtype == T.float32:
+            A = (A.view(torch.int32) - 0x1000).view(torch.float32)
+            B = (B.view(torch.int32) - 0x1000).view(torch.float32)
+        C = torch.matmul(A.to(torch.float), B.to(torch.float))
+        C = C.to(torch.__getattribute__(out_dtype))
+        return C
+
+    profiler.assert_allclose(ref_program, atol=1e-2, rtol=1e-2)
+    print("assert_allclose")
+
+
+def run_gemm(
+    M,
+    N,
+    K,
+    trans_A,
+    trans_B,
+    in_dtype,
+    out_dtype,
+    dtypeAccum,
+    block_M,
+    block_N,
+    block_K,
+    num_stages=2,
+    num_threads=128,
+):
+    if block_N >= 256 or block_M >= 256 or block_K >= 256:
+        num_stages = 0
+    program = matmul(
+        M,
+        N,
+        K,
+        block_M,
+        block_N,
+        block_K,
+        trans_A,
+        trans_B,
+        in_dtype,
+        out_dtype,
+        dtypeAccum,
+        num_stages,
+        num_threads,
+    )
+
+    _compile_and_check(program, trans_A, trans_B, in_dtype, out_dtype)
+
+
+M_VALUES = [32, 64, 128, 256]
+N_VALUES = [64, 128, 256, 512]
+K_VALUES = [16, 32, 64, 128]
+K_VALUES_8Bit = [32, 64, 128]
+FALSE_TRUE_CASES = (
+    [
+        pytest.param(
+            k,
+            T.float16,
+            T.float32,
+            T.float32,
+            id=f"K{k}-float16-float-float",
+        )
+        for k in K_VALUES
+    ]
+    + [
+        pytest.param(
+            k,
+            T.float8_e5m2,
+            T.float32,
+            T.float32,
+            id="K32-float8_e5m2-float32-float32",
+        )
+        for k in K_VALUES_8Bit
+    ]
+    + [
+        pytest.param(
+            k,
+            T.int8,
+            T.int32,
+            T.int32,
+            id="K32-int8-int32-int32",
+        )
+        for k in K_VALUES_8Bit
+    ]
+)
+
+TRANS_CASES = [
+    pytest.param(False, True, id="nt"),
+]
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("k,in_dtype,out_dtype,accum_dtype", FALSE_TRUE_CASES)
+def test_gemm_false_true(m, n, k, in_dtype, out_dtype, accum_dtype):
+    import torch
+
+    required_torch_attrs = {
+        in_dtype,
+        out_dtype,
+        accum_dtype,
+    }
+    for attr in required_torch_attrs:
+        if not hasattr(torch, attr):
+            pytest.skip(f"Torch does not expose dtype {attr}")
+    run_gemm(
+        m,
+        n,
+        k * 3,
+        False,
+        True,
+        in_dtype,
+        out_dtype,
+        accum_dtype,
+        m,
+        n,
+        k,
+    )
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()
+
+    # # Test Pass
+    # for m in [32, 64, 128, 256]:
+    #     for n in [16, 32, 64, 128]:
+    #         for k in [16, 32, 64, 128]:
+    #             if m in [32, 64] and (n not in [64, 128, 256]):
+    #                 continue
+    #             print(f"======================= Test {m} {n} {k} False True =============================")
+    #             run_gemm(m, n, k * 3, False, True, T.float16, T.float, T.float, m, n, k, 2, 128)
+    #             print(f"Test {m} {n} {k} Pass")
+
+    # # Test Pass
+    # for m in [32, 64, 128, 256]:
+    #     for n in [32, 64, 128]:
+    #         for k in [16, 32, 64, 128]:
+    #             if m in [32, 64] and (n not in [64, 128, 256]):
+    #                 continue
+    #             print(f"======================= Test {m} {n} {k} False True =============================")
+    #             run_gemm(m, n, k * 3, False, True, T.float16, T.float, T.float, m, n, k, 2, 256)
+    #             print(f"Test {m} {n} {k} Pass")
+
+    # # Test Pass
+    # for m in [32, 64, 128, 256]:
+    #     for n in [16, 32, 64, 128]:
+    #         for k in [32, 64, 128]:
+    #             if m in [32, 64] and (n not in [64, 128, 256]):
+    #                 continue
+    #             print(f"======================= Test {m} {n} {k} False True =============================")
+    #             run_gemm(m, n, k * 3, False, True, T.float8_e5m2, T.float, T.float, m, n, k, 2, 128)

--- a/maint/gemm/correctness_evaluation_tcgen05_2cta.py
+++ b/maint/gemm/correctness_evaluation_tcgen05_2cta.py
@@ -1,0 +1,168 @@
+# pytest correctness_evaluation_tcgen05_2cta.py -n 32
+import pytest
+from tilelang import tvm as tvm
+import tilelang
+import tilelang.testing
+import tilelang.language as T
+
+tilelang.disable_cache()
+
+
+def matmul_2cta(
+    M,
+    N,
+    K,
+    block_M,
+    block_N,
+    block_K,
+    in_dtype,
+    out_dtype,
+    accum_dtype,
+    num_stages,
+):
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), in_dtype),
+        B: T.Tensor((K, N), in_dtype),
+        C: T.Tensor((M, N), out_dtype),
+    ):
+        with T.Kernel(T.ceildiv(M, block_M), T.ceildiv(N, block_N), threads=128, cluster_dims=2) as (bx, by):
+            A_shared = T.alloc_shared((num_stages, block_M, block_K), in_dtype)
+            B_shared = T.alloc_shared((num_stages, block_K, block_N // 2), in_dtype)  # each CTA holds half of B
+            C_tmem = T.alloc_tmem([block_M, block_N], accum_dtype)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+            C_shared = T.alloc_shared((block_M, block_N), out_dtype)
+            loaded = T.alloc_cluster_barrier([32 * 2] * num_stages)
+            consumed = T.alloc_cluster_barrier([1] * num_stages)
+            tmem_full = T.alloc_barrier([1])
+
+            tx = T.get_thread_binding()
+            cta_id = T.block_rank_in_cluster()
+            T.assume(cta_id < 2)
+
+            T.use_swizzle(16)
+
+            if tx < 32:  # warp 0: issue TMA loads
+                for k in T.serial(T.ceildiv(K, block_K)):
+                    T.mbarrier_wait_parity(consumed[k % num_stages], ((k // num_stages) & 1) ^ 1)
+                    T.tma_copy(
+                        A[bx * block_M : (bx + 1) * block_M, k * block_K : (k + 1) * block_K],
+                        A_shared[k % num_stages, :, :],
+                        barrier=loaded[k % num_stages],
+                    )
+                    T.tma_copy(
+                        B[k * block_K : (k + 1) * block_K, (by * 2 + cta_id) * (block_N // 2) : (by * 2 + cta_id + 1) * (block_N // 2)],
+                        B_shared[k % num_stages, :, :],
+                        barrier=loaded[k % num_stages],
+                    )
+                    T.mbarrier_arrive(loaded[k % num_stages], 0)  # arrive on leader CTA's barrier
+            elif cta_id == 0 and tx < 64:  # warp 1 on leader CTA: issue tcgen5 MMA
+                for k in T.serial(T.ceildiv(K, block_K)):
+                    T.mbarrier_wait_parity(loaded[k % num_stages], (k // num_stages) & 1)
+                    T.tcgen05_gemm(
+                        A_shared[k % num_stages, :, :],
+                        B_shared[k % num_stages, :, :],
+                        C_tmem,
+                        mbar=consumed[k % num_stages],
+                        clear_accum=k == 0,
+                        use_2cta=True,
+                    )
+                T.tcgen05_mma_arrive(tmem_full, arrive_2cta=True)
+
+            T.mbarrier_wait_parity(tmem_full, 0)
+            T.copy(C_tmem, C_local)
+            T.copy(C_local, C_shared)
+            T.copy(C_shared, C[bx * block_M, by * block_N])
+
+    return main
+
+
+def _compile_and_check(program, out_dtype):
+    kernel = tilelang.compile(program, out_idx=[2])
+
+    print(kernel.get_kernel_source())
+
+    profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
+
+    def ref_program(A, B):
+        import torch
+
+        C = torch.matmul(A.to(torch.float), B.to(torch.float))
+        return C.to(torch.__getattribute__(out_dtype))
+
+    profiler.assert_allclose(ref_program, atol=1e-2, rtol=1e-2)
+    print("assert_allclose passed")
+
+
+def run_gemm(
+    M,
+    N,
+    K,
+    in_dtype,
+    out_dtype,
+    accum_dtype,
+    block_M,
+    block_N,
+    block_K,
+    num_stages=4,
+):
+    program = matmul_2cta(
+        M,
+        N,
+        K,
+        block_M,
+        block_N,
+        block_K,
+        in_dtype,
+        out_dtype,
+        accum_dtype,
+        num_stages,
+    )
+    _compile_and_check(program, out_dtype)
+
+
+M_VALUES = [64, 128, 256]
+N_VALUES = [64, 128, 256]
+
+# atom_k=16 for fp16/bf16 (K%16==0), atom_k=32 for fp8/int8 (K%32==0)
+K_VALUES_16 = [16, 32, 64, 128]
+K_VALUES_32 = [32, 64, 128]
+
+# Dtype cases: (block_K, in_dtype, out_dtype, accum_dtype)
+FP16_CASES = [pytest.param(k, T.float16, T.float32, T.float32, id=f"K{k}-fp16-fp32-fp32") for k in K_VALUES_16]
+
+FP8_E5M2_CASES = [pytest.param(k, T.float8_e5m2, T.float32, T.float32, id=f"K{k}-fp8e5m2-fp32-fp32") for k in K_VALUES_32]
+
+INT8_CASES = [pytest.param(k, T.int8, T.int32, T.int32, id=f"K{k}-int8-int32-int32") for k in K_VALUES_32]
+
+ALL_DTYPE_CASES = FP16_CASES + FP8_E5M2_CASES + INT8_CASES
+
+
+@pytest.mark.parametrize("m", M_VALUES, ids=lambda v: f"M{v}")
+@pytest.mark.parametrize("n", N_VALUES, ids=lambda v: f"N{v}")
+@pytest.mark.parametrize("block_k,in_dtype,out_dtype,accum_dtype", ALL_DTYPE_CASES)
+def test_gemm_2cta(m, n, block_k, in_dtype, out_dtype, accum_dtype):
+    import torch
+
+    for attr in {in_dtype, out_dtype, accum_dtype}:
+        if not hasattr(torch, attr):
+            pytest.skip(f"Torch does not expose dtype {attr}")
+
+    # M = 2 * block_M so ceildiv(M, block_M) = 2 (cluster needs >= 2 tiles in M dim)
+    # K = 3 * block_K to exercise multi-iteration pipelining
+    k = block_k * 3
+    run_gemm(
+        m * 2,
+        n,
+        k,
+        in_dtype,
+        out_dtype,
+        accum_dtype,
+        block_M=m,
+        block_N=n,
+        block_K=block_k,
+    )
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/maint/gemm/correctness_evaluation_tcgen05_2cta.py
+++ b/maint/gemm/correctness_evaluation_tcgen05_2cta.py
@@ -5,8 +5,6 @@ import tilelang
 import tilelang.testing
 import tilelang.language as T
 
-tilelang.disable_cache()
-
 
 def matmul_2cta(
     M,
@@ -79,8 +77,6 @@ def matmul_2cta(
 
 def _compile_and_check(program, out_dtype):
     kernel = tilelang.compile(program, out_idx=[2])
-
-    print(kernel.get_kernel_source())
 
     profiler = kernel.get_profiler(tensor_supply_type=tilelang.TensorSupplyType.Normal)
 

--- a/maint/gemm/correctness_evaluation_tcgen05_fp4_unpacked.py
+++ b/maint/gemm/correctness_evaluation_tcgen05_fp4_unpacked.py
@@ -5,6 +5,7 @@ Cases:
   1. fp4 (packed global, unpacked SMEM) x fp8 tcgen05 GEMM
   2. mxfp4 (unpacked SMEM) x mxfp8 block-scaled tcgen05 GEMM
 """
+
 import sys
 import tilelang
 import tilelang.language as T
@@ -150,12 +151,7 @@ def _quantize_mxfp8_with_packed_ue8m0(x, gran_k: int = 128):
     else:
         sf_u8_padded = sf_u8
     words = sf_u8_padded.to(torch.int64)
-    packed = (
-        words[:, 0::4]
-        | (words[:, 1::4] << 8)
-        | (words[:, 2::4] << 16)
-        | (words[:, 3::4] << 24)
-    ).to(torch.uint32)
+    packed = (words[:, 0::4] | (words[:, 1::4] << 8) | (words[:, 2::4] << 16) | (words[:, 3::4] << 24)).to(torch.uint32)
     sf_packed_u32 = packed.T.contiguous().reshape(-1)
     return x_fp8, sf_packed_u32
 
@@ -252,12 +248,7 @@ def _quantize_mxfp4_with_packed_ue8m0(x, gran_k: int = 128):
     else:
         sf_u8_padded = sf_u8
     words = sf_u8_padded.to(torch.int64)
-    packed = (
-        words[:, 0::4]
-        | (words[:, 1::4] << 8)
-        | (words[:, 2::4] << 16)
-        | (words[:, 3::4] << 24)
-    ).to(torch.uint32)
+    packed = (words[:, 0::4] | (words[:, 1::4] << 8) | (words[:, 2::4] << 16) | (words[:, 3::4] << 24)).to(torch.uint32)
     sf_packed_u32 = packed.T.contiguous().reshape(-1)
     return x_fp4, sf_packed_u32
 

--- a/maint/gemm/correctness_evaluation_tcgen05_fp4_unpacked.py
+++ b/maint/gemm/correctness_evaluation_tcgen05_fp4_unpacked.py
@@ -1,0 +1,383 @@
+# python maint/gemm/correctness_evaluation_tcgen05_fp4_unpacked.py
+"""E2E correctness for tcgen05 f8f6f4 GEMM with float4_e2m1_unpacked SMEM.
+
+Cases:
+  1. fp4 (packed global, unpacked SMEM) x fp8 tcgen05 GEMM
+  2. mxfp4 (unpacked SMEM) x mxfp8 block-scaled tcgen05 GEMM
+"""
+import sys
+import tilelang
+import tilelang.language as T
+
+
+def _require_sm100() -> None:
+    import torch
+
+    if not torch.cuda.is_available():
+        print("SKIP: CUDA is required")
+        sys.exit(0)
+    major, _minor = torch.cuda.get_device_capability()
+    if major != 10:
+        print(f"SKIP: SM100 (major=10) required, got capability ({major}, {_minor})")
+        sys.exit(0)
+
+
+def fp4_unpacked_x_fp8_gemm(M: int, N: int, K: int):
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), T.float4_e2m1fn),
+        B: T.Tensor((N, K), T.float8_e4m3fn),
+        D: T.Tensor((M, N), T.float32),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((M, K), T.float4_e2m1_unpacked)
+            B_shared = T.alloc_shared((N, K), T.float8_e4m3fn)
+            C_tmem = T.alloc_tmem((M, N), T.float32)
+            loaded = T.alloc_barrier(128)
+            consumed = T.alloc_barrier(1)
+            C_local = T.alloc_fragment((M, N), T.float32)
+
+            T.tma_copy(A[0:M, 0:K], A_shared, barrier=loaded)
+            T.copy(B[0:N, 0:K], B_shared)
+            T.mbarrier_arrive(loaded)
+            T.mbarrier_wait_parity(loaded, 0)
+            T.tcgen05_gemm(
+                A_shared,
+                B_shared,
+                C_tmem,
+                transpose_B=True,
+                mbar=consumed,
+                clear_accum=True,
+            )
+            T.mbarrier_wait_parity(consumed, 0)
+            T.sync_threads()
+            T.copy(C_tmem, C_local)
+            T.copy(C_local, D[0:M, 0:N])
+
+    return main
+
+
+def blockscaled_mxfp4_unpacked_x_mxfp8_gemm(M: int, N: int, K: int):
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), T.float4_e2m1fn),
+        B: T.Tensor((N, K), T.float8_e4m3fn),
+        SFA: T.Tensor((M,), T.uint32),
+        SFB: T.Tensor((N,), T.uint32),
+        D: T.Tensor((M, N), T.float32),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((M, K), T.float4_e2m1_unpacked)
+            B_shared = T.alloc_shared((N, K), T.float8_e4m3fn)
+            SFA_shared = T.alloc_shared((M,), T.uint32)
+            SFB_shared = T.alloc_shared((N,), T.uint32)
+            C_tmem = T.alloc_tmem((M, N), T.float32)
+            SFA_tmem = T.alloc_tmem((M, 4), T.uint32)
+            SFB_tmem = T.alloc_tmem((M, 4), T.uint32)
+            loaded = T.alloc_barrier(32)
+            with_sf_full = T.alloc_barrier(32)
+            consumed = T.alloc_barrier(1)
+            C_local = T.alloc_fragment((M, N), T.float32)
+            tx = T.get_thread_binding()
+
+            if tx < 32:
+                T.tma_copy(A[0:M, 0:K], A_shared, barrier=loaded)
+                T.copy(B[0:N, 0:K], B_shared)
+                T.copy(SFA, SFA_shared)
+                T.copy(SFB, SFB_shared)
+                T.mbarrier_arrive(loaded)
+            elif tx < 64:
+                T.mbarrier_wait_parity(loaded, 0)
+                T.mbarrier_wait_parity(with_sf_full, 0)
+                T.tcgen05_cp_warpx4(SFA_shared, SFA_tmem)
+                T.tcgen05_cp_warpx4(SFB_shared, SFB_tmem)
+                T.tcgen05_gemm_blockscaled(
+                    A_shared,
+                    B_shared,
+                    C_tmem,
+                    SFA_tmem,
+                    SFB_tmem,
+                    transpose_B=True,
+                    mbar=consumed,
+                    clear_accum=True,
+                    k_start=0,
+                    sf_a_granularity_k=128,
+                    sf_b_granularity_k=128,
+                )
+            elif tx < 96:
+                T.mbarrier_wait_parity(loaded, 0)
+                T.tcgen05_sf_warp_transpose(SFA_shared)
+                T.tcgen05_sf_warp_transpose(SFB_shared)
+                T.fence_proxy_async()
+                T.mbarrier_arrive(with_sf_full)
+
+            T.mbarrier_wait_parity(consumed, 0)
+            T.copy(C_tmem, C_local)
+            T.copy(C_local, D[0:M, 0:N])
+
+    return main
+
+
+def _quantize_mxfp8_with_packed_ue8m0(x, gran_k: int = 128):
+    import torch
+
+    def ceil_div_int(xv, yv):
+        return (xv + yv - 1) // yv
+
+    def align_up(xv, yv):
+        return ceil_div_int(xv, yv) * yv
+
+    def ceil_to_ue8m0(t):
+        bits = t.abs().float().view(torch.int32)
+        exp = ((bits >> 23) & 0xFF) + (bits & 0x7FFFFF).ne(0).to(torch.int32)
+        return (exp.clamp(1, 254) << 23).view(torch.float32)
+
+    mn, k = x.shape
+    padded_k = align_up(k, gran_k)
+    x_padded = torch.zeros((mn, padded_k), device=x.device, dtype=x.dtype)
+    x_padded[:, :k] = x
+    x_view = x_padded.view(mn, padded_k // gran_k, gran_k)
+    x_amax = x_view.abs().float().amax(dim=2).clamp_min(1e-4)
+    sf = ceil_to_ue8m0(x_amax / 448.0)
+    x_fp8 = (x_view * (1.0 / sf.unsqueeze(2))).to(torch.float8_e4m3fn)
+    x_fp8 = x_fp8.view(mn, padded_k)[:, :k].contiguous()
+    sf_u8 = (sf.contiguous().view(torch.int32) >> 23).to(torch.uint8)
+    sf_k_blocks = sf_u8.shape[1]
+    sf_k_padded = align_up(sf_k_blocks, 4)
+    if sf_k_padded != sf_k_blocks:
+        sf_u8_padded = torch.full((mn, sf_k_padded), 127, device=x.device, dtype=torch.uint8)
+        sf_u8_padded[:, :sf_k_blocks] = sf_u8
+    else:
+        sf_u8_padded = sf_u8
+    words = sf_u8_padded.to(torch.int64)
+    packed = (
+        words[:, 0::4]
+        | (words[:, 1::4] << 8)
+        | (words[:, 2::4] << 16)
+        | (words[:, 3::4] << 24)
+    ).to(torch.uint32)
+    sf_packed_u32 = packed.T.contiguous().reshape(-1)
+    return x_fp8, sf_packed_u32
+
+
+_FP4_E2M1_VALUES = (
+    0.0,
+    0.5,
+    1.0,
+    1.5,
+    2.0,
+    3.0,
+    4.0,
+    6.0,
+    -0.0,
+    -0.5,
+    -1.0,
+    -1.5,
+    -2.0,
+    -3.0,
+    -4.0,
+    -6.0,
+)
+
+
+def _fp4_lut(device: str = "cuda"):
+    import torch
+
+    return torch.tensor(_FP4_E2M1_VALUES, device=device, dtype=torch.float32)
+
+
+def _packed_fp4_bytes_to_f32(packed, k: int):
+    """Decode packed fp4 bytes (m, k//2) to logical (m, k) float32."""
+    import torch
+
+    u = packed.contiguous().view(torch.uint8)
+    lut = _fp4_lut(u.device)
+    lo = lut[(u & 0x0F).long()]
+    hi = lut[((u >> 4) & 0x0F).long()]
+    logical = torch.empty(u.shape[0], k, device=u.device, dtype=torch.float32)
+    logical[:, 0::2] = lo
+    logical[:, 1::2] = hi
+    return logical
+
+
+def _quantize_f32_to_packed_fp4(x):
+    """Quantize float32 (m, k) to packed fp4 bytes (m, k//2)."""
+    import torch
+
+    m, k = x.shape
+    assert k % 2 == 0
+    lut = _fp4_lut(x.device)
+    idx = (x.reshape(-1, 1) - lut.reshape(1, -1)).abs().argmin(dim=1).reshape(m, k)
+    lo = idx[:, 0::2].to(torch.uint8)
+    hi = idx[:, 1::2].to(torch.uint8)
+    return (lo | (hi << 4)).to(torch.int8)
+
+
+def _random_fp4_tensor(m: int, k: int, device: str = "cuda"):
+    """Create random packed fp4 tensor for logical shape (m, k)."""
+    import torch
+
+    return torch.randint(-128, 128, (m, k // 2), device=device, dtype=torch.int8)
+
+
+def _quantize_mxfp4_with_packed_ue8m0(x, gran_k: int = 128):
+    import torch
+
+    def ceil_div_int(xv, yv):
+        return (xv + yv - 1) // yv
+
+    def align_up(xv, yv):
+        return ceil_div_int(xv, yv) * yv
+
+    def ceil_to_ue8m0(t):
+        bits = t.abs().float().view(torch.int32)
+        exp = ((bits >> 23) & 0xFF) + (bits & 0x7FFFFF).ne(0).to(torch.int32)
+        return (exp.clamp(1, 254) << 23).view(torch.float32)
+
+    mn, k = x.shape
+    padded_k = align_up(k, gran_k)
+    x_padded = torch.zeros((mn, padded_k), device=x.device, dtype=x.dtype)
+    x_padded[:, :k] = x
+    x_view = x_padded.view(mn, padded_k // gran_k, gran_k)
+    x_amax = x_view.abs().float().amax(dim=2).clamp_min(1e-4)
+    sf = ceil_to_ue8m0(x_amax / 6.0)
+    x_scaled = x_view * (1.0 / sf.unsqueeze(2))
+    x_fp4 = _quantize_f32_to_packed_fp4(x_scaled.reshape(mn, padded_k))[:, : k // 2].contiguous()
+    sf_u8 = (sf.contiguous().view(torch.int32) >> 23).to(torch.uint8)
+    sf_k_blocks = sf_u8.shape[1]
+    sf_k_padded = align_up(sf_k_blocks, 4)
+    if sf_k_padded != sf_k_blocks:
+        sf_u8_padded = torch.full((mn, sf_k_padded), 127, device=x.device, dtype=torch.uint8)
+        sf_u8_padded[:, :sf_k_blocks] = sf_u8
+    else:
+        sf_u8_padded = sf_u8
+    words = sf_u8_padded.to(torch.int64)
+    packed = (
+        words[:, 0::4]
+        | (words[:, 1::4] << 8)
+        | (words[:, 2::4] << 16)
+        | (words[:, 3::4] << 24)
+    ).to(torch.uint32)
+    sf_packed_u32 = packed.T.contiguous().reshape(-1)
+    return x_fp4, sf_packed_u32
+
+
+def _unpack_sf_u32_1d(packed_sf, mn, sf_k_blocks):
+    import torch
+
+    sf_k_groups = (sf_k_blocks + 3) // 4
+    packed_2d = packed_sf.view(sf_k_groups, mn).T.contiguous().to(torch.int64)
+    unpacked = torch.empty((mn, sf_k_groups * 4), device=packed_sf.device, dtype=torch.uint8)
+    for i in range(4):
+        unpacked[:, i::4] = ((packed_2d >> (8 * i)) & 0xFF).to(torch.uint8)
+    return unpacked[:, :sf_k_blocks].contiguous()
+
+
+def _blockscaled_gemm_ref(a, b, sfa_packed, sfb_packed, *, sf_granularity_k=128, transpose_B=False):
+    import torch
+
+    m, k_packed = a.shape
+    k = k_packed * 2
+    if transpose_B:
+        n, k2 = b.shape
+    else:
+        k2, n = b.shape
+    assert k == k2
+    sf_k_blocks = (k + sf_granularity_k - 1) // sf_granularity_k
+    sfa_unpacked = _unpack_sf_u32_1d(sfa_packed, m, sf_k_blocks)
+    sfb_unpacked = _unpack_sf_u32_1d(sfb_packed, n, sf_k_blocks)
+    a_f32 = _packed_fp4_bytes_to_f32(a, k)
+    b_f32 = b.to(torch.float32)
+    sfa_scales = torch.pow(2.0, sfa_unpacked.to(torch.float32) - 127.0)
+    sfb_scales = torch.pow(2.0, sfb_unpacked.to(torch.float32) - 127.0)
+    c = torch.zeros(m, n, device=a.device, dtype=torch.float32)
+    for bi in range(sf_k_blocks):
+        k_start = bi * sf_granularity_k
+        k_end = min(k_start + sf_granularity_k, k)
+        a_block = a_f32[:, k_start:k_end] * sfa_scales[:, bi : bi + 1]
+        if transpose_B:
+            b_block = b_f32[:, k_start:k_end] * sfb_scales[:, bi : bi + 1]
+            c += a_block @ b_block.T
+        else:
+            b_block = b_f32[k_start:k_end, :] * sfb_scales[:, bi : bi + 1].T
+            c += a_block @ b_block
+    return c
+
+
+def run_fp4_unpacked_x_fp8(M: int = 128, N: int = 256, K: int = 128) -> None:
+    import torch
+
+    print(f"=== fp4_unpacked x fp8 tcgen05 GEMM correctness M={M} N={N} K={K} ===")
+    program = fp4_unpacked_x_fp8_gemm(M, N, K)
+    kernel = tilelang.compile(
+        program,
+        out_idx=[2],
+        target="cuda",
+        pass_configs={
+            tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        },
+    )
+    src = kernel.get_kernel_source()
+    print(src)
+    assert "tcgen05mma_ws_ss" in src
+    assert "kFloat4_e2m1fn" in src
+    assert "uint8_t*)A_shared" in src
+
+    profiler = kernel.get_profiler()
+
+    torch.manual_seed(0)
+    a_fp4 = _random_fp4_tensor(M, K)
+    b_fp8 = torch.randint(-128, 128, (N, K), device="cuda", dtype=torch.int8).to(torch.float8_e4m3fn)
+    input_tensors = [a_fp4, b_fp8]
+
+    def ref_program(A, B):
+        a = _packed_fp4_bytes_to_f32(A, K)
+        b = B.to(torch.float32)
+        return torch.matmul(a, b.T)
+
+    profiler.assert_allclose(ref_program, input_tensors=input_tensors, atol=0.25, rtol=0.25)
+    print("assert_allclose passed")
+
+
+def run_blockscaled_mxfp4_x_mxfp8(M: int = 128, N: int = 256, K: int = 128) -> None:
+    import torch
+
+    print(f"=== blockscaled mxfp4_unpacked x mxfp8 tcgen05 GEMM correctness M={M} N={N} K={K} ===")
+    program = blockscaled_mxfp4_unpacked_x_mxfp8_gemm(M, N, K)
+    kernel = tilelang.compile(
+        program,
+        out_idx=[4],
+        target="cuda",
+        pass_configs={
+            tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        },
+    )
+    src = kernel.get_kernel_source()
+    assert "tcgen05mma_blockscaled_ss" in src
+    assert "kFloat4_e2m1fn" in src
+
+    profiler = kernel.get_profiler()
+
+    torch.manual_seed(0)
+    a_f32 = torch.randn(M, K, device="cuda", dtype=torch.float32)
+    b_f32 = torch.randn(N, K, device="cuda", dtype=torch.float32)
+    a_fp4, sfa = _quantize_mxfp4_with_packed_ue8m0(a_f32)
+    b_fp8, sfb = _quantize_mxfp8_with_packed_ue8m0(b_f32)
+    input_tensors = [a_fp4, b_fp8, sfa, sfb]
+
+    def ref_program(A, B, SFA, SFB):
+        return _blockscaled_gemm_ref(A, B, SFA, SFB, transpose_B=True)
+
+    profiler.assert_allclose(ref_program, input_tensors=input_tensors, atol=0.5, rtol=0.5)
+    print("assert_allclose passed")
+
+
+def main() -> None:
+    _require_sm100()
+    run_fp4_unpacked_x_fp8()
+    run_blockscaled_mxfp4_x_mxfp8()
+    print("All fp4_unpacked tcgen05 correctness checks passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -2082,7 +2082,8 @@ std::string CodeGenTileLangCUDA::GetBufferRef(DataType t,
        << " + " << index_str << ")";
   } else if (t == buffer_element_dtype) {
     int div_factor = 1;
-    if (buffer_element_dtype.is_float4_e2m1fn() && buffer_element_dtype.lanes() == 1) {
+    if (buffer_element_dtype.is_float4_e2m1fn() &&
+        buffer_element_dtype.lanes() == 1) {
       div_factor = 2;
     }
     index_str =
@@ -2092,7 +2093,8 @@ std::string CodeGenTileLangCUDA::GetBufferRef(DataType t,
     // Fix fp4 pointer arithmetic: fp4 elements are 4-bit packed 2 per byte.
     // fp4* + n incorrectly advances n bytes (skipping 2n elements).
     int div_factor = 1;
-    if (buffer_element_dtype.is_float4_e2m1fn() && buffer_element_dtype.lanes() == 1) {
+    if (buffer_element_dtype.is_float4_e2m1fn() &&
+        buffer_element_dtype.lanes() == 1) {
       div_factor = 2;
     }
     index_str =
@@ -4512,8 +4514,8 @@ void CodeGenTileLangCUDA::VisitStmt_(const AllocBufferNode *op) {
   } else if (scope == "local.descriptor.tcgen05_instr") {
     stream << "tl::Tcgen05InstrDescriptor " << vid << ";\n";
   } else {
-    bool is_fp4_scalar_local =
-        alloc_dtype.is_float4_e2m1fn() && alloc_dtype.is_scalar() && scope == "local";
+    bool is_fp4_scalar_local = alloc_dtype.is_float4_e2m1fn() &&
+                               alloc_dtype.is_scalar() && scope == "local";
     bool is_int4_scalar_local =
         (alloc_dtype == DataType::Int(4) || alloc_dtype == DataType::UInt(4)) &&
         alloc_dtype.is_scalar() && scope == "local";

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -265,6 +265,11 @@ std::string GetTileLangFP6Type(DataType type) {
 }
 
 std::string GetTileLangFP4Type(DataType type) {
+  if (type.is_float4_e2m1_unpacked()) {
+    LOG(FATAL) << "float4_e2m1_unpacked is a SMEM/TMA storage tag and has no "
+                  "CUDA register type";
+  }
+
   std::stringstream stream;
   int32_t lanes = type.lanes();
   std::string vec;
@@ -288,7 +293,7 @@ std::string GetTileLangFP4Type(DataType type) {
   }
 
   std::string suffix;
-  if (type.code() == DataType::kFloat4_e2m1fn) {
+  if (type.is_float4_e2m1fn()) {
     suffix = "_e2";
   } else {
     LOG(FATAL) << "Unsupported FP4 type in CUDA codegen";
@@ -796,13 +801,8 @@ void CodeGenTileLangCUDA::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
     }
     fail = true;
   } else if (t.is_float4_e2m1_unpacked()) {
-    if (t.is_scalar()) {
-      os << "uint8_t";
-    } else if (t.lanes() <= 4) {
-      os << "uint8_t";
-    } else {
-      os << "uint8_t";
-    }
+    LOG(FATAL) << "float4_e2m1_unpacked is a SMEM/TMA storage tag and must be "
+                  "lowered through shared-memory allocation";
     return;
   } else if (t.is_float4_e2m1fn()) {
     enable_fp4_ = true;
@@ -2033,6 +2033,9 @@ std::string CodeGenTileLangCUDA::GetBufferRef(DataType t,
   if (alloc_storage_scope_.count(buffer_var)) {
     scope = alloc_storage_scope_.at(buffer_var);
   }
+  if (scope.empty()) {
+    scope = GetPtrStorageScope(buffer->data);
+  }
   // bool is_vol = IsVolatile(buffer_var);
   // always false for tl cutlass backend.
   bool is_vol = false;
@@ -2046,7 +2049,12 @@ std::string CodeGenTileLangCUDA::GetBufferRef(DataType t,
     if (!scope.empty() && IsScopePartOfType()) {
       PrintStorageScope(scope, ptr_os);
     }
-    PrintType(pointed_to, ptr_os);
+    if (pointed_to.is_float4_e2m1_unpacked() &&
+        (scope == "shared" || scope == "shared.dyn")) {
+      ptr_os << "uint8_t";
+    } else {
+      PrintType(pointed_to, ptr_os);
+    }
     ptr_os << "*)";
     return ptr_os.str();
   };
@@ -2058,9 +2066,6 @@ std::string CodeGenTileLangCUDA::GetBufferRef(DataType t,
     std::stringstream temp;
     temp << "(" << ptr_cast(buffer_element_dtype) << vid << ")";
     buffer_str = temp.str();
-  }
-  if (scope.empty()) {
-    scope = GetPtrStorageScope(buffer->data);
   }
   if (scope == "local.var" || scope.find("local.descriptor") == 0) {
     os << vid;
@@ -2082,7 +2087,8 @@ std::string CodeGenTileLangCUDA::GetBufferRef(DataType t,
        << " + " << index_str << ")";
   } else if (t == buffer_element_dtype) {
     int div_factor = 1;
-    if (buffer_element_dtype.bits() == 4 && buffer_element_dtype.lanes() == 1) {
+    if (buffer_element_dtype.is_float4_e2m1fn() &&
+        buffer_element_dtype.lanes() == 1) {
       div_factor = 2;
     }
     index_str =
@@ -3811,7 +3817,8 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     DataType src_dtype = op->args[0]->dtype;
     PrimExpr value = op->args[0];
 
-    // Handle float4_e2m1fn reinterpret
+    // Handle packed float4_e2m1fn reinterpret. The unpacked SMEM dtype is not a
+    // general register conversion dtype.
     if (!src_dtype.is_float4_e2m1fn() && !tgt_dtype.is_float4_e2m1fn()) {
       ICHECK_EQ(tgt_dtype.lanes() * tgt_dtype.bits(),
                 src_dtype.lanes() * src_dtype.bits())
@@ -4513,6 +4520,9 @@ void CodeGenTileLangCUDA::VisitStmt_(const AllocBufferNode *op) {
   } else if (scope == "local.descriptor.tcgen05_instr") {
     stream << "tl::Tcgen05InstrDescriptor " << vid << ";\n";
   } else {
+    bool is_float4_unpacked_shared =
+        alloc_dtype.is_float4_e2m1_unpacked() &&
+        (scope == "shared" || scope == "shared.dyn");
     bool is_fp4_scalar_local = alloc_dtype.is_float4_e2m1fn() &&
                                alloc_dtype.is_scalar() && scope == "local";
     bool is_int4_scalar_local =
@@ -4520,7 +4530,11 @@ void CodeGenTileLangCUDA::VisitStmt_(const AllocBufferNode *op) {
         alloc_dtype.is_scalar() && scope == "local";
     if (!is_fp4_scalar_local && !is_int4_scalar_local) {
       PrintStorageScope(scope, stream);
-      PrintType(alloc_dtype, stream);
+      if (is_float4_unpacked_shared) {
+        stream << "uint8_t";
+      } else {
+        PrintType(alloc_dtype, stream);
+      }
     }
   }
 

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -2082,8 +2082,7 @@ std::string CodeGenTileLangCUDA::GetBufferRef(DataType t,
        << " + " << index_str << ")";
   } else if (t == buffer_element_dtype) {
     int div_factor = 1;
-    if (buffer_element_dtype.is_float4_e2m1fn() &&
-        buffer_element_dtype.lanes() == 1) {
+    if (buffer_element_dtype.bits() == 4 && buffer_element_dtype.lanes() == 1) {
       div_factor = 2;
     }
     index_str =

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -795,7 +795,16 @@ void CodeGenTileLangCUDA::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
       return;
     }
     fail = true;
-  } else if (t.is_float4()) {
+  } else if (t.is_float4_e2m1_unpacked()) {
+    if (t.is_scalar()) {
+      os << "uint8_t";
+    } else if (t.lanes() <= 4) {
+      os << "uint8_t";
+    } else {
+      os << "uint8_t";
+    }
+    return;
+  } else if (t.is_float4_e2m1fn()) {
     enable_fp4_ = true;
     if (t.lanes() <= 64) {
       os << GetTileLangFP4Type(t);
@@ -2073,7 +2082,7 @@ std::string CodeGenTileLangCUDA::GetBufferRef(DataType t,
        << " + " << index_str << ")";
   } else if (t == buffer_element_dtype) {
     int div_factor = 1;
-    if (buffer_element_dtype.is_float4() && buffer_element_dtype.lanes() == 1) {
+    if (buffer_element_dtype.is_float4_e2m1fn() && buffer_element_dtype.lanes() == 1) {
       div_factor = 2;
     }
     index_str =
@@ -2083,7 +2092,7 @@ std::string CodeGenTileLangCUDA::GetBufferRef(DataType t,
     // Fix fp4 pointer arithmetic: fp4 elements are 4-bit packed 2 per byte.
     // fp4* + n incorrectly advances n bytes (skipping 2n elements).
     int div_factor = 1;
-    if (buffer_element_dtype.is_float4() && buffer_element_dtype.lanes() == 1) {
+    if (buffer_element_dtype.is_float4_e2m1fn() && buffer_element_dtype.lanes() == 1) {
       div_factor = 2;
     }
     index_str =
@@ -3305,8 +3314,8 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     tcgen05_call = replacer.rewrite(tcgen05_call);
     this->stream << tcgen05_call;
   } else if (op->op.same_as(tl::ptx_tcgen05_mma_blockscaled_ss())) {
-    ICHECK_EQ(op->args.size(), 17U)
-        << "ptx_tcgen05_mma_blockscaled_ss expects 17 arguments";
+    ICHECK_EQ(op->args.size(), 16U)
+        << "ptx_tcgen05_mma_blockscaled_ss expects 16 arguments";
     std::string kind_dtype = Downcast<StringImm>(op->args[0])->value;
     std::string a_desc = this->PrintExpr(op->args[1]);
     std::string A_offset = this->PrintExpr(op->args[2]);
@@ -3321,10 +3330,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     std::string sfb_ref = this->PrintExpr(op->args[11]);
     std::string sfb_offset = this->PrintExpr(op->args[12]);
     // args[13], [14] reserved for future mask/flags
-    bool enable_ws = Downcast<Bool>(op->args[15])->value;
-    bool enable_2cta = Downcast<Bool>(op->args[16])->value;
-    ICHECK(!(enable_ws && enable_2cta))
-        << "Block-scaled TCGEN05 does not support combining .ws and 2CTA";
+    bool enable_2cta = Downcast<Bool>(op->args[15])->value;
 
     auto dtype_enum = tl::codegen::ptx::DTypeFromString(kind_dtype);
 
@@ -3348,9 +3354,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     replacer.register_rule("(B_offset)", B_offset);
     replacer.register_rule("(C)", c_ref);
     replacer.register_rule("(C_offset)", c_offset);
-    replacer.register_rule("(tcgen05_name)",
-                           enable_ws ? "tcgen05mma_blockscaled_ws_ss"
-                                     : "tcgen05mma_blockscaled_ss");
+    replacer.register_rule("(tcgen05_name)", "tcgen05mma_blockscaled_ss");
     replacer.register_rule("(scale_out)", scale_out);
     replacer.register_rule("(desc_val)", this->PrintExpr(desc_expr));
     replacer.register_rule("(SFA)", sfa_ref);
@@ -4509,7 +4513,7 @@ void CodeGenTileLangCUDA::VisitStmt_(const AllocBufferNode *op) {
     stream << "tl::Tcgen05InstrDescriptor " << vid << ";\n";
   } else {
     bool is_fp4_scalar_local =
-        alloc_dtype.is_float4() && alloc_dtype.is_scalar() && scope == "local";
+        alloc_dtype.is_float4_e2m1fn() && alloc_dtype.is_scalar() && scope == "local";
     bool is_int4_scalar_local =
         (alloc_dtype == DataType::Int(4) || alloc_dtype == DataType::UInt(4)) &&
         alloc_dtype.is_scalar() && scope == "local";
@@ -4551,7 +4555,7 @@ void CodeGenTileLangCUDA::VisitStmt_(const AllocBufferNode *op) {
         PrintType(alloc_dtype, stream);
         stream << ' ' << vid << '[' << (constant_size + 1) / 2 << "];\n";
       } else {
-        if (alloc_dtype.is_float4() && alloc_dtype.is_scalar()) {
+        if (alloc_dtype.is_float4_e2m1fn() && alloc_dtype.is_scalar()) {
           auto vid_packed = vid + "_packed";
           stream << "fp4_e2_2_t " << vid_packed << '['
                  << (constant_size + 1) / 2 << "];\n";
@@ -4662,7 +4666,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const BufferLoadNode *op,
     // GetBufferRef maps two consecutive fp4 elements to the same byte, but
     // reading that byte only returns the low nibble — the odd-indexed element
     // is lost).
-    if (element_dtype.is_float4() && element_dtype.lanes() == 1) {
+    if (element_dtype.is_float4_e2m1fn() && element_dtype.lanes() == 1) {
       std::string idx_str = PrintExpr(index);
       std::string vid = GetVarID(buffer_var.get());
       os << "tl_fp4_packed_load((fp4_e2_2_t*)" << vid << ", " << idx_str << ")";
@@ -4761,7 +4765,7 @@ void CodeGenTileLangCUDA::VisitStmt_(const BufferStoreNode *op) {
     // to correctly handle nibble-level writes. The /2 in GetBufferRef maps two
     // consecutive fp4 elements to the same byte, and a plain assignment
     // overwrites the entire byte — destroying the neighboring nibble.
-    if (element_dtype.is_float4() && element_dtype.lanes() == 1) {
+    if (element_dtype.is_float4_e2m1fn() && element_dtype.lanes() == 1) {
       std::string idx_str = PrintExpr(index_expr);
       std::string value = this->PrintExpr(op->value);
       std::string vid = GetVarID(buffer_var.get());

--- a/src/cuda/codegen/ptx.cc
+++ b/src/cuda/codegen/ptx.cc
@@ -92,7 +92,9 @@ DataType DTypeFromString(const std::string str) {
     return DataType::kFloat6_e2m3fn;
   } else if (str == "float6_e3m2fn" || str == "e3m2" || str == ".e3m2") {
     return DataType::kFloat6_e3m2fn;
-  } else if (str == "float4_e2m1fn" || str == "e2m1" || str == ".e2m1") {
+  } else if (str == "float4_e2m1fn" || str == "float4_e2m1_unpacked" ||
+             str == "custom[float4_e2m1_unpacked]8" || str == "e2m1" ||
+             str == ".e2m1") {
     return DataType::kFloat4_e2m1fn;
   } else if (str == "float16" || str == "fp16" || str == ".f16") {
     return DataType::kFloat16;

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -46,7 +46,7 @@ PrimExpr MakeTmaLeaderCondition(PrimExpr thread_extent) {
 
 int TMAPayloadElementBits(DataType dtype) {
   // IR elements are 8-bit unpacked SMEM slots, but TMA/mbarrier transactions
-  // count the packed FP4 payload moved from/to global memory.
+  // count the packed FP4 payload loaded from global memory.
   if (dtype.is_float4_e2m1_unpacked()) {
     return 4;
   }

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -44,16 +44,16 @@ PrimExpr MakeTmaLeaderCondition(PrimExpr thread_extent) {
   return Call(DataType::Bool(), tl_shuffle_elect(), {std::move(thread_extent)});
 }
 
-int TMATransactionElementBits(DataType dtype) {
-  // float4_e2m1_unpacked stores one logical FP4 value per 8-bit SMEM slot,
-  // but TMA/mbarrier transaction counts reflect the moved FP4 payload (4b).
+int TMAPayloadElementBits(DataType dtype) {
+  // IR elements are 8-bit unpacked SMEM slots, but TMA/mbarrier transactions
+  // count the packed FP4 payload moved from/to global memory.
   if (dtype.is_float4_e2m1_unpacked()) {
     return 4;
   }
   return dtype.bits();
 }
 
-PrimExpr TMABytesFromElements(PrimExpr elements, DataType dtype, int bits) {
+PrimExpr TMABytesFromElements(PrimExpr elements, int bits) {
   PrimExpr elements_i64 = cast(DataType::Int(64), elements);
   if (bits % 8 == 0) {
     return elements_i64 * IntImm(DataType::Int(64), bits / 8);
@@ -63,26 +63,32 @@ PrimExpr TMABytesFromElements(PrimExpr elements, DataType dtype, int bits) {
                   IntImm(DataType::Int(64), 8));
 }
 
-int64_t TMABytesFromElements(int64_t elements, DataType dtype, int bits) {
+int64_t TMABytesFromElements(int64_t elements, int bits) {
   return (elements * bits + 7) / 8;
 }
 
 PrimExpr TMABytesFromElements(PrimExpr elements, DataType dtype) {
-  return TMABytesFromElements(elements, dtype, dtype.bits());
+  return TMABytesFromElements(elements, dtype.bits());
 }
 
 int64_t TMABytesFromElements(int64_t elements, DataType dtype) {
-  return TMABytesFromElements(elements, dtype, dtype.bits());
+  return TMABytesFromElements(elements, dtype.bits());
+}
+
+PrimExpr TMAGlobalBytesFromElements(PrimExpr elements, DataType dtype) {
+  return TMABytesFromElements(elements, TMAPayloadElementBits(dtype));
+}
+
+int64_t TMAGlobalBytesFromElements(int64_t elements, DataType dtype) {
+  return TMABytesFromElements(elements, TMAPayloadElementBits(dtype));
 }
 
 PrimExpr TMATransactionBytesFromElements(PrimExpr elements, DataType dtype) {
-  return TMABytesFromElements(elements, dtype,
-                              TMATransactionElementBits(dtype));
+  return TMABytesFromElements(elements, TMAPayloadElementBits(dtype));
 }
 
 int64_t TMATransactionBytesFromElements(int64_t elements, DataType dtype) {
-  return TMABytesFromElements(elements, dtype,
-                              TMATransactionElementBits(dtype));
+  return TMABytesFromElements(elements, TMAPayloadElementBits(dtype));
 }
 
 int64_t TMAElementsForBytes(int64_t bytes, DataType dtype) {
@@ -1418,7 +1424,8 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
   desc.rank = global_tensor->shape.size();
   ICHECK(desc.rank >= 1 && desc.rank <= 5) << desc.rank;
 
-  ICHECK(IsValidTMACopyDtypePair(global_tensor->dtype, shared_tensor->dtype))
+  ICHECK(
+      IsValidTMADtypePair(is_load, global_tensor->dtype, shared_tensor->dtype))
       << "Copy between buffer " << global_tensor->name << " and "
       << shared_tensor->name << " with incompatible data type "
       << global_tensor->dtype << " and " << shared_tensor->dtype;
@@ -1441,7 +1448,7 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
   }
   ICHECK(is_one(desc.global_stride[0])) << desc.global_stride;
   desc.global_stride = desc.global_stride.Map([&](PrimExpr e) {
-    return TMABytesFromElements(e, global_tensor->dtype);
+    return TMAGlobalBytesFromElements(e, global_tensor->dtype);
   });
   for (size_t i{1}; i < desc.global_stride.size(); i++) {
     auto stride = desc.global_stride[i].as<IntImmNode>();
@@ -1849,7 +1856,7 @@ Stmt Copy::LowerBulkGather4(const CopyNode &op, const LowerArgs &T,
       << "tma_gather4/scatter4 requires unit innermost global stride, got "
       << desc.global_stride;
   desc.global_stride = desc.global_stride.Map([&](PrimExpr e) {
-    return TMABytesFromElements(e, global_tensor->dtype);
+    return TMAGlobalBytesFromElements(e, global_tensor->dtype);
   });
   for (size_t i = 1; i < desc.global_stride.size(); ++i) {
     if (auto stride = desc.global_stride[i].as<IntImmNode>()) {
@@ -2130,7 +2137,7 @@ Stmt Im2Col::Lower(const Im2ColOpNode &op, const LowerArgs &T,
   }
   ICHECK(is_one(desc.global_stride[0])) << desc.global_stride;
   desc.global_stride = desc.global_stride.Map(
-      [&](PrimExpr e) { return TMABytesFromElements(e, src->dtype); });
+      [&](PrimExpr e) { return TMAGlobalBytesFromElements(e, src->dtype); });
   desc.elem_stride = {1, op.stride_, op.stride_, 1};
   desc.lower_corner = {-op.padding_, -op.padding_};
   desc.upper_corner = {-op.padding_, -op.padding_};

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -76,11 +76,13 @@ int64_t TMABytesFromElements(int64_t elements, DataType dtype) {
 }
 
 PrimExpr TMATransactionBytesFromElements(PrimExpr elements, DataType dtype) {
-  return TMABytesFromElements(elements, dtype, TMATransactionElementBits(dtype));
+  return TMABytesFromElements(elements, dtype,
+                              TMATransactionElementBits(dtype));
 }
 
 int64_t TMATransactionBytesFromElements(int64_t elements, DataType dtype) {
-  return TMABytesFromElements(elements, dtype, TMATransactionElementBits(dtype));
+  return TMABytesFromElements(elements, dtype,
+                              TMATransactionElementBits(dtype));
 }
 
 int64_t TMAElementsForBytes(int64_t bytes, DataType dtype) {
@@ -137,8 +139,9 @@ bool GetIsTmaCopy(const CopyNode &op) {
 }
 
 int TensorMapDataTypeForTMA(DataType global_dtype, DataType shared_dtype) {
-  // 16U4_ALIGN16B: f8f6f4 / mxf8f6f4 unpacked FP4 SMEM (float_e2m1_unpacksmem_t).
-  // 16U4_ALIGN8B: packed FP4 for mxf4 / mxf4nvf4 (float_e2m1_t).
+  // 16U4_ALIGN16B: f8f6f4 / mxf8f6f4 unpacked FP4 SMEM
+  // (float_e2m1_unpacksmem_t). 16U4_ALIGN8B: packed FP4 for mxf4 / mxf4nvf4
+  // (float_e2m1_t).
   constexpr int kTensorMapDataType16U4Align16B = 14;
   if (shared_dtype.is_float4_e2m1_unpacked()) {
     ICHECK(global_dtype.is_float4_e2m1fn())
@@ -1420,7 +1423,8 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
       << shared_tensor->name << " with incompatible data type "
       << global_tensor->dtype << " and " << shared_tensor->dtype;
 
-  desc.data_type = TensorMapDataTypeForTMA(global_tensor->dtype, shared_tensor->dtype);
+  desc.data_type =
+      TensorMapDataTypeForTMA(global_tensor->dtype, shared_tensor->dtype);
   desc.global_addr = global_tensor->data;
   desc.global_shape = ReverseArray(global_tensor->shape);
   Array<PrimExpr> global_coords =
@@ -1719,8 +1723,8 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
     PrimExpr total_bytes;
     if ((*inner_box_dim) != instruction_dim) {
       int loop_extent = (*inner_box_dim) / instruction_dim;
-      total_bytes = TMATransactionBytesFromElements(total_elements * loop_extent,
-                                                    shared_tensor->dtype);
+      total_bytes = TMATransactionBytesFromElements(
+          total_elements * loop_extent, shared_tensor->dtype);
     } else {
       total_bytes =
           TMATransactionBytesFromElements(total_elements, shared_tensor->dtype);

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -76,13 +76,11 @@ int64_t TMABytesFromElements(int64_t elements, DataType dtype) {
 }
 
 PrimExpr TMATransactionBytesFromElements(PrimExpr elements, DataType dtype) {
-  return TMABytesFromElements(elements, dtype,
-                              TMATransactionElementBits(dtype));
+  return TMABytesFromElements(elements, dtype, TMATransactionElementBits(dtype));
 }
 
 int64_t TMATransactionBytesFromElements(int64_t elements, DataType dtype) {
-  return TMABytesFromElements(elements, dtype,
-                              TMATransactionElementBits(dtype));
+  return TMABytesFromElements(elements, dtype, TMATransactionElementBits(dtype));
 }
 
 int64_t TMAElementsForBytes(int64_t bytes, DataType dtype) {
@@ -136,6 +134,18 @@ bool GetDisableTMA(const CopyNode &op) {
 
 bool GetIsTmaCopy(const CopyNode &op) {
   return GetBoolAnnotation(op, "is_tma_copy");
+}
+
+int TensorMapDataTypeForTMA(DataType global_dtype, DataType shared_dtype) {
+  // 16U4_ALIGN16B: f8f6f4 / mxf8f6f4 unpacked FP4 SMEM (float_e2m1_unpacksmem_t).
+  // 16U4_ALIGN8B: packed FP4 for mxf4 / mxf4nvf4 (float_e2m1_t).
+  constexpr int kTensorMapDataType16U4Align16B = 14;
+  if (shared_dtype.is_float4_e2m1_unpacked()) {
+    ICHECK(global_dtype.is_float4_e2m1fn())
+        << "FP4 packed global tensor required for unpacked shared TMA copy";
+    return kTensorMapDataType16U4Align16B;
+  }
+  return to_CUtensorMapDataType(global_dtype);
 }
 
 int GetEvictionPolicy(const CopyNode &op) {
@@ -1405,12 +1415,12 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
   desc.rank = global_tensor->shape.size();
   ICHECK(desc.rank >= 1 && desc.rank <= 5) << desc.rank;
 
-  ICHECK(global_tensor->dtype == shared_tensor->dtype)
+  ICHECK(IsValidTMACopyDtypePair(global_tensor->dtype, shared_tensor->dtype))
       << "Copy between buffer " << global_tensor->name << " and "
-      << shared_tensor->name << " with different data type "
+      << shared_tensor->name << " with incompatible data type "
       << global_tensor->dtype << " and " << shared_tensor->dtype;
 
-  desc.data_type = to_CUtensorMapDataType(global_tensor->dtype);
+  desc.data_type = TensorMapDataTypeForTMA(global_tensor->dtype, shared_tensor->dtype);
   desc.global_addr = global_tensor->data;
   desc.global_shape = ReverseArray(global_tensor->shape);
   Array<PrimExpr> global_coords =
@@ -1526,10 +1536,11 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
     return fallback_to_normal("non-constant inner box dimension");
   }
   int instruction_dim = *inner_box_dim;
+  DataType smem_elem_dtype = shared_tensor->dtype;
   if (desc.swizzle == static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B)) {
-    instruction_dim = TMAElementsForBytes(64, src->dtype);
+    instruction_dim = TMAElementsForBytes(64, smem_elem_dtype);
   } else if (desc.swizzle == static_cast<int>(CU_TENSOR_MAP_SWIZZLE_128B)) {
-    instruction_dim = TMAElementsForBytes(128, src->dtype);
+    instruction_dim = TMAElementsForBytes(128, smem_elem_dtype);
   }
   if (instruction_dim > 256) {
     ICHECK((*inner_box_dim) % 256 == 0)
@@ -1708,8 +1719,8 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
     PrimExpr total_bytes;
     if ((*inner_box_dim) != instruction_dim) {
       int loop_extent = (*inner_box_dim) / instruction_dim;
-      total_bytes = TMATransactionBytesFromElements(
-          total_elements * loop_extent, shared_tensor->dtype);
+      total_bytes = TMATransactionBytesFromElements(total_elements * loop_extent,
+                                                    shared_tensor->dtype);
     } else {
       total_bytes =
           TMATransactionBytesFromElements(total_elements, shared_tensor->dtype);

--- a/src/cuda/op/copy_analysis.cc
+++ b/src/cuda/op/copy_analysis.cc
@@ -27,9 +27,15 @@ using namespace ffi;
 
 namespace {
 
-PrimExpr TMABytesFromElements(PrimExpr elements, DataType dtype) {
+int TMAPayloadElementBits(DataType dtype) {
+  if (dtype.is_float4_e2m1_unpacked()) {
+    return 4;
+  }
+  return dtype.bits();
+}
+
+PrimExpr TMABytesFromElements(PrimExpr elements, int bits) {
   PrimExpr elements_i64 = cast(DataType::Int(64), elements);
-  int bits = dtype.bits();
   if (bits % 8 == 0) {
     return elements_i64 * IntImm(DataType::Int(64), bits / 8);
   }
@@ -38,9 +44,13 @@ PrimExpr TMABytesFromElements(PrimExpr elements, DataType dtype) {
                   IntImm(DataType::Int(64), 8));
 }
 
-PrimExpr TMABitsFromElements(PrimExpr elements, DataType dtype) {
+PrimExpr TMAGlobalBytesFromElements(PrimExpr elements, DataType dtype) {
+  return TMABytesFromElements(elements, TMAPayloadElementBits(dtype));
+}
+
+PrimExpr TMAGlobalBitsFromElements(PrimExpr elements, DataType dtype) {
   return cast(DataType::Int(64), elements) *
-         IntImm(DataType::Int(64), dtype.bits());
+         IntImm(DataType::Int(64), TMAPayloadElementBits(dtype));
 }
 
 bool GetBoolAnnotation(const CopyNode &op, const char *key) {
@@ -152,7 +162,8 @@ bool CheckGlobalStrides(const Buffer &buffer, arith::Analyzer *analyzer,
   }
 
   for (size_t i = 0; i + 1 < strides.size(); ++i) {
-    PrimExpr stride_bytes = TMABytesFromElements(strides[i], buffer->dtype);
+    PrimExpr stride_bytes =
+        TMAGlobalBytesFromElements(strides[i], buffer->dtype);
     if (analyzer->CanProve(
             FloorMod(stride_bytes, IntImm(DataType::Int(64), 16)) != 0,
             arith::ProofStrength::kSymbolicBound)) {
@@ -190,8 +201,8 @@ bool CheckBulkLoad(const CopyNode &op, Target target, arith::Analyzer *analyzer,
   if (check_last_dim &&
       analyzer->CanProve(
           FloorMod(
-              TMABitsFromElements(op.src_range[op.src_range.size() - 1]->extent,
-                                  op.src->dtype),
+              TMAGlobalBitsFromElements(
+                  op.src_range[op.src_range.size() - 1]->extent, op.src->dtype),
               IntImm(DataType::Int(64), 128)) != 0,
           arith::ProofStrength::kSymbolicBound)) {
     if (emit_diagnostics) {
@@ -204,7 +215,7 @@ bool CheckBulkLoad(const CopyNode &op, Target target, arith::Analyzer *analyzer,
     return false;
   }
 
-  if (!IsValidTMACopyDtypePair(op.src->dtype, op.dst->dtype)) {
+  if (!IsValidTMALoadDtypePair(op.src->dtype, op.dst->dtype)) {
     if (emit_diagnostics) {
       DLOG(WARNING) << "src and dst must have compatible dtypes for tma load "
                     << op.src->name << " vs. " << op.dst->name << " dtype "
@@ -229,8 +240,8 @@ bool CheckBulkStore(const CopyNode &op, Target target,
   if (check_last_dim &&
       analyzer->CanProve(
           FloorMod(
-              TMABitsFromElements(op.dst_range[op.dst_range.size() - 1]->extent,
-                                  op.dst->dtype),
+              TMAGlobalBitsFromElements(
+                  op.dst_range[op.dst_range.size() - 1]->extent, op.dst->dtype),
               IntImm(DataType::Int(64), 128)) != 0,
           arith::ProofStrength::kSymbolicBound)) {
     if (emit_diagnostics) {
@@ -242,7 +253,7 @@ bool CheckBulkStore(const CopyNode &op, Target target,
     }
     return false;
   }
-  if (!IsValidTMACopyDtypePair(op.dst->dtype, op.src->dtype)) {
+  if (!IsValidTMAStoreDtypePair(op.dst->dtype, op.src->dtype)) {
     if (emit_diagnostics) {
       DLOG(WARNING) << "src and dst must have compatible dtypes for tma store "
                     << op.src->name << " vs. " << op.dst->name << " dtype "

--- a/src/cuda/op/copy_analysis.cc
+++ b/src/cuda/op/copy_analysis.cc
@@ -451,6 +451,17 @@ CopyInstSelection Unsupported(std::string reason) {
 
 std::string MakeTmaUnavailableReason(const CopyNode &op) {
   std::ostringstream oss;
+  if (op.src->dtype.is_float4_e2m1_unpacked() ||
+      op.dst->dtype.is_float4_e2m1_unpacked()) {
+    oss << "T.tma_copy() only supports float4_e2m1_unpacked as an FP4 unpack "
+           "load from packed global float4_e2m1fn to unpacked shared memory. "
+           "The reverse unpacked shared -> packed global TMA store is not "
+           "supported. Got src="
+        << op.src->name << " (scope=" << op.src.scope()
+        << ", dtype=" << op.src->dtype << "), dst=" << op.dst->name
+        << " (scope=" << op.dst.scope() << ", dtype=" << op.dst->dtype << ").";
+    return oss.str();
+  }
   oss << "T.tma_copy() requires TMA-capable target and global<->shared copy "
          "pattern, but TMA is not available for src="
       << op.src->name << ", dst=" << op.dst->name;

--- a/src/cuda/op/copy_analysis.cc
+++ b/src/cuda/op/copy_analysis.cc
@@ -204,9 +204,9 @@ bool CheckBulkLoad(const CopyNode &op, Target target, arith::Analyzer *analyzer,
     return false;
   }
 
-  if (op.src->dtype != op.dst->dtype) {
+  if (!IsValidTMACopyDtypePair(op.src->dtype, op.dst->dtype)) {
     if (emit_diagnostics) {
-      DLOG(WARNING) << "src and dst must have the same dtype for tma load "
+      DLOG(WARNING) << "src and dst must have compatible dtypes for tma load "
                     << op.src->name << " vs. " << op.dst->name << " dtype "
                     << op.src->dtype << " vs. " << op.dst->dtype
                     << " will be fallback to normal copy";
@@ -242,9 +242,9 @@ bool CheckBulkStore(const CopyNode &op, Target target,
     }
     return false;
   }
-  if (op.src->dtype != op.dst->dtype) {
+  if (!IsValidTMACopyDtypePair(op.dst->dtype, op.src->dtype)) {
     if (emit_diagnostics) {
-      DLOG(WARNING) << "src and dst must have the same dtype for tma store "
+      DLOG(WARNING) << "src and dst must have compatible dtypes for tma store "
                     << op.src->name << " vs. " << op.dst->name << " dtype "
                     << op.src->dtype << " vs. " << op.dst->dtype
                     << " will be fallback to normal copy";

--- a/src/cuda/op/gemm.cc
+++ b/src/cuda/op/gemm.cc
@@ -348,9 +348,10 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = reflection;
   refl::GlobalDef().def(
       "tl.get_tcgen5_mma_meta", [](int M, int N, int K, DataType ab_dtype,
-                                   DataType c_dtype, bool disable_2cta) {
-        auto [success, meta] =
-            GetTCGEN5MMAMeta(M, N, K, ab_dtype, c_dtype, disable_2cta);
+                                   DataType c_dtype, bool disable_2cta,
+                                   bool disable_ws = false) {
+        auto [success, meta] = GetTCGEN5MMAMeta(
+            M, N, K, ab_dtype, c_dtype, disable_2cta, disable_ws);
         Array<Integer> result;
         if (success) {
           result.push_back(Integer(meta.atom_m));
@@ -363,20 +364,21 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       });
   refl::GlobalDef().def(
       "tl.get_tcgen5_instr_desc",
-      [](int atom_m, int atom_n, int atom_k, DataType ab_dtype,
+      [](int atom_m, int atom_n, int atom_k, DataType a_dtype, DataType b_dtype,
          DataType c_dtype, bool a_is_k_major, bool b_is_k_major, int scale_in_a,
          int scale_in_b) {
-        uint32_t desc = GetTCGEN5InstrDesc(atom_m, atom_n, atom_k, ab_dtype,
+        uint32_t desc = GetTCGEN5InstrDesc(atom_m, atom_n, atom_k, a_dtype, b_dtype,
                                            c_dtype, a_is_k_major, b_is_k_major,
                                            scale_in_a, scale_in_b);
         return Integer(static_cast<int64_t>(desc));
       });
   refl::GlobalDef().def("tl.get_tcgen5_blockscaled_instr_desc",
-                        [](int atom_m, int atom_n, DataType ab_dtype,
-                           bool a_is_k_major, bool b_is_k_major, int scale_in_a,
-                           int scale_in_b, int a_sf_id, int b_sf_id) {
+                        [](int atom_m, int atom_n, DataType a_dtype,
+                           DataType b_dtype, bool a_is_k_major,
+                           bool b_is_k_major, int scale_in_a, int scale_in_b,
+                           int a_sf_id, int b_sf_id) {
                           uint32_t desc = GetTCGEN5BlockScaledInstrDesc(
-                              atom_m, atom_n, ab_dtype, a_is_k_major,
+                              atom_m, atom_n, a_dtype, b_dtype, a_is_k_major,
                               b_is_k_major, scale_in_a, scale_in_b, a_sf_id,
                               b_sf_id);
                           return Integer(static_cast<int64_t>(desc));

--- a/src/cuda/op/gemm.cc
+++ b/src/cuda/op/gemm.cc
@@ -347,11 +347,11 @@ const bool cuda_gemm_registered = RegisterCudaGemm();
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = reflection;
   refl::GlobalDef().def(
-      "tl.get_tcgen5_mma_meta", [](int M, int N, int K, DataType ab_dtype,
-                                   DataType c_dtype, bool disable_2cta,
-                                   bool disable_ws = false) {
-        auto [success, meta] = GetTCGEN5MMAMeta(
-            M, N, K, ab_dtype, c_dtype, disable_2cta, disable_ws);
+      "tl.get_tcgen5_mma_meta",
+      [](int M, int N, int K, DataType ab_dtype, DataType c_dtype,
+         bool disable_2cta, bool disable_ws = false) {
+        auto [success, meta] = GetTCGEN5MMAMeta(M, N, K, ab_dtype, c_dtype,
+                                                disable_2cta, disable_ws);
         Array<Integer> result;
         if (success) {
           result.push_back(Integer(meta.atom_m));
@@ -367,22 +367,21 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       [](int atom_m, int atom_n, int atom_k, DataType a_dtype, DataType b_dtype,
          DataType c_dtype, bool a_is_k_major, bool b_is_k_major, int scale_in_a,
          int scale_in_b) {
-        uint32_t desc = GetTCGEN5InstrDesc(atom_m, atom_n, atom_k, a_dtype, b_dtype,
-                                           c_dtype, a_is_k_major, b_is_k_major,
-                                           scale_in_a, scale_in_b);
+        uint32_t desc = GetTCGEN5InstrDesc(
+            atom_m, atom_n, atom_k, a_dtype, b_dtype, c_dtype, a_is_k_major,
+            b_is_k_major, scale_in_a, scale_in_b);
         return Integer(static_cast<int64_t>(desc));
       });
-  refl::GlobalDef().def("tl.get_tcgen5_blockscaled_instr_desc",
-                        [](int atom_m, int atom_n, DataType a_dtype,
-                           DataType b_dtype, bool a_is_k_major,
-                           bool b_is_k_major, int scale_in_a, int scale_in_b,
-                           int a_sf_id, int b_sf_id) {
-                          uint32_t desc = GetTCGEN5BlockScaledInstrDesc(
-                              atom_m, atom_n, a_dtype, b_dtype, a_is_k_major,
-                              b_is_k_major, scale_in_a, scale_in_b, a_sf_id,
-                              b_sf_id);
-                          return Integer(static_cast<int64_t>(desc));
-                        });
+  refl::GlobalDef().def(
+      "tl.get_tcgen5_blockscaled_instr_desc",
+      [](int atom_m, int atom_n, DataType a_dtype, DataType b_dtype,
+         bool a_is_k_major, bool b_is_k_major, int scale_in_a, int scale_in_b,
+         int a_sf_id, int b_sf_id) {
+        uint32_t desc = GetTCGEN5BlockScaledInstrDesc(
+            atom_m, atom_n, a_dtype, b_dtype, a_is_k_major, b_is_k_major,
+            scale_in_a, scale_in_b, a_sf_id, b_sf_id);
+        return Integer(static_cast<int64_t>(desc));
+      });
 }
 
 } // namespace tl

--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -448,10 +448,10 @@ PrimExpr CopyNode::MakePredicate(arith::Analyzer *analyzer,
 
 // Constructs a SIMT-style nested loop that implements the copy.
 For CopyNode::MakeSIMTLoop(arith::Analyzer *analyzer) const {
-  if (IsFP4StorageCrossCopy(src->dtype, dst->dtype)) {
-    LOG(FATAL) << "SIMT copy between float4_e2m1fn and float4_e2m1_unpacked is "
-               << "not supported; use T.tma_copy() for packed global <-> "
-               << "unpacked shared FP4 transfers (src=" << src->name
+  if (IsFP4UnpackLoad(src, dst)) {
+    LOG(FATAL) << "SIMT copy from packed global float4_e2m1fn to unpacked "
+               << "shared float4_e2m1_unpacked is not supported; use "
+               << "T.tma_copy() for FP4 unpack loads (src=" << src->name
                << ", dst=" << dst->name << ").";
   }
 

--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -448,6 +448,13 @@ PrimExpr CopyNode::MakePredicate(arith::Analyzer *analyzer,
 
 // Constructs a SIMT-style nested loop that implements the copy.
 For CopyNode::MakeSIMTLoop(arith::Analyzer *analyzer) const {
+  if (IsFP4StorageCrossCopy(src->dtype, dst->dtype)) {
+    LOG(FATAL) << "SIMT copy between float4_e2m1fn and float4_e2m1_unpacked is "
+               << "not supported; use T.tma_copy() for packed global <-> "
+               << "unpacked shared FP4 transfers (src=" << src->name
+               << ", dst=" << dst->name << ").";
+  }
+
   Array<IterVar> loop_vars = MakeIterVars();
   bool is_scalar = loop_vars.empty();
 

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -136,10 +136,7 @@ Gemm::Gemm(Array<PrimExpr> args, Map<String, ObjectRef> annotations) {
     node->sfbRegion_ = NormalizeToBufferRegion(args[20]);
   }
   if (args.size() > 21) {
-    node->sfAId_ = args[21].as<PrimExpr>().value();
-  }
-  if (args.size() > 22) {
-    node->sfBId_ = args[22].as<PrimExpr>().value();
+    node->sfKStart_ = args[21].as<PrimExpr>().value();
   }
   node->annotations_ = annotations;
   data_ = std::move(node);

--- a/src/op/gemm.h
+++ b/src/op/gemm.h
@@ -121,7 +121,7 @@ public:
   mutable GemmWarpPolicy policy_;
   Map<String, ObjectRef> annotations_;
   BufferRegion sfaRegion_, sfbRegion_;
-  PrimExpr sfAId_, sfBId_;
+  PrimExpr sfKStart_;
 
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.Gemm", GemmNode, TileOperatorNode);
 
@@ -154,8 +154,7 @@ public:
         .def_ro("annotations", &GemmNode::annotations_)
         .def_ro("sfaRegion", &GemmNode::sfaRegion_)
         .def_ro("sfbRegion", &GemmNode::sfbRegion_)
-        .def_ro("sfAId", &GemmNode::sfAId_)
-        .def_ro("sfBId", &GemmNode::sfBId_);
+        .def_ro("sfKStart", &GemmNode::sfKStart_);
   }
 
   Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const override;

--- a/src/op/tcgen5_meta.h
+++ b/src/op/tcgen5_meta.h
@@ -21,11 +21,15 @@ struct TCGEN5MMAMeta {
 
 inline std::pair<bool, TCGEN5MMAMeta>
 GetTCGEN5MMAMeta(int M, int N, int K, DataType ab_dtype, DataType c_dtype,
-                 bool disable_2cta = false) {
+                 bool disable_2cta = false, bool disable_ws = false) {
 // TODO (lei) Currently not all shapes / dtypes are supported for TCGEN5MMA.
-// NOTE: In case that other tcgen5mma in the same kernel must use 1-cta,
-// we should disable 2cta for the current tcgen5mma.
-// TODO(wt): Add more 2cta-preferred shapes
+// TODO (wt): Add more 2cta-preferred shapes
+// NOTE: 
+// 1. In case that other tcgen5mma in the same kernel must use 1-cta,
+//    we should disable 2cta for the current tcgen5mma.
+// 2. For blockscaled gemm, we should disable ws for the current tcgen5mma.
+// 3. Note that the datatypes of A and B may differ, e.g. .f8f6f4/.mxf8f6f4,
+//    but only considering A is still correct.
 #define FAIL                                                                   \
   return {                                                                     \
     false, TCGEN5MMAMeta { 0, 0, 0, false, false }                             \
@@ -56,20 +60,24 @@ GetTCGEN5MMAMeta(int M, int N, int K, DataType ab_dtype, DataType c_dtype,
           SUCCESS(128, atom_n, 16, false, false);
       FAIL;
     } else if (M % 64 == 0) {
-      for (int atom_n : ws_valid_atom_ns)
-        if (N % atom_n == 0)
-          SUCCESS(64, atom_n, 16, true, false);
+      if (!disable_ws) {
+        for (int atom_n : ws_valid_atom_ns)
+          if (N % atom_n == 0)
+            SUCCESS(64, atom_n, 16, true, false);
+      }
       FAIL;
     } else if (M % 32 == 0) {
-      for (int atom_n : ws_valid_atom_ns)
-        if (N % atom_n == 0)
-          SUCCESS(32, atom_n, 16, true, false);
+      if (!disable_ws) {
+        for (int atom_n : ws_valid_atom_ns)
+          if (N % atom_n == 0)
+            SUCCESS(32, atom_n, 16, true, false);
+      }
       FAIL;
     } else {
       FAIL;
     }
   } else if ((ab_dtype.is_float8() || ab_dtype.is_float6_e2m3fn() ||
-              ab_dtype.is_float6_e3m2fn() || ab_dtype.is_float4_e2m1fn()) &&
+              ab_dtype.is_float6_e3m2fn() || ab_dtype.is_float4()) &&
              ((c_dtype.is_float() && c_dtype.bits() == 32) ||
               (c_dtype.is_float16() && c_dtype.bits() == 16))) {
     if (K % 32 != 0)
@@ -86,25 +94,31 @@ GetTCGEN5MMAMeta(int M, int N, int K, DataType ab_dtype, DataType c_dtype,
       }
     }
     if (M % 128 == 0) {
-      for (int atom_n : ws_valid_atom_ns)
-        if (N % atom_n == 0)
-          SUCCESS(128, atom_n, 32, true, false);
+      if (!disable_ws) {
+        for (int atom_n : ws_valid_atom_ns)
+          if (N % atom_n == 0)
+            SUCCESS(128, atom_n, 32, true, false);
+      }
       for (int atom_n = 256; atom_n >= 8; atom_n -= 8)
         if (N % atom_n == 0)
           SUCCESS(128, atom_n, 32, false, false);
       FAIL;
     } else if (M % 64 == 0) {
-      for (int atom_n : ws_valid_atom_ns)
-        if (N % atom_n == 0)
-          SUCCESS(64, atom_n, 32, true, false);
+      if (!disable_ws) {
+        for (int atom_n : ws_valid_atom_ns)
+          if (N % atom_n == 0)
+            SUCCESS(64, atom_n, 32, true, false);
+      }
       for (int atom_n = 256; atom_n >= 8; atom_n -= 8)
         if (N % atom_n == 0)
           SUCCESS(64, atom_n, 32, false, false);
       FAIL;
     } else if (M % 32 == 0) {
-      for (int atom_n : ws_valid_atom_ns)
-        if (N % atom_n == 0)
-          SUCCESS(32, atom_n, 32, true, false);
+      if (!disable_ws) {
+        for (int atom_n : ws_valid_atom_ns)
+          if (N % atom_n == 0)
+            SUCCESS(32, atom_n, 32, true, false);
+      }
       FAIL;
     } else {
       FAIL;
@@ -125,27 +139,33 @@ GetTCGEN5MMAMeta(int M, int N, int K, DataType ab_dtype, DataType c_dtype,
       }
     }
     if (M % 128 == 0) {
-      for (int atom_n : ws_valid_atom_ns)
-        if (N % atom_n == 0)
-          SUCCESS(128, atom_n, 32, true, false);
+      if (!disable_ws) {
+        for (int atom_n : ws_valid_atom_ns)
+          if (N % atom_n == 0)
+            SUCCESS(128, atom_n, 32, true, false);
+      }
       for (int atom_n = 256; atom_n >= 8; atom_n -= (atom_n > 32 ? 16 : 8))
         // steps of 16 after N > 32
         if (N % atom_n == 0)
           SUCCESS(128, atom_n, 32, false, false);
       FAIL;
     } else if (M % 64 == 0) {
-      for (int atom_n : ws_valid_atom_ns)
-        if (N % atom_n == 0)
-          SUCCESS(64, atom_n, 32, true, false);
+      if (!disable_ws) {
+        for (int atom_n : ws_valid_atom_ns)
+          if (N % atom_n == 0)
+            SUCCESS(64, atom_n, 32, true, false);
+      }
       for (int atom_n = 256; atom_n >= 8; atom_n -= (atom_n > 32 ? 16 : 8))
         // steps of 16 after N > 32
         if (N % atom_n == 0)
           SUCCESS(64, atom_n, 32, false, false);
       FAIL;
     } else if (M % 32 == 0) {
-      for (int atom_n : ws_valid_atom_ns)
-        if (N % atom_n == 0)
-          SUCCESS(32, atom_n, 32, true, false);
+      if (!disable_ws) {
+        for (int atom_n : ws_valid_atom_ns)
+          if (N % atom_n == 0)
+            SUCCESS(32, atom_n, 32, true, false);
+      }
       FAIL;
     } else {
       FAIL;
@@ -157,9 +177,10 @@ GetTCGEN5MMAMeta(int M, int N, int K, DataType ab_dtype, DataType c_dtype,
 }
 
 inline uint32_t GetTCGEN5InstrDesc(int atom_m, int atom_n, int atom_k,
-                                   DataType ab_dtype, DataType c_dtype,
-                                   bool a_is_k_major, bool b_is_k_major,
-                                   int scale_in_a, int scale_in_b) {
+                                   DataType a_dtype, DataType b_dtype,
+                                   DataType c_dtype, bool a_is_k_major,
+                                   bool b_is_k_major, int scale_in_a,
+                                   int scale_in_b) {
   ICHECK(atom_m % 16 == 0) << "atom_m must be divisible by 16";
   ICHECK(atom_n % 8 == 0) << "atom_n must be divisible by 8";
   ICHECK(atom_k == 16 || atom_k == 32)
@@ -183,7 +204,7 @@ inline uint32_t GetTCGEN5InstrDesc(int atom_m, int atom_n, int atom_k,
       return static_cast<uint32_t>(3);
     } else if (dtype.is_float6_e3m2fn()) {
       return static_cast<uint32_t>(4);
-    } else if (dtype.is_float4_e2m1fn()) {
+    } else if (dtype.is_float4()) {
       return static_cast<uint32_t>(5);
     } else if (dtype.is_int() && dtype.bits() == 8) {
       return static_cast<uint32_t>(1);
@@ -194,8 +215,8 @@ inline uint32_t GetTCGEN5InstrDesc(int atom_m, int atom_n, int atom_k,
     return 0u;
   };
 
-  uint32_t a_format = encode_dtype(ab_dtype);
-  uint32_t b_format = a_format;
+  uint32_t a_format = encode_dtype(a_dtype);
+  uint32_t b_format = encode_dtype(b_dtype);
 
   uint32_t c_format = 0;
   if (c_dtype.is_float16()) {
@@ -248,8 +269,10 @@ inline uint32_t GetTCGEN5InstrDesc(int atom_m, int atom_n, int atom_k,
 
 // Build block-scaled instruction descriptor for mxf8f6f4.block_scale
 // Bit layout: InstrDescriptorBlockScaled (see CUTLASS mma_sm100_desc.hpp)
+// TODO: Support nv-style block-scaled descriptor.
 inline uint32_t GetTCGEN5BlockScaledInstrDesc(int atom_m, int atom_n,
-                                              DataType ab_dtype,
+                                              DataType a_dtype,
+                                              DataType b_dtype,
                                               bool a_is_k_major,
                                               bool b_is_k_major, int scale_in_a,
                                               int scale_in_b, int a_sf_id,
@@ -270,10 +293,11 @@ inline uint32_t GetTCGEN5BlockScaledInstrDesc(int atom_m, int atom_n,
       return 3u; // E2M3
     } else if (dtype.is_float6_e3m2fn()) {
       return 4u; // E3M2
-    } else if (dtype.is_float4_e2m1fn()) {
-      return 5u; // E2M1
+    } else if (dtype.is_float4()) {
+      return 5u; // E2M1 (packed or f8f6f4/mxf8f6f4 unpacked storage)
     }
-    LOG(FATAL) << "Unsupported dtype for block-scaled descriptor: " << dtype;
+    LOG(FATAL) << "Unsupported dtype for block-scaled mxf8f6f4 descriptor: "
+               << dtype;
     return 0u;
   };
 
@@ -282,8 +306,8 @@ inline uint32_t GetTCGEN5BlockScaledInstrDesc(int atom_m, int atom_n,
     return (value & mask) << start;
   };
 
-  uint32_t a_format = encode_mxfp_dtype(ab_dtype);
-  uint32_t b_format = a_format;
+  uint32_t a_format = encode_mxfp_dtype(a_dtype);
+  uint32_t b_format = encode_mxfp_dtype(b_dtype);
   uint32_t a_neg = (scale_in_a == -1) ? 1u : 0u;
   uint32_t b_neg = (scale_in_b == -1) ? 1u : 0u;
   uint32_t a_major = a_is_k_major ? 0u : 1u;

--- a/src/op/tcgen5_meta.h
+++ b/src/op/tcgen5_meta.h
@@ -24,7 +24,7 @@ GetTCGEN5MMAMeta(int M, int N, int K, DataType ab_dtype, DataType c_dtype,
                  bool disable_2cta = false, bool disable_ws = false) {
 // TODO (lei) Currently not all shapes / dtypes are supported for TCGEN5MMA.
 // TODO (wt): Add more 2cta-preferred shapes
-// NOTE: 
+// NOTE:
 // 1. In case that other tcgen5mma in the same kernel must use 1-cta,
 //    we should disable 2cta for the current tcgen5mma.
 // 2. For blockscaled gemm, we should disable ws for the current tcgen5mma.
@@ -270,13 +270,11 @@ inline uint32_t GetTCGEN5InstrDesc(int atom_m, int atom_n, int atom_k,
 // Build block-scaled instruction descriptor for mxf8f6f4.block_scale
 // Bit layout: InstrDescriptorBlockScaled (see CUTLASS mma_sm100_desc.hpp)
 // TODO: Support nv-style block-scaled descriptor.
-inline uint32_t GetTCGEN5BlockScaledInstrDesc(int atom_m, int atom_n,
-                                              DataType a_dtype,
-                                              DataType b_dtype,
-                                              bool a_is_k_major,
-                                              bool b_is_k_major, int scale_in_a,
-                                              int scale_in_b, int a_sf_id,
-                                              int b_sf_id) {
+inline uint32_t
+GetTCGEN5BlockScaledInstrDesc(int atom_m, int atom_n, DataType a_dtype,
+                              DataType b_dtype, bool a_is_k_major,
+                              bool b_is_k_major, int scale_in_a, int scale_in_b,
+                              int a_sf_id, int b_sf_id) {
   ICHECK(atom_m % 16 == 0) << "atom_m must be divisible by 16";
   ICHECK(atom_n % 8 == 0) << "atom_n must be divisible by 8";
   ICHECK(scale_in_a == 1 || scale_in_a == -1);

--- a/src/op/utils.cc
+++ b/src/op/utils.cc
@@ -153,6 +153,10 @@ int to_CUtensorMapDataType(DataType dtype) {
   // CUDA 13 adds packed U4 TensorMap formats. The vendored CUDA stub may lag
   // the installed toolkit, so keep the enum value by CUDA's documented order.
   constexpr int kTensorMapDataType16U4Align8B = 13;
+  constexpr int kTensorMapDataType16U4Align16B = 14;
+  if (dtype.is_float4_e2m1_unpacked()) {
+    return kTensorMapDataType16U4Align16B;
+  }
   if (dtype.is_float4_e2m1fn()) {
     return kTensorMapDataType16U4Align8B;
   }

--- a/src/op/utils.h
+++ b/src/op/utils.h
@@ -121,13 +121,36 @@ inline bool IsFP4PackedToUnpackedStorageCopy(DataType global_dtype,
          shared_dtype.is_float4_e2m1_unpacked();
 }
 
-// Valid dtype pairs for TMA global<->shared copies.
-inline bool IsValidTMACopyDtypePair(DataType global_dtype,
+inline bool IsValidTMALoadDtypePair(DataType global_dtype,
                                     DataType shared_dtype) {
+  if (global_dtype.is_float4_e2m1_unpacked() ||
+      shared_dtype.is_float4_e2m1_unpacked()) {
+    return IsFP4PackedToUnpackedStorageCopy(global_dtype, shared_dtype);
+  }
   if (global_dtype == shared_dtype) {
     return true;
   }
-  return IsFP4PackedToUnpackedStorageCopy(global_dtype, shared_dtype);
+  return false;
+}
+
+inline bool IsValidTMAStoreDtypePair(DataType global_dtype,
+                                     DataType shared_dtype) {
+  return global_dtype == shared_dtype &&
+         !shared_dtype.is_float4_e2m1_unpacked();
+}
+
+inline bool IsValidTMADtypePair(bool is_load, DataType global_dtype,
+                                DataType shared_dtype) {
+  if (is_load) {
+    return IsValidTMALoadDtypePair(global_dtype, shared_dtype);
+  }
+  return IsValidTMAStoreDtypePair(global_dtype, shared_dtype);
+}
+
+// Valid dtype pairs for TMA global->shared copies.
+inline bool IsValidTMACopyDtypePair(DataType global_dtype,
+                                    DataType shared_dtype) {
+  return IsValidTMALoadDtypePair(global_dtype, shared_dtype);
 }
 
 // True for packed<->unpacked FP4 storage transitions (either direction).

--- a/src/op/utils.h
+++ b/src/op/utils.h
@@ -114,6 +114,31 @@ inline bool IsLocalVarBuffer(const Buffer &buffer) {
   return buffer.defined() && buffer.scope() == "local.var";
 }
 
+// True when global packed FP4 is copied into f8f6f4/mxf8f6f4 unpacked FP4 SMEM.
+inline bool IsFP4PackedToUnpackedStorageCopy(DataType global_dtype,
+                                             DataType shared_dtype) {
+  return global_dtype.is_float4_e2m1fn() &&
+         shared_dtype.is_float4_e2m1_unpacked();
+}
+
+// Valid dtype pairs for TMA global<->shared copies.
+inline bool IsValidTMACopyDtypePair(DataType global_dtype,
+                                    DataType shared_dtype) {
+  if (global_dtype == shared_dtype) {
+    return true;
+  }
+  return IsFP4PackedToUnpackedStorageCopy(global_dtype, shared_dtype);
+}
+
+// True for packed<->unpacked FP4 storage transitions (either direction).
+inline bool IsFP4StorageCrossCopy(DataType src_dtype, DataType dst_dtype) {
+  if (src_dtype == dst_dtype) {
+    return false;
+  }
+  return IsFP4PackedToUnpackedStorageCopy(src_dtype, dst_dtype) ||
+         IsFP4PackedToUnpackedStorageCopy(dst_dtype, src_dtype);
+}
+
 } // namespace tl
 } // namespace tvm
 

--- a/src/op/utils.h
+++ b/src/op/utils.h
@@ -153,13 +153,11 @@ inline bool IsValidTMACopyDtypePair(DataType global_dtype,
   return IsValidTMALoadDtypePair(global_dtype, shared_dtype);
 }
 
-// True for packed<->unpacked FP4 storage transitions (either direction).
-inline bool IsFP4StorageCrossCopy(DataType src_dtype, DataType dst_dtype) {
-  if (src_dtype == dst_dtype) {
-    return false;
-  }
-  return IsFP4PackedToUnpackedStorageCopy(src_dtype, dst_dtype) ||
-         IsFP4PackedToUnpackedStorageCopy(dst_dtype, src_dtype);
+// True only for the supported TMA load transition from packed global FP4 to
+// unpacked shared FP4. The reverse store direction is not a valid TMA path.
+inline bool IsFP4UnpackLoad(const Buffer &src, const Buffer &dst) {
+  return IsGlobalBuffer(src) && IsSharedBuffer(dst) &&
+         IsFP4PackedToUnpackedStorageCopy(src->dtype, dst->dtype);
 }
 
 } // namespace tl

--- a/src/tl_templates/cuda/cuda_fp4.h
+++ b/src/tl_templates/cuda/cuda_fp4.h
@@ -44,6 +44,14 @@ struct fp4_e2_t {
   TL_DEVICE operator __half() const { return __half(float(*this)); }
 };
 
+// Tag for tcgen05 unpacked FP4 shared-memory layout. The hardware atom carries
+// 16 4-bit payload values in the low 64 bits of a 128-bit aligned region.
+// See:
+// https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#tcgen05-packing-formats-mxf8f6f4-smem
+struct float4_e2m1_unpacked_t {
+  uint8_t __x;
+};
+
 class fp4_e2_2_t {
 public:
   __nv_fp4x2_storage_t __x;

--- a/testing/python/language/test_tilelang_language_float4_e2m1_unpacked_dtype.py
+++ b/testing/python/language/test_tilelang_language_float4_e2m1_unpacked_dtype.py
@@ -1,7 +1,13 @@
 """Tests for float4_e2m1_unpacked (CUTLASS float_e2m1_unpacksmem_t)."""
 
+import pytest
+
+import tilelang
+import tilelang.testing
 import tilelang.language as T
 from tilelang import tvm as tvm
+from tilelang import _ffi_api
+from tvm import DataType
 
 
 def test_float4_e2m1_unpacked_dtype_properties():
@@ -55,6 +61,48 @@ def test_float4_e2m1_unpacked_dtype_helpers():
     assert is_float4("float4_e2m1fn")
     assert is_float4("custom[float4_e2m1_unpacked]8")
     assert not is_float4(T.float16)
+
+
+@tilelang.testing.requires_cuda
+def test_float4_simt_copy_bans_packed_to_unpacked():
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 128), T.float4_e2m1fn),
+    ):
+        with T.Kernel(T.ceildiv(128, 64), T.ceildiv(64, 32), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((32, 64), T.float4_e2m1_unpacked)
+            T.copy(A[by * 32, bx * 64], A_shared)
+
+    with pytest.raises(tvm.TVMError, match="SIMT copy between float4_e2m1fn"):
+        tilelang.compile(main, target="cuda")
+
+
+def _decode_tcgen05_formats(desc: int) -> tuple[int, int]:
+    return (desc >> 7) & 0x7, (desc >> 10) & 0x7
+
+
+def test_tcgen05_instr_desc_fp4_unpacked_x_fp8():
+    fp4 = DataType("custom[float4_e2m1_unpacked]8")
+    fp8 = DataType("float8_e4m3fn")
+    f32 = DataType("float32")
+    desc = int(_ffi_api.get_tcgen5_instr_desc(128, 128, 32, fp4, fp8, f32, True, True, 1, 1))
+    a_format, b_format = _decode_tcgen05_formats(desc)
+    assert a_format == 5
+    assert b_format == 0
+
+
+def test_tcgen05_blockscaled_instr_desc_mxfp4_unpacked_x_mxfp8():
+    fp4 = DataType("custom[float4_e2m1_unpacked]8")
+    fp8 = DataType("float8_e4m3fn")
+    desc = int(
+        _ffi_api.get_tcgen5_blockscaled_instr_desc(
+            128, 128, fp4, fp8, True, True, 1, 1, 0, 0
+        )
+    )
+    a_format, b_format = _decode_tcgen05_formats(desc)
+    assert a_format == 5
+    assert b_format == 0
+    assert (desc >> 23) & 0x1 == 1  # scale_format = E8M0
 
 
 if __name__ == "__main__":

--- a/testing/python/language/test_tilelang_language_float4_e2m1_unpacked_dtype.py
+++ b/testing/python/language/test_tilelang_language_float4_e2m1_unpacked_dtype.py
@@ -1,4 +1,4 @@
-"""Tests for float4_e2m1_unpacked (CUTLASS float_e2m1_unpacksmem_t)."""
+"""Tests for the FP4 E2M1 unpacked shared-memory dtype."""
 
 import pytest
 
@@ -18,18 +18,12 @@ def test_float4_e2m1_unpacked_dtype_properties():
     assert dt.lanes == 1
 
 
-def test_float4_e2m1_unpacked_vector_lanes():
-    dt2 = T.float4_e2m1_unpackedx2
-    assert dt2.bits == 8
-    assert int(dt2.type_code) == 131
-    assert dt2.lanes == 2
-
-
-def test_float4_e2m1_unpacked_tir_cast():
+def test_float4_e2m1_unpacked_tir_dtype_tag():
     from tilelang import language as T_lang
 
     @T_lang.prim_func
     def main():
+        # IR-level tag only; runtime numeric conversion is intentionally absent.
         T_lang.evaluate(T_lang.float4_e2m1_unpacked(0.0))
 
     assert main.body.value.dtype.is_float4_e2m1_unpacked()
@@ -55,7 +49,7 @@ def test_float4_e2m1_unpacked_dtype_helpers():
     assert not unpacked.is_float4_e2m1fn()
     assert unpacked.is_float4()
     assert T.float4_e2m1fnx2.is_float4()
-    assert T.float4_e2m1_unpackedx4.is_float4()
+    assert not hasattr(T, "float4_e2m1_unpackedx2")
     assert is_float4_e2m1fn(packed)
     assert is_float4_e2m1_unpacked(unpacked)
     assert is_float4("float4_e2m1fn")
@@ -103,8 +97,7 @@ def test_tcgen05_blockscaled_instr_desc_mxfp4_unpacked_x_mxfp8():
 
 if __name__ == "__main__":
     test_float4_e2m1_unpacked_dtype_properties()
-    test_float4_e2m1_unpacked_vector_lanes()
-    test_float4_e2m1_unpacked_tir_cast()
+    test_float4_e2m1_unpacked_tir_dtype_tag()
     test_float4_e2m1_unpacked_distinct_from_packed()
     test_float4_e2m1_unpacked_dtype_helpers()
     print("ok")

--- a/testing/python/language/test_tilelang_language_float4_e2m1_unpacked_dtype.py
+++ b/testing/python/language/test_tilelang_language_float4_e2m1_unpacked_dtype.py
@@ -94,11 +94,7 @@ def test_tcgen05_instr_desc_fp4_unpacked_x_fp8():
 def test_tcgen05_blockscaled_instr_desc_mxfp4_unpacked_x_mxfp8():
     fp4 = DataType("custom[float4_e2m1_unpacked]8")
     fp8 = DataType("float8_e4m3fn")
-    desc = int(
-        _ffi_api.get_tcgen5_blockscaled_instr_desc(
-            128, 128, fp4, fp8, True, True, 1, 1, 0, 0
-        )
-    )
+    desc = int(_ffi_api.get_tcgen5_blockscaled_instr_desc(128, 128, fp4, fp8, True, True, 1, 1, 0, 0))
     a_format, b_format = _decode_tcgen05_formats(desc)
     assert a_format == 5
     assert b_format == 0

--- a/testing/python/language/test_tilelang_language_float4_e2m1_unpacked_dtype.py
+++ b/testing/python/language/test_tilelang_language_float4_e2m1_unpacked_dtype.py
@@ -67,7 +67,7 @@ def test_float4_simt_copy_bans_packed_to_unpacked():
             A_shared = T.alloc_shared((32, 64), T.float4_e2m1_unpacked)
             T.copy(A[by * 32, bx * 64], A_shared)
 
-    with pytest.raises(tvm.TVMError, match="SIMT copy between float4_e2m1fn"):
+    with pytest.raises(tvm.TVMError, match="SIMT copy from packed global float4_e2m1fn"):
         tilelang.compile(main, target="cuda")
 
 

--- a/testing/python/language/test_tilelang_language_tma_copy.py
+++ b/testing/python/language/test_tilelang_language_tma_copy.py
@@ -260,14 +260,14 @@ def run_gemm_tma_copy_store(num_stages):
     profiler.assert_allclose(ref_program, atol=1e-2, rtol=1e-2)
 
 
-def fp4_tma_copy_roundtrip(M=128, N=256, block_M=64, block_N=128):
+def fp4_tma_copy_roundtrip(M=128, N=256, block_M=64, block_N=128, smem_dtype=T.float4_e2m1fn):
     @T.prim_func
     def main(
         A: T.Tensor((M, N), T.float4_e2m1fn),
         B: T.Tensor((M, N), T.float4_e2m1fn),
     ):
         with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
-            A_shared = T.alloc_shared((block_M, block_N), T.float4_e2m1fn)
+            A_shared = T.alloc_shared((block_M, block_N), smem_dtype)
             mbar = T.alloc_barrier(128)
             T.tma_copy(A[by * block_M, bx * block_N], A_shared, barrier=mbar)
             T.barrier_arrive(mbar)
@@ -278,15 +278,83 @@ def fp4_tma_copy_roundtrip(M=128, N=256, block_M=64, block_N=128):
     return main
 
 
-def run_fp4_tma_copy_roundtrip():
+def fp4_tma_copy_unpacked_smem_load(M=128, N=256, block_M=64, block_N=128):
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), T.float4_e2m1fn),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_N), T.float4_e2m1_unpacked)
+            mbar = T.alloc_barrier(128)
+            T.tma_copy(
+                A[by * block_M, bx * block_N],
+                A_shared,
+                barrier=mbar,
+            )
+            T.barrier_arrive(mbar)
+            T.mbarrier_wait_parity(mbar, 0)
+
+    return main
+
+
+def _fp4_tma_descriptor_init_block(host_source, desc_name):
     import re
+
+    marker = f"[0].v_ptr) = {desc_name};"
+    start = host_source.find(marker)
+    assert start >= 0, f"Missing {desc_name} TensorMap initialization"
+    end = host_source.find("TVMFFIFunctionCall(__tvm_tensormap_create_tiled_packed", start)
+    assert end >= 0, f"Missing {desc_name} TensorMap creation call"
+    return host_source[start:end]
+
+
+def _fp4_tma_stack_int(block, index):
+    import re
+
+    match = re.search(rf"\[{index}\]\.v_int64\)\s*=\s*\(\(int64_t\)(-?\d+)\);", block)
+    assert match, f"Missing stack[{index}] integer assignment in:\n{block}"
+    return int(match.group(1))
+
+
+def _assert_fp4_packed_tma_descriptor(host_source, desc_name):
+    expected_tma_args = {
+        1: 13,  # CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B
+        2: 2,
+        4: 256,
+        5: 128,
+        6: 1,
+        7: 128,
+        8: 128,
+        9: 64,
+        10: 1,
+        11: 1,
+        12: 0,
+        13: 2,  # CU_TENSOR_MAP_SWIZZLE_64B
+        14: 2,
+        15: 0,
+    }
+    block = _fp4_tma_descriptor_init_block(host_source, desc_name)
+    for index, expected in expected_tma_args.items():
+        assert _fp4_tma_stack_int(block, index) == expected
+
+
+def _assert_fp4_unpacked_tma_descriptor(host_source, desc_name, *, expect_swizzle=None):
+    block = _fp4_tma_descriptor_init_block(host_source, desc_name)
+    assert _fp4_tma_stack_int(block, 1) == 14  # CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B
+    assert _fp4_tma_stack_int(block, 8) == 128  # 128-element inner box for 8-bit storage
+    if expect_swizzle is not None:
+        assert _fp4_tma_stack_int(block, 13) == expect_swizzle
+
+
+def run_fp4_tma_copy_roundtrip(smem_dtype=T.float4_e2m1fn):
     import torch
 
     M, N = 128, 256
-    program = fp4_tma_copy_roundtrip(M=M, N=N)
+    program = fp4_tma_copy_roundtrip(M=M, N=N, smem_dtype=smem_dtype)
     kernel = tilelang.compile(
         program,
         out_idx=[1],
+        target="cuda",
         pass_configs={tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True},
     )
     device_source = kernel.get_kernel_source()
@@ -296,42 +364,12 @@ def run_fp4_tma_copy_roundtrip():
     assert "tl::tma_store" in device_source
     assert host_source.count("__tvm_tensormap_create_tiled") >= 2
 
-    def descriptor_init_block(desc_name):
-        marker = f"[0].v_ptr) = {desc_name};"
-        start = host_source.find(marker)
-        assert start >= 0, f"Missing {desc_name} TensorMap initialization"
-        end = host_source.find("TVMFFIFunctionCall(__tvm_tensormap_create_tiled_packed", start)
-        assert end >= 0, f"Missing {desc_name} TensorMap creation call"
-        return host_source[start:end]
-
-    def stack_int(block, index):
-        match = re.search(rf"\[{index}\]\.v_int64\)\s*=\s*\(\(int64_t\)(-?\d+)\);", block)
-        assert match, f"Missing stack[{index}] integer assignment in:\n{block}"
-        return int(match.group(1))
-
-    # create_tma_descriptor(data_type, rank, global_addr,
-    #   global_shape..., global_stride..., smem_box..., smem_stride...,
-    #   interleave, swizzle, l2_promotion, oob_fill)
-    expected_tma_args = {
-        1: 13,  # CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN8B
-        2: 2,  # rank
-        4: 256,  # global_shape[0], reversed innermost dimension
-        5: 128,  # global_shape[1]
-        6: 1,  # raw innermost stride, ignored by CUDA encode
-        7: 128,  # next global stride in bytes: 256 fp4 elements == 128 bytes
-        8: 128,  # smem_box[0]: 128 fp4 elements == 64 bytes
-        9: 64,  # smem_box[1]
-        10: 1,  # element stride[0]
-        11: 1,  # element stride[1]
-        12: 0,  # CU_TENSOR_MAP_INTERLEAVE_NONE
-        13: 2,  # CU_TENSOR_MAP_SWIZZLE_64B
-        14: 2,  # CU_TENSOR_MAP_L2_PROMOTION_L2_128B
-        15: 0,  # CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE
-    }
-    for desc_name in ("A_desc", "B_desc"):
-        block = descriptor_init_block(desc_name)
-        for index, expected in expected_tma_args.items():
-            assert stack_int(block, index) == expected
+    if smem_dtype == T.float4_e2m1fn:
+        for desc_name in ("A_desc", "B_desc"):
+            _assert_fp4_packed_tma_descriptor(host_source, desc_name)
+    else:
+        _assert_fp4_unpacked_tma_descriptor(host_source, "A_desc")
+        _assert_fp4_unpacked_tma_descriptor(host_source, "B_desc")
 
     a = torch.randint(-128, 128, (M, N // 2), device="cuda", dtype=torch.int8)
     b = kernel(a)
@@ -360,10 +398,37 @@ def test_copy_prefer_tma_lowers_as_synchronous_tma_load():
     assert ".wait(0)" in device_source
 
 
+def run_fp4_tma_copy_unpacked_smem_load():
+    program = fp4_tma_copy_unpacked_smem_load()
+    kernel = tilelang.compile(
+        program,
+        target="cuda",
+        pass_configs={tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True},
+    )
+    device_source = kernel.get_kernel_source()
+    host_source = kernel.get_host_source()
+    assert "CUtensorMap" in device_source
+    _assert_fp4_unpacked_tma_descriptor(host_source, "A_desc")
+    # 64 x 128 logical FP4 elems -> 4096 transaction bytes (4b/elem), not 8192.
+    assert "expect_transaction(4096)" in device_source
+
+
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_ge(10, 0)
-def test_fp4_tma_copy_roundtrip():
-    run_fp4_tma_copy_roundtrip()
+def test_fp4_tma_copy_roundtrip_packed_smem():
+    run_fp4_tma_copy_roundtrip(smem_dtype=T.float4_e2m1fn)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(10, 0)
+def test_fp4_tma_copy_roundtrip_unpacked_smem():
+    run_fp4_tma_copy_roundtrip(smem_dtype=T.float4_e2m1_unpacked)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(10, 0)
+def test_fp4_tma_copy_unpacked_smem_load_descriptor_codegen():
+    run_fp4_tma_copy_unpacked_smem_load()
 
 
 @tilelang.testing.requires_cuda

--- a/testing/python/language/test_tilelang_language_tma_copy.py
+++ b/testing/python/language/test_tilelang_language_tma_copy.py
@@ -298,7 +298,6 @@ def fp4_tma_copy_unpacked_smem_load(M=128, N=256, block_M=64, block_N=128):
 
 
 def _fp4_tma_descriptor_init_block(host_source, desc_name):
-    import re
 
     marker = f"[0].v_ptr) = {desc_name};"
     start = host_source.find(marker)

--- a/testing/python/language/test_tilelang_language_tma_copy.py
+++ b/testing/python/language/test_tilelang_language_tma_copy.py
@@ -12,6 +12,8 @@ For TMA stores (shared -> global):
   No barrier argument is needed for stores.
 """
 
+import pytest
+
 from tilelang import tvm as tvm
 import tilelang.testing
 import tilelang.language as T
@@ -302,6 +304,27 @@ def fp4_tma_copy_unpacked_smem_load(M=128, N=256, block_M=64, block_N=128):
     return main
 
 
+def fp4_tma_copy_unpacked_smem_store(M=128, N=256, block_M=64, block_N=128):
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), T.float4_e2m1fn),
+        B: T.Tensor((M, N), T.float4_e2m1fn),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_N), T.float4_e2m1_unpacked)
+            mbar = T.alloc_barrier(128)
+            T.tma_copy(
+                A[by * block_M, bx * block_N],
+                A_shared,
+                barrier=mbar,
+            )
+            T.barrier_arrive(mbar)
+            T.mbarrier_wait_parity(mbar, 0)
+            T.tma_copy(A_shared, B[by * block_M, bx * block_N])
+
+    return main
+
+
 def _fp4_tma_descriptor_init_block(host_source, desc_name):
 
     marker = f"[0].v_ptr) = {desc_name};"
@@ -387,6 +410,16 @@ def test_fp4_unpacksmem_tma_descriptor_uses_align16b():
     assert 'A_shared = T.alloc_buffer((8192,), "custom[float4_e2m1_unpacked]"' in device_ir
     assert '["__tvm_tensormap_create_tiled", A_desc, 14,' in host_ir
     assert 'T.call_packed("__tvm_tensormap_create_tiled", A_desc, 14,' in host_ir
+
+
+def test_fp4_unpacksmem_tma_store_is_rejected():
+    program = fp4_tma_copy_unpacked_smem_store()
+    with pytest.raises(tvm.TVMError, match="only supports float4_e2m1_unpacked as an FP4 unpack load"):
+        tilelang.lower(
+            program,
+            target={"kind": "cuda", "arch": "sm_100"},
+            enable_device_compile=False,
+        )
 
 
 def test_copy_prefer_tma_lowers_as_synchronous_tma_load():

--- a/testing/python/language/test_tilelang_language_tma_copy.py
+++ b/testing/python/language/test_tilelang_language_tma_copy.py
@@ -260,14 +260,19 @@ def run_gemm_tma_copy_store(num_stages):
     profiler.assert_allclose(ref_program, atol=1e-2, rtol=1e-2)
 
 
-def fp4_tma_copy_roundtrip(M=128, N=256, block_M=64, block_N=128, smem_dtype=T.float4_e2m1fn):
+def fp4_tma_copy_roundtrip(
+    M=128,
+    N=256,
+    block_M=64,
+    block_N=128,
+):
     @T.prim_func
     def main(
         A: T.Tensor((M, N), T.float4_e2m1fn),
         B: T.Tensor((M, N), T.float4_e2m1fn),
     ):
         with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
-            A_shared = T.alloc_shared((block_M, block_N), smem_dtype)
+            A_shared = T.alloc_shared((block_M, block_N), T.float4_e2m1fn)
             mbar = T.alloc_barrier(128)
             T.tma_copy(A[by * block_M, bx * block_N], A_shared, barrier=mbar)
             T.barrier_arrive(mbar)
@@ -345,15 +350,14 @@ def _assert_fp4_unpacked_tma_descriptor(host_source, desc_name, *, expect_swizzl
         assert _fp4_tma_stack_int(block, 13) == expect_swizzle
 
 
-def run_fp4_tma_copy_roundtrip(smem_dtype=T.float4_e2m1fn):
+def run_fp4_tma_copy_roundtrip():
     import torch
 
     M, N = 128, 256
-    program = fp4_tma_copy_roundtrip(M=M, N=N, smem_dtype=smem_dtype)
+    program = fp4_tma_copy_roundtrip(M=M, N=N)
     kernel = tilelang.compile(
         program,
         out_idx=[1],
-        target="cuda",
         pass_configs={tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True},
     )
     device_source = kernel.get_kernel_source()
@@ -362,17 +366,27 @@ def run_fp4_tma_copy_roundtrip(smem_dtype=T.float4_e2m1fn):
     assert "tl::tma_load" in device_source
     assert "tl::tma_store" in device_source
     assert host_source.count("__tvm_tensormap_create_tiled") >= 2
-
-    if smem_dtype == T.float4_e2m1fn:
-        for desc_name in ("A_desc", "B_desc"):
-            _assert_fp4_packed_tma_descriptor(host_source, desc_name)
-    else:
-        _assert_fp4_unpacked_tma_descriptor(host_source, "A_desc")
-        _assert_fp4_unpacked_tma_descriptor(host_source, "B_desc")
+    for desc_name in ("A_desc", "B_desc"):
+        _assert_fp4_packed_tma_descriptor(host_source, desc_name)
 
     a = torch.randint(-128, 128, (M, N // 2), device="cuda", dtype=torch.int8)
     b = kernel(a)
     assert torch.equal(b.view(torch.int8), a)
+
+
+def test_fp4_unpacksmem_tma_descriptor_uses_align16b():
+    program = fp4_tma_copy_unpacked_smem_load()
+    artifact = tilelang.lower(
+        program,
+        target={"kind": "cuda", "arch": "sm_100"},
+        enable_device_compile=False,
+    )
+    host_ir = str(artifact.host_mod)
+    device_ir = str(artifact.device_mod)
+    assert 'T.handle("float4_e2m1fn", "global")' in host_ir
+    assert 'A_shared = T.alloc_buffer((8192,), "custom[float4_e2m1_unpacked]"' in device_ir
+    assert '["__tvm_tensormap_create_tiled", A_desc, 14,' in host_ir
+    assert 'T.call_packed("__tvm_tensormap_create_tiled", A_desc, 14,' in host_ir
 
 
 def test_copy_prefer_tma_lowers_as_synchronous_tma_load():
@@ -415,13 +429,7 @@ def run_fp4_tma_copy_unpacked_smem_load():
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_ge(10, 0)
 def test_fp4_tma_copy_roundtrip_packed_smem():
-    run_fp4_tma_copy_roundtrip(smem_dtype=T.float4_e2m1fn)
-
-
-@tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_ge(10, 0)
-def test_fp4_tma_copy_roundtrip_unpacked_smem():
-    run_fp4_tma_copy_roundtrip(smem_dtype=T.float4_e2m1_unpacked)
+    run_fp4_tma_copy_roundtrip()
 
 
 @tilelang.testing.requires_cuda

--- a/tilelang/cuda/intrinsics/macro/mma_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/mma_macro_generator.py
@@ -60,6 +60,7 @@ class TensorCoreIntrinEmitter:
         "float6_e2m3fn": "e2m3",
         "float6_e3m2fn": "e3m2",
         "float4_e2m1fn": "e2m1",
+        "custom[float4_e2m1_unpacked]8": "e2m1",
         "custom[tfloat32]": "tf32",
     }
 
@@ -141,6 +142,8 @@ class TensorCoreIntrinEmitter:
             self.b_dtype_abbrv = "tf32"
 
     def _get_dtype_abbrv(self, dtype: str) -> str:
+        if "float4_e2m1_unpacked" in dtype:
+            return "e2m1"
         if dtype not in self.dtype_abbrv:
             raise ValueError(f"Unsupported dtype: {dtype}")
         return self.dtype_abbrv[dtype]

--- a/tilelang/cuda/intrinsics/macro/tcgen05_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/tcgen05_macro_generator.py
@@ -7,6 +7,8 @@ from tvm import DataType
 from tvm.tirx import PrimExpr, Buffer, Var, BufferLoad, BufferRegion
 from tilelang import tvm as tvm
 from tilelang import _ffi_api
+from tilelang.language import dtypes as _dtypes  # noqa: F401  # register dtype helpers
+from tilelang.language.dtypes import get_tvm_dtype
 from tilelang.utils import is_tensor_memory
 from tilelang.layout import (
     Layout,
@@ -38,8 +40,8 @@ class TCGEN05DescriptorParams:
     """Number of elements per swizzle atom along the non-K dimension."""
     k_atom_size: int
     """``max(swizzle_atom_elems // micro_size_k, 1)``."""
-    elems_in_bytes: int
-    """Byte width of a single element: ``(DataType(dtype).bits + 7) // 8``."""
+    elem_bits: int
+    """Bit width of a single logical element."""
     is_k_major: bool
     """Whether the matrix is stored in K-major order (affects offset formula branching)."""
 
@@ -84,6 +86,21 @@ class SwizzleMode(IntEnum):
             return 1
 
 
+def _bytes_to_elements(byte_count: int, elem_bits: int) -> int:
+    # Use bit widths for offsets so sub-byte dtypes such as FP4 stay packed.
+    bits = byte_count * 8
+    if bits % elem_bits != 0:
+        raise ValueError(f"{byte_count} bytes cannot be represented as whole elements of {elem_bits}-bit dtype")
+    return bits // elem_bits
+
+
+def _elements_to_bytes(elem_count: int, elem_bits: int) -> int:
+    bits = elem_count * elem_bits
+    if isinstance(elem_count, int) and bits % 8 != 0:
+        raise ValueError(f"{elem_count} elements of {elem_bits}-bit dtype do not end on a byte boundary")
+    return bits // 8
+
+
 # derive from MMAIntrinEmitter as some layouts are the same
 class TensorCoreIntrinEmitter(MMAIntrinEmitter):
     """Intrinsic emitter for Blackwell (SM100) TCGEN5MMA instructions.
@@ -98,6 +115,12 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
 
     a_shared_layout: Layout = None
     b_shared_layout: Layout = None
+
+    @staticmethod
+    def _smem_elems_in_bytes(dtype) -> int:
+        """Byte width of one SMEM element for TCGEN05 descriptor offset math."""
+        dt = get_tvm_dtype(dtype)
+        return (dt.bits + 7) // 8
 
     def __init__(
         self,
@@ -149,14 +172,21 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
     def _initialize_k_dim(self, a_dtype=T.float16):
         if isinstance(a_dtype, str):
             a_dtype = DataType(a_dtype)
-        if a_dtype.bits == 6 or str(a_dtype) == "float4_e2m1fn":
+        if a_dtype.bits == 6 or a_dtype.is_float4():
             if self.chunk % 32 != 0:
                 raise ValueError(f"TCGEN5MMA FP{a_dtype.bits} requires chunk to be a multiple of 32, got {self.chunk}")
             self.k_dim = 32
             return
         super()._initialize_k_dim(a_dtype)
 
-    def _determinate_swizzle_mode(self, buffer: Buffer, layout: Layout) -> SwizzleMode:
+    @staticmethod
+    def _as_buffer(buf_or_region):
+        if isinstance(buf_or_region, BufferRegion):
+            return buf_or_region.buffer
+        return buf_or_region
+
+    def _determinate_swizzle_mode(self, buffer, layout: Layout) -> SwizzleMode:
+        buffer = self._as_buffer(buffer)
         # same behavior to src/layout/gemm_layouts.cc::makeGemmABLayoutHopper
         if layout is None or layout.is_equal(make_linear_layout(buffer)):
             return SwizzleMode.NONE
@@ -296,9 +326,10 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         SFA_tmem,
         SFB_tmem,
         mbar,
+        sf_k_start: PrimExpr,
+        sf_a_granularity_k: int,
+        sf_b_granularity_k: int,
         clear_accum: PrimExpr = False,
-        sf_a_id=0,
-        sf_b_id=0,
     ):
         """Emit a block-scaled TCGEN5MMA (SS variant with TMEM scale factors).
 
@@ -315,10 +346,10 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         b_is_k_major = self.b_transposed
         a_swizzle_mode = self._determinate_swizzle_mode(A_buf, self.a_shared_layout)
 
-        elems_in_bytes = (DataType(self.a_dtype).bits + 7) // 8
+        a_elem_bits = get_tvm_dtype(self._as_buffer(A_buf).dtype).bits
 
         if len(self.meta) != 5:
-            self.get_tcgen5_mma_meta(m_dim, n_dim, k_dim, disable_2cta=False)
+            self.get_tcgen5_mma_meta(m_dim, n_dim, k_dim, disable_2cta=False, disable_ws=True)
         if len(self.meta) != 5:
             raise ValueError(
                 f"Unsupported TCGEN5MMA configuration for block-scaled: M={m_dim}, N={n_dim}, "
@@ -327,11 +358,15 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         atom_m, atom_n, _, _, enable_2cta = self.tcgen05_meta_unpacked
         atom_m_per_cta = atom_m // 2 if enable_2cta else atom_m
 
-        a_swizzle_atom_elems = a_swizzle_mode.swizzle_byte_size() // elems_in_bytes
+        a_swizzle_atom_elems = (
+            atom_m_per_cta
+            if a_swizzle_mode.is_none()
+            else _bytes_to_elements(a_swizzle_mode.swizzle_byte_size(), a_elem_bits)
+        )
 
         # Block-scaled A LBO/SBO differ from regular SS (uses atom_m_per_cta instead of m_dim)
-        a_leading_byte_offset = (8 * 8 * elems_in_bytes) if a_is_k_major else (8 * atom_m_per_cta * elems_in_bytes)
-        a_stride_byte_offset = (8 * k_dim * elems_in_bytes) if a_is_k_major else (8 * 8 * elems_in_bytes)
+        a_leading_byte_offset = _elements_to_bytes(8 * 8, a_elem_bits) if a_is_k_major else _elements_to_bytes(8 * atom_m_per_cta, a_elem_bits)
+        a_stride_byte_offset = _elements_to_bytes(8 * k_dim, a_elem_bits) if a_is_k_major else _elements_to_bytes(8 * 8, a_elem_bits)
         if not a_swizzle_mode.is_none():
             if a_is_k_major:
                 a_leading_byte_offset = 16
@@ -340,7 +375,9 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
                 a_m_axis_atoms = atom_m_per_cta // a_swizzle_atom_elems
                 a_leading_byte_offset = k_dim * a_swizzle_mode.swizzle_byte_size() if a_m_axis_atoms > 1 else 0
                 a_stride_byte_offset = (
-                    8 * elems_in_bytes * a_swizzle_atom_elems if a_m_axis_atoms > 1 else 8 * elems_in_bytes * atom_m_per_cta
+                    _elements_to_bytes(8 * a_swizzle_atom_elems, a_elem_bits)
+                    if a_m_axis_atoms > 1
+                    else _elements_to_bytes(8 * atom_m_per_cta, a_elem_bits)
                 )
 
         a_params = TCGEN05DescriptorParams(
@@ -349,7 +386,7 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
             stride_byte_offset=int(a_stride_byte_offset >> 4),
             swizzle_atom_elems=a_swizzle_atom_elems,
             k_atom_size=max(a_swizzle_atom_elems // micro_size_k, 1),
-            elems_in_bytes=elems_in_bytes,
+            elem_bits=a_elem_bits,
             is_k_major=a_is_k_major,
         )
         b_params = self.compute_tcgen05_b_desc_params(B_buf)
@@ -390,12 +427,13 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
             self.init_tcgen05_a_desc(desc_a, A_buf, a_params)
             self.init_tcgen05_b_desc(desc_b, B_buf, b_params)
 
-            _sf_a = tvm.tirx.const(sf_a_id, "int32") if isinstance(sf_a_id, int) else sf_a_id
-            _sf_b = tvm.tirx.const(sf_b_id, "int32") if isinstance(sf_b_id, int) else sf_b_id
-            runtime_instr_desc = base_instr_desc | (_sf_a << 29) | (_sf_b << 4)
+            _sf_k_start = tvm.tirx.const(sf_k_start, "int32") if isinstance(sf_k_start, int) else sf_k_start
             for j in T.unroll(num_inst_n):
                 for i in T.unroll(num_inst_m):
                     for ki in T.unroll(0, num_k_atoms):
+                        runtime_sf_a_id = ((_sf_k_start + ki * micro_size_k) // int(sf_a_granularity_k)) % 4
+                        runtime_sf_b_id = ((_sf_k_start + ki * micro_size_k) // int(sf_b_granularity_k)) % 4
+                        runtime_instr_desc = base_instr_desc | (runtime_sf_a_id << 29) | (runtime_sf_b_id << 4)
                         self.tcgen05_blockscaled_atom(
                             desc_a,
                             desc_b,
@@ -429,7 +467,8 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         desc = _ffi_api.get_tcgen5_blockscaled_instr_desc(
             atom_m,
             atom_n,
-            DataType(self.a_dtype),
+            self.a_dtype,
+            self.b_dtype,
             a_is_k_major,
             b_is_k_major,
             scale_in_a,
@@ -470,7 +509,10 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         n = int(tmem_buf.shape[1])
         k = int(self.chunk)
 
-        meta = self.meta
+        meta = getattr(self, "meta", ())
+        if len(meta) != 5:
+            self.get_tcgen5_mma_meta(m, n, k, disable_2cta=True)
+            meta = self.meta
         if len(meta) != 5:
             raise ValueError(
                 f"Unsupported TCGEN5MMA configuration: M={m}, N={n}, K={k}, A dtype={self.a_dtype}, accum dtype={self.accum_dtype}"
@@ -527,10 +569,16 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
 
         return Layout([m, n], forward)
 
-    def get_tcgen5_mma_meta(self, m: int, n: int, k: int, disable_2cta: bool):
+    def get_tcgen5_mma_meta(self, m: int, n: int, k: int, disable_2cta: bool, disable_ws: bool = False):
         """Query the FFI for TCGEN5MMA atom metadata (atom_m, atom_n, atom_k, enable_ws, enable_2cta), and record them in `self.meta`."""
         self.meta = _ffi_api.get_tcgen5_mma_meta(
-            int(m), int(n), int(k), DataType(self.a_dtype), DataType(self.accum_dtype), bool(disable_2cta)
+            int(m),
+            int(n),
+            int(k),
+            self.a_dtype,
+            self.accum_dtype,
+            bool(disable_2cta),
+            bool(disable_ws),
         )
 
     def get_tcgen5_instr_desc(
@@ -541,8 +589,9 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
             atom_m,
             atom_n,
             atom_k,
-            DataType(self.a_dtype),
-            DataType(self.accum_dtype),
+            self.a_dtype,
+            self.b_dtype,
+            self.accum_dtype,
             a_is_k_major,
             b_is_k_major,
             scale_in_a,
@@ -628,14 +677,14 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         n_dim_per_cta = n_dim // 2 if enable_2cta else n_dim
         k_dim = self.chunk
         micro_size_k = self.micro_size_k
-        elems_in_bytes = (DataType(self.a_dtype).bits + 7) // 8
+        elem_bits = get_tvm_dtype(self._as_buffer(B_buf).dtype).bits
         b_is_k_major = self.b_transposed
 
         b_swizzle_mode = self._determinate_swizzle_mode(B_buf, self.b_shared_layout)
-        b_swizzle_atom_elems = n_dim_per_cta if b_swizzle_mode.is_none() else b_swizzle_mode.swizzle_byte_size() // elems_in_bytes
+        b_swizzle_atom_elems = n_dim_per_cta if b_swizzle_mode.is_none() else _bytes_to_elements(b_swizzle_mode.swizzle_byte_size(), elem_bits)
 
-        b_leading_byte_offset = (8 * 8 * elems_in_bytes) if b_is_k_major else (8 * n_dim_per_cta * elems_in_bytes)
-        b_stride_byte_offset = (8 * k_dim * elems_in_bytes) if b_is_k_major else (0 if n_dim_per_cta == 8 else (8 * 8 * elems_in_bytes))
+        b_leading_byte_offset = _elements_to_bytes(8 * 8, elem_bits) if b_is_k_major else _elements_to_bytes(8 * n_dim_per_cta, elem_bits)
+        b_stride_byte_offset = _elements_to_bytes(8 * k_dim, elem_bits) if b_is_k_major else (0 if n_dim_per_cta == 8 else _elements_to_bytes(8 * 8, elem_bits))
         if not b_swizzle_mode.is_none():
             if b_is_k_major:
                 b_leading_byte_offset = 16
@@ -645,11 +694,11 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
                 if b_n_axis_atoms <= 1:
                     b_leading_byte_offset = 0
                 else:
-                    b_leading_byte_offset = 8 * 8 * elems_in_bytes * k_dim
+                    b_leading_byte_offset = _elements_to_bytes(8 * 8 * k_dim, elem_bits)
                 if b_n_axis_atoms <= 1:
-                    b_stride_byte_offset = 8 * elems_in_bytes * n_dim_per_cta
+                    b_stride_byte_offset = _elements_to_bytes(8 * n_dim_per_cta, elem_bits)
                 else:
-                    b_stride_byte_offset = 8 * elems_in_bytes * b_swizzle_atom_elems
+                    b_stride_byte_offset = _elements_to_bytes(8 * b_swizzle_atom_elems, elem_bits)
 
         return TCGEN05DescriptorParams(
             swizzle_mode=int(b_swizzle_mode),
@@ -657,7 +706,7 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
             stride_byte_offset=int(b_stride_byte_offset >> 4),
             swizzle_atom_elems=b_swizzle_atom_elems,
             k_atom_size=max(b_swizzle_atom_elems // micro_size_k, 1),
-            elems_in_bytes=elems_in_bytes,
+            elem_bits=elem_bits,
             is_k_major=b_is_k_major,
         )
 
@@ -674,14 +723,18 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         m_dim = self.block_row_warps * self.warp_row_tiles
         k_dim = self.chunk
         micro_size_k = self.micro_size_k
-        elems_in_bytes = (DataType(self.a_dtype).bits + 7) // 8
+        elem_bits = get_tvm_dtype(self._as_buffer(A_buf).dtype).bits
         a_is_k_major = not self.a_transposed
 
         a_swizzle_mode = self._determinate_swizzle_mode(A_buf, self.a_shared_layout)
-        a_swizzle_atom_elems = a_swizzle_mode.swizzle_byte_size() // elems_in_bytes
+        a_swizzle_atom_elems = (
+            m_dim
+            if a_swizzle_mode.is_none()
+            else _bytes_to_elements(a_swizzle_mode.swizzle_byte_size(), elem_bits)
+        )
 
-        a_leading_byte_offset = (8 * 8 * elems_in_bytes) if a_is_k_major else (8 * m_dim * elems_in_bytes)
-        a_stride_byte_offset = (8 * k_dim * elems_in_bytes) if a_is_k_major else (8 * 8 * elems_in_bytes)
+        a_leading_byte_offset = _elements_to_bytes(8 * 8, elem_bits) if a_is_k_major else _elements_to_bytes(8 * m_dim, elem_bits)
+        a_stride_byte_offset = _elements_to_bytes(8 * k_dim, elem_bits) if a_is_k_major else _elements_to_bytes(8 * 8, elem_bits)
         if not a_swizzle_mode.is_none():
             if a_is_k_major:
                 a_leading_byte_offset = 16
@@ -693,9 +746,9 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
                 else:
                     a_leading_byte_offset = k_dim * a_swizzle_mode.swizzle_byte_size()
                 if a_m_axis_atoms <= 1:
-                    a_stride_byte_offset = 8 * elems_in_bytes * m_dim
+                    a_stride_byte_offset = _elements_to_bytes(8 * m_dim, elem_bits)
                 else:
-                    a_stride_byte_offset = 8 * elems_in_bytes * a_swizzle_atom_elems
+                    a_stride_byte_offset = _elements_to_bytes(8 * a_swizzle_atom_elems, elem_bits)
 
         return TCGEN05DescriptorParams(
             swizzle_mode=int(a_swizzle_mode),
@@ -703,7 +756,7 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
             stride_byte_offset=int(a_stride_byte_offset >> 4),
             swizzle_atom_elems=a_swizzle_atom_elems,
             k_atom_size=max(a_swizzle_atom_elems // micro_size_k, 1),
-            elems_in_bytes=elems_in_bytes,
+            elem_bits=elem_bits,
             is_k_major=a_is_k_major,
         )
 
@@ -828,10 +881,10 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         m_dim = self.block_row_warps * self.warp_row_tiles
         micro_size_k = self.micro_size_k
         k_dim = self.chunk
-        accum_dtype_in_bits = DataType(self.accum_dtype).bits
+        accum_dtype_in_bits = get_tvm_dtype(self.accum_dtype).bits
         a_dtype_abbrv = self.a_dtype_abbrv
-        a_elems_in_bytes = a_params.elems_in_bytes
-        b_elems_in_bytes = b_params.elems_in_bytes
+        a_elem_bits = a_params.elem_bits
+        b_elem_bits = b_params.elem_bits
         ak_atom_size = a_params.k_atom_size
         bk_atom_size = b_params.k_atom_size
         a_swizzle_atom_elems = a_params.swizzle_atom_elems
@@ -859,8 +912,8 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
                 k_dim if n_dim_per_cta // b_swizzle_atom_elems > 1 else 1
             )
 
-        A_byte_offset = A_elem_offset * a_elems_in_bytes
-        B_byte_offset = B_elem_offset * b_elems_in_bytes
+        A_byte_offset = _elements_to_bytes(A_elem_offset, a_elem_bits)
+        B_byte_offset = _elements_to_bytes(B_elem_offset, b_elem_bits)
         tmem_col_step = atom_n // (128 // atom_m_per_cta)
         C_offset = (inst_m_idx * n_dim + inst_n_idx * tmem_col_step) * accum_dtype_in_bits // 32
 
@@ -930,10 +983,10 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         n_dim_per_cta = n_dim // 2 if enable_2cta else n_dim
         micro_size_k = self.micro_size_k
         k_dim = self.chunk
-        a_dtype_in_bits = DataType(self.a_dtype).bits
-        accum_dtype_in_bits = DataType(self.accum_dtype).bits
+        a_dtype_in_bits = get_tvm_dtype(self.a_dtype).bits
+        accum_dtype_in_bits = get_tvm_dtype(self.accum_dtype).bits
         a_dtype_abbrv = self.a_dtype_abbrv
-        b_elems_in_bytes = b_params.elems_in_bytes
+        b_elem_bits = b_params.elem_bits
         bk_atom_size = b_params.k_atom_size
         b_swizzle_atom_elems = b_params.swizzle_atom_elems
         mask_zero = T.cast(0, T.int32)
@@ -955,7 +1008,7 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
             B_elem_offset = ki * b_swizzle_atom_elems * micro_size_k + inst_n_idx * atom_n * (
                 k_dim if n_dim_per_cta // b_swizzle_atom_elems > 1 else 1
             )
-        B_byte_offset = B_elem_offset * b_elems_in_bytes
+        B_byte_offset = _elements_to_bytes(B_elem_offset, b_elem_bits)
 
         tmem_col_step = atom_n // (128 // atom_m_per_cta)
         C_offset = (inst_m_idx * n_dim + inst_n_idx * tmem_col_step) * accum_dtype_in_bits // 32
@@ -1016,17 +1069,18 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         clear_accum : PrimExpr
             Whether to zero the accumulator on the first K atom.
         """
-        atom_m, atom_n, _, enable_ws, enable_2cta = self.tcgen05_meta_unpacked
+        atom_m, atom_n, _, _enable_ws, enable_2cta = self.tcgen05_meta_unpacked
+        del _enable_ws  # block-scaled TCGEN05 does not support .ws
         atom_m_per_cta = atom_m // 2 if enable_2cta else atom_m
         n_dim = self.block_col_warps * self.warp_col_tiles
         n_dim_per_cta = n_dim // 2 if enable_2cta else n_dim
         m_dim = self.block_row_warps * self.warp_row_tiles
         micro_size_k = self.micro_size_k
         k_dim = self.chunk
-        accum_dtype_in_bits = DataType(self.accum_dtype).bits
+        accum_dtype_in_bits = get_tvm_dtype(self.accum_dtype).bits
         a_dtype_abbrv = self.a_dtype_abbrv
-        a_elems_in_bytes = a_params.elems_in_bytes
-        b_elems_in_bytes = b_params.elems_in_bytes
+        a_elem_bits = a_params.elem_bits
+        b_elem_bits = b_params.elem_bits
         ak_atom_size = a_params.k_atom_size
         bk_atom_size = b_params.k_atom_size
         a_swizzle_atom_elems = a_params.swizzle_atom_elems
@@ -1052,8 +1106,8 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
                 k_dim if n_dim_per_cta // b_swizzle_atom_elems > 1 else 1
             )
 
-        A_byte_offset = A_elem_offset * a_elems_in_bytes
-        B_byte_offset = B_elem_offset * b_elems_in_bytes
+        A_byte_offset = _elements_to_bytes(A_elem_offset, a_elem_bits)
+        B_byte_offset = _elements_to_bytes(B_elem_offset, b_elem_bits)
         tmem_col_step = atom_n // (128 // atom_m_per_cta)
         C_offset = (inst_m_idx * n_dim + inst_n_idx * tmem_col_step) * accum_dtype_in_bits // 32
 
@@ -1076,7 +1130,6 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
                 0,
                 0,
                 0,
-                enable_ws,
                 enable_2cta,
             )
 

--- a/tilelang/cuda/intrinsics/macro/tcgen05_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/tcgen05_macro_generator.py
@@ -359,13 +359,13 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         atom_m_per_cta = atom_m // 2 if enable_2cta else atom_m
 
         a_swizzle_atom_elems = (
-            atom_m_per_cta
-            if a_swizzle_mode.is_none()
-            else _bytes_to_elements(a_swizzle_mode.swizzle_byte_size(), a_elem_bits)
+            atom_m_per_cta if a_swizzle_mode.is_none() else _bytes_to_elements(a_swizzle_mode.swizzle_byte_size(), a_elem_bits)
         )
 
         # Block-scaled A LBO/SBO differ from regular SS (uses atom_m_per_cta instead of m_dim)
-        a_leading_byte_offset = _elements_to_bytes(8 * 8, a_elem_bits) if a_is_k_major else _elements_to_bytes(8 * atom_m_per_cta, a_elem_bits)
+        a_leading_byte_offset = (
+            _elements_to_bytes(8 * 8, a_elem_bits) if a_is_k_major else _elements_to_bytes(8 * atom_m_per_cta, a_elem_bits)
+        )
         a_stride_byte_offset = _elements_to_bytes(8 * k_dim, a_elem_bits) if a_is_k_major else _elements_to_bytes(8 * 8, a_elem_bits)
         if not a_swizzle_mode.is_none():
             if a_is_k_major:
@@ -681,10 +681,16 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         b_is_k_major = self.b_transposed
 
         b_swizzle_mode = self._determinate_swizzle_mode(B_buf, self.b_shared_layout)
-        b_swizzle_atom_elems = n_dim_per_cta if b_swizzle_mode.is_none() else _bytes_to_elements(b_swizzle_mode.swizzle_byte_size(), elem_bits)
+        b_swizzle_atom_elems = (
+            n_dim_per_cta if b_swizzle_mode.is_none() else _bytes_to_elements(b_swizzle_mode.swizzle_byte_size(), elem_bits)
+        )
 
         b_leading_byte_offset = _elements_to_bytes(8 * 8, elem_bits) if b_is_k_major else _elements_to_bytes(8 * n_dim_per_cta, elem_bits)
-        b_stride_byte_offset = _elements_to_bytes(8 * k_dim, elem_bits) if b_is_k_major else (0 if n_dim_per_cta == 8 else _elements_to_bytes(8 * 8, elem_bits))
+        b_stride_byte_offset = (
+            _elements_to_bytes(8 * k_dim, elem_bits)
+            if b_is_k_major
+            else (0 if n_dim_per_cta == 8 else _elements_to_bytes(8 * 8, elem_bits))
+        )
         if not b_swizzle_mode.is_none():
             if b_is_k_major:
                 b_leading_byte_offset = 16
@@ -727,11 +733,7 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         a_is_k_major = not self.a_transposed
 
         a_swizzle_mode = self._determinate_swizzle_mode(A_buf, self.a_shared_layout)
-        a_swizzle_atom_elems = (
-            m_dim
-            if a_swizzle_mode.is_none()
-            else _bytes_to_elements(a_swizzle_mode.swizzle_byte_size(), elem_bits)
-        )
+        a_swizzle_atom_elems = m_dim if a_swizzle_mode.is_none() else _bytes_to_elements(a_swizzle_mode.swizzle_byte_size(), elem_bits)
 
         a_leading_byte_offset = _elements_to_bytes(8 * 8, elem_bits) if a_is_k_major else _elements_to_bytes(8 * m_dim, elem_bits)
         a_stride_byte_offset = _elements_to_bytes(8 * k_dim, elem_bits) if a_is_k_major else _elements_to_bytes(8 * 8, elem_bits)

--- a/tilelang/cuda/op/gemm/gemm_mma.py
+++ b/tilelang/cuda/op/gemm/gemm_mma.py
@@ -80,6 +80,7 @@ class GemmMMA(GemmBase):
         mma_emitter = self._make_mma_emitter(target, thread_nums, thread_var=thread_var)
 
         a_dtype = self.a_dtype
+        b_dtype = self.b_dtype
         warp_rows = mma_emitter.warp_rows
         warp_cols = mma_emitter.warp_cols
         local_size_a = mma_emitter.local_size_a
@@ -112,7 +113,7 @@ class GemmMMA(GemmBase):
                 accumulating into C_local.
                 """
                 A_local = T.alloc_local((warp_rows * local_size_a), a_dtype)
-                B_local = T.alloc_local((warp_cols * local_size_b), a_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b), b_dtype)
                 if clear_accum:
                     T.clear(C_buf)
                 for ki in T.serial(0, (block_K // micro_size_k)):
@@ -176,7 +177,7 @@ class GemmMMA(GemmBase):
                 B_shared into local fragments, then issues Tensor Core mma ops,
                 accumulating into C_local.
                 """
-                B_local = T.alloc_local((warp_cols * local_size_b), a_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b), b_dtype)
                 if clear_accum:
                     T.clear(C_buf)
                 for ki in T.serial(0, (block_K // micro_size_k)):

--- a/tilelang/cuda/op/gemm/gemm_mma.py
+++ b/tilelang/cuda/op/gemm/gemm_mma.py
@@ -25,8 +25,8 @@ class GemmMMA(GemmBase):
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
         emitter = self.intrin_emitter_cls(
-            a_dtype=self.in_dtype,
-            b_dtype=self.in_dtype,
+            a_dtype=self.a_dtype,
+            b_dtype=self.b_dtype,
             accum_dtype=self.accum_dtype,
             a_transposed=self.trans_A,
             b_transposed=self.trans_B,
@@ -79,7 +79,7 @@ class GemmMMA(GemmBase):
         thread_nums = thread_bounds.extent
         mma_emitter = self._make_mma_emitter(target, thread_nums, thread_var=thread_var)
 
-        in_dtype = self.in_dtype
+        a_dtype = self.a_dtype
         warp_rows = mma_emitter.warp_rows
         warp_cols = mma_emitter.warp_cols
         local_size_a = mma_emitter.local_size_a
@@ -111,8 +111,8 @@ class GemmMMA(GemmBase):
                 B_shared into local fragments, then issues Tensor Core mma ops,
                 accumulating into C_local.
                 """
-                A_local = T.alloc_local((warp_rows * local_size_a), in_dtype)
-                B_local = T.alloc_local((warp_cols * local_size_b), in_dtype)
+                A_local = T.alloc_local((warp_rows * local_size_a), a_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b), a_dtype)
                 if clear_accum:
                     T.clear(C_buf)
                 for ki in T.serial(0, (block_K // micro_size_k)):
@@ -146,7 +146,7 @@ class GemmMMA(GemmBase):
                 B_shared into local fragments, then issues Tensor Core mma ops,
                 accumulating into C_local.
                 """
-                A_local = T.alloc_local((warp_rows * local_size_a), in_dtype)
+                A_local = T.alloc_local((warp_rows * local_size_a), a_dtype)
 
                 for ki in T.serial(0, (block_K // micro_size_k)):
                     if clear_accum:
@@ -176,7 +176,7 @@ class GemmMMA(GemmBase):
                 B_shared into local fragments, then issues Tensor Core mma ops,
                 accumulating into C_local.
                 """
-                B_local = T.alloc_local((warp_cols * local_size_b), in_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b), a_dtype)
                 if clear_accum:
                     T.clear(C_buf)
                 for ki in T.serial(0, (block_K // micro_size_k)):

--- a/tilelang/cuda/op/gemm/gemm_mma_sm70.py
+++ b/tilelang/cuda/op/gemm/gemm_mma_sm70.py
@@ -24,8 +24,8 @@ class GemmMMASm70(GemmBase):
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
         mma_emitter = TensorCoreIntrinEmitter(
-            a_dtype=self.in_dtype,
-            b_dtype=self.in_dtype,
+            a_dtype=self.a_dtype,
+            b_dtype=self.b_dtype,
             accum_dtype=self.accum_dtype,
             a_transposed=self.trans_A,
             b_transposed=self.trans_B,
@@ -65,8 +65,8 @@ class GemmMMASm70(GemmBase):
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
         mma_emitter = TensorCoreIntrinEmitter(
-            a_dtype=self.in_dtype,
-            b_dtype=self.in_dtype,
+            a_dtype=self.a_dtype,
+            b_dtype=self.b_dtype,
             accum_dtype=self.accum_dtype,
             a_transposed=self.trans_A,
             b_transposed=self.trans_B,
@@ -78,7 +78,7 @@ class GemmMMASm70(GemmBase):
             thread_var=thread_var,
         )
 
-        in_dtype = self.in_dtype
+        a_dtype = self.a_dtype
         warp_rows = mma_emitter.warp_rows
         warp_cols = mma_emitter.warp_cols
         local_size_a = mma_emitter.local_size_a
@@ -108,8 +108,8 @@ class GemmMMASm70(GemmBase):
                 B_shared into local fragments, then issues Tensor Core mma ops,
                 accumulating into C_local.
                 """
-                A_local = T.alloc_local((warp_rows * local_size_a), in_dtype)
-                B_local = T.alloc_local((warp_cols * local_size_b), in_dtype)
+                A_local = T.alloc_local((warp_rows * local_size_a), a_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b), a_dtype)
 
                 if clear_accum:
                     T.clear(C_buf)
@@ -145,7 +145,7 @@ class GemmMMASm70(GemmBase):
                 B_shared into local fragments, then issues Tensor Core mma ops,
                 accumulating into C_local.
                 """
-                B_local = T.alloc_local((warp_cols * local_size_b), in_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b), a_dtype)
 
                 if clear_accum:
                     T.clear(C_buf)

--- a/tilelang/cuda/op/gemm/gemm_mma_sm70.py
+++ b/tilelang/cuda/op/gemm/gemm_mma_sm70.py
@@ -79,6 +79,7 @@ class GemmMMASm70(GemmBase):
         )
 
         a_dtype = self.a_dtype
+        b_dtype = self.b_dtype
         warp_rows = mma_emitter.warp_rows
         warp_cols = mma_emitter.warp_cols
         local_size_a = mma_emitter.local_size_a
@@ -109,7 +110,7 @@ class GemmMMASm70(GemmBase):
                 accumulating into C_local.
                 """
                 A_local = T.alloc_local((warp_rows * local_size_a), a_dtype)
-                B_local = T.alloc_local((warp_cols * local_size_b), a_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b), b_dtype)
 
                 if clear_accum:
                     T.clear(C_buf)
@@ -145,7 +146,7 @@ class GemmMMASm70(GemmBase):
                 B_shared into local fragments, then issues Tensor Core mma ops,
                 accumulating into C_local.
                 """
-                B_local = T.alloc_local((warp_cols * local_size_b), a_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b), b_dtype)
 
                 if clear_accum:
                     T.clear(C_buf)

--- a/tilelang/cuda/op/gemm/gemm_tcgen05.py
+++ b/tilelang/cuda/op/gemm/gemm_tcgen05.py
@@ -95,9 +95,7 @@ class GemmTCGEN5(GemmBase):
         annotations = getattr(self.gemm_node, "annotations", {})
         use_2cta = bool(annotations.get("use_2cta", 0))
         k = int(self.chunk)
-        mma_emitter.get_tcgen5_mma_meta(
-            int(self.M), int(self.N), k, disable_2cta=not use_2cta, disable_ws=self.is_blockscaled
-        )
+        mma_emitter.get_tcgen5_mma_meta(int(self.M), int(self.N), k, disable_2cta=not use_2cta, disable_ws=self.is_blockscaled)
 
         if self.is_blockscaled or self.is_gemm_ss():
             a_continuity = _shared_layout_continuity(self.A, a_is_k_major, self.K, self.M)

--- a/tilelang/cuda/op/gemm/gemm_tcgen05.py
+++ b/tilelang/cuda/op/gemm/gemm_tcgen05.py
@@ -31,6 +31,13 @@ _FLOAT8_DTYPES = {
 }
 
 
+def _shared_layout_continuity(buffer, is_k_major: bool, k_extent: int, mn_extent: int) -> int:
+    dtype_bits = buffer.dtype.bits
+    if dtype_bits < 8:
+        return int(buffer.shape[-1]) if is_k_major else mn_extent
+    return k_extent if is_k_major else mn_extent
+
+
 GEMM_INST_TCGEN05 = "cuda.tcgen05"
 
 
@@ -43,9 +50,10 @@ class GemmTCGEN5(GemmBase):
     of operands A and B.
     """
 
-    def infer_shared_layout(self, continuity: int) -> Callable[[tirx.Buffer], Layout]:
+    def infer_shared_layout(self, buffer: tirx.Buffer, continuity: int) -> Callable[[tirx.Buffer], Layout]:
         """Infer a standard shared-memory swizzle layout for TCGEN05 operands."""
-        vectorized_size = 128 // self.in_dtype.bits
+        elem_bits = buffer.dtype.bits
+        vectorized_size = 128 // elem_bits
         if continuity % (vectorized_size * 8) == 0:
             return make_full_bank_swizzled_layout
         elif continuity % (vectorized_size * 4) == 0:
@@ -70,8 +78,8 @@ class GemmTCGEN5(GemmBase):
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
         mma_emitter = TensorCoreIntrinEmitter(
-            a_dtype=self.in_dtype,
-            b_dtype=self.in_dtype,
+            a_dtype=self.a_dtype,
+            b_dtype=self.b_dtype,
             accum_dtype=self.accum_dtype,
             a_transposed=self.trans_A,
             b_transposed=self.trans_B,
@@ -86,22 +94,25 @@ class GemmTCGEN5(GemmBase):
 
         annotations = getattr(self.gemm_node, "annotations", {})
         use_2cta = bool(annotations.get("use_2cta", 0))
-        mma_emitter.get_tcgen5_mma_meta(self.M, self.N, self.K, disable_2cta=not use_2cta)
+        k = int(self.chunk)
+        mma_emitter.get_tcgen5_mma_meta(
+            int(self.M), int(self.N), k, disable_2cta=not use_2cta, disable_ws=self.is_blockscaled
+        )
 
         if self.is_blockscaled or self.is_gemm_ss():
-            a_continuity = self.K if a_is_k_major else self.M
-            b_continuity = self.K if b_is_k_major else int(self.B.shape[-1])  # don't use N, as it may be for 2cta
+            a_continuity = _shared_layout_continuity(self.A, a_is_k_major, self.K, self.M)
+            b_continuity = _shared_layout_continuity(self.B, b_is_k_major, self.K, int(self.B.shape[-1]))
 
             return {
-                self.A: self.infer_shared_layout(a_continuity)(self.A),
-                self.B: self.infer_shared_layout(b_continuity)(self.B),
+                self.A: self.infer_shared_layout(self.A, a_continuity)(self.A),
+                self.B: self.infer_shared_layout(self.B, b_continuity)(self.B),
                 self.C: mma_emitter.make_mma_store_layout(self.C),
             }
         if self.is_gemm_ts():
-            b_continuity = self.K if b_is_k_major else int(self.B.shape[-1])
+            b_continuity = _shared_layout_continuity(self.B, b_is_k_major, self.K, int(self.B.shape[-1]))
             layouts = {
                 self.A: mma_emitter.make_mma_store_layout(self.A),
-                self.B: self.infer_shared_layout(b_continuity)(self.B),
+                self.B: self.infer_shared_layout(self.B, b_continuity)(self.B),
                 self.C: mma_emitter.make_mma_store_layout(self.C),
             }
             return layouts
@@ -125,8 +136,8 @@ class GemmTCGEN5(GemmBase):
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
         mma_emitter = TensorCoreIntrinEmitter(
-            a_dtype=self.in_dtype,
-            b_dtype=self.in_dtype,
+            a_dtype=self.a_dtype,
+            b_dtype=self.b_dtype,
             accum_dtype=self.accum_dtype,
             a_transposed=self.trans_A,
             b_transposed=self.trans_B,
@@ -150,7 +161,8 @@ class GemmTCGEN5(GemmBase):
 
         annotations = getattr(self.gemm_node, "annotations", {})
         use_2cta = bool(annotations.get("use_2cta", 0))
-        mma_emitter.get_tcgen5_mma_meta(self.M, self.N, self.K, disable_2cta=not use_2cta)
+        k = int(self.chunk)
+        mma_emitter.get_tcgen5_mma_meta(int(self.M), int(self.N), k, disable_2cta=not use_2cta)
         atom_m, atom_n, atom_k, enable_ws, enable_2cta = mma_emitter.meta
 
         if self.A.scope() not in {"shared", "shared.dyn", "shared.tmem"}:
@@ -235,8 +247,7 @@ class GemmTCGEN5(GemmBase):
         clear_accum = self.clear_accum
         SFA_tmem = self.SFARegion.buffer
         SFB_tmem = self.SFBRegion.buffer
-        sf_a_id = self.sf_a_id
-        sf_b_id = self.sf_b_id
+        sf_k_start = self.sf_k_start
         # NOTE: mbar_phase_expr is intentionally unused in the current
         # frontend, which always requests explicit-async semantics. Keep the
         # parameter so the signature matches `_gemm_ss` and the call site in
@@ -245,7 +256,12 @@ class GemmTCGEN5(GemmBase):
 
         annotations = getattr(self.gemm_node, "annotations", {})
         use_2cta = bool(annotations.get("use_2cta", 0))
-        mma_emitter.get_tcgen5_mma_meta(self.M, self.N, self.K, disable_2cta=not use_2cta)
+        sf_a_granularity_k = annotations.get("sf_a_granularity_k")
+        sf_b_granularity_k = annotations.get("sf_b_granularity_k")
+        if sf_a_granularity_k is None or sf_b_granularity_k is None:
+            raise ValueError("Block-scaled GEMM requires sf_a_granularity_k and sf_b_granularity_k")
+        k = int(self.chunk)
+        mma_emitter.get_tcgen5_mma_meta(int(self.M), int(self.N), k, disable_2cta=not use_2cta, disable_ws=True)
         _atom_m, _atom_n, _atom_k, _enable_ws, enable_2cta = (int(x) for x in mma_emitter.meta)
 
         analyzer = Analyzer()
@@ -265,9 +281,10 @@ class GemmTCGEN5(GemmBase):
                     SFA_tmem,
                     SFB_tmem,
                     mbarptr,
-                    clear_accum,
-                    sf_a_id,
-                    sf_b_id,
+                    sf_k_start=sf_k_start,
+                    sf_a_granularity_k=int(sf_a_granularity_k),
+                    sf_b_granularity_k=int(sf_b_granularity_k),
+                    clear_accum=clear_accum,
                 )
 
         @T.prim_func
@@ -280,9 +297,10 @@ class GemmTCGEN5(GemmBase):
                     SFA_tmem,
                     SFB_tmem,
                     mbarptr,
-                    clear_accum,
-                    sf_a_id,
-                    sf_b_id,
+                    sf_k_start=sf_k_start,
+                    sf_a_granularity_k=int(sf_a_granularity_k),
+                    sf_b_granularity_k=int(sf_b_granularity_k),
+                    clear_accum=clear_accum,
                 )
 
         return (

--- a/tilelang/cuda/op/gemm/gemm_tcgen05.py
+++ b/tilelang/cuda/op/gemm/gemm_tcgen05.py
@@ -50,6 +50,10 @@ class GemmTCGEN5(GemmBase):
     of operands A and B.
     """
 
+    @property
+    def allow_f8f6f4_mixed_dtypes(self) -> bool:
+        return True
+
     def infer_shared_layout(self, buffer: tirx.Buffer, continuity: int) -> Callable[[tirx.Buffer], Layout]:
         """Infer a standard shared-memory swizzle layout for TCGEN05 operands."""
         elem_bits = buffer.dtype.bits

--- a/tilelang/cuda/op/gemm/gemm_wgmma.py
+++ b/tilelang/cuda/op/gemm/gemm_wgmma.py
@@ -38,7 +38,7 @@ class GemmWGMMA(GemmBase):
 
         See: https://docs.nvidia.com/cuda/cuda-driver-api/group__CUDA__TENSOR__MEMORY.html
         """
-        vectorized_size = 128 // self.in_dtype.bits
+        vectorized_size = 128 // self.a_dtype.bits
         if continuity % (vectorized_size * 8) == 0:
             return make_full_bank_swizzled_layout
         elif continuity % (vectorized_size * 4) == 0:
@@ -53,8 +53,8 @@ class GemmWGMMA(GemmBase):
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
         mma_emitter = TensorCoreIntrinEmitter(
-            a_dtype=self.in_dtype,
-            b_dtype=self.in_dtype,
+            a_dtype=self.a_dtype,
+            b_dtype=self.b_dtype,
             accum_dtype=self.accum_dtype,
             a_transposed=self.trans_A,
             b_transposed=self.trans_B,
@@ -97,8 +97,8 @@ class GemmWGMMA(GemmBase):
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
         mma_emitter = TensorCoreIntrinEmitter(
-            a_dtype=self.in_dtype,
-            b_dtype=self.in_dtype,
+            a_dtype=self.a_dtype,
+            b_dtype=self.b_dtype,
             accum_dtype=self.accum_dtype,
             a_transposed=self.trans_A,
             b_transposed=self.trans_B,

--- a/tilelang/cuda/op/gemm_sp/gemm_sp_mma.py
+++ b/tilelang/cuda/op/gemm_sp/gemm_sp_mma.py
@@ -79,6 +79,7 @@ class GemmSPMMA(GemmSPBase):
         )
 
         a_dtype = self.a_dtype
+        b_dtype = self.b_dtype
         warp_rows = mma_emitter.warp_rows
         warp_cols = mma_emitter.warp_cols
         local_size_a = mma_emitter.local_size_a
@@ -102,7 +103,7 @@ class GemmSPMMA(GemmSPBase):
                 """
                 A_local = T.alloc_local((warp_rows * local_size_a), a_dtype)
                 E_local = T.alloc_local((warp_rows * local_size_e), self.e_dtype)
-                B_local = T.alloc_local((warp_cols * local_size_b), a_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b), b_dtype)
 
                 if clear_accum:
                     T.clear(C_local)
@@ -185,7 +186,7 @@ class GemmSPMMA(GemmSPBase):
                 accumulating into C_local.
                 """
                 E_local = T.alloc_local((warp_rows * local_size_e), self.e_dtype)
-                B_local = T.alloc_local((warp_cols * local_size_b), a_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b), b_dtype)
 
                 if clear_accum:
                     T.clear(C_local)

--- a/tilelang/cuda/op/gemm_sp/gemm_sp_mma.py
+++ b/tilelang/cuda/op/gemm_sp/gemm_sp_mma.py
@@ -18,9 +18,9 @@ class GemmSPMMA(GemmSPBase):
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
         mma_emitter = SparseTensorCoreIntrinEmitter(
-            a_dtype=self.in_dtype,
+            a_dtype=self.a_dtype,
             e_dtype=self.e_dtype,
-            b_dtype=self.in_dtype,
+            b_dtype=self.b_dtype,
             accum_dtype=self.accum_dtype,
             a_transposed=self.trans_A,
             b_transposed=self.trans_B,
@@ -63,8 +63,8 @@ class GemmSPMMA(GemmSPBase):
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
         mma_emitter = SparseTensorCoreIntrinEmitter(
-            a_dtype=self.in_dtype,
-            b_dtype=self.in_dtype,
+            a_dtype=self.a_dtype,
+            b_dtype=self.b_dtype,
             e_dtype=self.e_dtype,
             accum_dtype=self.accum_dtype,
             a_transposed=self.trans_A,
@@ -78,7 +78,7 @@ class GemmSPMMA(GemmSPBase):
             thread_var=thread_var,
         )
 
-        in_dtype = self.in_dtype
+        a_dtype = self.a_dtype
         warp_rows = mma_emitter.warp_rows
         warp_cols = mma_emitter.warp_cols
         local_size_a = mma_emitter.local_size_a
@@ -100,9 +100,9 @@ class GemmSPMMA(GemmSPBase):
                 B_shared into local fragments, then issues Tensor Core mma ops,
                 accumulating into C_local.
                 """
-                A_local = T.alloc_local((warp_rows * local_size_a), in_dtype)
+                A_local = T.alloc_local((warp_rows * local_size_a), a_dtype)
                 E_local = T.alloc_local((warp_rows * local_size_e), self.e_dtype)
-                B_local = T.alloc_local((warp_cols * local_size_b), in_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b), a_dtype)
 
                 if clear_accum:
                     T.clear(C_local)
@@ -145,7 +145,7 @@ class GemmSPMMA(GemmSPBase):
                 B_shared into local fragments, then issues Tensor Core mma ops,
                 accumulating into C_local.
                 """
-                A_local = T.alloc_local((warp_rows * local_size_a), in_dtype)
+                A_local = T.alloc_local((warp_rows * local_size_a), a_dtype)
                 E_local = T.alloc_local((warp_rows * local_size_e), self.e_dtype)
 
                 if clear_accum:
@@ -185,7 +185,7 @@ class GemmSPMMA(GemmSPBase):
                 accumulating into C_local.
                 """
                 E_local = T.alloc_local((warp_rows * local_size_e), self.e_dtype)
-                B_local = T.alloc_local((warp_cols * local_size_b), in_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b), a_dtype)
 
                 if clear_accum:
                     T.clear(C_local)

--- a/tilelang/cuda/op/gemm_sp/gemm_sp_wgmma.py
+++ b/tilelang/cuda/op/gemm_sp/gemm_sp_wgmma.py
@@ -21,7 +21,7 @@ GEMM_SP_INST_WGMMA_SP = "cuda.wgmma.sp"
 
 class GemmSPWGMMA(GemmSPBase):
     def infer_shared_layout(self, continuity: int) -> Callable[[tirx.Buffer], Layout]:
-        vectorized_size = 128 // self.in_dtype.bits
+        vectorized_size = 128 // self.a_dtype.bits
         if continuity % (vectorized_size * 8) == 0:
             return make_full_bank_swizzled_layout
         elif continuity % (vectorized_size * 4) == 0:
@@ -36,9 +36,9 @@ class GemmSPWGMMA(GemmSPBase):
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
         mma_emitter = WGSparseTensorCoreIntrinEmitter(
-            a_dtype=self.in_dtype,
+            a_dtype=self.a_dtype,
             e_dtype=self.e_dtype,
-            b_dtype=self.in_dtype,
+            b_dtype=self.b_dtype,
             accum_dtype=self.accum_dtype,
             a_transposed=self.trans_A,
             b_transposed=self.trans_B,
@@ -81,9 +81,9 @@ class GemmSPWGMMA(GemmSPBase):
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
         mma_emitter = WGSparseTensorCoreIntrinEmitter(
-            a_dtype=self.in_dtype,
+            a_dtype=self.a_dtype,
             e_dtype=self.e_dtype,
-            b_dtype=self.in_dtype,
+            b_dtype=self.b_dtype,
             accum_dtype=self.accum_dtype,
             a_transposed=self.trans_A,
             b_transposed=self.trans_B,

--- a/tilelang/language/__init__.py
+++ b/tilelang/language/__init__.py
@@ -175,17 +175,6 @@ from .cluster import (
 )
 
 
-for _name in (
-    "float4_e2m1_unpackedx2",
-    "float4_e2m1_unpackedx4",
-    "float4_e2m1_unpackedx8",
-    "float4_e2m1_unpackedx16",
-    "float4_e2m1_unpackedx32",
-    "float4_e2m1_unpackedx64",
-):
-    globals().pop(_name, None)
-
-
 def import_source(source: str | None = None):
     # source is the source code to be imported
     from tvm.tirx.script.builder.ir import sblock_attr

--- a/tilelang/language/__init__.py
+++ b/tilelang/language/__init__.py
@@ -175,6 +175,17 @@ from .cluster import (
 )
 
 
+for _name in (
+    "float4_e2m1_unpackedx2",
+    "float4_e2m1_unpackedx4",
+    "float4_e2m1_unpackedx8",
+    "float4_e2m1_unpackedx16",
+    "float4_e2m1_unpackedx32",
+    "float4_e2m1_unpackedx64",
+):
+    globals().pop(_name, None)
+
+
 def import_source(source: str | None = None):
     # source is the source code to be imported
     from tvm.tirx.script.builder.ir import sblock_attr

--- a/tilelang/language/builtin.py
+++ b/tilelang/language/builtin.py
@@ -522,7 +522,7 @@ def mbarrier_expect_tx(mbarrier: BarrierType, tx: int):
 
 def mbarrier_arrive_expect_tx(mbarrier: BarrierType, tx: int):
     """Arrive at a memory barrier and expect completion of async transactions."""
-    from tilelang.language.tirx.op import ptx_arrive_barrier_expect_tx
+    from tilelang.language.tir.op import ptx_arrive_barrier_expect_tx
 
     mbarrier = _mbar_to_buffer_load(mbarrier)
     return ptx_arrive_barrier_expect_tx(mbarrier, tx)

--- a/tilelang/language/copy_op.py
+++ b/tilelang/language/copy_op.py
@@ -252,6 +252,9 @@ def tma_copy(
     Unlike T.copy() which emits tma_store + tma_store_arrive + tma_store_wait,
     T.tma_copy() omits the wait so the user can batch multiple stores before
     calling T.tma_store_wait() explicitly. ``barrier`` is not needed for stores.
+    FP4 unpacked shared-memory storage is load-only for TMA: packed global
+    ``float4_e2m1fn`` may be loaded into unpacked shared
+    ``float4_e2m1_unpacked``, but the reverse TMA store is not supported.
 
     Args:
         src: Source memory region (global or shared)

--- a/tilelang/language/copy_op.py
+++ b/tilelang/language/copy_op.py
@@ -261,7 +261,7 @@ def tma_copy(
             The TMA load will arrive at this barrier with expected byte count.
             The user must wait on the same barrier via T.mbarrier_wait_parity().
         leader_scope_threads: Number of threads in each TMA leader-election scope
-            (e.g., 32 for per-warp). Defaults to the full block size if not specified.
+            (e.g., 32 for per-warp). Defaults to the thread extend in the current context if not specified.
         eviction_policy: Cache eviction policy. Defaults to None.
         annotations: Additional annotations dict. Values in annotations take
             precedence over individual arguments.

--- a/tilelang/language/dtypes.py
+++ b/tilelang/language/dtypes.py
@@ -301,6 +301,36 @@ def is_float4(value: AnyDType) -> bool:
     return get_tvm_dtype(value).is_float4()
 
 
+def is_f8f6f4_family(value: AnyDType) -> bool:
+    """Whether *value* is a tcgen05 ``kind::f8f6f4`` / ``mxf8f6f4`` operand dtype."""
+    dt = get_tvm_dtype(value)
+    if dt.is_float4():
+        return True
+    name = str(dt)
+    return (dt.bits == 8 and name.startswith("float8")) or (
+        dt.bits == 6 and name.startswith("float6")
+    )
+
+
+def validate_gemm_ab_dtypes(
+    a_dtype: AnyDType, b_dtype: AnyDType, *, a_in_tmem: bool = False
+) -> None:
+    """Validate mixed A/B dtypes for GEMM tile ops.
+
+    TS variants (A in TMEM) skip validation because A/B dtypes may legitimately
+    differ. For SS/RS/SR, only f8f6f4-family mixed dtypes are allowed.
+    """
+    if a_in_tmem:
+        return
+    if a_dtype != b_dtype and not (
+        is_f8f6f4_family(a_dtype) and is_f8f6f4_family(b_dtype)
+    ):
+        raise ValueError(
+            f"Mixed-dtype GEMM only supports f8f6f4 family operands currently, "
+            f"got A={a_dtype}, B={b_dtype}"
+        )
+
+
 dtype.__call__ = __dtype_call__
 dtype.__new__ = __dtype_new__
 dtype.as_torch = __dtype_as_torch__
@@ -867,4 +897,6 @@ __all__ = list(_all_dtypes) + [
     "is_float4_e2m1fn",
     "is_float4_e2m1_unpacked",
     "is_float4",
+    "is_f8f6f4_family",
+    "validate_gemm_ab_dtypes",
 ]

--- a/tilelang/language/dtypes.py
+++ b/tilelang/language/dtypes.py
@@ -307,14 +307,10 @@ def is_f8f6f4_family(value: AnyDType) -> bool:
     if dt.is_float4():
         return True
     name = str(dt)
-    return (dt.bits == 8 and name.startswith("float8")) or (
-        dt.bits == 6 and name.startswith("float6")
-    )
+    return (dt.bits == 8 and name.startswith("float8")) or (dt.bits == 6 and name.startswith("float6"))
 
 
-def validate_gemm_ab_dtypes(
-    a_dtype: AnyDType, b_dtype: AnyDType, *, a_in_tmem: bool = False
-) -> None:
+def validate_gemm_ab_dtypes(a_dtype: AnyDType, b_dtype: AnyDType, *, a_in_tmem: bool = False) -> None:
     """Validate mixed A/B dtypes for GEMM tile ops.
 
     TS variants (A in TMEM) skip validation because A/B dtypes may legitimately
@@ -322,13 +318,8 @@ def validate_gemm_ab_dtypes(
     """
     if a_in_tmem:
         return
-    if a_dtype != b_dtype and not (
-        is_f8f6f4_family(a_dtype) and is_f8f6f4_family(b_dtype)
-    ):
-        raise ValueError(
-            f"Mixed-dtype GEMM only supports f8f6f4 family operands currently, "
-            f"got A={a_dtype}, B={b_dtype}"
-        )
+    if a_dtype != b_dtype and not (is_f8f6f4_family(a_dtype) and is_f8f6f4_family(b_dtype)):
+        raise ValueError(f"Mixed-dtype GEMM only supports f8f6f4 family operands currently, got A={a_dtype}, B={b_dtype}")
 
 
 dtype.__call__ = __dtype_call__

--- a/tilelang/language/dtypes.py
+++ b/tilelang/language/dtypes.py
@@ -310,16 +310,25 @@ def is_f8f6f4_family(value: AnyDType) -> bool:
     return (dt.bits == 8 and name.startswith("float8")) or (dt.bits == 6 and name.startswith("float6"))
 
 
-def validate_gemm_ab_dtypes(a_dtype: AnyDType, b_dtype: AnyDType, *, a_in_tmem: bool = False) -> None:
+def validate_gemm_ab_dtypes(
+    a_dtype: AnyDType,
+    b_dtype: AnyDType,
+    *,
+    a_in_tmem: bool = False,
+    allow_f8f6f4_mixed: bool = False,
+) -> None:
     """Validate mixed A/B dtypes for GEMM tile ops.
 
     TS variants (A in TMEM) skip validation because A/B dtypes may legitimately
-    differ. For SS/RS/SR, only f8f6f4-family mixed dtypes are allowed.
+    differ. Only TCGEN05 f8f6f4-family paths should opt in to mixed A/B dtypes.
     """
     if a_in_tmem:
         return
-    if a_dtype != b_dtype and not (is_f8f6f4_family(a_dtype) and is_f8f6f4_family(b_dtype)):
-        raise ValueError(f"Mixed-dtype GEMM only supports f8f6f4 family operands currently, got A={a_dtype}, B={b_dtype}")
+    if a_dtype == b_dtype:
+        return
+    if allow_f8f6f4_mixed and is_f8f6f4_family(a_dtype) and is_f8f6f4_family(b_dtype):
+        return
+    raise ValueError(f"Mixed-dtype GEMM only supports f8f6f4 family operands currently, got A={a_dtype}, B={b_dtype}")
 
 
 dtype.__call__ = __dtype_call__

--- a/tilelang/language/dtypes.py
+++ b/tilelang/language/dtypes.py
@@ -270,13 +270,13 @@ def __dtype_is_float4_e2m1fn__(self: dtype) -> bool:
 
 
 def __dtype_is_float4_e2m1_unpacked__(self: dtype) -> bool:
-    """8-bit FP4 E2M1 unpacked storage (CUTLASS float_e2m1_unpacksmem_t).
+    """8-bit FP4 E2M1 unpacked shared-memory storage.
 
     Only for tcgen05 ``kind::f8f6f4`` and block-scaled ``kind::mxf8f6f4``
-    mixed-precision paths where sub-byte types share 16-byte SMEM/TMEM padding
-    (one byte per FP4 element). Not for mxf4 / mxf4nvf4 packed FP4 kernels.
-    Pair with ``T.tma_copy`` from packed global FP4; TMA:
-    ``CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B``.
+    mixed-precision paths. It models the SMEM-side unpacked layout, one FP4
+    value per byte slot, and pairs with TMA
+    ``CU_TENSOR_MAP_DATA_TYPE_16U4_ALIGN16B``. Not for mxf4 / mxf4nvf4 packed
+    FP4 kernels or general SIMT copy/cast paths.
     """
     return self.bits == _FLOAT4_E2M1_UNPACKED_BITS and int(self.type_code) == _FLOAT4_E2M1_UNPACKED_TYPE_CODE
 
@@ -292,7 +292,7 @@ def is_float4_e2m1fn(value: AnyDType) -> bool:
 
 
 def is_float4_e2m1_unpacked(value: AnyDType) -> bool:
-    """Whether *value* is the 8-bit FP4 E2M1 unpacked shared-memory storage variant."""
+    """Whether *value* is the 8-bit FP4 E2M1 unpacked shared-memory variant."""
     return get_tvm_dtype(value).is_float4_e2m1_unpacked()
 
 
@@ -512,11 +512,6 @@ if TYPE_CHECKING:
     class float4_e2m1fnx32(dtype): ...
     class float4_e2m1fnx64(dtype): ...
     class float4_e2m1_unpacked(dtype): ...
-    class float4_e2m1_unpackedx2(dtype): ...
-    class float4_e2m1_unpackedx4(dtype): ...
-    class float4_e2m1_unpackedx8(dtype): ...
-    class float4_e2m1_unpackedx16(dtype): ...
-    class float4_e2m1_unpackedx32(dtype): ...
     class bfloat16(dtype): ...
     class bfloat16x2(dtype): ...
     class tfloat32(dtype): ...
@@ -693,12 +688,8 @@ else:
     float4_e2m1fnx16 = dtype("float4_e2m1fnx16")
     float4_e2m1fnx32 = dtype("float4_e2m1fnx32")
     float4_e2m1fnx64 = dtype("float4_e2m1fnx64")
+    # SMEM/TMA-only layout type; do not expose vectorized register/cast variants.
     float4_e2m1_unpacked = dtype("custom[float4_e2m1_unpacked]8")
-    float4_e2m1_unpackedx2 = dtype("custom[float4_e2m1_unpacked]8x2")
-    float4_e2m1_unpackedx4 = dtype("custom[float4_e2m1_unpacked]8x4")
-    float4_e2m1_unpackedx8 = dtype("custom[float4_e2m1_unpacked]8x8")
-    float4_e2m1_unpackedx16 = dtype("custom[float4_e2m1_unpacked]8x16")
-    float4_e2m1_unpackedx32 = dtype("custom[float4_e2m1_unpacked]8x32")
     bfloat16 = dtype("bfloat16")
     bfloat16x2 = dtype("bfloat16x2")
     tfloat32 = dtype("custom[tfloat32]")
@@ -874,11 +865,6 @@ _all_dtypes = [
     "float4_e2m1fnx32",
     "float4_e2m1fnx64",
     "float4_e2m1_unpacked",
-    "float4_e2m1_unpackedx2",
-    "float4_e2m1_unpackedx4",
-    "float4_e2m1_unpackedx8",
-    "float4_e2m1_unpackedx16",
-    "float4_e2m1_unpackedx32",
     "bfloat16",
     "bfloat16x2",
     "tfloat32",

--- a/tilelang/language/gemm_op.py
+++ b/tilelang/language/gemm_op.py
@@ -289,9 +289,10 @@ def tcgen05_gemm_blockscaled(
     clear_accum=False,
     wg_wait: int = 0,
     mbar: BarrierType | None = None,
-    sf_a_id: int = 0,
-    sf_b_id: int = 0,
     *,
+    k_start: int | tirx.PrimExpr,
+    sf_a_granularity_k: int,
+    sf_b_granularity_k: int,
     use_2cta: bool = False,
 ) -> tirx.PrimExpr:
     """Explicit Blackwell TCGEN05 block-scaled GEMM without an implicit wait.
@@ -305,14 +306,20 @@ def tcgen05_gemm_blockscaled(
     path only; there is no fallback or emulation. That mode requires
     ``cluster_dims`` to be ``(2,1,1)`` or ``(1,2,1)``.
 
-    A and B are FP8 (E4M3/E5M2) in shared memory, C is the accumulator in
-    tensor memory, and SFA/SFB are E8M0 scale factors already resident in
-    tensor memory. As with `T.tcgen05_gemm(...)`, this API is explicit-async:
-    it issues the MMA and leaves synchronization to the user schedule.
+    A and B are FP8/FP6/FP4 mxf8f6f4 operands in shared memory, C is the
+    accumulator in tensor memory, and SFA/SFB are E8M0 scale factors already
+    resident in tensor memory. As with `T.tcgen05_gemm(...)`, this API is
+    explicit-async: it issues the MMA and leaves synchronization to the user
+    schedule.
+
+    ``k_start`` is the logical K-axis start offset for this MMA tile.
+    ``sf_a_granularity_k`` and ``sf_b_granularity_k`` describe how many K
+    elements one packed scale factor covers. The compiler derives the PTX
+    scale-factor A/B IDs for each internal K32 MMA atom from these values.
 
     Args:
-        A: FP8 input buffer A in shared memory.
-        B: FP8 input buffer B in shared memory.
+        A: FP8/FP6/FP4 input buffer A in shared memory.
+        B: FP8/FP6/FP4 input buffer B in shared memory.
         C: Accumulator in tensor memory.
         SFA_tmem: Scale factors for A in tensor memory.
         SFB_tmem: Scale factors for B in tensor memory.
@@ -321,12 +328,16 @@ def tcgen05_gemm_blockscaled(
         clear_accum: Whether to zero the accumulator.
         wg_wait: Warp group wait identifier.
         mbar: Mbarrier for MMA completion signaling.
-        sf_a_id: Scale factor ID for A (0-3).
-        sf_b_id: Scale factor ID for B (0-3).
+        k_start: Logical K-axis start offset for this MMA tile.
+        sf_a_granularity_k: K elements covered by one A scale factor.
+        sf_b_granularity_k: K elements covered by one B scale factor.
         use_2cta: Whether to request true ``cta_group::2`` lowering.
     """
 
     ann = {"use_2cta": int(use_2cta)} if use_2cta else None
+    ann = {} if ann is None else dict(ann)
+    ann["sf_a_granularity_k"] = int(sf_a_granularity_k)
+    ann["sf_b_granularity_k"] = int(sf_b_granularity_k)
 
     # Re-read normalized regions below after let legalization.
 
@@ -396,11 +407,8 @@ def tcgen05_gemm_blockscaled(
 
     assert mbar is not None, "mbar is required for tcgen05_gemm_blockscaled"
 
-    # Ensure sf_a_id and sf_b_id are PrimExpr
-    if not isinstance(sf_a_id, tirx.PrimExpr):
-        sf_a_id = tirx.const(sf_a_id, dtype="int32")
-    if not isinstance(sf_b_id, tirx.PrimExpr):
-        sf_b_id = tirx.const(sf_b_id, dtype="int32")
+    if not isinstance(k_start, tirx.PrimExpr):
+        k_start = tirx.const(k_start, dtype="int32")
 
     # Block-scaled always uses Square policy (1x1 warp partition)
     policy = GemmWarpPolicy.Square
@@ -429,8 +437,7 @@ def tcgen05_gemm_blockscaled(
         C_coords[1],
         SFA_arg,  # arg 19
         SFB_arg,  # arg 20
-        sf_a_id,  # arg 21
-        sf_b_id,  # arg 22
+        k_start,  # arg 21
         annotations=ann,
     )
 

--- a/tilelang/language/tir/op.py
+++ b/tilelang/language/tir/op.py
@@ -1372,7 +1372,6 @@ def ptx_tcgen05_mma_blockscaled_ss(
     sfb_offset,
     reserved0=0,
     reserved1=0,
-    variant=False,
     enable_2cta=False,
 ):
     """TVM intrinsic for tcgen05.mma block-scaled (mxf8f6f4.block_scale) instructions.
@@ -1384,26 +1383,8 @@ def ptx_tcgen05_mma_blockscaled_ss(
     Positional args:
     kind_dtype, desc_a, A_offset, desc_b, B_offset, C_ptr, C_offset,
     desc_val, scale_out, sfa_ptr, sfa_offset, sfb_ptr, sfb_offset,
-    reserved0, reserved1, enable_ws, enable_2cta.
+    reserved0, reserved1, enable_2cta.
     """
-
-    if enable_2cta and isinstance(variant, str):
-        v_check = variant.lower()
-        if v_check in ("ws", "warp_specialized", "warp-specialized"):
-            raise ValueError("ptx_tcgen05_mma_blockscaled_ss: .ws and 2CTA cannot be combined")
-    elif enable_2cta and bool(variant):
-        raise ValueError("ptx_tcgen05_mma_blockscaled_ss: .ws and 2CTA cannot be combined")
-
-    if isinstance(variant, str):
-        v = variant.lower()
-        if v in ("ws", "warp_specialized", "warp-specialized"):
-            enable_ws = True
-        elif v in ("default", "std", "ss"):
-            enable_ws = False
-        else:
-            raise ValueError(f"ptx_tcgen05_mma_blockscaled_ss: unknown variant: {variant}")
-    else:
-        enable_ws = bool(variant)
 
     return call_intrin(
         "handle",
@@ -1423,7 +1404,6 @@ def ptx_tcgen05_mma_blockscaled_ss(
         sfb_offset,
         reserved0,
         reserved1,
-        enable_ws,
         enable_2cta,
     )
 

--- a/tilelang/metal/op/gemm/gemm_metal.py
+++ b/tilelang/metal/op/gemm/gemm_metal.py
@@ -45,6 +45,7 @@ class GemmMetal(GemmBase):
         )
 
         a_dtype = self.a_dtype
+        b_dtype = self.b_dtype
         accum_dtype = self.accum_dtype
         warp_rows = mps_emitter.warp_rows
         warp_cols = mps_emitter.warp_cols
@@ -73,7 +74,7 @@ class GemmMetal(GemmBase):
                 @T.prim_func
                 def _gemm_ss_simdgroup() -> None:
                     A_local = T.alloc_local((warp_rows * 64), a_dtype, scope="metal.simdgroup")
-                    B_local = T.alloc_local((warp_cols * 64), a_dtype, scope="metal.simdgroup")
+                    B_local = T.alloc_local((warp_cols * 64), b_dtype, scope="metal.simdgroup")
                     if clear_accum:
                         for _i in T.serial(num_simd_c):
                             T.make_filled_simdgroup_matrix(C_buf.data, _i, T.cast(0, accum_dtype))
@@ -88,7 +89,7 @@ class GemmMetal(GemmBase):
                 @T.prim_func
                 def _gemm_ss_shared() -> None:
                     A_local = T.alloc_local((warp_rows * 64), a_dtype, scope="metal.simdgroup")
-                    B_local = T.alloc_local((warp_cols * 64), a_dtype, scope="metal.simdgroup")
+                    B_local = T.alloc_local((warp_cols * 64), b_dtype, scope="metal.simdgroup")
                     C_simd = T.alloc_local((num_simd_c * 64), accum_dtype, scope="metal.simdgroup")
                     if clear_accum:
                         for _i in T.serial(num_simd_c):

--- a/tilelang/metal/op/gemm/gemm_metal.py
+++ b/tilelang/metal/op/gemm/gemm_metal.py
@@ -31,8 +31,8 @@ class GemmMetal(GemmBase):
         from tilelang.metal.intrinsics.metal_macro_generator import MPSIntrinEmitter
 
         mps_emitter = MPSIntrinEmitter(
-            a_dtype=self.in_dtype,
-            b_dtype=self.in_dtype,
+            a_dtype=self.a_dtype,
+            b_dtype=self.b_dtype,
             accum_dtype=self.accum_dtype,
             a_transposed=self.trans_A,
             b_transposed=self.trans_B,
@@ -44,7 +44,7 @@ class GemmMetal(GemmBase):
             thread_var=thread_var,
         )
 
-        in_dtype = self.in_dtype
+        a_dtype = self.a_dtype
         accum_dtype = self.accum_dtype
         warp_rows = mps_emitter.warp_rows
         warp_cols = mps_emitter.warp_cols
@@ -72,8 +72,8 @@ class GemmMetal(GemmBase):
 
                 @T.prim_func
                 def _gemm_ss_simdgroup() -> None:
-                    A_local = T.alloc_local((warp_rows * 64), in_dtype, scope="metal.simdgroup")
-                    B_local = T.alloc_local((warp_cols * 64), in_dtype, scope="metal.simdgroup")
+                    A_local = T.alloc_local((warp_rows * 64), a_dtype, scope="metal.simdgroup")
+                    B_local = T.alloc_local((warp_cols * 64), a_dtype, scope="metal.simdgroup")
                     if clear_accum:
                         for _i in T.serial(num_simd_c):
                             T.make_filled_simdgroup_matrix(C_buf.data, _i, T.cast(0, accum_dtype))
@@ -87,8 +87,8 @@ class GemmMetal(GemmBase):
 
                 @T.prim_func
                 def _gemm_ss_shared() -> None:
-                    A_local = T.alloc_local((warp_rows * 64), in_dtype, scope="metal.simdgroup")
-                    B_local = T.alloc_local((warp_cols * 64), in_dtype, scope="metal.simdgroup")
+                    A_local = T.alloc_local((warp_rows * 64), a_dtype, scope="metal.simdgroup")
+                    B_local = T.alloc_local((warp_cols * 64), a_dtype, scope="metal.simdgroup")
                     C_simd = T.alloc_local((num_simd_c * 64), accum_dtype, scope="metal.simdgroup")
                     if clear_accum:
                         for _i in T.serial(num_simd_c):

--- a/tilelang/profiler/__init__.py
+++ b/tilelang/profiler/__init__.py
@@ -138,12 +138,10 @@ class Profiler:
         elif ref_outs is None:
             ref_outs = []
 
-        ref_tensors = ins + ref_outs
-        lib_tensors = ins + lib_outs
-
-        assert len(lib_tensors) == len(ref_tensors), "len(lib_tensors) not equals to len(ref_tensors) !"
+        # only compare outputs
+        assert len(lib_outs) == len(ref_outs), "len(lib_outs) not equals to len(ref_outs) !"
         # torch.set_printoptions(edgeitems=torch.inf)
-        for lhs, rhs in zip(lib_tensors, ref_tensors):
+        for lhs, rhs in zip(lib_outs, ref_outs):
             # close_mask = torch.isclose(lhs, rhs, rtol=rtol, atol=atol)
             # total_elements = lhs.numel()
             # num_not_close = (~close_mask).sum().item()

--- a/tilelang/rocm/op/gemm/gemm_mfma.py
+++ b/tilelang/rocm/op/gemm/gemm_mfma.py
@@ -94,6 +94,7 @@ class GemmMFMA(GemmBase):
 
         k_pack = mfma_emitter.k_pack
         a_dtype = self.a_dtype
+        b_dtype = self.b_dtype
         warp_rows = mfma_emitter.warp_rows
         warp_cols = mfma_emitter.warp_cols
         local_size_a = mfma_emitter.local_size_a
@@ -130,7 +131,7 @@ class GemmMFMA(GemmBase):
                 accumulating into C_local.
                 """
                 A_local = T.alloc_local((warp_rows * local_size_a * k_pack), a_dtype)
-                B_local = T.alloc_local((warp_cols * local_size_b * k_pack), a_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b * k_pack), b_dtype)
                 if clear_accum:
                     T.clear(C_buf)
                 for ki in T.serial(0, (block_K // (micro_size_k * k_pack))):
@@ -195,7 +196,7 @@ class GemmMFMA(GemmBase):
                 B_shared into local fragments, then issues Matrix Core mfma ops,
                 accumulating into C_local.
                 """
-                B_local = T.alloc_local((warp_cols * local_size_b * k_pack), a_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b * k_pack), b_dtype)
                 if clear_accum:
                     T.clear(C_buf)
                 for ki in T.serial(0, (block_K // (micro_size_k * k_pack))):

--- a/tilelang/rocm/op/gemm/gemm_mfma.py
+++ b/tilelang/rocm/op/gemm/gemm_mfma.py
@@ -23,8 +23,8 @@ class GemmMFMA(GemmBase):
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
         mfma_emitter = MatrixCoreIntrinEmitter(
-            a_dtype=self.in_dtype,
-            b_dtype=self.in_dtype,
+            a_dtype=self.a_dtype,
+            b_dtype=self.b_dtype,
             accum_dtype=self.accum_dtype,
             a_transposed=self.trans_A,
             b_transposed=self.trans_B,
@@ -77,8 +77,8 @@ class GemmMFMA(GemmBase):
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
         mfma_emitter = MatrixCoreIntrinEmitter(
-            a_dtype=self.in_dtype,
-            b_dtype=self.in_dtype,
+            a_dtype=self.a_dtype,
+            b_dtype=self.b_dtype,
             accum_dtype=self.accum_dtype,
             a_transposed=self.trans_A,
             b_transposed=self.trans_B,
@@ -93,7 +93,7 @@ class GemmMFMA(GemmBase):
         )
 
         k_pack = mfma_emitter.k_pack
-        in_dtype = self.in_dtype
+        a_dtype = self.a_dtype
         warp_rows = mfma_emitter.warp_rows
         warp_cols = mfma_emitter.warp_cols
         local_size_a = mfma_emitter.local_size_a
@@ -129,8 +129,8 @@ class GemmMFMA(GemmBase):
                 B_shared into local fragments, then issues Matrix Core mfma ops,
                 accumulating into C_local.
                 """
-                A_local = T.alloc_local((warp_rows * local_size_a * k_pack), in_dtype)
-                B_local = T.alloc_local((warp_cols * local_size_b * k_pack), in_dtype)
+                A_local = T.alloc_local((warp_rows * local_size_a * k_pack), a_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b * k_pack), a_dtype)
                 if clear_accum:
                     T.clear(C_buf)
                 for ki in T.serial(0, (block_K // (micro_size_k * k_pack))):
@@ -164,7 +164,7 @@ class GemmMFMA(GemmBase):
                 B_shared into local fragments, then issues Matrix Core mfma ops,
                 accumulating into C_local.
                 """
-                A_local = T.alloc_local((warp_rows * local_size_a * k_pack), in_dtype)
+                A_local = T.alloc_local((warp_rows * local_size_a * k_pack), a_dtype)
 
                 if clear_accum:
                     T.clear(C_buf)
@@ -195,7 +195,7 @@ class GemmMFMA(GemmBase):
                 B_shared into local fragments, then issues Matrix Core mfma ops,
                 accumulating into C_local.
                 """
-                B_local = T.alloc_local((warp_cols * local_size_b * k_pack), in_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b * k_pack), a_dtype)
                 if clear_accum:
                     T.clear(C_buf)
                 for ki in T.serial(0, (block_K // (micro_size_k * k_pack))):

--- a/tilelang/rocm/op/gemm/gemm_wmma.py
+++ b/tilelang/rocm/op/gemm/gemm_wmma.py
@@ -25,8 +25,8 @@ class GemmWMMA(GemmBase):
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
         return WMMAIntrinEmitter(
-            a_dtype=self.in_dtype,
-            b_dtype=self.in_dtype,
+            a_dtype=self.a_dtype,
+            b_dtype=self.b_dtype,
             accum_dtype=self.accum_dtype,
             a_transposed=self.trans_A,
             b_transposed=self.trans_B,
@@ -78,7 +78,7 @@ class GemmWMMA(GemmBase):
 
         block_K = wmma_emitter.chunk
         micro_size_k = wmma_emitter.micro_size_k
-        in_dtype = self.in_dtype
+        a_dtype = self.a_dtype
         warp_rows = wmma_emitter.warp_rows
         warp_cols = wmma_emitter.warp_cols
         local_size_a = wmma_emitter.local_size_a
@@ -101,8 +101,8 @@ class GemmWMMA(GemmBase):
 
             @T.prim_func
             def _gemm_ssr() -> None:
-                A_local = T.alloc_local((warp_rows * local_size_a * k_pack), in_dtype)
-                B_local = T.alloc_local((warp_cols * local_size_b * k_pack), in_dtype)
+                A_local = T.alloc_local((warp_rows * local_size_a * k_pack), a_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b * k_pack), a_dtype)
                 if clear_accum:
                     T.clear(C_buf)
                 for ki in T.serial(0, (block_K // (micro_size_k * k_pack))):
@@ -117,7 +117,7 @@ class GemmWMMA(GemmBase):
 
             @T.prim_func
             def _gemm_srr() -> None:
-                A_local = T.alloc_local((warp_rows * local_size_a * k_pack), in_dtype)
+                A_local = T.alloc_local((warp_rows * local_size_a * k_pack), a_dtype)
                 if clear_accum:
                     T.clear(C_buf)
                 for ki in T.serial(0, (block_K // (micro_size_k * k_pack))):
@@ -131,7 +131,7 @@ class GemmWMMA(GemmBase):
 
             @T.prim_func
             def _gemm_rsr() -> None:
-                B_local = T.alloc_local((warp_cols * local_size_b * k_pack), in_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b * k_pack), a_dtype)
                 if clear_accum:
                     T.clear(C_buf)
                 for ki in T.serial(0, (block_K // (micro_size_k * k_pack))):

--- a/tilelang/rocm/op/gemm/gemm_wmma.py
+++ b/tilelang/rocm/op/gemm/gemm_wmma.py
@@ -79,6 +79,7 @@ class GemmWMMA(GemmBase):
         block_K = wmma_emitter.chunk
         micro_size_k = wmma_emitter.micro_size_k
         a_dtype = self.a_dtype
+        b_dtype = self.b_dtype
         warp_rows = wmma_emitter.warp_rows
         warp_cols = wmma_emitter.warp_cols
         local_size_a = wmma_emitter.local_size_a
@@ -102,7 +103,7 @@ class GemmWMMA(GemmBase):
             @T.prim_func
             def _gemm_ssr() -> None:
                 A_local = T.alloc_local((warp_rows * local_size_a * k_pack), a_dtype)
-                B_local = T.alloc_local((warp_cols * local_size_b * k_pack), a_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b * k_pack), b_dtype)
                 if clear_accum:
                     T.clear(C_buf)
                 for ki in T.serial(0, (block_K // (micro_size_k * k_pack))):
@@ -131,7 +132,7 @@ class GemmWMMA(GemmBase):
 
             @T.prim_func
             def _gemm_rsr() -> None:
-                B_local = T.alloc_local((warp_cols * local_size_b * k_pack), a_dtype)
+                B_local = T.alloc_local((warp_cols * local_size_b * k_pack), b_dtype)
                 if clear_accum:
                     T.clear(C_buf)
                 for ki in T.serial(0, (block_K // (micro_size_k * k_pack))):

--- a/tilelang/tileop/gemm/__init__.py
+++ b/tilelang/tileop/gemm/__init__.py
@@ -115,12 +115,8 @@ class Gemm(Node, Scriptable):
         return getattr(self, "isTcgen05", False)
 
     @property
-    def sf_a_id(self):
-        return self.sfAId
-
-    @property
-    def sf_b_id(self):
-        return self.sfBId
+    def sf_k_start(self):
+        return self.sfKStart
 
     def infer_layout(self, target: Target, thread_nums: int):
         """Infer the layout for the GEMM operation based on target architecture."""

--- a/tilelang/tileop/gemm/gemm_base.py
+++ b/tilelang/tileop/gemm/gemm_base.py
@@ -8,6 +8,7 @@ from tvm import tirx
 from tilelang import language as T
 from tilelang.utils.language import is_shared, is_fragment, is_tensor_memory
 from tilelang.tileop.base import GemmWarpPolicy
+from tilelang.language.dtypes import validate_gemm_ab_dtypes
 from tvm.ir.base import Node
 from tvm.ir import PrimExpr
 
@@ -22,6 +23,11 @@ class GemmBase:
     """
 
     gemm_node: Node
+
+    def __post_init__(self) -> None:
+        validate_gemm_ab_dtypes(
+            self.A.dtype, self.B.dtype, a_in_tmem=is_tensor_memory(self.A)
+        )
 
     def infer_layout(self, target: Target, thread_nums: int):
         raise NotImplementedError("infer_layout is not implemented")
@@ -77,16 +83,14 @@ class GemmBase:
         return getattr(self.gemm_node, "transB", None)
 
     @property
-    def in_dtype(self) -> str:
-        """Input data type for the multiplication.
-
-        For the TS variant, A resides in TMEM with the accumulator dtype, so
-        the actual input dtype is derived from B.
-        """
-        if is_tensor_memory(self.A):
-            return self.B.dtype
-        assert self.A.dtype == self.B.dtype, "A and B must have the same dtype"
+    def a_dtype(self):
+        """A operand dtype."""
         return self.A.dtype
+
+    @property
+    def b_dtype(self):
+        """B operand dtype."""
+        return self.B.dtype
 
     @property
     def accum_dtype(self) -> str:
@@ -181,12 +185,8 @@ class GemmBase:
         return getattr(self.gemm_node, "sfbRegion", None)
 
     @property
-    def sf_a_id(self) -> PrimExpr:
-        return getattr(self.gemm_node, "sfAId", tvm.tirx.const(0, T.int32))
-
-    @property
-    def sf_b_id(self) -> PrimExpr:
-        return getattr(self.gemm_node, "sfBId", tvm.tirx.const(0, T.int32))
+    def sf_k_start(self) -> PrimExpr:
+        return getattr(self.gemm_node, "sfKStart", tvm.tirx.const(0, T.int32))
 
     @property
     def is_blockscaled(self) -> bool:

--- a/tilelang/tileop/gemm/gemm_base.py
+++ b/tilelang/tileop/gemm/gemm_base.py
@@ -25,9 +25,7 @@ class GemmBase:
     gemm_node: Node
 
     def __post_init__(self) -> None:
-        validate_gemm_ab_dtypes(
-            self.A.dtype, self.B.dtype, a_in_tmem=is_tensor_memory(self.A)
-        )
+        validate_gemm_ab_dtypes(self.A.dtype, self.B.dtype, a_in_tmem=is_tensor_memory(self.A))
 
     def infer_layout(self, target: Target, thread_nums: int):
         raise NotImplementedError("infer_layout is not implemented")

--- a/tilelang/tileop/gemm/gemm_base.py
+++ b/tilelang/tileop/gemm/gemm_base.py
@@ -25,7 +25,17 @@ class GemmBase:
     gemm_node: Node
 
     def __post_init__(self) -> None:
-        validate_gemm_ab_dtypes(self.A.dtype, self.B.dtype, a_in_tmem=is_tensor_memory(self.A))
+        validate_gemm_ab_dtypes(
+            self.A.dtype,
+            self.B.dtype,
+            a_in_tmem=is_tensor_memory(self.A),
+            allow_f8f6f4_mixed=self.allow_f8f6f4_mixed_dtypes,
+        )
+
+    @property
+    def allow_f8f6f4_mixed_dtypes(self) -> bool:
+        # TODO(wt): Consider enabling mixed f8f6f4 operands for MMA paths too.
+        return False
 
     def infer_layout(self, target: Target, thread_nums: int):
         raise NotImplementedError("infer_layout is not implemented")

--- a/tilelang/tileop/gemm_sp/gemm_sp_base.py
+++ b/tilelang/tileop/gemm_sp/gemm_sp_base.py
@@ -58,9 +58,14 @@ class GemmSPBase:
         return self.E.dtype
 
     @property
-    def in_dtype(self) -> str:
+    def a_dtype(self):
         assert self.A.dtype == self.B.dtype, "A and B must have the same dtype"
         return self.A.dtype
+
+    @property
+    def b_dtype(self):
+        assert self.A.dtype == self.B.dtype, "A and B must have the same dtype"
+        return self.B.dtype
 
     @property
     def accum_dtype(self) -> str:

--- a/tilelang/tileop/gemm_sp/gemm_sp_wgmma.py
+++ b/tilelang/tileop/gemm_sp/gemm_sp_wgmma.py
@@ -21,7 +21,7 @@ GEMM_SP_INST_WGMMA_SP = "cuda.wgmma.sp"
 
 class GemmSPWGMMA(GemmSPBase):
     def infer_shared_layout(self, continuity: int) -> Callable[[tirx.Buffer], Layout]:
-        vectorized_size = 128 // self.in_dtype.bits
+        vectorized_size = 128 // self.a_dtype.bits
         if continuity % (vectorized_size * 8) == 0:
             return make_full_bank_swizzled_layout
         elif continuity % (vectorized_size * 4) == 0:
@@ -36,9 +36,9 @@ class GemmSPWGMMA(GemmSPBase):
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
         mma_emitter = WGSparseTensorCoreIntrinEmitter(
-            a_dtype=self.in_dtype,
+            a_dtype=self.a_dtype,
             e_dtype=self.e_dtype,
-            b_dtype=self.in_dtype,
+            b_dtype=self.b_dtype,
             accum_dtype=self.accum_dtype,
             a_transposed=self.trans_A,
             b_transposed=self.trans_B,
@@ -81,9 +81,9 @@ class GemmSPWGMMA(GemmSPBase):
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
         mma_emitter = WGSparseTensorCoreIntrinEmitter(
-            a_dtype=self.in_dtype,
+            a_dtype=self.a_dtype,
             e_dtype=self.e_dtype,
-            b_dtype=self.in_dtype,
+            b_dtype=self.b_dtype,
             accum_dtype=self.accum_dtype,
             a_transposed=self.trans_A,
             b_transposed=self.trans_B,


### PR DESCRIPTION
- Refactor `T.blockscaled_tcgen5_gemm` API: sf granularity and k_start passed in, sf_id inferred automatically
- Refactor Gemm to support .f8f6f4/.mxf8f6f4 mixed-dtype tcgen5
- Restore gemm maint scripts and add fp4-related tests
- Add dsv4 fp8-fp4 gemm kernel, performance comparable to DeepGEMM, preparing for MegaMoE later

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end correctness and validation suites for GEMM kernels across multiple hardware paths and execution modes
  * Added unpacked FP4 storage support alongside packed FP4

* **Improvements**
  * More flexible TMA/TensorMap handling for FP4 and mixed sub-byte formats
  * K-position–aware scale-factor indexing for block-scaled GEMM
  * Stronger mixed-dtype validation and dtype-aware lowering

* **Tests**
  * Expanded pytest coverage for many transpose/dtype/tile/thread combinations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->