### PR TITLE
[Autotune] Add early stop to skip slow configs during benchmark

### DIFF
--- a/examples/gemm/example_gemm_autotune_early_stop.py
+++ b/examples/gemm/example_gemm_autotune_early_stop.py
@@ -1,0 +1,142 @@
+"""Example: AutoTuning with early_stop.
+
+Demonstrates the early_stop feature with configs of varying tile sizes
+to produce large performance gaps (5-20x), making early stop effective.
+"""
+
+import os
+import time
+import tilelang as tl
+import tilelang.language as T
+from tilelang.autotuner import AutoTuner
+
+os.environ["TILELANG_DISABLE_CACHE"] = "1"
+
+
+def ref_program(A, B):
+    """Reference: C = A @ B^T."""
+    return A @ B.T
+
+
+def get_configs():
+    """Generate configs with large performance gaps across tile sizes."""
+    configs = []
+
+    for ns in [2, 1]:
+        configs.append({"block_M": 128, "block_N": 128, "block_K": 32, "num_stages": ns, "thread_num": 128})
+
+    for ns in [2, 1]:
+        configs.append({"block_M": 64, "block_N": 64, "block_K": 32, "num_stages": ns, "thread_num": 128})
+
+    for ns in [2, 1]:
+        configs.append({"block_M": 32, "block_N": 64, "block_K": 32, "num_stages": ns, "thread_num": 128})
+
+    for ns in [2, 1]:
+        configs.append({"block_M": 64, "block_N": 32, "block_K": 32, "num_stages": ns, "thread_num": 128})
+
+    for ns in [2, 1]:
+        configs.append({"block_M": 32, "block_N": 32, "block_K": 32, "num_stages": ns, "thread_num": 128})
+
+    return configs
+
+
+def make_kernel(M, N, K):
+    """Create a GEMM kernel factory for autotuning."""
+
+    def kernel(
+        block_M=None,
+        block_N=None,
+        block_K=None,
+        num_stages=None,
+        thread_num=None,
+    ):
+        dtype = T.float16
+        accum_dtype = T.float32
+
+        @T.prim_func
+        def main(
+            A: T.Tensor((M, K), dtype),
+            B: T.Tensor((N, K), dtype),
+            C: T.Tensor((M, N), dtype),
+        ):
+            with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=thread_num) as (
+                bx,
+                by,
+            ):
+                A_shared = T.alloc_shared((block_M, block_K), dtype)
+                B_shared = T.alloc_shared((block_N, block_K), dtype)
+                C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+                T.use_swizzle(panel_size=10)
+                T.clear(C_local)
+                for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
+                    T.copy(A[by * block_M, k * block_K], A_shared)
+                    T.copy(B[bx * block_N, k * block_K], B_shared)
+                    T.gemm(A_shared, B_shared, C_local, transpose_B=True)
+                T.copy(C_local, C[by * block_M, bx * block_N])
+
+        return main
+
+    return kernel
+
+
+def run_autotune(M, N, K, early_stop: bool, early_stop_factor: float = 1.2):
+    """Run autotune with or without early_stop, return (result, wall_time)."""
+    configs = get_configs()
+    kernel = make_kernel(M, N, K)
+
+    autotuner = (
+        AutoTuner.from_kernel(kernel=kernel, configs=configs)
+        .set_compile_args(out_idx=[-1], target="auto")
+        .set_profile_args(
+            supply_type=tl.TensorSupplyType.Integer,
+            ref_prog=ref_program,
+            skip_check=True,
+        )
+    )
+
+    start = time.perf_counter()
+    result = autotuner.run(warmup=5, rep=50, early_stop=early_stop, early_stop_factor=early_stop_factor)
+    wall_time = time.perf_counter() - start
+
+    return result, wall_time
+
+
+def main(M: int = 4096, N: int = 4096, K: int = 4096):
+    """Compare autotune wall time with and without early_stop."""
+    configs = get_configs()
+    print(f"Matrix size: {M}x{N}x{K}")
+    print(f"Total configs: {len(configs)}")
+    print()
+
+    print("=" * 60)
+    print("Run 1: early_stop=False (baseline)")
+    print("=" * 60)
+    result_baseline, time_baseline = run_autotune(M, N, K, early_stop=False)
+    print(f"\n  Best latency: {result_baseline.latency:.4f} ms")
+    print(f"  Best config:  {result_baseline.config}")
+    print(f"  Wall time:    {time_baseline:.2f} s")
+    print()
+
+    print("=" * 60)
+    print("Run 2: early_stop=True")
+    print("=" * 60)
+    result_early, time_early = run_autotune(M, N, K, early_stop=True)
+    print(f"\n  Best latency: {result_early.latency:.4f} ms")
+    print(f"  Best config:  {result_early.config}")
+    print(f"  Wall time:    {time_early:.2f} s")
+    print()
+
+    print("=" * 60)
+    print("Summary")
+    print("=" * 60)
+    speedup = time_baseline / time_early if time_early > 0 else float("inf")
+    saved = time_baseline - time_early
+    print(f"  Baseline wall time:    {time_baseline:.2f} s")
+    print(f"  Early stop wall time:  {time_early:.2f} s")
+    print(f"  Time saved:            {saved:.2f} s ({saved / time_baseline * 100:.1f}%)")
+    print(f"  Speedup:               {speedup:.2f}x")
+    print(f"  Best latency match:    {abs(result_baseline.latency - result_early.latency) < 0.1}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -233,6 +233,7 @@ class _BenchmarkWorkerState:
     jit_input_tensors: Any = None
     ref_input_tensors: Any = None
     ref_latency_cache: float | None = None
+    shared_best_latency: list[float] | None = None
 
 
 class AutoTuner:
@@ -706,6 +707,7 @@ class AutoTuner:
                         jit_input_tensors=worker_state.jit_input_tensors,
                         ref_input_tensors=worker_state.ref_input_tensors,
                         ref_latency_cache=worker_state.ref_latency_cache,
+                        shared_best_latency=worker_state.shared_best_latency,
                     )
 
                     def _run_benchmark_target(
@@ -766,6 +768,7 @@ class AutoTuner:
         jit_kernel: tilelang.JITKernel,
         warmup: int,
         rep: int,
+        early_stop_factor: float,
         benchmark_state: _BenchmarkWorkerState,
         benchmark_device: int | torch.device | None = None,
     ) -> tuple[float, float | None]:
@@ -837,7 +840,15 @@ class AutoTuner:
                 profiler.assert_allclose(
                     ref_prog, input_tensors=jit_input_tensors_cache, rtol=rtol, atol=atol, max_mismatched_ratio=max_mismatched_ratio
                 )
-        latency = profiler.do_bench(n_warmup=warmup, n_repeat=rep, input_tensors=jit_input_tensors_cache, backend=backend)
+        latency = profiler.do_bench(
+            n_warmup=warmup,
+            n_repeat=rep,
+            input_tensors=jit_input_tensors_cache,
+            backend=backend,
+            early_stop_baseline=(
+                benchmark_state.shared_best_latency[0] * early_stop_factor if benchmark_state.shared_best_latency is not None else None
+            ),
+        )
 
         if ref_latency_cache is None and ref_prog is not None:
             ref_input_tensors_cache = ref_input_tensors_supply()
@@ -931,6 +942,8 @@ class AutoTuner:
         group_compile_size: int = 2,
         benchmark_devices: list[int] | None = None,
         benchmark_multi_gpu: bool = False,
+        early_stop: bool = False,
+        early_stop_factor: float = 2.0,
     ):
         """Run the auto-tuning process.
 
@@ -943,6 +956,8 @@ class AutoTuner:
             group_compile_size: Number of configurations in one compile unit.
             benchmark_devices: CUDA device ordinals used for benchmark workers when benchmark_multi_gpu=True.
             benchmark_multi_gpu: Whether to benchmark configurations across multiple CUDA GPUs.
+            early_stop: Whether to skip full benchmark when estimate exceeds best * early_stop_factor.
+            early_stop_factor: Multiplier for best latency to compute early stop threshold.
 
         Returns:
             AutotuneResult: Results of the auto-tuning process.
@@ -1002,6 +1017,7 @@ class AutoTuner:
         best_latency: float = 1e8
         best_config: dict[str, Any] | None = None
         best_kernel: tilelang.JITKernel | None = None
+        shared_best_latency_ref: list[float] | None = [1e8] if early_stop else None
 
         compile_func, elaborate_func = self._ensure_jit_functions()
         self.jit_compile = compile_func
@@ -1083,6 +1099,7 @@ class AutoTuner:
             jit_input_tensors=self.jit_input_tensors,
             ref_input_tensors=self.ref_input_tensors,
             ref_latency_cache=self.ref_latency_cache,
+            shared_best_latency=shared_best_latency_ref,
         )
 
         def _record_benchmark_result(latency: float, config: dict[str, Any], jit_kernel: tilelang.JITKernel, idx: int, progress_bar):
@@ -1091,6 +1108,8 @@ class AutoTuner:
                 best_latency = latency
                 best_config = dict(self.configs[idx])
                 best_kernel = jit_kernel
+                if shared_best_latency_ref is not None:
+                    shared_best_latency_ref[0] = latency
 
             progress_bar.set_postfix({"best_latency": best_latency})
             tqdm.write(f"Tuned Latency {latency} with config {self.configs[idx]} at index {idx}")
@@ -1115,6 +1134,7 @@ class AutoTuner:
             self._benchmark_target,
             warmup=warmup,
             rep=rep,
+            early_stop_factor=early_stop_factor,
         )
 
         def _enqueue_benchmark_task(jit_kernel: tilelang.JITKernel, config: dict[str, Any], idx: int):
@@ -1156,7 +1176,11 @@ class AutoTuner:
 
         # Start benchmark worker threads
         for worker_idx, worker_device in enumerate(benchmark_worker_devices):
-            worker_state = _BenchmarkWorkerState() if benchmark_multi_gpu_active else main_thread_benchmark_state
+            worker_state = (
+                _BenchmarkWorkerState(shared_best_latency=shared_best_latency_ref)
+                if benchmark_multi_gpu_active
+                else main_thread_benchmark_state
+            )
             worker_thread = threading.Thread(
                 target=self._benchmark_worker_loop,
                 args=(

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -964,6 +964,9 @@ class AutoTuner:
         """
         _init_logger_handlers()
 
+        if early_stop and early_stop_factor < 1.0:
+            raise ValueError(f"early_stop_factor must be >= 1.0, got {early_stop_factor}")
+
         sig = inspect.signature(self.fn)
         parameters = sig.parameters
 
@@ -1014,10 +1017,10 @@ class AutoTuner:
                     self._memory_cache[key] = result
                     return result
 
-        best_latency: float = 1e8
+        best_latency: float = float("inf")
         best_config: dict[str, Any] | None = None
         best_kernel: tilelang.JITKernel | None = None
-        shared_best_latency_ref: list[float] | None = [1e8] if early_stop else None
+        shared_best_latency_ref: list[float] | None = [float("inf")] if early_stop else None
 
         compile_func, elaborate_func = self._ensure_jit_functions()
         self.jit_compile = compile_func

--- a/tilelang/profiler/__init__.py
+++ b/tilelang/profiler/__init__.py
@@ -230,6 +230,7 @@ class Profiler:
         return_mode: Literal["min", "max", "mean", "median"] = "mean",
         dynamic_symbolic_constraints: dict[str, int] | None = None,
         device: int | torch.device | None = None,
+        early_stop_baseline: float | None = None,
     ) -> float:
         """Benchmarks the execution time of a given function.
 
@@ -273,6 +274,7 @@ class Profiler:
                 backend=backend,
                 return_mode=return_mode,
                 device=device,
+                early_stop_baseline=early_stop_baseline,
             )
 
         if device is None:

--- a/tilelang/profiler/bench.py
+++ b/tilelang/profiler/bench.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import sys
 from typing import Literal
 from collections.abc import Callable
 
 import torch
+
+logger = logging.getLogger(__name__)
 
 
 class suppress_stdout_stderr:
@@ -74,6 +77,7 @@ def do_bench(
     return_mode: Literal["min", "max", "mean", "median"] = "mean",
     device: int | torch.device | None = None,
     cache_size: int = 256,
+    early_stop_baseline: float | None = None,
 ) -> float | list[float]:
     """Benchmark the runtime of a PyTorch function with L2 cache management.
 
@@ -118,6 +122,7 @@ def do_bench(
                 return_mode=return_mode,
                 device_idx=device_idx,
                 cache_size=cache_size,
+                early_stop_baseline=early_stop_baseline,
             )
 
     return _do_bench_impl(
@@ -132,6 +137,7 @@ def do_bench(
         return_mode=return_mode,
         device_idx=None,
         cache_size=cache_size,
+        early_stop_baseline=early_stop_baseline,
     )
 
 
@@ -175,6 +181,7 @@ def _do_bench_impl(
     return_mode: Literal["min", "max", "mean", "median"],
     device_idx: int | None,
     cache_size: int,
+    early_stop_baseline: float | None = None,
 ) -> float | list[float]:
     # Initial function call and synchronization
     fn()
@@ -198,6 +205,15 @@ def _do_bench_impl(
     start_event.synchronize()
     end_event.synchronize()
     estimate_ms = start_event.elapsed_time(end_event) / 5
+
+    # Early stop: skip full benchmark if estimate exceeds baseline
+    if early_stop_baseline is not None and estimate_ms > early_stop_baseline:
+        logger.warning(
+            "Early stop: estimate_ms=%.3fms exceeds baseline=%.3fms, skipping full benchmark.",
+            estimate_ms,
+            early_stop_baseline,
+        )
+        return estimate_ms
 
     # Calculate warmup and repeat counts (minimum 1 iteration each)
     n_warmup = _n_warmup if _n_warmup > 0 else max(1, int(warmup / estimate_ms))

--- a/tilelang/profiler/bench.py
+++ b/tilelang/profiler/bench.py
@@ -208,11 +208,13 @@ def _do_bench_impl(
 
     # Early stop: skip full benchmark if estimate exceeds baseline
     if early_stop_baseline is not None and estimate_ms > early_stop_baseline:
-        logger.warning(
+        logger.debug(
             "Early stop: estimate_ms=%.3fms exceeds baseline=%.3fms, skipping full benchmark.",
             estimate_ms,
             early_stop_baseline,
         )
+        if quantiles is not None:
+            return [estimate_ms] * len(quantiles)
         return estimate_ms
 
     # Calculate warmup and repeat counts (minimum 1 iteration each)


### PR DESCRIPTION
## Summary

Add an `early_stop` option to the autotuner `run()` method. When enabled, the benchmark phase uses the 5-iteration estimate to skip configs whose estimated latency exceeds `best_latency * early_stop_factor`, avoiding the full warmup + repeat cycle for obviously slow configurations.

## Motivation

In large search spaces, the majority of configs perform significantly worse than the best. The existing `do_bench` already computes a 5-iteration `estimate_ms` before the full benchmark — this estimate is typically within 10-20% of the final result. By comparing it against the current best, we can safely skip slow configs and reduce total tuning time.


## Usage

```python
autotuner.run(early_stop=True)                          # default factor=2.0
autotuner.run(early_stop=True, early_stop_factor=1.5)   # more aggressive
```
When early_stop=False (default), behavior is completely unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds optional `early_stop` support to `AutoTuner.run`, disabled by default.
- Uses an initial ~5-iteration latency estimate to skip configurations whose estimated latency exceeds `best_latency * early_stop_factor` (default `2.0`).
- Propagates the shared best-latency threshold across workers and supports coordinated early stopping for multi-GPU runs.
- Extends profiler benchmarking APIs (`Profiler.do_bench` and `tilelang.profiler.do_bench`) with `early_stop_baseline` to exit before warmup/repeat phases when the estimate exceeds the threshold.
- Adds a GEMM example script comparing baseline vs early-stop autotuning and reporting time saved/speedup.

## C++ style / lint notes

- No changes to C++ style documentation (`docs/developer_guide/cpp_style.md`), C++ style guidance, or CI/lint tooling related to C++ warnings were detected in this PR.
- No new TLCPP003/TLCPP004 (“C++ API Style Audit (warning only)”) warning-only findings appear to be introduced or touched by this PR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->