### PR TITLE
[Transform] Prefer full-thread loop partitioning

### DIFF
--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -672,9 +672,10 @@ Fragment ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &T) const {
   // As the pass will do post processing to the layout
   auto maybe_remapped_root_ =
       IfBufferRemapLoopGenerator::run(root_, T.buffer_remap, T.layout_map);
-  int vector_size =
+  int initial_vector_size =
       GetVectorizeSize(maybe_remapped_root_, T.analyzer, T.layout_map);
-  DLOG(INFO) << "[PlanLoopPartition] vector_size = " << vector_size << '\n';
+  DLOG(INFO) << "[PlanLoopPartition] vector_size = " << initial_vector_size
+             << '\n';
 
   PrimExpr loop_total_size = 1;
   for (Stmt l = root_; l.as<For>().has_value(); l = l.as<For>().value()->body)
@@ -686,15 +687,36 @@ Fragment ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &T) const {
       << "PlanLoopPartition requires constant thread extent, got "
       << T.thread_bounds;
   bool require_full_thread_replication = !indice_map_.empty();
-  auto has_compatible_threads = [&](int candidate_vector_size) {
+  auto has_full_thread_partition = [&](int candidate_vector_size) {
+    PrimExpr partition_width =
+        T.thread_bounds->extent *
+        make_const(T.thread_bounds->extent.dtype(), candidate_vector_size);
+    return analyzer_.CanProve(floormod(loop_total_size, partition_width) == 0);
+  };
+  auto has_active_thread_partition = [&](int candidate_vector_size) {
     return SelectActiveThreadExtent(root_, *thread_extent,
                                     candidate_vector_size, &analyzer_,
                                     require_full_thread_replication) > 0;
   };
-  while (!has_compatible_threads(vector_size) && vector_size > 1)
+
+  // Preserve the original layout strategy when possible: lower the vector
+  // width first so all block threads participate.  Active-thread partitioning
+  // is a fallback for genuinely ragged thread counts, because fragment layouts
+  // may replicate active partitions across the full block and duplicate work.
+  int vector_size = initial_vector_size;
+  bool use_active_thread_fallback = false;
+  while (!has_full_thread_partition(vector_size) && vector_size > 1)
     vector_size /= 2;
+  if (!has_full_thread_partition(vector_size)) {
+    use_active_thread_fallback = true;
+    vector_size = initial_vector_size;
+    while (!has_active_thread_partition(vector_size) && vector_size > 1)
+      vector_size /= 2;
+  }
   DLOG(INFO) << "[PlanLoopPartition] after adjust: vector_size = "
-             << vector_size << '\n';
+             << vector_size
+             << ", fallback_active_threads=" << use_active_thread_fallback
+             << '\n';
 
   // Check if coalesced_width is defined
   if (auto coalesced_width = root_->annotations.Get(attr::kCoalescedWidth)) {
@@ -710,13 +732,21 @@ Fragment ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &T) const {
       LOG(FATAL) << "coalesced_width should be an IntImmNode.";
     }
   }
-  ICHECK(has_compatible_threads(vector_size))
-      << "Cannot find an active thread extent <= " << *thread_extent
+  if (!use_active_thread_fallback && !has_full_thread_partition(vector_size)) {
+    use_active_thread_fallback = true;
+  }
+  ICHECK(use_active_thread_fallback ? has_active_thread_partition(vector_size)
+                                    : has_full_thread_partition(vector_size))
+      << "Cannot find "
+      << (use_active_thread_fallback ? "an active" : "a full-block")
+      << " thread extent <= " << *thread_extent
       << " that evenly partitions loop_total_size=" << loop_total_size
       << " with vector_size=" << vector_size;
   DLOG(INFO) << "[PlanLoopPartition] root_ = " << root_
              << " ############# vector_size = " << vector_size
-             << ", thread_bounds = " << T.thread_bounds << '\n';
+             << ", thread_bounds = " << T.thread_bounds
+             << ", fallback_active_threads=" << use_active_thread_fallback
+             << '\n';
   auto plan = PlanLoopPartition(root_, vector_size, T.thread_bounds, &analyzer_,
                                 require_full_thread_replication);
   DLOG(INFO) << "[PlanLoopPartition] candidate = " << plan->DebugOutput()

--- a/testing/python/transform/test_tilelang_transform_layout_inference.py
+++ b/testing/python/transform/test_tilelang_transform_layout_inference.py
@@ -149,5 +149,43 @@ def test_fragment_layout_replicates_active_partition_to_full_block():
         tl.transform.LayoutInference()(mod)
 
 
+def test_full_thread_partition_preferred_before_active_fallback():
+    n = tvm.te.var("n")
+    m = tvm.te.var("m")
+    d = 512
+    threads = 256
+    buf_m = 8
+    bm = 32
+    dtype = T.int8
+    index_dtype = T.int32
+
+    @T.prim_func
+    def main(
+        X: T.Tensor((n, d), dtype),
+        INDEX: T.Tensor((m,), index_dtype),
+        Y: T.Tensor((m, d), dtype),
+    ):
+        with T.Kernel(T.ceildiv(m, bm), threads=threads) as bx:
+            index = T.alloc_fragment((buf_m,), index_dtype)
+            values = T.alloc_fragment((buf_m, d), dtype)
+
+            for m_buf_i in T.serial(bm // buf_m):
+                for m_i in T.Parallel(buf_m):
+                    index[m_i] = INDEX[bx * bm + m_buf_i * buf_m + m_i]
+                for m_i, d_i in T.Parallel(buf_m, d):
+                    if index[m_i] >= 0 and index[m_i] < n:
+                        values[m_i, d_i] = X[index[m_i], d_i]
+                    else:
+                        values[m_i, d_i] = T.int8(0)
+                T.copy(values, Y[bx * bm + m_buf_i * buf_m : bx * bm + (m_buf_i + 1) * buf_m, 0:d])
+
+    with tvm.target.Target(auto_target):
+        artifact = tilelang.lower(main, target=auto_target, enable_device_compile=False)
+    kernel_source = str(artifact.kernel_source)
+    assert "signed char values[16]" in kernel_source
+    assert "signed char values[32]" not in kernel_source
+    assert "make_longlong4(" not in kernel_source
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Summary

- Prefer full-block loop partitioning by reducing vector width before falling back to active-thread subsets.
- Preserve the ragged SIMT copy fix for thread counts that cannot be partitioned by the full block.
- Add coverage for the gather-like int8 fragment copy case that should keep the original full-thread strategy.

## Changes

- Split plan candidate selection into a full-thread search followed by an active-thread fallback.
- Restart fallback search from the initial vector size only when full-block partitioning has no valid choice.
- Add a regression that checks CUDA source generation stays on the 16-byte vector path for the 256-thread gather-shaped case.

## Validation

- `pre-commit run --all-files`
- `cmake --build build -j$(nproc)`
- `python -m pytest testing/python/transform/test_tilelang_transform_layout_inference.py -x`
- `python /nfs-df/prod/data/permanent/wanglei/tilelang/debug/0527_bug/gather.py`

## Notes

- Active-thread fallback remains available for genuinely ragged thread counts, such as the 384-thread SIMT copy case where no full-block vector width can evenly partition the loop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced vectorization sizing strategy in parallel operations to better preserve original layout patterns and optimize fallback behavior.

* **Tests**
  * Added test case validating kernel code generation with vectorization strategy selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->