### PR TITLE
[JIT] Include closure free vars in frontend cache key

### DIFF
--- a/testing/python/cache/test_tilelang_kernel_cache_atomic_save.py
+++ b/testing/python/cache/test_tilelang_kernel_cache_atomic_save.py
@@ -264,6 +264,34 @@ def test_jit_frontend_cache_hit_skips_tir_elaboration(monkeypatch):
     assert "frontend_cached_kernel" in calls[0][0]["function"]
 
 
+def test_frontend_cache_key_includes_closure_vars():
+    import tilelang
+    import tilelang.language as T
+
+    def build(N):
+        @tilelang.jit
+        def make_kernel():
+            M = T.dynamic("M")
+
+            @T.prim_func
+            def kernel(x: T.Tensor[(M, N), T.float32]):
+                with T.Kernel(M):
+                    T.evaluate(0)
+
+            return kernel
+
+        return make_kernel
+
+    j16, j32 = build(16), build(32)
+    d16 = j16._frontend_cache_key_data(j16.func.parse_args()[0])
+    d32 = j32._frontend_cache_key_data(j32.func.parse_args()[0])
+
+    assert d16["source"] == d32["source"]
+    assert d16 != d32
+    assert d16["closure"]["N"] == "16"
+    assert d32["closure"]["N"] == "32"
+
+
 def test_kernel_cache_disk_hit_rejects_entries_missing_sources(cache_dirs, monkeypatch):
     cache = KernelCache()
     key = "missing-source-entry"

--- a/tilelang/jit/__init__.py
+++ b/tilelang/jit/__init__.py
@@ -428,10 +428,25 @@ class JITImpl(Generic[_P, _KP, _T, _Ret]):
         key = (key_args_tuple, key_kwargs_tuple, tuned_key_kwargs_tuple)
         return key
 
+    @staticmethod
+    def _frontend_closure_data(orig_func: Any) -> dict[str, str] | None:
+        freevars = getattr(getattr(orig_func, "__code__", None), "co_freevars", None)
+        closure = getattr(orig_func, "__closure__", None)
+        if not freevars or not closure:
+            return None
+        result: dict[str, str] = {}
+        for name, cell in zip(freevars, closure):
+            try:
+                result[name] = repr(cell.cell_contents)
+            except Exception:
+                result[name] = "<unrepr>"
+        return result
+
     def _frontend_cache_key_data(self, key: tuple) -> dict[str, Any]:
-        func_name = getattr(getattr(self.func, "orig_func", self.func), "__name__", "jit_kernel")
-        func_qualname = getattr(getattr(self.func, "orig_func", self.func), "__qualname__", func_name)
-        func_module = getattr(getattr(self.func, "orig_func", self.func), "__module__", None)
+        orig_func = getattr(self.func, "orig_func", self.func)
+        func_name = getattr(orig_func, "__name__", "jit_kernel")
+        func_qualname = getattr(orig_func, "__qualname__", func_name)
+        func_module = getattr(orig_func, "__module__", None)
         return {
             "function": func_name,
             "qualname": func_qualname,
@@ -440,6 +455,7 @@ class JITImpl(Generic[_P, _KP, _T, _Ret]):
             "signature": str(self.signature),
             "key": repr(key),
             "mode": self.mode,
+            "closure": self._frontend_closure_data(orig_func),
         }
 
     def get_kernel_source(self, *args: _P.args, **kwargs: _P.kwargs) -> str:


### PR DESCRIPTION
tilelang now fail with code like this
```python
import torch
import tilelang
import tilelang.language as T


def build(N):
    @tilelang.jit
    def make_kernel():
        M = T.dynamic("M")

        @T.prim_func
        def copy_kernel(
            x: T.Tensor[(M, N), T.float32],
            y: T.Tensor[(M, N), T.float32],
        ):
            with T.Kernel(M, threads=128) as pid:
                for j in T.Parallel(N):
                    y[pid, j] = x[pid, j]

        return copy_kernel

    return make_kernel()


def run(N):
    kernel = build(N)
    x = torch.randn(4, N, device="cuda", dtype=torch.float32)
    y = torch.empty(4, N, device="cuda", dtype=torch.float32)
    kernel(x, y)
    torch.cuda.synchronize()


run(128)
run(256)
```