### PR TITLE
[Refactor] Extract shared Int64Promoter into common header

### DIFF
--- a/src/transform/common/int64_promoter.h
+++ b/src/transform/common/int64_promoter.h
@@ -1,0 +1,61 @@
+/*!
+ * \file int64_promoter.h
+ * \brief Helper rewriter that promotes sub-64-bit integer expressions to int64.
+ */
+#ifndef TVM_TL_TRANSFORM_COMMON_INT64_PROMOTER_H_
+#define TVM_TL_TRANSFORM_COMMON_INT64_PROMOTER_H_
+
+#include <tvm/ir/cast.h>
+#include <tvm/tirx/op.h>
+#include <tvm/tirx/stmt.h>
+
+#include "../../../3rdparty/tvm/src/tirx/ir/data_type_rewriter.h"
+
+namespace tvm {
+namespace tl {
+
+/*!
+ * \brief Promote integer variables, immediates, and casts to int64.
+ *
+ * Used by passes that need to widen index expressions to avoid overflow.
+ */
+class Int64Promoter : public tirx::IndexDataTypeRewriter {
+public:
+  using Parent = tirx::IndexDataTypeRewriter;
+
+  PrimExpr VisitExpr_(const tirx::VarNode *op) final {
+    if (op->dtype.is_int() && op->dtype.bits() < 64) {
+      return tvm::cast(DataType::Int(64), ffi::GetRef<tirx::Var>(op));
+    }
+    return ffi::GetRef<PrimExpr>(op);
+  }
+
+  PrimExpr VisitExpr_(const tirx::IntImmNode *op) final {
+    if (op->dtype.is_int() && op->dtype.bits() < 64) {
+      return IntImm(DataType::Int(64), op->value);
+    }
+    return ffi::GetRef<PrimExpr>(op);
+  }
+
+  PrimExpr VisitExpr_(const tirx::CastNode *op) final {
+    if (op->dtype.is_int() && op->dtype.bits() < 64) {
+      return tvm::cast(DataType::Int(64), op->value);
+    }
+    return ffi::GetRef<PrimExpr>(op);
+  }
+
+  tirx::Stmt VisitStmt_(const tirx::BufferStoreNode *op) final {
+    auto node = Downcast<tirx::BufferStore>(Parent::VisitStmt_(op));
+    return std::move(node);
+  }
+
+  PrimExpr VisitExpr_(const tirx::BufferLoadNode *op) final {
+    auto node = Downcast<tirx::BufferLoad>(Parent::VisitExpr_(op));
+    return std::move(node);
+  }
+};
+
+} // namespace tl
+} // namespace tvm
+
+#endif // TVM_TL_TRANSFORM_COMMON_INT64_PROMOTER_H_

--- a/src/transform/config_index_bitwidth.cc
+++ b/src/transform/config_index_bitwidth.cc
@@ -1,6 +1,7 @@
 #include "../../3rdparty/tvm/src/tirx/ir/data_type_rewriter.h"
 #include "../op/builtin.h"
 #include "arith/ir_mutator_with_analyzer.h"
+#include "common/int64_promoter.h"
 #include "support/check.h"
 #include "tir/transforms/ir_utils.h"
 #include <tvm/ir/cast.h>
@@ -83,43 +84,6 @@ public:
 
 private:
   explicit IndexLegalizer(arith::Analyzer *ana) : IRMutatorWithAnalyzer(ana) {}
-
-  class Int64Promoter : public IndexDataTypeRewriter {
-  public:
-    using Parent = IndexDataTypeRewriter;
-
-    PrimExpr VisitExpr_(const VarNode *op) final {
-      if (op->dtype.is_int() && op->dtype.bits() < 64) {
-        return cast(DataType::Int(64), GetRef<Var>(op));
-      }
-      return GetRef<PrimExpr>(op);
-    }
-
-    PrimExpr VisitExpr_(const IntImmNode *op) final {
-      if (op->dtype.is_int() && op->dtype.bits() < 64) {
-        return IntImm(DataType::Int(64), op->value);
-      }
-      return GetRef<PrimExpr>(op);
-    }
-
-    PrimExpr VisitExpr_(const CastNode *op) final {
-      if (op->dtype.is_int() && op->dtype.bits() < 64) {
-        return cast(DataType::Int(64), op->value);
-      }
-      return GetRef<PrimExpr>(op);
-    }
-
-    Stmt VisitStmt_(const BufferStoreNode *op) final {
-      // Force indices to be int64
-      auto node = Downcast<BufferStore>(Parent::VisitStmt_(op));
-      return std::move(node);
-    }
-
-    PrimExpr VisitExpr_(const BufferLoadNode *op) final {
-      auto node = Downcast<BufferLoad>(Parent::VisitExpr_(op));
-      return std::move(node);
-    }
-  };
 
   Stmt VisitStmt_(const BufferStoreNode *op) final {
     auto buffer_store =

--- a/src/transform/flatten_buffer.cc
+++ b/src/transform/flatten_buffer.cc
@@ -23,6 +23,7 @@
 
 #include "../../3rdparty/tvm/src/tirx/ir/data_type_rewriter.h"
 #include "arith/ir_mutator_with_analyzer.h"
+#include "common/int64_promoter.h"
 #include "support/check.h"
 #include "tir/transforms/ir_utils.h"
 #include <tvm/arith/iter_affine_map.h>
@@ -71,43 +72,6 @@ private:
   using IRMutatorWithAnalyzer::VisitExpr_;
   using IRMutatorWithAnalyzer::VisitStmt;
   using IRMutatorWithAnalyzer::VisitStmt_;
-
-  class Int64Promoter : public tirx::IndexDataTypeRewriter {
-  public:
-    using Parent = IndexDataTypeRewriter;
-
-    PrimExpr VisitExpr_(const VarNode *op) final {
-      if (op->dtype.is_int() && op->dtype.bits() < 64) {
-        return cast(DataType::Int(64), GetRef<Var>(op));
-      }
-      return GetRef<PrimExpr>(op);
-    }
-
-    PrimExpr VisitExpr_(const IntImmNode *op) final {
-      if (op->dtype.is_int() && op->dtype.bits() < 64) {
-        return IntImm(DataType::Int(64), op->value);
-      }
-      return GetRef<PrimExpr>(op);
-    }
-
-    PrimExpr VisitExpr_(const CastNode *op) final {
-      if (op->dtype.is_int() && op->dtype.bits() < 64) {
-        return cast(DataType::Int(64), op->value);
-      }
-      return GetRef<PrimExpr>(op);
-    }
-
-    Stmt VisitStmt_(const BufferStoreNode *op) final {
-      // Force indices to be int64
-      auto node = Downcast<BufferStore>(Parent::VisitStmt_(op));
-      return std::move(node);
-    }
-
-    PrimExpr VisitExpr_(const BufferLoadNode *op) final {
-      auto node = Downcast<BufferLoad>(Parent::VisitExpr_(op));
-      return std::move(node);
-    }
-  };
 
   explicit BufferFlattener(arith::Analyzer *ana) : IRMutatorWithAnalyzer(ana) {}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary
- Extracted `Int64Promoter` into a shared header at `src/transform/common/int64_promoter.h`.
- Updated `config_index_bitwidth.cc` and `flatten_buffer.cc` to include and use the साझा promoter instead of local implementations.
- In `config_index_bitwidth.cc`, index legalization now promotes narrower integer indices to `int64` only when analyzer bounds indicate the original type may overflow.

## C++ style / lint notes
- This PR touches C++ code, but not the documented rules in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step may report warnings for the newly exposed `tvm::tl::Int64Promoter`, but any such findings are advisory unless they indicate a clear API/FFI/maintainability risk.
- No blocking build or test issues are indicated by the summary; any style-related warnings should be treated separately from correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->