### PR TITLE
[BugFix] Support runtime-dependent vector negative indices

### DIFF
--- a/src/transform/legalize_negative_index.cc
+++ b/src/transform/legalize_negative_index.cc
@@ -182,8 +182,13 @@ private:
           ramp->base + ramp->stride * IntImm(ramp->stride.dtype(), lane_id));
       if (analyzer_->CanProve(lane < 0))
         lane = analyzer_->Simplify(buffer_extent + lane);
-      else if (!analyzer_->CanProve(lane >= 0))
-        return PrimExpr();
+      else if (!analyzer_->CanProve(lane >= 0)) {
+        PrimExpr original = lane;
+        PrimExpr wrapped = analyzer_->Simplify(buffer_extent + lane);
+        wrapped = wrapped.dtype() == dtype ? wrapped : Cast(dtype, wrapped);
+        original = original.dtype() == dtype ? original : Cast(dtype, original);
+        lane = analyzer_->Simplify(Select(lane < 0, wrapped, original));
+      }
       values.push_back(lane.dtype() == dtype ? lane : Cast(dtype, lane));
       shuffle_indices.push_back(IntImm(DataType::Int(32), lane_id));
     }

--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -40,6 +40,61 @@ bool AccessMaskMayUse(const PrimExpr &expr, int required_mask) {
   return (GetConstAccessMask(expr) & required_mask) != 0;
 }
 
+// Extract a scalar lane from vector expressions used in bounds predicates.
+// This intentionally expands Ramp/Broadcast/Shuffle by structure instead of
+// using Shuffle::ExtractElement, because the arithmetic prover handles the
+// resulting scalar integer expressions more reliably.
+struct VectorLaneScalarizer : public ExprMutator {
+  explicit VectorLaneScalarizer(int lane) : lane_(lane) {}
+
+private:
+  int lane_;
+
+  PrimExpr VisitExpr_(const RampNode *op) final {
+    PrimExpr base = VisitExpr(op->base);
+    PrimExpr stride = VisitExpr(op->stride);
+    return base + stride * IntImm(stride.dtype(), lane_);
+  }
+
+  PrimExpr VisitExpr_(const BroadcastNode *op) final {
+    return VisitExpr(op->value);
+  }
+
+  PrimExpr VisitExpr_(const ShuffleNode *op) final {
+    ICHECK_LT(lane_, op->indices.size());
+    const int64_t *idx = as_const_int(op->indices[lane_]);
+    ICHECK(idx)
+        << "Vector condition scalarization requires constant Shuffle indices: "
+        << GetRef<Shuffle>(op);
+    int64_t src_lane = *idx;
+    for (const PrimExpr &vec : op->vectors) {
+      ICHECK(!vec.dtype().is_scalable_vector());
+      int lanes = vec.dtype().lanes();
+      if (src_lane < lanes) {
+        if (vec.dtype().is_scalar()) {
+          ICHECK_EQ(src_lane, 0);
+          return VisitExpr(vec);
+        }
+        return VectorLaneScalarizer(static_cast<int>(src_lane))(vec);
+      }
+      src_lane -= lanes;
+    }
+    ICHECK(false) << "Shuffle index out of range: " << GetRef<Shuffle>(op);
+    return PrimExpr();
+  }
+
+  PrimExpr VisitExpr_(const CastNode *op) final {
+    PrimExpr value = VisitExpr(op->value);
+    DataType dtype =
+        op->dtype.is_fixed_length_vector() ? op->dtype.element_of() : op->dtype;
+    if (value.dtype() == dtype) {
+      return value;
+    } else {
+      return Cast(dtype, value);
+    }
+  }
+};
+
 // SafeMemChecker for a BufferLoad/BufferStore node:
 // 1. Identify BufferLoad and BufferStore nodes.
 // 2. For each index, compare against the buffer's shape.
@@ -121,6 +176,40 @@ struct SafeMemChecker : public StmtExprVisitor {
     return scope == "global";
   }
 
+  // Helper function to store a bounds predicate as scalar Bool(1) conditions.
+  void PushCondition(const PrimExpr &cond) {
+    if (cond.dtype().is_scalar()) {
+      ICHECK(cond.dtype() == DataType::Bool(1))
+          << "condition is not a boolean: " << cond;
+      PushScalarCondition(cond);
+      return;
+    }
+    PrimExpr simplified = analyzer_->Simplify(cond);
+    ICHECK(simplified.dtype().is_fixed_length_vector() &&
+           simplified.dtype().is_bool())
+        << "condition is not a fixed-length boolean vector: " << simplified;
+    int lanes = simplified.dtype().lanes();
+    for (int lane = 0; lane < lanes; lane++) {
+      PrimExpr scalar =
+          analyzer_->Simplify(VectorLaneScalarizer(lane)(simplified));
+      ICHECK(scalar.dtype() == DataType::Bool(1))
+          << "scalarized condition is not a boolean: " << scalar;
+      PushScalarCondition(scalar);
+    }
+  }
+
+  // Keep only predicates that still need a runtime guard.
+  void PushScalarCondition(const PrimExpr &cond) {
+    try {
+      if (analyzer_->CanProve(cond, arith::ProofStrength::kSymbolicBound)) {
+        return;
+      }
+    } catch (const std::exception &) {
+      // Keep the runtime guard if proving fails.
+    }
+    _conditions.push_back(cond);
+  }
+
   // Check each index against the buffer shape dimensions
   void CheckBufferIndices(const Buffer &buffer, const Array<PrimExpr> &indices,
                           bool is_load, bool throw_warning) {
@@ -195,7 +284,7 @@ struct SafeMemChecker : public StmtExprVisitor {
                        << "; Buffer name: " << buffer->name;
         }
         if (IsGlobalBuffer(buffer)) {
-          _conditions.push_back(upper_bound_cond);
+          PushCondition(upper_bound_cond);
         }
       }
       // Check if index >= 0 can be proven.
@@ -222,7 +311,7 @@ struct SafeMemChecker : public StmtExprVisitor {
                        << "; Buffer name: " << buffer->name;
         }
         if (IsGlobalBuffer(buffer)) {
-          _conditions.push_back(lower_bound_cond);
+          PushCondition(lower_bound_cond);
         }
       }
     }

--- a/testing/python/issue/test_tilelang_issue_2554.py
+++ b/testing/python/issue/test_tilelang_issue_2554.py
@@ -1,0 +1,60 @@
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+def test_runtime_unknown_sign_vector_negative_index_load():
+    @T.prim_func
+    def main(A: T.Tensor((1024,), T.float32), B: T.Tensor((4, 4), T.float32)):
+        with T.Kernel(1, threads=1) as _:
+            for t in T.serial(4):
+                B[t, T.Ramp(0, 1, 4)] = A[T.Ramp(t - 2, 1, 4)]
+
+    kernel = tilelang.compile(main, out_idx=[1], target="cuda")
+
+    a = torch.arange(1024, device="cuda", dtype=torch.float32)
+    b = kernel(a)
+    expected = torch.tensor(
+        [
+            [1022.0, 1023.0, 0.0, 1.0],
+            [1023.0, 0.0, 1.0, 2.0],
+            [0.0, 1.0, 2.0, 3.0],
+            [1.0, 2.0, 3.0, 4.0],
+        ],
+        device="cuda",
+        dtype=torch.float32,
+    )
+
+    torch.testing.assert_close(b, expected)
+
+
+def test_runtime_unknown_sign_vector_negative_index_store():
+    @T.prim_func
+    def main(B: T.Tensor((4, 4), T.float32), A: T.Tensor((1024,), T.float32)):
+        with T.Kernel(1, threads=1) as _:
+            for i in T.serial(1024):
+                A[i] = T.float32(-1)
+            for t in T.serial(4):
+                A[T.Ramp(t - 2, 1, 4)] = B[t, T.Ramp(0, 1, 4)]
+
+    kernel = tilelang.compile(main, out_idx=[1], target="cuda")
+
+    b = torch.arange(16, device="cuda", dtype=torch.float32).reshape(4, 4)
+    a = kernel(b)
+
+    expected = torch.full((1024,), -1, device="cuda", dtype=torch.float32)
+    expected[0] = b[2, 0]
+    expected[1] = b[3, 0]
+    expected[2] = b[3, 1]
+    expected[3] = b[3, 2]
+    expected[4] = b[3, 3]
+    expected[1022] = b[0, 0]
+    expected[1023] = b[1, 0]
+
+    torch.testing.assert_close(a, expected)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_legalize_negative_index.py
+++ b/testing/python/transform/test_tilelang_transform_legalize_negative_index.py
@@ -262,6 +262,36 @@ def test_buffer_load_vector_index_mixed_sign_ramp_in_kernel():
     _check(before, after)
 
 
+def test_buffer_load_vector_index_runtime_unknown_sign_ramp_in_kernel():
+    """
+    Test runtime-dependent vector ramp lanes whose sign cannot be proven statically.
+    """
+
+    @T.prim_func
+    def before(A: T.Tensor((1024,), T.float32), B: T.Tensor((4, 4), T.float32)):
+        with T.Kernel(1, threads=1) as _:
+            for t in T.serial(4):
+                B[t, T.Ramp(0, 1, 4)] = A[T.Ramp(t - 2, 1, 4)]
+
+    @T.prim_func
+    def after(A: T.Tensor((1024,), T.float32), B: T.Tensor((4, 4), T.float32)):
+        with T.Kernel(1, threads=1) as _:
+            for t in T.serial(4):
+                B[t, T.Ramp(0, 1, 4)] = A[
+                    T.Shuffle(
+                        [
+                            T.Select(t < 2, t + 1022, t - 2),
+                            T.Select(t < 1, t + 1023, t - 1),
+                            t,
+                            t + 1,
+                        ],
+                        [0, 1, 2, 3],
+                    )
+                ]
+
+    _check(before, after)
+
+
 def test_buffer_load_nested_buffer_loads():
     """
     Test legalization with nested buffer load expressions.
@@ -409,6 +439,36 @@ def test_buffer_store_vector_index_mixed_sign_ramp():
         vec = T.Ramp(-2, 1, 4)  # noqa: F841
         values = T.Ramp(0.0, 1.0, 4)
         A[T.Shuffle([1022, 1023, 0, 1], [0, 1, 2, 3])] = values
+
+    _check(before, after)
+
+
+def test_buffer_store_vector_index_runtime_unknown_sign_ramp():
+    """
+    Test runtime-dependent vector store ramp lanes whose sign cannot be proven statically.
+    """
+
+    @T.prim_func
+    def before(A: T.Tensor((1024,), T.float32), B: T.Tensor((4, 4), T.float32)):
+        with T.Kernel(1, threads=1) as _:
+            for t in T.serial(4):
+                A[T.Ramp(t - 2, 1, 4)] = B[t, T.Ramp(0, 1, 4)]
+
+    @T.prim_func
+    def after(A: T.Tensor((1024,), T.float32), B: T.Tensor((4, 4), T.float32)):
+        with T.Kernel(1, threads=1) as _:
+            for t in T.serial(4):
+                A[
+                    T.Shuffle(
+                        [
+                            T.Select(t < 2, t + 1022, t - 2),
+                            T.Select(t < 1, t + 1023, t - 1),
+                            t,
+                            t + 1,
+                        ],
+                        [0, 1, 2, 3],
+                    )
+                ] = B[t, T.Ramp(0, 1, 4)]
 
     _check(before, after)
 

--- a/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
+++ b/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
@@ -78,6 +78,12 @@ def _assert_legalize_matches_expected(before, expected, strip_annotations: bool 
     )
 
 
+def _apply_negative_index_then_safe_memory(func):
+    mod = tvm.IRModule.from_expr(func.with_attr("global_symbol", "main"))
+    mod = tl.transform.LegalizeNegativeIndex()(mod)
+    return tl.transform.LegalizeSafeMemoryAccess()(mod)
+
+
 def vectorize_access_legalize(M: int = 64, N: int = 64, M_offset: int = 2, N_offset: int = 2):
     dtype = T.float32
 
@@ -480,6 +486,36 @@ def assert_call_extern_multiple_access_ptrs_legalize():
     _assert_legalize_matches_expected(func, expected)
 
 
+def assert_runtime_unknown_sign_vector_negative_index_legalize():
+    @T.prim_func
+    def main(A: T.Tensor((1024,), T.float32), B: T.Tensor((4, 4), T.float32)):
+        with T.Kernel(1, threads=1) as _:
+            for t in T.serial(4):
+                B[t, T.Ramp(0, 1, 4)] = A[T.Ramp(t - 2, 1, 4)]
+
+    @T.prim_func
+    def expected(A: T.Tensor((1024,), T.float32), B: T.Tensor((4, 4), T.float32)):
+        with T.Kernel(1, threads=1) as _:
+            for t in T.serial(4):
+                B[t, T.Ramp(0, 1, 4)] = A[
+                    T.Shuffle(
+                        [
+                            T.Select(t < 2, t + 1022, t - 2),
+                            T.Select(t < 1, t + 1023, t - 1),
+                            t,
+                            t + 1,
+                        ],
+                        [0, 1, 2, 3],
+                    )
+                ]
+
+    transformed = _apply_negative_index_then_safe_memory(main)
+    tvm.ir.assert_structural_equal(
+        _strip_block_reads_writes(transformed["main"].body),
+        _strip_block_reads_writes(expected.body),
+    )
+
+
 def test_vectorize_access():
     assert_vectorize_access(64, 64)
 
@@ -526,6 +562,10 @@ def test_call_extern_access_ptr_readwrite_mask_oob():
 
 def test_call_extern_multiple_access_ptrs_oob():
     assert_call_extern_multiple_access_ptrs_legalize()
+
+
+def test_runtime_unknown_sign_vector_negative_index_oob():
+    assert_runtime_unknown_sign_vector_negative_index_legalize()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fix #2554 .

Runtime-dependent vector negative indexing, e.g.

```
A[T.Ramp(t - 2, 1, 4)]
```

could fail during CUDA lowering with `tvm.error.InternalError: Check failed: (cond.dtype() == DataType::Bool(1)) is false: condition is not a boolean: ...`.

Root cause: `LegalizeNegativeIndex` only handled vector ramp lanes whose sign could be proven. For runtime-dependent lanes such as `t - 2`, the analyzer cannot prove either `lane < 0` or `lane >= 0`, so the pass failed to implement Python-style negative-index wrapping for those lanes.

The unresolved vector index then reached `LegalizeSafeMemoryAccess`, which produced vector-valued bounds predicates. Later safe-memory consumers expect runtime guards to be scalar `Bool(1)` conditions, causing the assertion failure.

## Changes

Changed two transform files:

- `src/transform/legalize_negative_index.cc`:
  - Added runtime wrapping for vector ramp lanes whose sign cannot be proven. Unknown-sign lanes are rewritten as  `Select(lane < 0, extent + lane, lane)`. For `T.Ramp(t - 2, 1, 4)`, this produces per-lane wrapped indices such as: `Select(t < 2, t + 1022, t - 2), Select(t < 1, t + 1023, t - 1), t, t + 1`.
- `src/transform/legalize_safe_memory_access.cc`:
  - Added scalarization for vector bounds predicates before they are used as runtime guards. This handles `Ramp`, `Broadcast`, `Shuffle`, and vector `Cast` structurally. Scalar conditions are unchanged.

## Testing

- `testing/python/transform/test_tilelang_transform_legalize_negative_index.py`: Added 2 tests about runtime unknown-sign vector ramp load/store.
- `testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py`:  Added test that runs `LegalizeNegativeIndex` followed by `LegalizeSafeMemoryAccess` on the issue pattern.
- `testing/python/issue/test_tilelang_issue_2554.py`: Added CUDA runtime tests about unknown-sign vector ramp load/store.

Ran:
`python3 -m pytest testing/python/transform/test_tilelang_transform_legalize_negative_index.py -q`
`python3 -m pytest testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py -q`
`python3 -m pytest testing/python/issue/test_tilelang_issue_2554.py -q`
all tests passed. And the issue repro now produces the expected wrapped-index result:
```
[
  [1022.0, 1023.0, 0.0, 1.0],
  [1023.0, 0.0, 1.0, 2.0],
  [0.0, 1.0, 2.0, 3.0],
  [1.0, 2.0, 3.0, 4.0],
]
```
`pre-commit run --all-files` was also run before commiting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes runtime-dependent vector negative indices such as `A[T.Ramp(t - 2, 1, 4)]`, preventing CUDA lowering assertions and preserving Python-style negative-index wrapping.

## Changes

- Added runtime conditional wrapping for vector ramp lanes whose sign cannot be proven statically.
- Scalarized vector bounds predicates in `LegalizeSafeMemoryAccess` for ramp, broadcast, shuffle, and cast expressions.
- Added transform-level and CUDA runtime regression tests covering vectorized loads and stores.

## C++ style / lint notes

- The PR changes C++ files; review them against `docs/developer_guide/cpp_style.md`.
- The warning-only **C++ API Style Audit** CI step is relevant.
- No correctness or build issues are indicated; any TLCPP003/TLCPP004 findings should remain advisory unless they reveal a clear API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->