### PR TITLE
[Autotune] Support early_stop in decorator mode and add decorator example

### DIFF
--- a/examples/gemm/example_gemm_autotune_early_stop.py
+++ b/examples/gemm/example_gemm_autotune_early_stop.py
@@ -2,13 +2,18 @@
 
 Demonstrates the early_stop feature with configs of varying tile sizes
 to produce large performance gaps (5-20x), making early stop effective.
+
+Two usage modes are shown:
+1. API mode: using AutoTuner.from_kernel() explicitly
+2. Decorator (wrapper) mode: using @autotune + @tilelang.jit decorators
 """
 
+import argparse
 import os
 import time
 import tilelang as tl
 import tilelang.language as T
-from tilelang.autotuner import AutoTuner
+from tilelang.autotuner import AutoTuner, autotune
 
 os.environ["TILELANG_DISABLE_CACHE"] = "1"
 
@@ -101,6 +106,68 @@ def run_autotune(M, N, K, early_stop: bool, early_stop_factor: float = 1.2):
     return result, wall_time
 
 
+# ======================== Decorator (wrapper) mode ========================
+
+
+@autotune(
+    configs=get_configs(),
+    warmup=5,
+    rep=50,
+    early_stop=True,
+    early_stop_factor=2.0,
+    supply_type=tl.TensorSupplyType.Integer,
+    ref_prog=ref_program,
+    skip_check=True,
+)
+@tl.jit(out_idx=[-1])
+def matmul_early_stop(
+    M,
+    N,
+    K,
+    block_M=128,
+    block_N=128,
+    block_K=32,
+    num_stages=2,
+    thread_num=128,
+):
+    """GEMM kernel with early_stop enabled via decorator mode."""
+    dtype = T.float16
+    accum_dtype = T.float32
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), dtype),
+        B: T.Tensor((N, K), dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=thread_num) as (
+            bx,
+            by,
+        ):
+            A_shared = T.alloc_shared((block_M, block_K), dtype)
+            B_shared = T.alloc_shared((block_N, block_K), dtype)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+            T.use_swizzle(panel_size=10)
+            T.clear(C_local)
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=num_stages):
+                T.copy(A[by * block_M, k * block_K], A_shared)
+                T.copy(B[bx * block_N, k * block_K], B_shared)
+                T.gemm(A_shared, B_shared, C_local, transpose_B=True)
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def main_decorator(M: int = 4096, N: int = 4096, K: int = 4096):
+    """Run decorator mode autotuning with early_stop and print results."""
+    print("Running decorator mode with early_stop=True, early_stop_factor=2.0 ...")
+    start = time.perf_counter()
+    kernel = matmul_early_stop(M, N, K)
+    wall_time = time.perf_counter() - start
+    print(f"  Wall time:     {wall_time:.2f} s")
+    print(f"  Kernel source: {len(kernel.get_kernel_source())} chars")
+
+
 def main(M: int = 4096, N: int = 4096, K: int = 4096):
     """Compare autotune wall time with and without early_stop."""
     configs = get_configs()
@@ -139,4 +206,25 @@ def main(M: int = 4096, N: int = 4096, K: int = 4096):
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description="AutoTune MatMul with early_stop")
+    parser.add_argument("--m", type=int, default=4096, help="Matrix dimension M")
+    parser.add_argument("--n", type=int, default=4096, help="Matrix dimension N")
+    parser.add_argument("--k", type=int, default=4096, help="Matrix dimension K")
+    parser.add_argument(
+        "--mode",
+        type=str,
+        default="both",
+        choices=["api", "decorator", "both"],
+        help="Which mode to run",
+    )
+    args = parser.parse_args()
+    if args.mode in ("api", "both"):
+        print("=" * 60)
+        print("API mode")
+        print("=" * 60)
+        main(args.m, args.n, args.k)
+    if args.mode in ("decorator", "both"):
+        print("=" * 60)
+        print("Decorator mode")
+        print("=" * 60)
+        main_decorator(args.m, args.n, args.k)

--- a/examples/gemm/example_gemm_autotune_early_stop.py
+++ b/examples/gemm/example_gemm_autotune_early_stop.py
@@ -1,14 +1,13 @@
-"""Example: AutoTuning with early_stop.
+"""AutoTuning GEMM with early_stop.
 
-Demonstrates the early_stop feature with configs of varying tile sizes
-to produce large performance gaps (5-20x), making early stop effective.
+Demonstrates the early_stop feature that skips clearly suboptimal configs
+during tuning, significantly reducing total tuning wall time.
 
-Two usage modes are shown:
-1. API mode: using AutoTuner.from_kernel() explicitly
-2. Decorator (wrapper) mode: using @autotune + @tilelang.jit decorators
+Two usage modes:
+- API mode: AutoTuner.from_kernel() with early_stop=True
+- Decorator mode: @autotune(..., early_stop=True) + @tilelang.jit
 """
 
-import argparse
 import os
 import time
 import tilelang as tl
@@ -17,44 +16,31 @@ from tilelang.autotuner import AutoTuner, autotune
 
 os.environ["TILELANG_DISABLE_CACHE"] = "1"
 
-
-def ref_program(A, B):
-    """Reference: C = A @ B^T."""
-    return A @ B.T
+M, N, K = 4096, 4096, 4096
 
 
 def get_configs():
-    """Generate configs with large performance gaps across tile sizes."""
+    """Configs with varying tile sizes to produce large performance gaps."""
     configs = []
-
-    for ns in [2, 1]:
-        configs.append({"block_M": 128, "block_N": 128, "block_K": 32, "num_stages": ns, "thread_num": 128})
-
-    for ns in [2, 1]:
-        configs.append({"block_M": 64, "block_N": 64, "block_K": 32, "num_stages": ns, "thread_num": 128})
-
-    for ns in [2, 1]:
-        configs.append({"block_M": 32, "block_N": 64, "block_K": 32, "num_stages": ns, "thread_num": 128})
-
-    for ns in [2, 1]:
-        configs.append({"block_M": 64, "block_N": 32, "block_K": 32, "num_stages": ns, "thread_num": 128})
-
-    for ns in [2, 1]:
-        configs.append({"block_M": 32, "block_N": 32, "block_K": 32, "num_stages": ns, "thread_num": 128})
-
+    tile_sizes = [(128, 128), (64, 64), (32, 64), (64, 32), (32, 32)]
+    for bm, bn in tile_sizes:
+        for ns in [2, 1]:
+            configs.append(
+                {
+                    "block_M": bm,
+                    "block_N": bn,
+                    "block_K": 32,
+                    "num_stages": ns,
+                    "thread_num": 128,
+                }
+            )
     return configs
 
 
-def make_kernel(M, N, K):
-    """Create a GEMM kernel factory for autotuning."""
+def make_kernel():
+    """GEMM kernel factory for API mode autotuning."""
 
-    def kernel(
-        block_M=None,
-        block_N=None,
-        block_K=None,
-        num_stages=None,
-        thread_num=None,
-    ):
+    def kernel(block_M=None, block_N=None, block_K=None, num_stages=None, thread_num=None):
         dtype = T.float16
         accum_dtype = T.float32
 
@@ -64,10 +50,7 @@ def make_kernel(M, N, K):
             B: T.Tensor((N, K), dtype),
             C: T.Tensor((M, N), dtype),
         ):
-            with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=thread_num) as (
-                bx,
-                by,
-            ):
+            with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=thread_num) as (bx, by):
                 A_shared = T.alloc_shared((block_M, block_K), dtype)
                 B_shared = T.alloc_shared((block_N, block_K), dtype)
                 C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
@@ -84,29 +67,34 @@ def make_kernel(M, N, K):
     return kernel
 
 
-def run_autotune(M, N, K, early_stop: bool, early_stop_factor: float = 1.2):
-    """Run autotune with or without early_stop, return (result, wall_time)."""
+# --- API mode ---
+
+
+def run_api_mode():
+    """Compare tuning wall time with and without early_stop."""
     configs = get_configs()
-    kernel = make_kernel(M, N, K)
+    print(f"Matrix: {M}x{N}x{K}, configs: {len(configs)}")
+    print()
 
-    autotuner = (
-        AutoTuner.from_kernel(kernel=kernel, configs=configs)
-        .set_compile_args(out_idx=[-1], target="auto")
-        .set_profile_args(
-            supply_type=tl.TensorSupplyType.Integer,
-            ref_prog=ref_program,
-            skip_check=True,
+    results = {}
+    for early_stop in [False, True]:
+        label = "early_stop=True" if early_stop else "baseline"
+        autotuner = (
+            AutoTuner.from_kernel(kernel=make_kernel(), configs=configs).set_compile_args(out_idx=[-1], target="auto").set_profile_args()
         )
-    )
+        start = time.perf_counter()
+        result = autotuner.run(warmup=5, rep=50, early_stop=early_stop, early_stop_factor=1.2)
+        wall = time.perf_counter() - start
+        results[label] = (result, wall)
+        print(f"[{label}] latency={result.latency:.4f}ms, wall={wall:.2f}s, config={result.config}")
 
-    start = time.perf_counter()
-    result = autotuner.run(warmup=5, rep=50, early_stop=early_stop, early_stop_factor=early_stop_factor)
-    wall_time = time.perf_counter() - start
+    print()
+    t_base = results["baseline"][1]
+    t_early = results["early_stop=True"][1]
+    print(f"Time saved: {t_base - t_early:.2f}s ({(t_base - t_early) / t_base * 100:.1f}%)")
 
-    return result, wall_time
 
-
-# ======================== Decorator (wrapper) mode ========================
+# --- Decorator mode ---
 
 
 @autotune(
@@ -115,9 +103,6 @@ def run_autotune(M, N, K, early_stop: bool, early_stop_factor: float = 1.2):
     rep=50,
     early_stop=True,
     early_stop_factor=2.0,
-    supply_type=tl.TensorSupplyType.Integer,
-    ref_prog=ref_program,
-    skip_check=True,
 )
 @tl.jit(out_idx=[-1])
 def matmul_early_stop(
@@ -130,7 +115,6 @@ def matmul_early_stop(
     num_stages=2,
     thread_num=128,
 ):
-    """GEMM kernel with early_stop enabled via decorator mode."""
     dtype = T.float16
     accum_dtype = T.float32
 
@@ -158,73 +142,23 @@ def matmul_early_stop(
     return main
 
 
-def main_decorator(M: int = 4096, N: int = 4096, K: int = 4096):
-    """Run decorator mode autotuning with early_stop and print results."""
-    print("Running decorator mode with early_stop=True, early_stop_factor=2.0 ...")
+def run_decorator_mode():
+    """Run decorator mode autotuning with early_stop."""
+    print("Decorator mode: early_stop=True, early_stop_factor=2.0")
     start = time.perf_counter()
     kernel = matmul_early_stop(M, N, K)
-    wall_time = time.perf_counter() - start
-    print(f"  Wall time:     {wall_time:.2f} s")
-    print(f"  Kernel source: {len(kernel.get_kernel_source())} chars")
-
-
-def main(M: int = 4096, N: int = 4096, K: int = 4096):
-    """Compare autotune wall time with and without early_stop."""
-    configs = get_configs()
-    print(f"Matrix size: {M}x{N}x{K}")
-    print(f"Total configs: {len(configs)}")
-    print()
-
-    print("=" * 60)
-    print("Run 1: early_stop=False (baseline)")
-    print("=" * 60)
-    result_baseline, time_baseline = run_autotune(M, N, K, early_stop=False)
-    print(f"\n  Best latency: {result_baseline.latency:.4f} ms")
-    print(f"  Best config:  {result_baseline.config}")
-    print(f"  Wall time:    {time_baseline:.2f} s")
-    print()
-
-    print("=" * 60)
-    print("Run 2: early_stop=True")
-    print("=" * 60)
-    result_early, time_early = run_autotune(M, N, K, early_stop=True)
-    print(f"\n  Best latency: {result_early.latency:.4f} ms")
-    print(f"  Best config:  {result_early.config}")
-    print(f"  Wall time:    {time_early:.2f} s")
-    print()
-
-    print("=" * 60)
-    print("Summary")
-    print("=" * 60)
-    speedup = time_baseline / time_early if time_early > 0 else float("inf")
-    saved = time_baseline - time_early
-    print(f"  Baseline wall time:    {time_baseline:.2f} s")
-    print(f"  Early stop wall time:  {time_early:.2f} s")
-    print(f"  Time saved:            {saved:.2f} s ({saved / time_baseline * 100:.1f}%)")
-    print(f"  Speedup:               {speedup:.2f}x")
-    print(f"  Best latency match:    {abs(result_baseline.latency - result_early.latency) < 0.1}")
+    wall = time.perf_counter() - start
+    print(f"  Wall time: {wall:.2f}s")
+    print(f"  Kernel source length: {len(kernel.get_kernel_source())} chars")
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="AutoTune MatMul with early_stop")
-    parser.add_argument("--m", type=int, default=4096, help="Matrix dimension M")
-    parser.add_argument("--n", type=int, default=4096, help="Matrix dimension N")
-    parser.add_argument("--k", type=int, default=4096, help="Matrix dimension K")
-    parser.add_argument(
-        "--mode",
-        type=str,
-        default="both",
-        choices=["api", "decorator", "both"],
-        help="Which mode to run",
-    )
-    args = parser.parse_args()
-    if args.mode in ("api", "both"):
-        print("=" * 60)
-        print("API mode")
-        print("=" * 60)
-        main(args.m, args.n, args.k)
-    if args.mode in ("decorator", "both"):
-        print("=" * 60)
-        print("Decorator mode")
-        print("=" * 60)
-        main_decorator(args.m, args.n, args.k)
+    print("=" * 60)
+    print("API mode")
+    print("=" * 60)
+    run_api_mode()
+    print()
+    print("=" * 60)
+    print("Decorator mode")
+    print("=" * 60)
+    run_decorator_mode()

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -1321,6 +1321,8 @@ class AutoTuneImpl(Generic[_P, _T]):
     manual_check_prog: Callable = None
     cache_input_tensors: bool = False
     do_not_specialize: tuple[str, ...] | list[str] | None = None
+    early_stop: bool = False
+    early_stop_factor: float = 2.0
 
     def __post_init__(self):
         self._tuner_cache = {}
@@ -1376,7 +1378,14 @@ class AutoTuneImpl(Generic[_P, _T]):
                 pass_configs=self.jit_impl.pass_configs,
             )
         )
-        autotuner.run = partial(autotuner.run, self.warmup, self.rep, self.timeout)
+        autotuner.run = partial(
+            autotuner.run,
+            self.warmup,
+            self.rep,
+            self.timeout,
+            early_stop=self.early_stop,
+            early_stop_factor=self.early_stop_factor,
+        )
         return autotuner
 
     def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> JITKernel | _T:
@@ -1449,6 +1458,8 @@ def autotune(  # This is the new public interface
     manual_check_prog: Callable = None,
     cache_input_tensors: bool = False,
     do_not_specialize: tuple[str, ...] | list[str] | None = None,
+    early_stop: bool = False,
+    early_stop_factor: float = 2.0,
 ):
     """
     Just-In-Time (JIT) compiler decorator for TileLang functions.
@@ -1525,6 +1536,8 @@ def autotune(  # This is the new public interface
                 manual_check_prog=manual_check_prog,
                 cache_input_tensors=cache_input_tensors,
                 do_not_specialize=do_not_specialize,
+                early_stop=early_stop,
+                early_stop_factor=early_stop_factor,
             )
 
         return decorator


### PR DESCRIPTION
## Description

The previous early stop PR (#2723) only added support for the API mode (`autotuner.run(early_stop=True)`). This follow-up adds early stop support to the decorator mode which was missed.

## Changes

- Add `early_stop` and `early_stop_factor` parameters to `@autotune()` decorator
- Simplify the early stop example to cover both API and decorator modes

## Usage

```python
@autotune(configs=get_configs(), warmup=5, rep=50, early_stop=True, early_stop_factor=2.0)
@tl.jit(out_idx=[-1])
def matmul(M, N, K, ...):
    ...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `early_stop` and `early_stop_factor` support to the `@autotune()` decorator API.
- Propagated early-stop configuration through `AutoTuneImpl` and tuner construction.
- Simplified the GEMM early-stop example to demonstrate both API and decorator-based autotuning modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->