### PR TITLE
[Enhancement] Add vectorized fp8x2 <-> fp16/bf16 cast codegen

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -1739,9 +1739,8 @@ void CodeGenTileLangCUDA::VisitExpr_(const CastNode *op, std::ostream &os) {
     bool from_type_is_e4m3 =
         from_ty.is_float8_e4m3() || from_ty.is_float8_e4m3fn();
     // PTX cvt encodes the fp8 type in the mnemonic, so pick the helper by name.
-    std::string cast_func = from_type_is_e4m3
-                                ? "__tl_cvt_e4m3x2_to_bfloat162"
-                                : "__tl_cvt_e5m2x2_to_bfloat162";
+    std::string cast_func = from_type_is_e4m3 ? "__tl_cvt_e4m3x2_to_bfloat162"
+                                              : "__tl_cvt_e5m2x2_to_bfloat162";
     if (lanes == 2 || lanes == 4 || lanes == 8) {
       PrintVectorizedCast(cast_func, "__nv_fp8x2_storage_t", "__nv_bfloat162",
                           "", true, false);

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -1677,6 +1677,35 @@ void CodeGenTileLangCUDA::VisitExpr_(const CastNode *op, std::ostream &os) {
     }
   }
 
+  // Handle conversion from float16 to float8 (E4M3/E5M2)
+  if (from_ty.is_float16() && tl::IsCudaVectorizableFP8(target_ty)) {
+    bool target_type_is_e4m3 =
+        target_ty.is_float8_e4m3() || target_ty.is_float8_e4m3fn();
+    std::string type_suffix = target_type_is_e4m3 ? "__NV_E4M3" : "__NV_E5M2";
+    // Use __tl_cvt_half2_to_fp8x2 for vectorized conversion (half2 -> fp8x2)
+    if (lanes == 2 || lanes == 4 || lanes == 8) {
+      PrintVectorizedCast("__tl_cvt_half2_to_fp8x2", "half2",
+                          "__nv_fp8x2_storage_t", ", " + type_suffix, false,
+                          true);
+      return;
+    }
+  }
+
+  // Handle conversion from bfloat16 to float8 (E4M3/E5M2)
+  if (from_ty.is_bfloat16() && tl::IsCudaVectorizableFP8(target_ty)) {
+    bool target_type_is_e4m3 =
+        target_ty.is_float8_e4m3() || target_ty.is_float8_e4m3fn();
+    std::string type_suffix = target_type_is_e4m3 ? "__NV_E4M3" : "__NV_E5M2";
+    // Use __tl_cvt_bfloat162_to_fp8x2 for vectorized conversion (bfloat162 ->
+    // fp8x2)
+    if (lanes == 2 || lanes == 4 || lanes == 8) {
+      PrintVectorizedCast("__tl_cvt_bfloat162_to_fp8x2", "__nv_bfloat162",
+                          "__nv_fp8x2_storage_t", ", " + type_suffix, true,
+                          true);
+      return;
+    }
+  }
+
   // Handle conversion from float8 (E4M3/E5M2) to float32
   if (tl::IsCudaVectorizableFP8(from_ty) && target_ty.is_float() &&
       target_ty.bits() == 32) {
@@ -1688,6 +1717,34 @@ void CodeGenTileLangCUDA::VisitExpr_(const CastNode *op, std::ostream &os) {
     if (lanes == 2 || lanes == 4 || lanes == 8) {
       PrintVectorizedCast("__tl_cvt_fp8x2_to_float2", "__nv_fp8x2_storage_t",
                           "float2", ", " + type_suffix, true, false);
+      return;
+    }
+  }
+
+  // Handle conversion from float8 (E4M3/E5M2) to float16
+  if (tl::IsCudaVectorizableFP8(from_ty) && target_ty.is_float16()) {
+    bool from_type_is_e4m3 =
+        from_ty.is_float8_e4m3() || from_ty.is_float8_e4m3fn();
+    std::string type_suffix = from_type_is_e4m3 ? "__NV_E4M3" : "__NV_E5M2";
+    // Use __tl_cvt_fp8x2_to_half2 for vectorized conversion (fp8x2 -> half2)
+    if (lanes == 2 || lanes == 4 || lanes == 8) {
+      PrintVectorizedCast("__tl_cvt_fp8x2_to_half2", "__nv_fp8x2_storage_t",
+                          "half2", ", " + type_suffix, true, false);
+      return;
+    }
+  }
+
+  // Handle conversion from float8 (E4M3/E5M2) to bfloat16
+  if (tl::IsCudaVectorizableFP8(from_ty) && target_ty.is_bfloat16()) {
+    bool from_type_is_e4m3 =
+        from_ty.is_float8_e4m3() || from_ty.is_float8_e4m3fn();
+    // PTX cvt encodes the fp8 type in the mnemonic, so pick the helper by name.
+    std::string cast_func = from_type_is_e4m3
+                                ? "__tl_cvt_e4m3x2_to_bfloat162"
+                                : "__tl_cvt_e5m2x2_to_bfloat162";
+    if (lanes == 2 || lanes == 4 || lanes == 8) {
+      PrintVectorizedCast(cast_func, "__nv_fp8x2_storage_t", "__nv_bfloat162",
+                          "", true, false);
       return;
     }
   }

--- a/src/cuda/target_utils.cc
+++ b/src/cuda/target_utils.cc
@@ -170,6 +170,22 @@ bool IsCudaVectorizableCast(DataType from_ty, DataType target_ty) {
       target_ty.bits() == 32)
     return true;
 
+  // float8 (E4M3/E5M2) -> float16
+  if (IsCudaVectorizableFP8(from_ty) && target_ty.is_float16())
+    return true;
+
+  // float8 (E4M3/E5M2) -> bfloat16
+  if (IsCudaVectorizableFP8(from_ty) && target_ty.is_bfloat16())
+    return true;
+
+  // float16 -> float8 (E4M3/E5M2)
+  if (from_ty.is_float16() && IsCudaVectorizableFP8(target_ty))
+    return true;
+
+  // bfloat16 -> float8 (E4M3/E5M2)
+  if (from_ty.is_bfloat16() && IsCudaVectorizableFP8(target_ty))
+    return true;
+
   // Not implemented for now
 
   // float64(double) -> float8 (E4M3/E5M2)

--- a/src/tl_templates/cuda/cuda_fp8.h
+++ b/src/tl_templates/cuda/cuda_fp8.h
@@ -350,7 +350,7 @@ TL_DEVICE __nv_fp8x2_storage_t
 __tl_cvt_bfloat162_to_fp8x2(const __nv_bfloat162 src,
                             const __nv_fp8_interpretation_t fp8_interpretation) {
   __nv_bfloat162_raw raw = *reinterpret_cast<const __nv_bfloat162_raw *>(&src);
-  return __nv_cvt_bfloat162raw_to_fp8x2(raw, __NV_SATFINITE,
+  return __nv_cvt_bfloat16raw2_to_fp8x2(raw, __NV_SATFINITE,
                                         fp8_interpretation);
 }
 

--- a/src/tl_templates/cuda/cuda_fp8.h
+++ b/src/tl_templates/cuda/cuda_fp8.h
@@ -313,6 +313,47 @@ __tl_cvt_fp8x2_to_float2(const __nv_fp8x2_storage_t x,
   return result;
 }
 
+// e4m3x2 -> half2
+TL_DEVICE half2
+__tl_cvt_fp8x2_to_half2(const __nv_fp8x2_storage_t x,
+                        const __nv_fp8_interpretation_t fp8_interpretation) {
+  __half2_raw raw = __nv_cvt_fp8x2_to_halfraw2(x, fp8_interpretation);
+  return *reinterpret_cast<half2 *>(&raw);
+}
+
+// half2 -> e4m3x2
+TL_DEVICE __nv_fp8x2_storage_t
+__tl_cvt_half2_to_fp8x2(const half2 src,
+                        const __nv_fp8_interpretation_t fp8_interpretation) {
+  __half2_raw raw = *reinterpret_cast<const __half2_raw *>(&src);
+  return __nv_cvt_halfraw2_to_fp8x2(raw, __NV_SATFINITE, fp8_interpretation);
+}
+
+// e4m3x2 -> bfloat162 (PTX: cvt.rn.satfinite.bf16x2.e4m3x2)
+TL_DEVICE __nv_bfloat162
+__tl_cvt_e4m3x2_to_bfloat162(const __nv_fp8x2_storage_t x) {
+  unsigned int packed;
+  asm("cvt.rn.satfinite.bf16x2.e4m3x2 %0, %1;" : "=r"(packed) : "h"(x));
+  return *reinterpret_cast<__nv_bfloat162 *>(&packed);
+}
+
+// e5m2x2 -> bfloat162 (PTX: cvt.rn.satfinite.bf16x2.e5m2x2)
+TL_DEVICE __nv_bfloat162
+__tl_cvt_e5m2x2_to_bfloat162(const __nv_fp8x2_storage_t x) {
+  unsigned int packed;
+  asm("cvt.rn.satfinite.bf16x2.e5m2x2 %0, %1;" : "=r"(packed) : "h"(x));
+  return *reinterpret_cast<__nv_bfloat162 *>(&packed);
+}
+
+// bfloat162 -> e4m3x2
+TL_DEVICE __nv_fp8x2_storage_t
+__tl_cvt_bfloat162_to_fp8x2(const __nv_bfloat162 src,
+                            const __nv_fp8_interpretation_t fp8_interpretation) {
+  __nv_bfloat162_raw raw = *reinterpret_cast<const __nv_bfloat162_raw *>(&src);
+  return __nv_cvt_bfloat162raw_to_fp8x2(raw, __NV_SATFINITE,
+                                        fp8_interpretation);
+}
+
 // ============================================================================
 // Inline PTX FP8 Conversions with Stochastic Rounding
 // ============================================================================

--- a/src/tl_templates/cuda/cuda_fp8.h
+++ b/src/tl_templates/cuda/cuda_fp8.h
@@ -322,9 +322,8 @@ __tl_cvt_fp8x2_to_half2(const __nv_fp8x2_storage_t x,
 }
 
 // half2 -> e4m3x2
-TL_DEVICE __nv_fp8x2_storage_t
-__tl_cvt_half2_to_fp8x2(const half2 src,
-                        const __nv_fp8_interpretation_t fp8_interpretation) {
+TL_DEVICE __nv_fp8x2_storage_t __tl_cvt_half2_to_fp8x2(
+    const half2 src, const __nv_fp8_interpretation_t fp8_interpretation) {
   __half2_raw raw = *reinterpret_cast<const __half2_raw *>(&src);
   return __nv_cvt_halfraw2_to_fp8x2(raw, __NV_SATFINITE, fp8_interpretation);
 }
@@ -346,9 +345,9 @@ __tl_cvt_e5m2x2_to_bfloat162(const __nv_fp8x2_storage_t x) {
 }
 
 // bfloat162 -> e4m3x2
-TL_DEVICE __nv_fp8x2_storage_t
-__tl_cvt_bfloat162_to_fp8x2(const __nv_bfloat162 src,
-                            const __nv_fp8_interpretation_t fp8_interpretation) {
+TL_DEVICE __nv_fp8x2_storage_t __tl_cvt_bfloat162_to_fp8x2(
+    const __nv_bfloat162 src,
+    const __nv_fp8_interpretation_t fp8_interpretation) {
   __nv_bfloat162_raw raw = *reinterpret_cast<const __nv_bfloat162_raw *>(&src);
   return __nv_cvt_bfloat16raw2_to_fp8x2(raw, __NV_SATFINITE,
                                         fp8_interpretation);

--- a/testing/python/language/test_tilelang_language_vectorized_cast.py
+++ b/testing/python/language/test_tilelang_language_vectorized_cast.py
@@ -110,6 +110,13 @@ def test_vectorized_cast(src_dtype, dst_dtype, check_str, lanes):
         (T.float8_e4m3fn, T.float32, "__tl_cvt_fp8x2_to_float2", 4),
         (T.float8_e5m2, T.float32, "__tl_cvt_fp8x2_to_float2", 2),
         (T.float8_e5m2, T.float32, "__tl_cvt_fp8x2_to_float2", 4),
+        # FP8 <-> Half
+        (T.float8_e4m3fn, T.float16, "__tl_cvt_fp8x2_to_half2", 2),
+        (T.float8_e4m3fn, T.float16, "__tl_cvt_fp8x2_to_half2", 4),
+        (T.float8_e5m2, T.float16, "__tl_cvt_fp8x2_to_half2", 2),
+        (T.float16, T.float8_e4m3fn, "__tl_cvt_half2_to_fp8x2", 2),
+        (T.float16, T.float8_e4m3fn, "__tl_cvt_half2_to_fp8x2", 4),
+        (T.float16, T.float8_e5m2, "__tl_cvt_half2_to_fp8x2", 2),
         # E8M0 <-> BFloat16
         (T.float8_e8m0fnu, T.bfloat16, "__tl_cvt_e8m0x2_to_bfloat162", 2),
         (T.bfloat16, T.float8_e8m0fnu, "__tl_cvt_bfloat162_to_e8m0x2", 2),
@@ -143,6 +150,24 @@ def test_vectorized_cast_fp8(src_dtype, dst_dtype, check_str, lanes):
     ],
 )
 def test_vectorized_cast_fp4(src_dtype, dst_dtype, check_str, lanes):
+    run_vectorized_cast(src_dtype, dst_dtype, check_str, lanes)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(10, 0)
+@pytest.mark.parametrize(
+    "src_dtype, dst_dtype, check_str, lanes",
+    [
+        # FP8 <-> BFloat16 (PTX cvt, Blackwell+)
+        (T.float8_e4m3fn, T.bfloat16, "__tl_cvt_e4m3x2_to_bfloat162", 2),
+        (T.float8_e4m3fn, T.bfloat16, "__tl_cvt_e4m3x2_to_bfloat162", 4),
+        (T.float8_e5m2, T.bfloat16, "__tl_cvt_e5m2x2_to_bfloat162", 2),
+        (T.bfloat16, T.float8_e4m3fn, "__tl_cvt_bfloat162_to_fp8x2", 2),
+        (T.bfloat16, T.float8_e4m3fn, "__tl_cvt_bfloat162_to_fp8x2", 4),
+        (T.bfloat16, T.float8_e5m2, "__tl_cvt_bfloat162_to_fp8x2", 2),
+    ],
+)
+def test_vectorized_cast_fp8_bf16(src_dtype, dst_dtype, check_str, lanes):
     run_vectorized_cast(src_dtype, dst_dtype, check_str, lanes)
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Added vectorized FP8 cast codegen for FP16/BF16 ↔ FP8 paths in CUDA, including lane-aware FP8 x2 helpers for e4m3/e5m2 variants.
- Extended CUDA cast-vectorizability detection so the new FP8 ↔ FP16/BF16 conversions are recognized as vectorizable.
- Added CUDA FP8 helper intrinsics for half2/bfloat162 ↔ fp8x2 conversions.
- Expanded Python coverage for vectorized FP8 casts and added CUDA-only BF16 ↔ FP8 test cases.

## C++ style / lint notes
- This PR touches C++ code and CUDA template headers, so it is relevant to the rules in `docs/developer_guide/cpp_style.md`.
- The changes are in the area covered by the “C++ API Style Audit (warning only)” CI step; any findings there should be treated as style warnings unless they point to a real API/FFI risk.
- No correctness or build issues are indicated by the summary; style-only warnings, if any, should be reviewed but are not merge-blocking by themselves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->