### PR TITLE
[BugFix] Resolve partial scalar reduce barrier participation

### DIFF
--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -7,6 +7,7 @@
 #define TVM_TL_BACKEND_COMMON_OP_REDUCE_H_
 
 #include "op/reduce.h"
+#include "backend/common/target_utils.h"
 #include "support/check.h"
 #include <tvm/ir/cast.h>
 #include <tvm/runtime/logging.h>
@@ -1117,7 +1118,13 @@ template <typename Impl> struct ReduceLowerer {
         }
         auto call = Call(clear_buffer->dtype, builtin::call_extern(),
                          thread_reduce_args);
-        stmts.push_back(BufferStore(clear_buffer, call, red_indices));
+        Stmt store = BufferStore(clear_buffer, call, red_indices);
+        if (reducing_threads > 32 &&
+            TargetHasSMVersionGE(lower_args.target, 90)) {
+          store = AttrStmt(Integer(0), "tl.deferred_scalar_allreduce_barrier",
+                           Integer(1), store);
+        }
+        stmts.push_back(store);
       }
 
       PrimExpr predicate = Bool(true);

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -5,6 +5,8 @@
 
 #include "support/check.h"
 #include <optional>
+#include <string>
+#include <tvm/ir/with_context.h>
 #include <tvm/ir/cast.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/s_tir/utils.h>
@@ -37,6 +39,119 @@ namespace tl {
 
 using namespace tirx;
 using namespace ffi;
+
+namespace {
+
+constexpr const char *kDeferredScalarAllReduceBarrier =
+    "tl.deferred_scalar_allreduce_barrier";
+
+class DeferredScalarAllReduceBarrierResolver : public StmtExprMutator {
+public:
+  static Stmt Resolve(Stmt stmt, const LowerArgs &lower_args) {
+    const auto *thread_var = lower_args.thread_index.as<VarNode>();
+    if (thread_var == nullptr || !TargetHasSMVersionGE(lower_args.target, 90)) {
+      return stmt;
+    }
+    const int64_t *block_threads = as_const_int(lower_args.thread_bounds->extent);
+    ICHECK(block_threads != nullptr);
+    DeferredScalarAllReduceBarrierResolver resolver(
+        GetRef<Var>(thread_var), *block_threads,
+        TargetCudaGetWarpSize(lower_args.target));
+    return resolver.VisitStmt(stmt);
+  }
+
+private:
+  DeferredScalarAllReduceBarrierResolver(Var thread_var, int64_t block_threads,
+                                         int warp_size)
+      : thread_var_(std::move(thread_var)), block_threads_(block_threads),
+        warp_size_(warp_size) {
+    analyzer_.Bind(thread_var_,
+                   Range::FromMinExtent(IntImm(thread_var_.dtype(), 0),
+                                        IntImm(thread_var_.dtype(), block_threads_)));
+  }
+
+  Stmt VisitStmt_(const ForNode *op) final {
+    With<arith::ConstraintContext> lower(&analyzer_, op->loop_var >= op->min);
+    With<arith::ConstraintContext> upper(
+        &analyzer_, op->loop_var < op->min + op->extent);
+    return StmtExprMutator::VisitStmt_(op);
+  }
+
+  Stmt VisitStmt_(const IfThenElseNode *op) final {
+    PrimExpr condition = VisitExpr(op->condition);
+    Stmt then_case;
+    {
+      With<arith::ConstraintContext> then_scope(&analyzer_, condition);
+      then_case = VisitStmt(op->then_case);
+    }
+    Optional<Stmt> else_case;
+    if (op->else_case.defined()) {
+      With<arith::ConstraintContext> else_scope(&analyzer_, !condition);
+      else_case = VisitStmt(op->else_case.value());
+    }
+    return IfThenElse(condition, then_case, else_case, op->span);
+  }
+
+  Stmt VisitStmt_(const AttrStmtNode *op) final {
+    if (op->attr_key != kDeferredScalarAllReduceBarrier) {
+      return StmtExprMutator::VisitStmt_(op);
+    }
+
+    Stmt body = VisitStmt(op->body);
+    auto store = body.as<BufferStoreNode>();
+    ICHECK(store != nullptr)
+        << "Deferred scalar AllReduce marker must wrap a BufferStore";
+    auto call = store->value.as<CallNode>();
+    ICHECK(call != nullptr)
+        << "Deferred scalar AllReduce marker must store a call";
+    if (call->args.empty()) {
+      return body;
+    }
+    auto symbol = call->args[0].as<StringImmNode>();
+    if (symbol == nullptr) {
+      return body;
+    }
+
+    std::string name = symbol->value;
+    size_t begin = name.find("tl::NamedBarrier<");
+    if (begin == std::string::npos) {
+      return body;
+    }
+    size_t count_begin = begin + std::string("tl::NamedBarrier<").size();
+    size_t count_end = name.find('>', count_begin);
+    ICHECK_NE(count_end, std::string::npos)
+        << "Malformed deferred scalar AllReduce symbol: " << name;
+
+    int64_t count = analyzer_.z3_prover.CountSatisfyingValues(
+        thread_var_, block_threads_, warp_size_);
+    auto bound = analyzer_.const_int_bound(thread_var_);
+    int64_t span = bound->max_value - bound->min_value + 1;
+    ICHECK_GT(count, 0)
+        << "Cannot determine the participating threads for scalar AllReduce";
+    ICHECK_EQ(bound->min_value, 0)
+        << "Partial scalar AllReduce must start at threadIdx.x = 0";
+    ICHECK_EQ(count, span)
+        << "Partial scalar AllReduce requires one contiguous thread range";
+    ICHECK_EQ(count % warp_size_, 0)
+        << "Partial scalar AllReduce requires a warp-aligned thread range";
+
+    name.replace(count_begin, count_end - count_begin, std::to_string(count));
+    Array<PrimExpr> args = call->args;
+    args.Set(0, StringImm(name));
+    auto rewritten_call = Call(call->dtype, call->op, args, call->annotations,
+                               call->span);
+    BufferStore rewritten_store = GetRef<BufferStore>(store);
+    rewritten_store.CopyOnWrite()->value = rewritten_call;
+    return rewritten_store;
+  }
+
+  arith::Analyzer analyzer_;
+  Var thread_var_;
+  int64_t block_threads_;
+  int warp_size_;
+};
+
+} // namespace
 
 static Buffer makeBufferWithLayout(const Buffer &buffer, const Layout &layout,
                                    Map<Var, Var> &var_remap) {
@@ -1193,6 +1308,8 @@ private:
     lower_args.require_smem_alignment = require_smem_alignment_callback;
 
     auto lowered = tile_op->Lower(lower_args, analyzer_);
+    lowered = DeferredScalarAllReduceBarrierResolver::Resolve(
+        std::move(lowered), lower_args);
 
     return IRMutatorWithAnalyzer::VisitStmt(lowered);
   }

--- a/testing/python/language/test_tilelang_language_reduce.py
+++ b/testing/python/language/test_tilelang_language_reduce.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import tilelang
 import tilelang as tl
 import tilelang.language as T
@@ -56,6 +58,229 @@ def _reduce_op(T, op, src, dst, dim, batch=1):
         T.reduce_abssum(src, dst, dim=dim, **kwargs)
     elif op == "absmax":
         T.reduce_absmax(src, dst, dim=dim, **kwargs)
+
+
+def _make_partial_reduce_kernel() -> Any:
+    block_threads = 128
+    fragment_threads = 64
+    rows = 4
+    width = 512
+    vector_size = 8
+
+    @tilelang.jit(
+        out_idx=1,
+        target="cuda",
+        pass_configs={
+            tilelang.PassConfigKey.TL_DISABLE_DATA_RACE_CHECK: True,
+            tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+        },
+    )
+    def make_kernel():
+        def x_layout(i: int, j: int) -> tuple[int, int]:
+            return j // vector_size, i * vector_size + j % vector_size
+
+        @T.prim_func
+        def fragment_reduce(
+            x: T.Tensor((rows, width), "float32"),
+            out: T.Tensor((rows, width), "float32"),
+        ) -> None:
+            with T.Kernel(1, threads=block_threads):
+                x_frag = T.alloc_fragment((rows, width), "float32")
+                sum_frag = T.alloc_fragment((rows,), "float32")
+                T.annotate_layout(
+                    {
+                        x_frag: T.Fragment(x_frag.shape, forward_fn=x_layout),
+                        sum_frag: T.Fragment(
+                            sum_frag.shape,
+                            forward_fn=lambda i, rep: (rep, i),
+                            replicate=fragment_threads,
+                        ),
+                    }
+                )
+                for i, j in T.Parallel(rows, width):
+                    x_frag[i, j] = x[i, j]
+                T.reduce_sum(x_frag, sum_frag, dim=1)
+                for i, j in T.Parallel(rows, width):
+                    out[i, j] = x_frag[i, j] / sum_frag[i]
+
+        return fragment_reduce
+
+    return make_kernel()
+
+
+def _make_two_group_reduce_kernel() -> Any:
+    @tilelang.jit(out_idx=1, target="cuda")
+    def make_kernel():
+        def x_layout(i: int, j: int) -> tuple[int, int]:
+            return i * 64 + j // 8, j % 8
+
+        @T.prim_func
+        def two_group_reduce(
+            x: T.Tensor((2, 512), "float32"),
+            out: T.Tensor((2,), "float32"),
+        ) -> None:
+            with T.Kernel(1, threads=128):
+                x_frag = T.alloc_fragment((2, 512), "float32")
+                out_frag = T.alloc_fragment((2,), "float32")
+                T.annotate_layout(
+                    {
+                        x_frag: T.Fragment(x_frag.shape, forward_fn=x_layout),
+                        out_frag: T.Fragment(
+                            out_frag.shape,
+                            forward_fn=lambda i, rep: (i * 64 + rep, 0),
+                            replicate=64,
+                        ),
+                    }
+                )
+                for i, j in T.Parallel(2, 512):
+                    x_frag[i, j] = x[i, j]
+                T.reduce_sum(x_frag, out_frag, dim=1)
+                for i in T.Parallel(2):
+                    out[i] = out_frag[i]
+
+        return two_group_reduce
+
+    return make_kernel()
+
+
+def _make_disjoint_group_reduce_kernel() -> Any:
+    @tilelang.jit(
+        out_idx=1,
+        target="cuda",
+        pass_configs={
+            tilelang.PassConfigKey.TL_DISABLE_DATA_RACE_CHECK: True,
+            tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+        },
+    )
+    def make_kernel():
+        def first_group_layout(i: int, j: int) -> tuple[int, int]:
+            return j // 8, j % 8
+
+        def second_group_layout(i: int, j: int) -> tuple[int, int]:
+            return 64 + j // 8, j % 8
+
+        @T.prim_func
+        def disjoint_group_reduce(
+            x: T.Tensor((2, 512), "float32"),
+            out: T.Tensor((2,), "float32"),
+        ) -> None:
+            with T.Kernel(1, threads=128):
+                first = T.alloc_fragment((1, 512), "float32")
+                second = T.alloc_fragment((1, 512), "float32")
+                first_sum = T.alloc_fragment((1,), "float32")
+                second_sum = T.alloc_fragment((1,), "float32")
+                out_frag = T.alloc_fragment((2,), "float32")
+                T.annotate_layout(
+                    {
+                        first: T.Fragment(first.shape, forward_fn=first_group_layout),
+                        second: T.Fragment(second.shape, forward_fn=second_group_layout),
+                        first_sum: T.Fragment(
+                            first_sum.shape,
+                            forward_fn=lambda i, rep: (rep, 0),
+                            replicate=64,
+                        ),
+                        second_sum: T.Fragment(
+                            second_sum.shape,
+                            forward_fn=lambda i, rep: (64 + rep, 0),
+                            replicate=64,
+                        ),
+                        out_frag: T.Fragment(
+                            out_frag.shape,
+                            forward_fn=lambda i, rep: (i * 64 + rep, 0),
+                            replicate=64,
+                        ),
+                    }
+                )
+                for j in T.Parallel(512):
+                    first[0, j] = x[0, j]
+                for j in T.Parallel(512):
+                    second[0, j] = x[1, j]
+                T.reduce_sum(first, first_sum, dim=1)
+                T.reduce_sum(second, second_sum, dim=1)
+                for i in T.Parallel(2):
+                    out_frag[i] = first_sum[0] if i == 0 else second_sum[0]
+                T.copy(out_frag, out)
+
+        return disjoint_group_reduce
+
+    return make_kernel()
+
+
+def _make_partial_warp_reduce_kernel() -> Any:
+    @tilelang.jit(
+        out_idx=1,
+        target="cuda",
+        pass_configs={
+            tilelang.PassConfigKey.TL_DISABLE_DATA_RACE_CHECK: True,
+            tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
+        },
+    )
+    def make_kernel():
+        @T.prim_func
+        def partial_warp_reduce(
+            x: T.Tensor((1, 384), "float32"),
+            out: T.Tensor((1,), "float32"),
+        ) -> None:
+            with T.Kernel(1, threads=128):
+                x_frag = T.alloc_fragment((1, 384), "float32")
+                sum_frag = T.alloc_fragment((1,), "float32")
+                T.annotate_layout(
+                    {
+                        x_frag: T.Fragment(
+                            x_frag.shape,
+                            forward_fn=lambda i, j: (j // 8, j % 8),
+                        ),
+                        sum_frag: T.Fragment(
+                            sum_frag.shape,
+                            forward_fn=lambda i, rep: (rep, 0),
+                            replicate=48,
+                        ),
+                    }
+                )
+                for i, j in T.Parallel(1, 384):
+                    x_frag[i, j] = x[i, j]
+                T.reduce_sum(x_frag, sum_frag, dim=1)
+                for i in T.Parallel(1):
+                    out[i] = sum_frag[i]
+
+        return partial_warp_reduce
+
+    return make_kernel()
+
+
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_reduce_partial_thread_barrier_correctness():
+    torch.manual_seed(0)
+    x = torch.rand((4, 512), dtype=torch.float32, device="cuda")
+    out = _make_partial_reduce_kernel()(x)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(
+        out,
+        x / x.sum(dim=1, keepdim=True),
+        rtol=1e-5,
+        atol=1e-6,
+    )
+
+
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_reduce_partial_thread_barrier_full_block_groups():
+    torch.manual_seed(1)
+    x = torch.rand((2, 512), dtype=torch.float32, device="cuda")
+    out = _make_two_group_reduce_kernel()(x)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(out, x.sum(dim=1), rtol=1e-5, atol=1e-5)
+
+
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_reduce_partial_thread_barrier_rejects_disjoint_groups():
+    with pytest.raises(Exception, match="must start at threadIdx.x = 0"):
+        _make_disjoint_group_reduce_kernel()
+
+
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_reduce_partial_thread_barrier_rejects_partial_warp():
+    with pytest.raises(Exception, match="warp-aligned thread range"):
+        _make_partial_warp_reduce_kernel()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
`T.reduce` will produce wrong barriers counts in `SM >= 90`.

This can be reproduced with

```python
"""Reproduce a conditional 128-thread barrier generated by TileLang."""

from __future__ import annotations

from typing import Any

import tilelang
import tilelang.language as T

BLOCK_THREADS = 128
FRAGMENT_THREADS = 64
ROWS = 4
WIDTH = 512
VECTOR_SIZE = 8


@tilelang.jit(
    out_idx=1,
    target="cuda",
    pass_configs={
        tilelang.PassConfigKey.TL_DISABLE_DATA_RACE_CHECK: True,
        tilelang.PassConfigKey.TL_DISABLE_THREAD_STORAGE_SYNC: True,
    },
)
def make_repro_kernel() -> Any:
    def x_layout(i: int, j: int) -> tuple[int, int]:
        # j // 8 is in [0, 64), so only threads 0..63 own x_frag.
        thread_id = j // VECTOR_SIZE
        local_id = i * VECTOR_SIZE + j % VECTOR_SIZE
        return thread_id, local_id

    @T.prim_func
    def fragment_reduce(
        x: T.Tensor((ROWS, WIDTH), "float32"),
        out: T.Tensor((ROWS, WIDTH), "float32"),
    ) -> None:
        with T.Kernel(1, threads=BLOCK_THREADS):
            x_frag = T.alloc_fragment((ROWS, WIDTH), "float32")
            sum_frag = T.alloc_fragment((ROWS,), "float32")

            T.annotate_layout(
                {
                    x_frag: T.Fragment(x_frag.shape, forward_fn=x_layout),
                    sum_frag: T.Fragment(
                        sum_frag.shape,
                        forward_fn=lambda i, rep: (rep, i),
                        replicate=FRAGMENT_THREADS,
                    ),
                }
            )

            # T.Parallel -> T.reduce_sum -> T.Parallel is the trigger.
            for i, j in T.Parallel(ROWS, WIDTH):
                x_frag[i, j] = x[i, j]

            T.reduce_sum(x_frag, sum_frag, dim=1)

            for i, j in T.Parallel(ROWS, WIDTH):
                out[i, j] = x_frag[i, j] / sum_frag[i]

    return fragment_reduce


def main() -> None:
    kernel = make_repro_kernel()
    print(kernel.get_kernel_source())


if __name__ == "__main__":
    main()
```

Now this issue is fixed by introducing intermediate representation in pass `LowerTileOp`.

Reduces that uses non-uniform registers layouts in a warp (e.g. using registers only in threads that `tx % 2 == 0`) or uses non-consecutive warps (e.g. `tx [0, 32)` and `tx [64, 92)`) will now be rejected by the compiler.

Extra tests over `T.reduce` are added.

The same issue will also occur in `SM < 90` and will be fixed in the upcomming PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes incorrect `T.reduce` barrier counts on SM ≥ 90 when scalar reductions only partially participate in barriers after `T.Parallel` operations.

- Defers scalar all-reduce barrier handling during `ReduceLowerer`, then resolves participating-thread counts in `LowerTileOp` using analyzer constraints.
- Rejects reductions with non-uniform warp register layouts or non-consecutive warp participation.
- Adds correctness and rejection tests for partial, grouped, disjoint, and partial-warp reductions.

## C++ style / lint notes

The PR changes C++ but does not alter documented rules in `docs/developer_guide/cpp_style.md`. The C++ API Style Audit is warning-only; any advisory findings should be evaluated separately from correctness, build, and test results and are not merge blockers absent a clear API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->