### PR TITLE
[DEBUG] PassConfig for printing compile commands

### DIFF
--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -32,6 +32,7 @@ TVM_REGISTER_PASS_CONFIG_OPTION(kDisableFastMath, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kEnableFastMath, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kPtxasRegisterUsageLevel, Integer);
 TVM_REGISTER_PASS_CONFIG_OPTION(kEnablePTXASVerboseOutput, Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION(kPrintDeviceCompileCommand, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableVectorize256, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kEnableAsyncCopy, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kEnableVectorizePlannerVerbose, Bool);

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -111,6 +111,8 @@ static constexpr const char *kPtxasRegisterUsageLevel =
     "tl.ptxas_register_usage_level";
 static constexpr const char *kEnablePTXASVerboseOutput =
     "tl.enable_ptxas_verbose_output";
+static constexpr const char *kPrintDeviceCompileCommand =
+    "tl.print_device_compile_command";
 static constexpr const char *kDisableVectorize256 = "tl.disable_vectorize_256";
 static constexpr const char *kEnableAsyncCopy = "tl.enable_async_copy";
 static constexpr const char *kEnableVectorizePlannerVerbose =

--- a/tilelang/contrib/nvcc.py
+++ b/tilelang/contrib/nvcc.py
@@ -128,6 +128,10 @@ def compile_cuda(code, target_format="ptx", arch=None, options=None, path_target
     cmd += ["-o", file_target]
     cmd += [temp_code]
 
+    print_compile_command = pass_context.config.get("tl.print_device_compile_command", False)
+    if print_compile_command:
+        print(f"nvcc compilation command: {' '.join(cmd)}")
+
     compiler_env = get_nvcc_subprocess_env()
 
     if compiler_env is None:

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -71,6 +71,10 @@ class PassConfigKey(str, Enum):
     TL_ENABLE_PTXAS_VERBOSE_OUTPUT = "tl.enable_ptxas_verbose_output"
     """Enable ptxas verbose output. Default: False"""
 
+    TL_PRINT_DEVICE_COMPILE_COMMAND = "tl.print_device_compile_command"
+    """Print the device compiler (e.g. nvcc) command line used to compile the
+    generated kernel. Useful for debugging compilation issues. Default: False"""
+
     TL_DEVICE_COMPILE_FLAGS = "tl.device_compile_flags"
     """Additional device compiler flags passed to nvcc/NVRTC.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Added a new pass config flag, `tl.print_device_compile_command`, to control printing the device compiler command used for CUDA compilation.
- Wired the flag through the C++ builtin/operator attribute keys and the Python pass config enum.
- Updated `compile_cuda` to emit the NVCC command when this pass config is enabled.

## C++ style / lint notes
- This PR touches C++ code in `src/op/builtin.cc` and `src/op/builtin.h`, which are covered by the project’s C++ style guidance in `docs/developer_guide/cpp_style.md`.
- The change appears to be a small API/config addition rather than a style-rule change; no blocking correctness, build, or test concerns are indicated from the summary.
- The “C++ API Style Audit (warning only)” CI step may surface advisory warnings for the new exported config key, but any TLCPP003/TLCPP004 findings here should be treated as warning-only unless they reveal a concrete API or maintainability issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->