### PR TITLE
[BugFix] Preserve if condition value when splitting statements

### DIFF
--- a/src/transform/if_stmt_binding.cc
+++ b/src/transform/if_stmt_binding.cc
@@ -190,6 +190,50 @@ private:
     return IfThenElse(condition, stmt, Stmt(), span);
   }
 
+  bool NeedsConditionSnapshot(const PrimExpr &condition,
+                              const Array<Stmt> &stmts) const {
+    if (SideEffect(condition) > CallEffectKind::kReadState) {
+      return true;
+    }
+
+    auto [condition_reads, _] = CollectStmtAccessRegions(Evaluate(condition));
+    if (condition_reads.empty()) {
+      return false;
+    }
+
+    const BufferSet write_buffers = CollectWriteBuffers(stmts);
+    for (const BufferRegion &read : condition_reads) {
+      if (write_buffers.count(read->buffer)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  Stmt GuardStmts(const PrimExpr &condition, Array<Stmt> stmts,
+                  Span span) const {
+    ICHECK(!stmts.empty());
+    if (stmts.size() == 1) {
+      return GuardStmt(condition, stmts[0], span);
+    }
+
+    if (!NeedsConditionSnapshot(condition, stmts)) {
+      Array<Stmt> guarded_stmts;
+      guarded_stmts.reserve(stmts.size());
+      for (const Stmt &stmt : stmts) {
+        guarded_stmts.push_back(GuardStmt(condition, stmt, span));
+      }
+      return MakeSeq(std::move(guarded_stmts));
+    }
+
+    Var condition_snapshot("if_condition", condition.dtype());
+    Array<Stmt> seq{Bind(condition_snapshot, condition, span)};
+    for (const Stmt &stmt : stmts) {
+      seq.push_back(GuardStmt(condition_snapshot, stmt, span));
+    }
+    return MakeSeq(std::move(seq));
+  }
+
   Stmt BindIfStmtLegacy(const Stmt &body, const PrimExpr &condition,
                         Span span) const {
     if (auto seq_stmt = body.as<SeqStmtNode>()) {
@@ -197,7 +241,7 @@ private:
       const size_t n = seq_stmt->seq.size();
       size_t i = 0;
       for (; i < n && !seq_stmt->seq[i].as<BindNode>(); ++i) {
-        seq.push_back(GuardStmt(condition, seq_stmt->seq[i], span));
+        seq.push_back(seq_stmt->seq[i]);
       }
 
       // A direct Bind is emitted as a C/CUDA declaration. Keep it and the
@@ -208,10 +252,9 @@ private:
         for (; i < n; ++i) {
           bind_scope.push_back(seq_stmt->seq[i]);
         }
-        seq.push_back(
-            GuardStmt(condition, MakeSeq(std::move(bind_scope)), span));
+        seq.push_back(MakeSeq(std::move(bind_scope)));
       }
-      return MakeSeq(std::move(seq));
+      return GuardStmts(condition, std::move(seq), span);
     }
     return GuardStmt(condition, body, span);
   }
@@ -229,7 +272,7 @@ private:
 
     const BufferSet write_buffers = CollectWriteBuffers(seq_stmt->seq);
     Map<Var, PrimExpr> replayable_binds;
-    Array<Stmt> guarded_stmts;
+    Array<Stmt> guarded_bodies;
     Array<Stmt> bind_scope;
     bool in_bind_scope = false;
 
@@ -246,22 +289,20 @@ private:
           in_bind_scope = true;
           continue;
         }
-        guarded_stmts.push_back(GuardStmt(
-            condition, RewriteWithReplayableBinds(stmt, replayable_binds),
-            span));
+        guarded_bodies.push_back(
+            RewriteWithReplayableBinds(stmt, replayable_binds));
         continue;
       }
       bind_scope.push_back(RewriteWithReplayableBinds(stmt, replayable_binds));
     }
 
     if (!bind_scope.empty()) {
-      guarded_stmts.push_back(
-          GuardStmt(condition, MakeSeq(std::move(bind_scope)), span));
+      guarded_bodies.push_back(MakeSeq(std::move(bind_scope)));
     }
-    if (guarded_stmts.empty()) {
+    if (guarded_bodies.empty()) {
       return Evaluate(0, span);
     }
-    return MakeSeq(std::move(guarded_stmts));
+    return GuardStmts(condition, std::move(guarded_bodies), span);
   }
 
   Stmt VisitStmt_(const IfThenElseNode *op) final {

--- a/testing/python/transform/test_tilelang_transform_if_stmt_binding.py
+++ b/testing/python/transform/test_tilelang_transform_if_stmt_binding.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from tilelang import tvm as tvm
 import tilelang
 import tilelang.testing
@@ -19,13 +21,30 @@ def test_if_stmt_binding_splits_plain_seq_stmt():
 
     @T.prim_func
     def expected(A: T.Buffer((4,), "float32")):
-        if A[0] >= T.float32(0):
+        if_condition = T.bind(A[0] >= T.float32(0))
+        if if_condition:
             A[0] = T.float32(1)
-        if A[0] >= T.float32(0):
+        if if_condition:
             A[1] = T.float32(2)
 
     after = _run_if_stmt_binding(before)
     tvm.ir.assert_structural_equal(after.body, expected.body, True)
+
+
+def test_if_stmt_binding_preserves_original_condition_value():
+    @T.prim_func
+    def before(A: T.Buffer((2,), "int32")):
+        if A[0] > 0:
+            A[0] = 0
+            A[1] = 1
+
+    after = _run_if_stmt_binding(before)
+    executable = tvm.compile(after, target="c").jit(options=["-std=c++17"])
+
+    values = tvm.runtime.tensor(np.array([1, 7], dtype="int32"))
+    executable(values)
+
+    np.testing.assert_array_equal(values.numpy(), np.array([0, 1], dtype="int32"))
 
 
 def test_if_stmt_binding_keeps_direct_bind_scope():
@@ -39,9 +58,10 @@ def test_if_stmt_binding_keeps_direct_bind_scope():
 
     @T.prim_func
     def expected(A: T.Buffer((4,), "float32"), B: T.Buffer((4,), "float32")):
-        if A[0] >= T.float32(0):
+        if_condition = T.bind(A[0] >= T.float32(0))
+        if if_condition:
             A[0] = T.float32(1)
-        if A[0] >= T.float32(0):
+        if if_condition:
             bound = T.bind(A[1] + T.float32(2))
             B[0] = bound
             B[1] = bound + T.float32(1)


### PR DESCRIPTION
## What changed

Snapshot an `if` condition once before `IfStmtBinding` splits a multi-statement body into separately guarded statements. Every generated guard now uses the snapshot instead of re-evaluating the original condition.

The shared helper is used by both the replayable-bind path and the legacy path. A body that produces only one guarded statement keeps the existing direct guard without an unnecessary snapshot.

## Why

A source `if` evaluates its condition exactly once before executing its body. Previously, `IfStmtBinding` could transform:

```python
if A[0] > 0:
    A[0] = 0
    A[1] = 1
```

into the equivalent of:

```python
if A[0] > 0:
    A[0] = 0
if A[0] > 0:
    A[1] = 1
```

The first generated statement changes `A[0]`, so the second generated condition becomes false. For input `[1, 7]`, the transformed function incorrectly produced `[0, 7]` instead of the source program's `[0, 1]`.

The pass now binds `A[0] > 0` once and guards both generated statements with that immutable value, preserving the original evaluation semantics.

## Validation

- Added an end-to-end behavioral regression test that transforms the function, compiles the result with the C target, executes it, and checks the output buffer.
- Confirmed the test fails without the fix (`[0, 7]`) and passes with the fix (`[0, 1]`).
- `pytest -q testing/python/transform/test_tilelang_transform_if_stmt_binding.py` (`8 passed`)
- `pre-commit run --files src/transform/if_stmt_binding.cc testing/python/transform/test_tilelang_transform_if_stmt_binding.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed `IfStmtBinding` so multi-statement `if` bodies evaluate the condition once and reuse a snapshot for generated guards, preserving source semantics.
- Added shared guarding logic that supports both replayable-bind and legacy paths; single-statement bodies retain direct guards.
- Updated structural expectations and added a runtime regression test ensuring the original condition value is preserved.
- Validation includes 8 targeted tests plus pre-commit checks.

## C++ style / lint notes

- The PR touches C++ implementation code (`src/transform/if_stmt_binding.cc`) but does not modify the rules in `docs/developer_guide/cpp_style.md`, nor any CI/lint tooling or style documentation.
- The C++ API Style Audit runs as a warning-only CI step; this change does not introduce an obvious API/FFI/maintainability risk that would make new advisory findings blocking for correctness/build purposes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->