### PR TITLE
[FFI] Support apache-tvm-ffi 0.1.12

### DIFF
--- a/docs/get_started/Installation.md
+++ b/docs/get_started/Installation.md
@@ -271,7 +271,7 @@ pip install -e . -v --no-build-isolation --no-deps
 
 # Manually install required runtime deps when using --no-deps.
 # Note: skip torch-c-dlpack-ext on ROCm (its wheel expects CUDA libs).
-pip install "apache-tvm-ffi>=0.1.12,<0.1.13" "z3-solver>=4.13.0"
+pip install "apache-tvm-ffi>=0.1.11,<0.1.13" "z3-solver>=4.13.0"
 # If you already installed torch-c-dlpack-ext and hit `libtorch_cuda.so` errors:
 # pip uninstall -y torch-c-dlpack-ext
 

--- a/docs/get_started/Installation.md
+++ b/docs/get_started/Installation.md
@@ -271,7 +271,7 @@ pip install -e . -v --no-build-isolation --no-deps
 
 # Manually install required runtime deps when using --no-deps.
 # Note: skip torch-c-dlpack-ext on ROCm (its wheel expects CUDA libs).
-pip install "apache-tvm-ffi>=0.1.11,<0.1.12" "z3-solver>=4.13.0"
+pip install "apache-tvm-ffi>=0.1.12,<0.1.13" "z3-solver>=4.13.0"
 # If you already installed torch-c-dlpack-ext and hit `libtorch_cuda.so` errors:
 # pip uninstall -y torch-c-dlpack-ext
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "apache-tvm-ffi>=0.1.11,<0.1.12",
+    "apache-tvm-ffi>=0.1.12,<0.1.13",
     # torch-c-dlpack-ext provides prebuilt torch extensions.
     # Without it, TVM FFI may require JIT compilation on first import.
     "torch-c-dlpack-ext; python_version < '3.14'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "apache-tvm-ffi>=0.1.12,<0.1.13",
+    "apache-tvm-ffi>=0.1.11,<0.1.13",
     # torch-c-dlpack-ext provides prebuilt torch extensions.
     # Without it, TVM FFI may require JIT compilation on first import.
     "torch-c-dlpack-ext; python_version < '3.14'",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Requirements to run local build with `--no-build-isolation` or other developments
 
-apache-tvm-ffi>=0.1.12,<0.1.13
+apache-tvm-ffi>=0.1.11,<0.1.13
 build
 cmake>=3.26
 cython>=3.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Requirements to run local build with `--no-build-isolation` or other developments
 
-apache-tvm-ffi>=0.1.11,<0.1.12
+apache-tvm-ffi>=0.1.12,<0.1.13
 build
 cmake>=3.26
 cython>=3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Runtime requirements
 
-apache-tvm-ffi>=0.1.12,<0.1.13
+apache-tvm-ffi>=0.1.11,<0.1.13
 torch-c-dlpack-ext; python_version < '3.14'
 cloudpickle
 ml-dtypes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Runtime requirements
 
-apache-tvm-ffi>=0.1.11,<0.1.12
+apache-tvm-ffi>=0.1.12,<0.1.13
 torch-c-dlpack-ext; python_version < '3.14'
 cloudpickle
 ml-dtypes


### PR DESCRIPTION
## Summary

- Update the TVM submodule to the compatibility fix: https://github.com/tile-ai/tvm/pull/60
- Allow `apache-tvm-ffi>=0.1.11,<0.1.13`, covering stable versions 0.1.11 and 0.1.12.
- Keep the manual installation documentation aligned with the package requirement.

## Validation

- CPU-only CMake build completed successfully: 662/662 targets.
- Built a CPU wheel successfully.
- Verified the wheel metadata requires `apache-tvm-ffi>=0.1.11,<0.1.13` and does not bundle `libtvm_ffi`.
- Installed the wheel alongside `apache-tvm-ffi==0.1.11`; pip metadata validation reported no TileLang/tvm-ffi requirement conflict.
- Imported the same wheel with pip FFI 0.1.11 and 0.1.12, confirming each process loaded only the selected pip-provided `libtvm_ffi.so`.
- Verified `DictAttrs.__dict__`, `SwizzleMode`, and TileLang FFI registration.
- Ran the focused TVM `test_dict_attrs` test function successfully.
- Ran pre-commit on all changed source and documentation files.

## Limitations

- GPU build and GPU tests were not run; validation used a CPU-only build.

Addresses #2367.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the `3rdparty/tvm` submodule to include the compatibility fix needed for `apache-tvm-ffi` `0.1.12`.
- Updated package metadata, development requirements, and installation documentation to require `apache-tvm-ffi>=0.1.11,<0.1.13` (preserving compatibility with `tvm-ffi` `0.1.11`).

## Validation

- CPU-only build, wheel creation, and metadata checks passed.
- Verified the pip-provided `libtvm_ffi.so` is loaded.
- Ran FFI functionality checks and a focused TVM test.
- Pre-commit checks passed.
- GPU builds and tests were not run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->