### PR TITLE
[CUDA] Support fp32x2 ops as reducers

### DIFF
--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -94,8 +94,10 @@ inline uint64_t UnsignedMax(int bits) {
   return (static_cast<uint64_t>(1) << bits) - 1;
 }
 
-inline int GetPreferedVectorizedSize(DataType dt) {
-  if (dt.is_bfloat16() || dt.is_float16())
+inline int GetPreferedVectorizedSize(DataType dt,
+                                     bool supports_fp32x2 = false) {
+  if (dt.is_bfloat16() || dt.is_float16() ||
+      (supports_fp32x2 && dt.is_float() && dt.bits() == 32))
     return 2;
   return 1;
 }
@@ -159,9 +161,10 @@ inline PrimExpr MakeReduce(const ReduceOpNode &op, int vsize,
     rhs = Cast(acc->dtype, rhs);
   }
 
+  const bool use_nan_op = op.nan_propagate && (acc.dtype().is_float16() ||
+                                               acc.dtype().is_bfloat16());
+
   if (vsize == 1) {
-    const bool use_nan_op = op.nan_propagate && (acc.dtype().is_float16() ||
-                                                 acc.dtype().is_bfloat16());
     if (op.type->IsSum()) {
       return acc + rhs;
     } else if (op.type->IsAbsSum()) {
@@ -193,13 +196,13 @@ inline PrimExpr MakeReduce(const ReduceOpNode &op, int vsize,
     return Call(acc.dtype(), tl::add2(),
                 {acc, Call(acc.dtype(), tl::abs2(), {rhs})});
   } else if (op.type->IsMax()) {
-    return Call(acc.dtype(), op.nan_propagate ? tl::max2_nan() : tl::max2(),
+    return Call(acc.dtype(), use_nan_op ? tl::max2_nan() : tl::max2(),
                 {acc, rhs});
   } else if (op.type->IsMin()) {
-    return Call(acc.dtype(), op.nan_propagate ? tl::min2_nan() : tl::min2(),
+    return Call(acc.dtype(), use_nan_op ? tl::min2_nan() : tl::min2(),
                 {acc, rhs});
   } else if (op.type->IsAbsMax()) {
-    return Call(acc.dtype(), op.nan_propagate ? tl::max2_nan() : tl::max2(),
+    return Call(acc.dtype(), use_nan_op ? tl::max2_nan() : tl::max2(),
                 {acc, Call(acc.dtype(), tl::abs2(), {rhs})});
   }
   LOG(FATAL) << "Unsupported packed reduce type: " << op.type->type;
@@ -239,6 +242,8 @@ inline std::optional<std::string> MakeCodegenReducer(const ReduceOpNode &op,
   }
 
   if (vsize == 2) {
+    if (op.dst->dtype.is_float() && op.dst->dtype.bits() == 32)
+      return base + "_f32x2";
     if (op.dst->dtype.is_bfloat16())
       return base + "_bf16x2";
     if (op.dst->dtype.is_float16())

--- a/src/cuda/op/reduce.cc
+++ b/src/cuda/op/reduce.cc
@@ -25,7 +25,8 @@ struct Reduce : backend::ReduceLowerer<Reduce> {
     if (!TargetIsCuda(target)) {
       return 1;
     }
-    return backend::reduce::GetPreferedVectorizedSize(dt);
+    bool supports_fp32x2 = TargetHasSMVersionGE(target, 100);
+    return backend::reduce::GetPreferedVectorizedSize(dt, supports_fp32x2);
   }
 
   static std::string MakeBatchAllReduce(std::string reducer,

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -821,7 +821,21 @@ TL_DEVICE __half2 add2(__half2 a, __half2 b) {
 // --- sub2 ----------------------------------------------------------------
 
 TL_DEVICE float2 sub2(float2 a, float2 b) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000) &&                       \
+    ((__CUDACC_VER_MAJOR__ > 12) ||                                            \
+     (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 8))
+  unsigned long long const &a_bits =
+      reinterpret_cast<unsigned long long const &>(a);
+  unsigned long long const &b_bits =
+      reinterpret_cast<unsigned long long const &>(b);
+  unsigned long long result_bits;
+  asm("sub.rn.f32x2 %0, %1, %2;"
+      : "=l"(result_bits)
+      : "l"(a_bits), "l"(b_bits));
+  return reinterpret_cast<float2 const &>(result_bits);
+#else
   return make_float2(a.x - b.x, a.y - b.y);
+#endif
 }
 
 TL_DEVICE __nv_bfloat162 sub2(__nv_bfloat162 a, __nv_bfloat162 b) {
@@ -1134,6 +1148,35 @@ template <> TL_DEVICE uint1 shfl_up_sync(unsigned mask, uint1 val, int delta) {
 
 template <> TL_DEVICE uint1 shfl_sync(unsigned mask, uint1 val, int srcLane) {
   return uint1{__shfl_sync(mask, val.x, srcLane)};
+}
+
+// Specializations for float2. CUDA has no shuffle overload for float2, so
+// shuffle its two lanes together through the 64-bit integer overload.
+template <>
+TL_DEVICE float2 shfl_xor_sync(unsigned mask, float2 val, int laneMask) {
+  unsigned long long raw = reinterpret_cast<unsigned long long const &>(val);
+  raw = __shfl_xor_sync(mask, raw, laneMask);
+  return reinterpret_cast<float2 const &>(raw);
+}
+
+template <>
+TL_DEVICE float2 shfl_down_sync(unsigned mask, float2 val, int delta) {
+  unsigned long long raw = reinterpret_cast<unsigned long long const &>(val);
+  raw = __shfl_down_sync(mask, raw, delta);
+  return reinterpret_cast<float2 const &>(raw);
+}
+
+template <>
+TL_DEVICE float2 shfl_up_sync(unsigned mask, float2 val, int delta) {
+  unsigned long long raw = reinterpret_cast<unsigned long long const &>(val);
+  raw = __shfl_up_sync(mask, raw, delta);
+  return reinterpret_cast<float2 const &>(raw);
+}
+
+template <> TL_DEVICE float2 shfl_sync(unsigned mask, float2 val, int srcLane) {
+  unsigned long long raw = reinterpret_cast<unsigned long long const &>(val);
+  raw = __shfl_sync(mask, raw, srcLane);
+  return reinterpret_cast<float2 const &>(raw);
 }
 
 } // namespace tl

--- a/src/tl_templates/cuda/reduce.h
+++ b/src/tl_templates/cuda/reduce.h
@@ -158,6 +158,24 @@ struct MinOpNan_fp16x2 {
   }
 };
 
+struct SumOp_f32x2 {
+  TL_DEVICE float2 operator()(float2 const &x, float2 const &y) {
+    return tl::add2(x, y);
+  }
+};
+
+struct MaxOp_f32x2 {
+  TL_DEVICE float2 operator()(float2 const &x, float2 const &y) {
+    return tl::max2(x, y);
+  }
+};
+
+struct MinOp_f32x2 {
+  TL_DEVICE float2 operator()(float2 const &x, float2 const &y) {
+    return tl::min2(x, y);
+  }
+};
+
 struct BitAndOp {
   template <typename T> TL_DEVICE T operator()(T const &x, T const &y) {
     return x & y;

--- a/testing/python/cuda/test_cuda_f32x2_intrinsics.py
+++ b/testing/python/cuda/test_cuda_f32x2_intrinsics.py
@@ -140,6 +140,45 @@ def _make_auto_vec_fma_kernel(dtype_tl, width: int = 4):
     return main
 
 
+def _make_auto_vec_reduce_kernel(reduce_func, *, nan_propagate=False):
+    """Build a row reduction whose local fragment is contiguous per thread."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, 128), dtype=T.float32),
+        C: T.Tensor((M,), dtype=T.float32),
+    ):
+        with T.Kernel(1, 1, threads=M) as (bx, by):
+            src = T.alloc_fragment((M, 128), T.float32)
+            dst = T.alloc_fragment((M,), T.float32)
+            T.copy(A, src)
+            if nan_propagate:
+                reduce_func(src, dst, dim=1, nan_propagate=True)
+            else:
+                reduce_func(src, dst, dim=1)
+            T.copy(dst, C)
+
+    return main
+
+
+def _make_auto_vec_batched_reduce_kernel(reduce_func, *, rows=M, width=64, threads=256):
+    """Build a reduction that shuffles packed values between threads."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((rows, width), dtype=T.float32),
+        C: T.Tensor((rows,), dtype=T.float32),
+    ):
+        with T.Kernel(1, threads=threads):
+            src = T.alloc_shared((rows, width), T.float32)
+            dst = T.alloc_fragment((rows,), T.float32)
+            T.copy(A, src, disable_tma=True)
+            reduce_func(src, dst, dim=1, batch=2)
+            T.copy(dst, C)
+
+    return main
+
+
 # ===================================================================
 # Parametrised op / dtype lists
 # ===================================================================
@@ -169,6 +208,28 @@ _TORCH_REFS = {
     "fma2": lambda a, b, c: a * b + c,
     "abs2": lambda a: torch.abs(a),
 }
+
+_REDUCE_OPS = [
+    ("sum", T.reduce_sum, ("add2",)),
+    ("abssum", T.reduce_abssum, ("add2", "abs2")),
+    ("max", T.reduce_max, ("max2",)),
+    ("min", T.reduce_min, ("min2",)),
+    ("absmax", T.reduce_absmax, ("max2", "abs2")),
+]
+
+
+def _torch_reduce(a, op_name):
+    if op_name == "sum":
+        return torch.sum(a, dim=1)
+    if op_name == "abssum":
+        return torch.sum(torch.abs(a), dim=1)
+    if op_name == "max":
+        return torch.max(a, dim=1).values
+    if op_name == "min":
+        return torch.min(a, dim=1).values
+    if op_name == "absmax":
+        return torch.max(torch.abs(a), dim=1).values
+    raise ValueError(f"Unsupported reduction: {op_name}")
 
 
 # ===================================================================
@@ -264,6 +325,36 @@ def test_codegen_auto_vec_fma_f32():
 
 
 @tilelang.testing.requires_cuda
+@pytest.mark.parametrize("op_name,reduce_func,packed_ops", _REDUCE_OPS, ids=[op[0] for op in _REDUCE_OPS])
+def test_codegen_auto_vec_reduce_f32_sm100(op_name, reduce_func, packed_ops):
+    func = _make_auto_vec_reduce_kernel(reduce_func)
+    src = _lower_to_cuda_source(func, target=SM100_TARGET)
+    for packed_op in packed_ops:
+        assert f"tl::{packed_op}" in src, f"Expected tl::{packed_op} in SM100 float32 {op_name} reduction"
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("op_name,reduce_func,packed_ops", _REDUCE_OPS, ids=[op[0] for op in _REDUCE_OPS])
+def test_codegen_auto_vec_reduce_f32_no_sm80(op_name, reduce_func, packed_ops):
+    func = _make_auto_vec_reduce_kernel(reduce_func)
+    src = _lower_to_cuda_source(func, target=SM80_TARGET)
+    for packed_op in packed_ops:
+        assert f"tl::{packed_op}" not in src, f"tl::{packed_op} should not appear in pre-SM100 float32 {op_name} reduction"
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize(
+    "reduce_func,packed_op",
+    [(T.reduce_max, "max2"), (T.reduce_min, "min2"), (T.reduce_absmax, "max2")],
+)
+def test_codegen_auto_vec_reduce_f32_ignores_half_nan_mode(reduce_func, packed_op):
+    func = _make_auto_vec_reduce_kernel(reduce_func, nan_propagate=True)
+    src = _lower_to_cuda_source(func, target=SM100_TARGET)
+    assert f"tl::{packed_op}" in src
+    assert f"tl::{packed_op}_nan" not in src
+
+
+@tilelang.testing.requires_cuda
 @pytest.mark.parametrize("dtype_name", ["bfloat16", "float16"])
 def test_codegen_auto_vec_fma_half_types(dtype_name):
     dtype_tl, _ = _DTYPE_MAP[dtype_name]
@@ -329,6 +420,28 @@ def test_correctness_fma2(dtype_name):
         torch.testing.assert_close(d, ref)
     else:
         torch.testing.assert_close(d, ref, atol=1e-2, rtol=1e-1)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@pytest.mark.parametrize("op_name,reduce_func", [(op_name, reduce_func) for op_name, reduce_func, _ in _REDUCE_OPS])
+def test_correctness_auto_vec_reduce_f32(op_name, reduce_func):
+    func = _make_auto_vec_reduce_kernel(reduce_func)
+    kernel = tilelang.compile(func, out_idx=[1], target="cuda")
+    a = torch.randn((M, 128), device="cuda", dtype=torch.float32)
+    result = kernel(a)
+    reference = _torch_reduce(a, op_name)
+    torch.testing.assert_close(result, reference, atol=1e-5, rtol=1e-5)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+def test_correctness_auto_vec_batched_reduce_f32():
+    func = _make_auto_vec_batched_reduce_kernel(T.reduce_sum)
+    kernel = tilelang.compile(func, out_idx=[1], target="cuda")
+    a = torch.randn((M, 64), device="cuda", dtype=torch.float32)
+    result = kernel(a)
+    torch.testing.assert_close(result, torch.sum(a, dim=1), atol=1e-5, rtol=1e-5)
 
 
 @tilelang.testing.requires_cuda


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added optional FP32x2 vectorization for CUDA reductions on SM100+ targets.
- Added float2 reduction functors, shuffle specializations, and optimized `sub.rn.f32x2` support.
- Updated packed reduction code generation and NaN handling for float32 accumulators.
- Added codegen and correctness tests for SM100, pre-SM100, batched, and NaN-propagation cases.

## C++ style / lint notes

The PR changes C++ code but does not appear to modify documented rules in `docs/developer_guide/cpp_style.md`. The C++ API Style Audit (warning only) may report advisory findings in the new overloads/functors; these are warning-only and should not block merging absent a clear API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->