### PR TITLE
[BugFix] Ensure producer warpgroup aligned and starting from zero

### DIFF
--- a/src/transform/producer_consumer_ws.cc
+++ b/src/transform/producer_consumer_ws.cc
@@ -11,7 +11,7 @@
  * The output IR is equivalent to a hand-written warp-specialized kernel:
  *   - TMA-annotated copies become `tl.tileop.tma_copy` with barrier refs
  *   - Barriers (`mbarrier_wait_parity`, `ptx_arrive_barrier`) are inserted
- *   - The loop body is wrapped in `if (threadIdx.x >= consumer_extent)`
+ *   - The loop body is wrapped in `if (threadIdx.x < producer_extent)`
  *
  * Limitations (v1):
  *   - Pure TMA pipelines only (no mixed TMA + cp.async)
@@ -1903,13 +1903,16 @@ private:
           consumer_phase_counter.value().WrapLoopWithAlloc(consumer_loop);
     }
 
-    // --- Rewrite threadIdx.x for producer partition ---
-    // Producer: threadIdx.x - consumer_extent (maps to [0, producer_extent))
-    Stmt rewritten_producer = PCThreadIdxRewriter::Rewrite(
-        final_producer_loop, thread_iv_->var, thread_iv_->var - consumer_extent,
-        producer_extent, false);
-    // Consumer: threadIdx.x stays, but extent is consumer_extent
-    Stmt rewritten_consumer = final_consumer_loop;
+    // --- Rewrite threadIdx.x for producer/consumer partitions ---
+    // Physical layout: producer first, consumer second.
+    // Producer: threadIdx.x already maps to [0, producer_extent)
+    Stmt rewritten_producer =
+        PCThreadIdxRewriter::Rewrite(final_producer_loop, thread_iv_->var,
+                                     thread_iv_->var, producer_extent, false);
+    // Consumer: threadIdx.x - producer_extent maps to [0, consumer_extent)
+    Stmt rewritten_consumer = PCThreadIdxRewriter::Rewrite(
+        final_consumer_loop, thread_iv_->var, thread_iv_->var - producer_extent,
+        consumer_extent, false);
 
     shared_prelude_live_seed_ = {};
     producer_prelude_live_seed_ = {};
@@ -1932,12 +1935,13 @@ private:
     // by doing a dry replacement that populates extracted_consumer_init_.
     Stmt dummy_producer = rewritten_producer;
     const Stmt &dummy_consumer = rewritten_consumer;
-    Stmt dummy_ws = IfThenElse(GE(thread_iv_->var, consumer_extent),
+    Stmt dummy_ws = IfThenElse(LT(thread_iv_->var, producer_extent),
                                dummy_producer, dummy_consumer);
     dummy_ws =
         AttrStmt(ws_partition, attr::kWarpSpecializationScope, 0, dummy_ws);
-    Optional<Stmt> replaced = ReplacePipelineLoopInStmt(
-        orig_block->body, pipeline_loop, dummy_ws, consumer_extent);
+    Optional<Stmt> replaced =
+        ReplacePipelineLoopInStmt(orig_block->body, pipeline_loop, dummy_ws,
+                                  producer_extent, consumer_extent);
     ICHECK(replaced.defined())
         << "ProducerConsumerWS: failed to replace pipeline loop";
     Stmt replaced_stmt = replaced.value();
@@ -2000,8 +2004,7 @@ private:
         Array<Stmt> producer_parts;
         for (const auto &s : extracted_producer_init_) {
           producer_parts.push_back(PCThreadIdxRewriter::Rewrite(
-              s, thread_iv_->var, thread_iv_->var - consumer_extent,
-              producer_extent, false));
+              s, thread_iv_->var, thread_iv_->var, producer_extent, false));
         }
         producer_parts.push_back(rewritten_producer);
         enriched_producer = producer_parts.size() == 1
@@ -2010,7 +2013,9 @@ private:
       }
       Array<Stmt> consumer_parts;
       for (const auto &s : extracted_consumer_init_) {
-        consumer_parts.push_back(s);
+        consumer_parts.push_back(PCThreadIdxRewriter::Rewrite(
+            s, thread_iv_->var, thread_iv_->var - producer_extent,
+            consumer_extent, false));
       }
       consumer_parts.push_back(rewritten_consumer);
       Stmt enriched_consumer = consumer_parts.size() == 1
@@ -2018,7 +2023,7 @@ private:
                                    : SeqStmt(consumer_parts);
       Stmt scoped_producer = enriched_producer;
       const Stmt &scoped_consumer = enriched_consumer;
-      Stmt ws_body = IfThenElse(GE(thread_iv_->var, consumer_extent),
+      Stmt ws_body = IfThenElse(LT(thread_iv_->var, producer_extent),
                                 scoped_producer, scoped_consumer);
       ws_body =
           AttrStmt(ws_partition, attr::kWarpSpecializationScope, 0, ws_body);
@@ -2046,7 +2051,7 @@ private:
       replaced_stmt = subst(replaced_stmt);
     }
     Stmt new_block_body = SinkGuardedConsumerPostlude::Rewrite(
-        replaced_stmt, thread_iv_->var, consumer_extent);
+        replaced_stmt, thread_iv_->var, producer_extent);
 
     // --- Update block ---
     SBlock new_block = orig_block;
@@ -2118,16 +2123,16 @@ private:
   class SinkGuardedConsumerPostlude : public StmtExprMutator {
   public:
     static Stmt Rewrite(const Stmt &stmt, Var thread_var,
-                        PrimExpr consumer_extent) {
+                        PrimExpr producer_extent) {
       SinkGuardedConsumerPostlude sinker(std::move(thread_var),
-                                         std::move(consumer_extent));
+                                         std::move(producer_extent));
       return sinker.VisitStmt(stmt);
     }
 
   private:
-    SinkGuardedConsumerPostlude(Var thread_var, PrimExpr consumer_extent)
+    SinkGuardedConsumerPostlude(Var thread_var, PrimExpr producer_extent)
         : thread_var_(std::move(thread_var)),
-          consumer_extent_(std::move(consumer_extent)) {}
+          producer_extent_(std::move(producer_extent)) {}
 
     static bool SameExpr(const PrimExpr &lhs, const PrimExpr &rhs) {
       return ExprDeepEqual()(lhs, rhs);
@@ -2138,15 +2143,15 @@ private:
       if (!if_node || !if_node->else_case.defined()) {
         return false;
       }
-      const auto *ge = if_node->condition.as<GENode>();
-      if (!ge) {
+      const auto *lt = if_node->condition.as<LTNode>();
+      if (!lt) {
         return false;
       }
-      const auto *lhs = ge->a.as<VarNode>();
+      const auto *lhs = lt->a.as<VarNode>();
       if (!lhs || !ffi::GetRef<Var>(lhs).same_as(thread_var_)) {
         return false;
       }
-      if (!SameExpr(ge->b, consumer_extent_)) {
+      if (!SameExpr(lt->b, producer_extent_)) {
         return false;
       }
       *branch = GetRef<IfThenElse>(if_node);
@@ -2175,15 +2180,15 @@ private:
       if (!if_node || if_node->else_case.defined()) {
         return false;
       }
-      const auto *lt = if_node->condition.as<LTNode>();
-      if (!lt) {
+      const auto *ge = if_node->condition.as<GENode>();
+      if (!ge) {
         return false;
       }
-      const auto *lhs = lt->a.as<VarNode>();
+      const auto *lhs = ge->a.as<VarNode>();
       if (!lhs || !ffi::GetRef<Var>(lhs).same_as(thread_var_)) {
         return false;
       }
-      if (!SameExpr(lt->b, consumer_extent_)) {
+      if (!SameExpr(ge->b, producer_extent_)) {
         return false;
       }
       *body = if_node->then_case;
@@ -2261,7 +2266,7 @@ private:
     }
 
     Var thread_var_;
-    PrimExpr consumer_extent_;
+    PrimExpr producer_extent_;
   };
 
   class PipelineLoopContainmentChecker
@@ -2323,9 +2328,11 @@ private:
 
     PipelineLoopInStmtReplacer(ProducerConsumerWSRewriter *rewriter,
                                For pipeline_loop, Stmt ws_body,
+                               PrimExpr producer_extent,
                                PrimExpr consumer_extent)
         : rewriter_(rewriter), pipeline_loop_(std::move(pipeline_loop)),
           ws_body_(std::move(ws_body)),
+          producer_extent_(std::move(producer_extent)),
           consumer_extent_(std::move(consumer_extent)) {}
 
     Optional<Stmt> VisitStmt(const Stmt &stmt) final {
@@ -2426,7 +2433,12 @@ private:
 
   private:
     Stmt GuardConsumerOnly(const Stmt &stmt) const {
-      return IfThenElse(LT(rewriter_->thread_iv_->var, consumer_extent_), stmt);
+      Stmt consumer_stmt = PCThreadIdxRewriter::Rewrite(
+          stmt, rewriter_->thread_iv_->var,
+          rewriter_->thread_iv_->var - producer_extent_, consumer_extent_,
+          false);
+      return IfThenElse(GE(rewriter_->thread_iv_->var, producer_extent_),
+                        consumer_stmt);
     }
 
     void PropagatePreludeLiveness(const SeqStmtNode *op, int loop_idx) {
@@ -2508,15 +2520,18 @@ private:
     ProducerConsumerWSRewriter *rewriter_;
     For pipeline_loop_;
     Stmt ws_body_;
+    PrimExpr producer_extent_;
     PrimExpr consumer_extent_;
   };
 
   Optional<Stmt> ReplacePipelineLoopInStmt(const Stmt &stmt,
                                            const For &pipeline_loop,
                                            const Stmt &ws_body,
+                                           PrimExpr producer_extent,
                                            PrimExpr consumer_extent) {
     PipelineLoopInStmtReplacer replacer(this, pipeline_loop, ws_body,
-                                        consumer_extent);
+                                        std::move(producer_extent),
+                                        std::move(consumer_extent));
     return replacer(stmt);
   }
 

--- a/testing/python/issue/test_tilelang_issue_tma_no_ws.py
+++ b/testing/python/issue/test_tilelang_issue_tma_no_ws.py
@@ -59,7 +59,7 @@ def test_num_stages_zero_pure_tma_does_not_auto_warp_specialize():
     src = kernel.get_kernel_source()
     assert "tl::tma_load" not in src
     assert "__launch_bounds__(160, 1)" not in src
-    assert "if (32 <= ((int)threadIdx.x))" not in src
+    assert "if (((int)threadIdx.x) < 128)" not in src
 
     x = torch.randn((M, K), device="cuda", dtype=torch.float16)
     y = kernel(x)
@@ -104,7 +104,7 @@ def test_num_stages_one_pure_tma_keeps_auto_warp_specialize():
     src = kernel.get_kernel_source()
     assert "tl::tma_load" in src
     assert "__launch_bounds__(160, 1)" in src
-    assert "if (32 <= ((int)threadIdx.x))" in src
+    assert "if (((int)threadIdx.x) < 128)" in src
 
     x = torch.randn((M, K), device="cuda", dtype=torch.float16)
     y = kernel(x)
@@ -151,7 +151,7 @@ def test_guarded_pure_tma_pipeline_keeps_auto_warp_specialize():
     src = kernel.get_kernel_source()
     assert "tl::tma_load" in src
     assert "__launch_bounds__(160, 1)" in src
-    assert "if (32 <= ((int)threadIdx.x))" in src
+    assert "if (((int)threadIdx.x) < 128)" in src
 
     x = torch.randn((M, K), device="cuda", dtype=torch.float16)
     y = kernel(x, M)
@@ -191,7 +191,7 @@ def test_num_stages_zero_cp_async_only_does_not_auto_warp_specialize():
     assert "cp_async_gs<16>" in src
     assert "__launch_bounds__(32, 1)" in src
     assert "__launch_bounds__(160, 1)" not in src
-    assert "if (32 <= ((int)threadIdx.x))" not in src
+    assert "if (((int)threadIdx.x) < 128)" not in src
 
     x = torch.randint(0, 256, (4 * bytes_per_copy,), device="cuda", dtype=torch.uint8)
     y = kernel(x)
@@ -231,7 +231,7 @@ def test_num_stages_one_cp_async_only_keeps_non_ws_launch_shape():
     assert "cp_async_gs<16>" in src
     assert "__launch_bounds__(32, 1)" in src
     assert "__launch_bounds__(160, 1)" not in src
-    assert "if (32 <= ((int)threadIdx.x))" not in src
+    assert "if (((int)threadIdx.x) < 128)" not in src
 
     x = torch.randint(0, 256, (4 * bytes_per_copy,), device="cuda", dtype=torch.uint8)
     y = kernel(x)
@@ -289,7 +289,7 @@ def test_num_stages_one_mixed_tma_cp_async_keeps_auto_ws():
 
     src = kernel.get_kernel_source()
     assert "tl::tma_load" in src
-    producer_idx = src.index("if (128 <= ((int)threadIdx.x)) {")
+    producer_idx = src.index("if (((int)threadIdx.x) < 128) {")
     consumer_idx = src.index("} else {", producer_idx)
     cp_async_idx = src.index("cp_async_gs<16>")
 
@@ -395,7 +395,7 @@ def test_sparse_ws_regular_metadata_copy_stays_in_producer():
     kernel = _compile_tvm_ffi(sparse_tensorcore_metadata_copy, pass_configs, out_idx=[3])
 
     src = kernel.get_kernel_source()
-    producer_idx = src.index("if (128 <= ((int)threadIdx.x)) {")
+    producer_idx = src.index("if (((int)threadIdx.x) < 128) {")
     consumer_idx = src.index("} else {", producer_idx)
     metadata_copy_idx = src.index("tl::tma_load(E_desc")
 
@@ -488,7 +488,7 @@ def test_pure_tma_consumer_local_init_does_not_leak_into_producer():
     kernel = _compile_tvm_ffi(sparse_flash_attn, pass_configs, out_idx=[4])
 
     src = kernel.get_kernel_source()
-    producer_idx = src.index("if (128 <= ((int)threadIdx.x)) {")
+    producer_idx = src.index("if (((int)threadIdx.x) < 128) {")
     consumer_idx = src.index("} else {", producer_idx)
     prelude_src = src[:producer_idx]
     producer_src = src[producer_idx:consumer_idx]

--- a/testing/python/issue/test_tilelang_issue_ws_simt_copy_full_producer_extent.py
+++ b/testing/python/issue/test_tilelang_issue_ws_simt_copy_full_producer_extent.py
@@ -52,8 +52,8 @@ def test_ws_keeps_full_producer_extent_for_lowered_simt_copy():
     flat_src = " ".join(src.split())
 
     assert "__launch_bounds__(512, 1)" in src
-    assert "if (256 <= ((int)threadIdx.x)) {" in flat_src
-    assert "tl::tl_shuffle_elect<256>()" in src or "if (((int)threadIdx.x) == 256) {" in src
+    assert "if (((int)threadIdx.x) < 256) {" in flat_src
+    assert "tl::tl_shuffle_elect<256>()" in src or "if (((int)threadIdx.x) == 0) {" in src
     assert re.search(r"tl::__sync_thread_partial\(\d+, 256\);", src), src
 
 

--- a/testing/python/transform/test_tilelang_transform_inject_set_max_nreg.py
+++ b/testing/python/transform/test_tilelang_transform_inject_set_max_nreg.py
@@ -201,7 +201,7 @@ def test_auto_ws_reg_hints_lower_into_matching_role_scopes():
     finally:
         tl.enable_cache()
 
-    producer_branch = src.index("if (128 <= ((int)threadIdx.x)) {")
+    producer_branch = src.index("if (((int)threadIdx.x) < 128) {")
     consumer_branch = src.index("} else {", producer_branch)
     reg_dealloc = src.index("tl::warpgroup_reg_dealloc<40>();")
     reg_alloc = src.index("tl::warpgroup_reg_alloc<232>();")

--- a/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
+++ b/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
@@ -514,7 +514,7 @@ def test_tiled_ws_sinks_preloop_tma_waits_into_consumer():
 
     k_load = src.find("tl::tma_load(K_in_desc")
     v_load = src.find("tl::tma_load(V_in_desc")
-    branch = src.find("if (128 <= ((int)threadIdx.x))")
+    branch = src.find("if (((int)threadIdx.x) < 128)")
     first_wait = src.find(".wait(0)")
 
     assert min(k_load, v_load, branch, first_wait) >= 0
@@ -543,6 +543,25 @@ def test_tiled_ws_explicit_cp_async_wait_precedes_first_consumer_read():
     assert wait < cp_async_read < tma_read
 
 
+def test_tiled_ws_auto_producer_uses_low_thread_partition():
+    """Auto WS should place producer in the low physical thread range."""
+
+    func = matmul_pipelined(128, 128, 128, 64, 32, 64, num_stages=2).with_attr("global_symbol", "main")
+    mod = tvm.IRModule.from_expr(func)
+    target = determine_target({"kind": "cuda", "arch": "sm_90"}, return_object=True)
+    mod = tvm.tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.ProducerConsumerWarpSpecialized()(mod)
+    script = mod["main"].script()
+
+    branch = _find_after(script, 'T.attr([128, 128], "kWarpSpecializationScope", 0)')
+    producer_guard = _find_after(script, "if tx < 128:", branch)
+    consumer_branch = _find_after(script, "else:", producer_guard)
+    producer_tma = _find_after(script, "T.tma_copy", producer_guard)
+    consumer_gemm = _find_after(script, "T.gemm", consumer_branch)
+
+    assert producer_guard < producer_tma < consumer_branch < consumer_gemm
+
+
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version(9, 0)
 def test_tiled_ws_keeps_preloop_tma_scalar_bind_shared():
@@ -554,7 +573,7 @@ def test_tiled_ws_keeps_preloop_tma_scalar_bind_shared():
 
     start_bind = _find_after(src, "int start =")
     k_load = _find_after(src, "tl::tma_load(K_in_desc")
-    branch = _find_after(src, "if (128 <= ((int)threadIdx.x))")
+    branch = _find_after(src, "if (((int)threadIdx.x) < 128)")
 
     assert start_bind < k_load < branch
 
@@ -586,7 +605,7 @@ def test_tiled_ws_keeps_shared_prelude_local_vars_for_grouped_gemm():
     kernel, batch_sizes = _compile_grouped_gemm_ws()
     src = kernel.get_kernel_source()
 
-    branch = _find_after(src, "if (256 <= ((int)threadIdx.x))")
+    branch = _find_after(src, "if (((int)threadIdx.x) < 128)")
     cur_batch_idx_loop = _find_after(src, "for (int i = 0; i < 2; ++i)")
     m_start = _find_after(src, "int m_start =")
     actual_rows = _find_after(src, "int actual_rows =")

--- a/tilelang/cuda/op/gemm/gemm_mma.py
+++ b/tilelang/cuda/op/gemm/gemm_mma.py
@@ -77,7 +77,8 @@ class GemmMMA(GemmBase):
         mbar_phase_expr: tirx.PrimExpr | None = None,
     ):
         thread_nums = thread_bounds.extent
-        mma_emitter = self._make_mma_emitter(target, thread_nums, thread_var=thread_var)
+        local_thread_var = thread_var - thread_bounds.min
+        mma_emitter = self._make_mma_emitter(target, thread_nums, thread_var=local_thread_var)
 
         in_dtype = self.in_dtype
         warp_rows = mma_emitter.warp_rows

--- a/tilelang/cuda/op/gemm/gemm_mma_sm70.py
+++ b/tilelang/cuda/op/gemm/gemm_mma_sm70.py
@@ -61,6 +61,7 @@ class GemmMMASm70(GemmBase):
         mbar_phase_expr: tirx.PrimExpr | None = None,
     ):
         thread_nums = thread_bounds.extent
+        local_thread_var = thread_var - thread_bounds.min
         m_warp, n_warp = self.policy.compute_warp_partition(self.M, self.N, thread_nums, target, GEMM_INST_MMA)
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
@@ -75,7 +76,7 @@ class GemmMMASm70(GemmBase):
             warp_row_tiles=warp_row_tiles,
             warp_col_tiles=warp_col_tiles,
             chunk=self.chunk,
-            thread_var=thread_var,
+            thread_var=local_thread_var,
         )
 
         in_dtype = self.in_dtype

--- a/tilelang/cuda/op/gemm/gemm_wgmma.py
+++ b/tilelang/cuda/op/gemm/gemm_wgmma.py
@@ -93,6 +93,7 @@ class GemmWGMMA(GemmBase):
         mbar_phase_expr: tirx.PrimExpr | None = None,
     ):
         thread_nums = thread_bounds.extent
+        local_thread_var = thread_var - thread_bounds.min
         m_warp, n_warp = self.policy.compute_warp_partition(self.M, self.N, thread_nums, target, GEMM_INST_WGMMA)
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
@@ -107,7 +108,7 @@ class GemmWGMMA(GemmBase):
             warp_row_tiles=warp_row_tiles,
             warp_col_tiles=warp_col_tiles,
             chunk=self.chunk,
-            thread_var=thread_var,
+            thread_var=local_thread_var,
         )
 
         if self.A in layout_map:

--- a/tilelang/cuda/op/gemm_sp/gemm_sp_mma.py
+++ b/tilelang/cuda/op/gemm_sp/gemm_sp_mma.py
@@ -4,6 +4,7 @@ from tilelang.cuda.intrinsics.macro.mma_sp_macro_generator import SparseTensorCo
 from tilelang.utils.language import is_shared, is_fragment
 from tilelang import tvm as tvm
 from tvm.target import Target
+from tvm.ir import Range
 from tvm import tirx
 from tilelang import language as T
 from tilelang.transform.simplify import _Simplify
@@ -58,7 +59,9 @@ class GemmSPMMA(GemmSPBase):
         else:
             raise ValueError(f"Unsupported gemm combination, A: {self.A.scope()}, B: {self.B.scope()}")
 
-    def lower(self, layout_map: dict, target: Target, thread_nums: int, thread_var: tirx.Var):
+    def lower(self, layout_map: dict, target: Target, thread_bounds: Range, thread_var: tirx.Var):
+        thread_nums = thread_bounds.extent
+        local_thread_var = thread_var - thread_bounds.min
         m_warp, n_warp = self.policy.compute_warp_partition(self.M, self.N, thread_nums, target, GEMM_SP_INST_MMA_SP)
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
@@ -75,7 +78,7 @@ class GemmSPMMA(GemmSPBase):
             warp_row_tiles=warp_row_tiles,
             warp_col_tiles=warp_col_tiles,
             warp_k=self.K,
-            thread_var=thread_var,
+            thread_var=local_thread_var,
         )
 
         in_dtype = self.in_dtype

--- a/tilelang/cuda/op/gemm_sp/gemm_sp_wgmma.py
+++ b/tilelang/cuda/op/gemm_sp/gemm_sp_wgmma.py
@@ -11,6 +11,7 @@ from tilelang.layout import (
 from tilelang.cuda.intrinsics.macro.wgmma_sp_macro_generator import WGSparseTensorCoreIntrinEmitter
 from tilelang.utils.language import is_shared, is_fragment
 from tvm.target import Target
+from tvm.ir import Range
 from tvm import tirx
 from tilelang import language as T
 from tilelang.transform.simplify import _Simplify
@@ -73,10 +74,12 @@ class GemmSPWGMMA(GemmSPBase):
         self,
         layout_map: dict,
         target: Target,
-        thread_nums: int,
+        thread_bounds: Range,
         thread_var: tirx.Var,
         mbar_phase_expr: tirx.PrimExpr | None = None,
     ):
+        thread_nums = thread_bounds.extent
+        local_thread_var = thread_var - thread_bounds.min
         m_warp, n_warp = self.policy.compute_warp_partition(self.M, self.N, thread_nums, target, GEMM_SP_INST_WGMMA_SP)
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
@@ -93,7 +96,7 @@ class GemmSPWGMMA(GemmSPBase):
             warp_row_tiles=warp_row_tiles,
             warp_col_tiles=warp_col_tiles,
             warp_k=self.K,
-            thread_var=thread_var,
+            thread_var=local_thread_var,
         )
 
         if self.A in layout_map:

--- a/tilelang/tileop/gemm_sp/__init__.py
+++ b/tilelang/tileop/gemm_sp/__init__.py
@@ -50,8 +50,7 @@ class GemmSP(Node, Scriptable):
 
     @tvm_ffi.register_global_func("tl.gemm_sp.lower")
     def gemm_sp_lower(self, target: Target, layout_map: dict, thread_bounds: Range, thread_var: tirx.Var):
-        thread_nums = thread_bounds.extent
-        stmt = self.lower(target, layout_map, thread_nums, thread_var)
+        stmt = self.lower(target, layout_map, thread_bounds, thread_var)
         return stmt
 
     def infer_layout(self, target: Target, thread_nums: int):
@@ -59,10 +58,11 @@ class GemmSP(Node, Scriptable):
         impl_class = self._get_implementation_class(gemm_inst, target)
         return impl_class(self).infer_layout(target, thread_nums)
 
-    def lower(self, target: Target, layout_map: dict, thread_nums: int, thread_var: tirx.Var):
+    def lower(self, target: Target, layout_map: dict, thread_bounds: Range, thread_var: tirx.Var):
+        thread_nums = thread_bounds.extent
         gemm_inst = self._select_gemm_instruction(thread_nums, target)
         impl_class = self._get_implementation_class(gemm_inst, target)
-        return impl_class(self).lower(layout_map, target, thread_nums, thread_var)
+        return impl_class(self).lower(layout_map, target, thread_bounds, thread_var)
 
     def _select_gemm_instruction(self, thread_nums: int, target: Target) -> str:
         return str(_ffi_api.GemmSPGetGemmInstructionKey(self, int(thread_nums), target))

--- a/tilelang/tileop/gemm_sp/gemm_sp_base.py
+++ b/tilelang/tileop/gemm_sp/gemm_sp_base.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from tilelang import tvm as tvm
 from tvm.target import Target
+from tvm.ir import Range
 from tvm import tirx
 from tilelang.utils.language import is_shared, is_fragment
 from tilelang.ir import GemmSPWarpPolicy
@@ -14,7 +15,7 @@ class GemmSPBase:
     def infer_layout(self, target: Target, thread_nums: int):
         raise NotImplementedError("infer_layout is not implemented")
 
-    def lower(self, layout_map: dict, target: Target, thread_nums: int, thread_var: tirx.Var):
+    def lower(self, layout_map: dict, target: Target, thread_bounds: Range, thread_var: tirx.Var):
         raise NotImplementedError("lower is not implemented")
 
     def is_gemm_ss(self) -> bool:

--- a/tilelang/tileop/gemm_sp/gemm_sp_wgmma.py
+++ b/tilelang/tileop/gemm_sp/gemm_sp_wgmma.py
@@ -11,6 +11,7 @@ from tilelang.layout import (
 from tilelang.cuda.intrinsics.macro.wgmma_sp_macro_generator import WGSparseTensorCoreIntrinEmitter
 from tilelang.utils.language import is_shared, is_fragment
 from tvm.target import Target
+from tvm.ir import Range
 from tvm import tirx
 from tilelang import language as T
 from tilelang.transform.simplify import _Simplify
@@ -73,10 +74,12 @@ class GemmSPWGMMA(GemmSPBase):
         self,
         layout_map: dict,
         target: Target,
-        thread_nums: int,
+        thread_bounds: Range,
         thread_var: tirx.Var,
         mbar_phase_expr: tirx.PrimExpr | None = None,
     ):
+        thread_nums = thread_bounds.extent
+        local_thread_var = thread_var - thread_bounds.min
         m_warp, n_warp = self.policy.compute_warp_partition(self.M, self.N, thread_nums, target, GEMM_SP_INST_WGMMA_SP)
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)
@@ -93,7 +96,7 @@ class GemmSPWGMMA(GemmSPBase):
             warp_row_tiles=warp_row_tiles,
             warp_col_tiles=warp_col_tiles,
             warp_k=self.K,
-            thread_var=thread_var,
+            thread_var=local_thread_var,
         )
 
         if self.A in layout_map:


### PR DESCRIPTION
fix #2301.
- before: consumer [0, orignal #threads), producer [orignal #threads, orignal #threads + 128)
- after: producer[0, 128) consumer [128, 128 + orignal #threads)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Changed warp-specialization so producer threads use the lower thread-index range and consumer threads the upper range.
  * GEMM lowering now accepts explicit thread-bound ranges and uses local thread indexing for more consistent thread-based codegen.

* **Tests**
  * Updated and added tests to reflect the new thread-partitioning conditions and verify producer/consumer ordering and GEMM behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->