### PR TITLE
[Transform] Preserve ragged parallel padding guards

### DIFF
--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -312,6 +312,9 @@ constexpr const char *kLayoutMap = "layout_map";
 constexpr const char *kParallelLoopLayout = "parallel_loop_layout";
 // ForAttr, Containing the predicate for a parallel for loop
 constexpr const char *kParallelLoopPredicate = "parallel_loop_predicate";
+// ForAttr, Marks a ragged SIMT loop layout that needs guarded inverse lowering
+constexpr const char *kParallelLoopRequiresPaddingGuard =
+    "parallel_loop_requires_padding_guard";
 // ForAttr, Width (in elements) for coalesced memory access
 constexpr const char *kCoalescedWidth = "coalesced_width";
 } // namespace attr

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -123,6 +123,20 @@ ParallelOpNode::ParallelOpNode(For root) : root_(root), V(this) {
     annotated_predicate_ = Downcast<PrimExpr>(
         root_->annotations.Get(kParallelLoopPredicate).value());
   }
+  if (auto padding_guard_anno =
+          root_->annotations.Get(kParallelLoopRequiresPaddingGuard)) {
+    if (auto padding_guard_bool = padding_guard_anno.value().try_cast<Bool>()) {
+      annotated_requires_padding_guard_ = padding_guard_bool.value()->value;
+    } else if (auto padding_guard_int =
+                   padding_guard_anno.value().as<IntImmNode>()) {
+      annotated_requires_padding_guard_ = padding_guard_int->value != 0;
+    } else {
+      LOG(WARNING) << "Loop annotation `" << kParallelLoopRequiresPaddingGuard
+                   << "` expects Bool value (True/False), but got "
+                   << padding_guard_anno.value().GetTypeKey()
+                   << ". Ignore override.";
+    }
+  }
   // Collect cross-thread access info and buffer store info.
   PostOrderVisit(root_, [&](const ObjectRef &obj) {
     if (const auto *store = obj.as<BufferStoreNode>()) {
@@ -405,6 +419,7 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
   if (!loop_layout_.defined() && annotated_layout_unbound_.defined()) {
     loop_layout_ =
         annotated_layout_unbound_.value()->BindThreadRange(T.thread_bounds);
+    loop_layout_requires_padding_guard_ = annotated_requires_padding_guard_;
     if (annotated_predicate_.defined()) {
       predicate_ = annotated_predicate_.value();
     }

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -76,6 +76,7 @@ public:
   // lets InferLayout adopt them cleanly without re-parsing annotations.
   mutable Optional<Fragment> annotated_layout_unbound_;
   mutable Optional<PrimExpr> annotated_predicate_;
+  mutable bool annotated_requires_padding_guard_ = false;
 
   // Type key for TVM object system.
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.ParallelOp", ParallelOpNode,
@@ -108,6 +109,7 @@ public:
         other.loop_layout_requires_padding_guard_;
     annotated_layout_unbound_ = other.annotated_layout_unbound_;
     annotated_predicate_ = other.annotated_predicate_;
+    annotated_requires_padding_guard_ = other.annotated_requires_padding_guard_;
   }
 
   // Get the inferred loop layout.

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -103,6 +103,7 @@ struct LayoutInferenceResult {
   Map<Buffer, Layout> layout_map;
   Map<For, Fragment> for_map;
   Map<For, PrimExpr> predicate_map;
+  Map<For, Bool> padding_guard_map;
 };
 
 class BufferUseDefCollector : public IRVisitorWithAnalyzer {
@@ -449,6 +450,7 @@ public:
     // Collect layout info for For nodes
     Map<For, Fragment> for_map;
     Map<For, PrimExpr> predicate_map;
+    Map<For, Bool> padding_guard_map;
     ICHECK(infer_list_.size() == thread_var_vec_.size())
         << "infer_list_ and thread_var_vec_ size mismatch";
     for (int i = 0; i < infer_list_.size(); i++) {
@@ -464,6 +466,9 @@ public:
             << "The Layout for Parallel for cannot be inferred correctly:\n"
             << for_infer->GetRoot();
         for_map.Set(for_infer->GetRoot(), for_infer->GetLoopLayout());
+        if (for_infer->LoopLayoutRequiresPaddingGuard()) {
+          padding_guard_map.Set(for_infer->GetRoot(), Bool(true));
+        }
         // thread_var_ should be defined if we rely on it
         ICHECK(thread_var.defined())
             << "thread_var is not defined. Cannot retrieve predicate.";
@@ -474,7 +479,7 @@ public:
       }
     }
 
-    return {layout_map, for_map, predicate_map};
+    return {layout_map, for_map, predicate_map, padding_guard_map};
   }
 
   void Collect(const PrimFunc &f) {
@@ -1244,6 +1249,8 @@ private:
    * The stored annotations are:
    * - attr::kParallelLoopLayout: The Fragment layout for the parallel loop
    * - attr::kParallelLoopPredicate: The predicate expression (if any)
+   * - attr::kParallelLoopRequiresPaddingGuard: Whether inverse lowering must
+   *   allow and guard padded points from a ragged SIMT partition
    *
    * @return The For statement with layout annotations attached
    */
@@ -1260,6 +1267,10 @@ private:
     // Store the loop layout as an annotation on the For node (outermost)
     auto for_ptr = for_node.CopyOnWrite();
     for_ptr->annotations.Set(attr::kParallelLoopLayout, loop_layout);
+    if (result_.padding_guard_map.count(root)) {
+      for_ptr->annotations.Set(attr::kParallelLoopRequiresPaddingGuard,
+                               result_.padding_guard_map[root]);
+    }
 
     // Store the predicate as an annotation if it exists and is not trivially
     // true

--- a/src/transform/loop_partition.cc
+++ b/src/transform/loop_partition.cc
@@ -287,6 +287,8 @@ Stmt LowerParallelLoop(For loop, const Fragment &loop_layout, Var thread_var,
   // Note: Map::erase(key) is a no-op if key doesn't exist.
   result_loop.CopyOnWrite()->annotations.erase(attr::kParallelLoopLayout);
   result_loop.CopyOnWrite()->annotations.erase(attr::kParallelLoopPredicate);
+  result_loop.CopyOnWrite()->annotations.erase(
+      attr::kParallelLoopRequiresPaddingGuard);
 
   // Step 1: Partition the loop based on the layout (if this is a parallel loop)
   if (parallel_loop) {

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -1286,6 +1286,23 @@ private:
       predicate = Downcast<PrimExpr>(
           op->annotations.Get(attr::kParallelLoopPredicate).value());
     }
+    bool require_padding_guard = false;
+    if (auto padding_guard_anno =
+            op->annotations.Get(attr::kParallelLoopRequiresPaddingGuard)) {
+      if (auto padding_guard_bool =
+              padding_guard_anno.value().try_cast<Bool>()) {
+        require_padding_guard = padding_guard_bool.value()->value;
+      } else if (auto padding_guard_int =
+                     padding_guard_anno.value().as<IntImmNode>()) {
+        require_padding_guard = padding_guard_int->value != 0;
+      } else {
+        LOG(WARNING) << "Loop annotation `"
+                     << attr::kParallelLoopRequiresPaddingGuard
+                     << "` expects Bool value (True/False), but got "
+                     << padding_guard_anno.value().GetTypeKey()
+                     << ". Ignore override.";
+      }
+    }
     bool parallel_prefer_async = false;
     if (auto prefer_async_anno = op->annotations.Get(attr::kLoopPreferAsync)) {
       if (auto prefer_async_bool = prefer_async_anno.value().try_cast<Bool>()) {
@@ -1432,9 +1449,9 @@ private:
     bool should_vectorize =
         (has_non_local || has_cast_operations) && !has_reducer;
     // Lower the parallel loop using the common function
-    Stmt lowered = LowerParallelLoop(for_node, loop_layout, thread_var_->var,
-                                     analyzer_, layout_map_, predicate,
-                                     parallel_loop, should_vectorize);
+    Stmt lowered = LowerParallelLoop(
+        for_node, loop_layout, thread_var_->var, analyzer_, layout_map_,
+        predicate, parallel_loop, should_vectorize, require_padding_guard);
 
     // Only parallel-loop lowering needs PTX cp.async injection. Thread-level
     // lowering does not require converting eligible global->shared copies to

--- a/testing/python/transform/test_tilelang_transform_layout_inference.py
+++ b/testing/python/transform/test_tilelang_transform_layout_inference.py
@@ -123,5 +123,28 @@ def test_static_ragged_copy_uses_full_block_predicate():
     assert "threadIdx.x) < 1" not in kernel_source
 
 
+def test_static_ragged_copy_allows_1024_elements_384_threads():
+    n = 1024
+    threads = 384
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((n,), T.float32),
+        B: T.Tensor((n,), T.float32),
+    ):
+        with T.Kernel(1, threads=threads):
+            T.copy(A, B, coalesced_width=1)
+
+    with tvm.target.Target(auto_target):
+        artifact = tl.lower(main, target=auto_target, enable_device_compile=False)
+
+    kernel_source = str(artifact.kernel_source)
+    assert "__launch_bounds__(384, 1)" in kernel_source
+    assert "for (int i = 0; i < 3; ++i)" in kernel_source
+    assert "B[((i * 384) + ((int)threadIdx.x))]" in kernel_source
+    assert "(((int)threadIdx.x) >> 7)) < 8" in kernel_source
+    assert "threadIdx.x) < 128" not in kernel_source
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_lower_tile_op.py
+++ b/testing/python/transform/test_tilelang_transform_lower_tile_op.py
@@ -107,5 +107,23 @@ def test_lower_tile_op_respects_parallel_loop_async_annotation_without_pipeline_
     assert calls.get("tirx.ptx_wait_group", 0) == 0
 
 
+def test_lower_tile_op_preserves_ragged_parallel_padding_guard():
+    target = tvm.target.Target({"kind": "cuda", "arch": "sm_80"})
+
+    @T.prim_func
+    def before(B: T.Tensor((8, 384), T.int32)):
+        T.func_attr({"global_symbol": "main", "target": target})
+        T.launch_thread("blockIdx.x", 1)
+        T.launch_thread("threadIdx.x", 256)
+        for row, col in T.Parallel(8, 384):
+            B[row, col] = T.if_then_else(col < 264, col, 2147483647)
+
+    mod = tvm.IRModule.from_expr(before)
+    with target:
+        mod = tl.transform.LayoutInference()(mod)
+        assert "parallel_loop_requires_padding_guard" in mod.script(show_meta=True)
+        tl.transform.LowerTileOp()(mod)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Summary

- Preserve ragged SIMT loop padding metadata from layout inference through lower tile op.
- Fix user-written `T.Parallel` loops whose inferred padded layouts need guarded inverse lowering.
- Keep support for cases such as copying 1024 elements with 384 threads instead of falling back to smaller active-thread partitions.

## Changes

- Add a `parallel_loop_requires_padding_guard` loop annotation alongside the inferred parallel loop layout.
- Propagate the padding guard flag through `LayoutInference`, annotated `ParallelOp` adoption, and `LowerTileOp`.
- Clear the padding guard annotation after parallel loop lowering, matching the existing layout and predicate cleanup.
- Add regression coverage for ragged `T.Parallel(8, 384)` lowering and 1024-element copy with 384 threads.

## Validation

- `cmake --build build -j$(nproc)`
- `pre-commit run --all-files`
- `python -m pytest testing/python/transform/test_tilelang_transform_lower_tile_op.py testing/python/transform/test_tilelang_transform_layout_inference.py -q`
- `python debug/0527_bug/topk_mtp_anchor.py`

## Notes

- The existing data-race warning in the debug repro is not changed by this patch; the failing layout inverse path now lowers successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added padding guard annotation support for parallel loops to handle ragged memory access patterns, enabling more efficient code generation for edge cases.

* **Tests**
  * Added comprehensive tests for ragged parallel copy operations.
  * Added tests verifying padding guard annotation handling through transform passes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2299?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->