### PR TITLE
[C++][Style] Normalize API context argument names

### DIFF
--- a/docs/developer_guide/cpp_style.md
+++ b/docs/developer_guide/cpp_style.md
@@ -306,6 +306,23 @@ Keep include order stable within each group and let the formatter handle
 spacing. Avoid adding transitive includes just because another header currently
 pulls in the type.
 
+## Audit Tool
+
+Use the C++ API style audit script to find cleanup candidates before starting a
+focused naming or header-boundary cleanup:
+
+```bash
+python3 maint/scripts/audit_cpp_api_style.py
+```
+
+The script is intentionally advisory. It reports candidates such as non-Pascal
+API names, ambiguous `T` parameters, public ObjectNode fields that need
+compatibility review, and broad namespace imports in headers. Review each
+finding before changing code, because FFI-visible names, overrides, generated
+interfaces, and backend/runtime shims may need exceptions. By default the audit
+excludes generated templates and runtime shim directories; use the script flags
+to include those areas when a cleanup explicitly targets them.
+
 ## Exceptions
 
 Generated kernel templates, CUDA/HIP runtime shims, and external API adapters

--- a/maint/scripts/audit_cpp_api_style.py
+++ b/maint/scripts/audit_cpp_api_style.py
@@ -1,0 +1,538 @@
+"""Audit TileLang C++ headers for API style cleanup candidates.
+
+This script intentionally reports heuristics instead of enforcing a lint gate.
+Use it to find review targets, then decide manually whether a finding is safe to
+rename, FFI-visible, or worth allowlisting.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections import Counter
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+HEADER_SUFFIXES = {".h", ".hh", ".hpp", ".cuh"}
+SOURCE_SUFFIXES = {".cc", ".cpp", ".cxx", ".cu"}
+DEFAULT_EXCLUDED_PARTS = {
+    "3rdparty",
+    "build",
+    "dist",
+    ".git",
+    ".ruff_cache",
+    ".pytest_cache",
+    "__pycache__",
+}
+DEFAULT_EXCLUDED_TEMPLATE_PREFIXES = (Path("src/tl_templates"),)
+DEFAULT_EXCLUDED_SHIM_PREFIXES = (
+    Path("src/cuda/stubs"),
+    Path("src/rocm/stubs"),
+)
+DEFAULT_EXCLUDED_VENDOR_PREFIXES = (
+    Path("src/cuda/stubs/vendor"),
+    Path("src/rocm/stubs/vendor"),
+)
+
+RULES = {
+    "TLCPP001": "function name is not PascalCase",
+    "TLCPP002": "ambiguous API parameter name",
+    "TLCPP003": "public ObjectNode field needs compatibility review",
+    "TLCPP004": "broad namespace import in header",
+}
+
+CONTROL_KEYWORDS = {
+    "catch",
+    "for",
+    "if",
+    "return",
+    "sizeof",
+    "switch",
+    "while",
+}
+
+QUALIFIER_TOKENS = {
+    "const",
+    "constexpr",
+    "explicit",
+    "final",
+    "inline",
+    "mutable",
+    "noexcept",
+    "override",
+    "static",
+    "virtual",
+}
+
+
+@dataclass(order=True)
+class Finding:
+    path: str
+    line: int
+    rule: str
+    symbol: str
+    message: str
+    snippet: str
+
+
+@dataclass
+class ClassState:
+    name: str
+    brace_depth: int
+    access: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Report C++ API style cleanup candidates in TileLang-owned code.")
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=["src"],
+        help="Files or directories to audit. Defaults to src.",
+    )
+    parser.add_argument(
+        "--include-sources",
+        action="store_true",
+        help="Also scan .cc/.cpp/.cu files. By default only headers are scanned.",
+    )
+    parser.add_argument(
+        "--include-templates",
+        action="store_true",
+        help="Include src/tl_templates, which is excluded by default.",
+    )
+    parser.add_argument(
+        "--include-runtime-shims",
+        action="store_true",
+        help="Include runtime shim headers under src/cuda/stubs and src/rocm/stubs.",
+    )
+    parser.add_argument(
+        "--include-vendor",
+        action="store_true",
+        help="Include vendored shim headers under src/*/stubs/vendor.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit JSON instead of text.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Maximum findings to print. 0 means no limit.",
+    )
+    parser.add_argument(
+        "--fail-on-findings",
+        action="store_true",
+        help="Return exit code 1 when findings are present.",
+    )
+    return parser.parse_args()
+
+
+def normalize_path(path: Path) -> Path:
+    try:
+        return path.relative_to(Path.cwd())
+    except ValueError:
+        return path
+
+
+def is_excluded(path: Path, args: argparse.Namespace) -> bool:
+    rel = normalize_path(path)
+    if any(part in DEFAULT_EXCLUDED_PARTS for part in rel.parts):
+        return True
+    if not args.include_templates:
+        for prefix in DEFAULT_EXCLUDED_TEMPLATE_PREFIXES:
+            if rel.is_relative_to(prefix):
+                return True
+    if not args.include_runtime_shims:
+        for prefix in DEFAULT_EXCLUDED_SHIM_PREFIXES:
+            if rel.is_relative_to(prefix):
+                return True
+    if not args.include_vendor:
+        for prefix in DEFAULT_EXCLUDED_VENDOR_PREFIXES:
+            if rel.is_relative_to(prefix):
+                return True
+    return False
+
+
+def candidate_files(args: argparse.Namespace) -> list[Path]:
+    suffixes = set(HEADER_SUFFIXES)
+    if args.include_sources:
+        suffixes |= SOURCE_SUFFIXES
+
+    result: list[Path] = []
+    for raw_path in args.paths:
+        path = Path(raw_path)
+        if not path.exists():
+            print(f"warning: path does not exist: {raw_path}", file=sys.stderr)
+            continue
+        if path.is_file():
+            if path.suffix in suffixes and not is_excluded(path, args):
+                result.append(path)
+            continue
+        for child in path.rglob("*"):
+            if child.is_file() and child.suffix in suffixes and not is_excluded(child, args):
+                result.append(child)
+    return sorted(set(result))
+
+
+def strip_line_comment(line: str) -> str:
+    """Strip // comments while preserving URLs and simple string literals enough for auditing."""
+    in_string = False
+    escaped = False
+    for index in range(len(line) - 1):
+        char = line[index]
+        if char == "\\" and in_string and not escaped:
+            escaped = True
+            continue
+        if char == '"' and not escaped:
+            in_string = not in_string
+        escaped = False
+        if not in_string and line[index : index + 2] == "//":
+            return line[:index]
+    return line
+
+
+def strip_block_comments(text: str) -> str:
+    return re.sub(r"/\*.*?\*/", lambda match: "\n" * match.group(0).count("\n"), text, flags=re.S)
+
+
+def is_pascal_case(name: str) -> bool:
+    if not re.fullmatch(r"[A-Z][A-Za-z0-9]*", name):
+        return False
+    return "__" not in name
+
+
+def is_tvm_hook_name(name: str) -> bool:
+    return bool(re.fullmatch(r"[A-Z][A-Za-z0-9]*_", name))
+
+
+def split_parameters(params: str) -> list[str]:
+    result: list[str] = []
+    current: list[str] = []
+    depth = 0
+    for char in params:
+        if char in "(<[{":
+            depth += 1
+        elif char in ")>}]" and depth > 0:
+            depth -= 1
+        if char == "," and depth == 0:
+            result.append("".join(current).strip())
+            current = []
+        else:
+            current.append(char)
+    if current:
+        result.append("".join(current).strip())
+    return result
+
+
+def parameter_name(param: str) -> str | None:
+    param = re.sub(r"=.*$", "", param).strip()
+    if not param or param == "void":
+        return None
+    param = re.sub(r"\[[^\]]*\]", "", param).strip()
+    match = re.search(r"([A-Za-z_][A-Za-z0-9_]*)\s*$", param)
+    if not match:
+        return None
+    name = match.group(1)
+    if name in QUALIFIER_TOKENS:
+        return None
+    return name
+
+
+def function_statement_name(statement: str) -> tuple[str, str] | None:
+    compact = " ".join(statement.strip().split())
+    compact = re.sub(r"^template\s*<[^>]+>\s*", "", compact)
+    if not compact or compact.startswith("#"):
+        return None
+    first_token = compact.split(maxsplit=1)[0]
+    if first_token in CONTROL_KEYWORDS:
+        return None
+    if compact.startswith(("using ", "typedef ", "static_assert", "template ")):
+        return None
+    if compact.startswith(("TVM_", "ICHECK", "LOG(", "CHECK")):
+        return None
+    first_paren = compact.find("(")
+    if first_paren >= 0 and "=" in compact[:first_paren]:
+        return None
+    if "->" in compact and compact.find("->") < compact.find("("):
+        return None
+
+    match = re.search(
+        r"(?:^|[\s:*&<>,~])([A-Za-z_][A-Za-z0-9_:~]*)\s*\(([^;{}]*)\)\s*"
+        r"(?:const\b|noexcept\b|override\b|final\b|->|[;{=])",
+        compact,
+    )
+    if not match:
+        return None
+
+    qualified_name = match.group(1)
+    name = qualified_name.split("::")[-1]
+    if name in CONTROL_KEYWORDS or name == "operator" or name.startswith("operator"):
+        return None
+    if name.startswith("~"):
+        return None
+    return name, match.group(2)
+
+
+def statement_starting_at(lines: list[str], index: int) -> tuple[str, int]:
+    pieces: list[str] = []
+    depth = 0
+    end_index = index
+    for offset, line in enumerate(lines[index : min(index + 8, len(lines))]):
+        stripped = strip_line_comment(line).strip()
+        if not stripped:
+            continue
+        end_index = index + offset
+        pieces.append(stripped)
+        depth += stripped.count("(") - stripped.count(")")
+        if depth <= 0 and (";" in stripped or "{" in stripped):
+            break
+    return " ".join(pieces), end_index
+
+
+def audit_functions(path: Path, lines: list[str]) -> list[Finding]:
+    findings: list[Finding] = []
+    class_stack: list[ClassState] = []
+    brace_depth = 0
+    processed_until = -1
+    function_body_depth: int | None = None
+    function_body_pending_until = -1
+
+    for index, line in enumerate(lines):
+        stripped = strip_line_comment(line).strip()
+        if not stripped:
+            continue
+
+        if function_body_depth is not None:
+            brace_depth += stripped.count("{") - stripped.count("}")
+            if index > function_body_pending_until and brace_depth < function_body_depth:
+                function_body_depth = None
+                function_body_pending_until = -1
+            continue
+
+        class_match = re.search(r"\b(class|struct)\s+([A-Za-z_][A-Za-z0-9_]*)\b", stripped)
+        if class_match and "{" in stripped and not stripped.endswith(";"):
+            default_access = "public" if class_match.group(1) == "struct" else "private"
+            class_stack.append(ClassState(class_match.group(2), brace_depth, default_access))
+
+        if class_stack and re.fullmatch(r"(public|private|protected):", stripped):
+            class_stack[-1].access = stripped[:-1]
+            brace_depth += stripped.count("{") - stripped.count("}")
+            continue
+
+        in_direct_class_scope = bool(class_stack and brace_depth == class_stack[-1].brace_depth + 1)
+        in_declaration_context = not class_stack or in_direct_class_scope
+
+        if not in_declaration_context or index <= processed_until or stripped.startswith(("//", "#")):
+            brace_depth += stripped.count("{") - stripped.count("}")
+            while class_stack and brace_depth <= class_stack[-1].brace_depth:
+                class_stack.pop()
+            continue
+
+        statement, end_index = statement_starting_at(lines, index)
+        parsed = function_statement_name(statement)
+        if not parsed:
+            brace_depth += stripped.count("{") - stripped.count("}")
+            while class_stack and brace_depth <= class_stack[-1].brace_depth:
+                class_stack.pop()
+            continue
+        processed_until = end_index
+
+        name, params = parsed
+        if not is_pascal_case(name) and not is_tvm_hook_name(name) and "override" not in statement:
+            findings.append(
+                Finding(
+                    str(normalize_path(path)),
+                    index + 1,
+                    "TLCPP001",
+                    name,
+                    f"Function or method `{name}` does not follow PascalCase.",
+                    stripped,
+                )
+            )
+        for param in split_parameters(params):
+            if parameter_name(param) == "T":
+                findings.append(
+                    Finding(
+                        str(normalize_path(path)),
+                        index + 1,
+                        "TLCPP002",
+                        "T",
+                        "Parameter `T` is ambiguous in API declarations; prefer a descriptive snake_case name.",
+                        stripped,
+                    )
+                )
+
+        if statement.count("{") > statement.count("}"):
+            function_body_depth = brace_depth + 1
+            function_body_pending_until = end_index
+
+        brace_depth += stripped.count("{") - stripped.count("}")
+        while class_stack and brace_depth <= class_stack[-1].brace_depth:
+            class_stack.pop()
+    return findings
+
+
+def field_names_from_statement(statement: str) -> list[str]:
+    statement = re.sub(r"=.*?(?=,|;)", "", statement)
+    statement = statement.rstrip(";").strip()
+    if not statement:
+        return []
+    names: list[str] = []
+    for part in split_parameters(statement):
+        match = re.search(r"([A-Za-z_][A-Za-z0-9_]*)\s*$", part.strip())
+        if match:
+            name = match.group(1)
+            if name not in QUALIFIER_TOKENS:
+                names.append(name)
+    return names
+
+
+def is_field_statement(stripped: str) -> bool:
+    if not stripped.endswith(";"):
+        return False
+    if "(" in stripped or ")" in stripped:
+        return False
+    if stripped.startswith(
+        (
+            "class ",
+            "enum ",
+            "friend ",
+            "namespace ",
+            "struct ",
+            "template ",
+            "typedef ",
+            "using ",
+            "TVM_",
+        )
+    ):
+        return False
+    return not stripped.startswith("static constexpr ")
+
+
+def audit_object_node_fields(path: Path, lines: list[str]) -> list[Finding]:
+    findings: list[Finding] = []
+    class_stack: list[ClassState] = []
+    brace_depth = 0
+
+    for index, line in enumerate(lines):
+        stripped = strip_line_comment(line).strip()
+        class_match = re.search(r"\b(class|struct)\s+([A-Za-z_][A-Za-z0-9_]*Node)\b", stripped)
+        if class_match:
+            default_access = "public" if class_match.group(1) == "struct" else "private"
+            class_stack.append(ClassState(class_match.group(2), brace_depth, default_access))
+
+        if class_stack and re.fullmatch(r"(public|private|protected):", stripped):
+            class_stack[-1].access = stripped[:-1]
+
+        if class_stack and class_stack[-1].access == "public" and is_field_statement(stripped):
+            for name in field_names_from_statement(stripped):
+                reasons: list[str] = []
+                if name.endswith("_"):
+                    reasons.append("has a trailing underscore")
+                if re.search(r"[a-z][A-Za-z0-9]*[A-Z]", name):
+                    reasons.append("uses camelCase")
+                if name.startswith("_type_") or name.startswith("kTVMFFISEqHashKind"):
+                    reasons = []
+                if reasons:
+                    findings.append(
+                        Finding(
+                            str(normalize_path(path)),
+                            index + 1,
+                            "TLCPP003",
+                            name,
+                            (
+                                f"Public ObjectNode field `{name}` {' and '.join(reasons)}; "
+                                "check FFI/reflection compatibility before renaming."
+                            ),
+                            stripped,
+                        )
+                    )
+
+        brace_depth += stripped.count("{") - stripped.count("}")
+        while class_stack and brace_depth <= class_stack[-1].brace_depth:
+            class_stack.pop()
+
+    return findings
+
+
+def audit_namespace_imports(path: Path, lines: list[str]) -> list[Finding]:
+    findings: list[Finding] = []
+    for index, line in enumerate(lines):
+        stripped = strip_line_comment(line).strip()
+        match = re.fullmatch(r"using\s+namespace\s+([A-Za-z_][A-Za-z0-9_:]*);", stripped)
+        if not match:
+            continue
+        namespace = match.group(1)
+        findings.append(
+            Finding(
+                str(normalize_path(path)),
+                index + 1,
+                "TLCPP004",
+                namespace,
+                f"Header imports namespace `{namespace}` broadly; verify this is not a shared interface.",
+                stripped,
+            )
+        )
+    return findings
+
+
+def audit_file(path: Path) -> list[Finding]:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    text = strip_block_comments(text)
+    lines = text.splitlines()
+    findings: list[Finding] = []
+    findings.extend(audit_namespace_imports(path, lines))
+    findings.extend(audit_functions(path, lines))
+    findings.extend(audit_object_node_fields(path, lines))
+    return sorted(findings)
+
+
+def print_text(findings: list[Finding], file_count: int, limit: int) -> None:
+    shown = findings if limit <= 0 else findings[:limit]
+    print("C++ API style audit")
+    print(f"Scanned {file_count} file(s); found {len(findings)} candidate(s).")
+    if findings:
+        counts = Counter(finding.rule for finding in findings)
+        print("Findings by rule:")
+        for code in sorted(counts):
+            print(f"  {code}: {counts[code]}")
+        print("Rules:")
+        for code, description in RULES.items():
+            print(f"  {code}: {description}")
+        print()
+    for finding in shown:
+        print(f"{finding.path}:{finding.line}: {finding.rule}: {finding.message}")
+        print(f"  {finding.snippet}")
+    if limit > 0 and len(findings) > limit:
+        print(f"... omitted {len(findings) - limit} finding(s); rerun with --limit 0 to show all.")
+
+
+def main() -> int:
+    args = parse_args()
+    files = candidate_files(args)
+    findings: list[Finding] = []
+    for path in files:
+        findings.extend(audit_file(path))
+    findings.sort()
+
+    if args.json:
+        payload = {
+            "file_count": len(files),
+            "finding_count": len(findings),
+            "rules": RULES,
+            "findings": [asdict(finding) for finding in findings],
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print_text(findings, len(files), args.limit)
+
+    return 1 if args.fail_on_findings and findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/backend/common/op/atomic_reduce.h
+++ b/src/backend/common/op/atomic_reduce.h
@@ -139,11 +139,13 @@ inline For MakeSIMTLoop(const AtomicOpBaseNode &op, arith::Analyzer *analyzer) {
 }
 
 inline LayoutMap InferSIMTLayout(const AtomicOpBaseNode &op,
-                                 const LayoutInferArgs &T, InferLevel) {
+                                 const LayoutInferArgs &layout_args,
+                                 InferLevel) {
   if (IsFragmentBuffer(op.src) && IsFragmentBuffer(op.dst)) {
-    if (T.layout_map.count(op.src) && T.layout_map.count(op.dst)) {
-      Layout src_layout = T.layout_map.at(op.src);
-      Layout dst_layout = T.layout_map.at(op.dst);
+    if (layout_args.layout_map.count(op.src) &&
+        layout_args.layout_map.count(op.dst)) {
+      Layout src_layout = layout_args.layout_map.at(op.src);
+      Layout dst_layout = layout_args.layout_map.at(op.dst);
       ICHECK(StructuralEqual()(src_layout, dst_layout))
           << "Atomic reduce requires src and dst to have the same layout, but "
              "got "
@@ -159,11 +161,12 @@ inline LayoutMap InferSIMTLayout(const AtomicOpBaseNode &op,
 
 struct AtomicReduce {
   static LayoutMap InferLayout(const AtomicOpBaseNode &op,
-                               const LayoutInferArgs &T, InferLevel level) {
-    return atomic_reduce::InferSIMTLayout(op, T, level);
+                               const LayoutInferArgs &layout_args,
+                               InferLevel level) {
+    return atomic_reduce::InferSIMTLayout(op, layout_args, level);
   }
 
-  static Stmt Lower(const AtomicOpBaseNode &op, const LowerArgs &T,
+  static Stmt Lower(const AtomicOpBaseNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer) {
     auto simt_loop = atomic_reduce::MakeSIMTLoop(op, analyzer);
     auto fused_loop = Downcast<For>(ParallelLoopFuser::Fuse(simt_loop));
@@ -171,18 +174,19 @@ struct AtomicReduce {
     std::vector<InferLevel> levels = {InferLevel::kCommon, InferLevel::kStrict,
                                       InferLevel::kFree};
     for (auto level : levels) {
-      par_op->InferLayout({T.target,
-                           T.thread_bounds,
-                           T.layout_map,
+      par_op->InferLayout({lower_args.target,
+                           lower_args.thread_bounds,
+                           lower_args.layout_map,
                            analyzer,
                            false,
-                           T.buffer_remap,
+                           lower_args.buffer_remap,
                            {}},
                           level);
     }
     auto loop_layout = par_op->GetLoopLayout();
-    return LowerParallelLoop(fused_loop, loop_layout, T.thread_var, analyzer,
-                             T.layout_map, par_op->GetPredicate(T.thread_var),
+    return LowerParallelLoop(fused_loop, loop_layout, lower_args.thread_var,
+                             analyzer, lower_args.layout_map,
+                             par_op->GetPredicate(lower_args.thread_var),
                              /*parallel_loop=*/true, /*should_vectorize=*/true,
                              par_op->LoopLayoutRequiresPaddingGuard());
   }

--- a/src/backend/common/op/fill.h
+++ b/src/backend/common/op/fill.h
@@ -20,25 +20,26 @@ namespace backend {
 using namespace tirx;
 
 struct Fill {
-  static Stmt Lower(const FillNode &op, const LowerArgs &T,
+  static Stmt Lower(const FillNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer) {
     if (IsFragmentBuffer(op.dst)) {
       auto par_op = ParallelOp(op.MakeSIMTLoop(analyzer));
-      par_op->InferLayout({T.target,
-                           T.thread_bounds,
-                           T.layout_map,
+      par_op->InferLayout({lower_args.target,
+                           lower_args.thread_bounds,
+                           lower_args.layout_map,
                            analyzer,
                            false,
-                           T.buffer_remap,
+                           lower_args.buffer_remap,
                            {}},
                           InferLevel::kFree);
-      auto thread_loop = PartitionLoop(par_op->GetRoot(), T.thread_var,
+      auto thread_loop = PartitionLoop(par_op->GetRoot(), lower_args.thread_var,
                                        analyzer, par_op->GetLoopLayout());
-      auto vectorized_loop = VectorizeLoop(thread_loop, analyzer, T.layout_map);
+      auto vectorized_loop =
+          VectorizeLoop(thread_loop, analyzer, lower_args.layout_map);
       auto unrolled_loop = PragmaUnrollLoop(vectorized_loop);
 
-      if (par_op->GetPredicate(T.thread_var).defined()) {
-        return IfThenElse(par_op->GetPredicate(T.thread_var).value(),
+      if (par_op->GetPredicate(lower_args.thread_var).defined()) {
+        return IfThenElse(par_op->GetPredicate(lower_args.thread_var).value(),
                           unrolled_loop);
       }
       return unrolled_loop;
@@ -46,26 +47,28 @@ struct Fill {
 
     if (IsLocalBuffer(op.dst) || IsLocalVarBuffer(op.dst)) {
       auto init_loop = op.MakeSIMTLoop(analyzer);
-      auto vectorized_loop = VectorizeLoop(init_loop, analyzer, T.layout_map);
+      auto vectorized_loop =
+          VectorizeLoop(init_loop, analyzer, lower_args.layout_map);
       return PragmaUnrollLoop(vectorized_loop);
     }
 
     if (IsSharedBuffer(op.dst) || IsGlobalBuffer(op.dst)) {
       auto par_op = ParallelOp(op.MakeSIMTLoop(analyzer));
-      par_op->InferLayout({T.target,
-                           T.thread_bounds,
-                           T.layout_map,
+      par_op->InferLayout({lower_args.target,
+                           lower_args.thread_bounds,
+                           lower_args.layout_map,
                            analyzer,
                            false,
-                           T.buffer_remap,
+                           lower_args.buffer_remap,
                            {}},
                           InferLevel::kFree);
-      auto thread_loop = PartitionLoop(par_op->GetRoot(), T.thread_var,
+      auto thread_loop = PartitionLoop(par_op->GetRoot(), lower_args.thread_var,
                                        analyzer, par_op->GetLoopLayout());
-      auto vectorized_loop = VectorizeLoop(thread_loop, analyzer, T.layout_map);
+      auto vectorized_loop =
+          VectorizeLoop(thread_loop, analyzer, lower_args.layout_map);
       auto unrolled_loop = PragmaUnrollLoop(vectorized_loop);
-      if (par_op->GetPredicate(T.thread_var).defined()) {
-        return IfThenElse(par_op->GetPredicate(T.thread_var).value(),
+      if (par_op->GetPredicate(lower_args.thread_var).defined()) {
+        return IfThenElse(par_op->GetPredicate(lower_args.thread_var).value(),
                           unrolled_loop);
       }
       return unrolled_loop;

--- a/src/backend/common/op/finalize_reducer.h
+++ b/src/backend/common/op/finalize_reducer.h
@@ -23,10 +23,10 @@ using namespace tirx;
 using namespace ffi;
 
 template <typename Impl> struct FinalizeReducerLowerer {
-  static Stmt Lower(const FinalizeReducerOpNode &op, const LowerArgs &T,
-                    arith::Analyzer *) {
-    auto buffer = T.buffer_remap[op.reducer];
-    auto opt_layout = T.layout_map.Get(op.reducer);
+  static Stmt Lower(const FinalizeReducerOpNode &op,
+                    const LowerArgs &lower_args, arith::Analyzer *) {
+    auto buffer = lower_args.buffer_remap[op.reducer];
+    auto opt_layout = lower_args.layout_map.Get(op.reducer);
     ICHECK(opt_layout);
     ICHECK(opt_layout->as<Fragment>());
     auto layout = opt_layout->as<Fragment>().value();
@@ -39,9 +39,10 @@ template <typename Impl> struct FinalizeReducerLowerer {
     const int64_t *p_extent = as_const_int(layout->ReplicateExtent());
     ICHECK(p_extent);
     int extent = *p_extent;
-    ICHECK(extent == 1 || extent == *as_const_int(T.thread_bounds->extent))
+    ICHECK(extent == 1 ||
+           extent == *as_const_int(lower_args.thread_bounds->extent))
         << "Illegal finalize_reducer: extent=" << extent
-        << "; T.thread_bounds=" << T.thread_bounds;
+        << "; T.thread_bounds=" << lower_args.thread_bounds;
 
     if (extent == 1) {
       return Evaluate(0);
@@ -51,7 +52,7 @@ template <typename Impl> struct FinalizeReducerLowerer {
     auto op_str = op_names[static_cast<int>(op.op)];
 
     int reducing_threads = extent;
-    auto thread_offset = T.thread_bounds->min;
+    auto thread_offset = lower_args.thread_bounds->min;
 
     int64_t layout_batch_size = 1;
     for (int i = 0; i < layout->OutputDim(); ++i) {
@@ -75,29 +76,30 @@ template <typename Impl> struct FinalizeReducerLowerer {
           << ")";
     }
 
-    bool use_batch =
-        effective_batch > 1 && reducing_threads > Impl::WarpSize(T.target);
+    bool use_batch = effective_batch > 1 &&
+                     reducing_threads > Impl::WarpSize(lower_args.target);
 
     if (use_batch) {
       int workspace_stride =
-          static_cast<int>(*as_const_int(T.thread_bounds->extent));
+          static_cast<int>(*as_const_int(lower_args.thread_bounds->extent));
       std::string allreduce = Impl::MakeBatchAllReduce(
-          op_str, reducing_threads, 1, thread_offset, T.thread_bounds->extent,
-          static_cast<int>(effective_batch), workspace_stride, T.target);
+          op_str, reducing_threads, 1, thread_offset,
+          lower_args.thread_bounds->extent, static_cast<int>(effective_batch),
+          workspace_stride, lower_args.target);
       int ws_size = workspace_stride * static_cast<int>(effective_batch);
-      PrimExpr workspace = T.add_workspace(ws_size, buffer->dtype);
+      PrimExpr workspace = lower_args.add_workspace(ws_size, buffer->dtype);
       Array<PrimExpr> args = {StringImm(allreduce), buffer->data, workspace};
       return Evaluate(Call(DataType::Handle(), builtin::call_extern(), args));
     }
 
-    std::string allreduce =
-        Impl::MakeScalarAllReduce(op_str, reducing_threads, 1, thread_offset,
-                                  T.thread_bounds->extent, T.target);
+    std::string allreduce = Impl::MakeScalarAllReduce(
+        op_str, reducing_threads, 1, thread_offset,
+        lower_args.thread_bounds->extent, lower_args.target);
     Array<PrimExpr> thread_reduce_args = {StringImm(allreduce),
                                           BufferLoad(buffer, indices_0)};
     if (reducing_threads >= 32) {
-      PrimExpr workspace = T.add_workspace(
-          *as_const_int(T.thread_bounds->extent), buffer->dtype);
+      PrimExpr workspace = lower_args.add_workspace(
+          *as_const_int(lower_args.thread_bounds->extent), buffer->dtype);
       thread_reduce_args.push_back(workspace);
     }
     auto call = Call(buffer->dtype, builtin::call_extern(), thread_reduce_args);

--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -297,19 +297,19 @@ inline PrimExpr MakeUpdate(const ReduceOpNode &op, PrimExpr dst_val,
 } // namespace reduce
 
 template <typename Impl> struct ReduceLowerer {
-  static Stmt Lower(const ReduceOpNode &op, const LowerArgs &T,
+  static Stmt Lower(const ReduceOpNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer) {
     if (op.nan_propagate &&
         (op.dst->dtype.is_float16() || op.dst->dtype.is_bfloat16()) &&
-        !Impl::SupportsFp16Bf16NanReduce(T.target)) {
+        !Impl::SupportsFp16Bf16NanReduce(lower_args.target)) {
       LOG(FATAL) << "ReduceOp: nan_propagate=True for fp16/bf16 "
                     "max/min/absmax is only supported on CUDA targets "
                     "(requires __hmax_nan/__hmin_nan intrinsics). Target was: "
-                 << T.target->str();
+                 << lower_args.target->str();
     }
     auto get_buffer = [&](const Buffer &buf) {
-      if (T.buffer_remap.count(buf)) {
-        return T.buffer_remap[buf];
+      if (lower_args.buffer_remap.count(buf)) {
+        return lower_args.buffer_remap[buf];
       }
       return buf;
     };
@@ -320,8 +320,8 @@ template <typename Impl> struct ReduceLowerer {
     if (src_scope == "local.fragment" && dst_scope == "local.fragment") {
       auto src_buffer = get_buffer(op.src);
       auto dst_buffer = get_buffer(op.dst);
-      auto src_layout = T.layout_map[op.src].as<Fragment>().value();
-      auto dst_layout = T.layout_map[op.dst].as<Fragment>().value();
+      auto src_layout = lower_args.layout_map[op.src].as<Fragment>().value();
+      auto dst_layout = lower_args.layout_map[op.dst].as<Fragment>().value();
       auto red_layout = reduce::ComputeReducerLayout(src_layout, op.dim);
       auto src_dim = src_layout->InputDim();
       auto dst_dim = dst_layout->InputDim();
@@ -414,8 +414,8 @@ template <typename Impl> struct ReduceLowerer {
       Buffer clear_buffer_packed;
       Buffer clear_batch_pack_buffer;
       {
-        int vsize =
-            Impl::GetPreferedVectorizedSize(clear_buffer->dtype, T.target);
+        int vsize = Impl::GetPreferedVectorizedSize(clear_buffer->dtype,
+                                                    lower_args.target);
         if (vsize > 1 && !src_var_compressed.empty()) {
           auto *ext = src_var_compressed.back()->dom->extent.as<IntImmNode>();
           if (ext && ext->value >= vsize && ext->value % vsize == 0 &&
@@ -545,8 +545,8 @@ template <typename Impl> struct ReduceLowerer {
           body = For(vars[i]->var, 0, vars[i]->dom->extent, ForKind::kParallel,
                      body);
         }
-        body = PartitionLoop(Downcast<For>(body), T.thread_var, analyzer,
-                             red_layout);
+        body = PartitionLoop(Downcast<For>(body), lower_args.thread_var,
+                             analyzer, red_layout);
         body = PragmaUnrollLoop(Downcast<For>(body));
         return body;
       };
@@ -589,10 +589,10 @@ template <typename Impl> struct ReduceLowerer {
           }
 
           int reducing_threads = (*extent) * (*scale);
-          auto thread_offset = T.thread_bounds->min;
+          auto thread_offset = lower_args.thread_bounds->min;
 
-          int vsize =
-              Impl::GetPreferedVectorizedSize(clear_buffer->dtype, T.target);
+          int vsize = Impl::GetPreferedVectorizedSize(clear_buffer->dtype,
+                                                      lower_args.target);
           bool can_batch_pack =
               vsize > 1 && batch >= vsize && batch % vsize == 0 &&
               reduce::MakeCodegenReducer(op, vsize).has_value();
@@ -602,7 +602,8 @@ template <typename Impl> struct ReduceLowerer {
                   .value();
           std::string allreduce = Impl::MakeBatchAllReduce(
               reducer, reducing_threads, *scale, thread_offset,
-              T.thread_bounds->extent, eff_batch, reducing_threads, T.target);
+              lower_args.thread_bounds->extent, eff_batch, reducing_threads,
+              lower_args.target);
 
           DataType ws_dtype = can_batch_pack
                                   ? clear_buffer->dtype.with_lanes(vsize)
@@ -611,7 +612,7 @@ template <typename Impl> struct ReduceLowerer {
           bool need_workspace = reducing_threads > 32;
           if (need_workspace) {
             int ws_size = reducing_threads * eff_batch;
-            workspace = T.add_workspace(ws_size, ws_dtype);
+            workspace = lower_args.add_workspace(ws_size, ws_dtype);
           }
 
           int64_t N_total = 1;
@@ -731,7 +732,7 @@ template <typename Impl> struct ReduceLowerer {
           PrimExpr predicate = Bool(true);
           {
             auto dst_th = post_dst_idx;
-            dst_th.push_back(T.thread_var);
+            dst_th.push_back(lower_args.thread_var);
             auto inv = dst_layout->Inverse()->Forward(dst_th);
             inv.pop_back();
             for (int i = 0; i < static_cast<int>(dst_layout->InputDim()); i++) {
@@ -782,17 +783,18 @@ template <typename Impl> struct ReduceLowerer {
           }
 
           int reducing_threads = (*extent) * (*scale);
-          auto thread_offset = T.thread_bounds->min;
+          auto thread_offset = lower_args.thread_bounds->min;
           std::string allreduce = Impl::MakeScalarAllReduce(
               reduce::MakeCodegenReducer(op).value(), reducing_threads, *scale,
-              thread_offset, T.thread_bounds->extent, T.target);
+              thread_offset, lower_args.thread_bounds->extent,
+              lower_args.target);
           Array<PrimExpr> thread_reduce_args = {
               StringImm(allreduce), BufferLoad(clear_buffer, red_indices)};
           if (reducing_threads > 32) {
-            int workspace_size =
-                static_cast<int>(*as_const_int(T.thread_bounds->extent));
+            int workspace_size = static_cast<int>(
+                *as_const_int(lower_args.thread_bounds->extent));
             PrimExpr workspace =
-                T.add_workspace(workspace_size, clear_buffer->dtype);
+                lower_args.add_workspace(workspace_size, clear_buffer->dtype);
             thread_reduce_args.push_back(workspace);
           }
           auto call = Call(clear_buffer->dtype, builtin::call_extern(),
@@ -804,7 +806,7 @@ template <typename Impl> struct ReduceLowerer {
       PrimExpr predicate = Bool(true);
       {
         auto dst_th_indices = dst_indices;
-        dst_th_indices.push_back(T.thread_var);
+        dst_th_indices.push_back(lower_args.thread_var);
         auto inv = dst_layout->Inverse()->Forward(dst_th_indices);
         inv.pop_back();
         for (int i = 0; i < static_cast<int>(dst_layout->InputDim()); i++) {
@@ -833,11 +835,11 @@ template <typename Impl> struct ReduceLowerer {
       }
 
       if (dst_layout->InputDim() > 0) {
-        body = PartitionLoop(Downcast<For>(body), T.thread_var, analyzer,
-                             red_layout);
+        body = PartitionLoop(Downcast<For>(body), lower_args.thread_var,
+                             analyzer, red_layout);
         body = PragmaUnrollLoop(Downcast<For>(body));
       } else {
-        auto guard = (T.thread_var == T.thread_bounds->min);
+        auto guard = (lower_args.thread_var == lower_args.thread_bounds->min);
         body = IfThenElse(guard, body);
       }
 

--- a/src/backend/common/op/scan.h
+++ b/src/backend/common/op/scan.h
@@ -26,7 +26,7 @@ using namespace ffi;
 namespace scan {
 
 template <typename ScanOpNode>
-Stmt LowerSharedScan(const ScanOpNode &op, const LowerArgs &T,
+Stmt LowerSharedScan(const ScanOpNode &op, const LowerArgs &lower_args,
                      const char *op_name, const char *pretty_name,
                      const char *symbol_prefix, const char *scan_noun) {
   if (IsFragmentBuffer(op.src) && IsFragmentBuffer(op.dst)) {
@@ -36,7 +36,7 @@ Stmt LowerSharedScan(const ScanOpNode &op, const LowerArgs &T,
   } else if (IsSharedBuffer(op.src)) {
     ICHECK(IsSharedBuffer(op.dst));
     std::stringstream ss;
-    auto threads = T.thread_bounds->extent;
+    auto threads = lower_args.thread_bounds->extent;
     Array<PrimExpr> args;
 
     PrimExpr src_ptr = MakeAccessPtrFromRegion(op.srcRegion_, 1);
@@ -73,14 +73,15 @@ Stmt LowerSharedScan(const ScanOpNode &op, const LowerArgs &T,
   return Stmt();
 }
 
-inline Stmt LowerCumSum(const CumSumOpNode &op, const LowerArgs &T,
+inline Stmt LowerCumSum(const CumSumOpNode &op, const LowerArgs &lower_args,
                         arith::Analyzer *) {
-  return LowerSharedScan(op, T, "cumsum", "CumSum", "CumSum", "Cumulative sum");
+  return LowerSharedScan(op, lower_args, "cumsum", "CumSum", "CumSum",
+                         "Cumulative sum");
 }
 
-inline Stmt LowerCumMax(const CumMaxOpNode &op, const LowerArgs &T,
+inline Stmt LowerCumMax(const CumMaxOpNode &op, const LowerArgs &lower_args,
                         arith::Analyzer *) {
-  return LowerSharedScan(op, T, "cummax", "CumMax", "CumMax",
+  return LowerSharedScan(op, lower_args, "cummax", "CumMax", "CumMax",
                          "Cumulative maximum");
 }
 

--- a/src/backend/common/op/transpose.h
+++ b/src/backend/common/op/transpose.h
@@ -25,35 +25,35 @@ namespace backend {
 using namespace tirx;
 
 struct Transpose {
-  static Stmt Lower(const TransposeNode &op, const LowerArgs &T,
+  static Stmt Lower(const TransposeNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer) {
-    bool is_cpu_target = T.target->GetTargetDeviceType() == kDLCPU;
+    bool is_cpu_target = lower_args.target->GetTargetDeviceType() == kDLCPU;
     auto simt_loop = op.MakeSIMTLoop(analyzer);
     auto fused_loop = Downcast<For>(ParallelLoopFuser::Fuse(simt_loop));
 
     if (is_cpu_target || IsLocalBuffer(op.src) || IsLocalBuffer(op.dst)) {
-      return VectorizeLoop(fused_loop, T.layout_map);
+      return VectorizeLoop(fused_loop, lower_args.layout_map);
     }
 
     auto par_op = ParallelOp(fused_loop);
     std::vector<InferLevel> levels = {InferLevel::kCommon, InferLevel::kStrict,
                                       InferLevel::kFree};
     for (auto level : levels) {
-      par_op->InferLayout({T.target,
-                           T.thread_bounds,
-                           T.layout_map,
+      par_op->InferLayout({lower_args.target,
+                           lower_args.thread_bounds,
+                           lower_args.layout_map,
                            analyzer,
                            false,
-                           T.buffer_remap,
+                           lower_args.buffer_remap,
                            {}},
                           level);
     }
     auto loop_layout = par_op->GetLoopLayout();
-    return LowerParallelLoop(par_op->GetRoot(), loop_layout, T.thread_var,
-                             analyzer, T.layout_map,
-                             par_op->GetPredicate(T.thread_var),
-                             /*parallel_loop=*/true, /*should_vectorize=*/true,
-                             par_op->LoopLayoutRequiresPaddingGuard());
+    return LowerParallelLoop(
+        par_op->GetRoot(), loop_layout, lower_args.thread_var, analyzer,
+        lower_args.layout_map, par_op->GetPredicate(lower_args.thread_var),
+        /*parallel_loop=*/true, /*should_vectorize=*/true,
+        par_op->LoopLayoutRequiresPaddingGuard());
   }
 };
 

--- a/src/cpu/op/copy.cc
+++ b/src/cpu/op/copy.cc
@@ -15,17 +15,18 @@ using namespace tirx;
 namespace cpu {
 
 struct Copy {
-  static LayoutMap InferLayout(const CopyNode &op, const LayoutInferArgs &T,
+  static LayoutMap InferLayout(const CopyNode &op,
+                               const LayoutInferArgs &layout_args,
                                InferLevel level) {
     (void)op;
-    (void)T;
+    (void)layout_args;
     (void)level;
     return {};
   }
 
-  static Stmt Lower(const CopyNode &op, const LowerArgs &T,
+  static Stmt Lower(const CopyNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer) {
-    return LowerNormalCopy(op, T, analyzer);
+    return LowerNormalCopy(op, lower_args, analyzer);
   }
 };
 

--- a/src/cpu/op/fill.cc
+++ b/src/cpu/op/fill.cc
@@ -17,11 +17,12 @@ namespace tl {
 namespace cpu {
 
 struct Fill {
-  static Stmt Lower(const FillNode &op, const LowerArgs &T,
+  static Stmt Lower(const FillNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer) {
     if (IsLocalBuffer(op.dst, true) || IsGlobalBuffer(op.dst)) {
       auto init_loop = op.MakeSIMTLoop(analyzer);
-      auto vectorized_loop = VectorizeLoop(init_loop, analyzer, T.layout_map);
+      auto vectorized_loop =
+          VectorizeLoop(init_loop, analyzer, lower_args.layout_map);
       return PragmaUnrollLoop(vectorized_loop);
     }
 

--- a/src/cpu/op/transpose.cc
+++ b/src/cpu/op/transpose.cc
@@ -18,7 +18,7 @@ namespace tl {
 namespace cpu {
 
 struct Transpose {
-  static Stmt Lower(const TransposeNode &op, const LowerArgs &T,
+  static Stmt Lower(const TransposeNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer) {
     if (!(IsLocalBuffer(op.src, true) || IsGlobalBuffer(op.src)) ||
         !(IsLocalBuffer(op.dst, true) || IsGlobalBuffer(op.dst))) {
@@ -28,7 +28,7 @@ struct Transpose {
     }
     auto simt_loop = op.MakeSIMTLoop(analyzer);
     auto fused_loop = Downcast<For>(ParallelLoopFuser::Fuse(simt_loop));
-    return VectorizeLoop(fused_loop, T.layout_map);
+    return VectorizeLoop(fused_loop, lower_args.layout_map);
   }
 };
 

--- a/src/cuda/op/atomic_add.cc
+++ b/src/cuda/op/atomic_add.cc
@@ -208,12 +208,13 @@ For MakeSIMTLoop(const AtomicAddNode &op, arith::Analyzer *analyzer) {
   return Downcast<For>(body);
 }
 
-LayoutMap InferSIMTLayout(const AtomicAddNode &op, const LayoutInferArgs &T,
-                          InferLevel) {
+LayoutMap InferSIMTLayout(const AtomicAddNode &op,
+                          const LayoutInferArgs &layout_args, InferLevel) {
   if (IsFragmentBuffer(op.src) && IsFragmentBuffer(op.dst)) {
-    if (T.layout_map.count(op.src) && T.layout_map.count(op.dst)) {
-      Layout src_layout = T.layout_map.at(op.src);
-      Layout dst_layout = T.layout_map.at(op.dst);
+    if (layout_args.layout_map.count(op.src) &&
+        layout_args.layout_map.count(op.dst)) {
+      Layout src_layout = layout_args.layout_map.at(op.src);
+      Layout dst_layout = layout_args.layout_map.at(op.dst);
       ICHECK(StructuralEqual()(src_layout, dst_layout))
           << "AtomicAdd requires src and dst to have the same layout, but got "
           << "src layout: " << src_layout << ", dst layout: " << dst_layout
@@ -227,7 +228,7 @@ LayoutMap InferSIMTLayout(const AtomicAddNode &op, const LayoutInferArgs &T,
 } // namespace
 
 struct AtomicAdd {
-  static Stmt LowerSIMT(const AtomicAddNode &op, const LowerArgs &T,
+  static Stmt LowerSIMT(const AtomicAddNode &op, const LowerArgs &lower_args,
                         arith::Analyzer *analyzer) {
     auto simt_loop = MakeSIMTLoop(op, analyzer);
     auto fused_loop = Downcast<For>(ParallelLoopFuser::Fuse(simt_loop));
@@ -235,26 +236,28 @@ struct AtomicAdd {
     std::vector<InferLevel> levels = {InferLevel::kCommon, InferLevel::kStrict,
                                       InferLevel::kFree};
     for (auto level : levels) {
-      par_op->InferLayout({T.target,
-                           T.thread_bounds,
-                           T.layout_map,
+      par_op->InferLayout({lower_args.target,
+                           lower_args.thread_bounds,
+                           lower_args.layout_map,
                            analyzer,
                            false,
-                           T.buffer_remap,
+                           lower_args.buffer_remap,
                            {}},
                           level);
     }
     auto loop_layout = par_op->GetLoopLayout();
-    return LowerParallelLoop(fused_loop, loop_layout, T.thread_var, analyzer,
-                             T.layout_map, par_op->GetPredicate(T.thread_var),
+    return LowerParallelLoop(fused_loop, loop_layout, lower_args.thread_var,
+                             analyzer, lower_args.layout_map,
+                             par_op->GetPredicate(lower_args.thread_var),
                              /*parallel_loop=*/true, /*should_vectorize=*/true,
                              par_op->LoopLayoutRequiresPaddingGuard());
   }
 
   static LayoutMap InferLayout(const AtomicAddNode &op,
-                               const LayoutInferArgs &T, InferLevel level) {
+                               const LayoutInferArgs &layout_args,
+                               InferLevel level) {
     if (!UseTMA(op)) {
-      return InferSIMTLayout(op, T, level);
+      return InferSIMTLayout(op, layout_args, level);
     }
 
     Map<Buffer, Layout> result_map;
@@ -265,7 +268,8 @@ struct AtomicAdd {
       return result_map;
     }
 
-    if (level == InferLevel::kFree && !T.layout_map.count(shared_tensor)) {
+    if (level == InferLevel::kFree &&
+        !layout_args.layout_map.count(shared_tensor)) {
       int dim = shared_tensor->shape.size();
       const int64_t mat_stride = *as_const_int(shared_tensor->shape[dim - 2]);
       const int64_t mat_continuous =
@@ -286,10 +290,10 @@ struct AtomicAdd {
     return result_map;
   }
 
-  static Stmt Lower(const AtomicAddNode &op, const LowerArgs &T,
+  static Stmt Lower(const AtomicAddNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer) {
     if (!UseTMA(op)) {
-      return LowerSIMT(op, T, analyzer);
+      return LowerSIMT(op, lower_args, analyzer);
     }
 
     // For AtomicAdd with TMA: src is shared memory, dst is global memory.
@@ -338,12 +342,12 @@ struct AtomicAdd {
     Buffer shared_tensor_unmapped = shared_tensor;
     desc.interleave = static_cast<int>(CU_TENSOR_MAP_INTERLEAVE_NONE);
     Layout shared_layout;
-    if (T.layout_map.count(shared_tensor)) {
-      shared_layout = T.layout_map.at(shared_tensor);
-      ICHECK(T.buffer_remap.count(shared_tensor))
+    if (lower_args.layout_map.count(shared_tensor)) {
+      shared_layout = lower_args.layout_map.at(shared_tensor);
+      ICHECK(lower_args.buffer_remap.count(shared_tensor))
           << "shared_tensor: " << shared_tensor->name
           << " not found in buffer_remap";
-      shared_tensor = T.buffer_remap.at(shared_tensor);
+      shared_tensor = lower_args.buffer_remap.at(shared_tensor);
     }
     if (!shared_layout.defined()) {
       desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_NONE);
@@ -492,7 +496,7 @@ struct AtomicAdd {
     seq.push_back(Evaluate(Call(DataType::Handle(), tma_store_arrive(), {})));
     seq.push_back(Evaluate(Call(DataType::Handle(), tma_store_wait(),
                                 {IntImm(DataType::Int(32), 0), Bool(true)})));
-    return IfThenElse(EQ(T.thread_var, T.thread_bounds->min),
+    return IfThenElse(EQ(lower_args.thread_var, lower_args.thread_bounds->min),
                       SeqStmt(std::move(seq)));
   }
 };

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -99,8 +99,8 @@ int64_t TMAElementsForBytes(int64_t bytes, DataType dtype) {
 }
 
 PrimExpr GetCopyMbarPhaseExpr(const Map<String, ObjectRef> &annotations,
-                              const LowerArgs &T) {
-  PrimExpr phase = T.mbar_phase_expr;
+                              const LowerArgs &lower_args) {
+  PrimExpr phase = lower_args.mbar_phase_expr;
   if (auto explicit_phase = GetAnnotatedMbarPhaseExpr(annotations)) {
     phase = explicit_phase.value();
   }
@@ -208,7 +208,8 @@ bool GetNoImplicitAsyncCommitWait(const CopyNode &op) {
   return GetBoolAnnotation(op, attr::kAsyncCopyNoImplicitCommitWait);
 }
 
-PrimExpr GetLeaderScopeThreads(const CopyNode &op, const LowerArgs &T) {
+PrimExpr GetLeaderScopeThreads(const CopyNode &op,
+                               const LowerArgs &lower_args) {
   if (auto val = op.annotations.Get("leader_scope_threads")) {
     auto int_val = val->as<IntImmNode>();
     ICHECK(int_val) << "T.tma_copy leader_scope_threads annotation must be an "
@@ -220,7 +221,7 @@ PrimExpr GetLeaderScopeThreads(const CopyNode &op, const LowerArgs &T) {
            "(32).";
     return IntImm(DataType::Int(32), int_val->value);
   }
-  return T.thread_bounds->extent;
+  return lower_args.thread_bounds->extent;
 }
 
 bool IsContiguousRegion(const Buffer &buf, const Array<Range> &ranges,
@@ -355,10 +356,10 @@ namespace cuda {
 // results, no fault). Report the requirement implied by the chosen
 // CU_TENSOR_MAP_SWIZZLE_* mode so MergeSharedMemoryAllocations can align the
 // buffer accordingly.
-static void RequireTMASmemAlignment(const LowerArgs &T,
+static void RequireTMASmemAlignment(const LowerArgs &lower_args,
                                     const Buffer &shared_tensor,
                                     int cu_tensor_map_swizzle) {
-  if (!T.require_smem_alignment)
+  if (!lower_args.require_smem_alignment)
     return;
   SwizzleMode mode = SwizzleMode::kNone;
   if (cu_tensor_map_swizzle == static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B)) {
@@ -370,7 +371,8 @@ static void RequireTMASmemAlignment(const LowerArgs &T,
              static_cast<int>(CU_TENSOR_MAP_SWIZZLE_128B)) {
     mode = SwizzleMode::kFull;
   }
-  T.require_smem_alignment(shared_tensor->data, SmemAlignmentForSwizzle(mode));
+  lower_args.require_smem_alignment(shared_tensor->data,
+                                    SmemAlignmentForSwizzle(mode));
 }
 
 struct TMAIm2ColDesc {
@@ -418,10 +420,11 @@ struct TMAIm2ColDesc {
 };
 
 struct Copy {
-  static LayoutMap InferLayout(const CopyNode &op, const LayoutInferArgs &T,
+  static LayoutMap InferLayout(const CopyNode &op,
+                               const LayoutInferArgs &layout_args,
                                InferLevel level);
 
-  static Stmt Lower(const CopyNode &op, const LowerArgs &T,
+  static Stmt Lower(const CopyNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer);
 
 private:
@@ -440,39 +443,41 @@ private:
 
   static void CheckParallelLoopLayout(const CopyNode &op, CopyInst copy_inst);
 
-  static LayoutMap InferTMemLayout(const CopyNode &op, const LayoutInferArgs &T,
+  static LayoutMap InferTMemLayout(const CopyNode &op,
+                                   const LayoutInferArgs &layout_args,
                                    CopyInst copy_inst);
 
-  static LayoutMap InferBulkLayout(const CopyNode &op, const LayoutInferArgs &T,
+  static LayoutMap InferBulkLayout(const CopyNode &op,
+                                   const LayoutInferArgs &layout_args,
                                    InferLevel level, CopyInst copy_inst);
 
-  static Stmt LowerNormal(const CopyNode &op, const LowerArgs &T,
+  static Stmt LowerNormal(const CopyNode &op, const LowerArgs &lower_args,
                           arith::Analyzer *analyzer);
 
-  static Stmt LowerCluster(const CopyNode &op, const LowerArgs &T,
+  static Stmt LowerCluster(const CopyNode &op, const LowerArgs &lower_args,
                            arith::Analyzer *analyzer);
 
-  static Stmt LowerCPAsync(const CopyNode &op, const LowerArgs &T,
+  static Stmt LowerCPAsync(const CopyNode &op, const LowerArgs &lower_args,
                            arith::Analyzer *analyzer);
 
-  static Stmt LowerLDSM(const CopyNode &op, const LowerArgs &T,
+  static Stmt LowerLDSM(const CopyNode &op, const LowerArgs &lower_args,
                         arith::Analyzer *analyzer, CopyInst copy_inst);
 
-  static Stmt LowerTmem(const CopyNode &op, const LowerArgs &T,
+  static Stmt LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
                         arith::Analyzer *analyzer);
 
-  static Stmt LowerBulk(const CopyNode &op, const LowerArgs &T,
+  static Stmt LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
                         arith::Analyzer *analyzer, CopyInst copy_inst);
 
-  static Stmt LowerBulkGather4(const CopyNode &op, const LowerArgs &T,
+  static Stmt LowerBulkGather4(const CopyNode &op, const LowerArgs &lower_args,
                                arith::Analyzer *analyzer, CopyInst copy_inst);
 
-  static Stmt LowerBulk1D(const CopyNode &op, const LowerArgs &T,
+  static Stmt LowerBulk1D(const CopyNode &op, const LowerArgs &lower_args,
                           arith::Analyzer *analyzer, CopyInst copy_inst);
 };
 
 struct Im2Col {
-  static Stmt Lower(const Im2ColOpNode &op, const LowerArgs &T,
+  static Stmt Lower(const Im2ColOpNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer);
 };
 
@@ -516,24 +521,26 @@ void Copy::CollectFragmentLayouts(const PrimExpr &expr,
   });
 }
 
-LayoutMap Copy::InferLayout(const CopyNode &op, const LayoutInferArgs &T,
+LayoutMap Copy::InferLayout(const CopyNode &op,
+                            const LayoutInferArgs &layout_args,
                             InferLevel level) {
   CopyInst copy_inst =
-      SelectInst(op, T.target, T.layout_map, T.analyzer, T.buffer_oob);
+      SelectInst(op, layout_args.target, layout_args.layout_map,
+                 layout_args.analyzer, layout_args.buffer_oob);
   CheckParallelLoopLayout(op, copy_inst);
 
   if (copy_inst == CopyInst::kTMemLoad || copy_inst == CopyInst::kTMemStore) {
-    return InferTMemLayout(op, T, copy_inst);
+    return InferTMemLayout(op, layout_args, copy_inst);
   }
   if (copy_inst == CopyInst::kBulkLoad || copy_inst == CopyInst::kBulkStore ||
       copy_inst == CopyInst::kBulkLoad1D ||
       copy_inst == CopyInst::kBulkStore1D) {
-    return InferBulkLayout(op, T, level, copy_inst);
+    return InferBulkLayout(op, layout_args, level, copy_inst);
   }
 
   // For normal/cp.async/LDSM/STSM, layout inference follows the generated
   // SIMT loop. CUDA-specific explicit layout cases are handled above.
-  return op.InferSIMTLayout(T, level);
+  return op.InferSIMTLayout(layout_args, level);
 }
 
 void Copy::CheckParallelLoopLayout(const CopyNode &op, CopyInst copy_inst) {
@@ -552,7 +559,8 @@ void Copy::CheckParallelLoopLayout(const CopyNode &op, CopyInst copy_inst) {
   LOG(FATAL) << oss.str();
 }
 
-LayoutMap Copy::InferTMemLayout(const CopyNode &op, const LayoutInferArgs &T,
+LayoutMap Copy::InferTMemLayout(const CopyNode &op,
+                                const LayoutInferArgs &layout_args,
                                 CopyInst copy_inst) {
   // TODO (mzw) Add support for tcgen05.cp in CUDA tmem lowering.
   LayoutMap results;
@@ -560,8 +568,9 @@ LayoutMap Copy::InferTMemLayout(const CopyNode &op, const LayoutInferArgs &T,
   Buffer tmem_buf = is_tmem_load ? op.src : op.dst;
   Buffer reg_buf = is_tmem_load ? op.dst : op.src;
 
-  if (!T.layout_map.count(reg_buf) && T.layout_map.count(tmem_buf)) {
-    Layout tmem_layout = T.layout_map[tmem_buf];
+  if (!layout_args.layout_map.count(reg_buf) &&
+      layout_args.layout_map.count(tmem_buf)) {
+    Layout tmem_layout = layout_args.layout_map[tmem_buf];
     Array<IterVar> logical_coords = op.MakeIterVars();
     Array<PrimExpr> logical_coords_var = {logical_coords[0]->var,
                                           logical_coords[1]->var};
@@ -582,14 +591,14 @@ LayoutMap Copy::InferTMemLayout(const CopyNode &op, const LayoutInferArgs &T,
 
     constexpr int WARP_SIZE = 32;
     constexpr int WARPGROUP_SIZE = 4 * WARP_SIZE;
-    ICHECK(is_const_int(T.thread_bounds->extent))
+    ICHECK(is_const_int(layout_args.thread_bounds->extent))
         << "Tensor memory copy requires thread_bounds->extent (num_threads) "
            "to be constant integers";
-    int num_threads = *as_const_int(T.thread_bounds->extent);
+    int num_threads = *as_const_int(layout_args.thread_bounds->extent);
     ICHECK(num_threads % WARPGROUP_SIZE == 0)
         << "Tensor memory copy requires thread bounds to be aligned to "
            "warpgroups, but found "
-        << "thread range = " << T.thread_bounds;
+        << "thread range = " << layout_args.thread_bounds;
 
     for (int num_useful_wgs = num_threads / WARPGROUP_SIZE; num_useful_wgs >= 1;
          --num_useful_wgs) {
@@ -607,8 +616,8 @@ LayoutMap Copy::InferTMemLayout(const CopyNode &op, const LayoutInferArgs &T,
           Fragment(logical_coords, tmem_coord2frag->Forward(phy_indices),
                    tmem_coord2frag->ForwardThread(phy_indices, std::nullopt),
                    make_itervar("rep", 1));
-      results.Set(reg_buf,
-                  logical_coord2frag->BindThreadRange(T.thread_bounds));
+      results.Set(reg_buf, logical_coord2frag->BindThreadRange(
+                               layout_args.thread_bounds));
       break;
     }
   }
@@ -616,7 +625,8 @@ LayoutMap Copy::InferTMemLayout(const CopyNode &op, const LayoutInferArgs &T,
   return results;
 }
 
-LayoutMap Copy::InferBulkLayout(const CopyNode &op, const LayoutInferArgs &T,
+LayoutMap Copy::InferBulkLayout(const CopyNode &op,
+                                const LayoutInferArgs &layout_args,
                                 InferLevel level, CopyInst copy_inst) {
   Map<Buffer, Layout> result_map;
 
@@ -636,18 +646,22 @@ LayoutMap Copy::InferBulkLayout(const CopyNode &op, const LayoutInferArgs &T,
   }
 
   // Fragment buffers used as TMA indices should be replicated on all threads.
-  PrimExpr thread_extent = T.thread_bounds->extent;
+  PrimExpr thread_extent = layout_args.thread_bounds->extent;
   for (const auto &range : op.src_range) {
-    CollectFragmentLayouts(range->min, T.bind_var_to_expr, T.layout_map,
-                           thread_extent, T.thread_bounds, result_map);
-    CollectFragmentLayouts(range->extent, T.bind_var_to_expr, T.layout_map,
-                           thread_extent, T.thread_bounds, result_map);
+    CollectFragmentLayouts(range->min, layout_args.bind_var_to_expr,
+                           layout_args.layout_map, thread_extent,
+                           layout_args.thread_bounds, result_map);
+    CollectFragmentLayouts(range->extent, layout_args.bind_var_to_expr,
+                           layout_args.layout_map, thread_extent,
+                           layout_args.thread_bounds, result_map);
   }
   for (const auto &range : op.dst_range) {
-    CollectFragmentLayouts(range->min, T.bind_var_to_expr, T.layout_map,
-                           thread_extent, T.thread_bounds, result_map);
-    CollectFragmentLayouts(range->extent, T.bind_var_to_expr, T.layout_map,
-                           thread_extent, T.thread_bounds, result_map);
+    CollectFragmentLayouts(range->min, layout_args.bind_var_to_expr,
+                           layout_args.layout_map, thread_extent,
+                           layout_args.thread_bounds, result_map);
+    CollectFragmentLayouts(range->extent, layout_args.bind_var_to_expr,
+                           layout_args.layout_map, thread_extent,
+                           layout_args.thread_bounds, result_map);
   }
 
   if (is_tma_1d) {
@@ -657,7 +671,8 @@ LayoutMap Copy::InferBulkLayout(const CopyNode &op, const LayoutInferArgs &T,
     return result_map;
   }
 
-  if (level == InferLevel::kFree && !T.layout_map.count(shared_tensor)) {
+  if (level == InferLevel::kFree &&
+      !layout_args.layout_map.count(shared_tensor)) {
     if (is_store) {
       // For BulkStore, infer a swizzled shared-memory layout when possible.
       int dim = shared_tensor->shape.size();
@@ -698,51 +713,51 @@ CopyInst Copy::SelectInst(const CopyNode &op, Target target,
   return result.inst;
 }
 
-Stmt Copy::Lower(const CopyNode &op, const LowerArgs &T,
+Stmt Copy::Lower(const CopyNode &op, const LowerArgs &lower_args,
                  arith::Analyzer *analyzer) {
-  auto copy_inst =
-      SelectInst(op, T.target, T.layout_map, analyzer, /*buffer_oob=*/false);
+  auto copy_inst = SelectInst(op, lower_args.target, lower_args.layout_map,
+                              analyzer, /*buffer_oob=*/false);
   if (op.dst_block.defined()) {
-    ICHECK(TargetHasBulkCopy(T.target))
+    ICHECK(TargetHasBulkCopy(lower_args.target))
         << "T.copy with dst_block requires cluster-copy support (CUDA SM90+). "
-        << "Got target=" << T.target;
-    return LowerCluster(op, T, analyzer);
+        << "Got target=" << lower_args.target;
+    return LowerCluster(op, lower_args, analyzer);
   }
   if (copy_inst == CopyInst::kTMemLoad || copy_inst == CopyInst::kTMemStore) {
-    auto tmem_copy = LowerTmem(op, T, analyzer);
+    auto tmem_copy = LowerTmem(op, lower_args, analyzer);
     ICHECK(tmem_copy.defined()) << "Failed to lower tensor memory copy";
     return tmem_copy;
   } else if (copy_inst == CopyInst::kBulkLoad1D ||
              copy_inst == CopyInst::kBulkStore1D) {
-    auto bulk_copy = LowerBulk1D(op, T, analyzer, copy_inst);
+    auto bulk_copy = LowerBulk1D(op, lower_args, analyzer, copy_inst);
     ICHECK(bulk_copy.defined()) << "Failed to lower bulk load 1d";
     return bulk_copy;
   } else if (copy_inst == CopyInst::kBulkLoad ||
              copy_inst == CopyInst::kBulkStore) {
-    auto bulk_copy = LowerBulk(op, T, analyzer, copy_inst);
+    auto bulk_copy = LowerBulk(op, lower_args, analyzer, copy_inst);
     ICHECK(bulk_copy.defined()) << "Failed to lower bulk load/store";
     return bulk_copy;
   } else if (copy_inst == CopyInst::kBulkLoadGather4 ||
              copy_inst == CopyInst::kBulkStoreScatter4) {
-    auto bulk_copy = LowerBulkGather4(op, T, analyzer, copy_inst);
+    auto bulk_copy = LowerBulkGather4(op, lower_args, analyzer, copy_inst);
     ICHECK(bulk_copy.defined()) << "Failed to lower tma gather4/scatter4";
     return bulk_copy;
   } else if (copy_inst == CopyInst::kLDSM || copy_inst == CopyInst::kSTSM) {
-    auto ldsm_copy = LowerLDSM(op, T, analyzer, copy_inst);
+    auto ldsm_copy = LowerLDSM(op, lower_args, analyzer, copy_inst);
     ICHECK(ldsm_copy.defined()) << "Failed to lower ptx matrix copy";
     return ldsm_copy;
   } else if (copy_inst == CopyInst::kCPAsync) {
-    auto cp_async_copy = LowerCPAsync(op, T, analyzer);
+    auto cp_async_copy = LowerCPAsync(op, lower_args, analyzer);
     ICHECK(cp_async_copy.defined()) << "Failed to lower cp.async copy";
     return cp_async_copy;
   } else if (copy_inst == CopyInst::kNormal) {
-    return LowerNormal(op, T, analyzer);
+    return LowerNormal(op, lower_args, analyzer);
   } else {
     LOG(FATAL) << "Unsupported copy inst " << static_cast<int>(copy_inst);
   }
 }
 
-Stmt Copy::LowerCPAsync(const CopyNode &op, const LowerArgs &T,
+Stmt Copy::LowerCPAsync(const CopyNode &op, const LowerArgs &lower_args,
                         arith::Analyzer *analyzer) {
   using namespace tvm::transform;
 
@@ -752,7 +767,7 @@ Stmt Copy::LowerCPAsync(const CopyNode &op, const LowerArgs &T,
   bool no_implicit_commit_wait = GetNoImplicitAsyncCommitWait(op);
   bool explicit_async_semantics = no_implicit_commit_wait || GetIsAsyncCopy(op);
   if (!enable_async_copy && !explicit_async_semantics) {
-    return LowerNormal(op, T, analyzer);
+    return LowerNormal(op, lower_args, analyzer);
   }
 
   auto simt_loop = op.MakeSIMTLoop(analyzer);
@@ -762,21 +777,21 @@ Stmt Copy::LowerCPAsync(const CopyNode &op, const LowerArgs &T,
   std::vector<InferLevel> levels = {InferLevel::kCommon, InferLevel::kStrict,
                                     InferLevel::kFree};
   for (auto level : levels) {
-    par_op->InferLayout({T.target,
-                         T.thread_bounds,
-                         T.layout_map,
+    par_op->InferLayout({lower_args.target,
+                         lower_args.thread_bounds,
+                         lower_args.layout_map,
                          analyzer,
                          false,
-                         T.buffer_remap,
+                         lower_args.buffer_remap,
                          {}},
                         level);
   }
   auto loop_layout = par_op->GetLoopLayout();
-  Stmt lowered_loop =
-      LowerParallelLoop(par_op->GetRoot(), loop_layout, T.thread_var, analyzer,
-                        T.layout_map, par_op->GetPredicate(T.thread_var),
-                        /*parallel_loop=*/true, /*should_vectorize=*/true,
-                        par_op->LoopLayoutRequiresPaddingGuard());
+  Stmt lowered_loop = LowerParallelLoop(
+      par_op->GetRoot(), loop_layout, lower_args.thread_var, analyzer,
+      lower_args.layout_map, par_op->GetPredicate(lower_args.thread_var),
+      /*parallel_loop=*/true, /*should_vectorize=*/true,
+      par_op->LoopLayoutRequiresPaddingGuard());
 
   auto inject_result =
       InjectPTXAsyncCopy(lowered_loop, /*enable_auto_async_copy=*/true,
@@ -803,7 +818,7 @@ Stmt Copy::LowerCPAsync(const CopyNode &op, const LowerArgs &T,
     }
     DLOG(WARNING) << "Fallback to normal copy because cp.async rewrite found "
                      "no eligible global->shared store.";
-    return LowerNormal(op, T, analyzer);
+    return LowerNormal(op, lower_args, analyzer);
   }
   if (no_implicit_commit_wait) {
     return cp_async_loop;
@@ -816,12 +831,12 @@ Stmt Copy::LowerCPAsync(const CopyNode &op, const LowerArgs &T,
   return cp_async_loop;
 }
 
-Stmt Copy::LowerNormal(const CopyNode &op, const LowerArgs &T,
+Stmt Copy::LowerNormal(const CopyNode &op, const LowerArgs &lower_args,
                        arith::Analyzer *analyzer) {
-  return tl::LowerNormalCopy(op, T, analyzer);
+  return tl::LowerNormalCopy(op, lower_args, analyzer);
 }
 
-Stmt Copy::LowerCluster(const CopyNode &op, const LowerArgs &T,
+Stmt Copy::LowerCluster(const CopyNode &op, const LowerArgs &lower_args,
                         arith::Analyzer *analyzer) {
   const Buffer &src = op.src;
   const Buffer &dst = op.dst;
@@ -879,7 +894,8 @@ Stmt Copy::LowerCluster(const CopyNode &op, const LowerArgs &T,
           DataType::Handle(), tma_store_cluster(),
           {dst_ptr, src_ptr, op.dst_block.value(), size_bytes, barrier_load}));
 
-      return IfThenElse(EQ(T.thread_var, T.thread_bounds->min), bulk_copy);
+      return IfThenElse(
+          EQ(lower_args.thread_var, lower_args.thread_bounds->min), bulk_copy);
     }
 
     bool same_shape = (src_range.size() == dst_range.size());
@@ -901,14 +917,15 @@ Stmt Copy::LowerCluster(const CopyNode &op, const LowerArgs &T,
           MakeTMARows(src, src_range, dst, dst_range, op.dst_block.value(),
                       barrier_load, analyzer);
 
-      if (T.update_barrier_arrive) {
-        T.update_barrier_arrive(barrier_data_var, n_rows);
+      if (lower_args.update_barrier_arrive) {
+        lower_args.update_barrier_arrive(barrier_data_var, n_rows);
       }
 
       Stmt seq = (tma_stmts.size() == 1)
                      ? tma_stmts[0]
                      : static_cast<Stmt>(SeqStmt(tma_stmts));
-      return IfThenElse(EQ(T.thread_var, T.thread_bounds->min), seq);
+      return IfThenElse(
+          EQ(lower_args.thread_var, lower_args.thread_bounds->min), seq);
     }
 
     LOG(WARNING)
@@ -925,20 +942,20 @@ Stmt Copy::LowerCluster(const CopyNode &op, const LowerArgs &T,
                                     InferLevel::kFree};
   auto par_op = ParallelOp(fused_loop);
   for (auto level : levels) {
-    par_op->InferLayout({T.target,
-                         T.thread_bounds,
-                         T.layout_map,
+    par_op->InferLayout({lower_args.target,
+                         lower_args.thread_bounds,
+                         lower_args.layout_map,
                          analyzer,
                          false,
-                         T.buffer_remap,
+                         lower_args.buffer_remap,
                          {}},
                         level);
   }
   auto loop_layout = par_op->GetLoopLayout();
-  auto thread_loop =
-      PartitionLoop(par_op->GetRoot(), T.thread_var, analyzer, loop_layout);
+  auto thread_loop = PartitionLoop(par_op->GetRoot(), lower_args.thread_var,
+                                   analyzer, loop_layout);
   auto vectorized_thread_loop =
-      VectorizeLoop(thread_loop, T.layout_map, /*vectorize_hint=*/1);
+      VectorizeLoop(thread_loop, lower_args.layout_map, /*vectorize_hint=*/1);
 
   class ClusterCopyReplacer : public StmtExprMutator {
   public:
@@ -996,13 +1013,13 @@ Stmt Copy::LowerCluster(const CopyNode &op, const LowerArgs &T,
   };
 
   Buffer target_dst = dst;
-  if (T.buffer_remap.count(dst)) {
-    target_dst = T.buffer_remap[dst];
+  if (lower_args.buffer_remap.count(dst)) {
+    target_dst = lower_args.buffer_remap[dst];
   }
 
   Optional<Layout> dst_layout = std::nullopt;
-  if (T.layout_map.count(dst)) {
-    dst_layout = T.layout_map[dst];
+  if (lower_args.layout_map.count(dst)) {
+    dst_layout = lower_args.layout_map[dst];
   }
 
   Stmt simt_copy = ClusterCopyReplacer(dst, op.dst_block.value(), target_dst,
@@ -1014,14 +1031,14 @@ Stmt Copy::LowerCluster(const CopyNode &op, const LowerArgs &T,
     Stmt arrive =
         Evaluate(Call(DataType::Handle(), ptx_arrive_cluster_barrier(),
                       {barrier_opt.value(), op.dst_block.value()}));
-    Stmt guarded_arrive =
-        IfThenElse(EQ(T.thread_var, T.thread_bounds->min), arrive);
+    Stmt guarded_arrive = IfThenElse(
+        EQ(lower_args.thread_var, lower_args.thread_bounds->min), arrive);
     return SeqStmt({simt_copy, sync, guarded_arrive});
   }
   return simt_copy;
 }
 
-Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
+Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &lower_args,
                      arith::Analyzer *analyzer, CopyInst copy_inst) {
   const Buffer &src = op.src;
   const Buffer &dst = op.dst;
@@ -1034,14 +1051,14 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
 
   Array<IterVar> loop_vars = op.MakeIterVars();
   if (loop_vars.size() < 2) {
-    return LowerNormal(op, T, analyzer);
+    return LowerNormal(op, lower_args, analyzer);
   }
   for (const auto &iv : loop_vars)
     analyzer->Bind(iv->var, iv->dom);
   PrimExpr src_predicate = op.MakePredicate(analyzer, loop_vars, src->shape, 0);
   PrimExpr dst_predicate = op.MakePredicate(analyzer, loop_vars, dst->shape, 1);
   if (src_predicate.defined() || dst_predicate.defined()) {
-    return LowerNormal(op, T, analyzer);
+    return LowerNormal(op, lower_args, analyzer);
   }
 
   Buffer shared_tensor = is_ldmatrix ? src : dst;
@@ -1056,17 +1073,18 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
     }
   }
   if (!is_full_range) {
-    return LowerNormal(op, T, analyzer);
+    return LowerNormal(op, lower_args, analyzer);
   }
 
   Array<PrimExpr> local_indices =
       op.MakeIndices(loop_vars, is_ldmatrix ? 1 : 0);
-  Fragment local_layout = Downcast<Fragment>(T.layout_map[local_tensor]);
+  Fragment local_layout =
+      Downcast<Fragment>(lower_args.layout_map[local_tensor]);
   Array<PrimExpr> local_indices_transformed =
       local_layout->Forward(local_indices);
-  local_tensor = T.buffer_remap[local_tensor];
+  local_tensor = lower_args.buffer_remap[local_tensor];
   if (local_layout->OutputDim() != 1) {
-    return LowerNormal(op, T, analyzer);
+    return LowerNormal(op, lower_args, analyzer);
   }
 
   Array<PrimExpr> shared_indices =
@@ -1093,21 +1111,21 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
                                  row_var->dom->extent, 2, analyzer)) {
     is_transposed = true;
   } else {
-    return LowerNormal(op, T, analyzer);
+    return LowerNormal(op, lower_args, analyzer);
   }
   if (shared_tensor->dtype.bytes() != 2) {
-    return LowerNormal(op, T, analyzer);
+    return LowerNormal(op, lower_args, analyzer);
   }
   PrimExpr flattened_indice = shared_tensor.OffsetOf(shared_indices).back();
   if (!IndicesCanVectorize(flattened_indice, loop_vars.back()->var,
                            loop_vars.back()->dom->extent, 8, analyzer)) {
-    return LowerNormal(op, T, analyzer);
+    return LowerNormal(op, lower_args, analyzer);
   }
 
   for (size_t i = 0; i < dst_range.size(); i++) {
     if (!is_zero(dst_range[i]->min) ||
         !analyzer->CanProveEqual(dst_range[i]->extent, dst->shape[i]))
-      return LowerNormal(op, T, analyzer);
+      return LowerNormal(op, lower_args, analyzer);
   }
 
   PrimExpr extent = local_tensor->shape[0];
@@ -1125,19 +1143,21 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
   Var local_iter("i");
   Layout inv = local_layout->Inverse();
   Array<PrimExpr> shared_coords;
-  PrimExpr warp = FloorDiv(T.thread_var, 32) * 32;
+  PrimExpr warp = FloorDiv(lower_args.thread_var, 32) * 32;
   if (!is_transposed) {
     auto local_index = analyzer->Simplify(
-        local_iter * 2 * num + 2 * FloorMod(FloorDiv(T.thread_var, 8), num));
+        local_iter * 2 * num +
+        2 * FloorMod(FloorDiv(lower_args.thread_var, 8), num));
     auto thread_index =
-        analyzer->Simplify(warp + FloorMod(T.thread_var, 8) * 4);
+        analyzer->Simplify(warp + FloorMod(lower_args.thread_var, 8) * 4);
     shared_coords = inv->Forward({local_index, thread_index});
   } else {
     auto local_index = analyzer->Simplify(
-        local_iter * 2 * num + 2 * FloorMod(FloorDiv(T.thread_var, 8), num) +
-        FloorMod(T.thread_var, 2));
-    auto thread_index =
-        analyzer->Simplify(warp + FloorDiv(FloorMod(T.thread_var, 8), 2));
+        local_iter * 2 * num +
+        2 * FloorMod(FloorDiv(lower_args.thread_var, 8), num) +
+        FloorMod(lower_args.thread_var, 2));
+    auto thread_index = analyzer->Simplify(
+        warp + FloorDiv(FloorMod(lower_args.thread_var, 8), 2));
     shared_coords = inv->Forward({local_index, thread_index});
   }
   shared_coords.pop_back();
@@ -1149,7 +1169,7 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
 
   if (is_ldmatrix) {
     if (local_tensor->dtype != shared_tensor->dtype) {
-      return LowerNormal(op, T, analyzer);
+      return LowerNormal(op, lower_args, analyzer);
     }
     PrimExpr local_addr =
         Call(DataType::Handle(), tl::access_ptr(),
@@ -1176,9 +1196,9 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
   For for_node =
       For(local_iter, 0, FloorDiv(extent, 2 * num), ForKind::kSerial, body);
   for_node = PragmaUnrollLoop(for_node);
-  auto range = T.thread_bounds;
+  auto range = lower_args.thread_bounds;
   if (range.defined()) {
-    auto thread_var = T.thread_var;
+    auto thread_var = lower_args.thread_var;
     auto thread_var_with_offset = thread_var - range->min;
     for_node.CopyOnWrite()->body =
         Substitute(for_node->body, {{thread_var, thread_var_with_offset}});
@@ -1186,7 +1206,7 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &T,
   return for_node;
 }
 
-Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &T,
+Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
                      arith::Analyzer *analyzer) {
   const Buffer &src = op.src;
   const Buffer &dst = op.dst;
@@ -1194,8 +1214,9 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &T,
   if (src.scope() != "shared.tmem" && dst.scope() != "shared.tmem") {
     return Stmt();
   }
-  ICHECK(TargetHasTmem(T.target))
-      << "Target " << T.target->str() << " does not support tensor memory copy";
+  ICHECK(TargetHasTmem(lower_args.target))
+      << "Target " << lower_args.target->str()
+      << " does not support tensor memory copy";
 
   bool is_ld = false;
   bool is_st = false;
@@ -1237,28 +1258,30 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &T,
 
   constexpr int WARP_SIZE = 32;
   constexpr int WARPGROUP_SIZE = 4 * WARP_SIZE;
-  ICHECK(is_const_int(T.thread_bounds->extent))
+  ICHECK(is_const_int(lower_args.thread_bounds->extent))
       << "Tensor memory copy requires thread_bounds->extent (num_threads) to "
          "be constant integers";
-  int num_threads = *as_const_int(T.thread_bounds->extent);
-  ICHECK(analyzer->CanProveEqual(FloorMod(T.thread_bounds->min, WARPGROUP_SIZE),
-                                 0) &&
+  int num_threads = *as_const_int(lower_args.thread_bounds->extent);
+  ICHECK(analyzer->CanProveEqual(
+             FloorMod(lower_args.thread_bounds->min, WARPGROUP_SIZE), 0) &&
          num_threads % WARPGROUP_SIZE == 0)
       << "Tensor memory copy requires thread bounds to be aligned to "
          "warpgroups, but found "
-      << "thread range = " << T.thread_bounds;
+      << "thread range = " << lower_args.thread_bounds;
 
   Buffer tmem_buf = is_ld ? src : dst;
   Buffer reg_buf = is_ld ? dst : src;
   int tmem_side = is_ld ? 0 : 1;
   bool needs_pack_unpack = is_ld ? src_needs_pack : dst_needs_unpack;
 
-  ICHECK(T.layout_map.count(tmem_buf)) << "Tmem buffer " << tmem_buf->name
-                                       << " does not have a layout specified";
-  ICHECK(T.layout_map.count(reg_buf)) << "Register buffer " << reg_buf->name
-                                      << " does not have a layout specified";
-  Layout tmem_layout = T.layout_map[tmem_buf];
-  Fragment reg_layout = Downcast<Fragment>(T.layout_map[reg_buf]);
+  ICHECK(lower_args.layout_map.count(tmem_buf))
+      << "Tmem buffer " << tmem_buf->name
+      << " does not have a layout specified";
+  ICHECK(lower_args.layout_map.count(reg_buf))
+      << "Register buffer " << reg_buf->name
+      << " does not have a layout specified";
+  Layout tmem_layout = lower_args.layout_map[tmem_buf];
+  Fragment reg_layout = Downcast<Fragment>(lower_args.layout_map[reg_buf]);
 
   Array<PrimExpr> logical_indices = op.MakeIndices(loop_vars, tmem_side);
   Array<PrimExpr> phy_indices = tmem_layout->Forward(logical_indices);
@@ -1316,7 +1339,8 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &T,
       int effective_chunks =
           needs_pack_unpack ? num_chunks_each_wg / 2 : num_chunks_each_wg;
       PrimExpr relative_wg_idx =
-          FloorDiv(Sub(T.thread_var, T.thread_bounds->min), WARPGROUP_SIZE);
+          FloorDiv(Sub(lower_args.thread_var, lower_args.thread_bounds->min),
+                   WARPGROUP_SIZE);
       PrimExpr col_offset =
           num_useful_threads == WARPGROUP_SIZE
               ? PrimExpr(0)
@@ -1349,7 +1373,8 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &T,
       }
       if (num_useful_threads != num_threads) {
         body =
-            IfThenElse(T.thread_var < T.thread_bounds->min + num_useful_threads,
+            IfThenElse(lower_args.thread_var <
+                           lower_args.thread_bounds->min + num_useful_threads,
                        call, Stmt());
       } else {
         body = call;
@@ -1496,7 +1521,7 @@ BulkCopyTile ComputeBulkCopyTile(const Array<PrimExpr> &shared_shape,
 
 } // namespace
 
-Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
+Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
                      arith::Analyzer *analyzer, CopyInst copy_inst) {
   const Buffer &src = op.src;
   const Buffer &dst = op.dst;
@@ -1518,10 +1543,10 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
                  << "LowerBulk: " << reason << ", src=" << src->name
                  << ", dst=" << dst->name;
     }
-    return LowerNormal(op, T, analyzer);
+    return LowerNormal(op, lower_args, analyzer);
   };
 
-  if (T.layout_map.count(global_tensor)) {
+  if (lower_args.layout_map.count(global_tensor)) {
     DLOG(WARNING) << "TMA bulk copy cannot support a non-swizzled global "
                      "layout, fallback to normal copy.";
     return fallback_to_normal("non-swizzled global layout");
@@ -1560,12 +1585,12 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
   Array<PrimExpr> shared_shape = shared_tensor->shape;
   // logical shared -> physical shared, in TileLang convention
   Layout shared_layout;
-  if (T.layout_map.count(shared_tensor)) {
-    shared_layout = T.layout_map.at(shared_tensor);
-    ICHECK(T.buffer_remap.count(shared_tensor))
+  if (lower_args.layout_map.count(shared_tensor)) {
+    shared_layout = lower_args.layout_map.at(shared_tensor);
+    ICHECK(lower_args.buffer_remap.count(shared_tensor))
         << "shared_tensor: " << shared_tensor->name
         << " not found in buffer_remap";
-    shared_tensor = T.buffer_remap.at(shared_tensor);
+    shared_tensor = lower_args.buffer_remap.at(shared_tensor);
   } else {
     shared_layout = makeLinearLayout(shared_shape);
   }
@@ -1609,7 +1634,7 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
   // repeat boundary or the data lands with a shifted phase (silently wrong
   // results, no fault). Report the requirement implied by the chosen swizzle
   // mode so MergeSharedMemoryAllocations can align the buffer accordingly.
-  RequireTMASmemAlignment(T, shared_tensor, desc.swizzle);
+  RequireTMASmemAlignment(lower_args, shared_tensor, desc.swizzle);
 
   // logical shared -> physical shared (without swizzle)
   // E.g., smem_plain = (64,64,8):(64,1,4096)
@@ -1860,11 +1885,11 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
     } else if (GetIsTmaCopy(op)) {
       LOG(FATAL) << "T.tma_copy() requires a barrier argument. "
                  << "Use T.tma_copy(src, dst, barrier=mbar[idx]).";
-    } else if (T.alloc_mbarrier) {
+    } else if (lower_args.alloc_mbarrier) {
       barrier_base_id =
-          T.alloc_mbarrier(1, MakeCopyMBarrierName(op.src, op.dst));
+          lower_args.alloc_mbarrier(1, MakeCopyMBarrierName(op.src, op.dst));
       PrimExpr mbar_idx = IntImm(DataType::Int(32), barrier_base_id);
-      mbar_handle = BufferLoad(T.mbarrier_buffer->value(), {mbar_idx});
+      mbar_handle = BufferLoad(lower_args.mbarrier_buffer->value(), {mbar_idx});
     }
   }
 
@@ -1936,7 +1961,7 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
       args.push_back(need_reduce);
     args.push_back(GetEvictionPolicy(op));
     Map<String, ObjectRef> ann_loop;
-    if (is_cluster_barrier && TargetIsSm100(T.target) && is_load) {
+    if (is_cluster_barrier && TargetIsSm100(lower_args.target) && is_load) {
       ann_loop.Set("use_2cta", IntImm(DataType::Int(32), 1));
     }
     tma_copy = For(loop_var, 0, loop_extent, ForKind::kUnrolled,
@@ -1972,7 +1997,7 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
       args.push_back(need_reduce);
     args.push_back(GetEvictionPolicy(op));
     Map<String, ObjectRef> ann;
-    if (TargetIsSm100(T.target) && is_load &&
+    if (TargetIsSm100(lower_args.target) && is_load &&
         (annotations.find("use_2cta") != annotations.end() ||
          is_cluster_barrier)) {
       ann.Set("use_2cta", IntImm(DataType::Int(32), 1));
@@ -2026,7 +2051,7 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
     if (GetIsTmaCopy(op)) {
       if (is_cluster_barrier) {
         PrimExpr cluster_total_bytes =
-            total_bytes * IntImm(DataType::Int(32), T.cluster_size);
+            total_bytes * IntImm(DataType::Int(32), lower_args.cluster_size);
         Stmt expect_stmt =
             Evaluate(Call(DataType::Handle(), mbarrier_expect_tx(),
                           {mbar_handle, cluster_total_bytes}));
@@ -2058,23 +2083,23 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &T,
       producer_seq.push_back(barrier_after_tma_stmt.value());
     }
 
-    Stmt producer =
-        IfThenElse(MakeTmaLeaderCondition(GetLeaderScopeThreads(op, T)),
-                   SeqStmt(producer_seq));
+    Stmt producer = IfThenElse(
+        MakeTmaLeaderCondition(GetLeaderScopeThreads(op, lower_args)),
+        SeqStmt(producer_seq));
 
     if (GetIsTmaCopy(op)) {
       return producer;
     }
 
-    Stmt wait_stmt =
-        Evaluate(Call(DataType::Handle(), mbarrier_wait_parity(),
-                      {mbar_handle, GetCopyMbarPhaseExpr(annotations, T)}));
+    Stmt wait_stmt = Evaluate(
+        Call(DataType::Handle(), mbarrier_wait_parity(),
+             {mbar_handle, GetCopyMbarPhaseExpr(annotations, lower_args)}));
 
     return SeqStmt({producer, wait_stmt});
   }
 
-  tma_copy = IfThenElse(MakeTmaLeaderCondition(GetLeaderScopeThreads(op, T)),
-                        tma_copy);
+  tma_copy = IfThenElse(
+      MakeTmaLeaderCondition(GetLeaderScopeThreads(op, lower_args)), tma_copy);
 
   return tma_copy;
 }
@@ -2097,7 +2122,7 @@ PrimExpr GetGather4Col(const CopyNode &op) {
 
 } // namespace
 
-Stmt Copy::LowerBulkGather4(const CopyNode &op, const LowerArgs &T,
+Stmt Copy::LowerBulkGather4(const CopyNode &op, const LowerArgs &lower_args,
                             arith::Analyzer *analyzer, CopyInst copy_inst) {
   ICHECK(copy_inst == CopyInst::kBulkLoadGather4 ||
          copy_inst == CopyInst::kBulkStoreScatter4);
@@ -2171,10 +2196,10 @@ Stmt Copy::LowerBulkGather4(const CopyNode &op, const LowerArgs &T,
   desc.oob_fill = static_cast<int>(CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
 
   Layout shared_layout;
-  if (T.layout_map.count(shared_tensor)) {
-    shared_layout = T.layout_map.at(shared_tensor);
-    ICHECK(T.buffer_remap.count(shared_tensor));
-    shared_tensor = T.buffer_remap.at(shared_tensor);
+  if (lower_args.layout_map.count(shared_tensor)) {
+    shared_layout = lower_args.layout_map.at(shared_tensor);
+    ICHECK(lower_args.buffer_remap.count(shared_tensor));
+    shared_tensor = lower_args.buffer_remap.at(shared_tensor);
   }
   desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_NONE);
   if (shared_layout.defined() && shared_layout->InputDim() >= 2) {
@@ -2202,7 +2227,7 @@ Stmt Copy::LowerBulkGather4(const CopyNode &op, const LowerArgs &T,
           << " exceeds " << max_bytes << "B swizzle limit";
     }
   }
-  RequireTMASmemAlignment(T, shared_tensor, desc.swizzle);
+  RequireTMASmemAlignment(lower_args, shared_tensor, desc.swizzle);
 
   Call create_descriptor =
       Call(DataType::Handle(), create_tma_descriptor(), desc.EncodeCallArgs());
@@ -2232,7 +2257,7 @@ Stmt Copy::LowerBulkGather4(const CopyNode &op, const LowerArgs &T,
   return Evaluate(Call(DataType::Handle(), tl_op, args));
 }
 
-Stmt Copy::LowerBulk1D(const CopyNode &op, const LowerArgs &T,
+Stmt Copy::LowerBulk1D(const CopyNode &op, const LowerArgs &lower_args,
                        arith::Analyzer *analyzer, CopyInst copy_inst) {
   const Buffer &src = op.src;
   const Buffer &dst = op.dst;
@@ -2311,11 +2336,11 @@ Stmt Copy::LowerBulk1D(const CopyNode &op, const LowerArgs &T,
     } else if (GetIsTmaCopy(op)) {
       LOG(FATAL) << "T.tma_copy() requires a barrier argument. "
                  << "Use T.tma_copy(src, dst, barrier=mbar[idx]).";
-    } else if (T.alloc_mbarrier) {
+    } else if (lower_args.alloc_mbarrier) {
       barrier_base_id =
-          T.alloc_mbarrier(1, MakeCopyMBarrierName(op.src, op.dst));
+          lower_args.alloc_mbarrier(1, MakeCopyMBarrierName(op.src, op.dst));
       PrimExpr mbar_idx = IntImm(DataType::Int(32), barrier_base_id);
-      mbar_handle = BufferLoad(T.mbarrier_buffer->value(), {mbar_idx});
+      mbar_handle = BufferLoad(lower_args.mbarrier_buffer->value(), {mbar_idx});
     }
   }
 
@@ -2366,33 +2391,33 @@ Stmt Copy::LowerBulk1D(const CopyNode &op, const LowerArgs &T,
       producer_seq.push_back(barrier_after_tma_stmt.value());
     }
 
-    Stmt producer =
-        IfThenElse(MakeTmaLeaderCondition(GetLeaderScopeThreads(op, T)),
-                   SeqStmt(producer_seq));
+    Stmt producer = IfThenElse(
+        MakeTmaLeaderCondition(GetLeaderScopeThreads(op, lower_args)),
+        SeqStmt(producer_seq));
 
     if (GetIsTmaCopy(op)) {
       return producer;
     }
 
-    Stmt wait_stmt =
-        Evaluate(Call(DataType::Handle(), mbarrier_wait_parity(),
-                      {mbar_handle, GetCopyMbarPhaseExpr(annotations, T)}));
+    Stmt wait_stmt = Evaluate(
+        Call(DataType::Handle(), mbarrier_wait_parity(),
+             {mbar_handle, GetCopyMbarPhaseExpr(annotations, lower_args)}));
 
     return SeqStmt({producer, wait_stmt});
   }
 
-  tma_copy = IfThenElse(MakeTmaLeaderCondition(GetLeaderScopeThreads(op, T)),
-                        tma_copy);
+  tma_copy = IfThenElse(
+      MakeTmaLeaderCondition(GetLeaderScopeThreads(op, lower_args)), tma_copy);
   return tma_copy;
 }
 
-Stmt Im2Col::Lower(const Im2ColOpNode &op, const LowerArgs &T,
+Stmt Im2Col::Lower(const Im2ColOpNode &op, const LowerArgs &lower_args,
                    arith::Analyzer *analyzer) {
   const BufferRegion &dst_region = op.dstRegion_;
   const Buffer &src = op.src_;
   const Buffer &dst = op.dst_;
 
-  ICHECK(TargetIsHopper(T.target));
+  ICHECK(TargetIsHopper(lower_args.target));
   ICHECK(IsGlobalBuffer(src) && IsSharedBuffer(dst));
   ICHECK(src->shape.size() == 4);
   ICHECK(src->dtype == dst->dtype);
@@ -2400,8 +2425,8 @@ Stmt Im2Col::Lower(const Im2ColOpNode &op, const LowerArgs &T,
   size_t ndim = dst_region->region.size();
   ICHECK(ndim >= 2) << "im2col dstRegion must have at least 2 dims";
   Layout shared_layout;
-  if (T.layout_map.count(dst)) {
-    shared_layout = T.layout_map[dst];
+  if (lower_args.layout_map.count(dst)) {
+    shared_layout = lower_args.layout_map[dst];
   }
 
   TMAIm2ColDesc desc;
@@ -2450,7 +2475,9 @@ Stmt Im2Col::Lower(const Im2ColOpNode &op, const LowerArgs &T,
     }
   }
   RequireTMASmemAlignment(
-      T, T.buffer_remap.count(dst) ? T.buffer_remap[dst] : dst, desc.swizzle);
+      lower_args,
+      lower_args.buffer_remap.count(dst) ? lower_args.buffer_remap[dst] : dst,
+      desc.swizzle);
 
   Call create_desc = Call(DataType::Handle(), create_tma_im2col_descriptor(),
                           desc.EncodeCallArgs());
@@ -2496,18 +2523,19 @@ Stmt Im2Col::Lower(const Im2ColOpNode &op, const LowerArgs &T,
   if (auto user_barrier = op.annotations_.Get("barrier")) {
     mbar_handle = Downcast<PrimExpr>(user_barrier.value());
     barrier_base_id = 0;
-  } else if (T.alloc_mbarrier) {
+  } else if (lower_args.alloc_mbarrier) {
     barrier_base_id =
-        T.alloc_mbarrier(1, MakeCopyMBarrierName(op.src_, op.dst_));
+        lower_args.alloc_mbarrier(1, MakeCopyMBarrierName(op.src_, op.dst_));
     PrimExpr mbar_idx = IntImm(DataType::Int(32), barrier_base_id);
-    mbar_handle = BufferLoad(T.mbarrier_buffer->value(), {mbar_idx});
+    mbar_handle = BufferLoad(lower_args.mbarrier_buffer->value(), {mbar_idx});
   }
 
   Array<PrimExpr> args;
   args.reserve(desc.rank * 2 + 2);
   args.push_back(create_desc);
   args.push_back(barrier_base_id >= 0 ? mbar_handle : PrimExpr(0));
-  Buffer dst_buffer = T.buffer_remap.count(dst) ? T.buffer_remap[dst] : dst;
+  Buffer dst_buffer =
+      lower_args.buffer_remap.count(dst) ? lower_args.buffer_remap[dst] : dst;
   PrimExpr flat_offset = IntImm(DataType::Int(32), 0);
   {
     PrimExpr stride = IntImm(DataType::Int(32), 1);
@@ -2548,25 +2576,27 @@ Stmt Im2Col::Lower(const Im2ColOpNode &op, const LowerArgs &T,
                             {mbar_handle})));
         }
       }
-      return IfThenElse(MakeTmaLeaderCondition(T.thread_bounds->extent),
-                        SeqStmt(producer_seq));
+      return IfThenElse(
+          MakeTmaLeaderCondition(lower_args.thread_bounds->extent),
+          SeqStmt(producer_seq));
     }
 
     Stmt barrier_after_tma_stmt = Evaluate(
         Call(DataType::Handle(), builtin::ptx_arrive_barrier(), {mbar_handle}));
 
-    Stmt producer = IfThenElse(MakeTmaLeaderCondition(T.thread_bounds->extent),
-                               SeqStmt({barrier_before_tma_stmt, tma_copy_stmt,
-                                        barrier_after_tma_stmt}));
+    Stmt producer =
+        IfThenElse(MakeTmaLeaderCondition(lower_args.thread_bounds->extent),
+                   SeqStmt({barrier_before_tma_stmt, tma_copy_stmt,
+                            barrier_after_tma_stmt}));
 
-    Stmt wait_stmt =
-        Evaluate(Call(DataType::Handle(), mbarrier_wait_parity(),
-                      {mbar_handle, GetCopyMbarPhaseExpr(op.annotations_, T)}));
+    Stmt wait_stmt = Evaluate(
+        Call(DataType::Handle(), mbarrier_wait_parity(),
+             {mbar_handle, GetCopyMbarPhaseExpr(op.annotations_, lower_args)}));
 
     return SeqStmt({producer, wait_stmt});
   }
 
-  return IfThenElse(MakeTmaLeaderCondition(T.thread_bounds->extent),
+  return IfThenElse(MakeTmaLeaderCondition(lower_args.thread_bounds->extent),
                     tma_copy_stmt);
 }
 

--- a/src/cuda/op/fill.cc
+++ b/src/cuda/op/fill.cc
@@ -52,9 +52,9 @@ std::optional<PrimExpr> FullRegionElements(const Buffer &buffer,
 }
 
 std::optional<Stmt> TryLowerSharedBulkZeroFill(const FillNode &op,
-                                               const LowerArgs &T,
+                                               const LowerArgs &lower_args,
                                                arith::Analyzer *analyzer) {
-  if (!CanUseStBulkShared(T.target)) {
+  if (!CanUseStBulkShared(lower_args.target)) {
     return std::nullopt;
   }
   if (!IsSharedBuffer(op.dst) || !IsZeroFillValue(op.value, analyzer)) {
@@ -84,18 +84,19 @@ std::optional<Stmt> TryLowerSharedBulkZeroFill(const FillNode &op,
       Call(DataType::Handle(), ptx_st_bulk_shared(),
            {op.dst->data, bytes, make_const(DataType::UInt(64), 0)});
   Stmt body = Evaluate(bulk_store);
-  if (T.thread_var.defined() && T.thread_bounds.defined()) {
-    body = IfThenElse(EQ(T.thread_var, T.thread_bounds->min), body);
+  if (lower_args.thread_var.defined() && lower_args.thread_bounds.defined()) {
+    body = IfThenElse(EQ(lower_args.thread_var, lower_args.thread_bounds->min),
+                      body);
   }
   return body;
 }
 
-Stmt LowerCudaFill(const FillNode &op, const LowerArgs &T,
+Stmt LowerCudaFill(const FillNode &op, const LowerArgs &lower_args,
                    arith::Analyzer *analyzer) {
-  if (auto bulk_fill = TryLowerSharedBulkZeroFill(op, T, analyzer)) {
+  if (auto bulk_fill = TryLowerSharedBulkZeroFill(op, lower_args, analyzer)) {
     return bulk_fill.value();
   }
-  return backend::Fill::Lower(op, T, analyzer);
+  return backend::Fill::Lower(op, lower_args, analyzer);
 }
 
 bool RegisterCudaFill() {

--- a/src/metal/op/copy.cc
+++ b/src/metal/op/copy.cc
@@ -25,7 +25,7 @@ bool CheckSIMDGroupCopy(const CopyNode &op) {
          (IsSharedBuffer(op.dst) || IsGlobalBuffer(op.dst));
 }
 
-Stmt LowerSIMDGroupCopy(const CopyNode &op, const LowerArgs &T,
+Stmt LowerSIMDGroupCopy(const CopyNode &op, const LowerArgs &lower_args,
                         arith::Analyzer *analyzer) {
   (void)analyzer;
   TVM_FFI_ICHECK(IsSIMDGroupBuffer(op.src));
@@ -48,13 +48,14 @@ Stmt LowerSIMDGroupCopy(const CopyNode &op, const LowerArgs &T,
   PrimExpr dst_col_base = op.dst_range[1]->min;
   PrimExpr dst_stride = op.dst->shape[op.dst->shape.size() - 1];
 
-  int warp_size = TargetMetalGetWarpSize(T.target);
-  const auto *block_size_imm = T.thread_bounds->extent.as<IntImmNode>();
+  int warp_size = TargetMetalGetWarpSize(lower_args.target);
+  const auto *block_size_imm =
+      lower_args.thread_bounds->extent.as<IntImmNode>();
   TVM_FFI_ICHECK(block_size_imm)
       << "simdgroup copy requires constant thread bounds";
   int block_size = block_size_imm->value;
   int num_warps = block_size / warp_size;
-  PrimExpr warp_id = FloorDiv(T.thread_var, warp_size);
+  PrimExpr warp_id = FloorDiv(lower_args.thread_var, warp_size);
 
   const auto *m_imm = op.src_range[0]->extent.as<IntImmNode>();
   const auto *n_imm = op.src_range[1]->extent.as<IntImmNode>();
@@ -106,17 +107,18 @@ Stmt LowerSIMDGroupCopy(const CopyNode &op, const LowerArgs &T,
 } // namespace
 
 struct Copy {
-  static LayoutMap InferLayout(const CopyNode &op, const LayoutInferArgs &T,
+  static LayoutMap InferLayout(const CopyNode &op,
+                               const LayoutInferArgs &layout_args,
                                InferLevel level) {
-    return op.InferSIMTLayout(T, level);
+    return op.InferSIMTLayout(layout_args, level);
   }
 
-  static Stmt Lower(const CopyNode &op, const LowerArgs &T,
+  static Stmt Lower(const CopyNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer) {
     if (CheckSIMDGroupCopy(op)) {
-      return LowerSIMDGroupCopy(op, T, analyzer);
+      return LowerSIMDGroupCopy(op, lower_args, analyzer);
     }
-    return LowerNormalCopy(op, T, analyzer);
+    return LowerNormalCopy(op, lower_args, analyzer);
   }
 };
 

--- a/src/metal/op/fill.cc
+++ b/src/metal/op/fill.cc
@@ -22,7 +22,7 @@ using namespace tirx;
 namespace metal {
 
 struct Fill {
-  static Stmt Lower(const FillNode &op, const LowerArgs &T,
+  static Stmt Lower(const FillNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer) {
     if (IsSIMDGroupBuffer(op.dst)) {
       int region_elements = 1;
@@ -53,21 +53,22 @@ struct Fill {
 
     if (IsFragmentBuffer(op.dst)) {
       auto par_op = ParallelOp(op.MakeSIMTLoop(analyzer));
-      par_op->InferLayout({T.target,
-                           T.thread_bounds,
-                           T.layout_map,
+      par_op->InferLayout({lower_args.target,
+                           lower_args.thread_bounds,
+                           lower_args.layout_map,
                            analyzer,
                            false,
-                           T.buffer_remap,
+                           lower_args.buffer_remap,
                            {}},
                           InferLevel::kFree);
-      auto thread_loop = PartitionLoop(par_op->GetRoot(), T.thread_var,
+      auto thread_loop = PartitionLoop(par_op->GetRoot(), lower_args.thread_var,
                                        analyzer, par_op->GetLoopLayout());
-      auto vectorized_loop = VectorizeLoop(thread_loop, analyzer, T.layout_map);
+      auto vectorized_loop =
+          VectorizeLoop(thread_loop, analyzer, lower_args.layout_map);
       auto unrolled_loop = PragmaUnrollLoop(vectorized_loop);
 
-      if (par_op->GetPredicate(T.thread_var).defined()) {
-        return IfThenElse(par_op->GetPredicate(T.thread_var).value(),
+      if (par_op->GetPredicate(lower_args.thread_var).defined()) {
+        return IfThenElse(par_op->GetPredicate(lower_args.thread_var).value(),
                           unrolled_loop);
       }
       return unrolled_loop;
@@ -75,26 +76,28 @@ struct Fill {
 
     if (IsLocalBuffer(op.dst) || IsLocalVarBuffer(op.dst)) {
       auto init_loop = op.MakeSIMTLoop(analyzer);
-      auto vectorized_loop = VectorizeLoop(init_loop, analyzer, T.layout_map);
+      auto vectorized_loop =
+          VectorizeLoop(init_loop, analyzer, lower_args.layout_map);
       return PragmaUnrollLoop(vectorized_loop);
     }
 
     if (IsSharedBuffer(op.dst) || IsGlobalBuffer(op.dst)) {
       auto par_op = ParallelOp(op.MakeSIMTLoop(analyzer));
-      par_op->InferLayout({T.target,
-                           T.thread_bounds,
-                           T.layout_map,
+      par_op->InferLayout({lower_args.target,
+                           lower_args.thread_bounds,
+                           lower_args.layout_map,
                            analyzer,
                            false,
-                           T.buffer_remap,
+                           lower_args.buffer_remap,
                            {}},
                           InferLevel::kFree);
-      auto thread_loop = PartitionLoop(par_op->GetRoot(), T.thread_var,
+      auto thread_loop = PartitionLoop(par_op->GetRoot(), lower_args.thread_var,
                                        analyzer, par_op->GetLoopLayout());
-      auto vectorized_loop = VectorizeLoop(thread_loop, analyzer, T.layout_map);
+      auto vectorized_loop =
+          VectorizeLoop(thread_loop, analyzer, lower_args.layout_map);
       auto unrolled_loop = PragmaUnrollLoop(vectorized_loop);
-      if (par_op->GetPredicate(T.thread_var).defined()) {
-        return IfThenElse(par_op->GetPredicate(T.thread_var).value(),
+      if (par_op->GetPredicate(lower_args.thread_var).defined()) {
+        return IfThenElse(par_op->GetPredicate(lower_args.thread_var).value(),
                           unrolled_loop);
       }
       return unrolled_loop;

--- a/src/metal/op/transpose.cc
+++ b/src/metal/op/transpose.cc
@@ -21,35 +21,35 @@ namespace tl {
 namespace metal {
 
 struct Transpose {
-  static Stmt Lower(const TransposeNode &op, const LowerArgs &T,
+  static Stmt Lower(const TransposeNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer) {
-    bool is_cpu_target = T.target->GetTargetDeviceType() == kDLCPU;
+    bool is_cpu_target = lower_args.target->GetTargetDeviceType() == kDLCPU;
     auto simt_loop = op.MakeSIMTLoop(analyzer);
     auto fused_loop = Downcast<For>(ParallelLoopFuser::Fuse(simt_loop));
 
     if (is_cpu_target || IsLocalBuffer(op.src) || IsLocalBuffer(op.dst)) {
-      return VectorizeLoop(fused_loop, T.layout_map);
+      return VectorizeLoop(fused_loop, lower_args.layout_map);
     }
 
     auto par_op = ParallelOp(fused_loop);
     std::vector<InferLevel> levels = {InferLevel::kCommon, InferLevel::kStrict,
                                       InferLevel::kFree};
     for (auto level : levels) {
-      par_op->InferLayout({T.target,
-                           T.thread_bounds,
-                           T.layout_map,
+      par_op->InferLayout({lower_args.target,
+                           lower_args.thread_bounds,
+                           lower_args.layout_map,
                            analyzer,
                            false,
-                           T.buffer_remap,
+                           lower_args.buffer_remap,
                            {}},
                           level);
     }
     auto loop_layout = par_op->GetLoopLayout();
-    return LowerParallelLoop(par_op->GetRoot(), loop_layout, T.thread_var,
-                             analyzer, T.layout_map,
-                             par_op->GetPredicate(T.thread_var),
-                             /*parallel_loop=*/true, /*should_vectorize=*/true,
-                             par_op->LoopLayoutRequiresPaddingGuard());
+    return LowerParallelLoop(
+        par_op->GetRoot(), loop_layout, lower_args.thread_var, analyzer,
+        lower_args.layout_map, par_op->GetPredicate(lower_args.thread_var),
+        /*parallel_loop=*/true, /*should_vectorize=*/true,
+        par_op->LoopLayoutRequiresPaddingGuard());
   }
 };
 

--- a/src/op/atomic_add.cc
+++ b/src/op/atomic_add.cc
@@ -123,13 +123,16 @@ TileOperator AtomicAddNode::Clone() const {
 
 const Op &AtomicAddNode::GetElemOp() const { return atomic_add_elem_op(); }
 
-LayoutMap AtomicAddNode::InferLayout(const LayoutInferArgs &T,
+LayoutMap AtomicAddNode::InferLayout(const LayoutInferArgs &layout_args,
                                      InferLevel level) const {
-  return ResolveAtomicAddImpl(T.target).infer_layout(*this, T, level);
+  return ResolveAtomicAddImpl(layout_args.target)
+      .infer_layout(*this, layout_args, level);
 }
 
-Stmt AtomicAddNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
-  return ResolveAtomicAddImpl(T.target).lower(*this, T, analyzer);
+Stmt AtomicAddNode::Lower(const LowerArgs &lower_args,
+                          arith::Analyzer *analyzer) const {
+  return ResolveAtomicAddImpl(lower_args.target)
+      .lower(*this, lower_args, analyzer);
 }
 
 TIR_REGISTER_TL_TILE_OP(AtomicAdd, atomicadd)

--- a/src/op/atomic_add.h
+++ b/src/op/atomic_add.h
@@ -25,10 +25,11 @@ public:
                                     TileOperatorNode);
 
   /// Override Lower to add TMA support
-  Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const;
+  Stmt Lower(const LowerArgs &lower_args, arith::Analyzer *analyzer) const;
 
   /// Override InferLayout to add TMA layout inference
-  LayoutMap InferLayout(const LayoutInferArgs &T, InferLevel level) const;
+  LayoutMap InferLayout(const LayoutInferArgs &layout_args,
+                        InferLevel level) const;
 
   static const Op &Get();
   const Op &GetElemOp() const override;
@@ -52,10 +53,11 @@ struct AtomicAddImpl {
   const char *name;
   AtomicAddTargetPredicate match_target;
 
-  LayoutMap (*infer_layout)(const AtomicAddNode &op, const LayoutInferArgs &T,
+  LayoutMap (*infer_layout)(const AtomicAddNode &op,
+                            const LayoutInferArgs &layout_args,
                             InferLevel level);
 
-  Stmt (*lower)(const AtomicAddNode &op, const LowerArgs &T,
+  Stmt (*lower)(const AtomicAddNode &op, const LowerArgs &lower_args,
                 arith::Analyzer *analyzer);
 };
 

--- a/src/op/atomic_reduce.cc
+++ b/src/op/atomic_reduce.cc
@@ -143,14 +143,16 @@ TileOperator AtomicMinNode::Clone() const {
 
 const Op &AtomicMinNode::GetElemOp() const { return atomic_min_elem_op(); }
 
-LayoutMap AtomicOpBaseNode::InferLayout(const LayoutInferArgs &T,
+LayoutMap AtomicOpBaseNode::InferLayout(const LayoutInferArgs &layout_args,
                                         InferLevel level) const {
-  return ResolveAtomicReduceImpl(T.target).infer_layout(*this, T, level);
+  return ResolveAtomicReduceImpl(layout_args.target)
+      .infer_layout(*this, layout_args, level);
 }
 
-Stmt AtomicOpBaseNode::Lower(const LowerArgs &T,
+Stmt AtomicOpBaseNode::Lower(const LowerArgs &lower_args,
                              arith::Analyzer *analyzer) const {
-  return ResolveAtomicReduceImpl(T.target).lower(*this, T, analyzer);
+  return ResolveAtomicReduceImpl(lower_args.target)
+      .lower(*this, lower_args, analyzer);
 }
 
 // ============================================================================

--- a/src/op/atomic_reduce.h
+++ b/src/op/atomic_reduce.h
@@ -36,10 +36,12 @@ public:
   mutable ParallelOp par_op_; ///< Associated parallel operation
 
   /// Lower through the registered target implementation.
-  Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const override;
+  Stmt Lower(const LowerArgs &lower_args,
+             arith::Analyzer *analyzer) const override;
 
   /// Infer layout through the registered target implementation.
-  LayoutMap InferLayout(const LayoutInferArgs &T, InferLevel level) const;
+  LayoutMap InferLayout(const LayoutInferArgs &layout_args,
+                        InferLevel level) const;
 
   /// Get memory order from annotations (default: relaxed = 0)
   int GetMemoryOrder() const {
@@ -62,9 +64,10 @@ struct AtomicReduceImpl {
   AtomicReduceTargetPredicate match_target;
 
   LayoutMap (*infer_layout)(const AtomicOpBaseNode &op,
-                            const LayoutInferArgs &T, InferLevel level);
+                            const LayoutInferArgs &layout_args,
+                            InferLevel level);
 
-  Stmt (*lower)(const AtomicOpBaseNode &op, const LowerArgs &T,
+  Stmt (*lower)(const AtomicOpBaseNode &op, const LowerArgs &lower_args,
                 arith::Analyzer *analyzer);
 };
 

--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -28,9 +28,9 @@ namespace tl {
 using namespace tirx;
 using namespace ffi;
 
-Stmt LowerNormalCopy(const CopyNode &op, const LowerArgs &T,
+Stmt LowerNormalCopy(const CopyNode &op, const LowerArgs &lower_args,
                      arith::Analyzer *analyzer) {
-  bool is_cpu_target = T.target->GetTargetDeviceType() == kDLCPU;
+  bool is_cpu_target = lower_args.target->GetTargetDeviceType() == kDLCPU;
   auto simt_loop = op.MakeSIMTLoop(analyzer);
   auto fused_loop = Downcast<For>(ParallelLoopFuser::Fuse(simt_loop));
 
@@ -46,7 +46,7 @@ Stmt LowerNormalCopy(const CopyNode &op, const LowerArgs &T,
       bool dst_depends_on_thread = false;
       for (const auto &range : op.dst_range) {
         if (tirx::UsesVar(range->min, [&](const VarNode *v) {
-              return v == T.thread_var.get();
+              return v == lower_args.thread_var.get();
             })) {
           dst_depends_on_thread = true;
           break;
@@ -58,28 +58,28 @@ Stmt LowerNormalCopy(const CopyNode &op, const LowerArgs &T,
                       << "` may cause conflicted write.";
       }
     }
-    vectorized_thread_loop = VectorizeLoop(fused_loop, T.layout_map);
+    vectorized_thread_loop = VectorizeLoop(fused_loop, lower_args.layout_map);
     return vectorized_thread_loop;
   }
 
   std::vector<InferLevel> levels = {InferLevel::kCommon, InferLevel::kStrict,
                                     InferLevel::kFree};
   for (auto level : levels) {
-    par_op->InferLayout({T.target,
-                         T.thread_bounds,
-                         T.layout_map,
+    par_op->InferLayout({lower_args.target,
+                         lower_args.thread_bounds,
+                         lower_args.layout_map,
                          analyzer,
                          false,
-                         T.buffer_remap,
+                         lower_args.buffer_remap,
                          {}},
                         level);
   }
   auto loop_layout = par_op->GetLoopLayout();
-  return LowerParallelLoop(par_op->GetRoot(), loop_layout, T.thread_var,
-                           analyzer, T.layout_map,
-                           par_op->GetPredicate(T.thread_var),
-                           /*parallel_loop=*/true, /*should_vectorize=*/true,
-                           par_op->LoopLayoutRequiresPaddingGuard());
+  return LowerParallelLoop(
+      par_op->GetRoot(), loop_layout, lower_args.thread_var, analyzer,
+      lower_args.layout_map, par_op->GetPredicate(lower_args.thread_var),
+      /*parallel_loop=*/true, /*should_vectorize=*/true,
+      par_op->LoopLayoutRequiresPaddingGuard());
 }
 
 namespace {
@@ -106,14 +106,16 @@ const CopyImpl &ResolveCopyImpl(Target target) {
   return *best_impl;
 }
 
-LayoutMap InferCopyLayout(const CopyNode &op, const LayoutInferArgs &T,
+LayoutMap InferCopyLayout(const CopyNode &op,
+                          const LayoutInferArgs &layout_args,
                           InferLevel level) {
-  return ResolveCopyImpl(T.target).infer_layout(op, T, level);
+  return ResolveCopyImpl(layout_args.target)
+      .infer_layout(op, layout_args, level);
 }
 
-Stmt LowerCopyForTarget(const CopyNode &op, const LowerArgs &T,
+Stmt LowerCopyForTarget(const CopyNode &op, const LowerArgs &lower_args,
                         arith::Analyzer *analyzer) {
-  return ResolveCopyImpl(T.target).lower(op, T, analyzer);
+  return ResolveCopyImpl(lower_args.target).lower(op, lower_args, analyzer);
 }
 
 std::vector<Im2ColImpl> &Im2ColImplRegistry() {
@@ -138,14 +140,14 @@ const Im2ColImpl &ResolveIm2ColImpl(Target target) {
   return *best_impl;
 }
 
-Stmt LowerIm2ColForTarget(const Im2ColOpNode &op, const LowerArgs &T,
+Stmt LowerIm2ColForTarget(const Im2ColOpNode &op, const LowerArgs &lower_args,
                           arith::Analyzer *analyzer) {
-  return ResolveIm2ColImpl(T.target).lower(op, T, analyzer);
+  return ResolveIm2ColImpl(lower_args.target).lower(op, lower_args, analyzer);
 }
 
 bool MatchAnyIm2ColTarget(Target /*target*/) { return true; }
 
-Stmt LowerIm2ColSIMT(const Im2ColOpNode &op, const LowerArgs &T,
+Stmt LowerIm2ColSIMT(const Im2ColOpNode &op, const LowerArgs &lower_args,
                      arith::Analyzer *analyzer) {
   const Buffer &src = op.src_;
   const Buffer &dst = op.dst_;
@@ -216,21 +218,21 @@ Stmt LowerIm2ColSIMT(const Im2ColOpNode &op, const LowerArgs &T,
   std::vector<InferLevel> levels = {InferLevel::kCommon, InferLevel::kStrict,
                                     InferLevel::kFree};
   for (auto level : levels) {
-    par_op->InferLayout({T.target,
-                         T.thread_bounds,
-                         T.layout_map,
+    par_op->InferLayout({lower_args.target,
+                         lower_args.thread_bounds,
+                         lower_args.layout_map,
                          analyzer,
                          false,
-                         T.buffer_remap,
+                         lower_args.buffer_remap,
                          {}},
                         level);
   }
   auto loop_layout = par_op->GetLoopLayout();
-  return LowerParallelLoop(par_op->GetRoot(), loop_layout, T.thread_var,
-                           analyzer, T.layout_map,
-                           par_op->GetPredicate(T.thread_var),
-                           /*parallel_loop=*/true, /*should_vectorize=*/true,
-                           par_op->LoopLayoutRequiresPaddingGuard());
+  return LowerParallelLoop(
+      par_op->GetRoot(), loop_layout, lower_args.thread_var, analyzer,
+      lower_args.layout_map, par_op->GetPredicate(lower_args.thread_var),
+      /*parallel_loop=*/true, /*should_vectorize=*/true,
+      par_op->LoopLayoutRequiresPaddingGuard());
 }
 
 bool RegisterDefaultIm2Col() {
@@ -512,23 +514,24 @@ For CopyNode::MakeSIMTLoop(arith::Analyzer *analyzer) const {
   return Downcast<For>(body);
 }
 
-LayoutMap CopyNode::InferLayout(const LayoutInferArgs &T,
+LayoutMap CopyNode::InferLayout(const LayoutInferArgs &layout_args,
                                 InferLevel level) const {
-  return InferCopyLayout(*this, T, level);
+  return InferCopyLayout(*this, layout_args, level);
 }
 
-LayoutMap CopyNode::InferSIMTLayout(const LayoutInferArgs &T,
+LayoutMap CopyNode::InferSIMTLayout(const LayoutInferArgs &layout_args,
                                     InferLevel level) const {
   if (!par_op_.defined()) {
     arith::Analyzer analyzer;
     par_op_ = ParallelOp(MakeSIMTLoop(&analyzer));
   }
-  return par_op_->InferLayout(T, level);
+  return par_op_->InferLayout(layout_args, level);
 }
 // Lowers the copy operation by dispatching to the selected target
 // implementation.
-Stmt CopyNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
-  return LowerCopyForTarget(*this, T, analyzer);
+Stmt CopyNode::Lower(const LowerArgs &lower_args,
+                     arith::Analyzer *analyzer) const {
+  return LowerCopyForTarget(*this, lower_args, analyzer);
 }
 
 // Constructs an Im2ColOp node from call arguments.
@@ -560,8 +563,9 @@ TileOperator Im2ColOpNode::Clone() const {
   return Im2ColOp(op);
 }
 
-Stmt Im2ColOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
-  return LowerIm2ColForTarget(*this, T, analyzer);
+Stmt Im2ColOpNode::Lower(const LowerArgs &lower_args,
+                         arith::Analyzer *analyzer) const {
+  return LowerIm2ColForTarget(*this, lower_args, analyzer);
 }
 
 // Register the Copy operation with TVM's TIR system
@@ -604,7 +608,7 @@ TVM_REGISTER_OP("tl.tileop.tma_copy")
                                Integer(CallEffectKind::kOpaque));
 
 // Layout inference hook - returns empty map (no layout suggestions).
-LayoutMap Im2ColOpNode::InferLayout(const LayoutInferArgs &T,
+LayoutMap Im2ColOpNode::InferLayout(const LayoutInferArgs &layout_args,
                                     InferLevel level) const {
   return {};
 }

--- a/src/op/copy.h
+++ b/src/op/copy.h
@@ -57,23 +57,25 @@ public:
 
   /*!
    * \brief Lower the copy operator to a TIR statement.
-   * \param T        Arguments for lowering.
+   * \param lower_args Arguments for lowering.
    * \param analyzer Analyzer for simplification and bounds checks.
    */
-  Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const override;
+  Stmt Lower(const LowerArgs &lower_args,
+             arith::Analyzer *analyzer) const override;
 
   /*!
    * \brief Infer buffer layouts after applying this operator.
-   * \param T     Arguments for layout inference.
+   * \param layout_args Arguments for layout inference.
    * \param level Level of inference (basic or detailed).
    */
-  LayoutMap InferLayout(const LayoutInferArgs &T,
+  LayoutMap InferLayout(const LayoutInferArgs &layout_args,
                         InferLevel level) const override;
 
   /*!
    * \brief Infer layout through the generated SIMT copy loop.
    */
-  LayoutMap InferSIMTLayout(const LayoutInferArgs &T, InferLevel level) const;
+  LayoutMap InferSIMTLayout(const LayoutInferArgs &layout_args,
+                            InferLevel level) const;
 
   /*!
    * \brief Generate SIMT (thread-level) loop for copying.
@@ -131,16 +133,17 @@ struct CopyImpl {
   CopyTargetPredicate match_target;
   int priority;
 
-  LayoutMap (*infer_layout)(const CopyNode &op, const LayoutInferArgs &T,
+  LayoutMap (*infer_layout)(const CopyNode &op,
+                            const LayoutInferArgs &layout_args,
                             InferLevel level);
 
-  Stmt (*lower)(const CopyNode &op, const LowerArgs &T,
+  Stmt (*lower)(const CopyNode &op, const LowerArgs &lower_args,
                 arith::Analyzer *analyzer);
 };
 
 void RegisterCopyImpl(CopyImpl impl);
 
-Stmt LowerNormalCopy(const CopyNode &op, const LowerArgs &T,
+Stmt LowerNormalCopy(const CopyNode &op, const LowerArgs &lower_args,
                      arith::Analyzer *analyzer);
 
 class Copy : public TileOperator {
@@ -201,12 +204,13 @@ public:
   /*!
    * \brief Lower to TIR statement.
    */
-  Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const override;
+  Stmt Lower(const LowerArgs &lower_args,
+             arith::Analyzer *analyzer) const override;
 
   /*!
    * \brief Infer layout for this operator.
    */
-  LayoutMap InferLayout(const LayoutInferArgs &T,
+  LayoutMap InferLayout(const LayoutInferArgs &layout_args,
                         InferLevel level) const override;
 
   /*!
@@ -221,7 +225,7 @@ struct Im2ColImpl {
   CopyTargetPredicate match_target;
   int priority;
 
-  Stmt (*lower)(const Im2ColOpNode &op, const LowerArgs &T,
+  Stmt (*lower)(const Im2ColOpNode &op, const LowerArgs &lower_args,
                 arith::Analyzer *analyzer);
 };
 

--- a/src/op/fill.cc
+++ b/src/op/fill.cc
@@ -186,11 +186,13 @@ For FillNode::MakeSIMTLoop(arith::Analyzer *analyzer) const {
  * The lowering may query layout and thread information from @p T and uses the
  * provided analyzer for any required arithmetic/layout analysis.
  *
- * @param T Lowering arguments (target, thread bounds, thread var, layout map).
+ * @param lower_args Lowering arguments (target, thread bounds, thread var,
+ * layout map).
  * @return Stmt The lowered TIR statement implementing the fill.
  */
-Stmt FillNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
-  return ResolveFillImpl(T.target).lower(*this, T, analyzer);
+Stmt FillNode::Lower(const LowerArgs &lower_args,
+                     arith::Analyzer *analyzer) const {
+  return ResolveFillImpl(lower_args.target).lower(*this, lower_args, analyzer);
 }
 
 /**
@@ -200,11 +202,11 @@ Stmt FillNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
  * Currently no layout inference is performed for Fill and the function returns
  * an empty LayoutMap.
  *
- * @param T Context required for layout inference (unused).
+ * @param layout_args Context required for layout inference (unused).
  * @param level The inference level requested (unused).
  * @return LayoutMap Empty map indicating no inferred layouts for this operator.
  */
-LayoutMap FillNode::InferLayout(const LayoutInferArgs &T,
+LayoutMap FillNode::InferLayout(const LayoutInferArgs &layout_args,
                                 InferLevel level) const {
   return {};
 }

--- a/src/op/fill.h
+++ b/src/op/fill.h
@@ -23,8 +23,9 @@ public:
   ffi::Array<Range> region; ///< Region to fill within the buffer
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.Fill", FillNode, TileOperatorNode);
 
-  Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const override;
-  LayoutMap InferLayout(const LayoutInferArgs &T,
+  Stmt Lower(const LowerArgs &lower_args,
+             arith::Analyzer *analyzer) const override;
+  LayoutMap InferLayout(const LayoutInferArgs &layout_args,
                         InferLevel level) const override;
   static const Op &Get();
 
@@ -48,7 +49,7 @@ struct FillImpl {
   const char *name;
   FillTargetPredicate match_target;
 
-  Stmt (*lower)(const FillNode &op, const LowerArgs &T,
+  Stmt (*lower)(const FillNode &op, const LowerArgs &lower_args,
                 arith::Analyzer *analyzer);
 };
 

--- a/src/op/finalize_reducer.cc
+++ b/src/op/finalize_reducer.cc
@@ -90,9 +90,10 @@ FinalizeReducerOp::FinalizeReducerOp(
   data_ = std::move(node);
 }
 
-Stmt FinalizeReducerOpNode::Lower(const LowerArgs &T,
+Stmt FinalizeReducerOpNode::Lower(const LowerArgs &lower_args,
                                   arith::Analyzer *analyzer) const {
-  return ResolveFinalizeReducerImpl(T.target).lower(*this, T, analyzer);
+  return ResolveFinalizeReducerImpl(lower_args.target)
+      .lower(*this, lower_args, analyzer);
 }
 
 /**
@@ -102,16 +103,16 @@ Stmt FinalizeReducerOpNode::Lower(const LowerArgs &T,
  * into a new LayoutMap and returns it. The inference does not modify the
  * layout; it preserves the reducer's current layout.
  *
- * @param T Provides the input layout map from which the reducer's layout is
- * copied.
+ * @param layout_args Provides the input layout map from which the reducer's
+ * layout is copied.
  * @param level Unused by this operator; present for API compatibility.
  * @return LayoutMap A map that contains the reducer buffer mapped to its
  * original layout.
  */
-LayoutMap FinalizeReducerOpNode::InferLayout(const LayoutInferArgs &T,
+LayoutMap FinalizeReducerOpNode::InferLayout(const LayoutInferArgs &layout_args,
                                              InferLevel level) const {
   LayoutMap layout_map;
-  layout_map.Set(reducer, T.layout_map.Get(reducer).value());
+  layout_map.Set(reducer, layout_args.layout_map.Get(reducer).value());
   return layout_map;
 }
 

--- a/src/op/finalize_reducer.h
+++ b/src/op/finalize_reducer.h
@@ -42,8 +42,9 @@ public:
         .def_ro("batch", &FinalizeReducerOpNode::batch);
   }
 
-  Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const override;
-  LayoutMap InferLayout(const LayoutInferArgs &T,
+  Stmt Lower(const LowerArgs &lower_args,
+             arith::Analyzer *analyzer) const override;
+  LayoutMap InferLayout(const LayoutInferArgs &layout_args,
                         InferLevel level) const override;
   static const Op &Get();
   TileOperator Clone() const;
@@ -55,7 +56,7 @@ struct FinalizeReducerImpl {
   const char *name;
   FinalizeReducerTargetPredicate match_target;
 
-  Stmt (*lower)(const FinalizeReducerOpNode &op, const LowerArgs &T,
+  Stmt (*lower)(const FinalizeReducerOpNode &op, const LowerArgs &lower_args,
                 arith::Analyzer *analyzer);
 };
 

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -173,17 +173,18 @@ std::pair<int, int> GemmWarpPolicyNode::computeWarpPartition(
                                                         target, gemm_inst);
 }
 
-Stmt GemmNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
+Stmt GemmNode::Lower(const LowerArgs &lower_args,
+                     arith::Analyzer *analyzer) const {
   if (const auto f = Function::GetGlobal("tl.gemm.lower")) {
-    PrimExpr mbar_phase = T.mbar_phase_expr;
+    PrimExpr mbar_phase = lower_args.mbar_phase_expr;
     if (auto explicit_phase = GetAnnotatedMbarPhaseExpr(annotations_)) {
       mbar_phase = explicit_phase.value();
     }
     // NOTE(wt): Decide the instruction key and compute warp partition on Python
     // side.
-    auto prim_func =
-        Downcast<PrimFunc>((*f)(GetRef<Gemm>(this), T.layout_map, T.target,
-                                T.thread_bounds, T.thread_var, mbar_phase));
+    auto prim_func = Downcast<PrimFunc>(
+        (*f)(GetRef<Gemm>(this), lower_args.layout_map, lower_args.target,
+             lower_args.thread_bounds, lower_args.thread_var, mbar_phase));
     ICHECK(prim_func->attrs.defined());
     auto global_symbol = prim_func->attrs.GetAttr<String>("global_symbol");
     ICHECK(global_symbol.has_value());
@@ -217,32 +218,34 @@ Stmt GemmNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
   }
 }
 
-LayoutMap GemmNode::InferLayout(const LayoutInferArgs &T,
+LayoutMap GemmNode::InferLayout(const LayoutInferArgs &layout_args,
                                 InferLevel level) const {
   if (completed_)
     return {};
   LayoutMap results;
   if (const auto f = Function::GetGlobal("tl.gemm.infer_layout")) {
-    auto inferred_layouts = Downcast<LayoutMap>(
-        (*f)(GetRef<Gemm>(this), T.target, T.thread_bounds));
+    auto inferred_layouts = Downcast<LayoutMap>((*f)(
+        GetRef<Gemm>(this), layout_args.target, layout_args.thread_bounds));
     // For MMA instructions, skip shared buffer layouts that are already
     // inferred by a prior operator to avoid layout conflicts when the same
     // shared buffer is consumed by multiple gemm ops with different transpose
     // semantics. WGMMA/TCGEN5MMA have strict shared memory layout requirements
     // and must always set their layouts.
-    auto block_size = *as_const_int(T.thread_bounds->extent);
-    String gemm_inst = getGemmInstructionKey(block_size, T.target);
+    auto block_size = *as_const_int(layout_args.thread_bounds->extent);
+    String gemm_inst = getGemmInstructionKey(block_size, layout_args.target);
     bool reuse_existing_shared_layout =
-        ResolveGemmImpl(T.target).reuse_existing_shared_layout(gemm_inst);
+        ResolveGemmImpl(layout_args.target)
+            .reuse_existing_shared_layout(gemm_inst);
     for (auto kv : inferred_layouts) {
       const Buffer &buf = kv.first;
       const Layout &layout = kv.second;
       if (reuse_existing_shared_layout && IsSharedBuffer(buf) &&
-          T.layout_map.count(buf)) {
+          layout_args.layout_map.count(buf)) {
         continue;
       }
       if (auto frag = layout.as<Fragment>()) {
-        results.Set(buf, frag.value()->BindThreadRange(T.thread_bounds));
+        results.Set(buf,
+                    frag.value()->BindThreadRange(layout_args.thread_bounds));
       } else {
         results.Set(buf, layout);
       }

--- a/src/op/gemm.h
+++ b/src/op/gemm.h
@@ -157,8 +157,9 @@ public:
         .def_ro("sfKStart", &GemmNode::sfKStart_);
   }
 
-  Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const override;
-  LayoutMap InferLayout(const LayoutInferArgs &T,
+  Stmt Lower(const LowerArgs &lower_args,
+             arith::Analyzer *analyzer) const override;
+  LayoutMap InferLayout(const LayoutInferArgs &layout_args,
                         InferLevel level) const override;
   AccessRegions GetAccessRegions() const override;
 

--- a/src/op/gemm_sp.cc
+++ b/src/op/gemm_sp.cc
@@ -161,11 +161,12 @@ String GemmSPNode::getGemmSPInstructionKey(int block_size,
   return ResolveGemmSPImpl(target).select_inst(*this, block_size, target);
 }
 
-Stmt GemmSPNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
+Stmt GemmSPNode::Lower(const LowerArgs &lower_args,
+                       arith::Analyzer *analyzer) const {
   if (const auto f = Function::GetGlobal("tl.gemm_sp.lower")) {
-    auto prim_func =
-        Downcast<PrimFunc>((*f)(GetRef<GemmSP>(this), T.target, T.layout_map,
-                                T.thread_bounds, T.thread_var));
+    auto prim_func = Downcast<PrimFunc>(
+        (*f)(GetRef<GemmSP>(this), lower_args.target, lower_args.layout_map,
+             lower_args.thread_bounds, lower_args.thread_var));
     ICHECK(prim_func->attrs.defined());
     auto global_symbol = prim_func->attrs.GetAttr<String>("global_symbol");
     ICHECK(global_symbol.has_value());
@@ -199,27 +200,29 @@ Stmt GemmSPNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
   }
 }
 
-LayoutMap GemmSPNode::InferLayout(const LayoutInferArgs &T,
+LayoutMap GemmSPNode::InferLayout(const LayoutInferArgs &layout_args,
                                   InferLevel level) const {
   if (completed_)
     return {};
   LayoutMap results;
   if (const auto f = Function::GetGlobal("tl.gemm_sp.infer_layout")) {
-    auto inferred_layouts = Downcast<LayoutMap>(
-        (*f)(GetRef<GemmSP>(this), T.target, T.thread_bounds));
-    auto block_size = *as_const_int(T.thread_bounds->extent);
-    String gemm_inst = getGemmSPInstructionKey(block_size, T.target);
+    auto inferred_layouts = Downcast<LayoutMap>((*f)(
+        GetRef<GemmSP>(this), layout_args.target, layout_args.thread_bounds));
+    auto block_size = *as_const_int(layout_args.thread_bounds->extent);
+    String gemm_inst = getGemmSPInstructionKey(block_size, layout_args.target);
     bool reuse_existing_shared_layout =
-        ResolveGemmSPImpl(T.target).reuse_existing_shared_layout(gemm_inst);
+        ResolveGemmSPImpl(layout_args.target)
+            .reuse_existing_shared_layout(gemm_inst);
     for (auto kv : inferred_layouts) {
       const Buffer &buf = kv.first;
       const Layout &layout = kv.second;
       if (reuse_existing_shared_layout && IsSharedBuffer(buf) &&
-          T.layout_map.count(buf)) {
+          layout_args.layout_map.count(buf)) {
         continue;
       }
       if (auto frag = layout.as<Fragment>()) {
-        results.Set(buf, frag.value()->BindThreadRange(T.thread_bounds));
+        results.Set(buf,
+                    frag.value()->BindThreadRange(layout_args.thread_bounds));
       } else {
         results.Set(buf, layout);
       }

--- a/src/op/gemm_sp.h
+++ b/src/op/gemm_sp.h
@@ -126,8 +126,9 @@ public:
         .def_ro("policy", &GemmSPNode::policy);
   }
 
-  Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const override;
-  LayoutMap InferLayout(const LayoutInferArgs &T,
+  Stmt Lower(const LowerArgs &lower_args,
+             arith::Analyzer *analyzer) const override;
+  LayoutMap InferLayout(const LayoutInferArgs &layout_args,
                         InferLevel level) const override;
   AccessRegions GetAccessRegions() const override;
 

--- a/src/op/operator.h
+++ b/src/op/operator.h
@@ -147,10 +147,10 @@ class TileOperator;
 
 class TileOperatorNode : public ffi::Object {
 public:
-  virtual tirx::Stmt Lower(const LowerArgs &T,
+  virtual tirx::Stmt Lower(const LowerArgs &lower_args,
                            arith::Analyzer *analyzer) const = 0;
 
-  virtual LayoutMap InferLayout(const LayoutInferArgs &T,
+  virtual LayoutMap InferLayout(const LayoutInferArgs &layout_args,
                                 InferLevel level) const = 0;
 
   virtual TileOperator Clone() const = 0;

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -290,7 +290,7 @@ bool ParallelOpNode::IsBufferCompletelyReplicated(
   return frag->IsCompletedReplicated();
 }
 
-Stmt ParallelOpNode::Lower(const LowerArgs &T,
+Stmt ParallelOpNode::Lower(const LowerArgs &lower_args,
                            arith::Analyzer *analyzer) const {
   return root_;
 }
@@ -320,15 +320,16 @@ bool ParallelOpNode::IsCommonAccessIndice(const Buffer &buffer) const {
  *                Can generate new layouts based on vectorization and thread
  * bounds. Used when maximum performance optimization is desired.
  */
-LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
+LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &layout_args,
                                       InferLevel level) const {
   if (loop_layout_inferred_)
     return {};
   loop_layout_requires_padding_guard_ = false;
 
   // Expand Bind values to find fragment buffer accesses
-  if (!T.bind_var_to_expr.empty()) {
-    const_cast<ParallelOpNode *>(this)->ExpandBindValues(T.bind_var_to_expr);
+  if (!layout_args.bind_var_to_expr.empty()) {
+    const_cast<ParallelOpNode *>(this)->ExpandBindValues(
+        layout_args.bind_var_to_expr);
   }
 
   if (level == InferLevel::kStrict) {
@@ -340,7 +341,7 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
     // then fragment[0] must be replicated on all threads.
     for (const auto &buffer : access_order_) {
       const auto &access = GetAccessInfo(buffer);
-      if (T.layout_map.count(buffer)) {
+      if (layout_args.layout_map.count(buffer)) {
         continue;
       }
       if (!IsFragmentBuffer(buffer))
@@ -371,8 +372,8 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
               IterVar(Range(0, s), Var(), IterVarType::kDataPar));
         }
         Var rep;
-        auto rep_iter =
-            IterVar({0, T.thread_bounds->extent}, rep, IterVarType::kDataPar);
+        auto rep_iter = IterVar({0, layout_args.thread_bounds->extent}, rep,
+                                IterVarType::kDataPar);
 
         // Use default fragment indexing (single output dim) to
         // stay consistent with other ops (e.g., ReduceOp), and
@@ -380,7 +381,7 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
         const PrimExpr &forward_thread = rep;
         auto frag = Fragment(forward_vars, /*forward_index=*/{}, forward_thread,
                              rep_iter)
-                        ->BindThreadRange(T.thread_bounds);
+                        ->BindThreadRange(layout_args.thread_bounds);
         results.Set(buffer, frag);
       }
     }
@@ -427,14 +428,14 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
 
   for (const auto &buffer : access_order_) {
     const auto &access = GetAccessInfo(buffer);
-    if (T.layout_map.count(buffer)) {
+    if (layout_args.layout_map.count(buffer)) {
       // skip reducers with rep=ALL
       if (auto info = reducer_info_map_.Get(buffer->data);
           info && info.value()->rep == ReducerRepType::ALL)
         continue;
 
       bool is_fully_replicated =
-          IsBufferCompletelyReplicated(buffer, T.layout_map);
+          IsBufferCompletelyReplicated(buffer, layout_args.layout_map);
 
       if (access.is_write) {
         source_buffer = buffer;
@@ -453,7 +454,7 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
         // If the buffer is not replicated and shape is equal to the
         // source_buffer, use it as source_buffer because the layout inference
         // is more accurate
-        auto frag = T.layout_map[buffer].as<Fragment>();
+        auto frag = layout_args.layout_map[buffer].as<Fragment>();
         if (frag.has_value() && is_one(frag.value()->ReplicateExtent()) &&
             !source_buffer.defined()) {
           source_buffer = buffer;
@@ -472,15 +473,15 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
   // 4. Fully replicated write buffer (backup, may cause issues)
   // 5. Free inference mode (no source buffer)
   if (!loop_layout_.defined() && annotated_layout_unbound_.defined()) {
-    loop_layout_ =
-        annotated_layout_unbound_.value()->BindThreadRange(T.thread_bounds);
+    loop_layout_ = annotated_layout_unbound_.value()->BindThreadRange(
+        layout_args.thread_bounds);
     loop_layout_requires_padding_guard_ = annotated_requires_padding_guard_;
     if (annotated_predicate_.defined()) {
       predicate_ = annotated_predicate_.value();
     }
   } else if (!loop_layout_.defined() && source_buffer.defined() &&
              (allow_layout_propgate || source_buffer_is_write)) {
-    loop_layout_ = ComputeLoopLayoutFromBuffer(source_buffer, T);
+    loop_layout_ = ComputeLoopLayoutFromBuffer(source_buffer, layout_args);
   } else if (!loop_layout_.defined() && level == InferLevel::kFree) {
     // For free layout inference
     // In free inference, try two mechanisms and prefer the one that
@@ -493,18 +494,18 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
 
     if (read_source_buffer.defined() && allow_layout_propgate) {
       candidate_from_buffer =
-          ComputeLoopLayoutFromBuffer(read_source_buffer, T);
+          ComputeLoopLayoutFromBuffer(read_source_buffer, layout_args);
     }
 
     // try to infer loop layout with two mechanisms and choose the best one
     {
-      candidate_from_plan = ComputePlanCandidate(T);
+      candidate_from_plan = ComputePlanCandidate(layout_args);
     }
 
     // Choose the best candidate:
     if (candidate_from_buffer.defined() && candidate_from_plan.defined()) {
-      loop_layout_ =
-          ChooseBestCandidate(candidate_from_buffer, candidate_from_plan, T);
+      loop_layout_ = ChooseBestCandidate(candidate_from_buffer,
+                                         candidate_from_plan, layout_args);
     } else if (candidate_from_plan.defined()) {
       loop_layout_ = candidate_from_plan;
       selected_plan_candidate = true;
@@ -538,7 +539,7 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
 
   PrimExpr loop_thread_extent = loop_layout_->ThreadExtent();
 
-  auto block_size = T.thread_bounds->extent;
+  auto block_size = layout_args.thread_bounds->extent;
   if (loop_layout_.defined()) {
     if (loop_layout_->ThreadRange().defined()) {
       auto thread_range = loop_layout_->ThreadRange();
@@ -550,27 +551,27 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &T,
   }
 
   if (!analyzer_.CanProveEqual(loop_thread_extent, block_size)) {
-    AddPredicate(
-        LT(InputPlaceholder(0), loop_thread_extent + T.thread_bounds->min));
+    AddPredicate(LT(InputPlaceholder(0),
+                    loop_thread_extent + layout_args.thread_bounds->min));
   }
 
   // Step 2: Check that the loop's partition can correctly align with all source
   // fragment, and infer layout only when it's not yet layout-ed.
-  ValidateCandidateAgainstFragments(loop_layout_, T, /*throw_on_error=*/true,
-                                    /*check_forward_index=*/false,
-                                    source_buffer);
+  ValidateCandidateAgainstFragments(
+      loop_layout_, layout_args, /*throw_on_error=*/true,
+      /*check_forward_index=*/false, source_buffer);
 
   // Step 3: Build replication guards
   BuildReplicationGuardsIfNeeded(
-      T, store_shared_global_buffers_, store_fragment_buffers_,
+      layout_args, store_shared_global_buffers_, store_fragment_buffers_,
       has_cross_thread_access_, const_index_fragment_buffer);
 
   // Step 4: Collect buffer fragments
   LayoutMap results;
   for (const auto &buffer : access_order_) {
-    if (!T.layout_map.count(buffer)) {
-      auto dst_layout =
-          CompleteBufferFragment(buffer)->BindThreadRange(T.thread_bounds);
+    if (!layout_args.layout_map.count(buffer)) {
+      auto dst_layout = CompleteBufferFragment(buffer)->BindThreadRange(
+          layout_args.thread_bounds);
       results.Set(buffer, dst_layout);
     }
   }
@@ -643,18 +644,19 @@ Fragment ParallelOpNode::CompleteBufferFragment(const Buffer &buffer) const {
 TVM_FFI_STATIC_INIT_BLOCK() { ParallelOpNode::RegisterReflection(); }
 
 bool ParallelOpNode::ValidateCandidateAgainstFragments(
-    const Fragment &candidate, const LayoutInferArgs &T, bool throw_on_error,
-    bool check_forward_index, const Buffer &source_buffer) const {
+    const Fragment &candidate, const LayoutInferArgs &layout_args,
+    bool throw_on_error, bool check_forward_index,
+    const Buffer &source_buffer) const {
   auto vars =
       loop_vars_.Map([](const IterVar &iv) { return PrimExpr(iv->var); });
   for (const auto &buffer : access_order_) {
     const auto &access = GetAccessInfo(buffer);
-    if (!T.layout_map.count(buffer))
+    if (!layout_args.layout_map.count(buffer))
       continue;
     if (auto info = reducer_info_map_.Get(buffer->data);
         info && info.value()->rep == ReducerRepType::ALL)
       continue;
-    auto fragment = T.layout_map[buffer].as<Fragment>().value();
+    auto fragment = layout_args.layout_map[buffer].as<Fragment>().value();
     std::ostringstream oss;
     bool success = true;
     if (access.is_read &&
@@ -694,10 +696,9 @@ bool ParallelOpNode::ValidateCandidateAgainstFragments(
   return true;
 }
 
-Fragment
-ParallelOpNode::ComputeLoopLayoutFromBuffer(const Buffer &buffer,
-                                            const LayoutInferArgs &T) const {
-  Fragment src_layout = T.layout_map[buffer].as<Fragment>().value();
+Fragment ParallelOpNode::ComputeLoopLayoutFromBuffer(
+    const Buffer &buffer, const LayoutInferArgs &layout_args) const {
+  Fragment src_layout = layout_args.layout_map[buffer].as<Fragment>().value();
   DLOG(INFO) << "[compute_loop_layout_from_buffer] infer from buffer `"
              << buffer << "` of layout " << src_layout->DebugOutput() << '\n';
 
@@ -724,7 +725,7 @@ ParallelOpNode::ComputeLoopLayoutFromBuffer(const Buffer &buffer,
 
     try {
       result = Fragment(loop_vars_, {}, loop_var_to_thread, rep_iter)
-                   ->BindThreadRange(T.thread_bounds);
+                   ->BindThreadRange(layout_args.thread_bounds);
     } catch (const Error &err) {
       std::ostringstream msg;
       msg << "Layout inference for buffer `" << buffer->name
@@ -751,13 +752,14 @@ ParallelOpNode::ComputeLoopLayoutFromBuffer(const Buffer &buffer,
   return result;
 }
 
-Fragment ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &T) const {
+Fragment
+ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &layout_args) const {
   // Vectorize Size must be aware of the buffer_remap
   // As the pass will do post processing to the layout
-  auto maybe_remapped_root_ =
-      IfBufferRemapLoopGenerator::run(root_, T.buffer_remap, T.layout_map);
-  int vector_size =
-      GetVectorizeSize(maybe_remapped_root_, T.analyzer, T.layout_map);
+  auto maybe_remapped_root_ = IfBufferRemapLoopGenerator::run(
+      root_, layout_args.buffer_remap, layout_args.layout_map);
+  int vector_size = GetVectorizeSize(maybe_remapped_root_, layout_args.analyzer,
+                                     layout_args.layout_map);
   DLOG(INFO) << "[PlanLoopPartition] vector_size = " << vector_size << '\n';
 
   PrimExpr loop_total_size = 1;
@@ -767,15 +769,16 @@ Fragment ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &T) const {
              << '\n';
   bool has_fragment_access = !indice_map_.empty();
   if (has_fragment_access) {
-    while (
-        !analyzer_.CanProve(floormod(loop_total_size, T.thread_bounds->extent *
-                                                          vector_size) == 0) &&
-        vector_size > 1) {
+    while (!analyzer_.CanProve(
+               floormod(loop_total_size, layout_args.thread_bounds->extent *
+                                             vector_size) == 0) &&
+           vector_size > 1) {
       vector_size /= 2;
     }
   } else if (!root_->annotations.count(attr::kCoalescedWidth)) {
-    vector_size = SelectMinPaddingVectorSize(
-        vector_size, loop_total_size, T.thread_bounds->extent, &analyzer_);
+    vector_size = SelectMinPaddingVectorSize(vector_size, loop_total_size,
+                                             layout_args.thread_bounds->extent,
+                                             &analyzer_);
   }
   DLOG(INFO) << "[PlanLoopPartition] after adjust: vector_size = "
              << vector_size << '\n';
@@ -796,15 +799,15 @@ Fragment ParallelOpNode::ComputePlanCandidate(const LayoutInferArgs &T) const {
   }
   DLOG(INFO) << "[PlanLoopPartition] root_ = " << root_
              << " ############# vector_size = " << vector_size
-             << ", thread_bounds = " << T.thread_bounds << '\n';
-  auto plan = PlanLoopPartition(root_, vector_size, T.thread_bounds);
+             << ", thread_bounds = " << layout_args.thread_bounds << '\n';
+  auto plan = PlanLoopPartition(root_, vector_size, layout_args.thread_bounds);
   DLOG(INFO) << "[PlanLoopPartition] candidate = " << plan->DebugOutput()
              << '\n';
   return plan;
 }
 
 void ParallelOpNode::BuildReplicationGuardsIfNeeded(
-    const LayoutInferArgs &T,
+    const LayoutInferArgs &layout_args,
     const std::vector<Buffer> &store_shared_global_buffers,
     const std::vector<Buffer> &store_fragment_buffers,
     bool has_cross_thread_access,
@@ -817,11 +820,12 @@ void ParallelOpNode::BuildReplicationGuardsIfNeeded(
   if (!store_fragment_buffers.empty()) {
     bool replicate_is_from_dynamic_index_fragment = false;
     for (const auto &fragment : store_fragment_buffers) {
-      if (!T.layout_map.count(fragment)) {
+      if (!layout_args.layout_map.count(fragment)) {
         continue;
       }
 
-      auto fragment_layout = T.layout_map[fragment].as<Fragment>().value();
+      auto fragment_layout =
+          layout_args.layout_map[fragment].as<Fragment>().value();
       if (is_one(fragment_layout->ReplicateExtent()))
         continue;
 
@@ -847,7 +851,7 @@ void ParallelOpNode::BuildReplicationGuardsIfNeeded(
     Array<PrimExpr> fwd;
     for (size_t i = 0; i < loop_layout_->OutputDim(); i++)
       fwd.push_back(0);
-    fwd.push_back(InputPlaceholder(0) - T.thread_bounds->min);
+    fwd.push_back(InputPlaceholder(0) - layout_args.thread_bounds->min);
     auto rep = inv->Forward(fwd).back();
     AddPredicate(EQ(rep, 0));
   }
@@ -855,7 +859,7 @@ void ParallelOpNode::BuildReplicationGuardsIfNeeded(
 Fragment
 ParallelOpNode::ChooseBestCandidate(const Fragment &candidate_from_buffer,
                                     const Fragment &candidate_from_plan,
-                                    const LayoutInferArgs &T) const {
+                                    const LayoutInferArgs &layout_args) const {
   // Strategy overview:
   // 1) Validate each candidate against all known source fragments. If only one
   //    is compatible, choose it immediately.
@@ -874,8 +878,10 @@ ParallelOpNode::ChooseBestCandidate(const Fragment &candidate_from_buffer,
     return ProveFragmentContains(small, big, vars, vars, analyzer_);
   };
 
-  bool buf_ok = ValidateCandidateAgainstFragments(candidate_from_buffer, T);
-  bool plan_ok = ValidateCandidateAgainstFragments(candidate_from_plan, T);
+  bool buf_ok =
+      ValidateCandidateAgainstFragments(candidate_from_buffer, layout_args);
+  bool plan_ok =
+      ValidateCandidateAgainstFragments(candidate_from_plan, layout_args);
 
   if (buf_ok && !plan_ok) {
     DLOG(INFO)

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -95,10 +95,11 @@ public:
   ParallelOpNode(For root);
 
   // Lower the operator to a TIR statement.
-  Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const override;
+  Stmt Lower(const LowerArgs &lower_args,
+             arith::Analyzer *analyzer) const override;
 
   // Infer the layout for this parallel operator.
-  LayoutMap InferLayout(const LayoutInferArgs &T,
+  LayoutMap InferLayout(const LayoutInferArgs &layout_args,
                         InferLevel level) const override;
 
   // Copy constructor for ParallelOpNode.
@@ -148,25 +149,26 @@ private:
   // false. When throw_on_error is true, throws LayoutConflictException with
   // detailed error message on failure.
   bool ValidateCandidateAgainstFragments(
-      const Fragment &candidate, const LayoutInferArgs &T,
+      const Fragment &candidate, const LayoutInferArgs &layout_args,
       bool throw_on_error = false, bool check_forward_index = false,
       const Buffer &source_buffer = Buffer()) const;
   // Choose the better loop layout from two candidates using validation,
   // containment and replication heuristic.
   Fragment ChooseBestCandidate(const Fragment &candidate_from_buffer,
                                const Fragment &candidate_from_plan,
-                               const LayoutInferArgs &T) const;
+                               const LayoutInferArgs &layout_args) const;
   // (No helper needed anymore; annotations are parsed once in ctor and adopted
   // inside InferLayout.)
   // Compute loop layout from a source buffer's fragment mapping.
-  Fragment ComputeLoopLayoutFromBuffer(const Buffer &buffer,
-                                       const LayoutInferArgs &T) const;
+  Fragment
+  ComputeLoopLayoutFromBuffer(const Buffer &buffer,
+                              const LayoutInferArgs &layout_args) const;
   // Compute plan-based loop layout candidate using vectorization and thread
   // bounds.
-  Fragment ComputePlanCandidate(const LayoutInferArgs &T) const;
+  Fragment ComputePlanCandidate(const LayoutInferArgs &layout_args) const;
   // Add replication guard predicates when needed for cross-thread stores.
   void BuildReplicationGuardsIfNeeded(
-      const LayoutInferArgs &T,
+      const LayoutInferArgs &layout_args,
       const std::vector<Buffer> &store_shared_global_buffers,
       const std::vector<Buffer> &store_fragment_buffers,
       bool has_cross_thread_access,

--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -179,32 +179,34 @@ static Fragment ComputeReducerLayout(const Fragment &src_layout, int dim) {
  *   dimensions and partitioned by the lowering thread variable. If a temporary
  *   clear buffer is used, it is allocated for the body.
  *
- * @param T Lowering context providing buffer and layout maps, thread bounds,
- *          target information, thread variable, and workspace allocation
- * helper.
+ * @param lower_args Lowering context providing buffer and layout maps, thread
+ * bounds, target information, thread variable, and workspace allocation helper.
  * @param analyzer Analyzer used for iterator compression and arithmetic
  * normalization.
  * @return Stmt Lowered TIR statement implementing the reduction.
  */
-Stmt ReduceOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
-  return ResolveReduceImpl(T.target).lower(*this, T, analyzer);
+Stmt ReduceOpNode::Lower(const LowerArgs &lower_args,
+                         arith::Analyzer *analyzer) const {
+  return ResolveReduceImpl(lower_args.target)
+      .lower(*this, lower_args, analyzer);
 }
 
-LayoutMap ReduceOpNode::InferLayout(const LayoutInferArgs &T,
+LayoutMap ReduceOpNode::InferLayout(const LayoutInferArgs &layout_args,
                                     InferLevel level) const {
   if (level >= InferLevel::kStrict)
     return {};
 
   if (IsFragmentBuffer(src) && IsFragmentBuffer(dst) &&
-      T.layout_map.count(src)) {
-    auto src_layout = T.layout_map[src].as<Fragment>().value();
+      layout_args.layout_map.count(src)) {
+    auto src_layout = layout_args.layout_map[src].as<Fragment>().value();
     auto reducer_layout = ComputeReducerLayout(src_layout, this->dim);
 
-    if (!T.layout_map.count(dst)) {
+    if (!layout_args.layout_map.count(dst)) {
       return {{dst, reducer_layout}};
     }
 
-    auto orig_dst_layout = T.layout_map.Get(dst).value().as<Fragment>().value();
+    auto orig_dst_layout =
+        layout_args.layout_map.Get(dst).value().as<Fragment>().value();
     ICHECK(reducer_layout->InputDim() == orig_dst_layout->InputDim());
 
     auto indices = InputPlaceholders(reducer_layout->InputDim());

--- a/src/op/reduce.h
+++ b/src/op/reduce.h
@@ -121,9 +121,10 @@ public:
   }
 
   /// Lower the operator to TIR statements
-  Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const override;
+  Stmt Lower(const LowerArgs &lower_args,
+             arith::Analyzer *analyzer) const override;
   /// Infer memory layout for buffers
-  LayoutMap InferLayout(const LayoutInferArgs &T,
+  LayoutMap InferLayout(const LayoutInferArgs &layout_args,
                         InferLevel level) const override;
   AccessRegions GetAccessRegions() const override;
   static const Op &Get();
@@ -136,7 +137,7 @@ struct ReduceImpl {
   const char *name;
   ReduceTargetPredicate match_target;
 
-  Stmt (*lower)(const ReduceOpNode &op, const LowerArgs &T,
+  Stmt (*lower)(const ReduceOpNode &op, const LowerArgs &lower_args,
                 arith::Analyzer *analyzer);
 };
 

--- a/src/op/region.cc
+++ b/src/op/region.cc
@@ -70,11 +70,12 @@ bool RegionOpNode::IsFullRegion() const {
   return true;
 }
 
-Stmt RegionOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
+Stmt RegionOpNode::Lower(const LowerArgs &lower_args,
+                         arith::Analyzer *analyzer) const {
   return Evaluate(0);
 }
 
-LayoutMap RegionOpNode::InferLayout(const LayoutInferArgs &T,
+LayoutMap RegionOpNode::InferLayout(const LayoutInferArgs &layout_args,
                                     InferLevel level) const {
   return {};
 }

--- a/src/op/region.h
+++ b/src/op/region.h
@@ -53,8 +53,9 @@ public:
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.RegionOp", RegionOpNode,
                                     TileOperatorNode);
 
-  Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const override;
-  LayoutMap InferLayout(const LayoutInferArgs &T,
+  Stmt Lower(const LowerArgs &lower_args,
+             arith::Analyzer *analyzer) const override;
+  LayoutMap InferLayout(const LayoutInferArgs &layout_args,
                         InferLevel level) const override;
 
   const Buffer &GetBuffer() const { return buffer_; }

--- a/src/op/scan.cc
+++ b/src/op/scan.cc
@@ -71,8 +71,9 @@ void InitScanOpNode(ScanOpNode *node, const Array<PrimExpr> &args,
 }
 
 template <typename ScanOpNode>
-LayoutMap InferScanLayout(const ScanOpNode &op, const LayoutInferArgs &T,
-                          InferLevel level, const char *pretty_name) {
+LayoutMap InferScanLayout(const ScanOpNode &op,
+                          const LayoutInferArgs &layout_args, InferLevel level,
+                          const char *pretty_name) {
   if (level != InferLevel::kStrict) {
     return {};
   }
@@ -88,8 +89,9 @@ LayoutMap InferScanLayout(const ScanOpNode &op, const LayoutInferArgs &T,
       return;
 
     Layout linear_layout = make_linear_layout(buf);
-    if (T.layout_map.count(buf)) {
-      Layout existing = T.layout_map.Get(buf).value().as<Layout>().value();
+    if (layout_args.layout_map.count(buf)) {
+      Layout existing =
+          layout_args.layout_map.Get(buf).value().as<Layout>().value();
       ICHECK(StructuralEqual()(existing, linear_layout))
           << pretty_name << " requires linear layout for shared buffer "
           << buf->name << ", but got non-linear layout.";
@@ -136,14 +138,15 @@ CumSumOp::CumSumOp(Array<PrimExpr> args, Map<String, ObjectRef> annotations) {
   data_ = std::move(node);
 }
 
-Stmt CumSumOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
-  return ResolveScanImpl<CumSumImpl>(T.target, "cumsum")
-      .lower(*this, T, analyzer);
+Stmt CumSumOpNode::Lower(const LowerArgs &lower_args,
+                         arith::Analyzer *analyzer) const {
+  return ResolveScanImpl<CumSumImpl>(lower_args.target, "cumsum")
+      .lower(*this, lower_args, analyzer);
 }
 
-LayoutMap CumSumOpNode::InferLayout(const LayoutInferArgs &T,
+LayoutMap CumSumOpNode::InferLayout(const LayoutInferArgs &layout_args,
                                     InferLevel level) const {
-  return InferScanLayout(*this, T, level, "CumSum");
+  return InferScanLayout(*this, layout_args, level, "CumSum");
 }
 
 TIR_REGISTER_TL_TILE_OP(CumSumOp, cumsum)
@@ -157,14 +160,15 @@ CumMaxOp::CumMaxOp(Array<PrimExpr> args, Map<String, ObjectRef> annotations) {
   data_ = std::move(node);
 }
 
-Stmt CumMaxOpNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
-  return ResolveScanImpl<CumMaxImpl>(T.target, "cummax")
-      .lower(*this, T, analyzer);
+Stmt CumMaxOpNode::Lower(const LowerArgs &lower_args,
+                         arith::Analyzer *analyzer) const {
+  return ResolveScanImpl<CumMaxImpl>(lower_args.target, "cummax")
+      .lower(*this, lower_args, analyzer);
 }
 
-LayoutMap CumMaxOpNode::InferLayout(const LayoutInferArgs &T,
+LayoutMap CumMaxOpNode::InferLayout(const LayoutInferArgs &layout_args,
                                     InferLevel level) const {
-  return InferScanLayout(*this, T, level, "CumMax");
+  return InferScanLayout(*this, layout_args, level, "CumMax");
 }
 
 TIR_REGISTER_TL_TILE_OP(CumMaxOp, cummax)

--- a/src/op/scan.h
+++ b/src/op/scan.h
@@ -35,8 +35,9 @@ public:
         .def_ro("reverse", &CumSumOpNode::reverse);
   }
 
-  Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const override;
-  LayoutMap InferLayout(const LayoutInferArgs &T,
+  Stmt Lower(const LowerArgs &lower_args,
+             arith::Analyzer *analyzer) const override;
+  LayoutMap InferLayout(const LayoutInferArgs &layout_args,
                         InferLevel level) const override;
   static const Op &Get();
   TileOperator Clone() const;
@@ -48,7 +49,7 @@ struct CumSumImpl {
   const char *name;
   CumSumTargetPredicate match_target;
 
-  Stmt (*lower)(const CumSumOpNode &op, const LowerArgs &T,
+  Stmt (*lower)(const CumSumOpNode &op, const LowerArgs &lower_args,
                 arith::Analyzer *analyzer);
 };
 
@@ -86,8 +87,9 @@ public:
         .def_ro("reverse", &CumMaxOpNode::reverse);
   }
 
-  Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const override;
-  LayoutMap InferLayout(const LayoutInferArgs &T,
+  Stmt Lower(const LowerArgs &lower_args,
+             arith::Analyzer *analyzer) const override;
+  LayoutMap InferLayout(const LayoutInferArgs &layout_args,
                         InferLevel level) const override;
   static const Op &Get();
   TileOperator Clone() const;
@@ -99,7 +101,7 @@ struct CumMaxImpl {
   const char *name;
   CumMaxTargetPredicate match_target;
 
-  Stmt (*lower)(const CumMaxOpNode &op, const LowerArgs &T,
+  Stmt (*lower)(const CumMaxOpNode &op, const LowerArgs &lower_args,
                 arith::Analyzer *analyzer);
 };
 

--- a/src/op/transpose.cc
+++ b/src/op/transpose.cc
@@ -204,11 +204,13 @@ For TransposeNode::MakeSIMTLoop(arith::Analyzer *analyzer) const {
   return Downcast<For>(body);
 }
 
-Stmt TransposeNode::Lower(const LowerArgs &T, arith::Analyzer *analyzer) const {
-  return ResolveTransposeImpl(T.target).lower(*this, T, analyzer);
+Stmt TransposeNode::Lower(const LowerArgs &lower_args,
+                          arith::Analyzer *analyzer) const {
+  return ResolveTransposeImpl(lower_args.target)
+      .lower(*this, lower_args, analyzer);
 }
 
-LayoutMap TransposeNode::InferLayout(const LayoutInferArgs &T,
+LayoutMap TransposeNode::InferLayout(const LayoutInferArgs &layout_args,
                                      InferLevel level) const {
   // Transpose always uses SIMT loops; no special layout inference needed.
   return {};

--- a/src/op/transpose.h
+++ b/src/op/transpose.h
@@ -33,8 +33,9 @@ public:
         .def_ro("dst_range", &TransposeNode::dst_range);
   }
 
-  Stmt Lower(const LowerArgs &T, arith::Analyzer *analyzer) const override;
-  LayoutMap InferLayout(const LayoutInferArgs &T,
+  Stmt Lower(const LowerArgs &lower_args,
+             arith::Analyzer *analyzer) const override;
+  LayoutMap InferLayout(const LayoutInferArgs &layout_args,
                         InferLevel level) const override;
   TileOperator Clone() const override;
 
@@ -61,7 +62,7 @@ struct TransposeImpl {
   const char *name;
   TransposeTargetPredicate match_target;
 
-  Stmt (*lower)(const TransposeNode &op, const LowerArgs &T,
+  Stmt (*lower)(const TransposeNode &op, const LowerArgs &lower_args,
                 arith::Analyzer *analyzer);
 };
 

--- a/src/rocm/op/atomic_add.cc
+++ b/src/rocm/op/atomic_add.cc
@@ -190,12 +190,13 @@ For MakeSIMTLoop(const AtomicAddNode &op, arith::Analyzer *analyzer) {
   return Downcast<For>(body);
 }
 
-LayoutMap InferSIMTLayout(const AtomicAddNode &op, const LayoutInferArgs &T,
-                          InferLevel) {
+LayoutMap InferSIMTLayout(const AtomicAddNode &op,
+                          const LayoutInferArgs &layout_args, InferLevel) {
   if (IsFragmentBuffer(op.src) && IsFragmentBuffer(op.dst)) {
-    if (T.layout_map.count(op.src) && T.layout_map.count(op.dst)) {
-      Layout src_layout = T.layout_map.at(op.src);
-      Layout dst_layout = T.layout_map.at(op.dst);
+    if (layout_args.layout_map.count(op.src) &&
+        layout_args.layout_map.count(op.dst)) {
+      Layout src_layout = layout_args.layout_map.at(op.src);
+      Layout dst_layout = layout_args.layout_map.at(op.dst);
       ICHECK(StructuralEqual()(src_layout, dst_layout))
           << "AtomicAdd requires src and dst to have the same layout, but got "
           << "src layout: " << src_layout << ", dst layout: " << dst_layout
@@ -209,7 +210,7 @@ LayoutMap InferSIMTLayout(const AtomicAddNode &op, const LayoutInferArgs &T,
 } // namespace
 
 struct AtomicAdd {
-  static Stmt LowerSIMT(const AtomicAddNode &op, const LowerArgs &T,
+  static Stmt LowerSIMT(const AtomicAddNode &op, const LowerArgs &lower_args,
                         arith::Analyzer *analyzer) {
     auto simt_loop = MakeSIMTLoop(op, analyzer);
     auto fused_loop = Downcast<For>(ParallelLoopFuser::Fuse(simt_loop));
@@ -217,34 +218,36 @@ struct AtomicAdd {
     std::vector<InferLevel> levels = {InferLevel::kCommon, InferLevel::kStrict,
                                       InferLevel::kFree};
     for (auto level : levels) {
-      par_op->InferLayout({T.target,
-                           T.thread_bounds,
-                           T.layout_map,
+      par_op->InferLayout({lower_args.target,
+                           lower_args.thread_bounds,
+                           lower_args.layout_map,
                            analyzer,
                            false,
-                           T.buffer_remap,
+                           lower_args.buffer_remap,
                            {}},
                           level);
     }
     auto loop_layout = par_op->GetLoopLayout();
-    return LowerParallelLoop(fused_loop, loop_layout, T.thread_var, analyzer,
-                             T.layout_map, par_op->GetPredicate(T.thread_var),
+    return LowerParallelLoop(fused_loop, loop_layout, lower_args.thread_var,
+                             analyzer, lower_args.layout_map,
+                             par_op->GetPredicate(lower_args.thread_var),
                              /*parallel_loop=*/true, /*should_vectorize=*/true,
                              par_op->LoopLayoutRequiresPaddingGuard());
   }
 
   static LayoutMap InferLayout(const AtomicAddNode &op,
-                               const LayoutInferArgs &T, InferLevel level) {
+                               const LayoutInferArgs &layout_args,
+                               InferLevel level) {
     ICHECK(!UseTMA(op))
         << "TMA atomic_add is only supported by the CUDA backend";
-    return InferSIMTLayout(op, T, level);
+    return InferSIMTLayout(op, layout_args, level);
   }
 
-  static Stmt Lower(const AtomicAddNode &op, const LowerArgs &T,
+  static Stmt Lower(const AtomicAddNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer) {
     ICHECK(!UseTMA(op))
         << "TMA atomic_add is only supported by the CUDA backend";
-    return LowerSIMT(op, T, analyzer);
+    return LowerSIMT(op, lower_args, analyzer);
   }
 };
 

--- a/src/rocm/op/copy.cc
+++ b/src/rocm/op/copy.cc
@@ -58,10 +58,12 @@ enum class CopyInst : uint8_t {
 };
 
 struct Copy {
-  static LayoutMap InferLayout(const CopyNode &op, const LayoutInferArgs &T,
+  static LayoutMap InferLayout(const CopyNode &op,
+                               const LayoutInferArgs &layout_args,
                                InferLevel level) {
-    SelectInst(op, T.target, T.layout_map, T.analyzer);
-    return op.InferSIMTLayout(T, level);
+    SelectInst(op, layout_args.target, layout_args.layout_map,
+               layout_args.analyzer);
+    return op.InferSIMTLayout(layout_args, level);
   }
 
   static CopyInst SelectInst(const CopyNode &op, Target target,
@@ -82,20 +84,21 @@ struct Copy {
     return CopyInst::kNormal;
   }
 
-  static Stmt Lower(const CopyNode &op, const LowerArgs &T,
+  static Stmt Lower(const CopyNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer) {
-    auto copy_inst = SelectInst(op, T.target, T.layout_map, analyzer);
+    auto copy_inst =
+        SelectInst(op, lower_args.target, lower_args.layout_map, analyzer);
     if (copy_inst == CopyInst::kCPAsync) {
-      return LowerCPAsync(op, T, analyzer);
+      return LowerCPAsync(op, lower_args, analyzer);
     }
     if (copy_inst == CopyInst::kNormal) {
-      return LowerNormalCopy(op, T, analyzer);
+      return LowerNormalCopy(op, lower_args, analyzer);
     }
     LOG(FATAL) << "Unsupported ROCm copy inst " << static_cast<int>(copy_inst);
   }
 
 private:
-  static Stmt LowerCPAsync(const CopyNode &op, const LowerArgs &T,
+  static Stmt LowerCPAsync(const CopyNode &op, const LowerArgs &lower_args,
                            arith::Analyzer *analyzer) {
     using namespace tvm::transform;
 
@@ -106,7 +109,7 @@ private:
     bool explicit_async_semantics =
         no_implicit_commit_wait || GetIsAsyncCopy(op);
     if (!enable_async_copy && !explicit_async_semantics) {
-      return LowerNormalCopy(op, T, analyzer);
+      return LowerNormalCopy(op, lower_args, analyzer);
     }
 
     auto simt_loop = op.MakeSIMTLoop(analyzer);
@@ -116,19 +119,19 @@ private:
     std::vector<InferLevel> levels = {InferLevel::kCommon, InferLevel::kStrict,
                                       InferLevel::kFree};
     for (auto level : levels) {
-      par_op->InferLayout({T.target,
-                           T.thread_bounds,
-                           T.layout_map,
+      par_op->InferLayout({lower_args.target,
+                           lower_args.thread_bounds,
+                           lower_args.layout_map,
                            analyzer,
                            false,
-                           T.buffer_remap,
+                           lower_args.buffer_remap,
                            {}},
                           level);
     }
     auto loop_layout = par_op->GetLoopLayout();
     Stmt lowered_loop = LowerParallelLoop(
-        par_op->GetRoot(), loop_layout, T.thread_var, analyzer, T.layout_map,
-        par_op->GetPredicate(T.thread_var),
+        par_op->GetRoot(), loop_layout, lower_args.thread_var, analyzer,
+        lower_args.layout_map, par_op->GetPredicate(lower_args.thread_var),
         /*parallel_loop=*/true,
         /*should_vectorize=*/true, par_op->LoopLayoutRequiresPaddingGuard());
 
@@ -161,7 +164,7 @@ private:
       DLOG(WARNING)
           << "Fallback to normal copy because ROCm async-copy rewrite "
              "found no eligible global->shared store.";
-      return LowerNormalCopy(op, T, analyzer);
+      return LowerNormalCopy(op, lower_args, analyzer);
     }
     if (no_implicit_commit_wait) {
       return async_copy_loop;

--- a/src/webgpu/op/copy.cc
+++ b/src/webgpu/op/copy.cc
@@ -13,14 +13,15 @@ using namespace tirx;
 namespace webgpu {
 
 struct Copy {
-  static LayoutMap InferLayout(const CopyNode &op, const LayoutInferArgs &T,
+  static LayoutMap InferLayout(const CopyNode &op,
+                               const LayoutInferArgs &layout_args,
                                InferLevel level) {
-    return op.InferSIMTLayout(T, level);
+    return op.InferSIMTLayout(layout_args, level);
   }
 
-  static Stmt Lower(const CopyNode &op, const LowerArgs &T,
+  static Stmt Lower(const CopyNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer) {
-    return LowerNormalCopy(op, T, analyzer);
+    return LowerNormalCopy(op, lower_args, analyzer);
   }
 };
 

--- a/src/webgpu/op/fill.cc
+++ b/src/webgpu/op/fill.cc
@@ -16,25 +16,26 @@ namespace tl {
 namespace webgpu {
 
 struct Fill {
-  static Stmt Lower(const FillNode &op, const LowerArgs &T,
+  static Stmt Lower(const FillNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer) {
     if (IsFragmentBuffer(op.dst)) {
       auto par_op = ParallelOp(op.MakeSIMTLoop(analyzer));
-      par_op->InferLayout({T.target,
-                           T.thread_bounds,
-                           T.layout_map,
+      par_op->InferLayout({lower_args.target,
+                           lower_args.thread_bounds,
+                           lower_args.layout_map,
                            analyzer,
                            false,
-                           T.buffer_remap,
+                           lower_args.buffer_remap,
                            {}},
                           InferLevel::kFree);
-      auto thread_loop = PartitionLoop(par_op->GetRoot(), T.thread_var,
+      auto thread_loop = PartitionLoop(par_op->GetRoot(), lower_args.thread_var,
                                        analyzer, par_op->GetLoopLayout());
-      auto vectorized_loop = VectorizeLoop(thread_loop, analyzer, T.layout_map);
+      auto vectorized_loop =
+          VectorizeLoop(thread_loop, analyzer, lower_args.layout_map);
       auto unrolled_loop = PragmaUnrollLoop(vectorized_loop);
 
-      if (par_op->GetPredicate(T.thread_var).defined()) {
-        return IfThenElse(par_op->GetPredicate(T.thread_var).value(),
+      if (par_op->GetPredicate(lower_args.thread_var).defined()) {
+        return IfThenElse(par_op->GetPredicate(lower_args.thread_var).value(),
                           unrolled_loop);
       }
       return unrolled_loop;
@@ -42,26 +43,28 @@ struct Fill {
 
     if (IsLocalBuffer(op.dst) || IsLocalVarBuffer(op.dst)) {
       auto init_loop = op.MakeSIMTLoop(analyzer);
-      auto vectorized_loop = VectorizeLoop(init_loop, analyzer, T.layout_map);
+      auto vectorized_loop =
+          VectorizeLoop(init_loop, analyzer, lower_args.layout_map);
       return PragmaUnrollLoop(vectorized_loop);
     }
 
     if (IsSharedBuffer(op.dst) || IsGlobalBuffer(op.dst)) {
       auto par_op = ParallelOp(op.MakeSIMTLoop(analyzer));
-      par_op->InferLayout({T.target,
-                           T.thread_bounds,
-                           T.layout_map,
+      par_op->InferLayout({lower_args.target,
+                           lower_args.thread_bounds,
+                           lower_args.layout_map,
                            analyzer,
                            false,
-                           T.buffer_remap,
+                           lower_args.buffer_remap,
                            {}},
                           InferLevel::kFree);
-      auto thread_loop = PartitionLoop(par_op->GetRoot(), T.thread_var,
+      auto thread_loop = PartitionLoop(par_op->GetRoot(), lower_args.thread_var,
                                        analyzer, par_op->GetLoopLayout());
-      auto vectorized_loop = VectorizeLoop(thread_loop, analyzer, T.layout_map);
+      auto vectorized_loop =
+          VectorizeLoop(thread_loop, analyzer, lower_args.layout_map);
       auto unrolled_loop = PragmaUnrollLoop(vectorized_loop);
-      if (par_op->GetPredicate(T.thread_var).defined()) {
-        return IfThenElse(par_op->GetPredicate(T.thread_var).value(),
+      if (par_op->GetPredicate(lower_args.thread_var).defined()) {
+        return IfThenElse(par_op->GetPredicate(lower_args.thread_var).value(),
                           unrolled_loop);
       }
       return unrolled_loop;

--- a/src/webgpu/op/transpose.cc
+++ b/src/webgpu/op/transpose.cc
@@ -20,35 +20,35 @@ namespace tl {
 namespace webgpu {
 
 struct Transpose {
-  static Stmt Lower(const TransposeNode &op, const LowerArgs &T,
+  static Stmt Lower(const TransposeNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer) {
-    bool is_cpu_target = T.target->GetTargetDeviceType() == kDLCPU;
+    bool is_cpu_target = lower_args.target->GetTargetDeviceType() == kDLCPU;
     auto simt_loop = op.MakeSIMTLoop(analyzer);
     auto fused_loop = Downcast<For>(ParallelLoopFuser::Fuse(simt_loop));
 
     if (is_cpu_target || IsLocalBuffer(op.src) || IsLocalBuffer(op.dst)) {
-      return VectorizeLoop(fused_loop, T.layout_map);
+      return VectorizeLoop(fused_loop, lower_args.layout_map);
     }
 
     auto par_op = ParallelOp(fused_loop);
     std::vector<InferLevel> levels = {InferLevel::kCommon, InferLevel::kStrict,
                                       InferLevel::kFree};
     for (auto level : levels) {
-      par_op->InferLayout({T.target,
-                           T.thread_bounds,
-                           T.layout_map,
+      par_op->InferLayout({lower_args.target,
+                           lower_args.thread_bounds,
+                           lower_args.layout_map,
                            analyzer,
                            false,
-                           T.buffer_remap,
+                           lower_args.buffer_remap,
                            {}},
                           level);
     }
     auto loop_layout = par_op->GetLoopLayout();
-    return LowerParallelLoop(par_op->GetRoot(), loop_layout, T.thread_var,
-                             analyzer, T.layout_map,
-                             par_op->GetPredicate(T.thread_var),
-                             /*parallel_loop=*/true, /*should_vectorize=*/true,
-                             par_op->LoopLayoutRequiresPaddingGuard());
+    return LowerParallelLoop(
+        par_op->GetRoot(), loop_layout, lower_args.thread_var, analyzer,
+        lower_args.layout_map, par_op->GetPredicate(lower_args.thread_var),
+        /*parallel_loop=*/true, /*should_vectorize=*/true,
+        par_op->LoopLayoutRequiresPaddingGuard());
   }
 };
 


### PR DESCRIPTION
## Summary

- Normalize Tile operator lowering and layout context parameters from ambiguous `T` names to `lower_args` or `layout_args`.
- Add an advisory C++ API style audit script and document how to use it for follow-up cleanup.

## Changes

- Update `LowerArgs` and `LayoutInferArgs` declarations and matching backend implementations across operator lowering and layout inference code.
- Add `maint/scripts/audit_cpp_api_style.py` to report C++ API style cleanup candidates without making the check a lint gate.
- Document the audit workflow in `docs/developer_guide/cpp_style.md`.
- Leave FFI-visible ObjectNode fields, non-Pascal API names, and broad header namespace imports for separate compatibility-focused follow-ups.

## Validation

- `./format.sh`
- `PYTHONDONTWRITEBYTECODE=1 python3 maint/scripts/audit_cpp_api_style.py --limit 20`
- `cmake --build build -j$(nproc)`

## Notes

- The audit report no longer contains `TLCPP002` findings for ambiguous `LowerArgs` or `LayoutInferArgs` parameter names. Remaining findings are still advisory and need case-by-case review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added C++ code style audit guidance to the developer guide, including instructions for running the code audit tool to identify potential API style cleanup candidates.

* **Chores**
  * Added a new code audit tool to help identify C++ API style improvements such as non-Pascal naming conventions and parameter naming issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->