### PR TITLE
[BugFix] Correct IEEE math intrinsic names for fp64/fp16/bf16

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -227,9 +227,10 @@ struct CUDAIEEEMath {
     // Unary ops (sqrt, rcp, rsqrt) use h<name> without leading "__".
     if (t.is_float16()) {
       if (rounding_mode != "rn") {
-        LOG(FATAL) << "IEEE " << name << " with rounding mode '" << rounding_mode
-                   << "' is not supported for float16 in CUDA. "
-                   << "Only rounding mode 'rn' is available for half precision.";
+        LOG(FATAL)
+            << "IEEE " << name << " with rounding mode '" << rounding_mode
+            << "' is not supported for float16 in CUDA. "
+            << "Only rounding mode 'rn' is available for half precision.";
         return "";
       }
       // fmaf -> __hfma (not __hmaf)
@@ -256,7 +257,8 @@ struct CUDAIEEEMath {
 
     // bfloat16: no native IEEE rounding intrinsics exist in CUDA.
     if (t.is_bfloat16()) {
-      LOG(FATAL) << "IEEE " << name << " is not supported for bfloat16 in CUDA. "
+      LOG(FATAL) << "IEEE " << name
+                 << " is not supported for bfloat16 in CUDA. "
                  << "bfloat16 has no native IEEE rounding intrinsics.";
       return "";
     }

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -222,14 +222,13 @@ struct CUDAIEEEMath {
       return "__d" + base + "_" + rounding_mode;
     }
 
-    // float16: half-precision intrinsics only exist for round-to-nearest-even.
-    // Binary ops use __h<name> (e.g., __hadd, __hmul, __hfma).
-    // Unary ops (sqrt, rcp, rsqrt) use h<name> without leading "__".
-    if (t.is_float16()) {
+    // float16/bfloat16: half-precision intrinsics only exist for
+    // round-to-nearest-even.
+    if (t.is_float16() || t.is_bfloat16()) {
       if (rounding_mode != "rn") {
         LOG(FATAL)
             << "IEEE " << name << " with rounding mode '" << rounding_mode
-            << "' is not supported for float16 in CUDA. "
+            << "' is not supported for float16/bfloat16 in CUDA. "
             << "Only rounding mode 'rn' is available for half precision.";
         return "";
       }
@@ -237,7 +236,7 @@ struct CUDAIEEEMath {
       if (name == "fmaf") {
         return "__hfma";
       }
-      // Unary ops: hsqrt, hrcp, hrsqrt (single underscore prefix)
+      // Unary ops: hsqrt, hrcp, hrsqrt
       if (name == "fsqrt") {
         return "hsqrt";
       }
@@ -247,20 +246,15 @@ struct CUDAIEEEMath {
       if (name == "frsqrt") {
         return "hrsqrt";
       }
-      // Binary ops: __hadd, __hsub, __hmul, __hdiv
+      // Binary ops: __hadd_rn, __hsub_rn, __hmul_rn, __hdiv
+      if (name == "fdiv") {
+        return "__hdiv";
+      }
       std::string base = name;
       if (!base.empty() && base[0] == 'f') {
         base = base.substr(1);
       }
-      return "__h" + base;
-    }
-
-    // bfloat16: no native IEEE rounding intrinsics exist in CUDA.
-    if (t.is_bfloat16()) {
-      LOG(FATAL) << "IEEE " << name
-                 << " is not supported for bfloat16 in CUDA. "
-                 << "bfloat16 has no native IEEE rounding intrinsics.";
-      return "";
+      return "__h" + base + "_rn";
     }
 
     LOG(FATAL) << "IEEE " << name << " is not supported for dtype " << t;
@@ -4473,99 +4467,53 @@ bool CodeGenTileLangCUDA::HandleLateIntrinsicCall(const CallNode *op,
     CUDAIEEEMath math_func;
     std::string rounding_mode = Downcast<StringImm>(op->args[2])->value;
     std::string func_name = math_func(op->dtype, "fadd", rounding_mode);
-    if (op->dtype.is_float16() && op->dtype.is_scalar()) {
-      os << "cutlass::half_t(" << func_name << "("
-         << "(" << PrintExpr(op->args[0]) << ").to_half(), "
-         << "(" << PrintExpr(op->args[1]) << ").to_half()))";
-    } else {
-      os << func_name << "(" << PrintExpr(op->args[0]) << ", "
-         << PrintExpr(op->args[1]) << ")";
-    }
+    os << func_name << "(" << PrintExpr(op->args[0]) << ", "
+       << PrintExpr(op->args[1]) << ")";
     return true;
   } else if (op->op.same_as(tl::ieee_sub())) {
     CUDAIEEEMath math_func;
     std::string rounding_mode = Downcast<StringImm>(op->args[2])->value;
     std::string func_name = math_func(op->dtype, "fsub", rounding_mode);
-    if (op->dtype.is_float16() && op->dtype.is_scalar()) {
-      os << "cutlass::half_t(" << func_name << "("
-         << "(" << PrintExpr(op->args[0]) << ").to_half(), "
-         << "(" << PrintExpr(op->args[1]) << ").to_half()))";
-    } else {
-      os << func_name << "(" << PrintExpr(op->args[0]) << ", "
-         << PrintExpr(op->args[1]) << ")";
-    }
+    os << func_name << "(" << PrintExpr(op->args[0]) << ", "
+       << PrintExpr(op->args[1]) << ")";
     return true;
   } else if (op->op.same_as(tl::ieee_mul())) {
     CUDAIEEEMath math_func;
     std::string rounding_mode = Downcast<StringImm>(op->args[2])->value;
     std::string func_name = math_func(op->dtype, "fmul", rounding_mode);
-    if (op->dtype.is_float16() && op->dtype.is_scalar()) {
-      os << "cutlass::half_t(" << func_name << "("
-         << "(" << PrintExpr(op->args[0]) << ").to_half(), "
-         << "(" << PrintExpr(op->args[1]) << ").to_half()))";
-    } else {
-      os << func_name << "(" << PrintExpr(op->args[0]) << ", "
-         << PrintExpr(op->args[1]) << ")";
-    }
+    os << func_name << "(" << PrintExpr(op->args[0]) << ", "
+       << PrintExpr(op->args[1]) << ")";
     return true;
   } else if (op->op.same_as(tl::ieee_fmaf())) {
     CUDAIEEEMath math_func;
     std::string rounding_mode = Downcast<StringImm>(op->args[3])->value;
     std::string func_name = math_func(op->dtype, "fmaf", rounding_mode);
-    if (op->dtype.is_float16() && op->dtype.is_scalar()) {
-      os << "cutlass::half_t(" << func_name << "("
-         << "(" << PrintExpr(op->args[0]) << ").to_half(), "
-         << "(" << PrintExpr(op->args[1]) << ").to_half(), "
-         << "(" << PrintExpr(op->args[2]) << ").to_half()))";
-    } else {
-      os << func_name << "(" << PrintExpr(op->args[0]) << ", "
-         << PrintExpr(op->args[1]) << ", " << PrintExpr(op->args[2]) << ")";
-    }
+    os << func_name << "(" << PrintExpr(op->args[0]) << ", "
+       << PrintExpr(op->args[1]) << ", " << PrintExpr(op->args[2]) << ")";
     return true;
   } else if (op->op.same_as(tl::ieee_frcp())) {
     CUDAIEEEMath math_func;
     std::string rounding_mode = Downcast<StringImm>(op->args[1])->value;
     std::string func_name = math_func(op->dtype, "frcp", rounding_mode);
-    if (op->dtype.is_float16() && op->dtype.is_scalar()) {
-      os << "cutlass::half_t(" << func_name << "("
-         << "(" << PrintExpr(op->args[0]) << ").to_half()))";
-    } else {
-      os << func_name << "(" << PrintExpr(op->args[0]) << ")";
-    }
+    os << func_name << "(" << PrintExpr(op->args[0]) << ")";
     return true;
   } else if (op->op.same_as(tl::ieee_fsqrt())) {
     CUDAIEEEMath math_func;
     std::string rounding_mode = Downcast<StringImm>(op->args[1])->value;
     std::string func_name = math_func(op->dtype, "fsqrt", rounding_mode);
-    if (op->dtype.is_float16() && op->dtype.is_scalar()) {
-      os << "cutlass::half_t(" << func_name << "("
-         << "(" << PrintExpr(op->args[0]) << ").to_half()))";
-    } else {
-      os << func_name << "(" << PrintExpr(op->args[0]) << ")";
-    }
+    os << func_name << "(" << PrintExpr(op->args[0]) << ")";
     return true;
   } else if (op->op.same_as(tl::ieee_frsqrt())) {
     CUDAIEEEMath math_func;
     std::string func_name = math_func(op->dtype, "frsqrt", "rn");
-    if (op->dtype.is_float16() && op->dtype.is_scalar()) {
-      os << "cutlass::half_t(" << func_name << "("
-         << "(" << PrintExpr(op->args[0]) << ").to_half()))";
-    } else {
-      os << func_name << "(" << PrintExpr(op->args[0]) << ")";
-    }
+    os << func_name << "(" << PrintExpr(op->args[0]) << ")";
     return true;
   } else if (op->op.same_as(tl::ieee_fdiv())) {
     CUDAIEEEMath math_func;
     std::string rounding_mode = Downcast<StringImm>(op->args[2])->value;
     std::string func_name = math_func(op->dtype, "fdiv", rounding_mode);
-    if (op->dtype.is_float16() && op->dtype.is_scalar()) {
-      os << "cutlass::half_t(" << func_name << "("
-         << "(" << PrintExpr(op->args[0]) << ").to_half(), "
-         << "(" << PrintExpr(op->args[1]) << ").to_half()))";
-    } else {
-      os << func_name << "(" << PrintExpr(op->args[0]) << ", "
-         << PrintExpr(op->args[1]) << ")";
-    }
+    os << func_name << "(" << PrintExpr(op->args[0]) << ", "
+       << PrintExpr(op->args[1]) << ")";
     return true;
   } else if (op->op.same_as(tl::fast_rcp())) {
     need_math_h_ = true;

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -194,11 +194,74 @@ struct CUDAFastMathTan : public CUDAMath {
 struct CUDAIEEEMath {
   std::string operator()(DataType t, std::string name,
                          std::string rounding_mode) const {
+    // float32: all ops with all rounding modes are supported.
+    //   Pattern: __<name>_<rm>   (e.g., __fadd_rn, __fmul_rz)
     if (t.is_float() && t.bits() == 32) {
       return "__" + name + "_" + rounding_mode;
-    } else if (t.is_float() && t.bits() == 64) {
-      return "__d" + name + "_" + rounding_mode;
     }
+
+    // float64: strip the leading 'f' from <name> and prefix with 'd'.
+    //   Pattern: __d<stem>_<rm>  (e.g., fadd -> __dadd_rn)
+    if (t.is_float() && t.bits() == 64) {
+      // Special case: fp64 FMA is __fma_rn, not __dmaf_rn or __dfmaf_rn.
+      if (name == "fmaf") {
+        return "__fma_" + rounding_mode;
+      }
+      // fp64 has no reciprocal-square-root intrinsic — must be composed.
+      if (name == "frsqrt") {
+        LOG(FATAL) << "IEEE frsqrt is not supported for float64 in CUDA. "
+                   << "Use ieee_fsqrt followed by ieee_frcp as a workaround.";
+        return "";
+      }
+      // fadd -> dadd, fsub -> dsub, fmul -> dmul, frcp -> drcp,
+      // fsqrt -> dsqrt, fdiv -> ddiv
+      std::string base = name;
+      if (!base.empty() && base[0] == 'f') {
+        base = base.substr(1);
+      }
+      return "__d" + base + "_" + rounding_mode;
+    }
+
+    // float16: half-precision intrinsics only exist for round-to-nearest-even.
+    // Binary ops use __h<name> (e.g., __hadd, __hmul, __hfma).
+    // Unary ops (sqrt, rcp, rsqrt) use h<name> without leading "__".
+    if (t.is_float16()) {
+      if (rounding_mode != "rn") {
+        LOG(FATAL) << "IEEE " << name << " with rounding mode '" << rounding_mode
+                   << "' is not supported for float16 in CUDA. "
+                   << "Only rounding mode 'rn' is available for half precision.";
+        return "";
+      }
+      // fmaf -> __hfma (not __hmaf)
+      if (name == "fmaf") {
+        return "__hfma";
+      }
+      // Unary ops: hsqrt, hrcp, hrsqrt (single underscore prefix)
+      if (name == "fsqrt") {
+        return "hsqrt";
+      }
+      if (name == "frcp") {
+        return "hrcp";
+      }
+      if (name == "frsqrt") {
+        return "hrsqrt";
+      }
+      // Binary ops: __hadd, __hsub, __hmul, __hdiv
+      std::string base = name;
+      if (!base.empty() && base[0] == 'f') {
+        base = base.substr(1);
+      }
+      return "__h" + base;
+    }
+
+    // bfloat16: no native IEEE rounding intrinsics exist in CUDA.
+    if (t.is_bfloat16()) {
+      LOG(FATAL) << "IEEE " << name << " is not supported for bfloat16 in CUDA. "
+                 << "bfloat16 has no native IEEE rounding intrinsics.";
+      return "";
+    }
+
+    LOG(FATAL) << "IEEE " << name << " is not supported for dtype " << t;
     return "";
   }
 };
@@ -4408,53 +4471,99 @@ bool CodeGenTileLangCUDA::HandleLateIntrinsicCall(const CallNode *op,
     CUDAIEEEMath math_func;
     std::string rounding_mode = Downcast<StringImm>(op->args[2])->value;
     std::string func_name = math_func(op->dtype, "fadd", rounding_mode);
-    os << func_name << "(" << PrintExpr(op->args[0]) << ", "
-       << PrintExpr(op->args[1]) << ")";
+    if (op->dtype.is_float16() && op->dtype.is_scalar()) {
+      os << "cutlass::half_t(" << func_name << "("
+         << "(" << PrintExpr(op->args[0]) << ").to_half(), "
+         << "(" << PrintExpr(op->args[1]) << ").to_half()))";
+    } else {
+      os << func_name << "(" << PrintExpr(op->args[0]) << ", "
+         << PrintExpr(op->args[1]) << ")";
+    }
     return true;
   } else if (op->op.same_as(tl::ieee_sub())) {
     CUDAIEEEMath math_func;
     std::string rounding_mode = Downcast<StringImm>(op->args[2])->value;
     std::string func_name = math_func(op->dtype, "fsub", rounding_mode);
-    os << func_name << "(" << PrintExpr(op->args[0]) << ", "
-       << PrintExpr(op->args[1]) << ")";
+    if (op->dtype.is_float16() && op->dtype.is_scalar()) {
+      os << "cutlass::half_t(" << func_name << "("
+         << "(" << PrintExpr(op->args[0]) << ").to_half(), "
+         << "(" << PrintExpr(op->args[1]) << ").to_half()))";
+    } else {
+      os << func_name << "(" << PrintExpr(op->args[0]) << ", "
+         << PrintExpr(op->args[1]) << ")";
+    }
     return true;
   } else if (op->op.same_as(tl::ieee_mul())) {
     CUDAIEEEMath math_func;
     std::string rounding_mode = Downcast<StringImm>(op->args[2])->value;
     std::string func_name = math_func(op->dtype, "fmul", rounding_mode);
-    os << func_name << "(" << PrintExpr(op->args[0]) << ", "
-       << PrintExpr(op->args[1]) << ")";
+    if (op->dtype.is_float16() && op->dtype.is_scalar()) {
+      os << "cutlass::half_t(" << func_name << "("
+         << "(" << PrintExpr(op->args[0]) << ").to_half(), "
+         << "(" << PrintExpr(op->args[1]) << ").to_half()))";
+    } else {
+      os << func_name << "(" << PrintExpr(op->args[0]) << ", "
+         << PrintExpr(op->args[1]) << ")";
+    }
     return true;
   } else if (op->op.same_as(tl::ieee_fmaf())) {
     CUDAIEEEMath math_func;
     std::string rounding_mode = Downcast<StringImm>(op->args[3])->value;
     std::string func_name = math_func(op->dtype, "fmaf", rounding_mode);
-    os << func_name << "(" << PrintExpr(op->args[0]) << ", "
-       << PrintExpr(op->args[1]) << ", " << PrintExpr(op->args[2]) << ")";
+    if (op->dtype.is_float16() && op->dtype.is_scalar()) {
+      os << "cutlass::half_t(" << func_name << "("
+         << "(" << PrintExpr(op->args[0]) << ").to_half(), "
+         << "(" << PrintExpr(op->args[1]) << ").to_half(), "
+         << "(" << PrintExpr(op->args[2]) << ").to_half()))";
+    } else {
+      os << func_name << "(" << PrintExpr(op->args[0]) << ", "
+         << PrintExpr(op->args[1]) << ", " << PrintExpr(op->args[2]) << ")";
+    }
     return true;
   } else if (op->op.same_as(tl::ieee_frcp())) {
     CUDAIEEEMath math_func;
     std::string rounding_mode = Downcast<StringImm>(op->args[1])->value;
     std::string func_name = math_func(op->dtype, "frcp", rounding_mode);
-    os << func_name << "(" << PrintExpr(op->args[0]) << ")";
+    if (op->dtype.is_float16() && op->dtype.is_scalar()) {
+      os << "cutlass::half_t(" << func_name << "("
+         << "(" << PrintExpr(op->args[0]) << ").to_half()))";
+    } else {
+      os << func_name << "(" << PrintExpr(op->args[0]) << ")";
+    }
     return true;
   } else if (op->op.same_as(tl::ieee_fsqrt())) {
     CUDAIEEEMath math_func;
     std::string rounding_mode = Downcast<StringImm>(op->args[1])->value;
     std::string func_name = math_func(op->dtype, "fsqrt", rounding_mode);
-    os << func_name << "(" << PrintExpr(op->args[0]) << ")";
+    if (op->dtype.is_float16() && op->dtype.is_scalar()) {
+      os << "cutlass::half_t(" << func_name << "("
+         << "(" << PrintExpr(op->args[0]) << ").to_half()))";
+    } else {
+      os << func_name << "(" << PrintExpr(op->args[0]) << ")";
+    }
     return true;
   } else if (op->op.same_as(tl::ieee_frsqrt())) {
     CUDAIEEEMath math_func;
     std::string func_name = math_func(op->dtype, "frsqrt", "rn");
-    os << func_name << "(" << PrintExpr(op->args[0]) << ")";
+    if (op->dtype.is_float16() && op->dtype.is_scalar()) {
+      os << "cutlass::half_t(" << func_name << "("
+         << "(" << PrintExpr(op->args[0]) << ").to_half()))";
+    } else {
+      os << func_name << "(" << PrintExpr(op->args[0]) << ")";
+    }
     return true;
   } else if (op->op.same_as(tl::ieee_fdiv())) {
     CUDAIEEEMath math_func;
     std::string rounding_mode = Downcast<StringImm>(op->args[2])->value;
     std::string func_name = math_func(op->dtype, "fdiv", rounding_mode);
-    os << func_name << "(" << PrintExpr(op->args[0]) << ", "
-       << PrintExpr(op->args[1]) << ")";
+    if (op->dtype.is_float16() && op->dtype.is_scalar()) {
+      os << "cutlass::half_t(" << func_name << "("
+         << "(" << PrintExpr(op->args[0]) << ").to_half(), "
+         << "(" << PrintExpr(op->args[1]) << ").to_half()))";
+    } else {
+      os << func_name << "(" << PrintExpr(op->args[0]) << ", "
+         << PrintExpr(op->args[1]) << ")";
+    }
     return true;
   } else if (op->op.same_as(tl::fast_rcp())) {
     need_math_h_ = true;

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -118,6 +118,82 @@ TL_PATCH TL_DEVICE bfloat16_t hrsqrt(const bfloat16_t x) {
   return bfloat16_t(hrsqrt(x.to_nv_bfloat16()));
 }
 
+// hsqrt function for half_t
+TL_PATCH TL_DEVICE half_t hsqrt(const half_t x) {
+  return half_t(hsqrt(x.to_half()));
+}
+
+// hsqrt function for bfloat16_t
+TL_PATCH TL_DEVICE bfloat16_t hsqrt(const bfloat16_t x) {
+  return bfloat16_t(hsqrt(x.to_nv_bfloat16()));
+}
+
+// hrcp function for half_t
+TL_PATCH TL_DEVICE half_t hrcp(const half_t x) {
+  return half_t(hrcp(x.to_half()));
+}
+
+// hrcp function for bfloat16_t
+TL_PATCH TL_DEVICE bfloat16_t hrcp(const bfloat16_t x) {
+  return bfloat16_t(hrcp(x.to_nv_bfloat16()));
+}
+
+// __hadd_rn function for half_t
+TL_PATCH TL_DEVICE half_t __hadd_rn(const half_t x, const half_t y) {
+  return half_t(__hadd_rn(x.to_half(), y.to_half()));
+}
+
+// __hadd_rn function for bfloat16_t
+TL_PATCH TL_DEVICE bfloat16_t __hadd_rn(const bfloat16_t x,
+                                        const bfloat16_t y) {
+  return bfloat16_t(__hadd_rn(x.to_nv_bfloat16(), y.to_nv_bfloat16()));
+}
+
+// __hsub_rn function for half_t
+TL_PATCH TL_DEVICE half_t __hsub_rn(const half_t x, const half_t y) {
+  return half_t(__hsub_rn(x.to_half(), y.to_half()));
+}
+
+// __hsub_rn function for bfloat16_t
+TL_PATCH TL_DEVICE bfloat16_t __hsub_rn(const bfloat16_t x,
+                                        const bfloat16_t y) {
+  return bfloat16_t(__hsub_rn(x.to_nv_bfloat16(), y.to_nv_bfloat16()));
+}
+
+// __hmul_rn function for half_t
+TL_PATCH TL_DEVICE half_t __hmul_rn(const half_t x, const half_t y) {
+  return half_t(__hmul_rn(x.to_half(), y.to_half()));
+}
+
+// __hmul_rn function for bfloat16_t
+TL_PATCH TL_DEVICE bfloat16_t __hmul_rn(const bfloat16_t x,
+                                        const bfloat16_t y) {
+  return bfloat16_t(__hmul_rn(x.to_nv_bfloat16(), y.to_nv_bfloat16()));
+}
+
+// __hdiv function for half_t
+TL_PATCH TL_DEVICE half_t __hdiv(const half_t x, const half_t y) {
+  return half_t(__hdiv(x.to_half(), y.to_half()));
+}
+
+// __hdiv function for bfloat16_t
+TL_PATCH TL_DEVICE bfloat16_t __hdiv(const bfloat16_t x, const bfloat16_t y) {
+  return bfloat16_t(__hdiv(x.to_nv_bfloat16(), y.to_nv_bfloat16()));
+}
+
+// __hfma function for half_t
+TL_PATCH TL_DEVICE half_t __hfma(const half_t x, const half_t y,
+                                 const half_t z) {
+  return half_t(__hfma(x.to_half(), y.to_half(), z.to_half()));
+}
+
+// __hfma function for bfloat16_t
+TL_PATCH TL_DEVICE bfloat16_t __hfma(const bfloat16_t x, const bfloat16_t y,
+                                     const bfloat16_t z) {
+  return bfloat16_t(
+      __hfma(x.to_nv_bfloat16(), y.to_nv_bfloat16(), z.to_nv_bfloat16()));
+}
+
 // TVM lowers T.exp(bfloat16) to the CUDA half-style `hexp` name. TileLang uses
 // cutlass::bfloat16_t for scalar bf16, while CUDA only overloads hexp for
 // __nv_bfloat16. Keep this narrow bridge in common.h so plain T.exp works

--- a/testing/python/math/test_math_ieee_math.py
+++ b/testing/python/math/test_math_ieee_math.py
@@ -8,8 +8,7 @@ ROUNDING_MODES = ["rn", "rz", "ru", "rd"]
 
 # (dtype, rounding_mode) pairs that must compile and produce correct results.
 # - fp32/fp64: all four IEEE rounding modes are natively supported by CUDA.
-# - fp16     : only round-to-nearest-even is available.
-# - bf16     : no native IEEE rounding intrinsics (tested separately via rejection).
+# - fp16/bf16: only round-to-nearest-even is available.
 IEEE_DTYPE_MODES = [
     (T.float32, "rn"),
     (T.float32, "rz"),
@@ -20,6 +19,7 @@ IEEE_DTYPE_MODES = [
     (T.float64, "ru"),
     (T.float64, "rd"),
     (T.float16, "rn"),
+    (T.bfloat16, "rn"),
 ]
 
 # Ops that carry a rounding_mode parameter (everything except frsqrt).
@@ -186,7 +186,7 @@ def test_rounding_mode_validation():
 @pytest.mark.parametrize("op_name,op_func", IEEE_OPS_WITH_RM)
 @pytest.mark.parametrize("dtype,mode", IEEE_DTYPE_MODES)
 def test_ieee_with_rounding_mode(op_name, op_func, dtype, mode):
-    """Compile + run every IEEE op across fp32 / fp64 / fp16 and all rounding
+    """Compile + run every IEEE op across fp32 / fp64 / fp16 / bf16 and all rounding
     modes that the hardware supports."""
     run_ieee_math_test(op_name, op_func, rounding_mode=mode, dtype=dtype, run_execution=(mode == "rn"))
 
@@ -195,7 +195,7 @@ def test_ieee_with_rounding_mode(op_name, op_func, dtype, mode):
 
 
 @tilelang.testing.requires_cuda
-@pytest.mark.parametrize("dtype", [T.float32, T.float16])
+@pytest.mark.parametrize("dtype", [T.float32, T.float16, T.bfloat16])
 def test_ieee_frsqrt(dtype):
     run_ieee_math_test("ieee_frsqrt", T.ieee_frsqrt, dtype=dtype)
 
@@ -213,18 +213,12 @@ def test_ieee_frsqrt_fp64_rejected():
 
 
 @tilelang.testing.requires_cuda
-def test_ieee_fp16_non_rn_rejected():
-    """fp16 only supports round-to-nearest-even."""
+def test_ieee_half_non_rn_rejected():
+    """fp16/bf16 only supports round-to-nearest-even."""
     with pytest.raises(Exception, match="Only rounding mode 'rn' is available for half precision"):
         run_ieee_math_test("ieee_add", T.ieee_add, rounding_mode="rz", dtype=T.float16)
-
-
-@tilelang.testing.requires_cuda
-@pytest.mark.parametrize("op_name,op_func", IEEE_ALL_OPS)
-def test_ieee_bf16_rejected(op_name, op_func):
-    """bf16 has no IEEE rounding intrinsics in CUDA — every op must FATAL."""
-    with pytest.raises(Exception, match="not supported for bfloat16"):
-        run_ieee_math_test(op_name, op_func, dtype=T.bfloat16)
+    with pytest.raises(Exception, match="Only rounding mode 'rn' is available for half precision"):
+        run_ieee_math_test("ieee_add", T.ieee_add, rounding_mode="rz", dtype=T.bfloat16)
 
 
 if __name__ == "__main__":

--- a/testing/python/math/test_math_ieee_math.py
+++ b/testing/python/math/test_math_ieee_math.py
@@ -11,16 +11,22 @@ ROUNDING_MODES = ["rn", "rz", "ru", "rd"]
 # - fp16     : only round-to-nearest-even is available.
 # - bf16     : no native IEEE rounding intrinsics (tested separately via rejection).
 IEEE_DTYPE_MODES = [
-    (T.float32, "rn"), (T.float32, "rz"), (T.float32, "ru"), (T.float32, "rd"),
-    (T.float64, "rn"), (T.float64, "rz"), (T.float64, "ru"), (T.float64, "rd"),
+    (T.float32, "rn"),
+    (T.float32, "rz"),
+    (T.float32, "ru"),
+    (T.float32, "rd"),
+    (T.float64, "rn"),
+    (T.float64, "rz"),
+    (T.float64, "ru"),
+    (T.float64, "rd"),
     (T.float16, "rn"),
 ]
 
 # Ops that carry a rounding_mode parameter (everything except frsqrt).
 IEEE_OPS_WITH_RM = [
-    ("ieee_add",  T.ieee_add),
-    ("ieee_sub",  T.ieee_sub),
-    ("ieee_mul",  T.ieee_mul),
+    ("ieee_add", T.ieee_add),
+    ("ieee_sub", T.ieee_sub),
+    ("ieee_mul", T.ieee_mul),
     ("ieee_fmaf", T.ieee_fmaf),
     ("ieee_frcp", T.ieee_frcp),
     ("ieee_fsqrt", T.ieee_fsqrt),
@@ -159,6 +165,7 @@ def run_ieee_math_test(
 # Rounding-mode validation (API-level, no GPU required)
 # ---------------------------------------------------------------------------
 
+
 def test_rounding_mode_validation():
     """Test that invalid rounding modes raise ValueError"""
     with pytest.raises(ValueError, match="Invalid rounding mode"):
@@ -174,17 +181,18 @@ def test_rounding_mode_validation():
 # Numerical tests — every (op × dtype × rounding_mode) valid combination
 # ---------------------------------------------------------------------------
 
+
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize("op_name,op_func", IEEE_OPS_WITH_RM)
 @pytest.mark.parametrize("dtype,mode", IEEE_DTYPE_MODES)
 def test_ieee_with_rounding_mode(op_name, op_func, dtype, mode):
     """Compile + run every IEEE op across fp32 / fp64 / fp16 and all rounding
     modes that the hardware supports."""
-    run_ieee_math_test(op_name, op_func, rounding_mode=mode, dtype=dtype,
-                       run_execution=(mode == "rn"))
+    run_ieee_math_test(op_name, op_func, rounding_mode=mode, dtype=dtype, run_execution=(mode == "rn"))
 
 
 # ieee_frsqrt — only round-to-nearest (no rounding_mode parameter).
+
 
 @tilelang.testing.requires_cuda
 @pytest.mark.parametrize("dtype", [T.float32, T.float16])
@@ -195,6 +203,7 @@ def test_ieee_frsqrt(dtype):
 # ---------------------------------------------------------------------------
 # Rejection tests — combinations that must fail at codegen time
 # ---------------------------------------------------------------------------
+
 
 @tilelang.testing.requires_cuda
 def test_ieee_frsqrt_fp64_rejected():

--- a/testing/python/math/test_math_ieee_math.py
+++ b/testing/python/math/test_math_ieee_math.py
@@ -6,6 +6,30 @@ import pytest
 
 ROUNDING_MODES = ["rn", "rz", "ru", "rd"]
 
+# (dtype, rounding_mode) pairs that must compile and produce correct results.
+# - fp32/fp64: all four IEEE rounding modes are natively supported by CUDA.
+# - fp16     : only round-to-nearest-even is available.
+# - bf16     : no native IEEE rounding intrinsics (tested separately via rejection).
+IEEE_DTYPE_MODES = [
+    (T.float32, "rn"), (T.float32, "rz"), (T.float32, "ru"), (T.float32, "rd"),
+    (T.float64, "rn"), (T.float64, "rz"), (T.float64, "ru"), (T.float64, "rd"),
+    (T.float16, "rn"),
+]
+
+# Ops that carry a rounding_mode parameter (everything except frsqrt).
+IEEE_OPS_WITH_RM = [
+    ("ieee_add",  T.ieee_add),
+    ("ieee_sub",  T.ieee_sub),
+    ("ieee_mul",  T.ieee_mul),
+    ("ieee_fmaf", T.ieee_fmaf),
+    ("ieee_frcp", T.ieee_frcp),
+    ("ieee_fsqrt", T.ieee_fsqrt),
+    ("ieee_fdiv", T.ieee_fdiv),
+]
+
+# All 8 ops (including frsqrt).
+IEEE_ALL_OPS = IEEE_OPS_WITH_RM + [("ieee_frsqrt", T.ieee_frsqrt)]
+
 
 def run_ieee_math_test(
     mathop_name,
@@ -22,7 +46,6 @@ def run_ieee_math_test(
     Test IEEE-compliant math operations with specified rounding modes.
     """
 
-    # Define the appropriate function based on operation type to avoid TVM parsing conflicts
     if mathop_name == "ieee_fmaf":
 
         @T.prim_func
@@ -59,7 +82,20 @@ def run_ieee_math_test(
 
         out_idx = [2]
         num_inputs = 2
-    else:  # Single argument operations
+    elif mathop_name == "ieee_frsqrt":  # no rounding_mode parameter
+
+        @T.prim_func
+        def main_func(
+            A: T.Tensor((M, N), dtype),
+            B: T.Tensor((M, N), dtype),
+        ):
+            with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+                for i, j in T.Parallel(block_M, block_N):
+                    B[by * block_M + i, bx * block_N + j] = mathop_func(A[by * block_M + i, bx * block_N + j])
+
+        out_idx = [1]
+        num_inputs = 1
+    else:  # Single argument with rounding_mode (frcp, fsqrt)
 
         @T.prim_func
         def main_func(
@@ -119,112 +155,67 @@ def run_ieee_math_test(
         print(f"Warning: {mathop_name} execution failed: {e}")
 
 
+# ---------------------------------------------------------------------------
+# Rounding-mode validation (API-level, no GPU required)
+# ---------------------------------------------------------------------------
+
 def test_rounding_mode_validation():
     """Test that invalid rounding modes raise ValueError"""
-
-    # Test with invalid rounding mode
     with pytest.raises(ValueError, match="Invalid rounding mode"):
         T.ieee_add(1.0, 2.0, "invalid_mode")
-
     with pytest.raises(ValueError, match="Invalid rounding mode"):
         T.ieee_mul(1.0, 2.0, "xy")
-
     with pytest.raises(ValueError, match="Invalid rounding mode"):
         T.ieee_fsqrt(4.0, "bad_mode")
-
     print("✓ Rounding mode validation test passed")
 
 
-@tilelang.testing.requires_cuda
-@pytest.mark.parametrize("mode", ROUNDING_MODES, ids=ROUNDING_MODES)
-def test_ieee_add_all_rounding_modes(mode):
-    """Test IEEE addition with all rounding modes"""
-    run_ieee_math_test("ieee_add", T.ieee_add, rounding_mode=mode, run_execution=mode == "rn")
-    print(f"✓ ieee_add with {mode} passed")
-
+# ---------------------------------------------------------------------------
+# Numerical tests — every (op × dtype × rounding_mode) valid combination
+# ---------------------------------------------------------------------------
 
 @tilelang.testing.requires_cuda
-@pytest.mark.parametrize("mode", ROUNDING_MODES, ids=ROUNDING_MODES)
-def test_ieee_sub_all_rounding_modes(mode):
-    """Test IEEE subtraction with all rounding modes"""
-    run_ieee_math_test("ieee_sub", T.ieee_sub, rounding_mode=mode, run_execution=mode == "rn")
-    print(f"✓ ieee_sub with {mode} passed")
+@pytest.mark.parametrize("op_name,op_func", IEEE_OPS_WITH_RM)
+@pytest.mark.parametrize("dtype,mode", IEEE_DTYPE_MODES)
+def test_ieee_with_rounding_mode(op_name, op_func, dtype, mode):
+    """Compile + run every IEEE op across fp32 / fp64 / fp16 and all rounding
+    modes that the hardware supports."""
+    run_ieee_math_test(op_name, op_func, rounding_mode=mode, dtype=dtype,
+                       run_execution=(mode == "rn"))
 
 
-@tilelang.testing.requires_cuda
-@pytest.mark.parametrize("mode", ROUNDING_MODES, ids=ROUNDING_MODES)
-def test_ieee_mul_all_rounding_modes(mode):
-    """Test IEEE multiplication with all rounding modes"""
-    run_ieee_math_test("ieee_mul", T.ieee_mul, rounding_mode=mode, run_execution=mode == "rn")
-    print(f"✓ ieee_mul with {mode} passed")
-
+# ieee_frsqrt — only round-to-nearest (no rounding_mode parameter).
 
 @tilelang.testing.requires_cuda
-@pytest.mark.parametrize("mode", ROUNDING_MODES, ids=ROUNDING_MODES)
-def test_ieee_fmaf_all_rounding_modes(mode):
-    """Test IEEE fused multiply-add with all rounding modes"""
-    run_ieee_math_test("ieee_fmaf", T.ieee_fmaf, rounding_mode=mode, run_execution=mode == "rn")
-    print(f"✓ ieee_fmaf with {mode} passed")
+@pytest.mark.parametrize("dtype", [T.float32, T.float16])
+def test_ieee_frsqrt(dtype):
+    run_ieee_math_test("ieee_frsqrt", T.ieee_frsqrt, dtype=dtype)
 
+
+# ---------------------------------------------------------------------------
+# Rejection tests — combinations that must fail at codegen time
+# ---------------------------------------------------------------------------
 
 @tilelang.testing.requires_cuda
-@pytest.mark.parametrize("mode", ROUNDING_MODES, ids=ROUNDING_MODES)
-def test_ieee_frcp_all_rounding_modes(mode):
-    """Test IEEE reciprocal with all rounding modes"""
-    run_ieee_math_test("ieee_frcp", T.ieee_frcp, rounding_mode=mode, run_execution=mode == "rn")
-    print(f"✓ ieee_frcp with {mode} passed")
+def test_ieee_frsqrt_fp64_rejected():
+    """fp64 has no rsqrt intrinsic — codegen must FATAL."""
+    with pytest.raises(Exception, match="frsqrt is not supported for float64"):
+        run_ieee_math_test("ieee_frsqrt", T.ieee_frsqrt, dtype=T.float64)
 
 
 @tilelang.testing.requires_cuda
-@pytest.mark.parametrize("mode", ROUNDING_MODES, ids=ROUNDING_MODES)
-def test_ieee_fsqrt_all_rounding_modes(mode):
-    """Test IEEE square root with all rounding modes"""
-    run_ieee_math_test("ieee_fsqrt", T.ieee_fsqrt, rounding_mode=mode, run_execution=mode == "rn")
-    print(f"✓ ieee_fsqrt with {mode} passed")
+def test_ieee_fp16_non_rn_rejected():
+    """fp16 only supports round-to-nearest-even."""
+    with pytest.raises(Exception, match="Only rounding mode 'rn' is available for half precision"):
+        run_ieee_math_test("ieee_add", T.ieee_add, rounding_mode="rz", dtype=T.float16)
 
 
 @tilelang.testing.requires_cuda
-def test_ieee_frsqrt_rn_only():
-    """Test IEEE reciprocal square root (round to nearest only)"""
-
-    @T.prim_func
-    def main(
-        A: T.Tensor((32, 32), T.float32),
-        B: T.Tensor((32, 32), T.float32),
-    ):
-        with T.Kernel(T.ceildiv(32, 16), T.ceildiv(32, 16), threads=128) as (bx, by):
-            for i, j in T.Parallel(16, 16):
-                B[by * 16 + i, bx * 16 + j] = T.ieee_frsqrt(A[by * 16 + i, bx * 16 + j])
-
-    kernel = tilelang.compile(
-        main,
-        out_idx=[1],
-        target="cuda",
-        pass_configs={
-            tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: False,
-        },
-    )
-
-    print("\n=== Testing ieee_frsqrt (rn only) ===")
-    print("✓ ieee_frsqrt compilation test passed")
-
-    # Test numerical execution
-    a = torch.abs(torch.randn(32, 32, device="cuda", dtype=torch.float32)) + 0.1
-
-    try:
-        result = kernel(a)
-        assert result is not None
-        print("✓ ieee_frsqrt numerical execution test passed")
-    except Exception as e:
-        print(f"Warning: ieee_frsqrt execution failed: {e}")
-
-
-@tilelang.testing.requires_cuda
-@pytest.mark.parametrize("mode", ROUNDING_MODES, ids=ROUNDING_MODES)
-def test_ieee_fdiv_all_rounding_modes(mode):
-    """Test IEEE division with all rounding modes"""
-    run_ieee_math_test("ieee_fdiv", T.ieee_fdiv, rounding_mode=mode, run_execution=mode == "rn")
-    print(f"✓ ieee_fdiv with {mode} passed")
+@pytest.mark.parametrize("op_name,op_func", IEEE_ALL_OPS)
+def test_ieee_bf16_rejected(op_name, op_func):
+    """bf16 has no IEEE rounding intrinsics in CUDA — every op must FATAL."""
+    with pytest.raises(Exception, match="not supported for bfloat16"):
+        run_ieee_math_test(op_name, op_func, dtype=T.bfloat16)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

Fixes #2510: M.ieee_* IEEE rounding intrinsics were broken for every dtype except float32. The defect was in CUDAIEEEMath::operator() which mapped dtypes to CUDA intrinsic names using simple string concatenation that produced wrong results.

- float64: generated __dfadd_rn instead of __dadd_rn → nvcc compile crash
- float16 / bfloat16: returned empty string → emit site produced C comma expression (A, B) → silently returned wrong result with no warning

### Changes

`src/cuda/codegen/codegen_cuda.cc`:
- CUDAIEEEMath::operator(): replaced the two-branch if/else with explicit per-dtype logic

`src/tl_templates/cuda/common.h`:
- added several overloaded functions for half_t and bfloat16_t

### Testing

Refactored the test suite to cover all dtype × rounding_mode combinations. The previous tests only covered float32.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed CUDA IEEE intrinsic code generation for `float32`, `float64`, `float16`, and `bfloat16`, including valid fp64 intrinsic name generation and explicit handling to avoid empty/invalid intrinsic function names.
- Added explicit dtype/rounding-mode logic for `CUDAIEEEMath::operator()` (including rejecting unsupported fp64 `frsqrt`, rejecting non-`rn` half modes, and special-casing `fmaf`/unary ops where needed).
- Wrapped `float16` scalar conversions using `cutlass::half_t(...)` and `.to_half()` at multiple call sites to ensure correct type lowering.
- Updated CUDA IEEE-math tests to centrally enumerate supported `(dtype, rounding_mode)` combinations, added `ieee_frsqrt`-specific dispatch/testing, and added rejection tests for unsupported combinations.

## C++ style / lint notes

- The PR changes C++ code (codegen and CUDA templates) and does not alter rules documented in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step is relevant; any TLCPP003/TLCPP004 findings should be treated as advisory unless they indicate a concrete API/FFI or maintainability risk.
- No correctness, build, or test implications are suggested by warning-only style findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->