### PR TITLE
[CI][Cache] Enable local ccache for self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,8 +123,8 @@ jobs:
           echo "UV_CACHE_DIR=${XDG_CACHE_HOME}/uv" | tee -a "${GITHUB_ENV}"
           echo "PRE_COMMIT_HOME=${XDG_CACHE_HOME}/pip/.pre-commit" | tee -a "${GITHUB_ENV}"
 
-      # Do not use ccache on self-hosted runners, as it will download/upload caches which is slow.
-      # Self-hosted runners usually have more CPU power to compile without ccache.
+      # Use the ccache action only on GitHub-hosted runners, where it manages
+      # remote cache restore/save. Self-hosted runners use a local cache below.
       - name: Setup ccache (GitHub-hosted runners)
         id: setup-ccache
         if: ${{ !startsWith(matrix.runner.name, 'self-hosted') }}
@@ -138,6 +138,26 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner.toolkit }}-${{ hashFiles('**/*.cc') }}
             ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner.toolkit }}
             ${{ runner.os }}-${{ runner.arch }}
+
+      - name: Setup ccache (self-hosted runners)
+        if: startsWith(matrix.runner.name, 'self-hosted')
+        run: |
+          if ! command -v ccache >/dev/null 2>&1; then
+            echo "::warning::ccache is not installed on this self-hosted runner; CMake will build without ccache."
+            exit 0
+          fi
+
+          export CCACHE_DIR="${XDG_CACHE_HOME}/ccache/${{ matrix.runner.name }}/${{ matrix.runner.toolkit }}"
+          mkdir -p "${CCACHE_DIR}"
+
+          echo "CCACHE_DIR=${CCACHE_DIR}" | tee -a "${GITHUB_ENV}"
+          echo "CCACHE_BASEDIR=${{ github.workspace }}" | tee -a "${GITHUB_ENV}"
+          echo "CCACHE_NOHASHDIR=true" | tee -a "${GITHUB_ENV}"
+          echo "CCACHE_COMPILERCHECK=content" | tee -a "${GITHUB_ENV}"
+
+          ccache -M 20G
+          ccache -z
+          ccache -s
 
       - name: Set environment (CUDA)
         if: contains(matrix.runner.toolkit, 'CUDA')
@@ -296,6 +316,13 @@ jobs:
         run: |
           uv pip install -v .
 
+      - name: Show ccache stats
+        if: always()
+        run: |
+          if command -v ccache >/dev/null 2>&1; then
+            ccache -s || true
+          fi
+
       - name: Clean up stale /tmp files (self-hosted runners)
         if: startsWith(matrix.runner.name, 'self-hosted')
         run: |
@@ -400,6 +427,25 @@ jobs:
           echo "UV_CACHE_DIR=${XDG_CACHE_HOME}/uv" | tee -a "${GITHUB_ENV}"
           echo "PRE_COMMIT_HOME=${XDG_CACHE_HOME}/pip/.pre-commit" | tee -a "${GITHUB_ENV}"
 
+      - name: Setup ccache (self-hosted runners)
+        run: |
+          if ! command -v ccache >/dev/null 2>&1; then
+            echo "::warning::ccache is not installed on this self-hosted runner; CMake will build without ccache."
+            exit 0
+          fi
+
+          export CCACHE_DIR="${XDG_CACHE_HOME}/ccache/self-hosted-nvidia/CUDA-12.8"
+          mkdir -p "${CCACHE_DIR}"
+
+          echo "CCACHE_DIR=${CCACHE_DIR}" | tee -a "${GITHUB_ENV}"
+          echo "CCACHE_BASEDIR=${{ github.workspace }}" | tee -a "${GITHUB_ENV}"
+          echo "CCACHE_NOHASHDIR=true" | tee -a "${GITHUB_ENV}"
+          echo "CCACHE_COMPILERCHECK=content" | tee -a "${GITHUB_ENV}"
+
+          ccache -M 20G
+          ccache -z
+          ccache -s
+
       - name: Set environment (CUDA)
         run: |
           TOOLKIT="CUDA-12.8"
@@ -471,6 +517,13 @@ jobs:
       - name: Install project (wheel form)
         run: |
           uv pip install -v .
+
+      - name: Show ccache stats
+        if: always()
+        run: |
+          if command -v ccache >/dev/null 2>&1; then
+            ccache -s || true
+          fi
 
       - name: Clean up stale /tmp files (self-hosted runners)
         run: |

--- a/.github/workflows/pr-regression-test-bot.yml
+++ b/.github/workflows/pr-regression-test-bot.yml
@@ -97,8 +97,8 @@ jobs:
           echo "UV_CACHE_DIR=${XDG_CACHE_HOME}/uv" | tee -a "${GITHUB_ENV}"
           echo "PRE_COMMIT_HOME=${XDG_CACHE_HOME}/pip/.pre-commit" | tee -a "${GITHUB_ENV}"
 
-      # Do not use ccache on self-hosted runners, as it will download/upload caches which is slow.
-      # Self-hosted runners usually have more CPU power to compile without ccache.
+      # Use the ccache action only on GitHub-hosted runners, where it manages
+      # remote cache restore/save. Self-hosted runners use a local cache below.
       - name: Setup ccache (GitHub-hosted runners)
         id: setup-ccache
         if: ${{ !startsWith(matrix.runner.name, 'self-hosted') }}
@@ -112,6 +112,26 @@ jobs:
             ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner.toolkit }}-${{ hashFiles('**/*.cc') }}
             ${{ runner.os }}-${{ runner.arch }}-${{ matrix.runner.toolkit }}
             ${{ runner.os }}-${{ runner.arch }}
+
+      - name: Setup ccache (self-hosted runners)
+        if: startsWith(matrix.runner.name, 'self-hosted')
+        run: |
+          if ! command -v ccache >/dev/null 2>&1; then
+            echo "::warning::ccache is not installed on this self-hosted runner; CMake will build without ccache."
+            exit 0
+          fi
+
+          export CCACHE_DIR="${XDG_CACHE_HOME}/ccache/${{ matrix.runner.name }}/${{ matrix.runner.toolkit }}"
+          mkdir -p "${CCACHE_DIR}"
+
+          echo "CCACHE_DIR=${CCACHE_DIR}" | tee -a "${GITHUB_ENV}"
+          echo "CCACHE_BASEDIR=${{ github.workspace }}" | tee -a "${GITHUB_ENV}"
+          echo "CCACHE_NOHASHDIR=true" | tee -a "${GITHUB_ENV}"
+          echo "CCACHE_COMPILERCHECK=content" | tee -a "${GITHUB_ENV}"
+
+          ccache -M 20G
+          ccache -z
+          ccache -s
 
       - name: Set environment (CUDA)
         if: contains(matrix.runner.toolkit, 'CUDA')
@@ -192,6 +212,13 @@ jobs:
           uv venv --python "${{ matrix.python-version }}" test_regression
           source test_regression/bin/activate
           uv pip install -v -r requirements-test.txt
+
+      - name: Show ccache stats
+        if: always()
+        run: |
+          if command -v ccache >/dev/null 2>&1; then
+            ccache -s || true
+          fi
 
       - name: Clear uv cache for self-hosted runners (if setup failed)
         if: >-


### PR DESCRIPTION
## Summary

- Enable self-hosted CI jobs to reuse a persistent local ccache directory during project installs.
- Keep GitHub-hosted runners on the existing ccache action while avoiding remote cache upload/download overhead on self-hosted runners.

## Changes

- Configure \`CCACHE_DIR\`, \`CCACHE_BASEDIR\`, \`CCACHE_NOHASHDIR\`, and \`CCACHE_COMPILERCHECK\` for self-hosted jobs in \`ci.yml\` and \`pr-regression-test-bot.yml\`.
- Add ccache stats output after project installation so cache usage is visible in CI logs.
- Leave builds functional when ccache is unavailable by emitting a warning and continuing without compiler caching.

## Validation

- \`./format.sh\`
- \`git diff --check -- .github/workflows/ci.yml .github/workflows/pr-regression-test-bot.yml\`
- YAML syntax parse for \`.github/workflows/ci.yml\` and \`.github/workflows/pr-regression-test-bot.yml\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/build system caching configuration to support both GitHub-hosted and self-hosted runners more effectively.
  * Added diagnostic reporting for compilation cache statistics in test workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->