### PR TITLE
Fix storage rewrite source codegen test

### DIFF
--- a/testing/python/components/test_storage_rewrite_detect_inplace.py
+++ b/testing/python/components/test_storage_rewrite_detect_inplace.py
@@ -1,6 +1,6 @@
 import tilelang
 import tilelang.testing
-from tilelang import language as T
+from tilelang import language as T, tvm
 
 
 @tilelang.jit
@@ -42,12 +42,13 @@ def _compile_kernel_with_inplace():
 
 
 def _get_device_kernel_script(detect_inplace: bool) -> str:
+    kernel = _compile_kernel_with_inplace if detect_inplace else _compile_kernel_without_inplace
+    pass_configs = {}
     if detect_inplace:
-        kernel = _compile_kernel_with_inplace()
-    else:
-        kernel = _compile_kernel_without_inplace()
-    source = kernel.get_kernel_source()
-    return source
+        pass_configs[tilelang.PassConfigKey.TL_STORAGE_REWRITE_DETECT_INPLACE] = True
+    with tvm.transform.PassContext(config=pass_configs):
+        artifact = tilelang.lower(kernel.get_tir(), target="cuda")
+    return artifact.kernel_source
 
 
 def test_storage_rewrite_detect_inplace_toggle():


### PR DESCRIPTION

## Motivation

This test only checks generated CUDA source strings, but the previous path could fail due to local CUDA compiler/toolkit mismatch before reaching the assertions.


## Summary

- Update `test_storage_rewrite_detect_inplace_toggle` to generate CUDA source via `get_tir()` + `tilelang.lower()`
- Avoid the default JIT `tvm_ffi` path, which triggers unnecessary NVCC cubin compilation
- Keep the same assertions for `TL_STORAGE_REWRITE_DETECT_INPLACE` source output

Fixes #2352.

## Testing

```bash
python -m pytest testing/python/components/test_storage_rewrite_detect_inplace.py -q
python -m pytest testing/python/components -x -q
python -m ruff check testing/python/components/test_storage_rewrite_detect_inplace.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test structure for storage optimization verification to use a unified lower path with conditional configuration while maintaining the same validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->