### PR TITLE
[BugFix] Track GEMM accumulator writes in warp-specialization liveness collector

### DIFF
--- a/src/cuda/transform/producer_consumer_ws.cc
+++ b/src/cuda/transform/producer_consumer_ws.cc
@@ -481,6 +481,26 @@ private:
         }
         return;
       }
+      if (const auto *gemm = tile_op.as<GemmNode>()) {
+        if (IsBranchPrivateBuffer(gemm->a_)) {
+          summary_.read_buffers.insert(gemm->a_);
+        }
+        if (IsBranchPrivateBuffer(gemm->b_)) {
+          summary_.read_buffers.insert(gemm->b_);
+        }
+        if (IsBranchPrivateBuffer(gemm->c_)) {
+          summary_.write_buffers.insert(gemm->c_);
+          if (!is_one(gemm->clearAccum_)) {
+            summary_.read_buffers.insert(gemm->c_);
+          }
+        }
+        VisitExpr(gemm->offsetA_);
+        VisitExpr(gemm->offsetB_);
+        for (const auto &coord : gemm->cCoords_) {
+          VisitExpr(coord);
+        }
+        return;
+      }
     }
 
     if (op->op.same_as(tl::access_ptr())) {

--- a/src/cuda/transform/producer_consumer_ws.cc
+++ b/src/cuda/transform/producer_consumer_ws.cc
@@ -482,22 +482,57 @@ private:
         return;
       }
       if (const auto *gemm = tile_op.as<GemmNode>()) {
-        if (IsBranchPrivateBuffer(gemm->a_)) {
-          summary_.read_buffers.insert(gemm->a_);
+        // Mirrors GemmNode::GetAccessRegions(): a_/b_ (and the optional MX
+        // scale-factor regions) are reads, c_ is always a write and also a
+        // read unless clearAccum_ clears it first. Region mins/extents are
+        // revisited (rather than just offsetA_/offsetB_/cCoords_) so any
+        // loop-variable dependency in a sliced operand or accumulator
+        // sub-block is still captured after the early return below.
+        if (IsBranchPrivateBuffer(gemm->aRegion_->buffer)) {
+          summary_.read_buffers.insert(gemm->aRegion_->buffer);
         }
-        if (IsBranchPrivateBuffer(gemm->b_)) {
-          summary_.read_buffers.insert(gemm->b_);
+        for (const auto &range : gemm->aRegion_->region) {
+          VisitExpr(range->min);
+          VisitExpr(range->extent);
         }
-        if (IsBranchPrivateBuffer(gemm->c_)) {
-          summary_.write_buffers.insert(gemm->c_);
+        if (IsBranchPrivateBuffer(gemm->bRegion_->buffer)) {
+          summary_.read_buffers.insert(gemm->bRegion_->buffer);
+        }
+        for (const auto &range : gemm->bRegion_->region) {
+          VisitExpr(range->min);
+          VisitExpr(range->extent);
+        }
+        if (IsBranchPrivateBuffer(gemm->cRegion_->buffer)) {
+          summary_.write_buffers.insert(gemm->cRegion_->buffer);
           if (!is_one(gemm->clearAccum_)) {
-            summary_.read_buffers.insert(gemm->c_);
+            summary_.read_buffers.insert(gemm->cRegion_->buffer);
           }
         }
-        VisitExpr(gemm->offsetA_);
-        VisitExpr(gemm->offsetB_);
-        for (const auto &coord : gemm->cCoords_) {
-          VisitExpr(coord);
+        for (const auto &range : gemm->cRegion_->region) {
+          VisitExpr(range->min);
+          VisitExpr(range->extent);
+        }
+        if (gemm->sfaRegion_.defined()) {
+          if (IsBranchPrivateBuffer(gemm->sfaRegion_->buffer)) {
+            summary_.read_buffers.insert(gemm->sfaRegion_->buffer);
+          }
+          for (const auto &range : gemm->sfaRegion_->region) {
+            VisitExpr(range->min);
+            VisitExpr(range->extent);
+          }
+        }
+        if (gemm->sfbRegion_.defined()) {
+          if (IsBranchPrivateBuffer(gemm->sfbRegion_->buffer)) {
+            summary_.read_buffers.insert(gemm->sfbRegion_->buffer);
+          }
+          for (const auto &range : gemm->sfbRegion_->region) {
+            VisitExpr(range->min);
+            VisitExpr(range->extent);
+          }
+        }
+        VisitExpr(gemm->clearAccum_);
+        if (gemm->sfKStart_.defined()) {
+          VisitExpr(gemm->sfKStart_);
         }
         return;
       }

--- a/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
+++ b/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
@@ -37,6 +37,61 @@ def matmul_pipelined(M, N, K, block_M, block_K, block_N, num_stages, dtype="floa
     return main
 
 
+def dual_gemm_shared_accumulator(
+    M,
+    N,
+    K0,
+    K1,
+    block_M,
+    block_N,
+    block_K,
+    num_stages,
+    dtype="float16",
+    threads=128,
+):
+    """A prelude GEMM and a pipelined-loop GEMM accumulating into the same
+    fragment, mirroring the #2547 `example_mamba_chunk_scan.py` pattern:
+    `T.gemm(A0, B0, acc)` runs once before the loop, then
+    `T.gemm(A1_k, B1_k, acc)` accumulates into the same `acc` inside a
+    `T.Pipelined` loop. Under warp specialization, the prelude GEMM must be
+    classified consumer-only so both GEMMs share one thread_range for `acc`.
+    """
+
+    @T.prim_func
+    def main(
+        A0: T.Tensor((M, K0), dtype),
+        B0: T.Tensor((K0, N), dtype),
+        A1: T.Tensor((M, K1), dtype),
+        B1: T.Tensor((K1, N), dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads) as (
+            bx,
+            by,
+        ):
+            acc = T.alloc_fragment((block_M, block_N), "float32")
+            A0_shared = T.alloc_shared((block_M, K0), dtype)
+            B0_shared = T.alloc_shared((K0, block_N), dtype)
+            A1_shared = T.alloc_shared((block_M, block_K), dtype)
+            B1_shared = T.alloc_shared((block_K, block_N), dtype)
+            C_local = T.alloc_fragment((block_M, block_N), dtype)
+
+            T.clear(acc)
+            T.copy(A0[by * block_M, 0], A0_shared)
+            T.copy(B0[0, bx * block_N], B0_shared)
+            T.gemm(A0_shared, B0_shared, acc)  # prelude GEMM -> acc
+
+            for ko in T.Pipelined(T.ceildiv(K1, block_K), num_stages=num_stages):
+                T.copy(A1[by * block_M, ko * block_K], A1_shared)
+                T.copy(B1[ko * block_K, bx * block_N], B1_shared)
+                T.gemm(A1_shared, B1_shared, acc)  # loop GEMM -> same acc
+
+            T.copy(acc, C_local)
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
 def matmul_windowed_pipelined(
     M,
     N,
@@ -420,6 +475,71 @@ def test_tiled_ws_stage3():
     torch.testing.assert_close(C.float(), ref, rtol=1e-2, atol=1e-2)
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(9, 0)
+def test_tiled_ws_dual_gemm_shared_accumulator_correctness():
+    """Regression test for #2547.
+
+    A prelude GEMM and a pipelined-loop GEMM accumulate into the same
+    fragment. Before the fix, `LocalAccessCollector` never recorded the
+    prelude GEMM's write to `acc`, so it was misclassified as
+    `kKeepSharedPrelude` and stayed in the shared `[0, 2*threads)` prelude,
+    while the loop GEMM ran consumer-only in `[threads, 2*threads)`.
+    `LayoutInference` then aborted with "Get different layout for acc"
+    because the two GEMMs disagreed on `acc`'s thread_range.
+    """
+    import torch
+
+    M, N, K0, K1 = 64, 64, 64, 128
+    block_M, block_N, block_K = 64, 64, 64
+    func = dual_gemm_shared_accumulator(M, N, K0, K1, block_M, block_N, block_K, num_stages=2)
+    target = determine_target()
+    kernel = tilelang.compile(func, target=target, out_idx=[4])
+
+    A0 = torch.randn(M, K0, dtype=torch.float16, device="cuda")
+    B0 = torch.randn(K0, N, dtype=torch.float16, device="cuda")
+    A1 = torch.randn(M, K1, dtype=torch.float16, device="cuda")
+    B1 = torch.randn(K1, N, dtype=torch.float16, device="cuda")
+    C = kernel(A0, B0, A1, B1)
+
+    ref = A0.float() @ B0.float() + A1.float() @ B1.float()
+    torch.testing.assert_close(C.float(), ref, rtol=1e-2, atol=1e-2)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(9, 0)
+def test_tiled_ws_dual_gemm_shared_accumulator_disable_wgmma():
+    """Same dual-GEMM-into-one-accumulator pattern, with WGMMA disabled.
+
+    #2547 showed the crash was gated purely by warp specialization, not by
+    WGMMA instruction selection: `tl.disable_wgmma=True` (WS still on) hit
+    the identical thread_range conflict on an MMA-shaped fragment, so this
+    is not an "accumulator unsupported" guard but a thread-range bookkeeping
+    defect in the WS pass itself.
+    """
+    import torch
+
+    M, N, K0, K1 = 64, 64, 64, 128
+    block_M, block_N, block_K = 64, 64, 64
+    func = dual_gemm_shared_accumulator(M, N, K0, K1, block_M, block_N, block_K, num_stages=2)
+    target = determine_target()
+    kernel = tilelang.compile(
+        func,
+        target=target,
+        out_idx=[4],
+        pass_configs={tilelang.PassConfigKey.TL_DISABLE_WGMMA: True},
+    )
+
+    A0 = torch.randn(M, K0, dtype=torch.float16, device="cuda")
+    B0 = torch.randn(K0, N, dtype=torch.float16, device="cuda")
+    A1 = torch.randn(M, K1, dtype=torch.float16, device="cuda")
+    B1 = torch.randn(K1, N, dtype=torch.float16, device="cuda")
+    C = kernel(A0, B0, A1, B1)
+
+    ref = A0.float() @ B0.float() + A1.float() @ B1.float()
+    torch.testing.assert_close(C.float(), ref, rtol=1e-2, atol=1e-2)
+
+
 def _compile_tvm_ffi(func, pass_configs=None, **kwargs):
     tilelang.disable_cache()
     try:
@@ -637,6 +757,8 @@ if __name__ == "__main__":
     test_tiled_ws_stage1_dynamic_loop_start()
     test_tiled_ws_correctness()
     test_tiled_ws_stage3()
+    test_tiled_ws_dual_gemm_shared_accumulator_correctness()
+    test_tiled_ws_dual_gemm_shared_accumulator_disable_wgmma()
     test_tiled_ws_swizzled_layout_allows_ws()
     test_tiled_ws_incompatible_layout_blocks_ws()
     test_tiled_ws_sinks_preloop_tma_waits_into_consumer()


### PR DESCRIPTION
## Issue

https://github.com/tile-ai/tilelang/issues/2547

## Summary

On Hopper (sm_90) with the default warp-specialized (WS) pipeline, a kernel
with a prelude `T.gemm` and a pipelined-loop `T.gemm` accumulating into the
same fragment aborts compilation in `LayoutInference` with:

```
tvm.error.InternalError: Get different layout for acc_o
 current layout:  thread_range: I.Range(128, 256)
 previous layout: thread_range: I.Range(0, 256)
```

This is a regression hit by the shipped `examples/linear_attention/example_mamba_chunk_scan.py`,
which compiles and runs correctly with `tl.disable_warp_specialized=True`.

## Root cause

`ProducerConsumerWarpSpecialized` runs before `LayoutInference` and splits the
kernel into a producer warpgroup `[0, threads)` and a consumer warpgroup
`[threads, 2*threads)`. Pre-loop ("prelude") statements are classified as
shared/producer-only/consumer-only by `ClassifyPreludeStmt`, based on read/write
buffer sets built by `LocalAccessCollector::VisitExpr_(CallNode*)`.

That collector special-cased `CopyNode` and `FillNode` only. `GemmNode` had no
case, so a prelude `T.gemm`'s accumulator write fell through to the generic
`BufferLoad` visitor and was recorded as a read only — never as a write. With
no tracked write, `ClassifyPreludeStmt` short-circuited to `kKeepSharedPrelude`
before even checking live sets, so the prelude GEMM stayed in the shared
`[0, 2*threads)` range while the loop-body GEMM (already consumer-only) ran in
`[threads, 2*threads)`. Both GEMMs then baked incompatible `thread_range`s into
the same accumulator fragment, and `LayoutInference` aborted.

## Fix

Add a `GemmNode` case to `LocalAccessCollector::VisitExpr_(CallNode*)`,
mirroring `GemmNode::GetAccessRegions()`: record `a_`/`b_` as reads and `c_` as
a write (plus a read unless `clearAccum_` is set), and revisit
`offsetA_`/`offsetB_`/`cCoords_` so index-variable dependencies are still
captured after the early return (matching how the existing `Copy`/`Fill` cases
revisit their own ranges/value).

With the accumulator write now tracked, the prelude GEMM is correctly
classified `kConsumerOnly` and extracted into the consumer branch alongside the
loop-body GEMM, so both share one `thread_range`.

## Tests

Added two regression tests in
`testing/python/transform/test_tilelang_transform_producer_consumer_ws.py`,
using a minimal prelude-GEMM + pipelined-loop-GEMM-into-the-same-fragment
kernel:

- `test_tiled_ws_dual_gemm_shared_accumulator_correctness`: compiles and runs
  under the default (WS-on) pipeline, checked against a PyTorch reference.
- `test_tiled_ws_dual_gemm_shared_accumulator_disable_wgmma`: same pattern with
  `TL_DISABLE_WGMMA=True`, covering the issue's point that this is a
  thread-range bookkeeping defect in the WS pass, not specific to WGMMA.

Verified both tests reproduce the original `Get different layout for acc`
failure when the `producer_consumer_ws.cc` fix is reverted, and pass with it
applied. Also re-ran `examples/linear_attention/example_mamba_chunk_scan.py`
(default WS-on config) end-to-end against its PyTorch reference — passes.

## C++ style / lint notes

This PR touches TileLang-owned C++ transform code under
`src/cuda/transform/producer_consumer_ws.cc` and keeps the change narrowly
scoped to the missing `GemmNode` case, following the existing `Copy`/`Fill`
case pattern in the same visitor rather than introducing a new abstraction.
Checked with the repository's `clang-format` and `ruff-format` pre-commit
hooks.

Fixes https://github.com/tile-ai/tilelang/issues/2547


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary
- **Bug Fixes**
  - Improved local access/liveness tracking for GEMM tile-ops, including accumulator writes, accumulator reuse reads, and related scale-factor region reads.
- **New Features / Testing**
  - Added regression coverage for a dual-GEMM shared-accumulator pattern, validating both default warp-specialization behavior and a configuration with WGMMA disabled.

## C++ style / lint notes
- No exported/public entity changes. Any C++ API style audit findings should be treated as advisory unless they impact public surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->