### PR TITLE
[Docs][Dev] Add C++ style guide

### DIFF
--- a/.agents/skills/tilelang-cpp-style/SKILL.md
+++ b/.agents/skills/tilelang-cpp-style/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: tilelang-cpp-style
+description: Use when editing, reviewing, or documenting TileLang C++ code style, including naming conventions, clang-format choices, headers, TVM ObjectRef/ObjectNode style, FFI-visible fields, and incremental style cleanup plans.
+---
+
+# TileLang C++ Style
+
+Use this skill when C++ style decisions matter in TileLang. For broad policy
+changes, review the full guide in `docs/developer_guide/cpp_style.md`.
+
+## Baseline
+
+TileLang C++ should be readable to TVM contributors. Follow TVM/Google C++ style
+unless a TileLang runtime template, generated kernel, backend shim, or external
+API adapter has a concrete reason to match another convention.
+
+Do not apply broad style churn to `3rdparty/` or generated/template code unless
+the task explicitly targets those files.
+
+## Naming Checklist
+
+- File names: `lower_snake_case`.
+- Types, classes, structs, ObjectRefs, ObjectNodes: `PascalCase`.
+- Object nodes: `PascalCaseNode`; ObjectRefs: `PascalCase`.
+- Functions and methods: `PascalCase`.
+- Boolean helpers: `Is`/`Has`/`Can` + `PascalCase`.
+- Parameters and local variables: `lower_snake_case`.
+- Private/protected members: `lower_snake_case_`.
+- Constants and enum values: `kPascalCase`.
+- Macros: `UPPER_SNAKE_CASE`.
+
+Prefer new C++ APIs like:
+
+```cpp
+Layout MakeLinearLayout(Array<PrimExpr> shape);
+bool IsSharedBuffer(const Buffer& buffer);
+Stmt Lower(const LowerArgs& args, arith::Analyzer* analyzer) const;
+```
+
+Avoid adding new lowerCamelCase helpers or ambiguous context names like
+`const LowerArgs& T`.
+
+## TVM Object Conventions
+
+Treat `Stmt`, `PrimExpr`, `Buffer`, `Var`, `SBlock`, `Layout`, and related types
+as TVM `ObjectRef` handles. Use handles across function boundaries and for
+stored state.
+
+Keep raw `*Node` pointers local to visitor callbacks, pattern checks, and
+`CopyOnWrite()` mutation sites. Convert callback nodes with `GetRef<T>(op)` if
+the value must be passed elsewhere or retained.
+
+Use `.same_as(other)` for identity comparisons between handles. Use TVM
+structural equality utilities for structural comparisons. Avoid `.get() ==
+other.get()` outside narrow adapter code.
+
+For identity maps/sets keyed by handles, use TVM pointer hash/equality helpers:
+
+```cpp
+using BufferSet = std::unordered_set<Buffer, ObjectPtrHash, ObjectPtrEqual>;
+using VarMap = std::unordered_map<Var, PrimExpr, ObjectPtrHash, ObjectPtrEqual>;
+```
+
+## ObjectNode Fields
+
+For TVM-style `ObjectNode` classes, public reflected fields should use
+`lower_snake_case` without a trailing underscore. Use trailing underscores for
+private/protected implementation state.
+
+Before renaming reflected fields, check whether the field name is FFI-visible or
+used by Python/debugging surfaces. Do not break compatibility without an
+explicit migration plan.
+
+## Headers And Includes
+
+- Avoid `using namespace` in headers.
+- Prefer explicit qualifications or narrow aliases in the smallest useful scope.
+- Include the headers that define the types used by the file.
+- Keep implementation-only helpers in `.cc` files or anonymous namespaces.
+- Group includes as paired header, standard library, TVM/third-party, then local
+  TileLang headers.
+
+## Migration Policy
+
+Style convergence should be incremental:
+
+- New C++ code should follow the style guide.
+- Touched code should avoid adding new inconsistencies.
+- Mechanical renames should be small and isolated.
+- Do not mix broad formatting changes with behavior changes.
+- Keep `.clang-format` changes in a focused PR.
+
+Validate style/documentation edits with:
+
+```bash
+python3 -m pre_commit run --files <changed-file>...
+```

--- a/docs/developer_guide/cpp_style.md
+++ b/docs/developer_guide/cpp_style.md
@@ -1,0 +1,268 @@
+# C++ Style Guide
+
+TileLang C++ code should be easy to read for contributors who already know TVM.
+Use TVM's C++ conventions as the baseline, with small TileLang-specific rules
+where the compiler, runtime, or generated kernel templates need them.
+
+This guide applies to C++ source under `src/` and TileLang-owned headers. Do not
+apply broad style-only churn to vendored code under `3rdparty/` or generated
+runtime templates unless a local change already needs to touch that code.
+
+## Formatting
+
+Run the repository formatter before sending a pull request:
+
+```bash
+bash format.sh --files <changed-file>...
+```
+
+For all changed files relative to the merge base:
+
+```bash
+bash format.sh
+```
+
+Formatting is mechanical. Keep style changes separate from behavior changes when
+the diff would otherwise become noisy.
+
+TileLang aims to stay close to TVM's Google-based C++ formatting. If the
+repository `.clang-format` is changed, do it in a focused pull request and avoid
+mixing that change with semantic edits.
+
+## Naming
+
+Use the following names in new C++ code.
+
+| Entity | Style | Example |
+| --- | --- | --- |
+| File names | `lower_snake_case` | `lower_tile_op.cc`, `layout_reducer.h` |
+| Namespaces | `lower_snake_case` | `tvm`, `tl`, `tirx` |
+| Types, classes, structs | `PascalCase` | `LayoutNode`, `TileOperator`, `LowerArgs` |
+| Object nodes | `PascalCaseNode` | `GemmNode`, `FragmentNode` |
+| Object refs | `PascalCase` | `Gemm`, `Fragment`, `Layout` |
+| Functions and methods | `PascalCase` | `MakeLinearLayout`, `InferLayout`, `GetAccessRegions` |
+| Boolean functions | `Is`/`Has`/`Can` + `PascalCase` | `IsFragmentBuffer`, `HasTmaBarrier` |
+| Parameters and locals | `lower_snake_case` | `layout_map`, `thread_bounds`, `buffer_remap` |
+| Private/protected members | `lower_snake_case_` | `layout_remap_`, `analyzer_` |
+| Constants and enum values | `kPascalCase` | `kWarpSize`, `kAccessRead` |
+| Macros | `UPPER_SNAKE_CASE` | `TVM_REGISTER_GLOBAL`, `TIR_REGISTER_TL_TILE_OP` |
+
+Prefer:
+
+```cpp
+Layout MakeLinearLayout(Array<PrimExpr> shape);
+bool IsSharedBuffer(const Buffer& buffer);
+
+Stmt Lower(const LowerArgs& args, arith::Analyzer* analyzer) const;
+LayoutMap InferLayout(const LayoutInferArgs& args, InferLevel level) const;
+```
+
+Avoid adding new names like:
+
+```cpp
+Layout makeLinearLayout(Array<PrimExpr> shape);
+bool isSharedBuffer(const Buffer& buffer);
+Stmt Lower(const LowerArgs& T, arith::Analyzer* analyzer) const;
+```
+
+Existing lowerCamelCase names can be migrated when related code is touched. Do
+not rename large areas solely to satisfy this guide unless the change is scoped
+and easy to review.
+
+## TVM Object And FFI Types
+
+TileLang C++ code uses TVM object handles heavily. Treat `Stmt`, `PrimExpr`,
+`Buffer`, `Var`, `SBlock`, `Layout`, and similar types as `ObjectRef` handles.
+Treat `StmtNode`, `BufferNode`, `VarNode`, and other `*Node` types as raw node
+views used mainly for visitor callbacks and local inspection.
+
+Use handle types across function boundaries:
+
+```cpp
+Optional<For> FindPipelineLoop(const Stmt& stmt);
+Map<Buffer, Layout> InferBufferLayouts(const SBlock& block);
+```
+
+Keep raw node pointers local to visitor callbacks, pattern checks, and
+`CopyOnWrite()` mutation sites:
+
+```cpp
+Stmt VisitStmt_(const ForNode* op) final {
+  For loop = GetRef<For>(op);
+  Optional<For> pipeline_loop = FindPipelineLoop(loop->body);
+  if (pipeline_loop.defined() && pipeline_loop.value().same_as(loop)) {
+    ...
+  }
+  return StmtMutator::VisitStmt_(op);
+}
+```
+
+For identity comparisons between handles, use `.same_as(other)`. For structural
+comparisons, use TVM structural equality utilities such as `StructuralEqual`.
+Do not use `handle.get() == other.get()` outside narrow adapter code.
+
+For unordered identity maps or sets keyed by TVM handles, use TVM pointer hash
+and equality helpers:
+
+```cpp
+using BufferSet = std::unordered_set<Buffer, ObjectPtrHash, ObjectPtrEqual>;
+using VarMap = std::unordered_map<Var, PrimExpr, ObjectPtrHash, ObjectPtrEqual>;
+```
+
+Use `Optional<T>` for nullable TVM handle values. Avoid storing `const *Node`
+pointers as nullable state.
+
+## ObjectNode Fields
+
+For TVM-style `ObjectNode` classes, public reflected fields should use
+`lower_snake_case` without a trailing underscore:
+
+```cpp
+class CopyNode : public TileOperatorNode {
+ public:
+  Buffer src;
+  Buffer dst;
+  Array<Range> ranges;
+
+  static void RegisterReflection() {
+    namespace refl = reflection;
+    refl::ObjectDef<CopyNode>()
+        .def_ro("src", &CopyNode::src)
+        .def_ro("dst", &CopyNode::dst)
+        .def_ro("ranges", &CopyNode::ranges);
+  }
+};
+```
+
+Use trailing underscores for private or protected implementation state:
+
+```cpp
+class LayoutRemapRewriter : public arith::IRMutatorWithAnalyzer {
+ private:
+  Map<Buffer, Layout> layout_remap_;
+};
+```
+
+Be careful when renaming reflected fields. FFI-visible field names are part of
+the Python/debugging surface, so compatibility should be considered before
+changing them.
+
+## Function Parameters
+
+Use descriptive parameter names:
+
+```cpp
+Stmt Lower(const LowerArgs& args, arith::Analyzer* analyzer) const;
+LayoutMap InferLayout(const LayoutInferArgs& args, InferLevel level) const;
+```
+
+Avoid `T` as a parameter name for lowering context. In TileLang code, `T` is
+already associated with the Python DSL namespace, and in C++ it is commonly used
+as a template type parameter.
+
+Pass non-trivial inputs by `const&` unless the function intentionally consumes
+the value. Take a value when the function will store it and move from it:
+
+```cpp
+explicit DeviceRegionAnnotator(Target device_target)
+    : device_target_(std::move(device_target)) {}
+```
+
+## Headers
+
+Keep headers narrow and predictable.
+
+- Avoid `using namespace` in headers.
+- Prefer explicit qualifications or narrow aliases in the smallest namespace
+  where they are needed.
+- Include the headers that define the types used by the file.
+- Keep implementation-only helpers in `.cc` files or anonymous namespaces.
+- Keep public macros rare and name them with a TileLang or TVM prefix.
+
+Prefer:
+
+```cpp
+namespace tvm {
+namespace tl {
+
+using LayoutMap = ffi::Map<tirx::Buffer, Layout>;
+
+}  // namespace tl
+}  // namespace tvm
+```
+
+Avoid:
+
+```cpp
+using namespace tirx;
+using namespace ffi;
+```
+
+## Comments And Documentation
+
+Use Doxygen comments for public APIs, public classes, and non-obvious fields.
+Use short line comments for local implementation notes only when they explain
+why the code exists or why a constraint matters.
+
+Good comments describe invariants:
+
+```cpp
+// The barrier buffer is allocated lazily because only TMA paths require it.
+Optional<Buffer> mbarrier_buffer;
+```
+
+Avoid comments that restate the code:
+
+```cpp
+// Set the target.
+args.target = target;
+```
+
+## Error Handling
+
+Use TVM-style checks and fatal errors for compiler invariants:
+
+```cpp
+ICHECK(layout.defined()) << "Expected layout for buffer " << buffer;
+LOG(FATAL) << "Unsupported copy instruction: " << instruction;
+```
+
+Make error messages actionable. Include the operation, relevant buffer or
+layout, and the unsupported condition where possible.
+
+Use user-facing validation errors where the problem can be caused by a TileLang
+program rather than an internal invariant. Keep internal invariant failures
+distinguishable from frontend validation failures.
+
+## Includes
+
+Group includes consistently:
+
+1. The paired header for a `.cc` file, when one exists.
+2. C and C++ standard library headers.
+3. TVM and other third-party headers.
+4. TileLang local headers.
+
+Keep include order stable within each group and let the formatter handle
+spacing. Avoid adding transitive includes just because another header currently
+pulls in the type.
+
+## Exceptions
+
+Generated kernel templates, CUDA/HIP runtime shims, and external API adapters
+may need to match the naming of CUDA, HIP, Metal, C APIs, or generated source.
+In those files, prefer consistency with the external interface over forced
+renaming.
+
+Do not reformat or rename vendored files under `3rdparty/` as part of TileLang
+style cleanup.
+
+## Migration Policy
+
+Style convergence should be incremental.
+
+- New C++ code should follow this guide.
+- Code touched for functional work should avoid adding new inconsistencies.
+- Mechanical renames should be small, focused, and easy to review.
+- Avoid combining broad formatting changes with behavior changes.
+- Preserve FFI-visible names unless a compatibility plan is documented.

--- a/docs/index.md
+++ b/docs/index.md
@@ -62,6 +62,13 @@ compiler_internals/tensor_checks
 
 :::{toctree}
 :maxdepth: 1
+:caption: DEVELOPER GUIDE
+
+developer_guide/cpp_style
+:::
+
+:::{toctree}
+:maxdepth: 1
 :caption: API Reference
 
 autoapi/tilelang/index


### PR DESCRIPTION
## Summary

- Add a developer-facing C++ style guide that documents TileLang's intended naming, formatting, header, and TVM object conventions.
- Add a local reusable style skill so future C++ edits and reviews can apply the same guidance consistently.

## Changes

- Document C++ naming rules, ObjectRef/ObjectNode usage, FFI-visible field guidance, header/include expectations, error handling, and incremental migration policy.
- Add the C++ style guide to the documentation navigation under Developer Guide.
- Add `.agents/skills/tilelang-cpp-style` as a concise companion reference for future repository work.

## Validation

- `./format.sh`
- `make html`

## Notes

- The docs build succeeds with existing generated AutoAPI warnings.
- Related to #2429.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive C++ style guide to developer documentation, covering formatting, naming conventions, handle/pointer usage patterns, reflected field requirements, and incremental migration policies.
  * Integrated new style guide into documentation index for improved discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->