### PR TITLE
Remove unused 'customized_code' from the exported symbols in IRBuilder

### DIFF
--- a/tilelang/language/ast/ir.py
+++ b/tilelang/language/ast/ir.py
@@ -2027,7 +2027,6 @@ __all__ = [
     "env_thread",
     "buffer_store",
     "prefetch",
-    "customized_code",
     "evaluate",
     "boolean",
     "handle",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated module exports by removing a previously exported symbol to clean up the public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->