### PR TITLE
[BugFix][CPU] Fix buffer region indexing for pipeline-expanded buffers

### DIFF
--- a/tilelang/cpu/op/gemm/gemm_scalar.py
+++ b/tilelang/cpu/op/gemm/gemm_scalar.py
@@ -34,21 +34,26 @@ class GemmScalar(GemmBase):
         accum_dtype = self.accum_dtype
 
         # Region offsets for strided gemm (e.g. T.gemm(A[0:64, :], B, C))
-        a0 = self.ARegion.region[0].min
-        a1 = self.ARegion.region[1].min
-        b0 = self.BRegion.region[0].min
-        b1 = self.BRegion.region[1].min
-        c0 = self.CRegion.region[0].min
-        c1 = self.CRegion.region[1].min
+        # Use negative indexing to correctly handle pipeline-expanded buffers
+        # (e.g. 2D -> 3D after InjectSoftwarePipeline prepends a version axis).
+        a_extra = tuple(r.min for r in self.ARegion.region[:-2])
+        a0 = self.ARegion.region[-2].min
+        a1 = self.ARegion.region[-1].min
+        b_extra = tuple(r.min for r in self.BRegion.region[:-2])
+        b0 = self.BRegion.region[-2].min
+        b1 = self.BRegion.region[-1].min
+        c_extra = tuple(r.min for r in self.CRegion.region[:-2])
+        c0 = self.CRegion.region[-2].min
+        c1 = self.CRegion.region[-1].min
 
         @T.prim_func
         def _gemm_scalar() -> None:
             if clear_accum:
                 T.clear(C_buf)
             for i, j, k in T.grid(M, N, K):
-                C_buf[c0 + i, c1 + j] += T.cast(
-                    A_buf[a0 + (k if trans_A else i), a1 + (i if trans_A else k)]
-                    * B_buf[b0 + (j if trans_B else k), b1 + (k if trans_B else j)],
+                C_buf[c_extra + (c0 + i, c1 + j)] += T.cast(
+                    A_buf[a_extra + (a0 + (k if trans_A else i), a1 + (i if trans_A else k))]
+                    * B_buf[b_extra + (b0 + (j if trans_B else k), b1 + (k if trans_B else j))],
                     accum_dtype,
                 )
 

--- a/tilelang/metal/intrinsics/metal_macro_generator.py
+++ b/tilelang/metal/intrinsics/metal_macro_generator.py
@@ -6,6 +6,8 @@ from tvm.tirx import Buffer, BufferRegion
 
 
 class MPSIntrinEmitter:
+    """Metal simdgroup MMA intrinsic emitter for GEMM operations."""
+
     WARP_SIZE = 32
 
     def __init__(
@@ -22,6 +24,7 @@ class MPSIntrinEmitter:
         chunk: int = 32,
         thread_var: tir.Var | None = None,
     ):
+        """Initialize the Metal simdgroup MMA emitter."""
         self.a_dtype = a_dtype
         self.b_dtype = b_dtype
         self.accum_dtype = accum_dtype
@@ -44,6 +47,7 @@ class MPSIntrinEmitter:
         self.warp_cols = warp_col_tiles // self.micro_size_y
 
     def get_thread_binding(self):
+        """Return the thread index expression for the current kernel."""
         if self.thread_var is None:
             current_frame = T.KernelLaunchFrame.Current()
             assert current_frame is not None, "Must be called in a T.Kernel Frame"
@@ -52,6 +56,7 @@ class MPSIntrinEmitter:
             return self.thread_var
 
     def _get_warp_indices(self):
+        """Compute (warp_m, warp_n) from the current thread binding."""
         thread_binding = self.get_thread_binding()
         WARP_SIZE = self.WARP_SIZE
         block_row_warps = self.block_row_warps
@@ -62,20 +67,28 @@ class MPSIntrinEmitter:
         return warp_m, warp_n
 
     @staticmethod
-    def _parse_buffer_2d(buf):
-        """Extract (buffer, row_offset, col_offset, stride) from Buffer or BufferRegion."""
+    def _parse_buffer_nd(buf):
+        """Extract (buffer, extra_indices, row_offset, col_offset, stride) from Buffer or BufferRegion.
+
+        For 2D buffers, extra_indices is an empty tuple.
+        For 3D+ buffers (e.g. after pipeline expansion), extra_indices contains
+        the leading dimension offsets so callers can index correctly.
+        """
         if isinstance(buf, BufferRegion):
             buffer = buf.buffer
             off_row = buf.region[-2].min
             off_col = buf.region[-1].min
+            extra = tuple(r.min for r in buf.region[:-2])
         else:
             buffer = buf
             off_row = 0
             off_col = 0
+            extra = ()
         stride = buffer.shape[-1]
-        return buffer, off_row, off_col, stride
+        return buffer, extra, off_row, off_col, stride
 
     def ldmatrix_a(self, A_local_buf, A_shared_buf: Buffer | BufferRegion, ki):
+        """Load matrix A tiles from shared memory into simdgroup local buffers."""
         warp_rows = self.warp_rows
         micro_size_x = self.micro_size_x
         micro_size_k = self.micro_size_k
@@ -83,10 +96,11 @@ class MPSIntrinEmitter:
 
         warp_m, _ = self._get_warp_indices()
 
-        buffer, offset_m, offset_k, stride = self._parse_buffer_2d(A_shared_buf)
+        buffer, extra, offset_m, offset_k, stride = self._parse_buffer_nd(A_shared_buf)
 
         @T.macro
         def _warp_ldmatrix_a(A_local_buf, buffer, offset_m, offset_k, stride, warp_m, ki):
+            """Load A matrix tiles via simdgroup_load per warp row."""
             for i in T.serial(warp_rows):
                 if a_transposed:
                     row_idx = offset_k + ki * micro_size_k
@@ -95,7 +109,8 @@ class MPSIntrinEmitter:
                     row_idx = offset_m + warp_m * (self.warp_row_tiles) + i * micro_size_x
                     col_idx = offset_k + ki * micro_size_k
 
-                ptr = T.access_ptr(buffer[row_idx, col_idx], "r")
+                indices = extra + (row_idx, col_idx)
+                ptr = T.access_ptr(buffer[indices], "r")
 
                 T.simdgroup_load(
                     A_local_buf.data,
@@ -110,6 +125,7 @@ class MPSIntrinEmitter:
         return _warp_ldmatrix_a(A_local_buf, buffer, offset_m, offset_k, stride, warp_m, ki)
 
     def ldmatrix_b(self, B_local_buf, B_shared_buf: Buffer | BufferRegion, ki):
+        """Load matrix B tiles from shared memory into simdgroup local buffers."""
         warp_cols = self.warp_cols
         micro_size_y = self.micro_size_y
         micro_size_k = self.micro_size_k
@@ -117,10 +133,11 @@ class MPSIntrinEmitter:
 
         _, warp_n = self._get_warp_indices()
 
-        buffer, offset_k, offset_n, stride = self._parse_buffer_2d(B_shared_buf)
+        buffer, extra, offset_k, offset_n, stride = self._parse_buffer_nd(B_shared_buf)
 
         @T.macro
         def _warp_ldmatrix_b(B_local_buf, buffer, offset_k, offset_n, stride, warp_n, ki):
+            """Load B matrix tiles via simdgroup_load per warp column."""
             for j in T.serial(warp_cols):
                 if b_transposed:
                     row_idx = offset_n + warp_n * (self.warp_col_tiles) + j * micro_size_y
@@ -129,7 +146,8 @@ class MPSIntrinEmitter:
                     row_idx = offset_k + ki * micro_size_k
                     col_idx = offset_n + warp_n * (self.warp_col_tiles) + j * micro_size_y
 
-                ptr = T.access_ptr(buffer[row_idx, col_idx], "r")
+                indices = extra + (row_idx, col_idx)
+                ptr = T.access_ptr(buffer[indices], "r")
 
                 T.simdgroup_load(
                     B_local_buf.data,
@@ -144,11 +162,13 @@ class MPSIntrinEmitter:
         return _warp_ldmatrix_b(B_local_buf, buffer, offset_k, offset_n, stride, warp_n, ki)
 
     def mma(self, A_local_buf, B_local_buf, C_local_buf):
+        """Perform simdgroup matrix multiply-accumulate: C += A * B."""
         warp_rows = self.warp_rows
         warp_cols = self.warp_cols
 
         @T.macro
         def _warp_mma(A_local_buf, B_local_buf, C_local_buf):
+            """Execute simdgroup matrix multiply-accumulate across all warp tiles."""
             for i, j in T.grid(warp_rows, warp_cols):
                 T.simdgroup_multiply_accumulate(
                     C_local_buf.data,
@@ -164,6 +184,7 @@ class MPSIntrinEmitter:
         return _warp_mma(A_local_buf, B_local_buf, C_local_buf)
 
     def simdgroup_copy(self, C_simd_buf, C_dst, is_store=True):
+        """Copy between simdgroup local buffers and shared/global memory."""
         warp_rows = self.warp_rows
         warp_cols = self.warp_cols
         micro_size_x = self.micro_size_x
@@ -171,23 +192,25 @@ class MPSIntrinEmitter:
 
         warp_m, warp_n = self._get_warp_indices()
 
-        buffer, offset_m, offset_n, stride = self._parse_buffer_2d(C_dst)
+        buffer, extra, offset_m, offset_n, stride = self._parse_buffer_nd(C_dst)
 
         simd_op = T.simdgroup_store if is_store else T.simdgroup_load
         access_mode = "w" if is_store else "r"
 
         @T.macro
         def _simdgroup_copy(C_simd_buf, buffer, offset_m, offset_n, stride, warp_m, warp_n):
+            """Copy tiles between simdgroup local and shared memory."""
             for i, j in T.grid(warp_rows, warp_cols):
                 row = offset_m + warp_m * self.warp_row_tiles + i * micro_size_x
                 col = offset_n + warp_n * self.warp_col_tiles + j * micro_size_y
 
                 index_c = i * warp_cols + j
 
+                indices = extra + (row, col)
                 simd_op(
                     C_simd_buf.data,
                     index_c,
-                    T.access_ptr(buffer[row, col], access_mode),
+                    T.access_ptr(buffer[indices], access_mode),
                     stride,
                     micro_size_x,
                     micro_size_y,
@@ -197,7 +220,9 @@ class MPSIntrinEmitter:
         return _simdgroup_copy(C_simd_buf, buffer, offset_m, offset_n, stride, warp_m, warp_n)
 
     def simd_store(self, C_simd_buf, C_dst):
+        """Store simdgroup local buffer to shared/global memory."""
         return self.simdgroup_copy(C_simd_buf, C_dst, is_store=True)
 
     def simd_load(self, C_simd_buf, C_src):
+        """Load shared/global memory into simdgroup local buffer."""
         return self.simdgroup_copy(C_simd_buf, C_src, is_store=False)


### PR DESCRIPTION
## Summary

- Fix `GemmScalar.lower()` using forward indexing (`region[0]`, `region[1]`) instead of negative indexing (`region[-2]`, `region[-1]`) for BufferRegion offsets
- After `InjectSoftwarePipeline` expands a 2D buffer to 3D, `region[0]` points to the pipeline version axis instead of the row axis, causing incorrect memory access

## Root Cause

`gemm_scalar.py` lines 37-42 used `self.ARegion.region[0].min` / `region[1].min` to extract row/column offsets. This is the same class of bug as [the Metal fix](https://github.com/tile-ai/tilelang/pull/2325) — forward indexing breaks when pipeline expansion prepends a dimension.

## Fix

Switch to negative indexing and collect leading dimensions via `region[:-2]`:

```python
# Before
a0 = self.ARegion.region[0].min
a1 = self.ARegion.region[1].min
C_buf[c0 + i, c1 + j] += ...

# After
a_extra = tuple(r.min for r in self.ARegion.region[:-2])
a0 = self.ARegion.region[-2].min
a1 = self.ARegion.region[-1].min
C_buf[c_extra + (c0 + i, c1 + j)] += ...
```

## Test plan

- [x] 3/3 existing CPU GEMM tests pass
- [x] Ruff lint and format check pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scalar GEMM lowering to correctly compute region offsets for pipeline-expanded buffer shapes
* **Improvements**
  * Enhanced Metal intrinsics to support multi-dimensional tensor operations beyond 2D matrices in load/store operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->