### PR TITLE
[Autotune] Support per-config pass_configs in autotuning

### DIFF
--- a/examples/gemm/example_gemm_autotune_pass_configs.py
+++ b/examples/gemm/example_gemm_autotune_pass_configs.py
@@ -18,6 +18,15 @@ from tilelang.transform import PassConfigKey
 
 
 def ref_program(A, B):
+    """Compute reference matrix multiplication C = A @ B^T.
+
+    Args:
+        A: Input matrix of shape (M, K).
+        B: Input matrix of shape (N, K).
+
+    Returns:
+        Result matrix of shape (M, N).
+    """
     return A @ B.T
 
 
@@ -45,6 +54,17 @@ def get_configs():
 
 
 def get_best_config(M, N, K):
+    """Run autotuning to find the best kernel config for GEMM (API mode).
+
+    Args:
+        M: Number of rows of matrix A and C.
+        N: Number of rows of matrix B (columns of C).
+        K: Shared dimension of A and B.
+
+    Returns:
+        AutoTuner result containing the best config and latency.
+    """
+
     def kernel(
         block_M=None,
         block_N=None,
@@ -52,6 +72,7 @@ def get_best_config(M, N, K):
         num_stages=None,
         thread_num=None,
     ):
+        """Kernel factory that returns a TIR GEMM prim_func for given tile parameters."""
         dtype = T.float16
         accum_dtype = T.float32
 
@@ -61,6 +82,7 @@ def get_best_config(M, N, K):
             B: T.Tensor((N, K), dtype),
             C: T.Tensor((M, N), dtype),
         ):
+            """Tiled GEMM kernel computing C = A @ B^T with pipelined shared memory loads."""
             with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=thread_num) as (
                 bx,
                 by,
@@ -94,6 +116,13 @@ def get_best_config(M, N, K):
 
 
 def main(M: int = 4096, N: int = 4096, K: int = 4096):
+    """Run autotuning in API mode and print the best config and performance.
+
+    Args:
+        M: Matrix dimension M (default 4096).
+        N: Matrix dimension N (default 4096).
+        K: Matrix dimension K (default 4096).
+    """
     result = get_best_config(M, N, K)
     print(f"Best config: {result.config}")
     print(f"Best latency: {result.latency} ms")
@@ -129,6 +158,7 @@ def matmul_decorator(
         B: T.Tensor((N, K), dtype),
         C: T.Tensor((M, N), dtype),
     ):
+        """Tiled GEMM kernel computing C = A @ B^T with pipelined shared memory loads."""
         with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=thread_num) as (
             bx,
             by,
@@ -148,9 +178,16 @@ def matmul_decorator(
 
 
 def main_decorator(M: int = 4096, N: int = 4096, K: int = 4096):
+    """Run autotuning in decorator mode and print the resulting kernel info.
+
+    Args:
+        M: Matrix dimension M (default 4096).
+        N: Matrix dimension N (default 4096).
+        K: Matrix dimension K (default 4096).
+    """
     # Calling the decorated function triggers autotuning and returns a JITKernel
     kernel = matmul_decorator(M, N, K)
-    print(f"[Decorator mode] Kernel compiled successfully")
+    print("[Decorator mode] Kernel compiled successfully")
     print(f"[Decorator mode] Kernel source length: {len(kernel.get_kernel_source())} chars")
 
 

--- a/examples/gemm/example_gemm_autotune_pass_configs.py
+++ b/examples/gemm/example_gemm_autotune_pass_configs.py
@@ -27,7 +27,7 @@ def get_configs():
     block_M = [128]
     block_N = [128]
     block_K = [32]
-    num_stages = [2]
+    num_stages = [1, 2]
     thread_num = [128]
     warp_spec = [True, False]
 
@@ -93,7 +93,7 @@ def get_best_config(M, N, K):
             skip_check=False,
         )
     )
-    return autotuner.run(warmup=3, rep=20)
+    return autotuner.run(warmup=3, rep=20, enable_grouped_compile=True)
 
 
 def main(M: int = 4096, N: int = 4096, K: int = 4096):

--- a/examples/gemm/example_gemm_autotune_pass_configs.py
+++ b/examples/gemm/example_gemm_autotune_pass_configs.py
@@ -18,15 +18,7 @@ from tilelang.transform import PassConfigKey
 
 
 def ref_program(A, B):
-    """Compute reference matrix multiplication C = A @ B^T.
-
-    Args:
-        A: Input matrix of shape (M, K).
-        B: Input matrix of shape (N, K).
-
-    Returns:
-        Result matrix of shape (M, N).
-    """
+    """Reference: C = A @ B^T."""
     return A @ B.T
 
 
@@ -54,16 +46,7 @@ def get_configs():
 
 
 def get_best_config(M, N, K):
-    """Run autotuning to find the best kernel config for GEMM (API mode).
-
-    Args:
-        M: Number of rows of matrix A and C.
-        N: Number of rows of matrix B (columns of C).
-        K: Shared dimension of A and B.
-
-    Returns:
-        AutoTuner result containing the best config and latency.
-    """
+    """Run autotuning to find the best kernel config (API mode)."""
 
     def kernel(
         block_M=None,
@@ -72,7 +55,6 @@ def get_best_config(M, N, K):
         num_stages=None,
         thread_num=None,
     ):
-        """Kernel factory that returns a TIR GEMM prim_func for given tile parameters."""
         dtype = T.float16
         accum_dtype = T.float32
 
@@ -82,7 +64,6 @@ def get_best_config(M, N, K):
             B: T.Tensor((N, K), dtype),
             C: T.Tensor((M, N), dtype),
         ):
-            """Tiled GEMM kernel computing C = A @ B^T with pipelined shared memory loads."""
             with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=thread_num) as (
                 bx,
                 by,
@@ -116,13 +97,7 @@ def get_best_config(M, N, K):
 
 
 def main(M: int = 4096, N: int = 4096, K: int = 4096):
-    """Run autotuning in API mode and print the best config and performance.
-
-    Args:
-        M: Matrix dimension M (default 4096).
-        N: Matrix dimension N (default 4096).
-        K: Matrix dimension K (default 4096).
-    """
+    """Run API mode autotuning and print results."""
     result = get_best_config(M, N, K)
     print(f"Best config: {result.config}")
     print(f"Best latency: {result.latency} ms")
@@ -158,7 +133,6 @@ def matmul_decorator(
         B: T.Tensor((N, K), dtype),
         C: T.Tensor((M, N), dtype),
     ):
-        """Tiled GEMM kernel computing C = A @ B^T with pipelined shared memory loads."""
         with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=thread_num) as (
             bx,
             by,
@@ -178,14 +152,7 @@ def matmul_decorator(
 
 
 def main_decorator(M: int = 4096, N: int = 4096, K: int = 4096):
-    """Run autotuning in decorator mode and print the resulting kernel info.
-
-    Args:
-        M: Matrix dimension M (default 4096).
-        N: Matrix dimension N (default 4096).
-        K: Matrix dimension K (default 4096).
-    """
-    # Calling the decorated function triggers autotuning and returns a JITKernel
+    """Run decorator mode autotuning and print results."""
     kernel = matmul_decorator(M, N, K)
     print("[Decorator mode] Kernel compiled successfully")
     print(f"[Decorator mode] Kernel source length: {len(kernel.get_kernel_source())} chars")

--- a/examples/gemm/example_gemm_autotune_pass_configs.py
+++ b/examples/gemm/example_gemm_autotune_pass_configs.py
@@ -1,0 +1,179 @@
+"""Example: AutoTuning with per-config pass_configs.
+
+This example demonstrates how to include pass_configs (compiler pass configurations)
+as part of the auto-tuning search space, allowing the tuner to find the best
+combination of kernel parameters AND compiler options.
+
+Two usage modes are shown:
+1. API mode: using AutoTuner.from_kernel() explicitly
+2. Decorator (wrapper) mode: using @autotune + @tilelang.jit decorators
+"""
+
+import argparse
+import itertools
+import tilelang as tl
+import tilelang.language as T
+from tilelang.autotuner import AutoTuner, autotune
+from tilelang.transform import PassConfigKey
+
+
+def ref_program(A, B):
+    return A @ B.T
+
+
+def get_configs():
+    """Generate configs that include pass_configs variations."""
+    block_M = [128]
+    block_N = [128]
+    block_K = [32]
+    num_stages = [2]
+    thread_num = [128]
+    warp_spec = [True, False]
+
+    configs = []
+    for bm, bn, bk, ns, tn, ws in itertools.product(block_M, block_N, block_K, num_stages, thread_num, warp_spec):
+        config = {
+            "block_M": bm,
+            "block_N": bn,
+            "block_K": bk,
+            "num_stages": ns,
+            "thread_num": tn,
+            "pass_configs": {PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: ws},
+        }
+        configs.append(config)
+    return configs
+
+
+def get_best_config(M, N, K):
+    def kernel(
+        block_M=None,
+        block_N=None,
+        block_K=None,
+        num_stages=None,
+        thread_num=None,
+    ):
+        dtype = T.float16
+        accum_dtype = T.float32
+
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, K), dtype),
+            B: T.Tensor((N, K), dtype),
+            C: T.Tensor((M, N), dtype),
+        ):
+            with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=thread_num) as (
+                bx,
+                by,
+            ):
+                A_shared = T.alloc_shared((block_M, block_K), dtype)
+                B_shared = T.alloc_shared((block_N, block_K), dtype)
+                C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+                T.use_swizzle(panel_size=10)
+                T.clear(C_local)
+                for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
+                    T.copy(A[by * block_M, k * block_K], A_shared)
+                    T.copy(B[bx * block_N, k * block_K], B_shared)
+                    T.gemm(A_shared, B_shared, C_local, transpose_B=True)
+                T.copy(C_local, C[by * block_M, bx * block_N])
+
+        return main
+
+    autotuner = (
+        AutoTuner.from_kernel(kernel=kernel, configs=get_configs())
+        .set_compile_args(
+            out_idx=[-1],
+            target="auto",
+        )
+        .set_profile_args(
+            supply_type=tl.TensorSupplyType.Integer,
+            ref_prog=ref_program,
+            skip_check=False,
+        )
+    )
+    return autotuner.run(warmup=3, rep=20)
+
+
+def main(M: int = 4096, N: int = 4096, K: int = 4096):
+    result = get_best_config(M, N, K)
+    print(f"Best config: {result.config}")
+    print(f"Best latency: {result.latency} ms")
+    print(f"TFlops: {2 * M * N * K / result.latency * 1e-9}")
+
+    if result.ref_latency:
+        print(f"Ref latency: {result.ref_latency} ms")
+        print(f"Ref TFlops: {2 * M * N * K / result.ref_latency * 1e-9}")
+
+
+# ======================== Decorator (wrapper) mode ========================
+
+
+@autotune(configs=get_configs(), warmup=3, rep=20)
+@tl.jit(out_idx=[-1])
+def matmul_decorator(
+    M,
+    N,
+    K,
+    block_M=128,
+    block_N=128,
+    block_K=32,
+    num_stages=2,
+    thread_num=128,
+):
+    """GEMM kernel with per-config pass_configs in autotune search space (decorator mode)."""
+    dtype = T.float16
+    accum_dtype = T.float32
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), dtype),
+        B: T.Tensor((N, K), dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=thread_num) as (
+            bx,
+            by,
+        ):
+            A_shared = T.alloc_shared((block_M, block_K), dtype)
+            B_shared = T.alloc_shared((block_N, block_K), dtype)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+            T.use_swizzle(panel_size=10)
+            T.clear(C_local)
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
+                T.copy(A[by * block_M, k * block_K], A_shared)
+                T.copy(B[bx * block_N, k * block_K], B_shared)
+                T.gemm(A_shared, B_shared, C_local, transpose_B=True)
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def main_decorator(M: int = 4096, N: int = 4096, K: int = 4096):
+    # Calling the decorated function triggers autotuning and returns a JITKernel
+    kernel = matmul_decorator(M, N, K)
+    print(f"[Decorator mode] Kernel compiled successfully")
+    print(f"[Decorator mode] Kernel source length: {len(kernel.get_kernel_source())} chars")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="AutoTune MatMul with pass_configs")
+    parser.add_argument("--m", type=int, default=4096, help="Matrix dimension M")
+    parser.add_argument("--n", type=int, default=4096, help="Matrix dimension N")
+    parser.add_argument("--k", type=int, default=4096, help="Matrix dimension K")
+    parser.add_argument(
+        "--mode",
+        type=str,
+        default="both",
+        choices=["api", "decorator", "both"],
+        help="Which mode to run",
+    )
+    args = parser.parse_args()
+    if args.mode in ("api", "both"):
+        print("=" * 60)
+        print("API mode")
+        print("=" * 60)
+        main(args.m, args.n, args.k)
+    if args.mode in ("decorator", "both"):
+        print("=" * 60)
+        print("Decorator mode")
+        print("=" * 60)
+        main_decorator(args.m, args.n, args.k)

--- a/testing/python/autotune/test_pass_configs_tuning.py
+++ b/testing/python/autotune/test_pass_configs_tuning.py
@@ -58,7 +58,6 @@ def _make_matmul_kernel(M, N, K):
     """Helper to create a simple matmul kernel factory."""
 
     def kernel(block_M=None, block_N=None, block_K=None):
-        """Kernel factory returning a tiled GEMM prim_func for given block sizes."""
 
         @T.prim_func
         def main(
@@ -66,7 +65,6 @@ def _make_matmul_kernel(M, N, K):
             B: T.Tensor((N, K), T.float16),
             C: T.Tensor((M, N), T.float16),
         ):
-            """Tiled GEMM kernel computing C = A @ B^T."""
             with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
                 A_shared = T.alloc_shared((block_M, block_K), T.float16)
                 B_shared = T.alloc_shared((block_N, block_K), T.float16)
@@ -170,7 +168,6 @@ def test_autotune_decorator_with_per_config_pass_configs():
     @autotune(configs=configs, warmup=1, rep=3, skip_check=True, supply_type=tilelang.TensorSupplyType.Integer)
     @tilelang.jit(out_idx=[-1])
     def matmul_kernel(M, N, K, block_M=64, block_N=64, block_K=64):
-        """GEMM kernel factory with per-config pass_configs in decorator mode."""
 
         @T.prim_func
         def main(
@@ -178,7 +175,6 @@ def test_autotune_decorator_with_per_config_pass_configs():
             B: T.Tensor((N, K), T.float16),
             C: T.Tensor((M, N), T.float16),
         ):
-            """Tiled GEMM kernel computing C = A @ B^T."""
             with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
                 A_shared = T.alloc_shared((block_M, block_K), T.float16)
                 B_shared = T.alloc_shared((block_N, block_K), T.float16)
@@ -192,7 +188,6 @@ def test_autotune_decorator_with_per_config_pass_configs():
 
         return main
 
-    # This should compile and return a kernel without errors
     kernel = matmul_kernel(M, N, K, __return_kernel=True)
     assert kernel is not None
 
@@ -207,7 +202,6 @@ def test_autotune_decorator_pass_configs_override_jit_global():
     @autotune(configs=configs, warmup=1, rep=3, skip_check=True, supply_type=tilelang.TensorSupplyType.Integer)
     @tilelang.jit(out_idx=[-1], pass_configs={PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True})
     def matmul_kernel(M, N, K, block_M=64, block_N=64, block_K=64):
-        """GEMM kernel factory verifying per-config pass_configs override global jit configs."""
 
         @T.prim_func
         def main(
@@ -215,7 +209,6 @@ def test_autotune_decorator_pass_configs_override_jit_global():
             B: T.Tensor((N, K), T.float16),
             C: T.Tensor((M, N), T.float16),
         ):
-            """Tiled GEMM kernel computing C = A @ B^T."""
             with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
                 A_shared = T.alloc_shared((block_M, block_K), T.float16)
                 B_shared = T.alloc_shared((block_N, block_K), T.float16)
@@ -229,7 +222,6 @@ def test_autotune_decorator_pass_configs_override_jit_global():
 
         return main
 
-    # This should compile and return a kernel without errors
     kernel = matmul_kernel(M, N, K, __return_kernel=True)
     assert kernel is not None
 

--- a/testing/python/autotune/test_pass_configs_tuning.py
+++ b/testing/python/autotune/test_pass_configs_tuning.py
@@ -58,12 +58,15 @@ def _make_matmul_kernel(M, N, K):
     """Helper to create a simple matmul kernel factory."""
 
     def kernel(block_M=None, block_N=None, block_K=None):
+        """Kernel factory returning a tiled GEMM prim_func for given block sizes."""
+
         @T.prim_func
         def main(
             A: T.Tensor((M, K), T.float16),
             B: T.Tensor((N, K), T.float16),
             C: T.Tensor((M, N), T.float16),
         ):
+            """Tiled GEMM kernel computing C = A @ B^T."""
             with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
                 A_shared = T.alloc_shared((block_M, block_K), T.float16)
                 B_shared = T.alloc_shared((block_N, block_K), T.float16)
@@ -167,12 +170,15 @@ def test_autotune_decorator_with_per_config_pass_configs():
     @autotune(configs=configs, warmup=1, rep=3, skip_check=True, supply_type=tilelang.TensorSupplyType.Integer)
     @tilelang.jit(out_idx=[-1])
     def matmul_kernel(M, N, K, block_M=64, block_N=64, block_K=64):
+        """GEMM kernel factory with per-config pass_configs in decorator mode."""
+
         @T.prim_func
         def main(
             A: T.Tensor((M, K), T.float16),
             B: T.Tensor((N, K), T.float16),
             C: T.Tensor((M, N), T.float16),
         ):
+            """Tiled GEMM kernel computing C = A @ B^T."""
             with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
                 A_shared = T.alloc_shared((block_M, block_K), T.float16)
                 B_shared = T.alloc_shared((block_N, block_K), T.float16)
@@ -201,12 +207,15 @@ def test_autotune_decorator_pass_configs_override_jit_global():
     @autotune(configs=configs, warmup=1, rep=3, skip_check=True, supply_type=tilelang.TensorSupplyType.Integer)
     @tilelang.jit(out_idx=[-1], pass_configs={PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True})
     def matmul_kernel(M, N, K, block_M=64, block_N=64, block_K=64):
+        """GEMM kernel factory verifying per-config pass_configs override global jit configs."""
+
         @T.prim_func
         def main(
             A: T.Tensor((M, K), T.float16),
             B: T.Tensor((N, K), T.float16),
             C: T.Tensor((M, N), T.float16),
         ):
+            """Tiled GEMM kernel computing C = A @ B^T."""
             with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
                 A_shared = T.alloc_shared((block_M, block_K), T.float16)
                 B_shared = T.alloc_shared((block_N, block_K), T.float16)

--- a/testing/python/autotune/test_pass_configs_tuning.py
+++ b/testing/python/autotune/test_pass_configs_tuning.py
@@ -1,0 +1,229 @@
+"""Tests for per-config pass_configs auto-tuning support."""
+
+import itertools
+
+import tilelang.testing
+import tilelang
+import tilelang.language as T
+from tilelang.autotuner import AutoTuner, autotune
+from tilelang.transform import PassConfigKey
+
+
+def _get_test_configs():
+    """Generate test configs using Cartesian product, including pass_configs variations."""
+    block_M = [64, 128]
+    block_N = [64, 128]
+    block_K = [64, 128]
+    warp_spec = [True, False]
+    _configs = list(itertools.product(block_M, block_N, block_K, warp_spec))
+    return [
+        {
+            "block_M": c[0],
+            "block_N": c[1],
+            "block_K": c[2],
+            "pass_configs": {PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: c[3]},
+        }
+        for c in _configs
+    ]
+
+
+def _get_test_configs_mixed():
+    """Generate configs where some have pass_configs and others don't."""
+    block_M = [64, 128]
+    block_N = [64, 128]
+    block_K = [64, 128]
+    configs = []
+    for bm, bn, bk in itertools.product(block_M, block_N, block_K):
+        # Some configs with pass_configs
+        configs.append(
+            {
+                "block_M": bm,
+                "block_N": bn,
+                "block_K": bk,
+                "pass_configs": {PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True},
+            }
+        )
+        # Some configs without pass_configs (use global default)
+        configs.append(
+            {
+                "block_M": bm,
+                "block_N": bn,
+                "block_K": bk,
+            }
+        )
+    return configs
+
+
+def _make_matmul_kernel(M, N, K):
+    """Helper to create a simple matmul kernel factory."""
+
+    def kernel(block_M=None, block_N=None, block_K=None):
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, K), T.float16),
+            B: T.Tensor((N, K), T.float16),
+            C: T.Tensor((M, N), T.float16),
+        ):
+            with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+                A_shared = T.alloc_shared((block_M, block_K), T.float16)
+                B_shared = T.alloc_shared((block_N, block_K), T.float16)
+                C_local = T.alloc_fragment((block_M, block_N), T.float32)
+                T.clear(C_local)
+                for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=1):
+                    T.copy(A[by * block_M, k * block_K], A_shared)
+                    T.copy(B[bx * block_N, k * block_K], B_shared)
+                    T.gemm(A_shared, B_shared, C_local, transpose_B=True)
+                T.copy(C_local, C[by * block_M, bx * block_N])
+
+        return main
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_autotune_with_per_config_pass_configs():
+    """Test that per-config pass_configs are correctly applied during autotuning."""
+    M, N, K = 128, 128, 128
+    kernel = _make_matmul_kernel(M, N, K)
+
+    configs = _get_test_configs()
+
+    autotuner = (
+        AutoTuner.from_kernel(kernel=kernel, configs=configs)
+        .set_compile_args(
+            out_idx=[-1],
+            target="auto",
+        )
+        .set_profile_args(
+            supply_type=tilelang.TensorSupplyType.Integer,
+            skip_check=True,
+        )
+    )
+    result = autotuner.run(warmup=1, rep=3)
+    assert result is not None
+    assert result.config is not None
+    assert result.kernel is not None
+
+
+@tilelang.testing.requires_cuda
+def test_autotune_mixed_pass_configs():
+    """Test configs where some have pass_configs and others don't."""
+    M, N, K = 128, 128, 128
+    kernel = _make_matmul_kernel(M, N, K)
+
+    configs = _get_test_configs_mixed()
+
+    autotuner = (
+        AutoTuner.from_kernel(kernel=kernel, configs=configs)
+        .set_compile_args(
+            out_idx=[-1],
+            target="auto",
+        )
+        .set_profile_args(
+            supply_type=tilelang.TensorSupplyType.Integer,
+            skip_check=True,
+        )
+    )
+    result = autotuner.run(warmup=1, rep=3)
+    assert result is not None
+    assert result.config is not None
+
+
+@tilelang.testing.requires_cuda
+def test_autotune_pass_configs_merge_with_global():
+    """Test that per-config pass_configs merge correctly over global pass_configs."""
+    M, N, K = 128, 128, 128
+    kernel = _make_matmul_kernel(M, N, K)
+
+    # Global pass_configs set via set_compile_args
+    global_pass_configs = {PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: False}
+
+    configs = _get_test_configs()
+
+    autotuner = (
+        AutoTuner.from_kernel(kernel=kernel, configs=configs)
+        .set_compile_args(
+            out_idx=[-1],
+            target="auto",
+            pass_configs=global_pass_configs,
+        )
+        .set_profile_args(
+            supply_type=tilelang.TensorSupplyType.Integer,
+            skip_check=True,
+        )
+    )
+    result = autotuner.run(warmup=1, rep=3)
+    assert result is not None
+    assert result.config is not None
+
+
+@tilelang.testing.requires_cuda
+def test_autotune_decorator_with_per_config_pass_configs():
+    """Test @autotune + @tilelang.jit decorator pattern with per-config pass_configs."""
+    M, N, K = 128, 128, 128
+
+    configs = _get_test_configs()
+
+    @autotune(configs=configs, warmup=1, rep=3, skip_check=True, supply_type=tilelang.TensorSupplyType.Integer)
+    @tilelang.jit(out_idx=[-1])
+    def matmul_kernel(M, N, K, block_M=64, block_N=64, block_K=64):
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, K), T.float16),
+            B: T.Tensor((N, K), T.float16),
+            C: T.Tensor((M, N), T.float16),
+        ):
+            with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+                A_shared = T.alloc_shared((block_M, block_K), T.float16)
+                B_shared = T.alloc_shared((block_N, block_K), T.float16)
+                C_local = T.alloc_fragment((block_M, block_N), T.float32)
+                T.clear(C_local)
+                for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=1):
+                    T.copy(A[by * block_M, k * block_K], A_shared)
+                    T.copy(B[bx * block_N, k * block_K], B_shared)
+                    T.gemm(A_shared, B_shared, C_local, transpose_B=True)
+                T.copy(C_local, C[by * block_M, bx * block_N])
+
+        return main
+
+    # This should compile and return a kernel without errors
+    kernel = matmul_kernel(M, N, K, __return_kernel=True)
+    assert kernel is not None
+
+
+@tilelang.testing.requires_cuda
+def test_autotune_decorator_pass_configs_override_jit_global():
+    """Test that per-config pass_configs in @autotune override @tilelang.jit's global pass_configs."""
+    M, N, K = 128, 128, 128
+
+    configs = _get_test_configs_mixed()
+
+    @autotune(configs=configs, warmup=1, rep=3, skip_check=True, supply_type=tilelang.TensorSupplyType.Integer)
+    @tilelang.jit(out_idx=[-1], pass_configs={PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True})
+    def matmul_kernel(M, N, K, block_M=64, block_N=64, block_K=64):
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, K), T.float16),
+            B: T.Tensor((N, K), T.float16),
+            C: T.Tensor((M, N), T.float16),
+        ):
+            with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+                A_shared = T.alloc_shared((block_M, block_K), T.float16)
+                B_shared = T.alloc_shared((block_N, block_K), T.float16)
+                C_local = T.alloc_fragment((block_M, block_N), T.float32)
+                T.clear(C_local)
+                for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=1):
+                    T.copy(A[by * block_M, k * block_K], A_shared)
+                    T.copy(B[bx * block_N, k * block_K], B_shared)
+                    T.gemm(A_shared, B_shared, C_local, transpose_B=True)
+                T.copy(C_local, C[by * block_M, bx * block_N])
+
+        return main
+
+    # This should compile and return a kernel without errors
+    kernel = matmul_kernel(M, N, K, __return_kernel=True)
+    assert kernel is not None
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/autotuner/grouped_compile.py
+++ b/tilelang/autotuner/grouped_compile.py
@@ -6,6 +6,7 @@ so tuner.py can stay focused on orchestration.
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from collections.abc import Callable
 
@@ -19,6 +20,8 @@ from tilelang.jit.adapter import TVMFFIKernelAdapter
 from tilelang.jit.kernel import JITKernel
 from tilelang.transform import PassConfigKey
 
+logger = logging.getLogger(__name__)
+
 CompileUnitResult = tuple[int, dict[str, Any], JITKernel | None, Exception | None]
 
 
@@ -26,11 +29,7 @@ def _merge_pass_configs_into_compile_args(
     base: CompileArgs,
     per_config_pass_configs: dict[str, Any] | None,
 ) -> CompileArgs:
-    """Merge per-config pass_configs over global CompileArgs defaults.
-
-    If *per_config_pass_configs* is None or empty, returns *base* unchanged.
-    Otherwise returns a new CompileArgs with merged pass_configs.
-    """
+    """Merge per-config pass_configs over global CompileArgs defaults."""
     if not per_config_pass_configs:
         return base
     merged = dict(base.pass_configs or {})
@@ -60,34 +59,28 @@ def compile_grouped_unit_tvm_ffi(
     5. Construct per-config JITKernel objects that share the grouped device module.
     """
 
-    # Extract per-config pass_configs and check uniformity
-    per_config_pass_configs_list = []
-    for _, config_arg in unit_items:
-        per_config_pass_configs_list.append(config_arg.pop("__pass_configs__", None))
+    per_config_pc_list = [cfg.pop("__pass_configs__", None) for _, cfg in unit_items]
 
-    # Determine if all per-config pass_configs are the same
-    # Normalize: treat None and {} (empty dict) as equivalent "no config"
-    normalized_list = [pc if pc else None for pc in per_config_pass_configs_list]
-    has_uniform_pass_configs = all(
-        pc == normalized_list[0] for pc in normalized_list[1:]
-    )
+    # Treat None and {} as equivalent for uniformity check
+    normalized = [pc if pc else None for pc in per_config_pc_list]
+    uniform = all(pc == normalized[0] for pc in normalized[1:])
 
-    if not has_uniform_pass_configs:
-        # Fall back to per-config compilation when pass_configs differ
+    if not uniform:
+        # Per-config compilation fallback
         unit_results: list[CompileUnitResult] = []
-        for (idx, config_arg), per_pc in zip(unit_items, per_config_pass_configs_list):
+        for (idx, config_arg), per_pc in zip(unit_items, per_config_pc_list, strict=True):
             try:
-                effective_compile_args = _merge_pass_configs_into_compile_args(compile_args, per_pc)
+                args = _merge_pass_configs_into_compile_args(compile_args, per_pc)
                 program = elaborate_func(**config_arg)
-                jit_kernel = effective_compile_args.compile_program(program)
+                jit_kernel = args.compile_program(program)
                 unit_results.append((idx, config_arg, jit_kernel, None))
             except Exception as e:
+                logger.debug("Per-config compile failed (idx=%d): %s", idx, e)
                 unit_results.append((idx, config_arg, None, e))
         return unit_results
 
-    # Resolve effective pass_configs for the uniform case
-    uniform_per_config_pc = normalized_list[0] if normalized_list else None
-    effective_compile_args = _merge_pass_configs_into_compile_args(compile_args, uniform_per_config_pc)
+    # Uniform pass_configs — proceed with grouped compilation
+    effective_compile_args = _merge_pass_configs_into_compile_args(compile_args, normalized[0])
     pass_configs = dict(effective_compile_args.pass_configs) if effective_compile_args.pass_configs else {}
 
     pass_instruments = []
@@ -125,6 +118,7 @@ def compile_grouped_unit_tvm_ffi(
                 }
             )
         except Exception as e:
+            logger.debug("Lowering failed (idx=%d): %s", idx, e)
             unit_results.append((idx, config_arg, None, e))
 
     if not lowered_items:
@@ -200,8 +194,10 @@ def compile_grouped_unit_tvm_ffi(
 
                 unit_results.append((idx, config_arg, jit_kernel, None))
             except Exception as e:
+                logger.debug("Host codegen failed (idx=%d): %s", idx, e)
                 unit_results.append((idx, config_arg, None, e))
     except Exception as e:
+        logger.debug("Grouped device codegen failed: %s", e)
         for item in lowered_items:
             unit_results.append((item["idx"], item["config_arg"], None, e))
 

--- a/tilelang/autotuner/grouped_compile.py
+++ b/tilelang/autotuner/grouped_compile.py
@@ -22,6 +22,29 @@ from tilelang.transform import PassConfigKey
 CompileUnitResult = tuple[int, dict[str, Any], JITKernel | None, Exception | None]
 
 
+def _merge_pass_configs_into_compile_args(
+    base: CompileArgs,
+    per_config_pass_configs: dict[str, Any] | None,
+) -> CompileArgs:
+    """Merge per-config pass_configs over global CompileArgs defaults.
+
+    If *per_config_pass_configs* is None or empty, returns *base* unchanged.
+    Otherwise returns a new CompileArgs with merged pass_configs.
+    """
+    if not per_config_pass_configs:
+        return base
+    merged = dict(base.pass_configs or {})
+    merged.update(per_config_pass_configs)
+    return CompileArgs(
+        out_idx=base.out_idx,
+        execution_backend=base.execution_backend,
+        target=base.target,
+        target_host=base.target_host,
+        verbose=base.verbose,
+        pass_configs=merged,
+    )
+
+
 def compile_grouped_unit_tvm_ffi(
     unit_items: list[tuple[int, dict[str, Any]]],
     compile_args: CompileArgs,
@@ -37,7 +60,36 @@ def compile_grouped_unit_tvm_ffi(
     5. Construct per-config JITKernel objects that share the grouped device module.
     """
 
-    pass_configs = dict(compile_args.pass_configs) if compile_args.pass_configs else {}
+    # Extract per-config pass_configs and check uniformity
+    per_config_pass_configs_list = []
+    for _, config_arg in unit_items:
+        per_config_pass_configs_list.append(config_arg.pop("__pass_configs__", None))
+
+    # Determine if all per-config pass_configs are the same
+    # Normalize: treat None and {} (empty dict) as equivalent "no config"
+    normalized_list = [pc if pc else None for pc in per_config_pass_configs_list]
+    has_uniform_pass_configs = all(
+        pc == normalized_list[0] for pc in normalized_list[1:]
+    )
+
+    if not has_uniform_pass_configs:
+        # Fall back to per-config compilation when pass_configs differ
+        unit_results: list[CompileUnitResult] = []
+        for (idx, config_arg), per_pc in zip(unit_items, per_config_pass_configs_list):
+            try:
+                effective_compile_args = _merge_pass_configs_into_compile_args(compile_args, per_pc)
+                program = elaborate_func(**config_arg)
+                jit_kernel = effective_compile_args.compile_program(program)
+                unit_results.append((idx, config_arg, jit_kernel, None))
+            except Exception as e:
+                unit_results.append((idx, config_arg, None, e))
+        return unit_results
+
+    # Resolve effective pass_configs for the uniform case
+    uniform_per_config_pc = normalized_list[0] if normalized_list else None
+    effective_compile_args = _merge_pass_configs_into_compile_args(compile_args, uniform_per_config_pc)
+    pass_configs = dict(effective_compile_args.pass_configs) if effective_compile_args.pass_configs else {}
+
     pass_instruments = []
     if pass_configs.get(PassConfigKey.TL_ENABLE_DUMP_IR):
         dump_ir_path = pass_configs.get(PassConfigKey.TL_DUMP_IR_DIR, "./dump_ir")

--- a/tilelang/autotuner/grouped_compile.py
+++ b/tilelang/autotuner/grouped_compile.py
@@ -6,7 +6,6 @@ so tuner.py can stay focused on orchestration.
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 from collections.abc import Callable
 
@@ -20,28 +19,7 @@ from tilelang.jit.adapter import TVMFFIKernelAdapter
 from tilelang.jit.kernel import JITKernel
 from tilelang.transform import PassConfigKey
 
-logger = logging.getLogger(__name__)
-
 CompileUnitResult = tuple[int, dict[str, Any], JITKernel | None, Exception | None]
-
-
-def _merge_pass_configs_into_compile_args(
-    base: CompileArgs,
-    per_config_pass_configs: dict[str, Any] | None,
-) -> CompileArgs:
-    """Merge per-config pass_configs over global CompileArgs defaults."""
-    if not per_config_pass_configs:
-        return base
-    merged = dict(base.pass_configs or {})
-    merged.update(per_config_pass_configs)
-    return CompileArgs(
-        out_idx=base.out_idx,
-        execution_backend=base.execution_backend,
-        target=base.target,
-        target_host=base.target_host,
-        verbose=base.verbose,
-        pass_configs=merged,
-    )
 
 
 def compile_grouped_unit_tvm_ffi(
@@ -59,30 +37,7 @@ def compile_grouped_unit_tvm_ffi(
     5. Construct per-config JITKernel objects that share the grouped device module.
     """
 
-    per_config_pc_list = [cfg.pop("__pass_configs__", None) for _, cfg in unit_items]
-
-    # Treat None and {} as equivalent for uniformity check
-    normalized = [pc if pc else None for pc in per_config_pc_list]
-    uniform = all(pc == normalized[0] for pc in normalized[1:])
-
-    if not uniform:
-        # Per-config compilation fallback
-        unit_results: list[CompileUnitResult] = []
-        for (idx, config_arg), per_pc in zip(unit_items, per_config_pc_list, strict=True):
-            try:
-                args = _merge_pass_configs_into_compile_args(compile_args, per_pc)
-                program = elaborate_func(**config_arg)
-                jit_kernel = args.compile_program(program)
-                unit_results.append((idx, config_arg, jit_kernel, None))
-            except Exception as e:
-                logger.debug("Per-config compile failed (idx=%d): %s", idx, e)
-                unit_results.append((idx, config_arg, None, e))
-        return unit_results
-
-    # Uniform pass_configs — proceed with grouped compilation
-    effective_compile_args = _merge_pass_configs_into_compile_args(compile_args, normalized[0])
-    pass_configs = dict(effective_compile_args.pass_configs) if effective_compile_args.pass_configs else {}
-
+    pass_configs = dict(compile_args.pass_configs) if compile_args.pass_configs else {}
     pass_instruments = []
     if pass_configs.get(PassConfigKey.TL_ENABLE_DUMP_IR):
         dump_ir_path = pass_configs.get(PassConfigKey.TL_DUMP_IR_DIR, "./dump_ir")
@@ -118,7 +73,6 @@ def compile_grouped_unit_tvm_ffi(
                 }
             )
         except Exception as e:
-            logger.debug("Lowering failed (idx=%d): %s", idx, e)
             unit_results.append((idx, config_arg, None, e))
 
     if not lowered_items:
@@ -194,10 +148,8 @@ def compile_grouped_unit_tvm_ffi(
 
                 unit_results.append((idx, config_arg, jit_kernel, None))
             except Exception as e:
-                logger.debug("Host codegen failed (idx=%d): %s", idx, e)
                 unit_results.append((idx, config_arg, None, e))
     except Exception as e:
-        logger.debug("Grouped device codegen failed: %s", e)
         for item in lowered_items:
             unit_results.append((item["idx"], item["config_arg"], None, e))
 

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -33,7 +33,7 @@ import traceback
 from pathlib import Path
 
 from tilelang.autotuner.param import CompileArgs, ProfileArgs, AutotuneResult
-from tilelang.autotuner.grouped_compile import compile_grouped_unit_tvm_ffi, _merge_pass_configs_into_compile_args
+from tilelang.autotuner.grouped_compile import compile_grouped_unit_tvm_ffi
 from tilelang.utils.language import get_prim_func_name
 from tilelang.autotuner.capture import get_autotune_inputs
 from tilelang.backend.target import determine_target
@@ -478,17 +478,31 @@ class AutoTuner:
         return result
 
     # Compile-related helpers
+    def _merge_pass_configs_into_compile_args(
+        self,
+        per_config_pass_configs: dict[str, Any] | None,
+    ) -> CompileArgs:
+        """Merge per-config pass_configs over global CompileArgs defaults."""
+        if not per_config_pass_configs:
+            return self.compile_args
+        merged = dict(self.compile_args.pass_configs or {})
+        merged.update(per_config_pass_configs)
+        return CompileArgs(
+            out_idx=self.compile_args.out_idx,
+            execution_backend=self.compile_args.execution_backend,
+            target=self.compile_args.target,
+            target_host=self.compile_args.target_host,
+            verbose=self.compile_args.verbose,
+            pass_configs=merged,
+        )
+
     def _default_compile(
         self,
         **config_arg,
     ) -> tilelang.JITKernel:
         per_config_pass_configs = config_arg.pop("__pass_configs__", None)
-        compile_args = self._resolve_compile_args(per_config_pass_configs)
+        compile_args = self._merge_pass_configs_into_compile_args(per_config_pass_configs)
         return compile_args.compile_program(self.fn(**config_arg))
-
-    def _resolve_compile_args(self, per_config_pass_configs: dict[str, Any] | None) -> CompileArgs:
-        """Resolve CompileArgs, merging per-config pass_configs over the global defaults."""
-        return _merge_pass_configs_into_compile_args(self.compile_args, per_config_pass_configs)
 
     def _default_elaborate(self, **config_arg) -> PrimFunc:
         config_arg.pop("__pass_configs__", None)
@@ -583,11 +597,12 @@ class AutoTuner:
                 elaborate_impl = cuda_device_wrapper(elaborate_func, device)
             return elaborate_impl
 
-        def compile_unit(unit_items: list[tuple[int, dict[str, Any]]]):
+        def compile_unit(unit_items: list[tuple[int, dict[str, Any]]], per_config_pass_configs=None):
             if grouped_compile_active:
+                effective_compile_args = self._merge_pass_configs_into_compile_args(per_config_pass_configs)
                 return compile_grouped_unit_tvm_ffi(
                     unit_items=unit_items,
-                    compile_args=self.compile_args,
+                    compile_args=effective_compile_args,
                     elaborate_func=get_elaborate_func(),
                 )
             compile_impl = get_compile_func()
@@ -600,17 +615,26 @@ class AutoTuner:
                     unit_results.append((idx, config_arg, None, e))
             return unit_results
 
-        compile_units: list[list[tuple[int, dict[str, Any]]]] = []
+        compile_units: list[tuple[list[tuple[int, dict[str, Any]]], dict | None]] = []
         if grouped_compile_active:
-            for start in range(0, len(config_args), group_compile_size):
-                end = min(start + group_compile_size, len(config_args))
-                compile_units.append([(i, config_args[i]) for i in range(start, end)])
+            # Bucket configs by __pass_configs__ value
+            buckets: dict[tuple | None, list[tuple[int, dict[str, Any], dict | None]]] = {}
+            for i, cfg in enumerate(config_args):
+                pc = cfg.pop("__pass_configs__", None)
+                key = tuple(sorted(pc.items())) if pc else None
+                buckets.setdefault(key, []).append((i, cfg, pc))
+            for bucket_items in buckets.values():
+                per_pc = bucket_items[0][2]  # all items in bucket share same pass_configs
+                items = [(idx, cfg) for idx, cfg, _ in bucket_items]
+                for start in range(0, len(items), group_compile_size):
+                    end = min(start + group_compile_size, len(items))
+                    compile_units.append((items[start:end], per_pc))
         else:
             for i, config_arg in enumerate(config_args):
-                compile_units.append([(i, config_arg)])
+                compile_units.append(([(i, config_arg)], None))
 
-        for unit_items in compile_units:
-            future = pool.submit(compile_unit, unit_items)
+        for unit_items, per_pc in compile_units:
+            future = pool.submit(compile_unit, unit_items, per_pc)
             futures.append(future)
             future_to_unit[future] = unit_items
 
@@ -1053,8 +1077,6 @@ class AutoTuner:
             nonlocal best_latency, best_config, best_kernel
             if latency < best_latency:
                 best_latency = latency
-                # Use the original user config (which contains 'pass_configs' if specified)
-                # instead of the internal config_arg (which uses '__pass_configs__')
                 best_config = dict(self.configs[idx])
                 best_kernel = jit_kernel
 

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -41,6 +41,12 @@ from tilelang import __version__
 
 TargetLike = str | dict[str, object] | Target
 
+ConfigArg = dict[str, Any]
+UnitItem = tuple[int, ConfigArg]
+UnitResult = tuple[int, ConfigArg, tilelang.JITKernel | None, Exception | None]
+CompileUnit = tuple[list[UnitItem], dict | None]
+BucketItem = tuple[int, ConfigArg, dict | None]
+
 # Reserved keys that are not kernel parameters but control compilation behavior
 _RESERVED_CONFIG_KEYS = frozenset({"pass_configs"})
 
@@ -563,7 +569,7 @@ class AutoTuner:
 
     def _prepare_compile_execution(
         self,
-        config_args: list[dict[str, Any]],
+        config_args: list[ConfigArg],
         grouped_compile_active: bool,
         group_compile_size: int,
         compile_func: Callable[..., tilelang.JITKernel],
@@ -571,13 +577,13 @@ class AutoTuner:
     ) -> tuple[
         concurrent.futures.ThreadPoolExecutor,
         list[concurrent.futures.Future],
-        dict[concurrent.futures.Future, list[tuple[int, dict[str, Any]]]],
+        dict[concurrent.futures.Future, list[UnitItem]],
         str,
     ]:
         num_workers = self._resolve_num_compile_workers()
         pool = concurrent.futures.ThreadPoolExecutor(max_workers=num_workers)
         futures: list[concurrent.futures.Future] = []
-        future_to_unit: dict[concurrent.futures.Future, list[tuple[int, dict[str, Any]]]] = {}
+        future_to_unit: dict[concurrent.futures.Future, list[UnitItem]] = {}
 
         def cuda_device_wrapper(func: Callable[..., Any], device: int):
             def inner(**config_arg):
@@ -600,7 +606,7 @@ class AutoTuner:
                 elaborate_impl = cuda_device_wrapper(elaborate_func, device)
             return elaborate_impl
 
-        def compile_unit(unit_items: list[tuple[int, dict[str, Any]]], per_config_pass_configs=None):
+        def compile_unit(unit_items: list[UnitItem], per_config_pass_configs=None):
             if grouped_compile_active:
                 effective_compile_args = self._merge_pass_configs_into_compile_args(per_config_pass_configs)
                 return compile_grouped_unit_tvm_ffi(
@@ -609,7 +615,7 @@ class AutoTuner:
                     elaborate_func=get_elaborate_func(),
                 )
             compile_impl = get_compile_func()
-            unit_results: list[tuple[int, dict[str, Any], tilelang.JITKernel | None, Exception | None]] = []
+            unit_results: list[UnitResult] = []
             for idx, config_arg in unit_items:
                 try:
                     jit_kernel = compile_impl(**config_arg)
@@ -618,10 +624,10 @@ class AutoTuner:
                     unit_results.append((idx, config_arg, None, e))
             return unit_results
 
-        compile_units: list[tuple[list[tuple[int, dict[str, Any]]], dict | None]] = []
+        compile_units: list[CompileUnit] = []
         if grouped_compile_active:
             # Bucket configs by per-config pass_configs value
-            buckets: dict[tuple | None, list[tuple[int, dict[str, Any], dict | None]]] = {}
+            buckets: dict[tuple | None, list[BucketItem]] = {}
             for i, cfg in enumerate(config_args):
                 pc = cfg.pop(_PASS_CONFIGS_KEY, None)
                 key = tuple(sorted(pc.items())) if pc else None

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -33,13 +33,16 @@ import traceback
 from pathlib import Path
 
 from tilelang.autotuner.param import CompileArgs, ProfileArgs, AutotuneResult
-from tilelang.autotuner.grouped_compile import compile_grouped_unit_tvm_ffi
+from tilelang.autotuner.grouped_compile import compile_grouped_unit_tvm_ffi, _merge_pass_configs_into_compile_args
 from tilelang.utils.language import get_prim_func_name
 from tilelang.autotuner.capture import get_autotune_inputs
 from tilelang.backend.target import determine_target
 from tilelang import __version__
 
 TargetLike = str | dict[str, object] | Target
+
+# Reserved keys that are not kernel parameters but control compilation behavior
+_RESERVED_CONFIG_KEYS = frozenset({"pass_configs"})
 
 
 class TimeoutException(Exception):
@@ -479,10 +482,16 @@ class AutoTuner:
         self,
         **config_arg,
     ) -> tilelang.JITKernel:
-        compile_args = self.compile_args
+        per_config_pass_configs = config_arg.pop("__pass_configs__", None)
+        compile_args = self._resolve_compile_args(per_config_pass_configs)
         return compile_args.compile_program(self.fn(**config_arg))
 
+    def _resolve_compile_args(self, per_config_pass_configs: dict[str, Any] | None) -> CompileArgs:
+        """Resolve CompileArgs, merging per-config pass_configs over the global defaults."""
+        return _merge_pass_configs_into_compile_args(self.compile_args, per_config_pass_configs)
+
     def _default_elaborate(self, **config_arg) -> PrimFunc:
+        config_arg.pop("__pass_configs__", None)
         return self.fn(**config_arg)
 
     def _ensure_jit_functions(
@@ -968,13 +977,15 @@ class AutoTuner:
         config_args = []
         for config in self.configs:
             new_kwargs = {}
+            per_config_pass_configs = config.get("pass_configs", None)
             keys = config.keys()
             for name, _ in parameters.items():
                 if name in config:
                     new_kwargs[name] = config[name]
-            unused_keys = set(keys) - set(new_kwargs.keys())
+            unused_keys = set(keys) - set(new_kwargs.keys()) - _RESERVED_CONFIG_KEYS
             if len(unused_keys) > 0:
                 raise ValueError(f"Unused keys in config: {unused_keys}")
+            new_kwargs["__pass_configs__"] = per_config_pass_configs
             config_args.append(new_kwargs)
 
         if len(config_args) == 0:
@@ -997,7 +1008,7 @@ class AutoTuner:
 
         if self._kernel_parameters is not None:
             key_args_tuple, key_kwargs_tuple = self._kernel_parameters
-            tunable_arguments = [key for key, _ in top_config.items()]
+            tunable_arguments = [key for key, _ in top_config.items() if key != "__pass_configs__"]
 
             def check_tunable_argument_value(key, parameters, key_args_tuple) -> bool:
                 params_list = list(parameters.keys())
@@ -1042,11 +1053,13 @@ class AutoTuner:
             nonlocal best_latency, best_config, best_kernel
             if latency < best_latency:
                 best_latency = latency
-                best_config = config
+                # Use the original user config (which contains 'pass_configs' if specified)
+                # instead of the internal config_arg (which uses '__pass_configs__')
+                best_config = dict(self.configs[idx])
                 best_kernel = jit_kernel
 
             progress_bar.set_postfix({"best_latency": best_latency})
-            tqdm.write(f"Tuned Latency {latency} with config {config} at index {idx}")
+            tqdm.write(f"Tuned Latency {latency} with config {self.configs[idx]} at index {idx}")
 
         benchmark_worker_devices = benchmark_device_list if benchmark_multi_gpu_active else [benchmark_device_list[0]]
         benchmark_task_queues = [queue.Queue() for _ in benchmark_worker_devices]
@@ -1083,10 +1096,10 @@ class AutoTuner:
             progress_bar.update(1)
 
             if status == "timeout":
-                logger.warning(f"A timeout occurred while testing config {config}, checkout autotuner.log for more details")
+                logger.warning(f"A timeout occurred while testing config {self.configs[idx]}, checkout autotuner.log for more details")
                 return
             if status == "error":
-                logger.warning(f"An error occurred while testing config {config}, checkout autotuner.log for more details")
+                logger.warning(f"An error occurred while testing config {self.configs[idx]}, checkout autotuner.log for more details")
                 if error_text:
                     logger.debug(f"Error: {error_text}")
                 return
@@ -1152,7 +1165,7 @@ class AutoTuner:
                     compile_progress.update(len(unit_results))
                     for idx, config, jit_kernel, error in unit_results:
                         if error is not None:
-                            logger.debug(f"Compilation failed for config {config} at index {idx} with error: {error}")
+                            logger.debug(f"Compilation failed for config {self.configs[idx]} at index {idx} with error: {error}")
                             continue
                         assert jit_kernel is not None
                         _enqueue_benchmark_task(jit_kernel=jit_kernel, config=config, idx=idx)
@@ -1250,6 +1263,38 @@ class AutoTuneImpl(Generic[_P, _T]):
 
     def __post_init__(self):
         self._tuner_cache = {}
+        self._pass_configs_lock = threading.Lock()
+
+    def _make_jit_compile_func(self, mode: str, args: tuple, kwargs: dict) -> Callable[..., JITKernel]:
+        """Create a jit_compile closure for the given mode ('lazy' or 'eager').
+
+        The pass_configs handling logic is shared; only the final compilation
+        call differs between modes.
+        """
+
+        def jit_compile(**config_arg):
+            per_config_pass_configs = config_arg.pop("__pass_configs__", None)
+            if per_config_pass_configs is not None:
+                with self._pass_configs_lock:
+                    original_pass_configs = self.jit_impl.pass_configs
+                    merged_pc = dict(original_pass_configs or {})
+                    merged_pc.update(per_config_pass_configs)
+                    self.jit_impl.pass_configs = merged_pc
+                    try:
+                        merged = dict(kwargs)
+                        merged.update(config_arg)
+                        return self.jit_impl.compile(*args, **merged)
+                    finally:
+                        self.jit_impl.pass_configs = original_pass_configs
+            else:
+                if mode == "lazy":
+                    return self.jit_impl(*args, **kwargs, __tune_params=config_arg)
+                else:
+                    merged = dict(kwargs)
+                    merged.update(config_arg)
+                    return self.jit_impl.compile(*args, **merged)
+
+        return jit_compile
 
     def get_tunner(self):
         autotuner = (
@@ -1303,28 +1348,14 @@ class AutoTuneImpl(Generic[_P, _T]):
         if key not in self._tuner_cache:
 
             def jit_elaborate(**config_arg):
+                config_arg.pop("__pass_configs__", None)
                 merged = dict(kwargs)
                 merged.update(config_arg)
                 return self.jit_impl.get_tir(*args, **merged)
 
-            if mode == "lazy":
-
-                def jit_compile(**config_arg):
-                    return self.jit_impl(*args, **kwargs, __tune_params=config_arg)
-
-                autotuner.jit_compile = jit_compile
-                autotuner.jit_elaborate = jit_elaborate
-                autotuner.set_kernel_parameters(key, self.jit_impl.signature.parameters)
-            else:
-
-                def jit_compile(**config_arg):
-                    merged = dict(kwargs)
-                    merged.update(config_arg)
-                    return self.jit_impl.compile(*args, **merged)
-
-                autotuner.jit_compile = jit_compile
-                autotuner.jit_elaborate = jit_elaborate
-                autotuner.set_kernel_parameters(key, self.jit_impl.signature.parameters)
+            autotuner.jit_compile = self._make_jit_compile_func(mode, args, kwargs)
+            autotuner.jit_elaborate = jit_elaborate
+            autotuner.set_kernel_parameters(key, self.jit_impl.signature.parameters)
 
             artifact = autotuner.run()
             self._tuner_cache[key] = artifact.kernel, artifact.config
@@ -1338,7 +1369,7 @@ class AutoTuneImpl(Generic[_P, _T]):
                 return best_kernel
             exec_kwargs = dict(kwargs)
             if best_config is not None:
-                exec_kwargs.update(best_config)
+                exec_kwargs.update({k: v for k, v in best_config.items() if k not in _RESERVED_CONFIG_KEYS})
             _, kernel_args = self.jit_impl.func.parse_args(*args, **exec_kwargs)
             return best_kernel(*kernel_args.values())
 

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -44,6 +44,9 @@ TargetLike = str | dict[str, object] | Target
 # Reserved keys that are not kernel parameters but control compilation behavior
 _RESERVED_CONFIG_KEYS = frozenset({"pass_configs"})
 
+# Internal key used to pass per-config pass_configs through config_arg dicts
+_PASS_CONFIGS_KEY = "__pass_configs__"
+
 
 class TimeoutException(Exception):
     pass
@@ -500,12 +503,12 @@ class AutoTuner:
         self,
         **config_arg,
     ) -> tilelang.JITKernel:
-        per_config_pass_configs = config_arg.pop("__pass_configs__", None)
+        per_config_pass_configs = config_arg.pop(_PASS_CONFIGS_KEY, None)
         compile_args = self._merge_pass_configs_into_compile_args(per_config_pass_configs)
         return compile_args.compile_program(self.fn(**config_arg))
 
     def _default_elaborate(self, **config_arg) -> PrimFunc:
-        config_arg.pop("__pass_configs__", None)
+        config_arg.pop(_PASS_CONFIGS_KEY, None)
         return self.fn(**config_arg)
 
     def _ensure_jit_functions(
@@ -617,10 +620,10 @@ class AutoTuner:
 
         compile_units: list[tuple[list[tuple[int, dict[str, Any]]], dict | None]] = []
         if grouped_compile_active:
-            # Bucket configs by __pass_configs__ value
+            # Bucket configs by per-config pass_configs value
             buckets: dict[tuple | None, list[tuple[int, dict[str, Any], dict | None]]] = {}
             for i, cfg in enumerate(config_args):
-                pc = cfg.pop("__pass_configs__", None)
+                pc = cfg.pop(_PASS_CONFIGS_KEY, None)
                 key = tuple(sorted(pc.items())) if pc else None
                 buckets.setdefault(key, []).append((i, cfg, pc))
             for bucket_items in buckets.values():
@@ -1009,7 +1012,7 @@ class AutoTuner:
             unused_keys = set(keys) - set(new_kwargs.keys()) - _RESERVED_CONFIG_KEYS
             if len(unused_keys) > 0:
                 raise ValueError(f"Unused keys in config: {unused_keys}")
-            new_kwargs["__pass_configs__"] = per_config_pass_configs
+            new_kwargs[_PASS_CONFIGS_KEY] = per_config_pass_configs
             config_args.append(new_kwargs)
 
         if len(config_args) == 0:
@@ -1032,7 +1035,7 @@ class AutoTuner:
 
         if self._kernel_parameters is not None:
             key_args_tuple, key_kwargs_tuple = self._kernel_parameters
-            tunable_arguments = [key for key, _ in top_config.items() if key != "__pass_configs__"]
+            tunable_arguments = [key for key, _ in top_config.items() if key != _PASS_CONFIGS_KEY]
 
             def check_tunable_argument_value(key, parameters, key_args_tuple) -> bool:
                 params_list = list(parameters.keys())
@@ -1290,31 +1293,27 @@ class AutoTuneImpl(Generic[_P, _T]):
     def _make_jit_compile_func(self, mode: str, args: tuple, kwargs: dict) -> Callable[..., JITKernel]:
         """Create a jit_compile closure for the given mode ('lazy' or 'eager').
 
-        The pass_configs handling logic is shared; only the final compilation
-        call differs between modes.
+        All compilation paths are serialized under _pass_configs_lock because
+        per-config pass_configs temporarily mutates self.jit_impl.pass_configs.
         """
 
         def jit_compile(**config_arg):
-            per_config_pass_configs = config_arg.pop("__pass_configs__", None)
-            if per_config_pass_configs is not None:
-                with self._pass_configs_lock:
-                    original_pass_configs = self.jit_impl.pass_configs
+            per_config_pass_configs = config_arg.pop(_PASS_CONFIGS_KEY, None)
+            with self._pass_configs_lock:
+                original_pass_configs = self.jit_impl.pass_configs
+                if per_config_pass_configs is not None:
                     merged_pc = dict(original_pass_configs or {})
                     merged_pc.update(per_config_pass_configs)
                     self.jit_impl.pass_configs = merged_pc
-                    try:
-                        merged = dict(kwargs)
-                        merged.update(config_arg)
-                        return self.jit_impl.compile(*args, **merged)
-                    finally:
-                        self.jit_impl.pass_configs = original_pass_configs
-            else:
-                if mode == "lazy":
-                    return self.jit_impl(*args, **kwargs, __tune_params=config_arg)
-                else:
+
+                try:
+                    if per_config_pass_configs is None and mode == "lazy":
+                        return self.jit_impl(*args, **kwargs, __tune_params=config_arg)
                     merged = dict(kwargs)
                     merged.update(config_arg)
                     return self.jit_impl.compile(*args, **merged)
+                finally:
+                    self.jit_impl.pass_configs = original_pass_configs
 
         return jit_compile
 
@@ -1370,7 +1369,7 @@ class AutoTuneImpl(Generic[_P, _T]):
         if key not in self._tuner_cache:
 
             def jit_elaborate(**config_arg):
-                config_arg.pop("__pass_configs__", None)
+                config_arg.pop(_PASS_CONFIGS_KEY, None)
                 merged = dict(kwargs)
                 merged.update(config_arg)
                 return self.jit_impl.get_tir(*args, **merged)


### PR DESCRIPTION
## Summary

Add support for specifying per-config `pass_configs` in the AutoTuner, allowing each tuning configuration to apply different compiler pass settings (e.g., enabling/disabling warp specialization per config). This enables more fine-grained exploration of compiler optimization combinations during autotuning.

## Changes

### Core Feature
- Each config in `configs` can now include a `pass_configs` key that overrides the global `pass_configs` for that specific compilation
- Per-config `pass_configs` is merged on top of global `pass_configs` (per-config takes priority)
- Supports both API mode (`AutoTuner.run()`) and decorator mode (`@autotune + @tilelang.jit`)

### Code Quality Improvements
- Extract `_merge_pass_configs_into_compile_args()` helper to deduplicate pass_configs merge logic across `grouped_compile.py` and `tuner.py`
- Replace `json.dumps` uniformity check with direct equality comparison (avoids unnecessary serialization overhead in large-scale tuning)
- Extract `_make_jit_compile_func()` factory method to unify lazy/eager `jit_compile` closure logic

### Bug Fix
- Fix decorator-mode cache isolation: use `compile()` directly when `per_config_pass_configs` is present to avoid JIT cache key collision (previously all configs with different pass_configs would share one cached result)

## Usage Example

```python
configs = [
    {"block_M": 128, "block_N": 128, "block_K": 32, "num_stages": 2, "thread_num": 128,
     "pass_configs": {PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True}},
    {"block_M": 128, "block_N": 128, "block_K": 32, "num_stages": 2, "thread_num": 128,
     "pass_configs": {PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: False}},
]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Added per-config `pass_configs` support to AutoTuner in both API mode and decorator/JIT flows.
- Per-config `pass_configs` are merged on top of global `pass_configs`, with per-config values taking priority, and `pass_configs` is treated as a reserved non-tunable key so it isn’t interpreted as an autotuning parameter.
- Updated grouped compilation to apply per-config `pass_configs` during compilation: when configs’ `pass_configs` differ, it bypasses grouped lowering/codegen and compiles each config separately; when uniform, it merges once and proceeds with grouped compilation.
- Extracted/centralized `pass_configs` merge logic and refactored JIT compilation plumbing to unify lazy/eager `jit_compile` closure behavior, including decorator-mode cache isolation fixes by using `compile()` directly when per-config `pass_configs` are present to avoid cache key collisions.
- Changed the grouped uniformity check for `pass_configs` from `json.dumps` comparison to direct equality.
- Added a GEMM autotuning example demonstrating per-config `pass_configs` usage (including `PassConfigKey.TL_DISABLE_WARP_SPECIALIZED`), plus CUDA-only tests covering per-config behavior, mixed global-vs-per-config handling, merge correctness, and decorator precedence/override.

## C++ style / lint notes
- This PR does not touch C++ code, FFI surfaces, or CI/lint/tooling configurations related to C++ style.
- No changes were made to `docs/developer_guide/cpp_style.md`, and no new TLCPP003/TLCPP004 warning-only issues are expected from this change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->