### PR TITLE
[BugFix] Fix WGMMA C-store layout for multiple warpgroups along M

### DIFF
--- a/testing/python/issue/test_tilelang_issue_2522.py
+++ b/testing/python/issue/test_tilelang_issue_2522.py
@@ -1,0 +1,112 @@
+"""Regression test for GitHub issue #2522."""
+
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.language import GemmWarpPolicy
+
+
+def _matmul(block_M, block_N, block_K, threads, policy, pass_configs=None):
+    """Single-block GEMM: C[block_M, block_N] = A @ B over K = 2 * block_K."""
+    M, N, K = block_M, block_N, block_K * 2
+
+    @T.prim_func
+    def main(A: T.Tensor((M, K), "float16"), B: T.Tensor((K, N), "float16"), C: T.Tensor((M, N), "float16")):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), "float16")
+            B_shared = T.alloc_shared((block_K, block_N), "float16")
+            C_frag = T.alloc_fragment((block_M, block_N), "float32")
+            T.clear(C_frag)
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=2):
+                T.copy(A[by * block_M, k * block_K], A_shared)
+                T.copy(B[k * block_K, bx * block_N], B_shared)
+                T.gemm(A_shared, B_shared, C_frag, policy=policy)
+            T.copy(C_frag, C[by * block_M, bx * block_N])
+
+    return tilelang.compile(main, out_idx=-1, pass_configs=pass_configs)
+
+
+def _check(kernel, M, N, K, seed=0):
+    torch.manual_seed(seed)
+    A = torch.randint(0, 3, (M, K), dtype=torch.float16, device="cuda")
+    B = torch.randint(0, 3, (K, N), dtype=torch.float16, device="cuda")
+    ref = A.float() @ B.float()
+    out = kernel(A, B).float()
+    torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+
+@tilelang.testing.requires_cuda_compute_version(9, 0)
+def test_wgmma_fullrow_two_warpgroups_along_m():
+    """FullRow, block_M=256, threads=256: m_warp=8 (two warpgroups along M).
+
+    The configuration reported in issue #2522: without the warpgroup-major
+    store layout, output rows [64:128) and [128:192) are exchanged.
+    """
+    kernel = _matmul(256, 128, 32, 256, GemmWarpPolicy.FullRow)
+    assert "wgmma" in kernel.get_kernel_source()
+    _check(kernel, 256, 128, 64)
+
+
+@tilelang.testing.requires_cuda_compute_version(9, 0)
+def test_wgmma_fullrow_single_warpgroup():
+    """FullRow, block_M=128, threads=128: single warpgroup along M."""
+    kernel = _matmul(128, 128, 32, 128, GemmWarpPolicy.FullRow)
+    assert "wgmma" in kernel.get_kernel_source()
+    _check(kernel, 128, 128, 64)
+
+
+@tilelang.testing.requires_cuda_compute_version(9, 0)
+def test_wgmma_two_warpgroups_with_col_warps():
+    """FullRow, block_M=128, threads=512: m_warp=8, n_warp=2.
+
+    Exercises block_col_warps > 1 together with multiple warpgroups along M
+    (warp_rows=1).  Guards the ordering of the inter-warpgroup and warp_n
+    thread repeats: warp_id = warp_m + block_row_warps * warp_n, so warp_n
+    must be the outermost repeat, not interleaved between the in-group warps
+    and the warpgroup index.
+    """
+    kernel = _matmul(128, 256, 32, 512, GemmWarpPolicy.FullRow)
+    assert "wgmma" in kernel.get_kernel_source()
+    _check(kernel, 128, 256, 64)
+
+
+@tilelang.testing.requires_cuda_compute_version(9, 0)
+def test_wgmma_two_warpgroups_col_warps_multi_atom():
+    """Square, block_M=256, block_N=16, threads=512: m_warp=8, n_warp=2, warp_rows=2.
+
+    All three layers of the M decomposition are active at once: multiple
+    warpgroups along M, multiple warps along N, and multiple 64-row WGMMA
+    atoms per warpgroup.  Uses K-major B (transpose_B) since block_N=16
+    N-major shared layouts are not supported.
+    """
+    M, N, K = 256, 16, 64
+    block_K, threads = 32, 512
+
+    @T.prim_func
+    def main(A: T.Tensor((M, K), "float16"), B: T.Tensor((N, K), "float16"), C: T.Tensor((M, N), "float16")):
+        with T.Kernel(1, 1, threads=threads) as (bx, by):
+            A_shared = T.alloc_shared((M, block_K), "float16")
+            B_shared = T.alloc_shared((N, block_K), "float16")
+            C_frag = T.alloc_fragment((M, N), "float32")
+            T.clear(C_frag)
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=2):
+                T.copy(A[0, k * block_K], A_shared)
+                T.copy(B[0, k * block_K], B_shared)
+                T.gemm(A_shared, B_shared, C_frag, transpose_B=True, policy=GemmWarpPolicy.Square)
+            T.copy(C_frag, C[0, 0])
+
+    kernel = tilelang.compile(main, out_idx=-1)
+    assert "wgmma" in kernel.get_kernel_source()
+
+    torch.manual_seed(0)
+    A = torch.randint(0, 3, (M, K), dtype=torch.float16, device="cuda")
+    B = torch.randint(0, 3, (N, K), dtype=torch.float16, device="cuda")
+    ref = A.float() @ B.float().T
+    out = kernel(A, B).float()
+    torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/issue/test_tilelang_issue_2522.py
+++ b/testing/python/issue/test_tilelang_issue_2522.py
@@ -37,7 +37,7 @@ def _check(kernel, M, N, K, seed=0):
     torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
 
 
-@tilelang.testing.requires_cuda_compute_version(9, 0)
+@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
 def test_wgmma_fullrow_two_warpgroups_along_m():
     """FullRow, block_M=256, threads=256: m_warp=8 (two warpgroups along M).
 
@@ -49,7 +49,7 @@ def test_wgmma_fullrow_two_warpgroups_along_m():
     _check(kernel, 256, 128, 64)
 
 
-@tilelang.testing.requires_cuda_compute_version(9, 0)
+@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
 def test_wgmma_fullrow_single_warpgroup():
     """FullRow, block_M=128, threads=128: single warpgroup along M."""
     kernel = _matmul(128, 128, 32, 128, GemmWarpPolicy.FullRow)
@@ -57,7 +57,7 @@ def test_wgmma_fullrow_single_warpgroup():
     _check(kernel, 128, 128, 64)
 
 
-@tilelang.testing.requires_cuda_compute_version(9, 0)
+@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
 def test_wgmma_two_warpgroups_with_col_warps():
     """FullRow, block_M=128, threads=512: m_warp=8, n_warp=2.
 
@@ -72,7 +72,7 @@ def test_wgmma_two_warpgroups_with_col_warps():
     _check(kernel, 128, 256, 64)
 
 
-@tilelang.testing.requires_cuda_compute_version(9, 0)
+@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
 def test_wgmma_two_warpgroups_col_warps_multi_atom():
     """Square, block_M=256, block_N=16, threads=512: m_warp=8, n_warp=2, warp_rows=2.
 

--- a/tilelang/cuda/intrinsics/macro/wgmma_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/wgmma_macro_generator.py
@@ -909,6 +909,20 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
             forward_index_fn=forward_index,
         )
         warp_n_layout = base_fragment.repeat([1, warp_cols], False, False)
-        block_layout = warp_n_layout.repeat([block_row_warps, block_col_warps], True, False)
-        warp_m_layout = block_layout.repeat([warp_rows, 1], False, False)
+        # Decompose M warpgroup-major to match the instruction-issue side:
+        # each group of 4 warps owns a contiguous 128-row tile, and the
+        # per-warpgroup 64-row WGMMA atoms are consecutive local accumulator
+        # indices (see C_offset in wgmma_ss_atom).
+        wg_row_warps = 4
+        assert block_row_warps % wg_row_warps == 0, f"block_row_warps must be a multiple of {wg_row_warps} for WGMMA, got {block_row_warps}"
+        num_warp_groups_m = block_row_warps // wg_row_warps
+        # Four M warps forming one warpgroup.
+        warpgroup_layout = warp_n_layout.repeat([wg_row_warps, 1], True, False)
+        # Per-warpgroup WGMMA M atoms are local accumulator indices.
+        warpgroup_layout = warpgroup_layout.repeat([warp_rows, 1], False, False)
+        # Repeat complete warpgroups along M.
+        warp_m_layout = warpgroup_layout.repeat([num_warp_groups_m, 1], True, False)
+        # Preserve the physical warp order:
+        # warp_id = warp_m + block_row_warps * warp_n.
+        warp_m_layout = warp_m_layout.repeat([1, block_col_warps], True, False)
         return warp_m_layout

--- a/tilelang/cuda/intrinsics/macro/wgmma_sp_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/wgmma_sp_macro_generator.py
@@ -589,6 +589,20 @@ class WGSparseTensorCoreIntrinEmitter(SparseTensorCoreIntrinEmitter):
             forward_index_fn=forward_index,
         )
         warp_n_layout = base_fragment.repeat([1, warp_cols], False, False)
-        block_layout = warp_n_layout.repeat([block_row_warps, block_col_warps], True, False)
-        warp_m_layout = block_layout.repeat([warp_rows, 1], False, False)
+        # Decompose M warpgroup-major to match the instruction-issue side:
+        # each group of 4 warps owns a contiguous 128-row tile, and the
+        # per-warpgroup 64-row WGMMA atoms are consecutive local accumulator
+        # indices (see C_offset in wgmma_sp).
+        wg_row_warps = 4
+        assert block_row_warps % wg_row_warps == 0, f"block_row_warps must be a multiple of {wg_row_warps} for WGMMA, got {block_row_warps}"
+        num_warp_groups_m = block_row_warps // wg_row_warps
+        # Four M warps forming one warpgroup.
+        warpgroup_layout = warp_n_layout.repeat([wg_row_warps, 1], True, False)
+        # Per-warpgroup WGMMA M atoms are local accumulator indices.
+        warpgroup_layout = warpgroup_layout.repeat([warp_rows, 1], False, False)
+        # Repeat complete warpgroups along M.
+        warp_m_layout = warpgroup_layout.repeat([num_warp_groups_m, 1], True, False)
+        # Preserve the physical warp order:
+        # warp_id = warp_m + block_row_warps * warp_n.
+        warp_m_layout = warp_m_layout.repeat([1, block_col_warps], True, False)
         return warp_m_layout


### PR DESCRIPTION
### Summary

Fixes #2522: a WGMMA `T.gemm` with more than one warpgroup along M (`block_row_warps > 4`, e.g. `FullRow` with `block_M=256, threads=256`) compiled and ran without error but silently swapped 64-row output sub-blocks across the warpgroup boundary (for `block_M=256`, rows `[64:128)` and `[128:192)` were exchanged — 128 of 256 rows wrong, deterministic).

The WGMMA instruction-issue side (`wgmma_ss_atom`) decomposes M warpgroup-major: warp `w` owns the 16-row strip at `(w // 4) * 128 * num_inst_m + inst_m * 64 + (w % 4) * 16`, matching the PTX wgmma D-fragment layout, with the per-warpgroup 64-row atoms stored as consecutive local accumulator indices (`C_offset = inst_m_idx * warp_cols * local_size_out`). `make_mma_store_layout` instead flattened all `block_row_warps` warps onto the thread axis and pushed the atom count to a
stride-`block_row_warps * 16` outer index — inverting the "which warpgroup" vs "which 64-row atom" roles. The two decompositions coincide only for a single warpgroup (`block_row_warps == 4`), so the bug was invisible in all `block_M <= 128`-per-warpgroup configs.

### Changes

- `tilelang/cuda/intrinsics/macro/wgmma_macro_generator.py` (`make_mma_store_layout`): decompose the M axis warpgroup-major to match the instruction-issue side, built in four `repeat` steps:
  1. 4 in-group warps along M on the **thread** axis (one warpgroup, 128 rows);
  2. per-warpgroup 64-row WGMMA atoms (`warp_rows`) on the local  **index** axis, matching `C_offset` in `wgmma_ss_atom`;
  3. warpgroups along M on the **thread** axis;
  4. `block_col_warps` as the **outermost** thread repeat, preserving the physical warp order `warp_id = warp_m + block_row_warps * warp_n` from `extract_thread_binding`.

  For `block_row_warps == 4` this is algebraically identical to the previous layout (step 3 is the identity and steps 1+4 fuse into the old `[block_row_warps, block_col_warps]` thread repeat), so single-warpgroup configs are bit-for-bit unchanged. A `block_row_warps % 4 == 0` assert guards the invariant already enforced by `ComputeWgmmaWarpPartition`.

- `testing/python/issue/test_tilelang_issue_2522.py`: new regression tests (sm_90) covering each layer of the M decomposition:
  - `FullRow, block_M=256, threads=256` — two warpgroups along M (the reported config);
  - `FullRow, block_M=128, threads=128` — single warpgroup baseline;
  - `FullRow, block_M=128, threads=512` — `m_warp=8, n_warp=2`, guards the ordering of the inter-warpgroup and `warp_n` thread repeats;
  - `Square, block_M=256, block_N=16, threads=512, transpose_B` — `m_warp=8, n_warp=2, warp_rows=2`, all three M-decomposition layers active at once;


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed WGMMA `T.gemm` C-store row mapping for `GemmWarpPolicy.FullRow` when using multiple warpgroups along M, preventing silent 64-row output sub-block swapping across warpgroup boundaries (e.g., `block_M=256`).
- Reworked `make_mma_store_layout` in the WGMMA macro generators to use a warpgroup-major M decomposition (with `wg_row_warps=4`) aligned with WGMMA instruction issue order and accumulator offsets.
- Preserved the existing layout behavior for single-warpgroup configurations and added an assertion that `block_row_warps` is divisible by 4.
- Applied the same warpgroup-major fix to the sparse WGMMA (`WGSparseTensorCoreIntrinEmitter`) variant.
- Added SM90 regression tests for multi-warpgroup and single-warpgroup FullRow GEMM correctness across multiple warp arrangements and multi-atom configurations, validating compiled kernels include `"wgmma"` and match PyTorch references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->