### PR TITLE
[BugFix] Fix vectorized fp16<->bf16 cast compilation

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -1883,13 +1883,22 @@ void CodeGenTileLangCUDA::VisitExpr_(const CastNode *op, std::ostream &os) {
                << " (only f32 -> fp8/fp4 supported)";
   }
 
-  // Fallback: elementwise cast
+  // Fallback: elementwise cast.
+  // fp16<->bf16 elements load as native __half/__nv_bfloat16, where a direct
+  // `(half_t)(__nv_bfloat16)` (or reverse) is an ambiguous conversion; route
+  // through float to disambiguate.
+  bool cross_half = (from_ty.is_float16() && target_ty.is_bfloat16()) ||
+                    (from_ty.is_bfloat16() && target_ty.is_float16());
   for (int i = 0, lanes = from_ty.lanes(); i < lanes; ++i) {
     std::ostringstream val;
     val << "(";
     PrintType(target_ty.element_of(), val);
     val << ")(";
+    if (cross_half)
+      val << "(float)(";
     PrintVecElemLoad(src, from_ty, i, val);
+    if (cross_half)
+      val << ")";
     val << ")";
     PrintVecElemStore(sret, target_ty, i, val.str());
   }

--- a/testing/python/language/test_tilelang_language_copy.py
+++ b/testing/python/language/test_tilelang_language_copy.py
@@ -44,6 +44,20 @@ def test_tilelang_copy():
     run_tilelang_copy(M=1024, N=576, block_M=32, block_N=576, dtype=T.float32)
 
 
+def run_tilelang_copy_cross_dtype(M=256, N=256, block_M=128, block_N=128, src_dtype=T.float16, dst_dtype=T.bfloat16):
+    program = tilelang_copy(M, N, block_M, block_N, src_dtype=src_dtype, dst_dtype=dst_dtype)
+    kernel = tilelang.compile(program, out_idx=[1])
+    a = torch.randn(M, N, device="cuda", dtype=getattr(torch, src_dtype))
+    b = kernel(a)
+    torch.testing.assert_close(b, a.to(getattr(torch, dst_dtype)), rtol=1e-2, atol=1e-2)
+
+
+@tilelang.testing.requires_cuda
+def test_tilelang_copy_cross_dtype():
+    run_tilelang_copy_cross_dtype(src_dtype=T.float16, dst_dtype=T.bfloat16)
+    run_tilelang_copy_cross_dtype(src_dtype=T.bfloat16, dst_dtype=T.float16)
+
+
 def tilelang_copy_with_stride(M, N, NN, block_M, block_N, dtype=T.float16):
     @T.prim_func
     def main(


### PR DESCRIPTION
## Summary



A vectorized `T.copy` between `float16` and `bfloat16` fails to compile.



The CUDA cast codegen (`VisitExpr_(const CastNode *)` in `src/cuda/codegen/codegen_cuda.cc`) has dedicated vectorized branches for fp16↔fp32, bf16↔fp32, fp8 and fp4, but none for fp16↔bf16. Such casts fall into the elementwise fallback loop, where each lane is loaded as a native `__half` / `__nv_bfloat16`. A direct `(half_t)(__nv_bfloat16)` (or the reverse) is then an **ambiguous user-defined conversion** — native `__nv_bfloat16` exposes multiple non-explicit conversion operators and `cutlass::half_t` has multiple converting constructors — so the generated code fails to compile:



    error: more than one user-defined conversion from "__nv_bfloat16" to "cutlass::half_t" applies



## Fix



Route cross-half elementwise casts through `float`, emitting `(half_t)((float)(__nv_bfloat16))` instead of the ambiguous direct form. `float` represents every fp16/bf16 value exactly, so this is a lossless intermediate and adds no extra rounding; the final narrowing to the target type is inherent to the conversion. This mirrors how CUTLASS itself bridges half types through `float`, for example `half_t fast_exp` in `fast_math.h`.



The gate only fires for fp16↔bf16. All existing vectorized branches return before it, so fp16↔fp32, bf16↔fp32, fp8, fp4 and same-type paths are unaffected. The scalar cast path is also unaffected: it returns early and uses CUTLASS wrapper types with a single `operator float()`, which are unambiguous.



## Tested



- `testing/python/language/test_tilelang_language_copy.py::test_tilelang_copy_cross_dtype` — new regression covering both directions, fp16→bf16 and bf16→fp16, compiles and matches the torch reference.

- Existing copy/cast tests still pass.



Fixes #2385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of float16 and bfloat16 type conversions in elementwise operations by using an intermediate float casting step to resolve ambiguous direct conversions between the two half-precision formats.

* **Tests**
  * Added comprehensive cross-dtype copy tests to validate bidirectional conversions between float16 and bfloat16, ensuring data integrity during dynamic format conversions on CUDA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->