### PR TITLE
[BugFix][Transform] Deduplicate DeclBuffer names after loop unrolling

### DIFF
--- a/src/transform/unroll_loop.cc
+++ b/src/transform/unroll_loop.cc
@@ -101,6 +101,51 @@ private:
 // The Visitor is used to check whether var is used as write index in a local
 // memory If a loop var is used as indices to a local memory, it must be
 // unrolled so the local memory access can be turned into register access.
+class UnrolledBodyDefFreshener : public StmtExprMutator {
+public:
+  PrimExpr VisitExpr_(const VarNode *op) final {
+    Var var = GetRef<Var>(op);
+    auto it = var_remap_.find(var);
+    if (it != var_remap_.end()) {
+      return (*it).second;
+    }
+    return var;
+  }
+
+  Buffer VisitBufferDef(const Buffer &buffer, bool alloc_data) final {
+    Var data;
+    if (alloc_data) {
+      data = FreshVar(buffer->data);
+    } else {
+      PrimExpr remapped_data = VisitExpr(buffer->data);
+      ICHECK(remapped_data.as<VarNode>())
+          << "Buffer data must remain a Var after freshening definitions";
+      data = Downcast<Var>(remapped_data);
+    }
+
+    auto visit_expr = [this](const PrimExpr &expr) {
+      return this->VisitExpr(expr);
+    };
+    Buffer new_buffer = buffer;
+    auto writer = new_buffer.CopyOnWrite();
+    writer->data = std::move(data);
+    writer->shape = buffer->shape.Map(visit_expr);
+    writer->strides = buffer->strides.Map(visit_expr);
+    writer->elem_offset = visit_expr(buffer->elem_offset);
+    buffer_remap_.Set(buffer, new_buffer);
+    return new_buffer;
+  }
+
+private:
+  Var FreshVar(const Var &var) {
+    Var new_var = Var(make_object<VarNode>(*var.get()));
+    var_remap_.Set(var, new_var);
+    return new_var;
+  }
+
+  Map<Var, Var> var_remap_;
+};
+
 class LoopUnroller : public StmtExprMutator {
 public:
   explicit LoopUnroller(int auto_max_step, int auto_max_depth,
@@ -244,6 +289,7 @@ public:
     for (int i = 0; i < value; ++i) {
       vmap.Set(op->loop_var, op->min + make_const(op->loop_var.dtype(), i));
       Stmt step = Substitute(body, vmap);
+      step = UnrolledBodyDefFreshener()(std::move(step));
       unrolled.push_back(step);
     }
     return SeqStmt::Flatten(unrolled);

--- a/testing/python/transform/test_tilelang_transform_unroll_loop.py
+++ b/testing/python/transform/test_tilelang_transform_unroll_loop.py
@@ -1,0 +1,31 @@
+import tilelang
+from tilelang import tvm
+from tvm.script import ir as I
+from tvm.script import tirx as T
+
+
+def test_unroll_decl_buffer_defs_are_fresh():
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def main(A: T.Buffer((16,), "float32")):
+            for i in T.unroll(2):
+                A_flat = T.decl_buffer((16,), "float32", data=A.data)
+                A_flat[0] = T.float32(i)
+
+    after = tilelang.transform.UnrollLoop()(Before)
+    body = after["main"].body
+
+    decls = [stmt for stmt in body.seq if isinstance(stmt, tvm.tirx.DeclBuffer)]
+    stores = [stmt for stmt in body.seq if isinstance(stmt, tvm.tirx.BufferStore)]
+
+    assert len(decls) == 2
+    assert len(stores) == 2
+    assert not decls[0].buffer.same_as(decls[1].buffer)
+    assert decls[0].buffer.data.same_as(decls[1].buffer.data)
+    assert stores[0].buffer.same_as(decls[0].buffer)
+    assert stores[1].buffer.same_as(decls[1].buffer)
+
+
+if __name__ == "__main__":
+    test_unroll_decl_buffer_defs_are_fresh()


### PR DESCRIPTION
- LoopUnroller::Unroll copies the loop body via Substitute, which preserves buffer names.  After SeqStmt::Flatten, duplicate DeclBuffer statements violate SSA and crash VarUseDefAnalyzer in SplitHostDevice.
- Add DeclBufferDeduper pass that renames duplicate DeclBuffers and remaps BufferLoad/BufferStore references accordingly.  No scope tracking needed since the unrolled body is flat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed loop unrolling to produce distinct buffer declarations for each unrolled iteration, preventing declaration conflicts and improving downstream transformation reliability.
* **Tests**
  * Added a unit test that verifies fresh buffer declarations are created and used correctly during unrolling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->