### PR TITLE
[BugFix] Reject floating-point predicates in vote intrinsics

### DIFF
--- a/testing/python/language/test_tilelang_language_warp_vote.py
+++ b/testing/python/language/test_tilelang_language_warp_vote.py
@@ -40,9 +40,10 @@ def test_predicate_intrinsics_reject_float(intrinsic):
         intrinsic(predicate)
 
 
+@pytest.mark.parametrize("predicate", [1, True], ids=["integer", "boolean"])
 @pytest.mark.parametrize("intrinsic", PREDICATE_INTRINSICS)
-def test_predicate_intrinsics_accept_integer(intrinsic):
-    result = intrinsic(1)
+def test_predicate_intrinsics_accept_integer_or_boolean(intrinsic, predicate):
+    result = intrinsic(predicate)
 
     assert isinstance(result, tilelang.tvm.tirx.Call)
 

--- a/testing/python/language/test_tilelang_language_warp_vote.py
+++ b/testing/python/language/test_tilelang_language_warp_vote.py
@@ -16,8 +16,35 @@ T.syncthreads_or    – __syncthreads_or
 
 import tilelang
 import tilelang.language as T
+import pytest
 import torch
 import tilelang.testing
+
+
+PREDICATE_INTRINSICS = [
+    T.any_sync,
+    T.all_sync,
+    T.ballot_sync,
+    T.ballot,
+    T.syncthreads_count,
+    T.syncthreads_and,
+    T.syncthreads_or,
+]
+
+
+@pytest.mark.parametrize("intrinsic", PREDICATE_INTRINSICS)
+def test_predicate_intrinsics_reject_float(intrinsic):
+    predicate = tilelang.tvm.tirx.FloatImm("float32", 0.5)
+
+    with pytest.raises(TypeError, match="requires an integer or boolean predicate"):
+        intrinsic(predicate)
+
+
+@pytest.mark.parametrize("intrinsic", PREDICATE_INTRINSICS)
+def test_predicate_intrinsics_accept_integer(intrinsic):
+    result = intrinsic(1)
+
+    assert isinstance(result, tilelang.tvm.tirx.Call)
 
 
 # ---------------------------------------------------------------------------

--- a/tilelang/language/builtin.py
+++ b/tilelang/language/builtin.py
@@ -8,7 +8,7 @@ from tilelang import tvm as tvm
 from tilelang.language.common import ptx_arrive_barrier, evaluate
 from tilelang.language.eager.builder import macro
 from tilelang.language.kernel import get_thread_bindings, get_block_extents
-from tvm import DataType, tirx
+from tvm import DataType, DataTypeCode, tirx
 from tvm.runtime import convert
 from tvm.tirx import PrimExpr, Var, Call, BufferLoad, BufferRegion
 from tilelang.utils.language import retrieve_ptr, get_buffer_region_from_load, retrieve_buffer_and_offset
@@ -1029,6 +1029,14 @@ def shfl_sync(
 # ---------------------------------------------------------------------------
 
 
+def _validate_predicate(predicate: int | PrimExpr, intrinsic: str) -> PrimExpr:
+    """Normalize an intrinsic predicate and reject lossy float-to-int coercion."""
+    predicate = tirx.convert(predicate)
+    if DataType(predicate.dtype).type_code not in (DataTypeCode.INT, DataTypeCode.UINT):
+        raise TypeError(f"T.{intrinsic} requires an integer or boolean predicate, but got {predicate.dtype}.")
+    return predicate
+
+
 def any_sync(
     predicate: int | PrimExpr,
     mask: int | PrimExpr = _FULL_WARP_MASK,
@@ -1046,6 +1054,7 @@ def any_sync(
     Returns:
         int32: Non-zero if any thread in the mask has a non-zero predicate.
     """
+    predicate = _validate_predicate(predicate, "any_sync")
     return tirx.call_intrin("int32", tirx.op.Op.get("tl.any_sync"), _as_uint32_mask(mask), predicate)
 
 
@@ -1065,6 +1074,7 @@ def all_sync(
     Returns:
         int32: Non-zero if all threads in the mask have a non-zero predicate.
     """
+    predicate = _validate_predicate(predicate, "all_sync")
     return tirx.call_intrin("int32", tirx.op.Op.get("tl.all_sync"), _as_uint32_mask(mask), predicate)
 
 
@@ -1082,6 +1092,7 @@ def ballot_sync(
     Returns:
         uint64: Bitmask with bit N set if lane N's predicate is non-zero.
     """
+    predicate = _validate_predicate(predicate, "ballot_sync")
     return tirx.call_intrin("uint64", tirx.op.Op.get("tl.ballot_sync"), _as_uint32_mask(mask), predicate)
 
 
@@ -1092,6 +1103,7 @@ def ballot(predicate: int | PrimExpr) -> PrimExpr:
     Returns:
         uint64: Bitmask with bit N set if lane N's predicate is non-zero.
     """
+    predicate = _validate_predicate(predicate, "ballot")
     return tirx.call_intrin("uint64", tirx.op.Op.get("tl.ballot"), predicate)
 
 
@@ -1113,6 +1125,7 @@ def syncthreads_count(predicate: int | PrimExpr) -> PrimExpr:
     """Block barrier that returns the number of threads whose ``predicate``
     evaluates to non-zero (``__syncthreads_count`` on CUDA and HIP).
     """
+    predicate = _validate_predicate(predicate, "syncthreads_count")
     return tirx.call_intrin("int32", tirx.op.Op.get("tl.syncthreads_count"), predicate)
 
 
@@ -1120,6 +1133,7 @@ def syncthreads_and(predicate: int | PrimExpr) -> PrimExpr:
     """Block barrier that returns non-zero only if ALL threads have a non-zero
     ``predicate`` (``__syncthreads_and`` on CUDA and HIP).
     """
+    predicate = _validate_predicate(predicate, "syncthreads_and")
     return tirx.call_intrin("int32", tirx.op.Op.get("tl.syncthreads_and"), predicate)
 
 
@@ -1127,6 +1141,7 @@ def syncthreads_or(predicate: int | PrimExpr) -> PrimExpr:
     """Block barrier that returns non-zero if ANY thread has a non-zero
     ``predicate`` (``__syncthreads_or`` on CUDA and HIP).
     """
+    predicate = _validate_predicate(predicate, "syncthreads_or")
     return tirx.call_intrin("int32", tirx.op.Op.get("tl.syncthreads_or"), predicate)
 
 

--- a/tilelang/language/builtin.py
+++ b/tilelang/language/builtin.py
@@ -1032,7 +1032,11 @@ def shfl_sync(
 def _validate_predicate(predicate: int | PrimExpr, intrinsic: str) -> PrimExpr:
     """Normalize an intrinsic predicate and reject lossy float-to-int coercion."""
     predicate = tirx.convert(predicate)
-    if DataType(predicate.dtype).type_code not in (DataTypeCode.INT, DataTypeCode.UINT):
+    if DataType(predicate.dtype).type_code not in (
+        DataTypeCode.INT,
+        DataTypeCode.UINT,
+        DataTypeCode.BOOL,
+    ):
         raise TypeError(f"T.{intrinsic} requires an integer or boolean predicate, but got {predicate.dtype}.")
     return predicate
 


### PR DESCRIPTION
## Summary

- reject floating-point predicates in warp-vote, ballot, and block-sync wrappers
- share predicate normalization and validation across all seven affected intrinsics
- add GPU-independent parameterized tests for rejected floats and accepted integers

## Root cause

The wrappers forwarded floating-point predicates directly to CUDA/HIP builtins whose predicate parameters are integers. Values such as `0.5` were therefore truncated to zero, silently changing their truth value and producing incorrect results.

The wrappers now enforce their documented integer-or-boolean predicate contract before constructing the intrinsic call.

Fixes #2607.

## Validation

- `python -m pytest testing/python/language/test_tilelang_language_warp_vote.py -q` (14 passed, 12 CUDA-dependent tests skipped)
- `bash format.sh --files tilelang/language/builtin.py testing/python/language/test_tilelang_language_warp_vote.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added centralized predicate validation for warp-vote and block-sync intrinsics.
- Rejects floating-point predicates before intrinsic construction while preserving integer and boolean support.
- Added parameterized GPU-independent tests covering rejected floats and accepted integers across all seven affected intrinsics.
- Prevents silent float-to-integer truncation that could produce incorrect CUDA/HIP results.

## C++ style / lint notes

- This PR does not touch C++ code, CI lint tooling, or the rules documented in `docs/developer_guide/cpp_style.md`.
- No changes are expected to the “C++ API Style Audit (warning only)” step (TLCPP003/TLCPP004).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->