### PR TITLE
[BugFix] Fix llvm auto backend resolution

### DIFF
--- a/testing/python/llvm/test_tilelang_llvm_gemm.py
+++ b/testing/python/llvm/test_tilelang_llvm_gemm.py
@@ -103,7 +103,8 @@ def test_matmul_compile():
     block_M, block_N, block_K = M // 4, N // 4, K // 4
     llvm_func = matmul_jit_test(M, N, K, block_M, block_N, block_K)
     with tvm.target.Target("llvm"):
-        complied_fun = tilelang.compile(llvm_func, -1, execution_backend="tvm_ffi")
+        complied_fun = tilelang.compile(llvm_func, -1)
+    assert complied_fun.execution_backend == "tvm_ffi"
 
     in_dtype = T.float16
     A = torch.randn(M, K, dtype=torch.__getattribute__(in_dtype))

--- a/tilelang/cpu/execution_backend.py
+++ b/tilelang/cpu/execution_backend.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 from tilelang.backend.execution_backend import ExecutionBackendSpec, register_execution_backend
 
 
-for _target_kind in ("c", "llvm"):
-    register_execution_backend(_target_kind, ExecutionBackendSpec("cython"), override=True)
-    register_execution_backend(
-        _target_kind,
-        ExecutionBackendSpec("tvm_ffi", enable_host_codegen=True, enable_device_compile=True),
-        override=True,
-    )
+register_execution_backend("c", ExecutionBackendSpec("cython"), override=True)
+register_execution_backend(
+    "c",
+    ExecutionBackendSpec("tvm_ffi", enable_host_codegen=True, enable_device_compile=True),
+    override=True,
+)
+
+register_execution_backend(
+    "llvm",
+    ExecutionBackendSpec("tvm_ffi", enable_host_codegen=True, enable_device_compile=True),
+    override=True,
+)


### PR DESCRIPTION
`llvm` currently produces a TVM runtime module rather than source code for the existing cython source-
  wrapper path, so it cannot be supported by `cython` yet.

  - Stop registering `cython` as an execution backend for `llvm`
  - Ensure `target="llvm", execution_backend="auto"` resolves to `tvm_ffi`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Fixed LLVM auto-backend resolution by making CPU execution backend registration explicit for both `c` and `llvm`, ensuring `tvm_ffi` is selected with host/device codegen enabled. Updated the LLVM GEMM JIT test to verify the resolved backend at runtime instead of passing it directly into `tilelang.compile`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->