### PR TITLE
[Build] Raise apache-tvm-ffi lower bound to 0.1.11

### DIFF
--- a/docs/get_started/Installation.md
+++ b/docs/get_started/Installation.md
@@ -271,7 +271,7 @@ pip install -e . -v --no-build-isolation --no-deps
 
 # Manually install required runtime deps when using --no-deps.
 # Note: skip torch-c-dlpack-ext on ROCm (its wheel expects CUDA libs).
-pip install "apache-tvm-ffi>=0.1.10,<=0.1.11" "z3-solver>=4.13.0"
+pip install "apache-tvm-ffi>=0.1.11,<0.1.12" "z3-solver>=4.13.0"
 # If you already installed torch-c-dlpack-ext and hit `libtorch_cuda.so` errors:
 # pip uninstall -y torch-c-dlpack-ext
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "apache-tvm-ffi>=0.1.10,<=0.1.11",
+    "apache-tvm-ffi>=0.1.11,<0.1.12",
     # torch-c-dlpack-ext provides prebuilt torch extensions.
     # Without it, TVM FFI may require JIT compilation on first import.
     "torch-c-dlpack-ext; python_version < '3.14'",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Requirements to run local build with `--no-build-isolation` or other developments
 
-apache-tvm-ffi>=0.1.10,<=0.1.11
+apache-tvm-ffi>=0.1.11,<0.1.12
 build
 cmake>=3.26
 cython>=3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Runtime requirements
 
-apache-tvm-ffi>=0.1.10,<=0.1.11
+apache-tvm-ffi>=0.1.11,<0.1.12
 torch-c-dlpack-ext; python_version < '3.14'
 cloudpickle
 ml-dtypes


### PR DESCRIPTION
## Summary

Since #2452 (merged 2026-07-01), `tilelang/layout/swizzle_mode.py` does:

```python
from tvm_ffi.dataclasses import Enum
```

`Enum` was only added to `tvm_ffi.dataclasses` in **apache-tvm-ffi 0.1.11** — 0.1.10 only exports `Field, KW_ONLY, c_class, field, py_class`. So the actual minimum requirement is 0.1.11, but the declared range is still `>=0.1.10,<=0.1.11` (from #2373).

## Failure mode

In an environment that already has apache-tvm-ffi **0.1.10** installed, `pip install .` considers the requirement satisfied and keeps 0.1.10. `import tilelang` then fails immediately:

```
File ".../tilelang/layout/swizzle_mode.py", line 7, in <module>
    from tvm_ffi.dataclasses import Enum
ImportError: cannot import name 'Enum' from 'tvm_ffi.dataclasses'
```

This is invisible to CI and to fresh installs, because dependency resolution on a clean venv always picks the upper bound (0.1.11). It only bites users who install from source into an existing environment that pinned/installed 0.1.10 back when it was current — which #2373 explicitly declared supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Raised the minimum `apache-tvm-ffi` version from `0.1.10` to `0.1.11`.
- Applied consistent bounds (`>=0.1.11,<0.1.12`) across runtime, development, project, and ROCm installation dependencies.
- Ensures `tvm_ffi.dataclasses.Enum` is available when importing TileLang.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->