### PR TITLE
[Autotune] Stabilize autotune benchmarking across devices and fix the unconsistency in the autotuning process.

### DIFF
--- a/examples/gemm/example_gemm_advanced_autotune.py
+++ b/examples/gemm/example_gemm_advanced_autotune.py
@@ -216,7 +216,7 @@ def _build_autotuner(
             execution_backend=execution_backend,
         )
         .set_profile_args(
-            supply_type=tl.TensorSupplyType.Integer,
+            supply_type=tl.TensorSupplyType.Auto,
             ref_prog=None if skip_check else ref_program,
             skip_check=skip_check,
             cache_input_tensors=cache_input_tensors,

--- a/examples/gemm/example_gemm_autotune.py
+++ b/examples/gemm/example_gemm_autotune.py
@@ -159,7 +159,7 @@ def get_best_config(
             target="auto",
         )
         .set_profile_args(
-            supply_type=tl.TensorSupplyType.Integer,
+            supply_type=tl.TensorSupplyType.Auto,
             ref_prog=ref_program,
             skip_check=False,
             backend=profile_backend,

--- a/tilelang/autotuner/param.py
+++ b/tilelang/autotuner/param.py
@@ -249,7 +249,7 @@ class AutotuneResult:
                     logger.debug(f"Copying kernel library to file: {kernel_lib_path}")
                 self._safe_write_file(kernel_lib_path, "wb", lambda f: f.write(self._load_binary(src_lib_path)))
             else:
-                executable = kernel.adapter.executable
+                executable = kernel.adapter.get_exportable_executable()
                 if verbose:
                     logger.debug(f"Saving kernel executable to file: {kernel_lib_path}")
                 self._safe_write_executable(executable, kernel_lib_path)

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -622,6 +622,26 @@ class AutoTuner:
                 logger.warning("Failed to bind benchmark worker to cuda:%s", worker_device)
                 logger.debug("Error: %s", traceback.format_exc())
 
+        benchmark_device = worker_device if torch.cuda.is_available() and target_kind == "cuda" else None
+
+        def _call_benchmark_target(
+            jit_kernel: tilelang.JITKernel,
+            benchmark_state: _BenchmarkWorkerState,
+        ) -> tuple[float, float | None]:
+            # Timeout mode runs benchmark_target in a fresh daemon thread, so
+            # scope the device at the actual call site.
+            def invoke():
+                return benchmark_target(
+                    jit_kernel=jit_kernel,
+                    benchmark_state=benchmark_state,
+                    benchmark_device=benchmark_device,
+                )
+
+            if benchmark_device is None:
+                return invoke()
+            with torch.cuda.device(benchmark_device):
+                return invoke()
+
         start_event.wait()
         queue_poll_timeout_s = 0.1
         while True:
@@ -647,10 +667,7 @@ class AutoTuner:
                         _call_result_queue: queue.Queue = call_result_queue,
                     ):
                         try:
-                            latency, worker_ref_latency = benchmark_target(
-                                jit_kernel=_jit_kernel,
-                                benchmark_state=_worker_state,
-                            )
+                            latency, worker_ref_latency = _call_benchmark_target(_jit_kernel, _worker_state)
                             _call_result_queue.put(("ok", latency, worker_ref_latency, ""))
                         except TimeoutException:
                             _call_result_queue.put(("timeout", None, None, ""))
@@ -690,10 +707,7 @@ class AutoTuner:
                     else:
                         result_queue.put((idx, config, jit_kernel, None, None, "error", error_text))
                 else:
-                    latency, worker_ref_latency = benchmark_target(
-                        jit_kernel=jit_kernel,
-                        benchmark_state=worker_state,
-                    )
+                    latency, worker_ref_latency = _call_benchmark_target(jit_kernel, worker_state)
                     result_queue.put((idx, config, jit_kernel, latency, worker_ref_latency, None, ""))
             except TimeoutException:
                 result_queue.put((idx, config, jit_kernel, None, None, "timeout", ""))
@@ -706,6 +720,7 @@ class AutoTuner:
         warmup: int,
         rep: int,
         benchmark_state: _BenchmarkWorkerState,
+        benchmark_device: int | torch.device | None = None,
     ) -> tuple[float, float | None]:
         profile_args = self.profile_args
         supply_type = profile_args.supply_type
@@ -785,6 +800,7 @@ class AutoTuner:
                 n_repeat=rep,
                 input_tensors=ref_input_tensors_cache,
                 backend=backend,
+                device=benchmark_device,
             )
 
         benchmark_state.jit_input_tensors = jit_input_tensors_cache
@@ -1051,7 +1067,7 @@ class AutoTuner:
 
         def _enqueue_benchmark_task(jit_kernel: tilelang.JITKernel, config: dict[str, Any], idx: int):
             nonlocal benchmark_expected_results
-            queue_idx = idx % len(benchmark_task_queues)
+            queue_idx = min(len(benchmark_task_queues) - 1, idx * len(benchmark_task_queues) // max(1, len(config_args)))
             benchmark_task_queues[queue_idx].put((jit_kernel, config, idx))
             benchmark_expected_results += 1
 

--- a/tilelang/jit/adapter/kernel_cache.py
+++ b/tilelang/jit/adapter/kernel_cache.py
@@ -15,7 +15,7 @@ class TVMFFIKernelCache(KernelCache):
 
     def _save_so_cubin_to_disk(self, kernel: JITKernel, cache_path: str, verbose: bool = False):
         kernel_lib_path = os.path.join(cache_path, self.kernel_lib_path)
-        executable = kernel.adapter.executable
+        executable = kernel.adapter.get_exportable_executable()
         if verbose:
             self.logger.debug(f"Saving kernel executable to file: {executable}")
         KernelCache._safe_write_executable(executable, kernel_lib_path)

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from typing import Any
 from collections.abc import Callable
 import sys
+import threading
 
 import torch
 from tilelang import tvm
@@ -112,8 +113,25 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
         self.compile_flags = compile_flags
         self.dynamic_symbolic_map = self._process_dynamic_symbolic()
         self.kernel_global_source = self.device_kernel_source
+        self.executable = None
+        self._executables_by_device: dict[int | str, tvm.runtime.Executable] = {}
+        self._executable_lock = threading.Lock()
 
         self._post_init()
+
+    def _make_executable(self) -> tvm.runtime.Executable:
+        if self.rt_mod is None:
+            raise RuntimeError("Cannot create TVM FFI executable without a runtime module.")
+        executable = runtime.Executable(self.rt_mod)
+        if COMPILE_ARGS:
+            # Precompile jit module with extra arguments.
+            executable.jit(**COMPILE_ARGS)
+        return executable
+
+    def get_exportable_executable(self) -> tvm.runtime.Executable:
+        if self.executable is not None:
+            return self.executable
+        return self._make_executable()
 
     def _process_dynamic_symbolic(self) -> dict[tirx.Var, tuple[int, int, int, int]]:
         """Extract information about dynamic shapes from the TIR function.
@@ -176,14 +194,26 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
                 native_shape[-1] = native_shape[-1] * tl_dtype.bits * tl_dtype.lanes // (stroage_dtype.bits * stroage_dtype.lanes)
             param_shapes.append(native_shape)
 
-        if self.executable is None:
-            self.executable = runtime.Executable(self.rt_mod)
-            if COMPILE_ARGS:
-                # Precompile jit module with extra arguments
-                self.executable.jit(**COMPILE_ARGS)
-
         dynamic_symbolic_map = self._process_dynamic_symbolic()
-        executable = self.executable
+
+        def get_executable():
+            if self.executable is not None:
+                return self.executable
+
+            device_key: int | str = "cpu"
+            if torch.cuda.is_available():
+                device_key = torch.cuda.current_device()
+
+            executable = self._executables_by_device.get(device_key)
+            if executable is not None:
+                return executable
+
+            with self._executable_lock:
+                executable = self._executables_by_device.get(device_key)
+                if executable is None:
+                    executable = self._make_executable()
+                    self._executables_by_device[device_key] = executable
+                return executable
 
         # Prepare helpers for friendly dtype error messages
         prim_func = self.prim_func
@@ -250,6 +280,7 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
                     ins_idx += 1
                 tensor_list.append(tensor)
 
+            executable = get_executable()
             executable(*tensor_list)
 
             # Return outputs in the requested form
@@ -298,6 +329,8 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
         adapter.kernel_global_source = device_kernel_source.text
         adapter.rt_mod = None
         adapter.executable = runtime.load_module(kernel_lib_path)
+        adapter._executables_by_device = {}
+        adapter._executable_lock = threading.Lock()
         adapter._post_init()
         return adapter
 

--- a/tilelang/profiler/__init__.py
+++ b/tilelang/profiler/__init__.py
@@ -229,6 +229,7 @@ class Profiler:
         quantiles: list[float] | None = None,
         return_mode: Literal["min", "max", "mean", "median"] = "mean",
         dynamic_symbolic_constraints: dict[str, int] | None = None,
+        device: int | torch.device | None = None,
     ) -> float:
         """Benchmarks the execution time of a given function.
 
@@ -243,30 +244,41 @@ class Profiler:
             dynamic_symbolic_constraints: Optional dict mapping dynamic symbolic variable
                 names to concrete int values. Use this when benchmarking kernels with
                 dynamic shapes, e.g., {"m": 2048, "n": 1024}
+            device: Optional CUDA device to benchmark on.
 
         Returns:
             float: Average execution time in milliseconds
         """
-        if func is None:
-            assert self.adapter is not None, "benchmarking function should be provided"
-            func = self.adapter
-        if input_tensors is not None:
-            ins = input_tensors
-        elif dynamic_symbolic_constraints is not None:
-            ins = self._get_inputs(dynamic_symbolic_constraints=dynamic_symbolic_constraints)
-        else:
-            ins = self._get_inputs()
-        bench_func = partial(func, *ins)
-        return do_bench(
-            bench_func,
-            warmup=warmup,
-            rep=rep,
-            _n_warmup=n_warmup,
-            _n_repeat=n_repeat,
-            quantiles=quantiles,
-            backend=backend,
-            return_mode=return_mode,
-        )
+
+        def run_bench():
+            if func is None:
+                assert self.adapter is not None, "benchmarking function should be provided"
+                bench_target = self.adapter
+            else:
+                bench_target = func
+            if input_tensors is not None:
+                ins = input_tensors
+            elif dynamic_symbolic_constraints is not None:
+                ins = self._get_inputs(dynamic_symbolic_constraints=dynamic_symbolic_constraints)
+            else:
+                ins = self._get_inputs()
+            bench_func = partial(bench_target, *ins)
+            return do_bench(
+                bench_func,
+                warmup=warmup,
+                rep=rep,
+                _n_warmup=n_warmup,
+                _n_repeat=n_repeat,
+                quantiles=quantiles,
+                backend=backend,
+                return_mode=return_mode,
+                device=device,
+            )
+
+        if device is None:
+            return run_bench()
+        with torch.cuda.device(device):
+            return run_bench()
 
     @property
     def func(self):

--- a/tilelang/profiler/bench.py
+++ b/tilelang/profiler/bench.py
@@ -59,7 +59,6 @@ class suppress_stdout_stderr:
 
 IS_CUDA = torch.cuda.is_available()
 device = "cuda:0" if IS_CUDA else "mps:0"
-Event = torch.cuda.Event if IS_CUDA else torch.mps.Event
 _CACHE_FLUSH_ID = "tilelang::cache_flush"
 
 
@@ -73,6 +72,7 @@ def do_bench(
     fast_flush: bool = True,
     backend: Literal["event", "cupti", "cudagraph"] = "event",
     return_mode: Literal["min", "max", "mean", "median"] = "mean",
+    device: int | torch.device | None = None,
 ) -> float | list[float]:
     """Benchmark the runtime of a PyTorch function with L2 cache management.
 
@@ -92,21 +92,94 @@ def do_bench(
         fast_flush: Use faster L2 cache flush with int32 vs int8 (default: True)
         backend: Profiler backend - "event" (CUDA events), "cupti", or "cudagraph" (default: "event")
         return_mode: Result aggregation method - "mean", "median", "min", or "max"
+        device: Optional CUDA device to benchmark on. When provided, CUDA
+            events, streams, cache buffers, and synchronizations are scoped to
+            that device.
 
     Returns:
         Runtime in milliseconds (float) or list of quantile values if quantiles specified
     """
     assert return_mode in ["min", "max", "mean", "median"], f"Invalid return_mode: {return_mode}"
 
+    device_idx = _normalize_cuda_device(device)
+    if device_idx is not None:
+        with torch.cuda.device(device_idx):
+            return _do_bench_impl(
+                fn,
+                warmup=warmup,
+                rep=rep,
+                _n_warmup=_n_warmup,
+                _n_repeat=_n_repeat,
+                quantiles=quantiles,
+                fast_flush=fast_flush,
+                backend=backend,
+                return_mode=return_mode,
+                device_idx=device_idx,
+            )
+
+    return _do_bench_impl(
+        fn,
+        warmup=warmup,
+        rep=rep,
+        _n_warmup=_n_warmup,
+        _n_repeat=_n_repeat,
+        quantiles=quantiles,
+        fast_flush=fast_flush,
+        backend=backend,
+        return_mode=return_mode,
+        device_idx=None,
+    )
+
+
+def _normalize_cuda_device(benchmark_device: int | torch.device | None) -> int | None:
+    """Return a concrete CUDA device index, preserving implicit mode for None."""
+    if benchmark_device is None:
+        return None
+    if isinstance(benchmark_device, int):
+        return benchmark_device
+
+    torch_device = torch.device(benchmark_device)
+    if torch_device.type != "cuda":
+        raise ValueError(f"do_bench device must be a CUDA device, got {torch_device}")
+    if torch_device.index is None:
+        return torch.cuda.current_device()
+    return torch_device.index
+
+
+def _cuda_synchronize(device_idx: int | None = None) -> None:
+    if device_idx is None:
+        torch.cuda.synchronize()
+    else:
+        torch.cuda.synchronize(device_idx)
+
+
+def _cache_device(device_idx: int | None) -> str | torch.device:
+    if device_idx is None:
+        return device
+    return torch.device("cuda", device_idx)
+
+
+def _do_bench_impl(
+    fn: Callable,
+    warmup: float,
+    rep: float,
+    _n_warmup: int,
+    _n_repeat: int,
+    quantiles: list[float] | None,
+    fast_flush: bool,
+    backend: Literal["event", "cupti", "cudagraph"],
+    return_mode: Literal["min", "max", "mean", "median"],
+    device_idx: int | None,
+) -> float | list[float]:
     # Initial function call and synchronization
     fn()
-    torch.cuda.synchronize()
+    _cuda_synchronize(device_idx)
 
     # Create L2 cache flush buffer (256 MB)
     # Fast flush uses int32 (4 bytes), regular uses int8 (1 byte)
     cache_size = int(256e6 // 4) if fast_flush else int(256e6)
     cache_dtype = torch.int if fast_flush else torch.int8
-    cache = torch.empty(cache_size, dtype=cache_dtype, device="cuda")
+    cache = torch.empty(cache_size, dtype=cache_dtype, device=_cache_device(device_idx))
 
     # Estimate kernel runtime with 5 iterations
     start_event = torch.cuda.Event(enable_timing=True)
@@ -130,11 +203,11 @@ def do_bench(
 
     # Benchmarking phase
     if backend == "event":
-        return _bench_with_cuda_events(fn, cache, n_repeat, quantiles, return_mode)
+        return _bench_with_cuda_events(fn, cache, n_repeat, quantiles, return_mode, device_idx)
     elif backend == "cupti":
         return _bench_with_cupti(fn, cache, n_repeat)
     elif backend == "cudagraph":
-        return _bench_with_cudagraph(fn, cache, n_repeat, quantiles, return_mode)
+        return _bench_with_cudagraph(fn, cache, n_repeat, quantiles, return_mode, device_idx)
     else:
         raise ValueError(f"Unknown profiler backend: {backend}")
 
@@ -145,6 +218,7 @@ def _bench_with_cuda_events(
     n_repeat: int,
     quantiles: list[float] | None,
     return_mode: str,
+    device_idx: int | None,
 ) -> float | list[float]:
     """Benchmark using CUDA events for timing."""
     # Create timing events
@@ -159,7 +233,7 @@ def _bench_with_cuda_events(
         end_events[i].record()
 
     # Synchronize and collect timings
-    torch.cuda.synchronize()
+    _cuda_synchronize(device_idx)
     times = torch.tensor(
         [s.elapsed_time(e) for s, e in zip(start_events, end_events)],
         dtype=torch.float,
@@ -225,6 +299,7 @@ def _bench_with_cudagraph(
     n_repeat: int,
     quantiles: list[float] | None,
     return_mode: str,
+    device_idx: int | None,
 ) -> float | list[float]:
     """Benchmark using CUDA graph for minimal launch overhead.
 
@@ -236,14 +311,15 @@ def _bench_with_cudagraph(
     since CUDA graphs require fixed execution patterns.
     """
     n_retries = 10
-    with torch.cuda.stream(torch.cuda.Stream()):
+    stream = torch.cuda.Stream(device=device_idx) if device_idx is not None else torch.cuda.Stream()
+    with torch.cuda.stream(stream):
         # Construct a CUDA graph with `n_repeat` unrolled function calls to minimize host overhead.
         g = torch.cuda.CUDAGraph()
         with torch.cuda.graph(g):
             for _ in range(n_repeat):
                 fn()
 
-        torch.cuda.synchronize()
+        _cuda_synchronize(device_idx)
 
         # Measure time by replaying the graph multiple times.
         # Clear cache before each replay for consistent measurements.
@@ -255,7 +331,7 @@ def _bench_with_cudagraph(
             g.replay()
             end_events[i].record()
 
-        torch.cuda.synchronize()
+        _cuda_synchronize(device_idx)
         times = torch.tensor(
             [s.elapsed_time(e) / n_repeat for s, e in zip(start_events, end_events)],
             dtype=torch.float,


### PR DESCRIPTION
## Summary
- Scope profiler benchmarking to the intended CUDA device for multi-GPU autotune workers.
- Avoid sharing TVM FFI executables across CUDA devices by caching executables per device.
- Use `TensorSupplyType.Auto` in GEMM autotune examples so generated inputs match the kernel tensor dtypes.

## Details
This fixes instability in autotune benchmarking when multiple GPUs are used. `Profiler.do_bench` now accepts an optional CUDA device and scopes events, streams, cache flush buffers, and synchronization to
that device. The autotuner passes each worker’s device through to reference benchmarking and runs benchmark calls under the correct CUDA device context.

The TVM FFI adapter now lazily creates runtime executables per device, while keeping an exportable executable path for autotune/kernel cache serialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for specifying CUDA devices during benchmarking.
  * Implemented per-device kernel executable caching for improved multi-GPU support.

* **Improvements**
  * Updated autotuning benchmarking to run on the correct per-worker CUDA device and improved benchmark queue distribution.
  * Adjusted GEMM autotune examples to use automatic tensor supply handling.
  * Improved kernel disk caching by saving the proper exportable executable artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->