### PR TITLE
[CUDA][ROCm] Rename GPU stub library artifacts

### DIFF
--- a/docs/runtime_internals/stubs.md
+++ b/docs/runtime_internals/stubs.md
@@ -7,10 +7,11 @@ libraries (CUDA and ROCm/HIP).
 
 CUDA:
 
-1. **CUDA Driver (`cuda_stub`)**: Allows TileLang to be imported on systems
-   without a GPU (e.g., CI/compilation nodes) by lazy-loading `libcuda.so` only
-   when needed.
-2. **CUDA Runtime & Compiler (`cudart_stub`, `nvrtc_stub`)**: Resolves SONAME
+1. **CUDA Driver (`cuda_stub`, file `libstub_cuda.so`)**: Allows TileLang to be
+   imported on systems without a GPU (e.g., CI/compilation nodes) by
+   lazy-loading `libcuda.so` only when needed.
+2. **CUDA Runtime & Compiler (`cudart_stub`, file `libstub_cudart.so`;
+   `nvrtc_stub`, file `libstub_nvrtc.so`)**: Resolves SONAME
    versioning mismatches (e.g. `libcudart.so.11` vs `libcudart.so.12`),
    enabling a single build to work across different CUDA versions. This is
    achieved by reusing CUDA libraries already loaded by frameworks like PyTorch
@@ -18,12 +19,14 @@ CUDA:
 
 ROCm:
 
-1. **HIP Runtime/Module API (`hip_stub`)**: Allows TileLang to be imported on
-   systems without ROCm installed by lazy-loading `libamdhip64.so` only when
-   needed. The stub also prefers already-loaded symbols via `RTLD_DEFAULT` /
-   `RTLD_NEXT` to interoperate with frameworks that have already loaded HIP.
-2. **HIP Runtime Compiler (`hiprtc_stub`)**: Lazily loads `libhiprtc.so` and
-   exposes the minimal HIPRTC API subset used by TileLang/TVM.
+1. **HIP Runtime/Module API (`hip_stub`, file `libstub_hip.so`)**: Allows
+   TileLang to be imported on systems without ROCm installed by lazy-loading
+   `libamdhip64.so` only when needed. The stub also prefers already-loaded
+   symbols via `RTLD_DEFAULT` / `RTLD_NEXT` to interoperate with frameworks that
+   have already loaded HIP.
+2. **HIP Runtime Compiler (`hiprtc_stub`, file `libstub_hiprtc.so`)**: Lazily
+   loads `libhiprtc.so` and exposes the minimal HIPRTC API subset used by
+   TileLang/TVM.
 
 ## Implementation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -278,7 +278,7 @@ environment.PATH = "/usr/local/cuda/bin:$PATH"
 environment.LD_LIBRARY_PATH = "/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs:$LD_LIBRARY_PATH"
 # Build a fat wheel that supports both CUDA and ROCm at runtime. ROCm sources
 # compile against the vendored HIP headers under 3rdparty/hip-headers/include
-# and link to libhip_stub (dlopen-based), so no ROCm runtime is required in
+# and link to libstub_hip (dlopen-based), so no ROCm runtime is required in
 # the cibuildwheel manylinux container. The resulting wheel still requires
 # a real ROCm runtime to be present at execution time on AMD hosts.
 environment.USE_CUDA = "ON"

--- a/src/cuda/CMakeLists.txt
+++ b/src/cuda/CMakeLists.txt
@@ -53,7 +53,7 @@ endif()
 
 if(TILELANG_USE_CUDA_STUBS)
   # ============================================================================
-  # CUDA Driver Stub Library (libcuda_stub.so / cuda_stub.dll)
+  # CUDA Driver Stub Library (libstub_cuda.so / stub_cuda.dll)
   # ============================================================================
   # This library provides drop-in replacements for CUDA driver API functions.
   # Instead of linking directly against libcuda.so (which would fail on
@@ -77,13 +77,14 @@ if(TILELANG_USE_CUDA_STUBS)
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    # Use consistent naming
-    OUTPUT_NAME "cuda_stub"
+    # Keep stub filenames distinct from real CUDA libraries, so naive
+    # substring-based library discovery does not confuse them with libcuda.
+    OUTPUT_NAME "stub_cuda"
     WINDOWS_EXPORT_ALL_SYMBOLS ON
   )
 
   # ============================================================================
-  # CUDA Runtime Stub Library (libcudart_stub.so / cudart_stub.dll)
+  # CUDA Runtime Stub Library (libstub_cudart.so / stub_cudart.dll)
   # ============================================================================
   # libcudart's SONAME includes its major version (e.g. libcudart.so.11.0 / .12 / .13).
   # Link against this stub instead of the real libcudart so a single wheel can
@@ -105,7 +106,7 @@ if(TILELANG_USE_CUDA_STUBS)
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    OUTPUT_NAME "cudart_stub"
+    OUTPUT_NAME "stub_cudart"
     WINDOWS_EXPORT_ALL_SYMBOLS ON
   )
 
@@ -117,7 +118,7 @@ if(TILELANG_USE_CUDA_STUBS)
   set(CUDA_CUDART_LIBRARY cudart_stub CACHE STRING "CUDART library to link against" FORCE)
 
   # ============================================================================
-  # NVRTC Stub Library (libnvrtc_stub.so / nvrtc_stub.dll)
+  # NVRTC Stub Library (libstub_nvrtc.so / stub_nvrtc.dll)
   # ============================================================================
   # NVRTC's SONAME includes its major version (e.g. libnvrtc.so.11.2 / .12 / .13).
   # Link against this stub instead of the real NVRTC library so a single wheel
@@ -139,7 +140,7 @@ if(TILELANG_USE_CUDA_STUBS)
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    OUTPUT_NAME "nvrtc_stub"
+    OUTPUT_NAME "stub_nvrtc"
     WINDOWS_EXPORT_ALL_SYMBOLS ON
   )
 

--- a/src/cuda/stubs/cuda.h
+++ b/src/cuda/stubs/cuda.h
@@ -19,7 +19,7 @@
  *
  * Usage:
  *
- * 1. Link against libcuda_stub.so instead of libcuda.so
+ * 1. Link against libstub_cuda.so instead of libcuda.so
  *
  * 2. Call CUDA driver API functions normally - they are provided as
  *    exported global functions with C linkage:

--- a/src/rocm/CMakeLists.txt
+++ b/src/rocm/CMakeLists.txt
@@ -77,7 +77,7 @@ if(TILELANG_USE_HIP_STUBS)
   endif()
 
   # ============================================================================
-  # HIP Stub Library (libhip_stub.so)
+  # HIP Stub Library (libstub_hip.so)
   # ============================================================================
   # This library provides drop-in replacements for HIP runtime/module APIs by
   # lazily loading libamdhip64.so at runtime.
@@ -93,11 +93,13 @@ if(TILELANG_USE_HIP_STUBS)
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    OUTPUT_NAME "hip_stub"
+    # Keep stub filenames distinct from real ROCm libraries, matching the CUDA
+    # stub naming convention.
+    OUTPUT_NAME "stub_hip"
   )
 
   # ============================================================================
-  # HIPRTC Stub Library (libhiprtc_stub.so)
+  # HIPRTC Stub Library (libstub_hiprtc.so)
   # ============================================================================
   # This library provides a minimal HIPRTC API surface and lazily loads
   # libhiprtc.so at runtime.
@@ -110,7 +112,7 @@ if(TILELANG_USE_HIP_STUBS)
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
     ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
-    OUTPUT_NAME "hiprtc_stub"
+    OUTPUT_NAME "stub_hiprtc"
   )
 
   # Make TVM link against our HIP stub instead of the real libamdhip64.so.

--- a/src/rocm/stubs/hip.h
+++ b/src/rocm/stubs/hip.h
@@ -4,7 +4,7 @@
  *
  * This mirrors the existing CUDA stubs in src/cuda/stubs/:
  * - Instead of linking against libamdhip64.so at build time, TileLang can link
- *   against a small stub library (libhip_stub.so) that resolves HIP symbols via
+ *   against a small stub library (libstub_hip.so) that resolves HIP symbols via
  *   dlopen()/dlsym() on first use.
  *
  * This enables:


### PR DESCRIPTION
## Summary

- Rename GPU stub library artifacts from the historical `lib<name>_stub` pattern to `libstub_<name>`.
- Keep CMake target names unchanged while avoiding filenames that can be mistaken for real CUDA or ROCm runtime libraries by substring-based discovery.

## Changes

- Rename CUDA stub outputs to `libstub_cuda.so`, `libstub_cudart.so`, and `libstub_nvrtc.so`.
- Rename ROCm stub outputs to `libstub_hip.so` and `libstub_hiprtc.so`.
- Update runtime stub documentation and build comments to use the new physical library names.
- Preserve the existing CMake target names such as `cuda_stub`, `cudart_stub`, and `hip_stub`, so internal link configuration remains stable.

## Validation

- `./format.sh`
- `cmake -S . -B build -G "Unix Makefiles" -DCMAKE_MAKE_PROGRAM=/usr/bin/make`
- `make -C build cuda_stub cudart_stub nvrtc_stub -j$(nproc)`
- `make -C build tilelang -j$(nproc)`
- Confirmed `libstub_cudart.so` has the expected SONAME and TileLang/TVM binaries link against `libstub_*` artifacts.

## Notes

- Related PR: vllm-project/vllm#47586.
- This is a filename-level hardening change; it does not expand the CUDA runtime stub API surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary
- Renamed GPU stub library artifacts from `lib<name>_stub` to `libstub_<name>` across CUDA and ROCm outputs.
- Kept CMake target names unchanged (`cuda_stub`, `cudart_stub`, `nvrtc_stub`, `hip_stub`, `hiprtc_stub`) so internal linkage remains stable.
- Updated stub documentation and inline comments to reflect the new filenames and the intended lazy-loading / discovery behavior.
- Adjusted the ROCm wheel packaging comment to match the new HIP stub name.

### C++ style / lint notes
- This PR does not appear to change `docs/developer_guide/cpp_style.md`.
- No new correctness, build, or test issues are indicated by the summary.
- Any C++ API style audit impact here is documentation/comment-level only; no warning-only style findings appear to introduce blocking risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->