### PR TITLE
[TIR][Analyzer] Fix vectorized Select constraint handling

### DIFF
--- a/testing/python/language/test_tilelang_language_select.py
+++ b/testing/python/language/test_tilelang_language_select.py
@@ -71,5 +71,31 @@ def test_select_codegen_no_if():
     assert "if (" not in source
 
 
+@tilelang.jit
+def get_parallel_select_kernel():
+    @T.prim_func
+    def main(
+        A: T.Tensor[(1024,), T.float32],
+        B: T.Tensor[(1024,), T.float32],
+    ):
+        with T.Kernel(1, threads=128):
+            for i in T.Parallel(1024):
+                B[i] = T.Select(i < 512, A[i], 0.0)
+
+    return main
+
+
+def test_parallel_select_vectorized_condition():
+    kernel = get_parallel_select_kernel()
+    A = torch.randn((1024,), dtype=torch.float32, device="cuda")
+    B = torch.empty_like(A)
+
+    kernel(A, B)
+
+    expected = torch.zeros_like(A)
+    expected[:512] = A[:512]
+    torch.testing.assert_close(B, expected)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Summary

- Prevent analyzer-backed TIR passes from sending vector `Select` conditions to scalar constraint solvers.
- Canonicalize uniform broadcast predicates to scalar conditions so CUDA code generation emits valid conditional expressions.
- Add regression coverage at the analyzer, transform, and TileLang CUDA levels.

## Changes

- Extract scalar predicates from scalar and `Broadcast` conditions in `IRMutatorWithAnalyzer`.
- Use scalar predicates for branch constraints and preserve genuinely per-lane vector conditions without applying a global constraint.
- Rebuild uniform vector `Select` expressions with their scalar predicate while preserving source spans.
- Make the Z3 constraint entry point conservatively ignore unsupported vector dtypes.
- Add transform tests for uniform and per-lane conditions, a direct Z3 guard test, and an end-to-end parallel `Select` CUDA test.

## Validation

- `./format.sh`
- `cmake --build build -j$(nproc)`
- `PYTHONPATH=$PWD:$PWD/3rdparty/tvm/python:$PYTHONPATH TVM_LIBRARY_PATH=$PWD/build/lib python -m pytest 3rdparty/tvm/tests/python/s_tir/transform/test_s_tir_transform_renormalize_split_pattern.py 3rdparty/tvm/tests/python/arith/test_arith_simplify.py -x -k "not vscale"`
- `PYTHONPATH=$PWD:$PYTHONPATH python -m pytest testing/python/language/test_tilelang_language_select.py -x`

## Notes

- Per-lane vector predicates intentionally do not create an analyzer constraint because they have no single truth value for the whole vector expression.
- The TVM validation excludes SVE/vscale cases because the CUDA-only development build does not register the LLVM target feature query.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## PR summary

Fixes vectorized `Select` constraint handling in analyzer-backed TIR passes.

- Extracts scalar predicates from scalar and `Broadcast` conditions for branch constraints.
- Preserves per-lane vector conditions without applying global constraints.
- Rebuilds uniform vector `Select` expressions from scalar predicates while preserving source spans.
- Ignores unsupported vector dtypes at the Z3 constraint boundary.
- Updates the TVM submodule and adds analyzer, transform, Z3 guard, and end-to-end TileLang CUDA regression coverage, including parallel vectorized-select behavior.

Validation includes formatting, C++ build, selected TVM tests, and the TileLang CUDA language test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->