### PR TITLE
[Reduce][Codegen] Guard packed local reduce ramp loads

### DIFF
--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -247,6 +247,34 @@ inline std::optional<std::string> MakeCodegenReducer(const ReduceOpNode &op,
   return std::nullopt;
 }
 
+inline bool CanUsePackedRamp(const PrimExpr &index, const Var &var, int vsize,
+                             arith::Analyzer *analyzer) {
+  ICHECK_GT(vsize, 1);
+
+  PrimExpr vector_size = make_const(var.dtype(), vsize);
+  PrimExpr packed_var = var * vector_size;
+  PrimExpr ramp_base =
+      analyzer->Simplify(Substitute(index, {{var, packed_var}}));
+
+  PrimExpr index_mod = FloorMod(ramp_base, make_const(index.dtype(), vsize));
+  if (!analyzer->CanProveEqual(index_mod, make_zero(index.dtype()))) {
+    return false;
+  }
+
+  for (int lane = 1; lane < vsize; ++lane) {
+    PrimExpr lane_value = make_const(var.dtype(), lane);
+    PrimExpr lane_index =
+        analyzer->Simplify(Substitute(index, {{var, packed_var + lane_value}}));
+    PrimExpr expected =
+        analyzer->Simplify(ramp_base + make_const(index.dtype(), lane));
+    if (!analyzer->CanProveEqual(lane_index, expected)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 inline PrimExpr MakeUpdate(const ReduceOpNode &op, PrimExpr dst_val,
                            PrimExpr src_val) {
   if (op.type->isSum() || op.type->isAbsSum()) {
@@ -391,7 +419,10 @@ template <typename Impl> struct ReduceLowerer {
         if (vsize > 1 && !src_var_compressed.empty()) {
           auto *ext = src_var_compressed.back()->dom->extent.as<IntImmNode>();
           if (ext && ext->value >= vsize && ext->value % vsize == 0 &&
-              reduce::MakeCodegenReducer(op, vsize).has_value()) {
+              reduce::MakeCodegenReducer(op, vsize).has_value() &&
+              reduce::CanUsePackedRamp(src_indice_compressed.back(),
+                                       src_var_compressed.back()->var, vsize,
+                                       analyzer)) {
             can_pack = true;
             DataType vec_dtype = clear_buffer->dtype.with_lanes(vsize);
             clear_buffer_packed =

--- a/testing/python/language/test_tilelang_language_reduce.py
+++ b/testing/python/language/test_tilelang_language_reduce.py
@@ -307,6 +307,38 @@ def test_finalize_reducer_invalid_batch(batch, exc_type, match):
         tl.compile(k, out_idx=-1, pass_configs=_COMPILE_FLAGS)
 
 
+@tilelang.testing.requires_cuda
+def test_reduce_absmax_bf16_noncontiguous_packed_layout_regression():
+    num_tokens = 64
+    hidden = 2560
+    num_threads = 128
+    num_vectorize = 4
+
+    def x_layout_fn(i, j):
+        idx = i * hidden + j
+        return (
+            idx // num_vectorize % num_threads,
+            idx // (num_vectorize * num_threads) * num_vectorize + idx % num_vectorize,
+        )
+
+    @T.prim_func
+    def kernel(A: T.Tensor((num_tokens, hidden), T.bfloat16), B: T.Tensor((num_tokens,), T.float32)):
+        with T.Kernel(num_tokens, threads=num_threads) as (pid,):
+            src = T.alloc_fragment((1, hidden), T.bfloat16)
+            dst = T.alloc_fragment((1, 1), T.bfloat16)
+            T.annotate_layout({src: T.Fragment((1, hidden), forward_fn=x_layout_fn)})
+            T.copy(A[pid, 0], src, disable_tma=True)
+            src_reshaped = T.reshape(src, (1, 1, hidden))
+            T.reduce_absmax(src_reshaped, dst, dim=2)
+            B[pid] = T.cast(dst[0, 0], T.float32)
+
+    A = torch.zeros((num_tokens, hidden), dtype=torch.bfloat16, device="cuda")
+    A[:, 512] = -10
+    B = _compile(kernel)(A)
+    ref = A.abs().amax(dim=1).float()
+    torch.testing.assert_close(B, ref, atol=0, rtol=0)
+
+
 # ---------------------------------------------------------------------------
 # nan_propagate tests – packed (vsize=2) path for bf16/fp16
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fix packed bf16/fp16 local reduce lowering so it only emits ramp loads when the reduced fragment index is lane-contiguous.
- Prevent `T.reduce_absmax` from missing elements for vectorized fragment layouts whose compressed local index is not physically contiguous.

## Changes

- Add a contiguity proof before enabling the packed ramp path in common reduce lowering.
- Fall back to the scalar local reduce path when the packed lane mapping cannot be proven safe.
- Add a CUDA regression test covering a bf16 absmax layout that previously skipped local elements.

## Validation

- `./format.sh`
- `cmake --build build -j$(nproc)`
- `python -m pytest testing/python/language/test_tilelang_language_reduce.py -q -k "noncontiguous_packed_layout_regression or packed_max_nan_propagate_uses_nan_intrinsics or packed_min_nan_propagate_uses_nan_intrinsics or packed_absmax_nan_propagate_uses_nan_intrinsics"`
- `TILELANG_DISABLE_CACHE=1 python debug/0528_issues/issue_2294.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling and correctness of reduce operations with non-contiguous packed data layouts, particularly for bfloat16 computations.

* **Tests**
  * Added regression test coverage for reduce operations with bfloat16 data on specialized memory layouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->