### PR TITLE
[BugFix][CUDA] Fix signed int4 LOP3 decode

### DIFF
--- a/testing/python/issue/test_tilelang_lop3_i4s_decode.py
+++ b/testing/python/issue/test_tilelang_lop3_i4s_decode.py
@@ -1,0 +1,102 @@
+"""Regression coverage for signed int4 LOP3 decode."""
+
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.quantize import _tir_packed_int_to_int_convert, get_lop3_intrin_group
+from tilelang.quantize.utils import interleave_weight
+
+
+N = 16
+K = 16
+NUM_BITS = 4
+STORAGE = T.int8
+IN_DTYPE = T.int8
+ELEMS_PER_BYTE = 8 // NUM_BITS
+K_PACKED = K // ELEMS_PER_BYTE
+
+
+def _build_scalar_signed_decode():
+    @T.prim_func
+    def main(B: T.Tensor((N, K_PACKED), STORAGE), D: T.Tensor((N, K), IN_DTYPE)):
+        with T.Kernel(N, threads=32) as bx:
+            B_local = T.alloc_local([K_PACKED], STORAGE)
+            for v in T.serial(K_PACKED):
+                B_local[v] = B[bx, v]
+            for ki in T.serial(K):
+                D[bx, ki] = _tir_packed_int_to_int_convert("int", 8)(NUM_BITS, B_local[ki // ELEMS_PER_BYTE], ki % ELEMS_PER_BYTE, IN_DTYPE)
+
+    return main
+
+
+def _build_lop3_decode(source_format):
+    lop3 = get_lop3_intrin_group(
+        out_dtype=IN_DTYPE,
+        source_format=source_format,
+        source_bit=NUM_BITS,
+        storage_dtype=STORAGE,
+        with_scaling=False,
+        with_zeros=False,
+    )
+    source = lop3["c_source"]
+    func_name = lop3["func_name"]
+    group = 16
+    group_bytes = group // ELEMS_PER_BYTE
+
+    @T.prim_func
+    def main(B: T.Tensor((N, K_PACKED), STORAGE), D: T.Tensor((N, K), IN_DTYPE)):
+        with T.Kernel(N, threads=32) as bx:
+            B_local = T.alloc_local([group_bytes], STORAGE)
+            D_local = T.alloc_local([group], IN_DTYPE)
+            T.import_source(source)
+            for g in T.serial(K // group):
+                for v in T.vectorized(group_bytes):
+                    B_local[v] = B[bx, g * group_bytes + v]
+                T.evaluate(T.call_extern("handle", func_name, T.access_ptr(B_local, "r"), T.access_ptr(D_local, "w")))
+                for v in T.serial(group):
+                    D[bx, g * group + v] = D_local[v]
+
+    return main
+
+
+def _pack_repeated_nibbles() -> torch.Tensor:
+    nibbles = torch.arange(16, dtype=torch.uint8).repeat(N, 1)
+    packed = nibbles[:, ::2] | (nibbles[:, 1::2] << 4)
+    return packed.contiguous().view(torch.int8).cuda()
+
+
+def _unpack_int4(qweight: torch.Tensor, signed: bool) -> torch.Tensor:
+    qweight = qweight.to(torch.uint8)
+    low = (qweight & 0x0F).to(torch.int8)
+    high = (qweight >> 4).to(torch.int8)
+    if signed:
+        low = (low << 4) >> 4
+        high = (high << 4) >> 4
+    return torch.stack((low, high), dim=-1).reshape(qweight.shape[0], qweight.shape[1] * 2)
+
+
+@tilelang.testing.requires_cuda
+def test_lop3_i4s_to_i8s_matches_scalar_signed_decode():
+    qweight = _pack_repeated_nibbles()
+    expected_signed = _unpack_int4(qweight, signed=True)
+    expected_unsigned = _unpack_int4(qweight, signed=False)
+
+    scalar_kernel = tilelang.compile(_build_scalar_signed_decode(), target="cuda", out_idx=[1])
+    scalar = scalar_kernel(qweight)
+    torch.testing.assert_close(scalar, expected_signed, rtol=0, atol=0)
+
+    lop3_signed_kernel = tilelang.compile(_build_lop3_decode(T.int), target="cuda", out_idx=[1])
+    qweight_interleaved = interleave_weight(qweight.clone(), NUM_BITS, "int8")
+    lop3_signed = lop3_signed_kernel(qweight_interleaved)
+    torch.testing.assert_close(lop3_signed, scalar, rtol=0, atol=0)
+    torch.testing.assert_close(lop3_signed, expected_signed, rtol=0, atol=0)
+
+    lop3_unsigned_kernel = tilelang.compile(_build_lop3_decode(T.uint), target="cuda", out_idx=[1])
+    lop3_unsigned = lop3_unsigned_kernel(qweight_interleaved)
+    torch.testing.assert_close(lop3_unsigned, expected_unsigned, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/quantize/lop3.py
+++ b/tilelang/quantize/lop3.py
@@ -1005,7 +1005,8 @@ __device__ void decode_i4s_to_i8s(T1 *_i4b, T2 *_i8s, const int N = 16)
     static constexpr uint immLut = (0xf0 & 0xcc) | 0xaa;
     static constexpr uint BOTTOM_MASK = 0x0f0f0f0f;          // 0xf -> 0b1111 select 0,4,8,12
     static constexpr uint I4b_TO_I8s_MAGIC_NUM = 0x00000000; // 0
-    static constexpr uint MEDIAN_NUM = 0x07070707;
+    static constexpr uint SIGN_BIT = 0x08080808;
+    static constexpr uint MEDIAN_NUM = 0x08080808;
 #pragma unroll
     for (int i = 0; i < (N / 8); i++)
     {
@@ -1017,8 +1018,8 @@ __device__ void decode_i4s_to_i8s(T1 *_i4b, T2 *_i8s, const int N = 16)
         asm volatile("lop3.b32 %0, %1, %2, %3, %4;\\n"
                      : "=r"(i8s[i + 2])
                      : "r"(i4b[1] >> (4 * i)), "n"(BOTTOM_MASK), "n"(I4b_TO_I8s_MAGIC_NUM), "n"(immLut));
-        i8s[i] = __vsubss4(i8s[i], MEDIAN_NUM);
-        i8s[i + 2] = __vsubss4(i8s[i + 2], MEDIAN_NUM);
+        i8s[i] = __vsubss4(i8s[i] ^ SIGN_BIT, MEDIAN_NUM);
+        i8s[i + 2] = __vsubss4(i8s[i + 2] ^ SIGN_BIT, MEDIAN_NUM);
     }
 }
 


### PR DESCRIPTION
Fixes #2477

## Summary
- Fix signed int4 to int8 LOP3 decode so it matches scalar two-complement int-to-int conversion.
- Replace the previous bias-7 subtract with `(nibble ^ 8) - 8` per unpacked byte.
- Keep the unsigned LOP3 decode path unchanged.
- Add CUDA regression coverage for all 16 int4 nibble values against scalar and Python reference outputs.

## Problem
The signed int4 LOP3 fast path extracted raw unsigned nibbles and subtracted `7`, producing a bias-7 range of `[-7, 8]`.

That silently disagreed with the scalar `_tir_packed_int_to_int_convert("int", 8)` path, which sign-extends packed int4 values as two-complement values in `[-8, 7]`.

## Fix
The signed LOP3 int4 decoder now computes `(nibble ^ 8) - 8` after extracting each nibble into an int8 lane. This converts the raw nibble to the same signed value as scalar sign extension while preserving the LOP3 extraction layout and leaving the unsigned decoder untouched.

## Regression Test
The new test covers every int4 nibble value and verifies:

- scalar signed decode matches a two-complement Python reference;
- signed LOP3 decode matches the scalar signed decode;
- unsigned LOP3 decode still matches unsigned nibble unpacking.

## Validation
- `pre-commit run --files tilelang/quantize/lop3.py testing/python/issue/test_tilelang_lop3_i4s_decode.py`
- Remote CUDA: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest testing/python/issue/test_tilelang_lop3_i4s_decode.py -q -s` passed

Co-authored-by: dingsg <shengge.ding@enflame-tech.com>
