### PR TITLE
[CUDA][TMA] Separate atomic-add dtype support from layout encoding

### DIFF
--- a/src/cuda/op/atomic_add.cc
+++ b/src/cuda/op/atomic_add.cc
@@ -11,6 +11,7 @@
 
 #include "backend/common/target_utils.h"
 #include "cuda/op/copy.h"
+#include "cuda/op/tma_layout.h"
 #include "layout/layout.h"
 #include "op/builtin.h"
 #include "op/utils.h"
@@ -22,6 +23,10 @@
 #include <tvm/tirx/op.h>
 #include <tvm/tirx/op_attr_types.h>
 
+#include <optional>
+#include <sstream>
+#include <string>
+#include <utility>
 #include <vector>
 
 namespace tvm {
@@ -62,6 +67,111 @@ bool UseTMA(const AtomicAddNode &op) {
     }
   }
   return false;
+}
+
+bool IsValidTMAReduceAddDtype(DataType dtype) {
+  if (!dtype.is_scalar()) {
+    return false;
+  }
+  if (dtype.is_bfloat16()) {
+    return true;
+  }
+  if (dtype.is_float()) {
+    return dtype.bits() == 16 || dtype.bits() == 32;
+  }
+  if (dtype.is_int()) {
+    return dtype.bits() == 32;
+  }
+  return dtype.is_uint() && (dtype.bits() == 32 || dtype.bits() == 64);
+}
+
+struct TMAAtomicAddPlan {
+  int tensor_map_dtype;
+  SwizzleMode swizzle_mode;
+};
+
+struct TMAAtomicAddAnalysis {
+  std::optional<TMAAtomicAddPlan> plan;
+  std::string reason;
+};
+
+TMAAtomicAddAnalysis UnsupportedTMAAtomicAdd(std::string reason) {
+  return {std::nullopt, std::move(reason)};
+}
+
+TMAAtomicAddAnalysis AnalyzeTMAAtomicAdd(const AtomicAddNode &op, Target target,
+                                         const Layout &shared_layout) {
+  if (!target.defined() || !TargetHasBulkCopy(target)) {
+    std::ostringstream reason;
+    reason << "TMA atomic add requires a CUDA target with TMA support (SM90+), "
+              "but got target "
+           << target;
+    return UnsupportedTMAAtomicAdd(reason.str());
+  }
+
+  if (op.src->dtype != op.dst->dtype) {
+    std::ostringstream reason;
+    reason << "TMA atomic add between buffer " << op.src->name << " and "
+           << op.dst->name << " requires matching dtypes, but got "
+           << op.src->dtype << " and " << op.dst->dtype;
+    return UnsupportedTMAAtomicAdd(reason.str());
+  }
+
+  DataType dtype = op.dst->dtype;
+  if (!IsValidTMAReduceAddDtype(dtype)) {
+    std::ostringstream reason;
+    reason << "TMA atomic add does not support dtype " << dtype
+           << "; supported scalar dtypes are float16, bfloat16, float32, "
+              "int32, uint32, and uint64";
+    return UnsupportedTMAAtomicAdd(reason.str());
+  }
+
+  TMASharedLayoutAnalysis layout_analysis =
+      AnalyzeTMASharedLayout(shared_layout, dtype);
+  if (!layout_analysis.encoding.has_value()) {
+    std::ostringstream reason;
+    reason << "TMA atomic add cannot encode the shared layout for buffer "
+           << op.src->name << ": " << layout_analysis.reason;
+    return UnsupportedTMAAtomicAdd(reason.str());
+  }
+
+  TMAAtomicAddPlan plan{
+      to_CUtensorMapDataType(dtype),
+      layout_analysis.encoding.value().swizzle_mode,
+  };
+  return {std::move(plan), ""};
+}
+
+Layout MakeTMAAtomicAddSharedLayout(const Buffer &shared_tensor) {
+  ICHECK_GE(shared_tensor->shape.size(), 2U)
+      << "TMA atomic add layout inference requires a rank-2+ shared buffer";
+  int ndim = static_cast<int>(shared_tensor->shape.size());
+  const int64_t *mat_stride = as_const_int(shared_tensor->shape[ndim - 2]);
+  const int64_t *mat_continuous = as_const_int(shared_tensor->shape[ndim - 1]);
+  ICHECK(mat_stride != nullptr && mat_continuous != nullptr)
+      << "TMA atomic add requires constant innermost shared-buffer shapes, "
+         "but got "
+      << shared_tensor->shape;
+
+  Layout inferred_layout = ComputeLinearLayout(shared_tensor);
+  int element_bits = shared_tensor->dtype.bits();
+  if ((element_bits == 16 || element_bits == 32) && *mat_stride % 8 == 0) {
+    int vector_size = 128 / element_bits;
+    if (*mat_continuous % (vector_size * 8) == 0) {
+      inferred_layout = MakeFullBankSwizzleLayout(shared_tensor);
+    } else if (*mat_continuous % (vector_size * 4) == 0) {
+      inferred_layout = MakeHalfBankSwizzleLayout(shared_tensor);
+    } else if (*mat_continuous % (vector_size * 2) == 0) {
+      inferred_layout = MakeQuarterBankSwizzleLayout(shared_tensor);
+    }
+  }
+
+  TMASharedLayoutAnalysis layout_analysis =
+      AnalyzeTMASharedLayout(inferred_layout, shared_tensor->dtype);
+  ICHECK(layout_analysis.encoding.has_value())
+      << "Internal error: inferred TMA atomic-add layout is not encodable: "
+      << layout_analysis.reason;
+  return inferred_layout;
 }
 
 Array<IterVar> MakeIterVars(const AtomicAddNode &op) {
@@ -271,21 +381,8 @@ struct AtomicAdd {
 
     if (level == InferLevel::kFree &&
         !layout_args.layout_map.count(shared_tensor)) {
-      int dim = shared_tensor->shape.size();
-      const int64_t mat_stride = *as_const_int(shared_tensor->shape[dim - 2]);
-      const int64_t mat_continuous =
-          *as_const_int(shared_tensor->shape[dim - 1]);
-      Layout swizzle_layout_2d =
-          MakeGemmABLayoutHopper(mat_stride, mat_continuous, mat_continuous,
-                                 shared_tensor->dtype.bits(), /*k_inner=*/true);
-      if (StructuralEqual()(swizzle_layout_2d, MakeLinearLayout(Array<PrimExpr>{
-                                                   Integer(mat_stride),
-                                                   Integer(mat_continuous)}))) {
-        result_map.Set(shared_tensor, ComputeLinearLayout(shared_tensor));
-      } else {
-        result_map.Set(shared_tensor, ExpandLayoutToMatchBuffer(
-                                          swizzle_layout_2d, shared_tensor));
-      }
+      result_map.Set(shared_tensor,
+                     MakeTMAAtomicAddSharedLayout(shared_tensor));
     }
 
     return result_map;
@@ -308,26 +405,22 @@ struct AtomicAdd {
     ICHECK(desc.rank >= 1 && desc.rank <= 5)
         << "TMA reduce only supports 1-5 dimensions, got " << desc.rank;
 
-    ICHECK(global_tensor->dtype == shared_tensor->dtype)
-        << "AtomicAdd between buffer " << shared_tensor->name << " and "
-        << global_tensor->name << " with different data type "
-        << shared_tensor->dtype << " and " << global_tensor->dtype;
+    Layout shared_layout = MakeLinearLayout(shared_tensor->shape);
+    if (lower_args.layout_map.count(shared_tensor)) {
+      shared_layout = lower_args.layout_map.at(shared_tensor);
+      ICHECK(lower_args.buffer_remap.count(shared_tensor))
+          << "shared_tensor: " << shared_tensor->name
+          << " not found in buffer_remap";
+      shared_tensor = lower_args.buffer_remap.at(shared_tensor);
+    }
 
-    DataType dtype = global_tensor->dtype;
-    // uint64 is legal in PTX, but its inferred 64-bit K-inner shared layout is
-    // not currently representable by the TensorMap swizzle selected below.
-    bool supports_tma_reduce_add =
-        dtype.is_scalar() &&
-        (dtype.is_bfloat16() ||
-         (dtype.is_float() && (dtype.bits() == 16 || dtype.bits() == 32)) ||
-         (dtype.is_int() && dtype.bits() == 32) ||
-         (dtype.is_uint() && dtype.bits() == 32));
-    ICHECK(supports_tma_reduce_add)
-        << "TMA atomic add does not support dtype " << dtype
-        << "; supported scalar dtypes are float16, bfloat16, float32, int32, "
-           "and uint32";
+    TMAAtomicAddAnalysis analysis =
+        AnalyzeTMAAtomicAdd(op, lower_args.target, shared_layout);
+    ICHECK(analysis.plan.has_value())
+        << analysis.reason << SpanHintSuffix({op.dst->span, op.src->span});
+    const TMAAtomicAddPlan &plan = analysis.plan.value();
 
-    desc.data_type = to_CUtensorMapDataType(global_tensor->dtype);
+    desc.data_type = plan.tensor_map_dtype;
     desc.global_addr = global_tensor->data;
     desc.global_shape = ReverseArray(global_tensor->shape);
     Array<PrimExpr> global_coords =
@@ -352,64 +445,17 @@ struct AtomicAdd {
     desc.smem_stride = Array<PrimExpr>(desc.rank, PrimExpr(1));
     desc.l2_promotion = static_cast<int>(CU_TENSOR_MAP_L2_PROMOTION_L2_128B);
     desc.oob_fill = static_cast<int>(CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
-
-    auto linear_layout = MakeLinearLayout(shared_tensor->shape);
-    Buffer shared_tensor_unmapped = shared_tensor;
     desc.interleave = static_cast<int>(CU_TENSOR_MAP_INTERLEAVE_NONE);
-    Layout shared_layout;
-    if (lower_args.layout_map.count(shared_tensor)) {
-      shared_layout = lower_args.layout_map.at(shared_tensor);
-      ICHECK(lower_args.buffer_remap.count(shared_tensor))
-          << "shared_tensor: " << shared_tensor->name
-          << " not found in buffer_remap";
-      shared_tensor = lower_args.buffer_remap.at(shared_tensor);
-    }
-    if (!shared_layout.defined()) {
-      desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_NONE);
-    } else if (StructuralEqual()(shared_layout, linear_layout)) {
-      desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_NONE);
-    } else {
-      ICHECK(shared_layout->InputDim() >= 2) << "Cannot detect TMA layout.";
-      const int ndim = static_cast<int>(shared_layout->InputDim());
-      auto stride = as_const_int(shared_layout->InputShape()[ndim - 2]);
-      auto continuous = as_const_int(shared_layout->InputShape()[ndim - 1]);
-      ICHECK(stride != nullptr && continuous != nullptr);
-      if (StructuralEqual()(shared_layout, MakeQuarterBankSwizzleLayout(
-                                               shared_tensor_unmapped))) {
-        desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B);
-      } else if (StructuralEqual()(
-                     shared_layout,
-                     MakeHalfBankSwizzleLayout(shared_tensor_unmapped))) {
-        desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B);
-      } else if (StructuralEqual()(
-                     shared_layout,
-                     MakeFullBankSwizzleLayout(shared_tensor_unmapped))) {
-        desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_128B);
-      } else if (StructuralEqual()(
-                     shared_layout,
-                     MakeGemmABLayoutPadded(*stride, *continuous,
-                                            shared_tensor->dtype.bits()))) {
-        DLOG(WARNING)
-            << "AtomicAdd TMA cannot support a padded layout for src: "
-            << op.src->name << ", dst: " << op.dst->name
-            << " fallback to none swizzle";
-        desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_NONE);
-      } else {
-        DLOG(WARNING) << "AtomicAdd TMA unsupported swizzle layout for src: "
-                      << op.src->name << ", dst: " << op.dst->name
-                      << " fallback to none swizzle";
-        desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_NONE);
-      }
-    }
+    desc.swizzle = plan.swizzle_mode.CanonicalOrdinal();
+    RequireTMASmemAlignment(lower_args, shared_tensor, plan.swizzle_mode);
 
     auto inner_box_dim = as_const_int(desc.smem_box[0]);
     ICHECK(inner_box_dim != nullptr)
         << "inner_box_dim must be a constant integer for TMA atomic add";
     int instruction_dim = *inner_box_dim;
-    if (desc.swizzle == static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B)) {
-      instruction_dim = 64 / shared_tensor->dtype.bytes();
-    } else if (desc.swizzle == static_cast<int>(CU_TENSOR_MAP_SWIZZLE_128B)) {
-      instruction_dim = 128 / shared_tensor->dtype.bytes();
+    if (!plan.swizzle_mode.IsNone()) {
+      instruction_dim =
+          plan.swizzle_mode.ByteWidth() / shared_tensor->dtype.bytes();
     }
     if (instruction_dim > 256) {
       ICHECK((*inner_box_dim) % 256 == 0)
@@ -420,25 +466,6 @@ struct AtomicAdd {
         << "inner_box_dim: " << *inner_box_dim
         << " is not divisible by instruction_dim: " << instruction_dim;
     desc.smem_box.Set(0, PrimExpr(instruction_dim));
-
-    int inner_box_dim_bytes = instruction_dim * shared_tensor->dtype.bytes();
-    struct SwizzleCheck {
-      int swizzle;
-      int max_dim;
-    };
-    static const std::vector<SwizzleCheck> swizzle_checks = {
-        {static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B), 32},
-        {static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B), 64},
-        {static_cast<int>(CU_TENSOR_MAP_SWIZZLE_128B), 128},
-    };
-    for (const auto &check : swizzle_checks) {
-      if (desc.swizzle == check.swizzle &&
-          inner_box_dim_bytes > check.max_dim) {
-        DLOG(WARNING) << "AtomicAdd TMA cannot support swizzled layout with "
-                         "inner_box_dim_bytes > "
-                      << check.max_dim;
-      }
-    }
 
     Array<PrimExpr> shared_indices;
     for (auto r : shared_range) {

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -10,6 +10,7 @@
 #include <tvm/runtime/logging.h>
 
 #include "cuda/op/copy.h"
+#include "cuda/op/tma_layout.h"
 #include "cuda/target_utils.h"
 #include "cuda/transform/ptx_async_copy_injector.h"
 #include "layout/cute_layout.h"
@@ -402,22 +403,6 @@ bool TmemFragmentNeedsPack16b(const cute::Layout &fragment) {
 } // namespace
 
 namespace cuda {
-
-// The TMA unit applies the descriptor's swizzle pattern relative to the
-// shared-memory base address, so the base must sit on a swizzle-pattern
-// repeat boundary or the data lands with a shifted phase (silently wrong
-// results, no fault). Report the requirement implied by the chosen
-// CU_TENSOR_MAP_SWIZZLE_* mode so MergeSharedMemoryAllocations can align the
-// buffer accordingly.
-static void RequireTMASmemAlignment(const LowerArgs &lower_args,
-                                    const Buffer &shared_tensor,
-                                    int cu_tensor_map_swizzle) {
-  if (!lower_args.require_smem_alignment)
-    return;
-  // CU_TENSOR_MAP_SWIZZLE_* values equal the SwizzleMode canonical ordinals.
-  SwizzleMode mode = SwizzleMode::FromOrdinal(cu_tensor_map_swizzle);
-  lower_args.require_smem_alignment(shared_tensor->data, mode.SmemAlignment());
-}
 
 struct TMAIm2ColDesc {
   size_t rank;
@@ -1827,7 +1812,7 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
   Array<Range> global_range = is_load ? src_range : dst_range;
   Array<Range> shared_range = is_load ? dst_range : src_range;
 
-  auto fallback_to_normal = [&](const char *reason) -> Stmt {
+  auto fallback_to_normal = [&](const std::string &reason) -> Stmt {
     if (GetIsTmaCopy(op)) {
       LOG(FATAL) << "T.tma_copy() cannot fall back to normal copy in "
                  << "LowerBulk: " << reason << ", src=" << src->name
@@ -1885,50 +1870,33 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
     shared_layout = MakeLinearLayout(shared_shape);
   }
 
-  // Convert the TileLang layout to a possibly swizzled CuTe ComposedLayout.
-  // This computes the swizzle from an arbitrary TileLang layout.
-  // E.g., composed = Sw<3,3,3> o 0 o (64,64,8):(64,1,4096)
-  auto composed = cute::ComposedLayoutFromTileLang(shared_layout);
-  if (!composed.defined()) {
+  // Convert the TileLang layout to a TensorMap-compatible CuTe layout.
+  TMASharedLayoutAnalysis layout_analysis =
+      AnalyzeTMASharedLayout(shared_layout, shared_tensor->dtype);
+  if (!layout_analysis.encoding.has_value()) {
     DLOG(WARNING) << "Shared layout for src: " << src->name
                   << ", dst: " << dst->name
-                  << " is not a CuTe swizzle over an affine layout, fallback "
-                     "to normal copy";
-    return fallback_to_normal("undecodable shared swizzle layout");
+                  << " cannot be encoded for TMA: " << layout_analysis.reason
+                  << ", fallback to normal copy";
+    return fallback_to_normal(layout_analysis.reason);
   }
-  // Recast element-space layout into byte-address space.
-  // Because CuTe swizzle are based on byte addresses.
+  const TMASharedLayoutEncoding &layout_encoding =
+      layout_analysis.encoding.value();
+  desc.swizzle = layout_encoding.swizzle_mode.CanonicalOrdinal();
   int elem_bits = shared_tensor->dtype.bits();
-  // E.g., composed_bytes = Sw<3,4,3> o 0 o (64,64,8):(128,2,8192)
-  auto composed_bytes = composed.value().Recast(elem_bits, /*new_bits=*/8);
-  const auto *sw = composed_bytes->swizzle.get();
-  int b_bits = sw->b_bits, m_base = sw->m_base, s_shift = sw->s_shift;
-  if (!sw->IsSwizzled()) {
-    desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_NONE);
-  } else if (b_bits == 1 && m_base == 4 && s_shift == 3) {
-    desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_32B);
-  } else if (b_bits == 2 && m_base == 4 && s_shift == 3) {
-    desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_64B);
-  } else if (b_bits == 3 && m_base == 4 && s_shift == 3) {
-    desc.swizzle = static_cast<int>(CU_TENSOR_MAP_SWIZZLE_128B);
-  } else {
-    DLOG(WARNING) << "Shared swizzle Sw<" << b_bits << "," << m_base << ","
-                  << s_shift << "> for src: " << src->name
-                  << ", dst: " << dst->name
-                  << " is not a TMA swizzle atom, fallback to normal copy";
-    return fallback_to_normal("non-TMA shared swizzle layout");
-  }
+  const cute::SwizzleNode *sw = layout_encoding.composed_bytes->swizzle.get();
 
   // The TMA unit applies the descriptor's swizzle pattern relative to the
   // shared-memory base address, so the base must sit on a swizzle-pattern
   // repeat boundary or the data lands with a shifted phase (silently wrong
   // results, no fault). Report the requirement implied by the chosen swizzle
   // mode so MergeSharedMemoryAllocations can align the buffer accordingly.
-  RequireTMASmemAlignment(lower_args, shared_tensor, desc.swizzle);
+  RequireTMASmemAlignment(lower_args, shared_tensor,
+                          layout_encoding.swizzle_mode);
 
   // logical shared -> physical shared (without swizzle)
   // E.g., smem_plain = (64,64,8):(64,1,4096)
-  auto smem_plain = composed.value()->layout;
+  auto smem_plain = layout_encoding.composed->layout;
 
   // tile -> logical shared -> physical shared (without siwzzle)
   // E.g., tile_to_smem_plain = (64,64,8):(64,1,4096)
@@ -2518,7 +2486,8 @@ Stmt Copy::LowerBulkGather4(const CopyNode &op, const LowerArgs &lower_args,
           << " exceeds " << max_bytes << "B swizzle limit";
     }
   }
-  RequireTMASmemAlignment(lower_args, shared_tensor, desc.swizzle);
+  RequireTMASmemAlignment(lower_args, shared_tensor,
+                          SwizzleMode::FromOrdinal(desc.swizzle));
 
   Call create_descriptor =
       Call(DataType::Handle(), create_tma_descriptor(), desc.EncodeCallArgs());
@@ -2793,7 +2762,7 @@ Stmt Im2Col::Lower(const Im2ColOpNode &op, const LowerArgs &lower_args,
   RequireTMASmemAlignment(
       lower_args,
       lower_args.buffer_remap.count(dst) ? lower_args.buffer_remap[dst] : dst,
-      desc.swizzle);
+      SwizzleMode::FromOrdinal(desc.swizzle));
 
   Call create_desc = Call(DataType::Handle(), create_tma_im2col_descriptor(),
                           desc.EncodeCallArgs());

--- a/src/cuda/op/tma_layout.cc
+++ b/src/cuda/op/tma_layout.cc
@@ -1,0 +1,52 @@
+/*!
+ * \file tl/cuda/op/tma_layout.cc
+ * \brief Shared CUDA TMA layout analysis helpers.
+ */
+
+#include "cuda/op/tma_layout.h"
+
+#include <sstream>
+#include <utility>
+
+namespace tvm {
+namespace tl {
+namespace cuda {
+
+TMASharedLayoutAnalysis AnalyzeTMASharedLayout(const Layout &layout,
+                                               DataType dtype) {
+  ffi::Optional<cute::ComposedLayout> composed =
+      cute::ComposedLayoutFromTileLang(layout);
+  if (!composed.defined()) {
+    return {std::nullopt,
+            "layout is not a recoverable XOR swizzle over an affine layout"};
+  }
+
+  cute::ComposedLayout composed_bytes =
+      composed.value().Recast(dtype.bits(), /*new_bits=*/8);
+  const cute::Swizzle &swizzle = composed_bytes->swizzle;
+  if (!swizzle->IsTMACompatible()) {
+    std::ostringstream reason;
+    reason << "byte-address swizzle Sw<" << swizzle->b_bits << ","
+           << swizzle->m_base << "," << swizzle->s_shift
+           << "> is not representable by a TensorMap descriptor";
+    return {std::nullopt, reason.str()};
+  }
+
+  TMASharedLayoutEncoding encoding{composed.value(), composed_bytes,
+                                   swizzle->ToSwizzleMode()};
+  return {std::move(encoding), ""};
+}
+
+void RequireTMASmemAlignment(const LowerArgs &lower_args,
+                             const tirx::Buffer &shared_tensor,
+                             const SwizzleMode &swizzle_mode) {
+  if (!lower_args.require_smem_alignment) {
+    return;
+  }
+  lower_args.require_smem_alignment(shared_tensor->data,
+                                    swizzle_mode.SmemAlignment());
+}
+
+} // namespace cuda
+} // namespace tl
+} // namespace tvm

--- a/src/cuda/op/tma_layout.h
+++ b/src/cuda/op/tma_layout.h
@@ -1,0 +1,45 @@
+/*!
+ * \file tl/cuda/op/tma_layout.h
+ * \brief Shared CUDA TMA layout analysis helpers.
+ */
+
+#ifndef TVM_TL_CUDA_OP_TMA_LAYOUT_H_
+#define TVM_TL_CUDA_OP_TMA_LAYOUT_H_
+
+#include "layout/cute_layout.h"
+#include "op/operator.h"
+
+#include <optional>
+#include <string>
+
+namespace tvm {
+namespace tl {
+namespace cuda {
+
+struct TMASharedLayoutEncoding {
+  cute::ComposedLayout composed;
+  cute::ComposedLayout composed_bytes;
+  SwizzleMode swizzle_mode;
+};
+
+struct TMASharedLayoutAnalysis {
+  std::optional<TMASharedLayoutEncoding> encoding;
+  std::string reason;
+};
+
+// Recover the affine layout and require its byte-address swizzle to be one of
+// the four modes representable by a TensorMap descriptor.
+TMASharedLayoutAnalysis AnalyzeTMASharedLayout(const Layout &layout,
+                                               DataType dtype);
+
+// Record the shared-memory base alignment required by the selected TensorMap
+// swizzle so later allocation merging cannot shift the swizzle phase.
+void RequireTMASmemAlignment(const LowerArgs &lower_args,
+                             const tirx::Buffer &shared_tensor,
+                             const SwizzleMode &swizzle_mode);
+
+} // namespace cuda
+} // namespace tl
+} // namespace tvm
+
+#endif // TVM_TL_CUDA_OP_TMA_LAYOUT_H_

--- a/testing/python/language/test_tilelang_language_atomic.py
+++ b/testing/python/language/test_tilelang_language_atomic.py
@@ -9,13 +9,6 @@ from tilelang import tvm
 # ======================= Thread-level atomic add =======================
 
 
-def _check_hopper():
-    if not torch.cuda.is_available() or torch.version.hip is not None:
-        return False
-    props = torch.cuda.get_device_properties(torch.cuda.current_device())
-    return (props.major, props.minor) == (9, 0)
-
-
 @tilelang.jit
 def atomic_add_program(K, M, N, block_M, block_N, dtype=T.float32):
     @T.prim_func
@@ -306,23 +299,59 @@ def tma_atomic_add_program(out, explicit_swizzle=False):
             T.atomic_add(out, out_shared, use_tma=True)
 
 
-def tma_atomic_add_compile_program(dtype):
+@tilelang.jit
+def tma_atomic_add_uint64_program(out):
+    out: T.Tensor[(16, 16), T.uint64]
+
+    with T.Kernel(1):
+        out_shared = T.alloc_shared((16, 16), dtype=T.uint64)
+        T.fill(out_shared, 1)
+        for _ in range(4):
+            T.atomic_add(out, out_shared, use_tma=True)
+
+
+@tilelang.jit
+def tma_atomic_add_32b_swizzle_program(out):
+    out: T.Tensor[(16, 24), T.float32]
+
+    with T.Kernel(1):
+        out_shared = T.alloc_shared((16, 24), dtype=T.float32)
+        T.fill(out_shared, 1)
+        T.atomic_add(out, out_shared, use_tma=True)
+
+
+def tma_atomic_add_compile_program(dtype, shape=(16, 16), explicit_layout=False):
     @T.prim_func
-    def main(out: T.Tensor((16, 16), dtype)):
+    def main(out: T.Tensor(shape, dtype)):
         with T.Kernel(1):
-            out_shared = T.alloc_shared((16, 16), dtype=dtype)
+            out_shared = T.alloc_shared(shape, dtype=dtype)
+            if explicit_layout:
+                T.annotate_layout({out_shared: tilelang.layout.make_wgmma_swizzled_layout(out_shared)})
             T.atomic_add(out, out_shared, use_tma=True)
 
     return main
 
 
-def lower_tma_atomic_add(dtype):
-    target = tvm.target.Target({"kind": "cuda", "arch": "sm_90"})
+def lower_tma_atomic_add(dtype, arch="sm_90", shape=(16, 16), explicit_layout=False):
+    target = tvm.target.Target({"kind": "cuda", "arch": arch})
     with target:
-        return tilelang.lower(tma_atomic_add_compile_program(dtype), target=target)
+        return tilelang.lower(
+            tma_atomic_add_compile_program(dtype, shape=shape, explicit_layout=explicit_layout),
+            target=target,
+        )
 
 
-@pytest.mark.skipif(not _check_hopper(), reason="Requires Hopper GPU (sm_90)")
+def get_tma_atomic_add_descriptor_args(artifact):
+    for func in artifact.host_mod.functions.values():
+        if func.attrs is None or "tma_descriptor_args" not in func.attrs:
+            continue
+        descriptors = list(func.attrs["tma_descriptor_args"].values())
+        assert len(descriptors) == 1
+        return list(descriptors[0])
+    raise AssertionError("TMA descriptor metadata not found")
+
+
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
 def test_tma_atomic_add():
     out = torch.zeros((16, 16), dtype=torch.float32, device="cuda")
     tma_atomic_add_program(out)
@@ -337,16 +366,65 @@ def test_tma_atomic_add():
     assert kernel.get_kernel_source() == kernel_with_explicit_swizzle.get_kernel_source()
 
 
-@pytest.mark.parametrize("dtype", [T.int16, T.float64, T.uint64, T.float32x2])
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_tma_atomic_add_uint64_runtime():
+    out = torch.zeros((16, 16), dtype=torch.uint64, device="cuda")
+    tma_atomic_add_uint64_program(out)
+    torch.testing.assert_close(out, torch.full_like(out, 4), rtol=0, atol=0)
+
+
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_tma_atomic_add_32b_swizzle_runtime():
+    out = torch.zeros((16, 24), dtype=torch.float32, device="cuda")
+    tma_atomic_add_32b_swizzle_program(out)
+    torch.testing.assert_close(out, torch.ones_like(out), rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("dtype", [T.int16, T.int64, T.float64, T.float32x2])
 def test_tma_atomic_add_rejects_unsupported_dtype(dtype):
-    with pytest.raises(Exception, match=rf"TMA atomic add does not support dtype {dtype}.*supported scalar dtypes"):
+    with pytest.raises(
+        tvm.error.InternalError,
+        match=rf"TMA atomic add does not support dtype {dtype}.*supported scalar dtypes",
+    ):
         lower_tma_atomic_add(dtype)
 
 
-@pytest.mark.parametrize("dtype", [T.float16, T.bfloat16, T.float32, T.int32, T.uint32])
-def test_tma_atomic_add_accepts_supported_dtype(dtype):
+@pytest.mark.parametrize("dtype", [T.float16, T.bfloat16, T.float32, T.int32, T.uint32, T.uint64])
+def test_tma_atomic_add_accepts_ptx_dtype(dtype):
     artifact = lower_tma_atomic_add(dtype)
     assert "tma_store_add" in artifact.kernel_source
+
+
+def test_tma_atomic_add_uint64_uses_linear_layout():
+    artifact = lower_tma_atomic_add(T.uint64)
+    descriptor_args = get_tma_atomic_add_descriptor_args(artifact)
+    # The final four descriptor arguments are interleave, swizzle, L2
+    # promotion, and OOB fill. uint64 intentionally uses no swizzle because
+    # its GEMM K-inner layout is not representable by TensorMap.
+    assert descriptor_args[-3].value == 0
+
+
+def test_tma_atomic_add_splits_32b_swizzle_box():
+    artifact = lower_tma_atomic_add(T.float32, shape=(16, 24))
+    descriptor_args = get_tma_atomic_add_descriptor_args(artifact)
+    assert descriptor_args[-3].value == 1
+    assert artifact.kernel_source.count("tma_store_add") == 3
+
+
+def test_tma_atomic_add_rejects_pre_hopper_target():
+    with pytest.raises(
+        tvm.error.InternalError,
+        match=r"TMA atomic add requires a CUDA target with TMA support \(SM90\+\)",
+    ):
+        lower_tma_atomic_add(T.float32, arch="sm_80")
+
+
+def test_tma_atomic_add_rejects_unencodable_explicit_layout():
+    with pytest.raises(
+        tvm.error.InternalError,
+        match=r"TMA atomic add cannot encode the shared layout.*not representable by a TensorMap descriptor",
+    ):
+        lower_tma_atomic_add(T.uint64, explicit_layout=True)
 
 
 def run_atomic_add_auto_vectorized(K, M, N, block_M, block_N, dtype=T.float32):


### PR DESCRIPTION
## Summary

- Separate PTX TMA reduce-add dtype support from shared-memory layout encoding.
- Preserve legal uint64 reductions with a TensorMap-compatible linear layout.
- Reject unsupported targets, dtypes, and layouts with actionable diagnostics instead of silently selecting no swizzle.

## Changes

- Add shared TMA layout analysis that recovers CuTe composed layouts, validates TensorMap swizzles, and records shared-memory alignment requirements.
- Reuse the shared analysis in TMA copy and atomic-add lowering.
- Replace GEMM-oriented atomic-add layout inference with operation-specific 32B, 64B, 128B, or linear selection.
- Derive descriptor dtype, swizzle, alignment, and split width from a validated lowering plan.
- Cover PTX-supported and unsupported dtypes, pre-Hopper targets, incompatible explicit layouts, uint64 execution, and 32B swizzle splitting.

## Validation

- `./format.sh`
- `cmake --build build -j$(nproc)`
- `python -m pytest -q testing/python/language/test_tilelang_language_atomic.py -k tma_atomic_add`
- `python -m pytest -q testing/python/language/test_tilelang_language_tma_copy.py testing/python/transform/test_tilelang_transform_smem_swizzle_alignment.py`

## Notes

- uint64 intentionally uses unswizzled linear shared storage because the existing 64-bit GEMM K-inner layout is not representable by a TensorMap descriptor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added shared TMA layout analysis for CuTe composed layouts, TensorMap swizzle validation, and shared-memory alignment requirements.
- Reused the analysis for TMA copy and atomic-add lowering.
- Updated atomic-add lowering to select operation-specific 32B, 64B, 128B, or linear layouts.
- Derived descriptor dtype, swizzle, alignment, and split width from validated lowering plans.
- Added actionable diagnostics for unsupported targets, dtypes, layouts, and incompatible explicit layouts.
- Added coverage for supported and unsupported PTX dtypes, pre-Hopper targets, `uint64`, invalid layouts, and 32B swizzle splitting.
- Kept `uint64` on unswizzled linear shared storage because the existing 64-bit GEMM K-inner layout cannot be represented by a TensorMap descriptor.

## C++ style / lint notes

- The PR changes C++ implementation and header files.
- The PR does not document changes to rules in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) may report advisory findings such as TLCPP003 or TLCPP004. These findings are not merge blockers unless they introduce a clear API, FFI, or maintainability risk.
- No correctness, build, or test issue is identified from the provided validation summary.

## Testing

- Formatting validation completed.
- Compilation validation completed.
- Targeted atomic-add pytest validation completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->