### PR TITLE
[BugFix] Skip descriptor TMA for device-bound copy bases

### DIFF
--- a/src/cuda/op/copy_analysis.cc
+++ b/src/cuda/op/copy_analysis.cc
@@ -89,6 +89,10 @@ bool GetNoImplicitAsyncCommitWait(const CopyNode &op) {
   return GetBoolAnnotation(op, attr::kAsyncCopyNoImplicitCommitWait);
 }
 
+bool GetTmaDescriptorBaseIsDeviceBound(const CopyNode &op) {
+  return GetBoolAnnotation(op, attr::kTmaDescriptorBaseIsDeviceBound);
+}
+
 enum class PreferredCopyInstruction {
   kAuto,
   kTMA,
@@ -490,6 +494,7 @@ struct CopyFacts {
   bool explicit_tma = false;
   bool explicit_cp_async = false;
   bool no_implicit_async_commit_wait = false;
+  bool tma_descriptor_base_is_device_bound = false;
   PreferredCopyInstruction prefer_instruction = PreferredCopyInstruction::kAuto;
   bool disable_tma = false;
   int64_t cluster_mask = 0;
@@ -522,6 +527,15 @@ CopyInstSelection Unsupported(std::string reason) {
 
 std::string MakeTmaUnavailableReason(const CopyNode &op) {
   std::ostringstream oss;
+  if (GetTmaDescriptorBaseIsDeviceBound(op)) {
+    const Buffer &global_buffer = IsGlobalBuffer(op.src) ? op.src : op.dst;
+    oss << "Descriptor-based TMA cannot use global base pointer `"
+        << global_buffer->data->name_hint
+        << "` because it is bound inside the device function body. "
+           "TensorMap descriptors are encoded on the host; use plain T.copy "
+           "to allow a descriptorless or synchronous fallback.";
+    return oss.str();
+  }
   if (op.src->dtype.is_float4_e2m1_unpacked() ||
       op.dst->dtype.is_float4_e2m1_unpacked()) {
     oss << "T.tma_copy() only supports float4_e2m1_unpacked as an FP4 unpack "
@@ -615,6 +629,8 @@ CopyFacts AnalyzeCopyFacts(const CopyNode &op, const CopyAnalysisContext &ctx) {
   facts.explicit_tma = GetIsTmaCopy(op);
   facts.explicit_cp_async = GetIsAsyncCopy(op);
   facts.no_implicit_async_commit_wait = GetNoImplicitAsyncCommitWait(op);
+  facts.tma_descriptor_base_is_device_bound =
+      GetTmaDescriptorBaseIsDeviceBound(op);
   facts.prefer_instruction = GetPreferredInstruction(op);
   facts.disable_tma = GetDisableTMA(op);
   facts.cluster_mask = GetClusterMask(op);
@@ -681,6 +697,14 @@ CopyFacts AnalyzeCopyFacts(const CopyNode &op, const CopyAnalysisContext &ctx) {
   facts.can_stsm = CheckSTSMCopy(op, ctx.target);
   facts.can_tmem_load = CheckTMemLoad(op, ctx.target);
   facts.can_tmem_store = CheckTMemStore(op, ctx.target);
+  if (facts.tma_descriptor_base_is_device_bound) {
+    // BulkLoad1D/BulkStore1D pass the device-computed address directly and do
+    // not create a host-side TensorMap descriptor, so keep those facts intact.
+    facts.can_bulk_load = false;
+    facts.can_bulk_store = false;
+    facts.can_bulk_load_ignore_last_dim = false;
+    facts.can_bulk_store_ignore_last_dim = false;
+  }
   return facts;
 }
 
@@ -692,9 +716,15 @@ CopyInstSelection SelectCopyInstForLowering(const CopyNode &op,
   // The IR carries explicit row indices via annotations and must always be
   // lowered through LowerBulkCopyGather4 (no fallback path makes sense).
   if (GetBoolAnnotation(op, "is_gather4")) {
+    if (GetTmaDescriptorBaseIsDeviceBound(op)) {
+      return Unsupported(MakeTmaUnavailableReason(op));
+    }
     return Supported(CopyInst::kBulkLoadGather4);
   }
   if (GetBoolAnnotation(op, "is_scatter4")) {
+    if (GetTmaDescriptorBaseIsDeviceBound(op)) {
+      return Unsupported(MakeTmaUnavailableReason(op));
+    }
     return Supported(CopyInst::kBulkStoreScatter4);
   }
 

--- a/src/cuda/transform/annotate_device_bound_tma_copies.cc
+++ b/src/cuda/transform/annotate_device_bound_tma_copies.cc
@@ -1,0 +1,115 @@
+/*!
+ * \file annotate_device_bound_tma_copies.cc
+ * \brief Mark copies whose TensorMap base pointer is defined in the body.
+ */
+
+#include <tvm/tirx/op.h>
+#include <tvm/tirx/stmt_functor.h>
+#include <tvm/tirx/transform.h>
+
+#include <unordered_set>
+#include <utility>
+
+#include "op/builtin.h"
+#include "op/copy.h"
+#include "op/operator.h"
+#include "op/utils.h"
+#include "support/check.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+using namespace ffi;
+
+namespace {
+
+using VarSet = std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual>;
+
+class BodyBoundHandleCollector : public StmtExprVisitor {
+public:
+  static VarSet Collect(const Stmt &stmt) {
+    BodyBoundHandleCollector collector;
+    collector(stmt);
+    return std::move(collector.vars_);
+  }
+
+private:
+  void VisitStmt_(const BindNode *op) final {
+    if (op->var->dtype.is_handle()) {
+      vars_.insert(op->var);
+    }
+    StmtExprVisitor::VisitStmt_(op);
+  }
+
+  VarSet vars_;
+};
+
+class DeviceBoundTmaCopyAnnotator : public StmtExprMutator {
+public:
+  static PrimFunc Rewrite(PrimFunc f) {
+    VarSet body_bound_handles = BodyBoundHandleCollector::Collect(f->body);
+    if (body_bound_handles.empty()) {
+      return f;
+    }
+    DeviceBoundTmaCopyAnnotator annotator(body_bound_handles);
+    Stmt body = annotator.VisitStmt(f->body);
+    f.CopyOnWrite()->body = std::move(body);
+    return f;
+  }
+
+private:
+  explicit DeviceBoundTmaCopyAnnotator(const VarSet &body_bound_handles)
+      : body_bound_handles_(body_bound_handles) {}
+
+  PrimExpr VisitExpr_(const CallNode *op) final {
+    Call call = Downcast<Call>(StmtExprMutator::VisitExpr_(op));
+    static const Op &copy_op = Op::Get("tl.tileop.copy");
+    static const Op &async_copy_op = Op::Get("tl.tileop.async_copy");
+    static const Op &tma_copy_op = Op::Get("tl.tileop.tma_copy");
+    if (!call->op.same_as(copy_op) && !call->op.same_as(async_copy_op) &&
+        !call->op.same_as(tma_copy_op)) {
+      return call;
+    }
+
+    TileOperator tile_op = ParseOperator(call);
+    const auto *copy = tile_op.as<CopyNode>();
+    ICHECK(copy != nullptr);
+    bool device_bound_global_base =
+        (IsGlobalBuffer(copy->src) &&
+         body_bound_handles_.count(copy->src->data)) ||
+        (IsGlobalBuffer(copy->dst) &&
+         body_bound_handles_.count(copy->dst->data));
+    if (!device_bound_global_base ||
+        call->annotations.count(attr::kTmaDescriptorBaseIsDeviceBound)) {
+      return call;
+    }
+
+    Map<String, ObjectRef> annotations = call->annotations;
+    annotations.Set(attr::kTmaDescriptorBaseIsDeviceBound,
+                    IntImm(DataType::Int(32), 1));
+    return Call(call->dtype, call->op, call->args, annotations, call->span);
+  }
+
+  const VarSet &body_bound_handles_;
+};
+
+} // namespace
+
+tvm::transform::Pass AnnotateDeviceBoundTmaCopies() {
+  using namespace tirx::transform;
+  auto pass_func = [](PrimFunc f, const IRModule &m, PassContext ctx) {
+    return DeviceBoundTmaCopyAnnotator::Rewrite(std::move(f));
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.AnnotateDeviceBoundTmaCopies",
+                            {});
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = reflection;
+  refl::GlobalDef().def("tl.cuda.transform.AnnotateDeviceBoundTmaCopies",
+                        AnnotateDeviceBoundTmaCopies);
+}
+
+} // namespace tl
+} // namespace tvm

--- a/src/cuda/transform/producer_consumer_ws.cc
+++ b/src/cuda/transform/producer_consumer_ws.cc
@@ -2906,7 +2906,16 @@ private:
 // Pass registration
 // ---------------------------------------------------------------------------
 
-tvm::transform::Pass ProducerConsumerWarpSpecialized() {
+static tvm::transform::Pass AnnotateDeviceBoundTmaCopies() {
+  using namespace tirx::transform;
+  auto pass_func = [](PrimFunc f, const IRModule &m, const PassContext &ctx) {
+    return DeviceBoundTmaCopyAnnotator::Rewrite(std::move(f));
+  };
+  return CreatePrimFuncPass(pass_func, 0,
+                            "tl.AnnotateDeviceBoundTmaCopiesInternal", {});
+}
+
+static tvm::transform::Pass ProducerConsumerWarpSpecializedInternal() {
   using namespace tirx::transform;
   auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     // Skip if disabled.
@@ -2923,9 +2932,6 @@ tvm::transform::Pass ProducerConsumerWarpSpecialized() {
     if (!target.defined() || !TargetHasBulkCopy(target.value())) {
       return f;
     }
-    // Preserve pointer provenance on each copy before WS classification so
-    // later lowering can consume it through CopyAnalysis.
-    f = DeviceBoundTmaCopyAnnotator::Rewrite(std::move(f));
     // Only apply MVB + WS if the function is a tiled WS candidate.
     if (!TiledWSCandidate::Check(f->body, target.value())) {
       DLOG(WARNING) << "[WS] skipped: no TMA copies in pipeline loop";
@@ -2972,8 +2978,14 @@ tvm::transform::Pass ProducerConsumerWarpSpecialized() {
     DLOG(WARNING) << "[WS] transformation applied successfully";
     return result;
   };
-  return CreatePrimFuncPass(pass_func, 0, "tl.ProducerConsumerWarpSpecialized",
-                            {});
+  return CreatePrimFuncPass(pass_func, 0,
+                            "tl.ProducerConsumerWarpSpecializedInternal", {});
+}
+
+tvm::transform::Pass ProducerConsumerWarpSpecialized() {
+  return tvm::transform::Sequential({AnnotateDeviceBoundTmaCopies(),
+                                     ProducerConsumerWarpSpecializedInternal()},
+                                    "tl.ProducerConsumerWarpSpecialized");
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {

--- a/src/cuda/transform/producer_consumer_ws.cc
+++ b/src/cuda/transform/producer_consumer_ws.cc
@@ -164,6 +164,74 @@ using StmtRewriteMap =
 using BufferLayoutMap = std::unordered_map<Var, std::pair<Buffer, Layout>,
                                            ObjectPtrHash, ObjectPtrEqual>;
 
+class BodyBoundHandleCollector : public StmtExprVisitor {
+public:
+  static VarSet Collect(const Stmt &stmt) {
+    BodyBoundHandleCollector collector;
+    collector(stmt);
+    return std::move(collector.vars_);
+  }
+
+private:
+  void VisitStmt_(const BindNode *op) final {
+    if (op->var->dtype.is_handle()) {
+      vars_.insert(op->var);
+    }
+    StmtExprVisitor::VisitStmt_(op);
+  }
+
+  VarSet vars_;
+};
+
+class DeviceBoundTmaCopyAnnotator : public StmtExprMutator {
+public:
+  static PrimFunc Rewrite(PrimFunc f) {
+    VarSet body_bound_handles = BodyBoundHandleCollector::Collect(f->body);
+    if (body_bound_handles.empty()) {
+      return f;
+    }
+    DeviceBoundTmaCopyAnnotator annotator(body_bound_handles);
+    Stmt body = annotator.VisitStmt(f->body);
+    f.CopyOnWrite()->body = std::move(body);
+    return f;
+  }
+
+private:
+  explicit DeviceBoundTmaCopyAnnotator(const VarSet &body_bound_handles)
+      : body_bound_handles_(body_bound_handles) {}
+
+  PrimExpr VisitExpr_(const CallNode *op) final {
+    Call call = Downcast<Call>(StmtExprMutator::VisitExpr_(op));
+    static const Op &copy_op = Op::Get("tl.tileop.copy");
+    static const Op &async_copy_op = Op::Get("tl.tileop.async_copy");
+    static const Op &tma_copy_op = Op::Get("tl.tileop.tma_copy");
+    if (!call->op.same_as(copy_op) && !call->op.same_as(async_copy_op) &&
+        !call->op.same_as(tma_copy_op)) {
+      return call;
+    }
+
+    TileOperator tile_op = ParseOperator(call);
+    const auto *copy = tile_op.as<CopyNode>();
+    ICHECK(copy != nullptr);
+    bool device_bound_global_base =
+        (IsGlobalBuffer(copy->src) &&
+         body_bound_handles_.count(copy->src->data)) ||
+        (IsGlobalBuffer(copy->dst) &&
+         body_bound_handles_.count(copy->dst->data));
+    if (!device_bound_global_base ||
+        call->annotations.count(attr::kTmaDescriptorBaseIsDeviceBound)) {
+      return call;
+    }
+
+    Map<String, ObjectRef> annotations = call->annotations;
+    annotations.Set(attr::kTmaDescriptorBaseIsDeviceBound,
+                    IntImm(DataType::Int(32), 1));
+    return Call(call->dtype, call->op, call->args, annotations, call->span);
+  }
+
+  const VarSet &body_bound_handles_;
+};
+
 struct LocalAccessSummary {
   BufferSet read_buffers;
   BufferSet write_buffers;
@@ -2855,6 +2923,9 @@ tvm::transform::Pass ProducerConsumerWarpSpecialized() {
     if (!target.defined() || !TargetHasBulkCopy(target.value())) {
       return f;
     }
+    // Preserve pointer provenance on each copy before WS classification so
+    // later lowering can consume it through CopyAnalysis.
+    f = DeviceBoundTmaCopyAnnotator::Rewrite(std::move(f));
     // Only apply MVB + WS if the function is a tiled WS candidate.
     if (!TiledWSCandidate::Check(f->body, target.value())) {
       DLOG(WARNING) << "[WS] skipped: no TMA copies in pipeline loop";

--- a/src/cuda/transform/producer_consumer_ws.cc
+++ b/src/cuda/transform/producer_consumer_ws.cc
@@ -164,74 +164,6 @@ using StmtRewriteMap =
 using BufferLayoutMap = std::unordered_map<Var, std::pair<Buffer, Layout>,
                                            ObjectPtrHash, ObjectPtrEqual>;
 
-class BodyBoundHandleCollector : public StmtExprVisitor {
-public:
-  static VarSet Collect(const Stmt &stmt) {
-    BodyBoundHandleCollector collector;
-    collector(stmt);
-    return std::move(collector.vars_);
-  }
-
-private:
-  void VisitStmt_(const BindNode *op) final {
-    if (op->var->dtype.is_handle()) {
-      vars_.insert(op->var);
-    }
-    StmtExprVisitor::VisitStmt_(op);
-  }
-
-  VarSet vars_;
-};
-
-class DeviceBoundTmaCopyAnnotator : public StmtExprMutator {
-public:
-  static PrimFunc Rewrite(PrimFunc f) {
-    VarSet body_bound_handles = BodyBoundHandleCollector::Collect(f->body);
-    if (body_bound_handles.empty()) {
-      return f;
-    }
-    DeviceBoundTmaCopyAnnotator annotator(body_bound_handles);
-    Stmt body = annotator.VisitStmt(f->body);
-    f.CopyOnWrite()->body = std::move(body);
-    return f;
-  }
-
-private:
-  explicit DeviceBoundTmaCopyAnnotator(const VarSet &body_bound_handles)
-      : body_bound_handles_(body_bound_handles) {}
-
-  PrimExpr VisitExpr_(const CallNode *op) final {
-    Call call = Downcast<Call>(StmtExprMutator::VisitExpr_(op));
-    static const Op &copy_op = Op::Get("tl.tileop.copy");
-    static const Op &async_copy_op = Op::Get("tl.tileop.async_copy");
-    static const Op &tma_copy_op = Op::Get("tl.tileop.tma_copy");
-    if (!call->op.same_as(copy_op) && !call->op.same_as(async_copy_op) &&
-        !call->op.same_as(tma_copy_op)) {
-      return call;
-    }
-
-    TileOperator tile_op = ParseOperator(call);
-    const auto *copy = tile_op.as<CopyNode>();
-    ICHECK(copy != nullptr);
-    bool device_bound_global_base =
-        (IsGlobalBuffer(copy->src) &&
-         body_bound_handles_.count(copy->src->data)) ||
-        (IsGlobalBuffer(copy->dst) &&
-         body_bound_handles_.count(copy->dst->data));
-    if (!device_bound_global_base ||
-        call->annotations.count(attr::kTmaDescriptorBaseIsDeviceBound)) {
-      return call;
-    }
-
-    Map<String, ObjectRef> annotations = call->annotations;
-    annotations.Set(attr::kTmaDescriptorBaseIsDeviceBound,
-                    IntImm(DataType::Int(32), 1));
-    return Call(call->dtype, call->op, call->args, annotations, call->span);
-  }
-
-  const VarSet &body_bound_handles_;
-};
-
 struct LocalAccessSummary {
   BufferSet read_buffers;
   BufferSet write_buffers;
@@ -2906,16 +2838,7 @@ private:
 // Pass registration
 // ---------------------------------------------------------------------------
 
-static tvm::transform::Pass AnnotateDeviceBoundTmaCopies() {
-  using namespace tirx::transform;
-  auto pass_func = [](PrimFunc f, const IRModule &m, const PassContext &ctx) {
-    return DeviceBoundTmaCopyAnnotator::Rewrite(std::move(f));
-  };
-  return CreatePrimFuncPass(pass_func, 0,
-                            "tl.AnnotateDeviceBoundTmaCopiesInternal", {});
-}
-
-static tvm::transform::Pass ProducerConsumerWarpSpecializedInternal() {
+tvm::transform::Pass ProducerConsumerWarpSpecialized() {
   using namespace tirx::transform;
   auto pass_func = [=](PrimFunc f, const IRModule &m, const PassContext &ctx) {
     // Skip if disabled.
@@ -2978,14 +2901,8 @@ static tvm::transform::Pass ProducerConsumerWarpSpecializedInternal() {
     DLOG(WARNING) << "[WS] transformation applied successfully";
     return result;
   };
-  return CreatePrimFuncPass(pass_func, 0,
-                            "tl.ProducerConsumerWarpSpecializedInternal", {});
-}
-
-tvm::transform::Pass ProducerConsumerWarpSpecialized() {
-  return tvm::transform::Sequential({AnnotateDeviceBoundTmaCopies(),
-                                     ProducerConsumerWarpSpecializedInternal()},
-                                    "tl.ProducerConsumerWarpSpecialized");
+  return CreatePrimFuncPass(pass_func, 0, "tl.ProducerConsumerWarpSpecialized",
+                            {});
 }
 
 TVM_FFI_STATIC_INIT_BLOCK() {

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -42,6 +42,12 @@ static constexpr const char *kParallelAsyncWithoutAsyncCommitWait =
 // Value should be IntImm/Bool-like truthy scalar.
 static constexpr const char *kAsyncCopyNoImplicitCommitWait =
     "no_implicit_async_commit_wait";
+// Copy-op annotation marking that a global endpoint's base pointer is a
+// handle Var defined by Bind inside the function body. Descriptor-based TMA
+// cannot encode such a pointer on the host, while descriptorless Bulk1D
+// remains valid. Value should be IntImm/Bool-like truthy scalar.
+static constexpr const char *kTmaDescriptorBaseIsDeviceBound =
+    "tma_descriptor_base_is_device_bound";
 // Tile-op annotation key carrying an explicit mbarrier parity expression.
 // Pipeline transforms set this on ops whose lowering would otherwise infer
 // parity from surrounding loop context.

--- a/testing/python/language/test_tilelang_language_ptr.py
+++ b/testing/python/language/test_tilelang_language_ptr.py
@@ -165,9 +165,8 @@ def run_pointer_table_multi_copy(G, N, dtype=T.float16):
 
 def run_pointer_table_grouped_matmul(batch_sizes_list, N, K, block_M, block_N, block_K, dtype=T.float16, accum_dtype=T.float32):
     program = pointer_table_grouped_matmul_test(batch_sizes_list, N, K, block_M, block_N, block_K, dtype, accum_dtype)
-    compile_kwargs = {"pass_configs": {"tl.disable_warp_specialized": True}}
-    cython_jit_kernel = tl.compile(program, execution_backend="cython", **compile_kwargs)
-    ffi_jit_kernel = tl.compile(program, execution_backend="tvm_ffi", **compile_kwargs)
+    cython_jit_kernel = tl.compile(program, execution_backend="cython")
+    ffi_jit_kernel = tl.compile(program, execution_backend="tvm_ffi")
 
     device = "cuda"
     torch_dtype = dtype.as_torch()

--- a/testing/python/language/test_tilelang_language_tma_copy.py
+++ b/testing/python/language/test_tilelang_language_tma_copy.py
@@ -402,7 +402,6 @@ def fp4_tma_copy_unpacked_smem_store(M=128, N=256, block_M=64, block_N=128):
 
 
 def _fp4_tma_descriptor_init_block(host_source, desc_name):
-
     marker = f"[0].v_ptr) = {desc_name};"
     start = host_source.find(marker)
     assert start >= 0, f"Missing {desc_name} TensorMap initialization"
@@ -518,6 +517,31 @@ def test_copy_prefer_tma_lowers_as_synchronous_tma_load():
     assert "x_to_x_shared_mbarrier[0]" in device_source
     assert "arrive_and_expect_tx" in device_source
     assert ".wait(0)" in device_source
+
+
+def test_device_bound_pointer_keeps_descriptorless_bulk1d():
+    @T.prim_func
+    def main(
+        src_ptrs: T.Tensor((1,), T.ptr),
+        out: T.Tensor((256,), T.float16),
+    ):
+        with T.Kernel(threads=128):
+            src = T.make_tensor(src_ptrs[0], (256,), T.float16)
+            src_shared = T.alloc_shared((256,), T.float16)
+            T.copy(src, src_shared, prefer_instruction="tma")
+            T.copy(src_shared, out, prefer_instruction="sync")
+
+    target = tvm.target.Target({"kind": "cuda", "arch": "sm_90"})
+    with target:
+        artifact = tilelang.lower(
+            main,
+            target=target,
+            enable_device_compile=False,
+        )
+
+    device_source = str(artifact.kernel_source)
+    assert "tl::tma_load" in device_source
+    assert "CUtensorMap" not in device_source
 
 
 def run_fp4_tma_copy_unpacked_smem_load():

--- a/testing/python/language/test_tilelang_language_tma_copy.py
+++ b/testing/python/language/test_tilelang_language_tma_copy.py
@@ -544,6 +544,38 @@ def test_device_bound_pointer_keeps_descriptorless_bulk1d():
     assert "CUtensorMap" not in device_source
 
 
+def test_device_bound_descriptor_tma_is_rejected_when_ws_disabled():
+    @T.prim_func
+    def main(src_ptrs: T.Tensor((1,), T.ptr)):
+        with T.Kernel(threads=128):
+            src = T.make_tensor(
+                src_ptrs[0],
+                (16, 32),
+                T.float16,
+                strides=(32, 1),
+            )
+            src_shared = T.alloc_shared((16, 16), T.float16)
+            T.copy(src[0, 0], src_shared, prefer_instruction="tma")
+
+    target = tvm.target.Target({"kind": "cuda", "arch": "sm_90"})
+    pass_configs = {
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED.value: True,
+    }
+    with (
+        target,
+        tvm.transform.PassContext(config=pass_configs),
+        pytest.raises(
+            tvm.TVMError,
+            match="bound inside the device function body",
+        ),
+    ):
+        tilelang.lower(
+            main,
+            target=target,
+            enable_device_compile=False,
+        )
+
+
 def run_fp4_tma_copy_unpacked_smem_load():
     program = fp4_tma_copy_unpacked_smem_load()
     kernel = tilelang.compile(

--- a/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
+++ b/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
@@ -409,6 +409,7 @@ def test_tiled_ws_skips_device_bound_tma_descriptor_base():
     target = determine_target({"kind": "cuda", "arch": "sm_90"}, return_object=True)
     mod = tvm.tirx.transform.BindTarget(target)(mod)
     mod = tilelang.transform.MaterializeKernelLaunch()(mod)
+    mod = tilelang.cuda.transform.AnnotateDeviceBoundTmaCopies()(mod)
     mod = tilelang.cuda.transform.ProducerConsumerWarpSpecialized()(mod)
 
     annotated, total = _count_device_bound_copy_annotations(mod["main"])

--- a/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
+++ b/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
@@ -37,6 +37,24 @@ def matmul_pipelined(M, N, K, block_M, block_K, block_N, num_stages, dtype="floa
     return main
 
 
+def device_bound_copy_pipelined(size=16, dtype="float16", threads=128):
+    """A TMA-shaped copy whose global base comes from a pointer table."""
+
+    @T.prim_func
+    def main(
+        src_ptrs: T.Tensor((1,), T.ptr),
+        out: T.Tensor((size, size), dtype),
+    ):
+        with T.Kernel(1, threads=threads):
+            src = T.make_tensor(src_ptrs[0], (size, size), dtype)
+            shared = T.alloc_shared((size, size), dtype)
+            for _ in T.Pipelined(1, num_stages=1):
+                T.copy(src, shared)
+                T.copy(shared, out)
+
+    return main
+
+
 def dual_gemm_shared_accumulator(
     M,
     N,
@@ -355,11 +373,50 @@ def _find_after(src, needle, start=0):
     return pos
 
 
+def _count_device_bound_copy_annotations(func):
+    annotated = 0
+    total = 0
+
+    def _visit(node):
+        nonlocal annotated, total
+        if not isinstance(node, tvm.tirx.Call) or not isinstance(node.op, tvm.ir.Op):
+            return
+        if str(node.op.name) not in {
+            "tl.tileop.copy",
+            "tl.tileop.async_copy",
+            "tl.tileop.tma_copy",
+        }:
+            return
+        total += 1
+        value = node.annotations.get("tma_descriptor_base_is_device_bound") if node.annotations else None
+        if isinstance(value, tvm.tirx.IntImm) and int(value.value) != 0:
+            annotated += 1
+
+    tvm.tirx.stmt_functor.post_order_visit(func.body, _visit)
+    return annotated, total
+
+
 def _compile_grouped_gemm_ws(batch_sizes=(63, 77), K=128, N=128, block_M=64, block_N=64, block_K=32):
     pass_configs = {tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: False}
     func = grouped_gemm_padded_pipelined(batch_sizes, K, N, block_M, block_N, block_K)
     kernel = _compile_tvm_ffi(func, pass_configs, out_idx=[2])
     return kernel, batch_sizes
+
+
+def test_tiled_ws_skips_device_bound_tma_descriptor_base():
+    func = device_bound_copy_pipelined().with_attr("global_symbol", "main")
+    mod = tvm.IRModule.from_expr(func)
+    target = determine_target({"kind": "cuda", "arch": "sm_90"}, return_object=True)
+    mod = tvm.tirx.transform.BindTarget(target)(mod)
+    mod = tilelang.transform.MaterializeKernelLaunch()(mod)
+    mod = tilelang.cuda.transform.ProducerConsumerWarpSpecialized()(mod)
+
+    annotated, total = _count_device_bound_copy_annotations(mod["main"])
+    assert (annotated, total) == (1, 2)
+
+    script = mod["main"].script()
+    assert "tl_tiled_ws_applied" not in script
+    assert "T.tma_copy" not in script
 
 
 def test_tiled_ws_places_producer_in_first_warp_group():
@@ -777,6 +834,7 @@ def test_tiled_ws_does_not_clone_local_var_into_producer_branch():
 
 
 if __name__ == "__main__":
+    test_tiled_ws_skips_device_bound_tma_descriptor_base()
     test_tiled_ws_places_producer_in_first_warp_group()
     test_tiled_ws_accepts_int64_pipeline_indices()
     test_tiled_ws_stage1_dynamic_loop_start()

--- a/tilelang/cuda/pipeline.py
+++ b/tilelang/cuda/pipeline.py
@@ -86,13 +86,10 @@ def CUDAPassPipelineBodyPrologue(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.LayoutReducer()(mod)
 
     # @CUDA-specific
-    # Tile-level warp specialization: runs before layout inference so that
-    # producer/consumer split happens at the high-level tile-op IR.
-    # The pass classifies copy ops as TMA/cp.async/sync inline. Shared buffers
-    # are multi-versioned internally only for functions where the WS
-    # transformation actually applies.
-    if allow_warp_specialized(target=target):
-        mod = tilelang.cuda.transform.ProducerConsumerWarpSpecialized()(mod)
+    # Always annotate body-bound copy bases before layout inference. The
+    # existing pass entry runs this analysis first, then conditionally applies
+    # warp specialization according to target, config, and manual WS state.
+    mod = tilelang.cuda.transform.ProducerConsumerWarpSpecialized()(mod)
 
     # @CUDA / Blackwell specific
     # Lower 2SM TCGEN5MMA and related on Blackwell target (must run before

--- a/tilelang/cuda/pipeline.py
+++ b/tilelang/cuda/pipeline.py
@@ -90,8 +90,11 @@ def CUDAPassPipelineBodyPrologue(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.LayoutReducer()(mod)
 
     # @CUDA-specific
-    # Tile-level warp specialization runs before layout inference so that
-    # producer/consumer splitting happens at the high-level tile-op IR.
+    # Tile-level warp specialization: runs before layout inference so that
+    # producer/consumer split happens at the high-level tile-op IR.
+    # The pass classifies copy ops as TMA/cp.async/sync inline. Shared buffers
+    # are multi-versioned internally only for functions where the WS
+    # transformation actually applies.
     if allow_warp_specialized(target=target):
         mod = tilelang.cuda.transform.ProducerConsumerWarpSpecialized()(mod)
 

--- a/tilelang/cuda/pipeline.py
+++ b/tilelang/cuda/pipeline.py
@@ -68,6 +68,10 @@ def _module_has_shared_barrier(mod: IRModule) -> bool:
 def CUDAPassPipelineBodyPrologue(mod: IRModule, target: Target) -> IRModule:
     mod = tirx.transform.BindTarget(target)(mod)
     mod = tilelang.transform.MaterializeKernelLaunch()(mod)
+    # Record body-bound global bases before optional let inlining obscures
+    # their provenance. CopyAnalysis consumes this marker for every lowering
+    # path, independently of whether warp specialization is enabled.
+    mod = tilelang.cuda.transform.AnnotateDeviceBoundTmaCopies()(mod)
     if should_force_let_inline():
         # Force-let inline whenever the pass config requests it.
         mod = tilelang.transform.LetInline()(mod)
@@ -86,10 +90,10 @@ def CUDAPassPipelineBodyPrologue(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.LayoutReducer()(mod)
 
     # @CUDA-specific
-    # Always annotate body-bound copy bases before layout inference. The
-    # existing pass entry runs this analysis first, then conditionally applies
-    # warp specialization according to target, config, and manual WS state.
-    mod = tilelang.cuda.transform.ProducerConsumerWarpSpecialized()(mod)
+    # Tile-level warp specialization runs before layout inference so that
+    # producer/consumer splitting happens at the high-level tile-op IR.
+    if allow_warp_specialized(target=target):
+        mod = tilelang.cuda.transform.ProducerConsumerWarpSpecialized()(mod)
 
     # @CUDA / Blackwell specific
     # Lower 2SM TCGEN5MMA and related on Blackwell target (must run before

--- a/tilelang/cuda/transform/__init__.py
+++ b/tilelang/cuda/transform/__init__.py
@@ -3,6 +3,17 @@
 from .. import _ffi_api
 
 
+def AnnotateDeviceBoundTmaCopies():
+    """Mark tile copies whose TensorMap base is defined in the device body.
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    """
+    return _ffi_api.AnnotateDeviceBoundTmaCopies()  # type: ignore
+
+
 def ProducerConsumerWarpSpecialized():
     """Producer-consumer warp specialization at the tile-op level.
 
@@ -132,6 +143,7 @@ def PersistThreadblock():
 
 
 __all__ = [
+    "AnnotateDeviceBoundTmaCopies",
     "AnnotateWarpGroupRegAlloc",
     "FuseMBarrierArriveExpectTx",
     "InjectFenceProxy",

--- a/tilelang/tools/pass_visualizer/core.py
+++ b/tilelang/tools/pass_visualizer/core.py
@@ -28,7 +28,6 @@ try:
 except ImportError:  # installed package (0.1.x) exposes it here
     from tilelang.utils.target import determine_target
 from tilelang.engine.lower import canon_target_host
-from tilelang.cuda.pipeline import allow_warp_specialized
 from tilelang.backend.pass_pipeline.pipeline_utils import (
     should_enable_race_check,
     should_force_let_inline,
@@ -116,8 +115,7 @@ def build_pass_stages(target: Target) -> list[tuple[str, object]]:
     stages.append(("Simplify", tilelang.transform.Simplify()))
     stages.append(("LayoutReducer", tilelang.transform.LayoutReducer()))
 
-    if allow_warp_specialized(target=target):
-        stages.append(("ProducerConsumerWarpSpecialized", tilelang.cuda.transform.ProducerConsumerWarpSpecialized()))
+    stages.append(("ProducerConsumerWarpSpecialized", tilelang.cuda.transform.ProducerConsumerWarpSpecialized()))
 
     stages.append(("LowerBlackwell2SM", tilelang.cuda.transform.LowerBlackwell2SM()))
     stages.append(("IfStmtBinding", tilelang.transform.IfStmtBinding()))

--- a/tilelang/tools/pass_visualizer/core.py
+++ b/tilelang/tools/pass_visualizer/core.py
@@ -28,6 +28,7 @@ try:
 except ImportError:  # installed package (0.1.x) exposes it here
     from tilelang.utils.target import determine_target
 from tilelang.engine.lower import canon_target_host
+from tilelang.cuda.pipeline import allow_warp_specialized
 from tilelang.backend.pass_pipeline.pipeline_utils import (
     should_enable_race_check,
     should_force_let_inline,
@@ -103,6 +104,7 @@ def build_pass_stages(target: Target) -> list[tuple[str, object]]:
 
     stages.append(("BindTarget", tirx.transform.BindTarget(target)))
     stages.append(("MaterializeKernelLaunch", tilelang.transform.MaterializeKernelLaunch()))
+    stages.append(("AnnotateDeviceBoundTmaCopies", tilelang.cuda.transform.AnnotateDeviceBoundTmaCopies()))
 
     if should_force_let_inline():
         stages.append(("LetInline", tilelang.transform.LetInline()))
@@ -115,7 +117,8 @@ def build_pass_stages(target: Target) -> list[tuple[str, object]]:
     stages.append(("Simplify", tilelang.transform.Simplify()))
     stages.append(("LayoutReducer", tilelang.transform.LayoutReducer()))
 
-    stages.append(("ProducerConsumerWarpSpecialized", tilelang.cuda.transform.ProducerConsumerWarpSpecialized()))
+    if allow_warp_specialized(target=target):
+        stages.append(("ProducerConsumerWarpSpecialized", tilelang.cuda.transform.ProducerConsumerWarpSpecialized()))
 
     stages.append(("LowerBlackwell2SM", tilelang.cuda.transform.LowerBlackwell2SM()))
     stages.append(("IfStmtBinding", tilelang.transform.IfStmtBinding()))


### PR DESCRIPTION
## Summary

This PR is an alternative implementation of a previous PR: https://github.com/tile-ai/tilelang/pull/2687. Thanks @Lyscoria for for the initial exploration and attempts.

- mark tile copies whose global base pointer is bound inside the function body before warp-specialized classification
- make CUDA CopyAnalysis reject only host-side TensorMap descriptor paths for those copies
- preserve descriptorless BulkLoad1D and BulkStore1D selection
- allow pointer-table grouped GEMM to compile and run with the default SM90 pipeline

## Testing

- native CMake and Ninja build
- test_tiled_ws_skips_device_bound_tma_descriptor_base
- test_device_bound_pointer_keeps_descriptorless_bulk1d
- test_copy_prefer_tma_lowers_as_synchronous_tma_load
- test_pointer_table_grouped_matmul on CUDA
- clang-format, Ruff check, and Ruff format

Fixes #2549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added `attr::kTmaDescriptorBaseIsDeviceBound` and a CUDA PrimFunc pass (`AnnotateDeviceBoundTmaCopies`) that annotates copy/tma ops whose global endpoint base is device-bound (computed in-kernel).
- Updated CUDA copy analysis to record `tma_descriptor_base_is_device_bound` and to forcibly disable descriptor-based TMA bulk lowering paths in this case, while preserving descriptorless `BulkLoad1D`/`BulkStore1D` selection.
- Improved unsupported/rejection diagnostics and instruction selection: `tile::gather4` / `tile::scatter4` now reject descriptor-based TMA when the descriptor base is device-bound, explaining that TensorMap descriptors are host-encoded and that a plain `T.copy`/descriptorless fallback is required.
- Inserted `AnnotateDeviceBoundTmaCopies` into the CUDA pipeline so pointer-table grouped GEMM compiles/runs under the default SM90 warp-specialized pipeline without triggering the previous `MakePackedAPI` failure.
- Added regression tests covering: device-bound pointer behavior staying descriptorless (no `CUtensorMap`), descriptor-based TMA rejection when warp specialization is disabled, and producer/consumer WS behavior skipping the annotated device-bound TMA descriptor-base case.

## C++ style / lint notes

- This PR touches C++ implementation and C++-level exported attributes/passes (`src/cuda/op/copy_analysis.cc`, `src/op/builtin.h`, and the new `src/cuda/transform/annotate_device_bound_tma_copies.cc`), so review against `docs/developer_guide/cpp_style.md` is relevant (notably formatting/includes, naming, and FFI-visible API/registration considerations).
- CI runs the “C++ API Style Audit (warning only)” (`python3 maint/scripts/audit_cpp_api_style.py`); any newly reported advisory findings should be treated as suggestions. Unless a finding indicates an actual new FFI/maintainability risk introduced by this PR, it should not be considered a correctness/build blocker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->