### PR TITLE
[Language] Fix TMA 1D load test lowering

### DIFF
--- a/testing/python/language/test_tilelang_language_tma_1d.py
+++ b/testing/python/language/test_tilelang_language_tma_1d.py
@@ -17,8 +17,16 @@ def elementwise_add(M, N, block_M, block_N, in_dtype, out_dtype, threads):
             C_local = T.alloc_fragment((block_M, block_N), out_dtype)
             C_shared = T.alloc_shared((block_M, block_N), out_dtype)
 
-            T.copy(A[by * block_M, bx * block_N], A_shared)
-            T.copy(B[by * block_M, bx * block_N], B_shared)
+            T.copy(
+                A[by * block_M, bx * block_N],
+                A_shared,
+                annotations={"prefer_instruction": "tma"},
+            )
+            T.copy(
+                B[by * block_M, bx * block_N],
+                B_shared,
+                annotations={"prefer_instruction": "tma"},
+            )
             for local_y, local_x in T.Parallel(block_M, block_N):
                 C_local[local_y, local_x] = A_shared[local_y, local_x] + B_shared[local_y, local_x]
             T.copy(C_local, C_shared)
@@ -46,11 +54,12 @@ def run_elementwise_add(M, N):
         assert "tma_load" in code and "CUtensorMap" in code
 
 
-def main():
+def test_tilelang_language_tma_1d():
     run_elementwise_add(128, 128)
     run_elementwise_add(256, 128)
     run_elementwise_add(256, 256)
 
 
 if __name__ == "__main__":
-    main()
+    tilelang.disable_cache()
+    run_elementwise_add(128, 128)

--- a/testing/python/language/test_tilelang_language_tma_1d.py
+++ b/testing/python/language/test_tilelang_language_tma_1d.py
@@ -61,5 +61,4 @@ def test_tilelang_language_tma_1d():
 
 
 if __name__ == "__main__":
-    tilelang.disable_cache()
-    run_elementwise_add(128, 128)
+    test_tilelang_language_tma_1d()


### PR DESCRIPTION
## Summary

- Update the TMA 1D language test so the global-to-shared input copies explicitly request TMA lowering.
- Keep the test aligned with CUDA copy selection behavior, where plain `T.copy` auto-selects TMA stores but does not auto-select TMA loads.
- Preserve the existing source checks for descriptor-free 1D TMA and descriptor-backed multi-tile cases.

## Changes

- Add `annotations={"prefer_instruction": "tma"}` to the A and B global-to-shared copies in `test_tilelang_language_tma_1d.py`.
- Expose the file as a pytest test via `test_tilelang_language_tma_1d` while keeping a direct execution path for the smallest case.

## Validation

- `pre-commit run --all-files`
- `python -m pytest testing/python/language/test_tilelang_language_tma_1d.py -q`
- `python testing/python/language/test_tilelang_language_tma_1d.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded the TileLang kernel test coverage by adding a dedicated test runner that executes the elementwise add workflow across multiple input shapes (128×128, 256×128, 256×256).
  * Updated shared-memory load behavior to use a TMA-oriented instruction preference, improving performance-oriented validation during the tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->