### PR TITLE
[BugFix] Honor nan_propagate in reduce max/min/absmax clear=False write-back

### DIFF
--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -528,7 +528,7 @@ MakeReduceOwnershipPlan(const Array<PrimExpr> &src_indices,
 inline PrimExpr MakeUpdate(const ReduceOpNode &op, PrimExpr dst_val,
                            PrimExpr src_val) {
   const bool use_nan_op = op.nan_propagate && (dst_val.dtype().is_float16() ||
-                                                dst_val.dtype().is_bfloat16());
+                                               dst_val.dtype().is_bfloat16());
   if (op.type->IsSum() || op.type->IsAbsSum()) {
     return dst_val + src_val;
   } else if (op.type->IsBitAnd()) {

--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -527,6 +527,8 @@ MakeReduceOwnershipPlan(const Array<PrimExpr> &src_indices,
 
 inline PrimExpr MakeUpdate(const ReduceOpNode &op, PrimExpr dst_val,
                            PrimExpr src_val) {
+  const bool use_nan_op = op.nan_propagate && (dst_val.dtype().is_float16() ||
+                                                dst_val.dtype().is_bfloat16());
   if (op.type->IsSum() || op.type->IsAbsSum()) {
     return dst_val + src_val;
   } else if (op.type->IsBitAnd()) {
@@ -536,9 +538,11 @@ inline PrimExpr MakeUpdate(const ReduceOpNode &op, PrimExpr dst_val,
   } else if (op.type->IsBitXor()) {
     return bitwise_xor(dst_val, src_val);
   } else if (op.type->IsMax() || op.type->IsAbsMax()) {
-    return Max(dst_val, src_val);
+    return use_nan_op ? Call(dst_val.dtype(), tl::max_nan(), {dst_val, src_val})
+                      : PrimExpr(Max(dst_val, src_val));
   } else if (op.type->IsMin()) {
-    return Min(dst_val, src_val);
+    return use_nan_op ? Call(dst_val.dtype(), tl::min_nan(), {dst_val, src_val})
+                      : PrimExpr(Min(dst_val, src_val));
   }
   LOG(FATAL) << "Unsupported reduce type: " << op.type->type;
   return PrimExpr();

--- a/testing/python/language/test_tilelang_language_reduce_maxmin_nan.py
+++ b/testing/python/language/test_tilelang_language_reduce_maxmin_nan.py
@@ -103,5 +103,83 @@ def test_reduce_min_runtime_nan_behavior():
         assert math.isnan(k_nan(a).float().item())
 
 
+# ---------------------------------------------------------------------------
+# clear=False path: the write-back merge (MakeUpdate) must also honor
+# nan_propagate.  See GH-2697.
+# ---------------------------------------------------------------------------
+
+
+def _make_reduce_clear_false_kernel(reduce_fn, length, dtype, *, nan_propagate):
+
+    @T.prim_func
+    def kernel(a: T.Tensor((length,), dtype), out: T.Tensor((1,), dtype)):
+        with T.Kernel(1, threads=32):
+            frag = T.alloc_fragment((length,), dtype)
+            out_frag = T.alloc_fragment((1,), dtype)
+            T.copy(a, frag)
+            # Seed the output fragment with -1 so the NaN test is meaningful.
+            out_frag[0] = -1.0
+            reduce_fn(frag, out_frag, clear=False, nan_propagate=nan_propagate)
+            T.copy(out_frag, out)
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_reduce_max_clear_false_nan_propagate():
+    """clear=False + nan_propagate=True must yield NaN (GH-2697)."""
+    for _, tl_dtype, torch_dtype in _DTYPES:
+        length = 64
+        a = torch.arange(length, dtype=torch.float32).to(torch_dtype).cuda()
+        a[7] = float("nan")
+
+        k_nan = _compile(_make_reduce_clear_false_kernel(T.reduce_max, length, tl_dtype, nan_propagate=True))
+        out = k_nan(a)
+        assert math.isnan(out.float().item()), (
+            f"{tl_dtype}: reduce_max clear=False nan_propagate=True should return NaN,"
+            f" got {out.item()}")
+
+        k_default = _compile(_make_reduce_clear_false_kernel(T.reduce_max, length, tl_dtype, nan_propagate=False))
+        out = k_default(a)
+        assert not math.isnan(out.float().item()), (
+            f"{tl_dtype}: reduce_max clear=False nan_propagate=False should not return NaN")
+
+
+@tilelang.testing.requires_cuda
+def test_reduce_min_clear_false_nan_propagate():
+    for _, tl_dtype, torch_dtype in _DTYPES:
+        length = 64
+        a = torch.arange(length, dtype=torch.float32).to(torch_dtype).cuda()
+        a[13] = float("nan")
+
+        k_nan = _compile(_make_reduce_clear_false_kernel(T.reduce_min, length, tl_dtype, nan_propagate=True))
+        out = k_nan(a)
+        assert math.isnan(out.float().item()), (
+            f"{tl_dtype}: reduce_min clear=False nan_propagate=True should return NaN,"
+            f" got {out.item()}")
+
+        k_default = _compile(_make_reduce_clear_false_kernel(T.reduce_min, length, tl_dtype, nan_propagate=False))
+        out = k_default(a)
+        assert not math.isnan(out.float().item())
+
+
+@tilelang.testing.requires_cuda
+def test_reduce_absmax_clear_false_nan_propagate():
+    for _, tl_dtype, torch_dtype in _DTYPES:
+        length = 64
+        a = torch.arange(length, dtype=torch.float32).to(torch_dtype).cuda()
+        a[13] = float("nan")
+
+        k_nan = _compile(_make_reduce_clear_false_kernel(T.reduce_absmax, length, tl_dtype, nan_propagate=True))
+        out = k_nan(a)
+        assert math.isnan(out.float().item()), (
+            f"{tl_dtype}: reduce_absmax clear=False nan_propagate=True should return NaN,"
+            f" got {out.item()}")
+
+        k_default = _compile(_make_reduce_clear_false_kernel(T.reduce_absmax, length, tl_dtype, nan_propagate=False))
+        out = k_default(a)
+        assert not math.isnan(out.float().item())
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/language/test_tilelang_language_reduce_maxmin_nan.py
+++ b/testing/python/language/test_tilelang_language_reduce_maxmin_nan.py
@@ -135,14 +135,11 @@ def test_reduce_max_clear_false_nan_propagate():
 
         k_nan = _compile(_make_reduce_clear_false_kernel(T.reduce_max, length, tl_dtype, nan_propagate=True))
         out = k_nan(a)
-        assert math.isnan(out.float().item()), (
-            f"{tl_dtype}: reduce_max clear=False nan_propagate=True should return NaN,"
-            f" got {out.item()}")
+        assert math.isnan(out.float().item()), f"{tl_dtype}: reduce_max clear=False nan_propagate=True should return NaN, got {out.item()}"
 
         k_default = _compile(_make_reduce_clear_false_kernel(T.reduce_max, length, tl_dtype, nan_propagate=False))
         out = k_default(a)
-        assert not math.isnan(out.float().item()), (
-            f"{tl_dtype}: reduce_max clear=False nan_propagate=False should not return NaN")
+        assert not math.isnan(out.float().item()), f"{tl_dtype}: reduce_max clear=False nan_propagate=False should not return NaN"
 
 
 @tilelang.testing.requires_cuda
@@ -154,9 +151,7 @@ def test_reduce_min_clear_false_nan_propagate():
 
         k_nan = _compile(_make_reduce_clear_false_kernel(T.reduce_min, length, tl_dtype, nan_propagate=True))
         out = k_nan(a)
-        assert math.isnan(out.float().item()), (
-            f"{tl_dtype}: reduce_min clear=False nan_propagate=True should return NaN,"
-            f" got {out.item()}")
+        assert math.isnan(out.float().item()), f"{tl_dtype}: reduce_min clear=False nan_propagate=True should return NaN, got {out.item()}"
 
         k_default = _compile(_make_reduce_clear_false_kernel(T.reduce_min, length, tl_dtype, nan_propagate=False))
         out = k_default(a)
@@ -173,8 +168,8 @@ def test_reduce_absmax_clear_false_nan_propagate():
         k_nan = _compile(_make_reduce_clear_false_kernel(T.reduce_absmax, length, tl_dtype, nan_propagate=True))
         out = k_nan(a)
         assert math.isnan(out.float().item()), (
-            f"{tl_dtype}: reduce_absmax clear=False nan_propagate=True should return NaN,"
-            f" got {out.item()}")
+            f"{tl_dtype}: reduce_absmax clear=False nan_propagate=True should return NaN, got {out.item()}"
+        )
 
         k_default = _compile(_make_reduce_clear_false_kernel(T.reduce_absmax, length, tl_dtype, nan_propagate=False))
         out = k_default(a)


### PR DESCRIPTION
### Problem

`T.reduce_max`/`T.reduce_min`/`T.reduce_absmax` with `clear=False` and
`nan_propagate=True` silently drops NaN: the write-back merge
(`MakeUpdate`) emits a plain `Max`/`Min` and never checks
`op.nan_propagate`, so NaN from the warp reduction is discarded when
merged into a pre-existing accumulator.

### Root cause

`src/backend/common/op/reduce.h`: `MakeUpdate` uses `Max(dst_val, src_val)`
/ `Min(dst_val, src_val)` for max/min/absmax without consulting
`op.nan_propagate`. The per-thread/warp `MakeReduce` path already honors
`use_nan_op` correctly; only the `clear=False` write-back path is affected.

### Fix

Add the same `use_nan_op` guard to `MakeUpdate` that `MakeReduce` already
has: emit `tl::max_nan()`/`tl::min_nan()` when `nan_propagate` is true
and the dtype is fp16 or bf16.

### Tests added

- `test_reduce_max_clear_false_nan_propagate`
- `test_reduce_min_clear_false_nan_propagate`
- `test_reduce_absmax_clear_false_nan_propagate`

Each tests both `nan_propagate=True` (expect NaN) and
`nan_propagate=False` (expect non-NaN) on the `clear=False` path
for fp16 and bf16.

Fixes #2697

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixes NaN propagation for `T.reduce_max`, `T.reduce_min`, and `T.reduce_absmax` when `clear=False` (fp16/bf16). The `MakeUpdate` write-back path now uses `tl::max_nan()` / `tl::min_nan()` (instead of plain max/min) when `nan_propagate=True`, ensuring NaNs are not discarded during accumulation merge.

## Tests

Added CUDA runtime coverage for `clear=False` NaN propagation for:
- `T.reduce_max`, `T.reduce_min`, and `T.reduce_absmax`
- `float16` and `bfloat16`
- Verifies `nan_propagate=True` produces NaN, while `nan_propagate=False` produces a non-NaN result.

## C++ style / lint notes

- Touches C++ reduction logic in `src/backend/common/op/reduce.h`; does not modify `docs/developer_guide/cpp_style.md` or C++/CI/lint configuration.
- As this is a correctness fix localized to existing reduction operations (no API/FFI/maintainability risk), any C++ API style issues should be limited to advisory-only checks; review the “C++ API Style Audit (warning only)” CI step for warnings, but no build/correctness regressions are implicated by the change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->