### PR TITLE
[TIR][Transform] Handle ragged SIMT copy partitioning

### DIFF
--- a/src/backend/cuda/op/copy.cc
+++ b/src/backend/cuda/op/copy.cc
@@ -335,7 +335,7 @@ private:
   static Layout ComputeLinearLayout(const Buffer &shared_tensor);
 
   static void CollectFragmentLayouts(const PrimExpr &expr,
-                                     const Map<Var, PrimExpr> &let_var_to_expr,
+                                     const Map<Var, PrimExpr> &bind_var_to_expr,
                                      const LayoutMap &existing_layouts,
                                      PrimExpr thread_extent,
                                      Range thread_bounds,
@@ -401,7 +401,7 @@ Layout Copy::ComputeLinearLayout(const Buffer &shared_tensor) {
 }
 
 void Copy::CollectFragmentLayouts(const PrimExpr &expr,
-                                  const Map<Var, PrimExpr> &let_var_to_expr,
+                                  const Map<Var, PrimExpr> &bind_var_to_expr,
                                   const LayoutMap &existing_layouts,
                                   PrimExpr thread_extent, Range thread_bounds,
                                   Map<Buffer, Layout> &result_map) {
@@ -414,8 +414,8 @@ void Copy::CollectFragmentLayouts(const PrimExpr &expr,
       }
     } else if (auto var_node = node.as<VarNode>()) {
       auto var = GetRef<Var>(var_node);
-      if (let_var_to_expr.count(var)) {
-        CollectFragmentLayouts(let_var_to_expr[var], let_var_to_expr,
+      if (bind_var_to_expr.count(var)) {
+        CollectFragmentLayouts(bind_var_to_expr[var], bind_var_to_expr,
                                existing_layouts, thread_extent, thread_bounds,
                                result_map);
       }
@@ -545,15 +545,15 @@ LayoutMap Copy::InferBulkLayout(const CopyNode &op, const LayoutInferArgs &T,
   // Fragment buffers used as TMA indices should be replicated on all threads.
   PrimExpr thread_extent = T.thread_bounds->extent;
   for (const auto &range : op.src_range) {
-    CollectFragmentLayouts(range->min, T.let_var_to_expr, T.layout_map,
+    CollectFragmentLayouts(range->min, T.bind_var_to_expr, T.layout_map,
                            thread_extent, T.thread_bounds, result_map);
-    CollectFragmentLayouts(range->extent, T.let_var_to_expr, T.layout_map,
+    CollectFragmentLayouts(range->extent, T.bind_var_to_expr, T.layout_map,
                            thread_extent, T.thread_bounds, result_map);
   }
   for (const auto &range : op.dst_range) {
-    CollectFragmentLayouts(range->min, T.let_var_to_expr, T.layout_map,
+    CollectFragmentLayouts(range->min, T.bind_var_to_expr, T.layout_map,
                            thread_extent, T.thread_bounds, result_map);
-    CollectFragmentLayouts(range->extent, T.let_var_to_expr, T.layout_map,
+    CollectFragmentLayouts(range->extent, T.bind_var_to_expr, T.layout_map,
                            thread_extent, T.thread_bounds, result_map);
   }
 

--- a/src/op/operator.h
+++ b/src/op/operator.h
@@ -93,9 +93,9 @@ struct LowerArgs {
   UpdateBarrierArriveCallback UpdateBarrierArrive;
   LayoutMap layout_map;
   Map<Buffer, Buffer> buffer_remap;
-  // Map from LetStmt variable to its bound expression, for resolving
-  // fragment buffer accesses through let bindings
-  Map<Var, PrimExpr> let_var_to_expr;
+  // Map from Bind variable to its bound expression, for resolving
+  // fragment buffer accesses through Bind values
+  Map<Var, PrimExpr> bind_var_to_expr;
   // Fallback mbarrier parity for ops that do not carry an explicit
   // tl.pipeline_mbar_phase_expr annotation. LowerTileOp derives this from the
   // nearest enclosing serial loop so non-pipelined TMA loops still alternate
@@ -118,9 +118,9 @@ struct LayoutInferArgs {
   arith::Analyzer *analyzer;
   bool buffer_oob = false;
   Map<Buffer, Buffer> buffer_remap;
-  // Map from LetStmt variable to its bound expression, for resolving
-  // fragment buffer accesses through let bindings
-  Map<Var, PrimExpr> let_var_to_expr;
+  // Map from Bind variable to its bound expression, for resolving
+  // fragment buffer accesses through Bind values
+  Map<Var, PrimExpr> bind_var_to_expr;
   // Whether the current TileOp is nested inside a pipelined loop
   // (i.e. a surrounding loop annotated with num_stages > 0).
   bool in_pipeline = false;

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -146,12 +146,12 @@ TileOperator ParallelOpNode::Clone() const {
   return ParallelOp(op);
 }
 
-void ParallelOpNode::ExpandLetBindings(
-    const Map<Var, PrimExpr> &let_var_to_expr) {
-  if (let_var_to_expr.empty())
+void ParallelOpNode::ExpandBindValues(
+    const Map<Var, PrimExpr> &bind_var_to_expr) {
+  if (bind_var_to_expr.empty())
     return;
 
-  // Helper function to recursively find BufferLoads through let bindings
+  // Helper function to recursively find BufferLoads through Bind values
   std::function<void(const PrimExpr &)> expand = [&](const PrimExpr &expr) {
     PostOrderVisit(expr, [&](const ObjectRef &node) {
       if (auto bl = node.as<BufferLoadNode>()) {
@@ -160,14 +160,14 @@ void ParallelOpNode::ExpandLetBindings(
         }
       } else if (auto var_node = node.as<VarNode>()) {
         auto var = GetRef<Var>(var_node);
-        if (let_var_to_expr.count(var)) {
-          expand(let_var_to_expr[var]);
+        if (bind_var_to_expr.count(var)) {
+          expand(bind_var_to_expr[var]);
         }
       }
     });
   };
 
-  // Only expand let bindings that are used in root_
+  // Only expand Bind values that are used in root_
   // First, collect all vars used in root_
   std::unordered_set<const VarNode *> used_vars;
   PostOrderVisit(root_, [&](const ObjectRef &node) {
@@ -176,8 +176,8 @@ void ParallelOpNode::ExpandLetBindings(
     }
   });
 
-  // Only expand let bindings for vars that are actually used in root_
-  for (const auto &[var, expr] : let_var_to_expr) {
+  // Only expand Bind values for vars that are actually used in root_
+  for (const auto &[var, expr] : bind_var_to_expr) {
     if (used_vars.count(var.get())) {
       expand(expr);
     }
@@ -262,9 +262,9 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
   if (loop_layout_inferred_)
     return {};
 
-  // Expand let bindings to find fragment buffer accesses
-  if (!T.let_var_to_expr.empty()) {
-    const_cast<ParallelOpNode *>(this)->ExpandLetBindings(T.let_var_to_expr);
+  // Expand Bind values to find fragment buffer accesses
+  if (!T.bind_var_to_expr.empty()) {
+    const_cast<ParallelOpNode *>(this)->ExpandBindValues(T.bind_var_to_expr);
   }
 
   if (level == InferLevel::kStrict) {
@@ -681,9 +681,17 @@ Fragment ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &T) const {
     loop_total_size = loop_total_size * l.as<For>().value()->extent;
   DLOG(INFO) << "[PlanLoopPartition] loop_total_size = " << loop_total_size
              << '\n';
-  while (!analyzer_.CanProve(floormod(loop_total_size, T.thread_bounds->extent *
-                                                           vector_size) == 0) &&
-         vector_size > 1)
+  const int64_t *thread_extent = as_const_int(T.thread_bounds->extent);
+  ICHECK(thread_extent != nullptr)
+      << "PlanLoopPartition requires constant thread extent, got "
+      << T.thread_bounds;
+  bool require_full_thread_replication = !indice_map_.empty();
+  auto has_compatible_threads = [&](int candidate_vector_size) {
+    return SelectActiveThreadExtent(root_, *thread_extent,
+                                    candidate_vector_size, &analyzer_,
+                                    require_full_thread_replication) > 0;
+  };
+  while (!has_compatible_threads(vector_size) && vector_size > 1)
     vector_size /= 2;
   DLOG(INFO) << "[PlanLoopPartition] after adjust: vector_size = "
              << vector_size << '\n';
@@ -702,10 +710,15 @@ Fragment ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &T) const {
       LOG(FATAL) << "coalesced_width should be an IntImmNode.";
     }
   }
+  ICHECK(has_compatible_threads(vector_size))
+      << "Cannot find an active thread extent <= " << *thread_extent
+      << " that evenly partitions loop_total_size=" << loop_total_size
+      << " with vector_size=" << vector_size;
   DLOG(INFO) << "[PlanLoopPartition] root_ = " << root_
              << " ############# vector_size = " << vector_size
              << ", thread_bounds = " << T.thread_bounds << '\n';
-  auto plan = PlanLoopPartition(root_, vector_size, T.thread_bounds);
+  auto plan = PlanLoopPartition(root_, vector_size, T.thread_bounds, &analyzer_,
+                                require_full_thread_replication);
   DLOG(INFO) << "[PlanLoopPartition] candidate = " << plan->DebugOutput()
              << '\n';
   return plan;

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -162,10 +162,10 @@ private:
   void AddPredicate(const PrimExpr &expr) const {
     predicate_ = predicate_.defined() ? And(expr, predicate_.value()) : expr;
   }
-  // Expand let bindings to find fragment buffer accesses and add them to
+  // Expand Bind values to find fragment buffer accesses and add them to
   // indice_map_. This handles cases like: a = block_mask_f[i]; T.copy(A[a, 0],
   // ...)
-  void ExpandLetBindings(const Map<Var, PrimExpr> &let_var_to_expr);
+  void ExpandBindValues(const Map<Var, PrimExpr> &bind_var_to_expr);
 
   // Allow ParallelLoopNestVisitor to access private members.
   friend class ParallelLoopNestVisitor;

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -156,7 +156,7 @@ public:
                                                      cur_analyzer,
                                                      buffer_oob,
                                                      {},
-                                                     let_var_to_expr_,
+                                                     bind_var_to_expr_,
                                                      false},
                                      level);
 
@@ -555,7 +555,7 @@ private:
         } else if (auto buffer = getBufferFromRegion(arg)) {
           addToUseList(buffer.value());
         }
-        // Check if the argument uses any LetStmt variables that reference
+        // Check if the argument uses any Bind variables that reference
         // fragment buffers. If so, add those buffers to the use list.
         // This handles cases like: a = block_mask_f[i]; T.copy(A[a, 0], ...)
         CollectFragmentBuffersFromExpr(arg);
@@ -805,14 +805,14 @@ private:
   }
 
   void VisitStmt_(const BindNode *op) final {
-    // Record Let variable to its bound expression.
-    // This enables tracking fragment buffer accesses through let bindings.
-    let_var_to_expr_.Set(op->var, op->value);
+    // Record Bind variable to its bound expression.
+    // This enables tracking fragment buffer accesses through Bind values.
+    bind_var_to_expr_.Set(op->var, op->value);
     IRVisitorWithAnalyzer::VisitStmt_(op);
   }
 
   // Helper: recursively collect fragment buffers from an expression,
-  // following let bindings chain.
+  // following Bind values chain.
   void CollectFragmentBuffersFromExpr(const PrimExpr &expr) {
     PostOrderVisit(expr, [this](const ObjectRef &node) {
       if (auto bl = node.as<BufferLoadNode>()) {
@@ -821,8 +821,8 @@ private:
         }
       } else if (auto var_node = node.as<VarNode>()) {
         auto var = GetRef<Var>(var_node);
-        if (let_var_to_expr_.count(var)) {
-          CollectFragmentBuffersFromExpr(let_var_to_expr_[var]);
+        if (bind_var_to_expr_.count(var)) {
+          CollectFragmentBuffersFromExpr(bind_var_to_expr_[var]);
         }
       }
     });
@@ -991,8 +991,8 @@ private:
   }
 
   Map<Var, Array<Buffer>> buffer_data_to_buffers_;
-  // Map from LetStmt variable to its bound expression
-  Map<Var, PrimExpr> let_var_to_expr_;
+  // Map from Bind variable to its bound expression
+  Map<Var, PrimExpr> bind_var_to_expr_;
   std::vector<ObjectRef> infer_list_stmt_;
   std::vector<TileOperator> infer_list_;
   // Fragment buffers that have accesses outside of TileOps.

--- a/src/transform/loop_partition.cc
+++ b/src/transform/loop_partition.cc
@@ -25,6 +25,7 @@
 #include "loop_partition.h"
 #include "support/check.h"
 #include <tvm/ir/cast.h>
+#include <tvm/runtime/logging.h>
 
 #include <tvm/tirx/stmt_functor.h>
 
@@ -192,8 +193,12 @@ class LoopPartitioner : public StmtExprVisitor {
 public:
   LoopPartitioner() = default;
 
-  Fragment Partition(const For &op, int num_thread, int vectorize_size) {
+  Fragment Partition(const For &op, int num_thread, int vectorize_size,
+                     int replicate_num_thread = -1) {
     this->VisitStmt(op);
+    if (replicate_num_thread < 0) {
+      replicate_num_thread = num_thread;
+    }
     DataType dtype = DataType::Int(32);
     if (!loop_vars_.empty()) {
       dtype = loop_vars_.back()->var.dtype();
@@ -212,9 +217,14 @@ public:
 
     auto fragment = Fragment(loop_vars_, {idx}, {thd}, {});
     if (has_fragment_) {
-      // for fragment buffer, we don't need to replicate the loop layout
+      // Fragment loops need a layout for the whole block. Build the base
+      // partition with active threads, then replicate it across the full block
+      // when the active width is a factor of the block size.
       auto thread_extent = *as_const_int(fragment->ThreadExtent());
-      auto num_thread_fragment = num_thread / thread_extent;
+      ICHECK_EQ(replicate_num_thread % thread_extent, 0)
+          << "Cannot replicate fragment loop layout with thread extent "
+          << thread_extent << " across " << replicate_num_thread << " threads";
+      auto num_thread_fragment = replicate_num_thread / thread_extent;
       fragment = fragment->Replicate(num_thread_fragment);
     }
     return fragment;
@@ -251,6 +261,63 @@ private:
   Array<IterVar> loop_vars_;
 };
 
+class LoopPartitionFragmentAccessDetector : public StmtExprVisitor {
+public:
+  bool HasFragmentAccess(const For &op) {
+    VisitStmt(op);
+    return has_fragment_;
+  }
+
+private:
+  void VisitExpr_(const BufferLoadNode *op) final {
+    if (IsFragmentBuffer(op->buffer)) {
+      has_fragment_ = true;
+    }
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
+  void VisitStmt_(const BufferStoreNode *op) final {
+    if (IsFragmentBuffer(op->buffer)) {
+      has_fragment_ = true;
+    }
+    StmtExprVisitor::VisitStmt_(op);
+  }
+
+  bool has_fragment_ = false;
+};
+
+static PrimExpr ComputeLoopTotalSize(const For &op) {
+  PrimExpr loop_total_size = 1;
+  for (Stmt l = op; l.as<For>().has_value(); l = l.as<For>().value()->body) {
+    loop_total_size = loop_total_size * l.as<For>().value()->extent;
+  }
+  return loop_total_size;
+}
+
+int64_t SelectActiveThreadExtent(const For &op, int64_t max_num_thread,
+                                 int vectorize_size, arith::Analyzer *analyzer,
+                                 bool require_full_thread_replication) {
+  ICHECK_GT(max_num_thread, 0);
+  ICHECK_GT(vectorize_size, 0);
+
+  arith::Analyzer local_analyzer;
+  arith::Analyzer *az = analyzer != nullptr ? analyzer : &local_analyzer;
+  PrimExpr loop_total_size = ComputeLoopTotalSize(op);
+
+  for (int64_t active_threads = max_num_thread; active_threads >= 1;
+       --active_threads) {
+    if (require_full_thread_replication &&
+        max_num_thread % active_threads != 0) {
+      continue;
+    }
+    PrimExpr partition_width = Integer(active_threads * vectorize_size);
+    if (az->CanProve(floormod(loop_total_size, partition_width) == 0)) {
+      return active_threads;
+    }
+  }
+  return 0;
+}
+
 Fragment PlanLoopPartition(const For &op, size_t num_thread,
                            int vectorize_size) {
   LoopPartitioner partitioner;
@@ -258,10 +325,38 @@ Fragment PlanLoopPartition(const For &op, size_t num_thread,
 }
 
 Fragment PlanLoopPartition(const For &op, int vectorize_size,
-                           const Range &thread_range) {
-  size_t num_thread = *as_const_int(thread_range->extent);
+                           const Range &thread_range, arith::Analyzer *analyzer,
+                           bool require_full_thread_replication) {
+  const int64_t *num_thread_ptr = as_const_int(thread_range->extent);
+  ICHECK(num_thread_ptr != nullptr)
+      << "PlanLoopPartition requires constant thread extent, got "
+      << thread_range;
+  int64_t num_thread = *num_thread_ptr;
+  bool needs_full_thread_replication =
+      require_full_thread_replication ||
+      LoopPartitionFragmentAccessDetector().HasFragmentAccess(op);
+  int64_t active_threads = SelectActiveThreadExtent(
+      op, num_thread, vectorize_size, analyzer, needs_full_thread_replication);
+  ICHECK_NE(active_threads, 0)
+      << "Cannot find an active thread extent <= " << num_thread
+      << " that evenly partitions loop_total_size=" << ComputeLoopTotalSize(op)
+      << " with vector_size=" << vectorize_size;
+  if (active_threads != num_thread) {
+    if (needs_full_thread_replication) {
+      DLOG(INFO) << "[PlanLoopPartition] using " << active_threads
+                 << "-thread fragment partition replicated across "
+                 << num_thread << " block threads.";
+    } else {
+      DLOG(INFO) << "[PlanLoopPartition] using " << active_threads
+                 << " active threads out of " << num_thread
+                 << " to avoid a ragged loop layout.";
+    }
+  }
   LoopPartitioner partitioner;
-  Fragment fragment = partitioner.Partition(op, num_thread, vectorize_size);
+  Fragment fragment = partitioner.Partition(
+      op, static_cast<int>(active_threads), vectorize_size,
+      needs_full_thread_replication ? static_cast<int>(num_thread)
+                                    : static_cast<int>(active_threads));
   return fragment->BindThreadRange(thread_range);
 }
 

--- a/src/transform/loop_partition.h
+++ b/src/transform/loop_partition.h
@@ -29,6 +29,8 @@
 #include <tvm/tirx/op.h>
 #include <tvm/tirx/stmt.h>
 
+#include <cstdint>
+
 #include "../layout/layout.h"
 #include "../op/operator.h"
 
@@ -43,8 +45,14 @@ For PartitionLoop(For op, Var thread_var, arith::Analyzer *analyzer,
 Fragment PlanLoopPartition(const For &op, size_t num_thread,
                            int vectorize_size);
 
+int64_t SelectActiveThreadExtent(const For &op, int64_t max_num_thread,
+                                 int vectorize_size, arith::Analyzer *analyzer,
+                                 bool require_full_thread_replication = false);
+
 Fragment PlanLoopPartition(const For &op, int vectorize_size,
-                           const Range &thread_range);
+                           const Range &thread_range,
+                           arith::Analyzer *analyzer = nullptr,
+                           bool require_full_thread_replication = false);
 
 For PragmaUnrollLoop(For stmt);
 

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -742,8 +742,8 @@ private:
     }
     if (const auto *var_node = expr.as<VarNode>()) {
       Var var = GetRef<Var>(var_node);
-      auto it = let_bindings_.find(var);
-      if (it != let_bindings_.end()) {
+      auto it = bind_var_to_expr_.find(var);
+      if (it != bind_var_to_expr_.end()) {
         return it->second;
       }
     }
@@ -1059,7 +1059,7 @@ private:
     PrimExpr value = this->VisitExpr(op->value);
     bool recorded = false;
     if (value->IsInstance<BufferLoadNode>()) {
-      let_bindings_[op->var] = value;
+      bind_var_to_expr_[op->var] = value;
       recorded = true;
     }
     if (SideEffect(value) <= CallEffectKind::kPure) {
@@ -1155,10 +1155,10 @@ private:
 
     Range thread_bounds = CurrentThreadBounds();
 
-    // Convert let_bindings_ to Map<Var, PrimExpr> for LowerArgs
-    Map<Var, PrimExpr> let_var_to_expr;
-    for (const auto &[var, expr] : let_bindings_) {
-      let_var_to_expr.Set(var, expr);
+    // Convert Bind values to Map<Var, PrimExpr> for LowerArgs
+    Map<Var, PrimExpr> bind_var_to_expr;
+    for (const auto &[var, expr] : bind_var_to_expr_) {
+      bind_var_to_expr.Set(var, expr);
     }
 
     AllocMBarrierCallback mbarrier_callback = [this](int arrive_count) -> int {
@@ -1178,7 +1178,7 @@ private:
     auto lowered = tile_op->Lower(
         LowerArgs{target_, thread_bounds, thread_var_->var, callback,
                   mbarrier_callback, barrier_arrive_callback, layout_map_,
-                  buffer_remap_, let_var_to_expr,
+                  buffer_remap_, bind_var_to_expr,
                   loop_mbar_phase_stack_.empty()
                       ? PrimExpr(IntImm(DataType::Int(32), 0))
                       : loop_mbar_phase_stack_.back(),
@@ -1485,7 +1485,7 @@ private:
   // By access CallNode instead of BufferLoad Node.
   bool is_ptx_{false};
   std::unordered_map<Var, PrimExpr, ObjectPtrHash, ObjectPtrEqual>
-      let_bindings_;
+      bind_var_to_expr_;
   // Mapping from data Var of a Buffer to Buffer, for lookup
   std::unordered_map<Var, Buffer, ObjectPtrHash, ObjectPtrEqual> buffer_map_;
   Map<Var, Var> var_remap_;

--- a/testing/python/transform/test_tilelang_transform_layout_inference.py
+++ b/testing/python/transform/test_tilelang_transform_layout_inference.py
@@ -100,6 +100,57 @@ def test_loop_tail_split(block_M, block_N, block_K, threads, vec_load_b, dtype):
         # tvm.ir.assert_structural_equal(mod, ref_mod)
 
 
+def test_copy_layout_uses_active_threads_for_ragged_thread_count():
+    block_M = 256
+    block_N = 128
+    threads = 384
+    dtype = T.bfloat16
+
+    @T.prim_func
+    def main(
+        Bias: T.Tensor((block_M, block_N), dtype),
+        C: T.Tensor((block_M, block_N), dtype),
+    ):
+        with T.Kernel(1, 1, threads=threads) as (bx, by):
+            Bias_shared = T.alloc_shared((block_M, block_N), dtype)
+            T.copy(Bias[0:block_M, 0:block_N], Bias_shared)
+            T.copy(Bias_shared, C[0:block_M, 0:block_N])
+
+    with tvm.target.Target(auto_target):
+        mod = tvm.IRModule({"main": main})
+        mod = tvm.tirx.transform.BindTarget(auto_target)(mod)
+        tl.transform.LayoutInference()(mod)
+
+
+def test_fragment_layout_replicates_active_partition_to_full_block():
+    threads = 96
+    hc_mult3 = 24
+    dtype = T.float32
+
+    @T.prim_func
+    def main(
+        Gemm: T.Tensor((hc_mult3,), dtype),
+        Out: T.Tensor((hc_mult3,), dtype),
+    ):
+        with T.Kernel(1, threads=threads) as _:
+            rms = T.alloc_fragment(1, dtype)
+            mixes = T.alloc_fragment(hc_mult3, dtype)
+            T.clear(mixes)
+            rms[0] = 0
+            for j in T.Parallel(hc_mult3):
+                mixes[j] = Gemm[j] + rms[0]
+            mixes_shared = T.alloc_shared(hc_mult3, dtype)
+            T.copy(mixes, mixes_shared)
+            T.copy(mixes_shared, Out[0:hc_mult3])
+
+    with tvm.target.Target(auto_target):
+        mod = tvm.IRModule({"main": main})
+        mod = tvm.tirx.transform.BindTarget(auto_target)(mod)
+        tl.transform.LayoutInference()(mod)
+
+
 if __name__ == "__main__":
     # tilelang.testing.main()
     test_loop_tail_split(64, 64, 32, 128, 8, T.float16)
+    test_copy_layout_uses_active_threads_for_ragged_thread_count()
+    test_fragment_layout_replicates_active_partition_to_full_block()

--- a/testing/python/transform/test_tilelang_transform_layout_inference.py
+++ b/testing/python/transform/test_tilelang_transform_layout_inference.py
@@ -150,7 +150,4 @@ def test_fragment_layout_replicates_active_partition_to_full_block():
 
 
 if __name__ == "__main__":
-    # tilelang.testing.main()
-    test_loop_tail_split(64, 64, 32, 128, 8, T.float16)
-    test_copy_layout_uses_active_threads_for_ragged_thread_count()
-    test_fragment_layout_replicates_active_partition_to_full_block()
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

- Allow SIMT copy layout planning to use a smaller active thread set when the full block thread count would create a ragged non-bijective layout.
- Preserve full-block replication for parallel loops that touch local fragment buffers, so scalar or small fragments remain available across the block.
- Add regressions for both the 384-thread shared-copy case and the 96-thread fragment replication case.

## Changes

- Add active thread extent selection in the loop partitioner based on divisibility of the flattened loop size and vector width.
- Require active fragment partitions to divide the full block thread count, then replicate the base partition across the complete block.
- Teach parallel copy plan candidate selection to account for fragment full-block replication when choosing vector widths.
- Cover ragged shared-copy and fragment-replication layout inference cases in tests.

## Validation

- `./format.sh`
- `cmake --build build -j$(nproc)`
- `PYTHONPATH=$(pwd):${PYTHONPATH} python examples/deepseek_mhc/example_mhc_pre.py`
- `python -m pytest testing/python/transform/test_tilelang_transform_layout_inference.py -x`
- `python -m pytest testing/python/transform/test_tilelang_transform_lower_tile_op.py -x`

## Notes

- Shared/global copies may predicate inactive block threads when a smaller active thread set avoids a ragged layout.
- Fragment loops keep a layout over the full block by replicating a compatible active partition instead of predicating away fragment-owning threads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust thread/vector validation to avoid incompatible or ragged layouts; clearer failures and debug diagnostics when adjustments are needed.
  * Layout inference now correctly tracks bind-variable-based buffer accesses, improving fragment detection and preventing missed layouts.

* **Chores**
  * Loop-partitioning and planning enhanced to use analyzer-assisted proofs and a replication flag to ensure correct active-thread selection and full-block replication.

* **Tests**
  * Added tests for ragged thread counts and fragment-layout replication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->