### PR TITLE
[Testing][CI] Isolate perf regression runner imports

### DIFF
--- a/maint/scripts/run_current_regression.py
+++ b/maint/scripts/run_current_regression.py
@@ -218,6 +218,7 @@ def _run_regression_case(
     case_id: str,
     examples_root: str | os.PathLike[str] | None,
     repo_root: Path,
+    use_installed_package: bool,
 ) -> tuple[dict[str, object] | None, dict[str, object] | None]:
     script = Path(__file__).with_name("regression_all.py")
     cmd = [sys.executable, str(script), "--format", "rich-json", case_id]
@@ -225,8 +226,9 @@ def _run_regression_case(
         cmd.extend(["--examples-root", str(examples_root)])
 
     child_env = os.environ.copy()
-    pythonpath = child_env.get("PYTHONPATH", "")
-    child_env["PYTHONPATH"] = str(repo_root) if not pythonpath else str(repo_root) + os.pathsep + pythonpath
+    if not use_installed_package:
+        pythonpath = child_env.get("PYTHONPATH", "")
+        child_env["PYTHONPATH"] = str(repo_root) if not pythonpath else str(repo_root) + os.pathsep + pythonpath
 
     proc = subprocess.Popen(
         cmd,
@@ -339,6 +341,11 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--refresh", action="store_true", help="Rerun selected cases and overwrite cached results")
     parser.add_argument("--list", action="store_true", help="List selected cases and cache status without running")
     parser.add_argument("--fail-on-error", action="store_true", help="Exit non-zero if any selected case fails")
+    parser.add_argument(
+        "--use-installed-package",
+        action="store_true",
+        help="Do not prepend the repo root to child PYTHONPATH; use the package installed in the active environment.",
+    )
     parser.add_argument("--output", default=None, help="Write final JSON payload to this path")
     parser.add_argument("--format", choices=("markdown", "json"), default="markdown", help="Final stdout format")
     return parser.parse_args(argv)
@@ -376,7 +383,7 @@ def main(argv: Sequence[str] | None = None) -> None:
             cache = _empty_cache(git_state, env_meta, env_key)
         for idx, case_id in enumerate(missing_case_ids, 1):
             print(f"\n[{idx}/{len(missing_case_ids)}] {case_id}")
-            run_data, failure = _run_regression_case(case_id, args.examples_root, repo_root)
+            run_data, failure = _run_regression_case(case_id, args.examples_root, repo_root, args.use_installed_package)
             if run_data is not None:
                 _merge_run_into_cache(cache, run_data)
             elif failure is not None:

--- a/maint/scripts/run_perf_regression.sh
+++ b/maint/scripts/run_perf_regression.sh
@@ -25,11 +25,13 @@
 #   REGRESSION_THRESHOLD Speedup threshold for FAIL_ON_REGRESSION (default: 1.0)
 #   FAIL_ON_MISSING      Exit non-zero if one side is missing results when set to 1
 #   CMAKE_GENERATOR      CMake generator for package builds (default: Ninja)
+#   INHERIT_PYTHONPATH   Keep caller PYTHONPATH when set to 1 (default: 0)
+#   EXTRA_PYTHONPATH     PYTHONPATH to expose to regression/compare processes
 
 set -euo pipefail
 
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
-    sed -n '1,35p' "$0"
+    sed -n '1,29p' "$0"
     exit 0
 fi
 
@@ -60,6 +62,8 @@ FAIL_ON_REGRESSION="${FAIL_ON_REGRESSION:-0}"
 REGRESSION_THRESHOLD="${REGRESSION_THRESHOLD:-1.0}"
 FAIL_ON_MISSING="${FAIL_ON_MISSING:-0}"
 UPDATE_SUBMODULES="${UPDATE_SUBMODULES:-1}"
+INHERIT_PYTHONPATH="${INHERIT_PYTHONPATH:-0}"
+EXTRA_PYTHONPATH="${EXTRA_PYTHONPATH:-}"
 
 mkdir -p "${WORK_DIR}"
 WORK_DIR="$(cd "${WORK_DIR}" && pwd)"
@@ -77,6 +81,20 @@ RESULT_PNG="${WORK_DIR}/regression_result.png"
 RESULT_JSON="${WORK_DIR}/regression_result.json"
 
 REGRESSION_ARGS=("$@")
+
+run_isolated_python() {
+    if [[ "${INHERIT_PYTHONPATH}" == "1" ]]; then
+        if [[ -n "${EXTRA_PYTHONPATH}" ]]; then
+            PYTHONPATH="${EXTRA_PYTHONPATH}${PYTHONPATH:+:${PYTHONPATH}}" "$@"
+        else
+            "$@"
+        fi
+    elif [[ -n "${EXTRA_PYTHONPATH}" ]]; then
+        PYTHONPATH="${EXTRA_PYTHONPATH}" "$@"
+    else
+        env -u PYTHONPATH "$@"
+    fi
+}
 
 handle_interrupt() {
     local status=$?
@@ -213,8 +231,10 @@ run_regression() {
     echo "============================================"
     (
         cd "${repo_dir}"
-        "${python_bin}" "${repo_dir}/maint/scripts/run_current_regression.py" \
+        run_isolated_python "${python_bin}" "${SCRIPT_DIR}/run_current_regression.py" \
             "${runner_flags[@]}" \
+            "--examples-root" "${repo_dir}/examples" \
+            "--use-installed-package" \
             "${REGRESSION_ARGS[@]}"
     )
 }
@@ -244,7 +264,7 @@ compare_results() {
     echo "============================================"
     echo "Comparing results"
     echo "============================================"
-    "${CURRENT_VENV}/bin/python" "${SCRIPT_DIR}/compare_perf_regression.py" "${compare_flags[@]}"
+    run_isolated_python "${CURRENT_VENV}/bin/python" "${SCRIPT_DIR}/compare_perf_regression.py" "${compare_flags[@]}"
 }
 
 fetch_baseline


### PR DESCRIPTION
## Summary

- Prevent the performance regression wrapper from inheriting caller PYTHONPATH by default.
- Make current and baseline runs use the TileLang package installed in their dedicated virtual environments.
- Keep an explicit escape hatch for callers that intentionally need additional Python import paths.

## Changes

- Add a `--use-installed-package` mode to `run_current_regression.py` so child benchmark runs do not prepend the repository root to PYTHONPATH.
- Add isolated Python invocation in `run_perf_regression.sh`, with `INHERIT_PYTHONPATH` and `EXTRA_PYTHONPATH` environment controls.
- Run both current and baseline regressions through the current wrapper script while pointing `--examples-root` at the checkout being measured.
- Keep result comparison under the same isolated import environment.

## Validation

- `./format.sh`
- `bash -n maint/scripts/run_perf_regression.sh`
- `python -m py_compile maint/scripts/run_current_regression.py maint/scripts/regression_all.py maint/scripts/compare_perf_regression.py`
- Narrow perf-regression smoke tests for `gemm/regression_example_gemm.py::example_gemm` and `attention_sink/regression_attention_sink.py::example_mha_sink_fwd_bhsd` passed with reused local virtual environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Added `--use-installed-package` to `run_current_regression.py` so benchmark subprocesses can use the package installed in their virtual environment instead of inheriting the repo root via `PYTHONPATH`.
- Updated `run_perf_regression.sh` to launch regression and comparison Python steps through an isolated wrapper that can strip or preserve `PYTHONPATH`, with optional `EXTRA_PYTHONPATH`.
- Switched perf regression orchestration to pass `--examples-root` and `--use-installed-package`, while keeping current/baseline comparisons under the same isolated import setup.

## Validation
- `./format.sh`
- Shell syntax checks
- Python compilation of updated scripts
- Narrow perf-regression smoke tests for GEMM and attention sink examples

## C++ style / lint notes
- This PR does not modify `docs/developer_guide/cpp_style.md` or any C++ sources.
- The C++ API Style Audit (warning only) CI step is not materially affected here; no new C++ API/style warnings are introduced by these script-only changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->