### PR TITLE
 [BugFix] Mark bare data vars passed to call_extern as written

### DIFF
--- a/src/transform/annotate_read_only_params.cc
+++ b/src/transform/annotate_read_only_params.cc
@@ -82,6 +82,13 @@ public:
       //   tl.tma_store(address_of(smem[..]), address_of(gmem[..]), ...)
       //   call_extern("AtomicAdd*", address_of(gmem[..]), ...)
       // and avoids over-marking plain BufferLoad used for reads.
+      //
+      // For call_extern specifically, also conservatively mark bare buffer data
+      // vars as written, since we cannot know whether the extern writes through
+      // the pointer. This matches patterns like:
+      //   call_extern("store_val", Out.data, value)
+      const bool is_call_extern = op->op.same_as(builtin::call_extern());
+
       for (const PrimExpr &a : op->args) {
         if (const auto *c = a.as<CallNode>()) {
           if (c->op.same_as(builtin::address_of()) && c->args.size() == 1U) {
@@ -90,6 +97,15 @@ public:
               if (param_or_data_vars_.count(data)) {
                 written_.insert(data);
               }
+            }
+          }
+        } else if (is_call_extern) {
+          // Bare data var passed to call_extern: conservatively assume
+          // the callee may write through it. We only apply this to call_extern,
+          // not to pure intrinsics or other calls with known semantics.
+          if (const auto *v = a.as<VarNode>()) {
+            if (param_or_data_vars_.count(v)) {
+              written_.insert(v);
             }
           }
         }

--- a/testing/python/transform/test_tilelang_transform_annotate_readonly_params.py
+++ b/testing/python/transform/test_tilelang_transform_annotate_readonly_params.py
@@ -1,0 +1,53 @@
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tvm import IRModule
+
+
+def test_annotate_readonly_bare_data_var():
+    """Regression test for #2598: bare .data var passed to call_extern should not be marked readonly.
+
+    When a parameter is written only by passing its bare .data pointer to an extern
+    (e.g., call_extern("store", Out.data, value)), the pass must recognize this as
+    a potential write and not mark the parameter as read-only.
+    """
+
+    @T.prim_func
+    def bare_data_var_write(A: T.Tensor((256,), "float32"), Out: T.Tensor((256,), "float32")):
+        with T.Kernel(256, threads=1) as i:
+            T.evaluate(T.call_extern("void", "store_val", Out.data, A[i] + 1.0))
+
+    @T.prim_func
+    def address_of_write(A: T.Tensor((256,), "float32"), Out: T.Tensor((256,), "float32")):
+        with T.Kernel(256, threads=1) as i:
+            T.evaluate(T.call_extern("void", "store_val", T.address_of(Out[i]), A[i] + 1.0))
+
+    @T.prim_func
+    def pure_intrinsic_with_bare_data(A: T.Tensor((16,), "float32"), Out: T.Tensor((16,), "float32")):
+        # tirx.isnullptr is pure and does not write A
+        T.evaluate(T.call_intrin("bool", "tirx.isnullptr", A.data))
+        Out[0] = A[0]
+
+    # Test bare data var write via call_extern
+    mod = IRModule.from_expr(bare_data_var_write)
+    mod_annotated = tilelang.transform.AnnotateReadOnlyParams()(mod)
+    readonly_indices = mod_annotated["bare_data_var_write"].attrs.get("tl.readonly_param_indices")
+    # Only A (param 0) should be readonly; Out (param 1) is written via bare data var
+    assert list(readonly_indices) == [0], f"Expected [0], got {list(readonly_indices)}"
+
+    # Test address_of write (control case, should work the same)
+    mod = IRModule.from_expr(address_of_write)
+    mod_annotated = tilelang.transform.AnnotateReadOnlyParams()(mod)
+    readonly_indices = mod_annotated["address_of_write"].attrs.get("tl.readonly_param_indices")
+    assert list(readonly_indices) == [0], f"Expected [0], got {list(readonly_indices)}"
+
+    # Test pure intrinsic with bare data var does NOT mark A as written
+    mod = IRModule.from_expr(pure_intrinsic_with_bare_data)
+    mod_annotated = tilelang.transform.AnnotateReadOnlyParams()(mod)
+    readonly_indices = mod_annotated["pure_intrinsic_with_bare_data"].attrs.get("tl.readonly_param_indices")
+    # A should remain readonly; pure intrinsics don't write even if they receive bare data vars
+    assert list(readonly_indices) == [0], f"Expected [0], got {list(readonly_indices)}"
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

Fix `AnnotateReadOnlyParams` incorrectly marking output buffers as read-only when their bare `.data` pointer is passed to `call_extern`.

## Example

```python
T.call_extern("void", "store_val", Out.data, value)
```

Previously, `Out.data` was not recognized as a potential write, so CUDA codegen could emit `const float* Out`. This caused nvcc compilation errors when the external function expected a writable `float*`.

## Fix

Conservatively treat parameter data vars passed directly to `call_extern` as potentially written.

This handling is restricted to `call_extern`, so pure intrinsics such as `tirx.isnullptr` continue to preserve read-only optimization.

## Tested

Added regression coverage for:

* bare `.data` passed to `call_extern`;
* the existing `address_of` form;
* pure intrinsics receiving bare data vars.

Verified locally.

Fixes #2598


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Treats bare `.data` variables passed to `call_extern` as potentially written, preventing incorrect `const` pointer generation for CUDA extern calls.
- Preserves read-only analysis for pure intrinsics and existing `address_of` handling.
- Adds regression coverage for bare data pointers, `address_of`, and pure intrinsic calls.

## C++ style / lint notes

- The change touches C++, but does not modify documented rules in `docs/developer_guide/cpp_style.md`.
- No C++ API or lint tooling changes are introduced. The warning-only C++ API Style Audit is therefore not materially affected.
- No correctness, build, or test issues are indicated; any existing advisory style warnings should remain non-blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->