### PR TITLE
[CUDA] Increase MMA descriptor without touching high bits

### DIFF
--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -430,8 +430,8 @@ union GmmaDescriptor {
   template <typename T>
   CUTE_HOST_DEVICE constexpr GmmaDescriptor operator+(const T &offset) const {
     GmmaDescriptor ret;
-    ret.reg32_[0] = reg32_[0] + uint32_t(offset);
-    ret.reg32_[1] = reg32_[1];
+    ret.desc_ = desc_;
+    ret.reg32_[0] += uint32_t(offset);
     return ret;
   }
 };
@@ -493,9 +493,9 @@ union Tcgen05SMemDescriptor {
   CUTE_HOST_DEVICE constexpr Tcgen05SMemDescriptor
   operator+(const T &offset) const {
     Tcgen05SMemDescriptor ret;
+    ret.desc_ = desc_;
     // Address addition is in units of 16 bytes (4 LSB not encoded)
-    ret.reg32_[0] = reg32_[0] + (uint32_t(offset) >> 4);
-    ret.reg32_[1] = reg32_[1];
+    ret.reg32_[0] += uint32_t(offset) >> 4;
     return ret;
   }
 };


### PR DESCRIPTION
Previously to increase the offset of a GMMA descriptor we used 
```cpp
GmmaDescriptor ret;
ret.reg32_[0] = reg32_[0] + uint32_t(offset);
ret.reg32_[1] = reg32_[1];
return ret;
```
The value in `reg32_[1]` can be theoretically kept in a 32-bit UR across descriptor increment. However I observed in generated SASS code that nvcc/ptxas fail to reason that this can be done, and extra UPRMT instructions get generated, slowing the pipeline. nvcc/ptxas cannot reason about "let's extract the higher 32 bits of a 64-bit value and splice it into another 64-bit value and magically allocate only 1 UR for it".

So the trick is
```cpp
GmmaDescriptor ret;
ret.desc_ = desc_;
ret.reg32_[0] += uint32_t(offset);
return ret;
```
And in this case I observe that the higher bits `reg32_[1]` indeed reside in one UR without changing. It seems that nvcc/ptxas reason about the bits in a single variable better.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Updated CUDA descriptor offset handling in `src/tl_templates/cuda/common.h` so GMMA and TCGEN05 descriptors are copied first and then adjusted by incrementing the low 32 bits in place, preserving the original high bits.

## C++ style / lint notes
- This PR touches C++ CUDA template code, but does not appear to change rules documented in `docs/developer_guide/cpp_style.md`.
- The change is aligned with the intent of the C++ API Style Audit (warning only) by avoiding unnecessary descriptor reconstruction.
- No new correctness, build, or test issues are indicated by the change; any remaining TLCPP-style warnings would be advisory only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->