### PR TITLE
[Metal] Validate GEMM shared memory budget against Metal 32KB limit

### DIFF
--- a/tilelang/metal/op/gemm/gemm_metal.py
+++ b/tilelang/metal/op/gemm/gemm_metal.py
@@ -51,6 +51,19 @@ class GemmMetalSimdGroup(GemmBase):
         mbar_phase_expr: tir.PrimExpr | None = None,
     ):
         thread_nums = thread_bounds.extent
+        # Metal shared memory budget: 32KB per threadgroup.
+        # A_shared + B_shared for GEMM: (M_tile + N_tile) * K_chunk * sizeof(dtype).
+        # Exceeding 32768 causes cryptic 'state != nullptr' runtime errors.
+        dtype_bytes = max(tvm.DataType(self.a_dtype).bytes, tvm.DataType(self.b_dtype).bytes)
+        shmem_est = dtype_bytes * (self.M + self.N) * self.chunk
+        if shmem_est > 32768:
+            max_chunk = 32768 // (dtype_bytes * (self.M + self.N))
+            raise ValueError(
+                f"Metal GEMM shared memory ({shmem_est} bytes) exceeds "
+                f"32KB limit. Reduce tile size or chunk. "
+                f"(M={self.M}, N={self.N}, chunk={self.chunk}, "
+                f"max_chunk_for_this_MN={max_chunk})"
+            )
         m_warp, n_warp = self.policy.compute_warp_partition(self.M, self.N, thread_nums, target, GEMM_INST_METAL)
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)


### PR DESCRIPTION
Metal GPU limits shared memory per threadgroup to 32KB.
For fp16 GEMM with tiles M×N and K chunk, shared memory usage is
`2 * (M + N) * chunk` bytes. When this exceeds 32KB, the kernel
fails at runtime with cryptic `state != nullptr`.

This adds an early validation in `gemm_metal.py` to compute the
expected shared memory and raise a clear `ValueError` if it exceeds
Metal limits, suggesting the user reduce tile or chunk size.

Verified on M2: correctly catches 64x64+K=512 (131KB > 32KB).

Only `tilelang/metal/op/gemm/gemm_metal.py` modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds an upfront Metal GEMM shared-memory budget check in `tilelang/metal/op/gemm/gemm_metal.py` (`GemmMetalSimdGroup.lower`) before warp partitioning/lowering. It estimates shared memory as `shmem_est = dtype_bytes * (M + N) * chunk`, where `dtype_bytes` is the larger byte size of `a_dtype`/`b_dtype`. If `shmem_est > 32768` (32KB per threadgroup), it raises a clear `ValueError` that reports the estimated bytes and a recommended `max_chunk_for_this_MN`, suggesting reduced tile size or chunk to avoid runtime failures.

Includes an example that exceeds the limit (64×64 tile with `K=512`, ~131KB usage) which should now fail fast instead of reaching the previous cryptic runtime error path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->