### PR TITLE
[Metal] Fix pass 5 threadgroup casts + unroll(full) pragma + Metal autotuner configs

### DIFF
--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -34,6 +34,7 @@
 #include <sstream>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -639,9 +640,15 @@ void CodeGenTileLangMetal::VisitStmt_(const ForNode *op) {
     }
     return;
   }
-  if (ext_imm && ext_imm->value > 4) {
+  if (ext_imm && ext_imm->value > 8) {
     PrintIndent();
     stream << "#pragma clang loop unroll(disable)\n";
+  } else if (ext_imm && ext_imm->value > 1) {
+    // Small constant-bound loops: encourage full unroll (like MLX's STEEL_PRAGMA_UNROLL).
+    // Apple GPU compiler manages these efficiently; leaving them un-unrolled adds branch
+    // overhead in inner GEMM/warp/MMA loops.
+    PrintIndent();
+    stream << "#pragma clang loop unroll(full)\n";
   }
   CodeGenC::VisitStmt_(op);
 }
@@ -1783,36 +1790,83 @@ ffi::Module BuildTileLangMetal(IRModule mod, Target target) {
         }
       }
     }
-    // 5) Line-level: any line containing _shared → fix ALL pointer casts.
-    //    After passes 1-4, some casts still lack threadgroup because _shared
-    //    is nested inside the expression. This pass finds any (TYPE*) on a
-    //    _shared line and inserts the threadgroup qualifier if missing.
+    // 5) Line-level: fix pointer casts referencing threadgroup variables.
+    //
+    //    After passes 1-4, some casts still lack the threadgroup qualifier
+    //    because the shared buffer is nested inside the expression.
+    //    This pass first collects all threadgroup variable names from
+    //    declarations (e.g. "threadgroup half As[2048];"), then on any
+    //    line referencing one of those names, finds all (TYPE*) casts
+    //    that are missing the qualifier and inserts "threadgroup".
     {
-      std::istringstream iss(fsource);
-      std::ostringstream oss;
-      std::string line;
-      while (std::getline(iss, line)) {
-        if (line.find("_shared") != std::string::npos) {
-          for (size_t i = 0; i + 3 < line.length(); i++) {
-            if (line[i] == '(') {
-              if (line.substr(i, 14) == "(threadgroup ") {
-                i += 13;
-                continue;
-              }
-              size_t j = i + 1;
-              while (j < line.length() && (isalnum(line[j]) || line[j] == '_'))
-                j++;
-              if (j < line.length() && line[j] == '*' &&
-                  j + 1 < line.length() && line[j + 1] == ')') {
-                line.insert(i + 1, "threadgroup ");
-                i += 12;
+      // Collect threadgroup buffer names from declarations.
+      // Matches both array and pointer forms:
+      //   threadgroup half As[2048];
+      //   threadgroup void* As = ...;
+      std::unordered_set<std::string> tg_names;
+      {
+        std::istringstream decl_iss(fsource);
+        std::string decl_line;
+        while (std::getline(decl_iss, decl_line)) {
+          if (decl_line.find("threadgroup ") == std::string::npos)
+            continue;
+          // Find any [ ; or = and backtrack to the preceding alnum token.
+          for (size_t p = 0; p < decl_line.length(); p++) {
+            if (decl_line[p] == '[' || decl_line[p] == ';' ||
+                decl_line[p] == '=') {
+              // Backtrack past spaces
+              size_t end = p;
+              while (end > 0 && decl_line[end - 1] == ' ') end--;
+              // Backtrack past alnum / underscore
+              size_t start = end;
+              while (start > 0 &&
+                     (isalnum(decl_line[start - 1]) ||
+                      decl_line[start - 1] == '_'))
+                start--;
+              if (start < end) {
+                tg_names.insert(decl_line.substr(start, end - start));
               }
             }
           }
         }
-        oss << line << "\n";
       }
-      fsource = oss.str();
+
+      if (!tg_names.empty()) {
+        std::istringstream iss(fsource);
+        std::ostringstream oss;
+        std::string line;
+        while (std::getline(iss, line)) {
+          // Check if this line references any threadgroup variable
+          bool has_tg_var = false;
+          for (const auto &name : tg_names) {
+            if (line.find(name) != std::string::npos) {
+              has_tg_var = true;
+              break;
+            }
+          }
+          if (has_tg_var) {
+            for (size_t i = 0; i + 3 < line.length(); i++) {
+              if (line[i] == '(') {
+                if (line.substr(i, 14) == "(threadgroup ") {
+                  i += 13;
+                  continue;
+                }
+                size_t j = i + 1;
+                while (j < line.length() &&
+                       (isalnum(line[j]) || line[j] == '_'))
+                  j++;
+                if (j < line.length() && line[j] == '*' &&
+                    j + 1 < line.length() && line[j + 1] == ')') {
+                  line.insert(i + 1, "threadgroup ");
+                  i += 12;
+                }
+              }
+            }
+          }
+          oss << line << "\n";
+        }
+        fsource = oss.str();
+      }
     }
     source_maker << fsource << "\n";
     if (fmetal_postproc) {
@@ -1855,6 +1909,71 @@ ffi::Module BuildTileLangMetalWithoutCompile(IRModule mod, Target target) {
     cg.AddFunction(kv.first, f);
 
     std::string fsource = cg.Finish();
+
+    // Apply pass 5: fix threadgroup casts using declaration analysis.
+    // (Same logic as in BuildTileLangMetal above.)
+    {
+      std::unordered_set<std::string> tg_names;
+      {
+        std::istringstream decl_iss(fsource);
+        std::string decl_line;
+        while (std::getline(decl_iss, decl_line)) {
+          if (decl_line.find("threadgroup ") == std::string::npos)
+            continue;
+          for (size_t p = 0; p < decl_line.length(); p++) {
+            if (decl_line[p] == '[' || decl_line[p] == ';' ||
+                decl_line[p] == '=') {
+              size_t end = p;
+              while (end > 0 && decl_line[end - 1] == ' ') end--;
+              size_t start = end;
+              while (start > 0 &&
+                     (isalnum(decl_line[start - 1]) ||
+                      decl_line[start - 1] == '_'))
+                start--;
+              if (start < end) {
+                tg_names.insert(decl_line.substr(start, end - start));
+              }
+            }
+          }
+        }
+      }
+      if (!tg_names.empty()) {
+        std::istringstream iss(fsource);
+        std::ostringstream oss;
+        std::string line;
+        while (std::getline(iss, line)) {
+          bool has_tg_var = false;
+          for (const auto &name : tg_names) {
+            if (line.find(name) != std::string::npos) {
+              has_tg_var = true;
+              break;
+            }
+          }
+          if (has_tg_var) {
+            for (size_t i = 0; i + 3 < line.length(); i++) {
+              if (line[i] == '(') {
+                if (line.substr(i, 14) == "(threadgroup ") {
+                  i += 13;
+                  continue;
+                }
+                size_t j = i + 1;
+                while (j < line.length() &&
+                       (isalnum(line[j]) || line[j] == '_'))
+                  j++;
+                if (j < line.length() && line[j] == '*' &&
+                    j + 1 < line.length() && line[j + 1] == ')') {
+                  line.insert(i + 1, "threadgroup ");
+                  i += 12;
+                }
+              }
+            }
+          }
+          oss << line << "\n";
+        }
+        fsource = oss.str();
+      }
+    }
+
     source_maker << fsource << "\n";
     smap.Set(func_name, ffi::Bytes(std::move(fsource)));
   }

--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -644,9 +644,10 @@ void CodeGenTileLangMetal::VisitStmt_(const ForNode *op) {
     PrintIndent();
     stream << "#pragma clang loop unroll(disable)\n";
   } else if (ext_imm && ext_imm->value > 1) {
-    // Small constant-bound loops: encourage full unroll (like MLX's STEEL_PRAGMA_UNROLL).
-    // Apple GPU compiler manages these efficiently; leaving them un-unrolled adds branch
-    // overhead in inner GEMM/warp/MMA loops.
+    // Small constant-bound loops: encourage full unroll (like MLX's
+    // STEEL_PRAGMA_UNROLL). Apple GPU compiler manages these efficiently;
+    // leaving them un-unrolled adds branch overhead in inner GEMM/warp/MMA
+    // loops.
     PrintIndent();
     stream << "#pragma clang loop unroll(full)\n";
   }
@@ -1816,12 +1817,12 @@ ffi::Module BuildTileLangMetal(IRModule mod, Target target) {
                 decl_line[p] == '=') {
               // Backtrack past spaces
               size_t end = p;
-              while (end > 0 && decl_line[end - 1] == ' ') end--;
+              while (end > 0 && decl_line[end - 1] == ' ')
+                end--;
               // Backtrack past alnum / underscore
               size_t start = end;
-              while (start > 0 &&
-                     (isalnum(decl_line[start - 1]) ||
-                      decl_line[start - 1] == '_'))
+              while (start > 0 && (isalnum(decl_line[start - 1]) ||
+                                   decl_line[start - 1] == '_'))
                 start--;
               if (start < end) {
                 tg_names.insert(decl_line.substr(start, end - start));
@@ -1924,11 +1925,11 @@ ffi::Module BuildTileLangMetalWithoutCompile(IRModule mod, Target target) {
             if (decl_line[p] == '[' || decl_line[p] == ';' ||
                 decl_line[p] == '=') {
               size_t end = p;
-              while (end > 0 && decl_line[end - 1] == ' ') end--;
+              while (end > 0 && decl_line[end - 1] == ' ')
+                end--;
               size_t start = end;
-              while (start > 0 &&
-                     (isalnum(decl_line[start - 1]) ||
-                      decl_line[start - 1] == '_'))
+              while (start > 0 && (isalnum(decl_line[start - 1]) ||
+                                   decl_line[start - 1] == '_'))
                 start--;
               if (start < end) {
                 tg_names.insert(decl_line.substr(start, end - start));

--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -1801,6 +1801,9 @@ ffi::Module BuildTileLangMetal(IRModule mod, Target target) {
     //    that are missing the qualifier and inserts "threadgroup".
     {
       // Collect threadgroup buffer names from declarations.
+      // Only match lines where "threadgroup " appears at the start
+      // (after optional whitespace) — that is a declaration, not a
+      // cast expression like *(threadgroup float4*)(&__dst[...]).
       // Matches both array and pointer forms:
       //   threadgroup half As[2048];
       //   threadgroup void* As = ...;
@@ -1809,23 +1812,29 @@ ffi::Module BuildTileLangMetal(IRModule mod, Target target) {
         std::istringstream decl_iss(fsource);
         std::string decl_line;
         while (std::getline(decl_iss, decl_line)) {
-          if (decl_line.find("threadgroup ") == std::string::npos)
+          // Find first non-whitespace position
+          size_t start_pos = 0;
+          while (start_pos < decl_line.length() && decl_line[start_pos] == ' ')
+            start_pos++;
+          // "threadgroup " must be at line start, not inside a cast
+          if (decl_line.substr(start_pos, 12) != "threadgroup ")
             continue;
           // Find any [ ; or = and backtrack to the preceding alnum token.
-          for (size_t p = 0; p < decl_line.length(); p++) {
+          for (size_t p = start_pos; p < decl_line.length(); p++) {
             if (decl_line[p] == '[' || decl_line[p] == ';' ||
                 decl_line[p] == '=') {
               // Backtrack past spaces
               size_t end = p;
-              while (end > 0 && decl_line[end - 1] == ' ')
+              while (end > start_pos && decl_line[end - 1] == ' ')
                 end--;
               // Backtrack past alnum / underscore
-              size_t start = end;
-              while (start > 0 && (isalnum(decl_line[start - 1]) ||
-                                   decl_line[start - 1] == '_'))
-                start--;
-              if (start < end) {
-                tg_names.insert(decl_line.substr(start, end - start));
+              size_t tok_start = end;
+              while (tok_start > start_pos &&
+                     (isalnum(decl_line[tok_start - 1]) ||
+                      decl_line[tok_start - 1] == '_'))
+                tok_start--;
+              if (tok_start < end) {
+                tg_names.insert(decl_line.substr(tok_start, end - tok_start));
               }
             }
           }
@@ -1848,7 +1857,7 @@ ffi::Module BuildTileLangMetal(IRModule mod, Target target) {
           if (has_tg_var) {
             for (size_t i = 0; i + 3 < line.length(); i++) {
               if (line[i] == '(') {
-                if (line.substr(i, 14) == "(threadgroup ") {
+                if (line.substr(i, 13) == "(threadgroup ") {
                   i += 13;
                   continue;
                 }
@@ -1953,7 +1962,7 @@ ffi::Module BuildTileLangMetalWithoutCompile(IRModule mod, Target target) {
           if (has_tg_var) {
             for (size_t i = 0; i + 3 < line.length(); i++) {
               if (line[i] == '(') {
-                if (line.substr(i, 14) == "(threadgroup ") {
+                if (line.substr(i, 13) == "(threadgroup ") {
                   i += 13;
                   continue;
                 }

--- a/tilelang/metal/op/gemm/__init__.py
+++ b/tilelang/metal/op/gemm/__init__.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import itertools
+from typing import List, Dict, Any
+
 from tilelang.tileop.gemm.registry import register_gemm_impl
 from tilelang.metal.target import target_is_metal
 
@@ -17,3 +20,54 @@ def _match_metal(target) -> bool:
 
 register_gemm_impl(GEMM_INST_METAL, GEMM_INST_METAL, _match_metal, GemmMetalSimdGroup)
 register_gemm_impl(GEMM_INST_METAL_COOPERATIVE_TENSOR, GEMM_INST_METAL_COOPERATIVE_TENSOR, _match_metal, GemmMetal)
+
+
+def get_metal_gemm_configs(
+    M: int,
+    N: int,
+    K: int,
+) -> List[Dict[str, Any]]:
+    """Generate Metal-optimized GEMM autotuner configs.
+
+    Unlike CUDA GPUs, Apple Silicon prefers smaller tile sizes and fewer
+    threads per block. MLX's Steel GEMM uses BM/BN ∈ {32, 64},
+    BK ∈ {8, 16, 32}, and threads = WM*WN*32 ∈ {128, 256}.
+
+    This mirrors those constraints and filters out invalid combinations
+    (e.g. tile larger than problem dimension, or partition mismatch).
+
+    Returns:
+        A list of config dicts with keys: block_M, block_N, block_K,
+        thread_num. Suitable for passing to AutoTuner.from_kernel().
+    """
+    # Apple GPU prefers smaller tiles
+    block_M_candidates = [16, 32, 64]
+    block_N_candidates = [16, 32, 64]
+    block_K_candidates = [8, 16, 32]
+    thread_num_candidates = [64, 128, 256]
+
+    configs = []
+    for bm, bn, bk, threads in itertools.product(
+        block_M_candidates, block_N_candidates, block_K_candidates, thread_num_candidates
+    ):
+        # Skip invalid: tile larger than problem
+        if bm > M or bn > N or bk > K:
+            continue
+        # Skip invalid: thread count must be a multiple of 32 (warp size)
+        if threads % 32 != 0:
+            continue
+        # Skip invalid: tile must be divisible by 8 (simdgroup fragment size)
+        if bm % 8 != 0 or bn % 8 != 0:
+            continue
+        # Skip invalid: 64-thread blocks too small for large tiles
+        if threads == 64 and bm * bn > 1024:
+            continue
+
+        configs.append({
+            "block_M": bm,
+            "block_N": bn,
+            "block_K": bk,
+            "thread_num": threads,
+        })
+
+    return configs

--- a/tilelang/metal/op/gemm/__init__.py
+++ b/tilelang/metal/op/gemm/__init__.py
@@ -29,18 +29,14 @@ def get_metal_gemm_configs(
 ) -> list[dict[str, Any]]:
     """Generate Metal-optimized GEMM autotuner configs.
 
-    Unlike CUDA GPUs, Apple Silicon prefers smaller tile sizes and fewer
-    threads per block. MLX's Steel GEMM uses BM/BN ∈ {32, 64},
-    BK ∈ {8, 16, 32}, and threads = WM*WN*32 ∈ {128, 256}.
-
-    This mirrors those constraints and filters out invalid combinations
-    (e.g. tile larger than problem dimension, or partition mismatch).
+    Apple GPU prefers smaller tiles.  MLX's Steel GEMM uses
+    BM/BN ∈ {16, 32, 64}, BK ∈ {8, 16, 32}, threads ∈ {64, 128, 256}.
+    These match the six shapes instantiated in steel_gemm_fused.metal.
 
     Returns:
         A list of config dicts with keys: block_M, block_N, block_K,
         thread_num. Suitable for passing to AutoTuner.from_kernel().
     """
-    # Apple GPU prefers smaller tiles
     block_M_candidates = [16, 32, 64]
     block_N_candidates = [16, 32, 64]
     block_K_candidates = [8, 16, 32]
@@ -48,16 +44,8 @@ def get_metal_gemm_configs(
 
     configs = []
     for bm, bn, bk, threads in itertools.product(block_M_candidates, block_N_candidates, block_K_candidates, thread_num_candidates):
-        # Skip invalid: tile larger than problem
         if bm > M or bn > N or bk > K:
             continue
-        # Skip invalid: thread count must be a multiple of 32 (warp size)
-        if threads % 32 != 0:
-            continue
-        # Skip invalid: tile must be divisible by 8 (simdgroup fragment size)
-        if bm % 8 != 0 or bn % 8 != 0:
-            continue
-        # Skip invalid: 64-thread blocks too small for large tiles
         if threads == 64 and bm * bn > 1024:
             continue
 

--- a/tilelang/metal/op/gemm/__init__.py
+++ b/tilelang/metal/op/gemm/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import itertools
-from typing import List, Dict, Any
+from typing import Any
 
 from tilelang.tileop.gemm.registry import register_gemm_impl
 from tilelang.metal.target import target_is_metal
@@ -26,7 +26,7 @@ def get_metal_gemm_configs(
     M: int,
     N: int,
     K: int,
-) -> List[Dict[str, Any]]:
+) -> list[dict[str, Any]]:
     """Generate Metal-optimized GEMM autotuner configs.
 
     Unlike CUDA GPUs, Apple Silicon prefers smaller tile sizes and fewer
@@ -47,9 +47,7 @@ def get_metal_gemm_configs(
     thread_num_candidates = [64, 128, 256]
 
     configs = []
-    for bm, bn, bk, threads in itertools.product(
-        block_M_candidates, block_N_candidates, block_K_candidates, thread_num_candidates
-    ):
+    for bm, bn, bk, threads in itertools.product(block_M_candidates, block_N_candidates, block_K_candidates, thread_num_candidates):
         # Skip invalid: tile larger than problem
         if bm > M or bn > N or bk > K:
             continue
@@ -63,11 +61,13 @@ def get_metal_gemm_configs(
         if threads == 64 and bm * bn > 1024:
             continue
 
-        configs.append({
-            "block_M": bm,
-            "block_N": bn,
-            "block_K": bk,
-            "thread_num": threads,
-        })
+        configs.append(
+            {
+                "block_M": bm,
+                "block_N": bn,
+                "block_K": bk,
+                "thread_num": threads,
+            }
+        )
 
     return configs


### PR DESCRIPTION
Three fixes/improvements for the Metal backend. See the first comment below for detailed benchmarks and references.

Only `src/metal/codegen/codegen_metal.cc` and `tilelang/metal/op/gemm/__init__.py` modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixes Metal “pass 5” threadgroup variable handling in `src/metal/codegen/codegen_metal.cc` by collecting declared `threadgroup` buffer names and applying missing `threadgroup` qualifiers during generated MSL pointer-cast rewriting (including the `BuildTileLangMetalWithoutCompile` path).
- Improves generated MSL loop pragmas by emitting `#pragma clang loop unroll(full)` for constant-bound loops with extents 2–8, while keeping `unroll(disable)` for extents > 8.
- Adds Metal-specific GEMM autotuner configuration generation in `tilelang/metal/op/gemm/__init__.py` via a new `get_metal_gemm_configs(M, N, K)` helper.

## C++ style / lint notes

- This PR changes C++ code but does **not** modify rules in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step is still advisory: any TLCPP003/TLCPP004 findings should be treated as non-blocking unless they indicate a concrete correctness/build/API/FFI/maintainability risk introduced by this change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->