### PR TITLE
[Feature] Add compiler pass timing profiling

### DIFF
--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -50,6 +50,8 @@ TVM_REGISTER_PASS_CONFIG_OPTION(kIfStmtBindingInlineReplayableBinds, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableOutOfBoundWarning, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kEnableDumpIR, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDumpIRDir, ffi::String);
+TVM_REGISTER_PASS_CONFIG_OPTION(kPassProfile, Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION(kPassProfileThresholdMs, FloatImm);
 
 DataType CuTensorMapType() { return DataType::UInt(8, 128); }
 

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -198,6 +198,10 @@ static constexpr const char *kDisableOutOfBoundWarning =
 static constexpr const char *kEnableDumpIR = "tl.enable_dump_ir";
 static constexpr const char *kDumpIRDir = "tl.dump_ir_path";
 
+static constexpr const char *kPassProfile = "tl.pass_profile";
+static constexpr const char *kPassProfileThresholdMs =
+    "tl.pass_profile_threshold_ms";
+
 /*!
  * \brief Get the type of the CUDA tensor map
  *

--- a/testing/python/components/test_tilelang_env.py
+++ b/testing/python/components/test_tilelang_env.py
@@ -1,6 +1,9 @@
 import os
 
+import pytest
+
 import tilelang
+from tilelang.env import resolve_pass_profile_threshold_ms
 
 
 def _env_var_descriptor(name):
@@ -59,3 +62,40 @@ def test_tilelang_tmp_dir_default_tracks_cache_dir(monkeypatch, tmp_path):
     finally:
         _restore_forced_value("TILELANG_CACHE_DIR", original_cache_forced_value)
         _restore_forced_value("TILELANG_TMP_DIR", original_tmp_forced_value)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(None, 0.0), ("", 0.0), ("   ", 0.0), ("0", 0.0), ("1.5", 1.5), (" 2.25 ", 2.25)],
+)
+def test_pass_profile_threshold_values(monkeypatch, value, expected):
+    desc = _env_var_descriptor("TILELANG_PASS_PROFILE_THRESHOLD_MS")
+    original_forced_value = desc._forced_value
+    desc._forced_value = None
+    try:
+        if value is None:
+            monkeypatch.delenv("TILELANG_PASS_PROFILE_THRESHOLD_MS", raising=False)
+        else:
+            monkeypatch.setenv("TILELANG_PASS_PROFILE_THRESHOLD_MS", value)
+        assert tilelang.env.get_pass_profile_threshold_ms() == expected
+    finally:
+        _restore_forced_value("TILELANG_PASS_PROFILE_THRESHOLD_MS", original_forced_value)
+
+
+@pytest.mark.parametrize("value", ["-1", "invalid", "nan", "inf", "-inf"])
+def test_pass_profile_threshold_rejects_invalid_values(monkeypatch, value):
+    desc = _env_var_descriptor("TILELANG_PASS_PROFILE_THRESHOLD_MS")
+    original_forced_value = desc._forced_value
+    desc._forced_value = None
+    try:
+        monkeypatch.setenv("TILELANG_PASS_PROFILE_THRESHOLD_MS", value)
+        with pytest.raises(ValueError, match="must be a finite non-negative number"):
+            tilelang.env.get_pass_profile_threshold_ms()
+    finally:
+        _restore_forced_value("TILELANG_PASS_PROFILE_THRESHOLD_MS", original_forced_value)
+
+
+def test_pass_profile_threshold_explicit_zero_overrides_environment():
+    key = tilelang.PassConfigKey.TL_PASS_PROFILE_THRESHOLD_MS
+
+    assert resolve_pass_profile_threshold_ms({key: 0}, key, lambda: 10.0) == 0.0

--- a/testing/python/debug/test_pass_timing.py
+++ b/testing/python/debug/test_pass_timing.py
@@ -1,0 +1,178 @@
+"""Tests for pass timing instrumentation."""
+
+import gc
+import logging
+import weakref
+from types import SimpleNamespace
+
+import pytest
+
+import tilelang.language as T
+from tilelang import tvm
+from tilelang.utils.pass_timing import (
+    PassTimingRecord,
+    TileLangPassTimingInstrument,
+    build_pass_instruments,
+    report_pass_timing_on_exit,
+)
+
+
+def _simple_module():
+    @T.prim_func
+    def program(A: T.Tensor((16,), "float32"), B: T.Tensor((16,), "float32")):
+        with T.Kernel(threads=16):
+            tid = T.get_thread_binding()
+            B[tid] = A[tid] + 1.0
+
+    return tvm.IRModule({"main": program})
+
+
+def test_pass_timing_records_simple_pass():
+    timing = TileLangPassTimingInstrument()
+
+    with tvm.transform.PassContext(instruments=[timing.instrument]):
+        tvm.tirx.transform.Simplify()(_simple_module())
+
+    assert timing.records
+    assert any(record.name.endswith(".Simplify") for record in timing.records)
+    assert all(record.duration_s >= 0 for record in timing.records)
+    assert all(0 <= record.self_duration_s <= record.duration_s for record in timing.records)
+
+
+def test_pass_timing_wrapper_can_be_collected():
+    timing = TileLangPassTimingInstrument()
+    timing_ref = weakref.ref(timing)
+    state_ref = weakref.ref(timing._state)
+
+    del timing
+    gc.collect()
+
+    assert timing_ref() is None
+    assert state_ref() is None
+
+
+def test_build_pass_instruments_prepends_timing():
+    base_instrument = object()
+
+    instruments, timing = build_pass_instruments([base_instrument], threshold_ms=0.0)
+
+    assert timing is not None
+    assert instruments[0] is timing.instrument
+    assert instruments[1] is base_instrument
+
+
+def test_build_pass_instruments_without_profile_preserves_base_instruments():
+    base_instrument = object()
+
+    instruments, timing = build_pass_instruments([base_instrument], threshold_ms=None)
+
+    assert timing is None
+    assert instruments == [base_instrument]
+
+
+def test_pass_timing_excludes_later_after_pass_callbacks(monkeypatch):
+    clock = [0.0]
+
+    @tvm.ir.instrument.pass_instrument
+    class AdvanceClockAfterPass:
+        def run_after_pass(self, mod, info):
+            clock[0] += 1.0
+
+    instruments, timing = build_pass_instruments([AdvanceClockAfterPass()], threshold_ms=0.0)
+    monkeypatch.setattr("tilelang.utils.pass_timing.time.monotonic", lambda: clock[0])
+
+    with tvm.transform.PassContext(instruments=instruments):
+        tvm.tirx.transform.Simplify()(_simple_module())
+
+    assert timing is not None
+    assert timing.records[0].duration_s == 0.0
+    assert clock[0] == 1.0
+
+
+def test_pass_timing_calculates_nested_self_time(monkeypatch):
+    timing = TileLangPassTimingInstrument()
+    timestamps = iter([0.0, 1.0, 3.0, 5.0])
+    monkeypatch.setattr("tilelang.utils.pass_timing.time.monotonic", lambda: next(timestamps))
+    parent = SimpleNamespace(name="parent")
+    child = SimpleNamespace(name="child")
+
+    timing._enter_pass_ctx()
+    timing._run_before_pass(parent)
+    timing._run_before_pass(child)
+    timing._run_after_pass(child)
+    timing._run_after_pass(parent)
+
+    parent_record, child_record = timing.records
+    assert parent_record.duration_s == pytest.approx(5.0)
+    assert parent_record.self_duration_s == pytest.approx(3.0)
+    assert child_record.duration_s == pytest.approx(2.0)
+    assert child_record.self_duration_s == pytest.approx(2.0)
+    assert timing.total_duration_s == pytest.approx(5.0)
+
+
+def test_pass_timing_report_filters_by_inclusive_threshold():
+    timing = TileLangPassTimingInstrument(threshold_ms=10.0)
+    timing._records.extend(
+        [
+            PassTimingRecord("slow", 0.020, 0, self_duration_s=0.015, sequence=0),
+            PassTimingRecord("fast", 0.005, 0, self_duration_s=0.005, sequence=1),
+        ]
+    )
+
+    report = timing.report()
+
+    assert "slow" in report
+    assert "fast" not in report
+    assert "1 passes skipped" in report
+    assert "Inclusive" in report
+    assert "Self" in report
+
+
+def test_pass_timing_report_includes_context():
+    timing = TileLangPassTimingInstrument()
+    timing._records.append(PassTimingRecord("pass", 0.001, 0))
+
+    report = timing.report(context="stage=grouped-host, config=3, kernel=main_gc_3")
+
+    assert "Context: stage=grouped-host, config=3, kernel=main_gc_3" in report
+
+
+def test_pass_timing_report_is_emitted_on_failure(monkeypatch):
+    timing = TileLangPassTimingInstrument()
+    contexts = []
+    monkeypatch.setattr(timing, "print_report", lambda context=None: contexts.append(context))
+
+    with (
+        pytest.raises(RuntimeError, match="expected failure"),
+        report_pass_timing_on_exit(timing, context="stage=jit-lower, kernel=main"),
+    ):
+        raise RuntimeError("expected failure")
+
+    assert contexts == ["stage=jit-lower, kernel=main"]
+
+
+def test_pass_timing_cleans_incomplete_frames_after_pass_failure(caplog):
+    timing = TileLangPassTimingInstrument()
+
+    @tvm.transform.module_pass(opt_level=0, name="FailingPass")
+    def failing_pass(mod, ctx):
+        raise RuntimeError("expected failure")
+
+    caplog.set_level(logging.WARNING, logger="tilelang.pass_timing")
+    with pytest.raises(RuntimeError, match="expected failure"), tvm.transform.PassContext(instruments=[timing.instrument]):
+        failing_pass(_simple_module())
+
+    assert not timing._stack
+    assert "Discarding 1 incomplete pass timing frame" in caplog.text
+
+
+def test_pass_timing_ignores_unmatched_after_callback(caplog):
+    timing = TileLangPassTimingInstrument()
+    caplog.set_level(logging.WARNING, logger="tilelang.pass_timing")
+
+    timing._enter_pass_ctx()
+    timing._run_after_pass(SimpleNamespace(name="unexpected"))
+
+    assert not timing.records
+    assert not timing._stack
+    assert "Ignoring unmatched pass timing callback" in caplog.text

--- a/tilelang/autotuner/grouped_compile.py
+++ b/tilelang/autotuner/grouped_compile.py
@@ -12,12 +12,15 @@ from collections.abc import Callable
 from tilelang import tvm
 from tvm.tirx import PrimFunc
 
+from tilelang import env
+from tilelang.env import resolve_pass_profile_threshold_ms
 from tilelang.autotuner.param import CompileArgs
 from tilelang.engine.lower import lower_to_host_device_ir, device_codegen, host_codegen
 from tilelang.engine.param import CompiledArtifact
 from tilelang.jit.adapter import TVMFFIKernelAdapter
 from tilelang.jit.kernel import JITKernel
 from tilelang.transform import PassConfigKey
+from tilelang.utils.pass_timing import build_pass_instruments, report_pass_timing_on_exit
 
 CompileUnitResult = tuple[int, dict[str, Any], JITKernel | None, Exception | None]
 
@@ -38,10 +41,22 @@ def compile_grouped_unit_tvm_ffi(
     """
 
     pass_configs = dict(compile_args.pass_configs) if compile_args.pass_configs else {}
-    pass_instruments = []
+    base_pass_instruments = []
     if pass_configs.get(PassConfigKey.TL_ENABLE_DUMP_IR):
         dump_ir_path = pass_configs.get(PassConfigKey.TL_DUMP_IR_DIR, "./dump_ir")
-        pass_instruments.append(tvm.ir.instrument.DumpIR(dump_dir=dump_ir_path))
+        base_pass_instruments.append(tvm.ir.instrument.DumpIR(dump_dir=dump_ir_path))
+
+    enable_profile = pass_configs.get(PassConfigKey.TL_PASS_PROFILE) or env.is_pass_profile_enabled()
+    profile_threshold_ms = None
+    if enable_profile:
+        profile_threshold_ms = resolve_pass_profile_threshold_ms(
+            pass_configs,
+            PassConfigKey.TL_PASS_PROFILE_THRESHOLD_MS,
+            env.get_pass_profile_threshold_ms,
+        )
+
+    def create_pass_instruments():
+        return build_pass_instruments(base_pass_instruments, profile_threshold_ms)
 
     unit_results: list[CompileUnitResult] = []
     lowered_items: list[dict[str, Any]] = []
@@ -53,7 +68,16 @@ def compile_grouped_unit_tvm_ffi(
             unique_symbol = f"{original_symbol}_gc_{idx}"
             program = program.with_attr("global_symbol", unique_symbol)
 
-            with tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=pass_instruments), compile_args.target:
+            config_instruments, timing_inst = create_pass_instruments()
+
+            with (
+                report_pass_timing_on_exit(
+                    timing_inst,
+                    context=f"stage=grouped-lower, config={idx}, kernel={unique_symbol}",
+                ),
+                tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=config_instruments),
+                compile_args.target,
+            ):
                 host_mod, device_mod, params, normalized_target, normalized_target_host = lower_to_host_device_ir(
                     program,
                     target=compile_args.target,
@@ -97,7 +121,16 @@ def compile_grouped_unit_tvm_ffi(
         merged_device_mod = tvm.IRModule(merged_funcs, attrs=merged_attrs)
 
         reference_target = lowered_items[0]["target"]
-        with tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=pass_instruments), reference_target:
+        device_instruments, device_timing_inst = create_pass_instruments()
+        grouped_config_indices = ",".join(str(item["idx"]) for item in lowered_items)
+        with (
+            report_pass_timing_on_exit(
+                device_timing_inst,
+                context=f"stage=grouped-device, configs=[{grouped_config_indices}]",
+            ),
+            tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=device_instruments),
+            reference_target,
+        ):
             grouped_device_rt_mod = device_codegen(merged_device_mod, reference_target)
 
         grouped_kernel_source = grouped_device_rt_mod.inspect_source()
@@ -106,7 +139,16 @@ def compile_grouped_unit_tvm_ffi(
             idx = item["idx"]
             config_arg = item["config_arg"]
             try:
-                with tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=pass_instruments), item["target"]:
+                host_instruments, host_timing_inst = create_pass_instruments()
+                kernel_symbol = str(item["program"].attrs["global_symbol"])
+                with (
+                    report_pass_timing_on_exit(
+                        host_timing_inst,
+                        context=f"stage=grouped-host, config={idx}, kernel={kernel_symbol}",
+                    ),
+                    tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=host_instruments),
+                    item["target"],
+                ):
                     grouped_host_rt_mod = host_codegen(item["host_mod"], item["target_host"], target=item["target"])
 
                 grouped_host_rt_mod.import_module(grouped_device_rt_mod)

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -16,6 +16,25 @@ logger = logging.getLogger(__name__)
 EnvVarDefault = str | None | Callable[[], str | None]
 TargetConfig = dict[str, object]
 
+
+def parse_pass_profile_threshold_ms(value: object, name: str = "pass profile threshold") -> float:
+    """Parse a finite, non-negative pass profile threshold in milliseconds."""
+    try:
+        threshold = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be a finite non-negative number") from exc
+    if not math.isfinite(threshold) or threshold < 0:
+        raise ValueError(f"{name} must be a finite non-negative number")
+    return threshold
+
+
+def resolve_pass_profile_threshold_ms(pass_configs: Mapping[object, object], key: object, env_threshold_ms: Callable[[], float]) -> float:
+    """Resolve pass profile threshold with an explicit pass config taking precedence."""
+    if key in pass_configs:
+        return parse_pass_profile_threshold_ms(pass_configs[key], str(key))
+    return env_threshold_ms()
+
+
 # SETUP ENVIRONMENT VARIABLES
 CUTLASS_NOT_FOUND_MESSAGE = "CUTLASS is not installed or found in the expected path"
 ", which may lead to compilation bugs when utilize tilelang backend."
@@ -356,6 +375,10 @@ class Environment:
     TILELANG_PASS_DIFF = EnvVar("TILELANG_PASS_DIFF", "0")  # "0"=off, "terminal", "html", "both"
     TILELANG_PASS_DIFF_OUTPUT = EnvVar("TILELANG_PASS_DIFF_OUTPUT", "tmp/pass_diff_output")  # output directory for HTML reports
 
+    # Pass timing / profiling
+    TILELANG_PASS_PROFILE = EnvVar("TILELANG_PASS_PROFILE", "0")  # "0"=off, "1"/"true"=on
+    TILELANG_PASS_PROFILE_THRESHOLD_MS = EnvVar("TILELANG_PASS_PROFILE_THRESHOLD_MS", "0")  # 0=show all
+
     # Auto-tuning settings
     TILELANG_AUTO_TUNING_DISABLE_CACHE = EnvVar("TILELANG_AUTO_TUNING_DISABLE_CACHE", "0")
     TILELANG_AUTO_TUNING_CPU_UTILITIES = EnvVar("TILELANG_AUTO_TUNING_CPU_UTILITIES", "0.9")  # percent of CPUs used
@@ -412,6 +435,15 @@ class Environment:
 
     def is_jit_diagnostics_enabled(self) -> bool:
         return str(self.TILELANG_JIT_DIAGNOSTICS).lower() in ("1", "true", "yes", "on")
+
+    def is_pass_profile_enabled(self) -> bool:
+        return str(self.TILELANG_PASS_PROFILE).strip().lower() in ("1", "true", "yes", "on")
+
+    def get_pass_profile_threshold_ms(self) -> float:
+        value = str(self.TILELANG_PASS_PROFILE_THRESHOLD_MS).strip()
+        if not value:
+            return 0.0
+        return parse_pass_profile_threshold_ms(value, "TILELANG_PASS_PROFILE_THRESHOLD_MS")
 
     def get_compile_timeout_seconds(self) -> float | None:
         value = str(self.TILELANG_COMPILE_TIMEOUT_SECONDS).strip()

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -8,6 +8,7 @@ from tvm.tirx import PrimFunc
 import tilelang
 from tilelang import tvm
 from tilelang import env
+from tilelang.env import resolve_pass_profile_threshold_ms
 from tilelang.backend.execution_backend import resolve_execution_backend_spec
 from tvm.target import Target
 from tilelang.engine.param import CompiledArtifact, KernelParam
@@ -26,6 +27,7 @@ from tilelang.contrib.hip_resource_info import pop_recorded, reset_recorder
 from tilelang.jit.diagnostics import jit_phase
 from tilelang.transform import PassConfigKey
 from tilelang.transform.pass_config import normalize_pass_configs
+from tilelang.utils.pass_timing import build_pass_instruments, report_pass_timing_on_exit
 import logging
 import os
 
@@ -234,10 +236,23 @@ class JITKernel(Generic[_P, _T]):
         enable_device_compile = self.execution_backend_spec.enable_device_compile
 
         # Additional pass instruments
-        pass_instruments = []
+        base_pass_instruments = []
         if pass_configs.get(PassConfigKey.TL_ENABLE_DUMP_IR):
             dump_ir_path = pass_configs.get(PassConfigKey.TL_DUMP_IR_DIR, "./dump_ir")  # Default dump path
-            pass_instruments.append(tvm.ir.instrument.DumpIR(dump_dir=dump_ir_path))
+            base_pass_instruments.append(tvm.ir.instrument.DumpIR(dump_dir=dump_ir_path))
+
+        # Pass timing instrument
+        profile_threshold_ms = None
+        if pass_configs.get(PassConfigKey.TL_PASS_PROFILE) or env.is_pass_profile_enabled():
+            profile_threshold_ms = resolve_pass_profile_threshold_ms(
+                pass_configs,
+                PassConfigKey.TL_PASS_PROFILE_THRESHOLD_MS,
+                env.get_pass_profile_threshold_ms,
+            )
+        pass_instruments, timing_instrument = build_pass_instruments(
+            base_pass_instruments,
+            profile_threshold_ms,
+        )
 
         # open a recorder window for kernel-resource-usage remarks
         capture_resources = is_hip_target(target)
@@ -251,6 +266,10 @@ class JITKernel(Generic[_P, _T]):
             "backend": execution_backend,
         }
         with (
+            report_pass_timing_on_exit(
+                timing_instrument,
+                context=f"stage=jit-lower, kernel={func_name}, backend={execution_backend}",
+            ),
             jit_phase("lower", verbose=verbose, **phase_context),
             tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=pass_instruments),
             self.target,

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -283,6 +283,12 @@ class PassConfigKey(str, Enum):
     TL_DUMP_IR_DIR = "tl.dump_ir_path"
     """Path to the directory where IR will be dumped. Default: ./dump_ir/"""
 
+    TL_PASS_PROFILE = "tl.pass_profile"
+    """Enable per-pass timing profiling. Default: False"""
+
+    TL_PASS_PROFILE_THRESHOLD_MS = "tl.pass_profile_threshold_ms"
+    """Only show passes slower than this threshold (ms). 0 = show all. Default: 0"""
+
 
 _DEPRECATED_PASS_CONFIG_MESSAGES = {
     PassConfigKey.TL_DISABLE_TMA_LOWER.value: (

--- a/tilelang/utils/__init__.py
+++ b/tilelang/utils/__init__.py
@@ -20,3 +20,4 @@ from .language import (
 )
 from .deprecated import deprecated  # noqa: F401
 from .version import build_date  # noqa: F401
+from .pass_timing import TileLangPassTimingInstrument, PassTimingRecord  # noqa: F401

--- a/tilelang/utils/pass_timing.py
+++ b/tilelang/utils/pass_timing.py
@@ -1,0 +1,242 @@
+"""Per-pass timing instrumentation for tilelang compilation pipelines.
+
+Records inclusive and self wall-clock duration for each pass using
+``time.monotonic()``. Data persists after PassContext exit for
+post-compilation reporting.
+
+Enabled via TILELANG_PASS_PROFILE=1 env var or
+PassConfigKey.TL_PASS_PROFILE pass config.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+from tvm.ir import _ffi_instrument_api
+
+logger = logging.getLogger("tilelang.pass_timing")
+
+
+@dataclass
+class PassTimingRecord:
+    """Single completed pass execution record."""
+
+    name: str
+    duration_s: float
+    depth: int  # nesting depth (0 = top-level)
+    self_duration_s: float = 0.0
+    sequence: int = 0
+
+
+@dataclass
+class _ActivePass:
+    name: str
+    start_time: float
+    depth: int
+    sequence: int
+    child_duration_s: float = 0.0
+
+
+class _PassTimingState:
+    """Mutable callback state owned by the underlying TVM instrument."""
+
+    def __init__(self):
+        self.records: list[PassTimingRecord] = []
+        self.stack: list[_ActivePass] = []
+        self.next_sequence = 0
+
+    def enter_pass_ctx(self):
+        self.records.clear()
+        self.stack.clear()
+        self.next_sequence = 0
+
+    def exit_pass_ctx(self):
+        if self.stack:
+            logger.warning(
+                "Discarding %d incomplete pass timing frame(s): %s",
+                len(self.stack),
+                ", ".join(frame.name for frame in self.stack),
+            )
+            self.stack.clear()
+
+    def run_before_pass(self, _mod, info):
+        self.stack.append(
+            _ActivePass(
+                name=info.name,
+                start_time=time.monotonic(),
+                depth=len(self.stack),
+                sequence=self.next_sequence,
+            )
+        )
+        self.next_sequence += 1
+
+    def run_after_pass(self, _mod, info):
+        if not self.stack or self.stack[-1].name != info.name:
+            expected = self.stack[-1].name if self.stack else "<none>"
+            logger.warning(
+                "Ignoring unmatched pass timing callback for %s (expected %s)",
+                info.name,
+                expected,
+            )
+            self.stack.clear()
+            return
+
+        frame = self.stack.pop()
+        duration_s = time.monotonic() - frame.start_time
+        self_duration_s = max(0.0, duration_s - frame.child_duration_s)
+        self.records.append(
+            PassTimingRecord(
+                name=frame.name,
+                duration_s=duration_s,
+                self_duration_s=self_duration_s,
+                depth=frame.depth,
+                sequence=frame.sequence,
+            )
+        )
+        if self.stack:
+            self.stack[-1].child_duration_s += duration_s
+
+
+class TileLangPassTimingInstrument:
+    """Per-pass timing instrument for tilelang compilation pipelines.
+
+    This is a plain-Python wrapper that creates a TVM ``PassInstrument``
+    internally. Callback state is kept separate so the native instrument does
+    not retain this wrapper.
+
+    Parameters
+    ----------
+    threshold_ms : float
+        Only show passes whose inclusive duration meets this threshold (ms).
+        0.0 means show all passes.
+    """
+
+    def __init__(self, threshold_ms: float = 0.0):
+        self._state = _PassTimingState()
+        self._records = self._state.records
+        self._stack = self._state.stack
+        self._threshold_ms = threshold_ms
+        self._instrument = self._create_tvm_instrument(self._state)
+
+    def _enter_pass_ctx(self):
+        self._state.enter_pass_ctx()
+
+    def _exit_pass_ctx(self):
+        self._state.exit_pass_ctx()
+
+    def _run_before_pass(self, info):
+        self._state.run_before_pass(None, info)
+
+    def _run_after_pass(self, info):
+        self._state.run_after_pass(None, info)
+
+    @staticmethod
+    def _create_tvm_instrument(state: _PassTimingState):
+        """Create an instrument whose callbacks do not retain the wrapper."""
+        return _ffi_instrument_api.PassInstrument(
+            "TileLangPassTimingInstrument",
+            state.enter_pass_ctx,
+            state.exit_pass_ctx,
+            None,
+            state.run_before_pass,
+            state.run_after_pass,
+        )
+
+    @property
+    def instrument(self):
+        """The underlying TVM PassInstrument to add to ``PassContext``."""
+        return self._instrument
+
+    @property
+    def records(self) -> list[PassTimingRecord]:
+        return sorted(self._records, key=lambda record: record.sequence)
+
+    @property
+    def total_duration_s(self) -> float:
+        # Sum only top-level passes to avoid double-counting nested passes.
+        return sum(record.duration_s for record in self._records if record.depth == 0)
+
+    def report(self, context: str | None = None) -> str:
+        """Generate a formatted timing report string."""
+        if not self._records:
+            message = "[tilelang pass timing] No passes recorded."
+            return f"{message} Context: {context}" if context else message
+
+        threshold_s = self._threshold_ms / 1000.0
+        total = self.total_duration_s
+        lines = []
+
+        lines.append("=" * 96)
+        lines.append("TileLang Pass Timing Report")
+        if context:
+            lines.append(f"Context: {context}")
+        lines.append("=" * 96)
+        lines.append(f"Total: {total:.4f}s ({len(self._records)} passes)")
+        if self._threshold_ms > 0:
+            lines.append(f"(inclusive threshold: {self._threshold_ms:.1f}ms)")
+        lines.append("-" * 96)
+        lines.append(f"{'#':>3}  {'Pass Name':<43} {'Inclusive':>10} {'Self':>10}  {'Incl %':>7} {'Self %':>7}")
+        lines.append("-" * 96)
+
+        skipped = 0
+        for index, record in enumerate(self.records, 1):
+            if record.duration_s < threshold_s:
+                skipped += 1
+                continue
+            inclusive_pct = (record.duration_s / total * 100) if total > 0 else 0
+            self_pct = (record.self_duration_s / total * 100) if total > 0 else 0
+            name_col = f"{'  ' * record.depth}{record.name}"
+            lines.append(
+                f"{index:>3}  {name_col:<43} {record.duration_s:>9.4f}s "
+                f"{record.self_duration_s:>9.4f}s {inclusive_pct:>6.1f}% {self_pct:>6.1f}%"
+            )
+
+        lines.append("-" * 96)
+        sorted_records = sorted(
+            (record for record in self._records if record.duration_s >= threshold_s),
+            key=lambda record: record.duration_s,
+            reverse=True,
+        )
+        top_n = min(10, len(sorted_records))
+        if top_n > 0:
+            lines.append(f"Top {top_n} Slowest Passes by Inclusive Time:")
+            for rank, record in enumerate(sorted_records[:top_n], 1):
+                inclusive_pct = (record.duration_s / total * 100) if total > 0 else 0
+                lines.append(f"  {rank:>2}. {record.name:<45} {record.duration_s:>9.4f}s {inclusive_pct:>5.1f}%")
+
+        if skipped > 0:
+            lines.append(f"\n({skipped} passes skipped - under {self._threshold_ms:.1f}ms inclusive threshold)")
+
+        lines.append("=" * 96)
+        return "\n".join(lines)
+
+    def print_report(self, context: str | None = None):
+        """Print the timing report to the logger."""
+        logger.info("\n%s", self.report(context=context))
+
+
+def build_pass_instruments(
+    base_instruments: Sequence[object], threshold_ms: float | None
+) -> tuple[list[object], TileLangPassTimingInstrument | None]:
+    """Build instruments with timing first so later after-pass callbacks are excluded."""
+    instruments = list(base_instruments)
+    if threshold_ms is None:
+        return instruments, None
+
+    timing_instrument = TileLangPassTimingInstrument(threshold_ms=threshold_ms)
+    instruments.insert(0, timing_instrument.instrument)
+    return instruments, timing_instrument
+
+
+@contextmanager
+def report_pass_timing_on_exit(timing_instrument: TileLangPassTimingInstrument | None, context: str) -> Iterator[None]:
+    """Emit a timing report after PassContext exits, including on failure."""
+    try:
+        yield
+    finally:
+        if timing_instrument is not None:
+            timing_instrument.print_report(context=context)


### PR DESCRIPTION
  Summary

  - Add compiler pass timing enabled through environment variables or PassConfig.
  - Report inclusive/self time, threshold filtering, Top-N passes, and compilation phase context.
  - Support regular JIT and grouped compilation, including failure-path reporting.

  Why not reuse TVM's PassTimingInstrument?

  1. **Data persistence**: TVM clears profiling data in `ExitPassContext`, so `render()` must be called
  inside the `with PassContext` block.
  2. **Custom output**: TileLang needs custom sorting, threshold filtering, Top-N reporting, and phase
  grouping.
  3. **Extensibility**: This can later include IR size statistics, skipped-pass counts, and other metrics.

  Example

```
2026-07-12 02:31:39  [TileLang:tilelang.pass_timing:INFO] (pass_timing.py:219): 
================================================================================================
TileLang Pass Timing Report
Context: stage=jit-lower, kernel=matmul, backend=cython
================================================================================================
Total: 0.1970s (55 passes)
------------------------------------------------------------------------------------------------
  #  Pass Name                                    Inclusive       Self   Incl %  Self %
------------------------------------------------------------------------------------------------
  1  pass_fn                                        0.0002s    0.0002s    0.1%    0.1%
  2  pass_fn                                        0.0004s    0.0004s    0.2%    0.2%
  3  tirx.BindTarget                                0.0011s    0.0011s    0.6%    0.6%
  4  tl.MaterializeKernelLaunch                     0.0001s    0.0001s    0.0%    0.0%
  5  pass_fn                                        0.0008s    0.0008s    0.4%    0.4%
  6  tl.LegalizeNegativeIndex                       0.0030s    0.0030s    1.5%    1.5%
  7  tl.VerifyParallelLoop                          0.0001s    0.0001s    0.0%    0.0%
  8  tl.InjectAssumes                               0.0001s    0.0001s    0.1%    0.1%
  9  tl.Simplify                                    0.0048s    0.0048s    2.4%    2.4%
 10  tl.LayoutReducer                               0.0016s    0.0016s    0.8%    0.8%
 11  tl.IfStmtBinding                               0.0001s    0.0001s    0.0%    0.0%
 12  tl.Simplify                                    0.0042s    0.0042s    2.1%    2.1%
 13  tl.LayoutInference                             0.0114s    0.0114s    5.8%    5.8%
 14  tl.LowerTileOp                                 0.0448s    0.0448s   22.7%   22.7%
 15  pass_fn                                        0.0011s    0.0011s    0.6%    0.6%
 16  tl.LegalizeVectorizedLoop                      0.0207s    0.0207s   10.5%   10.5%
 17  tl.LegalizeSafeMemoryAccess                    0.0056s    0.0056s    2.9%    2.9%
 18  tl.LowerAccessPtr                              0.0000s    0.0000s    0.0%    0.0%
 19  tl.Simplify                                    0.0080s    0.0080s    4.1%    4.1%
 20  tl.HoistNonRestrictParams                      0.0000s    0.0000s    0.0%    0.0%
 21  tl.PlanAndUpdateBufferAllocationLocation       0.0014s    0.0014s    0.7%    0.7%
 22  tl.HoistGlobalBufferAllocations                0.0000s    0.0000s    0.0%    0.0%
 23  tl.LowerOpaqueBlock                            0.0002s    0.0002s    0.1%    0.1%
 24  tl.Simplify                                    0.0063s    0.0063s    3.2%    3.2%
 25  tirx.NarrowDataType                            0.0019s    0.0019s    1.0%    1.0%
 26  tl.FlattenBuffer                               0.0053s    0.0053s    2.7%    2.7%
 27  tl.ConfigIndexBitwidth                         0.0025s    0.0025s    1.3%    1.3%
 28  tirx.Simplify                                  0.0060s    0.0060s    3.1%    3.1%
 29  tl.VectorizeLoop                               0.0001s    0.0001s    0.1%    0.1%
 30  tir.StorageRewrite                             0.0004s    0.0004s    0.2%    0.2%
 31  tl.LoopUnswitching                             0.0001s    0.0001s    0.0%    0.0%
 32  tl.UnrollLoop                                  0.0001s    0.0001s    0.1%    0.1%
 33  s_tir.RenormalizeSplitPattern                  0.0042s    0.0042s    2.1%    2.1%
 34  tirx.Simplify                                  0.0048s    0.0048s    2.5%    2.5%
 35  tirx.RemoveNoOp                                0.0027s    0.0027s    1.4%    1.4%
 36  s_tir.HoistIfThenElse                          0.0093s    0.0000s    4.7%    0.0%
 37    s_tir.InsertHoistIfThenElse                  0.0020s    0.0020s    1.0%    1.0%
 38    tirx.Simplify                                0.0047s    0.0047s    2.4%    2.4%
 39    tirx.RemoveNoOp                              0.0026s    0.0026s    1.3%    1.3%
 40  tirx.VerifyMemory                              0.0000s    0.0000s    0.0%    0.0%
 41  tirx.AnnotateEntryFunc                         0.0000s    0.0000s    0.0%    0.0%
 42  s_tir.InferFragment                            0.0000s    0.0000s    0.0%    0.0%
 43  tl.AnnotateDeviceRegions                       0.0000s    0.0000s    0.0%    0.0%
 44  tl.SplitHostDevice                             0.0008s    0.0006s    0.4%    0.3%
 45    tirx.ConvertSSA                              0.0001s    0.0001s    0.1%    0.1%
 46  tl.AnnotateReadOnlyParams                      0.0001s    0.0001s    0.0%    0.0%
 47  tl.MergeIfStmt                                 0.0001s    0.0001s    0.0%    0.0%
 48  tl.MakePackedAPI                               0.0105s    0.0105s    5.3%    5.3%
 49  tl.Simplify                                    0.0242s    0.0242s   12.3%   12.3%
 50  tl.LowerDeviceKernelLaunch                     0.0003s    0.0003s    0.1%    0.1%
 51  tirx.Filter                                    0.0001s    0.0001s    0.0%    0.0%
 52  tirx.Filter                                    0.0000s    0.0000s    0.0%    0.0%
 53  tl.LowerIntrin                                 0.0020s    0.0020s    1.0%    1.0%
 54  tirx.Simplify                                  0.0045s    0.0045s    2.3%    2.3%
 55  pass_fn                                        0.0006s    0.0006s    0.3%    0.3%
------------------------------------------------------------------------------------------------
Top 10 Slowest Passes by Inclusive Time:
   1. tl.LowerTileOp                                   0.0448s  22.7%
   2. tl.Simplify                                      0.0242s  12.3%
   3. tl.LegalizeVectorizedLoop                        0.0207s  10.5%
   4. tl.LayoutInference                               0.0114s   5.8%
   5. tl.MakePackedAPI                                 0.0105s   5.3%
   6. s_tir.HoistIfThenElse                            0.0093s   4.7%
   7. tl.Simplify                                      0.0080s   4.1%
   8. tl.Simplify                                      0.0063s   3.2%
   9. tirx.Simplify                                    0.0060s   3.1%
  10. tl.LegalizeSafeMemoryAccess                      0.0056s   2.9%
================================================================================================
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds configurable compiler pass-timing profiling for regular JIT and grouped compilation.

## Highlights

- Records inclusive and self pass durations with nested-pass tracking.
- Supports threshold filtering, contextual reports, and failure-path reporting.
- Enables profiling through environment variables or `PassConfig`.
- Adds profiling to lowering, host, and device compilation phases.
- Exposes timing records and instrumentation through `tilelang.utils`.
- Adds environment parsing, configuration keys, and comprehensive timing tests.

## C++ style / lint notes

- Touches C++ registration and declarations in `src/op/builtin.cc` and `src/op/builtin.h`.
- No changes are indicated for rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) may report advisory findings; these should remain separate from correctness, build, and test issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->