### PR TITLE
[BugFix] Complete CuTeDSL support for TileKernels full functional tests

### DIFF
--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -54,6 +54,31 @@ static bool ContainsLoopBreak(const Stmt &stmt) {
   return det.found;
 }
 
+static bool IsThreadReturnEvaluate(const Stmt &stmt) {
+  const auto *eval = stmt.as<EvaluateNode>();
+  if (eval == nullptr) {
+    return false;
+  }
+  const auto *call = eval->value.as<CallNode>();
+  return call != nullptr && call->op.same_as(builtin::thread_return());
+}
+
+std::optional<PrimExpr> GetConditionalThreadReturnCondition(const Stmt &stmt) {
+  const auto *if_node = stmt.as<IfThenElseNode>();
+  if (if_node == nullptr || if_node->else_case) {
+    return std::nullopt;
+  }
+  if (IsThreadReturnEvaluate(if_node->then_case)) {
+    return if_node->condition;
+  }
+  if (const auto *seq = if_node->then_case.as<SeqStmtNode>();
+      seq != nullptr && seq->seq.size() == 1 &&
+      IsThreadReturnEvaluate(seq->seq[0])) {
+    return if_node->condition;
+  }
+  return std::nullopt;
+}
+
 // The threshold of the loop extent to use cutlass.range_constexpr
 // Higher values would lead to DSLOptimizationWarning:
 // This static loop has 128 iterations, which may be very slow to compile,
@@ -146,6 +171,7 @@ CodeGenTileLangCuTeDSL::CodeGenTileLangCuTeDSL() {
 
 void CodeGenTileLangCuTeDSL::InitFuncState_(const PrimFunc &f) {
   raw_pointer_vars_.clear();
+  zero_like_vars_.clear();
   CodeGenTileLangPY::InitFuncState_(f);
 }
 
@@ -276,8 +302,48 @@ void CodeGenTileLangCuTeDSL::PrintType(DataType t,
   os << DTypeToString(t);
 }
 
+static bool IsZeroLike(const PrimExpr &expr) {
+  PrimExpr value = expr;
+  if (const CastNode *cast = value.as<CastNode>()) {
+    value = cast->value;
+  }
+  if (const IntImmNode *imm = value.as<IntImmNode>()) {
+    return imm->value == 0;
+  }
+  if (const FloatImmNode *imm = value.as<FloatImmNode>()) {
+    return imm->value == 0.0;
+  }
+  return false;
+}
+
+static bool IsZeroTensorLike(const PrimExpr &expr) {
+  PrimExpr value = expr;
+  if (const CastNode *cast = value.as<CastNode>()) {
+    value = cast->value;
+  }
+  if (const BroadcastNode *broadcast = value.as<BroadcastNode>()) {
+    return IsZeroLike(broadcast->value);
+  }
+  return IsZeroLike(value);
+}
+
 void CodeGenTileLangCuTeDSL::VisitExpr_(const BroadcastNode *op,
                                         std::ostream &os) { // NOLINT(*)
+  if (op->dtype.is_float4_e2m1fn()) {
+    bool is_zero = IsZeroLike(op->value);
+    if (!is_zero) {
+      if (const VarNode *var = op->value.as<VarNode>()) {
+        is_zero = zero_like_vars_.count(var);
+      }
+    }
+    ICHECK(is_zero)
+        << "CuTeDSL cannot materialize scalar Float4E2M1FN values; only zero "
+           "broadcast is supported via packed storage";
+    os << "tl.make_filled_tensor((" << PrintExpr_(op->lanes)
+       << ",), 0, dtype=cutlass.Float4E2M1FN).load()";
+    return;
+  }
+
   // Note: We need to pass the dtype to make_filled_tensor so it can create
   // the correct CuTeDSL type (e.g., cutlass.Int32 instead of Python int)
   std::ostringstream dtype_str;
@@ -371,14 +437,46 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CastNode *op,
   // extracting only value_lanes elements when writing back.
   bool is_narrow_unaligned = target_ty.bits() < 32 && lanes > 1 &&
                              (target_ty.bits() * lanes) % 32 != 0;
+  bool source_is_narrow_unaligned =
+      from_ty.bits() < 32 && from_ty.lanes() > 1 &&
+      (from_ty.bits() * from_ty.lanes()) % 32 != 0;
   int aligned_lanes = is_narrow_unaligned ? (32 / target_ty.bits()) : lanes;
 
   std::string src = SSAGetID(PrintExpr_(op->value), from_ty);
 
+  if (source_is_narrow_unaligned && !is_narrow_unaligned) {
+    int source_aligned_lanes = 32 / from_ty.bits();
+    std::string aligned_dst = name_supply_->FreshName("_aligned_cast");
+    PrintIndent();
+    stream << aligned_dst << " = tl.make_rmem_tensor((" << source_aligned_lanes
+           << ",), ";
+    PrintType(target_ty.element_of(), stream);
+    stream << ")\n";
+    PrintIndent();
+    stream << aligned_dst << ".store(tl.cast_tensor(" << src << ".load(), ";
+    PrintType(target_ty.element_of(), stream);
+    stream << "))\n";
+
+    std::string cast_dst = name_supply_->FreshName("_cast");
+    PrintIndent();
+    stream << cast_dst << " = tl.make_rmem_tensor((" << lanes << ",), ";
+    PrintType(target_ty.element_of(), stream);
+    stream << ")\n";
+    for (int i = 0; i < lanes; ++i) {
+      PrintIndent();
+      stream << cast_dst << "[" << i << "] = " << aligned_dst << "[" << i
+             << "]\n";
+    }
+    os << cast_dst << ".load()";
+    return;
+  }
+
   // If unaligned, pad source to aligned width
   std::string cast_src = src;
+  bool cast_src_is_tensor = false;
   if (is_narrow_unaligned) {
     cast_src = name_supply_->FreshName("_pad_src");
+    cast_src_is_tensor = true;
     PrintIndent();
     stream << cast_src << " = tl.make_rmem_tensor((" << aligned_lanes << ",), ";
     PrintType(from_ty.element_of(), stream);
@@ -402,11 +500,11 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CastNode *op,
   PrintType(target_ty.element_of(), stream);
   stream << ")\n";
   PrintIndent();
-  if (is_narrow_unaligned) {
-    stream << cast_dst << ".store(" << cast_src << ".load().to(";
-  } else {
-    stream << cast_dst << ".store(" << src << ".to(";
+  stream << cast_dst << ".store(tl.cast_tensor(" << cast_src;
+  if (cast_src_is_tensor) {
+    stream << ".load()";
   }
+  stream << ", ";
   PrintType(target_ty.element_of(), stream);
   stream << "))\n";
 
@@ -494,13 +592,43 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
     stream << ")\n";
   };
 
-  // NOTE: builtin::if_then_else is handled by the base class
-  // (CodeGenTileLangPY) as a Python ternary: (true_val if cond else false_val).
-  // This is correct for expression contexts (range(), arithmetic, etc.). When
-  // the result is used in a BufferStore that needs TensorSSA, the store handler
-  // wraps it with tl.where().
-
-  if (op->op.same_as(builtin::ptx_cp_async())) {
+  if (op->op.same_as(builtin::if_then_else()) ||
+      op->op.same_as(tirx::builtin::if_then_else())) {
+    ICHECK_EQ(op->args.size(), 3U)
+        << "if_then_else expects <condition, true_value, false_value>";
+    auto cast_branch = [&](std::string value, DataType branch_dtype) {
+      DataType result_dtype = op->dtype;
+      if (result_dtype.is_uint() && result_dtype.bits() == 8 &&
+          result_dtype.is_scalar()) {
+        std::ostringstream casted;
+        PrintType(result_dtype, casted);
+        casted << "(" << value << ")";
+        return casted.str();
+      }
+      if (branch_dtype == result_dtype || !branch_dtype.is_scalar() ||
+          !result_dtype.is_scalar()) {
+        return value;
+      }
+      const bool integer_like =
+          (branch_dtype.is_int() || branch_dtype.is_uint()) &&
+          (result_dtype.is_int() || result_dtype.is_uint());
+      const bool float_like =
+          branch_dtype.is_float() && result_dtype.is_float();
+      if (!integer_like && !float_like) {
+        return value;
+      }
+      std::ostringstream casted;
+      PrintType(result_dtype, casted);
+      casted << "(" << value << ")";
+      return casted.str();
+    };
+    std::string cond = PrintExpr_(op->args[0]);
+    std::string true_val =
+        cast_branch(PrintExpr_(op->args[1]), op->args[1].dtype());
+    std::string false_val =
+        cast_branch(PrintExpr_(op->args[2]), op->args[2].dtype());
+    os << "(" << true_val << " if " << cond << " else " << false_val << ")";
+  } else if (op->op.same_as(builtin::ptx_cp_async())) {
     // args[0] = dst_access_ptr, args[1] = src_access_ptr, args[2] = bytes,
     // args[3] = predicate (optional)
     ICHECK(op->args.size() == 3 || op->args.size() == 4)
@@ -1084,6 +1212,23 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
 
     const BufferLoadNode *load = op->args[0].as<BufferLoadNode>();
     if (load) {
+      std::string scope;
+      const VarNode *buffer_var = load->buffer->data.get();
+      if (alloc_storage_scope_.count(buffer_var)) {
+        scope = alloc_storage_scope_.at(buffer_var);
+      }
+      if (scope.empty()) {
+        scope = GetPtrStorageScope(load->buffer->data);
+      }
+      if (scope == "local.var") {
+        std::string expr_str =
+            GetBufferRef_(src_dtype, load->buffer.get(), load->indices[0]);
+        os << "tl.bitcast(" << expr_str << ", ";
+        PrintType(tgt_dtype.element_of(), os);
+        os << ")";
+        return;
+      }
+
       // Path 1: BufferLoad - use recast_ptr for memory access
       ICHECK_EQ(load->indices.size(), 1)
           << "CodeGenTileLangCuTeDSL only supports flat memory";
@@ -1099,7 +1244,12 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
       auto ptr_str = GetBufferPtr_(load->buffer.get(), index);
       os << "tl.make_tensor(tl.recast_ptr(" << ptr_str << ", dtype=";
       PrintType(tgt_dtype.element_of(), os);
-      os << "), (" << tgt_dtype.lanes() << ",)).load()";
+      os << "), (" << tgt_dtype.lanes() << ",))";
+      if (tgt_dtype.is_scalar()) {
+        os << "[0]";
+      } else {
+        os << ".load()";
+      }
     } else {
       // Path 2: General expression - use arith.bitcast
       std::string expr_str = PrintExpr_(op->args[0]);
@@ -1119,6 +1269,30 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
                      op->args, true, os);
   } else if (op->op.same_as(tl::tl_gemm_sp())) {
     LOG(FATAL) << "Currently unsupported op: " << op->op;
+  } else if (op->op.same_as(tl::shfl_sync())) {
+    ICHECK_EQ(op->args.size(), 4U)
+        << "tl.shfl_sync expects <mask, value, src_lane, width>.";
+    os << "tl.__shfl_sync(" << PrintExpr_(op->args[0]) << ", "
+       << PrintExpr_(op->args[1]) << ", " << PrintExpr_(op->args[2]) << ", "
+       << PrintExpr_(op->args[3]) << ")";
+  } else if (op->op.same_as(tl::shfl_xor_sync())) {
+    ICHECK_EQ(op->args.size(), 4U)
+        << "tl.shfl_xor_sync expects <mask, value, lane_mask, width>.";
+    os << "tl.__shfl_xor_sync(" << PrintExpr_(op->args[0]) << ", "
+       << PrintExpr_(op->args[1]) << ", " << PrintExpr_(op->args[2]) << ", "
+       << PrintExpr_(op->args[3]) << ")";
+  } else if (op->op.same_as(tl::shfl_down_sync())) {
+    ICHECK_EQ(op->args.size(), 4U)
+        << "tl.shfl_down_sync expects <mask, value, delta, width>.";
+    os << "tl.__shfl_down_sync(" << PrintExpr_(op->args[0]) << ", "
+       << PrintExpr_(op->args[1]) << ", " << PrintExpr_(op->args[2]) << ", "
+       << PrintExpr_(op->args[3]) << ")";
+  } else if (op->op.same_as(tl::shfl_up_sync())) {
+    ICHECK_EQ(op->args.size(), 4U)
+        << "tl.shfl_up_sync expects <mask, value, delta, width>.";
+    os << "tl.__shfl_up_sync(" << PrintExpr_(op->args[0]) << ", "
+       << PrintExpr_(op->args[1]) << ", " << PrintExpr_(op->args[2]) << ", "
+       << PrintExpr_(op->args[3]) << ")";
   } else if (op->op.same_as(tl::get_lane_idx())) {
     // get_lane_idx(warp_size?) -> threadIdx.x % warp_size
     ICHECK_LE(op->args.size(), 1U)
@@ -1240,6 +1414,33 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
     os << "tl.warp_reduce_bitand(" << PrintExpr_(op->args[0]) << ")";
   } else if (op->op.same_as(tl::warp_reduce_bitor())) {
     os << "tl.warp_reduce_bitor(" << PrintExpr_(op->args[0]) << ")";
+  } else if (op->op.same_as(tl::add2())) {
+    ICHECK_EQ(op->args.size(), 2U);
+    os << "(" << PrintExpr_(op->args[0]) << " + " << PrintExpr_(op->args[1])
+       << ")";
+  } else if (op->op.same_as(tl::sub2())) {
+    ICHECK_EQ(op->args.size(), 2U);
+    os << "(" << PrintExpr_(op->args[0]) << " - " << PrintExpr_(op->args[1])
+       << ")";
+  } else if (op->op.same_as(tl::mul2())) {
+    ICHECK_EQ(op->args.size(), 2U);
+    os << "(" << PrintExpr_(op->args[0]) << " * " << PrintExpr_(op->args[1])
+       << ")";
+  } else if (op->op.same_as(tl::fma2())) {
+    ICHECK_EQ(op->args.size(), 3U);
+    os << "((" << PrintExpr_(op->args[0]) << " * " << PrintExpr_(op->args[1])
+       << ") + " << PrintExpr_(op->args[2]) << ")";
+  } else if (op->op.same_as(tl::max2()) || op->op.same_as(tl::max2_nan())) {
+    ICHECK_EQ(op->args.size(), 2U);
+    os << "tl.max2(" << PrintExpr_(op->args[0]) << ", "
+       << PrintExpr_(op->args[1]) << ")";
+  } else if (op->op.same_as(tl::min2()) || op->op.same_as(tl::min2_nan())) {
+    ICHECK_EQ(op->args.size(), 2U);
+    os << "tl.min2(" << PrintExpr_(op->args[0]) << ", "
+       << PrintExpr_(op->args[1]) << ")";
+  } else if (op->op.same_as(tl::abs2())) {
+    ICHECK_EQ(op->args.size(), 1U);
+    os << "tl.abs2(" << PrintExpr_(op->args[0]) << ")";
   } else if (op->op.same_as(builtin::address_of())) {
     const BufferLoadNode *load = op->args[0].as<BufferLoadNode>();
     ICHECK(op->args.size() == 1 && load);
@@ -1337,7 +1538,92 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const SelectNode *op,
   std::string cond = PrintExpr_(op->condition);
   std::string t = PrintExpr_(op->true_value);
   std::string f = PrintExpr_(op->false_value);
+  auto cast_branch = [&](std::string value, DataType branch_dtype) {
+    DataType result_dtype = op->dtype;
+    if (result_dtype.is_uint() && result_dtype.bits() == 8 &&
+        result_dtype.is_scalar()) {
+      std::ostringstream casted;
+      PrintType(result_dtype, casted);
+      casted << "(" << value << ")";
+      return casted.str();
+    }
+    if (branch_dtype == result_dtype || !branch_dtype.is_scalar() ||
+        !result_dtype.is_scalar()) {
+      return value;
+    }
+    const bool integer_like =
+        (branch_dtype.is_int() || branch_dtype.is_uint()) &&
+        (result_dtype.is_int() || result_dtype.is_uint());
+    const bool float_like = branch_dtype.is_float() && result_dtype.is_float();
+    if (!integer_like && !float_like) {
+      return value;
+    }
+    std::ostringstream casted;
+    PrintType(result_dtype, casted);
+    casted << "(" << value << ")";
+    return casted.str();
+  };
+  t = cast_branch(t, op->true_value.dtype());
+  f = cast_branch(f, op->false_value.dtype());
   os << "(" << t << " if " << cond << " else " << f << ")";
+}
+
+void CodeGenTileLangCuTeDSL::VisitExpr_(const LetNode *op,
+                                        std::ostream &os) { // NOLINT(*)
+  std::string value = PrintExpr_(op->value);
+  ICHECK(!var_idmap_.count(op->var.get()));
+  PrintIndent();
+  stream << AllocVarID(op->var.get()) << " = " << value << "\n";
+  os << PrintExpr_(op->body);
+  bool removed = var_idmap_.erase(op->var.get());
+  ICHECK(removed);
+}
+
+void CodeGenTileLangCuTeDSL::VisitExpr_(const ShuffleNode *op,
+                                        std::ostream &os) { // NOLINT(*)
+  std::vector<std::string> concat_vec;
+
+  for (const PrimExpr &vec : op->vectors) {
+    std::string vec_value = PrintExpr_(vec);
+    if (vec.dtype().is_scalar()) {
+      concat_vec.push_back(vec_value);
+    } else {
+      std::string vec_id = SSAGetID(vec_value, vec.dtype());
+      for (int i = 0; i < vec.dtype().lanes(); ++i) {
+        std::ostringstream elem;
+        PrintVecElemLoad_(vec_id, vec.dtype(), i, elem);
+        concat_vec.push_back(elem.str());
+      }
+    }
+  }
+
+  if (op->indices.size() == 1) {
+    ICHECK(op->indices[0]->IsInstance<IntImmNode>())
+        << "ShuffleNode indices must be constants at codegen time, got "
+        << op->indices[0];
+    int64_t idx = Downcast<IntImm>(op->indices[0])->value;
+    ICHECK_GE(idx, 0);
+    ICHECK_LT(idx, static_cast<int64_t>(concat_vec.size()));
+    os << concat_vec[idx];
+    return;
+  }
+
+  std::string sret = name_supply_->FreshName("_shuffle");
+  PrintIndent();
+  stream << sret << " = tl.make_rmem_tensor((" << op->indices.size() << ",), ";
+  PrintType(op->dtype.element_of(), stream);
+  stream << ")\n";
+
+  for (size_t i = 0; i < op->indices.size(); ++i) {
+    ICHECK(op->indices[i]->IsInstance<IntImmNode>())
+        << "ShuffleNode indices must be constants at codegen time, got "
+        << op->indices[i];
+    int64_t idx = Downcast<IntImm>(op->indices[i])->value;
+    ICHECK_GE(idx, 0);
+    ICHECK_LT(idx, static_cast<int64_t>(concat_vec.size()));
+    PrintVecElemStore_(sret, op->dtype, static_cast<int>(i), concat_vec[idx]);
+  }
+  os << sret << ".load()";
 }
 
 void CodeGenTileLangCuTeDSL::VisitExpr_(const BufferLoadNode *op,
@@ -1387,8 +1673,65 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const BufferLoadNode *op,
     // extractelement (which fails due to unrealized_conversion_cast).
     std::string aligned_rmem = name_supply_->FreshName("_aload");
 
-    if (scope == "local") {
-      // For rmem: load aligned_lanes elements without cute.assume.
+    if (value_dtype.bits() < 8) {
+      const int packed_bits = value_lanes * value_dtype.bits();
+      ICHECK_EQ(packed_bits % 8, 0)
+          << "Sub-byte vector loads must cover whole bytes";
+      const int packed_bytes = packed_bits / 8;
+      const int aligned_bytes = aligned_lanes * value_dtype.bits() / 8;
+      const int byte_lanes = 8 / value_dtype.bits();
+
+      std::string ptr_str;
+      if (scope == "local" || scope == "shared" || scope == "shared.dyn") {
+        ptr_str = vid + ".iterator";
+      } else {
+        bool is_handle_match =
+            HandleTypeMatch_(buffer_var.get(), element_dtype);
+        if (is_handle_match) {
+          ptr_str = vid + ".iterator";
+        } else {
+          std::ostringstream ptr_os;
+          ptr_os << "tl.recast_ptr(" << vid << ".iterator, dtype=";
+          PrintType(value_dtype.element_of(), ptr_os);
+          ptr_os << ")";
+          ptr_str = ptr_os.str();
+        }
+      }
+
+      std::string dst_bytes = name_supply_->FreshName("_pload_dst");
+      std::string src_view = name_supply_->FreshName("_pload_view");
+      std::string src_bytes = name_supply_->FreshName("_pload_src");
+      PrintIndent();
+      stream << aligned_rmem << " = tl.make_rmem_tensor((" << aligned_lanes
+             << ",), ";
+      PrintType(value_dtype.element_of(), stream);
+      stream << ")\n";
+      PrintIndent();
+      stream << dst_bytes << " = cute.recast_tensor(" << aligned_rmem
+             << ", cutlass.Uint8)\n";
+      for (int i = 0; i < aligned_bytes; ++i) {
+        PrintIndent();
+        stream << dst_bytes << "[" << i << "] = cutlass.Uint8(0)\n";
+      }
+      PrintIndent();
+      stream << src_view << " = tl.make_tensor_at_offset(" << ptr_str << ", "
+             << PrintExpr_(scalar_base) << ", (" << value_lanes
+             << ",), div_by=" << byte_lanes << ")\n";
+      PrintIndent();
+      stream << src_bytes << " = cute.recast_tensor(" << src_view
+             << ", cutlass.Uint8)\n";
+      for (int i = 0; i < packed_bytes; ++i) {
+        PrintIndent();
+        stream << dst_bytes << "[" << i << "] = " << src_bytes << "[" << i
+               << "]\n";
+      }
+
+      os << aligned_rmem;
+      return;
+    }
+
+    if (scope == "local" || scope == "shared" || scope == "shared.dyn") {
+      // For rmem/smem: load aligned_lanes elements without cute.assume.
       // cute.assume(offset, divby=N) silently truncates offsets that
       // are not exact multiples of N; for rmem there is no hardware
       // alignment constraint, so we skip assume (use default div_by=1).
@@ -1540,61 +1883,145 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const BufferStoreNode *op) {
     int lanes = value_dtype.lanes();
     if (lanes == 0)
       lanes = 1;
-    // Helper: wrap a sub-expression as TensorSSA via make_rmem_tensor.
-    auto as_tsa = [this](const PrimExpr &e, int n,
-                         DataType elem_dt) -> std::string {
-      std::string s = PrintExpr_(e);
-      if (n == 0)
-        n = 1;
-      if (s.size() >= 7 && s.compare(s.size() - 7, 7, ".load()") == 0)
-        return s;
-      std::string var = name_supply_->FreshName("_tsa");
+    DataType conditional_dtype =
+        cast_to_dtype.bits() > 0 ? cast_to_dtype : value_dtype;
+    const bool is_subbyte_vector_conditional =
+        conditional_dtype.element_of().bits() < 8 &&
+        conditional_dtype.lanes() > 1;
+    if (is_subbyte_vector_conditional) {
+      std::string cond = PrintExpr_(cond_expr);
+      std::string true_data = PrintExpr_(true_expr);
+      std::string false_data = PrintExpr_(false_expr);
+      auto is_zero_tensor_string = [](const std::string &s) {
+        return s.find("tl.make_filled_tensor") != std::string::npos &&
+               s.find(", 0, dtype=") != std::string::npos;
+      };
+      const bool true_is_zero =
+          IsZeroTensorLike(true_expr) || is_zero_tensor_string(true_data);
+      const bool false_is_zero =
+          IsZeroTensorLike(false_expr) || is_zero_tensor_string(false_data);
+      ICHECK(true_is_zero || false_is_zero)
+          << "Sub-byte conditional vectors currently require one zero branch";
+      std::string data = true_is_zero ? false_data : true_data;
+      const int packed_bits =
+          conditional_dtype.lanes() * conditional_dtype.element_of().bits();
+      ICHECK_EQ(packed_bits % 8, 0)
+          << "Sub-byte conditional vectors must cover whole bytes";
+      const int packed_bytes = packed_bits / 8;
+
+      std::string result_tensor = name_supply_->FreshName("_where_tensor");
+      std::string data_bytes = name_supply_->FreshName("_where_src");
+      std::string result_bytes = name_supply_->FreshName("_where_dst");
       PrintIndent();
-      if (elem_dt.is_bool()) {
-        stream << var << " = tl.make_rmem_tensor((" << n
-               << ",), cutlass.Boolean)\n";
-      } else {
-        stream << var << " = tl.make_rmem_tensor((" << n << ",), "
-               << DTypeToString(elem_dt) << ")\n";
-      }
-      for (int i = 0; i < n; ++i) {
+      stream << result_tensor << " = tl.make_rmem_tensor(("
+             << conditional_dtype.lanes() << ",), "
+             << DTypeToString(conditional_dtype.element_of()) << ")\n";
+      PrintIndent();
+      stream << data_bytes << " = cute.recast_tensor(" << data
+             << ", cutlass.Uint8)\n";
+      PrintIndent();
+      stream << result_bytes << " = cute.recast_tensor(" << result_tensor
+             << ", cutlass.Uint8)\n";
+      for (int i = 0; i < packed_bytes; ++i) {
         PrintIndent();
-        if (n == 1) {
-          stream << var << "[0] = " << s << "\n";
+        stream << result_bytes << "[" << i << "] = ";
+        if (true_is_zero) {
+          stream << "(cutlass.Uint8(0) if " << cond << " else " << data_bytes
+                 << "[" << i << "])\n";
         } else {
-          stream << var << "[" << i << "] = " << s << "[" << i << "]\n";
+          stream << "(" << data_bytes << "[" << i << "] if " << cond
+                 << " else cutlass.Uint8(0))\n";
         }
       }
-      return var + ".load()";
-    };
-    DataType true_ty = true_expr.dtype().element_of();
-    DataType false_ty = false_expr.dtype().element_of();
-    std::string cond_tsa = as_tsa(cond_expr, 1, DataType::Bool());
-    std::string then_tsa = as_tsa(true_expr, lanes, true_ty);
-    std::string else_tsa = as_tsa(false_expr, lanes, false_ty);
-    if (true_ty != false_ty) {
-      DataType common =
-          (true_ty.bits() >= false_ty.bits()) ? true_ty : false_ty;
-      if (common.bits() < 32 && true_ty.is_float() && false_ty.is_float())
-        common = DataType::Float(32);
-      std::string common_str = DTypeToString(common);
-      then_tsa += ".to(" + common_str + ")";
-      else_tsa += ".to(" + common_str + ")";
-    }
-    std::string result = name_supply_->FreshName("_where");
-    PrintIndent();
-    stream << result << " = tl.where(" << cond_tsa << ", " << then_tsa << ", "
-           << else_tsa << ")\n";
-    // If the conditional was wrapped in a Cast, apply .to() on the result.
-    // tl.where() returns TensorSSA, and .to() on TensorSSA returns TensorSSA.
-    if (cast_to_dtype.bits() > 0) {
-      std::string cast_result = name_supply_->FreshName("_wcast");
-      PrintIndent();
-      stream << cast_result << " = " << result << ".to("
-             << DTypeToString(cast_to_dtype.element_of()) << ")\n";
-      value_str = cast_result;
+      value_str = result_tensor;
     } else {
-      value_str = result;
+      // Helper: wrap a sub-expression as TensorSSA via make_rmem_tensor.
+      auto as_tsa = [this](const PrimExpr &e, int n,
+                           DataType elem_dt) -> std::string {
+        std::string s = PrintExpr_(e);
+        if (n == 0)
+          n = 1;
+        if (s.size() >= 7 && s.compare(s.size() - 7, 7, ".load()") == 0)
+          return s;
+        std::string var = name_supply_->FreshName("_tsa");
+        PrintIndent();
+        if (elem_dt.is_bool()) {
+          stream << var << " = tl.make_rmem_tensor((" << n
+                 << ",), cutlass.Boolean)\n";
+        } else {
+          stream << var << " = tl.make_rmem_tensor((" << n << ",), "
+                 << DTypeToString(elem_dt) << ")\n";
+        }
+        if (elem_dt.bits() < 8 && n > 1) {
+          const int packed_bits = n * elem_dt.bits();
+          ICHECK_EQ(packed_bits % 8, 0)
+              << "Sub-byte conditional vectors must cover whole bytes";
+          const int packed_bytes = packed_bits / 8;
+          std::string src_bytes = name_supply_->FreshName("_where_src");
+          std::string dst_bytes = name_supply_->FreshName("_where_dst");
+          PrintIndent();
+          stream << src_bytes << " = cute.recast_tensor(" << s
+                 << ", cutlass.Uint8)\n";
+          PrintIndent();
+          stream << dst_bytes << " = cute.recast_tensor(" << var
+                 << ", cutlass.Uint8)\n";
+          for (int i = 0; i < packed_bytes; ++i) {
+            PrintIndent();
+            stream << dst_bytes << "[" << i << "] = " << src_bytes << "[" << i
+                   << "]\n";
+          }
+        } else {
+          for (int i = 0; i < n; ++i) {
+            PrintIndent();
+            if (n == 1) {
+              stream << var << "[0] = " << s << "\n";
+            } else {
+              stream << var << "[" << i << "] = " << s << "[" << i << "]\n";
+            }
+          }
+        }
+        return var + ".load()";
+      };
+      DataType true_ty = true_expr.dtype().element_of();
+      DataType false_ty = false_expr.dtype().element_of();
+      std::string cond_tsa = as_tsa(cond_expr, 1, DataType::Bool());
+      std::string then_tsa = as_tsa(true_expr, lanes, true_ty);
+      std::string else_tsa = as_tsa(false_expr, lanes, false_ty);
+      if (true_ty != false_ty) {
+        DataType common =
+            (true_ty.bits() >= false_ty.bits()) ? true_ty : false_ty;
+        if (common.bits() < 32 && true_ty.is_float() && false_ty.is_float())
+          common = DataType::Float(32);
+        std::string common_str = DTypeToString(common);
+        then_tsa += ".to(" + common_str + ")";
+        else_tsa += ".to(" + common_str + ")";
+      }
+      std::string result = name_supply_->FreshName("_where");
+      PrintIndent();
+      stream << result << " = tl.where(" << cond_tsa << ", " << then_tsa << ", "
+             << else_tsa << ")\n";
+      // If the conditional was wrapped in a Cast, apply .to() on the result.
+      // tl.where() returns TensorSSA, and .to() on TensorSSA returns TensorSSA.
+      if (cast_to_dtype.bits() > 0) {
+        std::string cast_result = name_supply_->FreshName("_wcast");
+        PrintIndent();
+        stream << cast_result << " = " << result << ".to("
+               << DTypeToString(cast_to_dtype.element_of()) << ")\n";
+        value_str = cast_result;
+      } else {
+        value_str = result;
+      }
+      if (conditional_dtype.element_of().bits() < 8 &&
+          conditional_dtype.lanes() > 1) {
+        std::string tensor_result = name_supply_->FreshName("_where_tensor");
+        PrintIndent();
+        stream << tensor_result << " = tl.make_rmem_tensor(("
+               << conditional_dtype.lanes() << ",), "
+               << DTypeToString(conditional_dtype.element_of()) << ")\n";
+        PrintIndent();
+        stream << tensor_result << ".store(" << value_str << ")\n";
+        value_str = tensor_result;
+      }
     }
   } else {
     value_str = PrintExpr_(op->value);
@@ -1637,13 +2064,10 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const BufferStoreNode *op) {
     }
 
     if (scope == "local") {
-      // For local rmem: use element-by-element assignment.
-      // A padded (aligned_lanes,) .store() writes beyond value_lanes
-      // elements, causing overlapping writes and OOB at the end of the
-      // rmem tensor.  And cute.assume with div_by=aligned_lanes silently
-      // truncates non-aligned offsets.  Element assignment (vid[i]=val)
-      // avoids both issues and does not trigger CuTeDSL's 32-bit
-      // alignment check that .store() enforces for FP8 types.
+      // For local rmem: use element-by-element assignment when the scalar
+      // element can be dereferenced.  Sub-byte types such as FP4 cannot be
+      // scalar-dereferenced by CuTeDSL, so move their packed byte storage
+      // through a Uint8 recast instead.
       PrimExpr scalar_base;
       if (value_lanes == element_dtype.lanes()) {
         scalar_base = index_expr * value_lanes;
@@ -1654,10 +2078,36 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const BufferStoreNode *op) {
             << "Non-contiguous narrow-precision store not supported";
         scalar_base = ramp_base.Eval() * element_dtype.lanes();
       }
-      for (int i = 0; i < value_lanes; ++i) {
+      if (value_dtype.bits() < 8) {
+        const int packed_bits = value_lanes * value_dtype.bits();
+        ICHECK_EQ(packed_bits % 8, 0)
+            << "Sub-byte local vector stores must cover whole bytes";
+        const int packed_bytes = packed_bits / 8;
+        const int byte_lanes = 8 / value_dtype.bits();
+        std::string src_bytes = name_supply_->FreshName("_pstore_src");
+        std::string dst_view = name_supply_->FreshName("_pstore_view");
+        std::string dst_bytes = name_supply_->FreshName("_pstore_dst");
         PrintIndent();
-        stream << vid << "[" << PrintExpr_(scalar_base) << " + " << i
-               << "] = " << value_str << "[" << i << "]\n";
+        stream << src_bytes << " = cute.recast_tensor(" << value_str
+               << ", cutlass.Uint8)\n";
+        PrintIndent();
+        stream << dst_view << " = tl.make_tensor_at_offset(" << vid
+               << ".iterator, " << PrintExpr_(scalar_base) << ", ("
+               << value_lanes << ",), div_by=" << byte_lanes << ")\n";
+        PrintIndent();
+        stream << dst_bytes << " = cute.recast_tensor(" << dst_view
+               << ", cutlass.Uint8)\n";
+        for (int i = 0; i < packed_bytes; ++i) {
+          PrintIndent();
+          stream << dst_bytes << "[" << i << "] = " << src_bytes << "[" << i
+                 << "]\n";
+        }
+      } else {
+        for (int i = 0; i < value_lanes; ++i) {
+          PrintIndent();
+          stream << vid << "[" << PrintExpr_(scalar_base) << " + " << i
+                 << "] = " << value_str << "[" << i << "]\n";
+        }
       }
     } else {
       // For global/shared: use scalar element stores (works at any alignment).
@@ -1685,15 +2135,44 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const BufferStoreNode *op) {
         ptr_str = ptr_os.str();
       }
 
-      // Create a tensor view and store each element individually
+      // Create a tensor view and store each element individually.  For
+      // sub-byte types, use a packed Uint8 view because CuTeDSL rejects scalar
+      // dereference of FP4/FP6 storage.
       std::string view_var = name_supply_->FreshName("_sview");
       PrintIndent();
-      stream << view_var << " = tl.make_tensor(" << ptr_str << " + "
-             << PrintExpr_(scalar_base) << ", (" << value_lanes << ",))\n";
-      for (int i = 0; i < value_lanes; ++i) {
+      if (value_dtype.bits() < 8) {
+        stream << view_var << " = tl.make_tensor_at_offset(" << ptr_str << ", "
+               << PrintExpr_(scalar_base) << ", (" << value_lanes
+               << ",), div_by=" << (8 / value_dtype.bits()) << ")\n";
+      } else {
+        stream << view_var << " = tl.make_tensor(" << ptr_str << " + "
+               << PrintExpr_(scalar_base) << ", (" << value_lanes << ",))\n";
+      }
+      if (value_dtype.bits() < 8) {
+        const int packed_bits = value_lanes * value_dtype.bits();
+        ICHECK_EQ(packed_bits % 8, 0)
+            << "Sub-byte vector stores must cover whole bytes";
+        const int packed_bytes = packed_bits / 8;
+        const int byte_lanes = 8 / value_dtype.bits();
+        std::string src_bytes = name_supply_->FreshName("_pstore_src");
+        std::string dst_bytes = name_supply_->FreshName("_pstore_dst");
         PrintIndent();
-        stream << view_var << "[" << i << "] = " << value_str << "[" << i
-               << "]\n";
+        stream << src_bytes << " = cute.recast_tensor(" << value_str
+               << ", cutlass.Uint8)\n";
+        PrintIndent();
+        stream << dst_bytes << " = cute.recast_tensor(" << view_var
+               << ", cutlass.Uint8)\n";
+        for (int i = 0; i < packed_bytes; ++i) {
+          PrintIndent();
+          stream << dst_bytes << "[" << i << "] = " << src_bytes << "[" << i
+                 << "]\n";
+        }
+      } else {
+        for (int i = 0; i < value_lanes; ++i) {
+          PrintIndent();
+          stream << view_var << "[" << i << "] = " << value_str << "[" << i
+                 << "]\n";
+        }
       }
     }
   } else if (value_lanes == element_dtype.lanes()) {
@@ -1786,6 +2265,9 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const BindNode *op) {
     }
   }
 
+  if (IsZeroLike(op->value)) {
+    zero_like_vars_.insert(op->var.get());
+  }
   CodeGenTileLangPY::VisitStmt_(op);
 }
 
@@ -1815,17 +2297,29 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const AllocBufferNode *op) {
         << (opt_size.has_value() ? opt_size.value() : 0) << " for "
         << op->buffer->data->name_hint;
     size_t constant_size = static_cast<size_t>(opt_size.value());
+    const bool scalarized_vector_alloc =
+        (scope == "shared" || scope == "local") &&
+        alloc_dtype.is_fixed_length_vector();
+    DataType storage_dtype =
+        scalarized_vector_alloc ? alloc_dtype.element_of() : alloc_dtype;
+    size_t storage_size = constant_size;
+    if (scalarized_vector_alloc) {
+      storage_size *= static_cast<size_t>(alloc_dtype.lanes());
+    }
+    if ((scope == "shared" || scope == "local") && storage_dtype.bits() < 8) {
+      storage_size += static_cast<size_t>(32 / storage_dtype.bits() - 1);
+    }
 
     if (scope == "shared") {
       stream << vid << " = tl.make_tensor(tl.alloc_smem(";
-      PrintType(alloc_dtype, stream);
-      stream << ", " << constant_size << "), (" << constant_size << ",))\n";
+      PrintType(storage_dtype, stream);
+      stream << ", " << storage_size << "), (" << storage_size << ",))\n";
     } else if (scope == "shared.barrier" || scope == "shared.cluster_barrier") {
       stream << vid << " = tl.alloc_smem(cutlass.Uint64, size_in_elems="
              << constant_size << ")\n";
     } else if (scope == "local") {
-      stream << vid << " = tl.make_rmem_tensor((" << constant_size << "),";
-      PrintType(alloc_dtype, stream);
+      stream << vid << " = tl.make_rmem_tensor((" << storage_size << "),";
+      PrintType(storage_dtype, stream);
       stream << ")\n";
     } else if (scope == "local.var") {
       PrimExpr init = tirx::make_const(alloc_dtype, 0);
@@ -1843,7 +2337,11 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const AllocBufferNode *op) {
     }
   }
 
-  RegisterHandleType_(op->buffer->data.get(), alloc_dtype);
+  DataType registered_dtype = ((scope == "shared" || scope == "local") &&
+                               alloc_dtype.is_fixed_length_vector())
+                                  ? alloc_dtype.element_of()
+                                  : alloc_dtype;
+  RegisterHandleType_(op->buffer->data.get(), registered_dtype);
 }
 
 void CodeGenTileLangCuTeDSL::VisitStmt_(const AttrStmtNode *op) {
@@ -1970,20 +2468,33 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const ForNode *op) {
 }
 
 void CodeGenTileLangCuTeDSL::VisitStmt_(const SeqStmtNode *op) {
-  if (!in_break_loop_) {
-    // Normal path: delegate to base class
-    CodeGenTileLangPY::VisitStmt_(op);
-    return;
-  }
+  // CuTeDSL does not allow dynamic early returns. Convert
+  // `if cond: thread_return(); rest` into `if not cond: rest`.
+  std::vector<int> thread_return_guard_scopes;
 
-  // In a break loop: after visiting a statement that contains loop_break(),
-  // wrap the remaining statements in an `if _loop_break_N == 0:` guard
-  // so they don't execute in the same iteration after the break.
+  // In a break loop, after visiting a statement that contains loop_break(),
+  // wrap the remaining statements in an `if _loop_break_N == 0:` guard so they
+  // don't execute in the same iteration after the break.
   int guard_scope = -1;
   for (size_t i = 0; i < op->seq.size(); ++i) {
+    if (auto condition = GetConditionalThreadReturnCondition(op->seq[i])) {
+      if (i + 1 < op->seq.size()) {
+        PrintIndent();
+        stream << "if not ("
+               << RemoveOutermostParentheses(PrintExpr_(condition.value()))
+               << "):\n";
+        thread_return_guard_scopes.push_back(BeginScope());
+      }
+      continue;
+    }
+    if (IsThreadReturnEvaluate(op->seq[i])) {
+      break;
+    }
+
     break_emitted_in_seq_ = false;
     PrintStmt_(op->seq[i]);
-    if (break_emitted_in_seq_ && guard_scope < 0 && i + 1 < op->seq.size()) {
+    if (in_break_loop_ && break_emitted_in_seq_ && guard_scope < 0 &&
+        i + 1 < op->seq.size()) {
       // Insert guard for remaining statements
       PrintIndent();
       stream << "if _loop_break_" << current_break_id_ << " == 0:\n";
@@ -1993,6 +2504,10 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const SeqStmtNode *op) {
   }
   if (guard_scope >= 0) {
     EndScope(guard_scope);
+  }
+  for (auto it = thread_return_guard_scopes.rbegin();
+       it != thread_return_guard_scopes.rend(); ++it) {
+    EndScope(*it);
   }
 }
 
@@ -2029,12 +2544,19 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const EvaluateNode *op) {
   if (call && (call->op.same_as(tvm::tl::device_assert()))) {
     std::string cond = RemoveOutermostParentheses(PrintExpr_(call->args[0]));
     PrintIndent();
-    stream << "assert " << cond << "\n";
+    stream << "tl.runtime_assert(" << cond << ")\n";
   } else if (call && call->op.same_as(tvm::tl::device_assert_with_msg())) {
     std::string cond = RemoveOutermostParentheses(PrintExpr_(call->args[0]));
     std::string msg_expr = PrintExpr_(call->args[1]);
     PrintIndent();
-    stream << "assert " << cond << ", " << msg_expr << "\n";
+    stream << "tl.runtime_assert(" << cond << ", " << msg_expr << ")\n";
+  } else if (call && call->op.same_as(tvm::tl::sync_warp())) {
+    PrintIndent();
+    stream << "tl.sync_warp(";
+    if (!call->args.empty()) {
+      stream << PrintExpr_(call->args[0]);
+    }
+    stream << ")\n";
   } else if (call && call->op.same_as(builtin::tvm_storage_sync())) {
     PrintStorageSync_(call);
   } else {
@@ -2283,15 +2805,20 @@ std::string CodeGenTileLangCuTeDSL::GetBufferPtr_(const BufferNode *buffer,
   const std::string vid = GetVarID(buffer_var);
 
   DataType buffer_element_dtype = buffer->dtype;
+  std::string scope;
+  if (alloc_storage_scope_.count(buffer_var)) {
+    scope = alloc_storage_scope_.at(buffer_var);
+  }
+  if (scope.empty())
+    scope = GetPtrStorageScope(buffer->data);
+  const bool scalarized_local_vector_buffer =
+      (scope == "local" || scope == "shared") &&
+      buffer_element_dtype.is_fixed_length_vector();
   // CuTeDSL only supports i1 (Boolean) in rmem; use Uint8 for gmem pointers.
-  DataType effective_dtype = buffer_element_dtype;
+  DataType effective_dtype = scalarized_local_vector_buffer
+                                 ? buffer_element_dtype.element_of()
+                                 : buffer_element_dtype;
   if (buffer_element_dtype.is_bool()) {
-    std::string scope;
-    if (alloc_storage_scope_.count(buffer_var)) {
-      scope = alloc_storage_scope_.at(buffer_var);
-    }
-    if (scope.empty())
-      scope = GetPtrStorageScope(buffer->data);
     if (scope != "local" && scope != "local.var") {
       effective_dtype = DataType::UInt(8);
     }
@@ -2299,12 +2826,6 @@ std::string CodeGenTileLangCuTeDSL::GetBufferPtr_(const BufferNode *buffer,
   // shared.barrier and shared.cluster_barrier are allocated via tl.alloc_smem()
   // which returns _Pointer (not _Tensor), so it doesn't have .iterator — use
   // vid directly.
-  std::string scope;
-  if (alloc_storage_scope_.count(buffer_var)) {
-    scope = alloc_storage_scope_.at(buffer_var);
-  }
-  if (scope.empty())
-    scope = GetPtrStorageScope(buffer->data);
 
   std::string ptr_str;
   if (raw_pointer_vars_.count(buffer_var)) {
@@ -2328,6 +2849,10 @@ std::string CodeGenTileLangCuTeDSL::GetBufferPtr_(const BufferNode *buffer,
   }
 
   std::string index_str = PrintExpr_(index);
+  if (scalarized_local_vector_buffer) {
+    index_str = "(" + index_str + " * " +
+                std::to_string(buffer_element_dtype.lanes()) + ")";
+  }
   return "(" + ptr_str + " + " + index_str + ")";
 }
 
@@ -2369,9 +2894,14 @@ std::string CodeGenTileLangCuTeDSL::GetBufferRef_(DataType t,
   }
 
   DataType buffer_element_dtype = buffer->dtype;
+  const bool scalarized_local_vector_buffer =
+      (scope == "local" || scope == "shared") &&
+      buffer_element_dtype.is_fixed_length_vector();
   // CuTeDSL only supports i1 (Boolean) in rmem. For gmem/shared bool buffers,
   // use Uint8 instead (matches PyTorch's torch.bool memory layout).
-  DataType effective_dtype = buffer_element_dtype;
+  DataType effective_dtype = scalarized_local_vector_buffer
+                                 ? buffer_element_dtype.element_of()
+                                 : buffer_element_dtype;
   if (buffer_element_dtype.is_bool() && scope != "local" &&
       scope != "local.var") {
     effective_dtype = DataType::UInt(8);
@@ -2409,6 +2939,11 @@ std::string CodeGenTileLangCuTeDSL::GetBufferRef_(DataType t,
     }
   }
   const std::string index_str = PrintExpr_(offset_expr);
+  const std::string scalarized_index_str =
+      scalarized_local_vector_buffer
+          ? "(" + index_str + " * " +
+                std::to_string(buffer_element_dtype.lanes()) + ")"
+          : index_str;
 
   if (t == buffer_element_dtype) {
     if (scope == "shared.barrier" || scope == "shared.cluster_barrier") {
@@ -2417,6 +2952,12 @@ std::string CodeGenTileLangCuTeDSL::GetBufferRef_(DataType t,
       // subscript access [i], but supports pointer arithmetic (ptr + i). Use
       // pointer addition instead of subscript.
       return "(" + vid + " + " + index_str + ")";
+    } else if (scalarized_local_vector_buffer) {
+      std::ostringstream os;
+      os << "tl.make_tensor_at_offset(" << vid << ".iterator, "
+         << scalarized_index_str << ", (" << buffer_element_dtype.lanes()
+         << ",), div_by=" << buffer_element_dtype.lanes() << ")";
+      return os.str();
     } else if (is_handle_type_match && buffer_element_dtype.is_scalar() &&
                (scope == "local" || scope == "shared")) {
       // Tensors in these scopes are allocated as one-dimensional, so can be
@@ -2437,15 +2978,23 @@ std::string CodeGenTileLangCuTeDSL::GetBufferRef_(DataType t,
       }
       return os.str();
     }
+  } else if (scalarized_local_vector_buffer &&
+             t == buffer_element_dtype.element_of()) {
+    return vid + "[" + index_str + "]";
   } else {
     const int num = t.bits() * t.lanes();
-    const int den = buffer_element_dtype.bits() * buffer_element_dtype.lanes();
+    DataType storage_element_dtype = scalarized_local_vector_buffer
+                                         ? buffer_element_dtype.element_of()
+                                         : buffer_element_dtype;
+    const int den =
+        storage_element_dtype.bits() * storage_element_dtype.lanes();
     ICHECK_EQ(num % den, 0) << "Cannot form view: bitwidth not divisible";
     int buffer_size = num / den;
 
     std::ostringstream os;
-    os << "tl.make_tensor_at_offset(" << ptr_str << ", " << index_str << ", ("
-       << buffer_size << ",), div_by=" << buffer_size << ")";
+    os << "tl.make_tensor_at_offset(" << ptr_str << ", "
+       << (scalarized_local_vector_buffer ? scalarized_index_str : index_str)
+       << ", (" << buffer_size << ",), div_by=" << buffer_size << ")";
     return os.str();
   }
 }

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -477,6 +477,30 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CastNode *op,
   const bool from_is_fp8_narrowing_source = from_ty == DataType::Float(16) ||
                                             from_ty == DataType::Float(32) ||
                                             from_ty.is_bfloat16();
+  if (from_ty.is_scalar() && target_ty.is_scalar() &&
+      (from_ty.is_int() || from_ty.is_uint()) &&
+      (target_ty.is_int() || target_ty.is_uint()) &&
+      target_ty.bits() > from_ty.bits()) {
+    if (const CallNode *call = op->value.as<CallNode>();
+        call && (call->op.same_as(builtin::shift_left()) ||
+                 call->op.same_as(builtin::shift_right()))) {
+      ICHECK_EQ(call->args.size(), 2U);
+      const DataType lhs_ty = call->args[0].dtype();
+      if ((lhs_ty.is_int() || lhs_ty.is_uint()) &&
+          lhs_ty.bits() < target_ty.bits()) {
+        const std::string lhs = PrintExpr_(call->args[0]);
+        const std::string rhs = PrintExpr_(call->args[1]);
+        PrintType(target_ty, os);
+        os << "((";
+        PrintType(target_ty, os);
+        os << "(" << lhs << ") "
+           << (call->op.same_as(builtin::shift_left()) ? "<<" : ">>") << " "
+           << rhs << "))";
+        return;
+      }
+    }
+  }
+
   if (from_ty.is_scalar() && from_is_cutedsl_fp8 && target_is_fp8_widening) {
     // CuTeDSL/NVGPU widens FP8 through nvgpu.cvt_fpext, whose operand must be
     // a 32-bit aligned vector.  Pack the scalar into a four-lane FP8 vector,

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -1325,8 +1325,9 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
         scope = GetPtrStorageScope(load->buffer->data);
       }
       if (scope == "local.var") {
-        std::string expr_str =
-            GetBufferRef_(src_dtype, load->buffer.get(), load->indices[0]);
+        std::string expr_str = GetBufferRef_(
+            src_dtype, load->buffer.get(),
+            LinearizeBufferIndices_(load->buffer.get(), load->indices));
         os << "tl.bitcast(" << expr_str << ", ";
         PrintType(tgt_dtype.element_of(), os);
         os << ")";
@@ -1334,15 +1335,18 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
       }
 
       // Path 1: BufferLoad - use recast_ptr for memory access
-      ICHECK_EQ(load->indices.size(), 1)
-          << "CodeGenTileLangCuTeDSL only supports flat memory";
-
-      PrimExpr index = load->indices[0];
+      PrimExpr index =
+          LinearizeBufferIndices_(load->buffer.get(), load->indices);
       if (const RampNode *node = index.as<RampNode>(); node) {
         auto *p_stride = as_const_int(node->stride);
         ICHECK(p_stride);
         ICHECK_EQ(*p_stride, 1) << "reinterpret expects contiguous elements";
         index = node->base;
+      } else {
+        arith::PVar<PrimExpr> ramp_base;
+        if (arith::ramp(ramp_base, 1, tgt_dtype.lanes()).Match(index)) {
+          index = ramp_base.Eval();
+        }
       }
 
       auto ptr_str = GetBufferPtr_(load->buffer.get(), index);
@@ -1397,6 +1401,11 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
     os << "tl.__shfl_up_sync(" << PrintExpr_(op->args[0]) << ", "
        << PrintExpr_(op->args[1]) << ", " << PrintExpr_(op->args[2]) << ", "
        << PrintExpr_(op->args[3]) << ")";
+  } else if (op->op.same_as(tl::match_any_sync())) {
+    ICHECK_EQ(op->args.size(), 2U)
+        << "tl.match_any_sync expects <mask, value>.";
+    os << "tl.__match_any_sync(" << PrintExpr_(op->args[0]) << ", "
+       << PrintExpr_(op->args[1]) << ")";
   } else if (op->op.same_as(tl::get_lane_idx())) {
     // get_lane_idx(warp_size?) -> threadIdx.x % warp_size
     ICHECK_LE(op->args.size(), 1U)
@@ -1548,9 +1557,9 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
   } else if (op->op.same_as(builtin::address_of())) {
     const BufferLoadNode *load = op->args[0].as<BufferLoadNode>();
     ICHECK(op->args.size() == 1 && load);
-    ICHECK_EQ(load->indices.size(), 1)
-        << "CodeGenTileLangCuTeDSL only supports flat memory";
-    os << GetBufferPtr_(load->buffer.get(), load->indices[0]);
+    os << GetBufferPtr_(
+        load->buffer.get(),
+        LinearizeBufferIndices_(load->buffer.get(), load->indices));
   } else if (op->op.same_as(builtin::handle_add_byte_offset())) {
     ICHECK_EQ(op->args.size(), 2U);
     os << "tl.handle_add_byte_offset(" << PrintExpr_(op->args[0]) << ", "
@@ -1739,13 +1748,13 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const ShuffleNode *op,
 
 void CodeGenTileLangCuTeDSL::VisitExpr_(const BufferLoadNode *op,
                                         std::ostream &os) { // NOLINT(*)
-  ICHECK_EQ(op->indices.size(), 1)
-      << "Load from non-flat memory not supported.";
+  ICHECK_GE(op->indices.size(), 1U)
+      << "Buffer load must have at least one index.";
   ICHECK(!op->predicate.defined())
       << "Predicated buffer load is not supported.";
 
   DataType value_dtype = op->dtype;
-  PrimExpr index = op->indices[0];
+  PrimExpr index = LinearizeBufferIndices_(op->buffer.get(), op->indices);
   Var buffer_var = op->buffer->data;
   DataType element_dtype = op->buffer->dtype;
 
@@ -1946,13 +1955,14 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const BufferLoadNode *op,
 }
 
 void CodeGenTileLangCuTeDSL::VisitStmt_(const BufferStoreNode *op) {
-  ICHECK_EQ(op->indices.size(), 1) << "Store to non-flat memory not supported.";
+  ICHECK_GE(op->indices.size(), 1U)
+      << "Buffer store must have at least one index.";
   ICHECK(!op->predicate.defined())
       << "Predicated buffer store is not supported.";
 
   DataType value_dtype = op->value.dtype();
   DataType element_dtype = op->buffer->dtype;
-  PrimExpr index_expr = op->indices[0];
+  PrimExpr index_expr = LinearizeBufferIndices_(op->buffer.get(), op->indices);
   Var buffer_var = op->buffer->data;
 
   // Pre-compute Select/if_then_else as tl.where() at statement level.
@@ -2579,7 +2589,9 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const AllocBufferNode *op) {
 void CodeGenTileLangCuTeDSL::VisitStmt_(const AttrStmtNode *op) {
   if (op->attr_key == tirx::attr::thread_extent) {
     IterVar iv = Downcast<IterVar>(op->node);
-    if (!iv->thread_tag.empty()) {
+    const std::string thread_tag =
+        !iv->thread_tag.empty() ? iv->thread_tag : iv->var->name_hint;
+    if (!thread_tag.empty()) {
       if (!var_idmap_.count(iv->var.get())) {
         BindThreadIndex_(iv);
       }
@@ -2977,9 +2989,9 @@ void CodeGenTileLangCuTeDSL::PrintCallExtern_(Type ret_type,
     global_symbol_str = "tl." + global_symbol_str;
     // Convert first argument (Buffer) to pointer for atomic operations
     if (const BufferLoadNode *load = args[arg_begin].as<BufferLoadNode>()) {
-      ICHECK_EQ(load->indices.size(), 1)
-          << "CodeGenTileLangCuTeDSL only supports flat memory";
-      sargs[0] = GetBufferPtr_(load->buffer.get(), load->indices[0]);
+      sargs[0] = GetBufferPtr_(
+          load->buffer.get(),
+          LinearizeBufferIndices_(load->buffer.get(), load->indices));
     }
   }
   // Quantization Functions (decode_i4u_to_f16, decode_i4s_to_f16, etc.)
@@ -3054,6 +3066,43 @@ void CodeGenTileLangCuTeDSL::PrintCallExtern_(Type ret_type,
     }
     os << ")";
   }
+}
+
+PrimExpr CodeGenTileLangCuTeDSL::LinearizeBufferIndices_(
+    const BufferNode *buffer, const ffi::Array<PrimExpr> &indices) {
+  ICHECK_GE(indices.size(), 1U)
+      << "Buffer access must have at least one index.";
+  if (indices.size() == 1) {
+    return indices[0];
+  }
+
+  ICHECK_EQ(indices.size(), buffer->shape.size())
+      << "Buffer access rank " << indices.size()
+      << " does not match buffer rank " << buffer->shape.size() << " for "
+      << buffer->name;
+
+  DataType index_dtype = buffer->DefaultIndexType();
+  auto cast_index = [index_dtype](const PrimExpr &expr) -> PrimExpr {
+    return expr.dtype() == index_dtype ? expr : tirx::Cast(index_dtype, expr);
+  };
+
+  PrimExpr offset = tirx::make_const(index_dtype, 0);
+  if (!buffer->strides.empty()) {
+    ICHECK_EQ(buffer->strides.size(), indices.size())
+        << "Buffer stride rank " << buffer->strides.size()
+        << " does not match index rank " << indices.size() << " for "
+        << buffer->name;
+    for (size_t i = 0; i < indices.size(); ++i) {
+      offset = offset + cast_index(indices[i]) * cast_index(buffer->strides[i]);
+    }
+  } else {
+    PrimExpr stride = tirx::make_const(index_dtype, 1);
+    for (int i = static_cast<int>(indices.size()) - 1; i >= 0; --i) {
+      offset = offset + cast_index(indices[i]) * stride;
+      stride = stride * cast_index(buffer->shape[i]);
+    }
+  }
+  return arith::Analyzer().Simplify(offset);
 }
 
 std::string CodeGenTileLangCuTeDSL::GetBufferPtr_(const BufferNode *buffer,
@@ -3264,7 +3313,8 @@ std::string CodeGenTileLangCuTeDSL::GetBufferRef_(DataType t,
 void CodeGenTileLangCuTeDSL::BindThreadIndex_(const IterVar &iv) {
   ICHECK(!var_idmap_.count(iv->var.get()));
 
-  auto &thread_tag = iv->thread_tag;
+  const std::string thread_tag =
+      !iv->thread_tag.empty() ? iv->thread_tag : iv->var->name_hint;
   ICHECK(thread_tag == "threadIdx.x" || thread_tag == "threadIdx.y" ||
          thread_tag == "threadIdx.z" || thread_tag == "blockIdx.x" ||
          thread_tag == "blockIdx.y" || thread_tag == "blockIdx.z");

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -185,6 +185,8 @@ std::string CodeGenTileLangCuTeDSL::CanonicalizeFastmathFunctionName_(
       {"exp2f", "tl.exp2"},
       {"log", "tl.log"},
       {"logf", "tl.log"},
+      {"log1p", "tl.log1p"},
+      {"log1pf", "tl.log1p"},
       {"log2", "tl.log2"},
       {"log2f", "tl.log2"},
       {"log10", "tl.log10"},
@@ -201,6 +203,7 @@ std::string CodeGenTileLangCuTeDSL::CanonicalizeFastmathFunctionName_(
       {"fabsf", "tl.fabsf"},
       {"copysign", "tl.copysignf"},
       {"copysignf", "tl.copysignf"},
+      {"isfinite", "tl.isfinite"},
   };
 
   auto it = kFastMathMap.find(func_name);
@@ -316,26 +319,48 @@ static bool IsZeroLike(const PrimExpr &expr) {
   return false;
 }
 
-static bool IsZeroTensorLike(const PrimExpr &expr) {
+static bool EndsWithLoad(const std::string &s) {
+  return s.size() >= 7 && s.compare(s.size() - 7, 7, ".load()") == 0;
+}
+
+static bool IsZeroTensorLike(
+    const PrimExpr &expr,
+    const std::unordered_set<const VarNode *> *zero_like_vars = nullptr) {
   PrimExpr value = expr;
-  if (const CastNode *cast = value.as<CastNode>()) {
-    value = cast->value;
+  while (true) {
+    if (const CastNode *cast = value.as<CastNode>()) {
+      value = cast->value;
+      continue;
+    }
+    if (const BroadcastNode *broadcast = value.as<BroadcastNode>()) {
+      value = broadcast->value;
+      continue;
+    }
+    break;
   }
-  if (const BroadcastNode *broadcast = value.as<BroadcastNode>()) {
-    return IsZeroLike(broadcast->value);
+  if (const VarNode *var = value.as<VarNode>()) {
+    return zero_like_vars != nullptr && zero_like_vars->count(var);
   }
   return IsZeroLike(value);
+}
+
+class BufferLoadDetector : public tirx::StmtExprVisitor {
+public:
+  bool found = false;
+
+  void VisitExpr_(const BufferLoadNode *op) override { found = true; }
+};
+
+static bool ContainsBufferLoad(const PrimExpr &expr) {
+  BufferLoadDetector det;
+  det(expr);
+  return det.found;
 }
 
 void CodeGenTileLangCuTeDSL::VisitExpr_(const BroadcastNode *op,
                                         std::ostream &os) { // NOLINT(*)
   if (op->dtype.is_float4_e2m1fn()) {
-    bool is_zero = IsZeroLike(op->value);
-    if (!is_zero) {
-      if (const VarNode *var = op->value.as<VarNode>()) {
-        is_zero = zero_like_vars_.count(var);
-      }
-    }
+    bool is_zero = IsZeroTensorLike(op->value, &zero_like_vars_);
     ICHECK(is_zero)
         << "CuTeDSL cannot materialize scalar Float4E2M1FN values; only zero "
            "broadcast is supported via packed storage";
@@ -425,6 +450,84 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CastNode *op,
   DataType target_ty = op->dtype;
   ICHECK_EQ(target_ty.lanes(), from_ty.lanes());
 
+  const bool from_is_cutedsl_fp8 = from_ty.is_float8_e4m3() ||
+                                   from_ty.is_float8_e4m3fn() ||
+                                   from_ty.is_float8_e5m2();
+  const bool target_is_fp8_widening = target_ty == DataType::Float(16) ||
+                                      target_ty == DataType::Float(32) ||
+                                      target_ty.is_bfloat16();
+  const bool target_is_cutedsl_fp8 = target_ty.is_float8_e4m3() ||
+                                     target_ty.is_float8_e4m3fn() ||
+                                     target_ty.is_float8_e5m2();
+  const bool from_is_fp8_narrowing_source = from_ty == DataType::Float(16) ||
+                                            from_ty == DataType::Float(32) ||
+                                            from_ty.is_bfloat16();
+  if (from_ty.is_scalar() && from_is_cutedsl_fp8 && target_is_fp8_widening) {
+    // CuTeDSL/NVGPU widens FP8 through nvgpu.cvt_fpext, whose operand must be
+    // a 32-bit aligned vector.  Pack the scalar into a four-lane FP8 vector,
+    // reuse the tensor cast path, then read back lane zero.
+    std::string src = SSAGetID(PrintExpr_(op->value), from_ty);
+    std::string src_vec = name_supply_->FreshName("_scalar_fp8_src");
+    PrintIndent();
+    stream << src_vec << " = tl.make_rmem_tensor((4,), ";
+    PrintType(from_ty, stream);
+    stream << ")\n";
+    PrintIndent();
+    stream << src_vec << "[0] = " << src << "\n";
+    for (int i = 1; i < 4; ++i) {
+      PrintIndent();
+      stream << src_vec << "[" << i << "] = ";
+      PrintType(from_ty, stream);
+      stream << "(0)\n";
+    }
+
+    std::string f16_vec = name_supply_->FreshName("_scalar_fp8_f16");
+    PrintIndent();
+    stream << f16_vec << " = tl.make_rmem_tensor((4,), cutlass.Float16)\n";
+    PrintIndent();
+    stream << f16_vec << ".store(tl.cast_tensor(" << src_vec
+           << ".load(), cutlass.Float16))\n";
+    if (target_ty == DataType::Float(16)) {
+      os << f16_vec << "[0]";
+    } else {
+      PrintType(target_ty, os);
+      os << "(" << f16_vec << "[0])";
+    }
+    return;
+  }
+
+  if (from_ty.is_scalar() && target_is_cutedsl_fp8 &&
+      from_is_fp8_narrowing_source) {
+    // CuTeDSL lowers FP8 narrowing through vector tensor casts.  Pack a scalar
+    // source into an aligned four-lane tensor, cast it, then extract lane zero.
+    std::string src = SSAGetID(PrintExpr_(op->value), from_ty);
+    std::string src_vec = name_supply_->FreshName("_scalar_fp8_src");
+    PrintIndent();
+    stream << src_vec << " = tl.make_rmem_tensor((4,), ";
+    PrintType(from_ty, stream);
+    stream << ")\n";
+    PrintIndent();
+    stream << src_vec << "[0] = " << src << "\n";
+    for (int i = 1; i < 4; ++i) {
+      PrintIndent();
+      stream << src_vec << "[" << i << "] = ";
+      PrintType(from_ty, stream);
+      stream << "(0)\n";
+    }
+
+    std::string dst_vec = name_supply_->FreshName("_scalar_fp8_dst");
+    PrintIndent();
+    stream << dst_vec << " = tl.make_rmem_tensor((4,), ";
+    PrintType(target_ty, stream);
+    stream << ")\n";
+    PrintIndent();
+    stream << dst_vec << ".store(tl.cast_tensor(" << src_vec << ".load(), ";
+    PrintType(target_ty, stream);
+    stream << "))\n";
+    os << dst_vec << "[0]";
+    return;
+  }
+
   if (from_ty.is_scalar())
     return CodeGenTileLangPY::VisitExpr_(op, os);
 
@@ -453,7 +556,8 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CastNode *op,
     PrintType(target_ty.element_of(), stream);
     stream << ")\n";
     PrintIndent();
-    stream << aligned_dst << ".store(tl.cast_tensor(" << src << ".load(), ";
+    stream << aligned_dst << ".store(tl.cast_tensor(tl.as_tensor_ssa(" << src
+           << "), ";
     PrintType(target_ty.element_of(), stream);
     stream << "))\n";
 
@@ -1572,9 +1676,16 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const LetNode *op,
                                         std::ostream &os) { // NOLINT(*)
   std::string value = PrintExpr_(op->value);
   ICHECK(!var_idmap_.count(op->var.get()));
+  const bool is_zero_like = IsZeroTensorLike(op->value, &zero_like_vars_);
   PrintIndent();
   stream << AllocVarID(op->var.get()) << " = " << value << "\n";
+  if (is_zero_like) {
+    zero_like_vars_.insert(op->var.get());
+  }
   os << PrintExpr_(op->body);
+  if (is_zero_like) {
+    zero_like_vars_.erase(op->var.get());
+  }
   bool removed = var_idmap_.erase(op->var.get());
   ICHECK(removed);
 }
@@ -1885,10 +1996,110 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const BufferStoreNode *op) {
       lanes = 1;
     DataType conditional_dtype =
         cast_to_dtype.bits() > 0 ? cast_to_dtype : value_dtype;
+    int conditional_lanes = conditional_dtype.lanes();
+    if (conditional_lanes == 0)
+      conditional_lanes = 1;
+    const bool true_is_zero_ast = IsZeroTensorLike(true_expr, &zero_like_vars_);
+    const bool false_is_zero_ast =
+        IsZeroTensorLike(false_expr, &zero_like_vars_);
+    const bool true_has_buffer_load = ContainsBufferLoad(true_expr);
+    const bool false_has_buffer_load = ContainsBufferLoad(false_expr);
     const bool is_subbyte_vector_conditional =
         conditional_dtype.element_of().bits() < 8 &&
         conditional_dtype.lanes() > 1;
-    if (is_subbyte_vector_conditional) {
+    if ((true_is_zero_ast && false_has_buffer_load) ||
+        (false_is_zero_ast && true_has_buffer_load)) {
+      const bool data_is_true_branch = false_is_zero_ast;
+      PrimExpr data_expr = data_is_true_branch ? true_expr : false_expr;
+      DataType elem_dtype = conditional_dtype.element_of();
+
+      std::string result_tensor = name_supply_->FreshName("_if_tensor");
+      PrintIndent();
+      stream << result_tensor << " = tl.make_rmem_tensor((" << conditional_lanes
+             << ",), " << DTypeToString(elem_dtype) << ")\n";
+
+      if (elem_dtype.bits() < 8 && conditional_lanes > 1) {
+        const int packed_bits = conditional_lanes * elem_dtype.bits();
+        ICHECK_EQ(packed_bits % 8, 0)
+            << "Sub-byte conditional vectors must cover whole bytes";
+        const int packed_bytes = packed_bits / 8;
+        std::string result_bytes = name_supply_->FreshName("_if_dst");
+        PrintIndent();
+        stream << result_bytes << " = cute.recast_tensor(" << result_tensor
+               << ", cutlass.Uint8)\n";
+        for (int i = 0; i < packed_bytes; ++i) {
+          PrintIndent();
+          stream << result_bytes << "[" << i << "] = cutlass.Uint8(0)\n";
+        }
+      } else {
+        for (int i = 0; i < conditional_lanes; ++i) {
+          PrintIndent();
+          stream << result_tensor << "[" << i << "] = ";
+          if (elem_dtype.is_bool()) {
+            stream << "False\n";
+          } else {
+            stream << DTypeToString(elem_dtype) << "(0)\n";
+          }
+        }
+      }
+
+      std::string cond = PrintExpr_(cond_expr);
+      PrintIndent();
+      if (data_is_true_branch) {
+        stream << "if " << cond << ":\n";
+      } else {
+        stream << "if not (" << cond << "):\n";
+      }
+      int scope = BeginScope();
+      DataType data_dtype = data_expr.dtype();
+      std::string data;
+      if (cast_to_dtype.bits() > 0 && data_dtype != conditional_dtype) {
+        if (conditional_dtype.is_scalar()) {
+          data = PrintExpr_(tirx::Cast(conditional_dtype, data_expr));
+        } else {
+          data = PrintExpr_(data_expr);
+          data = "tl.as_tensor_ssa(" + data + ").to(" +
+                 DTypeToString(elem_dtype) + ")";
+        }
+      } else {
+        data = PrintExpr_(data_expr);
+      }
+
+      if (elem_dtype.bits() < 8 && conditional_lanes > 1) {
+        const int packed_bits = conditional_lanes * elem_dtype.bits();
+        ICHECK_EQ(packed_bits % 8, 0)
+            << "Sub-byte conditional vectors must cover whole bytes";
+        const int packed_bytes = packed_bits / 8;
+        std::string data_tensor = name_supply_->FreshName("_if_src_tensor");
+        PrintIndent();
+        stream << data_tensor << " = tl.as_rmem_tensor(" << data << ", ("
+               << conditional_lanes << ",), " << DTypeToString(elem_dtype)
+               << ")\n";
+
+        std::string src_bytes = name_supply_->FreshName("_if_src");
+        std::string dst_bytes = name_supply_->FreshName("_if_dst");
+        PrintIndent();
+        stream << src_bytes << " = cute.recast_tensor(" << data_tensor
+               << ", cutlass.Uint8)\n";
+        PrintIndent();
+        stream << dst_bytes << " = cute.recast_tensor(" << result_tensor
+               << ", cutlass.Uint8)\n";
+        for (int i = 0; i < packed_bytes; ++i) {
+          PrintIndent();
+          stream << dst_bytes << "[" << i << "] = " << src_bytes << "[" << i
+                 << "]\n";
+        }
+      } else if (conditional_lanes == 1) {
+        PrintIndent();
+        stream << result_tensor << "[0] = " << data << "\n";
+      } else {
+        PrintIndent();
+        stream << result_tensor << ".store(tl.as_tensor_ssa(" << data << "))\n";
+      }
+      EndScope(scope);
+
+      value_str = result_tensor;
+    } else if (is_subbyte_vector_conditional) {
       std::string cond = PrintExpr_(cond_expr);
       std::string true_data = PrintExpr_(true_expr);
       std::string false_data = PrintExpr_(false_expr);
@@ -1897,27 +2108,32 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const BufferStoreNode *op) {
                s.find(", 0, dtype=") != std::string::npos;
       };
       const bool true_is_zero =
-          IsZeroTensorLike(true_expr) || is_zero_tensor_string(true_data);
+          true_is_zero_ast || is_zero_tensor_string(true_data);
       const bool false_is_zero =
-          IsZeroTensorLike(false_expr) || is_zero_tensor_string(false_data);
+          false_is_zero_ast || is_zero_tensor_string(false_data);
       ICHECK(true_is_zero || false_is_zero)
           << "Sub-byte conditional vectors currently require one zero branch";
       std::string data = true_is_zero ? false_data : true_data;
-      const int packed_bits =
-          conditional_dtype.lanes() * conditional_dtype.element_of().bits();
+      const DataType elem_dtype = conditional_dtype.element_of();
+      const int packed_bits = conditional_dtype.lanes() * elem_dtype.bits();
       ICHECK_EQ(packed_bits % 8, 0)
           << "Sub-byte conditional vectors must cover whole bytes";
       const int packed_bytes = packed_bits / 8;
 
       std::string result_tensor = name_supply_->FreshName("_where_tensor");
+      std::string data_tensor = name_supply_->FreshName("_where_data");
       std::string data_bytes = name_supply_->FreshName("_where_src");
       std::string result_bytes = name_supply_->FreshName("_where_dst");
       PrintIndent();
       stream << result_tensor << " = tl.make_rmem_tensor(("
-             << conditional_dtype.lanes() << ",), "
-             << DTypeToString(conditional_dtype.element_of()) << ")\n";
+             << conditional_dtype.lanes() << ",), " << DTypeToString(elem_dtype)
+             << ")\n";
       PrintIndent();
-      stream << data_bytes << " = cute.recast_tensor(" << data
+      stream << data_tensor << " = tl.as_rmem_tensor(" << data << ", ("
+             << conditional_dtype.lanes() << ",), " << DTypeToString(elem_dtype)
+             << ")\n";
+      PrintIndent();
+      stream << data_bytes << " = cute.recast_tensor(" << data_tensor
              << ", cutlass.Uint8)\n";
       PrintIndent();
       stream << result_bytes << " = cute.recast_tensor(" << result_tensor
@@ -1941,7 +2157,7 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const BufferStoreNode *op) {
         std::string s = PrintExpr_(e);
         if (n == 0)
           n = 1;
-        if (s.size() >= 7 && s.compare(s.size() - 7, 7, ".load()") == 0)
+        if (EndsWithLoad(s))
           return s;
         std::string var = name_supply_->FreshName("_tsa");
         PrintIndent();
@@ -2177,9 +2393,9 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const BufferStoreNode *op) {
     }
   } else if (value_lanes == element_dtype.lanes()) {
     std::string ref = GetBufferRef_(value_dtype, op->buffer.get(), index_expr);
-    PrintIndent();
 
     if (ref.back() != ')') {
+      PrintIndent();
       // Direct element assignment (e.g. vid[i] = value).
       // For conditionals (pre-computed as tl.where), extract scalar via [0].
       if (value_is_conditional && value_lanes == 1) {
@@ -2193,13 +2409,29 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const BufferStoreNode *op) {
       // (TensorSSA) at the top. For other scalar expressions, wrap in
       // make_filled_tensor.
       std::string store_rhs = value_str;
-      if (!value_is_conditional && value_lanes == 1 &&
-          !op->value.as<BufferLoadNode>()) {
+      if (!value_is_conditional && value_lanes > 1 &&
+          !op->value.as<BufferLoadNode>() &&
+          (store_rhs.size() < 7 ||
+           store_rhs.compare(store_rhs.size() - 7, 7, ".load()") != 0)) {
+        std::string store_tensor = name_supply_->FreshName("_store_tensor");
+        PrintIndent();
+        stream << store_tensor << " = tl.make_rmem_tensor((" << value_lanes
+               << ",), " << DTypeToString(value_dtype.element_of()) << ")\n";
+        for (int i = 0; i < value_lanes; ++i) {
+          PrintIndent();
+          stream << store_tensor << "[" << i << "] = ";
+          PrintVecElemLoad_(store_rhs, value_dtype, i, stream);
+          stream << "\n";
+        }
+        store_rhs = store_tensor + ".load()";
+      } else if (!value_is_conditional && value_lanes == 1 &&
+                 !op->value.as<BufferLoadNode>()) {
         if (store_rhs.size() < 7 ||
             store_rhs.compare(store_rhs.size() - 7, 7, ".load()") != 0) {
           store_rhs = "tl.make_filled_tensor((1,), " + store_rhs + ").load()";
         }
       }
+      PrintIndent();
       stream << ref << ".store(" << RemoveOutermostParentheses(store_rhs)
              << ")\n";
     }
@@ -2265,7 +2497,7 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const BindNode *op) {
     }
   }
 
-  if (IsZeroLike(op->value)) {
+  if (IsZeroTensorLike(op->value, &zero_like_vars_)) {
     zero_like_vars_.insert(op->var.get());
   }
   CodeGenTileLangPY::VisitStmt_(op);
@@ -2587,8 +2819,33 @@ void CodeGenTileLangCuTeDSL::PrintVecStore_(const BufferNode *buffer,
   ICHECK(!t.is_scalar()) << "PrintVecStore_() should not be used for scalar";
 
   std::string ref = GetBufferRef_(t, buffer, base);
+  std::string store_rhs = value;
+  if (t.element_of().bits() < 8) {
+    if (store_rhs.size() < 7 ||
+        store_rhs.compare(store_rhs.size() - 7, 7, ".load()") != 0) {
+      store_rhs += ".load()";
+    }
+    PrintIndent();
+    stream << ref << ".store(" << store_rhs << ")\n";
+    return;
+  }
+
+  if (store_rhs.size() < 7 ||
+      store_rhs.compare(store_rhs.size() - 7, 7, ".load()") != 0) {
+    std::string store_tensor = name_supply_->FreshName("_store_tensor");
+    PrintIndent();
+    stream << store_tensor << " = tl.make_rmem_tensor((" << t.lanes() << ",), "
+           << DTypeToString(t.element_of()) << ")\n";
+    for (int i = 0; i < t.lanes(); ++i) {
+      PrintIndent();
+      stream << store_tensor << "[" << i << "] = ";
+      PrintVecElemLoad_(store_rhs, t, i, stream);
+      stream << "\n";
+    }
+    store_rhs = store_tensor + ".load()";
+  }
   PrintIndent();
-  stream << ref << ".store(" << value << ")\n";
+  stream << ref << ".store(" << store_rhs << ")\n";
 }
 
 void CodeGenTileLangCuTeDSL::PrintVecBinaryOp_(const std::string &opstr,
@@ -2944,6 +3201,11 @@ std::string CodeGenTileLangCuTeDSL::GetBufferRef_(DataType t,
           ? "(" + index_str + " * " +
                 std::to_string(buffer_element_dtype.lanes()) + ")"
           : index_str;
+  const int scalarized_div_by =
+      scalarized_local_vector_buffer &&
+              buffer_element_dtype.element_of().bits() < 8
+          ? 8 / buffer_element_dtype.element_of().bits()
+          : buffer_element_dtype.lanes();
 
   if (t == buffer_element_dtype) {
     if (scope == "shared.barrier" || scope == "shared.cluster_barrier") {
@@ -2956,7 +3218,7 @@ std::string CodeGenTileLangCuTeDSL::GetBufferRef_(DataType t,
       std::ostringstream os;
       os << "tl.make_tensor_at_offset(" << vid << ".iterator, "
          << scalarized_index_str << ", (" << buffer_element_dtype.lanes()
-         << ",), div_by=" << buffer_element_dtype.lanes() << ")";
+         << ",), div_by=" << scalarized_div_by << ")";
       return os.str();
     } else if (is_handle_type_match && buffer_element_dtype.is_scalar() &&
                (scope == "local" || scope == "shared")) {
@@ -2970,7 +3232,7 @@ std::string CodeGenTileLangCuTeDSL::GetBufferRef_(DataType t,
     } else {
       std::ostringstream os;
       os << "tl.make_tensor_at_offset(" << ptr_str << ", " << index_str
-         << ", (1,), div_by=" << buffer_element_dtype.lanes() << ")";
+         << ", (1,), div_by=" << scalarized_div_by << ")";
       // for vector data types, ".load()" (added by BufferLoadNode) is neeed
       // instead of "[0]"
       if (buffer_element_dtype.is_scalar()) {

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -63,18 +63,33 @@ static bool IsThreadReturnEvaluate(const Stmt &stmt) {
   return call != nullptr && call->op.same_as(builtin::thread_return());
 }
 
-std::optional<PrimExpr> GetConditionalThreadReturnCondition(const Stmt &stmt) {
+struct ConditionalThreadReturn {
+  PrimExpr condition;
+  std::optional<Stmt> pre_return;
+};
+
+std::optional<ConditionalThreadReturn>
+GetConditionalThreadReturn(const Stmt &stmt) {
   const auto *if_node = stmt.as<IfThenElseNode>();
   if (if_node == nullptr || if_node->else_case) {
     return std::nullopt;
   }
   if (IsThreadReturnEvaluate(if_node->then_case)) {
-    return if_node->condition;
+    return ConditionalThreadReturn{if_node->condition, std::nullopt};
   }
   if (const auto *seq = if_node->then_case.as<SeqStmtNode>();
-      seq != nullptr && seq->seq.size() == 1 &&
-      IsThreadReturnEvaluate(seq->seq[0])) {
-    return if_node->condition;
+      seq != nullptr && !seq->seq.empty() &&
+      IsThreadReturnEvaluate(seq->seq[seq->seq.size() - 1])) {
+    if (seq->seq.size() == 1) {
+      return ConditionalThreadReturn{if_node->condition, std::nullopt};
+    }
+    Array<Stmt> pre_return;
+    for (size_t i = 0; i + 1 < seq->seq.size(); ++i) {
+      pre_return.push_back(seq->seq[i]);
+    }
+    Stmt pre_return_stmt =
+        pre_return.size() == 1 ? pre_return[0] : SeqStmt(pre_return);
+    return ConditionalThreadReturn{if_node->condition, pre_return_stmt};
   }
   return std::nullopt;
 }
@@ -2721,11 +2736,22 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const SeqStmtNode *op) {
   // don't execute in the same iteration after the break.
   int guard_scope = -1;
   for (size_t i = 0; i < op->seq.size(); ++i) {
-    if (auto condition = GetConditionalThreadReturnCondition(op->seq[i])) {
+    if (auto guarded_return = GetConditionalThreadReturn(op->seq[i])) {
+      if (guarded_return->pre_return) {
+        PrintIndent();
+        stream << "if "
+               << RemoveOutermostParentheses(
+                      PrintExpr_(guarded_return->condition))
+               << ":\n";
+        int pre_return_scope = BeginScope();
+        PrintStmt_(guarded_return->pre_return.value());
+        EndScope(pre_return_scope);
+      }
       if (i + 1 < op->seq.size()) {
         PrintIndent();
         stream << "if not ("
-               << RemoveOutermostParentheses(PrintExpr_(condition.value()))
+               << RemoveOutermostParentheses(
+                      PrintExpr_(guarded_return->condition))
                << "):\n";
         thread_return_guard_scopes.push_back(BeginScope());
       }
@@ -2871,8 +2897,12 @@ void CodeGenTileLangCuTeDSL::PrintVecBinaryOp_(const std::string &opstr,
   PrintType(dtype.element_of(), stream);
   stream << ")\n";
 
-  std::string vlhs = SSAGetID(PrintExpr_(lhs), lhs.dtype());
-  std::string vrhs = SSAGetID(PrintExpr_(rhs), rhs.dtype());
+  auto print_operand = [this](const PrimExpr &expr) {
+    std::string value = PrintExpr_(expr);
+    return ContainsBufferLoad(expr) ? value : SSAGetID(value, expr.dtype());
+  };
+  std::string vlhs = print_operand(lhs);
+  std::string vrhs = print_operand(rhs);
 
   const std::string one_char_op{"+-*%<>^|&"};
   const std::string two_char_op{"// == != <= >="};

--- a/src/cuda/codegen/codegen_cutedsl.h
+++ b/src/cuda/codegen/codegen_cutedsl.h
@@ -82,6 +82,8 @@ protected:
   std::string GetBufferPtr_(const BufferNode *buffer, PrimExpr index);
   std::string GetBufferRef_(DataType t, const BufferNode *buffer,
                             PrimExpr index) override;
+  PrimExpr LinearizeBufferIndices_(const BufferNode *buffer,
+                                   const ffi::Array<PrimExpr> &indices);
 
   // Get pointer string from a Var expression (local buffer -> vid.iterator)
   std::string GetVarPtr_(const PrimExpr &expr);

--- a/src/cuda/codegen/codegen_cutedsl.h
+++ b/src/cuda/codegen/codegen_cutedsl.h
@@ -44,6 +44,9 @@ protected:
   void VisitExpr_(const MaxNode *op, std::ostream &os) override;    // NOLINT(*)
   void VisitExpr_(const CallNode *op, std::ostream &os) override;   // NOLINT(*)
   void VisitExpr_(const SelectNode *op, std::ostream &os) override; // NOLINT(*)
+  void VisitExpr_(const LetNode *op, std::ostream &os) override;    // NOLINT(*)
+  void VisitExpr_(const ShuffleNode *op,
+                  std::ostream &os) override; // NOLINT(*)
   void VisitExpr_(const BufferLoadNode *op,
                   std::ostream &os) override; // NOLINT(*)
 
@@ -101,6 +104,7 @@ private:
   std::unordered_map<const VarNode *, IntImm> unroll_factor_;
 
   std::unordered_set<const VarNode *> raw_pointer_vars_;
+  std::unordered_set<const VarNode *> zero_like_vars_;
 
   std::vector<std::string> eviction_policy_names_ = {
       "EVICT_NORMAL", "EVICT_FIRST", "EVICT_LAST"};

--- a/testing/python/jit/test_tilelang_jit_cutedsl_host_codegen.py
+++ b/testing/python/jit/test_tilelang_jit_cutedsl_host_codegen.py
@@ -82,6 +82,27 @@ def repeated_dynamic_shape_program():
     return main
 
 
+def optional_stride_symbol_program():
+    """Create a program with an optional strided tensor stride symbol."""
+
+    N = T.dynamic("N")
+    stride = T.dynamic("stride")
+
+    @T.prim_func
+    def main(
+        source: T.Tensor((N,), T.float32),
+        optional: T.StridedTensor[(N,), (stride,), T.float32],
+        out: T.Tensor((N,), T.float32),
+    ):
+        with T.Kernel(T.ceildiv(N, 64), threads=64) as (bx,):
+            for i in T.Parallel(64):
+                idx = bx * 64 + i
+                if idx < N:
+                    out[idx] = source[idx]
+
+    return main
+
+
 def two_kernel_program(N, block_size=64, dtype=T.float32):
     """Create a program with two lowered host kernel call sites."""
 
@@ -244,6 +265,25 @@ def test_cutedsl_adapter_resolves_dynamic_symbol_from_live_tensor_candidate():
     assert len(adapter.dynamic_symbolic_order) == 1
     dynamic_symbol = adapter.dynamic_symbolic_order[0]
     assert adapter._resolve_dynamic_symbolic_value(dynamic_symbol, [None, torch.empty(7), torch.empty(7)]) == 7
+    with pytest.raises(TypeError, match="no live tensor source"):
+        adapter._resolve_dynamic_symbolic_value(dynamic_symbol, [None, None, None])
+
+
+def test_cutedsl_adapter_allows_optional_stride_symbol_without_live_tensor():
+    """Dynamic stride-only symbols may be absent for optional tensor params."""
+
+    from tilelang.jit.adapter.cutedsl.adapter import CuTeDSLKernelAdapter
+
+    program = optional_stride_symbol_program()
+    adapter = CuTeDSLKernelAdapter.__new__(CuTeDSLKernelAdapter)
+    adapter.ir_module = tilelang.tvm.IRModule({program.attrs["global_symbol"]: program})
+    adapter.dynamic_symbolic_map, adapter.dynamic_symbolic_order = adapter._process_dynamic_symbolic()
+
+    dynamic_symbols = {sym.name: sym for sym in adapter.dynamic_symbolic_order}
+    param_values = [torch.empty(7), None, torch.empty(7)]
+
+    assert adapter._resolve_dynamic_symbolic_value(dynamic_symbols["N"], param_values) == 7
+    assert adapter._resolve_dynamic_symbolic_value(dynamic_symbols["stride"], param_values) == 0
 
 
 def test_cutedsl_cache_restore_does_not_fallback_to_host_source(monkeypatch, tmp_path):

--- a/testing/python/jit/test_tilelang_jit_cutedsl_host_codegen.py
+++ b/testing/python/jit/test_tilelang_jit_cutedsl_host_codegen.py
@@ -103,6 +103,28 @@ def optional_stride_symbol_program():
     return main
 
 
+def optional_shape_symbol_program():
+    """Create a program with shape symbols that only belong to optional inputs."""
+
+    N = T.dynamic("N")
+    M = T.dynamic("M")
+
+    @T.prim_func
+    def main(
+        source: T.Tensor((N,), T.float32),
+        optional_a: T.Tensor((M,), T.float32),
+        optional_b: T.Tensor((M,), T.float32),
+        out: T.Tensor((N,), T.float32),
+    ):
+        with T.Kernel(T.ceildiv(N, 64), threads=64) as (bx,):
+            for i in T.Parallel(64):
+                idx = bx * 64 + i
+                if idx < N:
+                    out[idx] = source[idx]
+
+    return main
+
+
 def two_kernel_program(N, block_size=64, dtype=T.float32):
     """Create a program with two lowered host kernel call sites."""
 
@@ -284,6 +306,25 @@ def test_cutedsl_adapter_allows_optional_stride_symbol_without_live_tensor():
 
     assert adapter._resolve_dynamic_symbolic_value(dynamic_symbols["N"], param_values) == 7
     assert adapter._resolve_dynamic_symbolic_value(dynamic_symbols["stride"], param_values) == 0
+
+
+def test_cutedsl_adapter_allows_optional_abi_shape_symbol_without_live_tensor():
+    """Dynamic shape symbols may be absent when only needed as dead ABI args."""
+
+    from tilelang.jit.adapter.cutedsl.adapter import CuTeDSLKernelAdapter
+
+    program = optional_shape_symbol_program()
+    adapter = CuTeDSLKernelAdapter.__new__(CuTeDSLKernelAdapter)
+    adapter.ir_module = tilelang.tvm.IRModule({program.attrs["global_symbol"]: program})
+    adapter.dynamic_symbolic_map, adapter.dynamic_symbolic_order = adapter._process_dynamic_symbolic()
+
+    dynamic_symbols = {sym.name: sym for sym in adapter.dynamic_symbolic_order}
+    param_values = [torch.empty(7), None, None, torch.empty(7)]
+
+    assert adapter._resolve_dynamic_symbolic_value(dynamic_symbols["N"], param_values) == 7
+    with pytest.raises(TypeError, match="no live tensor source"):
+        adapter._resolve_dynamic_symbolic_value(dynamic_symbols["M"], param_values)
+    assert adapter._resolve_dynamic_symbolic_value(dynamic_symbols["M"], param_values, require_live_shape=False) == 0
 
 
 def test_cutedsl_cache_restore_does_not_fallback_to_host_source(monkeypatch, tmp_path):

--- a/testing/python/jit/test_tilelang_jit_cutedsl_host_codegen.py
+++ b/testing/python/jit/test_tilelang_jit_cutedsl_host_codegen.py
@@ -1,6 +1,7 @@
 """Tests for CuTeDSL host codegen integration."""
 
 import pytest
+import torch
 import tilelang
 import tilelang.language as T
 import tilelang.testing
@@ -57,6 +58,26 @@ def single_kernel_program(N, block_size=64, dtype=T.float32):
                 idx = bx * block_size + i
                 if idx < N:
                     B[idx] = A[idx] + 1.0
+
+    return main
+
+
+def repeated_dynamic_shape_program():
+    """Create a program where one dynamic symbol appears in multiple params."""
+
+    N = T.dynamic("N")
+
+    @T.prim_func
+    def main(
+        optional: T.Tensor((N,), T.float32),
+        source: T.Tensor((N,), T.float32),
+        out: T.Tensor((N,), T.float32),
+    ):
+        with T.Kernel(T.ceildiv(N, 64), threads=64) as (bx,):
+            for i in T.Parallel(64):
+                idx = bx * 64 + i
+                if idx < N:
+                    out[idx] = source[idx]
 
     return main
 
@@ -208,6 +229,21 @@ def test_cutedsl_adapter_exposes_device_and_host_sources():
     assert "_generate_cubin_if_needed" in host_source
     assert device_source in combined_source
     assert host_source in combined_source
+
+
+def test_cutedsl_adapter_resolves_dynamic_symbol_from_live_tensor_candidate():
+    """Dynamic shape resolution should skip optional None tensor params."""
+
+    from tilelang.jit.adapter.cutedsl.adapter import CuTeDSLKernelAdapter
+
+    program = repeated_dynamic_shape_program()
+    adapter = CuTeDSLKernelAdapter.__new__(CuTeDSLKernelAdapter)
+    adapter.ir_module = tilelang.tvm.IRModule({program.attrs["global_symbol"]: program})
+    adapter.dynamic_symbolic_map, adapter.dynamic_symbolic_order = adapter._process_dynamic_symbolic()
+
+    assert len(adapter.dynamic_symbolic_order) == 1
+    dynamic_symbol = adapter.dynamic_symbolic_order[0]
+    assert adapter._resolve_dynamic_symbolic_value(dynamic_symbol, [None, torch.empty(7), torch.empty(7)]) == 7
 
 
 def test_cutedsl_cache_restore_does_not_fallback_to_host_source(monkeypatch, tmp_path):

--- a/testing/python/target/test_tilelang_codegen_cutedsl_integer_shift.py
+++ b/testing/python/target/test_tilelang_codegen_cutedsl_integer_shift.py
@@ -1,0 +1,40 @@
+import pytest
+
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+from tilelang.engine.lower import lower
+from tilelang.utils.target import normalize_cutedsl_target
+
+
+def _lower_cutedsl(program):
+    if not tvm.runtime.enabled("cuda"):
+        pytest.skip("TileLang CuTeDSL codegen requires TVM built with CUDA support.")
+
+    build_cutedsl = tvm.ffi.get_global_func("target.build.tilelang_cutedsl_without_compile", allow_missing=True)
+    if build_cutedsl is None:
+        pytest.skip("TileLang CuTeDSL backend is not enabled in this build.")
+
+    target = normalize_cutedsl_target({"kind": "cutedsl", "arch": "sm_80"})
+    assert target is not None
+
+    with target:
+        return lower(program.with_attr("global_symbol", "main"), target=target)
+
+
+def test_cutedsl_codegen_promotes_narrow_shift_before_wide_cast():
+    @T.prim_func
+    def prog(A: T.Tensor((1,), "uint16"), B: T.Tensor((1,), "uint32")):
+        with T.Kernel(1, threads=1):
+            local = T.alloc_local((1,), "uint16")
+            local[0] = A[0]
+            B[0] = T.cast(local[0] << 20, T.uint32)
+
+    artifact = _lower_cutedsl(prog)
+
+    assert "cutlass.Uint32(local[0]) << cutlass.Uint16(20)" in artifact.kernel_source
+    assert "cutlass.Uint32(cutlass.Uint16((local[0] << cutlass.Uint16(20))))" not in artifact.kernel_source
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/contrib/cutedsl/__init__.py
+++ b/tilelang/contrib/cutedsl/__init__.py
@@ -4,7 +4,7 @@ import cutlass  # noqa: F401
 import cutlass.cute as cute  # noqa: F401
 
 # re-export cutlass.cute.arch functions first
-from cutlass.cute.arch import sync_threads  # noqa: F401
+from cutlass.cute.arch import sync_threads, sync_warp  # noqa: F401
 from cutlass.cute.arch import alloc_smem, get_dyn_smem  # noqa: F401
 from cutlass.cute.arch import warpgroup_reg_alloc, warpgroup_reg_dealloc  # noqa: F401
 
@@ -13,6 +13,7 @@ with suppress(ImportError):
 from cutlass.cute.nvgpu.warpgroup.helpers import wait_group as wgmma_wait_group  # noqa: F401
 
 from cutlass.cute import make_tensor, make_rmem_tensor, recast_ptr, where  # noqa: F401
+from cutlass.cute.testing import assert_ as runtime_assert  # noqa: F401
 from cutlass.cute.typing import Numeric  # noqa: F401
 
 from cutlass.base_dsl.typing import as_numeric, Int8, Int16, Int32, Uint8, Uint16, Uint32, Float16, Float32, BFloat16  # noqa: F401

--- a/tilelang/contrib/cutedsl/grid_sync.py
+++ b/tilelang/contrib/cutedsl/grid_sync.py
@@ -43,33 +43,52 @@ def _find_gpu_module_from_ip():
 def _ensure_global_counter(loc=None):
     """Declare the global counter variable at gpu.module level if not already done.
 
-    Creates: @__grid_sync_ctr = internal global i32 0, addrspace(1)
+    Creates:
+    - @__grid_sync_ctr = internal global i32 0, addrspace(1)
+    - @__grid_sync_gen = internal global i32 0, addrspace(1)
     """
     gpu_mod = _find_gpu_module_from_ip()
     if gpu_mod is None:
         raise RuntimeError("Cannot find gpu.module in MLIR hierarchy for global variable declaration")
 
-    # Check if the global already exists
+    # Check if the globals already exist.
     module_body = gpu_mod.regions[0].blocks[0]
+    found_ctr = False
+    found_gen = False
     for op in module_body.operations:
         if op.name == "llvm.mlir.global":
             sym = op.attributes.get("sym_name")
-            if sym is not None and str(sym) == '"__grid_sync_ctr"':
-                return
+            if sym is not None:
+                if str(sym) == '"__grid_sync_ctr"':
+                    found_ctr = True
+                elif str(sym) == '"__grid_sync_gen"':
+                    found_gen = True
+    if found_ctr and found_gen:
+        return
 
     # Insert at the beginning of the module body
     ctx = mlir_ir.Context.current
     linkage_attr = mlir_ir.Attribute.parse("#llvm.linkage<internal>", ctx)
 
     with mlir_ir.InsertionPoint.at_block_begin(module_body):
-        llvm.GlobalOp(
-            T.i32(),
-            "__grid_sync_ctr",
-            linkage_attr,
-            value=mlir_ir.IntegerAttr.get(T.i32(), 0),
-            addr_space=1,
-            loc=loc,
-        )
+        if not found_gen:
+            llvm.GlobalOp(
+                T.i32(),
+                "__grid_sync_gen",
+                linkage_attr,
+                value=mlir_ir.IntegerAttr.get(T.i32(), 0),
+                addr_space=1,
+                loc=loc,
+            )
+        if not found_ctr:
+            llvm.GlobalOp(
+                T.i32(),
+                "__grid_sync_ctr",
+                linkage_attr,
+                value=mlir_ir.IntegerAttr.get(T.i32(), 0),
+                addr_space=1,
+                loc=loc,
+            )
 
 
 def sync_grid():
@@ -94,19 +113,28 @@ def _grid_sync_barrier(*, loc=None, ip=None) -> None:
     """
     _ensure_global_counter(loc=loc)
 
-    # Get address of the global counter (ptr in address space 1 = global memory)
+    # Get addresses of the global barrier state (ptr in address space 1 = global memory)
     counter_ptr = llvm.mlir_addressof(
         llvm.PointerType.get(1),
         "__grid_sync_ctr",
         loc=loc,
         ip=ip,
     )
+    generation_ptr = llvm.mlir_addressof(
+        llvm.PointerType.get(1),
+        "__grid_sync_gen",
+        loc=loc,
+        ip=ip,
+    )
 
     # All barrier logic in one inline PTX block:
-    # - Thread 0 check, grid dim computation, atomic increment, spin-wait, reset
+    # - Thread 0 check, grid dim computation, atomic increment, sense wait
+    # - The last arriving block resets the counter and advances generation.
+    #   Other blocks wait for generation to change, so they cannot miss release
+    #   if the counter is reset before they observe the final arrival count.
     llvm.inline_asm(
         None,
-        [counter_ptr],
+        [counter_ptr, generation_ptr],
         """
 {
     .reg .s32 %r_tid;
@@ -115,7 +143,10 @@ def _grid_sync_barrier(*, loc=None, ip=None) -> None:
     .reg .s32 %r_nctaid_z;
     .reg .s32 %r_num_blocks;
     .reg .s32 %r_arrived;
+    .reg .s32 %r_generation;
+    .reg .s32 %r_new_generation;
     .reg .pred %p_is_thread0;
+    .reg .pred %p_is_last;
     .reg .pred %p_done;
 
     // Check if this is thread 0
@@ -130,22 +161,32 @@ def _grid_sync_barrier(*, loc=None, ip=None) -> None:
     mul.lo.s32 %r_num_blocks, %r_nctaid_x, %r_nctaid_y;
     mul.lo.s32 %r_num_blocks, %r_num_blocks, %r_nctaid_z;
 
-    // Atomic increment with GPU scope
+    // Capture the current barrier generation before publishing arrival.
+    ld.acquire.gpu.global.s32 %r_generation, [$1];
+
+    // Atomic increment with GPU scope. atom.add returns the old value.
     atom.add.release.gpu.s32 %r_arrived, [$0], 1;
+    add.s32 %r_arrived, %r_arrived, 1;
 
-    // Spin until all blocks arrive (acquire GPU scope)
-GRID_SYNC_SPIN:
-    ld.acquire.gpu.global.s32 %r_arrived, [$0];
-    setp.ge.s32 %p_done, %r_arrived, %r_num_blocks;
-    @!%p_done bra GRID_SYNC_SPIN;
+    // Last block releases the barrier by resetting the counter and advancing
+    // generation. Non-last blocks wait for generation to change.
+    setp.eq.s32 %p_is_last, %r_arrived, %r_num_blocks;
+    @!%p_is_last bra GRID_SYNC_SPIN;
 
-    // Reset counter with GPU scope
     st.release.gpu.global.s32 [$0], 0;
+    add.s32 %r_new_generation, %r_generation, 1;
+    st.release.gpu.global.s32 [$1], %r_new_generation;
+    bra GRID_SYNC_DONE;
+
+GRID_SYNC_SPIN:
+    ld.acquire.gpu.global.s32 %r_new_generation, [$1];
+    setp.ne.s32 %p_done, %r_new_generation, %r_generation;
+    @!%p_done bra GRID_SYNC_SPIN;
 
 GRID_SYNC_DONE:
 }
 """,
-        "l",
+        "l,l",
         has_side_effects=True,
         is_align_stack=False,
         asm_dialect=llvm.AsmDialect.AD_ATT,

--- a/tilelang/contrib/cutedsl/grid_sync.py
+++ b/tilelang/contrib/cutedsl/grid_sync.py
@@ -9,9 +9,9 @@ counter declared via llvm.mlir.global. Requires cooperative kernel launch
 
 The barrier:
 1. __syncthreads() within each block
-2. Thread 0 atomically increments global counter, spin-waits until all blocks arrive
-3. Thread 0 resets counter
-4. __syncthreads() within each block
+2. All threads execute a device-scope fence for prior global writes
+3. Thread 0 atomically increments global counter and spin-waits until release
+4. All threads wait for thread 0 and execute a device-scope fence before return
 """
 
 __all__ = ["sync_grid"]
@@ -109,7 +109,9 @@ def _grid_sync_barrier(*, loc=None, ip=None) -> None:
 
     Declares a module-level global counter via llvm.mlir.global, then uses
     inline PTX for the barrier protocol (atomic increment + spin-wait + reset).
-    Only thread 0 per block participates.
+    Only thread 0 per block updates the global barrier state. All threads
+    participate in device-scope fences around the thread-0 publish/wait path so
+    global memory protected by the grid barrier is ordered for the whole block.
     """
     _ensure_global_counter(loc=loc)
 
@@ -151,8 +153,11 @@ def _grid_sync_barrier(*, loc=None, ip=None) -> None:
 
     // Check if this is thread 0
     mov.u32 %r_tid, %tid.x;
+    // Order prior global writes from every thread before thread 0 publishes
+    // this block's arrival.
+    membar.gl;
     setp.ne.s32 %p_is_thread0, %r_tid, 0;
-    @%p_is_thread0 bra GRID_SYNC_DONE;
+    @%p_is_thread0 bra GRID_SYNC_BLOCK_WAIT;
 
     // Compute total number of blocks
     mov.u32 %r_nctaid_x, %nctaid.x;
@@ -176,12 +181,19 @@ def _grid_sync_barrier(*, loc=None, ip=None) -> None:
     st.release.gpu.global.s32 [$0], 0;
     add.s32 %r_new_generation, %r_generation, 1;
     st.release.gpu.global.s32 [$1], %r_new_generation;
-    bra GRID_SYNC_DONE;
+    bra GRID_SYNC_BLOCK_WAIT;
 
 GRID_SYNC_SPIN:
     ld.acquire.gpu.global.s32 %r_new_generation, [$1];
     setp.ne.s32 %p_done, %r_new_generation, %r_generation;
     @!%p_done bra GRID_SYNC_SPIN;
+
+GRID_SYNC_BLOCK_WAIT:
+    // Keep non-zero threads in the block from returning before thread 0 has
+    // observed the grid release, then acquire global writes before user code
+    // resumes after sync_grid().
+    bar.sync 0;
+    membar.gl;
 
 GRID_SYNC_DONE:
 }

--- a/tilelang/contrib/cutedsl/math.py
+++ b/tilelang/contrib/cutedsl/math.py
@@ -4,6 +4,7 @@ __all__ = [
     "exp2",
     "exp10",
     "log",
+    "log1p",
     "log2",
     "log10",
     "tan",
@@ -16,6 +17,9 @@ __all__ = [
     "min2",
     "copysignf",
     "divf",
+    "isfinite",
+    "__habs",
+    "__float2half_rz",
     "tanh",
 ]
 
@@ -28,7 +32,7 @@ from cutlass._mlir.dialects import arith, math
 from cutlass.cute.math import _math_op as _cute_math_op
 
 from cutlass._mlir.dialects import llvm
-from cutlass.base_dsl.typing import Float32, Uint32
+from cutlass.base_dsl.typing import BFloat16, Float16, Float32, Uint16, Uint32
 from cutlass.cutlass_dsl import T, dsl_user_op
 
 
@@ -95,6 +99,10 @@ def exp2(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Unio
 
 def log(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
     return _tl_math_op(math.log, fastmath, x, **kwargs)
+
+
+def log1p(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
+    return _tl_math_op(math.log1p, fastmath, x, **kwargs)
 
 
 def log2(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
@@ -166,12 +174,47 @@ def copysignf(x: Union[TensorSSA, Numeric], y: Union[TensorSSA, Numeric], fastma
     return (magnitude | sign).bitcast(Float32)
 
 
+def isfinite(x: Numeric) -> cutlass.Boolean:
+    result_type = _scalar_result_type(x)
+    if not result_type.is_float:
+        raise TypeError(f"isfinite expects a scalar float input, but got {result_type}")
+
+    x_bits = Float32(x).bitcast(Uint32)
+    exponent = x_bits & Uint32(0x7F800000)
+    return exponent != Uint32(0x7F800000)
+
+
 def divf(
     x: Union[TensorSSA, Numeric],
     y: Union[TensorSSA, Numeric],
     fastmath: bool = False,
 ) -> Union[TensorSSA, Numeric]:
     return _tl_math_op(arith.divf, fastmath, x, y)
+
+
+def __habs(x: Numeric) -> Numeric:
+    result_type = _scalar_result_type(x)
+    if result_type not in (Float16, BFloat16):
+        raise TypeError(f"__habs expects Float16 or BFloat16 input, but got {_scalar_type_name(result_type)}")
+
+    bits = result_type(x).bitcast(Uint16)
+    return (bits & Uint16(0x7FFF)).bitcast(result_type)
+
+
+@dsl_user_op
+def __float2half_rz(x: Union[float, Float32], *, loc=None, ip=None) -> Float16:
+    result_i16 = llvm.inline_asm(
+        T.i16(),
+        [Float32(x).ir_value(loc=loc, ip=ip)],
+        "cvt.rz.f16.f32 $0, $1;",
+        "=h,f",
+        has_side_effects=False,
+        is_align_stack=False,
+        asm_dialect=llvm.AsmDialect.AD_ATT,
+        loc=loc,
+        ip=ip,
+    )
+    return Float16(llvm.bitcast(T.f16(), result_i16, loc=loc, ip=ip))
 
 
 @dsl_user_op

--- a/tilelang/contrib/cutedsl/math.py
+++ b/tilelang/contrib/cutedsl/math.py
@@ -1,4 +1,5 @@
 __all__ = [
+    "abs2",
     "exp",
     "exp2",
     "exp10",
@@ -11,10 +12,15 @@ __all__ = [
     "sqrt",
     "rsqrt",
     "fabsf",
+    "max2",
+    "min2",
     "copysignf",
     "divf",
     "tanh",
 ]
+
+import cutlass
+import cutlass.cute as cute
 
 from cutlass.cute.typing import Union, Numeric
 from cutlass.cute.tensor import TensorSSA
@@ -127,6 +133,22 @@ def exp10(x: Union[TensorSSA, Numeric], fastmath: bool = False) -> Union[TensorS
 
 def fabsf(x: Union[TensorSSA, Numeric], fastmath: bool = False) -> Union[TensorSSA, Numeric]:
     return _tl_math_op(math.absf, fastmath, x)
+
+
+def abs2(x: Union[TensorSSA, Numeric]) -> Union[TensorSSA, Numeric]:
+    return fabsf(x)
+
+
+def max2(x: Union[TensorSSA, Numeric], y: Union[TensorSSA, Numeric]) -> Union[TensorSSA, Numeric]:
+    if any(isinstance(arg, TensorSSA) for arg in (x, y)):
+        return cute.where(x > y, x, y)
+    return cutlass.max(x, y)
+
+
+def min2(x: Union[TensorSSA, Numeric], y: Union[TensorSSA, Numeric]) -> Union[TensorSSA, Numeric]:
+    if any(isinstance(arg, TensorSSA) for arg in (x, y)):
+        return cute.where(x < y, x, y)
+    return cutlass.min(x, y)
 
 
 def copysignf(x: Union[TensorSSA, Numeric], y: Union[TensorSSA, Numeric], fastmath: bool = False) -> Union[TensorSSA, Numeric]:

--- a/tilelang/contrib/cutedsl/reduce.py
+++ b/tilelang/contrib/cutedsl/reduce.py
@@ -109,27 +109,19 @@ def _imax(a, b, *, loc=None, ip=None):
 
 
 def min(a, b, c=None):
-    """Type-aware min: uses arith.minsi for integers, nvvm.fmin for floats.
-    Falls back to integer path if float conversion fails (signless int types)."""
-    if _is_int_type(a) and _is_int_type(b):
-        return _imin(a, b)
-    try:
-        return _fmin(a, b, c)
-    except Exception:
-        # Float32 conversion may fail for signless integer types
-        return _imin(a, b)
+    """Type-preserving min for scalar CuTeDSL values."""
+    result = cutlass.min(a, b)
+    if c is not None:
+        result = cutlass.min(result, c)
+    return result
 
 
 def max(a, b, c=None):
-    """Type-aware max: uses arith.maxsi for integers, nvvm.fmax for floats.
-    Falls back to integer path if float conversion fails (signless int types)."""
-    if _is_int_type(a) and _is_int_type(b):
-        return _imax(a, b)
-    try:
-        return _fmax(a, b, c)
-    except Exception:
-        # Float32 conversion may fail for signless integer types
-        return _imax(a, b)
+    """Type-preserving max for scalar CuTeDSL values."""
+    result = cutlass.max(a, b)
+    if c is not None:
+        result = cutlass.max(result, c)
+    return result
 
 
 class SumOp:
@@ -306,7 +298,7 @@ class CumSum1D:
         dst_tensor = cute.make_tensor(dst, (N,))
 
         # Load value (0 if out of bounds)
-        val = Float32(0.0)
+        val = src_tensor.element_type(0)
         if tidx < N:
             val = src_tensor[tidx]
 
@@ -371,7 +363,7 @@ class CumSum2D:
             idx = row * W + col
 
             # Load value (0 if out of bounds)
-            val = Float32(0.0)
+            val = src_tensor.element_type(0)
             if row < H and col < W:
                 val = src_tensor[idx]
 
@@ -395,7 +387,7 @@ class CumSum2D:
             idx = row_in_col * W + col
 
             # Load value (0 if out of bounds)
-            val = Float32(0.0)
+            val = src_tensor.element_type(0)
             if row_in_col < H and col < W:
                 val = src_tensor[idx]
 
@@ -468,7 +460,7 @@ class CumMax2D:
             col = lane
             idx = row * W + col
 
-            val = Float32(0.0)
+            val = src_tensor.element_type(0)
             if row < H:
                 val = src_tensor[row * W]
             if row < H and col < W:
@@ -489,7 +481,7 @@ class CumMax2D:
             row_in_col = lane
             idx = row_in_col * W + col
 
-            val = Float32(0.0)
+            val = src_tensor.element_type(0)
             if col < W:
                 val = src_tensor[col]
             if row_in_col < H and col < W:

--- a/tilelang/contrib/cutedsl/reduce.py
+++ b/tilelang/contrib/cutedsl/reduce.py
@@ -192,7 +192,7 @@ def bar_sync_ptx(barrier_id, number_of_threads):
 
 
 # Import shuffle functions from warp module
-from .warp import __shfl_up_sync, __shfl_down_sync
+from .warp import __shfl_sync, __shfl_up_sync, __shfl_down_sync
 
 
 def _warp_prefix_sum_forward(val, lane, MASK=0xFFFFFFFF):
@@ -265,6 +265,92 @@ def _warp_prefix_max_reverse(val, lane, MASK=0xFFFFFFFF):
     return val
 
 
+@cute.jit
+def _scan_line_sum(src_tensor, dst_tensor, base_offset, extent, stride, lane, reverse, MASK=0xFFFFFFFF):
+    """Inclusive sum scan over one strided line using one warp."""
+    SEG = 32
+    carry = src_tensor.element_type(0)
+    has_carry = False
+    num_segments = (extent + SEG - 1) // SEG
+
+    if reverse:
+        for seg_offset in range(num_segments):
+            seg = num_segments - 1 - seg_offset
+            base = seg * SEG
+            active = min(extent - base, SEG)
+            val = src_tensor.element_type(0)
+            if lane < active:
+                val = src_tensor[base_offset + (base + lane) * stride]
+
+            val = _warp_prefix_sum_reverse(val, lane, MASK)
+            if has_carry and lane < active:
+                val = val + carry
+            if lane < active:
+                dst_tensor[base_offset + (base + lane) * stride] = val
+
+            carry = __shfl_sync(MASK, val, 0)
+            has_carry = True
+    else:
+        for seg in range(num_segments):
+            base = seg * SEG
+            active = min(extent - base, SEG)
+            val = src_tensor.element_type(0)
+            if lane < active:
+                val = src_tensor[base_offset + (base + lane) * stride]
+
+            val = _warp_prefix_sum_forward(val, lane, MASK)
+            if has_carry and lane < active:
+                val = val + carry
+            if lane < active:
+                dst_tensor[base_offset + (base + lane) * stride] = val
+
+            carry = __shfl_sync(MASK, val, active - 1)
+            has_carry = True
+
+
+@cute.jit
+def _scan_line_max(src_tensor, dst_tensor, base_offset, extent, stride, lane, reverse, MASK=0xFFFFFFFF):
+    """Inclusive max scan over one strided line using one warp."""
+    SEG = 32
+    carry = src_tensor.element_type(0)
+    has_carry = False
+    num_segments = (extent + SEG - 1) // SEG
+
+    if reverse:
+        for seg_offset in range(num_segments):
+            seg = num_segments - 1 - seg_offset
+            base = seg * SEG
+            active = min(extent - base, SEG)
+            val = src_tensor.element_type(0)
+            if lane < active:
+                val = src_tensor[base_offset + (base + lane) * stride]
+
+            val = _warp_prefix_max_reverse(val, lane, MASK)
+            if has_carry and lane < active:
+                val = max(val, carry)
+            if lane < active:
+                dst_tensor[base_offset + (base + lane) * stride] = val
+
+            carry = __shfl_sync(MASK, val, 0)
+            has_carry = True
+    else:
+        for seg in range(num_segments):
+            base = seg * SEG
+            active = min(extent - base, SEG)
+            val = src_tensor.element_type(0)
+            if lane < active:
+                val = src_tensor[base_offset + (base + lane) * stride]
+
+            val = _warp_prefix_max_forward(val, lane, MASK)
+            if has_carry and lane < active:
+                val = max(val, carry)
+            if lane < active:
+                dst_tensor[base_offset + (base + lane) * stride] = val
+
+            carry = __shfl_sync(MASK, val, active - 1)
+            has_carry = True
+
+
 class CumSum1D:
     """
     1D cumulative sum operation.
@@ -297,20 +383,8 @@ class CumSum1D:
         src_tensor = cute.make_tensor(src, (N,))
         dst_tensor = cute.make_tensor(dst, (N,))
 
-        # Load value (0 if out of bounds)
-        val = src_tensor.element_type(0)
-        if tidx < N:
-            val = src_tensor[tidx]
-
-        # Warp-level prefix sum
-        if self.reverse:
-            val = _warp_prefix_sum_reverse(val, lane, MASK)
-        else:
-            val = _warp_prefix_sum_forward(val, lane, MASK)
-
-        # Store result - only valid threads write
-        if tidx < N:
-            dst_tensor[tidx] = val
+        if tidx < self.SEG:
+            _scan_line_sum(src_tensor, dst_tensor, 0, N, 1, lane, self.reverse, MASK)
 
 
 class CumSum2D:
@@ -345,60 +419,24 @@ class CumSum2D:
         MASK = 0xFFFFFFFF
         tidx, _, _ = cute.arch.thread_idx()
         lane = tidx % self.SEG
-        row = tidx // self.SEG
+        item = tidx // self.SEG
+        tile = self.threads // self.SEG
 
         src_tensor = cute.make_tensor(src, (H * W,))
         dst_tensor = cute.make_tensor(dst, (H * W,))
 
-        # For 2D cumsum along dim=1 (row-wise cumsum):
-        # Each warp handles one row, lane id is the column index
-        # For dim=0 (column-wise), interpretation is swapped
-
         if self.dim == 1:
-            # Row-wise cumsum: each warp processes one row
-            # row = which row this warp handles
-            # lane = column index within the row
-            col = lane
-            # Linear index into the flattened buffer
-            idx = row * W + col
-
-            # Load value (0 if out of bounds)
-            val = src_tensor.element_type(0)
-            if row < H and col < W:
-                val = src_tensor[idx]
-
-            # Warp-level prefix sum along the row
-            if self.reverse:
-                val = _warp_prefix_sum_reverse(val, lane, MASK)
-            else:
-                val = _warp_prefix_sum_forward(val, lane, MASK)
-
-            # Store result - only valid threads write
-            if row < H and col < W:
-                dst_tensor[idx] = val
+            num_blocks = (H + tile - 1) // tile
+            for block in cutlass.range_constexpr(num_blocks):
+                row = block * tile + item
+                if row < H:
+                    _scan_line_sum(src_tensor, dst_tensor, row * W, W, 1, lane, self.reverse, MASK)
         else:
-            # Column-wise cumsum (dim=0): each warp processes one column
-            # Each lane maps to a row index, so H must be <= 32 (warp size).
-            assert H <= 32, (
-                f"CumSum2D dim=0 only supports H <= 32 (got H={H}). Use dim=1 for row-wise cumsum or implement multi-warp column iteration."
-            )
-            col = row  # warp index becomes column index
-            row_in_col = lane  # lane becomes row index within column
-            idx = row_in_col * W + col
-
-            # Load value (0 if out of bounds)
-            val = src_tensor.element_type(0)
-            if row_in_col < H and col < W:
-                val = src_tensor[idx]
-
-            if self.reverse:
-                val = _warp_prefix_sum_reverse(val, lane, MASK)
-            else:
-                val = _warp_prefix_sum_forward(val, lane, MASK)
-
-            # Store result - only valid threads write
-            if row_in_col < H and col < W:
-                dst_tensor[idx] = val
+            num_blocks = (W + tile - 1) // tile
+            for block in cutlass.range_constexpr(num_blocks):
+                col = block * tile + item
+                if col < W:
+                    _scan_line_sum(src_tensor, dst_tensor, col, H, W, lane, self.reverse, MASK)
 
 
 class CumMax1D:
@@ -421,17 +459,8 @@ class CumMax1D:
         src_tensor = cute.make_tensor(src, (N,))
         dst_tensor = cute.make_tensor(dst, (N,))
 
-        val = src_tensor[0]
-        if tidx < N:
-            val = src_tensor[tidx]
-
-        if self.reverse:
-            val = _warp_prefix_max_reverse(val, lane, MASK)
-        else:
-            val = _warp_prefix_max_forward(val, lane, MASK)
-
-        if tidx < N:
-            dst_tensor[tidx] = val
+        if tidx < self.SEG:
+            _scan_line_max(src_tensor, dst_tensor, 0, N, 1, lane, self.reverse, MASK)
 
 
 class CumMax2D:
@@ -451,49 +480,24 @@ class CumMax2D:
         MASK = 0xFFFFFFFF
         tidx, _, _ = cute.arch.thread_idx()
         lane = tidx % self.SEG
-        row = tidx // self.SEG
+        item = tidx // self.SEG
+        tile = self.threads // self.SEG
 
         src_tensor = cute.make_tensor(src, (H * W,))
         dst_tensor = cute.make_tensor(dst, (H * W,))
 
         if self.dim == 1:
-            col = lane
-            idx = row * W + col
-
-            val = src_tensor.element_type(0)
-            if row < H:
-                val = src_tensor[row * W]
-            if row < H and col < W:
-                val = src_tensor[idx]
-
-            if self.reverse:
-                val = _warp_prefix_max_reverse(val, lane, MASK)
-            else:
-                val = _warp_prefix_max_forward(val, lane, MASK)
-
-            if row < H and col < W:
-                dst_tensor[idx] = val
+            num_blocks = (H + tile - 1) // tile
+            for block in cutlass.range_constexpr(num_blocks):
+                row = block * tile + item
+                if row < H:
+                    _scan_line_max(src_tensor, dst_tensor, row * W, W, 1, lane, self.reverse, MASK)
         else:
-            assert H <= 32, (
-                f"CumMax2D dim=0 only supports H <= 32 (got H={H}). Use dim=1 for row-wise cummax or implement multi-warp column iteration."
-            )
-            col = row
-            row_in_col = lane
-            idx = row_in_col * W + col
-
-            val = src_tensor.element_type(0)
-            if col < W:
-                val = src_tensor[col]
-            if row_in_col < H and col < W:
-                val = src_tensor[idx]
-
-            if self.reverse:
-                val = _warp_prefix_max_reverse(val, lane, MASK)
-            else:
-                val = _warp_prefix_max_forward(val, lane, MASK)
-
-            if row_in_col < H and col < W:
-                dst_tensor[idx] = val
+            num_blocks = (W + tile - 1) // tile
+            for block in cutlass.range_constexpr(num_blocks):
+                col = block * tile + item
+                if col < W:
+                    _scan_line_max(src_tensor, dst_tensor, col, H, W, lane, self.reverse, MASK)
 
 
 class NamedBarrier:

--- a/tilelang/contrib/cutedsl/utils.py
+++ b/tilelang/contrib/cutedsl/utils.py
@@ -11,6 +11,7 @@ import cutlass.cute as cute
 from cutlass.base_dsl._mlir_helpers import arith as arith_helper
 from cutlass.base_dsl.typing import (
     BFloat16,
+    Float,
     Float16,
     Float32,
     Float4E2M1FN,
@@ -34,6 +35,8 @@ __all__ = [
     "type_map",
     "bitcast",
     "cast_tensor",
+    "as_tensor_ssa",
+    "as_rmem_tensor",
     "make_filled_tensor",
     "make_tensor_at_offset",
     "handle_add_byte_offset",
@@ -233,7 +236,12 @@ def cast_tensor(value, dtype):
             if value.dtype is not Float32:
                 value = value.to(Float32)
             return _float32_to_f4e2m1_tensor(value)
-        if dtype is Float16 and getattr(value.dtype, "width", 0) < Float16.width:
+        if (
+            dtype is Float16
+            and isinstance(value.dtype, type)
+            and issubclass(value.dtype, Float)
+            and getattr(value.dtype, "width", 0) < Float16.width
+        ):
             return _narrow_to_float16_tensor(value)
         elem_type = getattr(value.type, "element_type", None)
         if elem_type is None:
@@ -246,6 +254,20 @@ def cast_tensor(value, dtype):
             return value
         return value.to(dtype)
     return dtype(value)
+
+
+def as_tensor_ssa(value):
+    if isinstance(value, TensorSSA):
+        return value
+    return value.load()
+
+
+def as_rmem_tensor(value, shape, dtype):
+    if not isinstance(value, TensorSSA):
+        return value
+    tensor = cute.make_rmem_tensor(shape, dtype)
+    tensor.store(value)
+    return tensor
 
 
 def make_filled_tensor(shape, value, dtype=None):

--- a/tilelang/contrib/cutedsl/utils.py
+++ b/tilelang/contrib/cutedsl/utils.py
@@ -8,8 +8,23 @@ bitcast, tensor construction, warp election, barrier sync, and FP16 packing.
 import cutlass
 import cutlass.cute as cute
 
-from cutlass.base_dsl.typing import Int8, Int16, Int32, Uint8, Uint16, Uint32, Float16, Float32, BFloat16
-from cutlass._mlir.dialects import llvm, nvvm
+from cutlass.base_dsl._mlir_helpers import arith as arith_helper
+from cutlass.base_dsl.typing import (
+    BFloat16,
+    Float16,
+    Float32,
+    Float4E2M1FN,
+    Int4,
+    Int8,
+    Int16,
+    Int32,
+    Numeric,
+    Uint8,
+    Uint16,
+    Uint32,
+)
+from cutlass.cute.tensor import TensorSSA
+from cutlass._mlir.dialects import arith, builtin, llvm, nvgpu, nvvm, vector
 from cutlass._mlir import ir as mlir_ir
 from cutlass.cutlass_dsl import dsl_user_op
 
@@ -18,6 +33,7 @@ __all__ = [
     "BYTES_PER_POINTER",
     "type_map",
     "bitcast",
+    "cast_tensor",
     "make_filled_tensor",
     "make_tensor_at_offset",
     "handle_add_byte_offset",
@@ -94,8 +110,155 @@ def bitcast(value, target_dtype):
     return bitcast_impl(value)
 
 
-def make_filled_tensor(shape, value):
-    t = cute.make_rmem_tensor(shape, type(value))
+@dsl_user_op
+def _narrow_to_float16_tensor(value, *, loc=None, ip=None):
+    src = value.ir_value(loc=loc, ip=ip)
+    res_type = arith_helper.recast_type(src.type, Float16.mlir_type)
+    res = nvgpu.cvt_fpext(res_type, src, loc=loc, ip=ip)
+    return TensorSSA(res, value.shape, Float16)
+
+
+@dsl_user_op
+def _f4e2m1_to_float32_tensor(value, *, loc=None, ip=None):
+    length = cute.size(value.shape, loc=loc, ip=ip)
+    if not isinstance(length, int):
+        raise ValueError("Float4E2M1FN tensor casts require a static vector shape")
+
+    src = value.ir_value(loc=loc, ip=ip)
+    vec_i4 = builtin.unrealized_conversion_cast(
+        [mlir_ir.VectorType.get([length], Int4.mlir_type, loc=loc)],
+        [src],
+        loc=loc,
+        ip=ip,
+    )
+    vec_dst_type = mlir_ir.VectorType.get([length], Float32.mlir_type, loc=loc)
+    vec_dst = llvm.mlir_zero(vec_dst_type, loc=loc, ip=ip)
+
+    def i32(value):
+        return arith.constant(Int32.mlir_type, value, loc=loc, ip=ip)
+
+    zero = i32(0)
+    one = i32(1)
+    payload_mask = i32(0x7)
+    sign_mask = i32(0x8)
+    exp_mask = i32(0x3)
+    f32_subnormal_abs = i32(0x3F000000)
+
+    for idx in range(length):
+        pos = i32(idx)
+        nibble_i4 = vector.extractelement(vec_i4, position=pos, loc=loc, ip=ip)
+        nibble = arith.extui(Int32.mlir_type, nibble_i4, loc=loc, ip=ip)
+
+        payload = arith.andi(nibble, payload_mask, loc=loc, ip=ip)
+        sign = arith.shli(arith.andi(nibble, sign_mask, loc=loc, ip=ip), i32(28), loc=loc, ip=ip)
+        exp = arith.andi(arith.shrui(nibble, one, loc=loc, ip=ip), exp_mask, loc=loc, ip=ip)
+        mant = arith.andi(nibble, one, loc=loc, ip=ip)
+
+        normal_exp = arith.shli(arith.addi(exp, i32(126), loc=loc, ip=ip), i32(23), loc=loc, ip=ip)
+        normal_mant = arith.shli(mant, i32(22), loc=loc, ip=ip)
+        normal_abs = arith.ori(normal_exp, normal_mant, loc=loc, ip=ip)
+        is_exp_zero = arith.cmpi(arith.CmpIPredicate.eq, exp, zero, loc=loc, ip=ip)
+        nonzero_abs = arith.select(is_exp_zero, f32_subnormal_abs, normal_abs, loc=loc, ip=ip)
+        is_zero = arith.cmpi(arith.CmpIPredicate.eq, payload, zero, loc=loc, ip=ip)
+        abs_bits = arith.select(is_zero, zero, nonzero_abs, loc=loc, ip=ip)
+        bits = arith.ori(sign, abs_bits, loc=loc, ip=ip)
+        f32 = llvm.bitcast(Float32.mlir_type, bits, loc=loc, ip=ip)
+        vec_dst = vector.insertelement(f32, vec_dst, position=pos, loc=loc, ip=ip)
+
+    return TensorSSA(vec_dst, value.shape, Float32)
+
+
+@dsl_user_op
+def _float32_to_f4e2m1_tensor(value, *, loc=None, ip=None):
+    length = cute.size(value.shape, loc=loc, ip=ip)
+    if not isinstance(length, int):
+        raise ValueError("Float4E2M1FN tensor casts require a static vector shape")
+
+    src = value.ir_value(loc=loc, ip=ip)
+    vec_i32_type = mlir_ir.VectorType.get([length], Int32.mlir_type, loc=loc)
+    vec_i32 = llvm.bitcast(vec_i32_type, src, loc=loc, ip=ip)
+    vec_i4_type = mlir_ir.VectorType.get([length], Int4.mlir_type, loc=loc)
+    vec_i4 = llvm.mlir_zero(vec_i4_type, loc=loc, ip=ip)
+
+    def i32(value):
+        return arith.constant(Int32.mlir_type, value, loc=loc, ip=ip)
+
+    def f32(value):
+        return arith.constant(Float32.mlir_type, value, loc=loc, ip=ip)
+
+    def select_payload(abs_val, payload, predicate, threshold, value):
+        cond = arith.cmpf(predicate, abs_val, f32(threshold), loc=loc, ip=ip)
+        return arith.select(cond, i32(value), payload, loc=loc, ip=ip)
+
+    sign_mask = i32(0x80000000)
+    abs_mask = i32(0x7FFFFFFF)
+    shift_sign = i32(28)
+
+    for idx in range(length):
+        pos = i32(idx)
+        bits = vector.extractelement(vec_i32, position=pos, loc=loc, ip=ip)
+        sign = arith.shrui(arith.andi(bits, sign_mask, loc=loc, ip=ip), shift_sign, loc=loc, ip=ip)
+        abs_bits = arith.andi(bits, abs_mask, loc=loc, ip=ip)
+        abs_val = llvm.bitcast(Float32.mlir_type, abs_bits, loc=loc, ip=ip)
+
+        payload = i32(0)
+        payload = select_payload(abs_val, payload, arith.CmpFPredicate.OGT, 0.25, 1)
+        payload = select_payload(abs_val, payload, arith.CmpFPredicate.OGE, 0.75, 2)
+        payload = select_payload(abs_val, payload, arith.CmpFPredicate.OGT, 1.25, 3)
+        payload = select_payload(abs_val, payload, arith.CmpFPredicate.OGE, 1.75, 4)
+        payload = select_payload(abs_val, payload, arith.CmpFPredicate.OGT, 2.5, 5)
+        payload = select_payload(abs_val, payload, arith.CmpFPredicate.OGE, 3.5, 6)
+        payload = select_payload(abs_val, payload, arith.CmpFPredicate.OGT, 5.0, 7)
+        is_nan = arith.cmpf(arith.CmpFPredicate.UNO, abs_val, abs_val, loc=loc, ip=ip)
+        payload = arith.select(is_nan, i32(7), payload, loc=loc, ip=ip)
+
+        nibble = arith.trunci(Int4.mlir_type, arith.ori(sign, payload, loc=loc, ip=ip), loc=loc, ip=ip)
+        vec_i4 = vector.insertelement(nibble, vec_i4, position=pos, loc=loc, ip=ip)
+
+    vec_f4_type = mlir_ir.VectorType.get([length], Float4E2M1FN.mlir_type, loc=loc)
+    vec_f4 = builtin.unrealized_conversion_cast([vec_f4_type], [vec_i4], loc=loc, ip=ip)
+    return TensorSSA(vec_f4, value.shape, Float4E2M1FN)
+
+
+def cast_tensor(value, dtype):
+    if isinstance(value, TensorSSA):
+        if value.dtype is dtype:
+            return value
+        if value.dtype is Float4E2M1FN and dtype in (Float16, Float32):
+            f32 = _f4e2m1_to_float32_tensor(value)
+            if dtype is Float32:
+                return f32
+            return f32.to(Float16)
+        if dtype is Float4E2M1FN and value.dtype in (BFloat16, Float16, Float32):
+            if value.dtype is not Float32:
+                value = value.to(Float32)
+            return _float32_to_f4e2m1_tensor(value)
+        if dtype is Float16 and getattr(value.dtype, "width", 0) < Float16.width:
+            return _narrow_to_float16_tensor(value)
+        elem_type = getattr(value.type, "element_type", None)
+        if elem_type is None:
+            elem_type = getattr(value.ir_value().type, "element_type", None)
+        if elem_type == dtype.mlir_type or str(elem_type) == str(dtype.mlir_type):
+            return TensorSSA(value, value.shape, dtype)
+        return value.to(dtype)
+    if isinstance(value, Numeric):
+        if type(value) is dtype:
+            return value
+        return value.to(dtype)
+    return dtype(value)
+
+
+def make_filled_tensor(shape, value, dtype=None):
+    dtype = dtype or type(value)
+    if dtype is Float4E2M1FN:
+        if value != 0:
+            raise ValueError("Float4E2M1FN filled tensors only support zero values")
+        storage_layout = cute.recast_layout(8, Float4E2M1FN.width, cute.make_layout(shape))
+        storage = cute.make_rmem_tensor(storage_layout.shape, Uint8)
+        storage.fill(Uint8(0))
+        return cute.recast_tensor(storage, Float4E2M1FN)
+
+    t = cute.make_rmem_tensor(shape, dtype)
     t.fill(value)
     return t
 

--- a/tilelang/contrib/cutedsl/warp.py
+++ b/tilelang/contrib/cutedsl/warp.py
@@ -10,6 +10,9 @@ __all__ = [
     "__shfl_down_sync",
     "__shfl_up_sync",
     "__shfl_sync",
+    "__shfl_xor_sync",
+    "__match_any_sync",
+    "__popc",
     "warp_reduce_sum",
     "warp_reduce_max",
     "warp_reduce_min",
@@ -79,6 +82,64 @@ def __shfl_sync(mask, val, srcLane, width=32):
     """
     mask_and_clamp = ((WARP_SIZE - width) << 8) | ((width - 1) & 0x1F)
     return shuffle_sync(val, offset=srcLane, mask=mask, mask_and_clamp=mask_and_clamp)
+
+
+def __shfl_xor_sync(mask, val, lane_mask, width=32):
+    """
+    Butterfly (XOR) shuffle within warp.
+
+    Uses CuTeDSL's shuffle_sync_bfly with the same clamp encoding as CUDA
+    __shfl_xor_sync.
+    """
+    mask_and_clamp = ((WARP_SIZE - width) << 8) | ((width - 1) & 0x1F)
+    return shuffle_sync_bfly(val, offset=lane_mask, mask=mask, mask_and_clamp=mask_and_clamp)
+
+
+@dsl_user_op
+def __match_any_sync(mask, val, *, loc=None, ip=None) -> Uint32:
+    """
+    Return a bitmask of lanes whose value matches the calling lane.
+
+    PTX: match.any.sync.b32 d, a, membermask;
+    """
+    return Uint32(
+        llvm.inline_asm(
+            T.i32(),
+            [
+                Int32(val).ir_value(loc=loc, ip=ip),
+                Int32(mask).ir_value(loc=loc, ip=ip),
+            ],
+            "match.any.sync.b32 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=True,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def __popc(val, *, loc=None, ip=None) -> Int32:
+    """
+    Count set bits in a 32-bit value.
+
+    PTX: popc.b32 d, a;
+    """
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int32(val).ir_value(loc=loc, ip=ip)],
+            "popc.b32 $0, $1;",
+            "=r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
 
 
 def _shfl_xor_sync(val, lane_mask):

--- a/tilelang/jit/adapter/cutedsl/adapter.py
+++ b/tilelang/jit/adapter/cutedsl/adapter.py
@@ -253,7 +253,16 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
         """Resolve a dynamic shape/stride variable from the first live tensor source."""
         candidates = self._lookup_dynamic_symbolic_candidates(v)
         non_tensor_values: list[tuple[int, Any]] = []
+        has_shape_candidate = False
+        has_stride_candidate = False
         for ref_id, buffer_idx, dim_idx in candidates:
+            if ref_id == 0:
+                has_shape_candidate = True
+            elif ref_id == 1:
+                has_stride_candidate = True
+            else:
+                raise ValueError(f"Unknown dynamic symbol ref id: {ref_id}")
+
             ref_val = param_values[buffer_idx]
             if not isinstance(ref_val, torch.Tensor):
                 non_tensor_values.append((buffer_idx, ref_val))
@@ -262,7 +271,13 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
                 return ref_val.shape[dim_idx]
             if ref_id == 1:
                 return ref_val.stride()[dim_idx]
-            raise ValueError(f"Unknown dynamic symbol ref id: {ref_id}")
+
+        # Optional strided tensors can be absent from a lowered kernel variant
+        # while their dynamic stride remains in the host wrapper ABI. Shape
+        # symbols still require a live tensor source because they determine
+        # output allocation and launch dimensions.
+        if has_stride_candidate and not has_shape_candidate:
+            return 0
 
         details = ", ".join(f"param {buffer_idx}: {type(ref_val).__name__}" for buffer_idx, ref_val in non_tensor_values)
         raise TypeError(f"Dynamic symbolic var {v} has no live tensor source among candidates ({details})")

--- a/tilelang/jit/adapter/cutedsl/adapter.py
+++ b/tilelang/jit/adapter/cutedsl/adapter.py
@@ -189,6 +189,8 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
         buffer_map = func.buffer_map
         dynamic_symbolic_map: dict[tirx.Var, tuple[int, int, int]] = {}
         dynamic_symbolic_order: list[tirx.Var] = []
+        self._dynamic_symbolic_candidates_map: dict[tirx.Var, list[tuple[int, int, int]]] = {}
+        self._dynamic_symbolic_name_candidates_map: dict[str, list[tuple[int, int, int]]] = {}
         # Secondary index by variable name for fallback lookup when tirx.Var
         # object identity differs (e.g. params created from a different
         # PrimFunc instance than the one stored in ir_module).
@@ -196,6 +198,8 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
 
         def unique_push_back(v: tirx.Var, entry: tuple[int, int, int]):
             """Append one symbolic variable unless it has already been seen."""
+            self._dynamic_symbolic_candidates_map.setdefault(v, []).append(entry)
+            self._dynamic_symbolic_name_candidates_map.setdefault(v.name, []).append(entry)
             if v in dynamic_symbolic_map:
                 return
             dynamic_symbolic_map[v] = entry
@@ -236,6 +240,32 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
         if v.name in self._dynamic_symbolic_name_map:
             return self._dynamic_symbolic_name_map[v.name]
         raise KeyError(f"Dynamic symbolic variable '{v.name}' not found in symbolic map")
+
+    def _lookup_dynamic_symbolic_candidates(self, v: tirx.Var) -> list[tuple[int, int, int]]:
+        """Return all shape/stride sources for a dynamic symbolic variable."""
+        if v in self._dynamic_symbolic_candidates_map:
+            return self._dynamic_symbolic_candidates_map[v]
+        if v.name in self._dynamic_symbolic_name_candidates_map:
+            return self._dynamic_symbolic_name_candidates_map[v.name]
+        raise KeyError(f"Dynamic symbolic variable '{v.name}' not found in symbolic map")
+
+    def _resolve_dynamic_symbolic_value(self, v: tirx.Var, param_values: list[Any]) -> int:
+        """Resolve a dynamic shape/stride variable from the first live tensor source."""
+        candidates = self._lookup_dynamic_symbolic_candidates(v)
+        non_tensor_values: list[tuple[int, Any]] = []
+        for ref_id, buffer_idx, dim_idx in candidates:
+            ref_val = param_values[buffer_idx]
+            if not isinstance(ref_val, torch.Tensor):
+                non_tensor_values.append((buffer_idx, ref_val))
+                continue
+            if ref_id == 0:
+                return ref_val.shape[dim_idx]
+            if ref_id == 1:
+                return ref_val.stride()[dim_idx]
+            raise ValueError(f"Unknown dynamic symbol ref id: {ref_id}")
+
+        details = ", ".join(f"param {buffer_idx}: {type(ref_val).__name__}" for buffer_idx, ref_val in non_tensor_values)
+        raise TypeError(f"Dynamic symbolic var {v} has no live tensor source among candidates ({details})")
 
     def get_host_source(self) -> str | None:
         """Get the cached host-side source code."""
@@ -367,17 +397,7 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
                 # Now working with native Python list, no FFI calls needed
                 for s in self.param_shapes[i]:
                     if isinstance(s, tirx.Var):
-                        ref_id, ref_param_idx, ref_dim_idx = self._lookup_dynamic_symbolic(s)
-                        ref_val = param_values[ref_param_idx]
-                        if not isinstance(ref_val, torch.Tensor):
-                            raise TypeError(f"Dynamic shape/stride var {s} refers to a non-tensor param at index {ref_param_idx}")
-                        if ref_id == 0:
-                            shape.append(ref_val.shape[ref_dim_idx])
-                        elif ref_id == 1:
-                            # Stride vars are not expected in output shapes, but handle defensively.
-                            shape.append(ref_val.stride()[ref_dim_idx])
-                        else:
-                            raise ValueError(f"Unknown dynamic symbol ref id: {ref_id}")
+                        shape.append(self._resolve_dynamic_symbolic_value(s, param_values))
                     else:  # Already converted to Python int during initialization
                         shape.append(s)
                 tensor = torch.empty(*shape, dtype=dtype, device=first_tensor.device)
@@ -388,24 +408,7 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
 
         # dynamic symbolics
         for sym in self.dynamic_symbolic_order:
-            ref_id, buffer_idx, dim_idx = self.dynamic_symbolic_map[sym]
-            ref_val = param_values[buffer_idx]
-            if not isinstance(ref_val, torch.Tensor):
-                if ref_val is None:
-                    logger.warning(
-                        "Dynamic symbolic var %s refers to param index %s, but the runtime value is None; using 0 as a fallback",
-                        sym,
-                        buffer_idx,
-                    )
-                    args.append(0)
-                    continue
-                raise TypeError(f"Dynamic symbolic var {sym} refers to a non-tensor param at index {buffer_idx}")
-            if ref_id == 0:
-                args.append(ref_val.shape[dim_idx])
-            elif ref_id == 1:
-                args.append(ref_val.stride()[dim_idx])
-            else:
-                raise ValueError(f"Unknown dynamic symbol ref id: {ref_id}")
+            args.append(self._resolve_dynamic_symbolic_value(sym, param_values))
 
         # if stream is not None, we need to pass the stream to the library
         if stream is None:

--- a/tilelang/jit/adapter/cutedsl/adapter.py
+++ b/tilelang/jit/adapter/cutedsl/adapter.py
@@ -249,7 +249,13 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
             return self._dynamic_symbolic_name_candidates_map[v.name]
         raise KeyError(f"Dynamic symbolic variable '{v.name}' not found in symbolic map")
 
-    def _resolve_dynamic_symbolic_value(self, v: tirx.Var, param_values: list[Any]) -> int:
+    def _resolve_dynamic_symbolic_value(
+        self,
+        v: tirx.Var,
+        param_values: list[Any],
+        *,
+        require_live_shape: bool = True,
+    ) -> int:
         """Resolve a dynamic shape/stride variable from the first live tensor source."""
         candidates = self._lookup_dynamic_symbolic_candidates(v)
         non_tensor_values: list[tuple[int, Any]] = []
@@ -272,11 +278,14 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
             if ref_id == 1:
                 return ref_val.stride()[dim_idx]
 
-        # Optional strided tensors can be absent from a lowered kernel variant
-        # while their dynamic stride remains in the host wrapper ABI. Shape
-        # symbols still require a live tensor source because they determine
-        # output allocation and launch dimensions.
+        # Optional tensors can be absent from a lowered kernel variant while
+        # their dynamic shape/stride remains in the host wrapper ABI. Output
+        # allocation still calls this helper in the default strict mode, so a
+        # live tensor remains required for any shape symbol that materializes a
+        # result tensor.
         if has_stride_candidate and not has_shape_candidate:
+            return 0
+        if has_shape_candidate and not require_live_shape:
             return 0
 
         details = ", ".join(f"param {buffer_idx}: {type(ref_val).__name__}" for buffer_idx, ref_val in non_tensor_values)
@@ -423,7 +432,7 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
 
         # dynamic symbolics
         for sym in self.dynamic_symbolic_order:
-            args.append(self._resolve_dynamic_symbolic_value(sym, param_values))
+            args.append(self._resolve_dynamic_symbolic_value(sym, param_values, require_live_shape=False))
 
         # if stream is not None, we need to pass the stream to the library
         if stream is None:

--- a/tilelang/jit/adapter/cutedsl/adapter.py
+++ b/tilelang/jit/adapter/cutedsl/adapter.py
@@ -391,6 +391,9 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
             ref_id, buffer_idx, dim_idx = self.dynamic_symbolic_map[sym]
             ref_val = param_values[buffer_idx]
             if not isinstance(ref_val, torch.Tensor):
+                if ref_val is None:
+                    args.append(0)
+                    continue
                 raise TypeError(f"Dynamic symbolic var {sym} refers to a non-tensor param at index {buffer_idx}")
             if ref_id == 0:
                 args.append(ref_val.shape[dim_idx])

--- a/tilelang/jit/adapter/cutedsl/adapter.py
+++ b/tilelang/jit/adapter/cutedsl/adapter.py
@@ -392,6 +392,11 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
             ref_val = param_values[buffer_idx]
             if not isinstance(ref_val, torch.Tensor):
                 if ref_val is None:
+                    logger.warning(
+                        "Dynamic symbolic var %s refers to param index %s, but the runtime value is None; using 0 as a fallback",
+                        sym,
+                        buffer_idx,
+                    )
                     args.append(0)
                     continue
                 raise TypeError(f"Dynamic symbolic var {sym} refers to a non-tensor param at index {buffer_idx}")

--- a/tilelang/jit/adapter/cutedsl/wrapper.py
+++ b/tilelang/jit/adapter/cutedsl/wrapper.py
@@ -564,7 +564,7 @@ CUBIN_KERNEL_LAUNCH_TEMPLATE = """\
 
 # Fake tensor creation template
 CUBIN_FAKE_TENSOR_TEMPLATE = """\
-  __fake_{arg_name}__ = make_fake_compact_tensor(_DTYPE_MAP[str({arg_name}.dtype)], {arg_name}.shape, stride_order={arg_name}.dim_order()[::-1], assumed_align=16)"""
+  __fake_{arg_name}__ = make_fake_compact_tensor({dtype_expr}, {arg_name}.shape, stride_order={arg_name}.dim_order()[::-1], assumed_align=16)"""
 
 # Complete cubin generation code template
 # {lib_code} contains the @cute.kernel definitions and is embedded here
@@ -722,7 +722,9 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
         "float16": "cutlass.Float16",
         "bfloat16": "cutlass.BFloat16",
         "float8_e4m3": "cutlass.Float8E4M3",
+        "float8_e4m3fn": "cutlass.Float8E4M3FN",
         "float8_e5m2": "cutlass.Float8E5M2",
+        "float4_e2m1fn": "cutlass.Float4E2M1FN",
         "float64": "cutlass.Float64",
         "int64": "cutlass.Int64",
         "int32": "cutlass.Int32",
@@ -827,7 +829,7 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
 
     def _cxx_expr(self, expr: tvm.tirx.PrimExpr) -> str:
         """Convert TVM expression to C++ string for generated launcher code."""
-        return pythonic_expr(expr, self._CXX_TYPE_MAP)
+        return pythonic_expr(expr, self._CXX_TYPE_MAP, func_name_map={"min": "std::min", "max": "std::max"})
 
     @staticmethod
     def _cxx_cast(ctype: str, expr_str: str) -> str:
@@ -904,7 +906,13 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
         for param in self.prim_func.params:
             if param in self.prim_func.buffer_map:
                 buffer = self.prim_func.buffer_map[param]
-                function_args.append({"name": buffer.data.name, "type": "buffer"})
+                function_args.append(
+                    {
+                        "name": buffer.data.name,
+                        "type": "buffer",
+                        "dtype": self._TYPE_MAP.get(buffer.dtype) or self._TYPE_MAP.get(str(buffer.dtype)),
+                    }
+                )
                 buffer_args.append(buffer.data.name)
             elif isinstance(param, tvm.tirx.Var):
                 function_args.append({"name": param.name, "type": self._TYPE_MAP[param.dtype]})
@@ -1286,6 +1294,7 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
     def _generate_cubin_gen_code(
         self,
         kernel_metadata_list: list[dict],
+        function_args: list[dict],
         buffer_args: list[str],
         all_desc_names: list[str],
         lib_code: str = "",
@@ -1354,8 +1363,14 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
         # (e.g. Output_partial_) for another kernel. Skipping fake tensor creation
         # just because a matching "{arg}_desc" exists is a correctness bug and
         # results in undefined names like "__fake_Output_partial__".
+        buffer_arg_dtypes = {arg["name"]: arg.get("dtype") for arg in function_args if arg["type"] == "buffer"}
         fake_tensor_code = "\n".join(
-            CUBIN_FAKE_TENSOR_TEMPLATE.format(arg_name=arg_name) for arg_name in wrapper_params_union if arg_name in buffer_args
+            CUBIN_FAKE_TENSOR_TEMPLATE.format(
+                arg_name=arg_name,
+                dtype_expr=buffer_arg_dtypes.get(arg_name) or f"_DTYPE_MAP[str({arg_name}.dtype)]",
+            )
+            for arg_name in wrapper_params_union
+            if arg_name in buffer_args
         )
         if fake_tensor_code:
             fake_tensor_code += "\n"
@@ -1598,7 +1613,11 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
 
         # Generate cubin generation code (includes lib_code with @cute.kernel definitions)
         cubin_gen_code = self._generate_cubin_gen_code(
-            kernel_metadata, buffer_args, all_desc_names_union, lib_code=getattr(self, "lib_code", "")
+            kernel_metadata,
+            function_args,
+            buffer_args,
+            all_desc_names_union,
+            lib_code=getattr(self, "lib_code", ""),
         )
 
         # Generate Python wrapper

--- a/tilelang/jit/adapter/cutedsl/wrapper.py
+++ b/tilelang/jit/adapter/cutedsl/wrapper.py
@@ -564,7 +564,12 @@ CUBIN_KERNEL_LAUNCH_TEMPLATE = """\
 
 # Fake tensor creation template
 CUBIN_FAKE_TENSOR_TEMPLATE = """\
-  __fake_{arg_name}__ = make_fake_compact_tensor({dtype_expr}, {arg_name}.shape, stride_order={arg_name}.dim_order()[::-1], assumed_align=16)"""
+  __fake_{arg_name}__ = make_fake_compact_tensor(
+      {dtype_expr},
+      _positive_fake_shape({arg_name}.shape),
+      stride_order={arg_name}.dim_order()[::-1],
+      assumed_align=16,
+  )"""
 
 # Complete cubin generation code template
 # {lib_code} contains the @cute.kernel definitions and is embedded here
@@ -661,6 +666,9 @@ def _generate_cubin_if_needed({cubin_gen_params}):
       "torch.int16": cutlass.Int16,
       "torch.uint16": cutlass.Uint16,
       "torch.uchar": cutlass.Uint8}}
+
+  def _positive_fake_shape(shape):
+    return tuple(max(int(dim), 1) for dim in tuple(shape))
 
 {cubin_gen_code}
 

--- a/tilelang/jit/adapter/utils.py
+++ b/tilelang/jit/adapter/utils.py
@@ -153,7 +153,11 @@ def get_annotated_mod(
 
 
 def pythonic_expr(
-    expr: tvm.tirx.PrimExpr, dtype_map: dict[str, str] | None = None, ignore_cast: bool = False, floor_div_op: str = "/"
+    expr: tvm.tirx.PrimExpr,
+    dtype_map: dict[str, str] | None = None,
+    ignore_cast: bool = False,
+    floor_div_op: str = "/",
+    func_name_map: dict[str, str] | None = None,
 ) -> str:
     """
     Converts a TVM PrimExpr into a Python-style string, correctly handling operator precedence.
@@ -166,6 +170,8 @@ def pythonic_expr(
                       behavior (suitable for generating C/C++ expressions). For generating
                       Python code where integer division is required (e.g. grid/block),
                       pass '//' explicitly.
+        func_name_map: Optional mapping for rendered helper function names, e.g.
+                       {"max": "std::max"} when generating C++.
     Returns:
         A string representation of the expression.
     """
@@ -268,6 +274,8 @@ def pythonic_expr(
             p = my_precedence
         elif isinstance(node, (tvm.tirx.Min, tvm.tirx.Max)):
             op_name = "min" if isinstance(node, tvm.tirx.Min) else "max"
+            if func_name_map is not None:
+                op_name = func_name_map.get(op_name, op_name)
             a_str, _ = node_to_result_map[node.a]
             b_str, _ = node_to_result_map[node.b]
             s = f"{op_name}({a_str}, {b_str})"


### PR DESCRIPTION
## Summary

This PR completes the CuTeDSL backend fixes needed for the TileKernels full functional correctness suite on H100.

This branch currently contains 8 commits relative to `origin/main`. The first 3 are the benchmark-oriented CuTeDSL fixes from the earlier TileKernels benchmark work. The last 5 commits are the new full-functional correctness fixes.

Commits on this branch:

- `1aa67ed3` `[BugFix] CuTeDSL backend support for TileKernels benchmarks`
- `f90559de` `[BugFix] Complete CuTeDSL support for TileKernels benchmarks`
- `62786ddb` `[BugFix] Avoid zero-sized fake tensors in CuTeDSL cubin generation`
- `f83c2c0c` `[BugFix] Complete CuTeDSL scan lowering for TileKernels`
- `cb07934d` `[BugFix] Resolve CuTeDSL dynamic shapes from live tensors`
- `7bdf491a` `[BugFix] Permit dead optional CuTeDSL stride symbols`
- `fc084420` `[BugFix] Fix CuTeDSL optional ABI and early-return codegen`
- `d4ddd297` `[BugFix] Promote narrow CuTeDSL shifts before wide casts`

## Background

TileKernels exercises a wider set of CuTeDSL code paths than the existing TileLang unit tests. After the benchmark-oriented CuTeDSL support, the full TileKernels functional suite still exposed correctness and lowering gaps around prefix scans, dynamic symbolic shape resolution, optional tensor ABIs, early-return control flow, mutable vector operands, and integer shift promotion for packed quantization formats.

These fixes are not H100-only workarounds, TileKernels source specializations, or version-specific shims. The H100/CUDA/CuTeDSL environment is the reproducer that exposes the missing backend coverage. The underlying problems are semantic mismatches between TileLang TIR lowering and the current CuTeDSL Python/codegen path.

## Fixes

### Complete scan lowering for TileKernels

TileKernels MoE routing uses `T.cumsum` over shared buffers with more than one warp-sized segment. The previous CuTeDSL `CumSum1D` path only handled a single warp-local scan, so expert offsets reset at later 32-element chunks and routing positions overlapped.

This PR aligns the CuTeDSL scan helpers with the CUDA inclusive scan behavior by scanning 32-element segments with carry propagation. The same helper is used for `CumSum1D`, `CumMax1D`, and 2D row/column scan paths. The codegen side also adds shared index linearization support for non-flat buffer accesses and lowers `tl.match_any_sync` through the existing CuTeDSL warp intrinsic.

### Resolve dynamic shapes from live tensors

The CuTeDSL adapter previously recorded only the first shape/stride source for each dynamic symbol. That is unsafe when the first source belongs to an optional tensor that is `None` at runtime. In TileKernels `reduce_fused`, this caused `num_tokens` to resolve to `0` even though another live tensor carried the correct shape, resulting in an invalid zero-grid launch.

The adapter now records all candidates for a dynamic symbol and resolves runtime values from the first candidate backed by a live `torch.Tensor`. Missing shape symbols still fail clearly instead of silently using an unsafe value.

### Permit dead optional stride ABI symbols

Some optional tensor variants keep stride-only ABI symbols even after the optional tensor has been pruned out of the lowered device kernel. These symbols are ABI placeholders rather than values used for output allocation or launch dimensions.

This PR keeps shape symbols strict, but allows stride-only dead optional symbols to use a zero placeholder so the generated host call signature remains consistent without weakening dynamic shape correctness.

### Fix optional ABI handling and early-return codegen

TileKernels `top2_sum_gate` exposed three additional issues:

- Optional tensors compiled out by static flags could still leave host ABI dynamic shape arguments.
- The early-return rewriter only handled a bare `thread_return`, missing the common pattern where stores occur before the return.
- Vector binary codegen reused SSA aliases for operands containing mutable `BufferLoad` nodes, so later stores were not reflected in subsequent vector expressions.

The fix preserves strict output allocation, allows dead host ABI dynamic placeholders where appropriate, preserves pre-return stores before guarding fallthrough statements, and avoids SSA alias reuse for vector operands that contain buffer loads.

### Promote narrow shifts before widened casts

TileKernels E5M6 quantization packs truncated FP16 values into `uint32` words using expressions such as `T.cast(half_u16[i] << 20, T.uint32)`. CUDA C++ applies integer promotion before the final cast, but CuTeDSL strongly typed integer wrappers previously shifted in the narrow `uint16` type and then widened, dropping the high bits.

When a narrow integer shift is immediately cast to a wider integer type, CuTeDSL codegen now promotes the left operand to the target integer type before shifting. This preserves the intended packed-bit construction and fixes the downstream E5M6 cast-back/per-token quantization corruption.

## Validation

Environment:

- H100 CUDA backend, `sm_90`
- `CUDA_VISIBLE_DEVICES=0` maps to `NVIDIA H100 PCIe` in the local validation environment
- `TILELANG_TARGET=cutedsl`
- `TILELANG_DISABLE_CACHE=1`
- Local TileLang build from this branch
- TileKernels functional suite

Focused TileLang/TileKernels validation covered:

- CuTeDSL scan/codegen tests
- CuTeDSL dynamic symbolic shape adapter regressions
- TileKernels MoE `get_fused_mapping`, `reduce_fused`, `expand_to_fused`, and `top2_sum_gate` representative failures
- TileKernels E5M6 quantization focused cases

Full TileKernels functional run with `-n 2` completed with:

```text
7 failed, 36736 passed, 10165 skipped
```

The remaining 7 failures were all `torch.OutOfMemoryError` in large `test_swiglu_backward_and_per_token_cast` configurations under two-worker concurrency. They were rerun on a single H100 worker and all passed:

```text
7 passed, 16 warnings in 114.34s
```

This indicates the remaining full-run failures are H100 memory pressure under concurrent execution, not CuTeDSL correctness failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added math operations: `log1p`, `abs2`, `max2`, `min2`, and `isfinite`.
  * Introduced warp-level primitives: `__shfl_xor_sync`, `__match_any_sync`, and `__popc`.
  * Added `sync_warp` and `runtime_assert` utilities for device synchronization and assertions.

* **Improvements**
  * Enhanced FP8 and FP4 floating-point type support with improved casting and materialization.
  * Improved JIT compilation's dynamic shape and stride resolution for tensors.
  * Optimized grid synchronization with generation-based barrier protocol.
  * Extended reduction operations with improved cumulative sum and max implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->