### PR TITLE
[BugFix] Handle vectorized SelectNode in codegen_cuda

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -5381,6 +5381,46 @@ void CodeGenTileLangCUDA::VisitStmt_(const BufferStoreNode *op) {
   }
 }
 
+void CodeGenTileLangCUDA::VisitExpr_(const SelectNode *op, std::ostream &os) {
+  // Non-vector cases.
+  if (!op->dtype.is_fixed_length_vector()) {
+    CodeGenC::VisitExpr_(op, os);
+    return;
+  }
+
+  // Codegen vector condition case by serializing the select op.
+  TVM_FFI_ICHECK(op->false_value->dtype == op->dtype &&
+                 op->true_value->dtype == op->dtype &&
+                 op->dtype.lanes() == op->condition.dtype().lanes());
+
+  std::string r_var = name_supply_->FreshName("_");
+  this->PrintIndent();
+  this->PrintType(op->dtype, stream);
+  stream << ' ' << r_var << ";\n";
+  {
+    std::string c_var = SSAGetID(PrintExpr(op->condition), op->dtype);
+    std::string t_var = SSAGetID(PrintExpr(op->true_value), op->dtype);
+    std::string f_var = SSAGetID(PrintExpr(op->false_value), op->dtype);
+
+    // The condition is stored as an ushort vector.
+    int lanes = op->dtype.lanes();
+    DataType memory_ty(DataType::TypeCode::kUInt, 16, lanes);
+
+    for (int i = 0; i < lanes; ++i) {
+      std::ostringstream item;
+      item << "(bool(";
+      PrintVecElemLoad(c_var, memory_ty, i, item);
+      item << ")?";
+      PrintVecElemLoad(t_var, op->dtype, i, item);
+      item << ':';
+      PrintVecElemLoad(f_var, op->dtype, i, item);
+      item << ')';
+      PrintVecElemStore(r_var, op->dtype, i, item.str());
+    }
+  }
+  os << r_var;
+}
+
 void CodeGenTileLangCUDA::VisitExpr_(const ShuffleNode *op,
                                      std::ostream &os) { // NOLINT(*)
   // For bfloat16x2 / float16x2 construction from two scalar lanes, emit a

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -5383,7 +5383,7 @@ void CodeGenTileLangCUDA::VisitStmt_(const BufferStoreNode *op) {
 
 void CodeGenTileLangCUDA::VisitExpr_(const SelectNode *op, std::ostream &os) {
   // Non-vector cases.
-  if (!op->dtype.is_fixed_length_vector()) {
+  if (!op->condition.dtype().is_fixed_length_vector()) {
     CodeGenC::VisitExpr_(op, os);
     return;
   }

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -5398,7 +5398,8 @@ void CodeGenTileLangCUDA::VisitExpr_(const SelectNode *op, std::ostream &os) {
   this->PrintType(op->dtype, stream);
   stream << ' ' << r_var << ";\n";
   {
-    std::string c_var = SSAGetID(PrintExpr(op->condition), op->dtype);
+    std::string c_var =
+        SSAGetID(PrintExpr(op->condition), op->condition.dtype());
     std::string t_var = SSAGetID(PrintExpr(op->true_value), op->dtype);
     std::string f_var = SSAGetID(PrintExpr(op->false_value), op->dtype);
 

--- a/src/cuda/codegen/codegen_cuda.h
+++ b/src/cuda/codegen/codegen_cuda.h
@@ -62,6 +62,7 @@ public:
   void VisitStmt_(const AttrStmtNode *op) final;
   void VisitExpr_(const BufferLoadNode *op, std::ostream &os) final;
   void VisitStmt_(const BufferStoreNode *op) final;
+  void VisitExpr_(const SelectNode *op, std::ostream &os) final;
 
   // Override this as a work around for __grid_constant__ parameter
   void AddFunction(const GlobalVar &gvar, const PrimFunc &f);

--- a/testing/python/issue/test_tilelang_issue_2682.py
+++ b/testing/python/issue/test_tilelang_issue_2682.py
@@ -1,0 +1,31 @@
+"""Regression test for issue #2682.
+
+T.vectorized with T.Select incorrectly generates scalar ternary expressions.
+CodeGenTileLangCUDA misses the handling of vectorized SelectNode, causing
+a fallback to CodeGenC in tvm that generates a scalar ternary expression.
+"""
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+NUM_ELEMENTS = 4
+
+
+def test_vectorized_select():
+    @T.prim_func
+    def kernel(
+        source: T.Tensor[(NUM_ELEMENTS,), T.float32],
+        destination: T.Tensor[(NUM_ELEMENTS,), T.float32],
+    ):
+        with T.Kernel(1, threads=1):
+            for index in T.vectorized(NUM_ELEMENTS):
+                value = source[index]
+                destination[index] = T.Select(value > 0.0, value, value + 1.0)
+
+    tilelang.compile(kernel)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
Implement cuda codegen for vectorized SelectNode by overriding `visitExpr_(const SelectNode *op, std::ostream &os)` for `CodeGenTileLangCUDA`.
This correctly handles the case when the condition expression in a SelectNode is vectorized.

Fixes #2682 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added CUDA code generation for vectorized `SelectNode` expressions.
- Generated lane-wise conditional selection for vectorized branches and conditions.
- Preserved base `CodeGenC` generation for scalar and non-vector selections.
- Added a regression test for vectorized `T.Select`, fixing issue `#2682`.

## C++ style / lint notes

- The PR changes C++ code and adds a `SelectNode` override.
- The implementation does not change rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit remains warning-only.
- No correctness or build issue is indicated. Advisory TLCPP003/TLCPP004 findings should not block merge unless they identify a clear API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->