### PR TITLE
[Language][Scheduler] Expose scalar tile scheduler state

### DIFF
--- a/examples/blockscaled_gemm_sm100/gemm_mxfp8_blockscaled_1d1d.py
+++ b/examples/blockscaled_gemm_sm100/gemm_mxfp8_blockscaled_1d1d.py
@@ -2,9 +2,9 @@
 # Blockscale size: (M, N, K) = (1, 1, 128)
 #
 # Persistent 2-CTA variant uses PersistentTileScheduler: each warp role owns a
-# scheduler instance and drives ``while sched.valid()``. ``sched.current_iter[0]``
-# is the wave index for pipeline/double-buffering; ``sched.m_idx[0]`` /
-# ``sched.n_idx[0]`` decode the tile (with ``bx = m_idx * cluster_size + cta_id``).
+# scheduler instance and drives ``while sched.valid()``. ``sched.current_iter``
+# is the wave index for pipeline/double-buffering; ``sched.m_idx`` /
+# ``sched.n_idx`` decode the tile (with ``bx = m_idx * cluster_size + cta_id``).
 
 import argparse
 import torch
@@ -389,14 +389,14 @@ def mxfp8_blockscaled_gemm_2cta_persistent(
         warp_idx = tx // 32
 
         if warp_idx == 0:
-            sched = T.PersistentTileScheduler("sched_tma", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+            sched = T.PersistentTileScheduler(m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
             sched.init(block_id // cluster_size)
             while sched.valid():
-                bx = sched.m_idx[0] * cluster_size + cta_id
-                by = sched.n_idx[0]
+                bx = sched.m_idx * cluster_size + cta_id
+                by = sched.n_idx
 
                 for k in T.serial(k_iters):
-                    phase = sched.current_iter[0] * k_iters + k
+                    phase = sched.current_iter * k_iters + k
                     stage = phase % num_stages
                     parity = (phase // num_stages) & 1
                     T.mbarrier_wait_parity(consumed[stage], parity ^ 1)
@@ -439,12 +439,12 @@ def mxfp8_blockscaled_gemm_2cta_persistent(
                 sched.next_tile()
 
         elif warp_idx == 1 and cta_id == 0:
-            sched = T.PersistentTileScheduler("sched_mma", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+            sched = T.PersistentTileScheduler(m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
             sched.init(block_id // cluster_size)
             while sched.valid():
-                T.mbarrier_wait_parity(tmem_empty, (sched.current_iter[0] & 1) ^ 1)
+                T.mbarrier_wait_parity(tmem_empty, (sched.current_iter & 1) ^ 1)
                 for k in T.serial(k_iters):
-                    phase = sched.current_iter[0] * k_iters + k
+                    phase = sched.current_iter * k_iters + k
                     stage = phase % num_stages
                     parity = (phase // num_stages) & 1
                     T.mbarrier_wait_parity(with_sf_full[stage], parity)
@@ -469,11 +469,11 @@ def mxfp8_blockscaled_gemm_2cta_persistent(
                 sched.next_tile()
 
         elif warp_idx == 2:
-            sched = T.PersistentTileScheduler("sched_sf", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+            sched = T.PersistentTileScheduler(m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
             sched.init(block_id // cluster_size)
             while sched.valid():
                 for k in T.serial(k_iters):
-                    phase = sched.current_iter[0] * k_iters + k
+                    phase = sched.current_iter * k_iters + k
                     stage = phase % num_stages
                     parity = (phase // num_stages) & 1
                     T.mbarrier_wait_parity(loaded[stage], parity)
@@ -485,13 +485,13 @@ def mxfp8_blockscaled_gemm_2cta_persistent(
                 sched.next_tile()
 
         elif 128 <= tx < 256:
-            sched = T.PersistentTileScheduler("sched_epi", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+            sched = T.PersistentTileScheduler(m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
             sched.init(block_id // cluster_size)
             while sched.valid():
-                bx = sched.m_idx[0] * cluster_size + cta_id
-                by = sched.n_idx[0]
+                bx = sched.m_idx * cluster_size + cta_id
+                by = sched.n_idx
 
-                T.mbarrier_wait_parity(tmem_full, sched.current_iter[0] & 1)
+                T.mbarrier_wait_parity(tmem_full, sched.current_iter & 1)
                 T.copy(C_tmem, C_local)
                 T.mbarrier_arrive(tmem_empty, 0)
 

--- a/examples/deepseek_v4/fp8_fp4_gemm_1d1d_sm100.py
+++ b/examples/deepseek_v4/fp8_fp4_gemm_1d1d_sm100.py
@@ -81,14 +81,14 @@ def fp8_fp4_gemm_1d1d_persistent(
             tx = T.get_thread_binding()
 
             if tx < 32:  # issue TMA, load operands and SFs
-                sched = T.PersistentTileScheduler("sched_tma", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+                sched = T.PersistentTileScheduler(m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
                 sched.init(block_id // cluster_size)
                 while sched.valid():
-                    bx = sched.m_idx[0] * cluster_size + cta_id
-                    by = sched.n_idx[0]
+                    bx = sched.m_idx * cluster_size + cta_id
+                    by = sched.n_idx
 
                     for k in T.serial(k_iters):
-                        phase = sched.current_iter[0] * k_iters + k
+                        phase = sched.current_iter * k_iters + k
                         stage = phase % num_stages
                         parity = (phase // num_stages) & 1
                         T.mbarrier_wait_parity(consumed[stage], parity ^ 1)
@@ -121,12 +121,12 @@ def fp8_fp4_gemm_1d1d_persistent(
                     sched.next_tile()
 
             elif 32 <= tx < 64 and cta_id == 0:  # issue tcgen5
-                sched = T.PersistentTileScheduler("sched_mma", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+                sched = T.PersistentTileScheduler(m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
                 sched.init(block_id // cluster_size)
                 while sched.valid():
-                    T.mbarrier_wait_parity(tmem_empty, (sched.current_iter[0] & 1) ^ 1)
+                    T.mbarrier_wait_parity(tmem_empty, (sched.current_iter & 1) ^ 1)
                     for k in T.serial(k_iters):
-                        phase = sched.current_iter[0] * k_iters + k
+                        phase = sched.current_iter * k_iters + k
                         stage = phase % num_stages
                         parity = (phase // num_stages) & 1
                         T.mbarrier_wait_parity(with_sf_full[stage], parity)
@@ -151,11 +151,11 @@ def fp8_fp4_gemm_1d1d_persistent(
                     sched.next_tile()
 
             elif 64 <= tx < 96:  # transpose SFs
-                sched = T.PersistentTileScheduler("sched_sf", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+                sched = T.PersistentTileScheduler(m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
                 sched.init(block_id // cluster_size)
                 while sched.valid():
                     for k in T.serial(k_iters):
-                        phase = sched.current_iter[0] * k_iters + k
+                        phase = sched.current_iter * k_iters + k
                         stage = phase % num_stages
                         parity = (phase // num_stages) & 1
                         T.mbarrier_wait_parity(loaded[stage], parity)
@@ -167,13 +167,13 @@ def fp8_fp4_gemm_1d1d_persistent(
                     sched.next_tile()
 
             elif 128 <= tx < 256:  # epilogue
-                sched = T.PersistentTileScheduler("sched_epi", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+                sched = T.PersistentTileScheduler(m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
                 sched.init(block_id // cluster_size)
                 while sched.valid():
-                    bx = sched.m_idx[0] * cluster_size + cta_id
-                    by = sched.n_idx[0]
+                    bx = sched.m_idx * cluster_size + cta_id
+                    by = sched.n_idx
 
-                    T.mbarrier_wait_parity(tmem_full, sched.current_iter[0] & 1)
+                    T.mbarrier_wait_parity(tmem_full, sched.current_iter & 1)
                     T.copy(C_tmem, C_local)
                     T.mbarrier_arrive(tmem_empty, 0)
 

--- a/examples/gemm_sm100/gemm_tcgen5mma_ws_persistent.py
+++ b/examples/gemm_sm100/gemm_tcgen5mma_ws_persistent.py
@@ -2,9 +2,9 @@
 #
 # Each warp role (TMA / tcgen5 MMA / epilogue) creates its own scheduler instance
 # and drives a single ``while sched.valid()`` loop. The scheduler owns the only
-# iteration clock: ``sched.current_iter[0]`` drives pipeline phase /
-# ``sched.current_iter[0] & 1`` double-buffering; ``sched.m_idx[0]`` /
-# ``sched.n_idx[0]`` are the tile coords. One clock, held by the scheduler -- no
+# iteration clock: ``sched.current_iter`` drives pipeline phase /
+# ``sched.current_iter & 1`` double-buffering; ``sched.m_idx`` /
+# ``sched.n_idx`` are the tile coords. One clock, held by the scheduler -- no
 # separate ``for w in range(waves)`` counter.
 
 import torch
@@ -58,13 +58,13 @@ def gemm_persistent(
         tx = T.get_thread_binding()
 
         if tx < 32:  # warp 0: issue tma
-            sched = T.PersistentTileScheduler("sched_tma", m_blocks, n_blocks, swizzle_size=group_size)
+            sched = T.PersistentTileScheduler(m_blocks, n_blocks, swizzle_size=group_size)
             sched.init(block_id)
             while sched.valid():
-                bx, by = sched.m_idx[0], sched.n_idx[0]
+                bx, by = sched.m_idx, sched.n_idx
 
                 for k in T.serial(k_blocks):
-                    phase = sched.current_iter[0] * k_blocks + k
+                    phase = sched.current_iter * k_blocks + k
                     T.mbarrier_wait_parity(consumed[phase % num_stages], ((phase // num_stages) & 1) ^ 1)
                     T.tma_copy(
                         A[bx * block_M : (bx + 1) * block_M, k * block_K : (k + 1) * block_K],
@@ -80,14 +80,14 @@ def gemm_persistent(
                 sched.next_tile()
 
         elif tx < 64:  # warp 1: issue tcgen5
-            sched = T.PersistentTileScheduler("sched_mma", m_blocks, n_blocks, swizzle_size=group_size)
+            sched = T.PersistentTileScheduler(m_blocks, n_blocks, swizzle_size=group_size)
             sched.init(block_id)
             while sched.valid():
-                T.mbarrier_wait_parity(tmem_empty[sched.current_iter[0] & 1], ((sched.current_iter[0] // 2) & 1) ^ 1)
+                T.mbarrier_wait_parity(tmem_empty[sched.current_iter & 1], ((sched.current_iter // 2) & 1) ^ 1)
                 for k in T.serial(k_blocks):
-                    phase = sched.current_iter[0] * k_blocks + k
+                    phase = sched.current_iter * k_blocks + k
                     T.mbarrier_wait_parity(loaded[phase % num_stages], (phase // num_stages) & 1)
-                    if sched.current_iter[0] & 1 == 0:
+                    if sched.current_iter & 1 == 0:
                         T.tcgen05_gemm(
                             A_shared[k % num_stages, :, :],
                             B_shared[k % num_stages, :, :],
@@ -103,21 +103,21 @@ def gemm_persistent(
                             mbar=consumed[k % num_stages],
                             clear_accum=k == 0,
                         )
-                T.tcgen05_mma_arrive(tmem_full[sched.current_iter[0] & 1])
+                T.tcgen05_mma_arrive(tmem_full[sched.current_iter & 1])
                 sched.next_tile()
 
         elif 128 <= tx < 256:  # warp 4~7: epilogue
-            sched = T.PersistentTileScheduler("sched_epi", m_blocks, n_blocks, swizzle_size=group_size)
+            sched = T.PersistentTileScheduler(m_blocks, n_blocks, swizzle_size=group_size)
             sched.init(block_id)
             while sched.valid():
-                bx, by = sched.m_idx[0], sched.n_idx[0]
+                bx, by = sched.m_idx, sched.n_idx
 
-                T.mbarrier_wait_parity(tmem_full[sched.current_iter[0] & 1], (sched.current_iter[0] // 2) & 1)
-                if (sched.current_iter[0] & 1) == 0:
+                T.mbarrier_wait_parity(tmem_full[sched.current_iter & 1], (sched.current_iter // 2) & 1)
+                if (sched.current_iter & 1) == 0:
                     T.copy(C_tmem_0, C_local)
                 else:
                     T.copy(C_tmem_1, C_local)
-                T.mbarrier_arrive(tmem_empty[sched.current_iter[0] & 1])
+                T.mbarrier_arrive(tmem_empty[sched.current_iter & 1])
 
                 if use_tma_store:
                     for i in T.unroll(T.ceildiv(block_N, store_block_N)):
@@ -177,13 +177,13 @@ def gemm_persistent_2cta(
         T.assume(cta_id < 2)  # todo: automatically assume this
 
         if tx < 32:  # warp 0: issue tma
-            sched = T.PersistentTileScheduler("sched_tma", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+            sched = T.PersistentTileScheduler(m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
             sched.init(block_id // cluster_size)
             while sched.valid():
-                bx, by = sched.m_idx[0] * cluster_size + cta_id, sched.n_idx[0]
+                bx, by = sched.m_idx * cluster_size + cta_id, sched.n_idx
 
                 for k in T.serial(k_blocks):
-                    phase = sched.current_iter[0] * k_blocks + k
+                    phase = sched.current_iter * k_blocks + k
                     T.mbarrier_wait_parity(consumed[phase % num_stages], ((phase // num_stages) & 1) ^ 1)
                     T.tma_copy(
                         A[bx * block_M : (bx + 1) * block_M, k * block_K : (k + 1) * block_K],
@@ -200,14 +200,14 @@ def gemm_persistent_2cta(
                 sched.next_tile()
 
         elif tx < 64 and cta_id == 0:  # warp 1: issue tcgen5
-            sched = T.PersistentTileScheduler("sched_mma", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+            sched = T.PersistentTileScheduler(m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
             sched.init(block_id // cluster_size)
             while sched.valid():
-                T.mbarrier_wait_parity(tmem_empty[sched.current_iter[0] & 1], ((sched.current_iter[0] // 2) & 1) ^ 1)
+                T.mbarrier_wait_parity(tmem_empty[sched.current_iter & 1], ((sched.current_iter // 2) & 1) ^ 1)
                 for k in T.serial(k_blocks):
-                    phase = sched.current_iter[0] * k_blocks + k
+                    phase = sched.current_iter * k_blocks + k
                     T.mbarrier_wait_parity(loaded[phase % num_stages], (phase // num_stages) & 1)
-                    if sched.current_iter[0] & 1 == 0:
+                    if sched.current_iter & 1 == 0:
                         T.tcgen05_gemm(
                             A_shared[phase % num_stages, :, :],
                             B_shared[phase % num_stages, :, :],
@@ -225,21 +225,21 @@ def gemm_persistent_2cta(
                             clear_accum=k == 0,
                             use_2cta=True,
                         )
-                T.tcgen05_mma_arrive(tmem_full[sched.current_iter[0] & 1], arrive_2cta=True)
+                T.tcgen05_mma_arrive(tmem_full[sched.current_iter & 1], arrive_2cta=True)
                 sched.next_tile()
 
         elif 128 <= tx < 256:  # warp 4~7: epilogue
-            sched = T.PersistentTileScheduler("sched_epi", m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
+            sched = T.PersistentTileScheduler(m_blocks, n_blocks, swizzle_size=group_size, cluster_size=cluster_size)
             sched.init(block_id // cluster_size)
             while sched.valid():
-                bx, by = sched.m_idx[0] * cluster_size + cta_id, sched.n_idx[0]
+                bx, by = sched.m_idx * cluster_size + cta_id, sched.n_idx
 
-                T.mbarrier_wait_parity(tmem_full[sched.current_iter[0] & 1], (sched.current_iter[0] // 2) & 1)
-                if (sched.current_iter[0] & 1) == 0:
+                T.mbarrier_wait_parity(tmem_full[sched.current_iter & 1], (sched.current_iter // 2) & 1)
+                if (sched.current_iter & 1) == 0:
                     T.copy(C_tmem_0, C_local)
                 else:
                     T.copy(C_tmem_1, C_local)
-                T.mbarrier_arrive(tmem_empty[sched.current_iter[0] & 1], 0)
+                T.mbarrier_arrive(tmem_empty[sched.current_iter & 1], 0)
 
                 if use_tma_store:
                     for i in T.unroll(T.ceildiv(block_N, store_block_N)):

--- a/testing/python/language/test_tilelang_language_tile_schedule.py
+++ b/testing/python/language/test_tilelang_language_tile_schedule.py
@@ -1,0 +1,36 @@
+import tilelang.language as T
+import tilelang.testing
+
+
+def test_persistent_tile_scheduler_scalar_state_access():
+    @T.prim_func
+    def persistent(A: T.Tensor((8,), T.int32)):
+        with T.Kernel(1, threads=1) as (block_id,):
+            sched = T.PersistentTileScheduler(4, 2, num_workers=1, swizzle_size=1, name="sched")
+            sched.init(block_id)
+            while sched.valid():
+                A[sched.m_idx] = sched.n_idx + sched.current_iter
+                sched.next_tile()
+
+    script = persistent.script()
+    assert "sched_m_idx" in script
+    assert "sched_n_idx" in script
+    assert "sched_current_iter" in script
+    assert "while" in script
+
+
+def test_persistent_tile_scheduler_stateless_coord_access():
+    @T.prim_func
+    def stateless(A: T.Tensor((8,), T.int32)):
+        with T.Kernel(1, threads=1) as (block_id,):
+            sched = T.PersistentTileScheduler(4, 2, num_workers=1, swizzle_size=1, stateful=False)
+            bx, by = sched.coord(block_id)
+            A[bx] = by
+
+    script = stateless.script()
+    assert "alloc_var" not in script
+    assert "A[bx_1] = by" in script
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/language/meta.py
+++ b/tilelang/language/meta.py
@@ -100,49 +100,52 @@ def _emits_store(func: Callable) -> bool:
         return True
 
 
-def _name_buffer(prefix: str, attr: str, value: Any) -> None:
-    """Give a state buffer a readable name ``{prefix}_{attr}`` in the IR."""
+def _name_buffer(meta_name: str, attr: str, value: Any) -> None:
+    """Give a state buffer a readable name ``{meta_name}_{attr}`` in the IR."""
     from tvm.script.ir_builder import IRBuilder
     from tvm.tirx import Buffer
 
     if not isinstance(value, Buffer):
         return
     with contextlib.suppress(Exception):  # naming is best-effort, never fatal
-        IRBuilder.name(f"{prefix}_{attr}", value)
+        IRBuilder.name(f"{meta_name}_{attr}", value)
 
 
-def _install_prefix_naming(cls: type) -> None:
-    """Make ``self.<attr> = <buffer>`` auto-name the buffer using ``prefix``.
+def _install_buffer_naming(cls: type) -> None:
+    """Make ``self.<attr> = <buffer>`` auto-name the buffer using ``name``.
 
-    ``prefix`` is read from the constructor argument of the same name (if any),
-    so existing ``__init__(self, prefix, ...)`` signatures just work.
+    ``name`` is read from the constructor argument of the same name (if any);
+    it is optional and defaults to ``None`` = no naming, so classes without a
+    ``name`` constructor argument just work.
     """
-    if cls.__dict__.get("_tl_prefix_naming_installed", False):
+    if cls.__dict__.get("_tl_buffer_naming_installed", False):
         return
 
     orig_init = cls.__init__
     init_sig = inspect.signature(orig_init)
 
     def __init__(self, *args, **kwargs):
-        prefix = None
+        meta_name = None
         try:
             bound = init_sig.bind(self, *args, **kwargs)
             bound.apply_defaults()
-            prefix = bound.arguments.get("prefix")
+            meta_name = bound.arguments.get("name")
         except TypeError:
-            prefix = None
-        object.__setattr__(self, "_meta_prefix", prefix)
+            meta_name = None
+        object.__setattr__(self, "_meta_name", meta_name)
         orig_init(self, *args, **kwargs)
 
     def __setattr__(self, name, value):
         object.__setattr__(self, name, value)
-        prefix = getattr(self, "_meta_prefix", None)
-        if prefix and not name.startswith("_"):
-            _name_buffer(prefix, name, value)
+        meta_name = getattr(self, "_meta_name", None)
+        # State buffers live behind underscore attributes (public access goes
+        # through properties), so strip leading underscores for the IR name.
+        if meta_name and name.lstrip("_"):
+            _name_buffer(meta_name, name.lstrip("_"), value)
 
     cls.__init__ = __init__
     cls.__setattr__ = __setattr__
-    cls._tl_prefix_naming_installed = True
+    cls._tl_buffer_naming_installed = True
 
 
 def meta_class(cls: _C) -> _C:
@@ -169,17 +172,19 @@ def meta_class(cls: _C) -> _C:
          These stay plain so they can return values and be reused statelessly.
          A method that emits TIR only through control flow / nested calls (no
          direct store) should be marked explicitly with ``@inline``.
-    3. Auto-name state buffers ``{prefix}_{attr}`` in the generated IR, where
-       ``prefix`` is the constructor argument named ``prefix`` (so
-       ``Sched("sched", ...)`` yields ``sched_m_idx`` etc.). This wraps
-       ``__init__`` to capture ``prefix`` and installs a ``__setattr__`` that
-       names any ``Buffer`` assigned to a non-underscore attribute; non-buffers
-       (compile-time ints like ``num_n_tiles``) and underscore attributes are
-       skipped, and naming is best-effort (never fatal). It runs at
-       construction while an IR builder is active, so it works in both modes.
+    3. Auto-name state buffers ``{name}_{attr}`` in the generated IR, where
+       ``name`` is the optional constructor argument named ``name`` (so
+       ``Sched(..., name="sched")`` yields ``sched_m_idx`` etc.; the default
+       ``None`` skips naming). This wraps ``__init__`` to capture ``name`` and
+       installs a ``__setattr__`` that names any ``Buffer`` assigned to an
+       attribute (leading underscores are stripped, so ``self._m_idx``
+       becomes ``sched_m_idx``); non-buffers (compile-time ints like
+       ``num_n_tiles``) are skipped, and naming is
+       best-effort (never fatal). It runs at construction while an IR builder
+       is active, so it works in both modes.
     """
     cls._is_meta_class = True
-    _install_prefix_naming(cls)
+    _install_buffer_naming(cls)
     for name, attr in list(cls.__dict__.items()):
         if name.startswith("__"):
             continue

--- a/tilelang/language/tile_schedule.py
+++ b/tilelang/language/tile_schedule.py
@@ -1,12 +1,13 @@
 """Tile schedulers built on TileLang ``meta_class``.
 
 ``@meta_class`` auto-inlines every method that emits a buffer store, so state
-methods can freely read scalar state via ``self.x[0]`` and write via
-``self.x[0] = ...`` (the latter lowers to a ``BufferStore``). Store-free methods
-(``valid``, ``coord``) stay plain Python and just return ``PrimExpr`` values, so
-they work in conditions and can be reused statelessly. State lives in
-``T.alloc_var`` buffers allocated in ``__init__`` (only when ``stateful``). Works
-in both eager (``@tilelang.jit``) and lazy (``@T.prim_func``) modes.
+methods can freely read scalar state via ``self._x[0]`` and write via
+``self._x[0] = ...`` (the latter lowers to a ``BufferStore``). Store-free
+methods (``valid``, ``coord``) and the read-only state properties (``m_idx``,
+``n_idx``, ``current_iter``) stay plain Python and just return ``PrimExpr``
+values, so they work in conditions and can be reused statelessly. State lives
+in ``T.alloc_var`` buffers allocated in ``__init__`` (only when ``stateful``).
+Works in both eager (``@tilelang.jit``) and lazy (``@T.prim_func``) modes.
 
 Note on compile-time branching: the lazy TVMScript parser does not constant-fold
 a Python ``if`` on a compile-time value inside an inlined method (it would emit a
@@ -30,37 +31,62 @@ class BaseTileScheduler:
     State (single-element ``T.alloc_var`` buffers): ``m_idx`` / ``n_idx`` are the
     current tile coordinates; ``linear_idx`` is the worker's global linear cursor;
     ``current_iter`` is the 0-based iteration count (how many tiles this worker has
-    advanced past = the "wave" index). ``current_iter`` is the single iteration
-    clock the kernel can read for pipeline/double-buffer state (e.g.
-    ``sched.current_iter[0] & 1``), removing the need for a separate ``for w`` loop
-    counter. Subclasses implement ``update_current_idx`` to decode ``linear_idx``
-    into ``(m_idx, n_idx)`` and set ``self._total_tiles`` (used by ``valid``).
+    advanced past = the "wave" index). Each is exposed as a read-only property
+    returning the scalar ``PrimExpr`` (``sched.m_idx``, ``sched.current_iter``);
+    only scheduler methods mutate the underlying buffers (``self._m_idx[0] = ...``).
+    ``current_iter`` is the single iteration clock the kernel can read for
+    pipeline/double-buffer state (e.g. ``sched.current_iter & 1``), removing the
+    need for a separate ``for w`` loop counter. Subclasses implement
+    ``update_current_idx`` to decode ``linear_idx`` into ``(m_idx, n_idx)`` and
+    set ``self._total_tiles`` (used by ``valid``).
     """
 
-    def __init__(self, prefix: str, stateful: bool = True):
+    def __init__(self, stateful: bool = True, name: str | None = None):
+        # ``name`` is not read here: the ``meta_class`` __init__ wrapper binds
+        # it from the signature to auto-name the state buffers below.
         self._stateful = stateful
         if stateful:
-            self.m_idx = T.alloc_var(T.int32)
-            self.n_idx = T.alloc_var(T.int32)
-            self.linear_idx = T.alloc_var(T.int32)
-            self.current_iter = T.alloc_var(T.int32)
+            self._m_idx = T.alloc_var(T.int32)
+            self._n_idx = T.alloc_var(T.int32)
+            self._linear_idx = T.alloc_var(T.int32)
+            self._current_iter = T.alloc_var(T.int32)
         self._total_tiles = 0
+
+    @property
+    def m_idx(self):
+        """Current tile row as a scalar ``PrimExpr``."""
+        return self._m_idx[0]
+
+    @property
+    def n_idx(self):
+        """Current tile column as a scalar ``PrimExpr``."""
+        return self._n_idx[0]
+
+    @property
+    def linear_idx(self):
+        """This worker's global linear tile cursor as a scalar ``PrimExpr``."""
+        return self._linear_idx[0]
+
+    @property
+    def current_iter(self):
+        """0-based iteration count (wave index) as a scalar ``PrimExpr``."""
+        return self._current_iter[0]
 
     def update_current_idx(self, linear_idx):
         raise NotImplementedError("Subclasses must implement update_current_idx")
 
     def init(self, linear_init):
-        self.current_iter[0] = 0
-        self.linear_idx[0] = linear_init
-        self.update_current_idx(self.linear_idx[0])
+        self._current_iter[0] = 0
+        self._linear_idx[0] = linear_init
+        self.update_current_idx(self._linear_idx[0])
 
     def next_tile(self, step):
-        self.current_iter[0] = self.current_iter[0] + 1
-        self.linear_idx[0] = self.linear_idx[0] + step
-        self.update_current_idx(self.linear_idx[0])
+        self._current_iter[0] = self._current_iter[0] + 1
+        self._linear_idx[0] = self._linear_idx[0] + step
+        self.update_current_idx(self._linear_idx[0])
 
     def valid(self):
-        return self.linear_idx[0] < self._total_tiles
+        return self._linear_idx[0] < self._total_tiles
 
 
 @meta_class
@@ -89,9 +115,9 @@ class PersistentTileScheduler(BaseTileScheduler):
        ``num_n_tiles`` columns. The caller turns the cluster-row into a real
        block row by adding the in-cluster rank::
 
-           bx = sched.m_idx[0] * cluster_size + cta_rank_in_cluster
+           bx = sched.m_idx * cluster_size + cta_rank_in_cluster
 
-       (For ``cluster_size == 1`` this reduces to ``bx = sched.m_idx[0]``.)
+       (For ``cluster_size == 1`` this reduces to ``bx = sched.m_idx``.)
 
     Interaction: clustering reshapes the grid to ``M' x N'`` (with
     ``M' = ceildiv(num_m_tiles, cluster_size)``) *first*; the swizzle and
@@ -100,9 +126,6 @@ class PersistentTileScheduler(BaseTileScheduler):
 
     Parameters
     ----------
-    prefix : str
-        Name prefix for the scheduler's state buffers in the generated IR
-        (``{prefix}_m_idx`` / ``{prefix}_n_idx`` / ``{prefix}_linear_idx``).
     num_m_tiles : int | PrimExpr
         Number of tiles along M (``ceildiv(M, block_M)``).
     num_n_tiles : int | PrimExpr
@@ -124,6 +147,11 @@ class PersistentTileScheduler(BaseTileScheduler):
         and expose only the pure ``coord(tile_id) -> (m, n)`` decode (for
         ``for w in range(waves)`` loops and auto warp-specialization, where the
         loop owns the iteration clock and the WS pass owns the pipeline phase).
+    name : str, optional
+        Optional name prefix for the state buffers in the generated IR
+        (``{name}_m_idx`` / ``{name}_n_idx`` / ...). Default ``None`` leaves
+        the buffers with generic auto-generated names; pass a name to make the
+        IR easier to read when a kernel holds several scheduler instances.
 
     Examples
     --------
@@ -131,17 +159,17 @@ class PersistentTileScheduler(BaseTileScheduler):
 
         m_blocks, n_blocks = T.ceildiv(M, block_M), T.ceildiv(N, block_N)
         with T.Kernel(driver.get_num_sms(), threads=threads) as (block_id,):
-            sched = T.PersistentTileScheduler("sched", m_blocks, n_blocks)
+            sched = T.PersistentTileScheduler(m_blocks, n_blocks)
             sched.init(block_id)
             while sched.valid():
-                bx, by = sched.m_idx[0], sched.n_idx[0]
+                bx, by = sched.m_idx, sched.n_idx
                 # ... compute tile (bx, by) ...
                 sched.next_tile()
 
-    With L2 swizzle (panel width 8)::
+    With L2 swizzle (panel width 8) and named state buffers in the IR::
 
         sched = T.PersistentTileScheduler(
-            "sched", m_blocks, n_blocks, swizzle_size=8)
+            m_blocks, n_blocks, swizzle_size=8, name="sched")
 
     With a 2-CTA cluster along M (e.g. SM100 2-SM MMA)::
 
@@ -150,12 +178,12 @@ class PersistentTileScheduler(BaseTileScheduler):
         with T.ClusterKernel(sm_num, threads=256, cluster_dims=cluster_size) as (block_id):
             cta_rank = T.block_rank_in_cluster()
             sched = T.PersistentTileScheduler(
-                "sched", m_blocks, n_blocks,
+                m_blocks, n_blocks,
                 swizzle_size=8, cluster_size=cluster_size)
             sched.init(block_id // cluster_size)   # init with cluster id
             while sched.valid():
-                bx = sched.m_idx[0] * cluster_size + cta_rank
-                by = sched.n_idx[0]
+                bx = sched.m_idx * cluster_size + cta_rank
+                by = sched.n_idx
                 # ... compute tile (bx, by) ...
                 sched.next_tile()
 
@@ -163,7 +191,7 @@ class PersistentTileScheduler(BaseTileScheduler):
     scheduler is only a tile-coordinate decoder::
 
         sched = T.PersistentTileScheduler(
-            "sched", m_blocks, n_blocks, swizzle_size=8, stateful=False)
+            m_blocks, n_blocks, swizzle_size=8, stateful=False)
         for w in range(waves):
             bx, by = sched.coord(num_workers * w + worker_id)
             if bx * block_M < M and by * block_N < N:
@@ -172,26 +200,26 @@ class PersistentTileScheduler(BaseTileScheduler):
 
     Manual warp-specialized kernels use ``current_iter`` as the single iteration clock
     (no separate ``for w`` loop): each warp role runs its own
-    ``while sched.valid()`` loop and reads ``sched.current_iter[0]`` for
-    pipeline/double-buffer state (``sched.current_iter[0] & 1`` etc.) while reading
-    ``sched.m_idx[0]`` / ``sched.n_idx[0]`` for the tile::
+    ``while sched.valid()`` loop and reads ``sched.current_iter`` for
+    pipeline/double-buffer state (``sched.current_iter & 1`` etc.) while reading
+    ``sched.m_idx`` / ``sched.n_idx`` for the tile::
 
         sched.init(block_id)
         while sched.valid():
-            bx, by = sched.m_idx[0], sched.n_idx[0]
-            # ... use sched.current_iter[0] for barrier phase / double-buffering ...
+            bx, by = sched.m_idx, sched.n_idx
+            # ... use sched.current_iter for barrier phase / double-buffering ...
             sched.next_tile()
 
     Notes
     -----
-    State is held in single-element ``T.alloc_var`` buffers, so read with
-    ``sched.m_idx[0]`` / ``sched.current_iter[0]`` and (inside methods) write with
-    ``self.x[0] = ...``; the ``[0]`` is required for the write to lower to a
-    ``BufferStore``."""
+    State is held in single-element ``T.alloc_var`` buffers behind read-only
+    properties: ``sched.m_idx`` / ``sched.current_iter`` etc. return the scalar
+    ``PrimExpr`` directly (no ``[0]``). Only scheduler methods mutate state, via
+    ``self._x[0] = ...`` on the underlying buffers; the ``[0]`` is required
+    there for the write to lower to a ``BufferStore``."""
 
     def __init__(
         self,
-        prefix: str,
         num_m_tiles,
         num_n_tiles,
         num_workers=None,
@@ -199,8 +227,9 @@ class PersistentTileScheduler(BaseTileScheduler):
         column_major: bool = True,
         cluster_size: int = 1,
         stateful: bool = True,
+        name: str | None = None,
     ):
-        super().__init__(prefix, stateful=stateful)
+        super().__init__(stateful=stateful, name=name)
         self.cluster_size = cluster_size
         if num_workers is None:
             num_workers = driver.get_num_sms() // cluster_size
@@ -247,15 +276,15 @@ class PersistentTileScheduler(BaseTileScheduler):
 
     def update_current_idx(self, linear_idx):
         m, n = self.coord(linear_idx)
-        self.m_idx[0] = m
-        self.n_idx[0] = n
+        self._m_idx[0] = m
+        self._n_idx[0] = n
 
     def init(self, worker_id):
-        self.current_iter[0] = 0
-        self.linear_idx[0] = worker_id
-        self.update_current_idx(self.linear_idx[0])
+        self._current_iter[0] = 0
+        self._linear_idx[0] = worker_id
+        self.update_current_idx(self._linear_idx[0])
 
     def next_tile(self):
-        self.current_iter[0] = self.current_iter[0] + 1
-        self.linear_idx[0] = self.linear_idx[0] + self.num_workers
-        self.update_current_idx(self.linear_idx[0])
+        self._current_iter[0] = self._current_iter[0] + 1
+        self._linear_idx[0] = self._linear_idx[0] + self.num_workers
+        self.update_current_idx(self._linear_idx[0])


### PR DESCRIPTION
## Summary

- Expose tile scheduler state as scalar read-only properties so kernels can use `sched.m_idx`, `sched.n_idx`, and `sched.current_iter` directly.
- Make scheduler state buffer naming optional through `name=...`, keeping generated IR readable when requested.
- Update the SM100 persistent GEMM examples to the new scheduler state access style.

## Changes

- Store scheduler state buffers on underscored fields and expose scalar property accessors for `m_idx`, `n_idx`, `linear_idx`, and `current_iter`.
- Update `meta_class` buffer naming to bind an optional `name` constructor argument and strip leading underscores from state buffer names.
- Remove the required positional scheduler name from `PersistentTileScheduler`; callers can still pass `name="sched"` for explicit IR names.
- Add language tests for scalar state access and stateless `coord` decoding.

## Validation

- `./format.sh`
- `python -m pytest testing/python/language/test_tilelang_language_tile_schedule.py -q`
- `python -m pytest testing/python/language/test_tilelang_language_frontend_v2.py -q`
- Imported the changed SM100 example modules with Python.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary
- Exposed persistent tile scheduler state as read-only scalar properties (`sched.m_idx`, `sched.n_idx`, `sched.current_iter`) instead of indexed buffer access.
- Made scheduler state buffer naming optional via `name=...`, improving generated IR names when provided.
- Updated `PersistentTileScheduler` to drop the required positional scheduler name while preserving explicit naming support.
- Revised SM100 persistent GEMM examples to use the new scalar scheduler state access style.
- Added language tests covering scalar state access and stateless `coord()` decoding.

### Tests
- Added new Python language tests for scheduler scalar state access and stateless coordinate behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->