### PR TITLE
[BugFix][CuTeDSL] Support TileKernels backend cases

### DIFF
--- a/src/backend/cuda/codegen/codegen_cutedsl.cc
+++ b/src/backend/cuda/codegen/codegen_cutedsl.cc
@@ -144,16 +144,37 @@ CodeGenTileLangCuTeDSL::CodeGenTileLangCuTeDSL() {
       pass_ctx->GetConfig<Bool>(tl::kEnableFastMath, Bool(false)).value();
 }
 
+void CodeGenTileLangCuTeDSL::InitFuncState_(const PrimFunc &f) {
+  raw_pointer_vars_.clear();
+  CodeGenTileLangPY::InitFuncState_(f);
+}
+
 std::string CodeGenTileLangCuTeDSL::CanonicalizeFastmathFunctionName_(
     const std::string &func_name) const {
   static const std::unordered_map<std::string, std::string> kFastMathMap = {
-      {"divf", "tl.divf"},    {"exp", "tl.exp"},    {"expf", "tl.exp"},
-      {"exp2", "tl.exp2"},    {"exp2f", "tl.exp2"}, {"log", "tl.log"},
-      {"logf", "tl.log"},     {"log2", "tl.log2"},  {"log2f", "tl.log2"},
-      {"log10", "tl.log10"},  {"tan", "tl.tan"},    {"cos", "tl.cos"},
-      {"sin", "tl.sin"},      {"sqrt", "tl.sqrt"},  {"sqrtf", "tl.sqrt"},
-      {"tanh", "tl.tanh"},    {"tanhf", "tl.tanh"}, {"rsqrt", "tl.rsqrt"},
-      {"rsqrtf", "tl.rsqrt"}, {"fabs", "tl.fabsf"}, {"fabsf", "tl.fabsf"},
+      {"divf", "tl.divf"},
+      {"exp", "tl.exp"},
+      {"expf", "tl.exp"},
+      {"exp2", "tl.exp2"},
+      {"exp2f", "tl.exp2"},
+      {"log", "tl.log"},
+      {"logf", "tl.log"},
+      {"log2", "tl.log2"},
+      {"log2f", "tl.log2"},
+      {"log10", "tl.log10"},
+      {"tan", "tl.tan"},
+      {"cos", "tl.cos"},
+      {"sin", "tl.sin"},
+      {"sqrt", "tl.sqrt"},
+      {"sqrtf", "tl.sqrt"},
+      {"tanh", "tl.tanh"},
+      {"tanhf", "tl.tanh"},
+      {"rsqrt", "tl.rsqrt"},
+      {"rsqrtf", "tl.rsqrt"},
+      {"fabs", "tl.fabsf"},
+      {"fabsf", "tl.fabsf"},
+      {"copysign", "tl.copysignf"},
+      {"copysignf", "tl.copysignf"},
   };
 
   auto it = kFastMathMap.find(func_name);
@@ -1733,6 +1754,38 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const BufferStoreNode *op) {
   }
 }
 
+void CodeGenTileLangCuTeDSL::VisitStmt_(const BindNode *op) {
+  if (auto *ptr_type = op->var->type_annotation.as<PointerTypeNode>()) {
+    if (auto *prim_type = ptr_type->element_type.as<PrimTypeNode>()) {
+      if (const CallNode *call = op->value.as<CallNode>();
+          call && call->op.same_as(builtin::reinterpret()) &&
+          call->args.size() == 1U && op->value.dtype().is_handle()) {
+        RegisterHandleType_(op->var.get(), prim_type->dtype);
+        raw_pointer_vars_.insert(op->var.get());
+
+        std::string address_space = "tl.cute.AddressSpace.generic";
+        const std::string scope = ptr_type->storage_scope;
+        if (scope == "global" || scope.empty()) {
+          address_space = "tl.cute.AddressSpace.gmem";
+        } else if (scope == "shared" || scope.rfind("shared.", 0) == 0) {
+          address_space = "tl.cute.AddressSpace.smem";
+        } else if (scope == "local" || scope.rfind("local.", 0) == 0) {
+          address_space = "tl.cute.AddressSpace.rmem";
+        }
+
+        PrintIndent();
+        stream << AllocVarID(op->var.get()) << " = tl.cute.make_ptr(";
+        PrintType(prim_type->dtype, stream);
+        stream << ", " << PrintExpr_(call->args[0]) << ", " << address_space
+               << ")\n";
+        return;
+      }
+    }
+  }
+
+  CodeGenTileLangPY::VisitStmt_(op);
+}
+
 void CodeGenTileLangCuTeDSL::VisitStmt_(const AllocBufferNode *op) {
   DataType alloc_dtype = op->buffer->dtype;
   std::string vid = AllocVarID(op->buffer->data.get());
@@ -2251,7 +2304,15 @@ std::string CodeGenTileLangCuTeDSL::GetBufferPtr_(const BufferNode *buffer,
     scope = GetPtrStorageScope(buffer->data);
 
   std::string ptr_str;
-  if (scope == "shared.barrier" || scope == "shared.cluster_barrier") {
+  if (raw_pointer_vars_.count(buffer_var)) {
+    bool is_handle_type_match = HandleTypeMatch_(buffer_var, effective_dtype);
+    if (is_handle_type_match) {
+      ptr_str = vid;
+    } else {
+      ptr_str = "tl.recast_ptr(" + vid +
+                ", dtype=" + DTypeToString(effective_dtype) + ")";
+    }
+  } else if (scope == "shared.barrier" || scope == "shared.cluster_barrier") {
     ptr_str = vid;
   } else {
     bool is_handle_type_match = HandleTypeMatch_(buffer_var, effective_dtype);
@@ -2271,6 +2332,9 @@ std::string CodeGenTileLangCuTeDSL::GetVarPtr_(const PrimExpr &expr) {
   // For local buffers (rmem tensors), we need to use .iterator to get the
   // pointer since local buffers in CuTeDSL are tensors, not raw pointers
   if (const VarNode *var = expr.as<VarNode>()) {
+    if (raw_pointer_vars_.count(var)) {
+      return GetVarID(var);
+    }
     return GetVarID(var) + ".iterator";
   }
   return PrintExpr_(expr);
@@ -2311,7 +2375,14 @@ std::string CodeGenTileLangCuTeDSL::GetBufferRef_(DataType t,
   }
   bool is_handle_type_match = HandleTypeMatch_(buffer_var, effective_dtype);
   std::string ptr_str;
-  if (is_handle_type_match) {
+  if (raw_pointer_vars_.count(buffer_var)) {
+    if (is_handle_type_match) {
+      ptr_str = vid;
+    } else {
+      ptr_str = "tl.recast_ptr(" + vid +
+                ", dtype=" + DTypeToString(effective_dtype) + ")";
+    }
+  } else if (is_handle_type_match) {
     ptr_str = vid + ".iterator";
   } else {
     ptr_str = "tl.recast_ptr(" + vid +

--- a/src/backend/cuda/codegen/codegen_cutedsl.h
+++ b/src/backend/cuda/codegen/codegen_cutedsl.h
@@ -12,6 +12,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "codegen_py.h"
@@ -24,6 +25,8 @@ public:
   CodeGenTileLangCuTeDSL();
 
 protected:
+  void InitFuncState_(const PrimFunc &f) override;
+
   void PrintFuncDecorator_(std::ostream &os) override; // NOLINT(*)
   void PreFunctionBody_(const PrimFunc &f) override;
 
@@ -45,6 +48,7 @@ protected:
                   std::ostream &os) override; // NOLINT(*)
 
   void VisitStmt_(const BufferStoreNode *op) override;
+  void VisitStmt_(const BindNode *op) override;
   void VisitStmt_(const AllocBufferNode *op) override;
   void VisitStmt_(const AttrStmtNode *op) override;
   void VisitStmt_(const ForNode *op) override;
@@ -95,6 +99,8 @@ private:
   const std::string mbarrier_name_ = "mbarrier";
 
   std::unordered_map<const VarNode *, IntImm> unroll_factor_;
+
+  std::unordered_set<const VarNode *> raw_pointer_vars_;
 
   std::vector<std::string> eviction_policy_names_ = {
       "EVICT_NORMAL", "EVICT_FIRST", "EVICT_LAST"};

--- a/tilelang/contrib/cutedsl/math.py
+++ b/tilelang/contrib/cutedsl/math.py
@@ -11,20 +11,112 @@ __all__ = [
     "sqrt",
     "rsqrt",
     "fabsf",
+    "copysignf",
     "divf",
     "tanh",
 ]
 
-import cutlass.cute as cute
 from cutlass.cute.typing import Union, Numeric
 from cutlass.cute.tensor import TensorSSA
 from cutlass._mlir.dialects import arith, math
-from cutlass.cute.math import exp, exp2, log, log2, log10, tan, cos, sin, sqrt, rsqrt  # noqa: F401
 from cutlass.cute.math import _math_op as _cute_math_op
 
 from cutlass._mlir.dialects import llvm
-from cutlass.base_dsl.typing import Float32
+from cutlass.base_dsl.typing import Float32, Uint32
 from cutlass.cutlass_dsl import T, dsl_user_op
+
+
+def _scalar_arg_type(arg):
+    if isinstance(arg, Numeric):
+        return type(arg)
+    if hasattr(arg, "type"):
+        return Numeric.from_mlir_type(arg.type)
+    return None
+
+
+def _scalar_type_name(scalar_type):
+    return getattr(scalar_type, "__name__", str(scalar_type))
+
+
+def _scalar_result_type(*args):
+    result_type = None
+    for arg in args:
+        arg_type = _scalar_arg_type(arg)
+        if arg_type is None:
+            continue
+        if result_type is None:
+            result_type = arg_type
+        elif arg_type is not result_type:
+            raise TypeError(f"Mixed scalar dtypes are not supported: {_scalar_type_name(result_type)} and {_scalar_type_name(arg_type)}")
+    if result_type is None:
+        raise TypeError("Expected at least one scalar Numeric or MLIR value")
+    return result_type
+
+
+def _tl_math_op(func, fastmath: bool, *args, **kwargs):
+    if any(isinstance(arg, TensorSSA) for arg in args):
+        return _cute_math_op(func, fastmath, *args, **kwargs)
+
+    result_type = _scalar_result_type(*args)
+    if not result_type.is_float:
+        raise TypeError(f"Expected scalar float inputs, but got {result_type}")
+
+    ir_args = []
+    for arg in args:
+        if isinstance(arg, Numeric):
+            if not type(arg).is_float:
+                raise TypeError(f"Expected scalar float inputs, but got {type(arg)}")
+            if type(arg) is result_type:
+                ir_args.append(arg.ir_value())
+            else:
+                ir_args.append(result_type(arg).ir_value())
+        elif hasattr(arg, "ir_value"):
+            ir_args.append(result_type(arg.ir_value()).ir_value())
+        else:
+            ir_args.append(result_type(arg).ir_value())
+
+    fastmath_flag = arith.FastMathFlags.fast if fastmath else arith.FastMathFlags.none
+    return result_type(func(*ir_args, fastmath=fastmath_flag, **kwargs))
+
+
+def exp(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
+    return _tl_math_op(math.exp, fastmath, x, **kwargs)
+
+
+def exp2(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
+    return _tl_math_op(math.exp2, fastmath, x, **kwargs)
+
+
+def log(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
+    return _tl_math_op(math.log, fastmath, x, **kwargs)
+
+
+def log2(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
+    return _tl_math_op(math.log2, fastmath, x, **kwargs)
+
+
+def log10(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
+    return _tl_math_op(math.log10, fastmath, x, **kwargs)
+
+
+def tan(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
+    return _tl_math_op(math.tan, fastmath, x, **kwargs)
+
+
+def cos(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
+    return _tl_math_op(math.cos, fastmath, x, **kwargs)
+
+
+def sin(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
+    return _tl_math_op(math.sin, fastmath, x, **kwargs)
+
+
+def sqrt(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
+    return _tl_math_op(math.sqrt, fastmath, x, **kwargs)
+
+
+def rsqrt(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
+    return _tl_math_op(math.rsqrt, fastmath, x, **kwargs)
 
 
 def exp10(x: Union[TensorSSA, Numeric], fastmath: bool = False) -> Union[TensorSSA, Numeric]:
@@ -34,11 +126,30 @@ def exp10(x: Union[TensorSSA, Numeric], fastmath: bool = False) -> Union[TensorS
 
 
 def fabsf(x: Union[TensorSSA, Numeric], fastmath: bool = False) -> Union[TensorSSA, Numeric]:
-    return _cute_math_op(math.absf, fastmath, x)
+    return _tl_math_op(math.absf, fastmath, x)
 
 
-def divf(x: Union[TensorSSA, Numeric], y: Union[TensorSSA, Numeric], fastmath: bool = False) -> Union[TensorSSA, Numeric]:
-    return _cute_math_op(arith.divf, fastmath, x, y)
+def copysignf(x: Union[TensorSSA, Numeric], y: Union[TensorSSA, Numeric], fastmath: bool = False) -> Union[TensorSSA, Numeric]:
+    if any(isinstance(arg, TensorSSA) for arg in (x, y)):
+        return _cute_math_op(math.copysign, fastmath, x, y)
+
+    result_type = _scalar_result_type(x, y)
+    if result_type is not Float32:
+        raise TypeError(f"copysignf scalar lowering only supports Float32 inputs; got {_scalar_type_name(result_type)}")
+
+    x_bits = Float32(x).bitcast(Uint32)
+    y_bits = Float32(y).bitcast(Uint32)
+    magnitude = x_bits & Uint32(0x7FFFFFFF)
+    sign = y_bits & Uint32(0x80000000)
+    return (magnitude | sign).bitcast(Float32)
+
+
+def divf(
+    x: Union[TensorSSA, Numeric],
+    y: Union[TensorSSA, Numeric],
+    fastmath: bool = False,
+) -> Union[TensorSSA, Numeric]:
+    return _tl_math_op(arith.divf, fastmath, x, y)
 
 
 @dsl_user_op
@@ -60,4 +171,4 @@ def __tanhf(x: Union[float, Float32], *, fastmath, loc=None, ip=None) -> Float32
 
 def tanh(x: Union[TensorSSA, Numeric], fastmath: bool = False) -> Union[TensorSSA, Numeric]:
     tanh_op = __tanhf if fastmath else math.tanh
-    return cute.math._math_op(tanh_op, False, x)
+    return _tl_math_op(tanh_op, False, x)

--- a/tilelang/jit/adapter/cutedsl/wrapper.py
+++ b/tilelang/jit/adapter/cutedsl/wrapper.py
@@ -1203,6 +1203,26 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
     # C++ Launcher Generation
     # =========================================================================
 
+    @staticmethod
+    def _select_launcher_args(
+        function_args: list[dict],
+        kernel_metadata_list: list[dict],
+        all_tma_tensors: list[str],
+    ) -> list[dict]:
+        """Select host launcher args needed by the emitted device launches.
+
+        The Python wrapper still accepts the full PrimFunc signature so callers
+        can pass optional/unused tensors as None. The C++ launcher should only
+        type-bind buffers that are actually dereferenced or passed to CUDA.
+        """
+        active_buffers = set(all_tma_tensors)
+        for kernel_meta in kernel_metadata_list:
+            for arg_name, arg_type in kernel_meta["call_args"]:
+                if arg_type == "buffer":
+                    active_buffers.add(arg_name)
+
+        return [arg for arg in function_args if arg["type"] != "buffer" or arg["name"] in active_buffers]
+
     def _generate_cpp_launcher(
         self,
         kernel_metadata_list: list[dict],
@@ -1231,9 +1251,10 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
         tma_init_func = self._generate_tma_init_func(all_desc_names, all_tma_tensors, tensor_arg_map, scalar_args)
 
         # Generate launch function signature and get_ptr code
+        launcher_args = self._select_launcher_args(function_args, kernel_metadata_list, all_tma_tensors)
         func_sig_parts = []
         get_ptr_code = ""
-        for arg in function_args:
+        for arg in launcher_args:
             if arg["type"] == "buffer":
                 func_sig_parts.append(f"tvm::ffi::TensorView {arg['name']}")
                 get_ptr_code += f"  uint64_t {arg['name']}_ptr = reinterpret_cast<uint64_t>({arg['name']}.data_ptr());\n"
@@ -1364,13 +1385,14 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
     def _generate_python_wrapper(
         self,
         function_args: list[dict],
+        launcher_args: list[dict],
         cubin_gen_code: str,
         cubin_gen_params: str,
     ) -> str:
         """Generate Python wrapper code."""
         # Build function parameters
         call_func_params = ", ".join(arg["name"] for arg in function_args)
-        launcher_call_args = ", ".join(arg["name"] for arg in function_args)
+        launcher_call_args = ", ".join(arg["name"] for arg in launcher_args)
 
         return PYTHON_HOST_FUNC_TEMPLATE.format(
             cubin_gen_params=cubin_gen_params,
@@ -1565,6 +1587,7 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
         launcher_cpp_code = self._generate_cpp_launcher(
             kernel_metadata, function_args, all_tma_tensors, all_desc_names_union, tensor_arg_map
         )
+        launcher_args = self._select_launcher_args(function_args, kernel_metadata, all_tma_tensors)
 
         self.launcher_cpp_code = launcher_cpp_code
         # Use a deterministic name so that:
@@ -1586,7 +1609,7 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
         scalar_names = [arg["name"] for arg in function_args if arg["type"] != "buffer"]
         cubin_gen_params = ", ".join(buffer_names + scalar_names)
 
-        python_wrapper = self._generate_python_wrapper(function_args, cubin_gen_code, cubin_gen_params)
+        python_wrapper = self._generate_python_wrapper(function_args, launcher_args, cubin_gen_code, cubin_gen_params)
 
         return python_wrapper
 


### PR DESCRIPTION
## Summary

This fixes several CuTeDSL backend lowering gaps exposed by TileKernels workloads on H100. The failures are in TileLang's CuTeDSL/Python codegen path, not in the TileKernels test cases themselves.

The patch covers:

- nested scalar math composition for CuTeDSL `Numeric` values;
- scalar `copysignf` lowering that avoids an NVVM-unsupported LLVM intrinsic;
- generated host launcher argument filtering for optional unused buffers passed as `None`;
- pointer-table `reinterpret(handle, int64)` lowering for MHC workloads.

## Background And Failure Modes

TileKernels' CuTeDSL backend coverage exercises code patterns that were not fully legalized by the existing Python codegen.

1. Engram kernels generate nested scalar expressions such as:

```python
sqrt(divf(..., fabsf(...)))
```

The CUTLASS DSL `_math_op` path returns a raw `ArithValue` for scalar `Numeric` inputs. Once the first scalar math op returns `ArithValue`, the value can no longer be passed into another TileLang math wrapper. This showed up during TileKernels benchmark codegen as:

```text
Expected a TensorSSA or Numeric(Float), but got ArithValue
```

2. Engram gate forward uses `copysignf`. In the tested CUDA 13.2 and CUTLASS DSL 4.5.0 stack, directly mapping TileLang `copysignf` through CUTLASS DSL `math.copysign` emits:

```text
llvm.copysign.f32
```

NVVM then rejects that IR during CUDA compilation with:

```text
Unsupported intrinsic: llvm.copysign.f32
```

This is version-compatibility-sensitive behavior in the CUTLASS DSL / MLIR / NVVM pipeline. However, TileLang should not rely on `llvm.copysign.f32` being accepted by the CUDA backend. This is not an H100 hardware limitation and not a TileKernels case bug.

3. Some TileKernels entry points keep optional save-for-backward outputs in the full PrimFunc signature but pass `None` when those tensors are not used. The old generated C++ launcher typed every PrimFunc buffer argument as `TensorView`, so TVM FFI rejected `None` before the emitted CUDA launch was reached.

4. MHC pointer-table workloads read int64 data pointers and reinterpret them as handle-typed pointers for `T.make_tensor`. The old CuTeDSL codegen attempted to print the handle value as a normal scalar dtype and failed before forming a CuTe pointer.

## Fix

- Wrap scalar math op results back into the corresponding CuTeDSL `Numeric` type so nested scalar math remains composable. TensorSSA inputs continue to use the CUTLASS DSL path.
- Reject mixed scalar dtypes explicitly instead of selecting the result dtype from operand order.
- Add `tl.copysignf` lowering. For scalar f32, lower it with `Float32 <-> Uint32` bitcasts and magnitude/sign masks instead of relying on `llvm.copysign.f32`.
- Preserve IEEE sign-bit semantics for `-0.0` and signed NaNs. A compare/select implementation such as `y < 0 ? -abs(x) : abs(x)` would not be equivalent.
- Guard the scalar `copysignf` workaround to `Float32` inputs so non-f32 callers must cast explicitly instead of being silently narrowed.
- Generate C++ launcher parameters only for buffers actually used by emitted device launches or TMA descriptors. The Python wrapper still accepts the full PrimFunc signature, so callers can continue passing `None` for unused optional tensors.
- Lower `reinterpret(handle, int64)` pointer binds into `tl.cute.make_ptr(...)` with the correct element type and address space, and treat those variables as raw pointers when generating buffer references.
- Do not pass `assumed_align` for raw pointer-table addresses unless the IR provides alignment proof. This avoids baking an overstated alignment assumption into the generated CuTeDSL IR.

## Validation

Verified locally on H100 PCIe with:

```text
CUDA 13.2
PyTorch 2.12.0+cu132
nvidia-cutlass-dsl-libs-base 4.5.0
TILELANG_TARGET=cutedsl
```

Checks run:

- rebuilt TileLang native library with `cmake --build build -j 16`;
- `ruff check` / `ruff format --check` passed for the touched Python files;
- `clang-format --dry-run --Werror` passed for the touched C++ files;
- representative TileKernels MHC correctness case passed with `TILELANG_TARGET=cutedsl`;
- representative TileKernels engram gate forward, engram gate backward, and `grad_w_reduce` benchmark cases generated and ran on H100 with `TILELANG_TARGET=cutedsl`;
- review hardening verified that mixed scalar dtypes are rejected and the scalar `copysignf` workaround rejects non-`Float32` inputs.

JayceSu98 <jayce.su@enflame-tech.com>
Co-author GitHub: https://github.com/dingsg
Co-authored-by: dingsg <shengge.ding@enflame-tech.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `copysignf` mathematical function with support for both scalar and tensor inputs.
  * Introduced improved scalar-versus-tensor dispatch for transcendental math operations.

* **Improvements**
  * Extended fastmath function canonicalization coverage.
  * Enhanced pointer type handling in CUDA code generation with improved type casting for reinterpreted pointers and better address space selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->