### PR TITLE
[CI] Exclude agent files from markdown fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,3 +57,4 @@ repos:
     hooks:
       - id: pymarkdown
         args: ["--config", ".pymarkdown", "fix"]
+        exclude: ^\.agents/


### PR DESCRIPTION
## Summary

- Prevent the Markdown auto-fix hook from processing repository agent metadata under `.agents/`.
- Keep skill instruction files outside generic Markdown rewrites while preserving the existing hook for regular documentation.

## Changes

- Added a `pymarkdown` hook-level exclude for `^\.agents/`.
- Left other pre-commit hooks and global excludes unchanged.

## Validation

- `pre-commit run pymarkdown --files .agents/skills/tilelang-build/SKILL.md .agents/skills/tilelang-tvm-ir/SKILL.md`
- `pre-commit run check-yaml --files .pre-commit-config.yaml`
- `pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit configuration to exclude certain directories from linting checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->