### PR TITLE
feat: allow T.const() variables used only in grid dims or computations

### DIFF
--- a/testing/python/issue/test_tilelang_issue_2760.py
+++ b/testing/python/issue/test_tilelang_issue_2760.py
@@ -19,6 +19,7 @@ def test_const_grid_only():
 
     @tilelang.jit
     def kernel(A, B, block_N: int = 32):
+        """Copy A into B."""
         N = T.const("N")
         num_blocks = T.const("num_blocks")  # grid-only, not in any buffer shape
         A: T.Tensor((N,), T.float16)
@@ -40,6 +41,7 @@ def test_const_computation_only():
 
     @tilelang.jit
     def kernel(A, B, block_N: int = 32):
+        """Copy A into B."""
         N = T.const("N")
         scale = T.const("scale")  # computation-only, not in any buffer shape
         A: T.Tensor((N,), T.float16)
@@ -63,6 +65,7 @@ def test_const_mixed():
 
     @tilelang.jit
     def kernel(A, B, block_N: int = 32):
+        """Copy A into B."""
         N = T.const("N")
         num_blocks = T.const("num_blocks")
         scale = T.const("scale")
@@ -87,6 +90,7 @@ def test_const_pipelined_gemm():
 
     @tilelang.jit
     def kernel(A, B, C, block_M: int = 64, block_N: int = 64, block_K: int = 32):
+        """Pipelined GEMM: C = A @ B with grid-only const extents."""
         M, N, K = T.const("M, N, K")
         num_blocks_m = T.const("num_blocks_m")  # grid-only
         num_blocks_n = T.const("num_blocks_n")  # grid-only
@@ -118,6 +122,7 @@ def test_const_cache_isolation():
 
     @tilelang.jit
     def kernel(A, B, block_N: int = 32):
+        """Copy A into B."""
         N = T.const("N")
         num_blocks = T.const("num_blocks")
         A: T.Tensor((N,), T.float16)
@@ -147,6 +152,7 @@ def test_const_float_value():
 
     @tilelang.jit
     def kernel(A, B, block_N: int = 32):
+        """Copy A into B."""
         N = T.const("N")
         scale = T.const("scale")
         A: T.Tensor((N,), T.float16)
@@ -170,6 +176,7 @@ def test_const_missing_kwarg_errors():
 
     @tilelang.jit
     def kernel(A, B, block_N: int = 32):
+        """Copy A into B."""
         N = T.const("N")
         num_blocks = T.const("num_blocks")
         A: T.Tensor((N,), T.float16)

--- a/testing/python/issue/test_tilelang_issue_2760.py
+++ b/testing/python/issue/test_tilelang_issue_2760.py
@@ -82,6 +82,58 @@ def test_const_mixed():
 
 
 @tilelang.testing.requires_cuda
+def test_const_cache_isolation():
+    """Different kwarg values must produce distinct, correct kernels."""
+
+    @tilelang.jit
+    def kernel(A, B, block_N: int = 32):
+        N = T.const("N")
+        num_blocks = T.const("num_blocks")
+        A: T.Tensor((N,), T.float16)
+        B: T.Tensor((N,), T.float16)
+        with T.Kernel(num_blocks, threads=128) as (bx,):
+            A_shared = T.alloc_shared((block_N,), T.float16)
+            T.copy(A[bx * block_N], A_shared)
+            T.copy(A_shared, B[bx * block_N])
+
+    A = torch.randn(128, dtype=torch.float16, device="cuda")
+
+    # num_blocks=4 writes all 128 elements; num_blocks=2 writes only the first 64.
+    B_full = torch.zeros(128, dtype=torch.float16, device="cuda")
+    B_half = torch.zeros(128, dtype=torch.float16, device="cuda")
+    kernel(A, B_full, 32, num_blocks=4)
+    kernel(A, B_half, 32, num_blocks=2)
+
+    assert len(kernel.func.p1_cache) == 2
+    torch.testing.assert_close(B_full, A)
+    torch.testing.assert_close(B_half[:64], A[:64])
+    assert torch.equal(B_half[64:], torch.zeros(64, dtype=torch.float16, device="cuda"))
+
+
+@tilelang.testing.requires_cuda
+def test_const_float_value():
+    """A float kwarg value should be accepted and produce correct results."""
+
+    @tilelang.jit
+    def kernel(A, B, block_N: int = 32):
+        N = T.const("N")
+        scale = T.const("scale")
+        A: T.Tensor((N,), T.float16)
+        B: T.Tensor((N,), T.float16)
+        with T.Kernel(T.ceildiv(N, block_N), threads=128) as (bx,):
+            A_local = T.alloc_fragment((block_N,), T.float16)
+            T.copy(A[bx * block_N], A_local)
+            for i in T.Parallel(block_N):
+                A_local[i] = A_local[i] * T.cast(scale, T.float16)
+            T.copy(A_local, B[bx * block_N])
+
+    A = torch.randn(128, dtype=torch.float16, device="cuda")
+    B = torch.zeros(128, dtype=torch.float16, device="cuda")
+    kernel(A, B, 32, scale=2.0)
+    torch.testing.assert_close(B, (A * 2).half())
+
+
+@tilelang.testing.requires_cuda
 def test_const_missing_kwarg_errors():
     """A grid-only const without a value should raise a clear error."""
 

--- a/testing/python/issue/test_tilelang_issue_2760.py
+++ b/testing/python/issue/test_tilelang_issue_2760.py
@@ -4,6 +4,7 @@ T.const() variables that are used only in grid dimensions or kernel-body
 computations (not in any buffer shape/stride) should be resolvable via an
 explicit keyword argument at call time, instead of raising RuntimeError.
 """
+
 import pytest
 import torch
 

--- a/testing/python/issue/test_tilelang_issue_2760.py
+++ b/testing/python/issue/test_tilelang_issue_2760.py
@@ -1,0 +1,105 @@
+"""Regression test for issue #2760.
+
+T.const() variables that are used only in grid dimensions or kernel-body
+computations (not in any buffer shape/stride) should be resolvable via an
+explicit keyword argument at call time, instead of raising RuntimeError.
+"""
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+@tilelang.testing.requires_cuda
+def test_const_grid_only():
+    """A T.const() used only in T.Kernel(...) extent should be resolvable."""
+
+    @tilelang.jit
+    def kernel(A, B, block_N: int = 32):
+        N = T.const("N")
+        num_blocks = T.const("num_blocks")  # grid-only, not in any buffer shape
+        A: T.Tensor((N,), T.float16)
+        B: T.Tensor((N,), T.float16)
+        with T.Kernel(num_blocks, threads=128) as (bx,):
+            A_shared = T.alloc_shared((block_N,), T.float16)
+            T.copy(A[bx * block_N], A_shared)
+            T.copy(A_shared, B[bx * block_N])
+
+    A = torch.randn(128, dtype=torch.float16, device="cuda")
+    B = torch.zeros(128, dtype=torch.float16, device="cuda")
+    kernel(A, B, 32, num_blocks=4)
+    torch.testing.assert_close(B, A)
+
+
+@tilelang.testing.requires_cuda
+def test_const_computation_only():
+    """A T.const() used only in the kernel body should be resolvable."""
+
+    @tilelang.jit
+    def kernel(A, B, block_N: int = 32):
+        N = T.const("N")
+        scale = T.const("scale")  # computation-only, not in any buffer shape
+        A: T.Tensor((N,), T.float16)
+        B: T.Tensor((N,), T.float16)
+        with T.Kernel(T.ceildiv(N, block_N), threads=128) as (bx,):
+            A_local = T.alloc_fragment((block_N,), T.float16)
+            T.copy(A[bx * block_N], A_local)
+            for i in T.Parallel(block_N):
+                A_local[i] = A_local[i] * T.cast(scale, T.float16)
+            T.copy(A_local, B[bx * block_N])
+
+    A = torch.randn(128, dtype=torch.float16, device="cuda")
+    B = torch.zeros(128, dtype=torch.float16, device="cuda")
+    kernel(A, B, 32, scale=3)
+    torch.testing.assert_close(B, (A * 3).half())
+
+
+@tilelang.testing.requires_cuda
+def test_const_mixed():
+    """Mix of shape-derived and explicit-kwarg const should work together."""
+
+    @tilelang.jit
+    def kernel(A, B, block_N: int = 32):
+        N = T.const("N")
+        num_blocks = T.const("num_blocks")
+        scale = T.const("scale")
+        A: T.Tensor((N,), T.float16)
+        B: T.Tensor((N,), T.float16)
+        with T.Kernel(num_blocks, threads=128) as (bx,):
+            A_shared = T.alloc_shared((block_N,), T.float16)
+            T.copy(A[bx * block_N], A_shared)
+            for i in T.Parallel(block_N):
+                A_shared[i] = A_shared[i] * T.cast(scale, T.float16)
+            T.copy(A_shared, B[bx * block_N])
+
+    A = torch.randn(128, dtype=torch.float16, device="cuda")
+    B = torch.zeros(128, dtype=torch.float16, device="cuda")
+    kernel(A, B, 32, num_blocks=4, scale=2)
+    torch.testing.assert_close(B, (A * 2).half())
+
+
+@tilelang.testing.requires_cuda
+def test_const_missing_kwarg_errors():
+    """A grid-only const without a value should raise a clear error."""
+
+    @tilelang.jit
+    def kernel(A, B, block_N: int = 32):
+        N = T.const("N")
+        num_blocks = T.const("num_blocks")
+        A: T.Tensor((N,), T.float16)
+        B: T.Tensor((N,), T.float16)
+        with T.Kernel(num_blocks, threads=128) as (bx,):
+            A_shared = T.alloc_shared((block_N,), T.float16)
+            T.copy(A[bx * block_N], A_shared)
+            T.copy(A_shared, B[bx * block_N])
+
+    A = torch.randn(128, dtype=torch.float16, device="cuda")
+    B = torch.zeros(128, dtype=torch.float16, device="cuda")
+    with pytest.raises(ValueError, match="Cannot find value for constexpr variable"):
+        kernel(A, B, 32)  # num_blocks not provided
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/issue/test_tilelang_issue_2760.py
+++ b/testing/python/issue/test_tilelang_issue_2760.py
@@ -82,6 +82,37 @@ def test_const_mixed():
 
 
 @tilelang.testing.requires_cuda
+def test_const_pipelined_gemm():
+    """Grid-only const should work with T.Pipelined + T.gemm (real kernel pattern)."""
+
+    @tilelang.jit
+    def kernel(A, B, C, block_M: int = 64, block_N: int = 64, block_K: int = 32):
+        M, N, K = T.const("M, N, K")
+        num_blocks_m = T.const("num_blocks_m")  # grid-only
+        num_blocks_n = T.const("num_blocks_n")  # grid-only
+        A: T.Tensor((M, K), T.float16)
+        B: T.Tensor((K, N), T.float16)
+        C: T.Tensor((M, N), T.float16)
+        with T.Kernel(num_blocks_m, num_blocks_n, threads=128) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), T.float16)
+            B_shared = T.alloc_shared((block_K, block_N), T.float16)
+            C_local = T.alloc_fragment((block_M, block_N), T.float32)
+            T.clear(C_local)
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=3):
+                T.copy(A[bx * block_M, k * block_K], A_shared)
+                T.copy(B[k * block_K, by * block_N], B_shared)
+                T.gemm(A_shared, B_shared, C_local)
+            T.copy(C_local, C[bx * block_M, by * block_N])
+
+    M, N, K = 128, 128, 128
+    A = torch.randn(M, K, dtype=torch.float16, device="cuda")
+    B = torch.randn(K, N, dtype=torch.float16, device="cuda")
+    C = torch.zeros(M, N, dtype=torch.float16, device="cuda")
+    kernel(A, B, C, num_blocks_m=2, num_blocks_n=2)
+    torch.testing.assert_close(C, (A @ B).half(), atol=1e-2, rtol=1e-2)
+
+
+@tilelang.testing.requires_cuda
 def test_const_cache_isolation():
     """Different kwarg values must produce distinct, correct kernels."""
 

--- a/tilelang/language/eager/builder.py
+++ b/tilelang/language/eager/builder.py
@@ -1051,18 +1051,13 @@ class TirTemplate(Generic[_P, _T]):
             for i, s in enumerate(v.strides):
                 if s in constexpr and s not in matcher:
                     matcher[s] = (k.name, "stride", i, s.name)
+        # Constexpr variables that don't appear in any buffer shape/stride
+        # can still be resolved at call time via an explicit keyword argument
+        # (handled by ``_parse_phase2_key``).  Record them with a sentinel
+        # source so the value flows through the same matcher machinery.
         for s in constexpr:
             if s not in matcher:
-                shapes = {k: v.shape for k, v in prim_func.buffer_map.items()}
-                strides = {k: v.strides for k, v in prim_func.buffer_map.items()}
-                raise RuntimeError(
-                    f"Constexpr variable `{s}` is not used in any buffer shape or stride.\n"
-                    "At least one **DIRECT** usage is required. Please check:\n"
-                    "(1) the variable is not used\n"
-                    f"(2) all uses are indirect, e.g. {s} * 2, {s} * 3. (you can replace them with separate constexpr variables)\n"
-                    f"Buffer shapes: {shapes}\n"
-                    f"Buffer strides: {strides}"
-                )
+                matcher[s] = (s.name, "__kwarg__", -1, s.name)
         matcher = {k: matcher[k] for k in constexpr}
         return cls(name=name, prim_func=prim_func, matcher=matcher, constexprs=constexpr, is_lazy_style=False, ir_gen=ir_gen)
 


### PR DESCRIPTION
## Problem

In eager (`@tilelang.jit`) mode, `T.const()` is the only way to declare a
compile-time symbolic variable resolved from tensor arguments at runtime.
`TirTemplate.create()` requires every such variable to appear **directly**
in some buffer's shape or stride, and raises otherwise:

```
RuntimeError: Constexpr variable `X` is not used in any buffer shape or stride.
```

This rules out two common patterns where a compile-time value is known at
call time but does not itself index a buffer — a grid-only variable (number
of CTAs) and a computation-only variable (e.g. a scale factor).

Closes #2760.

## Solution

The phase-2 value-resolution path (`_parse_phase2_key`) already supports
resolving a constexpr via an explicit keyword argument (`if name in kwargs`),
and the JIT argument binder (#2357) already routes extra kwargs into
`compile_kwargs`. The only thing blocking this path was `create()` raising
before the template was cached.

This PR replaces the raise with a sentinel entry so grid-only /
computation-only constexpr vars flow through the existing explicit-kwarg
path — no binder changes, no new code paths:

```python
# before: raise RuntimeError(...)
# after:
matcher[s] = (s.name, "__kwarg__", -1, s.name)
```

## Value flow

```
kernel(a, b, num_blocks=4)
  → binder routes num_blocks into compile_kwargs (extra_kwargs, #2357)
  → _parse_phase2_key: name "num_blocks" in kwargs → returns 4
  → subs = {orig_name: 4}
  → phase2 T.const("num_blocks") → eager_jit_subs["num_blocks"] → 4
```

## Verification

Tested on **0.1.12** (wheel + source patch on the installed `builder.py`,
which is byte-identical to `main`):

```
python3 -m pytest testing/python/issue/test_tilelang_issue_2760.py -v
test_const_grid_only             PASSED
test_const_computation_only      PASSED
test_const_mixed                 PASSED
test_const_missing_kwarg_errors  PASSED
4 passed in 3.66s
```

- `test_const_grid_only` — `T.const("num_blocks")` used only in `T.Kernel(...)`, resolved via `num_blocks=4` kwarg.
- `test_const_computation_only` — `T.const("scale")` used only in kernel body, resolved via `scale=3`.
- `test_const_mixed` — mix of shape-derived (`N`) and explicit-kwarg (`num_blocks`, `scale`).
- `test_const_missing_kwarg_errors` — omitting the kwarg raises `ValueError` with a clear message.

Note: I don't have a `main` source build with CUDA locally, so verification
was done by applying the source patch to the 0.1.12 wheel installation
(`builder.py` is identical between 0.1.12 and `main` — 0 lines diff).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Allow `T.const()` constexpr variables used only for grid/kernel extent and/or inside kernel computations (i.e., not referenced by any buffer shape or stride) to be resolved via explicit call-time keyword arguments instead of being rejected during `TirTemplate.create()`.
- Update `TirTemplate.create()` to record such “missing from buffer shape/stride” constexpr variables into the template matcher using a `"__kwarg__"` sentinel (keyword-only substitution), so phase-2 matching/JIT argument binding can pull their values from provided `**kwargs`.
- Add regression coverage for issue `#2760`, including grid-only, computation-only, and mixed usage; cache isolation across different constexpr-kwarg configurations; float keyword handling; and a clear error when a required constexpr keyword is omitted (“Cannot find value for constexpr variable”).

## Testing

- Added `testing/python/issue/test_tilelang_issue_2760.py` with CUDA-gated tests:
  - `test_const_grid_only`
  - `test_const_computation_only`
  - `test_const_mixed`
  - `test_const_pipelined_gemm`
  - `test_const_missing_kwarg_errors`
  - `test_const_cache_isolation`
  - `test_const_float_value`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->