### PR TITLE
[CUDA][Transform] Fix PCWS index dtype handling

### DIFF
--- a/src/cuda/transform/multi_version_buffer_rewriter.cc
+++ b/src/cuda/transform/multi_version_buffer_rewriter.cc
@@ -496,13 +496,17 @@ private:
     if (buffer.scope() == "shared.barrier") {
       // Barrier buffers: expand first dimension to keep 1D shape.
       // (1,) -> (num_versions,) so lower_shared_barrier.cc still works.
-      new_buffer->shape.Set(0, PrimExpr(num_versions) * new_buffer->shape[0]);
+      DataType shape_dtype = new_buffer->shape[0].dtype();
+      new_buffer->shape.Set(0, make_const(shape_dtype, num_versions) *
+                                   new_buffer->shape[0]);
     } else {
       new_buffer->shape.insert(new_buffer->shape.begin(),
                                PrimExpr(num_versions));
       if (!new_buffer->strides.empty()) {
         ICHECK(new_buffer->strides.size() + 1 == new_buffer->shape.size());
-        PrimExpr stride_0 = new_buffer->strides[0] * new_buffer->shape[1];
+        DataType stride_dtype = new_buffer->shape[1].dtype();
+        PrimExpr stride_0 = tvm::cast(stride_dtype, new_buffer->strides[0]) *
+                            new_buffer->shape[1];
         new_buffer->strides.insert(new_buffer->strides.begin(), stride_0);
       }
     }
@@ -718,20 +722,26 @@ private:
     EnsureVersionedBuffers(SelectVersionedBuffers(op->body, num_stages),
                            num_stages);
 
-    PrimExpr linear_index = loop_stack_[0].first;
+    DataType pipeline_iter_dtype = op->loop_var.dtype();
+    PrimExpr linear_index =
+        tvm::cast(pipeline_iter_dtype, loop_stack_[0].first);
     for (size_t i = 1; i < loop_stack_.size(); ++i) {
-      linear_index =
-          linear_index * loop_stack_[i].second + loop_stack_[i].first;
+      PrimExpr extent = tvm::cast(pipeline_iter_dtype, loop_stack_[i].second);
+      PrimExpr loop_var = tvm::cast(pipeline_iter_dtype, loop_stack_[i].first);
+      linear_index = linear_index * extent + loop_var;
     }
     PrimExpr old_version_index = version_index_;
     PrimExpr old_parity_cycle = parity_cycle_;
     Var old_pipeline_loop_var = pipeline_loop_var_;
     PrimExpr old_pipeline_loop_min = pipeline_loop_min_;
-    PrimExpr raw_version_index = FloorMod(linear_index, num_stages);
-    version_index_ =
-        Call(raw_version_index->dtype, mvb_stage_index(), {raw_version_index});
+    PrimExpr stages = make_const(linear_index.dtype(), num_stages);
+    PrimExpr stage_index =
+        tvm::cast(DataType::Int(32), FloorMod(linear_index, stages));
+    version_index_ = Call(DataType::Int(32), mvb_stage_index(), {stage_index});
     // Parity cycles every num_stages iterations for mbarrier phase tracking.
-    parity_cycle_ = FloorMod(FloorDiv(linear_index, num_stages), 2);
+    PrimExpr two = make_const(linear_index.dtype(), 2);
+    parity_cycle_ = tvm::cast(DataType::Int(32),
+                              FloorMod(FloorDiv(linear_index, stages), two));
     // Store the pipelined loop variable and its min value so we can compute
     // the initial-phase offset of each mbarrier_wait_parity expression.
     pipeline_loop_var_ = op->loop_var;
@@ -762,7 +772,10 @@ private:
     n->buffer = new_buffer;
     if (old_buffer.scope() == "shared.barrier") {
       // Barrier: offset into expanded 1D array
-      n->indices.Set(0, version_index * old_buffer->shape[0] + n->indices[0]);
+      DataType index_dtype = n->indices[0].dtype();
+      PrimExpr version = tvm::cast(index_dtype, version_index);
+      PrimExpr shape = tvm::cast(index_dtype, old_buffer->shape[0]);
+      n->indices.Set(0, version * shape + n->indices[0]);
     } else {
       n->indices.insert(n->indices.begin(), version_index);
     }
@@ -783,7 +796,10 @@ private:
     auto *n = store.CopyOnWrite();
     n->buffer = new_buffer;
     if (old_buffer.scope() == "shared.barrier") {
-      n->indices.Set(0, version_index * old_buffer->shape[0] + n->indices[0]);
+      DataType index_dtype = n->indices[0].dtype();
+      PrimExpr version = tvm::cast(index_dtype, version_index);
+      PrimExpr shape = tvm::cast(index_dtype, old_buffer->shape[0]);
+      n->indices.Set(0, version * shape + n->indices[0]);
     } else {
       n->indices.insert(n->indices.begin(), version_index);
     }
@@ -849,11 +865,15 @@ private:
             init_orig = analyzer.Simplify(tirx::Substitute(init_orig, subst));
             init_cycle = analyzer.Simplify(tirx::Substitute(init_cycle, subst));
           }
-          PrimExpr offset =
-              analyzer.Simplify(FloorMod(init_orig - init_cycle, 2));
+          DataType offset_dtype = init_orig.dtype();
+          PrimExpr init_delta = init_orig - tvm::cast(offset_dtype, init_cycle);
+          PrimExpr offset = analyzer.Simplify(
+              FloorMod(init_delta, make_const(init_delta.dtype(), 2)));
           if (const int64_t *imm = as_const_int(offset)) {
             if (*imm % 2 != 0) {
-              new_parity = FloorMod(parity_cycle + 1, 2);
+              PrimExpr one = make_const(parity_cycle.dtype(), 1);
+              PrimExpr two = make_const(parity_cycle.dtype(), 2);
+              new_parity = FloorMod(parity_cycle + one, two);
             }
           }
           Array<PrimExpr> new_args = call->args;
@@ -867,12 +887,12 @@ private:
 
   PrimExpr RewriteBufferAccess(const Call &call,
                                const std::vector<int> &arg_indices) {
-    auto product = [](const Array<PrimExpr> &input) {
-      return foldl(
-          [](PrimExpr a, PrimExpr b, Span span) {
-            return mul(std::move(a), std::move(b), std::move(span));
-          },
-          make_const(DataType::Int(32), 1), input);
+    auto product = [](const Array<PrimExpr> &input, DataType dtype) {
+      PrimExpr result = make_const(dtype, 1);
+      for (const PrimExpr &expr : input) {
+        result = result * tvm::cast(dtype, expr);
+      }
+      return result;
     };
     Array<PrimExpr> new_args = call->args;
     for (int i : arg_indices) {
@@ -889,11 +909,12 @@ private:
         const PrimExpr &old_index = call->args[i + 1];
         PrimExpr offset;
         if (new_buffer->strides.empty()) {
-          offset = product(buffer->shape);
+          offset = product(buffer->shape, old_index.dtype());
         } else {
-          offset = new_buffer->strides[0];
+          offset = tvm::cast(old_index.dtype(), new_buffer->strides[0]);
         }
-        PrimExpr new_index = old_index + version_index * offset;
+        PrimExpr typed_version = tvm::cast(old_index.dtype(), version_index);
+        PrimExpr new_index = old_index + typed_version * offset;
         new_args.Set(i + 1, new_index);
       }
     }

--- a/src/cuda/transform/producer_consumer_ws.cc
+++ b/src/cuda/transform/producer_consumer_ws.cc
@@ -21,6 +21,7 @@
  */
 
 #include "support/check.h"
+#include <algorithm>
 #include <tvm/arith/analyzer.h>
 #include <tvm/ffi/extra/structural_equal.h>
 #include <tvm/ir/cast.h>
@@ -31,6 +32,7 @@
 #include <tvm/tirx/stmt.h>
 #include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/transform.h>
+#include <utility>
 
 #include "backend/common/target_utils.h"
 #include "cuda/op/copy.h"
@@ -103,15 +105,12 @@ struct PhaseCounter {
   Stmt InitStmt() const { return Init(); }
 
   PrimExpr StageExpr(int num_stages) const {
-    if (num_stages == 1)
-      return IntImm(DataType::Int(32), 0);
-    return FloorMod(Load(), num_stages);
+    return FloorMod(Load(), IntImm(DataType::Int(32), num_stages));
   }
 
   PrimExpr ParityExpr(int num_stages) const {
-    if (num_stages == 1)
-      return FloorMod(Load(), 2);
-    return FloorMod(FloorDiv(Load(), num_stages), 2);
+    PrimExpr stages = IntImm(DataType::Int(32), num_stages);
+    return FloorMod(FloorDiv(Load(), stages), IntImm(DataType::Int(32), 2));
   }
 };
 
@@ -1394,10 +1393,14 @@ private:
     Var loop_var = pipeline_loop->loop_var;
     PrimExpr loop_min = pipeline_loop->min;
     PrimExpr loop_extent = pipeline_loop->extent;
-    PrimExpr linear_idx = loop_var - loop_min;
-
-    PrimExpr base_stage_expr = FloorMod(linear_idx, num_stages);
-    PrimExpr base_parity_expr = FloorMod(FloorDiv(linear_idx, num_stages), 2);
+    DataType pipeline_iter_dtype = loop_var.dtype();
+    PrimExpr linear_idx = loop_var - tvm::cast(pipeline_iter_dtype, loop_min);
+    PrimExpr stages = make_const(linear_idx.dtype(), num_stages);
+    PrimExpr base_stage_expr =
+        tvm::cast(DataType::Int(32), FloorMod(linear_idx, stages));
+    PrimExpr two = make_const(linear_idx.dtype(), 2);
+    PrimExpr base_parity_expr = tvm::cast(
+        DataType::Int(32), FloorMod(FloorDiv(linear_idx, stages), two));
 
     // When to switch from loop-var-based to counter-based stage/parity:
     //   (a) `loop_body_condition.defined()`: the pipeline body is guarded
@@ -1708,10 +1711,13 @@ private:
 
     std::vector<Array<Stmt>> prelude_waits_before_consumer(
         consumer_compute_stmts.size());
-    PrimExpr prelude_wait_guard =
-        needs_phase_counter ? EQ(consumer_phase_counter.value().Load(),
-                                 IntImm(DataType::Int(32), 0))
-                            : EQ(loop_var, loop_min);
+    PrimExpr prelude_wait_guard;
+    if (needs_phase_counter) {
+      prelude_wait_guard = EQ(consumer_phase_counter.value().Load(),
+                              IntImm(DataType::Int(32), 0));
+    } else {
+      prelude_wait_guard = EQ(loop_var, tvm::cast(loop_var.dtype(), loop_min));
+    }
     int prelude_barrier_base = num_fwd + num_bp;
     for (size_t i = 0; i < prelude_tma_plans.size(); ++i) {
       PrimExpr barrier_id = IntImm(DataType::Int(32), prelude_barrier_base + i);

--- a/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
+++ b/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
@@ -383,6 +383,30 @@ def test_tiled_ws_places_producer_in_first_warp_group():
     assert "if 128 <= tx:" not in script
 
 
+def test_tiled_ws_accepts_int64_pipeline_indices():
+    """Inductor-style TIR may use int64 shapes and loop extents."""
+
+    func = matmul_pipelined(
+        T.int64(32),
+        T.int64(1024),
+        T.int64(256),
+        T.int64(32),
+        T.int64(64),
+        T.int64(128),
+        num_stages=4,
+        dtype="bfloat16",
+    ).with_attr("global_symbol", "main")
+    mod = tvm.IRModule.from_expr(func)
+    target = determine_target({"kind": "cuda", "arch": "sm_90"}, return_object=True)
+    mod = tvm.tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.MaterializeKernelLaunch()(mod)
+    mod = tilelang.cuda.transform.ProducerConsumerWarpSpecialized()(mod)
+    script = mod["main"].script()
+
+    assert "tl_tiled_ws_applied" in script
+    assert "T.tma_copy" in script
+
+
 def _run_grouped_gemm_ws(kernel, batch_sizes, K=128, N=128, block_M=64, dtype="float16"):
     import torch
 
@@ -754,6 +778,7 @@ def test_tiled_ws_does_not_clone_local_var_into_producer_branch():
 
 if __name__ == "__main__":
     test_tiled_ws_places_producer_in_first_warp_group()
+    test_tiled_ws_accepts_int64_pipeline_indices()
     test_tiled_ws_stage1_dynamic_loop_start()
     test_tiled_ws_correctness()
     test_tiled_ws_stage3()


### PR DESCRIPTION
## Summary

- Fix ProducerConsumerWarpSpecialized and MultiVersionBufferRewriter when scheduled TIR carries int64 loop bounds or shapes.
- Construct stage/parity and storage index expressions with explicit owner dtypes instead of relying on a generic promotion helper.
- Add regression coverage for inductor-style int64 pipeline indices.

## Changes

- Build pipeline stage/parity arithmetic from the pipeline loop dtype, then cast the small stage/parity values back to int32.
- Keep barrier ids and parity values as int32 control values while casting only at the expression boundary that needs another dtype.
- Build barrier-buffer and access_ptr offsets from the existing storage index dtype before combining version indices with shapes or offsets.

## Validation

- `./format.sh`
- `cmake --build build -j$(nproc)`
- `python -m pytest testing/python/transform/test_tilelang_transform_producer_consumer_ws.py testing/python/transform/test_tilelang_transform_producer_consumer_ws_persistent.py -q`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes CUDA producer-consumer warp specialization and multi-version buffer rewriting to be dtype-aware when scheduled TIR uses `int64` loop bounds/shapes. The CUDA transforms now derive stage/parity indexing from the pipeline iteration dtype and explicitly cast bookkeeping values (stage/parity, barrier IDs, parity control) to `int32`, while keeping barrier/version flattening and `access_ptr` offset math consistent with the existing storage/index dtype.

- `multi_version_buffer_rewriter.cc`: updates barrier-buffer shape leading dimension and all barrier/version flattening and `tvm_access_ptr` offset remapping to use explicit `Int(32)` typing for version/parity indices and cast shape/stride-derived factors to the target index dtype; adds `num_stages == 1` fast paths and correct typed modulo/parity constant construction.
- `producer_consumer_ws.cc`: rebuilds per-iteration WS linear indexing via dtype-matched casts of loop bounds, constructs stage/parity expressions as `Int32` (with `num_stages == 1` handling), and updates guard predicates to compare against dtype-cast `loop_min`.

- Added regression coverage: `test_tiled_ws_accepts_int64_pipeline_indices()` ensures the CUDA ProducerConsumerWarpSpecialized transform accepts inductor-style `int64` pipeline indices/extents, and verifies the expected warp-specialization marker and TMA copy usage.

## C++ style / lint notes

Touches C++ implementation files (CUDA transform sources) but does not appear to change rules documented in `docs/developer_guide/cpp_style.md` or any C++ style/lint tooling configuration. The “C++ API Style Audit (warning only)” CI step remains advisory; any TLCPP003/TLCPP004 warnings should be treated as non-blocking unless this PR introduces new API/FFI/maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->