### PR TITLE
[BugFix] Add pre-SM80 fallback for bf16 __hfma

### DIFF
--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -190,8 +190,15 @@ TL_PATCH TL_DEVICE half_t __hfma(const half_t x, const half_t y,
 // __hfma function for bfloat16_t
 TL_PATCH TL_DEVICE bfloat16_t __hfma(const bfloat16_t x, const bfloat16_t y,
                                      const bfloat16_t z) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
   return bfloat16_t(
       __hfma(x.to_nv_bfloat16(), y.to_nv_bfloat16(), z.to_nv_bfloat16()));
+#else
+  // CUDA declares the native __nv_bfloat16 __hfma overload only for SM80+.
+  // On earlier targets (e.g. SM75) evaluate with an fp32 FMA and convert back
+  // to bf16, matching cutlass::bfloat16_t's own pre-SM80 arithmetic fallback.
+  return bfloat16_t(fmaf(float(x), float(y), float(z)));
+#endif
 }
 
 // TVM lowers T.exp(bfloat16) to the CUDA half-style `hexp` name. TileLang uses

--- a/testing/python/math/test_math_ieee_math.py
+++ b/testing/python/math/test_math_ieee_math.py
@@ -47,6 +47,7 @@ def run_ieee_math_test(
     block_N=16,
     dtype=T.float32,
     run_execution=True,
+    target="cuda",
 ):
     """
     Test IEEE-compliant math operations with specified rounding modes.
@@ -119,7 +120,7 @@ def run_ieee_math_test(
     kernel = tilelang.compile(
         main_func,
         out_idx=out_idx,
-        target="cuda",
+        target=target,
         pass_configs={
             tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: False,
         },
@@ -219,6 +220,31 @@ def test_ieee_half_non_rn_rejected():
         run_ieee_math_test("ieee_add", T.ieee_add, rounding_mode="rz", dtype=T.float16)
     with pytest.raises(Exception, match="Only rounding mode 'rn' is available for half precision"):
         run_ieee_math_test("ieee_add", T.ieee_add, rounding_mode="rz", dtype=T.bfloat16)
+
+
+# ---------------------------------------------------------------------------
+# Architecture regression — the bf16 __hfma wrapper in common.h must keep
+# compiling for pre-SM80 targets. See the bf16 __hfma guard in
+# src/tl_templates/cuda/common.h.
+# ---------------------------------------------------------------------------
+
+
+@tilelang.testing.requires_cuda
+def test_ieee_fmaf_bf16_compiles_for_sm75():
+    """bf16 ieee_fmaf lowers to __hfma, whose native __nv_bfloat16 overload
+    only exists on SM80+. common.h is pulled into every generated kernel, so an
+    unguarded wrapper breaks *all* SM75 builds, not just bf16 ones. Compile (do
+    not run) a bf16 fmaf kernel explicitly for sm_75 to pin the fallback path.
+    Compile-only, so it runs on any CUDA runner regardless of the host GPU arch
+    -- the parametrized tests above use target="cuda" and would only exercise
+    the SM80+ branch on a modern runner."""
+    run_ieee_math_test(
+        "ieee_fmaf",
+        T.ieee_fmaf,
+        dtype=T.bfloat16,
+        target={"kind": "cuda", "arch": "sm_75"},
+        run_execution=False,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

On SM75, every generated kernel fails to compile, including kernels with no bf16 in them:

```text
src/tl_templates/cuda/common.h(194): error: no instance of overloaded function "__hfma"
    matches the argument list -- argument types are: (__nv_bfloat16, __nv_bfloat16, __nv_bfloat16)
```

## Root cause

`common.h` defines a `bfloat16_t __hfma` wrapper that forwards to the `__nv_bfloat16` overload, but CUDA declares that overload only for `__CUDA_ARCH__ >= 800`. Targeting `sm_75` preprocesses the declaration away.

The wrapper is a non-template function, so its body is compiled even if nothing calls it, and `common.h` reaches every generated kernel through `reduce.h` / `scan.h`. That turns a bf16-only gap into a failure for all SM75 builds.

This is a regression from #2619: `common.h` compiled for `sm_75` before that change and fails after it.

## Fix

Guard the native path on SM80+ and evaluate in fp32 below it, matching the existing pre-SM80 bf16 fallbacks in `common.h` (`add2`, `mul2`, `max2`, ...). The SM80+ branch is unchanged, and `__hfma` is the only affected intrinsic—the other half/bf16 intrinsics used here compile for `sm_75`.

## Tested

* Added `test_ieee_fmaf_bf16_compiles_for_sm75`, which builds a bf16 `ieee_fmaf` kernel for an explicit `sm_75` target. It is compile-only, so it runs on any CUDA runner. The existing IEEE tests use `target="cuda"`, so an SM80+ runner only ever compiles the native branch, which is why this went unnoticed.
* Reverting the `common.h` change makes the new test fail with the error above.
* `test_math_ieee_math.py` on `sm_75`: 77 passed. Before the fix, nothing in it compiled.
* Fallback output matches an fp32-FMA reference bit-exactly.
* Verified locally on a TITAN RTX (`sm_75`, Turing) with CUDA 12.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added an SM80+ guard for the native bf16 `__hfma` implementation.
- Added an fp32 `fmaf`-based fallback with conversion to bf16 for pre-SM80 architectures, enabling SM75 kernel compilation.
- Made IEEE math test compilation targets configurable.
- Added a compile-only regression test for bf16 `ieee_fmaf` targeting SM75.

## Testing

- 77 math tests pass on SM75.
- Verified bit-exact fallback output against an fp32-FMA reference.
- Locally verified on a TITAN RTX with CUDA 12.4.

## C++ style / lint notes

- The PR changes CUDA C++ implementation code but does not appear to touch rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) CI step is relevant; no new public API declarations are introduced.
- No correctness or build issues are indicated. Any TLCPP003/TLCPP004 findings would be advisory only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->