### PR TITLE
[BugFix][Transform] Preserve nested cast-store guards

### DIFF
--- a/testing/python/issue/test_tilelang_issue_decouple_type_cast_nested_guards.py
+++ b/testing/python/issue/test_tilelang_issue_decouple_type_cast_nested_guards.py
@@ -1,0 +1,36 @@
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+@tilelang.jit
+def _nested_guard_cast_store(
+    A: T.Tensor((16,), T.float8_e4m3fn),
+    B: T.Tensor((16,), T.float8_e4m3fn),
+):
+    with T.Kernel(1, threads=32):
+        a_local = T.alloc_local((16,), T.float32)
+        T.copy(A, a_local)
+        for i in T.vectorized(16):
+            if i < 12:  # noqa: SIM102
+                if i < 8:
+                    B[i] = T.cast(a_local[i], T.float8_e4m3fn)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(9)
+def test_nested_guard_cast_store_preserves_unwritten_lanes():
+    a = (torch.arange(16, device="cuda", dtype=torch.float32) * 0.5).to(torch.float8_e4m3fn)
+    b = torch.full((16,), 7.0, device="cuda").to(torch.float8_e4m3fn)
+
+    _nested_guard_cast_store(a, b)
+
+    expected = torch.full((16,), 7.0, device="cuda", dtype=torch.float32)
+    expected[:8] = a[:8].to(torch.float32)
+    torch.testing.assert_close(b.to(torch.float32), expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_decouple_type_cast.py
+++ b/testing/python/transform/test_tilelang_transform_decouple_type_cast.py
@@ -244,6 +244,81 @@ def test_local_to_memory_with_branch_local_bind():
     _check(before, after)
 
 
+def test_local_to_memory_with_nested_guards():
+    """Nested guards must be conjoined on the generated copy-to loop."""
+
+    @T.prim_func
+    def before(b: T.Tensor[(16,), T.float8_e4m3fn]):
+        a_frag = T.alloc_local((16,), T.float32)
+        for i in T.vectorized(16):
+            if i < 12:  # noqa: SIM102
+                if i < 8:
+                    b[i] = a_frag[i]
+
+    @T.prim_func
+    def after(b: T.Tensor[(16,), T.float8_e4m3fn]):
+        a_frag = T.alloc_local((16,), T.float32)
+        with T.sblock("decoupled_cast"):
+            T.sblock_attr({"lexical_alloc_scope": 1})
+            T.reads()
+            T.writes()
+            b_local_cast = T.decl_buffer((16,), T.float8_e4m3fn, scope="local")
+            for i in T.vectorized(16):
+                if i < 12:  # noqa: SIM102
+                    if i < 8:
+                        b_local_cast[i] = T.cast(a_frag[i], T.float8_e4m3fn)
+            for i_copy in T.vectorized(16):
+                if i_copy < 12 and i_copy < 8:
+                    b[i_copy] = b_local_cast[i_copy]
+
+    _check(before, after)
+
+
+def test_memory_to_local_with_nested_guards():
+    """Nested guards must be conjoined on the generated copy-from loop."""
+
+    @T.prim_func
+    def before(b: T.Tensor[(16,), T.float8_e4m3fn]):
+        a_frag = T.alloc_local((16,), T.float32)
+        for i in T.vectorized(16):
+            if i < 12:  # noqa: SIM102
+                if i < 8:
+                    a_frag[i] = b[i]
+
+    @T.prim_func
+    def after(b: T.Tensor[(16,), T.float8_e4m3fn]):
+        a_frag = T.alloc_local((16,), T.float32)
+        with T.sblock("decoupled_cast"):
+            T.sblock_attr({"lexical_alloc_scope": 1})
+            T.reads()
+            T.writes()
+            b_local_cast = T.decl_buffer((16,), T.float8_e4m3fn, scope="local")
+            for i_copy in T.vectorized(16):
+                if i_copy < 12 and i_copy < 8:
+                    b_local_cast[i_copy] = b[i_copy]
+            for i in T.vectorized(16):
+                if i < 12:  # noqa: SIM102
+                    if i < 8:
+                        a_frag[i] = T.cast(b_local_cast[i], T.float32)
+
+    _check(before, after)
+
+
+def test_if_else_control_flow_skips_decoupling():
+    """Copy loops cannot represent branch-specific guards, so keep the source."""
+
+    @T.prim_func
+    def before(b: T.Tensor[(16,), T.float8_e4m3fn]):
+        a_frag = T.alloc_local((16,), T.float32)
+        for i in T.vectorized(16):
+            if i < 8:
+                b[i] = a_frag[i]
+            else:
+                a_frag[i] = 0.0
+
+    _check(before, before)
+
+
 def test_cast_buffers_wrapped_in_lexical_alloc_scope():
     """The pass must wrap cast buffers in a block annotated with
     lexical_alloc_scope, so StorageRewrite keeps them scoped to the use site."""

--- a/tilelang/transform/decouple_type_cast.py
+++ b/tilelang/transform/decouple_type_cast.py
@@ -288,15 +288,38 @@ def normalize_flat_binds(stmt: Stmt) -> Stmt:
     return normalized if normalized is not None else stmt
 
 
-def extract_if_condition(stmt: Stmt) -> tuple[tirx.PrimExpr | None, Stmt]:
-    """Extract IfThenElse condition from statement if present.
+def _contains_if_then_else(stmt: Stmt) -> bool:
+    """Return whether ``stmt`` contains statement-level control flow."""
+    found = False
 
-    Returns:
-        A tuple of (condition, inner_body). If no IfThenElse, returns (None, stmt).
+    def visitor(node) -> None:
+        nonlocal found
+        if isinstance(node, IfThenElse):
+            found = True
+
+    post_order_visit(stmt, visitor)
+    return found
+
+
+def extract_if_condition(stmt: Stmt) -> tuple[tirx.PrimExpr | None, Stmt] | None:
+    """Extract a complete guard when control flow has one predicate.
+
+    Root-level nested ``if`` statements without ``else`` can be represented by
+    conjoining their predicates. Any other statement-level control flow cannot
+    be faithfully applied to the generated copy loops, so callers must skip the
+    optimization.
     """
-    if isinstance(stmt, IfThenElse) and stmt.else_case is None:
-        return stmt.condition, stmt.then_case
-    return None, stmt
+    condition: tirx.PrimExpr | None = None
+    inner_body = stmt
+    while isinstance(inner_body, IfThenElse):
+        if inner_body.else_case is not None:
+            return None
+        condition = inner_body.condition if condition is None else tirx.And(condition, inner_body.condition)
+        inner_body = inner_body.then_case
+
+    if _contains_if_then_else(inner_body):
+        return None
+    return condition, inner_body
 
 
 # Cast entry: (original buffer, original indices, cast buffer)
@@ -397,6 +420,13 @@ class DecoupleTypeCastMutator(tirx.PyStmtExprMutator):
         if _contains_seq_stmt(normalized_body):
             return self._make_for(op, new_body) if new_body is not op.body else op
 
+        # Generated copy loops can preserve only a single common predicate.
+        # Skip control flow that cannot be represented without weakening it.
+        condition_info = extract_if_condition(normalized_body)
+        if condition_info is None:
+            return self._make_for(op, new_body) if new_body is not op.body else op
+        condition, _ = condition_info
+
         # Collect all shared/global stores and loads
         collector = MemoryAccessCollector(op.loop_var)
         collector.visit_stmt(normalized_body)
@@ -406,9 +436,6 @@ class DecoupleTypeCastMutator(tirx.PyStmtExprMutator):
             return self._make_for(op, new_body) if new_body is not op.body else op
 
         extent = op.extent.value
-
-        # Extract condition (from normalized body for correctness)
-        condition, _ = extract_if_condition(normalized_body)
 
         # Create cast entries for stores and loads
         store_entries = self._create_cast_entries(collector.stores, extent)


### PR DESCRIPTION
Fixes #2616

## Summary

`DecoupleTypeCast` moves cast stores into generated copy loops. When a source store was nested under several `if` statements, the transform kept only one guard. The generated copy could therefore overwrite lanes that the source program left untouched.

The pass now combines nested no-`else` guards. If the surrounding control flow cannot be represented by one predicate, including an `if/else`, it leaves that store undecoupled. The pass may move a conversion, but it must preserve which lanes are written; that check belongs in the TileLang transform rather than in individual kernels.

## Changes

- Collect and conjoin nested root-level `if` predicates around cast stores.
- Preserve the combined predicate on generated copy stores.
- Treat any unrepresentable statement control flow, including `if/else`, as ineligible for decoupling.
- Add nested-guard, branch-shape, and runtime sentinel regressions.

## Review Notes

- Nested no-`else` guards are combined with logical conjunction.
- Unsupported branch shapes take the original path rather than a partially predicated rewrite.
- The behavior is intentionally conservative; this PR does not attempt general control-flow cloning.

## Validation

- `testing/python/issue/test_tilelang_issue_decouple_type_cast_nested_guards.py` preserves sentinel values in unwritten FP8 lanes on H100.
- A100 runtime case is skipped by the existing compute-capability requirement for FP8.
- Relevant DecoupleTypeCast suite: 22 passed, 1 skipped.
- Python compilation and `git diff --check` passed.
