### PR TITLE
[BugFix] Fix segfault when tunable params default to None

### DIFF
--- a/testing/python/autotune/test_tilelang_autotune_scalar_inputs.py
+++ b/testing/python/autotune/test_tilelang_autotune_scalar_inputs.py
@@ -39,5 +39,45 @@ def test_autotune_scalar_inputs_with_set_autotune_inputs():
     torch.testing.assert_close(a, before + tune_s, rtol=1e-4, atol=1e-4)
 
 
+# Reproduces the segfault from calling an autotuned kernel whose tunable
+# parameters default to ``None`` (the common ``block_M=None`` style) before any
+# config is applied. The old validation path built a prim_func with those
+# ``None`` values and crashed inside TVM (e.g. ``ceildiv`` over a None extent).
+# Tuning must elaborate a concrete config first and only then validate.
+@tilelang.autotune(
+    configs=[{"BLOCK_N": 128, "threads": 128}, {"BLOCK_N": 256, "threads": 256}],
+    warmup=1,
+    rep=1,
+    timeout=60,
+)
+@tilelang.jit(out_idx=[2])
+def vector_add_none_tunable(N: int = 4096, BLOCK_N: int = None, threads: int = None):
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((N,), T.float32),
+        B: T.Tensor((N,), T.float32),
+        C: T.Tensor((N,), T.float32),
+    ):
+        with T.Kernel(T.ceildiv(N, BLOCK_N), threads=threads) as pid_n:
+            A_local = T.alloc_fragment((BLOCK_N,), T.float32)
+            B_local = T.alloc_fragment((BLOCK_N,), T.float32)
+            T.copy(A[pid_n * BLOCK_N], A_local)
+            T.copy(B[pid_n * BLOCK_N], B_local)
+            for i in T.Parallel(BLOCK_N):
+                A_local[i] = A_local[i] + B_local[i]
+            T.copy(A_local, C[pid_n * BLOCK_N])
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_autotune_none_tunable_does_not_segfault():
+    # Calling with only the positional shape arg leaves BLOCK_N/threads at
+    # their None defaults; tuning must bind a concrete config before any TIR is
+    # constructed. A segfault here means the fix regressed.
+    kernel = vector_add_none_tunable()
+    assert kernel is not None
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -1019,8 +1019,11 @@ class AutoTuner:
 
         # After confirming tuning will actually run, validate that scalar
         # inputs can be supplied (either via supply_prog or set_autotune_inputs).
-        if hasattr(self, "_prim_func_for_validation"):
-            self._validate_input_supply_requirements(self._prim_func_for_validation, self.compile_args.out_idx)
+        # Build the prim_func from a concrete config so tunable parameters are
+        # bound to real values instead of their ``None`` defaults, which would
+        # otherwise crash inside TVM (e.g. ceildiv with a None extent).
+        prim_func_for_validation = elaborate_func(**top_config)
+        self._validate_input_supply_requirements(prim_func_for_validation, self.compile_args.out_idx)
 
         # Launch compile tasks
         pool, futures, future_to_unit, compile_desc = self._prepare_compile_execution(
@@ -1282,10 +1285,6 @@ class AutoTuneImpl(Generic[_P, _T]):
 
         mode = self.jit_impl.initialize_jit_mode(*args, **kwargs)
         autotuner = self.get_tunner()
-        # Defer scalar-input validation to run(), after we know whether
-        # tuning will actually execute or be skipped because all tunable
-        # parameters are already provided by the caller.
-        autotuner._prim_func_for_validation = self.jit_impl.get_tir(*args, **kwargs)
 
         # Compute the cache key, excluding do_not_specialize parameters
         # so that changing them does not trigger re-autotuning.


### PR DESCRIPTION
The autotuner built a validation prim_func with `self.jit_impl.get_tir(*args, **kwargs)`. At this point the tunable parameters (block_M, block_N, ...) are still at their None defaults, so the kernel body hits `T.ceildiv(N, None)` and dereferences a null PrimExpr inside TVM → segfault.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes a segmentation fault in the autotuner validation path when tunable parameters default to `None` (e.g., `BLOCK_N=None`, `threads=None`), which could lead to invalid TIR validation/elaboration (such as `T.ceildiv(N, None)`).

- Ensures `AutoTuner.run` always elaborates the current concrete “top” configuration into a concrete `prim_func` (`elaborate_func(**top_config)`) before validating scalar-input requirements.
- Removes the deferred validation path that relied on an internal `_prim_func_for_validation` cache, so scalar-input validation is driven entirely by the new elaboration step.
- Adds a CUDA-gated regression kernel/test that exercises an autotuned `@tilelang.jit` call with `None` tunable defaults to confirm the kernel object is created without crashing.

## Testing

- Added `test_autotune_none_tunable_does_not_segfault()` in `testing/python/autotune/test_tilelang_autotune_scalar_inputs.py`, covering an autotuned TileLang kernel where tunables default to `None`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->