### PR TITLE
[BugFix] Fix 1D bulk TMA transfer alignment check

### DIFF
--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -2349,6 +2349,18 @@ Stmt Copy::LowerBulk1D(const CopyNode &op, const LowerArgs &lower_args,
   Stmt tma_copy;
   PrimExpr total_bytes =
       TMATransactionBytesFromElements(elements, shared_tensor->dtype);
+
+  // Safety net: instruction selection (CheckBulkCopy1D) must not route a
+  // provably misaligned transfer here. Symbolic sizes cannot be proven
+  // either way and are allowed through, matching the selection logic.
+  ICHECK(!analyzer->CanProve(
+      FloorMod(total_bytes, make_const(total_bytes.dtype(), 16)) !=
+          make_const(total_bytes.dtype(), 0),
+      arith::ProofStrength::kSymbolicBound))
+      << "BulkCopy1D requires total_bytes to be 16-byte aligned, but got "
+         "invalid size.\n"
+      << "  Total_bytes = " << total_bytes << "\n";
+
   if (is_load) {
     PrimExpr mbar_arg = barrier_base_id >= 0 ? mbar_handle : PrimExpr(0);
     tma_copy = Evaluate(Call(DataType::Handle(), tma_load(),

--- a/src/cuda/op/copy_analysis.cc
+++ b/src/cuda/op/copy_analysis.cc
@@ -300,13 +300,25 @@ bool CheckBulkCopy1D(const Buffer &global_tensor, const Buffer &shared_tensor,
   for (size_t i = 0; i < shared_range.size(); i++) {
     shared_elements *= shared_range[i]->extent;
   }
+
   PrimExpr global_elements = 1;
   for (size_t i = 0; i < global_range.size(); i++) {
     global_elements *= global_range[i]->extent;
   }
+
   bool element_match =
       analyzer->CanProveEqual(shared_elements, global_elements);
-  return shared_is_contiguous && global_is_contiguous && element_match;
+
+  PrimExpr total_bits = shared_elements * shared_tensor->dtype.bits();
+
+  // Reject only when the total transfer size is provably not 16-byte
+  // aligned (e.g. constant shapes like 63 x fp32). Symbolic shapes stay on
+  // the 1D TMA path, consistent with the last-dim check in CheckBulkLoad.
+  bool total_16b_aligned = !analyzer->CanProve(
+      FloorMod(total_bits, 128) != 0, arith::ProofStrength::kSymbolicBound);
+
+  return shared_is_contiguous && global_is_contiguous && element_match &&
+         total_16b_aligned;
 }
 
 bool CheckBulkLoad1D(const CopyNode &op, Target target,


### PR DESCRIPTION
## Summary

Fix the 1-D bulk TMA copy eligibility check to require the total transfer size to be a multiple of 16 bytes.

Unaligned transfers now fall back to the non-TMA copy path, while aligned transfers continue to use bulk TMA.

A defensive `ICHECK` was also added in `LowerBulk1D` to prevent future callers from emitting an invalid transfer size.

Fixes #2525

## Testing

* `N=63`, `float32`: falls back to the non-TMA path and produces the correct result
* `N=64`, `float32`: continues to use TMA and produces the correct result

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary
- Tightened 1-D global↔shared bulk TMA eligibility so it now additionally requires the transferred payload size to be provably 16-byte aligned when this can be determined.
- Added a defensive runtime check during 1-D bulk lowering to fatally reject invalid or unprovably aligned `total_bytes`, including the computed size in the error.

## C++ style / lint notes
- No documentation or public API changes; existing C++ style/lint audit steps remain applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->