### PR TITLE
[BugFix] Reject uncovered warp partitions in T.gemm instead of producing silently wrong results

### DIFF
--- a/src/cuda/op/gemm.cc
+++ b/src/cuda/op/gemm.cc
@@ -125,55 +125,65 @@ ComputeDefaultWarpPartition(const GemmWarpPolicyNode &policy, int M, int N,
   ICHECK(N % k_n_per_warp == 0)
       << "N must be divisible by " << k_n_per_warp << ", but got " << N;
 
+  auto is_valid = [&](int m, int n) {
+    return m * n == num_warps && M % (m * kMPerWarp) == 0 &&
+           N % (n * k_n_per_warp) == 0;
+  };
+
+  bool found = false;
   if (policy.IsFullRow()) {
-    m_warp = num_warps;
-    n_warp = 1;
-    if (M % (m_warp * kMPerWarp) != 0) {
-      int max_m_warps = M / kMPerWarp;
-      m_warp = max_m_warps;
-      n_warp = num_warps / m_warp;
-      if (n_warp == 0)
-        n_warp = 1;
+    for (int m = num_warps; m >= 1; m--) {
+      if (num_warps % m != 0 || !is_valid(m, num_warps / m))
+        continue;
+      m_warp = m;
+      n_warp = num_warps / m;
+      found = true;
+      break;
     }
   } else if (policy.IsFullCol()) {
-    m_warp = 1;
-    n_warp = num_warps;
-    if (N % (n_warp * k_n_per_warp) != 0) {
-      int max_n_warps = N / k_n_per_warp;
-      n_warp = max_n_warps;
-      m_warp = num_warps / n_warp;
-      if (m_warp == 0)
-        m_warp = 1;
+    for (int n = num_warps; n >= 1; n--) {
+      if (num_warps % n != 0 || !is_valid(num_warps / n, n))
+        continue;
+      n_warp = n;
+      m_warp = num_warps / n;
+      found = true;
+      break;
     }
   } else if (policy.IsSquare()) {
-    int max_m_warps = M / kMPerWarp;
     float ideal_ratio = N > 0 ? static_cast<float>(M) / N : 1.0f;
 
-    int best_m = 1;
-    int best_n = 1;
     float best_balance = std::numeric_limits<float>::max();
-    for (int m = 1; m <= max_m_warps && m <= num_warps; m++) {
+    for (int m = 1; m <= num_warps; m++) {
+      if (num_warps % m != 0)
+        continue;
       int n = num_warps / m;
+      if (!is_valid(m, n))
+        continue;
 
       float m_per_warp = static_cast<float>(M) / (m * kMPerWarp);
       float n_per_warp = static_cast<float>(N) / (n * k_n_per_warp);
-      if (m_per_warp < 1 || n_per_warp < 1)
-        continue;
-      if (m * n != num_warps)
-        continue;
-
       float balance = std::abs(m_per_warp / n_per_warp - ideal_ratio);
       if (balance < best_balance) {
         best_balance = balance;
-        best_m = m;
-        best_n = n;
+        m_warp = m;
+        n_warp = n;
+        found = true;
       }
     }
-
-    m_warp = best_m;
-    n_warp = best_n;
   } else {
     ICHECK(0) << "Unknown GemmWarpPolicy";
+  }
+
+  if (!found) {
+    LOG(FATAL) << "No valid warp partition for T.gemm: M=" << M << ", N=" << N
+               << " cannot be evenly covered by " << num_warps
+               << " warps (policy="
+               << (policy.IsFullRow()   ? "FullRow"
+                   : policy.IsFullCol() ? "FullCol"
+                                        : "Square")
+               << "). Each warp must own a multiple of " << kMPerWarp
+               << " rows and " << k_n_per_warp
+               << " columns; adjust `threads` or the block tile shape.";
   }
 
   ICHECK(m_warp * n_warp == num_warps)
@@ -198,42 +208,39 @@ std::pair<int, int> ComputeWgmmaWarpPartition(const GemmWarpPolicyNode &policy,
   ICHECK(N % kNPerWarp == 0)
       << "N must be divisible by " << kNPerWarp << ", but got " << N;
 
-  m_warp = kGroup;
-  n_warp = num_warps / m_warp;
+  auto is_valid = [&](int m, int n) {
+    return m * n == num_warps && m % kGroup == 0 && M % (m * kMPerWarp) == 0 &&
+           N % (n * kNPerWarp) == 0;
+  };
 
+  bool found = false;
   if (policy.IsFullRow()) {
-    for (int cand = num_warps; cand >= kGroup; cand -= kGroup) {
-      if (M % (cand * kMPerWarp) == 0) {
-        m_warp = cand;
-        n_warp = num_warps / m_warp;
-        break;
-      }
+    for (int m = num_warps; m >= kGroup; m -= kGroup) {
+      if (num_warps % m != 0 || !is_valid(m, num_warps / m))
+        continue;
+      m_warp = m;
+      n_warp = num_warps / m;
+      found = true;
+      break;
     }
   } else if (policy.IsFullCol()) {
-    int cand_n = n_warp;
-    if (N % (cand_n * kNPerWarp) != 0) {
-      int max_n = N / kNPerWarp;
-      for (int n = std::min(cand_n, max_n); n >= 1; --n) {
-        if (num_warps % n == 0 && (num_warps / n) % kGroup == 0) {
-          n_warp = n;
-          m_warp = num_warps / n_warp;
-          break;
-        }
-      }
+    for (int n = num_warps / kGroup; n >= 1; n--) {
+      if (num_warps % n != 0 || !is_valid(num_warps / n, n))
+        continue;
+      n_warp = n;
+      m_warp = num_warps / n;
+      found = true;
+      break;
     }
   } else if (policy.IsSquare()) {
-    int max_m = M / kMPerWarp;
-    int max_n = N / kNPerWarp;
-
     float ideal = N > 0 ? static_cast<float>(M) / N : 1.f;
-    float best_score = std::numeric_limits<float>::max();
-    int best_m = kGroup, best_n = n_warp;
 
-    for (int m = kGroup; m <= num_warps && m <= max_m; m += kGroup) {
-      if (num_warps % m)
+    float best_score = std::numeric_limits<float>::max();
+    for (int m = kGroup; m <= num_warps; m += kGroup) {
+      if (num_warps % m != 0)
         continue;
       int n = num_warps / m;
-      if (n > max_n)
+      if (!is_valid(m, n))
         continue;
 
       float m_per_warp = static_cast<float>(M) / (m * kMPerWarp);
@@ -242,14 +249,26 @@ std::pair<int, int> ComputeWgmmaWarpPartition(const GemmWarpPolicyNode &policy,
 
       if (score < best_score) {
         best_score = score;
-        best_m = m;
-        best_n = n;
+        m_warp = m;
+        n_warp = n;
+        found = true;
       }
     }
-    m_warp = best_m;
-    n_warp = best_n;
   } else {
     ICHECK(0) << "Unknown GemmWarpPolicy";
+  }
+
+  if (!found) {
+    LOG(FATAL) << "No valid warp partition for T.gemm (Warp-Group MMA): M=" << M
+               << ", N=" << N << " cannot be evenly covered by " << num_warps
+               << " warps (policy="
+               << (policy.IsFullRow()   ? "FullRow"
+                   : policy.IsFullCol() ? "FullCol"
+                                        : "Square")
+               << "). Each warp must own a multiple of " << kMPerWarp
+               << " rows and " << kNPerWarp
+               << " columns, with m_warp a multiple of " << kGroup
+               << "; adjust `threads` or the block tile shape.";
   }
 
   ICHECK(m_warp * n_warp == num_warps)

--- a/testing/python/issue/test_tilelang_issue_2537.py
+++ b/testing/python/issue/test_tilelang_issue_2537.py
@@ -21,6 +21,14 @@ from tilelang.language import GemmWarpPolicy
 # Front-end error emitted by the fixed partition search.
 _REJECT = "No valid warp partition"
 
+# Tests whose docstring reasons about the *default MMA* search must pin the
+# backend: on sm_90 `SelectInst` silently reroutes any M >= 64 / warps % 4 == 0
+# shape to the WGMMA search, which is a different code path with different
+# constraints (and, for N = 104, a pre-existing descriptor-layer limitation
+# unrelated to the partition search).  Shapes with M < 64 or an odd warp count
+# can never take the WGMMA route and need no pin.
+_FORCE_MMA = {"tl.disable_wgmma": True}
+
 
 def _matmul(M, N, K, threads, policy):
     """Single-block GEMM with an M x N accumulator fragment."""
@@ -40,8 +48,8 @@ def _matmul(M, N, K, threads, policy):
     return main
 
 
-def _check(M, N, K, threads, policy):
-    kernel = tilelang.compile(_matmul(M, N, K, threads, policy), out_idx=[2])
+def _check(M, N, K, threads, policy, pass_configs=None):
+    kernel = tilelang.compile(_matmul(M, N, K, threads, policy), out_idx=[2], pass_configs=pass_configs)
     torch.manual_seed(0)
     A = torch.randint(0, 3, (M, K), dtype=torch.float16, device="cuda")
     B = torch.randint(0, 3, (K, N), dtype=torch.float16, device="cuda")
@@ -80,9 +88,12 @@ def test_fullrow_uncovered_n_rejected():
 
 @tilelang.testing.requires_cuda
 def test_fullcol_uncovered_m_rejected():
-    """FullCol, N=8 falls back to n_warp=1, m_warp=20 does not cover M=336."""
+    """FullCol, N=8 falls back to n_warp=1, m_warp=20 does not cover M=336.
+
+    Pinned to the MMA search: on sm_90 this shape would route to the WGMMA
+    search instead (covered by test_wgmma_fullcol_uncovered_m_rejected)."""
     with pytest.raises(Exception, match=_REJECT):
-        tilelang.compile(_matmul(336, 8, 32, 640, GemmWarpPolicy.FullCol), out_idx=[2])
+        tilelang.compile(_matmul(336, 8, 32, 640, GemmWarpPolicy.FullCol), out_idx=[2], pass_configs=_FORCE_MMA)
 
 
 # ---------------------------------------------------------------------------
@@ -106,8 +117,12 @@ def test_square_divisible_control_numeric():
 def test_fullcol_fallback_covering_numeric():
     """FullCol, N=104, 12 warps used to die on an internal ICHECK
     (n_warp = 104 / 8 = 13 does not divide 12).  The fixed search falls back
-    to (m_warp=12, n_warp=1), which covers M=192 x N=104: must compute."""
-    _check(192, 104, 32, 384, GemmWarpPolicy.FullCol)
+    to (m_warp=12, n_warp=1), which covers M=192 x N=104: must compute.
+
+    Pinned to the MMA path: N=104 (208 bytes/row of fp16) fits no canonical
+    GMMA swizzle atom, so the WGMMA route rejects this shape in the descriptor
+    layer on any warp partition, before and after the partition fix alike."""
+    _check(192, 104, 32, 384, GemmWarpPolicy.FullCol, pass_configs=_FORCE_MMA)
 
 
 @tilelang.testing.requires_cuda

--- a/testing/python/issue/test_tilelang_issue_2537.py
+++ b/testing/python/issue/test_tilelang_issue_2537.py
@@ -1,0 +1,176 @@
+"""Regression tests for GitHub issue #2537.
+
+The warp-partition search (``ComputeDefaultWarpPartition`` /
+``ComputeWgmmaWarpPartition``, ``src/cuda/op/gemm.cc``) accepted candidates
+without checking that the warps *cover* the M/N extents.  Depending on the
+shape this either silently left trailing row/column bands unwritten
+(``warp_col_tiles = N // n_warp`` floors) or tripped internal
+ICHECK/AssertionError where a clean diagnostic belongs.  The fix restricts
+the search to covering partitions and raises a clear front-end error when
+none exists.
+"""
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.language import GemmWarpPolicy
+
+# Front-end error emitted by the fixed partition search.
+_REJECT = "No valid warp partition"
+
+
+def _matmul(M, N, K, threads, policy):
+    """Single-block GEMM with an M x N accumulator fragment."""
+
+    @T.prim_func
+    def main(A: T.Tensor((M, K), "float16"), B: T.Tensor((K, N), "float16"), C: T.Tensor((M, N), "float32")):
+        with T.Kernel(1, 1, threads=threads):
+            A_shared = T.alloc_shared((M, K), "float16")
+            B_shared = T.alloc_shared((K, N), "float16")
+            C_frag = T.alloc_fragment((M, N), "float32")
+            T.clear(C_frag)
+            T.copy(A, A_shared)
+            T.copy(B, B_shared)
+            T.gemm(A_shared, B_shared, C_frag, policy=policy)
+            T.copy(C_frag, C)
+
+    return main
+
+
+def _check(M, N, K, threads, policy):
+    kernel = tilelang.compile(_matmul(M, N, K, threads, policy), out_idx=[2])
+    torch.manual_seed(0)
+    A = torch.randint(0, 3, (M, K), dtype=torch.float16, device="cuda")
+    B = torch.randint(0, 3, (K, N), dtype=torch.float16, device="cuda")
+    ref = A.float() @ B.float()
+    out = kernel(A, B).float()
+    torch.testing.assert_close(out, ref, atol=1e-2, rtol=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# Silent wrong-code faces: uncovered partitions must now be rejected.
+# ---------------------------------------------------------------------------
+
+
+@tilelang.testing.requires_cuda
+def test_square_uncovered_n_rejected():
+    """Issue #2537 repro: Square, N=104, 12 warps picked n_warp=12 and left
+    columns 96..103 unwritten (12 * (104 // 12) = 96).  Must reject now."""
+    with pytest.raises(Exception, match=_REJECT):
+        tilelang.compile(_matmul(16, 104, 32, 384, GemmWarpPolicy.Square), out_idx=[2])
+
+
+@tilelang.testing.requires_cuda
+def test_square_uncovered_m_rejected():
+    """M-axis sibling: Square, M=288, 17 warps picked m_warp=17 and left rows
+    272..287 unwritten (17 * (288 // 17) = 272).  Must reject now."""
+    with pytest.raises(Exception, match=_REJECT):
+        tilelang.compile(_matmul(288, 8, 32, 544, GemmWarpPolicy.Square), out_idx=[2])
+
+
+@tilelang.testing.requires_cuda
+def test_fullrow_uncovered_n_rejected():
+    """FullRow, M=16 forces m_warp=1, n_warp=12 does not cover N=104."""
+    with pytest.raises(Exception, match=_REJECT):
+        tilelang.compile(_matmul(16, 104, 32, 384, GemmWarpPolicy.FullRow), out_idx=[2])
+
+
+@tilelang.testing.requires_cuda
+def test_fullcol_uncovered_m_rejected():
+    """FullCol, N=8 falls back to n_warp=1, m_warp=20 does not cover M=336."""
+    with pytest.raises(Exception, match=_REJECT):
+        tilelang.compile(_matmul(336, 8, 32, 640, GemmWarpPolicy.FullCol), out_idx=[2])
+
+
+# ---------------------------------------------------------------------------
+# Covering shapes that still compute: ground-truth checks.
+# ---------------------------------------------------------------------------
+
+
+@tilelang.testing.requires_cuda
+def test_square_covering_warps_numeric():
+    """13 warps cover N=104 (13 * 8 = 104): the shape itself is computable."""
+    _check(16, 104, 32, 416, GemmWarpPolicy.Square)
+
+
+@tilelang.testing.requires_cuda
+def test_square_divisible_control_numeric():
+    """Control: N=96 divides evenly across 12 warps; unchanged by the fix."""
+    _check(16, 96, 32, 384, GemmWarpPolicy.Square)
+
+
+@tilelang.testing.requires_cuda
+def test_fullcol_fallback_covering_numeric():
+    """FullCol, N=104, 12 warps used to die on an internal ICHECK
+    (n_warp = 104 / 8 = 13 does not divide 12).  The fixed search falls back
+    to (m_warp=12, n_warp=1), which covers M=192 x N=104: must compute."""
+    _check(192, 104, 32, 384, GemmWarpPolicy.FullCol)
+
+
+@tilelang.testing.requires_cuda
+def test_fullrow_fallback_covering_numeric():
+    """FullRow, M=48, 8 warps used to die on an internal ICHECK
+    (m_warp = 48 / 16 = 3 does not divide 8).  The fixed search falls back
+    to (m_warp=1, n_warp=8), which covers M=48 x N=64: must compute."""
+    _check(48, 64, 32, 256, GemmWarpPolicy.FullRow)
+
+
+@tilelang.testing.requires_cuda
+def test_square_no_partition_clear_error():
+    """Square, 16x16 with 7 warps has no covering partition at all.  Used to
+    die on an internal ICHECK; must now raise the clear front-end error."""
+    with pytest.raises(Exception, match=_REJECT):
+        tilelang.compile(_matmul(16, 16, 32, 224, GemmWarpPolicy.Square), out_idx=[2])
+
+
+# ---------------------------------------------------------------------------
+# WGMMA path (sm_90).  N tiles are multiples of 16 in every case that
+# executes, steering clear of the unrelated n_dim=8 descriptor defect
+# (issue #2593).
+# ---------------------------------------------------------------------------
+
+
+@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
+def test_wgmma_uncovered_n_rejected():
+    """WGMMA Square, N=104, 12 warps picked (4, 3): 3 * (104 // 3) = 102 < 104
+    and warp_col_tiles=34 tripped an AssertionError.  Must reject cleanly."""
+    with pytest.raises(Exception, match=_REJECT):
+        tilelang.compile(_matmul(64, 104, 32, 384, GemmWarpPolicy.Square), out_idx=[2])
+
+
+@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
+def test_wgmma_uncovered_m_rejected():
+    """WGMMA Square, M=336, 20 warps picked m_warp=20 (covers only 320 rows)
+    and passed every emitter assert - the silent WGMMA face.  Must reject."""
+    with pytest.raises(Exception, match=_REJECT):
+        tilelang.compile(_matmul(336, 16, 32, 640, GemmWarpPolicy.Square), out_idx=[2])
+
+
+@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
+def test_wgmma_fullcol_uncovered_m_rejected():
+    """WGMMA FullCol retry loop picked (20, 1) without covering M=336."""
+    with pytest.raises(Exception, match=_REJECT):
+        tilelang.compile(_matmul(336, 16, 32, 640, GemmWarpPolicy.FullCol), out_idx=[2])
+
+
+@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
+def test_wgmma_square_conserved_control_numeric():
+    """Control: WGMMA Square, M=64, N=96, 4 warps picks (4, 1) both before and
+    after the fix (warp_col_tiles=96); the partition is conserved and the
+    result must match ground truth."""
+    _check(64, 96, 32, 128, GemmWarpPolicy.Square)
+
+
+@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
+def test_wgmma_fullrow_factoring_numeric():
+    """WGMMA FullRow, M=128, 12 warps used to die on an internal ICHECK
+    (cand=8 does not divide 12).  The fixed search picks (4, 3) with
+    warp_col_tiles=64, covering 128 x 192: must compute."""
+    _check(128, 192, 32, 384, GemmWarpPolicy.FullRow)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
# Title

`[BugFix] Reject uncovered warp partitions in T.gemm instead of producing silently wrong results`

# Summary

Fixes #2537.

`T.gemm` with `M=16, N=104, threads=384` (12 warps) produces **silently wrong results**: output columns 96–103 are never written and hold stale values. The shape passes every declared front-end check (`M % 16 == 0`, `N % 8 == 0`), the kernel compiles and runs cleanly — only the numbers are wrong. The same root cause also surfaces as internal `ICHECK` failures and emitter `AssertionError`s on other shape/policy combinations (previously reported as a "question" in #1554 and closed without a fix).

This PR turns the warp-partition computation in `src/cuda/op/gemm.cc` into a real search over *valid* partitions, and raises a clear, actionable front-end error when no valid partition exists.

# Root Cause

`ComputeDefaultWarpPartition` / `ComputeWgmmaWarpPartition` (`src/cuda/op/gemm.cc`) accept a candidate `(m_warp, n_warp)` without checking that the partition **covers** the M/N extents. A fully valid partition must satisfy four predicates:

1. factoring: `m_warp * n_warp == num_warps`
2. M-coverage: `M % (m_warp * 16) == 0`
3. N-coverage: `N % (n_warp * 8) == 0`
4. (WGMMA only) warpgroup alignment: `m_warp % 4 == 0`

The old code checked different subsets of these per policy branch, so each branch had its own failure face:

|                | Default FullRow | Default FullCol | Default Square | WGMMA FullRow | WGMMA FullCol | WGMMA Square |
| -------------- | --------------- | --------------- | -------------- | ------------- | ------------- | ------------ |
| ① factoring    | ✗ → ICHECK      | ✗ → ICHECK      | ✓              | ✗ → ICHECK    | ✓             | ✓            |
| ② M-coverage   | ◎               | ✗ → silent      | ✗ → silent     | ✓             | ✗ → silent    | ✗ → silent   |
| ③ N-coverage   | ✗ → silent      | ◎               | ✗ → silent     | ✗ → assert    | ✗ → assert    | ✗ → assert   |

(✗ = predicate not checked; ◎ = satisfied by construction of that branch.)

Causal chain for the issue's repro (Square, N=104, 12 warps): the search picks `n_warp = 12`; `warp_col_tiles = 104 // 12 = 8` floors, so the 12 warps cover only 96 columns. In `make_mma_store_layout`, elements with `j >= 96` map to `thread_id >= blockDim.x` — a thread that does not exist — so their clear/mma/store all silently vanish. Nothing ever writes columns 96–103.

The uncovered-partition logic dates back to #517 and was carried into `src/cuda/op/gemm.cc` unchanged by the backend split in #2153.

# Changes

**`src/cuda/op/gemm.cc`** — both partition functions now share the same structure:

- A single `is_valid(m, n)` predicate encodes all coverage requirements (the WGMMA variant adds `m % 4 == 0`).
- Each policy keeps its original preference, applied over the **valid** candidate set only:
  - `FullRow`: largest valid `m_warp` (was: hard fallback `m = M/16`, which crashes an `ICHECK` when it doesn't divide `num_warps`);
  - `FullCol`: largest valid `n_warp` (symmetric);
  - `Square`: the balance-scoring formula is **unchanged**; only the candidate set is restricted. Any shape that previously received a covering partition receives exactly the same partition after this PR.
- If the valid set is empty, `LOG(FATAL)` with an actionable message naming M, N, `num_warps`, the policy, and the per-warp granularity constraints — instead of wrong results or an internal-invariant crash.

Behavior changes are exactly these three classes, and nothing else:

1. **Silent wrong-code → clean error.** E.g. the issue's repro, and its M-axis siblings (`M=288`, 17 warps, rows 272–287 stale). Strictly a tightening; a "result" that was wrong has no compatibility claim.
2. **Internal ICHECK/assert crash → either a clean error, or a working kernel.** Shapes like FullCol `M=192, N=104`/12 warps (now `(12,1)`) or WGMMA FullRow `M=128, N=192`/12 warps (now `(4,3)`) previously passed every *declared* operator check and then crashed on internal invariants; they now compile and produce correct results. Since these code paths were never generated before, each such case carries a numeric ground-truth regression test, not just a "does not crash" check.
3. **Previously working shapes: no change.** Verified by diffing the selected `(m_warp, n_warp)` over a grid of covering shape/policy/warp-count combinations on both paths before and after the fix — zero diff (mechanically guaranteed for Square by the untouched scoring formula).

**`testing/python/issue/test_tilelang_issue_2537.py`** (new) — 14 regression tests: 4 uncovered-partition rejections + 4 numeric ground-truth cases + 1 no-partition clear-error case on the MMA path; 3 rejections + 2 numeric ground-truth cases on the WGMMA path (gated `requires_cuda_compute_version_eq(9, 0)`). The two default-search tests whose shapes would silently reroute to the WGMMA search on sm_90 (`M >= 64`, warps divisible by 4) pin their backend via `tl.disable_wgmma`, so they exercise the intended search on every arch.

## Notes for reviewers / related issues

- **WGMMA descriptor expressibility is a separate, pre-existing constraint layer** (related territory: #2593 / #2603). For a 16-bit MN-major B whose row width fits no canonical GMMA swizzle atom (e.g. N=104 → 208 bytes), `compute_gmma_descriptor` raises `Not a canonical GMMA_MN layout` at lowering. This depends only on the whole B tile's layout, not on the warp partition: at `threads=128` the old and the fixed search select the identical partition `(4, 1)` and hit the identical assert (verified), so this PR neither introduces nor exposes it — such shapes never compiled on the WGMMA route. The MMA-intent regression tests pin their backend via `tl.disable_wgmma` so they keep testing the default search on Hopper CI; the WGMMA numeric tests use canonical-width N. A follow-up note on #2593 (same shape family) will record the current-main status and propose surfacing this as an actionable front-end error at the WGMMA lowering entry (which knows N, dtype and majorness) — encoding it into the partition search instead would mis-attribute a shape constraint to `threads` and require plumbing operand majorness/dtype into `ComputeWarpPartition`.
- `src/cuda/op/gemm_sp.cc` contains independent copies of both partition functions with the same missing coverage checks; not touched here to keep the diff focused (and to avoid conflicting with #2603's candidate fixes). Happy to follow up.

# Tested

- Issue repro (`M=16, N=104, threads=384`, Square): wrong columns 96–103 before; clear front-end error after. Counterfactual `threads=416` (13 warps, covering) computes correctly in both.
- Full defect-face matrix (every ✗ cell above, both paths, all three policies) verified before/after: every silent face and every internal-crash face now yields either the clean error or a numerically correct kernel.
- Partition-selection diff over a grid of previously-working combinations on both MMA and WGMMA paths: identical `(m_warp, n_warp)` before and after.
- New regression tests pass on sm_89 (WGMMA cases skip; they are compile-verified via an sm_90 target and need Hopper CI for the numeric assertions).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed `T.gemm` warp-partition selection for MMA and WGMMA paths.
- Candidates now validate warp factoring, complete M/N coverage, and WGMMA warpgroup alignment.
- Added clear front-end errors when no valid partition exists, preventing silent miscompilation and internal assertion failures.
- Preserved existing policy preferences among valid partitions.
- Added 14 regression tests covering rejected uncovered partitions, numeric correctness, and no-partition diagnostics.

## C++ style / lint notes

- The PR changes C++ implementation code but does not modify the documented rules in `docs/developer_guide/cpp_style.md`.
- The warning-only C++ API Style Audit CI step remains relevant; this PR does not introduce any new expected correctness/build failures related to linting.
- Any advisory style findings should not block merging absent a clear API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->