### PR TITLE
[BugFix] Avoid unsafe MergeIfStmt across condition writes

### DIFF
--- a/src/transform/merge_if_stmt.cc
+++ b/src/transform/merge_if_stmt.cc
@@ -6,6 +6,8 @@
 #include "merge_if_stmt.h"
 #include "support/check.h"
 
+#include <unordered_set>
+
 #include <tvm/tirx/analysis.h>
 #include <tvm/tirx/builtin.h>
 #include <tvm/tirx/op.h>
@@ -19,6 +21,84 @@ namespace tl {
 
 using namespace tirx;
 using namespace ffi;
+
+using BufferDataVarSet = std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual>;
+
+struct BufferAccesses {
+  BufferDataVarSet reads;
+  BufferDataVarSet writes;
+};
+
+class BufferAccessCollector : public StmtExprVisitor {
+public:
+  static BufferAccesses Collect(const Array<Stmt> &statements) {
+    BufferAccesses accesses;
+    BufferAccessCollector collector(&accesses);
+    for (const Stmt &stmt : statements) {
+      collector(stmt);
+    }
+    return accesses;
+  }
+
+  static BufferAccesses Collect(const PrimExpr &expr) {
+    BufferAccesses accesses;
+    BufferAccessCollector collector(&accesses);
+    collector(expr);
+    return accesses;
+  }
+
+private:
+  static constexpr int kReadAccessMask = 1;
+  static constexpr int kWriteAccessMask = 2;
+
+  explicit BufferAccessCollector(BufferAccesses *accesses)
+      : accesses_(accesses) {}
+
+  void AddAccess(const Var &data, const PrimExpr &mask) {
+    const auto *flag = mask.as<IntImmNode>();
+    if (!flag || (flag->value & kReadAccessMask) != 0) {
+      accesses_->reads.insert(data);
+    }
+    if (!flag || (flag->value & kWriteAccessMask) != 0) {
+      accesses_->writes.insert(data);
+    }
+  }
+
+  void VisitStmt_(const BufferStoreNode *op) final {
+    accesses_->writes.insert(op->buffer->data);
+    StmtExprVisitor::VisitStmt_(op);
+  }
+
+  void VisitExpr_(const BufferLoadNode *op) final {
+    accesses_->reads.insert(op->buffer->data);
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
+  void VisitExpr_(const CallNode *op) final {
+    if (op->op.same_as(builtin::tvm_access_ptr())) {
+      ICHECK_EQ(op->args.size(), 5U);
+      const auto *data = op->args[1].as<VarNode>();
+      ICHECK(data) << "tvm_access_ptr data argument must be a Var";
+      AddAccess(GetRef<Var>(data), op->args[4]);
+    } else if (op->op.same_as(tl::access_ptr())) {
+      ICHECK_EQ(op->args.size(), 3U);
+      const auto *load = op->args[0].as<BufferLoadNode>();
+      ICHECK(load) << "tl.access_ptr base must be a BufferLoad";
+      AddAccess(load->buffer->data, op->args[2]);
+    } else if (op->op.same_as(builtin::address_of())) {
+      ICHECK_EQ(op->args.size(), 1U);
+      const auto *load = op->args[0].as<BufferLoadNode>();
+      ICHECK(load) << "address_of argument must be a BufferLoad";
+      // Without an access mask, conservatively assume the pointer may be read
+      // or written by its enclosing call.
+      accesses_->reads.insert(load->buffer->data);
+      accesses_->writes.insert(load->buffer->data);
+    }
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
+  BufferAccesses *accesses_;
+};
 
 class MergeIfStmtRewriter : public StmtExprMutator {
 public:
@@ -45,6 +125,23 @@ private:
     }
   }
 
+  bool BodyWritesConditionBuffer(const PrimExpr &condition,
+                                 const Array<Stmt> &prior_bodies) {
+    BufferAccesses body_accesses = BufferAccessCollector::Collect(prior_bodies);
+    if (body_accesses.writes.empty()) {
+      return false;
+    }
+
+    BufferAccesses condition_accesses =
+        BufferAccessCollector::Collect(condition);
+    for (const Var &read : condition_accesses.reads) {
+      if (body_accesses.writes.count(read)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   Stmt VisitStmt_(const SeqStmtNode *op) final {
     // First, recursively flatten nested SeqStmt so that
     //   SeqStmt{ if, SeqStmt{ if, SeqStmt{ if } } }
@@ -65,7 +162,9 @@ private:
       if (const auto *if_node = stmt.as<IfThenElseNode>()) {
         if (!if_node->else_case.defined()) {
           if (current_condition.defined() &&
-              ExprDeepEqual()(current_condition, if_node->condition)) {
+              ExprDeepEqual()(current_condition, if_node->condition) &&
+              !BodyWritesConditionBuffer(current_condition,
+                                         current_if_bodies)) {
             current_if_bodies.push_back(if_node->then_case);
             continue;
           } else {

--- a/testing/python/issue/test_tilelang_issue_merge_if.py
+++ b/testing/python/issue/test_tilelang_issue_merge_if.py
@@ -1,8 +1,46 @@
 import tilelang
 from tilelang import tvm as tvm
 from tvm.ir import IRModule
+from tvm.tirx.stmt_functor import post_order_visit
 import tilelang.testing
 import tilelang.language as T
+
+
+def collect_nodes(stmt, node_type):
+    nodes = []
+
+    def visit(node):
+        if isinstance(node, node_type):
+            nodes.append(node)
+
+    post_order_visit(stmt, visit)
+    return nodes
+
+
+def count_if_then_else(stmt):
+    return len(collect_nodes(stmt, tvm.tirx.IfThenElse))
+
+
+def count_calls_to(stmt, op_name):
+    return sum(
+        isinstance(node, tvm.tirx.Call) and isinstance(node.op, tvm.ir.Op) and node.op.name == op_name
+        for node in collect_nodes(stmt, tvm.tirx.Call)
+    )
+
+
+def apply_merge_if(func, lower_access_ptr=False):
+    module = IRModule.from_expr(func)
+    if lower_access_ptr:
+        module = tilelang.transform.LowerAccessPtr()(module)
+    before_merge = module
+    after_merge = tilelang.transform.MergeIfStmt()(module)
+    return before_merge["main"], after_merge["main"]
+
+
+def assert_merge_if_unchanged(func, lower_access_ptr=False):
+    before_merge, after_merge = apply_merge_if(func, lower_access_ptr)
+    tvm.ir.assert_structural_equal(before_merge, after_merge, True)
+    assert count_if_then_else(after_merge.body) == 2
 
 
 def merge_if_test():
@@ -24,11 +62,172 @@ def merge_if_test():
     return main
 
 
+def merge_if_written_buffer_test():
+    """Test: second if's condition reads buffer written in first if's body.
+
+    Should NOT merge because the second if's condition (A[0] == 0) reads A,
+    which the first if's body writes to (A[0] = 7). Merging would incorrectly
+    reuse the first condition and skip re-evaluating the second one.
+    """
+
+    @T.prim_func
+    def main():
+        A = T.alloc_fragment((1,), T.int32)
+        Out = T.alloc_fragment((1,), T.int32)
+        if A[0] == 0:
+            A[0] = 7
+        if A[0] == 0:
+            Out[0] = 20
+
+    return main
+
+
+def merge_if_safe_test():
+    """Test: same condition, body writes a different buffer (safe to merge).
+
+    Both ifs share condition A[0] == 0, which reads buffer A.
+    Neither body writes to A (they write to Out), so the condition cannot be
+    invalidated. The pass should merge these into a single if.
+    """
+
+    @T.prim_func
+    def main():
+        A = T.alloc_fragment((2,), T.int32)
+        Out = T.alloc_fragment((2,), T.int32)
+        if A[0] == 0:
+            Out[0] = 1
+        if A[0] == 0:
+            Out[1] = 2
+
+    return main
+
+
+def merge_if_atomic_write_test():
+    """An atomic write to the condition buffer must prevent merging."""
+
+    @T.prim_func
+    def main():
+        condition_buffer = T.alloc_fragment((1,), T.int32)
+        output = T.alloc_fragment((1,), T.int32)
+        if condition_buffer[0] == 0:
+            T.atomic_store(condition_buffer[0], 7)
+        if condition_buffer[0] == 0:
+            output[0] = 20
+
+    return main
+
+
+def merge_if_atomic_read_condition_test():
+    """A call-based condition read must observe writes from prior bodies."""
+
+    @T.prim_func
+    def main():
+        condition_buffer = T.alloc_fragment((1,), T.int32)
+        output = T.alloc_fragment((1,), T.int32)
+        if T.atomic_load(condition_buffer[0]) == 0:
+            condition_buffer[0] = 7
+        if T.atomic_load(condition_buffer[0]) == 0:
+            output[0] = 20
+
+    return main
+
+
+def merge_if_safe_atomic_write_test():
+    """An atomic write to an unrelated buffer must remain mergeable."""
+
+    @T.prim_func
+    def main():
+        condition_buffer = T.alloc_fragment((1,), T.int32)
+        output = T.alloc_fragment((2,), T.int32)
+        if condition_buffer[0] == 0:
+            T.atomic_store(output[0], 1)
+        if condition_buffer[0] == 0:
+            output[1] = 2
+
+    return main
+
+
+def merge_if_address_of_write_test():
+    """An opaque pointer call may invalidate a buffer-backed condition."""
+
+    @T.prim_func
+    def main():
+        condition_buffer = T.alloc_fragment((1,), T.int32)
+        output = T.alloc_fragment((1,), T.int32)
+        if condition_buffer[0] == 0:
+            T.evaluate(
+                T.call_extern(
+                    "handle",
+                    "custom_ptr_store",
+                    T.address_of(condition_buffer[0]),
+                )
+            )
+        if condition_buffer[0] == 0:
+            output[0] = 20
+
+    return main
+
+
 def test_merge_if():
     func = merge_if_test()
     original_module = IRModule.from_expr(func)
     transformed = tilelang.transform.MergeIfStmt()(original_module)
     tvm.ir.assert_structural_equal(original_module["main"], transformed["main"], True)
+
+
+def test_merge_if_written_buffer():
+    """Regression test for #2538: if conditions must not be invalidated by prior body writes.
+
+    When two ifs share the same condition and the second's condition reads a buffer
+    that the first's body writes to, the pass must NOT merge them.
+    """
+    func = merge_if_written_buffer_test()
+    original_module = IRModule.from_expr(func)
+    transformed = tilelang.transform.MergeIfStmt()(original_module)
+    tvm.ir.assert_structural_equal(original_module["main"], transformed["main"], True)
+    assert count_if_then_else(transformed["main"].body) == 2
+
+
+def test_merge_if_safe():
+    """Test that safe cases (same condition, body writes different buffer) are merged."""
+    func = merge_if_safe_test()
+    original_module = IRModule.from_expr(func)
+    transformed = tilelang.transform.MergeIfStmt()(original_module)
+    assert count_if_then_else(original_module["main"].body) == 2
+    assert count_if_then_else(transformed["main"].body) == 1
+    merged_if = collect_nodes(transformed["main"].body, tvm.tirx.IfThenElse)[0]
+    assert len(collect_nodes(merged_if.then_case, tvm.tirx.BufferStore)) == 2
+
+
+def test_merge_if_atomic_write():
+    """Cover tl.access_ptr and its lowered tvm_access_ptr representation."""
+    func = merge_if_atomic_write_test()
+    assert_merge_if_unchanged(func)
+    assert_merge_if_unchanged(func, lower_access_ptr=True)
+
+
+def test_merge_if_atomic_read_condition():
+    """The condition read remains visible after LowerAccessPtr."""
+    func = merge_if_atomic_read_condition_test()
+    assert_merge_if_unchanged(func)
+    assert_merge_if_unchanged(func, lower_access_ptr=True)
+
+
+def test_merge_if_safe_atomic_write():
+    """Pointer-based writes to another buffer should not block merging."""
+    func = merge_if_safe_atomic_write_test()
+    for lower_access_ptr in (False, True):
+        before_merge, after_merge = apply_merge_if(func, lower_access_ptr)
+        assert count_if_then_else(before_merge.body) == 2
+        assert count_if_then_else(after_merge.body) == 1
+        merged_if = collect_nodes(after_merge.body, tvm.tirx.IfThenElse)[0]
+        assert count_calls_to(merged_if.then_case, "tl.atomic_store_elem_op") == 1
+        assert len(collect_nodes(merged_if.then_case, tvm.tirx.BufferStore)) == 1
+
+
+def test_merge_if_address_of_write():
+    """Opaque address_of calls conservatively block invalidating merges."""
+    assert_merge_if_unchanged(merge_if_address_of_write_test())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`MergeIfStmt` merges consecutive `if` statements without `else` when their conditions are structurally equal. This is unsafe when an earlier `if` body writes storage read by a later condition, because the later condition must be re-evaluated after that write.

## Example

```python
if A[0] == 0:
    A[0] = 7
if A[0] == 0:
    Out[0] = 20
```

Before this fix, the pass could rewrite these statements into a single merged if, reusing the first evaluation of `A[0] == 0`. After the first body sets `A[0] = 7`, the second condition no longer holds, so reusing the stale condition changes program behavior.

## Root cause

The merge check only compared condition structure:

```cpp
ExprDeepEqual()(current_condition, if_node->condition)
```

Structural equality is necessary for this rewrite, but it is not sufficient. Even structurally identical expressions may evaluate differently if an earlier pending body modifies a buffer read by the condition.

The previous dependency check also only considered explicit `BufferStore` and `BufferLoad` nodes. Some TileLang operations encode memory accesses through calls such as `tl.access_ptr`, which may later be lowered to `tvm_access_ptr`. After lowering, the original `BufferLoad` is represented by a buffer data Var, offset, extent, and read/write mask, so a scan limited to `BufferLoad` nodes can miss the access.

## Fix

Add a conservative buffer-level dependency guard before merging same-condition if statements:

* collect buffer data vars written by pending if bodies;
* collect buffer data vars read by the shared condition;
* skip the merge when the two sets overlap.

Use a shared visitor for body and condition analysis. It recognizes:

  * explicit `BufferStore` writes;
  * explicit `BufferLoad` reads;
  * call-based memory accesses (e.g., atomic operations, represented as `tl.access_ptr` op before lowering);
  * lowered `tvm_access_ptr` calls;
  * `address_of` passed through opaque calls.

For `tl.access_ptr` and `tvm_access_ptr`, the visitor uses the read/write mask (`1 = read`, `2 = write`, `3 = read/write`). A non-constant mask is conservatively treated as both read and write. Since `address_of` has no access mask, it is also conservatively treated as potentially read and written by its enclosing call.

Buffer data vars are tracked by TVM object identity, so accesses through buffers that share the same underlying data var are treated as accesses to the same storage.

## Scope

The dependency check is intentionally buffer-level rather than index-level. If a pending body writes the same underlying buffer that the condition reads, the pass skips the merge even when the accessed indices may be disjoint.

This keeps the rewrite safe without adding alias or index-range analysis to `MergeIfStmt`. A follow-up may make the optimization less conservative by proving simple disjoint-index cases.

## Tested

Added IR regression coverage in `testing/python/issue/test_tilelang_issue_merge_if.py` for:

* an explicit write to the condition buffer remaining unmerged;
* a safe explicit write to another buffer still merging and preserving both stores;
* an atomic write to the condition buffer remaining unmerged;
* an atomic read in the condition observing an earlier explicit write;
* an atomic write to an unrelated buffer still merging and preserving both bodies;
* an opaque `address_of` call conservatively preventing the merge.

The atomic read/write cases are checked both before and after `LowerAccessPtr`, covering the frontend `tl.access_ptr` and lowered `tvm_access_ptr` representations.

Local verification:

* 7 passed in `testing/python/issue/test_tilelang_issue_merge_if.py`;
* all relevant pre-commit hooks passed.

Verified locally on a TITAN RTX (SM75).

Fixes #2538
