### PR TITLE
[Bugfix] Emit st.bulk destination as a shared write to fix missing barrier and potential compilation-introduced races

### DIFF
--- a/src/cuda/op/fill.cc
+++ b/src/cuda/op/fill.cc
@@ -80,9 +80,17 @@ std::optional<Stmt> TryLowerSharedBulkZeroFill(const FillNode &op,
     return std::nullopt;
   }
 
+  // Emit the destination as a write access_ptr so ThreadSync records the
+  // st.bulk as a shared write and inserts the required barrier.
+  PrimExpr dst_access_ptr =
+      Call(DataType::Handle(), builtin::tvm_access_ptr(),
+           {TypeAnnotation(op.dst->dtype), op.dst->data,
+            make_const(DataType::Int(32), 0),
+            cast(DataType::Int(32), elements.value()),
+            IntImm(DataType::Int(32), /*rw_mask=write*/ 2)});
   PrimExpr bulk_store =
       Call(DataType::Handle(), ptx_st_bulk_shared(),
-           {op.dst->data, bytes, make_const(DataType::UInt(64), 0)});
+           {dst_access_ptr, bytes, make_const(DataType::UInt(64), 0)});
   Stmt body = Evaluate(bulk_store);
   if (lower_args.thread_var.defined() && lower_args.thread_bounds.defined()) {
     body = IfThenElse(EQ(lower_args.thread_var, lower_args.thread_bounds->min),


### PR DESCRIPTION
### Description

Current `ThreadSync` does not recognize `ptx_st_bulk_shared` (the Blackwell lowering of `T.clear`) as a write, so it may fail to insert a barrier between `ptx_st_bulk_shared` and other read/writes, causing data races in compiled TVM TIR (and lowered CUDA), silently corrupt kernel results.

This PR emits the `st.bulk` destination as a write `tvm_access_ptr` in `fill.cc`, so the existing `tvm_access_ptr` handling in `ThreadSync` records it as a shared write and inserts the barrier.

### Bug Fix
Fix two bugs (issue #2699 and #2703) caused by a missing barrier between a `st.bulk` and a synchronized read:
- Fixes #2699 
- Fixes #2703 

### Note

An alternative is to add a branch in `ThreadSync` (`TileLangThreadSyncPlanner::VisitExpr_`) that recognizes `ptx_st_bulk_shared` and records it as a write. This PR instead marks the destination as a write in `fill.cc`, reusing the existing `tvm_access_ptr` handling (precise range, no new `ThreadSync` branch). Happy to switch if preferred.

### Regression Test

Existing tests pass: `test_tilelang_language_{clear, atomic, access_ptr_codegen, warp_sync, wgmma_gemm}`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed missing `ThreadSync` barriers for Blackwell `ptx_st_bulk_shared` lowering of `T.clear`.
- Emits the destination through `tvm_access_ptr` so `ThreadSync` records the operation as a shared-memory write and inserts the required barrier.
- Prevents data races and nondeterministic results caused by shared-memory aliasing.
- Regression reproducer results improved from failures in 20/20 runs to 0/20; related tests pass.

## C++ style / lint notes

- This PR changes C++ implementation code but does not touch rules documented in `docs/developer_guide/cpp_style.md`.
- No CI or lint tooling changes are included.
- The C++ API Style Audit (warning only) is not affected; any advisory warnings should not block merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->