### PR TITLE
[BugFix] Fix packed vector type printing for bfloat16 with metal codegen

### DIFF
--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -315,6 +315,9 @@ void CodeGenTileLangMetal::PrintVecElemStore(const std::string &vec, DataType t,
   if (t.is_float16() && t.lanes() > 4) {
     stream << "((thread half*)(&" << vec << "))[" << i << "] = " << value
            << ";\n";
+  } else if (t.is_bfloat16() && t.lanes() > 4) {
+    stream << "((thread bfloat*)(&" << vec << "))[" << i << "] = " << value
+           << ";\n";
   } else {
     stream << vec << "[" << i << "]"
            << " = " << value << ";\n";

--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -216,7 +216,7 @@ void CodeGenTileLangMetal::PrintType(DataType t,
     os << "bool";
     return;
   }
-  if (t.is_float() && t.bits() == 16 && lanes > 4 && lanes <= 8 &&
+  if ((t.is_float16() || t.is_bfloat16()) && lanes > 4 && lanes <= 8 &&
       lanes % 2 == 0) {
     os << "uint" << lanes / 2;
     return;

--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -302,6 +302,8 @@ void CodeGenTileLangMetal::PrintVecElemLoad(const std::string &vec, DataType t,
                                             std::ostream &os) { // NOLINT(*)
   if (t.is_float16() && t.lanes() > 4) {
     os << "((thread half*)(&" << vec << "))[" << i << "]";
+  } else if (t.is_bfloat16() && t.lanes() > 4) {
+    os << "((thread bfloat*)(&" << vec << "))[" << i << "]";
   } else {
     os << vec << "[" << i << "]";
   }
@@ -385,12 +387,17 @@ void CodeGenTileLangMetal::VisitExpr_(const BroadcastNode *op,
                                       std::ostream &os) { // NOLINT(*)
   std::string v = PrintExpr(op->value);
   int lanes = op->dtype.lanes();
-  if (op->dtype.is_float16() && lanes > 4 && lanes % 2 == 0) {
+  if ((op->dtype.is_float16() || op->dtype.is_bfloat16()) && lanes > 4 &&
+      lanes % 2 == 0) {
     os << "uint" << lanes / 2 << "(";
     for (int i = 0; i < lanes / 2; ++i) {
       if (i != 0)
         os << ", ";
-      os << "as_type<uint>(half2(" << v << ", " << v << "))";
+      if (op->dtype.is_float16()) {
+        os << "as_type<uint>(half2(" << v << ", " << v << "))";
+      } else if (op->dtype.is_bfloat16()) {
+        os << "as_type<uint>(bfloat2(" << v << ", " << v << "))";
+      }
     }
     os << ')';
   } else {

--- a/testing/python/metal/test_metal_bf16_codegen.py
+++ b/testing/python/metal/test_metal_bf16_codegen.py
@@ -1,0 +1,69 @@
+"""Test Metal code generation for bfloat16.
+
+These tests verify that TileLang can compile kernels down to Metal shader
+source code while correctly handling both float16 and bfloat16.
+"""
+
+import tilelang
+from tilelang import tvm as tvm
+import tilelang.testing
+import tilelang.language as T
+
+
+@tilelang.jit(out_idx=[2], target="metal", execution_backend="torch")
+def repro_gemm(dtype: str):
+    M = 32
+    N = 64
+    K = 16
+    threads = 64
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), dtype),
+        B: T.Tensor((K, N), dtype),
+        C: T.Tensor((M, N), "float32"),
+    ):
+        with T.Kernel(1, 1, threads=threads) as (_bx, _by):
+            A_shared = T.alloc_shared((M, K), dtype, "shared")
+            B_shared = T.alloc_shared((K, N), dtype, "shared")
+            C_local = T.alloc_fragment((M, N), "float32")
+
+            T.clear(C_local)
+            T.copy(A, A_shared)
+            T.copy(B, B_shared)
+            T.gemm(A_shared, B_shared, C_local)
+            T.copy(C_local, C)
+
+    return main
+
+
+def lower_to_metal(dtype: str) -> str:
+    prim_func = repro_gemm.get_tir(dtype)
+    target = tvm.target.Target("metal", tvm.target.Target("llvm"))
+    with target:
+        artifact = tilelang.lower(
+            prim_func,
+            target=target,
+            target_host="llvm",
+            enable_host_codegen=False,
+            enable_device_compile=False,
+        )
+    return artifact.kernel_source or ""
+
+
+def test_metal_bf16_vectorized_copy_uses_packed_uint_type():
+    src = lower_to_metal("bfloat16")
+
+    assert "simdgroup_bfloat8x8" in src
+    assert "*(threadgroup bfloat*)" not in src
+    assert "*(threadgroup uint4*)" in src
+
+
+def test_metal_fp16_vectorized_copy_still_uses_packed_uint_type():
+    src = lower_to_metal("float16")
+
+    assert "*(threadgroup uint4*)" in src
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
Metal codegen prints packed `float16` vectors with more than four lanes as `uintN`, e.g. `float16x8` as `uint4`, for vectorized memory copies.
However, `bfloat16x8` fell through to the scalar `bfloat` type, which caused vectorized global-to-threadgroup copies to emit scalar `threadgroup bfloat*` casts while still using vectorized indexing.

This patch handles `bfloat16` in the same way as `float16` for packed 16-bit vector types, so `bfloat16x8` is printed as `uint4`.

A regression test checks that bf16 Metal GEMM source no longer contains `*(threadgroup bfloat*)` and instead uses packed `uint4` copies.

Fixes #2421

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced Metal code generation to better support bfloat16, including correct vectorized element loads/stores and broadcast casting, aligned with existing float16 optimizations.
* **Tests**
  * Added Metal bfloat16 codegen tests (with float16 coverage) to verify the generated vectorized copy patterns and expected Metal type usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->