### PR TITLE
[BugFix] Fix wrong offset when scanning a non-zero-offset buffer sub-region

### DIFF
--- a/src/op/utils.cc
+++ b/src/op/utils.cc
@@ -101,9 +101,9 @@ PrimExpr MakeAccessPtrFromRegion(const BufferRegion &region, int rw_mask,
       strides[i] = cur;
       cur = cur * buf->shape[i];
     }
-    // Offset: sum_{i in [0..ndim-3]} min_i * stride_i
+    // Offset: sum_{i in [0..ndim-1]} min_i * stride_i
     offset = make_const(buf->shape[0].dtype(), 0);
-    for (int i = 0; i < ndim - 2; ++i) {
+    for (int i = 0; i < ndim; ++i) {
       offset = offset + region->region[i]->min * strides[i];
     }
     // Extent: last two extents product (elements)

--- a/testing/python/language/test_tilelang_language_scan.py
+++ b/testing/python/language/test_tilelang_language_scan.py
@@ -487,5 +487,63 @@ def test_cummax_fragment_1d():
     run_cummax_1d(512, 64, reverse=True, scope="fragment")
 
 
+def scan_offset_subregion_test(H, W, r0, r1, op="cumsum", dim=0, reverse=False, dtype=T.float32):
+    """Feed a row-offset 2D sub-region of shared memory directly to the scan.
+
+    Regression for #2536: MakeAccessPtrFromRegion dropped the innermost dims'
+    ``min`` from the access-pointer offset, so a sub-region like
+    ``A_shared[r0:r1, :]`` with ``r0 != 0`` silently scanned rows ``[0:r1-r0]``.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((H, W), dtype),
+        B: T.Tensor((H, W), dtype),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((H, W), dtype)
+            T.copy(A, A_shared)
+            scan = T.cumsum if op == "cumsum" else T.cummax
+            # Offset sub-region fed straight into the scan.
+            scan(src=A_shared[r0:r1, :], dim=dim, reverse=reverse)
+            T.copy(A_shared, B)
+
+    return main
+
+
+def run_scan_offset_subregion(H, W, r0, r1, op="cumsum", dim=0, reverse=False, dtype=T.float32):
+    program = scan_offset_subregion_test(H, W, r0, r1, op, dim, reverse, dtype)
+    jit_kernel = tl.compile(program, out_idx=-1)
+    A = torch.randn(H, W, dtype=getattr(torch, dtype)).cuda()
+
+    def ref_program(A):
+        ref_b = A.clone()  # rows outside [r0:r1] must be passed through untouched
+        chunk = A[r0:r1, :]
+        if op == "cumsum":
+            if reverse:
+                chunk = chunk.flip(dims=[dim]).cumsum(dim=dim).flip(dims=[dim])
+            else:
+                chunk = chunk.cumsum(dim=dim)
+        else:
+            chunk = _torch_cummax(chunk, dim, reverse)
+        ref_b[r0:r1, :] = chunk
+        return ref_b
+
+    tilelang_res = jit_kernel(A)
+    ref_res = ref_program(A)
+    torch.testing.assert_close(tilelang_res, ref_res, atol=1e-3, rtol=1e-3)
+
+
+def test_scan_offset_subregion():
+    """Regression for #2536: row-offset 2D shared sub-regions fed to the scan."""
+    H, W = 128, 8
+    for op in ("cumsum", "cummax"):
+        for dim in (0, 1):
+            for reverse in (False, True):
+                # r0 == 64 is the regressing case (r0 == 0 is already covered by
+                # the full-region region tests above).
+                run_scan_offset_subregion(H, W, 64, 128, op=op, dim=dim, reverse=reverse)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
# Summary

Fixes #2536.

`T.cumsum` / `T.cummax` on a shared-memory sub-region with a non-zero offset in the last two dimensions (e.g. `A_shared[64:128, :]`) silently operated on the wrong rows: the scan ran over `A_shared[0:64, :]` instead of the requested slice. This PR fixes the access-pointer offset computation in `MakeAccessPtrFromRegion` so the region's `min` in **every** dimension is folded into the pointer, and adds regression tests covering row-offset sub-regions for both `cumsum` and `cummax`. (Operating on buffer regions is documented behavior — the `cumsum` docstring's slice example uses a non-zero start.)

# Root Cause

In `src/op/utils.cc`, `MakeAccessPtrFromRegion` builds a `tvm_access_ptr` for the scan lowering. When computing the element offset it only accumulated `min_i * stride_i` for the **outer** `ndim - 2` dimensions:

```cpp
// Offset: sum_{i in [0..ndim-3]} min_i * stride_i
for (int i = 0; i < ndim - 2; ++i) {
  offset = offset + region->region[i]->min * strides[i];
}
```

The `min` of the last two dimensions was dropped entirely. For a 2D region like `A_shared[64:128, :]` (`ndim == 2`) the loop body never executes, so the offset is always 0 and the kernel scans from the start of the buffer. The scan device kernel (`LowerSharedScan` template) receives only a base pointer plus extents — it has no way to recover the row start itself, so the caller must fold `min * stride` into the pointer.

The bug was confirmed to be in this shared path (not in the scan algorithm or in slicing generally):

- With `r0 == 0` the same code is bit-exact correct → only the non-zero `min` case fails.
- A plain `T.copy(tile[64:128, :], B)` of the same region is correct → general region lowering handles offsets fine; only the scan path loses it.
- `T.cummax` fails identically to `T.cumsum` → both share `LowerSharedScan` / `MakeAccessPtrFromRegion`, so the defect is in the shared helper.

The `ndim - 2` upper bound looks like it was meant to pair with the "extent = product of the last two extents" convention, but the offset must still include *all* dimensions' `min` — extent and offset are independent.

A related note: the loop's `ndim >= 3` handling is currently dead code — the only caller (`src/backend/common/op/scan.h`) fatals on `ndim ∉ {1, 2}` since the scan is implemented as a 2D warp-shuffle. Even so, the fix sums over all `ndim` dimensions so the helper is correct if 3D+ regions are ever allowed (previously a 3D region would have also dropped the second-to-last dimension's `min`).

This bug is orthogonal to #2523: the kernel is missing two pieces of information about a sub-region — where it starts (offset, this issue, the caller's job to fold into the pointer) and the row pitch (#2523, where the kernel assumes `pitch == W`). This PR fixes only the former; column-sliced regions (`tile[:, 0:40]`) are #2523/#2620 territory and are intentionally not covered here.

# Changes

- **`src/op/utils.cc`** — `MakeAccessPtrFromRegion`: compute the access-pointer offset as `sum_{i in [0..ndim-1]} min_i * stride_i` (loop over all `ndim` dimensions instead of `ndim - 2`), so non-zero `min` in the innermost two dimensions is no longer dropped.
- **`testing/python/language/test_tilelang_language_scan.py`** — add `test_scan_offset_subregion`: feeds a row-offset 2D shared-memory sub-region (`A_shared[64:128, :]` of a 128×8 tile) directly to the scan, for both `cumsum` and `cummax`, `dim ∈ {0, 1}`, and `reverse ∈ {False, True}`; verifies against a PyTorch reference and also checks rows outside the region are passed through untouched. The zero-offset case (`r0 == 0`) is already covered by the existing `test_cumsum_region_2d` and full-buffer tests, which guard against regressing the previously-correct path.

# Tested

- New regression test `test_scan_offset_subregion` fails before the fix (scan output lands on the wrong rows) and passes after.
- Full test suite (`testing/python`) run on CUDA: the entire scan suite (`test_tilelang_language_scan.py`) passes, including all pre-existing region/full-buffer scan tests, confirming the zero-offset path is unchanged. The remaining failures are pre-existing and unrelated (reproduce without this patch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes incorrect scan offsets for `T.cumsum` and `T.cummax` on shared-memory sub-regions with non-zero row offsets.

- Corrects `MakeAccessPtrFromRegion` to include `min * stride` for every dimension.
- Adds regression coverage for cumsum/cummax across dimensions and reverse modes.
- Preserves rows outside the scanned sub-region.

## C++ style / lint notes

The C++ change is limited to offset calculation and does not alter public APIs or documented style rules. No new style or lint concerns are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->