### PR TITLE
[CUDA] Align swizzled TMA shared buffers

### DIFF
--- a/src/backend/common/op/finalize_reducer.h
+++ b/src/backend/common/op/finalize_reducer.h
@@ -85,7 +85,7 @@ template <typename Impl> struct FinalizeReducerLowerer {
           op_str, reducing_threads, 1, thread_offset, T.thread_bounds->extent,
           static_cast<int>(effective_batch), workspace_stride, T.target);
       int ws_size = workspace_stride * static_cast<int>(effective_batch);
-      PrimExpr workspace = T.AddWorkspace(ws_size, buffer->dtype);
+      PrimExpr workspace = T.add_workspace(ws_size, buffer->dtype);
       Array<PrimExpr> args = {StringImm(allreduce), buffer->data, workspace};
       return Evaluate(Call(DataType::Handle(), builtin::call_extern(), args));
     }
@@ -96,8 +96,8 @@ template <typename Impl> struct FinalizeReducerLowerer {
     Array<PrimExpr> thread_reduce_args = {StringImm(allreduce),
                                           BufferLoad(buffer, indices_0)};
     if (reducing_threads >= 32) {
-      PrimExpr workspace =
-          T.AddWorkspace(*as_const_int(T.thread_bounds->extent), buffer->dtype);
+      PrimExpr workspace = T.add_workspace(
+          *as_const_int(T.thread_bounds->extent), buffer->dtype);
       thread_reduce_args.push_back(workspace);
     }
     auto call = Call(buffer->dtype, builtin::call_extern(), thread_reduce_args);

--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -611,7 +611,7 @@ template <typename Impl> struct ReduceLowerer {
           bool need_workspace = reducing_threads > 32;
           if (need_workspace) {
             int ws_size = reducing_threads * eff_batch;
-            workspace = T.AddWorkspace(ws_size, ws_dtype);
+            workspace = T.add_workspace(ws_size, ws_dtype);
           }
 
           int64_t N_total = 1;
@@ -792,7 +792,7 @@ template <typename Impl> struct ReduceLowerer {
             int workspace_size =
                 static_cast<int>(*as_const_int(T.thread_bounds->extent));
             PrimExpr workspace =
-                T.AddWorkspace(workspace_size, clear_buffer->dtype);
+                T.add_workspace(workspace_size, clear_buffer->dtype);
             thread_reduce_args.push_back(workspace);
           }
           auto call = Call(clear_buffer->dtype, builtin::call_extern(),

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -348,6 +348,30 @@ MakeTMARows(const Buffer &src, const Array<Range> &src_ranges,
 
 namespace cuda {
 
+// The TMA unit applies the descriptor's swizzle pattern relative to the
+// shared-memory base address, so the base must sit on a swizzle-pattern
+// repeat boundary or the data lands with a shifted phase (silently wrong
+// results, no fault). Report the requirement implied by the chosen
+// CU_TENSOR_MAP_SWIZZLE_* mode so MergeSharedMemoryAllocations can align the
+// buffer accordingly.
+static void RequireTMASmemAlignment(const LowerArgs &T,
+                                    const Buffer &shared_tensor,
+                                    int cu_tensor_map_swizzle) {
+  if (!T.require_smem_alignment)
+    return;
+  SwizzleMode mode = SwizzleMode::kNone;
+  if (cu_tensor_map_swizzle == static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B)) {
+    mode = SwizzleMode::kQuarter;
+  } else if (cu_tensor_map_swizzle ==
+             static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B)) {
+    mode = SwizzleMode::kHalf;
+  } else if (cu_tensor_map_swizzle ==
+             static_cast<int>(CU_TENSOR_MAP_SWIZZLE_128B)) {
+    mode = SwizzleMode::kFull;
+  }
+  T.require_smem_alignment(shared_tensor->data, SmemAlignmentForSwizzle(mode));
+}
+
 struct TMAIm2ColDesc {
   size_t rank;
   int data_type;
@@ -876,8 +900,8 @@ Stmt Copy::LowerCluster(const CopyNode &op, const LowerArgs &T,
           MakeTMARows(src, src_range, dst, dst_range, op.dst_block.value(),
                       barrier_load, analyzer);
 
-      if (T.UpdateBarrierArrive) {
-        T.UpdateBarrierArrive(barrier_data_var, n_rows);
+      if (T.update_barrier_arrive) {
+        T.update_barrier_arrive(barrier_data_var, n_rows);
       }
 
       Stmt seq = (tma_stmts.size() == 1)
@@ -1539,6 +1563,13 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
     }
   }
 
+  // The TMA unit applies the descriptor's swizzle pattern relative to the
+  // shared-memory base address, so the base must sit on a swizzle-pattern
+  // repeat boundary or the data lands with a shifted phase (silently wrong
+  // results, no fault). Report the requirement implied by the chosen swizzle
+  // mode so MergeSharedMemoryAllocations can align the buffer accordingly.
+  RequireTMASmemAlignment(T, shared_tensor, desc.swizzle);
+
   auto inner_box_dim = as_const_int(desc.smem_box[0]);
   if (inner_box_dim == nullptr) {
     DLOG(WARNING) << "inner_box_dim " << desc.smem_box[0]
@@ -1604,9 +1635,9 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
     } else if (GetIsTmaCopy(op)) {
       LOG(FATAL) << "T.tma_copy() requires a barrier argument. "
                  << "Use T.tma_copy(src, dst, barrier=mbar[idx]).";
-    } else if (T.AllocMBarrier) {
+    } else if (T.alloc_mbarrier) {
       barrier_base_id =
-          T.AllocMBarrier(1, MakeCopyMBarrierName(op.src, op.dst));
+          T.alloc_mbarrier(1, MakeCopyMBarrierName(op.src, op.dst));
       PrimExpr mbar_idx = IntImm(DataType::Int(32), barrier_base_id);
       mbar_handle = BufferLoad(T.mbarrier_buffer->value(), {mbar_idx});
     }
@@ -1918,6 +1949,7 @@ Stmt Copy::LowerBulkGather4(const CopyNode &op, const LowerArgs &T,
           << " exceeds " << max_bytes << "B swizzle limit";
     }
   }
+  RequireTMASmemAlignment(T, shared_tensor, desc.swizzle);
 
   Call create_descriptor =
       Call(DataType::Handle(), create_tma_descriptor(), desc.EncodeCallArgs());
@@ -2026,9 +2058,9 @@ Stmt Copy::LowerBulk1D(const CopyNode &op, const LowerArgs &T,
     } else if (GetIsTmaCopy(op)) {
       LOG(FATAL) << "T.tma_copy() requires a barrier argument. "
                  << "Use T.tma_copy(src, dst, barrier=mbar[idx]).";
-    } else if (T.AllocMBarrier) {
+    } else if (T.alloc_mbarrier) {
       barrier_base_id =
-          T.AllocMBarrier(1, MakeCopyMBarrierName(op.src, op.dst));
+          T.alloc_mbarrier(1, MakeCopyMBarrierName(op.src, op.dst));
       PrimExpr mbar_idx = IntImm(DataType::Int(32), barrier_base_id);
       mbar_handle = BufferLoad(T.mbarrier_buffer->value(), {mbar_idx});
     }
@@ -2164,6 +2196,8 @@ Stmt Im2Col::Lower(const Im2ColOpNode &op, const LowerArgs &T,
       LOG(FATAL) << "Cannot detect TMA layout.";
     }
   }
+  RequireTMASmemAlignment(
+      T, T.buffer_remap.count(dst) ? T.buffer_remap[dst] : dst, desc.swizzle);
 
   Call create_desc = Call(DataType::Handle(), create_tma_im2col_descriptor(),
                           desc.EncodeCallArgs());
@@ -2209,9 +2243,9 @@ Stmt Im2Col::Lower(const Im2ColOpNode &op, const LowerArgs &T,
   if (auto user_barrier = op.annotations_.Get("barrier")) {
     mbar_handle = Downcast<PrimExpr>(user_barrier.value());
     barrier_base_id = 0;
-  } else if (T.AllocMBarrier) {
+  } else if (T.alloc_mbarrier) {
     barrier_base_id =
-        T.AllocMBarrier(1, MakeCopyMBarrierName(op.src_, op.dst_));
+        T.alloc_mbarrier(1, MakeCopyMBarrierName(op.src_, op.dst_));
     PrimExpr mbar_idx = IntImm(DataType::Int(32), barrier_base_id);
     mbar_handle = BufferLoad(T.mbarrier_buffer->value(), {mbar_idx});
   }

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -299,6 +299,25 @@ enum class SwizzleMode {
 // Detect which swizzle mode a layout uses
 SwizzleMode DetectSwizzleMode(const Layout &layout, const Buffer &buffer);
 
+// Required shared-memory base alignment (in bytes) for a TMA/bulk-copy or
+// MMA-descriptor operand with the given swizzle mode. The base must lie on a
+// swizzle-pattern repeat boundary (swizzle byte width x 8 rows); otherwise the
+// hardware applies the swizzle with a phase shift relative to the layout the
+// compiler assumed, silently producing wrong data.
+inline int SmemAlignmentForSwizzle(SwizzleMode mode) {
+  switch (mode) {
+  case SwizzleMode::kQuarter:
+    return 256; // 32B swizzle
+  case SwizzleMode::kHalf:
+    return 512; // 64B swizzle
+  case SwizzleMode::kFull:
+    return 1024; // 128B swizzle
+  case SwizzleMode::kNone:
+  default:
+    return 128; // bulk-copy base requirement for non-swizzled operands
+  }
+}
+
 // Merge two swizzle layouts by taking the smaller granularity
 // Returns NullOpt if either layout is not a swizzle layout
 Optional<Layout> MergeSwizzleLayouts(const Layout &layout1,

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -85,6 +85,14 @@ static constexpr const char *kDebugMergeSharedMemoryAllocations =
 // PrimFunc attribute: set by LowerTileOp to indicate TMA operations were
 // actually generated.  Read by OptimizeForTarget to pick the right pipeline.
 static constexpr const char *kHasTMA = "tl.has_tma";
+// PrimFunc attribute: Map<String, IntImm> from a shared buffer's data Var
+// name to the minimum base alignment (bytes) required by swizzle-sensitive
+// instructions that consume it (TMA bulk copy, wgmma/tcgen05 descriptors).
+// Keyed by name rather than Var so the attribute does not hold references
+// into the function body (which would perturb printing and SSA passes); a
+// name collision can only over-align, never under-align. Written by
+// LowerTileOp, consumed by MergeSharedMemoryAllocations.
+static constexpr const char *kSmemAlignmentMap = "tl.smem_alignment_map";
 static constexpr const char *kDisableSafeMemoryLegalize =
     "tl.disable_safe_memory_legalize";
 static constexpr const char *kDisableWarpSpecialized =

--- a/src/op/operator.h
+++ b/src/op/operator.h
@@ -38,6 +38,9 @@ using AddWorkspaceCallback = std::function<PrimExpr(int, DataType)>;
 using AllocMBarrierCallback =
     std::function<int(int arrive_count, std::optional<std::string> name)>;
 using UpdateBarrierArriveCallback = std::function<void(Var, PrimExpr)>;
+// Record a minimum shared-memory base alignment (bytes) required for the
+// buffer backed by the given data Var (e.g. TMA/MMA swizzle constraints).
+using RequireSmemAlignmentCallback = std::function<void(Var, int)>;
 using LayoutMap = Map<Buffer, Layout>;
 using BufferMap = Map<Var, Buffer>;
 
@@ -95,9 +98,6 @@ struct LowerArgs {
   Target target;
   Range thread_bounds;
   Var thread_var;
-  AddWorkspaceCallback AddWorkspace;
-  AllocMBarrierCallback AllocMBarrier;
-  UpdateBarrierArriveCallback UpdateBarrierArrive;
   LayoutMap layout_map;
   Map<Buffer, Buffer> buffer_remap;
   // Map from Bind variable to its bound expression, for resolving
@@ -110,12 +110,24 @@ struct LowerArgs {
   PrimExpr mbar_phase_expr = IntImm(DataType::Int(32), 0);
   // Pointer to the shared.barrier buffer for compiler-generated mbarriers.
   // Points to the LowerTileOpPass member so copy.cc sees the buffer
-  // even when created lazily by the AllocMBarrier callback.
+  // even when created lazily by the alloc_mbarrier callback.
   Optional<Buffer> *mbarrier_buffer = nullptr;
   // Product of cluster_dims (from block annotation). Defaults to 1 (no
   // cluster). Used by TMA copy lowering to scale expect_tx bytes for cluster
   // barriers.
   int cluster_size = 1;
+
+  // Callbacks used by op lowerings to request pass-owned resources or report
+  // metadata that later passes need.
+  AddWorkspaceCallback add_workspace = nullptr;
+  AllocMBarrierCallback alloc_mbarrier = nullptr;
+  UpdateBarrierArriveCallback update_barrier_arrive = nullptr;
+  // Optional callback to record a minimum shared-memory base alignment for a
+  // buffer's data Var. Lowerings that bind a buffer to a swizzle-sensitive
+  // instruction (TMA bulk copy, wgmma/tcgen05 descriptors) report the
+  // alignment implied by the chosen swizzle mode here; LowerTileOp collects
+  // the results into the kSmemAlignmentMap PrimFunc attribute.
+  RequireSmemAlignmentCallback require_smem_alignment = nullptr;
 };
 
 struct LayoutInferArgs {

--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -173,7 +173,7 @@ static Fragment ComputeReducerLayout(const Fragment &src_layout, int dim) {
  * - Detects parallel thread splitting from the normalized iterator sum and
  *   emits a call to a templated `tl::AllReduce<...>::run`
  *   via `builtin::call_extern`. For sufficiently large reducing thread counts
- *   (> 32) a workspace is allocated via T.AddWorkspace and passed to the
+ *   (> 32) a workspace is allocated via T.add_workspace and passed to the
  *   AllReduce call.
  * - The final body is wrapped in parallel loops over the destination spatial
  *   dimensions and partitioned by the lowering thread variable. If a temporary

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -248,6 +248,14 @@ public:
     // later phases (OptimizeForTarget) can choose the right pass pipeline
     // without relying on pass-context side-channel mutation.
     f = WithAttr(std::move(f), kHasTMA, Bool(substituter.has_tma_));
+    // Propagate per-buffer shared-memory alignment requirements collected
+    // during lowering (swizzle-dependent TMA/MMA constraints) so that
+    // MergeSharedMemoryAllocations can honor them when laying out the merged
+    // dynamic shared memory buffer.
+    if (!substituter.smem_alignment_map_.empty()) {
+      f = WithAttr(std::move(f), kSmemAlignmentMap,
+                   substituter.smem_alignment_map_);
+    }
     fptr = f.CopyOnWrite();
 
     // If any TMA copies allocated mbarriers, inject the barrier buffer
@@ -256,7 +264,7 @@ public:
     // LowerSharedBarrier will process it into ptx_init_barrier_thread_count.
     if (substituter.mbarrier_count_ > 0) {
       ICHECK(substituter.mbarrier_buffer_.defined())
-          << "mbarrier_buffer_ must have been created by AllocMBarrier "
+          << "mbarrier_buffer_ must have been created by alloc_mbarrier "
              "callback";
       Buffer mbar_buf = substituter.mbarrier_buffer_.value();
       // Update buffer shape in-place to final count. We use const_cast
@@ -1140,7 +1148,17 @@ private:
     auto tile_op = ParseOperator(GetRef<Stmt>(op));
     if (!tile_op.defined())
       return IRMutatorWithAnalyzer::VisitStmt_(op);
-    AddWorkspaceCallback callback = [this](int num_elem, DataType dtype) {
+
+    Range thread_bounds = CurrentThreadBounds();
+
+    // Convert bind_var_to_expr_ to Map<Var, PrimExpr> for LowerArgs
+    Map<Var, PrimExpr> bind_var_to_expr;
+    for (const auto &[var, expr] : bind_var_to_expr_) {
+      bind_var_to_expr.Set(var, expr);
+    }
+
+    AddWorkspaceCallback add_workspace_callback = [this](int num_elem,
+                                                         DataType dtype) {
       auto workspace =
           decl_buffer({PrimExpr(num_elem)}, dtype, "workspace", "shared.dyn");
       // Record workspace under the innermost block scope so its lifetime
@@ -1154,14 +1172,6 @@ private:
       }
       return workspace.access_ptr(2); // write
     };
-
-    Range thread_bounds = CurrentThreadBounds();
-
-    // Convert bind_var_to_expr_ to Map<Var, PrimExpr> for LowerArgs
-    Map<Var, PrimExpr> bind_var_to_expr;
-    for (const auto &[var, expr] : bind_var_to_expr_) {
-      bind_var_to_expr.Set(var, expr);
-    }
 
     AllocMBarrierCallback mbarrier_callback =
         [this](int arrive_count, std::optional<std::string> name) -> int {
@@ -1179,15 +1189,35 @@ private:
       barrier_arrive_updates_[data_var] = n;
     };
 
-    auto lowered = tile_op->Lower(
-        LowerArgs{target_, thread_bounds, thread_var_->var, callback,
-                  mbarrier_callback, barrier_arrive_callback, layout_map_,
-                  buffer_remap_, bind_var_to_expr,
-                  loop_mbar_phase_stack_.empty()
-                      ? PrimExpr(IntImm(DataType::Int(32), 0))
-                      : loop_mbar_phase_stack_.back(),
-                  &mbarrier_buffer_, cluster_size_},
-        analyzer_);
+    RequireSmemAlignmentCallback require_smem_alignment_callback =
+        [this](Var data_var, int alignment) {
+          String key = data_var->name_hint;
+          auto it = smem_alignment_map_.find(key);
+          int64_t prev =
+              it != smem_alignment_map_.end() ? (*it).second->value : 0;
+          if (alignment > prev) {
+            smem_alignment_map_.Set(key, IntImm(DataType::Int(32), alignment));
+          }
+        };
+
+    LowerArgs lower_args;
+    lower_args.target = target_;
+    lower_args.thread_bounds = thread_bounds;
+    lower_args.thread_var = thread_var_->var;
+    lower_args.layout_map = layout_map_;
+    lower_args.buffer_remap = buffer_remap_;
+    lower_args.bind_var_to_expr = bind_var_to_expr;
+    lower_args.mbar_phase_expr = loop_mbar_phase_stack_.empty()
+                                     ? PrimExpr(IntImm(DataType::Int(32), 0))
+                                     : loop_mbar_phase_stack_.back();
+    lower_args.mbarrier_buffer = &mbarrier_buffer_;
+    lower_args.cluster_size = cluster_size_;
+    lower_args.add_workspace = add_workspace_callback;
+    lower_args.alloc_mbarrier = mbarrier_callback;
+    lower_args.update_barrier_arrive = barrier_arrive_callback;
+    lower_args.require_smem_alignment = require_smem_alignment_callback;
+
+    auto lowered = tile_op->Lower(lower_args, analyzer_);
 
     return IRMutatorWithAnalyzer::VisitStmt(lowered);
   }
@@ -1515,11 +1545,11 @@ private:
   // Stack of per-Block workspace buffers gathered while visiting children
   std::vector<Array<Buffer>> workspace_stack_;
   // Counter and arrive-counts for mbarrier allocation via
-  // AllocMBarrierCallback. Used to inject a barrier buffer with
+  // alloc_mbarrier callback. Used to inject a barrier buffer with
   // barrier_init annotation into the root block after all tile ops are lowered.
   int mbarrier_count_{0};
   std::vector<int> mbarrier_arrive_counts_;
-  // The shared.barrier scope buffer created lazily by AllocMBarrier callback.
+  // The shared.barrier scope buffer created lazily by alloc_mbarrier callback.
   Optional<Buffer> mbarrier_buffer_;
   // Fallback mbarrier parity derived from the nearest enclosing serial loop.
   std::vector<PrimExpr> loop_mbar_phase_stack_;
@@ -1540,6 +1570,10 @@ private:
   // Pending barrier arrive-count overrides from multi-TMA cluster copies.
   std::unordered_map<Var, PrimExpr, ObjectPtrHash, ObjectPtrEqual>
       barrier_arrive_updates_;
+  // Per-buffer shared-memory alignment requirements (bytes) reported by op
+  // lowerings via the require_smem_alignment callback, keyed by the data Var's
+  // name hint. Written back as the kSmemAlignmentMap PrimFunc attribute.
+  Map<String, IntImm> smem_alignment_map_;
 };
 
 namespace transform {

--- a/src/transform/merge_shared_memory_allocations.cc
+++ b/src/transform/merge_shared_memory_allocations.cc
@@ -44,7 +44,6 @@
 #include <utility>
 
 #include "../op/builtin.h"
-#include "backend/common/target_utils.h"
 #include "runtime/thread_storage_scope.h"
 #include "tir/transforms/ir_utils.h"
 #include <tvm/tirx/function.h>
@@ -370,8 +369,16 @@ private:
 class SharedMemoryAlignmentPlanner : public StmtExprVisitor {
 
 public:
-  static std::unordered_map<const VarNode *, int> Plan(const Stmt &stmt) {
+  // explicit_alignments carries the per-buffer requirements recorded by op
+  // lowering (kSmemAlignmentMap); the scan below adds a conservative fallback
+  // for shared vars that reach swizzle-sensitive instructions without an
+  // explicit entry.
+  static std::unordered_map<const VarNode *, int>
+  Plan(const Stmt &stmt,
+       const std::unordered_map<const VarNode *, int> &explicit_alignments) {
     SharedMemoryAlignmentPlanner planner;
+    planner.shmem_alignment_map_ = explicit_alignments;
+    planner.explicit_alignment_map_ = &explicit_alignments;
     planner(stmt);
     return planner.shmem_alignment_map_;
   }
@@ -387,20 +394,17 @@ private:
       return;
     auto scope = GetPtrStorageScope(GetRef<Var>(op));
     if (scope == "shared" || scope == "shared.dyn") {
-      auto target = Target::Current();
-      ICHECK(target.defined()) << "Target is not defined";
-      // TMA bulk-copy operands have stricter shared-memory alignment than
-      // ordinary scalar/shared accesses. Hopper keeps the existing 1024-byte
-      // alignment used by the WGMMA/TMA path, while Blackwell/SM120 also needs
-      // TMA sources at least 128-byte aligned to avoid misaligned-address
-      // launch failures.
-      int alignment = 16;
-      if (TargetIsHopper(target)) {
-        alignment = 1024;
-      } else if (TargetHasBulkCopy(target)) {
-        alignment = 128;
-      }
-      shmem_alignment_map_[op] = alignment;
+      // An explicit requirement recorded at lowering time is exact; keep it.
+      if (explicit_alignment_map_->count(op))
+        return;
+      // TMA bulk-copy and MMA-descriptor operands have stricter shared-memory
+      // alignment than ordinary shared accesses, and the exact requirement
+      // depends on the operand's swizzle mode (up to 1024B for 128B swizzle).
+      // Buffers without an explicit kSmemAlignmentMap entry get the worst
+      // case: a misaligned base is not a launch error but silent data
+      // corruption, so never under-align here.
+      int &slot = shmem_alignment_map_[op];
+      slot = std::max(slot, 1024);
     }
   }
 
@@ -436,6 +440,8 @@ private:
 
   bool under_alignment_scope_{false};
 
+  const std::unordered_map<const VarNode *, int> *explicit_alignment_map_{
+      nullptr};
   std::unordered_map<const VarNode *, int> shmem_alignment_map_;
 };
 
@@ -464,11 +470,14 @@ public:
    */
   void PlanReuse(const Stmt &stmt, bool is_dynamic = true,
                  bool enable_aggressive_merge = false, bool verbose = false,
-                 bool disable_reuse = false) {
+                 bool disable_reuse = false,
+                 const std::unordered_map<const VarNode *, int>
+                     &explicit_alignments = {}) {
     SharedMemLinearAccessPatternFinder finder(is_dynamic,
                                               enable_aggressive_merge, verbose);
     finder(stmt);
-    shmem_alignment_map_ = SharedMemoryAlignmentPlanner::Plan(stmt);
+    shmem_alignment_map_ =
+        SharedMemoryAlignmentPlanner::Plan(stmt, explicit_alignments);
     if (disable_reuse) {
       this->PlanSequentialLayout();
     } else {
@@ -476,6 +485,21 @@ public:
       // the arena packer.
       this->LivenessAnalysis(finder.linear_seq_, finder.stmt_attrs_);
       this->PlanMemory(finder.linear_seq_, finder.stmt_attrs_);
+    }
+    // Post-condition: every buffer with an alignment requirement must have
+    // been placed on a conforming offset. A violation here would surface as
+    // silent data corruption at runtime (TMA/MMA swizzle phase mismatch), so
+    // fail loudly at compile time instead.
+    for (const auto &[var, required] : shmem_alignment_map_) {
+      auto offset_it = buffer_byte_offsets_.find(var);
+      if (offset_it == buffer_byte_offsets_.end())
+        continue;
+      if (const auto *imm = offset_it->second.as<IntImmNode>()) {
+        ICHECK_EQ(imm->value % required, 0)
+            << "Shared memory buffer " << var->name_hint << " placed at byte "
+            << "offset " << imm->value << ", which violates its required "
+            << required << "-byte alignment (TMA/MMA swizzle constraint)";
+      }
     }
   }
 
@@ -1599,15 +1623,35 @@ Stmt MergeSharedMemoryAllocations(Stmt stmt, bool merge_static_smem,
                                   bool enable_aggressive_merge,
                                   int align_bytes = 16, bool verbose = false,
                                   bool preserve_aliases = true,
-                                  bool disable_reuse = false) {
+                                  bool disable_reuse = false,
+                                  const std::unordered_map<std::string, int>
+                                      &explicit_alignments_by_name = {}) {
   AllocateCollector collector;
   collector(stmt);
+  // The kSmemAlignmentMap attribute is keyed by buffer-var name (names are
+  // stable across the pass pipeline while Var nodes may be rebuilt); resolve
+  // to the VarNodes of the collected allocations. Names of distinct shared
+  // allocations are unique within a kernel, and a collision could only
+  // over-align.
+  auto resolve =
+      [&](const std::unordered_map<const VarNode *, const AllocBufferNode *>
+              &allocs) {
+        std::unordered_map<const VarNode *, int> resolved;
+        for (const auto &[var, alloc] : allocs) {
+          auto it =
+              explicit_alignments_by_name.find(std::string(var->name_hint));
+          if (it != explicit_alignments_by_name.end()) {
+            resolved[var] = it->second;
+          }
+        }
+        return resolved;
+      };
   if (collector.dyn_shmem_allocs_.size() > 1) {
     SharedMemoryRewriter rewriter(collector.dyn_shmem_allocs_, true, verbose,
                                   align_bytes, preserve_aliases);
     rewriter.PlanReuse(stmt, true,
                        disable_reuse ? false : enable_aggressive_merge, false,
-                       disable_reuse);
+                       disable_reuse, resolve(collector.dyn_shmem_allocs_));
     stmt = rewriter(std::move(stmt));
   }
   if (merge_static_smem && collector.static_shmem_allocs_.size() > 1) {
@@ -1615,7 +1659,7 @@ Stmt MergeSharedMemoryAllocations(Stmt stmt, bool merge_static_smem,
                                   verbose, align_bytes, preserve_aliases);
     rewriter.PlanReuse(stmt, false,
                        disable_reuse ? false : enable_aggressive_merge, false,
-                       disable_reuse);
+                       disable_reuse, resolve(collector.static_shmem_allocs_));
     stmt = rewriter(std::move(stmt));
   }
   return stmt;
@@ -1639,11 +1683,20 @@ Pass MergeSharedMemoryAllocations(bool enable_aggressive_merge = false,
     if (auto target = f->GetAttr<Target>(tvm::attr::kTarget)) {
       preserve_aliases = target.value()->kind->name != "webgpu";
     }
+    // Per-buffer alignment requirements recorded by op lowering
+    // (swizzle-dependent TMA/MMA constraints), propagated onto the device
+    // kernel by SplitHostDevice.
+    std::unordered_map<std::string, int> explicit_alignments;
+    if (auto opt = f->GetAttr<Map<String, IntImm>>(kSmemAlignmentMap)) {
+      for (const auto &[name, align] : opt.value()) {
+        explicit_alignments[std::string(name)] = static_cast<int>(align->value);
+      }
+    }
     auto *n = f.CopyOnWrite();
     n->body = tl::MergeSharedMemoryAllocations(
         std::move(n->body), merge_static_smem, enable_aggressive_merge,
         align_bytes, debug_merge_shared_memory_allocations, preserve_aliases,
-        disable_reuse);
+        disable_reuse, explicit_alignments);
     return f;
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.MergeSharedMemoryAllocations",

--- a/src/transform/split_host_device.cc
+++ b/src/transform/split_host_device.cc
@@ -70,6 +70,10 @@ public:
     cluster_dims_ = std::move(cluster_dims);
   }
 
+  void SetSmemAlignmentMap(Map<String, IntImm> smem_alignment_map) {
+    smem_alignment_map_ = std::move(smem_alignment_map);
+  }
+
   void SetHostFuncSignature(const tirx::PrimFunc &func) {
     host_buffer_map_ = func->buffer_map;
   }
@@ -113,6 +117,9 @@ private:
   Map<tirx::Var, tirx::Buffer> host_buffer_map_;
   Array<tirx::Var> non_restrict_params_;
   Optional<Array<Integer>> cluster_dims_{std::nullopt};
+  // Per-buffer shared-memory alignment requirements (kSmemAlignmentMap)
+  // propagated from the host PrimFunc onto each split device kernel.
+  Map<String, IntImm> smem_alignment_map_;
   Optional<String> code_block_source_{std::nullopt};
   Optional<String> code_block_entry_name_{std::nullopt};
 
@@ -372,6 +379,9 @@ private:
     if (cluster_dims_.defined()) {
       device_attrs.Set("cluster_dims", cluster_dims_.value());
     }
+    if (!smem_alignment_map_.empty()) {
+      device_attrs.Set(tl::kSmemAlignmentMap, smem_alignment_map_);
+    }
     if (code_block_source_) {
       device_attrs.Set(tl::attr::kCodeBlockSource, code_block_source_.value());
     }
@@ -431,6 +441,13 @@ tirx::PrimFunc SplitHostDevice(tirx::PrimFunc func, IRModule *device_mod,
   if (auto opt = func->GetAttr<Array<Integer>>("cluster_dims")) {
     splitter.SetClusterDims(opt.value());
     func = tvm::WithoutAttr(std::move(func), "cluster_dims");
+  }
+  // Propagate per-buffer shared-memory alignment requirements collected by
+  // LowerTileOp onto the device kernel, where MergeSharedMemoryAllocations
+  // consumes them.
+  if (auto opt = func->GetAttr<Map<String, IntImm>>(tl::kSmemAlignmentMap)) {
+    splitter.SetSmemAlignmentMap(opt.value());
+    func = tvm::WithoutAttr(std::move(func), tl::kSmemAlignmentMap);
   }
 
   if (auto body = splitter(func->body); !body.same_as(func->body)) {

--- a/testing/python/transform/test_tilelang_transform_smem_swizzle_alignment.py
+++ b/testing/python/transform/test_tilelang_transform_smem_swizzle_alignment.py
@@ -1,0 +1,124 @@
+"""Regression tests for TMA copies into swizzled shared memory.
+
+TMA applies the descriptor swizzle relative to the destination shared-memory
+base. A swizzled destination therefore needs to start on the swizzle period
+boundary, not just on the generic 128B TMA base alignment.
+"""
+
+import re
+
+import pytest
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.layout import make_swizzled_layout
+
+TILE_M = 128
+THREADS = 256
+INT32_BYTES = 4
+MISALIGNING_PAD_ELEMS = 32
+
+
+@tilelang.jit(pass_configs={tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True})
+def _make_swizzled_tma_copy_kernel(pad_elems: int, dtype: str, columns: int):
+    elems_per_thread = TILE_M * columns // THREADS
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor[(TILE_M, columns), dtype],
+        out: T.Tensor[(TILE_M, columns), dtype],
+        dummy: T.Tensor[(1,), T.int32],
+    ):
+        with T.Kernel(1, threads=THREADS) as _:
+            pad = T.alloc_shared((pad_elems,), T.int32)
+            smem = T.alloc_shared((TILE_M, columns), dtype)
+            T.annotate_layout({smem: make_swizzled_layout(smem)})
+
+            tid = T.get_thread_binding(0)
+            if tid < pad_elems:
+                pad[tid] = tid
+            T.sync_threads()
+
+            bar = T.alloc_barrier(THREADS)
+            T.tma_copy(A[0, 0], smem, barrier=bar)
+            T.barrier_arrive(bar)
+            T.mbarrier_wait_parity(bar, 0)
+            for i in T.serial(elems_per_thread):
+                elem = tid * elems_per_thread + i
+                out[elem // columns, elem % columns] = smem[elem // columns, elem % columns]
+
+            if tid == 0:
+                dummy[0] = pad[pad_elems - 1]
+
+    return kernel
+
+
+def _compile_kernel(pad_elems: int, dtype: str, columns: int):
+    tilelang.disable_cache()
+    try:
+        return _make_swizzled_tma_copy_kernel(pad_elems, dtype, columns)
+    finally:
+        tilelang.enable_cache()
+
+
+def _dynamic_smem_offset(source: str, buffer_name: str) -> int:
+    """Extract the byte offset of a dynamic shared-memory alias."""
+    pattern = rf"void\*\s+{re.escape(buffer_name)}\s*=\s*\(\(void\*\)\(\(char\*\)buf_dyn_shmem\s*\+\s*(\d+)\)\)"
+    match = re.search(pattern, source)
+    assert match is not None, f"dynamic shared buffer {buffer_name!r} not found in source:\n{source}"
+    return int(match.group(1))
+
+
+SWIZZLE_ALIGNMENT_CASES = [
+    pytest.param("float16", 16, 256, id="32B-swizzle"),
+    pytest.param("float16", 32, 512, id="64B-swizzle"),
+    pytest.param("float16", 64, 1024, id="128B-swizzle"),
+]
+
+PAD_LIVENESS_CASES = [
+    pytest.param(32, id="pad-128B"),
+    pytest.param(96, id="pad-384B"),
+    pytest.param(256, id="pad-1024B"),
+]
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+@pytest.mark.parametrize(("dtype", "columns", "required_alignment"), SWIZZLE_ALIGNMENT_CASES)
+def test_tma_swizzled_smem_uses_swizzle_period_alignment(dtype, columns, required_alignment):
+    # 32 int32 values create a 128B live allocation before smem. That is enough
+    # for the generic TMA requirement, but not enough for any swizzle period.
+    kernel = _compile_kernel(MISALIGNING_PAD_ELEMS, dtype, columns)
+    source = kernel.get_kernel_source()
+    pad_offset = _dynamic_smem_offset(source, "pad")
+    smem_offset = _dynamic_smem_offset(source, "smem")
+
+    assert pad_offset == 0
+    assert MISALIGNING_PAD_ELEMS * INT32_BYTES == 128
+    assert smem_offset % required_alignment == 0, (
+        f"swizzled smem tile at +{smem_offset}B violates required {required_alignment}B alignment\n{source}"
+    )
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+@pytest.mark.parametrize("pad_elems", PAD_LIVENESS_CASES)
+def test_tma_swizzled_copy_correctness(pad_elems):
+    import torch
+
+    columns = 64
+    kernel = _compile_kernel(pad_elems, "bfloat16", columns)
+    A = torch.randn((TILE_M, columns), dtype=torch.bfloat16, device="cuda")
+    out = torch.zeros_like(A)
+    dummy = torch.zeros((1,), dtype=torch.int32, device="cuda")
+
+    kernel(A, out, dummy)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(out, A, rtol=0, atol=0)
+    # Keep the pad live so the allocator has to place smem after it.
+    assert int(dummy.item()) == pad_elems - 1
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

- Fix TMA bulk-copy destinations that use swizzled shared-memory layouts by carrying per-buffer base alignment requirements from tile-op lowering into shared-memory allocation merging.
- Prevent swizzled TMA tiles from being packed at a generic 128B-aligned offset when the selected swizzle mode requires a 256B, 512B, or 1024B base.
- Add CUDA regression coverage for generated dynamic shared-memory offsets and runtime copy correctness.

## Changes

- Add `SmemAlignmentForSwizzle` and a `tl.smem_alignment_map` PrimFunc attribute for exact swizzle-period alignment requirements.
- Thread a `require_smem_alignment` callback through `LowerArgs`, propagate the attribute through host/device splitting, and teach `MergeSharedMemoryAllocations` to honor explicit per-buffer alignments.
- Clean up `LowerArgs` callback naming and construction so callback fields are grouped and assigned explicitly.
- Add `test_tilelang_transform_smem_swizzle_alignment.py` for 32B, 64B, and 128B swizzle alignment plus BF16 runtime correctness checks.

## Validation

- `pre-commit run --all-files`
- `cmake --build build -j$(nproc)`
- `python -m pytest testing/python/transform/test_tilelang_transform_smem_swizzle_alignment.py -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced GPU shared memory alignment validation for TMA copy operations to prevent silent data corruption at compile time.

* **Tests**
  * Added comprehensive regression tests for GPU TMA copy operations with swizzled shared memory alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->