### PR TITLE
[BugFix] Isolate cross-compiler options per invocation

### DIFF
--- a/testing/python/contrib/test_tilelang_contrib_cc.py
+++ b/testing/python/contrib/test_tilelang_contrib_cc.py
@@ -1,0 +1,15 @@
+from tilelang.contrib import cc
+
+
+def test_cross_compiler_does_not_persist_per_call_options():
+    calls = []
+
+    def compile_func(outputs, objects, options):
+        calls.append((outputs, objects, options))
+
+    fcompile = cc.cross_compiler(compile_func, options=["-base"])
+    fcompile("first.so", ["first.o"], options=["-first"])
+    fcompile("second.so", ["second.o"], options=["-second"])
+
+    assert calls[0][2] == ["-base", "-first"]
+    assert calls[1][2] == ["-base", "-second"]

--- a/tilelang/contrib/cc.py
+++ b/tilelang/contrib/cc.py
@@ -350,7 +350,7 @@ def cross_compiler(compile_func, options=None, output_format=None, get_target_tr
         compile_func = create_shared
 
     def _fcompile(outputs, objects, options=None):
-        all_options = base_options
+        all_options = list(base_options)
         if options is not None:
             all_options += options
         compile_func(outputs, objects + add_files, options=all_options, **kwargs)

--- a/tilelang/contrib/cc.py
+++ b/tilelang/contrib/cc.py
@@ -350,6 +350,7 @@ def cross_compiler(compile_func, options=None, output_format=None, get_target_tr
         compile_func = create_shared
 
     def _fcompile(outputs, objects, options=None):
+        # Use a fresh list per invocation so per-call options do not leak across builds.
         all_options = list(base_options)
         if options is not None:
             all_options += options


### PR DESCRIPTION
## Summary

- copy the configured base compiler options for each `cross_compiler` invocation
- add a CPU-only regression test covering two builds with different per-call options

## Intended behavior

Options passed when constructing a cross compiler are persistent defaults, while options passed to `_fcompile` belong only to that individual build. Reusing the same cross compiler should therefore produce independent option lists:

```text
base options:  ["-base"]
first build:   ["-base", "-first"]
second build:  ["-base", "-second"]
```

The first build's `-first` option must not appear in the second build, and later invocations must not mutate the option list already supplied to an earlier invocation.

## Root cause and impact

`all_options = base_options` made both names refer to the same Python list. The subsequent in-place `+= options` mutated the captured base options, so per-call flags accumulated across builds. Because callers also received that same list object, a later build could even mutate an options list retained by an earlier callback.

This could silently apply stale compiler flags to later outputs produced by the same cross-compiler closure. Creating `all_options` with `list(base_options)` gives each invocation an independent list while preserving the configured defaults.

## Validation

- `pytest -q testing/python/contrib/test_tilelang_contrib_cc.py::test_cross_compiler_does_not_persist_per_call_options`
- verified the test fails with the original aliasing assignment and passes with the fix



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prevents cross-compiler option leakage by copying base options for each build invocation.
- Preserves constructor-provided options as defaults while isolating per-call `_fcompile` options.
- Adds a CPU-only regression test covering independent options across multiple builds and ensuring prior option lists remain unchanged.

## Testing

- Added `test_cross_compiler_does_not_persist_per_call_options`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->