### PR TITLE
[CUDA][Reduce] Fix packed AllReduce workspace pointer

### DIFF
--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -1145,7 +1145,7 @@ private:
         // Fallback: create a temporary frame (should be rare)
         workspace_stack_.emplace_back(Array<Buffer>{workspace});
       }
-      return workspace.access_ptr(2); // write
+      return workspace.access_ptr(kAccessReadWrite);
     };
 
     AllocMBarrierCallback mbarrier_callback =

--- a/testing/python/cuda/test_cuda_f32x2_intrinsics.py
+++ b/testing/python/cuda/test_cuda_f32x2_intrinsics.py
@@ -179,6 +179,35 @@ def _make_auto_vec_batched_reduce_kernel(reduce_func, *, rows=M, width=64, threa
     return main
 
 
+def _make_auto_vec_batched_reduce_workspace_kernel():
+    """Build a packed reduction whose cross-warp step uses shared workspace."""
+    rows = 4
+    width = 512
+    threads = 128
+    vec_size = 8
+
+    def fragment_layout(i, j):
+        linear = i * width + j
+        thread_id = linear // vec_size % threads
+        local_id = linear // (threads * vec_size) * vec_size + linear % vec_size
+        return thread_id, local_id
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((rows, width), dtype=T.float32),
+        C: T.Tensor((rows,), dtype=T.float32),
+    ):
+        with T.Kernel(1, threads=threads):
+            src = T.alloc_fragment((rows, width), T.float32)
+            dst = T.alloc_fragment((rows,), T.float32)
+            T.annotate_layout({src: T.Fragment(src.shape, forward_fn=fragment_layout)})
+            T.copy(A, src)
+            T.reduce_sum(src, dst, dim=1, batch=2)
+            T.copy(dst, C)
+
+    return main
+
+
 # ===================================================================
 # Parametrised op / dtype lists
 # ===================================================================
@@ -442,6 +471,21 @@ def test_correctness_auto_vec_batched_reduce_f32():
     a = torch.randn((M, 64), device="cuda", dtype=torch.float32)
     result = kernel(a)
     torch.testing.assert_close(result, torch.sum(a, dim=1), atol=1e-5, rtol=1e-5)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+def test_correctness_auto_vec_batched_reduce_f32_workspace():
+    func = _make_auto_vec_batched_reduce_workspace_kernel()
+    kernel = tilelang.compile(func, out_idx=[1], target="cuda")
+    source = kernel.get_kernel_source()
+    allreduce_call = next(line for line in source.splitlines() if "AllReduce<" in line)
+    assert "make_int2" not in allreduce_call
+    assert "(&(workspace[0]))" in allreduce_call
+
+    a = torch.randn((4, 512), device="cuda", dtype=torch.float32)
+    result = kernel(a)
+    torch.testing.assert_close(result, torch.sum(a, dim=1), atol=1e-4, rtol=1e-4)
 
 
 @tilelang.testing.requires_cuda


### PR DESCRIPTION
## Summary

- Update `3rdparty/tvm` to `d04be235be`, which includes [tile-ai/tvm#59](https://github.com/tile-ai/tvm/pull/59) and preserves vector dtypes while lowering `tvm_access_ptr`.
- Mark the compiler-generated cross-warp reduction workspace access as read-write.
- Add an SM100+ regression for a batched float32 reduction packed as `float32x2`.

## Problem

With `batch=2`, auto-vectorization packs two float32 reduction results into `float2`. The cross-warp reduction workspace therefore uses a vector-typed access pointer.

Before tile-ai/tvm#59, lowering expanded the scalar access offset into a ramp. CUDA codegen then emitted invalid pointer arithmetic such as:

    ((float*)workspace) + make_int2(0, 1)

NVCC rejects this because pointer arithmetic requires a scalar offset. With the updated TVM revision, the vector dtype remains on the buffer and the generated workspace argument is scalar-addressed:

    (&(workspace[0]))

The TileLang-side callback now uses `kAccessReadWrite`, preserving the actual scratch-buffer access mode instead of describing it as write-only.

## Reproduction

    import tilelang
    import tilelang.language as T
    import torch

    rows, width = 4, 512
    threads, vec_size = 128, 8

    def fragment_layout(i, j):
        linear = i * width + j
        thread_id = linear // vec_size % threads
        local_id = linear // (threads * vec_size) * vec_size + linear % vec_size
        return thread_id, local_id

    @T.prim_func
    def main(
        A: T.Tensor((rows, width), T.float32),
        B: T.Tensor((rows,), T.float32),
    ):
        with T.Kernel(1, threads=threads):
            src = T.alloc_fragment((rows, width), T.float32)
            dst = T.alloc_fragment((rows,), T.float32)
            T.annotate_layout({
                src: T.Fragment(src.shape, forward_fn=fragment_layout)
            })
            T.copy(A, src)
            T.reduce_sum(src, dst, dim=1, batch=2)
            T.copy(dst, B)

    kernel = tilelang.compile(main, out_idx=[1], target="cuda")
    source = kernel.get_kernel_source()
    print(next(line for line in source.splitlines() if "AllReduce<" in line))

    a = torch.randn((rows, width), device="cuda")
    torch.testing.assert_close(
        kernel(a), torch.sum(a, dim=1), atol=1e-4, rtol=1e-4
    )

## Validation

- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`
- `./format.sh`
- `python -m pytest testing/python/cuda/test_cuda_f32x2_intrinsics.py::test_correctness_auto_vec_batched_reduce_f32_workspace -q`
- `python -m pytest testing/python/cuda/test_cuda_f32x2_intrinsics.py testing/python/issue/test_tilelang_issue_2524.py -q -k reduce` (24 passed)
- `PYTHONPATH=python TVM_LIBRARY_PATH=../../build/lib python -m pytest tests/python/tirx-transform/test_tir_transform_lower_intrin.py -q -k vector_access_ptr` from `3rdparty/tvm`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the TVM submodule to preserve vector dtypes when lowering `tvm_access_ptr`, preventing invalid CUDA pointer arithmetic for packed AllReduce workspaces.
- Marked compiler-generated cross-warp reduction workspace accesses as read-write.
- Added an SM100+ regression test for batched `float32x2` reductions, verifying generated AllReduce workspace usage and numerical correctness.

## Validation

- Project builds and formatting checks.
- CUDA regression and reduction-related tests.
- TVM vector access-pointer lowering tests.

## C++ style / lint notes

- The PR changes C++ code but does not alter documented rules in `docs/developer_guide/cpp_style.md`.
- No new correctness or build issues are indicated.
- Any C++ API style audit findings are warning-only and should not block merging absent a clear API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->