### PR TITLE
[BugFix] Preserve if condition evaluation during fan-out

### DIFF
--- a/src/transform/if_stmt_binding.cc
+++ b/src/transform/if_stmt_binding.cc
@@ -199,11 +199,15 @@ private:
 
     Array<Stmt> guarded_stmts;
     PrimExpr guard_condition = condition;
-    // Fan-out must preserve the original if's single condition evaluation.
-    // Otherwise an earlier guarded body may mutate state read by a later guard.
-    if (SideEffect(condition) > CallEffectKind::kPure) {
-      Var condition_snapshot("if_condition", condition.dtype(), span);
-      guarded_stmts.push_back(Bind(condition_snapshot, condition, span));
+    Var condition_snapshot("if_condition", condition.dtype(), span);
+    Stmt condition_bind = Bind(condition_snapshot, condition, span);
+    auto [condition_reads, _] = CollectStmtAccessRegions(condition_bind);
+    const BufferSet write_buffers = CollectWriteBuffers(stmts);
+    // Replay a read-only condition when no guarded body can change its inputs.
+    // Otherwise preserve the original if's single condition evaluation.
+    if (!IsReplayableScalarBind(condition_bind, condition_reads,
+                                write_buffers)) {
+      guarded_stmts.push_back(condition_bind);
       guard_condition = condition_snapshot;
     }
     for (const Stmt &stmt : stmts) {

--- a/src/transform/if_stmt_binding.cc
+++ b/src/transform/if_stmt_binding.cc
@@ -190,14 +190,36 @@ private:
     return IfThenElse(condition, stmt, Stmt(), span);
   }
 
+  Stmt GuardStmts(const Array<Stmt> &stmts, const PrimExpr &condition,
+                  Span span) const {
+    ICHECK(!stmts.empty());
+    if (stmts.size() == 1) {
+      return GuardStmt(condition, stmts[0], span);
+    }
+
+    Array<Stmt> guarded_stmts;
+    PrimExpr guard_condition = condition;
+    // Fan-out must preserve the original if's single condition evaluation.
+    // Otherwise an earlier guarded body may mutate state read by a later guard.
+    if (SideEffect(condition) > CallEffectKind::kPure) {
+      Var condition_snapshot("if_condition", condition.dtype(), span);
+      guarded_stmts.push_back(Bind(condition_snapshot, condition, span));
+      guard_condition = condition_snapshot;
+    }
+    for (const Stmt &stmt : stmts) {
+      guarded_stmts.push_back(GuardStmt(guard_condition, stmt, span));
+    }
+    return MakeSeq(std::move(guarded_stmts));
+  }
+
   Stmt BindIfStmtLegacy(const Stmt &body, const PrimExpr &condition,
                         Span span) const {
     if (auto seq_stmt = body.as<SeqStmtNode>()) {
-      Array<Stmt> seq;
+      Array<Stmt> guarded_bodies;
       const size_t n = seq_stmt->seq.size();
       size_t i = 0;
       for (; i < n && !seq_stmt->seq[i].as<BindNode>(); ++i) {
-        seq.push_back(GuardStmt(condition, seq_stmt->seq[i], span));
+        guarded_bodies.push_back(seq_stmt->seq[i]);
       }
 
       // A direct Bind is emitted as a C/CUDA declaration. Keep it and the
@@ -208,10 +230,9 @@ private:
         for (; i < n; ++i) {
           bind_scope.push_back(seq_stmt->seq[i]);
         }
-        seq.push_back(
-            GuardStmt(condition, MakeSeq(std::move(bind_scope)), span));
+        guarded_bodies.push_back(MakeSeq(std::move(bind_scope)));
       }
-      return MakeSeq(std::move(seq));
+      return GuardStmts(guarded_bodies, condition, span);
     }
     return GuardStmt(condition, body, span);
   }
@@ -229,7 +250,7 @@ private:
 
     const BufferSet write_buffers = CollectWriteBuffers(seq_stmt->seq);
     Map<Var, PrimExpr> replayable_binds;
-    Array<Stmt> guarded_stmts;
+    Array<Stmt> guarded_bodies;
     Array<Stmt> bind_scope;
     bool in_bind_scope = false;
 
@@ -246,22 +267,20 @@ private:
           in_bind_scope = true;
           continue;
         }
-        guarded_stmts.push_back(GuardStmt(
-            condition, RewriteWithReplayableBinds(stmt, replayable_binds),
-            span));
+        guarded_bodies.push_back(
+            RewriteWithReplayableBinds(stmt, replayable_binds));
         continue;
       }
       bind_scope.push_back(RewriteWithReplayableBinds(stmt, replayable_binds));
     }
 
     if (!bind_scope.empty()) {
-      guarded_stmts.push_back(
-          GuardStmt(condition, MakeSeq(std::move(bind_scope)), span));
+      guarded_bodies.push_back(MakeSeq(std::move(bind_scope)));
     }
-    if (guarded_stmts.empty()) {
+    if (guarded_bodies.empty()) {
       return Evaluate(0, span);
     }
-    return MakeSeq(std::move(guarded_stmts));
+    return GuardStmts(guarded_bodies, condition, span);
   }
 
   Stmt VisitStmt_(const IfThenElseNode *op) final {

--- a/testing/python/issue/test_tilelang_issue_merge_if.py
+++ b/testing/python/issue/test_tilelang_issue_merge_if.py
@@ -51,5 +51,23 @@ def test_merge_if_preserves_re_evaluation_of_buffer_condition():
     np.testing.assert_array_equal(values.numpy(), np.array([0, 7], dtype="int32"))
 
 
+def test_if_stmt_binding_and_merge_if_preserve_single_evaluation():
+    @T.prim_func
+    def main(A: T.Tensor((2,), T.int32)):
+        if A[0] > 0:
+            A[0] = 0
+            A[1] = 1
+
+    transformed = IRModule.from_expr(main)
+    transformed = tilelang.transform.IfStmtBinding()(transformed)
+    transformed = tilelang.transform.MergeIfStmt()(transformed)
+    executable = tvm.compile(transformed["main"], target="c").jit(options=["-std=c++17"])
+
+    values = tvm.runtime.tensor(np.array([1, 7], dtype="int32"))
+    executable(values)
+
+    np.testing.assert_array_equal(values.numpy(), np.array([0, 1], dtype="int32"))
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_if_stmt_binding.py
+++ b/testing/python/transform/test_tilelang_transform_if_stmt_binding.py
@@ -51,6 +51,24 @@ def test_if_stmt_binding_does_not_snapshot_pure_condition():
     tvm.ir.assert_structural_equal(after.body, expected.body, True)
 
 
+def test_if_stmt_binding_replays_condition_disjoint_from_body_writes():
+    @T.prim_func
+    def before(A: T.Buffer((1,), "float32"), B: T.Buffer((2,), "float32")):
+        if A[0] >= T.float32(0):
+            B[0] = T.float32(1)
+            B[1] = T.float32(2)
+
+    @T.prim_func
+    def expected(A: T.Buffer((1,), "float32"), B: T.Buffer((2,), "float32")):
+        if A[0] >= T.float32(0):
+            B[0] = T.float32(1)
+        if A[0] >= T.float32(0):
+            B[1] = T.float32(2)
+
+    after = _run_if_stmt_binding(before)
+    tvm.ir.assert_structural_equal(after.body, expected.body, True)
+
+
 def test_if_stmt_binding_keeps_direct_bind_scope():
     @T.prim_func
     def before(A: T.Buffer((4,), "float32"), B: T.Buffer((4,), "float32")):
@@ -84,10 +102,9 @@ def test_if_stmt_binding_inlines_replayable_bind_by_default():
 
     @T.prim_func
     def expected(A: T.Buffer((4,), "float32"), B: T.Buffer((4,), "float32")):
-        condition = T.bind(A[0] >= T.float32(0))
-        if condition:
+        if A[0] >= T.float32(0):
             B[0] = A[1] + T.float32(2)
-        if condition:
+        if A[0] >= T.float32(0):
             B[1] = A[1] + T.float32(2) + T.float32(1)
 
     after = _run_if_stmt_binding(before)

--- a/testing/python/transform/test_tilelang_transform_if_stmt_binding.py
+++ b/testing/python/transform/test_tilelang_transform_if_stmt_binding.py
@@ -19,9 +19,32 @@ def test_if_stmt_binding_splits_plain_seq_stmt():
 
     @T.prim_func
     def expected(A: T.Buffer((4,), "float32")):
-        if A[0] >= T.float32(0):
+        condition = T.bind(A[0] >= T.float32(0))
+        if condition:
             A[0] = T.float32(1)
-        if A[0] >= T.float32(0):
+        if condition:
+            A[1] = T.float32(2)
+
+    after = _run_if_stmt_binding(before)
+    tvm.ir.assert_structural_equal(after.body, expected.body, True)
+
+    config_key = tilelang.PassConfigKey.TL_IF_STMT_BINDING_INLINE_REPLAYABLE_BINDS.value
+    legacy_after = _run_if_stmt_binding(before, config={config_key: False})
+    tvm.ir.assert_structural_equal(legacy_after.body, expected.body, True)
+
+
+def test_if_stmt_binding_does_not_snapshot_pure_condition():
+    @T.prim_func
+    def before(flag: T.int32, A: T.Buffer((2,), "float32")):
+        if flag > 0:
+            A[0] = T.float32(1)
+            A[1] = T.float32(2)
+
+    @T.prim_func
+    def expected(flag: T.int32, A: T.Buffer((2,), "float32")):
+        if flag > 0:
+            A[0] = T.float32(1)
+        if flag > 0:
             A[1] = T.float32(2)
 
     after = _run_if_stmt_binding(before)
@@ -39,9 +62,10 @@ def test_if_stmt_binding_keeps_direct_bind_scope():
 
     @T.prim_func
     def expected(A: T.Buffer((4,), "float32"), B: T.Buffer((4,), "float32")):
-        if A[0] >= T.float32(0):
+        condition = T.bind(A[0] >= T.float32(0))
+        if condition:
             A[0] = T.float32(1)
-        if A[0] >= T.float32(0):
+        if condition:
             bound = T.bind(A[1] + T.float32(2))
             B[0] = bound
             B[1] = bound + T.float32(1)
@@ -60,9 +84,10 @@ def test_if_stmt_binding_inlines_replayable_bind_by_default():
 
     @T.prim_func
     def expected(A: T.Buffer((4,), "float32"), B: T.Buffer((4,), "float32")):
-        if A[0] >= T.float32(0):
+        condition = T.bind(A[0] >= T.float32(0))
+        if condition:
             B[0] = A[1] + T.float32(2)
-        if A[0] >= T.float32(0):
+        if condition:
             B[1] = A[1] + T.float32(2) + T.float32(1)
 
     after = _run_if_stmt_binding(before)


### PR DESCRIPTION
## Motivation

`IfStmtBinding` fans an `if` body out into one guarded statement per body
statement.  #2744 correctly prevents `MergeIfStmt` from merging independently
authored state-reading conditions, because those conditions must be
re-evaluated.  The generated guards from one original `if`, however, must keep
the original single condition evaluation.

Without that distinction, an earlier generated guard can mutate state read by
a later guard.  For example, resetting the innermost tensor index makes the
next generated carry guard false, so outer indices no longer advance.

This is a follow-up to #2744 and the wrong-code report in #2538.

## Changes

- collect the bodies produced by `IfStmtBinding` before wrapping them in guards
- replay pure/read-only conditions when guarded bodies cannot modify their
  inputs; otherwise bind the condition once and reuse that snapshot
- leave pure conditions and single guarded bodies unchanged
- add a CPU-only runtime regression covering `IfStmtBinding` followed by
  `MergeIfStmt`, alongside #2744's independent-if regression
- cover both default and legacy bind handling, and verify pure conditions do
  not gain a snapshot

## Testing

- `cmake -S . -B build && cmake --build build -j$(nproc)`
- `python -m pytest testing/python/issue/test_tilelang_issue_merge_if.py testing/python/transform/test_tilelang_transform_if_stmt_binding.py -q` (`12 passed`)
- the four block-sparse pipeline tests that failed the first CUDA CI run (`4 passed`)
- related pipeline-planning, lexical-scope, and allocation-location tests (`31 passed`)
- full transform suite excluding one unrelated CUDA 13.1 `half_t` conversion failure (`339 passed, 7 skipped`)
- original `normal_kernel` reproducer (`33 passed`)
- pre-commit on all three changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Preserve single evaluation of state-reading `if` conditions when `IfStmtBinding` fans out guarded statements by binding the condition once to a fresh boolean and reusing it across generated guards.
- Centralize guard generation with a new `GuardStmts` helper that snapshots only potentially invalidated conditions; replayable read-only and pure conditions continue to be reused without snapshots.
- Refactor both `BindIfStmtLegacy` and `BindIfStmtWithReplayableBindInlining` to collect `IfStmtBinding` bodies first, then apply guarding once at the end (including correct handling of grouped `bind_scope` sequences), instead of emitting per-element guarded statements.
- Add/verify CPU-only runtime regressions for default and legacy bind handling, including ensuring pure conditions are not snapshotted and exercising `MergeIfStmt` interactions.

## Testing

- Passed targeted, related, transform-suite, reproducer, build, and pre-commit checks; one unrelated CUDA 13.1 `half_t` conversion failure remains excluded from the full transform suite.
- CUDA CI failures/spot checks and transform/pipeline-planning verification are reported as passing according to the PR’s verification notes.

## C++ style / lint notes

- This PR touches C++ implementation and related transform/tests, but does not update rules documented in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” remains advisory; no new blocking correctness/build issues or new TLCPP003/TLCPP004-style findings are indicated by the PR changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->