### PR TITLE
[BugFix][CUDA] Round-to-nearest-even for scalar int -> bfloat16 cast

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -1536,6 +1536,15 @@ void CodeGenTileLangCUDA::VisitExpr_(const CastNode *op, std::ostream &os) {
   bool cast_sat = get_bool_anno("sat", true);
   Optional<PrimExpr> cast_rbits = get_expr_anno("rbits");
 
+  if (from_ty.is_scalar() &&
+      (target_ty.is_bfloat16() || target_ty.is_float16()) &&
+      (from_ty.is_int() || from_ty.is_uint()) && cast_round.empty()) {
+    os << "((";
+    this->PrintType(target_ty, os);
+    os << ")(float)(" << PrintExpr(op->value) << "))";
+    return;
+  }
+
   // Emit simple C-style type conversion for scalar casts without custom
   // rounding.
   if (from_ty.is_scalar() && cast_round.empty())

--- a/testing/python/issue/test_tilelang_issue_2483.py
+++ b/testing/python/issue/test_tilelang_issue_2483.py
@@ -1,0 +1,124 @@
+import torch
+import tilelang
+import tilelang.testing
+import tilelang.language as T
+
+tilelang.disable_cache()
+
+# The three headline values from issue #2483. Each is one bf16 ULP away
+# from a bf16-representable neighbour, so RNE and truncate-toward-zero
+# produce different results:
+#   RNE  :  259 -> 260, 33000 -> 33024, -259 -> -260
+#   trunc:  259 -> 258, 33000 -> 32768, -259 -> -258
+ISSUE_2483_VALUES = [259, 33000, -259]
+ISSUE_2483_BF16_RNE = [260.0, 33024.0, -260.0]
+
+
+def test_int32_to_bf16_rounds_to_nearest_even():
+    """Faithful port of the issue #2483 reproducer."""
+    N = len(ISSUE_2483_VALUES)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), "int32"),
+        O: T.Tensor((N,), "bfloat16"),
+        Oh: T.Tensor((N,), "float16"),
+    ):
+        with T.Kernel(1, threads=N) as _:
+            Al = T.alloc_fragment((N,), "int32")
+            Ob = T.alloc_fragment((N,), "bfloat16")
+            Ol = T.alloc_fragment((N,), "float16")
+            T.copy(A, Al)
+            for i in T.Parallel(N):
+                Ob[i] = T.Cast("bfloat16", Al[i])  # int -> bf16
+                Ol[i] = T.Cast("float16", Al[i])  # int -> fp16
+            T.copy(Ob, O)
+            T.copy(Ol, Oh)
+
+    kernel = tilelang.compile(main)
+
+    a = torch.tensor(ISSUE_2483_VALUES, dtype=torch.int32, device="cuda")
+    o_bf16 = torch.zeros(N, dtype=torch.bfloat16, device="cuda")
+    o_fp16 = torch.zeros(N, dtype=torch.float16, device="cuda")
+    kernel(a, o_bf16, o_fp16)
+    torch.cuda.synchronize()
+
+    got = o_bf16.float().tolist()
+
+    assert got == ISSUE_2483_BF16_RNE, f"int->bf16 must round-to-nearest-even; got {got}, expected {ISSUE_2483_BF16_RNE}"
+
+    # Cross-check against torch's native int->bf16 (which is RNE).
+    ref = a.to(torch.bfloat16)
+    tilelang.testing.torch_assert_close(o_bf16, ref, rtol=0, atol=0)
+
+    ref_fp16 = a.to(torch.float16)
+    tilelang.testing.torch_assert_close(o_fp16, ref_fp16, rtol=0, atol=0)
+
+
+def test_int64_to_bf16_rounds_to_nearest_even():
+    N = len(ISSUE_2483_VALUES)
+
+    @T.prim_func
+    def main(A: T.Tensor((N,), "int64"), O: T.Tensor((N,), "bfloat16")):
+        with T.Kernel(1, threads=N) as _:
+            Al = T.alloc_fragment((N,), "int64")
+            Ob = T.alloc_fragment((N,), "bfloat16")
+            T.copy(A, Al)
+            for i in T.Parallel(N):
+                Ob[i] = T.Cast("bfloat16", Al[i])
+            T.copy(Ob, O)
+
+    kernel = tilelang.compile(main, out_idx=[1])
+
+    a = torch.tensor(ISSUE_2483_VALUES, dtype=torch.int64, device="cuda")
+    o = kernel(a)
+    ref = a.to(torch.bfloat16)
+    tilelang.testing.torch_assert_close(o, ref, rtol=0, atol=0)
+
+
+def test_int64_to_fp16_compiles_and_matches_torch():
+    N = len(ISSUE_2483_VALUES)
+
+    @T.prim_func
+    def main(A: T.Tensor((N,), "int64"), O: T.Tensor((N,), "float16")):
+        with T.Kernel(1, threads=N) as _:
+            Al = T.alloc_fragment((N,), "int64")
+            Ol = T.alloc_fragment((N,), "float16")
+            T.copy(A, Al)
+            for i in T.Parallel(N):
+                Ol[i] = T.Cast("float16", Al[i])
+            T.copy(Ol, O)
+
+    kernel = tilelang.compile(main, out_idx=[1])
+
+    a = torch.tensor(ISSUE_2483_VALUES, dtype=torch.int64, device="cuda")
+    o = kernel(a)
+    # Match torch's own int64 -> fp16 (RNE via fp32) exactly.
+    ref = a.to(torch.float16)
+    tilelang.testing.torch_assert_close(o, ref, rtol=0, atol=0)
+
+
+def test_float32_to_bf16_still_rounds_to_nearest_even():
+    """Regression guard: f32 -> bf16 was already correct and must stay so."""
+    N = len(ISSUE_2483_VALUES)
+
+    @T.prim_func
+    def main(A: T.Tensor((N,), "float32"), O: T.Tensor((N,), "bfloat16")):
+        with T.Kernel(1, threads=N) as _:
+            Al = T.alloc_fragment((N,), "float32")
+            Ob = T.alloc_fragment((N,), "bfloat16")
+            T.copy(A, Al)
+            for i in T.Parallel(N):
+                Ob[i] = T.Cast("bfloat16", Al[i])
+            T.copy(Ob, O)
+
+    kernel = tilelang.compile(main, out_idx=[1])
+
+    a = torch.tensor([float(v) for v in ISSUE_2483_VALUES], dtype=torch.float32, device="cuda")
+    o = kernel(a)
+    ref = a.to(torch.bfloat16)
+    tilelang.testing.torch_assert_close(o, ref, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/jit/test_tilelang_jit_diagnostics.py
+++ b/testing/python/jit/test_tilelang_jit_diagnostics.py
@@ -187,8 +187,11 @@ def test_cuda_compile_callback_uses_fatbin_for_multiple_target_code(monkeypatch)
     import importlib
 
     from tilelang.backend.target import determine_target
+    from tilelang.env import env
 
     lower = importlib.import_module("tilelang.engine.lower")
+
+    monkeypatch.setattr(env, "is_cache_enabled", lambda: False)
 
     captured = {}
 
@@ -212,7 +215,7 @@ def test_jit_compile_reports_timeout_for_hanging_nvcc(monkeypatch, tmp_path, cap
     from tilelang.env import env
 
     monkeypatch.setattr(env, "TILELANG_CACHE_DIR", str(tmp_path / "cache"))
-    monkeypatch.setenv("TILELANG_JIT_DIAGNOSTICS", "1")
+    monkeypatch.setattr(env, "TILELANG_JIT_DIAGNOSTICS", "1")
     monkeypatch.setenv("TILELANG_COMPILE_TIMEOUT_SECONDS", "0.25")
     monkeypatch.setattr(nvcc.subprocess, "Popen", lambda *args, **kwargs: _HangingProcess())
 
@@ -274,7 +277,7 @@ def test_kernel_cache_miss_compile_logs_context(monkeypatch, tmp_path, caplog, c
     tmp_dir.mkdir()
     monkeypatch.setattr(env, "TILELANG_CACHE_DIR", str(cache_dir))
     monkeypatch.setattr(env, "TILELANG_TMP_DIR", str(tmp_dir))
-    monkeypatch.setenv("TILELANG_JIT_DIAGNOSTICS", "1")
+    monkeypatch.setattr(env, "TILELANG_JIT_DIAGNOSTICS", "1")
 
     class _FakeKernel:
         params = []


### PR DESCRIPTION
Fixes #2483

## Summary

Scalar `Ob[i] = T.Cast("bfloat16", Al[i])` currently rounds toward zero instead of round-to-nearest-even. one bf16 ULP lead different result  

| Input (int32) | Expected (bf16, RNE) | Before | After |
|---|---|---|---|
| `259`   | `260`    | `258`    | `260` |
| `33000` | `33024`  | `32768`  | `33024` |
| `-259`  | `-260`   | `-258`   | `-260` |

## Root cause

The scalar `int/uint -> bfloat16` cast falls through to the generic scalar branch `CodeGenTileLangCUDA::VisitExpr_(CastNode)` and lowers to a plain C-style cast:

```cpp
((bfloat16_t)int_value)   // == cutlass::bfloat16_t(int)
```

`cutlass::bfloat16_t`'s integer constructor takes the `from_32_bit_integer` path (`bits >> 16`), which **truncates toward zero** — it doesn't apply RNE. Any integer whose magnitude needs more than 8 significand bits gets biased by up to one ULP toward zero.


## Fix

In `CodeGenTileLangCUDA::VisitExpr_(CastNode)`, add an early branch that routes scalar `int/uint -> bf16` through an explicit `(float)` step so we hit `bfloat16_t(float)`:

```cpp
  if (from_ty.is_scalar() &&
      (target_ty.is_bfloat16() || target_ty.is_float16()) &&
      (from_ty.is_int() || from_ty.is_uint()) && cast_round.empty()) {
    os << "((";
    this->PrintType(target_ty, os);
    os << ")(float)(" << PrintExpr(op->value) << "))";
    return;
  }
```


## Test
```
 python -m pytest testing/python/issue/test_tilelang_issue_2483.py -v
```
before
<img width="1077" height="341" alt="image" src="https://github.com/user-attachments/assets/0d1ff1b8-5527-4f54-9266-fde11ce00863" />
after
<img width="1064" height="170" alt="image" src="https://github.com/user-attachments/assets/4050cf8a-8c34-4a0e-a058-adbbc417a1d1" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary
- Fixed CUDA codegen for scalar integer/unsigned-integer casts to `bfloat16`/`float16`: when the cast has an empty `round` hint, it now forces an explicit `(float)` conversion in the emitted C++ so the conversion uses round-to-nearest-even instead of truncating toward zero.
- Added regression coverage in `testing/python/issue/test_tilelang_issue_2483.py` for:
  - `int32 -> bfloat16` (matches Torch RNE)
  - `int64 -> bfloat16` (matches Torch RNE)
  - `int64 -> float16` (compiles and matches Torch)
  - `float32 -> bfloat16` (guard to ensure existing rounding remains correct)
- Updated `testing/python/jit/test_tilelang_jit_diagnostics.py` to adjust how `TILELANG_JIT_DIAGNOSTICS` is enabled and to disable cache for the affected test (workaround for unrelated JIT diagnostics/timeout/cache-miss flakiness).

Test (suggested)
- `pytest testing/python/issue/test_tilelang_issue_2483.py`

### C++ style / lint notes
- Does not touch rules documented in `docs/developer_guide/cpp_style.md`.
- No additional correctness/build/test changes introduced purely for style; any `C++ API Style Audit (warning only)` findings would be advisory (this PR is focused on cast-codegen correctness, not public API/FFI/maintainability).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->