### PR TITLE
[BugFix] Return previous value for scalar atomic_min/atomic_max

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -4629,6 +4629,24 @@ bool CodeGenTileLangCUDA::HandleLateIntrinsicCall(const CallNode *op,
     }
     this->stream << ");\n";
     return true;
+  } else if (op->op.same_as(tl::atomic_addx2_ret_elem_op())) {
+    need_atomic_h_ = true;
+    // fp16/bf16 x2 is stored as uint1 but AtomicAddx2Ret returns half2/bf162;
+    // bridge with to_uint1. float32 is native float2, emitted bare.
+    bool need_cast = op->dtype.is_float16() || op->dtype.is_bfloat16();
+    if (need_cast) {
+      os << "tl::to_uint1(";
+    }
+    os << "AtomicAddx2Ret(" << PrintExpr(op->args[0]) << ", "
+       << PrintExpr(op->args[1]);
+    if (op->args.size() > 2) {
+      os << ", " << PrintExpr(op->args[2]);
+    }
+    os << ")";
+    if (need_cast) {
+      os << ")";
+    }
+    return true;
   } else if (op->op.same_as(tl::atomic_addx4_elem_op())) {
     need_atomic_h_ = true;
     // atomic_addx4_elem_op(dst_ptr, src_ptr[, memory_order])
@@ -4640,6 +4658,16 @@ bool CodeGenTileLangCUDA::HandleLateIntrinsicCall(const CallNode *op,
       this->stream << ", " << PrintExpr(op->args[2]);
     }
     this->stream << ");\n";
+    return true;
+  } else if (op->op.same_as(tl::atomic_addx4_ret_elem_op())) {
+    need_atomic_h_ = true;
+    // AtomicAddx4Ret already returns the store type (float4 / uint2), so bare.
+    os << "AtomicAddx4Ret(" << PrintExpr(op->args[0]) << ", "
+       << PrintExpr(op->args[1]);
+    if (op->args.size() > 2) {
+      os << ", " << PrintExpr(op->args[2]);
+    }
+    os << ")";
     return true;
   } else if (op->op.same_as(tl::atomic_load_elem_op())) {
     need_atomic_h_ = true;

--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -615,7 +615,17 @@ TIR_DEFINE_TL_BUILTIN(atomic_addx2_elem_op)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
+TIR_DEFINE_TL_BUILTIN(atomic_addx2_ret_elem_op)
+    .set_num_inputs(3)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
 TIR_DEFINE_TL_BUILTIN(atomic_addx4_elem_op)
+    .set_num_inputs(3)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(atomic_addx4_ret_elem_op)
     .set_num_inputs(3)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -1117,12 +1117,30 @@ TVM_DLL const Op &atomic_add_ret_elem_op();
 TVM_DLL const Op &atomic_addx2_elem_op();
 
 /*!
+ * \brief tilelang intrinsic for vectorized (x2) atomic addition with return
+ * value.
+ *
+ *  This op is used to represent a vectorized atomic add operation (2 elements)
+ * in tilelang that returns the previous packed value.
+ */
+TVM_DLL const Op &atomic_addx2_ret_elem_op();
+
+/*!
  * \brief tilelang intrinsic for vectorized (x4) atomic addition.
  *
  *  This op is used to represent a vectorized atomic add operation (4 elements)
  * in tilelang.
  */
 TVM_DLL const Op &atomic_addx4_elem_op();
+
+/*!
+ * \brief tilelang intrinsic for vectorized (x4) atomic addition with return
+ * value.
+ *
+ *  This op is used to represent a vectorized atomic add operation (4 elements)
+ * in tilelang that returns the previous packed value.
+ */
+TVM_DLL const Op &atomic_addx4_ret_elem_op();
 
 /*!
  * \brief tilelang intrinsic for atomic load.

--- a/src/tl_templates/cuda/atomic.h
+++ b/src/tl_templates/cuda/atomic.h
@@ -597,6 +597,21 @@ AtomicAddx2Ret(half_t *ref, ValType val,
   }
 }
 
+// No single-atomic fp16x4 exists, so this is two per-pair AtomicAddx2Ret
+// (per-pair atomic, like the fp32-x4 fallback). Returns uint2 (the half4 store
+// type): the two half2 packed.
+template <typename SrcType>
+TL_DEVICE uint2
+AtomicAddx4Ret(half_t *ref, SrcType *val,
+               int memory_order = int(cuda::memory_order_relaxed)) {
+  half2 prev_lo = AtomicAddx2Ret(ref, val, memory_order);
+  half2 prev_hi = AtomicAddx2Ret(ref + 2, val + 2, memory_order);
+  uint2 ret;
+  ret.x = *reinterpret_cast<const unsigned int *>(&prev_lo);
+  ret.y = *reinterpret_cast<const unsigned int *>(&prev_hi);
+  return ret;
+}
+
 #if (defined(__CUDA_ARCH_LIST__) && (__CUDA_ARCH_LIST__ > 750))
 template <typename T> TL_DEVICE __nv_bfloat162 ToBfloat162(T *val) {
   return *reinterpret_cast<const __nv_bfloat162 *>(val);
@@ -660,6 +675,19 @@ AtomicAddx2Ret(bfloat16_t *ref, src_type *val,
         tl_atomic_detail::UnpackBits16<__nv_bfloat16>(ret_val_x_cast),
         tl_atomic_detail::UnpackBits16<__nv_bfloat16>(ret_val_y_cast));
   }
+}
+
+// bf16 counterpart of the fp16 AtomicAddx4Ret above.
+template <typename SrcType>
+TL_DEVICE uint2
+AtomicAddx4Ret(bfloat16_t *ref, SrcType *val,
+               int memory_order = int(cuda::memory_order_relaxed)) {
+  __nv_bfloat162 prev_lo = AtomicAddx2Ret(ref, val, memory_order);
+  __nv_bfloat162 prev_hi = AtomicAddx2Ret(ref + 2, val + 2, memory_order);
+  uint2 ret;
+  ret.x = *reinterpret_cast<const unsigned int *>(&prev_lo);
+  ret.y = *reinterpret_cast<const unsigned int *>(&prev_hi);
+  return ret;
 }
 #endif
 

--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -313,6 +313,15 @@ private:
     }
 
     PrimExpr safe_value = GetSafeValue(fallback_ptr->base_load->buffer);
+    // Cast preserves the lane count, so vector-returning atomics need their
+    // scalar buffer fallback broadcast before any element-type conversion.
+    if (safe_value.dtype().lanes() != call.dtype().lanes()) {
+      ICHECK(safe_value.dtype().is_scalar() &&
+             call.dtype().is_fixed_length_vector())
+          << "Cannot adapt safe value " << safe_value << " with dtype "
+          << safe_value.dtype() << " to atomic return dtype " << call.dtype();
+      safe_value = Broadcast(safe_value, call.dtype().lanes());
+    }
     if (safe_value.dtype() != call.dtype()) {
       safe_value = Cast(call.dtype(), safe_value);
     }
@@ -407,7 +416,8 @@ private:
   // Check if the call is an atomic operation
   bool IsAtomicOp(const Op &op) {
     return op == atomic_add_elem_op() || op == atomic_add_ret_elem_op() ||
-           op == atomic_addx2_elem_op() || op == atomic_addx4_elem_op() ||
+           op == atomic_addx2_elem_op() || op == atomic_addx2_ret_elem_op() ||
+           op == atomic_addx4_elem_op() || op == atomic_addx4_ret_elem_op() ||
            op == atomic_load_elem_op() || op == atomic_store_elem_op() ||
            op == atomic_max_elem_op() || op == atomic_max_ret_elem_op() ||
            op == atomic_min_elem_op() || op == atomic_min_ret_elem_op();

--- a/testing/python/language/test_tilelang_language_atomic.py
+++ b/testing/python/language/test_tilelang_language_atomic.py
@@ -730,5 +730,131 @@ def test_tile_atomic_max_expr():
     run_tile_atomic_max_expr(128, 128, 32, 32)
 
 
+def atomic_scalar_return_prev_program(op_name, val):
+    atom = getattr(T, op_name)
+
+    @T.prim_func
+    def main(Dst: T.Tensor((1,), "float32"), Prev: T.Tensor((1,), "float32")):
+        with T.Kernel(1, threads=1):
+            Prev[0] = atom(Dst[0], val, return_prev=True)
+
+    return main
+
+
+def run_atomic_scalar_return_prev(op_name):
+    # Pick val so the op actually changes dst (else a silent no-op would still
+    # pass): max needs val > dst, min needs val < dst.
+    val = 5.0 if op_name == "atomic_max" else 1.0
+    kernel = tilelang.compile(atomic_scalar_return_prev_program(op_name, val))
+    dst = torch.tensor([3.0], dtype=torch.float32).cuda()
+    prev = torch.zeros(1, dtype=torch.float32).cuda()
+    kernel(dst, prev)
+    assert prev.item() == 3.0, f"{op_name} return_prev should be the old value"
+    expected = max(3.0, val) if op_name == "atomic_max" else min(3.0, val)
+    assert dst.item() == expected, f"{op_name} should still update Dst"
+
+
+@tilelang.testing.requires_cuda
+def test_atomic_scalar_return_prev():
+    run_atomic_scalar_return_prev("atomic_max")
+    run_atomic_scalar_return_prev("atomic_min")
+
+
+def atomic_addx2_return_prev_program(dtype=T.float32):
+    @T.prim_func
+    def main(Dst: T.Tensor((2,), dtype), Val: T.Tensor((2,), dtype), Prev: T.Tensor((2,), dtype)):
+        with T.Kernel(1, threads=1):
+            Prev[0:2] = T.atomic_addx2(Dst[0], Val[0], return_prev=True)
+
+    return main
+
+
+def atomic_addx4_return_prev_program(dtype=T.float32):
+    @T.prim_func
+    def main(Dst: T.Tensor((4,), dtype), Val: T.Tensor((4,), dtype), Prev: T.Tensor((4,), dtype)):
+        with T.Kernel(1, threads=1):
+            Prev[0:4] = T.atomic_addx4(Dst[0], Val[0], return_prev=True)
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+def test_atomic_addx2_return_prev():
+    kernel = tilelang.compile(atomic_addx2_return_prev_program(T.float32))
+    assert "AtomicAddx2Ret" in kernel.get_kernel_source()
+    dst = torch.tensor([1.0, 2.0], dtype=torch.float32).cuda()
+    val = torch.tensor([10.0, 20.0], dtype=torch.float32).cuda()
+    prev = torch.zeros(2, dtype=torch.float32).cuda()
+    kernel(dst, val, prev)
+    torch.testing.assert_close(prev, torch.tensor([1.0, 2.0], device="cuda"))
+    torch.testing.assert_close(dst, torch.tensor([11.0, 22.0], device="cuda"))
+
+
+@tilelang.testing.requires_cuda
+def test_atomic_addx4_return_prev():
+    kernel = tilelang.compile(atomic_addx4_return_prev_program(T.float32))
+    assert "AtomicAddx4Ret" in kernel.get_kernel_source()
+    dst = torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch.float32).cuda()
+    val = torch.tensor([10.0, 20.0, 30.0, 40.0], dtype=torch.float32).cuda()
+    prev = torch.zeros(4, dtype=torch.float32).cuda()
+    kernel(dst, val, prev)
+    torch.testing.assert_close(prev, torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda"))
+    torch.testing.assert_close(dst, torch.tensor([11.0, 22.0, 33.0, 44.0], device="cuda"))
+
+
+def run_atomic_addx2_return_prev_16bit(dtype, torch_dtype):
+    # The 16-bit packed 2-lane vector is stored as uint1 in codegen, while
+    # AtomicAddx2Ret returns the native __half2 / __nv_bfloat162. The ret path
+    # must bridge with tl::to_uint1 so the store LHS (uint1) matches; otherwise
+    # nvcc fails with `no operator "=" ... uint1 = half2`.
+    kernel = tilelang.compile(atomic_addx2_return_prev_program(dtype))
+    src = kernel.get_kernel_source()
+    assert "tl::to_uint1(AtomicAddx2Ret" in src, src
+    dst = torch.tensor([1.0, 2.0], dtype=torch_dtype).cuda()
+    val = torch.tensor([10.0, 20.0], dtype=torch_dtype).cuda()
+    prev = torch.zeros(2, dtype=torch_dtype).cuda()
+    kernel(dst, val, prev)
+    torch.testing.assert_close(prev, torch.tensor([1.0, 2.0], dtype=torch_dtype, device="cuda"))
+    torch.testing.assert_close(dst, torch.tensor([11.0, 22.0], dtype=torch_dtype, device="cuda"))
+
+
+@tilelang.testing.requires_cuda
+def test_atomic_addx2_return_prev_fp16():
+    run_atomic_addx2_return_prev_16bit(T.float16, torch.float16)
+
+
+@tilelang.testing.requires_cuda
+def test_atomic_addx2_return_prev_bf16():
+    run_atomic_addx2_return_prev_16bit(T.bfloat16, torch.bfloat16)
+
+
+def run_atomic_addx4_return_prev_16bit(dtype, torch_dtype):
+    # There is NO single-atomic fp16x4/bf16x4 add in hardware (PTX vector
+    # atomic .v4 tops out at .f16x2 for 16-bit types). The x4 ret path realizes
+    # the quad as two per-pair AtomicAddx2Ret calls and returns them packed as
+    # a uint2 (a half4/bf16x4 is stored as uint2), matching the store LHS. This
+    # is per-pair atomic, not whole-quad -- the same contract as the fp32-x4
+    # scalar fallback.
+    kernel = tilelang.compile(atomic_addx4_return_prev_program(dtype))
+    src = kernel.get_kernel_source()
+    assert "AtomicAddx4Ret" in src, src
+    dst = torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch_dtype).cuda()
+    val = torch.tensor([10.0, 20.0, 30.0, 40.0], dtype=torch_dtype).cuda()
+    prev = torch.zeros(4, dtype=torch_dtype).cuda()
+    kernel(dst, val, prev)
+    torch.testing.assert_close(prev, torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch_dtype, device="cuda"))
+    torch.testing.assert_close(dst, torch.tensor([11.0, 22.0, 33.0, 44.0], dtype=torch_dtype, device="cuda"))
+
+
+@tilelang.testing.requires_cuda
+def test_atomic_addx4_return_prev_fp16():
+    run_atomic_addx4_return_prev_16bit(T.float16, torch.float16)
+
+
+@tilelang.testing.requires_cuda
+def test_atomic_addx4_return_prev_bf16():
+    run_atomic_addx4_return_prev_16bit(T.bfloat16, torch.bfloat16)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
+++ b/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
@@ -343,6 +343,62 @@ def atomic_add_return_access_ptr_legalize():
     return main, expected
 
 
+def atomic_addx2_return_access_ptr_legalize():
+    dtype = T.float32
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((16,), dtype=dtype),
+        B: T.Tensor((8,), dtype=dtype),
+        out: T.Tensor((8,), dtype=dtype),
+    ):
+        for i in T.serial(4):
+            out[i * 2 : i * 2 + 2] = T.atomic_addx2(A[i * 4 + 10], B[i * 2], return_prev=True)
+
+    @T.prim_func
+    def expected(
+        A: T.Tensor((16,), dtype=dtype),
+        B: T.Tensor((8,), dtype=dtype),
+        out: T.Tensor((8,), dtype=dtype),
+    ):
+        for i in T.serial(4):
+            out[i * 2 : i * 2 + 2] = T.if_then_else(
+                i < 2,
+                T.atomic_addx2(A[i * 4 + 10], B[i * 2], return_prev=True),
+                T.Broadcast(T.float32(0), 2),
+            )
+
+    return main, expected
+
+
+def atomic_addx4_return_access_ptr_legalize():
+    dtype = T.float32
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((16,), dtype=dtype),
+        B: T.Tensor((16,), dtype=dtype),
+        out: T.Tensor((16,), dtype=dtype),
+    ):
+        for i in T.serial(4):
+            out[i * 4 : i * 4 + 4] = T.atomic_addx4(A[i * 4 + 8], B[i * 4], return_prev=True)
+
+    @T.prim_func
+    def expected(
+        A: T.Tensor((16,), dtype=dtype),
+        B: T.Tensor((16,), dtype=dtype),
+        out: T.Tensor((16,), dtype=dtype),
+    ):
+        for i in T.serial(4):
+            out[i * 4 : i * 4 + 4] = T.if_then_else(
+                i < 2,
+                T.atomic_addx4(A[i * 4 + 8], B[i * 4], return_prev=True),
+                T.Broadcast(T.float32(0), 4),
+            )
+
+    return main, expected
+
+
 def atomic_store_access_ptr_legalize():
     dtype = T.int32
 
@@ -459,6 +515,12 @@ def assert_atomic_add_return_access_ptr_legalize():
     _assert_legalize_matches_expected(func, expected)
 
 
+def assert_atomic_vector_add_return_access_ptr_legalize():
+    for make_case in (atomic_addx2_return_access_ptr_legalize, atomic_addx4_return_access_ptr_legalize):
+        func, expected = make_case()
+        _assert_legalize_matches_expected(func, expected)
+
+
 def assert_atomic_store_access_ptr_legalize():
     func, expected = atomic_store_access_ptr_legalize()
     _assert_legalize_matches_expected(func, expected)
@@ -506,6 +568,10 @@ def test_atomic_load_access_ptr_oob():
 
 def test_atomic_add_return_access_ptr_oob():
     assert_atomic_add_return_access_ptr_legalize()
+
+
+def test_atomic_vector_add_return_access_ptr_oob():
+    assert_atomic_vector_add_return_access_ptr_legalize()
 
 
 def test_atomic_store_access_ptr_oob():

--- a/tilelang/language/atomic.py
+++ b/tilelang/language/atomic.py
@@ -64,11 +64,12 @@ def atomic_max(dst: Buffer, value: PrimExpr, memory_order: str | None = None, re
     if dst_extent is None and src_extent is None:
         # Scalar path: use atomicmax_elem_op intrinsic
         return_type = dst.dtype if return_prev else "handle"
+        atomic_max_op = op.Op.get("tl.atomic_max_ret_elem_op") if return_prev else op.Op.get("tl.atomic_max_elem_op")
         memory_order_id = _MEMORY_ORDER_ID_MAP[memory_order] if memory_order else 0
 
         return T.call_intrin(
             return_type,
-            op.Op.get("tl.atomic_max_elem_op"),
+            atomic_max_op,
             T.access_ptr(dst, "rw"),
             value,
             memory_order_id,
@@ -146,11 +147,12 @@ def atomic_min(dst: Buffer, value: PrimExpr, memory_order: str | None = None, re
     if dst_extent is None and src_extent is None:
         # Scalar path: use atomicmin_elem_op intrinsic
         return_type = dst.dtype if return_prev else "handle"
+        atomic_min_op = op.Op.get("tl.atomic_min_ret_elem_op") if return_prev else op.Op.get("tl.atomic_min_elem_op")
         memory_order_id = _MEMORY_ORDER_ID_MAP[memory_order] if memory_order else 0
 
         return T.call_intrin(
             return_type,
-            op.Op.get("tl.atomic_min_elem_op"),
+            atomic_min_op,
             T.access_ptr(dst, "rw"),
             value,
             memory_order_id,
@@ -311,8 +313,10 @@ def atomic_addx2(dst: Buffer, value: PrimExpr, return_prev: bool = False) -> Pri
         >>>         for j in range(0, grads.shape[1], 2):  # Process in pairs
         >>>             atomic_addx2(global_grads[i, j:j+2], grads[i, j:j+2])
     """
-    atomic_addx2_op = op.Op.get("tl.atomic_addx2_elem_op") if return_prev else op.Op.get("tl.atomic_addx2_elem_op")
-    return_type = dst.dtype if return_prev else "handle"
+    atomic_addx2_op = op.Op.get("tl.atomic_addx2_ret_elem_op") if return_prev else op.Op.get("tl.atomic_addx2_elem_op")
+    # The ret variant returns the two previous elements packed as a 2-lane
+    # vector (e.g. half2/float2); type it accordingly so the store matches.
+    return_type = f"{dst.dtype}x2" if return_prev else "handle"
     return T.call_intrin(return_type, atomic_addx2_op, T.access_ptr(dst, "rw"), T.access_ptr(value, "r"))
 
 
@@ -349,8 +353,13 @@ def atomic_addx4(dst: Buffer, value: PrimExpr, return_prev: bool = False) -> Pri
         >>> rgba_add = T.Tensor([4], "float32", name="rgba_add")
         >>> atomic_addx4(rgba_dst, rgba_add)  # Atomic blend of all 4 channels
     """
-    atomic_addx4_op = op.Op.get("tl.atomic_addx4_elem_op") if return_prev else op.Op.get("tl.atomic_addx4_elem_op")
-    return_type = "float4" if "float" in str(dst.dtype).lower() else "handle"
+    atomic_addx4_op = op.Op.get("tl.atomic_addx4_ret_elem_op") if return_prev else op.Op.get("tl.atomic_addx4_elem_op")
+    if return_prev:
+        # The ret variant returns the four previous elements packed as a 4-lane
+        # vector (e.g. float4); type it accordingly so the store matches.
+        return_type = f"{dst.dtype}x4"
+    else:
+        return_type = "float4" if "float" in str(dst.dtype).lower() else "handle"
     return T.call_intrin(return_type, atomic_addx4_op, T.access_ptr(dst, "rw"), T.access_ptr(value, "r"))
 
 


### PR DESCRIPTION
Scalar `atomic_min`/`atomic_max` and vectorized `atomic_addx2`/`atomic_addx4` typed their call with a non-void return under `return_prev=True` but always selected the void `*_elem_op`, so codegen emitted an empty binding (`prev = ;`) and nvcc failed with "expected an expression".

This selects the `*_ret_elem_op` variant under `return_prev`, as `atomic_add` already does:

- **min/max**: the ret ops, codegen handlers, and device templates (`AtomicMaxRet`/`AtomicMinRet`) already existed.
- **addx2/addx4, float32**: register the ret ops and add codegen handlers emitting `AtomicAddx2Ret`/`AtomicAddx4Ret` (already in the device headers) as expressions; the return is typed as the packed 2-/4-lane vector so the store matches.
- **addx2, fp16/bf16**: the ret store LHS is `uint1`, so codegen wraps the `half2`/`bf162` result with `tl::to_uint1`.
- **addx4, fp16/bf16**: add `AtomicAddx4Ret(half_t*)`/`(bfloat16_t*)` device overloads that run two `AtomicAddx2Ret` halves and return them packed as `uint2` (a fp16x4 is stored as `uint2`).

The 16-bit x4 path is **per-pair atomic** (two `half2` atomics), not whole-quad single-atomic — hardware has no vector atomic wider than `.f16x2` for 16-bit types. This matches the existing fp32-x4 scalar fallback, and the docstring only promises "quad-width atomic addition". Tests cover scalar/x2/x4 across float32/fp16/bf16.

Fixes #2667


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed scalar `atomic_min`/`atomic_max` with `return_prev=True` by selecting the correct `*_ret_elem_op` intrinsic variants, preventing invalid generated CUDA such as `prev = ;` for both integer and floating-point cases.
- Extended `atomic_addx2` and `atomic_addx4` with `return_prev=True` by registering new `atomic_addx{2,4}_ret_elem_op` intrinsics and adding CUDA codegen handlers that emit `AtomicAddx{2,4}Ret(...)` (including optional `memory_order`), returning packed vector types for the previous values.
- Updated `tilelang/language/atomic.py` to route `return_prev=True` through the new `*_ret_elem_op` intrinsics and to use packed vector return types for the previous-value result.
- Added CUDA template support for fp16/bf16 `atomic_addx4` previous-value returns (`AtomicAddx4Ret`) via two `AtomicAddx2Ret` calls and repacking into `uint2`; for `atomic_addx2` fp16/bf16, codegen additionally uses `tl::to_uint1(...)` bridging to match storage representation.
- Added/extended Python tests to validate previous-value correctness for scalar `atomic_min`/`atomic_max` (including the min/max test adjustment), and for vectorized `atomic_addx2`/`atomic_addx4` `return_prev` across float32, fp16, and bf16, including kernel codegen marker-string checks (`AtomicAddx2Ret`/`AtomicAddx4Ret`).
- Added legalization coverage for `atomic_addx2`/`atomic_addx4` `return_prev` on `access_ptr` bases, including an OOB guard test.

## C++ style / lint notes

- Touches C++ implementation files (`src/cuda/codegen/codegen_cuda.cc`, `src/op/builtin.cc/h`, `src/tl_templates/cuda/atomic.h`, `src/transform/legalize_safe_memory_access.cc`), but does **not** modify `docs/developer_guide/cpp_style.md` (no style-rule documentation changes).
- The “C++ API Style Audit (warning only)” CI step may surface advisory TLCPP003/TLCPP004 findings; any such warnings are expected to be non-blocking unless this PR introduces an actual API/FFI/maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->