### PR TITLE
[BugFix] Prevent autotuner cache reuse across different outputs and validation settings

### DIFF
--- a/testing/python/autotune/test_autotune_cache_key.py
+++ b/testing/python/autotune/test_autotune_cache_key.py
@@ -1,6 +1,7 @@
 """Tests for auto-tuner cache-key identity."""
 
 import inspect
+import threading
 from dataclasses import replace
 
 from tilelang.autotuner import AutoTuner
@@ -9,13 +10,6 @@ from tilelang.autotuner.param import CompileArgs, ProfileArgs
 
 def _kernel(block_size=128):
     return block_size
-
-
-def _make_callback(offset):
-    def callback(value):
-        return value + offset
-
-    return callback
 
 
 def _cache_key(compile_args=None, profile_args=None):
@@ -32,18 +26,9 @@ def test_cache_key_includes_output_indices():
 
 
 def test_cache_key_includes_profile_validation_and_input_behavior():
-    base_args = ProfileArgs(
-        ref_prog=_make_callback(1),
-        supply_prog=_make_callback(2),
-        manual_check_prog=_make_callback(3),
-        skip_check=False,
-        cache_input_tensors=False,
-    )
+    base_args = ProfileArgs(skip_check=False, cache_input_tensors=False)
 
     variants = (
-        replace(base_args, ref_prog=_make_callback(4)),
-        replace(base_args, supply_prog=_make_callback(4)),
-        replace(base_args, manual_check_prog=_make_callback(4)),
         replace(base_args, skip_check=True),
         replace(base_args, cache_input_tensors=True),
     )
@@ -52,9 +37,12 @@ def test_cache_key_includes_profile_validation_and_input_behavior():
     assert all(base_key != _cache_key(profile_args=variant) for variant in variants)
 
 
-def test_cache_key_fingerprints_callback_content():
-    first_args = ProfileArgs(ref_prog=_make_callback(1))
-    equivalent_args = ProfileArgs(ref_prog=_make_callback(1))
+def test_cache_key_is_disabled_for_profile_callbacks():
+    lock = threading.Lock()
 
-    assert first_args.ref_prog is not equivalent_args.ref_prog
-    assert _cache_key(profile_args=first_args) == _cache_key(profile_args=equivalent_args)
+    def callback(value):
+        with lock:
+            return value
+
+    for callback_field in ("ref_prog", "supply_prog", "manual_check_prog"):
+        assert _cache_key(profile_args=ProfileArgs(**{callback_field: callback})) is None

--- a/testing/python/autotune/test_autotune_cache_key.py
+++ b/testing/python/autotune/test_autotune_cache_key.py
@@ -1,0 +1,60 @@
+"""Tests for auto-tuner cache-key identity."""
+
+import inspect
+from dataclasses import replace
+
+from tilelang.autotuner import AutoTuner
+from tilelang.autotuner.param import CompileArgs, ProfileArgs
+
+
+def _kernel(block_size=128):
+    return block_size
+
+
+def _make_callback(offset):
+    def callback(value):
+        return value + offset
+
+    return callback
+
+
+def _cache_key(compile_args=None, profile_args=None):
+    tuner = AutoTuner(_kernel, configs=[{"block_size": 128}])
+    tuner.compile_args = compile_args or CompileArgs()
+    tuner.profile_args = profile_args or ProfileArgs()
+    return tuner.generate_cache_key(inspect.signature(_kernel).parameters, {})
+
+
+def test_cache_key_includes_output_indices():
+    base_args = CompileArgs(out_idx=[0])
+
+    assert _cache_key(compile_args=base_args) != _cache_key(compile_args=replace(base_args, out_idx=[1]))
+
+
+def test_cache_key_includes_profile_validation_and_input_behavior():
+    base_args = ProfileArgs(
+        ref_prog=_make_callback(1),
+        supply_prog=_make_callback(2),
+        manual_check_prog=_make_callback(3),
+        skip_check=False,
+        cache_input_tensors=False,
+    )
+
+    variants = (
+        replace(base_args, ref_prog=_make_callback(4)),
+        replace(base_args, supply_prog=_make_callback(4)),
+        replace(base_args, manual_check_prog=_make_callback(4)),
+        replace(base_args, skip_check=True),
+        replace(base_args, cache_input_tensors=True),
+    )
+
+    base_key = _cache_key(profile_args=base_args)
+    assert all(base_key != _cache_key(profile_args=variant) for variant in variants)
+
+
+def test_cache_key_fingerprints_callback_content():
+    first_args = ProfileArgs(ref_prog=_make_callback(1))
+    equivalent_args = ProfileArgs(ref_prog=_make_callback(1))
+
+    assert first_args.ref_prog is not equivalent_args.ref_prog
+    assert _cache_key(profile_args=first_args) == _cache_key(profile_args=equivalent_args)

--- a/tilelang/autotuner/param.py
+++ b/tilelang/autotuner/param.py
@@ -41,6 +41,15 @@ PARAMS_PATH = "params.pkl"
 TargetLike = str | dict[str, object] | Target
 
 
+def _callable_fingerprint(func: Callable | None) -> str | None:
+    """Return a content-derived fingerprint for a profiling callback."""
+    if func is None:
+        return None
+    # Callable identity hashes are process-local. Serialize the callable's code
+    # and captured state so persistent cache keys follow its behavior instead.
+    return hashlib.sha256(cloudpickle.dumps(func)).hexdigest()
+
+
 @dataclass(frozen=True)
 class CompileArgs:
     """Compile arguments for the auto-tuner. Detailed description can be found in `tilelang.jit.compile`.
@@ -76,6 +85,7 @@ class CompileArgs:
     def __hash__(self):
         """Return a stable hash for cache key construction."""
         data = {
+            "out_idx": self.out_idx,
             "execution_backend": self.execution_backend,
             "target": str(self.target),
             "target_host": str(self.target_host) if self.target_host else None,
@@ -136,6 +146,11 @@ class ProfileArgs:
             "rtol": self.rtol,
             "atol": self.atol,
             "max_mismatched_ratio": self.max_mismatched_ratio,
+            "skip_check": self.skip_check,
+            "cache_input_tensors": self.cache_input_tensors,
+            "ref_prog": _callable_fingerprint(self.ref_prog),
+            "supply_prog": _callable_fingerprint(self.supply_prog),
+            "manual_check_prog": _callable_fingerprint(self.manual_check_prog),
         }
         hash_obj = hashlib.sha256(json.dumps(data, sort_keys=True).encode("utf-8"))
         return int.from_bytes(hash_obj.digest(), byteorder="big")

--- a/tilelang/autotuner/param.py
+++ b/tilelang/autotuner/param.py
@@ -41,15 +41,6 @@ PARAMS_PATH = "params.pkl"
 TargetLike = str | dict[str, object] | Target
 
 
-def _callable_fingerprint(func: Callable | None) -> str | None:
-    """Return a content-derived fingerprint for a profiling callback."""
-    if func is None:
-        return None
-    # Callable identity hashes are process-local. Serialize the callable's code
-    # and captured state so persistent cache keys follow its behavior instead.
-    return hashlib.sha256(cloudpickle.dumps(func)).hexdigest()
-
-
 @dataclass(frozen=True)
 class CompileArgs:
     """Compile arguments for the auto-tuner. Detailed description can be found in `tilelang.jit.compile`.
@@ -148,9 +139,6 @@ class ProfileArgs:
             "max_mismatched_ratio": self.max_mismatched_ratio,
             "skip_check": self.skip_check,
             "cache_input_tensors": self.cache_input_tensors,
-            "ref_prog": _callable_fingerprint(self.ref_prog),
-            "supply_prog": _callable_fingerprint(self.supply_prog),
-            "manual_check_prog": _callable_fingerprint(self.manual_check_prog),
         }
         hash_obj = hashlib.sha256(json.dumps(data, sort_keys=True).encode("utf-8"))
         return int.from_bytes(hash_obj.digest(), byteorder="big")

--- a/tilelang/autotuner/tuner.py
+++ b/tilelang/autotuner/tuner.py
@@ -454,8 +454,22 @@ class AutoTuner:
                     "Please provide concrete inputs with `with set_autotune_inputs(...)`."
                 )
 
-    def generate_cache_key(self, parameters: dict[str, Any], extra_parameters: dict[str, Any]) -> AutotuneResult | None:
+    def generate_cache_key(self, parameters: dict[str, Any], extra_parameters: dict[str, Any]) -> str | None:
         """Generate a cache key for the auto-tuning process."""
+
+        # Arbitrary callbacks do not have a reliable persistent identity:
+        # importable functions may serialize by name, while closures may hold
+        # unpicklable runtime state. Avoid cache reuse rather than risk serving
+        # results produced with different input or validation behavior.
+        if any(
+            callback is not None
+            for callback in (
+                self.profile_args.ref_prog,
+                self.profile_args.supply_prog,
+                self.profile_args.manual_check_prog,
+            )
+        ):
+            return None
 
         # extract parameters from the function signature
         op_parameters = []
@@ -997,7 +1011,7 @@ class AutoTuner:
         key = self.generate_cache_key(parameters, extra_parameters)
 
         with self._lock:
-            if env.is_cache_enabled() and not env.is_autotune_cache_disabled():
+            if key is not None and env.is_cache_enabled() and not env.is_autotune_cache_disabled():
                 # First check in-memory cache
                 if key in self._memory_cache:
                     # Include PrimFunc name when hitting autotuner memory cache
@@ -1077,7 +1091,8 @@ class AutoTuner:
                 # compile the kernel with the provided parameters
                 jit_kernel = self.jit_compile()
                 autotuner_result = AutotuneResult(libcode=jit_kernel.get_kernel_source(), func=jit_kernel.prim_func, kernel=jit_kernel)
-                self._memory_cache[key] = autotuner_result
+                if key is not None:
+                    self._memory_cache[key] = autotuner_result
                 return autotuner_result
 
         # After confirming tuning will actually run, validate that scalar
@@ -1283,10 +1298,11 @@ class AutoTuner:
             logger.warning("DLPack backend does not support cache saving to disk.")
         else:
             with self._lock:
-                if env.is_cache_enabled() and not env.is_autotune_cache_disabled():
+                if key is not None and env.is_cache_enabled() and not env.is_autotune_cache_disabled():
                     self._save_result_to_disk(key, autotuner_result)
 
-        self._memory_cache[key] = autotuner_result
+        if key is not None:
+            self._memory_cache[key] = autotuner_result
 
         return autotuner_result
 


### PR DESCRIPTION
Fixes #2791.

### Problem

The autotuner reused cache entries across settings that change compilation or correctness behavior:

| Setting | Behavior it controls | Previous cache identity |
| --- | --- | --- |
| `CompileArgs.out_idx` | Which arguments are returned as outputs | Omitted |
| `ProfileArgs.skip_check` | Whether correctness validation runs | Omitted |
| `ProfileArgs.cache_input_tensors` | Whether profiling inputs are reused | Omitted |
| Profile callbacks | Reference, input-supply, or manual-check behavior | No reliable identity |

Consequently, two requests with different output or validation contracts could produce the same key and become eligible to reuse the same memory or disk cache entry.

On the base revision, the three stable settings all collided:

```text
{'out_idx_collision': True, 'skip_check_collision': True, 'cache_input_collision': True}
```

### Change

- Include `out_idx`, `skip_check`, and `cache_input_tensors` in stable cache identity.
- Do not generate a reusable key when `ref_prog`, `supply_prog`, or `manual_check_prog` is present.
- Skip memory and disk cache reads and writes when no reliable key exists.

```mermaid
flowchart LR
    A["stable arguments"] --> K["content-derived key"]
    K --> C["memory/disk cache"]
    B["custom callback"] --> N["no reusable key"]
    N --> T["run tuning and validation"]
```

Arbitrary Python callbacks are intentionally not fingerprinted. Importable functions may serialize by module and name without capturing implementation changes, while closures may contain unpicklable runtime state. Re-running callback-driven tuning is the conservative behavior until the API provides an explicit callback-version contract.

### Regression coverage

The new tests verify that:

- different `out_idx` values produce different full autotuner keys;
- `skip_check` and `cache_input_tensors` change the key;
- all three callback fields disable reusable key generation, including a closure over unpicklable state.

### Validation

- `python -m pytest -q testing/python/autotune/test_autotune_cache_key.py` — `3 passed`
- `bash format.sh --files tilelang/autotuner/param.py tilelang/autotuner/tuner.py testing/python/autotune/test_autotune_cache_key.py` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Prevented autotuner cache-key collisions by including `out_idx`, `skip_check`, and `cache_input_tensors` in cache identity.
- Disabled memory and disk cache reuse when custom profiling callbacks are provided.
- Added regression tests covering cache-key differentiation and callback-based cache disabling.
- Validated with the autotune cache-key test suite and formatting checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->