### PR TITLE
[BugFix] Preserve loop step when unrolling loops

### DIFF
--- a/src/transform/unroll_loop.cc
+++ b/src/transform/unroll_loop.cc
@@ -287,7 +287,15 @@ public:
     Map<Var, PrimExpr> vmap;
     Array<Stmt> unrolled;
     for (int i = 0; i < value; ++i) {
-      vmap.Set(op->loop_var, op->min + make_const(op->loop_var.dtype(), i));
+      // The i-th iteration value is min + i * step (step defaults to 1).
+      PrimExpr iter_value;
+      if (op->step.defined() && !is_one(op->step.value())) {
+        iter_value =
+            op->min + make_const(op->loop_var.dtype(), i) * op->step.value();
+      } else {
+        iter_value = op->min + make_const(op->loop_var.dtype(), i);
+      }
+      vmap.Set(op->loop_var, iter_value);
       Stmt step = Substitute(body, vmap);
       step = UnrolledBodyDefFreshener()(std::move(step));
       unrolled.push_back(step);

--- a/testing/python/transform/test_tilelang_transform_preserve_loop_step.py
+++ b/testing/python/transform/test_tilelang_transform_preserve_loop_step.py
@@ -31,3 +31,32 @@ def test_lower_opaque_block_preserves_non_unit_loop_step():
         output.numpy(),
         np.array([0, 1, 0, 1, 0, 1], dtype="int32"),
     )
+
+
+def test_unroll_loop_preserves_non_unit_loop_step():
+    output_buffer = tvm.tirx.decl_buffer((8,), "int32", name="output")
+    i = tvm.tirx.Var("i", "int32")
+    loop = tvm.tirx.For(
+        i,
+        0,
+        4,
+        tvm.tirx.ForKind.UNROLLED,
+        tvm.tirx.BufferStore(output_buffer, i, [i]),
+        step=tvm.tirx.IntImm("int32", 2),
+    )
+    before = tvm.tirx.PrimFunc(
+        [output_buffer.data],
+        loop,
+        buffer_map={output_buffer.data: output_buffer},
+    ).with_attr("global_symbol", "main")
+
+    mod = tl.transform.UnrollLoop()(tvm.IRModule.from_expr(before))
+    executable = tvm.compile(mod["main"], target="c").jit(options=["-std=c++17"])
+
+    output = tvm.runtime.tensor(np.zeros(8, dtype="int32"))
+    executable["main"](output)
+
+    np.testing.assert_array_equal(
+        output.numpy(),
+        np.array([0, 0, 2, 0, 4, 0, 6, 0], dtype="int32"),
+    )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Preserves non-unit loop steps during loop unrolling.
- Adds a regression test for unrolling loops with step `2`.

## C++ style / lint notes

- `docs/developer_guide/cpp_style.md` is not modified, and no documented style rules are touched.
- The repository’s **C++ API Style Audit (warning only)** CI step remains advisory; no correctness or build issues are indicated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->