### PR TITLE
[BugFix] Fix FP4 dequant symbolic exponent clamp

### DIFF
--- a/testing/python/issue/test_tilelang_issue_2615.py
+++ b/testing/python/issue/test_tilelang_issue_2615.py
@@ -1,5 +1,6 @@
 import pytest
 
+import tilelang.testing
 import tilelang.language as T
 from tilelang import tvm
 from tilelang.quantize import _tir_u8_to_f4_to_bf16
@@ -39,4 +40,4 @@ def test_u8_to_f4_to_bf16_traces_symbolic_exponent_clamp(use_buffer_scale):
 
 
 if __name__ == "__main__":
-    pytest.main([__file__])
+    tilelang.testing.main()

--- a/testing/python/issue/test_tilelang_issue_2615.py
+++ b/testing/python/issue/test_tilelang_issue_2615.py
@@ -1,0 +1,42 @@
+import pytest
+
+import tilelang.language as T
+from tilelang import tvm
+from tilelang.quantize import _tir_u8_to_f4_to_bf16
+
+
+@pytest.mark.parametrize(
+    "use_buffer_scale",
+    [False, True],
+    ids=["python-int-zero", "uint16-buffer-load"],
+)
+def test_u8_to_f4_to_bf16_traces_symbolic_exponent_clamp(use_buffer_scale):
+    @T.prim_func
+    def main(
+        packed: T.Tensor((1,), "uint8"),
+        scale: T.Tensor((1,), "uint16"),
+        output: T.Tensor((1,), "bfloat16"),
+    ):
+        with T.Kernel(1, threads=1):
+            for i in T.Parallel(1):
+                exponent_scale = scale[0] if use_buffer_scale else 0
+                output[i] = _tir_u8_to_f4_to_bf16(
+                    4,
+                    packed[i],
+                    i,
+                    exponent_scale,
+                    dtype="bfloat16",
+                )
+
+    min_nodes = []
+    tvm.tirx.stmt_functor.post_order_visit(
+        main.body,
+        lambda node: min_nodes.append(node) if isinstance(node, tvm.tirx.Min) else None,
+    )
+
+    assert len(min_nodes) == 1
+    assert min_nodes[0].dtype == T.uint16
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tilelang/quantize/quantization.py
+++ b/tilelang/quantize/quantization.py
@@ -65,7 +65,7 @@ def _tir_u8_to_f4_to_bf16(nbit: int, val: tirx.PrimExpr, pos: tirx.PrimExpr, sca
     e_bf16 = e_f4 + tirx.const(126, T.uint16)
     # Scale is the exponential part, within the representation of uint8
     # Clamp the scaled exponent to the maximum value representable in 8 bits.
-    e_bf16 = T.min(e_bf16 + scale, tirx.const((1 << 8) - 1, T.uint16))
+    e_bf16 = T.min(e_bf16 + T.cast(scale, T.uint16), tirx.const((1 << 8) - 1, T.uint16))
     m_f4 = f4 & tirx.const(1, T.uint16)
     val_bf16 = tirx.reinterpret(T.bfloat16,
                                ((((s << tirx.const(8, T.uint16)) | e_bf16) << tirx.const(7, T.uint16))

--- a/tilelang/quantize/quantization.py
+++ b/tilelang/quantize/quantization.py
@@ -64,8 +64,8 @@ def _tir_u8_to_f4_to_bf16(nbit: int, val: tirx.PrimExpr, pos: tirx.PrimExpr, sca
     # Exponential bias between f4 and bf16 is 2^(8-1) - 2^(2-1) = 126
     e_bf16 = e_f4 + tirx.const(126, T.uint16)
     # Scale is the exponential part, within the representation of uint8
-    # To handle the overflow, we use the max function to limit the exponential part to 8 bits
-    e_bf16 = min(e_bf16 + scale, tirx.const((1 << 8) - 1, T.uint16))
+    # Clamp the scaled exponent to the maximum value representable in 8 bits.
+    e_bf16 = T.min(e_bf16 + scale, tirx.const((1 << 8) - 1, T.uint16))
     m_f4 = f4 & tirx.const(1, T.uint16)
     val_bf16 = tirx.reinterpret(T.bfloat16,
                                ((((s << tirx.const(8, T.uint16)) | e_bf16) << tirx.const(7, T.uint16))


### PR DESCRIPTION
## Summary

Fix the trace-time crash in `_tir_u8_to_f4_to_bf16` caused by applying Python's built-in `min` to symbolic `PrimExpr` operands.

## Changes

- Replace the eager Python `min` call with TileLang's lazy `T.min`.
- Remove the misleading comment that described the upper clamp as a max operation.
- Add trace regression coverage for:
  - Python integer `scale=0`.
  - A symbolic `uint16` scale loaded from a buffer.
- Verify that tracing produces exactly one `Min<uint16>` node.

## Validation

- Reproduced the original `PrimExpr.__bool__` failure on:
  - TileLang v0.1.11.
  - TileLang v0.1.12.
  - Latest `origin/main`.
- Verified the candidate fix produces `TRACE_OK` for both scale paths.
- Verified the existing builds with `ninja -j64`.
- Local experiments were not rerun after the final commit, as requested; remote CI is pending.

## C++ style / lint notes

- Python-only change; no C++ files were modified.
- `git diff --check` passed.
- C++ formatting and lint checks are not applicable.

Fixes #2615

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed a trace-time crash in `_tir_u8_to_f4_to_bf16` by replacing Python’s eager `min` with TileLang’s lazy `T.min`, avoiding symbolic `PrimExpr` truthiness (`PrimExpr.__bool__`).
- Removed the misleading clamp-related comment.
- Added regression coverage in `testing/python/issue/test_tilelang_issue_2615.py` for both `scale=0` and symbolic per-element `uint16` scales, asserting tracing produces exactly one `Min<uint16>` node.

## Validation

- Existing builds passed.
- `git diff --check` passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->