### PR TITLE
[Feature] Support unaligned barrier sync

### DIFF
--- a/src/backend/cuda/codegen/codegen_cuda.cc
+++ b/src/backend/cuda/codegen/codegen_cuda.cc
@@ -36,6 +36,13 @@ bool IsValidCPAsyncTransferBytes(int64_t bytes) {
   return bytes == 4 || bytes == 8 || bytes == 16;
 }
 
+bool GetBoolImm(const PrimExpr &expr, const char *name) {
+  const auto *imm = expr.as<IntImmNode>();
+  ICHECK(imm != nullptr && imm->dtype.is_bool())
+      << name << " must be a bool immediate.";
+  return imm->value != 0;
+}
+
 std::optional<DataType> GetAccessPtrElementType(const PrimExpr &expr) {
   const auto *ptr_call = expr.as<CallNode>();
   if (ptr_call == nullptr) {
@@ -1422,7 +1429,7 @@ void CodeGenTileLangCUDA::PrintStorageSync(const CallNode *op) {
           << args[1].dtype();
       this->stream << "tl::__sync_thread_partial(" << PrintExpr(args[1])
                    << ");\n";
-    } else if (args.size() == 3) {
+    } else if (args.size() == 3 || args.size() == 4) {
       ICHECK(args[1].dtype().is_int())
           << "storage_sync barrier_id must be integer type, got "
           << args[1].dtype();
@@ -1430,7 +1437,13 @@ void CodeGenTileLangCUDA::PrintStorageSync(const CallNode *op) {
           << "storage_sync thread_count must be integer type, got "
           << args[2].dtype();
       this->stream << "tl::__sync_thread_partial(" << PrintExpr(args[1]) << ", "
-                   << PrintExpr(args[2]) << ");\n";
+                   << PrintExpr(args[2]);
+      if (args.size() == 4) {
+        this->stream << ", "
+                     << (GetBoolImm(args[3], "storage_sync aligned") ? "true"
+                                                                     : "false");
+      }
+      this->stream << ");\n";
     } else {
       LOG(FATAL) << "Invalid number of arguments for storage sync: "
                  << args.size();
@@ -2541,11 +2554,20 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     }
     this->stream << ");\n";
   } else if (op->op.same_as(tl::named_barrier_arrive())) {
-    ICHECK_EQ(op->args.size(), 2U)
-        << "tl.named_barrier_arrive expects <barrier_id, thread_count>.";
+    ICHECK(op->args.size() == 2U || op->args.size() == 3U)
+        << "tl.named_barrier_arrive expects <barrier_id, thread_count[, "
+           "aligned]>.";
     this->PrintIndent();
-    this->stream << "tl::__named_barrier_arrive("
-                 << this->PrintExpr(op->args[0]) << ", "
+    this->stream << "tl::__named_barrier_arrive";
+    if (op->args.size() == 3U) {
+      this->stream << "<"
+                   << (GetBoolImm(op->args[2],
+                                  "tl.named_barrier_arrive aligned")
+                           ? "true"
+                           : "false")
+                   << ">";
+    }
+    this->stream << "(" << this->PrintExpr(op->args[0]) << ", "
                  << this->PrintExpr(op->args[1]) << ");\n";
   } else if (op->op.same_as(tl::pdl_trigger())) {
     this->PrintIndent();

--- a/src/backend/cuda/codegen/codegen_cutedsl.cc
+++ b/src/backend/cuda/codegen/codegen_cutedsl.cc
@@ -30,6 +30,13 @@ namespace codegen {
 using namespace ffi;
 namespace {
 
+bool GetBoolImm(const PrimExpr &expr, const char *name) {
+  const auto *imm = expr.as<IntImmNode>();
+  ICHECK(imm != nullptr && imm->dtype.is_bool())
+      << name << " must be a bool immediate.";
+  return imm->value != 0;
+}
+
 // Helper to check if a statement subtree contains loop break ops
 // (either tl::loop_break() or builtin::break_loop())
 class LoopBreakDetector : public tirx::StmtExprVisitor {
@@ -2478,7 +2485,7 @@ void CodeGenTileLangCuTeDSL::PrintStorageSync_(const CallNode *op) {
           << "storage_sync barrier_id must be integer type, got "
           << args[1].dtype();
       stream << "tl.sync_thread_partial(" << PrintExpr_(args[1]) << ")\n";
-    } else if (args.size() == 3) {
+    } else if (args.size() == 3 || args.size() == 4) {
       ICHECK(args[1].dtype().is_int())
           << "storage_sync barrier_id must be integer type, got "
           << args[1].dtype();
@@ -2486,7 +2493,13 @@ void CodeGenTileLangCuTeDSL::PrintStorageSync_(const CallNode *op) {
           << "storage_sync thread_count must be integer type, got "
           << args[2].dtype();
       stream << "tl.sync_thread_partial(" << PrintExpr_(args[1]) << ", "
-             << PrintExpr_(args[2]) << ")\n";
+             << PrintExpr_(args[2]);
+      if (args.size() == 4) {
+        stream << ", aligned="
+               << (GetBoolImm(args[3], "storage_sync aligned") ? "True"
+                                                               : "False");
+      }
+      stream << ")\n";
     } else {
       LOG(FATAL) << "Invalid number of arguments for storage sync: "
                  << args.size();

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -581,8 +581,13 @@ template <int y = 1, typename T> TL_DEVICE T pow_of_int(T x) {
 
 // Thread partial barrier synchronization
 // https://docs.nvidia.com/cuda/parallel-thread-execution/#memory-consistency-model
-TL_DEVICE void __sync_thread_partial(int barrier_id = 0, int thread_count = 0) {
-  asm volatile("bar.sync %0, %1;" : : "r"(barrier_id), "r"(thread_count));
+TL_DEVICE void __sync_thread_partial(int barrier_id = 0, int thread_count = 0,
+                                     bool aligned = true) {
+  if (aligned) {
+    asm volatile("bar.sync %0, %1;" : : "r"(barrier_id), "r"(thread_count));
+  } else {
+    asm volatile("barrier.sync %0, %1;" : : "r"(barrier_id), "r"(thread_count));
+  }
 }
 
 // CTA named barrier one-sided arrive (bar.arrive).
@@ -590,8 +595,15 @@ TL_DEVICE void __sync_thread_partial(int barrier_id = 0, int thread_count = 0) {
 // Useful in warp-specialized pipelines where one warp group signals readiness
 // without blocking, while the other waits with bar.sync /
 // __sync_thread_partial.
+template <bool aligned = true>
 TL_DEVICE void __named_barrier_arrive(int barrier_id, int thread_count) {
-  asm volatile("bar.arrive %0, %1;" : : "r"(barrier_id), "r"(thread_count));
+  if (aligned) {
+    asm volatile("bar.arrive %0, %1;" : : "r"(barrier_id), "r"(thread_count));
+  } else {
+    asm volatile("barrier.arrive %0, %1;"
+                 :
+                 : "r"(barrier_id), "r"(thread_count));
+  }
 }
 
 template <int layout_type = 0, int leading_byte_offset = 0,

--- a/testing/python/language/test_tilelang_language_sync_threads.py
+++ b/testing/python/language/test_tilelang_language_sync_threads.py
@@ -39,5 +39,42 @@ def test_sync_threads_with_computed_barrier_id():
     assert "tl::__sync_thread_partial(" in src, src
 
 
+@tilelang.testing.requires_cuda
+def test_sync_threads_unaligned():
+    @T.prim_func
+    def kernel():
+        with T.Kernel(1, threads=256) as (bx,):
+            barrier_id = T.int32(1)
+            T.sync_threads(barrier_id, 128, aligned=False)
+
+    kernel = _compile_cuda(kernel)
+    src = kernel.get_kernel_source()
+    assert "tl::__sync_thread_partial(1, 128, false);" in src, src
+
+
+@tilelang.testing.requires_cuda
+def test_sync_threads_unaligned_positional():
+    @T.prim_func
+    def kernel():
+        with T.Kernel(1, threads=256) as (bx,):
+            T.sync_threads(1, 128, False)
+
+    kernel = _compile_cuda(kernel)
+    src = kernel.get_kernel_source()
+    assert "tl::__sync_thread_partial(1, 128, false);" in src, src
+
+
+@tilelang.testing.requires_cuda
+def test_named_barrier_arrive_unaligned():
+    @T.prim_func
+    def kernel():
+        with T.Kernel(1, threads=256) as (bx,):
+            T.named_barrier_arrive(2, 128, aligned=False)
+
+    kernel = _compile_cuda(kernel)
+    src = kernel.get_kernel_source()
+    assert "tl::__named_barrier_arrive<false>(2, 128);" in src, src
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/tilelang/contrib/cutedsl/reduce.py
+++ b/tilelang/contrib/cutedsl/reduce.py
@@ -185,13 +185,14 @@ def bar_sync(barrier_id, number_of_threads):
     cute.arch.barrier(barrier_id=barrier_id, number_of_threads=number_of_threads)
 
 
-def bar_sync_ptx(barrier_id, number_of_threads):
+def bar_sync_ptx(barrier_id, number_of_threads, aligned=True):
     from cutlass._mlir.dialects import llvm
 
+    instruction = "bar.sync" if aligned else "barrier.sync"
     llvm.inline_asm(
         None,
         [Int32(barrier_id).ir_value(), Int32(number_of_threads).ir_value()],
-        "bar.sync $0, $1;",
+        f"{instruction} $0, $1;",
         "r,r",
         has_side_effects=True,
         is_align_stack=False,

--- a/tilelang/contrib/cutedsl/utils.py
+++ b/tilelang/contrib/cutedsl/utils.py
@@ -129,10 +129,10 @@ def shuffle_elect(thread_extent):
         return (warp_idx % (thread_extent // 32)) == 0
 
 
-def sync_thread_partial(barrier_id=None, thread_count=None):
+def sync_thread_partial(barrier_id=None, thread_count=None, aligned=True):
     from .reduce import bar_sync_ptx
 
-    bar_sync_ptx(barrier_id, thread_count)
+    bar_sync_ptx(barrier_id, thread_count, aligned=aligned)
 
 
 def pack_half2(x, y):

--- a/tilelang/language/builtin.py
+++ b/tilelang/language/builtin.py
@@ -951,17 +951,25 @@ def shfl_up(
     return tirx.call_intrin(value.dtype, tirx.op.Op.get("tl.shfl_up_sync"), _as_uint32_mask(mask), value, delta, width)
 
 
-def sync_threads(barrier_id: int = None, arrive_count: int = None):
+def sync_threads(barrier_id: int = None, arrive_count: int = None, aligned: bool = True):
     """Synchronize all threads in a block."""
     args = []
-    if barrier_id is not None:
+    if not isinstance(aligned, bool):
+        raise TypeError(f"Expect aligned to be bool, but got {type(aligned)}.")
+    if barrier_id is not None or not aligned:
+        if barrier_id is None:
+            barrier_id = 0
         args.append(barrier_id)
-    if arrive_count is not None:
+    if arrive_count is not None or not aligned:
+        if arrive_count is None:
+            arrive_count = 0
         args.append(arrive_count)
+    if not aligned:
+        args.append(tirx.IntImm("bool", False))
     return tirx.call_intrin("int32", "tirx.tvm_storage_sync", "shared", *args)
 
 
-def named_barrier_arrive(barrier_id, thread_count):
+def named_barrier_arrive(barrier_id, thread_count, *, aligned: bool = True):
     """CTA named barrier one-sided arrive (bar.arrive).
 
     Signals that the calling threads have arrived at the named barrier without
@@ -986,8 +994,15 @@ def named_barrier_arrive(barrier_id, thread_count):
                       May be a variable (PrimExpr).
 
     Lowers to: ``asm volatile("bar.arrive %0, %1;" : : "r"(id), "r"(cnt));``
+    by default. Set ``aligned=False`` to emit the unaligned ``barrier.arrive``
+    PTX form.
     """
-    return tirx.call_intrin("handle", tirx.op.Op.get("tl.named_barrier_arrive"), barrier_id, thread_count)
+    if not isinstance(aligned, bool):
+        raise TypeError(f"Expect aligned to be bool, but got {type(aligned)}.")
+    args = [barrier_id, thread_count]
+    if not aligned:
+        args.append(tirx.IntImm("bool", False))
+    return tirx.call_intrin("handle", tirx.op.Op.get("tl.named_barrier_arrive"), *args)
 
 
 def sync_warp(mask: int = None):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `aligned` parameter to sync primitives (`sync_threads()` and `named_barrier_arrive()`), letting callers choose aligned vs unaligned barrier behavior (default: True). Generated kernels will reflect the chosen form.

* **Tests**
  * Added CUDA-focused tests covering unaligned barrier synchronization, including positional and keyword argument usages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->