### PR TITLE
[BugFix] Preserve explicit loop steps when transforms rebuild For nodes

### DIFF
--- a/src/cuda/transform/inject_fence_proxy.cc
+++ b/src/cuda/transform/inject_fence_proxy.cc
@@ -490,7 +490,7 @@ private:
                                    : body_res.out_state;
 
       Stmt loop = For(op->loop_var, min, extent, op->kind, body_res.stmt,
-                      op->thread_binding, op->annotations);
+                      op->thread_binding, op->annotations, op->step, op->span);
       return SeqStmt(Array<Stmt>{pre_fence, loop});
     }
 
@@ -499,7 +499,7 @@ private:
         may_be_zero ? entry.Union(body_res.out_state) : body_res.out_state;
 
     return For(op->loop_var, min, extent, op->kind, body_res.stmt,
-               op->thread_binding, op->annotations);
+               op->thread_binding, op->annotations, op->step, op->span);
   }
 
   Stmt VisitStmt_(const WhileNode *op) final {

--- a/src/transform/common/loop_vectorization_utils.h
+++ b/src/transform/common/loop_vectorization_utils.h
@@ -614,7 +614,7 @@ public:
       return GetRef<Stmt>(op);
     } else {
       return For(op->loop_var, op->min, extent, op->kind, body,
-                 op->thread_binding, op->annotations);
+                 op->thread_binding, op->annotations, op->step, op->span);
     }
   }
   // IfThenElse

--- a/src/transform/lower_opaque_block.cc
+++ b/src/transform/lower_opaque_block.cc
@@ -166,7 +166,8 @@ private:
     } else {
       // Case 3. An ordinary loop
       body = For(op->loop_var, std::move(min), std::move(extent), op->kind,
-                 std::move(body), std::nullopt, new_annotations);
+                 std::move(body), std::nullopt, new_annotations, op->step,
+                 op->span);
     }
     // Step 5. Insert nested attrs
     for (auto it = pragma_attrs.rbegin(); it != pragma_attrs.rend(); ++it) {

--- a/src/transform/pipeline_planning.cc
+++ b/src/transform/pipeline_planning.cc
@@ -1344,7 +1344,7 @@ private:
     Stmt new_body = MakePipelineBody(flat_stmts);
 
     return For(loop->loop_var, loop->min, loop->extent, loop->kind, new_body,
-               loop->thread_binding, annotations);
+               loop->thread_binding, annotations, loop->step, loop->span);
   }
 
   Stmt VisitStmt_(const SBlockNode *op) final {

--- a/src/transform/storage_rewrite.cc
+++ b/src/transform/storage_rewrite.cc
@@ -576,7 +576,7 @@ public:
       op = stmt.as<ForNode>();
       return For(op->loop_var, op->min, op->extent, op->kind,
                  MakeAttach(svec, op->body), op->thread_binding,
-                 op->annotations);
+                 op->annotations, op->step, op->span);
     } else {
       return StmtExprMutator::VisitStmt_(op);
     }

--- a/src/transform/vectorize_loop.cc
+++ b/src/transform/vectorize_loop.cc
@@ -967,7 +967,7 @@ public:
       return GetRef<Stmt>(op);
     } else {
       return For(op->loop_var, op->min, extent, op->kind, body,
-                 op->thread_binding, op->annotations);
+                 op->thread_binding, op->annotations, op->step, op->span);
     }
   }
 
@@ -1203,7 +1203,8 @@ public:
     Stmt stmt = StmtMutator::VisitStmt_(op);
     op = stmt.as<ForNode>();
     if (op->kind == ForKind::kVectorized) {
-      return For(op->loop_var, op->min, op->extent, ForKind::kSerial, op->body);
+      return For(op->loop_var, op->min, op->extent, ForKind::kSerial, op->body,
+                 op->thread_binding, op->annotations, op->step, op->span);
     } else {
       return stmt;
     }

--- a/testing/python/transform/test_tilelang_transform_preserve_loop_step.py
+++ b/testing/python/transform/test_tilelang_transform_preserve_loop_step.py
@@ -1,0 +1,33 @@
+import numpy as np
+
+import tilelang as tl
+from tilelang import tvm
+
+
+def test_lower_opaque_block_preserves_non_unit_loop_step():
+    output_buffer = tvm.tirx.decl_buffer((6,), "int32", name="output")
+    i = tvm.tirx.Var("i", "int32")
+    loop = tvm.tirx.For(
+        i,
+        1,
+        5,
+        tvm.tirx.ForKind.SERIAL,
+        tvm.tirx.BufferStore(output_buffer, 1, [i]),
+        step=tvm.tirx.IntImm("int32", 2),
+    )
+    before = tvm.tirx.PrimFunc(
+        [output_buffer.data],
+        loop,
+        buffer_map={output_buffer.data: output_buffer},
+    ).with_attr("global_symbol", "main")
+
+    mod = tl.transform.LowerOpaqueBlock()(tvm.IRModule.from_expr(before))
+    executable = tvm.compile(mod["main"], target="c").jit(options=["-std=c++17"])
+
+    output = tvm.runtime.tensor(np.zeros(6, dtype="int32"))
+    executable["main"](output)
+
+    np.testing.assert_array_equal(
+        output.numpy(),
+        np.array([0, 1, 0, 1, 0, 1], dtype="int32"),
+    )


### PR DESCRIPTION
## Problem

Several transform passes reconstruct TIRX `For` nodes while copying the loop bounds, kind, body, thread binding, and annotations, but omit the explicit `step`. An omitted step defaults to `1`, so these passes silently change the iteration domain of non-unit-step loops.

```text
Original TIRX For
min=1, extent=5, step=2, body=...
                 |
                 v
        pass reconstructs For
          /                 \
         v                   v
Before fix                 After fix
step omitted               step copied
default step=1             original step=2
i = 1,2,3,4,5              i = 1,3,5
[0,1,1,1,1,1]              [0,1,0,1,0,1]
```

For `min=1`, `extent=5`, and `step=2`, the valid indices are

`{1 + 2k | k >= 0 and 1 + 2k < 6} = {1, 3, 5}`.

On current `main`, the executable regression instead produces `[0, 1, 1, 1, 1, 1]`, proving that indices `2` and `4` execute even though they are outside that progression.

## Change

Forward the original `step` and source `span` when rebuilding loops in LowerOpaqueBlock, pipeline planning, vectorization, storage rewrite, and fence-proxy injection paths. The included regression executes the transformed loop and compares its output bitmap with the expected iteration set.

This keeps the fix mechanical and scoped: it does not introduce a reconstruction abstraction or unrelated transform cleanup.

## Validation

- `cmake --build build-audit -j8`
- `python -m pytest -q testing/python/transform/test_tilelang_transform_preserve_loop_step.py` (`1 passed`)
- Repeated the incremental build and exact regression on an independent Ubuntu 24.04 CPU environment (`1 passed`)

Fixes #2749

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Preserve explicit non-unit loop steps and source spans when transform passes reconstruct TIRX `For` nodes.

Updated LowerOpaqueBlock, pipeline planning, loop vectorization, storage rewriting, and fence-proxy injection paths. Added an executable regression covering `min=1`, `extent=5`, `step=2`, verifying writes to indices 1, 3, and 5.

## Validation

- Build succeeds.
- Regression test passes.
- Independently verified on Ubuntu 24.04.
- Fixes `#2749`.

## C++ style / lint notes

- C++ transform and test-related files were updated.
- No public or exported API declarations changed.
- The documented C++ style guidance is not modified.
- The C++ API Style Audit is warning-only; no correctness or build issues are indicated by these changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->