### PR TITLE
[BugFix] Fix ROCm intrinsic resolution after language dialect refactor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ nvcc = [
     # On Windows, ship nvrtc through the runtime deps so `pip install tilelang`
     # works without a host CUDA install (TileLang JITs CUDA kernels via nvrtc).
     "nvidia-cuda-nvrtc>=13; platform_system == 'Windows'",
-    # cuRAND is required when kernels use tilelang.language.random
+    # cuRAND is required when kernels use tilelang.cuda.language.random
     "nvidia-curand>=10.4; platform_system == 'Windows'",
 ]
 

--- a/testing/python/amd/test_tilelang_ds_read_tr.py
+++ b/testing/python/amd/test_tilelang_ds_read_tr.py
@@ -13,7 +13,7 @@ ds_read_tr8_b64   – LDS transpose read, 64-bit, 8-element transpose.
 import pytest
 import torch
 import tilelang
-import tilelang.language as T
+from tilelang.rocm import language as T
 import tilelang.testing
 from tilelang.backend.target import determine_target
 from tilelang.rocm.target import target_is_gfx950

--- a/testing/python/language/test_tilelang_language_dialect.py
+++ b/testing/python/language/test_tilelang_language_dialect.py
@@ -26,9 +26,13 @@ CUDA_ONLY_NAMES = {
 
 ROCM_ONLY_NAMES = {
     "MatrixCoreIntrinEmitter",
+    "WMMAIntrinEmitter",
+    "ds_read_tr16_b64",
+    "ds_read_tr8_b64",
     "mfma",
     "rdna_wmma",
     "tvm_mfma",
+    "tvm_rdna_wmma",
 }
 
 
@@ -79,6 +83,44 @@ def test_rocm_language_composes_common_and_rocm_symbols():
     assert hasattr(T, "MatrixCoreIntrinEmitter")
     assert hasattr(T, "make_mfma_swizzle_layout")
     assert set(T.__all__) >= SHARED_LEGACY_TIR_EXPORTS
+
+
+@pytest.mark.parametrize(
+    ("emitter_name", "method_name", "mcpu", "expected_call"),
+    [
+        ("MatrixCoreIntrinEmitter", "mfma", "gfx942", "T.tvm_mfma"),
+        ("WMMAIntrinEmitter", "wmma", "gfx1100", "T.tvm_rdna_wmma"),
+    ],
+)
+def test_rocm_emitters_resolve_backend_tir_intrinsics(emitter_name, method_name, mcpu, expected_call):
+    from tilelang.rocm import intrinsics
+
+    target = tilelang.tvm.target.Target({"kind": "hip", "mcpu": mcpu})
+    emitter_cls = getattr(intrinsics, emitter_name)
+    emitter = emitter_cls(
+        a_dtype="float16",
+        b_dtype="float16",
+        accum_dtype="float32",
+        block_row_warps=1,
+        block_col_warps=1,
+        warp_row_tiles=16,
+        warp_col_tiles=16,
+        chunk=16,
+        target=target,
+    )
+    emit = getattr(emitter, method_name)
+    a_size = emitter.warp_rows * emitter.local_size_a
+    b_size = emitter.warp_cols * emitter.local_size_b
+    c_size = emitter.warp_rows * emitter.warp_cols * emitter.local_size_out
+
+    @common_language.prim_func
+    def main():
+        a_local = common_language.alloc_local((a_size,), "float16")
+        b_local = common_language.alloc_local((b_size,), "float16")
+        c_local = common_language.alloc_local((c_size,), "float32")
+        emit(a_local, b_local, c_local)
+
+    assert expected_call in main.script()
 
 
 def test_metal_language_owns_simdgroup_tir_exports():

--- a/testing/python/language/test_tilelang_language_dialect.py
+++ b/testing/python/language/test_tilelang_language_dialect.py
@@ -3,8 +3,8 @@ import importlib
 import pytest
 
 import tilelang
-import tilelang.language as default_language
-import tilelang.language.common as common_language
+import tilelang.language as T_default
+import tilelang.language.common as T_comm
 from tilelang.language.tir.exports import (
     CLASSIFIED_VENDOR_TIR_EXPORTS,
     CUDA_ONLY_TIR_EXPORTS,
@@ -39,29 +39,29 @@ ROCM_ONLY_NAMES = {
 def test_default_language_is_static_cuda_facade():
     from tilelang.cuda import language as cuda_language
 
-    assert tilelang.language is default_language
-    assert importlib.import_module("tilelang.language") is default_language
-    assert default_language.__tilelang_dialect__ == "cuda"
+    assert tilelang.language is T_default
+    assert importlib.import_module("tilelang.language") is T_default
+    assert T_default.__tilelang_dialect__ == "cuda"
     assert cuda_language.__tilelang_dialect__ == "cuda"
-    assert set(default_language.__all__) == set(cuda_language.__all__)
+    assert set(T_default.__all__) == set(cuda_language.__all__)
 
-    for name in default_language.__all__:
-        assert getattr(default_language, name) is getattr(cuda_language, name)
+    for name in T_default.__all__:
+        assert getattr(T_default, name) is getattr(cuda_language, name)
 
 
 def test_common_language_preserves_special_dsl_exports():
-    assert common_language.__tilelang_dialect__ == "common"
-    assert "__log" in common_language.__all__
-    assert hasattr(common_language, "__log")
-    assert CUDA_ONLY_TIR_EXPORTS.isdisjoint(common_language.__all__)
-    assert METAL_ONLY_TIR_EXPORTS.isdisjoint(common_language.__all__)
+    assert T_comm.__tilelang_dialect__ == "common"
+    assert "__log" in T_comm.__all__
+    assert hasattr(T_comm, "__log")
+    assert CUDA_ONLY_TIR_EXPORTS.isdisjoint(T_comm.__all__)
+    assert METAL_ONLY_TIR_EXPORTS.isdisjoint(T_comm.__all__)
 
 
 def test_cuda_language_composes_common_and_cuda_symbols():
     from tilelang.cuda import language as T
     from tilelang.cuda import debug as cuda_debug
 
-    assert T.copy is common_language.copy
+    assert T.copy is T_comm.copy
     assert T.tcgen05_mma is T.tcgen05_gemm
     assert T.tcgen05_mma_blockscaled is T.tcgen05_gemm_blockscaled
     assert T.wgmma_mma is T.wgmma_gemm
@@ -76,7 +76,7 @@ def test_rocm_language_composes_common_and_rocm_symbols():
     from tilelang.rocm import language as T
 
     assert T.__tilelang_dialect__ == "rocm"
-    assert T.copy is common_language.copy
+    assert T.copy is T_comm.copy
     assert T.mfma is T.tvm_mfma
     assert T.mfma_store is T.tvm_mfma_store
     assert set(T.__all__) >= ROCM_ONLY_NAMES
@@ -113,11 +113,11 @@ def test_rocm_emitters_resolve_backend_tir_intrinsics(emitter_name, method_name,
     b_size = emitter.warp_cols * emitter.local_size_b
     c_size = emitter.warp_rows * emitter.warp_cols * emitter.local_size_out
 
-    @common_language.prim_func
+    @T_comm.prim_func
     def main():
-        a_local = common_language.alloc_local((a_size,), "float16")
-        b_local = common_language.alloc_local((b_size,), "float16")
-        c_local = common_language.alloc_local((c_size,), "float32")
+        a_local = T_comm.alloc_local((a_size,), "float16")
+        b_local = T_comm.alloc_local((b_size,), "float16")
+        c_local = T_comm.alloc_local((c_size,), "float32")
         emit(a_local, b_local, c_local)
 
     assert expected_call in main.script()
@@ -168,8 +168,8 @@ def test_common_only_dialects_match_common_surface():
     from tilelang.cpu import language as cpu_language
     from tilelang.webgpu import language as webgpu_language
 
-    assert set(cpu_language.__all__) == set(common_language.__all__)
-    assert set(webgpu_language.__all__) == set(common_language.__all__)
+    assert set(cpu_language.__all__) == set(T_comm.__all__)
+    assert set(webgpu_language.__all__) == set(T_comm.__all__)
 
 
 def test_cuda_whole_module_implementations_live_under_cuda():

--- a/tilelang/rocm/intrinsics/mfma_macro_generator.py
+++ b/tilelang/rocm/intrinsics/mfma_macro_generator.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from tilelang import tvm as tvm
-import tilelang.language as T
+import tilelang.language.common as T
 import tilelang.language.dtypes as _dtypes
 from tvm import DataType
 from tvm import tirx
@@ -469,6 +469,9 @@ class MatrixCoreIntrinEmitter:
         return _warp_ldmatrix_b(B_local_buf, B_shared_buf, ki, thread_binding, rk)
 
     def mfma(self, A_local_buf: Buffer, B_local_buf: Buffer, C_local_buf: Buffer, k_inner: PrimExpr | None = 0):
+        # Import lazily to avoid a rocm.language -> rocm.intrinsics cycle.
+        from tilelang.rocm.language.tir import tvm_mfma
+
         warp_rows = self.warp_rows
         warp_cols = self.warp_cols
         local_size_a = self.local_size_a
@@ -489,7 +492,7 @@ class MatrixCoreIntrinEmitter:
         @T.macro
         def _warp_mfma(A_local_buf, B_local_buf, C_local_buf):
             for kp, i, j in T.grid(k_pack, warp_rows, warp_cols):
-                T.tvm_mfma(
+                tvm_mfma(
                     mfma_suffix,
                     "row",
                     "row",

--- a/tilelang/rocm/intrinsics/wmma_macro_generator.py
+++ b/tilelang/rocm/intrinsics/wmma_macro_generator.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-import tilelang.language as T
+import tilelang.language.common as T
 from tilelang import _ffi_api
 from tilelang import tvm as tvm
 from tvm import tirx
@@ -281,6 +281,9 @@ class WMMAIntrinEmitter:
     # ─────────────────────────────────────────────────────────────────────────
 
     def wmma(self, A_local_buf: Buffer, B_local_buf: Buffer, C_local_buf: Buffer, k_inner: PrimExpr | None = 0):
+        # Import lazily to avoid a rocm.language -> rocm.intrinsics cycle.
+        from tilelang.rocm.language.tir import tvm_rdna_wmma
+
         warp_rows = self.warp_rows
         warp_cols = self.warp_cols
         local_size_a = self.local_size_a
@@ -308,7 +311,7 @@ class WMMAIntrinEmitter:
                 # With hardware D layout: no A/B swap needed for either case.
                 # Both transposed and non-transposed B give correct results
                 # with A first, B second.
-                T.tvm_rdna_wmma(
+                tvm_rdna_wmma(
                     compute_out_dtype,
                     wmma_shape,
                     "row",


### PR DESCRIPTION
## Summary

- bind the MFMA and RDNA WMMA emitters to the backend-neutral common DSL
- resolve ROCm-only TIR intrinsics through lazy backend-specific imports
- make the gfx950 `ds_read_tr*` tests use the ROCm language dialect
- add host-only regression coverage for gfx942 MFMA and gfx1100 WMMA macro expansion
- update the stale cuRAND language-module reference

## Root cause

After the language dialect split in #2734, `tilelang.language` became the default CUDA facade. The ROCm emitters and gfx950 tests still used that facade for ROCm-only APIs, so macro expansion raised `AttributeError` for `tvm_mfma`, `tvm_rdna_wmma`, and `ds_read_tr*_b64`. This is the same class of migration gap fixed for `rng_init` in #2776.

The emitters now use `tilelang.language.common` for shared DSL constructs and lazily import ROCm TIR wrappers to avoid the `rocm.language -> rocm.intrinsics` initialization cycle.

## Validation

- `python3 -m pre_commit run --files pyproject.toml tilelang/rocm/intrinsics/mfma_macro_generator.py tilelang/rocm/intrinsics/wmma_macro_generator.py testing/python/amd/test_tilelang_ds_read_tr.py testing/python/language/test_tilelang_language_dialect.py`
- `python -m pytest testing/python/language/test_tilelang_language_dialect.py testing/python/language/test_tilelang_language_rand.py -x -q` (24 passed)
- backend dialect API identity audit: no mismatches for ROCm, Metal, CPU, or WebGPU
- gfx950 test collection: 4 tests collected

ROCm runtime execution was not available on the local NVIDIA host; the new MFMA/WMMA regression tests expand both macros without requiring ROCm hardware.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed ROCm intrinsic resolution after the language dialect split.
- Bound MFMA and RDNA WMMA emitters to the common DSL with lazy ROCm TIR imports.
- Updated gfx950 `ds_read_tr*` tests to use the ROCm dialect.
- Added host-only regression coverage for gfx942 MFMA and gfx1100 WMMA expansion.
- Updated the stale cuRAND language-module reference.

## Validation

- Pre-commit checks passed.
- 24 language tests passed.
- Backend dialect API identity checks passed.
- Four gfx950 tests collected.
- ROCm runtime execution was not performed because validation ran on NVIDIA hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->