### PR TITLE
[BugFix] Fix eager JIT sub-btye shape binding

### DIFF
--- a/examples/deepseek_v4/fp8_fp4_gemm_1d1d_sm100.py
+++ b/examples/deepseek_v4/fp8_fp4_gemm_1d1d_sm100.py
@@ -2,7 +2,6 @@
 
 import argparse
 from typing import Tuple
-from functools import lru_cache
 import torch
 import tilelang
 import tilelang.language as T
@@ -14,19 +13,21 @@ def _ceil_div(x: int, y: int) -> int:
     return (x + y - 1) // y
 
 
-def _make_fp8_fp4_gemm_1d1d_prim_func(
+@tilelang.jit(out_idx=[4])
+def fp8_fp4_gemm_1d1d_persistent(
     M: int,
     N: int,
     K: int,
-    block_M: int,
-    block_N: int,
-    block_K: int,
     out_dtype,
-    accum_dtype,
-    num_stages: int,
-    sf_granularity_k: int = 128,
-    store_block_N: int = 64,
 ):
+    block_M = 128
+    block_N = 256
+    block_K = 128
+    accum_dtype = T.float32
+    num_stages = 6
+    sf_granularity_k = 128
+    store_block_N = 64
+
     assert block_M == 128
     assert block_N == 256
     assert block_K == 128
@@ -57,6 +58,8 @@ def _make_fp8_fp4_gemm_1d1d_prim_func(
             cta_id = T.block_rank_in_cluster()
             T.assume(cta_id < 2)
 
+            # Use T.float4_e2m1_unpacked for A_shared, rather than T.float4_e2m1fn as a hint
+            # for TileLang to use desired layout for blockscaled tcgen5mma.
             A_shared = T.alloc_shared((num_stages, block_M, block_K), T.float4_e2m1_unpacked)
             B_shared = T.alloc_shared((num_stages, half_N, block_K), T.float8_e4m3fn)
             SFA_shared = T.alloc_shared((num_stages, block_M), "uint32")
@@ -142,7 +145,7 @@ def _make_fp8_fp4_gemm_1d1d_prim_func(
                                 transpose_B=True,
                                 mbar=consumed[stage],
                                 clear_accum=k == 0,
-                                k_start=k * block_K,
+                                k_start=k * block_K,  # global K offset (to help compiler infer sf_id)
                                 sf_a_granularity_k=sf_granularity_k,
                                 sf_b_granularity_k=sf_granularity_k,
                                 use_2cta=True,
@@ -184,32 +187,6 @@ def _make_fp8_fp4_gemm_1d1d_prim_func(
                             T.copy(C_shared, D[bx * block_M, by * block_N + i * store_block_N])
 
     return main
-
-
-@lru_cache(maxsize=None)
-def _compile_fp8_fp4_gemm_1d1d(
-    M: int,
-    N: int,
-    K: int,
-    out_dtype,
-):
-    program = _make_fp8_fp4_gemm_1d1d_prim_func(
-        M,
-        N,
-        K,
-        128,
-        256,
-        128,
-        out_dtype,
-        T.float32,
-        6,
-        128,
-    )
-    # NOTE(wt): Work around the @tilelang.jit wrapper's current packed-FP4 ABI check:
-    # T.float4_e2m1fn logical [M, K] inputs are passed as int8 [M, K / 2].
-    # See https://github.com/tile-ai/tilelang/issues/2292.
-
-    return tilelang.compile(program, out_idx=[4])
 
 
 def _align_up(x: int, y: int) -> int:
@@ -373,7 +350,7 @@ def run_fp8_fp4_gemm_1d1d(
     assert m % (2 * block_M) == 0, f"M={m} must be divisible by {2 * block_M}"
     assert n % (32 * block_N) == 0, f"N={n} must be divisible by {32 * block_N}"
     assert k % (2 * block_K) == 0, f"K={k} must be divisible by {2 * block_K}"
-    kernel = _compile_fp8_fp4_gemm_1d1d(m, n, k, out_dtype)
+    kernel = fp8_fp4_gemm_1d1d_persistent(m, n, k, out_dtype)
     return kernel(a_fp4, b_fp8, sfa, sfb)
 
 
@@ -408,7 +385,7 @@ def benchmark(M=512, N=8192, K=8192, seed=0, warmup=25, rep=100):
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument("--M", type=int, default=1024)
+    parser.add_argument("--M", type=int, default=8192)
     parser.add_argument("--N", type=int, default=8192)
     parser.add_argument("--K", type=int, default=8192)
     parser.add_argument("--seed", type=int, default=0)

--- a/testing/python/issue/test_tilelang_issue_2292.py
+++ b/testing/python/issue/test_tilelang_issue_2292.py
@@ -1,0 +1,75 @@
+import torch
+
+import tilelang
+import tilelang.language as T
+
+
+@tilelang.jit(
+    out_idx=None,
+    execution_backend="tvm_ffi",
+    pass_configs={"tl.disable_data_race_check": True},
+)
+def _fp4_eager_kernel(A):
+    M, K = T.const("M K")
+    A: T.Tensor((M, K), T.float4_e2m1fn)
+    with T.Kernel(1, threads=32):
+        T.evaluate(A[0, 0])
+
+
+@tilelang.jit(
+    out_idx=None,
+    execution_backend="tvm_ffi",
+    pass_configs={"tl.disable_data_race_check": True},
+)
+def _fp4_eager_strided_kernel(A):
+    M, K, S = T.const("M K S")
+    A: T.StridedTensor((M, K), (S, 1), T.float4_e2m1fn)
+    with T.Kernel(1, threads=32):
+        T.evaluate(A[0, 0])
+
+
+@tilelang.jit(
+    out_idx=None,
+    execution_backend="tvm_ffi",
+    pass_configs={"tl.disable_data_race_check": True},
+)
+def _fp4_lazy_kernel():
+    @T.prim_func
+    def main(A: T.Tensor((256, 512), T.float4_e2m1fn)):
+        with T.Kernel(1, threads=32):
+            T.evaluate(A[0, 0])
+
+    return main
+
+
+def _assert_runs_packed_fp4_storage(kernel, dtype):
+    tensor = torch.empty((256, 256), dtype=dtype, device="cuda")
+    kernel(tensor)
+    torch.cuda.synchronize()
+
+
+def _assert_accepts_packed_fp4_storage(kernel):
+    assert torch.cuda.is_available()
+    assert hasattr(torch, "float4_e2m1fn_x2")
+
+    _assert_runs_packed_fp4_storage(kernel, torch.int8)
+    _assert_runs_packed_fp4_storage(kernel, torch.uint8)
+    _assert_runs_packed_fp4_storage(kernel, torch.float4_e2m1fn_x2)
+
+
+def test_eager_jit_binds_logical_shape_for_packed_fp4_tensor():
+    _assert_accepts_packed_fp4_storage(_fp4_eager_kernel)
+
+
+def test_lazy_jit_accepts_packed_fp4_tensor():
+    _assert_accepts_packed_fp4_storage(_fp4_lazy_kernel())
+
+
+def test_eager_jit_binds_logical_stride_for_packed_fp4_tensor():
+    packed = torch.empty((512, 256), dtype=torch.int8)[::2, :]
+
+    prim_func = _fp4_eager_strided_kernel.get_tir(packed)
+    buffer = next(iter(prim_func.buffer_map.values()))
+
+    assert list(buffer.shape) == [256, 512]
+    assert list(buffer.strides) == [1024, 1]

--- a/tilelang/language/eager/builder.py
+++ b/tilelang/language/eager/builder.py
@@ -1042,18 +1042,31 @@ class TirTemplate(Generic[_P, _T]):
         if self.matcher is None:
             return ()
         result = []
+        buffers = {param.name: buffer for param, buffer in self.prim_func.buffer_map.items()}
         for k, ty, i, name in self.matcher.values():
             if name in kwargs:
                 result.append(kwargs.get(name))
             elif k in kwargs:
                 if ty == "shape":
-                    result.append(kwargs[k].shape[i])
+                    value = kwargs[k]
+                    shape = value.shape[i]
+                    buffer = buffers[k]
+                    if not isinstance(value, Buffer) and i == len(buffer.shape) - 1 and buffer.dtype.bits * buffer.dtype.lanes < 8:
+                        # Runtime tensors store sub-byte dtypes packed; constexprs need the logical extent.
+                        runtime_dtype = dt.dtype(value.dtype)
+                        shape = shape * runtime_dtype.bits * runtime_dtype.lanes // (buffer.dtype.bits * buffer.dtype.lanes)
+                    result.append(shape)
                 elif ty == "stride":
                     v = kwargs[k]
                     if isinstance(v, Buffer):
                         result.append(v.strides[i])
                     else:
-                        result.append(kwargs[k].stride()[i])
+                        stride = v.stride()[i]
+                        buffer = buffers[k]
+                        if i != len(buffer.strides) - 1 and buffer.dtype.bits * buffer.dtype.lanes < 8:
+                            runtime_dtype = dt.dtype(v.dtype)
+                            stride = stride * runtime_dtype.bits * runtime_dtype.lanes // (buffer.dtype.bits * buffer.dtype.lanes)
+                        result.append(stride)
             else:
                 raise ValueError(
                     f"Cannot find value for constexpr variable `{name}`\n"

--- a/tilelang/language/eager/builder.py
+++ b/tilelang/language/eager/builder.py
@@ -48,6 +48,39 @@ def unwrap_expr(expr) -> PrimExpr | int | float:
     return expr
 
 
+def _dtype_total_bits(dtype: dt.dtype) -> int:
+    return dtype.bits * dtype.lanes
+
+
+def _packed_storage_factor(buffer: Buffer, value) -> int:
+    if isinstance(value, Buffer):
+        return 1
+
+    logical_bits = _dtype_total_bits(buffer.dtype)
+    if logical_bits >= 8:
+        return 1
+
+    storage_dtype = dt.dtype(value.dtype)
+    return _dtype_total_bits(storage_dtype) // logical_bits
+
+
+def _logical_shape_value(value, buffer: Buffer, dim: int):
+    shape = value.shape[dim]
+    if dim == len(buffer.shape) - 1:
+        shape *= _packed_storage_factor(buffer, value)
+    return shape
+
+
+def _logical_stride_value(value, buffer: Buffer, dim: int):
+    if isinstance(value, Buffer):
+        return value.strides[dim]
+
+    stride = value.stride()[dim]
+    if dim != len(buffer.strides) - 1:
+        stride *= _packed_storage_factor(buffer, value)
+    return stride
+
+
 def unwrap_cond(expr):
     """
     unwrap expr and convert to bool condition
@@ -1047,26 +1080,12 @@ class TirTemplate(Generic[_P, _T]):
             if name in kwargs:
                 result.append(kwargs.get(name))
             elif k in kwargs:
+                value = kwargs[k]
+                buffer = buffers[k]
                 if ty == "shape":
-                    value = kwargs[k]
-                    shape = value.shape[i]
-                    buffer = buffers[k]
-                    if not isinstance(value, Buffer) and i == len(buffer.shape) - 1 and buffer.dtype.bits * buffer.dtype.lanes < 8:
-                        # Runtime tensors store sub-byte dtypes packed; constexprs need the logical extent.
-                        runtime_dtype = dt.dtype(value.dtype)
-                        shape = shape * runtime_dtype.bits * runtime_dtype.lanes // (buffer.dtype.bits * buffer.dtype.lanes)
-                    result.append(shape)
+                    result.append(_logical_shape_value(value, buffer, i))
                 elif ty == "stride":
-                    v = kwargs[k]
-                    if isinstance(v, Buffer):
-                        result.append(v.strides[i])
-                    else:
-                        stride = v.stride()[i]
-                        buffer = buffers[k]
-                        if i != len(buffer.strides) - 1 and buffer.dtype.bits * buffer.dtype.lanes < 8:
-                            runtime_dtype = dt.dtype(v.dtype)
-                            stride = stride * runtime_dtype.bits * runtime_dtype.lanes // (buffer.dtype.bits * buffer.dtype.lanes)
-                        result.append(stride)
+                    result.append(_logical_stride_value(value, buffer, i))
             else:
                 raise ValueError(
                     f"Cannot find value for constexpr variable `{name}`\n"


### PR DESCRIPTION
Resolve #2292

Fix eager `@tilelang.jit` constexpr binding for logical sub-byte tensors backed by packed runtime storage.

  For logical `T.float4_e2m1fn[M, K]`, runtime tensors may be physically packed as `int8/uint8/float4_e2m1fn_x2[M, K / 2]`. Eager JIT phase2 previously inferred constexpr shape/stride directly from the runtime tensor, so it could bind the packed physical extent instead of the logical FP4 extent.

  This updates eager JIT phase2 to convert packed runtime shape/stride back to logical shape/stride for sub-byte dtypes.

  Also removes the packed-FP4 workaround in the DeepSeek v4 FP8xFP4 tcgen5 GEMM example by using a direct top-level `@tilelang.jit(out_idx=[4])` kernel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a persistent JIT kernel path for FP8/FP4 GEMM to improve runtime reuse.

* **Bug Fixes**
  * Corrected shape and stride handling for sub-byte (packed) dtypes in JIT/kernel shape binding.

* **Tests**
  * Added tests covering packed FP4 tensor handling for eager and lazy execution, including stride and shape binding.

* **Chores**
  * Updated default CLI matrix size from 1024 to 8192.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->