### PR TITLE
[BugFix] Preserve re-evaluation of mutable if conditions

### DIFF
--- a/src/transform/merge_if_stmt.cc
+++ b/src/transform/merge_if_stmt.cc
@@ -65,6 +65,7 @@ private:
       if (const auto *if_node = stmt.as<IfThenElseNode>()) {
         if (!if_node->else_case.defined()) {
           if (current_condition.defined() &&
+              SideEffect(current_condition) <= CallEffectKind::kPure &&
               ExprDeepEqual()(current_condition, if_node->condition)) {
             current_if_bodies.push_back(if_node->then_case);
             continue;

--- a/testing/python/issue/test_tilelang_issue_merge_if.py
+++ b/testing/python/issue/test_tilelang_issue_merge_if.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 import tilelang
 from tilelang import tvm as tvm
 from tvm.ir import IRModule
@@ -29,6 +31,24 @@ def test_merge_if():
     original_module = IRModule.from_expr(func)
     transformed = tilelang.transform.MergeIfStmt()(original_module)
     tvm.ir.assert_structural_equal(original_module["main"], transformed["main"], True)
+
+
+def test_merge_if_preserves_re_evaluation_of_buffer_condition():
+    @T.prim_func
+    def main(A: T.Tensor((2,), T.int32)):
+        if A[0] > 0:
+            A[0] = 0
+        if A[0] > 0:
+            A[1] = 1
+
+    original_module = IRModule.from_expr(main)
+    transformed = tilelang.transform.MergeIfStmt()(original_module)
+    executable = tvm.compile(transformed["main"], target="c").jit(options=["-std=c++17"])
+
+    values = tvm.runtime.tensor(np.array([1, 7], dtype="int32"))
+    executable(values)
+
+    np.testing.assert_array_equal(values.numpy(), np.array([0, 7], dtype="int32"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

Require a repeated condition to be pure before `MergeIfStmt` combines consecutive `if` statements with structurally equal conditions.

## Why

Structural equality does not make it safe to reuse the first condition result when the condition reads mutable state. For example:

```python
if A[0] > 0:
    A[0] = 0
if A[0] > 0:
    A[1] = 1
```

The second condition is intentionally evaluated after `A[0]` changes. Previously, `MergeIfStmt` combined both bodies under one evaluation of `A[0] > 0`, changing the result for input `[1, 7]` from the intended `[0, 7]` to `[0, 1]`.

`SideEffect` classifies a `BufferLoad` condition as `kReadState`, so the transform now merges only conditions classified as `kPure`. Conditions composed from immutable TIR variables and pure arithmetic can still be merged.

## Validation

- Added a behavioral regression test that transforms the function, compiles it with the C target, executes it, and checks the resulting buffer.
- Confirmed the test fails without the fix (`[0, 1]`) and passes with the fix (`[0, 7]`).
- `pytest -q testing/python/issue/test_tilelang_issue_merge_if.py` (`2 passed`)
- `pre-commit run --files src/transform/merge_if_stmt.cc testing/python/issue/test_tilelang_issue_merge_if.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Restrict `MergeIfStmt` from merging repeated conditions unless they are classified as pure, preserving re-evaluation of conditions that read mutable state.
- Add a regression test that compiles and executes the transformed function to verify correct buffer results.

## C++ style / lint notes

- The C++ change does not alter rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit remains warning-only; no correctness or build issues are introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->