### PR TITLE
[Feature] Add LLVM backend support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,11 +250,12 @@ else()
 endif()
 
 # Configs
-set(TILELANG_BACKENDS CUDA ROCM METAL)
+set(TILELANG_BACKENDS CUDA ROCM METAL LLVM)
 
 set(TILELANG_BACKEND_DOC_CUDA "Enable CUDA backend (ON/OFF/or CUDA SDK path)")
 set(TILELANG_BACKEND_DOC_ROCM "Enable ROCm backend (ON/OFF/or ROCm SDK path)")
 set(TILELANG_BACKEND_DOC_METAL "Enable Metal backend")
+set(TILELANG_BACKEND_DOC_LLVM "Enable LLVM backend")
 
 # TVM's config.cmake redefines USE_* options later, so we cache the user's choice
 # (including explicit -DUSE_XXX arguments) before we include TVM and restore it
@@ -415,6 +416,16 @@ if(NOT TILELANG_BACKEND_USER_SELECTED)
       set(USE_METAL ON)
     else()
       set(USE_METAL OFF)
+    endif()
+  endif()
+
+
+  if(DEFINED ENV{USE_LLVM})
+    set(_tilelang_backend_env_selected ON)
+    if($ENV{USE_LLVM})
+      set(USE_LLVM ON)
+    else()
+      set(USE_LLVM OFF)
     endif()
   endif()
 

--- a/docs/get_started/Installation.md
+++ b/docs/get_started/Installation.md
@@ -124,6 +124,7 @@ Some useful CMake options you can toggle while configuring:
 - `-DUSE_CUDA=ON|OFF` builds against NVIDIA CUDA (default ON when CUDA headers are found).
 - `-DUSE_ROCM=ON` selects ROCm support when building on AMD GPUs.
 - `-DNO_VERSION_LABEL=ON` disables the backend/git suffix in `tilelang.__version__`.
+- `-DUSE_LLVM=ON` enables the LLVM backend for CPU codegen.
 
 (using-existing-tvm)=
 
@@ -304,6 +305,8 @@ pip install tilelang -f https://tile-ai.github.io/whl/nightly
 `USE_ROCM`: If to enable ROCm support, default: `OFF`. If your ROCm SDK does not located in `/opt/rocm`, set `USE_ROCM=<rocm_sdk>` to enable build ROCm against custom sdk path.
 
 `USE_METAL`: If to enable Metal support, default: `ON` on Darwin.
+
+`USE_LLVM`: If to enable LLVM support for CPU codegen, default: `OFF`. Set `USE_LLVM=1` for auto-detection, or pass `-DUSE_LLVM=/path/to/llvm-config` through `CMAKE_ARGS` when you need a specific LLVM installation. LLVM 15 or newer is required.
 
 `TVM_ROOT`: TVM source root to use.
 

--- a/testing/python/llvm/test_tilelang_llvm_gemm.py
+++ b/testing/python/llvm/test_tilelang_llvm_gemm.py
@@ -1,0 +1,158 @@
+import tilelang
+import tilelang.testing
+from tilelang import tvm as tvm
+import tilelang.language as T
+import torch
+
+
+def matmul(M, N, K, block_M, block_N, block_K, dtype=T.float16, accum_dtype=T.float32):
+    num_stages = 0
+
+    @T.prim_func
+    def matmul(
+        A: T.Tensor((M, K), dtype),
+        B: T.Tensor((K, N), dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M)) as (bx, by):
+            A_local = T.alloc_local((block_M, block_K), dtype)
+            B_local = T.alloc_local((block_K, block_N), dtype)
+            C_local = T.alloc_local((block_M, block_N), accum_dtype)
+
+            T.clear(C_local)
+
+            # Apply layout optimizations or define your own layout
+            # (Optional).
+            # T.annotate_layout(
+            #     {
+            #         A_local: make_swizzle_layout(A_local),
+            #         B_local: make_swizzle_layout(B_local),
+            #     }
+            # )
+
+            for ko in T.Pipelined(K // block_K, num_stages=num_stages):
+                T.copy(A[by * block_M, ko * block_K], A_local)
+
+                # Or Copy with Parallel
+                for k, j in T.Parallel(block_K, block_N):
+                    B_local[k, j] = B[ko * block_K + k, by * block_N + j]
+
+                for i, j, k in T.grid(block_M, block_N, block_K):
+                    C_local[i, j] += A_local[i, k] * B_local[k, j]
+
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return matmul
+
+
+def assert_matmul_codegen(M=1024, N=1024, K=1024, block_M=128, block_N=128, block_K=32):
+    func = matmul(M, N, K, block_M, block_N, block_K)
+
+    with tvm.target.Target("llvm"):
+        artifact = tilelang.lower(func)
+
+    code = artifact.kernel_source
+
+    assert code is not None, "Code generation failed"
+
+
+@tilelang.testing.requires_llvm
+def test_matmul_codegen():
+    assert_matmul_codegen(M=1024, N=1024, K=1024, block_M=128, block_N=128, block_K=32)
+
+
+@tilelang.testing.requires_llvm
+def test_matmul_compile():
+    def matmul_jit_test(M, N, K, block_M, block_N, block_K, dtype=T.float16, accum_dtype=T.float32):
+        # a simple kernel just for jit test
+        @T.prim_func
+        def matmul(
+            A: T.Tensor((M, K), dtype),
+            B: T.Tensor((K, N), dtype),
+            C: T.Tensor((M, N), dtype),
+        ):
+            with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M)) as (bx, by):
+                A_local = T.alloc_local((block_M, block_K), dtype)
+                B_local = T.alloc_local((block_K, block_N), dtype)
+                C_local = T.alloc_local((block_M, block_N), accum_dtype)
+
+                for p in T.serial(block_M):
+                    for w in T.serial(block_N):
+                        C_local[p, w] = 0
+                for ko in T.serial(K // block_K):
+                    for i in T.serial(block_M):
+                        for k in T.serial(block_K):
+                            A_local[i, k] = A[by * block_M + i, ko * block_K + k]
+
+                    for k in T.serial(block_K):
+                        for j in T.serial(block_N):
+                            B_local[k, j] = B[ko * block_K + k, bx * block_N + j]
+
+                    for i in T.serial(block_M):
+                        for j in T.serial(block_N):
+                            for k in T.serial(block_K):
+                                C_local[i, j] += A_local[i, k] * B_local[k, j]
+
+                for i in T.serial(block_M):
+                    for j in T.serial(block_N):
+                        C[by * block_M + i, bx * block_N + j] = C_local[i, j]
+
+        return matmul
+
+    M, N, K = 1024, 512, 512
+    block_M, block_N, block_K = M // 4, N // 4, K // 4
+    llvm_func = matmul_jit_test(M, N, K, block_M, block_N, block_K)
+    with tvm.target.Target("llvm"):
+        complied_fun = tilelang.compile(llvm_func, -1, execution_backend="tvm_ffi")
+
+    in_dtype = T.float16
+    A = torch.randn(M, K, dtype=torch.__getattribute__(in_dtype))
+    B = torch.randn(K, N, dtype=torch.__getattribute__(in_dtype))
+
+    C = complied_fun(A, B)
+    C_torch = torch.matmul(A, B)
+
+    tilelang.testing.torch_assert_close(C, C_torch, atol=1e-2, rtol=1e-2, max_mismatched_ratio=0.05)
+
+
+@tilelang.testing.requires_llvm
+def test_matmul_with_copy_tvm_ffi():
+    """LLVM kernel using T.copy with tvm_ffi backend.
+
+    Verifies that T.copy works end-to-end on LLVM backend: the vectorized copy
+    uses vector types (e.g. float4) defined in common.h, and the
+    wrapper correctly skips redundant re-lowering.
+    """
+    M, N, K = 128, 128, 128
+    block_M, block_N, block_K = 32, 32, 32
+
+    @T.prim_func
+    def matmul(
+        A: T.Tensor((M, K), "float32"),
+        B: T.Tensor((K, N), "float32"),
+        C: T.Tensor((M, N), "float32"),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M)) as (bx, by):
+            A_local = T.alloc_local((block_M, block_K), "float32")
+            B_local = T.alloc_local((block_K, block_N), "float32")
+            C_local = T.alloc_local((block_M, block_N), "float32")
+
+            T.clear(C_local)
+            for ko in T.serial(K // block_K):
+                T.copy(A[by * block_M, ko * block_K], A_local)
+                T.copy(B[ko * block_K, bx * block_N], B_local)
+                for i, j, k in T.grid(block_M, block_N, block_K):
+                    C_local[i, j] += A_local[i, k] * B_local[k, j]
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    compiled = tilelang.compile(matmul, target="llvm", out_idx=-1, execution_backend="tvm_ffi")
+
+    a = torch.randn(M, K, dtype=torch.float32)
+    b = torch.randn(K, N, dtype=torch.float32)
+    c = compiled(a, b)
+    ref = a @ b
+    torch.testing.assert_close(c, ref, rtol=1e-5, atol=1e-5)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/llvm/test_tilelang_llvm_tgemm.py
+++ b/testing/python/llvm/test_tilelang_llvm_tgemm.py
@@ -1,0 +1,136 @@
+"""Tests for T.gemm on LLVM target (GemmScalar path).
+
+Verifies that T.gemm works correctly with target="llvm" for various
+matrix sizes, block sizes, and transpose combinations.
+"""
+
+import pytest
+import torch
+import tilelang
+import tilelang.testing
+from tilelang import tvm as tvm
+import tilelang.language as T
+
+
+def matmul(M, N, K, block_M, block_N, block_K, trans_A=False, trans_B=False, dtype=T.float32, accum_dtype=T.float32):
+    A_shape = (K, M) if trans_A else (M, K)
+    B_shape = (N, K) if trans_B else (K, N)
+    A_local_shape = (block_K, block_M) if trans_A else (block_M, block_K)
+    B_local_shape = (block_N, block_K) if trans_B else (block_K, block_N)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor(A_shape, dtype),
+        B: T.Tensor(B_shape, dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M)) as (bx, by):
+            A_local = T.alloc_local(A_local_shape, dtype)
+            B_local = T.alloc_local(B_local_shape, dtype)
+            C_local = T.alloc_local((block_M, block_N), accum_dtype)
+            T.clear(C_local)
+            for ko in T.serial(T.ceildiv(K, block_K)):
+                if trans_A:
+                    T.copy(A[ko * block_K, by * block_M], A_local)
+                else:
+                    T.copy(A[by * block_M, ko * block_K], A_local)
+                if trans_B:
+                    T.copy(B[bx * block_N, ko * block_K], B_local)
+                else:
+                    T.copy(B[ko * block_K, bx * block_N], B_local)
+                T.gemm(A_local, B_local, C_local, trans_A, trans_B)
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def ref_matmul(A, B, trans_A, trans_B):
+    if trans_A:
+        A = A.T
+    if trans_B:
+        B = B.T
+    return torch.matmul(A.float(), B.float()).to(A.dtype)
+
+
+def run_gemm_codegen(M, N, K, block_M, block_N, block_K, trans_A=False, trans_B=False):
+    func = matmul(M, N, K, block_M, block_N, block_K, trans_A, trans_B)
+    with tvm.target.Target("llvm"):
+        artifact = tilelang.lower(func)
+    code = artifact.kernel_source
+    assert code is not None, "Code generation failed"
+    return code
+
+
+def run_gemm_compile(M, N, K, block_M, block_N, block_K, trans_A=False, trans_B=False, dtype=T.float32):
+    func = matmul(M, N, K, block_M, block_N, block_K, trans_A, trans_B, dtype=dtype)
+    kernel = tilelang.compile(func, target="llvm", out_idx=[2], execution_backend="tvm_ffi")
+
+    torch_dtype = torch.__getattribute__(dtype)
+    A_shape = (K, M) if trans_A else (M, K)
+    B_shape = (N, K) if trans_B else (K, N)
+    A = torch.randn(A_shape, dtype=torch_dtype)
+    B = torch.randn(B_shape, dtype=torch_dtype)
+
+    C = kernel(A, B)
+    C_ref = ref_matmul(A, B, trans_A, trans_B)
+
+    tilelang.testing.torch_assert_close(C, C_ref, atol=1e-2, rtol=1e-2)
+
+
+# --- Codegen tests ---
+
+
+@tilelang.testing.requires_llvm
+def test_codegen_basic():
+    run_gemm_codegen(128, 128, 128, 64, 64, 64)
+
+
+@tilelang.testing.requires_llvm
+def test_codegen_rectangular():
+    run_gemm_codegen(256, 512, 128, 64, 64, 64)
+
+
+@tilelang.testing.requires_llvm
+def test_codegen_trans_A():
+    run_gemm_codegen(128, 128, 128, 64, 64, 64, trans_A=True)
+
+
+@tilelang.testing.requires_llvm
+def test_codegen_trans_B():
+    run_gemm_codegen(128, 128, 128, 64, 64, 64, trans_B=True)
+
+
+# --- Compile + correctness tests ---
+
+
+@tilelang.testing.requires_llvm
+@pytest.mark.parametrize(
+    "M,N,K,block_M,block_N,block_K",
+    [
+        (128, 128, 128, 64, 64, 64),
+        (256, 256, 256, 64, 64, 64),
+        (256, 512, 128, 64, 64, 64),
+        (512, 512, 512, 128, 128, 128),
+    ],
+)
+def test_gemm_f32_nn(M, N, K, block_M, block_N, block_K):
+    run_gemm_compile(M, N, K, block_M, block_N, block_K)
+
+
+@tilelang.testing.requires_llvm
+def test_gemm_f32_tn():
+    run_gemm_compile(128, 128, 128, 64, 64, 64, trans_A=True)
+
+
+@tilelang.testing.requires_llvm
+def test_gemm_f32_nt():
+    run_gemm_compile(128, 128, 128, 64, 64, 64, trans_B=True)
+
+
+@tilelang.testing.requires_llvm
+def test_gemm_f32_tt():
+    run_gemm_compile(128, 128, 128, 64, 64, 64, trans_A=True, trans_B=True)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/llvm/test_tilelang_llvm_while_repro.py
+++ b/testing/python/llvm/test_tilelang_llvm_while_repro.py
@@ -1,0 +1,30 @@
+import tilelang
+import tilelang.testing
+import tilelang.language as T
+
+
+@tilelang.testing.requires_llvm
+def test_llvm_kernel_source_generation_with_while() -> None:
+    """Regression test: LLVM `T.While` kernels should compile without errors.
+
+    See: https://github.com/tile-ai/tilelang/issues/2202
+
+    Historically, a CPU kernel containing `T.While(...)` inside
+    `T.Kernel(...)` could leak the synthetic fallback thread variable
+    `v_thread` into host/device splitting. LLVM uses the same scalar lowering
+    path for this case, so this keeps equivalent coverage for target="llvm".
+    """
+
+    @T.prim_func
+    def main(flag: T.Tensor((1,), "int32"), out: T.Tensor((1,), "int32")):
+        with T.Kernel(1):
+            state = T.alloc_fragment((1,), "int32")
+            state[0] = 0
+
+            with T.While(state[0] == 0):
+                state[0] = flag[0]
+
+            out[0] = state[0]
+
+    compiled = tilelang.compile(main, target="llvm", execution_backend="tvm_ffi")
+    assert compiled is not None

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -241,6 +241,8 @@ def device_codegen(device_mod: tvm.IRModule, target: Target) -> tvm.IRModule:
         device_mod = tvm.ffi.get_global_func("target.build.tilelang_hip")(device_mod, target)
     elif target.kind.name == "metal":
         device_mod = tvm.ffi.get_global_func("target.build.tilelang_metal")(device_mod, target)
+    elif target.kind.name == "llvm":
+        device_mod = tvm.ffi.get_global_func("target.build.llvm")(device_mod, target)
     else:
         raise ValueError(f"Target {target.kind.name} is not supported")
 

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -209,7 +209,10 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
 
             # Resolve the device used for outputs. Prefer the first tensor input's device
             # if available, otherwise use PyTorch's current device.
-            out_device: torch.device | None = None
+            out_device: torch.device | None = next(
+                (input.device for input in inputs if isinstance(input, torch.Tensor)),
+                None,
+            )
 
             # Stitch the full positional argument list expected by the TVM executable
             ins_idx: int = 0


### PR DESCRIPTION
Enable LLVM as a TileLang backend in CMake and route llvm targets through TVM LLVM codegen during lowering.

Fix tvm_ffi output tensor device inference by deriving the output device from tensor inputs, and add LLVM codegen/compile regression tests for matmul, T.gemm, T.copy, and T.While.

Related issue:
https://github.com/tile-ai/tilelang/issues/2368#issuecomment-4690493542

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an LLVM backend as a selectable compilation target, including environment-variable based configuration.

* **Tests**
  * Added new LLVM-focused GEMM tests (code generation checks, JIT compilation with correctness validation, and copy-path coverage), plus an LLVM regression test for `While` kernel source generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->