### PR TITLE
????????????????

### DIFF
--- a/testing/python/target/test_tilelang_target.py
+++ b/testing/python/target/test_tilelang_target.py
@@ -16,6 +16,9 @@ from tilelang.backend.target import (
     determine_target,
     list_target_detectors,
     register_target_detector,
+    register_target_normalizer,
+    unregister_target_detector,
+    unregister_target_normalizer,
 )
 
 
@@ -106,6 +109,31 @@ def test_auto_target_detector_falls_through_none_result():
     finally:
         target_registry._TARGET_DETECTORS.clear()
         target_registry._TARGET_DETECTORS.update(old_detectors)
+
+
+def test_target_registry_unregister_removes_specs():
+    detector_name = "unit-detector-remove"
+    normalizer_name = "unit-normalizer-remove"
+    old_detectors = dict(target_registry._TARGET_DETECTORS)
+    old_normalizers = dict(target_registry._TARGET_NORMALIZERS)
+    try:
+        register_target_detector(detector_name, lambda: "llvm", override=True)
+        register_target_normalizer(normalizer_name, lambda target: None, override=True)
+
+        detector_spec = unregister_target_detector(detector_name)
+        normalizer_spec = unregister_target_normalizer(normalizer_name)
+
+        assert detector_spec is not None
+        assert detector_spec.name == detector_name
+        assert normalizer_spec is not None
+        assert normalizer_spec.name == normalizer_name
+        assert unregister_target_detector(detector_name) is None
+        assert unregister_target_normalizer(normalizer_name) is None
+    finally:
+        target_registry._TARGET_DETECTORS.clear()
+        target_registry._TARGET_DETECTORS.update(old_detectors)
+        target_registry._TARGET_NORMALIZERS.clear()
+        target_registry._TARGET_NORMALIZERS.update(old_normalizers)
 
 
 def test_execution_backend_registry_resolves_target_policy():

--- a/tilelang/backend/__init__.py
+++ b/tilelang/backend/__init__.py
@@ -31,6 +31,8 @@ from .target import (  # noqa: F401
     list_target_detectors,
     register_target_detector,
     register_target_normalizer,
+    unregister_target_detector,
+    unregister_target_normalizer,
 )
 
 register_lazy_execution_backends("cuda", "tilelang.cuda.execution_backend")

--- a/tilelang/backend/target.py
+++ b/tilelang/backend/target.py
@@ -42,6 +42,10 @@ def register_target_detector(
     return spec
 
 
+def unregister_target_detector(name: str) -> TargetDetectorSpec | None:
+    return _TARGET_DETECTORS.pop(name, None)
+
+
 def register_target_normalizer(
     name: str,
     normalize: TargetNormalizer,
@@ -53,6 +57,10 @@ def register_target_normalizer(
     spec = TargetNormalizerSpec(name=name, normalize=normalize)
     _TARGET_NORMALIZERS[name] = spec
     return spec
+
+
+def unregister_target_normalizer(name: str) -> TargetNormalizerSpec | None:
+    return _TARGET_NORMALIZERS.pop(name, None)
 
 
 def _normalize_registered_target(target: TargetLike) -> TargetInput | None:


### PR DESCRIPTION
?? PR ? target detector ? target normalizer ???????? unregister API????????????????????????????????? GPU ???????????? detector/normalizer ?????????????????????????????????????????????? spec??????? `None`???????????????? spec ????????? C500 / PyTorch-MACA / TileLang-MetaX ????? `py_compile`?`git diff --check`?TVM Target ?????????? `torch.cuda` ????? `mx-smi` ????????? import ??? TVM ? `tvm.tirx` ??????? PR ??????

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Added `unregister_target_detector` and `unregister_target_normalizer` helpers to remove entries from the target registry.
- Re-exported the new unregister APIs from `tilelang.backend`.
- Added a regression test covering unregister behavior, including repeated unregister calls returning `None`.

## Testing
- Added coverage for registry unregister semantics in `testing/python/target/test_tilelang_target.py`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->