### PR TITLE
[TIR][Transform] Fix ragged SIMT loop partitioning

### DIFF
--- a/src/backend/common/op/atomic_reduce.h
+++ b/src/backend/common/op/atomic_reduce.h
@@ -182,7 +182,9 @@ struct AtomicReduce {
     }
     auto loop_layout = par_op->GetLoopLayout();
     return LowerParallelLoop(fused_loop, loop_layout, T.thread_var, analyzer,
-                             T.layout_map, par_op->GetPredicate(T.thread_var));
+                             T.layout_map, par_op->GetPredicate(T.thread_var),
+                             /*parallel_loop=*/true, /*should_vectorize=*/true,
+                             par_op->LoopLayoutRequiresPaddingGuard());
   }
 };
 

--- a/src/backend/common/op/transpose.h
+++ b/src/backend/common/op/transpose.h
@@ -51,7 +51,9 @@ struct Transpose {
     auto loop_layout = par_op->GetLoopLayout();
     return LowerParallelLoop(par_op->GetRoot(), loop_layout, T.thread_var,
                              analyzer, T.layout_map,
-                             par_op->GetPredicate(T.thread_var));
+                             par_op->GetPredicate(T.thread_var),
+                             /*parallel_loop=*/true, /*should_vectorize=*/true,
+                             par_op->LoopLayoutRequiresPaddingGuard());
   }
 };
 

--- a/src/backend/cuda/op/atomic_add.cc
+++ b/src/backend/cuda/op/atomic_add.cc
@@ -246,7 +246,9 @@ struct AtomicAdd {
     }
     auto loop_layout = par_op->GetLoopLayout();
     return LowerParallelLoop(fused_loop, loop_layout, T.thread_var, analyzer,
-                             T.layout_map, par_op->GetPredicate(T.thread_var));
+                             T.layout_map, par_op->GetPredicate(T.thread_var),
+                             /*parallel_loop=*/true, /*should_vectorize=*/true,
+                             par_op->LoopLayoutRequiresPaddingGuard());
   }
 
   static LayoutMap InferLayout(const AtomicAddNode &op,

--- a/src/backend/cuda/op/copy.cc
+++ b/src/backend/cuda/op/copy.cc
@@ -361,7 +361,7 @@ private:
   static Layout ComputeLinearLayout(const Buffer &shared_tensor);
 
   static void CollectFragmentLayouts(const PrimExpr &expr,
-                                     const Map<Var, PrimExpr> &bind_var_to_expr,
+                                     const Map<Var, PrimExpr> &let_var_to_expr,
                                      const LayoutMap &existing_layouts,
                                      PrimExpr thread_extent,
                                      Range thread_bounds,
@@ -427,7 +427,7 @@ Layout Copy::ComputeLinearLayout(const Buffer &shared_tensor) {
 }
 
 void Copy::CollectFragmentLayouts(const PrimExpr &expr,
-                                  const Map<Var, PrimExpr> &bind_var_to_expr,
+                                  const Map<Var, PrimExpr> &let_var_to_expr,
                                   const LayoutMap &existing_layouts,
                                   PrimExpr thread_extent, Range thread_bounds,
                                   Map<Buffer, Layout> &result_map) {
@@ -440,8 +440,8 @@ void Copy::CollectFragmentLayouts(const PrimExpr &expr,
       }
     } else if (auto var_node = node.as<VarNode>()) {
       auto var = GetRef<Var>(var_node);
-      if (bind_var_to_expr.count(var)) {
-        CollectFragmentLayouts(bind_var_to_expr[var], bind_var_to_expr,
+      if (let_var_to_expr.count(var)) {
+        CollectFragmentLayouts(let_var_to_expr[var], let_var_to_expr,
                                existing_layouts, thread_extent, thread_bounds,
                                result_map);
       }
@@ -571,15 +571,15 @@ LayoutMap Copy::InferBulkLayout(const CopyNode &op, const LayoutInferArgs &T,
   // Fragment buffers used as TMA indices should be replicated on all threads.
   PrimExpr thread_extent = T.thread_bounds->extent;
   for (const auto &range : op.src_range) {
-    CollectFragmentLayouts(range->min, T.bind_var_to_expr, T.layout_map,
+    CollectFragmentLayouts(range->min, T.let_var_to_expr, T.layout_map,
                            thread_extent, T.thread_bounds, result_map);
-    CollectFragmentLayouts(range->extent, T.bind_var_to_expr, T.layout_map,
+    CollectFragmentLayouts(range->extent, T.let_var_to_expr, T.layout_map,
                            thread_extent, T.thread_bounds, result_map);
   }
   for (const auto &range : op.dst_range) {
-    CollectFragmentLayouts(range->min, T.bind_var_to_expr, T.layout_map,
+    CollectFragmentLayouts(range->min, T.let_var_to_expr, T.layout_map,
                            thread_extent, T.thread_bounds, result_map);
-    CollectFragmentLayouts(range->extent, T.bind_var_to_expr, T.layout_map,
+    CollectFragmentLayouts(range->extent, T.let_var_to_expr, T.layout_map,
                            thread_extent, T.thread_bounds, result_map);
   }
 

--- a/src/backend/cuda/op/copy.cc
+++ b/src/backend/cuda/op/copy.cc
@@ -361,7 +361,7 @@ private:
   static Layout ComputeLinearLayout(const Buffer &shared_tensor);
 
   static void CollectFragmentLayouts(const PrimExpr &expr,
-                                     const Map<Var, PrimExpr> &let_var_to_expr,
+                                     const Map<Var, PrimExpr> &bind_var_to_expr,
                                      const LayoutMap &existing_layouts,
                                      PrimExpr thread_extent,
                                      Range thread_bounds,
@@ -427,7 +427,7 @@ Layout Copy::ComputeLinearLayout(const Buffer &shared_tensor) {
 }
 
 void Copy::CollectFragmentLayouts(const PrimExpr &expr,
-                                  const Map<Var, PrimExpr> &let_var_to_expr,
+                                  const Map<Var, PrimExpr> &bind_var_to_expr,
                                   const LayoutMap &existing_layouts,
                                   PrimExpr thread_extent, Range thread_bounds,
                                   Map<Buffer, Layout> &result_map) {
@@ -440,8 +440,8 @@ void Copy::CollectFragmentLayouts(const PrimExpr &expr,
       }
     } else if (auto var_node = node.as<VarNode>()) {
       auto var = GetRef<Var>(var_node);
-      if (let_var_to_expr.count(var)) {
-        CollectFragmentLayouts(let_var_to_expr[var], let_var_to_expr,
+      if (bind_var_to_expr.count(var)) {
+        CollectFragmentLayouts(bind_var_to_expr[var], bind_var_to_expr,
                                existing_layouts, thread_extent, thread_bounds,
                                result_map);
       }
@@ -571,15 +571,15 @@ LayoutMap Copy::InferBulkLayout(const CopyNode &op, const LayoutInferArgs &T,
   // Fragment buffers used as TMA indices should be replicated on all threads.
   PrimExpr thread_extent = T.thread_bounds->extent;
   for (const auto &range : op.src_range) {
-    CollectFragmentLayouts(range->min, T.let_var_to_expr, T.layout_map,
+    CollectFragmentLayouts(range->min, T.bind_var_to_expr, T.layout_map,
                            thread_extent, T.thread_bounds, result_map);
-    CollectFragmentLayouts(range->extent, T.let_var_to_expr, T.layout_map,
+    CollectFragmentLayouts(range->extent, T.bind_var_to_expr, T.layout_map,
                            thread_extent, T.thread_bounds, result_map);
   }
   for (const auto &range : op.dst_range) {
-    CollectFragmentLayouts(range->min, T.let_var_to_expr, T.layout_map,
+    CollectFragmentLayouts(range->min, T.bind_var_to_expr, T.layout_map,
                            thread_extent, T.thread_bounds, result_map);
-    CollectFragmentLayouts(range->extent, T.let_var_to_expr, T.layout_map,
+    CollectFragmentLayouts(range->extent, T.bind_var_to_expr, T.layout_map,
                            thread_extent, T.thread_bounds, result_map);
   }
 

--- a/src/backend/cuda/op/copy.cc
+++ b/src/backend/cuda/op/copy.cc
@@ -707,7 +707,9 @@ Stmt Copy::LowerCPAsync(const CopyNode &op, const LowerArgs &T,
   auto loop_layout = par_op->GetLoopLayout();
   Stmt lowered_loop =
       LowerParallelLoop(par_op->GetRoot(), loop_layout, T.thread_var, analyzer,
-                        T.layout_map, par_op->GetPredicate(T.thread_var));
+                        T.layout_map, par_op->GetPredicate(T.thread_var),
+                        /*parallel_loop=*/true, /*should_vectorize=*/true,
+                        par_op->LoopLayoutRequiresPaddingGuard());
 
   auto inject_result =
       InjectPTXAsyncCopy(lowered_loop, /*enable_auto_async_copy=*/true,

--- a/src/backend/metal/op/transpose.cc
+++ b/src/backend/metal/op/transpose.cc
@@ -47,7 +47,9 @@ struct Transpose {
     auto loop_layout = par_op->GetLoopLayout();
     return LowerParallelLoop(par_op->GetRoot(), loop_layout, T.thread_var,
                              analyzer, T.layout_map,
-                             par_op->GetPredicate(T.thread_var));
+                             par_op->GetPredicate(T.thread_var),
+                             /*parallel_loop=*/true, /*should_vectorize=*/true,
+                             par_op->LoopLayoutRequiresPaddingGuard());
   }
 };
 

--- a/src/backend/rocm/op/atomic_add.cc
+++ b/src/backend/rocm/op/atomic_add.cc
@@ -228,7 +228,9 @@ struct AtomicAdd {
     }
     auto loop_layout = par_op->GetLoopLayout();
     return LowerParallelLoop(fused_loop, loop_layout, T.thread_var, analyzer,
-                             T.layout_map, par_op->GetPredicate(T.thread_var));
+                             T.layout_map, par_op->GetPredicate(T.thread_var),
+                             /*parallel_loop=*/true, /*should_vectorize=*/true,
+                             par_op->LoopLayoutRequiresPaddingGuard());
   }
 
   static LayoutMap InferLayout(const AtomicAddNode &op,

--- a/src/backend/rocm/op/copy.cc
+++ b/src/backend/rocm/op/copy.cc
@@ -126,9 +126,11 @@ private:
                           level);
     }
     auto loop_layout = par_op->GetLoopLayout();
-    Stmt lowered_loop = LowerParallelLoop(par_op->GetRoot(), loop_layout,
-                                          T.thread_var, analyzer, T.layout_map,
-                                          par_op->GetPredicate(T.thread_var));
+    Stmt lowered_loop = LowerParallelLoop(
+        par_op->GetRoot(), loop_layout, T.thread_var, analyzer, T.layout_map,
+        par_op->GetPredicate(T.thread_var),
+        /*parallel_loop=*/true,
+        /*should_vectorize=*/true, par_op->LoopLayoutRequiresPaddingGuard());
 
     auto inject_result =
         InjectPTXAsyncCopy(lowered_loop, /*enable_auto_async_copy=*/true,

--- a/src/backend/webgpu/op/transpose.cc
+++ b/src/backend/webgpu/op/transpose.cc
@@ -46,7 +46,9 @@ struct Transpose {
     auto loop_layout = par_op->GetLoopLayout();
     return LowerParallelLoop(par_op->GetRoot(), loop_layout, T.thread_var,
                              analyzer, T.layout_map,
-                             par_op->GetPredicate(T.thread_var));
+                             par_op->GetPredicate(T.thread_var),
+                             /*parallel_loop=*/true, /*should_vectorize=*/true,
+                             par_op->LoopLayoutRequiresPaddingGuard());
   }
 };
 

--- a/src/layout/layout.cc
+++ b/src/layout/layout.cc
@@ -594,7 +594,8 @@ Fragment FragmentNode::BindThreadRange(Range thread_range) const {
   return Fragment(n);
 }
 
-std::pair<Layout, arith::IterMapLevel> LayoutNode::InverseWithLevel() const {
+std::pair<Layout, arith::IterMapLevel>
+LayoutNode::InverseWithLevel(bool require_padding_guard) const {
   arith::Analyzer analyzer;
   auto collect_symbolic = [&](const Array<PrimExpr> &shape) {
     Array<PrimExpr> symbolic_dims;
@@ -611,8 +612,9 @@ std::pair<Layout, arith::IterMapLevel> LayoutNode::InverseWithLevel() const {
                        output_shape.end());
   symbolic_dims = collect_symbolic(symbolic_dims);
   bool is_static_shape = symbolic_dims.empty();
-  auto level = is_static_shape ? arith::IterMapLevel::Bijective
-                               : arith::IterMapLevel::NoCheck;
+  auto level = (is_static_shape && !require_padding_guard)
+                   ? arith::IterMapLevel::Bijective
+                   : arith::IterMapLevel::NoCheck;
   if (!is_static_shape) {
     // Runtime guards keep dynamic tails safe, so we allow NoCheck here and
     // warn.
@@ -853,10 +855,12 @@ bool FragmentNode::IsCompletedReplicated() const {
                          ReplicationPlaceholder());
 }
 
-arith::IterMapResult FragmentNode::DetectInjective() const {
-  // lei:To perform injective check, we need to reverse the layout
-  // and use surjective check, now we use bijective check for convenience
-  // can be relaxed in future
+arith::IterMapResult
+FragmentNode::DetectInjective(bool require_padding_guard) const {
+  // To check that the forward map is injective, reverse it and verify that the
+  // recovered coordinates remain independent. require_padding_guard is only
+  // used by generated full-block loop partitions whose mapping is known
+  // injective but whose padded domain is rejected by stricter iter-map checks.
   arith::Analyzer analyzer;
   // Build a flat indices array: [forward_thread_, forward_index_[...]]
   Array<PrimExpr> indices;
@@ -888,8 +892,9 @@ arith::IterMapResult FragmentNode::DetectInjective() const {
   symbolic_dims = collect_symbolic(symbolic_dims);
 
   bool is_static_shape = symbolic_dims.empty();
-  auto level = is_static_shape ? arith::IterMapLevel::Bijective
-                               : arith::IterMapLevel::NoCheck;
+  auto level = (is_static_shape && !require_padding_guard)
+                   ? arith::IterMapLevel::Bijective
+                   : arith::IterMapLevel::NoCheck;
   if (!is_static_shape) {
     DLOG(WARNING)
         << "Fragment::DetectInjective on symbolic layout, falling back to "
@@ -936,7 +941,8 @@ Layout FragmentNode::Inverse() const {
   return std::move(result.first);
 }
 
-std::pair<Layout, arith::IterMapLevel> FragmentNode::InverseWithLevel() const {
+std::pair<Layout, arith::IterMapLevel>
+FragmentNode::InverseWithLevel(bool require_padding_guard) const {
   auto input_size_copy = input_size_;
   input_size_copy.push_back(ReplicateExtent());
   auto forward_index_copy = forward_index_;
@@ -944,7 +950,7 @@ std::pair<Layout, arith::IterMapLevel> FragmentNode::InverseWithLevel() const {
       Substitute(forward_thread_,
                  {{ReplicationPlaceholder(), InputPlaceholder(InputDim())}}));
   auto fwd = Layout(input_size_copy, forward_index_copy);
-  return fwd->InverseWithLevel();
+  return fwd->InverseWithLevel(require_padding_guard);
 }
 
 Fragment FragmentNode::CondenseReplicateVar() const {

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -96,7 +96,8 @@ public:
                          const PrimExpr rescale_num = Integer(1),
                          const PrimExpr rescale_den = Integer(1)) const;
 
-  virtual std::pair<Layout, arith::IterMapLevel> InverseWithLevel() const;
+  virtual std::pair<Layout, arith::IterMapLevel>
+  InverseWithLevel(bool require_padding_guard = false) const;
 
   virtual std::string DebugOutput() const;
 
@@ -142,7 +143,8 @@ public:
                  const PrimExpr rescale_num = Integer(1),
                  const PrimExpr rescale_den = Integer(1)) const;
 
-  std::pair<Layout, arith::IterMapLevel> InverseWithLevel() const final;
+  std::pair<Layout, arith::IterMapLevel>
+  InverseWithLevel(bool require_padding_guard = false) const final;
 
   PrimExpr ThreadExtent() const;
 
@@ -170,7 +172,8 @@ public:
 
   bool IsCompletedReplicated() const;
 
-  arith::IterMapResult DetectInjective() const;
+  arith::IterMapResult
+  DetectInjective(bool require_padding_guard = false) const;
 
   static void RegisterReflection();
 

--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -77,7 +77,9 @@ Stmt LowerNormalCopy(const CopyNode &op, const LowerArgs &T,
   auto loop_layout = par_op->GetLoopLayout();
   return LowerParallelLoop(par_op->GetRoot(), loop_layout, T.thread_var,
                            analyzer, T.layout_map,
-                           par_op->GetPredicate(T.thread_var));
+                           par_op->GetPredicate(T.thread_var),
+                           /*parallel_loop=*/true, /*should_vectorize=*/true,
+                           par_op->LoopLayoutRequiresPaddingGuard());
 }
 
 namespace {
@@ -226,7 +228,9 @@ Stmt LowerIm2ColSIMT(const Im2ColOpNode &op, const LowerArgs &T,
   auto loop_layout = par_op->GetLoopLayout();
   return LowerParallelLoop(par_op->GetRoot(), loop_layout, T.thread_var,
                            analyzer, T.layout_map,
-                           par_op->GetPredicate(T.thread_var));
+                           par_op->GetPredicate(T.thread_var),
+                           /*parallel_loop=*/true, /*should_vectorize=*/true,
+                           par_op->LoopLayoutRequiresPaddingGuard());
 }
 
 bool RegisterDefaultIm2Col() {

--- a/src/op/operator.h
+++ b/src/op/operator.h
@@ -93,9 +93,9 @@ struct LowerArgs {
   UpdateBarrierArriveCallback UpdateBarrierArrive;
   LayoutMap layout_map;
   Map<Buffer, Buffer> buffer_remap;
-  // Map from Bind variable to its bound expression, for resolving
-  // fragment buffer accesses through Bind values
-  Map<Var, PrimExpr> bind_var_to_expr;
+  // Map from LetStmt variable to its bound expression, for resolving
+  // fragment buffer accesses through let bindings
+  Map<Var, PrimExpr> let_var_to_expr;
   // Fallback mbarrier parity for ops that do not carry an explicit
   // tl.pipeline_mbar_phase_expr annotation. LowerTileOp derives this from the
   // nearest enclosing serial loop so non-pipelined TMA loops still alternate
@@ -118,9 +118,9 @@ struct LayoutInferArgs {
   arith::Analyzer *analyzer;
   bool buffer_oob = false;
   Map<Buffer, Buffer> buffer_remap;
-  // Map from Bind variable to its bound expression, for resolving
-  // fragment buffer accesses through Bind values
-  Map<Var, PrimExpr> bind_var_to_expr;
+  // Map from LetStmt variable to its bound expression, for resolving
+  // fragment buffer accesses through let bindings
+  Map<Var, PrimExpr> let_var_to_expr;
   // Whether the current TileOp is nested inside a pipelined loop
   // (i.e. a surrounding loop annotated with num_stages > 0).
   bool in_pipeline = false;

--- a/src/op/operator.h
+++ b/src/op/operator.h
@@ -93,9 +93,9 @@ struct LowerArgs {
   UpdateBarrierArriveCallback UpdateBarrierArrive;
   LayoutMap layout_map;
   Map<Buffer, Buffer> buffer_remap;
-  // Map from LetStmt variable to its bound expression, for resolving
-  // fragment buffer accesses through let bindings
-  Map<Var, PrimExpr> let_var_to_expr;
+  // Map from Bind variable to its bound expression, for resolving
+  // fragment buffer accesses through Bind values
+  Map<Var, PrimExpr> bind_var_to_expr;
   // Fallback mbarrier parity for ops that do not carry an explicit
   // tl.pipeline_mbar_phase_expr annotation. LowerTileOp derives this from the
   // nearest enclosing serial loop so non-pipelined TMA loops still alternate
@@ -118,9 +118,9 @@ struct LayoutInferArgs {
   arith::Analyzer *analyzer;
   bool buffer_oob = false;
   Map<Buffer, Buffer> buffer_remap;
-  // Map from LetStmt variable to its bound expression, for resolving
-  // fragment buffer accesses through let bindings
-  Map<Var, PrimExpr> let_var_to_expr;
+  // Map from Bind variable to its bound expression, for resolving
+  // fragment buffer accesses through Bind values
+  Map<Var, PrimExpr> bind_var_to_expr;
   // Whether the current TileOp is nested inside a pipelined loop
   // (i.e. a surrounding loop annotated with num_stages > 0).
   bool in_pipeline = false;

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -146,12 +146,12 @@ TileOperator ParallelOpNode::Clone() const {
   return ParallelOp(op);
 }
 
-void ParallelOpNode::ExpandLetBindings(
-    const Map<Var, PrimExpr> &let_var_to_expr) {
-  if (let_var_to_expr.empty())
+void ParallelOpNode::ExpandBindValues(
+    const Map<Var, PrimExpr> &bind_var_to_expr) {
+  if (bind_var_to_expr.empty())
     return;
 
-  // Helper function to recursively find BufferLoads through let bindings
+  // Helper function to recursively find BufferLoads through Bind values
   std::function<void(const PrimExpr &)> expand = [&](const PrimExpr &expr) {
     PostOrderVisit(expr, [&](const ObjectRef &node) {
       if (auto bl = node.as<BufferLoadNode>()) {
@@ -160,14 +160,14 @@ void ParallelOpNode::ExpandLetBindings(
         }
       } else if (auto var_node = node.as<VarNode>()) {
         auto var = GetRef<Var>(var_node);
-        if (let_var_to_expr.count(var)) {
-          expand(let_var_to_expr[var]);
+        if (bind_var_to_expr.count(var)) {
+          expand(bind_var_to_expr[var]);
         }
       }
     });
   };
 
-  // Only expand let bindings that are used in root_
+  // Only expand Bind values that are used in root_
   // First, collect all vars used in root_
   std::unordered_set<const VarNode *> used_vars;
   PostOrderVisit(root_, [&](const ObjectRef &node) {
@@ -176,8 +176,8 @@ void ParallelOpNode::ExpandLetBindings(
     }
   });
 
-  // Only expand let bindings for vars that are actually used in root_
-  for (const auto &[var, expr] : let_var_to_expr) {
+  // Only expand Bind values for vars that are actually used in root_
+  for (const auto &[var, expr] : bind_var_to_expr) {
     if (used_vars.count(var.get())) {
       expand(expr);
     }
@@ -263,9 +263,9 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
     return {};
   loop_layout_requires_padding_guard_ = false;
 
-  // Expand let bindings to find fragment buffer accesses
-  if (!T.let_var_to_expr.empty()) {
-    const_cast<ParallelOpNode *>(this)->ExpandLetBindings(T.let_var_to_expr);
+  // Expand Bind values to find fragment buffer accesses
+  if (!T.bind_var_to_expr.empty()) {
+    const_cast<ParallelOpNode *>(this)->ExpandBindValues(T.bind_var_to_expr);
   }
 
   if (level == InferLevel::kStrict) {

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -146,12 +146,12 @@ TileOperator ParallelOpNode::Clone() const {
   return ParallelOp(op);
 }
 
-void ParallelOpNode::ExpandBindValues(
-    const Map<Var, PrimExpr> &bind_var_to_expr) {
-  if (bind_var_to_expr.empty())
+void ParallelOpNode::ExpandLetBindings(
+    const Map<Var, PrimExpr> &let_var_to_expr) {
+  if (let_var_to_expr.empty())
     return;
 
-  // Helper function to recursively find BufferLoads through Bind values
+  // Helper function to recursively find BufferLoads through let bindings
   std::function<void(const PrimExpr &)> expand = [&](const PrimExpr &expr) {
     PostOrderVisit(expr, [&](const ObjectRef &node) {
       if (auto bl = node.as<BufferLoadNode>()) {
@@ -160,14 +160,14 @@ void ParallelOpNode::ExpandBindValues(
         }
       } else if (auto var_node = node.as<VarNode>()) {
         auto var = GetRef<Var>(var_node);
-        if (bind_var_to_expr.count(var)) {
-          expand(bind_var_to_expr[var]);
+        if (let_var_to_expr.count(var)) {
+          expand(let_var_to_expr[var]);
         }
       }
     });
   };
 
-  // Only expand Bind values that are used in root_
+  // Only expand let bindings that are used in root_
   // First, collect all vars used in root_
   std::unordered_set<const VarNode *> used_vars;
   PostOrderVisit(root_, [&](const ObjectRef &node) {
@@ -176,8 +176,8 @@ void ParallelOpNode::ExpandBindValues(
     }
   });
 
-  // Only expand Bind values for vars that are actually used in root_
-  for (const auto &[var, expr] : bind_var_to_expr) {
+  // Only expand let bindings for vars that are actually used in root_
+  for (const auto &[var, expr] : let_var_to_expr) {
     if (used_vars.count(var.get())) {
       expand(expr);
     }
@@ -262,9 +262,9 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
   if (loop_layout_inferred_)
     return {};
 
-  // Expand Bind values to find fragment buffer accesses
-  if (!T.bind_var_to_expr.empty()) {
-    const_cast<ParallelOpNode *>(this)->ExpandBindValues(T.bind_var_to_expr);
+  // Expand let bindings to find fragment buffer accesses
+  if (!T.let_var_to_expr.empty()) {
+    const_cast<ParallelOpNode *>(this)->ExpandLetBindings(T.let_var_to_expr);
   }
 
   if (level == InferLevel::kStrict) {
@@ -681,17 +681,9 @@ Fragment ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &T) const {
     loop_total_size = loop_total_size * l.as<For>().value()->extent;
   DLOG(INFO) << "[PlanLoopPartition] loop_total_size = " << loop_total_size
              << '\n';
-  const int64_t *thread_extent = as_const_int(T.thread_bounds->extent);
-  ICHECK(thread_extent != nullptr)
-      << "PlanLoopPartition requires constant thread extent, got "
-      << T.thread_bounds;
-  bool require_full_thread_replication = !indice_map_.empty();
-  auto has_compatible_threads = [&](int candidate_vector_size) {
-    return SelectActiveThreadExtent(root_, *thread_extent,
-                                    candidate_vector_size, &analyzer_,
-                                    require_full_thread_replication) > 0;
-  };
-  while (!has_compatible_threads(vector_size) && vector_size > 1)
+  while (!analyzer_.CanProve(floormod(loop_total_size, T.thread_bounds->extent *
+                                                           vector_size) == 0) &&
+         vector_size > 1)
     vector_size /= 2;
   DLOG(INFO) << "[PlanLoopPartition] after adjust: vector_size = "
              << vector_size << '\n';
@@ -710,15 +702,10 @@ Fragment ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &T) const {
       LOG(FATAL) << "coalesced_width should be an IntImmNode.";
     }
   }
-  ICHECK(has_compatible_threads(vector_size))
-      << "Cannot find an active thread extent <= " << *thread_extent
-      << " that evenly partitions loop_total_size=" << loop_total_size
-      << " with vector_size=" << vector_size;
   DLOG(INFO) << "[PlanLoopPartition] root_ = " << root_
              << " ############# vector_size = " << vector_size
              << ", thread_bounds = " << T.thread_bounds << '\n';
-  auto plan = PlanLoopPartition(root_, vector_size, T.thread_bounds, &analyzer_,
-                                require_full_thread_replication);
+  auto plan = PlanLoopPartition(root_, vector_size, T.thread_bounds);
   DLOG(INFO) << "[PlanLoopPartition] candidate = " << plan->DebugOutput()
              << '\n';
   return plan;

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -261,6 +261,7 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
                                       InferLevel level) const {
   if (loop_layout_inferred_)
     return {};
+  loop_layout_requires_padding_guard_ = false;
 
   // Expand let bindings to find fragment buffer accesses
   if (!T.let_var_to_expr.empty()) {
@@ -418,6 +419,7 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
     // over-replicate) 2) PlanLoopPartition (often smaller replication)
     Fragment candidate_from_buffer;
     Fragment candidate_from_plan;
+    bool selected_plan_candidate = false;
 
     if (read_source_buffer.defined() && allow_layout_propgate) {
       candidate_from_buffer =
@@ -435,20 +437,26 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
           ChooseBestCandidate(candidate_from_buffer, candidate_from_plan, T);
     } else if (candidate_from_plan.defined()) {
       loop_layout_ = candidate_from_plan;
+      selected_plan_candidate = true;
       DLOG(INFO) << "[FreeInfer] only PlanLoopPartition available, choose it.";
     } else if (candidate_from_buffer.defined()) {
       loop_layout_ = candidate_from_buffer;
       DLOG(INFO)
           << "[FreeInfer] only compute_from_buffer available, choose it.";
     }
+    loop_layout_requires_padding_guard_ =
+        selected_plan_candidate && indice_map_.empty();
   } else if (!loop_layout_.defined()) {
     // In non-free mode without a source buffer, if we don't have any layout
     // yet (e.g., no annotation), we have nothing to infer here.
     return {};
   }
 
-  // check loop_layout_ is injective
-  auto injective_res = loop_layout_->DetectInjective();
+  // Non-fragment SIMT loops may deliberately over-cover a ragged iteration
+  // space; PartitionLoop emits guards for the padded points. Fragment/reducer
+  // loops stay strict because padding would change per-thread ownership.
+  auto injective_res =
+      loop_layout_->DetectInjective(loop_layout_requires_padding_guard_);
   if (!injective_res->errors.empty()) {
     std::ostringstream oss;
     oss << "Loop layout is not injective: " << loop_layout_->DebugOutput()
@@ -681,10 +689,15 @@ Fragment ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &T) const {
     loop_total_size = loop_total_size * l.as<For>().value()->extent;
   DLOG(INFO) << "[PlanLoopPartition] loop_total_size = " << loop_total_size
              << '\n';
-  while (!analyzer_.CanProve(floormod(loop_total_size, T.thread_bounds->extent *
-                                                           vector_size) == 0) &&
-         vector_size > 1)
-    vector_size /= 2;
+  bool has_fragment_access = !indice_map_.empty();
+  if (has_fragment_access) {
+    while (
+        !analyzer_.CanProve(floormod(loop_total_size, T.thread_bounds->extent *
+                                                          vector_size) == 0) &&
+        vector_size > 1) {
+      vector_size /= 2;
+    }
+  }
   DLOG(INFO) << "[PlanLoopPartition] after adjust: vector_size = "
              << vector_size << '\n';
 

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -672,10 +672,9 @@ Fragment ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &T) const {
   // As the pass will do post processing to the layout
   auto maybe_remapped_root_ =
       IfBufferRemapLoopGenerator::run(root_, T.buffer_remap, T.layout_map);
-  int initial_vector_size =
+  int vector_size =
       GetVectorizeSize(maybe_remapped_root_, T.analyzer, T.layout_map);
-  DLOG(INFO) << "[PlanLoopPartition] vector_size = " << initial_vector_size
-             << '\n';
+  DLOG(INFO) << "[PlanLoopPartition] vector_size = " << vector_size << '\n';
 
   PrimExpr loop_total_size = 1;
   for (Stmt l = root_; l.as<For>().has_value(); l = l.as<For>().value()->body)
@@ -687,36 +686,15 @@ Fragment ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &T) const {
       << "PlanLoopPartition requires constant thread extent, got "
       << T.thread_bounds;
   bool require_full_thread_replication = !indice_map_.empty();
-  auto has_full_thread_partition = [&](int candidate_vector_size) {
-    PrimExpr partition_width =
-        T.thread_bounds->extent *
-        make_const(T.thread_bounds->extent.dtype(), candidate_vector_size);
-    return analyzer_.CanProve(floormod(loop_total_size, partition_width) == 0);
-  };
-  auto has_active_thread_partition = [&](int candidate_vector_size) {
+  auto has_compatible_threads = [&](int candidate_vector_size) {
     return SelectActiveThreadExtent(root_, *thread_extent,
                                     candidate_vector_size, &analyzer_,
                                     require_full_thread_replication) > 0;
   };
-
-  // Preserve the original layout strategy when possible: lower the vector
-  // width first so all block threads participate.  Active-thread partitioning
-  // is a fallback for genuinely ragged thread counts, because fragment layouts
-  // may replicate active partitions across the full block and duplicate work.
-  int vector_size = initial_vector_size;
-  bool use_active_thread_fallback = false;
-  while (!has_full_thread_partition(vector_size) && vector_size > 1)
+  while (!has_compatible_threads(vector_size) && vector_size > 1)
     vector_size /= 2;
-  if (!has_full_thread_partition(vector_size)) {
-    use_active_thread_fallback = true;
-    vector_size = initial_vector_size;
-    while (!has_active_thread_partition(vector_size) && vector_size > 1)
-      vector_size /= 2;
-  }
   DLOG(INFO) << "[PlanLoopPartition] after adjust: vector_size = "
-             << vector_size
-             << ", fallback_active_threads=" << use_active_thread_fallback
-             << '\n';
+             << vector_size << '\n';
 
   // Check if coalesced_width is defined
   if (auto coalesced_width = root_->annotations.Get(attr::kCoalescedWidth)) {
@@ -732,21 +710,13 @@ Fragment ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &T) const {
       LOG(FATAL) << "coalesced_width should be an IntImmNode.";
     }
   }
-  if (!use_active_thread_fallback && !has_full_thread_partition(vector_size)) {
-    use_active_thread_fallback = true;
-  }
-  ICHECK(use_active_thread_fallback ? has_active_thread_partition(vector_size)
-                                    : has_full_thread_partition(vector_size))
-      << "Cannot find "
-      << (use_active_thread_fallback ? "an active" : "a full-block")
-      << " thread extent <= " << *thread_extent
+  ICHECK(has_compatible_threads(vector_size))
+      << "Cannot find an active thread extent <= " << *thread_extent
       << " that evenly partitions loop_total_size=" << loop_total_size
       << " with vector_size=" << vector_size;
   DLOG(INFO) << "[PlanLoopPartition] root_ = " << root_
              << " ############# vector_size = " << vector_size
-             << ", thread_bounds = " << T.thread_bounds
-             << ", fallback_active_threads=" << use_active_thread_fallback
-             << '\n';
+             << ", thread_bounds = " << T.thread_bounds << '\n';
   auto plan = PlanLoopPartition(root_, vector_size, T.thread_bounds, &analyzer_,
                                 require_full_thread_replication);
   DLOG(INFO) << "[PlanLoopPartition] candidate = " << plan->DebugOutput()

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -65,6 +65,9 @@ public:
   // annotations). When true, subsequent InferLayout calls can early-exit
   // without re-emitting buffer layout updates.
   mutable bool loop_layout_inferred_ = false;
+  // Whether the inferred loop layout intentionally over-covers a ragged
+  // non-fragment iteration space and therefore needs guarded inverse lowering.
+  mutable bool loop_layout_requires_padding_guard_ = false;
   // The predicate expression for the loop, if any, mutable for lazy
   // construction.
   mutable Optional<PrimExpr> predicate_;
@@ -101,12 +104,17 @@ public:
     loop_layout_ = other.loop_layout_;
     predicate_ = other.predicate_;
     loop_layout_inferred_ = other.loop_layout_inferred_;
+    loop_layout_requires_padding_guard_ =
+        other.loop_layout_requires_padding_guard_;
     annotated_layout_unbound_ = other.annotated_layout_unbound_;
     annotated_predicate_ = other.annotated_predicate_;
   }
 
   // Get the inferred loop layout.
   Fragment GetLoopLayout() const { return loop_layout_; }
+  bool LoopLayoutRequiresPaddingGuard() const {
+    return loop_layout_requires_padding_guard_;
+  }
   // Get the root For loop.
   For GetRoot() const { return root_; }
   // Get the mapping from buffer to access indices + access type.

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -170,10 +170,10 @@ private:
   void AddPredicate(const PrimExpr &expr) const {
     predicate_ = predicate_.defined() ? And(expr, predicate_.value()) : expr;
   }
-  // Expand let bindings to find fragment buffer accesses and add them to
+  // Expand Bind values to find fragment buffer accesses and add them to
   // indice_map_. This handles cases like: a = block_mask_f[i]; T.copy(A[a, 0],
   // ...)
-  void ExpandLetBindings(const Map<Var, PrimExpr> &let_var_to_expr);
+  void ExpandBindValues(const Map<Var, PrimExpr> &bind_var_to_expr);
 
   // Allow ParallelLoopNestVisitor to access private members.
   friend class ParallelLoopNestVisitor;

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -162,10 +162,10 @@ private:
   void AddPredicate(const PrimExpr &expr) const {
     predicate_ = predicate_.defined() ? And(expr, predicate_.value()) : expr;
   }
-  // Expand Bind values to find fragment buffer accesses and add them to
+  // Expand let bindings to find fragment buffer accesses and add them to
   // indice_map_. This handles cases like: a = block_mask_f[i]; T.copy(A[a, 0],
   // ...)
-  void ExpandBindValues(const Map<Var, PrimExpr> &bind_var_to_expr);
+  void ExpandLetBindings(const Map<Var, PrimExpr> &let_var_to_expr);
 
   // Allow ParallelLoopNestVisitor to access private members.
   friend class ParallelLoopNestVisitor;

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -156,7 +156,7 @@ public:
                                                      cur_analyzer,
                                                      buffer_oob,
                                                      {},
-                                                     bind_var_to_expr_,
+                                                     let_var_to_expr_,
                                                      false},
                                      level);
 
@@ -555,7 +555,7 @@ private:
         } else if (auto buffer = getBufferFromRegion(arg)) {
           addToUseList(buffer.value());
         }
-        // Check if the argument uses any Bind variables that reference
+        // Check if the argument uses any LetStmt variables that reference
         // fragment buffers. If so, add those buffers to the use list.
         // This handles cases like: a = block_mask_f[i]; T.copy(A[a, 0], ...)
         CollectFragmentBuffersFromExpr(arg);
@@ -805,14 +805,14 @@ private:
   }
 
   void VisitStmt_(const BindNode *op) final {
-    // Record Bind variable to its bound expression.
-    // This enables tracking fragment buffer accesses through Bind values.
-    bind_var_to_expr_.Set(op->var, op->value);
+    // Record Let variable to its bound expression.
+    // This enables tracking fragment buffer accesses through let bindings.
+    let_var_to_expr_.Set(op->var, op->value);
     IRVisitorWithAnalyzer::VisitStmt_(op);
   }
 
   // Helper: recursively collect fragment buffers from an expression,
-  // following Bind values chain.
+  // following let bindings chain.
   void CollectFragmentBuffersFromExpr(const PrimExpr &expr) {
     PostOrderVisit(expr, [this](const ObjectRef &node) {
       if (auto bl = node.as<BufferLoadNode>()) {
@@ -821,8 +821,8 @@ private:
         }
       } else if (auto var_node = node.as<VarNode>()) {
         auto var = GetRef<Var>(var_node);
-        if (bind_var_to_expr_.count(var)) {
-          CollectFragmentBuffersFromExpr(bind_var_to_expr_[var]);
+        if (let_var_to_expr_.count(var)) {
+          CollectFragmentBuffersFromExpr(let_var_to_expr_[var]);
         }
       }
     });
@@ -991,8 +991,8 @@ private:
   }
 
   Map<Var, Array<Buffer>> buffer_data_to_buffers_;
-  // Map from Bind variable to its bound expression
-  Map<Var, PrimExpr> bind_var_to_expr_;
+  // Map from LetStmt variable to its bound expression
+  Map<Var, PrimExpr> let_var_to_expr_;
   std::vector<ObjectRef> infer_list_stmt_;
   std::vector<TileOperator> infer_list_;
   // Fragment buffers that have accesses outside of TileOps.

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -156,7 +156,7 @@ public:
                                                      cur_analyzer,
                                                      buffer_oob,
                                                      {},
-                                                     let_var_to_expr_,
+                                                     bind_var_to_expr_,
                                                      false},
                                      level);
 
@@ -555,7 +555,7 @@ private:
         } else if (auto buffer = getBufferFromRegion(arg)) {
           addToUseList(buffer.value());
         }
-        // Check if the argument uses any LetStmt variables that reference
+        // Check if the argument uses any Bind variables that reference
         // fragment buffers. If so, add those buffers to the use list.
         // This handles cases like: a = block_mask_f[i]; T.copy(A[a, 0], ...)
         CollectFragmentBuffersFromExpr(arg);
@@ -805,14 +805,14 @@ private:
   }
 
   void VisitStmt_(const BindNode *op) final {
-    // Record Let variable to its bound expression.
-    // This enables tracking fragment buffer accesses through let bindings.
-    let_var_to_expr_.Set(op->var, op->value);
+    // Record Bind variable to its bound expression.
+    // This enables tracking fragment buffer accesses through Bind values.
+    bind_var_to_expr_.Set(op->var, op->value);
     IRVisitorWithAnalyzer::VisitStmt_(op);
   }
 
   // Helper: recursively collect fragment buffers from an expression,
-  // following let bindings chain.
+  // following Bind value chains.
   void CollectFragmentBuffersFromExpr(const PrimExpr &expr) {
     PostOrderVisit(expr, [this](const ObjectRef &node) {
       if (auto bl = node.as<BufferLoadNode>()) {
@@ -821,8 +821,8 @@ private:
         }
       } else if (auto var_node = node.as<VarNode>()) {
         auto var = GetRef<Var>(var_node);
-        if (let_var_to_expr_.count(var)) {
-          CollectFragmentBuffersFromExpr(let_var_to_expr_[var]);
+        if (bind_var_to_expr_.count(var)) {
+          CollectFragmentBuffersFromExpr(bind_var_to_expr_[var]);
         }
       }
     });
@@ -991,8 +991,8 @@ private:
   }
 
   Map<Var, Array<Buffer>> buffer_data_to_buffers_;
-  // Map from LetStmt variable to its bound expression
-  Map<Var, PrimExpr> let_var_to_expr_;
+  // Map from Bind variable to its bound expression
+  Map<Var, PrimExpr> bind_var_to_expr_;
   std::vector<ObjectRef> infer_list_stmt_;
   std::vector<TileOperator> infer_list_;
   // Fragment buffers that have accesses outside of TileOps.

--- a/src/transform/loop_partition.cc
+++ b/src/transform/loop_partition.cc
@@ -25,7 +25,6 @@
 #include "loop_partition.h"
 #include "support/check.h"
 #include <tvm/ir/cast.h>
-#include <tvm/runtime/logging.h>
 
 #include <tvm/tirx/stmt_functor.h>
 
@@ -193,12 +192,8 @@ class LoopPartitioner : public StmtExprVisitor {
 public:
   LoopPartitioner() = default;
 
-  Fragment Partition(const For &op, int num_thread, int vectorize_size,
-                     int replicate_num_thread = -1) {
+  Fragment Partition(const For &op, int num_thread, int vectorize_size) {
     this->VisitStmt(op);
-    if (replicate_num_thread < 0) {
-      replicate_num_thread = num_thread;
-    }
     DataType dtype = DataType::Int(32);
     if (!loop_vars_.empty()) {
       dtype = loop_vars_.back()->var.dtype();
@@ -217,14 +212,9 @@ public:
 
     auto fragment = Fragment(loop_vars_, {idx}, {thd}, {});
     if (has_fragment_) {
-      // Fragment loops need a layout for the whole block. Build the base
-      // partition with active threads, then replicate it across the full block
-      // when the active width is a factor of the block size.
+      // for fragment buffer, we don't need to replicate the loop layout
       auto thread_extent = *as_const_int(fragment->ThreadExtent());
-      ICHECK_EQ(replicate_num_thread % thread_extent, 0)
-          << "Cannot replicate fragment loop layout with thread extent "
-          << thread_extent << " across " << replicate_num_thread << " threads";
-      auto num_thread_fragment = replicate_num_thread / thread_extent;
+      auto num_thread_fragment = num_thread / thread_extent;
       fragment = fragment->Replicate(num_thread_fragment);
     }
     return fragment;
@@ -261,63 +251,6 @@ private:
   Array<IterVar> loop_vars_;
 };
 
-class LoopPartitionFragmentAccessDetector : public StmtExprVisitor {
-public:
-  bool HasFragmentAccess(const For &op) {
-    VisitStmt(op);
-    return has_fragment_;
-  }
-
-private:
-  void VisitExpr_(const BufferLoadNode *op) final {
-    if (IsFragmentBuffer(op->buffer)) {
-      has_fragment_ = true;
-    }
-    StmtExprVisitor::VisitExpr_(op);
-  }
-
-  void VisitStmt_(const BufferStoreNode *op) final {
-    if (IsFragmentBuffer(op->buffer)) {
-      has_fragment_ = true;
-    }
-    StmtExprVisitor::VisitStmt_(op);
-  }
-
-  bool has_fragment_ = false;
-};
-
-static PrimExpr ComputeLoopTotalSize(const For &op) {
-  PrimExpr loop_total_size = 1;
-  for (Stmt l = op; l.as<For>().has_value(); l = l.as<For>().value()->body) {
-    loop_total_size = loop_total_size * l.as<For>().value()->extent;
-  }
-  return loop_total_size;
-}
-
-int64_t SelectActiveThreadExtent(const For &op, int64_t max_num_thread,
-                                 int vectorize_size, arith::Analyzer *analyzer,
-                                 bool require_full_thread_replication) {
-  ICHECK_GT(max_num_thread, 0);
-  ICHECK_GT(vectorize_size, 0);
-
-  arith::Analyzer local_analyzer;
-  arith::Analyzer *az = analyzer != nullptr ? analyzer : &local_analyzer;
-  PrimExpr loop_total_size = ComputeLoopTotalSize(op);
-
-  for (int64_t active_threads = max_num_thread; active_threads >= 1;
-       --active_threads) {
-    if (require_full_thread_replication &&
-        max_num_thread % active_threads != 0) {
-      continue;
-    }
-    PrimExpr partition_width = Integer(active_threads * vectorize_size);
-    if (az->CanProve(floormod(loop_total_size, partition_width) == 0)) {
-      return active_threads;
-    }
-  }
-  return 0;
-}
-
 Fragment PlanLoopPartition(const For &op, size_t num_thread,
                            int vectorize_size) {
   LoopPartitioner partitioner;
@@ -325,38 +258,10 @@ Fragment PlanLoopPartition(const For &op, size_t num_thread,
 }
 
 Fragment PlanLoopPartition(const For &op, int vectorize_size,
-                           const Range &thread_range, arith::Analyzer *analyzer,
-                           bool require_full_thread_replication) {
-  const int64_t *num_thread_ptr = as_const_int(thread_range->extent);
-  ICHECK(num_thread_ptr != nullptr)
-      << "PlanLoopPartition requires constant thread extent, got "
-      << thread_range;
-  int64_t num_thread = *num_thread_ptr;
-  bool needs_full_thread_replication =
-      require_full_thread_replication ||
-      LoopPartitionFragmentAccessDetector().HasFragmentAccess(op);
-  int64_t active_threads = SelectActiveThreadExtent(
-      op, num_thread, vectorize_size, analyzer, needs_full_thread_replication);
-  ICHECK_NE(active_threads, 0)
-      << "Cannot find an active thread extent <= " << num_thread
-      << " that evenly partitions loop_total_size=" << ComputeLoopTotalSize(op)
-      << " with vector_size=" << vectorize_size;
-  if (active_threads != num_thread) {
-    if (needs_full_thread_replication) {
-      DLOG(INFO) << "[PlanLoopPartition] using " << active_threads
-                 << "-thread fragment partition replicated across "
-                 << num_thread << " block threads.";
-    } else {
-      DLOG(INFO) << "[PlanLoopPartition] using " << active_threads
-                 << " active threads out of " << num_thread
-                 << " to avoid a ragged loop layout.";
-    }
-  }
+                           const Range &thread_range) {
+  size_t num_thread = *as_const_int(thread_range->extent);
   LoopPartitioner partitioner;
-  Fragment fragment = partitioner.Partition(
-      op, static_cast<int>(active_threads), vectorize_size,
-      needs_full_thread_replication ? static_cast<int>(num_thread)
-                                    : static_cast<int>(active_threads));
+  Fragment fragment = partitioner.Partition(op, num_thread, vectorize_size);
   return fragment->BindThreadRange(thread_range);
 }
 

--- a/src/transform/loop_partition.cc
+++ b/src/transform/loop_partition.cc
@@ -65,7 +65,7 @@ private:
 
 // Rewrite the parallel loop into a common loop, which is mapped to threads
 For PartitionLoop(For op, Var thread_var, arith::Analyzer *analyzer,
-                  const Fragment &loop_layout) {
+                  const Fragment &loop_layout, bool require_padding_guard) {
   ICHECK(loop_layout.defined());
   ICHECK(thread_var.defined());
   int old_loop_depth = loop_layout->InputDim();
@@ -84,7 +84,7 @@ For PartitionLoop(For op, Var thread_var, arith::Analyzer *analyzer,
   Stmt body = std::move(op);
   Array<PrimExpr> loop_mins;
   Array<PrimExpr> loop_extents;
-  auto inverse_info = loop_layout->InverseWithLevel();
+  auto inverse_info = loop_layout->InverseWithLevel(require_padding_guard);
   auto inv_loop = inverse_info.first;
   auto indices = inv_loop->Forward(Array<PrimExpr>(vars.begin(), vars.end()));
   // Normalize thread var once so we can reuse the same substitution later.
@@ -274,7 +274,7 @@ For PragmaUnrollLoop(For stmt) {
 Stmt LowerParallelLoop(For loop, const Fragment &loop_layout, Var thread_var,
                        arith::Analyzer *analyzer, const LayoutMap &layout_map,
                        Optional<PrimExpr> predicate, bool parallel_loop,
-                       bool should_vectorize) {
+                       bool should_vectorize, bool require_padding_guard) {
   // Save analyzer state to prevent conflicted bindings during vectorization
   auto saved_analyzer = analyzer->Clone();
 
@@ -290,7 +290,8 @@ Stmt LowerParallelLoop(For loop, const Fragment &loop_layout, Var thread_var,
 
   // Step 1: Partition the loop based on the layout (if this is a parallel loop)
   if (parallel_loop) {
-    result_loop = PartitionLoop(result_loop, thread_var, analyzer, loop_layout);
+    result_loop = PartitionLoop(result_loop, thread_var, analyzer, loop_layout,
+                                require_padding_guard);
   }
 
   // Step 2: Vectorize the loop (if requested)

--- a/src/transform/loop_partition.h
+++ b/src/transform/loop_partition.h
@@ -29,8 +29,6 @@
 #include <tvm/tirx/op.h>
 #include <tvm/tirx/stmt.h>
 
-#include <cstdint>
-
 #include "../layout/layout.h"
 #include "../op/operator.h"
 
@@ -45,14 +43,8 @@ For PartitionLoop(For op, Var thread_var, arith::Analyzer *analyzer,
 Fragment PlanLoopPartition(const For &op, size_t num_thread,
                            int vectorize_size);
 
-int64_t SelectActiveThreadExtent(const For &op, int64_t max_num_thread,
-                                 int vectorize_size, arith::Analyzer *analyzer,
-                                 bool require_full_thread_replication = false);
-
 Fragment PlanLoopPartition(const For &op, int vectorize_size,
-                           const Range &thread_range,
-                           arith::Analyzer *analyzer = nullptr,
-                           bool require_full_thread_replication = false);
+                           const Range &thread_range);
 
 For PragmaUnrollLoop(For stmt);
 

--- a/src/transform/loop_partition.h
+++ b/src/transform/loop_partition.h
@@ -38,7 +38,8 @@ namespace tl {
 using namespace tirx;
 
 For PartitionLoop(For op, Var thread_var, arith::Analyzer *analyzer,
-                  const Fragment &loop_layout);
+                  const Fragment &loop_layout,
+                  bool require_padding_guard = false);
 
 Fragment PlanLoopPartition(const For &op, size_t num_thread,
                            int vectorize_size);
@@ -72,7 +73,8 @@ Stmt LowerParallelLoop(
     For loop, const Fragment &loop_layout, Var thread_var,
     arith::Analyzer *analyzer, const LayoutMap &layout_map = {},
     ffi::Optional<PrimExpr> predicate = ffi::Optional<PrimExpr>(),
-    bool parallel_loop = true, bool should_vectorize = true);
+    bool parallel_loop = true, bool should_vectorize = true,
+    bool require_padding_guard = false);
 
 } // namespace tl
 } // namespace tvm

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -742,8 +742,8 @@ private:
     }
     if (const auto *var_node = expr.as<VarNode>()) {
       Var var = GetRef<Var>(var_node);
-      auto it = bind_var_to_expr_.find(var);
-      if (it != bind_var_to_expr_.end()) {
+      auto it = let_bindings_.find(var);
+      if (it != let_bindings_.end()) {
         return it->second;
       }
     }
@@ -1059,7 +1059,7 @@ private:
     PrimExpr value = this->VisitExpr(op->value);
     bool recorded = false;
     if (value->IsInstance<BufferLoadNode>()) {
-      bind_var_to_expr_[op->var] = value;
+      let_bindings_[op->var] = value;
       recorded = true;
     }
     if (SideEffect(value) <= CallEffectKind::kPure) {
@@ -1155,10 +1155,10 @@ private:
 
     Range thread_bounds = CurrentThreadBounds();
 
-    // Convert Bind values to Map<Var, PrimExpr> for LowerArgs
-    Map<Var, PrimExpr> bind_var_to_expr;
-    for (const auto &[var, expr] : bind_var_to_expr_) {
-      bind_var_to_expr.Set(var, expr);
+    // Convert let_bindings_ to Map<Var, PrimExpr> for LowerArgs
+    Map<Var, PrimExpr> let_var_to_expr;
+    for (const auto &[var, expr] : let_bindings_) {
+      let_var_to_expr.Set(var, expr);
     }
 
     AllocMBarrierCallback mbarrier_callback = [this](int arrive_count) -> int {
@@ -1178,7 +1178,7 @@ private:
     auto lowered = tile_op->Lower(
         LowerArgs{target_, thread_bounds, thread_var_->var, callback,
                   mbarrier_callback, barrier_arrive_callback, layout_map_,
-                  buffer_remap_, bind_var_to_expr,
+                  buffer_remap_, let_var_to_expr,
                   loop_mbar_phase_stack_.empty()
                       ? PrimExpr(IntImm(DataType::Int(32), 0))
                       : loop_mbar_phase_stack_.back(),
@@ -1485,7 +1485,7 @@ private:
   // By access CallNode instead of BufferLoad Node.
   bool is_ptx_{false};
   std::unordered_map<Var, PrimExpr, ObjectPtrHash, ObjectPtrEqual>
-      bind_var_to_expr_;
+      let_bindings_;
   // Mapping from data Var of a Buffer to Buffer, for lookup
   std::unordered_map<Var, Buffer, ObjectPtrHash, ObjectPtrEqual> buffer_map_;
   Map<Var, Var> var_remap_;

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -742,8 +742,8 @@ private:
     }
     if (const auto *var_node = expr.as<VarNode>()) {
       Var var = GetRef<Var>(var_node);
-      auto it = let_bindings_.find(var);
-      if (it != let_bindings_.end()) {
+      auto it = bind_var_to_expr_.find(var);
+      if (it != bind_var_to_expr_.end()) {
         return it->second;
       }
     }
@@ -1059,7 +1059,7 @@ private:
     PrimExpr value = this->VisitExpr(op->value);
     bool recorded = false;
     if (value->IsInstance<BufferLoadNode>()) {
-      let_bindings_[op->var] = value;
+      bind_var_to_expr_[op->var] = value;
       recorded = true;
     }
     if (SideEffect(value) <= CallEffectKind::kPure) {
@@ -1155,10 +1155,10 @@ private:
 
     Range thread_bounds = CurrentThreadBounds();
 
-    // Convert let_bindings_ to Map<Var, PrimExpr> for LowerArgs
-    Map<Var, PrimExpr> let_var_to_expr;
-    for (const auto &[var, expr] : let_bindings_) {
-      let_var_to_expr.Set(var, expr);
+    // Convert bind_var_to_expr_ to Map<Var, PrimExpr> for LowerArgs
+    Map<Var, PrimExpr> bind_var_to_expr;
+    for (const auto &[var, expr] : bind_var_to_expr_) {
+      bind_var_to_expr.Set(var, expr);
     }
 
     AllocMBarrierCallback mbarrier_callback = [this](int arrive_count) -> int {
@@ -1178,7 +1178,7 @@ private:
     auto lowered = tile_op->Lower(
         LowerArgs{target_, thread_bounds, thread_var_->var, callback,
                   mbarrier_callback, barrier_arrive_callback, layout_map_,
-                  buffer_remap_, let_var_to_expr,
+                  buffer_remap_, bind_var_to_expr,
                   loop_mbar_phase_stack_.empty()
                       ? PrimExpr(IntImm(DataType::Int(32), 0))
                       : loop_mbar_phase_stack_.back(),
@@ -1485,7 +1485,7 @@ private:
   // By access CallNode instead of BufferLoad Node.
   bool is_ptx_{false};
   std::unordered_map<Var, PrimExpr, ObjectPtrHash, ObjectPtrEqual>
-      let_bindings_;
+      bind_var_to_expr_;
   // Mapping from data Var of a Buffer to Buffer, for lookup
   std::unordered_map<Var, Buffer, ObjectPtrHash, ObjectPtrEqual> buffer_map_;
   Map<Var, Var> var_remap_;

--- a/testing/python/transform/test_tilelang_transform_layout_inference.py
+++ b/testing/python/transform/test_tilelang_transform_layout_inference.py
@@ -100,54 +100,6 @@ def test_loop_tail_split(block_M, block_N, block_K, threads, vec_load_b, dtype):
         # tvm.ir.assert_structural_equal(mod, ref_mod)
 
 
-def test_copy_layout_uses_active_threads_for_ragged_thread_count():
-    block_M = 256
-    block_N = 128
-    threads = 384
-    dtype = T.bfloat16
-
-    @T.prim_func
-    def main(
-        Bias: T.Tensor((block_M, block_N), dtype),
-        C: T.Tensor((block_M, block_N), dtype),
-    ):
-        with T.Kernel(1, 1, threads=threads) as (bx, by):
-            Bias_shared = T.alloc_shared((block_M, block_N), dtype)
-            T.copy(Bias[0:block_M, 0:block_N], Bias_shared)
-            T.copy(Bias_shared, C[0:block_M, 0:block_N])
-
-    with tvm.target.Target(auto_target):
-        mod = tvm.IRModule({"main": main})
-        mod = tvm.tirx.transform.BindTarget(auto_target)(mod)
-        tl.transform.LayoutInference()(mod)
-
-
-def test_fragment_layout_replicates_active_partition_to_full_block():
-    threads = 96
-    hc_mult3 = 24
-    dtype = T.float32
-
-    @T.prim_func
-    def main(
-        Gemm: T.Tensor((hc_mult3,), dtype),
-        Out: T.Tensor((hc_mult3,), dtype),
-    ):
-        with T.Kernel(1, threads=threads) as _:
-            rms = T.alloc_fragment(1, dtype)
-            mixes = T.alloc_fragment(hc_mult3, dtype)
-            T.clear(mixes)
-            rms[0] = 0
-            for j in T.Parallel(hc_mult3):
-                mixes[j] = Gemm[j] + rms[0]
-            mixes_shared = T.alloc_shared(hc_mult3, dtype)
-            T.copy(mixes, mixes_shared)
-            T.copy(mixes_shared, Out[0:hc_mult3])
-
-    with tvm.target.Target(auto_target):
-        mod = tvm.IRModule({"main": main})
-        mod = tvm.tirx.transform.BindTarget(auto_target)(mod)
-        tl.transform.LayoutInference()(mod)
-
-
 if __name__ == "__main__":
-    tilelang.testing.main()
+    # tilelang.testing.main()
+    test_loop_tail_split(64, 64, 32, 128, 8, T.float16)

--- a/testing/python/transform/test_tilelang_transform_layout_inference.py
+++ b/testing/python/transform/test_tilelang_transform_layout_inference.py
@@ -124,5 +124,4 @@ def test_static_ragged_copy_uses_full_block_predicate():
 
 
 if __name__ == "__main__":
-    # tilelang.testing.main()
-    test_loop_tail_split(64, 64, 32, 128, 8, T.float16)
+    tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_layout_inference.py
+++ b/testing/python/transform/test_tilelang_transform_layout_inference.py
@@ -100,6 +100,29 @@ def test_loop_tail_split(block_M, block_N, block_K, threads, vec_load_b, dtype):
         # tvm.ir.assert_structural_equal(mod, ref_mod)
 
 
+def test_static_ragged_copy_uses_full_block_predicate():
+    n = 514
+    threads = 128
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((n,), T.float32),
+        B: T.Tensor((n,), T.float32),
+    ):
+        with T.Kernel(1, threads=threads):
+            T.copy(A, B)
+
+    with tvm.target.Target(auto_target):
+        artifact = tl.lower(main, target=auto_target, enable_device_compile=False)
+
+    kernel_source = str(artifact.kernel_source)
+    assert "__launch_bounds__(128, 1)" in kernel_source
+    assert "for (int i = 0; i < 3; ++i)" in kernel_source
+    assert "threadIdx.x)) < 257" in kernel_source
+    assert "float2" in kernel_source
+    assert "threadIdx.x) < 1" not in kernel_source
+
+
 if __name__ == "__main__":
     # tilelang.testing.main()
     test_loop_tail_split(64, 64, 32, 128, 8, T.float16)

--- a/testing/python/transform/test_tilelang_transform_layout_inference.py
+++ b/testing/python/transform/test_tilelang_transform_layout_inference.py
@@ -149,43 +149,5 @@ def test_fragment_layout_replicates_active_partition_to_full_block():
         tl.transform.LayoutInference()(mod)
 
 
-def test_full_thread_partition_preferred_before_active_fallback():
-    n = tvm.te.var("n")
-    m = tvm.te.var("m")
-    d = 512
-    threads = 256
-    buf_m = 8
-    bm = 32
-    dtype = T.int8
-    index_dtype = T.int32
-
-    @T.prim_func
-    def main(
-        X: T.Tensor((n, d), dtype),
-        INDEX: T.Tensor((m,), index_dtype),
-        Y: T.Tensor((m, d), dtype),
-    ):
-        with T.Kernel(T.ceildiv(m, bm), threads=threads) as bx:
-            index = T.alloc_fragment((buf_m,), index_dtype)
-            values = T.alloc_fragment((buf_m, d), dtype)
-
-            for m_buf_i in T.serial(bm // buf_m):
-                for m_i in T.Parallel(buf_m):
-                    index[m_i] = INDEX[bx * bm + m_buf_i * buf_m + m_i]
-                for m_i, d_i in T.Parallel(buf_m, d):
-                    if index[m_i] >= 0 and index[m_i] < n:
-                        values[m_i, d_i] = X[index[m_i], d_i]
-                    else:
-                        values[m_i, d_i] = T.int8(0)
-                T.copy(values, Y[bx * bm + m_buf_i * buf_m : bx * bm + (m_buf_i + 1) * buf_m, 0:d])
-
-    with tvm.target.Target(auto_target):
-        artifact = tilelang.lower(main, target=auto_target, enable_device_compile=False)
-    kernel_source = str(artifact.kernel_source)
-    assert "signed char values[16]" in kernel_source
-    assert "signed char values[32]" not in kernel_source
-    assert "make_longlong4(" not in kernel_source
-
-
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Summary

- Replace the active-thread ragged SIMT partitioning approach with full-block predicated lowering for non-fragment loops.
- Keep fragment and reducer loop layouts on strict full-block ownership semantics.
- Restore correctness for dynamic all-reducer loops while preserving efficient static ragged copy lowering.

## Changes

- Revert the previous ragged SIMT active-thread partition changes that could select poor active widths or duplicate reducer work.
- Thread a `LoopLayoutRequiresPaddingGuard()` flag from layout inference into loop partition lowering so generated non-fragment ragged layouts can use padded inverse mapping with runtime guards.
- Keep fragment/reducer paths strict by default and only enable guarded padded inverse for PlanLoopPartition-generated non-fragment layouts.
- Add a regression test for static ragged copy lowering that verifies full-block predicated `float2` copy generation instead of single-thread active fallback.

## Validation

- `./format.sh`
- `cmake --build build -j$(nproc)`
- `TILELANG_DISABLE_CACHE=1 PYTHONPATH=$PWD:$PYTHONPATH python debug/0528_issues/simple_copy.py`
- `TILELANG_DISABLE_CACHE=1 PYTHONPATH=$PWD:$PYTHONPATH python debug/0528_issues/schedule_mtp_varlen.py`
- `PYTHONPATH=$PWD:$PYTHONPATH python -m pytest testing/python/transform/test_tilelang_transform_layout_inference.py -x`
- `PYTHONPATH=$PWD:$PYTHONPATH python -m pytest testing/python/transform/test_tilelang_transform_lower_tile_op.py -x`

## Notes

- The dequant GEMM Hopper example now compiles past layout inference; it still hits the existing dynamic shared memory runtime limit when launched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactoring**
  * Improved parallel-loop lowering across multiple backends to enable vectorization and respect loop-layout padding guards
  * Simplified loop-partition planning and padding-guard handling for ragged/non-rectangular iteration spaces
  * Enhanced layout inference to better detect when padding guards are required

* **Tests**
  * Updated test coverage for static ragged copy behavior and lowered kernels

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->