### PR TITLE
[BugFix] Sign-extend packed uint32 signed decode

### DIFF
--- a/testing/python/issue/test_tilelang_u32_signed_decode.py
+++ b/testing/python/issue/test_tilelang_u32_signed_decode.py
@@ -1,0 +1,54 @@
+import math
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.testing
+import tilelang.language as T
+from tilelang.quantize.quantization import _tir_u32_to_int_to_float
+
+
+def _pack_signed_values(values: list[int], nbit: int) -> torch.Tensor:
+    lanes_per_word = 32 // nbit
+    words = []
+    mask = (1 << nbit) - 1
+    for word_start in range(0, len(values), lanes_per_word):
+        packed = 0
+        for pos, value in enumerate(values[word_start : word_start + lanes_per_word]):
+            packed |= (value & mask) << (pos * nbit)
+        words.append(packed)
+    return torch.tensor(words, dtype=torch.uint32, device="cuda")
+
+
+@pytest.mark.parametrize(
+    "nbit,values",
+    [
+        (2, [-2, -1, 0, 1]),
+        (4, list(range(-8, 8))),
+        (8, [-128, -17, -1, 0, 1, 42, 127]),
+    ],
+)
+@tilelang.testing.requires_cuda
+def test_u32_to_int_to_float_sign_extends_subword_values(nbit, values):
+    """Signed sub-word decode should preserve negative values from uint32 storage."""
+
+    lanes_per_word = 32 // nbit
+    num_words = math.ceil(len(values) / lanes_per_word)
+    num_values = len(values)
+
+    @T.prim_func
+    def main(packed_values: T.Tensor((num_words,), "uint32"), decoded_values: T.Tensor((num_values,), "float32")):
+        with T.Kernel(1, threads=1) as _:
+            for i in T.serial(num_values):
+                decoded_values[i] = _tir_u32_to_int_to_float(nbit, packed_values[i // lanes_per_word], i % lanes_per_word, "float32")
+
+    kernel = tilelang.compile(main, target="cuda")
+    packed = _pack_signed_values(values, nbit)
+    out = torch.empty(num_values, dtype=torch.float32, device="cuda")
+    kernel(packed, out)
+    torch.testing.assert_close(out.cpu(), torch.tensor(values, dtype=torch.float32), rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/quantize/quantization.py
+++ b/tilelang/quantize/quantization.py
@@ -110,7 +110,10 @@ def _tir_u32_to_bf16x2_to_f32x2(x: tirx.PrimExpr):
 def _tir_u32_to_int_to_float(nbit: int, val: tirx.PrimExpr, pos: tirx.PrimExpr, dtype: str):
     assert val.dtype == T.uint32
     mask = tvm.tirx.const((1 << nbit) - 1, T.uint32)
-    return tirx.Cast(dtype, (val >> (pos * nbit).astype(T.uint32)) & mask)
+    unextended = (val >> (pos * nbit).astype(T.uint32)) & mask
+    shift = tirx.const(32 - nbit, T.int32)
+    extended = (tirx.Cast(T.int32, unextended) << shift) >> shift
+    return tirx.Cast(dtype, extended)
 
 
 def _tir_packed_uint_to_uint_to_float(storage_nbit: int):


### PR DESCRIPTION
## Summary

`_tir_u32_to_int_to_float` decoded signed sub-word values from `uint32` storage as unsigned values. It masked out the selected field and cast it directly to the target float dtype, causing negative signed encodings to lose their sign.

For example, signed int4 `-1` is stored as `0xF`, but the old decode treated that as unsigned `15`:

```text
before fix: int4 0xF -> 15.0
after fix : int4 0xF -> -1.0
```

## Root cause

The helper extracted the selected nbit field with a mask:

```text
(val >> (pos * nbit)) & mask
```

This produces an unsigned value in the low bits of a `uint32`. For signed sub-word formats, the field's top bit is the sign bit, but it was never sign-extended before casting to float.

The existing packed signed-int decode helper already uses the standard sign-extension pattern.

## Fix

Sign-extend the extracted field through int32 before casting to the requested float dtype:

```python
unextended = (val >> (pos * nbit).astype(T.uint32)) & mask
shift = tirx.const(32 - nbit, T.int32)
extended = (tirx.Cast(T.int32, unextended) << shift) >> shift
return tirx.Cast(dtype, extended)
```

This preserves negative values for signed int2, int4, int8, and other signed sub-word widths stored in a `uint32`.

## Tested

- Added `testing/python/issue/test_tilelang_u32_signed_decode.py`, covering signed int2, int4, and int8 values decoded from `uint32` storage.
- Verified locally on a TITAN RTX (`sm_75`).

Fixes #2482

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Fixed `_tir_u32_to_int_to_float` to sign-extend packed sub-word values from `uint32` before casting, preserving negative values for signed int2/int4/int8-style inputs.
- Added CUDA regression coverage for decoding signed packed values from `uint32` storage across 2-, 4-, and 8-bit widths.

## Testing
- Added `testing/python/issue/test_tilelang_u32_signed_decode.py` to verify decoded outputs match the original signed values exactly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->