### PR TITLE
Enhance `T.view` and `T.reshape`

### DIFF
--- a/tilelang/language/customize.py
+++ b/tilelang/language/customize.py
@@ -54,8 +54,9 @@ def reshape(src: Buffer, shape: ShapeType) -> Buffer:
     Returns:
         Buffer: A new buffer view with the specified shape
     """
-    assert prim_expr_equal(bits_product(shape, src.dtype), bits_product(src.shape, src.dtype)), (
-        f"T.reshape/view shape check failed. src {src} src.shape: {src.shape}, src.dtype: {src.dtype}, target shape: {shape}, target dtype: {src.dtype}"
+    bits, src_bits = bits_product(shape, src.dtype), bits_product(src.shape, src.dtype)
+    assert prim_expr_equal(bits, src_bits) or arith.Analyzer().can_prove_equal(bits, src_bits), (
+        f"T.reshape/view shape check failed. {bits_product(shape, src.dtype)}, {bits_product(src.shape, src.dtype)}"
     )
     return T.Tensor(shape, src.dtype, src.data)
 
@@ -69,7 +70,10 @@ def view(src: Buffer, shape: ShapeType | None = None, dtype: DType | None = None
         shape = src.shape
     if dtype is None:
         dtype = src.dtype
-    assert prim_expr_equal(bits_product(shape, dtype), bits_product(src.shape, src.dtype)), "T.reshape/view shape check failed."
+    bits, src_bits = bits_product(shape, dtype), bits_product(src.shape, src.dtype)
+    assert prim_expr_equal(bits, src_bits) or arith.Analyzer().can_prove_equal(bits, src_bits), (
+        f"T.reshape/view shape check failed. {bits_product(shape, dtype)}, {bits_product(src.shape, src.dtype)}"
+    )
     return T.Tensor(shape, dtype, src.data)
 
 

--- a/tilelang/language/customize.py
+++ b/tilelang/language/customize.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 from tilelang._typing import ShapeType, DType
 import tilelang.language as T
+from tvm import arith
 from tvm.tirx import PrimExpr, Buffer, op
 from tilelang.utils.language import bits_product, prim_expr_equal
 from .atomic import atomic_max, atomic_min, atomic_add, atomic_addx2, atomic_addx4, atomic_load, atomic_store  # noqa: F401


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Adjusted `T.view` and `T.reshape` shape validation to accept both direct symbolic equality checks and arithmetic proofs from `tvm.arith.Analyzer`, making compatibility checks more flexible for equivalent expressions.

Also improved the assertion error message to report the computed bit products for source and target shapes/dtypes, which should make reshape/view mismatches easier to debug.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->