### PR TITLE
[BugFix][CUDA] Fix signed int2 LOP3 decode

### DIFF
--- a/testing/python/issue/test_tilelang_lop3_i2s_to_i4s_decode.py
+++ b/testing/python/issue/test_tilelang_lop3_i2s_to_i4s_decode.py
@@ -1,0 +1,84 @@
+"""Regression coverage for signed int2 to int4 LOP3 decode."""
+
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.quantize import get_lop3_intrin_group
+
+
+N = 16
+I2_STORAGE_BYTES = N // 4
+I4_STORAGE_BYTES = N // 2
+
+
+def _build_lop3_i2_to_i4_decode(source_format):
+    lop3 = get_lop3_intrin_group(
+        out_dtype=T.int4,
+        source_format=source_format,
+        source_bit=2,
+        storage_dtype=T.int8,
+        with_scaling=False,
+        with_zeros=False,
+    )
+    source = lop3["c_source"]
+    func_name = lop3["func_name"]
+
+    @T.prim_func
+    def main(I: T.Tensor((I2_STORAGE_BYTES,), T.int8), O: T.Tensor((I4_STORAGE_BYTES,), T.int8)):
+        with T.Kernel(1, threads=1):
+            T.import_source(source)
+            i2 = T.alloc_local((I2_STORAGE_BYTES,), T.int8)
+            i4 = T.alloc_local((I4_STORAGE_BYTES,), T.int8)
+            for k in T.serial(I2_STORAGE_BYTES):
+                i2[k] = I[k]
+            T.evaluate(T.call_extern("handle", func_name, T.address_of(i2[0]), T.address_of(i4[0]), N))
+            for k in T.serial(I4_STORAGE_BYTES):
+                O[k] = i4[k]
+
+    return main
+
+
+def _pack_i2_values(values):
+    values = torch.tensor(values, dtype=torch.uint8).reshape(-1, 4)
+    packed = values[:, 0] | (values[:, 1] << 2) | (values[:, 2] << 4) | (values[:, 3] << 6)
+    return packed.contiguous().view(torch.int8).cuda()
+
+
+def _unpack_i4_values(packed, signed):
+    packed = packed.to(torch.uint8)
+    low = (packed & 0x0F).to(torch.int8)
+    high = (packed >> 4).to(torch.int8)
+    if signed:
+        low = (low << 4) >> 4
+        high = (high << 4) >> 4
+    return torch.stack((low, high), dim=-1).reshape(-1)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(7, 5)
+def test_lop3_i2s_to_i4s_sign_extends_int2():
+    qweight = _pack_i2_values([0, 1, 2, 3] * 4)
+
+    signed_kernel = tilelang.compile(_build_lop3_i2_to_i4_decode(T.int), target="cuda")
+    unsigned_kernel = tilelang.compile(_build_lop3_i2_to_i4_decode(T.uint), target="cuda")
+
+    signed = torch.empty(I4_STORAGE_BYTES, dtype=torch.int8, device="cuda")
+    unsigned = torch.empty_like(signed)
+    signed_kernel(qweight, signed)
+    unsigned_kernel(qweight, unsigned)
+    torch.cuda.synchronize()
+
+    unsigned_values = _unpack_i4_values(unsigned, signed=False)
+    signed_values = _unpack_i4_values(signed, signed=True)
+    expected_signed = (unsigned_values << 6) >> 6
+
+    torch.testing.assert_close(signed_values, expected_signed, rtol=0, atol=0)
+    assert not torch.equal(signed, unsigned)
+    assert torch.any(unsigned_values == 2)
+    assert torch.any(unsigned_values == 3)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/quantize/lop3.py
+++ b/tilelang/quantize/lop3.py
@@ -1056,7 +1056,6 @@ __device__ void decode_i2b_to_i4s(T1 *_i2b, T2 *_i4s, const int N = 16)
     static constexpr uint immLut = (0xf0 & 0xcc) | 0xaa;
     static constexpr uint BOTTOM_MASK = 0x33333333;          // 0xf -> 0b1111 select 0,2,4,6,8,10,12
     static constexpr uint I4b_TO_I8s_MAGIC_NUM = 0x00000000; // 0
-    static constexpr uint MEDIAN_NUM = isSigned ? 0x33333333 : 0x00000000;
 
 #pragma unroll
     for (int i = 0; i < (N / 8); i++)
@@ -1067,9 +1066,9 @@ __device__ void decode_i2b_to_i4s(T1 *_i2b, T2 *_i4s, const int N = 16)
                      : "r"(i2b[i / 2] >> (2 * (i % 2))), "n"(BOTTOM_MASK), "n"(I4b_TO_I8s_MAGIC_NUM), "n"(immLut));
         if constexpr (isSigned)
         {
-            // TODO(lei): uint4 sub should be enhanced.
-            // 0x03 0x03 0x03 0x03
-            // i4s[i] = (((i4s[i] << 1) | i4s[i]) << 1) | i4s[i];
+            static constexpr uint SIGN_BIT_MASK = 0x22222222;
+            uint sign_bits = i4s[i] & SIGN_BIT_MASK;
+            i4s[i] |= (sign_bits << 1) | (sign_bits << 2);
         }
     }
 }


### PR DESCRIPTION
Fixes #2479

## Summary
- Implement the signed correction in `decode_i2b_to_i4s<..., isSigned=true>`.
- Sign-extend every extracted raw int2 lane inside its destination int4 nibble by propagating bit 1 into bits 2 and 3.
- Keep the unsigned `decode_i2u_to_i4s` path unchanged.
- Add CUDA regression coverage for signed int2 to int4 LOP3 decode using a payload that contains both negative raw int2 patterns.

## Problem
`get_lop3_intrin_group(out_dtype="int4", source_format="int", source_bit=2)` returns `decode_i2s_to_i4s`, so the signed int2 to int4 path is exposed as a supported fast decoder.

Inside the shared `decode_i2b_to_i4s` template, however, the `isSigned` branch was effectively empty. As a result, the signed decoder emitted the same raw unsigned int4 nibbles as `decode_i2u_to_i4s`. Raw int2 patterns with sign bit set, such as `0b10` and `0b11`, therefore decoded as non-negative values instead of signed int4 values.

## Fix
After the LOP3 extraction places each raw 2-bit lane in the low bits of an int4 nibble, the signed path now does nibble-local sign extension:

- mask the int2 sign bit in each nibble with `0x22222222`;
- copy that bit into the nibble bit2 and bit3 positions;
- leave the unsigned path byte-for-byte unchanged.

This matches the scalar int-to-int conversion semantics for signed packed integers while preserving the existing LOP3 layout.

## Regression Test
The new test compiles both signed and unsigned int2 to int4 LOP3 decoders. It decodes the same packed int2 payload through both paths, derives the expected signed int4 values from the unsigned raw lanes using two-bit sign extension, and verifies:

- signed output matches the sign-extended int4 expectation;
- signed output is no longer byte-identical to unsigned output;
- the payload covers raw `0b10` and `0b11`, so both negative int2 patterns are exercised.

## Validation
- `python -m ruff check tilelang/quantize/lop3.py testing/python/issue/test_tilelang_lop3_i2s_to_i4s_decode.py`
- `python -m ruff format --check tilelang/quantize/lop3.py testing/python/issue/test_tilelang_lop3_i2s_to_i4s_decode.py`
- `git diff --check`
- `pre-commit run --files tilelang/quantize/lop3.py testing/python/issue/test_tilelang_lop3_i2s_to_i4s_decode.py`
- Remote CUDA: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest testing/python/issue/test_tilelang_lop3_i2s_to_i4s_decode.py -q -s` passed

Co-authored-by: dingsg <shengge.ding@enflame-tech.com>
