### PR TITLE
[BugFix] Reject invalid atomic load and store memory orders

### DIFF
--- a/testing/python/language/test_tilelang_language_atomic.py
+++ b/testing/python/language/test_tilelang_language_atomic.py
@@ -1,3 +1,4 @@
+import pytest
 import tilelang.testing
 import tilelang.layout
 import tilelang.language as T
@@ -600,6 +601,46 @@ def run_atomic_load_store(M, N, block_M, block_N, dtype=T.float32):
     B = torch.zeros(M, N, dtype=getattr(torch, dtype)).cuda()
     kernel(A, B)
     torch.testing.assert_close(B, A, atol=1e-3, rtol=1e-3)
+
+
+def _build_atomic_load_with_memory_order(memory_order):
+    @T.prim_func
+    def kernel(source: T.Tensor((1,), T.int32), output: T.Tensor((1,), T.int32)):
+        with T.Kernel(1, threads=1):
+            output[0] = T.atomic_load(source[0], memory_order=memory_order)
+
+    return kernel
+
+
+def _build_atomic_store_with_memory_order(memory_order):
+    @T.prim_func
+    def kernel(destination: T.Tensor((1,), T.int32)):
+        with T.Kernel(1, threads=1):
+            T.atomic_store(destination[0], 1, memory_order=memory_order)
+
+    return kernel
+
+
+@pytest.mark.parametrize("memory_order", ["relaxed", "consume", "acquire", "seq_cst"])
+def test_atomic_load_accepts_valid_memory_orders(memory_order):
+    assert _build_atomic_load_with_memory_order(memory_order) is not None
+
+
+@pytest.mark.parametrize("memory_order", ["release", "acq_rel", "invalid"])
+def test_atomic_load_rejects_unsupported_memory_orders(memory_order):
+    with pytest.raises(ValueError, match="atomic_load does not support memory_order"):
+        _build_atomic_load_with_memory_order(memory_order)
+
+
+@pytest.mark.parametrize("memory_order", ["relaxed", "release", "seq_cst"])
+def test_atomic_store_accepts_valid_memory_orders(memory_order):
+    assert _build_atomic_store_with_memory_order(memory_order) is not None
+
+
+@pytest.mark.parametrize("memory_order", ["consume", "acquire", "acq_rel", "invalid"])
+def test_atomic_store_rejects_unsupported_memory_orders(memory_order):
+    with pytest.raises(ValueError, match="atomic_store does not support memory_order"):
+        _build_atomic_store_with_memory_order(memory_order)
 
 
 @tilelang.testing.requires_cuda

--- a/tilelang/language/atomic.py
+++ b/tilelang/language/atomic.py
@@ -17,6 +17,15 @@ _MEMORY_ORDER_ID_MAP = {
     "seq_cst": 5,
 }
 
+_ATOMIC_LOAD_MEMORY_ORDERS = frozenset({"relaxed", "consume", "acquire", "seq_cst"})
+_ATOMIC_STORE_MEMORY_ORDERS = frozenset({"relaxed", "release", "seq_cst"})
+
+
+def _get_memory_order_id(operation: str, memory_order: str, valid_orders: frozenset[str]) -> int:
+    if memory_order not in valid_orders:
+        raise ValueError(f"{operation} does not support memory_order={memory_order!r}; expected one of {sorted(valid_orders)}")
+    return _MEMORY_ORDER_ID_MAP[memory_order]
+
 
 def atomic_max(dst: Buffer, value: PrimExpr, memory_order: str | None = None, return_prev: bool = False) -> PrimExpr:
     """
@@ -360,8 +369,10 @@ def atomic_load(src: Buffer, memory_order: str = "seq_cst") -> PrimExpr:
 
     Performs an atomic load from `src` and returns a PrimExpr representing the loaded value.
     memory_order selects the ordering and must be one of: "relaxed", "consume", "acquire",
-    "release", "acq_rel", or "seq_cst" (default).
-    Raises KeyError if an unknown memory_order is provided.
+    or "seq_cst" (default).
+
+    Raises:
+        ValueError: If memory_order is not valid for an atomic load.
 
     Note: atomic_load always returns the loaded value, so no return_prev parameter is needed.
 
@@ -394,7 +405,7 @@ def atomic_load(src: Buffer, memory_order: str = "seq_cst") -> PrimExpr:
         src.dtype,
         op.Op.get("tl.atomic_load_elem_op"),
         T.access_ptr(src, "r"),
-        _MEMORY_ORDER_ID_MAP[memory_order],
+        _get_memory_order_id("atomic_load", memory_order, _ATOMIC_LOAD_MEMORY_ORDERS),
     )
 
 
@@ -405,15 +416,15 @@ def atomic_store(dst: Buffer, src: PrimExpr, memory_order: str = "seq_cst") -> P
     Parameters:
         dst (Buffer): Destination buffer to store into.
         src (PrimExpr): Value to store.
-        memory_order (str, optional): Memory ordering name; one of "relaxed", "consume",
-            "acquire", "release", "acq_rel", or "seq_cst". Defaults to "seq_cst".
+        memory_order (str, optional): Memory ordering name; one of "relaxed", "release",
+            or "seq_cst". Defaults to "seq_cst".
             The name is mapped to an internal numeric ID used by the underlying runtime.
 
     Returns:
         PrimExpr: A handle representing the issued atomic store operation.
 
     Raises:
-        KeyError: If `memory_order` is not one of the supported names.
+        ValueError: If memory_order is not valid for an atomic store.
 
     Note: atomic_store doesn't return a previous value, so no return_prev parameter is needed.
 
@@ -453,7 +464,7 @@ def atomic_store(dst: Buffer, src: PrimExpr, memory_order: str = "seq_cst") -> P
         op.Op.get("tl.atomic_store_elem_op"),
         T.access_ptr(dst, "w"),
         src,
-        _MEMORY_ORDER_ID_MAP[memory_order],
+        _get_memory_order_id("atomic_store", memory_order, _ATOMIC_STORE_MEMORY_ORDERS),
     )
 
 


### PR DESCRIPTION
## Summary

`T.atomic_load` and `T.atomic_store` previously accepted every order in the shared memory-order map, including combinations that are invalid for the corresponding C++ atomic operation. These combinations compiled successfully but triggered a device-side assertion in libcu++ at runtime.

## Fix

Add operation-specific frontend validation:

* `atomic_load` accepts `relaxed`, `consume`, `acquire`, and `seq_cst`;
* `atomic_store` accepts `relaxed`, `release`, and `seq_cst`;
* invalid or unsupported values raise a clear `ValueError` before lowering.

The corresponding docstrings were updated, and regression tests were added for both valid and invalid memory-order combinations.

## Tested

Verified locally with the atomic memory-order regression tests, the existing CUDA atomic load/store tests, related transform tests, and pre-commit checks.

Fixes #2574


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added operation-specific validation for `T.atomic_load` and `T.atomic_store` memory orders.
- Invalid orders now raise a frontend `ValueError` before code generation.
- Updated docstrings to document supported memory orders.
- Added regression tests covering valid and invalid load/store combinations.

## Testing

- Atomic and transform test suites
- Pre-commit checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->