### PR TITLE
[CI][BugFix] Flash bwd varlen: zero-init lse/Delta padding to avoid NaN in Dk

### DIFF
--- a/examples/flash_attention/example_gqa_bwd_tma_reduce_varlen.py
+++ b/examples/flash_attention/example_gqa_bwd_tma_reduce_varlen.py
@@ -128,8 +128,11 @@ def flashattn_fwd(batch, total_q, total_kv, N_CTX, heads, max_seq_len, dim_qk, d
 
             for i in T.Parallel(block_M):
                 logsum[i] = T.log2(logsum[i]) + scores_max[i] * scale
-                if bx * block_M + i < q_current_seqlen:
-                    lse[bz, by, bx * block_M + i] = logsum[i]
+                # NOTE(varlen): explicitly write 0 to padding positions; otherwise
+                # `lse` is auto-allocated via `out_idx` (torch.empty) and may
+                # contain NaN/Inf at padding rows, which later contaminates the
+                # backward pass through `T.exp2(... - lse)` and `0 * NaN = NaN`.
+                lse[bz, by, bx * block_M + i] = logsum[i] if bx * block_M + i < q_current_seqlen else T.cast(0, accum_dtype)
 
     return flash_fwd
 
@@ -178,8 +181,11 @@ def flashattn_bwd_preprocess(batch, heads, total_q, N_CTX, max_seq_len, dim_v):
             T.reduce_sum(acc, delta, 1)
 
             for i in T.Parallel(blk):
-                if by * blk + i < q_current_seqlen:
-                    Delta[bz, bx, by * blk + i] = delta[i]
+                # NOTE(varlen): same reason as `lse` above -- `Delta` is
+                # auto-allocated as `torch.empty` and may carry NaN/Inf into the
+                # backward kernel's `(dsT - delta)` term, eventually poisoning
+                # `dK` via the GEMM that accumulates over the padded columns.
+                Delta[bz, bx, by * blk + i] = delta[i] if by * blk + i < q_current_seqlen else T.cast(0, accum_dtype)
 
     return flash_bwd_prep
 


### PR DESCRIPTION
The varlen GQA backward example allocates lse and Delta via out_idx, which uses torch.empty under the hood. Their padding rows (i >= q_current_seqlen) were left untouched by the forward / preprocess kernels and could carry NaN/Inf from uninitialized memory.

These dirty values then leak into the backward kernel:

  * lse is consumed as exp2(qkT*scale - lse_shared[j]); a NaN poisons the whole column of P, dP and downstream dK.

  * Delta is consumed as qkT_cast * (dsT - delta[j]); even masked-out (qkT=0) columns become NaN through 0 * NaN = NaN, which is then accumulated into dK by the GEMM over padded K columns.

Fix: explicitly write 0.0 to the padding positions of lse (in flash_fwd) and Delta (in flash_bwd_prep), so the backward kernel always reads well-defined values regardless of the host-side allocator.

Verified by examples/flash_attention/test_example_flash_attention.py::test_example_gqa_bwd_tma_reduce_varlen (previously failed with dK == NaN, now passes; tilelang throughput restored from ~1 TFlops to ~7 TFlops on H100).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Fixed the variable-length GQA backward flash-attention example by explicitly writing `0` into the padding rows of:
  - `lse` in `flash_fwd` (previously auto-allocated via `out_idx`/`torch.empty`, so padding entries could contain NaN/Inf and later contaminate `T.exp2(... - lse)` because `0 * NaN = NaN`).
  - `Delta` in `flash_bwd_prep` (same padding/uninitialized hazard, now cleared before backward uses it).
- Added inline notes documenting the NaN/Inf propagation risk and why host-side zero-initializing the outputs is insufficient.

## Validation
- Verified `examples/flash_attention/test_example_flash_attention.py::test_example_gqa_bwd_tma_reduce_varlen`, which previously failed with `dK == NaN` and now passes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->