### PR TITLE
[Backend] Dispatch host CodeGen through backend registry

### DIFF
--- a/tilelang/backend/README.md
+++ b/tilelang/backend/README.md
@@ -9,10 +9,11 @@ TileLang language surface backend-neutral.
 The Python backend layer is split into two parts:
 
 - `tilelang/backend/`: common backend infrastructure, especially pass-pipeline
-  registration, device-codegen registration, and shared pipeline utilities.
+  registration, host/device-codegen registration, and shared pipeline
+  utilities.
 - `tilelang/<backend>/`: backend-owned Python implementation files, such as
-  pass pipelines, device-codegen entry registration, tile-op implementation
-  registration, and backend intrinsics.
+  pass pipelines, host/device-codegen entry registration, tile-op
+  implementation registration, and backend intrinsics.
 
 The native side mirrors this split under `src/<backend>/`, where C++ op
 lowering, codegen, runtime modules, stubs, and backend-local CMake files live.
@@ -48,6 +49,20 @@ variant, while CPU owns the `c` and `llvm` entries. The engine-level lowering
 code should not keep backend-specific `target.kind.name` dispatch for device
 codegen.
 
+Host codegen is resolved from the host target in the same style:
+
+```text
+host_mod = apply_host_codegen_hooks(host_mod, target_host, target)
+codegen = resolve_host_codegen(target_host)
+host_mod = codegen.lower(host_mod, target_host)
+```
+
+The resolver is implemented in `tilelang/backend/host_codegen.py`. Host build
+entries are registered by the package that owns the host target kind, such as
+`tilelang/cpu` for `c` and `llvm`. Device backends may also register host
+codegen hooks for target-specific host preparation; Metal uses this to mark
+host functions that need Metal runtime context.
+
 ## Target Registration
 
 | Python package | Target kind | Notes |
@@ -68,6 +83,7 @@ tilelang/backend/
   __init__.py
   common.py
   device_codegen.py
+  host_codegen.py
   pass_pipeline/
     __init__.py
     pipeline.py
@@ -78,6 +94,8 @@ tilelang/backend/
   `resolve_pipeline`.
 - `device_codegen.py` defines `DeviceCodegen`, `register_device_codegen`, and
   `resolve_device_codegen`.
+- `host_codegen.py` defines `HostCodegen`, host codegen hooks, and
+  `resolve_host_codegen`.
 - `pass_pipeline/pipeline_utils.py` contains small shared helpers for pass
   configuration, layout visualization, vectorization gates, and shared-memory
   reuse flags.
@@ -125,10 +143,10 @@ ordered pass list should be visible in the backend-owned file. CUDA-only,
 ROCm-only, and Metal-only passes should be called from the corresponding
 backend pipeline rather than from engine-level code.
 
-The `codegen.py` file should register the backend-owned device codegen entry
-points, usually by mapping the target kind to native `target.build.*` global
-functions. Target variants should be represented by backend-owned predicates,
-not by engine-level branching.
+The `codegen.py` file should register the backend-owned host/device codegen
+entry points, usually by mapping the target kind to native `target.build.*`
+global functions. Target variants should be represented by backend-owned
+predicates, not by engine-level branching.
 
 The `op/` and `intrinsics/` folders contain Python implementation and helper
 code used by tile-op lowering. For example, CUDA owns MMA/WGMMA/TCGEN05
@@ -165,6 +183,8 @@ Shared native helpers that have no target runtime dependency belong in
 
 - Keep `tilelang/language` and `tilelang/tileop` backend-neutral.
 - Keep backend-specific pass ordering in the backend package.
+- Keep backend-specific host-codegen dispatch and host preparation hooks in the
+  backend package.
 - Keep backend-specific device-codegen dispatch in the backend package.
 - Register backend implementations at import time, but keep import-time work
   light.

--- a/tilelang/backend/__init__.py
+++ b/tilelang/backend/__init__.py
@@ -6,6 +6,17 @@ from .device_codegen import (  # noqa: F401
     register_lazy_device_codegen,
     resolve_device_codegen,
 )
+from .host_codegen import (  # noqa: F401
+    HostCodegen,
+    HostCodegenHook,
+    allowed_host_codegens_for_target,
+    apply_host_codegen_hooks,
+    register_host_codegen,
+    register_host_codegen_hook,
+    register_lazy_host_codegen,
+    register_lazy_host_codegen_hooks,
+    resolve_host_codegen,
+)
 from .execution_backend import (  # noqa: F401
     ExecutionBackendSpec,
     allowed_backends_for_target,
@@ -34,5 +45,9 @@ register_lazy_device_codegen("c", "tilelang.cpu.codegen")
 register_lazy_device_codegen("llvm", "tilelang.cpu.codegen")
 register_lazy_device_codegen("metal", "tilelang.metal.codegen")
 register_lazy_device_codegen("webgpu", "tilelang.webgpu.codegen")
+
+register_lazy_host_codegen("c", "tilelang.cpu.codegen")
+register_lazy_host_codegen("llvm", "tilelang.cpu.codegen")
+register_lazy_host_codegen_hooks("metal", "tilelang.metal.codegen")
 
 from . import common as common  # noqa: F401,E402

--- a/tilelang/backend/host_codegen.py
+++ b/tilelang/backend/host_codegen.py
@@ -1,0 +1,174 @@
+"""Host codegen registry shared by backend packages."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from importlib import import_module
+
+from tvm import IRModule
+from tvm.target import Target
+
+from tilelang import tvm
+
+HostCodegenFunc = Callable[[IRModule, Target], IRModule]
+HostCodegenHookFunc = Callable[[IRModule, Target, Target], IRModule]
+TargetPredicate = Callable[[Target], bool]
+
+
+def global_func_host_codegen(global_func_name: str) -> HostCodegenFunc:
+    """Create a host codegen callback backed by a TVM global function."""
+
+    def build(mod: IRModule, target_host: Target) -> IRModule:
+        return tvm.ffi.get_global_func(global_func_name)(mod, target_host)
+
+    return build
+
+
+@dataclass(frozen=True, slots=True)
+class HostCodegen:
+    """Host codegen entry point for one host target variant."""
+
+    name: str
+    build: HostCodegenFunc
+    supports_target: TargetPredicate | None = None
+
+    def matches(self, target_host: Target) -> bool:
+        return True if self.supports_target is None else self.supports_target(target_host)
+
+    def lower(self, mod: IRModule, target_host: Target) -> IRModule:
+        return self.build(mod, target_host)
+
+
+@dataclass(frozen=True, slots=True)
+class HostCodegenHook:
+    """Device-backend hook applied before host codegen build."""
+
+    name: str
+    apply: HostCodegenHookFunc
+    supports_target: TargetPredicate | None = None
+
+    def matches(self, target: Target) -> bool:
+        return True if self.supports_target is None else self.supports_target(target)
+
+    def lower(self, mod: IRModule, target_host: Target, target: Target) -> IRModule:
+        return self.apply(mod, target_host, target)
+
+
+_HOST_CODEGENS: dict[str, list[HostCodegen]] = {}
+_LAZY_HOST_CODEGENS: dict[str, str] = {}
+_LOADED_HOST_CODEGENS: set[str] = set()
+
+_HOST_CODEGEN_HOOKS: dict[str, list[HostCodegenHook]] = {}
+_LAZY_HOST_CODEGEN_HOOKS: dict[str, str] = {}
+_LOADED_HOST_CODEGEN_HOOKS: set[str] = set()
+
+
+def register_host_codegen(
+    target_host_kind: str,
+    codegen: HostCodegen,
+    *,
+    override: bool = False,
+) -> HostCodegen:
+    """Register a host codegen entry for a host target kind."""
+
+    codegens = _HOST_CODEGENS.setdefault(target_host_kind, [])
+    if override:
+        codegens[:] = [item for item in codegens if item.name != codegen.name]
+    elif any(item.name == codegen.name for item in codegens):
+        raise ValueError(f"Host codegen {codegen.name!r} is already registered for target kind {target_host_kind!r}")
+    codegens.append(codegen)
+    return codegen
+
+
+def register_lazy_host_codegen(target_host_kind: str, import_path: str) -> None:
+    """Register a backend module to import when a host target kind is first used."""
+
+    _LAZY_HOST_CODEGENS[target_host_kind] = import_path
+    _LOADED_HOST_CODEGENS.discard(target_host_kind)
+
+
+def register_host_codegen_hook(
+    target_kind: str,
+    hook: HostCodegenHook,
+    *,
+    override: bool = False,
+) -> HostCodegenHook:
+    """Register a device-backend hook for host codegen preparation."""
+
+    hooks = _HOST_CODEGEN_HOOKS.setdefault(target_kind, [])
+    if override:
+        hooks[:] = [item for item in hooks if item.name != hook.name]
+    elif any(item.name == hook.name for item in hooks):
+        raise ValueError(f"Host codegen hook {hook.name!r} is already registered for target kind {target_kind!r}")
+    hooks.append(hook)
+    return hook
+
+
+def register_lazy_host_codegen_hooks(target_kind: str, import_path: str) -> None:
+    """Register a backend module to import before applying host codegen hooks."""
+
+    _LAZY_HOST_CODEGEN_HOOKS[target_kind] = import_path
+    _LOADED_HOST_CODEGEN_HOOKS.discard(target_kind)
+
+
+def _ensure_host_codegens_loaded(target_host_kind: str) -> None:
+    if target_host_kind in _LOADED_HOST_CODEGENS:
+        return
+    import_path = _LAZY_HOST_CODEGENS.get(target_host_kind)
+    if import_path is not None:
+        import_module(import_path)
+    _LOADED_HOST_CODEGENS.add(target_host_kind)
+
+
+def _ensure_host_codegen_hooks_loaded(target_kind: str) -> None:
+    if target_kind in _LOADED_HOST_CODEGEN_HOOKS:
+        return
+    import_path = _LAZY_HOST_CODEGEN_HOOKS.get(target_kind)
+    if import_path is not None:
+        import_module(import_path)
+    _LOADED_HOST_CODEGEN_HOOKS.add(target_kind)
+
+
+def _matching_host_codegens(target_host: Target) -> list[HostCodegen]:
+    target_host_kind = target_host.kind.name
+    _ensure_host_codegens_loaded(target_host_kind)
+    return [codegen for codegen in _HOST_CODEGENS.get(target_host_kind, ()) if codegen.matches(target_host)]
+
+
+def _matching_host_codegen_hooks(target: Target) -> list[HostCodegenHook]:
+    target_kind = target.kind.name
+    _ensure_host_codegen_hooks_loaded(target_kind)
+    return [hook for hook in _HOST_CODEGEN_HOOKS.get(target_kind, ()) if hook.matches(target)]
+
+
+def allowed_host_codegens_for_target(target_host: Target) -> list[str]:
+    """Return matching host codegen names for a host target."""
+
+    return [codegen.name for codegen in _matching_host_codegens(target_host)]
+
+
+def _format_host_codegen_names(codegens: list[HostCodegen]) -> str:
+    names = [codegen.name for codegen in codegens]
+    return ", ".join(names) if names else "<none>"
+
+
+def apply_host_codegen_hooks(mod: IRModule, target_host: Target, target: Target | None) -> IRModule:
+    """Apply device-backend host codegen hooks."""
+
+    if target is None:
+        return mod
+    for hook in _matching_host_codegen_hooks(target):
+        mod = hook.lower(mod, target_host, target)
+    return mod
+
+
+def resolve_host_codegen(target_host: Target) -> HostCodegen:
+    """Resolve a host codegen entry from a TVM host target."""
+
+    matches = _matching_host_codegens(target_host)
+    if not matches:
+        target_host_kind = target_host.kind.name
+        options = _format_host_codegen_names(_HOST_CODEGENS.get(target_host_kind, []))
+        raise ValueError(f"No host codegen registered for target host '{target_host_kind}'. Available: {options}.")
+    return matches[0]

--- a/tilelang/cpu/codegen.py
+++ b/tilelang/cpu/codegen.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from tilelang.backend.device_codegen import DeviceCodegen, global_func_device_codegen, register_device_codegen
+from tilelang.backend.host_codegen import HostCodegen, global_func_host_codegen, register_host_codegen
 
 
 _build_llvm = global_func_device_codegen("target.build.llvm")
+_build_host_llvm = global_func_host_codegen("target.build.llvm")
+_build_host_c = global_func_host_codegen("target.build.tilelang_c_host")
 
 
 register_device_codegen(
@@ -22,5 +25,17 @@ register_device_codegen(
         build=_build_llvm,
         build_without_compile=_build_llvm,
     ),
+    override=True,
+)
+
+register_host_codegen(
+    "c",
+    HostCodegen("c", build=_build_host_c),
+    override=True,
+)
+
+register_host_codegen(
+    "llvm",
+    HostCodegen("llvm", build=_build_host_llvm),
     override=True,
 )

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -16,6 +16,7 @@ from tilelang.transform import PassConfigKey
 from tilelang.engine.param import KernelParam, CompiledArtifact
 from tilelang.engine.semantic_check import PreLowerSemanticCheck
 from tilelang.backend.device_codegen import resolve_device_codegen
+from tilelang.backend.host_codegen import apply_host_codegen_hooks, resolve_host_codegen
 from tilelang.backend.target import determine_target
 from tilelang.backend.pass_pipeline import resolve_pipeline
 
@@ -217,17 +218,8 @@ def host_codegen(host_mod: tvm.IRModule, target_host: Target, target: Target | N
     combine_context_call = getattr(tirx.transform, "CombineContextCall", None)
     if combine_context_call is not None:
         host_mod = combine_context_call()(host_mod)
-    if target is not None and target.kind.name == "metal":
-        from tilelang.metal.transform import MarkHostMetalContext
-
-        host_mod = MarkHostMetalContext()(host_mod)
-    if target_host.kind.name == "llvm":
-        host_mod = tvm.ffi.get_global_func("target.build.llvm")(host_mod, target_host)
-    elif target_host.kind.name == "c":
-        host_mod = tvm.ffi.get_global_func("target.build.tilelang_c_host")(host_mod, target_host)
-    else:
-        raise ValueError(f"Target host {target_host.kind.name} is not supported")
-    return host_mod
+    host_mod = apply_host_codegen_hooks(host_mod, target_host, target)
+    return resolve_host_codegen(target_host).lower(host_mod, target_host)
 
 
 def _prepare_device_codegen_mod(device_mod: tvm.IRModule) -> tvm.IRModule:

--- a/tilelang/metal/codegen.py
+++ b/tilelang/metal/codegen.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
 
+from tvm import IRModule
+from tvm.target import Target
+
 from tilelang.backend.device_codegen import DeviceCodegen, global_func_device_codegen, register_device_codegen
+from tilelang.backend.host_codegen import HostCodegenHook, register_host_codegen_hook
 
 
 _build_metal = global_func_device_codegen("target.build.tilelang_metal")
+
+
+def _mark_host_metal_context(mod: IRModule, target_host: Target, target: Target) -> IRModule:
+    from tilelang.metal.transform import MarkHostMetalContext
+
+    return MarkHostMetalContext()(mod)
 
 
 register_device_codegen(
@@ -13,5 +23,11 @@ register_device_codegen(
         build=_build_metal,
         build_without_compile=_build_metal,
     ),
+    override=True,
+)
+
+register_host_codegen_hook(
+    "metal",
+    HostCodegenHook("metal_context", _mark_host_metal_context),
     override=True,
 )


### PR DESCRIPTION
## Summary
- add a backend host codegen registry with lazy host-target registration
- move host build dispatch for c/llvm into tilelang.cpu.codegen
- move Metal host-context preparation into a backend-owned host codegen hook
- update backend layout docs for host/device codegen ownership

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR refactors the backend architecture by introducing a centralized host codegen registry system that decentralizes host code generation dispatch logic. The changes move backend-specific host build logic out of the engine's lowering layer and into their respective backend packages, improving separation of concerns and maintainability.

## Key Changes

### New Infrastructure: Host Codegen Registry

**`tilelang/backend/host_codegen.py`** introduces a new registry system with:
- Type aliases for host codegen functions and hooks (`HostCodegenFunc`, `HostCodegenHookFunc`, `TargetPredicate`)
- `HostCodegen` dataclass to register host code generators with optional target predicates
- `HostCodegenHook` dataclass to register backend-owned host preparation hooks
- Registry functions with lazy-loading support:
  - `register_host_codegen()` and `register_lazy_host_codegen()` for host code generators
  - `register_host_codegen_hook()` and `register_lazy_host_codegen_hooks()` for host hooks
- Resolution functions:
  - `allowed_host_codegens_for_target()` to query available host codegens
  - `resolve_host_codegen()` to select the matching host codegen
  - `apply_host_codegen_hooks()` to apply all matching hooks sequentially
- Helper `global_func_host_codegen()` to wrap TVM global functions

### Backend Integration

**`tilelang/backend/__init__.py`** exposes the new host codegen infrastructure and registers lazy entries for `"c"` and `"llvm"` host codegens and `"metal"` host codegen hooks.

**`tilelang/cpu/codegen.py`** now registers host code generators for both `"c"` and `"llvm"` target kinds, wiring them to their respective TVM build functions (`target.build.tilelang_c_host` and `target.build.llvm`).

**`tilelang/metal/codegen.py`** introduces `_mark_host_metal_context()` hook function and registers it via the new host codegen hook system for Metal-specific host context preparation, keeping host-side Metal logic self-contained within the Metal backend.

### Simplified Engine Lowering

**`tilelang/engine/lower.py`** refactors the `host_codegen` function to use the new registry system instead of inline dispatch logic. It now:
- Applies registered host codegen hooks using `apply_host_codegen_hooks()`
- Delegates final host compilation to `resolve_host_codegen(target_host).lower()`

This eliminates hardcoded conditionals and centralizes host build dispatch logic in backend packages.

### Documentation

**`tilelang/backend/README.md`** updated to clarify backend ownership boundaries, distinguishing `tilelang/backend/` as shared infrastructure from `tilelang/<backend>/` as backend-owned implementations. Added documentation for the host-codegen resolution flow, including the new `apply_host_codegen_hooks` step and how backends register host build entries and hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->