### PR TITLE
[BugFix] Support return_prev for HIP vector atomic add

### DIFF
--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -1633,6 +1633,15 @@ void CodeGenTileLangHIP::VisitExpr_(const CallNode *op, std::ostream &os) {
       this->stream << ", " << PrintExpr(op->args[2]);
     }
     this->stream << ");\n";
+  } else if (op->op.same_as(tl::atomic_addx2_ret_elem_op())) {
+    // atomic_addx2_ret_elem_op(dst_ptr, src_ptr[, memory_order]) -> returns
+    // the previous two values
+    os << "AtomicAddx2Ret(" << PrintExpr(op->args[0]) << ", "
+       << PrintExpr(op->args[1]);
+    if (op->args.size() > 2) {
+      os << ", " << PrintExpr(op->args[2]);
+    }
+    os << ")";
   } else if (op->op.same_as(tl::atomic_addx4_elem_op())) {
     // atomic_addx4_elem_op(dst_ptr, src_ptr[, memory_order])
     std::string dst_ptr = PrintExpr(op->args[0]);
@@ -1643,6 +1652,15 @@ void CodeGenTileLangHIP::VisitExpr_(const CallNode *op, std::ostream &os) {
       this->stream << ", " << PrintExpr(op->args[2]);
     }
     this->stream << ");\n";
+  } else if (op->op.same_as(tl::atomic_addx4_ret_elem_op())) {
+    // atomic_addx4_ret_elem_op(dst_ptr, src_ptr[, memory_order]) -> returns
+    // the previous four values
+    os << "AtomicAddx4Ret(" << PrintExpr(op->args[0]) << ", "
+       << PrintExpr(op->args[1]);
+    if (op->args.size() > 2) {
+      os << ", " << PrintExpr(op->args[2]);
+    }
+    os << ")";
   } else if (op->op.same_as(tl::atomic_load_elem_op())) {
     // atomic_load_elem_op(src_ptr, memory_order) -> returns loaded value
     os << "AtomicLoad(" << PrintExpr(op->args[0]) << ", "

--- a/testing/python/amd/test_tilelang_hip_atomic_return_prev.py
+++ b/testing/python/amd/test_tilelang_hip_atomic_return_prev.py
@@ -1,0 +1,40 @@
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+def _atomic_add_vector_return_prev_program(lanes):
+    atomic_add = T.atomic_addx2 if lanes == 2 else T.atomic_addx4
+
+    @T.prim_func
+    def main(
+        Dst: T.Tensor((lanes,), T.float32),
+        Val: T.Tensor((lanes,), T.float32),
+        Prev: T.Tensor((lanes,), T.float32),
+    ):
+        with T.Kernel(1, threads=1):
+            Prev[0:lanes] = atomic_add(Dst[0], Val[0], return_prev=True)
+
+    return main
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize("lanes", [2, 4])
+def test_atomic_add_vector_return_prev(lanes):
+    kernel = tilelang.compile(_atomic_add_vector_return_prev_program(lanes), target="hip")
+    assert f"AtomicAddx{lanes}Ret" in kernel.get_kernel_source()
+
+    dst = torch.arange(1, lanes + 1, dtype=torch.float32, device="cuda")
+    val = torch.arange(1, lanes + 1, dtype=torch.float32, device="cuda") * 10
+    prev = torch.zeros(lanes, dtype=torch.float32, device="cuda")
+
+    kernel(dst, val, prev)
+
+    torch.testing.assert_close(prev, torch.arange(1, lanes + 1, dtype=torch.float32, device="cuda"))
+    torch.testing.assert_close(
+        dst,
+        torch.arange(1, lanes + 1, dtype=torch.float32, device="cuda") * 11,
+    )


### PR DESCRIPTION
## Problem

#2672 added `return_prev=True` codegen for CUDA vector atomic add, but the HIP code generator continued to select the void `AtomicAddx2` and `AtomicAddx4` helpers.

HIP already provides float32 `AtomicAddx2Ret` and `AtomicAddx4Ret` template implementations, so the missing dispatch caused a backend parity gap.

## Changes

- Select `AtomicAddx2Ret` when an x2 atomic add requests its previous value.
- Select `AtomicAddx4Ret` for the x4 form.
- Forward the optional memory-order argument through the return-value path.
- Preserve the existing void helper selection when `return_prev=False`.

This PR stays within the existing HIP vector atomic surface: float32 x2/x4. It does not introduce fp16 or bf16 overloads.

## Regression coverage

The new HIP regression checks generated source for both helper selections and exercises the returned previous lane values together with the final destination contents.

## Validation

- Python syntax and formatting checks.
- Confirmation that the return-value dispatch is absent on the base revision.
- Compilation of the modified HIP codegen object.
- `git diff --check`.

The HIP device-compilation and runtime regression was added but was not executed in this environment.

Fixes #2706

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added HIP codegen support for `return_prev=True` on float32 vector atomic additions with 2 and 4 lanes.
- Selects `AtomicAddx2Ret`/`AtomicAddx4Ret`, forwards optional memory order, and preserves existing void helpers for `return_prev=False`.
- Added regression tests validating generated helper selection, previous lane values, and final destination sums.
- Scope remains limited to the existing float32 vector atomic surface; no fp16 or bf16 overloads were added.

## Testing

- Added parametrized coverage for x2 and x4 vector atomics.
- HIP compilation and runtime regression were not executed in the reported environment.

## C++ style / lint notes

- The PR changes C++ code but does not appear to touch rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) may report advisory findings; these are separate from correctness or build issues and should not block merge absent a new API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->