### PR TITLE
[BugFix] Pack 32-lane 8-bit CUDA vectors correctly

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -37,46 +37,6 @@ bool IsValidCPAsyncTransferBytes(int64_t bytes) {
   return bytes == 4 || bytes == 8 || bytes == 16;
 }
 
-bool Needs64BitIntegerVectorPacking(DataType t) {
-  if (!t.is_int() && !t.is_uint()) {
-    return false;
-  }
-  return (t.bits() == 32 && t.lanes() > 4 && t.lanes() <= 8 &&
-          t.lanes() % 2 == 0) ||
-         (t.bits() == 8 && t.lanes() == 32);
-}
-
-void PrintPackedIntegerVectorArgs(DataType t,
-                                  const std::vector<std::string> &scalars,
-                                  std::ostream &os) {
-  ICHECK(t.bits() == 8 || t.bits() == 32);
-  ICHECK_EQ(64 % t.bits(), 0);
-  int lanes_per_field = 64 / t.bits();
-  ICHECK_EQ(scalars.size() % lanes_per_field, 0);
-
-  const char *unsigned_scalar_type =
-      t.bits() == 8 ? "unsigned char" : "unsigned int";
-  const char *field_type = t.is_uint() ? "unsigned long long" : "long long";
-  for (size_t i = 0; i < scalars.size(); i += lanes_per_field) {
-    if (i != 0) {
-      os << ", ";
-    }
-    os << "(" << field_type << ")(";
-    for (int j = 0; j < lanes_per_field; ++j) {
-      if (j != 0) {
-        os << " | ";
-      }
-      os << "((unsigned long long)(" << unsigned_scalar_type << ")("
-         << scalars[i + j] << ")";
-      if (j != 0) {
-        os << " << " << j * t.bits();
-      }
-      os << ")";
-    }
-    os << ")";
-  }
-}
-
 std::optional<DataType> GetAccessPtrElementType(const PrimExpr &expr) {
   const auto *ptr_call = expr.as<CallNode>();
   if (ptr_call == nullptr) {
@@ -5244,10 +5204,15 @@ void CodeGenTileLangCUDA::VisitExpr_(const ShuffleNode *op,
     return;
   }
 
-  // Some logical integer vectors use 64-bit fields in their CUDA storage type:
-  // int32x8 uses four fields and int8x32 uses four fields. Pack the logical
-  // lanes so the generated constructor receives its physical arity.
-  if (Needs64BitIntegerVectorPacking(t)) {
+  // 32-bit int/uint vectors with lanes > 4 are typed as (u)longlong{lanes/2}
+  // by PrintType. The base CodeGenC emits `make_<type>(v0, v1, ..., v_{N-1})`
+  // N args for N lanes, which produces e.g. `make_ulonglong4(8 args)` and
+  // nvcc rejects with "too many arguments in function call". Pack consecutive
+  // pairs of 32-bit values into a single 64-bit lane to match the type's real
+  // arity. Triggered e.g. by storing eight T.rng_rand() (uint32) results via
+  // a 256-bit vectorized store.
+  if ((t.is_int() || t.is_uint()) && t.bits() == 32 && t.lanes() > 4 &&
+      t.lanes() % 2 == 0) {
     int lanes = t.lanes();
     // Reuse CodeGenC's concat logic by reading individual scalars from the
     // shuffle's source vectors at the indices the shuffle requested.
@@ -5286,9 +5251,18 @@ void CodeGenTileLangCUDA::VisitExpr_(const ShuffleNode *op,
       }
     }
 
+    const char *u64 = t.is_uint() ? "unsigned long long" : "long long";
     PrintVecConstructor(t, os);
     os << '(';
-    PrintPackedIntegerVectorArgs(t, scalars, os);
+    for (int i = 0; i + 1 < lanes; i += 2) {
+      if (i != 0)
+        os << ", ";
+      // Pack lane i (lo) and lane i+1 (hi) into one 64-bit value. Widen through
+      // `unsigned int` so both lanes are zero-extended.
+      os << "(" << u64 << ")(((unsigned long long)(unsigned int)(" << scalars[i]
+         << ")) | ((unsigned long long)(unsigned int)(" << scalars[i + 1]
+         << ") << 32))";
+    }
     os << ')';
     return;
   }
@@ -5315,6 +5289,12 @@ void CodeGenTileLangCUDA::VisitExpr_(const BroadcastNode *op,
         }
         return;
       }
+      // lanes == 32 (int8x32, stored as (u)longlong4) is handled by the generic
+      // path below, which emits make_(u)longlong4 with 32 scalar args. That
+      // resolves to the 32-arg packing overloads in common.h, which fill all
+      // 64 bits of each field. Do NOT special-case it here with a 4-arg
+      // make_(u)longlong4: a 4-arg call binds the built-in overload and only
+      // fills the low 32 bits of each field, zeroing the upper half.
     }
   }
 
@@ -5377,17 +5357,30 @@ void CodeGenTileLangCUDA::VisitExpr_(const BroadcastNode *op,
     return;
   }
 
-  // Match the physical arity of integer vector types backed by 64-bit fields.
-  // Repeating the expression in `scalars` preserves the existing behavior for
-  // side-effecting uint32 broadcasts such as T.rng_rand().
-  if (Needs64BitIntegerVectorPacking(op->dtype)) {
+  // 32-bit int/uint broadcast with lanes > 4 lowers to (u)longlong{lanes/2}
+  // (each ulonglong holds two consecutive 32-bit lanes). Without packing,
+  // the generic loop below would emit one arg per lane, producing e.g.
+  // `make_ulonglong4(v, v, v, v, v, v, v, v)` which nvcc rejects with
+  // "too many arguments". This path is hit when a vectorized store of
+  // `T.rng_rand()` (uint32) is broadcast across the 8 lanes of a 256-bit
+  // store. PrintExpr is invoked twice per packed slot so the underlying
+  // side-effecting call (curand) executes once per uint32 lane, matching
+  // the lane count.
+  if ((op->dtype.is_int() || op->dtype.is_uint()) && op->dtype.bits() == 32 &&
+      op->dtype.lanes() > 4 && op->dtype.lanes() % 2 == 0) {
     int lanes = op->dtype.lanes();
     std::string v = PrintExpr(op->value);
-    std::vector<std::string> scalars(lanes, v);
+    const char *u64 = op->dtype.is_uint() ? "unsigned long long" : "long long";
     os << "make_";
     PrintType(op->dtype, os);
     os << '(';
-    PrintPackedIntegerVectorArgs(op->dtype, scalars, os);
+    for (int i = 0; i < lanes / 2; ++i) {
+      if (i != 0)
+        os << ", ";
+      // Widen through `unsigned int` so both lanes are zero-extended.
+      os << "(" << u64 << ")(((unsigned long long)(unsigned int)(" << v
+         << ")) | ((unsigned long long)(unsigned int)(" << v << ") << 32))";
+    }
     os << ')';
     return;
   }

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -37,6 +37,46 @@ bool IsValidCPAsyncTransferBytes(int64_t bytes) {
   return bytes == 4 || bytes == 8 || bytes == 16;
 }
 
+bool Needs64BitIntegerVectorPacking(DataType t) {
+  if (!t.is_int() && !t.is_uint()) {
+    return false;
+  }
+  return (t.bits() == 32 && t.lanes() > 4 && t.lanes() <= 8 &&
+          t.lanes() % 2 == 0) ||
+         (t.bits() == 8 && t.lanes() == 32);
+}
+
+void PrintPackedIntegerVectorArgs(DataType t,
+                                  const std::vector<std::string> &scalars,
+                                  std::ostream &os) {
+  ICHECK(t.bits() == 8 || t.bits() == 32);
+  ICHECK_EQ(64 % t.bits(), 0);
+  int lanes_per_field = 64 / t.bits();
+  ICHECK_EQ(scalars.size() % lanes_per_field, 0);
+
+  const char *unsigned_scalar_type =
+      t.bits() == 8 ? "unsigned char" : "unsigned int";
+  const char *field_type = t.is_uint() ? "unsigned long long" : "long long";
+  for (size_t i = 0; i < scalars.size(); i += lanes_per_field) {
+    if (i != 0) {
+      os << ", ";
+    }
+    os << "(" << field_type << ")(";
+    for (int j = 0; j < lanes_per_field; ++j) {
+      if (j != 0) {
+        os << " | ";
+      }
+      os << "((unsigned long long)(" << unsigned_scalar_type << ")("
+         << scalars[i + j] << ")";
+      if (j != 0) {
+        os << " << " << j * t.bits();
+      }
+      os << ")";
+    }
+    os << ")";
+  }
+}
+
 std::optional<DataType> GetAccessPtrElementType(const PrimExpr &expr) {
   const auto *ptr_call = expr.as<CallNode>();
   if (ptr_call == nullptr) {
@@ -5204,15 +5244,10 @@ void CodeGenTileLangCUDA::VisitExpr_(const ShuffleNode *op,
     return;
   }
 
-  // 32-bit int/uint vectors with lanes > 4 are typed as (u)longlong{lanes/2}
-  // by PrintType. The base CodeGenC emits `make_<type>(v0, v1, ..., v_{N-1})`
-  // N args for N lanes, which produces e.g. `make_ulonglong4(8 args)` and
-  // nvcc rejects with "too many arguments in function call". Pack consecutive
-  // pairs of 32-bit values into a single 64-bit lane to match the type's real
-  // arity. Triggered e.g. by storing eight T.rng_rand() (uint32) results via
-  // a 256-bit vectorized store.
-  if ((t.is_int() || t.is_uint()) && t.bits() == 32 && t.lanes() > 4 &&
-      t.lanes() % 2 == 0) {
+  // Some logical integer vectors use 64-bit fields in their CUDA storage type:
+  // int32x8 uses four fields and int8x32 uses four fields. Pack the logical
+  // lanes so the generated constructor receives its physical arity.
+  if (Needs64BitIntegerVectorPacking(t)) {
     int lanes = t.lanes();
     // Reuse CodeGenC's concat logic by reading individual scalars from the
     // shuffle's source vectors at the indices the shuffle requested.
@@ -5251,18 +5286,9 @@ void CodeGenTileLangCUDA::VisitExpr_(const ShuffleNode *op,
       }
     }
 
-    const char *u64 = t.is_uint() ? "unsigned long long" : "long long";
     PrintVecConstructor(t, os);
     os << '(';
-    for (int i = 0; i + 1 < lanes; i += 2) {
-      if (i != 0)
-        os << ", ";
-      // Pack lane i (lo) and lane i+1 (hi) into one 64-bit value. Widen through
-      // `unsigned int` so both lanes are zero-extended.
-      os << "(" << u64 << ")(((unsigned long long)(unsigned int)(" << scalars[i]
-         << ")) | ((unsigned long long)(unsigned int)(" << scalars[i + 1]
-         << ") << 32))";
-    }
+    PrintPackedIntegerVectorArgs(t, scalars, os);
     os << ')';
     return;
   }
@@ -5286,20 +5312,6 @@ void CodeGenTileLangCUDA::VisitExpr_(const BroadcastNode *op,
           os << "(uint)" << v;
         } else {
           os << "(int)" << v;
-        }
-        return;
-      } else if (lanes == 32) {
-        // make_int8x32
-        const int64_t *p = as_const_int(op->value);
-        ICHECK(p);
-        int64_t v = *p & 0xFF;
-        v = (v << 24) | (v << 16) | (v << 8) | v;
-        if (op->dtype.is_uint()) {
-          os << "make_ulonglong4(" << v << ", " << v << ", " << v << ", " << v
-             << ")";
-        } else {
-          os << "make_longlong4(" << v << ", " << v << ", " << v << ", " << v
-             << ")";
         }
         return;
       }
@@ -5365,30 +5377,17 @@ void CodeGenTileLangCUDA::VisitExpr_(const BroadcastNode *op,
     return;
   }
 
-  // 32-bit int/uint broadcast with lanes > 4 lowers to (u)longlong{lanes/2}
-  // (each ulonglong holds two consecutive 32-bit lanes). Without packing,
-  // the generic loop below would emit one arg per lane, producing e.g.
-  // `make_ulonglong4(v, v, v, v, v, v, v, v)` which nvcc rejects with
-  // "too many arguments". This path is hit when a vectorized store of
-  // `T.rng_rand()` (uint32) is broadcast across the 8 lanes of a 256-bit
-  // store. PrintExpr is invoked twice per packed slot so the underlying
-  // side-effecting call (curand) executes once per uint32 lane, matching
-  // the lane count.
-  if ((op->dtype.is_int() || op->dtype.is_uint()) && op->dtype.bits() == 32 &&
-      op->dtype.lanes() > 4 && op->dtype.lanes() % 2 == 0) {
+  // Match the physical arity of integer vector types backed by 64-bit fields.
+  // Repeating the expression in `scalars` preserves the existing behavior for
+  // side-effecting uint32 broadcasts such as T.rng_rand().
+  if (Needs64BitIntegerVectorPacking(op->dtype)) {
     int lanes = op->dtype.lanes();
     std::string v = PrintExpr(op->value);
-    const char *u64 = op->dtype.is_uint() ? "unsigned long long" : "long long";
+    std::vector<std::string> scalars(lanes, v);
     os << "make_";
     PrintType(op->dtype, os);
     os << '(';
-    for (int i = 0; i < lanes / 2; ++i) {
-      if (i != 0)
-        os << ", ";
-      // Widen through `unsigned int` so both lanes are zero-extended.
-      os << "(" << u64 << ")(((unsigned long long)(unsigned int)(" << v
-         << ")) | ((unsigned long long)(unsigned int)(" << v << ") << 32))";
-    }
+    PrintPackedIntegerVectorArgs(op->dtype, scalars, os);
     os << ')';
     return;
   }

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -309,6 +309,42 @@ TL_DEVICE longlong4 make_longlong4(int x0, int x1, int y0, int y1, int z0,
   return result;
 }
 
+// Pack thirty-two char values.
+TL_DEVICE longlong4
+make_longlong4(signed char x0, signed char x1, signed char x2, signed char x3,
+               signed char x4, signed char x5, signed char x6, signed char x7,
+               signed char y0, signed char y1, signed char y2, signed char y3,
+               signed char y4, signed char y5, signed char y6, signed char y7,
+               signed char z0, signed char z1, signed char z2, signed char z3,
+               signed char z4, signed char z5, signed char z6, signed char z7,
+               signed char w0, signed char w1, signed char w2, signed char w3,
+               signed char w4, signed char w5, signed char w6, signed char w7) {
+  longlong4 result;
+  *((int2 *)&result.x) = make_int2(x0, x1, x2, x3, x4, x5, x6, x7);
+  *((int2 *)&result.y) = make_int2(y0, y1, y2, y3, y4, y5, y6, y7);
+  *((int2 *)&result.z) = make_int2(z0, z1, z2, z3, z4, z5, z6, z7);
+  *((int2 *)&result.w) = make_int2(w0, w1, w2, w3, w4, w5, w6, w7);
+  return result;
+}
+
+// Pack thirty-two unsigned char values.
+TL_DEVICE ulonglong4 make_ulonglong4(
+    unsigned char x0, unsigned char x1, unsigned char x2, unsigned char x3,
+    unsigned char x4, unsigned char x5, unsigned char x6, unsigned char x7,
+    unsigned char y0, unsigned char y1, unsigned char y2, unsigned char y3,
+    unsigned char y4, unsigned char y5, unsigned char y6, unsigned char y7,
+    unsigned char z0, unsigned char z1, unsigned char z2, unsigned char z3,
+    unsigned char z4, unsigned char z5, unsigned char z6, unsigned char z7,
+    unsigned char w0, unsigned char w1, unsigned char w2, unsigned char w3,
+    unsigned char w4, unsigned char w5, unsigned char w6, unsigned char w7) {
+  ulonglong4 result;
+  *((uint2 *)&result.x) = make_uint2(x0, x1, x2, x3, x4, x5, x6, x7);
+  *((uint2 *)&result.y) = make_uint2(y0, y1, y2, y3, y4, y5, y6, y7);
+  *((uint2 *)&result.z) = make_uint2(z0, z1, z2, z3, z4, z5, z6, z7);
+  *((uint2 *)&result.w) = make_uint2(w0, w1, w2, w3, w4, w5, w6, w7);
+  return result;
+}
+
 // Helper to cast SMEM pointer to unsigned
 TL_DEVICE uint32_t smem_ptr_to_uint(void const *const ptr) {
   return static_cast<uint32_t>(__cvta_generic_to_shared(ptr));

--- a/testing/python/issue/test_tilelang_issue_2480.py
+++ b/testing/python/issue/test_tilelang_issue_2480.py
@@ -1,0 +1,50 @@
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+LANES = 32
+
+
+@pytest.mark.parametrize(
+    "dtype,torch_dtype,value",
+    [("int8", torch.int8, -37), ("uint8", torch.uint8, 213)],
+)
+@tilelang.testing.requires_cuda
+def test_runtime_int8_broadcast_to_32_lanes(dtype, torch_dtype, value):
+    @T.prim_func
+    def main(src: T.Tensor((1,), dtype), out: T.Tensor((LANES,), dtype)):
+        with T.Kernel(1, threads=1) as _:
+            out[0:LANES] = T.Broadcast(src[0], LANES)
+
+    kernel = tilelang.compile(main, target="cuda")
+    src = torch.tensor([value], dtype=torch_dtype, device="cuda")
+    out = torch.empty(LANES, dtype=torch_dtype, device="cuda")
+    kernel(src, out)
+
+    torch.testing.assert_close(out, torch.full_like(out, value), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "dtype,torch_dtype,value",
+    [("int8", torch.int8, -37), ("uint8", torch.uint8, 213)],
+)
+@tilelang.testing.requires_cuda
+def test_constant_int8_broadcast_to_32_lanes(dtype, torch_dtype, value):
+    @T.prim_func
+    def main(out: T.Tensor((LANES,), dtype)):
+        with T.Kernel(1, threads=1) as _:
+            out[0:LANES] = T.Broadcast(T.cast(value, dtype), LANES)
+
+    kernel = tilelang.compile(main, target="cuda")
+    out = torch.empty(LANES, dtype=torch_dtype, device="cuda")
+    kernel(out)
+
+    torch.testing.assert_close(out, torch.full_like(out, value), rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/issue/test_tilelang_issue_2480.py
+++ b/testing/python/issue/test_tilelang_issue_2480.py
@@ -18,9 +18,15 @@ def test_runtime_int8_broadcast_to_32_lanes(dtype, torch_dtype, value):
     @T.prim_func
     def main(src: T.Tensor((1,), dtype), out: T.Tensor((LANES,), dtype)):
         with T.Kernel(1, threads=1) as _:
-            out[0:LANES] = T.Broadcast(src[0], LANES)
+            # Scalar global stores keep this test runnable on pre-SM100 GPUs.
+            packed = T.alloc_local((LANES,), dtype)
+            packed[0:LANES] = T.Broadcast(src[0], LANES)
+            for i in T.serial(LANES):
+                out[i] = packed[i]
 
     kernel = tilelang.compile(main, target="cuda")
+    constructor = "make_ulonglong4" if dtype == "uint8" else "make_longlong4"
+    assert constructor in kernel.get_kernel_source()
     src = torch.tensor([value], dtype=torch_dtype, device="cuda")
     out = torch.empty(LANES, dtype=torch_dtype, device="cuda")
     kernel(src, out)
@@ -37,9 +43,14 @@ def test_constant_int8_broadcast_to_32_lanes(dtype, torch_dtype, value):
     @T.prim_func
     def main(out: T.Tensor((LANES,), dtype)):
         with T.Kernel(1, threads=1) as _:
-            out[0:LANES] = T.Broadcast(T.cast(value, dtype), LANES)
+            packed = T.alloc_local((LANES,), dtype)
+            packed[0:LANES] = T.Broadcast(T.cast(value, dtype), LANES)
+            for i in T.serial(LANES):
+                out[i] = packed[i]
 
     kernel = tilelang.compile(main, target="cuda")
+    constructor = "make_ulonglong4" if dtype == "uint8" else "make_longlong4"
+    assert constructor in kernel.get_kernel_source()
     out = torch.empty(LANES, dtype=torch_dtype, device="cuda")
     kernel(out)
 


### PR DESCRIPTION
## Summary

- Pack 32-lane `int8`/`uint8` vectors into four 64-bit CUDA constructor fields.
- Apply the packing to both `ShuffleNode` and `BroadcastNode`, including constant broadcasts.
- Preserve the existing `int32`/`uint32` vector packing behavior.
- Add CUDA regression coverage for signed and unsigned runtime and constant broadcasts.

## Testing

```text
cmake --build build --parallel 4
Build completed successfully
```

```text
python3 -m pytest -q testing/python/issue/test_tilelang_issue_2480.py
4 passed
```

```text
python3 -m pytest -q testing/python/language/test_tilelang_language_rand.py
6 passed
```

Fixes #2480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed CUDA code generation for 32-lane `int8` and `uint8` vectors by packing lanes into four 64-bit constructor fields so the emitted constructors use the correct `make_longlong4` / `make_ulonglong4` arity.
- Updated the CUDA `BroadcastNode` codegen to remove the incorrect 8-bit `lanes==32` special-case and route 32-lane `int8`/`uint8` through the generic packed-vector logic, while preserving existing `int32`/`uint32` packing behavior.
- Added CUDA template constructors in `src/tl_templates/cuda/common.h` for `make_longlong4` (32 signed 8-bit args) and `make_ulonglong4` (32 unsigned 8-bit args), with packing implemented via existing `make_int2`/`make_uint2` helpers.
- Added CUDA regression coverage for issue `#2480`, validating both runtime and constant `T.Broadcast` into 32-lane outputs for signed (`int8`) and unsigned (`uint8`) dtypes, including assertions on the generated CUDA constructor (`make_longlong4` vs `make_ulonglong4`).

## C++ style / lint notes

- This PR updates C++ CUDA codegen/templates (`src/cuda/codegen/codegen_cuda.cc`, `src/tl_templates/cuda/common.h`) but does not touch `docs/developer_guide/cpp_style.md`.
- CI includes a “C++ API Style Audit (warning only)” step; any advisory TLCPP003/TLCPP004 results should be treated as non-blocking unless this PR introduces an API/FFI/maintainability risk (not indicated by the change scope).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->