### PR TITLE
[TIR][Transform] Fix shared.dyn alias sync analysis

### DIFF
--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -1652,7 +1652,12 @@ private:
       }
     }
 
-    if (has_same_index) {
+    // When shared-memory allocation reuse aliases buffers with different
+    // element sizes, equal logical indices do not imply equal byte addresses
+    // (e.g. float32 index i aliases fp8 index 4*i). Fall through to byte-range
+    // analysis in that case so cross-thread WAR/RAW hazards are not missed.
+    bool same_index_means_same_byte = prev.dtype.bytes() == curr.dtype.bytes();
+    if (has_same_index && same_index_means_same_byte) {
       // Use Z3 to check if prev and curr constraints are equivalent.
       // If equivalent, the same set of threads execute both accesses, so no
       // sync is needed.

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -57,6 +57,37 @@ def test_no_sync_between_atomic_adds_to_shared():
 
 
 @tilelang.testing.requires_cuda
+def test_thread_sync_shared_dyn_alias_different_element_sizes():
+    """Reused shared.dyn aliases with different dtypes need byte-based checks."""
+
+    @T.prim_func(private=True)
+    def func():
+        buf_dyn_shmem = T.alloc_buffer((2048,), "uint8", scope="shared.dyn")
+        x_ub: T.handle("float32", "shared.dyn") = T.handle_add_byte_offset(buf_dyn_shmem.data, 0)
+        y_ub: T.handle("float8_e4m3fn", "shared.dyn") = T.handle_add_byte_offset(buf_dyn_shmem.data, 0)
+        x_local = T.alloc_buffer((4,), "float32", scope="local")
+        y_local = T.alloc_buffer((4,), "float8_e4m3fn", scope="local")
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        x_ub_1 = T.decl_buffer((512,), "float32", data=x_ub, scope="shared.dyn")
+        y_ub_1 = T.decl_buffer((512,), "float8_e4m3fn", data=y_ub, scope="shared.dyn")
+        x_local_1 = T.decl_buffer((4,), "float32", data=x_local.data, scope="local")
+        y_local_1 = T.decl_buffer((4,), "float8_e4m3fn", data=y_local.data, scope="local")
+        x_local_1[T.Ramp(0, 1, 4)] = x_ub_1[T.Ramp(tx * 4, 1, 4)]
+        y_local_1[T.Ramp(0, 1, 4)] = T.Cast("float8_e4m3fnx4", x_local_1[T.Ramp(0, 1, 4)])
+        y_ub_1[T.Ramp(tx * 4, 1, 4)] = y_local_1[T.Ramp(0, 1, 4)]
+
+    mod = tvm.IRModule({"main": func})
+    mod = tilelang.transform.ThreadSync("shared.dyn")(mod)
+    s = str(mod.script())
+    assert 'T.tvm_storage_sync("shared.dyn")' in s, f"Expected sync:\n{s}"
+    sync_pos = s.index('T.tvm_storage_sync("shared.dyn")')
+    write_pos = s.index(" = y_local_1[0:4]")
+    assert sync_pos < write_pos, f"Sync should appear before aliased fp8 write:\n{s}"
+
+
+@tilelang.testing.requires_cuda
 def test_thread_sync_handles_int64_tvm_access_ptr_offset():
     """Regression: shared/shared.dyn pointer offsets may be int64.
 


### PR DESCRIPTION
## Summary

- Fix ThreadSync conflict analysis for shared.dyn buffers that alias the same shared-memory bytes through different element sizes.
- Prevent missed cross-thread WAR/RAW hazards when shared-memory allocation reuse maps buffers such as float32 and fp8 to the same base address.

## Changes

- Require same-index fast-path conflict checks to also have matching element byte sizes.
- Fall through to the existing byte-range overlap analysis when reused shared-memory aliases use different dtypes.
- Add a regression test that verifies a sync is inserted before an aliased fp8 write after a float32 read.