### PR TITLE
[BugFix][Transform] Demote illegal-width residual cp.async to a synchronous copy

### DIFF
--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -1060,6 +1060,113 @@ For ParallelToSerial(const For &loop) {
   return Downcast<For>(rewriter(loop));
 }
 
+/*!
+ * \brief Demote a scalarized illegal-width cp.async to a synchronous masked
+ * copy.
+ *
+ * A residual copy whose out-of-bounds predicate depends on the vectorized lane
+ * (e.g. a 1-element K residual, "...+vec < 1") is scalarized to per-lane
+ * cp.async calls with num_elems == 1. For sub-16-byte dtypes that per-call
+ * width (fp16/bf16 = 2 B, fp8 = 1 B) is not a legal cp.async size {4, 8, 16}
+ * and would abort at codegen, so we demote it to a synchronous masked store:
+ *
+ *     As[idx] = if_then_else(pred, A[idx], (dtype)0)
+ */
+class IllegalCPAsyncToSyncDemoter : public StmtExprMutator {
+public:
+  /// Rewrite \p stmt, demoting any illegal-width cp.async it contains.
+  static Stmt Demote(Stmt stmt) {
+    IllegalCPAsyncToSyncDemoter demoter;
+    return demoter(std::move(stmt));
+  }
+
+private:
+  /// Recover the underlying BufferLoad (buffer + indices) from a
+  /// `tl::access_ptr(BufferLoad, extent, rw_mask)` argument, or null if \p arg
+  /// is not that form. At this pass cp.async still carries tl::access_ptr
+  /// (LowerAccessPtr has not run yet), so the BufferLoad is directly available.
+  static const BufferLoadNode *AsAccessPtrLoad(const PrimExpr &arg) {
+    const auto *call = arg.as<CallNode>();
+    if (call == nullptr || !call->op.same_as(tl::access_ptr())) {
+      return nullptr;
+    }
+    if (call->args.empty()) {
+      return nullptr;
+    }
+    return call->args[0].as<BufferLoadNode>();
+  }
+
+  /// Demote a single Evaluate(tl::ptx_cp_async(...)) of illegal width to a
+  /// synchronous masked store; leave every other statement unchanged.
+  Stmt VisitStmt_(const EvaluateNode *op) final {
+    const auto *call = op->value.as<CallNode>();
+    if (call == nullptr || !call->op.same_as(tl::ptx_cp_async())) {
+      return StmtExprMutator::VisitStmt_(op);
+    }
+    // args: [dst_access_ptr, src_access_ptr, num_elems, (predicate)]
+    if (call->args.size() != 3 && call->args.size() != 4) {
+      return StmtExprMutator::VisitStmt_(op);
+    }
+    const auto *num_elems_imm = call->args[2].as<IntImmNode>();
+    const BufferLoadNode *dst_load = AsAccessPtrLoad(call->args[0]);
+    const BufferLoadNode *src_load = AsAccessPtrLoad(call->args[1]);
+    if (num_elems_imm == nullptr || dst_load == nullptr ||
+        src_load == nullptr) {
+      // Not the recoverable tl::access_ptr form (e.g. already lowered, or a
+      // multi-element vectorized copy whose width is handled elsewhere). Leave
+      // it for the codegen guard.
+      return StmtExprMutator::VisitStmt_(op);
+    }
+
+    int64_t num_elems = num_elems_imm->value;
+    DataType dst_dtype = dst_load->buffer->dtype;
+    int64_t per_call_bits = num_elems * dst_dtype.bits() * dst_dtype.lanes();
+
+    // Demote only widths that are a whole number of bytes but not a legal
+    // cp.async size. Legal widths keep their cp.async; sub-byte (non-byte-
+    // aligned) widths are left to crash at the codegen guard, since an
+    // element-granular copy is unsafe for packed sub-byte dtypes (nibbles).
+    bool byte_aligned = (per_call_bits % 8 == 0);
+    bool legal = byte_aligned && IsValidCPAsyncTransferBytes(
+                                     static_cast<int>(per_call_bits / 8));
+    if (!byte_aligned || legal) {
+      return StmtExprMutator::VisitStmt_(op);
+    }
+
+    // An illegal width here is always num_elems == 1 (the injector only emits
+    // cp.async at a legal full width, so num_elems > 1 was filtered out above).
+    // The reconstruction copies a single element, so assert the invariant.
+    ICHECK_EQ(num_elems, 1)
+        << "illegal-width cp.async demotion expects num_elems == 1, got "
+        << num_elems;
+
+    PrimExpr loaded = BufferLoad(src_load->buffer, src_load->indices);
+    if (loaded.dtype() != dst_dtype) {
+      loaded = cast(dst_dtype, loaded);
+    }
+    PrimExpr value;
+    if (call->args.size() == 4) {
+      // The typed zero on the false branch replicates cp.async's hardware
+      // zero-fill of the destination when the predicate is false; without it
+      // the residual lane is left uninitialized and a downstream gemm reads
+      // garbage.
+      PrimExpr predicate = call->args[3];
+      value = if_then_else(predicate, loaded, make_zero(dst_dtype));
+    } else {
+      // Non-predicated illegal-width copy: still demote to a plain store (the
+      // address was in-bounds; only the async width was the problem).
+      value = loaded;
+    }
+    return BufferStore(dst_load->buffer, value, dst_load->indices);
+  }
+};
+
+/// Demote every illegal-width scalarized cp.async in \p stmt to a synchronous
+/// masked copy (see IllegalCPAsyncToSyncDemoter).
+Stmt DemoteIllegalCPAsyncToSync(Stmt stmt) {
+  return IllegalCPAsyncToSyncDemoter::Demote(std::move(stmt));
+}
+
 } // namespace
 
 For VectorizeLoop(const For &loop, const LayoutMap &layout_map,
@@ -1069,8 +1176,14 @@ For VectorizeLoop(const For &loop, const LayoutMap &layout_map,
     VectorizePlanner planner(&analyzer, layout_map);
     vectorize_hint = planner.Plan(loop);
   }
+  // Only the scalarized branch (vector_size == 1) can leave an illegal-width
+  // cp.async: the copy stays at num_elems == 1 and is never widened to a legal
+  // {4,8,16}-byte transfer by the later VectorizeLoop pass. Copies that DO
+  // vectorize (hint > 1) keep num_elems == 1 here too, but will be widened
+  // downstream, so they must NOT be demoted (doing so drops cp.async on the
+  // legal fast path -- a perf regression).
   if (vectorize_hint == 1)
-    return ParallelToSerial(loop);
+    return Downcast<For>(DemoteIllegalCPAsyncToSync(ParallelToSerial(loop)));
   auto rewriter = VectorizeRewriter(vectorize_hint);
   return Downcast<For>(rewriter(loop));
 }
@@ -1081,8 +1194,10 @@ For VectorizeLoop(const For &loop, arith::Analyzer *analyzer,
     VectorizePlanner planner(analyzer, layout_map);
     vectorize_hint = planner.Plan(loop);
   }
+  // See the note in the sibling overload: demote only in the scalarized
+  // (vector_size == 1) branch, where the illegal-width cp.async is final.
   if (vectorize_hint == 1)
-    return ParallelToSerial(loop);
+    return Downcast<For>(DemoteIllegalCPAsyncToSync(ParallelToSerial(loop)));
   auto rewriter = VectorizeRewriter(vectorize_hint);
   return Downcast<For>(rewriter(loop));
 }

--- a/testing/python/issue/test_tilelang_issue_2365.py
+++ b/testing/python/issue/test_tilelang_issue_2365.py
@@ -1,0 +1,220 @@
+"""Regression test for issue #2365.
+
+A pipelined fp16/bf16/fp8 GEMM whose K leaves a 1-element residual tile
+(K = BLOCK_K + 1, e.g. K=33 with BLOCK_K=32) used to crash at CUDA codegen with
+"tl::ptx_cp_async requires a final PTX byte width in {4, 8, 16}, but got 2": the
+residual copy's vec-dependent predicate forces LegalizeVectorizedLoop to
+scalarize the vectorized cp.async into a num_elems==1 (sub-16-byte) transfer,
+which is not a legal cp.async width. The fix demotes such copies to a
+synchronous masked store with a typed zero-fill (matching cp.async's hardware
+zero-fill on a false predicate).
+"""
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+import torch
+
+# cp.async exists from sm_80 (Ampere). fp8 e4m3 GEMM execution wants sm_89+.
+_MIN_CC = (8, 0)
+
+_TORCH_DTYPE = {
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "float8_e4m3": torch.float8_e4m3fn,
+    "float32": torch.float32,
+}
+# (rtol, atol) per dtype, matching the validated trigger surface.
+_TOL = {
+    "float16": (2e-2, 2e-1),
+    "bfloat16": (6e-2, 5e-1),
+    "float8_e4m3": (2e-1, 2.0),
+    "float32": (2e-2, 2e-1),
+}
+
+
+def _make_gemm(M, N, K, block_M, block_N, block_K, dtype, num_stages=2):
+    """Build a pipelined C = A @ B kernel (fp32 accum) for the given shapes/dtype."""
+    accum = "float32"
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), dtype),
+        B: T.Tensor((K, N), dtype),
+        C: T.Tensor((M, N), accum),
+    ):
+        """Pipelined tiled GEMM over K with cp.async global->shared copies."""
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            As = T.alloc_shared((block_M, block_K), dtype)
+            Bs = T.alloc_shared((block_K, block_N), dtype)
+            Cl = T.alloc_fragment((block_M, block_N), accum)
+            T.clear(Cl)
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
+                T.copy(A[by * block_M, k * block_K], As)
+                T.copy(B[k * block_K, bx * block_N], Bs)
+                T.gemm(As, Bs, Cl)
+            T.copy(Cl, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def _rand(shape, dtype):
+    """Random CUDA tensor of the given tilelang dtype (scaled down for fp8)."""
+    if dtype == "float8_e4m3":
+        # Small magnitudes so e4m3 can represent them and the fp32 accumulation is sane.
+        return (torch.randn(*shape, device="cuda") * 0.5).to(torch.float8_e4m3fn)
+    return torch.randn(*shape, device="cuda", dtype=_TORCH_DTYPE[dtype])
+
+
+def _compile_run(M, N, K, block_M, block_N, block_K, dtype, num_stages=2):
+    """Compile + run; returns (output_fp32, reference_fp32). Compilation errors
+    propagate (that IS the detection of the original crash)."""
+    func = _make_gemm(M, N, K, block_M, block_N, block_K, dtype, num_stages)
+    kernel = tilelang.compile(func, out_idx=[2], execution_backend="cython")
+    a = _rand((M, K), dtype)
+    b = _rand((K, N), dtype)
+    c = kernel(a, b).float()
+    torch.cuda.synchronize()
+    ref = a.float() @ b.float()
+    return c, ref
+
+
+# (name, M, N, K, block_M, block_N, block_K, dtype) -- residual = 1 element, the crash trigger.
+_TRIGGER_CASES = [
+    ("fp16 K33/BK32 (headline)", 128, 128, 33, 64, 64, 32, "float16"),
+    ("fp16 K65/BK64", 128, 128, 65, 64, 64, 64, "float16"),
+    ("fp16 K17/BK16", 128, 128, 17, 64, 64, 16, "float16"),
+    ("fp16 K97/BK96", 128, 128, 97, 64, 64, 96, "float16"),
+    ("fp16 K129/BK128", 128, 128, 129, 64, 64, 128, "float16"),
+    ("bf16 K33/BK32", 128, 128, 33, 64, 64, 32, "bfloat16"),
+    ("bf16 K17/BK16", 128, 128, 17, 64, 64, 16, "bfloat16"),
+]
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(*_MIN_CC)
+def test_pipelined_residual_gemm_compiles_and_correct():
+    """The original codegen crash: each trigger case must compile, run, produce
+    no NaN, and match torch."""
+    failures = []
+    for name, M, N, K, bM, bN, bK, dt in _TRIGGER_CASES:
+        rtol, atol = _TOL[dt]
+        try:
+            c, ref = _compile_run(M, N, K, bM, bN, bK, dt)
+        except RuntimeError as e:  # the bug we guard: tvm InternalError <- RuntimeError
+            failures.append(f"{name}: COMPILE/RUN RAISED: {str(e).splitlines()[-1][:120]}")
+            continue
+        nan = int(torch.isnan(c).sum().item())
+        if nan:
+            failures.append(f"{name}: output has {nan} NaNs (missing zero-fill?)")
+        elif not torch.allclose(c, ref, rtol=rtol, atol=atol):
+            max_abs = (c - ref).abs().max().item()
+            failures.append(f"{name}: numeric mismatch max_abs={max_abs:.4g}")
+    assert not failures, "illegal-width residual cp.async regressions:\n  " + "\n  ".join(failures)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(*_MIN_CC)
+def test_zero_fill_residual_no_garbage():
+    """The synchronous fallback must zero-fill out-of-bounds residual lanes.
+
+    Poison shared memory with NaN via a full-tile (no-residual) GEMM, then run
+    the 1-element-residual GEMM in the same process so it reuses the same SM
+    shared-memory region. If the residual's out-of-bounds lanes are not
+    zero-filled, they retain NaN and the result is NaN (deterministic).
+    """
+    for dt in ("float16", "bfloat16"):
+        rtol, atol = _TOL[dt]
+        block_M = block_N = 64
+        block_K = 32
+        poisoner = tilelang.compile(
+            _make_gemm(128, 128, block_K, block_M, block_N, block_K, dt),  # K == BK: full tile, no residual
+            out_idx=[2],
+            execution_backend="cython",
+        )
+        residual = tilelang.compile(
+            _make_gemm(128, 128, block_K + 1, block_M, block_N, block_K, dt),  # K = BK+1: 1-elem residual
+            out_idx=[2],
+            execution_backend="cython",
+        )
+        nan_runs = 0
+        for _ in range(8):
+            pa = torch.full((128, block_K), float("nan"), device="cuda", dtype=_TORCH_DTYPE[dt])
+            pb = torch.randn(block_K, 128, device="cuda", dtype=_TORCH_DTYPE[dt])
+            poisoner(pa, pb)
+            torch.cuda.synchronize()
+
+            a = torch.randn(128, block_K + 1, device="cuda", dtype=_TORCH_DTYPE[dt])
+            b = torch.randn(block_K + 1, 128, device="cuda", dtype=_TORCH_DTYPE[dt])
+            c = residual(a, b).float()
+            torch.cuda.synchronize()
+            ref = a.float() @ b.float()
+            if torch.isnan(c).any():
+                nan_runs += 1
+            else:
+                assert torch.allclose(c, ref, rtol=rtol, atol=atol), (
+                    f"{dt}: residual GEMM numerically wrong after poison (max_abs={(c - ref).abs().max().item():.4g})"
+                )
+        assert nan_runs == 0, (
+            f"{dt}: {nan_runs}/8 residual runs produced NaN -- the synchronous "
+            f"fallback is not zero-filling out-of-bounds shared-memory lanes "
+            f"(cp.async zero-fill semantics not replicated)."
+        )
+
+
+# (name, M, N, K, block_M, block_N, block_K, dtype): never hit the illegal-width path; must stay correct.
+_CONTROL_CASES = [
+    ("fp16 K32 divisible", 128, 128, 32, 64, 64, 32, "float16"),
+    ("fp16 K64 divisible", 128, 128, 64, 64, 64, 32, "float16"),
+    ("fp16 K128 multi-tile", 128, 128, 128, 64, 64, 32, "float16"),
+    ("fp16 K35 resid=3 (vec-indep, was-legal)", 128, 128, 35, 64, 64, 32, "float16"),
+    ("fp16 K34 resid=2 (4B, legal)", 128, 128, 34, 64, 64, 32, "float16"),
+    ("fp32 K33 resid=1 -> 4B (was-legal)", 128, 128, 33, 64, 64, 32, "float32"),
+]
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(*_MIN_CC)
+def test_controls_unaffected():
+    """Divisible-K and already-legal-width residual cases must remain correct
+    (the fix must not demote copies that are valid as cp.async)."""
+    failures = []
+    for name, M, N, K, bM, bN, bK, dt in _CONTROL_CASES:
+        rtol, atol = _TOL[dt]
+        c, ref = _compile_run(M, N, K, bM, bN, bK, dt)
+        if torch.isnan(c).any():
+            failures.append(f"{name}: NaN in a control case")
+        elif not torch.allclose(c, ref, rtol=rtol, atol=atol):
+            failures.append(f"{name}: max_abs={(c - ref).abs().max().item():.4g}")
+    assert not failures, "control-case regressions:\n  " + "\n  ".join(failures)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(*_MIN_CC)
+def test_legal_fast_path_preserves_cp_async():
+    """A divisible-K pipelined GEMM must still emit cp.async on its legal-width
+    fast path: the fix must demote only the illegal residual copy, not the bulk
+    copies."""
+    func = _make_gemm(128, 128, 128, 64, 64, 32, "float16", num_stages=2)
+    kernel = tilelang.compile(func, out_idx=[2], execution_backend="cython")
+    src = kernel.get_kernel_source()
+    assert ("cp_async_gs" in src) or ("cp.async" in src), (
+        "divisible-K fast path no longer emits cp.async -- the fix appears to "
+        "have demoted legal-width copies to synchronous (perf regression):\n" + src[:2000]
+    )
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(8, 9)  # fp8 e4m3 GEMM execution
+def test_pipelined_residual_gemm_fp8():
+    """fp8 e4m3 residual = 1 byte (also illegal). Same crash class; gated to
+    sm_89+ where fp8 GEMM actually executes."""
+    rtol, atol = _TOL["float8_e4m3"]
+    for name, K, bK in [("fp8 K33/BK32", 33, 32), ("fp8 K17/BK16", 17, 16)]:
+        c, ref = _compile_run(128, 128, K, 64, 64, bK, "float8_e4m3")
+        assert not torch.isnan(c).any(), f"{name}: NaN (missing zero-fill?)"
+        assert torch.allclose(c, ref, rtol=rtol, atol=atol), f"{name}: max_abs={(c - ref).abs().max().item():.4g}"
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary
A valid pipelined fp16/bf16/fp8 GEMM whose K dimension leaves a 1-element residual K-tile
(`K = BLOCK_K + 1`, e.g. `K=33`, `BLOCK_K=32`) crashed during CUDA codegen:

```
InternalError: Check failed: (IsValidCPAsyncTransferBytes(total_bytes)) is false:
tl::ptx_cp_async requires a final PTX byte width in {4, 8, 16}, but got 2
```

The program is valid — the same GEMM with a plain `T.serial` K-loop compiles and runs correctly.

Fixes #2365

## Root cause
A `cp.async`'s legality depends on its enclosing vectorized loop supplying a legal total width.

1. `InjectPTXAsyncCopy` selects `cp.async` while the residual copy is still a vectorized 16-byte transfer; its width guard passes.
2. `LegalizeSafeMemoryAccess` adds an out-of-bounds predicate that, for a 1-element residual, cuts inside a thread's vectorized lane group (`...+vec < 1`).
3. `LegalizeVectorizedLoop` (`src/transform/loop_vectorize.cc`) must therefore scalarize the loop, collapsing the 16-byte `cp.async` into per-lane `num_elems == 1` calls of `dtype_bits/8` bytes — 2 B for fp16/bf16, 1 B for fp8, none in `{4, 8, 16}`.
4. Nothing demotes the now-unrealizable `cp.async`, so it reaches the codegen `ICHECK`.

The codegen check is a correct last-line guard; the gap is that the pass which removes the vectorization (and thereby invalidates the `cp.async`) did not legalize the copy it broke.

## Fix
In `loop_vectorize.cc`, when `VectorizeLoop` scalarizes (`vector_size == 1`), demote a `tl::ptx_cp_async` whose per-call width is byte-aligned but not in `{4, 8, 16}` to a synchronous masked store — the form the async injector would have emitted had it declined `cp.async`:

```
As[idx] = if_then_else(pred, A[idx], (dtype)0)
```

- The typed zero-fill replicates `cp.async`'s hardware zero-fill on a false predicate; without it the residual lane is uninitialized and a downstream `T.gemm` reads garbage.
- Runs before `LowerAccessPtr`, so the operands are still `tl::access_ptr` carrying a recoverable `BufferLoad`.
- Gated to the scalarized branch: copies that vectorize keep `num_elems == 1` here but get widened to a legal width downstream, so demoting them would strip `cp.async` off the legal fast path.
- Sub-byte dtypes (int4/int1/fp4: non-byte-aligned width) are not demoted — an element-granular copy is unsafe for packed nibbles — and still hit the codegen guard.

`LegalizeVectorizedLoop` is shared by the CUDA, ROCm and Metal pipelines (CuTeDSL uses the CUDA pipeline), so the fix is backend-agnostic.

## Test plan
Adds `testing/python/issue/test_tilelang_issue_2365.py`:
- fp16/bf16 `K=BLOCK_K+1` (BLOCK_K 16/32/64/128) compiles, runs, matches `torch.matmul`;
- a NaN-poison test that fails if the zero-fill is dropped;
- controls (divisible K, residual ≥ 2, fp32) stay correct;
- a perf guard asserting the divisible-K fast path still emits `cp_async_gs`.

Verified on NVIDIA A10G (sm_86), CUDA 12.8: the new test passes on the patched build and fails on the unpatched build with the `got 2` crash; existing GEMM and async-copy transform tests pass. fp8 cases are gated to sm_89+.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Convert unsupported asynchronous memory-copy cases into safe synchronous masked copies to preserve zero-fill semantics, avoid out-of-bounds garbage, and ensure correctness in scalarized/vectorized paths.

* **Tests**
  * Added GPU regression tests for pipelined GEMM residuals (fp16/bf16/float32 and fp8), verifying compile/run success, absence of NaNs, numerical agreement with PyTorch, and that legal-width async copies remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->