### PR TITLE
[BugFix] Correctly preserve loop step when unrolling loops

### DIFF
--- a/src/transform/unroll_loop.cc
+++ b/src/transform/unroll_loop.cc
@@ -320,14 +320,19 @@ private:
     }
     auto *step = as_const_int(op->step.value());
     ICHECK(step) << "An loop's step must be constant";
+    ICHECK_GT(*step, 0) << "A loop's step must be positive";
     return *step;
   }
 
-  // returns the trip count of the loop
+  // returns the trip count of the loop if it's a constant integer, otherwise
+  // return -1
   int GetTripCount(const ForNode *op) {
     int extent = GetExtent(op);
+    if (extent < 0) {
+      return -1;
+    }
     int step = GetStep(op);
-    return (extent + step - 1) / step;
+    return 1 + (extent - 1) / step;
   }
 
   // maximum number of step to perform auto unroll.

--- a/src/transform/unroll_loop.cc
+++ b/src/transform/unroll_loop.cc
@@ -177,7 +177,7 @@ public:
     // Post order so we can collect more information
     Stmt stmt = StmtExprMutator::VisitStmt_(op);
     op = stmt.as<ForNode>();
-    int value = GetExtent(op);
+    int value = GetTripCount(op);
     // condition for auto unroll
     bool auto_unroll =
         (op->kind == ForKind::kSerial && value >= 0 &&
@@ -278,19 +278,21 @@ public:
   }
 
   Stmt Unroll(const ForNode *op) {
-    int value = GetExtent(op);
+    int value = GetTripCount(op);
     // For loop must have a constant integer extent
-    ICHECK_NE(value, -1) << "loop doesn't have a constant integer extent";
-    if (value == 0)
+    ICHECK_GE(value, 0) << "loop doesn't have a constant integer extent";
+    if (value <= 0)
       return Evaluate(0);
+    int step = GetStep(op);
     Stmt body = op->body;
     Map<Var, PrimExpr> vmap;
     Array<Stmt> unrolled;
     for (int i = 0; i < value; ++i) {
-      vmap.Set(op->loop_var, op->min + make_const(op->loop_var.dtype(), i));
-      Stmt step = Substitute(body, vmap);
-      step = UnrolledBodyDefFreshener()(std::move(step));
-      unrolled.push_back(step);
+      vmap.Set(op->loop_var,
+               op->min + make_const(op->loop_var.dtype(), i * step));
+      Stmt step_body = Substitute(body, vmap);
+      step_body = UnrolledBodyDefFreshener()(std::move(step_body));
+      unrolled.push_back(step_body);
     }
     return SeqStmt::Flatten(unrolled);
   }
@@ -309,6 +311,23 @@ private:
       value = static_cast<int>(v1->value);
     }
     return value;
+  }
+
+  // returns the step of the loop
+  int GetStep(const ForNode *op) {
+    if (!op->step.defined()) {
+      return 1;
+    }
+    auto *step = as_const_int(op->step.value());
+    ICHECK(step) << "An loop's step must be constant";
+    return *step;
+  }
+
+  // returns the trip count of the loop
+  int GetTripCount(const ForNode *op) {
+    int extent = GetExtent(op);
+    int step = GetStep(op);
+    return (extent + step - 1) / step;
   }
 
   // maximum number of step to perform auto unroll.

--- a/testing/python/transform/test_tilelang_transform_preserve_loop_step.py
+++ b/testing/python/transform/test_tilelang_transform_preserve_loop_step.py
@@ -1,3 +1,5 @@
+import pytest
+
 import numpy as np
 
 import tilelang as tl
@@ -30,4 +32,37 @@ def test_lower_opaque_block_preserves_non_unit_loop_step():
     np.testing.assert_array_equal(
         output.numpy(),
         np.array([0, 1, 0, 1, 0, 1], dtype="int32"),
+    )
+
+
+@pytest.mark.parametrize("rng", [(0, 6, 2), (0, 5, 2)], ids=lambda v: f"rng=({v[0]},{v[1]},{v[2]})")
+@pytest.mark.parametrize("explicit", [False, True], ids=lambda v: f"explicit={v}")
+def test_unroll_loop_preserves_non_unit_loop_step(rng, explicit):
+    output_buffer = tvm.tirx.decl_buffer((8,), "int32", name="output")
+    i = tvm.tirx.Var("i", "int32")
+    start, stop, step = rng
+    loop = tvm.tirx.For(
+        i,
+        start,
+        stop,
+        tvm.tirx.ForKind.UNROLLED,
+        tvm.tirx.BufferStore(output_buffer, i, [i]),
+        step=tvm.tirx.IntImm("int32", step),
+        annotations={"pragma_unroll_explicit": explicit},
+    )
+    before = tvm.tirx.PrimFunc(
+        [output_buffer.data],
+        loop,
+        buffer_map={output_buffer.data: output_buffer},
+    ).with_attr("global_symbol", "main")
+
+    mod = tl.transform.UnrollLoop()(tvm.IRModule.from_expr(before))
+    executable = tvm.compile(mod["main"], target="c").jit(options=["-std=c++17"])
+
+    output = tvm.runtime.tensor(np.zeros(8, dtype="int32"))
+    executable["main"](output)
+
+    np.testing.assert_array_equal(
+        output.numpy(),
+        np.array([0, 0, 2, 0, 4, 0, 0, 0], dtype="int32"),
     )


### PR DESCRIPTION
Corrected version of #2784

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed loop unrolling to preserve non-unit loop steps.
- Computed loop trip counts from the loop extent and constant step.
- Substituted unrolled loop variables using `i * step`.
- Added parametrized regression tests for explicit and implicit unrolling across multiple ranges.

## C++ style / lint notes

- The PR changes C++ implementation code.
- It does not change the rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) CI step may report advisory findings. These warnings are separate from correctness, build, and test results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->