### PR TITLE
[Build] Fix sdist version metadata

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -95,8 +95,8 @@ jobs:
           TEMP_DIR="$(mktemp -d -t tilelang-sdist-test)"
           cp -r dist "${TEMP_DIR}/dist"
           cd "${TEMP_DIR}"
-          uv pip install -v dist/*.tar.gz
-          python3 -c "import tilelang; print(tilelang.__version__)"
+          env -u NO_VERSION_LABEL uv pip install -v dist/*.tar.gz
+          env -u NO_VERSION_LABEL python3 -c "import tilelang; print(tilelang.__version__)"
 
       - name: Upload SDist
         # Not PR to save artifact storage, as SDist is only needed for releases.

--- a/testing/python/test_version_provider.py
+++ b/testing/python/test_version_provider.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import subprocess
+import uuid
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _clear_version_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in (
+        "CUDA_VERSION",
+        "NO_GIT_VERSION",
+        "NO_TOOLCHAIN_VERSION",
+        "NO_VERSION_LABEL",
+        "TILELANG_BUILD_WHEEL_WITH_DATE",
+        "USE_CUDA",
+        "USE_ROCM",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def _load_provider(root: Path):
+    spec = importlib.util.spec_from_file_location(
+        f"_tilelang_test_version_provider_{uuid.uuid4().hex}",
+        root / "version_provider.py",
+    )
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_provider_tree(root: Path) -> None:
+    shutil.copy(REPO_ROOT / "version_provider.py", root / "version_provider.py")
+    (root / "VERSION").write_text("1.2.3\n", encoding="utf-8")
+
+
+def test_extracted_sdist_uses_plain_version_by_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _clear_version_env(monkeypatch)
+    _make_provider_tree(tmp_path)
+    (tmp_path / ".git_commit.txt").write_text("abcdef1234567890\n", encoding="utf-8")
+
+    provider = _load_provider(tmp_path)
+
+    assert provider.dynamic_metadata("version") == "1.2.3"
+
+
+def test_extracted_sdist_can_opt_into_version_label(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _clear_version_env(monkeypatch)
+    monkeypatch.setenv("NO_VERSION_LABEL", "OFF")
+    monkeypatch.setenv("NO_TOOLCHAIN_VERSION", "ON")
+    _make_provider_tree(tmp_path)
+    (tmp_path / ".git_commit.txt").write_text("abcdef1234567890\n", encoding="utf-8")
+
+    provider = _load_provider(tmp_path)
+
+    assert provider.dynamic_metadata("version") == "1.2.3+gitabcdef12"
+
+
+@pytest.mark.skipif(shutil.which("git") is None, reason="git is required for checkout version test")
+def test_git_checkout_uses_version_label_by_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    _clear_version_env(monkeypatch)
+    monkeypatch.setenv("NO_TOOLCHAIN_VERSION", "ON")
+    _make_provider_tree(tmp_path)
+
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "TileLang Test"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "tilelang-test@example.com"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "add", "VERSION", "version_provider.py"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=tmp_path, check=True, capture_output=True)
+    commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        encoding="utf-8",
+    ).stdout.strip()
+
+    provider = _load_provider(tmp_path)
+
+    assert provider.dynamic_metadata("version") == f"1.2.3+git{commit[:8]}"
+    assert (tmp_path / ".git_commit.txt").read_text(encoding="utf-8") == commit

--- a/version_provider.py
+++ b/version_provider.py
@@ -28,15 +28,17 @@ def _read_cmake_bool(i: str | None, default=False):
 def get_git_commit_id() -> str | None:
     """Get the current git commit hash by running git in the current file's directory."""
 
-    r = subprocess.run(["git", "rev-parse", "HEAD"], cwd=ROOT, capture_output=True, encoding="utf-8")
-    if r.returncode == 0:
-        _git = r.stdout.strip()
-        git_pin.write_text(_git)
-        return _git
-    elif git_pin.exists():
+    if (ROOT / ".git").exists():
+        r = subprocess.run(["git", "rev-parse", "HEAD"], cwd=ROOT, capture_output=True, encoding="utf-8")
+        if r.returncode == 0:
+            _git = r.stdout.strip()
+            git_pin.write_text(_git)
+            return _git
+
+    if git_pin.exists():
         return git_pin.read_text().strip()
-    else:
-        return None
+
+    return None
 
 
 def dynamic_metadata(field: str, settings: dict[str, object] | None = None) -> str:
@@ -44,10 +46,14 @@ def dynamic_metadata(field: str, settings: dict[str, object] | None = None) -> s
 
     version = base_version
 
-    # generate git version for sdist
+    # Pin the source commit for sdists, even when the public version omits it.
     get_git_commit_id()
 
-    if not _read_cmake_bool(os.environ.get("NO_VERSION_LABEL")):
+    no_version_label = _read_cmake_bool(
+        os.environ.get("NO_VERSION_LABEL"),
+        default=not (ROOT / ".git").exists(),
+    )
+    if not no_version_label:
         exts = []
         backend = None
         if _read_cmake_bool(os.environ.get("NO_TOOLCHAIN_VERSION")):


### PR DESCRIPTION
## Summary

- Keep extracted sdists on the public release version by default so pip metadata generation matches the source archive version.
- Exercise the sdist install check without the CI-only NO_VERSION_LABEL environment override.
- Add regression coverage for issue #2371.

## Changes

- Default NO_VERSION_LABEL to enabled when version metadata is generated from an extracted source archive instead of a git checkout.
- Preserve explicit NO_VERSION_LABEL overrides and continue pinning the source commit into .git_commit.txt for provenance.
- Avoid resolving commits from an unrelated parent repository when reading git metadata from extracted sources.
- Add tests for extracted-sdist defaults, explicit local-version opt-in, and git-checkout local-version behavior.

## Validation

- ...                                                                      [100%]
3 passed in 0.09s
- All checks passed!
- 2 files already formatted
- check for broken symlinks............................(no files to check)Skipped
detect destroyed symlinks................................................Passed
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for added large files..............................................Passed
check for merge conflicts................................................Passed
check that executables have shebangs.....................................Passed
check that scripts with shebangs are executable..........................Passed
detect private key.......................................................Passed
check yaml...............................................................Passed
check toml...............................................................Passed
check python ast.........................................................Passed
debug statements (python)................................................Passed
file contents sorter.....................................................Passed
clang-format.............................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed
codespell................................................................Passed
PyMarkdown...............................................................Passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suite for version provider functionality across different build scenarios

* **Chores**
  * Improved version labeling logic in distributed packages to better support git-based versioning
  * Updated build workflow for version handling consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->