### PR TITLE
[BugFix] Make T.transpose swap only the final two axes

### DIFF
--- a/src/op/transpose.cc
+++ b/src/op/transpose.cc
@@ -150,40 +150,18 @@ Array<PrimExpr> TransposeNode::MakeIndices(const Array<IterVar> &ivs,
 }
 
 PrimExpr TransposeNode::MakePredicate(arith::Analyzer *analyzer,
-                                      const Array<IterVar> &ivs,
-                                      Array<PrimExpr> extents,
-                                      int src_dst) const {
-  bool do_transpose = (src_dst == 1);
-  Array<Range> ranges = src_dst == 0 ? src_range : dst_range;
-
-  std::vector<int> source_axis_to_iv;
-  if (do_transpose) {
-    ICHECK_EQ(src_range.size(), ranges.size())
-        << "Transpose source and destination ranks must match";
-    source_axis_to_iv = MakeSourceAxisToIterVarMap(src_range, ivs.size());
-  }
-
+                                      const Array<PrimExpr> &indices,
+                                      const Array<PrimExpr> &extents) const {
   Array<PrimExpr> cond_list;
-  ICHECK(extents.size() == ranges.size()) << extents << " " << ranges;
-  size_t idx = 0;
-  for (size_t i = 0; i < ranges.size(); i++) {
-    size_t iv_idx;
-    if (do_transpose) {
-      size_t src_axis = SourceAxisForDestinationAxis(i, ranges.size());
-      int mapped_iv_idx = source_axis_to_iv[src_axis];
-      if (mapped_iv_idx < 0)
-        continue;
-      iv_idx = static_cast<size_t>(mapped_iv_idx);
-    } else {
-      if (is_one(ranges[i]->extent))
-        continue;
-      iv_idx = idx++;
-    }
-    PrimExpr cond = ranges[i]->min + ivs[iv_idx]->var < extents[i];
+  ICHECK_EQ(indices.size(), extents.size())
+      << "Transpose index rank (" << indices.size()
+      << ") must match buffer rank (" << extents.size() << ")";
+  for (size_t i = 0; i < indices.size(); i++) {
+    PrimExpr cond = indices[i] < extents[i];
     if (!analyzer->CanProve(cond, arith::ProofStrength::kSymbolicBound)) {
       cond_list.push_back(cond);
     }
-    cond = ranges[i]->min + ivs[iv_idx]->var >= 0;
+    cond = indices[i] >= 0;
     if (!analyzer->CanProve(cond, arith::ProofStrength::kSymbolicBound)) {
       cond_list.push_back(cond);
     }
@@ -206,8 +184,8 @@ For TransposeNode::MakeSIMTLoop(arith::Analyzer *analyzer) const {
   Array<PrimExpr> src_indices = MakeIndices(loop_vars, 0);
   Array<PrimExpr> dst_indices = MakeIndices(loop_vars, 1);
 
-  PrimExpr src_predicate = MakePredicate(analyzer, loop_vars, src->shape, 0);
-  PrimExpr dst_predicate = MakePredicate(analyzer, loop_vars, dst->shape, 1);
+  PrimExpr src_predicate = MakePredicate(analyzer, src_indices, src->shape);
+  PrimExpr dst_predicate = MakePredicate(analyzer, dst_indices, dst->shape);
 
   PrimExpr value = BufferLoad(src, src_indices);
   if (src->dtype != dst->dtype)

--- a/src/op/transpose.cc
+++ b/src/op/transpose.cc
@@ -1,6 +1,6 @@
 /*!
  * \file tl/op/transpose.cc
- * \brief Transpose operator: dst[j, i] = src[i, j] using SIMT loops.
+ * \brief Transpose operator that swaps the final two axes using SIMT loops.
  */
 
 #include "transpose.h"
@@ -23,6 +23,30 @@ using namespace tirx;
 using namespace ffi;
 
 namespace {
+
+size_t SourceAxisForDestinationAxis(size_t dst_axis, size_t rank) {
+  ICHECK(rank >= 2) << "Transpose requires at least two dimensions";
+  if (dst_axis == rank - 2)
+    return rank - 1;
+  if (dst_axis == rank - 1)
+    return rank - 2;
+  return dst_axis;
+}
+
+std::vector<int> MakeSourceAxisToIterVarMap(Array<Range> ranges,
+                                            size_t iv_count) {
+  std::vector<int> source_axis_to_iv(ranges.size(), -1);
+  size_t iv_idx = 0;
+  for (size_t axis = 0; axis < ranges.size(); axis++) {
+    if (is_one(ranges[axis]->extent))
+      continue;
+    source_axis_to_iv[axis] = static_cast<int>(iv_idx++);
+  }
+  ICHECK_EQ(iv_idx, iv_count)
+      << "Transpose: source nontrivial dimensions (" << iv_idx
+      << ") != iterator count (" << iv_count << ")";
+  return source_axis_to_iv;
+}
 
 std::vector<TransposeImpl> &TransposeImplRegistry() {
   static std::vector<TransposeImpl> registry;
@@ -95,25 +119,17 @@ Array<PrimExpr> TransposeNode::MakeIndices(const Array<IterVar> &ivs,
   Array<Range> ranges = src_dst == 0 ? src_range : dst_range;
 
   if (src_dst == 1) {
-    // Transpose: reverse the loop variable assignment for non-trivial dims.
-    std::vector<size_t> nontrivial;
-    for (size_t i = 0; i < ranges.size(); i++) {
-      if (!is_one(ranges[i]->extent))
-        nontrivial.push_back(i);
-    }
-    ICHECK(nontrivial.size() == ivs.size())
-        << "Transpose: nontrivial dims (" << nontrivial.size()
-        << ") != ivs size (" << ivs.size() << ") for dst=" << dst->name;
-    size_t N = nontrivial.size();
-    size_t nt_idx = 0;
-    for (size_t i = 0; i < ranges.size(); i++) {
-      if (is_one(ranges[i]->extent)) {
-        indices.push_back(ranges[i]->min);
-      } else {
-        size_t rev = N - 1 - nt_idx;
-        indices.push_back(ranges[i]->min + ivs[rev]->var);
-        nt_idx++;
-      }
+    ICHECK_EQ(src_range.size(), ranges.size())
+        << "Transpose source and destination ranks must match";
+    std::vector<int> source_axis_to_iv =
+        MakeSourceAxisToIterVarMap(src_range, ivs.size());
+    for (size_t dst_axis = 0; dst_axis < ranges.size(); dst_axis++) {
+      size_t src_axis = SourceAxisForDestinationAxis(dst_axis, ranges.size());
+      int iv_idx = source_axis_to_iv[src_axis];
+      if (iv_idx < 0)
+        indices.push_back(ranges[dst_axis]->min);
+      else
+        indices.push_back(ranges[dst_axis]->min + ivs[iv_idx]->var);
     }
   } else {
     // Source: direct mapping.
@@ -140,19 +156,29 @@ PrimExpr TransposeNode::MakePredicate(arith::Analyzer *analyzer,
   bool do_transpose = (src_dst == 1);
   Array<Range> ranges = src_dst == 0 ? src_range : dst_range;
 
-  size_t num_nontrivial = 0;
-  for (size_t i = 0; i < ranges.size(); i++) {
-    if (!is_one(ranges[i]->extent))
-      num_nontrivial++;
+  std::vector<int> source_axis_to_iv;
+  if (do_transpose) {
+    ICHECK_EQ(src_range.size(), ranges.size())
+        << "Transpose source and destination ranks must match";
+    source_axis_to_iv = MakeSourceAxisToIterVarMap(src_range, ivs.size());
   }
 
   Array<PrimExpr> cond_list;
   ICHECK(extents.size() == ranges.size()) << extents << " " << ranges;
   size_t idx = 0;
   for (size_t i = 0; i < ranges.size(); i++) {
-    if (is_one(ranges[i]->extent))
-      continue;
-    size_t iv_idx = do_transpose ? (num_nontrivial - 1 - idx) : idx;
+    size_t iv_idx;
+    if (do_transpose) {
+      size_t src_axis = SourceAxisForDestinationAxis(i, ranges.size());
+      int mapped_iv_idx = source_axis_to_iv[src_axis];
+      if (mapped_iv_idx < 0)
+        continue;
+      iv_idx = static_cast<size_t>(mapped_iv_idx);
+    } else {
+      if (is_one(ranges[i]->extent))
+        continue;
+      iv_idx = idx++;
+    }
     PrimExpr cond = ranges[i]->min + ivs[iv_idx]->var < extents[i];
     if (!analyzer->CanProve(cond, arith::ProofStrength::kSymbolicBound)) {
       cond_list.push_back(cond);
@@ -161,7 +187,6 @@ PrimExpr TransposeNode::MakePredicate(arith::Analyzer *analyzer,
     if (!analyzer->CanProve(cond, arith::ProofStrength::kSymbolicBound)) {
       cond_list.push_back(cond);
     }
-    idx++;
   }
   if (cond_list.empty())
     return {};

--- a/src/op/transpose.h
+++ b/src/op/transpose.h
@@ -1,6 +1,6 @@
 /*!
  * \file tl/op/transpose.h
- * \brief Transpose operation for 2D shared memory buffers.
+ * \brief Transpose operation that swaps the final two buffer axes.
  */
 
 #ifndef TVM_TL_OP_TRANSPOSE_H_
@@ -15,7 +15,7 @@ namespace tl {
 using namespace tirx;
 using namespace ffi;
 
-/// Node class for transpose operations: dst[j, i] = src[i, j]
+/// Node class for transpose operations over the final two axes.
 class TransposeNode : public TileOperatorNode {
 public:
   Buffer src, dst;
@@ -47,8 +47,7 @@ private:
   Array<IterVar> MakeIterVars() const;
 
   /// Generate source (src_dst=0) or destination (src_dst=1) index expressions.
-  /// For the destination side, non-trivial dimension indices are reversed to
-  /// implement the transpose.
+  /// For the destination side, the final two source axes are exchanged.
   Array<PrimExpr> MakeIndices(const Array<IterVar> &ivs, int src_dst) const;
 
   /// Build boundary predicate with transposed index mapping for dst.

--- a/src/op/transpose.h
+++ b/src/op/transpose.h
@@ -50,9 +50,10 @@ private:
   /// For the destination side, the final two source axes are exchanged.
   Array<PrimExpr> MakeIndices(const Array<IterVar> &ivs, int src_dst) const;
 
-  /// Build boundary predicate with transposed index mapping for dst.
-  PrimExpr MakePredicate(arith::Analyzer *analyzer, const Array<IterVar> &ivs,
-                         Array<PrimExpr> extents, int src_dst) const;
+  /// Build a boundary predicate for generated buffer indices.
+  PrimExpr MakePredicate(arith::Analyzer *analyzer,
+                         const Array<PrimExpr> &indices,
+                         const Array<PrimExpr> &extents) const;
 };
 
 using TransposeTargetPredicate = bool (*)(Target target);

--- a/testing/python/cpu/test_tilelang_cpu_transpose.py
+++ b/testing/python/cpu/test_tilelang_cpu_transpose.py
@@ -42,3 +42,36 @@ def test_cpu_transpose_swaps_only_the_final_two_axes(src_shape):
     expected = src.transpose(-2, -1)
 
     torch.testing.assert_close(actual, expected)
+
+
+def test_cpu_transpose_maps_destination_boundary_predicate():
+    src_shape = (2, 3, 4)
+    dst_shape = (2, 4, 3)
+
+    @T.prim_func
+    def main(
+        src: T.Tensor(src_shape, T.float32),
+        dst: T.Tensor(dst_shape, T.float32),
+    ):
+        with T.Kernel(1):
+            T.fill(dst, -1.0)
+            T.transpose(
+                src[0:2, 0:3, 0:4],
+                dst[0:2, 0:4, 1:4],
+            )
+
+    with tvm.target.Target("c"):
+        kernel = tilelang.compile(
+            main,
+            out_idx=[1],
+            target="c",
+            target_host="c",
+            execution_backend="cython",
+        )
+
+    src = torch.arange(math.prod(src_shape), dtype=torch.float32).reshape(src_shape)
+    actual = kernel(src)
+    expected = torch.full(dst_shape, -1.0)
+    expected[:, :, 1:] = src[:, :2, :].transpose(-2, -1)
+
+    torch.testing.assert_close(actual, expected)

--- a/testing/python/cpu/test_tilelang_cpu_transpose.py
+++ b/testing/python/cpu/test_tilelang_cpu_transpose.py
@@ -1,0 +1,44 @@
+import math
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+from tilelang import tvm
+
+
+@pytest.mark.parametrize(
+    "src_shape",
+    [
+        (2, 3, 4),
+        (2, 3, 4, 5),
+        (2, 3, 1),
+        (2, 1, 3),
+    ],
+)
+def test_cpu_transpose_swaps_only_the_final_two_axes(src_shape):
+    dst_shape = (*src_shape[:-2], src_shape[-1], src_shape[-2])
+
+    @T.prim_func
+    def main(
+        src: T.Tensor(src_shape, T.float32),
+        dst: T.Tensor(dst_shape, T.float32),
+    ):
+        with T.Kernel(1):
+            T.transpose(src, dst)
+
+    with tvm.target.Target("c"):
+        kernel = tilelang.compile(
+            main,
+            out_idx=[1],
+            target="c",
+            target_host="c",
+            execution_backend="cython",
+        )
+
+    src = torch.arange(math.prod(src_shape), dtype=torch.float32).reshape(src_shape)
+    actual = kernel(src)
+    expected = src.transpose(-2, -1)
+
+    torch.testing.assert_close(actual, expected)

--- a/testing/python/cpu/test_tilelang_cpu_transpose.py
+++ b/testing/python/cpu/test_tilelang_cpu_transpose.py
@@ -75,3 +75,66 @@ def test_cpu_transpose_maps_destination_boundary_predicate():
     expected[:, :, 1:] = src[:, :2, :].transpose(-2, -1)
 
     torch.testing.assert_close(actual, expected)
+
+
+def test_cpu_transpose_guards_out_of_bounds_singleton_destination():
+    src_shape = (2, 3, 1)
+    dst_shape = (2, 1, 3)
+
+    @T.prim_func
+    def main(
+        src: T.Tensor(src_shape, T.float32),
+        dst: T.Tensor(dst_shape, T.float32),
+    ):
+        with T.Kernel(1):
+            T.fill(dst, -1.0)
+            T.transpose(
+                src[0:2, 0:3, 0:1],
+                dst[0:2, 1:2, 0:3],
+            )
+
+    with tvm.target.Target("c"):
+        kernel = tilelang.compile(
+            main,
+            out_idx=[1],
+            target="c",
+            target_host="c",
+            execution_backend="cython",
+        )
+
+    src = torch.arange(math.prod(src_shape), dtype=torch.float32).reshape(src_shape)
+    actual = kernel(src)
+    expected = torch.full(dst_shape, -1.0)
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_cpu_transpose_guards_out_of_bounds_singleton_source():
+    src_shape = (2, 3, 1)
+    dst_shape = (2, 1, 3)
+
+    @T.prim_func
+    def main(
+        src: T.Tensor(src_shape, T.float32),
+        dst: T.Tensor(dst_shape, T.float32),
+    ):
+        with T.Kernel(1):
+            T.transpose(
+                src[0:2, 0:3, 1:2],
+                dst[0:2, 0:1, 0:3],
+            )
+
+    with tvm.target.Target("c"):
+        kernel = tilelang.compile(
+            main,
+            out_idx=[1],
+            target="c",
+            target_host="c",
+            execution_backend="cython",
+        )
+
+    src = torch.arange(math.prod(src_shape), dtype=torch.float32).reshape(src_shape)
+    actual = kernel(src)
+    expected = torch.zeros(dst_shape, dtype=torch.float32)
+
+    torch.testing.assert_close(actual, expected)


### PR DESCRIPTION
## Summary

`T.transpose` documented a swap of the final two axes, but its destination index
construction reversed every nontrivial axis. Those operations coincide for a
2D buffer, which allowed the existing tests to pass, but rank-3 and higher
buffers produced wrong code.

For a source shaped `[B, M, N]`, the old and corrected mappings are:

```text
source index:       src[b, m, n]
old destination:   dst[n, m, b]  (full reversal)
new destination:   dst[b, n, m]  (final-two-axis swap)

destination axis:      0  1  2
mapped source axis:    0  2  1
```

This change defines that mapping once and applies it to both destination indices
and boundary predicates. It also maps through the source axes before accounting
for extent-one dimensions, preserving the semantics of cases such as
`[B, M, 1] -> [B, 1, M]`.

Closes #2626.

## Regression evidence

The CPU tests cover rank-3, rank-4, both positions of an extent-one final axis,
and a shifted destination region that requires boundary-predicate clipping.
Against `main`, the four full-region rank and singleton cases fail. With this
change, all five cases match their PyTorch references.

For the ordinary rank-3 case, generated C contains the equivalent of:

```text
dst[i, k, j] = src[i, j, k]
```

For the shifted destination region, generated C proves that the predicate uses
the source penultimate-axis iterator:

```text
if (j < 2) {
  dst[i, k, j + 1] = src[i, j, k];
}
```

## Test plan

- `pytest -q testing/python/cpu/test_tilelang_cpu_transpose.py` — 5 passed
- `bash format.sh --files src/op/transpose.cc src/op/transpose.h testing/python/cpu/test_tilelang_cpu_transpose.py` — passed
- Full source CMake build — passed

The implementation is in target-independent transpose lowering; the regression
suite executes the resulting kernels on the CPU backend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed `T.transpose` to swap only the final two axes while preserving leading dimensions for rank-3 and higher buffers.
- Updated the transpose implementation so the same final-two-axis mapping is used consistently for both index construction and boundary predicates, including cases where one of the transposed extents is `1` (e.g. `[B, M, 1] -> [B, 1, M]`).
- Updated C++/doc comments to reflect the corrected “final-two-axes swap” behavior.

## Validation

- Added CPU regression tests covering rank-3, rank-4, extent-one final-axis cases, and a shifted-destination boundary/predicate scenario.
- CPU regression suite, formatting checks, and full source CMake build pass.

## C++ style / lint notes

- Does not appear to touch `docs/developer_guide/cpp_style.md` or related C++ style guidance.
- The C++ API Style Audit (warning only) remains advisory; this PR does not introduce new/changed lint tooling or CI configuration, and no correctness/build impact is indicated by any warning-only style checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->