### PR TITLE
?? TileLang ???? JSON ??

### DIFF
--- a/testing/python/tools/test_env_report.py
+++ b/testing/python/tools/test_env_report.py
@@ -1,0 +1,41 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_env_report():
+    module_path = Path(__file__).resolve().parents[3] / "tilelang" / "tools" / "env_report.py"
+    spec = importlib.util.spec_from_file_location("unit_env_report", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_collect_env_report_includes_tilelang_and_selected_env(monkeypatch):
+    env = types.SimpleNamespace(
+        CUDA_HOME="/opt/cuda",
+        ROCM_HOME="",
+        get_default_target=lambda: {"kind": "cuda", "arch": "sm_90"},
+        get_default_execution_backend=lambda: "auto",
+        get_default_verbose=lambda: True,
+    )
+    tilelang_module = types.ModuleType("tilelang")
+    tilelang_module.env = env
+    target_module = types.ModuleType("tilelang.backend.target")
+    target_module.list_target_detectors = lambda: ("cuda", "hip")
+
+    monkeypatch.setitem(sys.modules, "tilelang", tilelang_module)
+    monkeypatch.setitem(sys.modules, "tilelang.backend", types.ModuleType("tilelang.backend"))
+    monkeypatch.setitem(sys.modules, "tilelang.backend.target", target_module)
+    monkeypatch.setenv("TILELANG_DEFAULT_TARGET", '{kind: "cuda", arch: "sm_90"}')
+    monkeypatch.setenv("MACA_HOME", "/opt/maca")
+
+    report = _load_env_report().collect_env_report(extra_env_keys=["MACA_HOME"])
+
+    assert report["tilelang"]["cuda_home"] == "/opt/cuda"
+    assert report["tilelang"]["default_target"] == {"kind": "cuda", "arch": "sm_90"}
+    assert report["tilelang"]["target_detectors"] == ["cuda", "hip"]
+    assert report["environment"]["TILELANG_DEFAULT_TARGET"] == '{kind: "cuda", arch: "sm_90"}'
+    assert report["environment"]["MACA_HOME"] == "/opt/maca"

--- a/tilelang/tools/env_report.py
+++ b/tilelang/tools/env_report.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import sys
+from collections.abc import Iterable
+
+
+def _selected_env(keys: Iterable[str]) -> dict[str, str]:
+    return {key: os.environ[key] for key in keys if key in os.environ}
+
+
+def collect_env_report(extra_env_keys: Iterable[str] = ()) -> dict[str, object]:
+    from tilelang import env as tilelang_env
+    from tilelang.backend.target import list_target_detectors
+
+    env_keys = [
+        "CUDA_HOME",
+        "CUDA_PATH",
+        "ROCM_HOME",
+        "ROCM_PATH",
+        "TILELANG_DEFAULT_TARGET",
+        "TILELANG_EXECUTION_BACKEND",
+        "TILELANG_VERBOSE",
+        "TILELANG_CACHE_DIR",
+        "TILELANG_TMP_DIR",
+        *extra_env_keys,
+    ]
+    return {
+        "python": sys.version.replace("\n", ""),
+        "platform": platform.platform(),
+        "tilelang": {
+            "cuda_home": tilelang_env.CUDA_HOME,
+            "rocm_home": tilelang_env.ROCM_HOME,
+            "default_target": tilelang_env.get_default_target(),
+            "default_execution_backend": tilelang_env.get_default_execution_backend(),
+            "verbose": tilelang_env.get_default_verbose(),
+            "target_detectors": list(list_target_detectors()),
+        },
+        "environment": _selected_env(env_keys),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Print a JSON TileLang environment report.")
+    parser.add_argument(
+        "--env",
+        action="append",
+        default=[],
+        help="Additional environment variable key to include. Can be passed multiple times.",
+    )
+    args = parser.parse_args(argv)
+    print(json.dumps(collect_env_report(args.env), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
?? PR ?? `tilelang.tools.env_report`???????? JSON ??????? Python??????TileLang ?? target?execution backend???? target detector ?? CUDA/ROCm/TileLang ????????????? GPU ????????????????????? shell?Python ?????????????????????? target ??????????????????????? `collect_env_report()` ? `python -m tilelang.tools.env_report` CLI???????????????????????????????? C500 / PyTorch-MACA / TileLang-MetaX ????? `pytest testing/python/tools/test_env_report.py -q`?`py_compile`?`git diff --check`??? `torch.cuda` ????? `mx-smi` ???????? TVM ??? `tvm.tirx`????? CLI ??? import ????????????????????????????

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Added a new `tilelang.tools.env_report` utility that emits a JSON environment report for TileLang debugging.

- Introduces `collect_env_report()` to gather:
  - host environment variables (with optional extra keys)
  - Python/platform details
  - TileLang CUDA/ROCm-related settings
  - default target / execution backend / verbose configuration
  - detected target detectors
- Adds a CLI entry point via `python -m tilelang.tools.env_report`
  - supports `--env` for extra environment keys
  - prints pretty-printed, sorted JSON to stdout
- Adds tests covering:
  - dynamic loading of the new module
  - inclusion of TileLang fields
  - inclusion of selected env vars such as `MACA_HOME` and `TILELANG_DEFAULT_TARGET`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->