### PR TITLE
[CUDA][Codegen] Keep RNG state in kernel scope

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -11,6 +11,7 @@
 #include <tvm/s_tir/stmt.h>
 #include <tvm/tirx/index_map.h>
 #include <tvm/tirx/op.h>
+#include <tvm/tirx/stmt_functor.h>
 
 #include <cmath>
 #include <cstdint>
@@ -4503,18 +4504,19 @@ bool CodeGenTileLangCUDA::HandleLateIntrinsicCall(const CallNode *op,
     return true;
   } else if (op->op.same_as(tl::rng_init())) {
     this->need_curand_kernel_h_ = true;
-    this->curand_random_generator_state =
-        name_supply_->FreshName("__random_generator_state");
+    auto it = rng_state_name_map_.find(op);
+    ICHECK(it != rng_state_name_map_.end())
+        << "tl.rng_init call was not registered by the AddFunction pre-scan";
+    this->curand_random_generator_state = it->second;
     this->curand_random_generator_state_type =
         op->args[3].as<StringImmNode>()->value;
-    this->PrintIndent();
-    this->stream << op->args[3].as<StringImmNode>()->value << " "
-                 << this->curand_random_generator_state << ";\n";
     this->PrintIndent();
     this->stream << "curand_init(" << PrintExpr(op->args[0]) << ", "
                  << PrintExpr(op->args[1]) << ", " << PrintExpr(op->args[2])
                  << ", &" << this->curand_random_generator_state << ");\n";
-    // State var is used later by rng_rand / rng_rand_float.
+    // The state var is declared at function scope (see AddFunction) so it
+    // stays visible to rng_rand / rng_rand_float even when passes split the
+    // enclosing block across __syncthreads() barriers.
     return true;
   } else if (op->op.same_as(tl::rng_rand())) {
     this->need_curand_kernel_h_ = true;
@@ -5829,6 +5831,22 @@ void CodeGenTileLangCUDA::AddFunction(const GlobalVar &gvar,
     stream << ' ' << vid;
   }
   stream << ") {\n";
+  // Declare curand states for all tl.rng_init calls at function scope.
+  // Sync-insertion passes may split the block containing rng_init across
+  // __syncthreads(), so a declaration emitted at the call site can go out
+  // of scope before later rng_rand / rng_rand_float uses.
+  rng_state_name_map_.clear();
+  tirx::PostOrderVisit(f->body, [this](const ObjectRef &n) {
+    const auto *call = n.as<CallNode>();
+    if (call == nullptr || !call->op.same_as(tl::rng_init())) {
+      return;
+    }
+    this->need_curand_kernel_h_ = true;
+    std::string name = name_supply_->FreshName("__random_generator_state");
+    this->stream << "  " << call->args[3].as<StringImmNode>()->value << " "
+                 << name << ";\n";
+    rng_state_name_map_.emplace(call, std::move(name));
+  });
   this->PreFunctionBody(f);
   int func_scope = this->BeginScope();
   this->PrintStmt(f->body);

--- a/src/cuda/codegen/codegen_cuda.h
+++ b/src/cuda/codegen/codegen_cuda.h
@@ -91,6 +91,12 @@ private:
   // Global curand state
   std::string curand_random_generator_state;
   std::string curand_random_generator_state_type;
+  // Function-scope curand state declarations: tl.rng_init call node -> var
+  // name. States are declared at kernel top (see AddFunction) because
+  // sync-insertion passes may split the block containing rng_init across
+  // __syncthreads(), which would put a call-site declaration out of scope
+  // for later rng_rand / rng_rand_float uses.
+  std::unordered_map<const CallNode *, std::string> rng_state_name_map_;
 
   // whether enable fp16
   bool enable_fp16_{false};

--- a/testing/python/language/test_tilelang_language_rand.py
+++ b/testing/python/language/test_tilelang_language_rand.py
@@ -65,5 +65,63 @@ def test_rand_1d(M, seed, generator):
     kernel(A, B, C, D, E)
 
 
+@tilelang.jit
+def tilelang_rand_blockwise(M=64, seed=42, generator="curandStatePhilox4_32_10_t"):
+    threads = 32
+
+    @T.prim_func
+    def rand_kernel(A: T.Tensor((M,), "uint32")):
+        with T.Kernel(M, threads=threads) as bx:
+            tx = T.get_thread_binding()
+            T.rng_init(seed, 0, bx, generator=generator)
+            if tx == 0:
+                A[bx] = T.rng_rand()
+
+    return rand_kernel
+
+
+@tilelang.jit
+def tilelang_rand_guarded_cumsum(M=64, seed=42, generator="curandStatePhilox4_32_10_t"):
+    threads = 32
+
+    @T.prim_func
+    def rand_kernel(
+        A: T.Tensor((M,), "uint32"),
+        n: T.int32,
+    ):
+        with T.Kernel(M, threads=threads) as bx:
+            tx = T.get_thread_binding()
+            s = T.alloc_shared((threads,), "int32")
+            # rng_init inside a runtime guard, with a shared-memory cumsum
+            # between init and use: sync legalization hoists __syncthreads()
+            # out of the guard and splits it into sibling blocks, so the
+            # curand state must be declared at function scope to stay visible.
+            if bx < n:
+                T.rng_init(seed, 0, bx, generator=generator)
+                s[tx] = 1
+                T.cumsum(s, dim=0)
+                if tx == 0:
+                    A[bx] = T.rng_rand() + T.cast(s[threads - 1], "uint32") * 0
+
+    return rand_kernel
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("generator", ["curandStateMRG32k3a_t", "curandStatePhilox4_32_10_t", "curandStateXORWOW_t"])
+def test_rand_init_in_split_guard(generator):
+    M, seed, n = 64, 42, 37
+    guarded = tilelang_rand_guarded_cumsum(M, seed, generator)
+    baseline = tilelang_rand_blockwise(M, seed, generator)
+
+    sentinel = 0xDEADBEEF
+    A = torch.full((M,), sentinel, dtype=torch.uint32, device="cuda")
+    guarded(A, n)
+    A_ref = torch.empty(M, dtype=torch.uint32, device="cuda")
+    baseline(A_ref)
+
+    assert torch.equal(A[:n], A_ref[:n]), "guarded rng output differs from unguarded baseline"
+    assert (A[n:] == sentinel).all(), "rows outside the guard must stay untouched"
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Summary

- Declare CUDA RNG state variables at kernel function scope so random draws remain valid after sync insertion splits guarded blocks.
- Add a regression test that covers `tl.rng_init` inside a runtime guard with a shared-memory cumsum between initialization and use.

## Changes

- Pre-scan each CUDA PrimFunc for `tl.rng_init` calls and assign stable per-call CURAND state names before emitting the function body.
- Reuse the pre-scanned state names when emitting `curand_init`, instead of declaring the state variable at the call site.
- Add guarded and unguarded rand kernels to compare outputs across supported CURAND generator types.

## Validation

- `./format.sh`
- `make -C build -j$(nproc)`
- `PYTHONPATH=$PWD:$PYTHONPATH python -m pytest testing/python/language/test_tilelang_language_rand.py -x -k "test_rand_init_in_split_guard"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Moved CUDA `tl.rng_init` state handling to kernel scope so RNG state remains valid after sync-insertion/block-splitting.
- Added a pre-scan in CUDA codegen to assign stable per-`rng_init` CURAND state names before emitting the function body, then reused those names when lowering `curand_init`.
- Added regression coverage for guarded RNG initialization with intervening shared-memory cumsum, plus guarded/unguarded rand comparisons across CURAND generator types.

## C++ style / lint notes
- This PR touches C++ codegen, but it does not appear to change rules documented in `docs/developer_guide/cpp_style.md`.
- No specific issues were called out here for the `C++ API Style Audit (warning only)` CI step.
- Any style-related findings would be advisory; the main change is correctness-focused.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->