### PR TITLE
[CUDA] Support arbitrary TMEM layouts

### DIFF
--- a/examples/deepseek_v4/test_tilelang_example_deepseek_v4.py
+++ b/examples/deepseek_v4/test_tilelang_example_deepseek_v4.py
@@ -13,7 +13,8 @@ def test_example_act_quant():
 
 
 @tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_eq(10, 0)
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
 def test_example_fp8_fp4_gemm_1d1d():
     fp8_fp4_gemm_1d1d_sm100.check_correctness(M=256, N=8192, K=512)
 

--- a/examples/gemm_sm100/gemm_tcgen5mma_ws.py
+++ b/examples/gemm_sm100/gemm_tcgen5mma_ws.py
@@ -9,7 +9,7 @@ from tilelang.profiler import do_bench
 
 
 @tilelang.jit
-def gemm(A, B, block_M, block_N, block_K, in_dtype, out_dtype, accum_dtype, num_stages, use_tma_store):
+def gemm(A, B, block_M, block_N, block_K, in_dtype, out_dtype, accum_dtype, num_stages, use_tma_store=True):
     M, N, K = T.const("M, N, K")
 
     k_iters = T.ceildiv(K, block_K)
@@ -74,7 +74,7 @@ def gemm(A, B, block_M, block_N, block_K, in_dtype, out_dtype, accum_dtype, num_
 
 
 @tilelang.jit
-def gemm_2cta(A, B, block_M, block_N, block_K, in_dtype, out_dtype, accum_dtype, num_stages, use_tma_store):
+def gemm_2cta(A, B, block_M, block_N, block_K, in_dtype, out_dtype, accum_dtype, num_stages, use_tma_store=True):
     M, N, K = T.const("M, N, K")
 
     k_iters = T.ceildiv(K, block_K)

--- a/examples/gemm_sm100/gemm_tcgen5mma_ws.py
+++ b/examples/gemm_sm100/gemm_tcgen5mma_ws.py
@@ -1,5 +1,7 @@
 # Non-persistent
 
+import argparse
+
 import torch
 import tilelang
 import tilelang.language as T
@@ -7,7 +9,7 @@ from tilelang.profiler import do_bench
 
 
 @tilelang.jit
-def gemm(A, B, block_M, block_N, block_K, in_dtype, out_dtype, accum_dtype, num_stages, use_tma_store=True):
+def gemm(A, B, block_M, block_N, block_K, in_dtype, out_dtype, accum_dtype, num_stages, use_tma_store):
     M, N, K = T.const("M, N, K")
 
     k_iters = T.ceildiv(K, block_K)
@@ -21,8 +23,10 @@ def gemm(A, B, block_M, block_N, block_K, in_dtype, out_dtype, accum_dtype, num_
         B_shared = T.alloc_shared((num_stages, block_K, block_N), in_dtype)
         C_tmem = T.alloc_tmem([block_M, block_N], accum_dtype)
         C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
-        C_shared = T.alloc_shared((block_M, block_N), out_dtype)
-        C_local_cast = T.alloc_fragment((block_M, block_N), out_dtype)
+        if use_tma_store:
+            C_shared = T.alloc_shared((block_M, block_N), out_dtype)
+        else:
+            C_local_cast = T.alloc_fragment((block_M, block_N), out_dtype)
         loaded = T.alloc_barrier([32] * num_stages)
         consumed = T.alloc_barrier([1] * num_stages)
         tmem_full = T.alloc_barrier([1])
@@ -70,7 +74,7 @@ def gemm(A, B, block_M, block_N, block_K, in_dtype, out_dtype, accum_dtype, num_
 
 
 @tilelang.jit
-def gemm_2cta(A, B, block_M, block_N, block_K, in_dtype, out_dtype, accum_dtype, num_stages, use_tma_store=True):
+def gemm_2cta(A, B, block_M, block_N, block_K, in_dtype, out_dtype, accum_dtype, num_stages, use_tma_store):
     M, N, K = T.const("M, N, K")
 
     k_iters = T.ceildiv(K, block_K)
@@ -84,8 +88,10 @@ def gemm_2cta(A, B, block_M, block_N, block_K, in_dtype, out_dtype, accum_dtype,
         B_shared = T.alloc_shared((num_stages, block_K, block_N // 2), in_dtype)  # Each cta hold half of B
         C_tmem = T.alloc_tmem([block_M, block_N], accum_dtype)
         C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
-        C_shared = T.alloc_shared((block_M, block_N), out_dtype)
-        C_local_cast = T.alloc_fragment((block_M, block_N), out_dtype)
+        if use_tma_store:
+            C_shared = T.alloc_shared((block_M, block_N), out_dtype)
+        else:
+            C_local_cast = T.alloc_fragment((block_M, block_N), out_dtype)
         loaded = T.alloc_cluster_barrier([32 * 2] * num_stages)
         consumed = T.alloc_cluster_barrier([1] * num_stages)
         tmem_full = T.alloc_barrier([1])
@@ -136,23 +142,47 @@ def gemm_2cta(A, B, block_M, block_N, block_K, in_dtype, out_dtype, accum_dtype,
 
 
 def main():
-    M, N, K = 8192, 8192, 8192
-    block_M, block_N, block_K = 128, 256, 64
+    parser = argparse.ArgumentParser(description="Non-persistent warp-specialized SM100 GEMM")
+    parser.add_argument("--m", type=int, default=8192)
+    parser.add_argument("--n", type=int, default=8192)
+    parser.add_argument("--k", type=int, default=8192)
+    parser.add_argument("--block_M", type=int, default=128)
+    parser.add_argument("--block_N", type=int, default=256)
+    parser.add_argument("--block_K", type=int, default=64)
+    parser.add_argument("--num_stages", type=int, default=None, help="pipeline stages (default: 6 with 2cta, else 4)")
+    parser.add_argument("--enable_2cta_tcgen5mma", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--use_tma_store", action=argparse.BooleanOptionalAction, default=True)
+    args = parser.parse_args()
+
+    M, N, K = args.m, args.n, args.k
     in_dtype, out_dtype, accum_dtype = T.bfloat16, T.bfloat16, T.float
-    enable_2cta_tcgen5mma = True
-    num_stages = 6 if enable_2cta_tcgen5mma else 4  # Each cta only needs to load half of B, enabling larger stages
+    enable_2cta_tcgen5mma = args.enable_2cta_tcgen5mma
+    if args.num_stages is not None:
+        num_stages = args.num_stages
+    else:
+        num_stages = 6 if enable_2cta_tcgen5mma else 4  # Each cta only needs to load half of B, enabling larger stages
     kernel = gemm_2cta if enable_2cta_tcgen5mma else gemm
+    kwargs = {
+        "block_M": args.block_M,
+        "block_N": args.block_N,
+        "block_K": args.block_K,
+        "in_dtype": in_dtype,
+        "out_dtype": out_dtype,
+        "accum_dtype": accum_dtype,
+        "num_stages": num_stages,
+        "use_tma_store": args.use_tma_store,
+    }
 
     a = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
     b = torch.randn(K, N, device="cuda", dtype=torch.bfloat16)
-    c = kernel(a, b, block_M, block_N, block_K, in_dtype, out_dtype, accum_dtype, num_stages)
-    print(kernel.get_kernel_source(a, b, block_M, block_N, block_K, in_dtype, out_dtype, accum_dtype, num_stages))
+    c = kernel(a, b, **kwargs)
+    print(kernel.get_kernel_source(a, b, **kwargs))
 
     ref_c = (a.to(torch.float) @ b.to(torch.float)).to(torch.bfloat16)
     torch.testing.assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
     print("All checks passed. ✅")
 
-    tl_latency = do_bench(lambda: kernel(a, b, block_M, block_N, block_K, in_dtype, out_dtype, accum_dtype, num_stages), backend="cupti")
+    tl_latency = do_bench(lambda: kernel(a, b, **kwargs), backend="cupti")
     torch_latency = do_bench(lambda: a @ b, backend="cupti")
     print(f"Tilelang latency: {tl_latency} ms")
     print(f"Flops: {2 * M * N * K / (tl_latency / 1e3) / 1e12} TFLOPS")

--- a/examples/gemm_sm100/gemm_tcgen5mma_ws_clc.py
+++ b/examples/gemm_sm100/gemm_tcgen5mma_ws_clc.py
@@ -1,3 +1,5 @@
+import argparse
+
 import torch
 import tilelang
 import tilelang.language as T
@@ -42,11 +44,12 @@ def gemm_clc_persistent_2cta(
     with T.ClusterKernel(total_cluster_tiles * 2, threads=256, cluster_dims=2) as block_id:
         A_shared = T.alloc_shared((num_stages, block_M, block_K), in_dtype)
         B_shared = T.alloc_shared((num_stages, block_K, block_N // 2), in_dtype)
-        C_tmem_0 = T.alloc_tmem([block_M, block_N], accum_dtype)
-        C_tmem_1 = T.alloc_tmem([block_M, block_N], accum_dtype)
-        C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
-        C_local_cast = T.alloc_fragment((block_M, block_N), out_dtype)
-        C_shared = T.alloc_shared((block_M, store_block_N), out_dtype)
+        C_tmem = T.alloc_tmem([2, block_M, block_N], accum_dtype)
+        C_local = T.alloc_fragment((block_M, store_block_N), accum_dtype)
+        if use_tma_store:
+            C_shared = T.alloc_shared((block_M, store_block_N), out_dtype)
+        else:
+            C_local_cast = T.alloc_fragment((block_M, store_block_N), out_dtype)
         loaded = T.alloc_cluster_barrier([32 * 2] * num_stages)
         consumed = T.alloc_cluster_barrier([1] * num_stages)
         tmem_full = T.alloc_cluster_barrier([1] * 2)
@@ -102,24 +105,14 @@ def gemm_clc_persistent_2cta(
                 for k in T.serial(k_blocks):
                     phase = work_iter * k_blocks + k
                     T.mbarrier_wait_parity(loaded[phase % num_stages], (phase // num_stages) & 1)
-                    if work_iter & 1 == 0:
-                        T.tcgen05_gemm(
-                            A_shared[phase % num_stages, :, :],
-                            B_shared[phase % num_stages, :, :],
-                            C_tmem_0,
-                            mbar=consumed[phase % num_stages],
-                            clear_accum=k == 0,
-                            use_2cta=True,
-                        )
-                    else:
-                        T.tcgen05_gemm(
-                            A_shared[phase % num_stages, :, :],
-                            B_shared[phase % num_stages, :, :],
-                            C_tmem_1,
-                            mbar=consumed[phase % num_stages],
-                            clear_accum=k == 0,
-                            use_2cta=True,
-                        )
+                    T.tcgen05_gemm(
+                        A_shared[phase % num_stages, :, :],
+                        B_shared[phase % num_stages, :, :],
+                        C_tmem[work_iter & 1, :, :],
+                        mbar=consumed[phase % num_stages],
+                        clear_accum=k == 0,
+                        use_2cta=True,
+                    )
                 T.tcgen05_mma_arrive(tmem_full[work_iter & 1], arrive_2cta=True)
 
         elif 64 <= tx < 96:
@@ -152,21 +145,29 @@ def gemm_clc_persistent_2cta(
 
                 T.mbarrier_wait_parity(tmem_full[work_iter & 1], (work_iter // 2) & 1)
                 T.sync_threads(1, 128)
-                if work_iter & 1 == 0:
-                    T.copy(C_tmem_0, C_local)
-                else:
-                    T.copy(C_tmem_1, C_local)
-                T.mbarrier_arrive(tmem_empty[work_iter & 1], 0)
 
-                if use_tma_store:
-                    for i in T.unroll(T.ceildiv(block_N, store_block_N)):
-                        T.copy(C_local[:, i * store_block_N : (i + 1) * store_block_N], C_shared)
+                for i in T.unroll(T.ceildiv(block_N, store_block_N)):
+                    T.copy(
+                        C_tmem[
+                            work_iter & 1,
+                            :,
+                            i * store_block_N : (i + 1) * store_block_N,
+                        ],
+                        C_local,
+                    )
+                    if use_tma_store:
+                        T.copy(C_local, C_shared)
                         T.sync_threads(3, 128)
                         T.copy(C_shared, C[bx * block_M, by * block_N + i * store_block_N])
                         T.sync_threads(3, 128)
-                else:
-                    T.copy(C_local, C_local_cast)
-                    T.copy(C_local_cast, C[bx * block_M, by * block_N])
+                    else:
+                        T.copy(C_local, C_local_cast)
+                        T.copy(
+                            C_local_cast,
+                            C[bx * block_M, by * block_N + i * store_block_N],
+                        )
+
+                T.mbarrier_arrive(tmem_empty[work_iter & 1], 0)
 
     return C
 
@@ -203,11 +204,12 @@ def gemm_clc_persistent_2cta_pipelined_clc(
     with T.ClusterKernel(total_cluster_tiles * 2, threads=256, cluster_dims=2) as block_id:
         A_shared = T.alloc_shared((num_stages, block_M, block_K), in_dtype)
         B_shared = T.alloc_shared((num_stages, block_K, block_N // 2), in_dtype)
-        C_tmem_0 = T.alloc_tmem([block_M, block_N], accum_dtype)
-        C_tmem_1 = T.alloc_tmem([block_M, block_N], accum_dtype)
-        C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
-        C_local_cast = T.alloc_fragment((block_M, block_N), out_dtype)
-        C_shared = T.alloc_shared((block_M, store_block_N), out_dtype)
+        C_tmem = T.alloc_tmem([2, block_M, block_N], accum_dtype)
+        C_local = T.alloc_fragment((block_M, store_block_N), accum_dtype)
+        if use_tma_store:
+            C_shared = T.alloc_shared((block_M, store_block_N), out_dtype)
+        else:
+            C_local_cast = T.alloc_fragment((block_M, store_block_N), out_dtype)
         loaded = T.alloc_cluster_barrier([32 * 2] * num_stages)
         consumed = T.alloc_cluster_barrier([1] * num_stages)
         tmem_full = T.alloc_cluster_barrier([1] * 2)
@@ -270,24 +272,14 @@ def gemm_clc_persistent_2cta_pipelined_clc(
                 for k in T.serial(k_blocks):
                     phase = work_iter * k_blocks + k
                     T.mbarrier_wait_parity(loaded[phase % num_stages], (phase // num_stages) & 1)
-                    if work_iter & 1 == 0:
-                        T.tcgen05_gemm(
-                            A_shared[phase % num_stages, :, :],
-                            B_shared[phase % num_stages, :, :],
-                            C_tmem_0,
-                            mbar=consumed[phase % num_stages],
-                            clear_accum=k == 0,
-                            use_2cta=True,
-                        )
-                    else:
-                        T.tcgen05_gemm(
-                            A_shared[phase % num_stages, :, :],
-                            B_shared[phase % num_stages, :, :],
-                            C_tmem_1,
-                            mbar=consumed[phase % num_stages],
-                            clear_accum=k == 0,
-                            use_2cta=True,
-                        )
+                    T.tcgen05_gemm(
+                        A_shared[phase % num_stages, :, :],
+                        B_shared[phase % num_stages, :, :],
+                        C_tmem[work_iter & 1, :, :],
+                        mbar=consumed[phase % num_stages],
+                        clear_accum=k == 0,
+                        use_2cta=True,
+                    )
                 T.tcgen05_mma_arrive(tmem_full[work_iter & 1], arrive_2cta=True)
 
         elif 64 <= tx < 96:
@@ -326,21 +318,29 @@ def gemm_clc_persistent_2cta_pipelined_clc(
 
                 T.mbarrier_wait_parity(tmem_full[work_iter & 1], (work_iter // 2) & 1)
                 T.sync_threads(1, 128)
-                if work_iter & 1 == 0:
-                    T.copy(C_tmem_0, C_local)
-                else:
-                    T.copy(C_tmem_1, C_local)
-                T.mbarrier_arrive(tmem_empty[work_iter & 1], 0)
 
-                if use_tma_store:
-                    for i in T.unroll(T.ceildiv(block_N, store_block_N)):
-                        T.copy(C_local[:, i * store_block_N : (i + 1) * store_block_N], C_shared)
+                for i in T.unroll(T.ceildiv(block_N, store_block_N)):
+                    T.copy(
+                        C_tmem[
+                            work_iter & 1,
+                            :,
+                            i * store_block_N : (i + 1) * store_block_N,
+                        ],
+                        C_local,
+                    )
+                    if use_tma_store:
+                        T.copy(C_local, C_shared)
                         T.sync_threads(3, 128)
                         T.copy(C_shared, C[bx * block_M, by * block_N + i * store_block_N])
                         T.sync_threads(3, 128)
-                else:
-                    T.copy(C_local, C_local_cast)
-                    T.copy(C_local_cast, C[bx * block_M, by * block_N])
+                    else:
+                        T.copy(C_local, C_local_cast)
+                        T.copy(
+                            C_local_cast,
+                            C[bx * block_M, by * block_N + i * store_block_N],
+                        )
+
+                T.mbarrier_arrive(tmem_empty[work_iter & 1], 0)
 
     return C
 
@@ -350,9 +350,28 @@ def ref_program(A, B):
 
 
 if __name__ == "__main__":
-    block_M, block_N, store_block_N, block_K = 128, 256, 64, 64
-    num_stages, group_size = 6, 8
-    base_args = (block_M, block_N, store_block_N, block_K, T.bfloat16, T.bfloat16, T.float, num_stages)
+    parser = argparse.ArgumentParser(description="CLC-scheduled persistent warp-specialized SM100 GEMM")
+    parser.add_argument("--block_M", type=int, default=128)
+    parser.add_argument("--block_N", type=int, default=256)
+    parser.add_argument("--store_block_N", type=int, default=64, help="block_N for C_shared")
+    parser.add_argument("--block_K", type=int, default=64)
+    parser.add_argument("--num_stages", type=int, default=6)
+    parser.add_argument("--group_size", type=int, default=8)
+    parser.add_argument("--use_tma_store", action=argparse.BooleanOptionalAction, default=True)
+    args = parser.parse_args()
+
+    group_size = args.group_size
+    use_tma_store = args.use_tma_store
+    base_args = (
+        args.block_M,
+        args.block_N,
+        args.store_block_N,
+        args.block_K,
+        T.bfloat16,
+        T.bfloat16,
+        T.float,
+        args.num_stages,
+    )
 
     for M, N, K in ((4096, 4096, 4096), (8192, 8192, 8192), (16384, 16384, 16384)):
         a = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
@@ -360,17 +379,18 @@ if __name__ == "__main__":
         ref = ref_program(a, b)
         flops = 2 * M * N * K
 
-        c = gemm_clc_persistent_2cta(a, b, *base_args, group_size)
+        c = gemm_clc_persistent_2cta(a, b, *base_args, group_size, use_tma_store)
         torch.testing.assert_close(c, ref, rtol=1e-2, atol=1e-2)
-        ms_base = do_bench(lambda a=a, b=b: gemm_clc_persistent_2cta(a, b, *base_args, group_size), backend="event")
+        ms_base = do_bench(lambda a=a, b=b: gemm_clc_persistent_2cta(a, b, *base_args, group_size, use_tma_store), backend="event")
 
         ms_torch = do_bench(lambda a=a, b=b: a @ b, backend="event")
         print(f"M=N=K={M:<6}  base: {flops / (ms_base / 1e3) / 1e12:6.1f} TFLOPS  torch: {flops / (ms_torch / 1e3) / 1e12:6.1f} TFLOPS")
 
         for clc in (2, 3, 4):
-            c2 = gemm_clc_persistent_2cta_pipelined_clc(a, b, *base_args, clc, group_size)
+            c2 = gemm_clc_persistent_2cta_pipelined_clc(a, b, *base_args, clc, group_size, use_tma_store)
             torch.testing.assert_close(c2, ref, rtol=1e-2, atol=1e-2)
             ms_pipe = do_bench(
-                lambda a=a, b=b, clc=clc: gemm_clc_persistent_2cta_pipelined_clc(a, b, *base_args, clc, group_size), backend="event"
+                lambda a=a, b=b, clc=clc: gemm_clc_persistent_2cta_pipelined_clc(a, b, *base_args, clc, group_size, use_tma_store),
+                backend="event",
             )
             print(f"             pipe(clc={clc}): {flops / (ms_pipe / 1e3) / 1e12:6.1f} TFLOPS  ({ms_base / ms_pipe:.3f}x vs base)")

--- a/examples/gemm_sm100/gemm_tcgen5mma_ws_persistent.py
+++ b/examples/gemm_sm100/gemm_tcgen5mma_ws_persistent.py
@@ -91,10 +91,10 @@ def gemm_persistent(
                     phase = sched.current_iter * k_blocks + k
                     T.mbarrier_wait_parity(loaded[phase % num_stages], (phase // num_stages) & 1)
                     T.tcgen05_gemm(
-                        A_shared[k % num_stages, :, :],
-                        B_shared[k % num_stages, :, :],
+                        A_shared[phase % num_stages, :, :],
+                        B_shared[phase % num_stages, :, :],
                         C_tmem[sched.current_iter & 1, :, :],
-                        mbar=consumed[k % num_stages],
+                        mbar=consumed[phase % num_stages],
                         clear_accum=k == 0,
                     )
                 T.tcgen05_mma_arrive(tmem_full[sched.current_iter & 1])

--- a/examples/gemm_sm100/gemm_tcgen5mma_ws_persistent.py
+++ b/examples/gemm_sm100/gemm_tcgen5mma_ws_persistent.py
@@ -7,6 +7,8 @@
 # ``sched.n_idx`` are the tile coords. One clock, held by the scheduler -- no
 # separate ``for w in range(waves)`` counter.
 
+import argparse
+
 import torch
 import tilelang
 import tilelang.language as T
@@ -26,7 +28,7 @@ def gemm_persistent(
     out_dtype,
     accum_dtype,
     num_stages,
-    use_tma_store=True,
+    use_tma_store,
 ):
     M, N, K = T.const("M, N, K")
 
@@ -45,11 +47,12 @@ def gemm_persistent(
     with T.Kernel(sm_num, threads=256) as (block_id):
         A_shared = T.alloc_shared((num_stages, block_M, block_K), in_dtype)
         B_shared = T.alloc_shared((num_stages, block_K, block_N), in_dtype)
-        C_tmem_0 = T.alloc_tmem([block_M, block_N], accum_dtype)
-        C_tmem_1 = T.alloc_tmem([block_M, block_N], accum_dtype)
-        C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
-        C_local_cast = T.alloc_fragment((block_M, block_N), out_dtype)
-        C_shared = T.alloc_shared((block_M, store_block_N), out_dtype)
+        C_tmem = T.alloc_tmem([2, block_M, block_N], accum_dtype)
+        C_local = T.alloc_fragment((block_M, store_block_N), accum_dtype)
+        if use_tma_store:
+            C_shared = T.alloc_shared((block_M, store_block_N), out_dtype)
+        else:
+            C_local_cast = T.alloc_fragment((block_M, store_block_N), out_dtype)
         loaded = T.alloc_barrier([32] * num_stages)
         consumed = T.alloc_barrier([1] * num_stages)
         tmem_full = T.alloc_barrier([1] * 2)
@@ -87,22 +90,13 @@ def gemm_persistent(
                 for k in T.serial(k_blocks):
                     phase = sched.current_iter * k_blocks + k
                     T.mbarrier_wait_parity(loaded[phase % num_stages], (phase // num_stages) & 1)
-                    if sched.current_iter & 1 == 0:
-                        T.tcgen05_gemm(
-                            A_shared[k % num_stages, :, :],
-                            B_shared[k % num_stages, :, :],
-                            C_tmem_0,
-                            mbar=consumed[k % num_stages],
-                            clear_accum=k == 0,
-                        )
-                    else:
-                        T.tcgen05_gemm(
-                            A_shared[k % num_stages, :, :],
-                            B_shared[k % num_stages, :, :],
-                            C_tmem_1,
-                            mbar=consumed[k % num_stages],
-                            clear_accum=k == 0,
-                        )
+                    T.tcgen05_gemm(
+                        A_shared[k % num_stages, :, :],
+                        B_shared[k % num_stages, :, :],
+                        C_tmem[sched.current_iter & 1, :, :],
+                        mbar=consumed[k % num_stages],
+                        clear_accum=k == 0,
+                    )
                 T.tcgen05_mma_arrive(tmem_full[sched.current_iter & 1])
                 sched.next_tile()
 
@@ -113,19 +107,28 @@ def gemm_persistent(
                 bx, by = sched.m_idx, sched.n_idx
 
                 T.mbarrier_wait_parity(tmem_full[sched.current_iter & 1], (sched.current_iter // 2) & 1)
-                if (sched.current_iter & 1) == 0:
-                    T.copy(C_tmem_0, C_local)
-                else:
-                    T.copy(C_tmem_1, C_local)
+
+                for i in T.unroll(T.ceildiv(block_N, store_block_N)):
+                    T.copy(
+                        C_tmem[
+                            sched.current_iter & 1,
+                            :,
+                            i * store_block_N : (i + 1) * store_block_N,
+                        ],
+                        C_local,
+                    )
+                    if use_tma_store:
+                        T.copy(C_local, C_shared)
+                        T.copy(C_shared, C[bx * block_M, by * block_N + i * store_block_N])
+                    else:
+                        T.copy(C_local, C_local_cast)
+                        T.copy(
+                            C_local_cast,
+                            C[bx * block_M, by * block_N + i * store_block_N],
+                        )
+
                 T.mbarrier_arrive(tmem_empty[sched.current_iter & 1])
 
-                if use_tma_store:
-                    for i in T.unroll(T.ceildiv(block_N, store_block_N)):
-                        T.copy(C_local[:, i * store_block_N : (i + 1) * store_block_N], C_shared)
-                        T.copy(C_shared, C[bx * block_M, by * block_N + i * store_block_N])
-                else:
-                    T.copy(C_local, C_local_cast)
-                    T.copy(C_local_cast, C[bx * block_M, by * block_N])
                 sched.next_tile()
     return C
 
@@ -142,7 +145,7 @@ def gemm_persistent_2cta(
     out_dtype,
     accum_dtype,
     num_stages,
-    use_tma_store=True,
+    use_tma_store,
 ):
     M, N, K = T.const("M, N, K")
 
@@ -162,11 +165,12 @@ def gemm_persistent_2cta(
     with T.ClusterKernel(sm_num, threads=256, cluster_dims=2) as (block_id):
         A_shared = T.alloc_shared((num_stages, block_M, block_K), in_dtype)
         B_shared = T.alloc_shared((num_stages, block_K, block_N // 2), in_dtype)
-        C_tmem_0 = T.alloc_tmem([block_M, block_N], accum_dtype)
-        C_tmem_1 = T.alloc_tmem([block_M, block_N], accum_dtype)
-        C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
-        C_local_cast = T.alloc_fragment((block_M, block_N), out_dtype)
-        C_shared = T.alloc_shared((block_M, store_block_N), out_dtype)
+        C_tmem = T.alloc_tmem([2, block_M, block_N], accum_dtype)
+        C_local = T.alloc_fragment((block_M, store_block_N), accum_dtype)
+        if use_tma_store:
+            C_shared = T.alloc_shared((block_M, store_block_N), out_dtype)
+        else:
+            C_local_cast = T.alloc_fragment((block_M, store_block_N), out_dtype)
         loaded = T.alloc_cluster_barrier([32 * 2] * num_stages)
         consumed = T.alloc_cluster_barrier([1] * num_stages)
         tmem_full = T.alloc_cluster_barrier([1] * 2)
@@ -207,24 +211,14 @@ def gemm_persistent_2cta(
                 for k in T.serial(k_blocks):
                     phase = sched.current_iter * k_blocks + k
                     T.mbarrier_wait_parity(loaded[phase % num_stages], (phase // num_stages) & 1)
-                    if sched.current_iter & 1 == 0:
-                        T.tcgen05_gemm(
-                            A_shared[phase % num_stages, :, :],
-                            B_shared[phase % num_stages, :, :],
-                            C_tmem_0,
-                            mbar=consumed[phase % num_stages],
-                            clear_accum=k == 0,
-                            use_2cta=True,
-                        )
-                    else:
-                        T.tcgen05_gemm(
-                            A_shared[phase % num_stages, :, :],
-                            B_shared[phase % num_stages, :, :],
-                            C_tmem_1,
-                            mbar=consumed[phase % num_stages],
-                            clear_accum=k == 0,
-                            use_2cta=True,
-                        )
+                    T.tcgen05_gemm(
+                        A_shared[phase % num_stages, :, :],
+                        B_shared[phase % num_stages, :, :],
+                        C_tmem[sched.current_iter & 1, :, :],
+                        mbar=consumed[phase % num_stages],
+                        clear_accum=k == 0,
+                        use_2cta=True,
+                    )
                 T.tcgen05_mma_arrive(tmem_full[sched.current_iter & 1], arrive_2cta=True)
                 sched.next_tile()
 
@@ -235,44 +229,78 @@ def gemm_persistent_2cta(
                 bx, by = sched.m_idx * cluster_size + cta_id, sched.n_idx
 
                 T.mbarrier_wait_parity(tmem_full[sched.current_iter & 1], (sched.current_iter // 2) & 1)
-                if (sched.current_iter & 1) == 0:
-                    T.copy(C_tmem_0, C_local)
-                else:
-                    T.copy(C_tmem_1, C_local)
+
+                for i in T.unroll(T.ceildiv(block_N, store_block_N)):
+                    T.copy(
+                        C_tmem[
+                            sched.current_iter & 1,
+                            :,
+                            i * store_block_N : (i + 1) * store_block_N,
+                        ],
+                        C_local,
+                    )
+                    if use_tma_store:
+                        T.copy(C_local, C_shared)
+                        T.copy(C_shared, C[bx * block_M, by * block_N + i * store_block_N])
+                    else:
+                        T.copy(C_local, C_local_cast)
+                        T.copy(
+                            C_local_cast,
+                            C[bx * block_M, by * block_N + i * store_block_N],
+                        )
+
                 T.mbarrier_arrive(tmem_empty[sched.current_iter & 1], 0)
 
-                if use_tma_store:
-                    for i in T.unroll(T.ceildiv(block_N, store_block_N)):
-                        T.copy(C_local[:, i * store_block_N : (i + 1) * store_block_N], C_shared)
-                        T.copy(C_shared, C[bx * block_M, by * block_N + i * store_block_N])
-                else:
-                    T.copy(C_local, C_local_cast)
-                    T.copy(C_local_cast, C[bx * block_M, by * block_N])
                 sched.next_tile()
 
     return C
 
 
 def main():
-    M, N, K = 8192, 8192, 8192
-    block_M, block_N, block_K = 128, 256, 64
-    store_block_N = 64
+    parser = argparse.ArgumentParser(description="Persistent warp-specialized SM100 GEMM")
+    parser.add_argument("--m", type=int, default=8192)
+    parser.add_argument("--n", type=int, default=8192)
+    parser.add_argument("--k", type=int, default=8192)
+    parser.add_argument("--block_M", type=int, default=128)
+    parser.add_argument("--block_N", type=int, default=256)
+    parser.add_argument("--block_K", type=int, default=64)
+    parser.add_argument("--store_block_N", type=int, default=64, help="block_N for C_shared")
+    parser.add_argument("--num_stages", type=int, default=None, help="pipeline stages (default: 6 with 2cta, else 4)")
+    parser.add_argument("--enable_2cta_tcgen5mma", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--use_tma_store", action=argparse.BooleanOptionalAction, default=True)
+    args = parser.parse_args()
+
+    M, N, K = args.m, args.n, args.k
     in_dtype, out_dtype, accum_dtype = T.bfloat16, T.bfloat16, T.float
-    enable_2cta_tcgen5mma = True
-    num_stages = 6 if enable_2cta_tcgen5mma else 4  # Each cta only needs to load half of B, enabling larger stages
+    enable_2cta_tcgen5mma = args.enable_2cta_tcgen5mma
+    if args.num_stages is not None:
+        num_stages = args.num_stages
+    else:
+        num_stages = 6 if enable_2cta_tcgen5mma else 4  # Each cta only needs to load half of B, enabling larger stages
     kernel = gemm_persistent_2cta if enable_2cta_tcgen5mma else gemm_persistent
+    kwargs = {
+        "block_M": args.block_M,
+        "block_N": args.block_N,
+        "store_block_N": args.store_block_N,
+        "block_K": args.block_K,
+        "in_dtype": in_dtype,
+        "out_dtype": out_dtype,
+        "accum_dtype": accum_dtype,
+        "num_stages": num_stages,
+        "use_tma_store": args.use_tma_store,
+    }
 
     a = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
     b = torch.randn(K, N, device="cuda", dtype=torch.bfloat16)
-    print(kernel.get_kernel_source(a, b, block_M, block_N, store_block_N, block_K, in_dtype, out_dtype, accum_dtype, num_stages))
-    c = kernel(a, b, block_M, block_N, store_block_N, block_K, in_dtype, out_dtype, accum_dtype, num_stages)
+    print(kernel.get_kernel_source(a, b, **kwargs))
+    c = kernel(a, b, **kwargs)
 
     ref_c = (a.to(torch.float) @ b.to(torch.float)).to(torch.bfloat16)
     torch.testing.assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
     print("All checks passed. ✅")
 
     tl_latency = do_bench(
-        lambda: kernel(a, b, block_M, block_N, store_block_N, block_K, in_dtype, out_dtype, accum_dtype, num_stages),
+        lambda: kernel(a, b, **kwargs),
         _n_warmup=50,
         _n_repeat=50,
         backend="cupti",

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -569,6 +569,17 @@ void Copy::CheckParallelLoopLayout(const CopyNode &op, CopyInst copy_inst) {
   LOG(FATAL) << oss.str();
 }
 
+// Infer the register Fragment of a TMEM<->fragment copy from the TMEM
+// buffer's inferred layout, so that the copy later lowers to one
+// tcgen05.ld/st (LowerTmem below).
+//
+// Running example used throughout (a split epilogue reading one accumulator
+// in two halves with 128 threads):
+//   C_tmem  = alloc_tmem((128, 128), f32), fragment (128,128):(1@0,1@1)
+//             (@0 = TMEM datapath axis, @1 = TMEM column axis)
+//   C_local = alloc_fragment((128, 128), f32)
+//   T.copy(C_tmem[:, 0:64],   C_local[:, 0:64])    <- this op
+//   T.copy(C_tmem[:, 64:128], C_local[:, 64:128])  <- a later op, same result
 LayoutMap Copy::InferTMemLayout(const CopyNode &op,
                                 const LayoutInferArgs &layout_args,
                                 CopyInst copy_inst) {
@@ -581,23 +592,43 @@ LayoutMap Copy::InferTMemLayout(const CopyNode &op,
   if (!layout_args.layout_map.count(reg_buf) &&
       layout_args.layout_map.count(tmem_buf)) {
     Layout tmem_layout = layout_args.layout_map[tmem_buf];
-    Array<IterVar> logical_coords = op.MakeIterVars();
-    Array<PrimExpr> logical_coords_var = {logical_coords[0]->var,
-                                          logical_coords[1]->var};
-    Array<PrimExpr> phy_indices = tmem_layout->Forward(logical_coords_var);
 
-    arith::Analyzer analyzer;
-    for (const auto &iv : logical_coords) {
-      analyzer.Bind(iv->var, iv->dom);
+    // logical buffer coord -> physical TMEM (datapath@0, column@1)
+    // E.g., tmem_frag = (128,128):(1@0,1@1)
+    Optional<cute::Layout> tmem_frag =
+        cute::LayoutFromTileLangHierarchical(tmem_layout);
+    ICHECK(tmem_frag.defined())
+        << "TMEM layout of " << tmem_buf->name
+        << " is not decodable by the CuTe analyzer: " << tmem_layout;
+
+    // As in CuTe's make_tmem_copy, the tiled copy is described relative to
+    // the Region origin: cute::Restrict splits the fragment into origin +
+    // tile, where the (possibly dynamic) origin only moves the tcgen05_ld/st
+    // base address and the static tile maps region-local coordinates to
+    // (datapath, column) steps.  Leading batch modes of a rank>2 buffer ride
+    // in the tile like any other mode (the fragment repeats them along
+    // columns).
+    // region-local coord -> (datapath, column) step from the origin
+    // E.g., origin = (0,0),  tile = (128,64):(1@0,1@1)
+    //       (the second copy differs only in origin = (0,64))
+    const Array<Range> &tmem_ranges =
+        is_tmem_load ? op.src_range : op.dst_range;
+    const Array<Range> &reg_ranges = is_tmem_load ? op.dst_range : op.src_range;
+    cute::Layout tile = cute::Restrict(tmem_frag.value(), tmem_ranges).get<1>();
+
+    // The register buffer is a grid of such slices (a split epilogue issues
+    // one copy per slice), each appending its own registers.
+    // E.g., nrep = (1, 2): two column halves.
+    size_t rank = reg_ranges.size();
+    Array<int64_t> nrep;
+    int64_t total_reps = 1;
+    for (size_t dim = 0; dim < rank; ++dim) {
+      const auto *buf_ext = as_const_int(reg_buf->shape[dim]);
+      const auto *reg_ext = as_const_int(reg_ranges[dim]->extent);
+      ICHECK(buf_ext && reg_ext && *buf_ext % *reg_ext == 0);
+      nrep.push_back(*buf_ext / *reg_ext);
+      total_reps *= nrep.back();
     }
-    arith::ConstIntBound phy_row_bounds =
-        analyzer.const_int_bound(phy_indices[0]);
-    arith::ConstIntBound phy_col_bounds =
-        analyzer.const_int_bound(phy_indices[1]);
-    Range row_dom = Range(static_cast<int>(phy_row_bounds->min_value),
-                          static_cast<int>(phy_row_bounds->max_value + 1));
-    Range col_dom = Range(static_cast<int>(phy_col_bounds->min_value),
-                          static_cast<int>(phy_col_bounds->max_value + 1));
 
     constexpr int WARP_SIZE = 32;
     constexpr int WARPGROUP_SIZE = 4 * WARP_SIZE;
@@ -613,19 +644,49 @@ LayoutMap Copy::InferTMemLayout(const CopyNode &op,
     for (int num_useful_wgs = num_threads / WARPGROUP_SIZE; num_useful_wgs >= 1;
          --num_useful_wgs) {
       int num_useful_threads = num_useful_wgs * WARPGROUP_SIZE;
-      Tcgen05Meta meta = GetTcgen05MetaLd32Dp32B();
-      auto [is_success, tmem_coord2frag, num_chunks_each_wg] =
-          ExpandTcgen05Layout(
-              meta, phy_col_bounds->max_value - phy_col_bounds->min_value + 1,
-              num_useful_threads, row_dom, col_dom);
-      (void)num_chunks_each_wg;
-      if (!is_success) {
+      // region-local coord -> (thread@0, value@1)
+      // E.g., local_frag = (128,64):(1@0,1@1) for 32dp32b, 128 threads
+      //       (thread = datapath, value = column within the slice).
+      Tcgen05CopyPlan expanded = ExpandTcgen05Layout(GetTcgen05MetaLd32Dp32B(),
+                                                     tile, num_useful_threads);
+      if (!expanded.defined()) {
         continue;
       }
-      Fragment logical_coord2frag =
-          Fragment(logical_coords, tmem_coord2frag->Forward(phy_indices),
-                   tmem_coord2frag->ForwardThread(phy_indices, std::nullopt),
-                   MakeIterVar("rep", 1));
+      cute::Layout local_frag = expanded->fragment;
+      int64_t vals_per_slice =
+          cute::AsConst(cute::Size(local_frag)) / num_useful_threads;
+
+      // Repeat the slice along the value vector to cover the whole register
+      // buffer: each further slice appends one slice's worth of registers
+      // per thread (row-major slice grid, matching the buffer's row-major
+      // element order), so every slice of a split copy lands in its own
+      // value range of one full-buffer Fragment.  Unit-extent region dims
+      // (dropped by Restrict) carry only their repetition mode.
+      // per-dim slice index -> value@1
+      // E.g., rep_grid = Composition(2:64@1, (1,2):(2,1)) = (1,2):(128@1,64@1)
+      //       full mode 1 pairs the slice's column mode with its repetition:
+      //       full = ((128,1),(64,2)):((1@0,128@1),(1@1,64@1))
+      //       so C_local[i, 64+j] -> thread i, value 64+j: the second copy's
+      //       64 registers per thread follow the first's, and the layout is
+      //       identical no matter which half inferred it.
+      cute::Layout rep_grid = cute::Composition(
+          cute::Layout(total_reps, vals_per_slice * cute::E({1})),
+          cute::MakeRowMajorLayout(nrep));
+      Array<cute::Layout> modes;
+      int64_t tile_idx = 0;
+      for (size_t dim = 0; dim < rank; ++dim) {
+        if (is_one(reg_ranges[dim]->extent)) {
+          modes.push_back(rep_grid[dim]);
+        } else {
+          modes.push_back(
+              cute::MakeLayout({local_frag[tile_idx++], rep_grid[dim]}));
+        }
+      }
+      ICHECK_EQ(tile_idx, cute::Rank(tile))
+          << "TMEM copy tile rank does not match the register loop rank";
+
+      // full buffer coord -> (thread@0, value@1)
+      Fragment logical_coord2frag = FragmentToTileLang(cute::MakeLayout(modes));
       results.Set(reg_buf, logical_coord2frag->BindThreadRange(
                                layout_args.thread_bounds));
       break;
@@ -1247,6 +1308,39 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &lower_args,
   return for_node;
 }
 
+namespace {
+
+// Unpack a (datapath, column) coordinate IntTuple produced by evaluating a
+// TMEM cute fragment into exactly two scalar expressions.  Adding the rank-2
+// zero ArithmeticTuple first normalizes the coordinate: an axis the layout
+// never touches materializes as a plain zero slot.
+Array<PrimExpr> TmemCoordExprs(const cute::IntTuple &coord) {
+  DataType dtype = DataType::Int(32);
+  cute::IntTuple normalized = coord + cute::IntTupleTuple({0, 0});
+  Array<cute::IntTuple> fields = cute::TupleFields(normalized);
+  ICHECK_EQ(fields.size(), 2U)
+      << "TMEM coordinate must be (datapath, column), got " << coord;
+  return {cute::AsConstOrPrimExpr(fields[0], dtype),
+          cute::AsConstOrPrimExpr(fields[1], dtype)};
+}
+
+} // namespace
+
+// Lower a TMEM<->fragment copy to one tcgen05.ld/st call.
+//
+// Running example (the same split epilogue as InferTMemLayout, lowering its
+// SECOND half so the Region origin is nonzero):
+//   C_tmem  = alloc_tmem((128, 128), f32), fragment (128,128):(1@0,1@1)
+//   C_local = alloc_fragment((128, 128), f32), 128 threads, whose inferred
+//             Fragment is full_tv = ((128,1),(64,2)):((1@0,128@1),(1@1,64@1))
+//   T.copy(C_tmem[:, 64:128], C_local[:, 64:128])
+//
+// The instruction pattern (which threads move which (datapath, column)) is
+// static and validated against the register Fragment; the Region origin only
+// selects WHERE: it becomes the tcgen05_ld/st base-address token
+// (LowerSharedTmem later encodes it as datapath<<16 | b32column), so a
+// dynamic origin -- e.g. a software-pipeline stage index -- just moves the
+// base address.
 Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
                      arith::Analyzer *analyzer) {
   const Buffer &src = op.src;
@@ -1272,16 +1366,16 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
   } else if (src.scope() == "shared.dyn" && dst.scope() == "shared.tmem") {
     is_cp = true;
   } else {
-    LOG(FATAL) << "Unsupported tensor memory copy: "
-               << "src scope = " << src.scope()
-               << ", dst scope = " << dst.scope();
+    LOG(FATAL) << "Unsupported tensor memory copy: " << "src scope = "
+               << src.scope() << ", dst scope = " << dst.scope();
   }
   ICHECK(!is_cp)
       << "Copy from shared memory to tensor memory is not supported yet";
 
   Array<IterVar> loop_vars = op.MakeIterVars();
-  ICHECK(loop_vars.size() == 2) << "Only support 2D tensor memory copy, got "
-                                << loop_vars.size() << " dimensions";
+  ICHECK_GE(loop_vars.size(), 2U)
+      << "Tensor memory copy needs at least the two matrix dimensions, got "
+      << loop_vars.size();
   for (const auto &iv : loop_vars)
     analyzer->Bind(iv->var, iv->dom);
   PrimExpr src_predicate = op.MakePredicate(analyzer, loop_vars, src->shape, 0);
@@ -1289,14 +1383,10 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
   ICHECK(!src_predicate.defined() && !dst_predicate.defined())
       << "Tensor memory copy does not support predicates, got " << src_predicate
       << " and " << dst_predicate;
-  ICHECK(is_const_int(loop_vars[0]->dom->min) &&
-         is_const_int(loop_vars[0]->dom->extent) &&
-         is_const_int(loop_vars[1]->dom->min) &&
-         is_const_int(loop_vars[1]->dom->extent))
-      << "Tensor memory copy requires loop bounds to be constant integers";
-  int64_t logical_row_min = *as_const_int(loop_vars[0]->dom->min);
-  int64_t logical_col_min = *as_const_int(loop_vars[1]->dom->min);
-
+  for (const auto &iv : loop_vars) {
+    ICHECK(is_const_int(iv->dom->min) && is_const_int(iv->dom->extent))
+        << "Tensor memory copy requires loop bounds to be constant integers";
+  }
   constexpr int WARP_SIZE = 32;
   constexpr int WARPGROUP_SIZE = 4 * WARP_SIZE;
   ICHECK(is_const_int(lower_args.thread_bounds->extent))
@@ -1324,55 +1414,108 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
   Layout tmem_layout = lower_args.layout_map[tmem_buf];
   Fragment reg_layout = Downcast<Fragment>(lower_args.layout_map[reg_buf]);
 
-  Array<PrimExpr> logical_indices = op.MakeIndices(loop_vars, tmem_side);
-  Array<PrimExpr> phy_indices = tmem_layout->Forward(logical_indices);
+  Array<PrimExpr> tmem_logical_indices = op.MakeIndices(loop_vars, tmem_side);
+  Array<PrimExpr> reg_logical_indices =
+      op.MakeIndices(loop_vars, 1 - tmem_side);
 
-  arith::ConstIntBound phy_row_bounds =
-      analyzer->const_int_bound(phy_indices[0]);
-  arith::ConstIntBound phy_col_bounds =
-      analyzer->const_int_bound(phy_indices[1]);
-  int tmem_phy_row_min = phy_row_bounds->min_value;
-  int tmem_phy_row_max = phy_row_bounds->max_value;
-  int tmem_phy_col_min = phy_col_bounds->min_value;
-  int tmem_phy_col_max = phy_col_bounds->max_value;
-  int tmem_phy_col_extent = tmem_phy_col_max - tmem_phy_col_min + 1;
-  Range row_dom = Range(tmem_phy_row_min, tmem_phy_row_max + 1);
-  Range col_dom = Range(tmem_phy_col_min, tmem_phy_col_max + 1);
+  // logical buffer coord -> physical TMEM (datapath@0, column@1)
+  Optional<cute::Layout> tmem_frag =
+      cute::LayoutFromTileLangHierarchical(tmem_layout);
+  ICHECK(tmem_frag.defined())
+      << "TMEM layout of " << tmem_buf->name
+      << " is not decodable by the CuTe analyzer: " << tmem_layout;
+
+  // As in CuTe's make_tmem_copy, describe the tiled copy relative to the
+  // Region origin: cute::Restrict splits the fragment into origin + tile,
+  // where the origin — which may be dynamic, for example a software-pipeline
+  // stage — only moves the base address carried by the tcgen05_ld/st address
+  // token, and the static tile maps the region-local loop coordinates to
+  // (datapath, column) steps.
+  // region-local coord -> (datapath, column) step from the origin
+  // E.g., phy_origin = (0, 64),  tile = (128,64):(1@0,1@1)
+  const Array<Range> &tmem_ranges =
+      tmem_side == 0 ? op.src_range : op.dst_range;
+  auto restricted = cute::Restrict(tmem_frag.value(), tmem_ranges);
+  Array<PrimExpr> phy_origin = TmemCoordExprs(restricted.get<0>());
+  cute::Layout tile = restricted.get<1>();
+  ICHECK_EQ(cute::Rank(tile), static_cast<int64_t>(loop_vars.size()))
+      << "TMEM copy tile rank does not match the copy loop rank";
+
+  size_t tmem_rank = tmem_buf->shape.size();
+
+  // The address token below is the Region's logical origin across all buffer
+  // modes (leading batch modes are pinned by the Region).  LowerTileOp
+  // materializes the buffer's layout over it, so no separate origin
+  // adjustment is needed here.
+  Map<Var, PrimExpr> loop_to_origin;
+  for (const auto &iv : loop_vars) {
+    loop_to_origin.Set(iv->var, iv->dom->min);
+  }
+  Array<PrimExpr> tmem_origin_indices =
+      tmem_logical_indices.Map([&](const PrimExpr &index) {
+        return analyzer->Simplify(Substitute(index, loop_to_origin));
+      });
+  if (needs_pack_unpack) {
+    ICHECK(analyzer->CanProveEqual(
+        FloorMod(tmem_origin_indices[tmem_rank - 1], 2), 0))
+        << "A sliced 16-bit TMEM copy must start at an even logical column";
+  }
 
   bool have_succeeded = false;
   Stmt body;
+
+  Array<PrimExpr> loop_exprs;
+  for (const auto &iv : loop_vars) {
+    loop_exprs.push_back(iv->var);
+  }
 
   auto try_tcgen05_instruction = [&](Tcgen05Meta meta) {
     if (have_succeeded) {
       return;
     }
-    if (tmem_phy_row_min != 0 || tmem_phy_row_max != 127) {
-      return;
-    }
-    if (tmem_phy_col_min % meta.width != 0 ||
-        (tmem_phy_col_max + 1) % meta.width != 0) {
+    int width = static_cast<int>(Tcgen05AtomWidth(meta));
+    if (!analyzer->CanProveEqual(phy_origin[0], 0) ||
+        !analyzer->CanProveEqual(FloorMod(phy_origin[1], width), 0)) {
       return;
     }
 
     for (int num_useful_wgs = num_threads / WARPGROUP_SIZE; num_useful_wgs >= 1;
          num_useful_wgs--) {
       int num_useful_threads = num_useful_wgs * WARPGROUP_SIZE;
-      auto [is_success, target_frag, num_chunks_each_wg] = ExpandTcgen05Layout(
-          meta, tmem_phy_col_extent, num_useful_threads, row_dom, col_dom);
-      if (!is_success) {
+      // region-local loop coord -> (thread@0, value@1)
+      Tcgen05CopyPlan plan =
+          ExpandTcgen05Layout(meta, tile, num_useful_threads);
+      if (!plan.defined()) {
         continue;
       }
+      int num_chunks_each_wg = static_cast<int>(plan->num_chunks_each_wg);
 
+      // The single conversion to a TileLang Fragment happens only on this
+      // final composed layout.
+      // E.g., fragment = (128,64):(1@0,1@1): loop (i, j) -> thread i,
+      //       value j.
+      Fragment target_frag = FragmentToTileLang(plan->fragment);
+
+      // The instruction's pattern must agree with the register buffer's
+      // Fragment on this Region, up to the Region's base register -- like
+      // the TMEM origin, that base may be dynamic (e.g. a serial slice
+      // loop) and only offsets the register pointer below.
+      // E.g., reg_layout maps C_local[i, 64+j] -> thread i, value 64+j, so
+      //       reg_thread == target_thread == i, and reg_val == 64+j with
+      //       reg_origin = 64: the instruction covers registers 64..127 of
+      //       each thread, and the access_ptr below starts at offset 64.
       PrimExpr target_thread =
-          target_frag->ForwardThread(phy_indices, std::nullopt);
+          target_frag->ForwardThread(loop_exprs, std::nullopt);
       PrimExpr reg_thread =
-          reg_layout->ForwardThread(logical_indices, std::nullopt);
+          reg_layout->ForwardThread(reg_logical_indices, std::nullopt);
       if (!analyzer->CanProveEqual(target_thread, reg_thread)) {
         continue;
       }
-      PrimExpr target_reg = target_frag->Forward(phy_indices)[0];
-      PrimExpr reg_val = reg_layout->Forward(logical_indices)[0];
-      if (!analyzer->CanProveEqual(target_reg, reg_val)) {
+      PrimExpr target_reg = target_frag->Forward(loop_exprs)[0];
+      PrimExpr reg_val = reg_layout->Forward(reg_logical_indices)[0];
+      PrimExpr reg_origin =
+          analyzer->Simplify(Substitute(reg_val, loop_to_origin));
+      if (!analyzer->CanProveEqual(target_reg, reg_val - reg_origin)) {
         continue;
       }
 
@@ -1382,36 +1525,63 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
       PrimExpr relative_wg_idx =
           FloorDiv(Sub(lower_args.thread_index, lower_args.thread_bounds->min),
                    WARPGROUP_SIZE);
-      PrimExpr col_offset =
-          num_useful_threads == WARPGROUP_SIZE
-              ? PrimExpr(0)
-              : relative_wg_idx * (effective_chunks * meta.width);
+      PrimExpr col_offset = num_useful_threads == WARPGROUP_SIZE
+                                ? PrimExpr(0)
+                                : relative_wg_idx * (effective_chunks * width);
+      int64_t vals_per_issue = plan->vals_per_issue;
       have_succeeded = true;
-      Array<PrimExpr> args;
-      Stmt call;
-      if (is_ld) {
-        args.push_back(IntImm(DataType::Int(32), meta.width * 32));
+
+      // One tcgen05 call per issue (rest coordinate): a gapped tile copies
+      // one contiguous chunk at a time.  Issue r starts at the region-local
+      // logical coords idx2crd(rest_domain(r)) -- decoded column-major over
+      // the loop extents -- and appends vals_per_issue registers per
+      // thread after the previous issues'.
+      // E.g., the running example (one issue) emits
+      //   tl::tcgen05_ld_32dp32bNx<64, false>(C_tmem[0, 64], 0,
+      //                                       &C_local[64]);
+      // where the C_tmem[0, 64] token becomes base + (0<<16 | 64) in
+      // LowerSharedTmem, and &C_local[64] is the per-thread register slice
+      // at offset reg_origin.
+      Array<Stmt> calls;
+      Buffer orig_reg_buf = is_ld ? op.dst : op.src;
+      for (int64_t issue = 0; issue < plan->num_issues; ++issue) {
+        int64_t flat = cute::AsConst(plan->rest_domain(issue));
+        Map<Var, PrimExpr> loop_to_issue;
+        for (const auto &iv : loop_vars) {
+          int64_t extent = *as_const_int(iv->dom->extent);
+          loop_to_issue.Set(iv->var, iv->dom->min +
+                                         IntImm(iv->var->dtype, flat % extent));
+          flat /= extent;
+        }
+        Array<PrimExpr> issue_tmem_indices =
+            tmem_logical_indices.Map([&](const PrimExpr &index) {
+              return analyzer->Simplify(Substitute(index, loop_to_issue));
+            });
+        // The access_ptr offset is a LOGICAL linear offset: LowerTileOp's
+        // HandleAccessPtrAndOffset later decodes it over the register
+        // buffer's logical shape and maps it through the Fragment to the
+        // per-thread register index.  Linearize the issue's register origin
+        // row-major over the buffer shape.
+        PrimExpr issue_reg_offset = IntImm(DataType::Int(32), 0);
+        for (size_t d = 0; d < reg_logical_indices.size(); ++d) {
+          issue_reg_offset = issue_reg_offset * orig_reg_buf->shape[d] +
+                             Substitute(reg_logical_indices[d], loop_to_issue);
+        }
+        issue_reg_offset = analyzer->Simplify(issue_reg_offset);
+        Array<PrimExpr> args;
+        args.push_back(IntImm(DataType::Int(32), width * 32));
         args.push_back(IntImm(DataType::Int(32), effective_chunks));
         args.push_back(Bool(use_pack_unpack_modifier));
-        args.push_back(
-            BufferLoad(tmem_buf, {(int)logical_row_min, (int)logical_col_min}));
+        args.push_back(BufferLoad(tmem_buf, issue_tmem_indices));
         args.push_back(col_offset);
-        args.push_back(reg_buf.access_ptr(/*access_mask=*/2, DataType::Handle(),
-                                          /*content_lanes=*/1, /*offset=*/0,
-                                          PrimExpr(tmem_phy_col_extent)));
-        call = Evaluate(Call(DataType::Handle(), tcgen05_ld(), args));
-      } else {
-        args.push_back(IntImm(DataType::Int(32), meta.width * 32));
-        args.push_back(IntImm(DataType::Int(32), effective_chunks));
-        args.push_back(Bool(use_pack_unpack_modifier));
-        args.push_back(
-            BufferLoad(tmem_buf, {(int)logical_row_min, (int)logical_col_min}));
-        args.push_back(col_offset);
-        args.push_back(reg_buf.access_ptr(/*access_mask=*/1, DataType::Handle(),
-                                          /*content_lanes=*/1, /*offset=*/0,
-                                          PrimExpr(tmem_phy_col_extent)));
-        call = Evaluate(Call(DataType::Handle(), tcgen05_st(), args));
+        args.push_back(reg_buf.access_ptr(
+            /*access_mask=*/is_ld ? 2 : 1, DataType::Handle(),
+            /*content_lanes=*/1, /*offset=*/issue_reg_offset,
+            PrimExpr(static_cast<int>(vals_per_issue))));
+        calls.push_back(Evaluate(Call(
+            DataType::Handle(), is_ld ? tcgen05_ld() : tcgen05_st(), args)));
       }
+      Stmt call = calls.size() == 1 ? calls[0] : SeqStmt(calls);
       if (num_useful_threads != num_threads) {
         body =
             IfThenElse(lower_args.thread_index <
@@ -1426,14 +1596,14 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
 
   if (is_ld) {
     try_tcgen05_instruction(GetTcgen05MetaLd32Dp32B());
-    try_tcgen05_instruction(GetTcgen05MetaLd32Dp64B());
-    try_tcgen05_instruction(GetTcgen05MetaLd32Dp128B());
-    try_tcgen05_instruction(GetTcgen05MetaLd32Dp256B());
+    try_tcgen05_instruction(GetTcgen05MetaLd16Dp64B());
+    try_tcgen05_instruction(GetTcgen05MetaLd16Dp128B());
+    try_tcgen05_instruction(GetTcgen05MetaLd16Dp256B());
   } else {
     try_tcgen05_instruction(GetTcgen05MetaSt32Dp32B());
-    try_tcgen05_instruction(GetTcgen05MetaSt32Dp64B());
-    try_tcgen05_instruction(GetTcgen05MetaSt32Dp128B());
-    try_tcgen05_instruction(GetTcgen05MetaSt32Dp256B());
+    try_tcgen05_instruction(GetTcgen05MetaSt16Dp64B());
+    try_tcgen05_instruction(GetTcgen05MetaSt16Dp128B());
+    try_tcgen05_instruction(GetTcgen05MetaSt16Dp256B());
   }
 
   ICHECK(have_succeeded) << "Failed to find a suitable instruction for tcgen05."

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -366,6 +366,39 @@ MakeTMARows(const Buffer &src, const Array<Range> &src_ranges,
   return std::make_pair(Array<Stmt>{for_loop}, extent * body_cnt);
 }
 
+// CuTe's make_tmem_copy works in the tensor's value width by upcasting the
+// atom's ValID (copy_traits_sm100.hpp:300).  Our tiles already address
+// (datapath@0, value-column@1), so the same unit change is one composition
+// with the value -> storage column map ((1),(vpb,1)):((1@0),(0,1@1)):
+// b32 column = value column / vpb, the sub-slot position dropping onto the
+// stride-0 mode (exactly CuTe upcast's shape-division, layout.hpp:1809).
+cute::Layout TmemTileToB32Columns(const cute::Layout &tile,
+                                  int64_t values_per_b32) {
+  cute::Layout value_to_b32 =
+      cute::MakeLayout({cute::Layout(1, cute::E({0})),
+                        cute::Layout(cute::IntTupleTuple({values_per_b32, 1}),
+                                     cute::IntTupleTuple({0, cute::E({1})}))});
+  return cute::Composition(value_to_b32, tile);
+}
+
+// A 16-bit fragment that needs the tcgen05.ld/st pack::16b / unpack::16b
+// modifiers does not cover its codomain: every value column is half-filled,
+// so size < cosize.  This is the accumulator format the MMA hardware writes
+// -- PTX ISA "Packing format for matrix D in Tensor Memory"
+// (9.7.17.10.4.1): a 16-bit matrix D element occupies the lower 16 bits of
+// its own 32-bit tensor-memory word (CUTLASS FrgTypeC's
+// StorageType=uint32_t / ValueType=half) -- and pack::16b is how tcgen05.ld
+// gathers those low halves (two adjacent words per register).  A fragment
+// with two values packed per b32 column is a bijection onto its footprint
+// and moves with the plain instruction.  The storage format is a property
+// of the buffer's layout, so it is decided on the WHOLE fragment -- a
+// Region slice of a batched buffer also leaves codomain gaps, but those
+// are batch gaps, not half-filled columns.
+bool TmemFragmentNeedsPack16b(const cute::Layout &fragment) {
+  return cute::AsConst(cute::Size(fragment)) !=
+         cute::AsConst(cute::Cosize(fragment));
+}
+
 } // namespace
 
 namespace cuda {
@@ -615,6 +648,17 @@ LayoutMap Copy::InferTMemLayout(const CopyNode &op,
         is_tmem_load ? op.src_range : op.dst_range;
     const Array<Range> &reg_ranges = is_tmem_load ? op.dst_range : op.src_range;
     cute::Layout tile = cute::Restrict(tmem_frag.value(), tmem_ranges).get<1>();
+
+    // A pack::16b tile (one value per b32 storage slot, CUTLASS FrgTypeC)
+    // is planned in b32 columns -- the CuTe upcast make_tmem_copy applies
+    // to ValID.  Shapes are untouched, so the fragment's logical
+    // coordinates and value order carry over unchanged (b32 column j holds
+    // exactly value j).  A 16-bit tile with two values per b32 column keeps
+    // its value-column planning: the plain instruction moves whole columns
+    // of packed pairs.
+    int64_t values_per_b32 = 32 / (tmem_buf->dtype.bits());
+    if (values_per_b32 > 1 && TmemFragmentNeedsPack16b(tmem_frag.value()))
+      tile = TmemTileToB32Columns(tile, values_per_b32);
 
     // The register buffer is a grid of such slices (a split epilogue issues
     // one copy per slice), each appending its own registers.
@@ -1441,6 +1485,32 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
   ICHECK_EQ(cute::Rank(tile), static_cast<int64_t>(loop_vars.size()))
       << "TMEM copy tile rank does not match the copy loop rank";
 
+  // 16-bit values in 32-bit TMEM columns come in two layouts (see
+  // InferTMemLayout):
+  //  * pack::16b / unpack::16b (one value in the low half of each word,
+  //    CUTLASS FrgTypeC): plan on the b32-upcast tile; the modifier's
+  //    registers gather the low halves of two ADJACENT b32 columns
+  //    (Copy_Traits<*_16b> ValID) -- one register per two columns;
+  //  * two values packed per b32 column: plan in value columns and move
+  //    whole columns of packed pairs with the PLAIN instruction -- one
+  //    register per column, i.e. per two values.
+  // Either way one register covers two values, so the wrapper's N is half
+  // the planned chunk count.
+  int64_t values_per_b32 = 32 / (tmem_buf->dtype.bits());
+  bool pack16b =
+      values_per_b32 > 1 && TmemFragmentNeedsPack16b(tmem_frag.value());
+  if (pack16b) {
+    tile = TmemTileToB32Columns(tile, values_per_b32);
+    // The width-alignment checks below run in the tile's (b32) units; a
+    // pack::16b origin is always storage-slot aligned.
+    ICHECK(analyzer->CanProveEqual(
+        FloorMod(phy_origin[1], IntImm(DataType::Int(32), values_per_b32)), 0))
+        << "A pack::16b TMEM origin must start on a b32 column";
+    phy_origin.Set(
+        1, analyzer->Simplify(FloorDiv(
+               phy_origin[1], IntImm(DataType::Int(32), values_per_b32))));
+  }
+
   size_t tmem_rank = tmem_buf->shape.size();
 
   // The address token below is the Region's logical origin across all buffer
@@ -1455,10 +1525,11 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
       tmem_logical_indices.Map([&](const PrimExpr &index) {
         return analyzer->Simplify(Substitute(index, loop_to_origin));
       });
-  if (needs_pack_unpack) {
+  if (needs_pack_unpack && !pack16b) {
     ICHECK(analyzer->CanProveEqual(
         FloorMod(tmem_origin_indices[tmem_rank - 1], 2), 0))
-        << "A sliced 16-bit TMEM copy must start at an even logical column";
+        << "A sliced packed 16-bit TMEM copy must start at an even logical "
+           "column";
   }
 
   bool have_succeeded = false;
@@ -1519,15 +1590,23 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
         continue;
       }
 
-      bool use_pack_unpack_modifier = is_ld ? needs_pack_unpack : false;
+      bool use_pack_unpack_modifier = pack16b;
+      // One register covers two 16-bit values -- pack::16b spans two b32
+      // columns, a packed pair shares one -- so the wrapper's N is half the
+      // planned chunk count (N is always a power of two).
       int effective_chunks =
           needs_pack_unpack ? num_chunks_each_wg / 2 : num_chunks_each_wg;
       PrimExpr relative_wg_idx =
           FloorDiv(Sub(lower_args.thread_index, lower_args.thread_bounds->min),
                    WARPGROUP_SIZE);
+      // Column offsets are raw b32 columns: a pack::16b tile's chunk count
+      // already is b32 columns, a packed-pair tile's is halved (planned in
+      // value columns, two per b32).
+      int chunk_cols =
+          pack16b ? num_chunks_each_wg * width : effective_chunks * width;
       PrimExpr col_offset = num_useful_threads == WARPGROUP_SIZE
                                 ? PrimExpr(0)
-                                : relative_wg_idx * (effective_chunks * width);
+                                : relative_wg_idx * chunk_cols;
       int64_t vals_per_issue = plan->vals_per_issue;
       have_succeeded = true;
 

--- a/src/cuda/op/gemm.cc
+++ b/src/cuda/op/gemm.cc
@@ -116,6 +116,15 @@ bool AllowVoltaMma(const GemmNode &op) {
   return op.m_ % 16 == 0 && op.n_ % 16 == 0 && op.k_ % 4 == 0;
 }
 
+bool Use2CtaRequested(const GemmNode &op) {
+  if (auto val = op.annotations_.Get("use_2cta")) {
+    const auto *imm = val.value().as<IntImmNode>();
+    ICHECK(imm) << "use_2cta annotation must be an IntImmNode";
+    return imm->value != 0;
+  }
+  return false;
+}
+
 void FatalWgmmaUnavailable(const GemmNode &op, Target target) {
   LOG(FATAL) << "T.wgmma_gemm() requires Hopper WGMMA lowering, but "
                 "constraints were not satisfied. Got target="
@@ -297,6 +306,18 @@ struct Gemm {
     if (op.isTcgen05_) {
       if (!AllowTcgen5Mma(op, target)) {
         FatalTcgen5Unavailable(op, target);
+      }
+      return kCudaTCGEN05;
+    }
+
+    // The public 2CTA shape contract supplies only half of B's N extent per
+    // CTA.
+    // Falling back to an ordinary one-CTA instruction would therefore be a
+    // silent out-of-bounds miscompile rather than a valid fallback.
+    if (Use2CtaRequested(op)) {
+      if (!AllowTcgen5Mma(op, target)) {
+        LOG(FATAL) << "use_2cta=True requires Blackwell TCGEN5MMA "
+                      "lowering; no one-CTA instruction fallback is valid.";
       }
       return kCudaTCGEN05;
     }

--- a/src/cuda/transform/lower_blackwell_2sm.cc
+++ b/src/cuda/transform/lower_blackwell_2sm.cc
@@ -46,7 +46,7 @@ static bool HasValidClusterDimsFor2Cta(const Stmt &body) {
       if (block->annotations.count("cluster_dims")) {
         if (auto arr = block->annotations.Get("cluster_dims")
                            ->try_cast<Array<Integer>>()) {
-          if (arr.value().size() >= 3) {
+          if (arr.value().size() == 3) {
             int64_t x = arr.value()[0]->value;
             int64_t y = arr.value()[1]->value;
             int64_t z = arr.value()[2]->value;
@@ -83,9 +83,10 @@ private:
           if (const auto *imm = val.as<IntImmNode>()) {
             if (imm->value) {
               if (!cluster_dims_valid_) {
-                LOG(WARNING) << "Invalid cluster_dims disables 2CTA "
-                                "TCGEN5MMA, use 1CTA variant instead.";
-                return StmtExprMutator::VisitStmt_(op);
+                LOG(FATAL) << "T.tcgen05_gemm(use_2cta=True) requires "
+                              "cluster_dims (2,1,1) or (1,2,1); a one-CTA "
+                              "fallback is not valid for rank-sharded "
+                              "operands.";
               }
               has_2sm_tcgen5mma_ = true;
             }

--- a/src/cuda/transform/lower_shared_tmem.cc
+++ b/src/cuda/transform/lower_shared_tmem.cc
@@ -106,13 +106,41 @@ public:
   }
 
 private:
+  static int GetValueBitWidth(DataType dtype) {
+    int value_bits = dtype.bits() * dtype.lanes();
+    ICHECK_GT(value_bits, 0) << "Invalid TMEM value dtype " << dtype;
+    return value_bits;
+  }
+
+  static PrimExpr ValueColumnOffsetToB32Column(PrimExpr value_col,
+                                               DataType dtype) {
+    arith::Analyzer analyzer;
+    DataType index_dtype = value_col->dtype;
+    PrimExpr value_bits = IntImm(index_dtype, GetValueBitWidth(dtype));
+    PrimExpr bits_per_column = IntImm(index_dtype, 32);
+    PrimExpr bit_offset = analyzer.Simplify(value_col * value_bits);
+    ICHECK(analyzer.CanProveEqual(FloorMod(bit_offset, bits_per_column),
+                                  IntImm(index_dtype, 0)))
+        << "TMEM address must start on a b32 column, but value-column offset "
+        << value_col << " of dtype " << dtype << " has bit offset "
+        << bit_offset;
+    return analyzer.Simplify(FloorDiv(bit_offset, bits_per_column));
+  }
+
   int GetNumColsAllocated(const Buffer &buffer) const {
+    // LowerTileOp has already materialized the buffer's inferred layout, so
+    // the buffer shape is the physical (datapath, value-column) footprint.
     ICHECK_EQ(buffer->shape.size(), 2U);
 
     auto analyzer = std::make_shared<arith::Analyzer>();
     arith::ConstIntBound phy_col_bounds =
         analyzer->const_int_bound(buffer->shape[1]);
-    int num_cols_required = phy_col_bounds->max_value;
+    int num_value_cols_required = phy_col_bounds->max_value;
+    // Layout column coordinates count values of buffer->dtype; PTX TMEM
+    // allocation counts 32-bit columns.  Round up so a final partially
+    // occupied b32 column is included.
+    int num_cols_required =
+        (num_value_cols_required * GetValueBitWidth(buffer->dtype) + 31) / 32;
     ICHECK(num_cols_required <= 512)
         << "The number of columns required for tmem buffer " << buffer->name
         << " is " << num_cols_required
@@ -316,30 +344,31 @@ private:
   }
 
   PrimExpr GetTmemOffset(const Buffer &buffer, const Array<PrimExpr> &indices) {
-    ICHECK(buffer->shape.size() == 2);
-    ICHECK(indices.size() == 2);
-    ICHECK(layout_map_.defined());
-    ICHECK(layout_map_.count(buffer))
-        << "The layout of tmem buffer " << buffer->name
-        << " is not defined in the layout map";
-    auto layout = layout_map_[buffer];
-    ICHECK(layout.defined());
-    Array<PrimExpr> tmem_phy_coords = layout->Forward(indices);
-    PrimExpr result =
-        tmem_phy_coords[0] << 16 |
-        tmem_phy_coords
-            [1]; // https://docs.nvidia.com/cuda/parallel-thread-execution/#tensor-memory-addressing
+    // LowerTileOp MATERIALIZED the buffer's inferred layout: it rewrote the
+    // allocation to the layout's physical shape and pushed every address
+    // token through Layout::Forward.  Whatever the fragment's structure --
+    // interleaved datapaths (PTX Layout F), weight-stationary N folding
+    // (Layouts E/G), 2SM shards, leading batch modes -- `indices` here are
+    // always the resulting physical (datapath, value-column) pair; this pass
+    // only encodes them into the hardware word.  A TMEM buffer that skipped
+    // layout inference would still be logical, which the rank check below
+    // (and the 2-D allocation check above) rejects.
+    ICHECK_EQ(indices.size(), 2U)
+        << "TMEM address for " << buffer->name
+        << " must be a (datapath, value-column) coordinate";
+    // https://docs.nvidia.com/cuda/parallel-thread-execution/#tensor-memory-addressing
+    PrimExpr result = indices[0] << 16 |
+                      ValueColumnOffsetToB32Column(indices[1], buffer->dtype);
     return result;
   }
 
   PrimExpr VisitExpr_(const BufferLoadNode *op) final {
-    // Translate tmem[logical_row, logical_col] to tmem[0] + tmem_offset
+    // Translate tmem[datapath, value_col] to tmem[0] + tmem_offset
     // Where
-    // - (logical_row, logical_col) is the logical address in the tmem buffer
+    // - (datapath, value_col) is the physical address in the tmem buffer
     // - tmem[0] is the base address allocated for the tmem buffer
-    // - tmem_offset = tmem_phy_coords[0]<<16 | tmem_phy_coords[1]
-    //   where tmem_phy_coords = layout.Forward(logical_row, logical_col)
-    //   is the physical address in the tmem buffer
+    // - tmem_offset = datapath<<16 | b32_col, with b32_col converted from
+    //   the typed value-column coordinate
     auto load = Downcast<BufferLoad>(StmtExprMutator::VisitExpr_(op));
     auto buffer = load->buffer;
     auto indices = load->indices;

--- a/src/layout/cute_layout.cc
+++ b/src/layout/cute_layout.cc
@@ -9,6 +9,8 @@
 
 #include "support/check.h"
 #include <algorithm>
+#include <cctype>
+#include <cstdio>
 #include <cstdlib>
 #include <limits>
 #include <map>
@@ -80,6 +82,20 @@ Swizzle Swizzle::Recast(int old_bits, int new_bits) const {
   return Swizzle(n->b_bits, n->m_base + (old_log - new_log), n->s_shift);
 }
 
+Swizzle Swizzle::Parse(const ffi::String &text) {
+  std::string s(text);
+  int b_bits, m_base, s_shift;
+  ICHECK_EQ(std::sscanf(s.c_str(), "Sw<%d,%d,%d>", &b_bits, &m_base, &s_shift),
+            3)
+      << "Swizzle text must be 'Sw<b,m,s>', got '" << s << "'";
+  return Swizzle(b_bits, m_base, s_shift);
+}
+
+void Swizzle::Print(std::ostream &os) const {
+  os << "Sw<" << (*this)->b_bits << "," << (*this)->m_base << ","
+     << (*this)->s_shift << ">";
+}
+
 IntTuple::IntTuple(int64_t value) {
   auto node = make_object<IntTupleConstNode>();
   node->value = value;
@@ -108,6 +124,121 @@ IntTuple IntTuple::operator[](int64_t index) const {
   // A scalar leaf has rank 1 and [0] returns itself.
   ICHECK(index == 0) << "Leaf index out of range: " << index << " vs 0";
   return *this;
+}
+
+namespace {
+
+// Recursive-descent parser for the CuTe IntTuple spelling emitted by
+// IntTuple::Print: nested "(a,b,...)" tuples, decimal integer leaves, and
+// scaled bases "v@m@..." with the mode path innermost-first (E<1,0> is
+// spelled 1@0@1), exactly inverting the printer. Whitespace is free.
+class IntTupleParser {
+public:
+  explicit IntTupleParser(const std::string &text) : text_(text) {}
+
+  IntTuple Parse() {
+    IntTuple result = ParseTerm();
+    SkipSpace();
+    ICHECK_EQ(pos_, text_.size()) << "Trailing characters in IntTuple text: '"
+                                  << text_.substr(pos_) << "'";
+    return result;
+  }
+
+  IntTuple ParseTerm() {
+    SkipSpace();
+    IntTuple value;
+    if (Peek() == '(') {
+      ++pos_;
+      Array<IntTuple> fields;
+      SkipSpace();
+      while (Peek() != ')') {
+        fields.push_back(ParseTerm());
+        SkipSpace();
+        if (Peek() == ',') {
+          ++pos_;
+        } else {
+          ICHECK_EQ(Peek(), ')') << "Expected ',' or ')' at position " << pos_
+                                 << " of '" << text_ << "'";
+        }
+        SkipSpace();
+      }
+      ++pos_;
+      value = IntTupleTuple(std::move(fields));
+    } else {
+      value = ParseInt();
+    }
+    // A scaled basis: value@m@... with the path innermost-first.
+    SkipSpace();
+    if (Peek() != '@')
+      return value;
+    std::vector<int64_t> path;
+    while (Peek() == '@') {
+      ++pos_;
+      path.push_back(ParseInt());
+      SkipSpace();
+    }
+    // The printed path is reversed (innermost-first); restore outer-first.
+    return value * E(Array<int64_t>(path.rbegin(), path.rend()));
+  }
+
+private:
+  char Peek() const { return pos_ < text_.size() ? text_[pos_] : '\0'; }
+
+  void SkipSpace() {
+    while (pos_ < text_.size() && std::isspace(text_[pos_]))
+      ++pos_;
+  }
+
+  int64_t ParseInt() {
+    SkipSpace();
+    size_t start = pos_;
+    if (Peek() == '-')
+      ++pos_;
+    while (pos_ < text_.size() && std::isdigit(text_[pos_]))
+      ++pos_;
+    ICHECK_GT(pos_, start + (text_[start] == '-' ? 1 : 0))
+        << "Expected an integer at position " << start << " of '" << text_
+        << "'";
+    return std::stoll(text_.substr(start, pos_ - start));
+  }
+
+  const std::string &text_;
+  size_t pos_{0};
+};
+
+} // namespace
+
+IntTuple IntTuple::Parse(const ffi::String &text) {
+  std::string s(text);
+  return IntTupleParser(s).Parse();
+}
+
+void IntTuple::Print(std::ostream &os) const {
+  if (const auto *c = as<IntTupleConstNode>()) {
+    os << c->value;
+    return;
+  }
+  if (const auto *e = as<IntTuplePrimExprNode>()) {
+    os << e->value;
+    return;
+  }
+  if (const auto *b = as<IntTupleScaledBasisNode>()) {
+    // CuTe scaled-basis spelling value@m@...: the mode path prints
+    // innermost-first (CuTe's E<...> print order), e.g. E<1,0> -> 1@0@1.
+    b->value.Print(os);
+    for (auto it = b->basis.rbegin(); it != b->basis.rend(); ++it)
+      os << "@" << *it;
+    return;
+  }
+  const auto *a = as<IntTupleTupleNode>();
+  ICHECK(a != nullptr) << "IntTuple::Print on an unknown IntTuple kind";
+  os << "(";
+  for (size_t i = 0; i < a->fields.size(); ++i) {
+    if (i > 0)
+      os << ",";
+    a->fields[i].Print(os);
+  }
+  os << ")";
 }
 
 namespace {
@@ -207,6 +338,10 @@ IntTuple CompactColMajor(const IntTuple &shape, IntTuple &acc) {
       out.push_back(CompactColMajor(shape[i], acc));
     return IntTupleTuple(out);
   }
+  // A static size-1 mode takes stride 0 (CuTe compact, stride.hpp:302) and
+  // leaves the running product untouched.
+  if (IsConst(shape) && AsConst(shape) == 1)
+    return IntTuple(int64_t(0));
   IntTuple stride = acc;
   acc = MulLeaf(acc, shape);
   return stride;
@@ -228,6 +363,9 @@ IntTuple CompactRowMajor(const IntTuple &shape, IntTuple &acc) {
       out.Set(i, CompactRowMajor(shape[i], acc));
     return IntTupleTuple(out);
   }
+  // A static size-1 mode takes stride 0 (CuTe compact, stride.hpp:302).
+  if (IsConst(shape) && AsConst(shape) == 1)
+    return IntTuple(int64_t(0));
   IntTuple stride = acc;
   acc = MulLeaf(acc, shape);
   return stride;
@@ -317,6 +455,23 @@ IntTuple operator+(const IntTuple &a, const IntTuple &b) {
 }
 
 IntTuple operator*(const IntTuple &a, const IntTuple &b) {
+  bool ba = IsScaledBasis(a), bb = IsScaledBasis(b);
+  ICHECK(!(ba && bb)) << "Two ScaledBasis leaves cannot multiply";
+  // A ScaledBasis multiplies into its scale (CuTe arithmetic_tuple.hpp
+  // operator*: a * E<Ns...>{v} == E<Ns...>{a * v}) with no special case for
+  // zero -- 0 * E<1> is the basis term 0@1, not the plain additive identity
+  // (only ArithmeticTuple ADDITION has C<0> shortcuts).  The recursion
+  // distributes a tuple peer over its leaves ((2,3) * E<1> == (2@1, 3@1)),
+  // an extension beyond CuTe (which only defines scalar peers).
+  if (ba || bb) {
+    const IntTuple &basis = ba ? a : b;
+    const IntTuple &peer = ba ? b : a;
+    Array<int64_t> path = BasisPath(basis);
+    IntTuple scale = BasisValue(basis);
+    return TransformLeaf(peer, [&](const IntTuple &leaf) -> IntTuple {
+      return IntTuple(IntTupleScaledBasis(MulLeaf(scale, leaf), path));
+    });
+  }
   if (IsTuple(a) || IsTuple(b)) {
     int64_t ra = Rank(a), rb = Rank(b);
     ICHECK_EQ(ra, rb) << "Must have the same rank";
@@ -326,12 +481,6 @@ IntTuple operator*(const IntTuple &a, const IntTuple &b) {
     }
     return IntTupleTuple(std::move(out));
   }
-  bool ba = IsScaledBasis(a), bb = IsScaledBasis(b);
-  ICHECK(!(ba && bb)) << "Two ScaledBasis leaves cannot multiply";
-  if (ba)
-    return IntTupleScaledBasis(MulLeaf(BasisValue(a), b), BasisPath(a));
-  if (bb)
-    return IntTupleScaledBasis(MulLeaf(a, BasisValue(b)), BasisPath(b));
   return MulLeaf(a, b);
 }
 
@@ -399,6 +548,47 @@ bool Congruent(const IntTuple &a, const IntTuple &b) {
     if (!Congruent(a[i], b[i]))
       return false;
   return true;
+}
+
+bool Compatible(const IntTuple &a, const IntTuple &b) {
+  if (IsTuple(a) && IsTuple(b)) {
+    int64_t n = Rank(a);
+    if (Rank(b) != n)
+      return false;
+    for (int64_t i = 0; i < n; ++i) {
+      if (!Compatible(a[i], b[i]))
+        return false;
+    }
+    return true;
+  }
+  if (IsTuple(a))
+    return false;
+
+  // Shapes have integral leaves.  A ScaledBasis is meaningful in a stride,
+  // but it is not a shape terminal and cannot participate in compatibility.
+  if ((!IsConst(a) && !IsPrimExpr(a)) ||
+      FoldLeaves(b, false, [](bool invalid, const IntTuple &leaf) {
+        return invalid || (!IsConst(leaf) && !IsPrimExpr(leaf));
+      })) {
+    return false;
+  }
+
+  IntTuple b_size = Product(b);
+  if (IsConst(a) && IsConst(b_size))
+    return AsConst(a) == AsConst(b_size);
+
+  // CuTe compares integral terminals by value, not by expression identity.
+  // Use the dynamic terminal's dtype for a constant peer and let Analyzer
+  // prove algebraically equivalent expressions (for example n + n == 2*n).
+  DataType dtype =
+      IsPrimExpr(a) ? AsPrimExpr(a)->dtype : AsPrimExpr(b_size)->dtype;
+  if (IsPrimExpr(a) && IsPrimExpr(b_size) &&
+      AsPrimExpr(a)->dtype != AsPrimExpr(b_size)->dtype) {
+    return false;
+  }
+  arith::Analyzer analyzer;
+  return analyzer.CanProveEqual(AsConstOrPrimExpr(a, dtype),
+                                AsConstOrPrimExpr(b_size, dtype));
 }
 
 Layout::Layout(Array<int64_t> shape, Array<int64_t> stride) {
@@ -494,8 +684,9 @@ IntTuple Crd2Idx(const IntTuple &coord, const IntTuple &shape,
     }
     return acc;
   }
-  // Scalar coord, scalar shape, scalar stride: c * d (operator* keeps a
-  // ScaledBasis stride's basis, yielding a coordinate term).
+  // Scalar coord, scalar shape, scalar stride: c * d. operator* keeps a
+  // zero product on its basis (0@i, like CuTe), which is what pads the
+  // coordinate sum to full rank: E<0>{c} + E<1>{0} == (c, 0).
   return coord * stride;
 }
 
@@ -636,6 +827,50 @@ Layout RightInverse(const Layout &layout) {
   if (out_sh.empty())
     return Coalesce(Layout(Array<int64_t>{1}, Array<int64_t>{0}));
   return Coalesce(Layout(out_sh, out_st));
+}
+
+Layout LeftInverse(const Layout &layout) {
+  // CuTe left_inverse (layout.hpp:1324): coalesce, sort the modes by stride,
+  // and divide successive strides.  Each emitted mode's shape is the ratio
+  // stride / size-so-far -- a serialized gap folds INTO the mode covering it
+  // -- and its stride is the sorted mode's position in the flattened domain
+  // (the exclusive prefix product), with a leading stride-0 slot absorbing
+  // everything below the smallest stride.  Stride-0 (broadcast) modes are
+  // skipped; the largest-stride mode contributes its full extent last.
+  Layout flat = Coalesce(layout);
+  IntTuple fsh = Flatten(flat->shape), fst = Flatten(flat->stride);
+  int64_t r = Rank(fsh);
+  std::vector<int64_t> order, preprod(r, 1);
+  int64_t acc = 1;
+  for (int64_t i = 0; i < r; ++i) {
+    ICHECK(IsConst(fsh[i]) && IsConst(fst[i]))
+        << "LeftInverse requires static shapes and strides, got " << flat;
+    preprod[i] = acc;
+    acc *= AsConst(fsh[i]);
+    order.push_back(i);
+  }
+  // stable_sort: ties (several stride-0 broadcast modes) keep their mode
+  // order, so the result is a pure function of the input on every platform
+  // (std::sort's tie order is implementation-defined).
+  std::stable_sort(order.begin(), order.end(), [&](int64_t a, int64_t b) {
+    return AsConst(fst[a]) < AsConst(fst[b]);
+  });
+  Array<IntTuple> out_sh;
+  Array<IntTuple> out_st{IntTuple(int64_t(0))};
+  int64_t covered = 1; // product of the emitted ratios == last stride
+  for (int64_t k = 0; k < r; ++k) {
+    int64_t d = AsConst(fst[order[k]]);
+    if (d == 0)
+      continue;
+    ICHECK(d % covered == 0)
+        << "LeftInverse divisibility condition: stride " << d
+        << " is not a multiple of the covered extent " << covered;
+    out_sh.push_back(d / covered);
+    out_st.push_back(preprod[order[k]]);
+    covered = d;
+  }
+  out_sh.push_back(fsh[order[r - 1]]);
+  return Coalesce(Layout(IntTupleTuple(out_sh), IntTupleTuple(out_st)));
 }
 
 namespace {
@@ -877,21 +1112,40 @@ Layout Filter(const Layout &layout) {
   return Coalesce(Layout(out_sh, out_st));
 }
 
+IntTuple Coshape(const Layout &layout) {
+  // CuTe coshape (layout.hpp:649):
+  //   m1_shapes   = transform_leaf(shape,  s => s - 1)
+  //   abs_strides = transform_leaf(stride, abs)
+  //   co_coord    = as_arithmetic_tuple(inner_product(m1_shapes, abs_strides))
+  //   coshape     = transform_leaf(co_coord, c => c + 1)
+  // The inner product's ArithmeticTuple sum is our operator+, so ScaledBasis
+  // strides accumulate per coordinate axis: coshape((128,32):(1@0,1@1)) ==
+  // (128,32); plain strides sum into one scalar extent.
+  IntTuple m1_shapes = TransformLeaf(layout->shape, [](const IntTuple &s) {
+    return IntTuple(AddLeaf(s, IntTuple(int64_t(-1))));
+  });
+  IntTuple abs_strides =
+      TransformLeaf(layout->stride, [](const IntTuple &d) -> IntTuple {
+        if (IsScaledBasis(d)) {
+          IntTuple v = BasisValue(d);
+          IntTuple abs_v = IsConst(v) ? IntTuple(std::abs(AsConst(v)))
+                                      : IntTuple(tvm::abs(AsPrimExpr(v)));
+          return IntTupleScaledBasis(abs_v, BasisPath(d));
+        }
+        return IsConst(d) ? IntTuple(std::abs(AsConst(d)))
+                          : IntTuple(tvm::abs(AsPrimExpr(d)));
+      });
+  IntTuple co_coord =
+      FoldLeaves(m1_shapes * abs_strides, IntTuple(int64_t(0)),
+                 [](IntTuple acc, const IntTuple &term) { return acc + term; });
+  return TransformLeaf(co_coord, [](const IntTuple &c) {
+    return IntTuple(AddLeaf(c, IntTuple(int64_t(1))));
+  });
+}
+
 IntTuple Cosize(const Layout &layout) {
-  // CuTe cosize = 1 + sum_i (shape_i - 1) * |stride_i| over flat scalar modes;
-  // stays symbolic if any shape/stride is dynamic.
-  IntTuple fsh = Flatten(layout->shape), fst = Flatten(layout->stride);
-  IntTuple co = IntTuple(int64_t(1));
-  for (int64_t i = 0, r = Rank(fsh); i < r; ++i) {
-    IntTuple sh = fsh[i], st = fst[i];
-    ICHECK(!IsTuple(sh) && !IsScaledBasis(sh) && !IsTuple(st) &&
-           !IsScaledBasis(st))
-        << "Cosize requires scalar shape/stride, got " << sh << " : " << st;
-    IntTuple abs_st = IsConst(st) ? IntTuple(std::abs(AsConst(st)))
-                                  : IntTuple(tvm::abs(AsPrimExpr(st)));
-    co = AddLeaf(co, MulLeaf(AddLeaf(sh, IntTuple(int64_t(-1))), abs_st));
-  }
-  return co;
+  // CuTe cosize = size(coshape(layout)).
+  return Product(Coshape(layout));
 }
 
 namespace {
@@ -1007,6 +1261,70 @@ Layout LogicalDivide(const Layout &layout, const Layout &tiler) {
   return Composition(layout, MakeLayout({tiler, comp}));
 }
 
+Layout LogicalProduct(const Layout &block, const Layout &tiler) {
+  // CuTe 2-arg logical_product (layout.hpp:1653-1656):
+  //   make_layout(block,
+  //               composition(complement(block,
+  //                                      size(block) * cosize(tiler)),
+  //                           tiler)).
+  // Like the C++ CuTe operation, this is the rank-2 primitive.  Higher-level
+  // zipped/tiled products only rearrange its profile.
+  IntTuple block_size = Size(block);
+  IntTuple tiler_cosize = Cosize(tiler);
+  ICHECK(IsConst(block_size) && IsConst(tiler_cosize))
+      << "LogicalProduct needs a static block size and tiler cosize, got "
+      << block_size << " and " << tiler_cosize;
+  int64_t cotarget = AsConst(block_size) * AsConst(tiler_cosize);
+  Layout rest = Composition(Complement(block, cotarget), tiler);
+  return MakeLayout({block, rest});
+}
+
+Layout TiledProduct(const Layout &block, const Layout &tiler) {
+  // A Layout tiler is atomic to CuTe's zip2_by, so zipped_product is the same
+  // rank-2 result as logical_product.  tiled_product unpacks the actual second
+  // mode, whose profile need only be compatible with the tiler: complement can
+  // split one tiler mode into several residual modes.  Slicing with
+  // repeat<R1>(_) leaves a rank-1 second mode untouched (repeat<1>(_) is _),
+  // so only rank >= 2 unpacks.
+  Layout product = LogicalProduct(block, tiler);
+  Layout rest = product[1];
+  if (Rank(rest) == 1)
+    return product;
+  Array<Layout> modes{product[0]};
+  for (int64_t i = 0, r = Rank(rest); i < r; ++i) {
+    modes.push_back(rest[i]);
+  }
+  return MakeLayout(modes);
+}
+
+Layout BlockedProduct(const Layout &block, const Layout &tiler) {
+  // CuTe blocked_product (layout.hpp:1726-1742):
+  //   R = max(rank(block), rank(tiler))
+  //   zip(get<0>(r), get<1>(r)) with r = logical_product(append<R>(block),
+  //                                                      append<R>(tiler)).
+  // Mode i of the result is ((block_i, rest_i)), so a flat per-mode coordinate
+  // splits into (within-block, block-index) by the ordinary idx2crd rule.
+  Layout scalar(1, 0);
+  int64_t rb = Rank(block), rt = Rank(tiler);
+  int64_t r = std::max(rb, rt);
+  Array<Layout> block_modes, tiler_modes;
+  for (int64_t i = 0; i < r; ++i) {
+    block_modes.push_back(i < rb ? block[i] : scalar);
+    tiler_modes.push_back(i < rt ? tiler[i] : scalar);
+  }
+  Layout product =
+      LogicalProduct(MakeLayout(block_modes), MakeLayout(tiler_modes));
+  Layout padded = product[0], rest = product[1];
+  // Composition against the padded tiler keeps one rest mode per tiler mode.
+  ICHECK_EQ(Rank(rest), r) << "BlockedProduct: rest profile " << rest->shape
+                           << " does not match the tiler rank " << r;
+  Array<Layout> modes;
+  for (int64_t i = 0; i < r; ++i) {
+    modes.push_back(MakeLayout({padded[i], rest[i]}));
+  }
+  return MakeLayout(modes);
+}
+
 Layout MakeColumnMajorLayout(const IntTuple &shape) {
   return Layout(shape, CompactColMajor(shape));
 }
@@ -1031,6 +1349,23 @@ Layout MakeLayout(const Array<Layout> &layouts) {
 
 Layout Layout::WithShape(const IntTuple &shape) const {
   return Composition(*this, MakeColumnMajorLayout(shape));
+}
+
+Layout Layout::Parse(const ffi::String &text) {
+  // The printed spelling "shape:stride"; the shape holds no ':' so the first
+  // one splits.
+  std::string s(text);
+  size_t colon = s.find(':');
+  ICHECK_NE(colon, std::string::npos)
+      << "Layout text must be 'shape:stride', got '" << s << "'";
+  return Layout(IntTuple::Parse(s.substr(0, colon)),
+                IntTuple::Parse(s.substr(colon + 1)));
+}
+
+void Layout::Print(std::ostream &os) const {
+  (*this)->shape.Print(os);
+  os << ":";
+  (*this)->stride.Print(os);
 }
 
 ComposedLayout::ComposedLayout(Swizzle swizzle, int64_t offset, Layout layout) {
@@ -1566,6 +1901,65 @@ Optional<Layout> LayoutFromTileLang(const tvm::tl::Layout &layout) {
   return plain.value().WithShape(ShapeTuple(A.shape()));
 }
 
+// Recover a multi-output TileLang layout while keeping its codomain hierarchy:
+// each output coordinate axis is recovered as its own plain affine layout and
+// rerouted onto the basis axis E<i>, so the result maps a logical coordinate to
+// the full output coordinate tuple (the inverse of Python's
+// Layout.to_tilelang). LayoutFromTileLang instead serializes all output axes
+// into one flat address.
+Optional<Layout> LayoutFromTileLangHierarchical(const tvm::tl::Layout &layout) {
+  ICHECK(layout.defined());
+  Array<PrimExpr> input_shape = layout->InputShape();
+  Array<PrimExpr> forward_index = layout->GetForwardIndex();
+  int64_t rank = static_cast<int64_t>(forward_index.size());
+  if (rank == 0)
+    return std::nullopt;
+
+  // Recover each output axis independently as a plain affine layout.
+  std::vector<Layout> projected;
+  projected.reserve(rank);
+  for (int64_t i = 0; i < rank; ++i) {
+    Optional<Layout> axis =
+        LayoutFromTileLang(tvm::tl::Layout(input_shape, {forward_index[i]}));
+    if (!axis.defined())
+      return std::nullopt;
+    projected.push_back(axis.value());
+  }
+
+  // Conform all axes to one common shape profile. WithShape is an exact
+  // composition, so refining a profile never changes the function. Threading
+  // the progressively refined profile forward hands the last axis every
+  // axis's split points; conforming each earlier axis to that finest profile
+  // then makes all shapes identical.
+  std::vector<Layout> scaled(projected);
+  for (int64_t i = 1; i < rank; ++i)
+    scaled[i] = projected[i].WithShape(scaled[i - 1]->shape);
+  for (int64_t i = 0; i + 1 < rank; ++i)
+    scaled[i] = projected[i].WithShape(scaled[rank - 1]->shape);
+  const IntTuple shape = scaled[rank - 1]->shape;
+  for (int64_t i = 0; i + 1 < rank; ++i)
+    ICHECK(StructuralEqual()(scaled[i]->shape, shape))
+        << "Hierarchical recovery produced incompatible axis profiles: "
+        << scaled[i]->shape << " vs " << shape;
+
+  // Reroute each axis onto its basis and sum, keeping broadcast (stride-0)
+  // leaves the plain additive identity -- official operator* would tag them
+  // 0@i, and 0@i + 0@j sums to a coordinate tuple, breaking shape/stride
+  // congruence for leaves no axis drives. A leaf driven by exactly one axis
+  // keeps a single ScaledBasis stride; a leaf driven by two axes sums to a
+  // coordinate tuple instead, breaking congruence -- the output axes are
+  // dependent and no cute::Layout represents that.
+  IntTuple stride = 0;
+  for (int64_t i = 0; i < rank; ++i) {
+    stride += TransformLeaf(scaled[i]->stride, [&](const IntTuple &leaf) {
+      return IsZeroLeaf(leaf) ? leaf : IntTuple(leaf * E({i}));
+    });
+  }
+  if (!Congruent(shape, stride))
+    return std::nullopt;
+  return Layout(shape, stride);
+}
+
 // Recover a swizzled affine layout, A(x) = Sw(offset + plain(x)), from a
 // TileLang layout, as a Swizzle composed with a plain cute::Layout. Sizes and
 // strides need not be powers of two.
@@ -1672,69 +2066,35 @@ Tuple<IntTuple, Layout> Restrict(const Layout &layout,
   Array<IntTuple> min_modes;
   Array<Layout> sub_modes;
   for (int64_t i = 0; i < r; ++i) {
-    min_modes.push_back(IntTuple(range[i]->min));
+    min_modes.push_back(range[i]->min);
     // Skip statically-extent-1 modes (e.g. a pipeline stage pinned to one
     // element): they'd leave size-1 modes that break the GMMA canonical divide.
     const auto *ext_imm = range[i]->extent.as<IntImmNode>();
     if (ext_imm && ext_imm->value == 1)
       continue;
-    sub_modes.push_back(layout[i].WithShape(IntTuple(range[i]->extent)));
+    sub_modes.push_back(layout[i].WithShape(range[i]->extent));
   }
   IntTuple offset = layout(IntTupleTuple(min_modes));
   if (sub_modes.empty()) // everything pinned to one element: scalar (1):(0).
-    return Tuple<IntTuple, Layout>(
-        offset, Layout(IntTuple(int64_t(1)), IntTuple(int64_t(0))));
+    return Tuple<IntTuple, Layout>(offset, Layout(1, 0));
   return Tuple<IntTuple, Layout>(offset, MakeLayout(sub_modes));
 }
 
 namespace {
 
-// CuTe-notation formatters (the single source of truth shared by C++ stream
-// output and Python __str__/__repr__ via the __ffi_repr__ hooks below).
-std::string FormatIntTuple(const IntTuple &t) {
-  if (const auto *c = t.as<IntTupleConstNode>()) {
-    return std::to_string(c->value);
-  }
-  if (const auto *e = t.as<IntTuplePrimExprNode>()) {
-    std::ostringstream os;
-    os << e->value;
-    return os.str();
-  }
-  if (const auto *b = t.as<IntTupleScaledBasisNode>()) {
-    // CuTe scaled-basis spelling value@m@...: the mode path prints
-    // innermost-first (CuTe's E<...> print order), e.g. E<1,0> -> 1@0@1.
-    std::ostringstream os;
-    os << FormatIntTuple(b->value);
-    for (auto it = b->basis.rbegin(); it != b->basis.rend(); ++it)
-      os << "@" << *it;
-    return os.str();
-  }
-  const auto *a = t.as<IntTupleTupleNode>();
-  ICHECK(a != nullptr) << "FormatIntTuple on an unknown IntTuple kind";
+// Stream any Print-able object into a String (for the __ffi_repr__ hooks).
+template <class T> ffi::String PrintToString(const T &value) {
   std::ostringstream os;
-  os << "(";
-  for (size_t i = 0; i < a->fields.size(); ++i) {
-    if (i > 0)
-      os << ",";
-    os << FormatIntTuple(a->fields[i]);
-  }
-  os << ")";
+  value.Print(os);
   return os.str();
-}
-
-std::string FormatSwizzle(const SwizzleNode *s) {
-  std::ostringstream os;
-  os << "Sw<" << s->b_bits << "," << s->m_base << "," << s->s_shift << ">";
-  return os.str();
-}
-
-std::string FormatLayout(const LayoutNode *l) {
-  return FormatIntTuple(l->shape) + ":" + FormatIntTuple(l->stride);
 }
 
 std::string FormatComposedLayout(const ComposedLayoutNode *c) {
-  return FormatSwizzle(c->swizzle.get()) + " o " + std::to_string(c->offset) +
-         " o " + FormatLayout(c->layout.get());
+  std::ostringstream os;
+  c->swizzle.Print(os);
+  os << " o " << c->offset << " o ";
+  c->layout.Print(os);
+  return os.str();
 }
 
 } // namespace
@@ -1756,29 +2116,27 @@ TVM_FFI_STATIC_INIT_BLOCK() {
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   refl::TypeAttrDef<SwizzleNode>().def(
-      refl::type_attr::kRepr, [](Swizzle s, ffi::Function) -> ffi::String {
-        return FormatSwizzle(s.get());
-      });
+      refl::type_attr::kRepr,
+      [](Swizzle s, ffi::Function) -> ffi::String { return PrintToString(s); });
   refl::TypeAttrDef<IntTupleConstNode>().def(
       refl::type_attr::kRepr, [](IntTuple t, ffi::Function) -> ffi::String {
-        return FormatIntTuple(t);
+        return PrintToString(t);
       });
   refl::TypeAttrDef<IntTuplePrimExprNode>().def(
       refl::type_attr::kRepr, [](IntTuple t, ffi::Function) -> ffi::String {
-        return FormatIntTuple(t);
+        return PrintToString(t);
       });
   refl::TypeAttrDef<IntTupleScaledBasisNode>().def(
       refl::type_attr::kRepr, [](IntTuple t, ffi::Function) -> ffi::String {
-        return FormatIntTuple(t);
+        return PrintToString(t);
       });
   refl::TypeAttrDef<IntTupleTupleNode>().def(
       refl::type_attr::kRepr, [](IntTuple t, ffi::Function) -> ffi::String {
-        return FormatIntTuple(t);
+        return PrintToString(t);
       });
   refl::TypeAttrDef<LayoutNode>().def(
-      refl::type_attr::kRepr, [](Layout l, ffi::Function) -> ffi::String {
-        return FormatLayout(l.get());
-      });
+      refl::type_attr::kRepr,
+      [](Layout l, ffi::Function) -> ffi::String { return PrintToString(l); });
   refl::TypeAttrDef<ComposedLayoutNode>().def(
       refl::type_attr::kRepr,
       [](ComposedLayout c, ffi::Function) -> ffi::String {
@@ -1804,6 +2162,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
            [](const Swizzle &swizzle, int old_bits, int new_bits) {
              return swizzle.Recast(old_bits, new_bits);
            })
+      .def("tl.cute.swizzle_parse",
+           [](const ffi::String &text) { return Swizzle::Parse(text); })
       // -- IntTuple leaf builders ----------------------------------------
       .def("tl.cute.make_int_const",
            [](int64_t value) { return IntTuple(value); })
@@ -1824,6 +2184,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
            [](const IntTuple &a, const IntTuple &b) { return a + b; })
       .def("tl.cute.int_tuple_mul",
            [](const IntTuple &a, const IntTuple &b) { return a * b; })
+      .def("tl.cute.int_tuple_parse",
+           [](const ffi::String &text) { return IntTuple::Parse(text); })
       .def("tl.cute.product", [](const IntTuple &t) { return Product(t); })
       // -- Layout constructor + accessors --------------------------------
       // Build a (possibly hierarchical / dynamic) layout from congruent
@@ -1846,6 +2208,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
            [](const Layout &layout, const IntTuple &coord) {
              return layout(coord);
            })
+      .def("tl.cute.layout_parse",
+           [](const ffi::String &text) { return Layout::Parse(text); })
       .def("tl.cute.layout_shape",
            [](const Layout &layout) { return layout->shape; })
       .def("tl.cute.layout_stride",
@@ -1861,6 +2225,8 @@ TVM_FFI_STATIC_INIT_BLOCK() {
            [](const Layout &layout) { return Coalesce(layout); })
       .def("tl.cute.right_inverse",
            [](const Layout &layout) { return RightInverse(layout); })
+      .def("tl.cute.left_inverse",
+           [](const Layout &layout) { return LeftInverse(layout); })
       .def("tl.cute.composition",
            [](const Layout &lhs, const Layout &rhs) {
              return Composition(lhs, rhs);
@@ -1873,6 +2239,11 @@ TVM_FFI_STATIC_INIT_BLOCK() {
            [](const Layout &layout) { return Filter(layout); })
       .def("tl.cute.congruent",
            [](const IntTuple &a, const IntTuple &b) { return Congruent(a, b); })
+      .def(
+          "tl.cute.compatible",
+          [](const IntTuple &a, const IntTuple &b) { return Compatible(a, b); })
+      .def("tl.cute.coshape",
+           [](const Layout &layout) { return Coshape(layout); })
       .def("tl.cute.cosize",
            [](const Layout &layout) { return Cosize(layout); })
       .def("tl.cute.complement",
@@ -1882,6 +2253,18 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def("tl.cute.logical_divide",
            [](const Layout &layout, const Layout &tiler) {
              return LogicalDivide(layout, tiler);
+           })
+      .def("tl.cute.logical_product",
+           [](const Layout &block, const Layout &tiler) {
+             return LogicalProduct(block, tiler);
+           })
+      .def("tl.cute.tiled_product",
+           [](const Layout &block, const Layout &tiler) {
+             return TiledProduct(block, tiler);
+           })
+      .def("tl.cute.blocked_product",
+           [](const Layout &block, const Layout &tiler) {
+             return BlockedProduct(block, tiler);
            })
       // -- Make*Layout ----------------------------------------------------
       .def("tl.cute.make_column_major_layout",
@@ -1899,6 +2282,10 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def("tl.cute.layout_from_tilelang",
            [](const tvm::tl::Layout &layout) {
              return LayoutFromTileLang(layout);
+           })
+      .def("tl.cute.layout_from_tilelang_hierarchical",
+           [](const tvm::tl::Layout &layout) {
+             return LayoutFromTileLangHierarchical(layout);
            })
       .def("tl.cute.composed_layout_from_tilelang",
            [](const tvm::tl::Layout &layout) {

--- a/src/layout/cute_layout.h
+++ b/src/layout/cute_layout.h
@@ -432,8 +432,8 @@ TVM_DLL Layout RightInverse(const Layout &layout);
 
 /// Left-inverse of an injective layout (CuTe left_inverse):
 /// @return result(layout(i)) == i for all i < size(layout).
-/// Realized as right_inverse(make_layout(layout, complement(layout))), which
-/// extends the codomain-covering chain that right_inverse alone stops at.
+/// Like CuTe, ICHECKs when the sorted strides do not form the divisibility
+/// chain the inverse requires (an injective layout with irregular gaps).
 TVM_DLL Layout LeftInverse(const Layout &layout);
 
 /// Composition lhs o rhs.

--- a/src/layout/cute_layout.h
+++ b/src/layout/cute_layout.h
@@ -106,6 +106,12 @@ public:
   // element type.
   TVM_DLL Swizzle Recast(int old_bits, int new_bits) const;
 
+  // Parse the CuTe spelling "Sw<b,m,s>" (the inverse of Print).
+  TVM_DLL static Swizzle Parse(const ffi::String &text);
+
+  // Print in the CuTe spelling "Sw<b,m,s>".
+  TVM_DLL void Print(std::ostream &os) const;
+
   TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Swizzle, ObjectRef, SwizzleNode);
 };
 
@@ -145,6 +151,14 @@ public:
     *this = *this * other;
     return *this;
   }
+
+  // Parse the CuTe spelling (the inverse of Print): nested "(a,b,...)"
+  // tuples, integer leaves, and scaled bases "v@m@..." with the mode path
+  // innermost-first (E<1,0> is spelled 1@0@1).
+  TVM_DLL static IntTuple Parse(const ffi::String &text);
+
+  // Print in the CuTe spelling.
+  TVM_DLL void Print(std::ostream &os) const;
 
   TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(IntTuple, ObjectRef, IntTupleNode);
 };
@@ -314,6 +328,10 @@ TVM_DLL IntTupleTuple Wrap(const IntTuple &t);
 // matches -- same nesting and same rank at every branch.
 TVM_DLL bool Congruent(const IntTuple &a, const IntTuple &b);
 
+/// CuTe shape compatibility (`a <= b`): `a` and `b` have the same total size,
+/// and every coordinate into `a` is also a valid coordinate into `b`.
+TVM_DLL bool Compatible(const IntTuple &a, const IntTuple &b);
+
 // Higher-order function mapping each leaf by `f`.
 template <class F> IntTuple TransformLeaf(const IntTuple &t, F &&f) {
   if (!IsTuple(t))
@@ -381,6 +399,12 @@ public:
   // Compose with a column-major layout of this shape.
   TVM_DLL Layout WithShape(const IntTuple &shape) const;
 
+  // Parse the CuTe spelling "shape:stride" (the inverse of Print).
+  TVM_DLL static Layout Parse(const ffi::String &text);
+
+  // Print in the CuTe spelling "shape:stride".
+  TVM_DLL void Print(std::ostream &os) const;
+
   TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Layout, ObjectRef, LayoutNode);
 };
 
@@ -406,6 +430,12 @@ TVM_DLL Layout Coalesce(const Layout &layout);
 /// @return layout(result(i)) == i for all i < size(result).
 TVM_DLL Layout RightInverse(const Layout &layout);
 
+/// Left-inverse of an injective layout (CuTe left_inverse):
+/// @return result(layout(i)) == i for all i < size(layout).
+/// Realized as right_inverse(make_layout(layout, complement(layout))), which
+/// extends the codomain-covering chain that right_inverse alone stops at.
+TVM_DLL Layout LeftInverse(const Layout &layout);
+
 /// Composition lhs o rhs.
 /// @return result(c) == lhs(rhs(c)) for all c in the domain of rhs.
 /// @post size(result) == size(rhs).
@@ -424,7 +454,12 @@ TVM_DLL Layout Take(const Layout &layout, int64_t n);
 /// Drop stride-0 and size-1 modes, then coalesce.
 TVM_DLL Layout Filter(const Layout &layout);
 
-/// Codomain size of a layout.
+/// Codomain shape of a layout (CuTe coshape): the per-axis extents
+/// 1 + inner_product(shape - 1, |stride|), e.g.
+/// coshape((128,32):(1@0,1@1)) == (128,32).
+TVM_DLL IntTuple Coshape(const Layout &layout);
+
+/// Codomain size of a layout (CuTe cosize): size(coshape(layout)).
 /// @post for all `0 <= i < size(layout)`, layout(i) < result.
 TVM_DLL IntTuple Cosize(const Layout &layout);
 
@@ -439,7 +474,23 @@ TVM_DLL Layout Complement(const Layout &layout);
 /// @pre `tiler` and `Size(layout)` must be static.
 TVM_DLL Layout LogicalDivide(const Layout &layout, const Layout &tiler);
 
-// Column major layout over `shape`.
+/// Logical product of a block layout and a tiler layout.
+/// Repeats `block` according to `tiler`, returning `(block, rest)`.
+/// @pre `Size(block)` and `Cosize(tiler)` must be static.
+TVM_DLL Layout LogicalProduct(const Layout &block, const Layout &tiler);
+
+/// Tiled product convenience form: keep `block` as the first mode and unpack
+/// the actual repeated mode of the logical product after it.
+TVM_DLL Layout TiledProduct(const Layout &block, const Layout &tiler);
+
+/// Blocked product: repeat `block` over `tiler` and zip the per-mode pairs, so
+/// mode i of the result is ((block_i, rest_i)) and accepts a flat coordinate
+/// covering block extent x tiler extent along that mode.
+/// @post Rank(result) == max(Rank(block), Rank(tiler)).
+TVM_DLL Layout BlockedProduct(const Layout &block, const Layout &tiler);
+
+// Column major layout over `shape`.  Size-1 modes take stride 0 and leave
+// the running product untouched (CuTe compact_col_major, stride.hpp:302).
 template <typename Container>
 inline Layout MakeColumnMajorLayout(const Container &shape) {
   int64_t n = shape.size();
@@ -449,13 +500,18 @@ inline Layout MakeColumnMajorLayout(const Container &shape) {
   IntTuple stride = 1;
   for (int64_t k = 0; k < n; ++k) {
     sh.push_back(shape[k]);
+    if (IsConst(IntTuple(shape[k])) && AsConst(IntTuple(shape[k])) == 1) {
+      st.push_back(IntTuple(int64_t(0)));
+      continue;
+    }
     st.push_back(stride);
     stride *= shape[k];
   }
   return Layout(std::move(sh), std::move(st));
 }
 
-// Row major layout over `shape`.
+// Row major layout over `shape`.  Size-1 modes take stride 0 (CuTe
+// compact_row_major).
 template <typename Container>
 inline Layout MakeRowMajorLayout(const Container &shape) {
   int64_t n = shape.size();
@@ -463,6 +519,10 @@ inline Layout MakeRowMajorLayout(const Container &shape) {
   IntTuple stride = 1;
   for (int64_t k = n - 1; k >= 0; --k) {
     sh.Set(k, shape[k]);
+    if (IsConst(IntTuple(shape[k])) && AsConst(IntTuple(shape[k])) == 1) {
+      st.Set(k, IntTuple(int64_t(0)));
+      continue;
+    }
     st.Set(k, stride);
     stride *= shape[k];
   }
@@ -536,10 +596,17 @@ public:
 };
 
 /// Recover an affine TileLang layout as a cute::Layout.
-/// @return result(coords) == layout(coords)
+/// @return result(coords) == serialize(layout(coords))
 /// @return nullopt if the address is not purely affine (e.g. it has a swizzle,
 ///         a non-zero base offset, or a non-constant extent).
 Optional<Layout> LayoutFromTileLang(const tvm::tl::Layout &layout);
+
+/// Recover a hierarchical affine TileLang layout as a cute::Layout.
+/// Each mode in the output indices is multiplied with a scaled basis.
+/// @return result(coords) == layout(coords)
+/// @return nullopt if any of the output modes is not purely affine, or
+///         different output modes are dependent.
+Optional<Layout> LayoutFromTileLangHierarchical(const tvm::tl::Layout &layout);
 
 /// Recover a possibly swizzled and offset TileLang layout as a
 /// cute::ComposedLayout.

--- a/src/layout/tcgen05_layout.cc
+++ b/src/layout/tcgen05_layout.cc
@@ -161,7 +161,9 @@ Tcgen05CopyPlan ExpandTcgen05Layout(const Tcgen05Meta &meta,
                                     const cute::Layout &tmem_tile,
                                     int num_threads) {
   static constexpr int WARPGROUP_SIZE = 128;
-  ICHECK(num_threads % WARPGROUP_SIZE == 0);
+  ICHECK(num_threads > 0 && num_threads % WARPGROUP_SIZE == 0)
+      << "ExpandTcgen05Layout needs a positive multiple of " << WARPGROUP_SIZE
+      << " threads, got " << num_threads;
   int num_wgs = num_threads / WARPGROUP_SIZE;
 
   // Serialize (datapath, column) into the flat address datapath + 128*column
@@ -238,27 +240,18 @@ Tcgen05CopyPlan ExpandTcgen05Layout(const Tcgen05Meta &meta,
                                          cute::MakeLayout({grid[1], grid[3]})});
   cute::Layout tiled = cute::BlockedProduct(serialized_fragment, tiler);
 
-  // Append the issue mode slowest of all value modes (each later issue
-  // appends registers).  The issue mode is the rest of dividing the
-  // serialized tile by its chunk.
-  // issue_mode: issue -> serialized TMEM;  E.g., 3:16384
-  // full_tv: (thread, value) -> serialized TMEM
-  // E.g., full_tv = ((32,(4,1)),((1,(64,1)),3)):
-  //                 ((1,(32,8192)),((0,(128,32)),16384))
-  cute::Layout issue_mode =
-      cute::LogicalDivide(serialized_tmem_tile, inv_prefix)[1];
-  cute::Layout value_modes = cute::MakeLayout({tiled[1], issue_mode});
-  cute::Layout full_tv = cute::MakeLayout({tiled[0], value_modes});
-
-  int64_t num_vals = cute::AsConst(cute::Size(value_modes));
-
-  // A gapped tile is injective but not surjective, so the LEFT inverse maps
-  // its serialized image back to flat logical indices.
+  // Map the copy back to flat logical indices piecewise, mirroring the
+  // (chunk, rest) split of the divide above: every replica of `tiled`
+  // addresses within one contiguous chunk, which inv_prefix inverts, and
+  // rest_domain already locates each issue's flat logical origin -- so the
+  // issue mode composes directly, without inverting the whole tile.
   // tile_tv: (thread, value) -> flat logical tile
-  // E.g., LeftInverse = (16384,3):(3,1),
-  //       tile_tv = ((32,(4,1)),((1,(64,1)),3)):((3,(96,1)),((0,(384,1)),1))
-  cute::Layout tile_tv =
-      cute::Composition(cute::LeftInverse(serialized_tmem_tile), full_tv);
+  // E.g., tile_tv = ((32,(4,1)),((1,(64,1)),3)):((3,(96,1)),((0,(384,1)),1))
+  cute::Layout tile_tv = cute::MakeLayout(
+      {cute::Composition(inv_prefix, tiled[0]),
+       cute::MakeLayout(
+           {cute::Composition(inv_prefix, tiled[1]), rest_domain})});
+  int64_t num_vals = cute::AsConst(cute::Size(tile_tv[1]));
 
   // Invert (the make_tiled_copy `right_inverse(...).with_shape(...)` idiom):
   // the identity layout tags the (thread@0, value@1) axes, with_shape

--- a/src/layout/tcgen05_layout.cc
+++ b/src/layout/tcgen05_layout.cc
@@ -1,13 +1,19 @@
 /*!
  * \file layout/tcgen05_layout.cc
- * \brief Define Layout used in tcgen05.ld/st.
+ * \brief tcgen05.ld/st data-movement shapes as CuTe TV atoms.
  *
+ * Each atom below is the CUTLASS ``Copy_Traits<SM100_TMEM_LOAD_*>`` TV
+ * layout (cute/atom/copy_traits_sm100.hpp) written over (datapath, b32
+ * column) coordinates, cross-checked against the PTX data-movement-shape
+ * figures
+ * (https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-memory-layout).
+ * Loads and stores share one data-movement shape per width.
  */
 
 #include "support/check.h"
+#include <tvm/ffi/reflection/registry.h>
+#include <tvm/tirx/op.h>
 #include <tvm/tirx/stmt_functor.h>
-
-#include <cmath>
 
 #include "layout.h"
 #include "tcgen05_layout.h"
@@ -16,118 +22,311 @@ namespace tvm {
 namespace tl {
 
 using namespace tirx;
+using tvm::ffi::Array;
 
-static IterVar MakeIterVar(std::string name, Range dom) {
+namespace {
+
+IterVar MakeIterVar(std::string name, Range dom) {
   Var var = Var(name, dom->min->dtype);
   return IterVar(dom, var, IterVarType::kDataPar);
 }
 
-// ld and st share the same Fragment layout; only the instruction name differs.
-static Tcgen05Meta makeTcgen05Meta_32dp32b(bool is_store) {
-  constexpr int INST_WIDTH = 1;
-  IterVar inst_row = MakeIterVar("row", 128);
-  IterVar inst_col = MakeIterVar("col", INST_WIDTH);
-  return Tcgen05Meta{is_store ? "tl::tcgen05_st_32dp32bNx"
+// The atoms are the CUTLASS ``Copy_Traits<...1x>`` TV layouts verbatim
+// (DstLayout over ValID, upcast to b32), written in CuTe spelling over the
+// physical coordinate axes, axis 0 = datapath ("@0"), axis 1 = b32 column
+// ("@1").  Each covers exactly one PTX issue of one warp: the 32x32b shape
+// fills the warp's whole 32-datapath sub-partition, the 16x shapes only its
+// low 16 datapaths.  ExpandTcgen05Layout replicates them over warps, the
+// high-datapath duplicate issue, .xN repetitions, and warpgroups purely by
+// layout algebra.
+
+Tcgen05Meta MakeTcgen05Meta_32dp32b(bool is_store) {
+  // PTX 32x32b (Copy_Traits 32dp32b1x, ValID (32,32):(1,DP_b)): lane t ->
+  // datapath t; one register on one column per repetition, and the wrapper
+  // chaining extends repetitions exactly, so any N is legal.
+  return Tcgen05Meta(is_store ? "tl::tcgen05_st_32dp32bNx"
                               : "tl::tcgen05_ld_32dp32bNx",
-                     Fragment({inst_row, inst_col}, {inst_col}, {inst_row},
-                              MakeIterVar("rep", Range(0, 1))),
-                     INST_WIDTH};
+                     cute::Layout::Parse("(32,1):(1@0,0)"),
+                     /*max_chunks=*/0);
 }
 
-static Tcgen05Meta makeTcgen05Meta_32dp64b(bool is_store) {
-  constexpr int INST_WIDTH = 2;
-  IterVar inst_row = MakeIterVar("row", 128);
-  IterVar inst_col = MakeIterVar("col", INST_WIDTH);
-  return Tcgen05Meta{
-      is_store ? "tl::tcgen05_st_32dp64bNx" : "tl::tcgen05_ld_32dp64bNx",
-      Fragment({inst_row, inst_col}, {FloorDiv(FloorMod(inst_row, 32), 16)},
-               {FloorDiv(inst_row, 32) * 32 + FloorMod(inst_row, 8) * 4 +
-                FloorDiv(FloorMod(inst_row, 16), 8) +
-                FloorMod(inst_col, 2) * 2},
-               MakeIterVar("rep", Range(0, 1))),
-      INST_WIDTH};
+Tcgen05Meta MakeTcgen05Meta_16dp64b(bool is_store) {
+  // PTX 16x64b (Copy_Traits 16dp64b1x, DstLayout ((2,2,8),32):((512,32,64),1)
+  // over ValID (64,16):(1,DP_b)): lane t -> datapath 8*(t%2) + t/4, column
+  // (t/2)%2; one register per issue.
+  return Tcgen05Meta{is_store ? "tl::tcgen05_st_32dp64bNx"
+                              : "tl::tcgen05_ld_32dp64bNx",
+                     cute::Layout::Parse("((2,2,8),1):((8@0,1@1,1@0),0)"),
+                     /*max_chunks=*/128};
 }
 
-static Tcgen05Meta makeTcgen05Meta_32dp128b(bool is_store) {
-  constexpr int INST_WIDTH = 4;
-  IterVar inst_row = MakeIterVar("row", 128);
-  IterVar inst_col = MakeIterVar("col", INST_WIDTH);
-  return Tcgen05Meta{
-      is_store ? "tl::tcgen05_st_32dp128bNx" : "tl::tcgen05_ld_32dp128bNx",
-      Fragment({inst_row, inst_col}, {FloorDiv(FloorMod(inst_row, 32), 8)},
-               {FloorDiv(inst_row, 32) * 32 + FloorMod(inst_row, 8) * 4 +
-                FloorMod(inst_col, 4)},
-               MakeIterVar("rep", Range(0, 1))),
-      INST_WIDTH};
+Tcgen05Meta MakeTcgen05Meta_16dp128b(bool is_store) {
+  // PTX 16x128b (Copy_Traits 16dp128b1x, DstLayout ((4,8),(32,2)):
+  // ((32,128),(1,1024)) over ValID (128,16):(1,DP_b)): lane t -> column t%4,
+  // datapath t/4; two registers stepping the 8-datapath half.
+  return Tcgen05Meta{is_store ? "tl::tcgen05_st_32dp128bNx"
+                              : "tl::tcgen05_ld_32dp128bNx",
+                     cute::Layout::Parse("((4,8),2):((1@1,1@0),8@0)"),
+                     /*max_chunks=*/64};
 }
 
-static Tcgen05Meta makeTcgen05Meta_32dp256b(bool is_store) {
-  constexpr int INST_WIDTH = 8;
-  IterVar inst_row = MakeIterVar("row", 128);
-  IterVar inst_col = MakeIterVar("col", INST_WIDTH);
-  return Tcgen05Meta{
-      is_store ? "tl::tcgen05_st_32dp256bNx" : "tl::tcgen05_ld_32dp256bNx",
-      Fragment(
-          {inst_row, inst_col},
-          {FloorMod(inst_col, 2) + FloorDiv(FloorMod(inst_row, 32), 8) * 2},
-          {FloorDiv(inst_row, 32) * 32 + FloorMod(inst_row, 8) * 4 +
-           FloorDiv(FloorMod(inst_col, 8), 2)},
-          MakeIterVar("rep", Range(0, 1))),
-      INST_WIDTH};
+Tcgen05Meta MakeTcgen05Meta_16dp256b(bool is_store) {
+  // PTX 16x256b (Copy_Traits 16dp256b1x, DstLayout ((4,8),(64,2)):
+  // ((64,256),(1,2048)) over ValID (256,16):(1,DP_b)): lane t -> column
+  // 2*(t%4), datapath t/4; four registers as (adjacent column, 8-datapath).
+  return Tcgen05Meta{is_store ? "tl::tcgen05_st_32dp256bNx"
+                              : "tl::tcgen05_ld_32dp256bNx",
+                     cute::Layout::Parse("((4,8),(2,2)):((2@1,1@0),(1@1,8@0))"),
+                     /*max_chunks=*/32};
 }
 
-Tcgen05Meta GetTcgen05MetaLd32Dp32B() { return makeTcgen05Meta_32dp32b(false); }
-Tcgen05Meta GetTcgen05MetaLd32Dp64B() { return makeTcgen05Meta_32dp64b(false); }
-Tcgen05Meta GetTcgen05MetaLd32Dp128B() {
-  return makeTcgen05Meta_32dp128b(false);
-}
-Tcgen05Meta GetTcgen05MetaLd32Dp256B() {
-  return makeTcgen05Meta_32dp256b(false);
+} // namespace
+
+Tcgen05Meta::Tcgen05Meta(ffi::String intrinsics_name, cute::Layout tv,
+                         int64_t max_chunks) {
+  auto node = ffi::make_object<Tcgen05MetaNode>();
+  node->intrinsics_name = std::move(intrinsics_name);
+  node->tv = std::move(tv);
+  node->max_chunks = max_chunks;
+  data_ = std::move(node);
 }
 
-Tcgen05Meta GetTcgen05MetaSt32Dp32B() { return makeTcgen05Meta_32dp32b(true); }
-Tcgen05Meta GetTcgen05MetaSt32Dp64B() { return makeTcgen05Meta_32dp64b(true); }
-Tcgen05Meta GetTcgen05MetaSt32Dp128B() {
-  return makeTcgen05Meta_32dp128b(true);
-}
-Tcgen05Meta GetTcgen05MetaSt32Dp256B() {
-  return makeTcgen05Meta_32dp256b(true);
+void Tcgen05MetaNode::RegisterReflection() {
+  namespace refl = tvm::ffi::reflection;
+  refl::ObjectDef<Tcgen05MetaNode>()
+      .def_ro("intrinsics_name", &Tcgen05MetaNode::intrinsics_name)
+      .def_ro("tv", &Tcgen05MetaNode::tv)
+      .def_ro("max_chunks", &Tcgen05MetaNode::max_chunks);
 }
 
-std::tuple<bool, Fragment, int>
-ExpandTcgen05Layout(const Tcgen05Meta &meta, int tmem_phy_col_extent,
-                    int num_threads, Range row_dom, Range col_dom) {
+Tcgen05Meta GetTcgen05MetaLd32Dp32B() { return MakeTcgen05Meta_32dp32b(false); }
+Tcgen05Meta GetTcgen05MetaLd16Dp64B() { return MakeTcgen05Meta_16dp64b(false); }
+Tcgen05Meta GetTcgen05MetaLd16Dp128B() {
+  return MakeTcgen05Meta_16dp128b(false);
+}
+Tcgen05Meta GetTcgen05MetaLd16Dp256B() {
+  return MakeTcgen05Meta_16dp256b(false);
+}
+
+Tcgen05Meta GetTcgen05MetaSt32Dp32B() { return MakeTcgen05Meta_32dp32b(true); }
+Tcgen05Meta GetTcgen05MetaSt16Dp64B() { return MakeTcgen05Meta_16dp64b(true); }
+Tcgen05Meta GetTcgen05MetaSt16Dp128B() {
+  return MakeTcgen05Meta_16dp128b(true);
+}
+Tcgen05Meta GetTcgen05MetaSt16Dp256B() {
+  return MakeTcgen05Meta_16dp256b(true);
+}
+
+// Project one physical axis through the TV atom (keep that axis's basis
+// strides, zero the other) and measure the footprint.  The datapath extent
+// determines the wrapper's duplication factor; the column extent is the
+// width of one .x1 repetition.
+int64_t Tcgen05AtomDatapaths(const Tcgen05Meta &meta) {
+  static const cute::Layout kDpOnly = cute::Layout::Parse("(1,1):(1,0)");
+  return cute::AsConst(cute::Cosize(cute::Composition(kDpOnly, meta->tv)));
+}
+
+int64_t Tcgen05AtomWidth(const Tcgen05Meta &meta) {
+  static const cute::Layout kColOnly = cute::Layout::Parse("(1,1):(0,1)");
+  return cute::AsConst(cute::Cosize(cute::Composition(kColOnly, meta->tv)));
+}
+
+Tcgen05CopyPlan::Tcgen05CopyPlan(cute::Layout fragment,
+                                 int64_t num_chunks_each_wg,
+                                 cute::Layout rest_domain, int64_t num_issues,
+                                 int64_t vals_per_issue) {
+  auto node = ffi::make_object<Tcgen05CopyPlanNode>();
+  node->fragment = std::move(fragment);
+  node->num_chunks_each_wg = num_chunks_each_wg;
+  node->rest_domain = std::move(rest_domain);
+  node->num_issues = num_issues;
+  node->vals_per_issue = vals_per_issue;
+  data_ = std::move(node);
+}
+
+void Tcgen05CopyPlanNode::RegisterReflection() {
+  namespace refl = tvm::ffi::reflection;
+  refl::ObjectDef<Tcgen05CopyPlanNode>()
+      .def_ro("fragment", &Tcgen05CopyPlanNode::fragment)
+      .def_ro("num_chunks_each_wg", &Tcgen05CopyPlanNode::num_chunks_each_wg)
+      .def_ro("rest_domain", &Tcgen05CopyPlanNode::rest_domain)
+      .def_ro("num_issues", &Tcgen05CopyPlanNode::num_issues)
+      .def_ro("vals_per_issue", &Tcgen05CopyPlanNode::vals_per_issue);
+}
+
+// Running example: 32dp32b, 128 threads, gapped tile from a column slice of
+// a batched accumulator:
+//   tmem_tile = (3,128,64):(128@1,1@0,1@1)   (batch, datapath, column)
+Tcgen05CopyPlan ExpandTcgen05Layout(const Tcgen05Meta &meta,
+                                    const cute::Layout &tmem_tile,
+                                    int num_threads) {
   static constexpr int WARPGROUP_SIZE = 128;
   ICHECK(num_threads % WARPGROUP_SIZE == 0);
   int num_wgs = num_threads / WARPGROUP_SIZE;
 
-#define FAIL_IF(cond)                                                          \
-  if (cond) {                                                                  \
-    return {false, Fragment(), 0};                                             \
+  // Serialize (datapath, column) into the flat address datapath + 128*column
+  // so everything below is algebra over one codomain.
+  // serialized_fragment: atom (lane/warp, reg) -> serialized TMEM
+  // serialized_tmem_tile: logical tile -> serialized TMEM
+  // E.g., serialized_tmem_tile = (3,128,64):(16384,1,128)
+  static const cute::Layout kSerialize = cute::Layout::Parse("(1,1):(1,128)");
+  cute::Layout serialized_fragment = cute::Composition(kSerialize, meta->tv);
+  cute::Layout serialized_tmem_tile = cute::Composition(kSerialize, tmem_tile);
+
+  int64_t size = cute::AsConst(cute::Size(serialized_tmem_tile));
+
+  // right_inverse's stride chain stops at the tile's first serialized gap,
+  // so its size is the maximal contiguous chunk = one tcgen05 issue.
+  // inv_prefix: serialized chunk -> flat logical tile
+  // E.g., inv_prefix = 8192:3, chunk = 8192, num_issues = 3
+  cute::Layout inv_prefix = cute::RightInverse(serialized_tmem_tile);
+  int64_t chunk = cute::AsConst(cute::Size(inv_prefix));
+  if (chunk % 128 != 0 || size % chunk != 0)
+    return Tcgen05CopyPlan(nullptr);
+  int64_t num_issues = size / chunk;
+
+  // Divide the flat logical domain by the chunk; the rest mode locates each
+  // issue's origin (CuTe's tiled-copy rest iteration).
+  // rest_domain: issue -> flat logical tile origin
+  // E.g., rest_domain = 3:1 -> origins 0, 1, 2 (idx2crd: batch 0, 1, 2)
+  cute::Layout rest_domain =
+      num_issues == 1 ? cute::Layout(1, 0)
+                      : cute::LogicalDivide(
+                            cute::MakeColumnMajorLayout(cute::Size(tmem_tile)),
+                            inv_prefix)[1];
+  if (cute::AsConst(cute::Size(rest_domain)) != num_issues)
+    return Tcgen05CopyPlan(nullptr);
+
+  // Instruction feasibility per issue.  The atom's column width and
+  // datapath extent come from its own algebra; a 16-datapath atom is issued
+  // twice per warp (low then high datapaths), so the whole per-warpgroup
+  // copy must stay one .xN issue for the wrapper's register order to hold.
+  // E.g., width = 1, ndup = 1, cols_per_issue = 64, num_chunks_each_wg = 64
+  int64_t width = Tcgen05AtomWidth(meta);
+  int64_t ndup = 32 / Tcgen05AtomDatapaths(meta);
+  int64_t cols_per_issue = chunk / 128;
+  if (cols_per_issue % width != 0)
+    return Tcgen05CopyPlan(nullptr);
+  int64_t total_chunks = cols_per_issue / width;
+  if (total_chunks % num_wgs != 0)
+    return Tcgen05CopyPlan(nullptr);
+  int num_chunks_each_wg = static_cast<int>(total_chunks / num_wgs);
+  if (ndup > 1) {
+    // The wrapper appends the duplicate issue's registers after ALL
+    // repetitions, so the per-warpgroup copy must be one .xN issue.
+    if (num_chunks_each_wg & (num_chunks_each_wg - 1))
+      return Tcgen05CopyPlan(nullptr);
+    if (num_chunks_each_wg > meta->max_chunks)
+      return Tcgen05CopyPlan(nullptr);
   }
 
-  FAIL_IF(tmem_phy_col_extent % meta.width != 0);
-  int total_chunks = tmem_phy_col_extent / meta.width;
-  FAIL_IF(total_chunks % num_wgs != 0); // Otherwise the layout is not bijective
-  int num_chunks_each_wg = total_chunks / num_wgs;
-  int num_cols_each_wg = num_chunks_each_wg * meta.width;
-  int num_elems_each_thread_in_one_chunk = meta.width * 128 / WARPGROUP_SIZE;
+  // Replicate the atom with one blocked product over the wrapper's
+  // replication grid.  The blocked product's complement enumerates the
+  // serialized gaps around the atom in ascending-stride order -- the
+  // duplicate high-16-datapath issue first, then the warp sub-partitions,
+  // then the .xN column repetitions, then the warpgroup column split -- so
+  // the row-major (wg, rep, warp, dup) grid indexes exactly those slots.
+  // Zipped per atom mode: thread gets (warp, wg), value gets (rep, dup);
+  // the value replicas are FASTER than the thread replicas, so a thread's
+  // values stay contiguous in TMEM, and the duplicate issue lands after the
+  // repetitions exactly as the wrapper appends its registers.
+  // tiled: ((lane, (warp, wg)), (reg, (rep, dup))) -> serialized chunk
+  // E.g., tiled = ((32,(4,1)),(1,(64,1))):((1,(32,8192)),(0,(128,32)))
+  cute::Layout grid = cute::MakeRowMajorLayout(
+      Array<int64_t>{num_wgs, num_chunks_each_wg, 4, ndup});
+  cute::Layout tiler = cute::MakeLayout({cute::MakeLayout({grid[2], grid[0]}),
+                                         cute::MakeLayout({grid[1], grid[3]})});
+  cute::Layout tiled = cute::BlockedProduct(serialized_fragment, tiler);
 
-  IterVar iter_row = MakeIterVar("row", row_dom);
-  IterVar iter_col = MakeIterVar("col", col_dom);
-  PrimExpr thread_idx =
-      meta.frag->ForwardThread({iter_row, FloorMod(iter_col, meta.width)},
-                               std::nullopt) +
-      FloorDiv(iter_col, num_cols_each_wg) * WARPGROUP_SIZE;
-  PrimExpr val_idx =
-      meta.frag->Forward({iter_row, FloorMod(iter_col, meta.width)})[0] +
-      FloorDiv(FloorMod(iter_col, num_cols_each_wg), meta.width) *
-          num_elems_each_thread_in_one_chunk;
+  // Append the issue mode slowest of all value modes (each later issue
+  // appends registers).  The issue mode is the rest of dividing the
+  // serialized tile by its chunk.
+  // issue_mode: issue -> serialized TMEM;  E.g., 3:16384
+  // full_tv: (thread, value) -> serialized TMEM
+  // E.g., full_tv = ((32,(4,1)),((1,(64,1)),3)):
+  //                 ((1,(32,8192)),((0,(128,32)),16384))
+  cute::Layout issue_mode =
+      cute::LogicalDivide(serialized_tmem_tile, inv_prefix)[1];
+  cute::Layout value_modes = cute::MakeLayout({tiled[1], issue_mode});
+  cute::Layout full_tv = cute::MakeLayout({tiled[0], value_modes});
 
-  return {true,
-          Fragment({iter_row, iter_col}, {val_idx}, thread_idx,
-                   MakeIterVar("rep", Range(0, 1))),
-          num_chunks_each_wg};
+  int64_t num_vals = cute::AsConst(cute::Size(value_modes));
+
+  // A gapped tile is injective but not surjective, so the LEFT inverse maps
+  // its serialized image back to flat logical indices.
+  // tile_tv: (thread, value) -> flat logical tile
+  // E.g., LeftInverse = (16384,3):(3,1),
+  //       tile_tv = ((32,(4,1)),((1,(64,1)),3)):((3,(96,1)),((0,(384,1)),1))
+  cute::Layout tile_tv =
+      cute::Composition(cute::LeftInverse(serialized_tmem_tile), full_tv);
+
+  // Invert (the make_tiled_copy `right_inverse(...).with_shape(...)` idiom):
+  // the identity layout tags the (thread@0, value@1) axes, with_shape
+  // restores the tile's logical modes.
+  // fragment: logical tile -> (thread@0, value@1)
+  // E.g., fragment = (3,128,64):(64@1,1@0,1@1)
+  cute::Layout inv_tv = cute::RightInverse(tile_tv);
+  if (cute::AsConst(cute::Size(inv_tv)) != size)
+    return Tcgen05CopyPlan(nullptr);
+  Array<cute::IntTuple> tile_shape;
+  for (int64_t i = 0, r = cute::Rank(tmem_tile); i < r; ++i)
+    tile_shape.push_back(cute::Product(tmem_tile->shape[i]));
+  cute::Layout fragment =
+      cute::Composition(
+          cute::MakeIdentityLayout(Array<int64_t>{num_threads, num_vals}),
+          inv_tv)
+          .WithShape(cute::IntTupleTuple(tile_shape));
+
+  return Tcgen05CopyPlan(fragment, num_chunks_each_wg, rest_domain, num_issues,
+                         chunk / num_threads);
+}
+
+Fragment FragmentToTileLang(const cute::Layout &layout) {
+  int64_t r = cute::Rank(layout);
+  Array<IterVar> ivs;
+  Array<cute::IntTuple> coords;
+  arith::Analyzer analyzer;
+  for (int64_t i = 0; i < r; ++i) {
+    int64_t size = cute::AsConst(cute::Product(layout->shape[i]));
+    IterVar iv =
+        MakeIterVar("i" + std::to_string(i), Range(0, static_cast<int>(size)));
+    analyzer.Bind(iv->var, iv->dom);
+    ivs.push_back(iv);
+    coords.push_back(iv->var);
+  }
+  // Normalize the (thread@0, value@1) coordinate by adding the rank-2 zero
+  // ArithmeticTuple, so an untouched axis materializes as a plain zero slot.
+  cute::IntTuple tv_coord =
+      layout(cute::IntTupleTuple(coords)) + cute::IntTupleTuple({0, 0});
+  Array<cute::IntTuple> fields = cute::TupleFields(tv_coord);
+  ICHECK_EQ(fields.size(), 2U)
+      << "Fragment must map into (thread@0, value@1), got " << tv_coord;
+  DataType dtype = DataType::Int(32);
+  PrimExpr thread =
+      analyzer.Simplify(cute::AsConstOrPrimExpr(fields[0], dtype));
+  PrimExpr value = analyzer.Simplify(cute::AsConstOrPrimExpr(fields[1], dtype));
+  return Fragment(ivs, {value}, thread, MakeIterVar("rep", Range(0, 1)));
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = tvm::ffi::reflection;
+  Tcgen05MetaNode::RegisterReflection();
+  Tcgen05CopyPlanNode::RegisterReflection();
+  refl::GlobalDef()
+      .def("tl.get_tcgen05_meta_ld_32dp32b", GetTcgen05MetaLd32Dp32B)
+      .def("tl.get_tcgen05_meta_ld_16dp64b", GetTcgen05MetaLd16Dp64B)
+      .def("tl.get_tcgen05_meta_ld_16dp128b", GetTcgen05MetaLd16Dp128B)
+      .def("tl.get_tcgen05_meta_ld_16dp256b", GetTcgen05MetaLd16Dp256B)
+      .def("tl.get_tcgen05_meta_st_32dp32b", GetTcgen05MetaSt32Dp32B)
+      .def("tl.get_tcgen05_meta_st_16dp64b", GetTcgen05MetaSt16Dp64B)
+      .def("tl.get_tcgen05_meta_st_16dp128b", GetTcgen05MetaSt16Dp128B)
+      .def("tl.get_tcgen05_meta_st_16dp256b", GetTcgen05MetaSt16Dp256B)
+      .def("tl.ExpandTcgen05Layout",
+           [](const Tcgen05Meta &meta, const cute::Layout &tmem_tile,
+              int64_t num_threads) {
+             return ExpandTcgen05Layout(meta, tmem_tile,
+                                        static_cast<int>(num_threads));
+           });
 }
 
 } // namespace tl

--- a/src/layout/tcgen05_layout.h
+++ b/src/layout/tcgen05_layout.h
@@ -1,39 +1,117 @@
 /*!
- * \file layout/tcgen05_layout.cc
- *
+ * \file layout/tcgen05_layout.h
+ * \brief tcgen05.ld/st data-movement shapes as CuTe TV atoms.
  */
 #pragma once
 
+#include "cute_layout.h"
 #include "layout.h"
 
 namespace tvm {
 namespace tl {
 
-// A structure encapsulating the metadata for a particular tcgen05.ld/st
-// instruction.
-struct Tcgen05Meta {
-  std::string intrinsics_name;
-  Fragment frag; // Physical tmem coord |-> (thread_id, val_id) in fragment
-  int width;
+// Metadata for one tcgen05.ld/st data-movement shape.
+//
+// `tv` is the CUTLASS ``Copy_Traits<SM100_TMEM_LOAD_*1x>`` TV atom verbatim
+// (DstLayout over ValID, upcast to b32): a rank-2 layout (lane modes,
+// register modes) whose ScaledBasis strides land in axis 0 = datapath and
+// axis 1 = b32 column.  It covers exactly what one PTX issue of the x1
+// shape covers -- one 32-lane warp and, for the 16-datapath shapes, only
+// the LOW 16 datapaths of the warp's sub-partition.  All replication is
+// applied algebraically by ExpandTcgen05Layout: the warp tiling
+// (make_tmem_copy's atom_t_layout), the wrapper's duplicate issue on the
+// high 16 datapaths, the .xN column repetitions, and the warpgroup split
+// enter as one blocked product over a replication grid, so the atom itself
+// stores none of them.
+class Tcgen05MetaNode : public ffi::Object {
+public:
+  ffi::String intrinsics_name;
+  cute::Layout tv;    // (lane..., reg...) -> (datapath, column), one issue
+  int64_t max_chunks; // largest .xN of one issue; 0 = wrapper chaining exact
+
+  static void RegisterReflection();
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.Tcgen05Meta", Tcgen05MetaNode,
+                                    ffi::Object);
+};
+
+class Tcgen05Meta : public ffi::ObjectRef {
+public:
+  TVM_DLL Tcgen05Meta(ffi::String intrinsics_name, cute::Layout tv,
+                      int64_t max_chunks);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Tcgen05Meta, ffi::ObjectRef,
+                                             Tcgen05MetaNode);
 };
 
 // Obtain the metadata for tcgen05.ld instructions.
 Tcgen05Meta GetTcgen05MetaLd32Dp32B();
-Tcgen05Meta GetTcgen05MetaLd32Dp64B();
-Tcgen05Meta GetTcgen05MetaLd32Dp128B();
-Tcgen05Meta GetTcgen05MetaLd32Dp256B();
+Tcgen05Meta GetTcgen05MetaLd16Dp64B();
+Tcgen05Meta GetTcgen05MetaLd16Dp128B();
+Tcgen05Meta GetTcgen05MetaLd16Dp256B();
 
 // Obtain the metadata for tcgen05.st instructions.
 Tcgen05Meta GetTcgen05MetaSt32Dp32B();
-Tcgen05Meta GetTcgen05MetaSt32Dp64B();
-Tcgen05Meta GetTcgen05MetaSt32Dp128B();
-Tcgen05Meta GetTcgen05MetaSt32Dp256B();
+Tcgen05Meta GetTcgen05MetaSt16Dp64B();
+Tcgen05Meta GetTcgen05MetaSt16Dp128B();
+Tcgen05Meta GetTcgen05MetaSt16Dp256B();
 
-// Expand a tcgen05 layout along thread_idx/value_idx (T/V) dimensions.
-// Return {is_success, fragment, num_chunks_each_wg}
-std::tuple<bool, Fragment, int>
-ExpandTcgen05Layout(const Tcgen05Meta &meta, int tmem_phy_col_extent,
-                    int num_threads, Range row_dom, Range col_dom);
+// The atom's extent along one physical axis, from the CuTe algebra: compose
+// an axis projection over the TV layout (keeping one axis's strides and
+// zeroing the other's) and take the cosize.  Datapaths determine the
+// wrapper's duplication factor (32 / datapaths issues fill a warp's
+// sub-partition); the width is the b32 columns of one .x1 repetition.
+int64_t Tcgen05AtomDatapaths(const Tcgen05Meta &meta);
+int64_t Tcgen05AtomWidth(const Tcgen05Meta &meta);
+
+// The tiled copy of one TMEM tile, built by ExpandTcgen05Layout.
+//
+// A tile whose serialized image is gapped (e.g. a column slice of a batched
+// accumulator, (3,128,64):(16384,1,128) serialized) cannot be one
+// instruction; the copy iterates its contiguous chunks instead, one issue
+// per rest coordinate (CuTe's tiled-copy rest modes).
+class Tcgen05CopyPlanNode : public ffi::Object {
+public:
+  cute::Layout fragment;      // logical tile coord -> (thread@0, value@1)
+  int64_t num_chunks_each_wg; // .xN repetitions per warpgroup, per issue
+  cute::Layout rest_domain;   // issue -> flat logical tile index of origin
+  int64_t num_issues;         // size(rest_domain)
+  int64_t vals_per_issue;     // registers per thread, per issue
+
+  static void RegisterReflection();
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.Tcgen05CopyPlan", Tcgen05CopyPlanNode,
+                                    ffi::Object);
+};
+
+class Tcgen05CopyPlan : public ffi::ObjectRef {
+public:
+  TVM_DLL Tcgen05CopyPlan(cute::Layout fragment, int64_t num_chunks_each_wg,
+                          cute::Layout rest_domain, int64_t num_issues,
+                          int64_t vals_per_issue);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Tcgen05CopyPlan, ffi::ObjectRef,
+                                             Tcgen05CopyPlanNode);
+};
+
+// Build the copy plan for one TMEM tile, in CuTe algebra: serialize the
+// atom TV layout and `tmem_tile` (logical tile coords -> physical
+// (datapath@0, column@1)) into linear TMEM addressing via (1,1):(1,128);
+// right_inverse of the serialized tile finds its maximal contiguous chunk,
+// and logical_divide by that inverse splits the tile into (chunk, rest);
+// tile the serialized atom over (warpgroups, repetitions) with a blocked
+// product whose appended value mode is FASTER than the appended thread mode
+// (the values a thread holds stay contiguous in TMEM for the longest
+// vectors), and append the rest mode slowest of all (later issues append
+// registers); compose with the left inverse of the serialized tile
+// (register TV -> serialized TMEM -> logical tile); and invert once more.
+//
+// Returns a null ref when this instruction/warpgroup arrangement cannot
+// express the tile's chunks bijectively.
+Tcgen05CopyPlan ExpandTcgen05Layout(const Tcgen05Meta &meta,
+                                    const cute::Layout &tmem_tile,
+                                    int num_threads);
+
+// Convert a fragment (logical coord -> (thread@0, value@1), like
+// Tcgen05CopyPlan::fragment) into a TileLang Fragment over its top-level
+// modes (the single, final conversion out of CuTe algebra).
+Fragment FragmentToTileLang(const cute::Layout &layout);
 
 } // namespace tl
 } // namespace tvm

--- a/testing/python/cuda/test_tilelang_cuda_tcgen05_operand_layout.py
+++ b/testing/python/cuda/test_tilelang_cuda_tcgen05_operand_layout.py
@@ -31,7 +31,7 @@ def _swizzle_128b(shape, plain_address):
 
 
 def _ranges(mins, extents):
-    return [tvm.ir.Range.from_min_extent(begin, extent) for begin, extent in zip(mins, extents)]
+    return [tvm.ir.Range.from_min_extent(begin, extent) for begin, extent in zip(mins, extents, strict=True)]
 
 
 def _make_emitter():

--- a/testing/python/cuda/test_tilelang_cuda_tcgen05_operand_layout.py
+++ b/testing/python/cuda/test_tilelang_cuda_tcgen05_operand_layout.py
@@ -1,0 +1,369 @@
+"""Unit tests for CUTLASS-compatible TCGEN05 operand layouts."""
+
+import pytest
+
+import tilelang.language as T
+from tilelang import tvm
+from tilelang.cuda.intrinsics.layout.mma_sm100_layout import (
+    TCGEN05Meta,
+    TCGEN05TmemAllocMode,
+    make_tmem_frg,
+    make_tmem_frg_a,
+    make_tmem_frg_atom,
+    make_tmem_frg_c,
+    validate_tcgen05_ts_instruction,
+)
+from tilelang.cuda.intrinsics.macro.tcgen05_macro_generator import (
+    TensorCoreIntrinEmitter,
+    compute_umma_descriptor,
+)
+from tilelang.layout import Layout
+
+
+def _swizzle_128b(shape, plain_address):
+    """Construct BF16 ``Sw<3,3,3> o plain_address`` for layout probes."""
+
+    def forward(*coords):
+        address = plain_address(*coords)
+        return address ^ ((address & (7 << 6)) >> 3)
+
+    return Layout(shape, forward)
+
+
+def _ranges(mins, extents):
+    return [tvm.ir.Range.from_min_extent(begin, extent) for begin, extent in zip(mins, extents)]
+
+
+def _make_emitter():
+    """One M256/N128/K32 BF16 emitter pinned to the (128, 64, 16) atom.
+
+    The default row-major orientation (``a_transposed=False``,
+    ``b_transposed=False``) covers both operand-under-test orientations: A is
+    validated untransposed and B transposed (``not b_transposed``).
+    """
+    emitter = TensorCoreIntrinEmitter(
+        a_dtype=T.bfloat16,
+        b_dtype=T.bfloat16,
+        accum_dtype=T.float32,
+        a_transposed=False,
+        b_transposed=False,
+        block_row_warps=1,
+        block_col_warps=1,
+        warp_row_tiles=256,
+        warp_col_tiles=128,
+        chunk=32,
+    )
+    emitter.meta = (128, 64, 16, 0, 0)
+    return emitter
+
+
+def _valid_operand_regions():
+    """Whole-buffer A/B/C Regions aligned to ``_make_emitter``'s atom grid."""
+    a_region = tvm.tirx.BufferRegion(
+        tvm.tirx.decl_buffer((256, 32), "bfloat16", scope="shared"),
+        _ranges((0, 0), (256, 32)),
+    )
+    b_region = tvm.tirx.BufferRegion(
+        tvm.tirx.decl_buffer((32, 64), "bfloat16", scope="shared"),
+        _ranges((0, 0), (32, 64)),
+    )
+    c_region = tvm.tirx.BufferRegion(
+        tvm.tirx.decl_buffer((256, 128), "float32", scope="shared.tmem"),
+        _ranges((0, 0), (256, 128)),
+    )
+    return a_region, b_region, c_region
+
+
+@pytest.mark.parametrize(
+    ("num_sms", "alloc_mode", "atom_m", "atom_n", "shape", "stride", "tile_stride"),
+    [
+        (1, TCGEN05TmemAllocMode.INTERLEAVED, 64, 32, ((16, 4), 32), ((1, 32), 128), 1),
+        (1, TCGEN05TmemAllocMode.NON_INTERLEAVED, 64, 32, ((16, 4), 32), ((1, 32), 128), 2),
+        (1, TCGEN05TmemAllocMode.NON_INTERLEAVED, 128, 16, (128, 16), (1, 128), 1),
+        (2, TCGEN05TmemAllocMode.INTERLEAVED, 32, 32, (32, (8, 4)), (1, (128, 32)), 1),
+        (2, TCGEN05TmemAllocMode.INTERLEAVED, 64, 64, (64, (32, 2)), (1, (128, 64)), 1),
+        (2, TCGEN05TmemAllocMode.DUPLICATED, 64, 64, (128, 64), (1, 128), 1),
+        (2, TCGEN05TmemAllocMode.INTERLEAVED, 128, 32, (128, 32), (1, 128), 1),
+    ],
+)
+def test_tcgen05_tmem_atoms_match_cutlass(
+    num_sms,
+    alloc_mode,
+    atom_m,
+    atom_n,
+    shape,
+    stride,
+    tile_stride,
+):
+    atom, actual_tile_stride = make_tmem_frg_atom(
+        num_sms,
+        alloc_mode,
+        atom_m,
+        atom_n,
+    )
+    assert atom.shape == shape
+    assert atom.stride == stride
+    assert actual_tile_stride == tile_stride
+
+
+def test_tcgen05_tmem_fragment_tiles_outer_m_and_n():
+    buffer = tvm.tirx.decl_buffer((256, 128), "float32", scope="shared.tmem")
+    fragment = make_tmem_frg(
+        buffer,
+        1,
+        TCGEN05TmemAllocMode.NON_INTERLEAVED,
+        128,
+        64,
+        32,
+    )
+    layout = fragment.to_tilelang()
+    assert [int(x) for x in layout.map_forward_index([0, 0])] == [0, 0]
+    assert [int(x) for x in layout.map_forward_index([128, 0])] == [0, 64]
+    assert [int(x) for x in layout.map_forward_index([0, 64])] == [0, 128]
+    assert [int(x) for x in layout.map_forward_index([128, 64])] == [0, 192]
+
+
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16"])
+def test_tcgen05_tmem_c_fragment_restrides_values_to_int32_storage(dtype):
+    buffer = tvm.tirx.decl_buffer((128, 128), dtype, scope="shared.tmem")
+    fragment = make_tmem_frg_c(buffer, TCGEN05Meta(128, 64, 16, False, False), is_ts=True)
+    layout = fragment.to_tilelang()
+
+    # CUTLASS FrgTypeC uses StorageType=int32 even when ValueType is 16-bit.
+    assert [int(x) for x in layout.map_forward_index([0, 1])] == [0, 2]
+    second_n_atom = [int(x) for x in layout.map_forward_index([0, 64])]
+    assert second_n_atom == [0, 128]
+    assert second_n_atom[1] * 16 // 32 == 64
+    assert [int(x) for x in layout.get_output_shape()] == [128, 255]
+
+
+def test_tcgen05_tmem_fragment_tiles_leading_batch_modes():
+    buffer = tvm.tirx.decl_buffer((2, 2, 128, 64), "float32", scope="shared.tmem")
+    fragment = make_tmem_frg_c(buffer, TCGEN05Meta(128, 64, 16, False, False), is_ts=True)
+    layout = fragment.to_tilelang()
+
+    # Batch modes continue the col-major tiling after the matrix tiles, with
+    # the last batch axis repeating fastest.
+    assert [int(x) for x in layout.map_forward_index([0, 0, 0, 0])] == [0, 0]
+    assert [int(x) for x in layout.map_forward_index([0, 1, 0, 0])] == [0, 64]
+    assert [int(x) for x in layout.map_forward_index([1, 1, 0, 0])] == [0, 192]
+    assert [int(x) for x in layout.get_output_shape()] == [128, 256]
+
+
+def test_tcgen05_tmem_fragment_rejects_unrepresentable_2sm_duplication():
+    buffer = tvm.tirx.decl_buffer((64, 128), "bfloat16", scope="shared.tmem")
+    with pytest.raises(ValueError, match=r"duplicated 2SM M64 allocation"):
+        make_tmem_frg_a(buffer, TCGEN05Meta(128, 64, 16, False, True))
+
+
+def test_tcgen05_tmem_m64_dense_fragment_interleaves_half_datapaths():
+    # tmem_frg 1SM M64: the ((16,4),N):((1,32),128) atom spreads consecutive
+    # M through datapath quarters; INTERLEAVED tiles the second M atom into
+    # the odd 16-datapath slots of the same columns.
+    buffer = tvm.tirx.decl_buffer((128, 32), "float32", scope="shared.tmem")
+    fragment = make_tmem_frg_c(buffer, TCGEN05Meta(64, 32, 16, False, False), is_ts=False)
+    layout = fragment.to_tilelang()
+    assert [int(x) for x in layout.map_forward_index([16, 0])] == [32, 0]
+    assert [int(x) for x in layout.map_forward_index([64, 0])] == [16, 0]
+    assert [int(x) for x in layout.map_forward_index([127, 31])] == [127, 31]
+
+
+def test_tcgen05_tmem_ws_c_fragment_matches_cutlass_ws_atom():
+    # tmem_frg_ws 1SM M64: (64,(N/2,2)):(1,(128,64)) folds the upper half of N
+    # into datapaths 64..127 instead of interleaving M tiles.
+    buffer = tvm.tirx.decl_buffer((64, 64), "float32", scope="shared.tmem")
+    fragment = make_tmem_frg_c(buffer, TCGEN05Meta(64, 64, 16, True, False), is_ts=False)
+    layout = fragment.to_tilelang()
+    assert [int(x) for x in layout.map_forward_index([32, 0])] == [32, 0]
+    assert [int(x) for x in layout.map_forward_index([0, 32])] == [64, 0]
+    assert [int(x) for x in layout.map_forward_index([63, 63])] == [127, 31]
+
+
+def test_tcgen05_tmem_ws_c_fragment_requires_ws_metadata():
+    buffer = tvm.tirx.decl_buffer((64, 64), "float32", scope="shared.tmem")
+    # A ws=False meta selects the ordinary dense fragment, not Layout E.
+    dense = make_tmem_frg_c(buffer, TCGEN05Meta(64, 64, 16, False, False), is_ts=False)
+    ws = make_tmem_frg_c(buffer, TCGEN05Meta(64, 64, 16, True, False), is_ts=False)
+    assert dense((0, 32)) != ws((0, 32))
+
+
+@pytest.mark.parametrize(
+    ("name", "shape", "dtype", "meta", "is_ts"),
+    [
+        # One case per PTX data-path layout variant plus the special forms.
+        ("layout_a_2sm_m256", (128, 128), "float32", (256, 128, 16, 0, 1), False),
+        ("layout_b_2sm_m128", (64, 128), "float32", (128, 128, 16, 0, 1), False),
+        ("layout_d_1sm_m128", (128, 128), "float32", (128, 128, 16, 0, 0), False),
+        ("layout_e_ws_m64", (64, 64), "float32", (64, 64, 16, 1, 0), False),
+        ("layout_f_1sm_m64", (128, 32), "float32", (64, 32, 16, 0, 0), False),
+        ("layout_g_ws_m32", (32, 128), "float32", (32, 128, 16, 1, 0), False),
+        ("f16_int32_storage", (128, 64), "float16", (128, 64, 16, 0, 0), True),
+        ("leading_batch", (2, 128, 64), "float32", (128, 64, 16, 0, 0), False),
+    ],
+)
+def test_tcgen05_tmem_fragment_tilelang_roundtrip(name, shape, dtype, meta, is_ts):
+    """to_tilelang and from_tilelang_hierarchical are exact inverses.
+
+    The TileLang form is what travels through the layout map; recovery must
+    reproduce the hierarchical ``(datapath, column)`` mapping, not a
+    serialized linear address.
+    """
+    import itertools
+
+    from tilelang.layout import cute
+
+    buffer = tvm.tirx.decl_buffer(shape, dtype, scope="shared.tmem")
+    fragment = make_tmem_frg_c(buffer, TCGEN05Meta.from_ffi(meta), is_ts=is_ts)
+    recovered = cute.Layout.from_tilelang_hierarchical(fragment.to_tilelang())
+    assert recovered is not None, f"{name} is not decodable by the CuTe analyzer"
+    extents = [cute.size(fragment[mode]) for mode in range(cute.rank(fragment))]
+    for coords in itertools.product(*(range(0, extent, max(1, extent // 7)) for extent in extents)):
+        assert fragment(coords) == recovered(coords), f"{name} diverges at {coords}"
+
+
+@pytest.mark.parametrize(
+    "meta",
+    [
+        (64, 8, 16, 0, 0),
+        (64, 256, 16, 0, 0),
+        (128, 16, 16, 0, 0),
+        (128, 256, 16, 0, 0),
+        (128, 32, 16, 0, 1),
+        (128, 256, 16, 0, 1),
+        (256, 32, 16, 0, 1),
+        (256, 256, 16, 0, 1),
+    ],
+)
+def test_tcgen05_ts_instruction_legal_boundaries_match_cutlass(meta):
+    validate_tcgen05_ts_instruction(TCGEN05Meta.from_ffi(meta), T.bfloat16, False)
+
+
+@pytest.mark.parametrize(
+    ("meta", "message"),
+    [
+        ((128, 8, 16, 0, 0), r"1CTA.*N.*multiple of 16"),
+        ((128, 24, 16, 0, 0), r"1CTA.*N.*multiple of 16"),
+        ((128, 16, 16, 0, 1), r"2CTA.*N.*multiple of 32"),
+        ((256, 48, 16, 0, 1), r"2CTA.*N.*multiple of 32"),
+    ],
+)
+def test_tcgen05_ts_instruction_rejects_cutlass_illegal_boundaries(meta, message):
+    with pytest.raises(ValueError, match=message):
+        validate_tcgen05_ts_instruction(TCGEN05Meta.from_ffi(meta), T.bfloat16, False)
+
+
+@pytest.mark.parametrize(
+    ("operand", "shape", "mins", "extents", "transposed", "mn_atom", "k_atom", "message"),
+    [
+        ("A", (256, 16), (0, 0), (192, 16), False, 128, 16, r"A M extent 192.*atom 128"),
+        ("A", (128, 32), (0, 0), (128, 24), False, 128, 16, r"A K extent 24.*atom 16"),
+        ("B", (32, 64), (0, 0), (24, 64), True, 64, 16, r"B K extent 24.*atom 16"),
+        ("B", (16, 128), (0, 0), (16, 96), True, 64, 16, r"B N extent 96.*atom 64"),
+    ],
+)
+def test_tcgen05_matrix_regions_reject_partial_atom_extents(
+    operand,
+    shape,
+    mins,
+    extents,
+    transposed,
+    mn_atom,
+    k_atom,
+    message,
+):
+    emitter = _make_emitter()
+    a_region, b_region, c_region = _valid_operand_regions()
+    sliced = tvm.tirx.BufferRegion(
+        tvm.tirx.decl_buffer(shape, "bfloat16", scope="shared"),
+        _ranges(mins, extents),
+    )
+    regions = {"A": a_region, "B": b_region, "C": c_region, operand: sliced}
+    with pytest.raises(AssertionError, match=message):
+        emitter.validate_tcgen05_operand_regions(regions["A"], regions["B"], regions["C"], is_ts=False)
+
+
+@pytest.mark.parametrize(
+    ("extents", "message"),
+    [
+        ((192, 64), r"C M extent 192.*atom 128"),
+        ((128, 96), r"C N extent 96.*atom 64"),
+    ],
+)
+def test_tcgen05_accumulator_regions_reject_partial_atom_extents(extents, message):
+    emitter = _make_emitter()
+    a_region, b_region, _ = _valid_operand_regions()
+    c_region = tvm.tirx.BufferRegion(
+        tvm.tirx.decl_buffer((256, 128), "float32", scope="shared.tmem"),
+        [tvm.ir.Range.from_min_extent(0, extent) for extent in extents],
+    )
+    with pytest.raises(AssertionError, match=message):
+        emitter.validate_tcgen05_operand_regions(a_region, b_region, c_region, is_ts=False)
+
+
+def test_tcgen05_matrix_region_rejects_wide_leading_mode():
+    emitter = _make_emitter()
+    _, b_region, c_region = _valid_operand_regions()
+    a_region = tvm.tirx.BufferRegion(
+        tvm.tirx.decl_buffer((2, 128, 16), "bfloat16", scope="shared"),
+        _ranges((0, 0, 0), (2, 128, 16)),
+    )
+    with pytest.raises(AssertionError, match=r"A leading mode 0 must have unit extent"):
+        emitter.validate_tcgen05_operand_regions(a_region, b_region, c_region, is_ts=False)
+
+
+def test_tcgen05_operand_validation_pins_leading_modes():
+    emitter = _make_emitter()
+    a_region = tvm.tirx.BufferRegion(
+        tvm.tirx.decl_buffer((2, 3, 256, 128), "bfloat16", scope="shared"),
+        _ranges((1, 2, 128, 16), (1, 1, 128, 32)),
+    )
+    b_region = tvm.tirx.BufferRegion(
+        tvm.tirx.decl_buffer((32, 64), "bfloat16", scope="shared"),
+        _ranges((0, 0), (32, 64)),
+    )
+    c_region = tvm.tirx.BufferRegion(
+        tvm.tirx.decl_buffer((2, 3, 256, 128), "float32", scope="shared.tmem"),
+        _ranges((1, 1, 128, 64), (1, 1, 128, 64)),
+    )
+    emitter.validate_tcgen05_operand_regions(a_region, b_region, c_region, is_ts=False)
+
+
+def test_tcgen05_descriptor_pins_leading_stage_mode():
+    """A pipeline-stage mode pinned by the Region shifts only the slice base."""
+
+    m_extent = k_extent = 128
+
+    def plain_2d(m, k):
+        return m * 64 + k % 64 + (k // 64) * m_extent * 64
+
+    reference_buffer = tvm.tirx.decl_buffer((m_extent, k_extent), "bfloat16", scope="shared")
+    reference = compute_umma_descriptor(
+        _swizzle_128b((m_extent, k_extent), plain_2d),
+        reference_buffer,
+        False,
+        region=_ranges((0, 64), (m_extent, 32)),
+    )
+
+    parent_shape = (3, m_extent, k_extent)
+    parent_buffer = tvm.tirx.decl_buffer(parent_shape, "bfloat16", scope="shared")
+    parent_layout = _swizzle_128b(
+        parent_shape,
+        lambda stage, m, k: stage * m_extent * k_extent + plain_2d(m, k),
+    )
+    staged = compute_umma_descriptor(
+        parent_layout,
+        parent_buffer,
+        False,
+        region=_ranges((2, 0, 64), (1, m_extent, 32)),
+    )
+
+    assert (
+        staged.leading_byte_offset,
+        staged.stride_byte_offset,
+        staged.is_k_major,
+    ) == (
+        reference.leading_byte_offset,
+        reference.stride_byte_offset,
+        reference.is_k_major,
+    )
+    assert staged.slice_byte_offset - reference.slice_byte_offset == 2 * m_extent * k_extent * 2

--- a/testing/python/language/test_tilelang_language_atom_mma.py
+++ b/testing/python/language/test_tilelang_language_atom_mma.py
@@ -14,6 +14,7 @@ from tilelang.layout import (
     make_quarter_bank_swizzled_layout,
     make_linear_layout,
 )
+from tilelang.utils.language import to_buffer_region
 
 
 def make_swizzle_layout(shared_buf):
@@ -280,6 +281,7 @@ def make_tcgen05_atom_kernel(M, N, K, in_dtype, out_dtype, accum_dtype):
 
             emi._assign_a_shared_layout(a_layout(A_shared))
             emi._assign_b_shared_layout(b_layout(B_shared))
+            emi._assign_c_tmem_layout(emi.make_mma_store_layout(C_tmem))
             T.annotate_layout(
                 {
                     A_shared: a_layout(A_shared),
@@ -295,6 +297,7 @@ def make_tcgen05_atom_kernel(M, N, K, in_dtype, out_dtype, accum_dtype):
 
             a_params = emi.compute_tcgen05_a_desc_params(A_shared)
             b_params = emi.compute_tcgen05_b_desc_params(B_shared)
+            c_params = emi.compute_tcgen05_c_tmem_params(to_buffer_region(C_tmem))
 
             if T.get_thread_binding() // 32 == 0:
                 desc_a = T.alloc_tcgen05_smem_desc()
@@ -305,7 +308,7 @@ def make_tcgen05_atom_kernel(M, N, K, in_dtype, out_dtype, accum_dtype):
                 for n in T.unroll(num_inst_n):
                     for m in T.unroll(num_inst_m):
                         for ki in T.unroll(0, num_k_atoms):
-                            emi.tcgen05_ss_atom(desc_a, desc_b, C_tmem, m, n, ki, a_params, b_params, instr_desc, T.bool(True))
+                            emi.tcgen05_ss_atom(desc_a, desc_b, m, n, ki, a_params, b_params, c_params, instr_desc, T.bool(True))
                 emi.tcgen05_atom_arrive(mbar)
             T.mbarrier_wait_parity(mbar, 0)
 
@@ -317,7 +320,8 @@ def make_tcgen05_atom_kernel(M, N, K, in_dtype, out_dtype, accum_dtype):
 
 
 @tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_eq(10, 0)
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
 def test_tcgen05_atom_gemm():
     M, N, K = 128, 128, 128
     in_dtype = T.bfloat16

--- a/testing/python/language/test_tilelang_language_tcgen05_gemm.py
+++ b/testing/python/language/test_tilelang_language_tcgen05_gemm.py
@@ -612,6 +612,57 @@ def test_tcgen05_ld_whole_batched_buffer_correctness():
     torch.testing.assert_close(d, ref, rtol=1e-2, atol=1e-2)
 
 
+def _make_fp16_accum_tcgen05_kernel():
+    @T.prim_func
+    def main(
+        A: T.Tensor((128, 128), T.float8_e4m3fn),
+        B: T.Tensor((128, 128), T.float8_e4m3fn),
+        D: T.Tensor((128, 128), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((128, 128), T.float8_e4m3fn)
+            B_shared = T.alloc_shared((128, 128), T.float8_e4m3fn)
+            C_tmem = T.alloc_tmem((128, 128), T.float16)
+            mbar = T.alloc_barrier(1)
+            C_local = T.alloc_fragment((128, 128), T.float16)
+            C_shared = T.alloc_shared((128, 128), T.float16)
+
+            T.copy(A, A_shared)
+            T.copy(B, B_shared)
+            T.gemm(A_shared, B_shared, C_tmem, transpose_B=True, mbar=mbar, clear_accum=True)
+            T.mbarrier_wait_parity(mbar, 0)
+            T.copy(C_tmem, C_local)
+            T.copy(C_local, C_shared)
+            T.copy(C_shared, D)
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_tcgen05_gemm_fp16_accumulator_pack16b_epilogue():
+    import torch
+
+    # A 16-bit matrix D element occupies the lower 16 bits of its own 32-bit
+    # tensor-memory word (PTX ISA "Packing format for matrix D in Tensor
+    # Memory"), so an FP8 GEMM with an fp16 accumulator writes a TMEM
+    # fragment the epilogue copy must plan in b32 columns and gather with
+    # the pack::16b modifier -- one register per two b32 columns, hence x64
+    # for 128 b32 columns.
+    kernel = tilelang.compile(_make_fp16_accum_tcgen05_kernel(), target="cuda")
+    source = kernel.get_kernel_source()
+    ld_line = next(line for line in source.splitlines() if "tcgen05_ld_" in line)
+    assert "tcgen05_ld_32dp32bNx<64, true>" in ld_line
+
+    a = (torch.randn(128, 128, device="cuda") * 0.25).to(torch.float8_e4m3fn)
+    b = (torch.randn(128, 128, device="cuda") * 0.25).to(torch.float8_e4m3fn)
+    d = torch.empty(128, 128, device="cuda", dtype=torch.float16)
+    kernel(a, b, d)
+    ref = (a.float() @ b.float().T).to(torch.float16)
+    torch.testing.assert_close(d, ref, rtol=1e-2, atol=1e-2)
+
+
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version(10)
 @tilelang.testing.requires_cuda_compute_version_lt(11)

--- a/testing/python/language/test_tilelang_language_tcgen05_gemm.py
+++ b/testing/python/language/test_tilelang_language_tcgen05_gemm.py
@@ -72,39 +72,325 @@ def _make_async_tcgen05_kernel(gemm_op):
     return main
 
 
+def _tcgen05_issue_block(source):
+    """Extract the complete guarded block that initializes and issues TCGEN05."""
+
+    lines = source.splitlines()
+    anchor = next(i for i, line in enumerate(lines) if "initialize_tcgen05_descriptor" in line)
+    start = next(i for i in range(anchor, -1, -1) if "if (" in lines[i] and "{" in lines[i])
+
+    depth = 0
+    for end in range(start, len(lines)):
+        depth += lines[end].count("{") - lines[end].count("}")
+        if depth == 0:
+            return "\n".join(line.strip() for line in lines[start : end + 1])
+    raise AssertionError("unterminated TCGEN05 issue block")
+
+
+def _make_issue_only_tcgen05_kernel():
+    @T.prim_func
+    def main(
+        A: T.Tensor((128, 128), T.bfloat16),
+        B: T.Tensor((128, 128), T.bfloat16),
+        D: T.Tensor((128, 128), T.bfloat16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((128, 128), T.bfloat16)
+            B_shared = T.alloc_shared((128, 128), T.bfloat16)
+            C_tmem = T.alloc_tmem((128, 128), T.float32)
+            mbar = T.alloc_barrier(1)
+            C_local = T.alloc_fragment((128, 128), T.float32)
+            C_shared = T.alloc_shared((128, 128), T.bfloat16)
+
+            T.copy(A, A_shared)
+            T.copy(B, B_shared)
+            # The MMAs remain ordered in the TC issue stream without
+            # publishing independent completion events; one manual commit
+            # from the issue warp posts the event consumed before reading C.
+            for k in T.serial(2):
+                T.tcgen05_gemm(
+                    A_shared,
+                    B_shared,
+                    C_tmem,
+                    transpose_B=True,
+                    mbar=None,
+                    clear_accum=k == 0,
+                )
+            if T.get_thread_binding() < 32:
+                T.tcgen05_mma_arrive(mbar)
+            T.mbarrier_wait_parity(mbar, 0)
+            T.copy(C_tmem, C_local)
+            T.copy(C_local, C_shared)
+            T.copy(C_shared, D)
+
+    return main
+
+
+def _make_sync_sliced_ts_tmem_kernel():
+    """The high-level GEMM keeps nonzero K origins until SM100 selection."""
+
+    @T.prim_func
+    def main():
+        with T.Kernel(1, threads=128):
+            P_tmem = T.alloc_tmem((128, 128), T.bfloat16)
+            V_shared = T.alloc_shared((128, 64), T.bfloat16)
+            O_tmem = T.alloc_tmem((128, 64), T.float32)
+            done_0 = T.alloc_barrier(1)
+            done_1 = T.alloc_barrier(1)
+            done_2 = T.alloc_barrier(1)
+            done_3 = T.alloc_barrier(1)
+
+            T.gemm(P_tmem[:, 0:32], V_shared[0:32, :], O_tmem, mbar=done_0, clear_accum=True)
+            T.gemm(P_tmem[:, 32:64], V_shared[32:64, :], O_tmem, mbar=done_1)
+            T.gemm(P_tmem[:, 64:96], V_shared[64:96, :], O_tmem, mbar=done_2)
+            T.gemm(P_tmem[:, 96:128], V_shared[96:128, :], O_tmem, mbar=done_3)
+
+    return main
+
+
+def _make_explicit_2cta_gemm_kernel():
+    """Explicit two-CTA GEMM: user-scheduled operand publish and completion.
+
+    The cluster-wide handoffs are manual: ``cluster_sync`` publishes both
+    ranks' shared shards before the leader issues, and the completion commit
+    multicasts to both ranks' barriers, so each rank waits locally.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((256, 64), T.bfloat16),
+        B: T.Tensor((256, 64), T.bfloat16),
+        D: T.Tensor((256, 256), T.bfloat16),
+    ):
+        with T.ClusterKernel(2, threads=128, cluster_dims=2):
+            rank = T.block_rank_in_cluster()
+            A_shared = T.alloc_shared((128, 64), T.bfloat16)
+            B_shared = T.alloc_shared((128, 64), T.bfloat16)
+            C_tmem = T.alloc_tmem((128, 256), T.float32)
+            done = T.alloc_cluster_barrier(1)
+            C_local = T.alloc_fragment((128, 256), T.float32)
+            C_shared = T.alloc_shared((128, 256), T.bfloat16)
+
+            T.copy(A[rank * 128 : (rank + 1) * 128, :], A_shared)
+            T.copy(B[rank * 128 : (rank + 1) * 128, :], B_shared)
+            T.cluster_sync()
+            T.tcgen05_gemm(
+                A_shared,
+                B_shared,
+                C_tmem,
+                transpose_B=True,
+                clear_accum=True,
+                mbar=done,
+                use_2cta=True,
+            )
+            T.mbarrier_wait_parity(done, 0)
+            T.copy(C_tmem, C_local)
+            T.copy(C_local, C_shared)
+            T.copy(C_shared, D[rank * 128 : (rank + 1) * 128, :])
+
+    return main
+
+
+def _make_explicit_2cta_ts_handoff_kernel():
+    """Thread-produced TMEM A consumed by a cooperative TS GEMM.
+
+    A TMEM input needs the canonical TCGEN visibility handoff around the
+    cluster rendezvous before the leader issues.
+    """
+
+    @T.prim_func
+    def main(
+        P: T.Tensor((256, 32), T.bfloat16),
+        V: T.Tensor((32, 64), T.bfloat16),
+        D: T.Tensor((256, 64), T.bfloat16),
+    ):
+        with T.ClusterKernel(2, threads=128, cluster_dims=2):
+            rank = T.block_rank_in_cluster()
+            P_shared = T.alloc_shared((128, 32), T.bfloat16)
+            P_local = T.alloc_fragment((128, 32), T.bfloat16)
+            P_tmem = T.alloc_tmem((128, 32), T.bfloat16)
+            V_shared = T.alloc_shared((32, 32), T.bfloat16)
+            O_tmem = T.alloc_tmem((128, 64), T.float32)
+            done = T.alloc_cluster_barrier(1)
+            O_local = T.alloc_fragment((128, 64), T.float32)
+            O_shared = T.alloc_shared((128, 64), T.bfloat16)
+
+            T.copy(P[rank * 128 : (rank + 1) * 128, :], P_shared)
+            T.copy(P_shared, P_local)
+            T.copy(P_local, P_tmem)
+            T.copy(V[:, rank * 32 : (rank + 1) * 32], V_shared)
+            T.tcgen05_before_thread_sync()
+            T.cluster_sync()
+            T.tcgen05_after_thread_sync()
+            T.tcgen05_gemm(
+                P_tmem,
+                V_shared,
+                O_tmem,
+                clear_accum=True,
+                mbar=done,
+                use_2cta=True,
+            )
+            T.mbarrier_wait_parity(done, 0)
+            T.copy(O_tmem, O_local)
+            T.copy(O_local, O_shared)
+            T.copy(O_shared, D[rank * 128 : (rank + 1) * 128, :])
+
+    return main
+
+
+def _make_2cta_without_cluster_kernel():
+    @T.prim_func
+    def main():
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((128, 64), T.bfloat16)
+            B_shared = T.alloc_shared((128, 64), T.bfloat16)
+            C_tmem = T.alloc_tmem((128, 256), T.float32)
+            done = T.alloc_barrier(1)
+            T.tcgen05_gemm(
+                A_shared,
+                B_shared,
+                C_tmem,
+                transpose_B=True,
+                clear_accum=True,
+                mbar=done,
+                use_2cta=True,
+            )
+
+    return main
+
+
+def _make_2cta_invalid_cluster_kernel():
+    @T.prim_func
+    def main():
+        with T.ClusterKernel(4, threads=128, cluster_dims=4):
+            A_shared = T.alloc_shared((128, 64), T.bfloat16)
+            B_shared = T.alloc_shared((128, 64), T.bfloat16)
+            C_tmem = T.alloc_tmem((128, 256), T.float32)
+            done = T.alloc_cluster_barrier(1)
+            T.tcgen05_gemm(
+                A_shared,
+                B_shared,
+                C_tmem,
+                transpose_B=True,
+                clear_accum=True,
+                mbar=done,
+                use_2cta=True,
+            )
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_tcgen05_gemm_matches_sync_gemm_issue_codegen():
+    def sync_api(A, B, C, mbar):
+        return T.gemm(A, B, C, transpose_B=True, mbar=mbar, clear_accum=True)
+
+    def async_api(A, B, C, mbar):
+        return T.tcgen05_gemm(A, B, C, transpose_B=True, mbar=mbar, clear_accum=True)
+
+    sync_kernel = tilelang.compile(_make_sync_tcgen05_kernel(sync_api), target="cuda")
+    async_kernel = tilelang.compile(_make_async_tcgen05_kernel(async_api), target="cuda")
+    sync_source = sync_kernel.get_kernel_source()
+    async_source = async_kernel.get_kernel_source()
+
+    assert _tcgen05_issue_block(sync_source) == _tcgen05_issue_block(async_source)
+    for source in (sync_source, async_source):
+        assert source.count(".wait(0)") == 1
+        assert source.index("tcgen05_mma_arrive") < source.index(".wait(0)")
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_tcgen05_gemm_can_omit_intermediate_completion_event():
+    kernel = tilelang.compile(_make_issue_only_tcgen05_kernel(), target="cuda")
+    source = kernel.get_kernel_source()
+    assert source.count("tcgen05_mma_arrive") == 1
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_sync_gemm_preserves_sliced_ts_operands_for_sm100_selection():
+    source = tilelang.compile(_make_sync_sliced_ts_tmem_kernel(), target="cuda").get_kernel_source()
+    assert source.count("tl::tcgen05mma_ts") == 4
+    assert "increase_descriptor_offset" in source
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_explicit_gemm_2cta_correctness():
+    import torch
+
+    kernel = tilelang.compile(_make_explicit_2cta_gemm_kernel(), target="cuda")
+    source = kernel.get_kernel_source()
+    assert "tcgen05mma_ss<tl::DataType::kBFloat16, true>" in source
+    mma_pos = source.index("tcgen05mma_ss<tl::DataType::kBFloat16, true>")
+    acquire_sync_pos = source.rfind("tl::cluster_sync()", 0, mma_pos)
+    assert 0 <= acquire_sync_pos < mma_pos
+
+    wait_pos = source.index(".wait(", mma_pos)
+    load_pos = source.index("tl::tcgen05_ld_", wait_pos)
+    assert 0 <= mma_pos < wait_pos < load_pos
+
+    a = torch.randn(256, 64, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(256, 64, device="cuda", dtype=torch.bfloat16)
+    d = torch.empty(256, 256, device="cuda", dtype=torch.bfloat16)
+    kernel(a, b, d)
+    ref = (a.float() @ b.float().T).to(torch.bfloat16)
+    torch.testing.assert_close(d, ref, rtol=1e-2, atol=1e-2)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_explicit_gemm_2cta_ts_thread_handoff_correctness():
+    import torch
+
+    kernel = tilelang.compile(_make_explicit_2cta_ts_handoff_kernel(), target="cuda")
+    source = kernel.get_kernel_source()
+    mma_pos = source.index("tcgen05mma_ts<tl::DataType::kBFloat16, true>")
+    store_pos = source.rfind("tl::tcgen05_st_", 0, mma_pos)
+    sync_pos = source.rfind("tl::cluster_sync()", 0, mma_pos)
+    before_pos = source.rfind("tl::tcgen05_before_thread_sync()", 0, sync_pos)
+    after_pos = source.index("tl::tcgen05_after_thread_sync()", sync_pos)
+    assert 0 <= store_pos < before_pos < sync_pos < after_pos < mma_pos
+
+    p = torch.randn(256, 32, device="cuda", dtype=torch.bfloat16)
+    v = torch.randn(32, 64, device="cuda", dtype=torch.bfloat16)
+    d = torch.empty(256, 64, device="cuda", dtype=torch.bfloat16)
+    kernel(p, v, d)
+    ref = (p.float() @ v.float()).to(torch.bfloat16)
+    torch.testing.assert_close(d, ref, rtol=1e-2, atol=1e-2)
+
+
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version(10)
 @tilelang.testing.requires_cuda_compute_version_lt(11)
 @pytest.mark.parametrize(
-    ("sync_api", "async_api"),
-    [
-        (
-            lambda A, B, C, mbar: T.gemm(A, B, C, transpose_B=True, mbar=mbar, clear_accum=True),
-            lambda A, B, C, mbar: T.tcgen05_gemm(A, B, C, transpose_B=True, mbar=mbar, clear_accum=True),
-        ),
-    ],
+    "kernel_factory",
+    [_make_2cta_without_cluster_kernel, _make_2cta_invalid_cluster_kernel],
 )
-def test_tcgen05_gemm_matches_sync_gemm_codegen(sync_api, async_api):
-    sync_kernel = tilelang.compile(_make_sync_tcgen05_kernel(sync_api), target="cuda")
-    async_kernel = tilelang.compile(_make_async_tcgen05_kernel(async_api), target="cuda")
-
-    assert sync_kernel.get_kernel_source() == async_kernel.get_kernel_source()
+def test_tcgen05_gemm_2cta_requires_two_cta_cluster(kernel_factory):
+    with pytest.raises(tvm.error.InternalError, match=r"requires cluster_dims"):
+        tilelang.compile(kernel_factory(), target="cuda")
 
 
 @tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version(10)
-@tilelang.testing.requires_cuda_compute_version_lt(11)
-def test_tcgen05_gemm_dispatch_matches_sync_gemm_codegen():
-    sync_kernel = tilelang.compile(
-        _make_sync_tcgen05_kernel(lambda A, B, C, mbar: T.gemm(A, B, C, transpose_B=True, mbar=mbar, clear_accum=True)),
-        target="cuda",
-    )
-    async_kernel = tilelang.compile(
-        _make_async_tcgen05_kernel(lambda A, B, C, mbar: T.tcgen05_gemm(A, B, C, transpose_B=True, mbar=mbar, clear_accum=True)),
-        target="cuda",
-    )
+def test_tcgen05_gemm_2cta_rejects_non_blackwell_target():
+    target = tvm.target.Target({"kind": "cuda", "arch": "sm_90"})
+    with pytest.raises(tvm.error.InternalError, match=r"requires Blackwell TCGEN5MMA"):
+        tilelang.compile(_make_explicit_2cta_gemm_kernel(), target=target)
 
-    assert sync_kernel.get_kernel_source() == async_kernel.get_kernel_source()
+
+def test_sync_gemm_has_no_2cta_parameter():
+    # The synchronous convenience wrapper deliberately does not model the
+    # cluster-wide handoffs; 2CTA lives only on T.tcgen05_gemm.
+    with pytest.raises(TypeError, match=r"use_2cta"):
+        T.gemm(None, None, None, use_2cta=True)
 
 
 @tilelang.testing.requires_cuda
@@ -211,4 +497,139 @@ def test_tcgen05_gemm_sliced_operand_correctness(M, N, K, num_k_tiles):
     d = torch.empty(M, N, device="cuda", dtype=torch.bfloat16)
     kernel(a, b, d)
     ref = (a.float() @ b.float().t()).to(torch.bfloat16)
+    torch.testing.assert_close(d, ref, rtol=1e-2, atol=1e-2)
+
+
+def _make_batched_tcgen05_kernel(batch_size):
+    """One independent GEMM per batch entry, all operands 3-D.
+
+    Every buffer carries the batch mode: the leading mode repeats the TMEM
+    accumulator fragment along columns, so per-entry results occupy disjoint
+    column windows of one allocation, while the SS operands slice their own
+    batch entry out of 3-D shared buffers.  The GEMM loop and the tcgen05.ld
+    epilogue both carry a dynamic batch origin: the MMA and copy tiles are
+    static relative to the Region origin, which only moves the descriptor and
+    TMEM base addresses.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((batch_size, 128, 64), T.bfloat16),
+        B: T.Tensor((batch_size, 128, 64), T.bfloat16),
+        D: T.Tensor((batch_size, 128, 128), T.bfloat16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((batch_size, 128, 64), T.bfloat16)
+            B_shared = T.alloc_shared((batch_size, 128, 64), T.bfloat16)
+            C_tmem = T.alloc_tmem((batch_size, 128, 128), T.float32)
+            done = T.alloc_barrier(1)
+            C_local = T.alloc_fragment((128, 128), T.float32)
+            C_shared = T.alloc_shared((128, 128), T.bfloat16)
+
+            T.copy(A, A_shared)
+            T.copy(B, B_shared)
+            for i in T.serial(batch_size):
+                T.tcgen05_gemm(
+                    A_shared[i, :, :],
+                    B_shared[i, :, :],
+                    C_tmem[i, :, :],
+                    transpose_B=True,
+                    mbar=done,
+                    clear_accum=True,
+                )
+                T.mbarrier_wait_parity(done, i % 2)
+            for i in T.serial(batch_size):
+                T.copy(C_tmem[i, :, :], C_local)
+                T.copy(C_local, C_shared)
+                T.copy(C_shared, D[i, :, :])
+
+    return main
+
+
+def _make_batched_whole_buffer_ld_kernel(batch_size):
+    """One tcgen05.ld epilogue over a whole 3-D TMEM buffer.
+
+    The leading batch mode repeats the accumulator along TMEM columns, so the
+    full-buffer copy is one (128, batch_size*128)-column tile; the register
+    fragment repeats along the value vector (each thread holds
+    batch_size*128 accumulators, batch slowest).
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((batch_size, 128, 64), T.bfloat16),
+        B: T.Tensor((batch_size, 128, 64), T.bfloat16),
+        D: T.Tensor((batch_size, 128, 128), T.bfloat16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((batch_size, 128, 64), T.bfloat16)
+            B_shared = T.alloc_shared((batch_size, 128, 64), T.bfloat16)
+            C_tmem = T.alloc_tmem((batch_size, 128, 128), T.float32)
+            done = T.alloc_barrier(1)
+            C_local = T.alloc_fragment((batch_size, 128, 128), T.float32)
+            C_shared = T.alloc_shared((128, 128), T.bfloat16)
+
+            T.copy(A, A_shared)
+            T.copy(B, B_shared)
+            for i in T.serial(batch_size):
+                T.tcgen05_gemm(
+                    A_shared[i, :, :],
+                    B_shared[i, :, :],
+                    C_tmem[i, :, :],
+                    transpose_B=True,
+                    mbar=done,
+                    clear_accum=True,
+                )
+                T.mbarrier_wait_parity(done, i % 2)
+            T.copy(C_tmem, C_local)
+            for i in T.serial(batch_size):
+                T.copy(C_local[i, :, :], C_shared)
+                T.copy(C_shared, D[i, :, :])
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_tcgen05_ld_whole_batched_buffer_correctness():
+    import torch
+
+    batch_size = 3
+    kernel = tilelang.compile(
+        _make_batched_whole_buffer_ld_kernel(batch_size),
+        target="cuda",
+        pass_configs={tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True},
+    )
+    source = kernel.get_kernel_source()
+    # One instruction covers all batch_size * 128 columns of the buffer.
+    assert f"tl::tcgen05_ld_32dp32bNx<{batch_size * 128}, false>" in source
+    a = torch.randn(batch_size, 128, 64, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(batch_size, 128, 64, device="cuda", dtype=torch.bfloat16)
+    d = torch.empty(batch_size, 128, 128, device="cuda", dtype=torch.bfloat16)
+    kernel(a, b, d)
+    ref = (a.float() @ b.float().transpose(1, 2)).to(torch.bfloat16)
+    torch.testing.assert_close(d, ref, rtol=1e-2, atol=1e-2)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_tcgen05_gemm_batched_correctness():
+    import torch
+
+    # Three batch entries: dynamic indices reach past the first two windows
+    # (C_tmem[2, ...]), so the test observes real column repetition rather
+    # than a base-window access that a batch size of one would also hit.
+    batch_size = 3
+    kernel = tilelang.compile(
+        _make_batched_tcgen05_kernel(batch_size),
+        target="cuda",
+        pass_configs={tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True},
+    )
+    a = torch.randn(batch_size, 128, 64, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(batch_size, 128, 64, device="cuda", dtype=torch.bfloat16)
+    d = torch.empty(batch_size, 128, 128, device="cuda", dtype=torch.bfloat16)
+    kernel(a, b, d)
+    ref = (a.float() @ b.float().transpose(1, 2)).to(torch.bfloat16)
     torch.testing.assert_close(d, ref, rtol=1e-2, atol=1e-2)

--- a/testing/python/language/test_tilelang_language_tcgen05_sliced_operands.py
+++ b/testing/python/language/test_tilelang_language_tcgen05_sliced_operands.py
@@ -426,7 +426,7 @@ def test_tcgen05_ts_issue_only_sliced_a_and_b():
     source = kernel.get_kernel_source()
     # The four K32 issues stay in the serial loop, so one instruction carries
     # a loop-dependent TMEM A origin and descriptor offset.
-    assert source.count("tcgen05mma_ts") == 1
+    assert source.count("tl::tcgen05mma_ts<") == 1
     assert source.count("tcgen05_mma_arrive") == 1
     assert "(k * 16)" in source
     assert "increase_descriptor_offset" in source
@@ -509,7 +509,7 @@ def test_tcgen05_ts_nonzero_c_m_n_origins_compile():
         target="cuda",
         pass_configs=PASS_CONFIGS,
     ).get_kernel_source()
-    ts_line = next(line for line in source.splitlines() if "tcgen05mma_ts" in line)
+    ts_line = next(line for line in source.splitlines() if "tl::tcgen05mma_ts<" in line)
     assert "C_tmem" in ts_line and "+ 192" in ts_line
 
 
@@ -523,7 +523,7 @@ def test_tcgen05_ss_pinned_leading_modes_end_to_end():
         pass_configs=PASS_CONFIGS,
     )
     source = kernel.get_kernel_source()
-    assert source.count("tcgen05mma_ss") == 1
+    assert source.count("tl::tcgen05mma_ss<") == 1
 
     a = torch.randn((128, 16), device="cuda", dtype=torch.bfloat16)
     b = torch.randn((16, 64), device="cuda", dtype=torch.bfloat16)

--- a/testing/python/language/test_tilelang_language_tcgen05_sliced_operands.py
+++ b/testing/python/language/test_tilelang_language_tcgen05_sliced_operands.py
@@ -1,0 +1,575 @@
+"""Coverage for atom-aligned operand regions in dense SM100 TCGEN5MMA.
+
+The cases here intentionally keep the backing buffers larger than an
+individual MMA.  That distinguishes region lowering from the already-covered
+whole-buffer path and mirrors the K-sliced SS and four-way TS schedules that a
+tiling pass needs to generate.
+"""
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+PASS_CONFIGS = {tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True}
+
+
+def _make_sliced_ss_kernel(k_extent, k_tile):
+    """Accumulate a whole BF16 GEMM from K regions of one SMEM allocation."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((128, k_extent), T.bfloat16),
+        B: T.Tensor((128, k_extent), T.bfloat16),
+        D: T.Tensor((128, 128), T.bfloat16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((128, k_extent), T.bfloat16)
+            B_shared = T.alloc_shared((128, k_extent), T.bfloat16)
+            C_tmem = T.alloc_tmem((128, 128), T.float32)
+            done = T.alloc_barrier(1)
+            C_local = T.alloc_fragment((128, 128), T.float32)
+            C_shared = T.alloc_shared((128, 128), T.bfloat16)
+
+            T.copy(A, A_shared)
+            T.copy(B, B_shared)
+            for ko in T.serial(0, k_extent, k_tile):
+                T.tcgen05_gemm(
+                    A_shared[:, ko : ko + k_tile],
+                    B_shared[:, ko : ko + k_tile],
+                    C_tmem,
+                    transpose_B=True,
+                    mbar=done,
+                    clear_accum=ko == 0,
+                )
+                T.mbarrier_wait_parity(done, (ko // k_tile) % 2)
+            T.copy(C_tmem, C_local)
+            T.copy(C_local, C_shared)
+            T.copy(C_shared, D)
+
+    return main
+
+
+def _make_offset_swizzle_atom_ss_kernel():
+    """A K32 view starting two swizzle atoms into a wider K-major buffer."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((128, 128), T.bfloat16),
+        B: T.Tensor((128, 128), T.bfloat16),
+        D: T.Tensor((128, 128), T.bfloat16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((128, 128), T.bfloat16)
+            B_shared = T.alloc_shared((128, 128), T.bfloat16)
+            C_tmem = T.alloc_tmem((128, 128), T.float32)
+            done = T.alloc_barrier(1)
+            C_local = T.alloc_fragment((128, 128), T.float32)
+            C_shared = T.alloc_shared((128, 128), T.bfloat16)
+
+            T.copy(A, A_shared)
+            T.copy(B, B_shared)
+            T.tcgen05_gemm(
+                A_shared[:, 64:96],
+                B_shared[:, 64:96],
+                C_tmem,
+                transpose_B=True,
+                mbar=done,
+                clear_accum=True,
+            )
+            T.mbarrier_wait_parity(done, 0)
+            T.copy(C_tmem, C_local)
+            T.copy(C_local, C_shared)
+            T.copy(C_shared, D)
+
+    return main
+
+
+def _make_issue_only_sliced_ts_kernel():
+    """Compute A @ B using sliced TMEM A and a staged, K-sliced SMEM B."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((128, 128), T.bfloat16),
+        B: T.Tensor((128, 64), T.bfloat16),
+        D: T.Tensor((128, 64), T.bfloat16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((128, 128), T.bfloat16)
+            A_local = T.alloc_fragment((128, 128), T.bfloat16)
+            A_tmem = T.alloc_tmem((128, 128), T.bfloat16)
+            # Slot zero is deliberately unused: B pins a parent-buffer mode to
+            # extent one and K-slices one of the two remaining Region modes.
+            B_ring = T.alloc_shared((2, 128, 64), T.bfloat16)
+            C_tmem = T.alloc_tmem((128, 64), T.float32)
+            done = T.alloc_barrier(1)
+            C_local = T.alloc_fragment((128, 64), T.float32)
+            C_shared = T.alloc_shared((128, 64), T.bfloat16)
+
+            T.copy(A, A_shared)
+            T.copy(A_shared, A_local)
+            T.copy(A_local, A_tmem)
+            T.copy(B, B_ring[1, :, :])
+
+            # All four issues stay ordered in the TC issue stream; a manual
+            # commit after the loop publishes one completion event for the
+            # whole sequence.  The commit must come from the issue warp (the
+            # lowering guards the MMAs to warp zero), or idle warps would
+            # arrive the barrier before the MMAs complete.
+            for k in T.serial(4):
+                T.tcgen05_gemm(
+                    A_tmem[:, k * 32 : (k + 1) * 32],
+                    B_ring[1, k * 32 : (k + 1) * 32, :],
+                    C_tmem,
+                    mbar=None,
+                    clear_accum=k == 0,
+                )
+            if T.get_thread_binding() < 32:
+                T.tcgen05_mma_arrive(done)
+            T.mbarrier_wait_parity(done, 0)
+
+            T.copy(C_tmem, C_local)
+            T.copy(C_local, C_shared)
+            T.copy(C_shared, D)
+
+    return main
+
+
+def _make_2cta_sliced_ts_kernel():
+    """Run four per-CTA K32 views of one cooperative TS accumulation chain.
+
+    Each CTA holds its rank's M shard of A in TMEM and its rank's N shard of
+    B in shared memory; the four K slices accumulate into one cooperative C.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((256, 128), T.bfloat16),
+        B: T.Tensor((128, 128), T.bfloat16),
+        D: T.Tensor((256, 128), T.bfloat16),
+    ):
+        with T.ClusterKernel(2, threads=128, cluster_dims=2):
+            rank = T.block_rank_in_cluster()
+            A_shared = T.alloc_shared((128, 128), T.bfloat16)
+            A_local = T.alloc_fragment((128, 128), T.bfloat16)
+            A_tmem = T.alloc_tmem((128, 128), T.bfloat16)
+            B_shared = T.alloc_shared((128, 64), T.bfloat16)
+            C_tmem = T.alloc_tmem((128, 128), T.float32)
+            done = T.alloc_cluster_barrier(1)
+            C_local = T.alloc_fragment((128, 128), T.float32)
+            C_shared = T.alloc_shared((128, 128), T.bfloat16)
+
+            T.copy(A[rank * 128 : (rank + 1) * 128, :], A_shared)
+            T.copy(A_shared, A_local)
+            T.copy(A_local, A_tmem)
+            T.copy(B[:, rank * 64 : (rank + 1) * 64], B_shared)
+            # Explicit tcgen05_gemm does not auto-emit the cooperative input
+            # handoff, so publish both ranks' TMEM/SMEM shards before the
+            # leader issues.
+            T.tcgen05_before_thread_sync()
+            T.cluster_sync()
+            T.tcgen05_after_thread_sync()
+            for k in T.serial(4):
+                T.tcgen05_gemm(
+                    A_tmem[:, k * 32 : (k + 1) * 32],
+                    B_shared[k * 32 : (k + 1) * 32, :],
+                    C_tmem,
+                    mbar=None,
+                    clear_accum=k == 0,
+                    use_2cta=True,
+                )
+            # Only the leader CTA's issue warp commits; the multicast arrives
+            # both ranks' barriers.
+            if rank == 0 and T.get_thread_binding() < 32:
+                T.tcgen05_mma_arrive(done, arrive_2cta=True)
+            T.mbarrier_wait_parity(done, 0)
+            T.copy(C_tmem, C_local)
+            T.copy(C_local, C_shared)
+            T.copy(C_shared, D[rank * 128 : (rank + 1) * 128, :])
+
+    return main
+
+
+def _make_transposed_sliced_ss_kernel():
+    """Slice K on the penultimate physical axis of both SS operands."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((32, 128), T.bfloat16),
+        B: T.Tensor((32, 64), T.bfloat16),
+        D: T.Tensor((128, 64), T.bfloat16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((32, 128), T.bfloat16)
+            B_shared = T.alloc_shared((32, 64), T.bfloat16)
+            C_tmem = T.alloc_tmem((128, 64), T.float32)
+            done = T.alloc_barrier(1)
+            C_local = T.alloc_fragment((128, 64), T.float32)
+            C_shared = T.alloc_shared((128, 64), T.bfloat16)
+
+            T.copy(A, A_shared)
+            T.copy(B, B_shared)
+            T.tcgen05_gemm(
+                A_shared[16:32, :],
+                B_shared[16:32, :],
+                C_tmem,
+                transpose_A=True,
+                mbar=done,
+                clear_accum=True,
+            )
+            T.mbarrier_wait_parity(done, 0)
+            T.copy(C_tmem, C_local)
+            T.copy(C_local, C_shared)
+            T.copy(C_shared, D)
+
+    return main
+
+
+def _make_nonzero_mn_origin_ts_kernel():
+    """Use the second M atom and second N atom of larger TMEM/SMEM owners."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((256, 16), T.bfloat16),
+        B: T.Tensor((16, 128), T.bfloat16),
+        D: T.Tensor((128, 64), T.bfloat16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((256, 16), T.bfloat16)
+            A_local = T.alloc_fragment((256, 16), T.bfloat16)
+            A_tmem = T.alloc_tmem((256, 16), T.bfloat16)
+            B_shared = T.alloc_shared((16, 128), T.bfloat16)
+            C_tmem = T.alloc_tmem((128, 64), T.float32)
+            done = T.alloc_barrier(1)
+            C_local = T.alloc_fragment((128, 64), T.float32)
+            C_shared = T.alloc_shared((128, 64), T.bfloat16)
+
+            T.copy(A, A_shared)
+            T.copy(A_shared, A_local)
+            T.copy(A_local, A_tmem)
+            T.copy(B, B_shared)
+            T.tcgen05_gemm(
+                A_tmem[128:256, :],
+                B_shared[:, 64:128],
+                C_tmem,
+                mbar=done,
+                clear_accum=True,
+            )
+            T.mbarrier_wait_parity(done, 0)
+            T.copy(C_tmem, C_local)
+            T.copy(C_local, C_shared)
+            T.copy(C_shared, D)
+
+    return main
+
+
+def _make_nonzero_c_origin_ts_kernel():
+    """Compile a C view that starts at the second outer M and N atoms."""
+
+    @T.prim_func
+    def main():
+        with T.Kernel(1, threads=128):
+            A_tmem = T.alloc_tmem((128, 16), T.bfloat16)
+            B_shared = T.alloc_shared((16, 64), T.bfloat16)
+            C_tmem = T.alloc_tmem((256, 128), T.float32)
+            T.tcgen05_gemm(
+                A_tmem,
+                B_shared,
+                C_tmem[128:256, 64:128],
+                mbar=None,
+                clear_accum=True,
+            )
+
+    return main
+
+
+def _make_pinned_leading_modes_ss_kernel():
+    """Pin both shared operands' leading batch modes to one element each."""
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((128, 16), T.bfloat16),
+        B: T.Tensor((16, 64), T.bfloat16),
+        D: T.Tensor((128, 64), T.bfloat16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((2, 2, 128, 16), T.bfloat16)
+            B_shared = T.alloc_shared((2, 2, 16, 64), T.bfloat16)
+            C_tmem = T.alloc_tmem((128, 64), T.float32)
+            done = T.alloc_barrier(1)
+            C_local = T.alloc_fragment((128, 64), T.float32)
+            C_shared = T.alloc_shared((128, 64), T.bfloat16)
+
+            T.copy(A, A_shared[1, 0, :, :])
+            T.copy(B, B_shared[0, 1, :, :])
+            T.tcgen05_gemm(
+                A_shared[1, 0, :, :],
+                B_shared[0, 1, :, :],
+                C_tmem,
+                mbar=done,
+                clear_accum=True,
+            )
+            T.mbarrier_wait_parity(done, 0)
+            T.copy(C_tmem, C_local)
+            T.copy(C_local, C_shared)
+            T.copy(C_shared, D)
+
+    return main
+
+
+def _make_misaligned_ss_slice_kernel(operand):
+    """Make only the selected operand begin halfway through a BF16 K16 atom."""
+
+    a_begin = 8 if operand == "A" else 0
+    b_begin = 8 if operand == "B" else 0
+
+    @T.prim_func
+    def main():
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((128, 32), T.bfloat16)
+            B_shared = T.alloc_shared((128, 32), T.bfloat16)
+            C_tmem = T.alloc_tmem((128, 128), T.float32)
+            T.tcgen05_gemm(
+                A_shared[:, a_begin : a_begin + 16],
+                B_shared[:, b_begin : b_begin + 16],
+                C_tmem,
+                transpose_B=True,
+                mbar=None,
+                clear_accum=True,
+            )
+
+    return main
+
+
+def _make_region_validation_kernel(case):
+    """Build one otherwise-valid SS atom with one misaligned region axis."""
+
+    transpose_a = case == "a_k_penultimate"
+    transpose_b = case == "b_k_last"
+    a_m = 64 if case == "a_m" else 0
+    a_k = 8 if case in {"a_k_last", "a_k_penultimate"} else 0
+    b_n = 32 if case == "b_n" else 0
+    b_k = 8 if case in {"b_k_last", "b_k_penultimate"} else 0
+    c_m = 64 if case == "c_m" else 0
+    c_n = 32 if case == "c_n" else 0
+
+    @T.prim_func
+    def main():
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((32, 256) if transpose_a else (256, 32), T.bfloat16)
+            B_shared = T.alloc_shared((128, 32) if transpose_b else (32, 128), T.bfloat16)
+            C_tmem = T.alloc_tmem((256, 128), T.float32)
+            T.tcgen05_gemm(
+                (A_shared[a_k : a_k + 16, a_m : a_m + 128] if transpose_a else A_shared[a_m : a_m + 128, a_k : a_k + 16]),
+                (B_shared[b_n : b_n + 64, b_k : b_k + 16] if transpose_b else B_shared[b_k : b_k + 16, b_n : b_n + 64]),
+                C_tmem[c_m : c_m + 128, c_n : c_n + 64],
+                transpose_A=transpose_a,
+                transpose_B=transpose_b,
+                mbar=None,
+                clear_accum=True,
+            )
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+@pytest.mark.parametrize("k_extent,k_tile", [(64, 16), (128, 32)])
+def test_tcgen05_ss_atom_aligned_k_slices(k_extent, k_tile):
+    kernel = tilelang.compile(
+        _make_sliced_ss_kernel(k_extent, k_tile),
+        target="cuda",
+        pass_configs=PASS_CONFIGS,
+    )
+    source = kernel.get_kernel_source()
+    assert "tcgen05mma_ss" in source
+    assert "increase_descriptor_offset" in source
+
+    a = torch.randn((128, k_extent), device="cuda", dtype=torch.bfloat16)
+    b = torch.randn((128, k_extent), device="cuda", dtype=torch.bfloat16)
+    d = torch.empty((128, 128), device="cuda", dtype=torch.bfloat16)
+    kernel(a, b, d)
+    expected = (a.cpu().float() @ b.cpu().float().T).to(torch.bfloat16)
+    tilelang.testing.torch_assert_close(d.cpu(), expected, rtol=1e-2, atol=1e-2)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_tcgen05_ss_slice_at_offset_swizzle_atom():
+    kernel = tilelang.compile(
+        _make_offset_swizzle_atom_ss_kernel(),
+        target="cuda",
+        pass_configs=PASS_CONFIGS,
+    )
+    a = torch.randn((128, 128), device="cuda", dtype=torch.bfloat16)
+    b = torch.randn((128, 128), device="cuda", dtype=torch.bfloat16)
+    d = torch.empty((128, 128), device="cuda", dtype=torch.bfloat16)
+    kernel(a, b, d)
+    expected = (a[:, 64:96].cpu().float() @ b[:, 64:96].cpu().float().T).to(torch.bfloat16)
+    tilelang.testing.torch_assert_close(d.cpu(), expected, rtol=1e-2, atol=1e-2)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_tcgen05_ts_issue_only_sliced_a_and_b():
+    kernel = tilelang.compile(
+        _make_issue_only_sliced_ts_kernel(),
+        target="cuda",
+        pass_configs=PASS_CONFIGS,
+    )
+    source = kernel.get_kernel_source()
+    # The four K32 issues stay in the serial loop, so one instruction carries
+    # a loop-dependent TMEM A origin and descriptor offset.
+    assert source.count("tcgen05mma_ts") == 1
+    assert source.count("tcgen05_mma_arrive") == 1
+    assert "(k * 16)" in source
+    assert "increase_descriptor_offset" in source
+    assert "(k * 4096)" in source
+
+    a = torch.randn((128, 128), device="cuda", dtype=torch.bfloat16)
+    b = torch.randn((128, 64), device="cuda", dtype=torch.bfloat16)
+    d = torch.empty((128, 64), device="cuda", dtype=torch.bfloat16)
+    kernel(a, b, d)
+    expected = (a.cpu().float() @ b.cpu().float()).to(torch.bfloat16)
+    tilelang.testing.torch_assert_close(d.cpu(), expected, rtol=1e-2, atol=1e-2)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_tcgen05_2cta_ts_slices_have_distinct_a_and_b_origins():
+    kernel = tilelang.compile(
+        _make_2cta_sliced_ts_kernel(),
+        target="cuda",
+        pass_configs=PASS_CONFIGS,
+    )
+    source = kernel.get_kernel_source()
+    # The four K32 issues stay in the serial loop, so one cooperative
+    # instruction carries the loop-dependent TMEM A origin (16 raw columns
+    # per slice) and B descriptor byte offset (4096 per slice).
+    assert source.count("tcgen05mma_ts<tl::DataType::kBFloat16, true>") == 1
+    assert "(k * 16)" in source
+    assert "(k * 4096)" in source
+    assert source.count("tcgen05_mma_arrive<true>") == 1
+
+    a = torch.randn((256, 128), device="cuda", dtype=torch.bfloat16)
+    b = torch.randn((128, 128), device="cuda", dtype=torch.bfloat16)
+    d = torch.empty((256, 128), device="cuda", dtype=torch.bfloat16)
+    kernel(a, b, d)
+    ref = (a.float() @ b.float()).to(torch.bfloat16)
+    torch.testing.assert_close(d, ref, rtol=1e-2, atol=1e-2)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_tcgen05_ss_k_slice_on_penultimate_axes():
+    kernel = tilelang.compile(
+        _make_transposed_sliced_ss_kernel(),
+        target="cuda",
+        pass_configs=PASS_CONFIGS,
+    )
+    a = torch.randn((32, 128), device="cuda", dtype=torch.bfloat16)
+    b = torch.randn((32, 64), device="cuda", dtype=torch.bfloat16)
+    d = torch.empty((128, 64), device="cuda", dtype=torch.bfloat16)
+    kernel(a, b, d)
+    expected = (a[16:32].cpu().float().T @ b[16:32].cpu().float()).to(torch.bfloat16)
+    tilelang.testing.torch_assert_close(d.cpu(), expected, rtol=1e-2, atol=1e-2)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_tcgen05_ts_nonzero_a_m_and_b_n_origins():
+    kernel = tilelang.compile(
+        _make_nonzero_mn_origin_ts_kernel(),
+        target="cuda",
+        pass_configs=PASS_CONFIGS,
+    )
+    a = torch.randn((256, 16), device="cuda", dtype=torch.bfloat16)
+    b = torch.randn((16, 128), device="cuda", dtype=torch.bfloat16)
+    d = torch.empty((128, 64), device="cuda", dtype=torch.bfloat16)
+    kernel(a, b, d)
+    expected = (a[128:256].cpu().float() @ b[:, 64:128].cpu().float()).to(torch.bfloat16)
+    tilelang.testing.torch_assert_close(d.cpu(), expected, rtol=1e-2, atol=1e-2)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_tcgen05_ts_nonzero_c_m_n_origins_compile():
+    source = tilelang.compile(
+        _make_nonzero_c_origin_ts_kernel(),
+        target="cuda",
+        pass_configs=PASS_CONFIGS,
+    ).get_kernel_source()
+    ts_line = next(line for line in source.splitlines() if "tcgen05mma_ts" in line)
+    assert "C_tmem" in ts_line and "+ 192" in ts_line
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_tcgen05_ss_pinned_leading_modes_end_to_end():
+    kernel = tilelang.compile(
+        _make_pinned_leading_modes_ss_kernel(),
+        target="cuda",
+        pass_configs=PASS_CONFIGS,
+    )
+    source = kernel.get_kernel_source()
+    assert source.count("tcgen05mma_ss") == 1
+
+    a = torch.randn((128, 16), device="cuda", dtype=torch.bfloat16)
+    b = torch.randn((16, 64), device="cuda", dtype=torch.bfloat16)
+    d = torch.empty((128, 64), device="cuda", dtype=torch.bfloat16)
+    kernel(a, b, d)
+    expected = (a.cpu().float() @ b.cpu().float()).to(torch.bfloat16)
+    tilelang.testing.torch_assert_close(d.cpu(), expected, rtol=1e-2, atol=1e-2)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+@pytest.mark.parametrize("operand", ["A", "B"])
+def test_tcgen05_ss_rejects_k_origin_inside_atom(operand):
+    with pytest.raises(AssertionError, match=rf"TCGEN5MMA {operand} K origin 8 must be aligned.*atom 16"):
+        tilelang.compile(
+            _make_misaligned_ss_slice_kernel(operand),
+            target="cuda",
+            pass_configs=PASS_CONFIGS,
+        )
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ("a_k_last", r"TCGEN5MMA A K origin 8 must be aligned.*atom 16"),
+        ("a_k_penultimate", r"TCGEN5MMA A K origin 8 must be aligned.*atom 16"),
+        ("b_k_last", r"TCGEN5MMA B K origin 8 must be aligned.*atom 16"),
+        ("b_k_penultimate", r"TCGEN5MMA B K origin 8 must be aligned.*atom 16"),
+        ("a_m", r"TCGEN5MMA A M origin 64 must be aligned.*atom 128"),
+        ("b_n", r"TCGEN5MMA B N origin 32 must be aligned.*atom 64"),
+        ("c_m", r"TCGEN5MMA C M origin 64 must be aligned.*atom 128"),
+        ("c_n", r"TCGEN5MMA C N origin 32 must be aligned.*atom 64"),
+    ],
+)
+def test_tcgen05_rejects_regions_that_split_instruction_atoms(case, message):
+    with pytest.raises(AssertionError, match=message):
+        tilelang.compile(
+            _make_region_validation_kernel(case),
+            target="cuda",
+            pass_configs=PASS_CONFIGS,
+        )
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/language/test_tilelang_language_tmem_copy.py
+++ b/testing/python/language/test_tilelang_language_tmem_copy.py
@@ -1,0 +1,236 @@
+"""Register<->TMEM copy roundtrips over general annotated TMEM layouts.
+
+Each kernel allocates one fragment and one TMEM buffer of the same logical
+shape, annotates the TMEM buffer with an explicit ``lambda *coords ->
+[datapath, column]`` layout, stores registers into TMEM (tcgen05.st), loads
+them back (tcgen05.ld), and writes the result out; the test verifies the
+roundtrip is the identity.  This exercises the generic CuTe-algebra TMEM
+copy path (InferTMemLayout / ExpandTcgen05Layout / LowerTmem) over
+multi-dimensional, permuted, and interleaved physical layouts, with and
+without slicing.
+"""
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+PASS_CONFIGS = {tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True}
+
+# (name, logical shape, forward map to [datapath, column], threads)
+# The layout in CuTe spelling is given alongside each case.
+LAYOUT_CASES = [
+    # (128,128):(1@0,1@1) -- the standard accumulator fragment.
+    ("std_2d", (128, 128), lambda i, j: [i, j], 128),
+    # (128,128):(1@1,1@0) -- transposed: rows map to columns.
+    ("transposed_2d", (128, 128), lambda i, j: [j, i], 128),
+    # (3,128,128):(128@1,1@0,1@1) -- leading batch repeated along columns.
+    ("batched_3d", (3, 128, 128), lambda a, i, j: [i, a * 128 + j], 128),
+    # (3,32,64,4):(64@1,1@0,1@1,32@0) -- datapaths split across two modes.
+    ("interleaved_4d", (3, 32, 64, 4), lambda a, i, j, k: [i + 32 * k, a * 64 + j], 128),
+    # (128,128):(1@0,1@1) spread across two warpgroups.
+    ("std_2d_2wg", (128, 128), lambda i, j: [i, j], 256),
+]
+
+
+def _make_roundtrip_kernel(shape, forward, threads):
+    @T.prim_func
+    def main(
+        A: T.Tensor(shape, T.float32),
+        D: T.Tensor(shape, T.float32),
+    ):
+        with T.Kernel(1, threads=threads):
+            A_shared = T.alloc_shared(shape, T.float32)
+            A_frag = T.alloc_fragment(shape, T.float32)
+            tmem = T.alloc_tmem(shape, T.float32)
+            B_frag = T.alloc_fragment(shape, T.float32)
+            B_shared = T.alloc_shared(shape, T.float32)
+
+            T.annotate_layout({tmem: T.Layout(shape, forward)})
+            T.copy(A, A_shared)
+            T.copy(A_shared, A_frag)
+            T.copy(A_frag, tmem)
+            T.copy(tmem, B_frag)
+            T.copy(B_frag, B_shared)
+            T.copy(B_shared, D)
+
+    return main
+
+
+def _last_dim_slice(buf, rank, lo, hi):
+    """buf[:, ..., lo:hi] spelled with explicit full slices per rank."""
+    index = tuple([slice(None)] * (rank - 1) + [slice(lo, hi)])
+    return buf[index]
+
+
+def _make_sliced_roundtrip_kernel(shape, forward, threads, nsplit):
+    """Split the store and the load along the last dim into nsplit slices."""
+    last = shape[-1]
+    assert last % nsplit == 0
+    step = last // nsplit
+    rank = len(shape)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor(shape, T.float32),
+        D: T.Tensor(shape, T.float32),
+    ):
+        with T.Kernel(1, threads=threads):
+            A_shared = T.alloc_shared(shape, T.float32)
+            A_frag = T.alloc_fragment(shape, T.float32)
+            tmem = T.alloc_tmem(shape, T.float32)
+            B_frag = T.alloc_fragment(shape, T.float32)
+            B_shared = T.alloc_shared(shape, T.float32)
+
+            T.annotate_layout({tmem: T.Layout(shape, forward)})
+            T.copy(A, A_shared)
+            T.copy(A_shared, A_frag)
+            for s in range(nsplit):
+                T.copy(
+                    _last_dim_slice(A_frag, rank, s * step, (s + 1) * step),
+                    _last_dim_slice(tmem, rank, s * step, (s + 1) * step),
+                )
+            for s in range(nsplit):
+                T.copy(
+                    _last_dim_slice(tmem, rank, s * step, (s + 1) * step),
+                    _last_dim_slice(B_frag, rank, s * step, (s + 1) * step),
+                )
+            T.copy(B_frag, B_shared)
+            T.copy(B_shared, D)
+
+    return main
+
+
+def _make_asymmetric_roundtrip_kernel(shape, forward, threads, nsplit):
+    """Sliced stores, one whole-buffer load.
+
+    Asymmetric on purpose: a bug that mislocates a slice's registers on the
+    store is NOT cancelled by the same bug on the load, unlike the symmetric
+    roundtrips above.
+    """
+    last = shape[-1]
+    assert last % nsplit == 0
+    step = last // nsplit
+    rank = len(shape)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor(shape, T.float32),
+        D: T.Tensor(shape, T.float32),
+    ):
+        with T.Kernel(1, threads=threads):
+            A_shared = T.alloc_shared(shape, T.float32)
+            A_frag = T.alloc_fragment(shape, T.float32)
+            tmem = T.alloc_tmem(shape, T.float32)
+            B_frag = T.alloc_fragment(shape, T.float32)
+            B_shared = T.alloc_shared(shape, T.float32)
+
+            T.annotate_layout({tmem: T.Layout(shape, forward)})
+            T.copy(A, A_shared)
+            T.copy(A_shared, A_frag)
+            for s in range(nsplit):
+                T.copy(
+                    _last_dim_slice(A_frag, rank, s * step, (s + 1) * step),
+                    _last_dim_slice(tmem, rank, s * step, (s + 1) * step),
+                )
+            T.copy(tmem, B_frag)
+            T.copy(B_frag, B_shared)
+            T.copy(B_shared, D)
+
+    return main
+
+
+def _make_batch_sliced_roundtrip_kernel(shape, forward, threads):
+    """Store/load one leading-dim batch entry at a time (dynamic origins)."""
+    tail = tuple([slice(None)] * (len(shape) - 1))
+
+    @T.prim_func
+    def main(
+        A: T.Tensor(shape, T.float32),
+        D: T.Tensor(shape, T.float32),
+    ):
+        with T.Kernel(1, threads=threads):
+            A_shared = T.alloc_shared(shape, T.float32)
+            A_frag = T.alloc_fragment(shape, T.float32)
+            tmem = T.alloc_tmem(shape, T.float32)
+            B_frag = T.alloc_fragment(shape, T.float32)
+            B_shared = T.alloc_shared(shape, T.float32)
+
+            T.annotate_layout({tmem: T.Layout(shape, forward)})
+            T.copy(A, A_shared)
+            T.copy(A_shared, A_frag)
+            for a in T.serial(shape[0]):
+                T.copy(A_frag[(a, *tail)], tmem[(a, *tail)])
+            for a in T.serial(shape[0]):
+                T.copy(tmem[(a, *tail)], B_frag[(a, *tail)])
+            T.copy(B_frag, B_shared)
+            T.copy(B_shared, D)
+
+    return main
+
+
+def _run_roundtrip(kernel_func, shape):
+    kernel = tilelang.compile(kernel_func, target="cuda", pass_configs=PASS_CONFIGS)
+    source = kernel.get_kernel_source()
+    assert "tcgen05_st_" in source and "tcgen05_ld_" in source
+    a = torch.randn(*shape, device="cuda", dtype=torch.float32)
+    d = torch.empty(*shape, device="cuda", dtype=torch.float32)
+    kernel(a, d)
+    torch.testing.assert_close(d, a, rtol=0.0, atol=0.0)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+@pytest.mark.parametrize(
+    ("name", "shape", "forward", "threads"),
+    LAYOUT_CASES,
+    ids=[case[0] for case in LAYOUT_CASES],
+)
+def test_tmem_copy_roundtrip(name, shape, forward, threads):
+    _run_roundtrip(_make_roundtrip_kernel(shape, forward, threads), shape)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+@pytest.mark.parametrize(
+    ("name", "shape", "forward", "threads"),
+    # A batched layout sliced along its column mode leaves per-batch column
+    # gaps in TMEM; the copy iterates the contiguous chunks, one tcgen05
+    # issue per batch entry (rest iteration).
+    [case for case in LAYOUT_CASES if case[0] in ("std_2d", "std_2d_2wg", "batched_3d")],
+    ids=["std_2d", "std_2d_2wg", "batched_3d"],
+)
+def test_tmem_copy_roundtrip_sliced_last_dim(name, shape, forward, threads):
+    _run_roundtrip(_make_sliced_roundtrip_kernel(shape, forward, threads, nsplit=2), shape)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+@pytest.mark.parametrize(
+    ("name", "shape", "forward", "threads"),
+    [case for case in LAYOUT_CASES if case[0] in ("std_2d", "batched_3d")],
+    ids=["std_2d", "batched_3d"],
+)
+def test_tmem_copy_sliced_store_whole_load(name, shape, forward, threads):
+    _run_roundtrip(_make_asymmetric_roundtrip_kernel(shape, forward, threads, nsplit=2), shape)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+@pytest.mark.parametrize(
+    ("name", "shape", "forward", "threads"),
+    [case for case in LAYOUT_CASES if case[0] in ("batched_3d", "interleaved_4d")],
+    ids=["batched_3d", "interleaved_4d"],
+)
+def test_tmem_copy_roundtrip_sliced_batch(name, shape, forward, threads):
+    _run_roundtrip(_make_batch_sliced_roundtrip_kernel(shape, forward, threads), shape)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/language/test_tilelang_language_tmem_copy.py
+++ b/testing/python/language/test_tilelang_language_tmem_copy.py
@@ -171,6 +171,34 @@ def _make_batch_sliced_roundtrip_kernel(shape, forward, threads):
     return main
 
 
+def _make_16bit_roundtrip_kernel(shape, forward, dtype):
+    @T.prim_func
+    def main(
+        A: T.Tensor(shape, dtype),
+        D: T.Tensor(shape, dtype),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared(shape, dtype)
+            A_frag = T.alloc_fragment(shape, dtype)
+            tmem = T.alloc_tmem(shape, dtype)
+            B_frag = T.alloc_fragment(shape, dtype)
+            B_shared = T.alloc_shared(shape, dtype)
+
+            T.annotate_layout({tmem: T.Layout(shape, forward)})
+            T.copy(A, A_shared)
+            T.copy(A_shared, A_frag)
+            T.copy(A_frag, tmem)
+            # Clobber both fragments so a partial load cannot be masked by
+            # stale register values that happen to alias the store's.
+            T.fill(A_frag, -1.0)
+            T.fill(B_frag, -2.0)
+            T.copy(tmem, B_frag)
+            T.copy(B_frag, B_shared)
+            T.copy(B_shared, D)
+
+    return main
+
+
 def _run_roundtrip(kernel_func, shape):
     kernel = tilelang.compile(kernel_func, target="cuda", pass_configs=PASS_CONFIGS)
     source = kernel.get_kernel_source()
@@ -191,6 +219,38 @@ def _run_roundtrip(kernel_func, shape):
 )
 def test_tmem_copy_roundtrip(name, shape, forward, threads):
     _run_roundtrip(_make_roundtrip_kernel(shape, forward, threads), shape)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+@pytest.mark.parametrize(
+    ("name", "shape", "forward", "modifier"),
+    [
+        # CUTLASS FrgTypeC keeps each 16-bit accumulator in the low half of
+        # its own 32-bit storage slot (column stride 2), so the copy plans
+        # in b32 columns and gathers with the pack::16b/unpack::16b
+        # modifiers.
+        ("pack16b", (128, 64), lambda i, j: [i, 2 * j], True),
+        # Two 16-bit values packed per b32 column move as whole columns with
+        # the plain instruction.
+        ("packed_pair", (128, 128), lambda i, j: [i, j], False),
+    ],
+    ids=["pack16b", "packed_pair"],
+)
+def test_tmem_copy_roundtrip_16bit(name, shape, forward, modifier):
+    kernel = tilelang.compile(
+        _make_16bit_roundtrip_kernel(shape, forward, T.bfloat16),
+        target="cuda",
+        pass_configs=PASS_CONFIGS,
+    )
+    source = kernel.get_kernel_source()
+    ld_line = next(line for line in source.splitlines() if "tcgen05_ld_" in line)
+    assert (", true>" in ld_line) == modifier
+    a = torch.randn(*shape, device="cuda", dtype=torch.bfloat16)
+    d = torch.empty(*shape, device="cuda", dtype=torch.bfloat16)
+    kernel(a, d)
+    torch.testing.assert_close(d, a, rtol=0.0, atol=0.0)
 
 
 @tilelang.testing.requires_cuda

--- a/testing/python/layout/test_tilelang_cute.py
+++ b/testing/python/layout/test_tilelang_cute.py
@@ -88,7 +88,7 @@ def test_int_tuple_tuple_arithmetic():
 def test_int_tuple_scaled_basis_arithmetic():
     # ScaledBasis terms expand to ArithmeticTuples and add (CuTe
     # as_arithmetic_tuple): same axis sums into one slot, distinct axes spread.
-    same = cute.from_python(cute.E(0)) + cute.from_python(cute.ScaledBasis(2, 0))
+    same = cute.from_python(cute.E(0)) + cute.from_python(2 * cute.E(0))
     assert cute.to_python(same) == (3,)  # 1@0 + 2@0 -> (1)+(2) -> (3)
     spread = cute.from_python(cute.E(0)) + cute.from_python(cute.E(1))
     assert cute.to_python(spread) == (1, 1)  # 1@0 + 1@1 -> (1)+(0,1) -> (1,1)
@@ -173,7 +173,7 @@ def test_eval_basis_is_coordinate_tuple():
     assert perm(5) == (2, 1)  # crd=(1,2): 1@slot1, 2@slot0
     # Same path on both modes sums into one slot; a single touched axis stays
     # a (1-)tuple, never a bare scalar.
-    same = cute.make_layout((2, 2), stride=(cute.E(0), cute.ScaledBasis(2, 0)))
+    same = cute.make_layout((2, 2), stride=(cute.E(0), 2 * cute.E(0)))
     assert all(same(c) == (c,) for c in range(4))
 
 
@@ -197,6 +197,81 @@ def test_layout_from_tilelang_affine():
 def test_layout_from_tilelang_rejects_swizzle():
     swz = _build_swizzled_layout((64, 512), lambda i, j: i * 512 + j, 3, 3, 3)
     assert cute.Layout.from_tilelang(swz) is None
+
+
+def test_parse_roundtrips_str():
+    # IntTuple.parse / Layout.parse / Swizzle.parse invert str() exactly,
+    # including nested tuples and innermost-first basis paths (E(1,0) is
+    # spelled 1@0@1).
+    for text in ("(((2,2,8),4),2):(((8@0,1@1,1@0),32@0),16@0)", "(128,64):(1@0,1@1)", "8:1"):
+        assert str(cute.Layout.parse(text)) == text
+    t = cute.from_python(cute.ScaledBasis(2, (1, 0)))
+    assert str(cute.IntTuple.parse(str(t))) == str(t)
+    assert str(cute.Swizzle.parse("Sw<3,4,3>")) == "Sw<3,4,3>"
+
+
+# ---------------------------------------------------------------------------
+# from_tilelang_hierarchical: recover a multi-output TileLang layout with each
+# output axis rerouted onto its basis (the inverse of to_tilelang).
+# ---------------------------------------------------------------------------
+def test_from_tilelang_hierarchical_identity():
+    r = cute.Layout.from_tilelang_hierarchical(Layout((128, 128), lambda i, j: [i, j]))
+    assert r is not None
+    assert tvm.ir.structural_equal(r, cute.make_identity_layout((128, 128)))
+
+
+def test_from_tilelang_hierarchical_permuted_axes():
+    # Rank-3 codomain: each input mode routes to the slot its output names.
+    r = cute.Layout.from_tilelang_hierarchical(Layout((2, 3, 4), lambda i, j, k: [k, i, j]))
+    assert r is not None
+    assert tvm.ir.structural_equal(r, cute.make_layout((2, 3, 4), stride=(cute.E(1), cute.E(2), cute.E(0))))
+
+
+def test_from_tilelang_hierarchical_single_output_is_flat_on_axis_zero():
+    L = Layout((16, 128), lambda i, j: [i * 128 + j])
+    flat = cute.Layout.from_tilelang(L)
+    hier = cute.Layout.from_tilelang_hierarchical(L)
+    assert hier is not None
+    for c in range(0, 16 * 128, 97):
+        assert hier(c) == (flat(c),)
+
+
+def test_from_tilelang_hierarchical_conforms_axis_profiles():
+    # Axis 0 sees j as one broadcast run while axis 1 splits j at 4; the
+    # with_shape passes refine both to the common (4, 4) profile so the
+    # strides can add leaf-wise.
+    L = Layout((8, 16), lambda i, j: [i, (j // 4) * 8 + j % 4])
+    r = cute.Layout.from_tilelang_hierarchical(L)
+    assert r is not None
+    assert tvm.ir.structural_equal(r, cute.make_layout((8, (4, 4)), stride=(cute.E(0), (cute.E(1), 8 * cute.E(1)))))
+    for i in range(8):
+        for j in range(16):
+            assert r((i, j)) == (i, (j // 4) * 8 + j % 4)
+
+
+def test_from_tilelang_hierarchical_roundtrips_to_tilelang():
+    # A TMEM-shaped fragment (PTX Layout F datapath halves) survives the
+    # to_tilelang -> from_tilelang_hierarchical round trip as a function.
+    restride = cute.make_layout((128, 16384), stride=(cute.E(0), cute.E(1)))
+    frag = cute.composition(restride, cute.make_layout(((16, 4), 32), stride=((1, 32), 128)))
+    r = cute.Layout.from_tilelang_hierarchical(frag.to_tilelang())
+    assert r is not None
+    for i in range(0, 64, 7):
+        for j in range(0, 32, 5):
+            assert r((i, j)) == frag((i, j))
+
+
+def test_from_tilelang_hierarchical_rejects_dependent_axes():
+    # j drives both output axes: the leaf-wise stride sum would need a
+    # coordinate-tuple stride, which no cute::Layout represents.
+    assert cute.Layout.from_tilelang_hierarchical(Layout((4, 4), lambda i, j: [i + j, j])) is None
+
+
+def test_from_tilelang_hierarchical_rejects_swizzled_axis():
+    def swizzled(j):
+        return j ^ ((j & (7 << 6)) >> 3)
+
+    assert cute.Layout.from_tilelang_hierarchical(Layout((64, 512), lambda i, j: [swizzled(j), i])) is None
 
 
 # ---------------------------------------------------------------------------
@@ -384,9 +459,8 @@ def test_tma_box_validity_via_composite():
 
 # ---------------------------------------------------------------------------
 # Layout algebra ported from CuTe for the GMMA descriptor analysis:
-# filter / cosize / complement / logical_divide. Reference values computed by
-# hand from CuTe (layout.hpp): complement sort-and-fold, logical_divide =
-# composition(layout, make_layout(tiler, complement(tiler, size(coalesce)))).
+# filter / cosize / complement / logical_divide / logical_product. Reference
+# values follow CuTe layout.hpp and its core logical_product unit test.
 # ---------------------------------------------------------------------------
 def test_filter_drops_trivial_modes():
     # filter = coalesce(filter_zeros): drop stride-0 and size-1 modes.
@@ -405,6 +479,21 @@ def test_cosize_matches_cute():
     assert cute.cosize(cute.make_layout((4, 2), stride=(1, 8))) == 12
     assert cute.cosize(cute.make_layout((8, 8), stride=(8, 1))) == 64
     assert cute.cosize(cute.make_layout((64, 8), stride=(8, 1))) == 512
+
+
+def test_coshape_basis_strides_is_per_axis():
+    # ScaledBasis strides make the codomain a coordinate space; coshape gives
+    # the per-axis extents and cosize their product (CuTe cosize ==
+    # size(coshape)).
+    L = cute.make_layout((128, 32), stride=(cute.E(0), cute.E(1)))
+    assert cute.coshape(L) == (128, 32)
+    assert cute.cosize(L) == 128 * 32
+    # PTX Layout F atom (interleaved half datapaths): only 112 datapaths are
+    # touched (max image 96 + 15), and 32 columns.
+    F = cute.make_layout(((16, 4), 32), stride=((cute.E(0), 32 * cute.E(0)), cute.E(1)))
+    assert cute.coshape(F) == (112, 32)
+    # A plain layout's coshape is its scalar codomain extent.
+    assert cute.coshape(cute.make_layout((4, 2), stride=(1, 8))) == 12
 
 
 def test_cosize_dynamic_is_symbolic():
@@ -477,6 +566,167 @@ def test_logical_divide_dynamic_layout_stride():
     assert ana.simplify(res(2) - 2 * s) == 0  # next rest element: stride 2s
 
 
+def test_compatible_is_directional_and_supports_symbolic_extents():
+    n = tvm.tirx.Var("n", "int32")
+
+    # A terminal in the profile may cover an arbitrarily nested subtree.
+    assert cute.compatible((2, 3), ((1, 2), 3))
+    assert not cute.compatible(((1, 2), 3), (2, 3))
+    assert not cute.compatible((2, 3), (6,))
+
+    # Dynamic terminals are compared by provable value, not expression form.
+    assert cute.compatible((n + n, 4), ((n, 2), (2, 2)))
+
+
+@pytest.mark.parametrize(
+    ("block", "tiler"),
+    [
+        (cute.make_layout(1, stride=0), cute.make_layout(1, stride=0)),
+        (cute.make_layout(1, stride=1), cute.make_layout(1, stride=0)),
+        (cute.make_layout(1, stride=0), cute.make_layout(1, stride=1)),
+        (cute.make_layout(1, stride=1), cute.make_layout(1, stride=1)),
+        (cute.make_layout(3, stride=1), cute.make_layout(4, stride=0)),
+        (cute.make_layout(3, stride=0), cute.make_layout(4, stride=1)),
+        (cute.make_layout(3, stride=0), cute.make_layout(4, stride=0)),
+        (cute.make_layout(3, stride=2), cute.make_layout(4, stride=1)),
+        (cute.make_layout((3, 1)), cute.make_layout((2, 4))),
+        (cute.make_layout((2, 4)), cute.make_layout(3)),
+        (cute.make_layout((8, (2, 2))), cute.make_layout(4, stride=2)),
+        (cute.make_layout((2, 2)), cute.make_layout((3, 3), stride=(3, 1))),
+        (cute.make_layout(3, stride=32), cute.make_layout(32)),
+        (cute.make_layout(3, stride=2), cute.make_layout(4)),
+        (cute.make_layout(3, stride=32), cute.make_layout(128)),
+        (cute.make_layout(3, stride=32), cute.make_layout((8, 8))),
+        (cute.make_layout(3, stride=32), cute.make_layout((8, 8), stride=(8, 1))),
+        (cute.make_layout(((4, 2),), stride=((1, 16),)), cute.make_layout((4, 4))),
+        (cute.make_layout(((4, 2),), stride=((1, 16),)), cute.make_layout((4, 2), stride=(2, 1))),
+        (
+            cute.make_layout(((2, 2), (2, 2)), stride=((1, 4), (8, 32))),
+            cute.make_layout((2, 2), stride=(1, 2)),
+        ),
+        (
+            cute.make_layout(((2, 2), (2, 2)), stride=((1, 4), (8, 32))),
+            cute.make_layout((2, 2), stride=(2, 1)),
+        ),
+        (cute.make_layout(((4, 6),), stride=((1, 6),)), cute.make_layout(3)),
+    ],
+)
+def test_logical_product_matches_cutlass_core_cases(block, tiler):
+    # CUTLASS test/unit/cute/core/logical_product.cpp specifies these two core
+    # properties: the result is rank-2, preserves the block as mode 0, and its
+    # repeated mode is shape-compatible with the tiler.
+    result = cute.logical_product(block, tiler)
+    assert cute.rank(result) == 2
+    assert tvm.ir.structural_equal(result[0], block)
+    assert cute.compatible(tiler.shape, result[1].shape)
+
+
+def test_logical_product_tmem_tiling():
+    # The exact construction used by CUTLASS tmem_frg::make: repeat a 128x16
+    # virtual TMEM atom over two M tiles and four K/N tiles, M-first.
+    atom = cute.make_layout((128, 16))
+    outer = cute.make_layout((2, 4))
+    result = cute.logical_product(atom, outer)
+    _assert_struct(result, ((128, 16), (2, 4)), ((1, 128), (2048, 4096)))
+
+    tiled = cute.tiled_product(atom, outer)
+    _assert_struct(tiled, ((128, 16), 2, 4), ((1, 128), 2048, 4096))
+    for m_tile in range(2):
+        for n_tile in range(4):
+            assert tiled(((0, 0), m_tile, n_tile)) == result(((0, 0), (m_tile, n_tile)))
+
+
+def test_logical_product_nested_strided_layout_exactly():
+    block = cute.make_layout(((4, 2),), stride=((1, 16),))
+    tiler = cute.make_layout((4, 2), stride=(2, 1))
+    result = cute.logical_product(block, tiler)
+
+    # Exact output for the corresponding CUTLASS core test case.  This covers
+    # both a hierarchical block and a nontrivially strided tiler.
+    _assert_struct(
+        result,
+        (((4, 2),), ((2, 2), 2)),
+        (((1, 16),), ((8, 32), 4)),
+    )
+
+
+def test_tiled_product_unpacks_complement_split_modes():
+    # A strided block can split one scalar tiler into two residual modes.
+    # Official tiled_product slices with repeat<R1>(_), and repeat<1>(_) is
+    # plain _, so only a rank >= 2 rest mode unpacks.  A scalar-leaf block's
+    # complement modes land directly in the rest (rank 2 -> unpacked); a
+    # tuple-wrapped block keeps them nested one level deeper (rank-1 rest ->
+    # identical to the zipped product).  Both pinned against the compiled
+    # official results.
+    block = cute.make_layout(3, stride=32)
+    tiler = cute.make_layout(128)
+    logical = cute.logical_product(block, tiler)
+    _assert_struct(logical, (3, (32, 4)), (32, (1, 96)))
+    tiled = cute.tiled_product(block, tiler)
+    _assert_struct(tiled, (3, 32, 4), (32, 1, 96))
+    for x in range(3):
+        for y0 in range(32):
+            for y1 in range(4):
+                assert tiled((x, y0, y1)) == logical((x, (y0, y1)))
+    # A tuple-wrapped TILER keeps the composed rest congruent to its rank-1
+    # profile, so the rest stays wrapped and tiled == zipped (official
+    # repeat<1>(_) slicing); the scalar-leaf tiler above unpacked because
+    # composition against a scalar profile leaves the split modes flat.
+    wrapped_tiler = cute.Layout.parse("(128):(1)")
+    tiled_wrapped = cute.tiled_product(block, wrapped_tiler)
+    assert tvm.ir.structural_equal(tiled_wrapped, cute.logical_product(block, wrapped_tiler))
+    assert str(tiled_wrapped) == "(3,((32,4))):(32,((1,96)))"
+
+
+def test_blocked_product_zips_block_and_tiler_modes():
+    # CuTe layout.hpp blocked_product: mode i of the result is
+    # ((block_i, rest_i)), so a flat per-mode coordinate covers
+    # block extent x tiler extent along that mode.
+    block = cute.make_layout((2, 5), stride=(5, 1))
+    tiler = cute.make_layout((3, 4))
+    result = cute.blocked_product(block, tiler)
+    _assert_struct(result, ((2, 3), (5, 4)), ((5, 10), (1, 30)))
+    logical = cute.logical_product(block, tiler)
+    for i in range(6):
+        for j in range(20):
+            assert result((i, j)) == logical(((i % 2, j % 5), (i // 2, j // 5)))
+
+
+def test_blocked_product_pads_rank_mismatch():
+    # A tiler of higher rank appends fresh modes (block padded with (1):(0)),
+    # exactly CuTe's append<R>() padding.
+    block = cute.make_layout((128, 16))
+    tiler = cute.make_layout((1, 1, 2, 4))
+    result = cute.blocked_product(block, tiler)
+    assert cute.rank(result) == 4
+    assert result((0, 0, 1, 0)) == 2048
+    assert result((0, 0, 0, 1)) == 4096
+    assert result((127, 15, 1, 3)) == 127 + 15 * 128 + 2048 + 3 * 4096
+    # Exact structural match with the official result (compiled against the
+    # CuTe headers): the tiler's size-1 modes carry stride 0, so the padded
+    # block modes pair with stride-0 rest modes, not leftover strides.
+    _assert_struct(
+        result,
+        ((128, 1), (16, 1), (1, 2), (1, 4)),
+        ((1, 0), (128, 0), (0, 2048), (0, 4096)),
+    )
+
+
+def test_restrict_slices_basis_coordinate_layout():
+    # A ScaledBasis-strided layout maps to (datapath, column) coordinates.
+    # restrict returns the region origin's coordinates plus the sliced
+    # sublayout, and the affine identity holds componentwise.
+    restride = cute.make_layout((128, 16384), stride=(cute.E(0), cute.E(1)))
+    frag = cute.composition(restride, cute.make_layout(((16, 4), 32), stride=((1, 32), 128)))
+    assert frag((16, 0)) == (32, 0)
+    offset, tile = cute.restrict(frag, [tvm.ir.Range.from_min_extent(0, 64), tvm.ir.Range.from_min_extent(8, 24)])
+    assert offset == (0, 8)
+    assert tile((0, 3)) == (0, 3)
+    for i in range(0, 64, 7):
+        for j in range(0, 24, 5):
+            assert frag((i, 8 + j)) == tuple(base + step for base, step in zip(offset, tile((i, j))))
+
+
 # ---------------------------------------------------------------------------
 # make_layout / make_column_major / make_row_major / make_identity_layout, and
 # the make_layout([layout, ...]) concat form.
@@ -511,7 +761,7 @@ def test_make_layout_nested_column_row_identity():
 
 def test_scaled_basis_and_int_expr_strides():
     # A non-unit ScaledBasis stride round-trips its scale and mode.
-    (sb,) = cute.make_layout((2,), stride=(cute.ScaledBasis(64, 1),)).stride
+    (sb,) = cute.make_layout((2,), stride=(64 * cute.E(1),)).stride
     assert isinstance(sb, cute.ScaledBasis) and sb.value == 64 and sb.mode == (1,)
     # A dynamic (PrimExpr) stride round-trips structurally.
     s = tvm.tirx.Var("s", "int32")

--- a/testing/python/layout/test_tilelang_cute.py
+++ b/testing/python/layout/test_tilelang_cute.py
@@ -508,6 +508,27 @@ def test_cosize_dynamic_is_symbolic():
         assert int(ana.simplify(sub)) == expect
 
 
+def test_left_inverse_matches_cute():
+    # Official left_inverse results (compiled against the CuTe headers):
+    # a permuted layout inverts across modes, and a broadcast/batch-sliced
+    # layout gets a leading stride-0 slot absorbing the skipped strides.
+    _assert_struct(cute.left_inverse(cute.make_layout((4, 8))), 32, 1)
+    _assert_struct(cute.left_inverse(cute.make_layout((4, 8), stride=(8, 1))), (8, 4), (4, 1))
+    _assert_struct(cute.left_inverse(cute.make_layout(8, stride=2)), (2, 8), (0, 1))
+    _assert_struct(cute.left_inverse(cute.make_layout((3, 8192), stride=(16384, 1))), (16384, 3), (3, 1))
+    _assert_struct(
+        cute.left_inverse(cute.make_layout((2, 3, 4), stride=(12, 1, 3))),
+        (12, 2),
+        (2, 1),
+    )
+    # result(layout(i)) == i on a permuted case.
+    L = cute.make_layout((4, 3), stride=(1, 8))
+    li = cute.left_inverse(L)
+    for i in range(4):
+        for j in range(3):
+            assert li(L((i, j))) == i + 4 * j
+
+
 def test_complement_matches_cute():
     # complement(layout, cotarget): the gaps the layout does not address.
     _assert_same_fn(cute.complement(cute.make_layout(2, stride=1), 16), cute.make_layout(8, stride=2))

--- a/testing/python/layout/test_tilelang_tcgen05_expand.py
+++ b/testing/python/layout/test_tilelang_tcgen05_expand.py
@@ -1,0 +1,134 @@
+# Pin ExpandTcgen05Layout against the CUTLASS Copy_Traits ground truth.
+#
+# The C++ side stores each tcgen05.ld/st atom as the per-warp, single-issue
+# CUTLASS ``Copy_Traits<...1x>`` TV layout and derives every replication --
+# warps, the high-datapath duplicate issue of the 16-datapath shapes, .xN
+# column repetitions, warpgroups -- by one blocked product over a row-major
+# replication grid.  These tests evaluate the resulting fragment at a
+# SYMBOLIC (datapath, column) coordinate built from the hand-evaluated
+# DstLayout formulas of cute/atom/copy_traits_sm100.hpp -- combined with the
+# register order of TileLang's tl::tcgen05_{ld,st}_32dpNNbNx wrappers (the
+# duplicate issue's registers land after all repetitions) -- and let the
+# arithmetic analyzer prove the (thread, value) result equals the wrapper's
+# slot for ALL lanes/registers/repetitions at once.
+
+import pytest
+
+import tilelang.testing
+from tilelang import _ffi_api
+from tilelang import tvm
+from tilelang.layout import cute
+
+
+def _dp_col(meta, t, j, n, d, w):
+    """CUTLASS DstLayout: lane t, per-repetition register j, repetition n,
+    duplicate issue d, warp w -> (datapath, b32 column)."""
+    if meta == "32dp32b":
+        return t + 32 * w, n
+    if meta == "16dp64b":
+        return 8 * (t % 2) + t // 4 + 16 * d + 32 * w, (t // 2) % 2 + 2 * n
+    if meta == "16dp128b":
+        return t // 4 + 8 * j + 16 * d + 32 * w, t % 4 + 4 * n
+    if meta == "16dp256b":
+        return t // 4 + 8 * (j // 2) + 16 * d + 32 * w, 2 * (t % 4) + j % 2 + 8 * n
+    raise KeyError(meta)
+
+
+# (meta suffix, columns of one repetition, registers per repetition,
+#  duplicate issues per warp)
+ATOM_SPECS = [
+    ("32dp32b", 1, 1, 1),
+    ("16dp64b", 2, 1, 2),
+    ("16dp128b", 4, 2, 2),
+    ("16dp256b", 8, 4, 2),
+]
+
+
+def _get_meta(name):
+    return getattr(_ffi_api, "get_tcgen05_meta_" + name)()
+
+
+def _column_major_tile(rows, cols):
+    return cute.make_layout((rows, cols), stride=(cute.E(0), cute.E(1)))
+
+
+@pytest.mark.parametrize(("meta", "width", "regs", "ndup"), ATOM_SPECS, ids=[s[0] for s in ATOM_SPECS])
+@pytest.mark.parametrize("num_wgs", [1, 2], ids=["1wg", "2wg"])
+@pytest.mark.parametrize("chunks", [1, 2, 4], ids=["x1", "x2", "x4"])
+def test_expand_matches_cutlass_dst_layout(meta, width, regs, ndup, num_wgs, chunks):
+    num_threads = 128 * num_wgs
+    cols = width * chunks * num_wgs
+    plan = _ffi_api.ExpandTcgen05Layout(_get_meta("ld_" + meta), _column_major_tile(128, cols), num_threads)
+    assert plan is not None, f"{meta} must expand a (128,{cols}) tile"
+    assert plan.num_chunks_each_wg == chunks
+    assert plan.num_issues == 1
+    assert plan.vals_per_issue == regs * chunks * ndup
+
+    # Bind one symbolic variable per replication axis and prove the fragment
+    # inverts the DstLayout formulas for every assignment simultaneously.
+    ana = tvm.arith.Analyzer()
+
+    def var(name, extent):
+        v = tvm.tirx.Var(name, "int32")
+        ana.bind(v, tvm.ir.Range(0, extent))
+        return v
+
+    t = var("t", 32)  # lane within the warp
+    j = var("j", regs)  # register within one repetition
+    n = var("n", chunks)  # .xN repetition
+    d = var("d", ndup)  # duplicate high-datapath issue
+    w = var("w", 4)  # warp within the warpgroup
+    g = var("g", num_wgs)  # warpgroup
+
+    dp, col = _dp_col(meta, t, j, n, d, w)
+    col = col + g * chunks * width  # each warpgroup owns a column slice
+
+    # Wrapper slot: threads are linear in (lane, warp, warpgroup); each
+    # thread's registers run per-repetition regs fastest, then repetitions,
+    # then the duplicate issue's registers after all repetitions.
+    thread_expect = t + 32 * (w + 4 * g)
+    value_expect = j + regs * (n + chunks * d)
+
+    # Normalize the (thread@0, value@1) coordinate to rank 2 by adding the
+    # zero ArithmeticTuple, exactly as FragmentToTileLang does.
+    thread_got, value_got = cute.to_python(cute.from_python(plan.fragment((dp, col))) + (0, 0))
+    assert ana.can_prove_equal(thread_got, thread_expect), (
+        f"{meta} wgs={num_wgs} x{chunks}: fragment thread {thread_got} != DstLayout thread {thread_expect}"
+    )
+    assert ana.can_prove_equal(value_got, value_expect), (
+        f"{meta} wgs={num_wgs} x{chunks}: fragment value {value_got} != DstLayout value {value_expect}"
+    )
+
+
+def test_expand_16dp_requires_pow2_single_issue():
+    # The duplicate issue's registers append after ALL repetitions, so a
+    # multi-issue (non-power-of-two) chunk count would interleave wrongly;
+    # Expand must refuse rather than emit a wrong layout.
+    tile = _column_major_tile(128, 6)
+    assert _ffi_api.ExpandTcgen05Layout(_get_meta("ld_16dp64b"), tile, 128) is None
+    # 32dp32b chains exactly, so the same shape is fine there.
+    assert _ffi_api.ExpandTcgen05Layout(_get_meta("ld_32dp32b"), tile, 128) is not None
+
+
+def test_expand_16dp_respects_max_chunks():
+    # One .xN issue caps at 128 b32 columns of registers: 16dp256b (width 8)
+    # allows at most 32 repetitions.
+    meta = _get_meta("ld_16dp256b")
+    assert _ffi_api.ExpandTcgen05Layout(meta, _column_major_tile(128, 256), 128) is not None
+    assert _ffi_api.ExpandTcgen05Layout(meta, _column_major_tile(128, 512), 128) is None
+
+
+def test_expand_gapped_tile_issues_per_batch():
+    # A column slice of a batched accumulator leaves per-batch serialized
+    # gaps: one tcgen05 issue per batch entry (rest iteration), later issues
+    # appending registers.
+    tile = cute.Layout.parse("(3,128,64):(128@1,1@0,1@1)")
+    plan = _ffi_api.ExpandTcgen05Layout(_get_meta("st_32dp32b"), tile, 128)
+    assert plan is not None
+    assert str(plan.fragment) == "(3,128,64):(64@1,1@0,1@1)"
+    assert (plan.num_chunks_each_wg, plan.num_issues, plan.vals_per_issue) == (64, 3, 64)
+    assert [plan.rest_domain(i) for i in range(3)] == [0, 1, 2]
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_tmem_physical_shape.py
+++ b/testing/python/transform/test_tilelang_transform_tmem_physical_shape.py
@@ -1,0 +1,85 @@
+"""TMEM allocation must follow the inferred physical fragment shape."""
+
+import pytest
+
+from tilelang import tvm
+import tilelang as tl
+import tilelang.language as T
+from tilelang.cuda.intrinsics.layout.mma_sm100_layout import (
+    TCGEN05Meta,
+    make_tmem_frg_c,
+)
+
+
+TARGET = tvm.target.Target({"kind": "cuda", "arch": "sm_100"})
+
+
+def _lower(func):
+    mod = tvm.IRModule.from_expr(func.with_attr("global_symbol", "main"))
+    mod = tvm.tirx.transform.BindTarget(TARGET)(mod)
+    mod = tl.transform.MaterializeKernelLaunch()(mod)
+    mod = tl.transform.LayoutInference()(mod)
+    # LowerTileOp materializes the inferred TMEM layout (physical buffer
+    # shape + physical access coordinates) before allocation sizing.
+    mod = tl.transform.LowerTileOp()(mod)
+    return tl.cuda.transform.LowerSharedTmem()(mod)
+
+
+def _collect_calls(stmt, op_name):
+    calls = []
+
+    def visitor(node):
+        if isinstance(node, tvm.tirx.Call) and getattr(node.op, "name", None) == op_name:
+            calls.append(node)
+
+    tvm.tirx.stmt_functor.post_order_visit(stmt, visitor)
+    return calls
+
+
+@pytest.mark.parametrize(
+    ("dtype", "expected_num_b32_cols"),
+    [(T.float32, 128), (T.bfloat16, 64)],
+)
+def test_tmem_outer_m_tiles_allocate_physical_columns(dtype, expected_num_b32_cols):
+    @T.prim_func
+    def func():
+        with T.Kernel(1, threads=128):
+            tmem = T.alloc_tmem((256, 64), dtype)
+            T.annotate_layout(
+                {
+                    tmem: T.Layout(
+                        (256, 64),
+                        lambda i, j: [i % 128, (i // 128) * 64 + j],
+                    )
+                }
+            )
+            T.evaluate(tmem[0, 0])
+
+    body = _lower(func)["main"].body
+    alloc = _collect_calls(body, "tl.ptx_init_tensor_memory")
+    dealloc = _collect_calls(body, "tl.ptx_deallocate_tensor_memory")
+    assert len(alloc) == len(dealloc) == 1
+    assert alloc[0].args[1].value == expected_num_b32_cols
+    assert dealloc[0].args[1].value == expected_num_b32_cols
+
+
+@pytest.mark.parametrize("dtype", [T.float16, T.bfloat16, T.float32])
+def test_tmem_frg_type_c_allocates_int32_storage_columns(dtype):
+    @T.prim_func
+    def func():
+        with T.Kernel(1, threads=128):
+            c_tmem = T.alloc_tmem((128, 64), dtype)
+            fragment = make_tmem_frg_c(c_tmem, TCGEN05Meta(128, 64, 16, False, False), is_ts=True)
+            T.annotate_layout({c_tmem: fragment.to_tilelang()})
+            T.evaluate(c_tmem[0, 0])
+
+    body = _lower(func)["main"].body
+    alloc = _collect_calls(body, "tl.ptx_init_tensor_memory")
+    dealloc = _collect_calls(body, "tl.ptx_deallocate_tensor_memory")
+    assert len(alloc) == len(dealloc) == 1
+    assert alloc[0].args[1].value == 64
+    assert dealloc[0].args[1].value == 64
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tilelang/cuda/intrinsics/layout/mma_sm100_layout.py
+++ b/tilelang/cuda/intrinsics/layout/mma_sm100_layout.py
@@ -217,8 +217,9 @@ def _tile_tmem_frg_atom(
     ordered = cute.make_layout([tiled[mode] for mode in mode_order])
 
     # ``tmem_restride``: virtual addresses to ``(datapath, column)``
-    # coordinates, the column dilated by StorageType/ValueType exactly as
-    # CUTLASS's COL_ADDR stride (a float16 accumulator occupies int32 slots).
+    # coordinates, the column scaled by StorageType/ValueType exactly as
+    # CUTLASS's COL_ADDR stride (a float16 accumulator occupies the low half
+    # of an int32 slot; tcgen05.ld reads it back with pack::16b).
     restride = cute.make_layout(
         (128, 16384),
         (cute.E(0), storage_bits // value_bits * cute.E(1)),

--- a/tilelang/cuda/intrinsics/layout/mma_sm100_layout.py
+++ b/tilelang/cuda/intrinsics/layout/mma_sm100_layout.py
@@ -1,0 +1,322 @@
+"""CuTe TMEM fragment layouts for dense SM100 MMA (``tmem_frg`` family).
+
+A TMEM fragment is a :class:`cute.Layout` with :class:`cute.ScaledBasis`
+strides, mapping logical buffer coordinates to hierarchical ``(datapath,
+column)`` TMEM coordinates, with the column measured in the buffer's value
+type.  Exactly as in CUTLASS ``mma_traits_sm100.hpp``, an atom in virtual
+TMEM addressing (datapath stride one, column stride 128) is repeated over the
+tile counts, then composed with ``tmem_restride`` into physical coordinates.
+Both TMEM allocation and MMA address formation consume the same layout, and a
+sliced operand is handled by ``cute.restrict`` like any other CuTe layout.
+
+The atoms are the PTX "TMEM data path layout organization" variants
+(https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-data-path-layout-organization):
+
+========  ==========================  ====================================
+PTX       CUTLASS atom                shape:stride (virtual addressing)
+========  ==========================  ====================================
+Layout A  2SM M256 (M128/CTA)         ``(128, N):(1, 128)``
+Layout B  2SM M128 (M64/CTA, "2x2")   ``(64, (N/2, 2)):(1, (128, 64))``
+Layout C  2SM M64  (M32/CTA, "1x4")   ``(32, (N/4, 4)):(1, (128, 32))``
+Layout D  1SM M128                    ``(128, N):(1, 128)``
+Layout E  1SM M64  ``.ws`` C/D        ``(64, (N/2, 2)):(1, (128, 64))``
+Layout F  1SM M64  half-datapath      ``((16, 4), N):((1, 32), 128)``
+Layout G  1SM M32  ``.ws`` C/D        ``(32, (N/4, 4)):(1, (128, 32))``
+========  ==========================  ====================================
+
+Only the compiler's MMA lowering (this module and
+``tcgen05_macro_generator``) sees CuTe layouts; everywhere else — the layout
+map, TMEM allocation, and copy lowering — a fragment travels as its TileLang
+``lambda *indices: [datapath, column]`` form via
+:meth:`cute.Layout.to_tilelang`, and
+:meth:`cute.Layout.from_tilelang_hierarchical` recovers the hierarchical
+CuTe layout losslessly.
+
+As everywhere else in the MMA lowering, the last two modes of a buffer are
+the matrix modes; any leading modes are batch dimensions (for example a
+software-pipeline stage) and repeat the fragment along TMEM columns.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import Enum
+
+from tvm.tirx import Buffer
+
+from tilelang.language.dtypes import get_tvm_dtype
+from tilelang.layout import cute
+
+
+class TCGEN05TmemAllocMode(Enum):
+    """Dense TMEM allocation modes from CUTLASS ``UMMA::TmemAllocMode``."""
+
+    INTERLEAVED = "interleaved"
+    NON_INTERLEAVED = "non_interleaved"
+    DUPLICATED = "duplicated"
+
+
+@dataclass(frozen=True)
+class TCGEN05Meta:
+    """The TCGEN5MMA instruction atom selected by ``get_tcgen5_mma_meta``."""
+
+    atom_m: int
+    atom_n: int
+    atom_k: int
+    enable_ws: bool
+    enable_2cta: bool
+
+    @classmethod
+    def from_ffi(cls, values: Iterable[int]) -> TCGEN05Meta:
+        atom_m, atom_n, atom_k, enable_ws, enable_2cta = (int(x) for x in values)
+        return cls(atom_m, atom_n, atom_k, bool(enable_ws), bool(enable_2cta))
+
+    @property
+    def num_sms(self) -> int:
+        return 2 if self.enable_2cta else 1
+
+    @property
+    def atom_m_per_cta(self) -> int:
+        return self.atom_m // self.num_sms
+
+    @property
+    def b_atom_n_per_cta(self) -> int:
+        """Each 2SM instruction reads an N/2 shard of B from each CTA."""
+        return self.atom_n // self.num_sms
+
+
+def make_tmem_frg_atom(
+    num_sms: int,
+    alloc_mode: TCGEN05TmemAllocMode,
+    atom_m: int,
+    atom_n: int,
+) -> tuple[cute.Layout, int]:
+    """Return CUTLASS ``tmem_frg``'s ``(tmem_atom, outer_tile_stride)`` pair.
+
+    ``atom_m`` is the per-CTA M extent.  The 1SM M64 atom is PTX Layout F
+    (half datapaths, 32-datapath halves interleaved); the 2SM atoms fold the
+    peer CTA's N shard into the upper datapaths (PTX Layouts A/B/C).
+    """
+
+    if num_sms == 1:
+        assert alloc_mode in {
+            TCGEN05TmemAllocMode.INTERLEAVED,
+            TCGEN05TmemAllocMode.NON_INTERLEAVED,
+        }, f"1SM TMEM fragments do not support allocation mode {alloc_mode.value}"
+        if atom_m == 64:
+            # PTX Layout F: even 16-datapath halves; a second tile may
+            # interleave into the odd halves (tile_stride one) or continue in
+            # fresh columns (NonInterleaved, tile_stride two).
+            atom = cute.make_layout(((16, 4), atom_n), ((1, 32), 128))
+            tile_stride = 1 if alloc_mode is TCGEN05TmemAllocMode.INTERLEAVED else 2
+            return atom, tile_stride
+        if atom_m == 128:
+            # PTX Layout D: all datapaths.
+            return cute.make_layout((128, atom_n)), 1
+        raise ValueError(f"1SM TMEM fragment M atom must be 64 or 128, got {atom_m}")
+
+    if num_sms == 2:
+        assert alloc_mode in {
+            TCGEN05TmemAllocMode.INTERLEAVED,
+            TCGEN05TmemAllocMode.DUPLICATED,
+        }, f"2SM TMEM fragments do not support allocation mode {alloc_mode.value}"
+        if atom_m == 32:
+            # PTX Layout C ("1x4"): four N quarters stacked across datapaths.
+            assert alloc_mode is TCGEN05TmemAllocMode.INTERLEAVED, "2SM M32 TMEM fragments only support interleaved allocation"
+            assert atom_n % 4 == 0, f"2SM M32 TMEM fragment N atom must be divisible by 4, got {atom_n}"
+            return cute.make_layout((32, (atom_n // 4, 4)), (1, (128, 32))), 1
+        if atom_m == 64:
+            if alloc_mode is TCGEN05TmemAllocMode.DUPLICATED:
+                # Duplicated allocation has a physical M domain twice as large
+                # as its logical domain.  ``make_tmem_frg_atom`` exposes the
+                # legal CUTLASS atom for tests and capability queries;
+                # ``make_tmem_frg`` rejects it because Layout is one-to-one.
+                return cute.make_layout((128, atom_n)), 1
+            # PTX Layout B ("2x2"): two N halves stacked across datapaths.
+            assert atom_n % 2 == 0, f"2SM M64 TMEM fragment N atom must be even, got {atom_n}"
+            return cute.make_layout((64, (atom_n // 2, 2)), (1, (128, 64))), 1
+        if atom_m == 128:
+            # PTX Layout A: all datapaths per CTA.
+            return cute.make_layout((128, atom_n)), 1
+        raise ValueError(f"2SM TMEM fragment M atom must be 32, 64, or 128, got {atom_m}")
+
+    raise ValueError(f"TCGEN05 TMEM fragments require one or two SMs, got {num_sms}")
+
+
+def make_tmem_frg_ws_atom(atom_m: int, atom_n: int) -> cute.Layout:
+    """Return CUTLASS ``tmem_frg_ws``'s dense 1SM weight-stationary C/D atom.
+
+    ``.ws`` instructions with M below 128 fold N shards into the upper
+    datapaths instead of leaving them idle: PTX Layout E for M64 and Layout G
+    for M32.
+    """
+
+    assert atom_n in (64, 128, 256), f"Weight-stationary 1SM TMEM fragment N atom must be 64, 128, or 256, got {atom_n}"
+    if atom_m == 32:
+        # PTX Layout G.
+        return cute.make_layout((32, (atom_n // 4, 4)), (1, (128, 32)))
+    if atom_m == 64:
+        # PTX Layout E.
+        return cute.make_layout((64, (atom_n // 2, 2)), (1, (128, 64)))
+    if atom_m == 128:
+        # Same as PTX Layout D; .ws with full datapaths has nothing to fold.
+        return cute.make_layout((128, atom_n))
+    raise ValueError(f"Weight-stationary 1SM TMEM fragment M atom must be 32, 64, or 128, got {atom_m}")
+
+
+def _tile_tmem_frg_atom(
+    buffer: Buffer,
+    atom: cute.Layout,
+    tile_stride: int,
+    atom_m: int,
+    atom_n: int,
+    storage_bits: int,
+) -> cute.Layout:
+    """CUTLASS ``tmem_frg::make`` for one validated atom, in CuTe algebra."""
+
+    shape = tuple(int(x) for x in buffer.shape)
+    assert len(shape) >= 2, f"TMEM buffer {buffer.name} must have at least two modes, got shape {shape}"
+    m_extent, n_extent = shape[-2:]
+    assert m_extent % atom_m == 0, f"TMEM buffer {buffer.name} M extent {m_extent} must be divisible by fragment atom M={atom_m}"
+    assert n_extent % atom_n == 0, f"TMEM buffer {buffer.name} second-mode extent {n_extent} must be divisible by fragment atom {atom_n}"
+
+    value_dtype = get_tvm_dtype(buffer.dtype)
+    value_bits = value_dtype.bits * value_dtype.lanes
+    assert storage_bits >= value_bits and storage_bits % value_bits == 0, (
+        f"TMEM buffer {buffer.name} storage width {storage_bits} must be an integer multiple of its value width {value_bits}"
+    )
+
+    batch_extents = tuple(reversed(shape[:-2]))
+    batch_count = 1
+    for extent in batch_extents:
+        batch_count *= extent
+
+    # CUTLASS checks storage capacity before constructing the fragment.
+    # TMEM contains 128 datapaths by 512 b32 columns.
+    assert batch_count * m_extent * n_extent * storage_bits <= 128 * 512 * 32, (
+        f"TMEM buffer {buffer.name} shape {shape} exceeds the 128x512 b32 TMEM capacity"
+    )
+
+    # ``tmem_frg::make``: repeat the virtual atom over the tile counts, first
+    # mode fastest, with the atom's requested base tile stride.  Batch modes
+    # continue the same column-major tiling, so they extend the tiler
+    # (row-major buffer axes reversed to keep the last batch axis fastest).
+    tiler_shape = (m_extent // atom_m, n_extent // atom_n, *batch_extents)
+    tiler_strides = []
+    stride = tile_stride
+    for extent in tiler_shape:
+        tiler_strides.append(stride)
+        stride *= extent
+    tiler = cute.make_layout(tiler_shape, tuple(tiler_strides))
+    tiled = cute.blocked_product(atom, tiler)
+
+    # Present the top-level modes in buffer order (batch..., M, N) so the
+    # layout consumes logical buffer coordinates directly.
+    mode_order = [*range(cute.rank(tiled) - 1, 1, -1), 0, 1]
+    ordered = cute.make_layout([tiled[mode] for mode in mode_order])
+
+    # ``tmem_restride``: virtual addresses to ``(datapath, column)``
+    # coordinates, the column dilated by StorageType/ValueType exactly as
+    # CUTLASS's COL_ADDR stride (a float16 accumulator occupies int32 slots).
+    restride = cute.make_layout(
+        (128, 16384),
+        (cute.E(0), storage_bits // value_bits * cute.E(1)),
+    )
+    return cute.composition(restride, ordered)
+
+
+def make_tmem_frg(
+    buffer: Buffer,
+    num_sms: int,
+    alloc_mode: TCGEN05TmemAllocMode,
+    atom_m: int,
+    atom_n: int,
+    storage_bits: int,
+) -> cute.Layout:
+    """Tile a legal ordinary CUTLASS atom over the buffer's matrix modes."""
+
+    if alloc_mode is TCGEN05TmemAllocMode.DUPLICATED and atom_m == 64:
+        raise ValueError(
+            f"TMEM buffer {buffer.name} uses CUTLASS's duplicated 2SM M64 allocation, which cannot be represented by "
+            "TileLang's one-to-one Layout; materialize the duplicated A storage explicitly"
+        )
+    atom, tile_stride = make_tmem_frg_atom(num_sms, alloc_mode, atom_m, atom_n)
+    return _tile_tmem_frg_atom(buffer, atom, tile_stride, atom_m, atom_n, storage_bits)
+
+
+def make_tmem_frg_a(buffer: Buffer, meta: TCGEN05Meta) -> cute.Layout:
+    """Build the exact dense TS ``FrgTypeA`` selected by CUTLASS."""
+
+    alloc_mode = TCGEN05TmemAllocMode.DUPLICATED if meta.enable_2cta else TCGEN05TmemAllocMode.NON_INTERLEAVED
+    value_dtype = get_tvm_dtype(buffer.dtype)
+    return make_tmem_frg(
+        buffer,
+        meta.num_sms,
+        alloc_mode,
+        meta.atom_m_per_cta,
+        meta.atom_k,
+        value_dtype.bits * value_dtype.lanes,
+    )
+
+
+def make_tmem_frg_c(buffer: Buffer, meta: TCGEN05Meta, *, is_ts: bool) -> cute.Layout:
+    """Build the dense ``FrgTypeC`` paired with the selected instruction.
+
+    Ordinary SS accumulators use the interleaved allocation; dense TS traits
+    pin CUTLASS's NonInterleaved (1SM) / Interleaved (2SM) modes; ``.ws`` SS
+    instructions use the weight-stationary fragment (PTX Layouts E/G).
+    """
+
+    if meta.enable_ws and not is_ts:
+        assert not meta.enable_2cta, "Weight-stationary TCGEN5MMA is 1SM-only"
+        return _tile_tmem_frg_atom(
+            buffer,
+            make_tmem_frg_ws_atom(meta.atom_m, meta.atom_n),
+            1,
+            meta.atom_m,
+            meta.atom_n,
+            32,
+        )
+    if is_ts:
+        alloc_mode = TCGEN05TmemAllocMode.INTERLEAVED if meta.enable_2cta else TCGEN05TmemAllocMode.NON_INTERLEAVED
+    else:
+        alloc_mode = TCGEN05TmemAllocMode.INTERLEAVED
+    return make_tmem_frg(
+        buffer,
+        meta.num_sms,
+        alloc_mode,
+        meta.atom_m_per_cta,
+        meta.atom_n,
+        32,
+    )
+
+
+def validate_tcgen05_ts_instruction(meta: TCGEN05Meta, a_dtype, transposed: bool) -> None:
+    """Validate a dense TS instruction atom against CUTLASS SM100 wrappers."""
+
+    if transposed:
+        raise ValueError("TCGEN5MMA TS requires K-major TMEM A (transpose_A=False)")
+
+    if meta.enable_2cta:
+        if meta.atom_m not in (128, 256):
+            raise ValueError(f"2CTA TCGEN5MMA TS instruction M must be 128 or 256, got {meta.atom_m}")
+        if not (32 <= meta.atom_n <= 256 and meta.atom_n % 32 == 0):
+            raise ValueError(f"2CTA TCGEN5MMA TS instruction N must be a multiple of 32 in [32, 256], got {meta.atom_n}")
+        return
+
+    if meta.atom_m not in (64, 128):
+        raise ValueError(f"1CTA TCGEN5MMA TS instruction M must be 64 or 128, got {meta.atom_m}")
+    dtype = get_tvm_dtype(a_dtype)
+    is_int8 = str(dtype) in {"int8", "uint8"}
+    if is_int8:
+        legal_n = meta.atom_n == 8 or (16 <= meta.atom_n <= 256 and meta.atom_n % 16 == 0)
+        requirement = "8 or a multiple of 16 in [16, 256]"
+    elif meta.atom_m == 64:
+        legal_n = 8 <= meta.atom_n <= 256 and meta.atom_n % 8 == 0
+        requirement = "a multiple of 8 in [8, 256] for M=64"
+    else:
+        legal_n = 16 <= meta.atom_n <= 256 and meta.atom_n % 16 == 0
+        requirement = "a multiple of 16 in [16, 256] for M=128"
+    if not legal_n:
+        raise ValueError(f"1CTA TCGEN5MMA TS instruction N must be {requirement}, got {meta.atom_n}")

--- a/tilelang/cuda/intrinsics/macro/tcgen05_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/tcgen05_macro_generator.py
@@ -2,6 +2,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 import tilelang.language as T
 from .mma_macro_generator import TensorCoreIntrinEmitter as MMAIntrinEmitter
+from ..layout.mma_sm100_layout import (
+    TCGEN05Meta,
+    make_tmem_frg_a,
+    make_tmem_frg_c,
+    validate_tcgen05_ts_instruction,
+)
 from tvm import DataType
 from tvm.tirx import PrimExpr, Buffer, Var, BufferLoad, BufferRegion
 from tilelang import tvm as tvm
@@ -52,6 +58,54 @@ class TCGEN05DescriptorParams:
     buffer; passed to ``T.increase_descriptor_offset`` after building the
     descriptor from the buffer base. ``0`` for a whole-buffer / base-origin
     operand. Computed by :func:`compute_umma_descriptor` from the CuTe layout."""
+
+
+@dataclass(frozen=True)
+class TCGEN05TensorMemoryParams:
+    """Pre-computed TMEM addressing for one operand Region.
+
+    The TMEM analog of :class:`TCGEN05DescriptorParams`: built by
+    ``compute_tcgen05_{a,c}_tmem_params()`` from the operand's CuTe fragment
+    and Region, and consumed by ``tcgen05_*_atom()`` to form each MMA atom's
+    raw TMEM address.
+    """
+
+    data: Var
+    """The TMEM buffer's data Var, carrying the base address."""
+    origin: tuple[PrimExpr, PrimExpr]
+    """Physical ``(datapath, value-column)`` of the Region origin."""
+    tile: cute.Layout
+    """Region-local matrix coordinates to physical coordinate steps."""
+    value_bits: int
+    """Bit width of one value; converts value columns to raw b32 columns."""
+
+    @classmethod
+    def from_region(cls, fragment: cute.Layout, region: BufferRegion) -> TCGEN05TensorMemoryParams:
+        """Restrict a TMEM fragment to one operand Region.
+
+        ``cute.restrict`` applies the Region exactly like the shared-memory
+        descriptor path: it yields the Region origin's physical ``(datapath,
+        column)`` plus the sliced sublayout, and each atom origin is then one
+        evaluation of that sublayout.
+        """
+        buffer, ranges = region.buffer, list(region.region)
+        assert cute.rank(fragment) == len(ranges), (
+            f"TCGEN5MMA region rank {len(ranges)} does not match its TMEM fragment rank {cute.rank(fragment)}"
+        )
+        origin, tile = cute.restrict(fragment, ranges)
+        value_dtype = get_tvm_dtype(buffer.dtype)
+        return cls(buffer.data, origin, tile, value_dtype.bits * value_dtype.lanes)
+
+    def atom_offset(self, row_offset: PrimExpr, col_offset: PrimExpr) -> PrimExpr:
+        """Raw TMEM address of the atom at a Region-local matrix origin.
+
+        The column coordinate counts values of the buffer's dtype; scaling it
+        to raw b32 columns here is the same conversion TMEM allocation uses.
+        """
+        datapath_step, column_step = self.tile((row_offset, col_offset))
+        datapath = self.origin[0] + datapath_step
+        column = (self.origin[1] + column_step) * self.value_bits // 32
+        return (datapath << 16) | column
 
 
 def _bytes_to_elements(byte_count: int, elem_bits: int) -> int:
@@ -196,8 +250,13 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
     # should be rewritten to support dynamic k_dim
     tcgen05_prefix: str
 
+    # The selected instruction atom; set by get_tcgen5_mma_meta().
+    meta: tuple = ()
+
     a_shared_layout: Layout = None
     b_shared_layout: Layout = None
+    a_tmem_layout: cute.Layout = None
+    c_tmem_layout: cute.Layout = None
 
     @staticmethod
     def _smem_elems_in_bytes(dtype) -> int:
@@ -247,6 +306,25 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         self.b_shared_layout = layout
         return self
 
+    def _assign_a_tmem_layout(self, layout: Layout):
+        """Adopt the inferred TS ``FrgTypeA`` layout from the layout map.
+
+        Layout inference guarantees every TMEM operand carries a layout, in
+        TileLang ``lambda *indices: [datapath, column]`` form;
+        ``cute.Layout.from_tilelang_hierarchical`` recovers the hierarchical
+        CuTe layout.
+        """
+
+        self.a_tmem_layout = cute.Layout.from_tilelang_hierarchical(layout)
+        assert self.a_tmem_layout is not None, f"TMEM layout is not decodable by the CuTe analyzer: {layout}"
+        return self
+
+    def _assign_c_tmem_layout(self, layout: Layout):
+        """Adopt the inferred ``FrgTypeC`` layout from the layout map."""
+        self.c_tmem_layout = cute.Layout.from_tilelang_hierarchical(layout)
+        assert self.c_tmem_layout is not None, f"TMEM layout is not decodable by the CuTe analyzer: {layout}"
+        return self
+
     def _initialize_micro_size(self, m_dim: int = 16, k_dim: int = 16):
         # tcgen05 doesn't care about warp partitioning
         self.micro_size_x = m_dim
@@ -268,130 +346,198 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
             return buf_or_region.buffer
         return buf_or_region
 
-    def tcgen05mma(self, A_buf: Buffer, B_buf: Buffer, C_local_buf: Buffer, mbar, clear_accum: PrimExpr = False):
+    def validate_tcgen05_operand_regions(
+        self, A_region: BufferRegion, B_region: BufferRegion, C_region: BufferRegion, *, is_ts: bool
+    ) -> None:
+        """Enforce the TCGEN5MMA operand contract at the emitter boundary.
+
+        Every operand is a complete BufferRegion whose leading modes are
+        pinned to one element and whose two trailing matrix modes are an
+        exact union of instruction atoms, atom-aligned in origin.  CUTLASS
+        forms sliced views only after partitioning into atoms; enforcing the
+        same contract here — once, before any address math — prevents
+        descriptor-aligned but atom-misaligned windows (for example BF16 K16
+        at K=8) from silently producing incorrect results, and lets the rest
+        of the lowering assume well-formed Regions without re-checking.
+        """
+        meta = self.tcgen05_meta
+        if is_ts:
+            validate_tcgen05_ts_instruction(meta, self.a_dtype, self.a_transposed)
+        if meta.enable_2cta:
+            # Each CTA holds an N/2 shard of B, so how a second cooperative
+            # instruction's window maps into the shard depends on how the
+            # shard was produced; that contract is not defined yet.  Reject
+            # instead of silently walking B's descriptor out of the shard.
+            assert self.tcgen05_num_inst_n == 1, (
+                f"2CTA TCGEN5MMA currently supports a single instruction along N; "
+                f"got N={self.block_col_warps * self.warp_col_tiles} with instruction N={meta.atom_n}"
+            )
+        analyzer = tvm.arith.Analyzer()
+
+        def check(region, operand, transposed, mn_atom, k_atom, mn_axis_name, k_axis_name):
+            ranges = region.region
+            assert len(ranges) >= 2, f"TCGEN5MMA {operand} must have at least two modes, got rank {len(ranges)}"
+            for axis, axis_range in enumerate(ranges[:-2]):
+                assert analyzer.can_prove_equal(axis_range.extent, 1), (
+                    f"TCGEN5MMA {operand} leading mode {axis} must have unit extent; the last two modes are the matrix modes"
+                )
+            row_range, col_range = ranges[-2:]
+            mn_range, k_range = (col_range, row_range) if transposed else (row_range, col_range)
+            for mode_name, mode_range, atom in ((mn_axis_name, mn_range, mn_atom), (k_axis_name, k_range, k_atom)):
+                assert analyzer.can_prove_equal(mode_range.min % atom, 0), (
+                    f"TCGEN5MMA {operand} {mode_name} origin {mode_range.min} must be aligned to the selected atom {atom}"
+                )
+                assert analyzer.can_prove_equal(mode_range.extent % atom, 0), (
+                    f"TCGEN5MMA {operand} {mode_name} extent {mode_range.extent} must be a multiple of the selected atom {atom}"
+                )
+
+        check(A_region, "A", self.a_transposed, meta.atom_m_per_cta, meta.atom_k, "M", "K")
+        # TileLang B is [K,N] by default and [N,K] when transpose_B=True,
+        # opposite to A's physical-axis convention.
+        # CUTLASS partitions each 2SM instruction's BLayout into N/2 per CTA.
+        check(B_region, "B", not self.b_transposed, meta.b_atom_n_per_cta, meta.atom_k, "N", "K")
+        check(C_region, "C", False, meta.atom_m_per_cta, meta.atom_n, "M", "N")
+
+    def compute_tcgen05_c_tmem_params(self, C_region: BufferRegion) -> TCGEN05TensorMemoryParams:
+        """Compute accumulator TMEM addressing for one operand Region.
+
+        The TMEM analog of ``compute_tcgen05_*_desc_params``: shared by the
+        SS, TS, and block-scaled emitters so the accumulator addressing
+        convention lives in exactly one place.
+        """
+        assert self.c_tmem_layout is not None, "TCGEN05 C operand has no assigned TMEM layout"
+        return TCGEN05TensorMemoryParams.from_region(self.c_tmem_layout, C_region)
+
+    def compute_tcgen05_a_tmem_params(self, A_region: BufferRegion) -> TCGEN05TensorMemoryParams:
+        """Compute TS A TMEM addressing for one operand Region."""
+        assert self.a_tmem_layout is not None, "TCGEN05 TS A operand has no assigned TMEM layout"
+        return TCGEN05TensorMemoryParams.from_region(self.a_tmem_layout, A_region)
+
+    def tcgen05mma(self, A_region: BufferRegion, B_region: BufferRegion, C_region: BufferRegion, mbar, clear_accum: PrimExpr = False):
         """Emit a TCGEN5MMA operation, dispatching to SS or TS variant based on A's memory scope.
 
-        If *A_buf* resides in tensor memory (``shared.tmem``), the TS variant is
-        emitted; otherwise the SS variant is used (both A and B from shared memory).
+        If *A_region* resides in tensor memory (``shared.tmem``), the TS
+        variant is emitted; otherwise the SS variant is used (both A and B
+        from shared memory).
 
         Parameters
         ----------
-        A_buf : Buffer
+        A_region : BufferRegion
             Operand A — either in shared memory (SS) or tensor memory (TS).
-        B_buf : Buffer
+        B_region : BufferRegion
             Operand B in shared memory.
-        C_local_buf : Buffer
-            Accumulator buffer in tensor memory.
+        C_region : BufferRegion
+            Accumulator Region in tensor memory.
         mbar : PrimExpr
             Memory barrier used for MMA completion signalling.
         clear_accum : PrimExpr
             Whether to zero the accumulator before the first MMA.
         """
-        if is_tensor_memory(A_buf):
-            return self.tcgen05mma_ts(A_buf, B_buf, C_local_buf, mbar, clear_accum)
-        return self.tcgen05mma_ss(A_buf, B_buf, C_local_buf, mbar, clear_accum)
+        if is_tensor_memory(A_region):
+            return self.tcgen05mma_ts(A_region, B_region, C_region, mbar, clear_accum)
+        return self.tcgen05mma_ss(A_region, B_region, C_region, mbar, clear_accum)
 
-    def tcgen05mma_ss(self, A_buf: Buffer, B_buf: Buffer, C_local_buf: Buffer, mbar, clear_accum: PrimExpr = False):
+    def tcgen05mma_ss(self, A_region: BufferRegion, B_region: BufferRegion, C_region: BufferRegion, mbar, clear_accum: PrimExpr = False):
         """Emit the SS (Shared-Shared) variant of TCGEN5MMA.
 
         Reads operand A and B from shared memory via a descriptor.
 
         Parameters
         ----------
-        A_buf : Buffer
+        A_region : BufferRegion
             Operand A in shared memory.
-        B_buf : Buffer
+        B_region : BufferRegion
             Operand B in shared memory.
-        C_local_buf : Buffer
-            Accumulator buffer in tensor memory.
+        C_region : BufferRegion
+            Accumulator Region in tensor memory.
         mbar : PrimExpr
-            Memory barrier for MMA completion signalling.
+            Memory barrier for MMA completion signalling. ``None`` keeps the
+            MMA ordered in the issue stream without publishing an event.
         clear_accum : PrimExpr
             Whether to zero the accumulator before the first MMA.
         """
         micro_size_k = self.micro_size_k
         k_dim = self.chunk
         assert k_dim >= micro_size_k, f"k_dim must be greater than or equal to {micro_size_k}, got k_dim: {k_dim}"
+        self.validate_tcgen05_operand_regions(A_region, B_region, C_region, is_ts=False)
 
         num_inst_m = self.tcgen05_num_inst_m
         num_inst_n = self.tcgen05_num_inst_n
         num_k_atoms = self.tcgen05_num_k_atoms
-        a_params = self.compute_tcgen05_a_desc_params(A_buf)
-        b_params = self.compute_tcgen05_b_desc_params(B_buf)
+        a_params = self.compute_tcgen05_a_desc_params(A_region)
+        b_params = self.compute_tcgen05_b_desc_params(B_region)
+        c_params = self.compute_tcgen05_c_tmem_params(C_region)
         instr_desc = self.compute_tcgen05_instr_desc()
 
         @T.macro
-        def _warp_mma_ss(A_buf, B_buf, C_local_buf, mbar):
+        def _warp_mma_ss(A_region, B_region, mbar):
             desc_a = T.alloc_tcgen05_smem_desc()
             desc_b = T.alloc_tcgen05_smem_desc()
-            self.init_tcgen05_a_desc(desc_a, A_buf, a_params)
-            self.init_tcgen05_b_desc(desc_b, B_buf, b_params)
+            self.init_tcgen05_a_desc(desc_a, A_region, a_params)
+            self.init_tcgen05_b_desc(desc_b, B_region, b_params)
 
             for j in T.unroll(num_inst_n):
                 for i in T.unroll(num_inst_m):
                     for ki in T.unroll(0, num_k_atoms):
-                        self.tcgen05_ss_atom(desc_a, desc_b, C_local_buf, i, j, ki, a_params, b_params, instr_desc, clear_accum)
-            self.tcgen05_atom_arrive(mbar)
+                        self.tcgen05_ss_atom(desc_a, desc_b, i, j, ki, a_params, b_params, c_params, instr_desc, clear_accum)
+            if mbar is not None:
+                self.tcgen05_atom_arrive(mbar)
 
-        return _warp_mma_ss(A_buf, B_buf, C_local_buf, mbar)
+        return _warp_mma_ss(A_region, B_region, mbar)
 
-    def tcgen05mma_ts(self, A_buf, B_buf, C_local_buf, mbar, clear_accum: PrimExpr = False):
+    def tcgen05mma_ts(self, A_region: BufferRegion, B_region: BufferRegion, C_region: BufferRegion, mbar, clear_accum: PrimExpr = False):
         """Emit the TS (TensorMemory-Shared) variant of TCGEN5MMA.
 
         Reads operand A directly from tensor memory (TMEM) and operand B from
-        shared memory via a descriptor.  The TMEM column offset for A is
-        computed assuming packed storage (e.g. two ``bfloat16`` values per
-        ``uint32`` column) to match the output of ``tcgen05.st``.
+        shared memory via a descriptor.  Every A and C atom origin is mapped
+        through its CuTe TMEM fragment.
 
         Parameters
         ----------
-        A_buf : Buffer
+        A_region : BufferRegion
             Operand A residing in tensor memory (``shared.tmem``).
-        B_buf : Buffer
+        B_region : BufferRegion
             Operand B in shared memory.
-        C_local_buf : Buffer
-            Accumulator buffer in tensor memory.
+        C_region : BufferRegion
+            Accumulator Region in tensor memory.
         mbar : PrimExpr
-            Memory barrier for MMA completion signalling.
+            Memory barrier for MMA completion signalling. ``None`` keeps the
+            MMA ordered in the issue stream without publishing an event.
         clear_accum : PrimExpr
             Whether to zero the accumulator before the first MMA.
         """
         micro_size_k = self.micro_size_k
         k_dim = self.chunk
         assert k_dim >= micro_size_k, f"k_dim must be >= {micro_size_k}, got {k_dim}"
+        self.validate_tcgen05_operand_regions(A_region, B_region, C_region, is_ts=True)
 
         num_inst_m = self.tcgen05_num_inst_m
         num_inst_n = self.tcgen05_num_inst_n
         num_k_atoms = self.tcgen05_num_k_atoms
-        b_params = self.compute_tcgen05_b_desc_params(B_buf)
+        a_params = self.compute_tcgen05_a_tmem_params(A_region)
+        b_params = self.compute_tcgen05_b_desc_params(B_region)
+        c_params = self.compute_tcgen05_c_tmem_params(C_region)
         instr_desc = self.compute_tcgen05_instr_desc()
 
-        # Resolve the TMEM data pointer for A
-        if isinstance(A_buf, BufferRegion):
-            a_tmem_data = A_buf.buffer.data
-        elif isinstance(A_buf, Buffer):
-            a_tmem_data = A_buf.data
-        else:
-            raise ValueError(f"Unsupported A_buf type for TS variant: {type(A_buf)}")
-
         @T.macro
-        def _warp_mma_ts(a_data, B_buf, C_local_buf, mbar):
+        def _warp_mma_ts(B_region, mbar):
             desc_b = T.alloc_tcgen05_smem_desc()
-            self.init_tcgen05_b_desc(desc_b, B_buf, b_params)
+            self.init_tcgen05_b_desc(desc_b, B_region, b_params)
 
             for j in T.unroll(num_inst_n):
                 for i in T.unroll(num_inst_m):
                     for ki in T.unroll(0, num_k_atoms):
-                        self.tcgen05_ts_atom(a_data, desc_b, C_local_buf, i, j, ki, b_params, instr_desc, clear_accum)
-            self.tcgen05_atom_arrive(mbar)
+                        self.tcgen05_ts_atom(desc_b, i, j, ki, a_params, b_params, c_params, instr_desc, clear_accum)
+            if mbar is not None:
+                self.tcgen05_atom_arrive(mbar)
 
-        return _warp_mma_ts(a_tmem_data, B_buf, C_local_buf, mbar)
+        return _warp_mma_ts(B_region, mbar)
 
     def tcgen05mma_blockscaled(
         self,
-        A_buf: Buffer,
-        B_buf: Buffer,
-        C_local_buf: Buffer,
+        A_region: BufferRegion,
+        B_region: BufferRegion,
+        C_region: BufferRegion,
         SFA_tmem,
         SFB_tmem,
         mbar,
@@ -414,15 +560,8 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         a_is_k_major = not self.a_transposed
         b_is_k_major = self.b_transposed
 
-        if len(self.meta) != 5:
-            self.get_tcgen5_mma_meta(m_dim, n_dim, k_dim, disable_2cta=False, disable_ws=True)
-        if len(self.meta) != 5:
-            raise ValueError(
-                f"Unsupported TCGEN5MMA configuration for block-scaled: M={m_dim}, N={n_dim}, "
-                f"K={k_dim}, A dtype={self.a_dtype}, accum dtype={self.accum_dtype}"
-            )
-        atom_m, atom_n, _, _, enable_2cta = self.tcgen05_meta_unpacked
-        atom_m_per_cta = atom_m // 2 if enable_2cta else atom_m
+        meta = self.tcgen05_meta
+        self.validate_tcgen05_operand_regions(A_region, B_region, C_region, is_ts=False)
 
         # CuTe builds the block-scaled A descriptor with FrgTypeA =
         # UMMA::smem_desc<a_major>, i.e. the *same* make_umma_desc as the regular
@@ -431,12 +570,13 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         # (which also handles a sliced A operand) rather than re-deriving SBO/LBO
         # from atom_m_per_cta. The per-atom M stepping in tcgen05_blockscaled_atom
         # walks within the whole-tile descriptor exactly as tcgen05_ss_atom does.
-        a_params = self.compute_tcgen05_a_desc_params(A_buf)
-        b_params = self.compute_tcgen05_b_desc_params(B_buf)
+        a_params = self.compute_tcgen05_a_desc_params(A_region)
+        b_params = self.compute_tcgen05_b_desc_params(B_region)
+        c_params = self.compute_tcgen05_c_tmem_params(C_region)
 
         base_instr_desc = self.get_tcgen5_blockscaled_instr_desc(
-            atom_m,
-            atom_n,
+            meta.atom_m,
+            meta.atom_n,
             a_is_k_major,
             b_is_k_major,
             1,
@@ -445,30 +585,19 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
             0,
         )
 
-        num_inst_m = m_dim // atom_m_per_cta
-        num_inst_n = n_dim // atom_n
+        num_inst_m = m_dim // meta.atom_m_per_cta
+        num_inst_n = n_dim // meta.atom_n
         num_k_atoms = self.tcgen05_num_k_atoms
 
-        if isinstance(SFA_tmem, BufferRegion):
-            sfa_data = SFA_tmem.buffer.data
-        elif isinstance(SFA_tmem, Buffer):
-            sfa_data = SFA_tmem.data
-        else:
-            raise ValueError(f"Unsupported SFA_tmem type: {type(SFA_tmem)}")
-
-        if isinstance(SFB_tmem, BufferRegion):
-            sfb_data = SFB_tmem.buffer.data
-        elif isinstance(SFB_tmem, Buffer):
-            sfb_data = SFB_tmem.data
-        else:
-            raise ValueError(f"Unsupported SFB_tmem type: {type(SFB_tmem)}")
+        sfa_data = self._as_buffer(SFA_tmem).data
+        sfb_data = self._as_buffer(SFB_tmem).data
 
         @T.macro
-        def _warp_mma_blockscaled(A_buf, B_buf, C_local_buf, sfa_data, sfb_data, mbar):
+        def _warp_mma_blockscaled(A_region, B_region, sfa_data, sfb_data, mbar):
             desc_a = T.alloc_tcgen05_smem_desc()
             desc_b = T.alloc_tcgen05_smem_desc()
-            self.init_tcgen05_a_desc(desc_a, A_buf, a_params)
-            self.init_tcgen05_b_desc(desc_b, B_buf, b_params)
+            self.init_tcgen05_a_desc(desc_a, A_region, a_params)
+            self.init_tcgen05_b_desc(desc_b, B_region, b_params)
 
             _sf_k_start = tvm.tirx.const(sf_k_start, "int32") if isinstance(sf_k_start, int) else sf_k_start
             for j in T.unroll(num_inst_n):
@@ -480,7 +609,6 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
                         self.tcgen05_blockscaled_atom(
                             desc_a,
                             desc_b,
-                            C_local_buf,
                             sfa_data,
                             sfb_data,
                             i,
@@ -488,12 +616,13 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
                             ki,
                             a_params,
                             b_params,
+                            c_params,
                             runtime_instr_desc,
                             clear_accum,
                         )
             self.tcgen05_atom_arrive(mbar)
 
-        return _warp_mma_blockscaled(A_buf, B_buf, C_local_buf, sfa_data, sfb_data, mbar)
+        return _warp_mma_blockscaled(A_region, B_region, sfa_data, sfb_data, mbar)
 
     def get_tcgen5_blockscaled_instr_desc(
         self,
@@ -524,93 +653,26 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
     def make_mma_load_layout(self, local_buf: Buffer, matrix: str = "A") -> T.Fragment:
         raise NotImplementedError
 
-    def make_mma_store_layout(self, tmem_buf: Buffer) -> Layout:
-        """
-        Create the TCGEN5 tensor-memory layout used to store MMA accumulators.
+    def make_mma_store_layout(self, tmem_buf: Buffer, *, operand: str = "C", is_ts: bool = False) -> Layout:
+        """Create the TMEM layout of one TCGEN5MMA operand for the layout map.
 
-        Parameters
-        ----------
-        tmem_buf : tir.Buffer
-            The local buffer representing tensormemory of a mma's output
+        Requires ``self.meta`` initialized via ``get_tcgen5_mma_meta()``; the
+        selected instruction atom decides the fragment.
 
-        Returns
-        -------
-        Layout
-            Layout object describing how logical (i, j) coordinates map to the
-            swizzled tensor-memory offsets required by TCGEN5MMA.
-
-        Raises
-        ------
-        AssertionError
-            If `tmem_buf` is not detected to be a tensor-memory buffer.
+        ``operand="A"`` builds the dense TS ``FrgTypeA`` (CuTe
+        ``tmem_frg_{1,2}sm<A, A, ...>``): 16-bit A remains expressed in value
+        columns here; two such columns are packed into one raw b32 TMEM
+        column only when an MMA atom address is formed.  ``operand="C"``
+        builds the accumulator ``FrgTypeC``; ``is_ts`` selects the TS traits'
+        allocation mode when the GEMM's A operand also lives in TMEM.
         """
         assert is_tensor_memory(tmem_buf), "tmem_buf must reside in tensor memory (shared.tmem)"
-        if len(tmem_buf.shape) != 2:
-            raise ValueError(f"TCGEN5MMA expects a 2-D tensor-memory buffer, got shape {tmem_buf.shape}")
-
-        m = int(tmem_buf.shape[0])
-        n = int(tmem_buf.shape[1])
-        k = int(self.chunk)
-
-        meta = getattr(self, "meta", ())
-        if len(meta) != 5:
-            self.get_tcgen5_mma_meta(m, n, k, disable_2cta=True)
-            meta = self.meta
-        if len(meta) != 5:
-            raise ValueError(
-                f"Unsupported TCGEN5MMA configuration: M={m}, N={n}, K={k}, A dtype={self.a_dtype}, accum dtype={self.accum_dtype}"
-            )
-        atom_m, atom_n, _, _, enable_2cta = (int(x) for x in meta)
-        atom_m_per_cta = atom_m // 2 if enable_2cta else atom_m
-
-        if m % atom_m_per_cta != 0 or n % atom_n != 0:
-            raise ValueError(f"Invalid TCGEN5MMA store layout for shape ({m}, {n}) with atoms ({atom_m}, {atom_n})")
-
-        def forward(i: PrimExpr, j: PrimExpr):
-            atom_idx = (i // atom_m_per_cta) + (j // atom_n) * (m // atom_m_per_cta)
-            ai = i % atom_m_per_cta
-            aj = j % atom_n
-
-            # NOTE: Currently not all 7 layout are supported
-            if atom_m == 256:
-                # Layout A (2 cta)
-                assert enable_2cta, "atom_m=256 for TCGEN5MMA must use 2cta"
-                return [
-                    ai % 128,
-                    aj + atom_idx * atom_n,
-                ]
-            if atom_m == 128:
-                if enable_2cta:
-                    # Layout B
-                    half_atom_n = atom_n // 2
-                    return [
-                        ai + (aj // half_atom_n) * 64,
-                        (aj % half_atom_n) + atom_idx * half_atom_n,
-                    ]
-                else:
-                    # Layout D
-                    return [
-                        ai,
-                        aj + atom_idx * atom_n,
-                    ]
-            if atom_m == 64:
-                # Layout E (.ws variant)
-                half_atom_n = atom_n // 2
-                return [
-                    (ai // 32) * 32 + ai % 32 + (aj // half_atom_n) * 64,
-                    (aj % half_atom_n) + atom_idx * half_atom_n,
-                ]
-            if atom_m == 32:
-                # Layout G
-                quarter_atom_n = atom_n // 4
-                return [
-                    ai % 32 + (aj // quarter_atom_n) * 32,
-                    (aj % quarter_atom_n) + atom_idx * quarter_atom_n,
-                ]
-
-            raise ValueError(f"Unsupported TCGEN5 atom_m={atom_m}")
-
-        return Layout([m, n], forward)
+        assert operand in ("A", "C"), f"TCGEN5MMA TMEM operand must be A or C, got {operand}"
+        if operand == "A" or is_ts:
+            validate_tcgen05_ts_instruction(self.tcgen05_meta, self.a_dtype, self.a_transposed)
+        if operand == "A":
+            return make_tmem_frg_a(tmem_buf, self.tcgen05_meta).to_tilelang()
+        return make_tmem_frg_c(tmem_buf, self.tcgen05_meta, is_ts=is_ts).to_tilelang()
 
     def get_tcgen5_mma_meta(self, m: int, n: int, k: int, disable_2cta: bool, disable_ws: bool = False):
         """Query the FFI for TCGEN5MMA atom metadata (atom_m, atom_n, atom_k, enable_ws, enable_2cta), and record them in `self.meta`."""
@@ -645,26 +707,23 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
     # ---- Atom-level interface ----
 
     @property
-    def tcgen05_meta_unpacked(self) -> tuple:
-        """Return ``(atom_m, atom_n, atom_k, enable_ws, enable_2cta)`` as ints.
+    def tcgen05_meta(self) -> TCGEN05Meta:
+        """The selected instruction atom, as named fields.
 
         Requires ``self.meta`` to have been set via ``get_tcgen5_mma_meta()``.
         """
         assert len(self.meta) == 5, "TCGEN05 meta not initialized; call get_tcgen5_mma_meta() first"
-        return tuple(int(x) for x in self.meta)
+        return TCGEN05Meta.from_ffi(self.meta)
 
     @property
     def tcgen05_num_inst_m(self) -> int:
         """Number of TCGEN05MMA instruction atoms along M (SS variant)."""
-        atom_m, _, _, _, enable_2cta = self.tcgen05_meta_unpacked
-        atom_m_per_cta = atom_m // 2 if enable_2cta else atom_m
-        return self.block_row_warps * self.warp_row_tiles // atom_m_per_cta
+        return self.block_row_warps * self.warp_row_tiles // self.tcgen05_meta.atom_m_per_cta
 
     @property
     def tcgen05_num_inst_n(self) -> int:
         """Number of TCGEN05MMA instruction atoms along N."""
-        _, atom_n, _, _, _ = self.tcgen05_meta_unpacked
-        return self.block_col_warps * self.warp_col_tiles // atom_n
+        return self.block_col_warps * self.warp_col_tiles // self.tcgen05_meta.atom_n
 
     @property
     def tcgen05_num_k_atoms(self) -> int:
@@ -805,16 +864,16 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
 
         Requires ``self.meta`` to have been set via ``get_tcgen5_mma_meta()``.
         """
-        atom_m, atom_n, atom_k, _, _ = self.tcgen05_meta_unpacked
+        meta = self.tcgen05_meta
         a_is_k_major = not self.a_transposed
         b_is_k_major = self.b_transposed
-        return self.get_tcgen5_instr_desc(atom_m, atom_n, atom_k, a_is_k_major, b_is_k_major, 1, 1)
+        return self.get_tcgen5_instr_desc(meta.atom_m, meta.atom_n, meta.atom_k, a_is_k_major, b_is_k_major, 1, 1)
 
     # -- Arrive --
 
     def tcgen05_atom_arrive(self, mbar):
         """Emit ``tcgen05_mma_arrive(mbar)``."""
-        _, _, _, _, enable_2cta = self.tcgen05_meta_unpacked
+        enable_2cta = self.tcgen05_meta.enable_2cta
 
         @T.macro
         def _arrive(mbar):
@@ -828,12 +887,12 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         self,
         desc_a,
         desc_b,
-        C_local_buf: Buffer,
         inst_m_idx: int,
         inst_n_idx: int,
         ki: int,
         a_params: TCGEN05DescriptorParams,
         b_params: TCGEN05DescriptorParams,
+        c_params: TCGEN05TensorMemoryParams,
         instr_desc: PrimExpr,
         clear_accum: PrimExpr = False,
     ):
@@ -845,8 +904,6 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         ----------
         desc_a, desc_b : Buffer
             Initialized A and B descriptors.
-        C_local_buf : Buffer
-            Accumulator buffer in tensor memory.
         inst_m_idx : int
             M-dimension atom index (0 .. tcgen05_num_inst_m - 1).
         inst_n_idx : int
@@ -857,19 +914,22 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
             Pre-computed A descriptor parameters.
         b_params : TCGEN05DescriptorParams
             Pre-computed B descriptor parameters.
+        c_params : TCGEN05TensorMemoryParams
+            Pre-computed accumulator TMEM parameters from
+            ``compute_tcgen05_c_tmem_params()``.
         instr_desc : PrimExpr
             Instruction descriptor from ``compute_tcgen05_instr_desc()``.
         clear_accum : PrimExpr
             Whether to zero the accumulator on the first K atom.
         """
-        atom_m, atom_n, _, enable_ws, enable_2cta = self.tcgen05_meta_unpacked
-        atom_m_per_cta = atom_m // 2 if enable_2cta else atom_m
+        meta = self.tcgen05_meta
+        atom_n = meta.atom_n
+        atom_m_per_cta = meta.atom_m_per_cta
         n_dim = self.block_col_warps * self.warp_col_tiles
-        n_dim_per_cta = n_dim // 2 if enable_2cta else n_dim
+        n_dim_per_cta = n_dim // 2 if meta.enable_2cta else n_dim
         m_dim = self.block_row_warps * self.warp_row_tiles
         micro_size_k = self.micro_size_k
         k_dim = self.chunk
-        accum_dtype_in_bits = get_tvm_dtype(self.accum_dtype).bits
         a_dtype_abbrv = self.a_dtype_abbrv
         a_elem_bits = a_params.elem_bits
         b_elem_bits = b_params.elem_bits
@@ -902,11 +962,11 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
 
         A_byte_offset = _elements_to_bytes(A_elem_offset, a_elem_bits)
         B_byte_offset = _elements_to_bytes(B_elem_offset, b_elem_bits)
-        tmem_col_step = atom_n // (128 // atom_m_per_cta)
-        C_offset = (inst_m_idx * n_dim + inst_n_idx * tmem_col_step) * accum_dtype_in_bits // 32
+        C_offset = c_params.atom_offset(inst_m_idx * atom_m_per_cta, inst_n_idx * atom_n)
+        c_data = c_params.data
 
         @T.macro
-        def _ss_atom(desc_a, desc_b, C_local_buf):
+        def _ss_atom(desc_a, desc_b):
             scale_out = T.Select(ki != 0, 1, T.Select(clear_accum, 0, 1))
             T.ptx_tcgen05_mma_ss(
                 a_dtype_abbrv,
@@ -914,7 +974,7 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
                 A_byte_offset,
                 desc_b.data,
                 B_byte_offset,
-                C_local_buf.data,
+                c_data,
                 C_offset,
                 instr_desc,
                 scale_out,
@@ -922,21 +982,21 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
                 mask_zero,
                 mask_zero,
                 mask_zero,
-                enable_ws,
-                enable_2cta,
+                meta.enable_ws,
+                meta.enable_2cta,
             )
 
-        return _ss_atom(desc_a, desc_b, C_local_buf)
+        return _ss_atom(desc_a, desc_b)
 
     def tcgen05_ts_atom(
         self,
-        a_tmem_data,
         desc_b,
-        C_local_buf: Buffer,
         inst_m_idx: int,
         inst_n_idx: int,
         ki: int,
+        a_params: TCGEN05TensorMemoryParams,
         b_params: TCGEN05DescriptorParams,
+        c_params: TCGEN05TensorMemoryParams,
         instr_desc: PrimExpr,
         clear_accum: PrimExpr = False,
     ):
@@ -946,45 +1006,41 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
 
         Parameters
         ----------
-        a_tmem_data : Var
-            Data pointer for the A operand in tensor memory (e.g., ``A_buf.data``).
         desc_b : Buffer
             Initialized B descriptor.
-        C_local_buf : Buffer
-            Accumulator buffer in tensor memory.
         inst_m_idx : int
             M-dimension atom index.
         inst_n_idx : int
             N-dimension atom index.
         ki : int
             K-dimension atom index.
+        a_params : TCGEN05TensorMemoryParams
+            Pre-computed A TMEM parameters from
+            ``compute_tcgen05_a_tmem_params()``.
         b_params : TCGEN05DescriptorParams
             Pre-computed B descriptor parameters.
+        c_params : TCGEN05TensorMemoryParams
+            Pre-computed accumulator TMEM parameters from
+            ``compute_tcgen05_c_tmem_params()``.
         instr_desc : PrimExpr
             Instruction descriptor from ``compute_tcgen05_instr_desc()``.
         clear_accum : PrimExpr
             Whether to zero the accumulator on the first K atom.
         """
-        atom_m, atom_n, atom_k, _, enable_2cta = self.tcgen05_meta_unpacked
-        atom_m_per_cta = atom_m // 2 if enable_2cta else atom_m
+        meta = self.tcgen05_meta
+        atom_n = meta.atom_n
+        atom_m_per_cta = meta.atom_m_per_cta
         n_dim = self.block_col_warps * self.warp_col_tiles
-        n_dim_per_cta = n_dim // 2 if enable_2cta else n_dim
+        n_dim_per_cta = n_dim // 2 if meta.enable_2cta else n_dim
         micro_size_k = self.micro_size_k
         k_dim = self.chunk
-        a_dtype_in_bits = get_tvm_dtype(self.a_dtype).bits
-        accum_dtype_in_bits = get_tvm_dtype(self.accum_dtype).bits
         a_dtype_abbrv = self.a_dtype_abbrv
         b_elem_bits = b_params.elem_bits
         bk_atom_size = b_params.k_atom_size
         b_swizzle_atom_elems = b_params.swizzle_atom_elems
         mask_zero = T.cast(0, T.int32)
 
-        # TMEM column geometry for A
-        interleave = max(128 // atom_m, 1)
-        a_tmem_cols_per_k_atom = atom_k * a_dtype_in_bits // 32 // interleave
-        a_tmem_k_stride = k_dim * a_dtype_in_bits // 32 // interleave
-
-        A_tmem_offset = inst_m_idx * a_tmem_k_stride + ki * a_tmem_cols_per_k_atom
+        A_tmem_offset = a_params.atom_offset(inst_m_idx * atom_m_per_cta, ki * meta.atom_k)
 
         if b_params.is_k_major:
             B_elem_offset = (
@@ -998,11 +1054,12 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
             )
         B_byte_offset = _elements_to_bytes(B_elem_offset, b_elem_bits)
 
-        tmem_col_step = atom_n // (128 // atom_m_per_cta)
-        C_offset = (inst_m_idx * n_dim + inst_n_idx * tmem_col_step) * accum_dtype_in_bits // 32
+        C_offset = c_params.atom_offset(inst_m_idx * atom_m_per_cta, inst_n_idx * atom_n)
+        a_data = a_params.data
+        c_data = c_params.data
 
         @T.macro
-        def _ts_atom(a_data, desc_b, C_local_buf):
+        def _ts_atom(desc_b):
             scale_out = T.Select(ki != 0, 1, T.Select(clear_accum, 0, 1))
             T.ptx_tcgen05_mma_ts(
                 a_dtype_abbrv,
@@ -1010,7 +1067,7 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
                 A_tmem_offset,
                 desc_b.data,
                 B_byte_offset,
-                C_local_buf.data,
+                c_data,
                 C_offset,
                 instr_desc,
                 scale_out,
@@ -1018,16 +1075,15 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
                 mask_zero,
                 mask_zero,
                 mask_zero,
-                enable_2cta,
+                meta.enable_2cta,
             )
 
-        return _ts_atom(a_tmem_data, desc_b, C_local_buf)
+        return _ts_atom(desc_b)
 
     def tcgen05_blockscaled_atom(
         self,
         desc_a,
         desc_b,
-        C_local_buf: Buffer,
         sfa_data,
         sfb_data,
         inst_m_idx: int,
@@ -1035,6 +1091,7 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         ki: int,
         a_params: TCGEN05DescriptorParams,
         b_params: TCGEN05DescriptorParams,
+        c_params: TCGEN05TensorMemoryParams,
         instr_desc: PrimExpr,
         clear_accum: PrimExpr = False,
     ):
@@ -1044,28 +1101,28 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         ----------
         desc_a, desc_b : Buffer
             Initialized A and B descriptors.
-        C_local_buf : Buffer
-            Accumulator buffer in tensor memory.
         sfa_data, sfb_data : Var
             Scale factor data pointers in tensor memory.
         inst_m_idx, inst_n_idx, ki : int
             Atom indices.
         a_params, b_params : TCGEN05DescriptorParams
             Pre-computed descriptor parameters.
+        c_params : TCGEN05TensorMemoryParams
+            Pre-computed accumulator TMEM parameters from
+            ``compute_tcgen05_c_tmem_params()``.
         instr_desc : PrimExpr
             Block-scaled instruction descriptor (with SF IDs already encoded).
         clear_accum : PrimExpr
             Whether to zero the accumulator on the first K atom.
         """
-        atom_m, atom_n, _, _enable_ws, enable_2cta = self.tcgen05_meta_unpacked
-        del _enable_ws  # block-scaled TCGEN05 does not support .ws
-        atom_m_per_cta = atom_m // 2 if enable_2cta else atom_m
+        meta = self.tcgen05_meta  # block-scaled TCGEN05 does not support .ws
+        atom_n = meta.atom_n
+        atom_m_per_cta = meta.atom_m_per_cta
         n_dim = self.block_col_warps * self.warp_col_tiles
-        n_dim_per_cta = n_dim // 2 if enable_2cta else n_dim
+        n_dim_per_cta = n_dim // 2 if meta.enable_2cta else n_dim
         m_dim = self.block_row_warps * self.warp_row_tiles
         micro_size_k = self.micro_size_k
         k_dim = self.chunk
-        accum_dtype_in_bits = get_tvm_dtype(self.accum_dtype).bits
         a_dtype_abbrv = self.a_dtype_abbrv
         a_elem_bits = a_params.elem_bits
         b_elem_bits = b_params.elem_bits
@@ -1096,11 +1153,11 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
 
         A_byte_offset = _elements_to_bytes(A_elem_offset, a_elem_bits)
         B_byte_offset = _elements_to_bytes(B_elem_offset, b_elem_bits)
-        tmem_col_step = atom_n // (128 // atom_m_per_cta)
-        C_offset = (inst_m_idx * n_dim + inst_n_idx * tmem_col_step) * accum_dtype_in_bits // 32
+        C_offset = c_params.atom_offset(inst_m_idx * atom_m_per_cta, inst_n_idx * atom_n)
+        c_data = c_params.data
 
         @T.macro
-        def _bs_atom(desc_a, desc_b, C_local_buf, sfa_data, sfb_data):
+        def _bs_atom(desc_a, desc_b, sfa_data, sfb_data):
             scale_out = T.Select(ki != 0, 1, T.Select(clear_accum, 0, 1))
             T.ptx_tcgen05_mma_blockscaled_ss(
                 a_dtype_abbrv,
@@ -1108,7 +1165,7 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
                 A_byte_offset,
                 desc_b.data,
                 B_byte_offset,
-                C_local_buf.data,
+                c_data,
                 C_offset,
                 instr_desc,
                 scale_out,
@@ -1118,7 +1175,7 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
                 0,
                 0,
                 0,
-                enable_2cta,
+                meta.enable_2cta,
             )
 
-        return _bs_atom(desc_a, desc_b, C_local_buf, sfa_data, sfb_data)
+        return _bs_atom(desc_a, desc_b, sfa_data, sfb_data)

--- a/tilelang/cuda/op/gemm/gemm_tcgen05.py
+++ b/tilelang/cuda/op/gemm/gemm_tcgen05.py
@@ -113,9 +113,9 @@ class GemmTCGEN5(GemmBase):
         if self.is_gemm_ts():
             b_continuity = _shared_layout_continuity(self.B, b_is_k_major, self.K, int(self.B.shape[-1]))
             layouts = {
-                self.A: mma_emitter.make_mma_store_layout(self.A),
+                self.A: mma_emitter.make_mma_store_layout(self.A, operand="A"),
                 self.B: self.infer_shared_layout(self.B, b_continuity)(self.B),
-                self.C: mma_emitter.make_mma_store_layout(self.C),
+                self.C: mma_emitter.make_mma_store_layout(self.C, is_ts=True),
             }
             return layouts
         return {}
@@ -151,9 +151,14 @@ class GemmTCGEN5(GemmBase):
         )
 
         if self.A in layout_map:
-            mma_emitter._assign_a_shared_layout(layout_map[self.A])
+            if self.A.scope() == "shared.tmem":
+                mma_emitter._assign_a_tmem_layout(layout_map[self.A])
+            else:
+                mma_emitter._assign_a_shared_layout(layout_map[self.A])
         if self.B in layout_map:
             mma_emitter._assign_b_shared_layout(layout_map[self.B])
+        if self.C in layout_map:
+            mma_emitter._assign_c_tmem_layout(layout_map[self.C])
 
         if self.is_blockscaled:
             return self._lower_blockscaled(mma_emitter, thread_bounds, thread_index, mbar_phase_expr)
@@ -163,9 +168,11 @@ class GemmTCGEN5(GemmBase):
 
         annotations = getattr(self.gemm_node, "annotations", {})
         use_2cta = bool(annotations.get("use_2cta", 0))
+        if use_2cta and not self.is_tcgen05:
+            raise ValueError("2CTA TCGEN5MMA is only available through the explicit T.tcgen05_gemm(use_2cta=True) path")
         k = int(self.chunk)
         mma_emitter.get_tcgen5_mma_meta(int(self.M), int(self.N), k, disable_2cta=not use_2cta)
-        atom_m, atom_n, atom_k, enable_ws, enable_2cta = mma_emitter.meta
+        enable_2cta = mma_emitter.tcgen05_meta.enable_2cta
 
         if self.A.scope() not in {"shared", "shared.dyn", "shared.tmem"}:
             raise ValueError(f"Unsupported A scope for TCGEN5MMA: {self.A.scope()}")
@@ -177,10 +184,12 @@ class GemmTCGEN5(GemmBase):
             raise ValueError("TCGEN5MMA only accepts wg_wait in {0, -1}")
 
         mbar = self.mbar
-        if mbar is None:
-            raise ValueError("TCGEN5MMA requires a valid mbarrier")
+        if mbar is None and not self.is_tcgen05:
+            raise ValueError("Synchronous TCGEN5MMA requires a valid mbarrier")
 
-        mbarptr = retrieve_ptr(mbar, "rw")
+        # Explicit asynchronous TCGEN5MMA may intentionally omit a completion
+        # event, to allow manual coordination.
+        mbarptr = retrieve_ptr(mbar, "rw") if mbar is not None else None
 
         C_coords = self.C_coords
         if len(C_coords) != 2:
@@ -192,7 +201,7 @@ class GemmTCGEN5(GemmBase):
 
         A_shared = self.ARegion
         B_shared = self.BRegion
-        C_local = self.C
+        C_local = self.CRegion
         clear_accum = self.clear_accum
         mbar_phase = mbar_phase_expr if mbar_phase_expr is not None else 0
 
@@ -245,7 +254,7 @@ class GemmTCGEN5(GemmBase):
 
         A_shared = self.ARegion
         B_shared = self.BRegion
-        C_local = self.C
+        C_local = self.CRegion
         clear_accum = self.clear_accum
         SFA_tmem = self.SFARegion.buffer
         SFB_tmem = self.SFBRegion.buffer
@@ -264,7 +273,7 @@ class GemmTCGEN5(GemmBase):
             raise ValueError("Block-scaled GEMM requires sf_a_granularity_k and sf_b_granularity_k")
         k = int(self.chunk)
         mma_emitter.get_tcgen5_mma_meta(int(self.M), int(self.N), k, disable_2cta=not use_2cta, disable_ws=True)
-        _atom_m, _atom_n, _atom_k, _enable_ws, enable_2cta = (int(x) for x in mma_emitter.meta)
+        enable_2cta = mma_emitter.tcgen05_meta.enable_2cta
 
         analyzer = Analyzer()
         warp_size = 32

--- a/tilelang/ir.py
+++ b/tilelang/ir.py
@@ -174,3 +174,21 @@ def span_coverage(func) -> dict:
     for _, buffer in func.buffer_map.items():
         count_buffer(buffer)
     return {"stmts": stmts, "buffers": buffers}
+
+
+@tvm_ffi.register_object("tl.Tcgen05Meta")
+class Tcgen05Meta(Node, Scriptable):
+    """One tcgen05.ld/st data-movement shape: the per-warp single-issue
+    CUTLASS TV atom plus the wrapper's chaining limit."""
+
+    intrinsics_name: str
+    max_chunks: int
+
+
+@tvm_ffi.register_object("tl.Tcgen05CopyPlan")
+class Tcgen05CopyPlan(Node, Scriptable):
+    """The tiled copy of one TMEM tile built by tl.ExpandTcgen05Layout."""
+
+    num_chunks_each_wg: int
+    num_issues: int
+    vals_per_issue: int

--- a/tilelang/language/allocate.py
+++ b/tilelang/language/allocate.py
@@ -257,7 +257,10 @@ def alloc_tmem(shape: ShapeType, dtype: DType) -> Buffer:
         - The number of columns allocated should not increase between any two allocations in the execution order within the CTA.
 
     Args:
-        num_cols (int): Number of columns to allocate in TMEM. Must be a power of 2 and >= 32 but less than or equal to 512.
+        shape (ShapeType): Logical buffer shape.  The last two modes are the
+            matrix modes; any leading modes are batch dimensions that repeat
+            the buffer along TMEM columns.
+        dtype (DType): Element data type.
 
     Returns:
         T.Buffer: A TVM buffer object allocated in TMEM scope, suitable for use as an accumulator or operand in TCGEN5.MMA operations.
@@ -268,7 +271,10 @@ def alloc_tmem(shape: ShapeType, dtype: DType) -> Buffer:
           Use ``T.deallocate_tmem`` only when you need an earlier, explicit release.
     """
 
-    assert len(shape) == 2, "shape must be a 2D tensor for TMEM allocation"
+    # The last two modes are the matrix modes; leading modes are batch
+    # dimensions (for example a software-pipeline stage) that repeat the
+    # accumulator along TMEM columns.
+    assert len(shape) >= 2, "shape must be a 2D or higher tensor for TMEM allocation"
     return _with_span(T.sblock_alloc_buffer(shape, dtype, scope="shared.tmem"))
 
 

--- a/tilelang/language/gemm_op.py
+++ b/tilelang/language/gemm_op.py
@@ -65,24 +65,16 @@ def _gemm_impl(
     B_shape = retrieve_shape(B_region)
     C_shape = retrieve_shape(C_region)
 
-    A_stride = retrieve_stride(A_region)
-    B_stride = retrieve_stride(B_region)
-
-    assert len(C_shape) == 2, "current only support C as a 2D tensor"
+    assert len(C_shape) >= 2, "current only support C as a 2D or higher-order tensor"
     assert len(A_shape) >= 2, "current only support A as a 2D or higher-order tensor"
     assert len(B_shape) >= 2, "current only support B as a 2D or higher-order tensor"
-    if len(A_shape) > 2:
-        for i in range(len(A_shape) - 2):
-            assert A_shape[i] == 1, (
-                "current only support A as a 2D or higher-order tensor with the last two dimensions being the matrix dimensions"
-            )
-    if len(B_shape) > 2:
-        for i in range(len(B_shape) - 2):
-            assert B_shape[i] == 1, (
-                "current only support B as a 2D or higher-order tensor with the last two dimensions being the matrix dimensions"
+    for shape, name in ((A_shape, "A"), (B_shape, "B"), (C_shape, "C")):
+        for i in range(len(shape) - 2):
+            assert shape[i] == 1, (
+                f"current only support {name} as a 2D or higher-order tensor with the last two dimensions being the matrix dimensions"
             )
 
-    M, N = C_shape
+    M, N = C_shape[-2], C_shape[-1]
     M_A = A_shape[-1] if transpose_A else A_shape[-2]
     K = A_shape[-2] if transpose_A else A_shape[-1]
     N_B = B_shape[-2] if transpose_B else B_shape[-1]
@@ -96,9 +88,15 @@ def _gemm_impl(
     else:
         assert prim_expr_equal(N_B, N), f"T.gemm N shape check failed: N_B = {N_B}, N_C = {N}"
 
+    # Deprecated: every lowering consumes the complete operand BufferRegions,
+    # so the serialized per-axis strides and final-axis offsets below are no
+    # longer read in-tree and are NOT validated (the historic
+    # ``A_offset[-2] == 0`` assertions are gone).  They are kept in the call
+    # protocol only for out-of-tree consumers of the GemmNode fields.
+    A_stride = retrieve_stride(A_region)
+    B_stride = retrieve_stride(B_region)
     stride_a = A_stride[-2]
     stride_b = B_stride[-2]
-
     A_offset = retrieve_offset(A_region)
     B_offset = retrieve_offset(B_region)
     offset_a = A_offset[-1]
@@ -109,7 +107,7 @@ def _gemm_impl(
             f"mbar for tcgen5mma must be a tirx.Buffer or tirx.BufferLoad, but got {type(mbar)}"
         )
         mbar = to_buffer_region(mbar, access_type="rw")
-    C_coords = [r.min for r in C_region.region]
+    C_coords = [r.min for r in C_region.region[-2:]]
     # Convert BufferRegion to tl.region calls for arguments
     A_arg = buffer_region_to_tile_region(A_region, "r", [r for r in A_shape])
     B_arg = buffer_region_to_tile_region(B_region, "r", [r for r in B_shape])
@@ -240,7 +238,7 @@ def tcgen05_gemm(
     policy: GemmWarpPolicy = GemmWarpPolicy.Square,
     clear_accum: bool = False,
     *,
-    mbar: BarrierType,
+    mbar: BarrierType | None,
     use_2cta: bool = False,
 ) -> tirx.PrimExpr:
     """Explicit Blackwell TCGEN05 GEMM without an implicit wait.
@@ -249,6 +247,10 @@ def tcgen05_gemm(
     default synchronous `T.gemm(...)` interface, with two stricter guarantees:
     - it always requests the TCGEN5MMA lowering path
     - it never auto-emits an inlined `mbarrier_wait_parity`
+
+    ``mbar=None`` omits the completion arrival for an intermediate issue.  A
+    later TCGEN05 operation remains ordered in the same issue stream and may
+    publish the completion event for the whole sequence.
 
     When ``use_2cta=True``, the instruction is lowered to the 2CTA variant
     which requires ``cluster_dims`` to be ``(2,1,1)`` or ``(1,2,1)``.
@@ -378,11 +380,12 @@ def tcgen05_gemm_blockscaled(
     else:
         assert prim_expr_equal(N_B, N), f"T.tcgen05_gemm_blockscaled N shape check failed: N_B = {N_B}, N_C = {N}"
 
+    # Deprecated: kept in the call protocol only for out-of-tree consumers;
+    # not read or validated in-tree.
     A_stride = retrieve_stride(A_region)
     B_stride = retrieve_stride(B_region)
     stride_a = A_stride[-2]
     stride_b = B_stride[-2]
-
     A_offset = retrieve_offset(A_region)
     B_offset = retrieve_offset(B_region)
     offset_a = A_offset[-1]
@@ -483,6 +486,8 @@ def make_blockscaled_gemm_layout(
         warp_col_tiles=N,
         chunk=K,
     )
+    # Block-scaled GEMM is 1CTA dense (no .ws), matching _lower_blockscaled.
+    emitter.get_tcgen5_mma_meta(M, N, K, disable_2cta=True, disable_ws=True)
 
     c_buf = C_region.buffer if isinstance(C_region, tirx.BufferRegion) else C
     return emitter.make_mma_store_layout(c_buf)

--- a/tilelang/layout/cute.py
+++ b/tilelang/layout/cute.py
@@ -65,6 +65,10 @@ class Swizzle(Node, Scriptable):
     def to_swizzle_mode(self) -> SwizzleMode:
         return _cute_ffi_api.swizzle_to_swizzle_mode(self)
 
+    @staticmethod
+    def parse(text: str) -> Swizzle:
+        return _cute_ffi_api.swizzle_parse(text)
+
 
 @tvm_ffi.register_object("tl.cute.IntTuple")
 class IntTuple(Node, Scriptable):
@@ -80,6 +84,10 @@ class IntTuple(Node, Scriptable):
     def __rmul__(self, other: IntTupleLike) -> IntTuple:
         return _cute_ffi_api.int_tuple_mul(from_python(other), self)
 
+    @staticmethod
+    def parse(text: str) -> IntTuple:
+        return _cute_ffi_api.int_tuple_parse(text)
+
 
 @tvm_ffi.register_object("tl.cute.IntTupleConst")
 class IntTupleConst(IntTuple):
@@ -88,7 +96,7 @@ class IntTupleConst(IntTuple):
 
 @tvm_ffi.register_object("tl.cute.IntTuplePrimExpr")
 class IntTuplePrimExpr(IntTuple):
-    value: object
+    value: PrimExpr
 
 
 @tvm_ffi.register_object("tl.cute.IntTupleScaledBasis")
@@ -116,6 +124,18 @@ class ScaledBasis:
     @property
     def mode(self) -> tuple:
         return self._mode
+
+    def __mul__(self, other: IntTupleLike) -> PyIntTuple:
+        return to_python(from_python(self) * from_python(other))
+
+    def __rmul__(self, other: IntTupleLike) -> PyIntTuple:
+        return to_python(from_python(other) * from_python(self))
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, ScaledBasis) and self._value == other._value and self._mode == other._mode
+
+    def __hash__(self) -> int:
+        return hash((self._value, self._mode))
 
     def __repr__(self) -> str:
         return "@".join([str(self._value), *(str(m) for m in reversed(self._mode))])
@@ -157,8 +177,27 @@ class Layout(Node, Scriptable):
         return _cute_ffi_api.with_shape(self, from_python(shape))
 
     @staticmethod
+    def parse(text: str) -> Layout:
+        return _cute_ffi_api.layout_parse(text)
+
+    @staticmethod
     def from_tilelang(layout) -> Layout | None:
         return _cute_ffi_api.layout_from_tilelang(layout)
+
+    @staticmethod
+    def from_tilelang_hierarchical(layout) -> Layout | None:
+        return _cute_ffi_api.layout_from_tilelang_hierarchical(layout)
+
+    def to_tilelang(self):
+        from .layout import Layout as TileLangLayout  # circular at module scope
+
+        shape = [size(self[i]) for i in range(rank(self))]
+
+        def forward(*coords):
+            result = self(tuple(coords))
+            return list(result) if isinstance(result, tuple) else [result]
+
+        return TileLangLayout(shape, forward)
 
 
 def rank(layout: Layout) -> int:
@@ -185,6 +224,10 @@ def right_inverse(layout: Layout) -> Layout:
     return _cute_ffi_api.right_inverse(layout)
 
 
+def left_inverse(layout: Layout) -> Layout:
+    return _cute_ffi_api.left_inverse(layout)
+
+
 def composition(lhs: Layout, rhs: Layout) -> Layout:
     return _cute_ffi_api.composition(lhs, rhs)
 
@@ -197,6 +240,14 @@ def congruent(a: IntTupleLike, b: IntTupleLike) -> bool:
     return bool(_cute_ffi_api.congruent(from_python(a), from_python(b)))
 
 
+def compatible(a: IntTupleLike, b: IntTupleLike) -> bool:
+    return bool(_cute_ffi_api.compatible(from_python(a), from_python(b)))
+
+
+def coshape(layout: Layout) -> PyIntTuple:
+    return to_python(_cute_ffi_api.coshape(layout))
+
+
 def cosize(layout: Layout) -> int:
     return to_python(_cute_ffi_api.cosize(layout))
 
@@ -207,6 +258,18 @@ def complement(layout: Layout, cotarget: int) -> Layout:
 
 def logical_divide(layout: Layout, tiler: Layout) -> Layout:
     return _cute_ffi_api.logical_divide(layout, tiler)
+
+
+def logical_product(block: Layout, tiler: Layout) -> Layout:
+    return _cute_ffi_api.logical_product(block, tiler)
+
+
+def tiled_product(block: Layout, tiler: Layout) -> Layout:
+    return _cute_ffi_api.tiled_product(block, tiler)
+
+
+def blocked_product(block: Layout, tiler: Layout) -> Layout:
+    return _cute_ffi_api.blocked_product(block, tiler)
 
 
 def make_layout(shape: IntTupleLike, stride=None) -> Layout:

--- a/tilelang/layout/cute.py
+++ b/tilelang/layout/cute.py
@@ -131,12 +131,6 @@ class ScaledBasis:
     def __rmul__(self, other: IntTupleLike) -> PyIntTuple:
         return to_python(from_python(other) * from_python(self))
 
-    def __eq__(self, other) -> bool:
-        return isinstance(other, ScaledBasis) and self._value == other._value and self._mode == other._mode
-
-    def __hash__(self) -> int:
-        return hash((self._value, self._mode))
-
     def __repr__(self) -> str:
         return "@".join([str(self._value), *(str(m) for m in reversed(self._mode))])
 


### PR DESCRIPTION
Previously support for TMEM in TileLang has always been restricted to 2D, row-major layouts, which prohibits sliced operands in TMEM ops e.g. `tcgen05.ld`.

This PR relaxes this constraint, by fully refactoring the TMEM-related logic with CuTe layouts. In CuTe, scaled bases are perfect for expressing hierarchical addresses like the 2D TMEM addresses. Currently, we use `@0` for TMEM rows and `@1` for TMEM columns. The CuTe layouts and TileLang layouts can be easily round-tripped.

Refactored `tcgen05_gemm` lowering and `tcgen05.ld/st` lowering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds CUDA support for arbitrary hierarchical TMEM layouts using CuTe layouts and scaled bases, with TMEM rows addressed by `@0` and columns by `@1`.
- Refactors TCGEN05 lowering and intrinsics to use CuTe-based layout algebra for hierarchical 2D TMEM addressing, sliced operands, and issue-specific TMEM addressing (including `tcgen05.ld/st` and `tcgen05_gemm`/`tcgen05_gemm_2cta` lowering changes).
- Reworks TCGEN05 metadata/copy planning around new CuTe layout algebra and FFI objects (`tl.Tcgen05Meta`, `tl.Tcgen05CopyPlan`), updating ld/st meta variants and the `ExpandTcgen05Layout` API.
- Extends CuTe layout utilities with parsing/printing, left-inverse/compatibility/coshape, product composition, and hierarchical recovery from TileLang layouts.
- Updates GEMM and TMEM APIs to operate on region-based operands with typed TMEM parameter plumbing, optional intermediate completion barriers, and stricter/explicit 2CTA validation for TCGEN05 paths.
- Updates SM100 tcgen05 MMA example/bench scripts (CLI-driven, unified TMEM ping-pong, conditional TMA-store routing) and adds extensive CUDA and layout/IR/lowering tests for operand layouts, sliced operands, TMEM copy roundtrips, and physical TMEM allocation sizing.

## C++ style / lint notes

- No changes to `docs/developer_guide/cpp_style.md` or CI/lint configuration files (e.g., `.github/`, `.circleci/`, `ci/`).
- This PR introduces/refactors C++ API/FFI and lowering logic, so the **C++ API Style Audit (warning only)** step is relevant; any TLCPP003/TLCPP004 warnings should be treated as advisory unless the new/changed API/FFI introduces a concrete maintainability or contract risk. Functional correctness/build confidence is covered by the expanded CUDA and layout test suites.

## Review / follow-ups

- Requested regression performance testing; also notes Rachmanino as an additional contact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->