### PR TITLE
[BugFix] Fix operator precedence in increase_descriptor_offset guard

### DIFF
--- a/tilelang/language/builtin.py
+++ b/tilelang/language/builtin.py
@@ -1252,7 +1252,7 @@ def increase_descriptor_offset(descriptor: PrimExpr, offset: PrimExpr) -> PrimEx
     if not isinstance(descriptor, (BufferLoad, tirx.Buffer)):
         raise TypeError("Descriptor must be a tvm.tirx.Buffer or tvm.tirx.BufferLoad.")
 
-    if isinstance(descriptor, tirx.Buffer) and len(descriptor.shape) != 1 or descriptor.shape[0] != 1:
+    if isinstance(descriptor, tirx.Buffer) and (len(descriptor.shape) != 1 or descriptor.shape[0] != 1):
         raise ValueError("Descriptor must be a 1D buffer of size 1.")
 
     descriptor = descriptor if isinstance(descriptor, BufferLoad) else tirx.BufferLoad(descriptor, [0])


### PR DESCRIPTION
The Buffer-shape guard was missing parentheses, so `and` bound tighter than `or` and `descriptor.shape[0]` was evaluated even when `descriptor` is a BufferLoad (which has no `.shape`), raising an uncaught `AttributeError`. Parenthesize the `or` to match the two sibling helpers initialize_wgmma_descriptor / initialize_tcgen05_descriptor.

Fixes #2631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed operator precedence in `increase_descriptor_offset` buffer-shape validation.
- Restricted shape checks to `tirx.Buffer` inputs, allowing valid `BufferLoad` inputs such as `D[0]` to lower without `AttributeError`.
- Ensured descriptors are validated as 1D buffers of size 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->