### PR TITLE
[Metal] Warn instead of silently capping thread_nums for Apple GPU

### DIFF
--- a/tilelang/metal/op/gemm/gemm_metal.py
+++ b/tilelang/metal/op/gemm/gemm_metal.py
@@ -55,9 +55,9 @@ class GemmMetalSimdGroup(GemmBase):
         thread_nums = thread_bounds.extent
         if thread_nums > 512:
             warnings.warn(
-                f"Metal GEMM: thread_nums={thread_nums} > 512 may cause "
-                f"register spilling on Apple GPU. Consider using ≤512 threads.",
-                stacklevel=2)
+                f"Metal GEMM: thread_nums={thread_nums} > 512 may cause register spilling on Apple GPU. Consider using ≤512 threads.",
+                stacklevel=2,
+            )
         m_warp, n_warp = self.policy.compute_warp_partition(self.M, self.N, thread_nums, target, GEMM_INST_METAL)
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)

--- a/tilelang/metal/op/gemm/gemm_metal.py
+++ b/tilelang/metal/op/gemm/gemm_metal.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import warnings
+
 
 from tilelang import tvm as tvm
 from tilelang.layout import Layout
@@ -51,6 +53,11 @@ class GemmMetalSimdGroup(GemmBase):
         mbar_phase_expr: tir.PrimExpr | None = None,
     ):
         thread_nums = thread_bounds.extent
+        if thread_nums > 512:
+            warnings.warn(
+                f"Metal GEMM: thread_nums={thread_nums} > 512 may cause "
+                f"register spilling on Apple GPU. Consider using ≤512 threads.",
+                stacklevel=2)
         m_warp, n_warp = self.policy.compute_warp_partition(self.M, self.N, thread_nums, target, GEMM_INST_METAL)
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)


### PR DESCRIPTION
Per maintainer review on PR #2787: silently truncating thread_nums is problematic.

Following the repo convention (layout/gemm_sp.py:33), this uses
warnings.warn() with stacklevel=2.

Only tilelang/metal/op/gemm/gemm_metal.py modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a `warnings.warn(..., stacklevel=2)` notice when Metal GEMM `thread_nums` exceeds 512, warning about potential register spilling on Apple GPUs.
- Updated the `3rdparty/tvm` submodule revision.

No other GEMM logic was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->