### PR TITLE
[BugFix] Preserve bf16 NaN and Inf during RNE packing

### DIFF
--- a/testing/python/issue/test_tilelang_bf16x2_pack_special_values.py
+++ b/testing/python/issue/test_tilelang_bf16x2_pack_special_values.py
@@ -1,0 +1,42 @@
+import torch
+
+import tilelang
+import tilelang.testing
+import tilelang.language as T
+from tilelang.quantize.quantization import (
+    _tir_f32x2_to_bf16x2_to_u32,
+    _tir_u32_to_bf16x2_to_f32x2,
+)
+
+
+@tilelang.testing.requires_cuda
+def test_f32x2_to_bf16x2_preserves_nan_and_inf():
+    """RNE bf16 packing must not round inf/NaN bit patterns."""
+
+    @T.prim_func
+    def main(bits: T.Tensor((4,), "uint32"), out: T.Tensor((4,), "float32")):
+        with T.Kernel(2, threads=1) as bx:
+            f0 = T.reinterpret(bits[bx * 2], T.float32)
+            f1 = T.reinterpret(bits[bx * 2 + 1], T.float32)
+            packed = _tir_f32x2_to_bf16x2_to_u32(f0, f1)
+            decoded = list(_tir_u32_to_bf16x2_to_f32x2(packed))
+            out[bx * 2] = decoded[0]
+            out[bx * 2 + 1] = decoded[1]
+
+    kernel = tilelang.compile(main, target="cuda")
+    bits = torch.tensor(
+        [0x7FFF8C22, 0x7FFFFFFF, 0x7F800000, 0xFF800000],
+        dtype=torch.uint32,
+        device="cuda",
+    )
+    out = torch.empty(4, dtype=torch.float32, device="cuda")
+    kernel(bits, out)
+
+    assert torch.isnan(out[:2]).all(), out.cpu().tolist()
+    assert torch.isinf(out[2:]).all(), out.cpu().tolist()
+    assert out[2].item() > 0
+    assert out[3].item() < 0
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/quantize/quantization.py
+++ b/tilelang/quantize/quantization.py
@@ -93,9 +93,10 @@ def _tir_f32x2_to_bf16x2_to_u32(v0: tirx.PrimExpr, v1: tirx.PrimExpr, round_to_e
     for data in [v0, v1]:
         u32_val = tirx.reinterpret(T.uint32, data)
         if round_to_even:
+            exp = (u32_val >> tirx.const(23, T.uint32)) & tirx.const(0xFF, T.uint32)
             rounding_bias = ((u32_val >> tirx.const(16, T.uint32))
                              & tirx.const(1, T.uint32)) + tirx.const(0x7FFF, T.uint32)
-            u32_val += rounding_bias
+            u32_val = tirx.Select(exp == tirx.const(0xFF, T.uint32), u32_val, u32_val + rounding_bias)
         res.append((u32_val >> tirx.const(16, T.uint32)) & mask)
     return res[0] | (res[1] << tirx.const(16, T.uint32))
 


### PR DESCRIPTION
## Summary

- Skip the round-to-nearest-even bias for f32 values with an `0xFF`
  exponent in `_tir_f32x2_to_bf16x2_to_u32`.
- Preserve NaN and positive/negative infinity during bf16x2 packing.
- Add a CUDA regression test covering the reported NaN bit patterns
  and both infinity signs.

## Testing

```text
python3 -m pytest -q testing/python/issue/test_tilelang_bf16x2_pack_special_values.py
1 passed
```

Fixes #2481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Skip RNE biasing for `float32` values with exponent `0xFF` when packing into `bf16x2`, preserving NaN and ±Inf bit patterns.
- Add a CUDA regression test covering NaN payloads and both infinity signs.
- Verified with `test_tilelang_bf16x2_pack_special_values.py`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->