### PR TITLE
[BugFix] Fix fp16/bf16 `T.atomic_max`/`atomic_min` silently corrupting fp32 values

### DIFF
--- a/src/tl_templates/cuda/atomic.h
+++ b/src/tl_templates/cuda/atomic.h
@@ -259,7 +259,8 @@ TL_DEVICE void AtomicMax(T1 *ref, T2 val,
     // We simulate this process by atomicCAS loop.
     unsigned short *address_as_ushort =
         reinterpret_cast<unsigned short *>(address);
-    unsigned short val_as_ushort = *reinterpret_cast<unsigned short *>(&val);
+    unsigned short val_as_ushort =
+        tl_atomic_detail::PackBits16(cuda_cast<NT1>(val));
     unsigned short old_val_ushort = *address_as_ushort;
     while (val > *reinterpret_cast<T1 *>(&old_val_ushort)) {
       unsigned short assumed_val_ushort = old_val_ushort;
@@ -288,7 +289,8 @@ TL_DEVICE T1 AtomicMaxRet(T1 *ref, T2 val,
                 std::is_same_v<NT1, __nv_bfloat16>) {
     unsigned short *address_as_ushort =
         reinterpret_cast<unsigned short *>(address);
-    unsigned short val_as_ushort = *reinterpret_cast<unsigned short *>(&val);
+    unsigned short val_as_ushort =
+        tl_atomic_detail::PackBits16(cuda_cast<NT1>(val));
     unsigned short old_val_ushort = *address_as_ushort;
     while (val > *reinterpret_cast<T1 *>(&old_val_ushort)) {
       unsigned short assumed_val_ushort = old_val_ushort;
@@ -321,7 +323,8 @@ TL_DEVICE void AtomicMin(T1 *ref, T2 val,
     // We simulate this process by atomicCAS loop.
     unsigned short *address_as_ushort =
         reinterpret_cast<unsigned short *>(address);
-    unsigned short val_as_ushort = *reinterpret_cast<unsigned short *>(&val);
+    unsigned short val_as_ushort =
+        tl_atomic_detail::PackBits16(cuda_cast<NT1>(val));
     unsigned short old_val_ushort = *address_as_ushort;
     while (val < *reinterpret_cast<T1 *>(&old_val_ushort)) {
       unsigned short assumed_val_ushort = old_val_ushort;
@@ -350,7 +353,8 @@ TL_DEVICE T1 AtomicMinRet(T1 *ref, T2 val,
                 std::is_same_v<NT1, __nv_bfloat16>) {
     unsigned short *address_as_ushort =
         reinterpret_cast<unsigned short *>(address);
-    unsigned short val_as_ushort = *reinterpret_cast<unsigned short *>(&val);
+    unsigned short val_as_ushort =
+        tl_atomic_detail::PackBits16(cuda_cast<NT1>(val));
     unsigned short old_val_ushort = *address_as_ushort;
     while (val < *reinterpret_cast<T1 *>(&old_val_ushort)) {
       unsigned short assumed_val_ushort = old_val_ushort;

--- a/testing/python/language/test_tilelang_language_atomic.py
+++ b/testing/python/language/test_tilelang_language_atomic.py
@@ -574,6 +574,61 @@ def test_atomic_min():
     run_atomic_min(4, 64, 64, 16, 16)
 
 
+# ======== fp16/bf16 scalar max/min value-dtype conversion (issue #2758) ========
+
+
+def run_atomic_max_scalar_literal(dtype):
+    @tilelang.jit
+    def wrapper():
+        @T.prim_func
+        def kernel(dst: T.Tensor((1,), dtype)):
+            with T.Kernel(1, threads=1):
+                T.atomic_max(dst[0], 42.0)  # python float literal is fp32
+
+        return kernel
+    kernel = wrapper()
+    dst = torch.full((1,), -1e4, device="cuda", dtype=getattr(torch, dtype))
+    kernel(dst)
+    torch.testing.assert_close(dst, torch.full((1,), 42.0, device="cuda", dtype=getattr(torch, dtype)))
+
+
+def run_atomic_min_scalar_literal(dtype):
+    @tilelang.jit
+    def wrapper():
+        @T.prim_func
+        def kernel(dst: T.Tensor((1,), dtype)):
+            with T.Kernel(1, threads=1):
+                T.atomic_min(dst[0], 42.0)  # python float literal is fp32
+
+        return kernel
+    kernel = wrapper()
+    dst = torch.full((1,), 1e4, device="cuda", dtype=getattr(torch, dtype))
+    kernel(dst)
+    torch.testing.assert_close(dst, torch.full((1,), 42.0, device="cuda", dtype=getattr(torch, dtype)))
+
+
+@tilelang.testing.requires_cuda
+def test_atomic_max_scalar_fp16():
+    run_atomic_max_scalar_literal("float16")
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(8, 0)
+def test_atomic_max_scalar_bf16():
+    run_atomic_max_scalar_literal("bfloat16")
+
+
+@tilelang.testing.requires_cuda
+def test_atomic_min_scalar_fp16():
+    run_atomic_min_scalar_literal("float16")
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(8, 0)
+def test_atomic_min_scalar_bf16():
+    run_atomic_min_scalar_literal("bfloat16")
+
+
 @tilelang.testing.requires_cuda
 def test_atomic_load_store():
     run_atomic_load_store(64, 64, 16, 16)

--- a/testing/python/language/test_tilelang_language_atomic.py
+++ b/testing/python/language/test_tilelang_language_atomic.py
@@ -586,6 +586,7 @@ def run_atomic_max_scalar_literal(dtype):
                 T.atomic_max(dst[0], 42.0)  # python float literal is fp32
 
         return kernel
+
     kernel = wrapper()
     dst = torch.full((1,), -1e4, device="cuda", dtype=getattr(torch, dtype))
     kernel(dst)
@@ -601,6 +602,7 @@ def run_atomic_min_scalar_literal(dtype):
                 T.atomic_min(dst[0], 42.0)  # python float literal is fp32
 
         return kernel
+
     kernel = wrapper()
     dst = torch.full((1,), 1e4, device="cuda", dtype=getattr(torch, dtype))
     kernel(dst)


### PR DESCRIPTION
`T.atomic_max`/`T.atomic_min` on a `float16`/`bfloat16` buffer silently stored a corrupted value when the operand was `float32`.
The fp16/bf16 atomic templates read the value's bytes via `*reinterpret_cast<unsigned short *>(&val)` without converting to the destination dtype.
For a 4-byte fp32 value this takes the low 2 bytes of the fp32 bits.

This PR converts the value via `cuda_cast<NT1>(val)` before packing to `unsigned short`, matching the fp16/bf16 `AtomicAdd` path.
This applies to four affected templates: `AtomicMax`, `AtomicMaxRet`, `AtomicMin`, `AtomicMinRet`.

Fixes #2758 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes silent corruption in `float16` and `bfloat16` `atomic_max`/`atomic_min` operations when given `float32` operands by converting values to the destination dtype before packing.

- Updated all four CUDA paths: `AtomicMax`, `AtomicMaxRet`, `AtomicMin`, and `AtomicMinRet`.
- Added CUDA regression tests covering scalar literals for both `float16` and `bfloat16`.
- Preserves destination-dtype rounding behavior.

## C++ style / lint notes

- The change touches C++ CUDA template code but does not alter documented API or style rules in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit remains warning-only; no correctness or build issues are indicated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->