### PR TITLE
[BugFix] Support keep-dim destinations in fragment reduce

### DIFF
--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -801,9 +801,9 @@ template <typename Impl> struct ReduceLowerer {
       auto dst_layout = lower_args.layout_map[op.dst].as<Fragment>().value();
       // Same keep-dim criterion as ReduceOpNode::InferLayout, so that
       // `red_layout` and `dst_layout` always agree on rank. Rank-1 sources are
-      // excluded: dropping their only axis already degenerates to extent 1. A
-      // same-rank destination whose reduced axis is not extent 1 is not a
-      // keep-dim reduction and must be rejected by the rank check below.
+      // excluded: dropping their only axis already degenerates to extent 1.
+      // A same-rank destination with a non-unit reduced axis is already
+      // diagnosed by ReduceOpNode::InferLayout, which runs before lowering.
       bool keepdim = src_layout->InputDim() > 1 &&
                      op.dst->shape.size() == src_layout->InputDim() &&
                      is_one(op.dst->shape[op.dim]);

--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -801,9 +801,12 @@ template <typename Impl> struct ReduceLowerer {
       auto dst_layout = lower_args.layout_map[op.dst].as<Fragment>().value();
       // Same keep-dim criterion as ReduceOpNode::InferLayout, so that
       // `red_layout` and `dst_layout` always agree on rank. Rank-1 sources are
-      // excluded: dropping their only axis already degenerates to extent 1.
+      // excluded: dropping their only axis already degenerates to extent 1. A
+      // same-rank destination whose reduced axis is not extent 1 is not a
+      // keep-dim reduction and must be rejected by the rank check below.
       bool keepdim = src_layout->InputDim() > 1 &&
-                     op.dst->shape.size() == src_layout->InputDim();
+                     op.dst->shape.size() == src_layout->InputDim() &&
+                     is_one(op.dst->shape[op.dim]);
       auto red_layout =
           reduce::ComputeReducerLayout(src_layout, op.dim, keepdim);
       auto src_dim = src_layout->InputDim();

--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -55,22 +55,38 @@ inline Array<PrimExpr> InputPlaceholders(size_t n) {
   return result;
 }
 
-inline Fragment ComputeReducerLayout(const Fragment &src_layout, int dim) {
+// NOTE: duplicated in src/op/reduce.cc; keep both in sync.
+// With `keepdim`, the reduced axis is retained as an extent-1 dummy axis so
+// that the layout rank matches a keep-dim destination buffer. The physical
+// thread mapping is unchanged; only the number of accepted logical indices
+// differs.
+inline Fragment ComputeReducerLayout(const Fragment &src_layout, int dim,
+                                     bool keepdim = false) {
   PrimExpr src_rep_extent = src_layout->ReplicateExtent();
   PrimExpr indice_rep_extent = src_layout->InputShape()[dim];
   PrimExpr reducer_rep_extent = indice_rep_extent * src_rep_extent;
 
-  auto fwd = InputPlaceholders(src_layout->InputDim() - 1);
-  fwd.insert(fwd.begin() + dim,
-             FloorMod(ReplicationPlaceholder(), indice_rep_extent));
+  Array<PrimExpr> fwd;
+  if (keepdim) {
+    fwd = InputPlaceholders(src_layout->InputDim());
+    fwd.Set(dim, FloorMod(ReplicationPlaceholder(), indice_rep_extent));
+  } else {
+    fwd = InputPlaceholders(src_layout->InputDim() - 1);
+    fwd.insert(fwd.begin() + dim,
+               FloorMod(ReplicationPlaceholder(), indice_rep_extent));
+  }
 
   auto thd = src_layout->ForwardThread(
       fwd, FloorDiv(ReplicationPlaceholder(), indice_rep_extent));
 
   auto reducer_shape = src_layout->InputShape();
-  reducer_shape.erase(reducer_shape.begin() + dim);
-  if (reducer_shape.empty()) {
-    reducer_shape.push_back(1);
+  if (keepdim) {
+    reducer_shape.Set(dim, 1);
+  } else {
+    reducer_shape.erase(reducer_shape.begin() + dim);
+    if (reducer_shape.empty()) {
+      reducer_shape.push_back(1);
+    }
   }
 
   return Fragment(reducer_shape, {}, thd, reducer_rep_extent, std::nullopt)
@@ -783,7 +799,13 @@ template <typename Impl> struct ReduceLowerer {
       auto dst_buffer = get_buffer(op.dst);
       auto src_layout = lower_args.layout_map[op.src].as<Fragment>().value();
       auto dst_layout = lower_args.layout_map[op.dst].as<Fragment>().value();
-      auto red_layout = reduce::ComputeReducerLayout(src_layout, op.dim);
+      // Same keep-dim criterion as ReduceOpNode::InferLayout, so that
+      // `red_layout` and `dst_layout` always agree on rank. Rank-1 sources are
+      // excluded: dropping their only axis already degenerates to extent 1.
+      bool keepdim = src_layout->InputDim() > 1 &&
+                     op.dst->shape.size() == src_layout->InputDim();
+      auto red_layout =
+          reduce::ComputeReducerLayout(src_layout, op.dim, keepdim);
       auto src_dim = src_layout->InputDim();
       auto dst_dim = dst_layout->InputDim();
 
@@ -792,6 +814,11 @@ template <typename Impl> struct ReduceLowerer {
       if (is_1d_reduce) {
         ICHECK(is_one(dst_layout->OutputShape().back()))
             << "Reduce for scalar not implemented.";
+      } else if (keepdim) {
+        ICHECK_EQ(src_dim, dst_dim) << "Reduce dimension mismatch.";
+        ICHECK(is_one(dst_layout->InputShape()[op.dim]))
+            << "Reduce for keep-dim requires the reduced axis to have extent 1 "
+               "in the destination layout.";
       } else {
         ICHECK_EQ(src_dim, dst_dim + 1) << "Reduce dimension mismatch.";
       }
@@ -809,7 +836,13 @@ template <typename Impl> struct ReduceLowerer {
       }
       Range reduce_dom(0, src_layout->InputShape()[op.dim]);
       IterVar reduce_iv(reduce_dom, Var("rv"), IterVarType::kDataPar);
-      src_vars.insert(src_vars.begin() + op.dim, reduce_iv);
+      if (keepdim) {
+        // `dst_vars` already carries the extent-1 dummy axis at `op.dim`;
+        // replace it instead of inserting, to keep `src_vars` at src rank.
+        src_vars.Set(op.dim, reduce_iv);
+      } else {
+        src_vars.insert(src_vars.begin() + op.dim, reduce_iv);
+      }
 
       auto src_indices = src_layout->Forward(
           src_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }));

--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -215,15 +215,25 @@ LayoutMap ReduceOpNode::InferLayout(const LayoutInferArgs &layout_args,
   if (IsFragmentBuffer(src) && IsFragmentBuffer(dst) &&
       layout_args.layout_map.count(src)) {
     auto src_layout = layout_args.layout_map[src].as<Fragment>().value();
+    // A destination of the same rank as the source is only meaningful as a
+    // keep-dim reduction, which requires the reduced axis to collapse to extent
+    // 1. Diagnose a non-unit extent here, where the actual defect is, instead
+    // of letting it fall through to the rank checks below and report a rank
+    // mismatch that does not describe the problem.
+    if (src_layout->InputDim() > 1 &&
+        dst->shape.size() == src_layout->InputDim()) {
+      ICHECK(is_one(dst->shape[this->dim]))
+          << "ReduceOp: a same-rank destination must keep the reduced axis at "
+             "extent 1, got "
+          << dst->shape[this->dim] << " for " << dst;
+    }
+
     // The destination buffer is the only place that records whether the user
     // asked for a keep-dim reduction; `dst->shape` keeps the reduced axis with
     // extent 1 in that case. Rank-1 sources are excluded: dropping their only
-    // axis already degenerates to extent 1. A same-rank destination whose
-    // reduced axis is not extent 1 is not a keep-dim reduction, so it must fall
-    // through to the rank check below rather than be silently accepted.
+    // axis already degenerates to extent 1.
     bool keepdim = src_layout->InputDim() > 1 &&
-                   dst->shape.size() == src_layout->InputDim() &&
-                   is_one(dst->shape[this->dim]);
+                   dst->shape.size() == src_layout->InputDim();
     auto reducer_layout = ComputeReducerLayout(src_layout, this->dim, keepdim);
 
     if (!layout_args.layout_map.count(dst)) {

--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -218,9 +218,12 @@ LayoutMap ReduceOpNode::InferLayout(const LayoutInferArgs &layout_args,
     // The destination buffer is the only place that records whether the user
     // asked for a keep-dim reduction; `dst->shape` keeps the reduced axis with
     // extent 1 in that case. Rank-1 sources are excluded: dropping their only
-    // axis already degenerates to extent 1.
+    // axis already degenerates to extent 1. A same-rank destination whose
+    // reduced axis is not extent 1 is not a keep-dim reduction, so it must fall
+    // through to the rank check below rather than be silently accepted.
     bool keepdim = src_layout->InputDim() > 1 &&
-                   dst->shape.size() == src_layout->InputDim();
+                   dst->shape.size() == src_layout->InputDim() &&
+                   is_one(dst->shape[this->dim]);
     auto reducer_layout = ComputeReducerLayout(src_layout, this->dim, keepdim);
 
     if (!layout_args.layout_map.count(dst)) {

--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -126,22 +126,38 @@ static Array<PrimExpr> InputPlaceholders(size_t n) {
   return result;
 }
 
-static Fragment ComputeReducerLayout(const Fragment &src_layout, int dim) {
+// NOTE: duplicated in src/backend/common/op/reduce.h; keep both in sync.
+// With `keepdim`, the reduced axis is retained as an extent-1 dummy axis so
+// that the layout rank matches a keep-dim destination buffer. The physical
+// thread mapping is unchanged; only the number of accepted logical indices
+// differs.
+static Fragment ComputeReducerLayout(const Fragment &src_layout, int dim,
+                                     bool keepdim = false) {
   PrimExpr src_rep_extent = src_layout->ReplicateExtent();
   PrimExpr indice_rep_extent = src_layout->InputShape()[dim];
   PrimExpr reducer_rep_extent = indice_rep_extent * src_rep_extent;
 
-  auto fwd = InputPlaceholders(src_layout->InputDim() - 1);
-  fwd.insert(fwd.begin() + dim,
-             FloorMod(ReplicationPlaceholder(), indice_rep_extent));
+  Array<PrimExpr> fwd;
+  if (keepdim) {
+    fwd = InputPlaceholders(src_layout->InputDim());
+    fwd.Set(dim, FloorMod(ReplicationPlaceholder(), indice_rep_extent));
+  } else {
+    fwd = InputPlaceholders(src_layout->InputDim() - 1);
+    fwd.insert(fwd.begin() + dim,
+               FloorMod(ReplicationPlaceholder(), indice_rep_extent));
+  }
 
   auto thd = src_layout->ForwardThread(
       fwd, FloorDiv(ReplicationPlaceholder(), indice_rep_extent));
 
   auto reducer_shape = src_layout->InputShape();
-  reducer_shape.erase(reducer_shape.begin() + dim);
-  if (reducer_shape.empty()) {
-    reducer_shape.push_back(1);
+  if (keepdim) {
+    reducer_shape.Set(dim, 1);
+  } else {
+    reducer_shape.erase(reducer_shape.begin() + dim);
+    if (reducer_shape.empty()) {
+      reducer_shape.push_back(1);
+    }
   }
 
   auto reducer_layout =
@@ -199,9 +215,19 @@ LayoutMap ReduceOpNode::InferLayout(const LayoutInferArgs &layout_args,
   if (IsFragmentBuffer(src) && IsFragmentBuffer(dst) &&
       layout_args.layout_map.count(src)) {
     auto src_layout = layout_args.layout_map[src].as<Fragment>().value();
-    auto reducer_layout = ComputeReducerLayout(src_layout, this->dim);
+    // The destination buffer is the only place that records whether the user
+    // asked for a keep-dim reduction; `dst->shape` keeps the reduced axis with
+    // extent 1 in that case. Rank-1 sources are excluded: dropping their only
+    // axis already degenerates to extent 1.
+    bool keepdim = src_layout->InputDim() > 1 &&
+                   dst->shape.size() == src_layout->InputDim();
+    auto reducer_layout = ComputeReducerLayout(src_layout, this->dim, keepdim);
 
     if (!layout_args.layout_map.count(dst)) {
+      ICHECK_EQ(reducer_layout->InputDim(), dst->shape.size())
+          << "ReduceOp: inferred reducer layout rank does not match the "
+             "destination buffer rank for "
+          << dst;
       return {{dst, reducer_layout}};
     }
 

--- a/testing/python/language/test_tilelang_language_reduce.py
+++ b/testing/python/language/test_tilelang_language_reduce.py
@@ -646,6 +646,80 @@ def test_reduce_clear(op, dtype, M, N, src_scope, dst_scope):
 
 
 # ---------------------------------------------------------------------------
+# test_reduce_keepdim  (destination keeps the reduced axis with extent 1)
+# ---------------------------------------------------------------------------
+
+REDUCE_KEEPDIM_CASES = [
+    # (op,   dtype,      shape,        dim, clear)
+    ("sum", T.float32, (64, 64), 1, True),
+    ("sum", T.float32, (64, 64), 0, True),
+    ("max", T.float32, (64, 64), 1, True),
+    ("min", T.float32, (64, 64), 0, True),
+    ("sum", T.float32, (32, 16, 64), 1, True),
+    ("sum", T.float32, (64, 64), 1, False),
+    ("max", T.float32, (64, 64), 1, False),
+]
+
+
+@pytest.mark.parametrize(
+    ("op", "dtype", "shape", "dim", "clear"),
+    REDUCE_KEEPDIM_CASES,
+    ids=[
+        f"{op}-{dtype}-{'x'.join(map(str, shape))}-dim{dim}-{'clear' if clear else 'accum'}"
+        for op, dtype, shape, dim, clear in REDUCE_KEEPDIM_CASES
+    ],
+)
+@tilelang.testing.requires_cuda
+def test_reduce_keepdim(op, dtype, shape, dim, clear):
+    """Keep-dim destinations are part of the documented reduce contract.
+
+    See tilelang/language/reduce_op.py, which accepts both [X, Y] and
+    [X, 1, Y] output shapes.
+    """
+    out_shape = tuple(1 if i == dim else s for i, s in enumerate(shape))
+
+    @tilelang.jit(out_idx=-1)
+    def kernel():
+
+        @T.prim_func
+        def main(A: T.Tensor(shape, dtype), B: T.Tensor(out_shape, dtype)):
+            with T.Kernel(1, threads=128):
+                src = T.alloc_fragment(shape, dtype)
+                dst = T.alloc_fragment(out_shape, dtype)
+                T.copy(A, src)
+                if not clear:
+                    if op == "sum":
+                        T.fill(dst, 1)
+                    else:
+                        T.fill(dst, -T.infinity(dtype))
+                if clear:
+                    _reduce_op(T, op, src, dst, dim)
+                elif op == "sum":
+                    T.reduce_sum(src, dst, dim=dim, clear=False)
+                else:
+                    T.reduce_max(src, dst, dim=dim, clear=False)
+                T.copy(dst, B)
+
+        return main
+
+    torch_dtype = getattr(torch, dtype)
+    A = torch.randn(*shape, dtype=torch_dtype).cuda()
+    B = kernel()(A)
+
+    assert tuple(B.shape) == out_shape, f"expected keep-dim output {out_shape}, got {tuple(B.shape)}"
+
+    if op == "sum":
+        ref = A.sum(dim=dim, keepdim=True)
+        if not clear:
+            ref = ref + 1
+    elif op == "max":
+        ref = A.amax(dim=dim, keepdim=True)
+    elif op == "min":
+        ref = A.amin(dim=dim, keepdim=True)
+    torch.testing.assert_close(B, ref, atol=1e-2, rtol=1e-2)
+
+
+# ---------------------------------------------------------------------------
 # T.finalize_reducer tests
 # ---------------------------------------------------------------------------
 

--- a/testing/python/language/test_tilelang_language_reduce.py
+++ b/testing/python/language/test_tilelang_language_reduce.py
@@ -658,6 +658,7 @@ REDUCE_KEEPDIM_CASES = [
     ("sum", T.float32, (32, 16, 64), 1, True),
     ("sum", T.float32, (64, 64), 1, False),
     ("max", T.float32, (64, 64), 1, False),
+    ("min", T.float32, (64, 64), 1, False),
 ]
 
 
@@ -690,12 +691,16 @@ def test_reduce_keepdim(op, dtype, shape, dim, clear):
                 if not clear:
                     if op == "sum":
                         T.fill(dst, 1)
+                    elif op == "min":
+                        T.fill(dst, T.infinity(dtype))
                     else:
                         T.fill(dst, -T.infinity(dtype))
                 if clear:
                     _reduce_op(T, op, src, dst, dim)
                 elif op == "sum":
                     T.reduce_sum(src, dst, dim=dim, clear=False)
+                elif op == "min":
+                    T.reduce_min(src, dst, dim=dim, clear=False)
                 else:
                     T.reduce_max(src, dst, dim=dim, clear=False)
                 T.copy(dst, B)


### PR DESCRIPTION
# [BugFix] Support keep-dim destinations in fragment reduce

## Summary

Fixes #2530.

`T.reduce_sum` / `T.reduce_max` / etc. crash at compile time when the
destination buffer keeps the reduced axis with extent 1 (e.g. reducing
`(64, 64)` along `dim=1` into a `(64, 1)` fragment):

```
Check failed: vars.size() == InputDim() (2 vs. 1)
```

This shape is part of the documented frontend contract — `tilelang/language/reduce_op.py:50-56`
explicitly accepts both `[X, Y]` and `[X, 1, Y]` output shapes and builds
`expected_shapes` for both — so this is a backend gap, not user misuse. The fix
teaches both the layout-inference and lowering stages to produce a reducer
layout whose rank matches the keep-dim destination.

## Root Cause

`ComputeReducerLayout` unconditionally **drops** the reduced axis when building
the reducer fragment, so it always returns a layout of rank `n-1` for a rank-`n`
source. Two places consume it, and both assume the destination is rank `n-1`.

**Stage 1 — layout inference** (`src/op/reduce.cc`)

`ReduceOpNode::InferLayout` binds that rank-`n-1` layout straight to the
destination buffer. When `dst` has no layout yet it takes an early `return`,
which skips the rank check further down in the same function — the one place that
would have caught the mismatch. A rank-1 layout gets bound to a rank-2 buffer,
and nothing complains until a much later `Forward` call trips the invariant guard
at `src/layout/layout.cc:929`:

```cpp
ICHECK_EQ(vars.size(), InputDim())
```

That is where the opaque `(2 vs. 1)` surfaces. The reported location is the
detection point, not the introduction point.

**Stage 2 — lowering** (`src/backend/common/op/reduce.h`)

Fixing stage 1 alone only relocates the crash. The lowering path derives its own
`red_layout` from the same helper, then feeds **one shared `dst_vars` array** to
two different layouts:

```cpp
auto dst_indices = dst_layout->Forward(dst_vars.Map(...));  // needs dst_dim args
auto red_indices = red_layout->Forward(dst_vars.Map(...));  // needs src_dim args
```

`dst_vars` has exactly one length, so `red_layout` and `dst_layout` must agree on
rank or one of the two calls fails the same assertion. On top of that,
`ICHECK_EQ(src_dim, dst_dim + 1)` rejects keep-dim outright (`2 vs. 3`), and
`src_vars.insert(begin() + op.dim, reduce_iv)` would push `src_vars` to rank
`n+1` because `dst_vars` already carries the dummy axis.

Note that `LowerLocal` (`src/backend/common/op/reduce.h:531`) already handles
keep-dim correctly for the `local` scope — it reads `op.dst->shape.size()` and
branches on `dst_dim == src_dim`. Only the `fragment` path was missing it, which
is why the bug is scope-specific.

## Changes

**`ComputeReducerLayout` — new `bool keepdim = false` parameter** (both copies:
`src/op/reduce.cc:134` and `src/backend/common/op/reduce.h:63`, which are
byte-for-byte duplicates apart from `static` vs `inline`)

- `reducer_shape`: `Set(dim, 1)` instead of `erase(dim)`, keeping the axis at
  extent 1 so `InputDim()` matches the destination rank.
- `fwd`: `InputPlaceholders(n)` + `Set(dim, FloorMod(rep, ...))` instead of
  `InputPlaceholders(n-1)` + `insert`. Non-keep-dim deliberately offsets
  placeholder *numbering* from *position*; keep-dim needs them aligned one-to-one,
  and the extent-1 dummy coordinate contributes nothing to the thread map, so
  overwriting it is correct.
- Replication handling (`reducer_rep_extent`, `CondenseReplicateVar`,
  `BindThreadRange`) is untouched: keep-dim and non-keep-dim describe the *same
  physical data* with the same thread mapping, differing only in how many logical
  coordinates they accept.
- Default argument keeps every existing caller behaviourally unchanged.
- Cross-referencing comments added to both copies so they do not drift apart.

**Stage 1** (`src/op/reduce.cc:235`)

- Derive `keepdim` from `dst->shape.size() == src_layout->InputDim()` **and**
  `is_one(dst->shape[this->dim])`. The destination buffer is **the only carrier**
  of this intent(keepdim) — `ReduceOpNode` has no keepdim field, and the function
  never read `dst->shape` before.
- Guard with `src_layout->InputDim() > 1`: a rank-1 source already degenerates to
  `[1]` via the `reducer_shape.empty()` fallback and would otherwise be
  misclassified.
- Add `ICHECK(is_one(dst->shape[this->dim]))` for same-rank destinations
  (`src/op/reduce.cc:226`), *before* the `keepdim` decision. A destination of the
  same rank as the source is only meaningful as a keep-dim reduction, so a
  non-unit reduced axis is a defect in the extent, and this reports it as one.
  Without it such a buffer would take `keepdim == false`, build a rank-`n-1`
  layout, and fail the rank check below with "reducer layout rank does not match
  the destination buffer rank" — a message that does not describe the actual
  problem. `tilelang/language/reduce_op.py:51-57` already rejects this shape at
  the frontend (`expected shapes are [64] or [64, 1]`), and every
  `_REDUCE_OP_KEY` construction site sits behind that check, so the new ICHECK is
  defensive: it keeps the C++ layer self-consistent without assuming that
  frontend guard survives future refactoring.
- Add `ICHECK_EQ(reducer_layout->InputDim(), dst->shape.size())` on the free
  binding path (`src/op/reduce.cc:242`), *before* the early return, so any future
  rank divergence fails here with a readable message instead of sliding into
  `layout.cc`. The pre-existing rank check at `:250` only covers the
  already-bound path.

**Stage 2** (`src/backend/common/op/reduce.h:807`)

- Same `keepdim` criterion — including the `is_one(op.dst->shape[op.dim])` extent
  check — so both stages cannot disagree. Stage 1 runs first and already
  diagnoses a same-rank destination with a non-unit reduced axis, so lowering
  never sees one.
- New keep-dim branch: `ICHECK_EQ(src_dim, dst_dim)` plus
  `ICHECK(is_one(dst_layout->InputShape()[op.dim]))`, replacing the
  unconditional `ICHECK_EQ(src_dim, dst_dim + 1)`.
- `src_vars`: `Set(op.dim, reduce_iv)` instead of `insert` under keep-dim.
  `src_vars` starts as a copy of `dst_vars`, which already holds the extent-1
  dummy at `op.dim`; replacing that slot keeps `src_vars` at source rank, while
  inserting would overshoot to `n+1`. This mirrors what `LowerLocal` already does.

**Deliberately unchanged**

- `src/layout/layout.cc:929` — a correct invariant guard. Relaxing it would turn a
  compile error into silent numerical corruption.
- `tilelang/language/reduce_op.py` — the frontend contract is right; the backend
  just had not honoured it.
- `LowerLocal` — already correct, and used as the reference for the fragment path.

## Tested

- `repro.py` from the issue: both the keep-dim `(64, 1)` case and the
  non-keep-dim `(64,)` control compile and match the torch reference.
- Extra variants, all matching torch: keep-dim on `dim=0`, `reduce_max` /
  `reduce_min` keep-dim, 3D `(32, 16, 64)` reducing the middle axis into
  `(32, 1, 64)`, plus non-keep-dim controls for each.
- New parametrized regression test `test_reduce_keepdim` in
  `testing/python/language/test_tilelang_language_reduce.py` — 8 cases covering
  sum/max/min, `dim=0` and `dim=1`, 2D and 3D, and both `clear=True` and
  `clear=False`. The accumulate (`clear=False`) path is the one that exercises
  `red_indices` against `clear_buffer` directly, so it is covered for sum, max and
  min. Each case asserts the output *shape* as well as the values, so a silent
  rank regression fails too.
- Frontend rejection of the invalid same-rank shape confirmed empirically: a
  `(64, 64)` source reduced along `dim=1` into a `(64, 64)` destination raises
  `ValueError: Invalid reduce output shape ... expected shapes are [64] or [64, 1]`
  before reaching the backend.
- `test_tilelang_language_reduce.py` re-run with `TILELANG_DISABLE_CACHE=1` after
  adding the extent check: 0 failed.
- Reduce suites plus `testing/python/layout` — `test_tilelang_language_reduce.py`,
  `test_tilelang_language_warp_reduce.py`,
  `test_tilelang_language_reduce_maxmin_nan.py`, `test_math_bitwise_reduce.py`,
  `layout/`: 0 failed.
- `testing/python/issue`: 0 failed.
- Both backends recompile clean: the shared header is included by
  `src/cuda/op/reduce.cc` and `src/rocm/op/reduce.cc`.

## Follow-up (not in this PR)

`ComputeReducerLayout` and its helper `InputPlaceholders` exist as identical
copies in `src/op/reduce.cc` and `src/backend/common/op/reduce.h`, in different
namespaces (`tvm::tl` vs `tvm::tl::backend::reduce`). Merging them would need
`src/op/reduce.cc` to depend on `src/backend/`, or a new shared header — a
layering change too broad for a bugfix. Both copies now carry comments pointing
at each other; a dedicated refactor PR could unify them if necessary.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added keep-dimension reducer layout inference and lowering for fragment reductions.
- Preserves reduced axes as extent-1 dimensions and validates destination rank/layout compatibility.
- Keeps existing non-keep-dimension behavior unchanged.
- Added coverage for sum, max, min, 2D/3D inputs, multiple dimensions, and clear/accumulate paths against PyTorch `keepdim=True` results.

## C++ style / lint notes

- The PR changes C++ reduction implementation and API declarations.
- Review `docs/developer_guide/cpp_style.md` and the warning-only “C++ API Style Audit” CI step for any advisory findings.
- No correctness or build issues are indicated; TLCPP003/TLCPP004 warnings should remain non-blocking unless they identify a concrete API or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->