### PR TITLE
[BugFix][Examples] Use tirx in CDNA4 MXFP4 example

### DIFF
--- a/examples/dequantize_gemm/example_dequant_gemm_bf16_mxfp4_cdna4.py
+++ b/examples/dequantize_gemm/example_dequant_gemm_bf16_mxfp4_cdna4.py
@@ -16,27 +16,27 @@ import tilelang
 import tilelang.language as T
 from tilelang import tvm as tvm
 from tvm import DataType
-from tvm import tir
+from tvm import tirx
 import torch
 
 from tilelang.quantize import get_mxfp_intrin_group
 from dequantize_utils import torch_convert_bit_twiddling, torch_convert
 
 
-def _tir_u8_to_f4_to_bf16(nbit: int, val: tir.PrimExpr, pos: tir.PrimExpr, scale: tir.PrimExpr, dtype: str):
+def _tir_u8_to_f4_to_bf16(nbit: int, val: tirx.PrimExpr, pos: tirx.PrimExpr, scale: tirx.PrimExpr, dtype: str):
     """Convert a packed 4-bit FP4 field to bfloat16 (mirrors Hopper example, ignoring overflow clamp)."""
     assert nbit == 4
     assert dtype == T.bfloat16
     assert val.dtype == T.uint8
-    mask = tir.const((1 << nbit) - 1, T.uint16)
-    f4 = (val >> (pos.astype(T.uint16) * tir.const(nbit, T.uint16))) & mask
-    s = f4 >> tir.const(3, T.uint16)
-    e_f4 = (f4 & tir.const(6, T.uint16)) >> tir.const(1, T.uint16)
-    e_bf16 = e_f4 + tir.const(126, T.uint16)
-    m_f4 = f4 & tir.const(1, T.uint16)
-    val_bf16 = tir.reinterpret(
+    mask = tirx.const((1 << nbit) - 1, T.uint16)
+    f4 = (val >> (pos.astype(T.uint16) * tirx.const(nbit, T.uint16))) & mask
+    s = f4 >> tirx.const(3, T.uint16)
+    e_f4 = (f4 & tirx.const(6, T.uint16)) >> tirx.const(1, T.uint16)
+    e_bf16 = e_f4 + tirx.const(126, T.uint16)
+    m_f4 = f4 & tirx.const(1, T.uint16)
+    val_bf16 = tirx.reinterpret(
         T.bfloat16,
-        ((((s << tir.const(8, T.uint16)) | e_bf16) << tir.const(7, T.uint16)) | (m_f4 << tir.const(6, T.uint16))).astype(T.uint16),
+        ((((s << tirx.const(8, T.uint16)) | e_bf16) << tirx.const(7, T.uint16)) | (m_f4 << tirx.const(6, T.uint16))).astype(T.uint16),
     )
     return val_bf16
 


### PR DESCRIPTION
- Follow up on #2216 by migrating the CDNA4 MXFP4 dequantize example from `tvm.tir` to `tvm.tirx`.
- Replace the leftover `from tvm import tir` usage with `from tvm import tirx` and update the helper annotations/calls accordingly.

Importing the example module was not runnable in this local checkout because TileLang/TVM build artifacts are absent (`build/lib`, `build/tvm`, and `tvm` module not found).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quantization conversion example to use current API standards for MXFP4 to bfloat16 operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tile-ai/tilelang/pull/2310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->