### PR TITLE
[TIR][Codegen] Preserve decoupled cast buffer scope

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -702,7 +702,15 @@ void CodeGenTileLangCUDA::VisitStmt_(const tirx::ForNode *op) {
   stream << ' ' << vid << " = " << start << "; " << vid << " < " << extent
          << "; ++" << vid << ") {\n";
   int for_scope = BeginScope();
-  PrintStmt(op->body);
+  // A lexical_alloc_scope spanning the entire loop body is redundant with
+  // the loop's own braces; unwrap it to avoid emitting `{ {`.
+  Stmt body = op->body;
+  while (const auto *attr = body.as<AttrStmtNode>()) {
+    if (attr->attr_key != tl::attr::kLexicalAllocScope)
+      break;
+    body = attr->body;
+  }
+  PrintStmt(body);
   this->EndScope(for_scope);
   PrintIndent();
   stream << "}\n";

--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -277,7 +277,15 @@ void CodeGenTileLangHIP::VisitStmt_(const tirx::ForNode *op) {
   stream << ' ' << vid << " = " << start << "; " << vid << " < " << extent
          << "; ++" << vid << ") {\n";
   int for_scope = BeginScope();
-  PrintStmt(op->body);
+  // A lexical_alloc_scope spanning the entire loop body is redundant with
+  // the loop's own braces; unwrap it to avoid emitting `{ {`.
+  Stmt body = op->body;
+  while (const auto *attr = body.as<AttrStmtNode>()) {
+    if (attr->attr_key != tl::attr::kLexicalAllocScope)
+      break;
+    body = attr->body;
+  }
+  PrintStmt(body);
   this->EndScope(for_scope);
   PrintIndent();
   stream << "}\n";

--- a/testing/python/transform/test_tilelang_transform_decouple_type_cast.py
+++ b/testing/python/transform/test_tilelang_transform_decouple_type_cast.py
@@ -27,11 +27,15 @@ def test_local_to_memory():
     @T.prim_func
     def after(b: T.Tensor[(16,), T.float4_e2m1fn]):
         b_frag = T.alloc_local((16,), T.float32)
-        b_local_cast = T.decl_buffer((16,), T.float4_e2m1fn, scope="local")
-        for i in T.vectorized(16):
-            b_local_cast[i] = T.cast(b_frag[i], T.float4_e2m1fn)
-        for i_copy in T.vectorized(16):
-            b[i_copy] = b_local_cast[i_copy]
+        with T.sblock("decoupled_cast"):
+            T.sblock_attr({"lexical_alloc_scope": 1})
+            T.reads()
+            T.writes()
+            b_local_cast = T.decl_buffer((16,), T.float4_e2m1fn, scope="local")
+            for i in T.vectorized(16):
+                b_local_cast[i] = T.cast(b_frag[i], T.float4_e2m1fn)
+            for i_copy in T.vectorized(16):
+                b[i_copy] = b_local_cast[i_copy]
 
     _check(before, after)
 
@@ -48,11 +52,15 @@ def test_memory_to_local():
     @T.prim_func
     def after(b: T.Tensor[(16,), T.float4_e2m1fn]):
         b_frag = T.alloc_local((16,), T.float32)
-        b_local_cast = T.decl_buffer((16,), T.float4_e2m1fn, scope="local")
-        for i in T.vectorized(16):
-            b_local_cast[i] = b_frag[i]
-        for i_copy in T.vectorized(16):
-            b[i_copy] = b_local_cast[i_copy]
+        with T.sblock("decoupled_cast"):
+            T.sblock_attr({"lexical_alloc_scope": 1})
+            T.reads()
+            T.writes()
+            b_local_cast = T.decl_buffer((16,), T.float4_e2m1fn, scope="local")
+            for i in T.vectorized(16):
+                b_local_cast[i] = b_frag[i]
+            for i_copy in T.vectorized(16):
+                b[i_copy] = b_local_cast[i_copy]
 
     _check(before, after)
 
@@ -163,11 +171,15 @@ def test_local_to_memory_with_let_stmt():
     def after(b: T.Tensor[(16,), T.float8_e4m3fn]):
         a_frag = T.alloc_local((16,), T.float32)
         scale = T.alloc_local((16,), T.float32)
-        b_local_cast = T.decl_buffer((16,), T.float8_e4m3fn, scope="local")
-        for i in T.vectorized(16):
-            b_local_cast[i] = T.cast(a_frag[i] * scale[i], T.float8_e4m3fn)
-        for i_copy in T.vectorized(16):
-            b[i_copy] = b_local_cast[i_copy]
+        with T.sblock("decoupled_cast"):
+            T.sblock_attr({"lexical_alloc_scope": 1})
+            T.reads()
+            T.writes()
+            b_local_cast = T.decl_buffer((16,), T.float8_e4m3fn, scope="local")
+            for i in T.vectorized(16):
+                b_local_cast[i] = T.cast(a_frag[i] * scale[i], T.float8_e4m3fn)
+            for i_copy in T.vectorized(16):
+                b[i_copy] = b_local_cast[i_copy]
 
     _check(before, after)
 
@@ -188,11 +200,15 @@ def test_local_to_memory_with_bind_chain():
     def after(b: T.Tensor[(16,), T.float8_e4m3fn]):
         a_frag = T.alloc_local((16,), T.float32)
         scale = T.alloc_local((16,), T.float32)
-        b_local_cast = T.decl_buffer((16,), T.float8_e4m3fn, scope="local")
-        for i in T.vectorized(16):
-            b_local_cast[i] = T.cast(a_frag[i] * (scale[i] + T.float32(1)), T.float8_e4m3fn)
-        for i_copy in T.vectorized(16):
-            b[i_copy] = b_local_cast[i_copy]
+        with T.sblock("decoupled_cast"):
+            T.sblock_attr({"lexical_alloc_scope": 1})
+            T.reads()
+            T.writes()
+            b_local_cast = T.decl_buffer((16,), T.float8_e4m3fn, scope="local")
+            for i in T.vectorized(16):
+                b_local_cast[i] = T.cast(a_frag[i] * (scale[i] + T.float32(1)), T.float8_e4m3fn)
+            for i_copy in T.vectorized(16):
+                b[i_copy] = b_local_cast[i_copy]
 
     _check(before, after)
 
@@ -213,15 +229,51 @@ def test_local_to_memory_with_branch_local_bind():
     def after(b: T.Tensor[(16,), T.float8_e4m3fn]):
         a_frag = T.alloc_local((16,), T.float32)
         scale = T.alloc_local((16,), T.float32)
-        b_local_cast = T.decl_buffer((16,), T.float8_e4m3fn, scope="local")
-        for i in T.vectorized(16):
-            if i < 8:
-                b_local_cast[i] = T.cast(a_frag[i] * scale[i], T.float8_e4m3fn)
-        for i_copy in T.vectorized(16):
-            if i_copy < 8:
-                b[i_copy] = b_local_cast[i_copy]
+        with T.sblock("decoupled_cast"):
+            T.sblock_attr({"lexical_alloc_scope": 1})
+            T.reads()
+            T.writes()
+            b_local_cast = T.decl_buffer((16,), T.float8_e4m3fn, scope="local")
+            for i in T.vectorized(16):
+                if i < 8:
+                    b_local_cast[i] = T.cast(a_frag[i] * scale[i], T.float8_e4m3fn)
+            for i_copy in T.vectorized(16):
+                if i_copy < 8:
+                    b[i_copy] = b_local_cast[i_copy]
 
     _check(before, after)
+
+
+def test_cast_buffers_wrapped_in_lexical_alloc_scope():
+    """The pass must wrap cast buffers in a block annotated with
+    lexical_alloc_scope, so StorageRewrite keeps them scoped to the use site."""
+    from tvm.tirx.stmt_functor import post_order_visit
+
+    @T.prim_func
+    def before(b: T.Tensor[(16,), T.float4_e2m1fn]):
+        b_frag = T.alloc_local((16,), T.float32)
+        for i in T.vectorized(16):
+            b[i] = b_frag[i]
+
+    mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
+    mod = DecoupleTypeCast()(mod)
+
+    annotated_blocks = [0]
+    allocs_inside = [0]
+
+    def _visit(node):
+        if isinstance(node, tvm.tirx.SBlock) and "lexical_alloc_scope" in node.annotations:
+            annotated_blocks[0] += 1
+
+            def _count(inner):
+                if isinstance(inner, tvm.tirx.AllocBuffer):
+                    allocs_inside[0] += 1
+
+            post_order_visit(node.body, _count)
+
+    post_order_visit(mod["main"].body, _visit)
+    assert annotated_blocks[0] == 1, f"Expected 1 lexical_alloc_scope block, got {annotated_blocks[0]}"
+    assert allocs_inside[0] == 1, f"Expected the cast buffer alloc inside the scope, got {allocs_inside[0]}"
 
 
 # =============================================================================

--- a/testing/python/transform/test_tilelang_transform_lexical_alloc_scope.py
+++ b/testing/python/transform/test_tilelang_transform_lexical_alloc_scope.py
@@ -360,6 +360,9 @@ def test_codegen_emits_braces():
                     S = T.alloc_buffer((128,), dtype=T.float32, scope="local")
                     S[T.get_thread_binding()] = A[T.get_thread_binding(), k]
                     B[T.get_thread_binding(), k] = S[T.get_thread_binding()]
+                # Sibling statement keeps the scope from being the sole loop
+                # body, so its braces are not elided as redundant.
+                B[T.get_thread_binding(), k] = B[T.get_thread_binding(), k] + T.float32(1)
 
     kernel = tilelang.compile(func, out_idx=[1], target="cuda")
     src = kernel.get_kernel_source()
@@ -369,6 +372,36 @@ def test_codegen_emits_braces():
 
     standalone_open_braces = re.findall(r"^\s*\{\s*$", src, re.MULTILINE)
     assert len(standalone_open_braces) >= 1, f"Expected at least 1 standalone '{{' for lexical scope, found {len(standalone_open_braces)}"
+
+
+@tilelang.testing.requires_cuda
+def test_codegen_unwraps_scope_spanning_entire_loop_body():
+    """A lexical scope that spans the entire loop body must not emit `{ {`:
+    the loop's own braces already delimit the same C scope."""
+
+    @T.prim_func
+    def func(
+        A: T.Tensor((128, 4), T.float32),
+        B: T.Tensor((128, 4), T.float32),
+    ):
+        with T.Kernel(1, threads=128):
+            for k in T.serial(4):
+                with T.sblock():
+                    T.sblock_attr({"lexical_alloc_scope": 1})
+                    S = T.alloc_buffer((128,), dtype=T.float32, scope="local")
+                    S[T.get_thread_binding()] = A[T.get_thread_binding(), k]
+                    B[T.get_thread_binding(), k] = S[T.get_thread_binding()]
+
+    kernel = tilelang.compile(func, out_idx=[1], target="cuda")
+    src = kernel.get_kernel_source()
+    import re
+
+    assert not re.search(r"\{\s*\n\s*\{", src), f"Redundant `{{ {{` emitted for loop-spanning lexical scope:\n{src}"
+    # The local alloc must still be declared inside the loop body, not hoisted
+    # to the kernel entry.
+    loop_pos = src.find("for (")
+    decl_pos = src.find("float S[")
+    assert loop_pos >= 0 and decl_pos > loop_pos, f"Expected S declared inside the loop body:\n{src}"
 
 
 @tilelang.testing.requires_cuda
@@ -389,6 +422,9 @@ def test_codegen_skips_redundant_top_level_braces():
                     S = T.alloc_buffer((128,), dtype=T.float32, scope="local")
                     S[T.get_thread_binding()] = A[T.get_thread_binding(), k]
                     C[T.get_thread_binding()] = S[T.get_thread_binding()]
+                # Sibling statement keeps the inner scope's braces from being
+                # elided as redundant with the loop body.
+                C[T.get_thread_binding()] = C[T.get_thread_binding()] + T.float32(1)
             for k in T.serial(4):
                 B[T.get_thread_binding(), k] = C[T.get_thread_binding()]
 
@@ -425,5 +461,6 @@ if __name__ == "__main__":
     test_lower_opaque_block_skips_fragment_root_in_disable_ws_pipeline()
     test_storage_rewrite_preserves_scope()
     test_codegen_emits_braces()
+    test_codegen_unwraps_scope_spanning_entire_loop_body()
     test_codegen_skips_redundant_top_level_braces()
     print("All tests passed!")

--- a/tilelang/transform/decouple_type_cast.py
+++ b/tilelang/transform/decouple_type_cast.py
@@ -36,6 +36,11 @@ After:
         cast_buf[vec_copy] = b[vec_copy]                      # copy from memory
     for vec in T.vectorized(16):
         a_frag[vec] = T.cast(cast_buf[vec], "float32")        # compute
+
+The staging cast buffers together with the transformed loops are wrapped in
+an opaque block annotated with `lexical_alloc_scope`, so their allocations
+stay lexically scoped to the use site (see LowerOpaqueBlock / StorageRewrite)
+instead of being hoisted to the kernel entry.
 """
 
 from __future__ import annotations
@@ -58,6 +63,8 @@ from tvm.tirx import (
     Evaluate,
     PrimFunc,
     PyStmtExprVisitor,
+    SBlock,
+    SBlockRealize,
     SeqStmt,
     Stmt,
     Var,
@@ -539,12 +546,27 @@ class DecoupleTypeCastMutator(tirx.PyStmtExprMutator):
         return copy_loops
 
     def _wrap_with_allocations(self, body: Stmt, entries: list[CastEntry]) -> Stmt:
-        """Wrap statement with buffer declarations and allocations."""
-        alloc_stmts = []
-        for _, _, cast_buffer in entries:
-            alloc_stmts.append(AllocBuffer(cast_buffer))
+        """Wrap statement with buffer allocations inside a lexical alloc scope.
+
+        The cast buffers are tiny per-site staging arrays. Placing them in an
+        opaque block annotated with `lexical_alloc_scope` makes LowerOpaqueBlock
+        materialize a scope boundary, so StorageRewrite keeps the allocations
+        next to their use site instead of hoisting them to the kernel entry,
+        and codegen emits a `{ ... }` scope with the declarations inside.
+        """
+        if not entries:
+            return body
+        alloc_stmts: list[Stmt] = [AllocBuffer(cast_buffer) for _, _, cast_buffer in entries]
         alloc_stmts.append(body)
-        return SeqStmt(alloc_stmts)
+        block = SBlock(
+            iter_vars=[],
+            reads=[],
+            writes=[],
+            name_hint="decoupled_cast",
+            body=SeqStmt(alloc_stmts),
+            annotations={"lexical_alloc_scope": 1},
+        )
+        return SBlockRealize([], True, block)
 
     def _replace_access(self, stmt: Stmt, store_entries: list[CastEntry], load_entries: list[CastEntry], loop_var: Var) -> Stmt:
         """Replace memory accesses with cast buffer accesses."""


### PR DESCRIPTION
## Summary

- Keep decoupled type-cast staging buffers lexically scoped to their transformed use site.
- Avoid redundant codegen braces when a lexical allocation scope spans an entire loop body.

## Changes

- Wrap decoupled cast buffer allocations and transformed loops in an opaque block annotated with `lexical_alloc_scope`.
- Update CUDA and HIP for-loop codegen to unwrap full-body lexical allocation scopes before printing the loop body.
- Extend transform and codegen tests to cover scoped cast buffers, preserved lexical braces, and redundant brace elision.

## Validation

- `./format.sh`
- `cmake --build build -j$(nproc)`
- `python -m pytest testing/python/transform/test_tilelang_transform_decouple_type_cast.py testing/python/transform/test_tilelang_transform_lexical_alloc_scope.py -x`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Kept decoupled type-cast staging buffers lexically scoped to their transformed use site by wrapping the generated buffer work in a `lexical_alloc_scope` SBlock/SBlockRealize.
- Updated CUDA and HIP for-loop codegen to unwrap full-body lexical alloc scopes before printing loop bodies, avoiding redundant nested braces.
- Expanded transform/codegen tests to cover scoped cast buffers, preserved lexical braces, and brace-elision behavior in loop bodies.

## C++ style / lint notes
- This PR touches C++ codegen paths, so the rules in `docs/developer_guide/cpp_style.md` are relevant.
- The `C++ API Style Audit (warning only)` step is the main CI check to watch for any style warnings here.
- No blocking correctness/build issues are evident from the change summary; any TLCPP003/TLCPP004-style findings would be advisory unless they indicate a real API/FFI/maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->