### PR TITLE
Fix HIP intrinsic rules registered on tir.* instead of tirx.*

### DIFF
--- a/src/backend/rocm/codegen/intrin_rule_hip.cc
+++ b/src/backend/rocm/codegen/intrin_rule_hip.cc
@@ -132,117 +132,125 @@ template <typename T> static PrimExpr DispatchHIPShuffle(const PrimExpr &e) {
   // NOLINTEND(clang-analyzer-cplusplus.InnerPointer)
 }
 
-TVM_REGISTER_OP("tir.clz").set_attr<FLowerIntrinsic>(
-    "hip.FLowerIntrinsic",
-    DispatchPureExtern<HIPMath, /*dtype_from_arg=*/true>);
+TVM_REGISTER_OP("tirx.clz")
+    .set_attr<FLowerIntrinsic>(
+        "hip.FLowerIntrinsic",
+        DispatchPureExtern<HIPMath, /*dtype_from_arg=*/true>);
 
-TVM_REGISTER_OP("tir.floor")
+TVM_REGISTER_OP("tirx.floor")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchPureExtern<HIPMath>);
 
-TVM_REGISTER_OP("tir.ceil")
+TVM_REGISTER_OP("tirx.ceil")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchPureExtern<HIPMath>);
 
-TVM_REGISTER_OP("tir.trunc")
+TVM_REGISTER_OP("tirx.trunc")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchPureExtern<HIPMath>);
 
-TVM_REGISTER_OP("tir.fabs")
+TVM_REGISTER_OP("tirx.fabs")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchPureExtern<HIPMath>);
 
-TVM_REGISTER_OP("tir.round")
+TVM_REGISTER_OP("tirx.round")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchPureExtern<HIPMath>);
 
-TVM_REGISTER_OP("tir.nearbyint")
+TVM_REGISTER_OP("tirx.nearbyint")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchPureExtern<HIPMath>);
 
-TVM_REGISTER_OP("tir.exp").set_attr<FLowerIntrinsic>(
-    "hip.FLowerIntrinsic", DispatchPureExtern<HIPFastMath>);
-
-TVM_REGISTER_OP("tir.exp2")
-    .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
-                               DispatchPureExtern<HIPMath>);
-
-TVM_REGISTER_OP("tir.exp10")
+TVM_REGISTER_OP("tirx.exp")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchPureExtern<HIPFastMath>);
 
-TVM_REGISTER_OP("tir.erf").set_attr<FLowerIntrinsic>(
-    "hip.FLowerIntrinsic", DispatchPureExtern<HIPMath>);
+TVM_REGISTER_OP("tirx.exp2")
+    .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
+                               DispatchPureExtern<HIPMath>);
 
-TVM_REGISTER_OP("tir.log").set_attr<FLowerIntrinsic>(
-    "hip.FLowerIntrinsic", DispatchPureExtern<HIPFastMath>);
-
-TVM_REGISTER_OP("tir.log2")
+TVM_REGISTER_OP("tirx.exp10")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchPureExtern<HIPFastMath>);
 
-TVM_REGISTER_OP("tir.log10")
+TVM_REGISTER_OP("tirx.erf")
+    .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
+                               DispatchPureExtern<HIPMath>);
+
+TVM_REGISTER_OP("tirx.log")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchPureExtern<HIPFastMath>);
 
-TVM_REGISTER_OP("tir.tan").set_attr<FLowerIntrinsic>(
-    "hip.FLowerIntrinsic", DispatchPureExtern<HIPFastMathTan>);
+TVM_REGISTER_OP("tirx.log2")
+    .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
+                               DispatchPureExtern<HIPFastMath>);
 
-TVM_REGISTER_OP("tir.cos").set_attr<FLowerIntrinsic>(
-    "hip.FLowerIntrinsic", DispatchPureExtern<HIPFastMath>);
+TVM_REGISTER_OP("tirx.log10")
+    .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
+                               DispatchPureExtern<HIPFastMath>);
 
-TVM_REGISTER_OP("tir.cosh")
+TVM_REGISTER_OP("tirx.tan")
+    .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
+                               DispatchPureExtern<HIPFastMathTan>);
+
+TVM_REGISTER_OP("tirx.cos")
+    .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
+                               DispatchPureExtern<HIPFastMath>);
+
+TVM_REGISTER_OP("tirx.cosh")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchPureExtern<HIPMath>);
 
-TVM_REGISTER_OP("tir.sin").set_attr<FLowerIntrinsic>(
-    "hip.FLowerIntrinsic", DispatchPureExtern<HIPFastMath>);
+TVM_REGISTER_OP("tirx.sin")
+    .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
+                               DispatchPureExtern<HIPFastMath>);
 
-TVM_REGISTER_OP("tir.sinh")
+TVM_REGISTER_OP("tirx.sinh")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchPureExtern<HIPMath>);
 
-TVM_REGISTER_OP("tir.atan")
+TVM_REGISTER_OP("tirx.atan")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchPureExtern<HIPMath>);
 
-TVM_REGISTER_OP("tir.tanh")
+TVM_REGISTER_OP("tirx.tanh")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchPureExtern<HIPMath>);
 
-TVM_REGISTER_OP("tir.sqrt")
+TVM_REGISTER_OP("tirx.sqrt")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchPureExtern<HIPMath>);
 
-TVM_REGISTER_OP("tir.pow").set_attr<FLowerIntrinsic>(
-    "hip.FLowerIntrinsic", DispatchPureExtern<HIPMath>);
+TVM_REGISTER_OP("tirx.pow")
+    .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
+                               DispatchPureExtern<HIPMath>);
 
-TVM_REGISTER_OP("tir.popcount")
+TVM_REGISTER_OP("tirx.popcount")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchPureExtern<HIPPopcount>);
 
-TVM_REGISTER_OP("tir.tvm_warp_shuffle")
+TVM_REGISTER_OP("tirx.tvm_warp_shuffle")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchHIPShuffle<HIPWarpIntrinsic>);
 
-TVM_REGISTER_OP("tir.tvm_warp_shuffle_up")
+TVM_REGISTER_OP("tirx.tvm_warp_shuffle_up")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchHIPShuffle<HIPWarpIntrinsic>);
 
-TVM_REGISTER_OP("tir.tvm_warp_shuffle_down")
+TVM_REGISTER_OP("tirx.tvm_warp_shuffle_down")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchHIPShuffle<HIPWarpIntrinsic>);
 
-TVM_REGISTER_OP("tir.tvm_warp_activemask")
+TVM_REGISTER_OP("tirx.tvm_warp_activemask")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchHIPWarpActiveMask);
 
-TVM_REGISTER_OP("tir.fmod")
+TVM_REGISTER_OP("tirx.fmod")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchPureExtern<HIPMath>);
 
 // Register low-level builtin ops.
-TVM_REGISTER_OP("tir.hip.__shfl_sync")
+TVM_REGISTER_OP("tirx.hip.__shfl_sync")
     .set_num_inputs(4)
     .add_argument("mask", "Expr", "The thread mask.")
     .add_argument("var", "Expr", "The variable to sync.")
@@ -254,7 +262,7 @@ TVM_REGISTER_OP("tir.hip.__shfl_sync")
                                Integer(CallEffectKind::kOpaque))
     .set_attr<bool>("hip.need_warp_shuffle", true);
 
-TVM_REGISTER_OP("tir.hip.__shfl_up_sync")
+TVM_REGISTER_OP("tirx.hip.__shfl_up_sync")
     .set_num_inputs(4)
     .add_argument("mask", "Expr", "The thread mask.")
     .add_argument("var", "Expr", "The variable to sync.")
@@ -266,7 +274,7 @@ TVM_REGISTER_OP("tir.hip.__shfl_up_sync")
                                Integer(CallEffectKind::kOpaque))
     .set_attr<bool>("hip.need_warp_shuffle", true);
 
-TVM_REGISTER_OP("tir.hip.__shfl_down_sync")
+TVM_REGISTER_OP("tirx.hip.__shfl_down_sync")
     .set_num_inputs(4)
     .add_argument("mask", "Expr", "The thread mask.")
     .add_argument("var", "Expr", "The variable to sync.")
@@ -279,7 +287,7 @@ TVM_REGISTER_OP("tir.hip.__shfl_down_sync")
                                Integer(CallEffectKind::kOpaque))
     .set_attr<bool>("hip.need_warp_shuffle", true);
 
-TVM_REGISTER_OP("tir.hip.__activemask")
+TVM_REGISTER_OP("tirx.hip.__activemask")
     .set_num_inputs(0)
     .set_attr<TGlobalSymbol>("TGlobalSymbol", "__activemask")
     .set_attr<TCallEffectKind>("TCallEffectKind",


### PR DESCRIPTION
  `intrin_rule_hip.cc` registers `hip.FLowerIntrinsic` rules on `tir.exp2`,  `tir.exp`, … but the IR uses the `tirx.*` ops (CUDA registers on `tirx.*`).   The HIP rules never match, so kernels using `T.exp2` etc. fail with:  

`tvm.error.InternalError: Unresolved call ir.Op(name="tirx.exp2")`

Switches all 33 registrations to `tirx.*` (also fixes the warp ops, which register `tir.hip.*` while dispatch looks up `tirx.hip.*`), bringing HIP in line with CUDA.

Hit on a Radeon 890M (gfx1150) iGPU, ROCm 7.2, torch 2.12.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated HIP backend intrinsic naming conventions for mathematical functions (floor, ceil, sqrt, exp, log, etc.) and warp-related operations. Functionality remains unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2282?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->