### PR TITLE
[C++][Style] Normalize API helper names

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,44 @@
+language: en-US
+
+reviews:
+  high_level_summary_instructions: |
+    Add a short "C++ style / lint notes" section when the PR changes C++, CI,
+    lint tooling, or C++ style documentation.
+
+    In that section:
+    - Mention whether the PR touches rules documented in docs/developer_guide/cpp_style.md.
+    - Mention the "C++ API Style Audit (warning only)" CI step when relevant.
+    - Focus on warnings introduced or touched by this PR; do not treat historical backlog as blocking.
+    - Clearly separate correctness, build, and test issues from warning-only style suggestions.
+    - Do not recommend blocking merge for advisory TLCPP003/TLCPP004 findings unless the PR
+      introduces a clear API, FFI, or maintainability risk.
+
+  path_instructions:
+    - path: "src/**/*.{h,hh,hpp,cuh,cc,cpp,cxx,cu}"
+      instructions: |
+        Review changed C++ against docs/developer_guide/cpp_style.md.
+
+        Pay attention to:
+        - Regular C++ APIs should use PascalCase function and method names.
+        - TIR/TileLang registered op accessors may intentionally use lower_snake to mirror registry names.
+        - Parameters and local variables should use descriptive lower_snake names; avoid ambiguous `T`
+          for API parameters.
+        - Public reflected ObjectNode fields are FFI-visible; do not recommend renaming without
+          compatibility notes.
+        - Shared headers should avoid broad `using namespace`; internal .cc/local helper code may
+          follow local TVM style.
+        - Existing warning-only audit findings are advisory unless this PR introduces or worsens them.
+
+    - path: "maint/scripts/audit_cpp_api_style.py"
+      instructions: |
+        Review this audit script as an advisory lint tool, not a hard gate.
+
+        Ensure new checks avoid broad path-specific hacks, support explicit suppressions like NOLINT
+        where appropriate, and do not turn existing TLCPP003/TLCPP004 backlog into CI failures.
+
+    - path: ".github/workflows/**"
+      instructions: |
+        For C++ style audit CI changes, verify the audit remains warning-only unless the PR explicitly
+        changes policy.
+
+        Do not suggest failing CI for existing advisory backlog.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,12 @@ jobs:
         run: |
           "${{ steps.setup-pylowest.outputs.python-path }}" -m compileall -q -f tilelang
 
+      - name: C++ API Style Audit (warning only)
+        env:
+          PYTHONDONTWRITEBYTECODE: "1"
+        run: |
+          "${{ steps.setup-pylowest.outputs.python-path }}" maint/scripts/audit_cpp_api_style.py --github-warnings --limit 20
+
       - name: Pre-commit Lint
         run: |
           if ! pipx run pre-commit run --all-files --color=always --show-diff-on-failure; then

--- a/docs/developer_guide/cpp_style.md
+++ b/docs/developer_guide/cpp_style.md
@@ -323,6 +323,11 @@ interfaces, and backend/runtime shims may need exceptions. By default the audit
 excludes generated templates and runtime shim directories; use the script flags
 to include those areas when a cleanup explicitly targets them.
 
+CI runs the audit in warning-only mode so new findings are visible on pull
+requests without blocking unrelated work. Use local review to decide whether a
+warning should be fixed, suppressed with a narrow `NOLINT`, or left for a
+focused cleanup.
+
 ## Exceptions
 
 Generated kernel templates, CUDA/HIP runtime shims, and external API adapters

--- a/maint/scripts/audit_cpp_api_style.py
+++ b/maint/scripts/audit_cpp_api_style.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 HEADER_SUFFIXES = {".h", ".hh", ".hpp", ".cuh"}
 SOURCE_SUFFIXES = {".cc", ".cpp", ".cxx", ".cu"}
+CPP_SUFFIXES = HEADER_SUFFIXES | SOURCE_SUFFIXES
 DEFAULT_EXCLUDED_PARTS = {
     "3rdparty",
     "build",
@@ -66,6 +67,10 @@ QUALIFIER_TOKENS = {
     "static",
     "virtual",
 }
+
+REGISTERED_TL_BUILTIN_RE = re.compile(r"\bTIR_DEFINE_TL_BUILTIN\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)")
+REGISTERED_LITERAL_TL_OP_RE = re.compile(r'\bTVM_REGISTER_OP\s*\(\s*"tl\.([A-Za-z_][A-Za-z0-9_]*)"\s*\)')
+OP_ACCESSOR_DECL_RE = re.compile(r"^(?:TVM_DLL\s+)?const\s+Op\s*&\s*([A-Za-z_][A-Za-z0-9_]*)\s*\(")
 
 
 @dataclass(order=True)
@@ -117,6 +122,11 @@ def parse_args() -> argparse.Namespace:
         "--json",
         action="store_true",
         help="Emit JSON instead of text.",
+    )
+    parser.add_argument(
+        "--github-warnings",
+        action="store_true",
+        help="Emit GitHub Actions warning annotations without changing the exit code.",
     )
     parser.add_argument(
         "--limit",
@@ -179,6 +189,23 @@ def candidate_files(args: argparse.Namespace) -> list[Path]:
     return sorted(set(result))
 
 
+def registry_scan_files(args: argparse.Namespace) -> list[Path]:
+    roots = {Path(raw_path) for raw_path in args.paths if Path(raw_path).exists()}
+    if Path("src").exists():
+        roots.add(Path("src"))
+
+    result: list[Path] = []
+    for root in roots:
+        if root.is_file():
+            if root.suffix in CPP_SUFFIXES and not is_excluded(root, args):
+                result.append(root)
+            continue
+        for child in root.rglob("*"):
+            if child.is_file() and child.suffix in CPP_SUFFIXES and not is_excluded(child, args):
+                result.append(child)
+    return sorted(set(result))
+
+
 def strip_line_comment(line: str) -> str:
     """Strip // comments while preserving URLs and simple string literals enough for auditing."""
     in_string = False
@@ -200,6 +227,25 @@ def strip_block_comments(text: str) -> str:
     return re.sub(r"/\*.*?\*/", lambda match: "\n" * match.group(0).count("\n"), text, flags=re.S)
 
 
+def has_nolint_suppression(lines: list[str], index: int) -> bool:
+    if "NOLINT" in lines[index]:
+        return True
+    return index > 0 and "NOLINTNEXTLINE" in lines[index - 1]
+
+
+def collect_registered_op_names(args: argparse.Namespace) -> set[str]:
+    names: set[str] = set()
+    for path in registry_scan_files(args):
+        text = strip_block_comments(path.read_text(encoding="utf-8", errors="replace"))
+        for line in text.splitlines():
+            stripped = strip_line_comment(line).strip()
+            if not stripped or stripped.startswith("#define"):
+                continue
+            names.update(REGISTERED_TL_BUILTIN_RE.findall(stripped))
+            names.update(REGISTERED_LITERAL_TL_OP_RE.findall(stripped))
+    return names
+
+
 def is_pascal_case(name: str) -> bool:
     if not re.fullmatch(r"[A-Z][A-Za-z0-9]*", name):
         return False
@@ -208,6 +254,12 @@ def is_pascal_case(name: str) -> bool:
 
 def is_tvm_hook_name(name: str) -> bool:
     return bool(re.fullmatch(r"[A-Z][A-Za-z0-9]*_", name))
+
+
+def is_registered_op_accessor(statement: str, registered_op_names: set[str]) -> bool:
+    compact = " ".join(statement.strip().split())
+    match = OP_ACCESSOR_DECL_RE.match(compact)
+    return bool(match and match.group(1) in registered_op_names)
 
 
 def split_parameters(params: str) -> list[str]:
@@ -255,6 +307,8 @@ def function_statement_name(statement: str) -> tuple[str, str] | None:
         return None
     if compact.startswith(("TVM_", "ICHECK", "LOG(", "CHECK")):
         return None
+    if re.search(r"\(\s*\*", compact):
+        return None
     first_paren = compact.find("(")
     if first_paren >= 0 and "=" in compact[:first_paren]:
         return None
@@ -294,7 +348,7 @@ def statement_starting_at(lines: list[str], index: int) -> tuple[str, int]:
     return " ".join(pieces), end_index
 
 
-def audit_functions(path: Path, lines: list[str]) -> list[Finding]:
+def audit_functions(path: Path, lines: list[str], registered_op_names: set[str]) -> list[Finding]:
     findings: list[Finding] = []
     class_stack: list[ClassState] = []
     brace_depth = 0
@@ -334,6 +388,13 @@ def audit_functions(path: Path, lines: list[str]) -> list[Finding]:
             continue
 
         statement, end_index = statement_starting_at(lines, index)
+        if is_registered_op_accessor(statement, registered_op_names):
+            processed_until = end_index
+            brace_depth += stripped.count("{") - stripped.count("}")
+            while class_stack and brace_depth <= class_stack[-1].brace_depth:
+                class_stack.pop()
+            continue
+
         parsed = function_statement_name(statement)
         if not parsed:
             brace_depth += stripped.count("{") - stripped.count("}")
@@ -343,7 +404,12 @@ def audit_functions(path: Path, lines: list[str]) -> list[Finding]:
         processed_until = end_index
 
         name, params = parsed
-        if not is_pascal_case(name) and not is_tvm_hook_name(name) and "override" not in statement:
+        if (
+            not has_nolint_suppression(lines, index)
+            and not is_pascal_case(name)
+            and not is_tvm_hook_name(name)
+            and "override" not in statement
+        ):
             findings.append(
                 Finding(
                     str(normalize_path(path)),
@@ -481,13 +547,13 @@ def audit_namespace_imports(path: Path, lines: list[str]) -> list[Finding]:
     return findings
 
 
-def audit_file(path: Path) -> list[Finding]:
+def audit_file(path: Path, registered_op_names: set[str]) -> list[Finding]:
     text = path.read_text(encoding="utf-8", errors="replace")
     text = strip_block_comments(text)
     lines = text.splitlines()
     findings: list[Finding] = []
     findings.extend(audit_namespace_imports(path, lines))
-    findings.extend(audit_functions(path, lines))
+    findings.extend(audit_functions(path, lines, registered_op_names))
     findings.extend(audit_object_node_fields(path, lines))
     return sorted(findings)
 
@@ -512,12 +578,33 @@ def print_text(findings: list[Finding], file_count: int, limit: int) -> None:
         print(f"... omitted {len(findings) - limit} finding(s); rerun with --limit 0 to show all.")
 
 
+def github_escape(value: str, *, property_value: bool = False) -> str:
+    value = value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+    if property_value:
+        value = value.replace(":", "%3A").replace(",", "%2C")
+    return value
+
+
+def print_github_warnings(findings: list[Finding], limit: int) -> None:
+    shown = findings if limit <= 0 else findings[:limit]
+    for finding in shown:
+        path = github_escape(finding.path, property_value=True)
+        title = github_escape(f"{finding.rule}: {finding.symbol}", property_value=True)
+        message = github_escape(f"{finding.message} Snippet: {finding.snippet}")
+        print(f"::warning file={path},line={finding.line},title={title}::{message}")
+    if limit > 0 and len(findings) > limit:
+        omitted = len(findings) - limit
+        message = github_escape(f"{omitted} additional C++ API style audit finding(s) omitted.")
+        print(f"::notice title=C++ API style audit::{message}")
+
+
 def main() -> int:
     args = parse_args()
     files = candidate_files(args)
+    registered_op_names = collect_registered_op_names(args)
     findings: list[Finding] = []
     for path in files:
-        findings.extend(audit_file(path))
+        findings.extend(audit_file(path, registered_op_names))
     findings.sort()
 
     if args.json:
@@ -530,6 +617,8 @@ def main() -> int:
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
         print_text(findings, len(files), args.limit)
+    if args.github_warnings:
+        print_github_warnings(findings, args.limit)
 
     return 1 if args.fail_on_findings and findings else 0
 

--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -107,9 +107,9 @@ inline PrimExpr MakeInitValue(const ReduceOpNode &op, int vsize = 1) {
   auto bits = dst_dtype.bits();
 
   PrimExpr scalar;
-  if (op.type->isSum() || op.type->isAbsSum()) {
+  if (op.type->IsSum() || op.type->IsAbsSum()) {
     scalar = make_zero(op.dst->dtype);
-  } else if (op.type->isMax()) {
+  } else if (op.type->IsMax()) {
     if (is_int) {
       scalar = make_const(op.dst->dtype, SignedMin(bits));
     } else if (is_uint) {
@@ -117,7 +117,7 @@ inline PrimExpr MakeInitValue(const ReduceOpNode &op, int vsize = 1) {
     } else {
       scalar = make_const(op.dst->dtype, -INFINITY);
     }
-  } else if (op.type->isMin()) {
+  } else if (op.type->IsMin()) {
     if (is_int) {
       scalar = make_const(op.dst->dtype, SignedMax(bits));
     } else if (is_uint) {
@@ -125,9 +125,9 @@ inline PrimExpr MakeInitValue(const ReduceOpNode &op, int vsize = 1) {
     } else {
       scalar = make_const(op.dst->dtype, INFINITY);
     }
-  } else if (op.type->isAbsMax()) {
+  } else if (op.type->IsAbsMax()) {
     scalar = make_const(op.dst->dtype, 0);
-  } else if (op.type->isBitAnd()) {
+  } else if (op.type->IsBitAnd()) {
     if (is_int) {
       scalar = make_const(op.dst->dtype, -1);
     } else if (is_uint) {
@@ -135,7 +135,7 @@ inline PrimExpr MakeInitValue(const ReduceOpNode &op, int vsize = 1) {
     } else {
       scalar = make_const(op.dst->dtype, -INFINITY);
     }
-  } else if (op.type->isBitOr() || op.type->isBitXor()) {
+  } else if (op.type->IsBitOr() || op.type->IsBitXor()) {
     scalar = make_zero(op.dst->dtype);
   } else {
     LOG(FATAL) << "Unsupported reduce type: " << op.type->type;
@@ -162,43 +162,43 @@ inline PrimExpr MakeReduce(const ReduceOpNode &op, int vsize,
   if (vsize == 1) {
     const bool use_nan_op = op.nan_propagate && (acc.dtype().is_float16() ||
                                                  acc.dtype().is_bfloat16());
-    if (op.type->isSum()) {
+    if (op.type->IsSum()) {
       return acc + rhs;
-    } else if (op.type->isAbsSum()) {
+    } else if (op.type->IsAbsSum()) {
       return acc + Max(rhs, -rhs);
-    } else if (op.type->isMax()) {
+    } else if (op.type->IsMax()) {
       return use_nan_op ? Call(acc.dtype(), tl::max_nan(), {acc, rhs})
                         : PrimExpr(Max(acc, rhs));
-    } else if (op.type->isMin()) {
+    } else if (op.type->IsMin()) {
       return use_nan_op ? Call(acc.dtype(), tl::min_nan(), {acc, rhs})
                         : PrimExpr(Min(acc, rhs));
-    } else if (op.type->isAbsMax()) {
+    } else if (op.type->IsAbsMax()) {
       auto abs_rhs = Max(rhs, -rhs);
       return use_nan_op ? Call(acc.dtype(), tl::max_nan(), {acc, abs_rhs})
                         : PrimExpr(Max(acc, abs_rhs));
-    } else if (op.type->isBitAnd()) {
+    } else if (op.type->IsBitAnd()) {
       return acc & rhs;
-    } else if (op.type->isBitOr()) {
+    } else if (op.type->IsBitOr()) {
       return acc | rhs;
-    } else if (op.type->isBitXor()) {
+    } else if (op.type->IsBitXor()) {
       return acc ^ rhs;
     }
     LOG(FATAL) << "Unsupported reduce type: " << op.type->type;
     return PrimExpr();
   }
 
-  if (op.type->isSum()) {
+  if (op.type->IsSum()) {
     return Call(acc.dtype(), tl::add2(), {acc, rhs});
-  } else if (op.type->isAbsSum()) {
+  } else if (op.type->IsAbsSum()) {
     return Call(acc.dtype(), tl::add2(),
                 {acc, Call(acc.dtype(), tl::abs2(), {rhs})});
-  } else if (op.type->isMax()) {
+  } else if (op.type->IsMax()) {
     return Call(acc.dtype(), op.nan_propagate ? tl::max2_nan() : tl::max2(),
                 {acc, rhs});
-  } else if (op.type->isMin()) {
+  } else if (op.type->IsMin()) {
     return Call(acc.dtype(), op.nan_propagate ? tl::min2_nan() : tl::min2(),
                 {acc, rhs});
-  } else if (op.type->isAbsMax()) {
+  } else if (op.type->IsAbsMax()) {
     return Call(acc.dtype(), op.nan_propagate ? tl::max2_nan() : tl::max2(),
                 {acc, Call(acc.dtype(), tl::abs2(), {rhs})});
   }
@@ -212,19 +212,19 @@ inline std::optional<std::string> MakeCodegenReducer(const ReduceOpNode &op,
                                                op.dst->dtype.is_bfloat16());
 
   auto base = [&]() -> std::string {
-    if (op.type->isSum() || op.type->isAbsSum())
+    if (op.type->IsSum() || op.type->IsAbsSum())
       return "tl::SumOp";
-    if (op.type->isMax())
+    if (op.type->IsMax())
       return use_nan_op ? "tl::MaxOpNan" : "tl::MaxOp";
-    if (op.type->isMin())
+    if (op.type->IsMin())
       return use_nan_op ? "tl::MinOpNan" : "tl::MinOp";
-    if (op.type->isAbsMax())
+    if (op.type->IsAbsMax())
       return use_nan_op ? "tl::MaxOpNan" : "tl::MaxOp";
-    if (op.type->isBitAnd())
+    if (op.type->IsBitAnd())
       return "tl::BitAndOp";
-    if (op.type->isBitOr())
+    if (op.type->IsBitOr())
       return "tl::BitOrOp";
-    if (op.type->isBitXor())
+    if (op.type->IsBitXor())
       return "tl::BitXorOp";
     LOG(FATAL) << "Unsupported reduce type: " << op.type->type;
     return "";
@@ -233,8 +233,8 @@ inline std::optional<std::string> MakeCodegenReducer(const ReduceOpNode &op,
   if (vsize <= 1)
     return base;
 
-  if (!(op.type->isSum() || op.type->isAbsSum() || op.type->isMax() ||
-        op.type->isMin() || op.type->isAbsMax())) {
+  if (!(op.type->IsSum() || op.type->IsAbsSum() || op.type->IsMax() ||
+        op.type->IsMin() || op.type->IsAbsMax())) {
     return std::nullopt;
   }
 
@@ -277,17 +277,17 @@ inline bool CanUsePackedRamp(const PrimExpr &index, const Var &var, int vsize,
 
 inline PrimExpr MakeUpdate(const ReduceOpNode &op, PrimExpr dst_val,
                            PrimExpr src_val) {
-  if (op.type->isSum() || op.type->isAbsSum()) {
+  if (op.type->IsSum() || op.type->IsAbsSum()) {
     return dst_val + src_val;
-  } else if (op.type->isBitAnd()) {
+  } else if (op.type->IsBitAnd()) {
     return op.clear ? src_val : bitwise_and(dst_val, src_val);
-  } else if (op.type->isBitOr()) {
+  } else if (op.type->IsBitOr()) {
     return bitwise_or(dst_val, src_val);
-  } else if (op.type->isBitXor()) {
+  } else if (op.type->IsBitXor()) {
     return bitwise_xor(dst_val, src_val);
-  } else if (op.type->isMax() || op.type->isAbsMax()) {
+  } else if (op.type->IsMax() || op.type->IsAbsMax()) {
     return Max(dst_val, src_val);
-  } else if (op.type->isMin()) {
+  } else if (op.type->IsMin()) {
     return Min(dst_val, src_val);
   }
   LOG(FATAL) << "Unsupported reduce type: " << op.type->type;
@@ -360,25 +360,25 @@ template <typename Impl> struct ReduceLowerer {
       Array<Stmt> stmts;
 
       auto require_init = op.clear;
-      if (op.type->isSum() || op.type->isAbsSum() || op.type->isBitAnd() ||
-          op.type->isBitOr() || op.type->isBitXor()) {
+      if (op.type->IsSum() || op.type->IsAbsSum() || op.type->IsBitAnd() ||
+          op.type->IsBitOr() || op.type->IsBitXor()) {
         require_init = true;
       }
 
       auto clear_buffer = dst_buffer;
       auto need_duplicate = false;
       auto need_update = false;
-      if ((op.type->isSum() || op.type->isAbsSum()) && !op.clear) {
+      if ((op.type->IsSum() || op.type->IsAbsSum()) && !op.clear) {
         need_duplicate = true;
         need_update = true;
-      } else if (op.type->isBitAnd() && !op.clear) {
+      } else if (op.type->IsBitAnd() && !op.clear) {
         need_duplicate = true;
         need_update = true;
-      } else if ((op.type->isBitOr() || op.type->isBitXor()) && !op.clear) {
+      } else if ((op.type->IsBitOr() || op.type->IsBitXor()) && !op.clear) {
         need_duplicate = true;
         need_update = true;
-      } else if ((op.type->isMax() || op.type->isMin() ||
-                  op.type->isAbsMax()) &&
+      } else if ((op.type->IsMax() || op.type->IsMin() ||
+                  op.type->IsAbsMax()) &&
                  !op.clear) {
         need_duplicate = true;
         need_update = true;
@@ -434,8 +434,8 @@ template <typename Impl> struct ReduceLowerer {
             Array<Stmt> local_body;
 
             if (require_init ||
-                (need_duplicate && (op.type->isMax() || op.type->isMin() ||
-                                    op.type->isAbsMax()))) {
+                (need_duplicate && (op.type->IsMax() || op.type->IsMin() ||
+                                    op.type->IsAbsMax()))) {
               local_body.push_back(BufferStore(clear_buffer_packed,
                                                reduce::MakeInitValue(op, vsize),
                                                red_indices));
@@ -496,7 +496,7 @@ template <typename Impl> struct ReduceLowerer {
       if (!can_pack) {
         if (require_init ||
             (need_duplicate &&
-             (op.type->isMax() || op.type->isMin() || op.type->isAbsMax()))) {
+             (op.type->IsMax() || op.type->IsMin() || op.type->IsAbsMax()))) {
           stmts.push_back(BufferStore(clear_buffer, reduce::MakeInitValue(op),
                                       red_indices));
         }

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -708,7 +708,7 @@ void CodeGenTileLangCUDA::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
     return;
   }
 
-  if (t == tl::cuTensorMapType()) {
+  if (t == tl::CuTensorMapType()) {
     os << "CUtensorMap";
     return;
   }

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -247,7 +247,7 @@ std::string DTypeToString(DataType t) {
   if (t.is_void()) {
     return "void";
   }
-  if (t == tl::cuTensorMapType()) {
+  if (t == tl::CuTensorMapType()) {
     return "CUtensorMap";
   }
 

--- a/src/cuda/codegen/ptx.h
+++ b/src/cuda/codegen/ptx.h
@@ -98,10 +98,12 @@ std::tuple<int, int, int> ParseMMAShape(const std::string &str);
  */
 class Replacer {
 public:
+  // NOLINTNEXTLINE(readability-identifier-naming): TVM local helper style.
   void register_rule(const std::string &pattern,
                      const std::string &replacement) {
     _rules.emplace_back(pattern, replacement);
   }
+  // NOLINTNEXTLINE(readability-identifier-naming): TVM local helper style.
   std::string rewrite(std::string str) {
     for (auto &&rule : _rules) {
       auto [pattern, replacement] = rule;
@@ -115,6 +117,7 @@ public:
     }
     return str;
   }
+  // NOLINTNEXTLINE(readability-identifier-naming): TVM local helper style.
   void empty_rules() { _rules.clear(); }
 
 private:

--- a/src/cuda/op/atomic_add.cc
+++ b/src/cuda/op/atomic_add.cc
@@ -275,9 +275,9 @@ struct AtomicAdd {
       const int64_t mat_continuous =
           *as_const_int(shared_tensor->shape[dim - 1]);
       Layout swizzle_layout_2d =
-          makeGemmABLayoutHopper(mat_stride, mat_continuous, mat_continuous,
+          MakeGemmABLayoutHopper(mat_stride, mat_continuous, mat_continuous,
                                  shared_tensor->dtype.bits(), /*k_inner=*/true);
-      if (StructuralEqual()(swizzle_layout_2d, makeLinearLayout(Array<PrimExpr>{
+      if (StructuralEqual()(swizzle_layout_2d, MakeLinearLayout(Array<PrimExpr>{
                                                    Integer(mat_stride),
                                                    Integer(mat_continuous)}))) {
         result_map.Set(shared_tensor, ComputeLinearLayout(shared_tensor));
@@ -338,7 +338,7 @@ struct AtomicAdd {
     desc.l2_promotion = static_cast<int>(CU_TENSOR_MAP_L2_PROMOTION_L2_128B);
     desc.oob_fill = static_cast<int>(CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
 
-    auto linear_layout = makeLinearLayout(shared_tensor->shape);
+    auto linear_layout = MakeLinearLayout(shared_tensor->shape);
     Buffer shared_tensor_unmapped = shared_tensor;
     desc.interleave = static_cast<int>(CU_TENSOR_MAP_INTERLEAVE_NONE);
     Layout shared_layout;
@@ -359,20 +359,20 @@ struct AtomicAdd {
       auto stride = as_const_int(shared_layout->InputShape()[ndim - 2]);
       auto continuous = as_const_int(shared_layout->InputShape()[ndim - 1]);
       ICHECK(stride != nullptr && continuous != nullptr);
-      if (StructuralEqual()(shared_layout, makeQuarterBankSwizzleLayout(
+      if (StructuralEqual()(shared_layout, MakeQuarterBankSwizzleLayout(
                                                shared_tensor_unmapped))) {
         desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B);
       } else if (StructuralEqual()(
                      shared_layout,
-                     makeHalfBankSwizzleLayout(shared_tensor_unmapped))) {
+                     MakeHalfBankSwizzleLayout(shared_tensor_unmapped))) {
         desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B);
       } else if (StructuralEqual()(
                      shared_layout,
-                     makeFullBankSwizzleLayout(shared_tensor_unmapped))) {
+                     MakeFullBankSwizzleLayout(shared_tensor_unmapped))) {
         desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_128B);
       } else if (StructuralEqual()(
                      shared_layout,
-                     makeGemmABLayoutPadded(*stride, *continuous,
+                     MakeGemmABLayoutPadded(*stride, *continuous,
                                             shared_tensor->dtype.bits()))) {
         DLOG(WARNING)
             << "AtomicAdd TMA cannot support a padded layout for src: "

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -603,9 +603,9 @@ LayoutMap Copy::InferTMemLayout(const CopyNode &op,
     for (int num_useful_wgs = num_threads / WARPGROUP_SIZE; num_useful_wgs >= 1;
          --num_useful_wgs) {
       int num_useful_threads = num_useful_wgs * WARPGROUP_SIZE;
-      Tcgen05Meta meta = getTcgen05MetaLd_32dp32b();
+      Tcgen05Meta meta = GetTcgen05MetaLd32Dp32B();
       auto [is_success, tmem_coord2frag, num_chunks_each_wg] =
-          expandTcgen05Layout(
+          ExpandTcgen05Layout(
               meta, phy_col_bounds->max_value - phy_col_bounds->min_value + 1,
               num_useful_threads, row_dom, col_dom);
       (void)num_chunks_each_wg;
@@ -615,7 +615,7 @@ LayoutMap Copy::InferTMemLayout(const CopyNode &op,
       Fragment logical_coord2frag =
           Fragment(logical_coords, tmem_coord2frag->Forward(phy_indices),
                    tmem_coord2frag->ForwardThread(phy_indices, std::nullopt),
-                   make_itervar("rep", 1));
+                   MakeIterVar("rep", 1));
       results.Set(reg_buf, logical_coord2frag->BindThreadRange(
                                layout_args.thread_bounds));
       break;
@@ -680,10 +680,10 @@ LayoutMap Copy::InferBulkLayout(const CopyNode &op,
       const int64_t mat_continuous =
           *as_const_int(shared_tensor->shape[dim - 1]);
       Layout swizzle_layout_2d =
-          makeGemmABLayoutHopper(mat_stride, mat_continuous, mat_continuous,
+          MakeGemmABLayoutHopper(mat_stride, mat_continuous, mat_continuous,
                                  shared_tensor->dtype.bits(),
                                  /*k_inner=*/true);
-      if (StructuralEqual()(swizzle_layout_2d, makeLinearLayout(Array<PrimExpr>{
+      if (StructuralEqual()(swizzle_layout_2d, MakeLinearLayout(Array<PrimExpr>{
                                                    Integer(mat_stride),
                                                    Integer(mat_continuous)}))) {
         result_map.Set(shared_tensor, ComputeLinearLayout(shared_tensor));
@@ -1094,10 +1094,10 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &lower_args,
   IterVar row_var = loop_vars[loop_vars.size() - 2];
   PrimExpr local_layout_thread_map =
       FloorMod(local_layout->ForwardThread(local_indices, std::nullopt), 32);
-  PrimExpr matrix_8x8_thread_map = makeGemmFragment8x8()->ForwardThread(
+  PrimExpr matrix_8x8_thread_map = MakeGemmFragment8x8()->ForwardThread(
       {FloorMod(row_var, 8), FloorMod(col_var, 8)}, std::nullopt);
   PrimExpr matrix_8x8_thread_map_trans =
-      makeGemmFragment8x8Transposed()->ForwardThread(
+      MakeGemmFragment8x8Transposed()->ForwardThread(
           {FloorMod(row_var, 8), FloorMod(col_var, 8)}, std::nullopt);
   PrimExpr local_indices_flattened =
       local_tensor.OffsetOf(local_indices_transformed).back();
@@ -1316,7 +1316,7 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
     for (int num_useful_wgs = num_threads / WARPGROUP_SIZE; num_useful_wgs >= 1;
          num_useful_wgs--) {
       int num_useful_threads = num_useful_wgs * WARPGROUP_SIZE;
-      auto [is_success, target_frag, num_chunks_each_wg] = expandTcgen05Layout(
+      auto [is_success, target_frag, num_chunks_each_wg] = ExpandTcgen05Layout(
           meta, tmem_phy_col_extent, num_useful_threads, row_dom, col_dom);
       if (!is_success) {
         continue;
@@ -1384,15 +1384,15 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
   };
 
   if (is_ld) {
-    try_tcgen05_instruction(getTcgen05MetaLd_32dp32b());
-    try_tcgen05_instruction(getTcgen05MetaLd_32dp64b());
-    try_tcgen05_instruction(getTcgen05MetaLd_32dp128b());
-    try_tcgen05_instruction(getTcgen05MetaLd_32dp256b());
+    try_tcgen05_instruction(GetTcgen05MetaLd32Dp32B());
+    try_tcgen05_instruction(GetTcgen05MetaLd32Dp64B());
+    try_tcgen05_instruction(GetTcgen05MetaLd32Dp128B());
+    try_tcgen05_instruction(GetTcgen05MetaLd32Dp256B());
   } else {
-    try_tcgen05_instruction(getTcgen05MetaSt_32dp32b());
-    try_tcgen05_instruction(getTcgen05MetaSt_32dp64b());
-    try_tcgen05_instruction(getTcgen05MetaSt_32dp128b());
-    try_tcgen05_instruction(getTcgen05MetaSt_32dp256b());
+    try_tcgen05_instruction(GetTcgen05MetaSt32Dp32B());
+    try_tcgen05_instruction(GetTcgen05MetaSt32Dp64B());
+    try_tcgen05_instruction(GetTcgen05MetaSt32Dp128B());
+    try_tcgen05_instruction(GetTcgen05MetaSt32Dp256B());
   }
 
   ICHECK(have_succeeded) << "Failed to find a suitable instruction for tcgen05."
@@ -1592,7 +1592,7 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
         << " not found in buffer_remap";
     shared_tensor = lower_args.buffer_remap.at(shared_tensor);
   } else {
-    shared_layout = makeLinearLayout(shared_shape);
+    shared_layout = MakeLinearLayout(shared_shape);
   }
 
   // Convert the TileLang layout to a possibly swizzled CuTe ComposedLayout.
@@ -2462,13 +2462,13 @@ Stmt Im2Col::Lower(const Im2ColOpNode &op, const LowerArgs &lower_args,
     desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_NONE);
   } else {
     ICHECK(shared_layout->InputDim() >= 2) << "Cannot detect TMA layout.";
-    if (StructuralEqual()(shared_layout, makeQuarterBankSwizzleLayout(dst))) {
+    if (StructuralEqual()(shared_layout, MakeQuarterBankSwizzleLayout(dst))) {
       desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B);
     } else if (StructuralEqual()(shared_layout,
-                                 makeHalfBankSwizzleLayout(dst))) {
+                                 MakeHalfBankSwizzleLayout(dst))) {
       desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B);
     } else if (StructuralEqual()(shared_layout,
-                                 makeFullBankSwizzleLayout(dst))) {
+                                 MakeFullBankSwizzleLayout(dst))) {
       desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_128B);
     } else {
       LOG(FATAL) << "Cannot detect TMA layout.";

--- a/src/cuda/op/copy_analysis.cc
+++ b/src/cuda/op/copy_analysis.cc
@@ -273,7 +273,7 @@ bool CheckBulkCopy1D(const Buffer &global_tensor, const Buffer &shared_tensor,
   if (layout_map.count(shared_tensor)) {
     Layout existing =
         layout_map.Get(shared_tensor).value().as<Layout>().value();
-    Layout linear_layout = makeLinearLayout(shared_tensor->shape);
+    Layout linear_layout = MakeLinearLayout(shared_tensor->shape);
     shared_is_contiguous = StructuralEqual()(existing, linear_layout);
   }
 

--- a/src/cuda/op/gemm.cc
+++ b/src/cuda/op/gemm.cc
@@ -125,7 +125,7 @@ ComputeDefaultWarpPartition(const GemmWarpPolicyNode &policy, int M, int N,
   ICHECK(N % k_n_per_warp == 0)
       << "N must be divisible by " << k_n_per_warp << ", but got " << N;
 
-  if (policy.isFullRow()) {
+  if (policy.IsFullRow()) {
     m_warp = num_warps;
     n_warp = 1;
     if (M % (m_warp * kMPerWarp) != 0) {
@@ -135,7 +135,7 @@ ComputeDefaultWarpPartition(const GemmWarpPolicyNode &policy, int M, int N,
       if (n_warp == 0)
         n_warp = 1;
     }
-  } else if (policy.isFullCol()) {
+  } else if (policy.IsFullCol()) {
     m_warp = 1;
     n_warp = num_warps;
     if (N % (n_warp * k_n_per_warp) != 0) {
@@ -145,7 +145,7 @@ ComputeDefaultWarpPartition(const GemmWarpPolicyNode &policy, int M, int N,
       if (m_warp == 0)
         m_warp = 1;
     }
-  } else if (policy.isSquare()) {
+  } else if (policy.IsSquare()) {
     int max_m_warps = M / kMPerWarp;
     float ideal_ratio = N > 0 ? static_cast<float>(M) / N : 1.0f;
 
@@ -201,7 +201,7 @@ std::pair<int, int> ComputeWgmmaWarpPartition(const GemmWarpPolicyNode &policy,
   m_warp = kGroup;
   n_warp = num_warps / m_warp;
 
-  if (policy.isFullRow()) {
+  if (policy.IsFullRow()) {
     for (int cand = num_warps; cand >= kGroup; cand -= kGroup) {
       if (M % (cand * kMPerWarp) == 0) {
         m_warp = cand;
@@ -209,7 +209,7 @@ std::pair<int, int> ComputeWgmmaWarpPartition(const GemmWarpPolicyNode &policy,
         break;
       }
     }
-  } else if (policy.isFullCol()) {
+  } else if (policy.IsFullCol()) {
     int cand_n = n_warp;
     if (N % (cand_n * kNPerWarp) != 0) {
       int max_n = N / kNPerWarp;
@@ -221,7 +221,7 @@ std::pair<int, int> ComputeWgmmaWarpPartition(const GemmWarpPolicyNode &policy,
         }
       }
     }
-  } else if (policy.isSquare()) {
+  } else if (policy.IsSquare()) {
     int max_m = M / kMPerWarp;
     int max_n = N / kNPerWarp;
 

--- a/src/cuda/op/gemm_sp.cc
+++ b/src/cuda/op/gemm_sp.cc
@@ -119,7 +119,7 @@ ComputeDefaultWarpPartition(const GemmSPWarpPolicyNode &policy, int M, int N,
   ICHECK(N % k_n_per_warp == 0)
       << "N must be divisible by " << k_n_per_warp << ", but got " << N;
 
-  if (policy.isFullRow()) {
+  if (policy.IsFullRow()) {
     m_warp = num_warps;
     n_warp = 1;
     if (M % (m_warp * kMPerWarp) != 0) {
@@ -129,7 +129,7 @@ ComputeDefaultWarpPartition(const GemmSPWarpPolicyNode &policy, int M, int N,
       if (n_warp == 0)
         n_warp = 1;
     }
-  } else if (policy.isFullCol()) {
+  } else if (policy.IsFullCol()) {
     m_warp = 1;
     n_warp = num_warps;
     if (N % (n_warp * k_n_per_warp) != 0) {
@@ -139,7 +139,7 @@ ComputeDefaultWarpPartition(const GemmSPWarpPolicyNode &policy, int M, int N,
       if (m_warp == 0)
         m_warp = 1;
     }
-  } else if (policy.isSquare()) {
+  } else if (policy.IsSquare()) {
     int max_m_warps = M / kMPerWarp;
     float ideal_ratio = N > 0 ? static_cast<float>(M) / N : 1.0f;
 
@@ -196,7 +196,7 @@ ComputeWgmmaWarpPartition(const GemmSPWarpPolicyNode &policy, int M, int N,
   m_warp = kGroup;
   n_warp = num_warps / m_warp;
 
-  if (policy.isFullRow()) {
+  if (policy.IsFullRow()) {
     for (int cand = num_warps; cand >= kGroup; cand -= kGroup) {
       if (M % (cand * kMPerWarp) == 0) {
         m_warp = cand;
@@ -204,7 +204,7 @@ ComputeWgmmaWarpPartition(const GemmSPWarpPolicyNode &policy, int M, int N,
         break;
       }
     }
-  } else if (policy.isFullCol()) {
+  } else if (policy.IsFullCol()) {
     int cand_n = n_warp;
     if (N % (cand_n * kNPerWarp) != 0) {
       int max_n = N / kNPerWarp;
@@ -216,7 +216,7 @@ ComputeWgmmaWarpPartition(const GemmSPWarpPolicyNode &policy, int M, int N,
         }
       }
     }
-  } else if (policy.isSquare()) {
+  } else if (policy.IsSquare()) {
     int max_m = M / kMPerWarp;
     int max_n = N / kNPerWarp;
 

--- a/src/cuda/transform/lower_hopper_intrin.cc
+++ b/src/cuda/transform/lower_hopper_intrin.cc
@@ -188,7 +188,7 @@ public:
       } else {
         String name = call->args[2].as<Var>().value()->name_hint;
         var = Var(name + "_desc",
-                  PointerType(PrimType(cuTensorMapType()), "grid_constant"));
+                  PointerType(PrimType(CuTensorMapType()), "grid_constant"));
         Call call_ref = GetRef<Call>(call);
         desc_map_[call_ref] = var;
         Array<PrimExpr> init_desc_args = MakeInitDescArgs(call_ref, var);

--- a/src/layout/gemm_layouts.cc
+++ b/src/layout/gemm_layouts.cc
@@ -28,42 +28,42 @@ namespace tl {
 using namespace tirx;
 using namespace ffi;
 
-IterVar make_itervar(std::string name, PrimExpr dom) {
+IterVar MakeIterVar(std::string name, PrimExpr dom) {
   Var var = Var(name, dom->dtype);
   return IterVar(Range(0, dom), var, IterVarType::kDataPar);
 }
 
 Fragment makeGemmFragment8x4() {
-  IterVar i = make_itervar("i", 8);
-  IterVar j = make_itervar("j", 4);
-  IterVar rep = make_itervar("rep", 1);
+  IterVar i = MakeIterVar("i", 8);
+  IterVar j = MakeIterVar("j", 4);
+  IterVar rep = MakeIterVar("rep", 1);
   PrimExpr forward_thread = FloorDiv(j->var, 1) + 4 * i;
   PrimExpr index = FloorMod(j->var, 1);
   return Fragment({i, j}, {index}, forward_thread, rep);
 }
 
-Fragment makeGemmFragment8x8() {
-  IterVar i = make_itervar("i", 8);
-  IterVar j = make_itervar("j", 8);
-  IterVar rep = make_itervar("rep", 1);
+Fragment MakeGemmFragment8x8() {
+  IterVar i = MakeIterVar("i", 8);
+  IterVar j = MakeIterVar("j", 8);
+  IterVar rep = MakeIterVar("rep", 1);
   PrimExpr forward_thread = FloorDiv(j->var, 2) + 4 * i;
   PrimExpr index = FloorMod(j->var, 2);
   return Fragment({i, j}, {index}, forward_thread, rep);
 }
 
 Fragment makeGemmFragment8x16() {
-  IterVar i = make_itervar("i", 8);
-  IterVar j = make_itervar("j", 16);
-  IterVar rep = make_itervar("rep", 1);
+  IterVar i = MakeIterVar("i", 8);
+  IterVar j = MakeIterVar("j", 16);
+  IterVar rep = MakeIterVar("rep", 1);
   PrimExpr forward_thread = FloorDiv(j->var, 4) + 4 * i;
   PrimExpr index = FloorMod(j->var, 4);
   return Fragment({i, j}, {index}, forward_thread, rep);
 }
 
-Fragment makeGemmFragment8x8Transposed() {
-  IterVar i = make_itervar("i", 8);
-  IterVar j = make_itervar("j", 8);
-  IterVar rep = make_itervar("rep", 1);
+Fragment MakeGemmFragment8x8Transposed() {
+  IterVar i = MakeIterVar("i", 8);
+  IterVar j = MakeIterVar("j", 8);
+  IterVar rep = MakeIterVar("rep", 1);
   PrimExpr forward_thread = FloorDiv(i->var, 2) + 4 * j;
   PrimExpr index = FloorMod(i->var, 2);
   return Fragment({i, j}, {index}, forward_thread, rep);
@@ -75,45 +75,45 @@ From https://github.com/RadeonOpenCompute/amd_matrix_instruction_calculator
 --detail-instruction
 */
 Fragment makeGemmFragmentAB16x16CDNA(const int k_pack) {
-  IterVar i = make_itervar("i", 16);
-  IterVar j = make_itervar("j", 16 * k_pack);
-  IterVar rep = make_itervar("rep", 1);
+  IterVar i = MakeIterVar("i", 16);
+  IterVar j = MakeIterVar("j", 16 * k_pack);
+  IterVar rep = MakeIterVar("rep", 1);
   PrimExpr forward_thread = 16 * FloorDiv(j->var, 4 * k_pack) + i;
   PrimExpr index = FloorMod(j->var, 4 * k_pack);
   return Fragment({i, j}, {index}, forward_thread, rep);
 }
 
 Fragment makeGemmFragmentAB16x16CDNATransposed(const int k_pack) {
-  IterVar i = make_itervar("i", 16 * k_pack);
-  IterVar j = make_itervar("j", 16);
-  IterVar rep = make_itervar("rep", 1);
+  IterVar i = MakeIterVar("i", 16 * k_pack);
+  IterVar j = MakeIterVar("j", 16);
+  IterVar rep = MakeIterVar("rep", 1);
   PrimExpr forward_thread = 16 * FloorDiv(i->var, 4 * k_pack) + j;
   PrimExpr index = FloorMod(i->var, 4 * k_pack);
   return Fragment({i, j}, {index}, forward_thread, rep);
 }
 
 Fragment makeGemmFragmentAB16x32CDNA(const int k_pack) {
-  IterVar i = make_itervar("i", 16);
-  IterVar j = make_itervar("j", 32 * k_pack);
-  IterVar rep = make_itervar("rep", 1);
+  IterVar i = MakeIterVar("i", 16);
+  IterVar j = MakeIterVar("j", 32 * k_pack);
+  IterVar rep = MakeIterVar("rep", 1);
   PrimExpr forward_thread = 16 * FloorDiv(j->var, 8 * k_pack) + i;
   PrimExpr index = FloorMod(j->var, 8 * k_pack);
   return Fragment({i, j}, {index}, forward_thread, rep);
 }
 
 Fragment makeGemmFragmentAB16x32CDNATransposed(const int k_pack) {
-  IterVar i = make_itervar("i", 32 * k_pack);
-  IterVar j = make_itervar("j", 16);
-  IterVar rep = make_itervar("rep", 1);
+  IterVar i = MakeIterVar("i", 32 * k_pack);
+  IterVar j = MakeIterVar("j", 16);
+  IterVar rep = MakeIterVar("rep", 1);
   PrimExpr forward_thread = 16 * FloorDiv(i->var, 8 * k_pack) + j;
   PrimExpr index = FloorMod(i->var, 8 * k_pack);
   return Fragment({i, j}, {index}, forward_thread, rep);
 }
 
 Fragment makeGemmFragmentC16x16CDNA() {
-  IterVar i = make_itervar("i", 16);
-  IterVar j = make_itervar("j", 16);
-  IterVar rep = make_itervar("rep", 1);
+  IterVar i = MakeIterVar("i", 16);
+  IterVar j = MakeIterVar("j", 16);
+  IterVar rep = MakeIterVar("rep", 1);
   PrimExpr forward_thread = 16 * FloorDiv(j->var, 4) + i;
   PrimExpr index = FloorMod(j->var, 4);
   return Fragment({i, j}, {index}, forward_thread, rep);
@@ -125,7 +125,7 @@ Fragment makeGemmFragmentC_F64(const int block_m, const int block_n,
   ICHECK(block_n % warp_n == 0);
   ICHECK(warp_m % 16 == 0);
   ICHECK(warp_n % 8 == 0);
-  auto base_layout = makeGemmFragment8x8();
+  auto base_layout = MakeGemmFragment8x8();
   auto warp_layout =
       base_layout->Repeat({block_m / warp_m, block_n / warp_n}, true, false);
   auto block_layout =
@@ -133,7 +133,7 @@ Fragment makeGemmFragmentC_F64(const int block_m, const int block_n,
   return block_layout;
 }
 
-Fragment makeGemmFragmentC(const int block_m, const int block_n,
+Fragment MakeGemmFragmentC(const int block_m, const int block_n,
                            const int warp_m, const int warp_n,
                            const int element_size) {
   if (element_size == 64)
@@ -142,7 +142,7 @@ Fragment makeGemmFragmentC(const int block_m, const int block_n,
   ICHECK(block_n % warp_n == 0);
   ICHECK(warp_m % 16 == 0) << "warp_m=" << warp_m;
   ICHECK(warp_n % 8 == 0) << "warp_n=" << warp_n;
-  auto base_layout = makeGemmFragment8x8()->Repeat({2, 1}, false);
+  auto base_layout = MakeGemmFragment8x8()->Repeat({2, 1}, false);
   auto warp_layout =
       base_layout->Repeat({block_m / warp_m, block_n / warp_n}, true, false);
   auto block_layout =
@@ -150,7 +150,7 @@ Fragment makeGemmFragmentC(const int block_m, const int block_n,
   return block_layout;
 }
 
-Fragment makeGemmSparseFragmentC(const int block_m, const int block_n,
+Fragment MakeGemmSparseFragmentC(const int block_m, const int block_n,
                                  const int warp_m, const int warp_n,
                                  const int element_size) {
   if (element_size == 64) {
@@ -160,7 +160,7 @@ Fragment makeGemmSparseFragmentC(const int block_m, const int block_n,
   ICHECK(block_n % warp_n == 0);
   ICHECK(warp_m % 16 == 0) << "warp_m=" << warp_m;
   ICHECK(warp_n % 8 == 0) << "warp_n=" << warp_n;
-  auto base_layout = makeGemmFragment8x8()->Repeat({2, 1}, false);
+  auto base_layout = MakeGemmFragment8x8()->Repeat({2, 1}, false);
   // NOTE: This func wasn't implemented by following the CUTLASS 2 iterator
   // but by inspecting the output, it appears that we first need to
   // repeat the warp layout while avoiding duplicate thread mappings.
@@ -171,7 +171,7 @@ Fragment makeGemmSparseFragmentC(const int block_m, const int block_n,
   return block_layout;
 }
 
-Fragment makeGemmFragmentCCDNA(const int block_m, const int block_n,
+Fragment MakeGemmFragmentCCDNA(const int block_m, const int block_n,
                                const int warp_m, const int warp_n,
                                const int element_size) {
   if (element_size == 64)
@@ -188,20 +188,20 @@ Fragment makeGemmFragmentCCDNA(const int block_m, const int block_n,
   return block_layout;
 }
 
-Fragment makeGemmFragmentCHopper(const int block_m, const int block_n,
+Fragment MakeGemmFragmentCHopper(const int block_m, const int block_n,
                                  const int warp_m, const int warp_n,
                                  const int element_size) {
   ICHECK(block_m % warp_m == 0);
   ICHECK(warp_m % 16 == 0) << "warp_m=" << warp_m;
 
-  auto warp_layout = makeGemmFragment8x8()->Repeat({2, warp_n / 8}, false,
+  auto warp_layout = MakeGemmFragment8x8()->Repeat({2, warp_n / 8}, false,
                                                    false); // 16 x N (1 warp)
   auto block_layout = warp_layout->Repeat({block_m / warp_m, block_n / warp_n},
                                           true, false); // 16*Y x N (Y warp)
   return block_layout->Repeat({warp_m / 16, 1}, false, false);
 }
 
-Fragment makeGemmFragmentA(const int block_m, const int block_n,
+Fragment MakeGemmFragmentA(const int block_m, const int block_n,
                            const int block_k, const int warp_m,
                            const int warp_n, const int element_size,
                            bool transposed) {
@@ -216,7 +216,7 @@ Fragment makeGemmFragmentA(const int block_m, const int block_n,
 
   if (transposed) {
     auto base_layout =
-        makeGemmFragment8x8Transposed()->Repeat({2, 2}, false, true);
+        MakeGemmFragment8x8Transposed()->Repeat({2, 2}, false, true);
     auto warp_layout = base_layout->Repeat({1, block_m / warp_m}, true, false)
                            ->Replicate(block_n / warp_n);
     auto block_layout =
@@ -231,7 +231,7 @@ Fragment makeGemmFragmentA(const int block_m, const int block_n,
           warp_layout->Repeat({warp_m / 16, block_k / 32}, false, false);
       return block_layout;
     } else if (element_size == 16) {
-      auto base_layout = makeGemmFragment8x8()->Repeat({2, 2}, false, false);
+      auto base_layout = MakeGemmFragment8x8()->Repeat({2, 2}, false, false);
       auto warp_layout = base_layout->Repeat({block_m / warp_m, 1}, true)
                              ->Replicate(block_n / warp_n);
       auto block_layout =
@@ -251,14 +251,14 @@ Fragment makeGemmFragmentA(const int block_m, const int block_n,
   }
 }
 
-Fragment makeGemmFragmentB(const int block_m, const int block_n,
+Fragment MakeGemmFragmentB(const int block_m, const int block_n,
                            const int block_k, const int warp_m,
                            const int warp_n, bool transposed) {
   // transposed
   ICHECK(warp_n % 8 == 0);
   ICHECK(block_k % 16 == 0);
   if (transposed) {
-    auto base_layout = makeGemmFragment8x8()->Repeat({1, 2}, false, false);
+    auto base_layout = MakeGemmFragment8x8()->Repeat({1, 2}, false, false);
     auto warp_layout = base_layout->Replicate(block_m / warp_m)
                            ->Repeat({block_n / warp_n, 1}, true, false);
     auto block_layout =
@@ -266,7 +266,7 @@ Fragment makeGemmFragmentB(const int block_m, const int block_n,
     return block_layout;
   } else {
     auto base_layout =
-        makeGemmFragment8x8Transposed()->Repeat({2, 1}, false, false);
+        MakeGemmFragment8x8Transposed()->Repeat({2, 1}, false, false);
     auto warp_layout = base_layout->Replicate(block_m / warp_m)
                            ->Repeat({1, block_n / warp_n}, true);
     auto block_layout =
@@ -275,7 +275,7 @@ Fragment makeGemmFragmentB(const int block_m, const int block_n,
   }
 }
 
-Fragment makeGemmFragmentACDNA(const int block_m, const int block_n,
+Fragment MakeGemmFragmentACDNA(const int block_m, const int block_n,
                                const int block_k, const int warp_m,
                                const int warp_n, const int element_size,
                                const int k_pack, bool transposed) {
@@ -313,9 +313,9 @@ Fragment makeGemmFragmentACDNA(const int block_m, const int block_n,
 }
 
 Fragment makeGemmFragment32x32(int element_size) {
-  IterVar i = make_itervar("i", 32);
-  IterVar j = make_itervar("j", 32);
-  IterVar rep = make_itervar("rep", 1);
+  IterVar i = MakeIterVar("i", 32);
+  IterVar j = MakeIterVar("j", 32);
+  IterVar rep = MakeIterVar("rep", 1);
   ICHECK(element_size == 16 || element_size == 32);
   if (element_size == 16) {
     PrimExpr thd = FloorMod(i, 4) + FloorDiv(FloorMod(i, 16), 8) * 4 +
@@ -335,7 +335,7 @@ Fragment makeGemmFragment32x32(int element_size) {
   }
 }
 
-Fragment makeGemmVoltaFragmentC(const int block_m, const int block_n,
+Fragment MakeGemmVoltaFragmentC(const int block_m, const int block_n,
                                 const int warp_m, const int warp_n,
                                 int element_size) {
   ICHECK(block_m % warp_m == 0);
@@ -350,7 +350,7 @@ Fragment makeGemmVoltaFragmentC(const int block_m, const int block_n,
   return block_layout;
 }
 
-Fragment makeGemmVoltaFragmentA(const int block_m, const int block_n,
+Fragment MakeGemmVoltaFragmentA(const int block_m, const int block_n,
                                 const int block_k, const int warp_m,
                                 const int warp_n) {
   // assume not transposed
@@ -359,9 +359,9 @@ Fragment makeGemmVoltaFragmentA(const int block_m, const int block_n,
   ICHECK(warp_m % 32 == 0);
   ICHECK(block_k % 4 == 0);
   // this is a special case
-  IterVar i = make_itervar("i", 32);
-  IterVar j = make_itervar("j", 4);
-  IterVar rep = make_itervar("rep", 2);
+  IterVar i = MakeIterVar("i", 32);
+  IterVar j = MakeIterVar("j", 4);
+  IterVar rep = MakeIterVar("rep", 2);
   PrimExpr thd = FloorDiv(FloorMod(i, 16), 8) * 4 + 16 * FloorDiv(i, 16) +
                  FloorMod(i, 4) + 8 * rep;
   PrimExpr idx = j + FloorDiv(FloorMod(i, 8), 4) * 4;
@@ -461,7 +461,7 @@ static Layout MakeQuarterBankSwizzleLayout2D(int stride, int continuous,
   return Layout(Array<PrimExpr>{stride, continuous}, {tc, ts, index});
 }
 
-Layout makeQuarterBankSwizzleLayout(const Buffer &buffer) {
+Layout MakeQuarterBankSwizzleLayout(const Buffer &buffer) {
   auto info = GetSwizzleShapeInfoChecked(buffer);
   auto base = MakeQuarterBankSwizzleLayout2D(static_cast<int>(info.stride),
                                              static_cast<int>(info.continuous),
@@ -490,7 +490,7 @@ static Layout MakeHalfBankSwizzleLayout2D(int stride, int continuous,
   return Layout(Array<PrimExpr>{stride, continuous}, {tc, ts, index});
 }
 
-Layout makeHalfBankSwizzleLayout(const Buffer &buffer) {
+Layout MakeHalfBankSwizzleLayout(const Buffer &buffer) {
   auto info = GetSwizzleShapeInfoChecked(buffer);
   auto base = MakeHalfBankSwizzleLayout2D(static_cast<int>(info.stride),
                                           static_cast<int>(info.continuous),
@@ -519,7 +519,7 @@ static Layout MakeFullBankSwizzleLayout2D(int stride, int continuous,
   return Layout(Array<PrimExpr>{stride, continuous}, {tc, ts, index});
 }
 
-Layout makeFullBankSwizzleLayout(const Buffer &buffer) {
+Layout MakeFullBankSwizzleLayout(const Buffer &buffer) {
   auto info = GetSwizzleShapeInfoChecked(buffer);
   auto base = MakeFullBankSwizzleLayout2D(static_cast<int>(info.stride),
                                           static_cast<int>(info.continuous),
@@ -542,8 +542,8 @@ Layout makeMatrixCoreSwizzleLayout(int stride, int continuous, int element_size,
   const int perPhase = std::max(1, elemsPerOneBanksRow / innerDimLength);
   const int maxPhase = std::min(SIMDWidth / perPhase, innerDimLength / vecSize);
 
-  IterVar row = make_itervar("row", stride);
-  IterVar col = make_itervar("col", continuous);
+  IterVar row = MakeIterVar("row", stride);
+  IterVar col = MakeIterVar("col", continuous);
   PrimExpr phase = FloorMod(FloorDiv(row, perPhase), maxPhase);
   PrimExpr colOffSwizzled = (FloorDiv(col, vecSize) ^ phase) * vecSize;
   PrimExpr colOffOrdered = FloorMod(col, vecSize);
@@ -579,11 +579,11 @@ Layout makeGemmABLayoutF64_Kouter(int stride, int continuous) {
 }
 
 // The Default Layout for Tensor Access (row-major linear layout)
-Layout makeLinearLayout(Array<PrimExpr> shape) {
+Layout MakeLinearLayout(Array<PrimExpr> shape) {
   int ndim = static_cast<int>(shape.size());
   Array<IterVar> iter_vars;
   for (int i = 0; i < ndim; i++) {
-    iter_vars.push_back(make_itervar(std::string{char('i' + i)}, shape[i]));
+    iter_vars.push_back(MakeIterVar(std::string{char('i' + i)}, shape[i]));
   }
   // Row-major: index = i0 * (d1 * d2 * ...) + i1 * (d2 * ...) + ... + i_{n-1}
   PrimExpr linear_index = 0;
@@ -597,9 +597,9 @@ Layout makeLinearLayout(Array<PrimExpr> shape) {
   return Layout(iter_vars, {linear_index});
 }
 
-Layout makeGemmABLayoutPadded(int stride, int continuous, int element_size) {
-  IterVar i = make_itervar("i", stride);
-  IterVar j = make_itervar("j", continuous);
+Layout MakeGemmABLayoutPadded(int stride, int continuous, int element_size) {
+  IterVar i = MakeIterVar("i", stride);
+  IterVar j = MakeIterVar("j", continuous);
   int padded = continuous;
   // Add 128 bits padding when the last dim is a multiple of 256 bits
   if ((element_size * continuous) % 256 == 0)
@@ -609,8 +609,8 @@ Layout makeGemmABLayoutPadded(int stride, int continuous, int element_size) {
 
 Layout MakeGemmVoltaABLayoutCrosswise(int stride, int continuous) {
   ICHECK(stride % 32 == 0 && continuous % 32 == 0);
-  IterVar i = make_itervar("i", stride);
-  IterVar j = make_itervar("j", continuous);
+  IterVar i = MakeIterVar("i", stride);
+  IterVar j = MakeIterVar("j", continuous);
   PrimExpr vec_contiguous_idx = FloorDiv(j, 4);
   PrimExpr vec_strided_within_tile = FloorMod(vec_contiguous_idx, 8);
 
@@ -630,8 +630,8 @@ Layout MakeGemmVoltaABLayoutCrosswise(int stride, int continuous) {
 
 Layout MakeGemmVoltaALayoutCongruous(int stride, int continuous) {
   ICHECK(stride % 4 == 0 && continuous % 64 == 0);
-  IterVar i = make_itervar("i", stride);
-  IterVar j = make_itervar("j", continuous);
+  IterVar i = MakeIterVar("i", stride);
+  IterVar j = MakeIterVar("j", continuous);
   PrimExpr vec_contiguous_idx = FloorDiv(j, 8);
   PrimExpr vec_strided_idx = i;
   PrimExpr tile_contiguous_idx = FloorDiv(vec_contiguous_idx, 8);
@@ -655,8 +655,8 @@ Layout MakeGemmVoltaALayoutCongruous(int stride, int continuous) {
 
 Layout MakeGemmVoltaBLayoutCongruous(int stride, int continuous) {
   ICHECK(stride % 4 == 0 && continuous % 64 == 0);
-  IterVar i = make_itervar("i", stride);
-  IterVar j = make_itervar("j", continuous);
+  IterVar i = MakeIterVar("i", stride);
+  IterVar j = MakeIterVar("j", continuous);
   PrimExpr vec_contiguous_idx = FloorDiv(j, 8);
   PrimExpr vec_strided_idx = i;
   PrimExpr tile_contiguous_idx = FloorDiv(vec_contiguous_idx, 8);
@@ -678,7 +678,7 @@ Layout MakeGemmVoltaBLayoutCongruous(int stride, int continuous) {
   return Layout(Array{i, j}, {offset});
 }
 
-Layout makeGemmVoltaABLayout(int stride, int continuous, bool is_a,
+Layout MakeGemmVoltaABLayout(int stride, int continuous, bool is_a,
                              bool k_inner) {
   if (k_inner && continuous % 32 == 0 && stride % 32 == 0)
     return MakeGemmVoltaABLayoutCrosswise(stride, continuous);
@@ -686,14 +686,14 @@ Layout makeGemmVoltaABLayout(int stride, int continuous, bool is_a,
     return MakeGemmVoltaALayoutCongruous(stride, continuous);
   if (!is_a && continuous % 64 == 0 && stride % 4 == 0)
     return MakeGemmVoltaBLayoutCongruous(stride, continuous);
-  return makeGemmABLayoutPadded(stride, continuous, 16);
+  return MakeGemmABLayoutPadded(stride, continuous, 16);
 }
 
 // ref:
 // https://github.com/nvidia/cutlass/blob/ad7b2f5e84fcfa124cb02b91d5bd26d238c0459e/include/cutlass/layout/tensor_op_multiplicand_sm75.h#L54
 // Although the four settings (T or NT) used distinct layouts in CUTLASS, they
 // appeared to result in the same mem layout
-Layout makeTensorOpMultiplicand(int mat_stride, int mat_continuous,
+Layout MakeTensorOpMultiplicand(int mat_stride, int mat_continuous,
                                 int elementsize, int crosswise) {
   /// This layout is optimized for 128b accesses
   static int const kAccessSize = 128;
@@ -728,8 +728,8 @@ Layout makeTensorOpMultiplicand(int mat_stride, int mat_continuous,
   const int kPartitionShapeStride = 4;
 
   // NOTE: it's always row major for tl
-  IterVar i = make_itervar("i", mat_stride);
-  IterVar j = make_itervar("j", mat_continuous);
+  IterVar i = MakeIterVar("i", mat_stride);
+  IterVar j = MakeIterVar("j", mat_continuous);
 
   PrimExpr vec_contiguous_idx = FloorDiv(j, kElementsPerAccess);
   PrimExpr vec_strided_idx = FloorDiv(i, kFactor);
@@ -783,10 +783,10 @@ Layout makeTensorOpMultiplicand(int mat_stride, int mat_continuous,
                 {element_contiguous + element_strided * stride * kFactor});
 }
 
-Layout makeGemmSparseAmpereABLayout(int mat_stride, int mat_continuous,
+Layout MakeGemmSparseAmpereABLayout(int mat_stride, int mat_continuous,
                                     int elementsize) {
   int kCrosswise = std::min(mat_continuous, (1024 / elementsize));
-  return makeTensorOpMultiplicand(mat_stride, mat_continuous, elementsize,
+  return MakeTensorOpMultiplicand(mat_stride, mat_continuous, elementsize,
                                   kCrosswise);
 }
 
@@ -820,18 +820,18 @@ Layout makeGemmSparseAmpereABLayout(int mat_stride, int mat_continuous,
  *                  - k_inner == false uses a padded layout.
  * \return A Layout object representing the chosen memory layout.
  */
-Layout makeGemmABLayout(int mat_stride, int mat_continuous, int continuity,
+Layout MakeGemmABLayout(int mat_stride, int mat_continuous, int continuity,
                         int element_size, bool k_inner) {
   if (element_size == 64) {
     if (!k_inner && continuity % 16 == 0) // float64 KxN
       return makeGemmABLayoutF64_Kouter(mat_stride, mat_continuous);
     if (k_inner && continuity % 16 == 0) // float64 NxK
       return makeGemmABLayoutF64_Kinner(mat_stride, mat_continuous);
-    return makeGemmABLayoutPadded(mat_stride, mat_continuous, element_size);
+    return MakeGemmABLayoutPadded(mat_stride, mat_continuous, element_size);
   }
   int vector_size = 128 / element_size;
   if (!k_inner && element_size == 8) // int8 KxN
-    return makeGemmABLayoutPadded(mat_stride, mat_continuous, element_size);
+    return MakeGemmABLayoutPadded(mat_stride, mat_continuous, element_size);
   else if (mat_continuous % (vector_size * 8) == 0)
     return MakeFullBankSwizzleLayout2D(mat_stride, mat_continuous,
                                        element_size);
@@ -842,11 +842,11 @@ Layout makeGemmABLayout(int mat_stride, int mat_continuous, int continuity,
     return MakeQuarterBankSwizzleLayout2D(mat_stride, mat_continuous,
                                           element_size);
   else {
-    return makeGemmABLayoutPadded(mat_stride, mat_continuous, element_size);
+    return MakeGemmABLayoutPadded(mat_stride, mat_continuous, element_size);
   }
 }
 
-Layout makeGemmABLayoutHopper(int mat_stride, int mat_continuous,
+Layout MakeGemmABLayoutHopper(int mat_stride, int mat_continuous,
                               int continuity, int element_size, bool k_inner) {
   if (element_size == 64) {
     if (!k_inner && continuity % 16 == 0) // float64 KxN
@@ -855,7 +855,7 @@ Layout makeGemmABLayoutHopper(int mat_stride, int mat_continuous,
       return makeGemmABLayoutF64_Kinner(mat_stride, mat_continuous);
     // fallback for float64 when stride % 8 != 0
     if (mat_stride % 8 != 0)
-      return makeLinearLayout(
+      return MakeLinearLayout(
           Array<PrimExpr>{Integer(mat_stride), Integer(mat_continuous)});
     return MakeQuarterBankSwizzleLayout2D(mat_stride, mat_continuous,
                                           element_size);
@@ -875,7 +875,7 @@ Layout makeGemmABLayoutHopper(int mat_stride, int mat_continuous,
   }
 
   if (mat_continuous % vector_size == 0)
-    return makeLinearLayout(
+    return MakeLinearLayout(
         Array<PrimExpr>{Integer(mat_stride), Integer(mat_continuous)});
   else
     ICHECK(0) << "Unsupported layout for Hopper with stride=" << mat_stride
@@ -884,7 +884,7 @@ Layout makeGemmABLayoutHopper(int mat_stride, int mat_continuous,
   TILELANG_COMPILER_UNREACHABLE(); // to prevent compiler warning
 }
 
-Layout makeGemmABLayoutSm100(int mat_stride, int mat_continuous, int continuity,
+Layout MakeGemmABLayoutSm100(int mat_stride, int mat_continuous, int continuity,
                              int element_size, bool k_inner) {
   if (element_size == 64) {
     ICHECK(0) << "float64 on sm100 is not supported now";
@@ -904,7 +904,7 @@ Layout makeGemmABLayoutSm100(int mat_stride, int mat_continuous, int continuity,
   }
 
   if (mat_continuous % vector_size == 0)
-    return makeLinearLayout(
+    return MakeLinearLayout(
         Array<PrimExpr>{Integer(mat_stride), Integer(mat_continuous)});
   else
     ICHECK(0) << "Unsupported layout for sm100 with stride=" << mat_stride
@@ -913,51 +913,51 @@ Layout makeGemmABLayoutSm100(int mat_stride, int mat_continuous, int continuity,
   TILELANG_COMPILER_UNREACHABLE(); // to prevent compiler warning
 }
 
-Layout makeGemmABLayoutCDNA(int stride, int continuous, int element_size,
+Layout MakeGemmABLayoutCDNA(int stride, int continuous, int element_size,
                             int kPack) {
   return makeMatrixCoreSwizzleLayout(stride, continuous, element_size, kPack);
 }
 
-Layout makeSwizzledLayout(const Buffer &buffer, bool k_inner, bool allow_pad) {
+Layout MakeSwizzledLayout(const Buffer &buffer, bool k_inner, bool allow_pad) {
   auto info = GetSwizzleShapeInfoChecked(buffer);
   Layout base;
   if (allow_pad) {
-    base = makeGemmABLayout(
+    base = MakeGemmABLayout(
         static_cast<int>(info.stride), static_cast<int>(info.continuous),
         static_cast<int>(info.continuous), info.element_size, k_inner);
   } else {
-    base = makeGemmABLayoutHopper(
+    base = MakeGemmABLayoutHopper(
         static_cast<int>(info.stride), static_cast<int>(info.continuous),
         static_cast<int>(info.continuous), info.element_size, k_inner);
   }
   return ExpandLayout2D(base, buffer);
 }
 
-Layout makeVoltaSwizzledLayout(const Buffer &buffer, bool is_a, bool k_inner) {
+Layout MakeVoltaSwizzledLayout(const Buffer &buffer, bool is_a, bool k_inner) {
   auto info = GetSwizzleShapeInfoChecked(buffer);
   auto base =
-      makeGemmVoltaABLayout(static_cast<int>(info.stride),
+      MakeGemmVoltaABLayout(static_cast<int>(info.stride),
                             static_cast<int>(info.continuous), is_a, k_inner);
   return ExpandLayout2D(base, buffer);
 }
 
-Layout makeWgmmaSwizzledLayout(const Buffer &buffer, int continuity,
+Layout MakeWgmmaSwizzledLayout(const Buffer &buffer, int continuity,
                                bool k_inner) {
   auto info = GetSwizzleShapeInfoChecked(buffer);
   if (continuity < 0)
     continuity = static_cast<int>(info.continuous);
-  auto base = makeGemmABLayoutHopper(static_cast<int>(info.stride),
+  auto base = MakeGemmABLayoutHopper(static_cast<int>(info.stride),
                                      static_cast<int>(info.continuous),
                                      continuity, info.element_size, k_inner);
   return ExpandLayout2D(base, buffer);
 }
 
-Layout makeTcgen05mmaSwizzledLayout(const Buffer &buffer, int continuity,
+Layout MakeTcgen05MmaSwizzledLayout(const Buffer &buffer, int continuity,
                                     bool k_inner) {
   auto info = GetSwizzleShapeInfoChecked(buffer);
   if (continuity < 0)
     continuity = static_cast<int>(info.continuous);
-  auto base = makeGemmABLayoutSm100(static_cast<int>(info.stride),
+  auto base = MakeGemmABLayoutSm100(static_cast<int>(info.stride),
                                     static_cast<int>(info.continuous),
                                     continuity, info.element_size, k_inner);
   return ExpandLayout2D(base, buffer);
@@ -977,19 +977,19 @@ SwizzleMode DetectSwizzleMode(const Layout &layout, const Buffer &buffer) {
   bool stride_ok = info.stride == 4 || info.stride % 8 == 0;
   if (stride_ok &&
       info.continuous % (static_cast<int64_t>(vector_size) * 2) == 0) {
-    if (StructuralEqual()(layout, makeQuarterBankSwizzleLayout(buffer))) {
+    if (StructuralEqual()(layout, MakeQuarterBankSwizzleLayout(buffer))) {
       return SwizzleMode::kQuarter;
     }
   }
   if (stride_ok &&
       info.continuous % (static_cast<int64_t>(vector_size) * 4) == 0) {
-    if (StructuralEqual()(layout, makeHalfBankSwizzleLayout(buffer))) {
+    if (StructuralEqual()(layout, MakeHalfBankSwizzleLayout(buffer))) {
       return SwizzleMode::kHalf;
     }
   }
   if (stride_ok &&
       info.continuous % (static_cast<int64_t>(vector_size) * 8) == 0) {
-    if (StructuralEqual()(layout, makeFullBankSwizzleLayout(buffer))) {
+    if (StructuralEqual()(layout, MakeFullBankSwizzleLayout(buffer))) {
       return SwizzleMode::kFull;
     }
   }
@@ -1016,11 +1016,11 @@ Optional<Layout> MergeSwizzleLayouts(const Layout &layout1,
 
   switch (min_mode) {
   case SwizzleMode::kQuarter:
-    return makeQuarterBankSwizzleLayout(buffer);
+    return MakeQuarterBankSwizzleLayout(buffer);
   case SwizzleMode::kHalf:
-    return makeHalfBankSwizzleLayout(buffer);
+    return MakeHalfBankSwizzleLayout(buffer);
   case SwizzleMode::kFull:
-    return makeFullBankSwizzleLayout(buffer);
+    return MakeFullBankSwizzleLayout(buffer);
   default:
     return std::nullopt;
   }

--- a/src/layout/layout.cc
+++ b/src/layout/layout.cc
@@ -300,7 +300,7 @@ Var InputPlaceholder(size_t idx) {
   return getPlaceholder(std::string{'_', char('i' + idx)});
 }
 
-Map<Var, Range> LayoutNode::getVarMap() const {
+Map<Var, Range> LayoutNode::GetVarMap() const {
   Map<Var, Range> map;
   for (size_t i = 0; i < InputDim(); i++) {
     map.Set(InputPlaceholder(i), {0, input_size_[i]});
@@ -308,8 +308,8 @@ Map<Var, Range> LayoutNode::getVarMap() const {
   return map;
 }
 
-Map<Var, Range> FragmentNode::getVarMap() const {
-  auto map = LayoutNode::getVarMap();
+Map<Var, Range> FragmentNode::GetVarMap() const {
+  auto map = LayoutNode::GetVarMap();
   map.Set(ReplicationPlaceholder(), {0, ReplicateExtent()});
   return map;
 }
@@ -351,7 +351,7 @@ void LayoutNode::RegisterReflection() {
 }
 
 void LayoutNode::UpdateAnalyzer(arith::Analyzer *analyzer) const {
-  for (const auto &[var, dom] : getVarMap()) {
+  for (const auto &[var, dom] : GetVarMap()) {
     analyzer->Bind(var, dom);
   }
 }
@@ -623,7 +623,7 @@ LayoutNode::InverseWithLevel(bool require_padding_guard) const {
                   << symbolic_dims;
   }
   arith::IterMapResult res =
-      arith::DetectIterMap(forward_index_, getVarMap(), 1, level, &analyzer);
+      arith::DetectIterMap(forward_index_, GetVarMap(), 1, level, &analyzer);
   if (!res->errors.empty()) {
     std::ostringstream msg;
     msg << "Layout " << DebugOutput() << " has errors: " << res->errors;
@@ -799,7 +799,7 @@ FragmentNode::FragmentNode(Array<PrimExpr> input_size,
   forward_thread_ = analyzer.Simplify(forward_thread);
   if (forward_index.empty()) {
     forward_index = {
-        infer_fragment_index(getVarMap(), forward_thread_, &analyzer)};
+        infer_fragment_index(GetVarMap(), forward_thread_, &analyzer)};
   }
   forward_index_ = forward_index.Map(
       [&](const PrimExpr &e) { return analyzer.Simplify(e); });
@@ -901,7 +901,7 @@ FragmentNode::DetectInjective(bool require_padding_guard) const {
         << "NoCheck; symbolic dims: " << symbolic_dims;
   }
 
-  return arith::DetectIterMap(indices, getVarMap(), 1, level, &analyzer);
+  return arith::DetectIterMap(indices, GetVarMap(), 1, level, &analyzer);
 }
 
 PrimExpr FragmentNode::ThreadExtent() const {
@@ -955,7 +955,7 @@ FragmentNode::InverseWithLevel(bool require_padding_guard) const {
 
 Fragment FragmentNode::CondenseReplicateVar() const {
   arith::Analyzer analyzer;
-  auto input_iters = getVarMap();
+  auto input_iters = GetVarMap();
   input_iters.Set(ReplicationPlaceholder(), {0, ReplicateExtent()});
   PrimExpr new_forward_thread;
   IterVar new_thread_replicate;
@@ -1133,37 +1133,37 @@ TVM_FFI_STATIC_INIT_BLOCK() {
            [](Fragment fragment) { return fragment->CondenseReplicateVar(); })
       .def("tl.make_swizzled_layout",
            [](const Buffer &buffer, bool k_inner, bool allow_pad) {
-             return makeSwizzledLayout(buffer, k_inner, allow_pad);
+             return MakeSwizzledLayout(buffer, k_inner, allow_pad);
            })
       .def("tl.make_volta_swizzled_layout",
            [](const Buffer &buffer, bool is_a, bool k_inner) {
-             return makeVoltaSwizzledLayout(buffer, is_a, k_inner);
+             return MakeVoltaSwizzledLayout(buffer, is_a, k_inner);
            })
       .def("tl.make_wgmma_swizzled_layout",
            [](const Buffer &buffer, int continuity, bool k_inner) {
-             return makeWgmmaSwizzledLayout(buffer, continuity, k_inner);
+             return MakeWgmmaSwizzledLayout(buffer, continuity, k_inner);
            })
       .def("tl.make_tcgen05mma_swizzled_layout",
            [](const Buffer &buffer, int continuity, bool k_inner) {
-             return makeTcgen05mmaSwizzledLayout(buffer, continuity, k_inner);
+             return MakeTcgen05MmaSwizzledLayout(buffer, continuity, k_inner);
            })
       .def("tl.make_full_bank_swizzled_layout",
            [](const Buffer &buffer) {
-             return makeFullBankSwizzleLayout(buffer);
+             return MakeFullBankSwizzleLayout(buffer);
            })
       .def("tl.make_half_bank_swizzled_layout",
            [](const Buffer &buffer) {
-             return makeHalfBankSwizzleLayout(buffer);
+             return MakeHalfBankSwizzleLayout(buffer);
            })
       .def("tl.make_quarter_bank_swizzled_layout",
            [](const Buffer &buffer) {
-             return makeQuarterBankSwizzleLayout(buffer);
+             return MakeQuarterBankSwizzleLayout(buffer);
            })
       .def("tl.make_linear_layout",
-           [](Array<PrimExpr> shape) { return makeLinearLayout(shape); })
-      .def("tl.make_gemm_fragment_8x8", []() { return makeGemmFragment8x8(); })
+           [](Array<PrimExpr> shape) { return MakeLinearLayout(shape); })
+      .def("tl.make_gemm_fragment_8x8", []() { return MakeGemmFragment8x8(); })
       .def("tl.make_gemm_fragment_8x8_transposed",
-           []() { return makeGemmFragment8x8Transposed(); })
+           []() { return MakeGemmFragment8x8Transposed(); })
       .def("tl.make_fully_replicated_layout_fragment",
            [](Array<PrimExpr> shape, PrimExpr thread_extent) {
              return Fragment::FullyReplicated(shape, thread_extent);

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -111,7 +111,7 @@ public:
       kTVMFFISEqHashKindTreeNode;
 
 protected:
-  virtual ffi::Map<tirx::Var, Range> getVarMap() const;
+  virtual ffi::Map<tirx::Var, Range> GetVarMap() const;
   void UpdateAnalyzer(arith::Analyzer *analyzer) const;
   ffi::Array<PrimExpr> forward_index_;
   ffi::Array<PrimExpr> input_size_;
@@ -188,7 +188,7 @@ public:
       kTVMFFISEqHashKindTreeNode;
 
 protected:
-  ffi::Map<tirx::Var, Range> getVarMap() const final;
+  ffi::Map<tirx::Var, Range> GetVarMap() const final;
   Range thread_range_;
   PrimExpr forward_thread_;
   PrimExpr replicate_size_;
@@ -227,73 +227,73 @@ public:
 
 tirx::Var InputPlaceholder(size_t idx);
 tirx::Var ReplicationPlaceholder();
-tirx::IterVar make_itervar(std::string name, PrimExpr dom);
+tirx::IterVar MakeIterVar(std::string name, PrimExpr dom);
 
-Fragment makeGemmFragment8x8();
-Fragment makeGemmFragment8x8Transposed();
-Fragment makeGemmFragmentC(const int block_m, const int block_n,
+Fragment MakeGemmFragment8x8();
+Fragment MakeGemmFragment8x8Transposed();
+Fragment MakeGemmFragmentC(const int block_m, const int block_n,
                            const int warp_m, const int warp_n,
                            const int element_size);
-Fragment makeGemmSparseFragmentC(const int block_m, const int block_n,
+Fragment MakeGemmSparseFragmentC(const int block_m, const int block_n,
                                  const int warp_m, const int warp_n,
                                  const int element_size);
-Fragment makeGemmFragmentCCDNA(const int block_m, const int block_n,
+Fragment MakeGemmFragmentCCDNA(const int block_m, const int block_n,
                                const int warp_m, const int warp_n,
                                const int element_size);
-Fragment makeGemmFragmentCHopper(const int block_m, const int block_n,
+Fragment MakeGemmFragmentCHopper(const int block_m, const int block_n,
                                  const int warp_m, const int warp_n,
                                  const int element_size);
-Fragment makeGemmFragmentA(const int block_m, const int block_n,
+Fragment MakeGemmFragmentA(const int block_m, const int block_n,
                            const int block_k, const int warp_m,
                            const int warp_n, const int element_size,
                            bool transposed = false);
-Fragment makeGemmFragmentB(const int block_m, const int block_n,
+Fragment MakeGemmFragmentB(const int block_m, const int block_n,
                            const int block_k, const int warp_m,
                            const int warp_n, bool transposed = false);
 
-Fragment makeGemmFragmentACDNA(const int block_m, const int block_n,
+Fragment MakeGemmFragmentACDNA(const int block_m, const int block_n,
                                const int block_k, const int warp_m,
                                const int warp_n, const int element_size,
                                const int k_pack, bool transposed = false);
 
 // Default Memory Layout (row-major linear layout for any dimension)
-Layout makeLinearLayout(ffi::Array<PrimExpr> shape);
-Layout makeGemmABLayoutPadded(int stride, int continuous, int element_size);
-Layout makeGemmABLayout(int mat_stride, int mat_continuous, int continuity,
+Layout MakeLinearLayout(ffi::Array<PrimExpr> shape);
+Layout MakeGemmABLayoutPadded(int stride, int continuous, int element_size);
+Layout MakeGemmABLayout(int mat_stride, int mat_continuous, int continuity,
                         int element_size, bool k_inner = true);
-Layout makeGemmABLayoutHopper(int mat_stride, int mat_continuous,
+Layout MakeGemmABLayoutHopper(int mat_stride, int mat_continuous,
                               int continuity, int element_size,
                               bool k_inner = true);
-Layout makeGemmABLayoutSm100(int mat_stride, int mat_continuous, int continuity,
+Layout MakeGemmABLayoutSm100(int mat_stride, int mat_continuous, int continuity,
                              int element_size, bool k_inner = true);
-Layout makeGemmABLayoutCDNA(int stride, int continuous, int element_size,
+Layout MakeGemmABLayoutCDNA(int stride, int continuous, int element_size,
                             int kPack);
 
-Fragment makeGemmVoltaFragmentC(const int block_m, const int block_n,
+Fragment MakeGemmVoltaFragmentC(const int block_m, const int block_n,
                                 const int warp_m, const int warp_n,
                                 const int element_size);
-Fragment makeGemmVoltaFragmentA(const int block_m, const int block_n,
+Fragment MakeGemmVoltaFragmentA(const int block_m, const int block_n,
                                 const int block_k, const int warp_m,
                                 const int warp_n);
-Layout makeGemmVoltaABLayout(int stride, int continuous, bool is_a,
+Layout MakeGemmVoltaABLayout(int stride, int continuous, bool is_a,
                              bool k_inner = true);
 
-Layout makeTensorOpMultiplicand(int mat_stride, int mat_continuous,
+Layout MakeTensorOpMultiplicand(int mat_stride, int mat_continuous,
                                 int elementsize, int crosswise);
-Layout makeGemmSparseAmpereABLayout(int mat_stride, int mat_continuous,
+Layout MakeGemmSparseAmpereABLayout(int mat_stride, int mat_continuous,
                                     int elementsize);
 
-Layout makeSwizzledLayout(const tirx::Buffer &buffer, bool k_inner = true,
+Layout MakeSwizzledLayout(const tirx::Buffer &buffer, bool k_inner = true,
                           bool allow_pad = true);
-Layout makeVoltaSwizzledLayout(const tirx::Buffer &buffer, bool is_a = true,
+Layout MakeVoltaSwizzledLayout(const tirx::Buffer &buffer, bool is_a = true,
                                bool k_inner = true);
-Layout makeWgmmaSwizzledLayout(const tirx::Buffer &buffer, int continuity = -1,
+Layout MakeWgmmaSwizzledLayout(const tirx::Buffer &buffer, int continuity = -1,
                                bool k_inner = true);
-Layout makeTcgen05mmaSwizzledLayout(const tirx::Buffer &buffer,
+Layout MakeTcgen05MmaSwizzledLayout(const tirx::Buffer &buffer,
                                     int continuity = -1, bool k_inner = true);
-Layout makeFullBankSwizzleLayout(const tirx::Buffer &buffer);
-Layout makeHalfBankSwizzleLayout(const tirx::Buffer &buffer);
-Layout makeQuarterBankSwizzleLayout(const tirx::Buffer &buffer);
+Layout MakeFullBankSwizzleLayout(const tirx::Buffer &buffer);
+Layout MakeHalfBankSwizzleLayout(const tirx::Buffer &buffer);
+Layout MakeQuarterBankSwizzleLayout(const tirx::Buffer &buffer);
 
 // Swizzle mode for shared memory layouts (nvidia only)
 // Smaller enum value = smaller swizzle granularity

--- a/src/layout/tcgen05_layout.cc
+++ b/src/layout/tcgen05_layout.cc
@@ -17,7 +17,7 @@ namespace tl {
 
 using namespace tirx;
 
-static IterVar make_itervar(std::string name, Range dom) {
+static IterVar MakeIterVar(std::string name, Range dom) {
   Var var = Var(name, dom->min->dtype);
   return IterVar(dom, var, IterVarType::kDataPar);
 }
@@ -25,46 +25,46 @@ static IterVar make_itervar(std::string name, Range dom) {
 // ld and st share the same Fragment layout; only the instruction name differs.
 static Tcgen05Meta makeTcgen05Meta_32dp32b(bool is_store) {
   constexpr int INST_WIDTH = 1;
-  IterVar inst_row = make_itervar("row", 128);
-  IterVar inst_col = make_itervar("col", INST_WIDTH);
+  IterVar inst_row = MakeIterVar("row", 128);
+  IterVar inst_col = MakeIterVar("col", INST_WIDTH);
   return Tcgen05Meta{is_store ? "tl::tcgen05_st_32dp32bNx"
                               : "tl::tcgen05_ld_32dp32bNx",
                      Fragment({inst_row, inst_col}, {inst_col}, {inst_row},
-                              make_itervar("rep", Range(0, 1))),
+                              MakeIterVar("rep", Range(0, 1))),
                      INST_WIDTH};
 }
 
 static Tcgen05Meta makeTcgen05Meta_32dp64b(bool is_store) {
   constexpr int INST_WIDTH = 2;
-  IterVar inst_row = make_itervar("row", 128);
-  IterVar inst_col = make_itervar("col", INST_WIDTH);
+  IterVar inst_row = MakeIterVar("row", 128);
+  IterVar inst_col = MakeIterVar("col", INST_WIDTH);
   return Tcgen05Meta{
       is_store ? "tl::tcgen05_st_32dp64bNx" : "tl::tcgen05_ld_32dp64bNx",
       Fragment({inst_row, inst_col}, {FloorDiv(FloorMod(inst_row, 32), 16)},
                {FloorDiv(inst_row, 32) * 32 + FloorMod(inst_row, 8) * 4 +
                 FloorDiv(FloorMod(inst_row, 16), 8) +
                 FloorMod(inst_col, 2) * 2},
-               make_itervar("rep", Range(0, 1))),
+               MakeIterVar("rep", Range(0, 1))),
       INST_WIDTH};
 }
 
 static Tcgen05Meta makeTcgen05Meta_32dp128b(bool is_store) {
   constexpr int INST_WIDTH = 4;
-  IterVar inst_row = make_itervar("row", 128);
-  IterVar inst_col = make_itervar("col", INST_WIDTH);
+  IterVar inst_row = MakeIterVar("row", 128);
+  IterVar inst_col = MakeIterVar("col", INST_WIDTH);
   return Tcgen05Meta{
       is_store ? "tl::tcgen05_st_32dp128bNx" : "tl::tcgen05_ld_32dp128bNx",
       Fragment({inst_row, inst_col}, {FloorDiv(FloorMod(inst_row, 32), 8)},
                {FloorDiv(inst_row, 32) * 32 + FloorMod(inst_row, 8) * 4 +
                 FloorMod(inst_col, 4)},
-               make_itervar("rep", Range(0, 1))),
+               MakeIterVar("rep", Range(0, 1))),
       INST_WIDTH};
 }
 
 static Tcgen05Meta makeTcgen05Meta_32dp256b(bool is_store) {
   constexpr int INST_WIDTH = 8;
-  IterVar inst_row = make_itervar("row", 128);
-  IterVar inst_col = make_itervar("col", INST_WIDTH);
+  IterVar inst_row = MakeIterVar("row", 128);
+  IterVar inst_col = MakeIterVar("col", INST_WIDTH);
   return Tcgen05Meta{
       is_store ? "tl::tcgen05_st_32dp256bNx" : "tl::tcgen05_ld_32dp256bNx",
       Fragment(
@@ -72,34 +72,30 @@ static Tcgen05Meta makeTcgen05Meta_32dp256b(bool is_store) {
           {FloorMod(inst_col, 2) + FloorDiv(FloorMod(inst_row, 32), 8) * 2},
           {FloorDiv(inst_row, 32) * 32 + FloorMod(inst_row, 8) * 4 +
            FloorDiv(FloorMod(inst_col, 8), 2)},
-          make_itervar("rep", Range(0, 1))),
+          MakeIterVar("rep", Range(0, 1))),
       INST_WIDTH};
 }
 
-Tcgen05Meta getTcgen05MetaLd_32dp32b() {
-  return makeTcgen05Meta_32dp32b(false);
-}
-Tcgen05Meta getTcgen05MetaLd_32dp64b() {
-  return makeTcgen05Meta_32dp64b(false);
-}
-Tcgen05Meta getTcgen05MetaLd_32dp128b() {
+Tcgen05Meta GetTcgen05MetaLd32Dp32B() { return makeTcgen05Meta_32dp32b(false); }
+Tcgen05Meta GetTcgen05MetaLd32Dp64B() { return makeTcgen05Meta_32dp64b(false); }
+Tcgen05Meta GetTcgen05MetaLd32Dp128B() {
   return makeTcgen05Meta_32dp128b(false);
 }
-Tcgen05Meta getTcgen05MetaLd_32dp256b() {
+Tcgen05Meta GetTcgen05MetaLd32Dp256B() {
   return makeTcgen05Meta_32dp256b(false);
 }
 
-Tcgen05Meta getTcgen05MetaSt_32dp32b() { return makeTcgen05Meta_32dp32b(true); }
-Tcgen05Meta getTcgen05MetaSt_32dp64b() { return makeTcgen05Meta_32dp64b(true); }
-Tcgen05Meta getTcgen05MetaSt_32dp128b() {
+Tcgen05Meta GetTcgen05MetaSt32Dp32B() { return makeTcgen05Meta_32dp32b(true); }
+Tcgen05Meta GetTcgen05MetaSt32Dp64B() { return makeTcgen05Meta_32dp64b(true); }
+Tcgen05Meta GetTcgen05MetaSt32Dp128B() {
   return makeTcgen05Meta_32dp128b(true);
 }
-Tcgen05Meta getTcgen05MetaSt_32dp256b() {
+Tcgen05Meta GetTcgen05MetaSt32Dp256B() {
   return makeTcgen05Meta_32dp256b(true);
 }
 
 std::tuple<bool, Fragment, int>
-expandTcgen05Layout(const Tcgen05Meta &meta, int tmem_phy_col_extent,
+ExpandTcgen05Layout(const Tcgen05Meta &meta, int tmem_phy_col_extent,
                     int num_threads, Range row_dom, Range col_dom) {
   static constexpr int WARPGROUP_SIZE = 128;
   ICHECK(num_threads % WARPGROUP_SIZE == 0);
@@ -117,8 +113,8 @@ expandTcgen05Layout(const Tcgen05Meta &meta, int tmem_phy_col_extent,
   int num_cols_each_wg = num_chunks_each_wg * meta.width;
   int num_elems_each_thread_in_one_chunk = meta.width * 128 / WARPGROUP_SIZE;
 
-  IterVar iter_row = make_itervar("row", row_dom);
-  IterVar iter_col = make_itervar("col", col_dom);
+  IterVar iter_row = MakeIterVar("row", row_dom);
+  IterVar iter_col = MakeIterVar("col", col_dom);
   PrimExpr thread_idx =
       meta.frag->ForwardThread({iter_row, FloorMod(iter_col, meta.width)},
                                std::nullopt) +
@@ -130,7 +126,7 @@ expandTcgen05Layout(const Tcgen05Meta &meta, int tmem_phy_col_extent,
 
   return {true,
           Fragment({iter_row, iter_col}, {val_idx}, thread_idx,
-                   make_itervar("rep", Range(0, 1))),
+                   MakeIterVar("rep", Range(0, 1))),
           num_chunks_each_wg};
 }
 

--- a/src/layout/tcgen05_layout.h
+++ b/src/layout/tcgen05_layout.h
@@ -18,21 +18,21 @@ struct Tcgen05Meta {
 };
 
 // Obtain the metadata for tcgen05.ld instructions.
-Tcgen05Meta getTcgen05MetaLd_32dp32b();
-Tcgen05Meta getTcgen05MetaLd_32dp64b();
-Tcgen05Meta getTcgen05MetaLd_32dp128b();
-Tcgen05Meta getTcgen05MetaLd_32dp256b();
+Tcgen05Meta GetTcgen05MetaLd32Dp32B();
+Tcgen05Meta GetTcgen05MetaLd32Dp64B();
+Tcgen05Meta GetTcgen05MetaLd32Dp128B();
+Tcgen05Meta GetTcgen05MetaLd32Dp256B();
 
 // Obtain the metadata for tcgen05.st instructions.
-Tcgen05Meta getTcgen05MetaSt_32dp32b();
-Tcgen05Meta getTcgen05MetaSt_32dp64b();
-Tcgen05Meta getTcgen05MetaSt_32dp128b();
-Tcgen05Meta getTcgen05MetaSt_32dp256b();
+Tcgen05Meta GetTcgen05MetaSt32Dp32B();
+Tcgen05Meta GetTcgen05MetaSt32Dp64B();
+Tcgen05Meta GetTcgen05MetaSt32Dp128B();
+Tcgen05Meta GetTcgen05MetaSt32Dp256B();
 
 // Expand a tcgen05 layout along thread_idx/value_idx (T/V) dimensions.
 // Return {is_success, fragment, num_chunks_each_wg}
 std::tuple<bool, Fragment, int>
-expandTcgen05Layout(const Tcgen05Meta &meta, int tmem_phy_col_extent,
+ExpandTcgen05Layout(const Tcgen05Meta &meta, int tmem_phy_col_extent,
                     int num_threads, Range row_dom, Range col_dom);
 
 } // namespace tl

--- a/src/metal/op/gemm.cc
+++ b/src/metal/op/gemm.cc
@@ -34,7 +34,7 @@ std::pair<int, int> ComputeMetalWarpPartition(const GemmWarpPolicyNode &policy,
   TVM_FFI_ICHECK(N % kNPerWarp == 0)
       << "N must be divisible by " << kNPerWarp << ", but got " << N;
 
-  if (policy.isFullRow()) {
+  if (policy.IsFullRow()) {
     m_warp = num_warps;
     n_warp = 1;
     if (M % (m_warp * kMPerWarp) != 0) {
@@ -45,7 +45,7 @@ std::pair<int, int> ComputeMetalWarpPartition(const GemmWarpPolicyNode &policy,
         n_warp = 1;
       }
     }
-  } else if (policy.isFullCol()) {
+  } else if (policy.IsFullCol()) {
     m_warp = 1;
     n_warp = num_warps;
     if (N % (n_warp * kNPerWarp) != 0) {
@@ -56,7 +56,7 @@ std::pair<int, int> ComputeMetalWarpPartition(const GemmWarpPolicyNode &policy,
         m_warp = 1;
       }
     }
-  } else if (policy.isSquare()) {
+  } else if (policy.IsSquare()) {
     std::tie(m_warp, n_warp) =
         ComputeSquareWarpPartition(num_warps, M, N, kMPerWarp, kNPerWarp);
   } else {

--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -52,7 +52,7 @@ TVM_REGISTER_PASS_CONFIG_OPTION(kDisableOutOfBoundWarning, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kEnableDumpIR, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDumpIRDir, ffi::String);
 
-DataType cuTensorMapType() { return DataType::UInt(8, 128); }
+DataType CuTensorMapType() { return DataType::UInt(8, 128); }
 
 #define TIR_DEFINE_TL_BUILTIN(OpName)                                          \
   const Op &OpName() {                                                         \

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -203,10 +203,10 @@ static constexpr const char *kDumpIRDir = "tl.dump_ir_path";
 /*!
  * \brief Get the type of the CUDA tensor map
  *
- * DataType cuTensorMapType()
+ * DataType CuTensorMapType()
  *
  */
-DataType cuTensorMapType();
+DataType CuTensorMapType();
 
 /*!
  * \brief TileLang intrinsic for carrying pointer access metadata in frontend.

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -163,11 +163,11 @@ TileOperator GemmNode::Clone() const {
   return Gemm(op);
 }
 
-String GemmNode::getGemmInstructionKey(int block_size, Target target) const {
+String GemmNode::GetGemmInstructionKey(int block_size, Target target) const {
   return ResolveGemmImpl(target).select_inst(*this, block_size, target);
 }
 
-std::pair<int, int> GemmWarpPolicyNode::computeWarpPartition(
+std::pair<int, int> GemmWarpPolicyNode::ComputeWarpPartition(
     int M, int N, int block_size, Target target, String gemm_inst) const {
   return ResolveGemmImpl(target).compute_warp_partition(*this, M, N, block_size,
                                                         target, gemm_inst);
@@ -232,7 +232,7 @@ LayoutMap GemmNode::InferLayout(const LayoutInferArgs &layout_args,
     // semantics. WGMMA/TCGEN5MMA have strict shared memory layout requirements
     // and must always set their layouts.
     auto block_size = *as_const_int(layout_args.thread_bounds->extent);
-    String gemm_inst = getGemmInstructionKey(block_size, layout_args.target);
+    String gemm_inst = GetGemmInstructionKey(block_size, layout_args.target);
     bool reuse_existing_shared_layout =
         ResolveGemmImpl(layout_args.target)
             .reuse_existing_shared_layout(gemm_inst);
@@ -301,12 +301,12 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   refl::GlobalDef().def("tl.GemmWarpPolicyComputeWarpPartition",
                         [](GemmWarpPolicy policy, int M, int N, int block_size,
                            Target target, String gemm_inst) {
-                          policy->computeWarpPartition(M, N, block_size, target,
+                          policy->ComputeWarpPartition(M, N, block_size, target,
                                                        gemm_inst);
                         });
   refl::GlobalDef().def("tl.GemmGetGemmInstructionKey",
                         [](Gemm gemm, int block_size, Target target) {
-                          return gemm->getGemmInstructionKey(block_size,
+                          return gemm->GetGemmInstructionKey(block_size,
                                                              target);
                         });
 }

--- a/src/op/gemm.h
+++ b/src/op/gemm.h
@@ -58,20 +58,20 @@ public:
         .def_ro("n_warp", &GemmWarpPolicyNode::n_warp);
   }
 
-  std::pair<int, int> computeWarpPartition(int M, int N, int block_size,
+  std::pair<int, int> ComputeWarpPartition(int M, int N, int block_size,
                                            Target target,
                                            String gemm_inst) const;
 
-  bool isSquare() const {
+  bool IsSquare() const {
     return policy_type == int(GemmWarpPolicyType::kSquare);
   }
-  bool isFullRow() const {
+  bool IsFullRow() const {
     return policy_type == int(GemmWarpPolicyType::kFullRow);
   }
-  bool isFullCol() const {
+  bool IsFullCol() const {
     return policy_type == int(GemmWarpPolicyType::kFullCol);
   }
-  bool isFree() const { return policy_type == int(GemmWarpPolicyType::kFree); }
+  bool IsFree() const { return policy_type == int(GemmWarpPolicyType::kFree); }
 };
 
 class GemmWarpPolicy : public ObjectRef {
@@ -166,7 +166,7 @@ public:
   TileOperator Clone() const;
 
   // Target-specific GEMM instruction key.
-  String getGemmInstructionKey(int block_size, Target target) const;
+  String GetGemmInstructionKey(int block_size, Target target) const;
 
 private:
   mutable bool completed_ = false;

--- a/src/op/gemm_sp.cc
+++ b/src/op/gemm_sp.cc
@@ -56,7 +56,7 @@ const GemmSPImpl &ResolveGemmSPImpl(Target target) {
 
 } // namespace
 
-std::pair<int, int> GemmSPWarpPolicyNode::computeWarpPartition(
+std::pair<int, int> GemmSPWarpPolicyNode::ComputeWarpPartition(
     int M, int N, int block_size, Target target, String gemm_inst) const {
   return ResolveGemmSPImpl(target).compute_warp_partition(
       *this, M, N, block_size, target, gemm_inst);
@@ -156,7 +156,7 @@ TileOperator GemmSPNode::Clone() const {
   return GemmSP(op);
 }
 
-String GemmSPNode::getGemmSPInstructionKey(int block_size,
+String GemmSPNode::GetGemmSPInstructionKey(int block_size,
                                            Target target) const {
   return ResolveGemmSPImpl(target).select_inst(*this, block_size, target);
 }
@@ -209,7 +209,7 @@ LayoutMap GemmSPNode::InferLayout(const LayoutInferArgs &layout_args,
     auto inferred_layouts = Downcast<LayoutMap>((*f)(
         GetRef<GemmSP>(this), layout_args.target, layout_args.thread_bounds));
     auto block_size = *as_const_int(layout_args.thread_bounds->extent);
-    String gemm_inst = getGemmSPInstructionKey(block_size, layout_args.target);
+    String gemm_inst = GetGemmSPInstructionKey(block_size, layout_args.target);
     bool reuse_existing_shared_layout =
         ResolveGemmSPImpl(layout_args.target)
             .reuse_existing_shared_layout(gemm_inst);
@@ -275,12 +275,12 @@ TVM_FFI_STATIC_INIT_BLOCK() {
   refl::GlobalDef().def("tl.GemmSPWarpPolicyComputeWarpPartition",
                         [](GemmSPWarpPolicy policy, int M, int N,
                            int block_size, Target target, String gemm_inst) {
-                          policy->computeWarpPartition(M, N, block_size, target,
+                          policy->ComputeWarpPartition(M, N, block_size, target,
                                                        gemm_inst);
                         });
   refl::GlobalDef().def("tl.GemmSPGetGemmInstructionKey",
                         [](GemmSP gemm, int block_size, Target target) {
-                          return gemm->getGemmSPInstructionKey(block_size,
+                          return gemm->GetGemmSPInstructionKey(block_size,
                                                                target);
                         });
 }

--- a/src/op/gemm_sp.h
+++ b/src/op/gemm_sp.h
@@ -35,20 +35,20 @@ public:
         .def_ro("n_warp", &GemmSPWarpPolicyNode::n_warp);
   }
 
-  std::pair<int, int> computeWarpPartition(int M, int N, int block_size,
+  std::pair<int, int> ComputeWarpPartition(int M, int N, int block_size,
                                            Target target,
                                            String gemm_inst) const;
 
-  bool isSquare() const {
+  bool IsSquare() const {
     return policy_type == int(GemmWarpPolicyType::kSquare);
   }
-  bool isFullRow() const {
+  bool IsFullRow() const {
     return policy_type == int(GemmWarpPolicyType::kFullRow);
   }
-  bool isFullCol() const {
+  bool IsFullCol() const {
     return policy_type == int(GemmWarpPolicyType::kFullCol);
   }
-  bool isFree() const { return policy_type == int(GemmWarpPolicyType::kFree); }
+  bool IsFree() const { return policy_type == int(GemmWarpPolicyType::kFree); }
 };
 
 class GemmSPWarpPolicy : public ObjectRef {
@@ -135,7 +135,7 @@ public:
   TileOperator Clone() const;
 
   // Target-specific GEMM SP instruction key.
-  String getGemmSPInstructionKey(int block_size, Target target) const;
+  String GetGemmSPInstructionKey(int block_size, Target target) const;
 
 private:
   mutable bool completed_ = false;

--- a/src/op/reduce.h
+++ b/src/op/reduce.h
@@ -41,14 +41,14 @@ public:
   }
 
   /// Type checking methods
-  bool isSum() const { return type == int(ReduceTypeEnum::kSum); }
-  bool isAbsSum() const { return type == int(ReduceTypeEnum::kAbsSum); }
-  bool isMax() const { return type == int(ReduceTypeEnum::kMax); }
-  bool isMin() const { return type == int(ReduceTypeEnum::kMin); }
-  bool isAbsMax() const { return type == int(ReduceTypeEnum::kAbsMax); }
-  bool isBitAnd() const { return type == int(ReduceTypeEnum::kBitAnd); }
-  bool isBitOr() const { return type == int(ReduceTypeEnum::kBitOr); }
-  bool isBitXor() const { return type == int(ReduceTypeEnum::kBitXor); }
+  bool IsSum() const { return type == int(ReduceTypeEnum::kSum); }
+  bool IsAbsSum() const { return type == int(ReduceTypeEnum::kAbsSum); }
+  bool IsMax() const { return type == int(ReduceTypeEnum::kMax); }
+  bool IsMin() const { return type == int(ReduceTypeEnum::kMin); }
+  bool IsAbsMax() const { return type == int(ReduceTypeEnum::kAbsMax); }
+  bool IsBitAnd() const { return type == int(ReduceTypeEnum::kBitAnd); }
+  bool IsBitOr() const { return type == int(ReduceTypeEnum::kBitOr); }
+  bool IsBitXor() const { return type == int(ReduceTypeEnum::kBitXor); }
 };
 
 /// Wrapper class for reduction type with string-based construction

--- a/src/op/scan.cc
+++ b/src/op/scan.cc
@@ -81,7 +81,7 @@ LayoutMap InferScanLayout(const ScanOpNode &op,
   LayoutMap result_map;
 
   auto make_linear_layout = [](const Buffer &buf) -> Layout {
-    return makeLinearLayout(buf->shape);
+    return MakeLinearLayout(buf->shape);
   };
 
   auto check_or_set_linear_layout = [&](const Buffer &buf) {

--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -302,7 +302,7 @@ void CodeGenTileLangHIP::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
     return;
   }
 
-  if (t == tl::cuTensorMapType()) {
+  if (t == tl::CuTensorMapType()) {
     os << "CUtensorMap";
     return;
   }

--- a/src/rocm/op/gemm.cc
+++ b/src/rocm/op/gemm.cc
@@ -37,7 +37,7 @@ ComputeDefaultWarpPartition(const GemmWarpPolicyNode &policy, int M, int N,
   ICHECK(N % kNPerWarp == 0)
       << "N must be divisible by " << kNPerWarp << ", but got " << N;
 
-  if (policy.isFullRow()) {
+  if (policy.IsFullRow()) {
     m_warp = num_warps;
     n_warp = 1;
     if (M % (m_warp * kMPerWarp) != 0) {
@@ -47,7 +47,7 @@ ComputeDefaultWarpPartition(const GemmWarpPolicyNode &policy, int M, int N,
       if (n_warp == 0)
         n_warp = 1;
     }
-  } else if (policy.isFullCol()) {
+  } else if (policy.IsFullCol()) {
     m_warp = 1;
     n_warp = num_warps;
     if (N % (n_warp * kNPerWarp) != 0) {
@@ -57,7 +57,7 @@ ComputeDefaultWarpPartition(const GemmWarpPolicyNode &policy, int M, int N,
       if (m_warp == 0)
         m_warp = 1;
     }
-  } else if (policy.isSquare()) {
+  } else if (policy.IsSquare()) {
     int max_m_warps = M / kMPerWarp;
     float ideal_ratio = N > 0 ? static_cast<float>(M) / N : 1.0f;
 

--- a/src/transform/common/constr_visitor.h
+++ b/src/transform/common/constr_visitor.h
@@ -42,7 +42,7 @@ struct Constr {
   Constr(Constr &&other) = default;
   Constr &operator=(const Constr &other) = default;
 
-  void format(std::ostream &os) const {
+  void Format(std::ostream &os) const {
     os << "Constr(kind=";
     switch (kind) {
     case kConstr:
@@ -138,11 +138,11 @@ struct ConstrSet {
     return result;
   }
 
-  void format(std::ostream &os) const {
+  void Format(std::ostream &os) const {
     os << "ConstrSet(size=" << constrs_.size() << ") {\n";
     for (size_t i = 0; i < constrs_.size(); ++i) {
       os << "  [" << i << "] ";
-      constrs_[i].format(os);
+      constrs_[i].Format(os);
       os << "\n";
     }
     os << "}";

--- a/src/transform/make_packed_api.cc
+++ b/src/transform/make_packed_api.cc
@@ -566,7 +566,7 @@ PrimFunc MakePackedAPI(PrimFunc func) {
   // Return error code of zero on success
   body = SeqStmt({body, Evaluate(ret(Integer(0)))});
 
-  body = MergeNest({seq_init, binder.init_nest(), seq_check, binder.asserts(),
+  body = MergeNest({seq_init, binder.InitNest(), seq_check, binder.Asserts(),
                     arg_buffer_declarations},
                    body);
   func_ptr->body = body;

--- a/src/transform/pipeline/stage_analysis.h
+++ b/src/transform/pipeline/stage_analysis.h
@@ -66,13 +66,11 @@ struct PipelineStageInfo {
       -1; // Initialized to -1, indicating no consumers found yet
 
 public:
-  bool is_first_stage() const { return copy_stage || producer_for_copy; }
-  bool is_copy_stage() const { return copy_stage; }
-  bool is_tma_copy() const { return tma_copy; }
-  bool is_producer_for_copy() const { return producer_for_copy; }
-  bool is_last_use_stmt_index_valid() const {
-    return last_use_stmt_index != -1;
-  }
+  bool IsFirstStage() const { return copy_stage || producer_for_copy; }
+  bool IsCopyStage() const { return copy_stage; }
+  bool IsTmaCopy() const { return tma_copy; }
+  bool IsProducerForCopy() const { return producer_for_copy; }
+  bool IsLastUseStmtIndexValid() const { return last_use_stmt_index != -1; }
 };
 
 class PipelineStageAnalyzer {
@@ -128,10 +126,10 @@ public:
     if (pinfo.conditional_execution) {
       return false;
     }
-    if (pinfo.is_tma_copy()) {
+    if (pinfo.IsTmaCopy()) {
       return false;
     }
-    return pinfo.is_copy_stage();
+    return pinfo.IsCopyStage();
   }
 
   bool IsPureCopyStmt(const Stmt &stmt) const {
@@ -271,7 +269,7 @@ public:
   void AnalyzeCopyLastUse(
       std::vector<PipelineStageInfo> *pipeline_stage_infos) const {
     for (auto &pinfo : *pipeline_stage_infos) {
-      if (!pinfo.is_first_stage()) {
+      if (!pinfo.IsFirstStage()) {
         continue;
       }
 
@@ -287,7 +285,7 @@ public:
           }
         }
 
-        if (!pinfo.is_copy_stage()) {
+        if (!pinfo.IsCopyStage()) {
           continue;
         }
 
@@ -339,7 +337,7 @@ public:
     CopyStageDependencyReadsManager copy_stage_dependency_reads_mgr;
 
     for (const auto &pinfo : *pipeline_stage_infos) {
-      if (pinfo.is_copy_stage()) {
+      if (pinfo.IsCopyStage()) {
         for (const BufferRegion &read : pinfo.reads) {
           copy_stage_dependency_reads_mgr.AddUnique(read);
         }
@@ -350,7 +348,7 @@ public:
     size_t iter_count = 0;
 
     for (auto &pinfo : *pipeline_stage_infos) {
-      if (!pinfo.is_copy_stage()) {
+      if (!pinfo.IsCopyStage()) {
         continue;
       }
       auto original_copy_stmt_index = pinfo.original_stmt_index;
@@ -358,7 +356,7 @@ public:
       while (updated) {
         updated = false;
         for (auto &pinfo_inner : *pipeline_stage_infos) {
-          if (pinfo_inner.is_copy_stage()) {
+          if (pinfo_inner.IsCopyStage()) {
             continue;
           }
           if (pinfo_inner.original_stmt_index >= original_copy_stmt_index) {
@@ -372,7 +370,7 @@ public:
               break;
             }
           }
-          if (should_prepare && !pinfo_inner.is_producer_for_copy()) {
+          if (should_prepare && !pinfo_inner.IsProducerForCopy()) {
             pinfo_inner.producer_for_copy = true;
             updated = true;
           }
@@ -425,7 +423,7 @@ public:
         producer->producer_for_copy = true;
         producer->last_use_stmt_index = consumer_last_use;
         changed = true;
-      } else if (!producer->is_last_use_stmt_index_valid() ||
+      } else if (!producer->IsLastUseStmtIndexValid() ||
                  consumer_last_use < producer->last_use_stmt_index) {
         producer->last_use_stmt_index = consumer_last_use;
         changed = true;
@@ -439,8 +437,7 @@ public:
            consumer_idx < static_cast<int>(pipeline_stage_infos->size());
            ++consumer_idx) {
         const auto &consumer = (*pipeline_stage_infos)[consumer_idx];
-        if (!(consumer.is_first_stage() &&
-              consumer.is_last_use_stmt_index_valid())) {
+        if (!(consumer.IsFirstStage() && consumer.IsLastUseStmtIndexValid())) {
           continue;
         }
         for (const VarNode *var : consumer.scalar_uses) {
@@ -449,7 +446,7 @@ public:
             continue;
           }
           auto &producer = (*pipeline_stage_infos)[it->second];
-          if (producer.is_copy_stage()) {
+          if (producer.IsCopyStage()) {
             continue;
           }
           updated |= update_producer(&producer, consumer.last_use_stmt_index);
@@ -580,7 +577,7 @@ public:
       ClassifyCopyLikeStage(pipeline_stmts[i], &pinfo);
       pinfo.order = static_cast<int>(order_array[i]->value);
       pinfo.stage = static_cast<int>(stage_array[i]->value);
-      if (!pinfo.is_copy_stage() && !pinfo.conditional_execution &&
+      if (!pinfo.IsCopyStage() && !pinfo.conditional_execution &&
           pinfo.stage == 0) {
         bool reads_global = false;
         bool writes_shared = false;

--- a/src/transform/pipeline_planning.cc
+++ b/src/transform/pipeline_planning.cc
@@ -252,7 +252,7 @@ private:
       // handling
       //    because they have consumers that depend on their data
       // 2. All Producer stages for copy stages.
-      if (pinfo.is_first_stage() && pinfo.is_last_use_stmt_index_valid()) {
+      if (pinfo.IsFirstStage() && pinfo.IsLastUseStmtIndexValid()) {
         continue;
       }
 
@@ -266,7 +266,7 @@ private:
       // This ensures copy operations are placed right before their final
       // consumer for optimal pipeline efficiency
       for (auto &pinfo_1 : pipeline_stage_infos) {
-        if ((pinfo_1.is_first_stage() &&
+        if ((pinfo_1.IsFirstStage() &&
              pinfo_1.last_use_stmt_index == pinfo.original_stmt_index)) {
           pinfo_1.order = order_idx++;
           pinfo_1.stage = 0; // Copy stages are typically assigned to stage 0
@@ -287,7 +287,7 @@ private:
       int copy_order_min = pipeline_stage_infos.size();
       int non_copy_order_max = 0;
       for (auto &pinfo : pipeline_stage_infos) {
-        if (pinfo.is_first_stage()) {
+        if (pinfo.IsFirstStage()) {
           copy_stage_cnt++;
           copy_order_min = std::min(copy_order_min, pinfo.order);
         } else {
@@ -302,7 +302,7 @@ private:
       for (auto &pinfo : pipeline_stage_infos) { // move copy to the beginning
         pinfo.order =
             (pinfo.order + copy_stage_at_end) % pipeline_stage_infos.size();
-        if (!pinfo.is_copy_stage() && !pinfo.is_producer_for_copy())
+        if (!pinfo.IsCopyStage() && !pinfo.IsProducerForCopy())
           pinfo.stage--;
       }
     }
@@ -349,9 +349,9 @@ private:
       tma_copies.reserve(pipeline_stage_infos.size());
       bool has_tma_copy = false;
       for (auto &pinfo : pipeline_stage_infos) {
-        bool is_tma_copy = pinfo.is_tma_copy();
-        has_tma_copy = has_tma_copy || is_tma_copy;
-        tma_copies.push_back(Integer(is_tma_copy ? 1 : 0));
+        bool IsTmaCopy = pinfo.IsTmaCopy();
+        has_tma_copy = has_tma_copy || IsTmaCopy;
+        tma_copies.push_back(Integer(IsTmaCopy ? 1 : 0));
       }
       if (has_tma_copy) {
         annotations.Set(kPipelineTmaCopies, Array<Integer>(tma_copies));

--- a/src/transform/tvm_ffi_binder.cc
+++ b/src/transform/tvm_ffi_binder.cc
@@ -76,7 +76,7 @@ void BinderAddAssert(arith::Analyzer *ana, PrimExpr cond,
 }
 
 std::vector<Var>
-TVMFFIABIBuilder::getUndefVars(const std::vector<PrimExpr> &args) {
+TVMFFIABIBuilder::GetUndefVars(const std::vector<PrimExpr> &args) {
   std::unordered_set<const VarNode *> visit;
   std::vector<Var> res;
   for (const auto &arg : args) {
@@ -125,7 +125,7 @@ bool TVMFFIABIBuilder::BindNullable(const PrimExpr &arg, const PrimExpr &value,
   } else {
     // 2. complex binding expr = value
     //  get undefined variables
-    auto undefs = Array<Var>(getUndefVars({arg}));
+    auto undefs = Array<Var>(GetUndefVars({arg}));
     if (!undefs.empty()) {
       // if value is not integer, such as float, we are unable to solve it
       if (!value.dtype().is_int() && !value.dtype().is_uint()) {

--- a/src/transform/tvm_ffi_binder.h
+++ b/src/transform/tvm_ffi_binder.h
@@ -128,23 +128,23 @@ public:
                 const std::unordered_set<const VarNode *> &used_shape_vars);
 
   /*! \return The defs generated in binding. */
-  const std::vector<Var> &defs() const { return defs_; }
+  const std::vector<Var> &Defs() const { return defs_; }
 
   /*! \return The asserts generated in binding
    *
    * This contains statements that assert the correct value has been
    * bound.  For example, `binder.Bind(var, expr_1)` will produce an
-   * entry mapping `var` to `expr_1` in the `binder.defs()`.  If
+   * entry mapping `var` to `expr_1` in the `binder.Defs()`.  If
    * `binder.Bind(var, expr_2)` is called later, then this will
    * produce an assert statemtn that `expr_1 == expr_2`.
    *
    * Note: Some assert statements produced by BindDLTensor are located
-   * in `binder.init_nest()`, not within `binder.asserts()`.  This is
+   * in `binder.InitNest()`, not within `binder.Asserts()`.  This is
    * deliberate, as some values may require checks prior to
    * initialization.  (e.g. Intializing `m = dl_tensor->shape[3]`
    * requires first asserting that `3 < dl_tensor->ndim`.)
    */
-  const std::vector<Stmt> &asserts() const { return asserts_; }
+  const std::vector<Stmt> &Asserts() const { return asserts_; }
 
   /*!
    * \brief Initialization nest generated
@@ -168,9 +168,9 @@ public:
    *
    * \return The initialization nest generated during binding.
    */
-  const std::vector<Stmt> &init_nest() const { return init_nest_; }
+  const std::vector<Stmt> &InitNest() const { return init_nest_; }
   /*! \return Handle data type of the data */
-  const ffi::Map<Var, PrimExpr> &def_handle_dtype() const {
+  const ffi::Map<Var, PrimExpr> &DefHandleDtype() const {
     return def_handle_dtype_;
   }
 
@@ -184,7 +184,7 @@ public:
                           const std::string &stride_element_name);
 
 private:
-  std::vector<Var> getUndefVars(const std::vector<PrimExpr> &arg);
+  std::vector<Var> GetUndefVars(const std::vector<PrimExpr> &arg);
   // Internal bind function
   bool Bind_(const PrimExpr &arg, const PrimExpr &value,
              const std::string &arg_name, bool with_lets);

--- a/tilelang/cuda/intrinsics/macro/tcgen05_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/tcgen05_macro_generator.py
@@ -187,7 +187,7 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
 
     def _determinate_swizzle_mode(self, buffer, layout: Layout) -> SwizzleMode:
         buffer = self._as_buffer(buffer)
-        # same behavior to src/layout/gemm_layouts.cc::makeGemmABLayoutHopper
+        # same behavior to src/layout/gemm_layouts.cc::MakeGemmABLayoutHopper
         if layout is None or layout.is_equal(make_linear_layout(buffer)):
             return SwizzleMode.NONE
         elif layout.is_equal(make_quarter_bank_swizzled_layout(buffer)):

--- a/tilelang/cuda/intrinsics/macro/wgmma_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/wgmma_macro_generator.py
@@ -188,7 +188,7 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         self.micro_size_k = k_dim
 
     def _determinate_swizzle_mode(self, buffer: Buffer, layout: Layout) -> SwizzleMode:
-        # same behavior to src/layout/gemm_layouts.cc::makeGemmABLayoutHopper
+        # same behavior to src/layout/gemm_layouts.cc::MakeGemmABLayoutHopper
         if layout is None or layout.is_equal(make_linear_layout(buffer)):
             return SwizzleMode.NONE
         elif layout.is_equal(make_quarter_bank_swizzled_layout(buffer)):
@@ -863,7 +863,7 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
             _, local_id = inverse_mma_store_layout.map_indices([i, j])
             return local_id
 
-        # reproduce src/layout/gemm_layouts.cc::makeGemmFragmentCHopper
+        # reproduce src/layout/gemm_layouts.cc::MakeGemmFragmentCHopper
         base_fragment = T.Fragment(
             [micro_size_x, micro_size_y],
             forward_thread_fn=forward_thread,

--- a/tilelang/cuda/intrinsics/macro/wgmma_sp_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/wgmma_sp_macro_generator.py
@@ -102,7 +102,7 @@ class WGSparseTensorCoreIntrinEmitter(SparseTensorCoreIntrinEmitter):
         self.wgmma_prefix = f"m{inst_m}n{inst_n}k{inst_k}"
 
     def _determinate_swizzle_mode(self, buffer: Buffer, layout: Layout) -> SwizzleMode:
-        # same behavior to src/layout/gemm_layouts.cc::makeGemmABLayoutHopper
+        # same behavior to src/layout/gemm_layouts.cc::MakeGemmABLayoutHopper
         if layout is None or layout.is_equal(make_linear_layout(buffer)):
             return SwizzleMode.NONE
         elif layout.is_equal(make_quarter_bank_swizzled_layout(buffer)):
@@ -601,7 +601,7 @@ class WGSparseTensorCoreIntrinEmitter(SparseTensorCoreIntrinEmitter):
             _, local_id = inverse_mma_store_layout.map_indices([i, j])
             return local_id
 
-        # reproduce src/layout/gemm_layouts.cc::makeGemmFragmentCHopper
+        # reproduce src/layout/gemm_layouts.cc::MakeGemmFragmentCHopper
         base_fragment = T.Fragment(
             [micro_size_x, micro_size_y],
             forward_thread_fn=forward_thread,


### PR DESCRIPTION
## Summary

- Normalize remaining C++ helper/API names reported by the style audit from lowerCamelCase or snake_case to PascalCase.
- Keep DSL-facing intrinsic names stable while clearing the advisory `TLCPP001` category.

## Changes

- Rename layout factory helpers, GEMM policy helpers, reduce type predicates, pipeline stage predicates, PTX/HIP replacement helpers, and TVM FFI binder accessors to PascalCase.
- Preserve Python/FFI-facing registration strings for layout constructors and keep `ptx_fence_barrier_init` allowlisted because it intentionally matches the registered DSL intrinsic name.
- Improve the C++ style audit by skipping function pointer fields and allowing known DSL intrinsic helper names.
- Update the style guide example to use a PascalCase layout helper name.

## Validation

- `./format.sh`
- `PYTHONDONTWRITEBYTECODE=1 python3 maint/scripts/audit_cpp_api_style.py --limit 20`
- `cmake --build build -j$(nproc)`

## Notes

- The audit report no longer contains `TLCPP001` or `TLCPP002` findings. Remaining findings are `TLCPP003` ObjectNode field review candidates and `TLCPP004` header namespace candidates, both left for separate follow-up work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Improved GPU all-reduce lowering to use consistent operator dispatch for initializer/duplicate/update across scalar and packed cases.
  * Corrected CUDA/HIP tensor-map type naming so generated code uses the expected `CUtensorMap` type.
  * Updated CUDA copy/TMA and atomic layout lowering to use the latest layout helper entrypoints for layout/swishle selection.

* **Chores**
  * Standardized C++ API naming to consistent PascalCase for layout, GEMM, pipeline, and related utilities.
  * Enhanced the C++ style audit with improved discovery/suppression and enabled warning-only CI GitHub annotations.
  * Documented the warning-only CI behavior in the developer C++ style guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->