### PR TITLE
[JIT][Cache] Cache PyTorch extensions and perf wheels

### DIFF
--- a/examples/conftest.py
+++ b/examples/conftest.py
@@ -4,6 +4,17 @@ import pytest
 
 os.environ["PYTHONHASHSEED"] = "0"
 
+
+def _configure_torch_extensions_dir():
+    cache_dir = os.environ.get("TILELANG_CACHE_DIR", os.path.expanduser("~/.tilelang/cache"))
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+    path = os.path.join(cache_dir, "torch_extension", f"{worker}-{os.getpid()}")
+    os.makedirs(path, exist_ok=True)
+    os.environ["TORCH_EXTENSIONS_DIR"] = path
+
+
+_configure_torch_extensions_dir()
+
 random.seed(0)
 
 try:

--- a/examples/minference/example_vertical_slash_sparse_attn.py
+++ b/examples/minference/example_vertical_slash_sparse_attn.py
@@ -3,6 +3,8 @@
 
 import math
 import argparse
+import hashlib
+import os
 
 import torch
 import triton
@@ -11,6 +13,49 @@ import triton.language as tl
 import tilelang
 import tilelang.language as T
 from tilelang.profiler import do_bench
+
+
+def _load_vertical_slash_index_ops():
+    from torch.utils.cpp_extension import load
+
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    source_paths = [
+        os.path.join(current_dir, "ops", "kernels.cpp"),
+        os.path.join(current_dir, "ops", "vertical_slash_index.cu"),
+    ]
+    digest = hashlib.sha256()
+    source_items = []
+    for path in source_paths:
+        with open(path, "rb") as src:
+            data = src.read()
+        source_items.append((path, data))
+        digest.update(os.path.basename(path).encode())
+        digest.update(data)
+    source_hash = digest.hexdigest()[:16]
+    name = f"tilelang_minference_convert_{source_hash}"
+
+    cache_dir = tilelang.env.TILELANG_CACHE_DIR
+    extension_root = os.path.join(cache_dir, "torch_extensions", "vertical_slash_index", source_hash)
+    source_dir = os.path.join(extension_root, "src")
+    build_dir = os.path.join(extension_root, "build")
+    os.makedirs(source_dir, exist_ok=True)
+    os.makedirs(build_dir, exist_ok=True)
+
+    stable_sources = []
+    for path, data in source_items:
+        stable_path = os.path.join(source_dir, os.path.basename(path))
+        existing_data = None
+        if os.path.exists(stable_path):
+            with open(stable_path, "rb") as existing:
+                existing_data = existing.read()
+        if existing_data != data:
+            tmp_path = f"{stable_path}.{os.getpid()}.tmp"
+            with open(tmp_path, "wb") as dst:
+                dst.write(data)
+            os.replace(tmp_path, stable_path)
+        stable_sources.append(stable_path)
+
+    return load(name=name, sources=stable_sources, build_directory=build_dir, verbose=False)
 
 
 @tilelang.jit(out_idx=[3])
@@ -490,12 +535,7 @@ def vertical_slash_sparse_attention(
     block_size_M: int = 64,
     block_size_N: int = 64,
 ):
-    from torch.utils.cpp_extension import load
-    import os
-
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    sources = [os.path.join(current_dir, "ops", "kernels.cpp"), os.path.join(current_dir, "ops", "vertical_slash_index.cu")]
-    ops = load(name="convert", sources=sources, verbose=False)
+    ops = _load_vertical_slash_index_ops()
     convert_vertical_slash_indexes = ops.convert_vertical_slash_indexes
     batch_size, num_heads, context_size, head_dim = query.shape
     pad = (block_size_M - context_size) & (block_size_M - 1)
@@ -626,12 +666,7 @@ def run_regression_perf(batch=1, heads=1, seq_len=16384, head_dim=64, vertical_s
     batch_size, num_heads, context_size, head_dim = query.shape
     v_idx = v_idx.to(torch.int32).reshape((batch_size, num_heads, -1)).sort(dim=-1, descending=False)[0]
     s_idx = s_idx.to(torch.int32).reshape((batch_size, num_heads, -1)).sort(dim=-1, descending=True)[0]
-    from torch.utils.cpp_extension import load
-    import os
-
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    sources = [os.path.join(current_dir, "ops", "kernels.cpp"), os.path.join(current_dir, "ops", "vertical_slash_index.cu")]
-    ops = load(name="convert", sources=sources, verbose=False)
+    ops = _load_vertical_slash_index_ops()
     convert_vertical_slash_indexes = ops.convert_vertical_slash_indexes
     batch_size, num_heads, context_size, head_dim = query.shape
     pad = (block_size_M - context_size) & (block_size_M - 1)

--- a/maint/scripts/run_perf_regression.sh
+++ b/maint/scripts/run_perf_regression.sh
@@ -18,6 +18,9 @@
 #   BASE_REF             Baseline git ref (default: origin/main)
 #   SKIP_BUILD_NEW       Reuse current venv when set to 1
 #   SKIP_BUILD_OLD       Reuse baseline venv when set to 1
+#   WHEEL_CACHE          Reuse/build cached TileLang wheels when set to 1 (default: 1)
+#   WHEEL_CACHE_DIR      Wheel cache directory (default: $HOME/.tilelang/perf-regression/wheels)
+#   REFRESH_WHEEL_CACHE  Rebuild selected wheels even if cached when set to 1
 #   REFRESH              Rerun selected cases and overwrite perf cache when set to 1
 #   NO_CACHE             Disable perf result cache when set to 1
 #   FAIL_ON_ERROR        Exit non-zero if either run has failed cases when set to 1
@@ -31,7 +34,7 @@
 set -euo pipefail
 
 if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
-    sed -n '1,29p' "$0"
+    awk '/^set -euo pipefail$/ {exit} {print}' "$0"
     exit 0
 fi
 
@@ -55,6 +58,8 @@ CURRENT_LABEL="${CURRENT_LABEL:-current}"
 
 SKIP_BUILD_NEW="${SKIP_BUILD_NEW:-0}"
 SKIP_BUILD_OLD="${SKIP_BUILD_OLD:-0}"
+WHEEL_CACHE="${WHEEL_CACHE:-1}"
+REFRESH_WHEEL_CACHE="${REFRESH_WHEEL_CACHE:-0}"
 REFRESH="${REFRESH:-0}"
 NO_CACHE="${NO_CACHE:-0}"
 FAIL_ON_ERROR="${FAIL_ON_ERROR:-0}"
@@ -64,6 +69,14 @@ FAIL_ON_MISSING="${FAIL_ON_MISSING:-0}"
 UPDATE_SUBMODULES="${UPDATE_SUBMODULES:-1}"
 INHERIT_PYTHONPATH="${INHERIT_PYTHONPATH:-0}"
 EXTRA_PYTHONPATH="${EXTRA_PYTHONPATH:-}"
+
+if [[ -z "${WHEEL_CACHE_DIR:-}" ]]; then
+    if [[ -n "${HOME:-}" ]]; then
+        WHEEL_CACHE_DIR="${HOME%/}/.tilelang/perf-regression/wheels"
+    else
+        WHEEL_CACHE_DIR="${WORK_DIR%/}/wheel-cache"
+    fi
+fi
 
 mkdir -p "${WORK_DIR}"
 WORK_DIR="$(cd "${WORK_DIR}" && pwd)"
@@ -117,6 +130,7 @@ echo "Work dir:       ${WORK_DIR}"
 echo "Python version: ${PYTHON_VERSION}"
 echo "Baseline ref:   ${BASE_REF}"
 echo "Filters:        ${REGRESSION_ARGS[*]:-(all)}"
+echo "Wheel cache:    ${WHEEL_CACHE} (${WHEEL_CACHE_DIR})"
 echo ""
 
 cd "${REPO_ROOT}"
@@ -169,6 +183,191 @@ create_venv() {
     fi
 }
 
+hash_stdin() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum | awk '{print $1}'
+    else
+        shasum -a 256 | awk '{print $1}'
+    fi
+}
+
+repo_has_untracked_files() {
+    local repo_dir="$1"
+    if [[ -n "$(git -C "${repo_dir}" ls-files --others --exclude-standard)" ]]; then
+        return 0
+    fi
+
+    local submodule_status
+    submodule_status="$(
+        git -C "${repo_dir}" submodule foreach --quiet --recursive \
+            'git ls-files --others --exclude-standard | sed "s#^#$name/#"' 2>/dev/null || true
+    )"
+    [[ -n "${submodule_status}" ]]
+}
+
+repo_source_key() {
+    local repo_dir="$1"
+    local commit
+    commit="$(git -C "${repo_dir}" rev-parse --verify HEAD)"
+
+    if git -C "${repo_dir}" diff --quiet --ignore-submodules=none &&
+        git -C "${repo_dir}" diff --cached --quiet --ignore-submodules=none &&
+        [[ -z "$(git -C "${repo_dir}" status --porcelain=v1 --untracked-files=no)" ]]; then
+        printf '%s-clean\n' "${commit}"
+        return
+    fi
+
+    local digest
+    digest="$(
+        {
+            git -C "${repo_dir}" rev-parse --verify HEAD
+            git -C "${repo_dir}" status --porcelain=v1 --untracked-files=no
+            git -C "${repo_dir}" diff --binary --no-ext-diff --submodule=short
+            git -C "${repo_dir}" diff --cached --binary --no-ext-diff --submodule=short
+            git -C "${repo_dir}" submodule status --recursive 2>/dev/null || true
+            git -C "${repo_dir}" submodule foreach --quiet --recursive '
+                printf "submodule %s\n" "$name"
+                git rev-parse --verify HEAD
+                git status --porcelain=v1 --untracked-files=no
+                git diff --binary --no-ext-diff
+                git diff --cached --binary --no-ext-diff
+            ' 2>/dev/null || true
+        } | hash_stdin
+    )"
+    printf '%s-dirty-%s\n' "${commit}" "${digest:0:16}"
+}
+
+wheel_cache_metadata() {
+    local repo_dir="$1"
+    local python_bin="$2"
+
+    printf 'schema=tilelang-perf-wheel-cache-v1\n'
+    printf 'source_key=%s\n' "$(repo_source_key "${repo_dir}")"
+    "${python_bin}" - <<'PY'
+import platform
+import sys
+import sysconfig
+
+print(f"python_version={sys.version.split()[0]}")
+print(f"python_cache_tag={sys.implementation.cache_tag or ''}")
+print(f"python_soabi={sysconfig.get_config_var('SOABI') or ''}")
+print(f"python_platform={sysconfig.get_platform()}")
+print(f"platform_system={platform.system()}")
+print(f"platform_machine={platform.machine()}")
+PY
+    printf 'uname_s=%s\n' "$(uname -s)"
+    printf 'uname_m=%s\n' "$(uname -m)"
+    if command -v cmake >/dev/null 2>&1; then
+        cmake --version | sed -n '1s/^cmake version /cmake_version=/p'
+    fi
+    if command -v ninja >/dev/null 2>&1; then
+        printf 'ninja_version=%s\n' "$(ninja --version)"
+    fi
+    if command -v nvcc >/dev/null 2>&1; then
+        nvcc --version | sed -n 's/.*release \([^,]*\).*/nvcc_release=\1/p'
+    fi
+    env | LC_ALL=C sort | grep -E '^(CMAKE_|SKBUILD_|USE_CUDA=|USE_ROCM=|USE_METAL=|TILELANG_USE_CUDA_STUBS=|WITH_PIP_CUDA_TOOLCHAIN=|CUDA_HOME=|CUDA_PATH=|CUDA_VERSION=|CUDACXX=|HIP_PATH=|ROCM_PATH=|NO_VERSION_LABEL=|NO_TOOLCHAIN_VERSION=|NO_GIT_VERSION=)' || true
+}
+
+build_wheel_to_dir() {
+    local repo_dir="$1"
+    local venv_dir="$2"
+    local build_dir="$3"
+    local wheel_dir="$4"
+
+    rm -rf "${build_dir}"
+    mkdir -p "$(dirname "${build_dir}")" "${wheel_dir}"
+
+    if command -v uv >/dev/null 2>&1; then
+        uv build -v --wheel --python "${venv_dir}/bin/python" -C "build-dir=${build_dir}" --out-dir "${wheel_dir}" "${repo_dir}"
+    else
+        "${venv_dir}/bin/python" -m pip wheel -v --no-deps -C "build-dir=${build_dir}" --wheel-dir "${wheel_dir}" "${repo_dir}"
+    fi
+}
+
+install_wheel_file() {
+    local venv_dir="$1"
+    local wheel_file="$2"
+
+    if [[ -z "${wheel_file}" || ! -f "${wheel_file}" ]]; then
+        echo "Wheel file not found: ${wheel_file}" >&2
+        exit 1
+    fi
+
+    if command -v uv >/dev/null 2>&1; then
+        uv pip install -v "${wheel_file}"
+    else
+        "${venv_dir}/bin/python" -m pip install -v "${wheel_file}"
+    fi
+}
+
+install_repo_wheel() {
+    local label="$1"
+    local repo_dir="$2"
+    local venv_dir="$3"
+    local build_dir="$4"
+
+    if [[ "${WHEEL_CACHE}" != "1" ]]; then
+        echo "Wheel cache disabled for ${label}."
+        local uncached_dir="${build_dir}-wheel"
+        rm -rf "${uncached_dir}"
+        build_wheel_to_dir "${repo_dir}" "${venv_dir}" "${build_dir}" "${uncached_dir}"
+        local uncached_wheel
+        uncached_wheel="$(find "${uncached_dir}" -maxdepth 1 -type f -name '*.whl' | sort | tail -n 1)"
+        install_wheel_file "${venv_dir}" "${uncached_wheel}"
+        return
+    fi
+
+    if repo_has_untracked_files "${repo_dir}"; then
+        echo "Wheel cache skipped for ${label}; untracked source files are present."
+        local untracked_dir="${build_dir}-wheel"
+        rm -rf "${untracked_dir}"
+        build_wheel_to_dir "${repo_dir}" "${venv_dir}" "${build_dir}" "${untracked_dir}"
+        local untracked_wheel
+        untracked_wheel="$(find "${untracked_dir}" -maxdepth 1 -type f -name '*.whl' | sort | tail -n 1)"
+        install_wheel_file "${venv_dir}" "${untracked_wheel}"
+        return
+    fi
+
+    local metadata
+    metadata="$(wheel_cache_metadata "${repo_dir}" "${venv_dir}/bin/python")"
+    local cache_key
+    cache_key="$(printf '%s\n' "${metadata}" | hash_stdin | cut -c 1-24)"
+    local cache_entry="${WHEEL_CACHE_DIR%/}/${cache_key}"
+    local cached_wheel
+    cached_wheel="$(find "${cache_entry}" -maxdepth 1 -type f -name '*.whl' 2>/dev/null | sort | tail -n 1 || true)"
+
+    mkdir -p "${WHEEL_CACHE_DIR}"
+    echo "Wheel cache key for ${label}: ${cache_key}"
+    echo "Wheel cache dir: ${WHEEL_CACHE_DIR}"
+
+    if [[ "${REFRESH_WHEEL_CACHE}" != "1" && -n "${cached_wheel}" && -f "${cached_wheel}" ]]; then
+        echo "Wheel cache hit for ${label}: ${cached_wheel}"
+        install_wheel_file "${venv_dir}" "${cached_wheel}"
+        return
+    fi
+
+    echo "Wheel cache miss for ${label}; building wheel."
+    local tmp_entry="${cache_entry}.tmp.$$"
+    rm -rf "${tmp_entry}"
+    mkdir -p "${tmp_entry}"
+    printf '%s\n' "${metadata}" >"${tmp_entry}/metadata.txt"
+    build_wheel_to_dir "${repo_dir}" "${venv_dir}" "${build_dir}" "${tmp_entry}"
+
+    local built_wheel
+    built_wheel="$(find "${tmp_entry}" -maxdepth 1 -type f -name '*.whl' | sort | tail -n 1)"
+    if [[ -z "${built_wheel}" || ! -f "${built_wheel}" ]]; then
+        echo "No wheel produced for ${label}." >&2
+        exit 1
+    fi
+
+    rm -rf "${cache_entry}"
+    mv "${tmp_entry}" "${cache_entry}"
+    cached_wheel="$(find "${cache_entry}" -maxdepth 1 -type f -name '*.whl' | sort | tail -n 1)"
+    echo "Wheel cached for ${label}: ${cached_wheel}"
+    install_wheel_file "${venv_dir}" "${cached_wheel}"
+}
+
 install_repo() {
     local label="$1"
     local repo_dir="$2"
@@ -203,11 +402,10 @@ install_repo() {
         unset CMAKE_MAKE_PROGRAM
         if command -v uv >/dev/null 2>&1; then
             uv pip install -v -r requirements-test.txt
-            uv pip install -v -C "build-dir=${build_dir}" .
         else
             python -m pip install -v -r requirements-test.txt
-            python -m pip install -v -C "build-dir=${build_dir}" .
         fi
+        install_repo_wheel "${label}" "${repo_dir}" "${venv_dir}" "${build_dir}"
     )
 }
 

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -11,6 +11,17 @@ REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
+
+def _configure_torch_extensions_dir():
+    cache_dir = os.environ.get("TILELANG_CACHE_DIR", os.path.expanduser("~/.tilelang/cache"))
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+    path = os.path.join(cache_dir, "torch_extension", f"{worker}-{os.getpid()}")
+    os.makedirs(path, exist_ok=True)
+    os.environ["TORCH_EXTENSIONS_DIR"] = path
+
+
+_configure_torch_extensions_dir()
+
 random.seed(0)
 
 try:


### PR DESCRIPTION
## Summary
- Isolate PyTorch extension builds in tests by assigning per-process extension directories under TileLang's cache root.
- Cache TileLang wheels during perf regression setup so repeated current/baseline installs can reuse matching package artifacts.
- Make the vertical/slash sparse attention benchmark load its helper extension from a content-addressed cache path so current and baseline checkouts do not invalidate each other.

## Changes
- Add perf regression wheel cache controls: `WHEEL_CACHE`, `WHEEL_CACHE_DIR`, and `REFRESH_WHEEL_CACHE`.
- Key cached wheels by source state, Python/platform details, and relevant build environment, while skipping cache use when untracked source files are present.
- Load the minference vertical/slash index extension from stable content-hashed sources under `TILELANG_CACHE_DIR`.

## Validation
- `git diff --check origin/main...HEAD`
- `bash -n maint/scripts/run_perf_regression.sh`
- `python -m py_compile examples/conftest.py testing/conftest.py examples/minference/example_vertical_slash_sparse_attn.py`
- `./format.sh` pre-commit hooks completed
- Targeted `run_regression_perf()` cache check confirmed that the same sources loaded from a different checkout path reused the extension cache and completed in about 7 seconds after the cold build.

## Notes
- The first build for a new source hash remains a cold compile; subsequent runs reuse the stable cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Isolated PyTorch JIT extension build outputs used by tests into TileLang’s cache directory by setting `TORCH_EXTENSIONS_DIR` at import time in both `testing/conftest.py` and `examples/conftest.py` to `${TILELANG_CACHE_DIR:-~/.tilelang/cache}/torch_extension/<worker>-<pid>`.

- Added a helper in each `conftest.py` that namespaces the directory with `PYTEST_XDIST_WORKER` (default `main`) and the current process ID, and creates the directory before exporting `TORCH_EXTENSIONS_DIR`
- Updated `examples/minference/example_vertical_slash_sparse_attn.py` to load the vertical/slash index CUDA extension via a content-hashed, cache-backed helper to avoid unstable build artifact naming
- Updated `maint/scripts/run_perf_regression.sh` to support optional cached wheel builds/installs for the regression workflow (configurable via env vars like `WHEEL_CACHE*` and `REFRESH_WHEEL_CACHE`)

## C++ style / lint notes

- `docs/developer_guide/cpp_style.md` is present but was not changed by this PR.
- This PR does not modify C++ headers/APIs or introduce FFI/maintainability-relevant C++ changes, so it should not affect (or be expected to introduce new) “C++ API Style Audit (warning only)” issues such as `TLCPP003`/`TLCPP004`; any such findings remain advisory and non-blocking in the context of this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->