### PR TITLE
[TIR][Z3] Handle broadcast Select conditions safely

### DIFF
--- a/testing/python/language/test_tilelang_language_select.py
+++ b/testing/python/language/test_tilelang_language_select.py
@@ -71,5 +71,31 @@ def test_select_codegen_no_if():
     assert "if (" not in source
 
 
+@tilelang.jit
+def get_parallel_select_kernel():
+    @T.prim_func
+    def main(
+        A: T.Tensor[(1024,), T.float32],
+        B: T.Tensor[(1024,), T.float32],
+    ):
+        with T.Kernel(1, threads=128):
+            for i in T.Parallel(1024):
+                B[i] = T.Select(i < 512, A[i], 0.0)
+
+    return main
+
+
+def test_parallel_select_vectorized_condition():
+    kernel = get_parallel_select_kernel()
+    A = torch.randn((1024,), dtype=torch.float32, device="cuda")
+    B = torch.empty_like(A)
+
+    kernel(A, B)
+
+    expected = torch.zeros_like(A)
+    expected[:512] = A[:512]
+    torch.testing.assert_close(B, expected)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Summary

- Prevent analyzer constraint scopes from treating vector-valued `Select` conditions as scalar predicates.
- Preserve scalar semantics for uniform broadcast conditions so CUDA code generation does not emit a vector condition in a scalar conditional expression.
- Add TileLang regression coverage for `T.Select` inside a parallel loop.

## Changes

- Advance the TVM submodule to the analyzer and Z3 fix for broadcast and per-lane conditions.
- Extract a scalar predicate from uniform broadcasts before simplifying `Select` branches.
- Skip scalar constraint propagation for true per-lane conditions and reject unsupported Z3 constraint dtypes safely.
- Verify that a parallel select copies the selected half of the input and zero-fills the remainder.

## Validation

- `./format.sh`
- `python -m pytest testing/python/language/test_tilelang_language_select.py -x` (3 passed)
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the TVM submodule with TIR analyzer and Z3 fixes for broadcast and per-lane `Select` conditions.
- Preserved scalar semantics for uniform broadcasts while avoiding invalid scalar constraint propagation for vector conditions.
- Added a CUDA regression test covering parallel vectorized selection and zero-filling.

## Testing

- Formatting checks passed.
- Targeted three-test suite passed.
- `git diff --check` passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->