### PR TITLE
[BugFix] Fix HIP predicated dword copy zero fill

### DIFF
--- a/src/tl_templates/hip/copy.h
+++ b/src/tl_templates/hip/copy.h
@@ -133,7 +133,7 @@ TL_DEVICE void cp_async_gs_conditional(void *lds_base_ptr,
                                     threadIdx.x),
           threadIdx.x * N /*assume 4 bytes*/);
     } else {
-      *(uint4 *)lds_base_ptr = make_uint4(0, 0, 0, 0);
+      *(u32 *)lds_base_ptr = 0;
     }
   }
 }

--- a/testing/python/amd/test_tilelang_hip_codegen.py
+++ b/testing/python/amd/test_tilelang_hip_codegen.py
@@ -1,7 +1,7 @@
 """
 Regression tests for HIP/AMD codegen fixes in TileLang.
 
-Covers seven bug fixes across five source files:
+Covers nine HIP/AMD codegen and runtime bug fixes:
 
   Fix 1 (reduce.h)            warp_reduce 5-step butterfly with width=32
   Fix 2 (codegen_hip.cc,      ShuffleNode bfloat16x2/float16x2 packing;
@@ -17,6 +17,9 @@ Covers seven bug fixes across five source files:
                                overflow (hipModuleLaunchKernel EINVAL)
   Fix 7 (codegen_hip.cc)      Packed int4 shared allocations round their
                               int32 storage-word extent up instead of down
+  Fix 8 (intrin_rule_hip.cc)  Vector math intrinsics are scalarized on HIP
+  Fix 9 (copy.h)              Four-byte predicated copy zero-fill preserves
+                              adjacent LDS dwords
 """
 
 import pytest
@@ -24,29 +27,6 @@ import torch
 import tilelang
 import tilelang.testing
 import tilelang.language as T
-
-
-# ---------------------------------------------------------------------------
-# Fix 7 — src/rocm/codegen/codegen_hip.cc
-#   Packed scalar int4/uint4 use one int32 storage word per eight elements.
-# ---------------------------------------------------------------------------
-
-
-@tilelang.testing.requires_rocm
-@pytest.mark.parametrize(
-    "dtype,storage_type",
-    [(T.int4, "int"), (T.dtype("uint4"), "uint")],
-)
-def test_static_packed_int4_shared_allocation_rounds_up(dtype, storage_type):
-    @T.prim_func
-    def kernel():
-        with T.Kernel(1, threads=1):
-            A_shared = T.alloc_shared((127,), dtype, scope="shared")
-            A_shared[126] = T.cast(1, dtype)
-
-    artifact = tilelang.lower(kernel, target="hip")
-
-    assert f"{storage_type} A_shared[16];" in artifact.kernel_source
 
 
 # ---------------------------------------------------------------------------
@@ -773,7 +753,30 @@ def test_pipelined_multi_stage_fp16_gemm(num_stages):
 
 
 # ---------------------------------------------------------------------------
-# Fix 7 — src/backend/rocm/codegen/intrin_rule_hip.cc
+# Fix 7 — src/rocm/codegen/codegen_hip.cc
+#   Packed scalar int4/uint4 use one int32 storage word per eight elements.
+# ---------------------------------------------------------------------------
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize(
+    "dtype,storage_type",
+    [(T.int4, "int"), (T.dtype("uint4"), "uint")],
+)
+def test_static_packed_int4_shared_allocation_rounds_up(dtype, storage_type):
+    @T.prim_func
+    def kernel():
+        with T.Kernel(1, threads=1):
+            A_shared = T.alloc_shared((127,), dtype, scope="shared")
+            A_shared[126] = T.cast(1, dtype)
+
+    artifact = tilelang.lower(kernel, target="hip")
+
+    assert f"{storage_type} A_shared[16];" in artifact.kernel_source
+
+
+# ---------------------------------------------------------------------------
+# Fix 8 — src/backend/rocm/codegen/intrin_rule_hip.cc
 #   Scalarize vector math intrinsics on HIP
 #
 # Symptom: A vectorized math op (e.g. tirx.exp2 on float32x4 from a 2D
@@ -820,6 +823,45 @@ def test_vector_math_scalarized_in_hip_source():
         f"T.exp2 over float32x4, got {src.count('exp2f')}. "
         "Generated HIP source:\n" + src
     )
+
+
+# ---------------------------------------------------------------------------
+# Fix 9 — src/tl_templates/hip/copy.h
+#   A false four-byte predicated copy must zero exactly one dword.
+#
+# Symptom: A false-predicate four-byte copy used uint4 zero-fill, overwriting
+#   16 bytes of LDS and corrupting three adjacent dwords.
+#
+# Fix: write one u32 so the zero-fill width matches the four-byte transfer.
+# ---------------------------------------------------------------------------
+
+
+@tilelang.testing.requires_rocm
+def test_predicated_dword_async_copy_preserves_adjacent_lds():
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((1,), T.float32),
+        B: T.Tensor((4,), T.float32),
+    ):
+        with T.Kernel(1, threads=1):
+            A_shared = T.alloc_shared((4,), T.float32)
+            for i in T.serial(4):
+                A_shared[i] = T.float32(i + 1)
+            T.ptx_cp_async(
+                T.access_ptr(A_shared[0], "w", 1),
+                T.access_ptr(A[0], "r", 1),
+                1,
+                predicate=False,
+            )
+            T.ptx_commit_group()
+            T.ptx_wait_group(0)
+            for i in T.serial(4):
+                B[i] = A_shared[i]
+
+    compiled = tilelang.compile(kernel, out_idx=[1], target="hip")
+    output = compiled(torch.ones(1, device="cuda", dtype=torch.float32))
+    expected = torch.tensor([0, 2, 3, 4], device="cuda", dtype=torch.float32)
+    torch.testing.assert_close(output, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fix the zero-fill path of a four-byte predicated HIP async copy so it only writes the requested dword.

## Problem

For a four-byte transfer, the false-predicate path stores a `uint4` to LDS. A `uint4` occupies 16 bytes, so the operation clears the requested dword and three adjacent dwords. This can corrupt neighboring shared-memory values in boundary tiles that use predicated copies.

## Fix

Store one `u32` in the four-byte path. This makes the zero-fill width match the corresponding `buffer_load_dword ... lds` transfer width.

The HIP regression test file is also reordered so its sections remain sequential: the packed int4 regression is Fix 7, vector math scalarization is Fix 8, and this predicated-copy regression is Fix 9. The module header now lists all nine fixes; the reordering does not change existing test behavior.

## Testing

- Added a ROCm regression test that initializes four adjacent LDS values and verifies that a false-predicate four-byte copy changes `[1, 2, 3, 4]` to `[0, 2, 3, 4]`.
- `bash format.sh --files src/tl_templates/hip/copy.h testing/python/amd/test_tilelang_hip_codegen.py` passed.
- The local C++ build completed successfully.
- The ROCm regression test was collected but skipped locally because no ROCm device is available.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed four-byte predicated HIP async-copy zero-fill behavior by writing a single `u32` to LDS instead of an oversized `uint4`, preventing corruption of adjacent dwords.
- Added a ROCm regression test confirming adjacent LDS values remain unchanged when the predicate is false.
- Updated and reordered HIP regression coverage to include all nine fixes.

## Validation

- Formatting and local C++ build checks passed.
- ROCm regression test was skipped because no ROCm device was available.

## C++ style / lint notes

- The C++ change does not alter documented rules in `docs/developer_guide/cpp_style.md`.
- No new C++ style or lint concerns were identified; the C++ API Style Audit is warning-only and does not affect correctness or build status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->