### PR TITLE
[BugFix] Emit Metal barriers for dynamic shared memory

### DIFF
--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -289,7 +289,7 @@ void CodeGenTileLangMetal::PrintStorageSync(const CallNode *op) {
     // though the hardware effect is identical.
     this->PrintIndent();
     this->stream << "simdgroup_barrier(mem_flags::mem_threadgroup);\n";
-  } else if (sync == "shared") {
+  } else if (sync == "shared" || sync == "shared.dyn") {
     this->PrintIndent();
     this->stream << "threadgroup_barrier(mem_flags::mem_threadgroup);\n";
   } else if (sync == "global") {

--- a/testing/python/metal/test_metal_gemm_v2_linux.py
+++ b/testing/python/metal/test_metal_gemm_v2_linux.py
@@ -104,5 +104,16 @@ def test_metal_gemm_validates_explicit_buffer_strides():
         MPSIntrinEmitter._parse_buffer_nd(noncontiguous_buffer)
 
 
+def test_metal_codegen_emits_dynamic_shared_barrier():
+    @T.prim_func
+    def main():
+        with T.Kernel(1, threads=32):
+            T.tvm_storage_sync("shared.dyn")
+
+    artifact = tilelang.lower(main, target="metal")
+
+    assert "threadgroup_barrier(mem_flags::mem_threadgroup)" in artifact.kernel_source
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Summary

- emit a Metal `threadgroup_barrier` for `tvm_storage_sync("shared.dyn")`
- add a focused Metal code-generation regression test

## Intended behavior

Metal maps both TileLang `shared` and `shared.dyn` buffers to the `threadgroup` address space. The difference between the two scopes is how their size is determined, not how threads access or synchronize the memory:

- `shared`: statically sized threadgroup memory
- `shared.dyn`: dynamically sized threadgroup memory

A storage synchronization operation for either scope must therefore emit:

```metal
threadgroup_barrier(mem_flags::mem_threadgroup);
```

Other scopes whose names begin with `shared`, such as `shared.tmem`, `shared.barrier`, and `shared.cluster_barrier`, are CUDA-specific storage concepts rather than ordinary Metal threadgroup memory. This change intentionally does not treat every `shared.*` scope as equivalent.

## Root cause and impact

`CodeGenTileLangMetal::PrintStorageScope` already mapped both `shared` and `shared.dyn` to Metal `threadgroup` memory, but `PrintStorageSync` only recognized `shared`. Consequently, a valid `tvm_storage_sync("shared.dyn")` call was silently omitted from generated Metal source.

Kernels using dynamic threadgroup memory could therefore execute without the required cross-thread synchronization, causing races and incorrect results. The fix makes synchronization consistent with the existing storage-scope mapping and with the CUDA and HIP backends.

## Validation

- `cmake --build build -j$(sysctl -n hw.ncpu)`
- `pre-commit run --files src/metal/codegen/codegen_metal.cc testing/python/metal/test_metal_gemm_v2_linux.py`
- `pytest -q testing/python/metal/test_metal_gemm_v2_linux.py` — 6 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed Metal code generation for `tvm_storage_sync("shared.dyn")` by emitting the appropriate threadgroup barrier, matching the existing `shared` behavior.
- Added a regression test verifying the generated Metal source contains `threadgroup_barrier(mem_flags::mem_threadgroup)`.

## Validation

- Build completed successfully.
- Pre-commit checks passed.
- Six Metal tests passed.

## C++ style / lint notes

- The C++ change is limited to storage-scope handling and does not alter public APIs.
- No documented C++ style rules or API-style audit behavior were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->