### PR TITLE
[BugFix] Fix LayoutInference divide-by-zero on non-power-of-two broadcast

### DIFF
--- a/src/layout/utils.cc
+++ b/src/layout/utils.cc
@@ -111,12 +111,17 @@ Array<IterSplitExpr> get_unused_iters(const IterMark &mark,
     } else {
       used[j] = true;
       i++;
-      expected_lower_factor = splits[j]->lower_factor * splits[j]->extent;
+      expected_lower_factor =
+          analyzer->Simplify(splits[j]->lower_factor * splits[j]->extent);
     }
   }
-  bool match_full_iter =
-      analyzer->CanProveEqual(expected_lower_factor, mark->extent);
-  if (!match_full_iter) {
+  // Iter split normalization may over-approximate the original mark span.
+  // Treat over-coverage as fully covered instead of synthesizing a zero-extent
+  // leftover iterator, which later normalizes into division by zero.
+  bool covers_full_iter =
+      analyzer->CanProveEqual(expected_lower_factor, mark->extent) ||
+      analyzer->CanProve(expected_lower_factor > mark->extent);
+  if (!covers_full_iter) {
     results.emplace_back(
         mark, expected_lower_factor,
         analyzer->Simplify(FloorDiv(mark->extent, expected_lower_factor)), 1);

--- a/testing/python/transform/test_tilelang_transform_layout_inference.py
+++ b/testing/python/transform/test_tilelang_transform_layout_inference.py
@@ -223,7 +223,7 @@ def _column_broadcast_fragment_kernel(block_n):
 
 
 @tilelang.testing.requires_cuda
-@pytest.mark.parametrize("block_n", [32, 48, 96])
+@pytest.mark.parametrize("block_n", [24, 32, 40, 48, 96])
 def test_column_broadcast_fragment_values(block_n):
     # Numerical regression for issue #2394: the column broadcast must match D*2.
     kernel = _column_broadcast_fragment_kernel(block_n)

--- a/testing/python/transform/test_tilelang_transform_layout_inference.py
+++ b/testing/python/transform/test_tilelang_transform_layout_inference.py
@@ -4,6 +4,7 @@ import tilelang as tl
 import tilelang.language as T
 import tilelang.testing
 import pytest
+import torch
 
 auto_target = tvm.target.Target(determine_target("auto"))
 
@@ -168,6 +169,70 @@ def test_static_ragged_copy_allows_1024_elements_384_threads():
     assert "B[((i * 384) + ((int)threadIdx.x))]" in kernel_source
     assert "(((int)threadIdx.x) >> 7)) < 8" in kernel_source
     assert "threadIdx.x) < 128" not in kernel_source
+
+
+@pytest.mark.parametrize("block_n", [24, 40, 48, 64, 96])
+def test_column_broadcast_fragment_tile_width_lowers(block_n):
+    # Regression for issue #2394: LayoutInference used to synthesize a zero-extent
+    # leftover iterator for non-power-of-two column broadcasts, then divide by zero.
+    m, n = 256, block_n * 4
+    block_m = 64
+
+    @T.prim_func
+    def main(D_in: T.Tensor((n,), T.bfloat16), Out: T.Tensor((m, n), T.bfloat16)):
+        with T.Kernel(T.ceildiv(n, block_n), T.ceildiv(m, block_m), threads=128) as (bx, by):
+            d_local = T.alloc_fragment((block_n,), T.float32)
+            d_shared = T.alloc_shared((block_n,), T.bfloat16)
+            x = T.alloc_fragment((block_m, block_n), T.float32)
+            xs = T.alloc_shared((block_m, block_n), T.bfloat16)
+
+            T.copy(D_in[bx * block_n], d_shared)
+            T.copy(d_shared, d_local)
+            for i, j in T.Parallel(block_m, block_n):
+                x[i, j] = d_local[j] * 2.0
+            T.copy(x, xs)
+            T.copy(xs, Out[by * block_m, bx * block_n])
+
+    with tvm.target.Target(auto_target):
+        artifact = tl.lower(main, target=auto_target, enable_device_compile=False)
+
+    assert artifact.kernel_source
+
+
+@tl.jit(out_idx=[1])
+def _column_broadcast_fragment_kernel(block_n):
+    m, n = 256, block_n * 4
+    block_m = 64
+
+    @T.prim_func
+    def main(D_in: T.Tensor((n,), T.float32), Out: T.Tensor((m, n), T.float32)):
+        with T.Kernel(T.ceildiv(n, block_n), T.ceildiv(m, block_m), threads=128) as (bx, by):
+            d_local = T.alloc_fragment((block_n,), T.float32)
+            d_shared = T.alloc_shared((block_n,), T.float32)
+            x = T.alloc_fragment((block_m, block_n), T.float32)
+            xs = T.alloc_shared((block_m, block_n), T.float32)
+
+            T.copy(D_in[bx * block_n], d_shared)
+            T.copy(d_shared, d_local)
+            for i, j in T.Parallel(block_m, block_n):
+                x[i, j] = d_local[j] * 2.0
+            T.copy(x, xs)
+            T.copy(xs, Out[by * block_m, bx * block_n])
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("block_n", [32, 48, 96])
+def test_column_broadcast_fragment_values(block_n):
+    # Numerical regression for issue #2394: the column broadcast must match D*2.
+    kernel = _column_broadcast_fragment_kernel(block_n)
+
+    d = torch.arange(block_n * 4, device="cuda", dtype=torch.float32)
+    out = kernel(d)
+    expected = d.unsqueeze(0).expand(256, -1) * 2.0
+
+    assert torch.equal(out, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
 ## Summary

  `LayoutInference` can crash with an internal `Divide by zero` when lowering a valid column-broadcast fragment access whose tile width is not a power of two.

  ```python
  d_local = T.alloc_fragment((BN,), T.float32)
  x = T.alloc_fragment((BM, BN), T.float32)

  for i, j in T.Parallel(BM, BN):
      x[i, j] = d_local[j] * 2.0
  ```

  ## Root cause

  `get_unused_iters` tracks the portion of an iterator already covered by existing `IterSplitExpr`s using:

  ```cpp
  expected_lower_factor = splits[j]->lower_factor * splits[j]->extent;
  ```

  For non-power-of-two tile widths, iter split normalization may over-approximate the covered span. For example, an iterator with extent `48` may be represented by a split span that covers up to `64`.

  The old logic only treated exact equality as full coverage:

  ```cpp
  expected_lower_factor == mark->extent
  ```

  So when the covered span became larger than the mark extent, it was treated as incomplete coverage. `get_unused_iters` then synthesized a leftover split with zero extent, which later normalized into a divide-
  by-zero.

  ## Fix

  Keep the split-chain progression intact, but treat proven over-coverage as full coverage at the final leftover check:

  ```cpp
  bool covers_full_iter =
      analyzer->CanProveEqual(expected_lower_factor, mark->extent) ||
      analyzer->CanProve(expected_lower_factor > mark->extent);
  ```

  If the consumed span is equal to or greater than the original iterator extent, there is no remaining iterator space to synthesize, so `get_unused_iters` does not emit a zero-extent leftover split.

  The fix also simplifies the newly advanced `expected_lower_factor` before the final coverage check.

  ## Tested

  - Added regression coverage in `testing/python/transform/test_tilelang_transform_layout_inference.py`:
    - host-lowering crash regression with `block_n = 24, 40, 48, 64, 96`
    - CUDA numerical regression with `block_n = 32, 48, 96`, checking that the column broadcast matches `D * 2`
  - Verified locally on a TITAN RTX host:
    - `testing/python/transform/test_tilelang_transform_layout_inference.py`
    - `testing/python/layout`

  Fixes #2394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Fixed a `LayoutInference` compile-time crash in leftover-iterator handling by treating proven over-coverage as full coverage, preventing zero-extent leftover splits that could lead to a divide-by-zero during lowering of valid non-power-of-two column-broadcast fragments (issue `#2394`).
- Added regression tests covering both lowering and CUDA numerical correctness for column-broadcast fragment kernels across several non-power-of-two `block_n` values (including newly added `24` and `40`), and verified that numerical output matches the reference broadcasted result.

## C++ style / lint notes
- This PR touches C++ layout inference logic in `src/layout/utils.cc`, so it is relevant to `docs/developer_guide/cpp_style.md`.
- No public API/FFI changes were introduced.
- The “C++ API Style Audit (warning only)” CI step should still be expected to run for this C++ change; this PR does not introduce any specific new warning-only findings based on the provided diff.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->