### PR TITLE
[BugFix] Fix rng_init after language dialect refactor

### DIFF
--- a/tilelang/cuda/language/random.py
+++ b/tilelang/cuda/language/random.py
@@ -29,7 +29,7 @@ def rng_init(seed, seq=None, off=0, generator="curandStatePhilox4_32_10_t") -> t
     seed = tirx.convert(seed)
     if seq is None:
         bx = T.get_block_binding()
-        ex = T.kernel.get_thread_extent()
+        ex = T.get_thread_extent()
         tx = T.get_thread_binding()
         id = tx + bx * ex
         seq = tirx.convert(id)

--- a/tilelang/language/common.py
+++ b/tilelang/language/common.py
@@ -36,8 +36,12 @@ from .kernel import (
     KernelLaunchFrame,  # noqa: F401
     get_thread_binding,  # noqa: F401
     get_thread_bindings,  # noqa: F401
+    get_thread_extent,  # noqa: F401
+    get_thread_extents,  # noqa: F401
     get_block_binding,  # noqa: F401
     get_block_bindings,  # noqa: F401
+    get_block_extent,  # noqa: F401
+    get_block_extents,  # noqa: F401
 )
 from .allocate import (
     alloc_var,  # noqa: F401
@@ -227,10 +231,14 @@ _LOCAL_EXPORTS = (
     "gemm_sp",
     "get_block_binding",
     "get_block_bindings",
+    "get_block_extent",
+    "get_block_extents",
     "get_lane_idx",
     "get_let_value",
     "get_thread_binding",
     "get_thread_bindings",
+    "get_thread_extent",
+    "get_thread_extents",
     "get_warp_idx",
     "get_warp_idx_sync",
     "has_let_value",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed `rng_init` to use `T.get_thread_extent()` after the language dialect refactor.
- Exported thread and block extent helpers through `tilelang.language.common`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->