### PR TITLE
[FIX] pass enable_2cta to ptx_tcgen05_mma_ts in tcgen05 macro generator

### DIFF
--- a/tilelang/cuda/intrinsics/macro/tcgen05_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/tcgen05_macro_generator.py
@@ -977,6 +977,7 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
                 mask_zero,
                 mask_zero,
                 mask_zero,
+                enable_2cta
             )
 
         return _ts_atom(a_tmem_data, desc_b, C_local_buf)

--- a/tilelang/cuda/intrinsics/macro/tcgen05_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/tcgen05_macro_generator.py
@@ -977,7 +977,7 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
                 mask_zero,
                 mask_zero,
                 mask_zero,
-                enable_2cta
+                enable_2cta,
             )
 
         return _ts_atom(a_tmem_data, desc_b, C_local_buf)


### PR DESCRIPTION
### Problem

When `T.tcgen05_gemm(..., use_2cta=True)` is called with a TMEM operand as A (the TS variant), the generated PTX emits `tcgen05.mma.cta_group::1` regardless of the `use_2cta` flag. The SS variant (both operands in shared memory) correctly emits `cta_group::2`.

Root cause: `tcgen05mma_ts` in `tcgen05_macro_generator.py` calls `T.ptx_tcgen05_mma_ts(...)` without the `enable_2cta` argument, causing it to default to `False`. The SS path at the equivalent location passes `enable_2cta` correctly (line 386).

### Impact

In a 2-CTA kernel that uses `T.tcgen05_gemm` with TMEM as operand A and `use_2cta=True`, the generated MMA instruction uses `cta_group::1`. The subsequent `T.tcgen05_mma_arrive(..., arrive_2cta=True)` then emits `tcgen05.commit.cta_group::2`. The Blackwell hardware requires the commit's `cta_group` to match the preceding MMA's `cta_group`. This mismatch produces `CUDA_ERROR_ILLEGAL_INSTRUCTION` at runtime.

The bug was discovered while implementing 2-CTA warp-specialized kernels that use TS-mode accumulators (e.g. TMEM-sourced operand A with shared-memory operand B).

### Fix

Pass `enable_2cta` as the final argument to `T.ptx_tcgen05_mma_ts`, matching the existing SS path.

### Testing

Verified that a 2-CTA kernel using `T.tcgen05_gemm` with a TMEM operand and `use_2cta=True` now generates `tcgen05.mma.cta_group::2` for the TS MMA instruction and passes correctness checks. Reverting the fix reproduces the illegal instruction.

**Files changed:** `tilelang/intrinsics/tcgen05_macro_generator.py` — one line added (`enable_2cta` as the last argument to `T.ptx_tcgen05_mma_ts`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tensor operation descriptor and TS MMA mode now include the 2-CTA enable flag to ensure correct behavior for multi-cluster / 2-CTA execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2287?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->