### PR TITLE
[Doc] Update SKILL.md to support editable installs and clarify develo…

### DIFF
--- a/.agents/skills/tilelang-build/SKILL.md
+++ b/.agents/skills/tilelang-build/SKILL.md
@@ -64,7 +64,18 @@ Useful cmake options:
 
 ## Editable Installs
 
-**Never use `pip install -e .`** (editable install). When running Python from the repo root, the local `./tilelang` directory is imported instead of the installed copy (because `.` is on `sys.path` by default). This makes editable installs unnecessary. Avoid `pip install -e .` as it can cause import confusion with this project's layout.
+`pip install -e .` is a supported development install, and is what `README.md`, `CONTRIBUTING.md`, and `docs/get_started/Installation.md` recommend for development:
+
+```bash
+pip install -r requirements-dev.txt
+pip install -e . -v --no-build-isolation
+```
+
+Notes specific to this repo's layout:
+
+- When Python is run from the repo root, the local `./tilelang` directory is imported instead of any copy installed into `site-packages` (because the repo root is on `sys.path` ahead of `site-packages`). This is by design: `tilelang/env.py` detects a dev checkout (when `3rdparty/` is not inside the package dir) and loads native libraries from `build/lib/` and `build/tvm/`, logging `Loading tilelang libs from dev root: <repo>/build`.
+- Because of the above, an editable install and a plain `PYTHONPATH=$(pwd)` import resolve to the same on-disk `./tilelang`. Either is fine; pick based on whether you want pip to manage metadata/deps.
+- For pure C++ iteration (no Python metadata needed), the `cmake + PYTHONPATH` flow above is faster and avoids re-running pip entirely.
 
 ## Running Tests
 

--- a/.agents/skills/tilelang-build/SKILL.md
+++ b/.agents/skills/tilelang-build/SKILL.md
@@ -74,7 +74,7 @@ pip install -e . -v --no-build-isolation
 Notes specific to this repo's layout:
 
 - When Python is run from the repo root, the local `./tilelang` directory is imported instead of any copy installed into `site-packages` (because the repo root is on `sys.path` ahead of `site-packages`). This is by design: `tilelang/env.py` detects a dev checkout (when `3rdparty/` is not inside the package dir) and loads native libraries from `build/lib/` and `build/tvm/`, logging `Loading tilelang libs from dev root: <repo>/build`.
-- Because of the above, an editable install and a plain `PYTHONPATH=$(pwd)` import resolve to the same on-disk `./tilelang`. Either is fine; pick based on whether you want pip to manage metadata/deps.
+- Because of the above, both approaches resolve imports to the local `./tilelang` when run from the repo root. Use `pip install -e .` when you want pip to manage package metadata/dependencies; use `PYTHONPATH=$(pwd)` only for the lighter-weight import-only workflow.
 - For pure C++ iteration (no Python metadata needed), the `cmake + PYTHONPATH` flow above is faster and avoids re-running pip entirely.
 
 ## Running Tests


### PR DESCRIPTION
…pment workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated `.agents/skills/tilelang-build/SKILL.md` to clarify the development workflow around editable installs. It explicitly documents that `pip install -e .` is supported for development and provides the recommended command sequence:

- `pip install -r requirements-dev.txt`
- `pip install -e . -v --no-build-isolation`

The “Editable Installs” guidance now also explains this repo’s dev-import behavior: when running from the repo root, Python imports the local `./tilelang` before anything in `site-packages`, and `tilelang/env.py` detects a dev checkout (when `3rdparty/` is not inside the package) to load native libraries from `build/lib/` and `build/tvm/`. It clarifies when to prefer `pip install -e .` (for pip-managed metadata/dependencies) versus `PYTHONPATH=$(pwd)` (for an import-only workflow), and notes the `cmake + PYTHONPATH` approach is faster for pure C++ iteration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->