### PR TITLE
[CUDA] Add SM75 MMA dispatchers for FP16 accumulation and UINT8

### DIFF
--- a/src/tl_templates/cuda/instruction/mma.h
+++ b/src/tl_templates/cuda/instruction/mma.h
@@ -104,6 +104,57 @@ struct SM75_8x8x32_S32U4U4S32_TN {
   }
 };
 
+struct SM75_16x8x8_F16F16F16F16_TN {
+  using DRegisters = uint32_t[2];
+  using ARegisters = uint32_t[2];
+  using BRegisters = uint32_t[1];
+  using CRegisters = uint32_t[2];
+
+  CUTE_HOST_DEVICE static void fma(uint32_t &d0, uint32_t &d1,
+                                   uint32_t const &a0, uint32_t const &a1,
+                                   uint32_t const &b0, uint32_t const &c0,
+                                   uint32_t const &c1) {
+#if defined(CUTE_ARCH_MMA_SM75_ENABLED)
+    asm volatile("mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16"
+                 "{%0, %1},"
+                 "{%2, %3},"
+                 "{%4},"
+                 "{%5, %6};\n"
+                 : "=r"(d0), "=r"(d1)
+                 : "r"(a0), "r"(a1), "r"(b0), "r"(c0), "r"(c1));
+#else
+    CUTE_INVALID_CONTROL_PATH(
+        "Attempting to use SM75_16x8x8_F16F16F16F16_TN without "
+        "CUTE_ARCH_MMA_SM75_ENABLED");
+#endif
+  }
+};
+
+struct SM75_8x8x16_S32U8U8S32_TN {
+  using DRegisters = uint32_t[2];
+  using ARegisters = uint32_t[1];
+  using BRegisters = uint32_t[1];
+  using CRegisters = uint32_t[2];
+
+  CUTE_HOST_DEVICE static void fma(uint32_t &d0, uint32_t &d1,
+                                   uint32_t const &a0, uint32_t const &b0,
+                                   uint32_t const &c0, uint32_t const &c1) {
+#if defined(CUTE_ARCH_MMA_SM75_ENABLED)
+    asm volatile("mma.sync.aligned.m8n8k16.row.col.s32.u8.u8.s32"
+                 "{%0, %1},"
+                 "{%2},"
+                 "{%3},"
+                 "{%4, %5};\n"
+                 : "=r"(d0), "=r"(d1)
+                 : "r"(a0), "r"(b0), "r"(c0), "r"(c1));
+#else
+    CUTE_INVALID_CONTROL_PATH(
+        "Attempting to use SM75_8x8x16_S32U8U8S32_TN without "
+        "CUTE_ARCH_MMA_SM75_ENABLED");
+#endif
+  }
+};
+
 template <DataType AType, DataType BType, DataType CType, int M, int N, int K,
           bool TransA, bool TransB, bool Saturate>
 struct MmaDispatcher {
@@ -146,6 +197,9 @@ TL_DEFINE_MMA_DISPATCHER(kFloat16, kFloat16, kFloat32, 16, 8, 16, false, true,
                          false, cute::SM80_16x8x16_F32F16F16F32_TN)
 TL_DEFINE_MMA_DISPATCHER(kFloat16, kFloat16, kFloat32, 16, 8, 8, false, true,
                          false, cute::SM75_16x8x8_F32F16F16F32_TN)
+// FP16 accumulation (k8) for SM75
+TL_DEFINE_MMA_DISPATCHER(kFloat16, kFloat16, kFloat16, 16, 8, 8, false, true,
+                         false, tl::detail::SM75_16x8x8_F16F16F16F16_TN)
 
 // BF16 inputs
 TL_DEFINE_MMA_DISPATCHER(kBFloat16, kBFloat16, kFloat32, 16, 8, 16, false, true,
@@ -160,6 +214,8 @@ TL_DEFINE_MMA_DISPATCHER(kUInt8, kUInt8, kInt32, 16, 8, 32, false, true, false,
 // INT8 inputs (k16) for SM75
 TL_DEFINE_MMA_DISPATCHER(kInt8, kInt8, kInt32, 8, 8, 16, false, true, false,
                          cute::SM75_8x8x16_S32S8S8S32_TN)
+TL_DEFINE_MMA_DISPATCHER(kUInt8, kUInt8, kInt32, 8, 8, 16, false, true, false,
+                         tl::detail::SM75_8x8x16_S32U8U8S32_TN)
 
 // INT4 inputs (k32) for SM75
 TL_DEFINE_MMA_DISPATCHER(kInt4, kInt4, kInt32, 8, 8, 32, false, true, false,

--- a/testing/python/cuda/test_cuda_mma_sm75_dispatch.py
+++ b/testing/python/cuda/test_cuda_mma_sm75_dispatch.py
@@ -70,6 +70,29 @@ def test_sm75_int8_emitter_uses_m8n8k16_shape():
     assert emitter.get_store_index_map() is not None
 
 
+def test_sm75_uint8_emitter_uses_m8n8k16_shape():
+    emitter = TensorCoreIntrinEmitterSM75(
+        a_dtype=T.uint8,
+        b_dtype=T.uint8,
+        accum_dtype=T.int32,
+        a_transposed=False,
+        b_transposed=True,
+        block_row_warps=2,
+        block_col_warps=2,
+        warp_row_tiles=32,
+        warp_col_tiles=32,
+        chunk=64,
+    )
+
+    assert emitter.mma_prefix == "m8n8k16"
+    assert emitter.micro_size_x == 8
+    assert emitter.micro_size_y == 8
+    assert emitter.micro_size_k == 16
+    assert emitter.local_size_a == 4
+    assert emitter.local_size_b == 4
+    assert emitter.local_size_out == 2
+
+
 def test_sm75_int4_emitter_uses_m8n8k32_shape():
     emitter = TensorCoreIntrinEmitterSM75(
         a_dtype=T.int4,

--- a/testing/python/kernel/test_tilelang_kernel_gemm_sm75.py
+++ b/testing/python/kernel/test_tilelang_kernel_gemm_sm75.py
@@ -60,6 +60,44 @@ def test_sm75_f16_gemm_uses_m16n8k8_and_matches_torch():
 
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_eq(7, 5)
+def test_sm75_f16_gemm_f16_accum_uses_m16n8k8_and_matches_torch():
+    M = N = K = 128
+    kernel = tilelang.compile(
+        _make_gemm_kernel(M, N, K, 64, 64, 32, T.float16, T.float16, T.float16),
+        target="cuda",
+        out_idx=[2],
+    )
+    _assert_mma_sync_shape(kernel.get_kernel_source(), "kFloat16", "kFloat16", 16, 8, 8)
+
+    a = torch.randn((M, K), device="cuda", dtype=torch.float16) * 0.1
+    b = torch.randn((N, K), device="cuda", dtype=torch.float16) * 0.1
+    c = kernel(a, b)
+    ref = (a.float() @ b.float().T).to(torch.float16)
+
+    tilelang.testing.torch_assert_close(c, ref, rtol=1e-2, atol=1e-2, max_mismatched_ratio=0.01)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(7, 5)
+def test_sm75_uint8_gemm_uses_m8n8k16_and_matches_torch():
+    M = N = K = 128
+    kernel = tilelang.compile(
+        _make_gemm_kernel(M, N, K, 64, 64, 64, T.uint8, T.int32, T.int32),
+        target="cuda",
+        out_idx=[2],
+    )
+    _assert_mma_sync_shape(kernel.get_kernel_source(), "kUInt8", "kInt32", 8, 8, 16)
+
+    a = torch.randint(0, 256, (M, K), device="cuda", dtype=torch.uint8)
+    b = torch.randint(0, 256, (N, K), device="cuda", dtype=torch.uint8)
+    c = kernel(a, b)
+    ref = (a.cpu().to(torch.int32) @ b.cpu().to(torch.int32).T).to(device="cuda")
+
+    tilelang.testing.torch_assert_close(c, ref, rtol=0, atol=0)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(7, 5)
 def test_sm75_int8_gemm_uses_m8n8k16_and_matches_torch():
     M = N = K = 128
     kernel = tilelang.compile(


### PR DESCRIPTION
## Summary

Adds two SM75/Turing MMA dispatchers that the GEMM emitter already produces shapes for but the C++ dispatcher table was missing:

- `fp16 → fp16` accumulation — `mma.sync.aligned.m16n8k8.row.col.f16.f16.f16.f16`
- `uint8 → int32` — `mma.sync.aligned.m8n8k16.row.col.s32.u8.u8.s32`

## Why

The SM75 emitter derives the MMA shape from the input `a_dtype` bit-width, independent of the accumulator dtype and operand signedness, so it emits the same `(16,8,8)` shape for `fp16→fp16` accum as for the registered `fp16→fp32` case, and the same `(8,8,16)` shape for `uint8` as for signed `int8` (`uint8` is already in `dtype_abbrv` on the generic `TensorCoreIntrinEmitter` base class). Both configurations already work on SM80; this brings SM75 to parity.

But the dispatcher table was missing these two configurations, so `fp16→fp16`-accum or `uint8` GEMM on Turing failed at nvcc with an opaque static assertion:

```
mma.h: error: static assertion failed with "tl::mma_sync: unsupported configuration"
  [with AType=kFloat16, BType=kFloat16, CType=kFloat16, M=16, N=8, K=8, ...]
```

CuTe's `cute/arch/mma_sm75.hpp` only ships the `fp16→fp32` and signed-`int8` atoms, so the two new atoms are hand-written in `tl::detail` with inline PTX matching CUTLASS's own `cutlass/arch/mma_sm75.h` — the same approach #2198 used for `int4`/`uint4`. The `uint8` atom uses the non-saturating form to match the existing signed-`int8` dispatcher.

## Tested

Environment: NVIDIA TITAN RTX (SM75), CUDA 12.4.

`nvcc -arch=sm_75` on the exact `tl::mma_sync<...>` calls codegen emits: both configs fail to compile before this change and compile after; emitted PTX is the two instructions listed above.

```
pytest testing/python/kernel/test_tilelang_kernel_gemm_sm75.py \
       testing/python/cuda/test_cuda_mma_sm75_dispatch.py
# 14 passed
```

`uint8` is checked against an exact int32 torch reference; `fp16→fp16` accum against a torch reference at `rtol/atol=1e-2`. Existing fp16/int8/int4 paths and the `uint4`-unadvertised negative test still pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled SM75 GPU optimizations for FP16 GEMM operations with FP16 accumulation
  * Enabled SM75 GPU optimizations for unsigned INT8 GEMM operations with INT32 accumulation

* **Tests**
  * Added validation tests for new SM75 GEMM optimizations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->