### PR TITLE
[BugFix] Preserve alloc_var initializer dtype

### DIFF
--- a/testing/python/language/test_tilelang_language_var_init.py
+++ b/testing/python/language/test_tilelang_language_var_init.py
@@ -1,6 +1,7 @@
 import tilelang
 import tilelang.language as T
 import tilelang.testing
+import pytest
 
 
 def test_alloc_var_preserves_float64_initializer_dtype() -> None:
@@ -18,6 +19,16 @@ def test_alloc_var_preserves_float64_initializer_dtype() -> None:
 
     tilelang.tvm.tirx.stmt_functor.post_order_visit(kernel.body, collect_float64_initializer)
     assert 1e300 in initializers
+
+
+def test_alloc_var_rejects_unrepresentable_float32_initializer() -> None:
+    with pytest.raises(ValueError, match="exceeds maximum of float32"):
+
+        @T.prim_func
+        def kernel(A: T.Tensor((1,), T.float32)):
+            with T.Kernel(1):
+                value = T.alloc_var(T.float32, init=1e300)
+                A[0] = value
 
 
 # TODO: var init is not supported on hip.

--- a/testing/python/language/test_tilelang_language_var_init.py
+++ b/testing/python/language/test_tilelang_language_var_init.py
@@ -3,6 +3,23 @@ import tilelang.language as T
 import tilelang.testing
 
 
+def test_alloc_var_preserves_float64_initializer_dtype() -> None:
+    @T.prim_func
+    def kernel(A: T.Tensor((1,), T.float64)):
+        with T.Kernel(1):
+            value = T.alloc_var(T.float64, init=1e300)
+            A[0] = value
+
+    initializers = []
+
+    def collect_float64_initializer(node):
+        if isinstance(node, tilelang.tvm.tirx.FloatImm) and node.dtype == T.float64:
+            initializers.append(node.value)
+
+    tilelang.tvm.tirx.stmt_functor.post_order_visit(kernel.body, collect_float64_initializer)
+    assert 1e300 in initializers
+
+
 # TODO: var init is not supported on hip.
 @tilelang.testing.requires_cuda
 def test_var_assign() -> None:

--- a/tilelang/language/allocate.py
+++ b/tilelang/language/allocate.py
@@ -160,7 +160,9 @@ def alloc_var(dtype: DType, *args, scope: str = "local.var", init: PrimExpr | in
         # annotation for integer/float literals, leaving the scalar
         # uninitialised).  T.buffer_store emits an explicit BufferStore TIR
         # node that every backend lowers to an assignment statement.
-        if isinstance(parsed_init, (int, float, IntImm, FloatImm)):
+        if isinstance(parsed_init, (int, float)):
+            parsed_init = tvm.tirx.const(parsed_init, dtype=tl_dtype(dtype))
+        elif isinstance(parsed_init, (IntImm, FloatImm)):
             parsed_init = tl_dtype(dtype)(parsed_init)
         T.buffer_store(buffer, parsed_init, 0)
     return buffer


### PR DESCRIPTION
## Summary

- construct Python literal initializers with the requested `T.alloc_var` dtype
- preserve the existing cast path for `IntImm` and `FloatImm` initializers
- add a GPU-independent regression test for a large finite float64 initializer

## Root cause

`T.alloc_var(T.float64, init=1e300)` passed the raw Python float through the dtype builder FFI. The FFI converted that argument to a float32 `FloatImm` before the requested float64 cast could run, so values outside the float32 range were rejected.

Python numeric literals now use `tvm.tirx.const` with the target dtype, preventing the intermediate float32 conversion.

Fixes #2575.

## Validation

- `python -m pytest testing/python/language/test_tilelang_language_var_init.py -q` (1 passed, 1 CUDA-dependent test skipped)
- focused frontend tests covering the new float64 case and existing macro initializer behavior (2 passed)
- `bash format.sh --files tilelang/language/allocate.py testing/python/language/test_tilelang_language_var_init.py`
- `git diff --check`

One broader frontend execution test requires automatic hardware target detection and could not run in the current device-less environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed `T.alloc_var` initializer dtype handling so Python `int`/`float` literals are materialized using the variable’s requested dtype (via a typed `tvm.tirx.const(..., dtype=...)`), preventing valid large `float64` values (e.g. `1e300`) from being prematurely converted to `float32`.
- Preserved existing behavior for `IntImm`/`FloatImm` initializers by continuing to cast them to the requested dtype.
- Added regression coverage for large finite `float64` initialization and for rejecting `float32` initializers that exceed the `float32` maximum.

## Testing

- Added `test_alloc_var_preserves_float64_initializer_dtype` to ensure a `T.alloc_var(T.float64, init=1e300)` initializer remains a `FloatImm` with value `1e300`.
- Added `test_alloc_var_rejects_unrepresentable_float32_initializer` to assert `T.alloc_var(T.float32, init=1e300)` raises `ValueError` (matching `exceeds maximum of float32`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->