### PR TITLE
fix: cast ptxas register usage level to int before building the nvcc command

### DIFF
--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -144,7 +144,7 @@ def tilelang_callback_cuda_compile(code, target, pass_config=None):
     if enable_fast_math:
         options.append("--use_fast_math")
     if ptxas_usage_level is not None:
-        options.append(f"--ptxas-options=--register-usage-level={ptxas_usage_level}")
+        options.append(f"--ptxas-options=--register-usage-level={int(ptxas_usage_level)}")
     if verbose:
         options.append("--ptxas-options=--verbose")
         options.append("-w")  # Suppress warnings to make ptxas output more readable

--- a/tilelang/jit/adapter/libgen.py
+++ b/tilelang/jit/adapter/libgen.py
@@ -111,7 +111,7 @@ class LibraryGenerator:
             if enable_fast_math:
                 command += ["--use_fast_math"]
             if ptxas_usage_level is not None:
-                command += [f"--ptxas-options=--register-usage-level={ptxas_usage_level}"]
+                command += [f"--ptxas-options=--register-usage-level={int(ptxas_usage_level)}"]
             if self.verbose:
                 command += ["--ptxas-options=--verbose"]
             command += [


### PR DESCRIPTION
Fixes #2640.

`cfg.get(PassConfigKey.TL_PTXAS_REGISTER_USAGE_LEVEL)` returns a TVM `IntImm`; its `str()` is the full repr (`ir.IntImm(span=None, dtype=int32, value=10)`), so both call sites emit

```
--ptxas-options=--register-usage-level=ir.IntImm(span=None, dtype=int32, value=10)
```

and nvcc's shell invocation dies with `sh: 1: Syntax error: "(" unexpected`. Any kernel carrying this pass config fails to compile; callers with a fallback fail silently.

Cast to `int(...)` at both sites (`IntImm.__int__` exists, and a plain Python int passes through unchanged).

Verified on sm_120 / CUDA 13.1: kernels with `TL_PTXAS_REGISTER_USAGE_LEVEL: 10` (sglang's DeepSeek-V4 MHC kernels) compile and produce numerically identical output to their torch reference after this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Cast `TL_PTXAS_REGISTER_USAGE_LEVEL` to `int` when constructing NVCC commands in:
  - `tilelang/engine/lower.py`
  - `tilelang/jit/adapter/libgen.py`
- Supports both TVM `IntImm` values and Python integers, preventing invalid shell syntax in NVCC commands.

## Testing

- Verified successful compilation on sm_120 with CUDA 13.1.
- Confirmed numerically identical kernel output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->