### PR TITLE
[Example][Opt] deepseek_v32 topk_selector kernel memory access optimization (~1.9× faster)

### DIFF
--- a/examples/deepseek_v32/topk_selector.py
+++ b/examples/deepseek_v32/topk_selector.py
@@ -71,11 +71,13 @@ def tl_topk_impl(input, index, starts, ends, in_dtype=T.float32, out_dtype=T.int
         T.fill(s_threshold_bin_id, 0)
 
         T.sync_threads()
-        for s in T.serial(T.ceildiv(seq_len, BLOCK_SIZE)):
-            input_idx = s * BLOCK_SIZE + tx
-            if input_idx < l_end_idx and input_idx >= l_start_idx and input_idx < seq_len:
-                inval_int16 = convert_to_uint16(input[bx, input_idx])
-                T.atomic_add(s_histogram[inval_int16], 1)
+        for s in T.serial(T.ceildiv(seq_len, BLOCK_SIZE * 4)):
+            input_base = s * BLOCK_SIZE * 4 + tx * 4
+            for j in T.serial(4):
+                input_idx = input_base + j
+                if input_idx < l_end_idx and input_idx >= l_start_idx and input_idx < seq_len:
+                    inval_int16 = convert_to_uint16(input[bx, input_idx])
+                    T.atomic_add(s_histogram[inval_int16], 1)
         T.sync_threads()
 
         # cumsum
@@ -101,21 +103,23 @@ def tl_topk_impl(input, index, starts, ends, in_dtype=T.float32, out_dtype=T.int
         T.sync_threads()
 
         # collect all elements with exponent ≥ threshold
-        for s in T.serial(T.ceildiv(seq_len, BLOCK_SIZE)):
+        for s in T.serial(T.ceildiv(seq_len, BLOCK_SIZE * 4)):
             T.sync_threads()
-            input_idx = s * BLOCK_SIZE + tx
-            if input_idx < l_end_idx and input_idx >= l_start_idx and input_idx < seq_len:
-                bin_id = convert_to_uint16(input[bx, input_idx])
-                l_bin_id32 = T.cast(bin_id, T.int32)
-                if l_bin_id32 > l_threshold_bin_id:
-                    # need a pos = T.atomic_add(s_histogram[bin_id32+1], 1)
-                    pos = T.atomic_add(s_histogram[l_bin_id32 + 1], 1, return_prev=True)
-                    index[bx, pos] = input_idx
+            input_base = s * BLOCK_SIZE * 4 + tx * 4
+            for j in T.serial(4):
+                input_idx = input_base + j
+                if input_idx < l_end_idx and input_idx >= l_start_idx and input_idx < seq_len:
+                    bin_id = convert_to_uint16(input[bx, input_idx])
+                    l_bin_id32 = T.cast(bin_id, T.int32)
+                    if l_bin_id32 > l_threshold_bin_id:
+                        # need a pos = T.atomic_add(s_histogram[bin_id32+1], 1)
+                        pos = T.atomic_add(s_histogram[l_bin_id32 + 1], 1, return_prev=True)
+                        index[bx, pos] = input_idx
 
-                elif l_bin_id32 == l_threshold_bin_id and l_new_topk > 0:
-                    # pos = s_num_input[0]
-                    pos = T.atomic_add(s_num_input[0], 1, return_prev=True)
-                    s_input_idx[0, pos] = input_idx
+                    elif l_bin_id32 == l_threshold_bin_id and l_new_topk > 0:
+                        # pos = s_num_input[0]
+                        pos = T.atomic_add(s_num_input[0], 1, return_prev=True)
+                        s_input_idx[0, pos] = input_idx
 
         # stage 2: tail pass
         for round in T.serial(4):


### PR DESCRIPTION
## Summary

This PR applies **thread coarsening** to the two full-sequence scan passes in `examples/deepseek_v32/topk_selector.py`. Each thread now processes **4 consecutive elements per iteration** instead of 1, which quarters the loop trip count and the number of `sync_threads()` barriers in the histogram and scatter passes.

The change is **purely a loop-structure optimization** — the per-element logic (bounds checks, `convert_to_uint16`, atomic histogram / scatter) is byte-for-byte identical, and stage-2 tail refinement is untouched. The set of selected indices is unchanged.

**Result: ~1.85–2.0× end-to-end speedup**, consistent across two batch sizes and two `topk` values.

## Performance

**Environment:** NVIDIA B300 SXM6 (CC 10.3), single GPU, tilelang 0.1.11, torch 2.11. `seq_len = 131072` (128k). `do_bench(warmup=25, rep=100)`, median.

| Scenario | topk | baseline (ms) | optimized (ms) | speedup |
|---|---|---|---|---|
| prefill bs=4096 | 512 | 3.346 | 1.699 | **1.97×** |
| prefill bs=4096 | 2048 | 3.706 | 2.009 | **1.84×** |
| train cp8 bs=16384 | 512 | 13.326 | 6.669 | **2.00×** |
| train cp8 bs=16384 | 2048 | 14.731 | 7.935 | **1.86×** |

Latency scales ~linearly with batch (4096→16384 ≈ 4×), consistent with the `grid = batch` per-row design. Speedup dips slightly at larger `topk` because stage-2 tail refinement (identical in both versions) takes a bigger share.

## Why it's faster (NCU)

Profiled `bs=16384, seq=128k, topk=2048` (Nsight Compute, 20 passes/kernel). NCU locks clocks so absolute duration is inflated vs `do_bench`, but ratios hold.

**This is not fewer instructions or higher occupancy — it's latency hiding:**

| Metric | baseline | optimized | |
|---|---|---|---|
| Duration | 22.40 ms | 13.49 ms | −39.8% |
| Executed Instructions | 4.103 G | 4.079 G | ~same (−0.6%) |
| Achieved Occupancy | 49.90% | 49.81% | same |
| Registers / Thread | 38 | 36 | −2 |
| **Warp cycles / issued inst** | **28.06** | **16.89** | **−40%** |
| Scheduler "No Eligible" | 71.51% | 52.70% | |
| Eligible warps / scheduler | 0.61 | 1.09 | +79% |
| Executed IPC (active) | 1.14 | 1.88 | +65% |
| SM busy | 28.30% | 46.86% | +65% |
| **L1/TEX hit rate** | **8.29%** | **73.31%** | **+65 pp** |
| Effective mem bandwidth | 405 GB/s | 667 GB/s | +65% |

The baseline is **memory-latency bound**: its #1 stall is *Long Scoreboard (L1TEX)* at **49.6%** of warp cycles — each iteration issues one global load and immediately consumes it (convert + atomic), with no independent work to hide the load-to-use latency.

Coarsening fixes this on three fronts:
1. **Memory-level parallelism** — 4 independent loads (`base+0..3`) issue before being consumed, overlapping their latencies. Long-Scoreboard drops out of the top stall.
2. **L1 spatial locality** — each thread reads a contiguous 16 B span, so a 32 B sector is reused across `j=0..3`: L1 hit rate 8% → 73%, effective bandwidth 405 → 667 GB/s.
3. **Fewer barriers** — 4× fewer loop iterations and `sync_threads()` reduce scheduler idle (No-Eligible 71.5% → 52.7%).

Net: a latency-bound kernel is pushed toward throughput-bound at unchanged instruction count and occupancy.

## Correctness

A/B tested against `torch.topk`: **100% index match** across all scenarios above. The change only reorders iteration; the collected index set and stage-2 refinement are identical to upstream.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Applied 4-way thread coarsening to stage-1 histogram and threshold-collection scans in `tl_topk_impl`.
- Reduced scan iterations and synchronization barriers while preserving per-element logic and stage-2 tail refinement.
- Achieved approximately 1.85–2.0× end-to-end speedup in benchmark scenarios.
- Verified 100% index agreement with `torch.topk`.
- No public API signatures changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->