### PR TITLE
Scalarize vectorized math intrinsics on HIP

### DIFF
--- a/src/backend/rocm/codegen/intrin_rule_hip.cc
+++ b/src/backend/rocm/codegen/intrin_rule_hip.cc
@@ -14,35 +14,36 @@ namespace codegen {
 namespace intrin {
 // Add float suffix to the intrinsics, HIP fast math.
 using tirx::FLowerIntrinsic;
-using tirx::Shuffle;
 
 // HIP has no vectorized fp32 math builtins: exp2f etc. are scalar
-// (float exp2f(float)), with no exp2(float4)/float2 overload (only half2
-// has packed intrinsics like h2exp2). HIPMath/FloatSuffix, therefore return
-// no name for non-scalar dtypes, leaving the op unlowered. Scalarize: lower
-// each lane to the scalar extern and re-pack with a shuffle; scalars fall
-// through to DispatchPureExtern unchanged. (CUDA does the equivalent in
-// codegen's PrintCallExtern; doing it in the lowering rule keeps HIP simple.)
+// (float exp2f(float)), with no exp2(float4)/float2 overload (only half2 has
+// packed intrinsics like h2exp2). So HIPMath/FloatSuffix return no name for a
+// vector dtype and DispatchPureExtern leaves the op unlowered, which the HIP
+// source codegen then can't print. Resolve the extern name from the *element*
+// type instead and emit a vector call_pure_extern; CodeGenTileLangHIP::
+// PrintCallExtern lowers it to one scalar call per lane and stores via
+// PrintVecElemStore, which is correct for HIP's packed carrier types
+// (float32x8 -> ulonglong4, float16x4 -> uint2, etc.). Scalars are unchanged.
 template <typename T, bool dtype_from_arg = false>
 inline PrimExpr DispatchPureExternScalarized(const PrimExpr &e) {
   const CallNode *call = e.as<CallNode>();
   ICHECK(call != nullptr);
-  int lanes = call->dtype.lanes();
-  if (lanes <= 1) {
+  DataType dtype = dtype_from_arg ? call->args[0].dtype() : call->dtype;
+  if (!dtype.is_vector()) {
     return DispatchPureExtern<T, dtype_from_arg>(e);
   }
-  ffi::Array<PrimExpr> lane_vals;
-  ffi::Array<PrimExpr> indices;
-  for (int i = 0; i < lanes; ++i) {
-    ffi::Array<PrimExpr> args;
-    for (auto arg : call->args) {
-      args.push_back(Shuffle::ExtractElement(arg, i));
-    }
-    Call scalar(call->dtype.element_of(), call->op, args);
-    lane_vals.push_back(DispatchPureExtern<T, dtype_from_arg>(scalar));
-    indices.push_back(IntImm(DataType::Int(32), i));
+  const OpNode *op = call->op.as<OpNode>();
+  ICHECK(op != nullptr);
+  std::string name = T()(dtype.element_of(), op->name.substr(5));
+  if (name.empty()) {
+    return e;
   }
-  return Shuffle(lane_vals, indices);
+  ffi::Array<PrimExpr> new_args = {StringImm(name)};
+  for (const auto &arg : call->args) {
+    new_args.push_back(arg);
+  }
+  return Call(call->dtype, builtin::call_pure_extern(), new_args,
+              call->annotations);
 }
 
 struct HIPMath {

--- a/src/backend/rocm/codegen/intrin_rule_hip.cc
+++ b/src/backend/rocm/codegen/intrin_rule_hip.cc
@@ -16,9 +16,9 @@ namespace intrin {
 using tirx::FLowerIntrinsic;
 using tirx::Shuffle;
 
-// HIP has no vectorized fp32 math builtins: exp2f et al. are scalar
+// HIP has no vectorized fp32 math builtins: exp2f etc. are scalar
 // (float exp2f(float)), with no exp2(float4)/float2 overload (only half2
-// has packed intrinsics like h2exp2). HIPMath/FloatSuffix therefore return
+// has packed intrinsics like h2exp2). HIPMath/FloatSuffix, therefore return
 // no name for non-scalar dtypes, leaving the op unlowered. Scalarize: lower
 // each lane to the scalar extern and re-pack with a shuffle; scalars fall
 // through to DispatchPureExtern unchanged. (CUDA does the equivalent in

--- a/src/backend/rocm/codegen/intrin_rule_hip.cc
+++ b/src/backend/rocm/codegen/intrin_rule_hip.cc
@@ -14,6 +14,32 @@ namespace codegen {
 namespace intrin {
 // Add float suffix to the intrinsics, HIP fast math.
 using tirx::FLowerIntrinsic;
+using tirx::Shuffle;
+
+// HIP has no vector math builtins (exp2(float4) etc.), so a vectorized
+// math intrinsic must be scalarized: lower each lane to the scalar extern
+// and re-pack with a shuffle. Falls back to DispatchPureExtern for scalars.
+template <typename T, bool dtype_from_arg = false>
+inline PrimExpr DispatchPureExternScalarized(const PrimExpr &e) {
+  const CallNode *call = e.as<CallNode>();
+  ICHECK(call != nullptr);
+  int lanes = call->dtype.lanes();
+  if (lanes <= 1) {
+    return DispatchPureExtern<T, dtype_from_arg>(e);
+  }
+  ffi::Array<PrimExpr> lane_vals;
+  ffi::Array<PrimExpr> indices;
+  for (int i = 0; i < lanes; ++i) {
+    ffi::Array<PrimExpr> args;
+    for (auto arg : call->args) {
+      args.push_back(Shuffle::ExtractElement(arg, i));
+    }
+    Call scalar(call->dtype.element_of(), call->op, args);
+    lane_vals.push_back(DispatchPureExtern<T, dtype_from_arg>(scalar));
+    indices.push_back(IntImm(DataType::Int(32), i));
+  }
+  return Shuffle(lane_vals, indices);
+}
 
 struct HIPMath {
   std::string operator()(DataType t, std::string name) const {
@@ -132,117 +158,125 @@ template <typename T> static PrimExpr DispatchHIPShuffle(const PrimExpr &e) {
   // NOLINTEND(clang-analyzer-cplusplus.InnerPointer)
 }
 
-TVM_REGISTER_OP("tir.clz").set_attr<FLowerIntrinsic>(
-    "hip.FLowerIntrinsic",
-    DispatchPureExtern<HIPMath, /*dtype_from_arg=*/true>);
+TVM_REGISTER_OP("tirx.clz")
+    .set_attr<FLowerIntrinsic>(
+        "hip.FLowerIntrinsic",
+        DispatchPureExtern<HIPMath, /*dtype_from_arg=*/true>);
 
-TVM_REGISTER_OP("tir.floor")
+TVM_REGISTER_OP("tirx.floor")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
-                               DispatchPureExtern<HIPMath>);
+                               DispatchPureExternScalarized<HIPMath>);
 
-TVM_REGISTER_OP("tir.ceil")
+TVM_REGISTER_OP("tirx.ceil")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
-                               DispatchPureExtern<HIPMath>);
+                               DispatchPureExternScalarized<HIPMath>);
 
-TVM_REGISTER_OP("tir.trunc")
+TVM_REGISTER_OP("tirx.trunc")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
-                               DispatchPureExtern<HIPMath>);
+                               DispatchPureExternScalarized<HIPMath>);
 
-TVM_REGISTER_OP("tir.fabs")
+TVM_REGISTER_OP("tirx.fabs")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
-                               DispatchPureExtern<HIPMath>);
+                               DispatchPureExternScalarized<HIPMath>);
 
-TVM_REGISTER_OP("tir.round")
+TVM_REGISTER_OP("tirx.round")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
-                               DispatchPureExtern<HIPMath>);
+                               DispatchPureExternScalarized<HIPMath>);
 
-TVM_REGISTER_OP("tir.nearbyint")
+TVM_REGISTER_OP("tirx.nearbyint")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
-                               DispatchPureExtern<HIPMath>);
+                               DispatchPureExternScalarized<HIPMath>);
 
-TVM_REGISTER_OP("tir.exp").set_attr<FLowerIntrinsic>(
-    "hip.FLowerIntrinsic", DispatchPureExtern<HIPFastMath>);
-
-TVM_REGISTER_OP("tir.exp2")
+TVM_REGISTER_OP("tirx.exp")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
-                               DispatchPureExtern<HIPMath>);
+                               DispatchPureExternScalarized<HIPFastMath>);
 
-TVM_REGISTER_OP("tir.exp10")
+TVM_REGISTER_OP("tirx.exp2")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
-                               DispatchPureExtern<HIPFastMath>);
+                               DispatchPureExternScalarized<HIPMath>);
 
-TVM_REGISTER_OP("tir.erf").set_attr<FLowerIntrinsic>(
-    "hip.FLowerIntrinsic", DispatchPureExtern<HIPMath>);
-
-TVM_REGISTER_OP("tir.log").set_attr<FLowerIntrinsic>(
-    "hip.FLowerIntrinsic", DispatchPureExtern<HIPFastMath>);
-
-TVM_REGISTER_OP("tir.log2")
+TVM_REGISTER_OP("tirx.exp10")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
-                               DispatchPureExtern<HIPFastMath>);
+                               DispatchPureExternScalarized<HIPFastMath>);
 
-TVM_REGISTER_OP("tir.log10")
+TVM_REGISTER_OP("tirx.erf")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
-                               DispatchPureExtern<HIPFastMath>);
+                               DispatchPureExternScalarized<HIPMath>);
 
-TVM_REGISTER_OP("tir.tan").set_attr<FLowerIntrinsic>(
-    "hip.FLowerIntrinsic", DispatchPureExtern<HIPFastMathTan>);
-
-TVM_REGISTER_OP("tir.cos").set_attr<FLowerIntrinsic>(
-    "hip.FLowerIntrinsic", DispatchPureExtern<HIPFastMath>);
-
-TVM_REGISTER_OP("tir.cosh")
+TVM_REGISTER_OP("tirx.log")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
-                               DispatchPureExtern<HIPMath>);
+                               DispatchPureExternScalarized<HIPFastMath>);
 
-TVM_REGISTER_OP("tir.sin").set_attr<FLowerIntrinsic>(
-    "hip.FLowerIntrinsic", DispatchPureExtern<HIPFastMath>);
-
-TVM_REGISTER_OP("tir.sinh")
+TVM_REGISTER_OP("tirx.log2")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
-                               DispatchPureExtern<HIPMath>);
+                               DispatchPureExternScalarized<HIPFastMath>);
 
-TVM_REGISTER_OP("tir.atan")
+TVM_REGISTER_OP("tirx.log10")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
-                               DispatchPureExtern<HIPMath>);
+                               DispatchPureExternScalarized<HIPFastMath>);
 
-TVM_REGISTER_OP("tir.tanh")
+TVM_REGISTER_OP("tirx.tan")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
-                               DispatchPureExtern<HIPMath>);
+                               DispatchPureExternScalarized<HIPFastMathTan>);
 
-TVM_REGISTER_OP("tir.sqrt")
+TVM_REGISTER_OP("tirx.cos")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
-                               DispatchPureExtern<HIPMath>);
+                               DispatchPureExternScalarized<HIPFastMath>);
 
-TVM_REGISTER_OP("tir.pow").set_attr<FLowerIntrinsic>(
-    "hip.FLowerIntrinsic", DispatchPureExtern<HIPMath>);
+TVM_REGISTER_OP("tirx.cosh")
+    .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
+                               DispatchPureExternScalarized<HIPMath>);
 
-TVM_REGISTER_OP("tir.popcount")
+TVM_REGISTER_OP("tirx.sin")
+    .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
+                               DispatchPureExternScalarized<HIPFastMath>);
+
+TVM_REGISTER_OP("tirx.sinh")
+    .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
+                               DispatchPureExternScalarized<HIPMath>);
+
+TVM_REGISTER_OP("tirx.atan")
+    .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
+                               DispatchPureExternScalarized<HIPMath>);
+
+TVM_REGISTER_OP("tirx.tanh")
+    .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
+                               DispatchPureExternScalarized<HIPMath>);
+
+TVM_REGISTER_OP("tirx.sqrt")
+    .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
+                               DispatchPureExternScalarized<HIPMath>);
+
+TVM_REGISTER_OP("tirx.pow")
+    .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
+                               DispatchPureExternScalarized<HIPMath>);
+
+TVM_REGISTER_OP("tirx.popcount")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchPureExtern<HIPPopcount>);
 
-TVM_REGISTER_OP("tir.tvm_warp_shuffle")
+TVM_REGISTER_OP("tirx.tvm_warp_shuffle")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchHIPShuffle<HIPWarpIntrinsic>);
 
-TVM_REGISTER_OP("tir.tvm_warp_shuffle_up")
+TVM_REGISTER_OP("tirx.tvm_warp_shuffle_up")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchHIPShuffle<HIPWarpIntrinsic>);
 
-TVM_REGISTER_OP("tir.tvm_warp_shuffle_down")
+TVM_REGISTER_OP("tirx.tvm_warp_shuffle_down")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchHIPShuffle<HIPWarpIntrinsic>);
 
-TVM_REGISTER_OP("tir.tvm_warp_activemask")
+TVM_REGISTER_OP("tirx.tvm_warp_activemask")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
                                DispatchHIPWarpActiveMask);
 
-TVM_REGISTER_OP("tir.fmod")
+TVM_REGISTER_OP("tirx.fmod")
     .set_attr<FLowerIntrinsic>("hip.FLowerIntrinsic",
-                               DispatchPureExtern<HIPMath>);
+                               DispatchPureExternScalarized<HIPMath>);
 
 // Register low-level builtin ops.
-TVM_REGISTER_OP("tir.hip.__shfl_sync")
+TVM_REGISTER_OP("tirx.hip.__shfl_sync")
     .set_num_inputs(4)
     .add_argument("mask", "Expr", "The thread mask.")
     .add_argument("var", "Expr", "The variable to sync.")
@@ -254,7 +288,7 @@ TVM_REGISTER_OP("tir.hip.__shfl_sync")
                                Integer(CallEffectKind::kOpaque))
     .set_attr<bool>("hip.need_warp_shuffle", true);
 
-TVM_REGISTER_OP("tir.hip.__shfl_up_sync")
+TVM_REGISTER_OP("tirx.hip.__shfl_up_sync")
     .set_num_inputs(4)
     .add_argument("mask", "Expr", "The thread mask.")
     .add_argument("var", "Expr", "The variable to sync.")
@@ -266,7 +300,7 @@ TVM_REGISTER_OP("tir.hip.__shfl_up_sync")
                                Integer(CallEffectKind::kOpaque))
     .set_attr<bool>("hip.need_warp_shuffle", true);
 
-TVM_REGISTER_OP("tir.hip.__shfl_down_sync")
+TVM_REGISTER_OP("tirx.hip.__shfl_down_sync")
     .set_num_inputs(4)
     .add_argument("mask", "Expr", "The thread mask.")
     .add_argument("var", "Expr", "The variable to sync.")
@@ -279,7 +313,7 @@ TVM_REGISTER_OP("tir.hip.__shfl_down_sync")
                                Integer(CallEffectKind::kOpaque))
     .set_attr<bool>("hip.need_warp_shuffle", true);
 
-TVM_REGISTER_OP("tir.hip.__activemask")
+TVM_REGISTER_OP("tirx.hip.__activemask")
     .set_num_inputs(0)
     .set_attr<TGlobalSymbol>("TGlobalSymbol", "__activemask")
     .set_attr<TCallEffectKind>("TCallEffectKind",

--- a/src/backend/rocm/codegen/intrin_rule_hip.cc
+++ b/src/backend/rocm/codegen/intrin_rule_hip.cc
@@ -16,11 +16,12 @@ namespace intrin {
 using tirx::FLowerIntrinsic;
 using tirx::Shuffle;
 
-// HIP has no vectorized math builtins (no exp2(float4) etc.; the hip
-// templates only provide packed float2 arithmetic), and HIPMath/FloatSuffix
-// return no name for non-scalar dtypes, leaving the op unlowered. Scalarize:
-// lower each lane to the scalar extern and re-pack with a shuffle. Scalars
-// fall through to DispatchPureExtern unchanged. (CUDA does the equivalent in
+// HIP has no vectorized fp32 math builtins: exp2f et al. are scalar
+// (float exp2f(float)), with no exp2(float4)/float2 overload (only half2
+// has packed intrinsics like h2exp2). HIPMath/FloatSuffix therefore return
+// no name for non-scalar dtypes, leaving the op unlowered. Scalarize: lower
+// each lane to the scalar extern and re-pack with a shuffle; scalars fall
+// through to DispatchPureExtern unchanged. (CUDA does the equivalent in
 // codegen's PrintCallExtern; doing it in the lowering rule keeps HIP simple.)
 template <typename T, bool dtype_from_arg = false>
 inline PrimExpr DispatchPureExternScalarized(const PrimExpr &e) {

--- a/testing/python/amd/test_tilelang_hip_codegen.py
+++ b/testing/python/amd/test_tilelang_hip_codegen.py
@@ -766,6 +766,7 @@ def test_pipelined_multi_stage_fp16_gemm(num_stages):
 # ---------------------------------------------------------------------------
 
 
+@tilelang.jit
 def _kernel_vector_exp2_codegen():
     """T.vectorized(VEC) makes T.exp2 lower as tirx.exp2 on float32xVEC."""
     N, VEC = 256, 4

--- a/testing/python/amd/test_tilelang_hip_codegen.py
+++ b/testing/python/amd/test_tilelang_hip_codegen.py
@@ -747,5 +747,54 @@ def test_pipelined_multi_stage_fp16_gemm(num_stages):
     torch.testing.assert_close(C, A.float() @ B.float(), atol=1.0, rtol=5e-2)
 
 
+# ---------------------------------------------------------------------------
+# Fix 7 — src/backend/rocm/codegen/intrin_rule_hip.cc
+#   Scalarize vector math intrinsics on HIP
+#
+# Symptom: A vectorized math op (e.g. tirx.exp2 on float32x4 from a 2D
+#   fragment + T.Parallel) was left unlowered.  HIPMath/FloatSuffix return
+#   "" for non-scalar dtypes, so DispatchPureExtern returned the op
+#   unchanged and CodeGenTileLangHIP -> CodeGenC then threw
+#       tvm.error.InternalError: Unresolved call ir.Op(name="tirx.exp2")
+#   at codegen_c.cc:771.
+#
+# Fix: DispatchPureExternScalarized resolves the extern name from the
+#   *element* dtype and emits a vector call_pure_extern; the existing
+#   CodeGenTileLangHIP::PrintCallExtern then lowers it to one scalar call
+#   per lane via PrintVecElemLoad / PrintVecElemStore, which is carrier-
+#   aware (handles float32x8 -> ulonglong4, float16x4 -> uint2, etc.).
+# ---------------------------------------------------------------------------
+
+
+def _kernel_vector_exp2_codegen():
+    """T.vectorized(VEC) makes T.exp2 lower as tirx.exp2 on float32xVEC."""
+    N, VEC = 256, 4
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), "float32"),
+        B: T.Tensor((N,), "float32"),
+    ):
+        with T.Kernel(N // VEC, threads=1) as bx:
+            for v in T.vectorized(VEC):
+                B[bx * VEC + v] = T.exp2(A[bx * VEC + v])
+
+    return main
+
+
+@tilelang.testing.requires_rocm
+def test_vector_math_scalarized_in_hip_source():
+    """Vectorized T.exp2 must lower to one scalar exp2f per lane on HIP."""
+    src = _kernel_vector_exp2_codegen().get_kernel_source()
+    assert "tirx.exp2" not in src, (
+        "Vectorized tirx.exp2 was left unlowered (would emit 'Unresolved call' from CodeGenC). Generated HIP source:\n" + src
+    )
+    assert src.count("exp2f") >= 4, (
+        "Expected one 'exp2f' per lane (>=4) in HIP source for vectorized "
+        f"T.exp2 over float32x4, got {src.count('exp2f')}. "
+        "Generated HIP source:\n" + src
+    )
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
On HIP, lowering rules now match, which is enough for scalar math, but anything that vectorizes a transcendental still breaks. E.g. `exp2(g)` where `g` is a `float32x4`, and that blows up  at codegen:

```
tvm.error.InternalError: Unresolved call ir.Op(name="tirx.exp2")
    at target/source/codegen_c.cc:771  (CodeGenTileLangHIP -> CodeGenC)
```

The reason is that HIPMath/FloatSuffix only returns a name for scalar float/double. For a `float32x4,` they return an empty string, so `DispatchPureExtern` leaves the call untouched, and the source codegen later trips over the unlowered op. HIP has no `exp2(float4)`. `exp2f` is scalar-only (confirmed with hipcc; only `h2exp2` for `__half2` is packed), so there's nothing to lower it to directly.

This PR adds `DispatchPureExternScalarized<T>`: when the call is a vector, it pulls each lane out with `Shuffle::ExtractElement`, lowers it to the scalar extern, and re-packs the results with a `Shuffle`. Scalars take the existing `DispatchPureExtern` path unchanged. The float-math ops (exp, exp2, log, sqrt, sin, cos, …) are switched over to it; integer/warp/popcount ops are left alone. This mirrors what the CUDA backend already does inside `PrintCallExtern`, just done in the lowering rule instead.

Tested on gfx1150 (Radeon 890M, ROCm 7.2):  A build/run on a larger AMD GPU would be a good extra check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Improvements**
  * Improved HIP code generation for many floating-point math intrinsics on packed/vector data (trig, exp, log, pow, sqrt, fmod), ensuring vector inputs are scalarized per lane for correct lowering.
* **Tests**
  * Added a regression test that verifies vectorized math is lowered into per-lane scalar calls in generated HIP source.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->