### PR TITLE
[BugFix][CUDA][HIP] Correct packed shared memory allocation sizes

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -4839,8 +4839,10 @@ void CodeGenTileLangCUDA::VisitStmt_(const AllocBufferNode *op) {
     if (scope.find("wmma.") == 0) {
       constant_size = GetWmmaFragmentSize(scope, buffer, constant_size);
     }
-    if ((alloc_dtype == DataType::Int(4) || alloc_dtype == DataType::UInt(4)) &&
-        scope == "shared") {
+    bool is_byte_packed_4bit =
+        alloc_dtype == DataType::Int(4) || alloc_dtype == DataType::UInt(4) ||
+        (alloc_dtype.is_float4_e2m1fn() && alloc_dtype.is_scalar());
+    if (is_byte_packed_4bit && scope == "shared") {
       constant_size = (constant_size + 1) / 2;
     } else if (alloc_dtype == DataType::Int(1) && scope == "shared") {
       constant_size = constant_size / 32;

--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -1770,11 +1770,15 @@ void CodeGenTileLangHIP::VisitStmt_(const AllocBufferNode *op) {
         << "Can only handle constant size stack allocation for now";
     size_t constant_size = static_cast<size_t>(opt_size.value());
 
-    if ((op->buffer->dtype == DataType::Int(4) ||
-         op->buffer->dtype == DataType::UInt(4) ||
-         op->buffer->dtype == DataType::Int(1)) &&
-        scope == "shared") {
-      constant_size = constant_size / (32 / op->buffer->dtype.bits());
+    if (scope == "shared") {
+      if (dtype.is_float4_e2m1fn() && dtype.is_scalar()) {
+        constant_size = (constant_size + 1) / 2;
+      } else if (dtype == DataType::Int(4) || dtype == DataType::UInt(4) ||
+                 dtype == DataType::Int(1)) {
+        size_t elements_per_storage_word = 32 / dtype.bits();
+        constant_size = (constant_size + elements_per_storage_word - 1) /
+                        elements_per_storage_word;
+      }
     }
 
     if (is_fp4_scalar_local) {

--- a/src/transform/common/storage_size.h
+++ b/src/transform/common/storage_size.h
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef TVM_TL_TRANSFORM_COMMON_STORAGE_SIZE_H_
+#define TVM_TL_TRANSFORM_COMMON_STORAGE_SIZE_H_
+
+#include <tvm/tirx/buffer.h>
+#include <tvm/tirx/expr.h>
+#include <tvm/tirx/op.h>
+
+#include <cstdint>
+
+namespace tvm {
+namespace tl {
+
+/*! \brief Return whether a dtype uses packed four-bit buffer storage. */
+inline bool IsPacked4BitStorage(DataType dtype) {
+  return dtype.is_float4_e2m1fn() ||
+         (dtype.bits() == 4 && (dtype.is_int() || dtype.is_uint()));
+}
+
+/*! \brief Return the physical storage bytes for a constant element count. */
+inline int64_t GetBufferStorageSizeBytes(int64_t num_elements, DataType dtype) {
+  if (IsPacked4BitStorage(dtype)) {
+    int64_t total_bits = num_elements * dtype.bits() * dtype.lanes();
+    return (total_bits + 7) / 8;
+  }
+  return num_elements * dtype.bytes() * dtype.lanes();
+}
+
+/*! \brief Return the physical storage bytes for a symbolic element count. */
+inline PrimExpr GetBufferStorageSizeBytes(const PrimExpr &num_elements,
+                                          DataType dtype) {
+  DataType index_dtype = num_elements.dtype();
+  if (IsPacked4BitStorage(dtype)) {
+    int64_t storage_bits = static_cast<int64_t>(dtype.bits()) * dtype.lanes();
+    PrimExpr total_bits =
+        num_elements * tirx::make_const(index_dtype, storage_bits);
+    return ceildiv(total_bits, tirx::make_const(index_dtype, 8));
+  }
+  int64_t storage_bytes = static_cast<int64_t>(dtype.bytes()) * dtype.lanes();
+  return num_elements * tirx::make_const(index_dtype, storage_bytes);
+}
+
+/*!
+ * \brief Return the physical storage bytes required by a compact buffer.
+ *
+ * DataType::bytes() rounds each scalar lane up to one byte.  Packed FP4 and
+ * four-bit integer buffers are exceptions because their buffer ABI stores two
+ * logical scalar values per byte.
+ */
+inline PrimExpr GetBufferStorageSizeBytes(const tirx::Buffer &buffer) {
+  DataType index_dtype = DataType::Int(32);
+  if (!buffer->shape.empty()) {
+    index_dtype = buffer->shape[0].dtype();
+  }
+  if (!index_dtype.is_int() && !index_dtype.is_uint()) {
+    index_dtype = DataType::Int(32);
+  }
+
+  PrimExpr num_elements = tirx::make_const(index_dtype, 1);
+  for (const PrimExpr &extent : buffer->shape) {
+    PrimExpr typed_extent = extent;
+    if (typed_extent.dtype() != index_dtype) {
+      typed_extent = tirx::Cast(index_dtype, typed_extent);
+    }
+    num_elements = num_elements * typed_extent;
+  }
+  return GetBufferStorageSizeBytes(num_elements, buffer->dtype);
+}
+
+} // namespace tl
+} // namespace tvm
+
+#endif // TVM_TL_TRANSFORM_COMMON_STORAGE_SIZE_H_

--- a/src/transform/lower_device_kernel_launch.cc
+++ b/src/transform/lower_device_kernel_launch.cc
@@ -31,6 +31,7 @@
 #include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/transform.h>
 
+#include "common/storage_size.h"
 #include "runtime/thread_storage_scope.h"
 #include "tir/transforms/ir_utils.h"
 
@@ -171,13 +172,7 @@ private:
           << "Only one dynamic shared memory allocation is allowed.";
       ICHECK_GT(op->buffer->shape.size(), 0);
 
-      PrimExpr dyn_size = Integer(1);
-      for (const auto &extent : op->buffer->shape) {
-        dyn_size *= extent;
-      }
-      dyn_size *= op->buffer->dtype.bytes() * op->buffer->dtype.lanes();
-
-      dyn_shmem_size = dyn_size;
+      dyn_shmem_size = GetBufferStorageSizeBytes(op->buffer);
     }
     StmtVisitor::VisitStmt_(op);
   }

--- a/src/transform/merge_shared_memory_allocations.cc
+++ b/src/transform/merge_shared_memory_allocations.cc
@@ -44,6 +44,7 @@
 #include <utility>
 
 #include "../op/builtin.h"
+#include "common/storage_size.h"
 #include "runtime/thread_storage_scope.h"
 #include "tir/transforms/ir_utils.h"
 #include <tvm/tirx/function.h>
@@ -570,25 +571,7 @@ private:
 
     for (const VarNode *var : sorted_vars) {
       const AllocBufferNode *alloc = shmem_allocs_.at(var);
-      int64_t bytes_per_elem = static_cast<int64_t>(
-          alloc->buffer->dtype.bytes() * alloc->buffer->dtype.lanes());
-
-      DataType size_dtype = DataType::Int(32);
-      if (!alloc->buffer->shape.empty()) {
-        size_dtype = alloc->buffer->shape[0].dtype();
-      }
-      if (!size_dtype.is_int() && !size_dtype.is_uint()) {
-        size_dtype = DataType::Int(32);
-      }
-
-      PrimExpr size_expr = make_const(size_dtype, bytes_per_elem);
-      for (const PrimExpr &extent : alloc->buffer->shape) {
-        PrimExpr e = extent;
-        if (e.dtype() != size_dtype) {
-          e = cast(size_dtype, e);
-        }
-        size_expr = size_expr * e;
-      }
+      PrimExpr size_expr = GetBufferStorageSizeBytes(alloc->buffer);
 
       int alignment = align_bytes_;
       auto align_it = shmem_alignment_map_.find(var);
@@ -627,9 +610,8 @@ private:
           auto alloc_it = shmem_allocs_.find(buffer_var_node);
           if (alloc_it != shmem_allocs_.end()) {
             const AllocBufferNode *alloc = alloc_it->second;
-            PrimExpr buffer_size_bytes = alloc->buffer->shape[0] *
-                                         alloc->buffer->dtype.bytes() *
-                                         alloc->buffer->dtype.lanes();
+            PrimExpr buffer_size_bytes =
+                GetBufferStorageSizeBytes(alloc->buffer);
             LOG(DEBUG) << "    Buffer: " << buffer_var_node->name_hint
                        << " (Type: " << alloc->buffer->dtype << ")"
                        << ", Start Offset: " << byte_offset
@@ -1406,30 +1388,14 @@ private:
       }
 
       const AllocBufferNode *alloc = shmem_allocs_.at(var);
-      int64_t bytes_per_elem = static_cast<int64_t>(
-          alloc->buffer->dtype.bytes() * alloc->buffer->dtype.lanes());
-      DataType size_dtype = DataType::Int(32);
-      if (!alloc->buffer->shape.empty()) {
-        size_dtype = alloc->buffer->shape[0].dtype();
-      }
-      if (!size_dtype.is_int() && !size_dtype.is_uint()) {
-        size_dtype = DataType::Int(32);
-      }
-
-      PrimExpr size_expr = make_const(size_dtype, bytes_per_elem);
-      for (const PrimExpr &extent : alloc->buffer->shape) {
-        PrimExpr e = extent;
-        if (e.dtype() != size_dtype) {
-          e = cast(size_dtype, e);
-        }
-        size_expr = size_expr * e;
-      }
-      info.size_dtype = size_dtype;
+      PrimExpr size_expr = GetBufferStorageSizeBytes(alloc->buffer);
+      info.size_dtype = size_expr.dtype();
       info.size_expr = size_expr;
 
       auto const_size = GetRef<AllocBuffer>(alloc).ConstantAllocationSize();
       if (const_size.has_value()) {
-        info.const_size_bytes = const_size.value() * bytes_per_elem;
+        info.const_size_bytes = GetBufferStorageSizeBytes(
+            static_cast<int64_t>(const_size.value()), alloc->buffer->dtype);
       }
 
       buf_infos.push_back(std::move(info));

--- a/testing/python/amd/test_tilelang_hip_codegen.py
+++ b/testing/python/amd/test_tilelang_hip_codegen.py
@@ -1,7 +1,7 @@
 """
 Regression tests for HIP/AMD codegen fixes in TileLang.
 
-Covers six bug fixes across five source files:
+Covers seven bug fixes across five source files:
 
   Fix 1 (reduce.h)            warp_reduce 5-step butterfly with width=32
   Fix 2 (codegen_hip.cc,      ShuffleNode bfloat16x2/float16x2 packing;
@@ -15,6 +15,8 @@ Covers six bug fixes across five source files:
   Fix 6 (pipeline_planning.cc) T.Pipelined(num_stages>1) falls back to a
                                plain sequential loop on ROCM to avoid LDS
                                overflow (hipModuleLaunchKernel EINVAL)
+  Fix 7 (codegen_hip.cc)      Packed int4 shared allocations round their
+                              int32 storage-word extent up instead of down
 """
 
 import pytest
@@ -22,6 +24,29 @@ import torch
 import tilelang
 import tilelang.testing
 import tilelang.language as T
+
+
+# ---------------------------------------------------------------------------
+# Fix 7 — src/rocm/codegen/codegen_hip.cc
+#   Packed scalar int4/uint4 use one int32 storage word per eight elements.
+# ---------------------------------------------------------------------------
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize(
+    "dtype,storage_type",
+    [(T.int4, "int"), (T.dtype("uint4"), "uint")],
+)
+def test_static_packed_int4_shared_allocation_rounds_up(dtype, storage_type):
+    @T.prim_func
+    def kernel():
+        with T.Kernel(1, threads=1):
+            A_shared = T.alloc_shared((127,), dtype, scope="shared")
+            A_shared[126] = T.cast(1, dtype)
+
+    artifact = tilelang.lower(kernel, target="hip")
+
+    assert f"{storage_type} A_shared[16];" in artifact.kernel_source
 
 
 # ---------------------------------------------------------------------------

--- a/testing/python/amd/test_tilelang_mxfp4_gfx950.py
+++ b/testing/python/amd/test_tilelang_mxfp4_gfx950.py
@@ -54,6 +54,19 @@ def _fp4_decode(packed: bytes):
     return result
 
 
+@tilelang.testing.requires_gfx950
+def test_static_fp4_shared_allocation_uses_packed_extent():
+    @T.prim_func
+    def kernel():
+        with T.Kernel(1, threads=1):
+            A_shared = T.alloc_shared((127,), T.float4_e2m1fn, scope="shared")
+            A_shared[126] = T.cast(0.0, T.float4_e2m1fn)
+
+    artifact = tilelang.lower(kernel, target={"kind": "hip", "mcpu": "gfx950"})
+
+    assert "fp4_e2_t A_shared[64];" in artifact.kernel_source
+
+
 # ---------------------------------------------------------------------------
 # Test 1: FP4 copy — shared-memory round-trip
 # ---------------------------------------------------------------------------

--- a/testing/python/components/test_cuda_shared_memory_alias_codegen.py
+++ b/testing/python/components/test_cuda_shared_memory_alias_codegen.py
@@ -1,6 +1,13 @@
+import pytest
 import tilelang
 import tilelang.language as T
 import tilelang.testing
+
+
+def _get_dynamic_shared_memory_bytes(artifact):
+    device_funcs = list(artifact.device_mod.functions.values())
+    assert len(device_funcs) == 1
+    return int(device_funcs[0].attrs["dyn_shared_memory_buf"])
 
 
 @tilelang.testing.requires_cuda
@@ -28,6 +35,110 @@ def test_dynamic_shared_memory_merge_emits_named_aliases():
     assert "A_shared" in source
     assert "B_shared" in source
     assert "((half_t*)buf_dyn_shmem)" not in source
+    assert _get_dynamic_shared_memory_bytes(artifact) == 128
+
+
+@tilelang.testing.requires_cuda
+def test_static_and_local_fp4_allocations_use_packed_extents():
+    @T.prim_func
+    def kernel():
+        with T.Kernel(1, threads=1):
+            A_shared = T.alloc_shared((127,), T.float4_e2m1fn, scope="shared")
+            A_local = T.alloc_local((127,), T.float4_e2m1fn)
+            A_shared[126] = T.cast(0.0, T.float4_e2m1fn)
+            A_local[126] = A_shared[126]
+
+    source = tilelang.lower(kernel, target="cuda").kernel_source
+
+    assert "fp4_e2_t A_shared[64];" in source
+    assert "fp4_e2_2_t A_local_packed[64];" in source
+
+
+@tilelang.testing.requires_cuda
+def test_single_dynamic_fp4_allocation_uses_packed_size():
+    @T.prim_func
+    def kernel():
+        with T.Kernel(1, threads=1):
+            A_shared = T.alloc_shared((127,), T.float4_e2m1fn)
+            A_shared[126] = T.cast(0.0, T.float4_e2m1fn)
+
+    artifact = tilelang.lower(kernel, target="cuda")
+
+    assert "extern __shared__ __align__(1024) fp4_e2_t A_shared[];" in artifact.kernel_source
+    assert _get_dynamic_shared_memory_bytes(artifact) == 64
+
+
+@tilelang.testing.requires_cuda
+def test_merged_dynamic_fp4_allocations_use_packed_sizes_and_offsets():
+    @T.prim_func
+    def kernel():
+        with T.Kernel(1, threads=1):
+            A_shared = T.alloc_shared((127,), T.float4_e2m1fn)
+            B_shared = T.alloc_shared((127,), T.float4_e2m1fn)
+            A_shared[126] = T.cast(0.0, T.float4_e2m1fn)
+            B_shared[126] = T.cast(1.0, T.float4_e2m1fn)
+            T.tvm_storage_sync("shared")
+            A_shared[0] = B_shared[126]
+
+    artifact = tilelang.lower(kernel, target="cuda")
+    source = artifact.kernel_source
+
+    assert "extern __shared__ __align__(1024) uchar buf_dyn_shmem[];" in source
+    assert "void* A_shared = ((void*)((char*)buf_dyn_shmem + 0));" in source
+    assert "void* B_shared = ((void*)((char*)buf_dyn_shmem + 64));" in source
+    assert _get_dynamic_shared_memory_bytes(artifact) == 128
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize(
+    "dtype,storage_type",
+    [(T.int4, "signed char"), (T.dtype("uint4"), "uchar")],
+)
+def test_static_packed_int4_allocation_uses_packed_extent(dtype, storage_type):
+    @T.prim_func
+    def kernel():
+        with T.Kernel(1, threads=1):
+            A_shared = T.alloc_shared((127,), dtype, scope="shared")
+            A_shared[126] = T.cast(1, dtype)
+
+    source = tilelang.lower(kernel, target="cuda").kernel_source
+
+    assert f"{storage_type} A_shared[64];" in source
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("dtype", [T.int4, T.dtype("uint4")])
+def test_single_dynamic_packed_int4_allocation_uses_packed_size(dtype):
+    @T.prim_func
+    def kernel():
+        with T.Kernel(1, threads=1):
+            A_shared = T.alloc_shared((127,), dtype)
+            A_shared[126] = T.cast(1, dtype)
+
+    artifact = tilelang.lower(kernel, target="cuda")
+
+    assert _get_dynamic_shared_memory_bytes(artifact) == 64
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("dtype", [T.int4, T.dtype("uint4")])
+def test_merged_dynamic_packed_int4_allocations_use_packed_sizes_and_offsets(dtype):
+    @T.prim_func
+    def kernel():
+        with T.Kernel(1, threads=1):
+            A_shared = T.alloc_shared((127,), dtype)
+            B_shared = T.alloc_shared((127,), dtype)
+            A_shared[126] = T.cast(0, dtype)
+            B_shared[126] = T.cast(1, dtype)
+            T.tvm_storage_sync("shared")
+            A_shared[0] = B_shared[126]
+
+    artifact = tilelang.lower(kernel, target="cuda")
+    source = artifact.kernel_source
+
+    assert "void* A_shared = ((void*)((char*)buf_dyn_shmem + 0));" in source
+    assert "void* B_shared = ((void*)((char*)buf_dyn_shmem + 64));" in source
+    assert _get_dynamic_shared_memory_bytes(artifact) == 128
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Correct shared-memory sizing for packed FP4, int4, and uint4 buffers.
- Prevent dynamic and merged shared-memory planning from treating every logical 4-bit element as a full byte.
- Preserve the existing byte-based storage ABI for non-packed data types.

## Changes

- Add a common physical storage-size helper that uses bit-level ceiling division for packed 4-bit buffers.
- Use the helper for dynamic shared-memory launch metadata and both shared-memory merge planners.
- Round CUDA byte-backed and HIP word-backed static shared allocations up for odd logical extents.
- Add CUDA and HIP codegen coverage for static, dynamic, and merged packed allocations, including odd-sized buffers.

## Validation

- `./format.sh`
- `cmake --build build -j$(nproc)`
- `python -m pytest -q testing/python/components/test_cuda_shared_memory_alias_codegen.py testing/python/language/test_tilelang_language_access_ptr_codegen.py::test_vectorized_int4_cp_async_num_elems_codegen testing/python/language/test_tilelang_language_float4_e2m1_unpacked_dtype.py testing/python/amd/test_tilelang_hip_codegen.py::test_static_packed_int4_shared_allocation_rounds_up` (18 passed, 2 skipped)

## Notes

- HIP-specific pytest cases are ROCm-gated and were skipped when ROCm was unavailable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Corrected shared-memory sizing for packed FP4, int4, and uint4 buffers across CUDA and HIP.
- Added shared storage-size helpers with bit-level ceiling division for packed 4-bit types while preserving byte-based sizing for other types.
- Applied packed sizing to dynamic shared-memory metadata and shared-memory merge planning.
- Rounded up static packed allocations for odd logical extents.
- Added CUDA and HIP coverage for static, dynamic, merged, and odd-sized packed allocations.

## Validation

- Formatting, builds, and targeted tests completed successfully.
- 18 tests passed; 2 were skipped because ROCm was unavailable.

## C++ style / lint notes

- The PR changes C++ source and headers but does not modify the rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) is relevant to the changed C++ code; any findings are advisory and should be evaluated separately from correctness, build, and test results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->