### PR TITLE
[BugFix] Fix T.pow/T.power for constant integer exponent y <= 0

### DIFF
--- a/tilelang/language/tir/op.py
+++ b/tilelang/language/tir/op.py
@@ -3060,7 +3060,13 @@ def power(x, y, span=None):
         The result.
     """
     if isinstance(y, (int, IntImm)):
-        return pow_of_int(x, y)
+        # pow_of_int's `for (i = 1; i < y; ...)` loop only computes x**y for y >= 1.
+        yv = int(y)
+        if yv == 0:
+            return const(1, dtype=x.dtype)
+        if yv >= 1:
+            return pow_of_int(x, yv)
+        return _tvm_op.power(x, yv, span)
     return _tvm_op.power(x, y, span)
 
 
@@ -3084,7 +3090,13 @@ def pow(x, y, span=None):
         The result.
     """
     if isinstance(y, (int, IntImm)):
-        return pow_of_int(x, y)
+        # pow_of_int's `for (i = 1; i < y; ...)` loop only computes x**y for y >= 1.
+        yv = int(y)
+        if yv == 0:
+            return const(1, dtype=x.dtype)
+        if yv >= 1:
+            return pow_of_int(x, yv)
+        return _tvm_op.pow(x, yv, span)
     return _tvm_op.pow(x, y, span)
 
 


### PR DESCRIPTION
The frontend routed any constant integer exponent to pow_of_int, whose device loop only computes x**y for y >= 1, so y <= 0 silently returned the base x. Route y == 0 to a constant 1 and y < 0 to the generic power (reciprocal for float base) instead.

Fixes #2614

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed `T.pow` and `T.power` for constant integer exponents.
- Returns `1` for exponent `0`.
- Uses generic power implementation for negative exponents, enabling reciprocal behavior.
- Preserves existing optimized handling for positive integer exponents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->