### PR TITLE
[BugFix] Fix T.Persistent dropping tiles when last dim is not a multiple of group_size

### DIFF
--- a/src/ir.cc
+++ b/src/ir.cc
@@ -143,9 +143,20 @@ ForFrame PersistentFor(const Array<PrimExpr> &domain, const PrimExpr &wave_size,
     domain_size *= domain[i];
   }
 
-  auto waves = ceildiv(domain_size, wave_size);
-  auto loop_var = Var("w", waves.dtype());
   group_size = min(group_size, domain[domain.size() - 1]);
+  Array<PrimExpr> grouped_domain;
+  grouped_domain.push_back(ceildiv(domain[domain.size() - 1], group_size));
+  for (int i = 0; i < domain.size() - 1; ++i) {
+    grouped_domain.push_back(domain[i]);
+  }
+  grouped_domain.push_back(group_size);
+  PrimExpr padded_domain_size = grouped_domain[0];
+  for (int i = 1; i < grouped_domain.size(); ++i) {
+    padded_domain_size *= grouped_domain[i];
+  }
+
+  auto waves = ceildiv(padded_domain_size, wave_size);
+  auto loop_var = Var("w", waves.dtype());
   Array<Var> coord_vars;
 
   for (int i = 0; i < domain.size(); ++i) {
@@ -155,13 +166,6 @@ ForFrame PersistentFor(const Array<PrimExpr> &domain, const PrimExpr &wave_size,
     n->vars.push_back(coord);
     n->doms.push_back(Range(make_const(dtype, 0), domain[i]));
   }
-
-  Array<PrimExpr> grouped_domain;
-  grouped_domain.push_back(truncdiv(domain[domain.size() - 1], group_size));
-  for (int i = 0; i < domain.size() - 1; ++i) {
-    grouped_domain.push_back(domain[i]);
-  }
-  grouped_domain.push_back(group_size);
 
   n->f_make_for_loop = [=](const Array<Var> &vars, const Array<Range> &doms,
                            const Array<Optional<PrimExpr>> &steps,
@@ -176,17 +180,20 @@ ForFrame PersistentFor(const Array<PrimExpr> &domain, const PrimExpr &wave_size,
       rem = truncdiv(rem, grouped_domain[i]);
     }
     idxs.Set(0, rem);
-
+    PrimExpr last_coord =
+        idxs[0] * group_size + idxs[grouped_domain.size() - 1];
+    PrimExpr in_range = last_coord < domain[domain.size() - 1];
     auto out_if = tvm::tirx::IfThenElse(
-        domain_size <= (loop_var * wave_size + index),
+        padded_domain_size <= (loop_var * wave_size + index),
         tvm::tirx::Evaluate(
             tvm::tirx::Call(DataType::Handle(), tvm::tl::loop_break(), {})),
         Stmt());
+    Stmt guarded_body = tvm::tirx::IfThenElse(in_range, body, Stmt());
 
     arith::Analyzer analyzer;
-    Stmt new_body = body;
+    Stmt new_body = guarded_body;
     if (analyzer.CanProveGreaterEqual(waves, 2)) {
-      new_body = SeqStmt({out_if, body});
+      new_body = SeqStmt({out_if, guarded_body});
     }
     Optional<PrimExpr> step =
         !steps.empty() ? steps[0] : Optional<PrimExpr>(std::nullopt);
@@ -196,9 +203,7 @@ ForFrame PersistentFor(const Array<PrimExpr> &domain, const PrimExpr &wave_size,
     for (int i = 0; i < vars.size() - 1; ++i) {
       outer = SeqStmt({tirx::Bind(vars[i], idxs[i + 1]), outer});
     }
-    outer = SeqStmt({tirx::Bind(vars[vars.size() - 1],
-                                idxs[0] * group_size + idxs[vars.size()]),
-                     outer});
+    outer = SeqStmt({tirx::Bind(vars[vars.size() - 1], last_coord), outer});
     return outer;
   };
 

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -143,9 +143,11 @@ ForFrame PersistentFor(const Array<PrimExpr> &domain, const PrimExpr &wave_size,
     domain_size *= domain[i];
   }
 
-  group_size = min(group_size, domain[domain.size() - 1]);
+  PrimExpr last_extent = domain[domain.size() - 1];
+  group_size =
+      max(make_const(group_size.dtype(), 1), min(group_size, last_extent));
   Array<PrimExpr> grouped_domain;
-  grouped_domain.push_back(ceildiv(domain[domain.size() - 1], group_size));
+  grouped_domain.push_back(ceildiv(last_extent, group_size));
   for (int i = 0; i < domain.size() - 1; ++i) {
     grouped_domain.push_back(domain[i]);
   }

--- a/testing/python/issue/test_tilelang_issue_2433.py
+++ b/testing/python/issue/test_tilelang_issue_2433.py
@@ -1,0 +1,93 @@
+"""Regression for tile-ai/tilelang issue #2433."""
+
+import torch
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+@tilelang.jit
+def _persistent_visit_kernel(MB, NB, sm_num):
+
+    @T.prim_func
+    def kernel(Visited: T.Tensor((MB, NB), T.int32)):
+        with T.Kernel(sm_num, threads=1) as block_id:
+            for bx, by in T.Persistent([MB, NB], sm_num, block_id):
+                Visited[bx, by] += 1
+
+    return kernel
+
+
+@tilelang.jit
+def _persistent_visit_kernel_3d(D0, D1, D2, sm_num):
+
+    @T.prim_func
+    def kernel(Visited: T.Tensor((D0, D1, D2), T.int32)):
+        with T.Kernel(sm_num, threads=1) as block_id:
+            for i, j, k in T.Persistent([D0, D1, D2], sm_num, block_id):
+                Visited[i, j, k] += 1
+
+    return kernel
+
+
+def run_persistent_visit(m_blocks: int, n_blocks: int, sm_num: int):
+    kernel = _persistent_visit_kernel(m_blocks, n_blocks, sm_num)
+    visited = torch.zeros(m_blocks, n_blocks, device="cuda", dtype=torch.int32)
+    kernel(visited)
+    expected = torch.ones_like(visited)
+    assert torch.equal(visited, expected), (
+        f"T.Persistent visited grid mismatch for "
+        f"m_blocks={m_blocks}, n_blocks={n_blocks}, sm_num={sm_num}: "
+        f"missing={(visited == 0).nonzero(as_tuple=False).tolist()}, "
+        f"overflow={(visited > 1).nonzero(as_tuple=False).tolist()}"
+    )
+
+
+def run_persistent_visit_3d(d0: int, d1: int, d2: int, sm_num: int):
+    kernel = _persistent_visit_kernel_3d(d0, d1, d2, sm_num)
+    visited = torch.zeros(d0, d1, d2, device="cuda", dtype=torch.int32)
+    kernel(visited)
+    expected = torch.ones_like(visited)
+    assert torch.equal(visited, expected), (
+        f"T.Persistent 3D visited grid mismatch for "
+        f"({d0},{d1},{d2}), sm_num={sm_num}: "
+        f"missing={(visited == 0).nonzero(as_tuple=False).tolist()}, "
+        f"overflow={(visited > 1).nonzero(as_tuple=False).tolist()}"
+    )
+
+
+@tilelang.testing.requires_cuda
+def test_issue_2433():
+    """Reproduce the failure table from the issue and the divisor controls.
+
+    With group_size defaulting to min(8, n_blocks), only the rows where
+    n_blocks % group_size != 0 trip the bug; the divisor rows act as
+    controls to make sure the fix doesn't regress them.
+    """
+    # Divisor controls (must always pass).
+    for n_blocks in (1, 2, 4, 8):
+        run_persistent_visit(m_blocks=4, n_blocks=n_blocks, sm_num=3)
+
+    # Non-divisor cases -- exactly the failing rows from the issue.
+    for n_blocks in (9, 10, 11, 12):
+        run_persistent_visit(m_blocks=4, n_blocks=n_blocks, sm_num=3)
+
+    # Single-wave control from the issue (sm_num >= total tiles): proves
+    # the bug is divisibility, not wave-count related.
+    run_persistent_visit(m_blocks=4, n_blocks=9, sm_num=36)
+
+    # Boundary: leading dim not a multiple of group_size either -- only the
+    # last dim is grouped, so this must still pass.
+    run_persistent_visit(m_blocks=7, n_blocks=11, sm_num=5)
+
+    # Boundary: 3D domain with non-divisor last dim, exercising the
+    # mixed-radix decode + range guard at higher rank.
+    run_persistent_visit_3d(d0=3, d1=5, d2=10, sm_num=4)
+
+    # Boundary: more SMs than tiles, so several waves end up entirely in
+    # the padded tail and must be skipped by the range guard.
+    run_persistent_visit(m_blocks=2, n_blocks=3, sm_num=16)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## [Bugfix] PersistentFor: stop dropping the trailing tile band when `n_blocks % group_size != 0`

Fixes #2433.

### Summary

`T.Persistent` silently drops a band of output tiles whenever the persistent loop's last domain dimension isn't a multiple of `group_size` (which defaults to `8`). On the issue's exact shape (`M=512, N=2304, K=512, block=128x256` →
`4×9` tile grid) the entire `by=8` column was never visited, leaving NaN columns in the output.

This PR fixes the IR construction in `PersistentFor` (`src/ir.cc`) and adds a primitive-level reproducer/regression test that doesn't depend on the warp-specialized GEMM path.


### The fix (three coupled changes)

1. `truncdiv → ceildiv` so the grouped space covers every real tile 
2. Iterate the wave loop and the early-break check over the **padded**grouped cardinality `padded_domain_size = grouped_domain`. Without this, padded slots steal flat-index positions from real tiles in earlier waves and just shift the "dropped band" symptom around.
3. Wrap the user body in an `if (last_coord < domain.back())` guard so the padded tail is skipped at execution time.


### Testing


<img width="604" height="225" alt="image" src="https://github.com/user-attachments/assets/9c03e14f-b5d3-446e-8018-00e177d9b7f6" />
<img width="1138" height="501" alt="image" src="https://github.com/user-attachments/assets/6400279d-2498-422e-9801-956bb6ebb039" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Fixed `T.Persistent` loop grouping in `src/ir.cc` so the final dimension uses ceil-based padding instead of truncation, preventing trailing tile columns from being silently skipped.
- Updated the wave loop/cardinality and `loop_break` sequencing to use the padded grouped size, and added an execution-time guard (`last_coord < domain.back()`) so padded tiles are not processed.
- Added a primitive-level regression test for issue `#2433` (`testing/python/issue/test_tilelang_issue_2433.py`) that reproduces the missing-tile/divisibility failure without relying on the warp-specialized GEMM path.

## Testing
- `pytest testing/python/issue/test_tilelang_issue_2433.py`
- `python -m pytest testing/python/issue/ -v --tb=short`

## C++ style / lint notes
- This PR touches C++ (`src/ir.cc`), which falls under `docs/developer_guide/cpp_style.md` (“This guide applies to C++ source under `src/`…”). It does not introduce a new public/API/FFI surface.
- CI note: the “C++ API Style Audit (warning only)” step is not expected to be affected by this behavioral fix; any TLCPP003/TLCPP004 findings (if they appear) should be treated as advisory unless the PR introduces a concrete API/maintainability risk.
- Warning-only signals from tests: observed pytest output includes `PytestUnknownMarkWarning` for `gpu`/`cuda` and some deprecation warnings (`T.symbolic`→`T.dynamic`, `T.Buffer`→`T.Tensor`, `tl.disable_tma_lower` deprecation). These do not indicate build/correctness issues introduced by this PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->