### PR TITLE
[BugFix] Improve diagnostic for T.serial fragment access

### DIFF
--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -719,8 +719,8 @@ Fragment ParallelOpNode::ComputeLoopLayoutFromBuffer(
         std::ostringstream oss;
         oss << "Cannot lower access to thread-distributed fragment `"
             << buffer->name
-            << "` from a T.serial loop: fragment elements are spread across "
-               "CUDA threads, so the serial loop variable `"
+            << "`: its elements are spread across CUDA threads, so the "
+               "non-parallel loop variable `"
             << *opt_var
             << "` cannot be used to address them safely (thread map: "
             << loop_var_to_thread

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -717,8 +717,15 @@ Fragment ParallelOpNode::ComputeLoopLayoutFromBuffer(
       if (auto opt_var = objref.as<Var>();
           opt_var && inner_vars_.count(*opt_var)) {
         std::ostringstream oss;
-        oss << "loop_var_to_thread = " << loop_var_to_thread
-            << "contains inner var" << *opt_var;
+        oss << "Cannot lower access to thread-distributed fragment `"
+            << buffer->name
+            << "` from a T.serial loop: fragment elements are spread across "
+               "CUDA threads, so the serial loop variable `"
+            << *opt_var
+            << "` cannot be used to address them safely (thread map: "
+            << loop_var_to_thread
+            << "). Use T.reduce_sum for reductions, T.Parallel for elementwise "
+               "access, or stage through shared memory to change the layout.";
         throw LayoutConflictException(oss.str());
       }
     });

--- a/testing/python/issue/test_tilelang_issue_serial_fragment_access.py
+++ b/testing/python/issue/test_tilelang_issue_serial_fragment_access.py
@@ -5,18 +5,11 @@ import tilelang.testing
 import tilelang.language as T
 
 
-# A T.serial loop runs sequentially inside each CUDA thread, but a fragment's
-# elements are distributed across threads, so indexing a fragment by a serial
-# loop variable has no valid thread-ownership mapping. The three cases below
-# (issues #2393, #2395, #2396) share this root cause and must be rejected with a
-# clear diagnostic instead of crashing nvcc / silently miscomputing. A scalar
-# fragment[0] store, which the rejection must NOT break, is also covered.
-
-
 @tilelang.testing.requires_cuda
 def test_issue_2393_serial_reduce_gemm_fragment_is_rejected():
     """#2393: a serial reduce of a GEMM-output (MMA-layout) fragment used to fail
-    with an unhelpful internal error ("contains inner var j")."""
+    with an unhelpful internal error ("contains inner var j"). Now rejected with
+    a clear diagnostic suggesting T.reduce_sum."""
     M, N, KD = 64, 64, 64
 
     @tilelang.jit
@@ -46,70 +39,6 @@ def test_issue_2393_serial_reduce_gemm_fragment_is_rejected():
         k(Q, Kk)
     msg = str(excinfo.value)
     assert "thread-distributed fragment" in msg and "T.reduce_sum" in msg
-
-
-@tilelang.testing.requires_cuda
-def test_issue_2395_serial_write_fragment_then_copy_is_rejected():
-    """#2395: serial write into a fragment then T.copy out used to emit an
-    owner-thread guard built from serial loop vars outside the loop that binds
-    them, so nvcc failed with "identifier undefined"."""
-    M = N = 16
-
-    @T.prim_func
-    def kernel(A: T.Tensor((M, N), "float32"), C: T.Tensor((M, N), "float32")):
-        with T.Kernel(1, 1, threads=128) as (bx, by):
-            Af = T.alloc_fragment((M, N), "float32")
-            Bf = T.alloc_fragment((M, N), "float32")
-            T.copy(A[0, 0], Af)
-            for i in T.serial(M):
-                for j in T.serial(N):
-                    Bf[i, j] = Af[i, j] * 2.0
-            T.copy(Bf, C[0, 0])
-
-    with pytest.raises(Exception) as excinfo:
-        tilelang.compile(kernel, target="cuda")
-    assert "serial" in str(excinfo.value) and "T.Parallel" in str(excinfo.value)
-
-
-@tilelang.testing.requires_cuda
-def test_issue_2396_serial_fragment_to_global_is_rejected():
-    """#2396: serial write of a fragment to global used to compile and run with
-    silently wrong results (concurrent threads race-write each cell)."""
-    M = N = 16
-
-    @T.prim_func
-    def kernel(A: T.Tensor((M, N), "float32"), C: T.Tensor((M, N), "float32")):
-        with T.Kernel(1, 1, threads=128) as (bx, by):
-            Af = T.alloc_fragment((M, N), "float32")
-            T.copy(A[0, 0], Af)
-            for i in T.serial(M):
-                for j in T.serial(N):
-                    C[i, j] = Af[i, j] * 2.0
-
-    with pytest.raises(Exception) as excinfo:
-        tilelang.compile(kernel, target="cuda")
-    assert "serial" in str(excinfo.value) and "T.Parallel" in str(excinfo.value)
-
-
-@tilelang.testing.requires_cuda
-def test_scalar_fragment_store_is_accepted():
-    """The rejection must not break the case this pass exists to handle: a bare
-    scalar fragment[0] store (not inside a tile op, not thread-bound) is still
-    wrapped and compiles to the correct result."""
-    import torch
-
-    @T.prim_func
-    def kernel(C: T.Tensor((1,), "float32")):
-        with T.Kernel(1, threads=128):
-            frag = T.alloc_fragment((1,), "float32")
-            frag[0] = 1.0
-            C[0] = frag[0]
-
-    kfn = tilelang.compile(kernel, target="cuda")
-    c = torch.empty(1, dtype=torch.float32, device="cuda")
-    kfn(c)
-    torch.cuda.synchronize()
-    torch.testing.assert_close(c, torch.ones(1, dtype=torch.float32, device="cuda"))
 
 
 if __name__ == "__main__":

--- a/testing/python/issue/test_tilelang_issue_serial_fragment_access.py
+++ b/testing/python/issue/test_tilelang_issue_serial_fragment_access.py
@@ -1,0 +1,116 @@
+# ruff: noqa
+import pytest
+import tilelang
+import tilelang.testing
+import tilelang.language as T
+
+
+# A T.serial loop runs sequentially inside each CUDA thread, but a fragment's
+# elements are distributed across threads, so indexing a fragment by a serial
+# loop variable has no valid thread-ownership mapping. The three cases below
+# (issues #2393, #2395, #2396) share this root cause and must be rejected with a
+# clear diagnostic instead of crashing nvcc / silently miscomputing. A scalar
+# fragment[0] store, which the rejection must NOT break, is also covered.
+
+
+@tilelang.testing.requires_cuda
+def test_issue_2393_serial_reduce_gemm_fragment_is_rejected():
+    """#2393: a serial reduce of a GEMM-output (MMA-layout) fragment used to fail
+    with an unhelpful internal error ("contains inner var j")."""
+    M, N, KD = 64, 64, 64
+
+    @tilelang.jit
+    def k(Q: T.Tensor((M, KD), T.float16), Kk: T.Tensor((N, KD), T.float16)):
+        out = T.empty((M,), T.float32)
+        with T.Kernel(1, threads=128) as bx:
+            Qs = T.alloc_shared((M, KD), T.float16)
+            Ks = T.alloc_shared((N, KD), T.float16)
+            acc = T.alloc_fragment((M, N), T.float32)
+            s = T.alloc_fragment((M,), T.float32)
+            T.copy(Q, Qs)
+            T.copy(Kk, Ks)
+            T.clear(acc)
+            T.gemm(Qs, Ks, acc, transpose_B=True)
+            T.fill(s, 0.0)
+            for i in T.Parallel(M):
+                for j in T.serial(N):
+                    s[i] += acc[i, j]
+            T.copy(s, out)
+        return out
+
+    import torch
+
+    Q = torch.randn(M, KD, dtype=torch.float16, device="cuda")
+    Kk = torch.randn(N, KD, dtype=torch.float16, device="cuda")
+    with pytest.raises(Exception) as excinfo:
+        k(Q, Kk)
+    msg = str(excinfo.value)
+    assert "thread-distributed fragment" in msg and "T.reduce_sum" in msg
+
+
+@tilelang.testing.requires_cuda
+def test_issue_2395_serial_write_fragment_then_copy_is_rejected():
+    """#2395: serial write into a fragment then T.copy out used to emit an
+    owner-thread guard built from serial loop vars outside the loop that binds
+    them, so nvcc failed with "identifier undefined"."""
+    M = N = 16
+
+    @T.prim_func
+    def kernel(A: T.Tensor((M, N), "float32"), C: T.Tensor((M, N), "float32")):
+        with T.Kernel(1, 1, threads=128) as (bx, by):
+            Af = T.alloc_fragment((M, N), "float32")
+            Bf = T.alloc_fragment((M, N), "float32")
+            T.copy(A[0, 0], Af)
+            for i in T.serial(M):
+                for j in T.serial(N):
+                    Bf[i, j] = Af[i, j] * 2.0
+            T.copy(Bf, C[0, 0])
+
+    with pytest.raises(Exception) as excinfo:
+        tilelang.compile(kernel, target="cuda")
+    assert "serial" in str(excinfo.value) and "T.Parallel" in str(excinfo.value)
+
+
+@tilelang.testing.requires_cuda
+def test_issue_2396_serial_fragment_to_global_is_rejected():
+    """#2396: serial write of a fragment to global used to compile and run with
+    silently wrong results (concurrent threads race-write each cell)."""
+    M = N = 16
+
+    @T.prim_func
+    def kernel(A: T.Tensor((M, N), "float32"), C: T.Tensor((M, N), "float32")):
+        with T.Kernel(1, 1, threads=128) as (bx, by):
+            Af = T.alloc_fragment((M, N), "float32")
+            T.copy(A[0, 0], Af)
+            for i in T.serial(M):
+                for j in T.serial(N):
+                    C[i, j] = Af[i, j] * 2.0
+
+    with pytest.raises(Exception) as excinfo:
+        tilelang.compile(kernel, target="cuda")
+    assert "serial" in str(excinfo.value) and "T.Parallel" in str(excinfo.value)
+
+
+@tilelang.testing.requires_cuda
+def test_scalar_fragment_store_is_accepted():
+    """The rejection must not break the case this pass exists to handle: a bare
+    scalar fragment[0] store (not inside a tile op, not thread-bound) is still
+    wrapped and compiles to the correct result."""
+    import torch
+
+    @T.prim_func
+    def kernel(C: T.Tensor((1,), "float32")):
+        with T.Kernel(1, threads=128):
+            frag = T.alloc_fragment((1,), "float32")
+            frag[0] = 1.0
+            C[0] = frag[0]
+
+    kfn = tilelang.compile(kernel, target="cuda")
+    c = torch.empty(1, dtype=torch.float32, device="cuda")
+    kfn(c)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(c, torch.ones(1, dtype=torch.float32, device="cuda"))
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/transform/add_bufstore_wrapper.py
+++ b/tilelang/transform/add_bufstore_wrapper.py
@@ -8,9 +8,13 @@ def AddWrapperForSingleBufStore():
     Creates a TVM pass that wraps single buffer stores with parallel loops.
 
     This transformation adds T.Parallel wrappers around buffer stores that:
-    1. Access fragment buffers with index 0
+    1. Access fragment buffers only at the constant all-zero index [0, 0, ...]
     2. Are not inside existing tile operations or thread bindings
-    3. Don't access fragment buffers with non-zero indices
+
+    A fragment accessed at any other index (a constant non-zero or a dynamic
+    index such as a T.serial loop variable) is rejected, since a fragment is
+    distributed across threads and such an access has no valid thread-ownership
+    mapping in this lowering path.
 
     Returns:
         A prim_func_pass that applies the transformation
@@ -68,21 +72,25 @@ def AddWrapperForSingleBufStore():
                     local_buffers.append(buffer)
             return local_buffers, fragment_buffers
 
-        def collect_buffer_indices(statement) -> dict[Buffer, list[int]]:
+        def collect_buffer_indices(statement) -> dict[Buffer, list]:
             """
-            Maps each buffer to its access indices.
+            Maps each buffer to the index vectors of every access to it.
+
+            A buffer can be accessed more than once in a statement (e.g. a
+            variable-index load and a constant-index store), so all occurrences are
+            kept; recording only the last would let one slip past validation.
 
             Args:
                 statement: The TIR statement to analyze
 
             Returns:
-                Dictionary mapping buffers to their access indices
+                Dictionary mapping buffers to a list of their access index vectors
             """
             buffer_to_indices = {}
 
             def visit_buffer_access(node):
                 if isinstance(node, (BufferLoad, BufferStore)):
-                    buffer_to_indices[node.buffer] = node.indices
+                    buffer_to_indices.setdefault(node.buffer, []).append(node.indices)
 
             post_order_visit(statement, visit_buffer_access)
             return buffer_to_indices
@@ -130,19 +138,31 @@ def AddWrapperForSingleBufStore():
                     if len(fragment_buffers) == 0:
                         return statement
 
-                    # Validate fragment buffer indices - only index 0 is supported
+                    # Validate fragment buffer indices. In this fallback lowering
+                    # path we only support the constant all-zero index [0, 0, ...]. A
+                    # dynamic index, such as a T.serial loop variable, would
+                    # address a thread-distributed fragment with no valid
+                    # thread-ownership mapping and otherwise lowers to invalid
+                    # code or races.
                     buffer_indices = collect_buffer_indices(statement)
-                    for buffer, indices in buffer_indices.items():
+                    for buffer, index_vectors in buffer_indices.items():
                         if buffer.scope() != "local.fragment":
                             continue
-                        for index in indices:
-                            if isinstance(index, IntImm) and index != 0:
+                        for indices in index_vectors:
+                            if any(not (isinstance(index, IntImm) and index.value == 0) for index in indices):
+                                index_str = ", ".join(str(index) for index in indices)
                                 raise ValueError(
-                                    f"Fragment buffer access with non-zero index [{index}] is not supported. "
-                                    "Only fragment[0] access is allowed."
+                                    f"Unsupported fragment access to '{buffer.name}' at index "
+                                    f"[{index_str}]: only the constant all-zero index "
+                                    "fragment[0, 0, ...] is supported in this fallback lowering "
+                                    "path. A fragment is "
+                                    "distributed across CUDA threads, so a dynamic index (e.g. a "
+                                    "T.serial loop variable) or a non-zero index has no valid "
+                                    "thread-ownership mapping. Use T.Parallel for elementwise "
+                                    "access, or T.reduce_sum for reductions."
                                 )
 
-                    # Wrap fragment[0] access with T.Parallel loop
+                    # Wrap the constant-index fragment[0, 0, ...] access with T.Parallel loop
                     return For(Var("_", "int32"), 0, 1, ForKind.PARALLEL, statement)
 
             return statement

--- a/tilelang/transform/add_bufstore_wrapper.py
+++ b/tilelang/transform/add_bufstore_wrapper.py
@@ -8,13 +8,9 @@ def AddWrapperForSingleBufStore():
     Creates a TVM pass that wraps single buffer stores with parallel loops.
 
     This transformation adds T.Parallel wrappers around buffer stores that:
-    1. Access fragment buffers only at the constant all-zero index [0, 0, ...]
+    1. Access fragment buffers with index 0
     2. Are not inside existing tile operations or thread bindings
-
-    A fragment accessed at any other index (a constant non-zero or a dynamic
-    index such as a T.serial loop variable) is rejected, since a fragment is
-    distributed across threads and such an access has no valid thread-ownership
-    mapping in this lowering path.
+    3. Don't access fragment buffers with non-zero indices
 
     Returns:
         A prim_func_pass that applies the transformation
@@ -72,25 +68,21 @@ def AddWrapperForSingleBufStore():
                     local_buffers.append(buffer)
             return local_buffers, fragment_buffers
 
-        def collect_buffer_indices(statement) -> dict[Buffer, list]:
+        def collect_buffer_indices(statement) -> dict[Buffer, list[int]]:
             """
-            Maps each buffer to the index vectors of every access to it.
-
-            A buffer can be accessed more than once in a statement (e.g. a
-            variable-index load and a constant-index store), so all occurrences are
-            kept; recording only the last would let one slip past validation.
+            Maps each buffer to its access indices.
 
             Args:
                 statement: The TIR statement to analyze
 
             Returns:
-                Dictionary mapping buffers to a list of their access index vectors
+                Dictionary mapping buffers to their access indices
             """
             buffer_to_indices = {}
 
             def visit_buffer_access(node):
                 if isinstance(node, (BufferLoad, BufferStore)):
-                    buffer_to_indices.setdefault(node.buffer, []).append(node.indices)
+                    buffer_to_indices[node.buffer] = node.indices
 
             post_order_visit(statement, visit_buffer_access)
             return buffer_to_indices
@@ -138,31 +130,19 @@ def AddWrapperForSingleBufStore():
                     if len(fragment_buffers) == 0:
                         return statement
 
-                    # Validate fragment buffer indices. In this fallback lowering
-                    # path we only support the constant all-zero index [0, 0, ...]. A
-                    # dynamic index, such as a T.serial loop variable, would
-                    # address a thread-distributed fragment with no valid
-                    # thread-ownership mapping and otherwise lowers to invalid
-                    # code or races.
+                    # Validate fragment buffer indices - only index 0 is supported
                     buffer_indices = collect_buffer_indices(statement)
-                    for buffer, index_vectors in buffer_indices.items():
+                    for buffer, indices in buffer_indices.items():
                         if buffer.scope() != "local.fragment":
                             continue
-                        for indices in index_vectors:
-                            if any(not (isinstance(index, IntImm) and index.value == 0) for index in indices):
-                                index_str = ", ".join(str(index) for index in indices)
+                        for index in indices:
+                            if isinstance(index, IntImm) and index != 0:
                                 raise ValueError(
-                                    f"Unsupported fragment access to '{buffer.name}' at index "
-                                    f"[{index_str}]: only the constant all-zero index "
-                                    "fragment[0, 0, ...] is supported in this fallback lowering "
-                                    "path. A fragment is "
-                                    "distributed across CUDA threads, so a dynamic index (e.g. a "
-                                    "T.serial loop variable) or a non-zero index has no valid "
-                                    "thread-ownership mapping. Use T.Parallel for elementwise "
-                                    "access, or T.reduce_sum for reductions."
+                                    f"Fragment buffer access with non-zero index [{index}] is not supported. "
+                                    "Only fragment[0] access is allowed."
                                 )
 
-                    # Wrap the constant-index fragment[0, 0, ...] access with T.Parallel loop
+                    # Wrap fragment[0] access with T.Parallel loop
                     return For(Var("_", "int32"), 0, 1, ForKind.PARALLEL, statement)
 
             return statement


### PR DESCRIPTION
## Summary

A `T.serial` loop runs sequentially inside each CUDA thread, while a fragment's elements are distributed across threads. When a non-parallel inner loop variable is used to index a thread-distributed fragment inside a tile-level `T.Parallel` operation, there is no valid thread-ownership mapping.

TileLang already rejected this invalid pattern in `ParallelOpNode`, but the diagnostic exposed an internal layout detail instead of explaining the user-facing constraint.

| Issue | Before | After |
|---|---|---|
| #2393 | unhelpful internal error `loop_var_to_thread = ... contains inner var j` | clear message naming the thread-distributed fragment indexing constraint + `T.reduce_sum` / `T.Parallel` / shared-memory alternatives |

## Root cause & fix

The existing inner-var layout check in `parallel.cc` already rejected this invalid pattern. The check detects that the inferred thread mapping for a fragment access depends on an inner non-parallel loop variable, such as the `j` from:

```python
for i in T.Parallel(M):
    for j in T.serial(N):
        s[i] += acc[i, j]
```

That condition is still invalid because `acc` is a thread-distributed fragment, while `j` does not represent a parallel ownership dimension.

This PR keeps the validation condition unchanged and only rephrases the diagnostic to explain:

- the operation being lowered: access to a thread-distributed fragment;
- the invalid condition: the access depends on a non-parallel inner loop variable;
- actionable alternatives: use `T.reduce_sum`, use `T.Parallel` for elementwise access, or stage through shared memory when serial indexing is required.

## Scope and follow-up

I initially tried to address #2395 and #2396 in the same PR by tightening `AddWrapperForSingleBufStore`, so fragment accesses in that fallback path would reject dynamic serial-loop indices earlier. That version also accumulated every access to a buffer in a statement, instead of recording only the last access, so mixed constant/dynamic accesses could not bypass the diagnostic.

CI exposed that the early check was too conservative: WebGPU has valid `alloc_fragment + T.grid` code that reaches `AddWrapperForSingleBufStore` while `T.grid` loop variables are still represented like ordinary serial loop variables. A naive "reject any dynamic fragment index" check therefore rejects valid WebGPU lowering.

#2395 and #2396 likely need a separate follow-up that can distinguish grid-derived dynamic accesses from true serial-loop accesses.

Possible follow-up directions:

- Preserve loop provenance for `T.grid` before `AddWrapperForSingleBufStore`, so the pass can allow grid-derived dynamic fragment indices while rejecting ordinary `T.serial` loop variables.
- Move the validation to a later stage where grid-derived accesses and true serial-loop accesses are distinguishable.
- Reintroduce the `collect_buffer_indices` accumulation hardening once the validation point is decided, so diagnostics cannot be bypassed when a statement accesses the same fragment at both constant and dynamic indices.

## Test plan

- Added `testing/python/issue/test_tilelang_issue_serial_fragment_access.py` with a regression test asserting the clearer diagnostic.
- Verified the regression on sm_75 (TITAN RTX).

Fixes #2393