### PR TITLE
[CUDA] Extend the GEMM FMA fallback to SM75

### DIFF
--- a/src/cuda/op/gemm.cc
+++ b/src/cuda/op/gemm.cc
@@ -125,6 +125,24 @@ bool Use2CtaRequested(const GemmNode &op) {
   return false;
 }
 
+// Native SM75 mma.sync atoms (see tl_templates/cuda/instruction/mma.h).
+// Dtype-only on purpose: SM75 MMA handles the same scopes and transposes as
+// the generic path, so scope checks here would wrongly demote f16 to FMA.
+bool AllowTuringMma(const GemmNode &op) {
+  DataType a = op.a_->dtype;
+  if (a != op.b_->dtype) {
+    return false;
+  }
+  if (a == DataType::Float(16)) {
+    return op.c_->dtype == DataType::Float(16) ||
+           op.c_->dtype == DataType::Float(32);
+  }
+  if ((a.is_int() || a.is_uint()) && (a.bits() == 8 || a.bits() == 4)) {
+    return op.c_->dtype == DataType::Int(32);
+  }
+  return false;
+}
+
 void FatalWgmmaUnavailable(const GemmNode &op, Target target) {
   LOG(FATAL) << "T.wgmma_gemm() requires Hopper WGMMA lowering, but "
                 "constraints were not satisfied. Got target="
@@ -329,6 +347,9 @@ struct Gemm {
       return kCudaWGMMA;
     }
     if (TargetIsVolta(target) && !AllowVoltaMma(op)) {
+      return kCudaFMA;
+    }
+    if (TargetIsTuring(target) && !AllowTuringMma(op)) {
       return kCudaFMA;
     }
     return kCudaMMA;

--- a/testing/python/cuda/test_cuda_mma_sm75_dispatch.py
+++ b/testing/python/cuda/test_cuda_mma_sm75_dispatch.py
@@ -19,6 +19,7 @@ def test_sm75_uses_sm75_mma_gemm_impl():
     assert resolve_gemm_impl("cuda.mma", Target({"kind": "cuda", "arch": "sm_75"})) is GemmMMASm75
     assert resolve_gemm_impl("cuda.mma", Target({"kind": "cuda", "arch": "sm_80"})) is GemmMMA
     assert resolve_gemm_impl("cuda.fma", Target({"kind": "cuda", "arch": "sm_70"})) is GemmFMA
+    assert resolve_gemm_impl("cuda.fma", Target({"kind": "cuda", "arch": "sm_75"})) is GemmFMA
 
 
 def test_sm75_fp16_emitter_uses_m16n8k8_shape():

--- a/testing/python/kernel/test_tilelang_kernel_sm75_gemm_fma.py
+++ b/testing/python/kernel/test_tilelang_kernel_sm75_gemm_fma.py
@@ -1,0 +1,102 @@
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+_SM75 = {"kind": "cuda", "arch": "sm_75"}
+
+
+def _make_ss_gemm(M, N, K, in_dtype, accum_dtype, threads=128):
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), in_dtype),
+        B: T.Tensor((K, N), in_dtype),
+        C: T.Tensor((M, N), accum_dtype),
+    ):
+        with T.Kernel(1, threads=threads):
+            A_shared = T.alloc_shared((M, K), in_dtype)
+            B_shared = T.alloc_shared((K, N), in_dtype)
+            C_local = T.alloc_fragment((M, N), accum_dtype)
+
+            T.copy(A, A_shared)
+            T.copy(B, B_shared)
+            T.clear(C_local)
+            T.gemm(A_shared, B_shared, C_local, policy=T.GemmWarpPolicy.FullRow)
+            T.copy(C_local, C)
+
+    return main
+
+
+# ---------------------------------------------------------------------------
+# Compile-only dispatch checks pinned to an explicit sm_75 target, so they run
+# on any CUDA runner regardless of the host GPU. Turing has no fp32/tf32,
+# fp64, or bf16 mma.sync atoms; these dtypes must lower through the FMA
+# fallback instead of tl::mma_sync (which fails nvcc's static_assert for bf16
+# and compiles into a cutlass runtime trap for fp32/fp64).
+# ---------------------------------------------------------------------------
+
+
+@tilelang.testing.requires_cuda
+def test_sm75_fp32_gemm_compiles_to_fma_fallback():
+    kernel = tilelang.compile(_make_ss_gemm(64, 64, 32, T.float32, T.float32), target=_SM75, out_idx=[2])
+    assert "tl::mma_sync" not in kernel.get_kernel_source()
+
+
+@tilelang.testing.requires_cuda
+def test_sm75_fp64_gemm_compiles_to_fma_fallback():
+    kernel = tilelang.compile(_make_ss_gemm(32, 32, 32, T.float64, T.float64), target=_SM75, out_idx=[2])
+    assert "tl::mma_sync" not in kernel.get_kernel_source()
+
+
+@tilelang.testing.requires_cuda
+def test_sm75_bf16_gemm_compiles_to_fma_fallback():
+    kernel = tilelang.compile(_make_ss_gemm(64, 64, 32, T.bfloat16, T.float32), target=_SM75, out_idx=[2])
+    assert "tl::mma_sync" not in kernel.get_kernel_source()
+
+
+@tilelang.testing.requires_cuda
+def test_sm75_fp16_gemm_keeps_mma_path():
+    """f16 has native Turing atoms; the fallback must not demote it."""
+    kernel = tilelang.compile(_make_ss_gemm(64, 64, 32, T.float16, T.float32), target=_SM75, out_idx=[2])
+    assert "tl::mma_sync" in kernel.get_kernel_source()
+
+
+# ---------------------------------------------------------------------------
+# Execution checks on real Turing hardware.
+# ---------------------------------------------------------------------------
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(7, 5)
+def test_sm75_fp32_gemm_fma_matches_torch():
+    kernel = tilelang.compile(_make_ss_gemm(64, 64, 32, T.float32, T.float32), target="cuda", out_idx=[2])
+    a = torch.randn((64, 32), device="cuda", dtype=torch.float32)
+    b = torch.randn((32, 64), device="cuda", dtype=torch.float32)
+    c = kernel(a, b)
+    tilelang.testing.torch_assert_close(c, a @ b, rtol=1e-4, atol=1e-4)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(7, 5)
+def test_sm75_fp64_gemm_fma_matches_torch():
+    kernel = tilelang.compile(_make_ss_gemm(32, 32, 32, T.float64, T.float64), target="cuda", out_idx=[2])
+    a = torch.randn((32, 32), device="cuda", dtype=torch.float64)
+    b = torch.randn((32, 32), device="cuda", dtype=torch.float64)
+    c = kernel(a, b)
+    tilelang.testing.torch_assert_close(c, a @ b, rtol=1e-8, atol=1e-8)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(7, 5)
+def test_sm75_bf16_gemm_fma_matches_torch():
+    kernel = tilelang.compile(_make_ss_gemm(64, 64, 32, T.bfloat16, T.float32), target="cuda", out_idx=[2])
+    a = torch.randn((64, 32), device="cuda", dtype=torch.bfloat16)
+    b = torch.randn((32, 64), device="cuda", dtype=torch.bfloat16)
+    c = kernel(a, b)
+    ref = a.float() @ b.float()
+    tilelang.testing.torch_assert_close(c, ref, rtol=1e-2, atol=1e-2, max_mismatched_ratio=0.01)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

On SM75 (Turing), a `T.gemm` whose dtype combination has no native Turing `mma.sync` atom crashes instead of computing. FP32 and FP64 compile but trap when the kernel launches, leaving the CUDA context in an error state:

```text
cute/arch/mma_sm80.hpp:315: Assertion `0 && "Attempting to use SM80_16x8x8_F32TF32TF32F32_TN without CUTE_ARCH_MMA_SM80_ENABLED"` failed.
```

BF16 fails during nvcc compilation:

```text
src/tl_templates/cuda/instruction/mma.h(167): error: static assertion failed with "tl::mma_sync: unsupported configuration"
```

The FP32, FP64, and BF16 cases in `test_tilelang_kernel_gemm.py` all hit these failures on an SM75 GPU. The device-side asserts from FP32 and FP64 also cause later tests in the same process to fail.

## Root Cause

On Turing, `SelectInst` routed GEMMs to the plain MMA path even when their dtype combination had no native SM75 atom. FP32, FP64, and BF16 therefore selected SM80-only atoms.

#2339 added the `cuda.fma` correctness fallback for GEMMs without a usable tensor-core MMA path, but only connected it to Volta.

## Fix

Add `AllowTuringMma` alongside the Volta check and select the existing `cuda.fma` implementation when SM75 has no native atom for the requested dtype combination.

Unlike the Volta check, the Turing check is intentionally dtype-only. The SM75 emitter supports the same operand scopes and transpose combinations as the generic MMA path, so scope-based routing would incorrectly demote valid FP16 `sr`/`rs` cases to the fallback. Besides being slower, the fallback accumulates serially, and FP16 accumulation loses accuracy over long K.

## Tested

* Added `test_tilelang_kernel_sm75_gemm_fma.py` following the SM70 pattern from #2339. Compile-only checks pinned to an explicit `sm_75` target, so they run on any CUDA runner, assert that FP32, FP64, and BF16 lower through the fallback while FP16 stays on MMA. Execution checks gated on compute capability 7.5 compare the results against PyTorch.
* Reverting the `SelectInst` change makes the fallback tests fail with the errors above, while the FP16 test still passes.
* Verified on a TITAN RTX (`sm_75`, Turing) with CUDA 12.4: `test_tilelang_kernel_gemm.py` and `test_tilelang_kernel_gemm_sm75.py` pass, with FP16, INT8, and INT4, including the `sr`/`rs` fragment cases, keeping their native MMA lowering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Extended SM75 GEMM instruction selection to use the existing `cuda.fma` fallback for unsupported FP32, FP64, and BF16 combinations.
- Preserved native Turing MMA lowering for supported FP16 and integer cases.
- Added SM75 dispatch, compile-only lowering, and hardware correctness tests.

## C++ style / lint notes

- This PR does not modify `docs/developer_guide/cpp_style.md` or public C++ APIs.
- The repository’s “C++ API Style Audit (warning only)” CI step remains applicable; no correctness or build issues are implied by advisory style findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->