### PR TITLE
[CUDA] Align swizzled TMA shared memory

### DIFF
--- a/src/cuda/transform/lower_hopper_intrin.cc
+++ b/src/cuda/transform/lower_hopper_intrin.cc
@@ -13,6 +13,7 @@
 #include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/transform.h>
 
+#include <optional>
 #include <unordered_map>
 #include <vector>
 
@@ -179,6 +180,22 @@ public:
   }
 
   PrimExpr VisitExpr_(const CallNode *call) final {
+    if (IsDescriptorBackedTmaCall(call)) {
+      Optional<PrimExpr> swizzle = GetDescriptorSwizzle(call->args[0]);
+
+      Array<PrimExpr> args;
+      args.reserve(call->args.size());
+      for (const PrimExpr &arg : call->args) {
+        args.push_back(this->VisitExpr(arg));
+      }
+
+      Map<String, ObjectRef> annotations = call->annotations;
+      if (swizzle.defined()) {
+        annotations.Set(attr::kTmaSwizzle, swizzle.value());
+      }
+      return Call(call->dtype, call->op, args, annotations, call->span);
+    }
+
     if (call->op.same_as(create_tma_descriptor()) ||
         call->op.same_as(create_tma_im2col_descriptor())) {
       Var var;
@@ -259,6 +276,29 @@ private:
     Call init_desc =
         Call(DataType::Handle(), builtin::tvm_call_packed(), init_desc_args);
     return SeqStmt({tirx::Bind(var, alloc_desc), Evaluate(init_desc)});
+  }
+
+  static bool IsDescriptorBackedTmaCall(const CallNode *call) {
+    return call->args.size() >= 1 && (call->op.same_as(tma_load()) ||
+                                      call->op.same_as(tma_load_im2col()) ||
+                                      call->op.same_as(tma_load_multicast()) ||
+                                      call->op.same_as(tma_store()) ||
+                                      call->op.same_as(tma_load_gather4()) ||
+                                      call->op.same_as(tma_store_scatter4()));
+  }
+
+  static Optional<PrimExpr> GetDescriptorSwizzle(const PrimExpr &descriptor) {
+    const auto *desc_call = descriptor.as<CallNode>();
+    if (desc_call == nullptr ||
+        !(desc_call->op.same_as(create_tma_descriptor()) ||
+          desc_call->op.same_as(create_tma_im2col_descriptor()))) {
+      return std::nullopt;
+    }
+
+    // Both descriptor encodings end with:
+    //   ..., interleave, swizzle, l2_promotion, oob_fill
+    ICHECK_GE(desc_call->args.size(), 4U);
+    return desc_call->args[desc_call->args.size() - 3];
   }
 
   Array<Stmt> prefetch_calls_;

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -47,6 +47,9 @@ static constexpr const char *kAsyncCopyNoImplicitCommitWait =
 // parity from surrounding loop context.
 static constexpr const char *kPipelineMbarPhaseExpr =
     "tl.pipeline_mbar_phase_expr";
+// Low-level TMA call annotation carrying the CUtensorMap swizzle enum encoded
+// in the descriptor used by that call.
+static constexpr const char *kTmaSwizzle = "tl.tma_swizzle";
 static constexpr const char *kLocalVarInit = "tl.local_var_init";
 // A PrimFunc-level attribute carrying a list of handle Vars
 // that must NOT be marked with the restrict qualifier in codegen.

--- a/src/transform/merge_shared_memory_allocations.cc
+++ b/src/transform/merge_shared_memory_allocations.cc
@@ -377,43 +377,90 @@ public:
   }
 
 private:
+  static constexpr int kTensorMapSwizzleNone = 0;
+  static constexpr int kTensorMapSwizzle32B = 1;
+  static constexpr int kTensorMapSwizzle64B = 2;
+  static constexpr int kTensorMapSwizzle128B = 3;
+
+  static int DefaultTmaAlignmentBytes(Target target) {
+    if (TargetIsHopper(target)) {
+      return 1024;
+    }
+    if (TargetHasBulkCopy(target)) {
+      return 128;
+    }
+    return 16;
+  }
+
+  static int SwizzledTmaAlignmentBytes(int swizzle) {
+    // TMA shared-memory swizzle uses the absolute shared base as part of the
+    // swizzle phase. Align to one full eight-span phase for the selected
+    // swizzle width.
+    switch (swizzle) {
+    case kTensorMapSwizzle32B:
+      return 256;
+    case kTensorMapSwizzle64B:
+      return 512;
+    case kTensorMapSwizzle128B:
+      return 1024;
+    case kTensorMapSwizzleNone:
+    default:
+      return 0;
+    }
+  }
+
+  static int TmaCallAlignmentBytes(const CallNode *op, Target target) {
+    int alignment = DefaultTmaAlignmentBytes(target);
+    if (auto swizzle_ref = op->annotations.Get(attr::kTmaSwizzle)) {
+      if (auto swizzle = swizzle_ref.value().as<IntImmNode>()) {
+        alignment = std::max(alignment, SwizzledTmaAlignmentBytes(
+                                            static_cast<int>(swizzle->value)));
+      }
+    }
+    return alignment;
+  }
+
+  static bool IsTmaLikeCall(const CallNode *op) {
+    return op->op.same_as(tl::tma_load()) ||
+           op->op.same_as(tl::tma_load_im2col()) ||
+           op->op.same_as(tl::tma_load_multicast()) ||
+           op->op.same_as(tl::tma_store()) ||
+           op->op.same_as(tl::tma_load_gather4()) ||
+           op->op.same_as(tl::tma_store_scatter4());
+  }
+
   // Helper to record alignment for a shared/shared.dyn Var under alignment
   // scope
   void MarkSharedVarIfNeeded(const VarNode *op) {
-    if (!op || !under_alignment_scope_)
+    if (!op || alignment_scope_bytes_ <= 0)
       return;
     auto ptr_type = op->type_annotation.as<PointerTypeNode>();
     if (!ptr_type)
       return;
     auto scope = GetPtrStorageScope(GetRef<Var>(op));
     if (scope == "shared" || scope == "shared.dyn") {
-      auto target = Target::Current();
-      ICHECK(target.defined()) << "Target is not defined";
-      // TMA bulk-copy operands have stricter shared-memory alignment than
-      // ordinary scalar/shared accesses. Hopper keeps the existing 1024-byte
-      // alignment used by the WGMMA/TMA path, while Blackwell/SM120 also needs
-      // TMA sources at least 128-byte aligned to avoid misaligned-address
-      // launch failures.
-      int alignment = 16;
-      if (TargetIsHopper(target)) {
-        alignment = 1024;
-      } else if (TargetHasBulkCopy(target)) {
-        alignment = 128;
-      }
-      shmem_alignment_map_[op] = alignment;
+      int &alignment = shmem_alignment_map_[op];
+      alignment = std::max(alignment, alignment_scope_bytes_);
     }
   }
 
   void VisitExpr_(const CallNode *op) {
     if (op->op.same_as(tl::tl_gemm()) || op->op.same_as(tl::tl_gemm_sp()) ||
-        op->op.same_as(tl::tma_load()) || op->op.same_as(tl::tma_store()) ||
+        IsTmaLikeCall(op) ||
         op->op.same_as(tl::initialize_wgmma_descriptor()) ||
         op->op.same_as(tl::initialize_tcgen05_descriptor())) {
       // These intrinsics introduce stricter SMEM alignment requirements; mark
       // the subtree.
-      under_alignment_scope_ = true;
+      auto target = Target::Current();
+      ICHECK(target.defined()) << "Target is not defined";
+      int required_alignment = IsTmaLikeCall(op)
+                                   ? TmaCallAlignmentBytes(op, target)
+                                   : DefaultTmaAlignmentBytes(target);
+      int previous_alignment_scope = alignment_scope_bytes_;
+      alignment_scope_bytes_ =
+          std::max(alignment_scope_bytes_, required_alignment);
       StmtExprVisitor::VisitExpr_(op);
-      under_alignment_scope_ = false;
+      alignment_scope_bytes_ = previous_alignment_scope;
     } else {
       StmtExprVisitor::VisitExpr_(op);
     }
@@ -427,14 +474,14 @@ private:
   void VisitExpr_(const BufferLoadNode *op) {
     // If we encounter address_of(BufferLoad(...)) or any direct BufferLoad
     // within an alignment scope, make sure we mark the underlying shared var.
-    if (op && under_alignment_scope_) {
+    if (op && alignment_scope_bytes_ > 0) {
       const VarNode *data_var = op->buffer->data.get();
       MarkSharedVarIfNeeded(data_var);
     }
     StmtExprVisitor::VisitExpr_(op);
   }
 
-  bool under_alignment_scope_{false};
+  int alignment_scope_bytes_{0};
 
   std::unordered_map<const VarNode *, int> shmem_alignment_map_;
 };

--- a/testing/python/issue/test_tilelang_issue_sm120_tma_smem_alignment.py
+++ b/testing/python/issue/test_tilelang_issue_sm120_tma_smem_alignment.py
@@ -18,11 +18,11 @@ arch >= 90 (sm_90, sm_100, sm_103, sm_120 and any future TMA-capable
 target) — the correct set, since TMA support and TMA's alignment
 requirements are coextensive.
 
-The test has two parts:
+The test has three parts:
 
 1. **Generated TIR check** (host-independent). Lowers the buggy-arena
    kernel for explicit `{"kind": "cuda", "arch": "sm_{90,100,120}"}` targets and asserts
-   every `tl.tma_load` destination `tirx.tvm_access_ptr` byte offset is
+   every `tl.tma_load` destination absolute shared-memory byte offset is
    provably 128-byte aligned. Runs on any host.
 
 2. **Runtime check** on the host GPU. Compiles + executes the same kernel
@@ -30,6 +30,11 @@ The test has two parts:
    `CUDA_ERROR_MISALIGNED_ADDRESS`. Pre-fix on sm_120 this crashes; on
    sm_90 (Hopper) the kernel happens to land buffers correctly even
    pre-fix. Post-fix it passes on every TMA-capable arch.
+
+3. **Swizzled TMA generated TIR check**. Lowers a direct `T.tma_copy` into a
+   `make_swizzled_layout` shared tile whose base would otherwise start at
+   `buf_dyn_shmem + 128`, and asserts the absolute TMA destination offsets are
+   1024-byte aligned. A 128B TMA swizzle has a 1024-byte base phase.
 """
 
 import torch
@@ -127,16 +132,22 @@ def _is_op_call(node, op_name: str) -> bool:
     return isinstance(node, tvm.tirx.Call) and isinstance(node.op, tvm.ir.Op) and node.op.name == op_name
 
 
-def _collect_tma_loads(mod):
+def _collect_tma_loads_from_stmt(stmt):
     loads = []
 
     def _visit(node):
         if _is_op_call(node, "tl.tma_load"):
             loads.append(node)
 
+    tvm.tirx.stmt_functor.post_order_visit(stmt, _visit)
+    return loads
+
+
+def _collect_tma_loads(mod):
+    loads = []
     for _, func in mod.functions.items():
         if isinstance(func, tvm.tirx.PrimFunc):
-            tvm.tirx.stmt_functor.post_order_visit(func.body, _visit)
+            loads.extend(_collect_tma_loads_from_stmt(func.body))
     return loads
 
 
@@ -145,20 +156,53 @@ def _byte_offset(access_ptr):
     return access_ptr.args[2] * dtype.bytes * dtype.lanes
 
 
+def _collect_alias_byte_offsets(stmt):
+    analyzer = tvm.arith.Analyzer()
+    alias_offsets = {}
+
+    def _visit(node):
+        if not isinstance(node, tvm.tirx.Bind):
+            return
+        value = node.value
+        if not _is_op_call(value, "tirx.handle_add_byte_offset"):
+            return
+        base = value.args[0]
+        base_offset = alias_offsets.get(base, 0)
+        alias_offsets[node.var] = analyzer.simplify(base_offset + value.args[1])
+
+    tvm.tirx.stmt_functor.post_order_visit(stmt, _visit)
+    return alias_offsets
+
+
+def _absolute_tma_destination_byte_offsets(mod):
+    analyzer = tvm.arith.Analyzer()
+    offsets = []
+    for _, func in mod.functions.items():
+        if not isinstance(func, tvm.tirx.PrimFunc):
+            continue
+        alias_offsets = _collect_alias_byte_offsets(func.body)
+        for load in _collect_tma_loads_from_stmt(func.body):
+            assert len(load.args) >= 3, f"malformed tl.tma_load call: {load}"
+            access_ptr = load.args[2]
+            assert _is_op_call(access_ptr, "tirx.tvm_access_ptr"), (
+                f"expected tl.tma_load destination argument to be tirx.tvm_access_ptr, got: {access_ptr}"
+            )
+            buffer_var = access_ptr.args[1]
+            base_offset = alias_offsets.get(buffer_var, 0)
+            offsets.append(analyzer.simplify(base_offset + _byte_offset(access_ptr)))
+    return offsets
+
+
 def _assert_tma_destinations_128_aligned(arch: str, mod):
     loads = _collect_tma_loads(mod)
     assert loads, f"[{arch}] expected at least one tl.tma_load in generated TIR — the kernel layout should produce TMA loads"
 
     analyzer = tvm.arith.Analyzer()
-    for load in loads:
-        assert len(load.args) >= 3, f"[{arch}] malformed tl.tma_load call: {load}"
-        access_ptr = load.args[2]
-        assert _is_op_call(access_ptr, "tirx.tvm_access_ptr"), (
-            f"[{arch}] expected tl.tma_load destination argument to be tirx.tvm_access_ptr, got: {access_ptr}"
-        )
-        byte_offset = analyzer.simplify(_byte_offset(access_ptr))
+    byte_offsets = _absolute_tma_destination_byte_offsets(mod)
+    assert len(byte_offsets) == len(loads)
+    for byte_offset in byte_offsets:
         assert analyzer.can_prove(byte_offset % 128 == 0), (
-            f"[{arch}] TMA load destination byte offset is not provably 128-byte aligned: {byte_offset}. access_ptr={access_ptr}"
+            f"[{arch}] TMA load destination absolute byte offset is not provably 128-byte aligned: {byte_offset}"
         )
 
 
@@ -187,6 +231,75 @@ def test_tma_smem_alignment_codegen_sm120_blackwell_consumer():
     silicon."""
     mod = _lower_for("sm_120")
     _assert_tma_destinations_128_aligned("sm_120", mod)
+
+
+def _make_swizzled_tma_alignment_kernel(pad_elems: int):
+    MG = 768
+    M = 128
+    K = 256
+    THREADS = 1024
+    ELEMS_PER_THREAD = M * K // THREADS
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((MG, K), "bfloat16"),
+        out: T.Tensor((M, K), "bfloat16"),
+        dummy: T.Tensor((1,), "int32"),
+        offset: T.Tensor((1,), "int32"),
+    ):
+        with T.Kernel(1, threads=THREADS):
+            pad = T.alloc_shared((pad_elems,), "int32")
+            smem = T.alloc_shared((M, K), "bfloat16")
+            T.annotate_layout({smem: tilelang.layout.make_swizzled_layout(smem)})
+
+            tid = T.get_thread_binding(0)
+            if tid < pad_elems:
+                pad[tid] = tid
+            T.sync_threads()
+
+            phys = T.alloc_var("int32", init=0)
+            phys = offset[0]
+            bar = T.alloc_barrier(THREADS)
+            T.tma_copy(A[phys, 0], smem, barrier=bar)
+            T.barrier_arrive(bar)
+            T.mbarrier_wait_parity(bar, 0)
+            for i in T.serial(ELEMS_PER_THREAD):
+                elem = tid * ELEMS_PER_THREAD + i
+                row = elem // K
+                col = elem % K
+                out[row, col] = smem[row, col]
+
+            if tid == 0:
+                dummy[0] = pad[pad_elems - 1]
+
+    return kernel
+
+
+def _lower_swizzled_for(arch: str, pad_elems: int):
+    target = tvm.target.Target({"kind": "cuda", "arch": arch})
+    tilelang.disable_cache()
+    try:
+        with target:
+            artifact = tilelang_lower(
+                _make_swizzled_tma_alignment_kernel(pad_elems),
+                target=target,
+            )
+    finally:
+        tilelang.enable_cache()
+    return artifact.device_mod
+
+
+@tilelang.testing.requires_cuda
+def test_swizzled_tma_smem_alignment_codegen_sm120_blackwell_consumer():
+    mod = _lower_swizzled_for("sm_120", pad_elems=32)
+    byte_offsets = _absolute_tma_destination_byte_offsets(mod)
+    assert byte_offsets, "[sm_120] expected swizzled T.tma_copy to lower to tl.tma_load calls"
+
+    analyzer = tvm.arith.Analyzer()
+    for byte_offset in byte_offsets:
+        assert analyzer.can_prove(byte_offset % 1024 == 0), (
+            f"[sm_120] swizzled TMA load destination absolute byte offset is not provably 1024-byte aligned: {byte_offset}"
+        )
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Preserve the CUtensorMap swizzle enum on descriptor-backed TMA calls so shared-memory planning can distinguish unswizzled and swizzled TMA users.
- Raise Blackwell shared-memory alignment only for swizzled TMA phases while keeping ordinary bulk-copy TMA at the existing 128-byte default.
- Add a regression check for a swizzled TMA destination that would otherwise be placed at `buf_dyn_shmem + 128`.

## Changes

- Add a `tl.tma_swizzle` call annotation in `LowerHopperIntrin` before descriptor calls are replaced by descriptor variables.
- Teach `MergeSharedMemoryAllocations` to compute TMA alignment from call annotations and keep the maximum required alignment per shared buffer.
- Extend the sm120 alignment issue test to compute absolute shared offsets through alias-preserving binds and assert 1024-byte alignment for 128B swizzled TMA.

## Validation

- `pre-commit run --all-files`
- `cmake --build build -j$(nproc)`
- `PYTHONPATH=$(pwd):${PYTHONPATH:-} python -m pytest testing/python/issue/test_tilelang_issue_sm120_tma_smem_alignment.py -x -k "codegen"`
- `PYTHONPATH=$(pwd):${PYTHONPATH:-} python -m pytest testing/python/transform/test_tilelang_transform_lower_hopper_intrin.py -x`

## Notes

- The host runtime test in `testing/python/issue/test_tilelang_issue_sm120_tma_smem_alignment.py` was not run by the selected codegen-only pytest command.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added TMA swizzle annotation support for Hopper architecture operations, enabling proper descriptor-backed tensor memory access configuration.
  * Enhanced shared memory alignment handling with stricter alignment requirements for TMA, WGMMA, and descriptor-related operations.

* **Tests**
  * Strengthened TMA shared-memory alignment validation tests with comprehensive absolute offset alignment checks, including swizzled layout verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->