### PR TITLE
[JIT][TVM-FFI] Reuse executable across kernel launches

### DIFF
--- a/testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py
+++ b/testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py
@@ -1,0 +1,92 @@
+import threading
+from types import SimpleNamespace
+
+import torch
+
+from tilelang.jit.adapter.tvm_ffi import TVMFFIKernelAdapter
+
+
+class _FakeKernelParam:
+    shape = [1]
+    dtype = SimpleNamespace(bits=32, lanes=1)
+
+    @staticmethod
+    def torch_dtype():
+        return torch.float32
+
+
+class _TestAdapter(TVMFFIKernelAdapter):
+    @property
+    def prim_func(self):
+        return self._test_prim_func
+
+
+def _make_adapter():
+    adapter = _TestAdapter.__new__(_TestAdapter)
+    tir_param = object()
+    adapter.params = [_FakeKernelParam()]
+    adapter.result_idx = []
+    adapter._test_prim_func = SimpleNamespace(
+        params=[tir_param],
+        buffer_map={tir_param: SimpleNamespace(dtype="float32")},
+    )
+    adapter._process_dynamic_symbolic = lambda: {}
+    adapter.executable = None
+    adapter._executable_lock = threading.Lock()
+
+    created = []
+
+    def make_executable():
+        def executable(*args):
+            return None
+
+        created.append(executable)
+        return executable
+
+    adapter._make_executable = make_executable
+    return adapter, created
+
+
+def test_cold_compiled_dispatch_does_not_probe_cuda(monkeypatch):
+    adapter, created = _make_adapter()
+    func = adapter._convert_torch_func()
+    tensor = torch.empty(1)
+    cuda_probe_count = 0
+
+    def counted_is_available():
+        nonlocal cuda_probe_count
+        cuda_probe_count += 1
+        return False
+
+    monkeypatch.setattr(torch.cuda, "is_available", counted_is_available)
+
+    for _ in range(3):
+        func(tensor)
+
+    assert cuda_probe_count == 0
+    assert len(created) == 1
+    assert adapter.executable is created[0]
+
+
+def test_executable_is_initialized_once_and_reused():
+    adapter, created = _make_adapter()
+
+    executable = adapter._get_executable()
+
+    assert adapter._get_executable() is executable
+    assert adapter.get_exportable_executable() is executable
+    assert adapter.executable is executable
+    assert len(created) == 1
+
+
+def test_preloaded_executable_is_reused():
+    adapter, created = _make_adapter()
+
+    def preloaded_executable(*args):
+        return None
+
+    adapter.executable = preloaded_executable
+
+    assert adapter._get_executable() is preloaded_executable
+    assert adapter.get_exportable_executable() is preloaded_executable
+    assert created == []

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -114,7 +114,6 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
         self.dynamic_symbolic_map = self._process_dynamic_symbolic()
         self.kernel_global_source = self.device_kernel_source
         self.executable = None
-        self._executables_by_device: dict[int | str, tvm.runtime.Executable] = {}
         self._executable_lock = threading.Lock()
 
         self._post_init()
@@ -128,10 +127,20 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
             executable.jit(**COMPILE_ARGS)
         return executable
 
+    def _get_executable(self) -> tvm.runtime.Executable:
+        executable = self.executable
+        if executable is not None:
+            return executable
+
+        with self._executable_lock:
+            executable = self.executable
+            if executable is None:
+                executable = self._make_executable()
+                self.executable = executable
+            return executable
+
     def get_exportable_executable(self) -> tvm.runtime.Executable:
-        if self.executable is not None:
-            return self.executable
-        return self._make_executable()
+        return self._get_executable()
 
     def _process_dynamic_symbolic(self) -> dict[tirx.Var, tuple[int, int, int, int]]:
         """Extract information about dynamic shapes from the TIR function.
@@ -195,25 +204,6 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
             param_shapes.append(native_shape)
 
         dynamic_symbolic_map = self._process_dynamic_symbolic()
-
-        def get_executable():
-            if self.executable is not None:
-                return self.executable
-
-            device_key: int | str = "cpu"
-            if torch.cuda.is_available():
-                device_key = torch.cuda.current_device()
-
-            executable = self._executables_by_device.get(device_key)
-            if executable is not None:
-                return executable
-
-            with self._executable_lock:
-                executable = self._executables_by_device.get(device_key)
-                if executable is None:
-                    executable = self._make_executable()
-                    self._executables_by_device[device_key] = executable
-                return executable
 
         # Prepare helpers for friendly dtype error messages
         prim_func = self.prim_func
@@ -283,7 +273,7 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
                     ins_idx += 1
                 tensor_list.append(tensor)
 
-            executable = get_executable()
+            executable = self._get_executable()
             executable(*tensor_list)
 
             # Return outputs in the requested form
@@ -332,7 +322,6 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
         adapter.kernel_global_source = device_kernel_source.text
         adapter.rt_mod = None
         adapter.executable = runtime.load_module(kernel_lib_path)
-        adapter._executables_by_device = {}
         adapter._executable_lock = threading.Lock()
         adapter._post_init()
         return adapter


### PR DESCRIPTION
## Summary

- Reuse one lazily initialized TVM FFI executable for cold-compiled kernels.
- Remove the CUDA availability and current-device probes from every warm dispatch.
- Make cold compilation and disk-cache loading follow the same executable reuse model.

## Changes

- Store the first runtime executable in `self.executable` under the existing initialization lock.
- Remove the Python-side per-device executable dictionary; device-specific module and function caches remain managed by the TVM runtime.
- Reuse the same executable for kernel calls and cache export.
- Add regression tests for warm dispatch without CUDA probing, one-time lazy initialization, and reuse of disk-preloaded executables.

Closes #2684.

## Validation

- `./format.sh`
- `python -m pytest testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py testing/python/jit/test_tilelang_jit_tvm_ffi.py::test_gemm_jit_kernel -x -q`
- `python -m pytest testing/python/cache/test_tilelang_kernel_cache_atomic_save.py -x -q`

## Notes

- The CUDA runtime selects its internal per-device module and function caches on each launch. The validation environment had one CUDA device, so multi-device behavior was verified against that runtime device-selection path rather than with a dual-GPU execution test.