### PR TITLE
[BugFix] Reject invalid dtypes in T.dp4a

### DIFF
--- a/testing/python/issue/test_tilelang_issue_2600.py
+++ b/testing/python/issue/test_tilelang_issue_2600.py
@@ -1,0 +1,54 @@
+"""Regression tests for T.dp4a dtype validation (issue #2600)."""
+
+import pytest
+
+import tilelang.language as T
+import tilelang.testing
+
+
+def _build_dp4a(a_dtype: str, b_dtype: str, c_dtype: str):
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((4,), a_dtype),
+        B: T.Tensor((4,), b_dtype),
+        C: T.Tensor((1,), c_dtype),
+    ):
+        T.dp4a(A, B, C)
+
+    return kernel
+
+
+def test_dp4a_accepts_int8_int32():
+    kernel = _build_dp4a("int8", "int8", "int32")
+    assert kernel is not None
+
+
+def test_dp4a_accepts_buffer_load_slice():
+    # Existing SIMT kernels call dp4a with BufferLoad arguments.
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((4,), "int8"),
+        B: T.Tensor((4,), "int8"),
+        C: T.Tensor((1,), "int32"),
+    ):
+        T.dp4a(A[0], B[0], C[0])
+
+    assert kernel is not None
+
+
+@pytest.mark.parametrize(
+    "a_dtype,b_dtype,c_dtype",
+    [
+        ("float16", "float16", "int32"),  # wrong input dtype
+        ("int8", "int8", "float32"),  # wrong accumulator dtype
+        ("uint8", "uint8", "int32"),  # unsigned inputs (signed-only intrinsic)
+        ("int8", "float16", "int32"),  # mixed input dtypes
+    ],
+)
+def test_dp4a_rejects_invalid_dtypes(a_dtype, b_dtype, c_dtype):
+    with pytest.raises(ValueError, match="dp4a requires"):
+        _build_dp4a(a_dtype, b_dtype, c_dtype)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/language/customize.py
+++ b/tilelang/language/customize.py
@@ -1,25 +1,37 @@
 """Some customized operations frequently used in tensor programming, exposed on the TileLang language surface."""
 
 from __future__ import annotations
-from tilelang._typing import ShapeType, DType
+from tilelang._typing import ShapeType, DType, BufferLikeType
 import tilelang.language as T
 from tvm import arith
 from tvm.tirx import PrimExpr, Buffer, op
-from tilelang.utils.language import bits_product, prim_expr_equal
+from tilelang.utils.language import bits_product, prim_expr_equal, retrieve_buffer_and_offset
 from .atomic import atomic_max, atomic_min, atomic_add, atomic_addx2, atomic_addx4, atomic_load, atomic_or, atomic_store  # noqa: F401
 
 
-def dp4a(A: Buffer, B: Buffer, C: Buffer) -> PrimExpr:
-    """Perform a 4-element dot product with accumulation (DP4A).
+def dp4a(A: BufferLikeType, B: BufferLikeType, C: BufferLikeType) -> PrimExpr:
+    """Perform a four-element signed int8 dot product accumulated into int32.
 
     Args:
-        A (Buffer): First input buffer
-        B (Buffer): Second input buffer
-        C (Buffer): Accumulation buffer
+        A: First int8 input buffer.
+        B: Second int8 input buffer.
+        C: Int32 accumulator buffer.
 
     Returns:
-        PrimExpr: Handle to the DP4A operation
+        Handle to the DP4A operation.
+
+    Raises:
+        ValueError: If A or B is not int8, or C is not int32.
     """
+    a_dtype = T.dtype(retrieve_buffer_and_offset(A)[0].dtype)
+    b_dtype = T.dtype(retrieve_buffer_and_offset(B)[0].dtype)
+    c_dtype = T.dtype(retrieve_buffer_and_offset(C)[0].dtype)
+    if a_dtype != T.int8:
+        raise ValueError(f"dp4a requires int8 inputs, got A.dtype='{a_dtype}'")
+    if b_dtype != T.int8:
+        raise ValueError(f"dp4a requires int8 inputs, got B.dtype='{b_dtype}'")
+    if c_dtype != T.int32:
+        raise ValueError(f"dp4a requires an int32 accumulator, got C.dtype='{c_dtype}'")
     return T.call_extern(
         "handle",
         "DP4A",


### PR DESCRIPTION
## Summary

`T.dp4a` accepted arbitrary input and accumulator dtypes. Unsupported dtypes could be silently reinterpreted by the backend DP4A implementation, producing incorrect results instead of raising an error.

## Root cause

The frontend emitted the DP4A external call without validating operand dtypes. The backend expects four packed signed `int8` lanes from each input and an `int32` accumulator.

## Fix

Validate the underlying buffer dtypes before emitting the DP4A call:

* Require both inputs to be `int8`.
* Require the accumulator to be `int32`.
* Raise `ValueError` for unsupported combinations.

The validation handles both Buffer and BufferLoad arguments used by existing SIMT kernels.

## Tested

Added regression coverage for valid Buffer and BufferLoad forms, invalid input dtypes, unsigned inputs, and invalid accumulator dtypes. Verified the existing int8 SIMT dp4a path locally.

Fixes #2600


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated `T.dp4a` dtype validation to enforce the DP4A contract:
  - Operand inputs `A` and `B` must be `int8`.
  - Accumulator input `C` must be `int32`.
  - Any unsupported dtype combinations now raise `ValueError` (documented in the `dp4a` docstring).
- Validation supports both `Buffer` and `BufferLoad`-style inputs (including slice-based usage).
- Added regression coverage for:
  - Valid `int8/int8/int32` and `BufferLoad`/slice forms.
  - Invalid operand dtypes (including unsigned) and invalid accumulator dtypes.

## C++ style / lint notes

- This PR does not touch C++, CI/lint tooling, or `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step is not relevant for this change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->