### PR TITLE
[Env] Require JSON for default target config

### DIFF
--- a/docs/get_started/targets.md
+++ b/docs/get_started/targets.md
@@ -57,12 +57,12 @@ the default is `auto`.
 export TILELANG_DEFAULT_TARGET=cuda
 ```
 
-For target options, use a dict-like string. This is useful in scripts that rely on the default target through
+For target options, use a JSON object string. This is useful in scripts that rely on the default target through
 `tilelang.compile(..., target=None)`, `@tilelang.jit`, or autotuning:
 
 ```bash
-export TILELANG_DEFAULT_TARGET='{kind: "cuda", arch: "sm_90"}'
-export TILELANG_DEFAULT_TARGET='{kind: "cuda", arch: "sm_100f", code: ["sm_100a", "sm_103a"]}'
+export TILELANG_DEFAULT_TARGET='{"kind": "cuda", "arch": "sm_90"}'
+export TILELANG_DEFAULT_TARGET='{"kind": "cuda", "arch": "sm_100f", "code": ["sm_100a", "sm_103a"]}'
 ```
 
 In Python code, prefer passing a real dictionary instead of a string:

--- a/testing/python/target/test_tilelang_target.py
+++ b/testing/python/target/test_tilelang_target.py
@@ -23,14 +23,21 @@ def test_tilelang_does_not_export_target_wrapper():
     assert not hasattr(tilelang, "Target")
 
 
-def test_default_target_env_accepts_dict_like_string(monkeypatch):
-    monkeypatch.setenv("TILELANG_DEFAULT_TARGET", '{kind: "cuda", "arch": "sm_100f", code: ["sm_100a", "sm_103a"]}')
+def test_default_target_env_accepts_json_string(monkeypatch):
+    monkeypatch.setenv("TILELANG_DEFAULT_TARGET", '{"kind": "cuda", "arch": "sm_100f", "code": ["sm_100a", "sm_103a"]}')
 
     assert tilelang.env.get_default_target() == {
         "kind": "cuda",
         "arch": "sm_100f",
         "code": ["sm_100a", "sm_103a"],
     }
+
+
+def test_default_target_env_rejects_unquoted_json_keys(monkeypatch):
+    monkeypatch.setenv("TILELANG_DEFAULT_TARGET", '{kind: "cuda", arch: "sm_100f"}')
+
+    with pytest.raises(ValueError, match="Use JSON syntax"):
+        tilelang.env.get_default_target()
 
 
 def test_default_target_env_keeps_plain_string(monkeypatch):

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -298,7 +298,7 @@ class AutoTuner:
             pass_configs: Additional keyword arguments to pass to the Compiler PassContext.
 
         Environment Variables:
-            TILELANG_DEFAULT_TARGET: Default compilation target (e.g., "cuda", "llvm", or a dict-like
+            TILELANG_DEFAULT_TARGET: Default compilation target (e.g., "cuda", "llvm", or a JSON
                 target config string). Defaults to "auto".
             TILELANG_EXECUTION_BACKEND: Default execution backend. Defaults to "auto".
             TILELANG_VERBOSE: Set to "1", "true", "yes", or "on" to enable verbose compilation by default.

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -305,7 +305,7 @@ class KernelCache:
         Environment Variables
         ---------------------
         TILELANG_DEFAULT_TARGET : str
-            Default compilation target (e.g., "cuda", "llvm", or a dict-like target config string).
+            Default compilation target (e.g., "cuda", "llvm", or a JSON target config string).
             Defaults to "auto".
         TILELANG_EXECUTION_BACKEND : str
             Default execution backend. Defaults to "auto".

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
-import ast
 import importlib.metadata
+import json
 import math
-import re
 import sys
 import os
 import pathlib
@@ -296,12 +295,11 @@ def _parse_target_config(value: str) -> TargetConfig | None:
     if not value.startswith("{"):
         return None
 
-    key_re = re.compile(r"([{\[,]\s*)([A-Za-z_][A-Za-z0-9_]*)(\s*:)")
     try:
-        parsed = ast.literal_eval(key_re.sub(r'\1"\2"\3', value))
-    except (ValueError, SyntaxError) as err:
+        parsed = json.loads(value)
+    except json.JSONDecodeError as err:
         raise ValueError(
-            'TILELANG_DEFAULT_TARGET looks like a dict but could not be parsed. Use syntax like {kind: "cuda", arch: "sm_100"}.'
+            'TILELANG_DEFAULT_TARGET looks like a dict but could not be parsed. Use JSON syntax like {"kind": "cuda", "arch": "sm_100"}.'
         ) from err
     if not isinstance(parsed, dict):
         raise ValueError("TILELANG_DEFAULT_TARGET must parse to a dict")

--- a/tilelang/jit/__init__.py
+++ b/tilelang/jit/__init__.py
@@ -126,7 +126,7 @@ def compile(
     Environment Variables
     ---------------------
     TILELANG_DEFAULT_TARGET : str
-        Default compilation target (e.g., "cuda", "llvm", or a dict-like target config string).
+        Default compilation target (e.g., "cuda", "llvm", or a JSON target config string).
         Defaults to "auto".
     TILELANG_EXECUTION_BACKEND : str
         Default execution backend. Defaults to "auto".
@@ -210,7 +210,7 @@ def par_compile(
     Environment Variables
     ---------------------
     TILELANG_DEFAULT_TARGET : str
-        Default compilation target (e.g., "cuda", "llvm", or a dict-like target config string).
+        Default compilation target (e.g., "cuda", "llvm", or a JSON target config string).
         Defaults to "auto".
     TILELANG_EXECUTION_BACKEND : str
         Default execution backend. Defaults to "auto".


### PR DESCRIPTION
## Summary

- Require `TILELANG_DEFAULT_TARGET` object values to use valid JSON instead of dict-like shorthand.
- Align tests, docs, and API docstrings with the JSON environment variable contract.

## Changes

- Parse target config environment values with `json.loads` and report a JSON-specific parse hint.
- Keep plain string targets such as `cuda` unchanged.
- Update target tests to accept quoted JSON keys and reject unquoted key shorthand.
- Update target documentation and docstrings to show JSON object examples.

## Validation

- `pre-commit run --all-files`
- `python -m pytest testing/python/target/test_tilelang_target.py -x`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary
- Changed `TILELANG_DEFAULT_TARGET` parsing to require valid JSON for object-valued target configuration, while keeping plain string targets like `cuda` unchanged.
- Updated the default-target parsing logic to use `json.loads` and return a JSON-specific hint when parsing fails.
- Adjusted target tests to accept quoted JSON keys and reject unquoted shorthand.
- Aligned docs and public docstrings with the JSON-based environment variable format.

### Validation
- `pre-commit run --all-files`
- `python -m pytest testing/python/target/test_tilelang_target.py -x`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->