### PR TITLE
[BugFix] Zero-extend signed int32 lanes in 256-bit vector pack

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -5222,15 +5222,16 @@ void CodeGenTileLangCUDA::VisitExpr_(const ShuffleNode *op,
     }
 
     const char *u64 = t.is_uint() ? "unsigned long long" : "long long";
-    const char *u32 = t.is_uint() ? "unsigned int" : "int";
     PrintVecConstructor(t, os);
     os << '(';
     for (int i = 0; i + 1 < lanes; i += 2) {
       if (i != 0)
         os << ", ";
-      // Pack lane i (lo) and lane i+1 (hi) into one 64-bit value.
-      os << "((" << u64 << ")(" << u32 << ")(" << scalars[i] << ")) | "
-         << "((" << u64 << ")(" << u32 << ")(" << scalars[i + 1] << ") << 32)";
+      // Pack lane i (lo) and lane i+1 (hi) into one 64-bit value. Widen through
+      // `unsigned int` so both lanes are zero-extended.
+      os << "(" << u64 << ")(((unsigned long long)(unsigned int)(" << scalars[i]
+         << ")) | ((unsigned long long)(unsigned int)(" << scalars[i + 1]
+         << ") << 32))";
     }
     os << ')';
     return;
@@ -5348,15 +5349,15 @@ void CodeGenTileLangCUDA::VisitExpr_(const BroadcastNode *op,
     int lanes = op->dtype.lanes();
     std::string v = PrintExpr(op->value);
     const char *u64 = op->dtype.is_uint() ? "unsigned long long" : "long long";
-    const char *u32 = op->dtype.is_uint() ? "unsigned int" : "int";
     os << "make_";
     PrintType(op->dtype, os);
     os << '(';
     for (int i = 0; i < lanes / 2; ++i) {
       if (i != 0)
         os << ", ";
-      os << "((" << u64 << ")(" << u32 << ")(" << v << ")) | "
-         << "((" << u64 << ")(" << u32 << ")(" << v << ") << 32)";
+      // Widen through `unsigned int` so both lanes are zero-extended.
+      os << "(" << u64 << ")(((unsigned long long)(unsigned int)(" << v
+         << ")) | ((unsigned long long)(unsigned int)(" << v << ") << 32))";
     }
     os << ')';
     return;


### PR DESCRIPTION
### Summary

Fixes #2489: a vectorized broadcast/shuffle store of a negative `int32` across a 256-bit vector (`int32x8`, typed as `longlong4`) silently wrote `-1` to the high lane of each packed 64-bit pair on sm_100.

Root cause: when packing two 32-bit lanes into a 64-bit slot, the signed path widened the low lane through `(long long)(int)`, which sign-extends — a negative value fills the high 32 bits with all-ones, which are then OR-ed over the high lane. The `is_uint()` sibling branch (zero-extend via `unsigned`) was already correct.

### Changes

- `src/cuda/codegen/codegen_cuda.cc`: in both 32-bit pack sites (`VisitExpr_(const ShuffleNode*)` and `VisitExpr_(const BroadcastNode*)`), widen both lanes through `unsigned int` → `unsigned long long` (zero-extend), then cast the packed 64-bit value back to the lane type (`long long` / `unsigned long long`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes incorrect packing of negative signed `int32` values during vectorized shuffle and broadcast stores on Blackwell (`sm_100`). Both 32-bit packing paths now zero-extend lanes through unsigned types before combining them into 64-bit values, preventing sign extension from corrupting adjacent high lanes while preserving unsigned behavior.

## C++ style / lint notes

The change touches C++ code but does not modify documented rules in `docs/developer_guide/cpp_style.md`. The warning-only C++ API Style Audit is not relevant to this internal codegen change; no correctness, build, or test issues are indicated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->