### PR TITLE
[BugFix][CuTeDSL] Fix TileOps H100 regressions

### DIFF
--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -2952,6 +2952,44 @@ void CodeGenTileLangCuTeDSL::PrintVecStore_(const BufferNode *buffer,
   }
 
   if (scope == "local" && buffer->dtype.is_scalar()) {
+    if (t.element_of().is_float8()) {
+      const int packed_bits = t.lanes() * t.element_of().bits();
+      ICHECK_EQ(packed_bits % 8, 0)
+          << "FP8 local vector stores must cover whole bytes";
+      const int packed_bytes = packed_bits / 8;
+
+      std::string src_tensor = store_rhs;
+      if (EndsWithLoad(src_tensor)) {
+        src_tensor = name_supply_->FreshName("_store_tensor");
+        PrintIndent();
+        stream << src_tensor << " = tl.make_rmem_tensor((" << t.lanes()
+               << ",), " << DTypeToString(t.element_of()) << ")\n";
+        PrintIndent();
+        stream << src_tensor << ".store(" << store_rhs << ")\n";
+      }
+
+      std::string vid = GetVarID(buffer_var);
+      std::string src_bytes = name_supply_->FreshName("_fp8_store_src");
+      std::string dst_view = name_supply_->FreshName("_fp8_store_view");
+      std::string dst_bytes = name_supply_->FreshName("_fp8_store_dst");
+      PrintIndent();
+      stream << src_bytes << " = cute.recast_tensor(" << src_tensor
+             << ", cutlass.Uint8)\n";
+      PrintIndent();
+      stream << dst_view << " = tl.make_tensor_at_offset(" << vid
+             << ".iterator, " << PrintExpr_(base) << ", (" << t.lanes()
+             << ",), div_by=1)\n";
+      PrintIndent();
+      stream << dst_bytes << " = cute.recast_tensor(" << dst_view
+             << ", cutlass.Uint8)\n";
+      for (int i = 0; i < packed_bytes; ++i) {
+        PrintIndent();
+        stream << dst_bytes << "[" << i << "] = " << src_bytes << "[" << i
+               << "]\n";
+      }
+      return;
+    }
+
     if (store_rhs.size() < 7 ||
         store_rhs.compare(store_rhs.size() - 7, 7, ".load()") != 0) {
       std::string store_tensor = name_supply_->FreshName("_store_tensor");

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -196,6 +196,7 @@ std::string CodeGenTileLangCuTeDSL::CanonicalizeFastmathFunctionName_(
       {"divf", "tl.divf"},
       {"exp", "tl.exp"},
       {"expf", "tl.exp"},
+      {"hexp", "tl.exp"},
       {"exp2", "tl.exp2"},
       {"exp2f", "tl.exp2"},
       {"log", "tl.log"},
@@ -205,11 +206,16 @@ std::string CodeGenTileLangCuTeDSL::CanonicalizeFastmathFunctionName_(
       {"log2", "tl.log2"},
       {"log2f", "tl.log2"},
       {"log10", "tl.log10"},
+      {"floor", "tl.floor"},
+      {"floorf", "tl.floor"},
       {"tan", "tl.tan"},
       {"cos", "tl.cos"},
       {"sin", "tl.sin"},
+      {"erf", "tl.erf"},
+      {"erff", "tl.erf"},
       {"sqrt", "tl.sqrt"},
       {"sqrtf", "tl.sqrt"},
+      {"hsqrt", "tl.sqrt"},
       {"tanh", "tl.tanh"},
       {"tanhf", "tl.tanh"},
       {"rsqrt", "tl.rsqrt"},
@@ -669,7 +675,7 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const DivNode *op,
   if (op->dtype.is_int() || op->dtype.is_uint()) {
     PrintBinaryExpr_("//", op->dtype, op->a, op->b, os);
   } else {
-    if (enable_fastmath_) {
+    if (enable_fastmath_ && op->dtype.is_scalar()) {
       os << "tl.divf(" << PrintExpr_(op->a) << ", " << PrintExpr_(op->b)
          << ", fastmath=True)";
     } else {
@@ -1175,13 +1181,29 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
     // scaleA/scaleB: True (scale_in) -> 1, False -> -1
     int scaleA = scale_in_a ? 1 : -1;
     int scaleB = scale_in_b ? 1 : -1;
-    PrintIndent();
-    stream << "tl.wgmma_ss(\"" << A_dtype << "\", \"" << B_dtype << "\", \""
-           << C_dtype << "\", " << m << ", " << n << ", " << k << ", " << tnspA
-           << ", " << tnspB << ", " << scaleA << ", " << scaleB << ", ("
-           << a_desc << " + " << A_offset << "), (" << b_desc << " + "
-           << B_offset << "), " << c_ref << " + " << c_offset << ", "
-           << scale_out << ")\n";
+    auto emit_wgmma_ss = [&](const std::string &scale_out_arg) {
+      PrintIndent();
+      stream << "tl.wgmma_ss(\"" << A_dtype << "\", \"" << B_dtype << "\", \""
+             << C_dtype << "\", " << m << ", " << n << ", " << k << ", "
+             << tnspA << ", " << tnspB << ", " << scaleA << ", " << scaleB
+             << ", (" << a_desc << " + " << A_offset << "), (" << b_desc
+             << " + " << B_offset << "), " << c_ref << " + " << c_offset << ", "
+             << scale_out_arg << ")\n";
+    };
+    if (const int64_t *scale_out_value = as_const_int(op->args[12])) {
+      emit_wgmma_ss(*scale_out_value != 0 ? "1" : "0");
+    } else {
+      PrintIndent();
+      stream << "if " << RemoveOutermostParentheses(scale_out) << ":\n";
+      int then_scope = BeginScope();
+      emit_wgmma_ss("1");
+      EndScope(then_scope);
+      PrintIndent();
+      stream << "else:\n";
+      int else_scope = BeginScope();
+      emit_wgmma_ss("0");
+      EndScope(else_scope);
+    }
   } else if (op->op.same_as(tl::ptx_wgmma_rs())) {
     // arg 0: shape (StringImm, e.g. "m64n128k16")
     // arg 1: b_is_k_major (Bool)
@@ -1961,6 +1983,31 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const BufferLoadNode *op,
     }
 
     if (is_contiguous) {
+      std::string scope;
+      if (alloc_storage_scope_.count(buffer_var.get())) {
+        scope = alloc_storage_scope_.at(buffer_var.get());
+      }
+      if (scope.empty()) {
+        scope = GetPtrStorageScope(buffer_var);
+      }
+      if (scope == "local" && element_dtype.is_scalar()) {
+        std::string sret = name_supply_->FreshName("_lvec");
+        PrintIndent();
+        stream << sret << " = tl.make_rmem_tensor((" << value_lanes << ",), ";
+        PrintType(element_dtype, stream);
+        stream << ")\n";
+        for (int i = 0; i < value_lanes; ++i) {
+          PrimExpr idx_expr =
+              arith::Analyzer().Simplify(base.Eval() + Integer(i));
+          PrintIndent();
+          stream << sret << "[" << i << "] = "
+                 << GetBufferRef_(element_dtype, op->buffer.get(), idx_expr)
+                 << "\n";
+        }
+        os << sret << ".load()";
+        return;
+      }
+
       std::string ref =
           GetBufferRef_(value_dtype, op->buffer.get(), base.Eval());
       if (ref.back() == ')') {
@@ -2883,9 +2930,18 @@ void CodeGenTileLangCuTeDSL::PrintVecStore_(const BufferNode *buffer,
                                             const std::string &value) {
   ICHECK(!t.is_scalar()) << "PrintVecStore_() should not be used for scalar";
 
-  std::string ref = GetBufferRef_(t, buffer, base);
   std::string store_rhs = value;
+  const VarNode *buffer_var = buffer->data.get();
+  std::string scope;
+  if (alloc_storage_scope_.count(buffer_var)) {
+    scope = alloc_storage_scope_.at(buffer_var);
+  }
+  if (scope.empty()) {
+    scope = GetPtrStorageScope(buffer->data);
+  }
+
   if (t.element_of().bits() < 8) {
+    std::string ref = GetBufferRef_(t, buffer, base);
     if (store_rhs.size() < 7 ||
         store_rhs.compare(store_rhs.size() - 7, 7, ".load()") != 0) {
       store_rhs += ".load()";
@@ -2895,6 +2951,32 @@ void CodeGenTileLangCuTeDSL::PrintVecStore_(const BufferNode *buffer,
     return;
   }
 
+  if (scope == "local" && buffer->dtype.is_scalar()) {
+    if (store_rhs.size() < 7 ||
+        store_rhs.compare(store_rhs.size() - 7, 7, ".load()") != 0) {
+      std::string store_tensor = name_supply_->FreshName("_store_tensor");
+      PrintIndent();
+      stream << store_tensor << " = tl.make_rmem_tensor((" << t.lanes()
+             << ",), " << DTypeToString(t.element_of()) << ")\n";
+      for (int i = 0; i < t.lanes(); ++i) {
+        PrintIndent();
+        stream << store_tensor << "[" << i << "] = ";
+        PrintVecElemLoad_(store_rhs, t, i, stream);
+        stream << "\n";
+      }
+      store_rhs = store_tensor;
+    }
+    for (int i = 0; i < t.lanes(); ++i) {
+      PrimExpr idx_expr = arith::Analyzer().Simplify(base + Integer(i));
+      PrintIndent();
+      stream << GetBufferRef_(t.element_of(), buffer, idx_expr) << " = ";
+      PrintVecElemLoad_(store_rhs, t, i, stream);
+      stream << "\n";
+    }
+    return;
+  }
+
+  std::string ref = GetBufferRef_(t, buffer, base);
   if (store_rhs.size() < 7 ||
       store_rhs.compare(store_rhs.size() - 7, 7, ".load()") != 0) {
     std::string store_tensor = name_supply_->FreshName("_store_tensor");
@@ -3058,6 +3140,9 @@ void CodeGenTileLangCuTeDSL::PrintCallExtern_(Type ret_type,
   // Warp-level primitives (__activemask, __shfl_down_sync, __shfl_sync)
   if (global_symbol_str.substr(0, 2) == "__") {
     global_symbol_str = "tl." + global_symbol_str;
+  }
+  if (global_symbol_str == "tl_atomic_add_offset") {
+    global_symbol_str = "tl.tl_atomic_add_offset";
   }
   // some optional template arguments might be ommited, so add names explicitly
   // for remain arguments

--- a/src/cuda/transform/producer_consumer_ws.cc
+++ b/src/cuda/transform/producer_consumer_ws.cc
@@ -1540,7 +1540,11 @@ private:
       LocalLiveSet movable_probe_live = producer_body_live;
       for (int ci = compute_cursor; ci < wait_pos; ++ci) {
         const LocalAccessSummary &summary = consumer_compute_summaries[ci];
-        if (consumer_compute_stmts[ci].as<BindNode>()) {
+        if (const auto *bind = consumer_compute_stmts[ci].as<BindNode>()) {
+          if (SideEffect(bind->value) > CallEffectKind::kReadState) {
+            all_movable = false;
+            break;
+          }
           if (!movable_probe_live.NeedsAnyDef(summary)) {
             all_movable = false;
             break;
@@ -1707,9 +1711,14 @@ private:
               bitwise_xor(p_parity_expr, IntImm(DataType::Int(32), 1))));
         }
 
-        // After the first bp_wait, emit all SIMT/cp.async producers
-        // followed immediately by commit_group so the hardware can start
-        // the async transfers as early as possible, overlapping with TMA.
+        for (const auto &stmt : producer_loop_prefix_stmts[tma_idx]) {
+          producer_stmts.push_back(stmt);
+        }
+
+        // After the first bp_wait and producer-local prefix definitions, emit
+        // all SIMT/cp.async producers followed immediately by commit_group so
+        // the hardware can start the async transfers as early as possible,
+        // overlapping with TMA.
         if (!simt_stmts_emitted && !simt_producer_stmts.empty()) {
           for (const auto &s : simt_producer_stmts) {
             producer_stmts.push_back(s);
@@ -1723,9 +1732,6 @@ private:
           simt_stmts_emitted = true;
         }
 
-        for (const auto &stmt : producer_loop_prefix_stmts[tma_idx]) {
-          producer_stmts.push_back(stmt);
-        }
         // Convert copy → tma_copy with barrier, or annotate non-copy
         // TMA tile-ops (e.g. im2col) with barrier reference.
         const auto *eval = flat_stmts[i].as<EvaluateNode>();

--- a/src/transform/common/bind_utils.h
+++ b/src/transform/common/bind_utils.h
@@ -6,6 +6,7 @@
 #define TVM_TL_TRANSFORM_COMMON_BIND_UTILS_H_
 
 #include <tvm/ir/type.h>
+#include <tvm/tirx/analysis.h>
 #include <tvm/tirx/stmt.h>
 
 #include <unordered_set>
@@ -30,6 +31,9 @@ inline bool IsReplayableScalarBind(const Stmt &stmt,
     return false;
   }
   if (!bind->value.dtype().is_scalar() || bind->value.dtype().is_handle()) {
+    return false;
+  }
+  if (SideEffect(bind->value) > CallEffectKind::kReadState) {
     return false;
   }
   for (const BufferRegion &read : reads) {

--- a/src/transform/frontend_legalize.cc
+++ b/src/transform/frontend_legalize.cc
@@ -23,6 +23,7 @@
  */
 
 #include "support/check.h"
+#include <tvm/tirx/analysis.h>
 #include <tvm/tirx/op.h>
 #include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/transform.h>
@@ -67,13 +68,28 @@ private:
   }
 
   Stmt VisitStmt_(const BindNode *node) final {
-    let_bindings_[node->var.get()] = node->value;
-    return Evaluate(Integer(0));
+    PrimExpr value = arith::IRMutatorWithAnalyzer::VisitExpr(node->value);
+    if (SideEffect(value) <= CallEffectKind::kReadState) {
+      let_bindings_[node->var.get()] = value;
+      return Evaluate(Integer(0));
+    }
+    if (value.same_as(node->value)) {
+      return ffi::GetRef<Stmt>(node);
+    }
+    return Bind(node->var, value, node->span);
   }
 
   PrimExpr VisitExpr_(const LetNode *node) final {
-    let_bindings_[node->var.get()] = node->value;
-    return arith::IRMutatorWithAnalyzer::VisitExpr(node->body);
+    PrimExpr value = arith::IRMutatorWithAnalyzer::VisitExpr(node->value);
+    if (SideEffect(value) <= CallEffectKind::kReadState) {
+      let_bindings_[node->var.get()] = value;
+      return arith::IRMutatorWithAnalyzer::VisitExpr(node->body);
+    }
+    PrimExpr body = arith::IRMutatorWithAnalyzer::VisitExpr(node->body);
+    if (value.same_as(node->value) && body.same_as(node->body)) {
+      return ffi::GetRef<PrimExpr>(node);
+    }
+    return Let(node->var, value, body, node->span);
   }
 
   int parallel_for_scope_ = 0;

--- a/testing/python/autotune/test_tilelang_autotune.py
+++ b/testing/python/autotune/test_tilelang_autotune.py
@@ -1,8 +1,10 @@
 import itertools
+import inspect
 
 import tilelang.testing
 import tilelang.language as T
 from tilelang.autotuner import AutoTuner
+from tilelang.autotuner.tuner import _first_autotune_config, _provided_jit_parameter_names
 
 
 def ref_program(A, B):
@@ -202,6 +204,71 @@ def matmul(M, N, K):
 @tilelang.testing.requires_cuda
 def test_autotune_get_configs():
     get_configs()
+
+
+def test_autotune_validation_config_skips_positional_args():
+    def kernel(
+        B,
+        S,
+        H,
+        DK,
+        DV,
+        input_dtype,
+        output_dtype,
+        accum_dtype,
+        gate_dtype,
+        state_dtype,
+        chunk_size,
+        use_g,
+        use_initial_state,
+        store_final_state,
+        save_new_value,
+        block_DK,
+        block_DV,
+        threads,
+        num_stages,
+    ):
+        return None
+
+    signature = inspect.signature(kernel)
+    args = (
+        1,
+        1024,
+        32,
+        128,
+        128,
+        "bfloat16",
+        "bfloat16",
+        "float32",
+        "float32",
+        "bfloat16",
+        64,
+        True,
+        True,
+        True,
+        False,
+        32,
+        32,
+        128,
+        1,
+    )
+
+    provided = _provided_jit_parameter_names(signature, args, {})
+    first_config = _first_autotune_config([{"block_DK": 64, "block_DV": 64, "threads": 256, "num_stages": 2}])
+    validation_kwargs = {}
+    for name in signature.parameters:
+        if name in first_config and name not in provided:
+            validation_kwargs[name] = first_config[name]
+
+    assert validation_kwargs == {}
+
+
+def test_first_autotune_config_accepts_mapping_and_sequence_shapes():
+    assert _first_autotune_config({"threads": 128}) == {"threads": 128}
+    assert _first_autotune_config([{"threads": 128}]) == {"threads": 128}
+    assert _first_autotune_config(({"threads": 128},)) == {"threads": 128}
+    assert _first_autotune_config(lambda: [{"threads": 128}]) is None
+    assert _first_autotune_config([]) is None
 
 
 @tilelang.testing.requires_cuda

--- a/testing/python/target/test_tilelang_codegen_cutedsl_integer_shift.py
+++ b/testing/python/target/test_tilelang_codegen_cutedsl_integer_shift.py
@@ -94,5 +94,23 @@ def test_cutedsl_codegen_local_vector_slice_uses_lane_access():
     assert "local[3]" in artifact.kernel_source
 
 
+def test_cutedsl_codegen_local_fp8_vector_store_uses_byte_recast():
+    @T.prim_func
+    def prog(A: T.Tensor((4,), "float32"), C: T.Tensor((4,), "float8_e4m3fn")):
+        with T.Kernel(1, threads=1):
+            local = T.alloc_local((4,), "float32")
+            local_fp8 = T.alloc_local((4,), "float8_e4m3fn")
+            idx = T.Ramp(0, 1, 4)
+            local[idx] = A[idx]
+            local_fp8[idx] = T.Cast("float8_e4m3fnx4", local[idx])
+            C[idx] = local_fp8[idx]
+
+    artifact = _lower_cutedsl(prog)
+
+    assert "cute.recast_tensor" in artifact.kernel_source
+    assert "cutlass.Uint8" in artifact.kernel_source
+    assert "local_fp8[0] = _cast.load()[0]" not in artifact.kernel_source
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/target/test_tilelang_codegen_cutedsl_integer_shift.py
+++ b/testing/python/target/test_tilelang_codegen_cutedsl_integer_shift.py
@@ -2,6 +2,7 @@ import pytest
 
 import tilelang.language as T
 import tilelang.testing
+import tilelang
 from tilelang import tvm
 from tilelang.engine.lower import lower
 from tilelang.cuda.target import normalize_cutedsl_target
@@ -47,6 +48,50 @@ def test_cutedsl_codegen_does_not_promote_shift_across_signedness():
     artifact = _lower_cutedsl(prog)
 
     assert "cutlass.Uint16(local[0]) >>" not in artifact.kernel_source
+
+
+def test_cutedsl_codegen_vector_div_uses_lane_path_with_fastmath():
+    @T.prim_func
+    def prog(A: T.Tensor((4,), "float32"), B: T.Tensor((4,), "float32"), C: T.Tensor((4,), "float32")):
+        with T.Kernel(1, threads=1):
+            idx = T.Ramp(0, 1, 4)
+            denom = B[idx] + T.Broadcast(T.float32(1), 4)
+            C[idx] = A[idx] / denom
+
+    config_key = tilelang.PassConfigKey.TL_ENABLE_FAST_MATH.value
+    with tvm.transform.PassContext(config={config_key: True}):
+        artifact = _lower_cutedsl(prog)
+
+    assert "fastmath=True" not in artifact.kernel_source
+    assert "tl.divf(" in artifact.kernel_source
+
+
+def test_cutedsl_codegen_canonicalizes_floor_math_call():
+    @T.prim_func
+    def prog(A: T.Tensor((1,), "float32"), B: T.Tensor((1,), "float32")):
+        with T.Kernel(1, threads=1):
+            B[0] = T.floor(A[0] / T.float32(2))
+
+    artifact = _lower_cutedsl(prog)
+
+    assert "tl.floor(" in artifact.kernel_source
+    assert "floorf(" not in artifact.kernel_source
+
+
+def test_cutedsl_codegen_local_vector_slice_uses_lane_access():
+    @T.prim_func
+    def prog(A: T.Tensor((4,), "float32"), C: T.Tensor((4,), "float32")):
+        with T.Kernel(1, threads=1):
+            local = T.alloc_local((4,), "float32")
+            idx = T.Ramp(0, 1, 4)
+            local[idx] = A[idx]
+            C[idx] = local[idx] + T.Broadcast(T.float32(1), 4)
+
+    artifact = _lower_cutedsl(prog)
+
+    assert "tl.make_tensor_at_offset(local.iterator" not in artifact.kernel_source
+    assert "local[0]" in artifact.kernel_source
+    assert "local[3]" in artifact.kernel_source
 
 
 if __name__ == "__main__":

--- a/testing/python/transform/test_tilelang_transform_if_stmt_binding.py
+++ b/testing/python/transform/test_tilelang_transform_if_stmt_binding.py
@@ -69,6 +69,25 @@ def test_if_stmt_binding_inlines_replayable_bind_by_default():
     tvm.ir.assert_structural_equal(after.body, expected.body, True)
 
 
+def test_if_stmt_binding_keeps_effectful_scalar_bind():
+    @T.prim_func
+    def before(A: T.Buffer((8,), "int32"), B: T.Buffer((8,), "int32"), C: T.Buffer((8,), "int32")):
+        if A[0] > T.int32(0):
+            slot = T.bind(T.call_extern("int32", "opaque_next", A[0]))
+            B[slot] = A[1]
+            C[0] = slot
+
+    @T.prim_func
+    def expected(A: T.Buffer((8,), "int32"), B: T.Buffer((8,), "int32"), C: T.Buffer((8,), "int32")):
+        if A[0] > T.int32(0):
+            slot = T.bind(T.call_extern("int32", "opaque_next", A[0]))
+            B[slot] = A[1]
+            C[0] = slot
+
+    after = _run_if_stmt_binding(before)
+    tvm.ir.assert_structural_equal(after.body, expected.body, True)
+
+
 def test_if_stmt_binding_does_not_inline_pointer_bind():
     @T.prim_func(check_well_formed=False)
     def before(A: T.Buffer((4,), "float32"), C: T.Buffer((4,), "float32")):

--- a/testing/python/transform/test_tilelang_transform_let_inline.py
+++ b/testing/python/transform/test_tilelang_transform_let_inline.py
@@ -48,5 +48,21 @@ def test_parallel_scope():
     _check(before, expected)
 
 
+def test_effectful_bind_is_not_inlined():
+    @T.prim_func
+    def before(A: T.Tensor((8,), T.int32), B: T.Tensor((8,), T.int32), C: T.Tensor((8,), T.int32)):
+        slot = T.call_extern("int32", "opaque_next", A[0])
+        B[slot] = A[1]
+        C[0] = slot
+
+    @T.prim_func
+    def expected(A: T.Tensor((8,), T.int32), B: T.Tensor((8,), T.int32), C: T.Tensor((8,), T.int32)):
+        slot = T.call_extern("int32", "opaque_next", A[0])
+        B[slot] = A[1]
+        C[0] = slot
+
+    _check(before, expected)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
+++ b/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
@@ -204,6 +204,43 @@ def explicit_cp_async_wait_position(iters=4, block=16, cp_elems=8, dtype="float1
     return main
 
 
+def guarded_simt_tma_prefix_bind(
+    block_m=64,
+    block_n=128,
+    block_k=128,
+    dtype="float16",
+    threads=128,
+):
+    """Mixed TMA + SIMT producer where SIMT uses a scalar prefix bind."""
+
+    @T.prim_func
+    def main(
+        W: T.Buffer((block_m, block_k), dtype),
+        X: T.Buffer((32, 260), dtype),
+        C: T.Buffer((block_m, block_n), "float32"),
+    ):
+        with T.Kernel(2, threads=threads) as bx:
+            W_shared = T.alloc_shared((block_m, block_k), dtype)
+            X_shared = T.alloc_shared((block_k, block_n), dtype)
+            C_local = T.alloc_fragment((block_m, block_n), "float32")
+
+            T.clear(C_local)
+            tile_spatial_full = bx < 1
+            for ko in T.Pipelined(1, num_stages=3):
+                T.copy(W[0, 0], W_shared)
+                tile_full = tile_spatial_full & (ko == 0)
+                for i, j in T.Parallel(block_k, block_n):
+                    if tile_full:
+                        X_shared[i, j] = X[i % 32, bx * block_n + j + i // 32]
+                    else:
+                        X_shared[i, j] = T.cast(0.0, dtype)
+                T.gemm(W_shared, X_shared, C_local)
+
+            T.copy(C_local, C[0, 0])
+
+    return main
+
+
 def grouped_gemm_padded_pipelined(
     batch_sizes,
     K,
@@ -326,6 +363,26 @@ def test_tiled_ws_places_producer_in_first_warp_group():
 
     assert branch < producer_tma < consumer_branch < consumer_gemm
     assert "if 128 <= tx:" not in script
+
+
+def test_tiled_ws_places_prefix_binds_before_simt_producer_use():
+    """Producer-local scalar binds must be emitted before SIMT producers use them."""
+
+    func = guarded_simt_tma_prefix_bind().with_attr("global_symbol", "main")
+    mod = tvm.IRModule.from_expr(func)
+    target = determine_target({"kind": "cuda", "arch": "sm_90"}, return_object=True)
+    mod = tvm.tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.MaterializeKernelLaunch()(mod)
+    mod = tilelang.cuda.transform.ProducerConsumerWarpSpecialized()(mod)
+    script = mod["main"].script()
+
+    producer_branch = _find_after(script, "if tx < 128:")
+    bp_wait = _find_after(script, "T.mbarrier_wait_parity", producer_branch)
+    tile_full_def = _find_after(script, "tile_full", bp_wait)
+    tile_full_use = _find_after(script, "if tile_full:", tile_full_def)
+    producer_tma = _find_after(script, "T.tma_copy", tile_full_use)
+
+    assert tile_full_def < tile_full_use < producer_tma
 
 
 def _run_grouped_gemm_ws(kernel, batch_sizes, K=128, N=128, block_M=64, dtype="float16"):

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -17,7 +17,7 @@ from tvm.target import Target
 import inspect
 from functools import partial
 from typing import Generic, Literal, Any, ParamSpec, TypeVar
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from tqdm.auto import tqdm
 import logging
 import concurrent.futures
@@ -212,6 +212,31 @@ def _normalize_value(value, sort_dict_items: bool = False):
             return tuple(sorted(items))
         return {k: v for k, v in items}
     return value
+
+
+def _provided_jit_parameter_names(signature: inspect.Signature, args: tuple[Any, ...], kwargs: dict[str, Any]) -> set[str]:
+    provided = set(kwargs)
+    positional_arg_count = len(args)
+    positional_index = 0
+    for name, param in signature.parameters.items():
+        if param.kind in (inspect.Parameter.POSITIONAL_ONLY, inspect.Parameter.POSITIONAL_OR_KEYWORD):
+            if positional_index >= positional_arg_count:
+                break
+            provided.add(name)
+            positional_index += 1
+        elif param.kind == inspect.Parameter.VAR_POSITIONAL:
+            break
+    return provided
+
+
+def _first_autotune_config(configs: Any) -> Mapping[str, Any] | None:
+    if isinstance(configs, Mapping):
+        return configs
+    if isinstance(configs, (list, tuple)) and configs:
+        first_config = configs[0]
+        if isinstance(first_config, Mapping):
+            return first_config
+    return None
 
 
 @dataclass
@@ -1277,10 +1302,19 @@ class AutoTuneImpl(Generic[_P, _T]):
 
         mode = self.jit_impl.initialize_jit_mode(*args, **kwargs)
         autotuner = self.get_tunner()
-        # Defer scalar-input validation to run(), after we know whether
-        # tuning will actually execute or be skipped because all tunable
-        # parameters are already provided by the caller.
-        autotuner._prim_func_for_validation = self.jit_impl.get_tir(*args, **kwargs)
+        validation_kwargs = dict(kwargs)
+        provided = _provided_jit_parameter_names(self.jit_impl.signature, args, kwargs)
+        first_config = _first_autotune_config(self.configs)
+        if first_config is not None:
+            for name in self.jit_impl.signature.parameters:
+                if name in first_config and name not in provided:
+                    validation_kwargs[name] = first_config[name]
+        try:
+            autotuner._prim_func_for_validation = self.jit_impl.get_tir(*args, **validation_kwargs)
+        except TypeError as exc:
+            if "missing a required argument" not in str(exc):
+                raise
+            logger.debug("Skipping autotune input validation TIR generation: %s", exc)
 
         # Compute the cache key, excluding do_not_specialize parameters
         # so that changing them does not trigger re-autotuning.

--- a/tilelang/contrib/cutedsl/atomic.py
+++ b/tilelang/contrib/cutedsl/atomic.py
@@ -15,6 +15,7 @@ __all__ = [
     "AtomicMinRet",
     "AtomicLoad",
     "AtomicStore",
+    "tl_atomic_add_offset",
 ]
 
 import cutlass
@@ -157,6 +158,11 @@ def AtomicAddRet(ptr: cute.Pointer, value: Numeric, *, loc=None, ip=None):
     This is the same as AtomicAdd since nvvm.atomicrmw always returns old value.
     """
     return AtomicAdd(ptr, value, loc=loc, ip=ip)
+
+
+def tl_atomic_add_offset(base: cute.Pointer, offset, value: Numeric, *, loc=None, ip=None):
+    """TileLang call_extern helper: atomicAdd(base + offset, value)."""
+    return AtomicAdd(base + offset, value, loc=loc, ip=ip)
 
 
 # =============================================================================

--- a/tilelang/contrib/cutedsl/math.py
+++ b/tilelang/contrib/cutedsl/math.py
@@ -7,10 +7,16 @@ __all__ = [
     "log1p",
     "log2",
     "log10",
+    "floor",
+    "floorf",
     "tan",
     "cos",
     "sin",
+    "erf",
+    "erff",
     "sqrt",
+    "hexp",
+    "hsqrt",
     "rsqrt",
     "fabsf",
     "max2",
@@ -113,6 +119,13 @@ def log10(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Uni
     return _tl_math_op(math.log10, fastmath, x, **kwargs)
 
 
+def floor(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
+    return _tl_math_op(math.floor, fastmath, x, **kwargs)
+
+
+floorf = floor
+
+
 def tan(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
     return _tl_math_op(math.tan, fastmath, x, **kwargs)
 
@@ -125,12 +138,21 @@ def sin(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union
     return _tl_math_op(math.sin, fastmath, x, **kwargs)
 
 
+def erf(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
+    return _tl_math_op(math.erf, fastmath, x, **kwargs)
+
+
 def sqrt(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
     return _tl_math_op(math.sqrt, fastmath, x, **kwargs)
 
 
 def rsqrt(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
     return _tl_math_op(math.rsqrt, fastmath, x, **kwargs)
+
+
+erff = erf
+hexp = exp
+hsqrt = sqrt
 
 
 def exp10(x: Union[TensorSSA, Numeric], fastmath: bool = False) -> Union[TensorSSA, Numeric]:


### PR DESCRIPTION
## Summary

This PR fixes TileLang-side regressions found while validating TileOps on H100 with the CuTeDSL backend. The active fork branch is `jayce/h100-cutedsl-tileops-regressions`.

The stack is split into five reviewable commits, each scoped to one root cause.

## Commit Stack

1. `4da9fc6` - **Preserve effectful scalar binds**
   - Root cause: `IfStmtBinding` and `LetInline` could replay scalar binds whose value contains a side-effecting extern call.
   - Failure mode: fused MoE could print/evaluate a source-level `slot = tl_atomic_add_offset(...)` expression more than once instead of reusing the bound value.
   - Fix: only treat scalar binds as replayable when `SideEffect(value) <= kReadState`; effectful binds stay in SSA form.

2. `1897268` - **Repair CuTeDSL backend lowering gaps**
   - Adds CuTeDSL math/runtime surface for generated TileOps code: `floor/floorf`, `erf/erff`, `hexp`, `hsqrt`, and `tl_atomic_add_offset`.
   - Restricts scalar fastmath division to scalar codegen so vector div does not emit an invalid `fastmath=True` TensorSSA form.
   - Scalarizes local/rmem vector load/store lanes instead of constructing invalid local pointer tensor views.
   - Emits dynamic `wgmma` `scale_out` through literal `0/1` branches because CuTeDSL expects literal scale operands.

3. `89362ea` - **Order warp-specialized producer prefix binds before use**
   - Root cause: mixed TMA + SIMT producer loops could classify scalar prefix binds as producer-local dependencies but emit SIMT/cp.async producers before those definitions.
   - Failure mode: guards such as `tile_full` were used before definition and `SplitHostDevice` rejected the IR.
   - Fix: move only read-state-safe prefix statements immediately after producer back-pressure wait and before SIMT/cp.async producers.
   - Review hardening: prefix `BindNode`s whose values have side effects beyond `kReadState` are not moved, so extern/atomic calls are not executed earlier than in the source IR.

4. `2b5c47c` - **Use the first autotune config for validation TIR**
   - Root cause: validation TIR generation ran before autotune config values were merged.
   - Failure mode: config-backed compile-time parameters could be missing; a naive config backfill could also duplicate parameters already supplied positionally, e.g. `block_DK`.
   - Fix: extract the first config only from supported mapping/list/tuple shapes, then skip config keys whose parameters are already provided by `*args` or explicit kwargs.

5. `86976ac` - **Handle CuTeDSL local FP8 vector stores**
   - Root cause: CuTeDSL lowers FP8 vector casts as packed i8 vectors. Re-reading `_cast.load()[i]` while scalarizing a local FP8 vector store forces MLIR to reinterpret `vector<4xi8>` as `vector<4xf8E4M3FN>`, which fails LLVM translation.
   - Failure mode: the CuTeDSL cast examples for per-token FP8 quantization failed with `builtin.unrealized_conversion_cast` during LLVM translation.
   - Fix: copy local FP8 vector stores through `Uint8` recast views so the packed byte representation is preserved without FP8 vector lane extraction.

## Why This Belongs In TileLang

The failures were observed through TileOps on H100, but the fixes are TileLang invariants:

- scalar-bind transforms must not replay side-effecting extern calls,
- CuTeDSL codegen should cover legal TileLang math/runtime calls emitted by kernels,
- producer/consumer warp-specialized IR must define producer-local scalar dependencies before all producer uses,
- autotune validation should use config defaults without duplicating caller-provided arguments,
- CuTeDSL local FP8 vector stores should preserve packed-byte storage and avoid unsupported FP8 vector lane extraction.

The producer/consumer ordering fix is not CuTeDSL-specific; the same transform feeds CUDA C lowering.

## Review Notes

Review comments from earlier iterations are addressed in this stack:

- `producer_consumer_ws.cc`: the bind-move selection checks `SideEffect(bind->value) > kReadState` and refuses to move effectful prefix binds.
- `tuner.py`: validation config extraction no longer assumes `self.configs[0]`; it supports mapping configs and list/tuple configs, and ignores unsupported/callable shapes on this pre-validation path.
- `tuner.py`: config backfill skips parameters already provided by positional args or explicit kwargs, fixing duplicate-value failures such as `block_DK`.

## Validation

Current branch:

- `pre-commit run --all-files`

Local H100 validation during the same fix cycle:

- `cmake --build build -j 16`
- TileLang targeted regressions:
  - `testing/python/transform/test_tilelang_transform_if_stmt_binding.py`
  - `testing/python/transform/test_tilelang_transform_let_inline.py`
  - `testing/python/transform/test_tilelang_transform_producer_consumer_ws.py::test_tiled_ws_places_prefix_binds_before_simt_producer_use`
  - `testing/python/target/test_tilelang_codegen_cutedsl_integer_shift.py`
  - `testing/python/autotune/test_tilelang_autotune.py::test_autotune_validation_config_skips_positional_args`
  - `testing/python/autotune/test_tilelang_autotune.py::test_first_autotune_config_accepts_mapping_and_sequence_shapes`
- CI repros fixed locally:
  - `examples/gdn/test_example_gdn_compilation.py::test_example_chunk_delta_h_compilation`
  - `examples/cast/test_example_cast.py::test_example_per_token_cast_to_fp8`
  - `examples/cast/test_example_cast.py::test_example_group_per_split_token_cast_to_fp8`
- Related local run: `testing/python/target/test_tilelang_codegen_cutedsl_integer_shift.py examples/cast/test_example_cast.py` passed.
- TileOps H100 CuTeDSL fused MoE coverage:
  - `tests/ops/test_moe_permute_nopad.py` passed
  - `tests/kernels/test_moe_grouped_gemm_3wg_fused_act.py` passed
- TileOps H100 packaging subsets:
  - CuTeDSL backend: `30 passed, 3245 deselected`
  - CUDA C backend: `30 passed, 3245 deselected`
- TileOps H100 CuTeDSL full functional run is in progress; final failure summary will be added after it completes.

Co-authored-by: dingsg <shengge.ding@enflame-tech.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added math operators: `floor`, `floorf`, `erf`, `erff`, `hexp`, and `hsqrt`.
  * Added atomic operation helper: `tl_atomic_add_offset`.
  * Improved CuTeDSL code generation for fastmath operations, division handling, and FP8 vector stores.
  * Enhanced autotuner validation to skip already-provided JIT parameters.

* **Bug Fixes**
  * Fixed side-effect handling in binding operations to prevent incorrect inlining.
  * Corrected statement ordering in warp-specialized producer/consumer code generation.

* **Tests**
  * Added comprehensive test coverage for new math operators, atomic operations, and code generation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->