### PR TITLE
[BugFix] Reject T.alloc_barrier() on pre-Hopper targets with a clear error

### DIFF
--- a/testing/python/target/test_tilelang_alloc_barrier_target_guard.py
+++ b/testing/python/target/test_tilelang_alloc_barrier_target_guard.py
@@ -1,0 +1,71 @@
+import pytest
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+CUDA_SM86_TARGET = {"kind": "cuda", "arch": "sm_86"}
+CUDA_SM90_TARGET = {"kind": "cuda", "arch": "sm_90"}
+
+
+def _barrier_kernel():
+    """A minimal kernel whose only special feature is a shared barrier."""
+
+    @T.prim_func
+    def main(C: T.Tensor((1,), "float32")):
+        with T.Kernel(1, threads=1) as _:
+            bar = T.alloc_barrier(1)  # noqa: F841
+            C[0] = 0.0
+
+    return main
+
+
+def _no_barrier_kernel():
+    """The same minimal kernel without any barrier, used as a control."""
+
+    @T.prim_func
+    def main(C: T.Tensor((1,), "float32")):
+        with T.Kernel(1, threads=1) as _:
+            C[0] = 0.0
+
+    return main
+
+
+def _compile(target, kernel_factory=_barrier_kernel):
+    """Compile a freshly built kernel for ``target`` with caching disabled."""
+    tilelang.disable_cache()
+    try:
+        return tilelang.compile(kernel_factory(), out_idx=-1, target=target)
+    finally:
+        tilelang.enable_cache()
+
+
+@tilelang.testing.requires_cuda
+def test_alloc_barrier_rejected_on_pre_hopper_target():
+    """T.alloc_barrier() must be rejected with a clear error on sm_86 instead of
+    emitting sm_90-only code that fails later inside nvcc."""
+    with pytest.raises(ValueError) as exc_info:
+        _compile(CUDA_SM86_TARGET)
+
+    message = str(exc_info.value)
+    assert "requires sm_90" in message
+    assert "sm_86" in message
+    # Names the offending primitives so users know what to remove.
+    assert "tl_shuffle_elect" in message or "Barrier" in message
+
+
+@tilelang.testing.requires_cuda
+def test_no_barrier_compiles_on_pre_hopper_target():
+    """The guard must not fire for pre-Hopper kernels that use no barrier."""
+    _compile(CUDA_SM86_TARGET, kernel_factory=_no_barrier_kernel)
+
+
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_alloc_barrier_allowed_on_hopper_target():
+    """The guard must not regress sm_90, where T.alloc_barrier() is valid."""
+    _compile(CUDA_SM90_TARGET)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/contrib/nvcc.py
+++ b/tilelang/contrib/nvcc.py
@@ -595,6 +595,19 @@ def have_pdl(target):
     return major >= 9
 
 
+def have_mbarrier(target):
+    """Whether hardware mbarrier support (the cutlass Barrier type,
+    tl_shuffle_elect, fence_barrier_init) is available on the target.
+
+    Available on Hopper (sm_90) and later architectures.
+    """
+    if target.kind.name != "cuda":
+        return False
+    compute_version = get_target_compute_version(target)
+    major, minor = parse_compute_version(compute_version)
+    return major >= 9
+
+
 def get_nvcc_compiler() -> str:
     """Get the path to the nvcc compiler"""
     return os.path.join(find_cuda_path(), "bin", "nvcc")

--- a/tilelang/cuda/pipeline.py
+++ b/tilelang/cuda/pipeline.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from tvm import IRModule, s_tir, tirx
 from tvm.target import Target
+from tvm.tirx import PrimFunc, SBlock
+from tvm.tirx.stmt_functor import post_order_visit
 
 import tilelang
 from tilelang.backend.pass_pipeline.pipeline import PassPipeline, register_pipeline
@@ -13,7 +15,12 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
     should_enable_race_check,
     should_force_let_inline,
 )
-from tilelang.contrib.nvcc import have_pdl, have_tma
+from tilelang.contrib.nvcc import (
+    get_target_compute_version,
+    have_mbarrier,
+    have_pdl,
+    have_tma,
+)
 from tilelang.transform import PassContext
 
 
@@ -37,6 +44,25 @@ def module_has_tma(mod: IRModule) -> bool:
     copies were actually generated.
     """
     return any(func.attrs and func.attrs.get("tl.has_tma", False) for _, func in mod.functions.items())
+
+
+def _module_has_shared_barrier(mod: IRModule) -> bool:
+    """Whether any function allocates a shared.barrier / shared.cluster_barrier
+    buffer (i.e. uses ``T.alloc_barrier``).
+    """
+    found = False
+
+    def visit(node):
+        nonlocal found
+        if isinstance(node, SBlock):
+            for buffer in node.alloc_buffers:
+                if buffer.scope() in ("shared.barrier", "shared.cluster_barrier"):
+                    found = True
+
+    for _, func in mod.functions.items():
+        if isinstance(func, PrimFunc):
+            post_order_visit(func.body, visit)
+    return found
 
 
 def CUDAPassPipelineBodyPrologue(mod: IRModule, target: Target) -> IRModule:
@@ -126,6 +152,20 @@ def CUDAPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     # Buffer allocation placement is handled uniformly for both paths.
     mod = tilelang.transform.PlanAndUpdateBufferAllocationLocation()(mod)
     # @CUDA-specific
+    # LowerSharedBarrier emits hardware mbarrier code (the cutlass Barrier type,
+    # tl::tl_shuffle_elect, tl::fence_barrier_init) which only exists on sm_90+.
+    # Reject T.alloc_barrier() up front on pre-Hopper targets instead of letting
+    # nvcc fail later with cryptic "identifier 'Barrier' is undefined" errors.
+    if not have_mbarrier(target) and _module_has_shared_barrier(mod):
+        compute_version = get_target_compute_version(target)
+        raise ValueError(
+            f"T.alloc_barrier() requires sm_90 (Hopper) or later, but the current "
+            f"target is sm_{compute_version.replace('.', '')} (compute capability "
+            f"{compute_version}). Hardware mbarrier operations (Barrier type, "
+            f"tl_shuffle_elect, fence_barrier_init) are not available on this "
+            f"architecture. Use __syncthreads() or named barriers for pre-Hopper "
+            f"targets."
+        )
     mod = tilelang.cuda.transform.LowerSharedBarrier()(mod)
 
     # @CUDA-specific


### PR DESCRIPTION

## Summary

`T.alloc_barrier()` is lowered by `LowerSharedBarrier` to hardware mbarrier code
— the cutlass `Barrier` type, `tl::tl_shuffle_elect`, and
`tl::fence_barrier_init` — all of which only exist on sm_90+. On a pre-Hopper
target (e.g. sm_86) the frontend accepted the call silently and the failure only
surfaced later inside `nvcc` (before this fix):

```
tvm_kernels.cu(14): error: identifier "Barrier" is undefined
tvm_kernels.cu(15): error: namespace "tl" has no member "tl_shuffle_elect"
tvm_kernels.cu(18): error: namespace "tl" has no member "fence_barrier_init"
```

This adds a static compute-capability guard so the failure surfaces at the
TileLang level with an actionable message instead.

Fixes #2344.

## Root cause

`CUDAPassPipelineBody` runs `LowerSharedBarrier()` unconditionally, with no check
on the target architecture. The primitives it emits resolve to sm_90+ only
constructs — `Barrier` (`cutlass::arch::ClusterTransactionBarrier`) and
`fence_barrier_init` in `src/tl_templates/cuda/barrier.h`, and `tl_shuffle_elect`
(via `cute::elect_one_sync`) in `intrin.h` — so the generated code does not
compile on older targets.

## Fix

A static guard in `tilelang/cuda/pipeline.py`, immediately before
`LowerSharedBarrier`: if the target is `< sm_90` **and** the module actually uses
a shared barrier, raise a `ValueError` that names the offending primitives and
points to `__syncthreads()` / named barriers as the pre-Hopper alternative.

- `have_mbarrier(target)` — a new capability helper in `tilelang.contrib.nvcc`,
  alongside the existing `have_tma` / `have_pdl`; true only for cuda targets with
  compute major `>= 9`.
- `_module_has_shared_barrier(mod)` — walks each function's blocks and checks
  `buffer.scope()` of the `alloc_buffers` for `shared.barrier` /
  `shared.cluster_barrier` (the same way `LowerSharedBarrier` detects them), so
  kernels without a barrier are unaffected.

This is intentionally a reject (option a), not a pre-Hopper lowering fallback
(option b): `T.alloc_barrier()` is a Hopper feature the compiler normally
inserts itself, and the immediate problem is the missing capability check. A
fallback lowering can be a follow-up.

## Test plan

- [x] Added `testing/python/target/test_tilelang_alloc_barrier_target_guard.py`:
  - `test_alloc_barrier_rejected_on_pre_hopper_target` (`@requires_cuda`) —
    compiling a minimal `T.alloc_barrier(1)` kernel to an `sm_86` target raises
    `ValueError` mentioning `requires sm_90` / `sm_86` / the offending primitive.
  - `test_alloc_barrier_allowed_on_hopper_target`
    (`@requires_cuda_compute_version_ge(9, 0)`) — ensures sm_90 still compiles
    (no regression); skipped on pre-Hopper runners.
- [x] `ruff check` / `ruff format --check` clean on the changed files.
- [x] Ran the new test file on an sm_86 box (A10G): the reject test passes
  (full `tilelang.compile` raises the guard `ValueError`); the sm_90 test is
  skipped as expected on non-Hopper hardware. No regression on the sibling
  `target/` codegen tests.
- [x] `have_mbarrier` returns the right answer across sm_75/80/86/89 (reject)
  and sm_90/90a/100/100a (allow).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation that prevents using shared/barrier allocation on CUDA targets lacking hardware support and provides a clear error indicating the required compute capability.

* **Tests**
  * Added tests verifying barrier-allocation rejection on older CUDA architectures, successful compilation without barriers, and successful barrier allocation on newer architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->