### PR TITLE
[Transform][Layout] Avoid thread-indexed replicated fragment readback

### DIFF
--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -10,6 +10,7 @@
 #include <tvm/runtime/logging.h>
 
 #include <algorithm>
+#include <tvm/tirx/analysis.h>
 #include <tvm/tirx/op.h>
 
 #include "../layout/layout.h"
@@ -906,6 +907,29 @@ ParallelOpNode::ChooseBestCandidate(const Fragment &candidate_from_buffer,
     return candidate_from_buffer; // arbitrary; caller will catch later
   }
 
+  // Both candidates may be semantically valid for reads from a fully
+  // replicated fragment.  The plan candidate often minimizes replication by
+  // assigning one logical element to each CUDA thread, but that can turn a
+  // register fragment access into `fragment[threadIdx.x]`.  CUDA cannot keep a
+  // register array with runtime indexing in scalar registers, so this shape
+  // spills the whole fragment to local memory before the final store.
+  //
+  // When this parallel loop publishes data to shared/global memory, prefer the
+  // valid candidate that keeps fragment physical indices independent of the
+  // thread variable.  For a fully replicated readback this selects the
+  // fragment-derived layout, and BuildReplicationGuardsIfNeeded then emits the
+  // single-replica guard (e.g. `threadIdx.x == 0`) to avoid duplicate stores.
+  // Fragment-only loops keep the old containment/replication heuristic below.
+  if (!store_shared_global_buffers_.empty()) {
+    bool buf_thread_index =
+        HasThreadDependentFragmentIndex(candidate_from_buffer, layout_args);
+    bool plan_thread_index =
+        HasThreadDependentFragmentIndex(candidate_from_plan, layout_args);
+    if (buf_thread_index != plan_thread_index) {
+      return buf_thread_index ? candidate_from_plan : candidate_from_buffer;
+    }
+  }
+
   bool buf_contains_plan = contains(candidate_from_buffer, candidate_from_plan);
   bool plan_contains_buf = contains(candidate_from_plan, candidate_from_buffer);
 
@@ -926,6 +950,82 @@ ParallelOpNode::ChooseBestCandidate(const Fragment &candidate_from_buffer,
   }
   // Safe fallback: buffer-based candidate is always correct.
   return candidate_from_buffer;
+}
+
+bool ParallelOpNode::HasThreadDependentFragmentIndex(
+    const Fragment &candidate, const LayoutInferArgs &layout_args) const {
+  // Mirror the index substitution that PartitionLoop would apply for this
+  // candidate without actually rebuilding the loop.  We create symbolic output
+  // coordinates plus a symbolic thread variable, invert the candidate layout
+  // back to the original loop variables, and then apply each known fragment
+  // layout's Forward() map.  If any resulting physical fragment index still
+  // contains the symbolic thread variable, lowering this candidate would emit a
+  // runtime-thread-indexed register array access such as
+  // `fragment[threadIdx.x]`.
+  if (!candidate.defined()) {
+    return false;
+  }
+
+  int old_loop_depth = static_cast<int>(loop_vars_.size());
+  if (candidate->InputDim() != static_cast<size_t>(old_loop_depth)) {
+    return false;
+  }
+
+  Var thread_var("__tl_candidate_thread");
+  Array<PrimExpr> partition_vars;
+  for (size_t i = 0; i < candidate->OutputDim(); ++i) {
+    partition_vars.push_back(Var("__tl_candidate_i" + std::to_string(i)));
+  }
+  partition_vars.push_back(thread_var);
+
+  auto inv_loop = candidate->InverseWithLevel().first;
+  Array<PrimExpr> recovered_indices = inv_loop->Forward(partition_vars);
+
+  Map<Var, PrimExpr> loop_var_map;
+  for (int i = 0; i < old_loop_depth; ++i) {
+    loop_var_map.Set(loop_vars_[i]->var, recovered_indices[i]);
+  }
+
+  Map<Var, PrimExpr> thread_offset_map;
+  bool has_thread_offset = false;
+  if (candidate->ThreadRange().defined()) {
+    auto range = candidate->ThreadRange();
+    thread_offset_map.Set(thread_var, thread_var - range->min);
+    has_thread_offset = true;
+  }
+
+  auto uses_thread_var = [&](const PrimExpr &expr) {
+    PrimExpr simplified = analyzer_.Simplify(expr);
+    return tirx::UsesVar(simplified, [&](const VarNode *var_node) {
+      return GetRef<Var>(var_node).same_as(thread_var);
+    });
+  };
+
+  for (const auto &buffer : access_order_) {
+    if (!IsFragmentBuffer(buffer) || !layout_args.layout_map.count(buffer)) {
+      continue;
+    }
+    auto fragment_layout = layout_args.layout_map[buffer].as<Fragment>();
+    if (!fragment_layout.has_value()) {
+      continue;
+    }
+
+    Array<PrimExpr> indices = GetAccessInfo(buffer).indices.Map(
+        [&](const PrimExpr &index) { return Substitute(index, loop_var_map); });
+    if (has_thread_offset) {
+      indices = Substitute(indices, thread_offset_map);
+    }
+
+    Array<PrimExpr> physical_indices =
+        fragment_layout.value()->Forward(indices);
+    for (const auto &index : physical_indices) {
+      if (uses_thread_var(index)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 } // namespace tl

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -157,6 +157,11 @@ private:
   Fragment ChooseBestCandidate(const Fragment &candidate_from_buffer,
                                const Fragment &candidate_from_plan,
                                const LayoutInferArgs &layout_args) const;
+  // Return true if partitioning by `candidate` would make any known fragment
+  // buffer's physical index depend on the CUDA thread variable.
+  bool
+  HasThreadDependentFragmentIndex(const Fragment &candidate,
+                                  const LayoutInferArgs &layout_args) const;
   // (No helper needed anymore; annotations are parsed once in ctor and adopted
   // inside InferLayout.)
   // Compute loop layout from a source buffer's fragment mapping.

--- a/testing/python/layout/test_tilelang_layout_inference.py
+++ b/testing/python/layout/test_tilelang_layout_inference.py
@@ -1,7 +1,11 @@
+import re
+
+import pytest
 import tilelang
 import tilelang.testing
-import pytest
+import tvm
 from tilelang import language as T
+from tvm.target import Target
 
 
 @tilelang.jit
@@ -81,6 +85,52 @@ def test_scalar_reduce_accumulator_owner_layout():
     kernel = _scalar_reduce_accumulator_owner_layout()
     source = kernel.get_kernel_source()
     assert "AllReduce" in source
+
+
+def _lower_fully_replicated_readback(use_copy: bool) -> str:
+    @T.prim_func
+    def main(inp: T.Tensor((128,), T.float32), out: T.Tensor((128,), T.float32)):
+        with T.Kernel(1, threads=128):
+            fragment = T.alloc_fragment((128,), T.float32)
+            T.annotate_layout({fragment: tilelang.layout.make_fully_replicated_layout_fragment(fragment, 128)})
+
+            for i in T.serial(128):
+                fragment[i] = inp[i]
+
+            if use_copy:
+                T.copy(fragment, out)
+            else:
+                for i in T.Parallel(128):
+                    out[i] = fragment[i]
+
+    target = Target("cuda")
+    pass_configs = {
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER.value: True,
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED.value: True,
+        tilelang.PassConfigKey.TL_DISABLE_DATA_RACE_CHECK.value: True,
+    }
+    with tvm.transform.PassContext(config=pass_configs), target:
+        artifact = tilelang.lower(main, target=target)
+    return artifact.kernel_source
+
+
+def _assert_single_thread_replicated_readback(src: str) -> None:
+    assert not re.search(r"fragment\[[^\]\n]*threadIdx\.x", src), src
+    assert not re.search(r"out\[[^\]\n]*threadIdx\.x", src), src
+    assert "if (((int)threadIdx.x) == 0)" in src
+    assert re.search(r"for \(int i(_\d+)? = 0; i(_\d+)? < 128; \+\+i(_\d+)?\)", src), src
+
+
+@tilelang.testing.requires_cuda
+def test_parallel_readback_from_fully_replicated_fragment_uses_rep_guard():
+    src = _lower_fully_replicated_readback(use_copy=False)
+    _assert_single_thread_replicated_readback(src)
+
+
+@tilelang.testing.requires_cuda
+def test_copy_readback_from_fully_replicated_fragment_uses_rep_guard():
+    src = _lower_fully_replicated_readback(use_copy=True)
+    _assert_single_thread_replicated_readback(src)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Prefer loop layout candidates that avoid thread-dependent physical indices for fragment accesses when publishing replicated fragments to shared or global memory.
- Prevent fully replicated fragment readback from lowering to `fragment[threadIdx.x]`, which can force register arrays into local memory.

## Changes

- Add a layout-candidate tie-breaker in `src/op/parallel.cc` that detects whether a candidate would make fragment physical indices depend on the CUDA thread variable.
- Keep fragment-only loops on the existing containment and replication heuristic, limiting the behavior change to shared/global store paths.
- Extend `testing/python/layout/test_tilelang_layout_inference.py` with coverage for both explicit `T.Parallel` readback and `T.copy` readback from fully replicated fragments.

## Validation

- `./format.sh`
- `cmake --build build -j$(nproc)`
- `python -m pytest testing/python/layout/test_tilelang_layout_inference.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary
- Improved layout inference for replicated fragment readback in `src/op/parallel.cc` by preferring candidates that avoid thread-dependent physical fragment indices when lowering stores to shared/global memory.
- Added a new helper in `ParallelOpNode` to detect whether a candidate layout would make fragment physical indices depend on the CUDA thread variable.
- Extended CUDA layout inference tests to cover fully replicated fragment readback through both `T.Parallel` and `T.copy`, with assertions that the generated kernel guards readback to a single thread.

### C++ style / lint notes
- This PR touches C++ code, so it falls under the rules in `docs/developer_guide/cpp_style.md`.
- No correctness, build, or test regressions are indicated in the change summary.
- The change appears focused on behavior rather than style; any `C++ API Style Audit (warning only)` findings should be treated as advisory unless they expose a clear API/FFI/maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->