### PR TITLE
[Feature] Support stochastic FP32 to FP16/BF16 casts

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -1699,6 +1699,29 @@ void CodeGenTileLangCUDA::VisitExpr_(const CastNode *op, std::ostream &os) {
 
   // Handle conversion from float32 to float16
   if (from_ty.is_float() && from_ty.bits() == 32 && target_ty.is_float16()) {
+    if (cast_round == "rs" && cast_rbits.defined()) {
+      ICHECK(cast_sat)
+          << "sat=false is not supported for stochastic rounding f32 -> fp16";
+      std::string extra_args = ", " + PrintExpr(cast_rbits.value());
+      if (lanes == 1) {
+        PrintIndent();
+        stream << "*reinterpret_cast<unsigned short*>(&" << sret
+               << ") = tl::__tl_cvt_f32x1_to_f16x1_rs_sat(" << src << extra_args
+               << ");\n";
+        os << sret;
+        return;
+      }
+      if (lanes == 2 || lanes == 4 || lanes == 8) {
+        PrintVectorizedCast("tl::__tl_cvt_f32x2_to_f16x2_rs_sat", "float2",
+                            "half2", extra_args);
+        return;
+      }
+    }
+    if (!cast_round.empty()) {
+      LOG(FATAL) << "Unsupported rounding mode '" << cast_round
+                 << "' for f32 -> FP16 cast. Only packed 'rs' stochastic "
+                    "rounding is supported.";
+    }
     // Use __float22half2_rn for vectorized conversion (float2 -> half2)
     if (lanes == 2 || lanes == 4 || lanes == 8) {
       PrintVectorizedCast("__float22half2_rn", "float2", "half2");
@@ -1718,6 +1741,29 @@ void CodeGenTileLangCUDA::VisitExpr_(const CastNode *op, std::ostream &os) {
 
   // Handle conversion from float32 to bfloat16
   if (from_ty.is_float() && from_ty.bits() == 32 && target_ty.is_bfloat16()) {
+    if (cast_round == "rs" && cast_rbits.defined()) {
+      ICHECK(cast_sat)
+          << "sat=false is not supported for stochastic rounding f32 -> bf16";
+      std::string extra_args = ", " + PrintExpr(cast_rbits.value());
+      if (lanes == 1) {
+        PrintIndent();
+        stream << "*reinterpret_cast<unsigned short*>(&" << sret
+               << ") = tl::__tl_cvt_f32x1_to_bf16x1_rs_sat(" << src
+               << extra_args << ");\n";
+        os << sret;
+        return;
+      }
+      if (lanes == 2 || lanes == 4 || lanes == 8) {
+        PrintVectorizedCast("tl::__tl_cvt_f32x2_to_bf16x2_rs_sat", "float2",
+                            "__nv_bfloat162", extra_args, false, true);
+        return;
+      }
+    }
+    if (!cast_round.empty()) {
+      LOG(FATAL) << "Unsupported rounding mode '" << cast_round
+                 << "' for f32 -> BF16 cast. Only packed 'rs' stochastic "
+                    "rounding is supported.";
+    }
     // Use __float22bfloat162_rn for vectorized conversion (float2 -> bfloat162)
     if (lanes == 2 || lanes == 4 || lanes == 8) {
       PrintVectorizedCast("__float22bfloat162_rn", "float2", "__nv_bfloat162",
@@ -2063,7 +2109,8 @@ void CodeGenTileLangCUDA::VisitExpr_(const CastNode *op, std::ostream &os) {
   if (!cast_round.empty()) {
     LOG(FATAL) << "round '" << cast_round << "' is not supported for cast from "
                << from_ty << " to " << target_ty
-               << " (only f32 -> fp8/fp4 supported)";
+               << " (only supported f32 packed stochastic conversions are "
+                  "available)";
   }
 
   // Fallback: elementwise cast.

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -883,6 +883,67 @@ TL_DEVICE uint1 pack_half2(half_t a, half_t b) {
   return uint1{packed};
 }
 
+// ============================================================================
+// Inline PTX FP16/BF16 Conversions with Stochastic Rounding
+// ============================================================================
+//
+// PTX packs operand a into the high half and operand b into the low half.
+// Reverse float2 lane order to preserve TVM's little-endian x/y layout.
+
+// --- float2 -> f16x2 stochastic rounding ---
+
+template <bool kDependentFalse = false>
+TL_DEVICE half2 __tl_cvt_f32x2_to_f16x2_rs_sat(float2 src, unsigned int rbits) {
+#if defined(__CUDA_ARCH_FEAT_SM100_ALL) || defined(__CUDA_ARCH_FEAT_SM103_ALL)
+  unsigned int result;
+  // FP32 -> FP16 consumes 13 random bits per lane; reserved bits must be zero.
+  rbits &= 0x1fff1fffU;
+  asm("cvt.rs.satfinite.f16x2.f32 %0, %1, %2, %3;"
+      : "=r"(result)
+      : "f"(src.y), "f"(src.x), "r"(rbits));
+  return *reinterpret_cast<half2 *>(&result);
+#else
+  static_assert(kDependentFalse,
+                "Stochastic rounding f32-to-FP16 requires sm_100a or sm_103a");
+  return {};
+#endif
+}
+
+template <bool kDependentFalse = false>
+TL_DEVICE unsigned short __tl_cvt_f32x1_to_f16x1_rs_sat(float src,
+                                                        unsigned int rbits) {
+  half2 result = __tl_cvt_f32x2_to_f16x2_rs_sat(make_float2(src, 0.0f), rbits);
+  return static_cast<unsigned short>(
+      *reinterpret_cast<unsigned int *>(&result));
+}
+
+// --- float2 -> bf16x2 stochastic rounding ---
+
+template <bool kDependentFalse = false>
+TL_DEVICE __nv_bfloat162 __tl_cvt_f32x2_to_bf16x2_rs_sat(float2 src,
+                                                         unsigned int rbits) {
+#if defined(__CUDA_ARCH_FEAT_SM100_ALL) || defined(__CUDA_ARCH_FEAT_SM103_ALL)
+  unsigned int result;
+  asm("cvt.rs.satfinite.bf16x2.f32 %0, %1, %2, %3;"
+      : "=r"(result)
+      : "f"(src.y), "f"(src.x), "r"(rbits));
+  return *reinterpret_cast<__nv_bfloat162 *>(&result);
+#else
+  static_assert(kDependentFalse,
+                "Stochastic rounding f32-to-BF16 requires sm_100a or sm_103a");
+  return {};
+#endif
+}
+
+template <bool kDependentFalse = false>
+TL_DEVICE unsigned short __tl_cvt_f32x1_to_bf16x1_rs_sat(float src,
+                                                         unsigned int rbits) {
+  __nv_bfloat162 result =
+      __tl_cvt_f32x2_to_bf16x2_rs_sat(make_float2(src, 0.0f), rbits);
+  return static_cast<unsigned short>(
+      *reinterpret_cast<unsigned int *>(&result));
+}
+
 template <uint64_t bytes, uint64_t init_val>
 TL_DEVICE void st_bulk_shared(void *smem_ptr) {
   static_assert(init_val == 0,

--- a/src/tl_templates/cuda/cuda_fp4.h
+++ b/src/tl_templates/cuda/cuda_fp4.h
@@ -283,7 +283,7 @@ TL_DEVICE __nv_fp4x2_storage_t __tl_cvt_float2_to_fp4x2(const float2 src) {
 template <bool kDependentFalse = false>
 TL_DEVICE __nv_fp4x4_storage_t
 __tl_cvt_f32x4_to_e2m1x4_rs_sat(float4 src, unsigned int rbits) {
-#if defined(__CUDA_ARCH_FEAT_SM100_ALL)
+#if defined(__CUDA_ARCH_FEAT_SM100_ALL) || defined(__CUDA_ARCH_FEAT_SM103_ALL)
   __nv_fp4x4_storage_t result;
   asm("cvt.rs.satfinite.e2m1x4.f32 %0, {%1, %2, %3, %4}, %5;"
       : "=h"(result)
@@ -291,7 +291,7 @@ __tl_cvt_f32x4_to_e2m1x4_rs_sat(float4 src, unsigned int rbits) {
   return result;
 #else
   static_assert(kDependentFalse,
-                "Stochastic rounding f32-to-FP4 requires sm_100a");
+                "Stochastic rounding f32-to-FP4 requires sm_100a or sm_103a");
   return {};
 #endif
 }
@@ -300,7 +300,7 @@ __tl_cvt_f32x4_to_e2m1x4_rs_sat(float4 src, unsigned int rbits) {
 template <bool kDependentFalse = false>
 TL_DEVICE __nv_fp4x2_storage_t
 __tl_cvt_f32x2_to_e2m1x2_rs_sat(float2 src, unsigned int rbits) {
-#if defined(__CUDA_ARCH_FEAT_SM100_ALL)
+#if defined(__CUDA_ARCH_FEAT_SM100_ALL) || defined(__CUDA_ARCH_FEAT_SM103_ALL)
   __nv_fp4x4_storage_t tmp;
   asm("cvt.rs.satfinite.e2m1x4.f32 %0, {%1, %2, %3, %4}, %5;"
       : "=h"(tmp)
@@ -308,7 +308,7 @@ __tl_cvt_f32x2_to_e2m1x2_rs_sat(float2 src, unsigned int rbits) {
   return static_cast<__nv_fp4x2_storage_t>(tmp & 0xFF);
 #else
   static_assert(kDependentFalse,
-                "Stochastic rounding f32-to-FP4 requires sm_100a");
+                "Stochastic rounding f32-to-FP4 requires sm_100a or sm_103a");
   return {};
 #endif
 }
@@ -317,7 +317,7 @@ __tl_cvt_f32x2_to_e2m1x2_rs_sat(float2 src, unsigned int rbits) {
 template <bool kDependentFalse = false>
 TL_DEVICE __nv_fp4_storage_t
 __tl_cvt_f32x1_to_e2m1x1_rs_sat(float src, unsigned int rbits) {
-#if defined(__CUDA_ARCH_FEAT_SM100_ALL)
+#if defined(__CUDA_ARCH_FEAT_SM100_ALL) || defined(__CUDA_ARCH_FEAT_SM103_ALL)
   __nv_fp4x4_storage_t tmp;
   asm("cvt.rs.satfinite.e2m1x4.f32 %0, {%1, %2, %3, %4}, %5;"
       : "=h"(tmp)
@@ -325,7 +325,7 @@ __tl_cvt_f32x1_to_e2m1x1_rs_sat(float src, unsigned int rbits) {
   return static_cast<__nv_fp4_storage_t>(tmp & 0x0F);
 #else
   static_assert(kDependentFalse,
-                "Stochastic rounding f32-to-FP4 requires sm_100a");
+                "Stochastic rounding f32-to-FP4 requires sm_100a or sm_103a");
   return {};
 #endif
 }

--- a/src/tl_templates/cuda/cuda_fp8.h
+++ b/src/tl_templates/cuda/cuda_fp8.h
@@ -437,7 +437,7 @@ TL_DEVICE __nv_fp8x2_storage_t __tl_cvt_bfloat162_to_fp8x2(
 template <bool kDependentFalse = false>
 TL_DEVICE __nv_fp8x4_storage_t
 __tl_cvt_f32x4_to_e4m3x4_rs_sat(float4 src, unsigned int rbits) {
-#if defined(__CUDA_ARCH_FEAT_SM100_ALL)
+#if defined(__CUDA_ARCH_FEAT_SM100_ALL) || defined(__CUDA_ARCH_FEAT_SM103_ALL)
   __nv_fp8x4_storage_t result;
   asm("cvt.rs.satfinite.e4m3x4.f32 %0, {%1, %2, %3, %4}, %5;"
       : "=r"(result)
@@ -445,7 +445,7 @@ __tl_cvt_f32x4_to_e4m3x4_rs_sat(float4 src, unsigned int rbits) {
   return result;
 #else
   static_assert(kDependentFalse,
-                "Stochastic rounding f32-to-FP8 requires sm_100a");
+                "Stochastic rounding f32-to-FP8 requires sm_100a or sm_103a");
   return {};
 #endif
 }
@@ -454,7 +454,7 @@ __tl_cvt_f32x4_to_e4m3x4_rs_sat(float4 src, unsigned int rbits) {
 template <bool kDependentFalse = false>
 TL_DEVICE __nv_fp8_storage_t
 __tl_cvt_f32x1_to_e4m3x1_rs_sat(float src, unsigned int rbits) {
-#if defined(__CUDA_ARCH_FEAT_SM100_ALL)
+#if defined(__CUDA_ARCH_FEAT_SM100_ALL) || defined(__CUDA_ARCH_FEAT_SM103_ALL)
   __nv_fp8x4_storage_t tmp;
   asm("cvt.rs.satfinite.e4m3x4.f32 %0, {%1, %2, %3, %4}, %5;"
       : "=r"(tmp)
@@ -462,7 +462,7 @@ __tl_cvt_f32x1_to_e4m3x1_rs_sat(float src, unsigned int rbits) {
   return static_cast<__nv_fp8_storage_t>(tmp & 0xFF);
 #else
   static_assert(kDependentFalse,
-                "Stochastic rounding f32-to-FP8 requires sm_100a");
+                "Stochastic rounding f32-to-FP8 requires sm_100a or sm_103a");
   return {};
 #endif
 }
@@ -471,7 +471,7 @@ __tl_cvt_f32x1_to_e4m3x1_rs_sat(float src, unsigned int rbits) {
 template <bool kDependentFalse = false>
 TL_DEVICE __nv_fp8x2_storage_t
 __tl_cvt_f32x2_to_e4m3x2_rs_sat(float2 src, unsigned int rbits) {
-#if defined(__CUDA_ARCH_FEAT_SM100_ALL)
+#if defined(__CUDA_ARCH_FEAT_SM100_ALL) || defined(__CUDA_ARCH_FEAT_SM103_ALL)
   __nv_fp8x4_storage_t tmp;
   asm("cvt.rs.satfinite.e4m3x4.f32 %0, {%1, %2, %3, %4}, %5;"
       : "=r"(tmp)
@@ -479,7 +479,7 @@ __tl_cvt_f32x2_to_e4m3x2_rs_sat(float2 src, unsigned int rbits) {
   return static_cast<__nv_fp8x2_storage_t>(tmp & 0xFFFF);
 #else
   static_assert(kDependentFalse,
-                "Stochastic rounding f32-to-FP8 requires sm_100a");
+                "Stochastic rounding f32-to-FP8 requires sm_100a or sm_103a");
   return {};
 #endif
 }
@@ -490,7 +490,7 @@ __tl_cvt_f32x2_to_e4m3x2_rs_sat(float2 src, unsigned int rbits) {
 template <bool kDependentFalse = false>
 TL_DEVICE __nv_fp8x4_storage_t
 __tl_cvt_f32x4_to_e5m2x4_rs_sat(float4 src, unsigned int rbits) {
-#if defined(__CUDA_ARCH_FEAT_SM100_ALL)
+#if defined(__CUDA_ARCH_FEAT_SM100_ALL) || defined(__CUDA_ARCH_FEAT_SM103_ALL)
   __nv_fp8x4_storage_t result;
   asm("cvt.rs.satfinite.e5m2x4.f32 %0, {%1, %2, %3, %4}, %5;"
       : "=r"(result)
@@ -498,7 +498,7 @@ __tl_cvt_f32x4_to_e5m2x4_rs_sat(float4 src, unsigned int rbits) {
   return result;
 #else
   static_assert(kDependentFalse,
-                "Stochastic rounding f32-to-FP8 requires sm_100a");
+                "Stochastic rounding f32-to-FP8 requires sm_100a or sm_103a");
   return {};
 #endif
 }
@@ -507,7 +507,7 @@ __tl_cvt_f32x4_to_e5m2x4_rs_sat(float4 src, unsigned int rbits) {
 template <bool kDependentFalse = false>
 TL_DEVICE __nv_fp8_storage_t
 __tl_cvt_f32x1_to_e5m2x1_rs_sat(float src, unsigned int rbits) {
-#if defined(__CUDA_ARCH_FEAT_SM100_ALL)
+#if defined(__CUDA_ARCH_FEAT_SM100_ALL) || defined(__CUDA_ARCH_FEAT_SM103_ALL)
   __nv_fp8x4_storage_t tmp;
   asm("cvt.rs.satfinite.e5m2x4.f32 %0, {%1, %2, %3, %4}, %5;"
       : "=r"(tmp)
@@ -515,7 +515,7 @@ __tl_cvt_f32x1_to_e5m2x1_rs_sat(float src, unsigned int rbits) {
   return static_cast<__nv_fp8_storage_t>(tmp & 0xFF);
 #else
   static_assert(kDependentFalse,
-                "Stochastic rounding f32-to-FP8 requires sm_100a");
+                "Stochastic rounding f32-to-FP8 requires sm_100a or sm_103a");
   return {};
 #endif
 }
@@ -524,7 +524,7 @@ __tl_cvt_f32x1_to_e5m2x1_rs_sat(float src, unsigned int rbits) {
 template <bool kDependentFalse = false>
 TL_DEVICE __nv_fp8x2_storage_t
 __tl_cvt_f32x2_to_e5m2x2_rs_sat(float2 src, unsigned int rbits) {
-#if defined(__CUDA_ARCH_FEAT_SM100_ALL)
+#if defined(__CUDA_ARCH_FEAT_SM100_ALL) || defined(__CUDA_ARCH_FEAT_SM103_ALL)
   __nv_fp8x4_storage_t tmp;
   asm("cvt.rs.satfinite.e5m2x4.f32 %0, {%1, %2, %3, %4}, %5;"
       : "=r"(tmp)
@@ -532,7 +532,7 @@ __tl_cvt_f32x2_to_e5m2x2_rs_sat(float2 src, unsigned int rbits) {
   return static_cast<__nv_fp8x2_storage_t>(tmp & 0xFFFF);
 #else
   static_assert(kDependentFalse,
-                "Stochastic rounding f32-to-FP8 requires sm_100a");
+                "Stochastic rounding f32-to-FP8 requires sm_100a or sm_103a");
   return {};
 #endif
 }

--- a/testing/python/language/test_tilelang_cast_rounding.py
+++ b/testing/python/language/test_tilelang_cast_rounding.py
@@ -151,15 +151,14 @@ def _make_rs_kernel(M: int, num_threads: int, target_dtype: str):
     return main
 
 
-def _make_rs_prim_func(target_dtype: str):
-    M = 128
+def _make_rs_prim_func(target_dtype: str, M: int = 128, threads: int = 128):
 
     @T.prim_func
     def main(
         A: T.Tensor[(M,), "float32"],  # noqa: F821
         B: T.Tensor[(M,), target_dtype],  # noqa: F821
     ):
-        with T.Kernel(1, threads=128):
+        with T.Kernel(1, threads=threads):
             A_local = T.alloc_fragment((M,), "float32")
             B_local = T.alloc_fragment((M,), target_dtype)
             rbits = T.alloc_fragment((1,), "int32")
@@ -180,6 +179,116 @@ def _lower_rs_prim_func(target_dtype: str, arch: str, *, enable_device_compile: 
             target=target,
             enable_device_compile=enable_device_compile,
         )
+
+
+@pytest.mark.parametrize(
+    "target_dtype,expected",
+    [
+        ("float16", "__tl_cvt_f32x1_to_f16x1_rs_sat"),
+        ("bfloat16", "__tl_cvt_f32x1_to_bf16x1_rs_sat"),
+    ],
+)
+def test_cast_rs_fp16_bf16_codegen(target_dtype, expected):
+    artifact = _lower_rs_prim_func(target_dtype, "sm_100a")
+
+    assert expected in artifact.kernel_source
+
+
+@pytest.mark.parametrize(
+    "target_dtype,expected",
+    [
+        ("float16", "__tl_cvt_f32x2_to_f16x2_rs_sat"),
+        ("bfloat16", "__tl_cvt_f32x2_to_bf16x2_rs_sat"),
+    ],
+)
+def test_cast_rs_fp16_bf16_packed_codegen(target_dtype, expected):
+    target = tvm.target.Target({"kind": "cuda", "arch": "sm_100a"})
+    with target:
+        artifact = tilelang.lower(_make_rs_prim_func(target_dtype, M=256), target=target)
+
+    assert expected in artifact.kernel_source
+
+
+@pytest.mark.parametrize("target_dtype", ["float16", "bfloat16"])
+def test_cast_rs_fp16_bf16_rejects_sat_false(target_dtype):
+    M = 256
+
+    @T.prim_func
+    def main(
+        A: T.Tensor[(M,), "float32"],  # noqa: F821
+        B: T.Tensor[(M,), target_dtype],  # noqa: F821
+    ):
+        with T.Kernel(1, threads=128):
+            A_local = T.alloc_fragment((M,), "float32")
+            B_local = T.alloc_fragment((M,), target_dtype)
+            T.copy(A, A_local)
+            for i in T.Parallel(M):
+                B_local[i] = T.cast(A_local[i], target_dtype, round="rs", sat=False, rbits=T.uint32(0x12345678))
+            T.copy(B_local, B)
+
+    target = tvm.target.Target({"kind": "cuda", "arch": "sm_100a"})
+    with target, pytest.raises(Exception, match="sat=false is not supported"):
+        tilelang.lower(main, target=target)
+
+
+@pytest.mark.parametrize(
+    "target_dtype,expected",
+    [
+        ("float16", "__tl_cvt_f32x1_to_f16x1_rs_sat"),
+        ("bfloat16", "__tl_cvt_f32x1_to_bf16x1_rs_sat"),
+    ],
+)
+def test_cast_rs_fp16_bf16_per_element_rbits_codegen(target_dtype, expected):
+    M = 128
+
+    @T.prim_func
+    def main(
+        A: T.Tensor[(M,), "float32"],  # noqa: F821
+        B: T.Tensor[(M,), target_dtype],  # noqa: F821
+    ):
+        with T.Kernel(1, threads=128):
+            A_local = T.alloc_fragment((M,), "float32")
+            B_local = T.alloc_fragment((M,), target_dtype)
+            rbits = T.alloc_fragment((M,), "uint32")
+            T.copy(A, A_local)
+            for i in T.Parallel(M):
+                rbits[i] = T.uint32(0x12345678)
+            for i in T.Parallel(M):
+                B_local[i] = T.cast(A_local[i], target_dtype, round="rs", rbits=rbits[i])
+            T.copy(B_local, B)
+
+    target = tvm.target.Target({"kind": "cuda", "arch": "sm_100a"})
+    with target:
+        artifact = tilelang.lower(main, target=target)
+
+    assert expected in artifact.kernel_source
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize(
+    "target_dtype,expected_error",
+    [
+        ("float16", "Stochastic rounding f32-to-FP16 requires sm_100a"),
+        ("bfloat16", "Stochastic rounding f32-to-BF16 requires sm_100a"),
+    ],
+)
+def test_cast_rs_fp16_bf16_requires_sm100a(target_dtype, expected_error):
+    with pytest.raises(RuntimeError, match=expected_error):
+        _lower_rs_prim_func(target_dtype, "sm_100", enable_device_compile=True)
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize(
+    "target_dtype,expected",
+    [
+        ("float16", "__tl_cvt_f32x1_to_f16x1_rs_sat"),
+        ("bfloat16", "__tl_cvt_f32x1_to_bf16x1_rs_sat"),
+    ],
+)
+def test_cast_rs_fp16_bf16_compiles_for_sm100a(target_dtype, expected):
+    artifact = _lower_rs_prim_func(target_dtype, "sm_100a", enable_device_compile=True)
+
+    assert expected in artifact.kernel_source
 
 
 @tilelang.testing.requires_cuda


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added stochastic FP32→FP16/BF16 cast code generation for scalar and packed lanes using `*_rs_sat` helpers.
- Rejects `sat=false` for these stochastic conversions.
- Added CUDA/PTX conversion helpers with SM100/SM103 support and guarded fallbacks.
- Extended FP4/FP8 stochastic conversion support to SM103.
- Expanded rounding code-generation and architecture-compatibility tests for FP16/BF16, including packed lanes, per-element `rbits`, saturation validation, and compilation checks.

## C++ style / lint notes

- The PR changes C++ code and CUDA template headers but does not appear to modify documented rules in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit is warning-only; any TLCPP003/TLCPP004 findings should be treated as advisory unless they indicate a concrete API, FFI, or maintainability risk.
- No correctness or build issues are indicated by the described changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->