### PR TITLE
Fix SM100 CLC GEMM schedule-state lifetime

### DIFF
--- a/examples/gemm_sm100/gemm_tcgen5mma_ws_clc.py
+++ b/examples/gemm_sm100/gemm_tcgen5mma_ws_clc.py
@@ -52,7 +52,8 @@ def gemm_clc_persistent_2cta(
         tmem_full = T.alloc_cluster_barrier([1] * 2)
         tmem_empty = T.alloc_cluster_barrier([128 * 2] * 2)
         schedule_arrived = T.alloc_cluster_barrier([1])
-        schedule_finished = T.alloc_cluster_barrier([7])
+        schedule_finished = T.alloc_cluster_barrier([13])
+        schedule_published = T.alloc_barrier([1])
         clc_result = T.alloc_shared((4,), "uint32", scope="shared")
         schedule_valid = T.alloc_shared((1,), "int32")
         schedule_tile_id = T.alloc_shared((1,), "int32")
@@ -63,18 +64,14 @@ def gemm_clc_persistent_2cta(
 
         if tx < 32:
             for work_iter in T.unroll(total_cluster_tiles):
+                tile_id = T.alloc_var(T.int32, init=block_id // 2)
                 if work_iter > 0:
-                    T.mbarrier_wait_parity(schedule_arrived, (work_iter - 1) & 1)
-                    if tx == 0:
-                        T.mbarrier_arrive(schedule_finished, 0)
+                    T.mbarrier_wait_parity(schedule_published, (work_iter - 1) & 1)
                     if schedule_valid[0] == 0:
                         break
-
-                tile_id = T.if_then_else(
-                    work_iter == 0,
-                    block_id // 2,
-                    schedule_tile_id[0],
-                )
+                    tile_id = schedule_tile_id[0]
+                    if tx == 0:
+                        T.mbarrier_arrive(schedule_finished, 0)
                 bx, by = get_swizzled_block_idx(tile_id, group_size, m_clusters, cta_id)
 
                 for k in T.serial(k_blocks):
@@ -95,11 +92,11 @@ def gemm_clc_persistent_2cta(
         elif cta_id == 0 and tx < 64:
             for work_iter in T.unroll(total_cluster_tiles):
                 if work_iter > 0:
-                    T.mbarrier_wait_parity(schedule_arrived, (work_iter - 1) & 1)
-                    if tx == 32:
-                        T.mbarrier_arrive(schedule_finished, 0)
+                    T.mbarrier_wait_parity(schedule_published, (work_iter - 1) & 1)
                     if schedule_valid[0] == 0:
                         break
+                    if tx == 32:
+                        T.mbarrier_arrive(schedule_finished, 0)
 
                 T.mbarrier_wait_parity(tmem_empty[work_iter & 1], ((work_iter // 2) & 1) ^ 1)
                 for k in T.serial(k_blocks):
@@ -136,24 +133,21 @@ def gemm_clc_persistent_2cta(
                     T.mbarrier_wait_parity(schedule_arrived, work_iter & 1)
                     schedule_valid[0] = T.clc_is_canceled(clc_result)
                     schedule_tile_id[0] = T.cast(T.clc_get_first_ctaid_x(clc_result), "int32") // 2
+                    T.mbarrier_arrive(schedule_published)
                     T.mbarrier_arrive(schedule_finished, 0)
                     if schedule_valid[0] == 0:
                         break
 
         elif 128 <= tx < 256:
             for work_iter in T.unroll(total_cluster_tiles):
+                tile_id = T.alloc_var(T.int32, init=block_id // 2)
                 if work_iter > 0:
-                    T.mbarrier_wait_parity(schedule_arrived, (work_iter - 1) & 1)
-                    if tx == 128:
-                        T.mbarrier_arrive(schedule_finished, 0)
+                    T.mbarrier_wait_parity(schedule_published, (work_iter - 1) & 1)
                     if schedule_valid[0] == 0:
                         break
-
-                tile_id = T.if_then_else(
-                    work_iter == 0,
-                    block_id // 2,
-                    schedule_tile_id[0],
-                )
+                    tile_id = schedule_tile_id[0]
+                    if tx % 32 == 0:
+                        T.mbarrier_arrive(schedule_finished, 0)
                 bx, by = get_swizzled_block_idx(tile_id, group_size, m_clusters, cta_id)
 
                 T.mbarrier_wait_parity(tmem_full[work_iter & 1], (work_iter // 2) & 1)
@@ -220,7 +214,8 @@ def gemm_clc_persistent_2cta_pipelined_clc(
         tmem_empty = T.alloc_cluster_barrier([128 * 2] * 2)
 
         schedule_arrived = T.alloc_cluster_barrier([1] * clc_stages)
-        schedule_finished = T.alloc_cluster_barrier([5] * clc_stages)
+        schedule_finished = T.alloc_cluster_barrier([11] * clc_stages)
+        schedule_published = T.alloc_barrier([1] * clc_stages)
         clc_result = T.alloc_shared((clc_stages, 4), "uint32", scope="shared")
         schedule_valid = T.alloc_shared((clc_stages,), "int32")
         schedule_tile_id = T.alloc_shared((clc_stages,), "int32")
@@ -233,19 +228,15 @@ def gemm_clc_persistent_2cta_pipelined_clc(
             for work_iter in T.unroll(total_cluster_tiles):
                 s_cons = (work_iter - 1) % clc_stages
                 c_cons = (work_iter - 1) // clc_stages
+                tile_id = T.alloc_var(T.int32, init=block_id // 2)
 
                 if work_iter > 0:
-                    T.mbarrier_wait_parity(schedule_arrived[s_cons], c_cons & 1)
-                    if tx == 0:
-                        T.mbarrier_arrive(schedule_finished[s_cons], 0)
+                    T.mbarrier_wait_parity(schedule_published[s_cons], c_cons & 1)
                     if schedule_valid[s_cons] == 0:
                         break
-
-                tile_id = T.if_then_else(
-                    work_iter == 0,
-                    block_id // 2,
-                    schedule_tile_id[s_cons],
-                )
+                    tile_id = schedule_tile_id[s_cons]
+                    if tx == 0:
+                        T.mbarrier_arrive(schedule_finished[s_cons], 0)
                 bx, by = get_swizzled_block_idx(tile_id, group_size, m_clusters, cta_id)
 
                 for k in T.serial(k_blocks):
@@ -269,11 +260,11 @@ def gemm_clc_persistent_2cta_pipelined_clc(
                 c_cons = (work_iter - 1) // clc_stages
 
                 if work_iter > 0:
-                    T.mbarrier_wait_parity(schedule_arrived[s_cons], c_cons & 1)
-                    if tx == 32:
-                        T.mbarrier_arrive(schedule_finished[s_cons], 0)
+                    T.mbarrier_wait_parity(schedule_published[s_cons], c_cons & 1)
                     if schedule_valid[s_cons] == 0:
                         break
+                    if tx == 32:
+                        T.mbarrier_arrive(schedule_finished[s_cons], 0)
 
                 T.mbarrier_wait_parity(tmem_empty[work_iter & 1], ((work_iter // 2) & 1) ^ 1)
                 for k in T.serial(k_blocks):
@@ -314,6 +305,7 @@ def gemm_clc_persistent_2cta_pipelined_clc(
                     T.mbarrier_wait_parity(schedule_arrived[s_clc], c_clc & 1)
                     schedule_valid[s_clc] = T.clc_is_canceled(clc_result[s_clc, :])
                     schedule_tile_id[s_clc] = T.cast(T.clc_get_first_ctaid_x(clc_result[s_clc, :]), "int32") // 2
+                    T.mbarrier_arrive(schedule_published[s_clc])
                     if schedule_valid[s_clc] == 0:
                         break
 
@@ -321,19 +313,15 @@ def gemm_clc_persistent_2cta_pipelined_clc(
             for work_iter in T.unroll(total_cluster_tiles):
                 s_cons = (work_iter - 1) % clc_stages
                 c_cons = (work_iter - 1) // clc_stages
+                tile_id = T.alloc_var(T.int32, init=block_id // 2)
 
                 if work_iter > 0:
-                    T.mbarrier_wait_parity(schedule_arrived[s_cons], c_cons & 1)
-                    if tx == 128:
-                        T.mbarrier_arrive(schedule_finished[s_cons], 0)
+                    T.mbarrier_wait_parity(schedule_published[s_cons], c_cons & 1)
                     if schedule_valid[s_cons] == 0:
                         break
-
-                tile_id = T.if_then_else(
-                    work_iter == 0,
-                    block_id // 2,
-                    schedule_tile_id[s_cons],
-                )
+                    tile_id = schedule_tile_id[s_cons]
+                    if tx % 32 == 0:
+                        T.mbarrier_arrive(schedule_finished[s_cons], 0)
                 bx, by = get_swizzled_block_idx(tile_id, group_size, m_clusters, cta_id)
 
                 T.mbarrier_wait_parity(tmem_full[work_iter & 1], (work_iter // 2) & 1)


### PR DESCRIPTION
Fixes #2410.

## Root cause

`gemm_tcgen5mma_ws_clc.py` stores each CLC scheduler result in shared `schedule_valid` / `schedule_tile_id` slots. The scheduler can reuse a stage after `schedule_finished` completes, so every warp that reads that shared schedule state must read it before releasing the stage.

The previous code released the stage too early:

- consumers could arrive `schedule_finished` before reading `schedule_valid` / `schedule_tile_id`;
- the store path under-counted consumers: each CTA has four store warps that read the schedule state, but only one store warp leader participated in `schedule_finished`.

That made the scheduler able to overwrite a schedule slot while later consumer warps were still reading the previous entry, which explains the intermittent hangs under repeated execution.

## Fix

- Add `schedule_published` so consumers wait until the scheduler has written the shared schedule state.
- Make consumers read/check `schedule_valid` before arriving `schedule_finished`.
- Count all store warp leaders in `schedule_finished`.
- Use `13` arrivals for the base kernel and `11` for the pipelined kernel.

The patch is intentionally limited to `examples/gemm_sm100/gemm_tcgen5mma_ws_clc.py`.

## Validation

Built from a clean local `build/` directory:

```bash
cmake -S . -B build \
  -DPython_EXECUTABLE=/home/vitalyr/dev/ai/tilelang/.venv/bin/python \
  -DPython3_EXECUTABLE=/home/vitalyr/dev/ai/tilelang/.venv/bin/python
cmake --build build -j"$(nproc)"
```

Static checks:

```bash
.venv/bin/python -m py_compile examples/gemm_sm100/gemm_tcgen5mma_ws_clc.py
git diff --check origin/main..HEAD
```

Repeated exact-example validation on this PR branch:

```bash
cd /home/vitalyr/dev/ai/tilelang

root=/home/vitalyr/dev/ai/tilelang/tmp/pr2410_pr_branch_5x50
cache="$root/cache"
rm -rf "$root"
mkdir -p "$root"

for round in $(seq 1 5); do
  logs="$root/logs_${round}"
  mkdir -p "$logs"
  for i in $(seq -w 1 50); do
    timeout_s=60
    if [ "$round" = "1" ] && [ "$i" = "01" ]; then
      timeout_s=600
    fi

    PYTHONUNBUFFERED=1 \
    TILELANG_CACHE_DIR="$cache" \
    timeout "$timeout_s" \
    .venv/bin/python examples/gemm_sm100/gemm_tcgen5mma_ws_clc.py \
      > "$logs/run_${i}.stdout.log" \
      2> "$logs/run_${i}.stderr.log"

    rc=$?
    if [ "$rc" -ne 0 ]; then
      tail -80 "$logs/run_${i}.stdout.log"
      tail -120 "$logs/run_${i}.stderr.log"
      exit "$rc"
    fi
  done
done
```

Result: all 5 rounds x 50 runs passed. Each round had 50 stdout logs, 50 stderr logs, and zero non-empty stderr logs.

## Important validation note

This bug is not covered by simply collecting or importing the example. The validating path is the `if __name__ == "__main__"` flow in `examples/gemm_sm100/gemm_tcgen5mma_ws_clc.py`, and the failure appears under repeated subprocess execution. Please actually run this example, preferably repeatedly as above, when validating the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized GEMM persistent kernel synchronization and scheduling mechanisms to improve performance and efficiency in matrix multiplication operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->