### PR TITLE
[Transform] Replace CPU fallback thread placeholder with a constant-zero logical thread index

### DIFF
--- a/src/backend/common/op/atomic_reduce.h
+++ b/src/backend/common/op/atomic_reduce.h
@@ -183,9 +183,9 @@ struct AtomicReduce {
                           level);
     }
     auto loop_layout = par_op->GetLoopLayout();
-    return LowerParallelLoop(fused_loop, loop_layout, lower_args.thread_var,
+    return LowerParallelLoop(fused_loop, loop_layout, lower_args.thread_index,
                              analyzer, lower_args.layout_map,
-                             par_op->GetPredicate(lower_args.thread_var),
+                             par_op->GetPredicate(lower_args.thread_index),
                              /*parallel_loop=*/true, /*should_vectorize=*/true,
                              par_op->LoopLayoutRequiresPaddingGuard());
   }

--- a/src/backend/common/op/fill.h
+++ b/src/backend/common/op/fill.h
@@ -31,14 +31,15 @@ struct Fill {
                            lower_args.buffer_remap,
                            {}},
                           InferLevel::kFree);
-      auto thread_loop = PartitionLoop(par_op->GetRoot(), lower_args.thread_var,
-                                       analyzer, par_op->GetLoopLayout());
+      auto thread_loop =
+          PartitionLoop(par_op->GetRoot(), lower_args.thread_index, analyzer,
+                        par_op->GetLoopLayout());
       auto vectorized_loop =
           VectorizeLoop(thread_loop, analyzer, lower_args.layout_map);
       auto unrolled_loop = PragmaUnrollLoop(vectorized_loop);
 
-      if (par_op->GetPredicate(lower_args.thread_var).defined()) {
-        return IfThenElse(par_op->GetPredicate(lower_args.thread_var).value(),
+      if (par_op->GetPredicate(lower_args.thread_index).defined()) {
+        return IfThenElse(par_op->GetPredicate(lower_args.thread_index).value(),
                           unrolled_loop);
       }
       return unrolled_loop;
@@ -60,13 +61,14 @@ struct Fill {
                            lower_args.buffer_remap,
                            {}},
                           InferLevel::kFree);
-      auto thread_loop = PartitionLoop(par_op->GetRoot(), lower_args.thread_var,
-                                       analyzer, par_op->GetLoopLayout());
+      auto thread_loop =
+          PartitionLoop(par_op->GetRoot(), lower_args.thread_index, analyzer,
+                        par_op->GetLoopLayout());
       auto vectorized_loop =
           VectorizeLoop(thread_loop, analyzer, lower_args.layout_map);
       auto unrolled_loop = PragmaUnrollLoop(vectorized_loop);
-      if (par_op->GetPredicate(lower_args.thread_var).defined()) {
-        return IfThenElse(par_op->GetPredicate(lower_args.thread_var).value(),
+      if (par_op->GetPredicate(lower_args.thread_index).defined()) {
+        return IfThenElse(par_op->GetPredicate(lower_args.thread_index).value(),
                           unrolled_loop);
       }
       return unrolled_loop;

--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -879,7 +879,7 @@ template <typename Impl> struct ReduceLowerer {
           body = For(vars[i]->var, 0, vars[i]->dom->extent, ForKind::kParallel,
                      body);
         }
-        body = PartitionLoop(Downcast<For>(body), lower_args.thread_var,
+        body = PartitionLoop(Downcast<For>(body), lower_args.thread_index,
                              analyzer, red_layout);
         body = PragmaUnrollLoop(Downcast<For>(body));
         return body;
@@ -1052,7 +1052,7 @@ template <typename Impl> struct ReduceLowerer {
           PrimExpr predicate = Bool(true);
           {
             auto dst_th = post_dst_idx;
-            dst_th.push_back(lower_args.thread_var);
+            dst_th.push_back(lower_args.thread_index);
             auto inv = dst_layout->Inverse()->Forward(dst_th);
             inv.pop_back();
             for (int i = 0; i < static_cast<int>(dst_layout->InputDim()); i++) {
@@ -1113,7 +1113,7 @@ template <typename Impl> struct ReduceLowerer {
       PrimExpr predicate = Bool(true);
       {
         auto dst_th_indices = dst_indices;
-        dst_th_indices.push_back(lower_args.thread_var);
+        dst_th_indices.push_back(lower_args.thread_index);
         auto inv = dst_layout->Inverse()->Forward(dst_th_indices);
         inv.pop_back();
         for (int i = 0; i < static_cast<int>(dst_layout->InputDim()); i++) {
@@ -1142,11 +1142,11 @@ template <typename Impl> struct ReduceLowerer {
       }
 
       if (dst_layout->InputDim() > 0) {
-        body = PartitionLoop(Downcast<For>(body), lower_args.thread_var,
+        body = PartitionLoop(Downcast<For>(body), lower_args.thread_index,
                              analyzer, red_layout);
         body = PragmaUnrollLoop(Downcast<For>(body));
       } else {
-        auto guard = (lower_args.thread_var == lower_args.thread_bounds->min);
+        auto guard = (lower_args.thread_index == lower_args.thread_bounds->min);
         body = IfThenElse(guard, body);
       }
 

--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -1051,8 +1051,16 @@ template <typename Impl> struct ReduceLowerer {
 
           PrimExpr predicate = Bool(true);
           {
+            // The fragment inverse expects a zero-based logical thread
+            // coordinate within the destination layout's thread range, so
+            // normalize the absolute thread index against that range.
+            PrimExpr local_thread_index = lower_args.thread_index;
+            if (dst_layout->ThreadRange().defined()) {
+              local_thread_index =
+                  local_thread_index - dst_layout->ThreadRange()->min;
+            }
             auto dst_th = post_dst_idx;
-            dst_th.push_back(lower_args.thread_index);
+            dst_th.push_back(local_thread_index);
             auto inv = dst_layout->Inverse()->Forward(dst_th);
             inv.pop_back();
             for (int i = 0; i < static_cast<int>(dst_layout->InputDim()); i++) {
@@ -1112,8 +1120,16 @@ template <typename Impl> struct ReduceLowerer {
 
       PrimExpr predicate = Bool(true);
       {
+        // The fragment inverse expects a zero-based logical thread coordinate
+        // within the destination layout's thread range, so normalize the
+        // absolute thread index against that range.
+        PrimExpr local_thread_index = lower_args.thread_index;
+        if (dst_layout->ThreadRange().defined()) {
+          local_thread_index =
+              local_thread_index - dst_layout->ThreadRange()->min;
+        }
         auto dst_th_indices = dst_indices;
-        dst_th_indices.push_back(lower_args.thread_index);
+        dst_th_indices.push_back(local_thread_index);
         auto inv = dst_layout->Inverse()->Forward(dst_th_indices);
         inv.pop_back();
         for (int i = 0; i < static_cast<int>(dst_layout->InputDim()); i++) {

--- a/src/backend/common/op/transpose.h
+++ b/src/backend/common/op/transpose.h
@@ -49,8 +49,8 @@ struct Transpose {
     }
     auto loop_layout = par_op->GetLoopLayout();
     return LowerParallelLoop(
-        par_op->GetRoot(), loop_layout, lower_args.thread_var, analyzer,
-        lower_args.layout_map, par_op->GetPredicate(lower_args.thread_var),
+        par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
+        lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
         /*parallel_loop=*/true, /*should_vectorize=*/true,
         par_op->LoopLayoutRequiresPaddingGuard());
   }

--- a/src/cuda/op/atomic_add.cc
+++ b/src/cuda/op/atomic_add.cc
@@ -245,9 +245,9 @@ struct AtomicAdd {
                           level);
     }
     auto loop_layout = par_op->GetLoopLayout();
-    return LowerParallelLoop(fused_loop, loop_layout, lower_args.thread_var,
+    return LowerParallelLoop(fused_loop, loop_layout, lower_args.thread_index,
                              analyzer, lower_args.layout_map,
-                             par_op->GetPredicate(lower_args.thread_var),
+                             par_op->GetPredicate(lower_args.thread_index),
                              /*parallel_loop=*/true, /*should_vectorize=*/true,
                              par_op->LoopLayoutRequiresPaddingGuard());
   }
@@ -495,8 +495,9 @@ struct AtomicAdd {
     seq.push_back(Evaluate(Call(DataType::Handle(), tma_store_arrive(), {})));
     seq.push_back(Evaluate(Call(DataType::Handle(), tma_store_wait(),
                                 {IntImm(DataType::Int(32), 0), Bool(true)})));
-    return IfThenElse(EQ(lower_args.thread_var, lower_args.thread_bounds->min),
-                      SeqStmt(std::move(seq)));
+    return IfThenElse(
+        EQ(lower_args.thread_index, lower_args.thread_bounds->min),
+        SeqStmt(std::move(seq)));
   }
 };
 

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -781,8 +781,8 @@ Stmt Copy::LowerCPAsync(const CopyNode &op, const LowerArgs &lower_args,
   }
   auto loop_layout = par_op->GetLoopLayout();
   Stmt lowered_loop = LowerParallelLoop(
-      par_op->GetRoot(), loop_layout, lower_args.thread_var, analyzer,
-      lower_args.layout_map, par_op->GetPredicate(lower_args.thread_var),
+      par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
+      lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
       /*parallel_loop=*/true, /*should_vectorize=*/true,
       par_op->LoopLayoutRequiresPaddingGuard());
 
@@ -887,7 +887,8 @@ Stmt Copy::LowerCluster(const CopyNode &op, const LowerArgs &lower_args,
           {dst_ptr, src_ptr, op.dst_block.value(), size_bytes, barrier_load}));
 
       return IfThenElse(
-          EQ(lower_args.thread_var, lower_args.thread_bounds->min), bulk_copy);
+          EQ(lower_args.thread_index, lower_args.thread_bounds->min),
+          bulk_copy);
     }
 
     bool same_shape = (src_range.size() == dst_range.size());
@@ -917,7 +918,7 @@ Stmt Copy::LowerCluster(const CopyNode &op, const LowerArgs &lower_args,
                      ? tma_stmts[0]
                      : static_cast<Stmt>(SeqStmt(tma_stmts));
       return IfThenElse(
-          EQ(lower_args.thread_var, lower_args.thread_bounds->min), seq);
+          EQ(lower_args.thread_index, lower_args.thread_bounds->min), seq);
     }
 
     LOG(WARNING)
@@ -943,7 +944,7 @@ Stmt Copy::LowerCluster(const CopyNode &op, const LowerArgs &lower_args,
                         level);
   }
   auto loop_layout = par_op->GetLoopLayout();
-  auto thread_loop = PartitionLoop(par_op->GetRoot(), lower_args.thread_var,
+  auto thread_loop = PartitionLoop(par_op->GetRoot(), lower_args.thread_index,
                                    analyzer, loop_layout);
   auto vectorized_thread_loop =
       VectorizeLoop(thread_loop, lower_args.layout_map, /*vectorize_hint=*/1);
@@ -1023,7 +1024,7 @@ Stmt Copy::LowerCluster(const CopyNode &op, const LowerArgs &lower_args,
         Evaluate(Call(DataType::Handle(), ptx_arrive_cluster_barrier(),
                       {barrier_opt.value(), op.dst_block.value()}));
     Stmt guarded_arrive = IfThenElse(
-        EQ(lower_args.thread_var, lower_args.thread_bounds->min), arrive);
+        EQ(lower_args.thread_index, lower_args.thread_bounds->min), arrive);
     return SeqStmt({simt_copy, sync, guarded_arrive});
   }
   return simt_copy;
@@ -1142,21 +1143,27 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &lower_args,
   Var local_iter("i");
   Layout inv = local_layout->Inverse();
   Array<PrimExpr> shared_coords;
-  PrimExpr warp = FloorDiv(lower_args.thread_var, 32) * 32;
+  // Normalize the logical thread index against the thread range once, and
+  // build the copy indices from the normalized expression directly.
+  PrimExpr norm_thread_index = lower_args.thread_index;
+  if (lower_args.thread_bounds.defined()) {
+    norm_thread_index = norm_thread_index - lower_args.thread_bounds->min;
+  }
+  PrimExpr warp = FloorDiv(norm_thread_index, 32) * 32;
   if (!is_transposed) {
     auto local_index = analyzer->Simplify(
         local_iter * elems_per_reg * num +
-        elems_per_reg * FloorMod(FloorDiv(lower_args.thread_var, 8), num));
+        elems_per_reg * FloorMod(FloorDiv(norm_thread_index, 8), num));
     auto thread_index =
-        analyzer->Simplify(warp + FloorMod(lower_args.thread_var, 8) * 4);
+        analyzer->Simplify(warp + FloorMod(norm_thread_index, 8) * 4);
     shared_coords = inv->Forward({local_index, thread_index});
   } else {
     auto local_index = analyzer->Simplify(
         local_iter * elems_per_reg * num +
-        elems_per_reg * FloorMod(FloorDiv(lower_args.thread_var, 8), num) +
-        FloorMod(lower_args.thread_var, elems_per_reg));
+        elems_per_reg * FloorMod(FloorDiv(norm_thread_index, 8), num) +
+        FloorMod(norm_thread_index, elems_per_reg));
     auto thread_index = analyzer->Simplify(
-        warp + FloorDiv(FloorMod(lower_args.thread_var, 8), elems_per_reg));
+        warp + FloorDiv(FloorMod(norm_thread_index, 8), elems_per_reg));
     shared_coords = inv->Forward({local_index, thread_index});
   }
   shared_coords.pop_back();
@@ -1199,13 +1206,6 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &lower_args,
   For for_node = For(local_iter, 0, FloorDiv(extent, elems_per_reg * num),
                      ForKind::kSerial, body);
   for_node = PragmaUnrollLoop(for_node);
-  auto range = lower_args.thread_bounds;
-  if (range.defined()) {
-    auto thread_var = lower_args.thread_var;
-    auto thread_var_with_offset = thread_var - range->min;
-    for_node.CopyOnWrite()->body =
-        Substitute(for_node->body, {{thread_var, thread_var_with_offset}});
-  }
   return for_node;
 }
 
@@ -1342,7 +1342,7 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
       int effective_chunks =
           needs_pack_unpack ? num_chunks_each_wg / 2 : num_chunks_each_wg;
       PrimExpr relative_wg_idx =
-          FloorDiv(Sub(lower_args.thread_var, lower_args.thread_bounds->min),
+          FloorDiv(Sub(lower_args.thread_index, lower_args.thread_bounds->min),
                    WARPGROUP_SIZE);
       PrimExpr col_offset =
           num_useful_threads == WARPGROUP_SIZE
@@ -1376,7 +1376,7 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
       }
       if (num_useful_threads != num_threads) {
         body =
-            IfThenElse(lower_args.thread_var <
+            IfThenElse(lower_args.thread_index <
                            lower_args.thread_bounds->min + num_useful_threads,
                        call, Stmt());
       } else {

--- a/src/cuda/op/fill.cc
+++ b/src/cuda/op/fill.cc
@@ -84,9 +84,9 @@ std::optional<Stmt> TryLowerSharedBulkZeroFill(const FillNode &op,
       Call(DataType::Handle(), ptx_st_bulk_shared(),
            {op.dst->data, bytes, make_const(DataType::UInt(64), 0)});
   Stmt body = Evaluate(bulk_store);
-  if (lower_args.thread_var.defined() && lower_args.thread_bounds.defined()) {
-    body = IfThenElse(EQ(lower_args.thread_var, lower_args.thread_bounds->min),
-                      body);
+  if (lower_args.thread_index.defined() && lower_args.thread_bounds.defined()) {
+    body = IfThenElse(
+        EQ(lower_args.thread_index, lower_args.thread_bounds->min), body);
   }
   return body;
 }

--- a/src/metal/op/copy.cc
+++ b/src/metal/op/copy.cc
@@ -55,7 +55,7 @@ Stmt LowerSIMDGroupCopy(const CopyNode &op, const LowerArgs &lower_args,
       << "simdgroup copy requires constant thread bounds";
   int block_size = block_size_imm->value;
   int num_warps = block_size / warp_size;
-  PrimExpr warp_id = FloorDiv(lower_args.thread_var, warp_size);
+  PrimExpr warp_id = FloorDiv(lower_args.thread_index, warp_size);
 
   const auto *m_imm = op.src_range[0]->extent.as<IntImmNode>();
   const auto *n_imm = op.src_range[1]->extent.as<IntImmNode>();

--- a/src/metal/op/fill.cc
+++ b/src/metal/op/fill.cc
@@ -60,14 +60,15 @@ struct Fill {
                            lower_args.buffer_remap,
                            {}},
                           InferLevel::kFree);
-      auto thread_loop = PartitionLoop(par_op->GetRoot(), lower_args.thread_var,
-                                       analyzer, par_op->GetLoopLayout());
+      auto thread_loop =
+          PartitionLoop(par_op->GetRoot(), lower_args.thread_index, analyzer,
+                        par_op->GetLoopLayout());
       auto vectorized_loop =
           VectorizeLoop(thread_loop, analyzer, lower_args.layout_map);
       auto unrolled_loop = PragmaUnrollLoop(vectorized_loop);
 
-      if (par_op->GetPredicate(lower_args.thread_var).defined()) {
-        return IfThenElse(par_op->GetPredicate(lower_args.thread_var).value(),
+      if (par_op->GetPredicate(lower_args.thread_index).defined()) {
+        return IfThenElse(par_op->GetPredicate(lower_args.thread_index).value(),
                           unrolled_loop);
       }
       return unrolled_loop;
@@ -89,13 +90,14 @@ struct Fill {
                            lower_args.buffer_remap,
                            {}},
                           InferLevel::kFree);
-      auto thread_loop = PartitionLoop(par_op->GetRoot(), lower_args.thread_var,
-                                       analyzer, par_op->GetLoopLayout());
+      auto thread_loop =
+          PartitionLoop(par_op->GetRoot(), lower_args.thread_index, analyzer,
+                        par_op->GetLoopLayout());
       auto vectorized_loop =
           VectorizeLoop(thread_loop, analyzer, lower_args.layout_map);
       auto unrolled_loop = PragmaUnrollLoop(vectorized_loop);
-      if (par_op->GetPredicate(lower_args.thread_var).defined()) {
-        return IfThenElse(par_op->GetPredicate(lower_args.thread_var).value(),
+      if (par_op->GetPredicate(lower_args.thread_index).defined()) {
+        return IfThenElse(par_op->GetPredicate(lower_args.thread_index).value(),
                           unrolled_loop);
       }
       return unrolled_loop;

--- a/src/metal/op/transpose.cc
+++ b/src/metal/op/transpose.cc
@@ -45,8 +45,8 @@ struct Transpose {
     }
     auto loop_layout = par_op->GetLoopLayout();
     return LowerParallelLoop(
-        par_op->GetRoot(), loop_layout, lower_args.thread_var, analyzer,
-        lower_args.layout_map, par_op->GetPredicate(lower_args.thread_var),
+        par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
+        lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
         /*parallel_loop=*/true, /*should_vectorize=*/true,
         par_op->LoopLayoutRequiresPaddingGuard());
   }

--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -20,6 +20,7 @@
 
 #include <limits>
 #include <sstream>
+#include <unordered_set>
 #include <vector>
 
 namespace tvm {
@@ -41,12 +42,19 @@ Stmt LowerNormalCopy(const CopyNode &op, const LowerArgs &lower_args,
     if (IsLocalBuffer(op.src) && !IsLocalBuffer(op.dst)) {
       // A conflict write only occurs when multiple threads write to the same
       // global address. If any dst_range dimension's min depends on the thread
-      // variable, each thread targets a distinct location and there is no
-      // conflict.
+      // index, each thread targets a distinct location and there is no
+      // conflict. The thread index is an expression: collect the variables it
+      // uses by identity (the real threadIdx.x Var on GPU; none when it is a
+      // constant, e.g. 0 on CPU).
+      std::unordered_set<const VarNode *> thread_index_vars;
+      tirx::UsesVar(lower_args.thread_index, [&](const VarNode *v) {
+        thread_index_vars.insert(v);
+        return false;
+      });
       bool dst_depends_on_thread = false;
       for (const auto &range : op.dst_range) {
         if (tirx::UsesVar(range->min, [&](const VarNode *v) {
-              return v == lower_args.thread_var.get();
+              return thread_index_vars.count(v) != 0;
             })) {
           dst_depends_on_thread = true;
           break;
@@ -75,8 +83,8 @@ Stmt LowerNormalCopy(const CopyNode &op, const LowerArgs &lower_args,
   }
   auto loop_layout = par_op->GetLoopLayout();
   return LowerParallelLoop(
-      par_op->GetRoot(), loop_layout, lower_args.thread_var, analyzer,
-      lower_args.layout_map, par_op->GetPredicate(lower_args.thread_var),
+      par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
+      lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
       /*parallel_loop=*/true, /*should_vectorize=*/true,
       par_op->LoopLayoutRequiresPaddingGuard());
 }
@@ -251,8 +259,8 @@ Stmt LowerIm2ColSIMT(const Im2ColOpNode &op, const LowerArgs &lower_args,
   }
   auto loop_layout = par_op->GetLoopLayout();
   return LowerParallelLoop(
-      par_op->GetRoot(), loop_layout, lower_args.thread_var, analyzer,
-      lower_args.layout_map, par_op->GetPredicate(lower_args.thread_var),
+      par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
+      lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
       /*parallel_loop=*/true, /*should_vectorize=*/true,
       par_op->LoopLayoutRequiresPaddingGuard());
 }

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -184,7 +184,7 @@ Stmt GemmNode::Lower(const LowerArgs &lower_args,
     // side.
     auto prim_func = Downcast<PrimFunc>(
         (*f)(GetRef<Gemm>(this), lower_args.layout_map, lower_args.target,
-             lower_args.thread_bounds, lower_args.thread_var, mbar_phase));
+             lower_args.thread_bounds, lower_args.thread_index, mbar_phase));
     ICHECK(prim_func->attrs.defined());
     auto global_symbol = prim_func->attrs.GetAttr<String>("global_symbol");
     ICHECK(global_symbol.has_value());

--- a/src/op/gemm_sp.cc
+++ b/src/op/gemm_sp.cc
@@ -166,7 +166,7 @@ Stmt GemmSPNode::Lower(const LowerArgs &lower_args,
   if (const auto f = Function::GetGlobal("tl.gemm_sp.lower")) {
     auto prim_func = Downcast<PrimFunc>(
         (*f)(GetRef<GemmSP>(this), lower_args.target, lower_args.layout_map,
-             lower_args.thread_bounds, lower_args.thread_var));
+             lower_args.thread_bounds, lower_args.thread_index));
     ICHECK(prim_func->attrs.defined());
     auto global_symbol = prim_func->attrs.GetAttr<String>("global_symbol");
     ICHECK(global_symbol.has_value());

--- a/src/op/operator.h
+++ b/src/op/operator.h
@@ -96,7 +96,11 @@ inline const char *InferLevelToString(InferLevel level) {
 struct LowerArgs {
   Target target;
   Range thread_bounds;
-  tirx::Var thread_var;
+  // Logical thread index consumed by lowering helpers. This is an expression
+  // rather than a Var: GPU lowering passes the real threadIdx.x Var (bound by
+  // a thread_extent AttrStmt), while targets without thread bindings (e.g.
+  // CPU) pass constant 0. It must never be an unbound synthetic Var.
+  PrimExpr thread_index;
   LayoutMap layout_map;
   ffi::Map<tirx::Buffer, tirx::Buffer> buffer_remap;
   // Map from Bind variable to its bound expression, for resolving

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -580,9 +580,10 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &layout_args,
   return results;
 }
 
-Optional<PrimExpr> ParallelOpNode::GetPredicate(Var thread_var) const {
+Optional<PrimExpr> ParallelOpNode::GetPredicate(PrimExpr thread_index) const {
   if (predicate_.defined()) {
-    return Substitute(predicate_.value(), {{InputPlaceholder(0), thread_var}});
+    return Substitute(predicate_.value(),
+                      {{InputPlaceholder(0), thread_index}});
   } else {
     return std::nullopt;
   }

--- a/src/op/parallel.h
+++ b/src/op/parallel.h
@@ -125,8 +125,10 @@ public:
   const BufferIndiceMap &GetIndiceMap() const { return indice_map_; }
   // Get buffers in the order they first appear in the loop body.
   const std::vector<Buffer> &GetAccessOrder() const { return access_order_; }
-  // Get the predicate for a given thread variable.
-  Optional<PrimExpr> GetPredicate(Var thread_var) const;
+  // Get the predicate for a given logical thread index. GPU callers pass the
+  // real threadIdx.x Var; callers without thread bindings (e.g. CPU) pass
+  // constant 0.
+  Optional<PrimExpr> GetPredicate(PrimExpr thread_index) const;
 
   // Clone this operator.
   TileOperator Clone() const override;

--- a/src/rocm/op/atomic_add.cc
+++ b/src/rocm/op/atomic_add.cc
@@ -227,9 +227,9 @@ struct AtomicAdd {
                           level);
     }
     auto loop_layout = par_op->GetLoopLayout();
-    return LowerParallelLoop(fused_loop, loop_layout, lower_args.thread_var,
+    return LowerParallelLoop(fused_loop, loop_layout, lower_args.thread_index,
                              analyzer, lower_args.layout_map,
-                             par_op->GetPredicate(lower_args.thread_var),
+                             par_op->GetPredicate(lower_args.thread_index),
                              /*parallel_loop=*/true, /*should_vectorize=*/true,
                              par_op->LoopLayoutRequiresPaddingGuard());
   }

--- a/src/rocm/op/copy.cc
+++ b/src/rocm/op/copy.cc
@@ -129,8 +129,8 @@ private:
     }
     auto loop_layout = par_op->GetLoopLayout();
     Stmt lowered_loop = LowerParallelLoop(
-        par_op->GetRoot(), loop_layout, lower_args.thread_var, analyzer,
-        lower_args.layout_map, par_op->GetPredicate(lower_args.thread_var),
+        par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
+        lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
         /*parallel_loop=*/true,
         /*should_vectorize=*/true, par_op->LoopLayoutRequiresPaddingGuard());
 

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -77,23 +77,6 @@ Optional<Buffer> FindLayoutAnchorBuffer(const Array<Buffer> &buffers,
 
 } // namespace
 
-/*!
- * \brief collect the mapping from the buffer var to it allocated buffer
- */
-class ThreadBindingCollector : public StmtExprVisitor {
-public:
-  void VisitStmt_(const AttrStmtNode *op) final {
-    if (op->attr_key == tirx::attr::thread_extent) {
-      IterVar iv = Downcast<IterVar>(op->node);
-      thread_binding_[iv->var.get()] = iv;
-    }
-    StmtExprVisitor::VisitStmt_(op);
-  }
-
-  // The thread binding map
-  std::unordered_map<const VarNode *, IterVar> thread_binding_;
-};
-
 using namespace tirx;
 using arith::IRMutatorWithAnalyzer;
 using arith::IRVisitorWithAnalyzer;
@@ -107,8 +90,7 @@ struct LayoutInferenceResult {
 
 class BufferUseDefCollector : public IRVisitorWithAnalyzer {
 public:
-  BufferUseDefCollector(bool skip_thread_partition)
-      : skip_thread_partition_(skip_thread_partition) {}
+  BufferUseDefCollector() = default;
 
   using arith::IRVisitorWithAnalyzer::IRVisitorWithAnalyzer;
 
@@ -124,28 +106,24 @@ public:
         << num_infer << ".";
 
     // Make sure we can safely access infer_list_[cur_infer_id] and
-    // thread_var_vec_[cur_infer_id]
+    // thread_index_vec_[cur_infer_id]
     auto &next = infer_list_[cur_infer_id];
-    auto iter_var = thread_var_vec_[cur_infer_id];
+    auto thread_index = thread_index_vec_[cur_infer_id];
     auto thread_bounds = thread_bounds_vec_[cur_infer_id];
     arith::Analyzer *cur_analyzer = analyzer_vec_[cur_infer_id].get();
     // Double-check that 'next' is valid
     ICHECK(next.defined()) << "infer_list_[" << cur_infer_id
                            << "] is null inside run_infer_step.";
 
-    // Check iter_var->dom and dom->extent
-    ICHECK(iter_var.defined())
-        << "thread_var_vec_[" << cur_infer_id << "] is not defined.";
-    ICHECK(iter_var->dom.defined())
-        << "iter_var->dom is not defined for infer_list_[" << cur_infer_id
-        << "].";
-    ICHECK(iter_var->dom->extent.defined())
-        << "iter_var->dom->extent is not defined for infer_list_["
-        << cur_infer_id << "].";
+    // Check the logical thread index and the thread bounds extent.
+    ICHECK(thread_index.defined())
+        << "thread_index_vec_[" << cur_infer_id << "] is not defined.";
+    ICHECK(thread_bounds.defined())
+        << "thread_bounds_vec_[" << cur_infer_id << "] is not defined.";
 
-    const int64_t *extent_ptr = as_const_int(iter_var->dom->extent);
+    const int64_t *extent_ptr = as_const_int(thread_bounds->extent);
     ICHECK(extent_ptr != nullptr)
-        << "iter_var->dom->extent is not a constant integer, which is "
+        << "thread_bounds->extent is not a constant integer, which is "
            "required for layout inference.";
 
     // Run InferLayout
@@ -324,10 +302,10 @@ public:
   };
 
   LayoutInferenceResult Run() {
-    // Basic consistency check: infer_list_ and thread_var_vec_ should have the
-    // same size
-    ICHECK_EQ(infer_list_.size(), thread_var_vec_.size())
-        << "Size mismatch: infer_list_ and thread_var_vec_ must match in "
+    // Basic consistency check: infer_list_ and thread_index_vec_ should have
+    // the same size
+    ICHECK_EQ(infer_list_.size(), thread_index_vec_.size())
+        << "Size mismatch: infer_list_ and thread_index_vec_ must match in "
            "length.";
     ICHECK_EQ(thread_bounds_vec_.size(), infer_list_.size())
         << "Size mismatch: thread_bounds_vec_ and infer_list_ must match in "
@@ -356,11 +334,6 @@ public:
       ICHECK(infer_list_[i].defined())
           << "infer_list_[" << i
           << "] is null. The inference object is not allocated properly.";
-
-      // Check that each thread_var_vec_ entry is defined
-      if (!thread_var_vec_[i].defined() && skip_thread_partition_) {
-        thread_var_vec_[i] = thread_var_;
-      }
       q.push_back(i);
     }
 
@@ -446,11 +419,11 @@ public:
     Map<For, Fragment> for_map;
     Map<For, PrimExpr> predicate_map;
     Map<For, Bool> padding_guard_map;
-    ICHECK(infer_list_.size() == thread_var_vec_.size())
-        << "infer_list_ and thread_var_vec_ size mismatch";
+    ICHECK(infer_list_.size() == thread_index_vec_.size())
+        << "infer_list_ and thread_index_vec_ size mismatch";
     for (int i = 0; i < infer_list_.size(); i++) {
       TileOperator base_infer = std::move(infer_list_[i]);
-      auto thread_var = thread_var_vec_[i];
+      auto thread_index = thread_index_vec_[i];
 
       // Check if base_infer is valid
       ICHECK(base_infer.defined()) << "Null pointer encountered in "
@@ -464,11 +437,11 @@ public:
         if (for_infer->LoopLayoutRequiresPaddingGuard()) {
           padding_guard_map.Set(for_infer->GetRoot(), Bool(true));
         }
-        // thread_var_ should be defined if we rely on it
-        ICHECK(thread_var.defined())
-            << "thread_var is not defined. Cannot retrieve predicate.";
+        // thread_index should be defined if we rely on it
+        ICHECK(thread_index.defined())
+            << "thread_index is not defined. Cannot retrieve predicate.";
 
-        if (auto predicate = for_infer->GetPredicate(thread_var->var)) {
+        if (auto predicate = for_infer->GetPredicate(thread_index)) {
           predicate_map.Set(for_infer->GetRoot(), predicate.value());
         }
       }
@@ -560,8 +533,8 @@ private:
         // This handles cases like: a = block_mask_f[i]; T.copy(A[a, 0], ...)
         CollectFragmentBuffersFromExpr(arg);
       }
-      // Compute thread_var_ and thread_bounds_
-      thread_var_vec_.push_back(thread_var_);
+      // Compute thread_index and thread_bounds
+      thread_index_vec_.push_back(CurrentThreadIndex());
       thread_bounds_vec_.push_back(CurrentThreadBounds());
       analyzer_vec_.push_back(analyzer_.Clone());
 
@@ -703,7 +676,7 @@ private:
       });
       infer_list_stmt_.push_back(GetRef<ObjectRef>(op));
       infer_list_.push_back(std::move(infer));
-      thread_var_vec_.push_back(thread_var_);
+      thread_index_vec_.push_back(CurrentThreadIndex());
       thread_bounds_vec_.push_back(CurrentThreadBounds());
       analyzer_vec_.push_back(analyzer_.Clone());
     } else {
@@ -768,7 +741,7 @@ private:
       IterVar iv = Downcast<IterVar>(op->node);
       if (iv->thread_tag == "threadIdx.x") {
         ICHECK(iv->dom->extent.as<IntImmNode>());
-        thread_var_ = iv;
+        thread_binding_ = iv;
       }
     }
     IRVisitorWithAnalyzer::VisitStmt_(op);
@@ -799,7 +772,17 @@ private:
   }
 
   Range CurrentThreadBounds() const {
-    return ComputeThreadBounds(thread_var_, analyzer_);
+    return ComputeThreadBounds(thread_binding_, analyzer_);
+  }
+
+  // Logical thread index for the current collection point: the real
+  // threadIdx.x Var when a thread_extent binding exists, otherwise constant
+  // 0 (e.g. CPU serial launch). Never an unbound synthetic Var.
+  PrimExpr CurrentThreadIndex() const {
+    if (thread_binding_.defined()) {
+      return thread_binding_->var;
+    }
+    return IntImm(DataType::Int(32), 0);
   }
 
   void VisitExpr_(const BufferLoadNode *op) final {
@@ -976,16 +959,16 @@ private:
       use_list_;
   // Per-op list of buffers it touches (fragment scope), used for prioritization
   std::unordered_map<int, std::vector<Buffer>> op_touched_buffers_;
-  // This is a workaround for cpu backend,
-  // we need to define a thread_var for the serial loop.
-  IterVar thread_var_ = IterVar(Range::FromMinExtent(0, 1), Var("v_thread"),
-                                IterVarType::kDataPar);
-  std::vector<IterVar> thread_var_vec_;
+  // Real threadIdx.x binding of the enclosing thread_extent scope, when one
+  // exists. Stays undefined for targets without thread bindings (e.g. CPU),
+  // where the logical thread index is the constant 0 and thread bounds are
+  // [0, 1) — no synthetic fallback Var is ever created.
+  IterVar thread_binding_;
+  std::vector<PrimExpr> thread_index_vec_;
   std::vector<Range> thread_bounds_vec_;
   std::vector<std::unique_ptr<arith::Analyzer>> analyzer_vec_;
   Target target_;
   LayoutMap annotated_layout_map_;
-  bool skip_thread_partition_{false};
 
   std::vector<TileOperator> BackupInferList() {
     std::vector<TileOperator> back_infer_list;
@@ -1155,11 +1138,11 @@ private:
 
 class LayoutInferencer : public IRMutatorWithAnalyzer {
 public:
-  static PrimFunc Substitute(PrimFunc f, bool skip_thread_partition = false) {
+  static PrimFunc Substitute(PrimFunc f) {
     arith::Analyzer analyzer;
     PrimFuncNode *fptr = f.CopyOnWrite();
     fptr->body = ParallelLoopFuser::Fuse(f->body);
-    BufferUseDefCollector collector(skip_thread_partition);
+    BufferUseDefCollector collector;
     collector.Collect(f);
     auto result = collector.Run();
     LayoutInferencer substituter(result, &analyzer);
@@ -1252,11 +1235,7 @@ private:
 tvm::transform::Pass LayoutInference() {
   using namespace tirx::transform;
   auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
-    ThreadBindingCollector collector;
-    collector(f->body);
-    bool has_thread_binding = !collector.thread_binding_.empty();
-    bool skip_thread_partition = !has_thread_binding;
-    f = LayoutInferencer::Substitute(std::move(f), skip_thread_partition);
+    f = LayoutInferencer::Substitute(std::move(f));
     // Validate parallel loop layout annotations
     ParallelLoopLayoutValidator::Validate(f->body);
     return f;

--- a/src/transform/loop_partition.cc
+++ b/src/transform/loop_partition.cc
@@ -64,10 +64,10 @@ private:
 };
 
 // Rewrite the parallel loop into a common loop, which is mapped to threads
-For PartitionLoop(For op, Var thread_var, arith::Analyzer *analyzer,
+For PartitionLoop(For op, PrimExpr thread_index, arith::Analyzer *analyzer,
                   const Fragment &loop_layout, bool require_padding_guard) {
   ICHECK(loop_layout.defined());
-  ICHECK(thread_var.defined());
+  ICHECK(thread_index.defined());
   int old_loop_depth = loop_layout->InputDim();
   int new_loop_depth = loop_layout->OutputDim();
   // Create the new loop iter var
@@ -78,7 +78,17 @@ For PartitionLoop(For op, Var thread_var, arith::Analyzer *analyzer,
                                              loop_layout->OutputShape()[i]));
     vars.push_back(var);
   }
-  vars.push_back(thread_var);
+  // Normalize the thread index against the layout thread range once, then
+  // feed the normalized expression into the inverse layout directly. The
+  // inverse indices, the bounds guard and the replicate index therefore all
+  // use the same normalized expression, without needing a Var-keyed
+  // substitution map.
+  PrimExpr normalized_thread_index = thread_index;
+  if (loop_layout->ThreadRange().defined()) {
+    normalized_thread_index = thread_index - loop_layout->ThreadRange()->min;
+  }
+  Array<PrimExpr> forward_inputs(vars.begin(), vars.end());
+  forward_inputs.push_back(normalized_thread_index);
   // create the substitute map, and the loop body
   Map<Var, PrimExpr> vmap;
   Stmt body = std::move(op);
@@ -86,15 +96,7 @@ For PartitionLoop(For op, Var thread_var, arith::Analyzer *analyzer,
   Array<PrimExpr> loop_extents;
   auto inverse_info = loop_layout->InverseWithLevel(require_padding_guard);
   auto inv_loop = inverse_info.first;
-  auto indices = inv_loop->Forward(Array<PrimExpr>(vars.begin(), vars.end()));
-  // Normalize thread var once so we can reuse the same substitution later.
-  Map<Var, PrimExpr> thread_offset_map;
-  bool has_thread_offset = false;
-  if (loop_layout->ThreadRange().defined()) {
-    auto range = loop_layout->ThreadRange();
-    thread_offset_map.Set(thread_var, thread_var - range->min);
-    has_thread_offset = true;
-  }
+  auto indices = inv_loop->Forward(forward_inputs);
   for (int i = 0; i < old_loop_depth; i++) {
     const ForNode *loop = body.as<ForNode>();
     ICHECK(loop != nullptr)
@@ -127,9 +129,6 @@ For PartitionLoop(For op, Var thread_var, arith::Analyzer *analyzer,
   PrimExpr guard = const_true();
   for (int i = 0; i < old_loop_depth; i++) {
     PrimExpr index = indices[i];
-    if (has_thread_offset) {
-      index = Substitute(index, thread_offset_map);
-    }
     PrimExpr lower_bound = analyzer->Simplify(index >= loop_mins[i]);
     PrimExpr upper_bound =
         analyzer->Simplify(index < loop_mins[i] + loop_extents[i]);
@@ -138,9 +137,6 @@ For PartitionLoop(For op, Var thread_var, arith::Analyzer *analyzer,
   auto inv_output_shape = inv_loop->OutputShape();
   if (inv_output_shape.size() > static_cast<size_t>(old_loop_depth)) {
     PrimExpr replicate_index = indices[old_loop_depth];
-    if (has_thread_offset) {
-      replicate_index = Substitute(replicate_index, thread_offset_map);
-    }
     PrimExpr replicate_extent = inv_output_shape[old_loop_depth];
     PrimExpr lower_bound = analyzer->Simplify(
         replicate_index >= make_zero(replicate_index.dtype()));
@@ -161,9 +157,6 @@ For PartitionLoop(For op, Var thread_var, arith::Analyzer *analyzer,
 
   body = BufferIndiceSimplify(analyzer)(body);
 
-  if (has_thread_offset) {
-    body = Substitute(body, thread_offset_map);
-  }
   return Downcast<For>(body);
 }
 
@@ -271,8 +264,9 @@ For PragmaUnrollLoop(For stmt) {
   return unrolled;
 }
 
-Stmt LowerParallelLoop(For loop, const Fragment &loop_layout, Var thread_var,
-                       arith::Analyzer *analyzer, const LayoutMap &layout_map,
+Stmt LowerParallelLoop(For loop, const Fragment &loop_layout,
+                       PrimExpr thread_index, arith::Analyzer *analyzer,
+                       const LayoutMap &layout_map,
                        Optional<PrimExpr> predicate, bool parallel_loop,
                        bool should_vectorize, bool require_padding_guard) {
   // Save analyzer state to prevent conflicted bindings during vectorization
@@ -292,8 +286,8 @@ Stmt LowerParallelLoop(For loop, const Fragment &loop_layout, Var thread_var,
 
   // Step 1: Partition the loop based on the layout (if this is a parallel loop)
   if (parallel_loop) {
-    result_loop = PartitionLoop(result_loop, thread_var, analyzer, loop_layout,
-                                require_padding_guard);
+    result_loop = PartitionLoop(result_loop, thread_index, analyzer,
+                                loop_layout, require_padding_guard);
   }
 
   // Step 2: Vectorize the loop (if requested)

--- a/src/transform/loop_partition.h
+++ b/src/transform/loop_partition.h
@@ -37,7 +37,7 @@ namespace tl {
 
 using namespace tirx;
 
-For PartitionLoop(For op, Var thread_var, arith::Analyzer *analyzer,
+For PartitionLoop(For op, PrimExpr thread_index, arith::Analyzer *analyzer,
                   const Fragment &loop_layout,
                   bool require_padding_guard = false);
 
@@ -58,7 +58,9 @@ For PragmaUnrollLoop(For stmt);
  *
  * \param loop The parallel For loop to lower.
  * \param loop_layout The Fragment layout for partitioning.
- * \param thread_var The thread variable for partitioning.
+ * \param thread_index The logical thread index expression for partitioning
+ *        (the real threadIdx.x Var on GPU, constant 0 without thread
+ *        bindings).
  * \param analyzer The arithmetic analyzer.
  * \param predicate ffi::Optional predicate to wrap the loop with IfThenElse.
  * \param parallel_loop Whether this is a true parallel loop requiring thread
@@ -70,7 +72,7 @@ For PragmaUnrollLoop(For stmt);
  * \return The lowered statement.
  */
 Stmt LowerParallelLoop(
-    For loop, const Fragment &loop_layout, Var thread_var,
+    For loop, const Fragment &loop_layout, PrimExpr thread_index,
     arith::Analyzer *analyzer, const LayoutMap &layout_map = {},
     ffi::Optional<PrimExpr> predicate = ffi::Optional<PrimExpr>(),
     bool parallel_loop = true, bool should_vectorize = true,

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -23,7 +23,6 @@
 #include "../op/gemm_sp.h"
 #include "../op/operator.h"
 #include "../op/utils.h"
-#include "cpu/target_utils.h"
 #include "cuda/target_utils.h"
 #include "cuda/transform/ptx_async_copy_injector.h"
 
@@ -189,36 +188,6 @@ private:
   Map<Buffer, Buffer> remap_;
 };
 
-/*! \brief Rewrite the synthetic CPU fallback thread variable to a constant.
- *
- * CPU `c` kernels use a degenerate fallback thread variable while fragment and
- * tile-op lowering still share thread-oriented helper code. After this pass has
- * consumed that helper variable, it should not remain in lowered CPU TIR.
- */
-class CPUFallbackThreadVarCanonicalizer : public StmtExprMutator {
-public:
-  static Stmt Rewrite(Stmt stmt, Var fallback_thread_var) {
-    CPUFallbackThreadVarCanonicalizer canonicalizer(
-        std::move(fallback_thread_var));
-    return canonicalizer(std::move(stmt));
-  }
-
-private:
-  explicit CPUFallbackThreadVarCanonicalizer(Var fallback_thread_var)
-      : fallback_thread_var_(std::move(fallback_thread_var)) {}
-
-  PrimExpr VisitExpr_(const VarNode *op) final {
-    if (fallback_thread_var_.defined() &&
-        (op == fallback_thread_var_.get() ||
-         op->name_hint == fallback_thread_var_->name_hint)) {
-      return make_zero(op->dtype);
-    }
-    return StmtExprMutator::VisitExpr_(op);
-  }
-
-  Var fallback_thread_var_;
-};
-
 class LowerTileOpPass : arith::IRMutatorWithAnalyzer {
 public:
   static PrimFunc Substitute(PrimFunc f) {
@@ -317,14 +286,6 @@ public:
       fptr->body = injector(fptr->body);
       ICHECK(injector.injected)
           << "Failed to find root SBlockRealize for barrier injection";
-    }
-
-    if (TargetIsCPU(substituter.target_)) {
-      // TODO(#2226): Remove the underlying CPU fallback-thread placeholder
-      // shared by LayoutInference/LowerTileOp. Until then, canonicalize the
-      // synthetic fallback after fragment/tile lowering has consumed it.
-      fptr->body = CPUFallbackThreadVarCanonicalizer::Rewrite(
-          std::move(fptr->body), substituter.thread_var_->var);
     }
 
     return f;
@@ -1111,12 +1072,12 @@ private:
    * buffer named "workspace" (storage scope "shared.dyn") and returns its write
    *   access pointer.
    * - Determines thread bounds for lowering from the analyzer's constant-int
-   *   information for thread_var_; if unavailable, a default range [0,1) is
-   * used.
+   *   information for the thread binding; if unavailable, a default range
+   *   [0,1) is used.
    * - Invokes tile_op->Lower(...) with LowerArgs containing target, thread
-   *   bounds, thread variable, the workspace callback, layout and buffer remap
-   *   maps, and the list of GEMM-involved buffer vars; the analyzer is passed
-   *   through for use during lowering.
+   *   bounds, the logical thread index, the workspace callback, layout and
+   *   buffer remap maps, and the list of GEMM-involved buffer vars; the
+   *   analyzer is passed through for use during lowering.
    *
    * The lowered statement returned by the operator is then visited by the base
    * IRMutatorWithAnalyzer and that result is returned.
@@ -1217,7 +1178,7 @@ private:
     LowerArgs lower_args;
     lower_args.target = target_;
     lower_args.thread_bounds = thread_bounds;
-    lower_args.thread_var = thread_var_->var;
+    lower_args.thread_index = CurrentThreadIndex();
     lower_args.layout_map = layout_map_;
     lower_args.buffer_remap = buffer_remap_;
     lower_args.bind_var_to_expr = bind_var_to_expr;
@@ -1241,7 +1202,7 @@ private:
       IterVar iv = Downcast<IterVar>(op->node);
       ICHECK_NE(iv->thread_tag.length(), 0U);
       if (iv->thread_tag == "threadIdx.x") {
-        thread_var_ = iv;
+        thread_binding_ = iv;
         ICHECK(iv->dom->extent.as<IntImmNode>());
         thread_block_size_ = iv->dom->extent.as<IntImmNode>()->value;
       }
@@ -1516,7 +1477,7 @@ private:
         (has_non_local || has_cast_operations) && !has_reducer;
     // Lower the parallel loop using the common function
     Stmt lowered = LowerParallelLoop(
-        for_node, loop_layout, thread_var_->var, analyzer_, layout_map_,
+        for_node, loop_layout, CurrentThreadIndex(), analyzer_, layout_map_,
         predicate, parallel_loop, should_vectorize, require_padding_guard);
 
     // Only parallel-loop lowering needs PTX cp.async injection. Thread-level
@@ -1539,7 +1500,17 @@ private:
   }
 
   Range CurrentThreadBounds() const {
-    return ComputeThreadBounds(thread_var_, *analyzer_);
+    return ComputeThreadBounds(thread_binding_, *analyzer_);
+  }
+
+  // Logical thread index handed to lowering helpers: the real threadIdx.x
+  // Var when a thread_extent binding exists, otherwise constant 0 (e.g. CPU
+  // serial launch). Never an unbound synthetic Var.
+  PrimExpr CurrentThreadIndex() const {
+    if (thread_binding_.defined()) {
+      return thread_binding_->var;
+    }
+    return IntImm(DataType::Int(32), 0);
   }
 
   void RecordSafeValueAnnotations(const SBlockNode *op) {
@@ -1560,10 +1531,9 @@ private:
   Map<Buffer, Layout> layout_map_;
   Map<Buffer, Layout> layout_remap_;
   Map<Buffer, Buffer> buffer_remap_;
-  // This is a workaround for cpu backend,
-  // we need to define a thread_var for the serial loop.
-  IterVar thread_var_ = IterVar(Range::FromMinExtent(0, 1), Var("v_thread"),
-                                IterVarType::kDataPar);
+  // Real threadIdx.x binding of the enclosing thread_extent scope, when one
+  // exists. Stays undefined for targets without thread bindings (e.g. CPU).
+  IterVar thread_binding_;
   size_t thread_block_size_ = 0;
   // Product of cluster_dims from block annotation (default 1).
   int cluster_size_ = 1;

--- a/src/webgpu/op/fill.cc
+++ b/src/webgpu/op/fill.cc
@@ -27,14 +27,15 @@ struct Fill {
                            lower_args.buffer_remap,
                            {}},
                           InferLevel::kFree);
-      auto thread_loop = PartitionLoop(par_op->GetRoot(), lower_args.thread_var,
-                                       analyzer, par_op->GetLoopLayout());
+      auto thread_loop =
+          PartitionLoop(par_op->GetRoot(), lower_args.thread_index, analyzer,
+                        par_op->GetLoopLayout());
       auto vectorized_loop =
           VectorizeLoop(thread_loop, analyzer, lower_args.layout_map);
       auto unrolled_loop = PragmaUnrollLoop(vectorized_loop);
 
-      if (par_op->GetPredicate(lower_args.thread_var).defined()) {
-        return IfThenElse(par_op->GetPredicate(lower_args.thread_var).value(),
+      if (par_op->GetPredicate(lower_args.thread_index).defined()) {
+        return IfThenElse(par_op->GetPredicate(lower_args.thread_index).value(),
                           unrolled_loop);
       }
       return unrolled_loop;
@@ -56,13 +57,14 @@ struct Fill {
                            lower_args.buffer_remap,
                            {}},
                           InferLevel::kFree);
-      auto thread_loop = PartitionLoop(par_op->GetRoot(), lower_args.thread_var,
-                                       analyzer, par_op->GetLoopLayout());
+      auto thread_loop =
+          PartitionLoop(par_op->GetRoot(), lower_args.thread_index, analyzer,
+                        par_op->GetLoopLayout());
       auto vectorized_loop =
           VectorizeLoop(thread_loop, analyzer, lower_args.layout_map);
       auto unrolled_loop = PragmaUnrollLoop(vectorized_loop);
-      if (par_op->GetPredicate(lower_args.thread_var).defined()) {
-        return IfThenElse(par_op->GetPredicate(lower_args.thread_var).value(),
+      if (par_op->GetPredicate(lower_args.thread_index).defined()) {
+        return IfThenElse(par_op->GetPredicate(lower_args.thread_index).value(),
                           unrolled_loop);
       }
       return unrolled_loop;

--- a/src/webgpu/op/transpose.cc
+++ b/src/webgpu/op/transpose.cc
@@ -44,8 +44,8 @@ struct Transpose {
     }
     auto loop_layout = par_op->GetLoopLayout();
     return LowerParallelLoop(
-        par_op->GetRoot(), loop_layout, lower_args.thread_var, analyzer,
-        lower_args.layout_map, par_op->GetPredicate(lower_args.thread_var),
+        par_op->GetRoot(), loop_layout, lower_args.thread_index, analyzer,
+        lower_args.layout_map, par_op->GetPredicate(lower_args.thread_index),
         /*parallel_loop=*/true, /*should_vectorize=*/true,
         par_op->LoopLayoutRequiresPaddingGuard());
   }

--- a/testing/python/transform/test_tilelang_transform_lower_tile_op.py
+++ b/testing/python/transform/test_tilelang_transform_lower_tile_op.py
@@ -125,8 +125,89 @@ def test_lower_tile_op_preserves_ragged_parallel_padding_guard():
         tl.transform.LowerTileOp()(mod)
 
 
-def _cpu_while_kernel_module():
-    """The while + fragment kernel from issue #2202, on a CPU `c` target."""
+def _var_name(var) -> str:
+    if hasattr(var, "name_hint"):
+        return var.name_hint
+    if hasattr(var, "name"):
+        return var.name
+    return str(var).split(":")[0].strip()
+
+
+def _vars_of(node) -> list:
+    """Collect all Var objects referenced by an expression or statement."""
+    vars_found = []
+
+    def _visit(n):
+        if isinstance(n, tvm.tirx.Var):
+            vars_found.append(n)
+
+    post_order_visit(node, _visit)
+    return vars_found
+
+
+def _collect_var_names(func: tvm.tirx.PrimFunc):
+    return {_var_name(var) for var in _vars_of(func.body)}
+
+
+def _for_predicate_annotations(func: tvm.tirx.PrimFunc) -> list:
+    """Every parallel_loop_predicate annotation expression in the function.
+
+    Generic statement visitors do not traverse annotation payloads, so the
+    annotation expressions are read out explicitly here.
+    """
+    predicates = []
+
+    def _visit(node):
+        if isinstance(node, tvm.tirx.For):
+            predicate = node.annotations.get("parallel_loop_predicate", None)
+            if predicate is not None:
+                predicates.append(predicate)
+
+    post_order_visit(func.body, _visit)
+    return predicates
+
+
+def _thread_extent_vars(func: tvm.tirx.PrimFunc) -> list:
+    """Vars bound by threadIdx.x thread_extent AttrStmts (real thread bindings)."""
+    vars_found = []
+
+    def _visit(node):
+        if isinstance(node, tvm.tirx.AttrStmt) and node.attr_key == "thread_extent" and node.node.thread_tag == "threadIdx.x":
+            vars_found.append(node.node.var)
+
+    post_order_visit(func.body, _visit)
+    return vars_found
+
+
+def _assert_no_unexpected_free_vars(func: tvm.tirx.PrimFunc):
+    """Every free var must be a buffer_map data var; nothing synthetic may leak.
+
+    Right after LowerTileOp/SplitHostDevice the buffer data vars still appear
+    "undefined" to var-use analysis (they are declared via match_buffer and
+    lowered later), so the assertion filters them out — by object identity,
+    not by name — and checks that no *other* free variable (e.g. a synthetic
+    thread placeholder) survives.
+    """
+    buffer_data_vars = [buffer.data for buffer in func.buffer_map.values()]
+    unexpected = [
+        var
+        for var in tvm.tirx.analysis.undefined_vars(func.body, func.params)
+        if not any(var.same_as(data_var) for data_var in buffer_data_vars)
+    ]
+    assert not unexpected, f"unexpected free variables: {unexpected}"
+
+
+def _cpu_target(with_host: bool = False) -> tvm.target.Target:
+    host = tvm.target.Target("llvm") if with_host else None
+    return tvm.target.Target("c", host) if with_host else tvm.target.Target("c")
+
+
+def _cpu_while_kernel_module(with_host: bool = False):
+    """The while + fragment kernel from issue #2202, on a CPU `c` target.
+
+    Returns (module, target); run subsequent passes inside `with target:` —
+    parallel-loop lowering queries Target::Current().
+    """
 
     @T.prim_func
     def main(flag: T.Tensor((1,), "int32"), out: T.Tensor((1,), "int32")):
@@ -140,81 +221,188 @@ def _cpu_while_kernel_module():
             out[0] = state[0]
 
     mod = tvm.IRModule.from_expr(main)
-    target = tvm.target.Target("c")
+    target = _cpu_target(with_host)
     mod = tvm.tirx.transform.BindTarget(target)(mod)
     mod = tl.transform.MaterializeKernelLaunch(lower_thread_binding=False)(mod)
-    return mod
+    return mod, target
 
 
-def _collect_var_names(func: tvm.tirx.PrimFunc):
-    names = set()
+def _cpu_parallel_kernel_module():
+    """A CPU `c` target module with T.Parallel loops and a fragment buffer.
 
-    def _visit(node):
-        if isinstance(node, tvm.tirx.Var):
-            names.add(_var_name(node))
+    Unlike the while repro, this exercises the thread-oriented helper paths
+    directly: `ParallelOpNode::GetPredicate` during LayoutInference and
+    `LowerParallelLoop`/`LowerArgs.thread_index` during LowerTileOp.
 
-    post_order_visit(func.body, _visit)
-    return names
-
-
-def _var_name(var) -> str:
-    if hasattr(var, "name_hint"):
-        return var.name_hint
-    if hasattr(var, "name"):
-        return var.name
-    return str(var).split(":")[0].strip()
-
-
-def _assert_no_unexpected_free_vars(func: tvm.tirx.PrimFunc):
-    """Every free var must come from the buffer_map; nothing synthetic may leak.
-
-    Right after LowerTileOp/SplitHostDevice the buffer data vars still appear
-    "undefined" to var-use analysis (they are declared via match_buffer and
-    lowered later), so the assertion filters them out and checks that no
-    *other* free variable — e.g. a synthetic thread placeholder — survives.
+    Returns (module, target); run subsequent passes inside `with target:`.
     """
-    buffer_data_names = {_var_name(buffer.data) for buffer in func.buffer_map.values()}
-    unexpected = [var for var in tvm.tirx.analysis.undefined_vars(func.body, func.params) if _var_name(var) not in buffer_data_names]
-    assert not unexpected, f"unexpected free variables: {unexpected}"
+
+    @T.prim_func
+    def main(A: T.Tensor((16,), "int32"), B: T.Tensor((16,), "int32")):
+        with T.Kernel(1):
+            frag = T.alloc_fragment((16,), "int32")
+            for i in T.Parallel(16):
+                frag[i] = A[i]
+            for i in T.Parallel(16):
+                B[i] = frag[i]
+
+    mod = tvm.IRModule.from_expr(main)
+    target = _cpu_target()
+    mod = tvm.tirx.transform.BindTarget(target)(mod)
+    mod = tl.transform.MaterializeKernelLaunch(lower_thread_binding=False)(mod)
+    return mod, target
+
+
+def test_layout_inference_cpu_parallel_predicate_is_ground():
+    """Producer-level regression for issue #2226 at the LayoutInference boundary.
+
+    With a real thread binding absent, LayoutInference must materialize
+    parallel-loop predicates with the constant 0 thread index. The historical
+    LowerTileOp canonicalizer would rewrite a leaked `v_thread` only at the
+    end of LowerTileOp, so checking right after LayoutInference is what
+    distinguishes a producer-level fix from the old compatibility cleanup:
+    the old code would leave `v_thread >= 0 && v_thread < 1` in the
+    annotation here.
+    """
+    mod, target = _cpu_parallel_kernel_module()
+    with target:
+        mod = tl.transform.LayoutInference()(mod)
+    func = mod["main"]
+
+    # CPU predicates substitute the constant 0 thread index, so they simplify
+    # away; any surviving annotation expression must be ground (Var-free).
+    for predicate in _for_predicate_annotations(func):
+        assert _vars_of(predicate) == [], f"CPU predicate must be ground, got: {predicate}"
+    assert "v_thread" not in _collect_var_names(func)
+
+
+def test_layout_inference_metal_parallel_predicate_uses_real_thread_var():
+    """Targets with a real thread binding keep the bound threadIdx.x in predicates.
+
+    Companion to the CPU boundary test: the logical thread index must remain
+    the real threadIdx.x Var (same object as the thread_extent binding) when
+    one exists.
+    """
+
+    @T.prim_func
+    def main(A: T.Tensor((8,), "float32"), B: T.Tensor((8,), "float32")):
+        with T.Kernel(1, threads=128):
+            for i in T.Parallel(8):
+                B[i] = A[i] * 2.0
+
+    mod = tvm.IRModule.from_expr(main)
+    target = tvm.target.Target("metal")
+    mod = tvm.tirx.transform.BindTarget(target)(mod)
+    mod = tl.transform.MaterializeKernelLaunch()(mod)
+    with target:
+        mod = tl.transform.LayoutInference()(mod)
+    func = mod["main"]
+
+    thread_vars = _thread_extent_vars(func)
+    assert len(thread_vars) == 1, "expected exactly one threadIdx.x binding"
+    predicates = _for_predicate_annotations(func)
+    assert predicates, "expected a parallel_loop_predicate annotation"
+    for predicate in predicates:
+        predicate_vars = _vars_of(predicate)
+        assert predicate_vars, f"predicate should reference threadIdx.x: {predicate}"
+        for var in predicate_vars:
+            assert any(var.same_as(tv) for tv in thread_vars), f"predicate variable {var} is not the bound threadIdx.x"
 
 
 def test_lower_tile_op_cpu_no_synthetic_thread_var():
     """CPU lowering must not materialize a synthetic thread placeholder.
 
-    Regression test for https://github.com/tile-ai/tilelang/issues/2226.
-    LayoutInference/LowerTileOp used to share a synthetic `v_thread` fallback
-    Var that could escape into later passes as a free variable. Thread-oriented
-    helpers must now receive constant 0 on CPU, so no synthetic thread Var may
-    appear in the lowered function or its annotations.
+    Historical end-to-end regression for https://github.com/tile-ai/tilelang/issues/2226
+    using the issue #2202 while + fragment kernel.
     """
-    mod = _cpu_while_kernel_module()
-    mod = tl.transform.LayoutInference()(mod)
-    mod = tl.transform.LowerTileOp()(mod)
+    mod, target = _cpu_while_kernel_module()
+    with target:
+        mod = tl.transform.LayoutInference()(mod)
+        mod = tl.transform.LowerTileOp()(mod)
 
     func = mod["main"]
     assert "v_thread" not in _collect_var_names(func)
     _assert_no_unexpected_free_vars(func)
 
 
-def test_lower_tile_op_cpu_split_host_device_abi_is_clean():
+def test_lower_tile_op_cpu_parallel_loop_no_synthetic_thread_var():
+    """CPU parallel-loop lowering receives constant 0 as the thread index (#2226)."""
+    mod, target = _cpu_parallel_kernel_module()
+    with target:
+        mod = tl.transform.LayoutInference()(mod)
+        mod = tl.transform.LowerTileOp()(mod)
+
+    func = mod["main"]
+    assert "v_thread" not in _collect_var_names(func)
+    _assert_no_unexpected_free_vars(func)
+
+
+def test_split_host_device_cpu_device_abi_is_clean():
     """SplitHostDevice must never see a synthetic CPU thread placeholder.
 
     See https://github.com/tile-ai/tilelang/issues/2226: a leaked `v_thread`
     would be picked up by SplitHostDevice's use-def analysis and become an
-    unexpected device ABI parameter.
+    unexpected device ABI parameter. Uses a device+host target pair (as the
+    production lowering does) so AnnotateDeviceRegions/SplitHostDevice really
+    extract a device function, then compares the exact device signature.
     """
-    mod = _cpu_while_kernel_module()
-    mod = tl.transform.LayoutInference()(mod)
-    mod = tl.transform.LowerTileOp()(mod)
-    mod = tl.transform.AnnotateDeviceRegions()(mod)
-    mod = tl.transform.SplitHostDevice()(mod)
+    mod, target = _cpu_while_kernel_module(with_host=True)
+    with target:
+        mod = tl.transform.LayoutInference()(mod)
+        mod = tl.transform.LowerTileOp()(mod)
+        mod = tl.transform.AnnotateDeviceRegions()(mod)
+        mod = tl.transform.SplitHostDevice()(mod)
 
-    assert len(mod.functions) >= 1
+    host_func = None
+    device_func = None
     for gvar, func in mod.functions.items():
-        param_names = {_var_name(param) for param in func.params}
-        assert "v_thread" not in param_names, f"{gvar} gained a synthetic thread parameter"
-        assert "v_thread" not in _collect_var_names(func)
-        _assert_no_unexpected_free_vars(func)
+        if "kernel" in gvar.name_hint:
+            device_func = func
+        else:
+            host_func = func
+
+    assert host_func is not None, "expected the original host function"
+    assert device_func is not None, "expected SplitHostDevice to extract a device function"
+
+    # The device signature is exactly the two buffer parameters the kernel
+    # reads/writes — any leaked synthetic scalar would show up as an extra
+    # parameter here.
+    device_param_names = {_var_name(param) for param in device_func.params}
+    assert device_param_names == {"flag", "out"}, f"unexpected device ABI: {device_param_names}"
+    _assert_no_unexpected_free_vars(device_func)
+
+
+def test_cpu_legitimate_v_thread_param_is_preserved():
+    """A user variable named `v_thread` must survive lowering untouched.
+
+    The old name-based canonicalizer rewrote *any* same-named variable to 0
+    (see issue #2226). A legitimate scalar parameter with that name must keep
+    its identity and its uses through LayoutInference and LowerTileOp.
+    """
+
+    @T.prim_func
+    def main(v_thread: T.int32, out: T.Tensor((1,), "int32")):
+        with T.Kernel(1):
+            state = T.alloc_fragment((1,), "int32")
+            state[0] = v_thread
+            out[0] = state[0]
+
+    original_param = main.params[0]
+    mod = tvm.IRModule.from_expr(main)
+    target = _cpu_target()
+    mod = tvm.tirx.transform.BindTarget(target)(mod)
+    mod = tl.transform.MaterializeKernelLaunch(lower_thread_binding=False)(mod)
+    with target:
+        mod = tl.transform.LayoutInference()(mod)
+        mod = tl.transform.LowerTileOp()(mod)
+
+    func = mod["main"]
+    matching_params = [p for p in func.params if _var_name(p) == "v_thread"]
+    assert len(matching_params) == 1, "the legitimate v_thread parameter must remain"
+    assert matching_params[0].same_as(original_param)
+    body_refs = [var for var in _vars_of(func.body) if _var_name(var) == "v_thread"]
+    assert body_refs, "the body must still read the v_thread parameter"
+    assert all(var.same_as(original_param) for var in body_refs)
 
 
 if __name__ == "__main__":

--- a/testing/python/transform/test_tilelang_transform_lower_tile_op.py
+++ b/testing/python/transform/test_tilelang_transform_lower_tile_op.py
@@ -125,5 +125,97 @@ def test_lower_tile_op_preserves_ragged_parallel_padding_guard():
         tl.transform.LowerTileOp()(mod)
 
 
+def _cpu_while_kernel_module():
+    """The while + fragment kernel from issue #2202, on a CPU `c` target."""
+
+    @T.prim_func
+    def main(flag: T.Tensor((1,), "int32"), out: T.Tensor((1,), "int32")):
+        with T.Kernel(1):
+            state = T.alloc_fragment((1,), "int32")
+            state[0] = 0
+
+            with T.While(state[0] == 0):
+                state[0] = flag[0]
+
+            out[0] = state[0]
+
+    mod = tvm.IRModule.from_expr(main)
+    target = tvm.target.Target("c")
+    mod = tvm.tirx.transform.BindTarget(target)(mod)
+    mod = tl.transform.MaterializeKernelLaunch(lower_thread_binding=False)(mod)
+    return mod
+
+
+def _collect_var_names(func: tvm.tirx.PrimFunc):
+    names = set()
+
+    def _visit(node):
+        if isinstance(node, tvm.tirx.Var):
+            names.add(_var_name(node))
+
+    post_order_visit(func.body, _visit)
+    return names
+
+
+def _var_name(var) -> str:
+    if hasattr(var, "name_hint"):
+        return var.name_hint
+    if hasattr(var, "name"):
+        return var.name
+    return str(var).split(":")[0].strip()
+
+
+def _assert_no_unexpected_free_vars(func: tvm.tirx.PrimFunc):
+    """Every free var must come from the buffer_map; nothing synthetic may leak.
+
+    Right after LowerTileOp/SplitHostDevice the buffer data vars still appear
+    "undefined" to var-use analysis (they are declared via match_buffer and
+    lowered later), so the assertion filters them out and checks that no
+    *other* free variable — e.g. a synthetic thread placeholder — survives.
+    """
+    buffer_data_names = {_var_name(buffer.data) for buffer in func.buffer_map.values()}
+    unexpected = [var for var in tvm.tirx.analysis.undefined_vars(func.body, func.params) if _var_name(var) not in buffer_data_names]
+    assert not unexpected, f"unexpected free variables: {unexpected}"
+
+
+def test_lower_tile_op_cpu_no_synthetic_thread_var():
+    """CPU lowering must not materialize a synthetic thread placeholder.
+
+    Regression test for https://github.com/tile-ai/tilelang/issues/2226.
+    LayoutInference/LowerTileOp used to share a synthetic `v_thread` fallback
+    Var that could escape into later passes as a free variable. Thread-oriented
+    helpers must now receive constant 0 on CPU, so no synthetic thread Var may
+    appear in the lowered function or its annotations.
+    """
+    mod = _cpu_while_kernel_module()
+    mod = tl.transform.LayoutInference()(mod)
+    mod = tl.transform.LowerTileOp()(mod)
+
+    func = mod["main"]
+    assert "v_thread" not in _collect_var_names(func)
+    _assert_no_unexpected_free_vars(func)
+
+
+def test_lower_tile_op_cpu_split_host_device_abi_is_clean():
+    """SplitHostDevice must never see a synthetic CPU thread placeholder.
+
+    See https://github.com/tile-ai/tilelang/issues/2226: a leaked `v_thread`
+    would be picked up by SplitHostDevice's use-def analysis and become an
+    unexpected device ABI parameter.
+    """
+    mod = _cpu_while_kernel_module()
+    mod = tl.transform.LayoutInference()(mod)
+    mod = tl.transform.LowerTileOp()(mod)
+    mod = tl.transform.AnnotateDeviceRegions()(mod)
+    mod = tl.transform.SplitHostDevice()(mod)
+
+    assert len(mod.functions) >= 1
+    for gvar, func in mod.functions.items():
+        param_names = {_var_name(param) for param in func.params}
+        assert "v_thread" not in param_names, f"{gvar} gained a synthetic thread parameter"
+        assert "v_thread" not in _collect_var_names(func)
+        _assert_no_unexpected_free_vars(func)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/tilelang/cpu/op/gemm/gemm_scalar.py
+++ b/tilelang/cpu/op/gemm/gemm_scalar.py
@@ -21,7 +21,7 @@ class GemmScalar(GemmBase):
         layout_map: dict,
         target: Target,
         thread_bounds: Range,
-        thread_var: tirx.Var,
+        thread_index: tirx.PrimExpr,
         mbar_phase_expr: tirx.PrimExpr | None = None,
     ):
         M, N, K = self.M, self.N, self.K

--- a/tilelang/cuda/op/gemm/gemm_mma.py
+++ b/tilelang/cuda/op/gemm/gemm_mma.py
@@ -73,12 +73,12 @@ class GemmMMA(GemmBase):
         layout_map: dict,
         target: Target,
         thread_bounds: Range,
-        thread_var: tirx.Var,
+        thread_index: tirx.PrimExpr,
         mbar_phase_expr: tirx.PrimExpr | None = None,
     ):
         thread_nums = thread_bounds.extent
         # Emitter lane/warp math uses zero-based ids within the current thread bounds.
-        local_thread_var = thread_var - thread_bounds.min
+        local_thread_var = thread_index - thread_bounds.min
         mma_emitter = self._make_mma_emitter(target, thread_nums, thread_var=local_thread_var)
 
         a_dtype = self.a_dtype

--- a/tilelang/cuda/op/gemm/gemm_mma_sm70.py
+++ b/tilelang/cuda/op/gemm/gemm_mma_sm70.py
@@ -57,12 +57,12 @@ class GemmMMASm70(GemmBase):
         layout_map: dict,
         target: Target,
         thread_bounds: Range,
-        thread_var: tirx.Var,
+        thread_index: tirx.PrimExpr,
         mbar_phase_expr: tirx.PrimExpr | None = None,
     ):
         thread_nums = thread_bounds.extent
         # Emitter lane/warp math uses zero-based ids within the current thread bounds.
-        local_thread_var = thread_var - thread_bounds.min
+        local_thread_var = thread_index - thread_bounds.min
         m_warp, n_warp = self.policy.compute_warp_partition(self.M, self.N, thread_nums, target, GEMM_INST_MMA)
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)

--- a/tilelang/cuda/op/gemm/gemm_tcgen05.py
+++ b/tilelang/cuda/op/gemm/gemm_tcgen05.py
@@ -125,7 +125,7 @@ class GemmTCGEN5(GemmBase):
         layout_map: dict,
         target: Target,
         thread_bounds: Range,
-        thread_var: tirx.Var,
+        thread_index: tirx.PrimExpr,
         mbar_phase_expr: tirx.PrimExpr | None = None,
     ):
         """Lower the GEMM tile-op into a TIR prim_func containing TCGEN5MMA calls."""
@@ -156,7 +156,7 @@ class GemmTCGEN5(GemmBase):
             mma_emitter._assign_b_shared_layout(layout_map[self.B])
 
         if self.is_blockscaled:
-            return self._lower_blockscaled(mma_emitter, thread_bounds, thread_var, mbar_phase_expr)
+            return self._lower_blockscaled(mma_emitter, thread_bounds, thread_index, mbar_phase_expr)
 
         if not (self.is_gemm_ss() or self.is_gemm_ts()):
             raise ValueError(f"TCGEN5MMA supports gemm_ss and gemm_ts, got A scope {self.A.scope()}, B scope {self.B.scope()}")
@@ -208,7 +208,7 @@ class GemmTCGEN5(GemmBase):
 
         @T.prim_func
         def _gemm_ss_cond() -> None:
-            if cluster_cond and thread_var // 32 == thread_bounds.min // warp_size:
+            if cluster_cond and thread_index // 32 == thread_bounds.min // warp_size:
                 mma_emitter.tcgen05mma(A_shared, B_shared, C_local, mbarptr, clear_accum)
             if not self.is_tcgen05:
                 T.mbarrier_wait_parity(mbar, mbar_phase)
@@ -226,7 +226,7 @@ class GemmTCGEN5(GemmBase):
             else _Simplify(_gemm_ss_cond, inline_let=True)
         )
 
-    def _lower_blockscaled(self, mma_emitter, thread_bounds, thread_var, mbar_phase_expr: tirx.PrimExpr | None = None):
+    def _lower_blockscaled(self, mma_emitter, thread_bounds, thread_index, mbar_phase_expr: tirx.PrimExpr | None = None):
         """Lower block-scaled MXFP8 GEMM to TIR.
 
         Block-scaled GEMM follows explicit-async TCGEN5MMA semantics: the MMA
@@ -275,7 +275,7 @@ class GemmTCGEN5(GemmBase):
 
         @T.prim_func
         def _gemm_blockscaled_cond() -> None:
-            if cluster_cond and thread_var // 32 == thread_bounds.min // warp_size:
+            if cluster_cond and thread_index // 32 == thread_bounds.min // warp_size:
                 mma_emitter.tcgen05mma_blockscaled(
                     A_shared,
                     B_shared,

--- a/tilelang/cuda/op/gemm/gemm_wgmma.py
+++ b/tilelang/cuda/op/gemm/gemm_wgmma.py
@@ -89,12 +89,12 @@ class GemmWGMMA(GemmBase):
         layout_map: dict,
         target: Target,
         thread_bounds: Range,
-        thread_var: tirx.Var,
+        thread_index: tirx.PrimExpr,
         mbar_phase_expr: tirx.PrimExpr | None = None,
     ):
         thread_nums = thread_bounds.extent
         # Emitter lane/warp math uses zero-based ids within the current thread bounds.
-        local_thread_var = thread_var - thread_bounds.min
+        local_thread_var = thread_index - thread_bounds.min
         m_warp, n_warp = self.policy.compute_warp_partition(self.M, self.N, thread_nums, target, GEMM_INST_WGMMA)
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)

--- a/tilelang/cuda/op/gemm_sp/gemm_sp_mma.py
+++ b/tilelang/cuda/op/gemm_sp/gemm_sp_mma.py
@@ -59,10 +59,10 @@ class GemmSPMMA(GemmSPBase):
         else:
             raise ValueError(f"Unsupported gemm combination, A: {self.A.scope()}, B: {self.B.scope()}")
 
-    def lower(self, layout_map: dict, target: Target, thread_bounds: Range, thread_var: tirx.Var):
+    def lower(self, layout_map: dict, target: Target, thread_bounds: Range, thread_index: tirx.PrimExpr):
         thread_nums = thread_bounds.extent
         # Emitter lane/warp math uses zero-based ids within the current thread bounds.
-        local_thread_var = thread_var - thread_bounds.min
+        local_thread_var = thread_index - thread_bounds.min
         m_warp, n_warp = self.policy.compute_warp_partition(self.M, self.N, thread_nums, target, GEMM_SP_INST_MMA_SP)
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)

--- a/tilelang/cuda/op/gemm_sp/gemm_sp_wgmma.py
+++ b/tilelang/cuda/op/gemm_sp/gemm_sp_wgmma.py
@@ -75,12 +75,12 @@ class GemmSPWGMMA(GemmSPBase):
         layout_map: dict,
         target: Target,
         thread_bounds: Range,
-        thread_var: tirx.Var,
+        thread_index: tirx.PrimExpr,
         mbar_phase_expr: tirx.PrimExpr | None = None,
     ):
         thread_nums = thread_bounds.extent
         # Emitter lane/warp math uses zero-based ids within the current thread bounds.
-        local_thread_var = thread_var - thread_bounds.min
+        local_thread_var = thread_index - thread_bounds.min
         m_warp, n_warp = self.policy.compute_warp_partition(self.M, self.N, thread_nums, target, GEMM_SP_INST_WGMMA_SP)
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)

--- a/tilelang/metal/op/gemm/gemm_metal.py
+++ b/tilelang/metal/op/gemm/gemm_metal.py
@@ -21,7 +21,12 @@ class GemmMetal(GemmBase):
         return {}
 
     def lower(
-        self, layout_map: dict, target: Target, thread_bounds: Range, thread_var: tir.Var, mbar_phase_expr: tir.PrimExpr | None = None
+        self,
+        layout_map: dict,
+        target: Target,
+        thread_bounds: Range,
+        thread_index: tir.PrimExpr,
+        mbar_phase_expr: tir.PrimExpr | None = None,
     ):
         thread_nums = thread_bounds.extent
         m_warp, n_warp = self.policy.compute_warp_partition(self.M, self.N, thread_nums, target, GEMM_INST_METAL)
@@ -41,7 +46,7 @@ class GemmMetal(GemmBase):
             warp_row_tiles=warp_row_tiles,
             warp_col_tiles=warp_col_tiles,
             chunk=self.chunk,
-            thread_var=thread_var,
+            thread_var=thread_index,
         )
 
         a_dtype = self.a_dtype

--- a/tilelang/rocm/op/gemm/gemm_mfma.py
+++ b/tilelang/rocm/op/gemm/gemm_mfma.py
@@ -69,7 +69,7 @@ class GemmMFMA(GemmBase):
         layout_map: dict,
         target: Target,
         thread_bounds: Range,
-        thread_var: tirx.Var,
+        thread_index: tirx.PrimExpr,
         mbar_phase_expr: tirx.PrimExpr | None = None,
     ):
         thread_nums = thread_bounds.extent
@@ -87,7 +87,7 @@ class GemmMFMA(GemmBase):
             warp_row_tiles=warp_row_tiles,
             warp_col_tiles=warp_col_tiles,
             chunk=self.chunk,
-            thread_var=thread_var,
+            thread_var=thread_index,
             k_pack=self.k_pack,
             target=target,
         )

--- a/tilelang/rocm/op/gemm/gemm_wmma.py
+++ b/tilelang/rocm/op/gemm/gemm_wmma.py
@@ -71,10 +71,15 @@ class GemmWMMA(GemmBase):
             raise ValueError(f"Unsupported gemm combination, A: {self.A.scope()}, B: {self.B.scope()}")
 
     def lower(
-        self, layout_map: dict, target: Target, thread_bounds: Range, thread_var: tirx.Var, mbar_phase_expr: tirx.PrimExpr | None = None
+        self,
+        layout_map: dict,
+        target: Target,
+        thread_bounds: Range,
+        thread_index: tirx.PrimExpr,
+        mbar_phase_expr: tirx.PrimExpr | None = None,
     ):
         thread_nums = thread_bounds.extent
-        wmma_emitter = self._make_emitter(target, thread_nums, thread_var=thread_var)
+        wmma_emitter = self._make_emitter(target, thread_nums, thread_var=thread_index)
 
         block_K = wmma_emitter.chunk
         micro_size_k = wmma_emitter.micro_size_k

--- a/tilelang/tileop/gemm/__init__.py
+++ b/tilelang/tileop/gemm/__init__.py
@@ -21,11 +21,11 @@ def gemm_lower(
     layout_map,
     target: Target,
     thread_bounds: Range,
-    thread_var: tirx.Var,
+    thread_index: tirx.PrimExpr,
     mbar_phase_expr: tirx.PrimExpr,
 ):
     # We pass thread_bounds rather than thread_extents because tcgen5mma need to check this
-    stmt = gemm.lower(layout_map, target, thread_bounds, thread_var, mbar_phase_expr)
+    stmt = gemm.lower(layout_map, target, thread_bounds, thread_index, mbar_phase_expr)
     return stmt
 
 
@@ -129,14 +129,14 @@ class Gemm(Node, Scriptable):
         layout_map: dict,
         target: Target,
         thread_bounds: Range,
-        thread_var: tirx.Var,
+        thread_index: tirx.PrimExpr,
         mbar_phase_expr: tirx.PrimExpr,
     ):
         """Lower the GEMM operation to TIR statements based on target architecture."""
         thread_nums = thread_bounds.extent
         gemm_inst = self._select_gemm_instruction(thread_nums, target)
         impl_class = self._get_implementation_class(gemm_inst, target)
-        return impl_class(self).lower(layout_map, target, thread_bounds, thread_var, mbar_phase_expr)
+        return impl_class(self).lower(layout_map, target, thread_bounds, thread_index, mbar_phase_expr)
 
     def _select_gemm_instruction(self, thread_nums: int, target: Target) -> str:
         """Select the appropriate GEMM instruction key based on target and thread configuration.

--- a/tilelang/tileop/gemm/gemm_base.py
+++ b/tilelang/tileop/gemm/gemm_base.py
@@ -45,7 +45,7 @@ class GemmBase:
         layout_map: dict,
         target: Target,
         thread_bounds: Range,
-        thread_var: tirx.Var,
+        thread_index: tirx.PrimExpr,
         mbar_phase_expr: tirx.PrimExpr | None = None,
     ):
         raise NotImplementedError("lower is not implemented")

--- a/tilelang/tileop/gemm_sp/__init__.py
+++ b/tilelang/tileop/gemm_sp/__init__.py
@@ -49,8 +49,8 @@ class GemmSP(Node, Scriptable):
         return self.infer_layout(target, thread_nums)
 
     @tvm_ffi.register_global_func("tl.gemm_sp.lower")
-    def gemm_sp_lower(self, target: Target, layout_map: dict, thread_bounds: Range, thread_var: tirx.Var):
-        stmt = self.lower(target, layout_map, thread_bounds, thread_var)
+    def gemm_sp_lower(self, target: Target, layout_map: dict, thread_bounds: Range, thread_index: tirx.PrimExpr):
+        stmt = self.lower(target, layout_map, thread_bounds, thread_index)
         return stmt
 
     def infer_layout(self, target: Target, thread_nums: int):
@@ -58,11 +58,11 @@ class GemmSP(Node, Scriptable):
         impl_class = self._get_implementation_class(gemm_inst, target)
         return impl_class(self).infer_layout(target, thread_nums)
 
-    def lower(self, target: Target, layout_map: dict, thread_bounds: Range, thread_var: tirx.Var):
+    def lower(self, target: Target, layout_map: dict, thread_bounds: Range, thread_index: tirx.PrimExpr):
         thread_nums = thread_bounds.extent
         gemm_inst = self._select_gemm_instruction(thread_nums, target)
         impl_class = self._get_implementation_class(gemm_inst, target)
-        return impl_class(self).lower(layout_map, target, thread_bounds, thread_var)
+        return impl_class(self).lower(layout_map, target, thread_bounds, thread_index)
 
     def _select_gemm_instruction(self, thread_nums: int, target: Target) -> str:
         return str(_ffi_api.GemmSPGetGemmInstructionKey(self, int(thread_nums), target))

--- a/tilelang/tileop/gemm_sp/gemm_sp_base.py
+++ b/tilelang/tileop/gemm_sp/gemm_sp_base.py
@@ -15,7 +15,7 @@ class GemmSPBase:
     def infer_layout(self, target: Target, thread_nums: int):
         raise NotImplementedError("infer_layout is not implemented")
 
-    def lower(self, layout_map: dict, target: Target, thread_bounds: Range, thread_var: tirx.Var):
+    def lower(self, layout_map: dict, target: Target, thread_bounds: Range, thread_index: tirx.PrimExpr):
         raise NotImplementedError("lower is not implemented")
 
     def is_gemm_ss(self) -> bool:

--- a/tilelang/tileop/gemm_sp/gemm_sp_wgmma.py
+++ b/tilelang/tileop/gemm_sp/gemm_sp_wgmma.py
@@ -75,12 +75,12 @@ class GemmSPWGMMA(GemmSPBase):
         layout_map: dict,
         target: Target,
         thread_bounds: Range,
-        thread_var: tirx.Var,
+        thread_index: tirx.PrimExpr,
         mbar_phase_expr: tirx.PrimExpr | None = None,
     ):
         thread_nums = thread_bounds.extent
         # Emitter lane/warp math uses zero-based ids within the current thread bounds.
-        local_thread_var = thread_var - thread_bounds.min
+        local_thread_var = thread_index - thread_bounds.min
         m_warp, n_warp = self.policy.compute_warp_partition(self.M, self.N, thread_nums, target, GEMM_SP_INST_WGMMA_SP)
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)


### PR DESCRIPTION
Fix #2226 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Replaced the synthetic CPU `v_thread` with a logical thread index expression, using constant `0` when no real thread binding exists.
- Propagated `thread_index` through loop partitioning, predicates, layout inference, and backend/GEMM lowerings.
- Removed CPU placeholder cleanup and normalized thread indices relative to thread bounds.
- Added regression tests for CPU lowering, clean host/device ABIs, real GPU bindings, and legitimate `v_thread` parameters.

## C++ style / lint notes

- No C++ style documentation or CI/lint files are changed.
- The C++ API Style Audit remains warning-only; any advisory findings should be considered separately from correctness, build, and test issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->