### PR TITLE
[BugFix] Fix bf16 CUDA exp self-recursion

### DIFF
--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -946,8 +946,11 @@ TL_DEVICE __half2 abs2(__half2 a) {
 using tl::tfloat32_t;
 
 namespace cutlass {
+// Mirror cutlass's own half_t fast_exp (fast_math.h): route through float.
+// A direct `return ::hexp(x)` recurses, since `hexp` is #define'd to this
+// same cutlass::fast_exp and x is already bfloat16_t.
 TL_DEVICE
-bfloat16_t fast_exp(bfloat16_t x) { return ::hexp(x); }
+bfloat16_t fast_exp(bfloat16_t x) { return bfloat16_t(fast_exp(float(x))); }
 } // namespace cutlass
 
 //

--- a/testing/python/cuda/test_cuda_bfloat16_math_intrinsics.py
+++ b/testing/python/cuda/test_cuda_bfloat16_math_intrinsics.py
@@ -41,3 +41,46 @@ def test_bfloat16_rsqrt_compiles_and_runs():
     actual = kernel(inputs)
 
     torch.testing.assert_close(actual, torch.full_like(actual, 0.5))
+
+
+def test_cuda_common_h_bfloat16_fast_exp_does_not_self_recurse():
+    repo_root = Path(__file__).resolve().parents[3]
+    common_h = repo_root / "src" / "tl_templates" / "cuda" / "common.h"
+    source = common_h.read_text()
+
+    # `hexp` is #define'd to cutlass::fast_exp, so the bf16 fast_exp overload
+    # must route through float; calling `::hexp(x)` here recurses into itself.
+    match = re.search(
+        r"bfloat16_t\s+fast_exp\s*\(\s*bfloat16_t\s+x\s*\)\s*\{([^}]*)\}",
+        source,
+    )
+    assert match, "common.h must define fast_exp(bfloat16_t) for bf16 T.exp codegen"
+    body = match.group(1)
+    assert "float(" in body, "bf16 fast_exp must route through float to avoid self-recursion"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_bfloat16_exp_compiles_and_runs():
+    import tilelang
+    import tilelang.language as T
+
+    if torch.cuda.get_device_capability() < (8, 0):
+        pytest.skip("bfloat16 CUDA math requires compute capability >= 8.0")
+
+    n = 32
+
+    @T.prim_func
+    def main(A: T.Tensor((n,), T.bfloat16), B: T.Tensor((n,), T.bfloat16)):
+        with T.Kernel(1, threads=32):
+            values = T.alloc_fragment((n,), T.bfloat16)
+            for i in T.Parallel(n):
+                values[i] = T.exp(A[i])
+            for i in T.Parallel(n):
+                B[i] = values[i]
+
+    kernel = tilelang.compile(main, out_idx=[1], target="cuda")
+    inputs = torch.full((n,), 1.0, dtype=torch.bfloat16, device="cuda")
+    actual = kernel(inputs)
+
+    expected = torch.exp(inputs)
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
## Summary

`T.exp` on `bfloat16` returns garbage. The hand-written `cutlass::fast_exp(bfloat16_t)` overload in `common.h` calls itself infinitely.

## Why

`common.h` redirects the fast-math intrinsics with `#define hexp cutlass::fast_exp` (line 37), and the bf16 overload was written as:

```cpp
namespace cutlass {
bfloat16_t fast_exp(bfloat16_t x) { return ::hexp(x); }
}
```

After macro expansion this is `return ::cutlass::fast_exp(x);` with `x` already a `bfloat16_t`, so it selects the same overload — infinite self-recursion, and bf16 `T.exp` returns garbage. `CUDAMath` lowers bf16 `exp` to scalar `hexp(...)` (there is no vectorized `h2exp` path), so every bf16 `T.exp` hits it.

The fix routes through `float`, mirroring cutlass's own `half_t fast_exp` (`cutlass/fast_math.h`):

```cpp
bfloat16_t fast_exp(bfloat16_t x) { return bfloat16_t(fast_exp(float(x))); }
```

`fast_exp(float(x))` resolves to `cutlass::fast_exp(float)` (= `::expf`), so there is no recursion. The `#define` is intentionally kept — it is the shared fast-math redirect used by all dtypes; only the broken overload is corrected. exp is the only macro-redirected intrinsic (`hexp/hlog/hsqrt/hsin/hcos/htanh`) that has a hand-written bf16 overload, so this is the only one affected.

## Tested

Verified with the #2383 repro (bf16 vs fp16 vs `math.exp`) on an NVIDIA TITAN RTX, CUDA 12.4:

Before — bf16 column is garbage:
```
    in   math.exp       fp16       bf16
  1.00     2.7183     2.7188    15.0000
  2.00     7.3891     7.3906 58368.0000
  3.00    20.0855    20.0781 139460608.0
```

After — bf16 matches:
```
    in   math.exp       fp16       bf16
  1.00     2.7183     2.7188     2.7188
  2.00     7.3891     7.3906     7.3750
  3.00    20.0855    20.0781    20.1250
```

Added two tests to `test_cuda_bfloat16_math_intrinsics.py`, mirroring the existing `rsqrt` tests (#2386): a source-level guard asserting the overload routes through `float`, and a runtime `T.exp` test compared against `torch.exp`.

Fixes #2383.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed exponential function computation for bfloat16 precision type on CUDA hardware to prevent infinite recursion and ensure accurate mathematical results.

* **Tests**
  * Added comprehensive unit tests for bfloat16 exponential operations, including static verification and end-to-end runtime testing on CUDA hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->