### PR TITLE
[TIR] Inject source spans into tirx IR and surface source locations in compiler errors

### DIFF
--- a/src/cuda/op/atomic_add.cc
+++ b/src/cuda/op/atomic_add.cc
@@ -14,6 +14,7 @@
 #include "layout/layout.h"
 #include "op/builtin.h"
 #include "op/utils.h"
+#include "span_utils.h"
 #include "transform/common/loop_fusion_utils.h"
 #include "transform/loop_partition.h"
 
@@ -219,7 +220,8 @@ LayoutMap InferSIMTLayout(const AtomicAddNode &op,
           << "AtomicAdd requires src and dst to have the same layout, but got "
           << "src layout: " << src_layout << ", dst layout: " << dst_layout
           << " for src buffer: " << op.src->name
-          << ", dst buffer: " << op.dst->name;
+          << ", dst buffer: " << op.dst->name
+          << SpanHintSuffix({op.dst->span, op.src->span});
     }
   }
   return {};

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -16,6 +16,7 @@
 #include "layout/tcgen05_layout.h"
 #include "op/builtin.h"
 #include "op/utils.h"
+#include "span_utils.h"
 #include "transform/common/loop_fusion_utils.h"
 #include "transform/loop_partition.h"
 #include "transform/loop_vectorize.h"
@@ -703,7 +704,8 @@ CopyInst Copy::SelectInst(const CopyNode &op, Target target,
   ctx.analyzer = analyzer;
   ctx.emit_diagnostics = true;
   auto result = SelectCopyInstForLowering(op, ctx);
-  ICHECK(result.supported) << result.reason;
+  ICHECK(result.supported) << result.reason
+                           << SpanHintSuffix({op.dst->span, op.src->span});
   return result.inst;
 }
 
@@ -1887,7 +1889,8 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
       }
     } else if (GetIsTmaCopy(op)) {
       LOG(FATAL) << "T.tma_copy() requires a barrier argument. "
-                 << "Use T.tma_copy(src, dst, barrier=mbar[idx]).";
+                 << "Use T.tma_copy(src, dst, barrier=mbar[idx])."
+                 << SpanHintSuffix({op.dst->span, op.src->span});
     } else if (lower_args.alloc_mbarrier) {
       barrier_base_id =
           lower_args.alloc_mbarrier(1, MakeCopyMBarrierName(op.src, op.dst));
@@ -2343,7 +2346,8 @@ Stmt Copy::LowerBulk1D(const CopyNode &op, const LowerArgs &lower_args,
       barrier_base_id = 0;
     } else if (GetIsTmaCopy(op)) {
       LOG(FATAL) << "T.tma_copy() requires a barrier argument. "
-                 << "Use T.tma_copy(src, dst, barrier=mbar[idx]).";
+                 << "Use T.tma_copy(src, dst, barrier=mbar[idx])."
+                 << SpanHintSuffix({op.dst->span, op.src->span});
     } else if (lower_args.alloc_mbarrier) {
       barrier_base_id =
           lower_args.alloc_mbarrier(1, MakeCopyMBarrierName(op.src, op.dst));

--- a/src/cuda/op/gemm.cc
+++ b/src/cuda/op/gemm.cc
@@ -107,14 +107,13 @@ void FatalWgmmaUnavailable(const GemmNode &op, Target target) {
 }
 
 void FatalTcgen5Unavailable(const GemmNode &op, Target target) {
-  LOG(FATAL) << "tcgen5";
-  //   LOG(FATAL) << "T.tcgen05_gemm() requires Blackwell TCGEN5MMA lowering, "
-  //                 "but constraints were not satisfied. Got target="
-  //              << target << ", A(scope=" << op.A.scope()
-  //              << ", dtype=" << op.A->dtype << "), B(scope=" << op.B.scope()
-  //              << ", dtype=" << op.B->dtype << "), C(scope=" << op.C.scope()
-  //              << ", dtype=" << op.C->dtype << "), M=" << op.M
-  //              << ", N=" << op.N << ", K=" << op.K << ".";
+  LOG(FATAL) << "T.tcgen05_gemm() requires Blackwell TCGEN5MMA lowering, "
+                "but constraints were not satisfied. Got target="
+             << target << ", A(scope=" << op.a_.scope()
+             << ", dtype=" << op.a_->dtype << "), B(scope=" << op.b_.scope()
+             << ", dtype=" << op.b_->dtype << "), C(scope=" << op.c_.scope()
+             << ", dtype=" << op.c_->dtype << "), M=" << op.m_
+             << ", N=" << op.n_ << ", K=" << op.k_ << ".";
 }
 
 std::pair<int, int>

--- a/src/cuda/op/gemm.cc
+++ b/src/cuda/op/gemm.cc
@@ -107,14 +107,14 @@ void FatalWgmmaUnavailable(const GemmNode &op, Target target) {
 }
 
 void FatalTcgen5Unavailable(const GemmNode &op, Target target) {
-  LOG(FATAL) << "T.tcgen05_gemm() requires Blackwell TCGEN5MMA lowering, "
-                "but constraints were not satisfied. Got target="
-             << target << ", A(scope=" << op.a_.scope()
-             << ", dtype=" << op.a_->dtype << "), B(scope=" << op.b_.scope()
-             << ", dtype=" << op.b_->dtype << "), C(scope=" << op.c_.scope()
-             << ", dtype=" << op.c_->dtype << "), M=" << op.m_
-             << ", N=" << op.n_ << ", K=" << op.k_ << "."
-             << SpanHintSuffix({op.a_->span, op.b_->span, op.c_->span});
+  LOG(FATAL) << "tcgen5";
+  //   LOG(FATAL) << "T.tcgen05_gemm() requires Blackwell TCGEN5MMA lowering, "
+  //                 "but constraints were not satisfied. Got target="
+  //              << target << ", A(scope=" << op.A.scope()
+  //              << ", dtype=" << op.A->dtype << "), B(scope=" << op.B.scope()
+  //              << ", dtype=" << op.B->dtype << "), C(scope=" << op.C.scope()
+  //              << ", dtype=" << op.C->dtype << "), M=" << op.M
+  //              << ", N=" << op.N << ", K=" << op.K << ".";
 }
 
 std::pair<int, int>

--- a/src/cuda/op/gemm.cc
+++ b/src/cuda/op/gemm.cc
@@ -11,6 +11,7 @@
 #include "op/builtin.h"
 #include "op/tcgen5_meta.h"
 #include "op/utils.h"
+#include "span_utils.h"
 
 #include <tvm/tirx/transform.h>
 
@@ -101,7 +102,8 @@ void FatalWgmmaUnavailable(const GemmNode &op, Target target) {
              << ", dtype=" << op.a_->dtype << "), B(scope=" << op.b_.scope()
              << ", dtype=" << op.b_->dtype << "), C(scope=" << op.c_.scope()
              << ", dtype=" << op.c_->dtype << "), M=" << op.m_
-             << ", N=" << op.n_ << ", K=" << op.k_ << ".";
+             << ", N=" << op.n_ << ", K=" << op.k_ << "."
+             << SpanHintSuffix({op.a_->span, op.b_->span, op.c_->span});
 }
 
 void FatalTcgen5Unavailable(const GemmNode &op, Target target) {
@@ -111,7 +113,8 @@ void FatalTcgen5Unavailable(const GemmNode &op, Target target) {
              << ", dtype=" << op.a_->dtype << "), B(scope=" << op.b_.scope()
              << ", dtype=" << op.b_->dtype << "), C(scope=" << op.c_.scope()
              << ", dtype=" << op.c_->dtype << "), M=" << op.m_
-             << ", N=" << op.n_ << ", K=" << op.k_ << ".";
+             << ", N=" << op.n_ << ", K=" << op.k_ << "."
+             << SpanHintSuffix({op.a_->span, op.b_->span, op.c_->span});
 }
 
 std::pair<int, int>

--- a/src/cuda/op/gemm.cc
+++ b/src/cuda/op/gemm.cc
@@ -113,7 +113,8 @@ void FatalTcgen5Unavailable(const GemmNode &op, Target target) {
              << ", dtype=" << op.a_->dtype << "), B(scope=" << op.b_.scope()
              << ", dtype=" << op.b_->dtype << "), C(scope=" << op.c_.scope()
              << ", dtype=" << op.c_->dtype << "), M=" << op.m_
-             << ", N=" << op.n_ << ", K=" << op.k_ << ".";
+             << ", N=" << op.n_ << ", K=" << op.k_ << "."
+             << SpanHintSuffix({op.a_->span, op.b_->span, op.c_->span});
 }
 
 std::pair<int, int>

--- a/src/cuda/op/gemm_sp.cc
+++ b/src/cuda/op/gemm_sp.cc
@@ -100,14 +100,14 @@ void FatalWgmmaUnavailable(const GemmSPNode &op, Target target) {
 }
 
 void FatalTcgen5Unavailable(const GemmSPNode &op, Target target) {
-  LOG(FATAL) << "T.tcgen05_gemm_sp() requires Blackwell TCGEN5MMA lowering, "
-                "but constraints were not satisfied. Got target="
-             << target << ", A(scope=" << op.A.scope()
-             << ", dtype=" << op.A->dtype << "), B(scope=" << op.B.scope()
-             << ", dtype=" << op.B->dtype << "), C(scope=" << op.C.scope()
-             << ", dtype=" << op.C->dtype << "), M=" << op.M << ", N=" << op.N
-             << ", K=" << op.K << "."
-             << SpanHintSuffix({op.A->span, op.B->span, op.C->span});
+  LOG(FATAL) << "tcgen5";
+  //   LOG(FATAL) << "T.tcgen05_gemm() requires Blackwell TCGEN5MMA lowering, "
+  //                 "but constraints were not satisfied. Got target="
+  //              << target << ", A(scope=" << op.A.scope()
+  //              << ", dtype=" << op.A->dtype << "), B(scope=" << op.B.scope()
+  //              << ", dtype=" << op.B->dtype << "), C(scope=" << op.C.scope()
+  //              << ", dtype=" << op.C->dtype << "), M=" << op.M
+  //              << ", N=" << op.N << ", K=" << op.K << ".";
 }
 
 std::pair<int, int>

--- a/src/cuda/op/gemm_sp.cc
+++ b/src/cuda/op/gemm_sp.cc
@@ -10,6 +10,7 @@
 #include "op/builtin.h"
 #include "op/tcgen5_meta.h"
 #include "op/utils.h"
+#include "span_utils.h"
 
 #include <tvm/tirx/builtin.h>
 #include <tvm/tirx/op.h>
@@ -94,18 +95,19 @@ void FatalWgmmaUnavailable(const GemmSPNode &op, Target target) {
              << ", dtype=" << op.A->dtype << "), B(scope=" << op.B.scope()
              << ", dtype=" << op.B->dtype << "), C(scope=" << op.C.scope()
              << ", dtype=" << op.C->dtype << "), M=" << op.M << ", N=" << op.N
-             << ", K=" << op.K << ".";
+             << ", K=" << op.K << "."
+             << SpanHintSuffix({op.A->span, op.B->span, op.C->span});
 }
 
 void FatalTcgen5Unavailable(const GemmSPNode &op, Target target) {
-  LOG(FATAL) << "tcgen5";
-  //   LOG(FATAL) << "T.tcgen05_gemm() requires Blackwell TCGEN5MMA lowering, "
-  //                 "but constraints were not satisfied. Got target="
-  //              << target << ", A(scope=" << op.A.scope()
-  //              << ", dtype=" << op.A->dtype << "), B(scope=" << op.B.scope()
-  //              << ", dtype=" << op.B->dtype << "), C(scope=" << op.C.scope()
-  //              << ", dtype=" << op.C->dtype << "), M=" << op.M
-  //              << ", N=" << op.N << ", K=" << op.K << ".";
+  LOG(FATAL) << "T.tcgen05_gemm_sp() requires Blackwell TCGEN5MMA lowering, "
+                "but constraints were not satisfied. Got target="
+             << target << ", A(scope=" << op.A.scope()
+             << ", dtype=" << op.A->dtype << "), B(scope=" << op.B.scope()
+             << ", dtype=" << op.B->dtype << "), C(scope=" << op.C.scope()
+             << ", dtype=" << op.C->dtype << "), M=" << op.M << ", N=" << op.N
+             << ", K=" << op.K << "."
+             << SpanHintSuffix({op.A->span, op.B->span, op.C->span});
 }
 
 std::pair<int, int>

--- a/src/cuda/op/gemm_sp.cc
+++ b/src/cuda/op/gemm_sp.cc
@@ -100,14 +100,17 @@ void FatalWgmmaUnavailable(const GemmSPNode &op, Target target) {
 }
 
 void FatalTcgen5Unavailable(const GemmSPNode &op, Target target) {
-  LOG(FATAL) << "tcgen5";
-  //   LOG(FATAL) << "T.tcgen05_gemm() requires Blackwell TCGEN5MMA lowering, "
-  //                 "but constraints were not satisfied. Got target="
-  //              << target << ", A(scope=" << op.A.scope()
-  //              << ", dtype=" << op.A->dtype << "), B(scope=" << op.B.scope()
-  //              << ", dtype=" << op.B->dtype << "), C(scope=" << op.C.scope()
-  //              << ", dtype=" << op.C->dtype << "), M=" << op.M
-  //              << ", N=" << op.N << ", K=" << op.K << ".";
+  LOG(FATAL) << "T.tcgen05_gemm_sp() requires Blackwell TCGEN5MMA sparse "
+                "lowering, but sparse TCGEN5MMA lowering is not yet available. "
+                "Got target="
+             << target << ", A(scope=" << op.A.scope()
+             << ", dtype=" << op.A->dtype << "), E(scope=" << op.E.scope()
+             << ", dtype=" << op.E->dtype << "), B(scope=" << op.B.scope()
+             << ", dtype=" << op.B->dtype << "), C(scope=" << op.C.scope()
+             << ", dtype=" << op.C->dtype << "), M=" << op.M << ", N=" << op.N
+             << ", K=" << op.K << "."
+             << SpanHintSuffix(
+                    {op.A->span, op.E->span, op.B->span, op.C->span});
 }
 
 std::pair<int, int>

--- a/src/op/copy.cc
+++ b/src/op/copy.cc
@@ -8,6 +8,7 @@
 #include "../transform/common/loop_fusion_utils.h"
 #include "../transform/loop_partition.h"
 #include "../transform/loop_vectorize.h"
+#include "span_utils.h"
 #include "support/check.h"
 #include "utils.h"
 #include <tvm/ir/cast.h>
@@ -391,7 +392,7 @@ Array<IterVar> CopyNode::MakeIterVars() const {
             << ", extent=" << base_ext << "\n";
         oss << "src_ranges[" << src_dim << "]: min=" << src_range[src_dim]->min
             << ", extent=" << src_ext << "\n";
-        LOG(FATAL) << oss.str();
+        LOG(FATAL) << oss.str() << SpanHintSuffix({dst->span, src->span});
       }
       ++base_dim;
       ++src_dim;

--- a/src/op/parallel.cc
+++ b/src/op/parallel.cc
@@ -14,12 +14,12 @@
 #include <tvm/tirx/op.h>
 
 #include "../layout/layout.h"
-#include "arith/int_operator.h"
-
 #include "../layout/utils.h"
 #include "../transform/loop_partition.h"
 #include "../transform/loop_vectorize.h"
+#include "arith/int_operator.h"
 #include "backend/common/target_utils.h"
+#include "span_utils.h"
 #include "utils.h"
 
 namespace tvm {
@@ -253,7 +253,8 @@ void ParallelOpNode::RecordBufferAccess(const Buffer &buffer,
   auto it = indice_map_.find(buffer);
   if (it != indice_map_.end()) {
     ICHECK(StructuralEqual()(it->second.indices, indices))
-        << buffer << ": " << indices << " and " << it->second.indices;
+        << buffer << ": " << indices << " and " << it->second.indices
+        << SpanHintSuffix(buffer->span);
   } else {
     BufferAccessInfo info;
     info.indices = indices;
@@ -357,7 +358,8 @@ LayoutMap ParallelOpNode::InferLayout(const LayoutInferArgs &layout_args,
             LOG(FATAL)
                 << "Fragment buffer access with non-zero index [" << imm->value
                 << "] is not supported. "
-                << "Only fragment[0] access is allowed within T.Parallel loop.";
+                << "Only fragment[0] access is allowed within T.Parallel loop."
+                << SpanHintSuffix(buffer->span);
           }
         } else {
           // Non-constant index, not all zero
@@ -744,7 +746,7 @@ Fragment ParallelOpNode::ComputeLoopLayoutFromBuffer(
       msg << "\nProblematic loop AST:\n " << root_;
       msg << "\nHint: ensure the loop extent divides the thread binding or "
              "adjust the fragment mapping.";
-      LOG(FATAL) << msg.str();
+      LOG(FATAL) << msg.str() << SpanHintSuffix(buffer->span);
     }
   }
   DLOG(INFO) << "[compute_loop_layout_from_buffer] ... and get "

--- a/src/span_utils.cc
+++ b/src/span_utils.cc
@@ -1,0 +1,61 @@
+/*!
+ * \file tl/span_utils.cc
+ * \brief FFI entry points to inject and read source spans on tirx IR nodes.
+ */
+
+#include "span_utils.h"
+
+#include <tvm/ffi/reflection/registry.h>
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+using namespace ffi;
+
+void SetStmtSpan(Stmt stmt, Span span) {
+  if (stmt.defined()) {
+    stmt.get()->span = std::move(span);
+  }
+}
+
+Span GetStmtSpan(const Stmt &stmt) {
+  return stmt.defined() ? stmt->span : Span();
+}
+
+void SetBufferSpan(Buffer buffer, Span span) {
+  if (buffer.defined()) {
+    buffer.get()->span = std::move(span);
+  }
+}
+
+Span GetBufferSpan(const Buffer &buffer) {
+  return buffer.defined() ? buffer->span : Span();
+}
+
+void SetPrimFuncSpan(PrimFunc func, Span span) {
+  if (func.defined()) {
+    func.get()->span = std::move(span);
+  }
+}
+
+Span GetPrimFuncSpan(const PrimFunc &func) {
+  return func.defined() ? func->span : Span();
+}
+
+String SpanToString(const Span &span) { return FormatSpan(span); }
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  refl::GlobalDef()
+      .def("tl.ir.SetStmtSpan", &SetStmtSpan)
+      .def("tl.ir.GetStmtSpan", &GetStmtSpan)
+      .def("tl.ir.SetBufferSpan", &SetBufferSpan)
+      .def("tl.ir.GetBufferSpan", &GetBufferSpan)
+      .def("tl.ir.SetPrimFuncSpan", &SetPrimFuncSpan)
+      .def("tl.ir.GetPrimFuncSpan", &GetPrimFuncSpan)
+      .def("tl.ir.SpanToString", &SpanToString);
+}
+
+} // namespace tl
+} // namespace tvm

--- a/src/span_utils.h
+++ b/src/span_utils.h
@@ -1,0 +1,71 @@
+/*!
+ * \file tl/span_utils.h
+ * \brief Helpers to read/write source spans on tirx IR nodes and to format
+ *        spans into compiler error messages.
+ *
+ * `StmtNode::span` / `BufferNode::span` / `PrimFuncNode::span` are mutable
+ * fields that are reflected read-only to Python. These helpers write them
+ * directly from C++, so spans can be injected during script parsing without
+ * touching the vendored TVM fork. Spans never participate in structural
+ * equality or hashing.
+ */
+#ifndef TVM_TL_SPAN_UTILS_H_
+#define TVM_TL_SPAN_UTILS_H_
+
+#include <tvm/ir/source_map.h>
+#include <tvm/tirx/buffer.h>
+#include <tvm/tirx/expr.h>
+#include <tvm/tirx/function.h>
+#include <tvm/tirx/stmt.h>
+
+#include <initializer_list>
+#include <sstream>
+#include <string>
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+using namespace ffi;
+
+/*!
+ * \brief Format a span as "file:line:col" for error messages.
+ * \return Empty string when the span or its source name is undefined.
+ */
+inline std::string FormatSpan(const Span &span) {
+  if (!span.defined() || !span->source_name.defined()) {
+    return "";
+  }
+  std::ostringstream os;
+  os << span->source_name->name << ":" << span->line << ":" << span->column;
+  return os.str();
+}
+
+/*!
+ * \brief Suffix for error messages pointing at a source location, e.g.
+ *        "\n  --> /path/to/kernel.py:21:1". Empty when no span is available.
+ */
+inline std::string SpanHintSuffix(const Span &span) {
+  std::string loc = FormatSpan(span);
+  return loc.empty() ? "" : "\n  --> " + loc;
+}
+
+/*!
+ * \brief SpanHintSuffix over multiple candidates; the first defined span wins.
+ * Useful when an error involves several buffers (e.g. src/dst) and any one of
+ * their declaration sites helps the user locate the problem.
+ */
+inline std::string SpanHintSuffix(std::initializer_list<Span> spans) {
+  for (const auto &span : spans) {
+    std::string hint = SpanHintSuffix(span);
+    if (!hint.empty()) {
+      return hint;
+    }
+  }
+  return "";
+}
+
+} // namespace tl
+} // namespace tvm
+
+#endif // TVM_TL_SPAN_UTILS_H_

--- a/src/span_utils.h
+++ b/src/span_utils.h
@@ -25,9 +25,6 @@
 namespace tvm {
 namespace tl {
 
-using namespace tirx;
-using namespace ffi;
-
 /*!
  * \brief Format a span as "file:line:col" for error messages.
  * \return Empty string when the span or its source name is undefined.

--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -16,6 +16,8 @@
 #include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/transform.h>
 
+#include "span_utils.h"
+
 #include <algorithm>
 #include <map>
 #include <memory>
@@ -3104,7 +3106,8 @@ private:
       int order = stmt_info.order;
       ICHECK(!used_orders.count(order))
           << "ValueError: Two statements in the software pipeline cannot have "
-             "the same order";
+             "the same order"
+          << SpanHintSuffix({block->body->span, block->span});
       used_orders.insert(order);
     }
 
@@ -3121,12 +3124,14 @@ private:
         ICHECK_LE(src_info.stage, dst_info.stage)
             << "ValueError: statement " << dst << " in stage " << dst_info.stage
             << " cannot depends on statement " << src << " in a later stage "
-            << src_info.stage;
+            << src_info.stage
+            << SpanHintSuffix({dst->body->span, src->body->span});
         if (src_info.stage == dst_info.stage) {
           ICHECK_LT(src_info.order, dst_info.order)
               << "ValueError: two statements with buffer "
                  "access dependency in the same stage of the "
-                 "software pipeline cannot be reordered";
+                 "software pipeline cannot be reordered"
+              << SpanHintSuffix({dst->body->span, src->body->span});
         }
       }
     }
@@ -3159,11 +3164,13 @@ private:
             << "ValueError: scheduled scalar Bind '" << var
             << "' is used from a different pipeline stage. Scalar Bind "
                "statements that cannot be replayed must be scheduled in the "
-               "same stage as their consumers.";
+               "same stage as their consumers."
+            << SpanHintSuffix(consumer->body->span);
         ICHECK_LT(producer_info.order, consumer_info.order)
             << "ValueError: scheduled scalar Bind '" << var
             << "' must be ordered before every consumer in the same pipeline "
-               "stage.";
+               "stage."
+            << SpanHintSuffix(consumer->body->span);
       }
     }
   }

--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -33,6 +33,7 @@
 #include "common/union_find.h"
 #include "layout_reducer.h"
 #include "parallel_loop_layout_validator.h"
+#include "span_utils.h"
 #include "tir/transforms/ir_utils.h"
 
 namespace tvm {
@@ -248,7 +249,8 @@ public:
           LOG(FATAL) << "Get different layout for " << buffer
                      << "\n current layout: " << layout->DebugOutput()
                      << "\n previous layout: "
-                     << layout_map[buffer]->DebugOutput();
+                     << layout_map[buffer]->DebugOutput()
+                     << SpanHintSuffix(buffer->span);
         }
         // Ensure aliases are consistent too
         propagate_alias(buffer, layout);
@@ -411,7 +413,8 @@ public:
       if (IsFragmentBuffer(buffer)) {
         ICHECK_NE(layout_map.count(buffer), 0)
             << "The layout for fragment " << buffer
-            << " can not be inferred correctly.";
+            << " can not be inferred correctly."
+            << SpanHintSuffix(buffer->span);
       }
     }
 
@@ -1117,7 +1120,8 @@ private:
                        "buffer. Non-constant shape expr is: "
                     << i
                     << ". This is possibly because you use symbolic shape when "
-                       "accessing a fragment/local buffer.";
+                       "accessing a fragment/local buffer."
+                    << SpanHintSuffix(buffer->span);
                 frag_reg_num *= *pci;
               }
               reg_num += frag_reg_num;

--- a/testing/python/language/test_tilelang_language_span.py
+++ b/testing/python/language/test_tilelang_language_span.py
@@ -1,0 +1,264 @@
+"""Tests for source span injection into tirx IR (TILELANG_ENABLE_IR_SPAN).
+
+Spans let compiler diagnostics and tools (LSP, visualizers) map IR nodes back
+to user source lines. Injection happens during eager parsing and must be
+exact: every emitted statement/buffer carries the line of the user statement
+that produced it.
+"""
+
+import pytest
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+from tilelang.ir import (
+    get_buffer_span,
+    get_stmt_span,
+    make_span,
+    set_buffer_span,
+    set_stmt_span,
+    span_coverage,
+    span_to_location,
+)
+from tvm.tirx.stmt_functor import post_order_visit
+
+
+def _marker_line(marker: str) -> int:
+    with open(__file__) as f:
+        for i, line in enumerate(f, 1):
+            if marker in line:
+                return i
+    raise ValueError(f"marker not found: {marker}")
+
+
+def _make_kernel():
+    @T.prim_func
+    def main(
+        A: T.Tensor((128, 128), "float16"),
+        B: T.Tensor((128, 128), "float16"),
+        C: T.Tensor((128, 128), "float16"),
+    ):
+        with T.Kernel(1, threads=128) as bx:  # span_marker_kernel
+            A_shared = T.alloc_shared((128, 128), "float16")  # span_marker_alloc_shared
+            C_local = T.alloc_fragment((128, 128), "float32")  # span_marker_alloc_fragment
+            T.copy(A, A_shared)  # span_marker_copy
+            T.clear(C_local)  # span_marker_clear
+            for _k in T.serial(8):  # span_marker_for
+                T.gemm(A_shared, A_shared, C_local)  # span_marker_gemm
+            if bx == 0:  # span_marker_if
+                T.copy(C_local, C)  # span_marker_copy_out
+
+    return main
+
+
+def _stmt_span_lines(func) -> dict[int, list[str]]:
+    """Map source line -> IR node type names stamped with that line."""
+    lines: dict[int, list[str]] = {}
+
+    def visit(node):
+        if not isinstance(node, tvm.tirx.Stmt):
+            return
+        loc = span_to_location(get_stmt_span(node))
+        if loc is not None:
+            assert loc[0] == __file__
+            lines.setdefault(loc[1], []).append(type(node).__name__)
+
+    post_order_visit(func.body, visit)
+    return lines
+
+
+def _alloc_buffer_span_lines(func) -> dict[int, list[str]]:
+    lines: dict[int, list[str]] = {}
+
+    def visit(node):
+        if type(node).__name__ == "SBlockRealize":
+            for buf in node.block.alloc_buffers:
+                loc = span_to_location(get_buffer_span(buf))
+                if loc is not None:
+                    assert loc[0] == __file__
+                    lines.setdefault(loc[1], []).append(buf.name)
+
+    post_order_visit(func.body, visit)
+    return lines
+
+
+def test_stmt_spans_point_to_user_lines():
+    func = _make_kernel()
+    lines = _stmt_span_lines(func)
+    assert _marker_line("span_marker_copy") in lines
+    assert _marker_line("span_marker_clear") in lines
+    assert _marker_line("span_marker_gemm") in lines
+    assert "For" in lines[_marker_line("span_marker_for")]
+    assert any(k.startswith("If") for k in lines[_marker_line("span_marker_if")])
+    assert _marker_line("span_marker_copy_out") in lines
+
+
+def test_buffer_spans_point_to_alloc_lines():
+    func = _make_kernel()
+    buf_lines = _alloc_buffer_span_lines(func)
+    assert "A_shared" in buf_lines[_marker_line("span_marker_alloc_shared")]
+    assert "C_local" in buf_lines[_marker_line("span_marker_alloc_fragment")]
+
+
+def test_span_disabled(monkeypatch):
+    monkeypatch.setenv("TILELANG_ENABLE_IR_SPAN", "0")
+    func = _make_kernel()
+    cov = span_coverage(func)
+    assert cov["stmts"] == [0, cov["stmts"][1]]
+    assert cov["buffers"][0] == 0
+
+
+def test_span_not_in_structural_equal(monkeypatch):
+    from tvm.ir import assert_structural_equal
+
+    func_on = _make_kernel()
+    monkeypatch.setenv("TILELANG_ENABLE_IR_SPAN", "0")
+    func_off = _make_kernel()
+    assert_structural_equal(func_on, func_off)
+
+
+def test_script_print_ignores_span():
+    func = _make_kernel()
+    text_with_span = func.script()
+    assert text_with_span and isinstance(text_with_span, str)
+
+
+def test_span_coverage_helper():
+    func = _make_kernel()
+    cov = span_coverage(func)
+    with_span, total = cov["stmts"]
+    assert total > 0
+    # SeqStmt and other assembly nodes are never stamped; user-level
+    # statements must dominate.
+    assert with_span / total > 0.5
+
+
+def test_make_span_and_setters_roundtrip():
+    span = make_span(__file__, 42)
+    func = _make_kernel()
+    # Exercise the raw setters on a real node.
+    set_stmt_span(func.body, span)
+    assert span_to_location(get_stmt_span(func.body)) == (__file__, 42)
+    buf = func.buffer_map[func.params[0]]
+    set_buffer_span(buf, span)
+    assert span_to_location(get_buffer_span(buf)) == (__file__, 42)
+
+
+def _make_macro_kernel():
+    @T.macro
+    def load_to_shared(A, A_shared):
+        T.copy(A, A_shared)  # span_marker_macro_copy
+
+    @T.prim_func
+    def main(A: T.Tensor((128, 128), "float16"), B: T.Tensor((128, 128), "float16")):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((128, 128), "float16")
+            load_to_shared(A, A_shared)  # span_marker_macro_call
+
+    return main
+
+
+def test_spans_inside_macro():
+    func = _make_macro_kernel()
+    lines = _stmt_span_lines(func)
+    # Statements inside a macro body point at the macro definition line,
+    # mirroring Python traceback semantics for the macro body frame.
+    macro_lines = lines.get(_marker_line("span_marker_macro_copy"))
+    call_lines = lines.get(_marker_line("span_marker_macro_call"))
+    assert macro_lines or call_lines, "macro copy statement carries no span"
+
+
+# ---------------------------------------------------------------------------
+# Error location tests: pass diagnostics must carry a `--> file:line` hint.
+# ---------------------------------------------------------------------------
+
+
+def _expect_error_at(excinfo, marker: str):
+    message = str(excinfo.value)
+    expected = f"--> {__file__}:{_marker_line(marker)}:"
+    assert expected in message, f"expected {expected!r} in error message:\n{message}"
+
+
+def _make_parallel_fragment_bad_index():
+    @T.prim_func
+    def main(A: T.Tensor((128,), "float32")):
+        with T.Kernel(1, threads=128):
+            frag = T.alloc_fragment((4,), "float32")  # span_marker_frag_alloc
+            for i in T.Parallel(4):
+                frag[1] = A[i]  # span_marker_frag_store
+
+    return main
+
+
+def test_error_span_parallel_fragment_nonzero_index():
+    func = _make_parallel_fragment_bad_index()
+    with pytest.raises(Exception) as excinfo:
+        tilelang.lower(func, target="c")
+    assert "Only fragment[0] access is allowed" in str(excinfo.value)
+    _expect_error_at(excinfo, "span_marker_frag_alloc")
+
+
+def _make_pipeline_duplicate_order():
+    @T.prim_func
+    def main(
+        A: T.Tensor((128, 128), "float16"),
+        B: T.Tensor((128, 128), "float16"),
+        C: T.Tensor((128, 128), "float16"),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((128, 128), "float16")
+            B_shared = T.alloc_shared((128, 128), "float16")
+            for _k in T.Pipelined(2, order=[0, 0], stage=[0, 1]):  # span_marker_pipelined
+                T.copy(A, A_shared)  # span_marker_pipe_copy1
+                T.copy(B, B_shared)  # span_marker_pipe_copy2
+
+    return main
+
+
+@tilelang.testing.requires_metal
+def test_error_span_pipeline_duplicate_order():
+    func = _make_pipeline_duplicate_order()
+    with pytest.raises(Exception) as excinfo, tvm.target.Target("metal"):
+        tilelang.lower(func, target="metal")
+    assert "same order" in str(excinfo.value)
+    _expect_error_at(excinfo, "span_marker_pipe_copy2")
+
+
+def _make_parallel_inconsistent_indices():
+    @T.prim_func
+    def main(A: T.Tensor((128,), "float32")):
+        with T.Kernel(1, threads=128):
+            frag = T.alloc_fragment((4,), "float32")  # span_marker_frag_alloc2
+            for i in T.Parallel(4):
+                frag[0] = A[i]
+                frag[1] = A[i]  # span_marker_frag_store2
+
+    return main
+
+
+def test_error_span_parallel_inconsistent_indices():
+    func = _make_parallel_inconsistent_indices()
+    with pytest.raises(Exception) as excinfo:
+        tilelang.lower(func, target="c")
+    _expect_error_at(excinfo, "span_marker_frag_alloc2")
+
+
+def _make_copy_range_mismatch():
+    @T.prim_func
+    def main(A: T.Tensor((128,), "float32"), B: T.Tensor((64,), "float32")):
+        with T.Kernel(1, threads=128):
+            B_shared = T.alloc_shared((64,), "float32")
+            T.copy(A[0:128], B_shared[0:64])  # span_marker_bad_copy
+
+    return main
+
+
+def test_error_span_copy_range_mismatch():
+    func = _make_copy_range_mismatch()
+    with pytest.raises(Exception) as excinfo:
+        tilelang.lower(func, target="c")
+    assert "--> " in str(excinfo.value)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/language/test_tilelang_language_span.py
+++ b/testing/python/language/test_tilelang_language_span.py
@@ -260,5 +260,86 @@ def test_error_span_copy_range_mismatch():
     assert "--> " in str(excinfo.value)
 
 
+# ---------------------------------------------------------------------------
+# Review hardening: parameter buffer spans, path edge cases, coverage stats.
+# ---------------------------------------------------------------------------
+
+
+def _make_kernel_param_span():
+    @T.prim_func
+    def main(
+        A: T.Tensor((128, 128), "float16"),  # span_marker_param_a
+        B: T.Tensor((128, 128), "float16"),
+    ):
+        with T.Kernel(1, threads=128):
+            T.copy(A, B)
+
+    return main
+
+
+def test_param_buffer_has_span():
+    func = _make_kernel_param_span()
+    buffer_a = func.buffer_map[func.params[0]]
+    loc = span_to_location(get_buffer_span(buffer_a))
+    assert loc is not None, "parameter buffer A carries no span"
+    assert loc == (__file__, _marker_line("span_marker_param_a"))
+
+
+def test_enrich_error_space_and_windows_paths(tmp_path):
+    from tilelang.errors import _MARKER_RE, enrich_error
+
+    # POSIX path containing spaces: snippet must render.
+    spaced = tmp_path / "dir with spaces"
+    spaced.mkdir()
+    src = spaced / "kernel.py"
+    src.write_text("line one\nline two\nline three\n")
+    exc = ValueError(f"boom\n  --> {src}:2:1")
+    enrich_error(exc)
+    assert "line two" in str(exc)
+
+    # Windows drive-letter path: regex must not stop at the drive colon.
+    m = _MARKER_RE.search("\n  --> C:\\work\\kernel.py:21:1")
+    assert m is not None
+    assert m.group("file") == "C:\\work\\kernel.py"
+    assert m.group("line") == "21"
+    assert m.group("col") == "1"
+
+
+def test_enrich_error_passes_through_plain_errors():
+    from tilelang.errors import enrich_error
+
+    exc = ValueError("plain error without marker")
+    assert enrich_error(exc) is exc
+    assert str(exc) == "plain error without marker"
+
+
+def test_mutate_with_windows_style_path():
+    """Windows absolute paths must not produce truncated \\U escapes."""
+    import ast as py_ast
+
+    import tilelang.language.eager.ast as eager_ast
+
+    def sample(a):
+        return a + 1
+
+    fake_path = r"C:\Users\fake\kernel.py"
+    tree = eager_ast.utils.get_ast(sample)
+    mut = eager_ast.DSLMutator({}, sample.__globals__, fake_path)
+    new_tree = mut.visit(tree)
+    source = py_ast.unparse(new_tree)
+    # repr() quoting keeps the path intact and the generated source valid.
+    assert repr(fake_path) in source
+    compile(source, "<mutated>", "exec")
+
+
+def test_span_coverage_counts_alloc_buffers():
+    func = _make_kernel()
+    cov = span_coverage(func)
+    # 3 parameter buffers + A_shared + C_local; all must be spanned and the
+    # alloc (non-parameter) buffers must be counted.
+    assert cov["buffers"][1] >= 5
+    assert cov["buffers"][0] == cov["buffers"][1]
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/language/test_tilelang_language_span.py
+++ b/testing/python/language/test_tilelang_language_span.py
@@ -177,6 +177,7 @@ def _expect_error_at(excinfo, marker: str):
     message = str(excinfo.value)
     expected = f"--> {__file__}:{_marker_line(marker)}:"
     assert expected in message, f"expected {expected!r} in error message:\n{message}"
+    assert marker in message, f"source snippet was not rendered:\n{message}"
 
 
 def _make_parallel_fragment_bad_index():
@@ -263,6 +264,84 @@ def test_error_span_copy_range_mismatch():
 # ---------------------------------------------------------------------------
 # Review hardening: parameter buffer spans, path edge cases, coverage stats.
 # ---------------------------------------------------------------------------
+
+
+def _make_eager_jit_buffers():
+    @tilelang.jit
+    def main(A):
+        A: T.Tensor((64,), T.float32)  # span_marker_eager_param
+        C = T.empty((64,), T.float32)  # span_marker_eager_empty
+        with T.Kernel(1, threads=128):
+            T.copy(A, C)
+        return C
+
+    return main.get_tir()
+
+
+def test_eager_jit_param_and_empty_buffer_spans():
+    func = _make_eager_jit_buffers()
+    locations = {buf.name: span_to_location(get_buffer_span(buf)) for buf in func.buffer_map.values()}
+    assert locations["A"] == (__file__, _marker_line("span_marker_eager_param"))
+    assert locations["C"] == (__file__, _marker_line("span_marker_eager_empty"))
+
+
+def _make_eager_jit_wgmma_error():
+    @tilelang.jit
+    def main(A, B, C):
+        A: T.Tensor((32, 16), T.float16)  # span_marker_eager_wgmma_param
+        B: T.Tensor((16, 64), T.float16)
+        C: T.Tensor((32, 64), T.float16)
+        with T.Kernel(1, threads=128):
+            T.wgmma_gemm(A, B, C, clear_accum=True)
+
+    return main.get_tir()
+
+
+@tilelang.testing.requires_cuda
+def test_eager_jit_buffer_only_diagnostic_has_span():
+    func = _make_eager_jit_wgmma_error()
+    with pytest.raises(Exception) as excinfo:
+        tilelang.lower(func, target={"kind": "cuda", "arch": "sm_80"})
+    assert "T.wgmma_gemm() requires Hopper WGMMA lowering" in str(excinfo.value)
+    _expect_error_at(excinfo, "span_marker_eager_wgmma_param")
+
+
+def _make_match_buffer_kernel():
+    @T.prim_func
+    def main(A_ptr: T.handle):
+        A = T.match_buffer(A_ptr, (16,), T.float32)  # span_marker_match_buffer
+        with T.Kernel(1, threads=1):
+            T.evaluate(A[0])
+
+    return main
+
+
+def test_match_buffer_has_span():
+    func = _make_match_buffer_kernel()
+    (buffer_a,) = func.buffer_map.values()
+    assert span_to_location(get_buffer_span(buffer_a)) == (
+        __file__,
+        _marker_line("span_marker_match_buffer"),
+    )
+
+
+def _make_tensor_from_ptr_kernel():
+    @T.prim_func
+    def main(A_ptr: T.ptr):
+        A = T.make_tensor(A_ptr, (16,), T.float32)  # span_marker_make_tensor
+        with T.Kernel(1, threads=1):
+            T.evaluate(A[0])
+
+    return main
+
+
+def test_make_tensor_has_span():
+    func = _make_tensor_from_ptr_kernel()
+    (buffer_a,) = func.buffer_map.values()
+    assert span_to_location(get_buffer_span(buffer_a)) == (
+        __file__,
+        _marker_line("span_marker_make_tensor"),
+    )
 
 
 def _make_kernel_param_span():

--- a/testing/python/language/test_tilelang_language_tcgen05_gemm.py
+++ b/testing/python/language/test_tilelang_language_tcgen05_gemm.py
@@ -6,6 +6,21 @@ import tilelang.testing
 from tilelang import tvm
 
 
+def _marker_line(marker: str) -> int:
+    with open(__file__) as f:
+        for i, line in enumerate(f, 1):
+            if marker in line:
+                return i
+    raise ValueError(f"marker not found: {marker}")
+
+
+def _assert_error_at(excinfo, marker: str):
+    message = str(excinfo.value)
+    expected = f"--> {__file__}:{_marker_line(marker)}:"
+    assert expected in message, f"expected {expected!r} in error message:\n{message}"
+    assert marker in message, f"source snippet was not rendered:\n{message}"
+
+
 def _make_sync_tcgen05_kernel(gemm_op):
     @T.prim_func
     def main(
@@ -103,7 +118,7 @@ def test_tcgen05_gemm_rejects_non_tcgen05_lowering():
         D: T.Tensor((128, 128), T.bfloat16),
     ):
         with T.Kernel(1, threads=128):
-            A_shared = T.alloc_shared((128, 128), T.bfloat16)
+            A_shared = T.alloc_shared((128, 128), T.bfloat16)  # tcgen05_dense_error_span
             B_shared = T.alloc_shared((128, 128), T.bfloat16)
             C_local = T.alloc_fragment((128, 128), T.float32)
             mbar = T.alloc_barrier(1)
@@ -116,8 +131,15 @@ def test_tcgen05_gemm_rejects_non_tcgen05_lowering():
     with pytest.raises(
         tvm.error.InternalError,
         match=r"T\.tcgen05_gemm\(\) requires Blackwell TCGEN5MMA lowering",
-    ):
+    ) as excinfo:
         tilelang.compile(main, target="cuda")
+    message = str(excinfo.value)
+    assert "target=" in message
+    assert "A(scope=shared.dyn, dtype=bfloat16)" in message
+    assert "B(scope=shared.dyn, dtype=bfloat16)" in message
+    assert "C(scope=local.fragment, dtype=float32)" in message
+    assert "M=128, N=128, K=128" in message
+    _assert_error_at(excinfo, "tcgen05_dense_error_span")
 
 
 def _make_sliced_tcgen05_kernel(M, N, K, num_k_tiles):

--- a/tilelang/backend/pass_pipeline/pipeline.py
+++ b/tilelang/backend/pass_pipeline/pipeline.py
@@ -20,7 +20,18 @@ class PassPipeline:
         self._lower = lower
 
     def lower(self, mod: IRModule, target: Target) -> IRModule:
-        return self._lower(mod, target)
+        """Run the pipeline and render source snippets for located errors."""
+        try:
+            return self._lower(mod, target)
+        except Exception as exc:
+            # Compiler passes append a machine-readable `--> file:line:col`
+            # marker when the relevant IR node carries a span. Keep enrichment
+            # at this shared boundary so every pipeline caller gets the same
+            # user-facing diagnostic without changing exception semantics.
+            from tilelang.errors import enrich_error
+
+            enrich_error(exc)
+            raise
 
 
 _PIPELINES: dict[str, PassPipeline] = {}

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -286,7 +286,14 @@ def lower_to_host_device_ir(
     PreLowerSemanticCheck(mod)
 
     pipeline = resolve_pipeline(target)
-    mod = pipeline.lower(mod, target)
+    try:
+        mod = pipeline.lower(mod, target)
+    except Exception as exc:
+        # Passes that report source spans embed a `--> file:line:col` marker
+        # in the message; enrich it into a rendered source snippet.
+        from tilelang.errors import enrich_error
+
+        raise enrich_error(exc) from None
 
     host_mod = tirx.transform.Filter(_is_host_call)(mod)
     device_mod = tirx.transform.Filter(_is_device_call)(mod)

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -290,10 +290,13 @@ def lower_to_host_device_ir(
         mod = pipeline.lower(mod, target)
     except Exception as exc:
         # Passes that report source spans embed a `--> file:line:col` marker
-        # in the message; enrich it into a rendered source snippet.
+        # in the message; enrich it into a rendered source snippet. enrich_error
+        # rewrites the message in place, so a bare re-raise keeps the original
+        # exception type, traceback, and __cause__ chain intact.
         from tilelang.errors import enrich_error
 
-        raise enrich_error(exc) from None
+        enrich_error(exc)
+        raise
 
     host_mod = tirx.transform.Filter(_is_host_call)(mod)
     device_mod = tirx.transform.Filter(_is_device_call)(mod)

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -286,17 +286,7 @@ def lower_to_host_device_ir(
     PreLowerSemanticCheck(mod)
 
     pipeline = resolve_pipeline(target)
-    try:
-        mod = pipeline.lower(mod, target)
-    except Exception as exc:
-        # Passes that report source spans embed a `--> file:line:col` marker
-        # in the message; enrich it into a rendered source snippet. enrich_error
-        # rewrites the message in place, so a bare re-raise keeps the original
-        # exception type, traceback, and __cause__ chain intact.
-        from tilelang.errors import enrich_error
-
-        enrich_error(exc)
-        raise
+    mod = pipeline.lower(mod, target)
 
     host_mod = tirx.transform.Filter(_is_host_call)(mod)
     device_mod = tirx.transform.Filter(_is_device_call)(mod)

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -385,6 +385,9 @@ class Environment:
     TILELANG_PASS_PROFILE = EnvVar("TILELANG_PASS_PROFILE", "0")  # "0"=off, "1"/"true"=on
     TILELANG_PASS_PROFILE_THRESHOLD_MS = EnvVar("TILELANG_PASS_PROFILE_THRESHOLD_MS", "0")  # 0=show all
 
+    # Source span injection into tirx IR (error locations / LSP / visualization)
+    TILELANG_ENABLE_IR_SPAN = EnvVar("TILELANG_ENABLE_IR_SPAN", "1")  # "1"=on (default), "0"=off
+
     # Auto-tuning settings
     TILELANG_AUTO_TUNING_DISABLE_CACHE = EnvVar("TILELANG_AUTO_TUNING_DISABLE_CACHE", "0")
     TILELANG_AUTO_TUNING_CPU_UTILITIES = EnvVar("TILELANG_AUTO_TUNING_CPU_UTILITIES", "0.9")  # percent of CPUs used

--- a/tilelang/env.py
+++ b/tilelang/env.py
@@ -523,6 +523,9 @@ class Environment:
         # other scripts that only require the minimal environment variables.
         return self.is_running_autodd()
 
+    def is_span_enable(self) -> bool:
+        return self.TILELANG_ENABLE_IR_SPAN.lower() in ("1", "true", "yes", "on")
+
 
 # Instantiate as a global configuration object
 env = Environment()

--- a/tilelang/errors.py
+++ b/tilelang/errors.py
@@ -15,8 +15,6 @@ to a clang/python-style snippet:
        |     ^
 """
 
-from __future__ import annotations
-
 import os
 import re
 

--- a/tilelang/errors.py
+++ b/tilelang/errors.py
@@ -20,7 +20,11 @@ from __future__ import annotations
 import os
 import re
 
-_MARKER_RE = re.compile(r"\n\s*-->\s+(?P<file>[^\s:]+):(?P<line>\d+)(?::(?P<col>\d+))?\s*$")
+# The file part is lazy so the trailing ":line[:col]" is split off from the
+# right: greedy matching would swallow ":line" into the file group, while
+# lazy matching still accommodates paths with spaces ("/path with spaces/")
+# and Windows drive letters ("C:\work\kernel.py") via backtracking.
+_MARKER_RE = re.compile(r"\n\s*-->\s+(?P<file>.+?):(?P<line>\d+)(?::(?P<col>\d+))?\s*$")
 
 
 def _render_snippet(file: str, line: int, col: int) -> str | None:

--- a/tilelang/errors.py
+++ b/tilelang/errors.py
@@ -1,0 +1,70 @@
+"""Render source-location hints embedded in compiler error messages.
+
+C++ passes append a machine-readable location line to error messages when the
+relevant IR node carries a source span (see `src/span_utils.h`):
+
+    \n  --> /abs/path/to/kernel.py:21:1
+
+`enrich_error` rewrites the exception message in place (same exception type)
+to a clang/python-style snippet:
+
+    tvm.error.InternalError: The layout for fragment C_local ...
+      --> /abs/path/to/kernel.py:21:1
+       |
+    21 |     C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+       |     ^
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+_MARKER_RE = re.compile(r"\n\s*-->\s+(?P<file>[^\s:]+):(?P<line>\d+)(?::(?P<col>\d+))?\s*$")
+
+
+def _render_snippet(file: str, line: int, col: int) -> str | None:
+    """Render the `--> file:line:col` header plus the source line and caret."""
+    try:
+        if not os.path.isfile(file):
+            return None
+        with open(file, encoding="utf-8", errors="replace") as f:
+            lines = f.read().splitlines()
+        if not (1 <= line <= len(lines)):
+            return None
+        text = lines[line - 1]
+    except OSError:
+        return None
+    gutter = str(line)
+    # Line-level spans carry no column; point at the first non-blank
+    # character instead of the line start.
+    caret_col = max(col, 1) if col > 1 else len(text) - len(text.lstrip()) + 1
+    return f"  --> {file}:{line}:{col}\n   {' ' * len(gutter)}|\n {gutter} | {text}\n   {' ' * len(gutter)}| {' ' * (caret_col - 1)}^"
+
+
+def enrich_error(exc: BaseException) -> BaseException:
+    """Append a rendered source snippet to a compiler error, when available.
+
+    The exception object is returned unchanged (type and traceback preserved);
+    only its message args are rewritten. Rendering failures fall back to the
+    original message silently.
+    """
+    try:
+        if not exc.args or not isinstance(exc.args[0], str):
+            return exc
+        message = exc.args[0]
+        match = _MARKER_RE.search(message)
+        if match is None:
+            return exc
+        file = match.group("file")
+        line = int(match.group("line"))
+        col = int(match.group("col") or 1)
+        snippet = _render_snippet(file, line, col)
+        if snippet is None:
+            return exc
+        # Replace the bare marker line with the full snippet.
+        message = message[: match.start()] + "\n" + snippet
+        exc.args = (message, *exc.args[1:])
+    except Exception:
+        pass
+    return exc

--- a/tilelang/ir.py
+++ b/tilelang/ir.py
@@ -83,10 +83,18 @@ class ReduceType(Node, Scriptable): ...
 # ---------------------------------------------------------------------------
 
 
+_span_ffi_cache: dict = {}
+
+
 def _span_ffi(name: str):
     # `tl.ir.*` names contain a dot and are therefore skipped by
-    # `init_ffi_api`; fetch them from the global registry directly.
-    return tvm_ffi.get_global_func(f"tl.ir.{name}")
+    # `init_ffi_api`; fetch them from the global registry directly. Cache the
+    # lookup: the stamping hot path calls this per IR node.
+    f = _span_ffi_cache.get(name)
+    if f is None:
+        f = tvm_ffi.get_global_func(f"tl.ir.{name}")
+        _span_ffi_cache[name] = f
+    return f
 
 
 def make_span(file: str, line: int) -> Span:
@@ -131,26 +139,38 @@ def span_to_location(span: Span | None) -> tuple[str, int] | None:
 def span_coverage(func) -> dict:
     """Statistics on span injection coverage for a PrimFunc.
 
-    Returns {"stmts": [with_span, total], "buffers": [with_span, total]}.
+    Returns {"stmts": [with_span, total], "buffers": [with_span, total]},
+    where buffers cover both function parameters (buffer_map) and block-
+    allocated buffers (SBlock.alloc_buffers, i.e. T.alloc_* sites).
     New nodes synthesized by passes legitimately have no span; this metric
     is meant for the freshly parsed IR (span injection validation).
     """
     from tvm.tirx.stmt_functor import post_order_visit
 
     stmts = [0, 0]
+    seen_buffers = []
 
-    def _visit(node):
-        if not isinstance(node, tvm.tirx.Stmt):
+    def count_buffer(buffer):
+        if any(buffer.same_as(b) for b in seen_buffers):
             return
-        stmts[1] += 1
-        if get_stmt_span(node) is not None:
-            stmts[0] += 1
-
-    post_order_visit(func.body, _visit)
-
-    buffers = [0, 0]
-    for _, buffer in func.buffer_map.items():
+        seen_buffers.append(buffer)
         buffers[1] += 1
         if get_buffer_span(buffer) is not None:
             buffers[0] += 1
+
+    buffers = [0, 0]
+
+    def _visit(node):
+        if isinstance(node, tvm.tirx.Stmt):
+            stmts[1] += 1
+            if get_stmt_span(node) is not None:
+                stmts[0] += 1
+        if type(node).__name__ == "SBlockRealize":
+            for buf in node.block.alloc_buffers:
+                count_buffer(buf)
+
+    post_order_visit(func.body, _visit)
+
+    for _, buffer in func.buffer_map.items():
+        count_buffer(buffer)
     return {"stmts": stmts, "buffers": buffers}

--- a/tilelang/ir.py
+++ b/tilelang/ir.py
@@ -1,5 +1,5 @@
 from tilelang import tvm as tvm
-from tvm.ir.base import Node
+from tvm.ir.base import Node, SourceName, Span
 from tvm.runtime import Scriptable
 import tvm_ffi
 from tvm.target import Target
@@ -70,3 +70,87 @@ class RegionOp(Node, Scriptable): ...
 
 @tvm_ffi.register_object("tl.ReduceType")
 class ReduceType(Node, Scriptable): ...
+
+
+# ---------------------------------------------------------------------------
+# Source span helpers
+#
+# tirx Stmt/Buffer/PrimFunc nodes carry a mutable `span` field that is
+# reflected read-only to Python and never participates in structural
+# equality/hashing. The functions below write spans during script parsing
+# (see tilelang/language/eager/builder.py) and read them back from
+# diagnostics, the LSP analyzer, and visualization tools.
+# ---------------------------------------------------------------------------
+
+
+def _span_ffi(name: str):
+    # `tl.ir.*` names contain a dot and are therefore skipped by
+    # `init_ffi_api`; fetch them from the global registry directly.
+    return tvm_ffi.get_global_func(f"tl.ir.{name}")
+
+
+def make_span(file: str, line: int) -> Span:
+    """Create a span covering a whole source line."""
+    return Span(SourceName(file), line, line, 1, 1 << 20)
+
+
+def set_stmt_span(stmt, span: Span) -> None:
+    _span_ffi("SetStmtSpan")(stmt, span)
+
+
+def get_stmt_span(stmt) -> Span | None:
+    span = _span_ffi("GetStmtSpan")(stmt)
+    return span if span is not None and span.source_name is not None else None
+
+
+def set_buffer_span(buffer, span: Span) -> None:
+    _span_ffi("SetBufferSpan")(buffer, span)
+
+
+def get_buffer_span(buffer) -> Span | None:
+    span = _span_ffi("GetBufferSpan")(buffer)
+    return span if span is not None and span.source_name is not None else None
+
+
+def set_prim_func_span(func, span: Span) -> None:
+    _span_ffi("SetPrimFuncSpan")(func, span)
+
+
+def get_prim_func_span(func) -> Span | None:
+    span = _span_ffi("GetPrimFuncSpan")(func)
+    return span if span is not None and span.source_name is not None else None
+
+
+def span_to_location(span: Span | None) -> tuple[str, int] | None:
+    """Convert a span to a (file, line) tuple, or None when undefined."""
+    if span is None or span.source_name is None:
+        return None
+    return (span.source_name.name, span.line)
+
+
+def span_coverage(func) -> dict:
+    """Statistics on span injection coverage for a PrimFunc.
+
+    Returns {"stmts": [with_span, total], "buffers": [with_span, total]}.
+    New nodes synthesized by passes legitimately have no span; this metric
+    is meant for the freshly parsed IR (span injection validation).
+    """
+    from tvm.tirx.stmt_functor import post_order_visit
+
+    stmts = [0, 0]
+
+    def _visit(node):
+        if not isinstance(node, tvm.tirx.Stmt):
+            return
+        stmts[1] += 1
+        if get_stmt_span(node) is not None:
+            stmts[0] += 1
+
+    post_order_visit(func.body, _visit)
+
+    buffers = [0, 0]
+    for _, buffer in func.buffer_map.items():
+        buffers[1] += 1
+        if get_buffer_span(buffer) is not None:
+            buffers[0] += 1
+    return {"stmts": stmts, "buffers": buffers}

--- a/tilelang/language/allocate.py
+++ b/tilelang/language/allocate.py
@@ -31,6 +31,25 @@ from .eager.builder import OutTensor
 from .proxy import Tensor, ptr as _ptr_sentinel
 
 
+def _with_span(buffer: Buffer) -> Buffer:
+    """Stamp the buffer with the current user source location.
+
+    The span lets compiler diagnostics (e.g. layout inference failures) and
+    tools (LSP, visualizers) point back to the `T.alloc_*` line. It is a no-op
+    outside eager parsing or when TILELANG_ENABLE_IR_SPAN is disabled.
+    """
+    from .eager.builder import Builder
+
+    builder = Builder.current()
+    if builder is not None and getattr(builder, "_spans_enabled", False):
+        file, line = builder.current_file, builder.current_line
+        if line > 0:
+            from tilelang.ir import make_span, set_buffer_span
+
+            set_buffer_span(buffer, make_span(file, line))
+    return buffer
+
+
 def alloc_shared(shape: ShapeType, dtype: DType, scope="shared.dyn") -> Buffer:
     """Allocate a shared memory buffer for inter-thread communication.
 
@@ -46,7 +65,7 @@ def alloc_shared(shape: ShapeType, dtype: DType, scope="shared.dyn") -> Buffer:
         # lei: This is a hack to handle bool type.
         # Because tilelang's merge smem pass cannot merge bool type currently.
         scope = "shared"
-    return T.sblock_alloc_buffer(shape, dtype, scope=scope)
+    return _with_span(T.sblock_alloc_buffer(shape, dtype, scope=scope))
 
 
 def alloc_local(shape: ShapeType, dtype: DType, scope="local") -> Buffer:
@@ -60,7 +79,7 @@ def alloc_local(shape: ShapeType, dtype: DType, scope="local") -> Buffer:
     Returns:
         T.Buffer: A TVM buffer object allocated in local memory
     """
-    return T.sblock_alloc_buffer(shape, dtype, scope=scope)
+    return _with_span(T.sblock_alloc_buffer(shape, dtype, scope=scope))
 
 
 def alloc_fragment(shape: ShapeType, dtype: DType, scope="local.fragment") -> Buffer:
@@ -74,7 +93,7 @@ def alloc_fragment(shape: ShapeType, dtype: DType, scope="local.fragment") -> Bu
     Returns:
         T.Buffer: A TVM buffer object allocated in fragment memory
     """
-    return T.sblock_alloc_buffer(shape, dtype, scope=scope)
+    return _with_span(T.sblock_alloc_buffer(shape, dtype, scope=scope))
 
 
 @overload
@@ -136,7 +155,7 @@ def alloc_var(dtype: DType, *args, scope: str = "local.var", init: PrimExpr | in
     if dtype is _ptr_sentinel:
         dtype = _dtypes.int64
 
-    buffer = T.sblock_alloc_buffer([1], dtype, scope=parsed_scope)
+    buffer = _with_span(T.sblock_alloc_buffer([1], dtype, scope=parsed_scope))
     if parsed_init is not None:
         # Always use T.buffer_store for reliable initialisation across all
         # backends.  The sblock_attr("tl.local_var_init") path feeds into the
@@ -171,7 +190,7 @@ def alloc_global(shape: ShapeType, dtype: DType, scope="global") -> Buffer:
         T.Buffer: A TVM buffer object allocated in global memory
     """
 
-    return T.sblock_alloc_buffer(shape, dtype, scope=scope)
+    return _with_span(T.sblock_alloc_buffer(shape, dtype, scope=scope))
 
 
 def alloc_barrier(arrive_count: int | list[int]) -> Buffer:
@@ -193,7 +212,7 @@ def alloc_barrier(arrive_count: int | list[int]) -> Buffer:
         arrive_count = [arrive_count]
     else:
         arrive_count = list(arrive_count)
-    buffer = T.sblock_alloc_buffer((len(arrive_count),), _dtypes.uint64, scope="shared.barrier")
+    buffer = _with_span(T.sblock_alloc_buffer((len(arrive_count),), _dtypes.uint64, scope="shared.barrier"))
     # Convert to TIR IntImm expressions for C++ pass to consume as Map<Var, Array<PrimExpr>>
     # Use buffer.data as key to support multiple barrier buffer allocations
     arrive_count_exprs = [IntImm("int32", c) for c in arrive_count]
@@ -216,7 +235,7 @@ def alloc_cluster_barrier(arrive_count: int | list[int]) -> Buffer:
         arrive_count = [arrive_count]
     else:
         arrive_count = list(arrive_count)
-    buffer = T.sblock_alloc_buffer((len(arrive_count),), _dtypes.uint64, scope="shared.cluster_barrier")
+    buffer = _with_span(T.sblock_alloc_buffer((len(arrive_count),), _dtypes.uint64, scope="shared.cluster_barrier"))
     # Convert to TIR IntImm expressions for C++ pass to consume as Map<Var, Array<PrimExpr>>
     # Use buffer.data as key to support multiple barrier buffer allocations
     arrive_count_exprs = [IntImm("int32", c) for c in arrive_count]
@@ -254,7 +273,7 @@ def alloc_tmem(shape: ShapeType, dtype: DType) -> Buffer:
     """
 
     assert len(shape) == 2, "shape must be a 2D tensor for TMEM allocation"
-    return T.sblock_alloc_buffer(shape, dtype, scope="shared.tmem")
+    return _with_span(T.sblock_alloc_buffer(shape, dtype, scope="shared.tmem"))
 
 
 ReducerOp = Literal["sum", "max", "min"]
@@ -290,7 +309,7 @@ def alloc_reducer(shape: ShapeType, dtype: DType, op: ReducerOp = "sum", replica
         replication = "none"
     assert replication in ["all", "none"]
 
-    reducer = T.sblock_alloc_buffer(shape, dtype, scope="local.fragment")
+    reducer = _with_span(T.sblock_alloc_buffer(shape, dtype, scope="local.fragment"))
     sblock_attr({"reducer_info": {reducer.data: {"rep": replication, "op": op}}})
 
     return reducer
@@ -315,7 +334,7 @@ def alloc_descriptor(
     scope = "local.descriptor." + kind
     # Buffer naming via `name` is not supported by this TVM builder signature;
     # keep parameter for forward-compat, but do not pass it.
-    return T.sblock_alloc_buffer([1], dtype, scope=scope)
+    return _with_span(T.sblock_alloc_buffer([1], dtype, scope=scope))
 
 
 def alloc_wgmma_desc(dtype: DType = _dtypes.uint64) -> Buffer:

--- a/tilelang/language/allocate.py
+++ b/tilelang/language/allocate.py
@@ -41,12 +41,8 @@ def _with_span(buffer: Buffer) -> Buffer:
     from .eager.builder import Builder
 
     builder = Builder.current()
-    if builder is not None and getattr(builder, "_spans_enabled", False):
-        file, line = builder.current_file, builder.current_line
-        if line > 0:
-            from tilelang.ir import make_span, set_buffer_span
-
-            set_buffer_span(buffer, make_span(file, line))
+    if builder is not None:
+        builder.with_buffer_span(buffer)
     return buffer
 
 

--- a/tilelang/language/eager/ast.py
+++ b/tilelang/language/eager/ast.py
@@ -503,8 +503,8 @@ class DSLMutator(ast.NodeTransformer):
         return quote1(
             f"def make_closure({', '.join(self.nonlocals.keys())}):\n"
             f"  def {name}(__tb):\n"
-            f"    __tb_fl = '{self.filename}'\n"
-            f"    __tb_fn = '{name}'\n"
+            f"    __tb_fl = {self.filename!r}\n"
+            f"    __tb_fn = {name!r}\n"
             "    range = __tb.override('range')\n"
             "    pass\n"
             f"    return {name}\n"

--- a/tilelang/language/eager/ast.py
+++ b/tilelang/language/eager/ast.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import ast
-import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Generic, Any, Literal, ParamSpec, TypeVar, TypeAlias, cast
@@ -684,9 +683,6 @@ def mutate(func: Callable[_P, _T]) -> IRGenerator[_P, _T]:
 
     tree = utils.get_ast(func)
     filename = inspect.getsourcefile(func) or inspect.getfile(func)
-    # Absolute path so that injected source spans (and remapped tracebacks)
-    # point at clickable file locations regardless of the invocation cwd.
-    filename = os.path.abspath(filename)
     nonlocals = utils.get_func_nonlocals(func)
 
     # DSLMutator generates a function named `make_closure`
@@ -703,7 +699,7 @@ def mutate(func: Callable[_P, _T]) -> IRGenerator[_P, _T]:
     #       def bar(): x
     #       return bar
     #     ```
-    mut = DSLMutator(nonlocals, func.__globals__, filename)
+    mut = DSLMutator(nonlocals, func.__globals__, str(Path(filename).absolute()))
     tree = mut.visit(tree)
     make_closure = utils.get_compiled_object(
         tree,

--- a/tilelang/language/eager/ast.py
+++ b/tilelang/language/eager/ast.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import ast
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Generic, Any, Literal, ParamSpec, TypeVar, TypeAlias, cast
@@ -683,6 +684,9 @@ def mutate(func: Callable[_P, _T]) -> IRGenerator[_P, _T]:
 
     tree = utils.get_ast(func)
     filename = inspect.getsourcefile(func) or inspect.getfile(func)
+    # Absolute path so that injected source spans (and remapped tracebacks)
+    # point at clickable file locations regardless of the invocation cwd.
+    filename = os.path.abspath(filename)
     nonlocals = utils.get_func_nonlocals(func)
 
     # DSLMutator generates a function named `make_closure`
@@ -699,7 +703,7 @@ def mutate(func: Callable[_P, _T]) -> IRGenerator[_P, _T]:
     #       def bar(): x
     #       return bar
     #     ```
-    mut = DSLMutator(nonlocals, func.__globals__, Path(filename).name)
+    mut = DSLMutator(nonlocals, func.__globals__, filename)
     tree = mut.visit(tree)
     make_closure = utils.get_compiled_object(
         tree,

--- a/tilelang/language/eager/builder.py
+++ b/tilelang/language/eager/builder.py
@@ -832,7 +832,16 @@ class Builder(BaseBuilder):
 
     def prim_func_arg(self, name, value):
         if isinstance(value, (Buffer, Var)):
-            return tirx.arg(name, value)
+            arg = tirx.arg(name, value)
+            # Stamp parameter buffers with the signature line (SpanAttacher
+            # emits set_fileline with the parameter's own line before each
+            # `__tb.arg(...)` call), so diagnostics involving only argument
+            # buffers (e.g. T.copy(A, B)) also carry a source location.
+            if self._spans_enabled and isinstance(arg, Buffer) and self.current_line > 0:
+                from tilelang.ir import make_span, set_buffer_span
+
+                set_buffer_span(arg, make_span(self.current_file, self.current_line))
+            return arg
         elif value is self.empty:
             raise ValueError(f"Argument `{name}` is not annotated")
         elif isinstance(value, Hashable):

--- a/tilelang/language/eager/builder.py
+++ b/tilelang/language/eager/builder.py
@@ -216,6 +216,19 @@ class Builder(BaseBuilder):
         self.current_macro_name = "<unknown-macro>"
         # stack to record caller fileline, not callee fileline
         self.macro_fileline_stack: list[tuple[str, int, str]] = []
+        # Source span injection state. When enabled, emitted IR nodes (Stmt,
+        # Buffer, PrimFunc) are stamped with the user source location so that
+        # compiler errors and tools (LSP, visualizers) can point back to the
+        # originating line. See tilelang/ir.py span helpers and
+        # docs/developer_guide/ir_span.md.
+        from tilelang.env import env
+
+        self._spans_enabled = str(env.TILELANG_ENABLE_IR_SPAN).lower() not in ("0", "false", "off")
+        # Pending leaf segment: (stmt_frame, stmt_count, file, line) recorded
+        # by set_fileline; stmts appended to the frame afterwards belong to
+        # that source statement until the next set_fileline / frame exit.
+        self._span_pending: tuple[Any, int, str, int] | None = None
+        self._span_first_fileline: tuple[str, int] | None = None
 
     @classmethod
     def current(cls) -> Self:
@@ -267,7 +280,78 @@ class Builder(BaseBuilder):
         self.name_inside_frame, self.macro_arg_annot = save
 
     def get(self) -> PrimFunc:
-        return self.ir_builder.get()
+        if self._spans_enabled:
+            self._flush_span_pending()
+        func = self.ir_builder.get()
+        if self._spans_enabled and self._span_first_fileline is not None:
+            from tilelang.ir import make_span, set_prim_func_span
+
+            set_prim_func_span(func, make_span(*self._span_first_fileline))
+        return func
+
+    # ------------------------------------------------------------------
+    # Source span injection (TILELANG_ENABLE_IR_SPAN)
+    # ------------------------------------------------------------------
+
+    def _current_stmt_frame(self):
+        """The innermost open frame whose `stmts` accumulates emitted stmts."""
+        for frame in reversed(self.frames):
+            if isinstance(frame, tirx.frame.TIRFrame):
+                f = frame
+                # KernelLaunchFrame nests launch/block frames entered C++-side;
+                # leaf statements accumulate in its innermost sub-frame.
+                while isinstance(f, KernelLaunchFrame) and len(f.frames) > 0 and isinstance(f.frames[-1], tirx.frame.TIRFrame):
+                    f = f.frames[-1]
+                return f
+        return None
+
+    def _flush_span_pending(self):
+        """Stamp stmts appended since the last recorded source statement."""
+        if self._span_pending is None:
+            return
+        from tilelang.ir import get_stmt_span, make_span, set_stmt_span
+
+        frame, start, file, line = self._span_pending
+        self._span_pending = None
+        if line <= 0:
+            return
+        try:
+            stmts = frame.stmts
+        except Exception:
+            return
+        span = make_span(file, line)
+        for i in range(start, len(stmts)):
+            if get_stmt_span(stmts[i]) is None:
+                set_stmt_span(stmts[i], span)
+
+    def _stamp_new_parent_stmts(self, parent, start: int, file: str, line: int):
+        """Stamp stmts produced by an exited frame into its parent frame.
+
+        Frames like KernelLaunchFrame assemble a whole subtree (launch grid
+        loops, block realize) whose intermediate nodes never pass through
+        `with_frame`; stamp every still-unspanned stmt in the produced
+        subtree with the frame's entry line. Nodes already stamped with their
+        own statement line keep their span.
+        """
+        if parent is None or line <= 0:
+            return
+        from tilelang.ir import get_stmt_span, make_span, set_stmt_span
+        from tvm.tirx.stmt_functor import post_order_visit
+
+        try:
+            stmts = parent.stmts
+        except Exception:
+            return
+        if len(stmts) <= start:
+            return
+        span = make_span(file, line)
+
+        def stamp(node):
+            if isinstance(node, tvm.tirx.Stmt) and get_stmt_span(node) is None:
+                set_stmt_span(node, span)
+
+        for i in range(start, len(stmts)):
+            post_order_visit(stmts[i], stamp)
 
     def find_frame_idx(self, frame: type | tuple[type, ...], start=0) -> int | None:
         for idx in reversed(range(start, len(self.frames))):
@@ -287,9 +371,27 @@ class Builder(BaseBuilder):
     @contextmanager
     def with_frame(self, frame: AbstractContextManager[Any] | None):
         pop_idx = len(self.frames)
+        span_entry = None
+        if self._spans_enabled and frame is not None:
+            # Record the enclosing stmt container and the entry position (the
+            # `with`/`for` line), so stmts this frame produces into its parent
+            # can be stamped after it exits.
+            parent = self._current_stmt_frame()
+            span_entry = (
+                parent,
+                len(parent.stmts) if parent is not None else 0,
+                self.current_file,
+                self.current_line,
+            )
         yield self.enter_frame(frame)
+        if self._spans_enabled:
+            # Flush leaf stmts of the frame being exited before its __exit__
+            # moves them into the produced node.
+            self._flush_span_pending()
         while len(self.frames) > pop_idx:
             self.frames.pop().__exit__(None, None, None)
+        if self._spans_enabled and span_entry is not None:
+            self._stamp_new_parent_stmts(*span_entry)
 
     class _has_if_frame: ...
 
@@ -761,6 +863,13 @@ class Builder(BaseBuilder):
         self.current_file = filename
         self.current_line = lineno
         self.current_macro_name = name
+        if self._spans_enabled:
+            self._flush_span_pending()
+            frame = self._current_stmt_frame()
+            if frame is not None:
+                self._span_pending = (frame, len(frame.stmts), filename, lineno)
+                if self._span_first_fileline is None and lineno > 0:
+                    self._span_first_fileline = (filename, lineno)
 
     def get_fileline_stack(self, stacklevel=1):
         stack = self.macro_fileline_stack + [(self.current_file, self.current_line, self.current_macro_name)]

--- a/tilelang/language/eager/builder.py
+++ b/tilelang/language/eager/builder.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager, AbstractContextManager
 from dataclasses import dataclass
 import inspect
 
+from tilelang import env
 from tilelang.language.kernel import KernelLaunchFrame
 from tvm_ffi.container import Map
 from tvm.ir.base import Span
@@ -216,14 +217,7 @@ class Builder(BaseBuilder):
         self.current_macro_name = "<unknown-macro>"
         # stack to record caller fileline, not callee fileline
         self.macro_fileline_stack: list[tuple[str, int, str]] = []
-        # Source span injection state. When enabled, emitted IR nodes (Stmt,
-        # Buffer, PrimFunc) are stamped with the user source location so that
-        # compiler errors and tools (LSP, visualizers) can point back to the
-        # originating line. See tilelang/ir.py span helpers and
-        # docs/developer_guide/ir_span.md.
-        from tilelang.env import env
-
-        self._spans_enabled = str(env.TILELANG_ENABLE_IR_SPAN).lower() not in ("0", "false", "off")
+        self._spans_enabled = env.is_span_enable()
         # Pending leaf segment: (stmt_frame, stmt_count, file, line) recorded
         # by set_fileline; stmts appended to the frame afterwards belong to
         # that source statement until the next set_fileline / frame exit.

--- a/tilelang/language/eager/builder.py
+++ b/tilelang/language/eager/builder.py
@@ -287,6 +287,17 @@ class Builder(BaseBuilder):
     # Source span injection (TILELANG_ENABLE_IR_SPAN)
     # ------------------------------------------------------------------
 
+    def with_buffer_span(self, buffer: Buffer) -> Buffer:
+        """Stamp an unspanned buffer with the current user source location."""
+        if not self._spans_enabled or self.current_line <= 0:
+            return buffer
+
+        from tilelang.ir import get_buffer_span, make_span, set_buffer_span
+
+        if get_buffer_span(buffer) is None:
+            set_buffer_span(buffer, make_span(self.current_file, self.current_line))
+        return buffer
+
     def _current_stmt_frame(self):
         """The innermost open frame whose `stmts` accumulates emitted stmts."""
         for frame in reversed(self.frames):
@@ -536,14 +547,16 @@ class Builder(BaseBuilder):
             if isinstance(annot, Buffer) and annot.scope() == "global":
                 from tilelang.language import match_buffer
 
-                return IRBuilder.name(
-                    name,
-                    match_buffer(
-                        orig_value,
-                        annot.shape,
-                        annot.dtype,
-                        strides=annot.strides,
-                    ),
+                return self.with_buffer_span(
+                    IRBuilder.name(
+                        name,
+                        match_buffer(
+                            orig_value,
+                            annot.shape,
+                            annot.dtype,
+                            strides=annot.strides,
+                        ),
+                    )
                 )
             else:
                 return orig_value
@@ -582,6 +595,8 @@ class Builder(BaseBuilder):
             # Bind TVM Var/Buffer names and also record scope so reusing the same
             # Python name (e.g., loop vars like `i`) across different for-frames
             # works without triggering out-of-scope errors.
+            if isinstance(value, Buffer):
+                self.with_buffer_span(value)
             IRBuilder.name(name, value)
             if name != "_":
                 frame = self.find_frame_idx(TIR_VAR_SCOPE_FRAME)
@@ -591,6 +606,8 @@ class Builder(BaseBuilder):
 
         # 3. Bind immutable tilelang objects
         res = self.bind_immutable(name, value)
+        if isinstance(res, Buffer):
+            self.with_buffer_span(res)
 
         # 4. Check variable scope and shadowing
         if name != "_":
@@ -831,10 +848,8 @@ class Builder(BaseBuilder):
             # emits set_fileline with the parameter's own line before each
             # `__tb.arg(...)` call), so diagnostics involving only argument
             # buffers (e.g. T.copy(A, B)) also carry a source location.
-            if self._spans_enabled and isinstance(arg, Buffer) and self.current_line > 0:
-                from tilelang.ir import make_span, set_buffer_span
-
-                set_buffer_span(arg, make_span(self.current_file, self.current_line))
+            if isinstance(arg, Buffer):
+                self.with_buffer_span(arg)
             return arg
         elif value is self.empty:
             raise ValueError(f"Argument `{name}` is not annotated")

--- a/tilelang/language/eager/utils.py
+++ b/tilelang/language/eager/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 import ast
 import inspect
+import os
 from typing import Any, Literal
 from collections.abc import Callable
 from tilelang import env
@@ -59,6 +60,9 @@ def get_func_nonlocals(func):
 def get_ast(func: Callable):
     _, start = inspect.getsourcelines(func)
     filename = inspect.getsourcefile(func) or inspect.getfile(func)
+    # Normalize to an absolute path so that source spans and remapped
+    # tracebacks are clickable links regardless of the invocation cwd.
+    filename = os.path.abspath(filename)
     source = inspect.getsource(func)
     source = _remove_leading_ident(source)
     source = "\n" * (start - 1) + source


### PR DESCRIPTION
This PR injects user source locations (file + line) into tirx IR nodes (`Stmt` / `Buffer` / `PrimFunc`) during eager parsing, and makes compiler diagnostics report them as clickable `--> file:line:col` hints with a rendered source snippet.

Example:
```
Loading tilelang libs from dev root: /Users/xxx/code/tilelang/build
2026-07-23 22:27:58  [TileLang:tilelang.jit.kernel:INFO] (kernel.py:131): TileLang begins to compile kernel `matmul` with `out_idx=[-1]`
Traceback (most recent call last):
  File "/Users/xxx/code/tilelang/examples/gemm/example_gemm.py", line 67, in <module>
    main()
    ~~~~^^
  File "/Users/xxx/code/tilelang/examples/gemm/example_gemm.py", line 30, in main
    kernel = matmul.compile(M=1024, N=1024, K=1024, block_M=128, block_N=128, block_K=32)
  File "/Users/xxx/code/tilelang/tilelang/jit/__init__.py", line 444, in compile
    kernel_result = compile(
        prim_func,
    ...<6 lines>...
        compile_flags=self.compile_flags,
    )
  ...
  File "<unknown>", line 0, in tvm::tl::LayoutInferencer::Substitute(tvm::tirx::PrimFunc)
  File "/Users/xxx/code/tilelang/src/transform/layout_inference.cc", line 414, in LayoutInferenceResult tvm::tl::BufferUseDefCollector::Run()
    ICHECK_NE(layout_map.count(buffer), 0)
    
tvm.error.InternalError: Check failed: layout_map.count(buffer) != 0 (0 vs. 0) : The layout for fragment C_local can not be inferred correctly.
  --> /Users/xxx/code/tilelang/examples/gemm/example_gemm.py:16:1
     |
 16 |         C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
     |
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Injects source file/line spans into eager TIRX `Stmt`, `Buffer`, and `PrimFunc` nodes, controlled by `TILELANG_ENABLE_IR_SPAN`.
- Adds span FFI/Python helpers, coverage utilities, and absolute-path handling.
- Enhances compiler diagnostics with clickable `--> file:line:col` hints and rendered source snippets.
- Adds span context to CUDA, copy, parallel, pipeline, and layout-inference diagnostics.
- Adds comprehensive tests for span injection, macros, disabled mode, coverage, path handling, and enriched errors.

## C++ style / lint notes

- Touches C++ diagnostic and FFI code; no changes to rules documented in `docs/developer_guide/cpp_style.md` are indicated.
- The “C++ API Style Audit (warning only)” CI step may report advisory findings for the new FFI helpers; these are warning-only and should be evaluated separately from correctness, build, and test failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->