### PR TITLE
[CUDA][Reduce] Restore exact thread image counting

### DIFF
--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -10,6 +10,7 @@
 #include "op/reduce.h"
 #include "support/check.h"
 #include <tvm/ir/cast.h>
+#include <tvm/ir/with_context.h>
 #include <tvm/runtime/logging.h>
 
 #include "layout/layout.h"
@@ -78,11 +79,13 @@ inline Fragment ComputeReducerLayout(const Fragment &src_layout, int dim) {
 }
 
 /*!
- * \brief Resolve the participating thread range of a scalar AllReduce.
+ * \brief Resolve the exact contiguous thread image of a scalar AllReduce.
  *
  * The result is derived from the reduce layout's forward thread map, which is
- * also the source of the guard later emitted by PartitionLoop. Const-int bounds
- * provide the minimum and maximum participating thread IDs.
+ * also the source of the guard later emitted by PartitionLoop. Z3 counts the
+ * distinct thread IDs in the image while const-int bounds provide its minimum
+ * and maximum; equality between the count and span proves that the image is
+ * contiguous.
  */
 inline Range ResolveAllReduceThreadRange(const Fragment &red_layout,
                                          const Range &thread_bounds,
@@ -127,11 +130,35 @@ inline Range ResolveAllReduceThreadRange(const Fragment &red_layout,
                   "participating thread range.";
   }
 
+  Var thread_var("allreduce_thread", thread_expr.dtype());
+  analyzer.Bind(thread_var, thread_bounds);
+  // Model enumeration performs one solver check per participating thread. The
+  // prover's default 10k rlimit is too small for otherwise simple CTA images.
+  analyzer.z3_prover.SetRLimit(1'000'000);
+  int64_t count;
+  {
+    With<arith::ConstraintContext> image_constraint(&analyzer,
+                                                    thread_var == thread_expr);
+    count = analyzer.z3_prover.CountSatisfyingValues(thread_var, *block_extent);
+  }
+
   const int64_t base = bound->min_value;
   const int64_t end = bound->max_value;
-  // TODO: Consider restoring CountSatisfyingValues when the Z3 prover is
-  // stable enough to reliably compute the exact participating thread image.
-  const int64_t count = end - base + 1;
+  const int64_t span = end - base + 1;
+  if (count < 0) {
+    LOG(WARNING) << "tl.reduce: Z3 returned unknown while counting scalar "
+                    "AllReduce participating threads; falling back to the "
+                    "bounding range ["
+                 << base << ", " << end << "].";
+    count = span;
+  }
+  ICHECK_GT(count, 0)
+      << "tl.reduce: scalar AllReduce participating thread constraints are "
+         "unsatisfiable";
+  ICHECK_EQ(count, span)
+      << "tl.reduce: partial scalar AllReduce requires one contiguous thread "
+         "range, but got "
+      << count << " distinct threads spanning [" << base << ", " << end << "]";
   ICHECK_GE(base, *block_min)
       << "tl.reduce: scalar AllReduce participating thread range starts "
          "before the CTA thread bounds";


### PR DESCRIPTION
First see & merge https://github.com/tile-ai/tvm/pull/61 .

Created safe fallback for counting threads in `src/backend/common/op/reduce.h` when determinating named barrier count.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Restores exact CUDA thread-image counting for reduction named barriers.
- Uses Z3 to count distinct participating thread IDs.
- Falls back to the bounding span when Z3 returns `unknown`.
- Rejects unsatisfiable or non-contiguous thread images.
- Updates the `3rdparty/tvm` submodule. Merge `tile-ai/tvm#61` first.

## C++ style / lint notes

- The PR changes C++ code in `src/backend/common/op/reduce.h`.
- It does not change the rules documented in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step is not affected.
- The changes introduce no known correctness, build, or test issues. Advisory style warnings remain non-blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->