### PR TITLE
[BugFix] Respect layouts in logical reductions

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -2399,6 +2399,52 @@ void CodeGenTileLangCUDA::PrintVecStore(const BufferNode *buffer, DataType t,
 }
 
 /**
+ * @brief Emit a tl.logical_reduce call as a tl::Logical[Vector]ReduceMap.
+ *
+ * The `Let` binds the logical vector index to its remapped load and becomes
+ * the C++ lambda parameter. Returns false if `op` is not a logical_reduce.
+ */
+bool CodeGenTileLangCUDA::PrintLogicalReduce(const CallNode *op,
+                                             std::ostream &os) {
+  if (!op->op.same_as(tl::logical_reduce())) {
+    return false;
+  }
+
+  ICHECK_EQ(op->args.size(), 3U);
+  const auto *mapping = op->args[0].as<LetNode>();
+  ICHECK(mapping) << "tl.logical_reduce expects a Let mapping expression";
+  const auto *placeholder = mapping->value.as<CallNode>();
+  ICHECK(placeholder && placeholder->op.same_as(tl::logical_reduce_index()))
+      << "tl.logical_reduce expects a logical_reduce_index Let value";
+  const int64_t *is_any = as_const_int(op->args[2]);
+  ICHECK(is_any && (*is_any == 0 || *is_any == 1));
+
+  DataType chunk_dtype = mapping->body.dtype();
+  ICHECK(!chunk_dtype.is_scalable_vector());
+  int vector_size = chunk_dtype.lanes();
+  os << "tl::Logical";
+  if (vector_size > 1) {
+    os << "Vector";
+  }
+  os << "ReduceMap<" << (*is_any ? "true" : "false");
+  if (vector_size > 1) {
+    os << ", ";
+    PrintType(chunk_dtype.element_of(), os);
+    os << ", " << vector_size;
+  }
+  os << ">(";
+  PrintExpr(op->args[1], os);
+  os << ", [&](";
+  PrintType(mapping->var.dtype(), os);
+  os << " " << AllocVarID(mapping->var.get()) << ") { return ";
+  PrintExpr(mapping->body, os);
+  os << "; })";
+  bool removed = var_idmap_.erase(mapping->var.get());
+  ICHECK(removed);
+  return true;
+}
+
+/**
  * @brief Emit CUDA/TensorLib-specific code for a call expression.
  *
  * This visitor handles CallNode intrinsics and builtins that require emitting
@@ -2458,6 +2504,9 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     }
     os << ")";
   };
+  if (PrintLogicalReduce(op, os)) {
+    return;
+  }
   if (op->op.same_as(tl::max_nan()) || op->op.same_as(tl::min_nan())) {
     ICHECK_EQ(op->args.size(), 2);
     const bool is_max = op->op.same_as(tl::max_nan());

--- a/src/cuda/codegen/codegen_cuda.h
+++ b/src/cuda/codegen/codegen_cuda.h
@@ -80,6 +80,7 @@ private:
   // Handle volatile loads
   void HandleVolatileLoads(const std::string &value, const BufferLoadNode *op,
                            std::ostream &os) final;
+  bool PrintLogicalReduce(const CallNode *op, std::ostream &os);
   bool HandleLateIntrinsicCall(const CallNode *op, std::ostream &os);
 
   // Whether scope such as "__shared__" or "__constant__"  is part of type.

--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -69,6 +69,16 @@ TIR_DEFINE_TL_BUILTIN(access_ptr)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kPure));
 
+TIR_DEFINE_TL_BUILTIN(logical_reduce)
+    .set_num_inputs(3)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(logical_reduce_index)
+    .set_num_inputs(0)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
 // fast math related op
 TIR_DEFINE_TL_BUILTIN(__exp).set_num_inputs(1).set_attr<TCallEffectKind>(
     "TCallEffectKind", Integer(CallEffectKind::kOpaque));

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -229,6 +229,21 @@ DataType CuTensorMapType();
  */
 TVM_DLL const Op &access_ptr();
 
+/*!
+ * \brief Compiler-internal mapped logical reduction.
+ *
+ * Arg 0 is a Let binding the runtime vector index to the layout-remapped
+ * load; codegen turns this into a LogicalReduceMap template call.
+ */
+TVM_DLL const Op &logical_reduce();
+
+/*!
+ * \brief Opaque placeholder keeping logical_reduce's Let binder intact.
+ *
+ * Consumed by logical_reduce codegen, never emitted on its own.
+ */
+TVM_DLL const Op &logical_reduce_index();
+
 // fast math related op
 // __exp(x) - fast exponential
 TVM_DLL const Op &__exp();

--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -1166,6 +1166,46 @@ std::string CodeGenTileLangHIP::GetBufferRef(DataType t,
   return os.str();
 }
 
+bool CodeGenTileLangHIP::PrintLogicalReduce(const CallNode *op,
+                                            std::ostream &os) {
+  if (!op->op.same_as(tl::logical_reduce())) {
+    return false;
+  }
+
+  ICHECK_EQ(op->args.size(), 3U);
+  const auto *mapping = op->args[0].as<LetNode>();
+  ICHECK(mapping) << "tl.logical_reduce expects a Let mapping expression";
+  const auto *placeholder = mapping->value.as<CallNode>();
+  ICHECK(placeholder && placeholder->op.same_as(tl::logical_reduce_index()))
+      << "tl.logical_reduce expects a logical_reduce_index Let value";
+  const int64_t *is_any = as_const_int(op->args[2]);
+  ICHECK(is_any && (*is_any == 0 || *is_any == 1));
+
+  DataType chunk_dtype = mapping->body.dtype();
+  ICHECK(!chunk_dtype.is_scalable_vector());
+  int vector_size = chunk_dtype.lanes();
+  os << "tl::Logical";
+  if (vector_size > 1) {
+    os << "Vector";
+  }
+  os << "ReduceMap<" << (*is_any ? "true" : "false");
+  if (vector_size > 1) {
+    os << ", ";
+    PrintType(chunk_dtype.element_of(), os);
+    os << ", " << vector_size;
+  }
+  os << ">(";
+  PrintExpr(op->args[1], os);
+  os << ", [&](";
+  PrintType(mapping->var.dtype(), os);
+  os << " " << AllocVarID(mapping->var.get()) << ") { return ";
+  PrintExpr(mapping->body, os);
+  os << "; })";
+  bool removed = var_idmap_.erase(mapping->var.get());
+  ICHECK(removed);
+  return true;
+}
+
 void CodeGenTileLangHIP::VisitExpr_(const CallNode *op, std::ostream &os) {
   auto print_extern_call_stmt = [&](std::string name, size_t start = 0,
                                     size_t end = 0) {
@@ -1178,6 +1218,9 @@ void CodeGenTileLangHIP::VisitExpr_(const CallNode *op, std::ostream &os) {
     }
     this->stream << ");\n";
   };
+  if (PrintLogicalReduce(op, os)) {
+    return;
+  }
   if (op->op.same_as(builtin::ptx_cp_async())) {
     // args[0] = dst_access_ptr, args[1] = src_access_ptr, args[2] = bytes,
     // args[3] = predicate (optional)

--- a/src/rocm/codegen/codegen_hip.h
+++ b/src/rocm/codegen/codegen_hip.h
@@ -69,6 +69,7 @@ private:
   // Handle volatile loads
   void HandleVolatileLoads(const std::string &value, const BufferLoadNode *op,
                            std::ostream &os) final;
+  bool PrintLogicalReduce(const CallNode *op, std::ostream &os);
 
   // Whether scope such as "__shared__" or "__constant__"  is part of type.
   bool IsScopePartOfType() const final { return false; }

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -740,6 +740,37 @@ template <typename T> TL_DEVICE bool All(T *a, int size) {
   return true;
 }
 
+// Layout-aware logical reduction. The load callback maps a logical vector
+// index to the corresponding (possibly swizzled) physical load.
+template <bool IsAny, typename Size, typename Load>
+TL_DEVICE bool LogicalReduceMap(Size size, Load load) {
+  for (Size i = 0; i < size; ++i) {
+    if (static_cast<bool>(load(i)) == IsAny) {
+      return IsAny;
+    }
+  }
+  return !IsAny;
+}
+
+template <bool IsAny, typename Element, int VectorSize, typename Size,
+          typename Load>
+TL_DEVICE bool LogicalVectorReduceMap(Size size, Load load) {
+  for (Size i = 0; i < size; ++i) {
+    auto chunk = load(i);
+    Element elements[VectorSize];
+    static_assert(sizeof(elements) == sizeof(chunk),
+                  "logical reduction vector type has an unexpected size");
+    __builtin_memcpy(elements, &chunk, sizeof(elements));
+#pragma unroll
+    for (int lane = 0; lane < VectorSize; ++lane) {
+      if (static_cast<bool>(elements[lane]) == IsAny) {
+        return IsAny;
+      }
+    }
+  }
+  return !IsAny;
+}
+
 // Pow of int
 template <int y = 1, typename T> TL_DEVICE T pow_of_int(T x) {
   T result = x;

--- a/src/tl_templates/hip/common.h
+++ b/src/tl_templates/hip/common.h
@@ -311,6 +311,37 @@ template <typename T> TL_DEVICE bool All(T *a, int size) {
   return true;
 }
 
+// Layout-aware logical reduction. The load callback maps a logical vector
+// index to the corresponding (possibly swizzled) physical load.
+template <bool IsAny, typename Size, typename Load>
+TL_DEVICE bool LogicalReduceMap(Size size, Load load) {
+  for (Size i = 0; i < size; ++i) {
+    if (static_cast<bool>(load(i)) == IsAny) {
+      return IsAny;
+    }
+  }
+  return !IsAny;
+}
+
+template <bool IsAny, typename Element, int VectorSize, typename Size,
+          typename Load>
+TL_DEVICE bool LogicalVectorReduceMap(Size size, Load load) {
+  for (Size i = 0; i < size; ++i) {
+    auto chunk = load(i);
+    Element elements[VectorSize];
+    static_assert(sizeof(elements) == sizeof(chunk),
+                  "logical reduction vector type has an unexpected size");
+    __builtin_memcpy(elements, &chunk, sizeof(elements));
+#pragma unroll
+    for (int lane = 0; lane < VectorSize; ++lane) {
+      if (static_cast<bool>(elements[lane]) == IsAny) {
+        return IsAny;
+      }
+    }
+  }
+  return !IsAny;
+}
+
 // TODO(gong): support shfl_sync(rocm 7.1.1 provide shfl_sync)
 // shfl_sync func
 template <typename T> TL_DEVICE T shfl_xor(T val, int delta) {

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -31,12 +31,27 @@
 #include "common/pipeline_utils.h"
 #include "layout_reducer.h"
 #include "loop_partition.h"
+#include "loop_vectorize.h"
 
 namespace tvm {
 namespace tl {
 
 using namespace tirx;
 using namespace ffi;
+
+namespace {
+
+const Op &LogicalAnyOfOp() {
+  static const Op &op = Op::Get("tl.any_of");
+  return op;
+}
+
+const Op &LogicalAllOfOp() {
+  static const Op &op = Op::Get("tl.all_of");
+  return op;
+}
+
+} // namespace
 
 static Buffer makeBufferWithLayout(const Buffer &buffer, const Layout &layout,
                                    Map<Var, Var> &var_remap) {
@@ -773,7 +788,163 @@ private:
     return Optional<Layout>();
   }
 
+  Optional<Layout> GetAccessPtrLayout(const PrimExpr &access_ptr) const {
+    const auto *call = access_ptr.as<CallNode>();
+    if (call == nullptr || !call->op.same_as(tl::access_ptr()) ||
+        call->args.size() != 3) {
+      return Optional<Layout>();
+    }
+
+    Optional<PrimExpr> resolved = ResolveBufferLoad(call->args[0]);
+    if (!resolved.defined()) {
+      return Optional<Layout>();
+    }
+
+    Buffer buffer = Downcast<BufferLoad>(resolved.value())->buffer;
+    Buffer remap_key = FindRemapBuffer(buffer).value_or(buffer);
+    if (!buffer_map_.count(remap_key->data)) {
+      return Optional<Layout>();
+    }
+    return FindLayout(remap_key);
+  }
+
+  PrimExpr LinearizedBufferIndex(const BufferLoad &load) {
+    ICHECK_EQ(load->indices.size(), load->buffer->shape.size());
+    ICHECK(!load->indices.empty());
+    DataType index_dtype = load->indices[0].dtype();
+    PrimExpr index = make_zero(index_dtype);
+    PrimExpr stride = make_const(index_dtype, 1);
+    for (int i = static_cast<int>(load->indices.size()) - 1; i >= 0; --i) {
+      index += load->indices[i] * stride;
+      stride *= load->buffer->shape[i];
+    }
+    return analyzer_->Simplify(index);
+  }
+
+  Buffer MakeFlattenedAlias(const Buffer &buffer) {
+    ICHECK(!buffer->shape.empty());
+    DataType index_dtype = buffer->shape[0].dtype();
+    PrimExpr extent = make_const(index_dtype, 1);
+    for (const PrimExpr &dim : buffer->shape) {
+      extent *= dim;
+    }
+    return Buffer(buffer->data, buffer->dtype, {analyzer_->Simplify(extent)},
+                  {}, buffer->elem_offset, buffer->name + "_logical_reduce",
+                  buffer->data_alignment, buffer->offset_factor,
+                  buffer->buffer_type);
+  }
+
+  int SelectLogicalReductionVectorSize(const BufferLoad &mapped_load,
+                                       const Var &logical_offset,
+                                       const PrimExpr &extent) {
+    DataType dtype = mapped_load->buffer->dtype;
+    if (dtype.is_bool() || dtype.bits() < 8) {
+      return 1;
+    }
+
+    int element_bits = dtype.bits() * dtype.lanes();
+    if (element_bits <= 0 || element_bits > 128) {
+      return 1;
+    }
+
+    // Swizzles keep a contiguous 128-bit vector inside each atom. Start at
+    // that lane count and shrink until the remapped physical address is
+    // provably aligned and contiguous.
+    int vector_size = 1;
+    int max_vector_size = 128 / element_bits;
+    while (vector_size <= max_vector_size / 2) {
+      vector_size *= 2;
+    }
+
+    PrimExpr physical_element_offset = analyzer_->Simplify(
+        mapped_load->buffer->elem_offset + LinearizedBufferIndex(mapped_load));
+    while (vector_size > 1 &&
+           !IndicesCanVectorize(physical_element_offset, logical_offset, extent,
+                                vector_size, analyzer_)) {
+      vector_size /= 2;
+    }
+    return vector_size;
+  }
+
+  PrimExpr MakeMappedLogicalReduction(const PrimExpr &access_ptr,
+                                      const PrimExpr &extent, DataType dtype,
+                                      bool is_any) {
+    DataType offset_dtype = extent.dtype();
+    Var logical_offset("logical_reduce_offset", offset_dtype);
+    AccessPtrResult mapped =
+        HandleAccessPtrAndOffset(access_ptr, logical_offset, dtype);
+    ICHECK(mapped.rewritten);
+    Call mapped_access_ptr = Downcast<Call>(mapped.expr);
+    ICHECK(mapped_access_ptr->op.same_as(tl::access_ptr()));
+    ICHECK_EQ(mapped_access_ptr->args.size(), 3U);
+    BufferLoad mapped_load = Downcast<BufferLoad>(mapped_access_ptr->args[0]);
+
+    int vector_size =
+        SelectLogicalReductionVectorSize(mapped_load, logical_offset, extent);
+    PrimExpr vector_size_expr = make_const(offset_dtype, vector_size);
+
+    Var vector_index("logical_reduce_vector", offset_dtype);
+    PrimExpr chunk_offset = vector_index * vector_size_expr;
+    AccessPtrResult chunk_mapped =
+        HandleAccessPtrAndOffset(access_ptr, chunk_offset, dtype);
+    ICHECK(chunk_mapped.rewritten);
+    Call chunk_access_ptr = Downcast<Call>(chunk_mapped.expr);
+    ICHECK(chunk_access_ptr->op.same_as(tl::access_ptr()));
+    ICHECK_EQ(chunk_access_ptr->args.size(), 3U);
+    BufferLoad chunk_base = Downcast<BufferLoad>(chunk_access_ptr->args[0]);
+
+    Buffer flat_buffer = MakeFlattenedAlias(chunk_base->buffer);
+    PrimExpr flat_index = LinearizedBufferIndex(chunk_base);
+    PrimExpr chunk_value;
+    if (vector_size > 1) {
+      int chunk_lanes = flat_buffer->dtype.lanes() * vector_size;
+      chunk_value = flat_buffer.vload(
+          {flat_index}, flat_buffer->dtype.with_lanes(chunk_lanes));
+    } else {
+      chunk_value = BufferLoad(flat_buffer, {flat_index});
+    }
+    PrimExpr vector_count =
+        analyzer_->Simplify(floordiv(extent, vector_size_expr));
+    // Keep the runtime vector index as a real TIR binder so ordinary passes
+    // can inspect and rewrite the mapped load. A call value is what keeps the
+    // Let alive for codegen: CanInlineLet only drops constants and bare vars.
+    PrimExpr index_placeholder =
+        Call(offset_dtype, tl::logical_reduce_index(), ffi::Array<PrimExpr>{});
+    PrimExpr mapped_chunk =
+        Let(vector_index, std::move(index_placeholder), std::move(chunk_value));
+    return Call(
+        dtype, tl::logical_reduce(),
+        {std::move(mapped_chunk), std::move(vector_count), Bool(is_any)});
+  }
+
+  Optional<PrimExpr> TryRewriteLogicalReduction(const CallNode *op) {
+    bool is_any = op->op.same_as(LogicalAnyOfOp());
+    bool is_all = op->op.same_as(LogicalAllOfOp());
+    if (!is_any && !is_all) {
+      return Optional<PrimExpr>();
+    }
+
+    ICHECK_EQ(op->args.size(), 2U)
+        << "tl.any_of/tl.all_of expect (access_ptr, extent)";
+    PrimExpr access_ptr = op->args[0];
+    if (!GetAccessPtrLayout(access_ptr).defined()) {
+      return Optional<PrimExpr>();
+    }
+
+    PrimExpr extent = analyzer_->Simplify(VisitExpr(op->args[1]));
+    if (const auto *extent_imm = extent.as<IntImmNode>()) {
+      ICHECK_GE(extent_imm->value, 0)
+          << "tl.any_of/tl.all_of extent must be non-negative, but got "
+          << extent;
+    }
+    return MakeMappedLogicalReduction(access_ptr, extent, op->dtype, is_any);
+  }
+
   PrimExpr VisitExpr_(const tirx::CallNode *op) final {
+    if (Optional<PrimExpr> reduction = TryRewriteLogicalReduction(op)) {
+      return reduction.value();
+    }
+
     if (op->op.same_as(tl::tma_load()) ||
         op->op.same_as(tl::tma_load_im2col()) ||
         op->op.same_as(tl::tma_load_multicast()) ||

--- a/src/transform/verify_parallel_loop.cc
+++ b/src/transform/verify_parallel_loop.cc
@@ -23,6 +23,23 @@ namespace {
 using tvm::tl::ConstrSet;
 using tvm::tl::ConstrVisitor;
 
+// arith::Analyzer only models scalar arithmetic, and its Z3 backend aborts
+// compilation on a vector node (Ramp, Broadcast, ...). Reduce a vector
+// expression to one lane's scalar expression, or return an undefined Optional
+// when that lane is not expressible as a scalar (e.g. a vector BufferLoad).
+Optional<PrimExpr> ExtractLane(const PrimExpr &value, int lane) {
+  if (value.dtype().is_scalar()) {
+    return value;
+  }
+  if (const auto *broadcast = value.as<BroadcastNode>()) {
+    return broadcast->value;
+  }
+  if (const auto *ramp = value.as<RampNode>()) {
+    return ramp->base + make_const(ramp->base.dtype(), lane) * ramp->stride;
+  }
+  return Optional<PrimExpr>();
+}
+
 struct ParallelLoopVerifier : public ConstrVisitor {
   std::vector<Var> parallel_loop_vars_;
   std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> reducers;
@@ -74,7 +91,23 @@ struct ParallelLoopVerifier : public ConstrVisitor {
 
     cset.Extend(cset.Substitute(subs));
     for (const auto &idx : op->indices) {
-      cset.AddConstr(idx == tirx::Substitute(idx, subs));
+      PrimExpr other_idx = tirx::Substitute(idx, subs);
+      if (idx.dtype().is_scalar()) {
+        cset.AddConstr(idx == other_idx);
+        continue;
+      }
+      // Constrain lanes one by one to keep the constraint scalar; dropping
+      // it would lose injectivity and report a spurious data race.
+      if (!idx.dtype().is_fixed_length_vector()) {
+        continue;
+      }
+      for (int lane = 0; lane < idx.dtype().lanes(); ++lane) {
+        Optional<PrimExpr> lane_idx = ExtractLane(idx, lane);
+        Optional<PrimExpr> other_lane_idx = ExtractLane(other_idx, lane);
+        if (lane_idx.defined() && other_lane_idx.defined()) {
+          cset.AddConstr(lane_idx.value() == other_lane_idx.value());
+        }
+      }
     }
     arith::Analyzer analyzer;
     cset.Populate(analyzer);
@@ -83,7 +116,29 @@ struct ParallelLoopVerifier : public ConstrVisitor {
     for (const auto &[var, other_var] : parallel_var_pairs) {
       same_iteration = And(same_iteration, EQ(var, other_var));
     }
-    PrimExpr same_value = op->value == tirx::Substitute(op->value, subs);
+    PrimExpr other_value = tirx::Substitute(op->value, subs);
+    PrimExpr same_value;
+    if (op->value.dtype().is_scalar()) {
+      same_value = op->value == other_value;
+    } else if (op->value.dtype().is_fixed_length_vector()) {
+      // Lane by lane: a vector-valued predicate is accepted by neither Or()
+      // nor the provers.
+      same_value = Bool(true);
+      for (int lane = 0; lane < op->value.dtype().lanes(); ++lane) {
+        Optional<PrimExpr> lane_value = ExtractLane(op->value, lane);
+        Optional<PrimExpr> other_lane_value = ExtractLane(other_value, lane);
+        if (!lane_value.defined() || !other_lane_value.defined()) {
+          // Not scalarizable: fall back to the same-iteration check.
+          same_value = Bool(false);
+          break;
+        }
+        same_value =
+            And(same_value, EQ(lane_value.value(), other_lane_value.value()));
+      }
+    } else {
+      // Scalable vector: the lane count is unknown at compile time.
+      same_value = Bool(false);
+    }
     PrimExpr race_free = Or(same_iteration, same_value);
     if (analyzer.CanProve(race_free)) {
       StmtExprVisitor::VisitStmt_(op);

--- a/testing/python/issue/test_tilelang_issue_2714.py
+++ b/testing/python/issue/test_tilelang_issue_2714.py
@@ -1,0 +1,210 @@
+"""Regression tests for GitHub issue #2714.
+
+T.all_of/T.any_of over a row of swizzled shared memory must scan logical row
+elements, not the contiguous physical addresses after the first swizzled base.
+"""
+
+import re
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+from tilelang.layout import (
+    Layout,
+    make_full_bank_swizzled_layout,
+    make_half_bank_swizzled_layout,
+    make_quarter_bank_swizzled_layout,
+    make_swizzled_layout,
+)
+
+THREADS = 128
+
+SHAPES = [
+    pytest.param((8, 128), id="8x128"),
+    pytest.param((16, 128), id="16x128"),
+    pytest.param((24, 128), id="24x128"),
+]
+ELEMENT_TYPES = ["int8", "int8x2", "int16", "float16", "int32", "float32"]
+LAYOUT_FNS = [
+    pytest.param(make_swizzled_layout, id="auto"),
+    pytest.param(make_quarter_bank_swizzled_layout, id="32B"),
+    pytest.param(make_half_bank_swizzled_layout, id="64B"),
+    pytest.param(make_full_bank_swizzled_layout, id="128B"),
+]
+SLICE_RANGES = [
+    pytest.param((0, 128), id="full"),
+    pytest.param((8, 40), id="slice8-40"),
+]
+# The CUDA and HIP backends share the lowering and emit the same
+# tl::Logical[Vector]ReduceMap template, so both run the whole matrix.
+TARGETS = [
+    pytest.param("cuda", id="cuda", marks=list(tilelang.testing.requires_cuda.marks())),
+    pytest.param("hip", id="hip", marks=list(tilelang.testing.requires_rocm.marks())),
+]
+
+
+def _xfail_packed_element_type_on_hip(request, target, element_type):
+    """HIP cannot emit a vector access to a buffer of packed elements.
+
+    Applied here rather than as a mark: the condition spans two parametrize
+    axes.
+    """
+    if target == "hip" and tilelang.DataType(element_type).lanes > 1:
+        request.applymarker(
+            pytest.mark.xfail(
+                reason="HIP emits a >4-lane Ramp for vector accesses to packed-element buffers",
+                raises=tvm.error.InternalError,
+                strict=True,
+            )
+        )
+
+
+def _compile(func, target):
+    cache_was_enabled = tilelang.is_cache_enabled()
+    tilelang.disable_cache()
+    try:
+        return tilelang.compile(func, out_idx=[1], target=target)
+    finally:
+        if cache_was_enabled:
+            tilelang.enable_cache()
+
+
+def _derive_vectorization(element_type, slice_range):
+    dtype = tilelang.DataType(element_type)
+    vector_elements = 1
+    max_vector_elements = 128 // (dtype.bits * dtype.lanes)
+    while vector_elements <= max_vector_elements // 2:
+        vector_elements *= 2
+
+    slice_begin, slice_end = slice_range
+    extent = slice_end - slice_begin
+    while vector_elements > 1 and (slice_begin % vector_elements != 0 or extent % vector_elements != 0):
+        vector_elements //= 2
+
+    vector_lanes = dtype.lanes * vector_elements
+    vector_count = extent // vector_elements
+    return vector_lanes, vector_count
+
+
+def _make_random_input(shape, reduce_kind, slice_range, element_type):
+    dtype = tilelang.DataType(element_type)
+    lanes = dtype.lanes
+    scalar_type = element_type.removesuffix(f"x{lanes}") if lanes > 1 else element_type
+    data = torch.randint(-4, 5, shape, dtype=tilelang.DataType(scalar_type).as_torch(), device="cuda")
+    selected_rows = torch.randperm(shape[0], device="cuda")[: shape[0] // 4]
+    slice_begin, slice_end = slice_range
+    scalar_begin = slice_begin * lanes
+    scalar_end = slice_end * lanes
+    data[selected_rows, scalar_begin:scalar_end] = 0 if reduce_kind == "any_of" else 1
+    return data
+
+
+def _torch_logical_reduce(data, reduce_kind, slice_range, lanes=1):
+    slice_begin, slice_end = slice_range
+    predicate = data[:, slice_begin * lanes : slice_end * lanes] != 0
+    reduce_fn = torch.any if reduce_kind == "any_of" else torch.all
+    return reduce_fn(predicate, dim=1).to(torch.int8)
+
+
+def _logical_reduce_kernel(reduce_kind, shape, element_type, layout_fn, slice_range):
+    assert reduce_kind in ("all_of", "any_of")
+    use_any = reduce_kind == "any_of"
+    slice_begin, slice_end = slice_range
+    dtype = tilelang.DataType(element_type)
+    lanes = dtype.lanes
+    scalar_type = element_type.removesuffix(f"x{lanes}") if lanes > 1 else element_type
+    input_shape = (shape[0], shape[1] * lanes)
+
+    @T.macro
+    def load_input(A, r, c):
+        if lanes == 1:
+            return A[r, c]
+        else:
+            return A[r, T.Ramp(c * lanes, 1, lanes)]
+
+    @T.macro
+    def logical_reduce(shared, r):
+        if use_any:
+            return T.any_of(shared[r, slice_begin:slice_end])
+        else:
+            return T.all_of(shared[r, slice_begin:slice_end])
+
+    @T.prim_func
+    def main(A: T.Tensor(input_shape, scalar_type), Out: T.Tensor((shape[0],), "int8")):
+        with T.Kernel(1, threads=THREADS):
+            shared = T.alloc_shared(shape, element_type)
+            T.annotate_layout({shared: layout_fn(shared)})
+
+            for r, c in T.Parallel(shape[0], shape[1]):
+                shared[r, c] = load_input(A, r, c)
+            T.sync_threads()
+
+            for r in T.Parallel(shape[0]):
+                Out[r] = T.cast(logical_reduce(shared, r), "int8")
+
+    return main
+
+
+@pytest.mark.parametrize("target", TARGETS)
+@pytest.mark.parametrize("reduce_kind", ["any_of", "all_of"])
+@pytest.mark.parametrize("shape", SHAPES)
+@pytest.mark.parametrize("element_type", ELEMENT_TYPES)
+@pytest.mark.parametrize("layout_fn", LAYOUT_FNS)
+@pytest.mark.parametrize("slice_range", SLICE_RANGES)
+def test_swizzled_shared_row_scans_logical_elements(
+    request,
+    target,
+    reduce_kind,
+    shape,
+    element_type,
+    layout_fn,
+    slice_range,
+):
+    _xfail_packed_element_type_on_hip(request, target, element_type)
+    kernel = _compile(
+        _logical_reduce_kernel(
+            reduce_kind,
+            shape,
+            element_type,
+            layout_fn,
+            slice_range,
+        ),
+        target,
+    )
+    lanes = tilelang.DataType(element_type).lanes
+    input_shape = (shape[0], shape[1] * lanes)
+    vector_lanes, vector_count = _derive_vectorization(element_type, slice_range)
+    data = _make_random_input(input_shape, reduce_kind, slice_range, element_type)
+
+    expected = _torch_logical_reduce(data, reduce_kind, slice_range, lanes)
+    torch.testing.assert_close(kernel(data), expected)
+
+    source = kernel.get_kernel_source()
+    assert f"tl::{reduce_kind.removesuffix('_of').title()}(" not in source
+    is_any = str(reduce_kind == "any_of").lower()
+    assert re.search(
+        rf"tl::LogicalVectorReduceMap<{is_any}, [^,]+, {vector_lanes}>\({vector_count}",
+        source,
+    )
+    vector_words = tilelang.DataType(element_type).bits * vector_lanes // 32
+    assert re.search(rf"return \*\([A-Za-z_][A-Za-z0-9_]*{vector_words}\*\)", source)
+
+
+@pytest.mark.parametrize("target", TARGETS)
+@pytest.mark.parametrize("reduce_kind", ["any_of", "all_of"])
+def test_padded_layout_logical_reduce(target, reduce_kind):
+    def padded_layout(_):
+        return Layout((4, 17), lambda i, j: [i, j * 2])
+
+    kernel = _compile(_logical_reduce_kernel(reduce_kind, (4, 17), "int8", padded_layout, (0, 17)), target)
+    data = _make_random_input((4, 17), reduce_kind, (0, 17), "int8")
+    expected = _torch_logical_reduce(data, reduce_kind, (0, 17))
+    torch.testing.assert_close(kernel(data), expected)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/language/test_tilelang_language_parallel.py
+++ b/testing/python/language/test_tilelang_language_parallel.py
@@ -89,5 +89,37 @@ def test_parallel_vectorize_var():
     assert "float2" not in source
 
 
+@tilelang.jit(out_idx=[1])
+def _parallel_vector_store(rows=8, cols=128, lanes=2, dtype=T.int8):
+    @T.prim_func
+    def main(
+        A: T.Tensor((rows, cols * lanes), dtype),
+        B: T.Tensor((rows, cols * lanes), dtype),
+    ):
+        with T.Kernel(1, threads=128):
+            for i, j in T.Parallel(rows, cols):
+                B[i, T.Ramp(j * lanes, 1, lanes)] = A[i, T.Ramp(j * lanes, 1, lanes)]
+
+    return main
+
+
+def test_parallel_vector_store_is_verifiable():
+    """A vector-valued store inside T.Parallel must survive the data race check.
+
+    Comparing the two written vectors as vectors builds a vector-valued
+    predicate the provers cannot consume, which used to abort compilation.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    # Compile for real: a cached artifact would hide a lowering regression.
+    tilelang.disable_cache()
+    try:
+        kernel = _parallel_vector_store()
+    finally:
+        tilelang.enable_cache()
+    data = torch.randint(-8, 8, (8, 256), device="cuda", dtype=torch.int8)
+    torch.testing.assert_close(kernel(data), data)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_verify_parallel_loop.py
+++ b/testing/python/transform/test_tilelang_transform_verify_parallel_loop.py
@@ -3,8 +3,14 @@ import tilelang.testing
 from tilelang import tvm
 
 
-def _make_parallel_store(*, injective_indices: bool, varying_value: bool = True):
-    output = tvm.tirx.decl_buffer((32, 128), "int32", name="output")
+def _make_parallel_store(
+    *,
+    injective_indices: bool,
+    varying_value: bool = True,
+    value_lanes: int = 1,
+):
+    output_dtype = "int32" if value_lanes == 1 else f"int32x{value_lanes}"
+    output = tvm.tirx.decl_buffer((32, 128), output_dtype, name="output")
     ti = tvm.tirx.Var("ti", "int32")
     tj = tvm.tirx.Var("tj", "int32")
     i = tvm.tirx.Var("i", "int32")
@@ -12,6 +18,8 @@ def _make_parallel_store(*, injective_indices: bool, varying_value: bool = True)
 
     indices = [i, j] if injective_indices else [0, 0]
     value = ti * 128 + tj if varying_value else 1
+    if value_lanes > 1:
+        value = tvm.tirx.Broadcast(value, value_lanes)
     store = tvm.tirx.BufferStore(output, value, indices)
     body = tvm.tirx.SeqStmt([tvm.tirx.Bind(i, ti), tvm.tirx.Bind(j, tj), store])
     body = tvm.tirx.For(tj, 0, 128, tvm.tirx.ForKind.PARALLEL, body)
@@ -38,6 +46,26 @@ def test_irrelevant_flat_binds_do_not_hide_race(capfd):
 
 def test_same_value_parallel_store_is_allowed(capfd):
     mod = _make_parallel_store(injective_indices=False, varying_value=False)
+
+    assert "Data race detected" not in _verify(mod, capfd)
+
+
+def test_vector_value_parallel_store_is_supported(capfd):
+    mod = _make_parallel_store(injective_indices=True, value_lanes=2)
+
+    assert "Data race detected" not in _verify(mod, capfd)
+
+
+def test_vector_value_race_reaches_the_prover(capfd):
+    # Non-injective indices defeat the rewrite simplifier, so the condition
+    # reaches the SMT prover -- which aborts on any vector node.
+    mod = _make_parallel_store(injective_indices=False, value_lanes=2)
+
+    assert "Data race detected" in _verify(mod, capfd)
+
+
+def test_same_vector_value_parallel_store_is_allowed(capfd):
+    mod = _make_parallel_store(injective_indices=False, varying_value=False, value_lanes=2)
 
     assert "Data race detected" not in _verify(mod, capfd)
 


### PR DESCRIPTION
[BugFix] Respect layouts in logical reductions

The int8x2 cases are marked xfail on HIP: that backend cannot emit a vector
access to a buffer of packed elements, so the compile aborts before the
reduction is reached. CUDA is unaffected.

Fixes https://github.com/tile-ai/tilelang/issues/2714

[BugFix] Verify parallel vector stores

The data race check proves that two iterations writing the same location
write the same value. For a vector-valued store that comparison is itself
vector-valued, which Or() rejects ("mismatched types"), so a T.Parallel
loop containing a vectorized store could not be compiled at all.

Compare the vectors lane by lane instead, so that nothing vector-valued
reaches arith::Analyzer: its Z3 backend models only scalar arithmetic and
aborts on a Ramp, Broadcast or Shuffle. Vector indices are constrained per
lane for the same reason -- dropping them would lose the injectivity of the
index map and report a spurious race on every vectorized copy. A lane that
does not reduce to a scalar falls back to the same-iteration check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added layout-aware logical reduction lowering and CUDA/HIP code generation, including scalar and vectorized reduction helpers.
- Registered new `tl.logical_reduce` and `tl.logical_reduce_index` intrinsics.
- Improved parallel-loop race verification by comparing vector store indices and values lane by lane, with safe fallback handling for non-scalarizable lanes.
- Added regression coverage for swizzled/padded logical reductions and vector-valued parallel stores, including expected HIP failures for packed element types.

## C++ style / lint notes

- The PR changes C++ code but does not appear to modify rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) remains advisory; any TLCPP003/TLCPP004 warnings should not block merging unless they indicate a concrete API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->