### PR TITLE
[Fix][Pipeline] Prevent double expansion of shared buffers across sibling pipelines

### DIFF
--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -360,6 +360,44 @@ private:
         CollectUsedPipelineBuffers(MakePipelineBody(pipeline_body_stmts),
                                    buffer_data_to_buffer_, allocated_buffers_);
 
+    // Filter out buffers that have already been expanded by a previous
+    // sibling pipeline.  When two T.Pipelined loops share the same
+    // alloc_shared buffer but request different num_stages, the first
+    // pipeline expands the buffer (e.g. (64,32) → (2,64,32)).  The
+    // second pipeline would then try to expand the already-3D buffer
+    // again, producing a 4D buffer and crashing LayoutInference.
+    //
+    // Fix: skip re-expansion for already-expanded buffers.  The second
+    // pipeline will still add version indexing via buffer_remap_, but
+    // using the existing shape[0] (the first pipeline's num_stages).
+    {
+      // Build reverse map: expanded → original for all pending remaps.
+      std::unordered_map<Buffer, Buffer, ObjectPtrHash, ObjectPtrEqual>
+          expanded_to_original;
+      for (const auto &[orig, expanded] : pending_buffer_remap_) {
+        expanded_to_original[expanded] = orig;
+      }
+      Array<Buffer> filtered_allocs;
+      for (const auto &buf : pipeline_allocs) {
+        auto it = expanded_to_original.find(buf);
+        if (it != expanded_to_original.end()) {
+          // Buffer was already expanded by a previous pipeline.
+          // Add an identity remap so the second pipeline's version
+          // indexing is still applied (using the existing shape[0]).
+          already_expanded_buffer_remaps_.Set(buf, buf);
+          LOG(WARNING) << "Buffer " << buf->name
+                       << " is shared across sibling Pipelined loops with "
+                          "different num_stages.  The second loop will reuse "
+                          "the existing pipeline expansion ("
+                       << buf->shape[0]
+                       << " versions) instead of re-expanding.";
+        } else {
+          filtered_allocs.push_back(buf);
+        }
+      }
+      pipeline_allocs = std::move(filtered_allocs);
+    }
+
     Optional<Array<Integer>> replayable_bind_mask;
     if (auto replayable_bind_anno =
             op->annotations.Get(kPipelineReplayableScalarBinds)) {
@@ -653,6 +691,14 @@ private:
     PipelineRewriteResult rewrite_result = RewritePipeline(
         buffer_data_to_buffer_, pipeline_allocs, local_allocs, for_node,
         pipeline_info, scalar_binding_blocks, target_);
+
+    // Merge identity remaps for already-expanded buffers so the second
+    // pipeline's version indexing is applied to the existing buffer.
+    for (const auto &[buf, _] : already_expanded_buffer_remaps_) {
+      rewrite_result.buffer_remap.Set(buf, buf);
+    }
+    already_expanded_buffer_remaps_.clear();
+
     Stmt pipeline = rewrite_result.pipeline;
     subtree_modified_ = true;
 
@@ -957,6 +1003,7 @@ private:
   Map<Var, Buffer> buffer_data_to_buffer_;
   std::unordered_set<Buffer, ObjectPtrHash, ObjectPtrEqual> allocated_buffers_;
   Map<Buffer, Buffer> pending_buffer_remap_;
+  Map<Buffer, Buffer> already_expanded_buffer_remaps_;
   std::vector<std::pair<Buffer, Buffer>> pending_layout_remapped_allocs_;
   Optional<Target> target_;
   Optional<String> global_symbol_;


### PR DESCRIPTION
## Summary

- Fix LayoutInference crash when two sibling `T.Pipelined` loops share the same `alloc_shared` buffer but use different `num_stages`
- Fixes #2309

## Root Cause

When two `T.Pipelined` loops share `A_shared`/`B_shared` buffers with different `num_stages` (e.g. 2 and 4):

1. First pipeline expands `A_shared` from `(64,32)` to `(2,64,32)` via `RewriteAllocBuffer`
2. `buffer_data_to_buffer_` is updated to point to the expanded buffer
3. Second pipeline's `CollectUsedPipelineBuffers` picks up the expanded `(2,64,32)` buffer
4. `RewriteAllocBuffer` inserts another dimension, producing `(4,2,64,32)` — a 4D buffer
5. `LayoutInference` crashes: `ICHECK` fails comparing `(2,64,32)` input shape with `(4,64,32)` expected shape

## Fix

After collecting `pipeline_allocs`, build a reverse map from `pending_buffer_remap_` to detect buffers already expanded by a previous sibling pipeline. Such buffers are:

1. **Removed** from `pipeline_allocs` to prevent double expansion
2. **Identity-remapped** (`buf → buf`) in `rewrite_result.buffer_remap` so the second pipeline's version indexing is still applied to the existing expanded buffer

The second pipeline reuses the existing pipeline dimension (first pipeline's `num_stages`) and emits a warning.

## Test plan

- [x] Reproducer from #2309 compiles successfully (previously crashed)
- [x] 27/27 existing Metal + CPU tests pass (no regression)
- [x] `make -j8` builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of pipeline buffer reuse to prevent redundant processing and to more reliably track previously-expanded buffers; a warning is logged when reuse is detected. No user-visible changes in this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->