### PR TITLE
[BugFix] Check shared-TMEM buffer pointer types before dereference

### DIFF
--- a/src/cuda/transform/lower_shared_tmem.cc
+++ b/src/cuda/transform/lower_shared_tmem.cc
@@ -146,8 +146,9 @@ private:
     for (const auto &[data, buffer] : buffer_map_) {
       const auto *ptr_type =
           buffer->data->type_annotation.as<PointerTypeNode>();
+      ICHECK(ptr_type) << "LowerSharedTmem requires buffer " << buffer->name
+                       << "'s data Var to have a PointerType annotation";
       auto storage_scope = ptr_type->storage_scope;
-      ICHECK(ptr_type) << "Buffer Var's type annotation must be of PointerType";
       if (storage_scope == "shared.tmem") {
         tmem_buffers.push_back(buffer);
       }

--- a/testing/python/transform/test_tilelang_transform_lower_shared_tmem.py
+++ b/testing/python/transform/test_tilelang_transform_lower_shared_tmem.py
@@ -1,4 +1,6 @@
 # ruff: noqa
+import pytest
+
 from tilelang import tvm as tvm
 import tilelang as tl
 import tilelang.language as T
@@ -89,7 +91,44 @@ def test_dealloc_before_thread_return_keeps_auto_dealloc():
     assert [call.args[1].value for call in dealloc_calls] == [128, 128]
 
 
+def test_untyped_buffer_reports_internal_error():
+    valid_buffer = tvm.tirx.decl_buffer((1,), name="malformed_buffer")
+    untyped_data = tvm.tirx.Var("malformed_buffer", "handle")
+    malformed_buffer = tvm.ir.make_node(
+        "tirx.Buffer",
+        data=untyped_data,
+        dtype=valid_buffer.dtype,
+        shape=valid_buffer.shape,
+        strides=valid_buffer.strides,
+        axis_separators=valid_buffer.axis_separators,
+        elem_offset=valid_buffer.elem_offset,
+        name=valid_buffer.name,
+        data_alignment=valid_buffer.data_alignment,
+        offset_factor=valid_buffer.offset_factor,
+        buffer_type=valid_buffer.buffer_type,
+        span=None,
+    )
+    block = tvm.tirx.SBlock(
+        iter_vars=[],
+        reads=[],
+        writes=[],
+        name_hint="root",
+        body=tvm.tirx.Evaluate(0),
+        alloc_buffers=[malformed_buffer],
+    )
+    func = tvm.tirx.PrimFunc([], block).with_attr("target", TARGET)
+    mod = tvm.IRModule.from_expr(func)
+
+    with pytest.raises(
+        tvm.error.InternalError,
+        match=r"LowerSharedTmem requires buffer malformed_buffer's data Var "
+        r"to have a PointerType annotation",
+    ):
+        tl.cuda.transform.LowerSharedTmem()(mod)
+
+
 if __name__ == "__main__":
     test_explicit_deallocate_tmem_suppresses_auto_dealloc()
     test_explicit_deallocate_only_suppresses_matching_buffer()
     test_dealloc_before_thread_return_keeps_auto_dealloc()
+    test_untyped_buffer_reports_internal_error()


### PR DESCRIPTION
Fixes #2792.

### Problem

`LowerSharedTmem` assumed every buffer data variable had a `PointerType` annotation, but checked that invariant only after dereferencing the result:

```text
ptr_type = data.type_annotation.as<PointerTypeNode>()
storage_scope = ptr_type->storage_scope   # dereference
ICHECK(ptr_type)                          # too late
```

A malformed or externally constructed TIRX buffer with an untyped handle therefore reached a null-pointer dereference instead of the intended compiler diagnostic.

### Change

Validate `ptr_type` before reading its storage scope and include the affected buffer name in the error:

```text
ptr_type = data.type_annotation.as<PointerTypeNode>()
ICHECK(ptr_type)                          # controlled InternalError
storage_scope = ptr_type->storage_scope
```

The normal lowering behavior for buffers with valid pointer annotations is unchanged.

### Regression coverage

The test constructs an `SBlock` allocation whose buffer data is an untyped handle, using TVM reflection to reach the malformed state. It then verifies that `LowerSharedTmem` raises:

```text
LowerSharedTmem requires buffer malformed_buffer's data Var to have a PointerType annotation
```

Without the reordered check, the same path dereferences `ptr_type` before an `ICHECK` can report the invariant violation.

### Validation

- CUDA-stub source build: `cmake --build build-cuda -j8` — passed
- `python -m pytest -q testing/python/transform/test_tilelang_transform_lower_shared_tmem.py` — `4 passed`
- `bash format.sh --files src/cuda/transform/lower_shared_tmem.cc testing/python/transform/test_tilelang_transform_lower_shared_tmem.py` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Validate TMEM candidate buffers have a `PointerType` annotation before accessing `storage_scope`.
- Report the affected buffer name and raise a controlled `InternalError` for malformed TIRX instead of crashing.
- Add regression coverage using malformed TIRX constructed through TVM reflection.

## Validation

- CUDA builds
- Targeted Python regression test
- Formatting checks

## C++ style / lint notes

- The change touches C++ implementation code but does not alter rules documented in `docs/developer_guide/cpp_style.md`.
- No correctness, build, or test issues are introduced.
- Any C++ API Style Audit warnings remain advisory; no new API or FFI surface is added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->