### PR TITLE
[Transform] Materialize kernel launch per backend

### DIFF
--- a/docs/programming_guides/cluster_tma.md
+++ b/docs/programming_guides/cluster_tma.md
@@ -3,7 +3,7 @@
 This page describes two advanced data-movement features that are available on
 NVIDIA Hopper (SM90) and later: **TMA multicast** and **SM-to-SM cluster
 copy**. Both features are exposed through extensions to the existing `T.copy`
-operator and require a kernel launched with thread block cluster, i.e., with `cluster_dims != (1, 1, 1)`.
+operator and require a kernel launched with `T.ClusterKernel`, i.e., with `cluster_dims != (1, 1, 1)`.
 
 Requirements:
 - CUDA Compute Capability ≥ 9.0 (Hopper / Blackwell / RTX 5090)
@@ -19,7 +19,7 @@ position inside the cluster), and all CTAs can observe each other's shared
 memory via the `shared::cluster` address space.
 
 ```python
-with T.Kernel(grid_x, grid_y, threads=128, cluster_dims=(4, 1, 1)) as (bx, by):
+with T.ClusterKernel(grid_x, grid_y, threads=128, cluster_dims=(4, 1, 1)) as (bx, by):
     rank  = T.block_rank_in_cluster()   # 0..3 within this cluster
     T.cluster_sync()                     # barrier across all CTAs in cluster
 ```
@@ -68,7 +68,7 @@ def make_tma_multicast_kernel(M, N, block_M, block_N, cluster_mask):
         B: T.Tensor((M, N), "float16"),
     ):
         # 4 CTAs per cluster; ranks 0 and 1 share the same tile via multicast.
-        with T.Kernel(
+        with T.ClusterKernel(
             T.ceildiv(N, block_N),
             T.ceildiv(M, block_M),
             threads=128,
@@ -166,7 +166,7 @@ def make_cluster_copy_kernel(N: int):
         A: T.Tensor((N,), "float32"),
         B: T.Tensor((N,), "float32"),
     ):
-        with T.Kernel(2, threads=128, cluster_dims=(2, 1, 1)) as pid:
+        with T.ClusterKernel(2, threads=128, cluster_dims=(2, 1, 1)) as pid:
             s_src     = T.alloc_shared((N,), "float32")
             s_dst     = T.alloc_shared((N,), "float32")
             s_barrier = T.alloc_cluster_barrier([1])
@@ -300,7 +300,7 @@ SM-to-SM copy (saving global-memory round trips).
 ```python
 @T.prim_func
 def split_k_gemm(A, B, C):
-    with T.Kernel(grid_x, grid_y, threads=256, cluster_dims=(4, 1, 1)) as (bx, by):
+    with T.ClusterKernel(grid_x, grid_y, threads=256, cluster_dims=(4, 1, 1)) as (bx, by):
         rank    = T.block_rank_in_cluster()
         A_s     = T.alloc_shared((BM, BK), "float16")
         B_s     = T.alloc_shared((BK, BN), "float16")

--- a/examples/blockscaled_gemm_sm100/gemm_mxfp8_blockscaled_1d1d.py
+++ b/examples/blockscaled_gemm_sm100/gemm_mxfp8_blockscaled_1d1d.py
@@ -201,7 +201,7 @@ def mxfp8_blockscaled_gemm_2cta(
     SFB: T.Tensor[[sf_k_groups * N], T.uint32]
     C = T.empty((M, N), out_dtype)
 
-    with T.Kernel(T.ceildiv(M, block_M), T.ceildiv(N, block_N), threads=128, cluster_dims=2) as (bx, by):
+    with T.ClusterKernel(T.ceildiv(M, block_M), T.ceildiv(N, block_N), threads=128, cluster_dims=2) as (bx, by):
         cta_id = T.block_rank_in_cluster()
         T.assume(cta_id < 2)
 
@@ -356,7 +356,7 @@ def mxfp8_blockscaled_gemm_2cta_persistent(
     group_size = 16  # in cluster
     assert n_blocks % (2 * group_size) == 0  # Please adjust group_size if not satisfied
 
-    with T.Kernel(sm_num, threads=256, cluster_dims=2) as (block_id):
+    with T.ClusterKernel(sm_num, threads=256, cluster_dims=2) as (block_id):
         cta_id = T.block_rank_in_cluster()
         T.assume(cta_id < 2)
 

--- a/examples/blockscaled_gemm_sm100/grouped_gemm_mxfp8_blockscaled_1d1d.py
+++ b/examples/blockscaled_gemm_sm100/grouped_gemm_mxfp8_blockscaled_1d1d.py
@@ -60,7 +60,7 @@ def grouped_mxfp8_blockscaled_gemm_2cta(
     max_M_blocks = T.ceildiv(max_M_per_E, block_M)
     max_M_blocks_padded = T.ceildiv(max_M_blocks, 2) * 2
 
-    with T.Kernel(max_M_blocks_padded, n_blocks, E, threads=128, cluster_dims=2) as (pid_m, pid_n, eid):
+    with T.ClusterKernel(max_M_blocks_padded, n_blocks, E, threads=128, cluster_dims=2) as (pid_m, pid_n, eid):
         cta_id = T.block_rank_in_cluster()
         T.assume(cta_id < 2)
 
@@ -242,7 +242,7 @@ def grouped_mxfp8_blockscaled_gemm_2cta_persistent(
     waves = T.ceildiv(total_cluster_tiles, num_clusters)
     group_size = 8
 
-    with T.Kernel(sm_num, threads=256, cluster_dims=2) as (block_id):
+    with T.ClusterKernel(sm_num, threads=256, cluster_dims=2) as (block_id):
         cta_id = T.block_rank_in_cluster()
         T.assume(cta_id < 2)
 

--- a/examples/blockscaled_gemm_sm100/mxfp8_illustrated.md
+++ b/examples/blockscaled_gemm_sm100/mxfp8_illustrated.md
@@ -18,7 +18,7 @@ one `uint32`.
 | --- | --- | --- | --- | --- |
 | 1CTA | `mxfp8_blockscaled_gemm` | `threads=128` | One CTA computes one logical `block_M x block_N` tile. | Local barriers. Warp 0 loads A/B/SF, warp 1 issues UTCCP and MMA, warp 2 transposes SF in SMEM. |
 | 2CTA | `mxfp8_blockscaled_gemm_2cta` | `threads=128, cluster_dims=2` | A CTA pair computes one logical `128 x 256` tile. | Each peer loads a half-N B panel, A is loaded in both peers, and leader CTA issues `use_2cta=True`. |
-| 2CTA persistent | `mxfp8_blockscaled_gemm_2cta_persistent` | `T.Kernel(sm_num, threads=256, cluster_dims=2)` | Resident CTA pairs walk logical tiles over multiple waves. | Adds a persistent scheduler and dedicated epilogue warpgroup, with `tmem_empty` handing TMEM back to the MMA warp. |
+| 2CTA persistent | `mxfp8_blockscaled_gemm_2cta_persistent` | `T.ClusterKernel(sm_num, threads=256, cluster_dims=2)` | Resident CTA pairs walk logical tiles over multiple waves. | Adds a persistent scheduler and dedicated epilogue warpgroup, with `tmem_empty` handing TMEM back to the MMA warp. |
 
 The grouped kernels reuse the same 2CTA and persistent structure. Their extra
 work is scheduler-side: map `(pid_m, pid_n, eid)` through `offsets`, clamp tail

--- a/examples/deepseek_v4/fp8_fp4_gemm_1d1d_sm100.py
+++ b/examples/deepseek_v4/fp8_fp4_gemm_1d1d_sm100.py
@@ -54,7 +54,7 @@ def fp8_fp4_gemm_1d1d_persistent(
         waves = T.ceildiv(m_blocks * n_blocks, sm_num)
         group_size = 16
 
-        with T.Kernel(sm_num, threads=256, cluster_dims=2) as (block_id):
+        with T.ClusterKernel(sm_num, threads=256, cluster_dims=2) as (block_id):
             cta_id = T.block_rank_in_cluster()
             T.assume(cta_id < 2)
 

--- a/examples/gemm_sm100/gemm_tcgen5mma_ws.py
+++ b/examples/gemm_sm100/gemm_tcgen5mma_ws.py
@@ -79,7 +79,7 @@ def gemm_2cta(A, B, block_M, block_N, block_K, in_dtype, out_dtype, accum_dtype,
     B: T.Tensor[[K, N], in_dtype]
     C = T.empty((M, N), out_dtype)
 
-    with T.Kernel(T.ceildiv(M, block_M), T.ceildiv(N, block_N), threads=128, cluster_dims=2) as (bx, by):
+    with T.ClusterKernel(T.ceildiv(M, block_M), T.ceildiv(N, block_N), threads=128, cluster_dims=2) as (bx, by):
         A_shared = T.alloc_shared((num_stages, block_M, block_K), in_dtype)
         B_shared = T.alloc_shared((num_stages, block_K, block_N // 2), in_dtype)  # Each cta hold half of B
         C_tmem = T.alloc_tmem([block_M, block_N], accum_dtype)

--- a/examples/gemm_sm100/gemm_tcgen5mma_ws_clc.py
+++ b/examples/gemm_sm100/gemm_tcgen5mma_ws_clc.py
@@ -39,7 +39,7 @@ def gemm_clc_persistent_2cta(
     k_blocks = T.ceildiv(K, block_K)
     assert n_blocks % (2 * group_size) == 0
 
-    with T.Kernel(total_cluster_tiles * 2, threads=256, cluster_dims=2) as block_id:
+    with T.ClusterKernel(total_cluster_tiles * 2, threads=256, cluster_dims=2) as block_id:
         A_shared = T.alloc_shared((num_stages, block_M, block_K), in_dtype)
         B_shared = T.alloc_shared((num_stages, block_K, block_N // 2), in_dtype)
         C_tmem_0 = T.alloc_tmem([block_M, block_N], accum_dtype)
@@ -206,7 +206,7 @@ def gemm_clc_persistent_2cta_pipelined_clc(
     k_blocks = T.ceildiv(K, block_K)
     assert n_blocks % (2 * group_size) == 0
 
-    with T.Kernel(total_cluster_tiles * 2, threads=256, cluster_dims=2) as block_id:
+    with T.ClusterKernel(total_cluster_tiles * 2, threads=256, cluster_dims=2) as block_id:
         A_shared = T.alloc_shared((num_stages, block_M, block_K), in_dtype)
         B_shared = T.alloc_shared((num_stages, block_K, block_N // 2), in_dtype)
         C_tmem_0 = T.alloc_tmem([block_M, block_N], accum_dtype)

--- a/examples/gemm_sm100/gemm_tcgen5mma_ws_persistent.py
+++ b/examples/gemm_sm100/gemm_tcgen5mma_ws_persistent.py
@@ -161,7 +161,7 @@ def gemm_persistent_2cta(
     group_size = 8  # in cluster
     assert n_blocks % (2 * group_size) == 0  # Please adjust group_size if not satisfied
 
-    with T.Kernel(sm_num, threads=256, cluster_dims=2) as (block_id):
+    with T.ClusterKernel(sm_num, threads=256, cluster_dims=2) as (block_id):
         A_shared = T.alloc_shared((num_stages, block_M, block_K), in_dtype)
         B_shared = T.alloc_shared((num_stages, block_K, block_N // 2), in_dtype)
         C_tmem_0 = T.alloc_tmem([block_M, block_N], accum_dtype)

--- a/maint/gemm/correctness_evaluation_tcgen05_2cta.py
+++ b/maint/gemm/correctness_evaluation_tcgen05_2cta.py
@@ -24,7 +24,7 @@ def matmul_2cta(
         B: T.Tensor((K, N), in_dtype),
         C: T.Tensor((M, N), out_dtype),
     ):
-        with T.Kernel(T.ceildiv(M, block_M), T.ceildiv(N, block_N), threads=128, cluster_dims=2) as (bx, by):
+        with T.ClusterKernel(T.ceildiv(M, block_M), T.ceildiv(N, block_N), threads=128, cluster_dims=2) as (bx, by):
             A_shared = T.alloc_shared((num_stages, block_M, block_K), in_dtype)
             B_shared = T.alloc_shared((num_stages, block_K, block_N // 2), in_dtype)  # each CTA holds half of B
             C_tmem = T.alloc_tmem([block_M, block_N], accum_dtype)

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -23,37 +23,31 @@ namespace tl {
 using namespace script::ir_builder::tirx;
 using namespace ffi;
 
-static Var CreateEnvThread(String name, String thread_tag, DataType dtype) {
+// Build a ForFrame that emits a target-neutral kThreadBinding loop for one
+// kernel-launch dimension. The launch nest is materialized into the
+// target-specific form (thread_extent AttrStmt on GPU, serial For on CPU) by
+// the tl.MaterializeKernelLaunch pass once the Target is known at compile
+// time.
+static ForFrame MakeThreadBindingFrame(const std::string &name,
+                                       const String &thread_tag,
+                                       const PrimExpr &extent) {
   using namespace tvm::tirx;
-  using namespace tvm::script::ir_builder;
-  IterVar iter_var(Range{nullptr}, Var(std::move(name), dtype),
-                   tvm::tirx::IterVarType::kThreadIndex, std::move(thread_tag));
-  Var var = iter_var->var;
-  if (Optional<PrimFuncFrame> opt_frame =
-          IRBuilder::Current()->FindFrame<PrimFuncFrame>()) {
-    opt_frame.value()->env_threads.Set(var, iter_var);
-  } else {
-    LOG(FATAL) << "EnvThread can only be used inside a PrimFunc";
-  }
-  return var;
-}
-
-static ForFrame MakeIterVarFrame(const std::string &name, const PrimExpr &dom) {
-  using namespace tvm::tirx;
-  Var var = Var(name, dom->dtype);
-  // Create a frame that represents a loop over the given domain.
+  Var var = Var(name, extent->dtype);
   ObjectPtr<ForFrameNode> n = make_object<ForFrameNode>();
   n->vars.push_back(var);
-  n->doms.push_back(Range(0, dom));
-  n->f_make_for_loop = [](const Array<Var> &vars, const Array<Range> &doms,
-                          const Array<Optional<PrimExpr>> &steps,
-                          Stmt body) -> Stmt {
+  n->doms.push_back(Range(make_const(extent->dtype, 0), extent));
+  n->f_make_for_loop =
+      [thread_tag](const Array<Var> &vars, const Array<Range> &doms,
+                   const Array<Optional<PrimExpr>> &steps, Stmt body) -> Stmt {
     ICHECK_EQ(vars.size(), 1);
     ICHECK_EQ(doms.size(), 1);
+    IterVar iter_var(Range{nullptr}, Var(thread_tag, vars[0]->dtype),
+                     IterVarType::kThreadIndex, thread_tag);
     Optional<PrimExpr> step =
         !steps.empty() ? steps[0] : Optional<PrimExpr>(std::nullopt);
-    return For(vars[0], doms[0]->min, doms[0]->extent, ForKind::kSerial, body,
-               /*thread_binding=*/std::nullopt,
+    return For(vars[0], doms[0]->min, doms[0]->extent, ForKind::kThreadBinding,
+               body,
+               /*thread_binding=*/iter_var,
                /*annotations=*/Map<String, Any>{},
                /*step=*/step);
   };
@@ -265,55 +259,23 @@ KernelLaunchFrame KernelLaunch(const Array<PrimExpr> &grid_size,
                                const Map<String, Any> &attrs) {
   ObjectPtr<KernelLaunchFrameNode> n = make_object<KernelLaunchFrameNode>();
 
-  // If the kernel is a CPU kernel, we don't need to launch any threads.
-  bool is_cpu_kernel_frame =
-      attrs.defined() && attrs.count(tilelang_is_cpu_kernel_frame);
-
   auto block_size = block_size_opt.value_or(Array<PrimExpr>());
+  ICHECK(grid_size.size() <= 3);
+  ICHECK(block_size.size() <= 3);
 
-  if (is_cpu_kernel_frame) {
-    // Launch CPU Kernel
-    ICHECK(grid_size.size() >= 0);
-    ICHECK(block_size.empty()) << "CPU kernel cannot have block size";
-    ICHECK(attrs.defined());
-    // create grid loop var
-    for (int i = 0; i < grid_size.size(); i++) {
-      n->frames.push_back(
-          MakeIterVarFrame("block_var_" + std::to_string(i), grid_size[i]));
-    }
-  } else {
-    // Launch GPU Kernel
-    ICHECK(grid_size.size() <= 3);
-    if (!grid_size.empty())
-      n->frames.push_back(LaunchThread(
-          CreateEnvThread("bx", "blockIdx.x", grid_size[0].dtype()),
-          grid_size[0]));
-    if (grid_size.size() > 1)
-      n->frames.push_back(LaunchThread(
-          CreateEnvThread("by", "blockIdx.y", grid_size[1].dtype()),
-          grid_size[1]));
-    if (grid_size.size() > 2)
-      n->frames.push_back(LaunchThread(
-          CreateEnvThread("bz", "blockIdx.z", grid_size[2].dtype()),
-          grid_size[2]));
-    if (block_size.defined()) {
-      ICHECK(block_size.size() <= 3);
-      if (!block_size.empty()) {
-        n->frames.push_back(LaunchThread(
-            CreateEnvThread("tx", "threadIdx.x", block_size[0].dtype()),
-            block_size[0]));
-      }
-      if (block_size.size() > 1) {
-        n->frames.push_back(LaunchThread(
-            CreateEnvThread("ty", "threadIdx.y", block_size[1].dtype()),
-            block_size[1]));
-      }
-      if (block_size.size() > 2) {
-        n->frames.push_back(LaunchThread(
-            CreateEnvThread("tz", "threadIdx.z", block_size[2].dtype()),
-            block_size[2]));
-      }
-    }
+  static const char *kBlockVarNames[3] = {"bx", "by", "bz"};
+  static const char *kBlockTags[3] = {"blockIdx.x", "blockIdx.y", "blockIdx.z"};
+  static const char *kThreadVarNames[3] = {"tx", "ty", "tz"};
+  static const char *kThreadTags[3] = {"threadIdx.x", "threadIdx.y",
+                                       "threadIdx.z"};
+
+  for (size_t i = 0; i < grid_size.size(); i++) {
+    n->frames.push_back(
+        MakeThreadBindingFrame(kBlockVarNames[i], kBlockTags[i], grid_size[i]));
+  }
+  for (size_t i = 0; i < block_size.size(); i++) {
+    n->frames.push_back(MakeThreadBindingFrame(kThreadVarNames[i],
+                                               kThreadTags[i], block_size[i]));
   }
 
   auto empty_block = tvm::script::ir_builder::tirx::Block(DeviceMainBlockName);

--- a/src/transform/common/attr.h
+++ b/src/transform/common/attr.h
@@ -24,9 +24,6 @@ inline bool IsDeviceMainBlock(const tirx::SBlockNode *node) {
   return node->name_hint == DeviceMainBlockName;
 }
 
-constexpr const char *tilelang_is_cpu_kernel_frame =
-    "tilelang.is_cpu_kernel_frame";
-
 namespace attr {
 // Attributes to mark CUDA sync calls
 constexpr const char *kHasTriggerLaunch = "has_cuda_pdl_trigger";

--- a/src/transform/materialize_kernel_launch.cc
+++ b/src/transform/materialize_kernel_launch.cc
@@ -1,0 +1,122 @@
+/*!
+ * \file materialize_kernel_launch.cc
+ * \brief Materialize the target-neutral kernel launch nest emitted by
+ *        T.Kernel into a backend-specific form.
+ *
+ * T.Kernel traces into a nest of For loops with ForKind::kThreadBinding
+ * tagged blockIdx.* / threadIdx.*. This pass runs right after BindTarget
+ * and rewrites the nest according to `lower_thread_binding`, which each
+ * backend pipeline chooses for itself (no target dispatch happens here):
+ *  - lower_thread_binding = true (SIMT backends, e.g. CUDA/ROCm/Metal):
+ *    each launch loop becomes an AttrStmt thread_extent, reusing the loop
+ *    variable so body references stay valid.
+ *  - lower_thread_binding = false (backends without SIMT, e.g. CPU):
+ *    blockIdx.* loops become serial For loops over the grid extent;
+ *    threadIdx.* loops are ignored; they become unit serial loops so the
+ *    loop variable stays defined (pinned to 0) while the requested thread
+ *    extent (e.g. the default threads=128) is dropped.
+ *
+ * Only the outermost contiguous launch nest is converted; thread_binding
+ * loops deeper inside the kernel body (separated by the tilelang_root
+ * block) are left for LowerOpaqueBlock to handle at its usual stage.
+ */
+
+#include "common/attr.h"
+#include "support/check.h"
+#include <tvm/ir/transform.h>
+#include <tvm/runtime/logging.h>
+#include <tvm/tirx/stmt_functor.h>
+#include <tvm/tirx/transform.h>
+
+#include <utility>
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+
+namespace {
+
+bool IsBlockBinding(const ForNode *op) {
+  if (op->kind != ForKind::kThreadBinding || !op->thread_binding.defined())
+    return false;
+  std::string tag = op->thread_binding.value()->thread_tag;
+  return tag.rfind("blockIdx.", 0) == 0;
+}
+
+bool IsThreadBinding(const ForNode *op) {
+  if (op->kind != ForKind::kThreadBinding || !op->thread_binding.defined())
+    return false;
+  std::string tag = op->thread_binding.value()->thread_tag;
+  return tag.rfind("threadIdx.", 0) == 0;
+}
+
+bool IsLaunchBinding(const ForNode *op) {
+  return IsBlockBinding(op) || IsThreadBinding(op);
+}
+
+class KernelLaunchMaterializer : public StmtMutator {
+public:
+  explicit KernelLaunchMaterializer(bool lower_thread_binding)
+      : lower_thread_binding_(lower_thread_binding) {}
+
+  Stmt VisitStmt_(const ForNode *op) final {
+    if (IsLaunchBinding(op)) {
+      return ConvertNest(op);
+    }
+    return StmtMutator::VisitStmt_(op);
+  }
+
+private:
+  // Peel the contiguous launch nest rooted at `op` without descending into
+  // the kernel body below it.
+  Stmt ConvertNest(const ForNode *op) {
+    Stmt body;
+    if (const ForNode *inner = op->body.as<ForNode>();
+        inner && IsLaunchBinding(inner)) {
+      body = ConvertNest(inner);
+    } else {
+      body = op->body;
+    }
+    if (lower_thread_binding_) {
+      ffi::String tag = op->thread_binding.value()->thread_tag;
+      IterVar iter_var(Range::FromMinExtent(op->min, op->extent), op->loop_var,
+                       IterVarType::kThreadIndex, tag);
+      return AttrStmt(std::move(iter_var), tirx::attr::thread_extent,
+                      op->extent, std::move(body));
+    }
+    // No SIMT: grid dims run as plain serial loops; thread dims are ignored
+    // (a unit loop keeps the loop variable defined and pinned to 0).
+    PrimExpr extent = IsThreadBinding(op)
+                          ? PrimExpr(IntImm(op->extent.dtype(), 1))
+                          : op->extent;
+    return For(op->loop_var, op->min, std::move(extent), ForKind::kSerial,
+               std::move(body),
+               /*thread_binding=*/std::nullopt, op->annotations, op->step);
+  }
+
+  bool lower_thread_binding_;
+};
+
+} // namespace
+
+tvm::transform::Pass MaterializeKernelLaunch(bool lower_thread_binding) {
+  using namespace tirx::transform;
+  auto pass_func = [lower_thread_binding](
+                       PrimFunc func, const IRModule &mod,
+                       const tvm::transform::PassContext &ctx) -> PrimFunc {
+    KernelLaunchMaterializer mutator(lower_thread_binding);
+    func.CopyOnWrite()->body = mutator(func->body);
+    return func;
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.MaterializeKernelLaunch", {});
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  refl::GlobalDef().def("tl.transform.MaterializeKernelLaunch",
+                        MaterializeKernelLaunch);
+}
+
+} // namespace tl
+} // namespace tvm

--- a/testing/python/cpu/test_tilelang_cpu_gemm.py
+++ b/testing/python/cpu/test_tilelang_cpu_gemm.py
@@ -14,7 +14,7 @@ def matmul(M, N, K, block_M, block_N, block_K, dtype=T.float16, accum_dtype=T.fl
         B: T.Tensor((K, N), dtype),
         C: T.Tensor((M, N), dtype),
     ):
-        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), is_cpu=True) as (bx, by):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M)) as (bx, by):
             A_local = T.alloc_local((block_M, block_K), dtype)
             B_local = T.alloc_local((block_K, block_N), dtype)
             C_local = T.alloc_local((block_M, block_N), accum_dtype)
@@ -69,7 +69,7 @@ def test_matmul_compile():
             B: T.Tensor((K, N), dtype),
             C: T.Tensor((M, N), dtype),
         ):
-            with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), is_cpu=True) as (bx, by):
+            with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M)) as (bx, by):
                 A_local = T.alloc_local((block_M, block_K), dtype)
                 B_local = T.alloc_local((block_K, block_N), dtype)
                 C_local = T.alloc_local((block_M, block_N), accum_dtype)
@@ -129,7 +129,7 @@ def test_matmul_with_copy_cython():
         B: T.Tensor((K, N), "float32"),
         C: T.Tensor((M, N), "float32"),
     ):
-        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), is_cpu=True) as (bx, by):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M)) as (bx, by):
             A_local = T.alloc_local((block_M, block_K), "float32")
             B_local = T.alloc_local((block_K, block_N), "float32")
             C_local = T.alloc_local((block_M, block_N), "float32")

--- a/testing/python/cpu/test_tilelang_cpu_tgemm.py
+++ b/testing/python/cpu/test_tilelang_cpu_tgemm.py
@@ -24,7 +24,7 @@ def matmul(M, N, K, block_M, block_N, block_K, trans_A=False, trans_B=False, dty
         B: T.Tensor(B_shape, dtype),
         C: T.Tensor((M, N), dtype),
     ):
-        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), is_cpu=True) as (bx, by):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M)) as (bx, by):
             A_local = T.alloc_local(A_local_shape, dtype)
             B_local = T.alloc_local(B_local_shape, dtype)
             C_local = T.alloc_local((block_M, block_N), accum_dtype)

--- a/testing/python/cpu/test_tilelang_cpu_while_repro.py
+++ b/testing/python/cpu/test_tilelang_cpu_while_repro.py
@@ -8,7 +8,7 @@ def test_cpu_kernel_source_generation_with_while() -> None:
     See: https://github.com/tile-ai/tilelang/issues/2202
 
     Historically, a CPU kernel containing `T.While(...)` inside
-    `T.Kernel(..., is_cpu=True)` could leak the synthetic fallback thread
+    `T.Kernel(...)` could leak the synthetic fallback thread
     variable `v_thread` into host/device splitting. That in turn caused CPU
     compilation to fail during packed-API generation or later C wrapper
     generation.
@@ -20,7 +20,7 @@ def test_cpu_kernel_source_generation_with_while() -> None:
 
     @T.prim_func
     def main(flag: T.Buffer((1,), "int32"), out: T.Buffer((1,), "int32")):
-        with T.Kernel(1, is_cpu=True):
+        with T.Kernel(1):
             state = T.alloc_fragment((1,), "int32")
             state[0] = 0
 

--- a/testing/python/cuda/test_tma_dsmem.py
+++ b/testing/python/cuda/test_tma_dsmem.py
@@ -13,7 +13,7 @@ def make_store_cluster_kernel(N: int):
         A: T.Tensor((N,), "float32"),
         B: T.Tensor((N,), "float32"),
     ):
-        with T.Kernel(2, threads=128, cluster_dims=(2, 1, 1)) as pid:
+        with T.ClusterKernel(2, threads=128, cluster_dims=(2, 1, 1)) as pid:
             s_src = T.alloc_shared((N,), "float32")
             s_dst = T.alloc_shared((N,), "float32")
             s_barrier = T.alloc_cluster_barrier([1])
@@ -43,7 +43,7 @@ def make_store_cluster_simt_no_barrier_kernel(N: int):
         A: T.Tensor((N,), "float32"),
         B: T.Tensor((N,), "float32"),
     ):
-        with T.Kernel(2, threads=128, cluster_dims=(2, 1, 1)) as pid:
+        with T.ClusterKernel(2, threads=128, cluster_dims=(2, 1, 1)) as pid:
             s_src = T.alloc_shared((N,), "float32")
             s_dst = T.alloc_shared((N,), "float32")
 
@@ -91,7 +91,7 @@ def make_store_cluster_simt_barrier_kernel(M: int, N_full: int, N_tile: int):
         A: T.Tensor((M, N_tile), "float32"),
         B: T.Tensor((M, N_tile), "float32"),
     ):
-        with T.Kernel(2, threads=128, cluster_dims=(2, 1, 1)) as pid:
+        with T.ClusterKernel(2, threads=128, cluster_dims=(2, 1, 1)) as pid:
             # Deliberately wider buffer: N_full > N_tile so the slice
             # [0:M, 0:N_tile] is non-contiguous in row-major storage.
             s_src = T.alloc_shared((M, N_full), "float32")
@@ -226,7 +226,7 @@ def make_store_cluster_3d_multi_tma_kernel(D: int, M: int, N_full: int, N_tile: 
         A: T.Tensor((D, M, N_tile), "float32"),
         B: T.Tensor((D, M, N_tile), "float32"),
     ):
-        with T.Kernel(2, threads=D * M * N_tile, cluster_dims=(2, 1, 1)) as pid:
+        with T.ClusterKernel(2, threads=D * M * N_tile, cluster_dims=(2, 1, 1)) as pid:
             s_src = T.alloc_shared((D, M, N_full), "float32")
             s_dst = T.alloc_shared((D, M, N_full), "float32")
             s_barrier = T.alloc_cluster_barrier([1])

--- a/testing/python/cuda/test_tma_multicast_demo.py
+++ b/testing/python/cuda/test_tma_multicast_demo.py
@@ -12,7 +12,7 @@ def make_tma_multicast_demo_kernel(M, N, block_M, block_N, cluster_mask):
         A: T.Tensor((M, N), "float16"),
         B: T.Tensor((M, N), "float16"),
     ):
-        with T.Kernel(
+        with T.ClusterKernel(
             T.ceildiv(N, block_N),
             T.ceildiv(M, block_M),
             threads=128,

--- a/testing/python/language/test_tilelang_language_cluster.py
+++ b/testing/python/language/test_tilelang_language_cluster.py
@@ -11,7 +11,7 @@ def matmul(M, N, K, block_M, block_N, block_K, dtype=T.float16, accum_dtype=T.fl
         B: T.Tensor((K, N), dtype),
         C: T.Tensor((M, N), dtype),
     ):
-        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128, cluster_dims=(2, 1, 1)) as (bx, by):
+        with T.ClusterKernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128, cluster_dims=(2, 1, 1)) as (bx, by):
             A_shared = T.alloc_shared((block_M, block_K), dtype)
             B_shared = T.alloc_shared((block_K, block_N), dtype)
             C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
@@ -33,7 +33,7 @@ def get_cta_rank_in_cluster(cluster_size=4):
 
     @T.prim_func
     def main(A: T.Tensor((128), T.int32)):
-        with T.Kernel(128, cluster_dims=(cluster_size, 1, 1)) as bx:
+        with T.ClusterKernel(128, cluster_dims=(cluster_size, 1, 1)) as bx:
             T.cluster_arrive()
             T.cluster_wait()
             cta_rank_in_cluster = T.block_rank_in_cluster()
@@ -48,7 +48,7 @@ def get_cta_rank_in_cluster(cluster_size=4):
 def barrier_kernel():
     @T.prim_func
     def main(A: T.Tensor((128), T.int32)):
-        with T.Kernel(128, threads=128, cluster_dims=(4, 1, 1)):
+        with T.ClusterKernel(128, threads=128, cluster_dims=(4, 1, 1)):
             mbar = T.alloc_cluster_barrier([256])
             T.cluster_sync()
             T.mbarrier_arrive(mbar, 0)

--- a/testing/python/transform/test_tilelang_transform_layout_inference.py
+++ b/testing/python/transform/test_tilelang_transform_layout_inference.py
@@ -89,9 +89,11 @@ def test_loop_tail_split(block_M, block_N, block_K, threads, vec_load_b, dtype):
 
     with tvm.target.Target(auto_target):
         mod = tvm.tirx.transform.BindTarget(auto_target)(before())
+        mod = tl.transform.MaterializeKernelLaunch()(mod)
         mod = tl.transform.LayoutInference()(mod)
         mod = tvm.tirx.transform.Simplify()(mod)
         ref_mod = tvm.tirx.transform.BindTarget(auto_target)(after())
+        ref_mod = tl.transform.MaterializeKernelLaunch()(ref_mod)
         ref_mod = tvm.tirx.transform.Simplify()(ref_mod)
         # Note(tzj): The structures are equal except one more "for" loop after the LayoutInference pass
         # This loop is "for vec in T.parallel(1)",

--- a/testing/python/transform/test_tilelang_transform_lower_hopper_intrin.py
+++ b/testing/python/transform/test_tilelang_transform_lower_hopper_intrin.py
@@ -12,10 +12,12 @@ def _check(original, transformed):
     func = original
     mod = tvm.IRModule.from_expr(func.with_attr("global_symbol", "main"))
     mod = tvm.tirx.transform.BindTarget(auto_target)(mod)
+    mod = tl.transform.MaterializeKernelLaunch()(mod)
     mod = cuda_transform.LowerHopperIntrin()(mod)
     mod = tl.transform.LowerOpaqueBlock()(mod)
     transformed = tvm.IRModule.from_expr(transformed.with_attr("global_symbol", "main"))
     transformed = tvm.tirx.transform.BindTarget(auto_target)(transformed)
+    transformed = tl.transform.MaterializeKernelLaunch()(transformed)
     transformed = tl.transform.LowerOpaqueBlock()(transformed)
     transformed["main"] = transformed["main"].with_attr("tma_descriptor_args", {})
 
@@ -39,6 +41,7 @@ def test_lower_shared_barrier():
 
     mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
     mod = tvm.tirx.transform.BindTarget(auto_target)(mod)
+    mod = tl.transform.MaterializeKernelLaunch()(mod)
     mod = cuda_transform.LowerSharedBarrier()(mod)
     mod = tl.transform.LowerOpaqueBlock()(mod)
 
@@ -90,6 +93,7 @@ def test_tma_descriptor_init_after_alloc_global():
 
     mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
     mod = tvm.tirx.transform.BindTarget(auto_target)(mod)
+    mod = tl.transform.MaterializeKernelLaunch()(mod)
     mod = cuda_transform.LowerHopperIntrin()(mod)
     func = mod["main"]
 

--- a/testing/python/transform/test_tilelang_transform_lower_shared_barrier.py
+++ b/testing/python/transform/test_tilelang_transform_lower_shared_barrier.py
@@ -13,6 +13,7 @@ auto_target = tvm.target.Target(determine_target("auto"))
 def _apply(func):
     mod = tvm.IRModule.from_expr(func.with_attr("global_symbol", "main"))
     mod = tvm.tirx.transform.BindTarget(auto_target)(mod)
+    mod = tl.transform.MaterializeKernelLaunch()(mod)
     mod = tl.cuda.transform.LowerSharedBarrier()(mod)
     return mod
 

--- a/testing/python/transform/test_tilelang_transform_lower_shared_tmem.py
+++ b/testing/python/transform/test_tilelang_transform_lower_shared_tmem.py
@@ -11,6 +11,7 @@ TARGET = tvm.target.Target({"kind": "cuda", "arch": "sm_100"})
 def _apply(func):
     mod = tvm.IRModule.from_expr(func.with_attr("global_symbol", "main"))
     mod = tvm.tirx.transform.BindTarget(TARGET)(mod)
+    mod = tl.transform.MaterializeKernelLaunch()(mod)
     mod = tl.cuda.transform.LowerSharedTmem()(mod)
     return mod
 

--- a/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
+++ b/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
@@ -314,6 +314,7 @@ def test_tiled_ws_places_producer_in_first_warp_group():
     mod = tvm.IRModule.from_expr(func)
     target = determine_target({"kind": "cuda", "arch": "sm_90"}, return_object=True)
     mod = tvm.tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.MaterializeKernelLaunch()(mod)
     mod = tilelang.cuda.transform.ProducerConsumerWarpSpecialized()(mod)
     script = mod["main"].script()
 
@@ -548,6 +549,7 @@ def test_tiled_ws_explicit_cp_async_wait_precedes_first_consumer_read():
     mod = tvm.IRModule.from_expr(func)
     target = determine_target({"kind": "cuda", "arch": "sm_90"}, return_object=True)
     mod = tvm.tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.MaterializeKernelLaunch()(mod)
     mod = tilelang.cuda.transform.ProducerConsumerWarpSpecialized()(mod)
     script = mod["main"].script()
 
@@ -586,6 +588,7 @@ def test_tiled_ws_propagates_nested_postloop_liveness_to_outer_prelude():
     mod = tvm.IRModule.from_expr(func)
     target = determine_target({"kind": "cuda", "arch": "sm_90"}, return_object=True)
     mod = tvm.tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.MaterializeKernelLaunch()(mod)
     mod = tilelang.cuda.transform.ProducerConsumerWarpSpecialized()(mod)
     script = mod["main"].script()
 

--- a/testing/python/transform/test_tilelang_transform_split_host_device.py
+++ b/testing/python/transform/test_tilelang_transform_split_host_device.py
@@ -13,6 +13,7 @@ def run_split_host_device_passes(func: tvm.tirx.PrimFunc):
     """Run the necessary passes before and including SplitHostDevice."""
     mod = tvm.IRModule({func.attrs["global_symbol"]: func})
     mod = tvm.tirx.transform.BindTarget(tvm.target.Target("cuda", "c"))(mod)
+    mod = tl.transform.MaterializeKernelLaunch()(mod)
     mod = tl.transform.InjectAssumes()(mod)
     mod = tl.transform.AnnotateDeviceRegions()(mod)
     mod = tl.transform.SplitHostDevice()(mod)

--- a/tilelang/backend/common.py
+++ b/tilelang/backend/common.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from tilelang.backend.execution_backend import ExecutionBackendSpec, register_execution_backend
-from tilelang.backend.pass_pipeline.pipeline import PassPipeline, register_pipeline
-from tilelang.cpu.pipeline import CPUPassPipelineBody
+
+# Importing the package registers its pass pipeline.
+import tilelang.webgpu  # noqa: F401
 
 
-register_pipeline(PassPipeline("webgpu", CPUPassPipelineBody))
 register_execution_backend("webgpu", ExecutionBackendSpec("cython"), override=True)
 register_execution_backend(
     "webgpu",

--- a/tilelang/cpu/pipeline.py
+++ b/tilelang/cpu/pipeline.py
@@ -17,6 +17,7 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
 
 def CPUPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.MaterializeKernelLaunch(lower_thread_binding=False)(mod)
     pass_ctx = tilelang.transform.get_pass_context()
 
     if should_force_let_inline():

--- a/tilelang/cuda/pipeline.py
+++ b/tilelang/cuda/pipeline.py
@@ -67,7 +67,7 @@ def _module_has_shared_barrier(mod: IRModule) -> bool:
 
 def CUDAPassPipelineBodyPrologue(mod: IRModule, target: Target) -> IRModule:
     mod = tirx.transform.BindTarget(target)(mod)
-    mod = tilelang.transform.MaterializeKernelLaunch(lower_thread_binding=True)(mod)
+    mod = tilelang.transform.MaterializeKernelLaunch()(mod)
     if should_force_let_inline():
         # Force-let inline whenever the pass config requests it.
         mod = tilelang.transform.LetInline()(mod)

--- a/tilelang/cuda/pipeline.py
+++ b/tilelang/cuda/pipeline.py
@@ -67,6 +67,7 @@ def _module_has_shared_barrier(mod: IRModule) -> bool:
 
 def CUDAPassPipelineBodyPrologue(mod: IRModule, target: Target) -> IRModule:
     mod = tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.MaterializeKernelLaunch(lower_thread_binding=True)(mod)
     if should_force_let_inline():
         # Force-let inline whenever the pass config requests it.
         mod = tilelang.transform.LetInline()(mod)

--- a/tilelang/language/__init__.py
+++ b/tilelang/language/__init__.py
@@ -30,6 +30,7 @@ from .frame import has_let_value, get_let_value  # noqa: F401
 from .math_intrinsics import *  # noqa: F401
 from .kernel import (
     Kernel,  # noqa: F401
+    ClusterKernel,  # noqa: F401
     CUDASourceCodeKernel,  # noqa: F401
     KernelLaunchFrame,  # noqa: F401
     get_thread_binding,  # noqa: F401

--- a/tilelang/language/eager/ast.py
+++ b/tilelang/language/eager/ast.py
@@ -587,11 +587,11 @@ class DSLMutator(ast.NodeTransformer):
         is_kernel_ctx = False
         for expr in node.items:
             cexpr = expr.context_expr
-            if isinstance(cexpr, ast.Call) and isinstance(cexpr.func, ast.Attribute) and cexpr.func.attr == "Kernel":
+            if isinstance(cexpr, ast.Call) and isinstance(cexpr.func, ast.Attribute) and cexpr.func.attr in ("Kernel", "ClusterKernel"):
                 eval_res = self._try_eval(cexpr.func)
-                from tilelang.language import Kernel
+                from tilelang.language import Kernel, ClusterKernel
 
-                if eval_res is Kernel:
+                if eval_res is Kernel or eval_res is ClusterKernel:
                     is_kernel_ctx = True
         node = self.generic_visit(node)
         for expr in node.items:

--- a/tilelang/language/kernel.py
+++ b/tilelang/language/kernel.py
@@ -97,10 +97,8 @@ def _normalize_bindings(bindings: list[Var]) -> Var | list[Var]:
 
 def _normalize_threads(
     threads: int | list[int] | tuple | None,
-    *,
-    is_cpu: bool,
-) -> list[int] | None:
-    if not is_cpu and threads is None:
+) -> list[int]:
+    if threads is None:
         threads = 128  # default thread number
 
     if isinstance(threads, int):
@@ -110,8 +108,7 @@ def _normalize_threads(
     if isinstance(threads, tuple):
         return list(threads) + [1] * (3 - len(threads))
 
-    assert is_cpu, "threads must be an integer or a list of integers"
-    return None
+    raise ValueError("threads must be an integer or a list of integers")
 
 
 def _normalize_cluster_dims(
@@ -149,15 +146,9 @@ class KernelLaunchFrame(TIRFrame):
         last_block_frame = self.frames[-1]
         assert isinstance(last_block_frame, SBlockFrame), f"Last frame must be a block frame, got {last_block_frame}"
 
-        maybe_cpu = last_block_frame.annotations.get("tilelang.is_cpu_kernel_frame", False)
-
-        if maybe_cpu:
-            # CPU kernel frame, return a list of for frame items.
-            return _normalize_bindings([frame.vars[0] for frame in self.frames[0:-1]])
-        else:
-            # Otherwise, return a list of iter_var.var objects (excluding the last 4 frames).
-            # As 4 frames for threadIdx.x, threadIdx.y, threadIdx.z and block frame with attributes
-            return _normalize_bindings([frame.iter_var.var for frame in self.frames[0:-4]])
+        # Return a list of grid loop vars (excluding the last 4 frames:
+        # threadIdx.x, threadIdx.y, threadIdx.z and the block frame with attributes).
+        return _normalize_bindings([frame.vars[0] for frame in self.frames[0:-4]])
 
     def __exit__(self, ptype, value, trace):
         """
@@ -183,8 +174,8 @@ class KernelLaunchFrame(TIRFrame):
         Returns the block extent for the given dimension.
         dim=0 corresponds to blockIdx.x, dim=1 to blockIdx.y, and dim=2 to blockIdx.z.
         """
-        iter_var = self.frames[dim].iter_var
-        return int(iter_var.dom.extent)
+        iter_var = self.frames[dim].doms[0]
+        return int(iter_var.extent)
 
     def get_block_extents(self) -> list[int]:
         """
@@ -197,8 +188,8 @@ class KernelLaunchFrame(TIRFrame):
         Returns the thread extent for the given dimension.
         dim=0 corresponds to threadIdx.x, dim=1 to threadIdx.y, and dim=2 to threadIdx.z.
         """
-        iter_var = self.frames[-4 + dim].iter_var
-        return int(iter_var.dom.extent)
+        iter_var = self.frames[-4 + dim].doms[0]
+        return int(iter_var.extent)
 
     def get_thread_extents(self) -> list[int]:
         """
@@ -211,14 +202,14 @@ class KernelLaunchFrame(TIRFrame):
         Returns the thread binding for the given dimension.
         dim=0 corresponds to threadIdx.x, dim=1 to threadIdx.y, and dim=2 to threadIdx.z.
         """
-        return self.frames[-4 + dim].iter_var.var
+        return self.frames[-4 + dim].vars[0]
 
     def get_thread_bindings(self) -> list[Var]:
         """
         Returns the thread binding for the given dimension.
         dim=0 corresponds to threadIdx.x, dim=1 to threadIdx.y, and dim=2 to threadIdx.z.
         """
-        return [frame.iter_var.var for frame in self.frames[-4:-1]]
+        return [frame.vars[0] for frame in self.frames[-4:-1]]
 
     def get_num_threads(self) -> int:
         """
@@ -234,27 +225,27 @@ class KernelLaunchFrame(TIRFrame):
         Returns the block binding for the given dimension.
         dim=0 corresponds to blockIdx.x, dim=1 to blockIdx.y, and dim=2 to blockIdx.z.
         """
-        return self.frames[dim].iter_var.var
+        return self.frames[dim].vars[0]
 
     def get_block_bindings(self) -> list[Var]:
         """
         Returns all three block bindings.
         """
-        return [frame.iter_var.var for frame in self.frames[0:-4]]
+        return [frame.vars[0] for frame in self.frames[0:-4]]
 
     @property
     def blocks(self) -> list[Var]:
         """
         Returns the block indices from the topmost frame.
         """
-        return [frame.iter_var.var for frame in self.frames[0:-4]]
+        return [frame.vars[0] for frame in self.frames[0:-4]]
 
     @property
     def threads(self) -> list[Var]:
         """
         Returns the thread indices from the topmost frame.
         """
-        return [frame.iter_var.var for frame in self.frames[-4:]]
+        return [frame.vars[0] for frame in self.frames[-4:-1]]
 
     @property
     def num_threads(self) -> int:
@@ -267,11 +258,15 @@ class KernelLaunchFrame(TIRFrame):
 def Kernel(
     *blocks: int | tirx.PrimExpr,
     threads: int | list[int] | tuple | None = None,
-    cluster_dims: int | tuple[int, int, int] | list[int] | None = None,
-    is_cpu: bool = False,
     prelude: str | None = None,
 ):
-    """Tools to quickly construct a GPU kernel launch frame.
+    """Tools to quickly construct a kernel launch frame.
+
+    The launch nest is emitted in a target-neutral form (thread_binding
+    For loops); each backend pipeline materializes it via
+    MaterializeKernelLaunch. Backends without SIMT (e.g. CPU) simply
+    ignore the thread extents at compile time, so the same kernel can be
+    compiled for any target.
 
     Parameters
     ----------
@@ -281,11 +276,6 @@ def Kernel(
         A integer representing blockDim.x
         Or a list of integers representing blockDim.(x|y|z)
         if the value is -1, we skip the threadIdx.x binding.
-    cluster_dims : int | tuple[int, int, int] | list[int] | None
-        The cluster dimensions for SM90+ cluster launch.
-        For example, use 2 or (2, 1, 1) to create 2-CTA clusters.
-        When specified, the kernel will be launched using cudaLaunchKernelEx
-        with cudaLaunchAttributeClusterDimension.
     prelude : str
         The import c code of the kernel,
         will be injected before the generated kernel code.
@@ -312,13 +302,6 @@ def Kernel(
         with T.Kernel(grid_x, grid_y, threads=(64, 2)) as (bx, by):
             tx, ty = T.get_thread_bindings()
             ...
-
-    Emit a CPU kernel where thread bindings are skipped:
-
-    .. code-block:: python
-
-        with T.Kernel(loop_extent, is_cpu=True) as (i,):
-            ...
     """
     # In eager mode, we construct AST directly without prim_func,
     # so there must be a Builder available. If not, this function
@@ -330,10 +313,56 @@ def Kernel(
         raise JITNoBuilderError("T.Kernel() can only be used inside @tilelang.jit or @T.prim_func context. No Builder is available.")
 
     attrs: dict = {}
-    threads = _normalize_threads(threads, is_cpu=is_cpu)
+    threads = _normalize_threads(threads)
 
-    if is_cpu:
-        attrs["tilelang.is_cpu_kernel_frame"] = True
+    if prelude is not None:
+        attrs["pragma_import_c"] = prelude
+
+    return _ffi_api.KernelLaunch(blocks, threads, attrs)
+
+
+def ClusterKernel(
+    *blocks: int | tirx.PrimExpr,
+    cluster_dims: int | tuple[int, int, int] | list[int],
+    threads: int | list[int] | tuple | None = None,
+    prelude: str | None = None,
+):
+    """Construct a kernel launch frame with a CUDA thread block cluster
+    (SM90+ only).
+
+    This is the CUDA-specific variant of :func:`Kernel`: identical launch
+    semantics and bindings, plus a ``cluster_dims`` annotation. The kernel
+    will be launched with cudaLaunchKernelEx using
+    cudaLaunchAttributeClusterDimension.
+
+    Parameters
+    ----------
+    blocks : int
+        A list of extent, can be 1-3 dimension, representing gridDim.(x|y|z)
+    cluster_dims : int | tuple[int, int, int] | list[int]
+        The cluster dimensions. For example, use 2 or (2, 1, 1) to create
+        2-CTA clusters.
+    threads : int
+        A integer representing blockDim.x
+        Or a list of integers representing blockDim.(x|y|z)
+    prelude : str
+        The import c code of the kernel,
+        will be injected before the generated kernel code.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        with T.ClusterKernel(grid_x, grid_y, cluster_dims=2, threads=128) as (bx, by):
+            ...
+    """
+    from tilelang.language.eager.builder import Builder
+
+    if Builder.current() is None:
+        raise JITNoBuilderError("T.ClusterKernel() can only be used inside @tilelang.jit or @T.prim_func context. No Builder is available.")
+
+    attrs: dict = {}
+    threads = _normalize_threads(threads)
 
     if prelude is not None:
         attrs["pragma_import_c"] = prelude
@@ -424,7 +453,7 @@ def CUDASourceCodeKernel(
         raise ValueError("entry_name must be a non-empty string when provided")
     attrs["code_block_entry_name"] = entry_name
 
-    threads = _normalize_threads(threads, is_cpu=False)
+    threads = _normalize_threads(threads)
 
     cluster_dims = _normalize_cluster_dims(cluster_dims)
     if cluster_dims is not None:

--- a/tilelang/metal/pipeline.py
+++ b/tilelang/metal/pipeline.py
@@ -18,6 +18,7 @@ from tilelang.metal.transform import MetalFragmentToSimdgroup
 
 def MetalPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.MaterializeKernelLaunch(lower_thread_binding=True)(mod)
     pass_ctx = tilelang.transform.get_pass_context()
 
     if should_force_let_inline():

--- a/tilelang/metal/pipeline.py
+++ b/tilelang/metal/pipeline.py
@@ -18,7 +18,7 @@ from tilelang.metal.transform import MetalFragmentToSimdgroup
 
 def MetalPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tirx.transform.BindTarget(target)(mod)
-    mod = tilelang.transform.MaterializeKernelLaunch(lower_thread_binding=True)(mod)
+    mod = tilelang.transform.MaterializeKernelLaunch()(mod)
     pass_ctx = tilelang.transform.get_pass_context()
 
     if should_force_let_inline():

--- a/tilelang/rocm/pipeline.py
+++ b/tilelang/rocm/pipeline.py
@@ -17,6 +17,7 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
 
 def ROCMPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.MaterializeKernelLaunch(lower_thread_binding=True)(mod)
     pass_ctx = tilelang.transform.get_pass_context()
 
     if should_force_let_inline():

--- a/tilelang/rocm/pipeline.py
+++ b/tilelang/rocm/pipeline.py
@@ -17,7 +17,7 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
 
 def ROCMPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tirx.transform.BindTarget(target)(mod)
-    mod = tilelang.transform.MaterializeKernelLaunch(lower_thread_binding=True)(mod)
+    mod = tilelang.transform.MaterializeKernelLaunch()(mod)
     pass_ctx = tilelang.transform.get_pass_context()
 
     if should_force_let_inline():

--- a/tilelang/transform/__init__.py
+++ b/tilelang/transform/__init__.py
@@ -214,6 +214,28 @@ def MakePackedAPI():
     return _ffi_api.MakePackedAPI()  # type: ignore
 
 
+def MaterializeKernelLaunch(lower_thread_binding: bool = True):
+    """Materialize the target-neutral kernel launch nest (thread_binding
+    For loops emitted by T.Kernel) into a backend-specific form. Each
+    backend pipeline decides the mode for itself:
+
+    Parameters
+    ----------
+    lower_thread_binding : bool
+        If True (SIMT backends, e.g. CUDA/ROCm/Metal), lower the
+        blockIdx.*/threadIdx.* loops into thread_extent AttrStmts.
+        If False (backends without SIMT, e.g. CPU), lower blockIdx.*
+        loops into plain serial For loops and ignore threadIdx.* loops
+        (their extents are dropped; the loop vars are pinned to 0).
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    """
+    return _ffi_api.MaterializeKernelLaunch(lower_thread_binding)  # type: ignore
+
+
 def AnnotateDeviceRegions():
     """AnnotateDeviceRegions
 

--- a/tilelang/webgpu/__init__.py
+++ b/tilelang/webgpu/__init__.py
@@ -1,0 +1,1 @@
+from . import pipeline  # noqa: F401

--- a/tilelang/webgpu/pipeline.py
+++ b/tilelang/webgpu/pipeline.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from tvm import IRModule, s_tir, tirx
+from tvm.target import Target
+
+import tilelang
+from tilelang.backend.pass_pipeline import PassPipeline, register_pipeline
+from tilelang.backend.pass_pipeline.pipeline_utils import (
+    LayoutVisual,
+    allow_vectorize,
+    should_disable_shared_memory_reuse,
+    should_enable_aggressive_merge,
+    should_enable_race_check,
+    should_force_let_inline,
+)
+
+
+def WebGPUPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
+    mod = tirx.transform.BindTarget(target)(mod)
+    # WebGPU is a SIMT backend: lower the launch nest to thread_extent
+    # bindings for codegen.
+    mod = tilelang.transform.MaterializeKernelLaunch()(mod)
+    pass_ctx = tilelang.transform.get_pass_context()
+
+    if should_force_let_inline():
+        mod = tilelang.transform.LetInline()(mod)
+    mod = tilelang.transform.AddWrapperForSingleBufStore()(mod)
+    mod = tilelang.transform.LegalizeNegativeIndex()(mod)
+    if should_enable_race_check():
+        mod = tilelang.transform.VerifyParallelLoop()(mod)
+    mod = tilelang.transform.InjectAssumes()(mod)
+    mod = tilelang.transform.Simplify()(mod)
+    mod = tilelang.transform.LayoutReducer()(mod)
+
+    mod = tilelang.transform.IfStmtBinding()(mod)
+    mod = tilelang.transform.PipelinePlanning()(mod)
+    mod = tilelang.transform.InjectSoftwarePipeline()(mod)
+    mod = tilelang.transform.Simplify()(mod)
+
+    mod = tilelang.transform.LayoutInference()(mod)
+    LayoutVisual(mod)
+    mod = tilelang.transform.LowerTileOp()(mod)
+
+    mod = tilelang.transform.DecoupleTypeCast()(mod)
+    mod = tilelang.transform.LegalizeVectorizedLoop()(mod)
+    mod = tilelang.transform.LegalizeSafeMemoryAccess()(mod)
+    mod = tilelang.transform.LowerAccessPtr()(mod)
+    mod = tilelang.transform.Simplify()(mod)
+    mod = tilelang.transform.HoistNonRestrictParams()(mod)
+
+    mod = tilelang.transform.PlanAndUpdateBufferAllocationLocation()(mod)
+    mod = tilelang.transform.HoistGlobalBufferAllocations()(mod)
+    mod = tilelang.transform.LowerOpaqueBlock()(mod)
+    mod = tilelang.transform.Simplify()(mod)
+    mod = tirx.transform.NarrowDataType(32)(mod)
+    mod = tilelang.transform.FlattenBuffer()(mod)
+    mod = tilelang.transform.ConfigIndexBitwidth()(mod)
+    mod = tirx.transform.Simplify()(mod)
+    mod = tilelang.transform.VectorizeLoop(enable_vectorize=allow_vectorize(pass_ctx=pass_ctx))(mod)
+    mod = tilelang.transform.StorageRewrite()(mod)
+    mod = tilelang.transform.LoopUnswitching()(mod)
+    mod = tilelang.transform.UnrollLoop()(mod)
+    mod = s_tir.transform.RenormalizeSplitPattern()(mod)
+    mod = tirx.transform.Simplify()(mod)
+    mod = tirx.transform.RemoveNoOp()(mod)
+    mod = s_tir.transform.HoistIfThenElse()(mod)
+
+    mod = tirx.transform.VerifyMemory()(mod)
+    mod = tirx.transform.AnnotateEntryFunc()(mod)
+    mod = s_tir.transform.InferFragment()(mod)
+    mod = tilelang.transform.LowerThreadAllreduce()(mod)
+
+    mod = tilelang.transform.AnnotateDeviceRegions()(mod)
+    mod = tilelang.transform.SplitHostDevice()(mod)
+    mod = tilelang.transform.AnnotateReadOnlyParams()(mod)
+
+    enable_aggressive_merge = should_enable_aggressive_merge(pass_ctx=pass_ctx, target=target)
+    disable_reuse = should_disable_shared_memory_reuse(pass_ctx=pass_ctx)
+    mod = tilelang.transform.MergeSharedMemoryAllocations(enable_aggressive_merge=enable_aggressive_merge, disable_reuse=disable_reuse)(mod)
+
+    mod = tilelang.transform.ThreadSync("shared")(mod)
+    mod = tilelang.transform.ThreadSync("shared.dyn")(mod)
+    mod = tilelang.transform.MergeIfStmt()(mod)
+    mod = tilelang.transform.MakePackedAPI()(mod)
+    mod = tilelang.transform.Simplify()(mod)
+    mod = tilelang.transform.LowerDeviceKernelLaunch()(mod)
+    return mod
+
+
+register_pipeline(PassPipeline("webgpu", WebGPUPassPipelineBody))


### PR DESCRIPTION
## Summary

- Refactor `T.Kernel` to emit a target-neutral launch nest that backend pipelines materialize after target binding.
- Add `T.ClusterKernel` for CUDA thread block cluster launches so plain `T.Kernel` can be shared across CPU and SIMT backends.
- Update tests, examples, maintenance scripts, and docs to use the new launch split where cluster dimensions are required.

## Changes

- Add `tl.MaterializeKernelLaunch`, which converts launch thread-binding loops into backend-specific forms.
- Run the materialization pass in CPU, CUDA, ROCm, and Metal pipelines with backend-appropriate lowering behavior.
- Remove the CPU-only kernel-frame attribute path and normalize launch thread handling through the shared `KernelLaunchFrame` API.
- Update cluster examples and tests to call `T.ClusterKernel` while leaving non-cluster kernels on `T.Kernel`.

## Validation

- `pre-commit run --all-files`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cluster-oriented kernel launch support exposed as a public API (ClusterKernel).
  * Compilation now materializes kernel launches earlier in backend pipelines.

* **Documentation**
  * Examples and guides updated to use cluster-aware kernel launches and reflect new launch patterns.

* **API Changes**
  * Kernel helper simplified; cluster-oriented launches should use ClusterKernel going forward.

* **Tests**
  * Tests and demos updated to exercise cluster-aware launches and the new launch-materialization pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->