### PR TITLE
[BugFix][CuTeDSL] Fix TileKernels scan, optional-shape, and e5m6 paths

### DIFF
--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -63,18 +63,33 @@ static bool IsThreadReturnEvaluate(const Stmt &stmt) {
   return call != nullptr && call->op.same_as(builtin::thread_return());
 }
 
-std::optional<PrimExpr> GetConditionalThreadReturnCondition(const Stmt &stmt) {
+struct ConditionalThreadReturn {
+  PrimExpr condition;
+  std::optional<Stmt> pre_return;
+};
+
+std::optional<ConditionalThreadReturn>
+GetConditionalThreadReturn(const Stmt &stmt) {
   const auto *if_node = stmt.as<IfThenElseNode>();
   if (if_node == nullptr || if_node->else_case) {
     return std::nullopt;
   }
   if (IsThreadReturnEvaluate(if_node->then_case)) {
-    return if_node->condition;
+    return ConditionalThreadReturn{if_node->condition, std::nullopt};
   }
   if (const auto *seq = if_node->then_case.as<SeqStmtNode>();
-      seq != nullptr && seq->seq.size() == 1 &&
-      IsThreadReturnEvaluate(seq->seq[0])) {
-    return if_node->condition;
+      seq != nullptr && !seq->seq.empty() &&
+      IsThreadReturnEvaluate(seq->seq[seq->seq.size() - 1])) {
+    if (seq->seq.size() == 1) {
+      return ConditionalThreadReturn{if_node->condition, std::nullopt};
+    }
+    Array<Stmt> pre_return;
+    for (size_t i = 0; i + 1 < seq->seq.size(); ++i) {
+      pre_return.push_back(seq->seq[i]);
+    }
+    Stmt pre_return_stmt =
+        pre_return.size() == 1 ? pre_return[0] : SeqStmt(pre_return);
+    return ConditionalThreadReturn{if_node->condition, pre_return_stmt};
   }
   return std::nullopt;
 }
@@ -2723,11 +2738,22 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const SeqStmtNode *op) {
   // don't execute in the same iteration after the break.
   int guard_scope = -1;
   for (size_t i = 0; i < op->seq.size(); ++i) {
-    if (auto condition = GetConditionalThreadReturnCondition(op->seq[i])) {
+    if (auto guarded_return = GetConditionalThreadReturn(op->seq[i])) {
+      if (guarded_return->pre_return) {
+        PrintIndent();
+        stream << "if "
+               << RemoveOutermostParentheses(
+                      PrintExpr_(guarded_return->condition))
+               << ":\n";
+        int pre_return_scope = BeginScope();
+        PrintStmt_(guarded_return->pre_return.value());
+        EndScope(pre_return_scope);
+      }
       if (i + 1 < op->seq.size()) {
         PrintIndent();
         stream << "if not ("
-               << RemoveOutermostParentheses(PrintExpr_(condition.value()))
+               << RemoveOutermostParentheses(
+                      PrintExpr_(guarded_return->condition))
                << "):\n";
         thread_return_guard_scopes.push_back(BeginScope());
       }
@@ -2873,8 +2899,12 @@ void CodeGenTileLangCuTeDSL::PrintVecBinaryOp_(const std::string &opstr,
   PrintType(dtype.element_of(), stream);
   stream << ")\n";
 
-  std::string vlhs = SSAGetID(PrintExpr_(lhs), lhs.dtype());
-  std::string vrhs = SSAGetID(PrintExpr_(rhs), rhs.dtype());
+  auto print_operand = [this](const PrimExpr &expr) {
+    std::string value = PrintExpr_(expr);
+    return ContainsBufferLoad(expr) ? value : SSAGetID(value, expr.dtype());
+  };
+  std::string vlhs = print_operand(lhs);
+  std::string vrhs = print_operand(rhs);
 
   const std::string one_char_op{"+-*%<>^|&"};
   const std::string two_char_op{"// == != <= >="};

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -1327,8 +1327,9 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
         scope = GetPtrStorageScope(load->buffer->data);
       }
       if (scope == "local.var") {
-        std::string expr_str =
-            GetBufferRef_(src_dtype, load->buffer.get(), load->indices[0]);
+        std::string expr_str = GetBufferRef_(
+            src_dtype, load->buffer.get(),
+            LinearizeBufferIndices_(load->buffer.get(), load->indices));
         os << "tl.bitcast(" << expr_str << ", ";
         PrintType(tgt_dtype.element_of(), os);
         os << ")";
@@ -1336,15 +1337,18 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
       }
 
       // Path 1: BufferLoad - use recast_ptr for memory access
-      ICHECK_EQ(load->indices.size(), 1)
-          << "CodeGenTileLangCuTeDSL only supports flat memory";
-
-      PrimExpr index = load->indices[0];
+      PrimExpr index =
+          LinearizeBufferIndices_(load->buffer.get(), load->indices);
       if (const RampNode *node = index.as<RampNode>(); node) {
         auto *p_stride = as_const_int(node->stride);
         ICHECK(p_stride);
         ICHECK_EQ(*p_stride, 1) << "reinterpret expects contiguous elements";
         index = node->base;
+      } else {
+        arith::PVar<PrimExpr> ramp_base;
+        if (arith::ramp(ramp_base, 1, tgt_dtype.lanes()).Match(index)) {
+          index = ramp_base.Eval();
+        }
       }
 
       auto ptr_str = GetBufferPtr_(load->buffer.get(), index);
@@ -1399,6 +1403,11 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
     os << "tl.__shfl_up_sync(" << PrintExpr_(op->args[0]) << ", "
        << PrintExpr_(op->args[1]) << ", " << PrintExpr_(op->args[2]) << ", "
        << PrintExpr_(op->args[3]) << ")";
+  } else if (op->op.same_as(tl::match_any_sync())) {
+    ICHECK_EQ(op->args.size(), 2U)
+        << "tl.match_any_sync expects <mask, value>.";
+    os << "tl.__match_any_sync(" << PrintExpr_(op->args[0]) << ", "
+       << PrintExpr_(op->args[1]) << ")";
   } else if (op->op.same_as(tl::get_lane_idx())) {
     // get_lane_idx(warp_size?) -> threadIdx.x % warp_size
     ICHECK_LE(op->args.size(), 1U)
@@ -1550,9 +1559,9 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
   } else if (op->op.same_as(builtin::address_of())) {
     const BufferLoadNode *load = op->args[0].as<BufferLoadNode>();
     ICHECK(op->args.size() == 1 && load);
-    ICHECK_EQ(load->indices.size(), 1)
-        << "CodeGenTileLangCuTeDSL only supports flat memory";
-    os << GetBufferPtr_(load->buffer.get(), load->indices[0]);
+    os << GetBufferPtr_(
+        load->buffer.get(),
+        LinearizeBufferIndices_(load->buffer.get(), load->indices));
   } else if (op->op.same_as(builtin::handle_add_byte_offset())) {
     ICHECK_EQ(op->args.size(), 2U);
     os << "tl.handle_add_byte_offset(" << PrintExpr_(op->args[0]) << ", "
@@ -1741,13 +1750,13 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const ShuffleNode *op,
 
 void CodeGenTileLangCuTeDSL::VisitExpr_(const BufferLoadNode *op,
                                         std::ostream &os) { // NOLINT(*)
-  ICHECK_EQ(op->indices.size(), 1)
-      << "Load from non-flat memory not supported.";
+  ICHECK_GE(op->indices.size(), 1U)
+      << "Buffer load must have at least one index.";
   ICHECK(!op->predicate.defined())
       << "Predicated buffer load is not supported.";
 
   DataType value_dtype = op->dtype;
-  PrimExpr index = op->indices[0];
+  PrimExpr index = LinearizeBufferIndices_(op->buffer.get(), op->indices);
   Var buffer_var = op->buffer->data;
   DataType element_dtype = op->buffer->dtype;
 
@@ -1948,13 +1957,14 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const BufferLoadNode *op,
 }
 
 void CodeGenTileLangCuTeDSL::VisitStmt_(const BufferStoreNode *op) {
-  ICHECK_EQ(op->indices.size(), 1) << "Store to non-flat memory not supported.";
+  ICHECK_GE(op->indices.size(), 1U)
+      << "Buffer store must have at least one index.";
   ICHECK(!op->predicate.defined())
       << "Predicated buffer store is not supported.";
 
   DataType value_dtype = op->value.dtype();
   DataType element_dtype = op->buffer->dtype;
-  PrimExpr index_expr = op->indices[0];
+  PrimExpr index_expr = LinearizeBufferIndices_(op->buffer.get(), op->indices);
   Var buffer_var = op->buffer->data;
 
   // Pre-compute Select/if_then_else as tl.where() at statement level.
@@ -2581,7 +2591,9 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const AllocBufferNode *op) {
 void CodeGenTileLangCuTeDSL::VisitStmt_(const AttrStmtNode *op) {
   if (op->attr_key == tirx::attr::thread_extent) {
     IterVar iv = Downcast<IterVar>(op->node);
-    if (!iv->thread_tag.empty()) {
+    const std::string thread_tag =
+        !iv->thread_tag.empty() ? iv->thread_tag : iv->var->name_hint;
+    if (!thread_tag.empty()) {
       if (!var_idmap_.count(iv->var.get())) {
         BindThreadIndex_(iv);
       }
@@ -2979,9 +2991,9 @@ void CodeGenTileLangCuTeDSL::PrintCallExtern_(Type ret_type,
     global_symbol_str = "tl." + global_symbol_str;
     // Convert first argument (Buffer) to pointer for atomic operations
     if (const BufferLoadNode *load = args[arg_begin].as<BufferLoadNode>()) {
-      ICHECK_EQ(load->indices.size(), 1)
-          << "CodeGenTileLangCuTeDSL only supports flat memory";
-      sargs[0] = GetBufferPtr_(load->buffer.get(), load->indices[0]);
+      sargs[0] = GetBufferPtr_(
+          load->buffer.get(),
+          LinearizeBufferIndices_(load->buffer.get(), load->indices));
     }
   }
   // Quantization Functions (decode_i4u_to_f16, decode_i4s_to_f16, etc.)
@@ -3056,6 +3068,45 @@ void CodeGenTileLangCuTeDSL::PrintCallExtern_(Type ret_type,
     }
     os << ")";
   }
+}
+
+PrimExpr CodeGenTileLangCuTeDSL::LinearizeBufferIndices_(
+    const BufferNode *buffer, const ffi::Array<PrimExpr> &indices) {
+  ICHECK_GE(indices.size(), 1U)
+      << "Buffer access must have at least one index.";
+  if (indices.size() == 1 &&
+      (buffer->shape.size() != 1 || buffer->strides.empty() ||
+       indices[0].dtype().lanes() != 1)) {
+    return indices[0];
+  }
+
+  ICHECK_EQ(indices.size(), buffer->shape.size())
+      << "Buffer access rank " << indices.size()
+      << " does not match buffer rank " << buffer->shape.size() << " for "
+      << buffer->name;
+
+  DataType index_dtype = buffer->DefaultIndexType();
+  auto cast_index = [index_dtype](const PrimExpr &expr) -> PrimExpr {
+    return expr.dtype() == index_dtype ? expr : tirx::Cast(index_dtype, expr);
+  };
+
+  PrimExpr offset = tirx::make_const(index_dtype, 0);
+  if (!buffer->strides.empty()) {
+    ICHECK_EQ(buffer->strides.size(), indices.size())
+        << "Buffer stride rank " << buffer->strides.size()
+        << " does not match index rank " << indices.size() << " for "
+        << buffer->name;
+    for (size_t i = 0; i < indices.size(); ++i) {
+      offset = offset + cast_index(indices[i]) * cast_index(buffer->strides[i]);
+    }
+  } else {
+    PrimExpr stride = tirx::make_const(index_dtype, 1);
+    for (int i = static_cast<int>(indices.size()) - 1; i >= 0; --i) {
+      offset = offset + cast_index(indices[i]) * stride;
+      stride = stride * cast_index(buffer->shape[i]);
+    }
+  }
+  return arith::Analyzer().Simplify(offset);
 }
 
 std::string CodeGenTileLangCuTeDSL::GetBufferPtr_(const BufferNode *buffer,
@@ -3266,7 +3317,8 @@ std::string CodeGenTileLangCuTeDSL::GetBufferRef_(DataType t,
 void CodeGenTileLangCuTeDSL::BindThreadIndex_(const IterVar &iv) {
   ICHECK(!var_idmap_.count(iv->var.get()));
 
-  auto &thread_tag = iv->thread_tag;
+  const std::string thread_tag =
+      !iv->thread_tag.empty() ? iv->thread_tag : iv->var->name_hint;
   ICHECK(thread_tag == "threadIdx.x" || thread_tag == "threadIdx.y" ||
          thread_tag == "threadIdx.z" || thread_tag == "blockIdx.x" ||
          thread_tag == "blockIdx.y" || thread_tag == "blockIdx.z");

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -477,6 +477,31 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CastNode *op,
   const bool from_is_fp8_narrowing_source = from_ty == DataType::Float(16) ||
                                             from_ty == DataType::Float(32) ||
                                             from_ty.is_bfloat16();
+  if (from_ty.is_scalar() && target_ty.is_scalar() &&
+      (from_ty.is_int() || from_ty.is_uint()) &&
+      (target_ty.is_int() || target_ty.is_uint()) &&
+      target_ty.bits() > from_ty.bits()) {
+    if (const CallNode *call = op->value.as<CallNode>();
+        call && (call->op.same_as(builtin::shift_left()) ||
+                 call->op.same_as(builtin::shift_right()))) {
+      ICHECK_EQ(call->args.size(), 2U);
+      const DataType lhs_ty = call->args[0].dtype();
+      const bool same_signedness = (lhs_ty.is_int() && target_ty.is_int()) ||
+                                   (lhs_ty.is_uint() && target_ty.is_uint());
+      if (same_signedness && lhs_ty.bits() < target_ty.bits()) {
+        const std::string lhs = PrintExpr_(call->args[0]);
+        const std::string rhs = PrintExpr_(call->args[1]);
+        PrintType(target_ty, os);
+        os << "((";
+        PrintType(target_ty, os);
+        os << "(" << lhs << ") "
+           << (call->op.same_as(builtin::shift_left()) ? "<<" : ">>") << " "
+           << rhs << "))";
+        return;
+      }
+    }
+  }
+
   if (from_ty.is_scalar() && from_is_cutedsl_fp8 && target_is_fp8_widening) {
     // CuTeDSL/NVGPU widens FP8 through nvgpu.cvt_fpext, whose operand must be
     // a 32-bit aligned vector.  Pack the scalar into a four-lane FP8 vector,

--- a/src/cuda/codegen/codegen_cutedsl.h
+++ b/src/cuda/codegen/codegen_cutedsl.h
@@ -82,6 +82,8 @@ protected:
   std::string GetBufferPtr_(const BufferNode *buffer, PrimExpr index);
   std::string GetBufferRef_(DataType t, const BufferNode *buffer,
                             PrimExpr index) override;
+  PrimExpr LinearizeBufferIndices_(const BufferNode *buffer,
+                                   const ffi::Array<PrimExpr> &indices);
 
   // Get pointer string from a Var expression (local buffer -> vid.iterator)
   std::string GetVarPtr_(const PrimExpr &expr);

--- a/testing/python/jit/test_tilelang_jit_cutedsl_host_codegen.py
+++ b/testing/python/jit/test_tilelang_jit_cutedsl_host_codegen.py
@@ -82,6 +82,27 @@ def repeated_dynamic_shape_program():
     return main
 
 
+def optional_stride_symbol_program():
+    """Create a program with an optional strided tensor stride symbol."""
+
+    N = T.dynamic("N")
+    stride = T.dynamic("stride")
+
+    @T.prim_func
+    def main(
+        source: T.Tensor((N,), T.float32),
+        optional: T.StridedTensor[(N,), (stride,), T.float32],
+        out: T.Tensor((N,), T.float32),
+    ):
+        with T.Kernel(T.ceildiv(N, 64), threads=64) as (bx,):
+            for i in T.Parallel(64):
+                idx = bx * 64 + i
+                if idx < N:
+                    out[idx] = source[idx]
+
+    return main
+
+
 def two_kernel_program(N, block_size=64, dtype=T.float32):
     """Create a program with two lowered host kernel call sites."""
 
@@ -244,6 +265,25 @@ def test_cutedsl_adapter_resolves_dynamic_symbol_from_live_tensor_candidate():
     assert len(adapter.dynamic_symbolic_order) == 1
     dynamic_symbol = adapter.dynamic_symbolic_order[0]
     assert adapter._resolve_dynamic_symbolic_value(dynamic_symbol, [None, torch.empty(7), torch.empty(7)]) == 7
+    with pytest.raises(TypeError, match="no live tensor source"):
+        adapter._resolve_dynamic_symbolic_value(dynamic_symbol, [None, None, None])
+
+
+def test_cutedsl_adapter_allows_optional_stride_symbol_without_live_tensor():
+    """Dynamic stride-only symbols may be absent for optional tensor params."""
+
+    from tilelang.jit.adapter.cutedsl.adapter import CuTeDSLKernelAdapter
+
+    program = optional_stride_symbol_program()
+    adapter = CuTeDSLKernelAdapter.__new__(CuTeDSLKernelAdapter)
+    adapter.ir_module = tilelang.tvm.IRModule({program.attrs["global_symbol"]: program})
+    adapter.dynamic_symbolic_map, adapter.dynamic_symbolic_order = adapter._process_dynamic_symbolic()
+
+    dynamic_symbols = {sym.name: sym for sym in adapter.dynamic_symbolic_order}
+    param_values = [torch.empty(7), None, torch.empty(7)]
+
+    assert adapter._resolve_dynamic_symbolic_value(dynamic_symbols["N"], param_values) == 7
+    assert adapter._resolve_dynamic_symbolic_value(dynamic_symbols["stride"], param_values) == 0
 
 
 def test_cutedsl_cache_restore_does_not_fallback_to_host_source(monkeypatch, tmp_path):

--- a/testing/python/jit/test_tilelang_jit_cutedsl_host_codegen.py
+++ b/testing/python/jit/test_tilelang_jit_cutedsl_host_codegen.py
@@ -73,11 +73,7 @@ def repeated_dynamic_shape_program():
         source: T.Tensor((N,), T.float32),
         out: T.Tensor((N,), T.float32),
     ):
-        with T.Kernel(T.ceildiv(N, 64), threads=64) as (bx,):
-            for i in T.Parallel(64):
-                idx = bx * 64 + i
-                if idx < N:
-                    out[idx] = source[idx]
+        T.evaluate(0)
 
     return main
 
@@ -94,11 +90,25 @@ def optional_stride_symbol_program():
         optional: T.StridedTensor[(N,), (stride,), T.float32],
         out: T.Tensor((N,), T.float32),
     ):
-        with T.Kernel(T.ceildiv(N, 64), threads=64) as (bx,):
-            for i in T.Parallel(64):
-                idx = bx * 64 + i
-                if idx < N:
-                    out[idx] = source[idx]
+        T.evaluate(0)
+
+    return main
+
+
+def optional_shape_symbol_program():
+    """Create a program with shape symbols that only belong to optional inputs."""
+
+    N = T.dynamic("N")
+    M = T.dynamic("M")
+
+    @T.prim_func
+    def main(
+        source: T.Tensor((N,), T.float32),
+        optional_a: T.Tensor((M,), T.float32),
+        optional_b: T.Tensor((M,), T.float32),
+        out: T.Tensor((N,), T.float32),
+    ):
+        T.evaluate(0)
 
     return main
 
@@ -255,6 +265,8 @@ def test_cutedsl_adapter_exposes_device_and_host_sources():
 def test_cutedsl_adapter_resolves_dynamic_symbol_from_live_tensor_candidate():
     """Dynamic shape resolution should skip optional None tensor params."""
 
+    _require_cutedsl()
+
     from tilelang.jit.adapter.cutedsl.adapter import CuTeDSLKernelAdapter
 
     program = repeated_dynamic_shape_program()
@@ -272,6 +284,8 @@ def test_cutedsl_adapter_resolves_dynamic_symbol_from_live_tensor_candidate():
 def test_cutedsl_adapter_allows_optional_stride_symbol_without_live_tensor():
     """Dynamic stride-only symbols may be absent for optional tensor params."""
 
+    _require_cutedsl()
+
     from tilelang.jit.adapter.cutedsl.adapter import CuTeDSLKernelAdapter
 
     program = optional_stride_symbol_program()
@@ -284,6 +298,27 @@ def test_cutedsl_adapter_allows_optional_stride_symbol_without_live_tensor():
 
     assert adapter._resolve_dynamic_symbolic_value(dynamic_symbols["N"], param_values) == 7
     assert adapter._resolve_dynamic_symbolic_value(dynamic_symbols["stride"], param_values) == 0
+
+
+def test_cutedsl_adapter_allows_optional_abi_shape_symbol_without_live_tensor():
+    """Dynamic shape symbols may be absent when only needed as dead ABI args."""
+
+    _require_cutedsl()
+
+    from tilelang.jit.adapter.cutedsl.adapter import CuTeDSLKernelAdapter
+
+    program = optional_shape_symbol_program()
+    adapter = CuTeDSLKernelAdapter.__new__(CuTeDSLKernelAdapter)
+    adapter.ir_module = tilelang.tvm.IRModule({program.attrs["global_symbol"]: program})
+    adapter.dynamic_symbolic_map, adapter.dynamic_symbolic_order = adapter._process_dynamic_symbolic()
+
+    dynamic_symbols = {sym.name: sym for sym in adapter.dynamic_symbolic_order}
+    param_values = [torch.empty(7), None, None, torch.empty(7)]
+
+    assert adapter._resolve_dynamic_symbolic_value(dynamic_symbols["N"], param_values) == 7
+    with pytest.raises(TypeError, match="no live tensor source"):
+        adapter._resolve_dynamic_symbolic_value(dynamic_symbols["M"], param_values)
+    assert adapter._resolve_dynamic_symbolic_value(dynamic_symbols["M"], param_values, require_live_shape=False) == 0
 
 
 def test_cutedsl_cache_restore_does_not_fallback_to_host_source(monkeypatch, tmp_path):

--- a/testing/python/jit/test_tilelang_jit_cutedsl_host_codegen.py
+++ b/testing/python/jit/test_tilelang_jit_cutedsl_host_codegen.py
@@ -1,6 +1,7 @@
 """Tests for CuTeDSL host codegen integration."""
 
 import pytest
+import torch
 import tilelang
 import tilelang.language as T
 import tilelang.testing
@@ -57,6 +58,26 @@ def single_kernel_program(N, block_size=64, dtype=T.float32):
                 idx = bx * block_size + i
                 if idx < N:
                     B[idx] = A[idx] + 1.0
+
+    return main
+
+
+def repeated_dynamic_shape_program():
+    """Create a program where one dynamic symbol appears in multiple params."""
+
+    N = T.dynamic("N")
+
+    @T.prim_func
+    def main(
+        optional: T.Tensor((N,), T.float32),
+        source: T.Tensor((N,), T.float32),
+        out: T.Tensor((N,), T.float32),
+    ):
+        with T.Kernel(T.ceildiv(N, 64), threads=64) as (bx,):
+            for i in T.Parallel(64):
+                idx = bx * 64 + i
+                if idx < N:
+                    out[idx] = source[idx]
 
     return main
 
@@ -208,6 +229,21 @@ def test_cutedsl_adapter_exposes_device_and_host_sources():
     assert "_generate_cubin_if_needed" in host_source
     assert device_source in combined_source
     assert host_source in combined_source
+
+
+def test_cutedsl_adapter_resolves_dynamic_symbol_from_live_tensor_candidate():
+    """Dynamic shape resolution should skip optional None tensor params."""
+
+    from tilelang.jit.adapter.cutedsl.adapter import CuTeDSLKernelAdapter
+
+    program = repeated_dynamic_shape_program()
+    adapter = CuTeDSLKernelAdapter.__new__(CuTeDSLKernelAdapter)
+    adapter.ir_module = tilelang.tvm.IRModule({program.attrs["global_symbol"]: program})
+    adapter.dynamic_symbolic_map, adapter.dynamic_symbolic_order = adapter._process_dynamic_symbolic()
+
+    assert len(adapter.dynamic_symbolic_order) == 1
+    dynamic_symbol = adapter.dynamic_symbolic_order[0]
+    assert adapter._resolve_dynamic_symbolic_value(dynamic_symbol, [None, torch.empty(7), torch.empty(7)]) == 7
 
 
 def test_cutedsl_cache_restore_does_not_fallback_to_host_source(monkeypatch, tmp_path):

--- a/testing/python/language/test_tilelang_language_scan.py
+++ b/testing/python/language/test_tilelang_language_scan.py
@@ -392,13 +392,16 @@ def run_cummax(M, N, block_M, block_N, dim=0, reverse=False, dtype=T.float32, sc
     torch.testing.assert_close(tilelang_res, ref_res, atol=1e-3, rtol=1e-3)
 
 
-def cummax_smem_test_1d(N, block_N, reverse=False, dtype=T.float32):
+def cummax_smem_test_1d(N, block_N, reverse=False, dtype=T.float32, threads=None):
+    if threads is None:
+        threads = block_N
+
     @T.prim_func
     def cummax(
         A: T.Tensor((N,), dtype),
         B: T.Tensor((N,), dtype),
     ):
-        with T.Kernel(T.ceildiv(N, block_N), threads=block_N) as bx:
+        with T.Kernel(T.ceildiv(N, block_N), threads=threads) as bx:
             A_shared = T.alloc_shared((block_N,), dtype)
 
             T.copy(A[bx * block_N], A_shared)
@@ -426,16 +429,20 @@ def cummax_fragment_test_1d(N, block_N, reverse=False, dtype=T.float32):
     return cummax
 
 
-def run_cummax_1d(N, block_N, reverse=False, dtype=T.float32, scope="smem"):
+def run_cummax_1d(N, block_N, reverse=False, dtype=T.float32, scope="smem", negative_input=False, threads=None):
     if scope == "smem":
-        program = cummax_smem_test_1d(N, block_N, reverse, dtype)
+        program = cummax_smem_test_1d(N, block_N, reverse, dtype, threads)
     elif scope == "fragment":
         program = cummax_fragment_test_1d(N, block_N, reverse, dtype)
     else:
         raise ValueError(f"Unknown scope {scope}")
 
     jit_kernel = tl.compile(program, out_idx=-1)
-    A = torch.randn(N, dtype=getattr(torch, dtype)).cuda()
+    torch_dtype = getattr(torch, dtype)
+    if negative_input:
+        A = -torch.arange(1, N + 1, dtype=torch.float32, device="cuda").to(torch_dtype)
+    else:
+        A = torch.randn(N, dtype=torch_dtype).cuda()
 
     def ref_program(A):
         ref_b = torch.empty_like(A)
@@ -472,6 +479,7 @@ def test_cummax_out_of_place():
 def test_cummax_smem_1d():
     run_cummax_1d(512, 64)
     run_cummax_1d(512, 64, reverse=True)
+    run_cummax_1d(80, 40, reverse=True, negative_input=True, threads=64)
 
 
 def test_cummax_fragment_1d():

--- a/testing/python/target/test_tilelang_codegen_cutedsl_integer_shift.py
+++ b/testing/python/target/test_tilelang_codegen_cutedsl_integer_shift.py
@@ -1,0 +1,53 @@
+import pytest
+
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+from tilelang.engine.lower import lower
+from tilelang.cuda.target import normalize_cutedsl_target
+
+
+def _lower_cutedsl(program):
+    if not tvm.runtime.enabled("cuda"):
+        pytest.skip("TileLang CuTeDSL codegen requires TVM built with CUDA support.")
+
+    build_cutedsl = tvm.ffi.get_global_func("target.build.tilelang_cutedsl_without_compile", allow_missing=True)
+    if build_cutedsl is None:
+        pytest.skip("TileLang CuTeDSL backend is not enabled in this build.")
+
+    target = normalize_cutedsl_target({"kind": "cutedsl", "arch": "sm_80"})
+    assert target is not None
+
+    with target:
+        return lower(program.with_attr("global_symbol", "main"), target=target)
+
+
+def test_cutedsl_codegen_promotes_narrow_shift_before_wide_cast():
+    @T.prim_func
+    def prog(A: T.Tensor((1,), "uint16"), B: T.Tensor((1,), "uint32")):
+        with T.Kernel(1, threads=1):
+            local = T.alloc_local((1,), "uint16")
+            local[0] = A[0]
+            B[0] = T.cast(local[0] << 20, T.uint32)
+
+    artifact = _lower_cutedsl(prog)
+
+    assert "cutlass.Uint32(local[0]) << cutlass.Uint16(20)" in artifact.kernel_source
+    assert "cutlass.Uint32(cutlass.Uint16((local[0] << cutlass.Uint16(20))))" not in artifact.kernel_source
+
+
+def test_cutedsl_codegen_does_not_promote_shift_across_signedness():
+    @T.prim_func
+    def prog(A: T.Tensor((1,), "int8"), B: T.Tensor((1,), "uint16")):
+        with T.Kernel(1, threads=1):
+            local = T.alloc_local((1,), "int8")
+            local[0] = A[0]
+            B[0] = T.cast(local[0] >> 1, T.uint16)
+
+    artifact = _lower_cutedsl(prog)
+
+    assert "cutlass.Uint16(local[0]) >>" not in artifact.kernel_source
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/contrib/cutedsl/reduce.py
+++ b/tilelang/contrib/cutedsl/reduce.py
@@ -115,7 +115,7 @@ def bar_sync_ptx(barrier_id, number_of_threads):
 
 
 # Import shuffle functions from warp module
-from .warp import __shfl_up_sync, __shfl_down_sync
+from .warp import __shfl_sync, __shfl_up_sync, __shfl_down_sync
 
 
 def _warp_prefix_sum_forward(val, lane, MASK=0xFFFFFFFF):
@@ -123,7 +123,7 @@ def _warp_prefix_sum_forward(val, lane, MASK=0xFFFFFFFF):
     Warp-level inclusive prefix sum (forward).
     Uses shfl.up to propagate values from lower lanes.
     """
-    # Unrolled loop for SEG=32: off = 1, 2, 4, 8, 16
+    # Unrolled loop for WARP_SIZE=32: off = 1, 2, 4, 8, 16
     n = __shfl_up_sync(MASK, val, 1)
     val = cutlass.select_(lane >= 1, val + n, val)
     n = __shfl_up_sync(MASK, val, 2)
@@ -142,18 +142,18 @@ def _warp_prefix_sum_reverse(val, lane, MASK=0xFFFFFFFF):
     Warp-level inclusive prefix sum (reverse).
     Uses shfl.down to propagate values from higher lanes.
     """
-    SEG = 32
-    # Unrolled loop for SEG=32: off = 1, 2, 4, 8, 16
+    WARP_SIZE = 32
+    # Unrolled loop for WARP_SIZE=32: off = 1, 2, 4, 8, 16
     n = __shfl_down_sync(MASK, val, 1)
-    val = cutlass.select_(lane < SEG - 1, val + n, val)
+    val = cutlass.select_(lane < WARP_SIZE - 1, val + n, val)
     n = __shfl_down_sync(MASK, val, 2)
-    val = cutlass.select_(lane < SEG - 2, val + n, val)
+    val = cutlass.select_(lane < WARP_SIZE - 2, val + n, val)
     n = __shfl_down_sync(MASK, val, 4)
-    val = cutlass.select_(lane < SEG - 4, val + n, val)
+    val = cutlass.select_(lane < WARP_SIZE - 4, val + n, val)
     n = __shfl_down_sync(MASK, val, 8)
-    val = cutlass.select_(lane < SEG - 8, val + n, val)
+    val = cutlass.select_(lane < WARP_SIZE - 8, val + n, val)
     n = __shfl_down_sync(MASK, val, 16)
-    val = cutlass.select_(lane < SEG - 16, val + n, val)
+    val = cutlass.select_(lane < WARP_SIZE - 16, val + n, val)
     return val
 
 
@@ -172,20 +172,105 @@ def _warp_prefix_max_forward(val, lane, MASK=0xFFFFFFFF):
     return val
 
 
-def _warp_prefix_max_reverse(val, lane, MASK=0xFFFFFFFF):
+def _warp_prefix_max_reverse(val, lane, active, MASK=0xFFFFFFFF):
     """Warp-level inclusive prefix max (reverse)."""
-    SEG = 32
     n = __shfl_down_sync(MASK, val, 1)
-    val = cutlass.select_(lane < SEG - 1, max(val, n), val)
+    val = cutlass.select_(lane + 1 < active, max(val, n), val)
     n = __shfl_down_sync(MASK, val, 2)
-    val = cutlass.select_(lane < SEG - 2, max(val, n), val)
+    val = cutlass.select_(lane + 2 < active, max(val, n), val)
     n = __shfl_down_sync(MASK, val, 4)
-    val = cutlass.select_(lane < SEG - 4, max(val, n), val)
+    val = cutlass.select_(lane + 4 < active, max(val, n), val)
     n = __shfl_down_sync(MASK, val, 8)
-    val = cutlass.select_(lane < SEG - 8, max(val, n), val)
+    val = cutlass.select_(lane + 8 < active, max(val, n), val)
     n = __shfl_down_sync(MASK, val, 16)
-    val = cutlass.select_(lane < SEG - 16, max(val, n), val)
+    val = cutlass.select_(lane + 16 < active, max(val, n), val)
     return val
+
+
+@cute.jit
+def _scan_line_sum(src_tensor, dst_tensor, base_offset, extent, stride, lane, reverse, MASK=0xFFFFFFFF):
+    """Inclusive sum scan over one strided line using one warp."""
+    WARP_SIZE = 32
+    carry = src_tensor.element_type(0)
+    has_carry = False
+    num_segments = (extent + WARP_SIZE - 1) // WARP_SIZE
+
+    if reverse:
+        for seg_offset in range(num_segments):
+            seg = num_segments - 1 - seg_offset
+            base = seg * WARP_SIZE
+            active = min(extent - base, WARP_SIZE)
+            val = src_tensor.element_type(0)
+            if lane < active:
+                val = src_tensor[base_offset + (base + lane) * stride]
+
+            val = _warp_prefix_sum_reverse(val, lane, MASK)
+            if has_carry and lane < active:
+                val = val + carry
+            if lane < active:
+                dst_tensor[base_offset + (base + lane) * stride] = val
+
+            carry = __shfl_sync(MASK, val, 0)
+            has_carry = True
+    else:
+        for seg in range(num_segments):
+            base = seg * WARP_SIZE
+            active = min(extent - base, WARP_SIZE)
+            val = src_tensor.element_type(0)
+            if lane < active:
+                val = src_tensor[base_offset + (base + lane) * stride]
+
+            val = _warp_prefix_sum_forward(val, lane, MASK)
+            if has_carry and lane < active:
+                val = val + carry
+            if lane < active:
+                dst_tensor[base_offset + (base + lane) * stride] = val
+
+            carry = __shfl_sync(MASK, val, active - 1)
+            has_carry = True
+
+
+@cute.jit
+def _scan_line_max(src_tensor, dst_tensor, base_offset, extent, stride, lane, reverse, MASK=0xFFFFFFFF):
+    """Inclusive max scan over one strided line using one warp."""
+    WARP_SIZE = 32
+    carry = src_tensor.element_type(0)
+    has_carry = False
+    num_segments = (extent + WARP_SIZE - 1) // WARP_SIZE
+
+    if reverse:
+        for seg_offset in range(num_segments):
+            seg = num_segments - 1 - seg_offset
+            base = seg * WARP_SIZE
+            active = min(extent - base, WARP_SIZE)
+            val = src_tensor.element_type(0)
+            if lane < active:
+                val = src_tensor[base_offset + (base + lane) * stride]
+
+            val = _warp_prefix_max_reverse(val, lane, active, MASK)
+            if has_carry and lane < active:
+                val = max(val, carry)
+            if lane < active:
+                dst_tensor[base_offset + (base + lane) * stride] = val
+
+            carry = __shfl_sync(MASK, val, 0)
+            has_carry = True
+    else:
+        for seg in range(num_segments):
+            base = seg * WARP_SIZE
+            active = min(extent - base, WARP_SIZE)
+            val = src_tensor.element_type(0)
+            if lane < active:
+                val = src_tensor[base_offset + (base + lane) * stride]
+
+            val = _warp_prefix_max_forward(val, lane, MASK)
+            if has_carry and lane < active:
+                val = max(val, carry)
+            if lane < active:
+                dst_tensor[base_offset + (base + lane) * stride] = val
+
+            carry = __shfl_sync(MASK, val, active - 1)
+            has_carry = True
 
 
 class CumSum1D:
@@ -201,7 +286,7 @@ class CumSum1D:
     def __init__(self, threads: cutlass.Constexpr[int], reverse: cutlass.Constexpr[bool]):
         self.threads = threads
         self.reverse = reverse
-        self.SEG = 32  # Warp size
+        self.WARP_SIZE = 32
 
     @cute.jit
     def run(self, src: cute.Pointer, dst: cute.Pointer, N):
@@ -215,25 +300,13 @@ class CumSum1D:
         """
         MASK = 0xFFFFFFFF
         tidx, _, _ = cute.arch.thread_idx()
-        lane = tidx % self.SEG
+        lane = tidx % self.WARP_SIZE
 
         src_tensor = cute.make_tensor(src, (N,))
         dst_tensor = cute.make_tensor(dst, (N,))
 
-        # Load value (0 if out of bounds)
-        val = src_tensor.element_type(0)
-        if tidx < N:
-            val = src_tensor[tidx]
-
-        # Warp-level prefix sum
-        if self.reverse:
-            val = _warp_prefix_sum_reverse(val, lane, MASK)
-        else:
-            val = _warp_prefix_sum_forward(val, lane, MASK)
-
-        # Store result - only valid threads write
-        if tidx < N:
-            dst_tensor[tidx] = val
+        if tidx < self.WARP_SIZE:
+            _scan_line_sum(src_tensor, dst_tensor, 0, N, 1, lane, self.reverse, MASK)
 
 
 class CumSum2D:
@@ -251,8 +324,8 @@ class CumSum2D:
         self.threads = threads
         self.dim = dim
         self.reverse = reverse
-        self.SEG = 32  # Warp size
-        self.TILE_H = threads // 32
+        self.WARP_SIZE = 32
+        self.TILE_H = threads // self.WARP_SIZE
 
     @cute.jit
     def run(self, src: cute.Pointer, dst: cute.Pointer, H, W):
@@ -267,61 +340,25 @@ class CumSum2D:
         """
         MASK = 0xFFFFFFFF
         tidx, _, _ = cute.arch.thread_idx()
-        lane = tidx % self.SEG
-        row = tidx // self.SEG
+        lane = tidx % self.WARP_SIZE
+        item = tidx // self.WARP_SIZE
+        tile = self.threads // self.WARP_SIZE
 
         src_tensor = cute.make_tensor(src, (H * W,))
         dst_tensor = cute.make_tensor(dst, (H * W,))
 
-        # For 2D cumsum along dim=1 (row-wise cumsum):
-        # Each warp handles one row, lane id is the column index
-        # For dim=0 (column-wise), interpretation is swapped
-
         if self.dim == 1:
-            # Row-wise cumsum: each warp processes one row
-            # row = which row this warp handles
-            # lane = column index within the row
-            col = lane
-            # Linear index into the flattened buffer
-            idx = row * W + col
-
-            # Load value (0 if out of bounds)
-            val = src_tensor.element_type(0)
-            if row < H and col < W:
-                val = src_tensor[idx]
-
-            # Warp-level prefix sum along the row
-            if self.reverse:
-                val = _warp_prefix_sum_reverse(val, lane, MASK)
-            else:
-                val = _warp_prefix_sum_forward(val, lane, MASK)
-
-            # Store result - only valid threads write
-            if row < H and col < W:
-                dst_tensor[idx] = val
+            num_blocks = (H + tile - 1) // tile
+            for block in cutlass.range_constexpr(num_blocks):
+                row = block * tile + item
+                if row < H:
+                    _scan_line_sum(src_tensor, dst_tensor, row * W, W, 1, lane, self.reverse, MASK)
         else:
-            # Column-wise cumsum (dim=0): each warp processes one column
-            # Each lane maps to a row index, so H must be <= 32 (warp size).
-            assert H <= 32, (
-                f"CumSum2D dim=0 only supports H <= 32 (got H={H}). Use dim=1 for row-wise cumsum or implement multi-warp column iteration."
-            )
-            col = row  # warp index becomes column index
-            row_in_col = lane  # lane becomes row index within column
-            idx = row_in_col * W + col
-
-            # Load value (0 if out of bounds)
-            val = src_tensor.element_type(0)
-            if row_in_col < H and col < W:
-                val = src_tensor[idx]
-
-            if self.reverse:
-                val = _warp_prefix_sum_reverse(val, lane, MASK)
-            else:
-                val = _warp_prefix_sum_forward(val, lane, MASK)
-
-            # Store result - only valid threads write
-            if row_in_col < H and col < W:
-                dst_tensor[idx] = val
+            num_blocks = (W + tile - 1) // tile
+            for block in cutlass.range_constexpr(num_blocks):
+                col = block * tile + item
+                if col < W:
+                    _scan_line_sum(src_tensor, dst_tensor, col, H, W, lane, self.reverse, MASK)
 
 
 class CumMax1D:
@@ -333,28 +370,19 @@ class CumMax1D:
     def __init__(self, threads: cutlass.Constexpr[int], reverse: cutlass.Constexpr[bool]):
         self.threads = threads
         self.reverse = reverse
-        self.SEG = 32
+        self.WARP_SIZE = 32
 
     @cute.jit
     def run(self, src: cute.Pointer, dst: cute.Pointer, N):
         MASK = 0xFFFFFFFF
         tidx, _, _ = cute.arch.thread_idx()
-        lane = tidx % self.SEG
+        lane = tidx % self.WARP_SIZE
 
         src_tensor = cute.make_tensor(src, (N,))
         dst_tensor = cute.make_tensor(dst, (N,))
 
-        val = src_tensor[0]
-        if tidx < N:
-            val = src_tensor[tidx]
-
-        if self.reverse:
-            val = _warp_prefix_max_reverse(val, lane, MASK)
-        else:
-            val = _warp_prefix_max_forward(val, lane, MASK)
-
-        if tidx < N:
-            dst_tensor[tidx] = val
+        if tidx < self.WARP_SIZE:
+            _scan_line_max(src_tensor, dst_tensor, 0, N, 1, lane, self.reverse, MASK)
 
 
 class CumMax2D:
@@ -367,56 +395,31 @@ class CumMax2D:
         self.threads = threads
         self.dim = dim
         self.reverse = reverse
-        self.SEG = 32
+        self.WARP_SIZE = 32
 
     @cute.jit
     def run(self, src: cute.Pointer, dst: cute.Pointer, H, W):
         MASK = 0xFFFFFFFF
         tidx, _, _ = cute.arch.thread_idx()
-        lane = tidx % self.SEG
-        row = tidx // self.SEG
+        lane = tidx % self.WARP_SIZE
+        item = tidx // self.WARP_SIZE
+        tile = self.threads // self.WARP_SIZE
 
         src_tensor = cute.make_tensor(src, (H * W,))
         dst_tensor = cute.make_tensor(dst, (H * W,))
 
         if self.dim == 1:
-            col = lane
-            idx = row * W + col
-
-            val = src_tensor.element_type(0)
-            if row < H:
-                val = src_tensor[row * W]
-            if row < H and col < W:
-                val = src_tensor[idx]
-
-            if self.reverse:
-                val = _warp_prefix_max_reverse(val, lane, MASK)
-            else:
-                val = _warp_prefix_max_forward(val, lane, MASK)
-
-            if row < H and col < W:
-                dst_tensor[idx] = val
+            num_blocks = (H + tile - 1) // tile
+            for block in cutlass.range_constexpr(num_blocks):
+                row = block * tile + item
+                if row < H:
+                    _scan_line_max(src_tensor, dst_tensor, row * W, W, 1, lane, self.reverse, MASK)
         else:
-            assert H <= 32, (
-                f"CumMax2D dim=0 only supports H <= 32 (got H={H}). Use dim=1 for row-wise cummax or implement multi-warp column iteration."
-            )
-            col = row
-            row_in_col = lane
-            idx = row_in_col * W + col
-
-            val = src_tensor.element_type(0)
-            if col < W:
-                val = src_tensor[col]
-            if row_in_col < H and col < W:
-                val = src_tensor[idx]
-
-            if self.reverse:
-                val = _warp_prefix_max_reverse(val, lane, MASK)
-            else:
-                val = _warp_prefix_max_forward(val, lane, MASK)
-
-            if row_in_col < H and col < W:
-                dst_tensor[idx] = val
+            num_blocks = (W + tile - 1) // tile
+            for block in cutlass.range_constexpr(num_blocks):
+                col = block * tile + item
+                if col < W:
+                    _scan_line_max(src_tensor, dst_tensor, col, H, W, lane, self.reverse, MASK)
 
 
 class NamedBarrier:

--- a/tilelang/jit/adapter/cutedsl/adapter.py
+++ b/tilelang/jit/adapter/cutedsl/adapter.py
@@ -255,7 +255,16 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
         """Resolve a dynamic shape/stride variable from the first live tensor source."""
         candidates = self._lookup_dynamic_symbolic_candidates(v)
         non_tensor_values: list[tuple[int, Any]] = []
+        has_shape_candidate = False
+        has_stride_candidate = False
         for ref_id, buffer_idx, dim_idx in candidates:
+            if ref_id == 0:
+                has_shape_candidate = True
+            elif ref_id == 1:
+                has_stride_candidate = True
+            else:
+                raise ValueError(f"Unknown dynamic symbol ref id: {ref_id}")
+
             ref_val = param_values[buffer_idx]
             if not isinstance(ref_val, torch.Tensor):
                 non_tensor_values.append((buffer_idx, ref_val))
@@ -264,7 +273,13 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
                 return ref_val.shape[dim_idx]
             if ref_id == 1:
                 return ref_val.stride()[dim_idx]
-            raise ValueError(f"Unknown dynamic symbol ref id: {ref_id}")
+
+        # Optional strided tensors can be absent from a lowered kernel variant
+        # while their dynamic stride remains in the host wrapper ABI. Shape
+        # symbols still require a live tensor source because they determine
+        # output allocation and launch dimensions.
+        if has_stride_candidate and not has_shape_candidate:
+            return 0
 
         details = ", ".join(f"param {buffer_idx}: {type(ref_val).__name__}" for buffer_idx, ref_val in non_tensor_values)
         raise TypeError(f"Dynamic symbolic var {v} has no live tensor source among candidates ({details})")

--- a/tilelang/jit/adapter/cutedsl/adapter.py
+++ b/tilelang/jit/adapter/cutedsl/adapter.py
@@ -191,6 +191,8 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
         buffer_map = func.buffer_map
         dynamic_symbolic_map: dict[tirx.Var, tuple[int, int, int]] = {}
         dynamic_symbolic_order: list[tirx.Var] = []
+        self._dynamic_symbolic_candidates_map: dict[tirx.Var, list[tuple[int, int, int]]] = {}
+        self._dynamic_symbolic_name_candidates_map: dict[str, list[tuple[int, int, int]]] = {}
         # Secondary index by variable name for fallback lookup when tirx.Var
         # object identity differs (e.g. params created from a different
         # PrimFunc instance than the one stored in ir_module).
@@ -198,6 +200,8 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
 
         def unique_push_back(v: tirx.Var, entry: tuple[int, int, int]):
             """Append one symbolic variable unless it has already been seen."""
+            self._dynamic_symbolic_candidates_map.setdefault(v, []).append(entry)
+            self._dynamic_symbolic_name_candidates_map.setdefault(v.name, []).append(entry)
             if v in dynamic_symbolic_map:
                 return
             dynamic_symbolic_map[v] = entry
@@ -238,6 +242,32 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
         if v.name in self._dynamic_symbolic_name_map:
             return self._dynamic_symbolic_name_map[v.name]
         raise KeyError(f"Dynamic symbolic variable '{v.name}' not found in symbolic map")
+
+    def _lookup_dynamic_symbolic_candidates(self, v: tirx.Var) -> list[tuple[int, int, int]]:
+        """Return all shape/stride sources for a dynamic symbolic variable."""
+        if v in self._dynamic_symbolic_candidates_map:
+            return self._dynamic_symbolic_candidates_map[v]
+        if v.name in self._dynamic_symbolic_name_candidates_map:
+            return self._dynamic_symbolic_name_candidates_map[v.name]
+        raise KeyError(f"Dynamic symbolic variable '{v.name}' not found in symbolic map")
+
+    def _resolve_dynamic_symbolic_value(self, v: tirx.Var, param_values: list[Any]) -> int:
+        """Resolve a dynamic shape/stride variable from the first live tensor source."""
+        candidates = self._lookup_dynamic_symbolic_candidates(v)
+        non_tensor_values: list[tuple[int, Any]] = []
+        for ref_id, buffer_idx, dim_idx in candidates:
+            ref_val = param_values[buffer_idx]
+            if not isinstance(ref_val, torch.Tensor):
+                non_tensor_values.append((buffer_idx, ref_val))
+                continue
+            if ref_id == 0:
+                return ref_val.shape[dim_idx]
+            if ref_id == 1:
+                return ref_val.stride()[dim_idx]
+            raise ValueError(f"Unknown dynamic symbol ref id: {ref_id}")
+
+        details = ", ".join(f"param {buffer_idx}: {type(ref_val).__name__}" for buffer_idx, ref_val in non_tensor_values)
+        raise TypeError(f"Dynamic symbolic var {v} has no live tensor source among candidates ({details})")
 
     def get_host_source(self) -> str | None:
         """Get the cached host-side source code."""
@@ -369,17 +399,7 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
                 # Now working with native Python list, no FFI calls needed
                 for s in self.param_shapes[i]:
                     if isinstance(s, tirx.Var):
-                        ref_id, ref_param_idx, ref_dim_idx = self._lookup_dynamic_symbolic(s)
-                        ref_val = param_values[ref_param_idx]
-                        if not isinstance(ref_val, torch.Tensor):
-                            raise TypeError(f"Dynamic shape/stride var {s} refers to a non-tensor param at index {ref_param_idx}")
-                        if ref_id == 0:
-                            shape.append(ref_val.shape[ref_dim_idx])
-                        elif ref_id == 1:
-                            # Stride vars are not expected in output shapes, but handle defensively.
-                            shape.append(ref_val.stride()[ref_dim_idx])
-                        else:
-                            raise ValueError(f"Unknown dynamic symbol ref id: {ref_id}")
+                        shape.append(self._resolve_dynamic_symbolic_value(s, param_values))
                     else:  # Already converted to Python int during initialization
                         shape.append(s)
                 tensor = torch.empty(*shape, dtype=dtype, device=first_tensor.device)
@@ -390,24 +410,7 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
 
         # dynamic symbolics
         for sym in self.dynamic_symbolic_order:
-            ref_id, buffer_idx, dim_idx = self.dynamic_symbolic_map[sym]
-            ref_val = param_values[buffer_idx]
-            if not isinstance(ref_val, torch.Tensor):
-                if ref_val is None:
-                    logger.warning(
-                        "Dynamic symbolic var %s refers to param index %s, but the runtime value is None; using 0 as a fallback",
-                        sym,
-                        buffer_idx,
-                    )
-                    args.append(0)
-                    continue
-                raise TypeError(f"Dynamic symbolic var {sym} refers to a non-tensor param at index {buffer_idx}")
-            if ref_id == 0:
-                args.append(ref_val.shape[dim_idx])
-            elif ref_id == 1:
-                args.append(ref_val.stride()[dim_idx])
-            else:
-                raise ValueError(f"Unknown dynamic symbol ref id: {ref_id}")
+            args.append(self._resolve_dynamic_symbolic_value(sym, param_values))
 
         # if stream is not None, we need to pass the stream to the library
         if stream is None:

--- a/tilelang/jit/adapter/cutedsl/adapter.py
+++ b/tilelang/jit/adapter/cutedsl/adapter.py
@@ -251,7 +251,13 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
             return self._dynamic_symbolic_name_candidates_map[v.name]
         raise KeyError(f"Dynamic symbolic variable '{v.name}' not found in symbolic map")
 
-    def _resolve_dynamic_symbolic_value(self, v: tirx.Var, param_values: list[Any]) -> int:
+    def _resolve_dynamic_symbolic_value(
+        self,
+        v: tirx.Var,
+        param_values: list[Any],
+        *,
+        require_live_shape: bool = True,
+    ) -> int:
         """Resolve a dynamic shape/stride variable from the first live tensor source."""
         candidates = self._lookup_dynamic_symbolic_candidates(v)
         non_tensor_values: list[tuple[int, Any]] = []
@@ -274,11 +280,14 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
             if ref_id == 1:
                 return ref_val.stride()[dim_idx]
 
-        # Optional strided tensors can be absent from a lowered kernel variant
-        # while their dynamic stride remains in the host wrapper ABI. Shape
-        # symbols still require a live tensor source because they determine
-        # output allocation and launch dimensions.
+        # Optional tensors can be absent from a lowered kernel variant while
+        # their dynamic shape/stride remains in the host wrapper ABI. Output
+        # allocation still calls this helper in the default strict mode, so a
+        # live tensor remains required for any shape symbol that materializes a
+        # result tensor.
         if has_stride_candidate and not has_shape_candidate:
+            return 0
+        if has_shape_candidate and not require_live_shape:
             return 0
 
         details = ", ".join(f"param {buffer_idx}: {type(ref_val).__name__}" for buffer_idx, ref_val in non_tensor_values)
@@ -425,7 +434,7 @@ class CuTeDSLKernelAdapter(BaseKernelAdapter):
 
         # dynamic symbolics
         for sym in self.dynamic_symbolic_order:
-            args.append(self._resolve_dynamic_symbolic_value(sym, param_values))
+            args.append(self._resolve_dynamic_symbolic_value(sym, param_values, require_live_shape=False))
 
         # if stream is not None, we need to pass the stream to the library
         if stream is None:


### PR DESCRIPTION
## Summary

This PR fixes the CuTeDSL lowering/runtime gaps that blocked TileKernels full functional coverage on H100, plus small review-driven correctness hardening for the same touched CuTeDSL paths.

## TileKernels Blockers

These are the changes directly needed by the TileKernels full CuTeDSL run:

- **Scan lowering and buffer addressing**
  - Rework `CumSum1D`/`CumSum2D` to carry prefix state across 32-lane segments, matching the CUDA scan behavior used by MoE routing prefix calculations.
  - Route `CumMax1D`/`CumMax2D` through the same line-scan implementation so the CuTeDSL scan helpers stay consistent.
  - Add shared index linearization for non-flat buffer loads/stores, `address_of`/`reinterpret`, and atomic pointer lowering.

- **Dynamic shape and optional tensor ABI handling**
  - Track all candidate sources for each dynamic symbol and resolve runtime values from the first live tensor.
  - Keep missing shape symbols strict for output allocation and launch dimensions.
  - Allow zero placeholders only for dead optional stride/ABI symbols that no longer have a live tensor source after optional-argument pruning.
  - Handle optional host ABI symbols in `top2_sum_gate` variants where optional tensors are compiled out.

- **CuTeDSL control-flow and mutable-vector correctness**
  - Recognize `if cond: stores; thread_return()` and guard the fallthrough body correctly.
  - Avoid reusing SSA aliases for vector operands containing `BufferLoad`, so mutable local tensors are reloaded after intervening stores.

- **E5M6 bit packing**
  - Promote narrow integer shift operands before widening casts, matching CUDA C integer-promotion behavior for packed e5m6 construction.

## Review Hardening

These are not separate TileKernels blockers. They are correctness boundaries for the same generic TileLang/CuTeDSL changes above and were added in response to review:

- Shift promotion now requires matching signedness, avoiding logical right shifts for signed source values widened to unsigned destinations.
- Rank-1 explicit-stride buffer accesses no longer bypass linearization, while vectorized/no-stride one-index `Ramp` accesses keep the previous fast path.
- Reverse `cummax` no longer lets inactive lanes in a partial segment contribute zero to negative-valued tails. The regression uses `block_N=40, threads=64` so CUDA's scan template constraints are respected while CuTeDSL still covers the `active=8` tail case.

## Commit Map

| Commit | Purpose |
| --- | --- |
| `[BugFix] Complete CuTeDSL scan lowering for TileKernels` | Scan carry across segments, non-flat buffer linearization, `match_any_sync`, thread-tag fallback, and review hardening for rank-1 stride / reverse-cummax tail semantics. |
| `[BugFix] Resolve CuTeDSL dynamic shapes from live tensors` | Resolve repeated dynamic symbols from live tensors instead of the first optional/`None` candidate. |
| `[BugFix] Permit dead optional CuTeDSL stride symbols` | Allow only stride-only dead optional ABI placeholders to resolve to zero. |
| `[BugFix] Fix CuTeDSL optional ABI and early-return codegen` | Optional host ABI placeholders, `stores; thread_return()` lowering, and mutable vector reload correctness. |
| `[BugFix] Promote narrow CuTeDSL shifts before wide casts` | Preserve e5m6 packed bits for `uint16 << 20` style expressions, with signedness guard. |

## Validation Environment

Local validation was run with:

- GPU: NVIDIA H100 PCIe
- CUDA toolkit / NVCC: CUDA 13.2, `nvcc` 13.2.78
- `cutlass.__version__`: 4.5.0

CuTeDSL-focused validation used:

```bash
TILELANG_TARGET=cutedsl
TILELANG_DISABLE_CACHE=1
```

For the CUDA-backend regression check that guards the shared language test, `TILELANG_TARGET` was intentionally left unset so the default CUDA backend path was exercised.

## Validation

- `cmake --build build -j 32`
- `ruff check testing/python/target/test_tilelang_codegen_cutedsl_integer_shift.py testing/python/language/test_tilelang_language_scan.py tilelang/contrib/cutedsl/reduce.py`
- `git diff --check origin/main..HEAD`
- `pytest testing/python/target/test_tilelang_codegen_cutedsl_integer_shift.py -q --tb=short`: 2 passed
- `pytest testing/python/target/test_tilelang_codegen_cutedsl_scan.py testing/python/language/test_tilelang_language_scan.py -q --tb=short` with `TILELANG_TARGET=cutedsl`: 13 passed
- `pytest testing/python/language/test_tilelang_language_scan.py::test_cummax_smem_1d -q --tb=short` with default CUDA backend: 1 passed
- `pytest testing/python/language/test_tilelang_language_scan.py::test_cummax_smem_1d -q --tb=short` with `TILELANG_TARGET=cutedsl`: 1 passed
- TileKernels full CuTeDSL run on H100 with `-n 2`: remaining failures were 8 reference-path CUDA OOM cases in `swiglu_backward_and_per_token_cast`; rerunning those exact node ids with `-n 1` passed, classifying them as parallel memory-budget failures rather than CuTeDSL correctness failures.

Co-authored-by: dingsg <shengge.ding@enflame-tech.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved CuTeDSL codegen for multi-dimensional buffer indexing and safer conditional return emission.
  * Reworked CuTeDSL segmented warp scans for `cumsum`/`cummax` with better correctness in tail segments.

* **Bug Fixes**
  * Fixed integer shift lowering by promoting narrow shifts before casts and avoiding incorrect cross-signedness promotion.
  * Enhanced dynamic symbol resolution for optional tensors (shape/stride now resolves from live inputs or uses configured fallback).

* **Tests**
  * Added/extended adapter and reduction/codegen regression tests, including optional-symbol cases and additional `cummax` scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->