### PR TITLE
[TIR][Transform] Warn on local var reads in assume

### DIFF
--- a/src/transform/inject_assumes.cc
+++ b/src/transform/inject_assumes.cc
@@ -12,6 +12,7 @@
 #include "tvm/ir/transform.h"
 #include <tvm/ffi/extra/structural_equal.h>
 #include <tvm/ffi/extra/structural_hash.h>
+#include <tvm/runtime/logging.h>
 #include <tvm/tirx/builtin.h>
 #include <tvm/tirx/expr.h>
 #include <tvm/tirx/op.h>
@@ -19,7 +20,10 @@
 #include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/transform.h>
 
+#include <algorithm>
 #include <sstream>
+#include <unordered_map>
+#include <vector>
 
 namespace tvm::tl {
 using namespace tirx;
@@ -178,6 +182,7 @@ private:
       //      ...
       //    }
       if (auto e = GetAssumeExprInEvaluateForm(stmt)) {
+        WarnIfAssumeReadsLocalVar(*e);
         groups.push_back(AssumeGroup{*e, {}});
       } else {
         groups.back().stmts.push_back(stmt);
@@ -199,6 +204,44 @@ private:
     return groups[0].stmts.size() == 1 ? groups[0].stmts[0]
                                        : SeqStmt(groups[0].stmts);
     // return SeqStmt(groups[0].stmts);
+  }
+
+  static std::vector<Buffer> CollectLocalVarBufferLoads(const PrimExpr &expr) {
+    std::vector<Buffer> buffers;
+    PostOrderVisit(expr, [&](const ffi::ObjectRef &obj) {
+      const auto *load = obj.as<BufferLoadNode>();
+      if (!load || load->buffer.scope() != "local.var") {
+        return;
+      }
+      if (std::none_of(buffers.begin(), buffers.end(), [&](const Buffer &b) {
+            return b.same_as(load->buffer);
+          })) {
+        buffers.push_back(load->buffer);
+      }
+    });
+    return buffers;
+  }
+
+  static void WarnIfAssumeReadsLocalVar(const PrimExpr &expr) {
+    std::vector<Buffer> buffers = CollectLocalVarBufferLoads(expr);
+    if (buffers.empty()) {
+      return;
+    }
+
+    std::stringstream ss;
+    for (size_t i = 0; i < buffers.size(); ++i) {
+      if (i) {
+        ss << ", ";
+      }
+      ss << "`" << buffers[i]->name << "`";
+    }
+    LOG(WARNING)
+        << "T.assume condition reads from T.alloc_var/local.var buffer "
+        << ss.str()
+        << ". local.var is mutable, so this assumption may not be propagated "
+           "to later memory-access proofs. If the value is not mutated, use an "
+           "immutable expression binding instead of T.alloc_var. Condition: "
+        << expr;
   }
 
   Stmt VisitStmt_(const SBlockNode *op) final {

--- a/testing/python/transform/test_tilelang_transform_inject_assumes.py
+++ b/testing/python/transform/test_tilelang_transform_inject_assumes.py
@@ -1,0 +1,44 @@
+from tilelang import tvm
+import tilelang as tl
+import tilelang.language as T
+import tilelang.testing
+
+
+def _run_inject_assumes(func: tvm.tirx.PrimFunc):
+    mod = tvm.IRModule.from_expr(func.with_attr("global_symbol", "main"))
+    return tl.transform.InjectAssumes()(mod)
+
+
+def test_inject_assumes_warns_on_local_var_assume(capfd):
+    @T.prim_func
+    def main(A: T.Tensor((128,), T.float32), l: T.int32):
+        with T.Kernel(1, threads=32):
+            x = T.alloc_var(T.int32)
+            x = l
+            T.assume(x >= 0 and x < 128)
+            A[x] = T.float32(0.0)
+
+    _run_inject_assumes(main)
+
+    captured = capfd.readouterr()
+    output = captured.out + captured.err
+    assert "T.assume condition reads from T.alloc_var/local.var buffer `x`" in output
+    assert "local.var is mutable" in output
+
+
+def test_inject_assumes_does_not_warn_on_scalar_assume(capfd):
+    @T.prim_func
+    def main(A: T.Tensor((128,), T.float32), x: T.int32):
+        with T.Kernel(1, threads=32):
+            T.assume(x >= 0 and x < 128)
+            A[x] = T.float32(0.0)
+
+    _run_inject_assumes(main)
+
+    captured = capfd.readouterr()
+    output = captured.out + captured.err
+    assert "T.assume condition reads from T.alloc_var/local.var buffer" not in output
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

- Warn when a user `T.assume` condition reads from a `T.alloc_var`/`local.var` buffer, since mutable values may not propagate reliably into later memory-access proofs.
- Keep ordinary scalar `T.assume` conditions silent.

## Changes

- Scan user assume expressions during `InjectAssumes` conversion and collect unique `local.var` buffer loads.
- Emit a warning that names the local var buffer, includes the condition, and suggests using an immutable binding when the value is not mutated.
- Add transform tests for the local-var warning and scalar no-warning cases.

## Validation

- `./format.sh`
- `cmake --build build -j$(nproc)`
- `python -m pytest testing/python/transform/test_tilelang_transform_inject_assumes.py -q`
- `python -m pytest testing/python/language/test_tilelang_language_assume.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * System now emits warnings when assumption conditions reference local mutable buffers, alerting users to conditions that may not propagate through subsequent memory access validations.

* **Tests**
  * Added comprehensive test coverage for assumption injection with validation of warning generation and non-warning scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->