### PR TITLE
[Transform] Validate fragment write owner compatibility

### DIFF
--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -257,6 +257,7 @@ void ParallelOpNode::RecordBufferAccess(const Buffer &buffer,
     BufferAccessInfo info;
     info.indices = indices;
     it = indice_map_.emplace(buffer, std::move(info)).first;
+    access_order_.push_back(buffer);
   }
   if (is_write) {
     it->second.is_write = true;
@@ -337,7 +338,8 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
     // for i in T.Parallel(m):
     //   fragment[0] = x[i]
     // then fragment[0] must be replicated on all threads.
-    for (const auto &[buffer, access] : indice_map_) {
+    for (const auto &buffer : access_order_) {
+      const auto &access = GetAccessInfo(buffer);
       if (T.layout_map.count(buffer)) {
         continue;
       }
@@ -387,7 +389,8 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
 
   // Collect fragment buffers with const index and all fragment_buffers
   std::vector<Buffer> const_index_fragment_buffer, fragment_buffers;
-  for (const auto &[buffer, access] : indice_map_) {
+  for (const auto &buffer : access_order_) {
+    const auto &access = GetAccessInfo(buffer);
     if (!IsFragmentBuffer(buffer))
       continue;
     fragment_buffers.push_back(buffer);
@@ -421,7 +424,8 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
   Buffer source_buffer, read_source_buffer;
   Buffer replicated_write_buffer; // Backup: fully replicated write buffer
 
-  for (const auto &[buffer, access] : indice_map_) {
+  for (const auto &buffer : access_order_) {
+    const auto &access = GetAccessInfo(buffer);
     if (T.layout_map.count(buffer)) {
       // skip reducers with rep=ALL
       if (auto info = reducer_info_map_.Get(buffer->data);
@@ -560,7 +564,7 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
 
   // Step 4: Collect buffer fragments
   LayoutMap results;
-  for (const auto &[buffer, access] : indice_map_) {
+  for (const auto &buffer : access_order_) {
     if (!T.layout_map.count(buffer)) {
       auto dst_layout =
           CompleteBufferFragment(buffer)->BindThreadRange(T.thread_bounds);
@@ -640,7 +644,8 @@ bool ParallelOpNode::ValidateCandidateAgainstFragments(
     bool check_forward_index, const Buffer &source_buffer) const {
   auto vars =
       loop_vars_.Map([](const IterVar &iv) { return PrimExpr(iv->var); });
-  for (const auto &[buffer, access] : indice_map_) {
+  for (const auto &buffer : access_order_) {
+    const auto &access = GetAccessInfo(buffer);
     if (!T.layout_map.count(buffer))
       continue;
     if (auto info = reducer_info_map_.Get(buffer->data);

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -665,9 +665,14 @@ bool ParallelOpNode::ValidateCandidateAgainstFragments(
       }
       success = false;
     }
+    // Fragment writes need exact owner-thread compatibility. Coverage alone
+    // allows extra loop threads to write local slots that belong to different
+    // logical fragment elements under the buffer layout.
     if (access.is_write &&
-        !ProveFragmentContains(fragment, candidate, access.indices, vars,
-                               analyzer_, check_forward_index)) {
+        (!ProveFragmentContains(fragment, candidate, access.indices, vars,
+                                analyzer_, check_forward_index) ||
+         !ProveFragmentContains(candidate, fragment, vars, access.indices,
+                                analyzer_, check_forward_index))) {
       if (throw_on_error) {
         oss << "Layout infer conflict between " << buffer << " and "
             << source_buffer << " in T.Parallel loop:" << '\n'

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -11,6 +11,7 @@
 #include <tvm/tirx/stmt_functor.h>
 
 #include <unordered_map>
+#include <vector>
 
 #include "../layout/layout.h"
 #include "../layout/utils.h"
@@ -121,6 +122,8 @@ public:
   For GetRoot() const { return root_; }
   // Get the mapping from buffer to access indices + access type.
   const BufferIndiceMap &GetIndiceMap() const { return indice_map_; }
+  // Get buffers in the order they first appear in the loop body.
+  const std::vector<Buffer> &GetAccessOrder() const { return access_order_; }
   // Get the predicate for a given thread variable.
   Optional<PrimExpr> GetPredicate(Var thread_var) const;
 
@@ -184,6 +187,9 @@ private:
   ParallelLoopNestVisitor V;
   // Mapping from buffer to their access indices and access type in the loop.
   BufferIndiceMap indice_map_;
+  // Stable first-use order for indice_map_.  Layout inference must not depend
+  // on std::unordered_map iteration order when selecting source buffers.
+  std::vector<Buffer> access_order_;
   // The loop variables for the parallel loop nest.
   Array<IterVar> loop_vars_;
   // The inner_vars_

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -668,7 +668,7 @@ private:
   void VisitStmt_(const ForNode *op) final {
     if (op->kind == ForKind::kParallel) {
       auto infer = ParallelOp(GetRef<For>(op));
-      for (const auto &[buffer, _] : infer->GetIndiceMap()) {
+      for (const auto &buffer : infer->GetAccessOrder()) {
         addToUseList(buffer);
       }
 

--- a/testing/python/layout/test_tilelang_layout_inference.py
+++ b/testing/python/layout/test_tilelang_layout_inference.py
@@ -1,5 +1,6 @@
 import tilelang
 import tilelang.testing
+import pytest
 from tilelang import language as T
 
 
@@ -30,6 +31,33 @@ def test_tilelang_issue_layout_free_inference_choose_smallest_replication():
     assert "float S_frag[4];" in source, "S_frag is not in the source"
     assert "float B_frag[4];" in source, "B_frag is not in the source"
     assert "float A_frag[4];" in source, "A_frag is not in the source"
+
+
+@tilelang.jit
+def _invalid_fragment_write_owner_layout():
+    def token_loop_layout_fn(i, j, rep):
+        return i * 4 + rep % 4 + (rep // 4) * 32, j
+
+    def scalar_buffer_layout_fn(i, j, rep):
+        return i * 4 + j + rep * 32, 0
+
+    loop_layout = T.Fragment((8, 4), forward_fn=token_loop_layout_fn, replicate=8)
+    buffer_layout = T.Fragment((8, 4), forward_fn=scalar_buffer_layout_fn, replicate=2)
+
+    @T.prim_func
+    def main():
+        with T.Kernel(1, threads=64):
+            frag = T.alloc_fragment((8, 4), T.float32)
+            T.annotate_layout({frag: buffer_layout})
+            for i, j in T.Parallel(8, 4, loop_layout=loop_layout):
+                frag[i, j] = T.float32(1.0)
+
+    return main
+
+
+def test_reject_fragment_write_from_non_owner_threads():
+    with pytest.raises(Exception, match="Layout infer conflict"):
+        _invalid_fragment_write_owner_layout()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Reject `T.Parallel` fragment writes when the loop layout can execute non-owner threads for a fragment buffer element.
- Stabilize parallel layout inference by preserving first-access buffer order when choosing and validating inferred layouts.
- Prevent fp4 scale fragments from compiling into layouts that silently overwrite per-channel local scale bytes.

## Changes

- Track fragment buffer accesses in first-seen order instead of iterating an `unordered_map` during inference.
- Validate fragment writes with bidirectional owner-thread containment so buffer owners are covered and loop writers are all legal owners.
- Add a layout inference regression test for an explicitly annotated scalar-channel fragment layout that used to pass and overwrite local storage.

## Validation

- `pre-commit run --all-files`
- `cmake --build build -j$(nproc)`
- `python -m pytest testing/python/layout/test_tilelang_layout_inference.py -q`
- `python debug/repro_fp4_explicit_layout.py` (expected `Layout infer conflict`)
- `PYTHONUNBUFFERED=1 timeout 45s python debug/cache.py` (timed out after multiple `correctness test passed` iterations, with no assertion or traceback)

## Risk

- This intentionally makes some previously accepted fragment write layouts fail at compile time when loop writer threads are not exactly compatible with the buffer layout owner threads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened write-side compatibility validation for fragment buffers to ensure stricter correctness checks.

* **Tests**
  * Added validation test to detect invalid fragment writes from non-owner threads, improving error detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->