### PR TITLE
[BugFix] Gate TMEM and TMA builtins by CUDA architecture

### DIFF
--- a/src/tl_templates/cuda/barrier.h
+++ b/src/tl_templates/cuda/barrier.h
@@ -171,16 +171,25 @@ TL_DEVICE void fence_barrier_init() {
 }
 
 // Indicate arrival of warp issuing TMA_STORE
-TL_DEVICE void tma_store_arrive() {
+template <bool kDependentFalse = false> TL_DEVICE void tma_store_arrive() {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   asm volatile("cp.async.bulk.commit_group;");
+#else
+  static_assert(kDependentFalse, "T.tma_store_arrive requires sm_90 or later");
+#endif
 }
 
-template <int Count, bool Read = true> TL_DEVICE void tma_store_wait() {
+template <int Count, bool Read = true, bool kDependentFalse = false>
+TL_DEVICE void tma_store_wait() {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   if constexpr (Read) {
     asm volatile("cp.async.bulk.wait_group.read %0;" : : "n"(Count) : "memory");
   } else {
     asm volatile("cp.async.bulk.wait_group %0;" : : "n"(Count) : "memory");
   }
+#else
+  static_assert(kDependentFalse, "T.tma_store_wait requires sm_90 or later");
+#endif
 }
 
 TL_DEVICE void syncthreads_partial(uint64_t &smem_barrier) {

--- a/src/tl_templates/cuda/copy_sm100.h
+++ b/src/tl_templates/cuda/copy_sm100.h
@@ -430,18 +430,20 @@ TL_DEVICE void tma_load_2sm(const CUtensorMap &descriptor,
                : "memory");
 }
 
-// cp.async.bulk.tensor.2d.tile::{gather4,scatter4} (PTX 8.6, sm_100a).
+// cp.async.bulk.tensor.2d.tile::{gather4,scatter4} (PTX 8.6).
+// The shared::cta gather4 form requires sm_100; scatter4 requires sm_100a.
 // Five coordinate operands: {col, r0, r1, r2, r3}; the 4-row pack is implicit.
 // CacheHintSm90 reused from copy_sm90.h (always included alongside this file).
 #if (__CUDACC_VER_MAJOR__ > 12) ||                                             \
     (__CUDACC_VER_MAJOR__ == 12 && __CUDACC_VER_MINOR__ >= 8)
 template <CacheHintSm90 cache_hint = CacheHintSm90::EVICT_NORMAL,
-          typename BarrierType = uint64_t>
+          typename BarrierType = uint64_t, bool kDependentFalse = false>
 TL_DEVICE void tma_load_gather4(const CUtensorMap &descriptor,
                                 BarrierType &smem_mbar,
                                 void const *const smem_ptr, int32_t const &col,
                                 int32_t const &r0, int32_t const &r1,
                                 int32_t const &r2, int32_t const &r3) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
   uint64_t gmem_int_desc = reinterpret_cast<uint64_t>(&descriptor);
   uint32_t smem_int_mbar;
   if constexpr (std::is_pointer_v<BarrierType>) {
@@ -457,13 +459,18 @@ TL_DEVICE void tma_load_gather4(const CUtensorMap &descriptor,
                : "r"(smem_int_ptr), "l"(gmem_int_desc), "r"(smem_int_mbar),
                  "r"(col), "r"(r0), "r"(r1), "r"(r2), "r"(r3), "l"(cache_hint)
                : "memory");
+#else
+  static_assert(kDependentFalse, "T.tma_gather4 requires sm_100 or later");
+#endif
 }
 
-template <CacheHintSm90 cache_hint = CacheHintSm90::EVICT_NORMAL>
+template <CacheHintSm90 cache_hint = CacheHintSm90::EVICT_NORMAL,
+          bool kDependentFalse = false>
 TL_DEVICE void
 tma_store_scatter4(const CUtensorMap &descriptor, void const *const smem_ptr,
                    int32_t const &col, int32_t const &r0, int32_t const &r1,
                    int32_t const &r2, int32_t const &r3) {
+#if defined(__CUDA_ARCH_FEAT_SM100_ALL)
   uint64_t gmem_int_desc = reinterpret_cast<uint64_t>(&descriptor);
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   asm volatile(
@@ -473,6 +480,9 @@ tma_store_scatter4(const CUtensorMap &descriptor, void const *const smem_ptr,
       : "l"(gmem_int_desc), "r"(smem_int_ptr), "r"(col), "r"(r0), "r"(r1),
         "r"(r2), "r"(r3), "l"(cache_hint)
       : "memory");
+#else
+  static_assert(kDependentFalse, "T.tma_scatter4 requires sm_100a");
+#endif
 }
 #endif // CUDA 12.8+
 

--- a/src/tl_templates/cuda/copy_sm90.h
+++ b/src/tl_templates/cuda/copy_sm90.h
@@ -489,18 +489,26 @@ TL_DEVICE void tma_store(const CUtensorMap &descriptor,
                : "memory");
 }
 
+template <bool kDependentFalse = false>
 TL_DEVICE void tma_store_add(float *const smem_ptr, float *gmem_ptr,
                              int32_t const &store_bytes) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   asm volatile("cp.reduce.async.bulk.global.shared::cta.bulk_group.add.f32 "
                "[%0], [%1], %2;\n"
                :
                : "l"(gmem_ptr), "r"(smem_int_ptr), "r"(store_bytes)
                : "memory");
+#else
+  static_assert(kDependentFalse,
+                "T.atomic_add(..., use_tma=True) requires sm_90 or later");
+#endif
 }
 
+template <bool kDependentFalse = false>
 TL_DEVICE void tma_store_add(const CUtensorMap &descriptor,
                              void const *const smem_ptr, int32_t const &crd0) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   uint64_t gmem_int_desc = reinterpret_cast<uint64_t>(&descriptor);
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   asm volatile(
@@ -509,11 +517,17 @@ TL_DEVICE void tma_store_add(const CUtensorMap &descriptor,
       :
       : "l"(gmem_int_desc), "r"(smem_int_ptr), "r"(crd0)
       : "memory");
+#else
+  static_assert(kDependentFalse,
+                "T.atomic_add(..., use_tma=True) requires sm_90 or later");
+#endif
 }
 
+template <bool kDependentFalse = false>
 TL_DEVICE void tma_store_add(const CUtensorMap &descriptor,
                              void const *const smem_ptr, int32_t const &crd0,
                              int32_t const &crd1) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   uint64_t gmem_int_desc = reinterpret_cast<uint64_t>(&descriptor);
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   asm volatile(
@@ -522,11 +536,17 @@ TL_DEVICE void tma_store_add(const CUtensorMap &descriptor,
       :
       : "l"(gmem_int_desc), "r"(smem_int_ptr), "r"(crd0), "r"(crd1)
       : "memory");
+#else
+  static_assert(kDependentFalse,
+                "T.atomic_add(..., use_tma=True) requires sm_90 or later");
+#endif
 }
 
+template <bool kDependentFalse = false>
 TL_DEVICE void tma_store_add(const CUtensorMap &descriptor,
                              void const *const smem_ptr, int32_t const &crd0,
                              int32_t const &crd1, int32_t const &crd2) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   uint64_t gmem_int_desc = reinterpret_cast<uint64_t>(&descriptor);
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   asm volatile(
@@ -535,12 +555,18 @@ TL_DEVICE void tma_store_add(const CUtensorMap &descriptor,
       :
       : "l"(gmem_int_desc), "r"(smem_int_ptr), "r"(crd0), "r"(crd1), "r"(crd2)
       : "memory");
+#else
+  static_assert(kDependentFalse,
+                "T.atomic_add(..., use_tma=True) requires sm_90 or later");
+#endif
 }
 
+template <bool kDependentFalse = false>
 TL_DEVICE void tma_store_add(const CUtensorMap &descriptor,
                              void const *const smem_ptr, int32_t const &crd0,
                              int32_t const &crd1, int32_t const &crd2,
                              int32_t const &crd3) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   uint64_t gmem_int_desc = reinterpret_cast<uint64_t>(&descriptor);
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   asm volatile(
@@ -550,12 +576,18 @@ TL_DEVICE void tma_store_add(const CUtensorMap &descriptor,
       : "l"(gmem_int_desc), "r"(smem_int_ptr), "r"(crd0), "r"(crd1), "r"(crd2),
         "r"(crd3)
       : "memory");
+#else
+  static_assert(kDependentFalse,
+                "T.atomic_add(..., use_tma=True) requires sm_90 or later");
+#endif
 }
 
+template <bool kDependentFalse = false>
 TL_DEVICE void tma_store_add(const CUtensorMap &descriptor,
                              void const *const smem_ptr, int32_t const &crd0,
                              int32_t const &crd1, int32_t const &crd2,
                              int32_t const &crd3, int32_t const &crd4) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   uint64_t gmem_int_desc = reinterpret_cast<uint64_t>(&descriptor);
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   asm volatile(
@@ -565,11 +597,21 @@ TL_DEVICE void tma_store_add(const CUtensorMap &descriptor,
       : "l"(gmem_int_desc), "r"(smem_int_ptr), "r"(crd0), "r"(crd1), "r"(crd2),
         "r"(crd3), "r"(crd4)
       : "memory");
+#else
+  static_assert(kDependentFalse,
+                "T.atomic_add(..., use_tma=True) requires sm_90 or later");
+#endif
 }
 
+template <bool kDependentFalse = false>
 TL_DEVICE void prefetch_tma_descriptor(const CUtensorMap &descriptor) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   uint64_t gmem_int_desc = reinterpret_cast<uint64_t>(&descriptor);
   asm volatile("prefetch.tensormap [%0];" : : "l"(gmem_int_desc) : "memory");
+#else
+  static_assert(kDependentFalse,
+                "T.prefetch_tma_descriptor requires sm_90 or later");
+#endif
 }
 
 } // namespace tl

--- a/src/tl_templates/cuda/tcgen_05.h
+++ b/src/tl_templates/cuda/tcgen_05.h
@@ -12,8 +12,9 @@
 
 namespace tl {
 
-template <bool use_2cta = false>
+template <bool use_2cta = false, bool kDependentFalse = false>
 TL_DEVICE void tmem_allocate(void *dst_ptr, int num_columns) {
+#if defined(__CUDA_ARCH_FEAT_SM100_ALL)
   uint32_t dst_intptr = smem_ptr_to_uint(dst_ptr);
   if constexpr (use_2cta) {
     asm volatile(
@@ -26,10 +27,14 @@ TL_DEVICE void tmem_allocate(void *dst_ptr, int num_columns) {
         :
         : "r"(dst_intptr), "r"(num_columns));
   }
+#else
+  static_assert(kDependentFalse, "T.alloc_tmem requires sm_100a");
+#endif
 }
 
-template <bool use_2cta = false>
+template <bool use_2cta = false, bool kDependentFalse = false>
 TL_DEVICE void tmem_deallocate(uint32_t *tmem_ptr, int num_columns) {
+#if defined(__CUDA_ARCH_FEAT_SM100_ALL)
   if constexpr (use_2cta) {
     asm volatile("{\n\t"
                  "tcgen05.dealloc.cta_group::2.sync.aligned.b32  %0, %1; \n\t"
@@ -43,6 +48,9 @@ TL_DEVICE void tmem_deallocate(uint32_t *tmem_ptr, int num_columns) {
                  :
                  : "r"(*tmem_ptr), "r"(num_columns));
   }
+#else
+  static_assert(kDependentFalse, "T.deallocate_tmem requires sm_100a");
+#endif
 }
 
 TL_DEVICE void tcgen05_before_thread_sync() {

--- a/testing/python/issue/test_tilelang_issue_2504.py
+++ b/testing/python/issue/test_tilelang_issue_2504.py
@@ -1,0 +1,243 @@
+"""Architecture diagnostics for TMEM and TMA DSL architecture gates."""
+
+import re
+
+import pytest
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+from tilelang.contrib import nvcc
+
+
+_PASS_CONFIG = {
+    tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED.value: True,
+}
+
+
+def _require_cuda_12_8():
+    if nvcc.get_cuda_version() < (12, 8):
+        pytest.skip("TMEM/TMA architecture-gate tests require CUDA toolkit >= 12.8")
+
+
+def _lower_for_arch(prim_func, arch):
+    target = tvm.target.Target({"kind": "cuda", "arch": arch})
+    with tvm.transform.PassContext(config=_PASS_CONFIG), target:
+        return tilelang.lower(
+            prim_func,
+            target=target,
+            enable_device_compile=True,
+        )
+
+
+def _make_tmem_prim_func():
+    @T.prim_func
+    def main():
+        with T.Kernel(1, threads=128):
+            tmem = T.alloc_tmem((128, 128), T.float32)
+            T.deallocate_tmem(tmem)
+
+    return main
+
+
+def _make_tma_store_arrive_prim_func():
+    @T.prim_func
+    def main():
+        with T.Kernel(1, threads=128):
+            T.tma_store_arrive()
+
+    return main
+
+
+def _make_tma_store_wait_prim_func():
+    @T.prim_func
+    def main():
+        with T.Kernel(1, threads=128):
+            T.tma_store_wait(0)
+
+    return main
+
+
+def _make_tma_atomic_add_prim_func():
+    @T.prim_func
+    def main(out: T.Tensor((16, 16), T.float32)):
+        with T.Kernel(1, threads=128):
+            out_shared = T.alloc_shared((16, 16), T.float32)
+            T.fill(out_shared, 1)
+            T.atomic_add(out, out_shared, use_tma=True)
+
+    return main
+
+
+def _make_tma_descriptor_prefetch_prim_func():
+    @T.prim_func
+    def main(descriptor: T.handle("uint8x128", "grid_constant")):
+        with T.Kernel(1, threads=32):
+            if T.shuffle_elect(0):
+                T.call_intrin(
+                    "handle",
+                    tvm.tirx.op.Op.get("tl.prefetch_tma_descriptor"),
+                    descriptor,
+                )
+
+    return main
+
+
+def _make_tma_gather4_prim_func():
+    @T.prim_func
+    def main(
+        src: T.Tensor((64, 64), T.float16),
+        indices: T.Tensor((4,), T.int32),
+        out: T.Tensor((4, 64), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            smem = T.alloc_shared((4, 64), T.float16)
+            mbar = T.alloc_barrier(1)
+
+            if T.shuffle_elect(128):
+                T.mbarrier_expect_tx(mbar, T.tma_gather4_bytes(64, "float16"))
+                T.tma_gather4(
+                    src,
+                    smem,
+                    0,
+                    [indices[0], indices[1], indices[2], indices[3]],
+                    barrier=mbar,
+                )
+                T.barrier_arrive(mbar)
+            T.mbarrier_wait_parity(mbar, 0)
+
+            for i, j in T.Parallel(4, 64):
+                out[i, j] = smem[i, j]
+
+    return main
+
+
+def _make_tma_scatter4_prim_func():
+    @T.prim_func
+    def main(
+        indices: T.Tensor((4,), T.int32),
+        out: T.Tensor((64, 64), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            smem = T.alloc_shared((4, 64), T.float16)
+            T.fill(smem, 1)
+
+            if T.shuffle_elect(128):
+                T.tma_scatter4(
+                    smem,
+                    out,
+                    0,
+                    [indices[0], indices[1], indices[2], indices[3]],
+                )
+                T.tma_store_arrive()
+            T.tma_store_wait(0, read=False)
+
+    return main
+
+
+_UNSUPPORTED_CASES = [
+    (
+        _make_tmem_prim_func,
+        "sm_90",
+        "T.alloc_tmem requires sm_100a",
+    ),
+    (
+        _make_tmem_prim_func,
+        "sm_90",
+        "T.deallocate_tmem requires sm_100a",
+    ),
+    (
+        _make_tma_store_arrive_prim_func,
+        "sm_80",
+        "T.tma_store_arrive requires sm_90 or later",
+    ),
+    (
+        _make_tma_store_wait_prim_func,
+        "sm_80",
+        "T.tma_store_wait requires sm_90 or later",
+    ),
+    (
+        _make_tma_atomic_add_prim_func,
+        "sm_80",
+        "T.atomic_add(..., use_tma=True) requires sm_90 or later",
+    ),
+    (
+        _make_tma_descriptor_prefetch_prim_func,
+        "sm_80",
+        "T.prefetch_tma_descriptor requires sm_90 or later",
+    ),
+    (
+        _make_tma_gather4_prim_func,
+        "sm_90",
+        "T.tma_gather4 requires sm_100 or later",
+    ),
+    (
+        _make_tma_scatter4_prim_func,
+        "sm_100",
+        "T.tma_scatter4 requires sm_100a",
+    ),
+]
+
+
+_SUPPORTED_CASES = [
+    (_make_tmem_prim_func, "sm_100a", "tl::tmem_deallocate"),
+    (_make_tma_store_arrive_prim_func, "sm_90", "tl::tma_store_arrive"),
+    (_make_tma_store_wait_prim_func, "sm_90", "tl::tma_store_wait<0"),
+    (_make_tma_atomic_add_prim_func, "sm_90", "tl::tma_store_add"),
+    (
+        _make_tma_descriptor_prefetch_prim_func,
+        "sm_90",
+        "tl::prefetch_tma_descriptor",
+    ),
+    (_make_tma_gather4_prim_func, "sm_100", "tl::tma_load_gather4"),
+    (_make_tma_scatter4_prim_func, "sm_100a", "tl::tma_store_scatter4"),
+]
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize(
+    "factory,arch,message",
+    _UNSUPPORTED_CASES,
+    ids=[
+        "tmem-allocate",
+        "tmem-deallocate",
+        "store-arrive",
+        "store-wait",
+        "atomic-add",
+        "descriptor-prefetch",
+        "gather4",
+        "scatter4",
+    ],
+)
+def test_tmem_tma_builtins_reject_unsupported_arch(factory, arch, message):
+    _require_cuda_12_8()
+
+    with pytest.raises(RuntimeError, match=re.escape(message)):
+        _lower_for_arch(factory(), arch)
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize(
+    "factory,arch,expected_helper",
+    _SUPPORTED_CASES,
+    ids=[
+        "tmem",
+        "store-arrive",
+        "store-wait",
+        "atomic-add",
+        "descriptor-prefetch",
+        "gather4",
+        "scatter4",
+    ],
+)
+def test_tmem_tma_builtins_compile_for_supported_arch(factory, arch, expected_helper):
+    _require_cuda_12_8()
+
+    artifact = _lower_for_arch(factory(), arch)
+
+    assert expected_helper in artifact.kernel_source
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

- Add compile-time architecture gates for TMEM and TMA CUDA helpers.
- Require `sm_100a` for TMEM allocation/deallocation and TMA scatter4.
- Require `sm_100` for the shared-CTA TMA gather4 path.
- Require `sm_90` for TMA store synchronization, TMA atomic add, and descriptor prefetch.
- Emit actionable `static_assert` diagnostics instead of cryptic CUDA assembler errors.
- Add regression coverage verifying rejection on unsupported targets and device compilation on supported targets.

## Testing

```text
bash format.sh --files \
  src/tl_templates/cuda/barrier.h \
  src/tl_templates/cuda/copy_sm90.h \
  src/tl_templates/cuda/copy_sm100.h \
  src/tl_templates/cuda/tcgen_05.h \
  testing/python/issue/test_tilelang_issue_2504.py

cmake --build build --parallel 4

python3 -m pytest -q \
  testing/python/issue/test_tilelang_issue_2504.py
  
  All checks and tests passed.
```

Fixes #2504


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added compile-time CUDA architecture gates for TMEM and TMA helpers.
- TMEM allocation/deallocation and TMA scatter4 now require `sm_100a`; TMA gather4 requires `sm_100`.
- TMA store synchronization, atomic add, and descriptor prefetch now require `sm_90`.
- Unsupported architectures receive actionable `static_assert` diagnostics instead of CUDA assembler errors.
- Added CUDA 12.8+ regression tests covering rejection on unsupported architectures and successful device compilation on supported architectures.

## C++ style / lint notes

- This PR changes C++ headers but does not alter documented rules in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step remains advisory; no correctness or build issue is implied by style warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->