### PR TITLE
[BugFix] Add arithmetic operators to vec_type in common.h for CPU codegen

### DIFF
--- a/reproducer_vec_type.py
+++ b/reproducer_vec_type.py
@@ -1,0 +1,37 @@
+"""
+Minimal reproducer for the missing vec_type arithmetic operators in common.h.
+
+Without the fix, compiling a CPU kernel with `c` target fails:
+  error: no match for 'operator-' (operand types are 'float4' and 'float4')
+
+Requires: tilelang, torch
+"""
+
+import tilelang
+import tilelang.language as T
+import torch
+
+
+@T.prim_func
+def vec_add(
+    A: T.Tensor((256,), "float32"),
+    B: T.Tensor((256,), "float32"),
+    C: T.Tensor((256,), "float32"),
+):
+    for i in T.Parallel(256):
+        C[i] = A[i] + B[i]
+
+
+def main():
+    f = tilelang.compile(vec_add, target="c")
+    A = torch.randn(256)
+    B = torch.randn(256)
+    C = torch.zeros(256)
+    f(A, B, C)
+    ref = A + B
+    assert (C - ref).abs().max().item() < 1e-5
+    print("OK: vec_add compiled and ran successfully")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tl_templates/cpp/common.h
+++ b/src/tl_templates/cpp/common.h
@@ -19,6 +19,51 @@ template <typename T, int N> struct vec_type {
     for (int i = 0; i < N; i++)
       data[i] = v;
   }
+  vec_type operator+(const vec_type &o) const {
+    vec_type r;
+    for (int i = 0; i < N; i++)
+      r.data[i] = data[i] + o.data[i];
+    return r;
+  }
+  vec_type operator-(const vec_type &o) const {
+    vec_type r;
+    for (int i = 0; i < N; i++)
+      r.data[i] = data[i] - o.data[i];
+    return r;
+  }
+  vec_type operator*(const vec_type &o) const {
+    vec_type r;
+    for (int i = 0; i < N; i++)
+      r.data[i] = data[i] * o.data[i];
+    return r;
+  }
+  vec_type operator/(const vec_type &o) const {
+    vec_type r;
+    for (int i = 0; i < N; i++)
+      r.data[i] = data[i] / o.data[i];
+    return r;
+  }
+  // Compound assignment — avoids temporary vec_type objects
+  vec_type &operator+=(const vec_type &o) {
+    for (int i = 0; i < N; i++)
+      data[i] += o.data[i];
+    return *this;
+  }
+  vec_type &operator-=(const vec_type &o) {
+    for (int i = 0; i < N; i++)
+      data[i] -= o.data[i];
+    return *this;
+  }
+  vec_type &operator*=(const vec_type &o) {
+    for (int i = 0; i < N; i++)
+      data[i] *= o.data[i];
+    return *this;
+  }
+  vec_type &operator/=(const vec_type &o) {
+    for (int i = 0; i < N; i++)
+      data[i] /= o.data[i];
+    return *this;
+  }
 };
 
 #define TL_DEFINE_VEC(T)                                                       \


### PR DESCRIPTION
## Problem

When the `c` target generates vectorized code via the AutoVectorize pass, it produces expressions like:

```cpp
*(float4*)(C + (i * 4)) = (*(float4*)(A + (i * 4)) - *(float4*)(B + (i * 4)));
```

PR #1901 introduced the `vec_type` template and its type aliases (`float4`, `int32_t4`, etc.), which resolved the `float4 was not declared in this scope` error. However, the arithmetic operators (`+`, `-`, `*`, `/`) for `vec_type` were not implemented, causing g++ to fail with:

```
error: no match for operator- (operand types are float4 {aka vec_type<float, 4>} and float4 {aka vec_type<float, 4>})
```

This error occurs on any platform where the C codegen uses the `vec_type` template instead of GCC native vector extensions (e.g., ARM64 macOS/Linux).

## Solution

Add the four arithmetic operators (`+`, `-`, `*`, `/`) to the `vec_type` struct in `src/tl_templates/cpp/common.h`.

## Verification

- A minimal reproducer (`reproducer_vec_type.py`) is included
- Verified on ARM64 macOS (M2) and ARM64 Linux (Neoverse-N1)
- All existing CPU `c` target tests pass after the fix

## Related

- PR #1901 introduced the initial vec_type definitions
- PR #2767 fixes a separate Metal codegen issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds element-wise arithmetic support to the `vec_type` C++ template for `+`, `-`, `*`, `/` and their compound-assignment forms. This fixes CPU C codegen failures when AutoVectorize emits expressions using vector aliases such as `float4` and `int32_t4`, including on ARM64 platforms.

Adds a minimal `vec_add` reproducer that compiles and validates a 256-element float32 vector addition through the C backend.

## Validation

- Verified on ARM64 macOS and ARM64 Linux.
- Existing CPU C-target tests pass.
- Reproducer validates output against the Torch reference within `1e-5`.

## C++ style / lint notes

- The PR changes C++ code but does not appear to touch rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) may report advisory findings for the added operators; these are warning-only and should not block merging absent a clear API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->