### PR TITLE
[Metal] Derive pointer address spaces from TIR types

### DIFF
--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -72,6 +72,21 @@ public:
   bool needs_fragment_lane_vars{false};
 };
 
+std::string MetalAddressSpaceForStorageScope(const std::string &scope) {
+  if (scope == "global") {
+    return "device";
+  }
+  if (scope == "shared" || scope == "shared.dyn" || scope == "threadgroup") {
+    return "threadgroup";
+  }
+  if (scope == "local" || scope == "local.var" || scope == "metal.simdgroup" ||
+      scope == "metal.cooperative_tensor") {
+    return "thread";
+  }
+  LOG(FATAL) << "Unknown Metal storage scope `" << scope << "`";
+  return "";
+}
+
 } // namespace
 
 void CodeGenTileLangMetal::InitFuncState(const PrimFunc &f) {
@@ -457,15 +472,43 @@ void CodeGenTileLangMetal::PrintVecElemStore(const std::string &vec, DataType t,
 
 void CodeGenTileLangMetal::PrintStorageScope(const std::string &scope,
                                              std::ostream &os) { // NOLINT(*)
-  if (scope == "global") {
-    os << "device ";
-  } else if (scope == "shared" || scope == "shared.dyn") {
-    os << "threadgroup ";
-  } else if (scope == "local" || scope == "local.var") {
-    os << "thread ";
-  } else {
-    LOG(FATAL) << "Unknown storage scope `" << scope << "`";
+  os << MetalAddressSpaceForStorageScope(scope) << " ";
+}
+
+void CodeGenTileLangMetal::VisitStmt_(const BindNode *op) {
+  if (!op->var.dtype().is_handle()) {
+    CodeGenC::VisitStmt_(op);
+    return;
   }
+
+  const auto *pointer_type = op->var->type_annotation.as<PointerTypeNode>();
+  TVM_FFI_ICHECK(pointer_type)
+      << "Metal handle binding requires a typed pointer: " << op->var;
+  const auto *element_type = pointer_type->element_type.as<PrimTypeNode>();
+  TVM_FFI_ICHECK(element_type)
+      << "Metal handle binding requires a primitive pointee type: " << op->var;
+
+  std::string storage_scope = pointer_type->storage_scope;
+  TVM_FFI_ICHECK(!storage_scope.empty())
+      << "Metal handle binding requires an explicit storage scope: " << op->var;
+
+  alloc_storage_scope_[op->var.get()] = storage_scope;
+  RegisterHandleType(op->var.get(), element_type->dtype);
+  std::string value = PrintExpr(op->value);
+
+  if (print_ssa_form_) {
+    TVM_FFI_ICHECK(!var_idmap_.count(op->var.get()));
+    var_idmap_[op->var.get()] = value;
+    return;
+  }
+
+  PrintIndent();
+  PrintStorageScope(storage_scope, stream);
+  PrintType(element_type->dtype, stream);
+  stream << "* " << AllocVarID(op->var.get()) << " = (";
+  PrintStorageScope(storage_scope, stream);
+  PrintType(element_type->dtype, stream);
+  stream << "*)" << value << ";\n";
 }
 
 void CodeGenTileLangMetal::VisitStmt_(const AttrStmtNode *op) {
@@ -868,74 +911,71 @@ void CodeGenTileLangMetal::VisitExpr_(const CastNode *op,
 }
 
 std::string
-CodeGenTileLangMetal::GetAddrSpaceOf(const PrimExpr &ptr_expr) const {
-  if (auto *call = ptr_expr.as<CallNode>()) {
-    if (call->op.same_as(builtin::address_of())) {
-      if (auto *load = call->args[0].as<BufferLoadNode>()) {
-        auto it = alloc_storage_scope_.find(load->buffer->data.get());
-        if (it != alloc_storage_scope_.end()) {
-          const std::string &scope = it->second;
-          if (scope == "shared" || scope == "shared.dyn") {
-            return "threadgroup";
-          }
-          if (scope == "local" || scope == "metal.cooperative_tensor") {
-            return "thread";
-          }
-          if (scope == "global") {
-            return "device";
-          }
-        }
-      }
-    }
-    for (const auto &arg : call->args) {
-      std::string result = GetAddrSpaceOf(arg);
-      if (!result.empty()) {
-        return result;
-      }
-    }
-  }
+CodeGenTileLangMetal::GetStorageScopeOf(const PrimExpr &ptr_expr) const {
   if (auto *var = ptr_expr.as<VarNode>()) {
     auto it = alloc_storage_scope_.find(var);
     if (it != alloc_storage_scope_.end()) {
-      const std::string &scope = it->second;
-      if (scope == "shared" || scope == "shared.dyn") {
-        return "threadgroup";
-      }
-      if (scope == "local" || scope == "metal.cooperative_tensor") {
-        return "thread";
-      }
-      if (scope == "global") {
-        return "device";
+      return it->second;
+    }
+    if (const auto *pointer_type = var->type_annotation.as<PointerTypeNode>()) {
+      if (!pointer_type->storage_scope.empty()) {
+        return pointer_type->storage_scope;
       }
     }
   }
-  return "thread";
+  if (auto *call = ptr_expr.as<CallNode>()) {
+    if (call->op.same_as(builtin::address_of())) {
+      TVM_FFI_ICHECK_EQ(call->args.size(), 1U);
+      if (auto *load = call->args[0].as<BufferLoadNode>()) {
+        return GetStorageScopeOf(load->buffer->data);
+      }
+    } else if (call->op.same_as(builtin::handle_add_byte_offset())) {
+      TVM_FFI_ICHECK_EQ(call->args.size(), 2U);
+      return GetStorageScopeOf(call->args[0]);
+    }
+  }
+  return "";
+}
+
+std::string
+CodeGenTileLangMetal::GetAddrSpaceOf(const PrimExpr &ptr_expr) const {
+  std::string storage_scope = GetStorageScopeOf(ptr_expr);
+  TVM_FFI_ICHECK(!storage_scope.empty())
+      << "Cannot determine Metal storage scope for pointer expression "
+      << ptr_expr;
+  return MetalAddressSpaceForStorageScope(storage_scope);
 }
 
 std::string
 CodeGenTileLangMetal::GetPointeeTypeOf(const PrimExpr &ptr_expr,
                                        const std::string &fallback) {
-  if (auto *call = ptr_expr.as<CallNode>()) {
-    if (call->op.same_as(builtin::address_of())) {
-      if (auto *load = call->args[0].as<BufferLoadNode>()) {
-        std::ostringstream os;
-        PrintType(load->buffer->dtype, os);
-        return os.str();
-      }
-    }
-    for (const auto &arg : call->args) {
-      std::string result = GetPointeeTypeOf(arg, "");
-      if (!result.empty()) {
-        return result;
-      }
-    }
-  }
   if (auto *var = ptr_expr.as<VarNode>()) {
     auto it = handle_data_type_.find(var);
     if (it != handle_data_type_.end()) {
       std::ostringstream os;
       PrintType(it->second, os);
       return os.str();
+    }
+    if (const auto *pointer_type = var->type_annotation.as<PointerTypeNode>()) {
+      if (const auto *element_type =
+              pointer_type->element_type.as<PrimTypeNode>()) {
+        std::ostringstream os;
+        PrintType(element_type->dtype, os);
+        return os.str();
+      }
+    }
+  }
+  if (auto *call = ptr_expr.as<CallNode>()) {
+    if (call->op.same_as(builtin::address_of())) {
+      TVM_FFI_ICHECK_EQ(call->args.size(), 1U);
+      if (auto *load = call->args[0].as<BufferLoadNode>()) {
+        std::ostringstream os;
+        PrintType(load->buffer->dtype, os);
+        return os.str();
+      }
+    } else if (call->op.same_as(builtin::handle_add_byte_offset())) {
+      TVM_FFI_ICHECK_EQ(call->args.size(), 2U);
+      return GetPointeeTypeOf(call->args[0], fallback);
     }
   }
   return fallback;
@@ -1642,11 +1682,9 @@ void CodeGenTileLangMetal::VisitExpr_(const CallNode *op,
     this->PrintExpr(op->args[0], os);
     os << "))";
   } else if (op->op.same_as(builtin::handle_add_byte_offset())) {
-    // Dynamic shared memory pointer arithmetic.
-    // Metal requires explicit address space qualifiers on all pointers.
-    // The base class emits ((void*)((char*)...)) which is invalid in MSL.
     TVM_FFI_ICHECK_EQ(op->args.size(), 2U);
-    os << "((threadgroup void*)((threadgroup char*)";
+    std::string addr_space = GetAddrSpaceOf(op->args[0]);
+    os << "((" << addr_space << " void*)((" << addr_space << " char*)";
     this->PrintExpr(op->args[0], os);
     os << " + ";
     this->PrintExpr(op->args[1], os);
@@ -1707,113 +1745,6 @@ ffi::Module BuildTileLangMetal(IRModule mod, Target target) {
     cg.AddFunction(kv.first, f);
 
     std::string fsource = cg.Finish();
-    // MSL requires explicit address space qualifiers on all pointers.
-    // The CUDA-oriented codegen emits void* for shared memory handles
-    // and pointer arithmetic casts, which is invalid in MSL. Fix them.
-    // 1) void* declarations for shared memory aliases
-    {
-      std::string from = "void* ";
-      std::string to = "threadgroup void* ";
-      for (size_t pos = 0;
-           (pos = fsource.find(from, pos)) != std::string::npos;) {
-        // Skip if already qualified (idempotent)
-        if (pos >= 12 && fsource.substr(pos - 12, 12) == "threadgroup ") {
-          pos += from.length();
-          continue;
-        }
-        fsource.replace(pos, from.length(), to);
-        pos += to.length();
-      }
-    }
-    // 2) void* casts in pointer arithmetic (handle_add_byte_offset)
-    {
-      std::string from = "((void*)((char*)";
-      std::string to = "((threadgroup void*)((threadgroup char*)";
-      for (size_t pos = 0;
-           (pos = fsource.find(from, pos)) != std::string::npos;) {
-        // Skip if already qualified
-        if (pos >= 2 && fsource.substr(pos - 2, 14) == "((threadgroup v") {
-          pos += from.length();
-          continue;
-        }
-        fsource.replace(pos, from.length(), to);
-        pos += to.length();
-      }
-    }
-    // 3) Pointer casts (TYPE*) on shared memory handles
-    {
-      std::string from = "((float2*)A_shared)";
-      std::string to = "((threadgroup float2*)A_shared)";
-      for (size_t pos = 0;
-           (pos = fsource.find(from, pos)) != std::string::npos;) {
-        if (pos >= 2 && fsource.substr(pos, 14) == "((threadgroup ") {
-          pos += from.length();
-          continue;
-        }
-        fsource.replace(pos, from.length(), to);
-        pos += to.length();
-      }
-    }
-    {
-      std::string from = "((float2*)B_shared)";
-      std::string to = "((threadgroup float2*)B_shared)";
-      for (size_t pos = 0;
-           (pos = fsource.find(from, pos)) != std::string::npos;) {
-        if (pos >= 2 && fsource.substr(pos, 14) == "((threadgroup ") {
-          pos += from.length();
-          continue;
-        }
-        fsource.replace(pos, from.length(), to);
-        pos += to.length();
-      }
-    }
-    // 4) Generalize: any ((TYPE*)_shared) pattern
-    {
-      size_t pos = 0;
-      while ((pos = fsource.find("*)_shared", pos)) != std::string::npos) {
-        size_t open = fsource.rfind("((", pos);
-        if (open != std::string::npos) {
-          // Skip if already has threadgroup qualifier
-          if (fsource.substr(open, 14) != "((threadgroup ") {
-            fsource.insert(open + 2, "threadgroup ");
-          }
-          pos = open + 2 + 12;
-        } else {
-          pos += 1;
-        }
-      }
-    }
-    // 5) Line-level: any line containing _shared → fix ALL pointer casts.
-    //    After passes 1-4, some casts still lack threadgroup because _shared
-    //    is nested inside the expression. This pass finds any (TYPE*) on a
-    //    _shared line and inserts the threadgroup qualifier if missing.
-    {
-      std::istringstream iss(fsource);
-      std::ostringstream oss;
-      std::string line;
-      while (std::getline(iss, line)) {
-        if (line.find("_shared") != std::string::npos) {
-          for (size_t i = 0; i + 3 < line.length(); i++) {
-            if (line[i] == '(') {
-              if (line.substr(i, 14) == "(threadgroup ") {
-                i += 13;
-                continue;
-              }
-              size_t j = i + 1;
-              while (j < line.length() && (isalnum(line[j]) || line[j] == '_'))
-                j++;
-              if (j < line.length() && line[j] == '*' &&
-                  j + 1 < line.length() && line[j + 1] == ')') {
-                line.insert(i + 1, "threadgroup ");
-                i += 12;
-              }
-            }
-          }
-        }
-        oss << line << "\n";
-      }
-      fsource = oss.str();
-    }
     source_maker << fsource << "\n";
     if (fmetal_postproc) {
       fsource = (*fmetal_postproc)(fsource, target).cast<std::string>();

--- a/src/metal/codegen/codegen_metal.h
+++ b/src/metal/codegen/codegen_metal.h
@@ -58,6 +58,7 @@ public:
   void PrintVecElemStore(const std::string &vec, DataType t, int i,
                          const std::string &value) final;
   // overload visitor
+  void VisitStmt_(const BindNode *op) final;                        // NOLINT(*)
   void VisitStmt_(const AllocBufferNode *op) final;                 // NOLINT(*)
   void VisitStmt_(const AttrStmtNode *op) final;                    // NOLINT(*)
   void VisitStmt_(const ForNode *op) final;                         // NOLINT(*)
@@ -72,6 +73,7 @@ public:
   using CodeGenC::PrintType;
 
 private:
+  std::string GetStorageScopeOf(const PrimExpr &ptr_expr) const;
   std::string GetAddrSpaceOf(const PrimExpr &ptr_expr) const;
   std::string GetPointeeTypeOf(const PrimExpr &ptr_expr,
                                const std::string &fallback);

--- a/testing/python/metal/test_metal_address_space.py
+++ b/testing/python/metal/test_metal_address_space.py
@@ -1,5 +1,7 @@
 """Regression tests for type-driven Metal pointer address spaces."""
 
+import re
+
 import pytest
 import torch
 
@@ -54,18 +56,21 @@ def lower_to_metal(enable_device_compile: bool) -> str:
     return artifact.kernel_source or ""
 
 
-def test_shared_alias_address_spaces_are_type_driven(monkeypatch):
+def test_both_metal_build_paths_use_type_driven_shared_aliases(monkeypatch):
+    # Keep this source comparison independent of an available Metal runtime.
     monkeypatch.setenv("TVM_COMPILE_FORCE_FALLBACK", "1")
     compiled_source = lower_to_metal(enable_device_compile=True)
     source_only = lower_to_metal(enable_device_compile=False)
 
     assert compiled_source == source_only
-    assert "threadgroup half* As = (threadgroup half*)" in compiled_source
-    assert "threadgroup half* Bs = (threadgroup half*)" in compiled_source
-    assert "*(threadgroup half2*)(As +" in compiled_source
-    assert "*(threadgroup half2*)(Bs +" in compiled_source
-    assert "(half*)As" not in compiled_source
-    assert "(half*)Bs" not in compiled_source
+    aliases = re.findall(
+        r"threadgroup half\* (\w+) = \(threadgroup half\*\)",
+        compiled_source,
+    )
+    assert len(aliases) >= 2, compiled_source
+    for alias in aliases:
+        assert f"*(threadgroup half2*)({alias} +" in compiled_source
+        assert f"(half*){alias}" not in compiled_source
 
 
 @tilelang.testing.requires_metal

--- a/testing/python/metal/test_metal_address_space.py
+++ b/testing/python/metal/test_metal_address_space.py
@@ -1,0 +1,92 @@
+"""Regression tests for type-driven Metal pointer address spaces."""
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+
+
+M = N = K = 128
+BLOCK_M = BLOCK_N = 16
+BLOCK_K = 8
+THREADS = 64
+
+
+def shared_alias_gemm():
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((M, K), T.float16),
+        B: T.Tensor((K, N), T.float16),
+        C: T.Tensor((M, N), T.float32),
+    ):
+        with T.Kernel(
+            T.ceildiv(N, BLOCK_N),
+            T.ceildiv(M, BLOCK_M),
+            threads=THREADS,
+        ) as (bx, by):
+            As = T.alloc_shared((BLOCK_M, BLOCK_K), T.float16)
+            Bs = T.alloc_shared((BLOCK_K, BLOCK_N), T.float16)
+            Cl = T.alloc_shared((BLOCK_M, BLOCK_N), T.float32)
+
+            T.clear(Cl)
+            for k in T.serial(T.ceildiv(K, BLOCK_K)):
+                T.copy(A[by * BLOCK_M, k * BLOCK_K], As)
+                T.copy(B[k * BLOCK_K, bx * BLOCK_N], Bs)
+                T.gemm(As, Bs, Cl)
+            T.copy(Cl, C[by * BLOCK_M, bx * BLOCK_N])
+
+    return kernel
+
+
+def lower_to_metal(enable_device_compile: bool) -> str:
+    target = tvm.target.Target("metal", tvm.target.Target("llvm"))
+    with target:
+        artifact = tilelang.lower(
+            shared_alias_gemm(),
+            target=target,
+            target_host="llvm",
+            enable_host_codegen=False,
+            enable_device_compile=enable_device_compile,
+        )
+    return artifact.kernel_source or ""
+
+
+def test_shared_alias_address_spaces_are_type_driven(monkeypatch):
+    monkeypatch.setenv("TVM_COMPILE_FORCE_FALLBACK", "1")
+    compiled_source = lower_to_metal(enable_device_compile=True)
+    source_only = lower_to_metal(enable_device_compile=False)
+
+    assert compiled_source == source_only
+    assert "threadgroup half* As = (threadgroup half*)" in compiled_source
+    assert "threadgroup half* Bs = (threadgroup half*)" in compiled_source
+    assert "*(threadgroup half2*)(As +" in compiled_source
+    assert "*(threadgroup half2*)(Bs +" in compiled_source
+    assert "(half*)As" not in compiled_source
+    assert "(half*)Bs" not in compiled_source
+
+
+@tilelang.testing.requires_metal
+@pytest.mark.parametrize("execution_backend", ["tvm_ffi", "torch"])
+def test_shared_alias_address_spaces_execute_on_metal(execution_backend):
+    kernel = tilelang.compile(
+        shared_alias_gemm(),
+        target="metal",
+        execution_backend=execution_backend,
+    )
+
+    a = torch.randn(M, K, dtype=torch.float16, device="mps")
+    b = torch.randn(K, N, dtype=torch.float16, device="mps")
+    c = torch.zeros(M, N, dtype=torch.float32, device="mps")
+
+    kernel(a, b, c)
+    torch.mps.synchronize()
+
+    expected = a.float() @ b.float()
+    assert torch.allclose(c, expected, atol=1e-2, rtol=1e-2)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Problem

Metal requires every pointer type to carry an explicit address-space qualifier. On an Apple M2, a regular FP16 GEMM using dynamic shared-memory aliases named `As` and `Bs` failed during MSL compilation with errors such as:

```text
error: pointer type must have explicit address space qualifier
*(half2*)(((half*)As) + ...)
simdgroup_load(..., (&(((half*)As)[...])), ...)
```

The existing source-rewrite passes handled a few hard-coded names and then scanned lines containing `_shared`. Therefore, correctness depended on variable names: `A_shared` could compile while an equivalent alias named `As` did not. The compiled and source-only Metal build entry points also exercised different rewrite logic.

This failure occurs in the Metal 3 simdgroup path and is independent of Metal 4 cooperative tensors. The invalid pointer types are rejected during MSL compilation, before GPU execution, so the issue can affect any Metal device that reaches this lowering path; the M2 is the hardware used to reproduce and validate it.

## Root-cause trace

This was reproduced and traced from a clean `main` at commit `e01c498b6499367e0a1cd64413e008d223a931b6`.

1. `T.alloc_shared` buffers are merged by `MergeSharedMemoryAllocations::MakeAliasBindings()` in `src/transform/merge_shared_memory_allocations.cc`.
2. That pass creates `tirx::Bind(buffer_var, handle_add_byte_offset(merged_buffer, offset))`. The alias variable still has a typed `PointerType`, including its element dtype and `shared.dyn` storage scope.
3. Generic `CodeGenC::VisitStmt_(const BindNode*)` did not register that type information in `handle_data_type_` or `alloc_storage_scope_`.
4. Metal codegen consequently emitted unqualified alias declarations and pointer casts. Five string post-processing passes in `BuildTileLangMetal` attempted to repair the generated MSL, but some depended on names such as `A_shared`, `B_shared`, or the `_shared` suffix.

The loss therefore happened at the TIR-to-MSL `BindNode` codegen boundary, not in the shared-memory merge pass and not in Metal runtime compilation.

## Fix

- Add a Metal-specific `BindNode` visitor that reads the alias `PointerType`, registers its pointee dtype and storage scope, and emits a typed, address-space-qualified declaration.
- Map TIR storage scopes to MSL address spaces in one place:
  - `global` -> `device`
  - `shared`, `shared.dyn`, `threadgroup` -> `threadgroup`
  - `local`, `local.var`, and Metal register scopes -> `thread`
- Derive `handle_add_byte_offset` address spaces from the pointer operand instead of hard-coding `threadgroup`.
- Trace pointer provenance only through `address_of(BufferLoad)` and the base operand of `handle_add_byte_offset`; reject unknown scopes instead of silently defaulting to `thread`.
- Remove all five name-based MSL source-rewrite passes. Both Metal build entry points now receive the same correct output directly from `CodeGenTileLangMetal`, while their existing callback behavior remains unchanged.

The failing aliases now generate:

```metal
threadgroup half* As = (threadgroup half*)...;
*(threadgroup half2*)(As + ...) = ...;
```

## Tests

Run on a MacBook Air with Apple M2, macOS 15.6.1, and Metal 3:

```text
ninja -C build -j4 tilelang
TILELANG_CACHE_DIR=... TILELANG_TMP_DIR=... python -m pytest testing/python/metal/test_metal_address_space.py -q -ra
# 3 passed (source-only + compiled codegen, tvm_ffi execution, torch execution)

TILELANG_CACHE_DIR=... TILELANG_TMP_DIR=... python -m pytest testing/python/metal -q -ra
# 36 passed, 3 skipped
# The skipped tests are guarded by TileLang's current Metal 4 detector,
# which requires macOS 26, SDK 26, and an M5-or-newer chip.

pre-commit run --all-files
# All hooks passed.
```

The skip condition above reflects TileLang's current capability detector, not Apple's published hardware boundary. Apple's May 2026 [Metal Feature Set Tables](https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf) list the Metal 4 programming model and tensors starting with Apple7 (the M1 generation). Metal 4 capability detection is separate from this Metal 3 codegen fix and is intentionally unchanged in this PR.

## Potentially affected hardware

This defect is in TIR-to-MSL source generation rather than GPU execution. Within TileLang's current macOS/arm64 deployment scope, any Apple silicon Mac generation from M1 through M5 can potentially hit it when a kernel uses merged dynamic shared-memory aliases and reaches the affected pointer-cast path. This does not mean every Metal kernel fails: the previous name-based rewrites masked many aliases containing `_shared`.

Only the M2/Metal 3 configuration has been validated on hardware in this PR. The M1, M3, M4, and M5 impact is inferred from the generation-independent MSL address-space rule and the shared TileLang codegen path, not from direct testing on each chip. iOS and iPadOS targets are not claimed here because TileLang's current availability detector only enables the backend on arm64 macOS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Derive Metal pointer address spaces from TIR types and storage scopes.
- Add `BindNode` handling for typed pointer bindings.
- Support `threadgroup`, `metal.simdgroup`, and `metal.cooperative_tensor` scopes.
- Infer address spaces for pointer expressions and `handle_add_byte_offset`.
- Reject unknown or unresolved storage scopes.
- Remove five name-based MSL rewrite passes.
- Add regression tests for dynamic shared-memory aliases through TVM FFI and Torch backends.
- Verify identical compiled and source-only Metal output.
- Tests passed on Apple M2: 36 Metal tests passed, with 3 skips for unsupported Metal 4 cooperative tensors.
- All pre-commit hooks passed.

## C++ style / lint notes

- The PR changes C++ code but does not change documented rules in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit remains warning-only. No correctness or build issue is reported.
- No new public API, FFI risk, or maintainability risk requires blocking merge for advisory TLCPP003/TLCPP004 findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->