### PR TITLE
[BugFix][CUDA] Use PTX v4 atomics for fp16/bf16 atomic_addx4

### DIFF
--- a/src/tl_templates/cuda/atomic.h
+++ b/src/tl_templates/cuda/atomic.h
@@ -168,6 +168,72 @@ TL_DEVICE void tl_atomic_add_v2_bf16(unsigned short &ret_x,
   }
 }
 
+TL_DEVICE void
+tl_atomic_add_v4_f16(unsigned short &ret_x, unsigned short &ret_y,
+                     unsigned short &ret_z, unsigned short &ret_w,
+                     unsigned long long addr, unsigned short val_x,
+                     unsigned short val_y, unsigned short val_z,
+                     unsigned short val_w, int memory_order) {
+  if (IsRelaxedMemoryOrder(memory_order)) {
+    asm volatile(
+        "atom.global.v4.f16.add.noftz {%0,%1,%2,%3}, [%4], {%5,%6,%7,%8};"
+        : "=h"(ret_x), "=h"(ret_y), "=h"(ret_z), "=h"(ret_w)
+        : "l"(addr), "h"(val_x), "h"(val_y), "h"(val_z), "h"(val_w)
+        : "memory");
+  } else if (IsReleaseLikeMemoryOrder(memory_order)) {
+    asm volatile("atom.release.gpu.global.v4.f16.add.noftz {%0,%1,%2,%3}, "
+                 "[%4], {%5,%6,%7,%8};"
+                 : "=h"(ret_x), "=h"(ret_y), "=h"(ret_z), "=h"(ret_w)
+                 : "l"(addr), "h"(val_x), "h"(val_y), "h"(val_z), "h"(val_w)
+                 : "memory");
+  } else if (IsAcquireMemoryOrder(memory_order)) {
+    asm volatile("atom.acquire.gpu.global.v4.f16.add.noftz {%0,%1,%2,%3}, "
+                 "[%4], {%5,%6,%7,%8};"
+                 : "=h"(ret_x), "=h"(ret_y), "=h"(ret_z), "=h"(ret_w)
+                 : "l"(addr), "h"(val_x), "h"(val_y), "h"(val_z), "h"(val_w)
+                 : "memory");
+  } else if (IsAcqRelLikeMemoryOrder(memory_order)) {
+    asm volatile("atom.acq_rel.gpu.global.v4.f16.add.noftz {%0,%1,%2,%3}, "
+                 "[%4], {%5,%6,%7,%8};"
+                 : "=h"(ret_x), "=h"(ret_y), "=h"(ret_z), "=h"(ret_w)
+                 : "l"(addr), "h"(val_x), "h"(val_y), "h"(val_z), "h"(val_w)
+                 : "memory");
+  }
+}
+
+TL_DEVICE void
+tl_atomic_add_v4_bf16(unsigned short &ret_x, unsigned short &ret_y,
+                      unsigned short &ret_z, unsigned short &ret_w,
+                      unsigned long long addr, unsigned short val_x,
+                      unsigned short val_y, unsigned short val_z,
+                      unsigned short val_w, int memory_order) {
+  if (IsRelaxedMemoryOrder(memory_order)) {
+    asm volatile(
+        "atom.global.v4.bf16.add.noftz {%0,%1,%2,%3}, [%4], {%5,%6,%7,%8};"
+        : "=h"(ret_x), "=h"(ret_y), "=h"(ret_z), "=h"(ret_w)
+        : "l"(addr), "h"(val_x), "h"(val_y), "h"(val_z), "h"(val_w)
+        : "memory");
+  } else if (IsReleaseLikeMemoryOrder(memory_order)) {
+    asm volatile("atom.release.gpu.global.v4.bf16.add.noftz {%0,%1,%2,%3}, "
+                 "[%4], {%5,%6,%7,%8};"
+                 : "=h"(ret_x), "=h"(ret_y), "=h"(ret_z), "=h"(ret_w)
+                 : "l"(addr), "h"(val_x), "h"(val_y), "h"(val_z), "h"(val_w)
+                 : "memory");
+  } else if (IsAcquireMemoryOrder(memory_order)) {
+    asm volatile("atom.acquire.gpu.global.v4.bf16.add.noftz {%0,%1,%2,%3}, "
+                 "[%4], {%5,%6,%7,%8};"
+                 : "=h"(ret_x), "=h"(ret_y), "=h"(ret_z), "=h"(ret_w)
+                 : "l"(addr), "h"(val_x), "h"(val_y), "h"(val_z), "h"(val_w)
+                 : "memory");
+  } else if (IsAcqRelLikeMemoryOrder(memory_order)) {
+    asm volatile("atom.acq_rel.gpu.global.v4.bf16.add.noftz {%0,%1,%2,%3}, "
+                 "[%4], {%5,%6,%7,%8};"
+                 : "=h"(ret_x), "=h"(ret_y), "=h"(ret_z), "=h"(ret_w)
+                 : "l"(addr), "h"(val_x), "h"(val_y), "h"(val_z), "h"(val_w)
+                 : "memory");
+  }
+}
+
 TL_DEVICE void tl_atomic_add_v2_f32(float &ret_x, float &ret_y,
                                     unsigned long long addr, float val_x,
                                     float val_y, int memory_order) {
@@ -595,6 +661,66 @@ AtomicAddx2Ret(bfloat16_t *ref, src_type *val,
         tl_atomic_detail::UnpackBits16<__nv_bfloat16>(ret_val_y_cast));
   }
 }
+#endif
+
+#if (defined(__CUDA_ARCH_LIST__) && (__CUDA_ARCH_LIST__ >= 900))
+template <typename SrcType>
+TL_DEVICE void AtomicAddx4(half_t *ref, SrcType *val,
+                           int memory_order = int(cuda::memory_order_relaxed)) {
+  half2 add_val_lo = ToHalf2(val);
+  half2 add_val_hi = ToHalf2(val + 2);
+  unsigned short add_val_x_cast = tl_atomic_detail::PackBits16(add_val_lo.x);
+  unsigned short add_val_y_cast = tl_atomic_detail::PackBits16(add_val_lo.y);
+  unsigned short add_val_z_cast = tl_atomic_detail::PackBits16(add_val_hi.x);
+  unsigned short add_val_w_cast = tl_atomic_detail::PackBits16(add_val_hi.y);
+  unsigned long long ref_addr = reinterpret_cast<unsigned long long>(ref);
+  unsigned short ret_val_x_cast;
+  unsigned short ret_val_y_cast;
+  unsigned short ret_val_z_cast;
+  unsigned short ret_val_w_cast;
+  tl_atomic_detail::tl_atomic_add_v4_f16(
+      ret_val_x_cast, ret_val_y_cast, ret_val_z_cast, ret_val_w_cast, ref_addr,
+      add_val_x_cast, add_val_y_cast, add_val_z_cast, add_val_w_cast,
+      memory_order);
+}
+#else
+template <typename SrcType>
+TL_DEVICE void AtomicAddx4(half_t *ref, SrcType *val,
+                           int memory_order = int(cuda::memory_order_relaxed)) {
+  AtomicAddx2(ref, val, memory_order);
+  AtomicAddx2(ref + 2, val + 2, memory_order);
+}
+#endif
+
+#if (defined(__CUDA_ARCH_LIST__) && (__CUDA_ARCH_LIST__ > 750))
+#if (defined(__CUDA_ARCH_LIST__) && (__CUDA_ARCH_LIST__ >= 900))
+template <typename SrcType>
+TL_DEVICE void AtomicAddx4(bfloat16_t *ref, SrcType *val,
+                           int memory_order = int(cuda::memory_order_relaxed)) {
+  __nv_bfloat162 add_val_lo = ToBfloat162(val);
+  __nv_bfloat162 add_val_hi = ToBfloat162(val + 2);
+  unsigned short add_val_x_cast = tl_atomic_detail::PackBits16(add_val_lo.x);
+  unsigned short add_val_y_cast = tl_atomic_detail::PackBits16(add_val_lo.y);
+  unsigned short add_val_z_cast = tl_atomic_detail::PackBits16(add_val_hi.x);
+  unsigned short add_val_w_cast = tl_atomic_detail::PackBits16(add_val_hi.y);
+  unsigned long long ref_addr = reinterpret_cast<unsigned long long>(ref);
+  unsigned short ret_val_x_cast;
+  unsigned short ret_val_y_cast;
+  unsigned short ret_val_z_cast;
+  unsigned short ret_val_w_cast;
+  tl_atomic_detail::tl_atomic_add_v4_bf16(
+      ret_val_x_cast, ret_val_y_cast, ret_val_z_cast, ret_val_w_cast, ref_addr,
+      add_val_x_cast, add_val_y_cast, add_val_z_cast, add_val_w_cast,
+      memory_order);
+}
+#else
+template <typename SrcType>
+TL_DEVICE void AtomicAddx4(bfloat16_t *ref, SrcType *val,
+                           int memory_order = int(cuda::memory_order_relaxed)) {
+  AtomicAddx2(ref, val, memory_order);
+  AtomicAddx2(ref + 2, val + 2, memory_order);
+}
+#endif
 #endif
 
 template <typename T> TL_DEVICE float2 ToFloat2(T *val) {

--- a/testing/python/language/test_tilelang_language_atomic.py
+++ b/testing/python/language/test_tilelang_language_atomic.py
@@ -205,6 +205,35 @@ def run_atomic_addx4(M, N, block_M, block_N):
 
 
 @tilelang.jit
+def atomic_addx4_16bit_program(dtype, offset, nthreads):
+    @T.prim_func
+    def atomic_addx4(A: T.Tensor((16,), dtype), B: T.Tensor((16,), dtype)):
+        with T.Kernel(1, threads=nthreads):
+            T.atomic_addx4(B[offset], A[offset])
+
+    return atomic_addx4
+
+
+def run_atomic_addx4_16bit(dtype, offset, nthreads):
+    kernel = atomic_addx4_16bit_program(dtype, offset, nthreads)
+    source = kernel.get_kernel_source()
+    assert "AtomicAddx4" in source
+
+    torch_dtype = getattr(torch, str(dtype))
+    A = torch.zeros(16, dtype=torch_dtype, device="cuda")
+    B_init = torch.zeros(16, dtype=torch_dtype, device="cuda")
+    A[offset : offset + 4] = torch.tensor([1, 2, 3, 4], dtype=torch_dtype, device="cuda")
+    B_init[offset : offset + 4] = torch.tensor([10, 20, 30, 40], dtype=torch_dtype, device="cuda")
+    B = B_init.clone()
+
+    ref_B = B_init.float()
+    ref_B[offset : offset + 4] += nthreads * A[offset : offset + 4].float()
+
+    kernel(A, B)
+    torch.testing.assert_close(B.float(), ref_B, atol=0, rtol=0)
+
+
+@tilelang.jit
 def atomic_return_prev_program(M, N, block_M, block_N, dtype=T.float32):
     @T.prim_func
     def atomic_with_return_prev(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype), old_vals: T.Tensor((M, N), dtype)):
@@ -342,9 +371,16 @@ def test_atomic_different_memory_orders():
     run_atomic_different_memory_orders(32, 32, 8, 8, dtype=T.bfloat16)
 
 
-# TODO: atomic_addx4 currently not support half
 def test_atomic_addx4():
     run_atomic_addx4(16, 64, 4, 4)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(8, 0)
+def test_atomic_addx4_16bit():
+    for dtype in (T.float16, T.bfloat16):
+        for offset in (0, 4):
+            run_atomic_addx4_16bit(dtype, offset=offset, nthreads=2)
 
 
 def test_atomic_return_prev():


### PR DESCRIPTION
## Summary

Fixes #2478.

This PR fixes CUDA `T.atomic_addx4` for `float16` and `bfloat16` destinations. The original failing path could select the generic `float4` atomic implementation for four 16-bit lanes, which is both the wrong element width and too strict on alignment for offset-4 half/bfloat16 destinations.

After the latest review, the Hopper path now uses native PTX vector atomics instead of simulating x4 with two x2 atomics:

- `atom.global.v4.f16.add.noftz` for fp16
- `atom.global.v4.bf16.add.noftz` for bf16

The PTX form follows NVIDIA PTX `atom` documentation: vector atomics are global-memory operations, 16-bit floating vector atomics require `.noftz`, and vector atomics require `sm_90+`. Pre-sm90 targets keep the existing two-`AtomicAddx2` fallback for correctness because native vector atomics are not available there.

## Changes

- Add sm90+ CUDA `AtomicAddx4(half_t*, ...)` and `AtomicAddx4(bfloat16_t*, ...)` overloads backed by native PTX v4 atomics.
- Support the existing memory-order variants for the new v4 helpers: relaxed, release-like, acquire, and acq_rel-like.
- Keep the existing fp32 `AtomicAddx4` path unchanged.
- Add a regression test covering `T.atomic_addx4` on fp16 and bf16 at offsets 0 and 4.

## Validation

- `pre-commit run --files src/tl_templates/cuda/atomic.h testing/python/language/test_tilelang_language_atomic.py`
- H100 / sm90, cache disabled:
  - `CUDA_VISIBLE_DEVICES=0 TILELANG_DISABLE_CACHE=1 TILELANG_CACHE_DIR=/tmp/tilelang-pr2492-cache-h100-docsyntax PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -B -m pytest testing/python/language/test_tilelang_language_atomic.py::test_atomic_addx4_16bit -q -s`
  - Result: `1 passed`
- A100 / sm80, cache disabled, fallback path:
  - `CUDA_VISIBLE_DEVICES=1 TILELANG_DISABLE_CACHE=1 TILELANG_CACHE_DIR=/tmp/tilelang-pr2492-cache-a100-docsyntax PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -B -m pytest testing/python/language/test_tilelang_language_atomic.py::test_atomic_addx4_16bit -q -s`
  - Result: `1 passed`

## Performance

Microbenchmark on H100 PCIe / sm90 with TileLang cache disabled, `N=65536`, `threads=128`, CUDA event median timing, comparing native v4 `T.atomic_addx4` against an equivalent two-`T.atomic_addx2` split implementation:

| dtype | native v4 | split 2x addx2 | speedup |
| --- | ---: | ---: | ---: |
| fp16 | 0.075136 ms | 0.184832 ms | 2.460x |
| bf16 | 0.076576 ms | 0.186816 ms | 2.440x |

Co-authored-by: dingsg <shengge.ding@enflame-tech.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Added `AtomicAddx4` support for `half_t` and `bfloat16_t` CUDA destinations in `src/tl_templates/cuda/atomic.h`.
- Implemented native SM90+ 4-wide PTX atomic add paths for fp16/bf16, with a pre-SM90 fallback that composes two existing `AtomicAddx2` calls.
- Kept the existing float32 `float4` path unchanged.
- Expanded CUDA regression coverage to verify `T.atomic_addx4` on prefilled fp16/bf16 tensors at offsets `0` and `4`, alongside the existing float32 coverage.

## Testing
- Added a new CUDA/compute-version-gated test for fp16 and bf16 `atomic_addx4`.
- Updated the existing `atomic_addx4` test to run directly instead of remaining TODO-only.

## C++ style / lint notes
- This PR touches C++-adjacent CUDA template code in `docs/developer_guide/cpp_style.md` scope.
- No clear build or correctness issues are introduced from a style/lint perspective.
- The added low-level atomic specializations may surface warning-only items in the “C++ API Style Audit (warning only)” step, but nothing here appears merge-blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->