### PR TITLE
[BugFix][Transform] Never classify side-effecting binds as replayable (atomics re-executed at every use site since v0.1.11)

### DIFF
--- a/examples/deepseek_v32/topk_selector.py
+++ b/examples/deepseek_v32/topk_selector.py
@@ -212,6 +212,10 @@ def test_topk_selector(batch=64, seq_len=32 * 1024, topk=2048):
         set_trt = set(trt_np)
         intersection = set_ref & set_trt
         print("selected/all:", len(intersection), "/", len(set_ref), "=", len(intersection) / len(set_ref))
+        recall = len(intersection) / len(set_ref)
+        # Exact top-k selection modulo float ties at the threshold boundary.
+        # Miscompiled builds (duplicated atomic return value) drop to ~0.98.
+        assert recall >= 0.999, f"row {i}: top-{topk} recall too low: {recall:.4f}"
 
     # Performance test with CUDA events
 

--- a/examples/deepseek_v32/topk_selector.py
+++ b/examples/deepseek_v32/topk_selector.py
@@ -212,10 +212,6 @@ def test_topk_selector(batch=64, seq_len=32 * 1024, topk=2048):
         set_trt = set(trt_np)
         intersection = set_ref & set_trt
         print("selected/all:", len(intersection), "/", len(set_ref), "=", len(intersection) / len(set_ref))
-        recall = len(intersection) / len(set_ref)
-        # Exact top-k selection modulo float ties at the threshold boundary.
-        # Miscompiled builds (duplicated atomic return value) drop to ~0.98.
-        assert recall >= 0.999, f"row {i}: top-{topk} recall too low: {recall:.4f}"
 
     # Performance test with CUDA events
 

--- a/src/op/operator.h
+++ b/src/op/operator.h
@@ -48,6 +48,15 @@ enum AccessMask : int {
   kAccessReadWrite = kAccessRead | kAccessWrite,
 };
 
+// Preserve known read/write bits and conservatively assume both when a mask
+// cannot be resolved at compile time.
+inline int GetConservativeAccessMask(const PrimExpr &rw_mask) {
+  if (const auto *mask = rw_mask.as<IntImmNode>()) {
+    return static_cast<int>(mask->value) & kAccessReadWrite;
+  }
+  return kAccessReadWrite;
+}
+
 struct AccessRegion {
   tirx::BufferRegion region;
   int access_mask{kAccessReadWrite};

--- a/src/transform/common/bind_utils.h
+++ b/src/transform/common/bind_utils.h
@@ -6,6 +6,7 @@
 #define TVM_TL_TRANSFORM_COMMON_BIND_UTILS_H_
 
 #include <tvm/ir/type.h>
+#include <tvm/tirx/analysis.h>
 #include <tvm/tirx/stmt.h>
 
 #include <unordered_set>
@@ -30,6 +31,14 @@ inline bool IsReplayableScalarBind(const Stmt &stmt,
     return false;
   }
   if (!bind->value.dtype().is_scalar() || bind->value.dtype().is_handle()) {
+    return false;
+  }
+  // A bind value that carries a side effect (e.g. an atomic RMW returning the
+  // previous value, or any opaque call) must be materialized exactly once:
+  // replaying it at every use site re-executes the side effect and silently
+  // corrupts results. Pure and read-only values remain replayable; read
+  // consistency is guaranteed by the read/write disjointness check below.
+  if (SideEffect(bind->value) > CallEffectKind::kReadState) {
     return false;
   }
   for (const BufferRegion &read : reads) {

--- a/src/transform/if_stmt_binding.cc
+++ b/src/transform/if_stmt_binding.cc
@@ -59,6 +59,15 @@ private:
       writes_.push_back(BufferRegion::FullRegion(buffer));
     }
 
+    void AddAccess(const Buffer &buffer, int access_mask) {
+      if (access_mask & kAccessRead) {
+        AddRead(buffer);
+      }
+      if (access_mask & kAccessWrite) {
+        AddWrite(buffer);
+      }
+    }
+
     void VisitStmt_(const BufferStoreNode *op) final {
       AddWrite(op->buffer);
       StmtExprVisitor::VisitStmt_(op);
@@ -91,12 +100,29 @@ private:
             AddRead((*it).second);
           }
         }
+      } else if (op->op.same_as(tl::access_ptr())) {
+        ICHECK_EQ(op->args.size(), 3U);
+        const auto *load = op->args[0].as<BufferLoadNode>();
+        ICHECK(load) << "tl.access_ptr base must be a BufferLoad";
+        AddAccess(load->buffer, GetConservativeAccessMask(op->args[2]));
+        for (const PrimExpr &index : load->indices) {
+          this->VisitExpr(index);
+        }
+        if (load->predicate.defined()) {
+          this->VisitExpr(load->predicate.value());
+        }
+        this->VisitExpr(op->args[1]);
+        this->VisitExpr(op->args[2]);
+        return;
       } else if (op->op.same_as(builtin::tvm_access_ptr())) {
         if (op->args.size() > 1) {
           if (const auto *var_node = op->args[1].as<VarNode>()) {
             auto it = buffer_data_to_buffer_.find(GetRef<Var>(var_node));
             if (it != buffer_data_to_buffer_.end()) {
-              AddRead((*it).second);
+              const int access_mask =
+                  op->args.size() == 5U ? GetConservativeAccessMask(op->args[4])
+                                        : kAccessReadWrite;
+              AddAccess((*it).second, access_mask);
             }
           }
         }

--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -3412,20 +3412,30 @@ private:
         }
       }
     }
-    BufferSet pipeline_write_buffers;
-    if (!replayable_bind_mask.defined()) {
-      pipeline_write_buffers = CollectPipelineWriteBuffers(original_order);
-    }
+    BufferSet pipeline_write_buffers =
+        CollectPipelineWriteBuffers(original_order);
     Array<SBlock> scalar_binding_blocks;
     Array<SBlock> scheduled_order;
     std::vector<char> is_replayable_bind;
     is_replayable_bind.reserve(original_order.size());
     for (size_t i = 0; i < original_order.size(); ++i) {
       const SBlock &block = original_order[i];
-      bool replayable =
-          replayable_bind_mask.defined()
-              ? !is_zero(replayable_bind_mask.value()[i])
-              : IsReplayableScalarBindBlock(block, pipeline_write_buffers);
+      const bool semantically_replayable =
+          IsReplayableScalarBindBlock(block, pipeline_write_buffers);
+      bool replayable = semantically_replayable;
+      if (replayable_bind_mask.defined()) {
+        replayable = !is_zero(replayable_bind_mask.value()[i]);
+        if (replayable && !semantically_replayable) {
+          const auto *bind = block->body.as<BindNode>();
+          ICHECK(bind != nullptr);
+          LOG(FATAL) << "PrimFunc " << global_symbol_ << " marks scalar Bind '"
+                     << bind->var << "' as replayable via "
+                     << kPipelineReplayableScalarBinds
+                     << ", but the Bind has an unsupported type, has side "
+                        "effects, or reads a buffer written by the pipeline "
+                        "and cannot be replayed safely";
+        }
+      }
       is_replayable_bind.push_back(replayable ? 1 : 0);
       if (replayable) {
         scalar_binding_blocks.push_back(block);

--- a/src/transform/pipeline_planning.cc
+++ b/src/transform/pipeline_planning.cc
@@ -206,6 +206,27 @@ void BufferRegionCollector::VisitExpr_(const CallNode *op) {
       // because we only care about the buffer itself instead of indices
       reads_.push_back(buffer_region);
     }
+  } else if (op->op.same_as(tl::access_ptr())) {
+    ICHECK_EQ(op->args.size(), 3U);
+    const auto *load = op->args[0].as<BufferLoadNode>();
+    ICHECK(load) << "tl.access_ptr base must be a BufferLoad";
+    const BufferRegion buffer_region = BufferRegion::FullRegion(load->buffer);
+    const int access_mask = GetConservativeAccessMask(op->args[2]);
+    // because we only care about the buffer itself instead of indices
+    if (access_mask & kAccessRead) {
+      reads_.push_back(buffer_region);
+    }
+    if (access_mask & kAccessWrite) {
+      writes_.push_back(buffer_region);
+    }
+    for (const PrimExpr &index : load->indices) {
+      this->VisitExpr(index);
+    }
+    if (load->predicate.defined()) {
+      this->VisitExpr(load->predicate.value());
+    }
+    this->VisitExpr(op->args[1]);
+    this->VisitExpr(op->args[2]);
   } else if (op->op.same_as(builtin::tvm_access_ptr())) {
     const VarNode *buffer_var = op->args[1].as<VarNode>();
     ICHECK(buffer_var);
@@ -213,8 +234,19 @@ void BufferRegionCollector::VisitExpr_(const CallNode *op) {
     if (it != buffer_data_to_buffer_.end()) {
       const Buffer &buffer = (*it).second;
       const BufferRegion buffer_region = BufferRegion::FullRegion(buffer);
+      const int access_mask = op->args.size() == 5U
+                                  ? GetConservativeAccessMask(op->args[4])
+                                  : kAccessReadWrite;
       // because we only care about the buffer itself instead of indices
-      reads_.push_back(buffer_region);
+      if (access_mask & kAccessRead) {
+        reads_.push_back(buffer_region);
+      }
+      if (access_mask & kAccessWrite) {
+        writes_.push_back(buffer_region);
+      }
+    }
+    for (size_t i = 2; i < op->args.size(); ++i) {
+      this->VisitExpr(op->args[i]);
     }
   } else if (op->op.same_as(builtin::if_then_else())) {
     within_condition_expr_ = true;

--- a/testing/python/language/test_tilelang_language_atomic.py
+++ b/testing/python/language/test_tilelang_language_atomic.py
@@ -897,5 +897,53 @@ def test_atomic_addx4_return_prev_bf16():
     run_atomic_addx4_return_prev_16bit(T.bfloat16, torch.bfloat16)
 
 
+# ======================= Atomic return value materialization =======================
+
+
+@tilelang.jit
+def atomic_add_return_prev_compaction_program(n, cap, block, dtype=T.float32):
+    @T.prim_func
+    def compact_positive(
+        x: T.Tensor((n,), dtype),
+        out: T.Tensor((cap,), T.int32),
+        counter: T.Tensor((1,), T.int32),
+    ):
+        with T.Kernel(T.ceildiv(n, block), threads=block) as bx:
+            tx = T.get_thread_binding()
+            i = bx * block + tx
+            if i < n and x[i] > 0:
+                # Side-effecting bind: the returned previous counter value is
+                # used at TWO sites (bound check + store index). The lowering
+                # must materialize the atomic exactly once; replaying it per
+                # use site executes the atomic twice per element.
+                pos = T.atomic_add(counter[0], 1, return_prev=True)
+                if pos < cap:
+                    out[pos] = i
+
+    return compact_positive
+
+
+@tilelang.testing.requires_cuda
+def test_atomic_add_return_prev_materialized_once():
+    n, cap, block = 4096, 4096, 256
+    kernel = atomic_add_return_prev_compaction_program(n, cap, block)
+
+    # Static check: the returned atomic must appear exactly once in the
+    # generated CUDA source (regression: duplicated AtomicAddRet calls).
+    assert kernel.get_kernel_source().count("AtomicAddRet") == 1
+
+    # Functional check: with all-positive input the counter must equal n and
+    # out must be a permutation of 0..n-1 (no unwritten slots).
+    x = torch.ones(n, dtype=torch.float32).cuda()
+    out = torch.full((cap,), -1, dtype=torch.int32).cuda()
+    counter = torch.zeros(1, dtype=torch.int32).cuda()
+    kernel(x, out, counter)
+    torch.cuda.synchronize()
+
+    assert counter.item() == n, f"atomic executed {counter.item()} times, expected {n}"
+    assert (out < 0).sum().item() == 0, "unwritten slots: atomic return value was re-evaluated"
+    assert torch.equal(out.sort().values.long(), torch.arange(n).cuda())
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py
+++ b/testing/python/transform/test_tilelang_transform_Inject_software_pipeline.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tilelang import tvm as tvm
 import tilelang as tl
 import tilelang.language as T
@@ -585,6 +587,30 @@ def test_inject_software_pipeline_replays_readonly_bufferload_bind():
     assert all(names[0].startswith("idx") for names in leading_binds["copy"])
     assert all(names[0].startswith("idx") for names in leading_binds["store"])
     assert "idx = T.int32()" not in mod["main"].script()
+
+
+def test_inject_software_pipeline_rejects_side_effecting_replay_mask():
+    @T.prim_func
+    def before(
+        counter: T.Tensor((1,), T.int32),
+        out: T.Tensor((8,), T.int32),
+    ):
+        for i in T.serial(
+            0,
+            4,
+            annotations={
+                "software_pipeline_stage": [0, 1],
+                "software_pipeline_order": [0, 1],
+                "software_pipeline_replayable_scalar_binds": [1, 0, 0],
+            },
+        ):
+            pos: T.int32 = T.atomic_add(counter[0], 1, return_prev=True)
+            out[i * 2] = pos
+            out[i * 2 + 1] = pos
+
+    mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
+    with pytest.raises(tvm.TVMError, match="cannot be replayed safely"):
+        tl.transform.InjectSoftwarePipeline()(mod)
 
 
 def test_inject_software_pipeline_schedules_bind_that_reads_pipeline_buffer():

--- a/testing/python/transform/test_tilelang_transform_if_stmt_binding.py
+++ b/testing/python/transform/test_tilelang_transform_if_stmt_binding.py
@@ -150,5 +150,86 @@ def test_if_stmt_binding_keeps_side_effecting_bind():
     tvm.ir.assert_structural_equal(after.body, expected.body, True)
 
 
+def test_if_stmt_binding_keeps_bind_that_reads_atomic_target():
+    @T.prim_func
+    def before(
+        flag: T.Buffer((2,), "int32"),
+        counter_tvm: T.Buffer((1,), "int32"),
+        counter_tl: T.Buffer((1,), "int32"),
+        out: T.Buffer((4,), "int32"),
+    ):
+        if flag[0] != 0:
+            snapshot_tvm = T.bind(counter_tvm[0])
+            pos_tvm = T.bind(
+                T.call_intrin(
+                    "int32",
+                    tvm.ir.Op.get("tl.atomic_add_ret_elem_op"),
+                    counter_tvm.access_ptr("rw"),
+                    1,
+                )
+            )
+            out[0] = snapshot_tvm
+            out[1] = pos_tvm
+        if flag[1] != 0:
+            snapshot_tl = T.bind(counter_tl[0])
+            pos_tl = T.bind(
+                T.call_intrin(
+                    "int32",
+                    tvm.ir.Op.get("tl.atomic_add_ret_elem_op"),
+                    T.call_intrin(
+                        "handle",
+                        tvm.ir.Op.get("tl.access_ptr"),
+                        counter_tl[0],
+                        1,
+                        3,
+                    ),
+                    1,
+                )
+            )
+            out[2] = snapshot_tl
+            out[3] = pos_tl
+
+    @T.prim_func
+    def expected(
+        flag: T.Buffer((2,), "int32"),
+        counter_tvm: T.Buffer((1,), "int32"),
+        counter_tl: T.Buffer((1,), "int32"),
+        out: T.Buffer((4,), "int32"),
+    ):
+        if flag[0] != 0:
+            snapshot_tvm = T.bind(counter_tvm[0])
+            pos_tvm = T.bind(
+                T.call_intrin(
+                    "int32",
+                    tvm.ir.Op.get("tl.atomic_add_ret_elem_op"),
+                    counter_tvm.access_ptr("rw"),
+                    1,
+                )
+            )
+            out[0] = snapshot_tvm
+            out[1] = pos_tvm
+        if flag[1] != 0:
+            snapshot_tl = T.bind(counter_tl[0])
+            pos_tl = T.bind(
+                T.call_intrin(
+                    "int32",
+                    tvm.ir.Op.get("tl.atomic_add_ret_elem_op"),
+                    T.call_intrin(
+                        "handle",
+                        tvm.ir.Op.get("tl.access_ptr"),
+                        counter_tl[0],
+                        1,
+                        3,
+                    ),
+                    1,
+                )
+            )
+            out[2] = snapshot_tl
+            out[3] = pos_tl
+
+    after = _run_if_stmt_binding(before)
+    tvm.ir.assert_structural_equal(after.body, expected.body, True)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_if_stmt_binding.py
+++ b/testing/python/transform/test_tilelang_transform_if_stmt_binding.py
@@ -109,5 +109,46 @@ def test_if_stmt_binding_can_disable_replayable_bind_inline():
     tvm.ir.assert_structural_equal(after.body, expected.body, True)
 
 
+def test_if_stmt_binding_keeps_side_effecting_bind():
+    """Regression test: a bind whose value carries a side effect (an atomic
+    RMW returning the previous value) must be materialized exactly once.
+
+    Replaying such a bind at every use site re-executes the atomic, which
+    silently corrupts results (e.g. compaction/histogram kernels where the
+    returned slot index is used both in a bound check and as a store index).
+    """
+
+    @T.prim_func
+    def before(A: T.Buffer((4,), "float32"), counter: T.Buffer((1,), "int32"), out: T.Buffer((4,), "int32")):
+        if A[0] >= T.float32(0):
+            pos = T.bind(
+                T.call_intrin(
+                    "int32",
+                    tvm.ir.Op.get("tl.atomic_add_ret_elem_op"),
+                    counter.access_ptr("rw"),
+                    1,
+                )
+            )
+            if pos < 4:
+                out[pos] = 1
+
+    @T.prim_func
+    def expected(A: T.Buffer((4,), "float32"), counter: T.Buffer((1,), "int32"), out: T.Buffer((4,), "int32")):
+        if A[0] >= T.float32(0):
+            pos = T.bind(
+                T.call_intrin(
+                    "int32",
+                    tvm.ir.Op.get("tl.atomic_add_ret_elem_op"),
+                    counter.access_ptr("rw"),
+                    1,
+                )
+            )
+            if pos < 4:
+                out[pos] = 1
+
+    after = _run_if_stmt_binding(before)
+    tvm.ir.assert_structural_equal(after.body, expected.body, True)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_pipeline_planning.py
+++ b/testing/python/transform/test_tilelang_transform_pipeline_planning.py
@@ -796,3 +796,31 @@ def test_pipeline_planning_keeps_bind_that_reads_pipeline_written_buffer():
     assert stages == [0, 1, 1]
     assert orders == [0, 1, 2]
     assert replayable_binds == [1, 0, 0, 0]
+
+
+def test_pipeline_planning_keeps_bind_that_reads_atomic_target():
+    @T.prim_func
+    def before(
+        counter: T.Tensor((1,), T.int32),
+        out: T.Tensor((8,), T.int32),
+    ):
+        for i in T.Pipelined(
+            4,
+            order=[0, 1, 2, 3],
+            stage=[0, 0, 1, 1],
+        ):
+            snapshot: T.int32 = counter[0]
+            pos: T.int32 = T.atomic_add(counter[0], 1, return_prev=True)
+            out[i * 2] = snapshot
+            out[i * 2 + 1] = pos
+
+    mod = _run_pipeline_planning(before, sm80_target)
+    annos = _collect_pipeline_loop_annotations(mod["main"])
+    assert annos, "Expected at least one loop annotated by PipelinePlanning"
+    anno = annos[0]
+    stages = [int(v) for v in anno["software_pipeline_stage"]]
+    orders = [int(v) for v in anno["software_pipeline_order"]]
+
+    assert stages == [0, 0, 1, 1]
+    assert orders == [0, 1, 2, 3]
+    assert "software_pipeline_replayable_scalar_binds" not in anno


### PR DESCRIPTION
### Summary

Since v0.1.11, a scalar bind whose value carries a side effect is dissolved by `tl.IfStmtBinding` and re-evaluated ("replayed") at **every use site**. The canonical victim is the documented usage of `atomic_add(..., return_prev=True)`:

```python
pos = T.atomic_add(counter[0], 1, return_prev=True)
if pos < cap:             # use 1: capacity guard
    out[pos] = i          # use 2: store index
```

The atomic executes once per use site instead of exactly once — silent data corruption for any compaction / histogram / top-k style kernel that uses the returned value more than once. `v0.1.8`–`v0.1.10` compile the same source correctly; the regression is present in `v0.1.11`, `v0.1.12` (PyPI latest) and current `main`.

### Reproduction

Minimal kernel (added as a regression test in this PR):

```python
@tilelang.jit
def compact_positive(n, cap, block, dtype="float32"):
    @T.prim_func
    def compact_kernel(
        x: T.Tensor[(n,), dtype],
        out: T.Tensor[(cap,), "int32"],
        counter: T.Tensor[(1,), "int32"],
    ):
        with T.Kernel(T.ceildiv(n, block), threads=block) as bx:
            tx = T.get_thread_binding()
            i = bx * block + tx
            if i < n and x[i] > 0:
                pos = T.atomic_add(counter[0], 1, return_prev=True)
                if pos < cap:
                    out[pos] = i
    return compact_kernel
```

v0.1.12 / main lower this to CUDA with the atomic inlined into **four** sites (the user's capacity guard, the store index, plus the two out-of-bounds guards that `tl.LegalizeSafeMemoryAccess` later builds by copying the already-inlined index expression):

```cuda
if (AtomicAddRet((&(counter[0])), 1) < 4096) {
  if (0 <= AtomicAddRet((&(counter[0])), 1)) {
    if (AtomicAddRet((&(counter[0])), 1) < 4096) {
      out[AtomicAddRet((&(counter[(int64_t)0])), (int64_t)1)] = i;
```

Functionally (n = cap = 4096, all-positive input; correct result is `counter == 4096` and `out` a permutation of `0..4095`):

| version | `AtomicAddRet` in lowered CUDA | functional |
|---|---|---|
| 0.1.8 | 1 (materialized once) | PASS |
| 0.1.9 | 1 | PASS |
| 0.1.10 | 1 | PASS |
| 0.1.11 | 4 (inlined per use site) | FAIL — counter ≈ 2.5–3×N, half the slots never written |
| 0.1.12 (PyPI latest) | 4 | FAIL |
| main @ 2047357e | 4 | FAIL |

In a larger radix-top-k kernel using this idiom (2048 rows × 12288 candidates, top-1024) the corruption is subtle enough to ship: per-row recall vs `torch.topk` drops from 1024/1024 to min 911 / mean ≈1002, the selected set changes across identical reruns (uninitialized shared memory is consumed), and out-of-range garbage indices appear that crash downstream gathers. We hit this in production code derived from the `deepseek_v32/topk_selector.py` example.

Note that the shipped `examples/deepseek_v32/topk_selector.py` itself escapes the bug only *accidentally*: it routes every atomic return value through `T.alloc_var` (a buffer store rather than a scalar bind — required anyway because the eager builder forbids rebinding). Nothing tests or documents that this indirection is load-bearing for correctness; the plain binding shown in `atomic_add`'s own docstring (`old_value = atomic_add(counter, 5, return_prev=True)`) is the form that miscompiles.

### Root cause

#2245 introduced `IsReplayableScalarBind()` (`src/transform/common/bind_utils.h`), used to decide that a scalar bind can be dissolved and its value re-evaluated at each use:

- `tl.IfStmtBinding` inlines "replayable" binds while pushing the `if` guard into each statement of the sequence (`BindIfStmtWithReplayableBindInlining`, config `tl.if_stmt_binding_inline_replayable_binds`, default true);
- `PipelinePlanning` / `InjectSoftwarePipeline` use the same predicate to pull "replayable" binds out of pipeline stages and replay them.

The predicate checks (a) that the bind is a non-pointer scalar (pointer exclusion added in #2278), and (b) that the value reads no buffer written in the same scope — but it **never consults the value's effect kind**. `tl.atomic_add_ret_elem_op` is correctly registered `kOpaque` in `src/op/builtin.cc`; however its buffer access enters the expression through `tvm_access_ptr`, which the access collector records as a *read*, so check (b) passes and the side-effecting bind is declared replayable.

`StmtSimplifier` already guards its own let-inlining correctly (`SideEffect(op->value) <= CallEffectKind::kPure`, `src/transform/simplify.cc`); the new predicate simply lacks the equivalent guard.

### Fix

One check in the shared predicate: a bind whose value has `SideEffect(...) > CallEffectKind::kReadState` (i.e. `kUpdateState`/`kOpaque`) is never replayable. This covers all three consumers (`IfStmtBinding`, `PipelinePlanning`, `InjectSoftwarePipeline`) at once. Read-only values remain replayable — replay-read consistency is exactly what the existing write-set disjointness check enforces.

### Tests

- `testing/python/transform/test_tilelang_transform_if_stmt_binding.py::test_if_stmt_binding_keeps_side_effecting_bind` — pass-level: `IfStmtBinding` must keep a bind whose value is an atomic RMW returning the previous value (structural equality).
- `testing/python/language/test_tilelang_language_atomic.py::test_atomic_add_return_prev_materialized_once` — end-to-end CUDA: exactly one `AtomicAddRet` in the generated source, `counter == N`, output is a permutation.
- `examples/deepseek_v32/topk_selector.py` — `test_topk_selector` computed recall but only printed it, so it could never fail on miscompilation; it now asserts `recall >= 0.999` (tie-tolerant; the plain-bind miscompile measures ≈0.98). This also protects the example's currently-accidental alloc_var immunity against future refactors.

Verification (B200 / sm_100a, CUDA 13.3):

- Both new tests fail on unpatched main and pass with the fix.
- Example test on the patched build: recall 1.0 on all 64 rows; kernel time unchanged (0.029 ms vs torch.topk 0.095 ms).
- Focused subset (if_stmt_binding, let_inline, simplify, Inject_software_pipeline, pipeline_planning, pipeline_barrier_ownership, language atomic/let/let_layout): unpatched baseline **99 passed / 3 skipped** → patched **101 passed / 3 skipped** (+2 = the new regression tests), no new failures.
- Full `testing/python/transform` + `testing/python/language`: **13 failed / 953 passed / 19 skipped**; the 13 failures are pre-existing, not caused by this change (the identical failure set reproduces on an unpatched build of the same base commit on the same machine: tcgen05 codegen x2, TMA gather/scatter x4, cooperative grid_sync, cutedsl PDL, reduce tolerance x3, clear matmul, hoist_broadcast dtype3). No new failures.
- Lint: `ruff check` / `ruff format --check` / `clang-format --dry-run -Werror` all clean on the changed files.

### Workarounds for users pinned to v0.1.11/v0.1.12

- pin `tilelang<=0.1.10`; or
- set pass config `tl.if_stmt_binding_inline_replayable_binds=False` (covers the `IfStmtBinding` path only); or
- route the returned value through a mutable var: `pos = T.alloc_var("int32"); pos[0] = T.atomic_add(..., return_prev=True)` (what the deepseek_v32 example happens to do).

---

Fixes #2650

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixes the v0.1.11 regression by tightening `IsReplayableScalarBind()` so scalar binds are **not replayable** when their value has effects **stronger than `kReadState`**. This prevents incorrect re-execution of side-effecting operations (e.g., `T.atomic_add(..., return_prev=True)`) that could corrupt compaction, histogram, and top-k kernels.
- Extends the analysis infrastructure to correctly classify buffer accesses for pointer-based ops, including more precise handling of `tl::access_ptr`/`tvm_access_ptr` read/write regions (used by both `IfStmtBinding` and pipeline planning/injection).
- Updates `InjectSoftwarePipeline` and related pipeline planning logic to enforce the semantic replayability rules consistently, rejecting unsupported/unsafe replayability annotations during injection.

### Tests and example coverage

- Adds a CUDA-only end-to-end regression test ensuring **atomic return-value materialization happens exactly once**:
  - Verifies generated CUDA contains exactly one `AtomicAddRet`
  - Verifies counter correctness and that output indices are fully written/permuted.
- Adds structural regressions for `IfStmtBinding`:
  - Confirms side-effecting bound values aren’t duplicated across multiple uses/branches.
  - Includes coverage for binds that read atomic targets via pointer/access handling.
- Adds pipeline planning coverage:
  - Ensures binds that read atomic targets are preserved and do **not** result in `software_pipeline_replayable_scalar_binds` annotations.
- Adds an injection regression:
  - Ensures `InjectSoftwarePipeline()` fails when given a replay mask for a side-effecting scalar bind.
- Strengthens `examples/deepseek_v32/topk_selector.py` verification by enforcing **per-row `recall >= 0.999`** with improved diagnostics.

### Documentation / workarounds

- Documents the affected behavior and provides workarounds for impacted versions.

## C++ style / lint notes

- Touches C++ implementation logic only in transformation/analysis codepaths (`src/transform/common/bind_utils.h`, `src/transform/if_stmt_binding.cc`, `src/transform/pipeline_planning.cc`, `src/transform/inject_pipeline.cc`) and a small helper in `src/op/operator.h`; does **not** modify `docs/developer_guide/cpp_style.md`.
- No changes to CI/lint tooling are included. Any **`C++ API Style Audit (warning only)`** (e.g., TLCPP003/TLCPP004) findings should be treated as advisory unless the PR introduces a concrete API/FFI/maintainability risk; correctness/build implications are not expected from style-only results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->