### PR TITLE
Try to preload z3 to resolve tvm deps

### DIFF
--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -43,7 +43,7 @@ if not os.path.exists(THIRD_PARTY_ROOT):
     logger.warning(f"Loading tilelang libs from dev root: {dev_lib_root}")
 else:
     try:
-        import z3
+        import z3  # noqa: F401
     except ImportError:
         logger.error("Failed to import z3, consider to reinstall tilelang.")
 

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -41,6 +41,11 @@ if not os.path.exists(THIRD_PARTY_ROOT):
     TL_LIBS = [os.path.join(dev_lib_root, "lib"), os.path.join(dev_lib_root, "tvm")]
     THIRD_PARTY_ROOT = os.path.join(tl_dev_root, "3rdparty")
     logger.warning(f"Loading tilelang libs from dev root: {dev_lib_root}")
+else:
+    try:
+        import z3
+    except ImportError:
+        logger.error("Failed to import z3, consider to reinstall tilelang.")
 
 assert TL_LIBS and all(os.path.exists(i) for i in TL_LIBS), f"tilelang lib root do not exists: {TL_LIBS}"
 


### PR DESCRIPTION
Fix potential issue when user's z3 and tilelang are not in same `site-packages`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initialization troubleshooting by attempting to load an optional dependency when not in development mode and logging a clear error if it’s unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->