### PR TITLE
[BugFix] Reject contracting shared-buffer layouts in T.annotate_layout

### DIFF
--- a/src/layout/cute_layout.cc
+++ b/src/layout/cute_layout.cc
@@ -5,6 +5,7 @@
 
 #include "cute_layout.h"
 #include "layout.h"
+#include "utils.h"
 
 #include "support/check.h"
 #include <algorithm>
@@ -1114,68 +1115,6 @@ ComposedLayout ComposedLayout::Recast(int old_bits, int new_bits) const {
 
 namespace {
 
-// Fully evaluate a PrimExpr to an integer constant. The expression must contain
-// only integer constants and the operators a swizzled layout is built from:
-// +, -, *, FloorDiv, FloorMod, and the bitwise/shift builtins. arith::Analyzer
-// does not constant-fold bitwise ops (e.g. T.bitwise_xor) even when both
-// operands are constant, so we evaluate them ourselves. Returns std::nullopt if
-// any node is not a recognized constant-foldable form.
-std::optional<int64_t> EvalConstExpr(const PrimExpr &e) {
-  if (auto c = as_const_int(e))
-    return *c;
-  // Floored division/modulo (rounds toward -inf), matching FloorDiv/FloorMod.
-  auto fdiv = [](int64_t a, int64_t b) {
-    int64_t q = a / b, r = a % b;
-    return q - ((r != 0) && ((r < 0) != (b < 0)) ? 1 : 0);
-  };
-  auto fmod = [&](int64_t a, int64_t b) { return a - fdiv(a, b) * b; };
-  if (const auto *op = e.as<AddNode>()) {
-    auto a = EvalConstExpr(op->a), b = EvalConstExpr(op->b);
-    if (a && b)
-      return *a + *b;
-  } else if (const auto *op = e.as<SubNode>()) {
-    auto a = EvalConstExpr(op->a), b = EvalConstExpr(op->b);
-    if (a && b)
-      return *a - *b;
-  } else if (const auto *op = e.as<MulNode>()) {
-    auto a = EvalConstExpr(op->a), b = EvalConstExpr(op->b);
-    if (a && b)
-      return *a * *b;
-  } else if (const auto *op = e.as<FloorDivNode>()) {
-    auto a = EvalConstExpr(op->a), b = EvalConstExpr(op->b);
-    if (a && b && *b != 0)
-      return fdiv(*a, *b);
-  } else if (const auto *op = e.as<FloorModNode>()) {
-    auto a = EvalConstExpr(op->a), b = EvalConstExpr(op->b);
-    if (a && b && *b != 0)
-      return fmod(*a, *b);
-  } else if (const auto *op = e.as<CallNode>()) {
-    if (op->args.size() == 2) {
-      auto a = EvalConstExpr(op->args[0]), b = EvalConstExpr(op->args[1]);
-      if (a && b) {
-        if (op->op.same_as(builtin::bitwise_xor()))
-          return *a ^ *b;
-        if (op->op.same_as(builtin::bitwise_and()))
-          return *a & *b;
-        if (op->op.same_as(builtin::bitwise_or()))
-          return *a | *b;
-        if (op->op.same_as(builtin::shift_left())) {
-          ICHECK(*b >= 0 && *b < 64);
-          return *a << *b;
-        }
-        if (op->op.same_as(builtin::shift_right())) {
-          ICHECK(*b >= 0 && *b < 64);
-          return *a >> *b;
-        }
-      }
-    } else if (op->args.size() == 1 && op->op.same_as(builtin::bitwise_not())) {
-      if (auto a = EvalConstExpr(op->args[0]))
-        return ~*a;
-    }
-  }
-  return std::nullopt;
-}
-
 // When processing shared tensor layout, all the shapes and strides are int32_t.
 // Also, we need to make sure not to mix with int64_t, because otherwise there
 // would be a lot of conversion nodes that prevent the analyzer from cancelling
@@ -1228,7 +1167,7 @@ public:
     int32_t addr = 0;
     for (size_t d = 0; d < forward_index_.size(); ++d) {
       PrimExpr e = Substitute(forward_index_[d], vmap);
-      std::optional<int64_t> val = EvalConstExpr(e);
+      std::optional<int64_t> val = EvaluateConstantInteger(e);
       if (!val)
         return std::nullopt;
       addr += static_cast<int32_t>(*val) * out_strides_[d];

--- a/src/layout/layout.cc
+++ b/src/layout/layout.cc
@@ -4,6 +4,16 @@
  */
 
 #include "layout.h"
+
+#include <cstdint>
+#include <functional>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
 #include "support/check.h"
 #include <tvm/ffi/extra/structural_equal.h>
 #include <tvm/runtime/logging.h>
@@ -313,6 +323,178 @@ Map<Var, Range> FragmentNode::GetVarMap() const {
   map.Set(ReplicationPlaceholder(), {0, ReplicateExtent()});
   return map;
 }
+
+namespace {
+
+constexpr int64_t kMaxExactInjectivityDomain = 1 << 18;
+
+struct IntTupleHash {
+  size_t operator()(const std::vector<int64_t> &values) const {
+    size_t seed = values.size();
+    for (int64_t value : values) {
+      seed ^=
+          std::hash<int64_t>{}(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    }
+    return seed;
+  }
+};
+
+std::string FormatIntTuple(const std::vector<int64_t> &values) {
+  std::ostringstream os;
+  os << '[';
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (i != 0) {
+      os << ", ";
+    }
+    os << values[i];
+  }
+  os << ']';
+  return os.str();
+}
+
+enum class ExactInjectivityStatus { kInjective, kNonInjective, kUnknown };
+
+struct ExactInjectivityResult {
+  ExactInjectivityStatus status;
+  std::string detail;
+};
+
+ExactInjectivityResult
+CheckStaticInjectivity(const Array<PrimExpr> &forward_indices,
+                       const Map<Var, Range> &input_iters) {
+  arith::Analyzer analyzer;
+  std::vector<Var> vars;
+  std::vector<int64_t> mins;
+  std::vector<int64_t> extents;
+  int64_t domain_size = 1;
+
+  for (const auto &[var, range] : input_iters) {
+    PrimExpr simplified_min = analyzer.Simplify(range->min);
+    PrimExpr simplified_extent = analyzer.Simplify(range->extent);
+    const int64_t *min = as_const_int(simplified_min);
+    const int64_t *extent = as_const_int(simplified_extent);
+    if (min == nullptr || extent == nullptr) {
+      return {ExactInjectivityStatus::kUnknown,
+              "the logical input domain is symbolic"};
+    }
+    if (*extent < 0) {
+      return {ExactInjectivityStatus::kUnknown,
+              "the logical input domain has a negative extent"};
+    }
+    if (*extent == 0) {
+      return {ExactInjectivityStatus::kInjective, ""};
+    }
+    if (*extent > kMaxExactInjectivityDomain / domain_size) {
+      return {ExactInjectivityStatus::kUnknown,
+              "the logical input domain exceeds the exact-check limit of " +
+                  std::to_string(kMaxExactInjectivityDomain) + " points"};
+    }
+    domain_size *= *extent;
+    vars.push_back(var);
+    mins.push_back(*min);
+    extents.push_back(*extent);
+  }
+
+  using Coordinate = std::vector<int64_t>;
+  std::unordered_map<Coordinate, Coordinate, IntTupleHash> first_preimage;
+  first_preimage.reserve(static_cast<size_t>(domain_size));
+
+  for (int64_t linear = 0; linear < domain_size; ++linear) {
+    int64_t residual = linear;
+    Coordinate input(vars.size());
+    Map<Var, PrimExpr> substitution;
+    for (size_t rev = vars.size(); rev > 0; --rev) {
+      size_t i = rev - 1;
+      input[i] = mins[i] + residual % extents[i];
+      residual /= extents[i];
+      substitution.Set(vars[i], IntImm(vars[i]->dtype, input[i]));
+    }
+
+    Coordinate output;
+    output.reserve(forward_indices.size());
+    for (const PrimExpr &index : forward_indices) {
+      PrimExpr value = analyzer.Simplify(Substitute(index, substitution));
+      std::optional<int64_t> constant = EvaluateConstantInteger(value);
+      if (!constant) {
+        return {ExactInjectivityStatus::kUnknown,
+                "the forward map could not be evaluated exactly at logical "
+                "coordinates " +
+                    FormatIntTuple(input)};
+      }
+      output.push_back(*constant);
+    }
+
+    auto [it, inserted] = first_preimage.emplace(output, input);
+    if (!inserted) {
+      return {ExactInjectivityStatus::kNonInjective,
+              "logical coordinates " + FormatIntTuple(it->second) + " and " +
+                  FormatIntTuple(input) + " both map to physical coordinates " +
+                  FormatIntTuple(output)};
+    }
+  }
+  return {ExactInjectivityStatus::kInjective, ""};
+}
+
+bool CanProveInjective(const Array<PrimExpr> &forward_indices,
+                       const Map<Var, Range> &input_iters) {
+  arith::Analyzer analyzer;
+  Map<Var, PrimExpr> other_substitution;
+  PrimExpr same_input = Bool(true);
+  for (const auto &[var, range] : input_iters) {
+    Var other(var->name_hint + "<OTHER>", var->dtype);
+    analyzer.Bind(var, range);
+    analyzer.Bind(other, range);
+    other_substitution.Set(var, other);
+    same_input = And(same_input, EQ(var, other));
+  }
+
+  PrimExpr same_output = Bool(true);
+  for (const PrimExpr &index : forward_indices) {
+    same_output =
+        And(same_output, EQ(index, Substitute(index, other_substitution)));
+  }
+  auto exit_constraint = analyzer.EnterConstraint(same_output);
+  bool injective = analyzer.CanProve(same_input);
+  exit_constraint();
+  return injective;
+}
+
+arith::IterMapResult MakeInjectivityError(const std::string &message) {
+  arith::IterMapResult result;
+  result->errors.push_back(message);
+  return result;
+}
+
+arith::IterMapResult
+DetectInjectiveMapping(const Array<PrimExpr> &forward_indices,
+                       const Map<Var, Range> &input_iters,
+                       bool require_padding_guard) {
+  if (!require_padding_guard) {
+    arith::Analyzer analyzer;
+    arith::IterMapResult iter_map =
+        arith::DetectIterMap(forward_indices, input_iters, 1,
+                             arith::IterMapLevel::Bijective, &analyzer);
+    if (iter_map->errors.empty()) {
+      return iter_map;
+    }
+  }
+
+  ExactInjectivityResult exact =
+      CheckStaticInjectivity(forward_indices, input_iters);
+  if (exact.status == ExactInjectivityStatus::kInjective) {
+    return arith::IterMapResult();
+  }
+  if (exact.status == ExactInjectivityStatus::kNonInjective) {
+    return MakeInjectivityError(exact.detail);
+  }
+  if (CanProveInjective(forward_indices, input_iters)) {
+    return arith::IterMapResult();
+  }
+  return MakeInjectivityError("injectivity could not be proven: " +
+                              exact.detail);
+}
+
+} // namespace
 
 LayoutNode::LayoutNode(Array<PrimExpr> input_size,
                        Array<PrimExpr> forward_index) {
@@ -856,52 +1038,18 @@ bool FragmentNode::IsCompletedReplicated() const {
 }
 
 arith::IterMapResult
+LayoutNode::DetectInjective(bool require_padding_guard) const {
+  return DetectInjectiveMapping(forward_index_, GetVarMap(),
+                                require_padding_guard);
+}
+
+arith::IterMapResult
 FragmentNode::DetectInjective(bool require_padding_guard) const {
-  // To check that the forward map is injective, reverse it and verify that the
-  // recovered coordinates remain independent. require_padding_guard is only
-  // used by generated full-block loop partitions whose mapping is known
-  // injective but whose padded domain is rejected by stricter iter-map checks.
-  arith::Analyzer analyzer;
-  // Build a flat indices array: [forward_thread_, forward_index_[...]]
-  Array<PrimExpr> indices;
-  indices.push_back(forward_thread_);
-  for (const auto &e : forward_index_) {
-    indices.push_back(e);
-  }
-
-  // Mirror Layout::InverseWithLevel(): if any participating shape is
-  // symbolic, relax to NoCheck and rely on runtime guards elsewhere.
-  auto collect_symbolic = [&](const Array<PrimExpr> &shape) {
-    Array<PrimExpr> symbolic_dims;
-    for (const auto &dim : shape) {
-      if (!as_const_int(dim)) {
-        symbolic_dims.push_back(dim);
-      }
-    }
-    return symbolic_dims;
-  };
-
-  Array<PrimExpr> symbolic_dims = collect_symbolic(InputShape());
-  Array<PrimExpr> output_shape = OutputShape();
-  symbolic_dims.insert(symbolic_dims.end(), output_shape.begin(),
-                       output_shape.end());
-  // Also consider replicate size for fragments
-  if (!as_const_int(ReplicateExtent())) {
-    symbolic_dims.push_back(ReplicateExtent());
-  }
-  symbolic_dims = collect_symbolic(symbolic_dims);
-
-  bool is_static_shape = symbolic_dims.empty();
-  auto level = (is_static_shape && !require_padding_guard)
-                   ? arith::IterMapLevel::Bijective
-                   : arith::IterMapLevel::NoCheck;
-  if (!is_static_shape) {
-    DLOG(WARNING)
-        << "Fragment::DetectInjective on symbolic layout, falling back to "
-        << "NoCheck; symbolic dims: " << symbolic_dims;
-  }
-
-  return arith::DetectIterMap(indices, GetVarMap(), 1, level, &analyzer);
+  // A fragment's physical identity includes its owning thread as well as its
+  // per-thread indices. The replication coordinate is part of GetVarMap().
+  Array<PrimExpr> indices{forward_thread_};
+  indices.insert(indices.end(), forward_index_.begin(), forward_index_.end());
+  return DetectInjectiveMapping(indices, GetVarMap(), require_padding_guard);
 }
 
 PrimExpr FragmentNode::ThreadExtent() const {

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -102,6 +102,16 @@ public:
   virtual std::pair<Layout, arith::IterMapLevel>
   InverseWithLevel(bool require_padding_guard = false) const;
 
+  /*!
+   * \brief Verify that distinct logical coordinates map to distinct physical
+   * coordinates.
+   *
+   * The returned errors array is empty on success. Exact fallback checks may
+   * succeed without populating the normalized iter-map indices.
+   */
+  virtual arith::IterMapResult
+  DetectInjective(bool require_padding_guard = false) const;
+
   virtual std::string DebugOutput() const;
 
   virtual bool IsEqual(const LayoutNode *other, bool skip_index = false) const;

--- a/src/layout/utils.cc
+++ b/src/layout/utils.cc
@@ -21,6 +21,84 @@ using namespace tirx;
 using namespace ffi;
 using namespace arith;
 
+std::optional<int64_t> EvaluateConstantInteger(const PrimExpr &expr) {
+  if (const int64_t *constant = as_const_int(expr)) {
+    return *constant;
+  }
+
+  // Floored division/modulo (rounds toward -inf), matching FloorDiv/FloorMod.
+  auto floor_div = [](int64_t lhs, int64_t rhs) {
+    int64_t quotient = lhs / rhs;
+    int64_t remainder = lhs % rhs;
+    return quotient -
+           ((remainder != 0) && ((remainder < 0) != (rhs < 0)) ? 1 : 0);
+  };
+  auto floor_mod = [&](int64_t lhs, int64_t rhs) {
+    return lhs - floor_div(lhs, rhs) * rhs;
+  };
+
+  if (const auto *op = expr.as<AddNode>()) {
+    auto lhs = EvaluateConstantInteger(op->a);
+    auto rhs = EvaluateConstantInteger(op->b);
+    if (lhs && rhs) {
+      return *lhs + *rhs;
+    }
+  } else if (const auto *op = expr.as<SubNode>()) {
+    auto lhs = EvaluateConstantInteger(op->a);
+    auto rhs = EvaluateConstantInteger(op->b);
+    if (lhs && rhs) {
+      return *lhs - *rhs;
+    }
+  } else if (const auto *op = expr.as<MulNode>()) {
+    auto lhs = EvaluateConstantInteger(op->a);
+    auto rhs = EvaluateConstantInteger(op->b);
+    if (lhs && rhs) {
+      return *lhs * *rhs;
+    }
+  } else if (const auto *op = expr.as<FloorDivNode>()) {
+    auto lhs = EvaluateConstantInteger(op->a);
+    auto rhs = EvaluateConstantInteger(op->b);
+    if (lhs && rhs && *rhs != 0) {
+      return floor_div(*lhs, *rhs);
+    }
+  } else if (const auto *op = expr.as<FloorModNode>()) {
+    auto lhs = EvaluateConstantInteger(op->a);
+    auto rhs = EvaluateConstantInteger(op->b);
+    if (lhs && rhs && *rhs != 0) {
+      return floor_mod(*lhs, *rhs);
+    }
+  } else if (const auto *op = expr.as<CallNode>()) {
+    if (op->args.size() == 2) {
+      auto lhs = EvaluateConstantInteger(op->args[0]);
+      auto rhs = EvaluateConstantInteger(op->args[1]);
+      if (lhs && rhs) {
+        if (op->op.same_as(builtin::bitwise_xor())) {
+          return *lhs ^ *rhs;
+        }
+        if (op->op.same_as(builtin::bitwise_and())) {
+          return *lhs & *rhs;
+        }
+        if (op->op.same_as(builtin::bitwise_or())) {
+          return *lhs | *rhs;
+        }
+        if (op->op.same_as(builtin::shift_left())) {
+          ICHECK(*rhs >= 0 && *rhs < 64);
+          return *lhs << *rhs;
+        }
+        if (op->op.same_as(builtin::shift_right())) {
+          ICHECK(*rhs >= 0 && *rhs < 64);
+          return *lhs >> *rhs;
+        }
+      }
+    } else if (op->args.size() == 1 && op->op.same_as(builtin::bitwise_not())) {
+      if (auto value = EvaluateConstantInteger(op->args[0])) {
+        return ~*value;
+      }
+    }
+  }
+  return std::nullopt;
+}
+
 bool CanProveDivisible(const PrimExpr &lhs, const PrimExpr &rhs) {
   const auto *clhs = lhs.as<IntImmNode>();
   const auto *crhs = rhs.as<IntImmNode>();

--- a/src/layout/utils.h
+++ b/src/layout/utils.h
@@ -7,6 +7,9 @@
 #ifndef TVM_TL_LAYOUT_UTILS_H_
 #define TVM_TL_LAYOUT_UTILS_H_
 
+#include <cstdint>
+#include <optional>
+
 #include "support/check.h"
 #include <tvm/arith/iter_affine_map.h>
 
@@ -26,6 +29,16 @@ public:
 private:
   std::string msg_;
 };
+
+/*!
+ * \brief Fully evaluate a constant integer expression used by a layout.
+ *
+ * In addition to ordinary arithmetic, this handles the bitwise and shift
+ * builtins that arith::Analyzer does not currently fold for constant operands.
+ *
+ * \return The integer value, or std::nullopt for an unsupported expression.
+ */
+std::optional<int64_t> EvaluateConstantInteger(const PrimExpr &expr);
 
 /*!
  * \brief Collect the IterSplit that is not used in expr.

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -786,14 +786,25 @@ private:
           bool shapes_equal =
               ShapesEqual(layout->InputShape(), buffer->shape, &analyzer_);
 
-          if (shapes_equal) {
-            annotated_layout_map_.Set(buffer, layout);
-          } else {
-            auto reshaped_layout =
-                layout->Reshape(buffer->shape, &analyzer_, Integer(anchor_bits),
-                                Integer(GetElementStorageBits(buffer->dtype)));
-            annotated_layout_map_.Set(buffer, reshaped_layout);
+          Layout resolved_layout =
+              shapes_equal
+                  ? layout
+                  : layout->Reshape(
+                        buffer->shape, &analyzer_, Integer(anchor_bits),
+                        Integer(GetElementStorageBits(buffer->dtype)));
+          if (IsSharedBuffer(buffer)) {
+            arith::IterMapResult injectivity =
+                resolved_layout->DetectInjective();
+            if (!injectivity->errors.empty()) {
+              TVM_FFI_THROW(ValueError)
+                  << "Invalid layout for shared buffer `" << buffer->name
+                  << "`: the forward map must be injective. Details: "
+                  << injectivity->errors
+                  << ". Layout: " << resolved_layout->DebugOutput()
+                  << ". Check the layout passed to T.annotate_layout.";
+            }
           }
+          annotated_layout_map_.Set(buffer, resolved_layout);
         }
       }
     }

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -78,6 +78,30 @@ static Buffer makeBufferWithLayout(const Buffer &buffer, const Layout &layout,
                     << layout_shape[i];
       layout_extent *= shape->value;
     }
+    // A forward map whose codomain is smaller than its domain is provably
+    // non-injective (pigeonhole): distinct logical elements would alias the
+    // same physical slot. Reject it here; otherwise the replication branch
+    // below would misread the shrunken codomain as a replicate extent and
+    // rewrite the buffer to a higher rank, crashing later on an unrelated
+    // BufferStore rank ICHECK.
+    int64_t layout_input_extent = 1;
+    bool layout_input_is_static = true;
+    for (const auto &dim : layout->InputShape()) {
+      const auto *imm = dim.as<IntImmNode>();
+      if (!imm) {
+        layout_input_is_static = false;
+        break;
+      }
+      layout_input_extent *= imm->value;
+    }
+    if (layout_input_is_static && layout_extent < layout_input_extent) {
+      TVM_FFI_THROW(ValueError)
+          << "Invalid layout for shared buffer `" << buffer->name
+          << "`: the forward map must be injective, but it maps "
+          << layout_input_extent << " logical elements into only "
+          << layout_extent
+          << " physical slots. Check the layout passed to T.annotate_layout.";
+    }
     replicate_extent = buffer_extent / layout_extent;
     if (replicate_extent > 1) {
       output_shape.insert(output_shape.begin(), replicate_extent);

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -78,30 +78,6 @@ static Buffer makeBufferWithLayout(const Buffer &buffer, const Layout &layout,
                     << layout_shape[i];
       layout_extent *= shape->value;
     }
-    // A forward map whose codomain is smaller than its domain is provably
-    // non-injective (pigeonhole): distinct logical elements would alias the
-    // same physical slot. Reject it here; otherwise the replication branch
-    // below would misread the shrunken codomain as a replicate extent and
-    // rewrite the buffer to a higher rank, crashing later on an unrelated
-    // BufferStore rank ICHECK.
-    int64_t layout_input_extent = 1;
-    bool layout_input_is_static = true;
-    for (const auto &dim : layout->InputShape()) {
-      const auto *imm = dim.as<IntImmNode>();
-      if (!imm) {
-        layout_input_is_static = false;
-        break;
-      }
-      layout_input_extent *= imm->value;
-    }
-    if (layout_input_is_static && layout_extent < layout_input_extent) {
-      TVM_FFI_THROW(ValueError)
-          << "Invalid layout for shared buffer `" << buffer->name
-          << "`: the forward map must be injective, but it maps "
-          << layout_input_extent << " logical elements into only "
-          << layout_extent
-          << " physical slots. Check the layout passed to T.annotate_layout.";
-    }
     replicate_extent = buffer_extent / layout_extent;
     if (replicate_extent > 1) {
       output_shape.insert(output_shape.begin(), replicate_extent);

--- a/testing/python/issue/test_tilelang_issue_2632.py
+++ b/testing/python/issue/test_tilelang_issue_2632.py
@@ -1,16 +1,10 @@
 """Regression test for GitHub issue #2632.
 
-A contracting (many-to-one) forward map passed to ``T.annotate_layout`` on a
-shared buffer used to be misread by ``makeBufferWithLayout`` as a replication
-factor: the buffer was rewritten to a higher rank and compilation aborted on an
-unrelated ``BufferStore`` rank ICHECK (``2 vs. 1``). It must instead be
-rejected with a ``ValueError`` naming the buffer and the non-injectivity.
-
-Note: the guard is a pigeonhole check (codomain extent < domain extent). It
-covers every layout that can reach the broken replication reinterpretation;
-non-injective maps whose output bounding box is not smaller than the domain
-(e.g. ``lambda i: (i % 64) * 4``) do not crash there and are out of scope
-for this fix.
+A many-to-one forward map passed to ``T.annotate_layout`` on a shared buffer
+can either crash during buffer remapping or silently alias distinct logical
+elements. It must instead be rejected with a ``ValueError`` naming the buffer
+and the non-injectivity, including when its sparse output bounding box is larger
+than the logical input domain.
 """
 
 import pytest
@@ -23,7 +17,7 @@ from tilelang.layout import Layout
 
 N = 128
 
-REJECT_MATCH = r"shared buffer `\w+`.*must be injective"
+REJECT_MATCH = r"shared buffer `[^`]*`.*must be injective.*both map to physical coordinates"
 
 
 def _roundtrip_kernel(fwd):
@@ -47,10 +41,11 @@ def _roundtrip_kernel(fwd):
     [
         pytest.param(lambda i: i % 64, id="mod64-2-to-1"),
         pytest.param(lambda i: i * 0, id="zero-N-to-1"),
+        pytest.param(lambda i: (i % 64) * 4, id="mod64-times4-padded-2-to-1"),
     ],
 )
-def test_contracting_shared_layout_rejected(fwd):
-    """A contracting many-to-one map must be a clean ValueError, not an ICE."""
+def test_noninjective_shared_layout_rejected(fwd):
+    """Every many-to-one map must be a clean ValueError, not an ICE or alias."""
     with pytest.raises(ValueError, match=REJECT_MATCH):
         tilelang.compile(_roundtrip_kernel(fwd), out_idx=[1], target="cuda")
 

--- a/testing/python/issue/test_tilelang_issue_2632.py
+++ b/testing/python/issue/test_tilelang_issue_2632.py
@@ -1,0 +1,76 @@
+"""Regression test for GitHub issue #2632.
+
+A contracting (many-to-one) forward map passed to ``T.annotate_layout`` on a
+shared buffer used to be misread by ``makeBufferWithLayout`` as a replication
+factor: the buffer was rewritten to a higher rank and compilation aborted on an
+unrelated ``BufferStore`` rank ICHECK (``2 vs. 1``). It must instead be
+rejected with a ``ValueError`` naming the buffer and the non-injectivity.
+
+Note: the guard is a pigeonhole check (codomain extent < domain extent). It
+covers every layout that can reach the broken replication reinterpretation;
+non-injective maps whose output bounding box is not smaller than the domain
+(e.g. ``lambda i: (i % 64) * 4``) do not crash there and are out of scope
+for this fix.
+"""
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.layout import Layout
+
+N = 128
+
+REJECT_MATCH = r"shared buffer `\w+`.*must be injective"
+
+
+def _roundtrip_kernel(fwd):
+
+    @T.prim_func
+    def main(A: T.Tensor((N,), "int32"), Out: T.Tensor((N,), "int32")):
+        with T.Kernel(1, threads=N):
+            s = T.alloc_shared((N,), "int32")
+            T.annotate_layout({s: Layout((N,), fwd)})
+            for i in T.Parallel(N):
+                s[i] = A[i]
+            for i in T.Parallel(N):
+                Out[i] = s[i]
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize(
+    "fwd",
+    [
+        pytest.param(lambda i: i % 64, id="mod64-2-to-1"),
+        pytest.param(lambda i: i * 0, id="zero-N-to-1"),
+    ],
+)
+def test_contracting_shared_layout_rejected(fwd):
+    """A contracting many-to-one map must be a clean ValueError, not an ICE."""
+    with pytest.raises(ValueError, match=REJECT_MATCH):
+        tilelang.compile(_roundtrip_kernel(fwd), out_idx=[1], target="cuda")
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize(
+    "fwd",
+    [
+        pytest.param(lambda i: i, id="identity"),
+        pytest.param(lambda i: i ^ 1, id="xor-pair-swap"),
+        pytest.param(lambda i: i * 2, id="grow-i-times-2"),
+        pytest.param(lambda i: i + 10, id="grow-i-plus-10"),
+    ],
+)
+def test_injective_shared_layout_still_compiles_and_runs(fwd):
+    """Injective maps (including codomain-growing ones) must keep working."""
+    kernel = tilelang.compile(_roundtrip_kernel(fwd), out_idx=[1], target="cuda")
+    A = torch.arange(N, dtype=torch.int32, device="cuda")
+    torch.testing.assert_close(kernel(A), A)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

`T.annotate_layout` did not reject a contracting (many-to-one) forward map on a shared buffer. When the layout output extent was smaller than its input extent, `makeBufferWithLayout` misread the smaller output extent as a replication factor, rewrote the 1-D buffer into a 2-D buffer, and eventually aborted in the TVM `BufferStore` constructor with an unrelated dimensionality ICHECK (`2 vs. 1`) that named neither `annotate_layout` nor the non-injective map.

## Fix

Add a pigeonhole check in `makeBufferWithLayout` before the replication branch. For a shared buffer whose layout has static shapes, if the layout output extent is smaller than its input extent, the map cannot be injective, so raise a `ValueError` that names the buffer and reports both extents. Identity, permutation, and output-growing maps are unchanged.

The check intentionally targets contracting maps; general injectivity analysis for maps with a larger output bounding box, such as `(i % 64) * 4`, is outside the scope of this change.

## Tests

Added `testing/python/issue/test_tilelang_issue_2632.py`:

* Rejects the contracting maps from the issue (`i % 64` and `i * 0`).
* Confirms that identity, `i ^ 1`, `i * 2`, and `i + 10` still compile and round-trip exactly.

Also ran the related `lower_tile_op` and `layout_inference` transform suites, as well as `pre-commit`.

Fixes #2632


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Rejects non-injective shared-buffer `T.annotate_layout` mappings with clear `ValueError` diagnostics instead of triggering lowering ICHECKs.
- Adds symbolic and exact static-domain injectivity checks for layouts and fragments, including constant-expression evaluation support.
- Validates layouts after reshaping while preserving valid identity, permutation, padded, and output-growing mappings.
- Adds CUDA regression tests for rejecting `i % 64`/`i * 0` and for successful injective mappings.

## C++ style / lint notes

- The PR changes C++ layout APIs and implementation but does not modify `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) remains relevant; no blocking style or correctness issues are reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->