### PR TITLE
[Metal] Add 16-byte alignment padding to shared/threadgroup memory

### DIFF
--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -372,6 +372,15 @@ void CodeGenTileLangMetal::VisitStmt_(const AllocBufferNode *op) {
     stream << "simdgroup_" << dtype_str << "8x8 " << vid << '['
            << constant_size / 64 << "];\n";
   } else {
+    // Apply 16-byte alignment padding to shared/threadgroup memory
+    // to avoid bank conflicts on Apple GPUs (following MLX practice).
+    // Apple GPU shared memory has banks of 16 bytes; padding prevents
+    // the same bank being accessed by multiple threads simultaneously.
+    if (scope == "shared" || scope == "threadgroup") {
+      int dtype_bytes = dtype.bytes();
+      int padding_elems = (dtype_bytes > 0) ? (16 / dtype_bytes) : 0;
+      constant_size += padding_elems;
+    }
     PrintStorageScope(scope, stream);
     PrintType(dtype, stream);
     stream << ' ' << vid << '[' << constant_size << "];\n";


### PR DESCRIPTION
Apple GPU shared memory banks are 16 bytes wide. Without padding,
concurrent access from multiple threads can hit the same bank,
causing serialization.

Following MLX's practice (`tgp_padding = 16 / sizeof(T)`), this adds
padding elements to align allocations to 16-byte boundaries when
allocating in shared/threadgroup scope.

- Only affects Metal backend (codegen_metal.cc)
- CUDA/HIP/CPU unchanged
- Reference: MLX `mlx/backend/metal/kernels/steel/gemm/gemm.h`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds 16-byte alignment padding to shared and threadgroup memory allocations in the Metal backend, matching MLX’s `tgp_padding` practice to reduce Apple GPU memory bank conflicts. Other backends remain unchanged.

## C++ style / lint notes

The change touches C++, but not rules documented in `docs/developer_guide/cpp_style.md`. The C++ API Style Audit (warning only) remains relevant; no new API or style risks are introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->