### PR TITLE
[CUDA] Pack logical TMEM buffers into shared `tcgen05.alloc` arenas

### DIFF
--- a/src/cuda/transform/lower_shared_tmem.cc
+++ b/src/cuda/transform/lower_shared_tmem.cc
@@ -2,11 +2,17 @@
  *  \file lower_shared_tmem.cc
  *  \brief Convert shared.tmem buffers to plain shared + ptx init, and do
  *         coordinate translation (from logical address to physical address)
+ *
+ *  Logical buffers are not one-to-one with tcgen05.alloc calls: PlanTmemArenas
+ *  packs several into one allocation when that saves columns, and shifts every
+ *  address a packed buffer forms by where it starts in the allocation.
  */
 #include "cuda/target_utils.h"
 #include "op/builtin.h"
 #include "support/check.h"
 #include "tvm/ir/type.h"
+#include <algorithm>
+#include <string>
 #include <tvm/arith/analyzer.h>
 #include <tvm/ir/cast.h>
 #include <tvm/tirx/analysis.h>
@@ -17,6 +23,8 @@
 #include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/transform.h>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 namespace tvm {
 namespace tl {
@@ -97,6 +105,175 @@ static std::pair<VarSet, bool> CollectFallthroughDeallocs(const Stmt &stmt) {
   return {{}, true};
 }
 
+/*!
+ * \brief Collect every TMEM buffer named by a tl.deallocate_tmem call.
+ *
+ * Unlike CollectFallthroughDeallocs this ignores control flow: a buffer whose
+ * lifetime the kernel manages by hand -- even on a path that ends in
+ * thread_return() -- must own its physical allocation outright, because
+ * releasing it would release whatever is packed alongside it.
+ */
+static VarSet CollectExplicitDeallocs(const Stmt &stmt) {
+  VarSet deallocs;
+  PostOrderVisit(stmt, [&](const ObjectRef &node) {
+    const auto *call = node.as<CallNode>();
+    if (call == nullptr || !call->op.same_as(tl::deallocate_tmem()))
+      return;
+    ICHECK_EQ(call->args.size(), 1U);
+    const auto *buffer_data = call->args[0].as<VarNode>();
+    ICHECK(buffer_data) << "tl.deallocate_tmem expects a buffer data Var";
+    deallocs.insert(GetRef<Var>(buffer_data));
+  });
+  return deallocs;
+}
+
+// A CTA's tensor memory is 128 datapaths (rows) of 512 32-bit columns.
+static constexpr int kTmemNumDatapaths = 128;
+static constexpr int kTmemNumColumns = 512;
+// tcgen05.alloc hands out columns in powers of two, 32 at a minimum.
+static constexpr int kTmemMinAllocColumns = 32;
+// tcgen05.cp.32x128b.warpx4 writes four b32 columns per instruction, which is
+// also the granularity tcgen05.mma.blockscaled reads its scale factors at.
+static constexpr int kTmemScaleFactorAlignment = 4;
+
+/*! \brief Round a column count up to a count tcgen05.alloc accepts. */
+static int TmemAllocationSize(int num_cols) {
+  int num_cols_allocated = kTmemMinAllocColumns;
+  for (; num_cols_allocated < num_cols; num_cols_allocated *= 2) {
+  }
+  return num_cols_allocated;
+}
+
+/*!
+ * \brief The column boundary a logical buffer may start on inside an arena.
+ *
+ * A buffer at least kTmemMinAllocColumns wide keeps the 32-column alignment
+ * tcgen05.alloc would have given it on its own, so sharing an allocation can
+ * never leave an accumulator -- or a TMEM-resident A operand -- less aligned
+ * than it is when allocated alone.  Narrower buffers are block-scale factors,
+ * written by tcgen05.cp.32x128b.warpx4 and read by tcgen05.mma.blockscaled;
+ * four columns is that instruction pair's granularity, and the boundary CUTLASS
+ * (cutlass::detail::find_tmem_tensor_col_offset) and DeepGEMM place the very
+ * same operands on.
+ */
+static int TmemSubAllocationAlignment(int num_cols) {
+  return num_cols >= kTmemMinAllocColumns ? kTmemMinAllocColumns
+                                          : kTmemScaleFactorAlignment;
+}
+
+/*! \brief Where one logical TMEM buffer sits inside a physical allocation. */
+struct TmemPlacement {
+  int arena_index = -1;
+  /*! \brief b32 columns from the allocation's base address to this buffer. */
+  int col_offset = 0;
+};
+
+/*! \brief One tcgen05.alloc, shared by one or more logical TMEM buffers. */
+struct TmemArena {
+  /*! \brief Indices of the logical buffers placed here, in placement order. */
+  std::vector<int> members;
+  /*! \brief Columns handed out so far, including alignment padding. */
+  int num_cols_used = 0;
+  /*! \brief Columns requested from tcgen05.alloc: a power of two, >= 32. */
+  int num_cols_allocated = 0;
+  /*!
+   * \brief Whether more buffers may join this allocation.
+   *
+   * Closed for a buffer with an explicit tl.deallocate_tmem, whose lifetime
+   * ends before the block does.
+   */
+  bool open = true;
+};
+
+/*!
+ * \brief Pack logical TMEM buffers into as few tcgen05.alloc calls as possible.
+ *
+ * Rounding each buffer up to a power of two on its own wastes whole columns: a
+ * 384-column accumulator next to three 4-column scale-factor buffers needs 396
+ * columns, but as four allocations asks for 512 + 32 + 32 + 32 = 608 of the 512
+ * a CTA has, so the kernel cannot be expressed at all.  CUTLASS and DeepGEMM
+ * share one allocation between these very operands by hand.
+ *
+ * Strategy: widest buffer first, each joining an existing arena only when that
+ * *strictly* lowers the total column count and otherwise opening its own.  Two
+ * properties follow:
+ *
+ *  - a placement costs at most the buffer's standalone allocation, so packing
+ *    can never grow a kernel's TMEM footprint;
+ *  - a kernel whose buffers already fit lowers exactly as it did before.
+ *
+ * Widest-first also keeps wide buffers on 32-column boundaries and lets narrow
+ * ones fill padding the power-of-two rounding has already paid for.
+ *
+ * TODO: this assumes every packable buffer is live for the whole block, and
+ * excludes a buffer with an explicit tl.deallocate_tmem instead of modelling
+ * its lifetime.  A liveness analysis would let buffers whose live ranges are
+ * disjoint reuse the same columns outright, rather than only fill each other's
+ * power-of-two padding, and would let a hand-released buffer pass its columns
+ * on to one that starts later.
+ *
+ * \param num_cols b32 columns each logical buffer needs.
+ * \param packable Whether a buffer may share an allocation, see
+ * TmemArena::open.
+ * \return The arenas, plus one placement per logical buffer.
+ */
+static std::pair<std::vector<TmemArena>, std::vector<TmemPlacement>>
+PlanTmemArenas(const std::vector<int> &num_cols,
+               const std::vector<bool> &packable) {
+  ICHECK_EQ(num_cols.size(), packable.size());
+
+  std::vector<int> order(num_cols.size());
+  for (size_t i = 0; i < order.size(); ++i) {
+    order[i] = static_cast<int>(i);
+  }
+  // Stable, so equally wide buffers keep their declaration order: the plan must
+  // not depend on sort or hash implementation details.
+  std::stable_sort(order.begin(), order.end(), [&](int lhs, int rhs) {
+    return num_cols[lhs] > num_cols[rhs];
+  });
+
+  std::vector<TmemArena> arenas;
+  std::vector<TmemPlacement> placements(num_cols.size());
+
+  for (int i : order) {
+    int alignment = TmemSubAllocationAlignment(num_cols[i]);
+    int best_arena = -1;
+    int best_offset = 0;
+    // A fresh allocation is the baseline an existing arena has to beat.
+    int best_delta = TmemAllocationSize(num_cols[i]);
+    if (packable[i]) {
+      for (size_t a = 0; a < arenas.size(); ++a) {
+        if (!arenas[a].open)
+          continue;
+        int offset =
+            (arenas[a].num_cols_used + alignment - 1) / alignment * alignment;
+        if (offset + num_cols[i] > kTmemNumColumns)
+          continue;
+        int delta = TmemAllocationSize(offset + num_cols[i]) -
+                    arenas[a].num_cols_allocated;
+        if (delta < best_delta) {
+          best_delta = delta;
+          best_arena = static_cast<int>(a);
+          best_offset = offset;
+        }
+      }
+    }
+    if (best_arena < 0) {
+      TmemArena arena;
+      arena.open = packable[i];
+      arenas.push_back(arena);
+      best_arena = static_cast<int>(arenas.size()) - 1;
+      best_offset = 0;
+    }
+    TmemArena &arena = arenas[best_arena];
+    arena.members.push_back(i);
+    arena.num_cols_used = best_offset + num_cols[i];
+    arena.num_cols_allocated = TmemAllocationSize(arena.num_cols_used);
+    placements[i] = TmemPlacement{best_arena, best_offset};
+  }
+  return {std::move(arenas), std::move(placements)};
+}
+
 class SharedTmemRewriter : public StmtExprMutator {
 public:
   static Stmt Rewrite(Stmt body, Target target) {
@@ -127,34 +304,47 @@ private:
     return analyzer.Simplify(FloorDiv(bit_offset, bits_per_column));
   }
 
-  int GetNumColsAllocated(const Buffer &buffer) const {
-    // LowerTileOp has already materialized the buffer's inferred layout, so
-    // the buffer shape is the physical (datapath, value-column) footprint.
+  /*!
+   * \brief The number of 32-bit TMEM columns a buffer occupies.
+   *
+   * LowerTileOp has already materialized the buffer's inferred layout, so the
+   * buffer shape is the physical (datapath, value-column) footprint.  This is
+   * what a buffer *needs*; PlanTmemArenas decides how many columns are actually
+   * allocated for it, alone or shared.
+   */
+  int GetNumB32ColsRequired(const Buffer &buffer) const {
     ICHECK_EQ(buffer->shape.size(), 2U);
 
-    auto analyzer = std::make_shared<arith::Analyzer>();
-    arith::ConstIntBound phy_col_bounds =
-        analyzer->const_int_bound(buffer->shape[1]);
-    int num_value_cols_required = phy_col_bounds->max_value;
+    arith::Analyzer analyzer;
+    int num_rows_required =
+        analyzer.const_int_bound(buffer->shape[0])->max_value;
+    ICHECK(num_rows_required <= kTmemNumDatapaths)
+        << "The number of rows required for tmem buffer " << buffer->name
+        << " is " << num_rows_required << ", which exceeds the maximum of "
+        << kTmemNumDatapaths << " rows";
+
+    int num_value_cols_required =
+        analyzer.const_int_bound(buffer->shape[1])->max_value;
     // Layout column coordinates count values of buffer->dtype; PTX TMEM
     // allocation counts 32-bit columns.  Round up so a final partially
     // occupied b32 column is included.
     int num_cols_required =
         (num_value_cols_required * GetValueBitWidth(buffer->dtype) + 31) / 32;
-    ICHECK(num_cols_required <= 512)
+    ICHECK(num_cols_required <= kTmemNumColumns)
         << "The number of columns required for tmem buffer " << buffer->name
-        << " is " << num_cols_required
-        << ", which exceeds the maximum of 512 columns";
+        << " is " << num_cols_required << ", which exceeds the maximum of "
+        << kTmemNumColumns << " columns";
+    return num_cols_required;
+  }
 
-    int num_cols_allocated = 32; // Align num_cols_allocated to power of 2
-    for (; num_cols_allocated < num_cols_required; num_cols_allocated *= 2) {
-    }
-    return num_cols_allocated;
+  /*! \brief The b32 column offset of a TMEM buffer inside its arena. */
+  int GetArenaColOffset(const Var &buffer_data) const {
+    auto it = tmem_col_offsets_.find(buffer_data);
+    return it == tmem_col_offsets_.end() ? 0 : it->second;
   }
 
   Stmt VisitStmt_(const SBlockNode *op) final {
     SBlock block = GetRef<SBlock>(op);
-    Array<Buffer> alloc_buffers = op->alloc_buffers;
     if (op->annotations.count(attr::kLayoutMap)) {
       auto layout_map = op->annotations.Get(attr::kLayoutMap);
       ICHECK(layout_map) << "layout map is not defined";
@@ -162,24 +352,33 @@ private:
     }
 
     // Record the mapping from buffer data var to buffer for later lookup
-    for (auto buffer : alloc_buffers) {
+    for (auto buffer : op->alloc_buffers) {
       buffer_map_.insert({buffer->data, buffer});
     }
     for (auto match_buffer : op->match_buffers) {
       buffer_map_.insert({match_buffer->buffer->data, match_buffer->buffer});
     }
 
+    // The TMEM buffers this block introduces, in declaration order.  Arena
+    // column offsets follow this order, so it must not come from a hash table.
     Array<Buffer> tmem_buffers;
-
-    for (const auto &[data, buffer] : buffer_map_) {
+    auto collect_tmem_buffer = [&](const Buffer &buffer) {
       const auto *ptr_type =
           buffer->data->type_annotation.as<PointerTypeNode>();
       ICHECK(ptr_type) << "LowerSharedTmem requires buffer " << buffer->name
                        << "'s data Var to have a PointerType annotation";
-      auto storage_scope = ptr_type->storage_scope;
-      if (storage_scope == "shared.tmem") {
-        tmem_buffers.push_back(buffer);
-      }
+      if (ptr_type->storage_scope != "shared.tmem")
+        return;
+      // Already lowered together with an enclosing block.
+      if (var_remap_.count(buffer->data))
+        return;
+      tmem_buffers.push_back(buffer);
+    };
+    for (auto buffer : op->alloc_buffers) {
+      collect_tmem_buffer(buffer);
+    }
+    for (auto match_buffer : op->match_buffers) {
+      collect_tmem_buffer(match_buffer->buffer);
     }
 
     if (tmem_buffers.empty()) {
@@ -189,66 +388,10 @@ private:
     ICHECK(thread_var_.defined()) << "thread_var_ is not defined";
 
     auto [fallthrough_deallocs, _] = CollectFallthroughDeallocs(op->body);
+    VarSet explicit_deallocs = CollectExplicitDeallocs(op->body);
 
     for (auto buffer : tmem_buffers) {
       buffer_data_to_buffer_.Set(buffer->data, buffer);
-    }
-
-    /*
-    Transform the tmem buffers to new allocations
-    transform:
-        tmem_buf0 = T.alloc_buffer((128, 128,), "uint64",
-    scope="shared.tmem")
-        tmem_buf1 = T.alloc_buffer((128, 128,), "uint64",
-    scope="shared.tmem")
-
-    into:
-        tmem_buf0 = T.alloc_buffer((1,), "uint64", scope="shared.tmem_addr")
-        tmem_buf1 = T.alloc_buffer((1,), "uint64", scope="shared.tmem_addr")
-
-        if tx == 0:
-          T.ptx_init_tensor_memory(tmem_buf0[0], 128)
-          T.ptx_init_tensor_memory(tmem_buf1[0], 128)
-    */
-    // 1. create new data vars
-    Array<Var> new_data_vars;
-    for (auto buffer : tmem_buffers) {
-      auto data = buffer->data;
-      if (var_remap_.count(data))
-        continue;
-      auto new_data =
-          Var(data->name_hint, PointerType(PrimType(tmem_dtype_), "shared"));
-      var_remap_.Set(data, new_data);
-      new_data_vars.push_back(new_data);
-    }
-
-    // 2. create new buffers
-    Array<Buffer> new_buffers;
-    for (auto buffer : tmem_buffers) {
-      auto data = buffer->data;
-      ICHECK(var_remap_.find(data) != var_remap_.end())
-          << "data not found in var_remap_";
-      auto new_data = var_remap_.at(data);
-      auto new_buffer = Buffer(new_data, tmem_dtype_, Array<PrimExpr>({1}),
-                               Array<PrimExpr>({1}), PrimExpr(0), buffer->name,
-                               buffer->data_alignment, buffer->offset_factor,
-                               buffer->buffer_type);
-      new_buffers.push_back(new_buffer);
-      buffer_remap_.Set(buffer, new_buffer);
-      buffer_data_to_buffer_.Set(new_data, new_buffer);
-    }
-
-    // remove the tmem buffers
-    alloc_buffers.MutateByApply([this](Buffer buf) {
-      if (buffer_remap_.find(buf) != buffer_remap_.end()) {
-        return buffer_remap_.at(buf);
-      }
-      return buf;
-    });
-    if (!alloc_buffers.same_as(op->alloc_buffers)) {
-      block.CopyOnWrite()->alloc_buffers = alloc_buffers;
-    } else {
-      return StmtExprMutator::VisitStmt_(op);
     }
 
     // If block has use_2cta attr, add use_2cta: 1 to tmem alloc/dealloc call
@@ -264,44 +407,114 @@ private:
       }
     }
 
-    // 3. create init & dealloc calls for new buffers
+    /*
+    Replace the tmem buffers with one shared address word per physical
+    allocation, and allocate each of those once:
+        tmem_buf0 = T.alloc_buffer((128, 384), "float32", scope="shared.tmem")
+        tmem_buf1 = T.alloc_buffer((128, 4), "uint32", scope="shared.tmem")
+
+    into:
+        tmem_buf0 = T.alloc_buffer((1,), "uint32", scope="shared")
+
+        if tx // 32 == 0:
+          T.ptx_init_tensor_memory(tmem_buf0[0], 512)
+
+    where tmem_buf1 shares tmem_buf0's allocation and is addressed as
+    tmem_buf0[0] + 384.  See PlanTmemArenas for which buffers get packed.
+    */
+    // 1. plan the physical allocations
+    std::vector<int> num_cols_required;
+    std::vector<bool> packable;
+    for (const Buffer &buffer : tmem_buffers) {
+      num_cols_required.push_back(GetNumB32ColsRequired(buffer));
+      packable.push_back(!explicit_deallocs.count(buffer->data));
+    }
+    auto [arenas, placements] = PlanTmemArenas(num_cols_required, packable);
+
+    // 2. one shared address word per allocation, named after the arena's first
+    // (widest) member so that a block with a single TMEM buffer -- or with
+    // buffers packing cannot help -- lowers exactly as it did before.
+    std::vector<Buffer> arena_buffers;
+    for (const TmemArena &arena : arenas) {
+      const Buffer &base_buffer = tmem_buffers[arena.members.front()];
+      Var arena_data(base_buffer->data->name_hint,
+                     PointerType(PrimType(tmem_dtype_), "shared"));
+      Buffer arena_buffer(arena_data, tmem_dtype_, Array<PrimExpr>({1}),
+                          Array<PrimExpr>({1}), PrimExpr(0), base_buffer->name,
+                          base_buffer->data_alignment,
+                          base_buffer->offset_factor, base_buffer->buffer_type);
+      arena_buffers.push_back(arena_buffer);
+      buffer_data_to_buffer_.Set(arena_data, arena_buffer);
+      for (int member : arena.members) {
+        const Buffer &buffer = tmem_buffers[member];
+        var_remap_.Set(buffer->data, arena_data);
+        buffer_remap_.Set(buffer, arena_buffer);
+        tmem_col_offsets_[buffer->data] = placements[member].col_offset;
+        tmem_num_cols_allocated_[buffer->data] = arena.num_cols_allocated;
+        tmem_call_annotations_[buffer->data] = tmem_call_ann;
+      }
+    }
+
+    // 3. swap the tmem buffers for their arenas' address words
+    Array<Buffer> alloc_buffers;
+    std::unordered_set<const BufferNode *> declared_arenas;
+    for (const Buffer &buffer : op->alloc_buffers) {
+      auto it = buffer_remap_.find(buffer);
+      if (it == buffer_remap_.end()) {
+        alloc_buffers.push_back(buffer);
+        continue;
+      }
+      // Buffers sharing an allocation share its word: declare it once, where
+      // the first of them used to be.
+      Buffer arena_buffer = (*it).second;
+      if (declared_arenas.insert(arena_buffer.get()).second) {
+        alloc_buffers.push_back(arena_buffer);
+      }
+    }
+    block.CopyOnWrite()->alloc_buffers = alloc_buffers;
+
+    // 4. create one init & dealloc call per allocation
     std::vector<Stmt> init_mtmem_calls_;
     std::vector<Stmt> dealloc_tmem_calls_;
-    for (auto buffer : tmem_buffers) {
-      auto data = buffer->data;
-      auto old_buffer = buffer_data_to_buffer_.at(data);
-      auto new_buffer = buffer_remap_.at(old_buffer);
-      int num_cols_allocated = GetNumColsAllocated(old_buffer);
+    int num_cols_total = 0;
+    for (size_t i = 0; i < arenas.size(); ++i) {
+      const TmemArena &arena = arenas[i];
+      int num_cols_allocated = arena.num_cols_allocated;
+      num_cols_total += num_cols_allocated;
 
-      // Check that the number of rows doesn't exceed the tmem limit
-      {
-        auto analyzer = std::make_shared<arith::Analyzer>();
-        arith::ConstIntBound phy_row_bounds =
-            analyzer->const_int_bound(old_buffer->shape[0]);
-        int num_rows_required = phy_row_bounds->max_value;
-        ICHECK(num_rows_required <= 128)
-            << "The number of rows required for tmem buffer "
-            << old_buffer->name << " is " << num_rows_required
-            << ", which exceeds the maximum of 128 rows";
-      }
-
-      tmem_num_cols_allocated_.insert({data, num_cols_allocated});
-      tmem_call_annotations_.insert({data, tmem_call_ann});
-
-      auto new_buffer_access = new_buffer.access_ptr(1, DataType::Handle(), 1,
-                                                     PrimExpr(0), PrimExpr(1));
-      auto alloc_call = Call(DataType::Handle(), tl::ptx_init_tensor_memory(),
-                             {new_buffer_access, PrimExpr(num_cols_allocated)},
-                             tmem_call_ann);
+      auto arena_access = arena_buffers[i].access_ptr(1, DataType::Handle(), 1,
+                                                      PrimExpr(0), PrimExpr(1));
+      auto alloc_call =
+          Call(DataType::Handle(), tl::ptx_init_tensor_memory(),
+               {arena_access, PrimExpr(num_cols_allocated)}, tmem_call_ann);
       init_mtmem_calls_.push_back(Evaluate(alloc_call));
-      if (!fallthrough_deallocs.count(data)) {
-        auto dealloc_call = Call(
-            DataType::Handle(), tl::ptx_deallocate_tensor_memory(),
-            {new_buffer_access, PrimExpr(num_cols_allocated)}, tmem_call_ann);
+      // A buffer that releases itself on every fallthrough path replaces the
+      // dealloc at block end.  Packing leaves such buffers alone, so an
+      // allocation released by hand never holds anything else.
+      bool released_by_hand =
+          arena.members.size() == 1 &&
+          fallthrough_deallocs.count(tmem_buffers[arena.members.front()]->data);
+      if (!released_by_hand) {
+        auto dealloc_call =
+            Call(DataType::Handle(), tl::ptx_deallocate_tensor_memory(),
+                 {arena_access, PrimExpr(num_cols_allocated)}, tmem_call_ann);
         dealloc_tmem_calls_.push_back(Evaluate(dealloc_call));
       }
     }
-    auto compare_by_buffer_name = [&](const Stmt &a, const Stmt &b) {
+    // Without an explicit tl.deallocate_tmem every allocation in the block is
+    // live at once, so an over-budget kernel can be reported here instead of
+    // failing inside tcgen05.alloc on device.
+    if (explicit_deallocs.empty()) {
+      ICHECK(num_cols_total <= kTmemNumColumns)
+          << "This block allocates " << num_cols_total
+          << " TMEM columns across " << arenas.size()
+          << " tcgen05.alloc calls, but a CTA only has " << kTmemNumColumns
+          << " columns; shrink the TMEM footprint or release a buffer earlier "
+             "with T.deallocate_tmem";
+    }
+    // PTX forbids a tcgen05.alloc from asking for more columns than one issued
+    // before it in the same CTA, so allocate the widest first.
+    auto compare_by_num_cols_desc = [&](const Stmt &a, const Stmt &b) {
       auto call_a = a.as<EvaluateNode>()->value.as<CallNode>();
       auto call_b = b.as<EvaluateNode>()->value.as<CallNode>();
       auto num_cols_a = call_a->args[1].as<IntImmNode>()->value;
@@ -309,7 +522,7 @@ private:
       return num_cols_a > num_cols_b;
     };
     std::sort(init_mtmem_calls_.begin(), init_mtmem_calls_.end(),
-              compare_by_buffer_name);
+              compare_by_num_cols_desc);
 
     Array<Stmt> new_body;
     ICHECK(target_.defined()) << "LowerSharedTmem requires a bound target";
@@ -363,26 +576,44 @@ private:
     return result;
   }
 
+  /*!
+   * \brief GetTmemOffset, shifted to where the buffer starts in its arena.
+   *
+   * A TMEM address is datapath<<16 | b32_column, so adding a column offset to
+   * the encoded coordinate lands in the same datapath of a later column -- the
+   * arena's base address plus this is the buffer's own base address.
+   */
+  PrimExpr GetArenaTmemOffset(const Buffer &buffer,
+                              const Array<PrimExpr> &indices) {
+    PrimExpr offset = GetTmemOffset(buffer, indices);
+    int col_offset = GetArenaColOffset(buffer->data);
+    if (col_offset == 0) {
+      return offset;
+    }
+    return offset + IntImm(offset.dtype(), col_offset);
+  }
+
   PrimExpr VisitExpr_(const BufferLoadNode *op) final {
     // Translate tmem[datapath, value_col] to tmem[0] + tmem_offset
     // Where
     // - (datapath, value_col) is the physical address in the tmem buffer
-    // - tmem[0] is the base address allocated for the tmem buffer
+    // - tmem[0] is the base address of the allocation holding the buffer
     // - tmem_offset = datapath<<16 | b32_col, with b32_col converted from
-    //   the typed value-column coordinate
+    //   the typed value-column coordinate and shifted by the buffer's column
+    //   offset when it shares that allocation with others
     auto load = Downcast<BufferLoad>(StmtExprMutator::VisitExpr_(op));
     auto buffer = load->buffer;
     auto indices = load->indices;
 
     if (buffer_remap_.count(buffer)) {
       auto new_buffer = buffer_remap_[load->buffer];
-      return BufferLoad(new_buffer, {0}) + GetTmemOffset(buffer, indices);
+      return BufferLoad(new_buffer, {0}) + GetArenaTmemOffset(buffer, indices);
     } else if (var_remap_.count(buffer->data)) {
       auto new_buffer = Buffer(
           var_remap_[buffer->data], tmem_dtype_, buffer->shape, buffer->strides,
           buffer->elem_offset, buffer->name, buffer->data_alignment,
           buffer->offset_factor, buffer->buffer_type);
-      return BufferLoad(new_buffer, {0}) + GetTmemOffset(buffer, indices);
+      return BufferLoad(new_buffer, {0}) + GetArenaTmemOffset(buffer, indices);
     }
     return load;
   }
@@ -426,17 +657,117 @@ private:
       if (!var_remap_.count(buffer_data)) {
         return StmtExprMutator::VisitExpr_(op);
       }
+      // A pointer to the address word carries no column offset, so a buffer
+      // sharing an allocation cannot be reached this way.  See
+      // VisitExpr_(VarNode) for the same argument.
+      CheckAddressableWithoutColOffset(buffer_data);
       Var new_data = var_remap_[buffer_data];
       return Call(
           op->dtype, op->op,
           {op->args[0], new_data, op->args[2], op->args[3], op->args[4]});
     }
+    if (HasPackedTmemOperand(op)) {
+      ICHECK(TakesTmemBaseOffsetPairs(op->op))
+          << op->op
+          << " names a TMEM buffer that shares a physical allocation, but only "
+             "the tl.ptx_tcgen05_* intrinsics pass tensor memory as a "
+             "(base, offset) pair this pass can shift";
+      return RebaseTmemOperands(op);
+    }
     auto expr = StmtExprMutator::VisitExpr_(op);
     return expr;
   }
+
+  /*!
+   * \brief Whether a call names a TMEM buffer that starts inside an allocation.
+   *
+   * Calls that only name buffers at column 0 need no rewriting, so they keep
+   * the exact expression -- source span included -- that they had before.
+   */
+  bool HasPackedTmemOperand(const CallNode *op) const {
+    for (const PrimExpr &arg : op->args) {
+      const auto *var = arg.as<VarNode>();
+      if (var != nullptr && GetArenaColOffset(GetRef<Var>(var)) != 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /*!
+   * \brief Whether an op takes its tensor-memory operands as (base, offset).
+   *
+   * Every tl.ptx_tcgen05_* intrinsic passes a tensor-memory operand as the
+   * buffer's base-address Var immediately followed by that operand's address
+   * offset: see ptx_tcgen05_mma_ss, _mma_ts, _mma_blockscaled_ss and
+   * cp_warpx4 in codegen_cuda.cc, which all emit
+   * `*(uint32_t*)base + offset`.  Packing folds a buffer's column offset into
+   * the second half of each such pair.
+   */
+  static bool TakesTmemBaseOffsetPairs(const RelaxExpr &op) {
+    const auto *op_node = op.as<OpNode>();
+    if (op_node == nullptr) {
+      return false;
+    }
+    const std::string name = op_node->name;
+    return name.rfind("tl.ptx_tcgen05_", 0) == 0;
+  }
+
+  /*!
+   * \brief Add the arena column offsets to one tl.ptx_tcgen05_* call's
+   * operands.
+   */
+  PrimExpr RebaseTmemOperands(const CallNode *op) {
+    Array<PrimExpr> args;
+    for (size_t i = 0; i < op->args.size(); ++i) {
+      const auto *var = op->args[i].as<VarNode>();
+      if (var == nullptr || !var_remap_.count(GetRef<Var>(var))) {
+        args.push_back(VisitExpr(op->args[i]));
+        continue;
+      }
+      Var buffer_data = GetRef<Var>(var);
+      ICHECK_LT(i + 1, op->args.size())
+          << op->op << " passes TMEM buffer " << buffer_data
+          << " without the address offset that has to follow it";
+      PrimExpr offset = VisitExpr(op->args[i + 1]);
+      ICHECK(offset.dtype().is_int() || offset.dtype().is_uint())
+          << op->op << " expects an integer TMEM address offset after buffer "
+          << buffer_data << ", got " << offset << " of type " << offset.dtype();
+      int col_offset = GetArenaColOffset(buffer_data);
+      args.push_back(var_remap_[buffer_data]);
+      args.push_back(col_offset == 0
+                         ? offset
+                         : offset + IntImm(offset.dtype(), col_offset));
+      // The offset argument was consumed together with its base.
+      ++i;
+    }
+    return Call(op->dtype, op->op, args, op->annotations, op->span);
+  }
+
+  /*!
+   * \brief Reject a base address that no column offset can be attached to.
+   *
+   * A buffer that starts partway into a shared allocation is only addressable
+   * through a construct this pass knows how to shift.  Reaching one of the
+   * remaining paths would silently address the start of the allocation --
+   * another buffer's data -- so report it instead.
+   */
+  void CheckAddressableWithoutColOffset(const Var &buffer_data) const {
+    int col_offset = GetArenaColOffset(buffer_data);
+    ICHECK_EQ(col_offset, 0)
+        << "TMEM buffer " << buffer_data
+        << " shares a physical TMEM allocation and starts at column "
+        << col_offset
+        << " of it, but its base address reaches an operation LowerSharedTmem "
+           "cannot offset; teach RebaseTmemOperands about that operation";
+  }
+
   PrimExpr VisitExpr_(const VarNode *op) final {
     Var var = GetRef<Var>(op);
     if (var_remap_.count(var)) {
+      // The base address escaped the (base, offset) rewrite above, so nothing
+      // downstream adds this buffer's column offset.
+      CheckAddressableWithoutColOffset(var);
       return var_remap_[var];
     }
     return var;
@@ -466,6 +797,8 @@ private:
   std::unordered_map<Var, Buffer, ObjectPtrHash, ObjectPtrEqual> buffer_map_;
   std::unordered_map<Var, int, ObjectPtrHash, ObjectPtrEqual>
       tmem_num_cols_allocated_;
+  // b32 columns between a TMEM buffer and the base of the allocation it shares
+  std::unordered_map<Var, int, ObjectPtrHash, ObjectPtrEqual> tmem_col_offsets_;
   std::unordered_map<Var, Map<String, ObjectRef>, ObjectPtrHash, ObjectPtrEqual>
       tmem_call_annotations_;
   Map<Buffer, Layout> layout_map_;

--- a/testing/python/language/test_tilelang_language_tmem_copy.py
+++ b/testing/python/language/test_tilelang_language_tmem_copy.py
@@ -199,6 +199,59 @@ def _make_16bit_roundtrip_kernel(shape, forward, dtype):
     return main
 
 
+def _make_shared_allocation_roundtrip_kernel(wide_cols, narrow_cols):
+    """Roundtrip two TMEM buffers that share one physical tcgen05.alloc.
+
+    LowerSharedTmem packs the narrow buffer at column ``wide_cols`` of the
+    allocation both use, because rounding their columns up to a power of two
+    together costs nothing.  The *wide* roundtrip is what catches a dropped
+    column offset: the narrow buffer would still round-trip if its store and its
+    load dropped the offset together, but its store would land on the wide
+    buffer's first columns.
+    """
+    wide_shape = (128, wide_cols)
+    narrow_shape = (128, narrow_cols)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor(wide_shape, T.float32),
+        B: T.Tensor(narrow_shape, T.float32),
+        DA: T.Tensor(wide_shape, T.float32),
+        DB: T.Tensor(narrow_shape, T.float32),
+    ):
+        with T.Kernel(1, threads=128):
+            a_shared = T.alloc_shared(wide_shape, T.float32)
+            a_in_frag = T.alloc_fragment(wide_shape, T.float32)
+            a_out_frag = T.alloc_fragment(wide_shape, T.float32)
+            b_shared = T.alloc_shared(narrow_shape, T.float32)
+            b_in_frag = T.alloc_fragment(narrow_shape, T.float32)
+            b_out_frag = T.alloc_fragment(narrow_shape, T.float32)
+            wide_tmem = T.alloc_tmem(wide_shape, T.float32)
+            narrow_tmem = T.alloc_tmem(narrow_shape, T.float32)
+
+            T.annotate_layout(
+                {
+                    wide_tmem: T.Layout(wide_shape, lambda i, j: [i, j]),
+                    narrow_tmem: T.Layout(narrow_shape, lambda i, j: [i, j]),
+                }
+            )
+            T.copy(A, a_shared)
+            T.copy(a_shared, a_in_frag)
+            T.copy(a_in_frag, wide_tmem)
+            T.copy(B, b_shared)
+            T.copy(b_shared, b_in_frag)
+            T.copy(b_in_frag, narrow_tmem)
+
+            T.copy(wide_tmem, a_out_frag)
+            T.copy(a_out_frag, a_shared)
+            T.copy(a_shared, DA)
+            T.copy(narrow_tmem, b_out_frag)
+            T.copy(b_out_frag, b_shared)
+            T.copy(b_shared, DB)
+
+    return main
+
+
 def _run_roundtrip(kernel_func, shape):
     kernel = tilelang.compile(kernel_func, target="cuda", pass_configs=PASS_CONFIGS)
     source = kernel.get_kernel_source()
@@ -290,6 +343,32 @@ def test_tmem_copy_sliced_store_whole_load(name, shape, forward, threads):
 )
 def test_tmem_copy_roundtrip_sliced_batch(name, shape, forward, threads):
     _run_roundtrip(_make_batch_sliced_roundtrip_kernel(shape, forward, threads), shape)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_tmem_copy_roundtrip_across_a_shared_allocation():
+    wide_cols, narrow_cols = 96, 32
+    kernel = tilelang.compile(
+        _make_shared_allocation_roundtrip_kernel(wide_cols, narrow_cols),
+        target="cuda",
+        pass_configs=PASS_CONFIGS,
+    )
+    source = kernel.get_kernel_source()
+    # 96 + 32 columns round up to the same 128 the wide buffer needs alone, so
+    # the two buffers share a single allocation.
+    assert source.count("tl::tmem_allocate") == 1
+    assert "tl::tmem_allocate((&(wide_tmem[0])), 128)" in source
+    assert "tcgen05_st_" in source and "tcgen05_ld_" in source
+
+    a = torch.randn(128, wide_cols, device="cuda", dtype=torch.float32)
+    b = torch.randn(128, narrow_cols, device="cuda", dtype=torch.float32)
+    da = torch.empty_like(a)
+    db = torch.empty_like(b)
+    kernel(a, b, da, db)
+    torch.testing.assert_close(da, a, rtol=0.0, atol=0.0)
+    torch.testing.assert_close(db, b, rtol=0.0, atol=0.0)
 
 
 if __name__ == "__main__":

--- a/testing/python/transform/test_tilelang_transform_inject_tcgen05_fence.py
+++ b/testing/python/transform/test_tilelang_transform_inject_tcgen05_fence.py
@@ -2,6 +2,7 @@
 from tilelang import tvm as tvm
 import tilelang as tl
 import tilelang.language as T
+import tilelang.testing
 from tilelang.cuda.pipeline import CUDAPassPipelineBodyPrologue
 from tvm import tirx
 
@@ -71,6 +72,9 @@ def _tcgen05_ld_call(tmem_ref, local_buf):
     )
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
 def test_storage_sync_is_wrapped_with_tcgen05_fences():
     @T.prim_func
     def before():
@@ -93,6 +97,9 @@ def test_storage_sync_is_wrapped_with_tcgen05_fences():
     _check(before, after)
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
 def test_lower_tmem_copy_uses_tcgen05_ld_intrin():
     @T.prim_func
     def func(X: T.Tensor((256, 256), T.float16), Y: T.Tensor((256, 256), T.float16)):
@@ -126,6 +133,9 @@ def test_lower_tmem_copy_uses_tcgen05_ld_intrin():
     assert _count_extern_calls_with_prefix(body, "tl::tcgen05_ld_") == 0
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
 def test_lower_tmem_copy_uses_tcgen05_st_intrin():
     @T.prim_func
     def func(X: T.Tensor((256, 256), T.bfloat16)):
@@ -174,6 +184,9 @@ def test_lower_tmem_copy_uses_tcgen05_st_intrin():
     assert _count_extern_calls_with_prefix(body, "tl::tcgen05_st_") == 0
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
 def test_wait_and_arrive_are_rewritten_only_at_tmem_handoffs():
     @T.prim_func
     def before():
@@ -200,6 +213,9 @@ def test_wait_and_arrive_are_rewritten_only_at_tmem_handoffs():
     _check(before, after)
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
 def test_wait_and_arrive_scan_across_neutral_statements():
     @T.prim_func
     def before():
@@ -230,6 +246,9 @@ def test_wait_and_arrive_scan_across_neutral_statements():
     _check(before, after)
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
 def test_sync_boundary_stops_wait_lookahead():
     @T.prim_func
     def func():
@@ -246,6 +265,9 @@ def test_sync_boundary_stops_wait_lookahead():
     assert _count_calls(mod["main"].body, "tl.tcgen05_after_thread_sync") == 0
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
 def test_existing_manual_fences_are_not_duplicated():
     @T.prim_func
     def func():
@@ -265,6 +287,9 @@ def test_existing_manual_fences_are_not_duplicated():
     assert _count_calls(body, "tl.tcgen05_before_thread_sync") == 1
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
 def test_non_sm100_targets_are_left_untouched():
     @T.prim_func
     def func():

--- a/testing/python/transform/test_tilelang_transform_lower_shared_tmem.py
+++ b/testing/python/transform/test_tilelang_transform_lower_shared_tmem.py
@@ -29,6 +29,9 @@ def _collect_calls(stmt, op_name: str):
     return calls
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
 def test_explicit_deallocate_tmem_suppresses_auto_dealloc():
     """Explicit T.deallocate_tmem on fallthrough suppresses auto-dealloc."""
 
@@ -48,6 +51,9 @@ def test_explicit_deallocate_tmem_suppresses_auto_dealloc():
     assert dealloc_call.args[1].value == 128
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
 def test_explicit_deallocate_only_suppresses_matching_buffer():
     """Only the explicitly-deallocated buffer skips auto-dealloc; others keep it."""
 
@@ -69,6 +75,9 @@ def test_explicit_deallocate_only_suppresses_matching_buffer():
     assert dealloc_num_cols == [64, 128]
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
 def test_dealloc_before_thread_return_keeps_auto_dealloc():
     """Dealloc on non-fallthrough path (before thread_return) does NOT suppress auto-dealloc."""
 
@@ -91,6 +100,9 @@ def test_dealloc_before_thread_return_keeps_auto_dealloc():
     assert [call.args[1].value for call in dealloc_calls] == [128, 128]
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
 def test_untyped_buffer_reports_internal_error():
     valid_buffer = tvm.tirx.decl_buffer((1,), name="malformed_buffer")
     untyped_data = tvm.tirx.Var("malformed_buffer", "handle")

--- a/testing/python/transform/test_tilelang_transform_tmem_arena_packing.py
+++ b/testing/python/transform/test_tilelang_transform_tmem_arena_packing.py
@@ -1,0 +1,267 @@
+# ruff: noqa
+"""Logical TMEM buffers share physical tcgen05.alloc calls when that saves columns."""
+
+import pytest
+
+from tilelang import tvm as tvm
+import tilelang as tl
+import tilelang.language as T
+import tilelang.testing
+
+
+TARGET = tvm.target.Target({"kind": "cuda", "arch": "sm_100"})
+
+
+def _apply(func):
+    mod = tvm.IRModule.from_expr(func.with_attr("global_symbol", "main"))
+    mod = tvm.tirx.transform.BindTarget(TARGET)(mod)
+    mod = tl.transform.MaterializeKernelLaunch()(mod)
+    return tl.cuda.transform.LowerSharedTmem()(mod)
+
+
+def _collect_calls(stmt, op_name):
+    calls = []
+
+    def visitor(node):
+        if isinstance(node, tvm.tirx.Call) and getattr(node.op, "name", None) == op_name:
+            calls.append(node)
+
+    tvm.tirx.stmt_functor.post_order_visit(stmt, visitor)
+    return calls
+
+
+def _num_cols_allocated(body):
+    """Columns passed to each tcgen05.alloc, in the order they are issued."""
+    return [int(call.args[1]) for call in _collect_calls(body, "tl.ptx_init_tensor_memory")]
+
+
+def _tmem_addresses(body):
+    """``(address word name, column offset)`` for every ``T.evaluate(buf[i, j])``.
+
+    A lowered TMEM address is ``word[0] + encoded_coordinate``, where the encoded
+    coordinate carries the buffer's offset inside the allocation it shares.  With
+    a ``[0, 0]`` coordinate the whole offset folds into one constant.
+    """
+    addresses = []
+
+    def visitor(node):
+        if not isinstance(node, tvm.tirx.Evaluate):
+            return
+        value = node.value
+        if isinstance(value, tvm.tirx.BufferLoad):
+            addresses.append((value.buffer.name, 0))
+        elif isinstance(value, tvm.tirx.Add) and isinstance(value.a, tvm.tirx.BufferLoad):
+            addresses.append((value.a.buffer.name, int(value.b)))
+
+    tvm.tirx.stmt_functor.post_order_visit(body, visitor)
+    return addresses
+
+
+def _int_imms(expr):
+    values = []
+    tvm.tirx.stmt_functor.post_order_visit(expr, lambda node: values.append(int(node)) if isinstance(node, tvm.tirx.IntImm) else None)
+    return values
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_narrow_buffers_join_a_wide_allocation():
+    """A 384-column accumulator plus three 4-column scale buffers need 396 columns.
+
+    Allocated separately they would ask for 512 + 32 + 32 + 32 = 608 of the 512
+    columns a CTA has.  Sharing one allocation fits, at the same offsets DeepGEMM
+    uses by hand for this kernel.
+    """
+
+    @T.prim_func
+    def func():
+        with T.Kernel(1, threads=128):
+            C_tmem = T.alloc_tmem([128, 384], T.float32)
+            SFQ_tmem = T.alloc_tmem([128, 4], "uint32")
+            SFKV0_tmem = T.alloc_tmem([128, 4], "uint32")
+            SFKV1_tmem = T.alloc_tmem([128, 4], "uint32")
+            T.evaluate(C_tmem[0, 0])
+            T.evaluate(SFQ_tmem[0, 0])
+            T.evaluate(SFKV0_tmem[0, 0])
+            T.evaluate(SFKV1_tmem[0, 0])
+
+    body = _apply(func)["main"].body
+    assert _num_cols_allocated(body) == [512]
+    assert [int(call.args[1]) for call in _collect_calls(body, "tl.ptx_deallocate_tensor_memory")] == [512]
+    assert _tmem_addresses(body) == [
+        ("C_tmem", 0),
+        ("C_tmem", 384),
+        ("C_tmem", 388),
+        ("C_tmem", 392),
+    ]
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_buffers_pack_only_when_it_saves_columns():
+    """Block-scale factors share one allocation; the accumulator keeps its own.
+
+    Putting all three together would round 136 columns up to 256, more than the
+    128 + 32 = 160 this plan uses.
+    """
+
+    @T.prim_func
+    def func():
+        with T.Kernel(1, threads=128):
+            C_tmem = T.alloc_tmem([128, 128], T.float32)
+            SFA_tmem = T.alloc_tmem([128, 4], "uint32")
+            SFB_tmem = T.alloc_tmem([128, 4], "uint32")
+            T.evaluate(C_tmem[0, 0])
+            T.evaluate(SFA_tmem[0, 0])
+            T.evaluate(SFB_tmem[0, 0])
+
+    body = _apply(func)["main"].body
+    assert _num_cols_allocated(body) == [128, 32]
+    assert _tmem_addresses(body) == [("C_tmem", 0), ("SFA_tmem", 0), ("SFA_tmem", 4)]
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_equal_cost_keeps_separate_allocations():
+    """Packing that saves nothing is not done, so such a kernel lowers unchanged."""
+
+    @T.prim_func
+    def func():
+        with T.Kernel(1, threads=128):
+            S_tmem = T.alloc_tmem([128, 128], T.float32)
+            P_tmem = T.alloc_tmem([128, 128], T.float16)
+            O_tmem = T.alloc_tmem([128, 128], T.float32)
+            T.evaluate(S_tmem[0, 0])
+            T.evaluate(P_tmem[0, 0])
+            T.evaluate(O_tmem[0, 0])
+
+    body = _apply(func)["main"].body
+    # 128 fp32 columns, 128 fp16 values in 64 b32 columns, 128 fp32 columns.
+    assert _num_cols_allocated(body) == [128, 128, 64]
+    assert _tmem_addresses(body) == [("S_tmem", 0), ("P_tmem", 0), ("O_tmem", 0)]
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_allocations_are_issued_widest_first():
+    """PTX forbids a tcgen05.alloc larger than one issued before it in the CTA."""
+
+    @T.prim_func
+    def func():
+        with T.Kernel(1, threads=128):
+            narrow_tmem = T.alloc_tmem([128, 32], T.float32)
+            wide_tmem = T.alloc_tmem([128, 256], T.float32)
+            T.evaluate(narrow_tmem[0, 0])
+            T.evaluate(wide_tmem[0, 0])
+
+    num_cols = _num_cols_allocated(_apply(func)["main"].body)
+    assert num_cols == sorted(num_cols, reverse=True)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        # (columns of a 32-bit dtype) per buffer
+        [384, 4, 4, 4],
+        [128, 4, 4],
+        [128, 128, 128],
+        [32, 32, 32, 32, 32],
+        [256, 8],
+        [64, 64, 4],
+    ],
+)
+def test_packing_never_allocates_more_than_separate_allocations(shapes):
+    """The planning invariant: sharing an allocation is never the costlier choice."""
+
+    @T.prim_func
+    def func():
+        with T.Kernel(1, threads=128):
+            _ = [T.alloc_tmem([128, num_cols], "uint32") for num_cols in shapes]
+
+    separate = sum(max(32, 1 << (num_cols - 1).bit_length()) for num_cols in shapes)
+    packed = sum(_num_cols_allocated(_apply(func)["main"].body))
+    assert packed <= separate
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_explicit_deallocate_keeps_its_own_allocation():
+    """A hand-managed lifetime cannot share an allocation it would release early."""
+
+    @T.prim_func
+    def func():
+        with T.Kernel(1, threads=128):
+            C_tmem = T.alloc_tmem([128, 384], T.float32)
+            SF_tmem = T.alloc_tmem([128, 4], "uint32")
+            T.evaluate(C_tmem[0, 0])
+            T.evaluate(SF_tmem[0, 0])
+            T.deallocate_tmem(SF_tmem)
+
+    body = _apply(func)["main"].body
+    assert _num_cols_allocated(body) == [512, 32]
+    assert _tmem_addresses(body) == [("C_tmem", 0), ("SF_tmem", 0)]
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_dynamic_coordinate_keeps_the_arena_offset():
+    """A software-pipeline stage index moves the address; the offset still applies."""
+
+    @T.prim_func
+    def func():
+        with T.Kernel(1, threads=128):
+            C_tmem = T.alloc_tmem([128, 384], T.float32)
+            SF_tmem = T.alloc_tmem([128, 8], "uint32")
+            stage = T.alloc_var(T.int32, init=0)
+            T.evaluate(SF_tmem[0, stage * 4])
+
+    body = _apply(func)["main"].body
+    assert _num_cols_allocated(body) == [512]
+    addresses = _collect_calls(body, "tl.ptx_init_tensor_memory")
+    assert len(addresses) == 1
+
+    dynamic_address = []
+    tvm.tirx.stmt_functor.post_order_visit(
+        body,
+        lambda node: (
+            dynamic_address.append(node.value)
+            if isinstance(node, tvm.tirx.Evaluate) and not isinstance(node.value, tvm.tirx.Call)
+            else None
+        ),
+    )
+    assert len(dynamic_address) == 1
+    assert 384 in _int_imms(dynamic_address[0])
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_block_over_the_column_budget_is_reported():
+    """Two 384-column buffers cannot share or fit, which is worth saying out loud."""
+
+    @T.prim_func
+    def func():
+        with T.Kernel(1, threads=128):
+            first_tmem = T.alloc_tmem([128, 384], T.float32)
+            second_tmem = T.alloc_tmem([128, 384], T.float32)
+            T.evaluate(first_tmem[0, 0])
+            T.evaluate(second_tmem[0, 0])
+
+    with pytest.raises(
+        tvm.error.InternalError,
+        match=r"allocates 1024 TMEM columns across 2 tcgen05.alloc calls, but a CTA only has 512",
+    ):
+        _apply(func)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/testing/python/transform/test_tilelang_transform_tmem_physical_shape.py
+++ b/testing/python/transform/test_tilelang_transform_tmem_physical_shape.py
@@ -5,6 +5,7 @@ import pytest
 from tilelang import tvm
 import tilelang as tl
 import tilelang.language as T
+import tilelang.testing
 from tilelang.cuda.intrinsics.layout.mma_sm100_layout import (
     TCGEN05Meta,
     make_tmem_frg_c,
@@ -36,6 +37,9 @@ def _collect_calls(stmt, op_name):
     return calls
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
 @pytest.mark.parametrize(
     ("dtype", "expected_num_b32_cols"),
     [(T.float32, 128), (T.bfloat16, 64)],
@@ -63,6 +67,9 @@ def test_tmem_outer_m_tiles_allocate_physical_columns(dtype, expected_num_b32_co
     assert dealloc[0].args[1].value == expected_num_b32_cols
 
 
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
 @pytest.mark.parametrize("dtype", [T.float16, T.bfloat16, T.float32])
 def test_tmem_frg_type_c_allocates_int32_storage_columns(dtype):
     @T.prim_func


### PR DESCRIPTION
#2827

## Problem

`LowerSharedTmem` gives every `T.alloc_tmem` buffer its own `tcgen05.alloc`, rounded up to a power of two with a minimum of 32 columns. Narrow buffers therefore each burn a full 32-column allocation even when they need 4.

That is not just waste — it makes some kernels inexpressible. A 384-column accumulator (three 128-column pipeline stages) next to three 4-column block-scale buffers needs **396** columns, but as four separate allocations it asks the hardware for `512 + 32 + 32 + 32 = 608` of the **512** columns a CTA has. Today nothing reports this; the kernel just compiles and misbehaves on device.

The workaround has been to declare one wide TMEM buffer and slice scale factors out of it by hand, passing column offsets manually — which is what a compiler should be doing.

CUTLASS solves the same problem with a bump allocator over one allocation (`cutlass::detail::find_tmem_tensor_col_offset`, used by `sm100_blockscaled_mma_warpspecialized.hpp` to place `accumulator → tCtSFA → tCtSFB`), and DeepGEMM hand-writes the equivalent layout.

## Approach

Plan the allocations before emitting them. `PlanTmemArenas` packs logical TMEM buffers into shared physical allocations, and each buffer's column offset inside the allocation it shares is folded into every address it forms.

Two addressing paths carry TMEM addresses today, and both are handled:

- `BufferLoad` on a TMEM buffer — used by `tcgen05.ld`/`tcgen05.st` — gains the offset in the encoded coordinate.
- The `(base address Var, offset)` argument pairs of the `tl.ptx_tcgen05_*` intrinsics (`_mma_ss`, `_mma_ts`, `_mma_blockscaled_ss`, `cp_warpx4`), which all codegen to `*(uint32_t*)base + offset`, get the offset added to the second half of the pair.

A base address that reaches anything else is rejected with a diagnostic rather than silently addressing the start of the allocation.

**Packing policy.** A buffer joins an existing allocation only when that *strictly* reduces the total number of allocated columns. Each placement therefore costs at most the buffer's own standalone allocation, so:

- packing can never grow a kernel's TMEM footprint, and
- a kernel whose buffers already fit lowers exactly as it did before.

Widest-first placement keeps wide buffers on 32-column boundaries.

**Alignment.** A buffer at least 32 columns wide starts on a 32-column boundary — the same alignment `tcgen05.alloc` would have given it alone — so sharing an allocation cannot leave an accumulator or a TMEM-resident A operand less aligned than it is today. Narrower buffers use the 4-column granularity of `tcgen05.cp.32x128b.warpx4`, the boundary CUTLASS and DeepGEMM place these very operands on.

**Lifetimes.** A buffer with an explicit `T.deallocate_tmem` keeps its own allocation: releasing it early would release whatever shares it. Every other buffer in a block is live for the whole block, so this needs no liveness analysis to be correct. It does leave value on the table — buffers with disjoint live ranges could reuse the same columns outright instead of only filling each other's power-of-two padding — which is marked as a TODO on the planner.

**New diagnostic.** A block that allocates more than 512 columns is now reported at compile time (unless it manages a lifetime by hand, where the peak is not the sum).

## Effect on existing kernels

Measured by capturing `device_kernel.cu` for every TMEM example under baseline and under this change (separate `TILELANG_CACHE_DIR`s, so no cache hit crosses versions) and diffing:

| example | before | after |
| --- | --- | --- |
| `gemm_mxfp8_blockscaled_1d1d` | 3 allocations, 320 columns | 2 allocations, **288 columns** |
| `grouped_gemm_mxfp8_blockscaled_1d1d` | 3 allocations, 320 columns | 2 allocations, **288 columns** |
| `fp8_fp4_gemm_1d1d_sm100` | 3 allocations, 320 columns | 2 allocations, **288 columns** |
| `mha_fwd_bshd`, `gqa_fwd_bshd` | 128 + 128 + 64 / 128 + 128 | same allocations at the same addresses; only the order the declarations and deallocs are emitted in changed |
| `gemm_tcgen5mma{,_ws,_ws_persistent,_ws_clc}` | 1 allocation | byte-identical generated CUDA |

All of them still pass their own correctness checks.

The whole difference in the generated CUDA for the block-scaled GEMM is:

```diff
-  __shared__ __align__(16) uint sfa_data[1];
-    tl::tmem_allocate<true>((&(sfa_data[0])), 32);
-    tl::tcgen05_cp<true>(..., (*reinterpret_cast<uint32_t*>(sfa_data)) + 0);
+    tl::tcgen05_cp<true>(..., (*reinterpret_cast<uint32_t*>(sfb_data)) + 8);
-    tl::tcgen05mma_blockscaled_ss<...>(..., (*reinterpret_cast<uint32_t*>(sfa_data)) + 0, (*reinterpret_cast<uint32_t*>(sfb_data)) + 0);
+    tl::tcgen05mma_blockscaled_ss<...>(..., (*reinterpret_cast<uint32_t*>(sfb_data)) + 8, (*reinterpret_cast<uint32_t*>(sfb_data)) + 0);
-    tl::tmem_deallocate<true>((&(sfa_data[0])), 32);
```

One fewer address word, one fewer alloc/dealloc pair, and the MMA loads one base address instead of two — so this removes a shared-memory load rather than adding one.

Wall-clock is not a usable signal on the machine I measured on (shared with another tenant): three interleaved rounds of the block-scaled GEMM gave baseline 3032 / 2931 / 1303 TFLOP/s against 2824 / 3031 / 1324, i.e. ±7% within a round and 2.3x across rounds. The code-level facts above are the claim; the timings only confirm nothing catastrophic.

## Tests

New `testing/python/transform/test_tilelang_transform_tmem_arena_packing.py`:

- 396 columns across four buffers become one 512-column allocation at offsets 0 / 384 / 388 / 392, matching DeepGEMM's hand-written layout column for column
- block-scale factors share an allocation while the accumulator keeps its own, because packing all three would cost more
- equal-cost cases keep separate allocations
- allocations are issued widest first (PTX forbids a later `tcgen05.alloc` from being larger)
- the never-worse invariant over six shape combinations
- explicit `T.deallocate_tmem` keeps its own allocation
- a dynamic (pipeline-stage) coordinate still carries the constant offset
- an over-budget block is reported

New GPU test in `test_tilelang_language_tmem_copy.py`: a store/load roundtrip through two buffers sharing one allocation. The *wide* buffer's roundtrip is the assertion that matters — the narrow one would still round-trip if its store and load dropped the offset together, but its store would land on the wide buffer's columns.

Existing coverage, on a B200:

- `testing/python/transform/`: 380 passed, 7 skipped
- `tcgen05` GEMM / sliced-operand / TMEM-copy / atom-MMA language tests plus the bf16-TS and int8 TMEM kernel tests: 58 passed, 1 skipped
- examples run end to end: mxfp8 and grouped mxfp8 block-scaled GEMM, `mha_fwd_bshd`, `gqa_fwd_bshd`, `fp8_fp4_gemm_1d1d_sm100`, and the three `gemm_sm100` variants

The new tests were validated by mutation: dropping the column offset in `LowerSharedTmem` fails the GPU roundtrip and three of the planning tests.

## Notes

- The planning step lives inside `LowerSharedTmem` rather than in a separate pass, since buffer collection, column sizing and allocation emission are all already there. It is a self-contained function and can be split out if a second consumer appears.
- Packing relies on the convention that a `tl.ptx_tcgen05_*` intrinsic passes a TMEM operand's base address immediately followed by its offset. That convention is now documented at the point where it is depended on, and a base address reaching any other context is a hard error.
