### PR TITLE
[CUDA] Add target code attribute support

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ Below is an example that demonstrates more advanced features: layout annotation,
 
 ```python
 # @tilelang.jit(target="cuda")
-# target currently can be "cuda" or "hip" or "cpu".
-# if not specified, it will be inferred from the input tensors during compile time
+# target can be "auto", a bare kind such as "cuda", or a config dict such as
+# {"kind": "cuda", "arch": "sm_90"}.
 @tilelang.jit
 def matmul_relu(
     A, B,

--- a/docs/get_started/targets.md
+++ b/docs/get_started/targets.md
@@ -32,6 +32,84 @@ def compiled_kernel(*args):
     return func(*args)
 ```
 
+## Target input forms
+
+Most TileLang APIs that accept a target, such as `tilelang.compile`, `tilelang.jit`, and the autotuner, accept the
+same input forms:
+
+```python
+target = "auto"                                      # detect CUDA, HIP, or Metal
+target = "cuda"                                      # bare TVM target kind
+target = {"kind": "cuda", "arch": "sm_90"}           # target config dict
+target = tvm.target.Target({"kind": "cuda"})         # already-built TVM Target
+```
+
+Use the bare string form for simple cases. Use a config dictionary when you need target attributes such as CUDA
+`arch`, CUDA `code`, HIP `mcpu`, or LLVM CPU options. Dictionary keys must be valid attributes for that target kind;
+invalid attributes are rejected when TVM constructs the target.
+
+## Default target
+
+If you do not pass `target=...`, TileLang reads `TILELANG_DEFAULT_TARGET`. When the environment variable is unset,
+the default is `auto`.
+
+```bash
+export TILELANG_DEFAULT_TARGET=cuda
+```
+
+For target options, use a dict-like string. This is useful in scripts that rely on the default target through
+`tilelang.compile(..., target=None)`, `@tilelang.jit`, or autotuning:
+
+```bash
+export TILELANG_DEFAULT_TARGET='{kind: "cuda", arch: "sm_90"}'
+export TILELANG_DEFAULT_TARGET='{kind: "cuda", arch: "sm_100f", code: ["sm_100a", "sm_103a"]}'
+```
+
+In Python code, prefer passing a real dictionary instead of a string:
+
+```python
+target = {"kind": "cuda", "arch": "sm_100f", "code": ["sm_100a", "sm_103a"]}
+kernel = tilelang.compile(func, target=target)
+```
+
+## CUDA `arch` and `code`
+
+For CUDA targets, `arch` selects the SM family TileLang/TVM should compile for. TileLang accepts `sm_...` architecture
+tokens for this field. In the common case, setting only `arch` is enough:
+
+```python
+target = {"kind": "cuda", "arch": "sm_90"}
+```
+
+TileLang passes this to NVCC as a single architecture target:
+
+```bash
+-arch=sm_90
+```
+
+Use `code` only when you need explicit NVCC `-gencode` behavior, for example when compiling the virtual architecture
+derived from `arch` but emitting SASS for multiple GPU code instances:
+
+```python
+target = {
+    "kind": "cuda",
+    "arch": "sm_100f",
+    "code": ["sm_100a", "sm_103a"],
+}
+```
+
+This produces NVCC flags equivalent to:
+
+```bash
+-gencode arch=compute_100f,code=[sm_100a,sm_103a]
+```
+
+`code` must be a Python list of exact SM code tokens such as `sm_100a` or `sm_103a`. String forms such as
+`"sm_100a,sm_103a"` or `"[sm_100a,sm_103a]"` are intentionally not supported.
+
+When `code` contains more than one entry, TileLang emits a fat binary (`fatbin`) because NVCC does not allow
+`--cubin` output with multiple GPU code instances.
+
 ### Advanced: Specify Exact Hardware
 
 When you already know the precise GPU model, you can encode it in the target config via `arch="sm_XX"` or by
@@ -77,7 +155,10 @@ by default, or the `Target` object when `return_object=True`):
 ```python
 from tilelang.backend.target import determine_target
 
-tvm_target = determine_target({"kind": "cuda", "arch": "sm_80"}, return_object=True)
+tvm_target = determine_target(
+    {"kind": "cuda", "arch": "sm_100f", "code": ["sm_100a", "sm_103a"]},
+    return_object=True,
+)
 kernel = tilelang.compile(func, target=tvm_target)
 ```
 
@@ -96,7 +177,9 @@ prefer config dictionaries over CLI-style strings.
 ## Troubleshooting tips
 
 - If you see `Target {'kind': 'cuda', 'arch': 'sm_80'} is not supported`, double-check the spellings and that the option is valid for
-  TVM. Any invalid option will surface as a target-construction error.
+  the target kind. Any invalid option will surface as a target-construction error.
+- If CUDA `code` fails validation, make sure it is a list of exact SM code tokens, for example
+  `["sm_100a", "sm_103a"]`, not a comma-separated string.
 - Runtime errors such as “no kernel image is available” usually mean the `arch` value does not match the GPU you are
   running on. Try dropping the flag or switching to the correct compute capability.
 - When targeting multiple environments, use `auto` for convenience and override with an explicit config only when

--- a/testing/python/jit/test_tilelang_jit_diagnostics.py
+++ b/testing/python/jit/test_tilelang_jit_diagnostics.py
@@ -33,6 +33,19 @@ class _FakeProcess:
         self.killed = True
 
 
+class _SuccessfulNvccProcess:
+    returncode = 0
+
+    def __init__(self, cmd):
+        self.cmd = cmd
+
+    def communicate(self, timeout=None):
+        output_path = self.cmd[self.cmd.index("-o") + 1]
+        with open(output_path, "wb") as output_file:
+            output_file.write(b"fake-cuda-binary")
+        return b"", None
+
+
 class _HangingProcess:
     returncode = 0
 
@@ -122,7 +135,75 @@ def test_nvcc_compile_cuda_honors_tilelang_timeout(monkeypatch):
     assert fake_proc.killed
     assert "timed out after 0.25 seconds" in message
     assert "Command:" in message
+    assert "-arch=sm_120" in message
+    assert "-gencode" not in message
     assert "Source:" in message
+
+
+def test_nvcc_target_code_list_parser():
+    from tilelang.contrib.nvcc import get_target_code_list
+
+    assert get_target_code_list(None) == []
+    assert get_target_code_list(["sm_100a"]) == ["sm_100a"]
+    assert get_target_code_list(["sm_100a", "sm_103a"]) == ["sm_100a", "sm_103a"]
+    with pytest.raises(ValueError, match="CUDA target code"):
+        get_target_code_list("sm_100a")
+    with pytest.raises(ValueError, match="CUDA target code"):
+        get_target_code_list([])
+    with pytest.raises(ValueError, match="CUDA target code"):
+        get_target_code_list(["sm100a+103a"])
+    with pytest.raises(ValueError, match="CUDA target code"):
+        get_target_code_list(["sm_100a", ""])
+    with pytest.raises(ValueError, match="CUDA target code"):
+        get_target_code_list(["compute_100f"])
+
+
+def test_nvcc_compile_cuda_honors_target_code(monkeypatch):
+    from tilelang.backend.target import determine_target
+    from tilelang.contrib import nvcc
+
+    captured = {}
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = cmd
+        return _SuccessfulNvccProcess(cmd)
+
+    monkeypatch.setattr(nvcc.env, "TILELANG_CLEANUP_TEMP_FILES", "0")
+    monkeypatch.setattr(nvcc, "get_nvcc_compiler", lambda: "nvcc")
+    monkeypatch.setattr(nvcc, "get_nvcc_subprocess_env", lambda: None)
+    monkeypatch.setattr(nvcc.subprocess, "Popen", fake_popen)
+
+    target = determine_target({"kind": "cuda", "arch": "sm_100f", "code": ["sm_100a", "sm_103a"]}, return_object=True)
+    with target, pytest.warns(RuntimeWarning, match="using '--fatbin' instead"):
+        nvcc.compile_cuda("__global__ void kernel() {}", target_format="cubin", verbose=False)
+
+    assert "--fatbin" in captured["cmd"]
+    assert "--cubin" not in captured["cmd"]
+    gencode_index = captured["cmd"].index("-gencode")
+    assert captured["cmd"][gencode_index + 1] == "arch=compute_100f,code=[sm_100a,sm_103a]"
+
+
+def test_cuda_compile_callback_uses_fatbin_for_multiple_target_code(monkeypatch):
+    import importlib
+
+    from tilelang.backend.target import determine_target
+
+    lower = importlib.import_module("tilelang.engine.lower")
+
+    captured = {}
+
+    def fake_compile_cuda(code, target_format, arch, options=None, verbose=False):
+        captured["target_format"] = target_format
+        captured["arch"] = arch
+        return bytearray(b"fake-cuda-binary")
+
+    monkeypatch.setattr(lower.nvcc, "compile_cuda", fake_compile_cuda)
+
+    target = determine_target({"kind": "cuda", "arch": "sm_100f", "code": ["sm_100a", "sm_103a"]}, return_object=True)
+    lower.tilelang_callback_cuda_compile("__global__ void kernel() {}", target)
+
+    assert captured["target_format"] == "fatbin"
+    assert captured["arch"] == ["-gencode", "arch=compute_100f,code=[sm_100a,sm_103a]"]
 
 
 def test_jit_compile_reports_timeout_for_hanging_nvcc(monkeypatch, tmp_path, caplog, capture_tilelang_logs):

--- a/testing/python/target/test_tilelang_target.py
+++ b/testing/python/target/test_tilelang_target.py
@@ -11,11 +11,55 @@ from tilelang.backend.execution_backend import (
     register_execution_backend,
     resolve_execution_backend,
 )
-from tilelang.backend.target import auto_detect_target, list_target_detectors, register_target_detector
+from tilelang.backend.target import (
+    auto_detect_target,
+    determine_target,
+    list_target_detectors,
+    register_target_detector,
+)
 
 
 def test_tilelang_does_not_export_target_wrapper():
     assert not hasattr(tilelang, "Target")
+
+
+def test_default_target_env_accepts_dict_like_string(monkeypatch):
+    monkeypatch.setenv("TILELANG_DEFAULT_TARGET", '{kind: "cuda", "arch": "sm_100f", code: ["sm_100a", "sm_103a"]}')
+
+    assert tilelang.env.get_default_target() == {
+        "kind": "cuda",
+        "arch": "sm_100f",
+        "code": ["sm_100a", "sm_103a"],
+    }
+
+
+def test_default_target_env_keeps_plain_string(monkeypatch):
+    monkeypatch.setenv("TILELANG_DEFAULT_TARGET", "cuda")
+
+    assert tilelang.env.get_default_target() == "cuda"
+
+
+def test_cuda_target_code_attr_survives_target_normalization():
+    target = determine_target(
+        {"kind": "cuda", "arch": "sm_100f", "code": ["sm_100a", "sm_103a"]},
+        return_object=True,
+    )
+
+    assert isinstance(target, Target)
+    assert target.kind.name == "cuda"
+    assert str(target.attrs["arch"]) == "sm_100f"
+    assert list(target.attrs["code"]) == ["sm_100a", "sm_103a"]
+    assert list(target.export()["code"]) == ["sm_100a", "sm_103a"]
+
+
+def test_cuda_target_code_attr_rejects_string_code():
+    with pytest.raises(AssertionError, match="valid target config dict"):
+        determine_target({"kind": "cuda", "arch": "sm_100f", "code": "sm_100a"}, return_object=True)
+
+
+def test_cuda_target_rejects_compute_arch():
+    with pytest.raises(AssertionError, match="valid target config dict"):
+        determine_target({"kind": "cuda", "arch": "compute_90"}, return_object=True)
 
 
 def test_auto_target_uses_registered_detectors():

--- a/testing/python/target/test_tilelang_target.py
+++ b/testing/python/target/test_tilelang_target.py
@@ -39,6 +39,18 @@ def test_default_target_env_keeps_plain_string(monkeypatch):
     assert tilelang.env.get_default_target() == "cuda"
 
 
+def test_bare_cuda_target_uses_detected_exact_arch(monkeypatch):
+    from tilelang.cuda import target as cuda_target
+
+    monkeypatch.setattr(cuda_target, "_detect_torch_cuda_arch", lambda: "sm_90a")
+
+    target = determine_target("cuda", return_object=True)
+
+    assert isinstance(target, Target)
+    assert target.kind.name == "cuda"
+    assert str(target.attrs["arch"]) == "sm_90a"
+
+
 def test_cuda_target_code_attr_survives_target_normalization():
     target = determine_target(
         {"kind": "cuda", "arch": "sm_100f", "code": ["sm_100a", "sm_103a"]},

--- a/tilelang/autotuner/param.py
+++ b/tilelang/autotuner/param.py
@@ -38,6 +38,7 @@ KERNEL_LIB_PATH = "kernel_lib.so"
 KERNEL_CUBIN_PATH = "kernel.cubin"
 KERNEL_PY_PATH = "kernel.py"
 PARAMS_PATH = "params.pkl"
+TargetLike = str | dict[str, object] | Target
 
 
 @dataclass(frozen=True)
@@ -46,7 +47,7 @@ class CompileArgs:
     Attributes:
         out_idx: List of output tensor indices.
         execution_backend: Execution backend to use for kernel execution (default: "auto").
-        target: Compilation target, either as a string or a TVM Target object (default: "auto").
+        target: Compilation target, either as a string, config dict, or a TVM Target object (default: "auto").
         target_host: Target host for cross-compilation (default: None).
         verbose: Whether to enable verbose output (default: False).
         pass_configs: Additional keyword arguments to pass to the Compiler PassContext.
@@ -55,8 +56,8 @@ class CompileArgs:
 
     out_idx: list[int] | int | None = None
     execution_backend: Literal["auto", "tvm_ffi", "cython", "nvrtc", "torch"] = "auto"
-    target: Literal["auto", "cuda", "hip"] = "auto"
-    target_host: str | Target = None
+    target: TargetLike = "auto"
+    target_host: TargetLike | None = None
     verbose: bool = False
     pass_configs: dict[str, Any] | None = None
 
@@ -293,8 +294,8 @@ class AutotuneResult:
     def _load_kernel_from_disk(
         self,
         cache_path: Path,
-        target: str | Target = "auto",
-        target_host: str | Target = None,
+        target: TargetLike = "auto",
+        target_host: TargetLike | None = None,
         out_idx: list[int] | int | None = None,
         execution_backend: Literal["tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"] = "tvm_ffi",
         pass_configs: dict = None,
@@ -307,8 +308,8 @@ class AutotuneResult:
 
         Args:
             key (str): The hash key identifying the kernel.
-            target (Union[str, Target]): Compilation target platform. Defaults to "auto".
-            target_host (Union[str, Target], optional): Host target platform.
+            target (Union[str, dict, Target]): Compilation target platform. Defaults to "auto".
+            target_host (Union[str, dict, Target], optional): Host target platform.
             out_idx (List[int], optional): Indices specifying which outputs to return.
             execution_backend (Literal): Backend type for execution. Defaults to "cython".
             pass_configs (dict, optional): Configuration for compiler passes.

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -39,6 +39,8 @@ from tilelang.autotuner.capture import get_autotune_inputs
 from tilelang.backend.target import determine_target
 from tilelang import __version__
 
+TargetLike = str | dict[str, object] | Target
+
 
 class TimeoutException(Exception):
     pass
@@ -275,9 +277,9 @@ class AutoTuner:
     def set_compile_args(
         self,
         out_idx: list[int] | int | None = None,
-        target: Literal["auto", "cuda", "hip", "metal"] | None = None,
+        target: TargetLike | None = None,
         execution_backend: Literal["auto", "tvm_ffi", "cython", "nvrtc", "torch"] | None = None,
-        target_host: str | Target | None = None,
+        target_host: TargetLike | None = None,
         verbose: bool | None = None,
         pass_configs: dict[str, Any] | None = None,
     ):
@@ -285,7 +287,9 @@ class AutoTuner:
 
         Args:
             out_idx: List of output tensor indices.
-            target: Target platform. If None, reads from TILELANG_TARGET environment variable (defaults to "auto").
+            target: Target platform. If None, reads from TILELANG_DEFAULT_TARGET environment variable
+                (defaults to "auto"). Use a dict for target attributes, for example
+                {"kind": "cuda", "arch": "sm_90"}.
             execution_backend: Execution backend to use for kernel execution. If None, reads from
                 TILELANG_EXECUTION_BACKEND environment variable (defaults to "auto").
             target_host: Target host for cross-compilation.
@@ -294,7 +298,8 @@ class AutoTuner:
             pass_configs: Additional keyword arguments to pass to the Compiler PassContext.
 
         Environment Variables:
-            TILELANG_TARGET: Default compilation target (e.g., "cuda", "llvm"). Defaults to "auto".
+            TILELANG_DEFAULT_TARGET: Default compilation target (e.g., "cuda", "llvm", or a dict-like
+                target config string). Defaults to "auto".
             TILELANG_EXECUTION_BACKEND: Default execution backend. Defaults to "auto".
             TILELANG_VERBOSE: Set to "1", "true", "yes", or "on" to enable verbose compilation by default.
 
@@ -1390,9 +1395,9 @@ def autotune(  # This is the new public interface
     rep : int, optional
         Number of repetitions for timing measurements.
     timeout : int, optional
-    target : Union[str, Target], optional
+    target : Union[str, dict, Target], optional
         Compilation target for TVM (e.g., "cuda", "llvm"). Defaults to "auto".
-    target_host : Union[str, Target], optional
+    target_host : Union[str, dict, Target], optional
         Target host for cross-compilation. Defaults to None.
     execution_backend : Literal["auto", "tvm_ffi", "cython", "nvrtc", "torch"], optional
         Backend for kernel execution and argument passing. Use "auto" to pick a sensible

--- a/tilelang/cache/__init__.py
+++ b/tilelang/cache/__init__.py
@@ -17,7 +17,7 @@ from tilelang.jit.adapter.kernel_cache import TVMFFIKernelCache
 if TYPE_CHECKING:
     from .kernel_cache import KernelCache
 
-TargetLike = str | TVMTarget
+TargetLike = str | dict[str, object] | TVMTarget
 
 # Create a map of singleton instance of KernelCaches
 _dispatch_map: dict[str, KernelCache] = {

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -246,8 +246,8 @@ class KernelCache:
             out_idx (List[int]): Indices specifying which outputs to return.
             execution_backend (Literal): Backend type for execution. Defaults to "tvm_ffi".
             args: Arguments passed to the function.
-            target (Union[str, Target]): Compilation target platform. Defaults to "auto".
-            target_host (Union[str, Target], optional): Host target platform.
+            target (Union[str, dict, Target]): Compilation target platform. Defaults to "auto".
+            target_host (Union[str, dict, Target], optional): Host target platform.
 
         Returns:
             str: SHA256 hash key for the kernel configuration.
@@ -291,7 +291,8 @@ class KernelCache:
         Args:
             func: Function to be compiled or a prepared PrimFunc
             out_idx: Indices specifying which outputs to return
-            target: Compilation target platform (None = read from TILELANG_TARGET env var)
+            target: Compilation target platform (None = read from TILELANG_DEFAULT_TARGET env var).
+                Use a dict for target attributes, for example {"kind": "cuda", "arch": "sm_90"}.
             target_host: Host target platform
             execution_backend: Execution backend (None = read from TILELANG_EXECUTION_BACKEND)
             verbose: Enable verbose output (None = read from TILELANG_VERBOSE)
@@ -302,8 +303,9 @@ class KernelCache:
 
         Environment Variables
         ---------------------
-        TILELANG_TARGET : str
-            Default compilation target (e.g., "cuda", "llvm"). Defaults to "auto".
+        TILELANG_DEFAULT_TARGET : str
+            Default compilation target (e.g., "cuda", "llvm", or a dict-like target config string).
+            Defaults to "auto".
         TILELANG_EXECUTION_BACKEND : str
             Default execution backend. Defaults to "auto".
         TILELANG_VERBOSE : str
@@ -550,8 +552,8 @@ class KernelCache:
 
         Args:
             key (str): The hash key identifying the kernel.
-            target (Union[str, Target]): Compilation target platform. Defaults to "auto".
-            target_host (Union[str, Target], optional): Host target platform.
+            target (Union[str, dict, Target]): Compilation target platform. Defaults to "auto".
+            target_host (Union[str, dict, Target], optional): Host target platform.
             out_idx (List[int], optional): Indices specifying which outputs to return.
             execution_backend (Literal): Backend type for execution. Defaults to "tvm_ffi".
             pass_configs (dict, optional): Configuration for compiler passes.

--- a/tilelang/contrib/nvcc.py
+++ b/tilelang/contrib/nvcc.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import warnings
 import contextlib
@@ -50,6 +51,46 @@ def _resolve_artifact_paths(temp, file_name, target_format, kernels_output_dir=N
     return temp_code, temp_target
 
 
+def get_target_arch_and_code(target: Target | None = None) -> tuple[str, list[str] | None]:
+    """Return the CUDA target arch suffix and optional NVCC code targets."""
+    target = target or Target.current(allow_none=True)
+    target_code = get_target_code_list(target.attrs["code"]) if target is not None and "code" in target.attrs else None
+
+    if target is not None and "arch" in target.attrs:
+        arch = str(target.attrs["arch"])
+        if arch.startswith("sm_"):
+            return arch.removeprefix("sm_"), target_code
+        raise ValueError("CUDA target arch must be an exact SM token such as 'sm_90' or 'sm_100f'.")
+
+    return get_target_arch(get_target_compute_version(target)), target_code
+
+
+def get_target_code_list(target_code: object | None) -> list[str]:
+    if target_code is None:
+        return []
+    if isinstance(target_code, str):
+        raise ValueError('CUDA target code must be a list of exact SM code tokens, for example ["sm_100a", "sm_103a"].')
+    try:
+        code_list = list(target_code)
+    except TypeError as err:
+        raise ValueError('CUDA target code must be a list of exact SM code tokens, for example ["sm_100a", "sm_103a"].') from err
+    if not code_list:
+        raise ValueError("CUDA target code must be a non-empty list of SM code tokens")
+
+    cuda_code_re = re.compile(r"^sm_[A-Za-z0-9]+$")
+    for code in code_list:
+        if not isinstance(code, str) or not cuda_code_re.fullmatch(code):
+            raise ValueError("CUDA target code entries must be exact SM code tokens such as 'sm_100a' or 'sm_103a'.")
+    return code_list
+
+
+def format_target_code_for_gencode(target_code: object | None) -> str | None:
+    code_list = get_target_code_list(target_code)
+    if not code_list:
+        return None
+    return code_list[0] if len(code_list) == 1 else f"[{','.join(code_list)}]"
+
+
 def compile_cuda(code, target_format="ptx", arch=None, options=None, path_target=None, verbose=False):
     """Compile cuda code with NVCC from env.
 
@@ -72,24 +113,31 @@ def compile_cuda(code, target_format="ptx", arch=None, options=None, path_target
 
     Return
     ------
-    cubin : bytearray
-        The bytearray of the cubin
+    data : bytearray
+        The compiled output bytes.
     """
+    target_code = None
     if arch is None:
         # If None, then it will use `tvm.target.Target.current().arch`.
-        # Target arch could be a str like "sm_xx", or a list, such as
-        # [
-        #   "-gencode", "arch=compute_52,code=sm_52",
-        #   "-gencode", "arch=compute_70,code=sm_70"
-        # ]
-        compute_version = get_target_compute_version(Target.current(allow_none=True))
-        target_arch = get_target_arch(compute_version)
-        arch = ["-gencode", f"arch=compute_{target_arch},code=sm_{target_arch}"]
+        target_arch, target_code = get_target_arch_and_code(Target.current(allow_none=True))
+        gencode_code = format_target_code_for_gencode(target_code)
+        if gencode_code is None:
+            arch = [f"-arch=sm_{target_arch}"]
+        else:
+            arch = ["-gencode", f"arch=compute_{target_arch},code={gencode_code}"]
+        if target_format == "cubin" and len(get_target_code_list(target_code)) > 1:
+            warnings.warn(
+                "NVCC does not allow '--cubin' with multiple code targets; using '--fatbin' instead.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            target_format = "fatbin"
 
     temp = utils.tempdir(keep_for_debug=not env.should_cleanup_temp_files())
     file_name = "tvm_kernels"
     if target_format not in ["cubin", "ptx", "fatbin"]:
         raise ValueError("target_format must be in cubin, ptx, fatbin")
+
     pass_context = tvm.get_global_func("transform.GetCurrentPassContext")()
     kernels_output_dir = pass_context.config.get("cuda.kernels_output_dir", None)
     temp_code, temp_target = _resolve_artifact_paths(temp, file_name, target_format, kernels_output_dir=kernels_output_dir)

--- a/tilelang/cuda/target.py
+++ b/tilelang/cuda/target.py
@@ -57,6 +57,13 @@ def _detect_cuda_target() -> Target | str | None:
     return _cuda_target_from_arch(arch)
 
 
+def normalize_cuda_target(target: TargetLike) -> Target | None:
+    if not isinstance(target, str) or target.strip() != "cuda":
+        return None
+    normalized = _cuda_target_from_arch(_detect_torch_cuda_arch())
+    return normalized if isinstance(normalized, Target) else None
+
+
 def _with_cutedsl_key(target: Target | str) -> Target:
     if not isinstance(target, Target):
         target = Target(target)
@@ -150,4 +157,5 @@ def target_has_bulk_copy(target: Target) -> bool:
 
 
 register_target_detector("cuda", _detect_cuda_target, override=True)
+register_target_normalizer("cuda", normalize_cuda_target, override=True)
 register_target_normalizer("cutedsl", _normalize_cutedsl_target_for_resolve, override=True)

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -98,10 +98,13 @@ def tilelang_callback_cuda_validate(device_mod):
 
 @tvm_ffi.register_global_func("tilelang_callback_cuda_compile", override=True)
 def tilelang_callback_cuda_compile(code, target, pass_config=None):
-    target_arch = nvcc.get_target_arch(nvcc.get_target_compute_version(target))
-
-    arch = [f"-arch=sm_{target_arch}"]
-    compile_format = "cubin"
+    target_arch, target_code = nvcc.get_target_arch_and_code(target)
+    gencode_code = nvcc.format_target_code_for_gencode(target_code)
+    if gencode_code is None:
+        arch = [f"-arch=sm_{target_arch}"]
+    else:
+        arch = ["-gencode", f"arch=compute_{target_arch},code={gencode_code}"]
+    compile_format = "fatbin" if len(nvcc.get_target_code_list(target_code)) > 1 else "cubin"
 
     # Read pass-config keys (string-valued) like in jit.adapter.libgen.compile_lib
     cfg = pass_config or {}

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+import ast
 import importlib.metadata
 import math
+import re
 import sys
 import os
 import pathlib
@@ -8,11 +10,12 @@ import logging
 import shutil
 import glob
 from dataclasses import dataclass
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 
 logger = logging.getLogger(__name__)
 
 EnvVarDefault = str | None | Callable[[], str | None]
+TargetConfig = dict[str, object]
 
 # SETUP ENVIRONMENT VARIABLES
 CUTLASS_NOT_FOUND_MESSAGE = "CUTLASS is not installed or found in the expected path"
@@ -257,7 +260,7 @@ class EnvVar:
 
     key: str  # Environment variable name (e.g. "TILELANG_PRINT_ON_COMPILATION")
     default: EnvVarDefault  # Default value if the environment variable is not set
-    _forced_value: str | None = None  # Temporary runtime override (mainly for tests/debugging)
+    _forced_value: object | None = None  # Temporary runtime override (mainly for tests/debugging)
 
     def _get_default(self):
         return self.default() if callable(self.default) else self.default
@@ -286,6 +289,25 @@ class EnvVar:
         self._forced_value = value
         # Uncomment the following line if you want the override to persist globally:
         # os.environ[self.key] = value
+
+
+def _parse_target_config(value: str) -> TargetConfig | None:
+    value = value.strip()
+    if not value.startswith("{"):
+        return None
+
+    key_re = re.compile(r"([{\[,]\s*)([A-Za-z_][A-Za-z0-9_]*)(\s*:)")
+    try:
+        parsed = ast.literal_eval(key_re.sub(r'\1"\2"\3', value))
+    except (ValueError, SyntaxError) as err:
+        raise ValueError(
+            'TILELANG_DEFAULT_TARGET looks like a dict but could not be parsed. Use syntax like {kind: "cuda", arch: "sm_100"}.'
+        ) from err
+    if not isinstance(parsed, dict):
+        raise ValueError("TILELANG_DEFAULT_TARGET must parse to a dict")
+    if not all(isinstance(key, str) for key in parsed):
+        raise ValueError("TILELANG_DEFAULT_TARGET dict keys must be strings")
+    return dict(parsed)
 
 
 # Utility function for environment variables with defaults
@@ -341,7 +363,7 @@ class Environment:
 
     # Compilation defaults (for jit, autotune, compile)
     # These allow overriding default compilation parameters via environment variables
-    TILELANG_DEFAULT_TARGET = EnvVar("TILELANG_TARGET", "auto")
+    TILELANG_DEFAULT_TARGET = EnvVar("TILELANG_DEFAULT_TARGET", "auto")
     TILELANG_DEFAULT_EXECUTION_BACKEND = EnvVar("TILELANG_EXECUTION_BACKEND", "auto")
     TILELANG_DEFAULT_VERBOSE = EnvVar("TILELANG_VERBOSE", "0")
 
@@ -410,9 +432,16 @@ class Environment:
             return value
         return "terminal"  # fallback for unrecognized truthy values
 
-    def get_default_target(self) -> str:
+    def get_default_target(self) -> str | TargetConfig:
         """Get default compilation target from environment."""
-        return self.TILELANG_DEFAULT_TARGET
+        target = self.TILELANG_DEFAULT_TARGET
+        if target is None:
+            return "auto"
+        if isinstance(target, Mapping):
+            return dict(target)
+        if isinstance(target, str):
+            return _parse_target_config(target) or target
+        raise TypeError("TILELANG_DEFAULT_TARGET must be a string or target config dict")
 
     def get_default_execution_backend(self) -> str:
         """Get default execution backend from environment."""

--- a/tilelang/jit/__init__.py
+++ b/tilelang/jit/__init__.py
@@ -38,7 +38,7 @@ _P = ParamSpec("_P")
 _KP = ParamSpec("_KP")
 _T = TypeVar("_T")
 _Ret = TypeVar("_Ret")
-TargetLike = str | Target
+TargetLike = str | dict[str, object] | Target
 _CallFormKey = tuple[tuple[Any, ...], tuple[tuple[str, Any], ...]]
 _CALL_FORM_CACHE_MISS = object()
 
@@ -110,10 +110,11 @@ def compile(
     execution_backend : Literal["auto", "dlpack", "tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"], optional
         Execution backend to use for kernel execution. If None, reads from
         TILELANG_EXECUTION_BACKEND environment variable (defaults to "auto").
-    target : str or tvm.target.Target, optional
-        Compilation target. If None, reads from TILELANG_TARGET environment
-        variable (defaults to "auto").
-    target_host : str or tvm.target.Target, optional
+    target : str, dict, or tvm.target.Target, optional
+        Compilation target. If None, reads from TILELANG_DEFAULT_TARGET environment
+        variable (defaults to "auto"). Use a dict for target attributes, for example
+        {"kind": "cuda", "arch": "sm_90"}.
+    target_host : str, dict, or tvm.target.Target, optional
         Target host for cross-compilation (default: None).
     verbose : bool, optional
         Whether to enable verbose output. If None, reads from
@@ -124,8 +125,9 @@ def compile(
 
     Environment Variables
     ---------------------
-    TILELANG_TARGET : str
-        Default compilation target (e.g., "cuda", "llvm"). Defaults to "auto".
+    TILELANG_DEFAULT_TARGET : str
+        Default compilation target (e.g., "cuda", "llvm", or a dict-like target config string).
+        Defaults to "auto".
     TILELANG_EXECUTION_BACKEND : str
         Default execution backend. Defaults to "auto".
     TILELANG_VERBOSE : str
@@ -192,10 +194,11 @@ def par_compile(
     execution_backend : Literal["auto", "dlpack", "tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"], optional
         Execution backend to use for kernel execution. If None, reads from
         TILELANG_EXECUTION_BACKEND environment variable (defaults to "auto").
-    target : str or tvm.target.Target, optional
-        Compilation target. If None, reads from TILELANG_TARGET environment
-        variable (defaults to "auto").
-    target_host : str or tvm.target.Target, optional
+    target : str, dict, or tvm.target.Target, optional
+        Compilation target. If None, reads from TILELANG_DEFAULT_TARGET environment
+        variable (defaults to "auto"). Use a dict for target attributes, for example
+        {"kind": "cuda", "arch": "sm_90"}.
+    target_host : str, dict, or tvm.target.Target, optional
         Target host for cross-compilation (default: None).
     verbose : bool, optional
         Whether to enable verbose output. If None, reads from
@@ -206,8 +209,9 @@ def par_compile(
 
     Environment Variables
     ---------------------
-    TILELANG_TARGET : str
-        Default compilation target (e.g., "cuda", "llvm"). Defaults to "auto".
+    TILELANG_DEFAULT_TARGET : str
+        Default compilation target (e.g., "cuda", "llvm", or a dict-like target config string).
+        Defaults to "auto".
     TILELANG_EXECUTION_BACKEND : str
         Default execution backend. Defaults to "auto".
     TILELANG_VERBOSE : str

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -12,10 +12,10 @@ from tvm.target import Target
 from tilelang import tvm as tvm
 from tilelang.transform import PassConfigKey
 from tilelang.contrib.nvcc import (
+    format_target_code_for_gencode,
     get_cuda_library_dirs,
     get_nvcc_compiler,
-    get_target_arch,
-    get_target_compute_version,
+    get_target_arch_and_code,
 )
 from tilelang.contrib.rocm import find_rocm_path, get_rocm_arch
 from tilelang.env import TILELANG_TEMPLATE_PATH
@@ -64,7 +64,6 @@ class LibraryGenerator:
 
             _lib_ext = ".dll" if sys.platform == "win32" else ".so"
             src = tempfile.NamedTemporaryFile(mode="w", suffix=".cu", delete=False)  # noqa: SIM115
-            target_arch = get_target_arch(get_target_compute_version(target))
             libpath = src.name.replace(".cu", _lib_ext)
 
             enable_fast_math = self.pass_configs.get(PassConfigKey.TL_ENABLE_FAST_MATH, False)
@@ -74,6 +73,11 @@ class LibraryGenerator:
                 ptxas_usage_level = int(ptxas_usage_level)
             verbose_ptxas_output = self.pass_configs.get(PassConfigKey.TL_ENABLE_PTXAS_VERBOSE_OUTPUT, False)
             cuda_library_flags = [f"-L{lib_dir}" for lib_dir in get_cuda_library_dirs()]
+            target_arch, target_code = get_target_arch_and_code(target)
+            arch_flags = [f"-arch=sm_{target_arch}"]
+            gencode_code = format_target_code_for_gencode(target_code)
+            if gencode_code is not None:
+                arch_flags = ["-gencode", f"arch=compute_{target_arch},code={gencode_code}"]
 
             command = [
                 get_nvcc_compiler(),
@@ -89,8 +93,7 @@ class LibraryGenerator:
                 src.name,
                 *cuda_library_flags,
                 "-lcuda",
-                "-gencode",
-                f"arch=compute_{target_arch},code=sm_{target_arch}",
+                *arch_flags,
             ]
             if sys.platform == "win32":
                 # /Zc:__cplusplus forces MSVC to report the actual C++ standard

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
-TargetLike = str | Target
+TargetLike = str | dict[str, object] | Target
 
 
 class JITKernel(Generic[_P, _T]):
@@ -84,9 +84,10 @@ class JITKernel(Generic[_P, _T]):
             Index(es) of the output tensors to return (default: None).
         execution_backend : Literal["tvm_ffi", "cython", "nvrtc", "torch", "cutedsl"], optional
             Execution backend to use for kernel execution.
-        target : str or tvm.target.Target, optional
-            Compilation target (default: "auto").
-        target_host : str or tvm.target.Target, optional
+        target : str, dict, or tvm.target.Target, optional
+            Compilation target (default: "auto"). Use a dict for target attributes,
+            for example {"kind": "cuda", "arch": "sm_90"}.
+        target_host : str, dict, or tvm.target.Target, optional
             Target host for cross-compilation (default: None).
         verbose : bool, optional
             Whether to enable verbose output (default: False).


### PR DESCRIPTION
## Summary

- Add structured CUDA target `code` support so TileLang can compile one virtual architecture while emitting code for explicit NVCC GPU instances.
- Allow default target configuration through `TILELANG_DEFAULT_TARGET` dict-like strings and document target input forms.

## Changes

- Update the TVM submodule pointer to a commit that registers CUDA `code` as a target attribute.
- Thread CUDA `code` through NVCC command generation, including `-gencode` formatting and fatbin fallback when multiple code instances are requested.
- Add tests for target config parsing, CUDA target `code` preservation, NVCC code validation, fatbin fallback, and the CUDA compile callback.
- Expand target documentation and API docstrings for string, dict, and `Target` inputs.

## Validation

- `cmake --build build -j$(nproc)`
- `pre-commit run --all-files`
- `python -m pytest testing/python/target/test_tilelang_target.py -q`
- `python -m pytest testing/python/jit/test_tilelang_jit_diagnostics.py -q -k "target_code or cuda_compile_callback or nvcc_compile_cuda_honors_tilelang_timeout"`

## Notes

- Docs build was not run locally because `sphinx` is not installed: `python -m sphinx -b html docs docs/_build/html`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Overview
Added structured support for CUDA target `code` attributes and expanded TileLang target configuration handling across JIT/autotuning/caching and CUDA NVCC code generation.

### What changed
- Updated the TVM submodule pointer to a commit that registers CUDA `code` as a target attribute.
- Added parsing support for dict-like `TILELANG_DEFAULT_TARGET` strings and updated `get_default_target()` to return `"auto"`, a string target, or a parsed target config dict.
- Broadened accepted target inputs across APIs by introducing/widening `TargetLike` to include:
  - string kinds (e.g., `"cuda"`),
  - dict-like target configs (e.g., `{"kind": "cuda", "arch": "...", "code": [...]}`),
  - `tvm.target.Target` objects.
- Made CUDA NVCC code generation `target`-`code` aware:
  - derive `arch` and (when present) `code` from target metadata,
  - generate `-gencode` when a `code` list is provided/derived,
  - switch to `fatbin` when multiple CUDA code targets are requested (avoiding `cubin` in that case).
- Refactored NVCC flag generation in both the library generator and CUDA compile callback to use new `arch/code` helpers and the fatbin fallback logic.
- Expanded documentation and API docstrings to document supported `target` input forms (string/dict/`Target` objects), CUDA `arch` vs `code` rules, and the `TILELANG_DEFAULT_TARGET` dict-like-string behavior.
- Added/expanded tests for default target parsing, CUDA `code` normalization/validation, and NVCC command-line flag selection (`-gencode` vs `-arch` and `fatbin` vs `cubin`).

### Tests
- Added/extended Python tests covering:
  - `TILELANG_DEFAULT_TARGET` parsing (string vs dict-like string),
  - CUDA target normalization/validation for `code`,
  - NVCC command-line flag generation, including multi-`code` behavior using `--fatbin`.

### C++ style / lint notes
- This PR does not modify C++ sources or `docs/developer_guide/cpp_style.md`; changes are limited to Python, docs, and the TVM submodule pointer.
- No C++ API Style Audit (“warning only”) relevance is indicated by the described changes; treat any CI warnings from that step as advisory unless they relate to an introduced C++/FFI/API surface or maintainability risk (not indicated here).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->