### PR TITLE
???????????????

### DIFF
--- a/testing/python/target/test_tilelang_target.py
+++ b/testing/python/target/test_tilelang_target.py
@@ -15,7 +15,9 @@ from tilelang.backend.target import (
     auto_detect_target,
     determine_target,
     list_target_detectors,
+    list_target_normalizers,
     register_target_detector,
+    register_target_normalizer,
 )
 
 
@@ -106,6 +108,19 @@ def test_auto_target_detector_falls_through_none_result():
     finally:
         target_registry._TARGET_DETECTORS.clear()
         target_registry._TARGET_DETECTORS.update(old_detectors)
+
+
+def test_target_normalizer_registry_lists_registered_names():
+    name = "unit-normalizer-list"
+    old_normalizers = dict(target_registry._TARGET_NORMALIZERS)
+    try:
+        target_registry._TARGET_NORMALIZERS.clear()
+        register_target_normalizer(name, lambda target: None, override=True)
+
+        assert list_target_normalizers() == (name,)
+    finally:
+        target_registry._TARGET_NORMALIZERS.clear()
+        target_registry._TARGET_NORMALIZERS.update(old_normalizers)
 
 
 def test_execution_backend_registry_resolves_target_policy():

--- a/tilelang/backend/__init__.py
+++ b/tilelang/backend/__init__.py
@@ -29,6 +29,7 @@ from .execution_backend import (  # noqa: F401
 from .target import (  # noqa: F401
     auto_detect_target,
     list_target_detectors,
+    list_target_normalizers,
     register_target_detector,
     register_target_normalizer,
 )

--- a/tilelang/backend/target.py
+++ b/tilelang/backend/target.py
@@ -82,6 +82,10 @@ def list_target_detectors() -> tuple[str, ...]:
     return tuple(_TARGET_DETECTORS)
 
 
+def list_target_normalizers() -> tuple[str, ...]:
+    return tuple(_TARGET_NORMALIZERS)
+
+
 def _validate_manual_target(target: TargetLike) -> TargetInput:
     normalized = _normalize_registered_target(target)
     if normalized is not None:


### PR DESCRIPTION
?? PR ? TileLang ??????????? `list_target_normalizers()`?? CUDA?HIP ?????? CUDA-like ????????????????????????????????????????????????????????? `tilelang.backend`?????? target detection/normalization ??????????????????????????????? C500 / PyTorch-MACA / TileLang-MetaX ??????????? `py_compile`?`git diff --check`?TVM Target ????????????? `torch.cuda` ????? `mx-smi` ????????????? TileLang-MetaX ? TVM ??????????? `tvm.tirx`????? `import tilelang` ?????????????????????????

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR exposes the target normalizer registry through a new `list_target_normalizers()` API in `tilelang.backend` and `tilelang.backend.target`.

- Adds `list_target_normalizers()` to return the registered normalizer names as a tuple.
- Re-exports the new helper from `tilelang/backend/__init__.py` for public access.
- Extends target registry tests to cover registering a normalizer and verifying the listing API returns the expected name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->