### PR TITLE
[TIR][Transform] Partition parallel loops with fragment access

### DIFF
--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -1335,8 +1335,9 @@ private:
 
     auto root = GetRef<For>(op);
 
-    // Check if the loop writes to any non-local buffer.
-    // Thread partitioning is unnecessary when all stores target local buffers.
+    // Check if the loop writes to any non-local buffer or touches a fragment.
+    // Thread partitioning is unnecessary when all stores target local buffers
+    // and there are no fragment accesses.
     // For example:
     //   for i in T.Parallel(1024):
     //     A_local[i] = A_global[i]
@@ -1351,8 +1352,16 @@ private:
     // Element-level intrinsics (e.g. atomic_add) pass non-local buffer
     // pointers via tvm_access_ptr / tl::access_ptr inside CallNodes.
     bool has_non_local_store = false;
+    bool has_fragment_access = false;
     PostOrderVisit(root, [&](const ObjectRef &obj) {
-      if (const auto *store = obj.as<BufferStoreNode>()) {
+      if (const auto *load = obj.as<BufferLoadNode>()) {
+        if (IsFragmentBuffer(load->buffer)) {
+          has_fragment_access = true;
+        }
+      } else if (const auto *store = obj.as<BufferStoreNode>()) {
+        if (IsFragmentBuffer(store->buffer)) {
+          has_fragment_access = true;
+        }
         if (!IsLocalBuffer(store->buffer)) {
           has_non_local_store = true;
         }
@@ -1363,13 +1372,21 @@ private:
           if (buffer_var) {
             Var var = GetRef<Var>(buffer_var);
             auto it = buffer_map_.find(var);
-            if (it != buffer_map_.end() && !IsLocalBuffer(it->second)) {
-              has_non_local_store = true;
+            if (it != buffer_map_.end()) {
+              if (IsFragmentBuffer(it->second)) {
+                has_fragment_access = true;
+              }
+              if (!IsLocalBuffer(it->second)) {
+                has_non_local_store = true;
+              }
             }
           }
         } else if (call->op.same_as(tl::access_ptr())) {
           // tl::access_ptr format: (BufferLoad, extent, rw_mask)
           if (const auto *load = call->args[0].as<BufferLoadNode>()) {
+            if (IsFragmentBuffer(load->buffer)) {
+              has_fragment_access = true;
+            }
             if (!IsLocalBuffer(load->buffer)) {
               has_non_local_store = true;
             }
@@ -1378,6 +1395,9 @@ private:
           // call_extern may pass address_of(non-local-buffer) pointers, and
           // PostOrderVisit reaches the address_of call directly.
           if (const auto *load = call->args[0].as<BufferLoadNode>()) {
+            if (IsFragmentBuffer(load->buffer)) {
+              has_fragment_access = true;
+            }
             if (!IsLocalBuffer(load->buffer)) {
               has_non_local_store = true;
             }
@@ -1386,10 +1406,11 @@ private:
       }
     });
 
-    // Determine if this is a true parallel loop requiring thread
-    // partitioning: parallel_loop = True if we need to partition the loop.
-    // Skip partitioning for loops that only have local stores.
-    bool parallel_loop = has_non_local_store;
+    // Determine if this loop requires thread partitioning. Fragment accesses
+    // must be partitioned together with their layout rewrite: once a logical
+    // fragment index is lowered to a physical per-thread slot, the logical loop
+    // iteration has to be owned by the corresponding thread.
+    bool parallel_loop = has_non_local_store || has_fragment_access;
 
     // Check if there are non-local buffer accesses (for vectorization decision)
     bool has_non_local = false;

--- a/testing/python/issue/test_tilelang_issue_2307.py
+++ b/testing/python/issue/test_tilelang_issue_2307.py
@@ -1,0 +1,40 @@
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tvm.target import Target
+
+
+def _get_issue_2307_source() -> str:
+    @T.prim_func
+    def main(score: T.Tensor((16,), T.float32)):
+        with T.Kernel(1, threads=32):
+            score_fragment = T.alloc_fragment(32, T.float32)
+            for i in T.Parallel(32):
+                if i < 16:
+                    score_fragment[i] = score[i]
+                else:
+                    score_fragment[i] = T.infinity(T.float32)
+            for i in T.Parallel(32):
+                if i < 16:
+                    T.device_assert(T.isfinite(score_fragment[i]))
+
+    target = Target("cuda")
+    with target:
+        artifact = tilelang.lower(main, target=target)
+    return artifact.kernel_source
+
+
+@tilelang.testing.requires_cuda
+def test_fragment_read_assert_parallel_loop_is_partitioned():
+    src = _get_issue_2307_source()
+    lines = src.splitlines()
+    assert "for (int i = 0; i < 32; ++i)" not in src
+
+    assert_idx = next(i for i, line in enumerate(lines) if "device_assert_with_msg" in line)
+    context = "\n".join(lines[max(0, assert_idx - 4) : assert_idx + 1])
+    assert "threadIdx.x) < 16" in context
+    assert "isfinite(score_fragment[0])" in context
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

- Partition `T.Parallel` loops whenever they access `local.fragment` buffers.
- Fixes fragment physicalization for read-only loops such as fragment-backed device assertions.

## Changes

- Track fragment loads and stores while deciding whether a parallel loop needs thread partitioning.
- Keep the existing non-local store partitioning behavior.
- Add an issue regression test covering a fragment read inside `T.device_assert`.

## Validation

- `./format.sh`
- `cmake --build build -j$(nproc)`
- `PYTHONPATH=$PWD python -m pytest testing/python/issue/test_tilelang_issue_2307.py testing/python/transform/test_tilelang_transform_layout_inference.py testing/python/language/test_tilelang_language_isfinite_codegen.py testing/python/language/test_tilelang_language_parallel.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed thread partitioning logic in parallel loop optimization to properly account for fragment buffer access patterns, ensuring correct behavior during execution.

* **Tests**
  * Added test coverage for device assertions operating on fragment buffers in parallel kernels to prevent future regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->