### PR TITLE
[BugFix] Fix make_int sign-extending negative int8 lanes

### DIFF
--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -137,10 +137,16 @@ TL_DEVICE unsigned __pack_nv_bfloat162(const bfloat16_t x, const bfloat16_t y) {
   return (v1 << 16) | v0;
 }
 
-// Pack four char values.
+// Pack four char values. Build the 32-bit pattern from unsigned bytes: a
+// negative signed char would otherwise sign-extend and flood the other lanes
+// through the OR.
 TL_DEVICE int make_int(signed char x0, signed char x1, signed char x2,
                        signed char x3) {
-  return (x3 << 24) | (x2 << 16) | (x1 << 8) | x0;
+  const unsigned int b0 = static_cast<unsigned char>(x0);
+  const unsigned int b1 = static_cast<unsigned char>(x1);
+  const unsigned int b2 = static_cast<unsigned char>(x2);
+  const unsigned int b3 = static_cast<unsigned char>(x3);
+  return static_cast<int>((b3 << 24) | (b2 << 16) | (b1 << 8) | b0);
 }
 
 // Pack eight char values.

--- a/testing/python/language/test_tilelang_language_clear.py
+++ b/testing/python/language/test_tilelang_language_clear.py
@@ -81,5 +81,27 @@ def test_shared_fill_cast_zero_uses_st_bulk():
     assert torch.allclose(out, torch.zeros_like(out))
 
 
+@tilelang.testing.requires_cuda
+def test_fill_int8_negative():
+    M, N = 8, 128
+
+    def program(value):
+        @T.prim_func
+        def main(out: T.Tensor((M, N), "int8")):
+            with T.Kernel(1, threads=128):
+                smem = T.alloc_shared((M, N), "int8")
+                T.fill(smem, value)
+                T.copy(smem, out)
+
+        return main
+
+    for value in (-7, -128, -1, 5):
+        kernel = tilelang.compile(program(value), out_idx=[0])
+        out = kernel()
+        torch.cuda.synchronize()
+        ref = torch.full((M, N), value, dtype=torch.int8, device="cuda")
+        torch.testing.assert_close(out, ref)
+
+
 if __name__ == "__main__":
     test_matmul()


### PR DESCRIPTION
## Summary

`T.fill` of an `int8` buffer with a negative scalar silently writes only 1 of every 4 elements with the intended value and sets the other 3 of every 4 to `-1` (`0xFF`). It compiles and runs with no error. Non-negative values are fine; `-1` is also fine because its bytes are already all `0xFF`.

```text
int8 dest, value = -7

before fix: [-7, -1, -1, -1, ...]
after fix : [-7, -7, -7, -7, ...]
```

## Root cause

A vectorized int8 `T.fill` packs four lanes into one 32-bit store via `make_int(v, v, v, v)` in `src/tl_templates/cuda/common.h`:

```cpp
return (x3 << 24) | (x2 << 16) | (x1 << 8) | x0;
```

Each `signed char` is integer-promoted to `int` before the shift/OR. A negative value sign-extends, for example `-7 -> 0xFFFFFFF9`, so the high 1-bits of the lower lanes flood the upper bytes through the OR. As a result, `make_int(-7, -7, -7, -7)` yields `0xFFFFFFF9`, whose bytes are `[F9, FF, FF, FF]`, i.e. `[-7, -1, -1, -1]`. Only the lowest lane survives. `-1` coincidentally looks correct because its bytes are already `0xFF`.

  ## Fix

  Build the 32-bit pattern from explicit unsigned bytes so the sign-extension bits cannot leak across lanes:

  ```cpp
  const unsigned int b0 = static_cast<unsigned char>(x0);
  const unsigned int b1 = static_cast<unsigned char>(x1);
  const unsigned int b2 = static_cast<unsigned char>(x2);
  const unsigned int b3 = static_cast<unsigned char>(x3);
  return static_cast<int>((b3 << 24) | (b2 << 16) | (b1 << 8) | b0);
  ```

  The constant int8x4 broadcast path in `src/cuda/codegen/codegen_cuda.cc` already takes the low byte before packing; only the runtime `make_int` helper was missing it. `make_int2` / `make_int4(char)` delegate to `make_int`; `make_uint*` take `unsigned char` and therefore do not sign-extend; and `make_int4(short...)` uses struct construction instead of byte packing.

## Tested

* Added `testing/python/language/test_tilelang_language_clear.py::test_fill_int8_negative`, which fills int8 buffers with `-7`, `-128`, `-1`, and `5`, then checks that every element equals the expected value.
* Verified locally on a TITAN RTX (sm_75, Turing): before the fix, negative fills produced 768/1024 wrong elements; after the fix, all elements are correct.

Fixes #2427


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CUDA integer packing to properly handle negative values without sign-extension interference.

* **Tests**
  * Added test coverage validating negative 8-bit integer operations in CUDA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->