### PR TITLE
[TIR][Transform] Allow unused fragment buffers without layouts

### DIFF
--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -1214,13 +1214,8 @@ private:
   /**
    * @brief Visit and mutate a Block node to attach inferred layout information.
    *
-   * Converts the visited Block via the base visitor, asserts that every buffer
-   * allocated with scope "local.fragment" has an inferred layout in
-   * result_.layout_map, and attaches result_.layout_map to the Block's
-   * annotations under attr::kLayoutMap.
-   *
-   * If any "local.fragment" buffer lacks an entry in result_.layout_map an
-   * ICHECK will fail with the offending buffer printed.
+   * Converts the visited Block via the base visitor and attaches
+   * result_.layout_map to the Block's annotations under attr::kLayoutMap.
    *
    * @return Stmt The (possibly modified) Block statement with the layout-map
    * annotation set.
@@ -1228,12 +1223,6 @@ private:
   Stmt VisitStmt_(const SBlockNode *op) final {
     SBlock block = Downcast<SBlock>(IRMutatorWithAnalyzer::VisitStmt_(op));
 
-    for (auto buffer : block->alloc_buffers) {
-      if (IsFragmentBuffer(buffer)) {
-        ICHECK(result_.layout_map.count(buffer))
-            << "Cannot inference fragment layout for " << buffer;
-      }
-    }
     auto block_ptr = block.CopyOnWrite();
     block_ptr->annotations.Set(attr::kLayoutMap, result_.layout_map);
     return block;


### PR DESCRIPTION
## Summary

- Allow unused `local.fragment` allocations to pass layout inference when no layout is needed.
- Avoid rejecting compile-time-specialized kernels that retain dead fragment declarations.

## Changes

- Remove the block-level assertion requiring every allocated fragment to appear in the inferred layout map.
- Keep the existing inference-time validation for fragment buffers that participate in layout inference.
- Update the block visitor documentation to match the relaxed behavior.

## Validation

- `./format.sh`
- `cmake --build build -j8`
- Targeted RMSNorm forward/backward integration test covering unused fragment allocations

## Risk

- The change only relaxes the blanket allocation-level check; fragment buffers participating in layout inference remain validated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed the redundant block-level assertion requiring every allocated `local.fragment` to appear in the inferred layout map.
- Preserved layout-map validation for fragments that participate in layout inference.
- Updated documentation to reflect that unused fragment allocations may pass inference when no layout is required.
- Added targeted RMSNorm forward/backward integration coverage for unused fragment allocations.
- Validation included formatting and a successful build.

## C++ style / lint notes

- The change touches C++ implementation code but does not alter rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit remains warning-only; no new correctness or build issues are indicated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->