### PR TITLE
[BugFix] Correct the spelling of fragment

### DIFF
--- a/examples/gdn/example_chunk_o_bwd.py
+++ b/examples/gdn/example_chunk_o_bwd.py
@@ -190,7 +190,6 @@ def tilelang_chunk_o_bwd_dqkwg(
             ds_fragment_positive_transpose = T.alloc_fragment((block_S, block_S), dtype=accum_dtype)
             dq_fragment = T.alloc_fragment((block_S, block_DK), dtype=accum_dtype)
             dk_fragment = T.alloc_fragment((block_S, block_DK), dtype=accum_dtype)
-            dk_fragment_2 = T.alloc_fragment((block_S, block_DK), dtype=accum_dtype)
             dw_fragment = T.alloc_fragment((block_S, block_DK), dtype=accum_dtype)
             q_fragment = T.alloc_fragment((block_S, block_DK), dtype=input_dtype)
             k_fragment = T.alloc_fragment((block_S, block_DK), dtype=input_dtype)
@@ -344,6 +343,7 @@ def tilelang_chunk_o_bwd_dqkwg(
                     dg[bk, bb, bs * block_S + i_s, bh] = dg_fragment_final[i_s]
 
             else:
+                dk_fragment_2 = T.alloc_fragment((block_S, block_DK), dtype=accum_dtype)
                 for i_s1, i_s2 in T.Parallel(block_S, block_S):
                     ds_fragment[i_s1, i_s2] = 0 if i_s1 < i_s2 else ds_fragment[i_s1, i_s2]
                 T.clear(dk_fragment_2)

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -1215,11 +1215,11 @@ private:
    * @brief Visit and mutate a Block node to attach inferred layout information.
    *
    * Converts the visited Block via the base visitor, asserts that every buffer
-   * allocated with scope "local.framgent" has an inferred layout in
+   * allocated with scope "local.fragment" has an inferred layout in
    * result_.layout_map, and attaches result_.layout_map to the Block's
    * annotations under attr::kLayoutMap.
    *
-   * If any "local.framgent" buffer lacks an entry in result_.layout_map an
+   * If any "local.fragment" buffer lacks an entry in result_.layout_map an
    * ICHECK will fail with the offending buffer printed.
    *
    * @return Stmt The (possibly modified) Block statement with the layout-map
@@ -1229,7 +1229,7 @@ private:
     SBlock block = Downcast<SBlock>(IRMutatorWithAnalyzer::VisitStmt_(op));
 
     for (auto buffer : block->alloc_buffers) {
-      if (buffer.scope() == "local.framgent") {
+      if (buffer.scope() == "local.fragment") {
         ICHECK(result_.layout_map.count(buffer))
             << "Cannot inference fragment layout for " << buffer;
       }

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -1229,7 +1229,7 @@ private:
     SBlock block = Downcast<SBlock>(IRMutatorWithAnalyzer::VisitStmt_(op));
 
     for (auto buffer : block->alloc_buffers) {
-      if (buffer.scope() == "local.fragment") {
+      if (IsFragmentBuffer(buffer)) {
         ICHECK(result_.layout_map.count(buffer))
             << "Cannot inference fragment layout for " << buffer;
       }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed the buffer allocation scope spelling in `src/transform/layout_inference.cc` by correcting `local.framgent` to `local.fragment`, ensuring layout inference attaches inferred layouts only for buffers allocated in the intended fragment scope.
- Updated `examples/gdn/example_chunk_o_bwd.py` so `dk_fragment_2` is allocated only inside the `else` branch (`use_g == False`), matching where the fragment is actually used.

## C++ style / lint notes

- Does not touch rules in `docs/developer_guide/cpp_style.md`.
- Does not modify CI/lint tooling (including `maint/scripts/audit_cpp_api_style.py`); the “C++ API Style Audit (warning only)” step remains advisory.
- No new TLCPP003/TLCPP004-style correctness/build concerns are expected, since this is a scope-string/layout-inference fix with no public API/FFI/header surface changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->