### PR TITLE
[Backend] Support TMA lowering for arbitrary (swizzled) SMEM layout

### DIFF
--- a/examples/gemm/example_gemm_intrinsics.py
+++ b/examples/gemm/example_gemm_intrinsics.py
@@ -17,8 +17,7 @@ def make_swizzle_layout(shared_buf):
         return T.Layout(shape, lambda *args: args)
 
     def transform_func(i, j):
-        new_warp_i, new_warp_j = get_swizzle_layout(i, j, shape[-1], dtype)
-        return [new_warp_i, new_warp_j]
+        return list(get_swizzle_layout(i, j, shape[-1], dtype))
 
     return T.Layout(shape, transform_func)
 

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -12,6 +12,7 @@
 #include "cuda/op/copy.h"
 #include "cuda/target_utils.h"
 #include "cuda/transform/ptx_async_copy_injector.h"
+#include "layout/cute_layout.h"
 #include "layout/tcgen05_layout.h"
 #include "op/builtin.h"
 #include "op/utils.h"
@@ -1375,6 +1376,126 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &T,
   return body;
 }
 
+namespace {
+
+Array<PrimExpr> makeRowMajorStrides(const Array<PrimExpr> &shape) {
+  Array<PrimExpr> strides(shape.size(), PrimExpr{1});
+  PrimExpr stride = 1;
+  for (int64_t i = static_cast<int64_t>(shape.size()) - 1; i >= 0; --i) {
+    strides.Set(i, stride);
+    stride *= shape[i];
+  }
+  return strides;
+}
+
+Array<PrimExpr> makeColumnMajorStrides(const Array<PrimExpr> &shape) {
+  Array<PrimExpr> strides;
+  PrimExpr stride = 1;
+  for (int64_t i = 0; i < shape.size(); i++) {
+    strides.push_back(stride);
+    stride *= shape[i];
+  }
+  return strides;
+}
+
+struct BulkCopyTile {
+  // Shape of the copied tile.
+  Array<int64_t> tile_shape;
+  // tile -> logical shared.
+  cute::Layout tile_to_shared_logical;
+  // tile -> logical global, using ScaledBasis for modes.
+  cute::Layout tile_to_global_mode;
+  // logical shared offset.
+  cute::IntTuple shared_logical_offset;
+  // logical global coords.
+  cute::IntTuple global_logical_coords;
+};
+
+// The shared tile and the global tile should be of the exact same size. And we
+// derive the mappings of the tile to the logical shared and global tensors.
+BulkCopyTile ComputeBulkCopyTile(const Array<PrimExpr> &shared_shape,
+                                 const Array<Range> &shared_range,
+                                 const Array<Range> &global_range) {
+  // The tile should have constant shape.
+  Array<int64_t> shared_range_extents =
+      shared_range.Map([](const Range &range) {
+        auto s = as_const_int(range->extent);
+        ICHECK(s) << "extent of shared_range: " << range << " is not constant";
+        return *s;
+      });
+  Array<int64_t> global_range_extents =
+      global_range.Map([](const Range &range) {
+        auto s = as_const_int(range->extent);
+        ICHECK(s) << "extent of global_range: " << range << " is not constant";
+        return *s;
+      });
+
+  // Find out the corresponding shared modes and global modes.
+  Array<int64_t> tile_shape;
+  Array<cute::IntTuple> tile_to_shared_mode_stride, tile_to_global_mode_stride;
+  int64_t shared_cur = 0, global_cur = 0;
+  while (shared_cur < shared_range_extents.size() &&
+         global_cur < global_range_extents.size()) {
+    int64_t s_extent = shared_range_extents[shared_cur];
+    int64_t g_extent = global_range_extents[global_cur];
+    if (s_extent <= 1) {
+      shared_cur++;
+      continue;
+    }
+    if (g_extent <= 1) {
+      global_cur++;
+      continue;
+    }
+    ICHECK_EQ(s_extent, g_extent)
+        << "Shared tile and global tile shape mismatch: tile_shape_shared["
+        << shared_cur << "] = " << s_extent << " != " << g_extent
+        << " = tile_shape_global[" << global_cur << "]";
+    tile_shape.push_back(s_extent);
+    tile_to_shared_mode_stride.push_back(cute::E({shared_cur}));
+    tile_to_global_mode_stride.push_back(cute::E({global_cur}));
+    shared_cur++;
+    global_cur++;
+  }
+  for (; shared_cur < shared_range_extents.size(); shared_cur++) {
+    ICHECK_EQ(shared_range_extents[shared_cur], 1)
+        << "Shared tile and global tile shape mismatch: "
+        << shared_range_extents << " vs " << global_range_extents;
+  }
+  for (; global_cur < global_range_extents.size(); global_cur++) {
+    ICHECK_EQ(global_range_extents[global_cur], 1)
+        << "Shared tile and global tile shape mismatch: "
+        << shared_range_extents << " vs " << global_range_extents;
+  }
+
+  // tile -> logical shared mode
+  auto tile_to_shared_mode =
+      cute::Layout(tile_shape, std::move(tile_to_shared_mode_stride));
+  // logical shared mode -> logical shared
+  auto shared_mode_to_shared_logical =
+      cute::MakeColumnMajorLayout(shared_shape);
+  // tile -> logical shared mode -> logical shared
+  auto tile_to_shared_logical =
+      cute::Composition(shared_mode_to_shared_logical, tile_to_shared_mode);
+
+  auto shared_coords =
+      shared_range.Map([](const Range &r) { return cute::IntTuple(r->min); });
+  auto shared_logical_offset =
+      shared_mode_to_shared_logical(cute::IntTupleTuple(shared_coords));
+
+  auto global_logical_coords =
+      global_range.Map([](const Range &r) { return cute::IntTuple(r->min); });
+
+  return {
+      tile_shape,
+      std::move(tile_to_shared_logical),
+      cute::Layout(tile_shape, std::move(tile_to_global_mode_stride)),
+      std::move(shared_logical_offset),
+      cute::IntTupleTuple(std::move(global_logical_coords)),
+  };
+}
+
+} // namespace
+
 Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
                      arith::Analyzer *analyzer, CopyInst copy_inst) {
   const Buffer &src = op.src;
@@ -1388,7 +1509,6 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
   bool is_load = copy_inst == CopyInst::kBulkLoad;
   Buffer global_tensor = is_load ? src : dst;
   Buffer shared_tensor = is_load ? dst : src;
-  Buffer shared_tensor_unmapped = shared_tensor;
   Array<Range> global_range = is_load ? src_range : dst_range;
   Array<Range> shared_range = is_load ? dst_range : src_range;
 
@@ -1407,47 +1527,23 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
     return fallback_to_normal("non-swizzled global layout");
   }
 
-  auto linear_layout = ComputeLinearLayout(shared_tensor);
-
-  Array<PrimExpr> shared_indices;
-  for (auto r : shared_range)
-    shared_indices.push_back(r->min);
-  std::vector<PrimExpr> shared_strides;
-  PrimExpr shared_stride = 1;
-  for (size_t i = 0; i < shared_tensor->shape.size(); i++) {
-    auto s = shared_tensor->shape[shared_tensor->shape.size() - i - 1];
-    shared_strides.insert(shared_strides.begin(), shared_stride);
-    shared_stride *= s;
+  Array<PrimExpr> global_shape = global_tensor->shape;
+  Array<PrimExpr> global_stride;
+  if (!global_tensor->strides.empty()) {
+    global_stride = global_tensor->strides;
+  } else {
+    global_stride = makeRowMajorStrides(global_shape);
   }
 
-  Array<PrimExpr> global_indices;
-  for (auto r : global_range) {
-    global_indices.push_back(r->min);
-  }
-  std::vector<PrimExpr> global_strides;
-  PrimExpr global_stride = 1;
-  for (size_t i = 0; i < global_tensor->shape.size(); i++) {
-    auto s = global_tensor->shape[global_tensor->shape.size() - i - 1];
-    global_strides.insert(global_strides.begin(), global_stride);
-    global_stride *= s;
-  }
-
-  ICHECK(shared_strides.size() == shared_indices.size())
-      << "shared_strides.size() != shared_indices.size()"
-      << shared_strides.size() << " " << shared_indices.size();
-  PrimExpr shared_offset = 0;
-  for (size_t i = 0; i < shared_indices.size(); i++) {
-    shared_offset += shared_indices[i] * shared_strides[i];
-  }
-  PrimExpr global_offset = 0;
-  for (size_t i = 0; i < global_indices.size(); i++) {
-    global_offset += global_indices[i] * global_strides[i];
-  }
+  // Check if tile shapes match, and compute the tile layouts.
+  // E.g., tile_shape = (64,512)
+  //       tile_to_shared_logical = (64,512):(1,64)
+  //       tile_to_global_mode = (64,512):(1@1,1@2)
+  auto [tile_shape, tile_to_shared_logical, tile_to_global_mode,
+        shared_logical_offset, global_logical_coords] =
+      ComputeBulkCopyTile(shared_tensor->shape, shared_range, global_range);
 
   TMADesc desc;
-  desc.rank = global_tensor->shape.size();
-  ICHECK(desc.rank >= 1 && desc.rank <= 5) << desc.rank;
-
   ICHECK(
       IsValidTMADtypePair(is_load, global_tensor->dtype, shared_tensor->dtype))
       << "Copy between buffer " << global_tensor->name << " and "
@@ -1457,65 +1553,12 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
   desc.data_type =
       TensorMapDataTypeForTMA(global_tensor->dtype, shared_tensor->dtype);
   desc.global_addr = global_tensor->data;
-  desc.global_shape = ReverseArray(global_tensor->shape);
-  Array<PrimExpr> global_coords =
-      ReverseArray(global_range.Map([](Range r) { return r->min; }));
-  if (!global_tensor->strides.empty()) {
-    desc.global_stride = ReverseArray(global_tensor->strides);
-  } else {
-    PrimExpr stride = 1;
-    desc.global_stride.reserve(desc.rank);
-    for (size_t i = 0; i < desc.rank; i++) {
-      desc.global_stride.push_back(stride);
-      stride *= desc.global_shape[i];
-    }
-  }
-  ICHECK(is_one(desc.global_stride[0])) << desc.global_stride;
-  desc.global_stride = desc.global_stride.Map([&](PrimExpr e) {
-    return TMAGlobalBytesFromElements(e, global_tensor->dtype);
-  });
-  for (size_t i{1}; i < desc.global_stride.size(); i++) {
-    auto stride = desc.global_stride[i].as<IntImmNode>();
-    if (stride != nullptr) {
-      if (stride->value % 16 != 0 || stride->value >= (1ULL << 40)) {
-        DLOG(WARNING) << "TMA bulk copy cannot support a global stride of "
-                      << desc.global_stride[i] << ", fallback to normal copy.";
-        return fallback_to_normal("unsupported global stride");
-      }
-    }
-  }
-
-  auto s_range_idx = 0;
-  for (size_t i = 0; i < global_range.size(); i++) {
-    auto g_range = global_range[i];
-    if (is_one(g_range->extent)) {
-      continue;
-    }
-    while (is_one(shared_range[s_range_idx]->extent) &&
-           s_range_idx < shared_range.size()) {
-      s_range_idx++;
-    }
-    if (s_range_idx >= shared_range.size()) {
-      LOG(FATAL) << "TMA bulk copy cannot support a global range of "
-                 << global_range << ", shared_range " << shared_range;
-    }
-    auto s_range = shared_range[s_range_idx];
-    s_range_idx++;
-
-    ICHECK(StructuralEqual()(g_range->extent, s_range->extent))
-        << global_tensor->name << "[" << i << "] is illegal, "
-        << global_tensor->name << "[" << i << "] = " << g_range->extent << ", "
-        << shared_tensor->name << "[" << s_range_idx
-        << "] = " << s_range->extent;
-  }
-  desc.smem_box =
-      ReverseArray(global_range.Map([](Range r) { return r->extent; }));
-
-  desc.smem_stride = Array<PrimExpr>(desc.rank, PrimExpr(1));
   desc.l2_promotion = static_cast<int>(CU_TENSOR_MAP_L2_PROMOTION_L2_128B);
   desc.oob_fill = static_cast<int>(CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
   desc.interleave = static_cast<int>(CU_TENSOR_MAP_INTERLEAVE_NONE);
 
+  Array<PrimExpr> shared_shape = shared_tensor->shape;
+  // logical shared -> physical shared, in TileLang convention
   Layout shared_layout;
   if (T.layout_map.count(shared_tensor)) {
     shared_layout = T.layout_map.at(shared_tensor);
@@ -1523,44 +1566,42 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
         << "shared_tensor: " << shared_tensor->name
         << " not found in buffer_remap";
     shared_tensor = T.buffer_remap.at(shared_tensor);
-  }
-  if (!shared_layout.defined()) {
-    desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_NONE);
-  } else if (StructuralEqual()(shared_layout, linear_layout)) {
-    desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_NONE);
   } else {
-    if (shared_layout->InputDim() < 2) {
-      DLOG(WARNING) << "TMA bulk copy cannot support shared layout with input "
-                    << "dimension " << shared_layout->InputDim()
-                    << ", fallback to normal copy.";
-      return fallback_to_normal("shared layout input dimension is less than 2");
-    }
-    const int ndim = static_cast<int>(shared_layout->InputDim());
-    auto stride = as_const_int(shared_layout->InputShape()[ndim - 2]);
-    auto continuous = as_const_int(shared_layout->InputShape()[ndim - 1]);
-    ICHECK(stride != nullptr && continuous != nullptr);
-    SwizzleMode swizzle_mode =
-        DetectSwizzleMode(shared_layout, shared_tensor_unmapped);
-    if (swizzle_mode == SwizzleMode::kQuarter) {
-      desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B);
-    } else if (swizzle_mode == SwizzleMode::kHalf) {
-      desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B);
-    } else if (swizzle_mode == SwizzleMode::kFull) {
-      desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_128B);
-    } else if (StructuralEqual()(
-                   shared_layout,
-                   makeGemmABLayoutPadded(*stride, *continuous,
-                                          shared_tensor->dtype.bits()))) {
-      DLOG(WARNING) << "Bulk copy cannot support a padded layout for src: "
-                    << src->name << ", dst: " << dst->name
-                    << ", fallback to normal copy";
-      return fallback_to_normal("padded shared layout");
-    } else {
-      DLOG(WARNING) << "Came across unsupported swizzle layout for src: "
-                    << src->name << ", dst: " << dst->name
-                    << ", fallback to normal copy";
-      return fallback_to_normal("unsupported shared swizzle layout");
-    }
+    shared_layout = makeLinearLayout(shared_shape);
+  }
+
+  // Convert the TileLang layout to a possibly swizzled CuTe ComposedLayout.
+  // This computes the swizzle from an arbitrary TileLang layout.
+  // E.g., composed = Sw<3,3,3> o 0 o (64,64,8):(64,1,4096)
+  auto composed = cute::ComposedLayoutFromTileLang(shared_layout);
+  if (!composed.defined()) {
+    DLOG(WARNING) << "Shared layout for src: " << src->name
+                  << ", dst: " << dst->name
+                  << " is not a CuTe swizzle over an affine layout, fallback "
+                     "to normal copy";
+    return fallback_to_normal("undecodable shared swizzle layout");
+  }
+  // Recast element-space layout into byte-address space.
+  // Because CuTe swizzle are based on byte addresses.
+  int elem_bits = shared_tensor->dtype.bits();
+  // E.g., composed_bytes = Sw<3,4,3> o 0 o (64,64,8):(128,2,8192)
+  auto composed_bytes = composed.value().Recast(elem_bits, /*new_bits=*/8);
+  const auto *sw = composed_bytes->swizzle.get();
+  int b_bits = sw->b_bits, m_base = sw->m_base, s_shift = sw->s_shift;
+  if (!sw->IsSwizzled()) {
+    desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_NONE);
+  } else if (b_bits == 1 && m_base == 4 && s_shift == 3) {
+    desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B);
+  } else if (b_bits == 2 && m_base == 4 && s_shift == 3) {
+    desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B);
+  } else if (b_bits == 3 && m_base == 4 && s_shift == 3) {
+    desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_128B);
+  } else {
+    DLOG(WARNING) << "Shared swizzle Sw<" << b_bits << "," << m_base << ","
+                  << s_shift << "> for src: " << src->name
+                  << ", dst: " << dst->name
+                  << " is not a TMA swizzle atom, fallback to normal copy";
+    return fallback_to_normal("non-TMA shared swizzle layout");
   }
 
   // The TMA unit applies the descriptor's swizzle pattern relative to the
@@ -1570,50 +1611,234 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
   // mode so MergeSharedMemoryAllocations can align the buffer accordingly.
   RequireTMASmemAlignment(T, shared_tensor, desc.swizzle);
 
-  auto inner_box_dim = as_const_int(desc.smem_box[0]);
-  if (inner_box_dim == nullptr) {
-    DLOG(WARNING) << "inner_box_dim " << desc.smem_box[0]
-                  << " can only be a constant integer for TMA bulk copy, "
-                     "fallback to normal copy";
-    return fallback_to_normal("non-constant inner box dimension");
-  }
-  int instruction_dim = *inner_box_dim;
-  DataType smem_elem_dtype = shared_tensor->dtype;
-  if (desc.swizzle == static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B)) {
-    instruction_dim = TMAElementsForBytes(64, smem_elem_dtype);
-  } else if (desc.swizzle == static_cast<int>(CU_TENSOR_MAP_SWIZZLE_128B)) {
-    instruction_dim = TMAElementsForBytes(128, smem_elem_dtype);
-  }
-  if (instruction_dim > 256) {
-    ICHECK((*inner_box_dim) % 256 == 0)
-        << "inner_box_dim: " << *inner_box_dim << " is not divisible by 256";
-    instruction_dim = 256;
-  }
-  ICHECK((*inner_box_dim) % instruction_dim == 0)
-      << "inner_box_dim: " << *inner_box_dim
-      << " is not divisible by instruction_dim: " << instruction_dim;
-  desc.smem_box.Set(0, PrimExpr(instruction_dim));
+  // logical shared -> physical shared (without swizzle)
+  // E.g., smem_plain = (64,64,8):(64,1,4096)
+  auto smem_plain = composed.value()->layout;
 
-  int inner_box_dim_ =
-      TMABytesFromElements(instruction_dim, shared_tensor->dtype);
+  // tile -> logical shared -> physical shared (without siwzzle)
+  // E.g., tile_to_smem_plain = (64,64,8):(64,1,4096)
+  auto tile_to_smem_plain =
+      cute::Composition(smem_plain, tile_to_shared_logical);
 
-  struct SwizzleCheck {
-    int swizzle;
-    int max_dim;
-  };
-  static const std::vector<SwizzleCheck> swizzle_checks = {
-      {static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B), 32},
-      {static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B), 64},
-      {static_cast<int>(CU_TENSOR_MAP_SWIZZLE_128B), 128},
-  };
-  for (const auto &check : swizzle_checks) {
-    if (desc.swizzle == check.swizzle && inner_box_dim_ > check.max_dim) {
-      DLOG(WARNING) << "TMA bulk copy cannot support a swizzled global layout "
-                       "with inner_box_dim_ > "
-                    << check.max_dim << ", will be fallback to normal copy";
-      return fallback_to_normal(
-          "swizzled shared box exceeds swizzle byte width");
+  // physical shared (without swizzle) -> tile
+  // E.g., smem_plain_to_tile = (64,64,8):(64,1,4096)
+  auto smem_plain_to_tile = cute::RightInverse(tile_to_smem_plain);
+  // right_inverse only inverts the bijective stride chain, so a gapped or
+  // non-injective SMEM layout would silently cover fewer elements than the
+  // tile.
+  int64_t inv_size = cute::AsConst(cute::Size(smem_plain_to_tile));
+  int64_t tile_size = cute::AsConst(cute::Size(tile_to_smem_plain));
+  ICHECK_EQ(inv_size, tile_size)
+      << "plain SMEM layout is not a bijection (gapped or non-injective): "
+      << "RightInverse covers " << inv_size << " of " << tile_size
+      << " elements; try to use annotate_layout to make your SMEM tile "
+         "contiguous";
+
+  // Each TMA box dim is at most 256.
+  const int64_t max_box_dim = 256;
+
+  // physical shared (without swizzle) -> tile -> logical global mode
+  // E.g, physical_shared_to_global_mode = (64,64,8):(1@2,1@1,64@2)
+  auto physical_shared_to_global_mode = cute::Coalesce(
+      cute::Composition(tile_to_global_mode, smem_plain_to_tile), max_box_dim);
+
+  // Truncate, because we do not want to start in the middle of a global mode.
+  // E.g., smem_rank = 2
+  int64_t smem_rank = 0;
+  while (smem_rank < cute::Rank(physical_shared_to_global_mode)) {
+    auto st =
+        cute::BasisValue(physical_shared_to_global_mode->stride[smem_rank]);
+    if (!cute::IsConst(st) || AsConst(st) != 1) {
+      break;
     }
+    smem_rank++;
+  }
+
+  if (smem_rank == 0) {
+    DLOG(WARNING) << "TMA bulk copy requires a contiguous innermost stride for "
+                     "SMEM, fallback to normal copy.";
+    return fallback_to_normal("non-contiguous SMEM innermost stride");
+  }
+
+  // physical shared (without swizzle) -> logical global mode (no > 1 stride)
+  // Ideally the shape of this is the exact box_dim. But we have
+  // several hardware constraints.
+  // E.g., tile_gbasis = (64, 64):(1@2, 1@1)
+  auto tile_gbasis = cute::Take(physical_shared_to_global_mode, smem_rank);
+
+  // logical global mode -> TMA mode
+  Array<cute::IntTuple> gmode_to_tma_mode_shape(global_shape.size(),
+                                                cute::IntTuple(int64_t(1)));
+  Array<cute::IntTuple> gmode_to_tma_mode_stride(global_shape.size(),
+                                                 cute::E({}));
+  // TMA mode -> logical global mode
+  std::vector<int64_t> tma_mode_to_gmode(global_shape.size());
+  // Some of the modes are not included in tile_gbasis and we need to track
+  // the modes, and later add the missed modes.
+  std::vector<bool> visited_global_modes(global_shape.size(), false);
+  // We have some hardware restrictions on tile_gbasis. But we can shrink it to
+  // meet some requirements if we need to. This is the modified tile_gbasis.
+  Array<cute::IntTuple> box_shape, box_stride;
+  for (int64_t i = 0; i < smem_rank; i++) {
+    int64_t cap = max_box_dim;
+    bool is_swizzle_inner = (i == 0 && sw->IsSwizzled());
+    if (is_swizzle_inner) {
+      int64_t span_bits = sw->Granularity() * 8;
+      cap = std::max<int64_t>(1, span_bits / elem_bits);
+    }
+    int64_t box_dim = cute::AsConst(tile_gbasis->shape[i]);
+    if (box_dim > cap) {
+      // This exceeds the hardware constraint. But we can make it work by
+      // spliting a mode.
+      // Only the slowest box mode has leftover the rest loop can absorb;
+      // shrinking a faster mode would gap the contiguous shared prefix.
+      int64_t inner = -1;
+      if (i == smem_rank - 1) {
+        for (int64_t d = cap; d > 1; --d) {
+          if (box_dim % d == 0) {
+            inner = d;
+            break;
+          }
+        }
+      }
+      if (inner != -1) {
+        box_dim = inner;
+      }
+    }
+    if (is_swizzle_inner) {
+      ICHECK_EQ(box_dim, cap)
+          << "The innermost box dim of a BulkCopy is not the swizzle "
+             "granularity: "
+          << "shared_layout = " << shared_layout << ", "
+          << "tile_to_smem_plain = " << tile_to_smem_plain << ", "
+          << "physical_shared_to_global_mode = "
+          << physical_shared_to_global_mode << ", "
+          << "tile_gbasis = " << tile_gbasis << ". "
+          << "Currently the automatically generated swizzling do not violate "
+             "this constraint. If you are annotating the layout, please make "
+             "sure the contiguous SMEM tile mode has size of your swizzle "
+             "granularity.";
+    } else {
+      if (box_dim > cap) {
+        DLOG(WARNING)
+            << "TMA box dim " << box_dim << " (mode " << i
+            << ") exceeds the cap " << cap
+            << " and cannot be cleanly split, fallback to normal copy";
+        return fallback_to_normal("box dim exceeds cap");
+      }
+    }
+    // The innermost box dim must be a whole 16-byte multiple: TMA transfers the
+    // innermost box as 16-byte vectors.
+    if (i == 0 &&
+        TMABytesFromElements(box_dim, shared_tensor->dtype) % 16 != 0) {
+      DLOG(WARNING) << "TMA innermost box dim " << box_dim << " (="
+                    << TMABytesFromElements(box_dim, shared_tensor->dtype)
+                    << " bytes) is not 16-byte aligned for src: " << src->name
+                    << ", dst: " << dst->name << ", fallback to normal copy";
+      return fallback_to_normal("inner box not 16-byte aligned");
+    }
+    box_shape.push_back(cute::IntTuple(box_dim));
+    box_stride.push_back(tile_gbasis->stride[i]);
+
+    // Collect the global mode information.
+    auto basis = cute::BasisPath(tile_gbasis->stride[i]);
+    ICHECK(basis.size() == 1);
+    auto mode = basis[0];
+    ICHECK(!visited_global_modes[mode]);
+    visited_global_modes[mode] = true;
+    gmode_to_tma_mode_stride.Set(mode, cute::E({i}));
+    tma_mode_to_gmode[i] = mode;
+  }
+
+  // Adopt the validated/shrunk box dims (a no-op when nothing was shrunk).
+  tile_gbasis = cute::Layout(cute::IntTupleTuple(std::move(box_shape)),
+                             cute::IntTupleTuple(std::move(box_stride)));
+
+  // The TMA rank with all the modes.
+  // E.g., tma_rank = 3
+  int64_t tma_rank = smem_rank;
+  // Basically tile_gbasis, but with all the global modes.
+  auto tma_gbasis_shape = cute::TupleFields(cute::Wrap(tile_gbasis->shape));
+  auto tma_gbasis_stride = cute::TupleFields(cute::Wrap(tile_gbasis->stride));
+  for (int64_t i = static_cast<int64_t>(global_shape.size()) - 1; i >= 0; i--) {
+    if (visited_global_modes[i])
+      continue;
+    gmode_to_tma_mode_stride.Set(i, cute::E({tma_rank}));
+    tma_mode_to_gmode[tma_rank] = i;
+    tma_gbasis_shape.push_back(1);
+    tma_gbasis_stride.push_back(cute::E({i}));
+    tma_rank++;
+  }
+
+  ICHECK_EQ(tma_rank, global_shape.size());
+  desc.rank = tma_rank;
+  ICHECK(desc.rank >= 1 && desc.rank <= 5) << desc.rank;
+
+  // logical global mode -> global mode in TMA's view
+  // E.g., (1,1,1):(1@2,1@1,1@0)
+  auto gmode_to_tma_mode = cute::Layout(std::move(gmode_to_tma_mode_shape),
+                                        std::move(gmode_to_tma_mode_stride));
+
+  // physical shared (without swizzle) -> logical global mode, all global modes
+  // E.g., tma_gbasis = (64,64.1):(1@2,1@1,1@0)
+  auto tma_gbasis =
+      cute::Layout(std::move(tma_gbasis_shape), std::move(tma_gbasis_stride));
+  ICHECK_EQ(cute::Rank(tma_gbasis), tma_rank);
+
+  // The size in the box.
+  // E.g., box_size = 4096
+  const int64_t box_size =
+      cute::AsConst(cute::Size(tile_gbasis)); // also tma_gbasis
+  // The size out of the box.
+  // E.g., rest_size = 8
+  const int64_t rest_size =
+      cute::AsConst(cute::Size(tile_to_shared_logical)) / box_size;
+
+  // Rest index -> physical shared
+  // E.g., 8:4096
+  auto rest_to_smem = cute::Coalesce(cute::Layout(rest_size, box_size));
+  // Rest index -> physical shared -> logical global mode
+  // E.g., 8:64@2
+  auto rest_to_gmode =
+      cute::Composition(physical_shared_to_global_mode, rest_to_smem);
+  // Rest index -> logical global mode -> global mode in TMA's view
+  // E.g., 8:64@0
+  auto rest_to_tma_mode =
+      cute::Coalesce(cute::Composition(gmode_to_tma_mode, rest_to_gmode));
+
+  desc.global_shape = Array<PrimExpr>();
+  desc.global_stride = Array<PrimExpr>();
+  desc.smem_box = Array<PrimExpr>();
+  desc.smem_stride = Array<PrimExpr>(tma_rank, PrimExpr(1));
+
+  for (int64_t i = 0; i < tma_rank; i++) {
+    desc.smem_box.push_back(
+        cute::AsConstOrPrimExpr(tma_gbasis->shape[i], DataType::Int(32)));
+
+    desc.global_shape.push_back(global_shape[tma_mode_to_gmode[i]]);
+
+    PrimExpr elem_stride = global_stride[tma_mode_to_gmode[i]];
+    if (i == 0 && !is_one(elem_stride)) {
+      DLOG(WARNING)
+          << "TMA innermost global stride " << elem_stride
+          << " != 1 element for src: " << src->name << ", dst: " << dst->name
+          << " (transposed/non-contiguous box), fallback to normal copy";
+      return fallback_to_normal("non-contiguous innermost TMA box");
+    }
+    PrimExpr byte_stride =
+        TMAGlobalBytesFromElements(elem_stride, global_tensor->dtype);
+    if (i >= 1) {
+      if (auto s = as_const_int(byte_stride)) {
+        if (*s % 16 != 0 || *s >= (1LL << 40)) {
+          DLOG(WARNING) << "TMA global stride " << byte_stride
+                        << " unsupported for src: " << src->name
+                        << ", dst: " << dst->name
+                        << ", fallback to normal copy";
+          return fallback_to_normal("unsupported global stride");
+        }
+      }
+    }
+    desc.global_stride.push_back(byte_stride);
   }
 
   Call create_descriptor =
@@ -1651,9 +1876,8 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
   auto tma_op = is_load ? tma_load() : tma_store();
 
   Stmt tma_copy;
-  PrimExpr total_elements = 1;
-  for (auto e : desc.smem_box)
-    total_elements *= e;
+
+  PrimExpr total_elements = IntImm(DataType::Int(32), box_size);
 
   auto build_multicast_args = [&](const Array<PrimExpr> &regular_args) {
     Array<PrimExpr> mc_args;
@@ -1668,16 +1892,44 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
     return mc_args;
   };
 
-  if ((*inner_box_dim) != instruction_dim) {
-    Var loop_var("i");
-    int loop_extent = (*inner_box_dim) / instruction_dim;
+  // physical shared offset
+  cute::IntTuple shared_offset = smem_plain(shared_logical_offset);
+  auto make_shared_offset = [&](std::optional<PrimExpr> rest_idx) {
+    cute::IntTuple off = shared_offset;
+    if (rest_idx.has_value())
+      off += rest_to_smem(*rest_idx);
+    return cute::AsConstOrPrimExpr(off, DataType::Int(32));
+  };
 
-    PrimExpr shared_addr = shared_tensor.access_ptr(
-        is_load ? 2 : 1, DataType::Handle(), 1,
-        shared_offset + total_elements * loop_var, total_elements);
+  // TMA coords
+  cute::IntTuple tma_coords;
+  {
+    Array<cute::IntTuple> modes;
+    modes.reserve(tma_rank);
+    for (int64_t i = 0; i < tma_rank; i++)
+      modes.push_back(global_logical_coords[tma_mode_to_gmode[i]]);
+    tma_coords = cute::IntTupleTuple(std::move(modes));
+  }
+  auto make_tma_coords = [&](std::optional<PrimExpr> rest_idx) {
+    cute::IntTuple coords = tma_coords;
+    if (rest_idx.has_value())
+      coords += rest_to_tma_mode(*rest_idx);
+    Array<PrimExpr> out;
+    out.reserve(tma_rank);
+    for (int64_t i = 0; i < tma_rank; i++)
+      out.push_back(cute::AsConstOrPrimExpr(coords[i], DataType::Int(32)));
+    return out;
+  };
+
+  if (rest_size > 1) {
+    Var loop_var("i", DataType::Int(32));
+    int loop_extent = rest_size;
+
+    PrimExpr shared_addr =
+        shared_tensor.access_ptr(is_load ? 2 : 1, DataType::Handle(), 1,
+                                 make_shared_offset(loop_var), total_elements);
     args.push_back(shared_addr);
-    global_coords.Set(0, global_coords[0] + instruction_dim * loop_var);
-    for (auto coord : global_coords)
+    for (auto coord : make_tma_coords(loop_var))
       args.push_back(coord);
     int need_reduce = 0;
     if (!is_load)
@@ -1710,9 +1962,10 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
     }
   } else {
     PrimExpr shared_addr = shared_tensor.access_ptr(
-        is_load ? 2 : 1, DataType::Handle(), 1, shared_offset, total_elements);
+        is_load ? 2 : 1, DataType::Handle(), 1,
+        make_shared_offset(std::nullopt), total_elements);
     args.push_back(shared_addr);
-    for (auto coord : global_coords)
+    for (auto coord : make_tma_coords(std::nullopt))
       args.push_back(coord);
     int need_reduce = 0;
     if (!is_load)
@@ -1759,8 +2012,8 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
 
   if (is_load && barrier_base_id >= 0) {
     PrimExpr total_bytes;
-    if ((*inner_box_dim) != instruction_dim) {
-      int loop_extent = (*inner_box_dim) / instruction_dim;
+    if (rest_size > 1) {
+      int loop_extent = rest_size;
       total_bytes = TMATransactionBytesFromElements(
           total_elements * loop_extent, shared_tensor->dtype);
     } else {

--- a/src/cuda/transform/producer_consumer_ws.cc
+++ b/src/cuda/transform/producer_consumer_ws.cc
@@ -34,6 +34,7 @@
 
 #include "backend/common/target_utils.h"
 #include "cuda/op/copy.h"
+#include "layout/cute_layout.h"
 #include "multi_version_buffer_rewriter.h"
 #include "op/builtin.h"
 #include "op/copy.h"
@@ -2620,15 +2621,14 @@ private:
 /// swizzle modes (32B / 64B / 128B).  Any other layout (e.g. padded,
 /// Volta-style) cannot be used with TMA.
 static bool IsTmaCompatibleLayout(const Layout &layout, const Buffer &buffer) {
-  // Recognised swizzle → TMA with swizzle.
-  if (DetectSwizzleMode(layout, buffer) != SwizzleMode::kNone) {
-    return true;
-  }
-  // Identity / row-major linear → TMA without swizzle.
-  if (StructuralEqual()(layout, makeLinearLayout(buffer->shape))) {
-    return true;
-  }
-  return false;
+  Optional<cute::ComposedLayout> composed =
+      cute::ComposedLayoutFromTileLang(layout);
+  if (!composed.defined())
+    return false;
+  // Recast to byte space (the swizzle atom is defined on byte addresses).
+  cute::ComposedLayout composed_bytes =
+      composed.value().Recast(buffer->dtype.bits(), /*new_bits=*/8);
+  return composed_bytes->swizzle->IsTMACompatible();
 }
 
 class TiledWSCandidate : public StmtExprVisitor {

--- a/src/layout/cute_layout.cc
+++ b/src/layout/cute_layout.cc
@@ -1,0 +1,1695 @@
+/*!
+ * \file cute_layout.cc
+ * \brief CuTe-style layout IR types and TileLang-to-CuTe layout recovery.
+ */
+
+#include "cute_layout.h"
+#include "layout.h"
+
+#include "support/check.h"
+#include <algorithm>
+#include <limits>
+#include <map>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <tvm/arith/analyzer.h>
+#include <tvm/ffi/extra/structural_equal.h>
+#include <tvm/ffi/extra/structural_hash.h>
+#include <tvm/runtime/logging.h>
+#include <tvm/tirx/op.h>
+#include <tvm/tirx/stmt_functor.h>
+
+namespace tvm {
+namespace tl {
+namespace cute {
+
+using namespace tirx;
+
+namespace {
+
+// Return log2(v) if v is a positive power of two (log2(1) == 0), else -1.
+int Log2Exact(int64_t v) {
+  if (v <= 0 || (v & (v - 1)) != 0)
+    return -1;
+  return __builtin_ctzll(static_cast<uint64_t>(v));
+}
+
+} // namespace
+
+int64_t SwizzleNode::Apply(int64_t offset) const {
+  if (b_bits <= 0)
+    return offset;
+  uint64_t mask = (static_cast<uint64_t>(1) << b_bits) - 1;
+  uint64_t yyy = mask << (m_base + s_shift);
+  uint64_t x = static_cast<uint64_t>(offset);
+  return static_cast<int64_t>(x ^ ((x & yyy) >> s_shift));
+}
+
+Swizzle::Swizzle(int b_bits, int m_base, int s_shift) {
+  auto node = make_object<SwizzleNode>();
+  node->b_bits = b_bits;
+  node->m_base = m_base;
+  node->s_shift = s_shift;
+  data_ = std::move(node);
+}
+
+Swizzle Swizzle::Recast(int old_bits, int new_bits) const {
+  const SwizzleNode *n = get();
+  ICHECK(n != nullptr) << "Recast on a null Swizzle";
+  if (!n->IsSwizzled())
+    return Swizzle::Identity();
+  // Reinterpreting the element size scales every address by old_bits/new_bits,
+  // so bit positions shift by log2(old_bits) - log2(new_bits). Element sizes
+  // must be powers of two for this to be a clean bit shift.
+  int old_log = Log2Exact(old_bits);
+  int new_log = Log2Exact(new_bits);
+  ICHECK(old_log >= 0 && new_log >= 0)
+      << "Recast expects power-of-two element sizes, got " << old_bits << " -> "
+      << new_bits;
+  int m_base = n->m_base + (old_log - new_log);
+  ICHECK(m_base >= 0) << "Recast produced negative m_base: " << m_base;
+  return Swizzle(n->b_bits, m_base, n->s_shift);
+}
+
+IntTuple::IntTuple(int64_t value) {
+  auto node = make_object<IntTupleConstNode>();
+  node->value = value;
+  data_ = std::move(node);
+}
+
+IntTuple::IntTuple(PrimExpr value) {
+  if (const auto *imm = value.as<IntImmNode>()) {
+    auto node = make_object<IntTupleConstNode>();
+    node->value = imm->value;
+    data_ = std::move(node);
+  } else {
+    auto node = make_object<IntTuplePrimExprNode>();
+    node->value = std::move(value);
+    data_ = std::move(node);
+  }
+}
+
+IntTuple IntTuple::operator[](int64_t index) const {
+  if (const auto *a = this->as<IntTupleTupleNode>()) {
+    int64_t n = a->fields.size();
+    ICHECK(index >= 0 && index < n)
+        << "IntTuple index " << index << " out of range " << n;
+    return a->fields[index];
+  }
+  // A scalar leaf has rank 1 and [0] returns itself.
+  ICHECK(index == 0) << "Leaf index out of range: " << index << " vs 0";
+  return *this;
+}
+
+namespace {
+
+// A leaf that is the constant 0 -- the additive identity (CuTe's C<0>).
+bool IsZeroLeaf(const IntTuple &t) { return IsConst(t) && AsConst(t) == 0; }
+
+// Sum two scalar leaves. As with MulLeaf, TVM's operator+ folds constants, so
+// the result is an IntImm exactly when both operands are constant. A
+// ScaledBasis leaf is not summable here -- the basis identity is preserved by
+// operator+'s recursion, not by adding raw basis values.
+IntTuple AddLeaf(const IntTuple &a, const IntTuple &b) {
+  ICHECK(!IsScaledBasis(a) && !IsScaledBasis(b))
+      << "Cannot add ScaledBasis leaves";
+  ICHECK(!IsTuple(a) && !IsTuple(b)) << "Can only add leaves";
+  if (IsConst(a) && IsConst(b))
+    return IntTuple(AsConst(a) + AsConst(b));
+  std::optional<DataType> dtype;
+  if (IsPrimExpr(a))
+    dtype = AsPrimExpr(a)->dtype;
+  if (IsPrimExpr(b)) {
+    auto dt = AsPrimExpr(b)->dtype;
+    if (dtype.has_value()) {
+      ICHECK_EQ(*dtype, dt) << "dtype mismatch: " << *dtype << " vs " << dt
+                            << " between operands " << a << " and " << b;
+    } else {
+      dtype = dt;
+    }
+  }
+  ICHECK(dtype.has_value()) << "At least one leaf must be a PrimExpr";
+  return IntTuple(AsConstOrPrimExpr(a, *dtype) + AsConstOrPrimExpr(b, *dtype));
+}
+
+// Multiply two plain (non-basis) scalar leaves. TVM's operator* already folds
+// constants and applies the 0/1 identities (arith::TryConstFold<Mul>), so the
+// product is an IntImm exactly when constant -> pick the leaf kind from that.
+IntTuple MulLeaf(const IntTuple &a, const IntTuple &b) {
+  ICHECK(!IsScaledBasis(a) && !IsScaledBasis(b));
+  ICHECK(!IsTuple(a) && !IsTuple(b)) << "Can only multiply leaves";
+  if (IsConst(a) && IsConst(b)) {
+    return IntTuple(AsConst(a) * AsConst(b));
+  }
+  std::optional<DataType> dtype;
+  if (IsPrimExpr(a)) {
+    dtype = AsPrimExpr(a)->dtype;
+  }
+  if (IsPrimExpr(b)) {
+    auto dt = AsPrimExpr(b)->dtype;
+    if (dtype.has_value()) {
+      ICHECK_EQ(*dtype, dt) << "dtype mismatch: " << *dtype << " vs " << dt
+                            << " between operands " << a << " and " << b;
+    } else {
+      dtype = dt;
+    }
+  }
+  ICHECK(dtype.has_value()) << "At least one leaf must be a PrimExpr";
+  PrimExpr p = AsConstOrPrimExpr(a, *dtype) * AsConstOrPrimExpr(b, *dtype);
+  return IntTuple(p);
+}
+
+// Floored divide / modulo of two scalar leaves (const folds to a const leaf,
+// else a PrimExpr leaf). Coordinates are non-negative, so floor matches the
+// FloorDiv/FloorMod the dynamic path uses.
+IntTuple DivLeaf(const IntTuple &a, const IntTuple &b) {
+  ICHECK(!IsTuple(a) && !IsScaledBasis(a)) << "DivLeaf on a non-scalar leaf";
+  if (IsConst(a) && IsConst(b)) {
+    int64_t x = AsConst(a), y = AsConst(b);
+    ICHECK(y != 0) << "division by zero";
+    int64_t q = x / y, r = x % y; // round toward -inf (floor)
+    return IntTuple(q - ((r != 0) && ((r < 0) != (y < 0)) ? 1 : 0));
+  }
+  DataType dt = IsPrimExpr(a) ? AsPrimExpr(a)->dtype : AsPrimExpr(b)->dtype;
+  return IntTuple(FloorDiv(AsConstOrPrimExpr(a, dt), AsConstOrPrimExpr(b, dt)));
+}
+
+IntTuple ModLeaf(const IntTuple &a, const IntTuple &b) {
+  ICHECK(!IsTuple(a) && !IsScaledBasis(a)) << "ModLeaf on a non-scalar leaf";
+  if (IsConst(a) && IsConst(b)) {
+    int64_t x = AsConst(a), y = AsConst(b);
+    ICHECK(y != 0) << "modulo by zero";
+    int64_t r = x % y;
+    return IntTuple((r != 0 && (r < 0) != (y < 0)) ? r + y : r); // floored
+  }
+  DataType dt = IsPrimExpr(a) ? AsPrimExpr(a)->dtype : AsPrimExpr(b)->dtype;
+  return IntTuple(FloorMod(AsConstOrPrimExpr(a, dt), AsConstOrPrimExpr(b, dt)));
+}
+
+// Compact column-major stride congruent to `shape` (CuTe compact_col_major):
+// thread a running product `acc` through the leaves depth-first, mode 0
+// fastest, keeping the nested structure -- each leaf takes the current `acc`
+// and advances it by the leaf's extent. e.g. (2,(2,2)) -> (1,(2,4)). Dynamic
+// extents thread through as PrimExpr products.
+IntTuple CompactColMajor(const IntTuple &shape, IntTuple &acc) {
+  if (IsTuple(shape)) {
+    Array<IntTuple> out;
+    for (int64_t i = 0, n = Rank(shape); i < n; ++i)
+      out.push_back(CompactColMajor(shape[i], acc));
+    return IntTupleTuple(out);
+  }
+  IntTuple stride = acc;
+  acc = MulLeaf(acc, shape);
+  return stride;
+}
+
+IntTuple CompactColMajor(const IntTuple &shape) {
+  IntTuple acc = IntTuple(int64_t(1));
+  return CompactColMajor(shape, acc);
+}
+
+// Compact row-major stride congruent to `shape` (CuTe compact_row_major): like
+// CompactColMajor but the running product threads through the leaves in reverse
+// (last mode fastest). e.g. (2,(2,2)) -> (4,(2,1)).
+IntTuple CompactRowMajor(const IntTuple &shape, IntTuple &acc) {
+  if (IsTuple(shape)) {
+    int64_t n = Rank(shape);
+    Array<IntTuple> out(n, IntTuple());
+    for (int64_t i = n - 1; i >= 0; --i)
+      out.Set(i, CompactRowMajor(shape[i], acc));
+    return IntTupleTuple(out);
+  }
+  IntTuple stride = acc;
+  acc = MulLeaf(acc, shape);
+  return stride;
+}
+
+IntTuple CompactRowMajor(const IntTuple &shape) {
+  IntTuple acc = IntTuple(int64_t(1));
+  return CompactRowMajor(shape, acc);
+}
+
+// Identity layout over `shape` (CuTe make_identity_layout): each leaf at tree
+// path (p0,p1,...) carries the unit basis E<p0,p1,...>, so the layout maps a
+// coordinate to itself tagged by its full nested axis path.
+IntTuple IdentityStride(const IntTuple &shape, std::vector<int64_t> &path) {
+  if (IsTuple(shape)) {
+    Array<IntTuple> out;
+    for (int64_t i = 0, n = Rank(shape); i < n; ++i) {
+      path.push_back(i);
+      out.push_back(IdentityStride(shape[i], path));
+      path.pop_back();
+    }
+    return IntTupleTuple(out);
+  }
+  return IntTupleScaledBasis(IntTuple(int64_t(1)),
+                             Array<int64_t>(path.begin(), path.end()));
+}
+
+// Expand a ScaledBasis leaf v@(n0,n1,...) into its ArithmeticTuple form (CuTe
+// as_arithmetic_tuple): v sits at nested position (n0,n1,...) with 0 in every
+// other slot, e.g. 1@0 -> (1), 1@1 -> (0,1), 2@(1,0) -> (0,(2)). This is what
+// lets two ScaledBasis terms on different axes add into one coordinate tuple.
+IntTuple AsArithmeticTuple(const IntTuple &sb) {
+  IntTuple result = BasisValue(sb);
+  Array<int64_t> path = BasisPath(sb);
+  for (int64_t i = static_cast<int64_t>(path.size()) - 1; i >= 0; --i) {
+    Array<IntTuple> fields;
+    for (int64_t j = 0; j < path[i]; ++j)
+      fields.push_back(IntTuple(int64_t(0)));
+    fields.push_back(result);
+    result = IntTupleTuple(fields);
+  }
+  return result;
+}
+
+} // namespace
+
+IntTuple operator+(const IntTuple &a, const IntTuple &b) {
+  // CuTe ArithmeticTuple addition. A zero leaf is the additive identity, so it
+  // adds to anything (including a tuple of a different rank).
+  if (IsZeroLeaf(a))
+    return b;
+  if (IsZeroLeaf(b))
+    return a;
+  if (IsTuple(a) || IsTuple(b)) {
+    // A ScaledBasis on either side expands to its ArithmeticTuple form so it
+    // can add to the tuple (CuTe as_arithmetic_tuple); a plain non-zero leaf
+    // has no slot and is ill-formed.
+    if (IsScaledBasis(a))
+      return AsArithmeticTuple(a) + b;
+    if (IsScaledBasis(b))
+      return a + AsArithmeticTuple(b);
+    ICHECK(IsTuple(a) && IsTuple(b))
+        << "Cannot add a non-zero leaf to a tuple: " << a << " + " << b;
+    // Zero-pad the shorter to the longer's rank, then add component-wise.
+    int64_t ra = Rank(a), rb = Rank(b), r = std::max(ra, rb);
+    Array<IntTuple> out;
+    out.reserve(r);
+    for (int64_t i = 0; i < r; i++) {
+      IntTuple ai = i < ra ? a[i] : IntTuple(int64_t(0));
+      IntTuple bi = i < rb ? b[i] : IntTuple(int64_t(0));
+      out.push_back(ai + bi);
+    }
+    return IntTupleTuple(std::move(out));
+  }
+  // ScaledBasis leaves expand to their ArithmeticTuple form and add as tuples
+  // (CuTe as_arithmetic_tuple): both same-axis and distinct-axis sums become
+  // coordinate tuples -- e.g. 1@0 + 2@0 -> (1)+(2) -> (3), and 1@0 + 1@1 ->
+  // (1)+(0,1) -> (1,1).
+  bool ba = IsScaledBasis(a), bb = IsScaledBasis(b);
+  if (ba && bb)
+    return AsArithmeticTuple(a) + AsArithmeticTuple(b);
+  // A lone ScaledBasis added to a plain leaf: only the zero identity (handled
+  // above) is well-formed; a non-zero plain leaf has no axis to land on.
+  ICHECK(!ba && !bb) << "Cannot add a ScaledBasis and a non-basis leaf: " << a
+                     << " + " << b;
+  return AddLeaf(a, b);
+}
+
+IntTuple operator*(const IntTuple &a, const IntTuple &b) {
+  if (IsTuple(a) || IsTuple(b)) {
+    int64_t ra = Rank(a), rb = Rank(b);
+    ICHECK_EQ(ra, rb) << "Must have the same rank";
+    Array<IntTuple> out;
+    for (int64_t i = 0; i < ra; i++) {
+      out.push_back(a[i] * b[i]);
+    }
+    return IntTupleTuple(std::move(out));
+  }
+  bool ba = IsScaledBasis(a), bb = IsScaledBasis(b);
+  ICHECK(!(ba && bb)) << "Two ScaledBasis leaves cannot multiply";
+  if (ba)
+    return IntTupleScaledBasis(MulLeaf(BasisValue(a), b), BasisPath(a));
+  if (bb)
+    return IntTupleScaledBasis(MulLeaf(a, BasisValue(b)), BasisPath(b));
+  return MulLeaf(a, b);
+}
+
+IntTupleScaledBasis::IntTupleScaledBasis(IntTuple value, Array<int64_t> basis) {
+  ICHECK(!IsTuple(value)) << "ScaledBasis value must be a scalar leaf "
+                             "(const/primexpr), not a tuple";
+  auto node = make_object<IntTupleScaledBasisNode>();
+  node->value = std::move(value);
+  node->basis = std::move(basis);
+  data_ = std::move(node);
+}
+
+IntTupleTuple::IntTupleTuple(Array<IntTuple> fields) {
+  auto node = make_object<IntTupleTupleNode>();
+  node->fields = std::move(fields);
+  data_ = std::move(node);
+}
+
+IntTuple BasisGet(const Array<int64_t> &path, const IntTuple &t) {
+  IntTuple result = t;
+  for (auto i : path) {
+    result = result[i];
+  }
+  return result;
+}
+
+int64_t Rank(const IntTuple &t) {
+  const auto *a = t.as<IntTupleTupleNode>();
+  return a ? static_cast<int64_t>(a->fields.size()) : 1;
+}
+
+IntTuple Product(const IntTuple &t) {
+  if (!IsTuple(t))
+    return t;
+  IntTuple acc = IntTuple(1);
+  for (int64_t i = 0, n = Rank(t); i < n; ++i)
+    acc = MulLeaf(acc, Product(t[i]));
+  return acc;
+}
+
+IntTuple Flatten(const IntTuple &t) {
+  if (!IsTuple(t))
+    return t;
+  Array<IntTuple> out;
+  FoldLeaves(t, 0, [&](int, const IntTuple &s) {
+    out.push_back(s);
+    return 0;
+  });
+  return IntTupleTuple(out);
+}
+
+IntTupleTuple Wrap(const IntTuple &t) {
+  return IsTuple(t) ? AsTuple(t) : IntTupleTuple({t});
+}
+
+bool Congruent(const IntTuple &a, const IntTuple &b) {
+  if (IsTuple(a) != IsTuple(b))
+    return false;
+  if (!IsTuple(a))
+    return true;
+  int64_t n = Rank(a);
+  if (Rank(b) != n)
+    return false;
+  for (int64_t i = 0; i < n; ++i)
+    if (!Congruent(a[i], b[i]))
+      return false;
+  return true;
+}
+
+Layout::Layout(Array<int64_t> shape, Array<int64_t> stride) {
+  ICHECK_EQ(shape.size(), stride.size());
+  Array<IntTuple> shape_fields, stride_fields;
+  for (size_t k = 0; k < shape.size(); ++k) {
+    shape_fields.push_back(IntTuple(shape[k]));
+    stride_fields.push_back(IntTuple(stride[k]));
+  }
+  auto node = make_object<LayoutNode>();
+  node->shape = IntTupleTuple(shape_fields);
+  node->stride = IntTupleTuple(stride_fields);
+  data_ = std::move(node);
+}
+
+Layout::Layout(Array<int64_t> shape, Array<IntTuple> stride) {
+  ICHECK_EQ(shape.size(), stride.size());
+  Array<IntTuple> shape_fields;
+  for (size_t k = 0; k < shape.size(); ++k) {
+    shape_fields.push_back(IntTuple(shape[k]));
+    ICHECK(!IsTuple(stride[k]));
+  }
+  auto node = make_object<LayoutNode>();
+  node->shape = IntTupleTuple(shape_fields);
+  node->stride = IntTupleTuple(stride);
+  data_ = std::move(node);
+}
+
+Layout::Layout(Array<IntTuple> shape, Array<IntTuple> stride) {
+  ICHECK(Congruent(IntTupleTuple(shape), IntTupleTuple(stride)))
+      << "Layout shape and stride must be congruent: " << IntTupleTuple(shape)
+      << " vs " << IntTupleTuple(stride);
+  auto node = make_object<LayoutNode>();
+  node->shape = IntTupleTuple(shape);
+  node->stride = IntTupleTuple(stride);
+  data_ = std::move(node);
+}
+
+Layout::Layout(IntTuple shape, IntTuple stride) {
+  ICHECK(Congruent(shape, stride))
+      << "Layout shape and stride must be congruent: " << shape << " vs "
+      << stride;
+  auto node = make_object<LayoutNode>();
+  node->shape = std::move(shape);
+  node->stride = std::move(stride);
+  data_ = std::move(node);
+}
+
+Layout Layout::operator[](int64_t index) const {
+  return Layout((*this)->shape[index], (*this)->stride[index]);
+}
+
+namespace {
+
+// CuTe crd2idx(coord, shape, stride): map a coordinate within <shape, stride>
+// to its codomain value. The result is a scalar leaf for plain strides and a
+// coordinate IntTuple when a stride is a ScaledBasis (operator+ accumulates the
+// per-axis contributions). Neither shape nor stride need be constant -- every
+// step goes through the dynamic-aware leaf helpers.
+//
+// Three cases (mirroring CuTe stride.hpp):
+//   op((c,C),(s,S),(d,D)) = op(c,s,d) + op((C),(S),(D))   [tuple coord]
+//   op(c,(s,S),(d,D))     = op(c%prod(s),s,d) + op(c/prod(s),(S),(D))  [itt]
+//   op(c,s,d)             = c * d                          [scalar]
+IntTuple Crd2Idx(const IntTuple &coord, const IntTuple &shape,
+                 const IntTuple &stride) {
+  if (IsTuple(coord)) {
+    // Coord, shape, stride are all tuples: per-mode, summed (crd2idx_ttt).
+    ICHECK(IsTuple(shape) && IsTuple(stride)) << "crd2idx rank mismatch";
+    int64_t r = Rank(coord);
+    ICHECK(Rank(shape) == r && Rank(stride) == r) << "crd2idx rank mismatch";
+    IntTuple acc = IntTuple(int64_t(0));
+    for (int64_t i = 0; i < r; ++i)
+      acc = acc + Crd2Idx(coord[i], shape[i], stride[i]);
+    return acc;
+  }
+  if (IsTuple(shape)) {
+    // Scalar coord, tuple shape/stride: split the coord across the modes by
+    // divmod, skipping the mod on the LAST mode so the layout extends linearly
+    // past its domain there (crd2idx_itt). For in-domain coords this matches a
+    // full mod, since the final remainder is already smaller than its extent.
+    ICHECK(IsTuple(stride)) << "crd2idx rank mismatch";
+    int64_t r = Rank(shape);
+    ICHECK(Rank(stride) == r) << "crd2idx rank mismatch";
+    IntTuple acc = IntTuple(int64_t(0));
+    IntTuple rem = coord;
+    for (int64_t i = 0; i < r; ++i) {
+      IntTuple prod = Product(shape[i]);
+      IntTuple crd = i + 1 < r ? ModLeaf(rem, prod) : rem;
+      acc = acc + Crd2Idx(crd, shape[i], stride[i]);
+      if (i + 1 < r)
+        rem = DivLeaf(rem, prod);
+    }
+    return acc;
+  }
+  // Scalar coord, scalar shape, scalar stride: c * d (operator* keeps a
+  // ScaledBasis stride's basis, yielding a coordinate term).
+  return coord * stride;
+}
+
+} // namespace
+
+IntTuple Layout::operator()(const IntTuple &coord) const {
+  return Crd2Idx(coord, (*this)->shape, (*this)->stride);
+}
+
+int64_t Rank(const Layout &layout) { return Rank(layout->shape); }
+
+Layout Flatten(const Layout &layout) {
+  return Layout(Flatten(layout->shape), Flatten(layout->stride));
+}
+
+IntTuple Size(const Layout &layout) { return Product(layout->shape); }
+
+namespace {
+
+// Core of coalesce (CuTe bw_coalesce): merge adjacent modes that describe the
+// same affine run. `fsh`/`fst` are the flat (leaf) modes fastest-first; the
+// scan runs from the slowest mode down to mode 0, accumulating into a running
+// "front" mode (front_sh, front_st) that the caller seeds with the slowest
+// mode. For each next-faster mode we either:
+//   - drop it if it has extent 1 (contributes nothing);
+//   - adopt it if the front is currently extent 1 (placeholder);
+//   - fuse it into the front when the front continues it contiguously, i.e.
+//     mode.shape * mode.stride == front.stride, and the fused extent stays
+//     within max_extent (the TMA box derivation caps this at 256); or
+//   - otherwise emit the front and start a new one.
+// A layout that collapses entirely (all extent-1) becomes the scalar (1):(0).
+Layout BwCoalesce(const IntTuple &fsh, const IntTuple &fst, IntTuple front_sh,
+                  IntTuple front_st, int64_t max_extent) {
+  std::vector<IntTuple> res_sh, res_st;
+  auto prepend = [&](IntTuple s, IntTuple d) {
+    res_sh.insert(res_sh.begin(), s);
+    res_st.insert(res_st.begin(), d);
+  };
+  for (int64_t i = Rank(fsh) - 2; i >= 0; --i) {
+    IntTuple os = fsh[i], od = fst[i];
+    if (IsConst(os) && AsConst(os) == 1)
+      continue; // extent-1 mode: contributes nothing.
+    if (IsConst(front_sh) && AsConst(front_sh) == 1) {
+      front_sh = os; // front is a placeholder: adopt this mode.
+      front_st = od;
+      continue;
+    }
+    // Contiguity test: this mode and the front fuse iff stepping past this mode
+    // (shape*stride) lands exactly on the front's stride.
+    bool mergeable = IsConst(os) && IsConst(front_sh) &&
+                     StructuralEqual()(os * od, front_st) &&
+                     AsConst(os) * AsConst(front_sh) <= max_extent;
+    if (mergeable) {
+      front_sh = IntTuple(AsConst(os) * AsConst(front_sh));
+      front_st = od;
+    } else {
+      prepend(front_sh, front_st);
+      front_sh = os;
+      front_st = od;
+    }
+  }
+  prepend(front_sh, front_st);
+  if (res_sh.size() == 1 && IsConst(res_sh[0]) && AsConst(res_sh[0]) == 1)
+    return Layout(Array<int64_t>{1}, Array<int64_t>{0});
+  return Layout(Array<IntTuple>(res_sh.begin(), res_sh.end()),
+                Array<IntTuple>(res_st.begin(), res_st.end()));
+}
+
+// Simplify a layout by fusing contiguous modes (CuTe coalesce). Result is flat
+// (depth <= 1) and equal to the input as a function on [0, size). `max_extent`
+// caps each fused run (the TMA box derivation passes 256 to keep box modes
+// within the descriptor's per-mode boxDim limit).
+Layout CoalesceImpl(const Layout &layout, int64_t max_extent) {
+  IntTuple fsh = Flatten(layout->shape), fst = Flatten(layout->stride);
+  int64_t R = Rank(fsh);
+  return BwCoalesce(fsh, fst, fsh[R - 1], fst[R - 1], max_extent);
+}
+
+} // namespace
+
+Layout Coalesce(const Layout &layout) {
+  ICHECK(layout.defined()) << "Coalesce on a null Layout";
+  constexpr int64_t kInf = std::numeric_limits<int64_t>::max();
+  return CoalesceImpl(layout, kInf);
+}
+
+Layout RightInverse(const Layout &layout) {
+  ICHECK(layout.defined()) << "RightInverse on a null Layout";
+  // Build the layout `r` with layout(r(i)) == i for i < size(r) (CuTe
+  // right_inverse). After coalescing, sort the modes by stride and walk them
+  // looking for the chain 1, s0, s0*s1, ... where each mode's stride equals the
+  // running product of previous extents. Such a chain is exactly the part of
+  // the layout that is a bijection onto a contiguous prefix; the inverse sends
+  // each chained mode back to its position (the input-side prefix product).
+  // Modes that break the chain -- including any with non-constant strides,
+  // which have no comparable order -- are dropped, so the result inverts only
+  // the bijective prefix. Requires a concrete stride order, hence const strides
+  // only.
+  Layout c = Coalesce(layout); // flat; no Flatten needed below.
+  IntTuple m_sh = c->shape, m_st = c->stride;
+  int64_t r = Rank(m_sh);
+
+  // preprod[k] = product of extents before mode k (its coordinate's weight).
+  std::vector<int64_t> sh(r), preprod(r);
+  int64_t acc = 1;
+  for (int64_t k = 0; k < r; ++k) {
+    sh[k] = AsConst(m_sh[k]);
+    preprod[k] = acc;
+    acc *= sh[k];
+  }
+
+  std::vector<int64_t> order;
+  for (int64_t k = 0; k < r; ++k)
+    if (IsConst(m_st[k]))
+      order.push_back(k);
+  std::stable_sort(order.begin(), order.end(), [&](int64_t a, int64_t b) {
+    return AsConst(m_st[a]) < AsConst(m_st[b]);
+  });
+
+  Array<IntTuple> out_sh, out_st;
+  int64_t current = 1; // next stride the chain must hit to stay contiguous.
+  for (int64_t k : order) {
+    int64_t st = AsConst(m_st[k]);
+    ICHECK(st >= 0) << "RightInverse requires non-negative strides, got " << st;
+    if (st == current) {
+      out_sh.push_back(IntTuple(sh[k]));
+      out_st.push_back(IntTuple(preprod[k]));
+      current = sh[k] * st;
+    }
+  }
+  // Empty chain (nothing invertible) is the scalar (1):(0).
+  if (out_sh.empty())
+    return Coalesce(Layout(Array<int64_t>{1}, Array<int64_t>{0}));
+  return Coalesce(Layout(out_sh, out_st));
+}
+
+namespace {
+
+int64_t Abs(int64_t v) { return v < 0 ? -v : v; }
+int64_t Signum(int64_t v) { return (v > 0) - (v < 0); }
+int64_t CeilDiv(int64_t a, int64_t b) { return (a + b - 1) / b; }
+
+// Like Coalesce, but additionally keeps the layout's behavior correct for
+// coordinates PAST its domain (CuTe coalesce_x). Plain Coalesce can drop a
+// trailing extent-1 mode whose stride still matters out of range -- e.g.
+// (4,1):(1,0) coalesces to 4:1, losing the trailing slot. Seeding the scan with
+// a shape-2 placeholder instead preserves that slot, yielding (4,2):(1,0).
+// Composition needs this because the rhs codomain can index the lhs beyond its
+// nominal size.
+Layout CoalesceX(const Layout &layout) {
+  IntTuple fsh = Flatten(layout->shape), fst = Flatten(layout->stride);
+  int64_t R = Rank(fsh);
+  IntTuple seed_sh = fsh[R - 1];
+  if (IsConst(seed_sh) && AsConst(seed_sh) == 1)
+    seed_sh = IntTuple(int64_t(2));
+  constexpr int64_t kInf = std::numeric_limits<int64_t>::max();
+  return BwCoalesce(fsh, fst, seed_sh, fst[R - 1], kInf);
+}
+
+// Reconstruct a tree shape from a set of basis paths. Each path is a sequence
+// of child indices (a ScaledBasis E<i,j,...>); this groups the paths by their
+// first index to rebuild the nesting they came from. A leaf IntTuple(0) marks a
+// position reached by a plain (path-free) stride; a tuple marks a position with
+// further structure. See Coprofile for what the result is used for.
+IntTuple BuildProfile(const std::vector<std::vector<int64_t>> &paths) {
+  int64_t max_idx = -1;
+  for (const auto &p : paths)
+    if (!p.empty())
+      max_idx = std::max(max_idx, p[0]);
+  if (max_idx < 0)
+    return IntTuple(int64_t(0)); // no structure remaining: a plain slot.
+  Array<IntTuple> fields;
+  for (int64_t j = 0; j <= max_idx; ++j) {
+    std::vector<std::vector<int64_t>> sub;
+    for (const auto &p : paths)
+      if (!p.empty() && p[0] == j)
+        sub.emplace_back(p.begin() + 1, p.end());
+    fields.push_back(sub.empty() ? IntTuple(int64_t(0)) : BuildProfile(sub));
+  }
+  return IntTupleTuple(fields);
+}
+
+// Describe the structure of a layout's codomain as a tree of placeholders (CuTe
+// coprofile). The shape (a tree of 0-leaves) tells composition how finely to
+// coalesce the lhs: composition coalesces the lhs "at the terminals" of this
+// profile, so a coarser profile fuses more lhs modes together. A layout with
+// only plain integer strides has an unstructured (scalar) codomain, so the
+// profile is a single leaf -- the lhs is fully coalesced. ScaledBasis strides
+// address distinct codomain axes by path, so the profile is a tree indexed by
+// those paths and the lhs is coalesced per-axis instead, which keeps each lhs
+// mode addressable by its basis path during composition.
+IntTuple Coprofile(const IntTuple &stride) {
+  std::vector<std::vector<int64_t>> paths;
+  bool any_basis = false;
+  FoldLeaves(stride, 0, [&](int, const IntTuple &s) {
+    if (IsScaledBasis(s)) {
+      any_basis = true;
+      Array<int64_t> p = BasisPath(s);
+      paths.emplace_back(p.begin(), p.end());
+    } else {
+      paths.emplace_back();
+    }
+    return 0;
+  });
+  if (!any_basis)
+    return IntTuple(int64_t(0));
+  return BuildProfile(paths);
+}
+
+// Coalesce a layout only as far as `profile` allows (CuTe coalesce_x at the
+// profile terminals): a leaf profile fully coalesces this (sub)layout, while a
+// tuple profile recurses into the corresponding lhs modes and leaves the rest
+// uncoalesced. Any lhs modes beyond the profile's rank are kept as-is.
+Layout CoalesceXProfile(const Layout &layout, const IntTuple &profile) {
+  if (!IsTuple(profile))
+    return CoalesceX(layout);
+  int64_t rl = Rank(layout->shape), rp = Rank(profile);
+  int64_t r = std::min(rl, rp);
+  Array<IntTuple> out_sh, out_st;
+  for (int64_t i = 0; i < r; ++i) {
+    Layout sub = CoalesceXProfile(layout[i], profile[i]);
+    out_sh.push_back(sub->shape);
+    out_st.push_back(sub->stride);
+  }
+  for (int64_t i = r; i < rl; ++i) { // lhs modes the profile doesn't reach.
+    out_sh.push_back(layout->shape[i]);
+    out_st.push_back(layout->stride[i]);
+  }
+  return Layout(IntTupleTuple(out_sh), IntTupleTuple(out_st));
+}
+
+// Collapse rank-1 tuples down to their single element (CuTe unwrap): ((x)) ->
+// x, stopping at the first leaf or rank>1 tuple.
+IntTuple Unwrap(const IntTuple &t) {
+  if (IsTuple(t) && Rank(t) == 1)
+    return Unwrap(t[0]);
+  return t;
+}
+
+// Compose one rhs mode through the lhs (CuTe composition_impl): returns the
+// layout r such that r(c) == lhs(rhs_mode(c)), with a shape tree congruent to
+// the rhs mode. The lhs is kept hierarchical (not flattened) so that a
+// ScaledBasis rhs stride can address a specific nested lhs mode by its path.
+// Five cases, in priority order:
+//   1. rhs is a tuple: compose each child independently (composition
+//   distributes
+//      over the rhs modes) and keep the rhs's tuple shape.
+//   2. rhs stride is a ScaledBasis E<path>*k: that codomain axis is lhs mode
+//      `path`, so recurse into that lhs mode with scalar rhs stride k.
+//   3. rhs stride 0: the rhs mode lands on a single lhs element; pass through.
+//   4. lhs is a single mode: the composed stride is just rhs_stride *
+//   lhs_stride.
+//   5. lhs is a tuple: peel the rhs mode across the lhs modes (the divide loop
+//      below).
+// rhs_stride is always a constant int or a ScaledBasis here; lhs shapes are
+// constant ints, lhs strides any leaf (const/dynamic/basis).
+Layout CompositionImpl(const IntTuple &lhs_shape, const IntTuple &lhs_stride,
+                       const IntTuple &rhs_shape, const IntTuple &rhs_stride) {
+  // 1. rhs tuple: compose each child, preserving rhs's shape.
+  if (IsTuple(rhs_shape)) {
+    int64_t r = Rank(rhs_shape);
+    Array<IntTuple> out_sh, out_st;
+    for (int64_t i = 0; i < r; ++i) {
+      Layout sub =
+          CompositionImpl(lhs_shape, lhs_stride, rhs_shape[i], rhs_stride[i]);
+      out_sh.push_back(sub->shape);
+      out_st.push_back(sub->stride);
+    }
+    return Layout(IntTupleTuple(out_sh), IntTupleTuple(out_st));
+  }
+  // 2. rhs stride E<path>*k: route into the lhs mode named by `path`.
+  if (IsScaledBasis(rhs_stride)) {
+    Array<int64_t> path = BasisPath(rhs_stride);
+    return CompositionImpl(BasisGet(path, lhs_shape),
+                           BasisGet(path, lhs_stride), rhs_shape,
+                           BasisValue(rhs_stride));
+  }
+  // 3. rhs stride 0: the whole rhs mode maps to one address.
+  if (IsConst(rhs_stride) && AsConst(rhs_stride) == 0)
+    return Layout(rhs_shape, rhs_stride);
+  // 4. single lhs mode: stride composes by multiplication.
+  if (!IsTuple(lhs_shape))
+    return Layout(rhs_shape, rhs_stride * lhs_stride);
+
+  // 5. lhs tuple, scalar rhs mode. Walk the lhs modes fastest-first, splitting
+  //    the rhs mode across them: each lhs mode i consumes the part of the rhs
+  //    extent that lands within it (new_shape) at stride
+  //    rest_stride*lhs.stride, and `rest_*` carries the leftover extent/stride
+  //    into the next lhs mode. The divisibility checks are CuTe's precondition
+  //    that composition is well-defined (the rhs mode must tile cleanly across
+  //    the lhs modes).
+  ICHECK(IsConst(rhs_stride))
+      << "Composition RHS stride must be a constant int or a ScaledBasis";
+  int64_t R = Rank(lhs_shape);
+  Array<IntTuple> res_shape, res_stride;
+  int64_t rest_shape = AsConst(rhs_shape);
+  int64_t rest_stride = AsConst(rhs_stride);
+  for (int64_t i = 0; i < R - 1; ++i) {
+    int64_t curr_shape = AsConst(lhs_shape[i]);
+    ICHECK(rest_stride % curr_shape == 0 || rest_stride < curr_shape)
+        << "Composition stride divisibility: rest_stride=" << rest_stride
+        << ", curr_shape=" << curr_shape;
+    // How much of this lhs mode the current stride spans, and the stride left
+    // over for the next mode.
+    int64_t next_shape = CeilDiv(curr_shape, Abs(rest_stride));
+    int64_t next_stride =
+        CeilDiv(Abs(rest_stride), curr_shape) * Signum(rest_stride);
+    if (next_shape == 1 || rest_shape == 1) {
+      rest_stride = next_stride; // nothing lands in this mode; carry on.
+    } else {
+      int64_t new_shape = std::min(next_shape, rest_shape);
+      ICHECK(rest_shape % new_shape == 0)
+          << "Composition shape divisibility: rest_shape=" << rest_shape
+          << ", new_shape=" << new_shape;
+      res_shape.push_back(IntTuple(new_shape));
+      res_stride.push_back(IntTuple(rest_stride) * lhs_stride[i]);
+      rest_shape /= new_shape;
+      rest_stride = next_stride;
+    }
+  }
+  // The remaining extent rides the slowest lhs mode's stride.
+  IntTuple last = lhs_stride[R - 1];
+  if (res_shape.empty())
+    return Layout(IntTuple(rest_shape), IntTuple(rest_stride) * last);
+  if (rest_shape == 1) // exactly tiled: drop the trivial trailing mode.
+    return Layout(Unwrap(IntTupleTuple(res_shape)),
+                  Unwrap(IntTupleTuple(res_stride)));
+  res_shape.push_back(IntTuple(rest_shape));
+  res_stride.push_back(IntTuple(rest_stride) * last);
+  return Layout(IntTupleTuple(res_shape), IntTupleTuple(res_stride));
+}
+
+} // namespace
+
+Layout Composition(const Layout &lhs, const Layout &rhs) {
+  ICHECK(lhs.defined() && rhs.defined()) << "Composition on a null Layout";
+  // result(c) == lhs(rhs(c)). The lhs is first coalesced to the granularity the
+  // rhs actually addresses (Coprofile): plain rhs strides let the lhs be fully
+  // coalesced, so CompositionImpl's divide loop sees flat lhs modes;
+  // ScaledBasis rhs strides keep the lhs split per-axis so each basis path
+  // still resolves to its own lhs mode. CompositionImpl then composes the
+  // (possibly hierarchical) trees directly.
+  Layout flat_lhs = CoalesceXProfile(lhs, Coprofile(rhs->stride));
+  return CompositionImpl(flat_lhs->shape, flat_lhs->stride, rhs->shape,
+                         rhs->stride);
+}
+
+Layout Coalesce(const Layout &layout, int64_t max_extent) {
+  ICHECK(layout.defined()) << "Coalesce on a null Layout";
+  return CoalesceImpl(layout, max_extent);
+}
+
+Layout Take(const Layout &layout, int64_t n) {
+  ICHECK(layout.defined());
+  int64_t r = Rank(layout);
+  ICHECK(0 <= n && n <= r) << "Take(n) out of range: n=" << n << ", rank=" << r;
+  Array<IntTuple> shape, stride;
+  for (int64_t i = 0; i < n; ++i) {
+    shape.push_back(layout->shape[i]);
+    stride.push_back(layout->stride[i]);
+  }
+  return Layout(std::move(shape), std::move(stride));
+}
+
+Layout MakeColumnMajorLayout(const IntTuple &shape) {
+  return Layout(shape, CompactColMajor(shape));
+}
+
+Layout MakeRowMajorLayout(const IntTuple &shape) {
+  return Layout(shape, CompactRowMajor(shape));
+}
+
+Layout MakeIdentityLayout(const IntTuple &shape) {
+  std::vector<int64_t> path;
+  return Layout(shape, IdentityStride(shape, path));
+}
+
+ComposedLayout::ComposedLayout(Swizzle swizzle, int64_t offset, Layout layout) {
+  auto node = make_object<ComposedLayoutNode>();
+  node->swizzle = std::move(swizzle);
+  node->offset = offset;
+  node->layout = std::move(layout);
+  data_ = std::move(node);
+}
+
+ComposedLayout ComposedLayout::Recast(int old_bits, int new_bits) const {
+  const ComposedLayoutNode *n = get();
+  ICHECK(n != nullptr) << "Recast on a null ComposedLayout";
+  int old_log = Log2Exact(old_bits);
+  int new_log = Log2Exact(new_bits);
+  ICHECK(old_log >= 0 && new_log >= 0)
+      << "Recast expects power-of-two element sizes, got " << old_bits << " -> "
+      << new_bits;
+  // Scaling the element width multiplies every address by old_bits/new_bits.
+  // For a clean integer layout this must be an exact power-of-two scale; the
+  // shift can be positive (smaller elements) or negative (larger elements).
+  int shift = old_log - new_log;
+  auto scale = [&](int64_t v) -> int64_t {
+    if (shift >= 0)
+      return v << shift;
+    int64_t d = static_cast<int64_t>(1) << (-shift);
+    ICHECK(v % d == 0) << "Recast cannot scale " << v << " by 2^" << shift
+                       << " without remainder";
+    return v / d;
+  };
+  // Scale every stride leaf, preserving the shape tree (TransformLeaf keeps the
+  // hierarchy; the recovered layout's strides are plain integers).
+  IntTuple new_stride = TransformLeaf(n->layout->stride, [&](IntTuple s) {
+    ICHECK(IsConst(s)) << "Recast requires plain integer strides";
+    return IntTuple(scale(AsConst(s)));
+  });
+  Layout new_layout(n->layout->shape, new_stride);
+  return ComposedLayout(n->swizzle.Recast(old_bits, new_bits), scale(n->offset),
+                        new_layout);
+}
+
+namespace {
+
+// Fully evaluate a PrimExpr to an integer constant. The expression must contain
+// only integer constants and the operators a swizzled layout is built from:
+// +, -, *, FloorDiv, FloorMod, and the bitwise/shift builtins. arith::Analyzer
+// does not constant-fold bitwise ops (e.g. T.bitwise_xor) even when both
+// operands are constant, so we evaluate them ourselves. Returns std::nullopt if
+// any node is not a recognized constant-foldable form.
+std::optional<int64_t> EvalConstExpr(const PrimExpr &e) {
+  if (auto c = as_const_int(e))
+    return *c;
+  // Floored division/modulo (rounds toward -inf), matching FloorDiv/FloorMod.
+  auto fdiv = [](int64_t a, int64_t b) {
+    int64_t q = a / b, r = a % b;
+    return q - ((r != 0) && ((r < 0) != (b < 0)) ? 1 : 0);
+  };
+  auto fmod = [&](int64_t a, int64_t b) { return a - fdiv(a, b) * b; };
+  if (const auto *op = e.as<AddNode>()) {
+    auto a = EvalConstExpr(op->a), b = EvalConstExpr(op->b);
+    if (a && b)
+      return *a + *b;
+  } else if (const auto *op = e.as<SubNode>()) {
+    auto a = EvalConstExpr(op->a), b = EvalConstExpr(op->b);
+    if (a && b)
+      return *a - *b;
+  } else if (const auto *op = e.as<MulNode>()) {
+    auto a = EvalConstExpr(op->a), b = EvalConstExpr(op->b);
+    if (a && b)
+      return *a * *b;
+  } else if (const auto *op = e.as<FloorDivNode>()) {
+    auto a = EvalConstExpr(op->a), b = EvalConstExpr(op->b);
+    if (a && b && *b != 0)
+      return fdiv(*a, *b);
+  } else if (const auto *op = e.as<FloorModNode>()) {
+    auto a = EvalConstExpr(op->a), b = EvalConstExpr(op->b);
+    if (a && b && *b != 0)
+      return fmod(*a, *b);
+  } else if (const auto *op = e.as<CallNode>()) {
+    if (op->args.size() == 2) {
+      auto a = EvalConstExpr(op->args[0]), b = EvalConstExpr(op->args[1]);
+      if (a && b) {
+        if (op->op.same_as(builtin::bitwise_xor()))
+          return *a ^ *b;
+        if (op->op.same_as(builtin::bitwise_and()))
+          return *a & *b;
+        if (op->op.same_as(builtin::bitwise_or()))
+          return *a | *b;
+        if (op->op.same_as(builtin::shift_left())) {
+          ICHECK(*b >= 0 && *b < 64);
+          return *a << *b;
+        }
+        if (op->op.same_as(builtin::shift_right())) {
+          ICHECK(*b >= 0 && *b < 64);
+          return *a >> *b;
+        }
+      }
+    } else if (op->args.size() == 1 && op->op.same_as(builtin::bitwise_not())) {
+      if (auto a = EvalConstExpr(op->args[0]))
+        return ~*a;
+    }
+  }
+  return std::nullopt;
+}
+
+// When processing shared tensor layout, all the shapes and strides are int32_t.
+// Also, we need to make sure not to mix with int64_t, because otherwise there
+// would be a lot of conversion nodes that prevent the analyzer from cancelling
+// out the terms.
+PrimExpr MakeI32(int x) { return IntImm(DataType::Int(32), x); }
+
+// Probes a TileLang layout's row-major linearized physical address A(x).
+// The constant input shape, output strides, forward-index expressions, and
+// input placeholders are parsed once in the constructor. operator() folds
+// concrete integer coordinates to a constant address; Symbolic() substitutes
+// fresh variables for the equivalence proof. valid() is false when any extent
+// is non-constant.
+class AddrProbe {
+public:
+  explicit AddrProbe(const tvm::tl::Layout &layout) {
+    ICHECK(layout.defined());
+    for (const auto &e : layout->InputShape()) {
+      auto c = as_const_int(e);
+      ICHECK(c) << "InputShape extent " << e
+                << " of a shared tensor layout must be constant";
+      shape_.push_back(*c);
+    }
+    std::vector<int32_t> out_sizes;
+    for (const auto &e : layout->OutputShape()) {
+      auto c = as_const_int(e);
+      ICHECK(c) << "OutputShape extent " << e
+                << " of a shared tensor layout must be constant";
+      out_sizes.push_back(*c);
+    }
+    out_strides_.assign(out_sizes.size(), 0);
+    int32_t acc = 1;
+    for (int64_t d = static_cast<int64_t>(out_sizes.size()) - 1; d >= 0; --d) {
+      out_strides_[d] = acc;
+      acc *= out_sizes[d];
+    }
+    forward_index_ = layout->GetForwardIndex();
+    ICHECK_EQ(forward_index_.size(), out_strides_.size());
+    ICHECK_EQ(layout->InputDim(), shape_.size());
+    for (size_t k = 0; k < shape_.size(); ++k)
+      placeholders_.push_back(InputPlaceholder(k));
+  }
+
+  const std::vector<int32_t> &shape() const { return shape_; }
+
+  // Concrete address A(coords); nullopt if it does not fold to a constant.
+  std::optional<int32_t> operator()(const std::vector<int32_t> &coords) const {
+    Map<Var, PrimExpr> vmap;
+    for (size_t k = 0; k < coords.size(); ++k)
+      vmap.Set(placeholders_[k], MakeI32(coords[k]));
+    int32_t addr = 0;
+    for (size_t d = 0; d < forward_index_.size(); ++d) {
+      PrimExpr e = Substitute(forward_index_[d], vmap);
+      std::optional<int64_t> val = EvalConstExpr(e);
+      if (!val)
+        return std::nullopt;
+      addr += static_cast<int32_t>(*val) * out_strides_[d];
+    }
+    return addr;
+  }
+
+  // Symbolic address A(vars). Built in int32 (the forward index's native
+  // dtype): int64 casts in the spine are opaque to the simplifier's div/mod
+  // rules and would defeat the equivalence proof.
+  PrimExpr Symbolic(const std::vector<Var> &vars) const {
+    Map<Var, PrimExpr> vmap;
+    for (size_t k = 0; k < vars.size(); ++k)
+      vmap.Set(placeholders_[k], vars[k]);
+    PrimExpr a = MakeI32(0);
+    for (size_t d = 0; d < forward_index_.size(); ++d) {
+      a = a + Substitute(forward_index_[d], vmap) * MakeI32(out_strides_[d]);
+    }
+    return a;
+  }
+
+private:
+  std::vector<int32_t> shape_;
+  std::vector<int32_t> out_strides_;
+  Array<PrimExpr> forward_index_;
+  std::vector<Var> placeholders_;
+};
+
+PrimExpr Bit(const PrimExpr &e, int k) {
+  PrimExpr shifted = k > 0 ? FloorDiv(e, IntImm(e->dtype, int64_t(1) << k)) : e;
+  return FloorMod(shifted, IntImm(e->dtype, 2));
+}
+
+// Rewrite the bitwise builtins a swizzle is built from into plain integer
+// arithmetic (+, -, *, FloorDiv, FloorMod) that the arith machinery can reason
+// about. Each rewrite is an exact identity:
+//   - shift_left(x, k)  == x * 2^k                       (k a constant)
+//   - shift_right(x, k) == FloorDiv(x, 2^k)              (k a constant, x >= 0)
+//   - bitwise_and(x, C) == sum_{bit k of C set} bit_k(x) * 2^k   (C constant)
+//   - bitwise_xor(x, y) == hi(wide) + sum_{k<w} ((bit_k(x)+bit_k(y))%2)*2^k
+// The xor expansion relies on single-bit parities not carrying, so it expands
+// only the low `w` bits, where w is the bit width of the NARROWER operand (the
+// one whose value is bounded small). Bits at or above w are zero in the narrow
+// operand, so there x^y == bit-of-wide unchanged; their sum is kept as the
+// single symbolic term hi(wide) = FloorDiv(wide, 2^w) * 2^w. This is what lets
+// a swizzle applied over an address carrying a large base offset reduce: the
+// offset stays intact in hi(wide) instead of being shattered into ~log2(offset)
+// parity terms that the prover cannot reconverge. Every other node recurses
+// through ExprMutator's default child-rebuilding visitors.
+class BitOpLowerer : public ExprMutator {
+public:
+  explicit BitOpLowerer(arith::Analyzer *ana) : ana_(ana) {}
+  using ExprMutator::operator();
+
+protected:
+  PrimExpr VisitExpr_(const CallNode *op) final {
+    if (op->args.size() == 2 && op->op.same_as(builtin::shift_left())) {
+      if (auto k = as_const_int(op->args[1])) {
+        ICHECK(*k >= 0 && *k < 64);
+        return VisitExpr(op->args[0]) * IntImm(op->dtype, int64_t(1) << *k);
+      }
+    }
+    if (op->args.size() == 2 && op->op.same_as(builtin::shift_right())) {
+      if (auto k = as_const_int(op->args[1])) {
+        ICHECK(*k >= 0 && *k < 64);
+        return FloorDiv(VisitExpr(op->args[0]),
+                        IntImm(op->dtype, int64_t(1) << *k));
+      }
+    }
+    if (op->args.size() == 2 && op->op.same_as(builtin::bitwise_and())) {
+      auto ca = as_const_int(op->args[0]), cb = as_const_int(op->args[1]);
+      if (ca || cb) {
+        int64_t mask = ca ? *ca : *cb;
+        PrimExpr x = VisitExpr(ca ? op->args[1] : op->args[0]);
+        if (mask >= 0) {
+          PrimExpr out = MakeI32(0);
+          for (int k = 0; (mask >> k) != 0; ++k)
+            if ((mask >> k) & 1)
+              out = out + Bit(x, k) * MakeI32(int64_t(1) << k);
+          return out;
+        }
+      }
+    }
+    if (op->args.size() == 2 && op->op.same_as(builtin::bitwise_xor())) {
+      PrimExpr x = VisitExpr(op->args[0]), y = VisitExpr(op->args[1]);
+      // Expand over the NARROWER operand's bit width: bits above it are zero
+      // there, so x^y == the wider operand unchanged in that range. Bounding by
+      // the min keeps a large base offset on the wide side out of the per-bit
+      // expansion (it rides along in hi() below) instead of exploding into
+      // ~log2(offset) parity terms the prover cannot reconverge.
+      int64_t bx = ana_->const_int_bound(x)->max_value;
+      int64_t by = ana_->const_int_bound(y)->max_value;
+      if (bx < 0 || by < 0)
+        return bitwise_xor(x, y); // unbounded operand: cannot size the window.
+      int64_t mn = std::min(bx, by);
+      if (mn < (int64_t(1) << 20)) {
+        int width = std::max<int>(
+            1, 64 - __builtin_clzll(static_cast<uint64_t>(mn) | 1));
+        // wide = the operand whose high bits (>= width) pass through unchanged.
+        PrimExpr wide = bx >= by ? x : y;
+        PrimExpr hi = FloorDiv(wide, MakeI32(int64_t(1) << width)) *
+                      MakeI32(int64_t(1) << width);
+        PrimExpr out = hi;
+        for (int k = 0; k < width; ++k)
+          out = out + FloorMod(Bit(x, k) + Bit(y, k), MakeI32(2)) *
+                          MakeI32(int64_t(1) << k);
+        return out;
+      }
+      return bitwise_xor(x, y);
+    }
+    return ExprMutator::VisitExpr_(op);
+  }
+
+private:
+  arith::Analyzer *ana_;
+};
+
+PrimExpr LowerBitOps(const PrimExpr &e, arith::Analyzer *ana) {
+  return BitOpLowerer(ana)(e);
+}
+
+// Canonicalize every parity node FloorMod(x, 2) in `e`. Working mod 2:
+// +/- coincide, even-coefficient terms vanish, and a nested (y % 2) inside a
+// parity sum equals y — so the parity's terms flatten into a bag. Each leaf
+// term is keyed by Simplify(term % 2) (the simplifier's canonical single-bit
+// form, e.g. (i // 2) % 2 == i % 4 // 2), keys appearing an even number of
+// times cancel, and the survivors are rebuilt in sorted order. Two equal
+// parities thus become structurally identical, which lets the surrounding
+// Simplify cancel them — the step the rewrite simplifier cannot do by itself.
+// Only FloorMod(_, 2) needs custom handling; every other node recurses through
+// ExprMutator's default child-rebuilding visitors.
+class ParityCanonicalizer : public ExprMutator {
+public:
+  explicit ParityCanonicalizer(arith::Analyzer *ana) : ana_(ana) {}
+  using ExprMutator::operator();
+
+protected:
+  PrimExpr VisitExpr_(const FloorModNode *op) final {
+    if (!is_two(op->b))
+      return ExprMutator::VisitExpr_(op);
+    std::vector<PrimExpr> terms;
+    int parity = 0;
+    flatten(op->a, &terms, &parity);
+    std::stable_sort(terms.begin(), terms.end(),
+                     [](const PrimExpr &a, const PrimExpr &b) {
+                       return StructuralHash()(a) < StructuralHash()(b);
+                     });
+    PrimExpr sum = MakeI32(parity);
+    for (size_t i = 0; i < terms.size();) {
+      if (i + 1 < terms.size() && StructuralEqual()(terms[i], terms[i + 1])) {
+        i += 2; // t + t == 0 (mod 2)
+      } else {
+        sum = sum + terms[i];
+        ++i;
+      }
+    }
+    return FloorMod(sum, MakeI32(2));
+  }
+
+private:
+  static bool is_two(const PrimExpr &x) {
+    auto c = as_const_int(x);
+    return c && *c == 2;
+  }
+
+  // Flatten `x` (interpreted mod 2) into leaf terms + a constant parity.
+  void flatten(const PrimExpr &x, std::vector<PrimExpr> *terms, int *parity) {
+    if (const auto *op = x.as<AddNode>()) {
+      flatten(op->a, terms, parity);
+      flatten(op->b, terms, parity);
+      return;
+    }
+    if (const auto *op = x.as<SubNode>()) { // -t == t (mod 2)
+      flatten(op->a, terms, parity);
+      flatten(op->b, terms, parity);
+      return;
+    }
+    if (const auto *imm = x.as<IntImmNode>()) {
+      *parity ^= static_cast<int>(imm->value & 1);
+      return;
+    }
+    if (const auto *op = x.as<MulNode>()) {
+      const auto *ca = op->a.as<IntImmNode>();
+      const auto *cb = op->b.as<IntImmNode>();
+      if (ca || cb) {
+        int64_t c = ca ? ca->value : cb->value;
+        if (c % 2 == 0)
+          return; // even coefficient: vanishes mod 2.
+        flatten(ca ? op->b : op->a, terms, parity);
+        return;
+      }
+    }
+    if (const auto *op = x.as<FloorModNode>()) {
+      if (is_two(op->b)) { // (y % 2) == y (mod 2)
+        flatten(op->a, terms, parity);
+        return;
+      }
+    }
+    // Leaf: canonicalize via the simplifier's single-bit form (recursing into
+    // any nested parities first). If that form is itself a parity of a sum,
+    // keep flattening through it.
+    PrimExpr key = ana_->Simplify(FloorMod(VisitExpr(x), 2));
+    if (const auto *km = key.as<FloorModNode>()) {
+      if (is_two(km->b) && (km->a.as<AddNode>() || km->a.as<SubNode>() ||
+                            km->a.as<MulNode>() || km->a.as<IntImmNode>())) {
+        flatten(km->a, terms, parity);
+        return;
+      }
+    }
+    if (const auto *imm = key.as<IntImmNode>()) {
+      *parity ^= static_cast<int>(imm->value & 1);
+      return;
+    }
+    terms->push_back(key);
+  }
+
+  arith::Analyzer *ana_;
+};
+
+PrimExpr ParityCanon(const PrimExpr &e, arith::Analyzer *ana) {
+  return ParityCanonicalizer(ana)(e);
+}
+
+// Decide E == 0 for all assignments of the analyzer's range-bound variables,
+// by iterating Simplify -> LowerBitOps -> ParityCanon to a fixpoint. Sound:
+// every step is an exact identity, so a 0 result is a proof; a non-0 fixpoint
+// means "not proven" and the caller must reject. Complete enough in practice
+// that neither sampling nor an SMT solver is needed.
+bool ProveZero(PrimExpr e, arith::Analyzer *ana, int max_rounds = 8) {
+  PrimExpr d = ana->Simplify(e);
+  size_t last_hash = 0;
+  for (int round = 0; round < max_rounds; ++round) {
+    if (is_zero(d))
+      return true;
+    size_t h = StructuralHash()(d);
+    if (round > 0 && h == last_hash)
+      return false; // fixpoint reached without proving 0.
+    last_hash = h;
+    d = ana->Simplify(ParityCanon(LowerBitOps(d, ana), ana));
+  }
+  return is_zero(d);
+}
+
+// Symbolically prove that the probed layout address equals the recovered
+// composed layout, A(x) == Sw(offset + plain(linearize(x))), for ALL logical
+// coordinates x. With mid(Q) = the swizzle's XOR of Q's target and source bit
+// fields written as per-bit parities, and tgt(Q) = Q's target field, the
+// equality is the single integer identity
+//
+//   A - Q - (mid(Q) - tgt(Q)) * 2^m_base == 0,
+//
+// which ProveZero decides with the parity-aware rewriting. All proof
+// arithmetic is int32; layouts that could overflow it are rejected.
+bool ProveEquivalent(const AddrProbe &probe, const Swizzle &swizzle,
+                     int64_t offset, const Layout &plain) {
+  const Layout cl = Flatten(plain);
+  const std::vector<int32_t> &shape = probe.shape();
+  // RecoverPlainLayout always builds `plain` flat with constant integer leaves.
+  std::vector<int32_t> cl_shape, cl_stride;
+  for (int64_t k = 0; k < Rank(cl->shape); ++k)
+    cl_shape.push_back(AsConst(cl->shape[k]));
+  for (int64_t k = 0; k < Rank(cl->stride); ++k)
+    cl_stride.push_back(AsConst(cl->stride[k]));
+
+  int b = swizzle->b_bits, m = swizzle->m_base, s = swizzle->s_shift;
+  if (b > 0 && m + s + b >= 31)
+    return false;
+
+  // Analyzer with each coordinate range-bound: x_k in [0, shape[k]).
+  arith::Analyzer ana;
+  std::vector<Var> vars;
+  for (size_t k = 0; k < shape.size(); ++k) {
+    Var v("c" + std::to_string(k), DataType::Int(32));
+    vars.push_back(v);
+    if (shape[k] > 0)
+      ana.Bind(v, Range(MakeI32(0), MakeI32(shape[k])));
+  }
+
+  PrimExpr A = probe.Symbolic(vars);
+
+  // Q(x) = offset + plain(linearize(x)): linearize x column-major over the
+  // input shape, then evaluate the plain layout's CuTe idx2crd symbolically.
+  PrimExpr coord = MakeI32(0);
+  int64_t place = 1;
+  for (size_t k = 0; k < vars.size(); ++k) {
+    coord = coord + vars[k] * MakeI32(place);
+    place *= std::max<int64_t>(shape[k], 1);
+  }
+  PrimExpr Q = MakeI32(offset);
+  {
+    PrimExpr rem = coord;
+    for (size_t i = 0; i < cl_shape.size(); ++i) {
+      int64_t ext = cl_shape[i];
+      PrimExpr crd = ext > 0 ? FloorMod(rem, MakeI32(ext)) : PrimExpr(rem);
+      Q = Q + crd * MakeI32(cl_stride[i]);
+      if (ext > 0)
+        rem = FloorDiv(rem, MakeI32(ext));
+    }
+  }
+
+  if (b <= 0)
+    return ProveZero(A - Q, &ana);
+
+  PrimExpr mid = MakeI32(0);
+  for (int p = 0; p < b; ++p)
+    mid = mid + FloorMod(Bit(Q, m + p) + Bit(Q, m + s + p), MakeI32(2)) *
+                    MakeI32(int64_t(1) << p);
+  PrimExpr tgt =
+      FloorMod(FloorDiv(Q, MakeI32(int64_t(1) << m)), MakeI32(int64_t(1) << b));
+  return ProveZero(A - Q - (mid - tgt) * MakeI32(int64_t(1) << m), &ana);
+}
+
+} // namespace
+
+namespace {
+
+// Recover the unswizzled affine cute::Layout underlying a probed address, given
+// the swizzle and base offset, returning nullopt unless the recovery provably
+// reproduces the probe for every coordinate. Shared by the two entry points
+// below (one detects the swizzle first, the other assumes none).
+//
+// The swizzle is an involution, so undoing it gives the plain address
+// P(x) = Sw(A(x)) - offset. Probing P at one-hot coordinates reads off the
+// strides: each input dim is broken into one mode per power-of-two bit plus a
+// non-power-of-2 remainder, which captures a dim even when it is split across
+// non-contiguous regions of the address space. Each mode's stride is P at the
+// coordinate that activates only that mode.
+Optional<Layout> RecoverPlainLayout(const AddrProbe &A, const Swizzle &swizzle,
+                                    int64_t offset) {
+  const std::vector<int32_t> &shape = A.shape();
+  int64_t n = shape.size();
+  auto P = [&](const std::vector<int32_t> &x) -> std::optional<int64_t> {
+    std::optional<int32_t> a = A(x);
+    if (!a)
+      return std::nullopt;
+    return swizzle->Apply(*a) - offset;
+  };
+  Array<int64_t> mode_shape, mode_stride;
+  for (int64_t k = 0; k < n; ++k) {
+    int64_t rem = shape[k];
+    if (rem <= 1) {
+      mode_shape.push_back(1); // singleton dim: extent-1 mode, stride 0.
+      mode_stride.push_back(0);
+      continue;
+    }
+    // One mode per power-of-two bit, then a non-power-of-2 remainder. Modes are
+    // emitted dim-by-dim in increasing place order, so the recovered layout's
+    // single-coordinate domain is the column-major linearization of `shape`.
+    for (int32_t place = 1; rem > 1;) {
+      int64_t ext = rem % 2 == 0 ? 2 : rem;
+      std::vector<int32_t> x(n, 0);
+      x[k] = place;
+      std::optional<int64_t> d = P(x);
+      if (!d)
+        return std::nullopt;
+      // A stride-0 mode is a valid broadcast (e.g. (8,8):(0,1)); the final
+      // ProveEquivalent check, not injectivity, is what gates correctness.
+      mode_shape.push_back(ext);
+      mode_stride.push_back(*d);
+      rem /= ext;
+      place *= ext;
+    }
+  }
+  Layout plain = Coalesce(Layout(mode_shape, mode_stride));
+
+  // The per-mode probe only samples one-hot coordinates; confirm the recovered
+  // layout matches the probe everywhere before trusting it.
+  if (!ProveEquivalent(A, swizzle, offset, plain))
+    return std::nullopt;
+  return plain;
+}
+
+} // namespace
+
+// Recover a TileLang layout that has no swizzle and zero offset as a plain
+// cute::Layout, returning nullopt if it is actually swizzled/offset (the
+// equivalence proof then fails). Same recovery as the swizzled case with the
+// detection step skipped.
+Optional<Layout> LayoutFromTileLang(const tvm::tl::Layout &layout) {
+  AddrProbe A(layout);
+  if (A.shape().empty())
+    return std::nullopt;
+  return RecoverPlainLayout(A, Swizzle::Identity(), /*offset=*/0);
+}
+
+// Recover a swizzled affine layout, A(x) = Sw(offset + plain(x)), from a
+// TileLang layout, as a Swizzle composed with a plain cute::Layout. Sizes and
+// strides need not be powers of two.
+//
+// First detect the XOR swizzle by GF(2) bit-incidence. Probing the address at
+// each power-of-two bit-atom of a power-of-two-sized input dim and XOR-ing
+// against A(0) isolates that bit's image column. An ordinary (identity) bit
+// gives a single-bit column; a swizzled bit gives a two-bit column {lo,
+// lo+s_shift} whose low bit lo also appears as some identity column -- that
+// cross-check distinguishes a real swizzle from a two-bit column that a
+// non-power-of-2 plain stride happens to produce. The swizzle parameters are
+// read off the lowest contiguous run of such columns that share one s_shift.
+//
+// Then recover the plain layout and prove equivalence via RecoverPlainLayout.
+Optional<ComposedLayout>
+ComposedLayoutFromTileLang(const tvm::tl::Layout &layout) {
+  AddrProbe A(layout);
+  if (A.shape().empty())
+    return std::nullopt;
+  const std::vector<int32_t> &shape = A.shape();
+  int64_t n = shape.size();
+
+  std::vector<int32_t> zero(n, 0);
+  std::optional<int32_t> A0 = A(zero);
+  if (!A0)
+    return std::nullopt;
+
+  // Collect the image column of every power-of-two bit-atom. Probe bit p of dim
+  // k (one-hot 1 << p) for p < ctz(shape[k]): only then does 2^(p+1) divide the
+  // extent, so bit p toggles cleanly within the dim and the one-hot isolates a
+  // single mode. A non-pow2 extent still contributes its low bits (192 = 64*3
+  // -> p < 6); an odd extent contributes none.
+  std::vector<uint64_t> cols;
+  uint64_t weight1 = 0; // bit positions that are some atom's identity image.
+  for (int64_t k = 0; k < n; ++k) {
+    ICHECK_GT(shape[k], 0); // ctz is undefined at 0; extents are >= 1.
+    int max_p = __builtin_ctz(static_cast<uint32_t>(shape[k]));
+    for (int p = 0; p < max_p; ++p) {
+      std::vector<int32_t> x(n, 0);
+      x[k] = int32_t(1) << p;
+      std::optional<int32_t> a = A(x);
+      if (!a)
+        return std::nullopt;
+      uint64_t col = static_cast<uint64_t>(*a ^ *A0);
+      cols.push_back(col);
+      if (__builtin_popcountll(col) == 1)
+        weight1 |= col;
+    }
+  }
+  std::map<int, int> s_at; // swizzle target bit -> s_shift.
+  for (uint64_t col : cols) {
+    if (__builtin_popcountll(col) != 2)
+      continue;
+    int lo = __builtin_ctzll(col);
+    int hi = 63 - __builtin_clzll(col);
+    if (!(weight1 & (uint64_t(1) << lo)))
+      continue; // two-bit column from a plain stride, not a swizzle.
+    if (s_at.count(lo))
+      return std::nullopt; // two sources hitting one target: not a Swizzle.
+    s_at.emplace(lo, hi - lo);
+  }
+  Swizzle swizzle = Swizzle::Identity();
+  if (!s_at.empty()) {
+    // Take the lowest contiguous run of target bits that share one s_shift.
+    int m_base = s_at.begin()->first;
+    int s_shift = s_at.begin()->second;
+    int b_bits = 0;
+    for (auto it = s_at.find(m_base + b_bits);
+         it != s_at.end() && it->second == s_shift;
+         it = s_at.find(m_base + b_bits))
+      ++b_bits;
+    if (s_shift < b_bits)
+      return std::nullopt; // source and target bit regions must not overlap.
+    swizzle = Swizzle(b_bits, m_base, s_shift);
+  }
+
+  // The base offset is Sw(A(0)), since Sw is an involution; recover the plain
+  // layout under that swizzle and offset.
+  int64_t offset = swizzle->Apply(*A0);
+  Optional<Layout> plain = RecoverPlainLayout(A, swizzle, offset);
+  if (!plain.defined())
+    return std::nullopt;
+  return ComposedLayout(swizzle, offset, plain.value());
+}
+
+namespace {
+
+// CuTe-notation formatters (the single source of truth shared by C++ stream
+// output and Python __str__/__repr__ via the __ffi_repr__ hooks below).
+std::string FormatIntTuple(const IntTuple &t) {
+  if (const auto *c = t.as<IntTupleConstNode>()) {
+    return std::to_string(c->value);
+  }
+  if (const auto *e = t.as<IntTuplePrimExprNode>()) {
+    std::ostringstream os;
+    os << e->value;
+    return os.str();
+  }
+  if (const auto *b = t.as<IntTupleScaledBasisNode>()) {
+    // CuTe scaled-basis spelling value@m@...: the mode path prints
+    // innermost-first (CuTe's E<...> print order), e.g. E<1,0> -> 1@0@1.
+    std::ostringstream os;
+    os << FormatIntTuple(b->value);
+    for (auto it = b->basis.rbegin(); it != b->basis.rend(); ++it)
+      os << "@" << *it;
+    return os.str();
+  }
+  const auto *a = t.as<IntTupleTupleNode>();
+  ICHECK(a != nullptr) << "FormatIntTuple on an unknown IntTuple kind";
+  std::ostringstream os;
+  os << "(";
+  for (size_t i = 0; i < a->fields.size(); ++i) {
+    if (i > 0)
+      os << ",";
+    os << FormatIntTuple(a->fields[i]);
+  }
+  os << ")";
+  return os.str();
+}
+
+std::string FormatSwizzle(const SwizzleNode *s) {
+  std::ostringstream os;
+  os << "Sw<" << s->b_bits << "," << s->m_base << "," << s->s_shift << ">";
+  return os.str();
+}
+
+std::string FormatLayout(const LayoutNode *l) {
+  return FormatIntTuple(l->shape) + ":" + FormatIntTuple(l->stride);
+}
+
+std::string FormatComposedLayout(const ComposedLayoutNode *c) {
+  return FormatSwizzle(c->swizzle.get()) + " o " + std::to_string(c->offset) +
+         " o " + FormatLayout(c->layout.get());
+}
+
+} // namespace
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  SwizzleNode::RegisterReflection();
+  IntTupleConstNode::RegisterReflection();
+  IntTuplePrimExprNode::RegisterReflection();
+  IntTupleScaledBasisNode::RegisterReflection();
+  IntTupleTupleNode::RegisterReflection();
+  LayoutNode::RegisterReflection();
+  ComposedLayoutNode::RegisterReflection();
+}
+
+// CuTe-notation printing: register an __ffi_repr__ hook per concrete type so
+// ffi.ReprPrint (and therefore Python's str()/repr()) renders these objects in
+// CuTe spelling. The hook is keyed by exact type index (no ancestor lookup), so
+// every concrete IntTuple kind is registered individually.
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  refl::TypeAttrDef<SwizzleNode>().def(
+      refl::type_attr::kRepr, [](Swizzle s, ffi::Function) -> ffi::String {
+        return FormatSwizzle(s.get());
+      });
+  refl::TypeAttrDef<IntTupleConstNode>().def(
+      refl::type_attr::kRepr, [](IntTuple t, ffi::Function) -> ffi::String {
+        return FormatIntTuple(t);
+      });
+  refl::TypeAttrDef<IntTuplePrimExprNode>().def(
+      refl::type_attr::kRepr, [](IntTuple t, ffi::Function) -> ffi::String {
+        return FormatIntTuple(t);
+      });
+  refl::TypeAttrDef<IntTupleScaledBasisNode>().def(
+      refl::type_attr::kRepr, [](IntTuple t, ffi::Function) -> ffi::String {
+        return FormatIntTuple(t);
+      });
+  refl::TypeAttrDef<IntTupleTupleNode>().def(
+      refl::type_attr::kRepr, [](IntTuple t, ffi::Function) -> ffi::String {
+        return FormatIntTuple(t);
+      });
+  refl::TypeAttrDef<LayoutNode>().def(
+      refl::type_attr::kRepr, [](Layout l, ffi::Function) -> ffi::String {
+        return FormatLayout(l.get());
+      });
+  refl::TypeAttrDef<ComposedLayoutNode>().def(
+      refl::type_attr::kRepr,
+      [](ComposedLayout c, ffi::Function) -> ffi::String {
+        return FormatComposedLayout(c.get());
+      });
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  // All CuTe-layout FFI lives under the `tl.cute.*` namespace so the Python
+  // side initializes a single module (tilelang.layout.cute). The Python layer
+  // reads a layout's hierarchical shape/stride as IntTuple objects
+  // (layout_shape / layout_stride) and walks them itself, mirroring CuTeDSL's
+  // tuple-valued Layout.shape / Layout.stride -- there is no flat-leaf accessor
+  // here.
+  refl::GlobalDef()
+      // -- Swizzle --------------------------------------------------------
+      .def("tl.cute.swizzle_is_swizzled",
+           [](const Swizzle &swizzle) { return swizzle->IsSwizzled(); })
+      .def("tl.cute.swizzle_recast",
+           [](const Swizzle &swizzle, int old_bits, int new_bits) {
+             return swizzle.Recast(old_bits, new_bits);
+           })
+      // -- IntTuple leaf builders ----------------------------------------
+      .def("tl.cute.make_int_const",
+           [](int64_t value) { return IntTuple(value); })
+      .def("tl.cute.make_int_expr",
+           [](PrimExpr value) { return IntTuple(std::move(value)); })
+      .def("tl.cute.make_scaled_basis",
+           [](IntTuple value, Array<int64_t> basis) {
+             return IntTupleScaledBasis(std::move(value), std::move(basis));
+           })
+      // Build an IntTupleTuple branch from already-built children (for
+      // hierarchical shape/stride trees).
+      .def("tl.cute.make_int_tuple_tuple",
+           [](Array<IntTuple> fields) {
+             return IntTuple(IntTupleTuple(std::move(fields)));
+           })
+      // -- IntTuple arithmetic -------------------------------------------
+      .def("tl.cute.int_tuple_add",
+           [](const IntTuple &a, const IntTuple &b) { return a + b; })
+      .def("tl.cute.int_tuple_mul",
+           [](const IntTuple &a, const IntTuple &b) { return a * b; })
+      .def("tl.cute.product", [](const IntTuple &t) { return Product(t); })
+      // -- Layout constructor + accessors --------------------------------
+      // Build a (possibly hierarchical / dynamic) layout from congruent
+      // shape/stride IntTuple trees.
+      .def("tl.cute.make_layout",
+           [](IntTuple shape, IntTuple stride) {
+             return Layout(std::move(shape), std::move(stride));
+           })
+      .def("tl.cute.layout_get",
+           [](const Layout &layout, int64_t index) { return layout[index]; })
+      // coord is an IntTuple: a scalar leaf for a single linear index, or a
+      // hierarchical coordinate (CuTe crd2idx).
+      .def("tl.cute.layout_eval",
+           [](const Layout &layout, const IntTuple &coord) {
+             return layout(coord);
+           })
+      .def("tl.cute.layout_shape",
+           [](const Layout &layout) { return layout->shape; })
+      .def("tl.cute.layout_stride",
+           [](const Layout &layout) { return layout->stride; })
+      // -- Layout algebra (header order) ---------------------------------
+      .def("tl.cute.layout_rank",
+           [](const Layout &layout) { return Rank(layout); })
+      .def("tl.cute.flatten",
+           [](const Layout &layout) { return Flatten(layout); })
+      .def("tl.cute.layout_size",
+           [](const Layout &layout) { return Size(layout); })
+      .def("tl.cute.coalesce",
+           [](const Layout &layout) { return Coalesce(layout); })
+      .def("tl.cute.right_inverse",
+           [](const Layout &layout) { return RightInverse(layout); })
+      .def("tl.cute.composition",
+           [](const Layout &lhs, const Layout &rhs) {
+             return Composition(lhs, rhs);
+           })
+      .def("tl.cute.coalesce_max",
+           [](const Layout &layout, int64_t max_extent) {
+             return Coalesce(layout, max_extent);
+           })
+      // -- Make*Layout ----------------------------------------------------
+      .def("tl.cute.make_column_major_layout",
+           [](const IntTuple &shape) { return MakeColumnMajorLayout(shape); })
+      .def("tl.cute.make_row_major_layout",
+           [](const IntTuple &shape) { return MakeRowMajorLayout(shape); })
+      .def("tl.cute.make_identity_layout",
+           [](const IntTuple &shape) { return MakeIdentityLayout(shape); })
+      // -- ComposedLayout -------------------------------------------------
+      .def("tl.cute.composed_layout_recast",
+           [](const ComposedLayout &layout, int old_bits, int new_bits) {
+             return layout.Recast(old_bits, new_bits);
+           })
+      // -- TileLang -> CuTe recovery -------------------------------------
+      .def("tl.cute.layout_from_tilelang",
+           [](const tvm::tl::Layout &layout) {
+             return LayoutFromTileLang(layout);
+           })
+      .def("tl.cute.composed_layout_from_tilelang",
+           [](const tvm::tl::Layout &layout) {
+             return ComposedLayoutFromTileLang(layout);
+           });
+}
+
+} // namespace cute
+} // namespace tl
+} // namespace tvm

--- a/src/layout/cute_layout.h
+++ b/src/layout/cute_layout.h
@@ -1,0 +1,520 @@
+/*!
+ * \file cute_layout.h
+ * \brief CuTe-style layout IR types for TileLang.
+ */
+
+#ifndef TVM_TL_LAYOUT_CUTE_LAYOUT_H_
+#define TVM_TL_LAYOUT_CUTE_LAYOUT_H_
+
+#include "support/check.h"
+#include <tvm/ffi/container/array.h>
+#include <tvm/ffi/object.h>
+#include <tvm/ffi/reflection/registry.h>
+#include <tvm/runtime/base.h>
+#include <tvm/tirx/buffer.h>
+
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace tvm {
+namespace tl {
+
+// Forward declaration: the TileLang layout (defined in layout.h).
+class Layout;
+
+namespace cute {
+
+using namespace ffi;
+using namespace tirx;
+
+// A generic CUTLASS/CuTe-style XOR swizzle, described by three bit-field
+// parameters (b_bits, m_base, s_shift):
+//
+// 0bxxxxxxxxxxxxxxxYYYxxxxxxxZZZxxxx
+//                               ^--^ m_base  (least-significant bits kept
+//                               fixed)
+//                  ^-^       ^-^     b_bits   (number of mask bits)
+//                    ^---------^     s_shift  (distance YYY is shifted onto
+//                    ZZZ)
+//
+// apply(x) = x ^ ((x & yyy_msk) >> s_shift)
+class SwizzleNode : public Object {
+public:
+  int b_bits{0};
+  int m_base{0};
+  int s_shift{0};
+
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.cute.Swizzle", SwizzleNode, Object);
+
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<SwizzleNode>()
+        .def_ro("b_bits", &SwizzleNode::b_bits)
+        .def_ro("m_base", &SwizzleNode::m_base)
+        .def_ro("s_shift", &SwizzleNode::s_shift);
+  }
+
+  // Whether the layout actually applies an XOR swizzle. An identity layout has
+  // b_bits == 0 and is not swizzled.
+  bool IsSwizzled() const { return b_bits > 0; }
+
+  /// Whether this swizzle can be lowered to TMA instructions.
+  /// TMA only supports unswizzled, 32B, 64B, and 128B swizzling.
+  /// @pre this should be recast to byte addresses.
+  bool IsTMACompatible() const {
+    if (!IsSwizzled()) {
+      return true;
+    }
+    // 128B: S<3, 4, 3>
+    // 64B:  S<2, 4, 3>
+    // 32B:  S<1, 4, 3>
+    return m_base == 4 && s_shift == 3 && b_bits >= 1 && b_bits <= 3;
+  }
+
+  // The span of one swizzle period: 2^(m_base + b_bits). For the TMA atoms
+  // <b,4,3> this is the CUtensorMap swizzle size (32/64/128 B for b = 1/2/3).
+  int64_t Granularity() const { return int64_t(1) << (m_base + b_bits); }
+
+  // Apply the swizzle to a physical offset: ZZZ ^= YYY.
+  int64_t Apply(int64_t offset) const;
+};
+
+class Swizzle : public ObjectRef {
+public:
+  TVM_DLL Swizzle(int b_bits, int m_base, int s_shift);
+
+  // A non-swizzle.
+  static Swizzle Identity() { return Swizzle(0, 0, 0); }
+
+  // Reinterpret the swizzle when the underlying buffer is viewed as a different
+  // element type.
+  TVM_DLL Swizzle Recast(int old_bits, int new_bits) const;
+
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Swizzle, ObjectRef, SwizzleNode);
+};
+
+// A hierarchical CuTe IntTuple.
+// A tuple can have multiple children.
+// A leaf can encode a constant (int64_t), a dynamic value (PrimExpr), or a
+// scaled basis (for describing hierarchical strides, 1@0 etc.).
+class IntTupleNode : public Object {
+public:
+  static constexpr uint32_t _type_child_slots = 4;
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind =
+      kTVMFFISEqHashKindTreeNode;
+  TVM_FFI_DECLARE_OBJECT_INFO("tl.cute.IntTuple", IntTupleNode, Object);
+};
+
+class IntTuple : public ObjectRef {
+public:
+  // Creates a static integer.
+  TVM_DLL IntTuple(int64_t value);
+
+  // Creates a either static or dynamic integer, based on the PrimExpr's value.
+  TVM_DLL IntTuple(PrimExpr value);
+
+  // The i-th child. A leaf has rank 1 and only index 0 is allowed.
+  TVM_DLL IntTuple operator[](int64_t index) const;
+
+  // Element-wise sum.
+  TVM_DLL friend IntTuple operator+(const IntTuple &a, const IntTuple &b);
+  IntTuple &operator+=(const IntTuple &other) {
+    *this = *this + other;
+    return *this;
+  }
+
+  // The product. The product of two tuples is dot-product.
+  TVM_DLL friend IntTuple operator*(const IntTuple &a, const IntTuple &b);
+  IntTuple &operator*=(const IntTuple &other) {
+    *this = *this * other;
+    return *this;
+  }
+
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IntTuple, ObjectRef, IntTupleNode);
+};
+
+// A constant integer.
+class IntTupleConstNode : public IntTupleNode {
+public:
+  int64_t value{0};
+
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.cute.IntTupleConst", IntTupleConstNode,
+                                    IntTupleNode);
+
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<IntTupleConstNode>().def_ro("value",
+                                                &IntTupleConstNode::value);
+  }
+};
+
+class IntTupleConst : public IntTuple {
+public:
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IntTupleConst, IntTuple,
+                                             IntTupleConstNode);
+};
+
+// A dynamic (runtime-valued) integer, carrying a PrimExpr.
+class IntTuplePrimExprNode : public IntTupleNode {
+public:
+  PrimExpr value;
+
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.cute.IntTuplePrimExpr",
+                                    IntTuplePrimExprNode, IntTupleNode);
+
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<IntTuplePrimExprNode>().def_ro(
+        "value", &IntTuplePrimExprNode::value);
+  }
+};
+
+class IntTuplePrimExpr : public IntTuple {
+public:
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IntTuplePrimExpr, IntTuple,
+                                             IntTuplePrimExprNode);
+};
+
+// A CuTe ScaledBasis: value * E<basis...>.
+class IntTupleScaledBasisNode : public IntTupleNode {
+public:
+  IntTuple value;
+  Array<int64_t> basis;
+
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.cute.IntTupleScaledBasis",
+                                    IntTupleScaledBasisNode, IntTupleNode);
+
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<IntTupleScaledBasisNode>()
+        .def_ro("value", &IntTupleScaledBasisNode::value)
+        .def_ro("basis", &IntTupleScaledBasisNode::basis);
+  }
+};
+
+class IntTupleScaledBasis : public IntTuple {
+public:
+  // Pre: `value` is a scalar leaf (IsConst or IsPrimExpr), not a tuple.
+  TVM_DLL IntTupleScaledBasis(IntTuple value, Array<int64_t> basis);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IntTupleScaledBasis, IntTuple,
+                                             IntTupleScaledBasisNode);
+};
+
+inline IntTupleScaledBasis E(Array<int64_t> basis) {
+  return IntTupleScaledBasis(IntTuple(1), std::move(basis));
+}
+
+// A tuple.
+class IntTupleTupleNode : public IntTupleNode {
+public:
+  Array<IntTuple> fields;
+
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.cute.IntTupleTuple", IntTupleTupleNode,
+                                    IntTupleNode);
+
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<IntTupleTupleNode>().def_ro("fields",
+                                                &IntTupleTupleNode::fields);
+  }
+};
+
+class IntTupleTuple : public IntTuple {
+public:
+  TVM_DLL explicit IntTupleTuple(Array<IntTuple> fields);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IntTupleTuple, IntTuple,
+                                             IntTupleTupleNode);
+};
+
+inline bool IsConst(const IntTuple &t) {
+  return t.as<IntTupleConstNode>() != nullptr;
+}
+inline bool IsPrimExpr(const IntTuple &t) {
+  return t.as<IntTuplePrimExprNode>() != nullptr;
+}
+inline bool IsScaledBasis(const IntTuple &t) {
+  return t.as<IntTupleScaledBasisNode>() != nullptr;
+}
+inline bool IsTuple(const IntTuple &t) {
+  return t.as<IntTupleTupleNode>() != nullptr;
+}
+
+inline int64_t AsConst(const IntTuple &t) {
+  const auto *c = t.as<IntTupleConstNode>();
+  ICHECK(c != nullptr) << "AsConst on a non-constant leaf";
+  return c->value;
+}
+inline PrimExpr AsPrimExpr(const IntTuple &t) {
+  const auto *e = t.as<IntTuplePrimExprNode>();
+  ICHECK(e != nullptr) << "AsPrimExpr on a non-PrimExpr leaf";
+  return e->value;
+}
+inline PrimExpr AsConstOrPrimExpr(const IntTuple &t, const DataType &dtype) {
+  if (const auto *c = t.as<IntTupleConstNode>())
+    return IntImm(dtype, c->value);
+  const auto *e = t.as<IntTuplePrimExprNode>();
+  ICHECK(e != nullptr) << "AsConstOrPrimExpr on a non-leaf";
+  return e->value;
+}
+inline IntTupleScaledBasis AsScaledBasis(const IntTuple &t) {
+  const auto *b = t.as<IntTupleScaledBasisNode>();
+  ICHECK(b != nullptr) << "AsScaledBasis on a non-ScaledBasis leaf";
+  return GetRef<IntTupleScaledBasis>(b);
+}
+inline IntTuple BasisValue(const IntTuple &t) {
+  return AsScaledBasis(t)->value;
+}
+inline Array<int64_t> BasisPath(const IntTuple &t) {
+  return AsScaledBasis(t)->basis;
+}
+inline IntTupleTuple AsTuple(const IntTuple &t) {
+  const auto *a = t.as<IntTupleTupleNode>();
+  ICHECK(a != nullptr) << "AsTuple on a leaf";
+  return GetRef<IntTupleTuple>(a);
+}
+inline Array<IntTuple> TupleFields(const IntTuple &t) {
+  return AsTuple(t)->fields;
+}
+
+// Select a child by a basis (ScaledBasis indexing).
+TVM_DLL IntTuple BasisGet(const Array<int64_t> &path, const IntTuple &t);
+
+// The rank, or number of children, of an IntTuple. For a leaf, the rank is 1.
+TVM_DLL int64_t Rank(const IntTuple &t);
+
+/// Product of all leaf values.
+TVM_DLL IntTuple Product(const IntTuple &t);
+
+/// Flatten a tree into a IntTupleTuple of leaves.
+/// A leaf flattens to itself.
+/// @post depth <= 1.
+TVM_DLL IntTuple Flatten(const IntTuple &t);
+
+/// Wrap an IntTuple into a tuple.
+/// @post IsTuple(result).
+TVM_DLL IntTupleTuple Wrap(const IntTuple &t);
+
+// Checks if two IntTuple's are congruent: whether their tree structure
+// matches -- same nesting and same rank at every branch.
+TVM_DLL bool Congruent(const IntTuple &a, const IntTuple &b);
+
+// Higher-order function mapping each leaf by `f`.
+template <class F> IntTuple TransformLeaf(const IntTuple &t, F &&f) {
+  if (!IsTuple(t))
+    return f(t);
+  const auto *a = t.as<IntTupleTupleNode>();
+  Array<IntTuple> out;
+  out.reserve(a->fields.size());
+  for (const auto &child : a->fields)
+    out.push_back(TransformLeaf(child, f));
+  return IntTupleTuple(out);
+}
+
+// Higher-order function reducing all the leaves by `f`.
+template <class Acc, class F>
+Acc FoldLeaves(const IntTuple &t, Acc init, F &&f) {
+  if (!IsTuple(t))
+    return f(std::move(init), t);
+  const auto *a = t.as<IntTupleTupleNode>();
+  for (const auto &child : a->fields)
+    init = FoldLeaves(child, std::move(init), f);
+  return init;
+}
+
+// A hierarchical CuTe layout.
+// `shape` and `stride` are congruent IntTuples (same tree structure).
+// NOTE: Aligned with CuTe, this layout is COLUMN-MAJOR.
+//       That is, the first mode is fastest-changing. Pay attention to this when
+//       you are calling operator().
+class LayoutNode : public Object {
+public:
+  IntTuple shape;
+  IntTuple stride;
+
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind =
+      kTVMFFISEqHashKindTreeNode;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.cute.Layout", LayoutNode, Object);
+
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<LayoutNode>()
+        .def_ro("shape", &LayoutNode::shape)
+        .def_ro("stride", &LayoutNode::stride);
+  }
+};
+
+class Layout : public ObjectRef {
+public:
+  // Convenience constructor: static shape, static stride.
+  TVM_DLL Layout(Array<int64_t> shape, Array<int64_t> stride);
+  // Convenience constructor: static shape, dynamic stride.
+  TVM_DLL Layout(Array<int64_t> shape, Array<IntTuple> stride);
+  // Convenience constructor: dynamic shape, dynamic stride.
+  TVM_DLL Layout(Array<IntTuple> shape, Array<IntTuple> stride);
+  // Canonical constructor.
+  TVM_DLL Layout(IntTuple shape, IntTuple stride);
+
+  // Sub-layout.
+  TVM_DLL Layout operator[](int64_t index) const;
+
+  /// Map a single coordinate to a physical index.
+  /// @return a const or an expression; when stride has scaled basis, the result
+  ///         is a tuple.
+  TVM_DLL IntTuple operator()(const IntTuple &coord) const;
+
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Layout, ObjectRef, LayoutNode);
+};
+
+/// Same with IntTuple.
+/// @return the rank of the shape (and stride).
+TVM_DLL int64_t Rank(const Layout &layout);
+
+/// Same with IntTuple.
+/// @return the flattened shape and stride.
+TVM_DLL Layout Flatten(const Layout &layout);
+
+/// The domain size of the shape.
+/// @return Product(layout->shape).
+TVM_DLL IntTuple Size(const Layout &layout);
+
+/// Flatten, and merge adjacent modes that can be composed into one.
+/// A fully collapsed layout is returned as CuTe's scalar mode (1):(0)
+/// @return result(i) == layout(i) for all i < size(result).
+/// @post depth <= 1, no need to flatten again.
+TVM_DLL Layout Coalesce(const Layout &layout);
+
+/// Right-inverse of a layout.
+/// @return layout(result(i)) == i for all i < size(result).
+TVM_DLL Layout RightInverse(const Layout &layout);
+
+/// Composition lhs o rhs.
+/// @return result(c) == lhs(rhs(c)) for all c in the domain of rhs.
+/// @post size(result) == size(rhs).
+/// @note a ScaledBasis rhs stride (value * E<path>) reroutes into the matching
+/// lhs axis.
+TVM_DLL Layout Composition(const Layout &lhs, const Layout &rhs);
+
+/// Same with Coalesce, but caps each merged run at `max_extent`. A run wider
+/// than the cap stays split instead of fusing into one oversized mode.
+/// @post depth <= 1.
+TVM_DLL Layout Coalesce(const Layout &layout, int64_t max_extent);
+
+/// Take a given number of modes from a layout.
+TVM_DLL Layout Take(const Layout &layout, int64_t n);
+
+// Column major layout over `shape`.
+template <typename Container>
+inline Layout MakeColumnMajorLayout(const Container &shape) {
+  int64_t n = shape.size();
+  Array<IntTuple> sh, st;
+  sh.reserve(n);
+  st.reserve(n);
+  IntTuple stride = 1;
+  for (int64_t k = 0; k < n; ++k) {
+    sh.push_back(shape[k]);
+    st.push_back(stride);
+    stride *= shape[k];
+  }
+  return Layout(std::move(sh), std::move(st));
+}
+
+// Row major layout over `shape`.
+template <typename Container>
+inline Layout MakeRowMajorLayout(const Container &shape) {
+  int64_t n = shape.size();
+  Array<IntTuple> sh(n, IntTuple()), st(n, IntTuple());
+  IntTuple stride = 1;
+  for (int64_t k = n - 1; k >= 0; --k) {
+    sh.Set(k, shape[k]);
+    st.Set(k, stride);
+    stride *= shape[k];
+  }
+  return Layout(std::move(sh), std::move(st));
+}
+
+// Identity layout over `shape`: per-axis unit ScaledBases E<k>.
+template <typename Container>
+inline Layout MakeIdentityLayout(const Container &shape) {
+  // Each mode k carries the unit basis E<k>, so the layout maps a coordinate to
+  // itself, tagged by which axis it came from (CuTe make_identity_layout).
+  int64_t n = shape.size();
+  Array<IntTuple> sh, st;
+  for (int64_t k = 0; k < n; ++k) {
+    sh.push_back(shape[k]);
+    st.push_back(E({k}));
+  }
+  return Layout(sh, st);
+}
+
+// Column major layout over `shape`.
+TVM_DLL Layout MakeColumnMajorLayout(const IntTuple &shape);
+
+// Row major layout over `shape`.
+TVM_DLL Layout MakeRowMajorLayout(const IntTuple &shape);
+
+// Identity layout over `shape`: per-axis unit ScaledBases.
+TVM_DLL Layout MakeIdentityLayout(const IntTuple &shape);
+
+// A CuTe ComposedLayout of the form Swizzle o offset o Layout.
+// Evaluating at x yields swizzle.apply(offset + layout(x)).
+class ComposedLayoutNode : public Object {
+public:
+  Swizzle swizzle;
+  int64_t offset{0};
+  Layout layout;
+
+  static constexpr TVMFFISEqHashKind _type_s_eq_hash_kind =
+      kTVMFFISEqHashKindTreeNode;
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.cute.ComposedLayout",
+                                    ComposedLayoutNode, Object);
+
+  static void RegisterReflection() {
+    namespace refl = tvm::ffi::reflection;
+    refl::ObjectDef<ComposedLayoutNode>()
+        .def_ro("swizzle", &ComposedLayoutNode::swizzle)
+        .def_ro("offset", &ComposedLayoutNode::offset)
+        .def_ro("layout", &ComposedLayoutNode::layout);
+  }
+
+  /// Map a single linear coordinate: Sw(offset + layout(coord)).
+  /// @pre: the layout is constant.
+  int64_t operator()(int64_t coord) const {
+    return swizzle->Apply(offset + AsConst(layout(IntTuple(coord))));
+  }
+};
+
+class ComposedLayout : public ObjectRef {
+public:
+  TVM_DLL ComposedLayout(Swizzle swizzle, int64_t offset, Layout layout);
+
+  // Recast into a different element width: the swizzle's m_base shifts (see
+  // Swizzle::Recast) and the strides/offset scale by old_bits/new_bits.
+  TVM_DLL ComposedLayout Recast(int old_bits, int new_bits) const;
+
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(ComposedLayout, ObjectRef,
+                                             ComposedLayoutNode);
+};
+
+/// Recover an affine TileLang layout as a cute::Layout.
+/// @return result(coords) == layout(coords)
+/// @return nullopt if the address is not purely affine (e.g. it has a swizzle,
+///         a non-zero base offset, or a non-constant extent).
+Optional<Layout> LayoutFromTileLang(const tvm::tl::Layout &layout);
+
+/// Recover a possibly swizzled and offset TileLang layout as a
+/// cute::ComposedLayout.
+/// @return result(coords) == layout(coords)
+/// @return nullopt if the recovery fails, e.g. the TileLang layout contains
+///         dynamic values, or the analyzer is unable to prove the equivalence
+///         between a cute::ComposedLayout and the TileLang layout.
+/// @note Addresses are element-offset positions; recast with
+///       `.Recast(dtype.bits(), 8)` for the byte-address uses.
+Optional<ComposedLayout>
+ComposedLayoutFromTileLang(const tvm::tl::Layout &layout);
+
+} // namespace cute
+} // namespace tl
+} // namespace tvm
+
+#endif // TVM_TL_LAYOUT_CUTE_LAYOUT_H_

--- a/testing/python/kernel/test_tilelang_kernel_gemm_simt.py
+++ b/testing/python/kernel/test_tilelang_kernel_gemm_simt.py
@@ -19,8 +19,7 @@ def make_swizzle_layout(shared_buf):
         return T.Layout(shape, lambda *args: args)
 
     def transform_func(i, j):
-        new_warp_i, new_warp_j = get_swizzle_layout(i, j, shape[-1], dtype)
-        return [new_warp_i, new_warp_j]
+        return list(get_swizzle_layout(i, j, shape[-1], dtype))
 
     return T.Layout(shape, transform_func)
 

--- a/testing/python/layout/test_tilelang_cute.py
+++ b/testing/python/layout/test_tilelang_cute.py
@@ -1,0 +1,643 @@
+import pytest
+
+import tilelang.testing
+import tvm
+from tvm import tirx
+
+from tilelang.layout import Layout
+from tilelang.layout import cute
+from tilelang.layout.swizzle import (
+    make_full_bank_swizzled_layout,
+    make_half_bank_swizzled_layout,
+    make_quarter_bank_swizzled_layout,
+)
+from tilelang.intrinsics import make_mma_swizzle_layout
+
+tilelang.testing.set_random_seed()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _swizzle(mode):
+    """The (b_bits, m_base, s_shift) triple of a ComposedLayout's swizzle."""
+    sw = mode.swizzle
+    return (sw.b_bits, sw.m_base, sw.s_shift)
+
+
+def _assert_struct(actual, shape, stride):
+    """Assert a flat layout structurally equals make_layout(shape, stride)."""
+    assert tvm.ir.structural_equal(actual, cute.make_layout(shape, stride=stride)), f"{actual} != {cute.make_layout(shape, stride=stride)}"
+
+
+def _assert_same_fn(result, ref):
+    """Assert two layouts are the same function: equal domain size and equal
+    image at every coordinate. Works for hierarchical results that cannot be
+    constructed with the flat make_layout."""
+    assert cute.size(result) == cute.size(ref), f"size {cute.size(result)} != {cute.size(ref)}"
+    for i in range(cute.size(ref)):
+        assert result(i) == ref(i), f"at {i}: {result(i)} != {ref(i)}"
+
+
+def _build_swizzled_layout(shape, intermediate_fn, b_bits, m_base, s_shift):
+    """A single-output Layout whose forward index swizzles a bijective pow2
+    intermediate address, applying the swizzle exactly as SwizzleNode::Apply:
+    apply(x) = x ^ ((x & yyy) >> s_shift), with yyy = mask << (m_base + s_shift)
+    and mask = (1 << b_bits) - 1."""
+
+    def forward(*vars):
+        addr = intermediate_fn(*vars)
+        mask = (1 << b_bits) - 1
+        yyy = mask << (m_base + s_shift)
+        return addr ^ ((addr & yyy) >> s_shift)
+
+    return Layout(shape, forward)
+
+
+# ---------------------------------------------------------------------------
+# IntTuple: construction, unpacking, and CuTe arithmetic (operator + / *).
+# ---------------------------------------------------------------------------
+def test_int_tuple_scalar_arithmetic():
+    # Scalars add and multiply their values; 0 is the additive identity.
+    assert cute.to_python(cute.from_python(3) + cute.from_python(4)) == 7
+    assert cute.to_python(cute.from_python(3) * cute.from_python(4)) == 12
+    assert cute.to_python(cute.from_python(5) + 0) == 5  # operand coercion + identity
+    assert cute.to_python(2 * cute.from_python(6)) == 12  # __rmul__
+
+
+def test_int_tuple_tuple_arithmetic():
+    # Tuple + tuple adds component-wise; the shorter operand is zero-padded.
+    a = cute.from_python([2, 3])
+    assert cute.to_python(a + cute.from_python([4, 5])) == (6, 8)
+    assert cute.to_python(a + cute.from_python([10])) == (12, 3)  # (2,3)+(10,) -> (12,3)
+
+
+def test_int_tuple_scaled_basis_arithmetic():
+    # ScaledBasis terms expand to ArithmeticTuples and add (CuTe
+    # as_arithmetic_tuple): same axis sums into one slot, distinct axes spread.
+    same = cute.from_python(cute.E(0)) + cute.from_python(cute.ScaledBasis(2, 0))
+    assert cute.to_python(same) == (3,)  # 1@0 + 2@0 -> (1)+(2) -> (3)
+    spread = cute.from_python(cute.E(0)) + cute.from_python(cute.E(1))
+    assert cute.to_python(spread) == (1, 1)  # 1@0 + 1@1 -> (1)+(0,1) -> (1,1)
+
+
+def test_from_python_roundtrips_to_python():
+    # from_python is the inverse of to_python for nested shapes.
+    assert cute.to_python(cute.from_python([2, (3, 4)])) == (2, (3, 4))
+    # A layout exposes its shape/stride as raw IntTuples for algebra.
+    L = cute.make_layout((2, 3))
+    assert L.shape == (2, 3)
+    assert L.stride == (1, 2)
+
+
+# ---------------------------------------------------------------------------
+# make_layout / make_identity_layout / accessors:
+# rank, size, layout[idx], layout(coord), flatten, flatten_to_tuple.
+# ---------------------------------------------------------------------------
+def test_make_layout_default_stride_is_column_major():
+    # Omitting stride yields the compact column-major stride (mode 0 fastest).
+    assert tvm.ir.structural_equal(cute.make_layout((4, 8)), cute.make_column_major_layout((4, 8)))
+    _assert_struct(cute.make_layout((4, 8)), (4, 8), (1, 4))
+
+
+def test_make_identity_layout_strides_are_unit_basis():
+    # Each identity stride is the unit basis E<k>.
+    L = cute.make_layout((4, 4), stride=(cute.E(0), cute.E(1)))
+    assert tvm.ir.structural_equal(L, cute.make_identity_layout((4, 4)))
+    for k, s in enumerate(L.stride):
+        assert isinstance(s, cute.ScaledBasis) and s.value == 1 and s.mode == (k,)
+
+
+def test_make_layout_nested_column_row_identity():
+    # Column/row-major and identity over a nested shape produce congruent nested
+    # strides (CuTe compact_col_major / compact_row_major / make_identity_layout).
+    assert tvm.ir.structural_equal(cute.make_column_major_layout((2, (2, 2))), cute.make_layout((2, (2, 2)), stride=(1, (2, 4))))
+    assert tvm.ir.structural_equal(cute.make_row_major_layout((2, (2, 2))), cute.make_layout((2, (2, 2)), stride=(4, (2, 1))))
+    # Identity maps each linear coord to its full nested idx2crd coordinate.
+    I = cute.make_identity_layout((2, (2, 2)))
+    assert I.shape == (2, (2, 2))
+    assert [I(c) for c in range(8)] == [(c % 2, (c // 2 % 2, c // 4)) for c in range(8)]
+    # Dynamic extents thread through the makers.
+    n = tvm.tirx.Var("n", "int32")
+    assert tvm.ir.structural_equal(cute.make_column_major_layout((n, 4)), cute.make_layout((n, 4), stride=(1, n)))
+
+
+def test_scaled_basis_and_int_expr_strides():
+    # A non-unit ScaledBasis stride round-trips its scale and mode.
+    (sb,) = cute.make_layout((2,), stride=(cute.ScaledBasis(64, 1),)).stride
+    assert isinstance(sb, cute.ScaledBasis) and sb.value == 64 and sb.mode == (1,)
+    # A dynamic (PrimExpr) stride round-trips structurally.
+    s = tvm.tirx.Var("s", "int32")
+    (leaf,) = cute.make_layout((8,), stride=(s,)).stride
+    assert tvm.ir.structural_equal(leaf, s)
+
+
+def test_rank_size_getitem_flatten():
+    L = cute.make_layout((4, 8), stride=(8, 1))
+    assert cute.rank(L) == 2 and cute.size(L) == 32
+    # layout[idx] is the i-th sublayout (a single mode unpacks to a scalar).
+    assert L[0].shape == 4 and L[0].stride == 8
+    assert L[1].shape == 8 and L[1].stride == 1
+    # flatten of an already-flat layout is itself.
+    assert tvm.ir.structural_equal(cute.flatten(L), L)
+
+
+def test_size_and_product():
+    # size() is the domain of a Layout / ComposedLayout; product() is the leaf
+    # product of a raw shape (flat, nested, or a scalar).
+    assert cute.size(cute.make_layout((4, 8))) == 32
+    assert cute.product((4, 8)) == 32
+    assert cute.product((2, (2, 2))) == 8
+    assert cute.product(5) == 5
+    # Both thread PrimExprs for dynamic extents.
+    n = tvm.tirx.Var("n", "int32")
+    assert tvm.ir.structural_equal(cute.product((n, 4)), n * 4)
+    assert tvm.ir.structural_equal(cute.size(cute.make_layout((n, 4), stride=(1, n))), n * 4)
+
+
+def test_eval_plain_is_scalar():
+    # layout(coord): idx2crd (mode 0 fastest) dotted with the strides.
+    L = cute.make_layout((4, 8), stride=(8, 1))
+    assert [L(c) for c in range(4)] == [0, 8, 16, 24]
+    assert L(4) == 1 and L(7) == 25 and isinstance(L(4), int)
+
+
+def test_eval_tuple_coord():
+    # crd2idx accepts a hierarchical coordinate (CuTe crd2idx_ttt), congruent to
+    # the shape: layout((c0, c1)) == c0*stride0 + c1*stride1.
+    L = cute.make_layout((4, 8), stride=(8, 1))
+    assert L((1, 1)) == 9 and L((3, 7)) == 31
+    assert all(L((c % 4, c // 4)) == L(c) for c in range(32))
+    # Nested shape/stride with a nested coordinate.
+    H = cute.make_layout((2, (2, 2)), stride=(1, (2, 4)))
+    assert H((1, (1, 1))) == 1 + 2 + 4
+    assert all(H(c) == H((c % 2, (c // 2 % 2, c // 4))) for c in range(8))
+
+
+def test_eval_dynamic_shape_and_stride():
+    # Neither shape nor stride need be constant: crd2idx threads PrimExprs.
+    s = tvm.tirx.Var("s", "int32")
+    L = cute.make_layout((4,), stride=(s,))
+    assert tvm.ir.structural_equal(L(2), 2 * s)
+    assert tvm.ir.structural_equal(L((3,)), 3 * s)
+    # Dynamic extent: the mode is sized by a Var.
+    n = tvm.tirx.Var("n", "int32")
+    D = cute.make_layout((n, 4), stride=(1, n))
+    assert tvm.ir.structural_equal(D((2, 1)), 2 + n)
+
+
+def test_eval_basis_is_coordinate_tuple():
+    # ScaledBasis strides make layout(coord) a coordinate: crd_k * (v@path)
+    # lands v*crd_k in slot `path`, same-path contributions summing.
+    ident = cute.make_identity_layout((4, 4))
+    assert [ident(c) for c in range(16)] == [(c % 4, c // 4) for c in range(16)]
+    # Permuted axes route mode k into the slot its basis names.
+    perm = cute.make_layout((2, 3), stride=(cute.E(1), cute.E(0)))
+    assert perm(5) == (2, 1)  # crd=(1,2): 1@slot1, 2@slot0
+    # Same path on both modes sums into one slot; a single touched axis stays
+    # a (1-)tuple, never a bare scalar.
+    same = cute.make_layout((2, 2), stride=(cute.E(0), cute.ScaledBasis(2, 0)))
+    assert all(same(c) == (c,) for c in range(4))
+
+
+def test_flatten_to_tuple_collapses_hierarchy():
+    # A hierarchical composition result flattens to a flat tuple of leaves.
+    R = cute.composition(cute.make_layout((8, 8), stride=(8, 1)), cute.make_layout((2, 4), stride=(1, 4)))
+    assert cute.flatten_to_tuple(R.shape) == tuple(int(s) for s in cute.flatten(R).shape)
+    assert len(cute.flatten_to_tuple(R.shape)) == len(cute.flatten_to_tuple(R.stride))
+
+
+# ---------------------------------------------------------------------------
+# coalesce: ported from CuTe pycute test_coalesce (flat cases). coalesce never
+# changes layout(i), and a full collapse yields the scalar (1):(0).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "shape,stride",
+    [
+        ((1,), (0,)),
+        ((1,), (1,)),
+        ((2, 4), (1, 2)),
+        ((2, 4, 6), (1, 2, 8)),
+        ((2, 4, 6), (1, 6, 2)),
+        ((2, 1, 6), (1, 7, 2)),
+        ((2, 1, 6), (4, 7, 8)),
+        ((2, 4), (4, 1)),
+        ((2, 4, 6), (24, 6, 1)),
+        ((2, 1, 3), (2, 4, 4)),
+        # Hierarchical operands (ported from CuTe pycute test_coalesce).
+        ((2, (4, 6)), None),  # default (compact column-major) nested stride
+        (((2, 2), (2, 2)), ((1, 4), (8, 32))),
+    ],
+)
+def test_coalesce_preserves_function(shape, stride):
+    L = cute.make_layout(shape, stride=stride)
+    _assert_same_fn(cute.coalesce(L), L)
+
+
+def test_coalesce_structural_results():
+    # Contiguous bit-modes fuse to one; non-contiguous stay split; a fully
+    # size-1 layout collapses to the scalar (1):(0).
+    _assert_struct(cute.coalesce(cute.make_layout((2, 2, 2, 2, 2), stride=(1, 2, 4, 8, 16))), (32,), (1,))
+    _assert_struct(cute.coalesce(cute.make_layout((8, 8), stride=(64, 1))), (8, 8), (64, 1))
+    _assert_struct(cute.coalesce(cute.make_layout((1, 1), stride=(5, 7))), (1,), (0,))
+    # A nested layout flattens, then fuses the contiguous (2,2):(1,4) prefix into
+    # one mode while the gapped last mode stays split (CuTe pycute coalesce).
+    _assert_struct(cute.coalesce(cute.make_layout(((2, 2), (2, 2)), stride=((1, 4), (8, 32)))), (2, 4, 2), (1, 4, 32))
+
+
+# ---------------------------------------------------------------------------
+# right_inverse: ported from CuTe pycute test_right_inverse (flat cases).
+# Defining property: layout(inv(i)) == i for all i < size(inv).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "shape,stride",
+    [
+        ((1,), (0,)),
+        ((1, 1), (0, 0)),
+        ((3, 7), (0, 0)),
+        ((1,), (1,)),
+        ((4,), (0,)),
+        ((4,), (1,)),
+        ((4,), (2,)),
+        ((2, 4), (0, 2)),
+        ((8, 4), (1, 8)),
+        ((8, 4), (4, 1)),
+        ((2, 4, 6), (1, 2, 8)),
+        ((2, 4, 6), (4, 1, 8)),
+        ((4, 2), (1, 16)),
+        ((64, 8), (1, 64)),
+    ],
+)
+def test_right_inverse(shape, stride):
+    L = cute.make_layout(shape, stride=stride)
+    inv = cute.right_inverse(L)
+    for i in range(cute.size(inv)):
+        assert L(inv(i)) == i
+
+
+# ---------------------------------------------------------------------------
+# composition: ported from CuTe pycute test_composition (flat cases).
+# Defining property: (A o B)(i) == A(B(i)) for all i; size(A o B) == size(B).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "ashape,astride,bshape,bstride",
+    [
+        ((1,), (0,), (1,), (0,)),
+        ((1,), (1,), (1,), (1,)),
+        ((4,), (1,), (4,), (1,)),
+        ((4,), (2,), (4,), (1,)),
+        ((4,), (0,), (4,), (1,)),
+        ((4,), (1,), (2,), (2,)),
+        ((4,), (2,), (2,), (2,)),
+        ((12,), (1,), (4, 3), (3, 1)),
+        ((12,), (1,), (2, 3), (2, 4)),
+        ((12,), (2,), (4, 3), (1, 4)),
+        ((4, 3), (1, 4), (12,), (1,)),
+        ((4, 3), (1, 4), (6,), (2,)),
+        ((4, 3), (3, 1), (12,), (1,)),
+        ((4, 3), (3, 1), (6, 2), (2, 1)),
+        ((4, 8), (8, 1), (8, 4), (1, 8)),
+        ((2, 3, 4), (1, 2, 6), (6, 4), (1, 6)),
+        ((64, 8), (8, 1), (8, 64), (1, 8)),
+        ((8, 8), (8, 1), (2, 4), (1, 4)),
+        ((4, 8, 2), (1, 4, 32), (8,), (2,)),
+        # LHS contiguous only after coalescing (coalesce_x with a scalar
+        # coprofile before the peel).
+        ((2, 2), (1, 2), (4,), (1,)),
+        ((4, 4), (1, 4), (8,), (1,)),
+        ((3, 4), (1, 3), (6,), (1,)),
+        # RHS reaches past the LHS domain via a trailing size-1 LHS mode (only
+        # coalesce_x's shape-2 sentinel keeps the trailing slot).
+        ((4, 1), (1, 0), (4,), (1,)),
+        ((8, 1), (1, 0), (8,), (1,)),
+        # Hierarchical operands (ported from CuTe pycute test_composition).
+        ((8, 8), (8, 1), ((2, 2, 2), (2, 2, 2)), ((1, 16, 4), (8, 2, 32))),
+        (((4, 2),), ((1, 16),), (4, 2), (2, 1)),
+        ((4, 8, 2), (2, 8, 1), (2, 2, 2), (1, 8, 2)),
+        ((4, 6, 8), (1, 4, 7), (6,), (1,)),
+        ((4, 6, 8, 10), (2, 3, 5, 7), (6,), (12,)),
+        # Nested LHS composed with a flat RHS (the lhs tree is addressed by the
+        # rhs's reach, not its own rank).
+        (((2, 2, 2), (2, 2, 2)), ((1, 16, 4), (8, 2, 32)), (8,), (4,)),
+        # Default (compact column-major) LHS stride composed with a nested RHS.
+        ((8, 8), None, ((2, 2, 2), (2, 2, 2)), ((1, 16, 4), (8, 2, 32))),
+        # Both operands rank-3, RHS reorders/strides into the LHS modes.
+        ((4, 8, 2), (2, 8, 1), (4, 2, 2), (2, 8, 1)),
+    ],
+)
+def test_composition_matches_bruteforce(ashape, astride, bshape, bstride):
+    A = cute.make_layout(ashape, stride=astride)
+    B = cute.make_layout(bshape, stride=bstride)
+    R = cute.composition(A, B)
+    # (A o B)(i) == A(B(i)) for all i; size(A o B) == size(B).
+    assert cute.size(R) == cute.size(B)
+    for i in range(cute.size(B)):
+        assert R(i) == A(B(i))
+
+
+def test_composition_structural_results():
+    # Structural checks for results whose RHS reaches past the LHS domain (CuTe
+    # extends the last mode linearly, so the brute-force oracle -- which wraps --
+    # cannot validate these): (4):(1) o (4):(2) == (4):(2).
+    _assert_struct(cute.composition(cute.make_layout((4,), stride=(1,)), cute.make_layout((4,), stride=(2,))), (4,), (2,))
+    # A row-major LHS sub-block: (4,3):(3,1) o (12):(1) flattens to (4,3):(3,1).
+    R = cute.composition(cute.make_layout((4, 3), stride=(3, 1)), cute.make_layout((12,), stride=(1,)))
+    assert cute.flatten_to_tuple(R.shape) == (4, 3)
+    assert cute.flatten_to_tuple(R.stride) == (3, 1)
+
+
+def test_composition_scaled_basis_routing():
+    # A ScaledBasis RHS routes each result mode into the LHS axis its path
+    # names (basis_get), independent of mode order. E(1),E(0) swaps axes, so the
+    # result strides follow the routing -> structurally [4,8]:[100,10].
+    A = cute.make_layout((8, 4), stride=(10, 100))
+    B = cute.make_layout((4, 8), stride=(cute.E(1), cute.E(0)))
+    _assert_struct(cute.composition(A, B), (4, 8), (100, 10))
+    # The identity RHS over [4,4] selects the [4,4] sub-block of A.
+    A2 = cute.make_layout((16, 16), stride=(1, 16))
+    R = cute.composition(A2, cute.make_identity_layout((4, 4)))
+    _assert_struct(R, (4, 4), (1, 16))
+
+
+def test_composition_scaled_basis_dynamic_strides():
+    # Identity RHS routes each mode into the matching LHS axis, so the result
+    # strides are the LHS's dynamic strides s_m, s_n (the is_scaled_basis branch).
+    s_m, s_n = tvm.tirx.Var("s_m", "int32"), tvm.tirx.Var("s_n", "int32")
+    R = cute.composition(cute.make_layout((16, 16), stride=(s_m, s_n)), cute.make_identity_layout((4, 4)))
+    assert R.shape == (4, 4)
+    sm, sn = R.stride
+    assert tvm.ir.structural_equal(sm, s_m) and tvm.ir.structural_equal(sn, s_n)
+
+
+def test_right_inverse_composition_smem_to_gmem():
+    # The TMA building block: composing a GMEM layout with the inverse of a SMEM
+    # layout yields a SMEM-address -> GMEM-address map.
+    smem = cute.make_layout((8, 64), stride=(64, 1))
+    gmem = cute.make_layout((8, 64), stride=(1024, 1))
+    composite = cute.composition(gmem, cute.right_inverse(smem))
+    for c in range(cute.product((8, 64))):
+        assert composite(smem(c)) == gmem(c)
+
+
+def test_tma_box_validity_via_composite():
+    # Coalesce(GMEM o RightInverse(SMEM)) decides TMA-expressibility: its
+    # innermost stride must be 1. Row-major SMEM passes; transposed fails.
+    gmem = cute.make_layout((8, 64), stride=(256, 1))
+    ok = cute.coalesce(cute.composition(gmem, cute.right_inverse(cute.make_layout((8, 64), stride=(64, 1)))))
+    bad = cute.coalesce(cute.composition(gmem, cute.right_inverse(cute.make_layout((8, 64), stride=(1, 8)))))
+    assert list(ok.stride)[0] == 1
+    assert list(bad.stride)[0] != 1
+
+
+# ---------------------------------------------------------------------------
+# Layout.from_tilelang: recover a plain affine layout (no swizzle, zero offset),
+# else None.
+# ---------------------------------------------------------------------------
+def test_layout_from_tilelang_affine():
+    L = cute.Layout.from_tilelang(Layout((16, 128), lambda i, j: i * 128 + j))
+    assert L is not None
+    _assert_struct(L, (16, 128), (128, 1))
+
+
+def test_layout_from_tilelang_rejects_swizzle():
+    swz = _build_swizzled_layout((64, 512), lambda i, j: i * 512 + j, 3, 3, 3)
+    assert cute.Layout.from_tilelang(swz) is None
+
+
+# ---------------------------------------------------------------------------
+# ComposedLayout.from_tilelang: recover a Swizzle over an affine layout.
+# Bank swizzles are Sw<b, 4, 3> in byte space (b = 1/2/3 for 32/64/128B).
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "maker,b_bits",
+    [
+        (make_quarter_bank_swizzled_layout, 1),
+        (make_half_bank_swizzled_layout, 2),
+        (make_full_bank_swizzled_layout, 3),
+    ],
+)
+def test_real_bank_swizzles(maker, b_bits):
+    # continuous = vector_size * 2^b columns (float16 => vector_size 8).
+    buf = tirx.decl_buffer((8, 8 * (1 << b_bits)), "float16", name="A", scope="shared")
+    mode = cute.ComposedLayout.from_tilelang(maker(buf), buf)
+    assert mode is not None and _swizzle(mode) == (b_bits, 4, 3)
+
+
+@pytest.mark.parametrize("dtype", ["int8", "float16", "float32"])
+def test_bank_swizzle_mbase_is_byte_invariant(dtype):
+    # m_base is 4 in byte space for every dtype (the swizzle acts at a fixed
+    # 128-bit vector granularity): int8 (4+0), float16 (3+1), float32 (2+2).
+    vector_size = 128 // int(tvm.DataType(dtype).bits)
+    buf = tirx.decl_buffer((8, vector_size * 8), dtype, name="A", scope="shared")
+    mode = cute.ComposedLayout.from_tilelang(make_full_bank_swizzled_layout(buf), buf)
+    assert mode is not None and _swizzle(mode) == (3, 4, 3)
+
+
+@pytest.mark.parametrize("lead", [2, 3, 5])
+def test_expanded_layout_with_nonpow2_leading_dim(lead):
+    # ExpandLayout2D prepends a (possibly non-pow2) batch dim; the trailing
+    # swizzled tile is still detected.
+    layout = make_full_bank_swizzled_layout(tirx.decl_buffer((8, 64), "float16", name="A", scope="shared")).expand([lead])
+    buf = tirx.decl_buffer((lead, 8, 64), "float16", name="A", scope="shared")
+    mode = cute.ComposedLayout.from_tilelang(layout, buf)
+    assert mode is not None and _swizzle(mode) == (3, 4, 3)
+
+
+# make_mma_swizzle_layout is the canonical bank swizzle Sw<b, 4, 3>: the shift
+# stays 3 (8-row period) and b follows the 16B-vector count per row -- full(8)/
+# half(4)/quarter(2) -> b=3/2/1. Wider rows keep b=3 (the block index tiles into
+# an outer mode), so every case stays hardware-expressible.
+@pytest.mark.parametrize(
+    "dtype,cols,b_bits",
+    [
+        ("float16", 32, 2),
+        ("float16", 64, 3),
+        ("float16", 128, 3),
+        ("float16", 256, 3),
+        ("float32", 32, 3),
+        ("float32", 64, 3),
+        ("int8", 64, 2),
+        ("int8", 128, 3),
+    ],
+)
+def test_mma_swizzle_layout(dtype, cols, b_bits):
+    buf = tirx.decl_buffer((16, cols), dtype, name="A", scope="shared")
+    mode = cute.ComposedLayout.from_tilelang(make_mma_swizzle_layout(buf), buf)
+    assert mode is not None and _swizzle(mode) == (b_bits, 4, 3)
+
+
+@pytest.mark.parametrize("cols", [192, 384, 576])
+def test_mma_swizzle_nonpow2_columns(cols):
+    # A non-pow2 column count (e.g. head_dim 192 = 64*3) tiles the swizzle into
+    # an outer mode of non-pow2 extent. The decoder must still find the swizzle,
+    # which lives in the addressable low pow2 prefix of the column dim -- probing
+    # only pow2-extent dims would miss it (regression: gqa_bwd TMA copy, PR #2380).
+    buf = tirx.decl_buffer((128, cols), "float16", name="A", scope="shared")
+    mode = cute.ComposedLayout.from_tilelang(make_mma_swizzle_layout(buf), buf)
+    assert mode is not None and _swizzle(mode) == (3, 4, 3)
+
+
+def test_mma_swizzle_smooth_is_linear():
+    # is_smooth=True yields an identity layout, which is linear (not swizzled).
+    buf = tirx.decl_buffer((16, 64), "float16", name="A", scope="shared")
+    mode = cute.ComposedLayout.from_tilelang(make_mma_swizzle_layout(buf, is_smooth=True), buf)
+    assert mode is not None and not mode.swizzle.is_swizzled
+
+
+def test_core_is_dtype_agnostic_and_buffer_recasts():
+    # The no-buffer core reports m_base in element-offset bits (3 for float16's
+    # vector_size 8); the buffer overload recasts it to byte-space 4.
+    buf = tirx.decl_buffer((8, 64), "float16", name="A", scope="shared")
+    layout = make_full_bank_swizzled_layout(buf)
+    assert _swizzle(cute.ComposedLayout.from_tilelang(layout)) == (3, 3, 3)
+    assert _swizzle(cute.ComposedLayout.from_tilelang(layout, buf)) == (3, 4, 3)
+
+
+def test_recast_method():
+    # Recast shifts m_base by log2(old) - log2(new); b_bits / s_shift preserved.
+    mode = cute.ComposedLayout.from_tilelang(_build_swizzled_layout((64, 512), lambda i, j: (j % 64) + i * 64 + (j // 64) * 4096, 3, 3, 3))
+    assert _swizzle(mode) == (3, 3, 3)
+    assert _swizzle(mode.recast(16, 8)) == (3, 4, 3)  # smaller elem -> m_base += 1
+    assert _swizzle(mode.recast(32, 8)) == (3, 5, 3)  # m_base += 2
+    assert _swizzle(mode.recast(16, 16)) == (3, 3, 3)  # same width -> no-op
+
+
+def test_recast_linear_is_noop():
+    mode = cute.ComposedLayout.from_tilelang(Layout((16, 128), lambda i, j: i * 128 + j))
+    assert not mode.swizzle.is_swizzled
+    assert _swizzle(mode.recast(32, 8)) == (0, 0, 0)
+
+
+@pytest.mark.parametrize("OFFSET", [4096, 5 * 4096, 8192 + 4096])
+def test_swizzle_with_nonzero_base_offset(OFFSET):
+    # A swizzle over a high, disjoint base offset: the base is carried as the
+    # ComposedLayout offset (offset = Sw(A(0))), not baked into the strides.
+    mode = cute.ComposedLayout.from_tilelang(_build_swizzled_layout((8, 64), lambda i, j: OFFSET + i * 64 + j, 3, 3, 3))
+    assert mode is not None and _swizzle(mode) == (3, 3, 3)
+    assert mode.offset == OFFSET
+
+
+@pytest.mark.parametrize(
+    "b_bits,m_base,s_shift",
+    [(b, m, s) for b in (1, 2, 3) for m in (0, 2, 4) for s in (1, 3, 4) if s >= b],
+)
+def test_synthetic_swizzle_sweep(b_bits, m_base, s_shift):
+    # Recovery is exact across many (b, m, s) on a clean row-major intermediate.
+    # Only s >= b (non-overlapping source/target), as in real swizzles.
+    W = m_base + s_shift + b_bits + 1
+    n_rows = 1 << (W - 3) if W > 3 else 1
+    mode = cute.ComposedLayout.from_tilelang(_build_swizzled_layout((n_rows, 8), lambda i, j: i * 8 + j, b_bits, m_base, s_shift))
+    assert mode is not None and _swizzle(mode) == (b_bits, m_base, s_shift)
+
+
+@pytest.mark.parametrize(
+    "shape,fwd",
+    [
+        ((16, 128), lambda i, j: i * 128 + j),  # row-major linear
+        ((8, 8), lambda i, j: j * 8 + i),  # permutation (no XOR)
+        ((3, 8), lambda i, j: i * 8 + j),  # non-pow2 leading dim, linear
+    ],
+)
+def test_linear_layouts_detected_as_unswizzled(shape, fwd):
+    # Linear / permutation layouts are recovered with b_bits == 0 (distinct from
+    # the not-detectable None case).
+    mode = cute.ComposedLayout.from_tilelang(Layout(shape, fwd))
+    assert mode is not None and _swizzle(mode) == (0, 0, 0)
+
+
+def test_general_pow2_dim_with_nonpow2_high_stride():
+    # A pow2-SIZE dim may carry a non-pow2 STRIDE in high bits that is NOT a
+    # swizzle source; the detector isolates the inner swizzle and keeps the high
+    # strides in the residual layout.
+    TILE = 8 * 64
+
+    def addr(a, b, i, j):
+        inner = (j % 8) + ((i % 8) ^ ((j // 8) % 8)) * 8 + i * 64
+        return a * (3 * TILE) + b * TILE + inner
+
+    mode = cute.ComposedLayout.from_tilelang(Layout((2, 3, 8, 64), addr))
+    assert mode is not None and _swizzle(mode) == (3, 3, 3)
+    strides = list(mode.layout.stride)
+    assert 1536 in strides and 512 in strides  # outer high strides untouched
+
+
+def test_nonpow2_leading_size_with_swizzled_inner_tile():
+    # A non-pow2 leading SIZE dim is a pass-through; the inner swizzle is still
+    # recovered and the batch dim becomes a residual atom.
+    def addr(batch, i, j):
+        return batch * (8 * 64) + (j % 8) + ((i % 8) ^ ((j // 8) % 8)) * 8 + i * 64
+
+    mode = cute.ComposedLayout.from_tilelang(Layout((5, 8, 64), addr))
+    assert mode is not None and _swizzle(mode) == (3, 3, 3)
+    assert 5 in list(mode.layout.shape) and 512 in list(mode.layout.stride)
+
+
+def test_broadcast_stride_zero_is_recovered():
+    # A stride-0 (broadcast) mode is a valid affine layout (8,8):(0,1), not a
+    # failure: recovery returns it unswizzled rather than rejecting it.
+    mode = cute.ComposedLayout.from_tilelang(Layout((8, 8), lambda i, j: j))
+    assert mode is not None and _swizzle(mode) == (0, 0, 0)
+    _assert_struct(mode.layout, (8, 8), (0, 1))
+
+
+def test_nonlinear_not_detectable():
+    # A genuinely non-affine map (i*j is not a linear function of the coords)
+    # cannot be recovered as a swizzle-over-affine layout, so it returns None.
+    assert cute.ComposedLayout.from_tilelang(Layout((8, 8), lambda i, j: i * j)) is None
+
+
+def test_non_constant_extent_rejected():
+    # A symbolic extent has no fixed-width bit map; ICHECK requires constant.
+    n = tvm.tirx.Var("n", "int32")
+    with pytest.raises(Exception, match="must be constant"):
+        cute.ComposedLayout.from_tilelang(Layout((n, 8), lambda i, j: i * 8 + j))
+
+
+# ---------------------------------------------------------------------------
+# End-to-end TMA copy with an explicitly-written swizzled layout. The forward
+# index gives the design's full-bank (128B) swizzle address:
+#   (j % 8) + ((i % 8) ^ ((j // 8) % 8)) * 8 + i * 64 + (j // 64) * 4096
+# ToCuteComposedLayout decodes it to Sw<3,4,3> and LowerBulk drives a swizzled
+# TMA load; the box truncates at the first non-contiguous global mode so the
+# rest replays as 8 unrolled tma_load calls.
+# ---------------------------------------------------------------------------
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_tma_load_with_explicit_swizzled_layout():
+    import torch
+    import tilelang
+    import tilelang.language as T
+
+    M, N = 64, 512
+
+    def swizzled_addr(i, j):
+        return (j % 8) + ((i % 8) ^ ((j // 8) % 8)) * 8 + i * 64 + (j // 64) * 4096
+
+    @T.prim_func
+    def copy_swizzled(X: T.Tensor((M, N), "float16"), ok: T.Tensor((M, N), "int32")):
+        with T.Kernel(1, threads=128) as _:
+            S = T.alloc_shared((M, N), "float16")
+            T.annotate_layout({S: Layout((M, N), swizzled_addr)})
+            T.copy(X, S, prefer_instruction="tma")
+            # Reading S[i, j] must return the value originally at X[i, j], since
+            # annotate_layout changes only physical storage, not the logical map.
+            for i, j in T.Parallel(M, N):
+                ok[i, j] = T.if_then_else(S[i, j] == T.cast((i * N + j) % 2048, "float16"), 1, 0)
+
+    buf = tirx.decl_buffer((M, N), "float16", name="S", scope="shared")
+    mode = cute.ComposedLayout.from_tilelang(Layout((M, N), swizzled_addr), buf)
+    assert mode is not None and _swizzle(mode) == (3, 4, 3)
+
+    kernel = tilelang.compile(copy_swizzled, out_idx=[1])
+    src = kernel.get_kernel_source()
+    assert src.count("tma_load(") == 8, "expected 8 (unrolled) TMA loads"
+
+    ii = torch.arange(M, device="cuda").view(M, 1)
+    jj = torch.arange(N, device="cuda").view(1, N)
+    X = ((ii * N + jj) % 2048).to(torch.float16)
+    ok = kernel(X)
+    assert int(ok.min()) == 1, f"{(ok == 0).sum().item()} shared elements mismatched"
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/cuda/intrinsics/layout/mma_layout.py
+++ b/tilelang/cuda/intrinsics/layout/mma_layout.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from tvm import arith, DataType
+from tvm import DataType
 import tilelang.language as T
 
 
@@ -201,7 +201,6 @@ def shared_32x16_to_mma_32x16_smoothlayout(i, j):
 
 
 def get_swizzle_layout(row_idx, col_idx, row_size, dtype: DataType | str, swizzle_bytes=None):
-    ana = arith.Analyzer()
     if isinstance(dtype, str):
         dtype = DataType(dtype)
     row_bytes = dtype.bits * row_size // 8
@@ -220,22 +219,26 @@ def get_swizzle_layout(row_idx, col_idx, row_size, dtype: DataType | str, swizzl
     #   0  1  2  3  4  5  6  7    ==>    6  7  4  5  2  3  0  1
     #   0  1  2  3  4  5  6  7    ==>    7  6  5  4  3  2  1  0
     # 64B swizzle
-    #  Use 8 * 4 permuted layout
-    #  Every number below corresponds to 16B
-    #  0  1  2  3  4  0  1  2  3    ==>    0  1  2  3  0  1  2  3
-    #  0  1  2  3  4  0  1  2  3    ==>    1  0  3  2  1  0  3  2
-    #  0  1  2  3  4  0  1  2  3    ==>    2  3  0  1  2  3  0  1
-    #  0  1  2  3  4  0  1  2  3    ==>    3  2  1  0  3  2  1  0
+    #   Use 8 * 4 permuted layout
+    #   Every number below corresponds to 16B
+    #   0  1  2  3  0  1  2  3    ==>    0  1  2  3  0  1  2  3
+    #   0  1  2  3  0  1  2  3    ==>    1  0  3  2  1  0  3  2
+    #   0  1  2  3  0  1  2  3    ==>    2  3  0  1  2  3  0  1
+    #   0  1  2  3  0  1  2  3    ==>    3  2  1  0  3  2  1  0
     # 32B swizzle
-    #  Use 8 * 2 permuted layout
-    #  Every number below corresponds to 16B
-    #  0  1  2  3  4  5  6  7    ==>    0  1  2  3  4  5  6  7
-    #  0  1  2  3  4  5  6  7    ==>    1  0  3  2  5  4  7  6
+    #   Use 8 * 2 permuted layout
+    #   Every number below corresponds to 16B
+    #   0  1  0  1  0  1  0  1    ==>    0  1  0  1  0  1  0  1
+    #   0  1  0  1  0  1  0  1    ==>    1  0  1  0  1  0  1  0
     elem_per_16B = 128 // dtype.bits
+    swizzle_vectors = int(swizzle_bytes) // 16
     col_idx_16B = col_idx // elem_per_16B
     col_idx_in_16B = col_idx % elem_per_16B
-    new_col_idx_16B = col_idx_16B ^ (row_idx % (swizzle_bytes // 16))
-    return row_idx, ana.simplify(new_col_idx_16B * elem_per_16B + col_idx_in_16B)
+    col_tile = col_idx_16B // swizzle_vectors
+    c = col_idx_16B % swizzle_vectors
+    src = (row_idx % 8) // (8 // swizzle_vectors)
+    swizzled_col = (c ^ src) * elem_per_16B + col_idx_in_16B
+    return col_tile, row_idx, swizzled_col
 
 
 def make_mma_swizzle_layout(shared_buf, is_smooth: bool = False):
@@ -248,7 +251,6 @@ def make_mma_swizzle_layout(shared_buf, is_smooth: bool = False):
 
     def transform_func(*args):
         i, j = args[-2:]
-        new_warp_i, new_warp_j = get_swizzle_layout(i, j, shape[-1], dtype)
-        return [*args[:-2], new_warp_i, new_warp_j]
+        return [*args[:-2], *get_swizzle_layout(i, j, shape[-1], dtype)]
 
     return T.Layout(shape, transform_func)

--- a/tilelang/layout/__init__.py
+++ b/tilelang/layout/__init__.py
@@ -17,3 +17,4 @@ from .swizzle import (
     make_fully_replicated_layout_fragment,  # noqa: F401
 )
 from .gemm_sp import make_cutlass_metadata_layout  # noqa: F401
+from . import cute  # noqa: F401  (registers tl.cute.* FFI objects on import)

--- a/tilelang/layout/_cute_ffi_api.py
+++ b/tilelang/layout/_cute_ffi_api.py
@@ -1,0 +1,12 @@
+"""FFI APIs for the CuTe layout-algebra namespace.
+
+The C++ side registers all CuTe-layout functions under the dotted ``tl.cute.*``
+namespace (which the flat ``tilelang._ffi_api`` module skips, since its remaining
+name still contains a dot). Initializing a module against the ``tl.cute`` prefix
+strips it cleanly, surfacing ``coalesce``, ``right_inverse``, ``composition``,
+``make_layout`` etc. as plain attributes (``_cute_ffi_api.coalesce(...)``).
+"""
+
+import tvm_ffi
+
+tvm_ffi.init_ffi_api("tl.cute", __name__)

--- a/tilelang/layout/cute.py
+++ b/tilelang/layout/cute.py
@@ -1,0 +1,220 @@
+"""CuTe layout IR objects and layout-algebra Python API, in TileLang."""
+
+from __future__ import annotations
+
+from itertools import chain
+from typing import Union
+from collections.abc import Sequence
+
+import tvm
+import tvm_ffi
+from tvm.ir import PrimExpr
+from tvm.ir.base import Node
+from tvm.runtime import Scriptable
+
+from tilelang._typing import BufferLikeType
+from . import _cute_ffi_api
+
+PyIntTuple = Union[int, PrimExpr, "ScaledBasis", tuple]
+IntTupleLike = Union[int, PrimExpr, "ScaledBasis", Sequence, "IntTuple"]
+ModeLike = int | Sequence[int]
+
+
+def to_python(t: IntTuple) -> PyIntTuple:
+    """Unpack an :class:`IntTuple` into Python: a branch becomes a nested ``tuple``, and each leaf becomes a plain ``int`` (static), a PrimExpr (dynamic), or a :class:`ScaledBasis` (basis stride)."""
+    if isinstance(t, IntTupleTuple):
+        return tuple(to_python(c) for c in t.fields)
+    if isinstance(t, IntTupleConst):
+        return int(t.value)
+    if isinstance(t, IntTuplePrimExpr):
+        return t.value
+    if isinstance(t, IntTupleScaledBasis):
+        return ScaledBasis(to_python(t.value), tuple(t.basis))
+    raise TypeError(f"not an IntTuple: {t!r}")
+
+
+def from_python(value: IntTupleLike) -> IntTuple:
+    """Convert a Python value to an FFI :class:`IntTuple` (the inverse of :func:`to_python`): a nested tuple/list becomes an :class:`IntTupleTuple` branch; an int becomes :class:`IntTupleConst`; a PrimExpr becomes :class:`IntTuplePrimExpr`; a :class:`ScaledBasis` becomes :class:`IntTupleScaledBasis`; an already-built :class:`IntTuple` passes through."""
+    if isinstance(value, IntTuple):
+        return value
+    if isinstance(value, (tuple, list)):
+        return _cute_ffi_api.make_int_tuple_tuple([from_python(v) for v in value])
+    if isinstance(value, int):
+        return _cute_ffi_api.make_int_const(int(value))
+    if isinstance(value, PrimExpr):
+        return _cute_ffi_api.make_int_expr(value)
+    if isinstance(value, ScaledBasis):
+        return _cute_ffi_api.make_scaled_basis(from_python(value.value), list(value.mode))
+    raise TypeError(f"cannot convert to IntTuple: {value!r}")
+
+
+@tvm_ffi.register_object("tl.cute.Swizzle")
+class Swizzle(Node, Scriptable):
+    b_bits: int
+    m_base: int
+    s_shift: int
+
+    @property
+    def is_swizzled(self) -> bool:
+        return _cute_ffi_api.swizzle_is_swizzled(self)
+
+    def recast(self, old_bits: int, new_bits: int) -> Swizzle:
+        return _cute_ffi_api.swizzle_recast(self, int(old_bits), int(new_bits))
+
+
+@tvm_ffi.register_object("tl.cute.IntTuple")
+class IntTuple(Node, Scriptable):
+    def __add__(self, other: IntTupleLike) -> IntTuple:
+        return _cute_ffi_api.int_tuple_add(self, from_python(other))
+
+    def __radd__(self, other: IntTupleLike) -> IntTuple:
+        return _cute_ffi_api.int_tuple_add(from_python(other), self)
+
+    def __mul__(self, other: IntTupleLike) -> IntTuple:
+        return _cute_ffi_api.int_tuple_mul(self, from_python(other))
+
+    def __rmul__(self, other: IntTupleLike) -> IntTuple:
+        return _cute_ffi_api.int_tuple_mul(from_python(other), self)
+
+
+@tvm_ffi.register_object("tl.cute.IntTupleConst")
+class IntTupleConst(IntTuple):
+    value: int
+
+
+@tvm_ffi.register_object("tl.cute.IntTuplePrimExpr")
+class IntTuplePrimExpr(IntTuple):
+    value: object
+
+
+@tvm_ffi.register_object("tl.cute.IntTupleScaledBasis")
+class IntTupleScaledBasis(IntTuple):
+    value: IntTuple
+    basis: list
+
+
+@tvm_ffi.register_object("tl.cute.IntTupleTuple")
+class IntTupleTuple(IntTuple):
+    fields: list
+
+
+class ScaledBasis:
+    """A ScaledBasis wrapper."""
+
+    def __init__(self, value: PyIntTuple, mode: ModeLike):
+        self._value = value
+        self._mode = (mode,) if isinstance(mode, int) else tuple(int(m) for m in mode)
+
+    @property
+    def value(self) -> PyIntTuple:
+        return self._value
+
+    @property
+    def mode(self) -> tuple:
+        return self._mode
+
+    def __repr__(self) -> str:
+        return "@".join([str(self._value), *(str(m) for m in reversed(self._mode))])
+
+
+def E(mode: ModeLike) -> ScaledBasis:
+    return ScaledBasis(1, mode)
+
+
+def product(shape: IntTupleLike) -> PyIntTuple:
+    return to_python(_cute_ffi_api.product(from_python(shape)))
+
+
+def flatten_to_tuple(value: IntTupleLike) -> tuple:
+    if isinstance(value, IntTuple):
+        value = to_python(value)
+    if not isinstance(value, (tuple, list)):
+        return (value,)
+    return tuple(chain.from_iterable(flatten_to_tuple(x) for x in value))
+
+
+@tvm_ffi.register_object("tl.cute.Layout")
+class Layout(Node, Scriptable):
+    @property
+    def shape(self):
+        return to_python(_cute_ffi_api.layout_shape(self))
+
+    @property
+    def stride(self):
+        return to_python(_cute_ffi_api.layout_stride(self))
+
+    def __getitem__(self, idx: int) -> Layout:
+        return _cute_ffi_api.layout_get(self, int(idx))
+
+    def __call__(self, coord: IntTupleLike):
+        return to_python(_cute_ffi_api.layout_eval(self, from_python(coord)))
+
+    @staticmethod
+    def from_tilelang(layout) -> Layout | None:
+        return _cute_ffi_api.layout_from_tilelang(layout)
+
+
+def rank(layout: Layout) -> int:
+    return int(_cute_ffi_api.layout_rank(layout))
+
+
+def flatten(layout: Layout) -> Layout:
+    return _cute_ffi_api.flatten(layout)
+
+
+def size(layout: Layout | ComposedLayout) -> PyIntTuple:
+    if isinstance(layout, ComposedLayout):
+        layout = layout.layout
+    return to_python(_cute_ffi_api.layout_size(layout))
+
+
+def coalesce(layout: Layout, max_extent: int | None = None) -> Layout:
+    if max_extent is None:
+        return _cute_ffi_api.coalesce(layout)
+    return _cute_ffi_api.coalesce_max(layout, int(max_extent))
+
+
+def right_inverse(layout: Layout) -> Layout:
+    return _cute_ffi_api.right_inverse(layout)
+
+
+def composition(lhs: Layout, rhs: Layout) -> Layout:
+    return _cute_ffi_api.composition(lhs, rhs)
+
+
+def make_layout(shape: PyIntTuple, stride=None) -> Layout:
+    if stride is None:
+        return _cute_ffi_api.make_column_major_layout(from_python(shape))
+    return _cute_ffi_api.make_layout(from_python(shape), from_python(stride))
+
+
+def make_column_major_layout(shape: PyIntTuple) -> Layout:
+    return _cute_ffi_api.make_column_major_layout(from_python(shape))
+
+
+def make_row_major_layout(shape: PyIntTuple) -> Layout:
+    return _cute_ffi_api.make_row_major_layout(from_python(shape))
+
+
+def make_identity_layout(shape: PyIntTuple) -> Layout:
+    return _cute_ffi_api.make_identity_layout(from_python(shape))
+
+
+@tvm_ffi.register_object("tl.cute.ComposedLayout")
+class ComposedLayout(Node, Scriptable):
+    swizzle: Swizzle
+    offset: int
+    layout: Layout
+
+    def recast(self, old_bits: int, new_bits: int) -> ComposedLayout:
+        return _cute_ffi_api.composed_layout_recast(self, int(old_bits), int(new_bits))
+
+    @staticmethod
+    def from_tilelang(layout, buffer: BufferLikeType = None) -> ComposedLayout | None:
+        mode = _cute_ffi_api.composed_layout_from_tilelang(layout)
+        if buffer is None or mode is None:
+            return mode
+        from tilelang.layout.swizzle import _get_buffer_info
+
+        _, _, dtype = _get_buffer_info(buffer)
+        return mode.recast(int(tvm.DataType(dtype).bits), 8)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CuTe-style hierarchical layout algebra (including swizzle operations, coordinate mapping, and TileLang recovery) with a new Python API.
  * Enhanced CUDA TMA lowering using more consistent bulk-tile mapping and swizzle-aware compatibility.
* **Bug Fixes**
  * Corrected MMA swizzle layout generation to match expected swizzle mapping output.
  * Improved TMA barrier sizing and rest/loop routing handling for multi-iteration cases.
* **Tests**
  * Added comprehensive unit tests for CuTe semantics, swizzle recovery, and an end-to-end TMA load integration test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->