### PR TITLE
[BugFix] Ignore flat Bind nodes in ForBodyContainsSeqStmt

### DIFF
--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -157,10 +157,20 @@ private:
  * local buffer optimization.
  */
 bool ForBodyContainsSeqStmt(const For &loop) {
+  // Ignore flat Bind nodes (SSA value defs): a single store wrapped in leading
+  // Binds is not multi-stmt. Keeps this in sync with DecoupleTypeCast.
   bool has_seq_stmt = false;
   PostOrderVisit(loop->body, [&](const ObjectRef &obj) {
-    if (obj.as<SeqStmtNode>()) {
-      has_seq_stmt = true;
+    if (auto seq = obj.as<SeqStmtNode>()) {
+      int num_real_stmts = 0;
+      for (const Stmt &s : seq->seq) {
+        if (!s.as<BindNode>()) {
+          ++num_real_stmts;
+        }
+      }
+      if (num_real_stmts >= 2) {
+        has_seq_stmt = true;
+      }
     }
   });
   return has_seq_stmt;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Refined `ForBodyContainsSeqStmt` in `src/transform/loop_vectorize.cc` to ignore flat `BindNode` entries when detecting whether a `SeqStmt` באמת contains multiple real statements.
- The check now only marks `has_seq_stmt` when there are at least two non-`BindNode` statements, preventing false positives from SSA/`DecoupleTypeCast`-related bindings.
- Added comments clarifying the expected alignment with `DecoupleTypeCast` and SSA `Bind` handling.

## C++ style / lint notes
- This PR touches C++ source but does not appear to change rules documented in `docs/developer_guide/cpp_style.md`.
- No new build or test issues are indicated by the change summary.
- The C++ API Style Audit (warning only) is only relevant if it surfaces warnings for the touched code; any such warnings here would be advisory, not blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->