### PR TITLE
[BugFix] Implement atomic load and store for HIP

### DIFF
--- a/src/tl_templates/hip/atomic.h
+++ b/src/tl_templates/hip/atomic.h
@@ -78,6 +78,18 @@ __forceinline__ __device__ void AtomicOr(T1 &address, T2 val,
   atomicOr(reinterpret_cast<T1 *>(&address), static_cast<T1>(val));
 }
 
+template <typename T>
+__forceinline__ __device__ T AtomicLoad(T *ref, int memory_order) {
+  return __hip_atomic_load(ref, memory_order, __HIP_MEMORY_SCOPE_AGENT);
+}
+
+template <typename T1, typename T2>
+__forceinline__ __device__ void AtomicStore(T1 *ref, T2 value,
+                                            int memory_order) {
+  __hip_atomic_store(ref, static_cast<T1>(value), memory_order,
+                     __HIP_MEMORY_SCOPE_AGENT);
+}
+
 __forceinline__ __device__ void AtomicAddx2(float *ref, float *val,
                                             int memory_order = 0) {
   float2 add_val = *reinterpret_cast<float2 *>(val);

--- a/testing/python/amd/test_tilelang_hip_atomic_load_store.py
+++ b/testing/python/amd/test_tilelang_hip_atomic_load_store.py
@@ -1,0 +1,61 @@
+import re
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+_MEMORY_ORDER_IDS = {
+    "relaxed": 0,
+    "consume": 1,
+    "acquire": 2,
+    "release": 3,
+    "seq_cst": 5,
+}
+
+
+def _atomic_load_store_kernel(load_order, store_order):
+    @T.prim_func
+    def kernel(source: T.Tensor((32,), T.int32), destination: T.Tensor((32,), T.int32)):
+        with T.Kernel(1, threads=32):
+            index = T.get_thread_binding()
+            value = T.atomic_load(source[index], memory_order=load_order)
+            T.atomic_store(destination[index], value, memory_order=store_order)
+
+    return kernel
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize(
+    "load_order,store_order",
+    [
+        ("relaxed", "relaxed"),
+        ("consume", "release"),
+        ("acquire", "seq_cst"),
+        ("seq_cst", "relaxed"),
+    ],
+)
+def test_atomic_load_store_hip(load_order, store_order):
+    kernel = tilelang.compile(
+        _atomic_load_store_kernel(load_order, store_order),
+        out_idx=[1],
+        target="hip",
+    )
+    source = kernel.get_kernel_source()
+
+    load_pattern = rf"AtomicLoad\([^;\n]*, {_MEMORY_ORDER_IDS[load_order]}\)"
+    store_pattern = rf"AtomicStore\([^;\n]*, {_MEMORY_ORDER_IDS[store_order]}\);"
+    assert re.search(load_pattern, source)
+    assert re.search(store_pattern, source)
+
+    input_tensor = torch.arange(32, dtype=torch.int32, device="cuda")
+    output_tensor = kernel(input_tensor)
+
+    torch.testing.assert_close(output_tensor, input_tensor)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Problem

HIP code generation already emits `AtomicLoad` and `AtomicStore`, but the HIP atomic template did not define either helper.

```text
Before: T.atomic_* -> HIP codegen -> AtomicLoad/AtomicStore -> missing definition
After:  T.atomic_* -> HIP codegen -> AtomicLoad/AtomicStore -> __hip_atomic_*
```

Valid kernels could therefore reach HIP device compilation with unresolved template calls.

## Changes

- Add `AtomicLoad` using `__hip_atomic_load`.
- Add `AtomicStore` using `__hip_atomic_store`.
- Convert store values to the destination type before the builtin call.
- Use device scope consistently with the existing TileLang atomic contract.
- Add frontend-to-codegen coverage for every valid operation-specific order ID.

| Operation | Covered orders |
|---|---|
| load | relaxed, consume, acquire, sequentially consistent |
| store | relaxed, release, sequentially consistent |

Vector atomic operations are intentionally outside this PR.

## Regression coverage

The new test compiles HIP kernels containing atomic load and store for every valid order and checks a load/store runtime pair, including returned and final memory values.

## Validation

- Python syntax and formatting checks.
- ROCm-stub CMake configuration.
- Compilation of the modified HIP codegen object.
- `git diff --check`.

The HIP device-compilation and runtime regression was added but was not executed in this environment.

Fixes #2705

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added HIP device-scope `AtomicLoad` and `AtomicStore` helpers using native HIP atomic builtins.
- Preserved valid operation-specific memory orders and converted store values to the destination type.
- Added HIP code-generation and regression coverage for scalar atomic load/store operations, including returned and final values.

## Validation

- Syntax, formatting, ROCm-stub CMake configuration, HIP codegen compilation, and `git diff --check` passed.
- HIP device compilation and runtime regression tests were not run in the stated environment.

## C++ style / lint notes

- `docs/developer_guide/cpp_style.md` was not modified, and no documented style rules were changed.
- The warning-only C++ API Style Audit was not reported as run; any TLCPP003/TLCPP004 findings should remain advisory unless they indicate a concrete API or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->