### PR TITLE
[Enhancement] Aggregate VerifyParallelLoop race diagnostics with span

### DIFF
--- a/src/transform/verify_parallel_loop.cc
+++ b/src/transform/verify_parallel_loop.cc
@@ -1,9 +1,11 @@
 #include "../op/utils.h"
 #include "common/constr_visitor.h"
 #include "layout_reducer.h"
+#include "span_utils.h"
 #include "support/check.h"
 #include "tvm/arith/analyzer.h"
 #include "tvm/ir/expr.h"
+#include <sstream>
 #include <tvm/runtime/logging.h>
 #include <tvm/tirx/analysis.h>
 #include <tvm/tirx/builtin.h>
@@ -24,14 +26,30 @@ using tvm::tl::ConstrSet;
 using tvm::tl::ConstrVisitor;
 
 struct ParallelLoopVerifier : public ConstrVisitor {
+  /*! \brief One suspected data race, reported together at the end. */
+  struct RaceReport {
+    Buffer buffer;
+    Array<PrimExpr> indices;
+    Array<Var> failed_vars;
+    String model;
+    Span span;
+    // Span of the innermost enclosing parallel loop; fallback location when
+    // the store itself carries no span.
+    Span loop_span;
+  };
+
   std::vector<Var> parallel_loop_vars_;
+  std::vector<Span> parallel_loop_spans_;
   std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> reducers;
+  std::vector<RaceReport> reports_;
 
   void VisitStmt_(const ForNode *op) override {
     if (op->kind == ForKind::kParallel) {
       parallel_loop_vars_.push_back(op->loop_var);
+      parallel_loop_spans_.push_back(op->span);
       ConstrVisitor::VisitStmt_(op);
       parallel_loop_vars_.pop_back();
+      parallel_loop_spans_.pop_back();
     } else {
       ConstrVisitor::VisitStmt_(op);
     }
@@ -97,14 +115,11 @@ struct ParallelLoopVerifier : public ConstrVisitor {
       }
     }
     if (!failed_vars.empty()) {
-      LOG(WARNING) << "Data race detected: `" << op->buffer << op->indices
-                   << "` "
-                   << "is written by multiple threads in loop " << failed_vars
-                   << ", Example:\n"
-                   << analyzer.z3_prover.GetModel(race_free)
-                   << "If you believe this is a false positive, pass "
-                      "`PassKey.TL_DISABLE_DATA_RACE_CHECK` to pass key to "
-                      "disable this check.";
+      reports_.push_back({op->buffer, op->indices, failed_vars,
+                          analyzer.z3_prover.GetModel(race_free), op->span,
+                          parallel_loop_spans_.empty()
+                              ? Span()
+                              : parallel_loop_spans_.back()});
     }
     StmtExprVisitor::VisitStmt_(op);
   }
@@ -119,6 +134,30 @@ struct ParallelLoopVerifier : public ConstrVisitor {
     }
     return StmtExprVisitor::VisitStmt_(op);
   }
+
+  /*! \brief Emit all collected races as one aggregated warning. */
+  void EmitReport() const {
+    if (reports_.empty()) {
+      return;
+    }
+    std::ostringstream os;
+    os << "Data race detected: " << reports_.size() << " potential race(s)\n";
+    for (size_t k = 0; k < reports_.size(); ++k) {
+      const RaceReport &report = reports_[k];
+      os << "  [" << k + 1 << "] `" << report.buffer << report.indices
+         << "` is written by multiple threads in loop " << report.failed_vars
+         << SpanHintSuffix({report.span, report.loop_span}) << "\n"
+         << "  Example:\n"
+         << report.model;
+      if (report.model.empty()) {
+        os << "\n";
+      }
+    }
+    os << "If you believe this is a false positive, pass "
+          "`PassKey.TL_DISABLE_DATA_RACE_CHECK` to pass key to "
+          "disable this check.";
+    LOG(WARNING) << os.str();
+  }
 };
 
 using namespace tirx::transform;
@@ -127,6 +166,7 @@ tvm::transform::Pass VerifyParallelLoop() {
   auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
     ParallelLoopVerifier verifier;
     verifier(f->body);
+    verifier.EmitReport();
     return f;
   };
   return CreatePrimFuncPass(pass_func, 0, "tl.VerifyParallelLoop", {});

--- a/testing/python/transform/test_tilelang_transform_verify_parallel_loop.py
+++ b/testing/python/transform/test_tilelang_transform_verify_parallel_loop.py
@@ -1,5 +1,6 @@
 import tilelang as tl
 import tilelang.testing
+from tilelang import ir as tl_ir
 from tilelang import tvm
 
 
@@ -40,6 +41,31 @@ def test_same_value_parallel_store_is_allowed(capfd):
     mod = _make_parallel_store(injective_indices=False, varying_value=False)
 
     assert "Data race detected" not in _verify(mod, capfd)
+
+
+def _make_two_racy_stores():
+    out_a = tvm.tirx.decl_buffer((32,), "int32", name="out_a")
+    out_b = tvm.tirx.decl_buffer((32,), "int32", name="out_b")
+    ti = tvm.tirx.Var("ti", "int32")
+    store_a = tvm.tirx.BufferStore(out_a, ti, [0])
+    store_b = tvm.tirx.BufferStore(out_b, ti, [0])
+    body = tvm.tirx.SeqStmt([store_a, store_b])
+    body = tvm.tirx.For(ti, 0, 32, tvm.tirx.ForKind.PARALLEL, body)
+    mod = tvm.IRModule.from_expr(tvm.tirx.PrimFunc([out_a, out_b], body))
+    return mod, store_a, store_b
+
+
+def test_data_race_diagnostic_includes_span(capfd):
+    mod, store_a, store_b = _make_two_racy_stores()
+    tl_ir.set_stmt_span(store_a, tl_ir.make_span("kernel.py", 21))
+    tl_ir.set_stmt_span(store_b, tl_ir.make_span("kernel.py", 22))
+
+    err = _verify(mod, capfd)
+    assert err.count("Data race detected") == 1
+    assert "[1]" in err
+    assert "--> kernel.py:21:1" in err
+    assert "[2]" in err
+    assert "--> kernel.py:22:1" in err
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Aggregated parallel-loop race diagnostics into a single warning with numbered reports.
- Added store and enclosing parallel-loop span information to each race report.
- Added a regression test verifying one diagnostic includes both source spans.

## C++ style / lint notes

- The PR changes C++ implementation code but does not appear to modify the documented rules in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) remains relevant; any TLCPP003/TLCPP004 findings should be treated as advisory unless they indicate a concrete API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->