### PR TITLE
[CI] Trigger CI when a PR is marked ready for review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
       - opened
       - synchronize
       - reopened
+      - ready_for_review
   # Allow to trigger the workflow manually
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- The `tests` and `cutedsl` jobs in `ci.yml` are gated on the PR not being a draft (`!github.event.pull_request.draft`), but `ready_for_review` was missing from the `pull_request` trigger `types`.
- As a result, flipping a PR from **draft → ready for review** did not re-trigger CI; the stale draft-time run kept showing the gated jobs as "skipping", forcing a dummy commit or a close/reopen to get tests to run.
- This adds `ready_for_review` to the trigger types so marking a PR ready re-runs the workflow with the draft gate satisfied.

## Test plan
- [ ] Open a draft PR (tests/cutedsl skip), then mark it ready for review and confirm CI re-triggers and the gated jobs run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to enhance pull request review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->