### PR TITLE
[Feature] Support stmatrix m16n8 on Blackwell

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -2504,7 +2504,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
       shape = Downcast<StringImm>(op->args.back())->value;
     }
     std::string func_name =
-        "tl::ptx_stmatrix_x" + std::to_string(num) + "_" + shape;
+        "tl::ptx_stmatrix_" + shape + "_x" + std::to_string(num);
     if (trans == 1)
       func_name += "_trans";
     print_extern_call_stmt(func_name, 2, has_shape ? 1 : 0);

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -2498,16 +2498,16 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     int trans = Downcast<IntImm>(op->args[0])->value;
     int num = Downcast<IntImm>(op->args[1])->value;
     std::string shape = "m8n8";
-    int payload_start = 2;
-    if (op->args.size() >= 4 && op->args[2].as<StringImmNode>()) {
-      shape = Downcast<StringImm>(op->args[2])->value;
-      payload_start = 3;
+    bool has_shape =
+        op->args.size() >= 4 && op->args.back().as<StringImmNode>();
+    if (has_shape) {
+      shape = Downcast<StringImm>(op->args.back())->value;
     }
     std::string func_name =
         "tl::ptx_stmatrix_x" + std::to_string(num) + "_" + shape;
     if (trans == 1)
       func_name += "_trans";
-    print_extern_call_stmt(func_name, payload_start);
+    print_extern_call_stmt(func_name, 2, has_shape ? 1 : 0);
   } else if (op->op.same_as(tl::fence_proxy_async())) {
     print_extern_call_stmt("tl::fence_proxy_async");
   } else if (op->op.same_as(tl::tma_store_arrive())) {

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -2497,10 +2497,17 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
   } else if (op->op.same_as(tl::ptx_stmatrix())) {
     int trans = Downcast<IntImm>(op->args[0])->value;
     int num = Downcast<IntImm>(op->args[1])->value;
-    std::string func_name = "tl::ptx_stmatrix_x" + std::to_string(num);
+    std::string shape = "m8n8";
+    int payload_start = 2;
+    if (op->args.size() >= 4 && op->args[2].as<StringImmNode>()) {
+      shape = Downcast<StringImm>(op->args[2])->value;
+      payload_start = 3;
+    }
+    std::string func_name =
+        "tl::ptx_stmatrix_x" + std::to_string(num) + "_" + shape;
     if (trans == 1)
       func_name += "_trans";
-    print_extern_call_stmt(func_name, 2);
+    print_extern_call_stmt(func_name, payload_start);
   } else if (op->op.same_as(tl::fence_proxy_async())) {
     print_extern_call_stmt("tl::fence_proxy_async");
   } else if (op->op.same_as(tl::tma_store_arrive())) {
@@ -2554,6 +2561,14 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
   } else if (op->op.same_as(tl::pack_b16())) {
     os << "__pack_half2(" << this->PrintExpr(op->args[0]) << ", "
        << this->PrintExpr(op->args[1]) << ")";
+  } else if (op->op.same_as(tl::pack_b8x4())) {
+    os << "tl::pack_b8x4(";
+    for (int i = 0; i < 4; ++i) {
+      if (i > 0)
+        os << ", ";
+      os << this->PrintExpr(op->args[i]);
+    }
+    os << ")";
   } else if (op->op.same_as(tl::sync_grid())) {
     this->need_cooperative_groups_ = true;
     this->PrintIndent();

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -2216,6 +2216,16 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     this->stream << ss.str();
     this->stream << ");\n";
   };
+  auto print_extern_call_expr = [&](std::ostream &os, std::string name,
+                                    size_t start = 0, size_t end = 0) {
+    os << name << "(";
+    for (size_t i = start; i < op->args.size() - end; i++) {
+      if (i > start)
+        os << ", ";
+      os << this->PrintExpr(op->args[i]);
+    }
+    os << ")";
+  };
   if (op->op.same_as(tl::max_nan()) || op->op.same_as(tl::min_nan())) {
     ICHECK_EQ(op->args.size(), 2);
     const bool is_max = op->op.same_as(tl::max_nan());
@@ -2564,13 +2574,7 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     os << "__pack_half2(" << this->PrintExpr(op->args[0]) << ", "
        << this->PrintExpr(op->args[1]) << ")";
   } else if (op->op.same_as(tl::pack_b8x4())) {
-    os << "tl::pack_b8x4(";
-    for (int i = 0; i < 4; ++i) {
-      if (i > 0)
-        os << ", ";
-      os << this->PrintExpr(op->args[i]);
-    }
-    os << ")";
+    print_extern_call_expr(os, "tl::pack_b8x4");
   } else if (op->op.same_as(tl::sync_grid())) {
     this->need_cooperative_groups_ = true;
     this->PrintIndent();

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -2508,18 +2508,16 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     int trans = Downcast<IntImm>(op->args[0])->value;
     int num = Downcast<IntImm>(op->args[1])->value;
     std::string shape = "m8n8";
-    bool has_shape =
-        op->args.size() >= 4 && op->args.back().as<StringImmNode>();
-    if (has_shape) {
-      shape = Downcast<StringImm>(op->args.back())->value;
+    bool is_shape_encoded = op->args.size() >= 4;
+    if (is_shape_encoded) {
+      ICHECK(op->args[3].as<StringImmNode>());
+      shape = Downcast<StringImm>(op->args[3])->value;
     }
     std::string func_name =
         "tl::ptx_stmatrix_" + shape + "_x" + std::to_string(num);
     if (trans == 1)
       func_name += "_trans";
-    // trans, num, and shape are encoded in the helper name; print only smem_ptr
-    // and value operands.
-    print_extern_call_stmt(func_name, 2, has_shape ? 1 : 0);
+    print_extern_call_stmt(func_name, 2, is_shape_encoded ? 1 : 0);
   } else if (op->op.same_as(tl::fence_proxy_async())) {
     print_extern_call_stmt("tl::fence_proxy_async");
   } else if (op->op.same_as(tl::tma_store_arrive())) {

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -2507,6 +2507,8 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
         "tl::ptx_stmatrix_" + shape + "_x" + std::to_string(num);
     if (trans == 1)
       func_name += "_trans";
+    // trans, num, and shape are encoded in the helper name; print only smem_ptr
+    // and value operands.
     print_extern_call_stmt(func_name, 2, has_shape ? 1 : 0);
   } else if (op->op.same_as(tl::fence_proxy_async())) {
     print_extern_call_stmt("tl::fence_proxy_async");

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -2508,10 +2508,10 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     int trans = Downcast<IntImm>(op->args[0])->value;
     int num = Downcast<IntImm>(op->args[1])->value;
     std::string shape = "m8n8";
-    bool is_shape_encoded = op->args.size() >= 4;
+    bool is_shape_encoded =
+        op->args.size() >= 4 && op->args.back().as<StringImmNode>();
     if (is_shape_encoded) {
-      ICHECK(op->args[3].as<StringImmNode>());
-      shape = Downcast<StringImm>(op->args[3])->value;
+      shape = Downcast<StringImm>(op->args.back())->value;
     }
     std::string func_name =
         "tl::ptx_stmatrix_" + shape + "_x" + std::to_string(num);

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -993,10 +993,10 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
   } else if (op->op.same_as(tl::ptx_stmatrix())) {
     int trans = Downcast<IntImm>(op->args[0])->value;
     int num = Downcast<IntImm>(op->args[1])->value;
-    bool is_shape_encoded = op->args.size() >= 4;
+    bool is_shape_encoded =
+        op->args.size() >= 4 && op->args.back().as<StringImmNode>();
     if (is_shape_encoded) {
-      ICHECK(op->args[3].as<StringImmNode>());
-      ICHECK_EQ(Downcast<StringImm>(op->args[3])->value, "m8n8")
+      ICHECK_EQ(Downcast<StringImm>(op->args.back())->value, "m8n8")
           << "CuTeDSL stmatrix codegen only supports m8n8";
     }
     std::string func_name = "tl.ptx_stmatrix_x" + std::to_string(num);

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -993,16 +993,16 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
   } else if (op->op.same_as(tl::ptx_stmatrix())) {
     int trans = Downcast<IntImm>(op->args[0])->value;
     int num = Downcast<IntImm>(op->args[1])->value;
-    bool has_shape =
-        op->args.size() >= 4 && op->args.back().as<StringImmNode>();
-    if (has_shape) {
-      ICHECK_EQ(Downcast<StringImm>(op->args.back())->value, "m8n8")
+    bool is_shape_encoded = op->args.size() >= 4;
+    if (is_shape_encoded) {
+      ICHECK(op->args[3].as<StringImmNode>());
+      ICHECK_EQ(Downcast<StringImm>(op->args[3])->value, "m8n8")
           << "CuTeDSL stmatrix codegen only supports m8n8";
     }
     std::string func_name = "tl.ptx_stmatrix_x" + std::to_string(num);
     if (trans == 1)
       func_name += "_trans";
-    print_extern_call_stmt(func_name, 2, has_shape ? 1 : 0);
+    print_extern_call_stmt(func_name, 2, is_shape_encoded ? 1 : 0);
   } else if (op->op.same_as(tl::fence_proxy_async())) {
     print_extern_call_stmt("tl.fence_proxy_async");
   } else if (op->op.same_as(tl::tma_store_arrive())) {

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -993,10 +993,16 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
   } else if (op->op.same_as(tl::ptx_stmatrix())) {
     int trans = Downcast<IntImm>(op->args[0])->value;
     int num = Downcast<IntImm>(op->args[1])->value;
+    int payload_start = 2;
+    if (op->args.size() >= 4 && op->args[2].as<StringImmNode>()) {
+      ICHECK_EQ(Downcast<StringImm>(op->args[2])->value, "m8n8")
+          << "CuTeDSL stmatrix codegen only supports m8n8";
+      payload_start = 3;
+    }
     std::string func_name = "tl.ptx_stmatrix_x" + std::to_string(num);
     if (trans == 1)
       func_name += "_trans";
-    print_extern_call_stmt(func_name, 2);
+    print_extern_call_stmt(func_name, payload_start);
   } else if (op->op.same_as(tl::fence_proxy_async())) {
     print_extern_call_stmt("tl.fence_proxy_async");
   } else if (op->op.same_as(tl::tma_store_arrive())) {

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -993,16 +993,16 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
   } else if (op->op.same_as(tl::ptx_stmatrix())) {
     int trans = Downcast<IntImm>(op->args[0])->value;
     int num = Downcast<IntImm>(op->args[1])->value;
-    int payload_start = 2;
-    if (op->args.size() >= 4 && op->args[2].as<StringImmNode>()) {
-      ICHECK_EQ(Downcast<StringImm>(op->args[2])->value, "m8n8")
+    bool has_shape =
+        op->args.size() >= 4 && op->args.back().as<StringImmNode>();
+    if (has_shape) {
+      ICHECK_EQ(Downcast<StringImm>(op->args.back())->value, "m8n8")
           << "CuTeDSL stmatrix codegen only supports m8n8";
-      payload_start = 3;
     }
     std::string func_name = "tl.ptx_stmatrix_x" + std::to_string(num);
     if (trans == 1)
       func_name += "_trans";
-    print_extern_call_stmt(func_name, payload_start);
+    print_extern_call_stmt(func_name, 2, has_shape ? 1 : 0);
   } else if (op->op.same_as(tl::fence_proxy_async())) {
     print_extern_call_stmt("tl.fence_proxy_async");
   } else if (op->op.same_as(tl::tma_store_arrive())) {

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -1131,9 +1131,6 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
   const Op &copy_op = is_ldmatrix ? tl::ptx_ldmatrix() : tl::ptx_stmatrix();
   args.push_back(static_cast<int>(is_transposed));
   args.push_back(num);
-  if (!is_ldmatrix) {
-    args.push_back(StringImm(use_m16n8_stmatrix ? "m16n8" : "m8n8"));
-  }
 
   Var local_iter("i");
   Layout inv = local_layout->Inverse();
@@ -1188,6 +1185,7 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
                                   : Call(DataType::Int(32), pack_b16(), values);
       args.push_back(value_packed);
     }
+    args.push_back(StringImm(use_m16n8_stmatrix ? "m16n8" : "m8n8"));
   }
 
   auto body = Evaluate(Call(DataType::Handle(), copy_op, args));

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -1094,12 +1094,23 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
   } else {
     return LowerNormal(op, T, analyzer);
   }
-  if (shared_tensor->dtype.bytes() != 2) {
+
+  const bool use_m16n8_stmatrix =
+      !is_ldmatrix && is_transposed &&
+      TargetHasStmatrix(T.target, /*is_m16n8=*/true) &&
+      shared_tensor->dtype.bits() == 8;
+  const int elems_per_reg = use_m16n8_stmatrix ? 4 : 2;
+  if (is_ldmatrix || !use_m16n8_stmatrix) {
+    if (shared_tensor->dtype.bytes() != 2) {
+      return LowerNormal(op, T, analyzer);
+    }
+  } else if (shared_tensor->dtype.bytes() != 1) {
     return LowerNormal(op, T, analyzer);
   }
   PrimExpr flattened_indice = shared_tensor.OffsetOf(shared_indices).back();
   if (!IndicesCanVectorize(flattened_indice, loop_vars.back()->var,
-                           loop_vars.back()->dom->extent, 8, analyzer)) {
+                           loop_vars.back()->dom->extent,
+                           use_m16n8_stmatrix ? 4 : 8, analyzer)) {
     return LowerNormal(op, T, analyzer);
   }
 
@@ -1111,15 +1122,18 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
 
   PrimExpr extent = local_tensor->shape[0];
   int num = 1;
-  if (analyzer->CanProveEqual(FloorMod(extent, 8), 0))
+  if (analyzer->CanProveEqual(FloorMod(extent, elems_per_reg * 4), 0))
     num = 4;
-  else if (analyzer->CanProveEqual(FloorMod(extent, 4), 0))
+  else if (analyzer->CanProveEqual(FloorMod(extent, elems_per_reg * 2), 0))
     num = 2;
 
   Array<PrimExpr> args;
   const Op &copy_op = is_ldmatrix ? tl::ptx_ldmatrix() : tl::ptx_stmatrix();
   args.push_back(static_cast<int>(is_transposed));
   args.push_back(num);
+  if (!is_ldmatrix) {
+    args.push_back(StringImm(use_m16n8_stmatrix ? "m16n8" : "m8n8"));
+  }
 
   Var local_iter("i");
   Layout inv = local_layout->Inverse();
@@ -1127,23 +1141,25 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
   PrimExpr warp = FloorDiv(T.thread_var, 32) * 32;
   if (!is_transposed) {
     auto local_index = analyzer->Simplify(
-        local_iter * 2 * num + 2 * FloorMod(FloorDiv(T.thread_var, 8), num));
+        local_iter * elems_per_reg * num +
+        elems_per_reg * FloorMod(FloorDiv(T.thread_var, 8), num));
     auto thread_index =
         analyzer->Simplify(warp + FloorMod(T.thread_var, 8) * 4);
     shared_coords = inv->Forward({local_index, thread_index});
   } else {
     auto local_index = analyzer->Simplify(
-        local_iter * 2 * num + 2 * FloorMod(FloorDiv(T.thread_var, 8), num) +
-        FloorMod(T.thread_var, 2));
-    auto thread_index =
-        analyzer->Simplify(warp + FloorDiv(FloorMod(T.thread_var, 8), 2));
+        local_iter * elems_per_reg * num +
+        elems_per_reg * FloorMod(FloorDiv(T.thread_var, 8), num) +
+        FloorMod(T.thread_var, elems_per_reg));
+    auto thread_index = analyzer->Simplify(
+        warp + FloorDiv(FloorMod(T.thread_var, 8), elems_per_reg));
     shared_coords = inv->Forward({local_index, thread_index});
   }
   shared_coords.pop_back();
-  PrimExpr shared_addr =
-      Call(DataType::Handle(), tl::access_ptr(),
-           {BufferLoad(shared_tensor, shared_coords), PrimExpr(2 * num),
-            make_const(DataType::Int(32), is_ldmatrix ? 1 : 2)});
+  PrimExpr shared_addr = Call(
+      DataType::Handle(), tl::access_ptr(),
+      {BufferLoad(shared_tensor, shared_coords), PrimExpr(elems_per_reg * num),
+       make_const(DataType::Int(32), is_ldmatrix ? 1 : 2)});
   args.push_back(shared_addr);
 
   if (is_ldmatrix) {
@@ -1157,23 +1173,26 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
     args.push_back(local_addr);
   } else {
     for (int i = 0; i < num; i++) {
-      PrimExpr value0 =
-          BufferLoad(local_tensor, {local_iter * 2 * num + 2 * i});
-      PrimExpr value1 =
-          BufferLoad(local_tensor, {local_iter * 2 * num + 2 * i + 1});
-      if (local_tensor->dtype != shared_tensor->dtype) {
-        value0 = Cast(shared_tensor->dtype, value0);
-        value1 = Cast(shared_tensor->dtype, value1);
+      Array<PrimExpr> values;
+      for (int j = 0; j < elems_per_reg; ++j) {
+        PrimExpr value =
+            BufferLoad(local_tensor, {local_iter * elems_per_reg * num +
+                                      elems_per_reg * i + j});
+        if (local_tensor->dtype != shared_tensor->dtype) {
+          value = Cast(shared_tensor->dtype, value);
+        }
+        values.push_back(value);
       }
-      PrimExpr value_packed =
-          Call(DataType::Int(32), pack_b16(), {value0, value1});
+      PrimExpr value_packed = use_m16n8_stmatrix
+                                  ? Call(DataType::Int(32), pack_b8x4(), values)
+                                  : Call(DataType::Int(32), pack_b16(), values);
       args.push_back(value_packed);
     }
   }
 
   auto body = Evaluate(Call(DataType::Handle(), copy_op, args));
-  For for_node =
-      For(local_iter, 0, FloorDiv(extent, 2 * num), ForKind::kSerial, body);
+  For for_node = For(local_iter, 0, FloorDiv(extent, elems_per_reg * num),
+                     ForKind::kSerial, body);
   for_node = PragmaUnrollLoop(for_node);
   auto range = T.thread_bounds;
   if (range.defined()) {

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -1099,14 +1099,11 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
       !is_ldmatrix && is_transposed &&
       TargetHasStmatrix(T.target, /*is_m16n8=*/true) &&
       shared_tensor->dtype.bits() == 8;
-  const int elems_per_reg = use_m16n8_stmatrix ? 4 : 2;
-  if (is_ldmatrix || !use_m16n8_stmatrix) {
-    if (shared_tensor->dtype.bytes() != 2) {
-      return LowerNormal(op, T, analyzer);
-    }
-  } else if (shared_tensor->dtype.bytes() != 1) {
+  const int shared_elem_bytes = use_m16n8_stmatrix ? 1 : 2;
+  if (shared_tensor->dtype.bytes() != shared_elem_bytes) {
     return LowerNormal(op, T, analyzer);
   }
+  const int elems_per_reg = 4 / shared_elem_bytes;
   PrimExpr flattened_indice = shared_tensor.OffsetOf(shared_indices).back();
   if (!IndicesCanVectorize(flattened_indice, loop_vars.back()->var,
                            loop_vars.back()->dom->extent,

--- a/src/cuda/target_utils.cc
+++ b/src/cuda/target_utils.cc
@@ -101,11 +101,11 @@ bool TargetHasLdmatrix(Target target) {
   return arch >= 75;
 }
 
-bool TargetHasStmatrix(Target target) {
+bool TargetHasStmatrix(Target target, bool is_m16n8) {
   if (!TargetIsCuda(target))
     return false;
   int arch = GetCudaArchInt(target);
-  return arch >= 90;
+  return is_m16n8 ? arch >= 100 : arch >= 90;
 }
 
 bool TargetHasTmem(Target target) {
@@ -258,8 +258,15 @@ TVM_FFI_STATIC_INIT_BLOCK() {
            [](Target target) { return TargetCudaGetWarpSize(target); })
       .def("tl.TargetHasLdmatrix",
            [](Target target) { return TargetHasLdmatrix(target); })
-      .def("tl.TargetHasStmatrix",
-           [](Target target) { return TargetHasStmatrix(target); })
+      .def_packed(
+          "tl.TargetHasStmatrix",
+          [](ffi::PackedArgs args, ffi::Any *ret) {
+            ICHECK(args.size() == 1 || args.size() == 2)
+                << "TargetHasStmatrix expects target and optional is_m16n8";
+            Target target = args[0].cast<Target>();
+            bool is_m16n8 = args.size() == 2 ? args[1].cast<bool>() : false;
+            *ret = TargetHasStmatrix(target, is_m16n8);
+          })
       .def("tl.TargetHasBulkCopy",
            [](Target target) { return TargetHasBulkCopy(target); });
 }

--- a/src/cuda/target_utils.h
+++ b/src/cuda/target_utils.h
@@ -25,7 +25,7 @@ bool TargetIsSM120(Target target);
 bool TargetCudaHasAsyncCopy(Target target);
 int TargetCudaGetWarpSize(Target target);
 bool TargetHasLdmatrix(Target target);
-bool TargetHasStmatrix(Target target);
+bool TargetHasStmatrix(Target target, bool is_m16n8 = false);
 bool TargetHasTmem(Target target);
 bool TargetHasBulkCopy(Target target);
 bool TargetSupportVectorize256(Target target);

--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -403,6 +403,9 @@ TIR_DEFINE_TL_BUILTIN(wait_wgmma)
 TIR_DEFINE_TL_BUILTIN(pack_b16).set_num_inputs(2).set_attr<TCallEffectKind>(
     "TCallEffectKind", Integer(CallEffectKind::kPure));
 
+TIR_DEFINE_TL_BUILTIN(pack_b8x4).set_num_inputs(4).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
 TIR_DEFINE_TL_BUILTIN(cluster_arrive_relaxed)
     .set_num_inputs(0)
     .set_attr<TCallEffectKind>("TCallEffectKind",

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -541,6 +541,14 @@ TVM_DLL const Op &ptx_st_bulk_shared();
 TVM_DLL const Op &pack_b16();
 
 /*!
+ * \brief Pack four b8 value into a b32 value
+ *
+ * int32 pack_b8x4(b8_value, b8_value, b8_value, b8_value)
+ *
+ */
+TVM_DLL const Op &pack_b8x4();
+
+/*!
  * \brief Issue a shared memory fence for async operations
  *
  * FenceProxyAsync()

--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -1230,10 +1230,16 @@ void CodeGenTileLangHIP::VisitExpr_(const CallNode *op, std::ostream &os) {
   } else if (op->op.same_as(tl::ptx_stmatrix())) {
     int trans = Downcast<IntImm>(op->args[0])->value;
     int num = Downcast<IntImm>(op->args[1])->value;
+    int payload_start = 2;
+    if (op->args.size() >= 4 && op->args[2].as<StringImmNode>()) {
+      ICHECK_EQ(Downcast<StringImm>(op->args[2])->value, "m8n8")
+          << "HIP stmatrix codegen only supports m8n8";
+      payload_start = 3;
+    }
     std::string func_name = "tl::ptx_stmatrix_x" + std::to_string(num);
     if (trans == 1)
       func_name += "_trans";
-    print_extern_call_stmt(func_name, 2);
+    print_extern_call_stmt(func_name, payload_start);
   } else if (op->op.same_as(tl::wait_wgmma())) {
     this->PrintIndent();
     int num_mma = Downcast<IntImm>(op->args[0])->value;

--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -1159,11 +1159,12 @@ std::string CodeGenTileLangHIP::GetBufferRef(DataType t,
 }
 
 void CodeGenTileLangHIP::VisitExpr_(const CallNode *op, std::ostream &os) {
-  auto print_extern_call_stmt = [&](std::string name, size_t offset = 0) {
+  auto print_extern_call_stmt = [&](std::string name, size_t start = 0,
+                                    size_t end = 0) {
     this->PrintIndent();
     this->stream << name << "(";
-    for (size_t i = offset; i < op->args.size(); i++) {
-      if (i > offset)
+    for (size_t i = start; i < op->args.size() - end; i++) {
+      if (i > start)
         this->stream << ", ";
       this->stream << this->PrintExpr(op->args[i]);
     }
@@ -1230,16 +1231,16 @@ void CodeGenTileLangHIP::VisitExpr_(const CallNode *op, std::ostream &os) {
   } else if (op->op.same_as(tl::ptx_stmatrix())) {
     int trans = Downcast<IntImm>(op->args[0])->value;
     int num = Downcast<IntImm>(op->args[1])->value;
-    int payload_start = 2;
-    if (op->args.size() >= 4 && op->args[2].as<StringImmNode>()) {
-      ICHECK_EQ(Downcast<StringImm>(op->args[2])->value, "m8n8")
+    bool has_shape =
+        op->args.size() >= 4 && op->args.back().as<StringImmNode>();
+    if (has_shape) {
+      ICHECK_EQ(Downcast<StringImm>(op->args.back())->value, "m8n8")
           << "HIP stmatrix codegen only supports m8n8";
-      payload_start = 3;
     }
     std::string func_name = "tl::ptx_stmatrix_x" + std::to_string(num);
     if (trans == 1)
       func_name += "_trans";
-    print_extern_call_stmt(func_name, payload_start);
+    print_extern_call_stmt(func_name, 2, has_shape ? 1 : 0);
   } else if (op->op.same_as(tl::wait_wgmma())) {
     this->PrintIndent();
     int num_mma = Downcast<IntImm>(op->args[0])->value;

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -184,6 +184,13 @@ TL_DEVICE unsigned int make_uint(unsigned char x0, unsigned char x1,
   return (x3 << 24) | (x2 << 16) | (x1 << 8) | x0;
 }
 
+template <typename T> TL_DEVICE unsigned int pack_b8x4(T x0, T x1, T x2, T x3) {
+  return make_uint(*reinterpret_cast<unsigned char *>(&x0),
+                   *reinterpret_cast<unsigned char *>(&x1),
+                   *reinterpret_cast<unsigned char *>(&x2),
+                   *reinterpret_cast<unsigned char *>(&x3));
+}
+
 // Pack eight char values.
 TL_DEVICE uint2 make_uint2(unsigned char x0, unsigned char x1, unsigned char x2,
                            unsigned char x3, unsigned char y0, unsigned char y1,

--- a/src/tl_templates/cuda/ldsm.h
+++ b/src/tl_templates/cuda/ldsm.h
@@ -61,7 +61,7 @@ TL_DEVICE void ptx_ldmatrix_x4_trans(void const *const smem_ptr,
       : "r"(smem_int_ptr));
 }
 
-TL_DEVICE void ptx_stmatrix_x1_m8n8(void const *const smem_ptr,
+TL_DEVICE void ptx_stmatrix_m8n8_x1(void const *const smem_ptr,
                                     const int32_t &value0) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   asm volatile("stmatrix.sync.aligned.x1.m8n8.shared.b16 [%0], {%1};\n" ::"r"(
@@ -69,7 +69,7 @@ TL_DEVICE void ptx_stmatrix_x1_m8n8(void const *const smem_ptr,
                "r"(value0));
 }
 
-TL_DEVICE void ptx_stmatrix_x2_m8n8(void const *const smem_ptr,
+TL_DEVICE void ptx_stmatrix_m8n8_x2(void const *const smem_ptr,
                                     const int32_t &value0,
                                     const int32_t &value1) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
@@ -79,7 +79,7 @@ TL_DEVICE void ptx_stmatrix_x2_m8n8(void const *const smem_ptr,
       "r"(value0), "r"(value1));
 }
 
-TL_DEVICE void ptx_stmatrix_x4_m8n8(void const *const smem_ptr,
+TL_DEVICE void ptx_stmatrix_m8n8_x4(void const *const smem_ptr,
                                     const int32_t &value0,
                                     const int32_t &value1,
                                     const int32_t &value2,
@@ -91,7 +91,7 @@ TL_DEVICE void ptx_stmatrix_x4_m8n8(void const *const smem_ptr,
       "r"(value0), "r"(value1), "r"(value2), "r"(value3));
 }
 
-TL_DEVICE void ptx_stmatrix_x1_m8n8_trans(void const *const smem_ptr,
+TL_DEVICE void ptx_stmatrix_m8n8_x1_trans(void const *const smem_ptr,
                                           const int32_t &value0) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   asm volatile(
@@ -100,7 +100,7 @@ TL_DEVICE void ptx_stmatrix_x1_m8n8_trans(void const *const smem_ptr,
       "r"(value0));
 }
 
-TL_DEVICE void ptx_stmatrix_x2_m8n8_trans(void const *const smem_ptr,
+TL_DEVICE void ptx_stmatrix_m8n8_x2_trans(void const *const smem_ptr,
                                           const int32_t &value0,
                                           const int32_t &value1) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
@@ -110,7 +110,7 @@ TL_DEVICE void ptx_stmatrix_x2_m8n8_trans(void const *const smem_ptr,
       "r"(value0), "r"(value1));
 }
 
-TL_DEVICE void ptx_stmatrix_x4_m8n8_trans(void const *const smem_ptr,
+TL_DEVICE void ptx_stmatrix_m8n8_x4_trans(void const *const smem_ptr,
                                           const int32_t &value0,
                                           const int32_t &value1,
                                           const int32_t &value2,
@@ -124,7 +124,7 @@ TL_DEVICE void ptx_stmatrix_x4_m8n8_trans(void const *const smem_ptr,
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000) &&                       \
     (defined(__CUDA_ARCH_FEAT_SM100_ALL) || defined(__CUDA_ARCH_FEAT_SM100_F))
 
-TL_DEVICE void ptx_stmatrix_x1_m16n8_trans(void const *const smem_ptr,
+TL_DEVICE void ptx_stmatrix_m16n8_x1_trans(void const *const smem_ptr,
                                            const int32_t &value0) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   asm volatile(
@@ -133,7 +133,7 @@ TL_DEVICE void ptx_stmatrix_x1_m16n8_trans(void const *const smem_ptr,
       "r"(value0));
 }
 
-TL_DEVICE void ptx_stmatrix_x2_m16n8_trans(void const *const smem_ptr,
+TL_DEVICE void ptx_stmatrix_m16n8_x2_trans(void const *const smem_ptr,
                                            const int32_t &value0,
                                            const int32_t &value1) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
@@ -143,7 +143,7 @@ TL_DEVICE void ptx_stmatrix_x2_m16n8_trans(void const *const smem_ptr,
       "r"(value0), "r"(value1));
 }
 
-TL_DEVICE void ptx_stmatrix_x4_m16n8_trans(void const *const smem_ptr,
+TL_DEVICE void ptx_stmatrix_m16n8_x4_trans(void const *const smem_ptr,
                                            const int32_t &value0,
                                            const int32_t &value1,
                                            const int32_t &value2,
@@ -159,29 +159,29 @@ TL_DEVICE void ptx_stmatrix_x4_m16n8_trans(void const *const smem_ptr,
 
 TL_DEVICE void ptx_stmatrix_x1(void const *const smem_ptr,
                                const int32_t &value0) {
-  ptx_stmatrix_x1_m8n8(smem_ptr, value0);
+  ptx_stmatrix_m8n8_x1(smem_ptr, value0);
 }
 
 TL_DEVICE void ptx_stmatrix_x2(void const *const smem_ptr,
                                const int32_t &value0, const int32_t &value1) {
-  ptx_stmatrix_x2_m8n8(smem_ptr, value0, value1);
+  ptx_stmatrix_m8n8_x2(smem_ptr, value0, value1);
 }
 
 TL_DEVICE void ptx_stmatrix_x4(void const *const smem_ptr,
                                const int32_t &value0, const int32_t &value1,
                                const int32_t &value2, const int32_t &value3) {
-  ptx_stmatrix_x4_m8n8(smem_ptr, value0, value1, value2, value3);
+  ptx_stmatrix_m8n8_x4(smem_ptr, value0, value1, value2, value3);
 }
 
 TL_DEVICE void ptx_stmatrix_x1_trans(void const *const smem_ptr,
                                      const int32_t &value0) {
-  ptx_stmatrix_x1_m8n8_trans(smem_ptr, value0);
+  ptx_stmatrix_m8n8_x1_trans(smem_ptr, value0);
 }
 
 TL_DEVICE void ptx_stmatrix_x2_trans(void const *const smem_ptr,
                                      const int32_t &value0,
                                      const int32_t &value1) {
-  ptx_stmatrix_x2_m8n8_trans(smem_ptr, value0, value1);
+  ptx_stmatrix_m8n8_x2_trans(smem_ptr, value0, value1);
 }
 
 TL_DEVICE void ptx_stmatrix_x4_trans(void const *const smem_ptr,
@@ -189,7 +189,7 @@ TL_DEVICE void ptx_stmatrix_x4_trans(void const *const smem_ptr,
                                      const int32_t &value1,
                                      const int32_t &value2,
                                      const int32_t &value3) {
-  ptx_stmatrix_x4_m8n8_trans(smem_ptr, value0, value1, value2, value3);
+  ptx_stmatrix_m8n8_x4_trans(smem_ptr, value0, value1, value2, value3);
 }
 
 } // namespace tl

--- a/src/tl_templates/cuda/ldsm.h
+++ b/src/tl_templates/cuda/ldsm.h
@@ -61,16 +61,17 @@ TL_DEVICE void ptx_ldmatrix_x4_trans(void const *const smem_ptr,
       : "r"(smem_int_ptr));
 }
 
-TL_DEVICE void ptx_stmatrix_x1(void const *const smem_ptr,
-                               const int32_t &value0) {
+TL_DEVICE void ptx_stmatrix_x1_m8n8(void const *const smem_ptr,
+                                    const int32_t &value0) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   asm volatile("stmatrix.sync.aligned.x1.m8n8.shared.b16 [%0], {%1};\n" ::"r"(
                    smem_int_ptr),
                "r"(value0));
 }
 
-TL_DEVICE void ptx_stmatrix_x2(void const *const smem_ptr,
-                               const int32_t &value0, const int32_t &value1) {
+TL_DEVICE void ptx_stmatrix_x2_m8n8(void const *const smem_ptr,
+                                    const int32_t &value0,
+                                    const int32_t &value1) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   asm volatile(
       "stmatrix.sync.aligned.x2.m8n8.shared.b16 [%0], {%1, %2};\n" ::"r"(
@@ -78,9 +79,11 @@ TL_DEVICE void ptx_stmatrix_x2(void const *const smem_ptr,
       "r"(value0), "r"(value1));
 }
 
-TL_DEVICE void ptx_stmatrix_x4(void const *const smem_ptr,
-                               const int32_t &value0, const int32_t &value1,
-                               const int32_t &value2, const int32_t &value3) {
+TL_DEVICE void ptx_stmatrix_x4_m8n8(void const *const smem_ptr,
+                                    const int32_t &value0,
+                                    const int32_t &value1,
+                                    const int32_t &value2,
+                                    const int32_t &value3) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   asm volatile(
       "stmatrix.sync.aligned.x4.m8n8.shared.b16 [%0], {%1, %2, %3, %4};\n" ::
@@ -88,8 +91,8 @@ TL_DEVICE void ptx_stmatrix_x4(void const *const smem_ptr,
       "r"(value0), "r"(value1), "r"(value2), "r"(value3));
 }
 
-TL_DEVICE void ptx_stmatrix_x1_trans(void const *const smem_ptr,
-                                     const int32_t &value0) {
+TL_DEVICE void ptx_stmatrix_x1_m8n8_trans(void const *const smem_ptr,
+                                          const int32_t &value0) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   asm volatile(
       "stmatrix.sync.aligned.x1.trans.m8n8.shared.b16 [%0], {%1};\n" ::"r"(
@@ -97,9 +100,9 @@ TL_DEVICE void ptx_stmatrix_x1_trans(void const *const smem_ptr,
       "r"(value0));
 }
 
-TL_DEVICE void ptx_stmatrix_x2_trans(void const *const smem_ptr,
-                                     const int32_t &value0,
-                                     const int32_t &value1) {
+TL_DEVICE void ptx_stmatrix_x2_m8n8_trans(void const *const smem_ptr,
+                                          const int32_t &value0,
+                                          const int32_t &value1) {
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   asm volatile(
       "stmatrix.sync.aligned.x2.trans.m8n8.shared.b16 [%0], {%1, %2};\n" ::"r"(
@@ -107,15 +110,86 @@ TL_DEVICE void ptx_stmatrix_x2_trans(void const *const smem_ptr,
       "r"(value0), "r"(value1));
 }
 
+TL_DEVICE void ptx_stmatrix_x4_m8n8_trans(void const *const smem_ptr,
+                                          const int32_t &value0,
+                                          const int32_t &value1,
+                                          const int32_t &value2,
+                                          const int32_t &value3) {
+  uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
+  asm volatile("stmatrix.sync.aligned.x4.trans.m8n8.shared.b16 [%0], {%1, %2, "
+               "%3, %4};\n" ::"r"(smem_int_ptr),
+               "r"(value0), "r"(value1), "r"(value2), "r"(value3));
+}
+
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000) &&                       \
+    (defined(__CUDA_ARCH_FEAT_SM100_ALL) || defined(__CUDA_ARCH_FEAT_SM100_F))
+
+TL_DEVICE void ptx_stmatrix_x1_m16n8_trans(void const *const smem_ptr,
+                                           const int32_t &value0) {
+  uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
+  asm volatile(
+      "stmatrix.sync.aligned.m16n8.x1.trans.shared.b8 [%0], {%1};\n" ::"r"(
+          smem_int_ptr),
+      "r"(value0));
+}
+
+TL_DEVICE void ptx_stmatrix_x2_m16n8_trans(void const *const smem_ptr,
+                                           const int32_t &value0,
+                                           const int32_t &value1) {
+  uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
+  asm volatile(
+      "stmatrix.sync.aligned.m16n8.x2.trans.shared.b8 [%0], {%1, %2};\n" ::"r"(
+          smem_int_ptr),
+      "r"(value0), "r"(value1));
+}
+
+TL_DEVICE void ptx_stmatrix_x4_m16n8_trans(void const *const smem_ptr,
+                                           const int32_t &value0,
+                                           const int32_t &value1,
+                                           const int32_t &value2,
+                                           const int32_t &value3) {
+  uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
+  asm volatile(
+      "stmatrix.sync.aligned.m16n8.x4.trans.shared.b8 [%0], {%1, %2, %3, "
+      "%4};\n" ::"r"(smem_int_ptr),
+      "r"(value0), "r"(value1), "r"(value2), "r"(value3));
+}
+
+#endif
+
+TL_DEVICE void ptx_stmatrix_x1(void const *const smem_ptr,
+                               const int32_t &value0) {
+  ptx_stmatrix_x1_m8n8(smem_ptr, value0);
+}
+
+TL_DEVICE void ptx_stmatrix_x2(void const *const smem_ptr,
+                               const int32_t &value0, const int32_t &value1) {
+  ptx_stmatrix_x2_m8n8(smem_ptr, value0, value1);
+}
+
+TL_DEVICE void ptx_stmatrix_x4(void const *const smem_ptr,
+                               const int32_t &value0, const int32_t &value1,
+                               const int32_t &value2, const int32_t &value3) {
+  ptx_stmatrix_x4_m8n8(smem_ptr, value0, value1, value2, value3);
+}
+
+TL_DEVICE void ptx_stmatrix_x1_trans(void const *const smem_ptr,
+                                     const int32_t &value0) {
+  ptx_stmatrix_x1_m8n8_trans(smem_ptr, value0);
+}
+
+TL_DEVICE void ptx_stmatrix_x2_trans(void const *const smem_ptr,
+                                     const int32_t &value0,
+                                     const int32_t &value1) {
+  ptx_stmatrix_x2_m8n8_trans(smem_ptr, value0, value1);
+}
+
 TL_DEVICE void ptx_stmatrix_x4_trans(void const *const smem_ptr,
                                      const int32_t &value0,
                                      const int32_t &value1,
                                      const int32_t &value2,
                                      const int32_t &value3) {
-  uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
-  asm volatile("stmatrix.sync.aligned.x4.trans.m8n8.shared.b16 [%0], {%1, %2, "
-               "%3, %4};\n" ::"r"(smem_int_ptr),
-               "r"(value0), "r"(value1), "r"(value2), "r"(value3));
+  ptx_stmatrix_x4_m8n8_trans(smem_ptr, value0, value1, value2, value3);
 }
 
 } // namespace tl

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -935,12 +935,10 @@ private:
       is_ptx_ = true;
       auto call = Downcast<Call>(IRMutatorWithAnalyzer::VisitExpr_(op));
       is_ptx_ = false;
-      // form: T.ptx_stmatrix(trans, num, [shape,] smem_ptr, value0, value1,
-      // ...) smem_ptr: T.tvm_access_ptr(ptype, data, offset, extent, rw_mask)
-      // or T.address_of(buffer, offset)
-      int access_ptr_index =
-          call->args.size() >= 4 && call->args[2].as<StringImmNode>() ? 3 : 2;
-      PrimExpr access_ptr = call->args[access_ptr_index];
+      // form: T.ptx_stmatrix(trans, num, smem_ptr, value0, value1, ...,
+      // [shape]) smem_ptr: T.tvm_access_ptr(ptype, data, offset, extent,
+      // rw_mask) or T.address_of(buffer, offset)
+      PrimExpr access_ptr = call->args[2];
       Call access_ptr_call = Downcast<Call>(access_ptr);
 
       // Handle both tvm_access_ptr and address_of
@@ -949,7 +947,7 @@ private:
             HandleAccessPtrAndOffset(access_ptr, std::nullopt, call->dtype);
         if (new_access_ptr.rewritten) {
           auto new_call = call.CopyOnWrite();
-          new_call->args.Set(access_ptr_index, new_access_ptr.expr);
+          new_call->args.Set(2, new_access_ptr.expr);
         }
       } else if (access_ptr_call->op.same_as(builtin::address_of())) {
         Optional<PrimExpr> resolved =
@@ -960,25 +958,24 @@ private:
         PrimExpr load_expr = resolved.value();
         if (!load_expr.same_as(access_ptr_call->args[0])) {
           auto call_node = call.CopyOnWrite();
-          call_node->args.Set(access_ptr_index,
-                              Call(access_ptr_call->dtype, access_ptr_call->op,
-                                   {load_expr}, access_ptr_call->annotations,
-                                   access_ptr_call->span));
-          access_ptr_call = Downcast<Call>(call->args[access_ptr_index]);
-          access_ptr = call->args[access_ptr_index];
+          call_node->args.Set(
+              2, Call(access_ptr_call->dtype, access_ptr_call->op, {load_expr},
+                      access_ptr_call->annotations, access_ptr_call->span));
+          access_ptr_call = Downcast<Call>(call->args[2]);
+          access_ptr = call->args[2];
         }
         auto new_access_ptr =
             HandleAccessPtrAndOffset(access_ptr, std::nullopt, call->dtype);
         if (new_access_ptr.rewritten) {
           auto new_call = call.CopyOnWrite();
-          new_call->args.Set(access_ptr_index, new_access_ptr.expr);
+          new_call->args.Set(2, new_access_ptr.expr);
         }
       } else if (access_ptr_call->op.same_as(tl::access_ptr())) {
         auto new_access_ptr =
             HandleAccessPtrAndOffset(access_ptr, std::nullopt, call->dtype);
         if (new_access_ptr.rewritten) {
           auto new_call = call.CopyOnWrite();
-          new_call->args.Set(access_ptr_index, new_access_ptr.expr);
+          new_call->args.Set(2, new_access_ptr.expr);
         }
       } else {
         LOG(FATAL) << "Invalid access ptr for permuted layout: " << access_ptr;

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -935,10 +935,12 @@ private:
       is_ptx_ = true;
       auto call = Downcast<Call>(IRMutatorWithAnalyzer::VisitExpr_(op));
       is_ptx_ = false;
-      // form: T.ptx_stmatrix(trans, num, smem_ptr, value0, value1, ...)
-      // smem_ptr: T.tvm_access_ptr(ptype, data, offset, extent, rw_mask)
+      // form: T.ptx_stmatrix(trans, num, [shape,] smem_ptr, value0, value1,
+      // ...) smem_ptr: T.tvm_access_ptr(ptype, data, offset, extent, rw_mask)
       // or T.address_of(buffer, offset)
-      PrimExpr access_ptr = call->args[2];
+      int access_ptr_index =
+          call->args.size() >= 4 && call->args[2].as<StringImmNode>() ? 3 : 2;
+      PrimExpr access_ptr = call->args[access_ptr_index];
       Call access_ptr_call = Downcast<Call>(access_ptr);
 
       // Handle both tvm_access_ptr and address_of
@@ -947,7 +949,7 @@ private:
             HandleAccessPtrAndOffset(access_ptr, std::nullopt, call->dtype);
         if (new_access_ptr.rewritten) {
           auto new_call = call.CopyOnWrite();
-          new_call->args.Set(2, new_access_ptr.expr);
+          new_call->args.Set(access_ptr_index, new_access_ptr.expr);
         }
       } else if (access_ptr_call->op.same_as(builtin::address_of())) {
         Optional<PrimExpr> resolved =
@@ -958,24 +960,25 @@ private:
         PrimExpr load_expr = resolved.value();
         if (!load_expr.same_as(access_ptr_call->args[0])) {
           auto call_node = call.CopyOnWrite();
-          call_node->args.Set(
-              2, Call(access_ptr_call->dtype, access_ptr_call->op, {load_expr},
-                      access_ptr_call->annotations, access_ptr_call->span));
-          access_ptr_call = Downcast<Call>(call->args[2]);
-          access_ptr = call->args[2];
+          call_node->args.Set(access_ptr_index,
+                              Call(access_ptr_call->dtype, access_ptr_call->op,
+                                   {load_expr}, access_ptr_call->annotations,
+                                   access_ptr_call->span));
+          access_ptr_call = Downcast<Call>(call->args[access_ptr_index]);
+          access_ptr = call->args[access_ptr_index];
         }
         auto new_access_ptr =
             HandleAccessPtrAndOffset(access_ptr, std::nullopt, call->dtype);
         if (new_access_ptr.rewritten) {
           auto new_call = call.CopyOnWrite();
-          new_call->args.Set(2, new_access_ptr.expr);
+          new_call->args.Set(access_ptr_index, new_access_ptr.expr);
         }
       } else if (access_ptr_call->op.same_as(tl::access_ptr())) {
         auto new_access_ptr =
             HandleAccessPtrAndOffset(access_ptr, std::nullopt, call->dtype);
         if (new_access_ptr.rewritten) {
           auto new_call = call.CopyOnWrite();
-          new_call->args.Set(2, new_access_ptr.expr);
+          new_call->args.Set(access_ptr_index, new_access_ptr.expr);
         }
       } else {
         LOG(FATAL) << "Invalid access ptr for permuted layout: " << access_ptr;

--- a/testing/python/language/test_tilelang_language_copy.py
+++ b/testing/python/language/test_tilelang_language_copy.py
@@ -241,7 +241,7 @@ def test_tilelang_copy_uses_stmatrix_m16n8_for_sm100_int8_shared_store():
             T.copy(frag, smem)
 
     target = {"kind": "cuda", "arch": "sm_100a"}
-    with tvm.transform.PassContext(), tvm.target.Target(target):
+    with tvm.target.Target(target):
         artifact = tilelang.lower(main, target=target)
 
     assert "tl::ptx_stmatrix_m16n8_x1_trans" in artifact.kernel_source

--- a/testing/python/language/test_tilelang_language_copy.py
+++ b/testing/python/language/test_tilelang_language_copy.py
@@ -233,13 +233,7 @@ def test_tilelang_copy_uses_stmatrix_m16n8_for_sm100_int8_shared_store():
             frag = T.alloc_fragment((16, 8), T.int8)
             smem = T.alloc_shared((16, 8), T.int8)
 
-            T.annotate_layout(
-                {
-                    frag: make_gemm_fragment_8x8_transposed().repeat(
-                        [2, 1], repeat_on_thread=False
-                    )
-                }
-            )
+            T.annotate_layout({frag: make_gemm_fragment_8x8_transposed().repeat([2, 1], repeat_on_thread=False)})
 
             for i, j in T.Parallel(16, 8):
                 frag[i, j] = A[i, j]

--- a/testing/python/language/test_tilelang_language_copy.py
+++ b/testing/python/language/test_tilelang_language_copy.py
@@ -244,7 +244,7 @@ def test_tilelang_copy_uses_stmatrix_m16n8_for_sm100_int8_shared_store():
     with tvm.transform.PassContext(), tvm.target.Target(target):
         artifact = tilelang.lower(main, target=target)
 
-    assert "tl::ptx_stmatrix_x1_m16n8_trans" in artifact.kernel_source
+    assert "tl::ptx_stmatrix_m16n8_x1_trans" in artifact.kernel_source
 
 
 if __name__ == "__main__":

--- a/testing/python/language/test_tilelang_language_copy.py
+++ b/testing/python/language/test_tilelang_language_copy.py
@@ -2,6 +2,8 @@ import tilelang
 import tilelang.language as T
 import torch
 import tilelang.testing
+from tilelang import tvm
+from tilelang.layout import make_gemm_fragment_8x8_transposed
 
 print(torch.__version__)
 
@@ -221,6 +223,34 @@ def test_tilelang_copy_fp4():
     run_tilelang_copy_fp4(src_dtype=T.float4_e2m1fn, dst_dtype=T.float4_e2m1fn)
     run_tilelang_copy_fp4(src_dtype=T.float4_e2m1fn, dst_dtype=T.float16)
     run_tilelang_copy_fp4(src_dtype=T.float4_e2m1fn, dst_dtype=T.bfloat16)
+
+
+@tilelang.testing.requires_cuda
+def test_tilelang_copy_uses_stmatrix_m16n8_for_sm100_int8_shared_store():
+    @T.prim_func
+    def main(A: T.Tensor((16, 8), T.int8)):
+        with T.Kernel(1, threads=32):
+            frag = T.alloc_fragment((16, 8), T.int8)
+            smem = T.alloc_shared((16, 8), T.int8)
+
+            T.annotate_layout(
+                {
+                    frag: make_gemm_fragment_8x8_transposed().repeat(
+                        [2, 1], repeat_on_thread=False
+                    )
+                }
+            )
+
+            for i, j in T.Parallel(16, 8):
+                frag[i, j] = A[i, j]
+
+            T.copy(frag, smem)
+
+    target = {"kind": "cuda", "arch": "sm_100a"}
+    with tvm.transform.PassContext(), tvm.target.Target(target):
+        artifact = tilelang.lower(main, target=target)
+
+    assert "tl::ptx_stmatrix_x1_m16n8_trans" in artifact.kernel_source
 
 
 if __name__ == "__main__":

--- a/tilelang/cuda/target.py
+++ b/tilelang/cuda/target.py
@@ -141,8 +141,8 @@ def target_has_ldmatrix(target: Target) -> bool:
     return _target_ffi_api().TargetHasLdmatrix(target)
 
 
-def target_has_stmatrix(target: Target) -> bool:
-    return _target_ffi_api().TargetHasStmatrix(target)
+def target_has_stmatrix(target: Target, is_m16n8: bool = False) -> bool:
+    return _target_ffi_api().TargetHasStmatrix(target, is_m16n8)
 
 
 def target_has_bulk_copy(target: Target) -> bool:


### PR DESCRIPTION
https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-matrix-instructions-stmatrix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the `tl.pack_b8x4` intrinsic for packing four 8-bit values into one 32-bit value.
  * Expanded `stmatrix` support with `m8n8` store variants/wrappers and improved `m16n8` support on supported hardware.
* **Bug Fixes / Improvements**
  * Fixed `ptx_stmatrix` code generation to correctly handle the optional trailing shape argument consistently across CUDA and HIP.
  * Improved `tl.copy` lowering to select the `m16n8` `stmatrix` path (e.g., SM100+ int8 shared stores) with generalized register packing.
* **Tests**
  * Added a CUDA-only test validating `m16n8` `stmatrix` usage for int8 shared stores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->