### PR TITLE
[BugFix] reject float dtype in bitwise reduce with an actionable error

### DIFF
--- a/tilelang/language/reduce_op.py
+++ b/tilelang/language/reduce_op.py
@@ -44,6 +44,8 @@ def reduce(
     """
     if batch < 1:
         raise ValueError(f"batch must be >= 1, got {batch}")
+    if reduce_type in ("bitand", "bitor", "bitxor") and not (out.dtype.startswith(("int", "uint")) or out.dtype == "bool"):
+        raise ValueError(f"reduce_{reduce_type} requires an integer/bool buffer, got dtype {out.dtype}")
     # input shape: [X, d, Y], expected output shape: [X, Y] or [X, 1, Y]
     expected_shapes = [buffer.shape[:dim] + buffer.shape[dim + 1 :], buffer.shape[:dim] + [1] + buffer.shape[dim + 1 :]]
     if list(out.shape) not in expected_shapes:


### PR DESCRIPTION
reduce_bitand/bitor/bitxor admitted any buffer dtype, so a float destination died deep in lowering on an internal ICHECK (type_check_int_or_bool_args) instead of a user-facing diagnostic. Guard the reduce surface to reject non-integer/non-bool dtypes with a ValueError naming the op and dtype, mirroring the existing shape check.

Fixes #2570

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added reduce-surface validation for `bitand`, `bitor`, and `bitxor`.
- Raises an actionable `ValueError` for non-integer and non-boolean output dtypes, avoiding internal lowering `ICHECK` failures.
- Preserves valid integer and boolean reductions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->