### PR TITLE
???????????

### DIFF
--- a/testing/python/components/test_tilelang_env.py
+++ b/testing/python/components/test_tilelang_env.py
@@ -1,5 +1,6 @@
 import os
 
+import pytest
 import tilelang
 
 
@@ -59,3 +60,29 @@ def test_tilelang_tmp_dir_default_tracks_cache_dir(monkeypatch, tmp_path):
     finally:
         _restore_forced_value("TILELANG_CACHE_DIR", original_cache_forced_value)
         _restore_forced_value("TILELANG_TMP_DIR", original_tmp_forced_value)
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", " yes ", "On"])
+def test_env_bool_helpers_accept_common_truthy_values(monkeypatch, value):
+    desc = _env_var_descriptor("TILELANG_VERBOSE")
+    original_forced_value = desc._forced_value
+    _restore_forced_value("TILELANG_VERBOSE", None)
+
+    try:
+        monkeypatch.setenv("TILELANG_VERBOSE", value)
+        assert tilelang.env.get_default_verbose() is True
+    finally:
+        _restore_forced_value("TILELANG_VERBOSE", original_forced_value)
+
+
+@pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+def test_env_bool_helpers_reject_common_false_values(monkeypatch, value):
+    desc = _env_var_descriptor("TILELANG_VERBOSE")
+    original_forced_value = desc._forced_value
+    _restore_forced_value("TILELANG_VERBOSE", None)
+
+    try:
+        monkeypatch.setenv("TILELANG_VERBOSE", value)
+        assert tilelang.env.get_default_verbose() is False
+    finally:
+        _restore_forced_value("TILELANG_VERBOSE", original_forced_value)

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -310,6 +310,10 @@ def _parse_target_config(value: str) -> TargetConfig | None:
     return dict(parsed)
 
 
+def _env_flag_enabled(value: object) -> bool:
+    return str(value).strip().lower() in ("1", "true", "yes", "on")
+
+
 # Utility function for environment variables with defaults
 # Assuming EnvVar and CacheState are defined elsewhere
 class Environment:
@@ -398,22 +402,22 @@ class Environment:
         CacheState.disable()
 
     def is_cache_globally_disabled(self) -> bool:
-        return self.TILELANG_DISABLE_CACHE.lower() in ("1", "true", "yes", "on")
+        return _env_flag_enabled(self.TILELANG_DISABLE_CACHE)
 
     def should_use_kernel_cache_lib_stamp(self) -> bool:
-        return str(self.TILELANG_KERNEL_CACHE_USE_LIB_STAMP).lower() in ("1", "true", "yes", "on")
+        return _env_flag_enabled(self.TILELANG_KERNEL_CACHE_USE_LIB_STAMP)
 
     def is_autotune_cache_disabled(self) -> bool:
-        return self.TILELANG_AUTO_TUNING_DISABLE_CACHE.lower() in ("1", "true", "yes", "on")
+        return _env_flag_enabled(self.TILELANG_AUTO_TUNING_DISABLE_CACHE)
 
     def is_print_on_compilation_enabled(self) -> bool:
-        return self.TILELANG_PRINT_ON_COMPILATION.lower() in ("1", "true", "yes", "on")
+        return _env_flag_enabled(self.TILELANG_PRINT_ON_COMPILATION)
 
     def should_cleanup_temp_files(self) -> bool:
-        return str(self.TILELANG_CLEANUP_TEMP_FILES).lower() in ("1", "true", "yes", "on")
+        return _env_flag_enabled(self.TILELANG_CLEANUP_TEMP_FILES)
 
     def is_jit_diagnostics_enabled(self) -> bool:
-        return str(self.TILELANG_JIT_DIAGNOSTICS).lower() in ("1", "true", "yes", "on")
+        return _env_flag_enabled(self.TILELANG_JIT_DIAGNOSTICS)
 
     def get_compile_timeout_seconds(self) -> float | None:
         value = str(self.TILELANG_COMPILE_TIMEOUT_SECONDS).strip()
@@ -455,7 +459,7 @@ class Environment:
 
     def get_default_verbose(self) -> bool:
         """Get default verbose flag from environment."""
-        return self.TILELANG_DEFAULT_VERBOSE.lower() in ("1", "true", "yes", "on")
+        return _env_flag_enabled(self.TILELANG_DEFAULT_VERBOSE)
 
     def is_running_autodd(self) -> bool:
         """Return True if we are running under `python -m tilelang.autodd`."""


### PR DESCRIPTION
?? PR ?? TileLang ??????????????????? CI ???????????????????????? `TILELANG_VERBOSE=" yes "` ????????????????? `_env_flag_enabled()`????????JIT diagnostics????????????????? `strip + lower` ???????????? API??????? truthy/falsey ??????? C500 / PyTorch-MACA / TileLang-MetaX ????? `py_compile`?`git diff --check`???????????? `torch.cuda` ????? `mx-smi` ?????

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Normalized boolean environment-flag parsing in `tilelang/env.py` by adding a shared helper that trims whitespace and compares case-insensitively.
- Updated several `Environment` boolean accessors to use the shared parsing path, including verbose/JIT diagnostics and cache/temp-file related flags.
- Added tests covering `TILELANG_VERBOSE` truthy and falsey values, including whitespace-padded inputs.

## C++ style / lint notes
- This PR does not appear to modify `docs/developer_guide/cpp_style.md`.
- No C++ API Style Audit warnings are directly introduced by the shown changes.
- Changes are limited to Python env handling and tests, so there are no C++ build or FFI concerns from this PR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->