### PR TITLE
[Feature] Support `st.bulk` for shared zero fill on SM100+

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -3586,6 +3586,13 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
         barrier_name_ + "[" + std::to_string(barrier_id) + "]";
     this->stream << PrintCpAsyncBulkAsm(dst, dst_offset, src, src_offset, size,
                                         barrier);
+  } else if (op->op.same_as(tl::ptx_st_bulk_shared())) {
+    need_cast_smem_ptr_to_int_ = true;
+    std::string smem = this->PrintExpr(op->args[0]);
+    int64_t bytes = Downcast<IntImm>(op->args[1])->value;
+    int64_t init_val = Downcast<IntImm>(op->args[2])->value;
+    this->stream << "tl::st_bulk_shared<" << bytes << ", " << init_val
+                 << ">((void*)(" << smem << "));\n";
   } else if (op->op.same_as(builtin::ptx_commit_group())) {
     this->stream << "__asm__ __volatile__(\"cp.async.commit_group;\");\n\n";
   } else if (op->op.same_as(builtin::ptx_wait_group())) {

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -1302,6 +1302,8 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
     LOG(FATAL) << "Currently unsupported op: " << op->op;
   } else if (op->op.same_as(builtin::ptx_cp_async_bulk())) {
     LOG(FATAL) << "Currently unsupported op: " << op->op;
+  } else if (op->op.same_as(tl::ptx_st_bulk_shared())) {
+    LOG(FATAL) << "Currently unsupported op: " << op->op;
   } else if (op->op.same_as(builtin::ptx_wait_barrier())) {
     LOG(FATAL) << "Currently unsupported op: " << op->op;
   } else if (op->op.same_as(builtin::ptx_ldg32())) {

--- a/src/cuda/op/fill.cc
+++ b/src/cuda/op/fill.cc
@@ -6,21 +6,103 @@
 #include "backend/common/op/fill.h"
 
 #include "backend/common/target_utils.h"
+#include "op/builtin.h"
+#include "op/utils.h"
+#include <tvm/arith/analyzer.h>
+#include <tvm/tirx/op.h>
+
+#include <optional>
 
 namespace tvm {
 namespace tl {
 
 namespace {
 
+using namespace tirx;
+
+bool CanUseStBulkShared(Target target) {
+  return TargetIsCuda(target) && !TargetIsCuTeDSL(target) &&
+         TargetHasSMVersionGE(target, 100);
+}
+
 bool MatchCudaFillTarget(Target target) {
   return TargetIsCuda(target) || TargetIsCuTeDSL(target);
+}
+
+bool IsZeroFillValue(const PrimExpr &value, arith::Analyzer *analyzer) {
+  if (const auto *broadcast = value.as<BroadcastNode>()) {
+    return IsZeroFillValue(broadcast->value, analyzer);
+  }
+  return analyzer->CanProveEqual(value, make_zero(value.dtype()));
+}
+
+std::optional<PrimExpr> FullRegionElements(const Buffer &buffer,
+                                           const Array<Range> &region,
+                                           arith::Analyzer *analyzer) {
+  ICHECK_EQ(buffer->shape.size(), region.size());
+  PrimExpr elements = make_const(DataType::Int(64), 1);
+  for (size_t i = 0; i < region.size(); ++i) {
+    if (!analyzer->CanProveEqual(region[i]->min, 0) ||
+        !analyzer->CanProveEqual(region[i]->extent, buffer->shape[i])) {
+      return std::nullopt;
+    }
+    elements = elements * cast(DataType::Int(64), region[i]->extent);
+  }
+  return elements;
+}
+
+std::optional<Stmt> TryLowerSharedBulkZeroFill(const FillNode &op,
+                                               const LowerArgs &T,
+                                               arith::Analyzer *analyzer) {
+  if (!CanUseStBulkShared(T.target)) {
+    return std::nullopt;
+  }
+  if (!IsSharedBuffer(op.dst) || !IsZeroFillValue(op.value, analyzer)) {
+    return std::nullopt;
+  }
+  if (!op.dst->strides.empty()) {
+    return std::nullopt;
+  }
+
+  auto elements = FullRegionElements(op.dst, op.region, analyzer);
+  if (!elements.has_value()) {
+    return std::nullopt;
+  }
+
+  int bits = op.dst->dtype.bits() * op.dst->dtype.lanes();
+  if (bits % 8 != 0) {
+    return std::nullopt;
+  }
+  PrimExpr bytes = analyzer->Simplify(elements.value() *
+                                      IntImm(DataType::Int(64), bits / 8));
+  auto bytes_imm = bytes.as<IntImmNode>();
+  if (bytes_imm == nullptr || bytes_imm->value % 8 != 0) {
+    return std::nullopt;
+  }
+
+  PrimExpr bulk_store =
+      Call(DataType::Handle(), ptx_st_bulk_shared(),
+           {op.dst->data, bytes, make_const(DataType::UInt(64), 0)});
+  Stmt body = Evaluate(bulk_store);
+  if (T.thread_var.defined() && T.thread_bounds.defined()) {
+    body = IfThenElse(EQ(T.thread_var, T.thread_bounds->min), body);
+  }
+  return body;
+}
+
+Stmt LowerCudaFill(const FillNode &op, const LowerArgs &T,
+                   arith::Analyzer *analyzer) {
+  if (auto bulk_fill = TryLowerSharedBulkZeroFill(op, T, analyzer)) {
+    return bulk_fill.value();
+  }
+  return backend::Fill::Lower(op, T, analyzer);
 }
 
 bool RegisterCudaFill() {
   RegisterFillImpl(FillImpl{
       "cuda.Fill",
       MatchCudaFillTarget,
-      backend::Fill::Lower,
+      LowerCudaFill,
   });
   return true;
 }

--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -306,6 +306,11 @@ TIR_DEFINE_TL_BUILTIN(ptx_cp_async)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
+TIR_DEFINE_TL_BUILTIN(ptx_st_bulk_shared)
+    .set_num_inputs(3)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
 TIR_DEFINE_TL_BUILTIN(fence_proxy_async)
     .set_num_inputs(0)
     .set_attr<TCallEffectKind>("TCallEffectKind",

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -525,6 +525,14 @@ TVM_DLL const Op &ptx_cp_async_barrier_noinc();
 TVM_DLL const Op &ptx_cp_async();
 
 /*!
+ * \brief TileLang intrinsic for zeroing shared memory with st.bulk.
+ *
+ * ptx_st_bulk_shared(smem_data, bytes, init_val)
+ *
+ */
+TVM_DLL const Op &ptx_st_bulk_shared();
+
+/*!
  * \brief Pack two b16 value into a b32 value
  *
  * int32 pack_b16(b16_value, b16_value)

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -726,6 +726,21 @@ TL_DEVICE uint1 pack_half2(half_t a, half_t b) {
   return uint1{packed};
 }
 
+template <uint64_t bytes, uint64_t init_val>
+TL_DEVICE void st_bulk_shared(void *smem_ptr) {
+  static_assert(init_val == 0,
+                "tl::st_bulk_shared only supports init_val == 0");
+#if (__CUDACC_VER_MAJOR__ > 12) ||                                             \
+    (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 8)
+  asm volatile("st.bulk.weak.shared::cta [%0], %1, 0;" ::"l"(
+                   __cvta_generic_to_shared(smem_ptr)),
+               "l"(bytes)
+               : "memory");
+#else
+  static_assert(false, "tl::st_bulk_shared requires CUDA >= 12.8");
+#endif
+}
+
 // --- add2 ----------------------------------------------------------------
 
 TL_DEVICE float2 add2(float2 a, float2 b) {

--- a/testing/python/language/test_tilelang_language_clear.py
+++ b/testing/python/language/test_tilelang_language_clear.py
@@ -1,5 +1,9 @@
 import tilelang
+import tilelang.testing
 import tilelang.language as T
+import pytest
+import torch
+from tilelang.contrib import nvcc
 
 
 # add decorator @tilelang.jit if you want to return a torch function
@@ -52,6 +56,29 @@ def run_matmul(M, N, K, block_M, block_N, block_K, dtype=T.float16, accum_dtype=
 
 def test_matmul():
     run_matmul(1024, 1024, 1024, 128, 128, 32)
+
+
+@tilelang.testing.requires_cuda_compute_version(10)
+def test_shared_fill_cast_zero_uses_st_bulk():
+    if nvcc.get_cuda_version() < (12, 8):
+        pytest.skip("st.bulk shared lowering requires CUDA toolkit >= 12.8")
+
+    @T.prim_func
+    def main(out: T.Tensor((128,), T.float32)):
+        with T.Kernel(1, threads=128):
+            smem = T.alloc_shared((128,), T.float32)
+            for i in T.Parallel(128):
+                smem[i] = T.float32(1.0)
+            T.fill(smem, T.cast(0, T.float32))
+            T.copy(smem, out)
+
+    kernel = tilelang.compile(main, target="cuda")
+    assert "tl::st_bulk_shared<512, 0>" in kernel.get_kernel_source()
+
+    out = torch.empty((128,), dtype=torch.float32, device="cuda")
+    kernel(out)
+    torch.cuda.synchronize()
+    assert torch.allclose(out, torch.zeros_like(out))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optimized CUDA shared memory fill operations using bulk store instructions, enabling faster zero-initialization of shared memory on compatible hardware (CUDA 12.8+).

* **Tests**
  * Added test validating the new bulk shared memory fill optimization for CUDA kernels, confirming correct code generation and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->