### PR TITLE
[Pipeline] Remove split pattern renormalization pass

### DIFF
--- a/tilelang/cpu/pipeline.py
+++ b/tilelang/cpu/pipeline.py
@@ -58,7 +58,6 @@ def CPUPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.StorageRewrite()(mod)
     mod = tilelang.transform.LoopUnswitching()(mod)
     mod = tilelang.transform.UnrollLoop()(mod)
-    mod = s_tir.transform.RenormalizeSplitPattern()(mod)
     mod = tirx.transform.Simplify()(mod)
     mod = tirx.transform.RemoveNoOp()(mod)
     mod = s_tir.transform.HoistIfThenElse()(mod)

--- a/tilelang/cuda/pipeline.py
+++ b/tilelang/cuda/pipeline.py
@@ -186,7 +186,6 @@ def CUDAPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.StorageRewrite()(mod)
     mod = tilelang.transform.LoopUnswitching()(mod)
     mod = tilelang.transform.UnrollLoop()(mod)
-    mod = s_tir.transform.RenormalizeSplitPattern()(mod)
     mod = tirx.transform.Simplify()(mod)
     mod = tirx.transform.RemoveNoOp()(mod)
     mod = s_tir.transform.HoistIfThenElse()(mod)

--- a/tilelang/metal/pipeline.py
+++ b/tilelang/metal/pipeline.py
@@ -65,7 +65,6 @@ def MetalPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.StorageRewrite()(mod)
     mod = tilelang.transform.LoopUnswitching()(mod)
     mod = tilelang.transform.UnrollLoop()(mod)
-    mod = s_tir.transform.RenormalizeSplitPattern()(mod)
     mod = tirx.transform.Simplify()(mod)
     mod = tirx.transform.RemoveNoOp()(mod)
     mod = s_tir.transform.HoistIfThenElse()(mod)

--- a/tilelang/rocm/pipeline.py
+++ b/tilelang/rocm/pipeline.py
@@ -58,7 +58,6 @@ def ROCMPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.StorageRewrite()(mod)
     mod = tilelang.transform.LoopUnswitching()(mod)
     mod = tilelang.transform.UnrollLoop()(mod)
-    mod = s_tir.transform.RenormalizeSplitPattern()(mod)
     mod = tirx.transform.Simplify()(mod)
     mod = tirx.transform.RemoveNoOp()(mod)
     mod = s_tir.transform.HoistIfThenElse()(mod)

--- a/tilelang/webgpu/pipeline.py
+++ b/tilelang/webgpu/pipeline.py
@@ -60,7 +60,6 @@ def WebGPUPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.StorageRewrite()(mod)
     mod = tilelang.transform.LoopUnswitching()(mod)
     mod = tilelang.transform.UnrollLoop()(mod)
-    mod = s_tir.transform.RenormalizeSplitPattern()(mod)
     mod = tirx.transform.Simplify()(mod)
     mod = tirx.transform.RemoveNoOp()(mod)
     mod = s_tir.transform.HoistIfThenElse()(mod)


### PR DESCRIPTION
## Summary

- Remove the legacy split-pattern renormalization pass from TileLang backend pipelines.
- Keep the existing simplification pass sequence responsible for canonicalizing index expressions.

## Changes

- Drop `s_tir.transform.RenormalizeSplitPattern()` from CUDA, CPU, ROCm, Metal, and WebGPU pipeline bodies.
- Leave the remaining `s_tir` transform calls in place for follow-up migration work.

## Validation

- `python -m py_compile tilelang/cuda/pipeline.py tilelang/cpu/pipeline.py tilelang/rocm/pipeline.py tilelang/metal/pipeline.py tilelang/webgpu/pipeline.py`
- `python - <<'PY' ... lower_to_host_device_ir(...) ... PY`
- `pre-commit run --all-files`

## Notes

- The quickstart CUDA lowering check completed successfully and produced one host function and one device function.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Removed the legacy `s_tir.transform.RenormalizeSplitPattern()` pass from the TileLang backend pipelines for CUDA, CPU, ROCm, Metal, and WebGPU.

- Kept the existing simplification and cleanup pass sequences intact so index-expression canonicalization still occurs.
- Left other `s_tir` transform usage unchanged for follow-up migration work.
- Validation included Python compilation checks, a lowering test, and `pre-commit run --all-files`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->