### PR TITLE
[BugFix] Fix two-instance modeling in ThreadSync cross-thread race checks

### DIFF
--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,4 +1,5 @@
 cancelled
+disjointness
 dout
 hsa
 inouts

--- a/src/transform/common/constr_visitor.h
+++ b/src/transform/common/constr_visitor.h
@@ -27,23 +27,25 @@ namespace tvm::tl {
  * \brief Replace every mutable read in an expression with a fresh, independent
  *        variable.
  *
- * `Analyzer::Bind` installs a rewrite `var -> value`, so a value reading
- * mutable state would equate two reads across a store this does not track, and
- * make two instances agree where two threads read two different registers. A
- * fresh unknown per read only ever weakens equalities.
+ * `Analyzer::Bind` installs a rewrite `var -> value`, so a definition reading
+ * mutable state would outlive a store this does not track, and would make two
+ * instances agree where two threads read two different registers.
  */
 class FreshenMutableReads : public tirx::ExprMutator {
 public:
   using tirx::ExprMutator::operator();
 
 private:
+  /*!
+   * \brief A fresh variable for one occurrence of \p e, never reused for a
+   *        structurally equal one.
+   *
+   * An opaque call need not return the same value twice (`f() - f()` is not
+   * zero), and two reads of one location may be separated by a store. Sharing
+   * would assert an equality that need not hold.
+   */
   PrimExpr Fresh(const PrimExpr &e) {
-    auto it = memo_.find(e);
-    if (it != memo_.end())
-      return it->second;
-    tirx::Var var("free" + std::to_string(memo_.size()), e.dtype());
-    memo_.emplace(e, var);
-    return var;
+    return tirx::Var("free" + std::to_string(count_++), e.dtype());
   }
 
   PrimExpr VisitExpr_(const tirx::BufferLoadNode *op) override {
@@ -56,17 +58,16 @@ private:
     return Fresh(ffi::GetRef<PrimExpr>(op));
   }
   PrimExpr VisitExpr_(const tirx::CallNode *op) override {
-    // Opaque or stateful calls are unknowns; pure calls recurse so that their
-    // pure sub-structure survives.
+    // `SideEffect` covers the arguments as well, so a call reading state
+    // anywhere below it becomes a single unknown; only a wholly pure one
+    // recurses.
     if (tirx::SideEffect(ffi::GetRef<PrimExpr>(op)) >
         tirx::CallEffectKind::kPure)
       return Fresh(ffi::GetRef<PrimExpr>(op));
     return tirx::ExprMutator::VisitExpr_(op);
   }
 
-  std::unordered_map<PrimExpr, PrimExpr, ffi::StructuralHash,
-                     tirx::ExprDeepEqual>
-      memo_;
+  int count_{0};
 };
 
 struct Constr {
@@ -161,20 +162,42 @@ struct Constr {
     LOG(FATAL) << "Unreachable";
     return Constr();
   }
-  void Populate(arith::Analyzer &analyzer) const {
+  /*!
+   * \brief A copy whose definition no longer reads mutable state.
+   *
+   * Only a bind needs it: `Bind` installs a rewrite, so `v == A[i]` would keep
+   * being substituted after a store invalidated it. A predicate states a fact
+   * that held on entry and stays usable as a premise inside the scope it
+   * guards.
+   *
+   * Every consumer goes through here, so no path can miss the substitution.
+   */
+  Constr FreshenReads() const {
+    FreshenMutableReads freshen;
     switch (kind) {
     case kConstr:
-      analyzer.EnterConstraint(value, is_assume);
+      return *this;
+    case kBindValue:
+      return Constr(var, freshen(value));
+    case kBindRange:
+      return Constr(var, Range::FromMinExtent(freshen(range->min),
+                                              freshen(range->extent)));
+    }
+    LOG(FATAL) << "Unreachable";
+    return Constr();
+  }
+  void Populate(arith::Analyzer &analyzer) const {
+    Constr c = FreshenReads();
+    switch (c.kind) {
+    case kConstr:
+      analyzer.EnterConstraint(c.value, c.is_assume);
       break;
     case kBindValue:
-      analyzer.Bind(var, FreshenMutableReads()(value));
+      analyzer.Bind(c.var, c.value);
       break;
-    case kBindRange: {
-      FreshenMutableReads freshen;
-      analyzer.Bind(var, Range::FromMinExtent(freshen(range->min),
-                                              freshen(range->extent)));
+    case kBindRange:
+      analyzer.Bind(c.var, c.range);
       break;
-    }
     default:
       LOG(FATAL) << "Unreachable";
     }
@@ -278,8 +301,9 @@ struct ConstrSet {
   ConstrSet ToConstraints() const {
     ConstrSet out;
     out.constrs_.reserve(constrs_.size());
-    for (const auto &c : constrs_)
-      out.constrs_.push_back(Constr(c.ToGenericConstr(), c.is_assume));
+    for (const Constr &c : constrs_)
+      out.constrs_.push_back(
+          Constr(c.FreshenReads().ToGenericConstr(), c.is_assume));
     return out;
   }
 

--- a/src/transform/common/constr_visitor.h
+++ b/src/transform/common/constr_visitor.h
@@ -28,10 +28,9 @@ namespace tvm::tl {
  *        variable.
  *
  * `Analyzer::Bind` installs a rewrite `var -> value`, so a value reading
- * mutable state lets the analyzer equate two reads across a store it does not
- * track, and makes two instances of one constraint set agree where two threads
- * would read two different registers. A fresh unknown per read only ever
- * weakens equalities, and keeps the pure structure around the read.
+ * mutable state would equate two reads across a store this does not track, and
+ * make two instances agree where two threads read two different registers. A
+ * fresh unknown per read only ever weakens equalities.
  */
 class FreshenMutableReads : public tirx::ExprMutator {
 public:
@@ -200,12 +199,10 @@ struct ConstrSet {
    * `v == f(a)` and `v == f(b)` into `f(a) == f(b)`, contradicting `a != b` for
    * an injective `f` and leaving a set under which every query holds vacuously.
    *
-   * \param subs Map to extend; the new renames accumulate so the caller can
-   *        apply the same map to expressions held outside the set.
-   * \param from Pivot; renames every bind when not given. Has to be an
-   *        `Optional` as `tirx::Var()` builds a real variable named "v".
-   * \param rename_ranges Pass false to keep iteration variables shared, which
-   *        ThreadSync's loop-carry model needs to compare `i` with `i + 1`.
+   * \p subs accumulates the renames, so the caller can apply the same map to
+   * expressions held outside the set. \p from has to be an `Optional`, as
+   * `tirx::Var()` builds a real variable named "v". Pass \p rename_ranges false
+   * to keep iteration variables shared, as ThreadSync's loop-carry model needs.
    */
   ConstrSet RenameFrom(const std::string &suffix,
                        ffi::Map<tirx::Var, PrimExpr> &subs,
@@ -230,9 +227,8 @@ struct ConstrSet {
    *
    * A variable bound to conflicting values on the two sides is a caller error
    * -- it should have been renamed per side -- and is reported rather than
-   * merged. `is_assume` is cleared: an assume is trusted only at the program
-   * point that stated it, and being trusted it may reference mutable reads, so
-   * it must not become a global fact once two points are merged.
+   * merged. `is_assume` is cleared: an assume is trusted only where it was
+   * stated, and being trusted it may reference mutable reads.
    */
   ConstrSet Merge(const ConstrSet &other) const {
     ConstrSet out = *this;
@@ -275,9 +271,9 @@ struct ConstrSet {
   /*!
    * \brief Lower every bind to a predicate, leaving predicates as they are.
    *
-   * Use this when merging into an analyzer that binds one of the shared
-   * variables itself: a second `Bind` of it trips the analyzer's re-bind check,
-   * while predicates coexist with any external bind.
+   * Use this when the analyzer binds one of the shared variables itself: a
+   * second `Bind` of it trips the re-bind check, while predicates coexist with
+   * any bind.
    */
   ConstrSet ToConstraints() const {
     ConstrSet out;
@@ -372,11 +368,10 @@ public:
         constr_stack_.emplace_back(bind->var, bind->value);
       } else if (const auto *assert_stmt = stmt.as<tirx::AssertStmtNode>()) {
         // A tirx AssertStmt carries no body, so it sits next to the statements
-        // it guards rather than around them; control reaches them only once it
-        // has passed. Pure conditions only: an assert states what held when
-        // control passed it, not a standing promise like an assume, so a
-        // condition reading mutable state may be falsified by a later store,
-        // which is not tracked here.
+        // it guards; control reaches them only once it has passed. Pure
+        // conditions only: unlike an assume it states what held at that point,
+        // so one reading mutable state may be falsified by a later store,
+        // untracked here.
         if (tirx::SideEffect(assert_stmt->condition) <=
             tirx::CallEffectKind::kPure) {
           constr_stack_.emplace_back(assert_stmt->condition);

--- a/src/transform/common/constr_visitor.h
+++ b/src/transform/common/constr_visitor.h
@@ -5,6 +5,8 @@
 #include "tvm/arith/analyzer.h"
 #include "tvm/ir/expr.h"
 #include <ostream>
+#include <string>
+#include <tvm/ffi/extra/structural_hash.h>
 #include <tvm/ir/cast.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/s_tir/stmt.h>
@@ -15,8 +17,58 @@
 #include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/transform.h>
 #include <tvm/tirx/var.h>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 namespace tvm::tl {
+
+/*!
+ * \brief Replace every mutable read in an expression with a fresh, independent
+ *        variable.
+ *
+ * `Analyzer::Bind` installs a rewrite `var -> value`, so a value reading
+ * mutable state lets the analyzer equate two reads across a store it does not
+ * track, and makes two instances of one constraint set agree where two threads
+ * would read two different registers. A fresh unknown per read only ever
+ * weakens equalities, and keeps the pure structure around the read.
+ */
+class FreshenMutableReads : public tirx::ExprMutator {
+public:
+  using tirx::ExprMutator::operator();
+
+private:
+  PrimExpr Fresh(const PrimExpr &e) {
+    auto it = memo_.find(e);
+    if (it != memo_.end())
+      return it->second;
+    tirx::Var var("free" + std::to_string(memo_.size()), e.dtype());
+    memo_.emplace(e, var);
+    return var;
+  }
+
+  PrimExpr VisitExpr_(const tirx::BufferLoadNode *op) override {
+    return Fresh(ffi::GetRef<PrimExpr>(op));
+  }
+  PrimExpr VisitExpr_(const tirx::ProducerLoadNode *op) override {
+    return Fresh(ffi::GetRef<PrimExpr>(op));
+  }
+  PrimExpr VisitExpr_(const tirx::ReduceNode *op) override {
+    return Fresh(ffi::GetRef<PrimExpr>(op));
+  }
+  PrimExpr VisitExpr_(const tirx::CallNode *op) override {
+    // Opaque or stateful calls are unknowns; pure calls recurse so that their
+    // pure sub-structure survives.
+    if (tirx::SideEffect(ffi::GetRef<PrimExpr>(op)) >
+        tirx::CallEffectKind::kPure)
+      return Fresh(ffi::GetRef<PrimExpr>(op));
+    return tirx::ExprMutator::VisitExpr_(op);
+  }
+
+  std::unordered_map<PrimExpr, PrimExpr, ffi::StructuralHash,
+                     tirx::ExprDeepEqual>
+      memo_;
+};
 
 struct Constr {
 
@@ -72,6 +124,9 @@ struct Constr {
     case kConstr:
       return value;
     case kBindValue:
+      // A vector-typed bind cannot be stated as an equality.
+      if (var.dtype().is_vector())
+        return Bool(true);
       return var == value;
     case kBindRange:
       return tirx::And(var >= range->min, var < (range->min + range->extent));
@@ -79,20 +134,48 @@ struct Constr {
     LOG(FATAL) << "Unreachable";
     return PrimExpr();
   }
+  /*!
+   * \brief Rewrite through \p subs, keeping the kind whenever possible, so that
+   *        renaming one side of a two-instance comparison keeps its binds.
+   */
   Constr Substitute(ffi::Map<tirx::Var, PrimExpr> subs) const {
-    return Constr(tirx::Substitute(ToGenericConstr(), subs));
+    switch (kind) {
+    case kConstr:
+      return Constr(tirx::Substitute(value, subs), is_assume);
+    case kBindValue:
+    case kBindRange: {
+      auto it = subs.find(var);
+      const auto *new_var =
+          it == subs.end() ? var.get() : (*it).second.as<tirx::VarNode>();
+      // A bind remapped onto a non-variable is only expressible as a predicate.
+      if (new_var == nullptr)
+        return Constr(tirx::Substitute(ToGenericConstr(), subs), is_assume);
+      if (kind == kBindValue)
+        return Constr(ffi::GetRef<tirx::Var>(new_var),
+                      tirx::Substitute(value, subs));
+      return Constr(
+          ffi::GetRef<tirx::Var>(new_var),
+          Range::FromMinExtent(tirx::Substitute(range->min, subs),
+                               tirx::Substitute(range->extent, subs)));
+    }
+    }
+    LOG(FATAL) << "Unreachable";
+    return Constr();
   }
   void Populate(arith::Analyzer &analyzer) const {
     switch (kind) {
     case kConstr:
-      analyzer.EnterConstraint(value);
+      analyzer.EnterConstraint(value, is_assume);
       break;
     case kBindValue:
-      analyzer.Bind(var, value);
+      analyzer.Bind(var, FreshenMutableReads()(value));
       break;
-    case kBindRange:
-      analyzer.Bind(var, range);
+    case kBindRange: {
+      FreshenMutableReads freshen;
+      analyzer.Bind(var, Range::FromMinExtent(freshen(range->min),
+                                              freshen(range->extent)));
       break;
+    }
     default:
       LOG(FATAL) << "Unreachable";
     }
@@ -107,7 +190,107 @@ struct ConstrSet {
     }
     return new_set;
   }
+  /*!
+   * \brief Rename \p from and every bind defined at or after it by appending
+   *        \p suffix; binds defined before \p from stay shared.
+   *
+   * Used when one set is instantiated twice in a single analyzer to model two
+   * concurrent executions: two threads in ThreadSync, two logical iterations in
+   * VerifyParallelLoop. Sharing a variable private to an execution turns
+   * `v == f(a)` and `v == f(b)` into `f(a) == f(b)`, contradicting `a != b` for
+   * an injective `f` and leaving a set under which every query holds vacuously.
+   *
+   * \param subs Map to extend; the new renames accumulate so the caller can
+   *        apply the same map to expressions held outside the set.
+   * \param from Pivot; renames every bind when not given. Has to be an
+   *        `Optional` as `tirx::Var()` builds a real variable named "v".
+   * \param rename_ranges Pass false to keep iteration variables shared, which
+   *        ThreadSync's loop-carry model needs to compare `i` with `i + 1`.
+   */
+  ConstrSet RenameFrom(const std::string &suffix,
+                       ffi::Map<tirx::Var, PrimExpr> &subs,
+                       const ffi::Optional<tirx::Var> &from = std::nullopt,
+                       bool rename_ranges = true) const {
+    bool active = !from.has_value();
+    for (const Constr &c : constrs_) {
+      if (c.kind != Constr::kBindValue && c.kind != Constr::kBindRange)
+        continue;
+      if (from.has_value() && c.var.same_as(from.value()))
+        active = true;
+      if (!rename_ranges && c.kind == Constr::kBindRange)
+        continue;
+      if (active && !subs.count(c.var))
+        subs.Set(c.var, tirx::Var(c.var->name_hint + suffix, c.var.dtype()));
+    }
+    return Substitute(subs);
+  }
+
+  /*!
+   * \brief Union with \p other, dropping duplicates.
+   *
+   * A variable bound to conflicting values on the two sides is a caller error
+   * -- it should have been renamed per side -- and is reported rather than
+   * merged. `is_assume` is cleared: an assume is trusted only at the program
+   * point that stated it, and being trusted it may reference mutable reads, so
+   * it must not become a global fact once two points are merged.
+   */
+  ConstrSet Merge(const ConstrSet &other) const {
+    ConstrSet out = *this;
+    std::unordered_map<const tirx::VarNode *, Constr> bound;
+    std::unordered_set<PrimExpr, ffi::StructuralHash, tirx::ExprDeepEqual>
+        preds;
+    for (const Constr &c : out.constrs_) {
+      if (c.kind == Constr::kConstr)
+        preds.insert(c.value);
+      else
+        bound.emplace(c.var.get(), c);
+    }
+    for (const Constr &c : other.constrs_) {
+      if (c.kind == Constr::kConstr) {
+        if (preds.insert(c.value).second)
+          out.constrs_.push_back(c);
+        continue;
+      }
+      auto it = bound.find(c.var.get());
+      if (it == bound.end()) {
+        bound.emplace(c.var.get(), c);
+        out.constrs_.push_back(c);
+      } else if (it->second.kind != c.kind ||
+                 !tirx::ExprDeepEqual()(it->second.ToGenericConstr(),
+                                        c.ToGenericConstr())) {
+        LOG(WARNING) << "ConstrSet::Merge: var '" << c.var->name_hint
+                     << "' bound to conflicting values across merged sets; "
+                        "caller should rename per-side-varying vars. Dropping "
+                        "the incoming bind. existing="
+                     << it->second.ToGenericConstr()
+                     << " incoming=" << c.ToGenericConstr();
+      }
+    }
+    for (Constr &c : out.constrs_) {
+      c.is_assume = false;
+    }
+    return out;
+  }
+
+  /*!
+   * \brief Lower every bind to a predicate, leaving predicates as they are.
+   *
+   * Use this when merging into an analyzer that binds one of the shared
+   * variables itself: a second `Bind` of it trips the analyzer's re-bind check,
+   * while predicates coexist with any external bind.
+   */
+  ConstrSet ToConstraints() const {
+    ConstrSet out;
+    out.constrs_.reserve(constrs_.size());
+    for (const auto &c : constrs_)
+      out.constrs_.push_back(Constr(c.ToGenericConstr(), c.is_assume));
+    return out;
+  }
+
   void Populate(arith::Analyzer &analyzer) const {
+    // Keep program order: `Analyzer::Bind` evaluates the bounds and modular set
+    // of the value at bind time, so entering the binds first would widen them
+    // -- a `v = tx` inside `if tx < 64` would lose its upper bound.
     for (const auto &c : constrs_) {
       c.Populate(analyzer);
     }
@@ -119,11 +302,6 @@ struct ConstrSet {
   }
   template <typename... Args> void AddConstr(Args... args) {
     constrs_.push_back(Constr(args...));
-  }
-  void Extend(const ConstrSet &other) {
-    for (const auto &c : other.constrs_) {
-      constrs_.push_back(c);
-    }
   }
 
   /*! \brief Convert the constraint set to a conjunction (AND) of all
@@ -192,6 +370,17 @@ public:
         // A flat Bind defines its variable for following statements in this
         // sequence, but not while its own value is being evaluated.
         constr_stack_.emplace_back(bind->var, bind->value);
+      } else if (const auto *assert_stmt = stmt.as<tirx::AssertStmtNode>()) {
+        // A tirx AssertStmt carries no body, so it sits next to the statements
+        // it guards rather than around them; control reaches them only once it
+        // has passed. Pure conditions only: an assert states what held when
+        // control passed it, not a standing promise like an assume, so a
+        // condition reading mutable state may be falsified by a later store,
+        // which is not tracked here.
+        if (tirx::SideEffect(assert_stmt->condition) <=
+            tirx::CallEffectKind::kPure) {
+          constr_stack_.emplace_back(assert_stmt->condition);
+        }
       }
     }
     constr_stack_.resize(old_size);
@@ -211,10 +400,6 @@ public:
     } else {
       Base::VisitStmt_(op);
     }
-  }
-  void VisitStmt_(const tirx::AssertStmtNode *op) override {
-    auto guard = MakeGuard(op->condition);
-    Base::VisitStmt_(op);
   }
   void VisitStmt_(const tirx::IfThenElseNode *op) override {
     {

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -1,18 +1,18 @@
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
+ * or more contributor license agreements. See the NOTICE file
  * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
+ * regarding copyright ownership. The ASF licenses this file
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * with the License. You may obtain a copy of the License at
  *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -521,10 +521,19 @@ private:
   PrimExpr VisitExpr_(const VarNode *op) final {
     if (IsThreadVar(op)) {
       current_.is_block_uniform = false;
+      return GetRef<Var>(op);
     }
     auto it = let_var_properties_.find(op);
     if (it != let_var_properties_.end()) {
       current_.Merge(it->second);
+    } else {
+      // Any other free variable (a kernel parameter, blockIdx, an enclosing
+      // serial loop var) has no compile-time value, so the participating thread
+      // set is unknown; the participation counter cannot help either, as it
+      // enumerates the thread variable alone. Leave is_block_uniform alone so
+      // that a condition built only from these (`bx < 2`, `flags[bx] > 0`)
+      // keeps its sync in place.
+      current_.depends_on_runtime = true;
     }
     return GetRef<Var>(op);
   }
@@ -532,9 +541,9 @@ private:
   PrimExpr VisitExpr_(const BufferLoadNode *op) final {
     current_.depends_on_runtime = true;
     // Do not mark local-scope loads as non-block-uniform solely based on
-    // storage scope.  Thread-local buffers (fragments) commonly hold
+    // storage scope. Thread-local buffers (fragments) commonly hold
     // block-uniform data when populated from block-uniform global addresses
-    // (e.g., T.copy(BlockMask[blockIdx.y, :], fragment)).  If the load
+    // (e.g., T.copy(BlockMask[blockIdx.y, :], fragment)). If the load
     // indices actually depend on threadIdx, the recursive visit of indices
     // below (via IRMutatorWithAnalyzer::VisitExpr_) will correctly set
     // is_block_uniform = false through VisitExpr_(VarNode*).
@@ -546,10 +555,10 @@ private:
         op->op.same_as(builtin::address_of())) {
       current_.depends_on_runtime = true;
       // Do not mark local-scope tvm_access_ptr loads as non-block-uniform
-      // solely based on storage scope.  Thread-local buffers (fragments)
+      // solely based on storage scope. Thread-local buffers (fragments)
       // commonly hold block-uniform data when populated from block-uniform
       // global addresses (e.g., a per-thread fragment that every thread
-      // fills with the same global value).  If the access indices actually
+      // fills with the same global value). If the access indices actually
       // depend on threadIdx, the recursive visit of args below (via
       // IRMutatorWithAnalyzer::VisitExpr_) will correctly mark the
       // condition as non-block-uniform through VisitExpr_(VarNode*).
@@ -700,6 +709,49 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     }
     LOG(FATAL) << "Thread variable " << tag << " not found";
     return IterVar();
+  }
+
+  /*!
+   * \brief Try to prove that every thread reaches the same verdict on
+   *        \p condition.
+   *
+   * Builds two thread instances and proves they agree under the live constraint
+   * set, a `T.assume` included. `CanProve` quantifies over the free variables,
+   * so this asks the `forall unknowns, forall tx1, tx2` question -- which is
+   * how `tx < n` comes out uniform under `assume(n % 128 == 0)`, something the
+   * syntax alone cannot show.
+   *
+   * Only ever *adds* uniformity to the syntactic estimate: failing to prove
+   * agreement is not a proof of disagreement, and the prover has a resource
+   * limit.
+   */
+  bool IsBlockUniformCondition(const PrimExpr &condition) {
+    Map<Var, PrimExpr> sub1, sub2;
+    for (const auto &iv : env_threads_) {
+      if (runtime::ThreadScope::Create(iv->thread_tag).rank != 1)
+        continue;
+      sub1.Set(iv->var, Var(iv->var->name_hint + "<T1>", iv->var.dtype()));
+      sub2.Set(iv->var, Var(iv->var->name_hint + "<T2>", iv->var.dtype()));
+    }
+    if (sub1.empty()) {
+      // Nothing is indexed by a thread, so the condition cannot diverge.
+      return true;
+    }
+    ConstrSet cset = GetConstrSet();
+    // Ranges stay shared: an enclosing iteration variable takes the same value
+    // for the two threads being compared.
+    ConstrSet c1 =
+        cset.RenameFrom("<T1>", sub1, std::nullopt, /*rename_ranges=*/false);
+    ConstrSet c2 =
+        cset.RenameFrom("<T2>", sub2, std::nullopt, /*rename_ranges=*/false);
+    arith::Analyzer analyzer;
+    c1.ToConstraints().Merge(c2.ToConstraints()).Populate(analyzer);
+    PrimExpr lhs = Substitute(condition, sub1);
+    PrimExpr rhs = Substitute(condition, sub2);
+    // Spelled out rather than as an equality so that it stays a boolean query.
+    PrimExpr agree = tirx::Or(tirx::And(lhs, rhs),
+                              tirx::And(tirx::Not(lhs), tirx::Not(rhs)));
+    return analyzer.CanProve(agree);
   }
 
   void VisitExpr_(const BufferLoadNode *op) final {
@@ -949,12 +1001,31 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       IterVar tx = GetThreadVar("threadIdx.x");
       auto condition_prop = checker.AnalyzeCondition(op->condition, tx);
 
-      if ((condition_prop.depends_on_runtime &&
-           !condition_prop.is_block_uniform) ||
-          condition_prop.requires_hoist) {
+      // The syntactic estimate calls anything mentioning a thread variable
+      // possibly divergent; ask the prover before hoisting out of a branch that
+      // every thread agrees on. Only added to the estimate, never subtracted.
+      bool proven_uniform = IsBlockUniformCondition(op->condition);
+      bool is_block_uniform = condition_prop.is_block_uniform || proven_uniform;
+      // requires_hoist means the participation count was not established, so
+      // ThreadPartialSyncRewriter cannot emit `bar.sync id, count`. Uniformity
+      // answers that: the barrier is reached either by the whole block, where a
+      // plain __syncthreads() is exactly right, or by nobody. Only a proof
+      // counts here, not the syntactic heuristic.
+      if ((condition_prop.depends_on_runtime && !is_block_uniform) ||
+          (condition_prop.requires_hoist && !proven_uniform)) {
         LOG(WARNING)
             << "[ThreadSync] Hoisting sync from inside if to before if. "
             << "Condition is not safe for in-if sync: " << op->condition;
+        // Both ends of the conflict are inside the branch, since the branch is
+        // summarized from an empty scope. Hoisting therefore keeps every thread
+        // reaching the barrier but stops it separating them; ordering those
+        // needs the branch split around the barrier, which ThreadSyncInserter
+        // cannot express yet.
+        LOG(WARNING) << "[ThreadSync] The hoisted barrier no longer separates "
+                        "the accesses it was inserted for, as both ends of the "
+                        "conflict are inside the branch, so the race remains. "
+                        "Constrain the condition -- a T.assume on the "
+                        "parameters it reads -- to keep the barrier in place.";
         for (const auto &sync : syncs_in_then) {
           syncs_inserted_.erase(sync);
         }
@@ -1459,21 +1530,30 @@ private:
     PrimExpr lhs_max = analyzer.Simplify(lhs.touched[0].max());
     PrimExpr rhs_min = analyzer.Simplify(rhs.touched[0].min());
     PrimExpr rhs_max = analyzer.Simplify(rhs.touched[0].max());
+    Map<Var, PrimExpr> prev_sub, curr_sub;
     for (unsigned idx = 0; idx != 3; ++idx) {
       auto &info = thread_vars[idx];
       Var old_prev_var = lhs.threads[lhs.threads.size() + idx - 3]->var;
       Var old_curr_var = rhs.threads[rhs.threads.size() + idx - 3]->var;
-      Var prev_var(info.name_prev, old_prev_var.dtype());
-      Var curr_var(info.name_curr, old_curr_var.dtype());
-      lhs_min = Substitute(lhs_min, {{old_prev_var, prev_var}});
-      lhs_max = Substitute(lhs_max, {{old_prev_var, prev_var}});
-      prev_cset = prev_cset.Substitute({{old_prev_var, prev_var}});
-      rhs_min = Substitute(rhs_min, {{old_curr_var, curr_var}});
-      rhs_max = Substitute(rhs_max, {{old_curr_var, curr_var}});
-      curr_cset = curr_cset.Substitute({{old_curr_var, curr_var}});
+      prev_sub.Set(old_prev_var, Var(info.name_prev, old_prev_var.dtype()));
+      curr_sub.Set(old_curr_var, Var(info.name_curr, old_curr_var.dtype()));
     }
-    prev_cset.Populate(analyzer);
-    curr_cset.Populate(analyzer);
+    // Two threads here as well, so every per-thread bind needs its own copy;
+    // sharing one would force the two thread variables to agree. Ranges stay
+    // shared: an enclosing iteration variable is the same for both sides.
+    prev_cset = prev_cset.RenameFrom("<PREV>", prev_sub, std::nullopt,
+                                     /*rename_ranges=*/false);
+    curr_cset = curr_cset.RenameFrom("<CURR>", curr_sub, std::nullopt,
+                                     /*rename_ranges=*/false);
+    lhs_min = Substitute(lhs_min, prev_sub);
+    lhs_max = Substitute(lhs_max, prev_sub);
+    rhs_min = Substitute(rhs_min, curr_sub);
+    rhs_max = Substitute(rhs_max, curr_sub);
+    // Lower to predicates before merging so that a variable bound to different
+    // values on the two sides does not trip the analyzer's re-bind check.
+    prev_cset.ToConstraints()
+        .Merge(curr_cset.ToConstraints())
+        .Populate(analyzer);
 
     if (analyzer.CanProve(lhs_max < rhs_min,
                           arith::ProofStrength::kSymbolicBound)) {
@@ -1696,15 +1776,19 @@ private:
           tirx::Or(tirx::Not(curr_constr), prev_constr));
 
       if (prev_implies_curr && curr_implies_prev) {
-        // If constraints are equivalent, they are not in conflict
+        // Same index, same participants: a collision would mean two threads
+        // wrote one location (RAR never reaches FindConflict), which is
+        // undefined behaviour rather than a hazard to order.
         return false;
-      } else {
-        // If constraints are not equivalent, they are in conflict
-        return true;
       }
+      // Unequal participation alone says nothing about two threads reaching the
+      // same address; a real same-index hazard needs a non-injective index too,
+      // which the cross-thread proof below decides. Fall through.
     }
 
-    // Indices are different, need to check if they can overlap
+    // Check whether two distinct threads can touch the same byte. Proving the
+    // addresses unequal shows the index is injective over the participating
+    // threads, which rules out a hazard for same and different indices alike.
     bool range_is_overlap = true;
 
     for (size_t i = 0; i < prev.buffer_indices.size(); i++) {
@@ -1776,8 +1860,27 @@ private:
       if (!same_access_type) {
         analyzer.EnterConstraint(thread_condition);
       }
-      prev_cset.Substitute(prev_sub).Populate(analyzer);
-      curr_cset.Substitute(curr_sub).Populate(analyzer);
+      // Two instances of the same code in one analyzer, so per-instance binds
+      // need their own copy; see ConstrSet::RenameFrom. The instances differ
+      // when they are two threads (RAW/WAR) or two iterations of one thread
+      // (loop carry); a same-type pair within one iteration is a single
+      // execution, where a bind holds one value and renaming would lose it.
+      // Ranges stay shared, which loop_shift_sub and the bind above assume too.
+      if (!same_access_type || loop != nullptr) {
+        prev_cset = prev_cset.RenameFrom("<PREV>", prev_sub, std::nullopt,
+                                         /*rename_ranges=*/false);
+        curr_cset = curr_cset.RenameFrom("<CURR>", curr_sub, std::nullopt,
+                                         /*rename_ranges=*/false);
+      } else {
+        prev_cset = prev_cset.Substitute(prev_sub);
+        curr_cset = curr_cset.Substitute(curr_sub);
+      }
+      // Lower to predicates before merging: the analyzer already binds the loop
+      // variable to an adjusted range above while each side still carries its
+      // full range, so keeping the binds would trip the re-bind check.
+      prev_cset.ToConstraints()
+          .Merge(curr_cset.ToConstraints())
+          .Populate(analyzer);
       bool provably_disjoint = false;
 
       prev_indice_bytes =

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -527,12 +527,10 @@ private:
     if (it != let_var_properties_.end()) {
       current_.Merge(it->second);
     } else {
-      // Any other free variable (a kernel parameter, blockIdx, an enclosing
-      // serial loop var) has no compile-time value, so the participating thread
-      // set is unknown; the participation counter cannot help either, as it
-      // enumerates the thread variable alone. Leave is_block_uniform alone so
-      // that a condition built only from these (`bx < 2`, `flags[bx] > 0`)
-      // keeps its sync in place.
+      // A kernel parameter, blockIdx or an enclosing serial loop var has no
+      // compile-time value, so the participating set is unknown. Leave
+      // is_block_uniform alone, so a condition built only from these
+      // (`bx < 2`, `flags[bx] > 0`) keeps its sync in place.
       current_.depends_on_runtime = true;
     }
     return GetRef<Var>(op);
@@ -713,17 +711,13 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
 
   /*!
    * \brief Try to prove that every thread reaches the same verdict on
-   *        \p condition.
+   *        \p condition, using the live constraint set as premises.
    *
-   * Builds two thread instances and proves they agree under the live constraint
-   * set, a `T.assume` included. `CanProve` quantifies over the free variables,
-   * so this asks the `forall unknowns, forall tx1, tx2` question -- which is
-   * how `tx < n` comes out uniform under `assume(n % 128 == 0)`, something the
-   * syntax alone cannot show.
-   *
-   * Only ever *adds* uniformity to the syntactic estimate: failing to prove
-   * agreement is not a proof of disagreement, and the prover has a resource
-   * limit.
+   * `CanProve` quantifies over the free variables, so this is the
+   * `forall unknowns, forall tx1, tx2` question -- which is how `tx < n` comes
+   * out uniform under `assume(n % 128 == 0)`. Only ever *adds* uniformity to
+   * the syntactic estimate: failing to prove agreement is not a proof of the
+   * reverse.
    */
   bool IsBlockUniformCondition(const PrimExpr &condition) {
     Map<Var, PrimExpr> sub1, sub2;
@@ -738,8 +732,6 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       return true;
     }
     ConstrSet cset = GetConstrSet();
-    // Ranges stay shared: an enclosing iteration variable takes the same value
-    // for the two threads being compared.
     ConstrSet c1 =
         cset.RenameFrom("<T1>", sub1, std::nullopt, /*rename_ranges=*/false);
     ConstrSet c2 =
@@ -1001,26 +993,20 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       IterVar tx = GetThreadVar("threadIdx.x");
       auto condition_prop = checker.AnalyzeCondition(op->condition, tx);
 
-      // The syntactic estimate calls anything mentioning a thread variable
-      // possibly divergent; ask the prover before hoisting out of a branch that
-      // every thread agrees on. Only added to the estimate, never subtracted.
+      // The estimate calls anything mentioning a thread variable divergent; ask
+      // the prover before hoisting. Only added to it, never subtracted.
       bool proven_uniform = IsBlockUniformCondition(op->condition);
       bool is_block_uniform = condition_prop.is_block_uniform || proven_uniform;
       // requires_hoist means the participation count was not established, so
       // ThreadPartialSyncRewriter cannot emit `bar.sync id, count`. Uniformity
-      // answers that: the barrier is reached either by the whole block, where a
-      // plain __syncthreads() is exactly right, or by nobody. Only a proof
-      // counts here, not the syntactic heuristic.
+      // answers that: the barrier is reached by the whole block or by nobody,
+      // and a plain __syncthreads() is right. Only a proof counts, not the
+      // heuristic.
       if ((condition_prop.depends_on_runtime && !is_block_uniform) ||
           (condition_prop.requires_hoist && !proven_uniform)) {
         LOG(WARNING)
             << "[ThreadSync] Hoisting sync from inside if to before if. "
             << "Condition is not safe for in-if sync: " << op->condition;
-        // Both ends of the conflict are inside the branch, since the branch is
-        // summarized from an empty scope. Hoisting therefore keeps every thread
-        // reaching the barrier but stops it separating them; ordering those
-        // needs the branch split around the barrier, which ThreadSyncInserter
-        // cannot express yet.
         LOG(WARNING) << "[ThreadSync] The hoisted barrier no longer separates "
                         "the accesses it was inserted for, as both ends of the "
                         "conflict are inside the branch, so the race remains. "
@@ -1786,9 +1772,8 @@ private:
       // which the cross-thread proof below decides. Fall through.
     }
 
-    // Check whether two distinct threads can touch the same byte. Proving the
-    // addresses unequal shows the index is injective over the participating
-    // threads, which rules out a hazard for same and different indices alike.
+    // Proving the addresses unequal shows the index is injective over the
+    // participating threads, which rules out a hazard for any pair of indices.
     bool range_is_overlap = true;
 
     for (size_t i = 0; i < prev.buffer_indices.size(); i++) {
@@ -1860,12 +1845,11 @@ private:
       if (!same_access_type) {
         analyzer.EnterConstraint(thread_condition);
       }
-      // Two instances of the same code in one analyzer, so per-instance binds
-      // need their own copy; see ConstrSet::RenameFrom. The instances differ
-      // when they are two threads (RAW/WAR) or two iterations of one thread
-      // (loop carry); a same-type pair within one iteration is a single
-      // execution, where a bind holds one value and renaming would lose it.
-      // Ranges stay shared, which loop_shift_sub and the bind above assume too.
+      // Two instances in one analyzer, so per-instance binds need their own
+      // copy; see ConstrSet::RenameFrom. They differ when they are two threads
+      // (RAW/WAR) or two iterations of one thread (loop carry); a same-type
+      // pair within one iteration is one execution, where renaming would only
+      // lose the bind.
       if (!same_access_type || loop != nullptr) {
         prev_cset = prev_cset.RenameFrom("<PREV>", prev_sub, std::nullopt,
                                          /*rename_ranges=*/false);

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -994,8 +994,11 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       auto condition_prop = checker.AnalyzeCondition(op->condition, tx);
 
       // The estimate calls anything mentioning a thread variable divergent; ask
-      // the prover before hoisting. Only added to it, never subtracted.
-      bool proven_uniform = IsBlockUniformCondition(op->condition);
+      // the prover before hoisting. Only added to it, never subtracted, and
+      // only asked when something below could act on the answer.
+      bool may_hoist =
+          condition_prop.depends_on_runtime || condition_prop.requires_hoist;
+      bool proven_uniform = may_hoist && IsBlockUniformCondition(op->condition);
       bool is_block_uniform = condition_prop.is_block_uniform || proven_uniform;
       // requires_hoist means the participation count was not established, so
       // ThreadPartialSyncRewriter cannot emit `bar.sync id, count`. Uniformity
@@ -1005,13 +1008,14 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       if ((condition_prop.depends_on_runtime && !is_block_uniform) ||
           (condition_prop.requires_hoist && !proven_uniform)) {
         LOG(WARNING)
-            << "[ThreadSync] Hoisting sync from inside if to before if. "
-            << "Condition is not safe for in-if sync: " << op->condition;
-        LOG(WARNING) << "[ThreadSync] The hoisted barrier no longer separates "
-                        "the accesses it was inserted for, as both ends of the "
-                        "conflict are inside the branch, so the race remains. "
-                        "Constrain the condition -- a T.assume on the "
-                        "parameters it reads -- to keep the barrier in place.";
+            << "[ThreadSync] Hoisting sync out of an if whose condition is not "
+               "safe for an in-if sync. This is not a fix: both ends of the "
+               "conflict are inside the branch, so the hoisted barrier no "
+               "longer separates them and the race remains. Constraining the "
+               "condition -- a T.assume on the parameters it reads -- keeps "
+               "the "
+               "barrier in place instead. Condition: "
+            << op->condition;
         for (const auto &sync : syncs_in_then) {
           syncs_inserted_.erase(sync);
         }

--- a/src/transform/verify_parallel_loop.cc
+++ b/src/transform/verify_parallel_loop.cc
@@ -49,12 +49,9 @@ struct ParallelLoopVerifier : public ConstrVisitor {
 
     ConstrSet cset{constr_stack_};
     // Model a second logical iteration. Renaming starts at the outermost
-    // parallel loop variable: everything defined before it is outside all
-    // parallelism, hence invariant and shared, while the parallel loop
-    // variables and any bind inside the region are private to an iteration and
-    // must get their own copy -- sharing them would force the parallel loop
-    // variables equal. Merge (not append) so that a bind kept shared is not
-    // populated twice.
+    // parallel loop variable: binds before it are outside all parallelism and
+    // stay shared, while the loop variables and anything inside the region are
+    // private per iteration. Merge, so a shared bind is not populated twice.
     Map<Var, PrimExpr> subs;
     cset = cset.Merge(
         cset.RenameFrom("<OTHER>", subs, parallel_loop_vars_.front()));

--- a/src/transform/verify_parallel_loop.cc
+++ b/src/transform/verify_parallel_loop.cc
@@ -48,40 +48,30 @@ struct ParallelLoopVerifier : public ConstrVisitor {
     }
 
     ConstrSet cset{constr_stack_};
-    std::vector<std::pair<Var, Var>> parallel_var_pairs;
-    std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> parallel_vars;
+    // Model a second logical iteration. Renaming starts at the outermost
+    // parallel loop variable: everything defined before it is outside all
+    // parallelism, hence invariant and shared, while the parallel loop
+    // variables and any bind inside the region are private to an iteration and
+    // must get their own copy -- sharing them would force the parallel loop
+    // variables equal. Merge (not append) so that a bind kept shared is not
+    // populated twice.
     Map<Var, PrimExpr> subs;
-    for (const auto &var : parallel_loop_vars_) {
-      Var other_var(var->name_hint + "<OTHER>", var->dtype);
-      parallel_var_pairs.emplace_back(var, other_var);
-      parallel_vars.insert(var);
-      subs.Set(var, other_var);
-    }
-
-    // Bind variables defined within a parallel loop are private SSA values of
-    // each logical iteration. Give the second iteration its own definitions;
-    // sharing them would incorrectly force the parallel loop variables equal.
-    bool inside_parallel_scope = false;
-    for (const Constr &constr : constr_stack_) {
-      if (constr.kind == Constr::kBindRange &&
-          parallel_vars.count(constr.var)) {
-        inside_parallel_scope = true;
-      } else if (inside_parallel_scope && constr.kind == Constr::kBindValue) {
-        Var other_var(constr.var->name_hint + "<OTHER>", constr.var->dtype);
-        subs.Set(constr.var, other_var);
-      }
-    }
-
-    cset.Extend(cset.Substitute(subs));
+    cset = cset.Merge(
+        cset.RenameFrom("<OTHER>", subs, parallel_loop_vars_.front()));
     for (const auto &idx : op->indices) {
       cset.AddConstr(idx == tirx::Substitute(idx, subs));
     }
     arith::Analyzer analyzer;
     cset.Populate(analyzer);
 
+    Array<Var> parallel_var_pairs;
     PrimExpr same_iteration = Bool(true);
-    for (const auto &[var, other_var] : parallel_var_pairs) {
-      same_iteration = And(same_iteration, EQ(var, other_var));
+    for (const auto &var : parallel_loop_vars_) {
+      auto it = subs.find(var);
+      if (it != subs.end()) {
+        same_iteration = And(same_iteration, EQ(var, (*it).second));
+        parallel_var_pairs.push_back(var);
+      }
     }
     PrimExpr same_value = op->value == tirx::Substitute(op->value, subs);
     PrimExpr race_free = Or(same_iteration, same_value);
@@ -91,8 +81,8 @@ struct ParallelLoopVerifier : public ConstrVisitor {
     }
 
     Array<Var> failed_vars;
-    for (const auto &[var, other_var] : parallel_var_pairs) {
-      if (!analyzer.CanProve(EQ(var, other_var))) {
+    for (const auto &var : parallel_var_pairs) {
+      if (!analyzer.CanProve(EQ(var, subs.at(var)))) {
         failed_vars.push_back(var);
       }
     }

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -843,7 +843,7 @@ def test_partial_sync_warp_multiple_still_lowered():
 #   sits under a thread-divergent guard.
 # * the cross-thread path instantiates the same code twice, once per thread. A
 #   definition shared between the two instances forces the two thread variables
-#   to agree, which shrinks -- or empties -- the domain the disjointness proof
+#   to agree, which shrinks -- or empties -- the domain the disjointedness proof
 #   runs on, so a real hazard can be "proven" away.
 # =============================================================================
 
@@ -1185,7 +1185,7 @@ def test_bool_bind_does_not_hide_cross_thread_hazard():
     integer values away, so a predicate such as ``tx < 64`` reaches ThreadSync
     intact. Sharing it between the two instances asserts
     ``(tx1 < 64) == (tx2 < 64)``, confining both threads to the same half of the
-    block and letting the disjointness proof succeed where it must not.
+    block and letting the disjointedness proof succeed where it must not.
     """
 
     @T.prim_func(private=True)

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -843,7 +843,7 @@ def test_partial_sync_warp_multiple_still_lowered():
 #   sits under a thread-divergent guard.
 # * the cross-thread path instantiates the same code twice, once per thread. A
 #   definition shared between the two instances forces the two thread variables
-#   to agree, which shrinks -- or empties -- the domain the disjointedness proof
+#   to agree, which shrinks -- or empties -- the domain the disjointness proof
 #   runs on, so a real hazard can be "proven" away.
 # =============================================================================
 
@@ -1185,7 +1185,7 @@ def test_bool_bind_does_not_hide_cross_thread_hazard():
     integer values away, so a predicate such as ``tx < 64`` reaches ThreadSync
     intact. Sharing it between the two instances asserts
     ``(tx1 < 64) == (tx2 < 64)``, confining both threads to the same half of the
-    block and letting the disjointedness proof succeed where it must not.
+    block and letting the disjointness proof succeed where it must not.
     """
 
     @T.prim_func(private=True)

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -17,6 +17,10 @@ def run_passes(func: tvm.tirx.PrimFunc):
     return tilelang.transform.ThreadSync("shared")(mod)
 
 
+def run_passes_script(func: tvm.tirx.PrimFunc) -> str:
+    return str(run_passes(func).script())
+
+
 @tilelang.testing.requires_cuda
 def test_no_sync_between_atomic_adds_to_shared():
     """Atomic WAW (and RMW) should not trigger thread-level sync insertion.
@@ -149,8 +153,18 @@ def test_sync_if_with_same_index():
     assert "T.tvm_storage_sync" in str(mod.script())
 
 
-@tilelang.testing.requires_cuda
-def test_sync_if_with_same_index_with_modulo_if():
+def test_no_sync_if_with_same_index_with_modulo_if():
+    """A thread-private update needs no barrier even under a divergent guard.
+
+    Every thread accesses ``temp_shared[threadIdx_x]`` and nothing else, so the
+    index is injective and no two threads ever reach the same address; the
+    threads that skip the guarded write simply read an uninitialised slot, which
+    is not a cross-thread hazard. Unequal participation alone (only
+    ``tx % 4 == 0`` writes, everybody reads) is one of the two conditions a
+    same-index hazard needs -- the other being a non-injective index -- so it
+    must not by itself trigger a barrier.
+    """
+
     @T.prim_func(check_well_formed=False)
     def func() -> None:
         threadIdx_x = T.env_thread("threadIdx.x")
@@ -168,7 +182,7 @@ def test_sync_if_with_same_index_with_modulo_if():
         result_local[0] = temp_shared[threadIdx_x]
 
     mod = run_passes(func)
-    assert "T.tvm_storage_sync" in str(mod.script())
+    assert "T.tvm_storage_sync" not in str(mod.script())
 
 
 @tilelang.testing.requires_cuda
@@ -545,14 +559,14 @@ def test_sync_hoist_non_uniform_if_with_threadidx():
     assert sync_pos < if_pos, f"Sync should be before if statement:\n{s}"
 
 
-@tilelang.testing.requires_cuda
-def test_sync_hoist_non_uniform_if_shared_memory_condition():
-    """Test sync hoisting when if condition reads from shared memory with thread-dependent index.
+def test_no_sync_for_thread_private_read_inside_non_uniform_if():
+    """A thread-private read guarded by a non-uniform condition needs no barrier.
 
-    This is the exact pattern that caused the original deadlock:
-    - Condition reads shared memory at index depending on threadIdx
-    - Different threads get different values -> non-uniform condition
-    - Sync inside if would cause deadlock
+    This is the shape that caused the original deadlock report: the condition
+    reads shared memory at a threadIdx-dependent index, so a barrier inside the
+    branch would hang. The guarded access is ``data_shared[tx]`` though -- the
+    slot this very thread wrote just above -- so no two threads reach the same
+    address and there is nothing to order.
     """
 
     @T.prim_func(private=True)
@@ -571,18 +585,12 @@ def test_sync_hoist_non_uniform_if_shared_memory_condition():
         # token_ids[tx] can be different for each thread (e.g., some are -1, some are valid)
         if token_ids[tx] != -1:
             # Inside the if, we read from data_shared
-            # Sync is needed but must be hoisted because condition is non-uniform
             result_local[0] = data_shared[tx]
 
     mod = tvm.IRModule({"main": func})
     mod = tilelang.transform.ThreadSync("shared")(mod)
     s = str(mod.script())
-    # Sync should appear before the if statement
-    assert 'T.tvm_storage_sync("shared")' in s, f"Expected sync:\n{s}"
-    # The sync should be before the if that checks token_ids
-    sync_pos = s.index('T.tvm_storage_sync("shared")')
-    if_pos = s.index("if token_ids")
-    assert sync_pos < if_pos, f"Sync should be hoisted before non-uniform if:\n{s}"
+    assert 'T.tvm_storage_sync("shared")' not in s, f"Unexpected sync:\n{s}"
 
 
 @tilelang.testing.requires_cuda
@@ -675,9 +683,13 @@ def test_sync_hoist_nested_non_uniform_if():
     assert sync_pos < if_pos, f"Sync should be hoisted before outer if:\n{s}"
 
 
-@tilelang.testing.requires_cuda
-def test_sync_hoist_non_uniform_if_in_loop():
-    """Test sync hoisting when non-uniform if is inside a loop."""
+def test_no_sync_for_thread_private_read_inside_non_uniform_if_in_loop():
+    """Same shape as above inside a loop, and still thread private.
+
+    Iteration ``k`` writes ``data_shared[tx]`` and the guarded read of iteration
+    ``k`` or ``k + 1`` targets the same slot, always from the same thread, so
+    program order already orders them.
+    """
 
     @T.prim_func(private=True)
     def func():
@@ -699,9 +711,7 @@ def test_sync_hoist_non_uniform_if_in_loop():
     mod = tvm.IRModule({"main": func})
     mod = tilelang.transform.ThreadSync("shared")(mod)
     s = str(mod.script())
-    assert 'T.tvm_storage_sync("shared")' in s, f"Expected sync:\n{s}"
-    # Sync should be before the if inside the loop, not inside the if
-    # This ensures all threads can reach the sync point
+    assert 'T.tvm_storage_sync("shared")' not in s, f"Unexpected sync:\n{s}"
 
 
 @tilelang.testing.requires_cuda
@@ -733,9 +743,12 @@ def test_no_sync_needed_uniform_accesses():
     assert 'T.tvm_storage_sync("shared")' not in s, f"Unexpected sync:\n{s}"
 
 
-@tilelang.testing.requires_cuda
-def test_sync_hoist_non_uniform_if_in_loop_with_shared_memory():
-    """Test sync hoisting when non-uniform if is inside a loop with shared memory."""
+def test_no_sync_for_thread_private_write_read_by_if_condition_in_loop():
+    """A non-uniform condition reading the slot the same thread just wrote.
+
+    The write and the condition's read are both ``token_ids[tx]``, so the pair is
+    thread private even though the condition is divergent and sits in a loop.
+    """
 
     @T.prim_func(private=True)
     def func():
@@ -756,11 +769,7 @@ def test_sync_hoist_non_uniform_if_in_loop_with_shared_memory():
     mod = tvm.IRModule({"main": func})
     mod = tilelang.transform.ThreadSync("shared")(mod)
     s = str(mod.script())
-    assert 'T.tvm_storage_sync("shared")' in s, f"Expected sync:\n{s}"
-    # Sync should be before the if inside the loop, not inside the if
-    sync_pos = s.index('T.tvm_storage_sync("shared")')
-    if_pos = s.index("if token_ids[tx] >= 0")
-    assert sync_pos < if_pos, f"Sync should be hoisted before non-uniform if:\n{s}"
+    assert 'T.tvm_storage_sync("shared")' not in s, f"Unexpected sync:\n{s}"
 
 
 @tilelang.testing.requires_cuda
@@ -816,6 +825,464 @@ def test_partial_sync_warp_multiple_still_lowered():
     mod = tilelang.transform.ThreadSync("shared")(mod)
     s = str(mod.script())
     assert re.search(r'tvm_storage_sync\("shared",\s*\d+,\s*32\)', s), f"Expected a partial barrier with thread_count=32:\n{s}"
+
+
+# =============================================================================
+# Tests for flat Bind definitions inside the recorded constraint sets
+#
+# ``AccessEntry.cset`` snapshots the constraint stack that is live when an access
+# is recorded, so it also carries the definitions of the flat ``Bind`` statements
+# that precede the access. A definition is not a participation constraint -- it
+# never restricts which threads execute an access -- and feeding it to the prover
+# as a proposition ``var == value`` distorts both queries in ``FindConflict``:
+#
+# * the same-index path compares the two constraint sets for logical equivalence.
+#   A write sitting behind extra definitions can never be proven equivalent to
+#   the matching read, so a thread-private read-modify-write is reported as a
+#   hazard -- a spurious barrier, which is undefined behaviour once the access
+#   sits under a thread-divergent guard.
+# * the cross-thread path instantiates the same code twice, once per thread. A
+#   definition shared between the two instances forces the two thread variables
+#   to agree, which shrinks -- or empties -- the domain the disjointness proof
+#   runs on, so a real hazard can be "proven" away.
+# =============================================================================
+
+
+def test_no_sync_for_thread_private_read_modify_write():
+    """``v = s[tx]; s[tx] = f(v)`` is thread private and needs no barrier.
+
+    Every thread reads and writes the one element it owns, so no two threads
+    touch the same address. The read is recorded while evaluating the bind's
+    value, making the write's constraint set the read's plus ``v == s[tx]``.
+    """
+
+    @T.prim_func(private=True)
+    def func():
+        s = T.alloc_buffer((128,), dtype="float32", scope="shared")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        v: T.float32 = s[tx]
+        s[tx] = v * T.float32(2)
+
+    s = run_passes_script(func)
+    assert 'T.tvm_storage_sync("shared")' not in s, f"Unexpected sync for a thread-private update:\n{s}"
+
+
+def test_no_sync_for_thread_private_pair_read_modify_write():
+    """A butterfly-looking update where each thread owns both slots it touches.
+
+    Thread ``t`` reads and writes exactly ``{2t, 2t+1}``; those sets are pairwise
+    disjoint, so there is no cross-thread dependency to order.
+    """
+
+    @T.prim_func(private=True)
+    def func():
+        s = T.alloc_buffer((128,), dtype="float32", scope="shared")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 64)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        x1: T.float32 = s[tx * 2]
+        x2: T.float32 = s[tx * 2 + 1]
+        s[tx * 2] = x1 + x2
+        s[tx * 2 + 1] = x1 - x2
+
+    s = run_passes_script(func)
+    assert 'T.tvm_storage_sync("shared")' not in s, f"Unexpected sync for per-thread private pairs:\n{s}"
+
+
+def test_no_plain_sync_inside_divergent_symbolic_guard():
+    """A barrier must never be emitted inside a thread-divergent guard.
+
+    ``bx * 4 + tx // 32 < n`` mixes a thread variable with a runtime parameter,
+    so for a tail block only some warps enter. A block-wide barrier inside the
+    branch is then waited on by a subset of the block, which hangs. Whether or
+    not the pass considers the guarded update a hazard, any barrier it emits has
+    to sit outside the guard.
+    """
+
+    @T.prim_func(private=True)
+    def func(n: T.int32):
+        s = T.alloc_buffer((128,), dtype="float32", scope="shared")
+        bx = T.launch_thread("blockIdx.x", 32)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        if bx * 4 + tx // 32 < n:
+            v: T.float32 = s[tx]
+            s[tx] = v * T.float32(2)
+
+    s = run_passes_script(func)
+    if 'T.tvm_storage_sync("shared")' in s:
+        sync_pos = s.index('T.tvm_storage_sync("shared")')
+        if_pos = s.index("if ")
+        assert sync_pos < if_pos, f"Barrier must be hoisted out of the divergent guard:\n{s}"
+
+
+def test_unorderable_hazard_in_divergent_guard_is_reported(capfd):
+    """A hazard confined to a divergent branch has no correct barrier placement.
+
+    ``bx * 4 + tx // 32 < n`` mixes a thread variable with a runtime parameter, so
+    for a tail block only some warps enter, and both ends of the hazard are inside
+    that branch. A barrier inside it hangs on the threads that skip the branch,
+    while one in front of it is reached by everyone but no longer separates the
+    accesses. Ordering this needs the branch split around the barrier, which the
+    pass cannot express, so reporting the program is the only thing it can get
+    right. Where the barrier ends up is deliberately not asserted.
+    """
+
+    @T.prim_func(private=True)
+    def func(n: T.int32):
+        s = T.alloc_buffer((128,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 32)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        if bx * 4 + tx // 32 < n:
+            s[tx] = T.cast(tx, "float32")
+            l[0] = s[(tx + 64) % 128]
+
+    run_passes_script(func)
+    warnings = capfd.readouterr().err
+    assert "no longer separates" in warnings, f"Expected the pass to report the hazard:\n{warnings}"
+
+
+def test_unorderable_hazard_in_divergent_else_branch_is_reported(capfd):
+    """The else branch needs the same treatment as the then branch.
+
+    Syncs found in either arm are tracked separately, so a hazard placed only in
+    the else arm exercises the second of the two paths. It is as unorderable as
+    the one above, so again only the report is asserted.
+    """
+
+    @T.prim_func(private=True)
+    def func(n: T.int32):
+        s = T.alloc_buffer((128,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        if tx < n:
+            l[0] = 0.0
+        else:
+            s[tx] = T.cast(tx, "float32")
+            l[0] = s[(tx + 64) % 128]
+
+    run_passes_script(func)
+    warnings = capfd.readouterr().err
+    assert "no longer separates" in warnings, f"Expected the pass to report the hazard:\n{warnings}"
+
+
+def test_sync_stays_inside_guard_proven_uniform_by_premise(capfd):
+    """A premise can make a threadIdx-dependent guard provably block uniform.
+
+    ``tx < n`` mentions a thread variable, so no inspection of the condition can
+    call it uniform. But given ``n % 128 == 0`` and a block of 128 threads, either
+    all of them enter or none do. This is the one shape here that does have a
+    correct answer, so the placement is asserted: the barrier stays inside the
+    branch, where it still separates the two accesses, and nothing is reported.
+    """
+
+    @T.prim_func(private=True)
+    def func(n: T.int32):
+        s = T.alloc_buffer((128,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        with T.Assert(n % 128 == 0, "n must be a multiple of the block size"):
+            if tx < n:
+                s[tx] = T.cast(tx, "float32")
+                l[0] = s[(tx + 64) % 128]
+
+    s = run_passes_script(func)
+    warnings = capfd.readouterr().err
+    assert 'T.tvm_storage_sync("shared")' in s, f"Expected a barrier for a cross-thread hazard:\n{s}"
+    sync_pos = s.index('T.tvm_storage_sync("shared")')
+    if_pos = s.index("if tx < n")
+    assert sync_pos > if_pos, f"Barrier should stay inside the uniform guard:\n{s}"
+    assert "no longer separates" not in warnings, f"A provably uniform guard should not be reported:\n{warnings}"
+
+
+def test_premise_weaker_than_the_block_is_not_taken_as_uniform(capfd):
+    """The premise has to rule divergence out for the block size actually used.
+
+    ``n % 64 == 0`` with a block of 128 threads still admits ``n == 64``, where
+    half the block enters. This pins down the boundary of the check above: it must
+    accept a premise only when the premise really excludes divergence. The guard
+    is therefore treated as divergent, which for this shape means reported.
+    """
+
+    @T.prim_func(private=True)
+    def func(n: T.int32):
+        s = T.alloc_buffer((128,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        with T.Assert(n % 64 == 0, "n must be a multiple of half the block"):
+            if tx < n:
+                s[tx] = T.cast(tx, "float32")
+                l[0] = s[(tx + 64) % 128]
+
+    run_passes_script(func)
+    warnings = capfd.readouterr().err
+    assert "no longer separates" in warnings, f"A premise that still allows divergence must not be accepted:\n{warnings}"
+
+
+def test_premise_holds_across_an_enclosing_guard():
+    """A premise stated outside an enclosing branch still reaches the inner guard.
+
+    The constraint set accumulates down the nesting, so ``n % 128 == 0`` is
+    available where ``tx < n`` is judged even though an ``if n > 0`` sits in
+    between.
+    """
+
+    @T.prim_func(private=True)
+    def func(n: T.int32):
+        s = T.alloc_buffer((128,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        with T.Assert(n % 128 == 0, "n must be a multiple of the block size"):
+            if n > 0:
+                if tx < n:
+                    s[tx] = T.cast(tx, "float32")
+                    l[0] = s[(tx + 64) % 128]
+
+    s = run_passes_script(func)
+    assert 'T.tvm_storage_sync("shared")' in s, f"Expected a barrier for a cross-thread hazard:\n{s}"
+    sync_pos = s.index('T.tvm_storage_sync("shared")')
+    if_pos = s.index("if tx < n")
+    assert sync_pos > if_pos, f"Barrier should stay inside the uniform guard:\n{s}"
+
+
+def test_premise_covers_every_thread_dimension():
+    """Uniformity has to hold over all of threadIdx.x/y/z, not just x.
+
+    With ``threadIdx.y`` extended, two threads compared for divergence may differ
+    in ``y`` as well as ``x``; the guard is still uniform, and the barrier stays.
+    """
+
+    @T.prim_func(private=True)
+    def func(n: T.int32):
+        s = T.alloc_buffer((256,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 2)
+        tz = T.launch_thread("threadIdx.z", 1)
+        with T.Assert(n % 128 == 0, "n must be a multiple of the x extent"):
+            if tx < n:
+                s[ty * 128 + tx] = T.cast(tx, "float32")
+                l[0] = s[ty * 128 + (tx + 64) % 128]
+
+    s = run_passes_script(func)
+    assert 'T.tvm_storage_sync("shared")' in s, f"Expected a barrier for a cross-thread hazard:\n{s}"
+    sync_pos = s.index('T.tvm_storage_sync("shared")')
+    if_pos = s.index("if tx < n")
+    assert sync_pos > if_pos, f"Barrier should stay inside the uniform guard:\n{s}"
+
+
+def test_assume_serves_as_a_premise_like_an_assert():
+    """``T.assume`` reaches the check the same way an assert does.
+
+    An assume is what a caller-facing constraint looks like in practice, and it
+    arrives as a scoped attribute rather than a flat statement, so it exercises
+    the other of the two shapes a premise can take.
+    """
+
+    @T.prim_func(private=True)
+    def func(n: T.int32):
+        s = T.alloc_buffer((128,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        T.assume(n % 128 == 0)
+        if tx < n:
+            s[tx] = T.cast(tx, "float32")
+            l[0] = s[(tx + 64) % 128]
+
+    mod = tvm.IRModule.from_expr(func)
+    cuda_target = tvm.target.Target("cuda", host="llvm")
+    mod = tvm.tirx.transform.Apply(lambda f: f.with_attr({"global_symbol": "test", "target": cuda_target}))(mod)
+    mod = tvm.tirx.transform.AnnotateDeviceRegions()(mod)
+    mod = tvm.tirx.transform.SplitHostDevice()(mod)
+    mod = tilelang.transform.InjectAssumes()(mod)
+    s = str(tilelang.transform.ThreadSync("shared")(mod).script())
+
+    assert 'T.tvm_storage_sync("shared")' in s, f"Expected a barrier for a cross-thread hazard:\n{s}"
+    sync_pos = s.index('T.tvm_storage_sync("shared")')
+    if_pos = s.index("if tx < n")
+    assert sync_pos > if_pos, f"Barrier should stay inside the uniform guard:\n{s}"
+
+
+def test_hazard_across_split_divergent_symbolic_guard_is_ordered():
+    """The accepted shape for the program above: split the guard by hand.
+
+    With the branch split around the synchronization point, the two accesses no
+    longer sit in one branch: the conflict spans the guard, so the barrier is
+    anchored in the enclosing sequence and is reached by every thread.
+    """
+
+    @T.prim_func(private=True)
+    def func(n: T.int32):
+        s = T.alloc_buffer((128,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 32)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        if bx * 4 + tx // 32 < n:
+            s[tx] = T.cast(tx, "float32")
+        if bx * 4 + tx // 32 < n:
+            l[0] = s[(tx + 64) % 128]
+
+    s = run_passes_script(func)
+    assert 'T.tvm_storage_sync("shared")' in s, f"Expected a barrier for a cross-thread hazard:\n{s}"
+
+
+def test_bind_definition_does_not_hide_cross_thread_hazard():
+    """A bind that is live across both accesses must not weaken the analysis.
+
+    ``idx`` is defined before both the write and the read, so both constraint
+    sets carry its definition. Sharing it would state ``idx == tx1 + 7`` and
+    ``idx == tx2 + 7``, forcing ``tx1 == tx2`` against the proof's ``tx1 != tx2``:
+    every query would hold vacuously and the real hazard -- thread ``t`` reads the
+    slot owned by ``t + 7`` -- would be "proven" absent.
+    """
+
+    @T.prim_func(private=True)
+    def func():
+        s = T.alloc_buffer((128,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        idx: T.int32 = tx + 7
+        s[tx] = T.cast(tx, "float32")
+        l[0] = s[idx % 128]
+
+    s = run_passes_script(func)
+    assert 'T.tvm_storage_sync("shared")' in s, f"Missing barrier: a bind definition hid a cross-thread hazard:\n{s}"
+
+
+def test_bool_bind_does_not_hide_cross_thread_hazard():
+    """Same defect, reached through a boolean bind.
+
+    Boolean binds matter in the full pipeline because let-inlining only folds
+    integer values away, so a predicate such as ``tx < 64`` reaches ThreadSync
+    intact. Sharing it between the two instances asserts
+    ``(tx1 < 64) == (tx2 < 64)``, confining both threads to the same half of the
+    block and letting the disjointness proof succeed where it must not.
+    """
+
+    @T.prim_func(private=True)
+    def func():
+        s = T.alloc_buffer((128,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        c: T.bool = tx < 64
+        s[tx] = T.cast(tx, "float32")
+        l[0] = s[(tx + 64) % 128] + T.cast(c, "float32")
+
+    s = run_passes_script(func)
+    assert 'T.tvm_storage_sync("shared")' in s, f"Missing barrier: a boolean bind hid a cross-thread hazard:\n{s}"
+
+
+def test_opaque_bind_index_does_not_hide_cross_thread_hazard():
+    """A bind whose definition is dropped still needs a per-side instance.
+
+    ``a`` is loaded from a buffer, so its definition is dropped from the
+    constraint set rather than substituted away. The variable survives in the two
+    indices, so each side still needs its own copy: sharing one ``a`` would let
+    the prover assume both threads loaded the same value and discharge
+    ``4*a != 4*a + 4``, hiding the hazard between the thread writing ``s[a]`` and
+    the thread whose ``a`` is one lower. Spelling the load out at both indices
+    instead of binding it must give the same answer.
+    """
+
+    @T.prim_func(private=True)
+    def func(idx_buf: T.Buffer((128,), "int32")):
+        s = T.alloc_buffer((256,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        a: T.int32 = idx_buf[tx]
+        s[a] = T.cast(tx, "float32")
+        l[0] = s[a + 1]
+
+    @T.prim_func(private=True)
+    def without_bind(idx_buf: T.Buffer((128,), "int32")):
+        s = T.alloc_buffer((256,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        s[idx_buf[tx]] = T.cast(tx, "float32")
+        l[0] = s[idx_buf[tx] + 1]
+
+    s = run_passes_script(func)
+    assert 'T.tvm_storage_sync("shared")' in s, f"Missing barrier: an opaque bind index hid a cross-thread hazard:\n{s}"
+    assert 'T.tvm_storage_sync("shared")' in run_passes_script(without_bind), "Control case lost its barrier"
+
+
+def test_cross_thread_hazard_still_requires_sync():
+    """Reading another thread's slot is a genuine hazard and must be ordered."""
+
+    @T.prim_func(private=True)
+    def func():
+        s = T.alloc_buffer((128,), dtype="float32", scope="shared")
+        l = T.alloc_buffer((1,), dtype="float32", scope="local")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        s[tx] = T.cast(tx, "float32")
+        l[0] = s[(tx + 64) % 128]
+
+    s = run_passes_script(func)
+    assert 'T.tvm_storage_sync("shared")' in s, f"Expected a barrier for a cross-thread hazard:\n{s}"
+
+
+def test_sync_may_stay_inside_block_uniform_guard():
+    """A guard that does not mention a thread variable is block uniform.
+
+    All threads agree on it, so a barrier inside the branch is reached by the
+    whole block and does not need hoisting.
+    """
+
+    @T.prim_func(private=True)
+    def func(flag: T.int32):
+        s = T.alloc_buffer((128,), dtype="float32", scope="shared")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        if flag < 0:
+            s[tx] = T.cast(tx, "float32")
+            x1: T.float32 = s[(tx + 64) % 128]
+            s[tx] = x1 * T.float32(2)
+
+    s = run_passes_script(func)
+    assert 'T.tvm_storage_sync("shared")' in s, f"Expected a barrier for a cross-thread hazard:\n{s}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed ThreadSync cross-thread race modeling by introducing/using `FreshenMutableReads`, improving constraint renaming/substitution/merging semantics, and refining `is_assume`/assumption handling to avoid incorrect “two-instance” cross-thread equivalence checks.
- Strengthened barrier hoisting decisions under divergent/non-uniform control flow by adding a proof-based “block-uniform condition” check for `if` hoist candidates and refining condition/thread-variable property tracking.
- Improved cross-thread conflict detection by adjusting constraint preparation/instance substitution for disjoint-pointer and cross-thread hazard proofs, and refining same-index conflict short-circuiting.
- Reworked parallel-loop race verification to model “other iteration” constraints via renamed constraint-set merging and updated equality proof logic accordingly.
- Expanded ThreadSync regression coverage for cases where thread-private accesses must not sync (including modulo-`if`, non-uniform if/else branches, loop cases), plus new assertions around barrier insertion and unorderable-hazard reporting with premise/assume/bind interactions.
- Minor doc maintenance: added `disjointness` to the spelling wordlist.

## C++ style / lint notes

- This PR changes C++ implementation/declarations (not documented C++ style rules) and does **not** modify `docs/developer_guide/cpp_style.md`.
- The CI step **“C++ API Style Audit (warning only)”** may emit advisory findings (e.g., TLCPP003/TLCPP004) due to header surface changes (adding `tvm::tl::FreshenMutableReads` and `Constr::FreshenReads`, and related constraint visitor/set behavior). These are warning-only and should be treated separately from correctness/build/test outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->