### PR TITLE
[BugFix] Preserve guard identity in LoopUnswitching

### DIFF
--- a/src/transform/loop_unswitching.cc
+++ b/src/transform/loop_unswitching.cc
@@ -15,7 +15,6 @@
  */
 
 #include "support/check.h"
-#include <tvm/ffi/extra/structural_equal.h>
 #include <tvm/tirx/analysis.h>
 #include <tvm/tirx/builtin.h>
 #include <tvm/tirx/stmt.h>
@@ -169,7 +168,7 @@ public:
   void VisitStmt_(const IfThenElseNode *op) final {
     // Skip the interior of any if statement with matching condition
     if (excluded_condition.defined() &&
-        StructuralEqual()(op->condition, excluded_condition)) {
+        ExprDeepEqual()(op->condition, excluded_condition)) {
       return;
     }
     StmtExprVisitor::VisitStmt_(op);
@@ -415,8 +414,8 @@ public:
   }
 
   Stmt VisitStmt_(const IfThenElseNode *op) final {
-    // Replace if the condition is structurally equal to the hoisted condition
-    if (StructuralEqual()(op->condition, hoisted_condition)) {
+    // Replace if the condition matches the hoisted condition.
+    if (ExprDeepEqual()(op->condition, hoisted_condition)) {
       if (take_then) {
         return VisitStmt(op->then_case);
       } else {

--- a/testing/python/transform/test_tilelang_transform_loop_unswitching.py
+++ b/testing/python/transform/test_tilelang_transform_loop_unswitching.py
@@ -326,6 +326,99 @@ def test_multiple_identical_conditions():
     _check(before, expected)
 
 
+def test_same_buffer_rebuilt_load_conditions_are_replaced():
+    """Repeated loads from the same buffer/index are the same guard."""
+
+    @T.prim_func
+    def before(
+        A: T.Tensor((128,), T.float32),
+        B: T.Tensor((128,), T.float32),
+        C: T.Tensor((128,), T.float32),
+        P: T.Tensor((1,), T.int32),
+    ):
+        for i in range(128):
+            if P[0] < 4:
+                B[i] = A[i]
+            if P[0] < 4:
+                C[i] = A[i] * T.float32(2.0)
+
+    @T.prim_func
+    def expected(
+        A: T.Tensor((128,), T.float32),
+        B: T.Tensor((128,), T.float32),
+        C: T.Tensor((128,), T.float32),
+        P: T.Tensor((1,), T.int32),
+    ):
+        if P[0] < 4:
+            for i in range(128):
+                B[i] = A[i]
+                C[i] = A[i] * T.float32(2.0)
+        else:
+            for _i in range(128):
+                T.evaluate(0)
+                T.evaluate(0)
+
+    _check(before, expected)
+
+
+def test_same_shape_different_buffer_conditions_are_not_collapsed():
+    """Structurally similar guards on different buffers are distinct."""
+
+    @T.prim_func
+    def before(
+        A: T.Tensor((128,), T.float32),
+        B: T.Tensor((128,), T.float32),
+        C: T.Tensor((128,), T.float32),
+        P: T.Tensor((1,), T.int32),
+        Q: T.Tensor((1,), T.int32),
+    ):
+        for i in range(128):
+            if P[0] < 4:
+                B[i] = A[i]
+            if Q[0] < 4:
+                C[i] = A[i] * T.float32(2.0)
+
+    _check(before, before)
+
+
+def test_same_buffer_different_index_conditions_are_not_collapsed():
+    """Guards on the same buffer but different indices are distinct."""
+
+    @T.prim_func
+    def before(
+        A: T.Tensor((128,), T.float32),
+        B: T.Tensor((128,), T.float32),
+        C: T.Tensor((128,), T.float32),
+        P: T.Tensor((2,), T.int32),
+    ):
+        for i in range(128):
+            if P[0] < 4:
+                B[i] = A[i]
+            if P[1] < 4:
+                C[i] = A[i] * T.float32(2.0)
+
+    _check(before, before)
+
+
+def test_call_checker_does_not_exclude_different_buffer_guard():
+    """Calls under a sibling guard on another buffer still block unswitching."""
+
+    @T.prim_func
+    def before(
+        A: T.Tensor((128,), T.float32),
+        B: T.Tensor((128,), T.float32),
+        P: T.Tensor((1,), T.int32),
+        Q: T.Tensor((1,), T.int32),
+    ):
+        for i in range(128):
+            if P[0] < 4:
+                B[i] = A[i]
+            if Q[0] < 4:
+                T.evaluate(T.call_extern("handle", "generic_op"))
+
+    _check(before, before)
+
+
 def test_multiple_identical_conditions_with_else():
     """Conservative: multiple if-else statements should NOT be hoisted."""
 


### PR DESCRIPTION
## Issue

https://github.com/tile-ai/tilelang/issues/2539

## Summary

LoopUnswitching treated sibling guards as the same predicate when their
conditions were structurally equal. This is unsafe when two conditions have the
same arithmetic shape but read from different buffers, because the guards are
not the same runtime predicate.

## Example

```python
for k in T.serial(K):
    if P[bx] < 2:
        OA[bx] = 1
    if Q[bx] < 2:
        OB[bx] = 1
```

Before this fix, LoopUnswitching could collapse the `Q[bx] < 2` guard into the
hoisted `P[bx] < 2` guard because the two `BufferLoad < const` expressions are
structurally similar. As a result, `OB` followed `P` instead of `Q`. Disabling
only LoopUnswitching restored the correct behavior, isolating the issue to this
pass.

## Root cause

The pass used structural equality directly when deciding whether an `if` matched
the hoisted condition:

```cpp
StructuralEqual()(op->condition, hoisted_condition)
```

The same structural check was also used in `CallCheckerExcludingIf` when
excluding calls inside ifs that match the candidate condition.

Structural equality is useful for proving that two expressions have the same
shape, but it does not prove that they read the same runtime values. In
particular, structurally similar `BufferLoad` expressions over `P` and `Q` can
match even though the underlying buffer data Vars are distinct.

## Fix

Use the existing `ExprDeepEqual` predicate for LoopUnswitching condition matches
instead of the looser structural equality predicate:

- update `CallCheckerExcludingIf` so calls are excluded only under truly matching
  guards;
- update `IfBranchReplacer` so only matching guards are collapsed after the
  condition is hoisted;
- keep the same predicate in both analysis and rewrite paths.

This keeps the pass aligned with other TileLang transforms such as
`MergeIfStmt`, which already uses `ExprDeepEqual` for same-condition matching,
and avoids adding a custom equality helper for this pass.

## Tested

Added regression coverage in
`testing/python/transform/test_tilelang_transform_loop_unswitching.py`:

- same-buffer rebuilt load conditions still collapse;
- same-shape guards on different buffers are not collapsed;
- same-buffer different-index guards are not collapsed;
- `CallCheckerExcludingIf` does not exclude calls under a different-buffer guard.


Also verified the CUDA repro from
https://github.com/tile-ai/tilelang/issues/2539 locally on an NVIDIA H200:

```text
expected (OB follows Q<2): [1, 0, 1, 0]
default build            : [1, 0, 1, 0]
bypass  build            : [1, 0, 1, 0]
```

Fixes https://github.com/tile-ai/tilelang/issues/2539

## Summary

Replaced LoopUnswitching's direct `StructuralEqual` condition matches with
`ExprDeepEqual`, so same-shape guards over different buffers are no longer
treated as the same predicate.

Kept the existing same-buffer optimization intact for conditions that still
compare equal under `ExprDeepEqual`.

Used the same predicate in both `CallCheckerExcludingIf` and `IfBranchReplacer`,
so analysis and rewrite decisions stay consistent.

## C++ style / lint notes

This PR touches TileLang-owned C++ transform code under `src/transform` and keeps
the change narrowly focused on behavior rather than broad style cleanup.

The implementation follows the nearby TileLang transform pattern by reusing
`ExprDeepEqual` instead of adding a new pass-local equality abstraction.

The C++ code was checked with the repository pre-commit hooks, including
`clang-format`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed `LoopUnswitching` predicate matching to be identity-sensitive: structurally similar guards over different buffers now remain distinct, while truly identical conditions (including same-buffer rebuilt loads) can still be merged.
- Applied the identity-sensitive condition equivalence consistently to both call exclusion (`CallCheckerExcludingIf`) and branch replacement (`IfBranchReplacer`).
- Added regression tests covering:
  - different buffers collapsing incorrectly (now prevented),
  - same-buffer rebuilt loads being safely replaced/hoisted,
  - different indices preventing collapsing,
  - call-exclusion behavior when guards differ by buffer.
- Verified CUDA output behavior via the new regression coverage.

## C++ style / lint notes

- The PR updates C++ implementation code (`src/transform/loop_unswitching.cc`) and adds Python regression tests, but does not modify documented C++ style rules in `docs/developer_guide/cpp_style.md`.
- No CI/lint configuration changes are indicated; the **C++ API Style Audit (warning only)** step should remain relevant. Any TLCPP003/TLCPP004 findings would be advisory unless this PR introduces an API/FFI/maintainability risk (none indicated by the changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->