### PR TITLE
[CUDA] Remove `__shfl_sync` from `tl_shuffle_elect`

### DIFF
--- a/src/tl_templates/cuda/intrin.h
+++ b/src/tl_templates/cuda/intrin.h
@@ -86,7 +86,7 @@ TL_DEVICE void warpgroup_fence_operand(float *regs, int count) {
 //                  within which we want to elect exactly ONE representative
 //                  thread.
 template <int thread_extent> TL_DEVICE bool tl_shuffle_elect() {
-
+  static_assert(thread_extent % 32 == 0);
   // Special case: thread_extent == 0 means "elect exactly one thread
   // in the entire thread block", i.e., the leader of the first warp of the
   // block.

--- a/src/tl_templates/cuda/intrin.h
+++ b/src/tl_templates/cuda/intrin.h
@@ -114,11 +114,12 @@ template <int thread_extent> TL_DEVICE bool tl_shuffle_elect() {
     return cute::elect_one_sync();
   } else {
     // General case: thread_extent != 0
-    // We select warps with multiple of (thread_extent / 32) warp IDs.
+    // We select warps with multiple of ceil(thread_extent / 32) warp IDs.
     // NOTE: we use canonical_warp_idx for the same reason as above.
-    static_assert(thread_extent % 32 == 0);
+    constexpr int warp_extent = (thread_extent + 31) / 32;
+    static_assert(warp_extent > 0);
     return cute::elect_one_sync() &&
-           (cutlass::canonical_warp_idx() % (thread_extent / 32)) == 0;
+           (cutlass::canonical_warp_idx() % warp_extent) == 0;
   }
 }
 

--- a/src/tl_templates/cuda/intrin.h
+++ b/src/tl_templates/cuda/intrin.h
@@ -86,7 +86,6 @@ TL_DEVICE void warpgroup_fence_operand(float *regs, int count) {
 //                  within which we want to elect exactly ONE representative
 //                  thread.
 template <int thread_extent> TL_DEVICE bool tl_shuffle_elect() {
-  static_assert(thread_extent % 32 == 0);
   // Special case: thread_extent == 0 means "elect exactly one thread
   // in the entire thread block", i.e., the leader of the first warp of the
   // block.
@@ -113,12 +112,14 @@ template <int thread_extent> TL_DEVICE bool tl_shuffle_elect() {
     return cute::elect_one_sync() && cutlass::canonical_warp_idx() == 0;
   } else if constexpr (thread_extent == 32) {
     return cute::elect_one_sync();
+  } else {
+    // General case: thread_extent != 0
+    // We select warps with multiple of (thread_extent / 32) warp IDs.
+    // NOTE: we use canonical_warp_idx for the same reason as above.
+    static_assert(thread_extent % 32 == 0);
+    return cute::elect_one_sync() &&
+           (cutlass::canonical_warp_idx() % (thread_extent / 32)) == 0;
   }
-  // General case: thread_extent != 0
-  // We select warps with multiple of (thread_extent / 32) warp IDs.
-  // NOTE: we use canonical_warp_idx for the same reason as above.
-  return cute::elect_one_sync() &&
-         (cutlass::canonical_warp_idx() % (thread_extent / 32)) == 0;
 }
 
 template <uint32_t RegCount> TL_DEVICE void warpgroup_reg_alloc() {

--- a/src/tl_templates/cuda/intrin.h
+++ b/src/tl_templates/cuda/intrin.h
@@ -91,7 +91,7 @@ template <int thread_extent> TL_DEVICE bool tl_shuffle_elect() {
   // in the entire thread block", i.e., the leader of the first warp of the
   // block.
   if constexpr (thread_extent == 0) {
-    // cutlass::canonical_warp_idx_sync():
+    // cutlass::canonical_warp_idx():
     //   Returns the warp ID within the thread block in a "canonical" way
     //   (0 for the first warp, 1 for the second, ...).
     // cute::elect_one_sync():
@@ -100,26 +100,25 @@ template <int thread_extent> TL_DEVICE bool tl_shuffle_elect() {
     // The condition ensures that:
     //   (1) We are in warp 0 of the block.
     //   (2) We are the elected lane in this warp.
-    return cutlass::canonical_warp_idx_sync() == 0 && cute::elect_one_sync();
+    // NOTE: we prefer canonical_warp_idx to canonical_warp_idx_sync here,
+    //       because the latter uses shfl.sync to broadcast the value from lane
+    //       0 to the whole warp to ensure that ptxas knows it is warp-uniform,
+    //       which helps the register allocator to assign the value to a uniform
+    //       register. However, shfl.sync is dispatched to the LSU pipe, causing
+    //       contention with other SMEM traffic, which can cause serious
+    //       performance degradation in SMEM-intensive kernels.
+    //       Here, we use elect.sync to inform ptxas that we are executing this
+    //       with only one thread, so we do not need shfl.sync to make it
+    //       warp-uniform.
+    return cute::elect_one_sync() && cutlass::canonical_warp_idx() == 0;
   } else if constexpr (thread_extent == 32) {
     return cute::elect_one_sync();
   }
   // General case: thread_extent != 0
-  // (threadIdx.x / 32) is the warp index in the block.
-  // (thread_extent / 32) is the number of warps in one group of size
-  // thread_extent. We take warp_id % num_warps_in_group to get the warp's index
-  // within the group.
-  // __shfl_sync(mask, value, srcLane): broadcast 'value' from srcLane to all
-  // lanes in the warp. Here it broadcasts the group-local warp index from lane
-  // 0. Comparing to 0 selects only the group's warp 0.
-  return __shfl_sync(0xffffffff, // full warp mask
-                     (threadIdx.x / 32) %
-                         (thread_extent / 32), // warp index within group
-                     0                         // take the value from lane 0
-                     ) == 0 &&
-         // Within that group leader warp, elect exactly one lane (typically
-         // lane 0) to be the single representative for the group.
-         cute::elect_one_sync();
+  // We select warps with multiple of (thread_extent / 32) warp IDs.
+  // NOTE: we use canonical_warp_idx for the same reason as above.
+  return cute::elect_one_sync() &&
+         (cutlass::canonical_warp_idx() % (thread_extent / 32)) == 0;
 }
 
 template <uint32_t RegCount> TL_DEVICE void warpgroup_reg_alloc() {

--- a/tilelang/language/builtin.py
+++ b/tilelang/language/builtin.py
@@ -679,7 +679,6 @@ def shuffle_elect(thread_extent: int) -> PrimExpr:
     thread_extent : int
         Size (in threads) of the group in which a single lane should be elected.
         Passing 0 elects a single lane in the entire thread block.
-        Must be multiple of 32 (warp size).
 
     Example
     -------

--- a/tilelang/language/builtin.py
+++ b/tilelang/language/builtin.py
@@ -679,6 +679,7 @@ def shuffle_elect(thread_extent: int) -> PrimExpr:
     thread_extent : int
         Size (in threads) of the group in which a single lane should be elected.
         Passing 0 elects a single lane in the entire thread block.
+        Must be multiple of 32 (warp size).
 
     Example
     -------
@@ -689,8 +690,8 @@ def shuffle_elect(thread_extent: int) -> PrimExpr:
     --------------------
     Lowered to the CUDA helper `tl::tl_shuffle_elect<thread_extent>()` defined in
     `src/tl_templates/cuda/intrin.h`, which relies on
-    `cutlass::canonical_warp_idx_sync()` and `cute::elect_one_sync()` (or
-    `__shfl_sync`) to pick one lane per group.
+    `cutlass::canonical_warp_idx()` and `cute::elect_one_sync()`
+    to pick one lane per group.
     """
     return tirx.call_intrin("bool", tirx.op.Op.get("tl.tl_shuffle_elect"), thread_extent)
 


### PR DESCRIPTION
tl_shuffle_elect elected its leader thread via canonical_warp_idx_sync()
(thread_extent == 0) and an explicit __shfl_sync group-leader broadcast
(general case). Both rely on shfl.sync purely to mark the warp index as
warp-uniform so ptxas can optimize.

shfl.sync is dispatched to the LSU pipe, so in SMEM-intensive kernels it
contends with shared-memory load/store traffic. Since tl_shuffle_elect
guards async mbarrier-arrive / TMA issues, that contention serializes the
warp right before each async op and exposes the latency it was meant to hide.

Gate the election with cute::elect_one_sync() (the ELECT instruction, ALU
pipe) first. Because only one lane then proceeds, canonical_warp_idx()
(plain threadIdx.x / 32, no shuffle) is warp-uniform by construction and
stays UR-eligible — without touching the LSU.

Verified on the SM90 warp-specialized FlashMLA decode kernel (H100, fp16,
b132 h128 kv8192): ~456 -> ~507 TFlops, matching the FlashMLA CUTLASS
baseline. SASS confirms the per-iteration SHFL.IDX are gone (LSU freed) and
the leader election lowers to ELECT with UR-addressed mbarrier arrives.
Correctness unchanged; the elected thread is identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR optimizes `tl_shuffle_elect<thread_extent>()` in CUDA by changing warp leader election to avoid `shfl.sync` (LSU-dispatched shuffle) and instead use ALU-pipe `ELECT` via `cute::elect_one_sync()`. The goal is to prevent LSU contention immediately before async `mbarrier-arrive` / TMA operations in shared-memory-intensive kernels.

## Changes

### `src/tl_templates/cuda/intrin.h`
Updated `tl_shuffle_elect<thread_extent>()` leader-election logic:

- **General approach:** election is now gated through `cute::elect_one_sync()` and uses `cutlass::canonical_warp_idx()` (not the `*_sync`/shuffle-based variant).
- **`thread_extent == 0`:**
  - Elect only when `cutlass::canonical_warp_idx() == 0`:
    - `return cute::elect_one_sync() && cutlass::canonical_warp_idx() == 0;`
- **`thread_extent == 32`:**
  - Returns `cute::elect_one_sync()` (as before, but now without shuffle).
- **Other `thread_extent` values:**
  - Computes `warp_extent = (thread_extent + 31) / 32`
  - Elect representative with:
    - `cute::elect_one_sync() && (cutlass::canonical_warp_idx() % warp_extent) == 0`
- **Comments/documentation in code:** updated to explain why avoiding `shfl.sync` (and therefore LSU dispatch) preserves latency hiding for the guarded async operations.

### `tilelang/language/builtin.py`
Updated the `shuffle_elect` lowering docstring/notes to reflect lane selection via `cutlass::canonical_warp_idx()` with `cute::elect_one_sync()` (documentation-only).

## Motivation

`shfl.sync`/`__shfl_sync` can be dispatched to the LSU pipe. In SMEM-heavy kernels, that can serialize execution right before LSU-sensitive async operations, reducing the latency-hiding benefit this election mechanism is intended to enable. Using ALU `ELECT` removes that LSU dependency.

## Performance / verification

- Performance verified on an SM90 warp-specialized FlashMLA decode kernel on H100 (fp16; `b132 h128 kv8192`), improving from ~456 to ~507 TFlops (matching the FlashMLA CUTLASS baseline).
- SASS verification shows per-iteration `SHFL.IDX` instructions are eliminated, freeing LSU resources; leader election uses `ELECT` for the mbarrier path.
- Correctness maintained: the elected leader thread matches the previous implementation.

## Testing request

The author requested triggering `@regression-perf` to guard against performance regressions beyond the specific FlashMLA decode benchmark used for initial verification.

## C++ Style / Lint Notes

- **Touches `docs/developer_guide/cpp_style.md` rules?** No (the referenced file documents how to run the audit; it is not modified by this PR).
- **C++ API Style Audit (warning only):** The repo’s CI includes **“C++ API Style Audit (warning only)”**. This change is limited to device-side CUDA intrinsic/templated implementation details (`tl_shuffle_elect` in `src/tl_templates/cuda/intrin.h`) and does not change public headers/FFI surface area, so it should not introduce meaningful TLCPP003/TLCPP004-style compatibility/maintainability risk. Any findings from the audit step would be advisory and should not be treated as correctness/build/test blockers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->