### PR TITLE
[Runtime][Cache] Make tmp dir default follow cache dir

### DIFF
--- a/testing/python/components/test_tilelang_env.py
+++ b/testing/python/components/test_tilelang_env.py
@@ -1,17 +1,61 @@
-import tilelang
 import os
 
+import tilelang
 
-def test_env_var():
+
+def _env_var_descriptor(name):
+    return type(tilelang.env).__dict__[name]
+
+
+def _restore_forced_value(name, value):
+    _env_var_descriptor(name)._forced_value = value
+
+
+def test_env_var(monkeypatch):
+    desc = _env_var_descriptor("TILELANG_PRINT_ON_COMPILATION")
+    original_forced_value = desc._forced_value
+    desc._forced_value = None
+
     # test default value
-    assert tilelang.env.TILELANG_PRINT_ON_COMPILATION == "1"
-    # test forced value
-    os.environ["TILELANG_PRINT_ON_COMPILATION"] = "0"
-    assert tilelang.env.TILELANG_PRINT_ON_COMPILATION == "0"
-    # test forced value with class method
-    tilelang.env.TILELANG_PRINT_ON_COMPILATION = "1"
-    assert tilelang.env.TILELANG_PRINT_ON_COMPILATION == "1"
+    try:
+        monkeypatch.delenv("TILELANG_PRINT_ON_COMPILATION", raising=False)
+        assert tilelang.env.TILELANG_PRINT_ON_COMPILATION == "1"
+
+        # test environment value
+        monkeypatch.setenv("TILELANG_PRINT_ON_COMPILATION", "0")
+        assert tilelang.env.TILELANG_PRINT_ON_COMPILATION == "0"
+
+        # test forced value with class method
+        tilelang.env.TILELANG_PRINT_ON_COMPILATION = "1"
+        assert tilelang.env.TILELANG_PRINT_ON_COMPILATION == "1"
+    finally:
+        _restore_forced_value("TILELANG_PRINT_ON_COMPILATION", original_forced_value)
 
 
-if __name__ == "__main__":
-    test_env_var()
+def test_tilelang_tmp_dir_default_tracks_cache_dir(monkeypatch, tmp_path):
+    original_cache_forced_value = _env_var_descriptor("TILELANG_CACHE_DIR")._forced_value
+    original_tmp_forced_value = _env_var_descriptor("TILELANG_TMP_DIR")._forced_value
+    _restore_forced_value("TILELANG_CACHE_DIR", None)
+    _restore_forced_value("TILELANG_TMP_DIR", None)
+
+    try:
+        monkeypatch.delenv("TILELANG_CACHE_DIR", raising=False)
+        monkeypatch.delenv("TILELANG_TMP_DIR", raising=False)
+
+        monkeypatch.setenv("TILELANG_CACHE_DIR", str(tmp_path / "env_cache_a"))
+        assert os.path.join(str(tmp_path / "env_cache_a"), "tmp") == tilelang.env.TILELANG_TMP_DIR
+
+        monkeypatch.setenv("TILELANG_CACHE_DIR", str(tmp_path / "env_cache_b"))
+        assert os.path.join(str(tmp_path / "env_cache_b"), "tmp") == tilelang.env.TILELANG_TMP_DIR
+
+        tilelang.env.TILELANG_CACHE_DIR = str(tmp_path / "cache_a")
+        assert os.path.join(str(tmp_path / "cache_a"), "tmp") == tilelang.env.TILELANG_TMP_DIR
+
+        tilelang.env.TILELANG_CACHE_DIR = str(tmp_path / "cache_b")
+        assert os.path.join(str(tmp_path / "cache_b"), "tmp") == tilelang.env.TILELANG_TMP_DIR
+
+        monkeypatch.setenv("TILELANG_TMP_DIR", str(tmp_path / "explicit_tmp"))
+        assert str(tmp_path / "explicit_tmp") == tilelang.env.TILELANG_TMP_DIR
+    finally:
+        _restore_forced_value("TILELANG_CACHE_DIR", original_cache_forced_value)
+        _restore_forced_value("TILELANG_TMP_DIR", original_tmp_forced_value)

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -7,8 +7,11 @@ import logging
 import shutil
 import glob
 from dataclasses import dataclass
+from collections.abc import Callable
 
 logger = logging.getLogger(__name__)
+
+EnvVarDefault = str | None | Callable[[], str | None]
 
 # SETUP ENVIRONMENT VARIABLES
 CUTLASS_NOT_FOUND_MESSAGE = "CUTLASS is not installed or found in the expected path"
@@ -247,13 +250,18 @@ class EnvVar:
     """
 
     key: str  # Environment variable name (e.g. "TILELANG_PRINT_ON_COMPILATION")
-    default: str  # Default value if the environment variable is not set
+    default: EnvVarDefault  # Default value if the environment variable is not set
     _forced_value: str | None = None  # Temporary runtime override (mainly for tests/debugging)
+
+    def _get_default(self):
+        return self.default() if callable(self.default) else self.default
 
     def get(self):
         if self._forced_value is not None:
             return self._forced_value
-        return os.environ.get(self.key, self.default)
+        if self.key in os.environ:
+            return os.environ[self.key]
+        return self._get_default()
 
     def __get__(self, instance, owner):
         """
@@ -301,7 +309,7 @@ class Environment:
     # TileLang resources
     TILELANG_TEMPLATE_PATH = EnvVar("TL_TEMPLATE_PATH", None)
     TILELANG_CACHE_DIR = EnvVar("TILELANG_CACHE_DIR", os.path.expanduser("~/.tilelang/cache"))
-    TILELANG_TMP_DIR = EnvVar("TILELANG_TMP_DIR", os.path.join(TILELANG_CACHE_DIR.get(), "tmp"))
+    TILELANG_TMP_DIR = EnvVar("TILELANG_TMP_DIR", lambda: os.path.join(Environment.TILELANG_CACHE_DIR, "tmp"))
 
     # Kernel Build options
     TILELANG_PRINT_ON_COMPILATION = EnvVar("TILELANG_PRINT_ON_COMPILATION", "1")  # print kernel name on compile


### PR DESCRIPTION
## Summary

- Make `TILELANG_TMP_DIR` derive from the current `TILELANG_CACHE_DIR` when no explicit tmp dir is set.
- Prevent runtime cache-dir overrides from leaving tmp writes on a different filesystem.

## Changes

- Allows `EnvVar` defaults to be callable, so defaults can be evaluated dynamically.
- Changes `TILELANG_TMP_DIR` to compute its default from the current cache dir on access.
- Adds component tests covering environment-variable updates, runtime overrides, and explicit tmp-dir precedence.

## Validation

- `./format.sh`
- `python -m pytest testing/python/components/test_tilelang_env.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced environment variable handling: The temporary directory configuration now dynamically defaults to a subdirectory within your cache directory and properly reflects runtime changes, providing more flexible and consistent behavior when managing cached data locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->