### PR TITLE
[CUDA][Pipeline] Fix 1D TMA selection for versioned layouts

### DIFF
--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -2393,6 +2393,13 @@ Stmt Copy::LowerBulk1D(const CopyNode &op, const LowerArgs &lower_args,
       barrier_before_tma_stmt =
           Evaluate(Call(DataType::Handle(), mbarrier_expect_tx(),
                         {mbar_handle, total_bytes}));
+      if (auto emit_arrive_val = annotations.Get("emit_arrive")) {
+        if (Downcast<IntImm>(emit_arrive_val.value())->value != 0) {
+          barrier_after_tma_stmt =
+              Evaluate(Call(DataType::Handle(), builtin::ptx_arrive_barrier(),
+                            {mbar_handle}));
+        }
+      }
     } else {
       barrier_before_tma_stmt =
           Evaluate(Call(DataType::Handle(), mbarrier_expect_tx(),

--- a/src/cuda/op/copy_analysis.cc
+++ b/src/cuda/op/copy_analysis.cc
@@ -5,7 +5,6 @@
 
 #include "cuda/op/copy.h"
 #include "support/check.h"
-#include <tvm/ffi/extra/structural_equal.h>
 #include <tvm/runtime/logging.h>
 
 #include "cuda/target_utils.h"
@@ -265,6 +264,24 @@ bool CheckBulkStore(const CopyNode &op, Target target,
   return CheckGlobalStrides(op.dst, analyzer, emit_diagnostics);
 }
 
+bool IsSemanticallyLinearLayout(const Layout &layout,
+                                const Array<PrimExpr> &shape,
+                                arith::Analyzer *analyzer) {
+  Array<PrimExpr> input_shape = layout->InputShape();
+  if (input_shape.size() != shape.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < shape.size(); ++i) {
+    if (!analyzer->CanProveEqual(input_shape[i], shape[i])) {
+      return false;
+    }
+  }
+
+  Layout linear_layout = MakeLinearLayout(shape);
+  return analyzer->CanProveEqual(layout->GetLinearizedForwardIndex(),
+                                 linear_layout->GetLinearizedForwardIndex());
+}
+
 bool CheckBulkCopy1D(const Buffer &global_tensor, const Buffer &shared_tensor,
                      const Array<Range> &global_range,
                      const Array<Range> &shared_range,
@@ -273,8 +290,8 @@ bool CheckBulkCopy1D(const Buffer &global_tensor, const Buffer &shared_tensor,
   if (layout_map.count(shared_tensor)) {
     Layout existing =
         layout_map.Get(shared_tensor).value().as<Layout>().value();
-    Layout linear_layout = MakeLinearLayout(shared_tensor->shape);
-    shared_is_contiguous = StructuralEqual()(existing, linear_layout);
+    shared_is_contiguous =
+        IsSemanticallyLinearLayout(existing, shared_tensor->shape, analyzer);
   }
 
   bool global_is_contiguous = true;

--- a/src/layout/layout.cc
+++ b/src/layout/layout.cc
@@ -395,6 +395,17 @@ Array<PrimExpr> LayoutNode::OutputShape() const {
   return ret;
 }
 
+PrimExpr LayoutNode::GetLinearizedForwardIndex() const {
+  Array<PrimExpr> output_shape = OutputShape();
+  ICHECK_EQ(output_shape.size(), forward_index_.size());
+
+  PrimExpr linearized_index = Integer(0);
+  for (size_t i = 0; i < forward_index_.size(); ++i) {
+    linearized_index = linearized_index * output_shape[i] + forward_index_[i];
+  }
+  return linearized_index;
+}
+
 Array<PrimExpr> LayoutNode::Forward(const Array<PrimExpr> &vars) const {
   if (vars.empty())
     return forward_index_;
@@ -1087,6 +1098,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
            })
       .def("tl.Layout_index",
            [](Layout layout) { return layout->GetForwardIndex(); })
+      .def("tl.Layout_linearized_index",
+           [](Layout layout) { return layout->GetLinearizedForwardIndex(); })
       .def("tl.Layout_forward_vars",
            [](Layout layout) { return layout->GetForwardVars(); })
       .def("tl.Layout_repeat",

--- a/src/layout/layout.h
+++ b/src/layout/layout.h
@@ -59,6 +59,16 @@ public:
 
   ffi::Array<PrimExpr> GetForwardIndex() const { return forward_index_; }
 
+  /*!
+   * \brief Convert the physical output coordinates to a row-major linear
+   * index.
+   *
+   * For output coordinates [f0, f1, ..., fn] with shape
+   * [s0, s1, ..., sn], this returns
+   * (((f0 * s1 + f1) * s2 + f2) ... * sn + fn).
+   */
+  PrimExpr GetLinearizedForwardIndex() const;
+
   virtual ffi::Array<PrimExpr> GetForwardVars() const;
 
   virtual ffi::Array<PrimExpr> Forward(const ffi::Array<PrimExpr> &vars) const;

--- a/testing/python/issue/test_tilelang_issue_2528.py
+++ b/testing/python/issue/test_tilelang_issue_2528.py
@@ -1,0 +1,44 @@
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+def make_kernel(chunk_size, block_k, num_stages, threads=128):
+    @T.prim_func
+    def main(
+        source: T.Tensor((chunk_size,), T.float16),
+        output: T.Tensor((chunk_size,), T.float32),
+    ):
+        with T.Kernel(1, threads=threads):
+            source_shared = T.alloc_shared((block_k,), T.float16)
+            source_local = T.alloc_fragment((block_k,), T.float32)
+            for k in T.Pipelined(T.ceildiv(chunk_size, block_k), num_stages=num_stages):
+                T.copy(source[k * block_k : (k + 1) * block_k], source_shared)
+                T.copy(source_shared, source_local)
+                for i in T.Parallel(block_k):
+                    output[k * block_k + i] = source_local[i] * 2.0
+
+    return tilelang.compile(main)
+
+
+@tilelang.testing.requires_cuda_compute_version(9, 0)
+def test_pipeline_versioned_1d_copy_uses_linear_bulk():
+    chunk_size = 256
+    source = torch.randint(0, 3, (chunk_size,), device="cuda").half()
+
+    for num_stages in (2, 3):
+        kernel = make_kernel(chunk_size, block_k=32, num_stages=num_stages)
+        code = kernel.get_kernel_source()
+        assert "tl::tma_load" in code
+        assert "CUtensorMap" not in code
+        assert ".arrive_and_expect_tx(64)" in code
+
+        output = torch.empty(chunk_size, device="cuda", dtype=torch.float32)
+        kernel(source, output)
+        torch.testing.assert_close(output, source.float() * 2.0)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/layout/test_tilelang_layout_linearized_index.py
+++ b/testing/python/layout/test_tilelang_layout_linearized_index.py
@@ -1,0 +1,41 @@
+import tilelang.testing
+from tilelang import tvm
+from tilelang.layout import Layout
+
+
+def _assert_indices_equal(lhs, rhs):
+    assert tvm.arith.Analyzer().can_prove_equal(lhs, rhs), f"{lhs} != {rhs}"
+
+
+def test_linearized_forward_index_for_multi_dimensional_output():
+    layout = Layout([2, 3, 4], lambda i, j, k: [i, j, k])
+    linear = Layout([2, 3, 4], lambda i, j, k: i * 12 + j * 4 + k)
+
+    _assert_indices_equal(
+        layout.get_linearized_forward_index(),
+        linear.get_linearized_forward_index(),
+    )
+
+
+def test_linearized_forward_index_for_split_output():
+    layout = Layout([64], lambda i: [i // 32, i % 32])
+    linear = Layout([64], lambda i: i)
+
+    _assert_indices_equal(
+        layout.get_linearized_forward_index(),
+        linear.get_linearized_forward_index(),
+    )
+
+
+def test_linearized_forward_index_uses_output_shape():
+    transposed = Layout([2, 32], lambda i, j: [j, i])
+    expected = Layout([2, 32], lambda i, j: j * 2 + i)
+
+    _assert_indices_equal(
+        transposed.get_linearized_forward_index(),
+        expected.get_linearized_forward_index(),
+    )
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/layout/layout.py
+++ b/tilelang/layout/layout.py
@@ -90,6 +90,10 @@ class Layout(Node):
     def get_forward_index(self):
         return self.index
 
+    def get_linearized_forward_index(self) -> PrimExpr:
+        """Return the row-major linear offset of the physical output index."""
+        return _ffi_api.Layout_linearized_index(self)
+
     def map_forward_index(self, indices: list[PrimExpr]) -> PrimExpr:
         """
         Compute the forward index mapping for a given set of input indices.


### PR DESCRIPTION
## Summary

- Keep pipeline-versioned 1D shared-memory copies on the descriptor-less `cp.async.bulk` path when their physical layout is semantically row-major.
- Add a reusable linearized-forward-index query to Layout and expose it through Python.
- Complete the 1D bulk TMA barrier protocol for pure TMA producer pipelines.

Fixes #2528

## Changes

- Add `LayoutNode::GetLinearizedForwardIndex()` to fold multidimensional output coordinates into a row-major element offset.
- Replace structural layout equality in `CheckBulkCopy1D` with analyzer-proven equivalence of input shapes and linearized address expressions.
- Honor `emit_arrive` in `LowerBulk1D`, allowing the barrier fusion pass to emit `arrive_and_expect_tx` and preventing pipeline waits from stalling.
- Add layout-level unit coverage and a CUDA regression for two- and three-stage pipeline versioning. Existing explicit swizzle coverage confirms non-linear layouts remain on descriptor TMA.

## Validation

- `./format.sh`
- `cmake --build build`
- `TILELANG_DISABLE_CACHE=1 PYTHONPATH=$PWD:$PWD/3rdparty/tvm/python python3 -m pytest testing/python/layout/test_tilelang_layout_linearized_index.py testing/python/layout/test_tilelang_layout_repeat.py testing/python/layout/test_tilelang_layout_expand.py testing/python/issue/test_tilelang_issue_2528.py testing/python/language/test_tilelang_language_tma_1d.py testing/python/layout/test_tilelang_cute.py::test_tma_load_with_explicit_swizzled_layout -q -s`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed versioned 1D TMA selection by recognizing semantically row-major layouts through analyzer-based equivalence checks.
- Added `Layout.get_linearized_forward_index()` with Python FFI bindings for reusable linearized index queries.
- Completed the 1D bulk TMA barrier protocol with conditional `emit_arrive` handling.
- Preserved descriptor-based TMA for explicitly non-linear swizzled layouts.

## Testing

- Added layout tests covering multidimensional, split, and transposed mappings.
- Added CUDA regressions for two- and three-stage pipelined copies, validating generated TMA instructions and output correctness.
- Covers the issue `#2528` alignment scenarios, including `block_K=32` and `block_K=64` configurations.

## C++ style / lint notes

- This PR changes C++ implementation and public API/FFI declarations; review against `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) may report advisory findings for the new API or FFI binding; these are not merge blockers unless they indicate a concrete API or maintainability risk.
- No correctness or build issues are indicated by the changes summarized here.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->