### PR TITLE
[Enhancement] Add local buffer reduction lowering

### DIFF
--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -529,8 +529,8 @@ inline PrimExpr MakeUpdate(const ReduceOpNode &op, PrimExpr dst_val,
 
 template <typename Impl> struct ReduceLowerer {
   static Stmt LowerLocal(const ReduceOpNode &op, const Buffer &src_buffer,
-                         const Buffer &dst_buffer, const LowerArgs &lower_args,
-                         arith::Analyzer *analyzer) {
+                         const Buffer &dst_buffer,
+                         const LowerArgs &lower_args) {
     ICHECK_EQ(op.batch, 1)
         << "ReduceOp: local reduction does not support batch";
     ICHECK(op.src->dtype == op.dst->dtype)
@@ -575,9 +575,9 @@ template <typename Impl> struct ReduceLowerer {
     Array<Stmt> stmts;
     Buffer packed_buffer;
     if (can_pack) {
-      packed_buffer = decl_buffer(
-          dst_buffer->shape, dst_buffer->dtype.with_lanes(vsize),
-          dst_buffer->name + "_pack", GetPtrStorageScope(src_buffer->data));
+      packed_buffer =
+          decl_buffer(dst_buffer->shape, dst_buffer->dtype.with_lanes(vsize),
+                      dst_buffer->name + "_pack", src_buffer.scope());
       stmts.push_back(BufferStore(
           packed_buffer, reduce::MakeInitValue(op, vsize), dst_indices));
 
@@ -648,17 +648,13 @@ template <typename Impl> struct ReduceLowerer {
                     "(requires __hmax_nan/__hmin_nan intrinsics). Target was: "
                  << lower_args.target->str();
     }
-    auto get_buffer = [&](const Buffer &buf) {
-      if (lower_args.buffer_remap.count(buf)) {
-        return lower_args.buffer_remap[buf];
-      }
-      return buf;
+    auto get_buffer = [&](const Buffer &buffer) {
+      auto it = lower_args.buffer_remap.find(buffer);
+      return it == lower_args.buffer_remap.end() ? buffer : (*it).second;
     };
 
-    if (IsLocalBuffer(op.src) &&
-        (IsLocalBuffer(op.dst) || IsLocalVarBuffer(op.dst))) {
-      return LowerLocal(op, get_buffer(op.src), get_buffer(op.dst), lower_args,
-                        analyzer);
+    if (IsLocalBuffer(op.src) && IsLocalBuffer(op.dst, /*allow_var*/ true)) {
+      return LowerLocal(op, get_buffer(op.src), get_buffer(op.dst), lower_args);
     }
 
     if (IsFragmentBuffer(op.src) && IsFragmentBuffer(op.dst)) {

--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -528,6 +528,116 @@ inline PrimExpr MakeUpdate(const ReduceOpNode &op, PrimExpr dst_val,
 } // namespace reduce
 
 template <typename Impl> struct ReduceLowerer {
+  static Stmt LowerLocal(const ReduceOpNode &op, const Buffer &src_buffer,
+                         const Buffer &dst_buffer, const LowerArgs &lower_args,
+                         arith::Analyzer *analyzer) {
+    ICHECK_EQ(op.batch, 1)
+        << "ReduceOp: local reduction does not support batch";
+    ICHECK(op.src->dtype == op.dst->dtype)
+        << "ReduceOp: local packed reduction currently requires matching src "
+           "and dst dtypes";
+
+    int src_dim = static_cast<int>(op.src->shape.size());
+    int dst_dim = static_cast<int>(op.dst->shape.size());
+    ICHECK(op.dim >= 0 && op.dim < src_dim);
+    ICHECK(dst_dim == src_dim - 1 || dst_dim == src_dim)
+        << "ReduceOp: local reduction dimension mismatch";
+
+    Array<Var> dst_vars;
+    Array<PrimExpr> dst_indices;
+    for (int i = 0; i < dst_dim; ++i) {
+      Var var("i" + std::to_string(i));
+      dst_vars.push_back(var);
+      dst_indices.push_back(var);
+    }
+
+    auto make_src_indices = [&](PrimExpr reduce_index) {
+      Array<PrimExpr> indices;
+      for (int i = 0; i < src_dim; ++i) {
+        if (i == op.dim) {
+          indices.push_back(reduce_index);
+        } else if (dst_dim == src_dim) {
+          indices.push_back(dst_vars[i]);
+        } else {
+          indices.push_back(dst_vars[i < op.dim ? i : i - 1]);
+        }
+      }
+      return indices;
+    };
+
+    int vsize =
+        Impl::GetPreferedVectorizedSize(dst_buffer->dtype, lower_args.target);
+    const int64_t *reduce_extent = as_const_int(op.src->shape[op.dim]);
+    bool can_pack = op.clear && vsize == 2 && reduce_extent &&
+                    *reduce_extent >= vsize && *reduce_extent % vsize == 0 &&
+                    reduce::MakeCodegenReducer(op, vsize).has_value();
+
+    Array<Stmt> stmts;
+    Buffer packed_buffer;
+    if (can_pack) {
+      packed_buffer = decl_buffer(
+          dst_buffer->shape, dst_buffer->dtype.with_lanes(vsize),
+          dst_buffer->name + "_pack", GetPtrStorageScope(src_buffer->data));
+      stmts.push_back(BufferStore(
+          packed_buffer, reduce::MakeInitValue(op, vsize), dst_indices));
+
+      Var rv("rv");
+      PrimExpr base = rv * vsize;
+      PrimExpr src_value;
+      if (op.dim == src_dim - 1) {
+        Array<PrimExpr> src_indices =
+            make_src_indices(Ramp(base, Integer(1), vsize));
+        BufferLoad src_load(src_buffer, src_indices);
+        src_load.CopyOnWrite()->dtype = src_buffer->dtype.with_lanes(vsize);
+        src_value = src_load;
+      } else {
+        PrimExpr value0 = BufferLoad(src_buffer, make_src_indices(base));
+        PrimExpr value1 =
+            BufferLoad(src_buffer, make_src_indices(base + Integer(1)));
+        src_value = Shuffle({value0, value1}, {0, 1});
+      }
+      Stmt reduce_body = BufferStore(
+          packed_buffer,
+          reduce::MakeReduce(op, vsize, BufferLoad(packed_buffer, dst_indices),
+                             src_value),
+          dst_indices);
+      stmts.push_back(For(rv, 0, Integer(*reduce_extent / vsize),
+                          ForKind::kUnrolled, reduce_body, std::nullopt,
+                          {{tirx::attr::pragma_unroll_explicit, Bool(false)}}));
+
+      PrimExpr packed = BufferLoad(packed_buffer, dst_indices);
+      PrimExpr result =
+          reduce::MakeReduce(op, 1, Shuffle::ExtractElement(packed, 0),
+                             Shuffle::ExtractElement(packed, 1));
+      stmts.push_back(BufferStore(dst_buffer, result, dst_indices));
+    } else {
+      if (op.clear) {
+        stmts.push_back(
+            BufferStore(dst_buffer, reduce::MakeInitValue(op), dst_indices));
+      }
+      Var rv("rv");
+      Stmt reduce_body = BufferStore(
+          dst_buffer,
+          reduce::MakeReduce(op, 1, BufferLoad(dst_buffer, dst_indices),
+                             BufferLoad(src_buffer, make_src_indices(rv))),
+          dst_indices);
+      stmts.push_back(For(rv, 0, op.src->shape[op.dim], ForKind::kUnrolled,
+                          reduce_body, std::nullopt,
+                          {{tirx::attr::pragma_unroll_explicit, Bool(false)}}));
+    }
+
+    Stmt body = SeqStmt(stmts);
+    for (int i = dst_dim - 1; i >= 0; --i) {
+      body = For(dst_vars[i], 0, op.dst->shape[i], ForKind::kUnrolled, body,
+                 std::nullopt,
+                 {{tirx::attr::pragma_unroll_explicit, Bool(false)}});
+    }
+    if (can_pack) {
+      body = SeqStmt({AllocBuffer(packed_buffer), body});
+    }
+    return body;
+  }
+
   static Stmt Lower(const ReduceOpNode &op, const LowerArgs &lower_args,
                     arith::Analyzer *analyzer) {
     if (op.nan_propagate &&
@@ -544,6 +654,12 @@ template <typename Impl> struct ReduceLowerer {
       }
       return buf;
     };
+
+    if (IsLocalBuffer(op.src) &&
+        (IsLocalBuffer(op.dst) || IsLocalVarBuffer(op.dst))) {
+      return LowerLocal(op, get_buffer(op.src), get_buffer(op.dst), lower_args,
+                        analyzer);
+    }
 
     if (IsFragmentBuffer(op.src) && IsFragmentBuffer(op.dst)) {
       auto src_buffer = get_buffer(op.src);

--- a/testing/python/language/test_tilelang_language_reduce.py
+++ b/testing/python/language/test_tilelang_language_reduce.py
@@ -4,6 +4,7 @@ import tilelang.language as T
 import tilelang.testing
 import pytest
 import torch
+from tilelang import tvm
 
 tilelang.testing.set_random_seed()
 
@@ -139,6 +140,94 @@ def test_reduce(op, dtype, M, N, src_scope, dst_scope, threads, batch):
     # float16/bfloat16 accumulate more rounding error over large reductions
     tol = 1e-1 if dtype in (T.float16, T.bfloat16) else 1e-2
     torch.testing.assert_close(B, _ref(A, op), atol=tol, rtol=tol)
+
+
+@pytest.mark.parametrize(
+    ("op", "packed_op"),
+    [("sum", "add2"), ("max", "max2"), ("min", "min2")],
+)
+def test_reduce_local_packed_codegen(op, packed_op):
+    @T.prim_func
+    def main(A: T.Tensor((8,), T.float16), B: T.Tensor((1,), T.float16)):
+        with T.Kernel(1, threads=1):
+            src = T.alloc_local((8,), T.float16)
+            dst = T.alloc_local((1,), T.float16)
+            for i in T.serial(8):
+                src[i] = A[i]
+            _reduce_op(T, op, src, dst, dim=0)
+            B[0] = dst[0]
+
+    target = {"kind": "cuda", "arch": "sm_80"}
+    with tvm.transform.PassContext(), tvm.target.Target(target):
+        artifact = tilelang.lower(main, target=target)
+    assert f"tl::{packed_op}" in artifact.kernel_source
+
+
+@pytest.mark.parametrize(
+    ("op", "packed_op"),
+    [("sum", "add2"), ("max", "max2"), ("min", "min2")],
+)
+def test_reduce_local_noncontiguous_dim_packed_codegen(op, packed_op):
+    @T.prim_func
+    def main(A: T.Tensor((8, 4), T.float16), B: T.Tensor((4,), T.float16)):
+        with T.Kernel(1, threads=1):
+            src = T.alloc_local((8, 4), T.float16)
+            dst = T.alloc_local((4,), T.float16)
+            for i in T.serial(8):
+                for j in T.serial(4):
+                    src[i, j] = A[i, j]
+            _reduce_op(T, op, src, dst, dim=0)
+            for j in T.serial(4):
+                B[j] = dst[j]
+
+    target = {"kind": "cuda", "arch": "sm_80"}
+    with tvm.transform.PassContext(), tvm.target.Target(target):
+        artifact = tilelang.lower(main, target=target)
+    assert f"tl::{packed_op}" in artifact.kernel_source
+
+
+@pytest.mark.parametrize(
+    ("op", "packed_op"),
+    [("sum", "add2"), ("max", "max2"), ("min", "min2")],
+)
+def test_reduce_local_to_var_packed_codegen(op, packed_op):
+    @T.prim_func
+    def main(A: T.Tensor((8,), T.float16), B: T.Tensor((1,), T.float16)):
+        with T.Kernel(1, threads=1):
+            src = T.alloc_local((8,), T.float16)
+            dst = T.alloc_var(T.float16)
+            for i in T.serial(8):
+                src[i] = A[i]
+            _reduce_op(T, op, src, dst, dim=0)
+            B[0] = dst
+
+    target = {"kind": "cuda", "arch": "sm_80"}
+    with tvm.transform.PassContext(), tvm.target.Target(target):
+        artifact = tilelang.lower(main, target=target)
+    assert f"tl::{packed_op}" in artifact.kernel_source
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("op", ["sum", "max", "min"])
+def test_reduce_local_packed_correctness(op):
+    @tilelang.jit(out_idx=-1)
+    def kernel():
+        @T.prim_func
+        def main(A: T.Tensor((8,), T.float16), B: T.Tensor((1,), T.float16)):
+            with T.Kernel(1, threads=1):
+                src = T.alloc_local((8,), T.float16)
+                dst = T.alloc_local((1,), T.float16)
+                for i in T.serial(8):
+                    src[i] = A[i]
+                _reduce_op(T, op, src, dst, dim=0)
+                B[0] = dst[0]
+
+        return main
+
+    jit_kernel = kernel()
+    A = torch.randn((8,), dtype=torch.float16, device="cuda")
+    B = jit_kernel(A)
+    torch.testing.assert_close(B[0], _ref(A.reshape(1, 8), op)[0], atol=1e-1, rtol=1e-1)
 
 
 # ---------------------------------------------------------------------------

--- a/tilelang/language/reduce_op.py
+++ b/tilelang/language/reduce_op.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 from typing import Literal
 from tvm import tirx
-from tilelang.language import copy, macro, alloc_fragment, evaluate, has_let_value, get_let_value
-from tilelang.utils.language import to_tile_region
-from tilelang.utils.language import is_shared, is_fragment, is_local, is_local_var
+from tilelang.language import copy, macro, alloc_fragment, evaluate
+from tilelang.utils.language import to_buffer_region, to_tile_region
+from tilelang.utils.language import is_shared, is_fragment, is_local
 from tvm.script.ir_builder import IRBuilder
 
 
@@ -44,9 +44,7 @@ def reduce(
     """
     if batch < 1:
         raise ValueError(f"batch must be >= 1, got {batch}")
-    if isinstance(out, tirx.Var) and has_let_value(out):
-        out = get_let_value(out)
-    out_buffer = out.buffer if isinstance(out, tirx.BufferLoad) else out
+    out_buffer = to_buffer_region(out).buffer
     if reduce_type in ("bitand", "bitor", "bitxor") and not (out_buffer.dtype.startswith(("int", "uint")) or out_buffer.dtype == "bool"):
         raise ValueError(f"reduce_{reduce_type} requires an integer/bool buffer, got dtype {out_buffer.dtype}")
     # input shape: [X, d, Y], expected output shape: [X, Y] or [X, 1, Y]
@@ -66,10 +64,10 @@ def reduce(
     if not annotations:
         annotations = None
 
-    # local.var is represented as a scalar Var inside a macro. Emit this case
-    # before macro expansion while the underlying Buffer is still available.
-    if is_local(buffer) and is_local_var(out_buffer):
-        evaluate(
+    # Emit local reductions before macro expansion so alloc_var retains its
+    # underlying Buffer rather than becoming a scalar expression.
+    if is_local(buffer) and out_buffer.scope() in ("local", "local.var"):
+        return evaluate(
             tirx.call_intrin(
                 "handle",
                 tirx.op.Op.get(_REDUCE_OP_KEY),
@@ -81,7 +79,6 @@ def reduce(
                 annotations=annotations,
             )
         )
-        return
 
     @macro
     def reduce_macro(buffer: tirx.Buffer, out: tirx.Buffer, reduce_type: str, dim: int, clear: bool) -> None:
@@ -141,7 +138,7 @@ def reduce(
                 annotations=annotations,
             )
             copy(red_frag_out, out)
-        elif is_fragment(buffer) and is_fragment(out) or is_local(buffer) and is_local(out):
+        elif is_fragment(buffer) and is_fragment(out):
             tirx.call_intrin(
                 "handle",
                 tirx.op.Op.get(_REDUCE_OP_KEY),

--- a/tilelang/language/reduce_op.py
+++ b/tilelang/language/reduce_op.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from typing import Literal
 from tvm import tirx
-from tilelang.language import copy, macro, alloc_fragment
+from tilelang.language import copy, macro, alloc_fragment, evaluate, has_let_value, get_let_value
 from tilelang.utils.language import to_tile_region
 from tilelang.utils.language import is_shared, is_fragment, is_local, is_local_var
 from tvm.script.ir_builder import IRBuilder
@@ -44,13 +44,16 @@ def reduce(
     """
     if batch < 1:
         raise ValueError(f"batch must be >= 1, got {batch}")
+    if isinstance(out, tirx.Var) and has_let_value(out):
+        out = get_let_value(out)
+    out_buffer = out.buffer if isinstance(out, tirx.BufferLoad) else out
     # input shape: [X, d, Y], expected output shape: [X, Y] or [X, 1, Y]
     expected_shapes = [buffer.shape[:dim] + buffer.shape[dim + 1 :], buffer.shape[:dim] + [1] + buffer.shape[dim + 1 :]]
-    if list(out.shape) not in expected_shapes:
+    if list(out_buffer.shape) not in expected_shapes:
         expected_shapes_str = " or ".join(map(str, expected_shapes))
         raise ValueError(
             f"Invalid reduce output shape, buffer shape is {buffer.shape}, dim is {dim}, "
-            f"output shape is {out.shape}, expected shapes are {expected_shapes_str}"
+            f"output shape is {out_buffer.shape}, expected shapes are {expected_shapes_str}"
         )
 
     annotations = {}
@@ -60,6 +63,23 @@ def reduce(
         annotations["nan_propagate"] = True
     if not annotations:
         annotations = None
+
+    # local.var is represented as a scalar Var inside a macro. Emit this case
+    # before macro expansion while the underlying Buffer is still available.
+    if is_local(buffer) and is_local_var(out_buffer):
+        evaluate(
+            tirx.call_intrin(
+                "handle",
+                tirx.op.Op.get(_REDUCE_OP_KEY),
+                to_tile_region(buffer, access_type="r"),
+                to_tile_region(out_buffer, access_type="w"),
+                reduce_type,
+                dim,
+                clear,
+                annotations=annotations,
+            )
+        )
+        return
 
     @macro
     def reduce_macro(buffer: tirx.Buffer, out: tirx.Buffer, reduce_type: str, dim: int, clear: bool) -> None:
@@ -119,7 +139,7 @@ def reduce(
                 annotations=annotations,
             )
             copy(red_frag_out, out)
-        elif is_fragment(buffer) and is_fragment(out) or is_local(buffer) and (is_local(out) or is_local_var(out)):
+        elif is_fragment(buffer) and is_fragment(out) or is_local(buffer) and is_local(out):
             tirx.call_intrin(
                 "handle",
                 tirx.op.Op.get(_REDUCE_OP_KEY),

--- a/tilelang/language/reduce_op.py
+++ b/tilelang/language/reduce_op.py
@@ -5,7 +5,7 @@ from typing import Literal
 from tvm import tirx
 from tilelang.language import copy, macro, alloc_fragment
 from tilelang.utils.language import to_tile_region
-from tilelang.utils.language import is_shared, is_fragment
+from tilelang.utils.language import is_shared, is_fragment, is_local, is_local_var
 from tvm.script.ir_builder import IRBuilder
 
 
@@ -119,7 +119,7 @@ def reduce(
                 annotations=annotations,
             )
             copy(red_frag_out, out)
-        elif is_fragment(buffer) and is_fragment(out):
+        elif is_fragment(buffer) and is_fragment(out) or is_local(buffer) and (is_local(out) or is_local_var(out)):
             tirx.call_intrin(
                 "handle",
                 tirx.op.Op.get(_REDUCE_OP_KEY),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added a dedicated lowering path for **local-to-local** `ReduceOp` operations in `src/backend/common/op/reduce.h`, including:
  - Compile-time validations for supported local reduction constraints (e.g., `batch == 1`, matching `src`/`dst` dtypes, valid reduce dimension, and expected `dst` dimensionality).
  - Scalar local reduction lowering, optionally initializing `dst` when `op.clear` is set.
  - Optional packed/vectorized lowering (when `op.clear` is enabled and strict vector/extent/codegen-reducer conditions are met, e.g., emitting packed `tl::{add2,max2,min2}`-style ops) followed by lane extraction and storage back to the scalar `dst`.
- Updated `ReduceLowerer<Impl>::Lower` to early-route local reductions when both `op.src` and `op.dst` are local buffers (including `"local.var"` cases) through the new `LowerLocal` path, bypassing the fragment/layout-based reduction lowering.
- Extended `tilelang/language/reduce_op.py`:
  - Resolve `out` to its underlying buffer region (`out_buffer`) and perform dtype/shape validation against `out_buffer`.
  - Add an early-return lowering path for local input buffers with local scalar destinations, emitting the reduction intrinsic directly via `evaluate(tirx.call_intrin(...))` before macro expansion.
- Added CUDA-focused reduction regression tests in `testing/python/language/test_tilelang_language_reduce.py` to validate packed-op codegen and runtime correctness for local reductions (`sum/max/min`), including noncontiguous reduce dimensions and variable destinations.

## C++ style / lint notes

- This PR changes C++ code in `src/backend/common/op/reduce.h`, so it should follow the rules in `docs/developer_guide/cpp_style.md` (especially around using the **C++ API style audit** before cleanup work).
- No CI/lint tooling changes are included; however, the **“C++ API Style Audit (warning only)”** CI step may surface advisory findings (e.g., TLCPP003/TLCPP004). Since this PR is primarily backend lowering logic (not an FFI/public API rename), treat any such warnings as non-blocking unless a concrete API/FFI/maintainability risk is identified.
- Correctness/build/test concerns are addressed via the added CUDA regression tests; style findings should be reviewed only for warning-only lint compliance with the new `LowerLocal` logic and control flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->