### PR TITLE
[BugFix] Marshal NVRTC scalar parameters and dynamic strides

### DIFF
--- a/testing/python/jit/test_tilelang_jit_nvrtc_host.py
+++ b/testing/python/jit/test_tilelang_jit_nvrtc_host.py
@@ -1,0 +1,59 @@
+import torch
+
+import tilelang
+import tilelang.language as T
+from tilelang.engine.lower import extrac_params
+from tilelang.jit.adapter.nvrtc.adapter import NVRTCKernelAdapter
+
+
+def _make_host_only_adapter(program):
+    adapter = NVRTCKernelAdapter.__new__(NVRTCKernelAdapter)
+    adapter.ir_module = tilelang.tvm.IRModule({program.attrs["global_symbol"]: program})
+    adapter.params = extrac_params(program)
+    adapter.result_idx = []
+    adapter.param_dtypes = [param.torch_dtype() for param in adapter.params]
+    adapter.param_shapes = [list(param.shape) for param in adapter.params]
+    adapter.dynamic_symbolic_map = adapter._process_dynamic_symbolic()
+    adapter.target = "cuda"
+    return adapter
+
+
+def test_nvrtc_adapter_forwards_scalar_primfunc_parameters():
+    @T.prim_func
+    def main(A: T.Tensor((8,), T.float32), offset: T.int32):
+        T.evaluate(0)
+
+    adapter = _make_host_only_adapter(main)
+    forwarded = []
+    adapter._forward_from_prebuild_lib = lambda *args, stream: forwarded.append((args, stream))
+
+    tensor = torch.empty(8)
+    adapter._wrap_forward_from_prebuild_lib(tensor, 3)
+
+    assert len(forwarded) == 1
+    args, stream = forwarded[0]
+    assert args[0] is tensor
+    assert args[1:] == (3,)
+    assert stream == 0
+
+
+def test_nvrtc_adapter_forwards_dynamic_strides_after_dynamic_shapes():
+    length = T.dynamic("length")
+    stride = T.dynamic("stride")
+
+    @T.prim_func
+    def main(A: T.StridedTensor[(length,), (stride,), T.float32]):
+        T.evaluate(0)
+
+    adapter = _make_host_only_adapter(main)
+    forwarded = []
+    adapter._forward_from_prebuild_lib = lambda *args, stream: forwarded.append((args, stream))
+
+    tensor = torch.empty_strided((7,), (3,))
+    adapter._wrap_forward_from_prebuild_lib(tensor)
+
+    assert len(forwarded) == 1
+    args, stream = forwarded[0]
+    assert args[0] is tensor
+    assert args[1:] == (7, 3)
+    assert stream == 0

--- a/testing/python/jit/test_tilelang_jit_nvrtc_host.py
+++ b/testing/python/jit/test_tilelang_jit_nvrtc_host.py
@@ -12,11 +12,11 @@ if not is_nvrtc_available:
 from tilelang.jit.adapter.nvrtc.adapter import NVRTCKernelAdapter
 
 
-def _make_host_only_adapter(program):
+def _make_host_only_adapter(program, result_idx=None):
     adapter = NVRTCKernelAdapter.__new__(NVRTCKernelAdapter)
     adapter.ir_module = tilelang.tvm.IRModule({program.attrs["global_symbol"]: program})
     adapter.params = extrac_params(program)
-    adapter.result_idx = []
+    adapter.result_idx = [] if result_idx is None else result_idx
     adapter.param_dtypes = [param.torch_dtype() for param in adapter.params]
     adapter.param_shapes = [list(param.shape) for param in adapter.params]
     adapter.dynamic_symbolic_map = adapter._process_dynamic_symbolic()
@@ -62,4 +62,49 @@ def test_nvrtc_adapter_forwards_dynamic_strides_after_dynamic_shapes():
     args, stream = forwarded[0]
     assert args[0] is tensor
     assert args[1:] == (7, 3)
+    assert stream == 0
+
+
+def test_nvrtc_adapter_scales_sub_byte_dynamic_strides():
+    length = T.dynamic("length")
+    stride = T.dynamic("stride")
+
+    @T.prim_func
+    def main(A: T.StridedTensor[(length,), (stride,), T.int4]):
+        T.evaluate(0)
+
+    adapter = _make_host_only_adapter(main)
+    forwarded = []
+    adapter._forward_from_prebuild_lib = lambda *args, stream: forwarded.append((args, stream))
+
+    tensor = torch.empty_strided((7,), (3,), dtype=torch.int8)
+    adapter._wrap_forward_from_prebuild_lib(tensor)
+
+    assert len(forwarded) == 1
+    args, stream = forwarded[0]
+    assert args[0] is tensor
+    assert args[1:] == (7, 6)
+    assert stream == 0
+
+
+def test_nvrtc_adapter_resolves_output_shape_from_later_input():
+    length = T.dynamic("length")
+
+    @T.prim_func
+    def main(B: T.Tensor((length,), T.float32), A: T.Tensor((length,), T.float32)):
+        T.evaluate(0)
+
+    adapter = _make_host_only_adapter(main, result_idx=[0])
+    forwarded = []
+    adapter._forward_from_prebuild_lib = lambda *args, stream: forwarded.append((args, stream))
+
+    tensor = torch.empty(7)
+    output = adapter._wrap_forward_from_prebuild_lib(tensor)
+
+    assert output.shape == (7,)
+    assert len(forwarded) == 1
+    args, stream = forwarded[0]
+    assert args[0] is output
+    assert args[1] is tensor
+    assert args[2:] == (7,)
     assert stream == 0

--- a/testing/python/jit/test_tilelang_jit_nvrtc_host.py
+++ b/testing/python/jit/test_tilelang_jit_nvrtc_host.py
@@ -1,8 +1,14 @@
 import torch
+import pytest
 
 import tilelang
 import tilelang.language as T
 from tilelang.engine.lower import extrac_params
+from tilelang.jit.adapter.nvrtc import is_nvrtc_available
+
+if not is_nvrtc_available:
+    pytest.skip("cuda-python is required to import the NVRTC adapter", allow_module_level=True)
+
 from tilelang.jit.adapter.nvrtc.adapter import NVRTCKernelAdapter
 
 

--- a/testing/python/jit/test_tilelang_jit_nvrtc_host.py
+++ b/testing/python/jit/test_tilelang_jit_nvrtc_host.py
@@ -34,7 +34,7 @@ def test_nvrtc_adapter_forwards_scalar_primfunc_parameters():
     adapter._forward_from_prebuild_lib = lambda *args, stream: forwarded.append((args, stream))
 
     tensor = torch.empty(8)
-    adapter._wrap_forward_from_prebuild_lib(tensor, 3)
+    adapter._wrap_forward_from_prebuild_lib(tensor, 3, stream=0)
 
     assert len(forwarded) == 1
     args, stream = forwarded[0]
@@ -56,7 +56,7 @@ def test_nvrtc_adapter_forwards_dynamic_strides_after_dynamic_shapes():
     adapter._forward_from_prebuild_lib = lambda *args, stream: forwarded.append((args, stream))
 
     tensor = torch.empty_strided((7,), (3,))
-    adapter._wrap_forward_from_prebuild_lib(tensor)
+    adapter._wrap_forward_from_prebuild_lib(tensor, stream=0)
 
     assert len(forwarded) == 1
     args, stream = forwarded[0]
@@ -78,7 +78,7 @@ def test_nvrtc_adapter_scales_sub_byte_dynamic_strides():
     adapter._forward_from_prebuild_lib = lambda *args, stream: forwarded.append((args, stream))
 
     tensor = torch.empty_strided((7,), (3,), dtype=torch.int8)
-    adapter._wrap_forward_from_prebuild_lib(tensor)
+    adapter._wrap_forward_from_prebuild_lib(tensor, stream=0)
 
     assert len(forwarded) == 1
     args, stream = forwarded[0]
@@ -99,7 +99,7 @@ def test_nvrtc_adapter_resolves_output_shape_from_later_input():
     adapter._forward_from_prebuild_lib = lambda *args, stream: forwarded.append((args, stream))
 
     tensor = torch.empty(7)
-    output = adapter._wrap_forward_from_prebuild_lib(tensor)
+    output = adapter._wrap_forward_from_prebuild_lib(tensor, stream=0)
 
     assert output.shape == (7,)
     assert len(forwarded) == 1

--- a/tilelang/jit/adapter/nvrtc/adapter.py
+++ b/tilelang/jit/adapter/nvrtc/adapter.py
@@ -156,34 +156,57 @@ class NVRTCKernelAdapter(BaseKernelAdapter):
         adapter._post_init()
         return adapter
 
-    def _process_dynamic_symbolic(self) -> dict[tirx.Var, tuple[int, int]]:
-        """Extract information about dynamic shapes from the TIR function.
+    def _process_dynamic_symbolic(self) -> dict[tirx.Var, tuple[int, int, int, int]]:
+        """Extract runtime sources for scalar, shape, and stride symbols.
 
-        Maps symbolic variables to their corresponding (buffer_index, shape_dimension)
-        for runtime shape resolution.
-
-        Returns
-        -------
-        Dict[tirx.Var, Tuple[int, int]]
-            Mapping from symbolic variable to (buffer_index, shape_dimension)
+        Each entry contains ``(kind, parameter_index, dimension, scale)``.
+        ``kind`` is 0 for a shape, 1 for a stride, and 2 for an explicit
+        scalar parameter. Shape symbols precede stride symbols to match the
+        generated NVRTC host wrapper ABI.
         """
         func = self.prim_func
         params = func.params
         buffer_map = func.buffer_map
-        dynamic_symbolic_map = {}
+        dynamic_symbolic_map: dict[tirx.Var, tuple[int, int, int, int]] = {}
         # Secondary index by variable name for fallback lookup when tirx.Var
         # object identity differs (e.g. params created from a different
         # PrimFunc instance than the one stored in ir_module).
-        self._dynamic_symbolic_name_map: dict[str, tuple[int, int]] = {}
+        self._dynamic_symbolic_name_map: dict[str, tuple[int, int, int, int]] = {}
+
+        def unique_push_back(v: tirx.Var, entry: tuple[int, int, int, int]):
+            if v in dynamic_symbolic_map or v.name in self._dynamic_symbolic_name_map:
+                return
+            dynamic_symbolic_map[v] = entry
+            self._dynamic_symbolic_name_map[v.name] = entry
+
+        # Explicit scalar parameters are already part of the wrapper's primary
+        # argument list. Recording them here permits output-shape resolution,
+        # but they must not be appended again as implicit dynamic arguments.
         for i, param in enumerate(params):
+            if param not in buffer_map:
+                unique_push_back(param, (2, i, -1, 1))
+
+        for i, param in enumerate(params):
+            if param not in buffer_map:
+                continue
             buffer = buffer_map[param]
             for j, shape in enumerate(buffer.shape):
-                if isinstance(shape, tirx.Var) and (shape not in dynamic_symbolic_map):
-                    dynamic_symbolic_map[shape] = (i, j)
-                    self._dynamic_symbolic_name_map[shape.name] = (i, j)
+                if isinstance(shape, tirx.Var):
+                    unique_push_back(shape, (0, i, j, 1))
+
+        for i, param in enumerate(params):
+            if param not in buffer_map:
+                continue
+            buffer = buffer_map[param]
+            element_bits = buffer.dtype.bits * buffer.dtype.lanes
+            stride_scale = 8 // element_bits if element_bits < 8 else 1
+            for j, stride in enumerate(buffer.strides):
+                if isinstance(stride, tirx.Var):
+                    unique_push_back(stride, (1, i, j, stride_scale))
+
         return dynamic_symbolic_map
 
-    def _lookup_dynamic_symbolic(self, v: tirx.Var) -> tuple[int, int]:
+    def _lookup_dynamic_symbolic(self, v: tirx.Var) -> tuple[int, int, int, int]:
         """Look up a tirx.Var in the dynamic symbolic map.
 
         Falls back to name-based lookup when object identity doesn't match.
@@ -193,6 +216,20 @@ class NVRTCKernelAdapter(BaseKernelAdapter):
         if v.name in self._dynamic_symbolic_name_map:
             return self._dynamic_symbolic_name_map[v.name]
         raise KeyError(f"Dynamic symbolic variable '{v.name}' not found in symbolic map")
+
+    def _resolve_dynamic_symbolic_value(self, v: tirx.Var, param_values: list[Any]):
+        """Resolve one symbolic value from its scalar or tensor argument."""
+        ref_id, param_idx, dim_idx, stride_scale = self._lookup_dynamic_symbolic(v)
+        ref_value = param_values[param_idx]
+        if ref_id == 2:
+            return ref_value
+        if not isinstance(ref_value, torch.Tensor):
+            raise TypeError(f"Dynamic symbolic variable '{v.name}' requires tensor parameter {param_idx}, got {type(ref_value).__name__}")
+        if ref_id == 0:
+            return ref_value.shape[dim_idx]
+        if ref_id == 1:
+            return ref_value.stride()[dim_idx] * stride_scale
+        raise ValueError(f"Unknown dynamic symbolic reference kind: {ref_id}")
 
     def get_kernel_source(self, kernel_only: bool = True) -> str | None:
         """Get the CUDA kernel source code.
@@ -215,7 +252,7 @@ class NVRTCKernelAdapter(BaseKernelAdapter):
         """Low-level function to call the compiled CUDA kernel."""
         return self.pymodule.call(self.kernels, *args, stream=stream)
 
-    def _wrap_forward_from_prebuild_lib(self, *ins: list[torch.Tensor], stream: int | None = None):
+    def _wrap_forward_from_prebuild_lib(self, *ins: Any, stream: int | None = None):
         """High-level wrapper for kernel execution.
 
         Handles:
@@ -236,9 +273,16 @@ class NVRTCKernelAdapter(BaseKernelAdapter):
                 f"Expected {len(self.params)} inputs, got {len(ins) + len(self.result_idx)} with {len(ins)} inputs and {len(self.result_idx)} outputs"
             )
         ins_idx = 0
-        args = []
+        param_values: list[Any] = [None] * len(self.params)
+        for i in range(len(self.params)):
+            if i in self.result_idx:
+                continue
+            param_values[i] = ins[ins_idx]
+            ins_idx += 1
 
-        # tensor pointers
+        first_tensor = next((value for value in param_values if isinstance(value, torch.Tensor)), None)
+
+        # Allocate output tensors in their PrimFunc parameter positions.
         for i in range(len(self.params)):
             if i in self.result_idx:
                 dtype = self.param_dtypes[i]
@@ -246,20 +290,18 @@ class NVRTCKernelAdapter(BaseKernelAdapter):
                 # Now working with native Python list, no FFI calls needed
                 for s in self.param_shapes[i]:
                     if isinstance(s, tirx.Var):
-                        ref_tensor_idx, ref_shape_idx = self._lookup_dynamic_symbolic(s)
-                        shape.append(ins[ref_tensor_idx].shape[ref_shape_idx])
+                        shape.append(self._resolve_dynamic_symbolic_value(s, param_values))
                     else:  # Already converted to Python int during initialization
                         shape.append(s)
-                device = ins[0].device if len(ins) > 0 else torch.cuda.current_device()
+                device = first_tensor.device if first_tensor is not None else torch.cuda.current_device()
                 tensor = torch.empty(*shape, dtype=dtype, device=device)
-            else:
-                tensor = ins[ins_idx]
-                ins_idx += 1
-            args.append(tensor)
+                param_values[i] = tensor
 
         # dynamic symbolics
-        for _, (buffer_idx, shape_idx) in self.dynamic_symbolic_map.items():
-            args.append(ins[buffer_idx].shape[shape_idx])
+        args = list(param_values)
+        for symbol, (ref_id, _, _, _) in self.dynamic_symbolic_map.items():
+            if ref_id != 2:
+                args.append(self._resolve_dynamic_symbolic_value(symbol, param_values))
 
         # if stream is not None, we need to pass the stream to the library
         if stream is None:

--- a/tilelang/jit/adapter/nvrtc/adapter.py
+++ b/tilelang/jit/adapter/nvrtc/adapter.py
@@ -168,12 +168,16 @@ class NVRTCKernelAdapter(BaseKernelAdapter):
         params = func.params
         buffer_map = func.buffer_map
         dynamic_symbolic_map: dict[tirx.Var, tuple[int, int, int, int]] = {}
+        self._dynamic_symbolic_candidates_map: dict[tirx.Var, list[tuple[int, int, int, int]]] = {}
+        self._dynamic_symbolic_name_candidates_map: dict[str, list[tuple[int, int, int, int]]] = {}
         # Secondary index by variable name for fallback lookup when tirx.Var
         # object identity differs (e.g. params created from a different
         # PrimFunc instance than the one stored in ir_module).
         self._dynamic_symbolic_name_map: dict[str, tuple[int, int, int, int]] = {}
 
         def unique_push_back(v: tirx.Var, entry: tuple[int, int, int, int]):
+            self._dynamic_symbolic_candidates_map.setdefault(v, []).append(entry)
+            self._dynamic_symbolic_name_candidates_map.setdefault(v.name, []).append(entry)
             if v in dynamic_symbolic_map or v.name in self._dynamic_symbolic_name_map:
                 return
             dynamic_symbolic_map[v] = entry
@@ -206,30 +210,30 @@ class NVRTCKernelAdapter(BaseKernelAdapter):
 
         return dynamic_symbolic_map
 
-    def _lookup_dynamic_symbolic(self, v: tirx.Var) -> tuple[int, int, int, int]:
-        """Look up a tirx.Var in the dynamic symbolic map.
-
-        Falls back to name-based lookup when object identity doesn't match.
-        """
-        if v in self.dynamic_symbolic_map:
-            return self.dynamic_symbolic_map[v]
-        if v.name in self._dynamic_symbolic_name_map:
-            return self._dynamic_symbolic_name_map[v.name]
+    def _lookup_dynamic_symbolic_candidates(self, v: tirx.Var) -> list[tuple[int, int, int, int]]:
+        """Return all scalar, shape, and stride sources for a dynamic symbol."""
+        if v in self._dynamic_symbolic_candidates_map:
+            return self._dynamic_symbolic_candidates_map[v]
+        if v.name in self._dynamic_symbolic_name_candidates_map:
+            return self._dynamic_symbolic_name_candidates_map[v.name]
         raise KeyError(f"Dynamic symbolic variable '{v.name}' not found in symbolic map")
 
     def _resolve_dynamic_symbolic_value(self, v: tirx.Var, param_values: list[Any]):
-        """Resolve one symbolic value from its scalar or tensor argument."""
-        ref_id, param_idx, dim_idx, stride_scale = self._lookup_dynamic_symbolic(v)
-        ref_value = param_values[param_idx]
-        if ref_id == 2:
-            return ref_value
-        if not isinstance(ref_value, torch.Tensor):
-            raise TypeError(f"Dynamic symbolic variable '{v.name}' requires tensor parameter {param_idx}, got {type(ref_value).__name__}")
-        if ref_id == 0:
-            return ref_value.shape[dim_idx]
-        if ref_id == 1:
-            return ref_value.stride()[dim_idx] * stride_scale
-        raise ValueError(f"Unknown dynamic symbolic reference kind: {ref_id}")
+        """Resolve one symbolic value from the first available runtime source."""
+        unavailable_sources = []
+        for ref_id, param_idx, dim_idx, stride_scale in self._lookup_dynamic_symbolic_candidates(v):
+            ref_value = param_values[param_idx]
+            if ref_id == 2 and ref_value is not None:
+                return ref_value
+            if isinstance(ref_value, torch.Tensor):
+                if ref_id == 0:
+                    return ref_value.shape[dim_idx]
+                if ref_id == 1:
+                    return ref_value.stride()[dim_idx] * stride_scale
+                raise ValueError(f"Unknown dynamic symbolic reference kind: {ref_id}")
+            unavailable_sources.append(f"parameter {param_idx}: {type(ref_value).__name__}")
+        details = ", ".join(unavailable_sources)
+        raise TypeError(f"Dynamic symbolic variable '{v.name}' has no available runtime source ({details})")
 
     def get_kernel_source(self, kernel_only: bool = True) -> str | None:
         """Get the CUDA kernel source code.
@@ -262,7 +266,7 @@ class NVRTCKernelAdapter(BaseKernelAdapter):
         4. CUDA stream management
 
         Args:
-            ins: Input PyTorch tensors
+            ins: Input PyTorch tensors and scalar values
             stream: Optional CUDA stream for asynchronous execution
 
         Returns:


### PR DESCRIPTION
## Summary

The NVRTC adapter assumed every `PrimFunc` parameter was a buffer. An explicit
scalar therefore raised `KeyError` while the adapter built its dynamic symbol
map. The same map scanned buffer shapes but not buffer strides, so a symbolic
stride required by the generated host wrapper was omitted at launch.

This change records where each runtime symbol comes from—an explicit scalar,
tensor shape, or tensor stride—and marshals arguments in the wrapper ABI order:

```text
[tensor, scalar] + [shape] + [stride] + [stream]
     primary       implicit  implicit
```

Explicit scalars remain in their `PrimFunc` parameter positions and are not
appended a second time. Dynamic shapes are resolved before dynamic strides, and
sub-byte strides use the same scaling convention as the other host adapters.
When a symbol occurs in more than one buffer, the adapter retains every
candidate and resolves it from the first live runtime value. This supports
output parameters that precede the input carrying their dynamic shape.

Closes #2755.

## Regression evidence

The host-side regression tests intercept the final NVRTC launcher call, so they
exercise argument extraction without requiring a GPU kernel launch.

On `main`:

- a tensor-plus-scalar function fails while looking up the scalar in
  `buffer_map`;
- a strided tensor with runtime shape `7` and stride `3` launches with `(7,)`
  instead of `(7, 3)`.

The tests also cover:

- an `int4` buffer whose storage stride `3` must be forwarded as logical stride
  `6`;
- an output at parameter 0 whose dynamic shape must be resolved from the live
  input at parameter 1.

## Test plan

- `pytest -q testing/python/jit/test_tilelang_jit_nvrtc_host.py` — 4 passed
- `bash format.sh --files tilelang/jit/adapter/nvrtc/adapter.py testing/python/jit/test_tilelang_jit_nvrtc_host.py` — passed
- Full source CMake build — passed

The regression tests validate the exact host-launch boundary. A CUDA device was
not available for an end-to-end NVRTC kernel launch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed NVRTC host argument marshalling for explicit scalar parameters and dynamic tensor shapes/strides.
- Preserved scalar positions without duplication and enforced `[tensor, scalar] + [shape] + [stride] + [stream]` ordering.
- Added symbol resolution fallback across runtime values and sub-byte stride scaling.
- Added four host-side regression tests covering scalars, dynamic strides, sub-byte strides, and output shape resolution.

## Testing

- Focused tests, formatting, and full source CMake build passed.
- CUDA execution was not run because no CUDA device was available.
- NVRTC tests retain the availability skip for environments without `cuda-python`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->