### PR TITLE
[BugFix] Fix absmax and abssum for uint dtypes

### DIFF
--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -270,7 +270,8 @@ inline PrimExpr MakeReduce(const ReduceOpNode &op, int vsize,
     if (op.type->IsSum()) {
       return acc + rhs;
     } else if (op.type->IsAbsSum()) {
-      return acc + Max(rhs, -rhs);
+      auto abs_rhs = rhs.dtype().is_uint() ? rhs : Max(rhs, -rhs);
+      return acc + abs_rhs;
     } else if (op.type->IsMax()) {
       return use_nan_op ? Call(acc.dtype(), tl::max_nan(), {acc, rhs})
                         : PrimExpr(Max(acc, rhs));
@@ -278,7 +279,7 @@ inline PrimExpr MakeReduce(const ReduceOpNode &op, int vsize,
       return use_nan_op ? Call(acc.dtype(), tl::min_nan(), {acc, rhs})
                         : PrimExpr(Min(acc, rhs));
     } else if (op.type->IsAbsMax()) {
-      auto abs_rhs = Max(rhs, -rhs);
+      auto abs_rhs = rhs.dtype().is_uint() ? rhs : Max(rhs, -rhs);
       return use_nan_op ? Call(acc.dtype(), tl::max_nan(), {acc, abs_rhs})
                         : PrimExpr(Max(acc, abs_rhs));
     } else if (op.type->IsBitAnd()) {

--- a/testing/python/issue/test_tilelang_issue_2624.py
+++ b/testing/python/issue/test_tilelang_issue_2624.py
@@ -1,0 +1,37 @@
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+import torch
+
+N = 4
+
+
+def make_kernel(op, dt):
+    @T.prim_func
+    def main(A: T.Tensor((N,), dt), B: T.Tensor((1,), dt)):
+        with T.Kernel(1, threads=N):
+            As = T.alloc_fragment((N,), dt)
+            Bs = T.alloc_fragment((1,), dt)
+            T.copy(A, As)
+            (T.reduce_absmax if op == "absmax" else T.reduce_max)(As, Bs, dim=0)
+            T.copy(Bs, B)
+
+    return main
+
+
+def test_reduce_absmax():
+    A = torch.tensor([100, 10, 20, 30], dtype=torch.uint32, device="cuda")
+    uint32_max = tilelang.compile(make_kernel("max", "uint32"), out_idx=[1])(A)
+    uint32_absmax = tilelang.compile(make_kernel("absmax", "uint32"), out_idx=[1])(A)
+    torch.testing.assert_close(uint32_max, uint32_absmax, rtol=0, atol=0)
+
+
+def test_reduce_abssum():
+    A = torch.tensor([100, 10, 20, 30], dtype=torch.uint32, device="cuda")
+    uint32_sum = tilelang.compile(make_kernel("sum", "uint32"), out_idx=[1])(A)
+    uint32_abssum = tilelang.compile(make_kernel("abssum", "uint32"), out_idx=[1])(A)
+    torch.testing.assert_close(uint32_sum, uint32_abssum, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/issue/test_tilelang_issue_2624.py
+++ b/testing/python/issue/test_tilelang_issue_2624.py
@@ -2,6 +2,7 @@ import tilelang
 import tilelang.language as T
 import tilelang.testing
 import torch
+import pytest
 
 N = 4
 
@@ -19,18 +20,20 @@ def make_kernel(op, dt):
     return main
 
 
-def test_reduce_absmax():
-    A = torch.tensor([100, 10, 20, 30], dtype=torch.uint32, device="cuda")
-    uint32_max = tilelang.compile(make_kernel("max", "uint32"), out_idx=[1])(A)
-    uint32_absmax = tilelang.compile(make_kernel("absmax", "uint32"), out_idx=[1])(A)
-    torch.testing.assert_close(uint32_max, uint32_absmax, rtol=0, atol=0)
-
-
-def test_reduce_abssum():
-    A = torch.tensor([100, 10, 20, 30], dtype=torch.uint32, device="cuda")
-    uint32_sum = tilelang.compile(make_kernel("sum", "uint32"), out_idx=[1])(A)
-    uint32_abssum = tilelang.compile(make_kernel("abssum", "uint32"), out_idx=[1])(A)
-    torch.testing.assert_close(uint32_sum, uint32_abssum, rtol=0, atol=0)
+@pytest.mark.parametrize(
+    "op,dtype",
+    [
+        ("absmax", "uint32"),
+        ("absmax", "uint64"),
+        ("abssum", "uint32"),
+        ("abssum", "uint64"),
+    ],
+)
+def test_reduce_absmax_abssum_with_positive_input(op: str, dtype: str):
+    A = torch.tensor([100, 10, 20, 30], dtype=getattr(torch, dtype), device="cuda")
+    raw_op = tilelang.compile(make_kernel(op.replace("abs", ""), dtype), out_idx=[1])(A)
+    abs_op = tilelang.compile(make_kernel(op, dtype), out_idx=[1])(A)
+    torch.testing.assert_close(raw_op, abs_op, rtol=0, atol=0)
 
 
 if __name__ == "__main__":

--- a/testing/python/issue/test_tilelang_issue_2624.py
+++ b/testing/python/issue/test_tilelang_issue_2624.py
@@ -14,7 +14,7 @@ def make_kernel(op, dt):
             As = T.alloc_fragment((N,), dt)
             Bs = T.alloc_fragment((1,), dt)
             T.copy(A, As)
-            (T.reduce_absmax if op == "absmax" else T.reduce_max)(As, Bs, dim=0)
+            getattr(T, "reduce_" + op)(As, Bs, dim=0)
             T.copy(Bs, B)
 
     return main


### PR DESCRIPTION
The `abs` function during `reduce_absmax`/`reduce_abssum` is implemented as `max(rhs, -rhs)`, which silently fails when `rhs` is unsigned.
Simply use `rhs` if we know it is unsigned, and fall back to `max(rhs, -rhs)` otherwise.

Fixes #2624 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fix unsigned `uint32` and `uint64` handling in `AbsMax` and `AbsSum` reductions.
- Use the operand directly for unsigned dtypes.
- Preserve `Max(rhs, -rhs)` for signed and floating-point dtypes.
- Add CUDA tests for `absmax` and `abssum` against `max` and `sum`.

## C++ style / lint notes

- The change touches C++ reduction lowering.
- It does not touch rules documented in `docs/developer_guide/cpp_style.md`.
- No CI or lint configuration changes are included.
- The C++ API Style Audit remains warning-only. No new correctness or build issue is identified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->