### PR TITLE
[BugFix] Fix vectorized atomic_add dtype mismatch reinterpret

### DIFF
--- a/src/tl_templates/cuda/atomic.h
+++ b/src/tl_templates/cuda/atomic.h
@@ -476,6 +476,15 @@ template <typename T> TL_DEVICE half2 ToHalf2(T val) {
 
 TL_DEVICE half2 ToHalf2(half2 val) { return val; }
 
+// fp32 source: convert (round-to-nearest) instead of reinterpreting
+TL_DEVICE half2 ToHalf2(float2 val) { return __float22half2_rn(val); }
+TL_DEVICE half2 ToHalf2(const float *val) {
+  return __float22half2_rn(make_float2(val[0], val[1]));
+}
+TL_DEVICE half2 ToHalf2(float *val) {
+  return ToHalf2(static_cast<const float *>(val));
+}
+
 // Here ValType can be either value or value* (pointer)
 
 template <typename ValType>
@@ -533,6 +542,17 @@ template <typename T> TL_DEVICE __nv_bfloat162 ToBfloat162(T val) {
 }
 
 TL_DEVICE __nv_bfloat162 ToBfloat162(__nv_bfloat162 val) { return val; }
+
+// fp32 source: convert (round-to-nearest) instead of reinterpreting
+TL_DEVICE __nv_bfloat162 ToBfloat162(float2 val) {
+  return __float22bfloat162_rn(val);
+}
+TL_DEVICE __nv_bfloat162 ToBfloat162(const float *val) {
+  return __float22bfloat162_rn(make_float2(val[0], val[1]));
+}
+TL_DEVICE __nv_bfloat162 ToBfloat162(float *val) {
+  return ToBfloat162(static_cast<const float *>(val));
+}
 
 template <typename ValType>
 TL_DEVICE void AtomicAddx2(bfloat16_t *ref, ValType val,

--- a/testing/python/language/test_tilelang_language_atomic.py
+++ b/testing/python/language/test_tilelang_language_atomic.py
@@ -90,6 +90,54 @@ def run_atomic_addx2(M, N, block_M, block_N, dtype=T.float16):
 
 
 @tilelang.jit
+def atomic_add_mixed_dtype_program(N, src_dtype, dst_dtype):
+    @T.prim_func
+    def atomic_add(Src: T.Tensor((N,), src_dtype), Out: T.Tensor((N,), dst_dtype)):
+        with T.Kernel(threads=1):
+            frag = T.alloc_fragment((N,), src_dtype)
+            for i in T.Parallel(N):
+                frag[i] = Src[i]
+            for i in T.Parallel(N):
+                T.atomic_add(Out[i], frag[i])
+
+    return atomic_add
+
+
+def run_atomic_add_mixed_dtype(N, src_dtype, dst_dtype):
+    kernel = atomic_add_mixed_dtype_program(N, src_dtype, dst_dtype)
+    assert "AtomicAddx2" in kernel.get_kernel_source()
+
+    src = torch.arange(1, N + 1, dtype=getattr(torch, src_dtype)).cuda()
+    out = torch.zeros(N, dtype=getattr(torch, dst_dtype)).cuda()
+    kernel(src, out)
+    torch.testing.assert_close(out, src.to(getattr(torch, dst_dtype)), atol=1e-2, rtol=1e-2)
+
+
+@tilelang.jit
+def atomic_addx2_mixed_dtype_program(M, N, block_M, block_N, src_dtype, dst_dtype):
+    @T.prim_func
+    def atomic_addx2(A: T.Tensor((M, N), src_dtype), B: T.Tensor((M, N), dst_dtype)):
+        with T.Kernel(T.ceildiv(M, block_M), T.ceildiv(N, block_N), threads=32) as (bx, by):
+            for i, j in T.Parallel(block_M, block_N // 2):
+                idx_i = bx * block_M + i
+                idx_j = by * block_N + j * 2
+                T.atomic_addx2(B[idx_i, idx_j], A[idx_i, idx_j])
+
+    return atomic_addx2
+
+
+def run_atomic_addx2_mixed_dtype(M, N, block_M, block_N, src_dtype, dst_dtype):
+    kernel = atomic_addx2_mixed_dtype_program(M, N, block_M, block_N, src_dtype, dst_dtype)
+    assert "AtomicAddx2" in kernel.get_kernel_source()
+
+    A = torch.randn(M, N, dtype=getattr(torch, src_dtype)).cuda()
+    B = torch.zeros(M, N, dtype=getattr(torch, dst_dtype)).cuda()
+    ref_B = A.to(getattr(torch, dst_dtype))
+    kernel(A, B)
+    torch.testing.assert_close(B, ref_B, atol=1e-2, rtol=1e-2)
+
+
+@tilelang.jit
 def atomic_different_memory_orders_program(M, N, block_M, block_N, dtype=T.float32):
     @T.prim_func
     def atomic_different_orders(
@@ -272,6 +320,19 @@ def test_atomic_addx2_half():
 
 def test_atomic_addx2_float():
     run_atomic_addx2(32, 64, 8, 16, dtype=T.float32)
+
+
+@tilelang.testing.requires_cuda
+def test_atomic_add_mixed_dtype_fp16():
+    run_atomic_add_mixed_dtype(8, T.float32, T.float16)
+    run_atomic_addx2_mixed_dtype(32, 64, 8, 16, T.float32, T.float16)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(8, 0)
+def test_atomic_add_mixed_dtype_bf16():
+    run_atomic_add_mixed_dtype(8, T.float32, T.bfloat16)
+    run_atomic_addx2_mixed_dtype(32, 64, 8, 16, T.float32, T.bfloat16)
 
 
 @tilelang.testing.requires_cuda


### PR DESCRIPTION
## Summary

A vectorized `atomic_add` into an fp16/bf16 destination from an **fp32 source** bit-reinterpreted the source `float2` as `half2` / `__nv_bfloat162` instead of numerically converting it. It compiled and ran with no error, but produced silently wrong results.

A contiguous `T.atomic_add(out_fp16[i], src_fp32[i])` auto-vectorizes to `AtomicAddx2` and reinterprets the `float2` source instead of converting it:

```text
fp16 dest, fp32 source = [1..8]

before : [0.0, 1.875, 0.0, 2.125, 0.0, 2.3125, 0.0, 2.4375]
after  : [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
```

## Fix

The vectorized helpers `ToHalf2` / `ToBfloat162` (`src/tl_templates/cuda/atomic.h`) only had a generic template that `reinterpret_cast`s the source. This adds non-template converting overloads for fp32 sources (`float2` / `float*` / `const float*`) using `__float22half2_rn` / `__float22bfloat162_rn` (round-to-nearest). The overloads only intercept actual fp32 arguments; matched-dtype paths keep their existing reinterpret-passthrough, and no codegen/vectorizer change is needed.

## Two entry points fixed

* **Auto-vectorized `T.atomic_add`** — the reported path. Codegen emits the value form `AtomicAddx2(dst, *(float2*)src)`.
* **Explicit `T.atomic_addx2` API** — not in the original report, found while fixing it. The public API passes the source as a pointer (`access_ptr`), so codegen emits the pointer form `AtomicAddx2(dst, &src)` (`float*` or `const float*`). Same reinterpret bug, reachable from documented user code, so fixed here too.

## Tested

* `testing/python/language/test_tilelang_language_atomic.py`:

  * `test_atomic_add_mixed_dtype_fp16` — both entry points, fp32→fp16; asserts the vectorized `AtomicAddx2` is emitted and checks numerics.
  * `test_atomic_add_mixed_dtype_bf16` — same, fp32→bf16, gated to compute capability ≥ 8.0 (bf16 atomic requires sm_80+).
* Verified locally on an sm_75 (Turing) card: fp16←fp32 numerically correct for both the auto-vectorized and explicit paths, still vectorized; matched-dtype atomics unchanged. sm_75 has no bf16 atomic, so the bf16 case is left to CI (sm_80+).

Fixes #2382


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added support for mixed-dtype atomic operations, enabling efficient conversion and atomic addition across float32, float16, and bfloat16 data types
* Expanded atomic pair operations support for mixed-precision scenarios
* Extended test coverage for mixed-precision atomic operations on CUDA-enabled systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->