### PR TITLE
[CUDA][Cache] Include compile options in binary cache key

### DIFF
--- a/testing/python/cache/test_tilelang_cuda_binary_cache.py
+++ b/testing/python/cache/test_tilelang_cuda_binary_cache.py
@@ -51,23 +51,27 @@ def test_cuda_binary_cache_hit_skips_nvcc_compile(monkeypatch, tmp_path):
     target = Target({"kind": "cuda", "arch": "sm_90a"})
     source = 'extern "C" __global__ void kernel() {}'
 
+    fast_math_pass_configs = {
+        tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+        tilelang.PassConfigKey.TL_DEVICE_COMPILE_FLAGS: ["--extra-device-vectorization"],
+    }
+
     first = lower.tilelang_callback_cuda_compile(source, target)
     second = lower.tilelang_callback_cuda_compile(source, target)
-    third = lower.tilelang_callback_cuda_compile(
-        source,
-        target,
-        {
-            tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
-            tilelang.PassConfigKey.TL_DEVICE_COMPILE_FLAGS: ["--extra-device-vectorization"],
-        },
-    )
+    # Different compiler options (e.g. --use_fast_math) change the generated
+    # SASS without changing the source, so they must NOT share a cache entry.
+    third = lower.tilelang_callback_cuda_compile(source, target, fast_math_pass_configs)
+    fourth = lower.tilelang_callback_cuda_compile(source, target, fast_math_pass_configs)
 
     assert bytes(first) == b"fake-cubin"
     assert bytes(second) == b"fake-cubin"
     assert bytes(third) == b"fake-cubin"
-    assert len(compile_calls) == 1
+    assert bytes(fourth) == b"fake-cubin"
+    # first compiles, second hits; third compiles (new options), fourth hits
+    assert len(compile_calls) == 2
+    assert compile_calls[0][3] != compile_calls[1][3]
     cache_files = list((tmp_path / "cache").glob("*/cuda-binaries/*.cubin"))
-    assert len(cache_files) == 1
+    assert len(cache_files) == 2
 
 
 def test_disk_cache_load_failure_is_cache_miss(monkeypatch, tmp_path):

--- a/tilelang/cache/cuda_binary_cache.py
+++ b/tilelang/cache/cuda_binary_cache.py
@@ -95,7 +95,12 @@ class CUDABinaryCache:
         target_arch: str,
         target_code: list[str],
         compile_format: str,
+        options: list[str] | None = None,
     ) -> str:
+        # Compiler options must be part of the key: flags like --use_fast_math
+        # change the generated SASS without changing the CUDA source, so keying
+        # on the code hash alone lets a fast-math binary satisfy a
+        # precise-math compile (and vice versa).
         key_data: dict[str, Any] = {
             "tilelang_version": __version__,
             "code_hash": sha256(code.encode()).hexdigest(),
@@ -103,6 +108,7 @@ class CUDABinaryCache:
             "target_arch": target_arch,
             "target_code": tuple(target_code),
             "compile_format": compile_format,
+            "options": tuple(options or []),
         }
         if env.should_use_kernel_cache_lib_stamp():
             lib_stamp = cls._get_tilelang_lib_stamp()

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -157,6 +157,7 @@ def tilelang_callback_cuda_compile(code, target, pass_config=None):
         target_arch=target_arch,
         target_code=target_code_list,
         compile_format=compile_format,
+        options=options,
     )
     cached_binary = CUDABinaryCache.load(cache_key, compile_format)
     if cached_binary is not None:


### PR DESCRIPTION
## Summary

- Include CUDA device compiler options in the binary cache key.
- Prevent binaries compiled with different options, such as fast math or ptxas flags, from reusing the same cached artifact.

## Changes

- Add an optional `options` field to `CUDABinaryCache.make_key` and include it in the stable key data.
- Pass the actual CUDA compile options from `tilelang_callback_cuda_compile` into the cache key calculation.

## Validation

- `./format.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Added an optional `options` parameter to `CUDABinaryCache.make_key` and included it in the stable cache-key payload.
- Updated CUDA compile-site key generation to pass through the effective NVCC options, so binaries built with different flags no longer share the same cache entry.

## Validation
- `./format.sh`

## C++ style / lint notes
- No C++ code, CI lint tooling changes, or edits to `docs/developer_guide/cpp_style.md` were made; this PR only affects CUDA binary cache keying and related Python tests.
- The “C++ API Style Audit (warning only)” CI step is not directly impacted by these changes, and there’s no indication of newly introduced TLCPP003/TLCPP004 findings from this PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->