### PR TITLE
[BugFix] Only allocate reducer workspace for cross-warp AllReduce

### DIFF
--- a/src/backend/common/op/finalize_reducer.h
+++ b/src/backend/common/op/finalize_reducer.h
@@ -97,7 +97,7 @@ template <typename Impl> struct FinalizeReducerLowerer {
         lower_args.thread_bounds->extent, lower_args.target);
     Array<PrimExpr> thread_reduce_args = {StringImm(allreduce),
                                           BufferLoad(buffer, indices_0)};
-    if (reducing_threads >= 32) {
+    if (reducing_threads > Impl::WarpSize(lower_args.target)) {
       PrimExpr workspace = lower_args.add_workspace(
           *as_const_int(lower_args.thread_bounds->extent), buffer->dtype);
       thread_reduce_args.push_back(workspace);


### PR DESCRIPTION
## Summary

- The scalar `AllReduce` path in `finalize_reducer` allocated a shared-memory workspace (and a guarding `__syncthreads`) whenever `reducing_threads >= 32`. But the butterfly reduction only touches that workspace at levels with `offset >= 32`, i.e. only when `reducing_threads > warp size`. At exactly warp width the workspace and the barrier are dead code.

## Changes

- `src/backend/common/op/finalize_reducer.h`: gate the scalar `AllReduce` workspace/barrier on `reducing_threads > Impl::WarpSize(target)` instead of `reducing_threads >= 32`.

## Validation

- `pre-commit run --all-files`.
- Codegen diff for a warp-width (`threads=32`) reducer:

```python
import tilelang as tl
import tilelang.language as T


@tl.jit(pass_configs={
    tl.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
    tl.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
})
def row_reduce(x: T.Tensor((32, 8), "float32")):
    o = T.empty((32,), "float32")
    with T.Kernel(1, threads=32):  # threads == warp size
        red = T.alloc_reducer((32,), "float32", op="sum", replication="all")
        T.clear(red)
        for i, k in T.Parallel(32, 8):
            red[i] += x[i, k]
        T.finalize_reducer(red)
        T.copy(red, o)
    return o


print(row_reduce.get_kernel_source())
```

**Before**:

```cuda
float red[32];
extern __shared__ __align__(1024) float workspace[];
...
__syncthreads();
for (int __finred_0 = 0; __finred_0 < 32; ++__finred_0) {
  red[__finred_0] = tl::AllReduce<tl::SumOp, 32, 1, 0, tl::NamedBarrier<32>>::run(red[__finred_0], (&(workspace[0])));
}
```

**After**:

```cuda
float red[32];
...
for (int __finred_0 = 0; __finred_0 < 32; ++__finred_0) {
  red[__finred_0] = tl::AllReduce<tl::SumOp, 32, 1, 0, tl::NamedBarrier<32>>::run(red[__finred_0]);
}
```

## Notes

- No behavioral change: the gated workspace/barrier was already unreachable code at warp width.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary
- Updated `FinalizeReducerLowerer::Lower` so the scalar `AllReduce` path only adds shared-memory workspace when `reducing_threads` exceeds the target’s warp size.
- Replaced the hard-coded `>= 32` check with `> Impl::WarpSize(lower_args.target)`, aligning the behavior with the target architecture and avoiding dead workspace/barrier code at exact warp width.

### C++ style / lint notes
- This change touches C++ source but not `docs/developer_guide/cpp_style.md`.
- No new C++ API/style concerns are introduced by this patch.
- The `C++ API Style Audit (warning only)` step is relevant for this area, but this PR appears to address correctness rather than adding warning-only style issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->