### PR TITLE
[Feature]Add JIT diagnostics and configurable NVCC timeout

### DIFF
--- a/testing/python/jit/test_tilelang_jit_diagnostics.py
+++ b/testing/python/jit/test_tilelang_jit_diagnostics.py
@@ -1,0 +1,263 @@
+import logging
+import subprocess
+
+import tilelang.testing
+import pytest
+
+
+@pytest.fixture
+def capture_tilelang_logs():
+    import tilelang  # noqa: F401
+
+    tilelang_logger = logging.getLogger("tilelang")
+    old_propagate = tilelang_logger.propagate
+    tilelang_logger.propagate = True
+    try:
+        yield
+    finally:
+        tilelang_logger.propagate = old_propagate
+
+
+class _FakeProcess:
+    returncode = 0
+
+    def __init__(self):
+        self.killed = False
+
+    def communicate(self, timeout=None):
+        if timeout == 0.25:
+            raise subprocess.TimeoutExpired(["nvcc"], timeout)
+        return b"", None
+
+    def kill(self):
+        self.killed = True
+
+
+class _HangingProcess:
+    returncode = 0
+
+    def communicate(self, timeout=None):
+        if timeout is not None:
+            raise subprocess.TimeoutExpired(["nvcc"], timeout, output=b"simulated nvcc hang")
+        return b"simulated nvcc hang cleaned up", None
+
+    def kill(self):
+        pass
+
+
+class _ScriptableFunc:
+    attrs = {"global_symbol": "cache_diag_kernel"}
+
+    def script(self, show_meta=True):
+        return "cache_diag_kernel"
+
+
+def _make_cuda_compile_probe():
+    from tilelang import language as T
+
+    @T.prim_func
+    def add_one(a: T.Tensor((128,), "float32"), b: T.Tensor((128,), "float32")):
+        with T.Kernel(1, threads=128) as _:
+            i = T.get_thread_binding(0)
+            b[i] = a[i] + 1.0
+
+    return add_one
+
+
+def test_jit_phase_logs_start_done_and_context(caplog, capture_tilelang_logs):
+    from tilelang.jit.diagnostics import jit_phase
+
+    caplog.set_level(logging.INFO, logger="tilelang.jit.diagnostics")
+
+    with jit_phase("unit.phase", enabled=True, kernel="kernel_a", target="cuda -arch=sm_120"):
+        pass
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("TileLang JIT phase start: unit.phase" in message for message in messages)
+    assert any("TileLang JIT phase done: unit.phase" in message for message in messages)
+    assert any("kernel_a" in message and "sm_120" in message for message in messages)
+
+
+def test_jit_phase_logs_failure_and_preserves_exception(caplog, capture_tilelang_logs):
+    from tilelang.jit.diagnostics import jit_phase
+
+    caplog.set_level(logging.INFO, logger="tilelang.jit.diagnostics")
+
+    with pytest.raises(ValueError, match="boom"):
+        with jit_phase("unit.failure", enabled=True, backend="tvm_ffi"):
+            raise ValueError("boom")
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("TileLang JIT phase failed: unit.failure" in message for message in messages)
+    assert any("backend='tvm_ffi'" in message or '"backend": "tvm_ffi"' in message for message in messages)
+
+
+def test_jit_phase_is_silent_when_disabled(caplog, capture_tilelang_logs):
+    from tilelang.jit.diagnostics import jit_phase
+
+    caplog.set_level(logging.INFO, logger="tilelang.jit.diagnostics")
+
+    with jit_phase("unit.silent", enabled=False):
+        pass
+
+    assert not caplog.records
+
+
+def test_nvcc_compile_cuda_honors_tilelang_timeout(monkeypatch):
+    from tilelang.contrib import nvcc
+
+    fake_proc = _FakeProcess()
+
+    monkeypatch.setenv("TILELANG_COMPILE_TIMEOUT_SECONDS", "0.25")
+    monkeypatch.setattr(nvcc.env, "TILELANG_CLEANUP_TEMP_FILES", "0")
+    monkeypatch.setattr(nvcc, "get_nvcc_compiler", lambda: "nvcc")
+    monkeypatch.setattr(nvcc, "get_target_compute_version", lambda target=None: "12.0")
+    monkeypatch.setattr(nvcc, "get_target_arch", lambda compute_version: "120")
+    monkeypatch.setattr(nvcc, "get_nvcc_subprocess_env", lambda: None)
+    monkeypatch.setattr(nvcc.subprocess, "Popen", lambda *args, **kwargs: fake_proc)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        nvcc.compile_cuda("__global__ void kernel() {}", target_format="ptx", verbose=False)
+
+    message = str(exc_info.value)
+    assert fake_proc.killed
+    assert "timed out after 0.25 seconds" in message
+    assert "Command:" in message
+    assert "Source:" in message
+
+
+def test_jit_compile_reports_timeout_for_hanging_nvcc(monkeypatch, tmp_path, caplog, capture_tilelang_logs):
+    import tilelang
+    from tilelang.contrib import nvcc
+    from tilelang.env import env
+
+    monkeypatch.setattr(env, "TILELANG_CACHE_DIR", str(tmp_path / "cache"))
+    monkeypatch.setenv("TILELANG_JIT_DIAGNOSTICS", "1")
+    monkeypatch.setenv("TILELANG_COMPILE_TIMEOUT_SECONDS", "0.25")
+    monkeypatch.setattr(nvcc.subprocess, "Popen", lambda *args, **kwargs: _HangingProcess())
+
+    caplog.set_level(logging.INFO, logger="tilelang.jit.diagnostics")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        tilelang.compile(
+            _make_cuda_compile_probe(),
+            out_idx=-1,
+            target={"kind": "cuda", "arch": "sm_120"},
+        )
+
+    message = str(exc_info.value)
+    assert "NVCC compilation timed out after 0.25 seconds" in message
+    assert "Command:" in message
+    assert "Source:" in message
+    assert "Target:" in message
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("TileLang JIT phase start: cache.compile" in message for message in messages)
+    assert any("TileLang JIT phase start: lower" in message for message in messages)
+    assert any("TileLang JIT phase failed: lower" in message for message in messages)
+    assert any("TileLang JIT phase failed: cache.compile" in message for message in messages)
+
+
+def test_compile_timeout_env_parser_accepts_empty_zero_and_positive(monkeypatch):
+    from tilelang.contrib.nvcc import _get_compile_timeout_seconds
+
+    monkeypatch.delenv("TILELANG_COMPILE_TIMEOUT_SECONDS", raising=False)
+    assert _get_compile_timeout_seconds() is None
+
+    monkeypatch.setenv("TILELANG_COMPILE_TIMEOUT_SECONDS", "0")
+    assert _get_compile_timeout_seconds() is None
+
+    monkeypatch.setenv("TILELANG_COMPILE_TIMEOUT_SECONDS", "1.5")
+    assert _get_compile_timeout_seconds() == 1.5
+
+    monkeypatch.setenv("TILELANG_COMPILE_TIMEOUT_SECONDS", "bad")
+    with pytest.raises(ValueError, match="TILELANG_COMPILE_TIMEOUT_SECONDS"):
+        _get_compile_timeout_seconds()
+
+    monkeypatch.setenv("TILELANG_COMPILE_TIMEOUT_SECONDS", "nan")
+    with pytest.raises(ValueError, match="TILELANG_COMPILE_TIMEOUT_SECONDS"):
+        _get_compile_timeout_seconds()
+
+    monkeypatch.setenv("TILELANG_COMPILE_TIMEOUT_SECONDS", "inf")
+    with pytest.raises(ValueError, match="TILELANG_COMPILE_TIMEOUT_SECONDS"):
+        _get_compile_timeout_seconds()
+
+
+def test_kernel_cache_miss_compile_logs_context(monkeypatch, tmp_path, caplog, capture_tilelang_logs):
+    import tilelang.cache.kernel_cache as kernel_cache_mod
+    from tilelang.cache.kernel_cache import KernelCache
+    from tilelang.env import env
+
+    cache_dir = tmp_path / "cache"
+    tmp_dir = tmp_path / "tmp"
+    cache_dir.mkdir()
+    tmp_dir.mkdir()
+    monkeypatch.setattr(env, "TILELANG_CACHE_DIR", str(cache_dir))
+    monkeypatch.setattr(env, "TILELANG_TMP_DIR", str(tmp_dir))
+    monkeypatch.setenv("TILELANG_JIT_DIAGNOSTICS", "1")
+
+    class _FakeKernel:
+        params = []
+        kernel_source = "// device"
+
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("compile failed")
+
+    monkeypatch.setattr(kernel_cache_mod, "JITKernel", _FakeKernel)
+
+    caplog.set_level(logging.INFO, logger="tilelang.jit.diagnostics")
+    cache = KernelCache()
+
+    with pytest.raises(RuntimeError, match="compile failed"):
+        cache.cached(
+            _ScriptableFunc(),
+            out_idx=[],
+            target="cuda -arch=sm_120",
+            target_host=None,
+            execution_backend="tvm_ffi",
+            verbose=False,
+            pass_configs=None,
+            compile_flags=None,
+        )
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any("TileLang JIT phase start: cache.compile" in message for message in messages)
+    assert any("TileLang JIT phase failed: cache.compile" in message for message in messages)
+    assert any("cache_diag_kernel" in message and "sm_120" in message for message in messages)
+
+
+def test_explicit_cuda_arch_source_generation_probe():
+    import tilelang
+    from tilelang import tvm
+    from tilelang.engine.lower import lower as tilelang_lower
+
+    target = tvm.target.Target({"kind": "cuda", "arch": "sm_120"})
+    tilelang.disable_cache()
+    try:
+        with target:
+            artifact = tilelang_lower(
+                _make_cuda_compile_probe(),
+                target=target,
+                enable_device_compile=False,
+            )
+    finally:
+        tilelang.enable_cache()
+
+    assert "__global__" in artifact.kernel_source
+    assert "add_one" in artifact.kernel_source
+
+
+@tilelang.testing.requires_cuda_compute_version_eq(12, 0)
+def test_explicit_cuda_arch_runtime_probe_completes():
+    import tilelang
+    import torch
+
+    kernel = tilelang.compile(
+        _make_cuda_compile_probe(),
+        out_idx=-1,
+        target={"kind": "cuda", "arch": "sm_120"},
+    )
+    x = torch.ones(128, device="cuda", dtype=torch.float32)
+    y = kernel(x)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(y, x + 1)

--- a/testing/python/jit/test_tilelang_jit_diagnostics.py
+++ b/testing/python/jit/test_tilelang_jit_diagnostics.py
@@ -83,9 +83,8 @@ def test_jit_phase_logs_failure_and_preserves_exception(caplog, capture_tilelang
 
     caplog.set_level(logging.INFO, logger="tilelang.jit.diagnostics")
 
-    with pytest.raises(ValueError, match="boom"):
-        with jit_phase("unit.failure", enabled=True, backend="tvm_ffi"):
-            raise ValueError("boom")
+    with pytest.raises(ValueError, match="boom"), jit_phase("unit.failure", enabled=True, backend="tvm_ffi"):
+        raise ValueError("boom")
 
     messages = [record.getMessage() for record in caplog.records]
     assert any("TileLang JIT phase failed: unit.failure" in message for message in messages)

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -24,6 +24,7 @@ from tilelang.utils.language import get_prim_func_name
 from tilelang import env
 from tilelang.jit import JITKernel
 from tilelang.jit.adapter.base import CachedTextSource
+from tilelang.jit.diagnostics import jit_phase
 from tilelang.contrib.hip_resource_info import dump_to_file, load_from_file
 from tilelang import __version__
 import platform
@@ -374,16 +375,26 @@ class KernelCache:
         if verbose:
             self.logger.debug(f"No cached kernel for {get_prim_func_name(func, '<unknown>')}")
         # Compile kernel if cache miss; leave critical section
-        kernel = JITKernel(
-            func,
-            out_idx=out_idx,
-            execution_backend=execution_backend,
-            target=target,
-            target_host=target_host,
+        with jit_phase(
+            "cache.compile",
             verbose=verbose,
-            pass_configs=pass_configs,
-            compile_flags=compile_flags,
-        )
+            kernel=get_prim_func_name(func, "<unknown>"),
+            target=str(target),
+            target_host=str(target_host) if target_host is not None else None,
+            backend=execution_backend,
+            cache_key=key,
+            cache_path=self._get_cache_path(key),
+        ):
+            kernel = JITKernel(
+                func,
+                out_idx=out_idx,
+                execution_backend=execution_backend,
+                target=target,
+                target_host=target_host,
+                verbose=verbose,
+                pass_configs=pass_configs,
+                compile_flags=compile_flags,
+            )
         with self._lock:
             if env.is_cache_enabled():
                 cache_path = self._get_cache_path(key)

--- a/tilelang/contrib/nvcc.py
+++ b/tilelang/contrib/nvcc.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+import math
 import subprocess
 import warnings
 import contextlib
@@ -31,6 +32,23 @@ def get_nvcc_subprocess_env() -> dict[str, str] | None:
     from tilelang.contrib.msvc import get_msvc_subprocess_env
 
     return get_msvc_subprocess_env()
+
+
+def _get_compile_timeout_seconds() -> float | None:
+    value = os.environ.get("TILELANG_COMPILE_TIMEOUT_SECONDS", "").strip()
+    if not value:
+        return None
+    try:
+        timeout = float(value)
+    except ValueError as exc:
+        raise ValueError(
+            "TILELANG_COMPILE_TIMEOUT_SECONDS must be empty or a non-negative number"
+        ) from exc
+    if not math.isfinite(timeout) or timeout < 0:
+        raise ValueError(
+            "TILELANG_COMPILE_TIMEOUT_SECONDS must be empty or a non-negative number"
+        )
+    return timeout if timeout > 0 else None
 
 
 def _resolve_artifact_paths(temp, file_name, target_format, kernels_output_dir=None):
@@ -128,7 +146,25 @@ def compile_cuda(code, target_format="ptx", arch=None, options=None, path_target
     else:
         proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=compiler_env)
 
-    (out, _) = proc.communicate()
+    timeout = _get_compile_timeout_seconds()
+    try:
+        (out, _) = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        proc.kill()
+        try:
+            out, _ = proc.communicate()
+        except Exception:
+            out = exc.output or b""
+        captured = py_str(out or b"")
+        msg = (
+            f"NVCC compilation timed out after {timeout} seconds.\n"
+            f"Command: {' '.join(cmd)}\n"
+            f"Source: {temp_code}\n"
+            f"Target: {file_target}\n"
+        )
+        if captured:
+            msg += f"Output:\n{captured}\n"
+        raise RuntimeError(msg) from exc
 
     if verbose:
         print(py_str(out))

--- a/tilelang/contrib/nvcc.py
+++ b/tilelang/contrib/nvcc.py
@@ -41,13 +41,9 @@ def _get_compile_timeout_seconds() -> float | None:
     try:
         timeout = float(value)
     except ValueError as exc:
-        raise ValueError(
-            "TILELANG_COMPILE_TIMEOUT_SECONDS must be empty or a non-negative number"
-        ) from exc
+        raise ValueError("TILELANG_COMPILE_TIMEOUT_SECONDS must be empty or a non-negative number") from exc
     if not math.isfinite(timeout) or timeout < 0:
-        raise ValueError(
-            "TILELANG_COMPILE_TIMEOUT_SECONDS must be empty or a non-negative number"
-        )
+        raise ValueError("TILELANG_COMPILE_TIMEOUT_SECONDS must be empty or a non-negative number")
     return timeout if timeout > 0 else None
 
 
@@ -156,12 +152,7 @@ def compile_cuda(code, target_format="ptx", arch=None, options=None, path_target
         except Exception:
             out = exc.output or b""
         captured = py_str(out or b"")
-        msg = (
-            f"NVCC compilation timed out after {timeout} seconds.\n"
-            f"Command: {' '.join(cmd)}\n"
-            f"Source: {temp_code}\n"
-            f"Target: {file_target}\n"
-        )
+        msg = f"NVCC compilation timed out after {timeout} seconds.\nCommand: {' '.join(cmd)}\nSource: {temp_code}\nTarget: {file_target}\n"
         if captured:
             msg += f"Output:\n{captured}\n"
         raise RuntimeError(msg) from exc

--- a/tilelang/jit/diagnostics.py
+++ b/tilelang/jit/diagnostics.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+import logging
+import os
+import time
+
+logger = logging.getLogger("tilelang.jit.diagnostics")
+
+
+def diagnostics_enabled(*, verbose: bool = False) -> bool:
+    value = os.environ.get("TILELANG_JIT_DIAGNOSTICS", "0")
+    return bool(verbose) or value.lower() in ("1", "true", "yes", "on")
+
+
+def _format_context(context: dict[str, object]) -> str:
+    if not context:
+        return ""
+    parts = [f"{key}={value!r}" for key, value in sorted(context.items())]
+    return " " + ", ".join(parts)
+
+
+@contextmanager
+def jit_phase(
+    name: str, *, enabled: bool | None = None, verbose: bool = False, **context: object
+) -> Iterator[None]:
+    if enabled is None:
+        enabled = diagnostics_enabled(verbose=verbose)
+    if not enabled:
+        yield
+        return
+
+    context_msg = _format_context(context)
+    start = time.monotonic()
+    logger.info("TileLang JIT phase start: %s%s", name, context_msg)
+    try:
+        yield
+    except Exception:
+        elapsed = time.monotonic() - start
+        logger.exception("TileLang JIT phase failed: %s elapsed=%.3fs%s", name, elapsed, context_msg)
+        raise
+    else:
+        elapsed = time.monotonic() - start
+        logger.info("TileLang JIT phase done: %s elapsed=%.3fs%s", name, elapsed, context_msg)

--- a/tilelang/jit/diagnostics.py
+++ b/tilelang/jit/diagnostics.py
@@ -22,9 +22,7 @@ def _format_context(context: dict[str, object]) -> str:
 
 
 @contextmanager
-def jit_phase(
-    name: str, *, enabled: bool | None = None, verbose: bool = False, **context: object
-) -> Iterator[None]:
+def jit_phase(name: str, *, enabled: bool | None = None, verbose: bool = False, **context: object) -> Iterator[None]:
     if enabled is None:
         enabled = diagnostics_enabled(verbose=verbose)
     if not enabled:

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -22,6 +22,7 @@ from tilelang.profiler import Profiler, TensorSupplyType
 from tilelang.utils.target import determine_target
 from tilelang.contrib import nvcc as tl_nvcc
 from tilelang.contrib.hip_resource_info import pop_recorded, reset_recorder
+from tilelang.jit.diagnostics import jit_phase
 from tilelang.transform import PassConfigKey
 from tilelang.transform.pass_config import normalize_pass_configs
 import logging
@@ -244,7 +245,16 @@ class JITKernel(Generic[_P, _T]):
         capture_resources = is_hip_target(target)
         if capture_resources:
             reset_recorder()
-        with tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=pass_instruments), self.target:
+        func_name = tilelang_func.attrs.get("global_symbol", "<unknown>")
+        phase_context = {
+            "kernel": func_name,
+            "target": str(target),
+            "target_host": str(target_host) if target_host is not None else None,
+            "backend": execution_backend,
+        }
+        with jit_phase("lower", verbose=verbose, **phase_context), tvm.transform.PassContext(
+            opt_level=3, config=pass_configs, instruments=pass_instruments
+        ), self.target:
             artifact = tilelang.lower(
                 tilelang_func,
                 target=target,
@@ -255,12 +265,17 @@ class JITKernel(Generic[_P, _T]):
 
         self.artifact = artifact
 
+        def create_adapter(adapter_cls: Callable[..., BaseKernelAdapter], **kwargs: Any) -> BaseKernelAdapter:
+            with jit_phase("adapter", verbose=verbose, **phase_context):
+                return adapter_cls(**kwargs)
+
         # Create an adapter based on the specified execution backend.
         if execution_backend == "tvm_ffi":
             # Use TVMFFIKernelAdapter for interoperability with PyTorch via DLPack.
             # But we need to ensure that the runtime is enabled and the runtime module is not None.
             assert artifact.rt_mod is not None, "tvm_ffi backend requires a runtime module."
-            adapter = TVMFFIKernelAdapter(
+            adapter = create_adapter(
+                TVMFFIKernelAdapter,
                 params=artifact.params,
                 result_idx=out_idx,
                 target=target,
@@ -274,7 +289,8 @@ class JITKernel(Generic[_P, _T]):
                 compile_flags=compile_flags,
             )
         elif execution_backend == "cython":
-            adapter = CythonKernelAdapter(
+            adapter = create_adapter(
+                CythonKernelAdapter,
                 params=artifact.params,
                 result_idx=out_idx,
                 target=target,
@@ -289,7 +305,8 @@ class JITKernel(Generic[_P, _T]):
         elif execution_backend == "nvrtc":
             from tilelang.jit.adapter import NVRTCKernelAdapter
 
-            adapter = NVRTCKernelAdapter(
+            adapter = create_adapter(
+                NVRTCKernelAdapter,
                 params=artifact.params,
                 result_idx=out_idx,
                 target=target,
@@ -303,7 +320,8 @@ class JITKernel(Generic[_P, _T]):
             )
         elif execution_backend == "torch":
             assert is_metal_target(target)
-            adapter = MetalKernelAdapter(
+            adapter = create_adapter(
+                MetalKernelAdapter,
                 params=artifact.params,
                 result_idx=out_idx,
                 # target=target,
@@ -317,7 +335,8 @@ class JITKernel(Generic[_P, _T]):
             )
         elif execution_backend == "cutedsl":
             assert is_cutedsl_target(target)
-            adapter = CuTeDSLKernelAdapter(
+            adapter = create_adapter(
+                CuTeDSLKernelAdapter,
                 params=artifact.params,
                 result_idx=out_idx,
                 target=target,

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -252,9 +252,11 @@ class JITKernel(Generic[_P, _T]):
             "target_host": str(target_host) if target_host is not None else None,
             "backend": execution_backend,
         }
-        with jit_phase("lower", verbose=verbose, **phase_context), tvm.transform.PassContext(
-            opt_level=3, config=pass_configs, instruments=pass_instruments
-        ), self.target:
+        with (
+            jit_phase("lower", verbose=verbose, **phase_context),
+            tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=pass_instruments),
+            self.target,
+        ):
             artifact = tilelang.lower(
                 tilelang_func,
                 target=target,


### PR DESCRIPTION
## Summary

Feature: add JIT diagnostics and configurable NVCC timeout support.

## Changes

- Add lightweight JIT phase diagnostics for:
  - cache-miss compilation
  - lowering
  - adapter construction
- Add `TILELANG_COMPILE_TIMEOUT_SECONDS` for NVCC subprocess compilation.
- Report actionable timeout context, including compiler command, generated source path, and target output path.
- Add regression coverage for:
  - phase logging success/failure
  - cache compile context
  - simulated hanging NVCC subprocess
  - tiny explicit `sm_120` JIT compile/runtime probe

## Example

A minimal JIT kernel used to exercise explicit CUDA target compilation:

```python
import tilelang
from tilelang import language as T


@T.prim_func
def add_one(a: T.Tensor((128,), "float32"), b: T.Tensor((128,), "float32")):
    with T.Kernel(1, threads=128) as _:
        i = T.get_thread_binding(0)
        b[i] = a[i] + 1.0


kernel = tilelang.compile(
    add_one,
    out_idx=-1,
    target={"kind": "cuda", "arch": "sm_120"},
)
```

With diagnostics and timeout enabled:

```bash
TILELANG_JIT_DIAGNOSTICS=1 \
TILELANG_COMPILE_TIMEOUT_SECONDS=180 \
python your_script.py
```

## Notes

If compilation stalls inside the NVCC subprocess path, it now becomes a bounded timeout error. If compilation stalls elsewhere, the phase logs identify which JIT stage is active.

## Test Plan

- [x] `python3 -m py_compile tilelang/jit/diagnostics.py tilelang/jit/kernel.py tilelang/cache/kernel_cache.py tilelang/contrib/nvcc.py testing/python/jit/test_tilelang_jit_diagnostics.py`
- [x] `git diff --check`
- [x] `pytest -q testing/python/jit/test_tilelang_jit_diagnostics.py`
  - Result: `9 passed, 9 warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JIT diagnostics system to track compilation phases and timing (enable via TILELANG_JIT_DIAGNOSTICS)
  * Configurable CUDA compilation timeout to prevent hanging builds (TILELANG_COMPILE_TIMEOUT_SECONDS)
  * More detailed contextual logging for kernel compilation failures

* **Bug Fixes**
  * NVCC compilation timeouts now terminate the compiler process and surface timeout/context info

* **Tests**
  * New diagnostics- and CUDA-focused tests covering phase logs, timeouts, cache-miss logging, and runtime probes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->