### PR TITLE
[BugFix] Preserve buffer element offsets in access pointers

### DIFF
--- a/src/transform/lower_access_ptr.cc
+++ b/src/transform/lower_access_ptr.cc
@@ -99,7 +99,7 @@ public:
 
     PrimExpr ptype = tirx::TypeAnnotation(buffer->dtype);
     PrimExpr data = buffer->data;
-    PrimExpr offset = LinearOffsetFromLoad(base_load);
+    PrimExpr offset = buffer->elem_offset + LinearOffsetFromLoad(base_load);
 
     Array<PrimExpr> args{ptype, data, offset, extent, rw_mask};
     return Call(DataType::Handle(), builtin::tvm_access_ptr(), args);

--- a/testing/python/language/test_tilelang_language_access_ptr.py
+++ b/testing/python/language/test_tilelang_language_access_ptr.py
@@ -86,3 +86,24 @@ def test_lower_access_ptr_rewrites_to_tvm_access_ptr():
     assert int(extent.value) == 20
     assert isinstance(acc.args[4], tirx.IntImm)
     assert int(acc.args[4].value) == 2
+
+
+def test_lower_access_ptr_preserves_buffer_element_offset():
+    elem_offset = tirx.IntImm("int32", 5)
+    buf = tirx.decl_buffer((8, 8), "float16", name="A", elem_offset=elem_offset)
+    load = tirx.BufferLoad(buf, [tirx.IntImm("int32", 2), tirx.IntImm("int32", 3)])
+    ptr = T.access_ptr(load, "r", 1)
+
+    func = tirx.PrimFunc([buf.data], tirx.Evaluate(ptr), buffer_map={buf.data: buf})
+    mod = tvm.IRModule.from_expr(func.with_attr("global_symbol", "main"))
+    lowered = tilelang.transform.LowerAccessPtr()(mod)
+
+    calls = []
+    tirx.stmt_functor.post_order_visit(
+        lowered["main"].body,
+        lambda expr: calls.append(expr) if isinstance(expr, tirx.Call) else None,
+    )
+    acc = [call for call in calls if call.op.same_as(op.Op.get("tirx.tvm_access_ptr"))][0]
+    offset = arith.Analyzer().simplify(acc.args[2])
+    assert isinstance(offset, tirx.IntImm)
+    assert int(offset.value) == 24


### PR DESCRIPTION
## Summary

- preserve a buffer's `elem_offset` when lowering `T.access_ptr` to `tirx.tvm_access_ptr`
- add a regression test for a non-zero-offset 2D buffer

## Intended behavior

`tvm_access_ptr(dtype, data, offset, extent, rw_mask)` represents `&data[offset]`. Its `data` argument is the underlying raw buffer pointer, so the emitted `offset` must be relative to that pointer, not merely relative to the logical beginning of the `Buffer` view.

For a buffer view with element offset `e`, the address of an indexed element must therefore be lowered as:

```text
final offset = buffer.elem_offset + linearized element index
```

For example, the regression test uses a contiguous `(8, 8)` buffer with `elem_offset = 5` and takes an access pointer to element `[2, 3]`. The index within the logical buffer is `2 * 8 + 3 = 19`, while the offset relative to the raw `data` pointer is `5 + 19 = 24`. The lowered `tvm_access_ptr` is expected to carry `24`.

## Root cause and impact

`LowerAccessPtr` previously passed `buffer->data` unchanged but used only `LinearOffsetFromLoad(base_load)` as the intrinsic offset. This dropped `buffer->elem_offset`, causing access pointers for buffer views or other buffers with non-zero element offsets to point to earlier elements in the underlying allocation.

The fix mirrors TVM's `Buffer::access_ptr` behavior by adding `buffer->elem_offset` to the linearized index.

## Validation

- `cmake --build build -j$(sysctl -n hw.ncpu)`
- `pytest -q testing/python/language/test_tilelang_language_access_ptr.py::test_lower_access_ptr_preserves_buffer_element_offset`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Preserve `Buffer.elem_offset` when lowering `T.access_ptr` to `tirx.tvm_access_ptr`.
- Add the buffer element offset to the linearized element index, matching TVM behavior.
- Add a regression test covering a contiguous 2D buffer with a non-zero element offset.

## Validation

- Build completed successfully.
- Targeted access-pointer pytest passed.

## C++ style / lint notes

- The change does not modify rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit remains warning-only; no correctness or build issues are introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->