### PR TITLE
[BugFix] Fallback non-16B cluster bulk copies

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -3050,6 +3050,16 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
   } else if (op->op.same_as(tl::tma_store_cluster())) {
     need_copy_sm90_h_ = true;
     ICHECK_EQ(op->args.size(), 5U) << "tma_store_cluster requires 5 args";
+    PrimExpr size_arg = op->args[3];
+    while (const auto *cast_node = size_arg.as<CastNode>()) {
+      size_arg = cast_node->value;
+    }
+    if (const auto *size_imm = size_arg.as<IntImmNode>()) {
+      ICHECK_EQ(size_imm->value % 16, 0)
+          << "tma_store_cluster transfer size (" << size_imm->value
+          << " bytes) must be a multiple of 16 bytes as required by "
+             "cp.async.bulk";
+    }
     this->PrintIndent();
     this->stream << "tl::tma_store_cluster(";
     this->stream << this->PrintExpr(op->args[0]) << ", ";

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -28,6 +28,7 @@
 
 #include <cctype>
 #include <cstdint>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <utility>
@@ -96,6 +97,12 @@ int64_t TMAElementsForBytes(int64_t bytes, DataType dtype) {
   ICHECK_EQ((bytes * 8) % dtype.bits(), 0)
       << bytes << " bytes cannot be represented as whole elements of " << dtype;
   return bytes * 8 / dtype.bits();
+}
+
+bool IsProvably16ByteMultiple(const PrimExpr &bytes,
+                              arith::Analyzer *analyzer) {
+  return analyzer->CanProveEqual(FloorMod(bytes, IntImm(bytes.dtype(), 16)),
+                                 IntImm(bytes.dtype(), 0));
 }
 
 PrimExpr GetCopyMbarPhaseExpr(const Map<String, ObjectRef> &annotations,
@@ -257,7 +264,7 @@ bool IsContiguousRegion(const Buffer &buf, const Array<Range> &ranges,
   return true;
 }
 
-std::pair<Array<Stmt>, PrimExpr>
+std::optional<std::pair<Array<Stmt>, PrimExpr>>
 MakeTMARows(const Buffer &src, const Array<Range> &src_ranges,
             const Buffer &dst, const Array<Range> &dst_ranges,
             PrimExpr dst_block, PrimExpr barrier_load,
@@ -283,8 +290,11 @@ MakeTMARows(const Buffer &src, const Array<Range> &src_ranges,
     for (const auto &r : src_ranges) {
       total_elems = total_elems * r->extent;
     }
-    PrimExpr size_bytes =
-        cast(DataType::UInt(32), TMABytesFromElements(total_elems, src->dtype));
+    PrimExpr total_bytes = TMABytesFromElements(total_elems, src->dtype);
+    if (!IsProvably16ByteMultiple(total_bytes, analyzer)) {
+      return std::nullopt;
+    }
+    PrimExpr size_bytes = cast(DataType::UInt(32), total_bytes);
     PrimExpr src_ptr = src.access_ptr(1, DataType::Handle(), 1,
                                       linear_off(src, src_ranges), total_elems);
     PrimExpr dst_ptr = dst.access_ptr(2, DataType::Handle(), 1,
@@ -292,7 +302,8 @@ MakeTMARows(const Buffer &src, const Array<Range> &src_ranges,
     Stmt call =
         Evaluate(Call(DataType::Handle(), tma_store_cluster(),
                       {dst_ptr, src_ptr, dst_block, size_bytes, barrier_load}));
-    return {{call}, IntImm(DataType::Int(32), 1)};
+    return std::make_pair(Array<Stmt>{call},
+                          PrimExpr(IntImm(DataType::Int(32), 1)));
   }
 
   int split_dim = -1;
@@ -320,14 +331,18 @@ MakeTMARows(const Buffer &src, const Array<Range> &src_ranges,
                   Range::FromMinExtent(src_ranges[split_dim]->min + kexpr, 1));
       new_dst.Set(split_dim,
                   Range::FromMinExtent(dst_ranges[split_dim]->min + kexpr, 1));
-      auto [stmts, cnt] = MakeTMARows(src, new_src, dst, new_dst, dst_block,
-                                      barrier_load, analyzer);
+      auto sub = MakeTMARows(src, new_src, dst, new_dst, dst_block,
+                             barrier_load, analyzer);
+      if (!sub.has_value()) {
+        return std::nullopt;
+      }
+      auto &[stmts, cnt] = sub.value();
       for (const auto &s : stmts) {
         all_stmts.push_back(s);
       }
       total = total + cnt;
     }
-    return {all_stmts, total};
+    return std::make_pair(all_stmts, total);
   }
 
   Var k("k_tma_row", DataType::Int(32));
@@ -337,13 +352,17 @@ MakeTMARows(const Buffer &src, const Array<Range> &src_ranges,
                Range::FromMinExtent(src_ranges[split_dim]->min + k, 1));
   body_dst.Set(split_dim,
                Range::FromMinExtent(dst_ranges[split_dim]->min + k, 1));
-  auto [body_stmts, body_cnt] = MakeTMARows(src, body_src, dst, body_dst,
-                                            dst_block, barrier_load, analyzer);
+  auto body_result = MakeTMARows(src, body_src, dst, body_dst, dst_block,
+                                 barrier_load, analyzer);
+  if (!body_result.has_value()) {
+    return std::nullopt;
+  }
+  auto &[body_stmts, body_cnt] = body_result.value();
   Stmt body = body_stmts.size() == 1 ? body_stmts[0]
                                      : static_cast<Stmt>(SeqStmt(body_stmts));
   Stmt for_loop =
       For(k, IntImm(DataType::Int(32), 0), extent, ForKind::kSerial, body);
-  return {{for_loop}, extent * body_cnt};
+  return std::make_pair(Array<Stmt>{for_loop}, extent * body_cnt);
 }
 
 } // namespace
@@ -874,58 +893,75 @@ Stmt Copy::LowerCluster(const CopyNode &op, const LowerArgs &lower_args,
       for (auto r : src_range) {
         total_elements = total_elements * r->extent;
       }
-      PrimExpr size_bytes = cast(
-          DataType::UInt(32), TMABytesFromElements(total_elements, src->dtype));
+      PrimExpr total_bytes = TMABytesFromElements(total_elements, src->dtype);
 
-      PrimExpr dst_ptr =
-          dst.access_ptr(2, DataType::Handle(), 1, dst_offset, total_elements);
-      PrimExpr src_ptr =
-          src.access_ptr(1, DataType::Handle(), 1, src_offset, total_elements);
+      if (IsProvably16ByteMultiple(total_bytes, analyzer)) {
+        PrimExpr size_bytes = cast(DataType::UInt(32), total_bytes);
 
-      Stmt bulk_copy = Evaluate(Call(
-          DataType::Handle(), tma_store_cluster(),
-          {dst_ptr, src_ptr, op.dst_block.value(), size_bytes, barrier_load}));
+        PrimExpr dst_ptr = dst.access_ptr(2, DataType::Handle(), 1, dst_offset,
+                                          total_elements);
+        PrimExpr src_ptr = src.access_ptr(1, DataType::Handle(), 1, src_offset,
+                                          total_elements);
 
-      return IfThenElse(
-          EQ(lower_args.thread_index, lower_args.thread_bounds->min),
-          bulk_copy);
-    }
+        Stmt bulk_copy = Evaluate(Call(DataType::Handle(), tma_store_cluster(),
+                                       {dst_ptr, src_ptr, op.dst_block.value(),
+                                        size_bytes, barrier_load}));
 
-    bool same_shape = (src_range.size() == dst_range.size());
-    for (size_t d = 0; d < src_range.size() && same_shape; ++d) {
-      if (!analyzer->CanProveEqual(src_range[d]->extent,
-                                   dst_range[d]->extent)) {
-        same_shape = false;
+        return IfThenElse(
+            EQ(lower_args.thread_index, lower_args.thread_bounds->min),
+            bulk_copy);
       }
-    }
-
-    if (element_match && same_shape) {
-      PrimExpr barrier_load = barrier_opt.value();
-      const auto *barrier_buf_load = barrier_load.as<tirx::BufferLoadNode>();
-      ICHECK(barrier_buf_load)
-          << "LowerCluster: expected BufferLoad for barrier annotation";
-      Var barrier_data_var = barrier_buf_load->buffer->data;
-
-      auto [tma_stmts, n_rows] =
-          MakeTMARows(src, src_range, dst, dst_range, op.dst_block.value(),
-                      barrier_load, analyzer);
-
-      if (lower_args.update_barrier_arrive) {
-        lower_args.update_barrier_arrive(barrier_data_var, n_rows);
+      LOG(WARNING) << "Cluster bulk copy size " << total_bytes
+                   << " bytes is not a multiple of 16 as required by "
+                      "cp.async.bulk; falling back to element-wise cluster "
+                      "copy. src="
+                   << src->name << ", dst=" << dst->name;
+    } else {
+      bool same_shape = (src_range.size() == dst_range.size());
+      for (size_t d = 0; d < src_range.size() && same_shape; ++d) {
+        if (!analyzer->CanProveEqual(src_range[d]->extent,
+                                     dst_range[d]->extent)) {
+          same_shape = false;
+        }
       }
 
-      Stmt seq = (tma_stmts.size() == 1)
-                     ? tma_stmts[0]
-                     : static_cast<Stmt>(SeqStmt(tma_stmts));
-      return IfThenElse(
-          EQ(lower_args.thread_index, lower_args.thread_bounds->min), seq);
-    }
+      if (element_match && same_shape) {
+        PrimExpr barrier_load = barrier_opt.value();
+        const auto *barrier_buf_load = barrier_load.as<tirx::BufferLoadNode>();
+        ICHECK(barrier_buf_load)
+            << "LowerCluster: expected BufferLoad for barrier annotation";
+        Var barrier_data_var = barrier_buf_load->buffer->data;
 
-    LOG(WARNING)
-        << "Falling back to element-wise cluster copy: bulk cluster paths "
-           "require matching element counts and same per-dim extents between "
-           "src and dst. src="
-        << src->name << ", dst=" << dst->name;
+        auto tma_rows =
+            MakeTMARows(src, src_range, dst, dst_range, op.dst_block.value(),
+                        barrier_load, analyzer);
+
+        if (tma_rows.has_value()) {
+          auto &[tma_stmts, n_rows] = tma_rows.value();
+
+          if (lower_args.update_barrier_arrive) {
+            lower_args.update_barrier_arrive(barrier_data_var, n_rows);
+          }
+
+          Stmt seq = (tma_stmts.size() == 1)
+                         ? tma_stmts[0]
+                         : static_cast<Stmt>(SeqStmt(tma_stmts));
+          return IfThenElse(
+              EQ(lower_args.thread_index, lower_args.thread_bounds->min), seq);
+        }
+        LOG(WARNING)
+            << "Cluster bulk copy row size is not a multiple of 16 bytes as "
+               "required by cp.async.bulk; falling back to element-wise "
+               "cluster copy. src="
+            << src->name << ", dst=" << dst->name;
+      } else {
+        LOG(WARNING)
+            << "Falling back to element-wise cluster copy: bulk cluster paths "
+               "require matching element counts and same per-dim extents "
+               "between src and dst. src="
+            << src->name << ", dst=" << dst->name;
+      }
+    }
   }
 
   auto simt_loop = op.MakeSIMTLoop(analyzer);

--- a/testing/python/cuda/test_tma_dsmem.py
+++ b/testing/python/cuda/test_tma_dsmem.py
@@ -164,7 +164,10 @@ def test_store_cluster_non_16b_contiguous_fallback(capfd):
     assert "tl::tma_store_cluster" not in src, f"Non-16B copy must not emit tma_store_cluster.\nKernel source:\n{src}"
     assert "map_shared_rank" in src, f"Expected SIMT cluster-copy fallback.\nKernel source:\n{src}"
     captured = capfd.readouterr()
-    assert "Cluster bulk copy size 508 bytes is not a multiple of 16" in (captured.out + captured.err)
+    warning_output = captured.out + captured.err
+    assert "Cluster bulk copy size" in warning_output
+    assert "508" in warning_output
+    assert "bytes is not a multiple of 16" in warning_output
 
     A = torch.arange(N, dtype=torch.float32, device="cuda")
     B = mod(A)

--- a/testing/python/cuda/test_tma_dsmem.py
+++ b/testing/python/cuda/test_tma_dsmem.py
@@ -154,6 +154,31 @@ def test_tma_store_cluster():
 
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_store_cluster_non_16b_contiguous_fallback(capfd):
+    """A contiguous 508B copy must use the barrier-aware SIMT fallback."""
+    N = 127  # 127 * sizeof(float32) = 508 bytes
+    prim_func = make_store_cluster_kernel(N)
+    mod = tilelang.compile(prim_func, out_idx=[1], execution_backend="cython")
+
+    src = mod.get_kernel_source()
+    assert "tl::tma_store_cluster" not in src, f"Non-16B copy must not emit tma_store_cluster.\nKernel source:\n{src}"
+    assert "map_shared_rank" in src, f"Expected SIMT cluster-copy fallback.\nKernel source:\n{src}"
+    captured = capfd.readouterr()
+    assert "Cluster bulk copy size 508 bytes is not a multiple of 16" in (captured.out + captured.err)
+
+    A = torch.arange(N, dtype=torch.float32, device="cuda")
+    B = mod(A)
+    np.testing.assert_allclose(
+        B.cpu().numpy(),
+        A.cpu().numpy(),
+        rtol=0,
+        atol=0,
+        err_msg="Non-16B contiguous cluster-copy fallback produced wrong result",
+    )
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_store_cluster_simt_no_barrier():
     """SIMT fallback (no remote_barrier): map_shared_rank + cluster_sync ordering."""
     N = 128
@@ -209,6 +234,32 @@ def test_store_cluster_multi_tma_barrier():
         rtol=0,
         atol=0,
         err_msg="Multi-TMA row-decomposed cluster copy produced wrong result",
+    )
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_store_cluster_non_16b_row_fallback(capfd):
+    """A non-contiguous copy with 124B rows must reject row-wise TMA."""
+    M, N_full, N_tile = 4, 64, 31  # Each row is 31 * 4 = 124 bytes
+    prim_func = make_store_cluster_simt_barrier_kernel(M, N_full, N_tile)
+    mod = tilelang.compile(prim_func, out_idx=[1], execution_backend="cython")
+
+    src = mod.get_kernel_source()
+    assert "tl::tma_store_cluster" not in src, f"Non-16B rows must not emit tma_store_cluster.\nKernel source:\n{src}"
+    assert "map_shared_rank" in src, f"Expected SIMT cluster-copy fallback.\nKernel source:\n{src}"
+    assert "s_barrier[0].init(1)" in src, f"SIMT fallback must keep a single remote arrival.\nKernel source:\n{src}"
+    captured = capfd.readouterr()
+    assert "Cluster bulk copy row size is not a multiple of 16 bytes" in (captured.out + captured.err)
+
+    A = torch.arange(M * N_tile, dtype=torch.float32, device="cuda").reshape(M, N_tile)
+    B = mod(A)
+    np.testing.assert_allclose(
+        B.cpu().numpy(),
+        A.cpu().numpy(),
+        rtol=0,
+        atol=0,
+        err_msg="Non-16B row cluster-copy fallback produced wrong result",
     )
 
 


### PR DESCRIPTION
## Summary

Fixes #2506.

This PR prevents `T.copy_cluster` from emitting an invalid `cp.async.bulk` operation when the transfer size is not a multiple of 16 bytes.

For transfers that satisfy the bulk-copy requirements, the existing TMA-based cluster-copy path is preserved. For transfers whose byte size is not divisible by 16, the compiler now emits a warning and falls back to the regular cluster-copy implementation instead of generating a `tma_store_cluster` call with an ISA-invalid transfer size.

## Problem

The TMA lowering path for `T.copy_cluster` computes the transfer size from the number of elements and the element data type:

```text
size_bytes = number_of_elements * bytes_per_element
```

The resulting byte count was passed directly to `tma_store_cluster` without checking whether it was a multiple of 16.

For example, a copy of 127 `float32` elements has a transfer size of:

```text
127 * 4 = 508 bytes
```

The generated code could therefore contain a call equivalent to:

```cpp
tl::tma_store_cluster(..., static_cast<uint32_t>(508), ...);
```

The underlying `cp.async.bulk` instruction requires the transfer size to be a multiple of 16 bytes. Emitting a non-conforming size results in PTX-undefined behavior. Depending on the GPU and driver, this may manifest as a kernel hang, an unspecified launch failure, incorrect output, or another device-side failure.

This path does not use a tensor-map descriptor, so descriptor validation does not catch the invalid transfer size before it reaches the generated device code.

## Solution

This PR adds an eligibility check before selecting the TMA cluster-copy path.

The updated behavior is:

* If the transfer size is a multiple of 16 bytes, preserve the existing `tma_store_cluster` lowering.
* If the transfer size is not a multiple of 16 bytes:

  * emit a compiler warning explaining that the bulk-copy requirement is not satisfied;
  * skip the TMA lowering;
  * fall back to the regular element-wise cluster-copy path.

This keeps `T.copy_cluster` correct for arbitrary supported shapes while retaining the optimized TMA path for eligible transfers.

The fallback is intentionally not silent because it may have a meaningful performance impact. The warning makes the lowering decision visible without rejecting an otherwise valid high-level cluster-copy operation.

## Warning behavior

When the TMA path is skipped, the compiler emits a warning indicating that:

* `cp.async.bulk` requires a transfer size divisible by 16 bytes;
* the current transfer size does not satisfy that requirement;
* the operation is being lowered to the regular cluster-copy implementation.

Aligned copies do not emit this warning.

## Testcase correction

The original reproducer in #2506 also contained an independent cluster-programming issue.

It allowed every CTA in the cluster to execute:

```python
T.copy_cluster(..., dst_block=1, ...)
T.mbarrier_wait_parity(...)
```

With a two-CTA cluster, this means that both CTA 0 and CTA 1 issue a copy targeting cluster rank 1, and both CTAs wait on their local barrier. This mixes the transfer-size issue with producer/consumer role and barrier-synchronization behavior. In particular, an aligned transfer may still fail for reasons unrelated to the 16-byte bulk-copy requirement.

The regression test therefore assigns explicit CTA roles:

* CTA 0 initializes the source data and issues the remote cluster copy.
* CTA 1 waits on its local completion barrier and validates the received data.

The test also uses the current `T.ClusterKernel` API rather than passing `cluster_dims` to `T.Kernel`.

This isolates the lowering behavior under test and ensures that the only relevant difference between the aligned and non-aligned cases is TMA eligibility.

## Test coverage

The regression test covers both optimized and fallback behavior:

* An aligned `float32` transfer, such as 128 elements / 512 bytes:

  * still emits `tma_store_cluster`;
  * does not use the fallback;
  * completes successfully and produces the expected output.

* A non-aligned `float32` transfer, such as 127 elements / 508 bytes:

  * does not emit an invalid `tma_store_cluster`;
  * emits the fallback warning;
  * uses the regular cluster-copy path;
  * completes successfully and produces the expected output.

Additional boundary cases can cover aligned and non-aligned sizes on both sides of the boundary, such as 124 elements / 496 bytes and 126 elements / 504 bytes.

Tests are skipped on devices that do not support thread-block clusters.

## Behavioral impact

For valid TMA transfers, this change does not alter the generated bulk-copy path.

For non-16-byte-sized transfers, behavior changes from emitting an ISA-invalid bulk-copy operation to issuing a warning and using a correct, potentially slower fallback.

This prioritizes correctness while preserving the optimized implementation whenever its hardware requirements are satisfied.

## Scope

This PR addresses the transfer-size requirement for the cluster bulk-copy path. It does not synthesize shared-memory padding or otherwise enlarge source or destination allocations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixes `T.copy_cluster` to prevent emitting ISA-undefined `cp.async.bulk`/bulk-copy lowering when the transfer byte size is not provably divisible by 16.
- Preserves the optimized TMA fast path (`tl::tma_store_cluster`) only when the transfer size is provably 16-byte aligned; otherwise it falls back to the regular SIMT/element-wise cluster-copy lowering.
- Adds compile-time validation for `tma_store_cluster` arguments in CUDA codegen by stripping `CastNode` wrappers before checking constants, and issues a compiler warning when the 16B-multiple requirement cannot be satisfied.
- Updates TMA row construction and barrier/row logic to safely propagate “cannot prove 16B multiple” failures via an `std::optional` return, guarding TMA-row/barrier emission so fallback paths remain correct.
- Adds regression tests covering:
  - non-16B contiguous and non-16B row-sized cluster copies (asserting `tl::tma_store_cluster` is not generated and `map_shared_rank`/SIMT fallback is used),
  - expected diagnostic text for both contiguous and row cases,
  - correct barrier initialization (e.g., `s_barrier[0].init(1)`) and successful numerical execution.

## C++ style / lint notes

- Touches C++ implementation code (`src/cuda/codegen/codegen_cuda.cc`, `src/cuda/op/copy.cc`) but does **not** modify documented rules in `docs/developer_guide/cpp_style.md`.
- Introduces/relies on new compiler warnings for non-16B-multiple cluster transfers; this is correctness-facing diagnostics, not style-only guidance.
- The “C++ API Style Audit (warning only)” CI step is unchanged/advisory.
- Any TLCPP003/TLCPP004 findings should be treated as warning-only style suggestions; this PR does not introduce a clear API/FFI/maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->