### PR TITLE
[CUDA][Reduce] Fix packed mixed-dtype reduce casts

### DIFF
--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -147,14 +147,19 @@ inline PrimExpr MakeInitValue(const ReduceOpNode &op, int vsize = 1) {
   return Broadcast(scalar, vsize);
 }
 
-inline std::optional<PrimExpr> MakeReduce(const ReduceOpNode &op, int vsize,
-                                          const PrimExpr &acc,
-                                          const PrimExpr &b) {
+inline PrimExpr MakeReduce(const ReduceOpNode &op, int vsize,
+                           const PrimExpr &acc, const PrimExpr &b) {
+  if (vsize != 1 && vsize != 2) {
+    LOG(FATAL) << "Unsupported reduce vector size: " << vsize;
+    return PrimExpr();
+  }
+
+  PrimExpr rhs = b;
+  if (acc->dtype != rhs->dtype) {
+    rhs = Cast(acc->dtype, rhs);
+  }
+
   if (vsize == 1) {
-    PrimExpr rhs = b;
-    if (acc->dtype != rhs->dtype) {
-      rhs = Cast(acc->dtype, rhs);
-    }
     const bool use_nan_op = op.nan_propagate && (acc.dtype().is_float16() ||
                                                  acc.dtype().is_bfloat16());
     if (op.type->isSum()) {
@@ -179,28 +184,26 @@ inline std::optional<PrimExpr> MakeReduce(const ReduceOpNode &op, int vsize,
       return acc ^ rhs;
     }
     LOG(FATAL) << "Unsupported reduce type: " << op.type->type;
-    return std::nullopt;
+    return PrimExpr();
   }
-
-  if (vsize != 2)
-    return std::nullopt;
 
   if (op.type->isSum()) {
-    return Call(acc.dtype(), tl::add2(), {acc, b});
+    return Call(acc.dtype(), tl::add2(), {acc, rhs});
   } else if (op.type->isAbsSum()) {
     return Call(acc.dtype(), tl::add2(),
-                {acc, Call(acc.dtype(), tl::abs2(), {b})});
+                {acc, Call(acc.dtype(), tl::abs2(), {rhs})});
   } else if (op.type->isMax()) {
     return Call(acc.dtype(), op.nan_propagate ? tl::max2_nan() : tl::max2(),
-                {acc, b});
+                {acc, rhs});
   } else if (op.type->isMin()) {
     return Call(acc.dtype(), op.nan_propagate ? tl::min2_nan() : tl::min2(),
-                {acc, b});
+                {acc, rhs});
   } else if (op.type->isAbsMax()) {
     return Call(acc.dtype(), op.nan_propagate ? tl::max2_nan() : tl::max2(),
-                {acc, Call(acc.dtype(), tl::abs2(), {b})});
+                {acc, Call(acc.dtype(), tl::abs2(), {rhs})});
   }
-  return std::nullopt;
+  LOG(FATAL) << "Unsupported packed reduce type: " << op.type->type;
+  return PrimExpr();
 }
 
 inline std::optional<std::string> MakeCodegenReducer(const ReduceOpNode &op,
@@ -423,14 +426,13 @@ template <typename Impl> struct ReduceLowerer {
 
             auto src_load = BufferLoad(src_buffer, src_indice_compressed);
             auto *src_writer = src_load.CopyOnWrite();
-            src_writer->dtype = vec_dtype;
+            src_writer->dtype = src_buffer->dtype.with_lanes(vsize);
 
             Stmt reduce_local = BufferStore(
                 clear_buffer_packed,
                 reduce::MakeReduce(op, vsize,
                                    BufferLoad(clear_buffer_packed, red_indices),
-                                   src_load)
-                    .value(),
+                                   src_load),
                 red_indices);
 
             reduce_local =
@@ -451,8 +453,7 @@ template <typename Impl> struct ReduceLowerer {
             auto acc_vec = BufferLoad(clear_buffer_packed, red_indices);
             auto lane0 = Shuffle::ExtractElement(acc_vec, 0);
             auto lane1 = Shuffle::ExtractElement(acc_vec, 1);
-            auto scalar_result =
-                reduce::MakeReduce(op, 1, lane0, lane1).value();
+            auto scalar_result = reduce::MakeReduce(op, 1, lane0, lane1);
             local_body.push_back(
                 BufferStore(clear_buffer, scalar_result, red_indices));
 
@@ -472,8 +473,7 @@ template <typename Impl> struct ReduceLowerer {
         Stmt reduce_local = BufferStore(
             clear_buffer,
             reduce::MakeReduce(op, 1, BufferLoad(clear_buffer, red_indices),
-                               BufferLoad(src_buffer, src_indice_compressed))
-                .value(),
+                               BufferLoad(src_buffer, src_indice_compressed)),
             red_indices);
 
         for (int i = static_cast<int>(src_layout->OutputDim()) - 1; i >= 0;

--- a/testing/python/language/test_tilelang_language_reduce.py
+++ b/testing/python/language/test_tilelang_language_reduce.py
@@ -330,6 +330,36 @@ def _make_nan_reduce_kernel(reduce_fn, M, N, dtype, threads, *, nan_propagate):
 
 
 @tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(8, 9)
+def test_reduce_packed_fp8_to_float16_absmax_runtime():
+    if not hasattr(torch, "float8_e4m3fn"):
+        pytest.skip("torch.float8_e4m3fn is not available")
+
+    @T.prim_func
+    def kernel(A: T.Tensor((4, 32), T.float8_e4m3fn), B: T.Tensor((4,), T.float16)):
+        with T.Kernel(1, threads=32):
+            src = T.alloc_fragment((4, 32), T.float8_e4m3fn)
+            dst = T.alloc_fragment((4,), T.float16)
+            T.copy(A, src)
+            T.reduce_absmax(src, dst, dim=1)
+            T.copy(dst, B)
+
+    k = _compile(kernel)
+    source = k.get_kernel_source()
+    assert "from_uint1<__half2>(*(fp8" not in source
+
+    base = torch.linspace(-2.0, 2.0, 128, device="cuda", dtype=torch.float16).reshape(4, 32)
+    base[0, 3] = -7.0
+    base[1, 17] = 5.5
+    base[2, 31] = -3.25
+    base[3, 0] = 4.0
+    A = base.to(torch.float8_e4m3fn)
+    B = k(A)
+    ref = A.to(torch.float16).abs().amax(dim=1)
+    torch.testing.assert_close(B, ref, atol=0, rtol=0)
+
+
+@tilelang.testing.requires_cuda
 def test_reduce_packed_max_nan_propagate_uses_nan_intrinsics():
     k = _compile(_make_nan_reduce_kernel(T.reduce_max, 128, 128, T.float16, threads=256, nan_propagate=True))
     src = k.get_kernel_source()


### PR DESCRIPTION
## Summary

- Fix packed reduce lowering when the source fragment dtype differs from the accumulator dtype.
- Preserve the source vector load dtype so fp8 inputs are explicitly cast before packed abs/max operations.
- Add a focused runtime regression for fp8 absmax reduction into float16 output.

## Changes

- Normalize reduce RHS expressions to the accumulator dtype before scalar or packed reduce construction.
- Make `MakeReduce` return `PrimExpr` directly and fail explicitly for unsupported reduce forms instead of returning an optional consumed with `.value()`.
- Avoid retyping packed source loads as accumulator vectors before cast insertion.

## Validation

- `cmake --build build -j$(nproc)`
- `./format.sh`
- `PYTHONPATH=$(pwd):$PYTHONPATH python -m pytest testing/python/language/test_tilelang_language_reduce.py -x -k fp8_to_float16_absmax -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation test for packed FP8 to FP16 reduction operations, ensuring accurate handling of edge cases including NaN values.

* **Refactor**
  * Updated reduce operation implementation for improved error handling and type safety.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->