### PR TITLE
[Enhancement] More compile-time guards for architecture-specific CUDA intrinsics

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -3540,6 +3540,9 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     std::string ab_type_str = tl::codegen::ptx::DTypeEnumToString(dtype_enum);
 
     need_tcgen05mma_instruction_h_ = true;
+    need_tcgen05_common_h_ = true;
+    this->PrintIndent();
+    this->stream << "tl::require_tcgen05mma_ss();\n";
     this->PrintIndent();
     std::string tcgen05_call =
         "tl::(tcgen05_name)<(ABType)(USE_2CTA_SUFFIX)>(uint64_t((desc_a) + "
@@ -3591,6 +3594,9 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
         std::string(", ") + (enable_2cta ? "true" : "false");
 
     need_tcgen05mma_instruction_h_ = true;
+    need_tcgen05_common_h_ = true;
+    this->PrintIndent();
+    this->stream << "tl::require_tcgen05mma_ts();\n";
     this->PrintIndent();
     std::string tcgen05_call =
         "tl::tcgen05mma_ts<(ABType)(USE_2CTA_SUFFIX)>( "
@@ -3640,6 +3646,9 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     auto dtype_enum = tl::codegen::ptx::DTypeFromString(kind_dtype);
 
     need_tcgen05mma_instruction_h_ = true;
+    need_tcgen05_common_h_ = true;
+    this->PrintIndent();
+    this->stream << "tl::require_tcgen05mma_blockscaled_ss();\n";
     this->PrintIndent();
     std::string tcgen05_call =
         "tl::(tcgen05_name)<(ABType), (USE_2CTA)>(uint64_t((desc_a) + "
@@ -3706,6 +3715,8 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     std::string col_offset = this->PrintExpr(op->args[4]);
     std::string dst_ptr = this->PrintExpr(op->args[5]);
     this->PrintIndent();
+    this->stream << "tl::require_tcgen05_ld();\n";
+    this->PrintIndent();
     this->stream << "tl::tcgen05_ld_32dp" << inst_bits << "bNx<" << chunks
                  << ", " << (pack16 ? "true" : "false") << ">("
                  << tmem_start_col << ", " << col_offset << ", " << dst_ptr
@@ -3720,6 +3731,8 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     std::string tmem_start_col = this->PrintExpr(op->args[3]);
     std::string col_offset = this->PrintExpr(op->args[4]);
     std::string src_ptr = this->PrintExpr(op->args[5]);
+    this->PrintIndent();
+    this->stream << "tl::require_tcgen05_st();\n";
     this->PrintIndent();
     this->stream << "tl::tcgen05_st_32dp" << inst_bits << "bNx<" << chunks
                  << ", " << (unpack16 ? "true" : "false") << ">("

--- a/src/tl_templates/cuda/barrier.h
+++ b/src/tl_templates/cuda/barrier.h
@@ -162,12 +162,22 @@ TL_DEVICE void mbarrier_cp_async_arrive_noinc(BarrierType &smem_mbar) {
                : "r"(smem_int_mbar));
 }
 
-TL_DEVICE void fence_proxy_async() {
+template <bool kDependentFalse = false> TL_DEVICE void fence_proxy_async() {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   asm volatile("fence.proxy.async.shared::cta;" : :);
+#else
+  static_assert(kDependentFalse,
+                "tl::fence_proxy_async requires sm_90 or later");
+#endif
 }
 
-TL_DEVICE void fence_barrier_init() {
+template <bool kDependentFalse = false> TL_DEVICE void fence_barrier_init() {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   asm volatile("fence.mbarrier_init.release.cluster;" : :);
+#else
+  static_assert(kDependentFalse,
+                "tl::fence_barrier_init requires sm_90 or later");
+#endif
 }
 
 // Indicate arrival of warp issuing TMA_STORE
@@ -175,7 +185,8 @@ template <bool kDependentFalse = false> TL_DEVICE void tma_store_arrive() {
 #if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   asm volatile("cp.async.bulk.commit_group;");
 #else
-  static_assert(kDependentFalse, "T.tma_store_arrive requires sm_90 or later");
+  static_assert(kDependentFalse,
+                "tl::tma_store_arrive requires sm_90 or later");
 #endif
 }
 
@@ -188,7 +199,7 @@ TL_DEVICE void tma_store_wait() {
     asm volatile("cp.async.bulk.wait_group %0;" : : "n"(Count) : "memory");
   }
 #else
-  static_assert(kDependentFalse, "T.tma_store_wait requires sm_90 or later");
+  static_assert(kDependentFalse, "tl::tma_store_wait requires sm_90 or later");
 #endif
 }
 

--- a/src/tl_templates/cuda/cluster.h
+++ b/src/tl_templates/cuda/cluster.h
@@ -11,37 +11,43 @@
 
 namespace tl {
 
+template <bool kDependentFalse = false>
 TL_DEVICE void cluster_arrive_relaxed() {
 #if defined(TILELANG_CLUSTER_ENABLED)
   asm volatile("barrier.cluster.arrive.relaxed.aligned;\n" : :);
 #else
-  TILELANG_UNREACHABLE("TILELANG_CLUSTER_ENABLED is not defined");
+  static_assert(kDependentFalse,
+                "tl::cluster_arrive_relaxed requires sm_90 or later");
 #endif
 }
 
-TL_DEVICE void cluster_arrive() {
+template <bool kDependentFalse = false> TL_DEVICE void cluster_arrive() {
 #if defined(TILELANG_CLUSTER_ENABLED)
   asm volatile("barrier.cluster.arrive.aligned;\n" : :);
 #else
-  TILELANG_UNREACHABLE("TILELANG_CLUSTER_ENABLED is not defined");
+  static_assert(kDependentFalse, "tl::cluster_arrive requires sm_90 or later");
 #endif
 }
 
-TL_DEVICE void cluster_wait() {
+template <bool kDependentFalse = false> TL_DEVICE void cluster_wait() {
 #if defined(TILELANG_CLUSTER_ENABLED)
   asm volatile("barrier.cluster.wait.aligned;\n" : :);
 #else
-  TILELANG_UNREACHABLE("TILELANG_CLUSTER_ENABLED is not defined");
+  static_assert(kDependentFalse, "tl::cluster_wait requires sm_90 or later");
 #endif
 }
 
-TL_DEVICE void cluster_sync() {
+template <bool kDependentFalse = false> TL_DEVICE void cluster_sync() {
+#if defined(TILELANG_CLUSTER_ENABLED)
   cluster_arrive();
   cluster_wait();
+#else
+  static_assert(kDependentFalse, "tl::cluster_sync requires sm_90 or later");
+#endif
 }
 
 // Returns the dim3 grid size in terms of number of clusters.
-TL_DEVICE dim3 cluster_grid_dims() {
+template <bool kDependentFalse = false> TL_DEVICE dim3 cluster_grid_dims() {
 #if defined(TILELANG_CLUSTER_ENABLED)
   uint32_t x, y, z;
   asm volatile("mov.u32 %0, %%nclusterid.x;\n" : "=r"(x) :);
@@ -49,12 +55,14 @@ TL_DEVICE dim3 cluster_grid_dims() {
   asm volatile("mov.u32 %0, %%nclusterid.z;\n" : "=r"(z) :);
   return {x, y, z};
 #else
-  TILELANG_UNREACHABLE("TILELANG_CLUSTER_ENABLED is not defined");
+  static_assert(kDependentFalse,
+                "tl::cluster_grid_dims requires sm_90 or later");
+  return {};
 #endif
 }
 
 // Returns the dim3 cluster rank in the grid.
-TL_DEVICE dim3 cluster_id_in_grid() {
+template <bool kDependentFalse = false> TL_DEVICE dim3 cluster_id_in_grid() {
 #if defined(TILELANG_CLUSTER_ENABLED)
   uint32_t x, y, z;
   asm volatile("mov.u32 %0, %%clusterid.x;\n" : "=r"(x) :);
@@ -62,12 +70,14 @@ TL_DEVICE dim3 cluster_id_in_grid() {
   asm volatile("mov.u32 %0, %%clusterid.z;\n" : "=r"(z) :);
   return {x, y, z};
 #else
-  TILELANG_UNREACHABLE("TILELANG_CLUSTER_ENABLED is not defined");
+  static_assert(kDependentFalse,
+                "tl::cluster_id_in_grid requires sm_90 or later");
+  return {};
 #endif
 }
 
 // Returns the dim3 cluster shape.
-TL_DEVICE dim3 cluster_shape() {
+template <bool kDependentFalse = false> TL_DEVICE dim3 cluster_shape() {
 #if defined(TILELANG_CLUSTER_ENABLED)
   uint32_t x, y, z;
   asm volatile("mov.u32 %0, %%cluster_nctaid.x;\n" : "=r"(x) :);
@@ -75,12 +85,13 @@ TL_DEVICE dim3 cluster_shape() {
   asm volatile("mov.u32 %0, %%cluster_nctaid.z;\n" : "=r"(z) :);
   return {x, y, z};
 #else
-  TILELANG_UNREACHABLE("TILELANG_CLUSTER_ENABLED is not defined");
+  static_assert(kDependentFalse, "tl::cluster_shape requires sm_90 or later");
+  return {};
 #endif
 }
 
 // Returns the relative dim3 block rank local to the cluster.
-TL_DEVICE dim3 block_id_in_cluster() {
+template <bool kDependentFalse = false> TL_DEVICE dim3 block_id_in_cluster() {
 #if defined(TILELANG_CLUSTER_ENABLED)
   uint32_t x, y, z;
   asm volatile("mov.u32 %0, %%cluster_ctaid.x;\n" : "=r"(x) :);
@@ -88,12 +99,14 @@ TL_DEVICE dim3 block_id_in_cluster() {
   asm volatile("mov.u32 %0, %%cluster_ctaid.z;\n" : "=r"(z) :);
   return {x, y, z};
 #else
-  TILELANG_UNREACHABLE("TILELANG_CLUSTER_ENABLED is not defined");
+  static_assert(kDependentFalse,
+                "tl::block_id_in_cluster requires sm_90 or later");
+  return {};
 #endif
 }
 
 // Get 1D ctaid in a cluster.
-TL_DEVICE int block_rank_in_cluster() {
+template <bool kDependentFalse = false> TL_DEVICE int block_rank_in_cluster() {
 #if defined(TILELANG_CLUSTER_ENABLED)
   // NOTE(wt): cluster_ctarank is a uint32_t inherently,
   // we return as int32 for TL analysis convenience.
@@ -101,12 +114,15 @@ TL_DEVICE int block_rank_in_cluster() {
   asm volatile("mov.u32 %0, %%cluster_ctarank;\n" : "=r"(rank) :);
   return static_cast<int>(rank);
 #else
-  TILELANG_UNREACHABLE("TILELANG_CLUSTER_ENABLED is not defined");
+  static_assert(kDependentFalse,
+                "tl::block_rank_in_cluster requires sm_90 or later");
+  return {};
 #endif
 }
 
 /* Cluster launch control for tile schedule (Available on sm100) */
 
+template <bool kDependentFalse = false>
 TL_DEVICE void clc_try_cancel(void *result_ptr, void *mbar_ptr) {
 #if defined(CUTLASS_ARCH_CLC_ENABLED)
   uint32_t result_addr = smem_ptr_to_uint(result_ptr);
@@ -118,10 +134,13 @@ TL_DEVICE void clc_try_cancel(void *result_ptr, void *mbar_ptr) {
                :
                : "r"(result_addr), "r"(mbar_addr));
 #else
-  TILELANG_UNREACHABLE("CUTLASS_ARCH_CLC_ENABLED is not defined");
+  static_assert(kDependentFalse,
+                "tl::clc_try_cancel requires sm_100a or a compatible "
+                "architecture-specific target");
 #endif
 }
 
+template <bool kDependentFalse = false>
 TL_DEVICE void clc_try_cancel_multicast(void *result_ptr, void *mbar_ptr) {
 #if defined(CUTLASS_ARCH_CLC_ENABLED)
   uint32_t result_addr = smem_ptr_to_uint(result_ptr);
@@ -133,17 +152,22 @@ TL_DEVICE void clc_try_cancel_multicast(void *result_ptr, void *mbar_ptr) {
                :
                : "r"(result_addr), "r"(mbar_addr));
 #else
-  TILELANG_UNREACHABLE("CUTLASS_ARCH_CLC_ENABLED is not defined");
+  static_assert(kDependentFalse,
+                "tl::clc_try_cancel_multicast requires sm_100a or a "
+                "compatible architecture-specific target");
 #endif
 }
 
 // CLC query responses are produced through the async shared-memory proxy and
 // must be fenced before normal shared-memory loads decode the 16-byte result.
+template <bool kDependentFalse = false>
 TL_DEVICE void clc_fence_proxy_async_shared_cta() {
 #if defined(CUTLASS_ARCH_CLC_ENABLED)
   asm volatile("fence.proxy.async.shared::cta;" : : : "memory");
 #else
-  TILELANG_UNREACHABLE("CUTLASS_ARCH_CLC_ENABLED is not defined");
+  static_assert(kDependentFalse,
+                "tl::clc_fence_proxy_async_shared_cta requires sm_100a or a "
+                "compatible architecture-specific target");
 #endif
 }
 
@@ -154,6 +178,7 @@ struct CLCResponseDecode {
   uint32_t is_canceled = 0;
 };
 
+template <bool kDependentFalse = false>
 TL_DEVICE CLCResponseDecode clc_decode_response(void const *result_ptr) {
 #if defined(CUTLASS_ARCH_CLC_ENABLED)
   uint32_t result_addr = smem_ptr_to_uint(result_ptr);
@@ -178,43 +203,63 @@ TL_DEVICE CLCResponseDecode clc_decode_response(void const *result_ptr) {
   clc_fence_proxy_async_shared_cta();
   return decoded;
 #else
-  TILELANG_UNREACHABLE("CUTLASS_ARCH_CLC_ENABLED is not defined");
+  static_assert(kDependentFalse,
+                "tl::clc_decode_response requires sm_100a or a compatible "
+                "architecture-specific target");
+  return {};
 #endif
 }
 
+template <bool kDependentFalse = false>
 TL_DEVICE int clc_is_canceled(void const *result_ptr) {
 #if defined(CUTLASS_ARCH_CLC_ENABLED)
   return static_cast<int>(clc_decode_response(result_ptr).is_canceled);
 #else
-  TILELANG_UNREACHABLE("CUTLASS_ARCH_CLC_ENABLED is not defined");
+  static_assert(kDependentFalse,
+                "tl::clc_is_canceled requires sm_100a or a compatible "
+                "architecture-specific target");
+  return {};
 #endif
 }
 
+template <bool kDependentFalse = false>
 TL_DEVICE uint32_t clc_get_first_ctaid_x(void const *result_ptr) {
 #if defined(CUTLASS_ARCH_CLC_ENABLED)
   return clc_decode_response(result_ptr).x;
 #else
-  TILELANG_UNREACHABLE("CUTLASS_ARCH_CLC_ENABLED is not defined");
+  static_assert(kDependentFalse,
+                "tl::clc_get_first_ctaid_x requires sm_100a or a compatible "
+                "architecture-specific target");
+  return {};
 #endif
 }
 
+template <bool kDependentFalse = false>
 TL_DEVICE uint32_t clc_get_first_ctaid_y(void const *result_ptr) {
 #if defined(CUTLASS_ARCH_CLC_ENABLED)
   return clc_decode_response(result_ptr).y;
 #else
-  TILELANG_UNREACHABLE("CUTLASS_ARCH_CLC_ENABLED is not defined");
+  static_assert(kDependentFalse,
+                "tl::clc_get_first_ctaid_y requires sm_100a or a compatible "
+                "architecture-specific target");
+  return {};
 #endif
 }
 
+template <bool kDependentFalse = false>
 TL_DEVICE uint32_t clc_get_first_ctaid_z(void const *result_ptr) {
 #if defined(CUTLASS_ARCH_CLC_ENABLED)
   return clc_decode_response(result_ptr).z;
 #else
-  TILELANG_UNREACHABLE("CUTLASS_ARCH_CLC_ENABLED is not defined");
+  static_assert(kDependentFalse,
+                "tl::clc_get_first_ctaid_z requires sm_100a or a compatible "
+                "architecture-specific target");
+  return {};
 #endif
 }
 
 // Set the destination block-ID in cluster for a given SMEM Address
+template <bool kDependentFalse = false>
 TL_DEVICE uint32_t set_block_rank(uint32_t smemAddr, uint32_t rank) {
 #if defined(TILELANG_CLUSTER_ENABLED)
   uint32_t result;
@@ -223,7 +268,8 @@ TL_DEVICE uint32_t set_block_rank(uint32_t smemAddr, uint32_t rank) {
                : "r"(smemAddr), "r"(rank));
   return result;
 #else
-  TILELANG_UNREACHABLE("TILELANG_CLUSTER_ENABLED is not defined");
+  static_assert(kDependentFalse, "tl::set_block_rank requires sm_90 or later");
+  return {};
 #endif
 }
 

--- a/src/tl_templates/cuda/copy_sm100.h
+++ b/src/tl_templates/cuda/copy_sm100.h
@@ -460,7 +460,8 @@ TL_DEVICE void tma_load_gather4(const CUtensorMap &descriptor,
                  "r"(col), "r"(r0), "r"(r1), "r"(r2), "r"(r3), "l"(cache_hint)
                : "memory");
 #else
-  static_assert(kDependentFalse, "T.tma_gather4 requires sm_100 or later");
+  static_assert(kDependentFalse,
+                "tl::tma_load_gather4 requires sm_100 or later");
 #endif
 }
 
@@ -481,7 +482,7 @@ tma_store_scatter4(const CUtensorMap &descriptor, void const *const smem_ptr,
         "r"(r2), "r"(r3), "l"(cache_hint)
       : "memory");
 #else
-  static_assert(kDependentFalse, "T.tma_scatter4 requires sm_100a");
+  static_assert(kDependentFalse, "tl::tma_store_scatter4 requires sm_100a");
 #endif
 }
 #endif // CUDA 12.8+

--- a/src/tl_templates/cuda/copy_sm90.h
+++ b/src/tl_templates/cuda/copy_sm90.h
@@ -500,8 +500,7 @@ TL_DEVICE void tma_store_add(float *const smem_ptr, float *gmem_ptr,
                : "l"(gmem_ptr), "r"(smem_int_ptr), "r"(store_bytes)
                : "memory");
 #else
-  static_assert(kDependentFalse,
-                "T.atomic_add(..., use_tma=True) requires sm_90 or later");
+  static_assert(kDependentFalse, "tl::tma_store_add requires sm_90 or later");
 #endif
 }
 
@@ -518,8 +517,7 @@ TL_DEVICE void tma_store_add(const CUtensorMap &descriptor,
       : "l"(gmem_int_desc), "r"(smem_int_ptr), "r"(crd0)
       : "memory");
 #else
-  static_assert(kDependentFalse,
-                "T.atomic_add(..., use_tma=True) requires sm_90 or later");
+  static_assert(kDependentFalse, "tl::tma_store_add requires sm_90 or later");
 #endif
 }
 
@@ -537,8 +535,7 @@ TL_DEVICE void tma_store_add(const CUtensorMap &descriptor,
       : "l"(gmem_int_desc), "r"(smem_int_ptr), "r"(crd0), "r"(crd1)
       : "memory");
 #else
-  static_assert(kDependentFalse,
-                "T.atomic_add(..., use_tma=True) requires sm_90 or later");
+  static_assert(kDependentFalse, "tl::tma_store_add requires sm_90 or later");
 #endif
 }
 
@@ -556,8 +553,7 @@ TL_DEVICE void tma_store_add(const CUtensorMap &descriptor,
       : "l"(gmem_int_desc), "r"(smem_int_ptr), "r"(crd0), "r"(crd1), "r"(crd2)
       : "memory");
 #else
-  static_assert(kDependentFalse,
-                "T.atomic_add(..., use_tma=True) requires sm_90 or later");
+  static_assert(kDependentFalse, "tl::tma_store_add requires sm_90 or later");
 #endif
 }
 
@@ -577,8 +573,7 @@ TL_DEVICE void tma_store_add(const CUtensorMap &descriptor,
         "r"(crd3)
       : "memory");
 #else
-  static_assert(kDependentFalse,
-                "T.atomic_add(..., use_tma=True) requires sm_90 or later");
+  static_assert(kDependentFalse, "tl::tma_store_add requires sm_90 or later");
 #endif
 }
 
@@ -598,8 +593,7 @@ TL_DEVICE void tma_store_add(const CUtensorMap &descriptor,
         "r"(crd3), "r"(crd4)
       : "memory");
 #else
-  static_assert(kDependentFalse,
-                "T.atomic_add(..., use_tma=True) requires sm_90 or later");
+  static_assert(kDependentFalse, "tl::tma_store_add requires sm_90 or later");
 #endif
 }
 
@@ -610,7 +604,7 @@ TL_DEVICE void prefetch_tma_descriptor(const CUtensorMap &descriptor) {
   asm volatile("prefetch.tensormap [%0];" : : "l"(gmem_int_desc) : "memory");
 #else
   static_assert(kDependentFalse,
-                "T.prefetch_tma_descriptor requires sm_90 or later");
+                "tl::prefetch_tma_descriptor requires sm_90 or later");
 #endif
 }
 

--- a/src/tl_templates/cuda/instruction/wgmma.h
+++ b/src/tl_templates/cuda/instruction/wgmma.h
@@ -455,19 +455,29 @@ TL_WGMMA_FOREACH_N_FLOAT_MUL8(TL_WGMMA_DEFINE_F32_E5M2E5M2_RS_TN);
 #undef TL_WGMMA_DEFINE_RS_TN
 
 template <DataType A_type, DataType B_type, DataType C_type, int M, int N,
-          int K, bool tnspA, bool tnspB, int scaleA = 1, int scaleB = 1>
+          int K, bool tnspA, bool tnspB, int scaleA = 1, int scaleB = 1,
+          bool kDependentFalse = false>
 TL_DEVICE void wgmma_ss(uint64_t desc_a, uint64_t desc_b, uint32_t *c,
                         bool scale_out) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 900)
   WgmmaSSImpl<A_type, B_type, C_type, M, N, K, tnspA, tnspB, scaleA,
               scaleB>::execute(desc_a, desc_b, c, scale_out);
+#else
+  static_assert(kDependentFalse, "tl::wgmma_ss requires sm_90");
+#endif
 }
 
 template <DataType A_type, DataType B_type, DataType C_type, int M, int N,
-          int K, bool tnspA, bool tnspB, int scaleA = 1, int scaleB = 1>
+          int K, bool tnspA, bool tnspB, int scaleA = 1, int scaleB = 1,
+          bool kDependentFalse = false>
 TL_DEVICE void wgmma_rs(const uint32_t *a, uint64_t desc_b, uint32_t *c,
                         bool scale_out) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 900)
   WgmmaRSImpl<A_type, B_type, C_type, M, N, K, tnspA, tnspB, scaleA,
               scaleB>::execute(a, desc_b, c, scale_out);
+#else
+  static_assert(kDependentFalse, "tl::wgmma_rs requires sm_90");
+#endif
 }
 
 } // namespace tl

--- a/src/tl_templates/cuda/instruction/wgmma_sp.h
+++ b/src/tl_templates/cuda/instruction/wgmma_sp.h
@@ -448,20 +448,30 @@ TL_WGMMA_SP_FOREACH_N_FLOAT_MUL8(TL_WGMMA_SP_DEFINE_F32_E5M2E5M2_RS_TN);
 
 template <DataType A_type, DataType B_type, DataType C_type, int M, int N,
           int K, bool tnspA, bool tnspB, int scaleA = 1, int scaleB = 1,
-          cute::SM90::GMMA::SparseSel spsel = cute::SM90::GMMA::SparseSel::Zero>
+          cute::SM90::GMMA::SparseSel spsel = cute::SM90::GMMA::SparseSel::Zero,
+          bool kDependentFalse = false>
 TL_DEVICE void wgmma_sp_ss(uint64_t desc_a, uint64_t desc_b, uint32_t *c,
                            bool scale_out, uint32_t e) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 900)
   WgmmaSpSSImpl<A_type, B_type, C_type, M, N, K, tnspA, tnspB, scaleA, scaleB,
                 spsel>::execute(desc_a, desc_b, c, scale_out, e);
+#else
+  static_assert(kDependentFalse, "tl::wgmma_sp_ss requires sm_90");
+#endif
 }
 
 template <DataType A_type, DataType B_type, DataType C_type, int M, int N,
           int K, bool tnspA, bool tnspB, int scaleA = 1, int scaleB = 1,
-          cute::SM90::GMMA::SparseSel spsel = cute::SM90::GMMA::SparseSel::Zero>
+          cute::SM90::GMMA::SparseSel spsel = cute::SM90::GMMA::SparseSel::Zero,
+          bool kDependentFalse = false>
 TL_DEVICE void wgmma_sp_rs(const uint32_t *a, uint64_t desc_b, uint32_t *c,
                            bool scale_out, uint32_t e) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 900)
   WgmmaSpRSImpl<A_type, B_type, C_type, M, N, K, tnspA, tnspB, scaleA, scaleB,
                 spsel>::execute(a, desc_b, c, scale_out, e);
+#else
+  static_assert(kDependentFalse, "tl::wgmma_sp_rs requires sm_90");
+#endif
 }
 
 } // namespace tl

--- a/src/tl_templates/cuda/intrin.h
+++ b/src/tl_templates/cuda/intrin.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common.h"
+#include "cutlass/arch/reg_reconfig.h"
 #include "cutlass/cutlass.h"
 
 #if __CUDA_ARCH_LIST__ >= 900
@@ -59,29 +60,52 @@ get_warp_group_idx(int warp_size = detail::default_warp_size(),
   return detail::linear_thread_idx_in_block() / threads_per_group;
 }
 
-#if __CUDA_ARCH_LIST__ >= 900
-TL_DEVICE void warpgroup_arrive() { cute::warpgroup_arrive(); }
-TL_DEVICE void warpgroup_commit_batch() { cute::warpgroup_commit_batch(); }
-
-template <int NumMma> TL_DEVICE void warpgroup_wait() {
-  cute::warpgroup_wait<NumMma>();
+template <bool kDependentFalse = false> TL_DEVICE void warpgroup_arrive() {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 900)
+  cute::warpgroup_arrive();
+#else
+  static_assert(kDependentFalse, "tl::warpgroup_arrive requires sm_90");
+#endif
 }
 
-template <int NumMma> TL_DEVICE void wait_wgmma() {
+template <bool kDependentFalse = false>
+TL_DEVICE void warpgroup_commit_batch() {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 900)
+  cute::warpgroup_commit_batch();
+#else
+  static_assert(kDependentFalse, "tl::warpgroup_commit_batch requires sm_90");
+#endif
+}
+
+template <int NumMma, bool kDependentFalse = false>
+TL_DEVICE void warpgroup_wait() {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 900)
   cute::warpgroup_wait<NumMma>();
+#else
+  static_assert(kDependentFalse, "tl::warpgroup_wait requires sm_90");
+#endif
+}
+
+template <int NumMma, bool kDependentFalse = false>
+TL_DEVICE void wait_wgmma() {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 900)
+  cute::warpgroup_wait<NumMma>();
+#else
+  static_assert(kDependentFalse, "tl::wait_wgmma requires sm_90");
+#endif
 }
 
 TL_DEVICE void warpgroup_fence_operand(uint32_t *regs, int count) {
 #pragma unroll
   for (int i = 0; i < count; ++i) {
-    cute::warpgroup_fence_operand(regs[i]);
+    asm volatile("" : "+r"(regs[i]) : : "memory");
   }
 }
 
 TL_DEVICE void warpgroup_fence_operand(float *regs, int count) {
 #pragma unroll
   for (int i = 0; i < count; ++i) {
-    cute::warpgroup_fence_operand(regs[i]);
+    asm volatile("" : "+f"(regs[i]) : : "memory");
   }
 }
 
@@ -89,7 +113,9 @@ TL_DEVICE void warpgroup_fence_operand(float *regs, int count) {
 //   thread_extent: the logical size (in number of threads) of each "group"
 //                  within which we want to elect exactly ONE representative
 //                  thread.
-template <int thread_extent> TL_DEVICE bool tl_shuffle_elect() {
+template <int thread_extent, bool kDependentFalse = false>
+TL_DEVICE bool tl_shuffle_elect() {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900)
   // Special case: thread_extent == 0 means "elect exactly one thread
   // in the entire thread block", i.e., the leader of the first warp of the
   // block.
@@ -125,15 +151,33 @@ template <int thread_extent> TL_DEVICE bool tl_shuffle_elect() {
     return cute::elect_one_sync() &&
            (cutlass::canonical_warp_idx() % warp_extent) == 0;
   }
-}
-
-template <uint32_t RegCount> TL_DEVICE void warpgroup_reg_alloc() {
-  asm volatile("setmaxnreg.inc.sync.aligned.u32 %0;\n" : : "n"(RegCount));
-}
-
-template <uint32_t RegCount> TL_DEVICE void warpgroup_reg_dealloc() {
-  asm volatile("setmaxnreg.dec.sync.aligned.u32 %0;\n" : : "n"(RegCount));
-}
+#else
+  static_assert(kDependentFalse,
+                "tl::tl_shuffle_elect requires sm_90 or later");
+  return {};
 #endif
+}
+
+template <uint32_t RegCount, bool kDependentFalse = false>
+TL_DEVICE void warpgroup_reg_alloc() {
+#if CUDA_CTA_RECONFIG_ACTIVATED
+  asm volatile("setmaxnreg.inc.sync.aligned.u32 %0;\n" : : "n"(RegCount));
+#else
+  static_assert(kDependentFalse,
+                "tl::warpgroup_reg_alloc requires a target with CTA register "
+                "reconfiguration, such as sm_90a");
+#endif
+}
+
+template <uint32_t RegCount, bool kDependentFalse = false>
+TL_DEVICE void warpgroup_reg_dealloc() {
+#if CUDA_CTA_RECONFIG_ACTIVATED
+  asm volatile("setmaxnreg.dec.sync.aligned.u32 %0;\n" : : "n"(RegCount));
+#else
+  static_assert(kDependentFalse,
+                "tl::warpgroup_reg_dealloc requires a target with CTA register "
+                "reconfiguration, such as sm_90a");
+#endif
+}
 
 } // namespace tl

--- a/src/tl_templates/cuda/tcgen_05.h
+++ b/src/tl_templates/cuda/tcgen_05.h
@@ -9,12 +9,65 @@
 
 #include "common.h"
 #include <cute/arch/cluster_sm90.hpp>
+#include <cute/arch/config.hpp>
 
 namespace tl {
 
+template <bool kDependentFalse = false> TL_DEVICE void require_tcgen05mma_ss() {
+#if defined(CUTE_ARCH_TCGEN05_TMEM_ENABLED)
+  return;
+#else
+  static_assert(kDependentFalse,
+                "tl::tcgen05mma_ss requires sm_100a or a compatible "
+                "architecture-specific target");
+#endif
+}
+
+template <bool kDependentFalse = false> TL_DEVICE void require_tcgen05mma_ts() {
+#if defined(CUTE_ARCH_TCGEN05_TMEM_ENABLED)
+  return;
+#else
+  static_assert(kDependentFalse,
+                "tl::tcgen05mma_ts requires sm_100a or a compatible "
+                "architecture-specific target");
+#endif
+}
+
+template <bool kDependentFalse = false>
+TL_DEVICE void require_tcgen05mma_blockscaled_ss() {
+#if defined(CUTE_ARCH_TCGEN05_TMEM_ENABLED)
+  return;
+#else
+  static_assert(
+      kDependentFalse,
+      "tl::tcgen05mma_blockscaled_ss requires sm_100a or a compatible "
+      "architecture-specific target");
+#endif
+}
+
+template <bool kDependentFalse = false> TL_DEVICE void require_tcgen05_ld() {
+#if defined(CUTE_ARCH_TCGEN05_TMEM_ENABLED)
+  return;
+#else
+  static_assert(kDependentFalse,
+                "tl::tcgen05_ld_* requires sm_100a or a compatible "
+                "architecture-specific target");
+#endif
+}
+
+template <bool kDependentFalse = false> TL_DEVICE void require_tcgen05_st() {
+#if defined(CUTE_ARCH_TCGEN05_TMEM_ENABLED)
+  return;
+#else
+  static_assert(kDependentFalse,
+                "tl::tcgen05_st_* requires sm_100a or a compatible "
+                "architecture-specific target");
+#endif
+}
+
 template <bool use_2cta = false, bool kDependentFalse = false>
 TL_DEVICE void tmem_allocate(void *dst_ptr, int num_columns) {
-#if defined(__CUDA_ARCH_FEAT_SM100_ALL)
+#if defined(CUTE_ARCH_TCGEN05_TMEM_ENABLED)
   uint32_t dst_intptr = smem_ptr_to_uint(dst_ptr);
   if constexpr (use_2cta) {
     asm volatile(
@@ -28,13 +81,15 @@ TL_DEVICE void tmem_allocate(void *dst_ptr, int num_columns) {
         : "r"(dst_intptr), "r"(num_columns));
   }
 #else
-  static_assert(kDependentFalse, "T.alloc_tmem requires sm_100a");
+  static_assert(kDependentFalse,
+                "tl::tmem_allocate requires sm_100a or a compatible "
+                "architecture-specific target");
 #endif
 }
 
 template <bool use_2cta = false, bool kDependentFalse = false>
 TL_DEVICE void tmem_deallocate(uint32_t *tmem_ptr, int num_columns) {
-#if defined(__CUDA_ARCH_FEAT_SM100_ALL)
+#if defined(CUTE_ARCH_TCGEN05_TMEM_ENABLED)
   if constexpr (use_2cta) {
     asm volatile("{\n\t"
                  "tcgen05.dealloc.cta_group::2.sync.aligned.b32  %0, %1; \n\t"
@@ -49,16 +104,32 @@ TL_DEVICE void tmem_deallocate(uint32_t *tmem_ptr, int num_columns) {
                  : "r"(*tmem_ptr), "r"(num_columns));
   }
 #else
-  static_assert(kDependentFalse, "T.deallocate_tmem requires sm_100a");
+  static_assert(kDependentFalse,
+                "tl::tmem_deallocate requires sm_100a or a compatible "
+                "architecture-specific target");
 #endif
 }
 
+template <bool kDependentFalse = false>
 TL_DEVICE void tcgen05_before_thread_sync() {
+#if defined(CUTE_ARCH_TCGEN05_TMEM_ENABLED)
   asm volatile("tcgen05.fence::before_thread_sync;");
+#else
+  static_assert(kDependentFalse,
+                "tl::tcgen05_before_thread_sync requires sm_100a or a "
+                "compatible architecture-specific target");
+#endif
 }
 
+template <bool kDependentFalse = false>
 TL_DEVICE void tcgen05_after_thread_sync() {
+#if defined(CUTE_ARCH_TCGEN05_TMEM_ENABLED)
   asm volatile("tcgen05.fence::after_thread_sync;");
+#else
+  static_assert(kDependentFalse,
+                "tl::tcgen05_after_thread_sync requires sm_100a or a "
+                "compatible architecture-specific target");
+#endif
 }
 
 TL_DEVICE void fence_view_async_tmem_load() {
@@ -70,9 +141,10 @@ TL_DEVICE void fence_view_async_tmem_store() {
 }
 
 // Wrapper for CUTLASS umma_arrive: elect one lane, then arrive the mbarrier
-template <bool use_2cta = false>
+template <bool use_2cta = false, bool kDependentFalse = false>
 TL_DEVICE void tcgen05_mma_arrive(void const *smem_ptr,
                                   const uint16_t cta_mask = 3) {
+#if defined(CUTE_ARCH_TCGEN05_TMEM_ENABLED)
   uint32_t bar_intptr = smem_ptr_to_uint(smem_ptr);
   if constexpr (use_2cta) {
     // Adapted from cute::arch::umma_arrive_multicast_2x1SM
@@ -94,12 +166,18 @@ TL_DEVICE void tcgen05_mma_arrive(void const *smem_ptr,
                    : "r"(bar_intptr));
     }
   }
+#else
+  static_assert(kDependentFalse,
+                "tl::tcgen05_mma_arrive requires sm_100a or a compatible "
+                "architecture-specific target");
+#endif
 }
 
 // UTCCP: Copy scale factors from shared memory to tensor memory.
 // Must be called by one warp; only one elected thread issues the instruction.
-template <bool use_2cta = false>
+template <bool use_2cta = false, bool kDependentFalse = false>
 TL_DEVICE void tcgen05_cp(uint64_t const &smem_desc, uint32_t const &tmem_col) {
+#if defined(CUTE_ARCH_TCGEN05_TMEM_ENABLED)
   if (cute::elect_one_sync()) {
     if constexpr (use_2cta) {
       asm volatile("tcgen05.cp.cta_group::2.32x128b.warpx4 [%0], %1;"
@@ -111,6 +189,11 @@ TL_DEVICE void tcgen05_cp(uint64_t const &smem_desc, uint32_t const &tmem_col) {
                    : "r"(tmem_col), "l"(smem_desc));
     }
   }
+#else
+  static_assert(kDependentFalse,
+                "tl::tcgen05_cp requires sm_100a or a compatible "
+                "architecture-specific target");
+#endif
 }
 
 // Warp-level transpose of 128 uint32 elements in shared memory for UTCCP.

--- a/testing/python/issue/test_tilelang_issue_2504.py
+++ b/testing/python/issue/test_tilelang_issue_2504.py
@@ -140,42 +140,42 @@ _UNSUPPORTED_CASES = [
     (
         _make_tmem_prim_func,
         "sm_90",
-        "T.alloc_tmem requires sm_100a",
+        "tl::tmem_allocate requires sm_100a or a compatible architecture-specific target",
     ),
     (
         _make_tmem_prim_func,
         "sm_90",
-        "T.deallocate_tmem requires sm_100a",
+        "tl::tmem_deallocate requires sm_100a or a compatible architecture-specific target",
     ),
     (
         _make_tma_store_arrive_prim_func,
         "sm_80",
-        "T.tma_store_arrive requires sm_90 or later",
+        "tl::tma_store_arrive requires sm_90 or later",
     ),
     (
         _make_tma_store_wait_prim_func,
         "sm_80",
-        "T.tma_store_wait requires sm_90 or later",
+        "tl::tma_store_wait requires sm_90 or later",
     ),
     (
         _make_tma_atomic_add_prim_func,
         "sm_80",
-        "T.atomic_add(..., use_tma=True) requires sm_90 or later",
+        "tl::tma_store_add requires sm_90 or later",
     ),
     (
         _make_tma_descriptor_prefetch_prim_func,
         "sm_80",
-        "T.prefetch_tma_descriptor requires sm_90 or later",
+        "tl::prefetch_tma_descriptor requires sm_90 or later",
     ),
     (
         _make_tma_gather4_prim_func,
         "sm_90",
-        "T.tma_gather4 requires sm_100 or later",
+        "tl::tma_load_gather4 requires sm_100 or later",
     ),
     (
         _make_tma_scatter4_prim_func,
         "sm_100",
-        "T.tma_scatter4 requires sm_100a",
+        "tl::tma_store_scatter4 requires sm_100a",
     ),
 ]
 

--- a/testing/python/issue/test_tilelang_issue_2602.py
+++ b/testing/python/issue/test_tilelang_issue_2602.py
@@ -1,0 +1,313 @@
+"""Architecture diagnostics for CUDA device helpers."""
+
+import pytest
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+from tilelang.contrib import nvcc
+
+
+_PASS_CONFIG = {
+    tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED.value: True,
+}
+
+
+def _require_cuda_12_8():
+    if nvcc.get_cuda_version() < (12, 8):
+        pytest.skip("CUDA architecture-gate tests require CUDA toolkit >= 12.8")
+
+
+def _lower_for_arch(prim_func, arch):
+    target = tvm.target.Target({"kind": "cuda", "arch": arch})
+    with tvm.transform.PassContext(config=_PASS_CONFIG), target:
+        return tilelang.lower(
+            prim_func,
+            target=target,
+            enable_device_compile=True,
+        )
+
+
+def _make_cluster_prim_func():
+    @T.prim_func
+    def main(out: T.Tensor((1,), T.int32)):
+        with T.Kernel(1, threads=1):
+            T.cluster_arrive_relaxed()
+            T.cluster_arrive()
+            T.cluster_wait()
+            T.cluster_sync()
+            out[0] = T.block_rank_in_cluster()
+
+    return main
+
+
+def _make_clc_prim_func():
+    @T.prim_func
+    def main(out: T.Tensor((4,), T.uint32)):
+        with T.Kernel(1, threads=1):
+            result = T.alloc_shared((4,), T.uint32)
+            mbarrier = T.alloc_shared((1,), T.uint64)
+            T.clc_try_cancel(result, mbarrier)
+            T.clc_try_cancel_multicast(result, mbarrier)
+            out[0] = T.Cast("uint32", T.clc_is_canceled(result))
+            out[1] = T.clc_get_first_ctaid_x(result)
+            out[2] = T.clc_get_first_ctaid_y(result)
+            out[3] = T.clc_get_first_ctaid_z(result)
+
+    return main
+
+
+def _make_fence_proxy_async_prim_func():
+    @T.prim_func
+    def main():
+        with T.Kernel(1, threads=1):
+            T.fence_proxy_async()
+
+    return main
+
+
+def _make_tcgen05_thread_fence_prim_func():
+    @T.prim_func
+    def main():
+        with T.Kernel(1, threads=1):
+            T.tcgen05_before_thread_sync()
+            T.tcgen05_after_thread_sync()
+
+    return main
+
+
+def _make_warpgroup_prim_func():
+    @T.prim_func
+    def main():
+        with T.Kernel(1, threads=128):
+            T.warpgroup_arrive()
+            T.warpgroup_commit_batch()
+            T.warpgroup_wait(0)
+            T.wait_wgmma(0)
+
+    return main
+
+
+def _make_shuffle_elect_prim_func():
+    @T.prim_func
+    def main(out: T.Tensor((1,), T.int32)):
+        with T.Kernel(1, threads=32):
+            if T.shuffle_elect(0):
+                out[0] = 1
+
+    return main
+
+
+def _make_register_reconfiguration_prim_func():
+    @T.prim_func
+    def main():
+        with T.Kernel(1, threads=128):
+            T.inc_max_nreg(40)
+            T.dec_max_nreg(40)
+
+    return main
+
+
+def _make_wgmma_prim_func():
+    @T.prim_func
+    def main(
+        a: T.Tensor((64, 16), T.float16),
+        b: T.Tensor((16, 64), T.float16),
+        out: T.Tensor((64, 64), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            a_shared = T.alloc_shared((64, 16), T.float16)
+            b_shared = T.alloc_shared((16, 64), T.float16)
+            accum = T.alloc_fragment((64, 64), T.float16)
+
+            T.copy(a, a_shared)
+            T.copy(b, b_shared)
+            T.wgmma_gemm(a_shared, b_shared, accum, clear_accum=True)
+            T.wait_wgmma(0)
+            T.copy(accum, out)
+
+    return main
+
+
+def _make_tcgen05_mma_prim_func():
+    @T.prim_func
+    def main(
+        a: T.Tensor((128, 128), T.bfloat16),
+        b: T.Tensor((128, 128), T.bfloat16),
+        out: T.Tensor((128, 128), T.bfloat16),
+    ):
+        with T.Kernel(1, threads=128):
+            a_shared = T.alloc_shared((128, 128), T.bfloat16)
+            b_shared = T.alloc_shared((128, 128), T.bfloat16)
+            accum_tmem = T.alloc_tmem((128, 128), T.float32)
+            mbarrier = T.alloc_barrier(1)
+            accum = T.alloc_fragment((128, 128), T.float32)
+            out_shared = T.alloc_shared((128, 128), T.bfloat16)
+
+            T.copy(a, a_shared)
+            T.copy(b, b_shared)
+            T.tcgen05_gemm(
+                a_shared,
+                b_shared,
+                accum_tmem,
+                transpose_B=True,
+                mbar=mbarrier,
+                clear_accum=True,
+            )
+            T.mbarrier_wait_parity(mbarrier, 0)
+            T.copy(accum_tmem, accum)
+            T.copy(accum, out_shared)
+            T.copy(out_shared, out)
+
+    return main
+
+
+_UNSUPPORTED_CASES = [
+    (
+        _make_cluster_prim_func,
+        "sm_89",
+        (
+            "tl::cluster_arrive_relaxed requires sm_90 or later",
+            "tl::cluster_arrive requires sm_90 or later",
+            "tl::cluster_wait requires sm_90 or later",
+            "tl::cluster_sync requires sm_90 or later",
+            "tl::block_rank_in_cluster requires sm_90 or later",
+        ),
+    ),
+    (
+        _make_clc_prim_func,
+        "sm_90",
+        (
+            "tl::clc_try_cancel requires sm_100a or a compatible architecture-specific target",
+            "tl::clc_try_cancel_multicast requires sm_100a or a compatible architecture-specific target",
+            "tl::clc_is_canceled requires sm_100a or a compatible architecture-specific target",
+            "tl::clc_get_first_ctaid_x requires sm_100a or a compatible architecture-specific target",
+            "tl::clc_get_first_ctaid_y requires sm_100a or a compatible architecture-specific target",
+            "tl::clc_get_first_ctaid_z requires sm_100a or a compatible architecture-specific target",
+        ),
+    ),
+    (
+        _make_fence_proxy_async_prim_func,
+        "sm_89",
+        ("tl::fence_proxy_async requires sm_90 or later",),
+    ),
+    (
+        _make_tcgen05_thread_fence_prim_func,
+        "sm_100",
+        (
+            "tl::tcgen05_before_thread_sync requires sm_100a or a compatible architecture-specific target",
+            "tl::tcgen05_after_thread_sync requires sm_100a or a compatible architecture-specific target",
+        ),
+    ),
+    (
+        _make_warpgroup_prim_func,
+        "sm_89",
+        (
+            "tl::warpgroup_arrive requires sm_90",
+            "tl::warpgroup_commit_batch requires sm_90",
+            "tl::warpgroup_wait requires sm_90",
+            "tl::wait_wgmma requires sm_90",
+        ),
+    ),
+    (
+        _make_shuffle_elect_prim_func,
+        "sm_89",
+        ("tl::tl_shuffle_elect requires sm_90 or later",),
+    ),
+    (
+        _make_register_reconfiguration_prim_func,
+        "sm_100",
+        (
+            "tl::warpgroup_reg_alloc requires a target with CTA register reconfiguration, such as sm_90a",
+            "tl::warpgroup_reg_dealloc requires a target with CTA register reconfiguration, such as sm_90a",
+        ),
+    ),
+    (
+        _make_tcgen05_mma_prim_func,
+        "sm_100",
+        ("tl::tcgen05mma_ss requires sm_100a or a compatible architecture-specific target",),
+    ),
+]
+
+
+_SUPPORTED_CASES = [
+    (_make_cluster_prim_func, "sm_90", "tl::block_rank_in_cluster()"),
+    (_make_clc_prim_func, "sm_100a", "tl::clc_get_first_ctaid_z("),
+    (
+        _make_fence_proxy_async_prim_func,
+        "sm_90",
+        "tl::fence_proxy_async()",
+    ),
+    (
+        _make_tcgen05_thread_fence_prim_func,
+        "sm_100a",
+        "tl::tcgen05_after_thread_sync()",
+    ),
+    (_make_warpgroup_prim_func, "sm_90", "tl::wait_wgmma<0>()"),
+    (_make_shuffle_elect_prim_func, "sm_90", "tl::tl_shuffle_elect<0>()"),
+    (
+        _make_register_reconfiguration_prim_func,
+        "sm_100a",
+        "tl::warpgroup_reg_dealloc<40>()",
+    ),
+    (_make_wgmma_prim_func, "sm_90", "tl::wgmma_ss"),
+    (
+        _make_tcgen05_mma_prim_func,
+        "sm_100a",
+        "tl::require_tcgen05mma_ss()",
+    ),
+]
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize(
+    "factory,arch,messages",
+    _UNSUPPORTED_CASES,
+    ids=[
+        "cluster-sm89",
+        "clc-sm90",
+        "fence-proxy-sm89",
+        "tcgen05-fence-sm100",
+        "warpgroup-sm89",
+        "shuffle-elect-sm89",
+        "register-reconfiguration-sm100",
+        "tcgen05-mma-sm100",
+    ],
+)
+def test_device_helpers_reject_unsupported_arch(factory, arch, messages):
+    _require_cuda_12_8()
+
+    with pytest.raises(RuntimeError) as exc_info:
+        _lower_for_arch(factory(), arch)
+
+    error = str(exc_info.value)
+    for message in messages:
+        assert message in error
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize(
+    "factory,arch,expected_helper",
+    _SUPPORTED_CASES,
+    ids=[
+        "cluster-sm90",
+        "clc-sm100a",
+        "fence-proxy-sm90",
+        "tcgen05-fence-sm100a",
+        "warpgroup-sm90",
+        "shuffle-elect-sm90",
+        "register-reconfiguration-sm100a",
+        "wgmma-sm90",
+        "tcgen05-mma-sm100a",
+    ],
+)
+def test_device_helpers_compile_for_supported_arch(factory, arch, expected_helper):
+    _require_cuda_12_8()
+
+    artifact = _lower_for_arch(factory(), arch)
+    assert expected_helper in artifact.kernel_source
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

- Replace runtime unreachable fallbacks with dependent compile-time `static_assert` diagnostics for architecture-specific CUDA device functions.
- Guard each helper with the same architecture capability macros used by CUTLASS/CuTe.
- Report the actual generated device function names instead of TileLang DSL names.

## Guard coverage

- **Cluster, sm_90+:** `tl::cluster_arrive_relaxed`, `tl::cluster_arrive`, `tl::cluster_wait`, `tl::cluster_sync`, cluster grid/rank/shape queries, and `tl::set_block_rank`.
- **Cluster Launch Control, architecture-specific sm_100 family targets:** cancel, multicast cancel, async-proxy fence, response decode, cancellation query, and first-CTA coordinate helpers.
- **Async barrier/TMA, sm_90+:** `tl::fence_proxy_async` and `tl::fence_barrier_init`; normalize diagnostics for TMA store arrive/wait, atomic add, and descriptor prefetch.
- **WGMMA, sm_90:** warpgroup arrive/commit/wait helpers plus dense and sparse SS/RS WGMMA wrappers.
- **CTA register reconfiguration:** `tl::warpgroup_reg_alloc` and `tl::warpgroup_reg_dealloc` use the CUTLASS capability macro; `tl::tl_shuffle_elect` is guarded for sm_90+.
- **TCGEN05/tensor memory:** guard MMA SS/TS/blockscaled dispatch, load/store dispatch, tensor-memory allocation/deallocation, thread-sync fences, MMA barrier arrival, and UTCCP copy with `CUTE_ARCH_TCGEN05_TMEM_ENABLED`.
- **SM100 TMA diagnostics:** report `tl::tma_load_gather4` and `tl::tma_store_scatter4` directly.

## Tests

- `ninja -C build`
- `pytest testing/python/issue/test_tilelang_issue_2504.py testing/python/issue/test_tilelang_issue_2602.py` (33 passed)
- pre-commit hooks on all changed files

Fixes #2602

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Replaced runtime “unreachable” fallbacks for architecture-specific CUDA/TensorLib intrinsics with compile-time dependent `static_assert` diagnostics (via a new `bool kDependentFalse = false` template parameter pattern), so unsupported code fails to compile with actionable messages naming the required `sm_*`/feature and the generated `tl::...` device helper.
- Added/updated compile-time guards across:
  - Cluster builtins + `T.block_rank_in_cluster` (requires `sm_90`+)
  - Cluster Launch Control (CLC) builtins (requires `sm_100a` and related SM gating)
  - Async barrier / TMA helpers (e.g., `fence_proxy_async`, `fence_barrier_init`, `tma_store_*` / `tma_store_arrive` / `tma_store_wait`)
  - WGMMA + sparse WGMMA (SM90A/`__CUDA_ARCH__ == 900` gating)
  - CTA register reconfiguration / warpgroup intrinsics (guarded by `CUDA_CTA_RECONFIG_ACTIVATED` + SM availability)
  - Shuffle elect + TCGen05 / TMEM helpers (TCGen05 TMEM availability and required SM/feature)
  - SM100 TMA helpers (e.g., `tma_load_gather4`, `tma_store_scatter4`)
- Updated TCGen05 codegen to emit architecture requirement helpers (`tl::require_tcgen05mma_*`, `tl::require_tcgen05_ld`, `tl::require_tcgen05_st`) immediately before the corresponding emitted `tl::tcgen05*` calls.
- Updated diagnostic strings in existing TMEM/TMA issue tests and added a new test suite that verifies both:
  - unsupported-architecture rejection (matching required diagnostic substrings), and
  - successful compilation for supported architectures (including expected lowered helper-expression snippets).

## Validation

- Successful build.
- 33 issue-test passes.
- Pre-commit checks on changed files passed.

## C++ style / lint notes

- Touches C++ CUDA template headers and code generation (`src/cuda/codegen/*`, `src/tl_templates/cuda/*`), but does not modify `docs/developer_guide/cpp_style.md`.
- Any “C++ API Style Audit (warning only)” CI findings (TLCPP003/TLCPP004) should be treated as advisory unless this PR introduces a clear API/FFI/maintainability risk; this change primarily adjusts template signatures and compile-time diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->