### PR TITLE
[BugFix] Handle strided global buffers correctly in 1D TMA copies

### DIFF
--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -2307,11 +2307,16 @@ Stmt Copy::LowerBulk1D(const CopyNode &op, const LowerArgs &lower_args,
     global_indices.push_back(r->min);
   }
   std::vector<PrimExpr> global_strides;
-  PrimExpr global_stride = 1;
-  for (size_t i = 0; i < global_tensor->shape.size(); i++) {
-    auto s = global_tensor->shape[global_tensor->shape.size() - i - 1];
-    global_strides.insert(global_strides.begin(), global_stride);
-    global_stride *= s;
+  if (global_tensor->strides.empty()) {
+    PrimExpr global_stride = 1;
+    for (size_t i = 0; i < global_tensor->shape.size(); i++) {
+      auto s = global_tensor->shape[global_tensor->shape.size() - i - 1];
+      global_strides.insert(global_strides.begin(), global_stride);
+      global_stride *= s;
+    }
+  } else {
+    global_strides.assign(global_tensor->strides.begin(),
+                          global_tensor->strides.end());
   }
 
   PrimExpr global_offset = 0;

--- a/src/cuda/op/copy_analysis.cc
+++ b/src/cuda/op/copy_analysis.cc
@@ -282,6 +282,43 @@ bool IsSemanticallyLinearLayout(const Layout &layout,
                                  linear_layout->GetLinearizedForwardIndex());
 }
 
+bool IsContiguousGlobalRegion(const Buffer &global_tensor,
+                              const Array<Range> &global_range,
+                              arith::Analyzer *analyzer) {
+  ICHECK_EQ(global_range.size(), global_tensor->shape.size());
+  ICHECK(global_tensor->strides.empty() ||
+         global_tensor->strides.size() == global_tensor->shape.size());
+
+  // Pointer-based 1D TMA can coalesce multiple logical dimensions only when
+  // every varying dimension is packed directly after its contiguous suffix.
+  bool non_full_dim_encountered = false;
+  PrimExpr expected_stride = 1;
+  for (int i = static_cast<int>(global_range.size()) - 1; i >= 0; --i) {
+    bool is_singleton = analyzer->CanProve(
+        global_range[i]->extent == 1, arith::ProofStrength::kSymbolicBound);
+    if (!non_full_dim_encountered) {
+      if (!is_singleton && !global_tensor->strides.empty() &&
+          !analyzer->CanProveEqual(global_tensor->strides[i],
+                                   expected_stride)) {
+        return false;
+      }
+
+      bool is_full_dim = analyzer->CanProve(
+          global_range[i]->extent == global_tensor->shape[i] &&
+              global_range[i]->min == 0,
+          arith::ProofStrength::kSymbolicBound);
+      if (is_full_dim) {
+        expected_stride *= global_tensor->shape[i];
+      } else {
+        non_full_dim_encountered = true;
+      }
+    } else if (!is_singleton) {
+      return false;
+    }
+  }
+  return true;
+}
+
 bool CheckBulkCopy1D(const Buffer &global_tensor, const Buffer &shared_tensor,
                      const Array<Range> &global_range,
                      const Array<Range> &shared_range,
@@ -294,24 +331,8 @@ bool CheckBulkCopy1D(const Buffer &global_tensor, const Buffer &shared_tensor,
         IsSemanticallyLinearLayout(existing, shared_tensor->shape, analyzer);
   }
 
-  bool global_is_contiguous = true;
-  bool global_not_full_dim_encounter = false;
-  for (int i = global_range.size() - 1; i >= 0; i--) {
-    if (!global_not_full_dim_encounter) {
-      if (!analyzer->CanProve(global_range[i]->extent ==
-                                      global_tensor->shape[i] &&
-                                  global_range[i]->min == 0,
-                              arith::ProofStrength::kSymbolicBound)) {
-        global_not_full_dim_encounter = true;
-      }
-    } else {
-      if (!analyzer->CanProve(global_range[i]->extent == 1,
-                              arith::ProofStrength::kSymbolicBound)) {
-        global_is_contiguous = false;
-        break;
-      }
-    }
-  }
+  bool global_is_contiguous =
+      IsContiguousGlobalRegion(global_tensor, global_range, analyzer);
 
   PrimExpr shared_elements = 1;
   for (size_t i = 0; i < shared_range.size(); i++) {

--- a/testing/python/language/test_tilelang_language_tma_copy.py
+++ b/testing/python/language/test_tilelang_language_tma_copy.py
@@ -177,6 +177,33 @@ def test_tma_copy_default_block_leader_scope_codegen():
     assert "tl_shuffle_elect<256>()" in source, "Expected block-wide elect<256>"
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_tma_copy_uses_explicit_global_stride_for_row_offset():
+    rows = 2
+    cols = 32
+    row_stride = 40
+
+    @T.prim_func
+    def main(
+        A: T.StridedTensor((rows, cols), (row_stride, 1), T.float32),
+        B: T.Tensor((cols,), T.float32),
+    ):
+        with T.Kernel(1, threads=32):
+            a_shared = T.alloc_shared((cols,), T.float32)
+            T.copy(A[1, 0:cols], a_shared, prefer_instruction="tma")
+            T.copy(a_shared, B)
+
+    import torch
+
+    kernel = tilelang.compile(main, out_idx=[1])
+    padded = torch.arange(rows * row_stride, dtype=torch.float32, device="cuda").reshape(rows, row_stride)
+    source = padded[:, :cols]
+    assert source.stride() == (row_stride, 1)
+    output = kernel(source)
+    torch.testing.assert_close(output, source[1])
+
+
 def matmul_tma_copy_store(
     M,
     N,

--- a/testing/python/language/test_tilelang_language_tma_copy.py
+++ b/testing/python/language/test_tilelang_language_tma_copy.py
@@ -197,11 +197,60 @@ def test_tma_copy_uses_explicit_global_stride_for_row_offset():
     import torch
 
     kernel = tilelang.compile(main, out_idx=[1])
+    assert "CUtensorMap" not in kernel.get_kernel_source()
     padded = torch.arange(rows * row_stride, dtype=torch.float32, device="cuda").reshape(rows, row_stride)
     source = padded[:, :cols]
     assert source.stride() == (row_stride, 1)
     output = kernel(source)
     torch.testing.assert_close(output, source[1])
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_tma_copy_uses_descriptor_for_padded_multirow_region():
+    rows = 2
+    cols = 32
+    row_stride = 40
+
+    @T.prim_func
+    def load(
+        A: T.StridedTensor((rows, cols), (row_stride, 1), T.float32),
+        B: T.Tensor((rows, cols), T.float32),
+    ):
+        with T.Kernel(1, threads=32):
+            a_shared = T.alloc_shared((rows, cols), T.float32)
+            T.copy(A, a_shared, prefer_instruction="tma")
+            T.copy(a_shared, B, prefer_instruction="sync")
+
+    @T.prim_func
+    def store(
+        A: T.Tensor((rows, cols), T.float32),
+        B: T.StridedTensor((rows, cols), (row_stride, 1), T.float32),
+    ):
+        with T.Kernel(1, threads=32):
+            a_shared = T.alloc_shared((rows, cols), T.float32)
+            T.copy(A, a_shared, prefer_instruction="sync")
+            T.copy(a_shared, B, prefer_instruction="tma")
+
+    import torch
+
+    source = torch.arange(rows * cols, dtype=torch.float32, device="cuda").reshape(rows, cols)
+
+    load_kernel = tilelang.compile(load, out_idx=[1])
+    assert "CUtensorMap" in load_kernel.get_kernel_source()
+    padded_source = torch.full((rows, row_stride), -1.0, dtype=torch.float32, device="cuda")
+    strided_source = padded_source[:, :cols]
+    strided_source.copy_(source)
+    output = load_kernel(strided_source)
+    torch.testing.assert_close(output, source)
+
+    store_kernel = tilelang.compile(store)
+    assert "CUtensorMap" in store_kernel.get_kernel_source()
+    padded_destination = torch.full((rows, row_stride), -1.0, dtype=torch.float32, device="cuda")
+    strided_destination = padded_destination[:, :cols]
+    store_kernel(source, strided_destination)
+    torch.testing.assert_close(strided_destination, source)
+    torch.testing.assert_close(padded_destination[:, cols:], torch.full_like(padded_destination[:, cols:], -1.0))
 
 
 def matmul_tma_copy_store(


### PR DESCRIPTION
## Summary

- use the global buffer's declared strides when computing 1D TMA source/destination offsets
- retain the existing contiguous-stride derivation only for buffers without explicit strides
- add a CUDA execution test that uses ordinary `T.copy(..., prefer_instruction="tma")` on a padded tensor view

## Root cause

`Copy::LowerBulk1D` reconstructed global strides solely from the buffer shape. For a legal strided buffer such as shape `(2, 32)` with strides `(40, 1)`, this produced a row stride of `32` instead of the declared `40`.

As a result, copying `A[1, 0:32]` started at physical element offset `32` instead of `40`. The access remained in bounds, but returned the wrong row data.

## Intended behavior

A buffer's explicit strides define how logical indices map to physical storage. `LowerBulk1D` should therefore compute the global address using `buffer.strides` when they are present. Shape-derived contiguous strides remain the fallback for ordinary contiguous buffers whose stride list is empty.

## Validation

- `pre-commit run --files src/cuda/op/copy.cc testing/python/language/test_tilelang_language_tma_copy.py`
- `cmake --build build -j4` (macOS non-CUDA build)
- `pytest -q testing/python/language/test_tilelang_language_tma_copy.py -k explicit_global_stride` (collected successfully; skipped on the local non-CUDA host)

The regression test creates a padded `(2, 40)` allocation, passes its first 32 columns as a normal `(2, 32)` view with stride `(40, 1)`, copies the second logical row through the 1D TMA path, and compares the output with that row.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed 1D TMA source/destination offset calculation to honor explicitly declared global buffer strides, while keeping the contiguous row-major stride derivation as the fallback when explicit strides are not provided.
- Strengthened 1D bulk copy analysis to more accurately detect the required “contiguous global region” shape/stride packing.
- Added CUDA regression coverage for `T.copy(..., prefer_instruction="tma")` on padded/strided tensor views, including a row-stride `(40, 1)` scenario that ensures the physical offset is correct (not assumed contiguous with row stride `32`).

## Validation

- Formatting checks passed.
- Non-CUDA build passed.
- Targeted CUDA test(s) were collected but skipped on the local non-CUDA host.

## C++ style / lint notes

- The PR touches C++ implementation code (`src/cuda/op/*`) but does not change documented C++ style rules in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step remains advisory; no correctness/build issues are indicated by the changes described here.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->