### PR TITLE
[BugFix] Preserve loop steps during unswitching

### DIFF
--- a/src/transform/loop_unswitching.cc
+++ b/src/transform/loop_unswitching.cc
@@ -553,7 +553,7 @@ public:
         result = GetRef<Stmt>(op);
       } else {
         result = For(op->loop_var, op->min, op->extent, op->kind, body,
-                     op->thread_binding, op->annotations);
+                     op->thread_binding, op->annotations, op->step);
       }
       if (pushed_thread_idx) {
         thread_idx_vars_in_scope_.erase(op->loop_var.get());
@@ -573,7 +573,7 @@ public:
         result = GetRef<Stmt>(op);
       } else {
         result = For(op->loop_var, op->min, op->extent, op->kind, body,
-                     op->thread_binding, op->annotations);
+                     op->thread_binding, op->annotations, op->step);
       }
       if (pushed_thread_idx) {
         thread_idx_vars_in_scope_.erase(op->loop_var.get());
@@ -596,7 +596,7 @@ public:
     // two versions.
     if (!allow_non_trivial_else_ && !IsSideEffectFreeStmt(else_body)) {
       result = For(op->loop_var, op->min, op->extent, op->kind, body,
-                   op->thread_binding, op->annotations);
+                   op->thread_binding, op->annotations, op->step);
       if (pushed_thread_idx) {
         thread_idx_vars_in_scope_.erase(op->loop_var.get());
       }
@@ -608,9 +608,9 @@ public:
     else_body = Substitute(else_body, {{op->loop_var, else_loop_var}});
 
     For then_loop(op->loop_var, op->min, op->extent, op->kind, then_body,
-                  op->thread_binding, op->annotations);
+                  op->thread_binding, op->annotations, op->step);
     For else_loop(else_loop_var, op->min, op->extent, op->kind, else_body,
-                  op->thread_binding, op->annotations);
+                  op->thread_binding, op->annotations, op->step);
 
     result = IfThenElse(if_node->condition, then_loop, else_loop);
 

--- a/testing/python/transform/test_tilelang_transform_loop_unswitching.py
+++ b/testing/python/transform/test_tilelang_transform_loop_unswitching.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from tilelang import tvm as tvm
 import tilelang as tl
 import tilelang.language as T
@@ -47,6 +49,43 @@ def test_basic_hoist():
                 T.evaluate(0)
 
     _check(before, expected)
+
+
+def test_hoist_preserves_non_unit_loop_step():
+    output_buffer = tvm.tirx.decl_buffer((6,), "int32", name="output")
+    cond_buffer = tvm.tirx.decl_buffer((1,), "int32", name="cond")
+    i = tvm.tirx.Var("i", "int32")
+    body = tvm.tirx.IfThenElse(
+        tvm.tirx.BufferLoad(cond_buffer, [0]) > 0,
+        tvm.tirx.BufferStore(output_buffer, 1, [i]),
+        None,
+    )
+    loop = tvm.tirx.For(
+        i,
+        1,
+        5,
+        tvm.tirx.ForKind.SERIAL,
+        body,
+        step=tvm.tirx.IntImm("int32", 2),
+    )
+    before = tvm.tirx.PrimFunc(
+        [output_buffer.data, cond_buffer.data],
+        loop,
+        buffer_map={
+            output_buffer.data: output_buffer,
+            cond_buffer.data: cond_buffer,
+        },
+    ).with_attr("global_symbol", "main")
+
+    mod = tvm.IRModule.from_expr(before)
+    mod = tl.transform.LoopUnswitching()(mod)
+    executable = tvm.compile(mod["main"], target="c").jit(options=["-std=c++17"])
+
+    output = tvm.runtime.tensor(np.zeros(6, dtype="int32"))
+    cond = tvm.runtime.tensor(np.ones(1, dtype="int32"))
+    executable["main"](output, cond)
+
+    np.testing.assert_array_equal(output.numpy(), np.array([0, 1, 0, 1, 0, 1], dtype="int32"))
 
 
 def test_hoist_with_else():


### PR DESCRIPTION
## Summary

- preserve a `For` node's explicit `step` whenever loop unswitching reconstructs the loop
- add an executable regression test covering a loop-invariant condition inside a non-unit-step loop

## Intended behavior

Loop unswitching may hoist a loop-invariant condition and reconstruct the original loop as one or two new `For` nodes. This transformation may change control-flow placement, but it must preserve the original loop's iteration semantics, including:

- minimum
- extent
- loop kind
- thread binding and annotations
- step

For a loop declared with `step=2`, every reconstructed version must therefore retain `step=2`.

## Root cause and impact

The reconstruction paths copied the original loop's minimum, extent, kind, body, thread binding, and annotations, but omitted `op->step` from the `For` constructor. The omitted argument falls back to the default unit-step representation.

As a result, applying loop unswitching to a valid non-unit-step loop could change the set of executed iterations and produce incorrect memory accesses or results. The fix passes `op->step` through all five reconstruction sites.

## Regression test

The test constructs a loop covering indices `1, 3, 5`, applies `LoopUnswitching`, compiles the transformed TIR to an executable C module, and runs it against a zero-initialized output buffer.

Expected output:

```text
[0, 1, 0, 1, 0, 1]
```

Against the original implementation, the reconstructed loop defaults to unit step and actually produces:

```text
[0, 1, 1, 1, 1, 1]
```

This validates the observable behavior rather than inspecting the transformed `For.step` field.

## Validation

- verified the executable regression test fails with the original implementation and passes with the fix
- `cmake --build build -j$(sysctl -n hw.ncpu)`
- `pytest -q testing/python/transform/test_tilelang_transform_loop_unswitching.py::test_hoist_preserves_non_unit_loop_step` — 1 passed
- `pytest -q testing/python/transform/test_tilelang_transform_loop_unswitching.py -k 'not test_no_hoist_multiple_let'` — 21 passed, 1 deselected
- `pre-commit run --files src/transform/loop_unswitching.cc testing/python/transform/test_tilelang_transform_loop_unswitching.py`

The deselected test currently reaches an unrelated existing Metal code-generation failure for `tl.atomic_add_elem_op` on this macOS environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Preserve explicit `For` loop steps across all loop-unswitching reconstruction paths.
- Add a runtime regression test covering loop-invariant conditions in a `step=2` loop, verifying expected output `[0, 1, 0, 1, 0, 1]`.
- Validation passed through builds, targeted and broader loop-unswitching tests, and pre-commit checks. An unrelated Metal test was deselected due to an existing macOS `tl.atomic_add_elem_op` failure.

## C++ style / lint notes

- The C++ implementation was updated, but no documented rules in `docs/developer_guide/cpp_style.md` were changed.
- The C++ API Style Audit remains warning-only; no new blocking correctness or build issues are identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->