### PR TITLE
[JIT] Remove frontend disk cache

### DIFF
--- a/testing/python/cache/test_tilelang_kernel_cache_atomic_save.py
+++ b/testing/python/cache/test_tilelang_kernel_cache_atomic_save.py
@@ -56,7 +56,6 @@ def _write_complete_kernel_cache_entry(
     key: str,
     device_source: str = "// device kernel",
     host_source: str = "// host kernel",
-    prim_func=None,
 ) -> Path:
     cache_path = Path(cache._get_cache_path(key))
     cache_path.mkdir(parents=True)
@@ -65,9 +64,6 @@ def _write_complete_kernel_cache_entry(
     (cache_path / cache.kernel_lib_path).write_bytes(b"fake-so")
     with (cache_path / cache.params_path).open("wb") as f:
         cloudpickle.dump(["param"], f)
-    if prim_func is not None:
-        with (cache_path / cache.prim_func_path).open("wb") as f:
-            cloudpickle.dump(prim_func, f)
     return cache_path
 
 
@@ -159,109 +155,45 @@ def test_kernel_cache_disk_hit_perf_skips_large_source_file_reads(cache_dirs, mo
     assert source_read_count == 0
 
 
-def test_kernel_cache_frontend_hit_loads_serialized_prim_func(cache_dirs, monkeypatch):
-    cache = KernelCache()
-    key = "frontend-kernel-key"
-    prim_func = {"name": "cached_prim_func"}
-    cache_path = _write_complete_kernel_cache_entry(cache, key, prim_func=prim_func)
-    cache.store_frontend_cache("frontend-key", key)
-
-    sentinel = object()
-    captured = {}
-
-    def fake_from_database(cls, **kwargs):
-        captured.update(kwargs)
-        return sentinel
-
-    monkeypatch.setattr(kernel_cache_mod.JITKernel, "from_database", classmethod(fake_from_database))
-
-    loaded = cache.load_frontend_cached(
-        "frontend-key",
-        target="cuda",
-        target_host=None,
-        out_idx=[0],
-        execution_backend="tvm_ffi",
-        pass_configs=None,
-        compile_flags=None,
-    )
-
-    assert loaded is sentinel
-    assert captured["func"] == prim_func
-    assert captured["host_kernel_source"] == CachedTextSource(path=str(cache_path / cache.host_kernel_path))
-    assert captured["device_kernel_source"] == CachedTextSource(path=str(cache_path / cache.device_kernel_path))
-
-
-def test_kernel_cache_frontend_hit_round_trips_real_prim_func(cache_dirs, tmp_path, monkeypatch):
-    import tilelang.language as T
-    import tvm
-
-    @T.prim_func
-    def kernel():
-        T.evaluate(0)
-
-    cache = KernelCache()
-    key = "frontend-real-prim-func-key"
-    frontend_key = "frontend-real-prim-func"
-    cache_path = Path(cache._get_cache_path(key))
-
-    cache._save_kernel_to_disk(key, _make_fake_kernel(tmp_path), func=kernel)
-    cache.store_frontend_cache(frontend_key, key)
-
-    sentinel = object()
-    captured = {}
-
-    def fake_from_database(cls, **kwargs):
-        captured.update(kwargs)
-        return sentinel
-
-    monkeypatch.setattr(kernel_cache_mod.JITKernel, "from_database", classmethod(fake_from_database))
-
-    loaded = cache.load_frontend_cached(
-        frontend_key,
-        target="cuda",
-        target_host=None,
-        out_idx=[0],
-        execution_backend="tvm_ffi",
-        pass_configs=None,
-        compile_flags=None,
-    )
-
-    assert loaded is sentinel
-    assert (cache_path / cache.prim_func_path).exists()
-    assert isinstance(captured["func"], tvm.tirx.PrimFunc)
-    assert tvm.ir.structural_equal(captured["func"], kernel)
-    assert str(captured["func"].attrs["global_symbol"]) == str(kernel.attrs["global_symbol"])
-
-
-def test_jit_frontend_cache_hit_skips_tir_elaboration(monkeypatch):
+def test_lazy_jit_closure_specialization_re_elaborates_before_kernel_cache(cache_dirs):
     import tilelang
     import tilelang.language as T
-    from tilelang.jit import JITImpl
+    from tilelang.cache import _dispatch_map
 
-    sentinel = object()
-    calls = []
+    try:
+        import torch
+    except ImportError:
+        pytest.skip("PyTorch is required for CUDA availability checks")
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required to compile the test kernel")
 
-    @tilelang.jit
-    def frontend_cached_kernel(block_m: int = 16):
-        @T.prim_func
-        def kernel():
-            T.evaluate(0)
+    for cache in _dispatch_map.values():
+        cache._memory_cache.clear()
 
-        return kernel
+    def build(n: int):
+        @tilelang.jit
+        def make_kernel():
+            m = T.dynamic("M")
 
-    def fake_load_frontend_cached(frontend_key_data, **kwargs):
-        calls.append((frontend_key_data, kwargs))
-        return sentinel
+            @T.prim_func
+            def copy_kernel(
+                x: T.Tensor[(m, n), T.float32],
+                y: T.Tensor[(m, n), T.float32],
+            ):
+                with T.Kernel(m, threads=128) as pid:
+                    for j in T.Parallel(n):
+                        y[pid, j] = x[pid, j]
 
-    def fail_compile(self, *args, **kwargs):
-        raise AssertionError("frontend cache hit should not elaborate TIR")
+            return copy_kernel
 
-    monkeypatch.setattr("tilelang.cache.load_frontend_cached", fake_load_frontend_cached)
-    monkeypatch.setattr(JITImpl, "compile", fail_compile)
+        return make_kernel()
 
-    assert frontend_cached_kernel(block_m=32) is sentinel
-    assert calls
-    assert "frontend_cached_kernel" in calls[0][0]["function"]
+    kernel_128 = build(128)
+    kernel_256 = build(256)
+
+    assert kernel_128 is not kernel_256
+    assert [tuple(map(str, param.shape)) for param in kernel_128.adapter.params] == [("M", "128"), ("M", "128")]
+    assert [tuple(map(str, param.shape)) for param in kernel_256.adapter.params] == [("M", "256"), ("M", "256")]
 
 
 def test_kernel_cache_disk_hit_rejects_entries_missing_sources(cache_dirs, monkeypatch):

--- a/tilelang/cache/__init__.py
+++ b/tilelang/cache/__init__.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import logging
-import json
-from hashlib import sha256
 from typing import TYPE_CHECKING, Literal
 from tvm.target import Target as TVMTarget
 from tvm.tirx import PrimFunc
@@ -29,16 +27,6 @@ _dispatch_map: dict[str, KernelCache] = {
     "cutedsl": CuTeDSLKernelCache(),
     "torch": TorchKernelCache(),
 }
-
-
-def _normalize_for_json(value):
-    if isinstance(value, dict):
-        return {str(k): _normalize_for_json(v) for k, v in sorted(value.items(), key=lambda item: str(item[0]))}
-    if isinstance(value, (list, tuple)):
-        return [_normalize_for_json(v) for v in value]
-    if isinstance(value, (str, int, float, bool)) or value is None:
-        return value
-    return repr(value)
 
 
 def _resolve_cache_dispatch(
@@ -76,29 +64,6 @@ def _resolve_cache_dispatch(
     return _dispatch_map[resolved_backend], norm_target, resolved_backend, verbose
 
 
-def _make_frontend_cache_key(
-    frontend_key_data: dict,
-    *,
-    target: TVMTarget,
-    target_host: TargetLike | None,
-    execution_backend: str,
-    out_idx: list[int] | int | None,
-    pass_configs: dict | None,
-    compile_flags: list[str] | str | None,
-) -> str:
-    key_data = {
-        "frontend": _normalize_for_json(frontend_key_data),
-        "out_idx": _normalize_for_json(out_idx),
-        "target": str(target),
-        "target_host": str(target_host) if target_host else None,
-        "execution_backend": execution_backend,
-        "pass_configs": _normalize_for_json(pass_configs),
-        "compile_flags": _normalize_for_json(compile_flags),
-    }
-    key_string = json.dumps(key_data, sort_keys=True)
-    return sha256(key_string.encode()).hexdigest()
-
-
 def cached(
     func: PrimFunc = None,
     out_idx: list[int] = None,
@@ -125,64 +90,6 @@ def cached(
         pass_configs=pass_configs,
         compile_flags=compile_flags,
     )
-
-
-def load_frontend_cached(
-    frontend_key_data: dict,
-    *,
-    out_idx: list[int] | int | None = None,
-    target: TargetLike | None = None,
-    target_host: TargetLike | None = None,
-    execution_backend: Literal["auto", "tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"] | None = None,
-    verbose: bool | None = None,
-    pass_configs: dict | None = None,
-    compile_flags: list[str] | str | None = None,
-) -> JITKernel | None:
-    cache, norm_target, execution_backend, verbose = _resolve_cache_dispatch(target, execution_backend, verbose)
-    frontend_key = _make_frontend_cache_key(
-        frontend_key_data,
-        target=norm_target,
-        target_host=target_host,
-        execution_backend=execution_backend,
-        out_idx=out_idx,
-        pass_configs=pass_configs,
-        compile_flags=compile_flags,
-    )
-    return cache.load_frontend_cached(
-        frontend_key,
-        target=norm_target,
-        target_host=target_host,
-        out_idx=out_idx,
-        execution_backend=execution_backend,
-        verbose=verbose,
-        pass_configs=pass_configs,
-        compile_flags=compile_flags,
-    )
-
-
-def store_frontend_cache(
-    frontend_key_data: dict,
-    kernel_key: str,
-    *,
-    out_idx: list[int] | int | None = None,
-    target: TargetLike | None = None,
-    target_host: TargetLike | None = None,
-    execution_backend: Literal["auto", "tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"] | None = None,
-    verbose: bool | None = None,
-    pass_configs: dict | None = None,
-    compile_flags: list[str] | str | None = None,
-) -> None:
-    cache, norm_target, execution_backend, verbose = _resolve_cache_dispatch(target, execution_backend, verbose)
-    frontend_key = _make_frontend_cache_key(
-        frontend_key_data,
-        target=norm_target,
-        target_host=target_host,
-        execution_backend=execution_backend,
-        out_idx=out_idx,
-        pass_configs=pass_configs,
-        compile_flags=compile_flags,
-    )
-    cache.store_frontend_cache(frontend_key, kernel_key, verbose=verbose)
 
 
 def clear_cache():

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -50,10 +50,8 @@ class KernelCache:
     host_kernel_path = "host_kernel.cu"
     kernel_lib_path = "kernel_lib.so"
     params_path = "params.pkl"
-    prim_func_path = "prim_func.pkl"
     resource_usage_path = "resource_usage.json"
     cache_root_dir = "kernels"
-    frontend_cache_root_dir = "frontend"
     staging_root_dir = ".staging"
 
     @staticmethod
@@ -185,7 +183,6 @@ class KernelCache:
         os.makedirs(env.TILELANG_TMP_DIR, exist_ok=True)
         os.makedirs(KernelCache._get_namespace_root(), exist_ok=True)
         os.makedirs(KernelCache._get_cache_root(), exist_ok=True)
-        os.makedirs(KernelCache._get_frontend_cache_root(), exist_ok=True)
         os.makedirs(KernelCache._get_staging_root(), exist_ok=True)
 
         staging_root = KernelCache._get_staging_root()
@@ -201,10 +198,6 @@ class KernelCache:
     @staticmethod
     def _get_cache_root() -> str:
         return os.path.join(KernelCache._get_namespace_root(), KernelCache.cache_root_dir)
-
-    @staticmethod
-    def _get_frontend_cache_root() -> str:
-        return os.path.join(KernelCache._get_namespace_root(), KernelCache.frontend_cache_root_dir)
 
     @staticmethod
     def _get_staging_root() -> str:
@@ -431,12 +424,6 @@ class KernelCache:
         """
         return os.path.join(self._get_cache_root(), key)
 
-    def _get_frontend_cache_path(self, frontend_key: str) -> str:
-        return os.path.join(
-            self._get_frontend_cache_root(),
-            f"{self._sanitize_path_component(frontend_key)}.json",
-        )
-
     @staticmethod
     def _tag_kernel_cache_entry(kernel: JITKernel, key: str, cache_path: str) -> None:
         try:
@@ -520,19 +507,6 @@ class KernelCache:
             if verbose:
                 self.logger.debug(f"Saving kernel parameters to disk: {params_path}")
             KernelCache._safe_write_file(params_path, "wb", lambda file: cloudpickle.dump(kernel.params, file))
-
-            # Save the PrimFunc so frontend cache hits can rebuild the adapter
-            # without re-elaborating the Python DSL in a fresh process. This is
-            # optional for backward compatibility with existing cache entries.
-            if func is not None:
-                prim_func_path = os.path.join(staging_path, self.prim_func_path)
-                if verbose:
-                    self.logger.debug(f"Saving PrimFunc to disk: {prim_func_path}")
-                try:
-                    KernelCache._safe_write_file(prim_func_path, "wb", lambda file: cloudpickle.dump(func, file))
-                except Exception:
-                    if verbose:
-                        self.logger.exception("Error saving optional PrimFunc cache metadata")
 
             # Persist HIP kernel-resource-usage remarks
             usage = getattr(kernel, "_resource_usage", None) or {}
@@ -623,14 +597,6 @@ class KernelCache:
             compile_flags=compile_flags,
         )
         if kernel is not None:
-            prim_func_path = os.path.join(cache_path, self.prim_func_path)
-            if func is not None and not os.path.exists(prim_func_path):
-                try:
-                    KernelCache._safe_write_file(prim_func_path, "wb", lambda file: cloudpickle.dump(func, file))
-                except Exception:
-                    if verbose:
-                        self.logger.exception("Error upgrading cache entry with PrimFunc")
-
             # Restore parsed kernel-resource-usage if a previous compile
             # persisted it; absent file is fine (older caches, non-HIP).
             ru_path = os.path.join(cache_path, self.resource_usage_path)
@@ -642,85 +608,6 @@ class KernelCache:
 
             self._tag_kernel_cache_entry(kernel, key, cache_path)
         return kernel
-
-    def load_frontend_cached(
-        self,
-        frontend_key: str,
-        *,
-        target: str | Target = "auto",
-        target_host: str | Target | None = None,
-        out_idx: list[int] | None = None,
-        execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"] = "tvm_ffi",
-        pass_configs: dict | None = None,
-        compile_flags: list[str] | str | None = None,
-        verbose: bool = False,
-    ) -> JITKernel | None:
-        if not env.is_cache_enabled():
-            return None
-
-        frontend_path = self._get_frontend_cache_path(frontend_key)
-        try:
-            with open(frontend_path, encoding="utf-8") as file:
-                frontend_entry = json.load(file)
-        except OSError:
-            return None
-        except Exception:
-            self.logger.exception("Error loading frontend cache entry")
-            return None
-
-        key = frontend_entry.get("kernel_key")
-        if not isinstance(key, str) or not key:
-            return None
-
-        with self._lock:
-            existing = self._memory_cache.get(key)
-            if existing is not None:
-                return existing
-
-        cache_path = self._get_cache_path(key)
-        prim_func_path = os.path.join(cache_path, self.prim_func_path)
-        try:
-            with open(prim_func_path, "rb") as file:
-                func = cloudpickle.load(file)
-        except OSError:
-            return None
-        except Exception:
-            self.logger.exception("Error loading PrimFunc from frontend cache entry")
-            return None
-
-        kernel = self._load_kernel_from_disk(
-            key,
-            target=target,
-            target_host=target_host,
-            out_idx=out_idx,
-            execution_backend=execution_backend,
-            pass_configs=pass_configs,
-            compile_flags=compile_flags,
-            func=func,
-            verbose=verbose,
-        )
-        if kernel is None:
-            return None
-
-        with self._lock:
-            existing = self._memory_cache.get(key)
-            if existing is not None:
-                return existing
-            self._memory_cache[key] = kernel
-        return kernel
-
-    def store_frontend_cache(self, frontend_key: str, kernel_key: str, *, verbose: bool = False) -> None:
-        if not env.is_cache_enabled():
-            return
-
-        KernelCache._create_dirs()
-        frontend_path = self._get_frontend_cache_path(frontend_key)
-        payload = {"kernel_key": kernel_key}
-        try:
-            KernelCache._safe_write_file(frontend_path, "w", lambda file: json.dump(payload, file, sort_keys=True))
-        except Exception:
-            if verbose:
-                self.logger.exception("Error saving frontend cache entry")
 
     def _clear_disk_cache(self):
         """

--- a/tilelang/jit/__init__.py
+++ b/tilelang/jit/__init__.py
@@ -476,20 +476,6 @@ class JITImpl(Generic[_P, _KP, _T, _Ret]):
         key = (key_args_tuple, key_kwargs_tuple, tuned_key_kwargs_tuple)
         return key
 
-    def _frontend_cache_key_data(self, key: tuple) -> dict[str, Any]:
-        func_name = getattr(getattr(self.func, "orig_func", self.func), "__name__", "jit_kernel")
-        func_qualname = getattr(getattr(self.func, "orig_func", self.func), "__qualname__", func_name)
-        func_module = getattr(getattr(self.func, "orig_func", self.func), "__module__", None)
-        return {
-            "function": func_name,
-            "qualname": func_qualname,
-            "module": func_module,
-            "source": self.func_source,
-            "signature": str(self.signature),
-            "key": repr(key),
-            "mode": self.mode,
-        }
-
     def get_kernel_source(self, *args: _P.args, **kwargs: _P.kwargs) -> str:
         kernel = self.compile(*args, **kwargs)
         return kernel.get_kernel_source()
@@ -536,42 +522,7 @@ class JITImpl(Generic[_P, _KP, _T, _Ret]):
         key, kernel_args = self.func.parse_args(*args, **kwargs)
         kernel = self._kernel_cache.get(key, None)
         if kernel is None:
-            frontend_key_data = None
-            # Frontend cache is only safe when lazy-mode parse_args leaves no
-            # runtime kernel_args; then _frontend_cache_key_data fully identifies
-            # the compiled kernel, assuming compile-time values have stable reprs.
-            if self.is_lazy_mode() and not kernel_args:
-                frontend_key_data = self._frontend_cache_key_data(key)
-                from tilelang.cache import load_frontend_cached
-
-                kernel = load_frontend_cached(
-                    frontend_key_data,
-                    out_idx=self.out_idx,
-                    execution_backend=self.execution_backend,
-                    target=self.target,
-                    target_host=self.target_host,
-                    verbose=self.verbose,
-                    pass_configs=self.pass_configs,
-                    compile_flags=self.compile_flags,
-                )
-            if kernel is None:
-                kernel = self.compile(*args, **kwargs)
-                if frontend_key_data is not None:
-                    kernel_key = getattr(kernel, "_tilelang_cache_key", None)
-                    if kernel_key:
-                        from tilelang.cache import store_frontend_cache
-
-                        store_frontend_cache(
-                            frontend_key_data,
-                            kernel_key,
-                            out_idx=self.out_idx,
-                            execution_backend=self.execution_backend,
-                            target=self.target,
-                            target_host=self.target_host,
-                            verbose=self.verbose,
-                            pass_configs=self.pass_configs,
-                            compile_flags=self.compile_flags,
-                        )
+            kernel = self.compile(*args, **kwargs)
             self._kernel_cache[key] = kernel
 
         if call_form_key is not None and self.is_lazy_mode() and not kernel_args:


### PR DESCRIPTION
## Summary

- Remove the frontend disk cache path that mapped Python JIT call forms directly to cached kernel entries.
- Ensure lazy JIT kernels are re-elaborated into `PrimFunc` before hitting the existing kernel cache, so closure-specialized shapes are keyed by the generated IR.

**This is a following pr of #2358 **
## Changes

- Deleted frontend cache key generation and load/store APIs from `tilelang.cache`.
- Removed frontend cache directory handling and `PrimFunc` sidecar persistence from `KernelCache`.
- Simplified JIT cache misses to compile through the normal `PrimFunc`-based cache path.
- Replaced frontend-cache tests with a closure-specialization regression covering `N=128` and `N=256` lazy kernels.

## Validation

- `pre-commit run --all-files`
- `python -m py_compile tilelang/jit/__init__.py tilelang/cache/__init__.py tilelang/cache/kernel_cache.py testing/python/cache/test_tilelang_kernel_cache_atomic_save.py`
- `python debug/reproduce_issue.py`
- `python -m pytest testing/python/cache/test_tilelang_kernel_cache_atomic_save.py -x`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated kernel cache test utilities and adjusted coverage.
  * Removed tests for serialized function loading; added test for specialization re-elaboration.

* **Refactor**
  * Removed frontend cache layer from kernel caching system.
  * Kernels now compile directly on cache miss without intermediate lookup.
  * Removed public cache APIs (`load_frontend_cached`, `store_frontend_cache`) to streamline architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->