### PR TITLE
[TIR][Transform] Fix flat Bind modeling in parallel race checks

### DIFF
--- a/src/transform/common/constr_visitor.h
+++ b/src/transform/common/constr_visitor.h
@@ -183,9 +183,18 @@ public:
       Base::VisitExpr(false_value);
     }
   }
-  void VisitStmt_(const tirx::BindNode *op) override {
-    auto guard = MakeGuard(op->var, op->value);
-    Base::VisitStmt_(op);
+  void VisitStmt_(const tirx::BindNode *op) override { Base::VisitStmt_(op); }
+  void VisitStmt_(const tirx::SeqStmtNode *op) override {
+    size_t old_size = constr_stack_.size();
+    for (const tirx::Stmt &stmt : op->seq) {
+      Base::VisitStmt(stmt);
+      if (const auto *bind = stmt.as<tirx::BindNode>()) {
+        // A flat Bind defines its variable for following statements in this
+        // sequence, but not while its own value is being evaluated.
+        constr_stack_.emplace_back(bind->var, bind->value);
+      }
+    }
+    constr_stack_.resize(old_size);
   }
   void VisitStmt_(const tirx::AttrStmtNode *op) override {
     if (op->attr_key == tirx::attr::tilelang_assume) {

--- a/src/transform/verify_parallel_loop.cc
+++ b/src/transform/verify_parallel_loop.cc
@@ -12,6 +12,7 @@
 #include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/transform.h>
 #include <tvm/tirx/var.h>
+#include <utility>
 
 namespace tvm::tl {
 
@@ -41,40 +42,66 @@ struct ParallelLoopVerifier : public ConstrVisitor {
       StmtExprVisitor::VisitStmt_(op);
       return;
     }
+    if (parallel_loop_vars_.empty()) {
+      StmtExprVisitor::VisitStmt_(op);
+      return;
+    }
+
     ConstrSet cset{constr_stack_};
-    std::vector<Var> other_thread_vars_;
+    std::vector<std::pair<Var, Var>> parallel_var_pairs;
+    std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> parallel_vars;
     Map<Var, PrimExpr> subs;
     for (const auto &var : parallel_loop_vars_) {
-      Var v_other_thread(var->name_hint + "<OTHER>", var->dtype);
-      other_thread_vars_.push_back(v_other_thread);
-      subs.Set(var, v_other_thread);
+      Var other_var(var->name_hint + "<OTHER>", var->dtype);
+      parallel_var_pairs.emplace_back(var, other_var);
+      parallel_vars.insert(var);
+      subs.Set(var, other_var);
     }
+
+    // Bind variables defined within a parallel loop are private SSA values of
+    // each logical iteration. Give the second iteration its own definitions;
+    // sharing them would incorrectly force the parallel loop variables equal.
+    bool inside_parallel_scope = false;
+    for (const Constr &constr : constr_stack_) {
+      if (constr.kind == Constr::kBindRange &&
+          parallel_vars.count(constr.var)) {
+        inside_parallel_scope = true;
+      } else if (inside_parallel_scope && constr.kind == Constr::kBindValue) {
+        Var other_var(constr.var->name_hint + "<OTHER>", constr.var->dtype);
+        subs.Set(constr.var, other_var);
+      }
+    }
+
     cset.Extend(cset.Substitute(subs));
     for (const auto &idx : op->indices) {
       cset.AddConstr(idx == tirx::Substitute(idx, subs));
     }
     arith::Analyzer analyzer;
     cset.Populate(analyzer);
-    // If we can prove the values are the same, then no data race can happen.
-    if (analyzer.CanProve(op->value == tirx::Substitute(op->value, subs))) {
+
+    PrimExpr same_iteration = Bool(true);
+    for (const auto &[var, other_var] : parallel_var_pairs) {
+      same_iteration = And(same_iteration, EQ(var, other_var));
+    }
+    PrimExpr same_value = op->value == tirx::Substitute(op->value, subs);
+    PrimExpr race_free = Or(same_iteration, same_value);
+    if (analyzer.CanProve(race_free)) {
       StmtExprVisitor::VisitStmt_(op);
       return;
     }
+
     Array<Var> failed_vars;
-    PrimExpr failed_var_expr;
-    for (auto [k, v] : subs) {
-      if (!analyzer.CanProve(k == v)) {
-        failed_vars.push_back(k);
-        failed_var_expr =
-            failed_var_expr.defined() ? And(failed_var_expr, k == v) : (k == v);
+    for (const auto &[var, other_var] : parallel_var_pairs) {
+      if (!analyzer.CanProve(EQ(var, other_var))) {
+        failed_vars.push_back(var);
       }
     }
     if (!failed_vars.empty()) {
       LOG(WARNING) << "Data race detected: `" << op->buffer << op->indices
-                   << "`"
+                   << "` "
                    << "is written by multiple threads in loop " << failed_vars
                    << ", Example:\n"
-                   << analyzer.z3_prover.GetModel(failed_var_expr)
+                   << analyzer.z3_prover.GetModel(race_free)
                    << "If you believe this is a false positive, pass "
                       "`PassKey.TL_DISABLE_DATA_RACE_CHECK` to pass key to "
                       "disable this check.";

--- a/testing/python/transform/test_tilelang_transform_verify_parallel_loop.py
+++ b/testing/python/transform/test_tilelang_transform_verify_parallel_loop.py
@@ -1,0 +1,46 @@
+import tilelang as tl
+import tilelang.testing
+from tilelang import tvm
+
+
+def _make_parallel_store(*, injective_indices: bool, varying_value: bool = True):
+    output = tvm.tirx.decl_buffer((32, 128), "int32", name="output")
+    ti = tvm.tirx.Var("ti", "int32")
+    tj = tvm.tirx.Var("tj", "int32")
+    i = tvm.tirx.Var("i", "int32")
+    j = tvm.tirx.Var("j", "int32")
+
+    indices = [i, j] if injective_indices else [0, 0]
+    value = ti * 128 + tj if varying_value else 1
+    store = tvm.tirx.BufferStore(output, value, indices)
+    body = tvm.tirx.SeqStmt([tvm.tirx.Bind(i, ti), tvm.tirx.Bind(j, tj), store])
+    body = tvm.tirx.For(tj, 0, 128, tvm.tirx.ForKind.PARALLEL, body)
+    body = tvm.tirx.For(ti, 0, 32, tvm.tirx.ForKind.PARALLEL, body)
+    return tvm.IRModule.from_expr(tvm.tirx.PrimFunc([output], body))
+
+
+def _verify(mod, capfd):
+    tl.transform.VerifyParallelLoop()(mod)
+    return capfd.readouterr().err
+
+
+def test_flat_bind_indices_are_proven_race_free(capfd):
+    mod = _make_parallel_store(injective_indices=True)
+
+    assert "Data race detected" not in _verify(mod, capfd)
+
+
+def test_irrelevant_flat_binds_do_not_hide_race(capfd):
+    mod = _make_parallel_store(injective_indices=False)
+
+    assert "Data race detected" in _verify(mod, capfd)
+
+
+def test_same_value_parallel_store_is_allowed(capfd):
+    mod = _make_parallel_store(injective_indices=False, varying_value=False)
+
+    assert "Data race detected" not in _verify(mod, capfd)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

- Fix false-positive data-race warnings when parallel stores use indices defined through flat `Bind` statements.
- Preserve detection of real races by modeling each logical parallel iteration with independent local SSA values.

## Changes

- Keep flat `Bind` constraints visible to subsequent statements in the enclosing `SeqStmt`, matching TIRX scope semantics.
- Alpha-rename `Bind` variables defined inside parallel scopes when constructing the second logical iteration.
- Prove race freedom with the combined condition that colliding stores come from the same iteration or write the same value.
- Add transform regression tests for injective bound indices, irrelevant bindings around a real race, and benign same-value stores.

## Validation

- `./format.sh`
- `cmake --build build -j$(nproc)`
- `python -m pytest testing/python/transform/test_tilelang_transform_verify_parallel_loop.py testing/python/transform/test_tilelang_transform_thread_sync.py -q`
- `python -m pytest testing/python/language/test_tilelang_language_let.py -q`
- `python debug/0714_assume/none_positive_warning.py`

## Notes

- Same-value concurrent stores remain accepted, preserving the checker’s existing behavior.
