### PR TITLE
fix(cuda): detect auto target arch from current device, not device 0

### DIFF
--- a/tilelang/cuda/target.py
+++ b/tilelang/cuda/target.py
@@ -34,7 +34,7 @@ def _detect_torch_cuda_arch() -> str | None:
 
     if not torch.cuda.is_available():
         return None
-    cap = torch.cuda.get_device_capability(0)
+    cap = torch.cuda.get_device_capability(torch.cuda.current_device())
     return f"sm_{nvcc.get_target_arch(cap)}" if cap else None
 
 


### PR DESCRIPTION
Fixes #2516.

`_detect_torch_cuda_arch()` resolved the CUDA architecture via `torch.cuda.get_device_capability(0)`. On heterogeneous multi-GPU hosts (e.g. one sm_120 card + several sm_86 cards), worker processes bound to non-zero devices via `torch.cuda.set_device()` compiled every `target="auto"` kernel for device 0's architecture and then failed to load them:

```
Fatal: CUDAError: cuModuleLoadData(...) failed with error: CUDA_ERROR_NO_BINARY_FOR_GPU
```

This resolves the capability from `torch.cuda.current_device()` instead. Single-GPU and homogeneous multi-GPU behavior is unchanged (`current_device()` defaults to 0).

Verified on a 5-GPU mixed host (RTX PRO 6000 sm_120 + 4× RTX 3090 sm_86) running one vLLM pipeline-parallel worker per GPU: with this change each worker compiles for its own architecture and all kernels load and run; without it, all sm_86 workers fail at module load.

See #2516 for a related cache-key hardening suggestion (hashing the resolved target instead of the raw "auto" string) — kept out of this PR to stay minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary
- Updated CUDA auto-target SM detection to use `torch.cuda.current_device()` instead of hardcoded device `0`.
- This keeps `target="auto"` aligned with the process’s active GPU, preventing incorrect kernel compilation on heterogeneous multi-GPU systems when workers are bound to non-zero devices.
- Single-GPU and homogeneous multi-GPU behavior remains unchanged.

### C++ style / lint notes
- This PR does not touch C++ code, CI, lint tooling, or `docs/developer_guide/cpp_style.md`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->