### PR TITLE
[BugFix] Honor explicit row strides in Metal GEMM

### DIFF
--- a/testing/python/metal/test_metal_gemm_v2_linux.py
+++ b/testing/python/metal/test_metal_gemm_v2_linux.py
@@ -5,10 +5,13 @@ down to Metal shader source code with simdgroup matrix operations,
 without requiring a Metal runtime or macOS.
 """
 
+import pytest
+
 import tilelang
 from tilelang import tvm as tvm
 import tilelang.testing
 import tilelang.language as T
+from tilelang.metal.intrinsics.metal_macro_generator import MPSIntrinEmitter
 
 
 def matmul_gemm_v2(M, N, K, block_M, block_N, block_K, dtype=T.float16, accum_dtype=T.float32):
@@ -76,6 +79,29 @@ def test_metal_gemm_v2_small_blocks():
     produced incorrect results due to swizzle padding changing the stride.
     """
     assert_metal_gemm_v2_codegen(16, 16, 16, 16, 16, 16, dtype=T.float16)
+
+
+def test_metal_gemm_validates_explicit_buffer_strides():
+    padded_buffer = tvm.tirx.decl_buffer(
+        (16, 16),
+        T.float16,
+        strides=(32, 1),
+        scope="shared",
+    )
+
+    *_, stride = MPSIntrinEmitter._parse_buffer_nd(padded_buffer)
+
+    assert tvm.ir.structural_equal(stride, tvm.tirx.IntImm("int32", 32))
+
+    noncontiguous_buffer = tvm.tirx.decl_buffer(
+        (16, 16),
+        T.float16,
+        strides=(32, 2),
+        scope="shared",
+    )
+
+    with pytest.raises(ValueError, match="contiguous innermost dimension"):
+        MPSIntrinEmitter._parse_buffer_nd(noncontiguous_buffer)
 
 
 if __name__ == "__main__":

--- a/tilelang/metal/intrinsics/metal_macro_generator.py
+++ b/tilelang/metal/intrinsics/metal_macro_generator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import tilelang.language as T
+from tvm import arith
 from tvm import tirx as tir
 from tvm.tirx import Buffer, BufferRegion
 
@@ -73,6 +74,8 @@ class MPSIntrinEmitter:
         For 2D buffers, extra_indices is an empty tuple.
         For 3D+ buffers (e.g. after pipeline expansion), extra_indices contains
         the leading dimension offsets so callers can index correctly.
+        Metal simdgroup matrix operations accept a row stride but require the
+        innermost dimension to be contiguous.
         """
         if isinstance(buf, BufferRegion):
             buffer = buf.buffer
@@ -84,7 +87,15 @@ class MPSIntrinEmitter:
             off_row = 0
             off_col = 0
             extra = ()
-        stride = buffer.shape[-1]
+        if buffer.strides:
+            inner_stride = buffer.strides[-1]
+            if not arith.Analyzer().can_prove_equal(inner_stride, 1):
+                raise ValueError(
+                    f"Metal simdgroup matrix operations require a contiguous innermost dimension (stride 1), but got stride {inner_stride}"
+                )
+            stride = buffer.strides[-2]
+        else:
+            stride = buffer.shape[-1]
         return buffer, extra, off_row, off_col, stride
 
     def ldmatrix_a(self, A_local_buf, A_shared_buf: Buffer | BufferRegion, ki):


### PR DESCRIPTION
## Summary

- use a Metal GEMM buffer's declared row stride when one is present
- retain the compact-layout fallback for buffers without explicit strides
- reject explicit layouts whose innermost dimension is not provably contiguous
- add a focused regression test for supported and unsupported explicit strides

## Intended behavior

Metal `simdgroup_load` and `simdgroup_store` accept a single leading-dimension stride. TileLang should therefore support row padding as long as elements within each row remain contiguous.

For a logical `(16, 16)` buffer declared with `strides=(32, 1)`, adjacent rows begin 32 elements apart even though each row contains 16 logical elements. The emitted simdgroup operation must receive a row stride of 32. Using `buffer.shape[-1]` would incorrectly pass 16 and load subsequent rows from padding or from the wrong logical row.

The supported layout contract is:

```text
row stride:       may be explicitly padded
innermost stride: must be provably 1
```

This does not claim support for arbitrary 2D strides. A layout such as `strides=(32, 2)` cannot be represented by Metal's single stride argument, so lowering now rejects it instead of silently generating incorrect code.

## Root cause and impact

`MPSIntrinEmitter._parse_buffer_nd` previously derived the row stride only from `buffer.shape[-1]`. That is correct for compact row-major buffers but ignores explicit Buffer stride metadata introduced by padded or transformed shared-memory layouts. Metal GEMM could consequently address the wrong rows and produce incorrect results.

The fix uses `buffer.strides[-2]` for explicitly strided buffers, while preserving `buffer.shape[-1]` for implicit compact layouts.

## Validation

- `pytest -q testing/python/metal/test_metal_gemm_v2_linux.py`
- 5 tests passed, including `(32, 1)` acceptance and `(32, 2)` rejection



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated Metal GEMM buffer parsing to honor explicitly declared row strides.
- Retained compact-layout fallback for buffers without explicit strides.
- Require a provably contiguous innermost dimension; reject unsupported layouts such as `(32, 2)`.
- Added regression coverage for supported `(32, 1)` and rejected `(32, 2)` layouts.

## Testing

- Referenced test suite passes all 5 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->