### PR TITLE
[BugFix] Support T.infinity for float8_e5m2

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -5527,6 +5527,17 @@ inline void PrintConst(const FloatImmNode *op, std::ostream &os,
   }
   // Type code is kFloat8_e5m2 or kE4M4Float
   if (op->dtype.is_float8() || op->dtype.is_float4()) {
+    // e5m2 inf/NaN have no float-literal spelling; emit the bit pattern.
+    if (op->dtype.is_float8_e5m2() && std::isinf(op->value)) {
+      p->PrintType(op->dtype, os);
+      os << "::bitcast(" << (op->value < 0 ? "0xfc" : "0x7c") << ")";
+      return;
+    }
+    if (op->dtype.is_float8_e5m2() && std::isnan(op->value)) {
+      p->PrintType(op->dtype, os);
+      os << "::bitcast(0x7e)";
+      return;
+    }
     p->PrintType(op->dtype, os);
     os << '(' << FlexibleHexFormat(op->value) << 'f';
     os << "/*" << std::scientific << op->value << "*/";

--- a/src/op/math.cc
+++ b/src/op/math.cc
@@ -51,6 +51,10 @@ PrimExpr infinity_op(PrimExpr args) {
     return FloatImm(dtype, std::numeric_limits<float>::infinity(), call->span);
   } else if (dtype.is_tfloat32()) {
     return FloatImm(dtype, std::numeric_limits<float>::infinity(), call->span);
+  } else if (dtype.is_float8_e5m2()) {
+    // e5m2 is the only fp8 format with a representable inf; the rest keep
+    // the fatal below.
+    return FloatImm(dtype, std::numeric_limits<float>::infinity(), call->span);
   }
   LOG(FATAL) << "Cannot decide infinity for type " << dtype;
   throw; // Unreachable, keeps compiler happy

--- a/testing/python/language/test_tilelang_language_infinity.py
+++ b/testing/python/language/test_tilelang_language_infinity.py
@@ -27,6 +27,7 @@ def test_infinity():
     _test_infinity(T.bfloat16)
     _test_infinity(T.float32)
     _test_infinity(T.float64)
+    _test_infinity(T.float8_e5m2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`T.infinity` aborted with an internal `LOG(FATAL)` ("Cannot decide infinity for type float8_e5m2") because `infinity_op` had no fp8 branch. e5m2 is the only fp8 format with a representable inf, so add a branch returning +inf, and emit it in codegen via its bit pattern (`::bitcast(0x7c)`, mirroring the tfloat32 path) since inf/NaN cannot be spelled as a float literal for the fp8 constructor. Other fp8 formats (e4m3*, e3m4, e8m0, finite fnuz incl. e5m2fnuz) have no inf and keep the fatal. Adds e5m2 to the infinity test.

Fixes #2670.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `float8_e5m2` support to `T.infinity`, returning its representable positive infinity.
- Generated FP8 e5m2 infinities and NaNs using the appropriate `::bitcast` bit patterns.
- Preserved existing rejection behavior for unsupported FP8 formats.
- Extended CUDA infinity coverage for `T.float8_e5m2`.
- Fixes issue `#2670`.

## C++ style / lint notes

- The PR changes C++ implementation files but does not appear to touch rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) remains relevant; no new public API declarations are introduced.
- Any TLCPP003/TLCPP004 findings would be advisory and should not block merging absent a clear API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->