### PR TITLE
[BugFix] Round up sub-byte TVM FFI output storage

### DIFF
--- a/testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py
+++ b/testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py
@@ -1,6 +1,7 @@
 import threading
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from tilelang.jit.adapter.tvm_ffi import TVMFFIKernelAdapter
@@ -13,6 +14,17 @@ class _FakeKernelParam:
     @staticmethod
     def torch_dtype():
         return torch.float32
+
+
+class _FakeInt4KernelParam:
+    dtype = SimpleNamespace(bits=4, lanes=1)
+
+    def __init__(self, logical_elements):
+        self.shape = [logical_elements]
+
+    @staticmethod
+    def torch_dtype():
+        return torch.int8
 
 
 class _TestAdapter(TVMFFIKernelAdapter):
@@ -90,3 +102,23 @@ def test_preloaded_executable_is_reused():
     assert adapter._get_executable() is preloaded_executable
     assert adapter.get_exportable_executable() is preloaded_executable
     assert created == []
+
+
+@pytest.mark.parametrize(
+    ("logical_elements", "expected_storage_elements"),
+    [
+        (2, 1),
+        (3, 2),
+        (4, 2),
+    ],
+)
+def test_subbyte_output_storage_rounds_up_at_byte_boundary(logical_elements, expected_storage_elements):
+    adapter, _ = _make_adapter()
+    adapter.params = [_FakeInt4KernelParam(logical_elements)]
+    adapter.result_idx = [0]
+    adapter.executable = lambda output: None
+
+    output = adapter._convert_torch_func()()
+
+    assert output.dtype == torch.int8
+    assert output.shape == (expected_storage_elements,)

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -198,9 +198,10 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
                     native_shape.append(dim)
             tl_dtype = param.dtype
             if tl_dtype.bits < 8:
-                stroage_dtype: dtype = dtype(param.torch_dtype())
-                # last dim divide by bits to get the actual shape
-                native_shape[-1] = native_shape[-1] * tl_dtype.bits * tl_dtype.lanes // (stroage_dtype.bits * stroage_dtype.lanes)
+                storage_dtype: dtype = dtype(param.torch_dtype())
+                logical_bits = native_shape[-1] * tl_dtype.bits * tl_dtype.lanes
+                storage_bits = storage_dtype.bits * storage_dtype.lanes
+                native_shape[-1] = (logical_bits + storage_bits - 1) // storage_bits
             param_shapes.append(native_shape)
 
         dynamic_symbolic_map = self._process_dynamic_symbolic()


### PR DESCRIPTION
## Summary

- round sub-byte TVM FFI output storage up to the next complete backing element
- add a CPU-only boundary regression test for int4 outputs backed by int8 storage

## Intended behavior

A logical sub-byte tensor is passed through PyTorch using a wider storage dtype. The backing tensor must contain enough complete storage elements for every logical bit.

For a logical output with three int4 elements:

```text
logical size:  3 × 4 bits = 12 bits
storage dtype: int8 = 8 bits
required size: ceil(12 / 8) = 2 int8 elements
```

Returning one int8 element provides only 8 bits and cannot hold the 12-bit logical output.

## Root cause and impact

The TVM FFI adapter previously converted the logical final dimension with integer floor division. Whenever the logical bit count was not exactly divisible by the backing dtype width, it discarded the partial final storage element.

The resulting output tensor could therefore be too small for a valid sub-byte output, potentially truncating data or allowing the compiled kernel to write past the allocated backing storage. The fix performs integer ceiling division while retaining dtype lane counts in both the logical and storage widths.

## Regression test

The parameterized test exercises the byte boundary directly:

```text
2 int4 elements =  8 bits -> 1 int8 storage element
3 int4 elements = 12 bits -> 2 int8 storage elements
4 int4 elements = 16 bits -> 2 int8 storage elements
```

The executable is intentionally a no-op: the behavior under test is the output tensor shape allocated and returned by the host-side TVM FFI wrapper before kernel execution.

## Validation

- verified the three-element case returns `torch.Size([1])` with the original floor division
- verified the fixed boundary cases return `(1,)`, `(2,)`, and `(2,)`
- `pytest -q testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py` — 6 passed
- `pre-commit run --files tilelang/jit/adapter/tvm_ffi.py testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated TVM FFI storage sizing for sub-byte outputs to use ceiling division, ensuring sufficient backing elements.
- Added CPU-only regression coverage for int4 outputs at 2-, 3-, and 4-element boundaries.

## Testing

- Added parametrized pytest coverage verifying int8 storage dtype and rounded-up output sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->