### PR TITLE
[BugFix] Use blockDim as workspace stride in batch AllReduce

### DIFF
--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -797,6 +797,8 @@ template <typename Impl> struct ReduceLowerer {
 
         for (const auto &thread_step : reduce_plan.thread_steps) {
           int reducing_threads = thread_step.ReducingThreads();
+          int block_threads =
+              static_cast<int>(*as_const_int(lower_args.thread_bounds->extent));
           auto thread_offset = lower_args.thread_bounds->min;
 
           int vsize = Impl::GetPreferedVectorizedSize(clear_buffer->dtype,
@@ -810,7 +812,7 @@ template <typename Impl> struct ReduceLowerer {
                   .value();
           std::string allreduce = Impl::MakeBatchAllReduce(
               reducer, reducing_threads, thread_step.scale, thread_offset,
-              lower_args.thread_bounds->extent, eff_batch, reducing_threads,
+              lower_args.thread_bounds->extent, eff_batch, block_threads,
               lower_args.target);
 
           DataType ws_dtype = can_batch_pack
@@ -819,7 +821,7 @@ template <typename Impl> struct ReduceLowerer {
           PrimExpr workspace;
           bool need_workspace = reducing_threads > 32;
           if (need_workspace) {
-            int ws_size = reducing_threads * eff_batch;
+            int ws_size = block_threads * eff_batch;
             workspace = lower_args.add_workspace(ws_size, ws_dtype);
           }
 

--- a/testing/python/issue/test_tilelang_issue_2524.py
+++ b/testing/python/issue/test_tilelang_issue_2524.py
@@ -1,0 +1,141 @@
+"""Regression test for issue #2524.
+
+T.reduce_sum / T.reduce_max with batch > 1 silently returned wrong results
+when reducing_threads < blockDim. The workspace was allocated with
+reducing_threads as the stride, but the device template indexed with
+threadIdx.x (the full block index), causing cross-batch overwrites.
+"""
+
+import torch
+
+import tilelang
+import tilelang.language as T
+from tilelang.testing import requires_cuda
+
+
+def _make_reduce_kernel(batch: int, op: str):
+    """Build a kernel that reduces a (2, 8, 16) fragment along dim=1.
+
+    Each block has 128 threads. The reduce dimension (dim=1, length 8) only
+    involves 64 threads, so reducing_threads < blockDim — this is the
+    condition that triggered issue #2524.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((16, 8, 16), "float32"),
+        C: T.Tensor((16, 16), "float32"),
+    ):
+        with T.Kernel(8, threads=128) as bx:
+            a_s = T.alloc_shared((2, 8, 16), "float32")
+            a_f = T.alloc_fragment((2, 8, 16), "float32")
+            c_f = T.alloc_fragment((2, 16), "float32")
+            T.copy(A[bx * 2, 0, 0], a_s)
+            T.copy(a_s, a_f)
+            if op == "sum":
+                T.reduce_sum(a_f, c_f, dim=1, batch=batch)
+            elif op == "max":
+                T.reduce_max(a_f, c_f, dim=1, batch=batch)
+            elif op == "min":
+                T.reduce_min(a_f, c_f, dim=1, batch=batch)
+            T.copy(c_f, C[bx * 2, 0])
+
+    return main
+
+
+def _torch_ref(A: torch.Tensor, op: str):
+    if op == "sum":
+        return A.sum(dim=1)
+    elif op == "max":
+        return A.max(dim=1).values
+    elif op == "min":
+        return A.min(dim=1).values
+    raise ValueError(f"Unknown op: {op}")
+
+
+@requires_cuda
+def test_issue_2524_reduce_sum_batch_gt_1():
+    """reduce_sum with batch=2 — reducing_threads(64) < blockDim(128)."""
+    tilelang.disable_cache()
+    torch.manual_seed(0)
+    A = torch.randint(0, 8, (16, 8, 16)).float().cuda()
+    ref = _torch_ref(A, "sum").cpu()
+
+    kernel = tilelang.compile(
+        _make_reduce_kernel(batch=2, op="sum"),
+        target="cuda",
+    )
+    C = torch.empty((16, 16), dtype=torch.float32, device="cuda")
+    kernel(A, C)
+    torch.cuda.synchronize()
+
+    diff = (C.cpu() - ref).abs()
+    ndiff = int((diff > 1e-4).sum())
+    assert ndiff == 0, f"Batch=2 sum had {ndiff} mismatches (max diff {diff.max().item():g})"
+
+
+@requires_cuda
+def test_issue_2524_reduce_sum_batch_eq_1():
+    """reduce_sum with batch=1 — sanity check (should always pass)."""
+    tilelang.disable_cache()
+    torch.manual_seed(0)
+    A = torch.randint(0, 8, (16, 8, 16)).float().cuda()
+    ref = _torch_ref(A, "sum").cpu()
+
+    kernel = tilelang.compile(
+        _make_reduce_kernel(batch=1, op="sum"),
+        target="cuda",
+    )
+    C = torch.empty((16, 16), dtype=torch.float32, device="cuda")
+    kernel(A, C)
+    torch.cuda.synchronize()
+
+    diff = (C.cpu() - ref).abs()
+    ndiff = int((diff > 1e-4).sum())
+    assert ndiff == 0, f"Batch=1 sum had {ndiff} mismatches (max diff {diff.max().item():g})"
+
+
+@requires_cuda
+def test_issue_2524_reduce_max_batch_gt_1():
+    """reduce_max with batch=2 — reducing_threads(64) < blockDim(128)."""
+    tilelang.disable_cache()
+    torch.manual_seed(0)
+    A = torch.randint(0, 8, (16, 8, 16)).float().cuda()
+    ref = _torch_ref(A, "max").cpu()
+
+    kernel = tilelang.compile(
+        _make_reduce_kernel(batch=2, op="max"),
+        target="cuda",
+    )
+    C = torch.empty((16, 16), dtype=torch.float32, device="cuda")
+    kernel(A, C)
+    torch.cuda.synchronize()
+
+    diff = (C.cpu() - ref).abs()
+    ndiff = int((diff > 1e-4).sum())
+    assert ndiff == 0, f"Batch=2 max had {ndiff} mismatches (max diff {diff.max().item():g})"
+
+
+@requires_cuda
+def test_issue_2524_reduce_min_batch_gt_1():
+    """reduce_min with batch=2 — reducing_threads(64) < blockDim(128)."""
+    tilelang.disable_cache()
+    torch.manual_seed(0)
+    A = torch.randint(0, 8, (16, 8, 16)).float().cuda()
+    ref = _torch_ref(A, "min").cpu()
+
+    kernel = tilelang.compile(
+        _make_reduce_kernel(batch=2, op="min"),
+        target="cuda",
+    )
+    C = torch.empty((16, 16), dtype=torch.float32, device="cuda")
+    kernel(A, C)
+    torch.cuda.synchronize()
+
+    diff = (C.cpu() - ref).abs()
+    ndiff = int((diff > 1e-4).sum())
+    assert ndiff == 0, f"Batch=2 min had {ndiff} mismatches (max diff {diff.max().item():g})"
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
### Summary

Fixes #2524.

`T.reduce_sum` / `T.reduce_max` (and other `T.reduce_*` ops) silently produced incorrect results when both `batch > 1` and `reducing_threads < blockDim`. The bug was introduced by PR #1976 (Feature Batched AllReduce).

Root cause: The batched AllReduce path allocated shared memory workspace using `reducing_threads` as the per-channel stride, but the device template (`butterfly_reduce_batch`) indexed the workspace with `threadIdx.x` — the full block thread index. When `reducing_threads < blockDim`, threads with `threadIdx.x >= reducing_threads` wrote past their batch channel boundary, causing cross-batch overwrites and out-of-bounds accesses.

Conditions that masked the bug:
- `batch = 1` — takes the scalar AllReduce path, which already used the correct `blockDim`-based workspace size
- `reducing_threads <= 32` — the butterfly AllReduce never reaches the shared-memory stage (warp shuffle only)
- `reducing_threads == blockDim` — the two coordinate systems happen to coincide

### Changes

One file changed: `src/backend/common/op/reduce.h`

- Added a `block_threads` variable extracted from `lower_args.thread_bounds->extent` (the full block thread count)
- Changed `MakeBatchAllReduce`'s `workspace_stride` parameter from `reducing_threads` to `block_threads`
- Changed the shared-memory workspace allocation size from `reducing_threads * eff_batch` to `block_threads * eff_batch`

This makes the batched path consistent with:
1. The scalar AllReduce path in the same file (line 796–797), which already uses `lower_args.thread_bounds->extent` as the workspace size
2. The batched path in `finalize_reducer.h` (line 83–89), which already uses the correct `blockDim`-based stride

### Testing

Added `testing/python/issue/test_tilelang_issue_2524.py` with 4 test cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed batched `T.reduce_*` correctness for `batch > 1` when `reducing_threads < blockDim` by updating the GPU batch all-reduce lowering in `src/backend/common/op/reduce.h` to use the full `blockDim` (`block_threads`) for both workspace stride/indexing and allocation sizing.
- Added CUDA regression coverage in `testing/python/issue/test_tilelang_issue_2524.py` for `reduce_sum` (with `batch=2` and `batch=1`) and for `reduce_max`/`reduce_min` (with `batch=2`), validating outputs against PyTorch references.

## C++ style / lint notes

- This PR does not touch `docs/developer_guide/cpp_style.md` or any documented C++ style rules.
- No C++ API/FFI surface changes are introduced; the “C++ API Style Audit (warning only)” CI step should remain advisory. No new warning-only findings are expected to be introduced or required to block merge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->