### PR TITLE
[BugFix][Transform] Normalize vectorized loop domains

### DIFF
--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -176,6 +176,20 @@ bool ForBodyContainsSeqStmt(const For &loop) {
   return has_seq_stmt;
 }
 
+static For NormalizeLoopDomain(const For &loop) {
+  if (is_zero(loop->min) && loop->HasTrivialStep()) {
+    return loop;
+  }
+
+  Var normalized_var(loop->loop_var->name_hint, loop->loop_var.dtype());
+  PrimExpr step = loop->step.value_or(make_const(loop->loop_var.dtype(), 1));
+  Map<Var, PrimExpr> vmap;
+  vmap.Set(loop->loop_var, loop->min + normalized_var * step);
+  Stmt body = Substitute(loop->body, vmap);
+  return For(normalized_var, 0, loop->extent, loop->kind, body,
+             loop->thread_binding, loop->annotations, std::nullopt, loop->span);
+}
+
 class VectorizePlanner : public arith::IRMutatorWithAnalyzer {
 public:
   explicit VectorizePlanner(arith::Analyzer *analyzer,
@@ -185,12 +199,13 @@ public:
         reducer_info_map_(reducer_info_map) {}
 
   int Plan(const For &node) {
+    For normalized_node = NormalizeLoopDomain(node);
     bool disable_vectorize_256 = tl_config::Vectorize256Disabled();
     bool verbose = tl_config::VectorizePlannerVerboseEnabled();
 
     if (TargetSupportVectorize256(Target::Current(false)) &&
         !disable_vectorize_256 &&
-        VectorizeFindMemoryAccess::MaySupportVectorize256(node)) {
+        VectorizeFindMemoryAccess::MaySupportVectorize256(normalized_node)) {
       vector_load_bits_max_ = initial_vector_size_ = loop_extent_vector_size_ =
           256;
     } else {
@@ -203,11 +218,11 @@ public:
     // buffers the same as memory buffers. The special local buffer optimization
     // (ignoring local buffer constraints) only applies to simple single
     // BufferStore cases.
-    bool has_seq_stmt = ForBodyContainsSeqStmt(node);
+    bool has_seq_stmt = ForBodyContainsSeqStmt(normalized_node);
 
     // Clear previous buffer info and collect new ones
     buffer_vector_infos_.clear();
-    this->operator()(node);
+    this->operator()(normalized_node);
 
     // Compute final vector size from collected buffer infos
     // Strategy:
@@ -916,7 +931,7 @@ private:
     inner_for_ = node;
     auto ret = StmtExprMutator::VisitStmt_(node);
     if (inner_for_ == node) { // rewrite the innermost loop
-      For fnode = ret.as<For>().value();
+      For fnode = NormalizeLoopDomain(ret.as<For>().value());
       auto old_var = fnode->loop_var;
       auto extent_ptr = as_const_int(fnode->extent);
       ICHECK(extent_ptr) << fnode->extent;
@@ -924,7 +939,6 @@ private:
       ICHECK(extent % vector_size_ == 0)
           << "extent: " << extent << " vector_size_: " << vector_size_
           << " for loop: " << fnode;
-      ICHECK(is_zero(fnode->min));
       if (extent == vector_size_) {
         fnode.CopyOnWrite()->kind = ForKind::kVectorized;
         return fnode;

--- a/testing/python/issue/test_tilelang_issue_vectorized_nonzero_min.py
+++ b/testing/python/issue/test_tilelang_issue_vectorized_nonzero_min.py
@@ -1,0 +1,34 @@
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+@tilelang.jit
+def _nonzero_min_vectorized(
+    A: T.Tensor((8,), T.int32),
+    B: T.Tensor((8,), T.int32),
+):
+    with T.Kernel(1, threads=1):
+        for value in T.vectorized(2, 6):
+            B[value] = A[value] + 1
+
+
+@tilelang.testing.requires_cuda
+def test_vectorized_nonzero_min():
+    a = torch.arange(8, device="cuda", dtype=torch.int32)
+    b = torch.full((8,), -1, device="cuda", dtype=torch.int32)
+
+    _nonzero_min_vectorized(a, b)
+
+    expected = torch.tensor(
+        [-1, -1, 3, 4, 5, 6, -1, -1],
+        device="cuda",
+        dtype=torch.int32,
+    )
+    torch.testing.assert_close(b, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_legalize_vectorized_loop.py
+++ b/testing/python/transform/test_tilelang_transform_legalize_vectorized_loop.py
@@ -45,5 +45,29 @@ def test_vectorize_access():
     assert_vectorize_access(64, 64)
 
 
+def test_vectorized_nonzero_min_uses_aligned_vector_width():
+    @T.prim_func
+    def before(
+        A: T.Tensor((8,), T.int32),
+        B: T.Tensor((8,), T.int32),
+    ):
+        for value in T.vectorized(2, 6):
+            B[value] = A[value] + 1
+
+    @T.prim_func
+    def expected(
+        A: T.Tensor((8,), T.int32),
+        B: T.Tensor((8,), T.int32),
+    ):
+        for value_outer in T.serial(2):
+            for vec in T.vectorized(2):
+                B[2 + (value_outer * 2 + vec)] = A[2 + (value_outer * 2 + vec)] + 1
+
+    mod = tvm.IRModule.from_expr(before)
+    with tvm.target.Target("cuda"):
+        transformed = tl.transform.LegalizeVectorizedLoop()(mod)
+    tvm.ir.assert_structural_equal(transformed["before"].body, expected.body)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
Fixes #2669

## Summary

The vectorization planner assumed that every `T.vectorized` loop had a zero minimum. A loop such as `T.vectorized(2, 6)` reached legalization with `min=2` and tripped `ICHECK(is_zero(fnode->min))`. Planning from the unnormalized base could also select a width that was misaligned at the first real access.

Legalization now plans on a zero-based domain and keeps the original minimum and step when rewriting accesses. Nonzero bounds are valid frontend input, so the normalization is handled in the TileLang transform rather than imposed on kernel authors.

## Changes

- Normalize vectorized loop domains before vector-width planning.
- Carry the original loop minimum and step into access rewriting.
- Select widths using the actual base alignment after normalization.
- Add transform-level checks and an end-to-end CUDA regression for a nonzero loop minimum.

## Review Notes

- The loop still executes the original logical values `[2, 6)`.
- For the int32 regression, the real base alignment selects width 2 instead of an invalid width 4.
- Zero-min vectorized loops keep their existing behavior.

## Validation

- `testing/python/issue/test_tilelang_issue_vectorized_nonzero_min.py` passed on NVIDIA A100 and NVIDIA H100.
- `testing/python/transform/test_tilelang_transform_legalize_vectorized_loop.py` passed.
- Python compilation and `git diff --check` passed.
