### PR TITLE
Fix eager AST handling for *args and **kwargs

### DIFF
--- a/testing/python/language/test_tilelang_language_eager_ast_signature.py
+++ b/testing/python/language/test_tilelang_language_eager_ast_signature.py
@@ -1,0 +1,29 @@
+from tilelang.language.eager.ast import BaseBuilder, mutate
+
+
+class _TestBuilder(BaseBuilder):
+    def override(self, name: str):
+        if name == "range":
+            return range
+        return super().override(name)
+
+    def set_fileline(self, filename: str, lineno: int, name: str):
+        pass
+
+
+def test_mutate_accepts_varargs_parameter():
+    def first_arg(*args):
+        return args[0]
+
+    ir_gen = mutate(first_arg)
+
+    assert ir_gen.gen(_TestBuilder())("sentinel", "ignored") == "sentinel"
+
+
+def test_mutate_preserves_kwargs_parameter():
+    def get_kwarg(**kwargs):
+        return kwargs["key"]
+
+    ir_gen = mutate(get_kwarg)
+
+    assert ir_gen.gen(_TestBuilder())(key="value") == "value"

--- a/tilelang/language/eager/ast.py
+++ b/tilelang/language/eager/ast.py
@@ -469,8 +469,10 @@ class DSLMutator(ast.NodeTransformer):
         arg_names = set()
         all_args = node.args.posonlyargs + node.args.args
         if node.args.vararg is not None:
-            all_args += node.args.vararg
+            all_args.append(node.args.vararg)
         all_args += node.args.kwonlyargs
+        if node.args.kwarg is not None:
+            all_args.append(node.args.kwarg)
         for arg in all_args:
             name = arg.arg
             arg_names.add(name)
@@ -487,7 +489,8 @@ class DSLMutator(ast.NodeTransformer):
         node.body = stmts + node.body
         node.decorator_list.clear()
         name = node.name
-        node.args.kwarg = ast.arg(arg="__kwargs")
+        if node.args.kwarg is None:
+            node.args.kwarg = ast.arg(arg="__kwargs")
         node = SpanAttacher("__tb_fl", "__tb_fn").visit(node)
         return quote1(
             f"def make_closure({', '.join(self.nonlocals.keys())}):\n"


### PR DESCRIPTION
### Summary

Fix the eager AST mutator's handling of Python variadic parameters.

`ast.arguments.vararg` and `ast.arguments.kwarg` are optional single `ast.arg` objects, not iterables. The existing code used `all_args += node.args.vararg`, which crashes with:

```text
TypeError: 'arg' object is not iterable
```

This affects `@tilelang.jit` functions with `*args`, including lazy-style wrappers that still pass through `mutate(func)` during `jit` initialization.

### Changes

- Use `append()` for `node.args.vararg`.
- Include `node.args.kwarg` in the collected argument list when present.
- Preserve a user-provided `**kwargs` parameter instead of overwriting it with TileLang's internal `**__kwargs` sink.
- Add a lightweight regression test for `mutate()` with `*args` and `**kwargs` signatures.

### Validation

- Reproduced against `v0.1.10` source on Python 3.12.12:

```text
Exception: TypeError 'arg' object is not iterable
  v0.1.10/tilelang/language/eager/ast.py:472 in visit_FunctionDef: all_args += node.args.vararg
```

- Verified patched `mutate()` path with Python 3.12.12 using a lightweight AST harness:

```text
first_arg: sentinel
get_kwarg: value
first signature preserved: True
kwargs signature preserved: True
```

- Built and installed TileLang locally from this branch in a fresh venv on Python 3.12 using shallow/partial submodule checkout:

```text
USE_CUDA=OFF USE_ROCM=OFF USE_METAL=ON /tmp/tilelang-pr-verify/bin/python -m pip install . -v
Successfully built tilelang
Successfully installed tilelang-0.1.10+gite200cbdb
```

- Ran:

```text
python -m compileall -q tilelang/language/eager/ast.py testing/python/language/test_tilelang_language_eager_ast_signature.py
git diff --check -- tilelang/language/eager/ast.py testing/python/language/test_tilelang_language_eager_ast_signature.py
/tmp/tilelang-pr-verify/bin/python -m pytest testing/python/language/test_tilelang_language_eager_ast_signature.py -q
/tmp/tilelang-pr-verify/bin/python -m pytest testing/python/language/test_tilelang_language_augassign.py -q
/tmp/tilelang-pr-verify/bin/python -m pytest testing/python/language/test_tilelang_language_eager_jit.py::test_jit2_compile_with_consts -q
```

Fixes #2329


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DSL function signature handling to conditionally include and preserve `*args` and `**kwargs` parameters, preventing unintended injection of default kwargs when user-defined variants exist.

* **Tests**
  * Added test module with comprehensive coverage for varargs and kwargs parameter handling in DSL function definitions, verifying correct IR generator behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->