### PR TITLE
[BugFix] Respect runtime pointer alignment when vectorizing tensor views

### DIFF
--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -805,6 +805,23 @@ private:
 
     int buffer_vec_size = loop_extent_vector_size_;
 
+    // A vector access of `vec_size` lanes issues a `vec_size * elem_bits`-wide
+    // load/store whose address is only guaranteed to be a multiple of the
+    // buffer's base alignment plus an elem_offset the divisibility checks
+    // below reason about. The base alignment itself is recorded in
+    // buffer->data_alignment: ordinary allocations and kernel arguments carry
+    // the default kAllocAlignment (64B, never restrictive here), but a buffer
+    // viewing an opaque runtime pointer (e.g. T.make_tensor over an address)
+    // may only be element-aligned, so cap the vector width by it.
+    if (IsGlobalBuffer(buffer)) {
+      int elem_bits = buffer->dtype.bits() * buffer->dtype.lanes();
+      if (buffer->data_alignment > 0 && elem_bits > 0) {
+        int align_lanes =
+            std::max(buffer->data_alignment * 8 / elem_bits, 1);
+        buffer_vec_size = arith::ZeroAwareGCD(buffer_vec_size, align_lanes);
+      }
+    }
+
     // Transform indices using layout_map if present
     auto transformed_indices = TransformIndices(indices, buffer);
 

--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -816,8 +816,7 @@ private:
     if (IsGlobalBuffer(buffer)) {
       int elem_bits = buffer->dtype.bits() * buffer->dtype.lanes();
       if (buffer->data_alignment > 0 && elem_bits > 0) {
-        int align_lanes =
-            std::max(buffer->data_alignment * 8 / elem_bits, 1);
+        int align_lanes = std::max(buffer->data_alignment * 8 / elem_bits, 1);
         buffer_vec_size = arith::ZeroAwareGCD(buffer_vec_size, align_lanes);
       }
     }

--- a/tilelang/language/proxy.py
+++ b/tilelang/language/proxy.py
@@ -325,7 +325,6 @@ def make_tensor_from_addr(
 
     dtype = _normalize_tensor_dtype(dtype)
     if align is None:
-        
         dtype_info = DataType(dtype)
         align = max(dtype_info.bits * dtype_info.lanes // 8, 1)
     pointer_var = _materialize_pointer_from_addr(addr, dtype, storage_scope)

--- a/tilelang/language/proxy.py
+++ b/tilelang/language/proxy.py
@@ -313,7 +313,9 @@ def make_tensor_from_addr(
     dtype: DType = "float32",
     strides: tuple[PrimExpr, ...] | None = None,
     storage_scope: str = "global",
+    align: int | None = None,
 ) -> tirx.Buffer:
+
     from tilelang.language.eager.builder import Builder
 
     if Builder.current() is None:
@@ -322,12 +324,20 @@ def make_tensor_from_addr(
         )
 
     dtype = _normalize_tensor_dtype(dtype)
+    if align is None:
+        
+        dtype_info = DataType(dtype)
+        align = max(dtype_info.bits * dtype_info.lanes // 8, 1)
     pointer_var = _materialize_pointer_from_addr(addr, dtype, storage_scope)
-    return buffer(shape, dtype=dtype, data=pointer_var, strides=strides, scope=storage_scope)
+    return buffer(shape, dtype=dtype, data=pointer_var, strides=strides, scope=storage_scope, align=align)
 
 
 def make_tensor(
-    ptr: Var | PrimExpr, shape: ShapeType, dtype: DType = "float32", strides: tuple[PrimExpr, ...] | None = None
+    ptr: Var | PrimExpr,
+    shape: ShapeType,
+    dtype: DType = "float32",
+    strides: tuple[PrimExpr, ...] | None = None,
+    align: int | None = None,
 ) -> tirx.Buffer:
     from tilelang.language.eager.builder import Builder
 
@@ -340,4 +350,4 @@ def make_tensor(
 
     ptr_type = _get_pointer_type_annotation(ptr)
     storage_scope = ptr_type.storage_scope if ptr_type is not None and ptr_type.storage_scope else "global"
-    return make_tensor_from_addr(ptr, shape, dtype=dtype, strides=strides, storage_scope=storage_scope)
+    return make_tensor_from_addr(ptr, shape, dtype=dtype, strides=strides, storage_scope=storage_scope, align=align)


### PR DESCRIPTION
## Summary

Fixes #2526.

When a tensor view is created from a runtime address, the underlying pointer alignment may be weaker than the default alignment assumed by the compiler. This can cause the vectorizer to generate vectorized memory accesses (e.g. int4 loads) for pointers that are not properly aligned, resulting in CUDA misaligned address errors.

This PR adds explicit alignment propagation for tensors created from runtime addresses and uses the alignment information to constrain vectorization.

## Root Cause

The vectorization decision depends on `Buffer.data_alignment`.

For tensors created from runtime addresses, the alignment information was not explicitly specified. As a result, the generated Buffer could contain an inaccurate alignment assumption.

A pointer with insufficient alignment could therefore be treated as vectorizable:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Propagate explicit or inferred alignment through `make_tensor` and `make_tensor_from_addr`.
- Constrain global-buffer vectorization using `buffer->data_alignment`, preventing unsafe wide accesses from insufficiently aligned runtime pointers.
- Preserve vectorization when alignment is proven, while reducing vector width for weaker alignment.

## C++ style / lint notes

- The C++ change does not modify rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) may report advisory findings; these are not correctness or build blockers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->