### PR TITLE
[BugFix] Reject unsafe non-warp-multiple partial thread sync

### DIFF
--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -239,15 +239,15 @@ private:
 
 class ThreadPartialSyncRewriter : public IRMutatorWithAnalyzer {
 public:
-  static Stmt Rewrite(Stmt stmt) {
+  static Stmt Rewrite(Stmt stmt, int warp_size = 32) {
     arith::Analyzer analyzer;
-    ThreadPartialSyncRewriter rewriter(&analyzer);
+    ThreadPartialSyncRewriter rewriter(&analyzer, warp_size);
     return rewriter(std::move(stmt));
   }
 
 private:
-  explicit ThreadPartialSyncRewriter(arith::Analyzer *analyzer)
-      : IRMutatorWithAnalyzer(analyzer) {}
+  explicit ThreadPartialSyncRewriter(arith::Analyzer *analyzer, int warp_size)
+      : IRMutatorWithAnalyzer(analyzer), warp_size_(warp_size) {}
 
   Stmt VisitStmt_(const EvaluateNode *op) final {
     const CallNode *call = nullptr;
@@ -295,15 +295,16 @@ private:
 
     auto [barrier_id, thread_count] =
         GetOrCreateBarrier(key, extent_tx, extent_ty, extent_tz);
-    if (thread_count % 32 != 0) {
+    if (thread_count % warp_size_ != 0) {
       // TODO(lei): This is a workaround for the case where the thread count is
-      // not a multiple of 32. we should enhance the pass to analysis index
-      // instead of buffer expression etc.
-      // bar.sync requires a warp-multiple thread count; silently dropping
-      // the barrier causes a data race.
+      // not a multiple of the warp size. we should enhance the pass to analysis
+      // index instead of buffer expression etc. bar.sync requires a
+      // warp-multiple thread count; silently dropping the barrier causes a data
+      // race.
       LOG(FATAL) << "[ThreadSync] Cannot lower a required shared-memory sync "
                  << "inside a divergent region with " << thread_count
-                 << " participating threads (not a multiple of 32). "
+                 << " participating threads (not a multiple of " << warp_size_
+                 << "). "
                  << "Make the guarded thread range a warp multiple.";
     }
 
@@ -407,6 +408,7 @@ private:
       IterVar(Range::FromMinExtent(0, 1), Var("tz"), IterVarType::kDataPar);
   std::unordered_map<ThreadBoundKey, size_t> barrier_id_map_;
   std::unordered_map<ThreadBoundKey, size_t> thread_count_map_;
+  int warp_size_;
 };
 
 struct ConditionThreadProperty {
@@ -1891,7 +1893,7 @@ PrimFunc TileLangThreadSync(PrimFunc func, const std::string &storage_scope) {
   planner(stmt);
   stmt =
       ThreadSyncInserter(sync_scope, planner.syncs_inserted_)(std::move(stmt));
-  n->body = ThreadPartialSyncRewriter::Rewrite(std::move(stmt));
+  n->body = ThreadPartialSyncRewriter::Rewrite(std::move(stmt), warp_size);
   return func;
 }
 

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -299,7 +299,12 @@ private:
       // TODO(lei): This is a workaround for the case where the thread count is
       // not a multiple of 32. we should enhance the pass to analysis index
       // instead of buffer expression etc.
-      return Stmt();
+      // bar.sync requires a warp-multiple thread count; silently dropping
+      // the barrier causes a data race.
+      LOG(FATAL) << "[ThreadSync] Cannot lower a required shared-memory sync "
+                 << "inside a divergent region with " << thread_count
+                 << " participating threads (not a multiple of 32). "
+                 << "Make the guarded thread range a warp multiple.";
     }
 
     // Create new sync call with barrier info

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -763,5 +763,60 @@ def test_sync_hoist_non_uniform_if_in_loop_with_shared_memory():
     assert sync_pos < if_pos, f"Sync should be hoisted before non-uniform if:\n{s}"
 
 
+@tilelang.testing.requires_cuda
+def test_partial_sync_non_warp_multiple_rejected():
+    """Regression test for issue #2556: a required barrier inside a divergent
+    region whose participating thread count is not a multiple of the warp size
+    must be a compile-time error, not silently dropped (data race)."""
+    import pytest
+
+    @T.prim_func(private=True)
+    def func():
+        S = T.alloc_buffer((64,), dtype="float32", scope="shared")
+        acc = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 64)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        # 48 participating threads: not a warp multiple.
+        if tx < 48:
+            acc[0] = T.float32(0)
+            for i in range(2):
+                S[tx] = T.float32(1)
+                # Cross-thread read: planner must insert a sync here.
+                acc[0] += S[47 - tx]
+
+    mod = tvm.IRModule({"main": func})
+    with pytest.raises(Exception, match="not a multiple of 32"):
+        tilelang.transform.ThreadSync("shared")(mod)
+
+
+@tilelang.testing.requires_cuda
+def test_partial_sync_warp_multiple_still_lowered():
+    """Control for issue #2556: the same pattern with a warp-multiple
+    participating thread count must still lower to a partial barrier."""
+    import re
+
+    @T.prim_func(private=True)
+    def func():
+        S = T.alloc_buffer((64,), dtype="float32", scope="shared")
+        acc = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 64)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        # 32 participating threads: exactly one warp.
+        if tx < 32:
+            acc[0] = T.float32(0)
+            for i in range(2):
+                S[tx] = T.float32(1)
+                acc[0] += S[31 - tx]
+
+    mod = tvm.IRModule({"main": func})
+    mod = tilelang.transform.ThreadSync("shared")(mod)
+    s = str(mod.script())
+    assert re.search(r'tvm_storage_sync\("shared",\s*\d+,\s*32\)', s), f"Expected a partial barrier with thread_count=32:\n{s}"
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Summary

Fix #2556 .

Required shared-memory sync inside a divergent region with a non-warp-multiple participating thread count, e.g.

```python
if tx < 48:
    S[tx] = T.float32(1)
    acc[0] += S[47 - tx]
```

could be silently dropped by `ThreadSync`.

Root cause: partial `bar.sync` requires a warp-multiple thread count. When `ThreadSync` found a required sync in a divergent region whose participating thread count was not a multiple of 32, the pass returned an empty statement as a workaround. That means a required barrier could disappear instead of producing a compile-time error, leaving shared-memory cross-thread accesses with a potential data race.

## Changes

Changed one transform file:

- `src/transform/thread_storage_sync.cc`:
  - Replaced the silent barrier drop with a clear `LOG(FATAL)` when a required shared-memory sync is inside a divergent region with a non-warp-multiple thread count.
  - The error message reports the participating thread count and asks users to make the guarded thread range a warp multiple.

Added regression tests:

- `testing/python/transform/test_tilelang_transform_thread_sync.py`:
  - Added a test for a 48-thread divergent region that requires a shared-memory sync. This now raises an error instead of silently dropping the barrier.
  - Added a control test for a 32-thread divergent region to confirm warp-multiple partial barriers are still lowered correctly.

## Testing

- Ran: `pytest ~/tilelang/testing/python/transform/test_tilelang_transform_thread_sync.py -v`, 23 passed.
- Ran the original repro:
  - `ACTIVE=48`: compilation fails with expected error.
  - `ACTIVE=64`: behavior is unchanged.

Also ran `pre-commit run --all-files`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated `ThreadPartialSyncRewriter::ProcessSharedSync` in `src/transform/thread_storage_sync.cc` to prevent silently dropping required shared-memory `tvm_storage_sync` barriers for divergent regions when the participating thread count is not a warp-multiple.
- The pass now emits `LOG(FATAL)` (reporting the participating thread count and the warp-multiple requirement) when barrier lowering would be unsafe, with the check parameterized by the target `thread_warp_size` (defaulting to 32).
- Added CUDA regression tests in `testing/python/transform/test_tilelang_transform_thread_sync.py` to cover:
  - Rejection of a 48-thread divergent shared-memory case (now fails compilation).
  - Continued lowering for a 32-thread (warp-multiple) case (partial barrier remains present in the lowered IR).
- Tests: 23 passing tests; pre-commit checks completed.

## C++ style / lint notes

- Touches C++ code (`src/transform/thread_storage_sync.cc`) and corresponding Python CUDA tests, but does not modify any documented rules in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step remains advisory; this PR’s changes are correctness/safety-focused (intentional hard-fail on unsafe barrier lowering) rather than warning-driven style remediation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->