### PR TITLE
[BugFix] Decode FP8 E4M3 special encodings correctly

### DIFF
--- a/testing/python/quantize/test_tilelang_quantize_fp8.py
+++ b/testing/python/quantize/test_tilelang_quantize_fp8.py
@@ -1,0 +1,56 @@
+import numpy as np
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+from tilelang.quantize.quantization import (
+    _tir_u8_to_f8_e4m3_to_f16,
+    _tir_u8_to_f8_e4m3_to_f16_naive,
+)
+
+
+def _e4m3_to_float16(code: int) -> np.float16:
+    sign = -1.0 if code & 0x80 else 1.0
+    exponent = (code >> 3) & 0xF
+    mantissa = code & 0x7
+
+    if exponent == 0:
+        return np.float16(sign * np.ldexp(mantissa / 8.0, -6))
+    if exponent == 0xF and mantissa == 0x7:
+        return np.float16(np.nan)
+    return np.float16(sign * np.ldexp(1.0 + mantissa / 8.0, exponent - 7))
+
+
+@tilelang.testing.requires_llvm
+def test_u8_to_f8_e4m3_to_f16_all_codes():
+    @T.prim_func
+    def decode(
+        values: T.Tensor((256,), "uint8"),
+        naive: T.Tensor((256,), "uint16"),
+        optimized: T.Tensor((256,), "uint16"),
+    ):
+        for i in T.serial(256):
+            naive[i] = T.reinterpret(_tir_u8_to_f8_e4m3_to_f16_naive(8, values[i], T.float16), T.uint16)
+            optimized[i] = T.reinterpret(_tir_u8_to_f8_e4m3_to_f16(8, values[i], T.float16), T.uint16)
+
+    built = tvm.compile(decode, target="llvm")
+    values = tvm.runtime.tensor(np.arange(256, dtype=np.uint8))
+    naive = tvm.runtime.empty((256,), "uint16", tvm.cpu())
+    optimized = tvm.runtime.empty((256,), "uint16", tvm.cpu())
+    built(values, naive, optimized)
+
+    naive_bits = naive.numpy()
+    optimized_bits = optimized.numpy()
+    expected = np.array([_e4m3_to_float16(code) for code in range(256)], dtype=np.float16)
+    finite = ~np.isnan(expected)
+
+    np.testing.assert_array_equal(naive_bits[finite], expected[finite].view(np.uint16))
+    np.testing.assert_array_equal(optimized_bits[finite], expected[finite].view(np.uint16))
+    np.testing.assert_array_equal(np.isnan(naive_bits.view(np.float16)), np.isnan(expected))
+    np.testing.assert_array_equal(np.isnan(optimized_bits.view(np.float16)), np.isnan(expected))
+    np.testing.assert_array_equal(naive_bits, optimized_bits)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/quantize/quantization.py
+++ b/tilelang/quantize/quantization.py
@@ -220,25 +220,73 @@ def _tir_packed_to_fp4_to_f16(storage_type="uint", storage_nbit=8):
 
     return f_convert
 
+
+def _tir_u8_to_f8_e4m3_subnormal_to_f16_bits(mantissa: tirx.PrimExpr):
+    # E4M3 subnormals have value mantissa * 2^-9; normalize that value into binary16 bits.
+    return tirx.Select(
+        mantissa >= tirx.const(4, T.uint16),
+        tirx.const(0x2000, T.uint16)
+        | ((mantissa & tirx.const(0x3, T.uint16)) << tirx.const(8, T.uint16)),
+        tirx.Select(
+            mantissa >= tirx.const(2, T.uint16),
+            tirx.const(0x1C00, T.uint16)
+            | ((mantissa & tirx.const(0x1, T.uint16)) << tirx.const(9, T.uint16)),
+            tirx.Select(
+                mantissa == tirx.const(1, T.uint16),
+                tirx.const(0x1800, T.uint16),
+                tirx.const(0, T.uint16),
+            ),
+        ),
+    )
+
+
 def _tir_u8_to_f8_e4m3_to_f16_naive(nbit: int, val: tirx.PrimExpr, dtype: str):
     assert nbit == 8
     assert dtype == T.float16
-    s_f16 = (val >> tirx.const(7, T.uint16)) << tirx.const(15, T.uint16)
-    e4 = val & tirx.const(0x40, T.uint16)
-    prefix = tirx.Select(e4 == tirx.const(0, T.uint16), tirx.const(0x2000, T.uint16),
-                        tirx.const(0x4000, T.uint16))
-    e_f16 = ((val & tirx.const(63, T.uint16)) << tirx.const(7, T.uint16)) | prefix
-    return tirx.reinterpret(T.float16, s_f16 | e_f16)
+    val_u16 = val.astype(T.uint16)
+    s_f16 = (val_u16 >> tirx.const(7, T.uint16)) << tirx.const(15, T.uint16)
+    exponent = (val_u16 >> tirx.const(3, T.uint16)) & tirx.const(0xF, T.uint16)
+    mantissa = val_u16 & tirx.const(0x7, T.uint16)
+    normal_f16 = ((exponent + tirx.const(8, T.uint16)) << tirx.const(10, T.uint16)) | (
+        mantissa << tirx.const(7, T.uint16)
+    )
+    subnormal_f16 = _tir_u8_to_f8_e4m3_subnormal_to_f16_bits(mantissa)
+    magnitude_f16 = tirx.Select(
+        exponent == tirx.const(0, T.uint16),
+        subnormal_f16,
+        tirx.Select(
+            (exponent == tirx.const(0xF, T.uint16))
+            & (mantissa == tirx.const(0x7, T.uint16)),
+            tirx.const(0x7E00, T.uint16),
+            normal_f16,
+        ),
+    )
+    return tirx.reinterpret(T.float16, s_f16 | magnitude_f16)
 
 
 def _tir_u8_to_f8_e4m3_to_f16(nbit: int, val: tirx.PrimExpr, dtype: str):
     assert nbit == 8
     assert dtype == T.float16
-    s_f16 = (val >> tirx.const(7, T.uint16)) << tirx.const(15, T.uint16)
-    e4 = val & tirx.const(0x40, T.uint16)
-    e_f16 = ((val & tirx.const(63, T.uint16)) << tirx.const(7, T.uint16)) | (e4 << tirx.const(8, T.uint16)) | (e4 << tirx.const(7, T.uint16))
-    e_f16 = e_f16 ^ tirx.const(0x2000, T.uint16)
-    return tirx.reinterpret(T.float16, s_f16 | e_f16)
+    val_u16 = val.astype(T.uint16)
+    s_f16 = (val_u16 >> tirx.const(7, T.uint16)) << tirx.const(15, T.uint16)
+    e4 = val_u16 & tirx.const(0x40, T.uint16)
+    normal_f16 = (
+        ((val_u16 & tirx.const(63, T.uint16)) << tirx.const(7, T.uint16))
+        | (e4 << tirx.const(8, T.uint16))
+        | (e4 << tirx.const(7, T.uint16))
+    ) ^ tirx.const(0x2000, T.uint16)
+    mantissa = val_u16 & tirx.const(0x7, T.uint16)
+    subnormal_f16 = _tir_u8_to_f8_e4m3_subnormal_to_f16_bits(mantissa)
+    magnitude_f16 = tirx.Select(
+        (val_u16 & tirx.const(0x78, T.uint16)) == tirx.const(0, T.uint16),
+        subnormal_f16,
+        tirx.Select(
+            (val_u16 & tirx.const(0x7F, T.uint16)) == tirx.const(0x7F, T.uint16),
+            tirx.const(0x7E00, T.uint16),
+            normal_f16,
+        ),
+    )
+    return tirx.reinterpret(T.float16, s_f16 | magnitude_f16)
 
 
 def _tir_u8_to_f8_e5m2_to_f16(nbit: int, val: tirx.PrimExpr, dtype: str):


### PR DESCRIPTION
## Problem

Both FP8 E4M3-to-F16 decoders applied normal-number reconstruction to every code word. That mishandled the exponent-zero regime and the format's two NaN encodings.

| Input codes | Class | Previous result | Correct result |
|---|---|---|---|
| `0x00`, `0x80` | signed zero | `±2^-7` | `±0` |
| `0x01–0x07`, `0x81–0x87` | subnormal | incorrect finite normals | `±mantissa × 2^-9` |
| `0x7f`, `0xff` | NaN | `±480` | F16 NaN |
| all other codes | finite normal | correct | unchanged |

The mismatch set is exactly 18 of the 256 possible byte values.

Specification:
https://www.opencompute.org/documents/ocp-8-bit-floating-point-specification-ofp8-revision-1-0-2023-06-20-pdf

## Changes

- Add explicit signed-zero, subnormal, and NaN paths to both the naive and optimized decoders.
- Share only the subnormal bit conversion between the two implementations.
- Keep each decoder's normal-number path independent so the optimized implementation retains a meaningful reference implementation.
- Preserve the existing behavior for all 238 finite normal encodings.

## Regression coverage

The new regression evaluates all 256 byte values through both helpers, compares exact F16 bits for finite values, checks signed-zero bits directly, verifies both NaN encodings, and asserts equivalence between the naive and optimized decoders.

## Validation

- Compiled host-codegen proof over all 256 inputs.
- Python formatting and `git diff --check`.

The LLVM-backed regression was added but was not executed in this environment.

Fixes #2702

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed FP8 E4M3-to-F16 decoding for signed zero, subnormals, and NaNs (`0x7f`/`0xff`) in both decoder paths.
- Added exhaustive coverage for all 256 byte values, including exact F16 bits and signed-zero behavior.
- Preserved decoding of the 238 finite normal encodings.
- Host-codegen and formatting checks passed; the LLVM-backed regression is guarded by `requires_llvm` and was not run in the available environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->