### PR TITLE
[CUDA] Support preferred copy instruction lowering

### DIFF
--- a/src/backend/cuda/op/copy.cc
+++ b/src/backend/cuda/op/copy.cc
@@ -25,8 +25,10 @@
 #include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/transform.h>
 
+#include <cctype>
 #include <cstdint>
 #include <sstream>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -96,6 +98,27 @@ PrimExpr GetCopyMbarPhaseExpr(const Map<String, ObjectRef> &annotations,
     phase = explicit_phase.value();
   }
   return phase;
+}
+
+std::string SanitizeIdentifierPart(const std::string &name) {
+  std::string sanitized;
+  sanitized.reserve(name.size());
+  for (unsigned char ch : name) {
+    sanitized.push_back(std::isalnum(ch) || ch == '_' ? static_cast<char>(ch)
+                                                      : '_');
+  }
+  if (sanitized.empty()) {
+    sanitized = "buffer";
+  }
+  if (std::isdigit(static_cast<unsigned char>(sanitized.front()))) {
+    sanitized.insert(sanitized.begin(), '_');
+  }
+  return sanitized;
+}
+
+std::string MakeCopyMBarrierName(const Buffer &src, const Buffer &dst) {
+  return SanitizeIdentifierPart(src->name) + "_to_" +
+         SanitizeIdentifierPart(dst->name) + "_mbarrier";
 }
 
 bool GetBoolAnnotation(const CopyNode &op, const char *key) {
@@ -1560,7 +1583,8 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
       LOG(FATAL) << "T.tma_copy() requires a barrier argument. "
                  << "Use T.tma_copy(src, dst, barrier=mbar[idx]).";
     } else if (T.AllocMBarrier) {
-      barrier_base_id = T.AllocMBarrier(1);
+      barrier_base_id =
+          T.AllocMBarrier(1, MakeCopyMBarrierName(op.src, op.dst));
       PrimExpr mbar_idx = IntImm(DataType::Int(32), barrier_base_id);
       mbar_handle = BufferLoad(T.mbarrier_buffer->value(), {mbar_idx});
     }
@@ -1981,7 +2005,8 @@ Stmt Copy::LowerBulk1D(const CopyNode &op, const LowerArgs &T,
       LOG(FATAL) << "T.tma_copy() requires a barrier argument. "
                  << "Use T.tma_copy(src, dst, barrier=mbar[idx]).";
     } else if (T.AllocMBarrier) {
-      barrier_base_id = T.AllocMBarrier(1);
+      barrier_base_id =
+          T.AllocMBarrier(1, MakeCopyMBarrierName(op.src, op.dst));
       PrimExpr mbar_idx = IntImm(DataType::Int(32), barrier_base_id);
       mbar_handle = BufferLoad(T.mbarrier_buffer->value(), {mbar_idx});
     }
@@ -2163,7 +2188,8 @@ Stmt Im2Col::Lower(const Im2ColOpNode &op, const LowerArgs &T,
     mbar_handle = Downcast<PrimExpr>(user_barrier.value());
     barrier_base_id = 0;
   } else if (T.AllocMBarrier) {
-    barrier_base_id = T.AllocMBarrier(1);
+    barrier_base_id =
+        T.AllocMBarrier(1, MakeCopyMBarrierName(op.src_, op.dst_));
     PrimExpr mbar_idx = IntImm(DataType::Int(32), barrier_base_id);
     mbar_handle = BufferLoad(T.mbarrier_buffer->value(), {mbar_idx});
   }

--- a/src/backend/cuda/op/copy_analysis.cc
+++ b/src/backend/cuda/op/copy_analysis.cc
@@ -14,6 +14,7 @@
 
 #include <tvm/tirx/transform.h>
 
+#include <optional>
 #include <sstream>
 #include <utility>
 
@@ -77,6 +78,53 @@ bool GetIsAsyncCopy(const CopyNode &op) {
 
 bool GetNoImplicitAsyncCommitWait(const CopyNode &op) {
   return GetBoolAnnotation(op, attr::kAsyncCopyNoImplicitCommitWait);
+}
+
+enum class PreferredCopyInstruction {
+  kAuto,
+  kTMA,
+  kCPAsync,
+  kSync,
+};
+
+constexpr const char *kPreferInstruction = "prefer_instruction";
+
+constexpr std::pair<const char *, PreferredCopyInstruction>
+    kPreferredCopyInstructions[] = {
+        {"tma", PreferredCopyInstruction::kTMA},
+        {"cp_async", PreferredCopyInstruction::kCPAsync},
+        {"sync", PreferredCopyInstruction::kSync},
+};
+
+std::optional<std::string> GetStringAnnotation(const CopyNode &op,
+                                               const char *key) {
+  auto val = op.annotations.Get(key);
+  if (!val) {
+    return std::nullopt;
+  }
+  auto str = val->as<StringImmNode>();
+  ICHECK(str) << "T.copy " << key << " annotation must be a string, but got "
+              << val.value().GetTypeKey();
+  return str->value;
+}
+
+PreferredCopyInstruction
+ParsePreferredCopyInstruction(const std::string &prefer) {
+  for (const auto &[name, inst] : kPreferredCopyInstructions) {
+    if (prefer == name) {
+      return inst;
+    }
+  }
+  LOG(FATAL) << "Unsupported T.copy prefer_instruction=\"" << prefer
+             << "\". Expected one of: \"tma\", \"cp_async\", \"sync\".";
+  return PreferredCopyInstruction::kAuto;
+}
+
+PreferredCopyInstruction GetPreferredInstruction(const CopyNode &op) {
+  if (auto prefer = GetStringAnnotation(op, kPreferInstruction)) {
+    return ParsePreferredCopyInstruction(prefer.value());
+  }
+  return PreferredCopyInstruction::kAuto;
 }
 
 bool CheckGlobalStrides(const Buffer &buffer, arith::Analyzer *analyzer,
@@ -360,6 +408,7 @@ struct CopyFacts {
   bool explicit_tma = false;
   bool explicit_cp_async = false;
   bool no_implicit_async_commit_wait = false;
+  PreferredCopyInstruction prefer_instruction = PreferredCopyInstruction::kAuto;
   bool disable_tma = false;
   int64_t cluster_mask = 0;
   bool can_bulk_load_1d = false;
@@ -473,6 +522,7 @@ CopyFacts AnalyzeCopyFacts(const CopyNode &op, const CopyAnalysisContext &ctx) {
   facts.explicit_tma = GetIsTmaCopy(op);
   facts.explicit_cp_async = GetIsAsyncCopy(op);
   facts.no_implicit_async_commit_wait = GetNoImplicitAsyncCommitWait(op);
+  facts.prefer_instruction = GetPreferredInstruction(op);
   facts.disable_tma = GetDisableTMA(op);
   facts.cluster_mask = GetClusterMask(op);
   facts.tma_unavailable_reason = MakeTmaUnavailableReason(op);
@@ -581,6 +631,42 @@ CopyInstSelection SelectCopyInstForLowering(const CopyNode &op,
   if (facts.explicit_cp_async || facts.no_implicit_async_commit_wait) {
     return facts.can_cp_async ? Supported(CopyInst::kCPAsync)
                               : Unsupported(facts.async_unavailable_reason);
+  }
+
+  if (facts.prefer_instruction == PreferredCopyInstruction::kTMA) {
+    if (facts.disable_tma) {
+      return Unsupported("T.copy prefer_instruction=\"tma\" conflicts with "
+                         "disable_tma=true.");
+    }
+    if (facts.pass_context_disables_tma) {
+      return Unsupported("T.copy prefer_instruction=\"tma\" conflicts with "
+                         "pass config tl.disable_tma_lower=true.");
+    }
+    CopyInst inst =
+        SelectTmaInst(facts, /*allow_load=*/true, /*allow_store=*/true,
+                      /*check_last_dim=*/true);
+    return inst == CopyInst::kInvalid
+               ? Unsupported("T.copy prefer_instruction=\"tma\" could not be "
+                             "honored: " +
+                             facts.tma_unavailable_reason)
+               : Supported(inst);
+  }
+
+  if (facts.prefer_instruction == PreferredCopyInstruction::kCPAsync) {
+    if (!IsAutoAsyncCopyEnabled(/*default_enabled=*/true)) {
+      return Unsupported(
+          "T.copy prefer_instruction=\"cp_async\" conflicts with "
+          "pass config tl.enable_async_copy=false.");
+    }
+    return facts.can_cp_async
+               ? Supported(CopyInst::kCPAsync)
+               : Unsupported("T.copy prefer_instruction="
+                             "\"cp_async\" could not be honored: " +
+                             facts.async_unavailable_reason);
+  }
+
+  if (facts.prefer_instruction == PreferredCopyInstruction::kSync) {
+    return Supported(SelectSyncLikeInst(facts));
   }
 
   if (!facts.disable_tma && !facts.pass_context_disables_tma) {

--- a/src/op/operator.h
+++ b/src/op/operator.h
@@ -10,6 +10,9 @@
 // Dependencies for operators
 #include "support/check.h"
 #include <array>
+#include <functional>
+#include <optional>
+#include <string>
 #include <tvm/arith/analyzer.h>
 #include <tvm/ir/op.h>
 #include <tvm/target/target.h>
@@ -29,7 +32,11 @@ using namespace tirx;
 using namespace ffi;
 
 using AddWorkspaceCallback = std::function<PrimExpr(int, DataType)>;
-using AllocMBarrierCallback = std::function<int(int arrive_count)>;
+// Allocate a compiler-generated shared mbarrier slot. The optional hint names
+// the backing barrier buffer when the first slot is created; later slots share
+// the same buffer and may ignore the hint.
+using AllocMBarrierCallback =
+    std::function<int(int arrive_count, std::optional<std::string> name)>;
 using UpdateBarrierArriveCallback = std::function<void(Var, PrimExpr)>;
 using LayoutMap = Map<Buffer, Layout>;
 using BufferMap = Map<Var, Buffer>;

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -4,6 +4,7 @@
  */
 
 #include "support/check.h"
+#include <optional>
 #include <tvm/ir/cast.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/s_tir/utils.h>
@@ -1161,9 +1162,11 @@ private:
       bind_var_to_expr.Set(var, expr);
     }
 
-    AllocMBarrierCallback mbarrier_callback = [this](int arrive_count) -> int {
+    AllocMBarrierCallback mbarrier_callback =
+        [this](int arrive_count, std::optional<std::string> name) -> int {
       if (!mbarrier_buffer_.defined()) {
-        mbarrier_buffer_ = CreateMBarrierBuffer(injected_mbarrier_name_, 1);
+        mbarrier_buffer_ =
+            CreateMBarrierBuffer(name.value_or(injected_mbarrier_name_), 1);
       }
       int id = mbarrier_count_++;
       mbarrier_arrive_counts_.push_back(arrive_count);

--- a/testing/python/language/test_tilelang_language_tma_copy.py
+++ b/testing/python/language/test_tilelang_language_tma_copy.py
@@ -338,6 +338,28 @@ def run_fp4_tma_copy_roundtrip():
     assert torch.equal(b.view(torch.int8), a)
 
 
+def test_copy_prefer_tma_lowers_as_synchronous_tma_load():
+    @T.prim_func
+    def main(x: T.Tensor((128, 32), T.float32)):
+        with T.Kernel(threads=128):
+            x_shared = T.alloc_shared((128, 32), T.float32)
+            T.copy(x, x_shared, annotations={"prefer_instruction": "tma"})
+
+    target = {"kind": "cuda", "arch": "sm_90"}
+    artifact = tilelang.lower(
+        main,
+        target=target,
+        enable_device_compile=False,
+    )
+
+    device_source = str(artifact.kernel_source)
+    assert "tl::tma_load" in device_source
+    assert "x_to_x_shared_mbarrier_mem" in device_source
+    assert "x_to_x_shared_mbarrier[0]" in device_source
+    assert "arrive_and_expect_tx" in device_source
+    assert ".wait(0)" in device_source
+
+
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_ge(10, 0)
 def test_fp4_tma_copy_roundtrip():

--- a/tilelang/language/copy_op.py
+++ b/tilelang/language/copy_op.py
@@ -58,6 +58,7 @@ def copy(
     coalesced_width: int | None = None,
     disable_tma: bool = False,
     eviction_policy: Literal["evict_normal", "evict_first", "evict_last"] | None = None,
+    prefer_instruction: str | None = None,
     annotations: dict | None = None,
     loop_layout: Any | None = None,
 ) -> tirx.PrimExpr | tirx.Stmt:
@@ -69,8 +70,14 @@ def copy(
         coalesced_width (Optional[int], keyword-only): Width for coalesced memory access. Defaults to None.
         disable_tma (bool, keyword-only): Whether to disable TMA acceleration. Defaults to False.
         eviction_policy (Optional[str], keyword-only): Cache eviction policy. Defaults to None.
+        prefer_instruction (Optional[str], keyword-only): Backend-specific preferred lowering
+            instruction category. For CUDA, recognized values include "tma", "cp_async", and
+            "sync". For "tma", T.copy keeps synchronous copy semantics; global -> shared copies
+            lower through TMA with an automatically allocated barrier and wait when constraints
+            are satisfied.
         annotations (Optional[dict], keyword-only): Additional annotations dict. If provided,
-            coalesced_width, disable_tma, and eviction_policy can also be specified here.
+            coalesced_width, disable_tma, eviction_policy, and prefer_instruction can also
+            be specified here.
             Values in annotations take precedence over individual arguments.
         loop_layout (Optional[Fragment], keyword-only): A parallel loop layout hint for the SIMT copy
             (only valid for normal SIMT copy; incompatible with TMA/LDSM/STSM/TMem). When provided,
@@ -115,6 +122,10 @@ def copy(
     if "eviction_policy" not in ann and eviction_policy is not None:
         eviction_policy_map = {"evict_normal": 0, "evict_first": 1, "evict_last": 2}
         ann["eviction_policy"] = eviction_policy_map[eviction_policy]
+    if "prefer_instruction" not in ann and prefer_instruction is not None:
+        ann["prefer_instruction"] = prefer_instruction
+    if isinstance(ann.get("prefer_instruction"), str):
+        ann["prefer_instruction"] = tirx.StringImm(ann["prefer_instruction"])
 
     # Parallel loop layout hint (Fragment). Mirrors T.Parallel(loop_layout=...)
     if loop_layout is not None and "parallel_loop_layout" not in ann:


### PR DESCRIPTION
## Summary

- Adds a backend-preferred instruction hint for `T.copy` so CUDA can honor `"tma"`, `"cp_async"`, or `"sync"` while keeping validation backend-local.
- Allows ordinary `T.copy(... prefer_instruction="tma")` and annotation-based calls to lower through synchronous TMA load semantics with compiler-generated barrier allocation and wait.
- Names compiler-generated mbarrier buffers from copy source and destination buffer names for clearer generated CUDA.

## Changes

- Normalizes Python string `prefer_instruction` annotations without CUDA-specific validation in the frontend.
- Extends CUDA copy analysis selection with `PreferredCopyInstruction`, rejecting unsupported or unhonorable hints in the backend.
- Updates compiler-generated mbarrier allocation callback to accept optional buffer name hints, and passes copy-derived names from CUDA TMA lowering.
- Adds a lower-only regression asserting TMA load, auto barrier init/expect/wait, and source/destination-derived barrier naming.

## Validation

- `pre-commit run --all-files`
- `cmake --build build -j$(nproc)`
- `python -m pytest testing/python/language/test_tilelang_language_tma_copy.py -k copy_prefer_tma_lowers_as_synchronous_tma_load -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a high-level `prefer_instruction` option for copy operations to request "tma", "cp_async", or "sync" lowering.
  * Copy lowering now emits deterministic, sanitized mbarrier allocation names derived from buffer identifiers.

* **Tests**
  * Added a test validating TMA-preferred copy lowering and the associated mbarrier artifacts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->