### PR TITLE
[BugFix][CUDA] Guard cp.async transfers by full source extent

### DIFF
--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -15,6 +15,7 @@
 
 #include <optional>
 #include <utility>
+#include <vector>
 
 #include "../op/builtin.h"
 #include "../op/parallel.h"
@@ -686,6 +687,70 @@ private:
     return Optional<PrimExpr>();
   }
 
+  Stmt MakeCPAsyncFallbackStores(const AccessPtrInfo &dst_info,
+                                 const Call &call, const PrimExpr &safe_value) {
+    Buffer dst_buffer = dst_info.base_load->buffer;
+    Array<PrimExpr> physical_indices =
+        dst_buffer.OffsetOf(dst_info.base_load->indices);
+    Buffer flattened_dst_buffer = dst_buffer.GetFlattenedBuffer();
+    ICHECK_EQ(physical_indices.size(), flattened_dst_buffer->shape.size())
+        << "cp.async destination access cannot be flattened: " << call;
+    ICHECK(!physical_indices.empty())
+        << "cp.async destination access has no physical offset: " << call;
+
+    PrimExpr linear_index = physical_indices[0];
+    for (size_t i = 1; i < physical_indices.size(); ++i) {
+      linear_index =
+          linear_index * flattened_dst_buffer->shape[i] + physical_indices[i];
+    }
+    PrimExpr elem_offset = dst_buffer->elem_offset;
+    if (elem_offset.dtype() != linear_index.dtype()) {
+      elem_offset = Cast(linear_index.dtype(), elem_offset);
+    }
+    linear_index = linear_index - elem_offset;
+
+    PrimExpr num_elems = call->args[2];
+    if (call->op.same_as(builtin::ptx_cp_async())) {
+      int dst_elem_bits = dst_buffer->dtype.bits() * dst_buffer->dtype.lanes();
+      ICHECK_GT(dst_elem_bits, 0)
+          << "cp.async destination element width must be positive: " << call;
+      PrimExpr dst_elem_bits_expr = IntImm(num_elems.dtype(), dst_elem_bits);
+      PrimExpr transfer_bits = num_elems * IntImm(num_elems.dtype(), 8);
+      num_elems = FloorDiv(transfer_bits + dst_elem_bits_expr -
+                               IntImm(num_elems.dtype(), 1),
+                           dst_elem_bits_expr);
+    }
+
+    Var fallback_offset("cp_async_fallback_offset", num_elems.dtype());
+    PrimExpr typed_fallback_offset = fallback_offset;
+    if (typed_fallback_offset.dtype() != linear_index.dtype()) {
+      typed_fallback_offset = Cast(linear_index.dtype(), typed_fallback_offset);
+    }
+    PrimExpr remaining_index = linear_index + typed_fallback_offset;
+    std::vector<PrimExpr> reversed_indices;
+    reversed_indices.reserve(flattened_dst_buffer->shape.size());
+    for (size_t axis = flattened_dst_buffer->shape.size(); axis > 0; --axis) {
+      size_t index = axis - 1;
+      if (index == 0) {
+        reversed_indices.push_back(remaining_index);
+      } else {
+        reversed_indices.push_back(
+            FloorMod(remaining_index, flattened_dst_buffer->shape[index]));
+        remaining_index =
+            FloorDiv(remaining_index, flattened_dst_buffer->shape[index]);
+      }
+    }
+    Array<PrimExpr> dst_indices;
+    for (auto it = reversed_indices.rbegin(); it != reversed_indices.rend();
+         ++it) {
+      dst_indices.push_back(*it);
+    }
+    Stmt fallback_store =
+        BufferStore(flattened_dst_buffer, safe_value, dst_indices);
+    return For(fallback_offset, make_zero(num_elems.dtype()), num_elems,
+               ForKind::kSerial, fallback_store);
+  }
+
   Stmt RewriteCPAsync(const Evaluate &evaluate, const Call &call,
                       const Array<PrimExpr> &conditions) {
     if (conditions.empty()) {
@@ -723,8 +788,7 @@ private:
           Call(call->dtype, call->op, new_args, call->annotations, call->span));
     }
 
-    Stmt else_case = BufferStore(dst_info.base_load->buffer, safe_value,
-                                 dst_info.base_load->indices);
+    Stmt else_case = MakeCPAsyncFallbackStores(dst_info, call, safe_value);
     return IfThenElse(combined, evaluate, else_case);
   }
 

--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -551,10 +551,23 @@ private:
           << "Buffer data var " << buffer_data
           << " is not registered in buffer_data_to_buffer_.";
       Buffer flat = buffer_data_to_buffer_[buffer_data].GetFlattenedBuffer();
+      DataType pointer_element_dtype = ptr_call->args[0].dtype();
+      PrimExpr offset = ptr_call->args[2];
+      if (pointer_element_dtype != flat->dtype) {
+        int pointer_elem_bits =
+            pointer_element_dtype.bits() * pointer_element_dtype.lanes();
+        int buffer_elem_bits = flat->dtype.bits() * flat->dtype.lanes();
+        ICHECK_GT(pointer_elem_bits, 0)
+            << "tvm_access_ptr element width must be positive: " << expr;
+        ICHECK_GT(buffer_elem_bits, 0)
+            << "tvm_access_ptr buffer element width must be positive: " << expr;
+        offset = FloorDiv(offset * IntImm(offset.dtype(), pointer_elem_bits),
+                          IntImm(offset.dtype(), buffer_elem_bits));
+      }
       return AccessPtrInfo{
-          BufferLoad(flat, Array<PrimExpr>{ptr_call->args[2]}),
+          BufferLoad(flat, Array<PrimExpr>{offset}),
           ptr_call->args[4],
-          ptr_call->args[0].dtype(),
+          pointer_element_dtype,
       };
     }
 
@@ -654,6 +667,7 @@ private:
       }
       checker.PushCondition(condition);
     };
+    push_distinct_condition(linear_index >= make_zero(linear_index.dtype()));
     push_distinct_condition(last_index < flattened_extent);
     return checker.GetConditions();
   }

--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -369,6 +369,7 @@ private:
   struct AccessPtrInfo {
     BufferLoad base_load;
     PrimExpr rw_mask;
+    DataType element_dtype;
   };
 
   // Constructor initializing the base class with the analyzer
@@ -535,6 +536,7 @@ private:
       return AccessPtrInfo{
           Downcast<BufferLoad>(ptr_call->args[0]),
           ptr_call->args[2],
+          base_load->buffer->dtype,
       };
     }
 
@@ -552,6 +554,7 @@ private:
       return AccessPtrInfo{
           BufferLoad(flat, Array<PrimExpr>{ptr_call->args[2]}),
           ptr_call->args[4],
+          ptr_call->args[0].dtype(),
       };
     }
 
@@ -632,19 +635,8 @@ private:
     }
     linear_index = linear_index - elem_offset;
 
-    PrimExpr num_elems = call->args[2];
-    if (call->op.same_as(builtin::ptx_cp_async())) {
-      int source_elem_bits =
-          src_buffer->dtype.bits() * src_buffer->dtype.lanes();
-      ICHECK_GT(source_elem_bits, 0)
-          << "cp.async source element width must be positive: " << call;
-      PrimExpr source_elem_bits_expr =
-          IntImm(num_elems.dtype(), source_elem_bits);
-      PrimExpr transfer_bits = num_elems * IntImm(num_elems.dtype(), 8);
-      num_elems = FloorDiv(transfer_bits + source_elem_bits_expr -
-                               IntImm(num_elems.dtype(), 1),
-                           source_elem_bits_expr);
-    }
+    PrimExpr num_elems =
+        GetCPAsyncTransferBufferElements(call, src_info, "source");
     if (num_elems.dtype() != linear_index.dtype()) {
       num_elems = Cast(linear_index.dtype(), num_elems);
     }
@@ -672,6 +664,38 @@ private:
     AccessPtrInfo src_info =
         GetRequiredAccessPtrInfo(call->args[kCPAsyncSrcPtrArg], "cp.async");
     return src_info.base_load->buffer;
+  }
+
+  PrimExpr GetCPAsyncTransferBufferElements(const Call &call,
+                                            const AccessPtrInfo &info,
+                                            const char *operand_name) {
+    PrimExpr num_elems = call->args[2];
+    if (!call->op.same_as(builtin::ptx_cp_async()) &&
+        info.element_dtype == info.base_load->buffer->dtype) {
+      return num_elems;
+    }
+
+    int buffer_elem_bits = info.base_load->buffer->dtype.bits() *
+                           info.base_load->buffer->dtype.lanes();
+    ICHECK_GT(buffer_elem_bits, 0)
+        << "cp.async " << operand_name
+        << " buffer element width must be positive: " << call;
+    int transfer_elem_bits = 8;
+    if (!call->op.same_as(builtin::ptx_cp_async())) {
+      transfer_elem_bits =
+          info.element_dtype.bits() * info.element_dtype.lanes();
+      ICHECK_GT(transfer_elem_bits, 0)
+          << "cp.async " << operand_name
+          << " access pointer element width must be positive: " << call;
+    }
+
+    PrimExpr transfer_bits =
+        num_elems * IntImm(num_elems.dtype(), transfer_elem_bits);
+    PrimExpr buffer_elem_bits_expr =
+        IntImm(num_elems.dtype(), buffer_elem_bits);
+    return analyzer_->Simplify(FloorDiv(transfer_bits + buffer_elem_bits_expr -
+                                            IntImm(num_elems.dtype(), 1),
+                                        buffer_elem_bits_expr));
   }
 
   PrimExpr CombineConditions(const Array<PrimExpr> &conditions) {
@@ -713,17 +737,8 @@ private:
     }
     linear_index = linear_index - elem_offset;
 
-    PrimExpr num_elems = call->args[2];
-    if (call->op.same_as(builtin::ptx_cp_async())) {
-      int dst_elem_bits = dst_buffer->dtype.bits() * dst_buffer->dtype.lanes();
-      ICHECK_GT(dst_elem_bits, 0)
-          << "cp.async destination element width must be positive: " << call;
-      PrimExpr dst_elem_bits_expr = IntImm(num_elems.dtype(), dst_elem_bits);
-      PrimExpr transfer_bits = num_elems * IntImm(num_elems.dtype(), 8);
-      num_elems = FloorDiv(transfer_bits + dst_elem_bits_expr -
-                               IntImm(num_elems.dtype(), 1),
-                           dst_elem_bits_expr);
-    }
+    PrimExpr num_elems =
+        GetCPAsyncTransferBufferElements(call, dst_info, "destination");
 
     Var fallback_offset("cp_async_fallback_offset", num_elems.dtype());
     PrimExpr typed_fallback_offset = fallback_offset;

--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -645,8 +645,11 @@ private:
                                IntImm(num_elems.dtype(), 1),
                            source_elem_bits_expr);
     }
+    if (num_elems.dtype() != linear_index.dtype()) {
+      num_elems = Cast(linear_index.dtype(), num_elems);
+    }
     PrimExpr last_index =
-        linear_index + num_elems - IntImm(num_elems.dtype(), 1);
+        linear_index + num_elems - IntImm(linear_index.dtype(), 1);
     PrimExpr flattened_extent = flattened_src_buffer->shape[0];
     for (size_t i = 1; i < flattened_src_buffer->shape.size(); ++i) {
       flattened_extent = flattened_extent * flattened_src_buffer->shape[i];
@@ -688,7 +691,8 @@ private:
   }
 
   Stmt MakeCPAsyncFallbackStores(const AccessPtrInfo &dst_info,
-                                 const Call &call, const PrimExpr &safe_value) {
+                                 const Call &call, const PrimExpr &safe_value,
+                                 const Optional<PrimExpr> &existing_predicate) {
     Buffer dst_buffer = dst_info.base_load->buffer;
     Array<PrimExpr> physical_indices =
         dst_buffer.OffsetOf(dst_info.base_load->indices);
@@ -745,8 +749,14 @@ private:
          ++it) {
       dst_indices.push_back(*it);
     }
+    PrimExpr fallback_value = safe_value;
+    if (existing_predicate.defined()) {
+      fallback_value = analyzer_->Simplify(
+          if_then_else(existing_predicate.value(), safe_value,
+                       make_zero(safe_value.dtype())));
+    }
     Stmt fallback_store =
-        BufferStore(flattened_dst_buffer, safe_value, dst_indices);
+        BufferStore(flattened_dst_buffer, fallback_value, dst_indices);
     return For(fallback_offset, make_zero(num_elems.dtype()), num_elems,
                ForKind::kSerial, fallback_store);
   }
@@ -788,7 +798,8 @@ private:
           Call(call->dtype, call->op, new_args, call->annotations, call->span));
     }
 
-    Stmt else_case = MakeCPAsyncFallbackStores(dst_info, call, safe_value);
+    Stmt else_case = MakeCPAsyncFallbackStores(dst_info, call, safe_value,
+                                               existing_predicate);
     return IfThenElse(combined, evaluate, else_case);
   }
 

--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -370,6 +370,10 @@ private:
     BufferLoad base_load;
     PrimExpr rw_mask;
     DataType element_dtype;
+    // tvm_access_ptr offsets are expressed in element_dtype units. Keep the
+    // original offset so byte-granular accesses can be checked without losing
+    // an intra-element address through the flattened BufferLoad.
+    std::optional<PrimExpr> raw_element_offset;
   };
 
   // Constructor initializing the base class with the analyzer
@@ -537,6 +541,7 @@ private:
           Downcast<BufferLoad>(ptr_call->args[0]),
           ptr_call->args[2],
           base_load->buffer->dtype,
+          std::nullopt,
       };
     }
 
@@ -568,6 +573,7 @@ private:
           BufferLoad(flat, Array<PrimExpr>{offset}),
           ptr_call->args[4],
           pointer_element_dtype,
+          ptr_call->args[2],
       };
     }
 
@@ -624,8 +630,57 @@ private:
       return conditions;
     }
 
-    SafeMemChecker checker(analyzer_, /*recursively_collect_conds=*/false);
     Buffer src_buffer = src_info.base_load->buffer;
+    int src_buffer_elem_bits =
+        src_buffer->dtype.bits() * src_buffer->dtype.lanes();
+    int src_pointer_elem_bits =
+        src_info.element_dtype.bits() * src_info.element_dtype.lanes();
+    ICHECK_GT(src_buffer_elem_bits, 0)
+        << "cp.async source buffer element width must be positive: " << call;
+    ICHECK_GT(src_pointer_elem_bits, 0)
+        << "cp.async source access pointer element width must be positive: "
+        << call;
+
+    // A tvm_access_ptr may address a typed buffer through a narrower element
+    // type (for example, uint8 into float64). In that case, rounding the byte
+    // address down to a BufferLoad element loses the intra-element offset and
+    // can miss the final bytes of a transfer. Check that byte range directly.
+    if (src_info.raw_element_offset.has_value() &&
+        src_pointer_elem_bits != src_buffer_elem_bits) {
+      PrimExpr byte_offset = src_info.raw_element_offset.value() *
+                             IntImm(src_info.raw_element_offset.value().dtype(),
+                                    src_pointer_elem_bits);
+      PrimExpr elem_offset = src_buffer->elem_offset;
+      if (elem_offset.dtype() != byte_offset.dtype()) {
+        elem_offset = Cast(byte_offset.dtype(), elem_offset);
+      }
+      byte_offset = byte_offset - elem_offset * IntImm(byte_offset.dtype(),
+                                                       src_buffer_elem_bits);
+
+      PrimExpr transfer_bits = GetCPAsyncTransferBits(call, src_info, "source");
+      if (transfer_bits.dtype() != byte_offset.dtype()) {
+        transfer_bits = Cast(byte_offset.dtype(), transfer_bits);
+      }
+      Buffer flattened_src_buffer = src_buffer.GetFlattenedBuffer();
+      PrimExpr flattened_extent = flattened_src_buffer->shape[0];
+      for (size_t i = 1; i < flattened_src_buffer->shape.size(); ++i) {
+        flattened_extent = flattened_extent * flattened_src_buffer->shape[i];
+      }
+      PrimExpr flattened_extent_bits =
+          flattened_extent *
+          IntImm(flattened_extent.dtype(), src_buffer_elem_bits);
+      if (flattened_extent_bits.dtype() != byte_offset.dtype()) {
+        flattened_extent_bits =
+            Cast(byte_offset.dtype(), flattened_extent_bits);
+      }
+      SafeMemChecker checker(analyzer_, /*recursively_collect_conds=*/false);
+      checker.PushCondition(byte_offset >= make_zero(byte_offset.dtype()));
+      checker.PushCondition(byte_offset + transfer_bits <=
+                            flattened_extent_bits);
+      return checker.GetConditions();
+    }
+
+    SafeMemChecker checker(analyzer_, /*recursively_collect_conds=*/false);
     checker.CheckBufferIndices(src_buffer, src_info.base_load->indices,
                                /*is_load=*/true, /*throw_warning=*/false);
 
@@ -680,20 +735,9 @@ private:
     return src_info.base_load->buffer;
   }
 
-  PrimExpr GetCPAsyncTransferBufferElements(const Call &call,
-                                            const AccessPtrInfo &info,
-                                            const char *operand_name) {
+  PrimExpr GetCPAsyncTransferBits(const Call &call, const AccessPtrInfo &info,
+                                  const char *operand_name) {
     PrimExpr num_elems = call->args[2];
-    if (!call->op.same_as(builtin::ptx_cp_async()) &&
-        info.element_dtype == info.base_load->buffer->dtype) {
-      return num_elems;
-    }
-
-    int buffer_elem_bits = info.base_load->buffer->dtype.bits() *
-                           info.base_load->buffer->dtype.lanes();
-    ICHECK_GT(buffer_elem_bits, 0)
-        << "cp.async " << operand_name
-        << " buffer element width must be positive: " << call;
     int transfer_elem_bits = 8;
     if (!call->op.same_as(builtin::ptx_cp_async())) {
       transfer_elem_bits =
@@ -702,14 +746,73 @@ private:
           << "cp.async " << operand_name
           << " access pointer element width must be positive: " << call;
     }
+    return num_elems * IntImm(num_elems.dtype(), transfer_elem_bits);
+  }
 
-    PrimExpr transfer_bits =
-        num_elems * IntImm(num_elems.dtype(), transfer_elem_bits);
+  PrimExpr GetCPAsyncTransferBufferElements(const Call &call,
+                                            const AccessPtrInfo &info,
+                                            const char *operand_name) {
+    if (!call->op.same_as(builtin::ptx_cp_async()) &&
+        info.element_dtype == info.base_load->buffer->dtype) {
+      return call->args[2];
+    }
+
+    int buffer_elem_bits = info.base_load->buffer->dtype.bits() *
+                           info.base_load->buffer->dtype.lanes();
+    ICHECK_GT(buffer_elem_bits, 0)
+        << "cp.async " << operand_name
+        << " buffer element width must be positive: " << call;
+
+    PrimExpr transfer_bits = GetCPAsyncTransferBits(call, info, operand_name);
+    PrimExpr num_elems = call->args[2];
     PrimExpr buffer_elem_bits_expr =
         IntImm(num_elems.dtype(), buffer_elem_bits);
     return analyzer_->Simplify(FloorDiv(transfer_bits + buffer_elem_bits_expr -
                                             IntImm(num_elems.dtype(), 1),
                                         buffer_elem_bits_expr));
+  }
+
+  bool CanMakeCPAsyncFallbackStores(const AccessPtrInfo &dst_info,
+                                    const Call &call) {
+    Buffer dst_buffer = dst_info.base_load->buffer;
+    int buffer_elem_bits = dst_buffer->dtype.bits() * dst_buffer->dtype.lanes();
+    ICHECK_GT(buffer_elem_bits, 0)
+        << "cp.async destination buffer element width must be positive: "
+        << call;
+
+    PrimExpr transfer_bits =
+        GetCPAsyncTransferBits(call, dst_info, "destination");
+    PrimExpr buffer_elem_bits_expr =
+        IntImm(transfer_bits.dtype(), buffer_elem_bits);
+    if (!analyzer_->CanProveEqual(
+            FloorMod(transfer_bits, buffer_elem_bits_expr),
+            make_zero(transfer_bits.dtype()))) {
+      return false;
+    }
+
+    if (!dst_info.raw_element_offset.has_value()) {
+      return true;
+    }
+
+    int pointer_elem_bits =
+        dst_info.element_dtype.bits() * dst_info.element_dtype.lanes();
+    ICHECK_GT(pointer_elem_bits, 0) << "cp.async destination access pointer "
+                                       "element width must be positive: "
+                                    << call;
+    PrimExpr byte_offset =
+        dst_info.raw_element_offset.value() *
+        IntImm(dst_info.raw_element_offset.value().dtype(), pointer_elem_bits);
+    PrimExpr elem_offset = dst_buffer->elem_offset;
+    if (elem_offset.dtype() != byte_offset.dtype()) {
+      elem_offset = Cast(byte_offset.dtype(), elem_offset);
+    }
+    byte_offset = byte_offset -
+                  elem_offset * IntImm(byte_offset.dtype(), buffer_elem_bits);
+    PrimExpr offset_elem_bits_expr =
+        IntImm(byte_offset.dtype(), buffer_elem_bits);
+    return analyzer_->CanProveEqual(
+        FloorMod(byte_offset, offset_elem_bits_expr),
+        make_zero(byte_offset.dtype()));
   }
 
   PrimExpr CombineConditions(const Array<PrimExpr> &conditions) {
@@ -825,6 +928,15 @@ private:
       new_args.push_back(predicate);
       return Evaluate(
           Call(call->dtype, call->op, new_args, call->annotations, call->span));
+    }
+
+    if (!CanMakeCPAsyncFallbackStores(dst_info, call)) {
+      LOG(FATAL)
+          << "cp.async nonzero safe-value fallback requires a destination byte "
+             "range aligned to backing-buffer elements; byte-granular "
+             "fallback stores are unsupported because a BufferStore could "
+             "overwrite bytes outside the transfer. Got "
+          << call;
     }
 
     Stmt else_case = MakeCPAsyncFallbackStores(dst_info, call, safe_value,

--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -566,8 +566,18 @@ private:
             << "tvm_access_ptr element width must be positive: " << expr;
         ICHECK_GT(buffer_elem_bits, 0)
             << "tvm_access_ptr buffer element width must be positive: " << expr;
-        offset = FloorDiv(offset * IntImm(offset.dtype(), pointer_elem_bits),
-                          IntImm(offset.dtype(), buffer_elem_bits));
+        DataType address_dtype = DataType::Int(64);
+        offset = FloorDiv(Cast(address_dtype, offset) *
+                              IntImm(address_dtype, pointer_elem_bits),
+                          IntImm(address_dtype, buffer_elem_bits));
+      }
+      PrimExpr elem_offset = flat->elem_offset;
+      if (elem_offset.dtype() != offset.dtype()) {
+        elem_offset = Cast(offset.dtype(), elem_offset);
+      }
+      offset = offset - elem_offset;
+      if (offset.dtype() != flat->shape[0].dtype()) {
+        offset = Cast(flat->shape[0].dtype(), offset);
       }
       return AccessPtrInfo{
           BufferLoad(flat, Array<PrimExpr>{offset}),
@@ -647,32 +657,25 @@ private:
     // can miss the final bytes of a transfer. Check that byte range directly.
     if (src_info.raw_element_offset.has_value() &&
         src_pointer_elem_bits != src_buffer_elem_bits) {
-      PrimExpr byte_offset = src_info.raw_element_offset.value() *
-                             IntImm(src_info.raw_element_offset.value().dtype(),
-                                    src_pointer_elem_bits);
-      PrimExpr elem_offset = src_buffer->elem_offset;
-      if (elem_offset.dtype() != byte_offset.dtype()) {
-        elem_offset = Cast(byte_offset.dtype(), elem_offset);
-      }
-      byte_offset = byte_offset - elem_offset * IntImm(byte_offset.dtype(),
-                                                       src_buffer_elem_bits);
+      DataType address_dtype = DataType::Int(64);
+      PrimExpr byte_offset =
+          Cast(address_dtype, src_info.raw_element_offset.value()) *
+          IntImm(address_dtype, src_pointer_elem_bits);
+      byte_offset =
+          byte_offset - Cast(address_dtype, src_buffer->elem_offset) *
+                            IntImm(address_dtype, src_buffer_elem_bits);
 
-      PrimExpr transfer_bits = GetCPAsyncTransferBits(call, src_info, "source");
-      if (transfer_bits.dtype() != byte_offset.dtype()) {
-        transfer_bits = Cast(byte_offset.dtype(), transfer_bits);
-      }
+      PrimExpr transfer_bits = GetCPAsyncTransferBits(
+          call, src_info, "source", /*address_dtype=*/address_dtype);
       Buffer flattened_src_buffer = src_buffer.GetFlattenedBuffer();
-      PrimExpr flattened_extent = flattened_src_buffer->shape[0];
+      PrimExpr flattened_extent =
+          Cast(address_dtype, flattened_src_buffer->shape[0]);
       for (size_t i = 1; i < flattened_src_buffer->shape.size(); ++i) {
-        flattened_extent = flattened_extent * flattened_src_buffer->shape[i];
+        flattened_extent = flattened_extent *
+                           Cast(address_dtype, flattened_src_buffer->shape[i]);
       }
       PrimExpr flattened_extent_bits =
-          flattened_extent *
-          IntImm(flattened_extent.dtype(), src_buffer_elem_bits);
-      if (flattened_extent_bits.dtype() != byte_offset.dtype()) {
-        flattened_extent_bits =
-            Cast(byte_offset.dtype(), flattened_extent_bits);
-      }
+          flattened_extent * IntImm(address_dtype, src_buffer_elem_bits);
       SafeMemChecker checker(analyzer_, /*recursively_collect_conds=*/false);
       checker.PushCondition(byte_offset >= make_zero(byte_offset.dtype()));
       checker.PushCondition(byte_offset + transfer_bits <=
@@ -737,6 +740,13 @@ private:
 
   PrimExpr GetCPAsyncTransferBits(const Call &call, const AccessPtrInfo &info,
                                   const char *operand_name) {
+    return GetCPAsyncTransferBits(call, info, operand_name,
+                                  call->args[2].dtype());
+  }
+
+  PrimExpr GetCPAsyncTransferBits(const Call &call, const AccessPtrInfo &info,
+                                  const char *operand_name,
+                                  DataType address_dtype) {
     PrimExpr num_elems = call->args[2];
     int transfer_elem_bits = 8;
     if (!call->op.same_as(builtin::ptx_cp_async())) {
@@ -746,7 +756,8 @@ private:
           << "cp.async " << operand_name
           << " access pointer element width must be positive: " << call;
     }
-    return num_elems * IntImm(num_elems.dtype(), transfer_elem_bits);
+    return Cast(address_dtype, num_elems) *
+           IntImm(address_dtype, transfer_elem_bits);
   }
 
   PrimExpr GetCPAsyncTransferBufferElements(const Call &call,
@@ -799,17 +810,13 @@ private:
     ICHECK_GT(pointer_elem_bits, 0) << "cp.async destination access pointer "
                                        "element width must be positive: "
                                     << call;
+    DataType address_dtype = DataType::Int(64);
     PrimExpr byte_offset =
-        dst_info.raw_element_offset.value() *
-        IntImm(dst_info.raw_element_offset.value().dtype(), pointer_elem_bits);
-    PrimExpr elem_offset = dst_buffer->elem_offset;
-    if (elem_offset.dtype() != byte_offset.dtype()) {
-      elem_offset = Cast(byte_offset.dtype(), elem_offset);
-    }
-    byte_offset = byte_offset -
-                  elem_offset * IntImm(byte_offset.dtype(), buffer_elem_bits);
-    PrimExpr offset_elem_bits_expr =
-        IntImm(byte_offset.dtype(), buffer_elem_bits);
+        Cast(address_dtype, dst_info.raw_element_offset.value()) *
+        IntImm(address_dtype, pointer_elem_bits);
+    byte_offset = byte_offset - Cast(address_dtype, dst_buffer->elem_offset) *
+                                    IntImm(address_dtype, buffer_elem_bits);
+    PrimExpr offset_elem_bits_expr = IntImm(address_dtype, buffer_elem_bits);
     return analyzer_->CanProveEqual(
         FloorMod(byte_offset, offset_elem_bits_expr),
         make_zero(byte_offset.dtype()));
@@ -856,8 +863,23 @@ private:
 
     PrimExpr num_elems =
         GetCPAsyncTransferBufferElements(call, dst_info, "destination");
+    if (num_elems.dtype() != linear_index.dtype()) {
+      num_elems = Cast(linear_index.dtype(), num_elems);
+    }
+    PrimExpr flattened_extent = flattened_dst_buffer->shape[0];
+    for (size_t i = 1; i < flattened_dst_buffer->shape.size(); ++i) {
+      flattened_extent = flattened_extent * flattened_dst_buffer->shape[i];
+    }
+    if (flattened_extent.dtype() != linear_index.dtype()) {
+      flattened_extent = Cast(linear_index.dtype(), flattened_extent);
+    }
+    PrimExpr zero = make_zero(linear_index.dtype());
+    PrimExpr fallback_extent =
+        tirx::Min(num_elems, tirx::Max(zero, flattened_extent - linear_index));
+    fallback_extent = analyzer_->Simplify(
+        if_then_else(linear_index >= zero, fallback_extent, zero));
 
-    Var fallback_offset("cp_async_fallback_offset", num_elems.dtype());
+    Var fallback_offset("cp_async_fallback_offset", fallback_extent.dtype());
     PrimExpr typed_fallback_offset = fallback_offset;
     if (typed_fallback_offset.dtype() != linear_index.dtype()) {
       typed_fallback_offset = Cast(linear_index.dtype(), typed_fallback_offset);
@@ -889,8 +911,8 @@ private:
     }
     Stmt fallback_store =
         BufferStore(flattened_dst_buffer, fallback_value, dst_indices);
-    return For(fallback_offset, make_zero(num_elems.dtype()), num_elems,
-               ForKind::kSerial, fallback_store);
+    return For(fallback_offset, make_zero(fallback_extent.dtype()),
+               fallback_extent, ForKind::kSerial, fallback_store);
   }
 
   Stmt RewriteCPAsync(const Evaluate &evaluate, const Call &call,

--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -608,9 +608,39 @@ private:
     }
 
     SafeMemChecker checker(analyzer_, /*recursively_collect_conds=*/false);
-    checker.CheckBufferIndices(src_info.base_load->buffer,
-                               src_info.base_load->indices,
+    Buffer src_buffer = src_info.base_load->buffer;
+    checker.CheckBufferIndices(src_buffer, src_info.base_load->indices,
                                /*is_load=*/true, /*throw_warning=*/false);
+
+    Array<PrimExpr> physical_indices =
+        src_buffer.OffsetOf(src_info.base_load->indices);
+    Buffer flattened_src_buffer = src_buffer.GetFlattenedBuffer();
+    ICHECK_EQ(physical_indices.size(), flattened_src_buffer->shape.size())
+        << "cp.async source access cannot be flattened: " << call;
+    ICHECK(!physical_indices.empty())
+        << "cp.async source access has no physical offset: " << call;
+
+    PrimExpr linear_index = physical_indices[0];
+    for (size_t i = 1; i < physical_indices.size(); ++i) {
+      linear_index =
+          linear_index * flattened_src_buffer->shape[i] + physical_indices[i];
+    }
+    PrimExpr num_elems = call->args[2];
+    PrimExpr last_index =
+        linear_index + num_elems - IntImm(num_elems.dtype(), 1);
+    PrimExpr flattened_extent = flattened_src_buffer->shape[0];
+    for (size_t i = 1; i < flattened_src_buffer->shape.size(); ++i) {
+      flattened_extent = flattened_extent * flattened_src_buffer->shape[i];
+    }
+    auto push_distinct_condition = [this, &checker](const PrimExpr &condition) {
+      for (const PrimExpr &existing : checker.GetConditions()) {
+        if (analyzer_->CanProveEqual(existing, condition)) {
+          return;
+        }
+      }
+      checker.PushCondition(condition);
+    };
+    push_distinct_condition(last_index < flattened_extent);
     return checker.GetConditions();
   }
 

--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -625,7 +625,25 @@ private:
       linear_index =
           linear_index * flattened_src_buffer->shape[i] + physical_indices[i];
     }
+    PrimExpr elem_offset = src_buffer->elem_offset;
+    if (elem_offset.dtype() != linear_index.dtype()) {
+      elem_offset = Cast(linear_index.dtype(), elem_offset);
+    }
+    linear_index = linear_index - elem_offset;
+
     PrimExpr num_elems = call->args[2];
+    if (call->op.same_as(builtin::ptx_cp_async())) {
+      int source_elem_bits =
+          src_buffer->dtype.bits() * src_buffer->dtype.lanes();
+      ICHECK_GT(source_elem_bits, 0)
+          << "cp.async source element width must be positive: " << call;
+      PrimExpr source_elem_bits_expr =
+          IntImm(num_elems.dtype(), source_elem_bits);
+      PrimExpr transfer_bits = num_elems * IntImm(num_elems.dtype(), 8);
+      num_elems = FloorDiv(transfer_bits + source_elem_bits_expr -
+                               IntImm(num_elems.dtype(), 1),
+                           source_elem_bits_expr);
+    }
     PrimExpr last_index =
         linear_index + num_elems - IntImm(num_elems.dtype(), 1);
     PrimExpr flattened_extent = flattened_src_buffer->shape[0];

--- a/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
+++ b/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
@@ -296,6 +296,44 @@ def assert_cp_async_access_ptr_transfer_range_legalize():
     _assert_legalize_matches_expected(func, expected)
 
 
+def cp_async_access_ptr_rank2_transfer_range_legalize():
+    dtype = T.float16
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((2, 4), dtype=dtype),
+    ):
+        A_shared = T.alloc_buffer((2,), dtype=dtype, scope="shared")
+        T.ptx_cp_async(
+            T.access_ptr(A_shared[0], "w", 2),
+            T.access_ptr(A[1, 3], "r", 2),
+            2,
+        )
+        T.ptx_commit_group()
+        T.ptx_wait_group(0)
+
+    @T.prim_func
+    def expected(
+        A: T.Tensor((2, 4), dtype=dtype),
+    ):
+        A_shared = T.alloc_buffer((2,), dtype=dtype, scope="shared")
+        T.ptx_cp_async(
+            T.access_ptr(A_shared[0], "w", 2),
+            T.access_ptr(A[1, 3], "r", 2),
+            2,
+            False,
+        )
+        T.ptx_commit_group()
+        T.ptx_wait_group(0)
+
+    return main, expected
+
+
+def assert_cp_async_access_ptr_rank2_transfer_range_legalize():
+    func, expected = cp_async_access_ptr_rank2_transfer_range_legalize()
+    _assert_legalize_matches_expected(func, expected)
+
+
 def cp_async_access_ptr_nonzero_safe_value_legalize():
     dtype = T.float16
 
@@ -640,6 +678,10 @@ def test_cp_async_access_ptr_oob():
 
 def test_cp_async_access_ptr_transfer_range_oob():
     assert_cp_async_access_ptr_transfer_range_legalize()
+
+
+def test_cp_async_access_ptr_rank2_transfer_range_oob():
+    assert_cp_async_access_ptr_rank2_transfer_range_legalize()
 
 
 def test_cp_async_access_ptr_nonzero_safe_value_oob():

--- a/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
+++ b/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
@@ -385,6 +385,81 @@ def assert_cp_async_access_ptr_byte_pointer_transfer_range_legalize():
     assert float(fallback_loops[0].body.value.value) == 3
 
 
+def cp_async_access_ptr_byte_pointer_offset_legalize():
+    dtype = T.float16
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((6,), dtype=dtype),
+    ):
+        with T.sblock("root"):
+            T.reads()
+            T.writes()
+            T.sblock_attr({"safe_value_map": {A.data: T.float16(3)}})
+            A_shared = T.sblock_alloc_buffer((4,), dtype=dtype, scope="shared")
+            T.ptx_cp_async(
+                T.tvm_access_ptr(T.type_annotation(T.uint8), A_shared.data, 0, 8, 2),
+                T.tvm_access_ptr(T.type_annotation(T.uint8), A.data, 4, 8, 1),
+                8,
+            )
+            T.ptx_commit_group()
+            T.ptx_wait_group(0)
+
+    return main
+
+
+def assert_cp_async_access_ptr_byte_pointer_offset_legalize():
+    func = cp_async_access_ptr_byte_pointer_offset_legalize()
+    mod = tvm.IRModule({func.attrs["global_symbol"]: func})
+    transformed = tl.transform.LegalizeSafeMemoryAccess()(mod)
+    cp_async_calls = _collect_call_nodes(transformed["main"].body, {"tirx.ptx_cp_async", "tl.ptx_cp_async"})
+    assert len(cp_async_calls) == 1
+    assert len(cp_async_calls[0].args) == 3
+    assert _count_if_then_else(transformed["main"].body) == 0
+
+
+def cp_async_access_ptr_negative_transfer_legalize():
+    dtype = T.float16
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((4,), dtype=dtype),
+    ):
+        with T.sblock("root"):
+            T.reads()
+            T.writes()
+            T.sblock_attr({"safe_value_map": {A.data: T.float16(3)}})
+            A_shared = T.sblock_alloc_buffer((4,), dtype=dtype, scope="shared")
+            T.ptx_cp_async(
+                T.access_ptr(A_shared[0], "w", 4),
+                T.access_ptr(A[-1], "r", 4),
+                4,
+            )
+            T.ptx_commit_group()
+            T.ptx_wait_group(0)
+
+    return main
+
+
+def assert_cp_async_access_ptr_negative_transfer_legalize():
+    func = cp_async_access_ptr_negative_transfer_legalize()
+    mod = tvm.IRModule({func.attrs["global_symbol"]: func})
+    transformed = tl.transform.LegalizeSafeMemoryAccess()(mod)
+    body = transformed["main"].body
+    assert _count_if_then_else(body) > 0
+
+    fallback_loops = []
+
+    def _visit(node):
+        if isinstance(node, tvm.tirx.For):
+            fallback_loops.append(node)
+
+    post_order_visit(body, _visit)
+    assert len(fallback_loops) == 1
+    assert int(fallback_loops[0].extent.value) == 4
+    assert float(fallback_loops[0].body.value.value) == 3
+
+
 def cp_async_access_ptr_nonzero_safe_value_legalize():
     dtype = T.float16
 
@@ -742,6 +817,14 @@ def test_cp_async_access_ptr_rank2_transfer_range_oob():
 
 def test_cp_async_access_ptr_byte_pointer_transfer_range_oob():
     assert_cp_async_access_ptr_byte_pointer_transfer_range_legalize()
+
+
+def test_cp_async_access_ptr_byte_pointer_offset():
+    assert_cp_async_access_ptr_byte_pointer_offset_legalize()
+
+
+def test_cp_async_access_ptr_negative_transfer_oob():
+    assert_cp_async_access_ptr_negative_transfer_legalize()
 
 
 def test_cp_async_access_ptr_nonzero_safe_value_oob():

--- a/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
+++ b/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
@@ -252,6 +252,50 @@ def assert_cp_async_access_ptr_legalize():
     _assert_legalize_matches_expected(func, expected)
 
 
+def cp_async_access_ptr_transfer_range_legalize():
+    dtype = T.float16
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((9,), dtype=dtype),
+    ):
+        A_shared = T.alloc_buffer((8,), dtype=dtype, scope="shared")
+        T.ptx_cp_async(
+            T.access_ptr(A_shared[0], "w", 8),
+            T.access_ptr(A[8], "r", 8),
+            8,
+        )
+        T.ptx_commit_group()
+        T.ptx_wait_group(0)
+
+    @T.prim_func
+    def expected(
+        A: T.Tensor((9,), dtype=dtype),
+    ):
+        A_shared = T.alloc_buffer((8,), dtype=dtype, scope="shared")
+        T.ptx_cp_async(
+            T.access_ptr(A_shared[0], "w", 8),
+            T.access_ptr(A[8], "r", 8),
+            8,
+            False,
+        )
+        T.ptx_commit_group()
+        T.ptx_wait_group(0)
+
+    return main, expected
+
+
+def assert_cp_async_access_ptr_transfer_range_legalize():
+    func, expected = cp_async_access_ptr_transfer_range_legalize()
+    mod = tvm.IRModule({func.attrs["global_symbol"]: func})
+    transformed = tl.transform.LegalizeSafeMemoryAccess()(mod)
+    body = transformed["main"].body
+    cp_async_calls = _collect_call_nodes(body, {"tirx.ptx_cp_async", "tl.ptx_cp_async"})
+    assert len(cp_async_calls) == 1
+    assert len(cp_async_calls[0].args) == 4
+    _assert_legalize_matches_expected(func, expected)
+
+
 def cp_async_access_ptr_nonzero_safe_value_legalize():
     dtype = T.float16
 
@@ -592,6 +636,10 @@ def test_oob_store():
 
 def test_cp_async_access_ptr_oob():
     assert_cp_async_access_ptr_legalize()
+
+
+def test_cp_async_access_ptr_transfer_range_oob():
+    assert_cp_async_access_ptr_transfer_range_legalize()
 
 
 def test_cp_async_access_ptr_nonzero_safe_value_oob():

--- a/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
+++ b/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
@@ -344,6 +344,47 @@ def assert_cp_async_access_ptr_rank2_transfer_range_legalize():
     _assert_legalize_matches_expected(func, expected)
 
 
+def cp_async_access_ptr_byte_pointer_transfer_range_legalize():
+    dtype = T.float16
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((3,), dtype=dtype),
+    ):
+        with T.sblock("root"):
+            T.reads()
+            T.writes()
+            T.sblock_attr({"safe_value_map": {A.data: T.float16(3)}})
+            A_shared = T.sblock_alloc_buffer((4,), dtype=dtype, scope="shared")
+            T.ptx_cp_async(
+                T.tvm_access_ptr(T.type_annotation(T.uint8), A_shared.data, 0, 8, 2),
+                T.tvm_access_ptr(T.type_annotation(T.uint8), A.data, 0, 8, 1),
+                8,
+            )
+            T.ptx_commit_group()
+            T.ptx_wait_group(0)
+
+    return main
+
+
+def assert_cp_async_access_ptr_byte_pointer_transfer_range_legalize():
+    func = cp_async_access_ptr_byte_pointer_transfer_range_legalize()
+    mod = tvm.IRModule({func.attrs["global_symbol"]: func})
+    transformed = tl.transform.LegalizeSafeMemoryAccess()(mod)
+
+    fallback_loops = []
+
+    def _visit(node):
+        if isinstance(node, tvm.tirx.For):
+            fallback_loops.append(node)
+
+    post_order_visit(transformed["main"].body, _visit)
+    assert len(fallback_loops) == 1
+    assert isinstance(fallback_loops[0].body, tvm.tirx.BufferStore)
+    assert int(fallback_loops[0].extent.value) == 4
+    assert float(fallback_loops[0].body.value.value) == 3
+
+
 def cp_async_access_ptr_nonzero_safe_value_legalize():
     dtype = T.float16
 
@@ -697,6 +738,10 @@ def test_cp_async_access_ptr_predicate_transfer_range_oob():
 
 def test_cp_async_access_ptr_rank2_transfer_range_oob():
     assert_cp_async_access_ptr_rank2_transfer_range_legalize()
+
+
+def test_cp_async_access_ptr_byte_pointer_transfer_range_oob():
+    assert_cp_async_access_ptr_byte_pointer_transfer_range_legalize()
 
 
 def test_cp_async_access_ptr_nonzero_safe_value_oob():

--- a/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
+++ b/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
@@ -259,41 +259,42 @@ def cp_async_access_ptr_transfer_range_legalize():
     def main(
         A: T.Tensor((9,), dtype=dtype),
     ):
-        A_shared = T.alloc_buffer((8,), dtype=dtype, scope="shared")
-        T.ptx_cp_async(
-            T.access_ptr(A_shared[0], "w", 8),
-            T.access_ptr(A[8], "r", 8),
-            8,
-        )
-        T.ptx_commit_group()
-        T.ptx_wait_group(0)
+        with T.sblock("root"):
+            T.reads()
+            T.writes()
+            T.sblock_attr({"safe_value_map": {A.data: T.float16(3)}})
+            A_shared = T.sblock_alloc_buffer((8,), dtype=dtype, scope="shared")
+            T.ptx_cp_async(
+                T.access_ptr(A_shared[0], "w", 8),
+                T.access_ptr(A[8], "r", 8),
+                8,
+            )
+            T.ptx_commit_group()
+            T.ptx_wait_group(0)
 
-    @T.prim_func
-    def expected(
-        A: T.Tensor((9,), dtype=dtype),
-    ):
-        A_shared = T.alloc_buffer((8,), dtype=dtype, scope="shared")
-        T.ptx_cp_async(
-            T.access_ptr(A_shared[0], "w", 8),
-            T.access_ptr(A[8], "r", 8),
-            8,
-            False,
-        )
-        T.ptx_commit_group()
-        T.ptx_wait_group(0)
-
-    return main, expected
+    return main
 
 
 def assert_cp_async_access_ptr_transfer_range_legalize():
-    func, expected = cp_async_access_ptr_transfer_range_legalize()
+    func = cp_async_access_ptr_transfer_range_legalize()
     mod = tvm.IRModule({func.attrs["global_symbol"]: func})
     transformed = tl.transform.LegalizeSafeMemoryAccess()(mod)
     body = transformed["main"].body
     cp_async_calls = _collect_call_nodes(body, {"tirx.ptx_cp_async", "tl.ptx_cp_async"})
     assert len(cp_async_calls) == 1
-    assert len(cp_async_calls[0].args) == 4
-    _assert_legalize_matches_expected(func, expected)
+    assert len(cp_async_calls[0].args) == 3
+    assert _count_if_then_else(body) > 0
+
+    fallback_loops = []
+
+    def _visit(node):
+        if isinstance(node, tvm.tirx.For):
+            fallback_loops.append(node)
+
+    post_order_visit(body, _visit)
+    assert len(fallback_loops) == 1
+    assert isinstance(fallback_loops[0].body, tvm.tirx.BufferStore)
+    assert int(fallback_loops[0].extent.value) == 8
 
 
 def cp_async_access_ptr_rank2_transfer_range_legalize():
@@ -372,7 +373,8 @@ def cp_async_access_ptr_nonzero_safe_value_legalize():
                         4,
                     )
                 else:
-                    A_shared[i * 4] = T.float16(3)
+                    for j in T.serial(4):
+                        A_shared[i * 4 + j] = T.float16(3)
             T.ptx_commit_group()
             T.ptx_wait_group(0)
 

--- a/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
+++ b/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
@@ -252,7 +252,7 @@ def assert_cp_async_access_ptr_legalize():
     _assert_legalize_matches_expected(func, expected)
 
 
-def cp_async_access_ptr_transfer_range_legalize():
+def cp_async_access_ptr_transfer_range_legalize(predicate=None):
     dtype = T.float16
 
     @T.prim_func
@@ -264,25 +264,33 @@ def cp_async_access_ptr_transfer_range_legalize():
             T.writes()
             T.sblock_attr({"safe_value_map": {A.data: T.float16(3)}})
             A_shared = T.sblock_alloc_buffer((8,), dtype=dtype, scope="shared")
-            T.ptx_cp_async(
-                T.access_ptr(A_shared[0], "w", 8),
-                T.access_ptr(A[8], "r", 8),
-                8,
-            )
+            if predicate is None:
+                T.ptx_cp_async(
+                    T.access_ptr(A_shared[0], "w", 8),
+                    T.access_ptr(A[8], "r", 8),
+                    8,
+                )
+            else:
+                T.ptx_cp_async(
+                    T.access_ptr(A_shared[0], "w", 8),
+                    T.access_ptr(A[8], "r", 8),
+                    8,
+                    predicate,
+                )
             T.ptx_commit_group()
             T.ptx_wait_group(0)
 
     return main
 
 
-def assert_cp_async_access_ptr_transfer_range_legalize():
-    func = cp_async_access_ptr_transfer_range_legalize()
+def assert_cp_async_access_ptr_transfer_range_legalize(predicate=None, expected_safe_value=3):
+    func = cp_async_access_ptr_transfer_range_legalize(predicate)
     mod = tvm.IRModule({func.attrs["global_symbol"]: func})
     transformed = tl.transform.LegalizeSafeMemoryAccess()(mod)
     body = transformed["main"].body
     cp_async_calls = _collect_call_nodes(body, {"tirx.ptx_cp_async", "tl.ptx_cp_async"})
     assert len(cp_async_calls) == 1
-    assert len(cp_async_calls[0].args) == 3
+    assert len(cp_async_calls[0].args) == (3 if predicate is None else 4)
     assert _count_if_then_else(body) > 0
 
     fallback_loops = []
@@ -295,6 +303,7 @@ def assert_cp_async_access_ptr_transfer_range_legalize():
     assert len(fallback_loops) == 1
     assert isinstance(fallback_loops[0].body, tvm.tirx.BufferStore)
     assert int(fallback_loops[0].extent.value) == 8
+    assert float(fallback_loops[0].body.value.value) == expected_safe_value
 
 
 def cp_async_access_ptr_rank2_transfer_range_legalize():
@@ -680,6 +689,10 @@ def test_cp_async_access_ptr_oob():
 
 def test_cp_async_access_ptr_transfer_range_oob():
     assert_cp_async_access_ptr_transfer_range_legalize()
+
+
+def test_cp_async_access_ptr_predicate_transfer_range_oob():
+    assert_cp_async_access_ptr_transfer_range_legalize(predicate=False, expected_safe_value=0)
 
 
 def test_cp_async_access_ptr_rank2_transfer_range_oob():

--- a/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
+++ b/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
@@ -307,6 +307,46 @@ def assert_cp_async_access_ptr_transfer_range_legalize(predicate=None, expected_
     assert float(fallback_loops[0].body.value.value) == expected_safe_value
 
 
+def cp_async_access_ptr_destination_transfer_range_legalize():
+    dtype = T.float16
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((4,), dtype=dtype),
+    ):
+        with T.sblock("root"):
+            T.reads()
+            T.writes()
+            T.sblock_attr({"safe_value_map": {A.data: T.float16(3)}})
+            A_shared = T.sblock_alloc_buffer((4,), dtype=dtype, scope="shared")
+            T.ptx_cp_async(
+                T.access_ptr(A_shared[0], "w", 8),
+                T.access_ptr(A[4], "r", 8),
+                8,
+            )
+            T.ptx_commit_group()
+            T.ptx_wait_group(0)
+
+    return main
+
+
+def assert_cp_async_access_ptr_destination_transfer_range_legalize():
+    func = cp_async_access_ptr_destination_transfer_range_legalize()
+    mod = tvm.IRModule({func.attrs["global_symbol"]: func})
+    transformed = tl.transform.LegalizeSafeMemoryAccess()(mod)
+
+    fallback_loops = []
+
+    def _visit(node):
+        if isinstance(node, tvm.tirx.For):
+            fallback_loops.append(node)
+
+    post_order_visit(transformed["main"].body, _visit)
+    assert len(fallback_loops) == 1
+    assert isinstance(fallback_loops[0].body, tvm.tirx.BufferStore)
+    assert int(fallback_loops[0].extent.value) == 4
+
+
 def cp_async_access_ptr_rank2_transfer_range_legalize():
     dtype = T.float16
 
@@ -416,6 +456,64 @@ def assert_cp_async_access_ptr_byte_pointer_offset_legalize():
     cp_async_calls = _collect_call_nodes(transformed["main"].body, {"tirx.ptx_cp_async", "tl.ptx_cp_async"})
     assert len(cp_async_calls) == 1
     assert len(cp_async_calls[0].args) == 3
+    assert _count_if_then_else(transformed["main"].body) == 0
+
+
+def cp_async_access_ptr_elem_offset_legalize():
+    dtype = T.float16
+
+    @T.prim_func
+    def main(A_handle: T.handle):
+        A = T.match_buffer(A_handle, (4,), dtype=dtype, elem_offset=4)
+        with T.sblock("root"):
+            T.reads()
+            T.writes()
+            A_shared = T.sblock_alloc_buffer((4,), dtype=dtype, scope="shared")
+            T.ptx_cp_async(
+                T.tvm_access_ptr(T.type_annotation(dtype), A_shared.data, 0, 4, 2),
+                T.tvm_access_ptr(T.type_annotation(dtype), A.data, 4, 4, 1),
+                4,
+            )
+            T.ptx_commit_group()
+            T.ptx_wait_group(0)
+
+    return main
+
+
+def assert_cp_async_access_ptr_elem_offset_legalize():
+    func = cp_async_access_ptr_elem_offset_legalize()
+    mod = tvm.IRModule({func.attrs["global_symbol"]: func})
+    transformed = tl.transform.LegalizeSafeMemoryAccess()(mod)
+    assert _count_if_then_else(transformed["main"].body) == 0
+
+
+def cp_async_access_ptr_large_byte_range_legalize():
+    dtype = T.float16
+    transfer_bytes = 300_000_000
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((transfer_bytes // 2,), dtype=dtype),
+    ):
+        with T.sblock("root"):
+            T.reads()
+            T.writes()
+            A_shared = T.sblock_alloc_buffer((transfer_bytes // 2,), dtype=dtype, scope="shared")
+            T.ptx_cp_async(
+                T.tvm_access_ptr(T.type_annotation(T.uint8), A_shared.data, 0, transfer_bytes, 2),
+                T.tvm_access_ptr(T.type_annotation(T.uint8), A.data, 0, transfer_bytes, 1),
+                transfer_bytes,
+            )
+            T.ptx_commit_group()
+            T.ptx_wait_group(0)
+
+    return main
+
+
+def assert_cp_async_access_ptr_large_byte_range_legalize():
+    func = cp_async_access_ptr_large_byte_range_legalize()
+    mod = tvm.IRModule({func.attrs["global_symbol"]: func})
+    transformed = tl.transform.LegalizeSafeMemoryAccess()(mod)
     assert _count_if_then_else(transformed["main"].body) == 0
 
 
@@ -868,6 +966,10 @@ def test_cp_async_access_ptr_transfer_range_oob():
     assert_cp_async_access_ptr_transfer_range_legalize()
 
 
+def test_cp_async_access_ptr_destination_transfer_range_oob():
+    assert_cp_async_access_ptr_destination_transfer_range_legalize()
+
+
 def test_cp_async_access_ptr_predicate_transfer_range_oob():
     assert_cp_async_access_ptr_transfer_range_legalize(predicate=False, expected_safe_value=0)
 
@@ -882,6 +984,14 @@ def test_cp_async_access_ptr_byte_pointer_transfer_range_oob():
 
 def test_cp_async_access_ptr_byte_pointer_offset():
     assert_cp_async_access_ptr_byte_pointer_offset_legalize()
+
+
+def test_cp_async_access_ptr_elem_offset():
+    assert_cp_async_access_ptr_elem_offset_legalize()
+
+
+def test_cp_async_access_ptr_large_byte_range():
+    assert_cp_async_access_ptr_large_byte_range_legalize()
 
 
 def test_cp_async_access_ptr_partial_byte_range_oob():

--- a/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
+++ b/testing/python/transform/test_tilelang_transform_legalize_safe_memory_access.py
@@ -2,6 +2,7 @@ from tilelang import tvm as tvm
 import tilelang as tl
 import tilelang.language as T
 import tilelang.testing
+import pytest
 from tvm.tirx.stmt_functor import ir_transform, post_order_visit
 
 
@@ -418,6 +419,66 @@ def assert_cp_async_access_ptr_byte_pointer_offset_legalize():
     assert _count_if_then_else(transformed["main"].body) == 0
 
 
+def cp_async_access_ptr_partial_byte_range_legalize():
+    dtype = T.float64
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((1,), dtype=dtype),
+    ):
+        with T.sblock("root"):
+            T.reads()
+            T.writes()
+            T.sblock_attr({"safe_value_map": {A.data: T.float64(3)}})
+            A_shared = T.sblock_alloc_buffer((2,), dtype=dtype, scope="shared")
+            T.ptx_cp_async(
+                T.tvm_access_ptr(T.type_annotation(T.uint8), A_shared.data, 0, 4, 2),
+                T.tvm_access_ptr(T.type_annotation(T.uint8), A.data, 6, 4, 1),
+                4,
+            )
+            T.ptx_commit_group()
+            T.ptx_wait_group(0)
+
+    return main
+
+
+def assert_cp_async_access_ptr_partial_byte_range_legalize():
+    func = cp_async_access_ptr_partial_byte_range_legalize()
+    mod = tvm.IRModule({func.attrs["global_symbol"]: func})
+    with pytest.raises(tvm.TVMError, match="destination byte range aligned"):
+        tl.transform.LegalizeSafeMemoryAccess()(mod)
+
+
+def cp_async_access_ptr_unaligned_byte_destination_legalize():
+    dtype = T.float64
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((1,), dtype=dtype),
+    ):
+        with T.sblock("root"):
+            T.reads()
+            T.writes()
+            T.sblock_attr({"safe_value_map": {A.data: T.float64(3)}})
+            A_shared = T.sblock_alloc_buffer((2,), dtype=dtype, scope="shared")
+            T.ptx_cp_async(
+                T.tvm_access_ptr(T.type_annotation(T.uint8), A_shared.data, 4, 8, 2),
+                T.tvm_access_ptr(T.type_annotation(T.uint8), A.data, 8, 8, 1),
+                8,
+            )
+            T.ptx_commit_group()
+            T.ptx_wait_group(0)
+
+    return main
+
+
+def assert_cp_async_access_ptr_unaligned_byte_destination_legalize():
+    func = cp_async_access_ptr_unaligned_byte_destination_legalize()
+    mod = tvm.IRModule({func.attrs["global_symbol"]: func})
+    with pytest.raises(tvm.TVMError, match="destination byte range aligned"):
+        tl.transform.LegalizeSafeMemoryAccess()(mod)
+
+
 def cp_async_access_ptr_negative_transfer_legalize():
     dtype = T.float16
 
@@ -821,6 +882,14 @@ def test_cp_async_access_ptr_byte_pointer_transfer_range_oob():
 
 def test_cp_async_access_ptr_byte_pointer_offset():
     assert_cp_async_access_ptr_byte_pointer_offset_legalize()
+
+
+def test_cp_async_access_ptr_partial_byte_range_oob():
+    assert_cp_async_access_ptr_partial_byte_range_legalize()
+
+
+def test_cp_async_access_ptr_unaligned_byte_destination_oob():
+    assert_cp_async_access_ptr_unaligned_byte_destination_legalize()
 
 
 def test_cp_async_access_ptr_negative_transfer_oob():


### PR DESCRIPTION
Fixes #2841.

### Problem

LegalizeSafeMemoryAccess only checked the source base index of a direct ptx_cp_async call. A valid base plus an invalid transfer width could therefore lower to an unguarded global-memory read.

```text
logical fp16 A: [0 ... 8]
copy request: A[8], 8 elements

before: validates A[8]       -> unguarded
after:  validates A[8 ...15] -> false predicate / zero-fill
```

The higher-level async-copy tail path already emits guards; this patch targets the direct low-level ptx_cp_async form.

### Change

- Flatten the physical source offset.
- Check base + num_elems - 1 against the flattened source extent.
- Reuse the existing predicate mechanism and deduplicate the equivalent condition for one-element transfers.

### Regression coverage

The added case copies eight fp16 elements from A[8] of a logical A[9]. It fails on the base branch because the call remains unpredicated and passes with the final rebuilt candidate.

### Validation

- transfer-range and existing cp.async legalization tests against the final rebuilt library — 3 passed, 12 deselected
- access-pointer codegen tests against the final rebuilt library — 7 passed
- clang-format, Ruff format check, git diff --check, and exact-diff autoreview — passed

The candidate library was built with CUDA_HOME set to the detected pip CUDA root and includes the RTX 3060-compatible CUDA path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed direct `ptx_cp_async` source-range validation.
- Flattened physical source offsets and validated the complete transfer range with `base + num_elems - 1`.
- Reused existing predicate handling and deduplicated equivalent predicates for one-element transfers.
- Added regression coverage for out-of-bounds 1D, rank-2, byte-pointer, offset, negative-index, partial-range, and unaligned-destination transfers.
- Confirmed that legalization appends a false predicate and preserves the four `ptx_cp_async` call arguments.

## C++ style / lint notes

- The PR changes C++ implementation code.
- It does not change rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) remains advisory.
- No correctness, build, or test issues are indicated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->