### PR TITLE
[Build] Pin apache-tvm-ffi to compatible versions

### DIFF
--- a/docs/get_started/Installation.md
+++ b/docs/get_started/Installation.md
@@ -270,7 +270,7 @@ pip install -e . -v --no-build-isolation --no-deps
 
 # Manually install required runtime deps when using --no-deps.
 # Note: skip torch-c-dlpack-ext on ROCm (its wheel expects CUDA libs).
-pip install "apache-tvm-ffi>=0.1.10,<=0.1.12" "z3-solver>=4.13.0"
+pip install "apache-tvm-ffi>=0.1.10,<=0.1.11" "z3-solver>=4.13.0"
 # If you already installed torch-c-dlpack-ext and hit `libtorch_cuda.so` errors:
 # pip uninstall -y torch-c-dlpack-ext
 

--- a/docs/get_started/Installation.md
+++ b/docs/get_started/Installation.md
@@ -270,7 +270,7 @@ pip install -e . -v --no-build-isolation --no-deps
 
 # Manually install required runtime deps when using --no-deps.
 # Note: skip torch-c-dlpack-ext on ROCm (its wheel expects CUDA libs).
-pip install "apache-tvm-ffi>=0.1.6" "z3-solver>=4.13.0"
+pip install "apache-tvm-ffi>=0.1.10,<=0.1.12" "z3-solver>=4.13.0"
 # If you already installed torch-c-dlpack-ext and hit `libtorch_cuda.so` errors:
 # pip uninstall -y torch-c-dlpack-ext
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "apache-tvm-ffi~=0.1.0,>=0.1.10",
+    "apache-tvm-ffi>=0.1.10,<=0.1.12",
     # torch-c-dlpack-ext provides prebuilt torch extensions.
     # Without it, TVM FFI may require JIT compilation on first import.
     "torch-c-dlpack-ext; python_version < '3.14'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "apache-tvm-ffi>=0.1.10,<=0.1.12",
+    "apache-tvm-ffi>=0.1.10,<=0.1.11",
     # torch-c-dlpack-ext provides prebuilt torch extensions.
     # Without it, TVM FFI may require JIT compilation on first import.
     "torch-c-dlpack-ext; python_version < '3.14'",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Requirements to run local build with `--no-build-isolation` or other developments
 
-apache-tvm-ffi>=0.1.10,<=0.1.12
+apache-tvm-ffi>=0.1.10,<=0.1.11
 build
 cmake>=3.26
 cython>=3.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Requirements to run local build with `--no-build-isolation` or other developments
 
-apache-tvm-ffi~=0.1.0,>=0.1.10
+apache-tvm-ffi>=0.1.10,<=0.1.12
 build
 cmake>=3.26
 cython>=3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Runtime requirements
 
-apache-tvm-ffi>=0.1.10,<=0.1.12
+apache-tvm-ffi>=0.1.10,<=0.1.11
 torch-c-dlpack-ext; python_version < '3.14'
 cloudpickle
 ml-dtypes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Runtime requirements
 
-apache-tvm-ffi~=0.1.0,>=0.1.10
+apache-tvm-ffi>=0.1.10,<=0.1.12
 torch-c-dlpack-ext; python_version < '3.14'
 cloudpickle
 ml-dtypes


### PR DESCRIPTION
## Summary

- Pin `apache-tvm-ffi` to `>=0.1.10,<=0.1.11` across package metadata and requirements files.
- Keep the manual ROCm `--no-deps` installation path aligned with the runtime dependency range.

## Changes

- Replace the previous compatible-release specifier with an explicit upper bound in `pyproject.toml`, `requirements.txt`, and `requirements-dev.txt`.
- Update the ROCm installation guide so manual dependency installation does not pull a newer unsupported `apache-tvm-ffi` release.

## Validation

- `pre-commit run --all-files`
- `python -c "import pathlib, tomllib; tomllib.loads(pathlib.Path('pyproject.toml').read_text()); print('pyproject.toml ok')"`
- `git diff --check -- pyproject.toml requirements.txt requirements-dev.txt docs/get_started/Installation.md`

## Notes

- This is a compatibility cap for the current TVM integration, whose bundled `tvm-ffi` submodule is at v0.1.11. After upgrading the bundled or upstream TVM dependency and validating against newer `apache-tvm-ffi` releases, this upper bound can be relaxed or removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified ROCm Docker installation instructions to specify a narrower allowed range for a required native library.

* **Chores**
  * Tightened a dependency constraint across configuration files to allow only versions 0.1.10–0.1.11, improving build reproducibility (other runtime requirements unchanged).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->