### PR TITLE
[Feature] Introduce tile scheduler

### DIFF
--- a/examples/blockscaled_gemm_sm100/gemm_mxfp8_blockscaled_1d1d.py
+++ b/examples/blockscaled_gemm_sm100/gemm_mxfp8_blockscaled_1d1d.py
@@ -1,5 +1,10 @@
 # MXFP8 Block-Scaled GEMM on SM100
 # Blockscale size: (M, N, K) = (1, 1, 128)
+#
+# Persistent 2-CTA variant uses PersistentTileScheduler: each warp role owns a
+# scheduler instance and drives ``while sched.valid()``. ``sched.current_iter[0]``
+# is the wave index for pipeline/double-buffering; ``sched.m_idx[0]`` /
+# ``sched.n_idx[0]`` decode the tile (with ``bx = m_idx * cluster_size + cta_id``).
 
 import argparse
 import torch
@@ -347,16 +352,14 @@ def mxfp8_blockscaled_gemm_2cta_persistent(
     C = T.empty((M, N), out_dtype)
 
     sm_num = driver.get_num_sms()
-    num_clusters = sm_num // 2
     m_blocks = T.ceildiv(M, block_M)
-    m_clusters = m_blocks // 2
     n_blocks = T.ceildiv(N, block_N)
     assert K % (2 * block_K) == 0  # for simplicity
-    waves = T.ceildiv(m_blocks * n_blocks, sm_num)
-    group_size = 16  # in cluster
+    cluster_size = 2
+    group_size = 16
     assert n_blocks % (2 * group_size) == 0  # Please adjust group_size if not satisfied
 
-    with T.ClusterKernel(sm_num, threads=256, cluster_dims=2) as (block_id):
+    with T.ClusterKernel(sm_num, threads=256, cluster_dims=cluster_size) as (block_id):
         cta_id = T.block_rank_in_cluster()
         T.assume(cta_id < 2)
 
@@ -386,130 +389,120 @@ def mxfp8_blockscaled_gemm_2cta_persistent(
         warp_idx = tx // 32
 
         if warp_idx == 0:
-            for w in T.unroll(waves):
-                cluster_id = block_id // 2
-                tile_id = num_clusters * w + cluster_id
-                bx_cluster = (tile_id // group_size) % m_clusters
-                bx = bx_cluster * 2 + cta_id
-                by = (tile_id % group_size) + (tile_id // group_size) // m_clusters * group_size
+            sched = T.PersistentTileScheduler("sched_tma", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+            sched.init(block_id // cluster_size)
+            while sched.valid():
+                bx = sched.m_idx[0] * cluster_size + cta_id
+                by = sched.n_idx[0]
 
-                if bx * block_M < M and by * block_N < N:
-                    for k in T.serial(k_iters):
-                        phase = w * k_iters + k
-                        stage = phase % num_stages
-                        parity = (phase // num_stages) & 1
-                        T.mbarrier_wait_parity(consumed[stage], parity ^ 1)
+                for k in T.serial(k_iters):
+                    phase = sched.current_iter[0] * k_iters + k
+                    stage = phase % num_stages
+                    parity = (phase // num_stages) & 1
+                    T.mbarrier_wait_parity(consumed[stage], parity ^ 1)
+                    T.tma_copy(
+                        A[bx * block_M : (bx + 1) * block_M, k * block_K : (k + 1) * block_K],
+                        A_shared[stage, :, :],
+                        barrier=loaded[stage],
+                    )
+                    if transpose_B:
                         T.tma_copy(
-                            A[bx * block_M : (bx + 1) * block_M, k * block_K : (k + 1) * block_K],
-                            A_shared[stage, :, :],
+                            B[
+                                by * block_N + cta_id * half_N : by * block_N + (cta_id + 1) * half_N,
+                                k * block_K : (k + 1) * block_K,
+                            ],
+                            B_shared[stage, :, :],
                             barrier=loaded[stage],
                         )
-                        if transpose_B:
-                            T.tma_copy(
-                                B[
-                                    by * block_N + cta_id * half_N : by * block_N + (cta_id + 1) * half_N,
-                                    k * block_K : (k + 1) * block_K,
-                                ],
-                                B_shared[stage, :, :],
-                                barrier=loaded[stage],
-                            )
-                        else:
-                            T.tma_copy(
-                                B[
-                                    k * block_K : (k + 1) * block_K,
-                                    by * block_N + cta_id * half_N : by * block_N + (cta_id + 1) * half_N,
-                                ],
-                                B_shared[stage, :, :],
-                                barrier=loaded[stage],
-                            )
-                        if k % sf_load_period == 0:
-                            sf_group_idx = k // sf_load_period
-                            T.tma_copy(
-                                SFA[sf_group_idx * M + bx * block_M : sf_group_idx * M + (bx + 1) * block_M],
-                                SFA_shared[stage, :],
-                                barrier=loaded[stage],
-                            )
-                            T.tma_copy(
-                                SFB[sf_group_idx * N + by * block_N : sf_group_idx * N + (by + 1) * block_N],
-                                SFB_shared[stage, :],
-                                barrier=loaded[stage],
-                            )
-                        T.mbarrier_arrive(loaded[stage])
+                    else:
+                        T.tma_copy(
+                            B[
+                                k * block_K : (k + 1) * block_K,
+                                by * block_N + cta_id * half_N : by * block_N + (cta_id + 1) * half_N,
+                            ],
+                            B_shared[stage, :, :],
+                            barrier=loaded[stage],
+                        )
+                    if k % sf_load_period == 0:
+                        sf_group_idx = k // sf_load_period
+                        T.tma_copy(
+                            SFA[sf_group_idx * M + bx * block_M : sf_group_idx * M + (bx + 1) * block_M],
+                            SFA_shared[stage, :],
+                            barrier=loaded[stage],
+                        )
+                        T.tma_copy(
+                            SFB[sf_group_idx * N + by * block_N : sf_group_idx * N + (by + 1) * block_N],
+                            SFB_shared[stage, :],
+                            barrier=loaded[stage],
+                        )
+                    T.mbarrier_arrive(loaded[stage])
+                sched.next_tile()
 
         elif warp_idx == 1 and cta_id == 0:
-            for w in T.unroll(waves):
-                cluster_id = block_id // 2
-                tile_id = num_clusters * w + cluster_id
-                bx_cluster = (tile_id // group_size) % m_clusters
-                bx = bx_cluster * 2 + cta_id
-                by = (tile_id % group_size) + (tile_id // group_size) // m_clusters * group_size
-
-                if bx * block_M < M and by * block_N < N:
-                    T.mbarrier_wait_parity(tmem_empty, (w & 1) ^ 1)
-                    for k in T.serial(k_iters):
-                        phase = w * k_iters + k
-                        stage = phase % num_stages
-                        parity = (phase // num_stages) & 1
-                        T.mbarrier_wait_parity(with_sf_full[stage], parity)
-                        if k % sf_load_period == 0:
-                            T.tcgen05_cp_warpx4(SFA_shared[stage, :], SFA_tmem, use_2cta=True)
-                            T.tcgen05_cp_warpx4(SFB_shared[stage, :], SFB_tmem, use_2cta=True)
-                        T.tcgen05_gemm_blockscaled(
-                            A_shared[stage, :, :],
-                            B_shared[stage, :, :],
-                            C_tmem,
-                            SFA_tmem,
-                            SFB_tmem,
-                            transpose_B=transpose_B,
-                            mbar=consumed[stage],
-                            clear_accum=k == 0,
-                            k_start=k * block_K,
-                            sf_a_granularity_k=sf_granularity_k,
-                            sf_b_granularity_k=sf_granularity_k,
-                            use_2cta=True,
-                        )
-                    T.tcgen05_mma_arrive(tmem_full, arrive_2cta=True)
+            sched = T.PersistentTileScheduler("sched_mma", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+            sched.init(block_id // cluster_size)
+            while sched.valid():
+                T.mbarrier_wait_parity(tmem_empty, (sched.current_iter[0] & 1) ^ 1)
+                for k in T.serial(k_iters):
+                    phase = sched.current_iter[0] * k_iters + k
+                    stage = phase % num_stages
+                    parity = (phase // num_stages) & 1
+                    T.mbarrier_wait_parity(with_sf_full[stage], parity)
+                    if k % sf_load_period == 0:
+                        T.tcgen05_cp_warpx4(SFA_shared[stage, :], SFA_tmem, use_2cta=True)
+                        T.tcgen05_cp_warpx4(SFB_shared[stage, :], SFB_tmem, use_2cta=True)
+                    T.tcgen05_gemm_blockscaled(
+                        A_shared[stage, :, :],
+                        B_shared[stage, :, :],
+                        C_tmem,
+                        SFA_tmem,
+                        SFB_tmem,
+                        transpose_B=transpose_B,
+                        mbar=consumed[stage],
+                        clear_accum=k == 0,
+                        k_start=k * block_K,
+                        sf_a_granularity_k=sf_granularity_k,
+                        sf_b_granularity_k=sf_granularity_k,
+                        use_2cta=True,
+                    )
+                T.tcgen05_mma_arrive(tmem_full, arrive_2cta=True)
+                sched.next_tile()
 
         elif warp_idx == 2:
-            for w in T.unroll(waves):
-                cluster_id = block_id // 2
-                tile_id = num_clusters * w + cluster_id
-                bx_cluster = (tile_id // group_size) % m_clusters
-                bx = bx_cluster * 2 + cta_id
-                by = (tile_id % group_size) + (tile_id // group_size) // m_clusters * group_size
-
-                if bx * block_M < M and by * block_N < N:
-                    for k in T.serial(k_iters):
-                        phase = w * k_iters + k
-                        stage = phase % num_stages
-                        parity = (phase // num_stages) & 1
-                        T.mbarrier_wait_parity(loaded[stage], parity)
-                        if k % sf_load_period == 0:
-                            T.tcgen05_sf_warp_transpose(SFA_shared[stage, :])
-                            T.tcgen05_sf_warp_transpose(SFB_shared[stage, :])
-                            T.fence_proxy_async()
-                        T.mbarrier_arrive(with_sf_full[stage], 0)
+            sched = T.PersistentTileScheduler("sched_sf", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+            sched.init(block_id // cluster_size)
+            while sched.valid():
+                for k in T.serial(k_iters):
+                    phase = sched.current_iter[0] * k_iters + k
+                    stage = phase % num_stages
+                    parity = (phase // num_stages) & 1
+                    T.mbarrier_wait_parity(loaded[stage], parity)
+                    if k % sf_load_period == 0:
+                        T.tcgen05_sf_warp_transpose(SFA_shared[stage, :])
+                        T.tcgen05_sf_warp_transpose(SFB_shared[stage, :])
+                        T.fence_proxy_async()
+                    T.mbarrier_arrive(with_sf_full[stage], 0)
+                sched.next_tile()
 
         elif 128 <= tx < 256:
-            for w in T.unroll(waves):
-                cluster_id = block_id // 2
-                tile_id = num_clusters * w + cluster_id
-                bx_cluster = (tile_id // group_size) % m_clusters
-                bx = bx_cluster * 2 + cta_id
-                by = (tile_id % group_size) + (tile_id // group_size) // m_clusters * group_size
+            sched = T.PersistentTileScheduler("sched_epi", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+            sched.init(block_id // cluster_size)
+            while sched.valid():
+                bx = sched.m_idx[0] * cluster_size + cta_id
+                by = sched.n_idx[0]
 
-                if bx * block_M < M and by * block_N < N:
-                    T.mbarrier_wait_parity(tmem_full, w & 1)
-                    T.copy(C_tmem, C_local)
-                    T.mbarrier_arrive(tmem_empty, 0)
+                T.mbarrier_wait_parity(tmem_full, sched.current_iter[0] & 1)
+                T.copy(C_tmem, C_local)
+                T.mbarrier_arrive(tmem_empty, 0)
 
-                    if use_tma_store:
-                        for i in T.unroll(T.ceildiv(block_N, store_block_N)):
-                            T.copy(C_local[:, i * store_block_N : (i + 1) * store_block_N], C_shared)
-                            T.copy(C_shared, C[bx * block_M, by * block_N + i * store_block_N])
-                    else:
-                        T.copy(C_local, C_local_cast)
-                        T.copy(C_local_cast, C[bx * block_M, by * block_N])
+                if use_tma_store:
+                    for i in T.unroll(T.ceildiv(block_N, store_block_N)):
+                        T.copy(C_local[:, i * store_block_N : (i + 1) * store_block_N], C_shared)
+                        T.copy(C_shared, C[bx * block_M, by * block_N + i * store_block_N])
+                else:
+                    T.copy(C_local, C_local_cast)
+                    T.copy(C_local_cast, C[bx * block_M, by * block_N])
+                sched.next_tile()
     return C
 
 

--- a/examples/deepseek_v4/fp8_fp4_gemm_1d1d_sm100.py
+++ b/examples/deepseek_v4/fp8_fp4_gemm_1d1d_sm100.py
@@ -1,4 +1,6 @@
 # Schedule adapted from DeepGEMM.
+#
+# Persistent 2-CTA kernel uses PersistentTileScheduler (see gemm_tcgen5mma_ws_persistent.py).
 
 import argparse
 from typing import Tuple
@@ -45,16 +47,14 @@ def fp8_fp4_gemm_1d1d_persistent(
         D: T.Tensor((M, N), out_dtype),
     ):
         sm_num = driver.get_num_sms()
-        num_clusters = sm_num // 2
         m_blocks = T.ceildiv(M, block_M)
-        m_clusters = m_blocks // 2
         n_blocks = T.ceildiv(N, block_N)
         k_iters = T.ceildiv(K, block_K)
         sf_load_period = sf_granularity_k * 4 // block_K
-        waves = T.ceildiv(m_blocks * n_blocks, sm_num)
+        cluster_size = 2
         group_size = 16
 
-        with T.ClusterKernel(sm_num, threads=256, cluster_dims=2) as (block_id):
+        with T.ClusterKernel(sm_num, threads=256, cluster_dims=cluster_size) as (block_id):
             cta_id = T.block_rank_in_cluster()
             T.assume(cta_id < 2)
 
@@ -81,110 +81,106 @@ def fp8_fp4_gemm_1d1d_persistent(
             tx = T.get_thread_binding()
 
             if tx < 32:  # issue TMA, load operands and SFs
-                for w in T.unroll(waves):
-                    cluster_id = block_id // 2
-                    tile_id = num_clusters * w + cluster_id
-                    bx_cluster = (tile_id // group_size) % m_clusters
-                    bx = bx_cluster * 2 + cta_id
-                    by = (tile_id % group_size) + (tile_id // group_size) // m_clusters * group_size
+                sched = T.PersistentTileScheduler("sched_tma", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+                sched.init(block_id // cluster_size)
+                while sched.valid():
+                    bx = sched.m_idx[0] * cluster_size + cta_id
+                    by = sched.n_idx[0]
 
-                    if bx * block_M < M and by * block_N < N:
-                        for k in T.serial(k_iters):
-                            phase = w * k_iters + k
-                            stage = phase % num_stages
-                            parity = (phase // num_stages) & 1
-                            T.mbarrier_wait_parity(consumed[stage], parity ^ 1)
+                    for k in T.serial(k_iters):
+                        phase = sched.current_iter[0] * k_iters + k
+                        stage = phase % num_stages
+                        parity = (phase // num_stages) & 1
+                        T.mbarrier_wait_parity(consumed[stage], parity ^ 1)
+                        T.tma_copy(
+                            A[bx * block_M : (bx + 1) * block_M, k * block_K : (k + 1) * block_K],
+                            A_shared[stage, :, :],
+                            barrier=loaded[stage],
+                        )
+                        T.tma_copy(
+                            B[
+                                by * block_N + cta_id * half_N : by * block_N + (cta_id + 1) * half_N,
+                                k * block_K : (k + 1) * block_K,
+                            ],
+                            B_shared[stage, :, :],
+                            barrier=loaded[stage],
+                        )
+                        if k % sf_load_period == 0:
+                            sf_group_idx = k // sf_load_period
                             T.tma_copy(
-                                A[bx * block_M : (bx + 1) * block_M, k * block_K : (k + 1) * block_K],
-                                A_shared[stage, :, :],
+                                SFA[sf_group_idx * M + bx * block_M : sf_group_idx * M + (bx + 1) * block_M],
+                                SFA_shared[stage, :],
                                 barrier=loaded[stage],
                             )
                             T.tma_copy(
-                                B[
-                                    by * block_N + cta_id * half_N : by * block_N + (cta_id + 1) * half_N,
-                                    k * block_K : (k + 1) * block_K,
-                                ],
-                                B_shared[stage, :, :],
+                                SFB[sf_group_idx * N + by * block_N : sf_group_idx * N + (by + 1) * block_N],
+                                SFB_shared[stage, :],
                                 barrier=loaded[stage],
                             )
-                            if k % sf_load_period == 0:
-                                sf_group_idx = k // sf_load_period
-                                T.tma_copy(
-                                    SFA[sf_group_idx * M + bx * block_M : sf_group_idx * M + (bx + 1) * block_M],
-                                    SFA_shared[stage, :],
-                                    barrier=loaded[stage],
-                                )
-                                T.tma_copy(
-                                    SFB[sf_group_idx * N + by * block_N : sf_group_idx * N + (by + 1) * block_N],
-                                    SFB_shared[stage, :],
-                                    barrier=loaded[stage],
-                                )
-                            T.mbarrier_arrive(loaded[stage])
+                        T.mbarrier_arrive(loaded[stage])
+                    sched.next_tile()
 
             elif 32 <= tx < 64 and cta_id == 0:  # issue tcgen5
-                for w in T.unroll(waves):
-                    cluster_id = block_id // 2
-                    tile_id = num_clusters * w + cluster_id
-
-                    if tile_id < m_clusters * n_blocks:
-                        T.mbarrier_wait_parity(tmem_empty, (w & 1) ^ 1)
-                        for k in T.serial(k_iters):
-                            phase = w * k_iters + k
-                            stage = phase % num_stages
-                            parity = (phase // num_stages) & 1
-                            T.mbarrier_wait_parity(with_sf_full[stage], parity)
-                            if k % sf_load_period == 0:
-                                T.tcgen05_cp_warpx4(SFA_shared[stage, :], SFA_tmem, use_2cta=True)
-                                T.tcgen05_cp_warpx4(SFB_shared[stage, :], SFB_tmem, use_2cta=True)
-                            T.tcgen05_gemm_blockscaled(
-                                A_shared[stage, :, :],
-                                B_shared[stage, :, :],
-                                C_tmem,
-                                SFA_tmem,
-                                SFB_tmem,
-                                transpose_B=True,
-                                mbar=consumed[stage],
-                                clear_accum=k == 0,
-                                k_start=k * block_K,  # global K offset (to help compiler infer sf_id)
-                                sf_a_granularity_k=sf_granularity_k,
-                                sf_b_granularity_k=sf_granularity_k,
-                                use_2cta=True,
-                            )
-                        T.tcgen05_mma_arrive(tmem_full, arrive_2cta=True)
+                sched = T.PersistentTileScheduler("sched_mma", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+                sched.init(block_id // cluster_size)
+                while sched.valid():
+                    T.mbarrier_wait_parity(tmem_empty, (sched.current_iter[0] & 1) ^ 1)
+                    for k in T.serial(k_iters):
+                        phase = sched.current_iter[0] * k_iters + k
+                        stage = phase % num_stages
+                        parity = (phase // num_stages) & 1
+                        T.mbarrier_wait_parity(with_sf_full[stage], parity)
+                        if k % sf_load_period == 0:
+                            T.tcgen05_cp_warpx4(SFA_shared[stage, :], SFA_tmem, use_2cta=True)
+                            T.tcgen05_cp_warpx4(SFB_shared[stage, :], SFB_tmem, use_2cta=True)
+                        T.tcgen05_gemm_blockscaled(
+                            A_shared[stage, :, :],
+                            B_shared[stage, :, :],
+                            C_tmem,
+                            SFA_tmem,
+                            SFB_tmem,
+                            transpose_B=True,
+                            mbar=consumed[stage],
+                            clear_accum=k == 0,
+                            k_start=k * block_K,  # global K offset (to help compiler infer sf_id)
+                            sf_a_granularity_k=sf_granularity_k,
+                            sf_b_granularity_k=sf_granularity_k,
+                            use_2cta=True,
+                        )
+                    T.tcgen05_mma_arrive(tmem_full, arrive_2cta=True)
+                    sched.next_tile()
 
             elif 64 <= tx < 96:  # transpose SFs
-                for w in T.unroll(waves):
-                    cluster_id = block_id // 2
-                    tile_id = num_clusters * w + cluster_id
-
-                    if tile_id < m_clusters * n_blocks:
-                        for k in T.serial(k_iters):
-                            phase = w * k_iters + k
-                            stage = phase % num_stages
-                            parity = (phase // num_stages) & 1
-                            T.mbarrier_wait_parity(loaded[stage], parity)
-                            if k % sf_load_period == 0:
-                                T.tcgen05_sf_warp_transpose(SFA_shared[stage, :])
-                                T.tcgen05_sf_warp_transpose(SFB_shared[stage, :])
-                                T.fence_proxy_async()
-                            T.mbarrier_arrive(with_sf_full[stage], 0)
+                sched = T.PersistentTileScheduler("sched_sf", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+                sched.init(block_id // cluster_size)
+                while sched.valid():
+                    for k in T.serial(k_iters):
+                        phase = sched.current_iter[0] * k_iters + k
+                        stage = phase % num_stages
+                        parity = (phase // num_stages) & 1
+                        T.mbarrier_wait_parity(loaded[stage], parity)
+                        if k % sf_load_period == 0:
+                            T.tcgen05_sf_warp_transpose(SFA_shared[stage, :])
+                            T.tcgen05_sf_warp_transpose(SFB_shared[stage, :])
+                            T.fence_proxy_async()
+                        T.mbarrier_arrive(with_sf_full[stage], 0)
+                    sched.next_tile()
 
             elif 128 <= tx < 256:  # epilogue
-                for w in T.unroll(waves):
-                    cluster_id = block_id // 2
-                    tile_id = num_clusters * w + cluster_id
-                    bx_cluster = (tile_id // group_size) % m_clusters
-                    bx = bx_cluster * 2 + cta_id
-                    by = (tile_id % group_size) + (tile_id // group_size) // m_clusters * group_size
+                sched = T.PersistentTileScheduler("sched_epi", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+                sched.init(block_id // cluster_size)
+                while sched.valid():
+                    bx = sched.m_idx[0] * cluster_size + cta_id
+                    by = sched.n_idx[0]
 
-                    if bx * block_M < M and by * block_N < N:
-                        T.mbarrier_wait_parity(tmem_full, w & 1)
-                        T.copy(C_tmem, C_local)
-                        T.mbarrier_arrive(tmem_empty, 0)
+                    T.mbarrier_wait_parity(tmem_full, sched.current_iter[0] & 1)
+                    T.copy(C_tmem, C_local)
+                    T.mbarrier_arrive(tmem_empty, 0)
 
-                        for i in T.unroll(T.ceildiv(block_N, store_block_N)):
-                            T.copy(C_local[:, i * store_block_N : (i + 1) * store_block_N], C_shared)
-                            T.copy(C_shared, D[bx * block_M, by * block_N + i * store_block_N])
+                    for i in T.unroll(T.ceildiv(block_N, store_block_N)):
+                        T.copy(C_local[:, i * store_block_N : (i + 1) * store_block_N], C_shared)
+                        T.copy(C_shared, D[bx * block_M, by * block_N + i * store_block_N])
+                    sched.next_tile()
 
     return main
 

--- a/examples/gemm_sm100/gemm_tcgen5mma_ws_persistent.py
+++ b/examples/gemm_sm100/gemm_tcgen5mma_ws_persistent.py
@@ -1,4 +1,11 @@
-# Persistent, num_epi_stages = 2
+# Persistent, warp-specialized SM100 GEMM using PersistentTileScheduler.
+#
+# Each warp role (TMA / tcgen5 MMA / epilogue) creates its own scheduler instance
+# and drives a single ``while sched.valid()`` loop. The scheduler owns the only
+# iteration clock: ``sched.current_iter[0]`` is the wave index ``w`` (used for the
+# pipeline phase / ``w & 1`` double-buffering) and ``sched.m_idx[0]`` /
+# ``sched.n_idx[0]`` are the tile coords. One clock, held by the scheduler -- no
+# separate ``for w in range(waves)`` counter.
 
 import torch
 import tilelang
@@ -32,7 +39,6 @@ def gemm_persistent(
     n_blocks = T.ceildiv(N, block_N)
     assert K % (2 * block_K) == 0  # for simplicity
     k_blocks = T.ceildiv(K, block_K)
-    waves = T.ceildiv(m_blocks * n_blocks, sm_num)
     group_size = 8
     assert n_blocks % (2 * group_size) == 0  # Please adjust group_size if not satisfied
 
@@ -52,81 +58,77 @@ def gemm_persistent(
         tx = T.get_thread_binding()
 
         if tx < 32:  # warp 0: issue tma
-            for w in T.unroll(waves):
-                tile_id = sm_num * w + block_id
-                bx = (tile_id // group_size) % m_blocks
-                by = (tile_id % group_size) + (tile_id // group_size) // m_blocks * group_size
+            sched = T.PersistentTileScheduler("sched_tma", m_blocks, n_blocks, swizzle_size=group_size)
+            sched.init(block_id)
+            while sched.valid():
+                w, bx, by = sched.current_iter[0], sched.m_idx[0], sched.n_idx[0]
 
-                if bx * block_M < M and by * block_N < N:
-                    for k in T.serial(k_blocks):
-                        phase = w * k_blocks + k
-                        T.mbarrier_wait_parity(consumed[phase % num_stages], ((phase // num_stages) & 1) ^ 1)
-                        T.tma_copy(
-                            A[bx * block_M : (bx + 1) * block_M, k * block_K : (k + 1) * block_K],
-                            A_shared[phase % num_stages, :, :],
-                            barrier=loaded[phase % num_stages],
-                        )
-                        T.tma_copy(
-                            B[k * block_K : (k + 1) * block_K, by * block_N : (by + 1) * block_N],
-                            B_shared[phase % num_stages, :, :],
-                            barrier=loaded[phase % num_stages],
-                        )
-                        T.mbarrier_arrive(loaded[phase % num_stages])
+                for k in T.serial(k_blocks):
+                    phase = w * k_blocks + k
+                    T.mbarrier_wait_parity(consumed[phase % num_stages], ((phase // num_stages) & 1) ^ 1)
+                    T.tma_copy(
+                        A[bx * block_M : (bx + 1) * block_M, k * block_K : (k + 1) * block_K],
+                        A_shared[phase % num_stages, :, :],
+                        barrier=loaded[phase % num_stages],
+                    )
+                    T.tma_copy(
+                        B[k * block_K : (k + 1) * block_K, by * block_N : (by + 1) * block_N],
+                        B_shared[phase % num_stages, :, :],
+                        barrier=loaded[phase % num_stages],
+                    )
+                    T.mbarrier_arrive(loaded[phase % num_stages])
+                sched.next_tile()
 
         elif tx < 64:  # warp 1: issue tcgen5
-            for w in T.unroll(waves):
-                tile_id = sm_num * w + block_id
-                bx = (tile_id // group_size) % m_blocks
-                by = (tile_id % group_size) + (tile_id // group_size) // m_blocks * group_size
+            sched = T.PersistentTileScheduler("sched_mma", m_blocks, n_blocks, swizzle_size=group_size)
+            sched.init(block_id)
+            while sched.valid():
+                w = sched.current_iter[0]
 
-                if bx * block_M < M and by * block_N < N:
-                    T.mbarrier_wait_parity(tmem_empty[w & 1], ((w // 2) & 1) ^ 1)
-                    for k in T.serial(k_blocks):
-                        phase = w * k_blocks + k
-                        T.mbarrier_wait_parity(loaded[phase % num_stages], (phase // num_stages) & 1)
-                        if w & 1 == 0:
-                            T.tcgen05_gemm(
-                                A_shared[k % num_stages, :, :],
-                                B_shared[k % num_stages, :, :],
-                                C_tmem_0,
-                                False,
-                                False,
-                                mbar=consumed[k % num_stages],
-                                clear_accum=k == 0,
-                            )
-                        else:
-                            T.tcgen05_gemm(
-                                A_shared[k % num_stages, :, :],
-                                B_shared[k % num_stages, :, :],
-                                C_tmem_1,
-                                False,
-                                False,
-                                mbar=consumed[k % num_stages],
-                                clear_accum=k == 0,
-                            )
-                    T.tcgen05_mma_arrive(tmem_full[w & 1])
+                T.mbarrier_wait_parity(tmem_empty[w & 1], ((w // 2) & 1) ^ 1)
+                for k in T.serial(k_blocks):
+                    phase = w * k_blocks + k
+                    T.mbarrier_wait_parity(loaded[phase % num_stages], (phase // num_stages) & 1)
+                    if w & 1 == 0:
+                        T.tcgen05_gemm(
+                            A_shared[k % num_stages, :, :],
+                            B_shared[k % num_stages, :, :],
+                            C_tmem_0,
+                            mbar=consumed[k % num_stages],
+                            clear_accum=k == 0,
+                        )
+                    else:
+                        T.tcgen05_gemm(
+                            A_shared[k % num_stages, :, :],
+                            B_shared[k % num_stages, :, :],
+                            C_tmem_1,
+                            mbar=consumed[k % num_stages],
+                            clear_accum=k == 0,
+                        )
+                T.tcgen05_mma_arrive(tmem_full[w & 1])
+                sched.next_tile()
 
         elif 128 <= tx < 256:  # warp 4~7: epilogue
-            for w in T.unroll(waves):
-                tile_id = sm_num * w + block_id
-                bx = (tile_id // group_size) % m_blocks
-                by = (tile_id % group_size) + (tile_id // group_size) // m_blocks * group_size
+            sched = T.PersistentTileScheduler("sched_epi", m_blocks, n_blocks, swizzle_size=group_size)
+            sched.init(block_id)
+            while sched.valid():
+                w, bx, by = sched.current_iter[0], sched.m_idx[0], sched.n_idx[0]
 
-                if bx * block_M < M and by * block_N < N:
-                    T.mbarrier_wait_parity(tmem_full[w & 1], (w // 2) & 1)
-                    if (w & 1) == 0:
-                        T.copy(C_tmem_0, C_local)
-                    else:
-                        T.copy(C_tmem_1, C_local)
-                    T.mbarrier_arrive(tmem_empty[w & 1])
+                T.mbarrier_wait_parity(tmem_full[w & 1], (w // 2) & 1)
+                if (w & 1) == 0:
+                    T.copy(C_tmem_0, C_local)
+                else:
+                    T.copy(C_tmem_1, C_local)
+                T.mbarrier_arrive(tmem_empty[w & 1])
 
-                    if use_tma_store:
-                        for i in T.unroll(T.ceildiv(block_N, store_block_N)):
-                            T.copy(C_local[:, i * store_block_N : (i + 1) * store_block_N], C_shared)
-                            T.copy(C_shared, C[bx * block_M, by * block_N + i * store_block_N])
-                    else:
-                        T.copy(C_local, C_local_cast)
-                        T.copy(C_local_cast, C[bx * block_M, by * block_N])
+                if use_tma_store:
+                    for i in T.unroll(T.ceildiv(block_N, store_block_N)):
+                        T.copy(C_local[:, i * store_block_N : (i + 1) * store_block_N], C_shared)
+                        T.copy(C_shared, C[bx * block_M, by * block_N + i * store_block_N])
+                else:
+                    T.copy(C_local, C_local_cast)
+                    T.copy(C_local_cast, C[bx * block_M, by * block_N])
+                sched.next_tile()
     return C
 
 
@@ -151,15 +153,13 @@ def gemm_persistent_2cta(
     C = T.empty((M, N), out_dtype)
 
     sm_num = driver.get_num_sms()
-    num_clusters = sm_num // 2
     m_blocks = T.ceildiv(M, block_M)
-    m_clusters = m_blocks // 2
     n_blocks = T.ceildiv(N, block_N)
     assert K % (2 * block_K) == 0  # for simplicity
     k_blocks = T.ceildiv(K, block_K)
-    waves = T.ceildiv(m_blocks * n_blocks, sm_num)
     group_size = 8  # in cluster
     assert n_blocks % (2 * group_size) == 0  # Please adjust group_size if not satisfied
+    cluster_size = 2
 
     with T.ClusterKernel(sm_num, threads=256, cluster_dims=2) as (block_id):
         A_shared = T.alloc_shared((num_stages, block_M, block_K), in_dtype)
@@ -179,89 +179,85 @@ def gemm_persistent_2cta(
         T.assume(cta_id < 2)  # todo: automatically assume this
 
         if tx < 32:  # warp 0: issue tma
-            for w in T.unroll(waves):
-                # manual threadblock swizzle
-                cluster_id = block_id // 2
-                tile_id = num_clusters * w + cluster_id
-                bx_cluster = (tile_id // group_size) % m_clusters
-                bx = bx_cluster * 2 + cta_id
-                by = (tile_id % group_size) + (tile_id // group_size) // m_clusters * group_size
+            sched = T.PersistentTileScheduler(
+                "sched_tma", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+            sched.init(block_id // cluster_size)
+            while sched.valid():
+                w = sched.current_iter[0]
+                bx, by = sched.m_idx[0] * cluster_size + cta_id, sched.n_idx[0]
 
-                if bx * block_M < M and by * block_N < N:
-                    for k in T.serial(k_blocks):
-                        phase = w * k_blocks + k
-                        T.mbarrier_wait_parity(consumed[phase % num_stages], ((phase // num_stages) & 1) ^ 1)
-                        T.tma_copy(
-                            A[bx * block_M : (bx + 1) * block_M, k * block_K : (k + 1) * block_K],
-                            A_shared[phase % num_stages, :, :],
-                            barrier=loaded[phase % num_stages],
-                        )
+                for k in T.serial(k_blocks):
+                    phase = w * k_blocks + k
+                    T.mbarrier_wait_parity(consumed[phase % num_stages], ((phase // num_stages) & 1) ^ 1)
+                    T.tma_copy(
+                        A[bx * block_M : (bx + 1) * block_M, k * block_K : (k + 1) * block_K],
+                        A_shared[phase % num_stages, :, :],
+                        barrier=loaded[phase % num_stages],
+                    )
 
-                        T.tma_copy(
-                            B[k * block_K : (k + 1) * block_K, (by * 2 + cta_id) * block_N // 2 : (by * 2 + cta_id + 1) * block_N // 2],
-                            B_shared[phase % num_stages, :, :],
-                            barrier=loaded[phase % num_stages],
-                        )
-                        T.mbarrier_arrive(loaded[phase % num_stages], 0)
+                    T.tma_copy(
+                        B[k * block_K : (k + 1) * block_K, (by * 2 + cta_id) * block_N // 2 : (by * 2 + cta_id + 1) * block_N // 2],
+                        B_shared[phase % num_stages, :, :],
+                        barrier=loaded[phase % num_stages],
+                    )
+                    T.mbarrier_arrive(loaded[phase % num_stages], 0)
+                sched.next_tile()
 
         elif tx < 64 and cta_id == 0:  # warp 1: issue tcgen5
-            for w in T.unroll(waves):
-                # manual threadblock swizzle
-                cluster_id = block_id // 2
-                tile_id = num_clusters * w + cluster_id
-                bx_cluster = (tile_id // group_size) % m_clusters
-                bx = bx_cluster * 2 + cta_id
-                by = (tile_id % group_size) + (tile_id // group_size) // m_clusters * group_size
+            sched = T.PersistentTileScheduler(
+                "sched_mma", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+            sched.init(block_id // cluster_size)
+            while sched.valid():
+                w = sched.current_iter[0]
 
-                if bx * block_M < M and by * block_N < N:
-                    T.mbarrier_wait_parity(tmem_empty[w & 1], ((w // 2) & 1) ^ 1)
-                    for k in T.serial(k_blocks):
-                        phase = w * k_blocks + k
-                        T.mbarrier_wait_parity(loaded[phase % num_stages], (phase // num_stages) & 1)
-                        if w & 1 == 0:
-                            T.tcgen05_gemm(
-                                A_shared[phase % num_stages, :, :],
-                                B_shared[phase % num_stages, :, :],
-                                C_tmem_0,
-                                mbar=consumed[phase % num_stages],
-                                clear_accum=k == 0,
-                                use_2cta=True,
-                            )
-                        else:
-                            T.tcgen05_gemm(
-                                A_shared[phase % num_stages, :, :],
-                                B_shared[phase % num_stages, :, :],
-                                C_tmem_1,
-                                mbar=consumed[phase % num_stages],
-                                clear_accum=k == 0,
-                                use_2cta=True,
-                            )
-                    T.tcgen05_mma_arrive(tmem_full[w & 1], arrive_2cta=True)
+                T.mbarrier_wait_parity(tmem_empty[w & 1], ((w // 2) & 1) ^ 1)
+                for k in T.serial(k_blocks):
+                    phase = w * k_blocks + k
+                    T.mbarrier_wait_parity(loaded[phase % num_stages], (phase // num_stages) & 1)
+                    if w & 1 == 0:
+                        T.tcgen05_gemm(
+                            A_shared[phase % num_stages, :, :],
+                            B_shared[phase % num_stages, :, :],
+                            C_tmem_0,
+                            mbar=consumed[phase % num_stages],
+                            clear_accum=k == 0,
+                            use_2cta=True,
+                        )
+                    else:
+                        T.tcgen05_gemm(
+                            A_shared[phase % num_stages, :, :],
+                            B_shared[phase % num_stages, :, :],
+                            C_tmem_1,
+                            mbar=consumed[phase % num_stages],
+                            clear_accum=k == 0,
+                            use_2cta=True,
+                        )
+                T.tcgen05_mma_arrive(tmem_full[w & 1], arrive_2cta=True)
+                sched.next_tile()
 
         elif 128 <= tx < 256:  # warp 4~7: epilogue
-            for w in T.unroll(waves):
-                # manual threadblock swizzle
-                cluster_id = block_id // 2
-                tile_id = num_clusters * w + cluster_id
-                bx_cluster = (tile_id // group_size) % m_clusters
-                bx = bx_cluster * 2 + cta_id
-                by = (tile_id % group_size) + (tile_id // group_size) // m_clusters * group_size
+            sched = T.PersistentTileScheduler(
+                "sched_epi", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+            sched.init(block_id // cluster_size)
+            while sched.valid():
+                w = sched.current_iter[0]
+                bx, by = sched.m_idx[0] * cluster_size + cta_id, sched.n_idx[0]
 
-                if bx * block_M < M and by * block_N < N:
-                    T.mbarrier_wait_parity(tmem_full[w & 1], (w // 2) & 1)
-                    if (w & 1) == 0:
-                        T.copy(C_tmem_0, C_local)
-                    else:
-                        T.copy(C_tmem_1, C_local)
-                    T.mbarrier_arrive(tmem_empty[w & 1], 0)
+                T.mbarrier_wait_parity(tmem_full[w & 1], (w // 2) & 1)
+                if (w & 1) == 0:
+                    T.copy(C_tmem_0, C_local)
+                else:
+                    T.copy(C_tmem_1, C_local)
+                T.mbarrier_arrive(tmem_empty[w & 1], 0)
 
-                    if use_tma_store:
-                        for i in T.unroll(T.ceildiv(block_N, store_block_N)):
-                            T.copy(C_local[:, i * store_block_N : (i + 1) * store_block_N], C_shared)
-                            T.copy(C_shared, C[bx * block_M, by * block_N + i * store_block_N])
-                    else:
-                        T.copy(C_local, C_local_cast)
-                        T.copy(C_local_cast, C[bx * block_M, by * block_N])
+                if use_tma_store:
+                    for i in T.unroll(T.ceildiv(block_N, store_block_N)):
+                        T.copy(C_local[:, i * store_block_N : (i + 1) * store_block_N], C_shared)
+                        T.copy(C_shared, C[bx * block_M, by * block_N + i * store_block_N])
+                else:
+                    T.copy(C_local, C_local_cast)
+                    T.copy(C_local_cast, C[bx * block_M, by * block_N])
+                sched.next_tile()
 
     return C
 
@@ -285,7 +281,10 @@ def main():
     print("All checks passed. ✅")
 
     tl_latency = do_bench(
-        lambda: kernel(a, b, block_M, block_N, store_block_N, block_K, in_dtype, out_dtype, accum_dtype, num_stages), backend="cupti"
+        lambda: kernel(a, b, block_M, block_N, store_block_N, block_K, in_dtype, out_dtype, accum_dtype, num_stages), 
+        _n_warmup=50,
+        _n_repeat=50,
+        backend="cupti"
     )
     torch_latency = do_bench(lambda: a @ b, backend="cupti")
     print(f"Tilelang latency: {tl_latency} ms")

--- a/examples/gemm_sm100/gemm_tcgen5mma_ws_persistent.py
+++ b/examples/gemm_sm100/gemm_tcgen5mma_ws_persistent.py
@@ -2,8 +2,8 @@
 #
 # Each warp role (TMA / tcgen5 MMA / epilogue) creates its own scheduler instance
 # and drives a single ``while sched.valid()`` loop. The scheduler owns the only
-# iteration clock: ``sched.current_iter[0]`` is the wave index ``w`` (used for the
-# pipeline phase / ``w & 1`` double-buffering) and ``sched.m_idx[0]`` /
+# iteration clock: ``sched.current_iter[0]`` drives pipeline phase /
+# ``sched.current_iter[0] & 1`` double-buffering; ``sched.m_idx[0]`` /
 # ``sched.n_idx[0]`` are the tile coords. One clock, held by the scheduler -- no
 # separate ``for w in range(waves)`` counter.
 
@@ -61,10 +61,10 @@ def gemm_persistent(
             sched = T.PersistentTileScheduler("sched_tma", m_blocks, n_blocks, swizzle_size=group_size)
             sched.init(block_id)
             while sched.valid():
-                w, bx, by = sched.current_iter[0], sched.m_idx[0], sched.n_idx[0]
+                bx, by = sched.m_idx[0], sched.n_idx[0]
 
                 for k in T.serial(k_blocks):
-                    phase = w * k_blocks + k
+                    phase = sched.current_iter[0] * k_blocks + k
                     T.mbarrier_wait_parity(consumed[phase % num_stages], ((phase // num_stages) & 1) ^ 1)
                     T.tma_copy(
                         A[bx * block_M : (bx + 1) * block_M, k * block_K : (k + 1) * block_K],
@@ -83,13 +83,11 @@ def gemm_persistent(
             sched = T.PersistentTileScheduler("sched_mma", m_blocks, n_blocks, swizzle_size=group_size)
             sched.init(block_id)
             while sched.valid():
-                w = sched.current_iter[0]
-
-                T.mbarrier_wait_parity(tmem_empty[w & 1], ((w // 2) & 1) ^ 1)
+                T.mbarrier_wait_parity(tmem_empty[sched.current_iter[0] & 1], ((sched.current_iter[0] // 2) & 1) ^ 1)
                 for k in T.serial(k_blocks):
-                    phase = w * k_blocks + k
+                    phase = sched.current_iter[0] * k_blocks + k
                     T.mbarrier_wait_parity(loaded[phase % num_stages], (phase // num_stages) & 1)
-                    if w & 1 == 0:
+                    if sched.current_iter[0] & 1 == 0:
                         T.tcgen05_gemm(
                             A_shared[k % num_stages, :, :],
                             B_shared[k % num_stages, :, :],
@@ -105,21 +103,21 @@ def gemm_persistent(
                             mbar=consumed[k % num_stages],
                             clear_accum=k == 0,
                         )
-                T.tcgen05_mma_arrive(tmem_full[w & 1])
+                T.tcgen05_mma_arrive(tmem_full[sched.current_iter[0] & 1])
                 sched.next_tile()
 
         elif 128 <= tx < 256:  # warp 4~7: epilogue
             sched = T.PersistentTileScheduler("sched_epi", m_blocks, n_blocks, swizzle_size=group_size)
             sched.init(block_id)
             while sched.valid():
-                w, bx, by = sched.current_iter[0], sched.m_idx[0], sched.n_idx[0]
+                bx, by = sched.m_idx[0], sched.n_idx[0]
 
-                T.mbarrier_wait_parity(tmem_full[w & 1], (w // 2) & 1)
-                if (w & 1) == 0:
+                T.mbarrier_wait_parity(tmem_full[sched.current_iter[0] & 1], (sched.current_iter[0] // 2) & 1)
+                if (sched.current_iter[0] & 1) == 0:
                     T.copy(C_tmem_0, C_local)
                 else:
                     T.copy(C_tmem_1, C_local)
-                T.mbarrier_arrive(tmem_empty[w & 1])
+                T.mbarrier_arrive(tmem_empty[sched.current_iter[0] & 1])
 
                 if use_tma_store:
                     for i in T.unroll(T.ceildiv(block_N, store_block_N)):
@@ -179,15 +177,13 @@ def gemm_persistent_2cta(
         T.assume(cta_id < 2)  # todo: automatically assume this
 
         if tx < 32:  # warp 0: issue tma
-            sched = T.PersistentTileScheduler(
-                "sched_tma", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+            sched = T.PersistentTileScheduler("sched_tma", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
             sched.init(block_id // cluster_size)
             while sched.valid():
-                w = sched.current_iter[0]
                 bx, by = sched.m_idx[0] * cluster_size + cta_id, sched.n_idx[0]
 
                 for k in T.serial(k_blocks):
-                    phase = w * k_blocks + k
+                    phase = sched.current_iter[0] * k_blocks + k
                     T.mbarrier_wait_parity(consumed[phase % num_stages], ((phase // num_stages) & 1) ^ 1)
                     T.tma_copy(
                         A[bx * block_M : (bx + 1) * block_M, k * block_K : (k + 1) * block_K],
@@ -204,17 +200,14 @@ def gemm_persistent_2cta(
                 sched.next_tile()
 
         elif tx < 64 and cta_id == 0:  # warp 1: issue tcgen5
-            sched = T.PersistentTileScheduler(
-                "sched_mma", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+            sched = T.PersistentTileScheduler("sched_mma", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
             sched.init(block_id // cluster_size)
             while sched.valid():
-                w = sched.current_iter[0]
-
-                T.mbarrier_wait_parity(tmem_empty[w & 1], ((w // 2) & 1) ^ 1)
+                T.mbarrier_wait_parity(tmem_empty[sched.current_iter[0] & 1], ((sched.current_iter[0] // 2) & 1) ^ 1)
                 for k in T.serial(k_blocks):
-                    phase = w * k_blocks + k
+                    phase = sched.current_iter[0] * k_blocks + k
                     T.mbarrier_wait_parity(loaded[phase % num_stages], (phase // num_stages) & 1)
-                    if w & 1 == 0:
+                    if sched.current_iter[0] & 1 == 0:
                         T.tcgen05_gemm(
                             A_shared[phase % num_stages, :, :],
                             B_shared[phase % num_stages, :, :],
@@ -232,23 +225,21 @@ def gemm_persistent_2cta(
                             clear_accum=k == 0,
                             use_2cta=True,
                         )
-                T.tcgen05_mma_arrive(tmem_full[w & 1], arrive_2cta=True)
+                T.tcgen05_mma_arrive(tmem_full[sched.current_iter[0] & 1], arrive_2cta=True)
                 sched.next_tile()
 
         elif 128 <= tx < 256:  # warp 4~7: epilogue
-            sched = T.PersistentTileScheduler(
-                "sched_epi", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+            sched = T.PersistentTileScheduler("sched_epi", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
             sched.init(block_id // cluster_size)
             while sched.valid():
-                w = sched.current_iter[0]
                 bx, by = sched.m_idx[0] * cluster_size + cta_id, sched.n_idx[0]
 
-                T.mbarrier_wait_parity(tmem_full[w & 1], (w // 2) & 1)
-                if (w & 1) == 0:
+                T.mbarrier_wait_parity(tmem_full[sched.current_iter[0] & 1], (sched.current_iter[0] // 2) & 1)
+                if (sched.current_iter[0] & 1) == 0:
                     T.copy(C_tmem_0, C_local)
                 else:
                     T.copy(C_tmem_1, C_local)
-                T.mbarrier_arrive(tmem_empty[w & 1], 0)
+                T.mbarrier_arrive(tmem_empty[sched.current_iter[0] & 1], 0)
 
                 if use_tma_store:
                     for i in T.unroll(T.ceildiv(block_N, store_block_N)):
@@ -281,10 +272,10 @@ def main():
     print("All checks passed. ✅")
 
     tl_latency = do_bench(
-        lambda: kernel(a, b, block_M, block_N, store_block_N, block_K, in_dtype, out_dtype, accum_dtype, num_stages), 
+        lambda: kernel(a, b, block_M, block_N, store_block_N, block_K, in_dtype, out_dtype, accum_dtype, num_stages),
         _n_warmup=50,
         _n_repeat=50,
-        backend="cupti"
+        backend="cupti",
     )
     torch_latency = do_bench(lambda: a @ b, backend="cupti")
     print(f"Tilelang latency: {tl_latency} ms")

--- a/tilelang/language/__init__.py
+++ b/tilelang/language/__init__.py
@@ -175,6 +175,16 @@ from .cluster import (
     clc_get_first_ctaid_z,  # noqa: F401
 )
 
+from .meta import (
+    inline,  # noqa: F401
+    meta_class,  # noqa: F401
+)
+
+from .tile_schedule import (
+    BaseTileScheduler,  # noqa: F401
+    PersistentTileScheduler,  # noqa: F401
+)
+
 
 def import_source(source: str | None = None):
     # source is the source code to be imported

--- a/tilelang/language/meta.py
+++ b/tilelang/language/meta.py
@@ -9,6 +9,7 @@ docstring for the details.
 from __future__ import annotations
 
 import ast
+import contextlib
 import inspect
 import textwrap
 from collections.abc import Callable
@@ -106,10 +107,8 @@ def _name_buffer(prefix: str, attr: str, value: Any) -> None:
 
     if not isinstance(value, Buffer):
         return
-    try:
+    with contextlib.suppress(Exception):  # naming is best-effort, never fatal
         IRBuilder.name(f"{prefix}_{attr}", value)
-    except Exception:  # noqa: BLE001 - naming is best-effort, never fatal
-        pass
 
 
 def _install_prefix_naming(cls: type) -> None:

--- a/tilelang/language/meta.py
+++ b/tilelang/language/meta.py
@@ -1,0 +1,193 @@
+"""Turn Python classes/methods into TIR, in both eager and lazy modes.
+
+Two DSL primitives -- ``inline`` (method -> inlined TIR) and ``meta_class``
+(class of JIT-time stateful helpers) -- that behave the same in eager
+(``@tilelang.jit``) and lazy (``@T.prim_func``) frontends. See each function's
+docstring for the details.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+_C = TypeVar("_C", bound=type)
+
+
+class _InlineMethod:
+    """Descriptor that inlines a method, dispatching eager vs lazy per call."""
+
+    def __init__(self, func: Callable) -> None:
+        self._func = func
+        self._eager = None  # eager macro, built lazily
+        self._lazy = None  # TVMScript parser inline, built lazily
+        self.__name__ = getattr(func, "__name__", "inline")
+        self.__doc__ = getattr(func, "__doc__", None)
+
+    def _eager_macro(self):
+        if self._eager is None:
+            from tilelang.language.eager.builder import macro
+
+            self._eager = macro(self._func)
+        return self._eager
+
+    def _lazy_macro(self):
+        if self._lazy is None:
+            from tvm.tirx.script.parser.entry import inline as _tvm_inline
+
+            self._lazy = _tvm_inline(self._func)
+        return self._lazy
+
+    def _dispatch(self, obj: Any, *args: Any, **kwargs: Any):
+        from tilelang.language.eager.builder import Builder
+
+        if Builder.current() is not None:
+            return self._eager_macro()(obj, *args, **kwargs)
+        return self._lazy_macro()(obj, *args, **kwargs)
+
+    def __get__(self, obj: Any, owner: type | None = None):
+        if obj is None:
+            return self
+        return lambda *args, **kwargs: self._dispatch(obj, *args, **kwargs)
+
+
+def inline(func: Callable) -> _InlineMethod:
+    """Decorator: lower a method body to TIR, inlined at each call site.
+
+    ``self`` is bound automatically. The lowering engine is chosen per call so
+    the same method works in both frontends:
+
+    - eager mode (an eager ``Builder`` is active) -> the eager ``macro`` engine;
+    - lazy mode (no eager builder; a TVMScript parser is active) -> TVM's
+      parser-level ``inline`` (``TIRInline``).
+
+    Both engines are built lazily on first use of the respective mode.
+
+    Inside an inlined method, read scalar state via ``self.x[0]`` and write via
+    ``self.x[0] = ...``; the store lowers to ``BufferStore`` through whichever
+    engine is active, so no core builder/parser changes are needed.
+    """
+    return _InlineMethod(func)
+
+
+def _emits_store(func: Callable) -> bool:
+    """True if ``func`` contains a buffer store (subscript-target assignment).
+
+    A subscript target ``self.x[...] = ...`` (or its augmented form) is how state
+    methods lower to ``BufferStore``, so such methods must be inlined. Methods
+    without any store only build/return ``PrimExpr`` values and are kept plain
+    Python (they work in both modes and can be reused statelessly).
+    """
+    try:
+        src = textwrap.dedent(inspect.getsource(func))
+        fn = ast.parse(src).body[0]
+        for node in ast.walk(fn):
+            targets = []
+            if isinstance(node, ast.Assign):
+                targets = list(node.targets)
+            elif isinstance(node, (ast.AugAssign, ast.AnnAssign)):
+                targets = [node.target]
+            for tgt in targets:
+                for sub in ast.walk(tgt):
+                    if isinstance(sub, ast.Subscript):
+                        return True
+        return False
+    except Exception:  # noqa: BLE001 - if we cannot tell, default to inlining
+        return True
+
+
+def _name_buffer(prefix: str, attr: str, value: Any) -> None:
+    """Give a state buffer a readable name ``{prefix}_{attr}`` in the IR."""
+    from tvm.script.ir_builder import IRBuilder
+    from tvm.tirx import Buffer
+
+    if not isinstance(value, Buffer):
+        return
+    try:
+        IRBuilder.name(f"{prefix}_{attr}", value)
+    except Exception:  # noqa: BLE001 - naming is best-effort, never fatal
+        pass
+
+
+def _install_prefix_naming(cls: type) -> None:
+    """Make ``self.<attr> = <buffer>`` auto-name the buffer using ``prefix``.
+
+    ``prefix`` is read from the constructor argument of the same name (if any),
+    so existing ``__init__(self, prefix, ...)`` signatures just work.
+    """
+    if cls.__dict__.get("_tl_prefix_naming_installed", False):
+        return
+
+    orig_init = cls.__init__
+    init_sig = inspect.signature(orig_init)
+
+    def __init__(self, *args, **kwargs):
+        prefix = None
+        try:
+            bound = init_sig.bind(self, *args, **kwargs)
+            bound.apply_defaults()
+            prefix = bound.arguments.get("prefix")
+        except TypeError:
+            prefix = None
+        object.__setattr__(self, "_meta_prefix", prefix)
+        orig_init(self, *args, **kwargs)
+
+    def __setattr__(self, name, value):
+        object.__setattr__(self, name, value)
+        prefix = getattr(self, "_meta_prefix", None)
+        if prefix and not name.startswith("_"):
+            _name_buffer(prefix, name, value)
+
+    cls.__init__ = __init__
+    cls.__setattr__ = __setattr__
+    cls._tl_prefix_naming_installed = True
+
+
+def meta_class(cls: _C) -> _C:
+    """Class decorator for JIT-time stateful helpers (e.g. tile schedulers).
+
+    Instances exist only during JIT tracing / parsing and hold ``T.alloc_var``
+    buffers as state (``T.alloc_var`` emits into the active IR frame in both
+    modes). The decorator has three responsibilities:
+
+    1. Mark the class with ``_is_meta_class``. The lazy parser needs this to
+       bind ``sched = Sched(...)`` as a (non-TIR) instance in its scope instead
+       of trying to turn it into a constant.
+    2. Auto-``inline`` every TIR-emitting method, so methods need no per-method
+       ``@inline``. A method is considered TIR-emitting iff it contains a
+       buffer store, i.e. a subscript-target assignment ``self.x[...] = ...``
+       (see ``_emits_store``). Left as plain Python:
+
+       - dunders (``__init__`` allocates state as plain Python),
+       - ``staticmethod`` / ``classmethod`` / ``property``,
+       - methods already decorated with ``@inline``,
+       - methods with no buffer store -- pure compile-time helpers that only
+         build/return ``PrimExpr`` expressions (e.g. ``valid`` returning a
+         loop condition, or a ``coord(tile_id)`` decode returning ``(m, n)``).
+         These stay plain so they can return values and be reused statelessly.
+         A method that emits TIR only through control flow / nested calls (no
+         direct store) should be marked explicitly with ``@inline``.
+    3. Auto-name state buffers ``{prefix}_{attr}`` in the generated IR, where
+       ``prefix`` is the constructor argument named ``prefix`` (so
+       ``Sched("sched", ...)`` yields ``sched_m_idx`` etc.). This wraps
+       ``__init__`` to capture ``prefix`` and installs a ``__setattr__`` that
+       names any ``Buffer`` assigned to a non-underscore attribute; non-buffers
+       (compile-time ints like ``num_n_tiles``) and underscore attributes are
+       skipped, and naming is best-effort (never fatal). It runs at
+       construction while an IR builder is active, so it works in both modes.
+    """
+    cls._is_meta_class = True
+    _install_prefix_naming(cls)
+    for name, attr in list(cls.__dict__.items()):
+        if name.startswith("__"):
+            continue
+        if isinstance(attr, _InlineMethod):
+            continue
+        if isinstance(attr, (staticmethod, classmethod, property)):
+            continue
+        if inspect.isfunction(attr) and _emits_store(attr):
+            setattr(cls, name, inline(attr))
+    return cls

--- a/tilelang/language/tile_schedule.py
+++ b/tilelang/language/tile_schedule.py
@@ -1,0 +1,262 @@
+"""Tile schedulers built on TileLang ``meta_class``.
+
+``@meta_class`` auto-inlines every method that emits a buffer store, so state
+methods can freely read scalar state via ``self.x[0]`` and write via
+``self.x[0] = ...`` (the latter lowers to a ``BufferStore``). Store-free methods
+(``valid``, ``coord``) stay plain Python and just return ``PrimExpr`` values, so
+they work in conditions and can be reused statelessly. State lives in
+``T.alloc_var`` buffers allocated in ``__init__`` (only when ``stateful``). Works
+in both eager (``@tilelang.jit``) and lazy (``@T.prim_func``) modes.
+
+Note on compile-time branching: the lazy TVMScript parser does not constant-fold
+a Python ``if`` on a compile-time value inside an inlined method (it would emit a
+dead TIR branch). So all compile-time decisions (traversal order, clustering)
+are made in ``__init__`` (plain Python); the inlined hot methods contain only
+uniform runtime arithmetic. The store-free ``coord`` may use a compile-time
+``if`` because, being plain Python, it is evaluated (not traced) per call.
+"""
+
+from __future__ import annotations
+
+import tilelang.language as T
+from tilelang.carver.arch import driver
+from tilelang.language.meta import meta_class
+
+
+@meta_class
+class BaseTileScheduler:
+    """Common state and tile-traversal skeleton.
+
+    State (single-element ``T.alloc_var`` buffers): ``m_idx`` / ``n_idx`` are the
+    current tile coordinates; ``linear_idx`` is the worker's global linear cursor;
+    ``current_iter`` is the 0-based iteration count (how many tiles this worker has
+    advanced past = the "wave" index). ``current_iter`` is the single iteration
+    clock the kernel can read for pipeline/double-buffer state (e.g.
+    ``sched.current_iter[0] & 1``), removing the need for a separate ``for w`` loop
+    counter. Subclasses implement ``update_current_idx`` to decode ``linear_idx``
+    into ``(m_idx, n_idx)`` and set ``self._total_tiles`` (used by ``valid``).
+    """
+
+    def __init__(self, prefix: str, stateful: bool = True):
+        self._stateful = stateful
+        if stateful:
+            self.m_idx = T.alloc_var(T.int32)
+            self.n_idx = T.alloc_var(T.int32)
+            self.linear_idx = T.alloc_var(T.int32)
+            self.current_iter = T.alloc_var(T.int32)
+        self._total_tiles = 0
+
+    def update_current_idx(self, linear_idx):
+        raise NotImplementedError("Subclasses must implement update_current_idx")
+
+    def init(self, linear_init):
+        self.current_iter[0] = 0
+        self.linear_idx[0] = linear_init
+        self.update_current_idx(self.linear_idx[0])
+
+    def next_tile(self, step):
+        self.current_iter[0] = self.current_iter[0] + 1
+        self.linear_idx[0] = self.linear_idx[0] + step
+        self.update_current_idx(self.linear_idx[0])
+
+    def valid(self):
+        return self.linear_idx[0] < self._total_tiles
+
+
+@meta_class
+class PersistentTileScheduler(BaseTileScheduler):
+    """Persistent, grid-strided tile scheduler with L2 swizzle and clustering.
+
+    The 2D tile grid (``num_m_tiles`` x ``num_n_tiles``) is flattened into a
+    linear order and distributed across ``num_workers`` persistent workers:
+    worker ``w`` processes linear indices ``w, w + num_workers, ...`` until they
+    run past the total. The linear-to-2D decode is controlled by three
+    independent, interacting factors:
+
+    1. ``column_major`` -- traversal order. With ``swizzle_size == 1`` this is
+       pure column-major (``m`` varies fastest) when ``True``, or pure row-major
+       (``n`` varies fastest) when ``False``.
+    2. ``swizzle_size`` -- L2-locality panel width. The "fast" axis is widened
+       into panels of ``swizzle_size`` tiles along the "slow" axis: a full strip
+       of the fast axis is swept for each group of ``swizzle_size`` slow-axis
+       tiles before advancing. ``swizzle_size == 1`` disables swizzling. This is
+       the CUTLASS-style threadblock swizzle used by the SM100 persistent GEMM
+       examples. Non-divisible tail panels are handled (narrower last panel).
+    3. ``cluster_size`` -- block clustering along M (x) only. The M tiles are
+       grouped into clusters of ``cluster_size`` rows, and the scheduler runs at
+       *cluster* granularity: it produces the cluster-row in ``m_idx`` over a
+       grid of ``ceildiv(num_m_tiles, cluster_size)`` cluster-rows x
+       ``num_n_tiles`` columns. The caller turns the cluster-row into a real
+       block row by adding the in-cluster rank::
+
+           bx = sched.m_idx[0] * cluster_size + cta_rank_in_cluster
+
+       (For ``cluster_size == 1`` this reduces to ``bx = sched.m_idx[0]``.)
+
+    Interaction: clustering reshapes the grid to ``M' x N'`` (with
+    ``M' = ceildiv(num_m_tiles, cluster_size)``) *first*; the swizzle and
+    traversal order then operate on that reshaped grid. ``num_workers`` is the
+    number of resident workers (= clusters when ``cluster_size > 1``).
+
+    Parameters
+    ----------
+    prefix : str
+        Name prefix for the scheduler's state buffers in the generated IR
+        (``{prefix}_m_idx`` / ``{prefix}_n_idx`` / ``{prefix}_linear_idx``).
+    num_m_tiles : int | PrimExpr
+        Number of tiles along M (``ceildiv(M, block_M)``).
+    num_n_tiles : int | PrimExpr
+        Number of tiles along N (``ceildiv(N, block_N)``).
+    num_workers : int | PrimExpr, optional
+        Persistent stride = number of resident workers/clusters. Defaults to
+        ``driver.get_num_sms() // cluster_size`` (one block per SM, grouped into
+        clusters).
+    swizzle_size : int
+        L2 swizzle panel width (default ``1`` = no swizzle).
+    column_major : bool
+        Traversal order (default ``True`` = column-major / M fastest).
+    cluster_size : int
+        Block-cluster size along M only (default ``1`` = no clustering).
+    stateful : bool
+        If ``True`` (default), allocate the ``m_idx`` / ``n_idx`` / ``linear_idx``
+        / ``current_iter`` state buffers and enable ``init`` / ``next_tile`` /
+        ``valid`` for a ``while`` persistent loop. If ``False``, allocate no state
+        and expose only the pure ``coord(tile_id) -> (m, n)`` decode (for
+        ``for w in range(waves)`` loops and auto warp-specialization, where the
+        loop owns the iteration clock and the WS pass owns the pipeline phase).
+
+    Examples
+    --------
+    Plain persistent GEMM (one block per SM)::
+
+        m_blocks, n_blocks = T.ceildiv(M, block_M), T.ceildiv(N, block_N)
+        with T.Kernel(driver.get_num_sms(), threads=threads) as (block_id,):
+            sched = T.PersistentTileScheduler("sched", m_blocks, n_blocks)
+            sched.init(block_id)
+            while sched.valid():
+                bx, by = sched.m_idx[0], sched.n_idx[0]
+                # ... compute tile (bx, by) ...
+                sched.next_tile()
+
+    With L2 swizzle (panel width 8)::
+
+        sched = T.PersistentTileScheduler(
+            "sched", m_blocks, n_blocks, swizzle_size=8)
+
+    With a 2-CTA cluster along M (e.g. SM100 2-SM MMA)::
+
+        sm_num = driver.get_num_sms()
+        cluster_size = 2
+        with T.ClusterKernel(sm_num, threads=256, cluster_dims=cluster_size) as (block_id):
+            cta_rank = T.block_rank_in_cluster()
+            sched = T.PersistentTileScheduler(
+                "sched", m_blocks, n_blocks,
+                swizzle_size=8, cluster_size=cluster_size)
+            sched.init(block_id // cluster_size)   # init with cluster id
+            while sched.valid():
+                bx = sched.m_idx[0] * cluster_size + cta_rank
+                by = sched.n_idx[0]
+                # ... compute tile (bx, by) ...
+                sched.next_tile()
+
+    Stateless form (``stateful=False``) for ``for w`` loops / auto-WS, where the
+    scheduler is only a tile-coordinate decoder::
+
+        sched = T.PersistentTileScheduler(
+            "sched", m_blocks, n_blocks, swizzle_size=8, stateful=False)
+        for w in range(waves):
+            bx, by = sched.coord(num_workers * w + worker_id)
+            if bx * block_M < M and by * block_N < N:
+                # ... pipelined inner loop (T.Pipelined / T.copy / T.gemm) ...
+                pass
+
+    Manual warp-specialized kernels use ``current_iter`` as the single iteration clock
+    (no separate ``for w`` loop): each warp role runs its own
+    ``while sched.valid()`` loop and reads ``w = sched.current_iter[0]`` for
+    pipeline/double-buffer state (``w & 1`` etc.) while reading ``sched.m_idx[0]``
+    / ``sched.n_idx[0]`` for the tile::
+
+        sched.init(block_id)
+        while sched.valid():
+            w = sched.current_iter[0]
+            bx, by = sched.m_idx[0], sched.n_idx[0]
+            # ... use w for barrier phase / w & 1 double-buffering ...
+            sched.next_tile()
+
+    Notes
+    -----
+    State is held in single-element ``T.alloc_var`` buffers, so read with
+    ``sched.m_idx[0]`` / ``sched.current_iter[0]`` and (inside methods) write with
+    ``self.x[0] = ...``; the ``[0]`` is required for the write to lower to a
+    ``BufferStore``."""
+
+    def __init__(
+        self,
+        prefix: str,
+        num_m_tiles,
+        num_n_tiles,
+        num_workers=None,
+        swizzle_size: int = 1,
+        column_major: bool = True,
+        cluster_size: int = 1,
+        stateful: bool = True,
+    ):
+        super().__init__(prefix, stateful=stateful)
+        self.cluster_size = cluster_size
+        if num_workers is None:
+            num_workers = driver.get_num_sms() // cluster_size
+        self.num_workers = num_workers
+        self.swizzle_size = swizzle_size
+        self._column_major = column_major
+
+        # Cluster reshapes the grid along M first: M' x N'.
+        m_clusters = T.ceildiv(num_m_tiles, cluster_size)
+        self._total_tiles = m_clusters * num_n_tiles
+
+        # "primary" axis is swept fully within a swizzle panel; "secondary" axis
+        # is chunked into panels of width ``swizzle_size``.
+        if column_major:  # M fastest
+            self._primary = m_clusters
+            self._secondary = num_n_tiles
+        else:  # N fastest
+            self._primary = num_n_tiles
+            self._secondary = m_clusters
+
+    def coord(self, tile_id):
+        """Decode a linear ``tile_id`` into ``(m_idx, n_idx)`` (pure PrimExpr).
+
+        Stateless: builds expressions only, touches no state buffer, so it is
+        usable on a ``stateful=False`` instance and can be called independently
+        from any loop / warp role. ``m_idx`` is the cluster row when
+        ``cluster_size > 1`` (caller adds the in-cluster rank).
+        """
+        primary = self._primary
+        secondary = self._secondary
+        swizzle = self.swizzle_size
+
+        group = tile_id // (primary * swizzle)
+        base = group * swizzle
+        # Panel width along the slow axis; narrower for a non-divisible tail, and
+        # clamped to >= 1 so decoding an out-of-range tile_id never divides by 0.
+        width = T.max(1, T.min(swizzle, secondary - base))
+        in_group = tile_id - group * (primary * swizzle)
+        fast = in_group // width
+        slow = base + in_group % width
+        if self._column_major:
+            return fast, slow  # (m, n)
+        return slow, fast  # (m, n)
+
+    def update_current_idx(self, linear_idx):
+        m, n = self.coord(linear_idx)
+        self.m_idx[0] = m
+        self.n_idx[0] = n
+
+    def init(self, worker_id):
+        self.current_iter[0] = 0
+        self.linear_idx[0] = worker_id
+        self.update_current_idx(self.linear_idx[0])
+
+    def next_tile(self):
+        self.current_iter[0] = self.current_iter[0] + 1
+        self.linear_idx[0] = self.linear_idx[0] + self.num_workers
+        self.update_current_idx(self.linear_idx[0])

--- a/tilelang/language/tile_schedule.py
+++ b/tilelang/language/tile_schedule.py
@@ -172,15 +172,14 @@ class PersistentTileScheduler(BaseTileScheduler):
 
     Manual warp-specialized kernels use ``current_iter`` as the single iteration clock
     (no separate ``for w`` loop): each warp role runs its own
-    ``while sched.valid()`` loop and reads ``w = sched.current_iter[0]`` for
-    pipeline/double-buffer state (``w & 1`` etc.) while reading ``sched.m_idx[0]``
-    / ``sched.n_idx[0]`` for the tile::
+    ``while sched.valid()`` loop and reads ``sched.current_iter[0]`` for
+    pipeline/double-buffer state (``sched.current_iter[0] & 1`` etc.) while reading
+    ``sched.m_idx[0]`` / ``sched.n_idx[0]`` for the tile::
 
         sched.init(block_id)
         while sched.valid():
-            w = sched.current_iter[0]
             bx, by = sched.m_idx[0], sched.n_idx[0]
-            # ... use w for barrier phase / w & 1 double-buffering ...
+            # ... use sched.current_iter[0] for barrier phase / double-buffering ...
             sched.next_tile()
 
     Notes


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR introduces tile scheduler infrastructure to TileLang, enabling persistent kernel patterns with flexible tile iteration strategies. It adds meta-programming utilities (`@inline`, `@meta_class`) for lowering stateful Python helpers into TIR, and new scheduler classes (`BaseTileScheduler`, `PersistentTileScheduler`) that manage tile traversal with clustering and swizzling options. It also refactors multiple SM100 persistent GEMM example kernels to use the new persistent schedulers instead of precomputed `waves`/manual tile-walk logic.

## Key Changes

### New Modules
- `tilelang/language/meta.py` (+193 lines): Implements meta-programming utilities:
  - `@inline` descriptor that dispatches to eager `macro` generation when an eager builder is active, otherwise lowers to TVMScript `inline`.
  - `@meta_class` class decorator for JIT-time stateful helper classes:
    - captures an optional `prefix` for buffer naming
    - best-effort renames assigned `Buffer` attributes as `{prefix}_{attr}`
    - auto-wraps selected store-emitting methods with `@inline` via AST inspection.

- `tilelang/language/tile_schedule.py` (+262 lines): Adds scheduler implementations:
  - `BaseTileScheduler`: core iteration logic with optional state buffers (`m_idx`, `n_idx`, `linear_idx`, `current_iter`) and control-flow methods (`init`, `valid`, `next_tile`, plus abstract coordinate decoding).
  - `PersistentTileScheduler`: persistent/grid-strided traversal with configurable:
    - `cluster_size` (clustered M tiling)
    - `swizzle_size` (L2/panel swizzling behavior)
    - `column_major` (axis fast/slow selection)
    - `coord(tile_id)` stateless coordinate decoding and stateful worker-based iteration (`init(worker_id)`, `next_tile()`).

### Updated Modules
- `tilelang/language/__init__.py` (+10 lines): Re-exports `inline`, `meta_class`, `BaseTileScheduler`, and `PersistentTileScheduler`.

### Refactored Examples to Use `T.PersistentTileScheduler`
- `examples/gemm_sm100/gemm_tcgen5mma_ws_persistent.py`: Refactors `gemm_persistent` and `gemm_persistent_2cta` to replace `waves`/manual tile-walk counters with scheduler-driven `while sched.valid()` loops. Loader/MMA/epilogue roles each own a scheduler instance and advance via `sched.next_tile()`, deriving tile coordinates from scheduler state.

- `examples/blockscaled_gemm_sm100/gemm_mxfp8_blockscaled_1d1d.py`: Updates the persistent 2-CTA scheduling across TMA load / MMA compute / scale-factor transpose / epilogue to scheduler-driven iteration, and adjusts persistent cluster configuration to use `cluster_size = 2`.

- `examples/deepseek_v4/fp8_fp4_gemm_1d1d_sm100.py`: Converts persistent scheduling logic to `PersistentTileScheduler`-driven loops for load, MMA, scale-factor transpose, and epilogue phases, removing explicit `waves`-based tile indexing and associated bounds guards.

## Design Notes
- Schedulers are implemented as Python classes decorated with `@meta_class`, allowing stateful tile traversal logic to be lowered into TIR while keeping coordinate decoding reusable (`coord(tile_id)` vs. stateful `update_current_idx`).
- Persistent kernels now use scheduler state (`current_iter`, `m_idx`, `n_idx`, etc.) to drive role-specific pipeline progress and tile coordinate selection.

## Testing & Review Notes
- High review effort is expected due to new scheduler/meta-programming infrastructure and multiple kernel refactors.
- The example changes demonstrate the intended usage pattern: multiple warp roles each instantiate and iterate their own persistent scheduler via `while sched.valid()`.

## C++ style / lint notes
- This PR does **not** touch C++ sources or CI logic related to C++ linting; it only changes Python modules and Python example kernels.
- The PR does **not** modify `docs/developer_guide/cpp_style.md`, so C++ style rule guidance is unaffected.
- CI includes **“C++ API Style Audit (warning only)”**; since this PR does not change C++/API surface code, it should not introduce new warning-only TLCPP003/TLCPP004 findings from this change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->