### PR TITLE
[BugFix] Cast to the destination dtype in the scalar T.copy path

### DIFF
--- a/testing/python/language/test_tilelang_language_copy.py
+++ b/testing/python/language/test_tilelang_language_copy.py
@@ -279,6 +279,41 @@ def test_tilelang_copy_bufferload():
     run_tilelang_copy_bufferload(num_tokens=128)
 
 
+def tilelang_copy_bufferload_cross_dtype(num_tokens, index_dtype=T.int64):
+    @T.prim_func
+    def main(
+        indices: T.Tensor((num_tokens,), index_dtype),
+        out: T.Tensor((num_tokens,), T.int32),
+    ):
+        with T.Kernel(num_tokens, threads=1) as pid:
+            idx = T.alloc_local([1], T.int32)
+            T.copy(indices[pid], idx[0])
+            out[pid] = idx[0]
+
+    return main
+
+
+def run_tilelang_copy_bufferload_cross_dtype(num_tokens=128, index_dtype=T.int64):
+    program = tilelang_copy_bufferload_cross_dtype(num_tokens, index_dtype)
+    kernel = tilelang.compile(
+        program,
+        out_idx=[1],
+        pass_configs={tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True},
+    )
+    # Keep the range within the (possibly narrow) index dtype.
+    hi = 30000 if index_dtype == T.int16 else 1_000_000
+    indices = torch.randint(0, hi, (num_tokens,), dtype=getattr(torch, index_dtype), device="cuda")
+    out = kernel(indices)
+    torch.testing.assert_close(out, indices.to(torch.int32))
+
+
+@tilelang.testing.requires_cuda
+def test_tilelang_copy_bufferload_cross_dtype():
+    # int64 index into an int32 scratch -- the gather from #2689.
+    run_tilelang_copy_bufferload_cross_dtype(num_tokens=128, index_dtype=T.int64)
+    run_tilelang_copy_bufferload_cross_dtype(num_tokens=128, index_dtype=T.int16)
+
+
 def tilelang_copy_buffer_load_with_parallel(M, N, block_M, block_N, dtype=T.float16):
     @T.prim_func
     def main(

--- a/testing/python/language/test_tilelang_language_copy.py
+++ b/testing/python/language/test_tilelang_language_copy.py
@@ -302,7 +302,7 @@ def run_tilelang_copy_bufferload_cross_dtype(num_tokens=128, index_dtype=T.int64
     )
     # Keep the range within the (possibly narrow) index dtype.
     hi = 30000 if index_dtype == T.int16 else 1_000_000
-    indices = torch.randint(0, hi, (num_tokens,), dtype=getattr(torch, index_dtype), device="cuda")
+    indices = torch.randint(0, hi, (num_tokens,), dtype=index_dtype.as_torch(), device="cuda")
     out = kernel(indices)
     torch.testing.assert_close(out, indices.to(torch.int32))
 

--- a/tilelang/language/copy_op.py
+++ b/tilelang/language/copy_op.py
@@ -109,7 +109,13 @@ def copy(
     """
     src, dst = _normalize_copy_regions(src, dst)
     if isinstance(src, tirx.BufferLoad) and isinstance(dst, tirx.BufferLoad):
-        return tirx.BufferStore(dst.buffer, src, dst.indices)
+        # Scalar fast path. Mirror the dtype conversion the region path applies
+        # in copy.cc; cast to the load dtype, which is what BufferStore checks
+        # once index lanes are folded in.
+        value = src
+        if src.dtype != dst.dtype:
+            value = tirx.Cast(dst.dtype, src)
+        return tirx.BufferStore(dst.buffer, value, dst.indices)
 
     # Build annotations dict
     ann = annotations.copy() if annotations else {}


### PR DESCRIPTION
## Summary

A single-element `T.copy` fails when the source and destination dtypes differ:

```python
idx = T.alloc_local([1], "int32")
T.copy(indices[pid], idx[0])  # indices is int64
```

```text
TypeError: dtype mismatch on BufferStore: buffer's dtype is `int32`,
the lanes of indexing are: `1`, ..., but RHS's dtype is `int64`
```

This affects the common gather pattern of copying an int64 index tensor (PyTorch's default for `argsort` and `topk`) into an int32 on-device scratch buffer. The equivalent region copy already compiles and converts the value as expected.

## Root cause

When both operands are scalar `BufferLoad`s, `T.copy` takes a fast path that lowers directly to a `BufferStore` instead of going through `tl.tileop.copy`.

The general region path casts the loaded value to the destination dtype in `src/op/copy.cc`, but the scalar fast path stored the source value unchanged. The strict `BufferStore` constructor therefore rejected cross-dtype copies.

## Fix

Cast the source value to the destination `BufferLoad` dtype when the source and destination dtypes differ, matching the region-copy behavior. Using the `BufferLoad` dtype also preserves any index lanes. Same-dtype copies remain unchanged and do not receive an unnecessary cast.

## Tested

* Added `test_tilelang_copy_bufferload_cross_dtype`, covering int64-to-int32 narrowing and int16-to-int32 widening with runtime result validation.
* Confirmed that reverting the fix makes the new regression test fail with the original dtype-mismatch error.
* Verified `test_tilelang_language_copy.py` locally on a TITAN RTX (`sm_75`, Turing) with CUDA 12.4.

Fixes #2689


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed scalar `T.copy` operations between different dtypes by casting the source `tir.BufferLoad` to the destination `tir.BufferLoad` dtype before creating the `tir.BufferStore` (same-dtype copies remain unchanged).
- Matched the destination-dtype conversion behavior of existing region-copy semantics while preventing IR construction failures due to `BufferStore` dtype mismatches.
- Added CUDA regression coverage for cross-dtype integer copies—specifically int64→int32 narrowing and int16→int32 widening—with runtime output validation.

Fixes `#2689`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->