### PR TITLE
fix(gemm_sm100): fix intermittent hang in pipelined CLC scheduler GEMM

### DIFF
--- a/examples/gemm_sm100/gemm_tcgen5mma_ws_clc.py
+++ b/examples/gemm_sm100/gemm_tcgen5mma_ws_clc.py
@@ -224,6 +224,10 @@ def gemm_clc_persistent_2cta_pipelined_clc(
         clc_result = T.alloc_shared((clc_stages, 4), "uint32", scope="shared")
         schedule_valid = T.alloc_shared((clc_stages,), "int32")
         schedule_tile_id = T.alloc_shared((clc_stages,), "int32")
+        # Reading the schedule into thread local registers before arriving schedule_finished,
+        # so the pipelined scheduler can't overwrite the slot mid-read (causing intermittent hang).
+        local_valid = T.alloc_local((1,), "int32")
+        local_tile_id = T.alloc_local((1,), "int32")
 
         tx = T.get_thread_binding()
         cta_id = T.block_rank_in_cluster()
@@ -236,15 +240,17 @@ def gemm_clc_persistent_2cta_pipelined_clc(
 
                 if work_iter > 0:
                     T.mbarrier_wait_parity(schedule_arrived[s_cons], c_cons & 1)
+                    local_valid[0] = schedule_valid[s_cons]
+                    local_tile_id[0] = schedule_tile_id[s_cons]
                     if tx == 0:
                         T.mbarrier_arrive(schedule_finished[s_cons], 0)
-                    if schedule_valid[s_cons] == 0:
+                    if local_valid[0] == 0:
                         break
 
                 tile_id = T.if_then_else(
                     work_iter == 0,
                     block_id // 2,
-                    schedule_tile_id[s_cons],
+                    local_tile_id[0],
                 )
                 bx, by = get_swizzled_block_idx(tile_id, group_size, m_clusters, cta_id)
 
@@ -270,9 +276,10 @@ def gemm_clc_persistent_2cta_pipelined_clc(
 
                 if work_iter > 0:
                     T.mbarrier_wait_parity(schedule_arrived[s_cons], c_cons & 1)
+                    local_valid[0] = schedule_valid[s_cons]
                     if tx == 32:
                         T.mbarrier_arrive(schedule_finished[s_cons], 0)
-                    if schedule_valid[s_cons] == 0:
+                    if local_valid[0] == 0:
                         break
 
                 T.mbarrier_wait_parity(tmem_empty[work_iter & 1], ((work_iter // 2) & 1) ^ 1)
@@ -324,15 +331,17 @@ def gemm_clc_persistent_2cta_pipelined_clc(
 
                 if work_iter > 0:
                     T.mbarrier_wait_parity(schedule_arrived[s_cons], c_cons & 1)
+                    local_valid[0] = schedule_valid[s_cons]
+                    local_tile_id[0] = schedule_tile_id[s_cons]
                     if tx == 128:
                         T.mbarrier_arrive(schedule_finished[s_cons], 0)
-                    if schedule_valid[s_cons] == 0:
+                    if local_valid[0] == 0:
                         break
 
                 tile_id = T.if_then_else(
                     work_iter == 0,
                     block_id // 2,
-                    schedule_tile_id[s_cons],
+                    local_tile_id[0],
                 )
                 bx, by = get_swizzled_block_idx(tile_id, group_size, m_clusters, cta_id)
 
@@ -362,6 +371,12 @@ def ref_program(A, B):
 
 
 if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--stress", type=int, default=0)
+    args = parser.parse_args()
+
     block_M, block_N, store_block_N, block_K = 128, 256, 64, 64
     num_stages, group_size = 6, 8
     base_args = (block_M, block_N, store_block_N, block_K, T.bfloat16, T.bfloat16, T.float, num_stages)
@@ -382,6 +397,9 @@ if __name__ == "__main__":
         for clc in (2, 3, 4):
             c2 = gemm_clc_persistent_2cta_pipelined_clc(a, b, *base_args, clc, group_size)
             torch.testing.assert_close(c2, ref, rtol=1e-2, atol=1e-2)
+            for _ in range(args.stress):
+                gemm_clc_persistent_2cta_pipelined_clc(a, b, *base_args, clc, group_size)
+                torch.cuda.synchronize()
             ms_pipe = do_bench(
                 lambda a=a, b=b, clc=clc: gemm_clc_persistent_2cta_pipelined_clc(a, b, *base_args, clc, group_size), backend="event"
             )


### PR DESCRIPTION
Fixes #2410

## Problem

`gemm_clc_persistent_2cta_pipelined_clc` intermittently hangs under repeated execution / benchmarking (e.g. 8192^3 with many reps and a sync between each). The hang is timing-dependent and does not reproduce on every run.

## Cause

A cross-warp read/write race on the CLC schedule slots, exposed by pipelining.

In each consumer warp (TMA, MMA, epilogue) the order was:

```python
T.mbarrier_wait_parity(schedule_arrived[s_cons], c_cons & 1)
if tx == ...:
    T.mbarrier_arrive(schedule_finished[s_cons], 0)   # signals "slot free"
if schedule_valid[s_cons] == 0:                       # ...but reads slot AFTER
    break
tile_id = ... schedule_tile_id[s_cons] ...            # ...and reads slot AFTER
```

The consumer arrives schedule_finished before reading schedule_valid / schedule_tile_id. That arrival is exactly what unblocks the CLC scheduler warp to reuse (overwrite) the same slot. With clc_stages > 1 the scheduler runs
ahead and its next try_cancel is already in flight, so the overwrite can land between the consumer's arrive and its read. Different consumer warps then read different schedule_valid for the same slot -> some break, some don't -> mismatched barrier arrival counts ->  deadlock.

The non-pipelined variant has the same ordering but survives because the unhidden try_cancel latency leaves a large gap between the arrive and the overwrite. Pipelining exists precisely to hide that latency, which collapses the protective gap and exposes the race -> hence the intermittency.

## Fix

Each consumer warp now captures schedule_valid / schedule_tile_id into thread-local registers immediately after the wait, and only then arrives schedule_finished. The break check and tile_id are taken from the registers, so the slot is fully read before it can be reused. No barrier counts or pipelining structure change; the latency-hiding benefit of clc_stages is
preserved.

## Verification

- Correctness: torch.testing.assert_close passes for clc=2,3,4 at 4096³ / 8192³ / 16384³.
- Stress: survives 200 relaunch+sync reps per (shape, clc) (--stress 200).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--stress` command-line argument to enable repeated stress testing iterations on GEMM operations with synchronized CUDA execution between runs.

* **Refactor**
  * Optimized scheduler status handling in GEMM pipeline execution for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->