### PR TITLE
[Metal] Warn instead of silently capping thread_nums for Apple GPU

### DIFF
--- a/tilelang/metal/op/gemm/gemm_metal.py
+++ b/tilelang/metal/op/gemm/gemm_metal.py
@@ -1,4 +1,6 @@
 from __future__ import annotations
+import warnings
+
 
 from tilelang import tvm as tvm
 from tilelang.layout import Layout
@@ -50,7 +52,12 @@ class GemmMetalSimdGroup(GemmBase):
         thread_index: tir.PrimExpr,
         mbar_phase_expr: tir.PrimExpr | None = None,
     ):
-        thread_nums = thread_bounds.extent
+        thread_nums = int(thread_bounds.extent)
+        if thread_nums > 512:
+            warnings.warn(
+                f"Metal GEMM: thread_nums={thread_nums} > 512 may cause register spilling on Apple GPU. Consider using ≤512 threads.",
+                stacklevel=2,
+            )
         m_warp, n_warp = self.policy.compute_warp_partition(self.M, self.N, thread_nums, target, GEMM_INST_METAL)
         warp_row_tiles = int(self.M // m_warp)
         warp_col_tiles = int(self.N // n_warp)


### PR DESCRIPTION
Per maintainer review on #2787: silently truncating thread_nums is problematic.

Following repo convention (layout/gemm_sp.py:33), uses
warnings.warn() with stacklevel=2.

Only tilelang/metal/op/gemm/gemm_metal.py modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updates `tilelang/metal/op/gemm/gemm_metal.py` so `GemmMetalSimdGroup.lower` emits a `warnings.warn(..., stacklevel=2)` (and derives `thread_nums` as an `int`) when the derived value for Apple GPUs exceeds `512`, guiding users to consider `≤512` threads instead of silently truncating.
- Adjusts Metal C++ codegen loop unrolling pragma selection in `src/metal/codegen/codegen_metal.cc` (changes thresholds for `#pragma clang loop unroll(full/disable)`).
- Fixes Ruff unused-import errors and applies Ruff formatting.

## C++ style / lint notes

- Touches `src/metal/codegen/codegen_metal.cc`, which falls under the C++ style guidance in `docs/developer_guide/cpp_style.md` (focused, TVM-style convention-aligned change; no broad style churn).
- The “C++ API Style Audit (warning only)” CI step should not be materially impacted by this PR since the change does not introduce or modify C++ APIs/FFI surface (it only adjusts pragma selection logic).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->