### PR TITLE
[BugFix] Fix warp_reduce truncating int64/uint64 to 32 bits on sm_80+

### DIFF
--- a/src/tl_templates/cuda/reduce.h
+++ b/src/tl_templates/cuda/reduce.h
@@ -344,7 +344,7 @@ TL_DEVICE T warp_reduce(T value, ReduceOp op) {
 
   if constexpr (std::is_same_v<T, int32_t> || std::is_same_v<T, uint32_t>) {
     return run_reduce_sync(value);
-  } else if constexpr (std::is_integral_v<T>) {
+  } else if constexpr (std::is_integral_v<T> && sizeof(T) <= 4) {
     return static_cast<T>(run_reduce_sync(static_cast<int32_t>(value)));
   }
 #endif

--- a/testing/python/language/test_tilelang_language_warp_reduce.py
+++ b/testing/python/language/test_tilelang_language_warp_reduce.py
@@ -1,4 +1,5 @@
 import torch
+import pytest
 
 import tilelang
 import tilelang.testing
@@ -78,12 +79,49 @@ def test_warp_reduce_bitor():
     torch.testing.assert_close(a, ref)
 
 
-def test_warp_reduce_sum_int64():
-    a = torch.zeros((32,), dtype=torch.int64, device="cuda")
-    a[7] = 1 << 40
-    kernel = get_kernel("sum", T.int64)
-    ref = torch.full_like(a, (1 << 40))
+WARP_REDUCE_CASES_64 = [
+    # (op, dtype, N)
+    ("sum", "int64", 32),
+    ("max", "int64", 32),
+    ("min", "int64", 32),
+    ("bitand", "int64", 32),
+    ("bitor", "int64", 32),
+]
+
+
+@pytest.mark.parametrize(
+    ("op", "dtype", "N"),
+    WARP_REDUCE_CASES_64,
+)
+def test_warp_reduce_64(op, dtype, N):
+    def warp_reduce_ref(a):
+        if op == "sum":
+            return torch.full_like(a, a.sum())
+        elif op == "max":
+            return torch.full_like(a, a.max())
+        elif op == "min":
+            return torch.full_like(a, a.min())
+        elif op == "bitand":
+            ref_val = a[0]
+            for i in range(1, a.shape[0]):
+                ref_val = ref_val & a[i]
+            return torch.full_like(a, ref_val)
+        elif op == "bitor":
+            ref_val = a[0]
+            for i in range(1, a.shape[0]):
+                ref_val = ref_val | a[i]
+            return torch.full_like(a, ref_val)
+        raise AssertionError(f"Unknown op: {op}")
+
+    torch_dtype = getattr(torch, dtype)
+    tl_dtype = getattr(T, dtype)
+
+    a = torch.randint(1 << 32, (1 << 63) - 1, (N,), dtype=torch_dtype, device="cuda")
+    ref = warp_reduce_ref(a)
+
+    kernel = get_kernel(op, tl_dtype)
     kernel(a)
+
     torch.testing.assert_close(a, ref)
 
 

--- a/testing/python/language/test_tilelang_language_warp_reduce.py
+++ b/testing/python/language/test_tilelang_language_warp_reduce.py
@@ -78,5 +78,14 @@ def test_warp_reduce_bitor():
     torch.testing.assert_close(a, ref)
 
 
+def test_warp_reduce_sum_int64():
+    a = torch.zeros((32,), dtype=torch.int64, device="cuda")
+    a[7] = 1 << 40
+    kernel = get_kernel("sum", T.int64)
+    ref = torch.full_like(a, (1 << 40))
+    kernel(a)
+    torch.testing.assert_close(a, ref)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
`tl::warp_reduce_*` on `int64`/`uint64` operands silently dropping the high 32 bits on `sm_80+`.
The root cause for this issue is that the fast path for `sm_80`+ routes any integral `T` other than `int32`/`uint32` through `static_cast<T>(run_reduce_sync(static_cast<int32_t>(value)))`.
The cast is invalid for wide integrals, as they are truncated.

This PR strengthens the fast-path condition to `std::is_integral_v<T> && sizeof(T) <= 4` so wider integrals fall through to the native-width `shfl_xor` butterfly, which reduces `int64` correctly.

Fixes #2754 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed `tl::warp_reduce_*` for `int64` and `uint64` on `sm_80+` by narrowing the integral fast path: the `int32_t`-casting branch now applies only to integral types where `sizeof(T) <= 4`.
- Wider integral types (`int64`/`uint64`) now use the native-width `shfl_xor` butterfly reduction path, preventing silent truncation of the upper 32 bits for sum/max/min/bitand/bitor.
- Added CUDA test coverage for `int64` warp reductions (`sum`, `max`, `min`, `bitand`, `bitor`) to validate full-width correctness with large 64-bit values.
- Existing 32-bit behavior for `int32_t`/`uint32_t` remains unchanged.

## C++ style / lint notes

- Touches C++ code (`src/tl_templates/cuda/reduce.h`) but does not alter any rules documented in `docs/developer_guide/cpp_style.md`.
- No new style/lint risks are introduced by this change; the “C++ API Style Audit (warning only)” CI step remains advisory rather than blocking correctness/build issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->