### PR TITLE
[BugFix][CUDA] Lower FP32 MMA operands as TF32

### DIFF
--- a/tilelang/cuda/intrinsics/macro/mma_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/mma_macro_generator.py
@@ -135,11 +135,21 @@ class TensorCoreIntrinEmitter:
         self.a_dtype_abbrv = self._get_dtype_abbrv(a_dtype)
         self.b_dtype_abbrv = self._get_dtype_abbrv(b_dtype)
         self.accum_dtype_abbrv = self._get_dtype_abbrv(accum_dtype)
+        if self._should_use_tf32_mma_operand(a_dtype, accum_dtype):
+            self.a_dtype_abbrv = "tf32"
+        if self._should_use_tf32_mma_operand(b_dtype, accum_dtype):
+            self.b_dtype_abbrv = "tf32"
 
     def _get_dtype_abbrv(self, dtype: str) -> str:
         if dtype not in self.dtype_abbrv:
             raise ValueError(f"Unsupported dtype: {dtype}")
         return self.dtype_abbrv[dtype]
+
+    @staticmethod
+    def _should_use_tf32_mma_operand(dtype: str, accum_dtype: str) -> bool:
+        operand_dtype = DataType(dtype)
+        accumulator_dtype = DataType(accum_dtype)
+        return str(operand_dtype) == "float32" and str(accumulator_dtype) == "float32"
 
     def _initialize_mma_prefix(self, k_dim: int = 16):
         if k_dim == 4:


### PR DESCRIPTION
TileKernels MHC correctness tests on H100 disable WGMMA for the affected kernels, so their FP32 x FP32 T.gemm path falls back to TileLang's cuda.mma lowering. CUDA tensor-core MMA does not provide a true FP32 multiplicand variant for the m16n8k8 instruction shape used here; FP32 inputs with FP32 accumulation must be issued as TF32 multiplicands with FP32 accumulators.

Before this change, the CUDA MMA emitter kept the A/B operand abbreviations as fp32. The generated CUDA therefore called tl::mma_sync with kFloat32, kFloat32, kFloat32, 16, 8, 8, false, true. The CUDA template dispatcher only has the TF32 multiplicand specialization for this shape, so NVCC failed with the static assertion "tl::mma_sync: unsupported configuration" while compiling the MHC kernels.

Map FP32 A/B operand abbreviations to tf32 when the accumulator dtype is also FP32. The generated ptx_mma call now selects tl::DataType::kTensorFloat32 for the multiplicands and keeps tl::DataType::kFloat32 for C, matching CUDA tensor-core semantics without changing storage dtype or accumulator/output dtype.

Verified on H100 CUDA backend with Python 3.12.3, PyTorch 2.12.0+cu132, CUDA 13.2, and local TileKernels: the 36 previously failing MHC correctness cases from tests/mhc/test_norm_fn.py and tests/mhc/test_pre_big_fuse.py pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated CUDA tensor core intrinsic operations with enhanced conditional precision handling for float32 scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->