### PR TITLE
[BugFix][CUDA] Fall back for non-MMA GEMM K shapes

### DIFF
--- a/src/cuda/op/gemm.cc
+++ b/src/cuda/op/gemm.cc
@@ -144,6 +144,19 @@ bool AllowTuringMma(const GemmNode &op) {
   return false;
 }
 
+bool AllowMmaKShape(const GemmNode &op) {
+  int element_bits = op.a_->dtype.bits();
+  if (element_bits <= 0 || element_bits > 64 || 256 % element_bits != 0) {
+    return false;
+  }
+
+  int atom_k = std::min(256 / element_bits, op.k_);
+  bool atom_k_supported = atom_k == 4 || atom_k == 8 || atom_k == 16 ||
+                          atom_k == 32 || atom_k == 64 || atom_k == 128 ||
+                          atom_k == 256;
+  return atom_k_supported && op.k_ % atom_k == 0;
+}
+
 void FatalWgmmaUnavailable(const GemmNode &op, Target target) {
   LOG(FATAL) << "T.wgmma_gemm() requires Hopper WGMMA lowering, but "
                 "constraints were not satisfied. Got target="
@@ -384,6 +397,9 @@ struct Gemm {
       return kCudaFMA;
     }
     if (TargetIsTuring(target) && !AllowTuringMma(op)) {
+      return kCudaFMA;
+    }
+    if (!AllowMmaKShape(op)) {
       return kCudaFMA;
     }
     return kCudaMMA;

--- a/src/layout/gemm_layouts.cc
+++ b/src/layout/gemm_layouts.cc
@@ -830,9 +830,10 @@ Layout MakeGemmABLayout(int mat_stride, int mat_continuous, int continuity,
     return MakeGemmABLayoutPadded(mat_stride, mat_continuous, element_size);
   }
   int vector_size = 128 / element_size;
-  if (!k_inner && element_size == 8) // int8 KxN
+  if ((!k_inner && element_size == 8) ||
+      (mat_stride != 4 && mat_stride % 8 != 0))
     return MakeGemmABLayoutPadded(mat_stride, mat_continuous, element_size);
-  else if (mat_continuous % (vector_size * 8) == 0)
+  if (mat_continuous % (vector_size * 8) == 0)
     return MakeFullBankSwizzleLayout2D(mat_stride, mat_continuous,
                                        element_size);
   else if (mat_continuous % (vector_size * 4) == 0)

--- a/testing/python/issue/test_tilelang_issue_gemm_non_mma_k_fallback.py
+++ b/testing/python/issue/test_tilelang_issue_gemm_non_mma_k_fallback.py
@@ -1,0 +1,44 @@
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+def _make_gemm(m, n, k):
+    @tilelang.jit
+    def gemm(
+        A: T.Tensor((m, k), T.float16),
+        B: T.Tensor((k, n), T.float16),
+        C: T.Tensor((m, n), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((m, k), T.float16)
+            B_shared = T.alloc_shared((k, n), T.float16)
+            C_local = T.alloc_fragment((m, n), T.float16)
+            T.copy(A, A_shared)
+            T.copy(B, B_shared)
+            T.clear(C_local)
+            T.gemm(A_shared, B_shared, C_local)
+            T.copy(C_local, C)
+
+    return gemm
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("k", [16, 20, 28])
+def test_gemm_falls_back_for_non_swizzle_stride(k):
+    m = n = 64
+    kernel = _make_gemm(m, n, k)
+
+    a = torch.randn(m, k, device="cuda", dtype=torch.float16)
+    b = torch.randn(k, n, device="cuda", dtype=torch.float16)
+    c = torch.empty(m, n, device="cuda", dtype=torch.float16)
+    kernel(a, b, c)
+
+    torch.testing.assert_close(c, a @ b, rtol=2e-2, atol=2e-2)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
Fixes #2715

## Summary

CUDA GEMM lowering selected the shared-memory layout and the MMA emitter independently. For K=20 and K=28, the swizzled layout fails its stride check; bypassing that check only moves the failure to the MMA atom divisibility check.

The layout and emitter now use the same MMA-shape check. Supported shapes keep the existing MMA path; other valid K extents use the padded shared-memory layout and the existing CUDA FMA emitter. Both choices are made in TileLang's GEMM lowering, so callers do not need to pad the mathematical K extent.

## Changes

- Add a shared GEMM-shape eligibility check before selecting tensor-core MMA.
- Route non-MMA K extents through the existing CUDA FMA emitter.
- Use the padded shared-memory layout when the bank-swizzle stride contract is not satisfied.
- Add numerical CUDA regressions for K=16, K=20, and K=28.

## Review Notes

- K=16 remains on the existing optimized path.
- K=20 and K=28 use the fallback path.
- The change does not pad or reinterpret the mathematical K extent.

## Validation

- `testing/python/issue/test_tilelang_issue_gemm_non_mma_k_fallback.py`: 3 passed on NVIDIA A100.
- `testing/python/issue/test_tilelang_issue_gemm_non_mma_k_fallback.py`: 3 passed on NVIDIA H100.
- Numerical output compared against PyTorch GEMM for all three K shapes.
- `clang-format` and `git diff --check` passed.
