### PR TITLE
[BugFix] Use callee global symbols for cross-target calls

### DIFF
--- a/src/transform/lower_device_kernel_launch.cc
+++ b/src/transform/lower_device_kernel_launch.cc
@@ -329,7 +329,7 @@ private:
       // launch, but need to be replaced with call_extern.
       extern_function_call_.insert(gvar);
       Array<PrimExpr> args;
-      args.push_back(StringImm(gvar->name_hint));
+      args.push_back(StringImm(dev_info.global_symbol));
       for (const auto &arg : node->args) {
         args.push_back(arg);
       }

--- a/testing/python/transform/test_tilelang_transform_lower_device_kernel_launch.py
+++ b/testing/python/transform/test_tilelang_transform_lower_device_kernel_launch.py
@@ -1,0 +1,30 @@
+import tilelang
+from tilelang import tvm
+
+
+def test_same_device_cross_target_call_uses_callee_global_symbol():
+    callee_gvar = tvm.ir.GlobalVar("callee_hint")
+    callee = (
+        tvm.tirx.PrimFunc([], tvm.tirx.Evaluate(0))
+        .with_attr("target", tvm.target.Target("llvm"))
+        .with_attr("global_symbol", "actual_callee")
+    )
+    caller = (
+        tvm.tirx.PrimFunc(
+            [],
+            tvm.tirx.Evaluate(tvm.tirx.Call("int32", callee_gvar, [])),
+        )
+        .with_attr("target", tvm.target.Target({"kind": "llvm", "mcpu": "generic"}))
+        .with_attr("global_symbol", "caller")
+    )
+    mod = tvm.IRModule({callee_gvar: callee, "caller": caller})
+
+    after = tilelang.transform.LowerDeviceKernelLaunch()(mod)
+    call = after["caller"].body.value
+
+    assert call.op.same_as(tvm.ir.Op.get("tirx.call_extern"))
+    assert call.args[0].value == "actual_callee"
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

- use the callee `PrimFunc`'s `global_symbol` when lowering same-device cross-target calls to `call_extern`
- add a focused transform regression test where the IR-internal `GlobalVar` name differs from the exported symbol

## Intended behavior

A `GlobalVar` identifies a function inside an `IRModule`; its `name_hint` is the IR-facing name used to find and print that function. A `PrimFunc`'s `global_symbol` attribute is the external ABI symbol emitted by code generation.

Before lowering, an internal call can refer directly to the callee's `GlobalVar`. Once `LowerDeviceKernelLaunch` converts that call to `call_extern`, the object reference is gone and the call must name the symbol that will actually exist in the generated module.

For example:

```text
GlobalVar.name_hint:  callee_hint
PrimFunc.global_symbol: actual_callee
```

must lower to:

```text
call_extern("actual_callee")
```

The two names are often identical, but the IR does not require that.

## Root cause and impact

The same-device cross-target lowering path previously constructed `call_extern` with `gvar->name_hint`. When the callee's exported `global_symbol` differed, the generated call referenced the IR-internal name instead of the emitted function symbol. This could leave the call pointing at a missing symbol during linking or execution.

The fix uses the already-resolved callee metadata, `dev_info.global_symbol`, for the external call name.

## Validation

- verified the regression test fails against the original implementation: `callee_hint != actual_callee`
- `cmake --build build -j$(sysctl -n hw.ncpu)`
- `pytest -q testing/python/transform/test_tilelang_transform_lower_device_kernel_launch.py` — 1 passed
- `pre-commit run --files src/transform/lower_device_kernel_launch.cc testing/python/transform/test_tilelang_transform_lower_device_kernel_launch.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed same-device cross-target call lowering to use the callee `PrimFunc`’s `global_symbol` when generating `call_extern`, rather than the IR `GlobalVar.name_hint`.
- Added a regression test covering differing internal and externally emitted symbol names.

## Validation

- Build, test, and pre-commit checks completed successfully.

## C++ style / lint notes

- The C++ implementation changes do not modify rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) remains advisory; no new correctness or build issues are introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->