### PR TITLE
fix: remove abandoned TILELANG_CLEAR_CACHE env var and dead clear_cache()

### DIFF
--- a/tilelang/__init__.py
+++ b/tilelang/__init__.py
@@ -185,7 +185,6 @@ if not env.is_light_import():
 
     from .jit import jit, JITKernel, compile, par_compile  # noqa: F401
     from .profiler import Profiler  # noqa: F401
-    from .cache import clear_cache  # noqa: F401
     from .utils import (
         TensorSupplyType,  # noqa: F401
         deprecated,  # noqa: F401

--- a/tilelang/cache/__init__.py
+++ b/tilelang/cache/__init__.py
@@ -90,22 +90,3 @@ def cached(
         pass_configs=pass_configs,
         compile_flags=compile_flags,
     )
-
-
-def clear_cache():
-    """
-    Disabled helper that previously removed the entire kernel cache.
-
-    Raises:
-        RuntimeError: Always raised to warn users to clear the cache manually.
-    """
-    cache_dir = env.TILELANG_CACHE_DIR
-    raise RuntimeError(
-        "tilelang.clear_cache() is disabled because deleting the cache directory "
-        "is dangerous. If you accept the risk, remove it manually with "
-        f"`rm -rf '{cache_dir}'`."
-    )
-
-
-if env.TILELANG_CLEAR_CACHE.lower() in ("1", "true", "yes", "on"):
-    clear_cache()

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -322,7 +322,6 @@ class Environment:
     TILELANG_DISABLE_CACHE = EnvVar(
         "TILELANG_DISABLE_CACHE", "0"
     )  # disable kernel cache, usually for unit testing / debugging, high priority
-    TILELANG_CLEAR_CACHE = EnvVar("TILELANG_CLEAR_CACHE", "0")  # DEPRECATED! clear cache automatically if set
     TILELANG_CLEANUP_TEMP_FILES = EnvVar(
         "TILELANG_CLEANUP_TEMP_FILES", "1"
     )  # cleanup temporary compiler files/dirs after compilation (set to 0 to keep for debugging)


### PR DESCRIPTION
## Summary

Remove the abandoned `TILELANG_CLEAR_CACHE` environment variable and its associated dead code.

## Problem

`TILELANG_CLEAR_CACHE` was marked as `DEPRECATED` in `tilelang/env.py`, but the code path it triggered was still active: setting `TILELANG_CLEAR_CACHE=1` would call `clear_cache()` at import time, which **unconditionally raised `RuntimeError`**, causing `import tilelang` to crash.

```
RuntimeError: tilelang.clear_cache() is disabled because deleting the cache directory is dangerous. If you accept the risk, remove it manually with \`rm -rf '~/.tilelang/cache'\`.
```

The env var had no usage in docs, tests, scripts, or CI — it was purely a trap.

## Changes

| File | Change |
|------|--------|
| `tilelang/env.py` | Remove `TILELANG_CLEAR_CACHE = EnvVar(...)` definition |
| `tilelang/cache/__init__.py` | Remove `clear_cache()` function and the import-time `TILELANG_CLEAR_CACHE` check |
| `tilelang/__init__.py` | Remove `from .cache import clear_cache` public export |

- The internal `KernelCache.clear_cache()` method is **preserved** (it is a legitimate internal cache-clearing implementation, unrelated to this dead code).

## Verification

- `import tilelang` works normally
- `TILELANG_CLEAR_CACHE=1 python -c "import tilelang"` no longer crashes
- `hasattr(tilelang, 'clear_cache')` returns `False` (broken public API removed)

Closes #2413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed deprecated cache clearing functionality and associated environment variable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->