### PR TITLE
[Fix] `T.__exp` must compute e**x, not 2**x (docstring + CuTeDSL codegen)

### DIFF
--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -1182,7 +1182,7 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
     os << "tl.increase_descriptor_offset(" << descriptor << ", " << offset
        << ")";
   } else if (op->op.same_as(tl::__exp())) {
-    os << "tl.exp2(" << PrintExpr_(op->args[0]) << ", fastmath=True)";
+    os << "tl.exp(" << PrintExpr_(op->args[0]) << ", fastmath=True)";
   } else if (op->op.same_as(tl::__exp10())) {
     os << "tl.exp10(" << PrintExpr_(op->args[0]) << ", fastmath=True)";
   } else if (op->op.same_as(tl::__log())) {

--- a/tilelang/language/fastmath.py
+++ b/tilelang/language/fastmath.py
@@ -124,7 +124,7 @@ def __exp10(x: PrimExpr) -> PrimExpr:
 
 
 def __exp(x: PrimExpr) -> PrimExpr:
-    """Calculate 2**x with fast math
+    """Calculate e**x with fast math
 
     Parameters
     ----------

--- a/tilelang/language/math_intrinsics.py
+++ b/tilelang/language/math_intrinsics.py
@@ -132,7 +132,7 @@ def __exp10(x: PrimExpr) -> PrimExpr:
 
 
 def __exp(x: PrimExpr) -> PrimExpr:
-    """Calculate 2**x with fast math
+    """Calculate e**x with fast math
 
     Parameters
     ----------


### PR DESCRIPTION
`T.__exp` is the fast **exponential** (`e**x`): the CUDA backend lowers it to `__expf` (base-e), and the fast-math test asserts exactly that (`testing/python/fastmath/test_mathops_fastmath.py` checks `torch.exp`). A stale `2**x` was followed in two places; this corrects both so the whole `__exp` path is base-e:

- **Docstring** said `Calculate 2**x` in both copies (`language/math_intrinsics.py`, `language/fastmath.py`) → `e**x`.
- **CuTeDSL codegen** lowered `tl.__exp` to `tl.exp2` (base-2) at `src/cuda/codegen/codegen_cutedsl.cc`, diverging from the CUDA backend and the frontend contract for the same op — identical source computes `e**x` on CUDA and `2**x` on CuTeDSL. Mapped to `tl.exp` (base-e), matching every sibling (`__log`→`tl.log`, `__log2`→`tl.log2`, `__exp10`→`tl.exp10`, …), which already map to their matching base. The base-2 exponential remains available as the separate `exp2` op.

The CuTeDSL fix is confirmed by source (frontend contract + CUDA backend + the base-e value test + cutlass `exp2`=base-2 semantics); I have not run the CuTeDSL backend on silicon to observe the numeric change (requires `nvidia-cutlass-dsl`). Reach is small — CuTeDSL is an opt-in backend and no shipped kernel calls `__exp` today — so this is primarily a correctness cleanup of a latent divergence.