### PR TITLE
[Transform] Lower T.Kernel by backend

### DIFF
--- a/src/ir.cc
+++ b/src/ir.cc
@@ -20,41 +20,34 @@
 namespace tvm {
 namespace tl {
 
-using namespace script::ir_builder::tirx;
 using namespace ffi;
+using namespace script::ir_builder::tirx;
 
-static Var CreateEnvThread(String name, String thread_tag, DataType dtype) {
-  using namespace tvm::tirx;
-  using namespace tvm::script::ir_builder;
-  IterVar iter_var(Range{nullptr}, Var(std::move(name), dtype),
-                   tvm::tirx::IterVarType::kThreadIndex, std::move(thread_tag));
-  Var var = iter_var->var;
-  if (Optional<PrimFuncFrame> opt_frame =
-          IRBuilder::Current()->FindFrame<PrimFuncFrame>()) {
-    opt_frame.value()->env_threads.Set(var, iter_var);
-  } else {
-    LOG(FATAL) << "EnvThread can only be used inside a PrimFunc";
-  }
-  return var;
-}
-
-static ForFrame MakeIterVarFrame(const std::string &name, const PrimExpr &dom) {
+static ForFrame MakeKernelDimFrame(const std::string &name, const PrimExpr &dom,
+                                   int dim_kind, int axis,
+                                   bool is_default_thread) {
   using namespace tvm::tirx;
   Var var = Var(name, dom->dtype);
-  // Create a frame that represents a loop over the given domain.
   ObjectPtr<ForFrameNode> n = make_object<ForFrameNode>();
   n->vars.push_back(var);
   n->doms.push_back(Range(0, dom));
-  n->f_make_for_loop = [](const Array<Var> &vars, const Array<Range> &doms,
-                          const Array<Optional<PrimExpr>> &steps,
-                          Stmt body) -> Stmt {
+  n->f_make_for_loop = [=](const Array<Var> &vars, const Array<Range> &doms,
+                           const Array<Optional<PrimExpr>> &steps,
+                           Stmt body) -> Stmt {
     ICHECK_EQ(vars.size(), 1);
     ICHECK_EQ(doms.size(), 1);
+    Map<String, Any> annotations = {
+        {tilelang_kernel_dim_kind, Integer(dim_kind)},
+        {tilelang_kernel_dim_axis, Integer(axis)},
+    };
+    if (is_default_thread) {
+      annotations.Set(tilelang_kernel_thread_default, Integer(1));
+    }
     Optional<PrimExpr> step =
         !steps.empty() ? steps[0] : Optional<PrimExpr>(std::nullopt);
     return For(vars[0], doms[0]->min, doms[0]->extent, ForKind::kSerial, body,
                /*thread_binding=*/std::nullopt,
-               /*annotations=*/Map<String, Any>{},
+               /*annotations=*/annotations,
                /*step=*/step);
   };
   return ForFrame(n);
@@ -265,55 +258,24 @@ KernelLaunchFrame KernelLaunch(const Array<PrimExpr> &grid_size,
                                const Map<String, Any> &attrs) {
   ObjectPtr<KernelLaunchFrameNode> n = make_object<KernelLaunchFrameNode>();
 
-  // If the kernel is a CPU kernel, we don't need to launch any threads.
-  bool is_cpu_kernel_frame =
-      attrs.defined() && attrs.count(tilelang_is_cpu_kernel_frame);
-
   auto block_size = block_size_opt.value_or(Array<PrimExpr>());
+  bool is_default_thread =
+      attrs.defined() && attrs.count(tilelang_kernel_thread_default);
 
-  if (is_cpu_kernel_frame) {
-    // Launch CPU Kernel
-    ICHECK(grid_size.size() >= 0);
-    ICHECK(block_size.empty()) << "CPU kernel cannot have block size";
-    ICHECK(attrs.defined());
-    // create grid loop var
-    for (int i = 0; i < grid_size.size(); i++) {
-      n->frames.push_back(
-          MakeIterVarFrame("block_var_" + std::to_string(i), grid_size[i]));
-    }
-  } else {
-    // Launch GPU Kernel
-    ICHECK(grid_size.size() <= 3);
-    if (!grid_size.empty())
-      n->frames.push_back(LaunchThread(
-          CreateEnvThread("bx", "blockIdx.x", grid_size[0].dtype()),
-          grid_size[0]));
-    if (grid_size.size() > 1)
-      n->frames.push_back(LaunchThread(
-          CreateEnvThread("by", "blockIdx.y", grid_size[1].dtype()),
-          grid_size[1]));
-    if (grid_size.size() > 2)
-      n->frames.push_back(LaunchThread(
-          CreateEnvThread("bz", "blockIdx.z", grid_size[2].dtype()),
-          grid_size[2]));
-    if (block_size.defined()) {
-      ICHECK(block_size.size() <= 3);
-      if (!block_size.empty()) {
-        n->frames.push_back(LaunchThread(
-            CreateEnvThread("tx", "threadIdx.x", block_size[0].dtype()),
-            block_size[0]));
-      }
-      if (block_size.size() > 1) {
-        n->frames.push_back(LaunchThread(
-            CreateEnvThread("ty", "threadIdx.y", block_size[1].dtype()),
-            block_size[1]));
-      }
-      if (block_size.size() > 2) {
-        n->frames.push_back(LaunchThread(
-            CreateEnvThread("tz", "threadIdx.z", block_size[2].dtype()),
-            block_size[2]));
-      }
-    }
+  ICHECK(grid_size.size() <= 3);
+  static const char *const block_names[] = {"bx", "by", "bz"};
+  for (size_t i = 0; i < grid_size.size(); ++i) {
+    n->frames.push_back(MakeKernelDimFrame(block_names[i], grid_size[i],
+                                           kTilelangKernelDimBlock, i,
+                                           /*is_default_thread=*/false));
+  }
+
+  ICHECK(block_size.size() <= 3);
+  static const char *const thread_names[] = {"tx", "ty", "tz"};
+  for (size_t i = 0; i < block_size.size(); ++i) {
+    n->frames.push_back(MakeKernelDimFrame(thread_names[i], block_size[i],
+                                           kTilelangKernelDimThread, i,
+                                           is_default_thread));
   }
 
   auto empty_block = tvm::script::ir_builder::tirx::Block(DeviceMainBlockName);
@@ -321,6 +283,11 @@ KernelLaunchFrame KernelLaunch(const Array<PrimExpr> &grid_size,
   empty_block->writes = Array<tvm::tirx::BufferRegion>();
   Map<String, Any> block_annotations =
       attrs.defined() ? attrs : Map<String, Any>{};
+  block_annotations.Set(tilelang_kernel_scope, Integer(1));
+  block_annotations.Set(tilelang_kernel_num_blocks,
+                        Integer(static_cast<int64_t>(grid_size.size())));
+  block_annotations.Set(tilelang_kernel_num_threads,
+                        Integer(static_cast<int64_t>(block_size.size())));
   empty_block->annotations = block_annotations;
   n->frames.push_back(empty_block);
 

--- a/src/transform/common/attr.h
+++ b/src/transform/common/attr.h
@@ -27,6 +27,18 @@ inline bool IsDeviceMainBlock(const tirx::SBlockNode *node) {
 constexpr const char *tilelang_is_cpu_kernel_frame =
     "tilelang.is_cpu_kernel_frame";
 
+constexpr const char *tilelang_kernel_scope = "tilelang.kernel_scope";
+constexpr const char *tilelang_kernel_num_blocks = "tilelang.kernel_num_blocks";
+constexpr const char *tilelang_kernel_num_threads =
+    "tilelang.kernel_num_threads";
+constexpr const char *tilelang_kernel_dim_kind = "tilelang.kernel_dim_kind";
+constexpr const char *tilelang_kernel_dim_axis = "tilelang.kernel_dim_axis";
+constexpr const char *tilelang_kernel_thread_default =
+    "tilelang.kernel_thread_default";
+
+constexpr int kTilelangKernelDimBlock = 0;
+constexpr int kTilelangKernelDimThread = 1;
+
 namespace attr {
 // Attributes to mark CUDA sync calls
 constexpr const char *kHasTriggerLaunch = "has_cuda_pdl_trigger";

--- a/src/transform/lower_kernel_launch.cc
+++ b/src/transform/lower_kernel_launch.cc
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file lower_kernel_launch.cc
+ * \brief Lower target-neutral T.Kernel loops to target-specific loop forms.
+ */
+
+#include "support/check.h"
+#include <tvm/arith/analyzer.h>
+#include <tvm/ir/transform.h>
+#include <tvm/runtime/logging.h>
+#include <tvm/tirx/op.h>
+#include <tvm/tirx/stmt.h>
+#include <tvm/tirx/stmt_functor.h>
+#include <tvm/tirx/transform.h>
+
+#include "common/attr.h"
+#include "tir/transforms/ir_utils.h"
+
+#include <utility>
+
+namespace tvm {
+namespace tl {
+
+using namespace ffi;
+using namespace tirx;
+
+namespace {
+
+enum class KernelLaunchLoweringKind {
+  kSerial,
+  kThreadBinding,
+};
+
+bool IsKernelLaunchAnnotation(const String &key) {
+  return key == tilelang_kernel_scope || key == tilelang_kernel_num_blocks ||
+         key == tilelang_kernel_num_threads ||
+         key == tilelang_kernel_dim_kind || key == tilelang_kernel_dim_axis ||
+         key == tilelang_kernel_thread_default;
+}
+
+bool HasKernelLaunchAnnotation(const Map<String, Any> &annotations) {
+  for (const auto &kv : annotations) {
+    if (IsKernelLaunchAnnotation(kv.first)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+Map<String, Any>
+StripKernelLaunchAnnotations(const Map<String, Any> &annotations) {
+  Map<String, Any> result;
+  for (const auto &kv : annotations) {
+    if (!IsKernelLaunchAnnotation(kv.first)) {
+      result.Set(kv.first, kv.second);
+    }
+  }
+  return result;
+}
+
+Optional<Integer> GetIntegerAnnotation(const Map<String, Any> &annotations,
+                                       const char *key) {
+  auto it = annotations.find(key);
+  if (it == annotations.end()) {
+    return Optional<Integer>(std::nullopt);
+  }
+  if (auto value = (*it).second.try_cast<Integer>()) {
+    return value.value();
+  }
+  LOG(FATAL) << "Expected `" << key << "` to be an Integer, but got "
+             << (*it).second.GetTypeKey();
+  return Optional<Integer>(std::nullopt);
+}
+
+bool HasAnnotation(const Map<String, Any> &annotations, const char *key) {
+  return annotations.find(key) != annotations.end();
+}
+
+bool IsOne(const PrimExpr &expr, arith::Analyzer *analyzer) {
+  return is_const_int(expr, 1) || analyzer->CanProveEqual(expr, 1);
+}
+
+String KernelThreadTag(int64_t dim_kind, int64_t axis) {
+  static const char *const block_tags[] = {"blockIdx.x", "blockIdx.y",
+                                           "blockIdx.z"};
+  static const char *const thread_tags[] = {"threadIdx.x", "threadIdx.y",
+                                            "threadIdx.z"};
+  ICHECK_GE(axis, 0);
+  ICHECK_LT(axis, 3);
+  if (dim_kind == kTilelangKernelDimBlock) {
+    return String(block_tags[axis]);
+  }
+  ICHECK_EQ(dim_kind, kTilelangKernelDimThread);
+  return String(thread_tags[axis]);
+}
+
+Stmt MakeLaunchThread(PrimExpr min, PrimExpr extent, Var var, String thread_tag,
+                      Stmt body) {
+  IterVar iter_var(/*dom=*/Range::FromMinExtent(std::move(min), extent),
+                   /*var=*/std::move(var),
+                   /*iter_type=*/IterVarType::kThreadIndex,
+                   /*thread_tag=*/std::move(thread_tag));
+  return AttrStmt(/*node=*/std::move(iter_var),
+                  /*attr_key=*/tirx::attr::thread_extent,
+                  /*value=*/std::move(extent),
+                  /*body=*/std::move(body));
+}
+
+class KernelLaunchLower : public StmtExprMutator {
+public:
+  explicit KernelLaunchLower(KernelLaunchLoweringKind kind) : kind_(kind) {}
+
+private:
+  using Parent = StmtExprMutator;
+
+  Stmt VisitStmt_(const ForNode *op) final {
+    For loop = Downcast<For>(Parent::VisitStmt_(op));
+    auto dim_kind =
+        GetIntegerAnnotation(loop->annotations, tilelang_kernel_dim_kind);
+    if (!dim_kind.defined()) {
+      return loop;
+    }
+
+    auto axis =
+        GetIntegerAnnotation(loop->annotations, tilelang_kernel_dim_axis);
+    ICHECK(axis.defined()) << "T.Kernel dimension loop is missing `"
+                           << tilelang_kernel_dim_axis << "`";
+
+    bool is_default_thread =
+        dim_kind.value()->value == kTilelangKernelDimThread &&
+        HasAnnotation(loop->annotations, tilelang_kernel_thread_default);
+    bool is_thread = dim_kind.value()->value == kTilelangKernelDimThread;
+    Map<String, Any> annotations =
+        StripKernelLaunchAnnotations(loop->annotations);
+
+    if (kind_ == KernelLaunchLoweringKind::kSerial) {
+      if (is_thread) {
+        if (!is_default_thread && !IsOne(loop->extent, &analyzer_)) {
+          LOG(WARNING)
+              << "T.Kernel thread extent `" << loop->extent
+              << "` is ignored by serial backends such as CPU; "
+                 "thread bindings are lowered as a single logical thread.";
+        }
+        Map<Var, PrimExpr> var_map;
+        var_map.Set(loop->loop_var, make_const(loop->loop_var.dtype(), 0));
+        return Substitute(loop->body, var_map);
+      }
+      return For(loop->loop_var, loop->min, loop->extent, ForKind::kSerial,
+                 loop->body, /*thread_binding=*/std::nullopt, annotations,
+                 loop->step, loop->span);
+    }
+
+    ICHECK(annotations.empty())
+        << "T.Kernel hardware dimension loops cannot carry annotations after "
+           "kernel launch lowering";
+    return MakeLaunchThread(
+        loop->min, loop->extent, loop->loop_var,
+        KernelThreadTag(dim_kind.value()->value, axis.value()->value),
+        loop->body);
+  }
+
+  Stmt VisitStmt_(const SBlockNode *op) final {
+    SBlock block = Downcast<SBlock>(Parent::VisitStmt_(op));
+    if (!HasKernelLaunchAnnotation(block->annotations)) {
+      return block;
+    }
+    Map<String, Any> annotations =
+        StripKernelLaunchAnnotations(block->annotations);
+    return SBlock(block->iter_vars, block->reads, block->writes,
+                  block->name_hint, block->body, block->init,
+                  block->alloc_buffers, block->match_buffers, annotations);
+  }
+
+  KernelLaunchLoweringKind kind_;
+  arith::Analyzer analyzer_;
+};
+
+PrimFunc LowerKernelLaunchInFunc(PrimFunc func, KernelLaunchLoweringKind kind) {
+  KernelLaunchLower lower(kind);
+  Stmt body = lower(func->body);
+  if (!body.same_as(func->body)) {
+    func.CopyOnWrite()->body = body;
+  }
+  return func;
+}
+
+} // namespace
+
+namespace transform {
+
+tirx::transform::Pass LowerKernelLaunchPass(KernelLaunchLoweringKind kind,
+                                            const char *pass_name) {
+  using namespace tirx::transform;
+  auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
+    return LowerKernelLaunchInFunc(std::move(f), kind);
+  };
+  return CreatePrimFuncPass(pass_func, 0, pass_name, {});
+}
+
+tirx::transform::Pass LowerKernelLaunchToSerial() {
+  return LowerKernelLaunchPass(KernelLaunchLoweringKind::kSerial,
+                               "tl.LowerKernelLaunchToSerial");
+}
+
+tirx::transform::Pass LowerKernelLaunchToThreadBinding() {
+  return LowerKernelLaunchPass(KernelLaunchLoweringKind::kThreadBinding,
+                               "tl.LowerKernelLaunchToThreadBinding");
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = reflection;
+  refl::GlobalDef()
+      .def("tl.transform.LowerKernelLaunchToSerial", LowerKernelLaunchToSerial)
+      .def("tl.transform.LowerKernelLaunchToThreadBinding",
+           LowerKernelLaunchToThreadBinding);
+}
+
+} // namespace transform
+} // namespace tl
+} // namespace tvm

--- a/testing/python/cpu/test_tilelang_cpu_gemm.py
+++ b/testing/python/cpu/test_tilelang_cpu_gemm.py
@@ -14,7 +14,7 @@ def matmul(M, N, K, block_M, block_N, block_K, dtype=T.float16, accum_dtype=T.fl
         B: T.Tensor((K, N), dtype),
         C: T.Tensor((M, N), dtype),
     ):
-        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), is_cpu=True) as (bx, by):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M)) as (bx, by):
             A_local = T.alloc_local((block_M, block_K), dtype)
             B_local = T.alloc_local((block_K, block_N), dtype)
             C_local = T.alloc_local((block_M, block_N), accum_dtype)
@@ -69,7 +69,7 @@ def test_matmul_compile():
             B: T.Tensor((K, N), dtype),
             C: T.Tensor((M, N), dtype),
         ):
-            with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), is_cpu=True) as (bx, by):
+            with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M)) as (bx, by):
                 A_local = T.alloc_local((block_M, block_K), dtype)
                 B_local = T.alloc_local((block_K, block_N), dtype)
                 C_local = T.alloc_local((block_M, block_N), accum_dtype)
@@ -129,7 +129,7 @@ def test_matmul_with_copy_cython():
         B: T.Tensor((K, N), "float32"),
         C: T.Tensor((M, N), "float32"),
     ):
-        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), is_cpu=True) as (bx, by):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M)) as (bx, by):
             A_local = T.alloc_local((block_M, block_K), "float32")
             B_local = T.alloc_local((block_K, block_N), "float32")
             C_local = T.alloc_local((block_M, block_N), "float32")

--- a/testing/python/cpu/test_tilelang_cpu_tgemm.py
+++ b/testing/python/cpu/test_tilelang_cpu_tgemm.py
@@ -24,7 +24,7 @@ def matmul(M, N, K, block_M, block_N, block_K, trans_A=False, trans_B=False, dty
         B: T.Tensor(B_shape, dtype),
         C: T.Tensor((M, N), dtype),
     ):
-        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), is_cpu=True) as (bx, by):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M)) as (bx, by):
             A_local = T.alloc_local(A_local_shape, dtype)
             B_local = T.alloc_local(B_local_shape, dtype)
             C_local = T.alloc_local((block_M, block_N), accum_dtype)

--- a/testing/python/cpu/test_tilelang_cpu_while_repro.py
+++ b/testing/python/cpu/test_tilelang_cpu_while_repro.py
@@ -7,11 +7,10 @@ def test_cpu_kernel_source_generation_with_while() -> None:
 
     See: https://github.com/tile-ai/tilelang/issues/2202
 
-    Historically, a CPU kernel containing `T.While(...)` inside
-    `T.Kernel(..., is_cpu=True)` could leak the synthetic fallback thread
-    variable `v_thread` into host/device splitting. That in turn caused CPU
-    compilation to fail during packed-API generation or later C wrapper
-    generation.
+    Historically, a CPU kernel containing `T.While(...)` inside `T.Kernel(...)`
+    could leak a synthetic fallback thread variable into host/device splitting.
+    That in turn caused CPU compilation to fail during packed-API generation or
+    later C wrapper generation.
 
     This test follows the existing compile-only regression style used in the
     repository: success is defined by `tilelang.compile(..., target="c")`
@@ -20,7 +19,7 @@ def test_cpu_kernel_source_generation_with_while() -> None:
 
     @T.prim_func
     def main(flag: T.Buffer((1,), "int32"), out: T.Buffer((1,), "int32")):
-        with T.Kernel(1, is_cpu=True):
+        with T.Kernel(1):
             state = T.alloc_fragment((1,), "int32")
             state[0] = 0
 

--- a/testing/python/language/test_tilelang_kernel_target_lowering.py
+++ b/testing/python/language/test_tilelang_kernel_target_lowering.py
@@ -1,0 +1,109 @@
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+
+
+def _make_default_thread_kernel():
+    @T.prim_func
+    def main(A: T.Tensor((8,), "float32")):
+        with T.Kernel(8) as bx:
+            A[bx] = T.float32(1)
+
+    return main.with_attr("global_symbol", "main")
+
+
+def _make_explicit_thread_kernel():
+    @T.prim_func
+    def main(A: T.Tensor((8,), "float32")):
+        with T.Kernel(8, threads=4) as bx:
+            tx = T.get_thread_binding()
+            A[bx] = T.cast(tx, "float32")
+
+    return main.with_attr("global_symbol", "main")
+
+
+def _make_unit_thread_kernel():
+    @T.prim_func
+    def main(A: T.Tensor((8,), "float32")):
+        with T.Kernel(8, threads=1) as bx:
+            tx = T.get_thread_binding()
+            A[bx] = T.cast(tx, "float32")
+
+    return main.with_attr("global_symbol", "main")
+
+
+def _lower_kernel_launch(func, target, lower_pass):
+    target = tvm.target.Target(target)
+    mod = tvm.IRModule.from_expr(func)
+    mod = tvm.tirx.transform.BindTarget(target)(mod)
+    return lower_pass()(mod)
+
+
+def test_kernel_ast_is_target_neutral():
+    script = _make_default_thread_kernel().script()
+
+    assert "threadIdx" not in script
+    assert "blockIdx" not in script
+    assert "tilelang.kernel_dim_kind" in script
+
+
+def test_kernel_lower_to_cuda_thread_bindings():
+    mod = _lower_kernel_launch(
+        _make_default_thread_kernel(),
+        {"kind": "cuda", "arch": "sm_80"},
+        tilelang.transform.LowerKernelLaunchToThreadBinding,
+    )
+    script = mod["main"].script()
+
+    assert "blockIdx.x" in script
+    assert "threadIdx.x" in script
+
+
+def test_kernel_lower_to_cpu_serial_grid_without_default_threads():
+    mod = _lower_kernel_launch(
+        _make_default_thread_kernel(),
+        "c",
+        tilelang.transform.LowerKernelLaunchToSerial,
+    )
+    script = mod["main"].script()
+
+    assert "blockIdx" not in script
+    assert "threadIdx" not in script
+    assert "for tx" not in script
+
+
+def test_kernel_lower_to_cpu_serial_ignores_explicit_threads(capfd):
+    mod = _lower_kernel_launch(
+        _make_explicit_thread_kernel(),
+        "c",
+        tilelang.transform.LowerKernelLaunchToSerial,
+    )
+    script = mod["main"].script()
+    captured = capfd.readouterr()
+
+    assert "threadIdx" not in script
+    assert "for tx" not in script
+    assert "for ty" not in script
+    assert "for tz" not in script
+    assert 'A[bx] = T.Cast("float32", 0)' in script
+    assert "thread extent `4` is ignored by serial backends" in captured.out + captured.err
+
+
+def test_kernel_lower_to_cpu_serial_unit_thread_without_warning(capfd):
+    mod = _lower_kernel_launch(
+        _make_unit_thread_kernel(),
+        "c",
+        tilelang.transform.LowerKernelLaunchToSerial,
+    )
+    script = mod["main"].script()
+    captured = capfd.readouterr()
+
+    assert "threadIdx" not in script
+    assert "for tx" not in script
+    assert 'A[bx] = T.Cast("float32", 0)' in script
+    assert "ignored by serial backends" not in captured.out + captured.err
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_cluster_planning.py
+++ b/testing/python/transform/test_tilelang_transform_cluster_planning.py
@@ -11,10 +11,12 @@ def _check(original, transformed):
     func = original
     mod = tvm.IRModule.from_expr(func.with_attr("global_symbol", "main"))
     mod = tvm.tirx.transform.BindTarget(auto_target)(mod)
+    mod = tl.transform.LowerKernelLaunchToThreadBinding()(mod)
     mod = tl.transform.LowerOpaqueBlock()(mod)
     mod = tl.transform.ClusterPlanning()(mod)
     transformed = tvm.IRModule.from_expr(transformed.with_attr("global_symbol", "main"))
     transformed = tvm.tirx.transform.BindTarget(auto_target)(transformed)
+    transformed = tl.transform.LowerKernelLaunchToThreadBinding()(transformed)
     transformed = tl.transform.LowerOpaqueBlock()(transformed)
 
     tvm.ir.assert_structural_equal(mod["main"], transformed["main"], True)

--- a/testing/python/transform/test_tilelang_transform_lower_hopper_intrin.py
+++ b/testing/python/transform/test_tilelang_transform_lower_hopper_intrin.py
@@ -12,10 +12,12 @@ def _check(original, transformed):
     func = original
     mod = tvm.IRModule.from_expr(func.with_attr("global_symbol", "main"))
     mod = tvm.tirx.transform.BindTarget(auto_target)(mod)
+    mod = tl.transform.LowerKernelLaunchToThreadBinding()(mod)
     mod = cuda_transform.LowerHopperIntrin()(mod)
     mod = tl.transform.LowerOpaqueBlock()(mod)
     transformed = tvm.IRModule.from_expr(transformed.with_attr("global_symbol", "main"))
     transformed = tvm.tirx.transform.BindTarget(auto_target)(transformed)
+    transformed = tl.transform.LowerKernelLaunchToThreadBinding()(transformed)
     transformed = tl.transform.LowerOpaqueBlock()(transformed)
     transformed["main"] = transformed["main"].with_attr("tma_descriptor_args", {})
 
@@ -39,6 +41,7 @@ def test_lower_shared_barrier():
 
     mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
     mod = tvm.tirx.transform.BindTarget(auto_target)(mod)
+    mod = tl.transform.LowerKernelLaunchToThreadBinding()(mod)
     mod = cuda_transform.LowerSharedBarrier()(mod)
     mod = tl.transform.LowerOpaqueBlock()(mod)
 

--- a/testing/python/transform/test_tilelang_transform_lower_shared_barrier.py
+++ b/testing/python/transform/test_tilelang_transform_lower_shared_barrier.py
@@ -13,6 +13,7 @@ auto_target = tvm.target.Target(determine_target("auto"))
 def _apply(func):
     mod = tvm.IRModule.from_expr(func.with_attr("global_symbol", "main"))
     mod = tvm.tirx.transform.BindTarget(auto_target)(mod)
+    mod = tl.transform.LowerKernelLaunchToThreadBinding()(mod)
     mod = tl.cuda.transform.LowerSharedBarrier()(mod)
     return mod
 

--- a/testing/python/transform/test_tilelang_transform_lower_shared_tmem.py
+++ b/testing/python/transform/test_tilelang_transform_lower_shared_tmem.py
@@ -11,6 +11,7 @@ TARGET = tvm.target.Target({"kind": "cuda", "arch": "sm_100"})
 def _apply(func):
     mod = tvm.IRModule.from_expr(func.with_attr("global_symbol", "main"))
     mod = tvm.tirx.transform.BindTarget(TARGET)(mod)
+    mod = tl.transform.LowerKernelLaunchToThreadBinding()(mod)
     mod = tl.cuda.transform.LowerSharedTmem()(mod)
     return mod
 

--- a/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
+++ b/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
@@ -314,6 +314,7 @@ def test_tiled_ws_places_producer_in_first_warp_group():
     mod = tvm.IRModule.from_expr(func)
     target = determine_target({"kind": "cuda", "arch": "sm_90"}, return_object=True)
     mod = tvm.tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.LowerKernelLaunchToThreadBinding()(mod)
     mod = tilelang.cuda.transform.ProducerConsumerWarpSpecialized()(mod)
     script = mod["main"].script()
 
@@ -548,6 +549,7 @@ def test_tiled_ws_explicit_cp_async_wait_precedes_first_consumer_read():
     mod = tvm.IRModule.from_expr(func)
     target = determine_target({"kind": "cuda", "arch": "sm_90"}, return_object=True)
     mod = tvm.tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.LowerKernelLaunchToThreadBinding()(mod)
     mod = tilelang.cuda.transform.ProducerConsumerWarpSpecialized()(mod)
     script = mod["main"].script()
 
@@ -586,6 +588,7 @@ def test_tiled_ws_propagates_nested_postloop_liveness_to_outer_prelude():
     mod = tvm.IRModule.from_expr(func)
     target = determine_target({"kind": "cuda", "arch": "sm_90"}, return_object=True)
     mod = tvm.tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.LowerKernelLaunchToThreadBinding()(mod)
     mod = tilelang.cuda.transform.ProducerConsumerWarpSpecialized()(mod)
     script = mod["main"].script()
 

--- a/testing/python/transform/test_tilelang_transform_split_host_device.py
+++ b/testing/python/transform/test_tilelang_transform_split_host_device.py
@@ -13,6 +13,7 @@ def run_split_host_device_passes(func: tvm.tirx.PrimFunc):
     """Run the necessary passes before and including SplitHostDevice."""
     mod = tvm.IRModule({func.attrs["global_symbol"]: func})
     mod = tvm.tirx.transform.BindTarget(tvm.target.Target("cuda", "c"))(mod)
+    mod = tl.transform.LowerKernelLaunchToThreadBinding()(mod)
     mod = tl.transform.InjectAssumes()(mod)
     mod = tl.transform.AnnotateDeviceRegions()(mod)
     mod = tl.transform.SplitHostDevice()(mod)

--- a/tilelang/backend/common.py
+++ b/tilelang/backend/common.py
@@ -1,11 +1,24 @@
 from __future__ import annotations
 
-from tilelang.backend.execution_backend import ExecutionBackendSpec, register_execution_backend
+from tvm import IRModule, tirx
+from tvm.target import Target
+
+import tilelang
+from tilelang.backend.execution_backend import (
+    ExecutionBackendSpec,
+    register_execution_backend,
+)
 from tilelang.backend.pass_pipeline.pipeline import PassPipeline, register_pipeline
-from tilelang.cpu.pipeline import CPUPassPipelineBody
+from tilelang.cpu.pipeline import CPUPassPipelineBodyAfterKernelLaunch
 
 
-register_pipeline(PassPipeline("webgpu", CPUPassPipelineBody))
+def WebGPUPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
+    mod = tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.LowerKernelLaunchToThreadBinding()(mod)
+    return CPUPassPipelineBodyAfterKernelLaunch(mod, target)
+
+
+register_pipeline(PassPipeline("webgpu", WebGPUPassPipelineBody))
 register_execution_backend("webgpu", ExecutionBackendSpec("cython"), override=True)
 register_execution_backend(
     "webgpu",

--- a/tilelang/cpu/pipeline.py
+++ b/tilelang/cpu/pipeline.py
@@ -15,8 +15,7 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
 )
 
 
-def CPUPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
-    mod = tirx.transform.BindTarget(target)(mod)
+def CPUPassPipelineBodyAfterKernelLaunch(mod: IRModule, target: Target) -> IRModule:
     pass_ctx = tilelang.transform.get_pass_context()
 
     if should_force_let_inline():
@@ -82,6 +81,12 @@ def CPUPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.Simplify()(mod)
     mod = tilelang.transform.LowerDeviceKernelLaunch()(mod)
     return mod
+
+
+def CPUPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
+    mod = tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.LowerKernelLaunchToSerial()(mod)
+    return CPUPassPipelineBodyAfterKernelLaunch(mod, target)
 
 
 for _kind in ("c", "llvm"):

--- a/tilelang/cuda/pipeline.py
+++ b/tilelang/cuda/pipeline.py
@@ -67,6 +67,7 @@ def _module_has_shared_barrier(mod: IRModule) -> bool:
 
 def CUDAPassPipelineBodyPrologue(mod: IRModule, target: Target) -> IRModule:
     mod = tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.LowerKernelLaunchToThreadBinding()(mod)
     if should_force_let_inline():
         # Force-let inline whenever the pass config requests it.
         mod = tilelang.transform.LetInline()(mod)

--- a/tilelang/language/kernel.py
+++ b/tilelang/language/kernel.py
@@ -95,23 +95,41 @@ def _normalize_bindings(bindings: list[Var]) -> Var | list[Var]:
     return bindings
 
 
+def _as_int(value, default: int) -> int:
+    if value is None:
+        return default
+    if hasattr(value, "value"):
+        return int(value.value)
+    return int(value)
+
+
+def _frame_var(frame) -> Var:
+    if hasattr(frame, "vars"):
+        return frame.vars[0]
+    return frame.iter_var.var
+
+
+def _frame_extent(frame):
+    if hasattr(frame, "doms"):
+        return frame.doms[0].extent
+    return frame.iter_var.dom.extent
+
+
 def _normalize_threads(
     threads: int | list[int] | tuple | None,
-    *,
-    is_cpu: bool,
-) -> list[int] | None:
-    if not is_cpu and threads is None:
-        threads = 128  # default thread number
+) -> tuple[list[int], bool]:
+    is_default = threads is None
+    if threads is None:
+        threads = 128  # default thread number for targets that have threads
 
     if isinstance(threads, int):
-        return [threads, 1, 1]
+        return [threads, 1, 1], is_default
     if isinstance(threads, list):
-        return threads + [1] * (3 - len(threads))
+        return threads + [1] * (3 - len(threads)), is_default
     if isinstance(threads, tuple):
-        return list(threads) + [1] * (3 - len(threads))
+        return list(threads) + [1] * (3 - len(threads)), is_default
 
-    assert is_cpu, "threads must be an integer or a list of integers"
-    return None
+    raise TypeError("threads must be an integer, a list of integers, a tuple of integers, or None")
 
 
 def _normalize_cluster_dims(
@@ -140,8 +158,8 @@ class KernelLaunchFrame(TIRFrame):
     def __enter__(self) -> Var | list[Var]:
         """
         Enters the KernelLaunchFrame scope and pushes this frame onto the stack.
-        Returns one Var if we detect exactly 5 frames (meaning there is a single
-        block dimension), or a list of Vars otherwise.
+        Returns a block index Var, or a list of block index Vars for
+        multi-dimensional launches.
         """
         super().__enter__()
         _get_current_stack().push(self)
@@ -149,15 +167,7 @@ class KernelLaunchFrame(TIRFrame):
         last_block_frame = self.frames[-1]
         assert isinstance(last_block_frame, SBlockFrame), f"Last frame must be a block frame, got {last_block_frame}"
 
-        maybe_cpu = last_block_frame.annotations.get("tilelang.is_cpu_kernel_frame", False)
-
-        if maybe_cpu:
-            # CPU kernel frame, return a list of for frame items.
-            return _normalize_bindings([frame.vars[0] for frame in self.frames[0:-1]])
-        else:
-            # Otherwise, return a list of iter_var.var objects (excluding the last 4 frames).
-            # As 4 frames for threadIdx.x, threadIdx.y, threadIdx.z and block frame with attributes
-            return _normalize_bindings([frame.iter_var.var for frame in self.frames[0:-4]])
+        return _normalize_bindings([_frame_var(frame) for frame in self._block_frames()])
 
     def __exit__(self, ptype, value, trace):
         """
@@ -178,54 +188,74 @@ class KernelLaunchFrame(TIRFrame):
         stack = _get_current_stack()
         return stack.top() if stack else None
 
+    def _num_block_dims(self) -> int:
+        annotations = self.frames[-1].annotations
+        if "tilelang.kernel_num_blocks" in annotations:
+            return _as_int(annotations.get("tilelang.kernel_num_blocks"), 0)
+        if annotations.get("tilelang.is_cpu_kernel_frame", False):
+            return len(self.frames) - 1
+        return max(0, len(self.frames) - 4)
+
+    def _num_thread_dims(self) -> int:
+        annotations = self.frames[-1].annotations
+        if "tilelang.kernel_num_threads" in annotations:
+            return _as_int(annotations.get("tilelang.kernel_num_threads"), 0)
+        return max(0, len(self.frames) - self._num_block_dims() - 1)
+
+    def _block_frames(self):
+        return self.frames[: self._num_block_dims()]
+
+    def _thread_frames(self):
+        start = self._num_block_dims()
+        stop = start + self._num_thread_dims()
+        return self.frames[start:stop]
+
     def get_block_extent(self, dim: int) -> int:
         """
         Returns the block extent for the given dimension.
         dim=0 corresponds to blockIdx.x, dim=1 to blockIdx.y, and dim=2 to blockIdx.z.
         """
-        iter_var = self.frames[dim].iter_var
-        return int(iter_var.dom.extent)
+        return int(_frame_extent(self._block_frames()[dim]))
 
     def get_block_extents(self) -> list[int]:
         """
         Returns the block extents for all three dimensions.
         """
-        return [self.get_block_extent(dim) for dim in range(3)]
+        return [self.get_block_extent(dim) for dim in range(self._num_block_dims())]
 
     def get_thread_extent(self, dim: int) -> int:
         """
         Returns the thread extent for the given dimension.
         dim=0 corresponds to threadIdx.x, dim=1 to threadIdx.y, and dim=2 to threadIdx.z.
         """
-        iter_var = self.frames[-4 + dim].iter_var
-        return int(iter_var.dom.extent)
+        return int(_frame_extent(self._thread_frames()[dim]))
 
     def get_thread_extents(self) -> list[int]:
         """
         Returns the thread extents for all three dimensions.
         """
-        return [self.get_thread_extent(dim) for dim in range(3)]
+        return [self.get_thread_extent(dim) for dim in range(self._num_thread_dims())]
 
     def get_thread_binding(self, dim: int = 0) -> Var:
         """
         Returns the thread binding for the given dimension.
         dim=0 corresponds to threadIdx.x, dim=1 to threadIdx.y, and dim=2 to threadIdx.z.
         """
-        return self.frames[-4 + dim].iter_var.var
+        return _frame_var(self._thread_frames()[dim])
 
     def get_thread_bindings(self) -> list[Var]:
         """
         Returns the thread binding for the given dimension.
         dim=0 corresponds to threadIdx.x, dim=1 to threadIdx.y, and dim=2 to threadIdx.z.
         """
-        return [frame.iter_var.var for frame in self.frames[-4:-1]]
+        return [_frame_var(frame) for frame in self._thread_frames()]
 
     def get_num_threads(self) -> int:
         """
         Returns the thread indices from the topmost frame.
         """
         num_threads: int = 1
-        for thread_dim in range(3):
+        for thread_dim in range(self._num_thread_dims()):
             num_threads *= self.get_thread_extent(thread_dim)
         return num_threads
 
@@ -234,27 +264,27 @@ class KernelLaunchFrame(TIRFrame):
         Returns the block binding for the given dimension.
         dim=0 corresponds to blockIdx.x, dim=1 to blockIdx.y, and dim=2 to blockIdx.z.
         """
-        return self.frames[dim].iter_var.var
+        return _frame_var(self._block_frames()[dim])
 
     def get_block_bindings(self) -> list[Var]:
         """
         Returns all three block bindings.
         """
-        return [frame.iter_var.var for frame in self.frames[0:-4]]
+        return [_frame_var(frame) for frame in self._block_frames()]
 
     @property
     def blocks(self) -> list[Var]:
         """
         Returns the block indices from the topmost frame.
         """
-        return [frame.iter_var.var for frame in self.frames[0:-4]]
+        return [_frame_var(frame) for frame in self._block_frames()]
 
     @property
     def threads(self) -> list[Var]:
         """
         Returns the thread indices from the topmost frame.
         """
-        return [frame.iter_var.var for frame in self.frames[-4:]]
+        return [_frame_var(frame) for frame in self._thread_frames()]
 
     @property
     def num_threads(self) -> int:
@@ -271,7 +301,7 @@ def Kernel(
     is_cpu: bool = False,
     prelude: str | None = None,
 ):
-    """Tools to quickly construct a GPU kernel launch frame.
+    """Tools to construct a target-neutral kernel launch frame.
 
     Parameters
     ----------
@@ -281,6 +311,8 @@ def Kernel(
         A integer representing blockDim.x
         Or a list of integers representing blockDim.(x|y|z)
         if the value is -1, we skip the threadIdx.x binding.
+        When omitted, threaded backends use the default block size while CPU
+        backends lower the kernel without synthetic thread loops.
     cluster_dims : int | tuple[int, int, int] | list[int] | None
         The cluster dimensions for SM90+ cluster launch.
         For example, use 2 or (2, 1, 1) to create 2-CTA clusters.
@@ -313,11 +345,12 @@ def Kernel(
             tx, ty = T.get_thread_bindings()
             ...
 
-    Emit a CPU kernel where thread bindings are skipped:
+    The same source can be lowered for CPU or GPU targets. The target-specific
+    loop form is selected during compilation:
 
     .. code-block:: python
 
-        with T.Kernel(loop_extent, is_cpu=True) as (i,):
+        with T.Kernel(loop_extent) as i:
             ...
     """
     # In eager mode, we construct AST directly without prim_func,
@@ -330,10 +363,9 @@ def Kernel(
         raise JITNoBuilderError("T.Kernel() can only be used inside @tilelang.jit or @T.prim_func context. No Builder is available.")
 
     attrs: dict = {}
-    threads = _normalize_threads(threads, is_cpu=is_cpu)
-
-    if is_cpu:
-        attrs["tilelang.is_cpu_kernel_frame"] = True
+    threads, threads_defaulted = _normalize_threads(threads)
+    if threads_defaulted:
+        attrs["tilelang.kernel_thread_default"] = True
 
     if prelude is not None:
         attrs["pragma_import_c"] = prelude
@@ -424,7 +456,9 @@ def CUDASourceCodeKernel(
         raise ValueError("entry_name must be a non-empty string when provided")
     attrs["code_block_entry_name"] = entry_name
 
-    threads = _normalize_threads(threads, is_cpu=False)
+    threads, threads_defaulted = _normalize_threads(threads)
+    if threads_defaulted:
+        attrs["tilelang.kernel_thread_default"] = True
 
     cluster_dims = _normalize_cluster_dims(cluster_dims)
     if cluster_dims is not None:

--- a/tilelang/metal/pipeline.py
+++ b/tilelang/metal/pipeline.py
@@ -18,6 +18,7 @@ from tilelang.metal.transform import MetalFragmentToSimdgroup
 
 def MetalPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.LowerKernelLaunchToThreadBinding()(mod)
     pass_ctx = tilelang.transform.get_pass_context()
 
     if should_force_let_inline():

--- a/tilelang/rocm/pipeline.py
+++ b/tilelang/rocm/pipeline.py
@@ -17,6 +17,7 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
 
 def ROCMPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.LowerKernelLaunchToThreadBinding()(mod)
     pass_ctx = tilelang.transform.get_pass_context()
 
     if should_force_let_inline():

--- a/tilelang/transform/__init__.py
+++ b/tilelang/transform/__init__.py
@@ -338,6 +338,16 @@ def LowerOpaqueBlock():
     return _ffi_api.LowerOpaqueBlock()  # type: ignore
 
 
+def LowerKernelLaunchToSerial():
+    """Lower target-neutral T.Kernel loops to ordinary serial loops."""
+    return _ffi_api.LowerKernelLaunchToSerial()  # type: ignore
+
+
+def LowerKernelLaunchToThreadBinding():
+    """Lower target-neutral T.Kernel loops to blockIdx/threadIdx bindings."""
+    return _ffi_api.LowerKernelLaunchToThreadBinding()  # type: ignore
+
+
 def LowerThreadAllreduce():
     """LowerThreadAllreduce"""
     return _ffi_api.LowerThreadAllreduce()  # type: ignore


### PR DESCRIPTION
## Summary

- Make `T.Kernel` build a target-neutral launch scope instead of committing to `blockIdx`/`threadIdx` during AST construction.
- Move kernel launch lowering into backend-selected passes so CPU and future backends do not need frontend flags such as `is_cpu=True`.
- Keep CUDA/ROCM-style thread binding as a shared lowering mode while allowing each backend pipeline to opt in explicitly.

## Changes

- Add target-neutral `tilelang.kernel_*` annotations in the frontend launch frame and preserve `T.Kernel` block/thread introspection from those neutral frames.
- Add explicit `LowerKernelLaunchToSerial` and `LowerKernelLaunchToThreadBinding` transform passes.
- Route CPU/LLVM through serial lowering, and route CUDA, ROCM, Metal, and WebGPU through thread-binding lowering in their own pipeline entry points.
- Split the CPU pipeline after kernel-launch lowering so WebGPU can choose thread-binding lowering while reusing the existing common pass tail.
- Update CPU examples/tests to use `T.Kernel(...)` without `is_cpu=True`, and add coverage for neutral AST construction plus target-specific lowering.

## Validation

- `pre-commit run --all-files`
- `cmake --build build -j$(nproc)`
- `python -m pytest testing/python/language/test_tilelang_kernel_target_lowering.py -q`
- `python -m pytest testing/python/webgpu/test_webgpu_codegen.py -q`
- `python -m pytest testing/python/cpu/test_tilelang_cpu_while_repro.py -q`
- `python -m pytest testing/python/cpu/test_tilelang_cpu_gemm.py -q -k "test_matmul_codegen"`
- `python -m pytest testing/python/cpu/test_tilelang_cpu_tgemm.py -q -k "test_codegen_basic"`
- `python -m pytest testing/python/transform/test_tilelang_transform_hoist_broadcast_values.py -q -k "test_transform_hoist and not let"`

## Notes

- The thread-binding lowering emits the existing `thread_extent` AttrStmt shape directly so layout inference and tile-op lowering continue to see the same form they used before opaque-block lowering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized kernel-launch framing and block/thread handling; kernels now record when threads are defaulted instead of requiring explicit CPU marking.
* **New Features**
  * Added target‑neutral kernel-launch lowering passes (serial and thread‑binding) and hooked them into CPU, CUDA, Metal, ROCm, and WebGPU pipelines; introduced kernel-launch metadata attributes.
* **Tests**
  * Expanded and updated tests to cover default/explicit/unit-thread kernels, serial vs thread-binding lowering, and a CPU regression case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->