### PR TITLE
[BugFix] Support warpgroup register reallocation for 1P1C

### DIFF
--- a/src/cuda/transform/annotate_warp_group_reg_alloc.cc
+++ b/src/cuda/transform/annotate_warp_group_reg_alloc.cc
@@ -281,8 +281,10 @@ private:
             int consumer_wg = (total_threads > producer_threads)
                                   ? (total_threads - producer_threads) / 128
                                   : -1;
-            if (producer_wg == 1 && consumer_wg == 2) {
-              // 1P + 2C (384 threads): 128*24 + 256*240 = 64512. Original pair.
+            if (producer_wg == 1 && consumer_wg <= 2) {
+              // 1P + 1C (128 threads): 128*24 + 128*240 = 32256 <= 64512.
+              // 1P + 2C (384 threads): 128*24 + 256*240 = 64512.
+              // Original pair is good.
             } else if (producer_wg == 2 && consumer_wg == 2) {
               // 2P + 2C (512 threads): 256*24 + 256*224 = 63488 <= 64512.
               final_inc_reg = 224;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR broadens the warp-specialization register reallocation logic in `AnnotateWarpGroupRegAlloc` to support the `1P1C` (1 producer, 1 consumer) configuration in addition to the previously-supported `1P2C` (1 producer, 2 consumers) layout.

## Changes

**src/cuda/transform/annotate_warp_group_reg_alloc.cc:**
- Modified the condition on line 284 from `producer_wg == 1 && consumer_wg == 2` to `producer_wg == 1 && consumer_wg <= 2`, allowing both `1P1C` and `1P2C` layouts to use the same register allocation strategy without adjustment.
- Updated the associated comment to reflect that both `1P + 1C` (128 threads) and `1P + 2C` (384 threads) configurations fit within the 64512 register limit and require no special handling.
- No changes to other register-injection logic or warning branches.

## C++ Style / Lint Notes

The modified file passes the C++ API Style Audit with no warnings (0 candidates found). The change adheres to the TileLang C++ style guide:
- Variable naming follows `lower_snake_case` conventions
- The minimal change (+4/-2 lines) keeps the diff focused on the functional update
- Comments are updated appropriately to document the broadened condition without restating the code
- No formatting or namespace-related issues introduced

<!-- end of auto-generated comment: release notes by coderabbit.ai -->