### PR TITLE
[CUDA] Adopt multi-staged buffers in examples

### DIFF
--- a/examples/deepseek_mla/example_mla_decode_ws.py
+++ b/examples/deepseek_mla/example_mla_decode_ws.py
@@ -88,7 +88,7 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
                 T.barrier_wait(bar_q, 0)
 
                 for i_i in T.serial(T.ceildiv(NI, num_stages)):
-                    for stage in T.unroll(num_stages, explicit=True):
+                    for stage in T.unroll(num_stages):
                         T.barrier_wait(bar_k_ready[stage], (i_i & 1))
 
                         T.clear(acc_s)
@@ -138,7 +138,7 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
                 T.set_max_nreg(168, 1)
                 T.fill(acc_o_r, 0)
                 for i_i in T.serial(T.ceildiv(NI, num_stages)):
-                    for stage in T.unroll(num_stages, explicit=True):
+                    for stage in T.unroll(num_stages):
                         T.barrier_arrive(bar_sScale_and_sS_ready)
                         T.barrier_wait(bar_sScale_and_sS_ready, ((i_i * num_stages + stage) & 1))
                         for h_i, d_i in T.Parallel(block_H, dim // 2):
@@ -159,7 +159,7 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
                 # producer
                 T.set_max_nreg(80, 0)
                 for i_i in T.serial(T.ceildiv(NI, num_stages)):
-                    for stage in T.unroll(num_stages, explicit=True):
+                    for stage in T.unroll(num_stages):
                         T.barrier_wait(bar_k_free[stage], ((i_i & 1) ^ 1))
                         for r in T.serial(4):
                             kv_indices = (seqlen_kv // num_split) * bz + (i_i * num_stages + stage) * block_N + r * 16 + (tx - 256) // 8
@@ -269,7 +269,7 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
                 T.barrier_wait(bar_q, 0)
 
                 for i_i in T.serial(T.ceildiv(NI, num_stages)):
-                    for stage in T.unroll(num_stages, explicit=True):
+                    for stage in T.unroll(num_stages):
                         T.barrier_wait(bar_k_ready[stage], (i_i & 1))
 
                         T.clear(acc_s)
@@ -318,7 +318,7 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
                 T.set_max_nreg(168, 1)
                 T.fill(acc_o_r, 0)
                 for i_i in T.serial(T.ceildiv(NI, num_stages)):
-                    for stage in T.unroll(num_stages, explicit=True):
+                    for stage in T.unroll(num_stages):
                         T.barrier_arrive(bar_sScale_and_sS_ready)
                         T.barrier_wait(bar_sScale_and_sS_ready, ((i_i * num_stages + stage) & 1))
                         for h_i, d_i in T.Parallel(block_H, dim // 2):
@@ -339,7 +339,7 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
                 # producer
                 T.set_max_nreg(80, 0)
                 for i_i in T.serial(T.ceildiv(NI, num_stages)):
-                    for stage in T.unroll(num_stages, explicit=True):
+                    for stage in T.unroll(num_stages):
                         T.barrier_wait(bar_k_free[stage], ((i_i & 1) ^ 1))
                         for r in T.serial(4):
                             kv_indices = (i_i * num_stages + stage) * block_N + r * 16 + (tx - 256) // 8

--- a/examples/deepseek_mla/example_mla_decode_ws.py
+++ b/examples/deepseek_mla/example_mla_decode_ws.py
@@ -31,6 +31,7 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
     accum_dtype = T.float32
     kv_group_num = heads // kv_head_num
     VALID_BLOCK_H = min(block_H, kv_group_num)
+    num_stages = 2
     assert kv_head_num == 1, "kv_head_num must be 1"
 
     @T.prim_func
@@ -45,17 +46,11 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
     ):
         # flash_attn_split
         with T.Kernel(batch, heads // min(block_H, kv_group_num), num_split, threads=384) as (bid, hid, bz):
-            Q_shared_l = T.alloc_shared([block_H, dim // 2], dtype)
-            Q_shared_r = T.alloc_shared([block_H, dim // 2], dtype)
+            Q_shared = T.alloc_shared([block_H, dim], dtype)
             Q_tail_shared = T.alloc_shared([block_H, pe_dim], dtype)
-            KV_shared_0_l = T.alloc_shared([block_N, dim // 2], dtype)
-            KV_shared_0_r = T.alloc_shared([block_N, dim // 2], dtype)
-            KV_shared_1_l = T.alloc_shared([block_N, dim // 2], dtype)
-            KV_shared_1_r = T.alloc_shared([block_N, dim // 2], dtype)
-            K_tail_shared_0 = T.alloc_shared([block_N, pe_dim], dtype)
-            K_tail_shared_1 = T.alloc_shared([block_N, pe_dim], dtype)
-            O_shared_l = Q_shared_l
-            O_shared_r = Q_shared_r
+            KV_shared = T.alloc_shared([num_stages, block_N, dim], dtype)
+            K_tail_shared = T.alloc_shared([num_stages, block_N, pe_dim], dtype)
+            O_shared = Q_shared
 
             acc_o_l = T.alloc_fragment([block_H, dim // 2], accum_dtype)
             acc_o_r = T.alloc_fragment([block_H, dim // 2], accum_dtype)
@@ -69,12 +64,9 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
             m_i = T.alloc_fragment([block_H], accum_dtype)
             m_i_prev = T.alloc_fragment([block_H], accum_dtype)
 
-            # TODO: Multi buffer
             bar_q = T.alloc_barrier(arrive_count=384)
-            bar_k_0_ready = T.alloc_barrier(arrive_count=128)
-            bar_k_1_ready = T.alloc_barrier(arrive_count=128)
-            bar_k_0_free = T.alloc_barrier(arrive_count=256)
-            bar_k_1_free = T.alloc_barrier(arrive_count=256)
+            bar_k_ready = T.alloc_barrier(arrive_count=[128] * num_stages)
+            bar_k_free = T.alloc_barrier(arrive_count=[256] * num_stages)
             bar_sScale_and_sS_ready = T.alloc_barrier(arrive_count=256)
             bar_sScale_and_sS_free = T.alloc_barrier(arrive_count=256)
 
@@ -83,8 +75,7 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
 
             tx = T.get_thread_binding()
 
-            T.copy(Q[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, 0 : dim // 2], Q_shared_l)
-            T.copy(Q[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, dim // 2 : dim], Q_shared_r)
+            T.copy(Q[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, :], Q_shared)
             T.copy(Q_pe[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, :], Q_tail_shared)
 
             T.barrier_arrive(bar_q)
@@ -96,75 +87,41 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
                 T.fill(acc_o_l, 0)
                 T.barrier_wait(bar_q, 0)
 
-                for i_i in T.serial(T.ceildiv(NI, 2)):
-                    # Buffer 0
-                    T.barrier_wait(bar_k_0_ready[0], (i_i & 1))
+                for i_i in T.serial(T.ceildiv(NI, num_stages)):
+                    for stage in T.unroll(num_stages, explicit=True):
+                        T.barrier_wait(bar_k_ready[stage], (i_i & 1))
 
-                    T.clear(acc_s)
-                    T.wgmma_gemm(Q_shared_l, KV_shared_0_l, acc_s, transpose_B=True)
-                    T.wgmma_gemm(Q_shared_r, KV_shared_0_r, acc_s, transpose_B=True)
-                    T.wgmma_gemm(Q_tail_shared, K_tail_shared_0, acc_s, transpose_B=True)
+                        T.clear(acc_s)
+                        T.wgmma_gemm(Q_shared[:, : dim // 2], KV_shared[stage, :, : dim // 2], acc_s, transpose_B=True)
+                        T.wgmma_gemm(Q_shared[:, dim // 2 :], KV_shared[stage, :, dim // 2 :], acc_s, transpose_B=True)
+                        T.wgmma_gemm(Q_tail_shared, K_tail_shared[stage, :, :], acc_s, transpose_B=True)
 
-                    T.wait_wgmma(0)
+                        T.wait_wgmma(0)
 
-                    if i_i != 0:
-                        T.barrier_arrive(bar_sScale_and_sS_free)
-                        T.barrier_wait(bar_sScale_and_sS_free, ((i_i * 2) & 1) ^ 1)
+                        if i_i != 0 or stage != 0:
+                            T.barrier_arrive(bar_sScale_and_sS_free)
+                            T.barrier_wait(bar_sScale_and_sS_free, ((i_i * num_stages + stage) & 1) ^ 1)
 
-                    T.copy(m_i, m_i_prev)
-                    T.reduce_max(acc_s, m_i, dim=1, clear=False)
-                    for h_i in T.Parallel(block_H):
-                        m_i[h_i] = T.max(m_i[h_i], m_i_prev[h_i])
-                    for h_i in T.Parallel(block_H):
-                        alpha_local[h_i] = T.exp2((m_i_prev[h_i] - m_i[h_i]) * sm_scale)
-                    for h_i, bi_i in T.Parallel(block_H, block_N):
-                        acc_s[h_i, bi_i] = T.exp2(acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale)
-                    T.reduce_sum(acc_s, sumexp_i, dim=1)  # is this a accumulate operator?
-                    for h_i in T.Parallel(block_H):
-                        sumexp[h_i] = sumexp[h_i] * alpha_local[h_i] + sumexp_i[h_i]
-                    for h_i, d_i in T.Parallel(block_H, dim // 2):
-                        acc_o_l[h_i, d_i] *= alpha_local[h_i]
-                    T.copy(alpha_local, alpha_shared)
+                        T.copy(m_i, m_i_prev)
+                        T.reduce_max(acc_s, m_i, dim=1, clear=False)
+                        for h_i in T.Parallel(block_H):
+                            m_i[h_i] = T.max(m_i[h_i], m_i_prev[h_i])
+                        for h_i in T.Parallel(block_H):
+                            alpha_local[h_i] = T.exp2((m_i_prev[h_i] - m_i[h_i]) * sm_scale)
+                        for h_i, bi_i in T.Parallel(block_H, block_N):
+                            acc_s[h_i, bi_i] = T.exp2(acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale)
+                        T.reduce_sum(acc_s, sumexp_i, dim=1)  # is this a accumulate operator?
+                        for h_i in T.Parallel(block_H):
+                            sumexp[h_i] = sumexp[h_i] * alpha_local[h_i] + sumexp_i[h_i]
+                        for h_i, d_i in T.Parallel(block_H, dim // 2):
+                            acc_o_l[h_i, d_i] *= alpha_local[h_i]
+                        T.copy(alpha_local, alpha_shared)
 
-                    T.copy(acc_s, S_shared)
-                    T.gemm(S_shared, KV_shared_0_l, acc_o_l)
+                        T.copy(acc_s, S_shared)
+                        T.gemm(S_shared, KV_shared[stage, :, : dim // 2], acc_o_l)
 
-                    T.barrier_arrive(bar_sScale_and_sS_ready)
-                    T.barrier_arrive(bar_k_0_free[0])
-
-                    # Buffer 1
-                    T.barrier_wait(bar_k_1_ready[0], (i_i & 1))
-
-                    T.clear(acc_s)
-                    T.wgmma_gemm(Q_shared_l, KV_shared_1_l, acc_s, transpose_B=True)
-                    T.wgmma_gemm(Q_shared_r, KV_shared_1_r, acc_s, transpose_B=True)
-                    T.wgmma_gemm(Q_tail_shared, K_tail_shared_1, acc_s, transpose_B=True)
-
-                    T.wait_wgmma(0)
-
-                    T.barrier_arrive(bar_sScale_and_sS_free)
-                    T.barrier_wait(bar_sScale_and_sS_free, ((i_i * 2 + 1) & 1) ^ 1)
-
-                    T.copy(m_i, m_i_prev)
-                    T.reduce_max(acc_s, m_i, dim=1, clear=False)
-                    for h_i in T.Parallel(block_H):
-                        m_i[h_i] = T.max(m_i[h_i], m_i_prev[h_i])
-                    for h_i in T.Parallel(block_H):
-                        alpha_local[h_i] = T.exp2((m_i_prev[h_i] - m_i[h_i]) * sm_scale)
-                    for h_i, bi_i in T.Parallel(block_H, block_N):
-                        acc_s[h_i, bi_i] = T.exp2(acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale)
-                    T.reduce_sum(acc_s, sumexp_i, dim=1)  # is this a accumulate operator?
-                    for h_i in T.Parallel(block_H):
-                        sumexp[h_i] = sumexp[h_i] * alpha_local[h_i] + sumexp_i[h_i]
-                    for h_i, d_i in T.Parallel(block_H, dim // 2):
-                        acc_o_l[h_i, d_i] *= alpha_local[h_i]
-                    T.copy(alpha_local, alpha_shared)
-
-                    T.copy(acc_s, S_shared)
-                    T.gemm(S_shared, KV_shared_1_l, acc_o_l)
-
-                    T.barrier_arrive(bar_sScale_and_sS_ready)
-                    T.barrier_arrive(bar_k_1_free[0])
+                        T.barrier_arrive(bar_sScale_and_sS_ready)
+                        T.barrier_arrive(bar_k_free[stage])
 
                 # Rescale
                 for h_i in T.Parallel(block_H):
@@ -173,87 +130,63 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
                     acc_o_l[h_i, d_i] /= sumexp[h_i]
                 for h_i in T.Parallel(block_H):
                     sumexp[h_i] = T.log2(sumexp[h_i]) + m_i[h_i] * sm_scale
-                T.copy(acc_o_l, O_shared_l)
-                T.copy(O_shared_l, Output_partial[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, bz, 0 : dim // 2])
+                T.copy(acc_o_l, O_shared[:, : dim // 2])
+                T.copy(O_shared[:, : dim // 2], Output_partial[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, bz, 0 : dim // 2])
                 T.copy(sumexp, glse[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, bz])
 
             elif tx >= 128 and tx < 256:
                 T.set_max_nreg(168, 1)
                 T.fill(acc_o_r, 0)
-                for i_i in T.serial(T.ceildiv(NI, 2)):
-                    # Buffer 0
-                    T.barrier_arrive(bar_sScale_and_sS_ready)
-                    T.barrier_wait(bar_sScale_and_sS_ready, ((i_i * 2) & 1))
-                    for h_i, d_i in T.Parallel(block_H, dim // 2):
-                        acc_o_r[h_i, d_i] *= alpha_shared[h_i]
-                    T.gemm(S_shared, KV_shared_0_r, acc_o_r)
-                    T.barrier_arrive(bar_k_0_free[0])
-                    T.barrier_arrive(bar_sScale_and_sS_free)
-
-                    # Buffer 1
-                    T.barrier_arrive(bar_sScale_and_sS_ready)
-                    T.barrier_wait(bar_sScale_and_sS_ready, ((i_i * 2 + 1) & 1))
-                    for h_i, d_i in T.Parallel(block_H, dim // 2):
-                        acc_o_r[h_i, d_i] *= alpha_shared[h_i]
-                    T.gemm(S_shared, KV_shared_1_r, acc_o_r)
-                    T.barrier_arrive(bar_k_1_free[0])
-                    if i_i != T.ceildiv(NI, 2) - 1:
-                        T.barrier_arrive(bar_sScale_and_sS_free)
+                for i_i in T.serial(T.ceildiv(NI, num_stages)):
+                    for stage in T.unroll(num_stages, explicit=True):
+                        T.barrier_arrive(bar_sScale_and_sS_ready)
+                        T.barrier_wait(bar_sScale_and_sS_ready, ((i_i * num_stages + stage) & 1))
+                        for h_i, d_i in T.Parallel(block_H, dim // 2):
+                            acc_o_r[h_i, d_i] *= alpha_shared[h_i]
+                        T.gemm(S_shared, KV_shared[stage, :, dim // 2 :], acc_o_r)
+                        T.barrier_arrive(bar_k_free[stage])
+                        if stage != num_stages - 1 or i_i != T.ceildiv(NI, num_stages) - 1:
+                            T.barrier_arrive(bar_sScale_and_sS_free)
 
                 # Rescale
                 for h_i, d_i in T.Parallel(block_H, dim // 2):
                     acc_o_r[h_i, d_i] /= sum_exp_shared[h_i]
 
-                T.copy(acc_o_r, O_shared_r)
-                T.copy(O_shared_r, Output_partial[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, bz, dim // 2 : dim])
+                T.copy(acc_o_r, O_shared[:, dim // 2 :])
+                T.copy(O_shared[:, dim // 2 :], Output_partial[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, bz, dim // 2 : dim])
 
             elif tx >= 256:
                 # producer
                 T.set_max_nreg(80, 0)
-                for i_i in T.serial(T.ceildiv(NI, 2)):
-                    # Buffer 0
-                    T.barrier_wait(bar_k_0_free[0], ((i_i & 1) ^ 1))
-                    for r in T.serial(4):
-                        kv_indices = (seqlen_kv // num_split) * bz + (i_i * 2) * block_N + r * 16 + (tx - 256) // 8
-                        for u in T.serial(4):
+                for i_i in T.serial(T.ceildiv(NI, num_stages)):
+                    for stage in T.unroll(num_stages, explicit=True):
+                        T.barrier_wait(bar_k_free[stage], ((i_i & 1) ^ 1))
+                        for r in T.serial(4):
+                            kv_indices = (seqlen_kv // num_split) * bz + (i_i * num_stages + stage) * block_N + r * 16 + (tx - 256) // 8
+                            for u in T.serial(dim // 64):
+                                T.ptx_cp_async(
+                                    T.access_ptr(
+                                        KV_shared[
+                                            stage,
+                                            r * 16 + (tx - 256) // 8,
+                                            64 * u + (tx - 256) % 8 * 8,
+                                        ],
+                                        "w",
+                                        8,
+                                    ),
+                                    T.access_ptr(KV[bid, kv_indices, cur_kv_head, 64 * u + (tx - 256) % 8 * 8], "r", 8),
+                                    8,
+                                )
                             T.ptx_cp_async(
-                                T.access_ptr(KV_shared_0_l[r * 16 + (tx - 256) // 8, 64 * u + (tx - 256) % 8 * 8], "w", 8),
-                                T.access_ptr(KV[bid, kv_indices, cur_kv_head, 64 * u + (tx - 256) % 8 * 8], "r", 8),
+                                T.access_ptr(
+                                    K_tail_shared[stage, r * 16 + (tx - 256) // 8, (tx - 256) % 8 * 8],
+                                    "w",
+                                    8,
+                                ),
+                                T.access_ptr(K_pe[bid, kv_indices, cur_kv_head, (tx - 256) % 8 * 8], "r", 8),
                                 8,
                             )
-                            T.ptx_cp_async(
-                                T.access_ptr(KV_shared_0_r[r * 16 + (tx - 256) // 8, 64 * u + (tx - 256) % 8 * 8], "w", 8),
-                                T.access_ptr(KV[bid, kv_indices, cur_kv_head, dim // 2 + 64 * u + (tx - 256) % 8 * 8], "r", 8),
-                                8,
-                            )
-                        T.ptx_cp_async(
-                            T.access_ptr(K_tail_shared_0[r * 16 + (tx - 256) // 8, (tx - 256) % 8 * 8], "w", 8),
-                            T.access_ptr(K_pe[bid, kv_indices, cur_kv_head, (tx - 256) % 8 * 8], "r", 8),
-                            8,
-                        )
-                    T.cp_async_barrier_noinc(bar_k_0_ready[0])
-
-                    # Buffer 1
-                    T.barrier_wait(bar_k_1_free[0], ((i_i & 1) ^ 1))
-                    for r in T.serial(4):
-                        kv_indices = (seqlen_kv // num_split) * bz + (i_i * 2 + 1) * block_N + r * 16 + (tx - 256) // 8
-                        for u in T.serial(4):
-                            T.ptx_cp_async(
-                                T.access_ptr(KV_shared_1_l[r * 16 + (tx - 256) // 8, 64 * u + (tx - 256) % 8 * 8], "w", 8),
-                                T.access_ptr(KV[bid, kv_indices, cur_kv_head, 64 * u + (tx - 256) % 8 * 8], "r", 8),
-                                8,
-                            )
-                            T.ptx_cp_async(
-                                T.access_ptr(KV_shared_1_r[r * 16 + (tx - 256) // 8, 64 * u + (tx - 256) % 8 * 8], "w", 8),
-                                T.access_ptr(KV[bid, kv_indices, cur_kv_head, dim // 2 + 64 * u + (tx - 256) % 8 * 8], "r", 8),
-                                8,
-                            )
-                        T.ptx_cp_async(
-                            T.access_ptr(K_tail_shared_1[r * 16 + (tx - 256) // 8, (tx - 256) % 8 * 8], "w", 8),
-                            T.access_ptr(K_pe[bid, kv_indices, cur_kv_head, (tx - 256) % 8 * 8], "r", 8),
-                            8,
-                        )
-                    T.cp_async_barrier_noinc(bar_k_1_ready[0])
+                        T.cp_async_barrier_noinc(bar_k_ready[stage])
 
         # combine
         with T.Kernel(heads, batch, threads=128) as (hid, bz):
@@ -294,17 +227,11 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
         Output: T.Tensor([batch, heads, dim], dtype),
     ):
         with T.Kernel(heads // min(block_H, kv_group_num), batch, threads=384) as (hid, bid):
-            Q_shared_l = T.alloc_shared([block_H, dim // 2], dtype)
-            Q_shared_r = T.alloc_shared([block_H, dim // 2], dtype)
+            Q_shared = T.alloc_shared([block_H, dim], dtype)
             Q_tail_shared = T.alloc_shared([block_H, pe_dim], dtype)
-            KV_shared_0_l = T.alloc_shared([block_N, dim // 2], dtype)
-            KV_shared_0_r = T.alloc_shared([block_N, dim // 2], dtype)
-            KV_shared_1_l = T.alloc_shared([block_N, dim // 2], dtype)
-            KV_shared_1_r = T.alloc_shared([block_N, dim // 2], dtype)
-            K_tail_shared_0 = T.alloc_shared([block_N, pe_dim], dtype)
-            K_tail_shared_1 = T.alloc_shared([block_N, pe_dim], dtype)
-            O_shared_l = Q_shared_l
-            O_shared_r = Q_shared_r
+            KV_shared = T.alloc_shared([num_stages, block_N, dim], dtype)
+            K_tail_shared = T.alloc_shared([num_stages, block_N, pe_dim], dtype)
+            O_shared = Q_shared
 
             acc_o_l = T.alloc_fragment([block_H, dim // 2], accum_dtype)
             acc_o_r = T.alloc_fragment([block_H, dim // 2], accum_dtype)
@@ -318,12 +245,9 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
             m_i = T.alloc_fragment([block_H], accum_dtype)
             m_i_prev = T.alloc_fragment([block_H], accum_dtype)
 
-            # TODO: Multi buffer
             bar_q = T.alloc_barrier(arrive_count=384)
-            bar_k_0_ready = T.alloc_barrier(arrive_count=128)
-            bar_k_1_ready = T.alloc_barrier(arrive_count=128)
-            bar_k_0_free = T.alloc_barrier(arrive_count=256)
-            bar_k_1_free = T.alloc_barrier(arrive_count=256)
+            bar_k_ready = T.alloc_barrier(arrive_count=[128] * num_stages)
+            bar_k_free = T.alloc_barrier(arrive_count=[256] * num_stages)
             bar_sScale_and_sS_ready = T.alloc_barrier(arrive_count=256)
             bar_sScale_and_sS_free = T.alloc_barrier(arrive_count=256)
 
@@ -332,8 +256,7 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
 
             tx = T.get_thread_binding()
 
-            T.copy(Q[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, 0 : dim // 2], Q_shared_l)
-            T.copy(Q[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, dim // 2 : dim], Q_shared_r)
+            T.copy(Q[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, :], Q_shared)
             T.copy(Q_pe[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, :], Q_tail_shared)
 
             T.barrier_arrive(bar_q)
@@ -345,75 +268,41 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
                 T.fill(acc_o_l, 0)
                 T.barrier_wait(bar_q, 0)
 
-                for i_i in T.serial(T.ceildiv(NI, 2)):
-                    # Buffer 0
-                    T.barrier_wait(bar_k_0_ready[0], (i_i & 1))
+                for i_i in T.serial(T.ceildiv(NI, num_stages)):
+                    for stage in T.unroll(num_stages, explicit=True):
+                        T.barrier_wait(bar_k_ready[stage], (i_i & 1))
 
-                    T.clear(acc_s)
-                    T.wgmma_gemm(Q_shared_l, KV_shared_0_l, acc_s, transpose_B=True)
-                    T.wgmma_gemm(Q_shared_r, KV_shared_0_r, acc_s, transpose_B=True)
-                    T.wgmma_gemm(Q_tail_shared, K_tail_shared_0, acc_s, transpose_B=True)
+                        T.clear(acc_s)
+                        T.wgmma_gemm(Q_shared[:, : dim // 2], KV_shared[stage, :, : dim // 2], acc_s, transpose_B=True)
+                        T.wgmma_gemm(Q_shared[:, dim // 2 :], KV_shared[stage, :, dim // 2 :], acc_s, transpose_B=True)
+                        T.wgmma_gemm(Q_tail_shared, K_tail_shared[stage, :, :], acc_s, transpose_B=True)
 
-                    T.wait_wgmma(0)
+                        T.wait_wgmma(0)
 
-                    if i_i != 0:
-                        T.barrier_arrive(bar_sScale_and_sS_free)
-                        T.barrier_wait(bar_sScale_and_sS_free, ((i_i * 2) & 1) ^ 1)
+                        if i_i != 0 or stage != 0:
+                            T.barrier_arrive(bar_sScale_and_sS_free)
+                            T.barrier_wait(bar_sScale_and_sS_free, ((i_i * num_stages + stage) & 1) ^ 1)
 
-                    T.copy(m_i, m_i_prev)
-                    T.reduce_max(acc_s, out=m_i, dim=1, clear=False)
-                    for h_i in T.Parallel(block_H):
-                        m_i[h_i] = T.max(m_i[h_i], m_i_prev[h_i])
-                    for h_i in T.Parallel(block_H):
-                        alpha_local[h_i] = T.exp2((m_i_prev[h_i] - m_i[h_i]) * sm_scale)
-                    for h_i, bi_i in T.Parallel(block_H, block_N):
-                        acc_s[h_i, bi_i] = T.exp2(acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale)
-                    T.reduce_sum(acc_s, sumexp_i, dim=1)  # is this a accumulate operator?
-                    for h_i in T.Parallel(block_H):
-                        sumexp[h_i] = sumexp[h_i] * alpha_local[h_i] + sumexp_i[h_i]
-                    for h_i, d_i in T.Parallel(block_H, dim // 2):
-                        acc_o_l[h_i, d_i] *= alpha_local[h_i]
-                    T.copy(alpha_local, alpha_shared)
+                        T.copy(m_i, m_i_prev)
+                        T.reduce_max(acc_s, m_i, dim=1, clear=False)
+                        for h_i in T.Parallel(block_H):
+                            m_i[h_i] = T.max(m_i[h_i], m_i_prev[h_i])
+                        for h_i in T.Parallel(block_H):
+                            alpha_local[h_i] = T.exp2((m_i_prev[h_i] - m_i[h_i]) * sm_scale)
+                        for h_i, bi_i in T.Parallel(block_H, block_N):
+                            acc_s[h_i, bi_i] = T.exp2(acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale)
+                        T.reduce_sum(acc_s, sumexp_i, dim=1)  # is this a accumulate operator?
+                        for h_i in T.Parallel(block_H):
+                            sumexp[h_i] = sumexp[h_i] * alpha_local[h_i] + sumexp_i[h_i]
+                        for h_i, d_i in T.Parallel(block_H, dim // 2):
+                            acc_o_l[h_i, d_i] *= alpha_local[h_i]
+                        T.copy(alpha_local, alpha_shared)
 
-                    T.copy(acc_s, S_shared)
-                    T.gemm(S_shared, KV_shared_0_l, acc_o_l)
+                        T.copy(acc_s, S_shared)
+                        T.gemm(S_shared, KV_shared[stage, :, : dim // 2], acc_o_l)
 
-                    T.barrier_arrive(bar_sScale_and_sS_ready)
-                    T.barrier_arrive(bar_k_0_free[0])
-
-                    # Buffer 1
-                    T.barrier_wait(bar_k_1_ready[0], (i_i & 1))
-
-                    T.clear(acc_s)
-                    T.wgmma_gemm(Q_shared_l, KV_shared_1_l, acc_s, transpose_B=True)
-                    T.wgmma_gemm(Q_shared_r, KV_shared_1_r, acc_s, transpose_B=True)
-                    T.wgmma_gemm(Q_tail_shared, K_tail_shared_1, acc_s, transpose_B=True)
-
-                    T.wait_wgmma(0)
-
-                    T.barrier_arrive(bar_sScale_and_sS_free)
-                    T.barrier_wait(bar_sScale_and_sS_free, ((i_i * 2 + 1) & 1) ^ 1)
-
-                    T.copy(m_i, m_i_prev)
-                    T.reduce_max(acc_s, m_i, dim=1, clear=False)
-                    for h_i in T.Parallel(block_H):
-                        m_i[h_i] = T.max(m_i[h_i], m_i_prev[h_i])
-                    for h_i in T.Parallel(block_H):
-                        alpha_local[h_i] = T.exp2((m_i_prev[h_i] - m_i[h_i]) * sm_scale)
-                    for h_i, bi_i in T.Parallel(block_H, block_N):
-                        acc_s[h_i, bi_i] = T.exp2(acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale)
-                    T.reduce_sum(acc_s, sumexp_i, dim=1)  # is this a accumulate operator?
-                    for h_i in T.Parallel(block_H):
-                        sumexp[h_i] = sumexp[h_i] * alpha_local[h_i] + sumexp_i[h_i]
-                    for h_i, d_i in T.Parallel(block_H, dim // 2):
-                        acc_o_l[h_i, d_i] *= alpha_local[h_i]
-                    T.copy(alpha_local, alpha_shared)
-
-                    T.copy(acc_s, S_shared)
-                    T.gemm(S_shared, KV_shared_1_l, acc_o_l)
-
-                    T.barrier_arrive(bar_sScale_and_sS_ready)
-                    T.barrier_arrive(bar_k_1_free[0])
+                        T.barrier_arrive(bar_sScale_and_sS_ready)
+                        T.barrier_arrive(bar_k_free[stage])
 
                 # Rescale
                 for h_i in T.Parallel(block_H):
@@ -422,86 +311,62 @@ def flashattn(batch, heads, kv_head_num, seqlen_kv, dim, pe_dim, block_N, block_
                     acc_o_l[h_i, d_i] /= sumexp[h_i]
                 for h_i in T.Parallel(block_H):
                     sumexp[h_i] = T.log2(sumexp[h_i]) + m_i[h_i] * sm_scale
-                T.copy(acc_o_l, O_shared_l)
-                T.copy(O_shared_l, Output[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, 0 : dim // 2])
+                T.copy(acc_o_l, O_shared[:, : dim // 2])
+                T.copy(O_shared[:, : dim // 2], Output[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, 0 : dim // 2])
 
             elif tx >= 128 and tx < 256:
                 T.set_max_nreg(168, 1)
                 T.fill(acc_o_r, 0)
-                for i_i in T.serial(T.ceildiv(NI, 2)):
-                    # Buffer 0
-                    T.barrier_arrive(bar_sScale_and_sS_ready)
-                    T.barrier_wait(bar_sScale_and_sS_ready, ((i_i * 2) & 1))
-                    for h_i, d_i in T.Parallel(block_H, dim // 2):
-                        acc_o_r[h_i, d_i] *= alpha_shared[h_i]
-                    T.gemm(S_shared, KV_shared_0_r, acc_o_r)
-                    T.barrier_arrive(bar_k_0_free[0])
-                    T.barrier_arrive(bar_sScale_and_sS_free)
-
-                    # Buffer 1
-                    T.barrier_arrive(bar_sScale_and_sS_ready)
-                    T.barrier_wait(bar_sScale_and_sS_ready, ((i_i * 2 + 1) & 1))
-                    for h_i, d_i in T.Parallel(block_H, dim // 2):
-                        acc_o_r[h_i, d_i] *= alpha_shared[h_i]
-                    T.gemm(S_shared, KV_shared_1_r, acc_o_r)
-                    T.barrier_arrive(bar_k_1_free[0])
-                    if i_i != T.ceildiv(NI, 2) - 1:
-                        T.barrier_arrive(bar_sScale_and_sS_free)
+                for i_i in T.serial(T.ceildiv(NI, num_stages)):
+                    for stage in T.unroll(num_stages, explicit=True):
+                        T.barrier_arrive(bar_sScale_and_sS_ready)
+                        T.barrier_wait(bar_sScale_and_sS_ready, ((i_i * num_stages + stage) & 1))
+                        for h_i, d_i in T.Parallel(block_H, dim // 2):
+                            acc_o_r[h_i, d_i] *= alpha_shared[h_i]
+                        T.gemm(S_shared, KV_shared[stage, :, dim // 2 :], acc_o_r)
+                        T.barrier_arrive(bar_k_free[stage])
+                        if stage != num_stages - 1 or i_i != T.ceildiv(NI, num_stages) - 1:
+                            T.barrier_arrive(bar_sScale_and_sS_free)
 
                 # Rescale
                 for h_i, d_i in T.Parallel(block_H, dim // 2):
                     acc_o_r[h_i, d_i] /= sum_exp_shared[h_i]
 
-                T.copy(acc_o_r, O_shared_r)
-                T.copy(O_shared_r, Output[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, dim // 2 : dim])
+                T.copy(acc_o_r, O_shared[:, dim // 2 :])
+                T.copy(O_shared[:, dim // 2 :], Output[bid, hid * VALID_BLOCK_H : (hid + 1) * VALID_BLOCK_H, dim // 2 : dim])
 
             elif tx >= 256:
                 # producer
                 T.set_max_nreg(80, 0)
-                for i_i in T.serial(T.ceildiv(NI, 2)):
-                    # Buffer 0
-                    T.barrier_wait(bar_k_0_free[0], ((i_i & 1) ^ 1))
-                    for r in T.serial(4):
-                        kv_indices = (i_i * 2) * block_N + r * 16 + (tx - 256) // 8
-                        for u in T.serial(4):
+                for i_i in T.serial(T.ceildiv(NI, num_stages)):
+                    for stage in T.unroll(num_stages, explicit=True):
+                        T.barrier_wait(bar_k_free[stage], ((i_i & 1) ^ 1))
+                        for r in T.serial(4):
+                            kv_indices = (i_i * num_stages + stage) * block_N + r * 16 + (tx - 256) // 8
+                            for u in T.serial(dim // 64):
+                                T.ptx_cp_async(
+                                    T.access_ptr(
+                                        KV_shared[
+                                            stage,
+                                            r * 16 + (tx - 256) // 8,
+                                            64 * u + (tx - 256) % 8 * 8,
+                                        ],
+                                        "w",
+                                        8,
+                                    ),
+                                    T.access_ptr(KV[bid, kv_indices, cur_kv_head, 64 * u + (tx - 256) % 8 * 8], "r", 8),
+                                    8,
+                                )
                             T.ptx_cp_async(
-                                T.access_ptr(KV_shared_0_l[r * 16 + (tx - 256) // 8, 64 * u + (tx - 256) % 8 * 8], "w", 8),
-                                T.access_ptr(KV[bid, kv_indices, cur_kv_head, 64 * u + (tx - 256) % 8 * 8], "r", 8),
+                                T.access_ptr(
+                                    K_tail_shared[stage, r * 16 + (tx - 256) // 8, (tx - 256) % 8 * 8],
+                                    "w",
+                                    8,
+                                ),
+                                T.access_ptr(K_pe[bid, kv_indices, cur_kv_head, (tx - 256) % 8 * 8], "r", 8),
                                 8,
                             )
-                            T.ptx_cp_async(
-                                T.access_ptr(KV_shared_0_r[r * 16 + (tx - 256) // 8, 64 * u + (tx - 256) % 8 * 8], "w", 8),
-                                T.access_ptr(KV[bid, kv_indices, cur_kv_head, dim // 2 + 64 * u + (tx - 256) % 8 * 8], "r", 8),
-                                8,
-                            )
-                        T.ptx_cp_async(
-                            T.access_ptr(K_tail_shared_0[r * 16 + (tx - 256) // 8, (tx - 256) % 8 * 8], "w", 8),
-                            T.access_ptr(K_pe[bid, kv_indices, cur_kv_head, (tx - 256) % 8 * 8], "r", 8),
-                            8,
-                        )
-                    T.cp_async_barrier_noinc(bar_k_0_ready[0])
-
-                    # Buffer 1
-                    T.barrier_wait(bar_k_1_free[0], ((i_i & 1) ^ 1))
-                    for r in T.serial(4):
-                        kv_indices = (i_i * 2 + 1) * block_N + r * 16 + (tx - 256) // 8
-                        for u in T.serial(4):
-                            T.ptx_cp_async(
-                                T.access_ptr(KV_shared_1_l[r * 16 + (tx - 256) // 8, 64 * u + (tx - 256) % 8 * 8], "w", 8),
-                                T.access_ptr(KV[bid, kv_indices, cur_kv_head, 64 * u + (tx - 256) % 8 * 8], "r", 8),
-                                8,
-                            )
-                            T.ptx_cp_async(
-                                T.access_ptr(KV_shared_1_r[r * 16 + (tx - 256) // 8, 64 * u + (tx - 256) % 8 * 8], "w", 8),
-                                T.access_ptr(KV[bid, kv_indices, cur_kv_head, dim // 2 + 64 * u + (tx - 256) % 8 * 8], "r", 8),
-                                8,
-                            )
-                        T.ptx_cp_async(
-                            T.access_ptr(K_tail_shared_1[r * 16 + (tx - 256) // 8, (tx - 256) % 8 * 8], "w", 8),
-                            T.access_ptr(K_pe[bid, kv_indices, cur_kv_head, (tx - 256) % 8 * 8], "r", 8),
-                            8,
-                        )
-                    T.cp_async_barrier_noinc(bar_k_1_ready[0])
+                        T.cp_async_barrier_noinc(bar_k_ready[stage])
 
     if num_split > 1:
         return main_split

--- a/examples/deepseek_v32/README.md
+++ b/examples/deepseek_v32/README.md
@@ -153,17 +153,17 @@ elif tx >= 256:
 The producer thread group (tx >= 256) uses double buffering with barriers to keep consumers fed:
 
 ```python
-# Producer alternates between two buffers
-for i_i in T.serial(T.ceildiv(NI, 2)):
-    # Buffer 0
-    T.barrier_wait(bar_k_0_free[0], ((i_i & 1) ^ 1))
-    # ... load KV into buffer 0
-    T.cp_async_barrier_noinc(bar_k_0_ready[0])
+num_stages = 2
+KV_shared = T.alloc_shared([num_stages, BI, D], dtype)
+bar_k_ready = T.alloc_barrier(arrive_count=[128] * num_stages)
+bar_k_free = T.alloc_barrier(arrive_count=[256] * num_stages)
 
-    # Buffer 1
-    T.barrier_wait(bar_k_1_free[0], ((i_i & 1) ^ 1))
-    # ... load KV into buffer 1
-    T.cp_async_barrier_noinc(bar_k_1_ready[0])
+# Producer alternates between slices of one multi-version buffer
+for i_i in T.serial(T.ceildiv(NI, num_stages)):
+    for stage in T.unroll(num_stages):
+        T.barrier_wait(bar_k_free[stage], ((i_i & 1) ^ 1))
+        # ... load KV into KV_shared[stage, :, :]
+        T.cp_async_barrier_noinc(bar_k_ready[stage])
 ```
 
 Consumer threads wait on barriers and process buffers as they become ready. This manual orchestration hides memory latency behind compute, which is why it outperforms the simpler auto-pipelined version. The output dimension is also split in half so that the two consumer groups can work in parallel on different parts of the matmul.

--- a/examples/deepseek_v32/sparse_mla_bwd.py
+++ b/examples/deepseek_v32/sparse_mla_bwd.py
@@ -146,8 +146,7 @@ def bwd(
     dKV: T.Tensor(k_shape, accum_dtype)
 
     with T.Kernel(S, B, kv_group * NH, threads=threads) as (s_i, by, bz):
-        Q_shared = T.alloc_shared([block_H, D], dtype)
-        Q_tail_shared = T.alloc_shared([block_H, D_tail], dtype)
+        Q_shared = T.alloc_shared([block_H, D + D_tail], dtype)
         KV_shared = T.alloc_shared([BS, D], dtype)
         KV_tail_shared = T.alloc_shared([BS, D_tail], dtype)
         dO_shared = T.alloc_shared([block_H, D], dtype)
@@ -169,8 +168,9 @@ def bwd(
 
         max_kv_i = s_i
 
-        T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, :D], Q_shared)
-        T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, D:], Q_tail_shared)
+        # TODO: merge the statements when the compiler has better support for non-power-of-2 extents.
+        T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, :D], Q_shared[:, :D])
+        T.copy(Q[by, s_i, bz * block_H : (bz + 1) * block_H, D:], Q_shared[:, D:])
         T.copy(dO[by, s_i, bz * block_H : (bz + 1) * block_H, :D], dO_shared)
 
         T.clear(acc_dq)
@@ -190,11 +190,11 @@ def bwd(
             for bi_i, d_i in T.Parallel(BS, D):
                 KV_shared[bi_i, d_i] = KV[by, Indices[by, s_i, bz // NH, i_i * BS + bi_i], bz // NH, d_i]
 
-            T.gemm(Q_shared, KV_shared, acc_p, transpose_B=True, policy=T.GemmWarpPolicy.FullCol)
+            T.gemm(Q_shared[:, :D], KV_shared, acc_p, transpose_B=True, policy=T.GemmWarpPolicy.FullCol)
 
             for bi_i, d_i in T.Parallel(BS, D_tail):
                 KV_tail_shared[bi_i, d_i] = KV[by, Indices[by, s_i, bz // NH, i_i * BS + bi_i], bz // NH, D + d_i]
-            T.gemm(Q_tail_shared, KV_tail_shared, acc_p, transpose_B=True, policy=T.GemmWarpPolicy.FullCol)
+            T.gemm(Q_shared[:, D:], KV_tail_shared, acc_p, transpose_B=True, policy=T.GemmWarpPolicy.FullCol)
 
             for h_i, bi_i in T.Parallel(block_H, BS):
                 acc_p[h_i, bi_i] = T.exp2(acc_p[h_i, bi_i] * sm_scale_mul_reciprocal_log2 - Lse[by, s_i, bz * block_H + h_i])
@@ -210,11 +210,11 @@ def bwd(
             T.gemm(dP_shared_cast, KV_shared, acc_dq, policy=T.GemmWarpPolicy.FullCol)
             T.gemm(dP_shared_cast, KV_tail_shared, acc_dq_tail, policy=T.GemmWarpPolicy.FullCol)
 
-            T.gemm(dP_shared_cast, Q_shared, acc_dkv, transpose_A=True, policy=T.GemmWarpPolicy.FullCol, clear_accum=True)
+            T.gemm(dP_shared_cast, Q_shared[:, :D], acc_dkv, transpose_A=True, policy=T.GemmWarpPolicy.FullCol, clear_accum=True)
             T.gemm(P_shared_cast, dO_shared, acc_dkv, transpose_A=True, policy=T.GemmWarpPolicy.FullCol)
 
             T.clear(acc_dkv_tail)
-            T.gemm(dP_shared_cast, Q_tail_shared, acc_dkv_tail, transpose_A=True, policy=T.GemmWarpPolicy.FullCol)
+            T.gemm(dP_shared_cast, Q_shared[:, D:], acc_dkv_tail, transpose_A=True, policy=T.GemmWarpPolicy.FullCol)
 
             for s in range(split_store):
                 for bi_i, d_i in T.Parallel(BS, D):

--- a/examples/deepseek_v32/sparse_mla_fwd.py
+++ b/examples/deepseek_v32/sparse_mla_fwd.py
@@ -82,12 +82,9 @@ def sparse_mla_fwd(
         by,
         bz,
     ):
-        Q_shared = T.alloc_shared([H_per_block, D], dtype)
-        Q_tail_shared = T.alloc_shared([H_per_block, D_tail], dtype)
+        Q_shared = T.alloc_shared([H_per_block, D + D_tail], dtype)
         KV_shared = T.alloc_shared([BI, D], dtype)
         K_tail_shared = T.alloc_shared([BI, D_tail], dtype)
-        O_shared = T.alloc_shared([H_per_block, D], dtype)
-        Lse_shared = T.alloc_shared([H_per_block], accum_dtype)
         mask = T.alloc_fragment([BI], "bool")
 
         acc_o = T.alloc_fragment([H_per_block, D], accum_dtype)
@@ -111,8 +108,9 @@ def sparse_mla_fwd(
         H0 = g_i * padded_H + (0 if REPLICATE_H == 1 else (bx % REPLICATE_H) * 64)
         H1 = H0 + H_per_block
 
-        T.copy(Q[b_i, s_i, H0:H1, :D], Q_shared)
-        T.copy(Q[b_i, s_i, H0:H1, D:], Q_tail_shared)
+        # TODO: merge the statements when the compiler has better support for non-power-of-2 extents.
+        T.copy(Q[b_i, s_i, H0:H1, :D], Q_shared[:, :D])
+        T.copy(Q[b_i, s_i, H0:H1, D:], Q_shared[:, D:])
 
         for i_i in T.Pipelined(NI, num_stages=num_stages):
             for bi_i in T.Parallel(BI):
@@ -126,14 +124,14 @@ def sparse_mla_fwd(
             for h_i, bi_i in T.Parallel(H_per_block, BI):
                 acc_s[h_i, bi_i] = T.if_then_else(mask[bi_i], 0, -T.infinity(acc_s.dtype))
             T.gemm(
-                Q_shared,
+                Q_shared[:, :D],
                 KV_shared,
                 acc_s,
                 transpose_B=True,
                 policy=T.GemmWarpPolicy.FullRow,
             )
             T.gemm(
-                Q_tail_shared,
+                Q_shared[:, D:],
                 K_tail_shared,
                 acc_s,
                 transpose_B=True,

--- a/examples/deepseek_v32/sparse_mla_fwd_pipelined.py
+++ b/examples/deepseek_v32/sparse_mla_fwd_pipelined.py
@@ -25,7 +25,7 @@ def sparse_mla_fwd(
     is_causal=True,
     CP0=True,
     block_I=64,
-    num_stages=0,
+    num_stages=2,
     threads=384,
 ):
     assert dim == tilelang.math.next_power_of_2(dim), f"haven't check padding correctness yet, dim={dim}"
@@ -59,6 +59,7 @@ def sparse_mla_fwd(
     BI = block_I
     NI = tilelang.cdiv(topk, block_I)
     assert NI % 2 == 0, "NI should be a multiple of 2"
+    assert num_stages == 2, "the manually synchronized pipeline requires two stages"
     D = dim
     D_tail = tail_dim
     KV_stride = kv_stride
@@ -78,18 +79,10 @@ def sparse_mla_fwd(
     Lse = T.empty(lse_shape, accum_dtype)
 
     with T.Kernel((seq_len - kv_stride + 1 if CP0 else seq_len) * REPLICATE_H, batch, kv_group, threads=threads) as (bx, by, bz):
-        Q_shared_l = T.alloc_shared([H_per_block, D // 2], dtype)
-        Q_shared_r = T.alloc_shared([H_per_block, D // 2], dtype)
-        Q_tail_shared = T.alloc_shared([H_per_block, D_tail], dtype)
-        KV_shared_0_l = T.alloc_shared([BI, D // 2], dtype)
-        KV_shared_0_r = T.alloc_shared([BI, D // 2], dtype)
-        KV_shared_1_l = T.alloc_shared([BI, D // 2], dtype)
-        KV_shared_1_r = T.alloc_shared([BI, D // 2], dtype)
-        K_tail_shared_0 = T.alloc_shared([BI, D_tail], dtype)
-        K_tail_shared_1 = T.alloc_shared([BI, D_tail], dtype)
-        O_shared_l = Q_shared_l
-        O_shared_r = Q_shared_r
-        is_kv_valid = T.alloc_shared([BI], "bool", scope="shared")
+        Q_shared = T.alloc_shared([H_per_block, D + D_tail], dtype)
+        KV_shared = T.alloc_shared([num_stages, BI, D + D_tail], dtype)
+        O_shared = Q_shared
+        is_kv_valid = T.alloc_shared([num_stages, BI], "bool", scope="shared")
 
         acc_o_l = T.alloc_fragment([H_per_block, D // 2], accum_dtype)
         acc_o_r = T.alloc_fragment([H_per_block, D // 2], accum_dtype)
@@ -104,12 +97,9 @@ def sparse_mla_fwd(
         m_i_prev = T.alloc_fragment([H_per_block], accum_dtype)
         indices_local = T.alloc_var(indices_dtype)
 
-        # TODO: Multi buffer
         bar_q = T.alloc_barrier(arrive_count=384)
-        bar_k_0_ready = T.alloc_barrier(arrive_count=128)
-        bar_k_1_ready = T.alloc_barrier(arrive_count=128)
-        bar_k_0_free = T.alloc_barrier(arrive_count=256)
-        bar_k_1_free = T.alloc_barrier(arrive_count=256)
+        bar_k_ready = T.alloc_barrier(arrive_count=[128] * num_stages)
+        bar_k_free = T.alloc_barrier(arrive_count=[256] * num_stages)
         bar_sScale_and_sS_ready = T.alloc_barrier(arrive_count=256)
         bar_sScale_and_sS_free = T.alloc_barrier(arrive_count=256)
 
@@ -123,9 +113,7 @@ def sparse_mla_fwd(
 
         tx = T.get_thread_binding()
 
-        T.tma_copy(Q[b_i, s_i, H0:H1, 0 : D // 2], Q_shared_l, barrier=bar_q)
-        T.tma_copy(Q[b_i, s_i, H0:H1, D // 2 : D], Q_shared_r, barrier=bar_q)
-        T.tma_copy(Q[b_i, s_i, H0:H1, D:], Q_tail_shared, barrier=bar_q)
+        T.tma_copy(Q[b_i, s_i, H0:H1, :], Q_shared, barrier=bar_q)
         T.barrier_arrive(bar_q)
 
         if tx < 128:
@@ -135,77 +123,42 @@ def sparse_mla_fwd(
             T.fill(acc_o_l, 0)
             T.barrier_wait(bar_q, 0)
 
-            for i_i in T.serial(T.ceildiv(NI, 2)):
-                # Buffer 0
-                T.barrier_wait(bar_k_0_ready[0], (i_i & 1))
+            for i_i in T.serial(T.ceildiv(NI, num_stages)):
+                for stage in T.unroll(num_stages, explicit=True):
+                    T.barrier_wait(bar_k_ready[stage], (i_i & 1))
 
-                for h_i, bi_i in T.Parallel(H_per_block, BI):
-                    acc_s[h_i, bi_i] = T.if_then_else(is_kv_valid[bi_i], 0, -T.infinity(acc_s.dtype))
-                T.wgmma_gemm(Q_shared_l, KV_shared_0_l, acc_s, transpose_B=True)
-                T.wgmma_gemm(Q_shared_r, KV_shared_0_r, acc_s, transpose_B=True)
-                T.wgmma_gemm(Q_tail_shared, K_tail_shared_0, acc_s, transpose_B=True)
+                    for h_i, bi_i in T.Parallel(H_per_block, BI):
+                        acc_s[h_i, bi_i] = T.if_then_else(is_kv_valid[stage, bi_i], 0, -T.infinity(acc_s.dtype))
+                    T.wgmma_gemm(Q_shared[:, : D // 2], KV_shared[stage, :, : D // 2], acc_s, transpose_B=True)
+                    T.wgmma_gemm(Q_shared[:, D // 2 : D], KV_shared[stage, :, D // 2 : D], acc_s, transpose_B=True)
+                    T.wgmma_gemm(Q_shared[:, D:], KV_shared[stage, :, D:], acc_s, transpose_B=True)
 
-                T.wait_wgmma(0)
+                    T.wait_wgmma(0)
 
-                if i_i != 0:
-                    T.barrier_arrive(bar_sScale_and_sS_free)
-                    T.barrier_wait(bar_sScale_and_sS_free, ((i_i * 2) & 1) ^ 1)
+                    if i_i != 0 or stage != 0:
+                        T.barrier_arrive(bar_sScale_and_sS_free)
+                        T.barrier_wait(bar_sScale_and_sS_free, ((i_i * num_stages + stage) & 1) ^ 1)
 
-                T.copy(m_i, m_i_prev)
-                T.reduce_max(acc_s, m_i, dim=1, clear=False)
-                for h_i in T.Parallel(H_per_block):
-                    m_i[h_i] = T.max(m_i[h_i], m_i_prev[h_i])
-                for h_i in T.Parallel(H_per_block):
-                    alpha_local[h_i] = T.exp2((m_i_prev[h_i] - m_i[h_i]) * sm_scale)
-                for h_i, bi_i in T.Parallel(H_per_block, BI):
-                    acc_s[h_i, bi_i] = T.exp2(acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale)
-                T.reduce_sum(acc_s, sumexp_i, dim=1)  # is this a accumulate operator?
-                for h_i in T.Parallel(H_per_block):
-                    sumexp[h_i] = sumexp[h_i] * alpha_local[h_i] + sumexp_i[h_i]
-                for h_i, d_i in T.Parallel(H_per_block, D // 2):
-                    acc_o_l[h_i, d_i] *= alpha_local[h_i]
-                T.copy(alpha_local, alpha_shared)
+                    T.copy(m_i, m_i_prev)
+                    T.reduce_max(acc_s, m_i, dim=1, clear=False)
+                    for h_i in T.Parallel(H_per_block):
+                        m_i[h_i] = T.max(m_i[h_i], m_i_prev[h_i])
+                    for h_i in T.Parallel(H_per_block):
+                        alpha_local[h_i] = T.exp2((m_i_prev[h_i] - m_i[h_i]) * sm_scale)
+                    for h_i, bi_i in T.Parallel(H_per_block, BI):
+                        acc_s[h_i, bi_i] = T.exp2(acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale)
+                    T.reduce_sum(acc_s, sumexp_i, dim=1)  # is this a accumulate operator?
+                    for h_i in T.Parallel(H_per_block):
+                        sumexp[h_i] = sumexp[h_i] * alpha_local[h_i] + sumexp_i[h_i]
+                    for h_i, d_i in T.Parallel(H_per_block, D // 2):
+                        acc_o_l[h_i, d_i] *= alpha_local[h_i]
+                    T.copy(alpha_local, alpha_shared)
 
-                T.copy(acc_s, S_shared)
-                T.gemm(S_shared, KV_shared_0_l, acc_o_l)
+                    T.copy(acc_s, S_shared)
+                    T.gemm(S_shared, KV_shared[stage, :, : D // 2], acc_o_l)
 
-                T.barrier_arrive(bar_sScale_and_sS_ready)
-                T.barrier_arrive(bar_k_0_free[0])
-
-                # Buffer 1
-                T.barrier_wait(bar_k_1_ready[0], (i_i & 1))
-
-                for h_i, bi_i in T.Parallel(H_per_block, BI):
-                    acc_s[h_i, bi_i] = T.if_then_else(is_kv_valid[bi_i], 0, -T.infinity(acc_s.dtype))
-                T.wgmma_gemm(Q_shared_l, KV_shared_1_l, acc_s, transpose_B=True)
-                T.wgmma_gemm(Q_shared_r, KV_shared_1_r, acc_s, transpose_B=True)
-                T.wgmma_gemm(Q_tail_shared, K_tail_shared_1, acc_s, transpose_B=True)
-
-                T.wait_wgmma(0)
-
-                T.barrier_arrive(bar_sScale_and_sS_free)
-                T.barrier_wait(bar_sScale_and_sS_free, ((i_i * 2 + 1) & 1) ^ 1)
-
-                T.copy(m_i, m_i_prev)
-                T.reduce_max(acc_s, m_i, dim=1, clear=False)
-                for h_i in T.Parallel(H_per_block):
-                    m_i[h_i] = T.max(m_i[h_i], m_i_prev[h_i])
-                for h_i in T.Parallel(H_per_block):
-                    alpha_local[h_i] = T.exp2((m_i_prev[h_i] - m_i[h_i]) * sm_scale)
-                for h_i, bi_i in T.Parallel(H_per_block, BI):
-                    acc_s[h_i, bi_i] = T.exp2(acc_s[h_i, bi_i] * sm_scale - m_i[h_i] * sm_scale)
-                T.reduce_sum(acc_s, sumexp_i, dim=1)  # is this a accumulate operator?
-                for h_i in T.Parallel(H_per_block):
-                    sumexp[h_i] = sumexp[h_i] * alpha_local[h_i] + sumexp_i[h_i]
-                for h_i, d_i in T.Parallel(H_per_block, D // 2):
-                    acc_o_l[h_i, d_i] *= alpha_local[h_i]
-                T.copy(alpha_local, alpha_shared)
-
-                T.copy(acc_s, S_shared)
-                T.gemm(S_shared, KV_shared_1_l, acc_o_l)
-
-                T.barrier_arrive(bar_sScale_and_sS_ready)
-                T.barrier_arrive(bar_k_1_free[0])
+                    T.barrier_arrive(bar_sScale_and_sS_ready)
+                    T.barrier_arrive(bar_k_free[stage])
 
             # Rescale
             for h_i in T.Parallel(H_per_block):
@@ -214,91 +167,59 @@ def sparse_mla_fwd(
                 acc_o_l[h_i, d_i] /= sumexp[h_i]
             for h_i in T.Parallel(H_per_block):
                 sumexp[h_i] = T.log2(sumexp[h_i]) + m_i[h_i] * sm_scale
-            T.copy(acc_o_l, O_shared_l)
-            T.copy(O_shared_l, Output[b_i, s_i, H0:H1, 0 : D // 2])
+            T.copy(acc_o_l, O_shared[:, : D // 2])
+            T.copy(O_shared[:, : D // 2], Output[b_i, s_i, H0:H1, 0 : D // 2])
 
         elif tx >= 128 and tx < 256:
             T.set_max_nreg(168, 1)
             T.fill(acc_o_r, 0)
-            for i_i in T.serial(T.ceildiv(NI, 2)):
-                # Buffer 0
-                T.barrier_arrive(bar_sScale_and_sS_ready)
-                T.barrier_wait(bar_sScale_and_sS_ready, ((i_i * 2) & 1))
-                for h_i, d_i in T.Parallel(H_per_block, D // 2):
-                    acc_o_r[h_i, d_i] *= alpha_shared[h_i]
-                T.gemm(S_shared, KV_shared_0_r, acc_o_r)
-                T.barrier_arrive(bar_k_0_free[0])
-                T.barrier_arrive(bar_sScale_and_sS_free)
-
-                # Buffer 1
-                T.barrier_arrive(bar_sScale_and_sS_ready)
-                T.barrier_wait(bar_sScale_and_sS_ready, ((i_i * 2 + 1) & 1))
-                for h_i, d_i in T.Parallel(H_per_block, D // 2):
-                    acc_o_r[h_i, d_i] *= alpha_shared[h_i]
-                T.gemm(S_shared, KV_shared_1_r, acc_o_r)
-                T.barrier_arrive(bar_k_1_free[0])
-                if i_i != T.ceildiv(NI, 2) - 1:
-                    T.barrier_arrive(bar_sScale_and_sS_free)
+            for i_i in T.serial(T.ceildiv(NI, num_stages)):
+                for stage in T.unroll(num_stages, explicit=True):
+                    T.barrier_arrive(bar_sScale_and_sS_ready)
+                    T.barrier_wait(bar_sScale_and_sS_ready, ((i_i * num_stages + stage) & 1))
+                    for h_i, d_i in T.Parallel(H_per_block, D // 2):
+                        acc_o_r[h_i, d_i] *= alpha_shared[h_i]
+                    T.gemm(S_shared, KV_shared[stage, :, D // 2 : D], acc_o_r)
+                    T.barrier_arrive(bar_k_free[stage])
+                    if stage != num_stages - 1 or i_i != T.ceildiv(NI, num_stages) - 1:
+                        T.barrier_arrive(bar_sScale_and_sS_free)
 
             # Rescale
             for h_i, d_i in T.Parallel(H_per_block, D // 2):
                 acc_o_r[h_i, d_i] /= sum_exp_shared[h_i]
 
-            T.copy(acc_o_r, O_shared_r)
-            T.copy(O_shared_r, Output[b_i, s_i, H0:H1, D // 2 : D])
+            T.copy(acc_o_r, O_shared[:, D // 2 : D])
+            T.copy(O_shared[:, D // 2 : D], Output[b_i, s_i, H0:H1, D // 2 : D])
         elif tx >= 256:
             # producer
             T.set_max_nreg(80, 0)
-            for i_i in T.serial(T.ceildiv(NI, 2)):
-                # Buffer 0
-                T.barrier_wait(bar_k_0_free[0], ((i_i & 1) ^ 1))
-                for r in T.serial(4):
-                    indices_local = Indices[b_i, s_i, g_i, (i_i * 2) * BI + r * 16 + (tx - 256) // 8]
-                    is_kv_valid[r * 16 + (tx - 256) // 8] = indices_local <= max_kv_i
-                    if is_kv_valid[r * 16 + (tx - 256) // 8]:
-                        # Manually issue cp.async copies for KV_left, KV_right, and K_tail.
-                        for u in T.serial(4):
-                            T.ptx_cp_async(
-                                T.access_ptr(KV_shared_0_l[r * 16 + (tx - 256) // 8, 64 * u + (tx - 256) % 8 * 8], "w", 8),
-                                T.access_ptr(KV[b_i, indices_local, g_i, 64 * u + (tx - 256) % 8 * 8], "r", 8),
-                                8,
-                            )
-                            T.ptx_cp_async(
-                                T.access_ptr(KV_shared_0_r[r * 16 + (tx - 256) // 8, 64 * u + (tx - 256) % 8 * 8], "w", 8),
-                                T.access_ptr(KV[b_i, indices_local, g_i, D // 2 + 64 * u + (tx - 256) % 8 * 8], "r", 8),
-                                8,
-                            )
-                        T.ptx_cp_async(
-                            T.access_ptr(K_tail_shared_0[r * 16 + (tx - 256) // 8, (tx - 256) % 8 * 8], "w", 8),
-                            T.access_ptr(KV[b_i, indices_local, g_i, D + (tx - 256) % 8 * 8], "r", 8),
-                            8,
-                        )
-                T.cp_async_barrier_noinc(bar_k_0_ready[0])
-
-                # Buffer 1
-                T.barrier_wait(bar_k_1_free[0], ((i_i & 1) ^ 1))
-                for r in T.serial(4):
-                    indices_local = Indices[b_i, s_i, g_i, (i_i * 2 + 1) * BI + r * 16 + (tx - 256) // 8]
-                    is_kv_valid[r * 16 + (tx - 256) // 8] = indices_local <= max_kv_i
-                    if is_kv_valid[r * 16 + (tx - 256) // 8]:
-                        # Manually issue cp.async copies for KV_left, KV_right, and K_tail.
-                        for u in T.serial(4):
-                            T.ptx_cp_async(
-                                T.access_ptr(KV_shared_1_l[r * 16 + (tx - 256) // 8, 64 * u + (tx - 256) % 8 * 8], "w", 8),
-                                T.access_ptr(KV[b_i, indices_local, g_i, 64 * u + (tx - 256) % 8 * 8], "r", 8),
-                                8,
-                            )
-                            T.ptx_cp_async(
-                                T.access_ptr(KV_shared_1_r[r * 16 + (tx - 256) // 8, 64 * u + (tx - 256) % 8 * 8], "w", 8),
-                                T.access_ptr(KV[b_i, indices_local, g_i, D // 2 + 64 * u + (tx - 256) % 8 * 8], "r", 8),
-                                8,
-                            )
-                        T.ptx_cp_async(
-                            T.access_ptr(K_tail_shared_1[r * 16 + (tx - 256) // 8, (tx - 256) % 8 * 8], "w", 8),
-                            T.access_ptr(KV[b_i, indices_local, g_i, D + (tx - 256) % 8 * 8], "r", 8),
-                            8,
-                        )
-                T.cp_async_barrier_noinc(bar_k_1_ready[0])
+            for i_i in T.serial(T.ceildiv(NI, num_stages)):
+                for stage in T.unroll(num_stages, explicit=True):
+                    T.barrier_wait(bar_k_free[stage], ((i_i & 1) ^ 1))
+                    for r in T.serial(4):
+                        indices_local = Indices[
+                            b_i,
+                            s_i,
+                            g_i,
+                            (i_i * num_stages + stage) * BI + r * 16 + (tx - 256) // 8,
+                        ]
+                        is_kv_valid[stage, r * 16 + (tx - 256) // 8] = indices_local <= max_kv_i
+                        if is_kv_valid[stage, r * 16 + (tx - 256) // 8]:
+                            for u in T.serial((D + D_tail) // 64):
+                                T.ptx_cp_async(
+                                    T.access_ptr(
+                                        KV_shared[
+                                            stage,
+                                            r * 16 + (tx - 256) // 8,
+                                            64 * u + (tx - 256) % 8 * 8,
+                                        ],
+                                        "w",
+                                        8,
+                                    ),
+                                    T.access_ptr(KV[b_i, indices_local, g_i, 64 * u + (tx - 256) % 8 * 8], "r", 8),
+                                    8,
+                                )
+                    T.cp_async_barrier_noinc(bar_k_ready[stage])
 
     return Output, Lse
 

--- a/examples/deepseek_v32/sparse_mla_fwd_pipelined.py
+++ b/examples/deepseek_v32/sparse_mla_fwd_pipelined.py
@@ -124,7 +124,7 @@ def sparse_mla_fwd(
             T.barrier_wait(bar_q, 0)
 
             for i_i in T.serial(T.ceildiv(NI, num_stages)):
-                for stage in T.unroll(num_stages, explicit=True):
+                for stage in T.unroll(num_stages):
                     T.barrier_wait(bar_k_ready[stage], (i_i & 1))
 
                     for h_i, bi_i in T.Parallel(H_per_block, BI):
@@ -174,7 +174,7 @@ def sparse_mla_fwd(
             T.set_max_nreg(168, 1)
             T.fill(acc_o_r, 0)
             for i_i in T.serial(T.ceildiv(NI, num_stages)):
-                for stage in T.unroll(num_stages, explicit=True):
+                for stage in T.unroll(num_stages):
                     T.barrier_arrive(bar_sScale_and_sS_ready)
                     T.barrier_wait(bar_sScale_and_sS_ready, ((i_i * num_stages + stage) & 1))
                     for h_i, d_i in T.Parallel(H_per_block, D // 2):
@@ -194,7 +194,7 @@ def sparse_mla_fwd(
             # producer
             T.set_max_nreg(80, 0)
             for i_i in T.serial(T.ceildiv(NI, num_stages)):
-                for stage in T.unroll(num_stages, explicit=True):
+                for stage in T.unroll(num_stages):
                     T.barrier_wait(bar_k_free[stage], ((i_i & 1) ^ 1))
                     for r in T.serial(4):
                         indices_local = Indices[

--- a/examples/deepseek_v32/sparse_mla_fwd_seesaw.py
+++ b/examples/deepseek_v32/sparse_mla_fwd_seesaw.py
@@ -186,11 +186,11 @@ def sparse_mla_fwd(
             # Prime the Pump! Prefetch indices for iter_0
             for r in T.serial(4):
                 # This read will cause a long scoreboard stall, but it only happens once before the loop starts
-                for stage in T.unroll(num_stages, explicit=True):
+                for stage in T.unroll(num_stages):
                     prefetch_indices[stage, r] = Indices[b_i, s_i, g_i, stage * BI + r * 16 + (tx - 256) // 8]
 
             for i_i in T.serial(T.ceildiv(NI, num_stages)):
-                for stage in T.unroll(num_stages, explicit=True):
+                for stage in T.unroll(num_stages):
                     T.barrier_wait(bar_k_free[stage], (i_i & 1))
 
                     # Block size `BI` is 64, loading is divided into 4 iterations, each processing 16 indices.
@@ -226,7 +226,7 @@ def sparse_mla_fwd(
 
             # pre-arrive free barriers to indicate buffers are initially free
             # At the beginning of phase0, tells producer it can load data into both buffers
-            for stage in T.unroll(num_stages, explicit=True):
+            for stage in T.unroll(num_stages):
                 T.barrier_arrive(bar_k_free[stage])
 
             # Consumer 0 (WG0): Responsible for Even Blocks and O_L (Left Half)
@@ -328,7 +328,7 @@ def sparse_mla_fwd(
 
             # pre-arrive free barriers to indicate buffers are initially free
             # At the beginning of phase0, tells producer it can load data into both buffers
-            for stage in T.unroll(num_stages, explicit=True):
+            for stage in T.unroll(num_stages):
                 T.barrier_arrive(bar_k_free[stage])
 
             # Consumer 1 (WG1): Responsible for Odd Blocks and O_R (Right Half)

--- a/examples/deepseek_v32/sparse_mla_fwd_seesaw.py
+++ b/examples/deepseek_v32/sparse_mla_fwd_seesaw.py
@@ -34,7 +34,7 @@ def sparse_mla_fwd(
     is_causal=True,
     CP0=True,
     block_I=64,
-    num_stages=0,
+    num_stages=2,
     threads=384,
 ):
     assert dim == tilelang.math.next_power_of_2(dim), f"haven't check padding correctness yet, dim={dim}"
@@ -70,7 +70,8 @@ def sparse_mla_fwd(
         )
     BI = block_I
     NI = tilelang.cdiv(topk, block_I)
-    assert NI % 2 == 0, "NI should be a multiple of 2"
+    assert num_stages == 2, "the seesaw pipeline requires exactly two stages"
+    assert NI % num_stages == 0, "NI should be a multiple of num_stages"
     D = dim
     D_tail = tail_dim
     KV_stride = kv_stride
@@ -83,6 +84,7 @@ def sparse_mla_fwd(
     # Increasing from 32->64 reduces the time spent reading kvcache. If num_query_head = 128
     # and num_kv_head = 1, the same kvcache originally needed to be read 4 times, but now only 2 times
     H_per_block = padded_H if REPLICATE_H == 1 else 64
+    assert H_per_block == BI == D_tail, "the score/K-tail shared-memory reuse requires matching dimensions"
 
     Q: T.Tensor(q_shape, dtype)  # type: ignore
     KV: T.Tensor(kv_shape, dtype)  # type: ignore
@@ -99,43 +101,31 @@ def sparse_mla_fwd(
         kv_group,
         threads=threads,
     ) as (bx, by, bz):
-        Q_shared_l = T.alloc_shared([H_per_block, D // 2], dtype)
-        Q_shared_r = T.alloc_shared([H_per_block, D // 2], dtype)
-        Q_tail_shared = T.alloc_shared([H_per_block, D_tail], dtype)
+        Q_shared = T.alloc_shared([H_per_block, D + D_tail], dtype)
+        KV_shared = T.alloc_shared([num_stages, BI, D + D_tail], dtype)
 
-        KV_shared_0_l = T.alloc_shared([BI, D // 2], dtype)
-        KV_shared_0_r = T.alloc_shared([BI, D // 2], dtype)
-        KV_shared_1_l = T.alloc_shared([BI, D // 2], dtype)
-        KV_shared_1_r = T.alloc_shared([BI, D // 2], dtype)
-        K_tail_shared_0 = T.alloc_shared([BI, D_tail], dtype)
-        K_tail_shared_1 = T.alloc_shared([BI, D_tail], dtype)
-
-        O_shared_l = Q_shared_l
-        O_shared_r = Q_shared_r
+        O_shared = Q_shared
 
         # Whether the kv in current BI is visible for this query
         # Producer alternates writing to buf0 and buf1 masks. To avoid the situation
         # where consumer0 is still reading buf0 mask when producer has already started
         # writing buf1 mask, we use two buf masks
-        is_kv_valid = T.alloc_shared([2, BI], "bool", scope="shared")
+        is_kv_valid = T.alloc_shared([num_stages, BI], "bool", scope="shared")
 
         acc_o_l = T.alloc_fragment([H_per_block, D // 2], accum_dtype)
         acc_o_r = T.alloc_fragment([H_per_block, D // 2], accum_dtype)
 
         # WG0 computes S0(BI_2*i), WG1 computes S1(BI_2*i+1), shared via shared memory
 
-        # Reuse K_tail_shared for S_shared to save memory when dimensions match
+        # Reuse the K-tail slice for S_shared to save memory when dimensions match.
         # Must reuse, otherwise H100 SM's shared mem is insufficient (> 228kb), this is shared mem bound
-        S_shared_0 = K_tail_shared_0
-        S_shared_1 = K_tail_shared_1
+        S_shared = KV_shared
 
         # WG0 and WG1 exchange local max with each other, compare to compute global max, and rescale their O_L or O_R accordingly
-        row_max_shared_0 = T.alloc_shared([H_per_block], accum_dtype)
-        row_max_shared_1 = T.alloc_shared([H_per_block], accum_dtype)
+        row_max_shared = T.alloc_shared([num_stages, H_per_block], accum_dtype)
 
         # Used to store sum of exps for even BI and odd BI respectively, which will be summed up for integration later
-        row_sum_shared_0 = T.alloc_shared([H_per_block], accum_dtype)
-        row_sum_shared_1 = T.alloc_shared([H_per_block], accum_dtype)
+        row_sum_shared = T.alloc_shared([num_stages, H_per_block], accum_dtype)
 
         # acc_s, sumexp, m_i each need to be allocated separately for consumer0 and consumer1
         acc_s_0 = T.alloc_fragment([H_per_block, BI], accum_dtype)
@@ -156,12 +146,10 @@ def sparse_mla_fwd(
         bar_q = T.alloc_barrier(arrive_count=384)
 
         # Producer -> Consumer Barriers
-        bar_k_0_ready = T.alloc_barrier(arrive_count=128)  # Prod arrives
-        bar_k_1_ready = T.alloc_barrier(arrive_count=128)  # Prod arrives
+        bar_k_ready = T.alloc_barrier(arrive_count=[128] * num_stages)  # Prod arrives
 
         # Consumer -> Producer Barriers (Both consumers must arrive)
-        bar_k_0_free = T.alloc_barrier(arrive_count=256)
-        bar_k_1_free = T.alloc_barrier(arrive_count=256)
+        bar_k_free = T.alloc_barrier(arrive_count=[256] * num_stages)
 
         # Inter-Consumer Barriers (Seesaw Sync)
         bar_stats_0_ready = T.alloc_barrier(arrive_count=128)  # Cons 0 arrives
@@ -184,9 +172,7 @@ def sparse_mla_fwd(
 
         tx = T.get_thread_binding()
 
-        T.copy(Q[b_i, s_i, H0:H1, 0 : D // 2], Q_shared_l)
-        T.copy(Q[b_i, s_i, H0:H1, D // 2 : D], Q_shared_r)
-        T.copy(Q[b_i, s_i, H0:H1, D:], Q_tail_shared)
+        T.copy(Q[b_i, s_i, H0:H1, :], Q_shared)
 
         # Non-blockingly increment the barrier's internal counter, producer threads can start loading kv ahead of time
         T.barrier_arrive(bar_q)
@@ -195,81 +181,43 @@ def sparse_mla_fwd(
             # producer: prefetch kvcache to shared mem
             T.set_max_nreg(72, 0)
 
-            prefetch_indices_0 = T.alloc_fragment([4], indices_dtype)
-            prefetch_indices_1 = T.alloc_fragment([4], indices_dtype)
+            prefetch_indices = T.alloc_fragment([num_stages, 4], indices_dtype)
 
             # Prime the Pump! Prefetch indices for iter_0
             for r in T.serial(4):
                 # This read will cause a long scoreboard stall, but it only happens once before the loop starts
-                prefetch_indices_0[r] = Indices[b_i, s_i, g_i, r * 16 + (tx - 256) // 8]
-                prefetch_indices_1[r] = Indices[b_i, s_i, g_i, BI + r * 16 + (tx - 256) // 8]
+                for stage in T.unroll(num_stages, explicit=True):
+                    prefetch_indices[stage, r] = Indices[b_i, s_i, g_i, stage * BI + r * 16 + (tx - 256) // 8]
 
-            for i_i in T.serial(T.ceildiv(NI, 2)):
-                # Buffer 0
-                # Wait for both KV_shared_0_l and KV_shared_0_r to be done being used
+            for i_i in T.serial(T.ceildiv(NI, num_stages)):
+                for stage in T.unroll(num_stages, explicit=True):
+                    T.barrier_wait(bar_k_free[stage], (i_i & 1))
 
-                T.barrier_wait(bar_k_0_free[0], (i_i & 1))
-
-                # Block size `BI` is 64, loading is divided into 4 iterations, each processing 16 indices
-                # Producer has 128 threads total, 8 consecutive threads collaborate to load kv for one index
-                for r in T.serial(4):
-                    # mitigate long scoreboard stall here
-                    index = prefetch_indices_0[r]
-                    is_kv_valid[0, r * 16 + (tx - 256) // 8] = index <= max_kv_i
-                    if is_kv_valid[0, r * 16 + (tx - 256) // 8]:
-                        # 8 threads collaborate to load one row of KV_dim (512) in 4 iters, each loading 8 elems
-                        for u in T.serial(4):
-                            T.ptx_cp_async(
-                                T.access_ptr(KV_shared_0_l[r * 16 + (tx - 256) // 8, 64 * u + (tx - 256) % 8 * 8], "w", 8),
-                                T.access_ptr(KV[b_i, index, g_i, 64 * u + (tx - 256) % 8 * 8], "r", 8),
-                                8,
-                            )
-                            T.ptx_cp_async(
-                                T.access_ptr(KV_shared_0_r[r * 16 + (tx - 256) // 8, 64 * u + (tx - 256) % 8 * 8], "w", 8),
-                                T.access_ptr(KV[b_i, index, g_i, D // 2 + 64 * u + (tx - 256) % 8 * 8], "r", 8),
-                                8,
-                            )
-                        # tail_dim (64) needs only one iter of 8 elems per 8 collaborating threads
-                        T.ptx_cp_async(
-                            T.access_ptr(K_tail_shared_0[r * 16 + (tx - 256) // 8, (tx - 256) % 8 * 8], "w", 8),
-                            T.access_ptr(KV[b_i, index, g_i, D + (tx - 256) % 8 * 8], "r", 8),
-                            8,
-                        )
-                T.cp_async_barrier_noinc(bar_k_0_ready[0])
-
-                if i_i + 1 < T.ceildiv(NI, 2):
-                    # Async prefetch indices needed for the next round of kv data loading, overlaps with current round to hide latency
+                    # Block size `BI` is 64, loading is divided into 4 iterations, each processing 16 indices.
                     for r in T.serial(4):
-                        prefetch_indices_0[r] = Indices[b_i, s_i, g_i, ((i_i + 1) * 2) * BI + r * 16 + (tx - 256) // 8]
+                        index = prefetch_indices[stage, r]
+                        is_kv_valid[stage, r * 16 + (tx - 256) // 8] = index <= max_kv_i
+                        if is_kv_valid[stage, r * 16 + (tx - 256) // 8]:
+                            for u in T.serial((D + D_tail) // 64):
+                                T.ptx_cp_async(
+                                    T.access_ptr(
+                                        KV_shared[stage, r * 16 + (tx - 256) // 8, 64 * u + (tx - 256) % 8 * 8],
+                                        "w",
+                                        8,
+                                    ),
+                                    T.access_ptr(KV[b_i, index, g_i, 64 * u + (tx - 256) % 8 * 8], "r", 8),
+                                    8,
+                                )
+                    T.cp_async_barrier_noinc(bar_k_ready[stage])
 
-                # Buffer 1
-                T.barrier_wait(bar_k_1_free[0], (i_i & 1))
-
-                for r in T.serial(4):
-                    index = prefetch_indices_1[r]
-                    is_kv_valid[1, r * 16 + (tx - 256) // 8] = index <= max_kv_i
-                    if is_kv_valid[1, r * 16 + (tx - 256) // 8]:
-                        for u in T.serial(4):
-                            T.ptx_cp_async(
-                                T.access_ptr(KV_shared_1_l[r * 16 + (tx - 256) // 8, 64 * u + (tx - 256) % 8 * 8], "w", 8),
-                                T.access_ptr(KV[b_i, index, g_i, 64 * u + (tx - 256) % 8 * 8], "r", 8),
-                                8,
-                            )
-                            T.ptx_cp_async(
-                                T.access_ptr(KV_shared_1_r[r * 16 + (tx - 256) // 8, 64 * u + (tx - 256) % 8 * 8], "w", 8),
-                                T.access_ptr(KV[b_i, index, g_i, D // 2 + 64 * u + (tx - 256) % 8 * 8], "r", 8),
-                                8,
-                            )
-                        T.ptx_cp_async(
-                            T.access_ptr(K_tail_shared_1[r * 16 + (tx - 256) // 8, (tx - 256) % 8 * 8], "w", 8),
-                            T.access_ptr(KV[b_i, index, g_i, D + (tx - 256) % 8 * 8], "r", 8),
-                            8,
-                        )
-                T.cp_async_barrier_noinc(bar_k_1_ready[0])
-
-                if i_i + 1 < T.ceildiv(NI, 2):
-                    for r in T.serial(4):
-                        prefetch_indices_1[r] = Indices[b_i, s_i, g_i, ((i_i + 1) * 2 + 1) * BI + r * 16 + (tx - 256) // 8]
+                    if i_i + 1 < T.ceildiv(NI, num_stages):
+                        for r in T.serial(4):
+                            prefetch_indices[stage, r] = Indices[
+                                b_i,
+                                s_i,
+                                g_i,
+                                ((i_i + 1) * num_stages + stage) * BI + r * 16 + (tx - 256) // 8,
+                            ]
 
         elif tx < 128:
             # Check if 384 threads have already arrived at bar_q (phase0 completed),
@@ -278,8 +226,8 @@ def sparse_mla_fwd(
 
             # pre-arrive free barriers to indicate buffers are initially free
             # At the beginning of phase0, tells producer it can load data into both buffers
-            T.barrier_arrive(bar_k_0_free[0])
-            T.barrier_arrive(bar_k_1_free[0])
+            for stage in T.unroll(num_stages, explicit=True):
+                T.barrier_arrive(bar_k_free[stage])
 
             # Consumer 0 (WG0): Responsible for Even Blocks and O_L (Left Half)
             T.set_max_nreg(216, 1)
@@ -289,14 +237,13 @@ def sparse_mla_fwd(
             T.fill(acc_o_l, 0)
 
             # Each iteration, two consumers cooperate to compute two BIs
-            for i_i in T.serial(T.ceildiv(NI, 2)):
+            for i_i in T.serial(T.ceildiv(NI, num_stages)):
                 # --- Step 1: Compute S0 = Q @ K0^T (Even Block) ---
-                T.barrier_wait(bar_k_0_ready[0], (i_i & 1))
+                T.barrier_wait(bar_k_ready[0], (i_i & 1))
 
                 T.fill(acc_s_0, 0)
-                T.wgmma_gemm(Q_shared_l, KV_shared_0_l, acc_s_0, transpose_B=True)
-                T.wgmma_gemm(Q_shared_r, KV_shared_0_r, acc_s_0, transpose_B=True)
-                T.wgmma_gemm(Q_tail_shared, K_tail_shared_0, acc_s_0, transpose_B=True)
+                T.wgmma_gemm(Q_shared[:, :D], KV_shared[0, :, :D], acc_s_0, transpose_B=True)
+                T.wgmma_gemm(Q_shared[:, D:], KV_shared[0, :, D:], acc_s_0, transpose_B=True)
 
                 T.copy(m_i_0, m_i_prev_0)
                 T.wait_wgmma(0)
@@ -307,13 +254,13 @@ def sparse_mla_fwd(
                 T.reduce_max(acc_s_0, m_i_0, dim=1, clear=False)
 
                 # --- Step 2: Local Softmax Stats & Exchange ---
-                T.copy(m_i_0, row_max_shared_0)
+                T.copy(m_i_0, row_max_shared[0, :])
                 T.barrier_arrive(bar_stats_0_ready)
                 # If consumer0 has received the local max from consumer1 at iter_i, this also means
                 # consumer1 has finished using S_0 passed by consumer0 at iter_i-1,
                 # so we can write to it directly without blocking below
                 T.barrier_wait(bar_stats_1_ready, (i_i & 1))
-                T.copy(row_max_shared_1, m_i_peer_0)
+                T.copy(row_max_shared[1, :], m_i_peer_0)
 
                 # Update global max and scale O
                 for h_i in T.Parallel(H_per_block):
@@ -339,29 +286,29 @@ def sparse_mla_fwd(
                 # --- Step 3: O_L += P0 @ V0_L (Self-Attention) ---
                 # Wait for S0 buffer to be free (consumed by peer in prev iter)
                 # T.barrier_wait(bar_S_0_free, (i_i & 1))
-                T.copy(acc_s_0, S_shared_0)
+                T.copy(acc_s_0, S_shared[0, :, D:])
                 T.barrier_arrive(bar_S_0_ready)
 
-                T.wgmma_gemm(S_shared_0, KV_shared_0_l, acc_o_l, transpose_B=False)
+                T.wgmma_gemm(S_shared[0, :, D:], KV_shared[0, :, : D // 2], acc_o_l, transpose_B=False)
 
                 # --- Step 4: O_L += P1 @ V1_L (Cross-Attention) ---
                 # Wait for P1 (S1) from peer
                 T.barrier_wait(bar_S_1_ready, (i_i & 1))
 
-                T.wgmma_gemm(S_shared_1, KV_shared_1_l, acc_o_l, transpose_B=False)
+                T.wgmma_gemm(S_shared[1, :, D:], KV_shared[1, :, : D // 2], acc_o_l, transpose_B=False)
 
                 # NOTE: However, k_0 and k_1 are used by both consumer0 and consumer1, so this doesn't bring much performance improvement
                 # Except for the most recent async gemm (i.e., S_shared_1 @ KV_shared_1_k), all others need to wait to finish
                 T.wait_wgmma(1)
-                T.barrier_arrive(bar_k_0_free[0])
+                T.barrier_arrive(bar_k_free[0])
                 # Wait for all async gemms to finish
                 T.wait_wgmma(0)
-                T.barrier_arrive(bar_k_1_free[0])
+                T.barrier_arrive(bar_k_free[1])
 
-            T.copy(sumexp_0, row_sum_shared_0)
+            T.copy(sumexp_0, row_sum_shared[0, :])
             T.barrier_arrive(bar_stats_0_ready)  # Reuse barrier
-            T.barrier_wait(bar_stats_1_ready, T.ceildiv(NI, 2) & 1)
-            T.copy(row_sum_shared_1, sumexp_i_0)  # Reuse sumexp_i buffer
+            T.barrier_wait(bar_stats_1_ready, T.ceildiv(NI, num_stages) & 1)
+            T.copy(row_sum_shared[1, :], sumexp_i_0)  # Reuse sumexp_i buffer
 
             for h_i in T.Parallel(H_per_block):
                 sumexp_0[h_i] += sumexp_i_0[h_i]
@@ -372,8 +319,8 @@ def sparse_mla_fwd(
             for h_i in T.Parallel(H_per_block):
                 sumexp_0[h_i] = T.log2(sumexp_0[h_i]) + m_i_0[h_i] * sm_scale
 
-            T.copy(acc_o_l, O_shared_l)
-            T.copy(O_shared_l, Output[b_i, s_i, H0:H1, 0 : D // 2])
+            T.copy(acc_o_l, O_shared[:, : D // 2])
+            T.copy(O_shared[:, : D // 2], Output[b_i, s_i, H0:H1, 0 : D // 2])
             T.copy(sumexp_0, Lse[b_i, s_i, H0:H1])  # Write LSE
 
         elif tx >= 128 and tx < 256:
@@ -381,8 +328,8 @@ def sparse_mla_fwd(
 
             # pre-arrive free barriers to indicate buffers are initially free
             # At the beginning of phase0, tells producer it can load data into both buffers
-            T.barrier_arrive(bar_k_0_free[0])
-            T.barrier_arrive(bar_k_1_free[0])
+            for stage in T.unroll(num_stages, explicit=True):
+                T.barrier_arrive(bar_k_free[stage])
 
             # Consumer 1 (WG1): Responsible for Odd Blocks and O_R (Right Half)
             # NOTE: 256 * 216 + 128 * 72 = 64,512 < 65536 (H100 SM RegFile Limit),
@@ -393,14 +340,13 @@ def sparse_mla_fwd(
                 m_i_1[h_i] = -5e4
             T.fill(acc_o_r, 0)
 
-            for i_i in T.serial(T.ceildiv(NI, 2)):
+            for i_i in T.serial(T.ceildiv(NI, num_stages)):
                 # --- Step 1: Compute S1 = Q @ K1^T (Odd Block) ---
-                T.barrier_wait(bar_k_1_ready[0], (i_i & 1))
+                T.barrier_wait(bar_k_ready[1], (i_i & 1))
 
                 T.fill(acc_s_1, 0)
-                T.wgmma_gemm(Q_shared_l, KV_shared_1_l, acc_s_1, transpose_B=True)
-                T.wgmma_gemm(Q_shared_r, KV_shared_1_r, acc_s_1, transpose_B=True)
-                T.wgmma_gemm(Q_tail_shared, K_tail_shared_1, acc_s_1, transpose_B=True)
+                T.wgmma_gemm(Q_shared[:, :D], KV_shared[1, :, :D], acc_s_1, transpose_B=True)
+                T.wgmma_gemm(Q_shared[:, D:], KV_shared[1, :, D:], acc_s_1, transpose_B=True)
 
                 # --- Step 2: Local Softmax Stats & Exchange ---
                 T.copy(m_i_1, m_i_prev_1)
@@ -411,10 +357,10 @@ def sparse_mla_fwd(
                         acc_s_1[h_i, bi_i] = -5e4
 
                 T.reduce_max(acc_s_1, m_i_1, dim=1, clear=False)
-                T.copy(m_i_1, row_max_shared_1)
+                T.copy(m_i_1, row_max_shared[1, :])
                 T.barrier_arrive(bar_stats_1_ready)
                 T.barrier_wait(bar_stats_0_ready, (i_i & 1))
-                T.copy(row_max_shared_0, m_i_peer_1)
+                T.copy(row_max_shared[0, :], m_i_peer_1)
 
                 for h_i in T.Parallel(H_per_block):
                     m_i_1[h_i] = T.max(m_i_1[h_i], m_i_peer_1[h_i])
@@ -433,26 +379,26 @@ def sparse_mla_fwd(
                     sumexp_1[h_i] += sumexp_i_1[h_i]
 
                 # --- Step 3: O_R += P1 @ V1_R (Self-Attention) ---
-                T.copy(acc_s_1, S_shared_1)
+                T.copy(acc_s_1, S_shared[1, :, D:])
 
                 T.barrier_arrive(bar_S_1_ready)
 
-                T.wgmma_gemm(S_shared_1, KV_shared_1_r, acc_o_r, transpose_B=False)
+                T.wgmma_gemm(S_shared[1, :, D:], KV_shared[1, :, D // 2 : D], acc_o_r, transpose_B=False)
 
                 # --- Step 4: O_R += P0 @ V0_R (Cross-Attention) ---
                 T.barrier_wait(bar_S_0_ready, (i_i & 1))
 
-                T.wgmma_gemm(S_shared_0, KV_shared_0_r, acc_o_r, transpose_B=False)
+                T.wgmma_gemm(S_shared[0, :, D:], KV_shared[0, :, D // 2 : D], acc_o_r, transpose_B=False)
 
                 T.wait_wgmma(1)
-                T.barrier_arrive(bar_k_1_free[0])
+                T.barrier_arrive(bar_k_free[1])
                 T.wait_wgmma(0)
-                T.barrier_arrive(bar_k_0_free[0])
+                T.barrier_arrive(bar_k_free[0])
 
-            T.copy(sumexp_1, row_sum_shared_1)
+            T.copy(sumexp_1, row_sum_shared[1, :])
             T.barrier_arrive(bar_stats_1_ready)
-            T.barrier_wait(bar_stats_0_ready, T.ceildiv(NI, 2) & 1)
-            T.copy(row_sum_shared_0, sumexp_i_1)
+            T.barrier_wait(bar_stats_0_ready, T.ceildiv(NI, num_stages) & 1)
+            T.copy(row_sum_shared[0, :], sumexp_i_1)
 
             for h_i in T.Parallel(H_per_block):
                 sumexp_1[h_i] += sumexp_i_1[h_i]
@@ -460,8 +406,8 @@ def sparse_mla_fwd(
             for h_i, d_i in T.Parallel(H_per_block, D // 2):
                 acc_o_r[h_i, d_i] /= sumexp_1[h_i]
 
-            T.copy(acc_o_r, O_shared_r)
-            T.copy(O_shared_r, Output[b_i, s_i, H0:H1, D // 2 : D])
+            T.copy(acc_o_r, O_shared[:, D // 2 : D])
+            T.copy(O_shared[:, D // 2 : D], Output[b_i, s_i, H0:H1, D // 2 : D])
 
     return Output, Lse
 

--- a/examples/flash_attention_sm100/gqa_fwd_bshd.py
+++ b/examples/flash_attention_sm100/gqa_fwd_bshd.py
@@ -205,10 +205,8 @@ def flashattn_wasp(
     ):
         with T.Kernel(T.ceildiv(seq_len, block_M), heads, batch, threads=threads) as (bx, by, bz):
             Q_shared = T.alloc_shared([block_M, dim], dtype)
-            K_shared_0 = T.alloc_shared([block_N, dim], dtype)
-            K_shared_1 = T.alloc_shared([block_N, dim], dtype)
-            V_shared_0 = T.alloc_shared([block_N, dim], dtype)
-            V_shared_1 = T.alloc_shared([block_N, dim], dtype)
+            K_shared = T.alloc_shared([num_stages, block_N, dim], dtype)
+            V_shared = T.alloc_shared([num_stages, block_N, dim], dtype)
             O_shared = T.alloc_shared([block_M, dim], dtype)
 
             S_tmem = T.alloc_tmem([block_M, block_N], accum_dtype)
@@ -265,18 +263,12 @@ def flashattn_wasp(
                     if k == 0:
                         T.copy(Q[bz, bx * block_M : (bx + 1) * block_M, by, :], Q_shared)
 
-                    if stage_id == 0:
-                        T.copy(K[bz, k * block_N : (k + 1) * block_N, by // groups, :], K_shared_0)
-                    else:
-                        T.copy(K[bz, k * block_N : (k + 1) * block_N, by // groups, :], K_shared_1)
+                    T.copy(K[bz, k * block_N : (k + 1) * block_N, by // groups, :], K_shared[stage_id, :, :])
                     T.mbarrier_arrive(mbar_dma1_full[stage_id])
 
                     T.mbarrier_wait_parity(mbar_dma2_empty[stage_id], parity_inv)
 
-                    if stage_id == 0:
-                        T.copy(V[bz, k * block_N : (k + 1) * block_N, by // groups, :], V_shared_0)
-                    else:
-                        T.copy(V[bz, k * block_N : (k + 1) * block_N, by // groups, :], V_shared_1)
+                    T.copy(V[bz, k * block_N : (k + 1) * block_N, by // groups, :], V_shared[stage_id, :, :])
 
                     T.mbarrier_arrive(mbar_dma2_full[stage_id])
 
@@ -284,45 +276,26 @@ def flashattn_wasp(
                     T.mbarrier_wait_parity(mbar_dma1_full[stage_id], parity)
                     T.mbarrier_wait_parity(mbar_bmm1_empty[stage_id], parity_inv)
 
-                    if stage_id == 0:
-                        T.tcgen05_gemm(
-                            Q_shared,
-                            K_shared_0,
-                            S_tmem,
-                            transpose_B=True,
-                            mbar=mbar_bmm1_full[stage_id],
-                            clear_accum=True,
-                        )
-                    else:
-                        T.tcgen05_gemm(
-                            Q_shared,
-                            K_shared_1,
-                            S_tmem,
-                            transpose_B=True,
-                            mbar=mbar_bmm1_full[stage_id],
-                            clear_accum=True,
-                        )
+                    T.tcgen05_gemm(
+                        Q_shared,
+                        K_shared[stage_id, :, :],
+                        S_tmem,
+                        transpose_B=True,
+                        mbar=mbar_bmm1_full[stage_id],
+                        clear_accum=True,
+                    )
                     T.mbarrier_arrive(mbar_dma1_empty[stage_id])
 
                     T.mbarrier_wait_parity(mbar_softmax_full[stage_id], parity)
                     T.mbarrier_wait_parity(mbar_dma2_full[stage_id], parity)
 
-                    if stage_id == 0:
-                        T.tcgen05_gemm(
-                            P_tmem,
-                            V_shared_0,
-                            O_tmem,
-                            mbar=mbar_bmm2_full[stage_id],
-                            clear_accum=is_clear_accum,
-                        )
-                    else:
-                        T.tcgen05_gemm(
-                            P_tmem,
-                            V_shared_1,
-                            O_tmem,
-                            mbar=mbar_bmm2_full[stage_id],
-                            clear_accum=is_clear_accum,
-                        )
+                    T.tcgen05_gemm(
+                        P_tmem,
+                        V_shared[stage_id, :, :],
+                        O_tmem,
+                        mbar=mbar_bmm2_full[stage_id],
+                        clear_accum=is_clear_accum,
+                    )
 
                     T.mbarrier_arrive(mbar_softmax_empty[stage_id])
                     T.mbarrier_arrive(mbar_dma2_empty[stage_id])

--- a/examples/flash_attention_sm100/mha_fwd_bshd.py
+++ b/examples/flash_attention_sm100/mha_fwd_bshd.py
@@ -200,10 +200,8 @@ def flashattn_wasp(
     ):
         with T.Kernel(T.ceildiv(seq_len, block_M), heads, batch, threads=threads) as (bx, by, bz):
             Q_shared = T.alloc_shared([block_M, dim], dtype)
-            K_shared_0 = T.alloc_shared([block_N, dim], dtype)
-            K_shared_1 = T.alloc_shared([block_N, dim], dtype)
-            V_shared_0 = T.alloc_shared([block_N, dim], dtype)
-            V_shared_1 = T.alloc_shared([block_N, dim], dtype)
+            K_shared = T.alloc_shared([num_stages, block_N, dim], dtype)
+            V_shared = T.alloc_shared([num_stages, block_N, dim], dtype)
             O_shared = T.alloc_shared([block_M, dim], dtype)
 
             S_tmem = T.alloc_tmem([block_M, block_N], accum_dtype)
@@ -260,18 +258,12 @@ def flashattn_wasp(
                     if k == 0:
                         T.copy(Q[bz, bx * block_M : (bx + 1) * block_M, by, :], Q_shared)
 
-                    if stage_id == 0:
-                        T.copy(K[bz, k * block_N : (k + 1) * block_N, by, :], K_shared_0)
-                    else:
-                        T.copy(K[bz, k * block_N : (k + 1) * block_N, by, :], K_shared_1)
+                    T.copy(K[bz, k * block_N : (k + 1) * block_N, by, :], K_shared[stage_id, :, :])
                     T.mbarrier_arrive(mbar_dma1_full[stage_id])
 
                     T.mbarrier_wait_parity(mbar_dma2_empty[stage_id], parity_inv)
 
-                    if stage_id == 0:
-                        T.copy(V[bz, k * block_N : (k + 1) * block_N, by, :], V_shared_0)
-                    else:
-                        T.copy(V[bz, k * block_N : (k + 1) * block_N, by, :], V_shared_1)
+                    T.copy(V[bz, k * block_N : (k + 1) * block_N, by, :], V_shared[stage_id, :, :])
 
                     T.mbarrier_arrive(mbar_dma2_full[stage_id])
 
@@ -279,45 +271,26 @@ def flashattn_wasp(
                     T.mbarrier_wait_parity(mbar_dma1_full[stage_id], parity)
                     T.mbarrier_wait_parity(mbar_bmm1_empty[stage_id], parity_inv)
 
-                    if stage_id == 0:
-                        T.tcgen05_gemm(
-                            Q_shared,
-                            K_shared_0,
-                            S_tmem,
-                            transpose_B=True,
-                            mbar=mbar_bmm1_full[stage_id],
-                            clear_accum=True,
-                        )
-                    else:
-                        T.tcgen05_gemm(
-                            Q_shared,
-                            K_shared_1,
-                            S_tmem,
-                            transpose_B=True,
-                            mbar=mbar_bmm1_full[stage_id],
-                            clear_accum=True,
-                        )
+                    T.tcgen05_gemm(
+                        Q_shared,
+                        K_shared[stage_id, :, :],
+                        S_tmem,
+                        transpose_B=True,
+                        mbar=mbar_bmm1_full[stage_id],
+                        clear_accum=True,
+                    )
                     T.mbarrier_arrive(mbar_dma1_empty[stage_id])
 
                     T.mbarrier_wait_parity(mbar_softmax_full[stage_id], parity)
                     T.mbarrier_wait_parity(mbar_dma2_full[stage_id], parity)
 
-                    if stage_id == 0:
-                        T.tcgen05_gemm(
-                            P_tmem,
-                            V_shared_0,
-                            O_tmem,
-                            mbar=mbar_bmm2_full[stage_id],
-                            clear_accum=is_clear_accum,
-                        )
-                    else:
-                        T.tcgen05_gemm(
-                            P_tmem,
-                            V_shared_1,
-                            O_tmem,
-                            mbar=mbar_bmm2_full[stage_id],
-                            clear_accum=is_clear_accum,
-                        )
+                    T.tcgen05_gemm(
+                        P_tmem,
+                        V_shared[stage_id, :, :],
+                        O_tmem,
+                        mbar=mbar_bmm2_full[stage_id],
+                        clear_accum=is_clear_accum,
+                    )
 
                     T.mbarrier_arrive(mbar_softmax_empty[stage_id])
                     T.mbarrier_arrive(mbar_dma2_empty[stage_id])

--- a/examples/minference/example_vertical_slash_sparse_attn.py
+++ b/examples/minference/example_vertical_slash_sparse_attn.py
@@ -85,8 +85,9 @@ def _tl_vs_sparse_flashattn(batch, heads, seq_len, dim, vertical_size, slash_siz
         def Prefetch(
             K: T.Tensor(shape, dtype),
             V: T.Tensor(shape, dtype),
-            K_shared: T.SharedBuffer([block_N, dim], dtype),
-            V_shared: T.SharedBuffer([block_N, dim], dtype),
+            K_shared: T.SharedBuffer([num_stages, block_N, dim], dtype),
+            V_shared: T.SharedBuffer([num_stages, block_N, dim], dtype),
+            stage: T.int32,
             column_index: T.SharedBuffer([vertical_size_round], int_dtype),
             column_count: T.int32,
             k: T.int32,
@@ -94,10 +95,10 @@ def _tl_vs_sparse_flashattn(batch, heads, seq_len, dim, vertical_size, slash_siz
             by: T.int32,
         ):
             for i, j in T.Parallel(block_N, dim, prefer_async=True, annotations={"parallel_async_without_async_commit_wait": True}):
-                K_shared[i, j] = T.if_then_else(k + i < column_count, K[bz, by, column_index[k + i], j], 0)
+                K_shared[stage, i, j] = T.if_then_else(k + i < column_count, K[bz, by, column_index[k + i], j], 0)
 
             for i, j in T.Parallel(block_N, dim, prefer_async=True, annotations={"parallel_async_without_async_commit_wait": True}):
-                V_shared[i, j] = T.if_then_else(k + i < column_count, V[bz, by, column_index[k + i], j], 0)
+                V_shared[stage, i, j] = T.if_then_else(k + i < column_count, V[bz, by, column_index[k + i], j], 0)
 
             T.ptx_commit_group()
 
@@ -111,8 +112,9 @@ def _tl_vs_sparse_flashattn(batch, heads, seq_len, dim, vertical_size, slash_siz
             k: T.int32,
             column_count: T.int32,
             Q_shared: T.SharedBuffer([block_M, dim], dtype),
-            K_shared: T.SharedBuffer([block_N, dim], dtype),
-            V_shared: T.SharedBuffer([block_N, dim], dtype),
+            K_shared: T.SharedBuffer([num_stages, block_N, dim], dtype),
+            V_shared: T.SharedBuffer([num_stages, block_N, dim], dtype),
+            stage: T.int32,
             scores_scale: T.FragmentBuffer([block_M], accum_dtype),
             scores_sum: T.FragmentBuffer([block_M], accum_dtype),
             logsum: T.FragmentBuffer([block_M], accum_dtype),
@@ -121,7 +123,7 @@ def _tl_vs_sparse_flashattn(batch, heads, seq_len, dim, vertical_size, slash_siz
             T.ptx_wait_group(count)
             for i, j in T.Parallel(block_M, block_N):
                 acc_s[i, j] = T.if_then_else(k + j < column_count, 0, -T.infinity(acc_s.dtype))
-            T.gemm(Q_shared, K_shared, acc_s, transpose_B=True, policy=T.GemmWarpPolicy.FullRow)
+            T.gemm(Q_shared, K_shared[stage, :, :], acc_s, transpose_B=True, policy=T.GemmWarpPolicy.FullRow)
 
             T.copy(scores_max, scores_max_prev)
             T.reduce_max(acc_s, scores_max, dim=1, clear=False)
@@ -137,7 +139,7 @@ def _tl_vs_sparse_flashattn(batch, heads, seq_len, dim, vertical_size, slash_siz
 
             T.copy(acc_s, acc_s_cast)
 
-            T.gemm(acc_s_cast, V_shared, acc_o, policy=T.GemmWarpPolicy.FullRow)
+            T.gemm(acc_s_cast, V_shared[stage, :, :], acc_o, policy=T.GemmWarpPolicy.FullRow)
 
             T.reduce_sum(acc_s, scores_sum, dim=1)
 
@@ -158,12 +160,8 @@ def _tl_vs_sparse_flashattn(batch, heads, seq_len, dim, vertical_size, slash_siz
             with T.Kernel(T.ceildiv(seq_len, block_M), heads, batch, threads=256) as (bc, by, bz):
                 bx = T.ceildiv(seq_len, block_M) - 1 - bc
                 Q_shared = T.alloc_shared([block_M, dim], dtype)
-                K_shared = T.alloc_shared([2, block_N, dim], dtype)
-                V_shared = T.alloc_shared([2, block_N, dim], dtype)
-                K_shared_1 = T.alloc_shared([block_N, dim], dtype)
-                V_shared_1 = T.alloc_shared([block_N, dim], dtype)
-                K_shared_2 = T.alloc_shared([block_N, dim], dtype)
-                V_shared_2 = T.alloc_shared([block_N, dim], dtype)
+                K_shared = T.alloc_shared([num_stages, block_N, dim], dtype)
+                V_shared = T.alloc_shared([num_stages, block_N, dim], dtype)
                 O_shared = T.alloc_shared([block_M, dim], dtype)
                 acc_s = T.alloc_fragment([block_M, block_N], accum_dtype)
                 acc_s_cast = T.alloc_fragment([block_M, block_N], dtype)
@@ -245,81 +243,57 @@ def _tl_vs_sparse_flashattn(batch, heads, seq_len, dim, vertical_size, slash_siz
                             logsum[i] = logsum[i] * scores_scale[i] + scores_sum[i]
 
                     if column_count != 0:
-                        Prefetch(K, V, K_shared_1, V_shared_1, column_index, column_count, 0, bz, by)
+                        Prefetch(K, V, K_shared, V_shared, 0, column_index, column_count, 0, bz, by)
                         for bi in T.serial(T.ceildiv(column_count, block_N) - 1):
                             k = bi * block_N
-                            if bi % 2 == 0:
-                                Prefetch(K, V, K_shared_2, V_shared_2, column_index, column_count, k + block_N, bz, by)
+                            Prefetch(
+                                K,
+                                V,
+                                K_shared,
+                                V_shared,
+                                (bi + 1) % num_stages,
+                                column_index,
+                                column_count,
+                                k + block_N,
+                                bz,
+                                by,
+                            )
 
-                                Compute(
-                                    acc_s,
-                                    acc_s_cast,
-                                    acc_o,
-                                    scores_max,
-                                    scores_max_prev,
-                                    k,
-                                    column_count,
-                                    Q_shared,
-                                    K_shared_1,
-                                    V_shared_1,
-                                    scores_scale,
-                                    scores_sum,
-                                    logsum,
-                                    1,
-                                )
-                            else:
-                                Prefetch(K, V, K_shared_1, V_shared_1, column_index, column_count, k + block_N, bz, by)
-
-                                Compute(
-                                    acc_s,
-                                    acc_s_cast,
-                                    acc_o,
-                                    scores_max,
-                                    scores_max_prev,
-                                    k,
-                                    column_count,
-                                    Q_shared,
-                                    K_shared_2,
-                                    V_shared_2,
-                                    scores_scale,
-                                    scores_sum,
-                                    logsum,
-                                    1,
-                                )
-                        if T.ceildiv(column_count, block_N) % 2 == 0:
                             Compute(
                                 acc_s,
                                 acc_s_cast,
                                 acc_o,
                                 scores_max,
                                 scores_max_prev,
-                                T.ceildiv(column_count, block_N) * block_N - block_N,
+                                k,
                                 column_count,
                                 Q_shared,
-                                K_shared_2,
-                                V_shared_2,
+                                K_shared,
+                                V_shared,
+                                bi % num_stages,
                                 scores_scale,
                                 scores_sum,
                                 logsum,
-                                0,
+                                1,
                             )
-                        else:
-                            Compute(
-                                acc_s,
-                                acc_s_cast,
-                                acc_o,
-                                scores_max,
-                                scores_max_prev,
-                                T.ceildiv(column_count, block_N) * block_N - block_N,
-                                column_count,
-                                Q_shared,
-                                K_shared_1,
-                                V_shared_1,
-                                scores_scale,
-                                scores_sum,
-                                logsum,
-                                0,
-                            )
+                        last_stage = (T.ceildiv(column_count, block_N) - 1) % num_stages
+                        Compute(
+                            acc_s,
+                            acc_s_cast,
+                            acc_o,
+                            scores_max,
+                            scores_max_prev,
+                            T.ceildiv(column_count, block_N) * block_N - block_N,
+                            column_count,
+                            Q_shared,
+                            K_shared,
+                            V_shared,
+                            last_stage,
+                            scores_scale,
+                            scores_sum,
+                            logsum,
+                            0,
+                        )
                     for i, j in T.Parallel(block_M, dim):
                         acc_o[i, j] /= logsum[i]
                     T.copy(acc_o, O_shared)

--- a/maint/gemm/gemm_sm120/benchmark_sm120_nvfp4_blockscaled_gemm.py
+++ b/maint/gemm/gemm_sm120/benchmark_sm120_nvfp4_blockscaled_gemm.py
@@ -159,7 +159,7 @@ def tilelang_nvfp4_blockscaled_gemm(
                         tile_m = tile_id // n_blocks
                         owner = stream & 1
                         owner_iter = stream // 2
-                        for ko in T.unroll(k_tiles, explicit=False, unroll_factor=1):
+                        for ko in T.unroll(k_tiles, unroll_factor=1):
                             stage = ko % num_stages
                             phase = ((owner_iter * k_tiles + ko) // num_stages) & 1
                             barrier_slot = owner * num_stages + stage
@@ -209,7 +209,7 @@ def tilelang_nvfp4_blockscaled_gemm(
                             T.barrier_wait(wg_order[0], (owner_iter - 1) & 1)
 
                         T.clear(C0_local)
-                        for ko in T.unroll(k_tiles, explicit=False, unroll_factor=1):
+                        for ko in T.unroll(k_tiles, unroll_factor=1):
                             stage = ko % num_stages
                             phase = ((owner_iter * k_tiles + ko) // num_stages) & 1
                             barrier_slot = stage
@@ -247,7 +247,7 @@ def tilelang_nvfp4_blockscaled_gemm(
                         T.barrier_wait(wg_order[1], owner_iter & 1)
 
                         T.clear(C1_local)
-                        for ko in T.unroll(k_tiles, explicit=False, unroll_factor=1):
+                        for ko in T.unroll(k_tiles, unroll_factor=1):
                             stage = ko % num_stages
                             phase = ((owner_iter * k_tiles + ko) // num_stages) & 1
                             barrier_slot = num_stages + stage

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -6,6 +6,7 @@
 #include "support/check.h"
 #include <optional>
 #include <tvm/ir/cast.h>
+#include <tvm/relax/analysis.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/s_tir/utils.h>
 #include <tvm/tirx/builtin.h>
@@ -405,14 +406,42 @@ private:
     return block;
   }
 
-  int CheckAndGetBufferRowSize(const Buffer &buffer) {
-    ICHECK(buffer->shape.size() >= 2)
-        << "The dimension of Buffer \"" << buffer->name << "\" with shape "
-        << buffer->shape << " should be at least 2";
+  Array<PrimExpr> RemapAccessIndices(const Array<PrimExpr> &indices,
+                                     const Array<PrimExpr> &old_shape,
+                                     const Array<PrimExpr> &new_shape,
+                                     const Layout &layout,
+                                     const Optional<PrimExpr> &offset) {
+    ICHECK_EQ(indices.size(), old_shape.size())
+        << "The access rank must match the original buffer rank, but got "
+        << indices << " and " << old_shape;
+    ICHECK(!old_shape.empty())
+        << "Layout-remapped access pointers do not support scalar buffers";
+    const Array<PrimExpr> input_shape = layout->InputShape();
+    const Array<PrimExpr> output_shape = layout->OutputShape();
+    ICHECK(relax::CanProveShapeEqual(old_shape, input_shape, analyzer_))
+        << "The original buffer shape must match the layout input shape, but "
+           "got "
+        << old_shape << " and " << input_shape;
+    ICHECK(relax::CanProveShapeEqual(new_shape, output_shape, analyzer_))
+        << "The remapped buffer shape must match the layout output shape, but "
+           "got "
+        << new_shape << " and " << output_shape;
 
-    auto dim = buffer->shape.size();
-    auto buffer_row_size = buffer->shape[dim - 1].as<IntImmNode>()->value;
-    return buffer_row_size;
+    // Delinearize only the additional offset. Keeping the original indices in
+    // multidimensional form preserves slice-local expressions for the layout.
+    PrimExpr remaining_offset =
+        analyzer_->Simplify(offset.value_or(make_zero(indices[0].dtype())));
+    Array<PrimExpr> multi_dim_indices;
+    for (int i = static_cast<int>(old_shape.size()) - 1; i >= 0; --i) {
+      multi_dim_indices.insert(multi_dim_indices.begin(),
+                               floormod(remaining_offset, old_shape[i]));
+      remaining_offset = floordiv(remaining_offset, old_shape[i]);
+    }
+    for (size_t i = 0; i < indices.size(); ++i) {
+      multi_dim_indices.Set(
+          i, analyzer_->Simplify(indices[i] + multi_dim_indices[i]));
+    }
+    return layout->Forward(multi_dim_indices);
   }
 
   struct AccessPtrResult {
@@ -480,21 +509,15 @@ private:
       if (offset.defined()) {
         elem_offset = elem_offset + offset.value();
       }
-      // Get original and new buffer shapes
+      // Get original and new buffer shapes.
       Array<PrimExpr> old_shape = original_buffer->shape;
       Array<PrimExpr> new_shape = new_buffer->shape;
-      // Convert linear offset to multi-dimensional indices
-      Array<PrimExpr> multi_dim_indices;
-      PrimExpr remaining_offset = elem_offset;
-      for (int i = static_cast<int>(old_shape.size()) - 1; i >= 0; --i) {
-        multi_dim_indices.insert(
-            multi_dim_indices.begin(),
-            analyzer_->Simplify(floormod(remaining_offset, old_shape[i])));
-        remaining_offset =
-            analyzer_->Simplify(floordiv(remaining_offset, old_shape[i]));
+      Array<PrimExpr> zero_indices;
+      for (size_t i = 0; i < old_shape.size(); ++i) {
+        zero_indices.push_back(make_zero(elem_offset.dtype()));
       }
-      // Apply layout transformation
-      auto forward_indices = layout->Forward(multi_dim_indices);
+      Array<PrimExpr> forward_indices = RemapAccessIndices(
+          zero_indices, old_shape, new_shape, layout, elem_offset);
       PrimExpr new_offset = 0;
       PrimExpr stride_offset = 1;
       for (int i = static_cast<int>(new_shape.size()) - 1; i >= 0; --i) {
@@ -560,47 +583,8 @@ private:
         return result;
       }
 
-      PrimExpr elem_offset = 0;
-      PrimExpr stride = 1;
-
-      for (int i = static_cast<int>(old_shape.size()) - 1; i >= 0; --i) {
-        elem_offset += indices[i] * stride;
-        stride *= old_shape[i];
-      }
-
-      PrimExpr smem_offset =
-          elem_offset + (offset.defined() ? offset.value() : 0);
-
-      auto buffer_map_iter = buffer_map_.find(Downcast<Var>(remap_key->data));
-
-      int buffer_row_size = CheckAndGetBufferRowSize(buffer_map_iter->second);
-      (void)buffer_row_size;
-
-      // Convert offset to target-dimension, reindex it and convert it back
-      Array<PrimExpr> multi_dim_indices;
-      PrimExpr remaining_offset = smem_offset;
-
-      for (int i = static_cast<int>(old_shape.size()) - 1; i >= 0; --i) {
-        multi_dim_indices.insert(multi_dim_indices.begin(),
-                                 floormod(remaining_offset, old_shape[i]));
-        remaining_offset = floordiv(remaining_offset, old_shape[i]);
-      }
-
-      auto forward_indices = layout.value()->Forward(multi_dim_indices);
-      PrimExpr new_offset = 0;
-      PrimExpr stride_offset = 1;
-      for (int i = static_cast<int>(new_shape.size()) - 1; i >= 0; --i) {
-        new_offset += forward_indices[i] * stride_offset;
-        stride_offset *= new_shape[i];
-      }
-      new_offset = analyzer_->Simplify(new_offset);
-
-      Array<PrimExpr> new_indices;
-      for (int i = static_cast<int>(new_shape.size()) - 1; i >= 0; --i) {
-        new_indices.insert(new_indices.begin(),
-                           floormod(new_offset, new_shape[i]));
-        new_offset = floordiv(new_offset, new_shape[i]);
-      }
+      Array<PrimExpr> new_indices = RemapAccessIndices(
+          indices, old_shape, new_shape, layout.value(), offset);
 
       Array<PrimExpr> new_args = {BufferLoad(new_buffer, new_indices)};
       if (buffer_remap_.count(remap_key)) {
@@ -666,44 +650,8 @@ private:
         return result;
       }
 
-      PrimExpr elem_offset = 0;
-      PrimExpr stride = 1;
-      for (int i = static_cast<int>(old_shape.size()) - 1; i >= 0; --i) {
-        elem_offset += indices[i] * stride;
-        stride *= old_shape[i];
-      }
-
-      PrimExpr smem_offset =
-          elem_offset + (offset.defined() ? offset.value() : 0);
-
-      auto buffer_map_iter = buffer_map_.find(Downcast<Var>(remap_key->data));
-      int buffer_row_size = CheckAndGetBufferRowSize(buffer_map_iter->second);
-      (void)buffer_row_size;
-
-      // Convert offset to target-dimension, reindex it and convert it back
-      Array<PrimExpr> multi_dim_indices;
-      PrimExpr remaining_offset = smem_offset;
-      for (int i = static_cast<int>(old_shape.size()) - 1; i >= 0; --i) {
-        multi_dim_indices.insert(multi_dim_indices.begin(),
-                                 floormod(remaining_offset, old_shape[i]));
-        remaining_offset = floordiv(remaining_offset, old_shape[i]);
-      }
-
-      auto forward_indices = layout.value()->Forward(multi_dim_indices);
-      PrimExpr new_offset = 0;
-      PrimExpr stride_offset = 1;
-      for (int i = static_cast<int>(new_shape.size()) - 1; i >= 0; --i) {
-        new_offset += forward_indices[i] * stride_offset;
-        stride_offset *= new_shape[i];
-      }
-      new_offset = analyzer_->Simplify(new_offset);
-
-      Array<PrimExpr> new_indices;
-      for (int i = static_cast<int>(new_shape.size()) - 1; i >= 0; --i) {
-        new_indices.insert(new_indices.begin(),
-                           floormod(new_offset, new_shape[i]));
-        new_offset = floordiv(new_offset, new_shape[i]);
-      }
+      Array<PrimExpr> new_indices = RemapAccessIndices(
+          indices, old_shape, new_shape, layout.value(), offset);
 
       Array<PrimExpr> new_args = {BufferLoad(new_buffer, new_indices), extent,
                                   rw_mask};

--- a/testing/python/language/test_tilelang_language_wgmma_gemm.py
+++ b/testing/python/language/test_tilelang_language_wgmma_gemm.py
@@ -155,6 +155,53 @@ def _make_sliced_wgmma_kernel(M, N, K, num_k_tiles):
     return main
 
 
+def _make_static_sliced_wgmma_kernel():
+    @T.prim_func
+    def main(
+        A: T.Tensor((64, 32), T.float16),
+        B: T.Tensor((64, 32), T.float16),
+        D: T.Tensor((64, 64), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((64, 32), T.float16)
+            B_shared = T.alloc_shared((64, 32), T.float16)
+            C_local = T.alloc_fragment((64, 64), T.float32)
+
+            T.copy(A, A_shared)
+            T.copy(B, B_shared)
+            T.clear(C_local)
+            T.wgmma_gemm(
+                A_shared[:, 16:],
+                B_shared[:, 16:],
+                C_local,
+                transpose_B=True,
+            )
+            T.wait_wgmma(0)
+            T.copy(C_local, D)
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
+def test_wgmma_gemm_static_slice_initializes_from_slice_pointer():
+    import torch
+
+    kernel = tilelang.compile(_make_static_sliced_wgmma_kernel(), target="cuda")
+    source = kernel.get_kernel_source()
+
+    assert source.count("initialize_wgmma_descriptor") == 2
+    assert "increase_descriptor_offset" not in source
+    assert source.count("+ 2048") == 2
+
+    a = torch.randn((64, 32), device="cuda", dtype=torch.float16)
+    b = torch.randn((64, 32), device="cuda", dtype=torch.float16)
+    d = torch.empty((64, 64), device="cuda", dtype=torch.float16)
+    kernel(a, b, d)
+    expected = (a[:, 16:].float() @ b[:, 16:].float().T).half()
+    torch.testing.assert_close(d, expected, rtol=1e-2, atol=1e-2)
+
+
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_eq(9, 0)
 def test_wgmma_gemm_sliced_operand_emits_offset():

--- a/tilelang/cuda/intrinsics/macro/tcgen05_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/tcgen05_macro_generator.py
@@ -9,7 +9,7 @@ from ..layout.mma_sm100_layout import (
     validate_tcgen05_ts_instruction,
 )
 from tvm import DataType
-from tvm.tirx import PrimExpr, Buffer, Var, BufferLoad, BufferRegion
+from tvm.tirx import PrimExpr, Buffer, Var, BufferLoad, BufferRegion, handle_add_byte_offset
 from tilelang import tvm as tvm
 from tilelang import _ffi_api
 from tilelang.language.dtypes import get_tvm_dtype
@@ -164,8 +164,9 @@ def compute_umma_descriptor(tl_layout, buffer, transposed: bool, micro_size_k: i
     slice_byte_offset = 0
     if region is not None:
         slice_off_elems, tile = cute.restrict(composed_elem.layout, region)
-        if slice_off_elems != 0:
-            slice_byte_offset = tvm.arith.Analyzer().simplify(slice_off_elems * elem_bits // 8)
+        slice_byte_offset = slice_off_elems * elem_bits // 8
+        if not isinstance(slice_byte_offset, int):
+            slice_byte_offset = tvm.arith.Analyzer().simplify(slice_byte_offset)
     assert cute.rank(tile) == 2, f"UMMA operand tile must be rank-2 (MN, K), got rank {cute.rank(tile)}"
     # Present in UMMA (MN, K) order, then recast the swizzled element layout to
     # uint128_t (exactly CuTe's recast<uint128_t const>(tensor)).
@@ -817,12 +818,20 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         sbo = b_params.stride_byte_offset
         swizzle_mode = b_params.swizzle_mode.tcgen05_layout_type()
         slice_byte_offset = b_params.slice_byte_offset
-        is_sliced = not isinstance(slice_byte_offset, int) or slice_byte_offset != 0
         B_base_ptr = self._as_buffer(B_buf).access_ptr("r")
+        if not isinstance(slice_byte_offset, int):
+            # A dynamic slice. Use `increase_descriptor_offset` to represent the dynamic offset, to share a common base pointer.
+            is_sliced = True
+        elif slice_byte_offset != 0:
+            # A static slice. Add to the pointer directly to avoid an excessive `increase_descriptor_offset`.
+            is_sliced = False
+            B_base_ptr = handle_add_byte_offset(B_base_ptr, slice_byte_offset)
+        else:
+            # Non-sliced.
+            is_sliced = False
 
         @T.macro
         def _init_b(desc_b, B_base_ptr):
-            # Build from the buffer base (uniform cvta), then advance to the slice origin.
             T.initialize_tcgen05_descriptor(desc_b, B_base_ptr, lbo, sbo, 0, False, swizzle_mode)
             if is_sliced:
                 T.increase_descriptor_offset(desc_b, slice_byte_offset)
@@ -845,12 +854,17 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         sbo = a_params.stride_byte_offset
         swizzle_mode = a_params.swizzle_mode.tcgen05_layout_type()
         slice_byte_offset = a_params.slice_byte_offset
-        is_sliced = not isinstance(slice_byte_offset, int) or slice_byte_offset != 0
         A_base_ptr = self._as_buffer(A_buf).access_ptr("r")
+        if not isinstance(slice_byte_offset, int):
+            is_sliced = True
+        elif slice_byte_offset != 0:
+            is_sliced = False
+            A_base_ptr = handle_add_byte_offset(A_base_ptr, slice_byte_offset)
+        else:
+            is_sliced = False
 
         @T.macro
         def _init_a(desc_a, A_base_ptr):
-            # Build from the buffer base (uniform cvta), then advance to the slice origin.
             T.initialize_tcgen05_descriptor(desc_a, A_base_ptr, lbo, sbo, 0, False, swizzle_mode)
             if is_sliced:
                 T.increase_descriptor_offset(desc_a, slice_byte_offset)

--- a/tilelang/cuda/intrinsics/macro/wgmma_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/wgmma_macro_generator.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from collections.abc import Callable
 from .mma_macro_generator import TensorCoreIntrinEmitter as MMAIntrinEmitter
 from tvm import DataType
-from tvm.tirx import PrimExpr, Buffer, Var, IndexMap, BufferRegion
+from tvm.tirx import PrimExpr, Buffer, Var, IndexMap, BufferRegion, handle_add_byte_offset
 from tilelang import tvm as tvm
 from tilelang.utils import is_fragment, is_full_region
 from math import gcd
@@ -101,8 +101,9 @@ def compute_gmma_descriptor(tl_layout, buffer, transposed: bool, micro_size_k: i
     if region is not None:
         slice_off_elems, tile = cute.restrict(composed_elem.layout, region)
         # A statically-zero origin is a plain int 0; a runtime origin is a PrimExpr.
-        if slice_off_elems != 0:
-            slice_byte_offset = tvm.arith.Analyzer().simplify(slice_off_elems * bits // 8)
+        slice_byte_offset = slice_off_elems * bits // 8
+        if not isinstance(slice_byte_offset, int):
+            slice_byte_offset = tvm.arith.Analyzer().simplify(slice_byte_offset)
     assert cute.rank(tile) == 2, f"WGMMA operand tile must be rank-2 (MN, K), got rank {cute.rank(tile)}"
 
     # Present in GMMA (MN, K) order, then recast the swizzled element layout to
@@ -443,7 +444,16 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         B_buf = B_region.buffer if isinstance(B_region, BufferRegion) else B_region
         B_base_ptr = B_buf.access_ptr("r")
         slice_byte_offset = b_params.slice_byte_offset
-        is_sliced = not isinstance(slice_byte_offset, int) or slice_byte_offset != 0
+        if not isinstance(slice_byte_offset, int):
+            # A dynamic slice. Use `increase_descriptor_offset` to represent the dynamic offset, to share a common base pointer.
+            is_sliced = True
+        elif slice_byte_offset != 0:
+            # A static slice. Add to the pointer directly to avoid an excessive `increase_descriptor_offset`.
+            is_sliced = False
+            B_base_ptr = handle_add_byte_offset(B_base_ptr, slice_byte_offset)
+        else:
+            # Non-sliced.
+            is_sliced = False
         swizzle_mode = b_params.swizzle_mode.wgmma_layout_type()
         lbo = b_params.leading_byte_offset
         sbo = b_params.stride_byte_offset
@@ -480,7 +490,13 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         A_buf = A_region.buffer if isinstance(A_region, BufferRegion) else A_region
         A_base_ptr = A_buf.access_ptr("r")
         slice_byte_offset = a_params.slice_byte_offset
-        is_sliced = not isinstance(slice_byte_offset, int) or slice_byte_offset != 0
+        if not isinstance(slice_byte_offset, int):
+            is_sliced = True
+        elif slice_byte_offset != 0:
+            is_sliced = False
+            A_base_ptr = handle_add_byte_offset(A_base_ptr, slice_byte_offset)
+        else:
+            is_sliced = False
         swizzle_mode = a_params.swizzle_mode.wgmma_layout_type()
         lbo = a_params.leading_byte_offset
         sbo = a_params.stride_byte_offset

--- a/tilelang/cuda/intrinsics/macro/wgmma_sp_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/wgmma_sp_macro_generator.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
-from tilelang.cuda.intrinsics.macro.wgmma_macro_generator import gcd, compute_gmma_descriptor, WGMMADescriptorParams
+from tilelang.cuda.intrinsics.macro.wgmma_macro_generator import (
+    WGMMADescriptorParams,
+    compute_gmma_descriptor,
+    gcd,
+)
 from tilelang.cuda.intrinsics.macro.mma_sp_macro_generator import SparseTensorCoreIntrinEmitter
 import tilelang.language as T
 from tvm import DataType
-from tvm.tirx import PrimExpr, Buffer, Var, BufferRegion, IndexMap
+from tvm.tirx import PrimExpr, Buffer, Var, BufferRegion, IndexMap, handle_add_byte_offset
 from tilelang.utils import is_fragment, is_shared, is_full_region
 from tilelang.cuda.intrinsics.layout.mma_layout import (
     shared_16x8_to_mma_32x4_layout_sr_a,
@@ -172,8 +176,6 @@ class WGSparseTensorCoreIntrinEmitter(SparseTensorCoreIntrinEmitter):
         b_swizzle_atom_elems = b_params.swizzle_atom_elems
         a_slice_byte_offset = a_params.slice_byte_offset
         b_slice_byte_offset = b_params.slice_byte_offset
-        a_is_sliced = not isinstance(a_slice_byte_offset, int) or a_slice_byte_offset != 0
-        b_is_sliced = not isinstance(b_slice_byte_offset, int) or b_slice_byte_offset != 0
 
         accum_bits = DataType(accum_dtype).bits
         accum_regs = ((m_dim // 64) * warp_cols * local_size_out * accum_bits + 31) // 32
@@ -191,7 +193,21 @@ class WGSparseTensorCoreIntrinEmitter(SparseTensorCoreIntrinEmitter):
         A_buf = A_region.buffer if isinstance(A_region, BufferRegion) else A_region
         B_buf = B_region.buffer if isinstance(B_region, BufferRegion) else B_region
         A_base_ptr = A_buf.access_ptr("r")
+        if not isinstance(a_slice_byte_offset, int):
+            a_is_sliced = True
+        elif a_slice_byte_offset != 0:
+            a_is_sliced = False
+            A_base_ptr = handle_add_byte_offset(A_base_ptr, a_slice_byte_offset)
+        else:
+            a_is_sliced = False
         B_base_ptr = B_buf.access_ptr("r")
+        if not isinstance(b_slice_byte_offset, int):
+            b_is_sliced = True
+        elif b_slice_byte_offset != 0:
+            b_is_sliced = False
+            B_base_ptr = handle_add_byte_offset(B_base_ptr, b_slice_byte_offset)
+        else:
+            b_is_sliced = False
         assert is_full_region(C_region), "Fragment output C must be a full region"
         C_buf = C_region.buffer
 
@@ -322,7 +338,6 @@ class WGSparseTensorCoreIntrinEmitter(SparseTensorCoreIntrinEmitter):
         b_swizzle_mode = b_params.swizzle_mode
         b_swizzle_atom_elems = b_params.swizzle_atom_elems
         b_slice_byte_offset = b_params.slice_byte_offset
-        b_is_sliced = not isinstance(b_slice_byte_offset, int) or b_slice_byte_offset != 0
         bk_atom_size = b_params.k_atom_size
         wgmma_inst_m, wgmma_inst_n = self.wgmma_inst_m, self.wgmma_inst_n
         num_inst_m = 4 * self.warp_row_tiles // wgmma_inst_m
@@ -335,6 +350,16 @@ class WGSparseTensorCoreIntrinEmitter(SparseTensorCoreIntrinEmitter):
         A_buf = A_region.buffer
         B_buf = B_region.buffer if isinstance(B_region, BufferRegion) else B_region
         B_base_ptr = B_buf.access_ptr("r")
+        if not isinstance(b_slice_byte_offset, int):
+            # A dynamic slice. Use `increase_descriptor_offset` to represent the dynamic offset, to share a common base pointer.
+            b_is_sliced = True
+        elif b_slice_byte_offset != 0:
+            # A static slice. Add to the pointer directly to avoid an excessive `increase_descriptor_offset`.
+            b_is_sliced = False
+            B_base_ptr = handle_add_byte_offset(B_base_ptr, b_slice_byte_offset)
+        else:
+            # Non-sliced.
+            b_is_sliced = False
         C_buf = C_region.buffer
 
         k_blocks = k_dim // micro_size_k


### PR DESCRIPTION
Thanks to my series of PRs (#2380, #2452, #2785), you can write arbitrary slicing expressions to express the multiple stages of a multi-version buffer. So you no longer need to write brittle code that declares multiple versions of a buffer for multiple times, just to pass it to the exact same T.copy, T.gemm, etc., due to lack of support for slicing. Use slicing and indexing. That's all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Reworked CUDA examples to use configurable, stage-indexed shared-memory buffers.
- Consolidated repeated query, KV, output, and barrier allocations.
- Replaced stage-specific branches with indexed multi-stage pipelines.
- Updated MLA, sparse attention, flash attention, and vertical/slash attention examples.
- Added sliced-buffer support for WGMMA and TCGEN05 descriptor initialization.
- Updated layout-remapped access handling in `lower_tile_op.cc`.
- Removed explicit unrolling flags from the SM120 NVFP4 benchmark.
- Added regression coverage for static non-zero-origin WGMMA slices.

## Testing

- Run regression performance testing twice for the updated CUDA kernels.
- Run the new WGMMA sliced-buffer test.

## C++ style / lint notes

- The PR changes C++ code in `src/transform/lower_tile_op.cc`.
- Review the changes against `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step is relevant.
- Treat TLCPP003 and TLCPP004 findings as advisory unless they indicate a clear API, FFI, or maintainability risk.
- Separate correctness and build failures from warning-only style findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->