### PR TITLE
[Metal] Add line-level threadgroup qualifier scanning (pass 5)

### DIFF
--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -613,6 +613,37 @@ ffi::Module BuildTileLangMetal(IRModule mod, Target target) {
         }
       }
     }
+    // 5) Line-level: any line containing _shared → fix ALL pointer casts.
+    //    After passes 1-4, some casts still lack threadgroup because _shared
+    //    is nested inside the expression. This pass finds any (TYPE*) on a
+    //    _shared line and inserts the threadgroup qualifier if missing.
+    {
+      std::istringstream iss(fsource);
+      std::ostringstream oss;
+      std::string line;
+      while (std::getline(iss, line)) {
+        if (line.find("_shared") != std::string::npos) {
+          for (size_t i = 0; i + 3 < line.length(); i++) {
+            if (line[i] == '(') {
+              if (line.substr(i, 14) == "(threadgroup ") {
+                i += 13;
+                continue;
+              }
+              size_t j = i + 1;
+              while (j < line.length() &&
+                     (isalnum(line[j]) || line[j] == '_')) j++;
+              if (j < line.length() && line[j] == '*' &&
+                  j + 1 < line.length() && line[j+1] == ')') {
+                line.insert(i + 1, "threadgroup ");
+                i += 12;
+              }
+            }
+          }
+        }
+        oss << line << "\n";
+      }
+      fsource = oss.str();
+    }
     source_maker << fsource << "\n";
     if (fmetal_compile) {
       fsource = (*fmetal_compile)(fsource, target).cast<std::string>();

--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -630,10 +630,10 @@ ffi::Module BuildTileLangMetal(IRModule mod, Target target) {
                 continue;
               }
               size_t j = i + 1;
-              while (j < line.length() &&
-                     (isalnum(line[j]) || line[j] == '_')) j++;
+              while (j < line.length() && (isalnum(line[j]) || line[j] == '_'))
+                j++;
               if (j < line.length() && line[j] == '*' &&
-                  j + 1 < line.length() && line[j+1] == ')') {
+                  j + 1 < line.length() && line[j + 1] == ')') {
                 line.insert(i + 1, "threadgroup ");
                 i += 12;
               }


### PR DESCRIPTION
After passes 1-4 handle declarations and common pointer patterns,
some casts inside kernel bodies still lack threadgroup qualifiers
because `_shared` is nested inside the expression.

This pass does a line-by-line scan: for every line containing
`_shared`, find any `(TYPE*)` cast that isn't already
`(threadgroup TYPE*)` and insert the qualifier.

Fixes Metal compiler errors on patterns like:
- `*(uint4*)((half*)A_shared + ...)` → `*(threadgroup uint4*)(...)`
- `simdgroup_load(..., ((half*)A_shared)[...])` → `(threadgroup half*)`

Verified on M2:
- MSL compiles via `torch.mps.compile_shader` with zero errors
- GEMM 64x64 through 512x512 all pass

Only `src/metal/codegen/codegen_metal.cc` modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Adds a fifth Metal source transformation pass in `BuildTileLangMetal`.
- Scans `_shared` lines for unqualified pointer casts and inserts the `threadgroup` address-space qualifier.
- Covers nested shared-memory cast patterns missed by earlier passes.
- Applies clang-format.

## Validation

- Verified on M2 with zero MSL compilation errors.
- GEMM tests pass for sizes from 64×64 through 512×512.

## C++ style / lint notes

- The change is confined to existing C++ implementation code and does not alter documented rules in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) is not materially relevant because no public or exported APIs changed.
- No correctness, build, or test issues are indicated; any advisory style warnings should remain non-blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->