### PR TITLE
[ROCm] Enable DeepSeek V4 FP8/FP4 activation quantization

### DIFF
--- a/docs/get_started/Installation.md
+++ b/docs/get_started/Installation.md
@@ -271,7 +271,7 @@ pip install -e . -v --no-build-isolation --no-deps
 
 # Manually install required runtime deps when using --no-deps.
 # Note: skip torch-c-dlpack-ext on ROCm (its wheel expects CUDA libs).
-pip install "apache-tvm-ffi>=0.1.11,<0.1.13" "z3-solver>=4.13.0"
+pip install "apache-tvm-ffi>=0.1.12,<0.1.13" "z3-solver>=4.13.0"
 # If you already installed torch-c-dlpack-ext and hit `libtorch_cuda.so` errors:
 # pip uninstall -y torch-c-dlpack-ext
 

--- a/examples/deepseek_v4/act_quant.py
+++ b/examples/deepseek_v4/act_quant.py
@@ -28,6 +28,7 @@ def fast_round_scale(amax, fp8_max_inv):
 )
 def fp8_quant_kernel(
     x,
+    fp8_max,
     block_size=128,
     round_scale=True,  # round scale to exponential of 2
 ):
@@ -35,7 +36,7 @@ def fp8_quant_kernel(
 
     M = T.dynamic("M")
     N = T.const("N")
-    fp8_min, fp8_max = -448.0, 448.0
+    fp8_min = -fp8_max
     in_dtype = T.bfloat16
     out_dtype = T.float8_e4m3
     scale_dtype = T.float32
@@ -94,13 +95,19 @@ def fp8_act_quant(x: torch.Tensor, block_size: int = 128, round_scale: bool = Fa
         round_scale: If True, round scale to nearest power of 2 (MXFP style).
 
     Returns:
-        quant: FP8 quantized tensor, same shape as x, dtype float8_e4m3fn.
+        quant: FP8 quantized tensor, same shape as x, using the target's E4M3 FN/FNUZ variant.
         scale: Per-block scales, shape (..., N // block_size), dtype float32.
     """
     N = x.size(-1)
     assert N % block_size == 0, f"N={N} must be divisible by block_size={block_size}"
     z = x.contiguous()
-    quant, scale = fp8_quant_kernel(z.view(-1, N), block_size=block_size, round_scale=round_scale)
+    fp8_max = float(torch.finfo(T.float8_e4m3.as_torch()).max)
+    quant, scale = fp8_quant_kernel(
+        z.view(-1, N),
+        fp8_max=fp8_max,
+        block_size=block_size,
+        round_scale=round_scale,
+    )
     return quant.view(x.shape), scale.view(*x.size()[:-1], -1)
 
 
@@ -196,7 +203,8 @@ def fp8_act_quant_ref(x: torch.Tensor, block_size: int = 128, round_scale: bool 
         scale: shape (M, num_blocks), dtype torch.float32.
     """
     M, N = x.shape
-    fp8_max = 448.0
+    out_dtype = T.float8_e4m3.as_torch()
+    fp8_max = float(torch.finfo(out_dtype).max)
     num_blocks = N // block_size
     x_float = x.float().reshape(M, num_blocks, block_size)
     amax = x_float.abs().amax(dim=-1).clamp(min=1e-4)
@@ -206,7 +214,7 @@ def fp8_act_quant_ref(x: torch.Tensor, block_size: int = 128, round_scale: bool 
         scale = amax / fp8_max
     x_scaled = x_float / scale.unsqueeze(-1)
     x_clamped = x_scaled.clamp(-fp8_max, fp8_max)
-    quant = x_clamped.reshape(M, N).to(torch.float8_e4m3fn)
+    quant = x_clamped.reshape(M, N).to(out_dtype)
     return quant, scale
 
 

--- a/examples/deepseek_v4/act_quant.py
+++ b/examples/deepseek_v4/act_quant.py
@@ -199,7 +199,7 @@ def fp8_act_quant_ref(x: torch.Tensor, block_size: int = 128, round_scale: bool 
     """PyTorch reference for block-wise FP8 quantization.
 
     Returns:
-        quant: shape (M, N), dtype torch.float8_e4m3fn.
+        quant: shape (M, N), using the target's E4M3 FN/FNUZ variant.
         scale: shape (M, num_blocks), dtype torch.float32.
     """
     M, N = x.shape

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "apache-tvm-ffi>=0.1.11,<0.1.13",
+    "apache-tvm-ffi>=0.1.12,<0.1.13",
     # torch-c-dlpack-ext provides prebuilt torch extensions.
     # Without it, TVM FFI may require JIT compilation on first import.
     "torch-c-dlpack-ext; python_version < '3.14'",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Requirements to run local build with `--no-build-isolation` or other developments
 
-apache-tvm-ffi>=0.1.11,<0.1.13
+apache-tvm-ffi>=0.1.12,<0.1.13
 build
 cmake>=3.26
 cython>=3.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Runtime requirements
 
-apache-tvm-ffi>=0.1.11,<0.1.13
+apache-tvm-ffi>=0.1.12,<0.1.13
 torch-c-dlpack-ext; python_version < '3.14'
 cloudpickle
 ml-dtypes

--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -613,13 +613,23 @@ void CodeGenTileLangHIP::PrintVecElemLoad(const std::string &vec, DataType t,
   }
 
   static const char access[] = {'x', 'y', 'z', 'w'};
-  ICHECK(i >= 0 && i < (t.is_float4()                        ? 32
+  bool is_packed_bool = t.is_vector_bool() && t.lanes() >= 8;
+  bool is_packed_int4 = t.bits() == 4 && (t.is_int() || t.is_uint());
+  ICHECK(i >= 0 && i < (is_packed_bool                       ? t.lanes()
+                        : is_packed_int4                     ? t.lanes()
+                        : t.is_float4()                      ? 32
                         : t.bits() == 8                      ? 16
                         : (t.lanes() == 16)                  ? 16
                         : (t.lanes() == 32)                  ? 32
                         : (t.bits() == 16 || t.bits() == 32) ? 8
                                                              : 4));
-  if (t.bits() == 8 && (t.is_int() || t.is_uint())) {
+  if (is_packed_bool) {
+    std::ostringstream packed_byte;
+    packed_byte << "((const unsigned char*)(&(" << vec << ")))[" << i / 8
+                << "]";
+    os << "((static_cast<unsigned int>(" << packed_byte.str() << ") >> "
+       << i % 8 << ") & 0x01u)";
+  } else if (t.bits() == 8 && (t.is_int() || t.is_uint())) {
     std::string type_name = t.is_int() ? "char" : "unsigned char";
     if (t.lanes() == 2 || t.lanes() == 3) {
       os << vec << "." << access[i % t.lanes()];
@@ -627,9 +637,6 @@ void CodeGenTileLangHIP::PrintVecElemLoad(const std::string &vec, DataType t,
       std::string ac = t.lanes() == 4 ? vec : (vec + "." + access[i / 4]);
       os << "((" << type_name << ")(" << ac << " >> " << i % 4 * 8 << "))";
     }
-  } else if (t.is_float4()) {
-    os << "((fp4_e2_2_t*)(&(" << vec << ")))[" << i / 2 << "]."
-       << ((i & 1) ? "y()" : "x()");
   } else if ((t.lanes() == 16 || t.lanes() == 32) && t.bits() == 32 &&
              t.is_float()) {
     // float32x16/float32x32: __attribute__((__vector_size__(...))) supports
@@ -644,6 +651,46 @@ void CodeGenTileLangHIP::PrintVecElemLoad(const std::string &vec, DataType t,
   } else if (t.is_bfloat16()) {
     os << "((bfloat16x2*)(&(" << vec << "." << access[i / 2] << ")))->"
        << access[i % 2];
+  } else if (is_packed_int4) {
+    std::ostringstream packed_byte;
+    packed_byte << "((const unsigned char*)(&(" << vec << ")))[" << i / 2
+                << "]";
+    int shift = i % 2 * 4;
+    if (t.is_uint()) {
+      os << "((static_cast<unsigned int>(" << packed_byte.str() << ") >> "
+         << shift << ") & 0x0fu)";
+    } else {
+      os << "((static_cast<int>((static_cast<unsigned int>("
+         << packed_byte.str() << ") >> " << shift << ") & 0x0fu) ^ 8) - 8)";
+    }
+  } else if (t.is_float8() && !t.is_float8_e8m0fnu()) {
+    if (t.lanes() == 2) {
+      os << "tl_fp8x2_get_lane<" << GetFP8Type(t.element_of()) << ">(" << vec
+         << ", " << i << ")";
+      return;
+    }
+    std::string element = vec;
+    int lanes = t.lanes();
+    int lane = i;
+    while (lanes > 4) {
+      int group_size = lanes / 2;
+      element += lane < group_size ? ".x" : ".y";
+      lane %= group_size;
+      lanes = group_size;
+    }
+    element += "." + std::string(1, access[lane]);
+    os << element;
+  } else if (t.is_float4()) {
+    std::string element = vec;
+    int lanes = t.lanes();
+    int lane = i;
+    while (lanes > 2) {
+      int group_size = lanes / 2;
+      element += lane < group_size ? ".x" : ".y";
+      lane %= group_size;
+      lanes = group_size;
+    }
+    os << element << (lane == 0 ? ".x()" : ".y()");
   } else if (t.lanes() > 4 && t.lanes() <= 8) {
     std::string type_name;
     if (t.bits() == 16) {
@@ -674,28 +721,41 @@ void CodeGenTileLangHIP::PrintVecElemStore(const std::string &vec, DataType t,
   this->PrintIndent();
   static const char access[] = {'x', 'y', 'z', 'w'};
 
-  ICHECK(i >= 0 && i < (t.is_float4()                        ? 32
+  bool is_packed_bool = t.is_vector_bool() && t.lanes() >= 8;
+  bool is_packed_int4 = t.bits() == 4 && (t.is_int() || t.is_uint());
+  ICHECK(i >= 0 && i < (is_packed_bool                       ? t.lanes()
+                        : is_packed_int4                     ? t.lanes()
+                        : t.is_float4()                      ? 32
                         : t.bits() == 8                      ? 16
                         : (t.lanes() == 16)                  ? 16
                         : (t.lanes() == 32)                  ? 32
                         : (t.bits() == 16 || t.bits() == 32) ? 8
                                                              : 4));
-  if (t.bits() == 8 && (t.is_int() || t.is_uint())) {
+  if (is_packed_bool) {
+    std::ostringstream packed_byte;
+    packed_byte << "((unsigned char*)(&(" << vec << ")))[" << i / 8 << "]";
+    stream << packed_byte.str() << " = ";
+    if (i % 8 != 0) {
+      stream << "(" << packed_byte.str() << " & ~(0x01u << " << i % 8
+             << ")) | ";
+    }
+    stream << "((static_cast<unsigned int>(" << value << ") & 0x01u) << "
+           << i % 8 << ");\n";
+  } else if (t.bits() == 8 && (t.is_int() || t.is_uint())) {
     if (t.lanes() == 2 || t.lanes() == 3) {
       stream << vec << '.' << access[i % t.lanes()] << "=" << "(" << value
              << ");\n";
     } else {
       std::string ac = t.lanes() == 4 ? vec : (vec + "." + access[i / 4]);
       stream << ac << "=";
-      // Do not read the first undef lane.
-      if (i != 0) {
-        stream << ac << " & ~(0x000000ff << " << i % 4 * 8 << ") |";
+      // Do not read the first lane of each carrier word.
+      if (i % 4 != 0) {
+        stream << "static_cast<unsigned int>(" << ac << ") & ~(0x000000ffu << "
+               << i % 4 * 8 << ") |";
       }
-      stream << "(" << value << " << " << i % 4 * 8 << ");\n";
+      stream << "(static_cast<unsigned int>(static_cast<unsigned char>("
+             << value << ")) << " << i % 4 * 8 << ");\n";
     }
-  } else if (t.is_float4()) {
-    stream << "((fp4_e2_2_t*)(&(" << vec << ")))[" << i / 2 << "]."
-           << ((i & 1) ? "set_y(" : "set_x(") << value << ");\n";
   } else if ((t.lanes() == 16 || t.lanes() == 32) && t.bits() == 32 &&
              t.is_float()) {
     // float32x16/float32x32: __attribute__((__vector_size__(...))) supports
@@ -710,6 +770,42 @@ void CodeGenTileLangHIP::PrintVecElemStore(const std::string &vec, DataType t,
   } else if (t.is_bfloat16()) {
     stream << "((bfloat16_t*)(&(" << vec << "." << access[i / 2] << ")))["
            << (i % 2) << "] = " << value << ";\n";
+  } else if (is_packed_int4) {
+    std::ostringstream packed_byte;
+    packed_byte << "((unsigned char*)(&(" << vec << ")))[" << i / 2 << "]";
+    stream << packed_byte.str() << " = ";
+    if (i % 2 != 0) {
+      stream << "(" << packed_byte.str() << " & 0x0fu) | ";
+    }
+    stream << "((static_cast<unsigned int>(" << value << ") & 0x0fu) << "
+           << i % 2 * 4 << ");\n";
+  } else if (t.is_float8() && !t.is_float8_e8m0fnu()) {
+    if (t.lanes() == 2) {
+      stream << "tl_fp8x2_set_lane(" << vec << ", " << i << ", " << value
+             << ");\n";
+      return;
+    }
+    std::string element = vec;
+    int lanes = t.lanes();
+    int lane = i;
+    while (lanes > 4) {
+      int group_size = lanes / 2;
+      element += lane < group_size ? ".x" : ".y";
+      lane %= group_size;
+      lanes = group_size;
+    }
+    stream << element << "." << access[lane] << " = " << value << ";\n";
+  } else if (t.is_float4()) {
+    std::string element = vec;
+    int lanes = t.lanes();
+    int lane = i;
+    while (lanes > 2) {
+      int group_size = lanes / 2;
+      element += lane < group_size ? ".x" : ".y";
+      lane %= group_size;
+      lanes = group_size;
+    }
+    stream << element << (lane == 0 ? ".set_x(" : ".set_y(") << value << ");\n";
   } else if (t.lanes() > 4 && t.lanes() <= 8) {
     std::string type_name;
     if (t.bits() == 16) {

--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -14,6 +14,7 @@
 #include <cmath>
 #include <cstdint>
 #include <optional>
+#include <sstream>
 #include <string>
 #include <utility>
 #include <vector>
@@ -2014,6 +2015,7 @@ void CodeGenTileLangHIP::VisitStmt_(const BufferStoreNode *op) {
   // stores; CodeGenC's generic scalarization advances one byte per element.
   if (element_dtype.is_float4() && element_dtype.is_scalar() &&
       value_dtype.is_float4() && !value_dtype.is_scalar()) {
+    enable_fp4_ = true;
     auto packed_it = fp4_packed_buffers_.find(buffer_var);
     std::string packed_buffer =
         packed_it != fp4_packed_buffers_.end()
@@ -2271,13 +2273,27 @@ inline void PrintConst(const FloatImmNode *op, std::ostream &os,
     } else if (std::isnan(op->value)) {
       temp << ((op->dtype.bits() == 32) ? "NAN" : "NAN");
     } else {
-      // Preserve the exact TIR constant. The default stream precision is not
-      // sufficient to round-trip float32 values (for example 1.0f / 6.0f),
-      // which can change branch and quantization boundary results.
-      temp << FlexibleHexFormat(op->value);
-      if (op->dtype.bits() == 32)
-        temp << 'f';
-      temp << "/*" << std::scientific << op->value << "*/";
+      std::ostringstream decimal;
+      decimal << std::scientific << op->value;
+      std::istringstream parser(decimal.str());
+      double round_tripped = 0.0;
+      parser >> round_tripped;
+      bool decimal_is_exact =
+          !parser.fail() && round_tripped == op->value &&
+          std::signbit(round_tripped) == std::signbit(op->value);
+      if (decimal_is_exact) {
+        temp << decimal.str();
+        if (op->dtype.bits() == 32)
+          temp << 'f';
+      } else {
+        // Preserve exact TIR constants whose legacy decimal spelling does not
+        // round-trip (for example 1.0f / 6.0f), which can otherwise change
+        // branch and quantization boundary results.
+        temp << FlexibleHexFormat(op->value);
+        if (op->dtype.bits() == 32)
+          temp << 'f';
+        temp << "/*" << decimal.str() << "*/";
+      }
     }
     p->MarkConst(temp.str());
     os << temp.str();

--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -3,6 +3,7 @@
  */
 
 #include "codegen_hip.h"
+#include "backend/common/codegen/codegen_utils.h"
 #include "support/check.h"
 #include <tvm/arith/analyzer.h>
 #include <tvm/ir/cast.h>
@@ -125,7 +126,7 @@ static std::string GetFP8Type(DataType type) {
 }
 
 // Returns the HIP C type string for a float4_e2m1fn DataType.
-// Only used on gfx950; caller sets enable_fp4_ before invoking.
+// The backing type and conversions in hip_fp4.h are software implementations.
 static std::string GetFP4Type(DataType type) {
   std::stringstream stream;
   int32_t lanes = type.lanes();
@@ -398,10 +399,9 @@ void CodeGenTileLangHIP::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
     os << GetFP8Type(t);
     return;
   } else if (t.is_float4()) {
-    // FP4 E2M1 is only supported on gfx950 (CDNA4). Setting enable_fp4_ will
-    // cause Finish() to include hip_fp4.h which is itself guarded by
-    // #if defined(__gfx950__), so this is safe to emit on all HIP targets
-    // (the compiler will reject FP4 kernel code on non-gfx950 anyway).
+    // FP4 E2M1 uses the target-independent software types and conversions in
+    // hip_fp4.h. Hardware-specific FP4 matrix instructions remain separately
+    // target-gated by the corresponding lowering paths.
     enable_fp4_ = true;
     if (t.lanes() <= 32) {
       os << GetFP4Type(t);
@@ -613,7 +613,8 @@ void CodeGenTileLangHIP::PrintVecElemLoad(const std::string &vec, DataType t,
   }
 
   static const char access[] = {'x', 'y', 'z', 'w'};
-  ICHECK(i >= 0 && i < (t.bits() == 8                        ? 16
+  ICHECK(i >= 0 && i < (t.is_float4()                        ? 32
+                        : t.bits() == 8                      ? 16
                         : (t.lanes() == 16)                  ? 16
                         : (t.lanes() == 32)                  ? 32
                         : (t.bits() == 16 || t.bits() == 32) ? 8
@@ -626,6 +627,9 @@ void CodeGenTileLangHIP::PrintVecElemLoad(const std::string &vec, DataType t,
       std::string ac = t.lanes() == 4 ? vec : (vec + "." + access[i / 4]);
       os << "((" << type_name << ")(" << ac << " >> " << i % 4 * 8 << "))";
     }
+  } else if (t.is_float4()) {
+    os << "((fp4_e2_2_t*)(&(" << vec << ")))[" << i / 2 << "]."
+       << ((i & 1) ? "y()" : "x()");
   } else if ((t.lanes() == 16 || t.lanes() == 32) && t.bits() == 32 &&
              t.is_float()) {
     // float32x16/float32x32: __attribute__((__vector_size__(...))) supports
@@ -670,7 +674,8 @@ void CodeGenTileLangHIP::PrintVecElemStore(const std::string &vec, DataType t,
   this->PrintIndent();
   static const char access[] = {'x', 'y', 'z', 'w'};
 
-  ICHECK(i >= 0 && i < (t.bits() == 8                        ? 16
+  ICHECK(i >= 0 && i < (t.is_float4()                        ? 32
+                        : t.bits() == 8                      ? 16
                         : (t.lanes() == 16)                  ? 16
                         : (t.lanes() == 32)                  ? 32
                         : (t.bits() == 16 || t.bits() == 32) ? 8
@@ -688,6 +693,9 @@ void CodeGenTileLangHIP::PrintVecElemStore(const std::string &vec, DataType t,
       }
       stream << "(" << value << " << " << i % 4 * 8 << ");\n";
     }
+  } else if (t.is_float4()) {
+    stream << "((fp4_e2_2_t*)(&(" << vec << ")))[" << i / 2 << "]."
+           << ((i & 1) ? "set_y(" : "set_x(") << value << ");\n";
   } else if ((t.lanes() == 16 || t.lanes() == 32) && t.bits() == 32 &&
              t.is_float()) {
     // float32x16/float32x32: __attribute__((__vector_size__(...))) supports
@@ -804,12 +812,20 @@ void CodeGenTileLangHIP::VisitExpr_(const CastNode *op, std::ostream &os) {
   DataType target_ty = op->dtype;
   ICHECK_EQ(target_ty.lanes(), from_ty.lanes());
 
+  if (from_ty.is_scalar() && target_ty.is_float4()) {
+    // A C-style cast would select fp4_e2_t(uint8_t) and truncate the numeric
+    // value into raw encoding bits. Use the software round-to-nearest encoder.
+    enable_fp4_ = true;
+    os << "__tl_float_to_fp4((float)(" << PrintExpr(op->value) << "))";
+    return;
+  }
+
   // Emit simple C-style type conversion.
   if (from_ty.is_scalar())
     return CodeGenC::VisitExpr_(op, os);
 
   // ---------------------------------------------------------------------------
-  // Vectorized FP4 <-> float/half/bfloat16 conversions (gfx950 only).
+  // Vectorized FP4 <-> float/half/bfloat16 software conversions.
   // These use the pair-wise helpers from hip_fp4.h.  We process two lanes at a
   // time: odd-indexed lane is the "high" nibble, even-indexed is "low".
   // Only enabled when the FP4 header is included (enable_fp4_ is set by
@@ -1092,7 +1108,7 @@ std::string CodeGenTileLangHIP::GetBufferRef(DataType t,
     scope = alloc_storage_scope_.at(buffer_var_node);
   }
 
-  // FP4 scalar access on gfx950: redirect to tl_fp4_packed_load helper.
+  // Redirect scalar FP4 access to the software packed-load helper.
   // Non-scalar FP4 accesses fall through to the normal path (the vector
   // types fp4_e2_4_t etc. are directly addressable as structs).
   if (t.is_float4() && t.is_scalar()) {
@@ -1830,6 +1846,63 @@ void CodeGenTileLangHIP::VisitStmt_(const AllocBufferNode *op) {
   RegisterHandleType(op->buffer->data.get(), op->buffer->dtype);
 }
 
+void CodeGenTileLangHIP::VisitExpr_(const BufferLoadNode *op,
+                                    std::ostream &os) { // NOLINT(*)
+  ICHECK_EQ(op->indices.size(), 1)
+      << "Load from non-flat memory not supported.";
+  ICHECK(!op->predicate.defined())
+      << "Predicated buffer load is not supported.";
+
+  DataType value_dtype = op->dtype;
+  DataType element_dtype = op->buffer->dtype;
+  if (!(element_dtype.is_float4() && element_dtype.is_scalar() &&
+        value_dtype.is_float4() && !value_dtype.is_scalar())) {
+    CodeGenC::VisitExpr_(op, os);
+    return;
+  }
+
+  // CodeGenC scalarizes vector FP4 loads, but its generic path addresses the
+  // logical buffer as one byte per element. HIP FP4 storage packs two logical
+  // elements per byte, including local buffers whose emitted name has a
+  // `_packed` suffix. Load each nibble through the packed helper instead.
+  Var buffer_var = op->buffer->data;
+  auto packed_it = fp4_packed_buffers_.find(buffer_var);
+  std::string packed_buffer =
+      packed_it != fp4_packed_buffers_.end()
+          ? packed_it->second
+          : "(fp4_e2_2_t*)" + GetVarID(buffer_var.get());
+  PrimExpr index_expr = op->indices[0];
+  const auto *ramp = index_expr.as<RampNode>();
+  std::string index;
+  std::string ramp_base;
+  std::string ramp_stride;
+  if (ramp != nullptr) {
+    ramp_base = SSAGetID(PrintExpr(ramp->base), ramp->base.dtype());
+    ramp_stride = SSAGetID(PrintExpr(ramp->stride), ramp->stride.dtype());
+  } else {
+    index = SSAGetID(PrintExpr(index_expr), index_expr.dtype());
+  }
+  auto print_lane_index = [&](int lane, std::ostream &lane_os) {
+    if (ramp != nullptr) {
+      lane_os << "(" << ramp_base << ")+(" << ramp_stride << "*" << lane << ")";
+    } else {
+      PrintVecElemLoad(index, index_expr.dtype(), lane, lane_os);
+    }
+  };
+  std::string result = name_supply_->FreshName("_fp4_load_");
+  this->PrintIndent();
+  this->PrintType(value_dtype, stream);
+  stream << ' ' << result << "{};\n";
+  for (int i = 0; i < value_dtype.lanes(); ++i) {
+    std::ostringstream lane_index;
+    print_lane_index(i, lane_index);
+    PrintVecElemStore(result, value_dtype, i,
+                      "tl_fp4_packed_load(" + packed_buffer + ", " +
+                          lane_index.str() + ")");
+  }
+  os << result;
+}
+
 void CodeGenTileLangHIP::VisitStmt_(const BufferStoreNode *op) {
   ICHECK_EQ(op->indices.size(), 1) << "Store to non-flat memory not supported.";
   ICHECK(!op->predicate.defined())
@@ -1838,6 +1911,49 @@ void CodeGenTileLangHIP::VisitStmt_(const BufferStoreNode *op) {
   DataType value_dtype = op->value.dtype();
   DataType element_dtype = op->buffer->dtype;
   Var buffer_var = op->buffer->data;
+
+  if (element_dtype.is_float4() && element_dtype.is_scalar() &&
+      value_dtype.is_float4() && !value_dtype.is_scalar()) {
+    // Match the packed vector-load path above: scalarize the logical FP4 store
+    // while preserving the two-elements-per-byte physical representation.
+    auto packed_it = fp4_packed_buffers_.find(buffer_var);
+    std::string packed_buffer =
+        packed_it != fp4_packed_buffers_.end()
+            ? packed_it->second
+            : "(fp4_e2_2_t*)" + GetVarID(buffer_var.get());
+    int vec_scope = BeginScope();
+    PrimExpr index_expr = op->indices[0];
+    const auto *ramp = index_expr.as<RampNode>();
+    std::string index;
+    std::string ramp_base;
+    std::string ramp_stride;
+    if (ramp != nullptr) {
+      ramp_base = SSAGetID(PrintExpr(ramp->base), ramp->base.dtype());
+      ramp_stride = SSAGetID(PrintExpr(ramp->stride), ramp->stride.dtype());
+    } else {
+      index = SSAGetID(PrintExpr(index_expr), index_expr.dtype());
+    }
+    auto print_lane_index = [&](int lane, std::ostream &lane_os) {
+      if (ramp != nullptr) {
+        lane_os << "(" << ramp_base << ")+(" << ramp_stride << "*" << lane
+                << ")";
+      } else {
+        PrintVecElemLoad(index, index_expr.dtype(), lane, lane_os);
+      }
+    };
+    std::string value = SSAGetID(PrintExpr(op->value), value_dtype);
+    for (int i = 0; i < value_dtype.lanes(); ++i) {
+      std::ostringstream lane_index;
+      std::ostringstream lane_value;
+      print_lane_index(i, lane_index);
+      PrintVecElemLoad(value, value_dtype, i, lane_value);
+      this->PrintIndent();
+      stream << "tl_fp4_packed_store(" << packed_buffer << ", "
+             << lane_index.str() << ", " << lane_value.str() << ");\n";
+    }
+    EndScope(vec_scope);
+    return;
+  }
 
   // FP4 scalar store: use tl_fp4_packed_store to correctly handle nibble-level
   // writes without corrupting the neighbouring nibble.
@@ -2057,9 +2173,13 @@ inline void PrintConst(const FloatImmNode *op, std::ostream &os,
     } else if (std::isnan(op->value)) {
       temp << ((op->dtype.bits() == 32) ? "NAN" : "NAN");
     } else {
-      temp << std::scientific << op->value;
+      // Preserve the exact TIR constant. The default stream precision is not
+      // sufficient to round-trip float32 values (for example 1.0f / 6.0f),
+      // which can change branch and quantization boundary results.
+      temp << FlexibleHexFormat(op->value);
       if (op->dtype.bits() == 32)
         temp << 'f';
+      temp << "/*" << std::scientific << op->value << "*/";
     }
     p->MarkConst(temp.str());
     os << temp.str();

--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -1914,10 +1914,10 @@ void CodeGenTileLangHIP::VisitStmt_(const BufferStoreNode *op) {
   DataType element_dtype = op->buffer->dtype;
   Var buffer_var = op->buffer->data;
 
+  // Vector FP4 values targeting scalar FP4 buffers need lane-wise packed
+  // stores; CodeGenC's generic scalarization advances one byte per element.
   if (element_dtype.is_float4() && element_dtype.is_scalar() &&
       value_dtype.is_float4() && !value_dtype.is_scalar()) {
-    // Match the packed vector-load path above: scalarize the logical FP4 store
-    // while preserving the two-elements-per-byte physical representation.
     auto packed_it = fp4_packed_buffers_.find(buffer_var);
     std::string packed_buffer =
         packed_it != fp4_packed_buffers_.end()

--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -1871,6 +1871,7 @@ void CodeGenTileLangHIP::VisitExpr_(const BufferLoadNode *op,
       packed_it != fp4_packed_buffers_.end()
           ? packed_it->second
           : "(fp4_e2_2_t*)" + GetVarID(buffer_var.get());
+  int vec_scope = BeginScope();
   PrimExpr index_expr = op->indices[0];
   const auto *ramp = index_expr.as<RampNode>();
   std::string index;
@@ -1900,6 +1901,7 @@ void CodeGenTileLangHIP::VisitExpr_(const BufferLoadNode *op,
                       "tl_fp4_packed_load(" + packed_buffer + ", " +
                           lane_index.str() + ")");
   }
+  EndScope(vec_scope);
   os << result;
 }
 

--- a/src/rocm/codegen/codegen_hip.h
+++ b/src/rocm/codegen/codegen_hip.h
@@ -51,6 +51,8 @@ public:
   void VisitExpr_(const CallNode *op, std::ostream &os) final;
   void VisitExpr_(const CastNode *op, std::ostream &os) final;
   void VisitExpr_(const ShuffleNode *op, std::ostream &os) final; // NOLINT(*)
+  void VisitExpr_(const BufferLoadNode *op,
+                  std::ostream &os) final; // NOLINT(*)
   void VisitStmt_(const AllocBufferNode *op) final;
   void VisitStmt_(const AttrStmtNode *op) final;
   void VisitStmt_(const BufferStoreNode *op) final;
@@ -84,9 +86,9 @@ private:
   bool need_wmma_h_{false};
   // whether need fp8.h
   bool enable_fp8_{false};
-  // whether need hip_fp4.h (gfx950 only)
+  // whether need the software FP4 helpers in hip_fp4.h
   bool enable_fp4_{false};
-  // Map from FP4 buffer Var to packed buffer variable name (gfx950)
+  // Map from an FP4 buffer Var to its packed buffer variable name
   std::unordered_map<Var, std::string> fp4_packed_buffers_;
   // The size of the barrier array in shared memory
   int barrier_count_ = -1;

--- a/src/tl_templates/hip/hip_fp4.h
+++ b/src/tl_templates/hip/hip_fp4.h
@@ -2,11 +2,11 @@
 
 #include "common.h"
 
-// FP4 E2M1 support for AMD gfx950 (CDNA4 / MI350).
-// All device types and conversion helpers are guarded by __gfx950__ so that
-// this header is safe to include on any ROCm target but only activates on
-// CDNA4.  The CUDA equivalent is tl_templates/cuda/cuda_fp4.h.
-#if defined(__gfx950__)
+// Software FP4 E2M1 support for AMD HIP targets.
+//
+// These device types and conversion helpers use portable bit manipulation;
+// they do not depend on a gfx950-only hardware intrinsic.  The CUDA equivalent
+// is tl_templates/cuda/cuda_fp4.h.
 
 #include <stdint.h>
 
@@ -254,5 +254,3 @@ TL_DEVICE void tl_fp4_packed_store(fp4_e2_2_t *packed, int idx, fp4_e2_t val) {
     packed[idx >> 1].set_x(val);
   }
 }
-
-#endif // defined(__gfx950__)

--- a/src/tl_templates/hip/hip_fp8.h
+++ b/src/tl_templates/hip/hip_fp8.h
@@ -31,7 +31,7 @@ using hip_fp8_e4_t = __hip_fp8_e4m3;
 using hip_fp8x2_e4_t = __hip_fp8x2_e4m3;
 using hip_fp8x4_e4_t = __hip_fp8x4_e4m3;
 #else
-// FNUZ path (MI300X and universal fallback)
+// FNUZ path (gfx940/gfx941/gfx942)
 using hip_fp8_e4_t = __hip_fp8_e4m3_fnuz;
 using hip_fp8x2_e4_t = __hip_fp8x2_e4m3_fnuz;
 using hip_fp8x4_e4_t = __hip_fp8x4_e4m3_fnuz;

--- a/testing/python/amd/test_tilelang_deepseek_v4_act_quant.py
+++ b/testing/python/amd/test_tilelang_deepseek_v4_act_quant.py
@@ -1,0 +1,19 @@
+"""DeepSeek V4 activation-quantization coverage for ROCm targets."""
+
+import sys
+from pathlib import Path
+
+import tilelang.testing
+
+
+EXAMPLE_DIR = Path(__file__).resolve().parents[3] / "examples" / "deepseek_v4"
+sys.path.insert(0, str(EXAMPLE_DIR))
+
+import act_quant  # noqa: E402
+
+
+@tilelang.testing.requires_rocm
+def test_deepseek_v4_activation_quantization():
+    tilelang.testing.set_random_seed(0)
+    act_quant.test_fp8_act_quant(M=64, N=256, block_size=128)
+    act_quant.test_fp4_act_quant(M=64, N=256, block_size=32)

--- a/testing/python/components/test_tilelang_env.py
+++ b/testing/python/components/test_tilelang_env.py
@@ -1,4 +1,5 @@
 import os
+from types import SimpleNamespace
 
 import pytest
 
@@ -33,6 +34,47 @@ def test_env_var(monkeypatch):
         assert tilelang.env.TILELANG_PRINT_ON_COMPILATION == "1"
     finally:
         _restore_forced_value("TILELANG_PRINT_ON_COMPILATION", original_forced_value)
+
+
+def test_rocm_keeps_tvm_ffi_torch_c_dlpack_enabled(monkeypatch):
+    monkeypatch.setattr(tilelang.sys, "platform", "linux")
+    monkeypatch.delenv("TVM_FFI_DISABLE_TORCH_C_DLPACK", raising=False)
+    monkeypatch.delenv("TVM_FFI_SKIP_DLPACK_C_EXCHANGE_API", raising=False)
+    torch_module = SimpleNamespace(
+        version=SimpleNamespace(hip="test"),
+        backends=SimpleNamespace(mps=SimpleNamespace(is_available=lambda: False)),
+    )
+
+    tilelang._disable_tvm_ffi_torch_c_dlpack(torch_module)
+
+    assert "TVM_FFI_DISABLE_TORCH_C_DLPACK" not in os.environ
+    assert "TVM_FFI_SKIP_DLPACK_C_EXCHANGE_API" not in os.environ
+
+
+def test_mps_still_disables_tvm_ffi_torch_c_dlpack(monkeypatch):
+    from tvm_ffi import _optional_torch_c_dlpack
+
+    monkeypatch.setattr(tilelang.sys, "platform", "darwin")
+    env_names = ("TVM_FFI_DISABLE_TORCH_C_DLPACK", "TVM_FFI_SKIP_DLPACK_C_EXCHANGE_API")
+    original_env = {name: os.environ.pop(name, None) for name in env_names}
+    original_loader = _optional_torch_c_dlpack.load_torch_c_dlpack_extension
+    monkeypatch.setattr(_optional_torch_c_dlpack, "load_torch_c_dlpack_extension", original_loader)
+    torch_module = SimpleNamespace(
+        backends=SimpleNamespace(mps=SimpleNamespace(is_available=lambda: True)),
+    )
+
+    try:
+        tilelang._disable_tvm_ffi_torch_c_dlpack(torch_module)
+
+        assert os.environ["TVM_FFI_DISABLE_TORCH_C_DLPACK"] == "1"
+        assert os.environ["TVM_FFI_SKIP_DLPACK_C_EXCHANGE_API"] == "1"
+        assert _optional_torch_c_dlpack.load_torch_c_dlpack_extension() is None
+    finally:
+        for name, value in original_env.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
 
 
 def test_tilelang_tmp_dir_default_tracks_cache_dir(monkeypatch, tmp_path):

--- a/testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py
+++ b/testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py
@@ -1,16 +1,12 @@
+import sys
 import threading
 from types import SimpleNamespace
 
 import pytest
 import torch
+import tvm_ffi
 
-from tilelang import tvm
-from tilelang.engine.param import KernelParam
-from tilelang.jit.adapter.tvm_ffi import (
-    TVMFFIKernelAdapter,
-    _export_rocm_narrow_float_as_tvm_view,
-    _rocm_narrow_float_param_mask,
-)
+from tilelang.jit.adapter.tvm_ffi import TVMFFIKernelAdapter
 
 
 class _FakeKernelParam:
@@ -99,55 +95,33 @@ def test_preloaded_executable_is_reused():
     assert created == []
 
 
+@pytest.mark.skipif(sys.platform == "darwin", reason="TileLang intentionally disables C DLPack on MPS")
 @pytest.mark.parametrize(
-    ("torch_dtype_name", "tilelang_dtype", "physical_shape", "logical_shape", "storage_dtype"),
+    ("torch_dtype_name", "shape", "expected_tvm_dtype"),
     [
-        ("float8_e4m3fnuz", "float8_e4m3", (2, 4), (2, 4), "float8_e4m3fnuz"),
-        ("float4_e2m1fn_x2", "float4_e2m1fn", (2, 2), (2, 4), "float4_e2m1fnx2"),
+        ("float8_e4m3fn", (2, 4), "float8_e4m3fn"),
+        ("float8_e4m3fnuz", (2, 4), "float8_e4m3fnuz"),
+        ("float4_e2m1fn_x2", (2, 2), "float4_e2m1fnx2"),
     ],
 )
-def test_rocm_narrow_float_uses_zero_copy_tvm_view(
-    monkeypatch,
-    torch_dtype_name,
-    tilelang_dtype,
-    physical_shape,
-    logical_shape,
-    storage_dtype,
-):
+def test_tvm_ffi_c_dlpack_preserves_narrow_float_metadata(torch_dtype_name, shape, expected_tvm_dtype):
     torch_dtype = getattr(torch, torch_dtype_name, None)
     if torch_dtype is None:
         pytest.skip(f"PyTorch does not provide {torch_dtype_name}")
 
-    monkeypatch.setattr(torch.version, "hip", "test")
-    param = KernelParam(tvm.DataType(tilelang_dtype), list(logical_shape))
-    tensor = torch.empty(physical_shape, dtype=torch_dtype)
+    assert hasattr(torch.Tensor, "__dlpack_c_exchange_api__")
+    observed = []
+    func_name = "testing.tilelang_narrow_float_c_dlpack_metadata"
 
-    assert _rocm_narrow_float_param_mask([param]) == (True,)
-    tvm_view = _export_rocm_narrow_float_as_tvm_view(tensor, param)
+    @tvm_ffi.register_global_func(func_name, override=True)
+    def capture_metadata(tensor):
+        observed.append((tuple(tensor.shape), str(tensor.dtype), str(tensor.device)))
+        return tensor.ndim
 
-    assert tuple(tvm_view.shape) == physical_shape
-    assert str(tvm_view.dtype) == storage_dtype
-    byte_view = tvm_view._create_view(physical_shape, dtype="int8")
-    round_trip = torch.utils.dlpack.from_dlpack(byte_view)
-    assert round_trip.data_ptr() == tensor.data_ptr()
-
-
-def test_rocm_narrow_float_rejects_non_contiguous_tensor(monkeypatch):
-    torch_dtype = getattr(torch, "float8_e4m3fnuz", None)
-    if torch_dtype is None:
-        pytest.skip("PyTorch does not provide float8_e4m3fnuz")
-
-    monkeypatch.setattr(torch.version, "hip", "test")
-    tensor = torch.empty((2, 4), dtype=torch_dtype).transpose(0, 1)
-    param = KernelParam(tvm.DataType("float8_e4m3"), list(tensor.shape))
-
-    assert not tensor.is_contiguous()
-    with pytest.raises(ValueError, match="requires a contiguous tensor"):
-        _export_rocm_narrow_float_as_tvm_view(tensor, param)
-
-
-def test_non_rocm_does_not_prepare_narrow_float_runtime_args(monkeypatch):
-    monkeypatch.setattr(torch.version, "hip", None)
-    param = KernelParam(tvm.DataType("float8_e4m3"), [2, 4])
-
-    assert _rocm_narrow_float_param_mask([param]) is None
+    try:
+        callback = tvm_ffi.get_global_func(func_name)
+        tensor = torch.empty(shape, dtype=torch_dtype, device="cpu")
+        assert callback(tensor) == len(shape)
+        assert observed == [(shape, expected_tvm_dtype, "cpu:0")]
+    finally:
+        tvm_ffi.remove_global_func(func_name)

--- a/testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py
+++ b/testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py
@@ -1,9 +1,16 @@
 import threading
 from types import SimpleNamespace
 
+import pytest
 import torch
 
-from tilelang.jit.adapter.tvm_ffi import TVMFFIKernelAdapter
+from tilelang import tvm
+from tilelang.engine.param import KernelParam
+from tilelang.jit.adapter.tvm_ffi import (
+    TVMFFIKernelAdapter,
+    _export_rocm_narrow_float_as_tvm_view,
+    _rocm_narrow_float_param_mask,
+)
 
 
 class _FakeKernelParam:
@@ -90,3 +97,43 @@ def test_preloaded_executable_is_reused():
     assert adapter._get_executable() is preloaded_executable
     assert adapter.get_exportable_executable() is preloaded_executable
     assert created == []
+
+
+@pytest.mark.parametrize(
+    ("torch_dtype_name", "tilelang_dtype", "physical_shape", "logical_shape", "storage_dtype"),
+    [
+        ("float8_e4m3fnuz", "float8_e4m3", (2, 4), (2, 4), "float8_e4m3fnuz"),
+        ("float4_e2m1fn_x2", "float4_e2m1fn", (2, 2), (2, 4), "float4_e2m1fnx2"),
+    ],
+)
+def test_rocm_narrow_float_uses_zero_copy_tvm_view(
+    monkeypatch,
+    torch_dtype_name,
+    tilelang_dtype,
+    physical_shape,
+    logical_shape,
+    storage_dtype,
+):
+    torch_dtype = getattr(torch, torch_dtype_name, None)
+    if torch_dtype is None:
+        pytest.skip(f"PyTorch does not provide {torch_dtype_name}")
+
+    monkeypatch.setattr(torch.version, "hip", "test")
+    param = KernelParam(tvm.DataType(tilelang_dtype), list(logical_shape))
+    tensor = torch.empty(physical_shape, dtype=torch_dtype)
+
+    assert _rocm_narrow_float_param_mask([param]) == (True,)
+    tvm_view = _export_rocm_narrow_float_as_tvm_view(tensor, param)
+
+    assert tuple(tvm_view.shape) == physical_shape
+    assert str(tvm_view.dtype) == storage_dtype
+    byte_view = tvm_view._create_view(physical_shape, dtype="int8")
+    round_trip = torch.utils.dlpack.from_dlpack(byte_view)
+    assert round_trip.data_ptr() == tensor.data_ptr()
+
+
+def test_non_rocm_does_not_prepare_narrow_float_runtime_args(monkeypatch):
+    monkeypatch.setattr(torch.version, "hip", None)
+    param = KernelParam(tvm.DataType("float8_e4m3"), [2, 4])
+
+    assert _rocm_narrow_float_param_mask([param]) is None

--- a/testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py
+++ b/testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py
@@ -6,7 +6,11 @@ import pytest
 import torch
 import tvm_ffi
 
+from tilelang import tvm
+from tilelang.jit.abi import prepare_tvm_ffi_callee_allocated_outputs
 from tilelang.jit.adapter.tvm_ffi import TVMFFIKernelAdapter
+
+tirx = tvm.tirx
 
 
 class _FakeKernelParam:
@@ -34,6 +38,8 @@ def _make_adapter():
         buffer_map={tir_param: SimpleNamespace(dtype="float32")},
     )
     adapter._process_dynamic_symbolic = lambda: {}
+    adapter.dynamic_symbolic_map = {}
+    adapter._ffi_callee_allocated_output_abi = False
     adapter.executable = None
     adapter._executable_lock = threading.Lock()
 
@@ -82,19 +88,6 @@ def test_executable_is_initialized_once_and_reused():
     assert len(created) == 1
 
 
-def test_preloaded_executable_is_reused():
-    adapter, created = _make_adapter()
-
-    def preloaded_executable(*args):
-        return None
-
-    adapter.executable = preloaded_executable
-
-    assert adapter._get_executable() is preloaded_executable
-    assert adapter.get_exportable_executable() is preloaded_executable
-    assert created == []
-
-
 @pytest.mark.skipif(sys.platform == "darwin", reason="TileLang intentionally disables C DLPack on MPS")
 @pytest.mark.parametrize(
     ("torch_dtype_name", "shape", "expected_tvm_dtype"),
@@ -125,3 +118,64 @@ def test_tvm_ffi_c_dlpack_preserves_narrow_float_metadata(torch_dtype_name, shap
         assert observed == [(shape, expected_tvm_dtype, "cpu:0")]
     finally:
         tvm_ffi.remove_global_func(func_name)
+
+
+def test_preloaded_executable_is_reused():
+    adapter, created = _make_adapter()
+
+    def preloaded_executable(*args):
+        return None
+
+    adapter.executable = preloaded_executable
+
+    assert adapter._get_executable() is preloaded_executable
+    assert adapter.get_exportable_executable() is preloaded_executable
+    assert created == []
+
+
+def test_callee_allocated_output_dispatch_uses_single_main_entry():
+    adapter, _ = _make_adapter()
+    adapter.params = [_FakeKernelParam(), _FakeKernelParam()]
+    adapter.result_idx = [1]
+    adapter._ffi_callee_allocated_output_abi = True
+    calls = []
+    expected = object()
+
+    def main(*args):
+        calls.append(args)
+        return expected
+
+    adapter.executable = main
+    tensor = torch.empty(1)
+
+    assert adapter._convert_torch_func()(tensor) is expected
+    assert calls == [(tensor, tensor)]
+
+
+def test_subbyte_output_uses_callee_allocated_abi():
+    adapter, _ = _make_adapter()
+    adapter.params = [SimpleNamespace(dtype=SimpleNamespace(bits=4))]
+    adapter.result_idx = [0]
+    adapter.target = tvm.target.Target("cuda", host="c")
+
+    assert adapter._uses_ffi_callee_allocated_output_abi()
+
+
+def test_manual_out_idx_is_exposed_to_tvm_ffi_lowering_without_mutating_source():
+    input_param = tirx.Var("input", "handle")
+    output_param = tirx.Var("output", "handle")
+    source = tirx.PrimFunc([input_param, output_param], tirx.Evaluate(0))
+
+    prepared, output_indices = prepare_tvm_ffi_callee_allocated_outputs(source, -1)
+
+    assert source.attrs is None or "tilelang_out_idx" not in source.attrs
+    assert list(prepared.attrs["tilelang_out_idx"]) == [-1]
+    assert output_indices == [-1]
+
+    attributed = source.with_attr("tilelang_out_idx", [-1])
+    prepared, output_indices = prepare_tvm_ffi_callee_allocated_outputs(attributed, [1])
+    assert prepared.same_as(attributed)
+    assert output_indices == [-1]
+
+    with pytest.raises(ValueError, match="does not match"):
+        prepare_tvm_ffi_callee_allocated_outputs(attributed, [0])

--- a/testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py
+++ b/testing/python/jit/test_tilelang_jit_tvm_ffi_executable.py
@@ -132,6 +132,20 @@ def test_rocm_narrow_float_uses_zero_copy_tvm_view(
     assert round_trip.data_ptr() == tensor.data_ptr()
 
 
+def test_rocm_narrow_float_rejects_non_contiguous_tensor(monkeypatch):
+    torch_dtype = getattr(torch, "float8_e4m3fnuz", None)
+    if torch_dtype is None:
+        pytest.skip("PyTorch does not provide float8_e4m3fnuz")
+
+    monkeypatch.setattr(torch.version, "hip", "test")
+    tensor = torch.empty((2, 4), dtype=torch_dtype).transpose(0, 1)
+    param = KernelParam(tvm.DataType("float8_e4m3"), list(tensor.shape))
+
+    assert not tensor.is_contiguous()
+    with pytest.raises(ValueError, match="requires a contiguous tensor"):
+        _export_rocm_narrow_float_as_tvm_view(tensor, param)
+
+
 def test_non_rocm_does_not_prepare_narrow_float_runtime_args(monkeypatch):
     monkeypatch.setattr(torch.version, "hip", None)
     param = KernelParam(tvm.DataType("float8_e4m3"), [2, 4])

--- a/testing/python/language/test_tilelang_language_fp8.py
+++ b/testing/python/language/test_tilelang_language_fp8.py
@@ -8,15 +8,15 @@ from tilelang.language.fp8 import determine_fp8_type
 
 
 @pytest.mark.parametrize(
-    ("gcn_arch", "expected_e4m3", "expected_e5m2"),
+    ("gcn_arch", "expected_e4m3", "expected_e5m2", "expected_e4m3_max"),
     [
-        ("gfx942", T.float8_e4m3fnuz, T.float8_e5m2fnuz),
-        ("gfx950", T.float8_e4m3fn, T.float8_e5m2),
-        ("gfx1100", T.float8_e4m3fn, T.float8_e5m2),
-        ("gfx1201", T.float8_e4m3fn, T.float8_e5m2),
+        ("gfx942", T.float8_e4m3fnuz, T.float8_e5m2fnuz, 240.0),
+        ("gfx950", T.float8_e4m3fn, T.float8_e5m2, 448.0),
+        ("gfx1100", T.float8_e4m3fn, T.float8_e5m2, 448.0),
+        ("gfx1201", T.float8_e4m3fn, T.float8_e5m2, 448.0),
     ],
 )
-def test_rocm_fp8_type_matches_hip_template_variant(monkeypatch, gcn_arch, expected_e4m3, expected_e5m2):
+def test_rocm_fp8_type_matches_hip_template_variant(monkeypatch, gcn_arch, expected_e4m3, expected_e5m2, expected_e4m3_max):
     monkeypatch.setattr(torch.version, "hip", "test")
     monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
     monkeypatch.setattr(torch.cuda, "current_device", lambda: 3)
@@ -29,6 +29,7 @@ def test_rocm_fp8_type_matches_hip_template_variant(monkeypatch, gcn_arch, expec
 
     assert determine_fp8_type("e4m3") == expected_e4m3
     assert determine_fp8_type("e5m2") == expected_e5m2
+    assert float(torch.finfo(T.float8_e4m3.as_torch()).max) == expected_e4m3_max
 
 
 def test_generic_fp8_torch_dtype_uses_current_rocm_arch(monkeypatch):

--- a/testing/python/language/test_tilelang_language_fp8.py
+++ b/testing/python/language/test_tilelang_language_fp8.py
@@ -1,0 +1,41 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import tilelang.language as T
+from tilelang.language.fp8 import determine_fp8_type
+
+
+@pytest.mark.parametrize(
+    ("gcn_arch", "expected_e4m3", "expected_e5m2"),
+    [
+        ("gfx942", T.float8_e4m3fnuz, T.float8_e5m2fnuz),
+        ("gfx950", T.float8_e4m3fn, T.float8_e5m2),
+        ("gfx1100", T.float8_e4m3fn, T.float8_e5m2),
+        ("gfx1201", T.float8_e4m3fn, T.float8_e5m2),
+    ],
+)
+def test_rocm_fp8_type_matches_hip_template_variant(monkeypatch, gcn_arch, expected_e4m3, expected_e5m2):
+    monkeypatch.setattr(torch.version, "hip", "test")
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 3)
+
+    def get_device_properties(device):
+        assert device == 3
+        return SimpleNamespace(gcnArchName=gcn_arch)
+
+    monkeypatch.setattr(torch.cuda, "get_device_properties", get_device_properties)
+
+    assert determine_fp8_type("e4m3") == expected_e4m3
+    assert determine_fp8_type("e5m2") == expected_e5m2
+
+
+def test_generic_fp8_torch_dtype_uses_current_rocm_arch(monkeypatch):
+    monkeypatch.setattr(torch.version, "hip", "test")
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(torch.cuda, "get_device_properties", lambda _: SimpleNamespace(gcnArchName="gfx1100"))
+
+    assert T.float8_e4m3.as_torch() == torch.float8_e4m3fn
+    assert T.float8_e5m2.as_torch() == torch.float8_e5m2

--- a/tilelang/__init__.py
+++ b/tilelang/__init__.py
@@ -107,16 +107,15 @@ del _init_logger
 
 
 def _disable_tvm_ffi_torch_c_dlpack(torch_module):
-    is_rocm = getattr(torch_module.version, "hip", None) is not None
     mps_backend = getattr(getattr(torch_module, "backends", None), "mps", None)
     is_mps = sys.platform == "darwin" and mps_backend is not None and mps_backend.is_available()
-    if not is_rocm and not is_mps:
+    if not is_mps:
         return
 
+    # tvm-ffi >= 0.1.12 provides a backend-aware ROCm exchange path. MPS still
+    # cannot provide the stream handle required by the native exchange API.
     os.environ.setdefault("TVM_FFI_DISABLE_TORCH_C_DLPACK", "1")
-    if is_mps:
-        # PyTorch's native exchange API queries a stream handle that MPS cannot provide.
-        os.environ.setdefault("TVM_FFI_SKIP_DLPACK_C_EXCHANGE_API", "1")
+    os.environ.setdefault("TVM_FFI_SKIP_DLPACK_C_EXCHANGE_API", "1")
     try:
         from tvm_ffi import _optional_torch_c_dlpack
     except Exception:

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -27,6 +27,37 @@ from tilelang.language.dtypes import dtype
 
 COMPILE_ARGS = {}
 
+
+def _rocm_narrow_float_param_mask(params: list[KernelParam]) -> tuple[bool, ...] | None:
+    """Return the FP8/FP4 parameters that need the ROCm DLPack fallback."""
+    if getattr(torch.version, "hip", None) is None:
+        return None
+
+    mask = tuple(bool(param.shape) and str(param.dtype).startswith(("float8", "float4")) for param in params)
+    return mask if any(mask) else None
+
+
+def _export_rocm_narrow_float_as_tvm_view(tensor: torch.Tensor, param: KernelParam):
+    """Expose FP8/FP4 storage through DLPack without copying it."""
+    storage_dtype = dtype(tensor.dtype)
+    storage_bits = storage_dtype.bits * storage_dtype.lanes
+    logical_bits = param.dtype.bits * param.dtype.lanes
+    if storage_bits % logical_bits != 0:
+        raise ValueError(
+            f"Cannot expose {tensor.dtype} storage as TileLang dtype {param.dtype}: "
+            f"{storage_bits} storage bits are not divisible by {logical_bits} logical bits"
+        )
+
+    # The Python DLPack fallback supports byte tensors, while FP8/FP4 are not
+    # portable DLPack dtypes. Reinterpret the same storage on both sides while
+    # retaining the Torch storage dtype and physical shape. In particular, the
+    # generated host wrapper expects packed FP4x2 as a subtype of scalar FP4;
+    # it validates the equivalent total bit count and physical strides.
+    byte_tensor = tensor.view(torch.int8)
+    tvm_tensor = runtime.from_dlpack(torch.utils.dlpack.to_dlpack(byte_tensor))
+    return tvm_tensor._create_view(list(tensor.shape), dtype=str(storage_dtype))
+
+
 if sys.platform == "darwin":
     from torch.utils import cpp_extension
 
@@ -204,6 +235,7 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
             param_shapes.append(native_shape)
 
         dynamic_symbolic_map = self._process_dynamic_symbolic()
+        rocm_narrow_float_mask = _rocm_narrow_float_param_mask(self.params)
 
         # Prepare helpers for friendly dtype error messages
         prim_func = self.prim_func
@@ -274,7 +306,14 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
                 tensor_list.append(tensor)
 
             executable = self._get_executable()
-            executable(*tensor_list)
+            if rocm_narrow_float_mask is None:
+                executable(*tensor_list)
+            else:
+                runtime_args = [
+                    _export_rocm_narrow_float_as_tvm_view(tensor, self.params[i]) if rocm_narrow_float_mask[i] else tensor
+                    for i, tensor in enumerate(tensor_list)
+                ]
+                executable(*runtime_args)
 
             # Return outputs in the requested form
             if len(self.result_idx) == 1:

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -66,7 +66,7 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
     # rt_mod
     rt_mod: tvm.runtime.Module | None = None
     # Maps symbolic variables to their corresponding buffer and shape indices
-    dynamic_symbolic_map: dict[tirx.Var, tuple[int, int, int]] | None = None
+    dynamic_symbolic_map: dict[tirx.Var, tuple[int, int, int, int]] | None = None
 
     # Stream/device functors are inherited from BaseKernelAdapter
     def __init__(
@@ -111,7 +111,8 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
         self.verbose = verbose
         self.pass_configs = pass_configs
         self.compile_flags = compile_flags
-        self.dynamic_symbolic_map = self._process_dynamic_symbolic()
+        self._ffi_callee_allocated_output_abi = self._uses_ffi_callee_allocated_output_abi()
+        self.dynamic_symbolic_map = None if self._ffi_callee_allocated_output_abi else self._process_dynamic_symbolic()
         self.kernel_global_source = self.device_kernel_source
         self.executable = None
         self._executable_lock = threading.Lock()
@@ -141,6 +142,19 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
 
     def get_exportable_executable(self) -> tvm.runtime.Executable:
         return self._get_executable()
+
+    def _uses_ffi_callee_allocated_output_abi(self) -> bool:
+        """Whether lowering gives this kernel the callee-allocated main ABI."""
+        if not self.result_idx:
+            return False
+
+        # The native wrapper is currently emitted for CUDA with TileLang's C
+        # host codegen. Other device and host backends retain the preallocated-
+        # output path until they have equivalent result-slot lowering.
+        if self.target.kind.name != "cuda":
+            return False
+        target_host = self.target.host
+        return target_host is not None and target_host.kind.name == "c"
 
     def _process_dynamic_symbolic(self) -> dict[tirx.Var, tuple[int, int, int, int]]:
         """Extract information about dynamic shapes from the TIR function.
@@ -175,6 +189,9 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
         return dynamic_symbolic_map
 
     def _convert_torch_func(self) -> Callable[..., Any]:
+        if getattr(self, "_ffi_callee_allocated_output_abi", False):
+            return self._convert_ffi_callee_allocated_output_func()
+
         # Capture thunks that reflect Torch's current stream and device.
         # These are evaluated at call time to align TVM execution with the
         # caller's active PyTorch stream/device.
@@ -203,7 +220,9 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
                 native_shape[-1] = native_shape[-1] * tl_dtype.bits * tl_dtype.lanes // (stroage_dtype.bits * stroage_dtype.lanes)
             param_shapes.append(native_shape)
 
-        dynamic_symbolic_map = self._process_dynamic_symbolic()
+        dynamic_symbolic_map = self.dynamic_symbolic_map
+        assert dynamic_symbolic_map is not None
+
         # Prepare helpers for friendly dtype error messages
         prim_func = self.prim_func
         buffer_map = prim_func.buffer_map
@@ -282,6 +301,39 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
 
         return func
 
+    def _convert_ffi_callee_allocated_output_func(self) -> Callable[..., Any]:
+        """Create a Torch callable whose outputs are allocated by TVM-FFI."""
+        current_device_functor = self.get_current_device_functor()
+        expected_inputs = len(self.params) - len(self.result_idx)
+        cuda_available = torch.cuda.is_available()
+        has_allocator_exchange = hasattr(torch.Tensor, "__dlpack_c_exchange_api__") or hasattr(torch.Tensor, "__c_dlpack_exchange_api__")
+
+        def func(*inputs: torch.Tensor | Any):
+            if len(inputs) != expected_inputs:
+                raise ValueError(f"Kernel expected {expected_inputs} inputs, but {len(inputs)} are provided.")
+
+            if not cuda_available:
+                raise RuntimeError("TVM-FFI callee-allocated outputs require an available CUDA device.")
+            if not has_allocator_exchange:
+                raise RuntimeError(
+                    "TVM-FFI callee-allocated outputs require Torch's DLPack allocator exchange API. "
+                    "Install a compatible torch-c-dlpack-ext or use a supported PyTorch build."
+                )
+
+            allocator_anchor = next((value for value in inputs if isinstance(value, torch.Tensor)), None)
+            if allocator_anchor is None:
+                # A Torch tensor argument installs the EnvTensorAllocator in
+                # TVM-FFI's thread-local call context.  Scalar-only kernels use
+                # a zero-element anchor solely for that allocator/device state.
+                allocator_anchor = torch.empty(0, device=current_device_functor())
+
+            result = self._get_executable()(*inputs, allocator_anchor)
+            if len(self.result_idx) == 1:
+                return result
+            return list(result)
+
+        return func
+
     @classmethod
     def from_database(
         cls,
@@ -321,6 +373,8 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
         adapter.kernel_global_source = device_kernel_source.text
         adapter.rt_mod = None
         adapter.executable = runtime.load_module(kernel_lib_path)
+        adapter._ffi_callee_allocated_output_abi = adapter._uses_ffi_callee_allocated_output_abi()
+        adapter.dynamic_symbolic_map = None if adapter._ffi_callee_allocated_output_abi else adapter._process_dynamic_symbolic()
         adapter._executable_lock = threading.Lock()
         adapter._post_init()
         return adapter

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -39,6 +39,12 @@ def _rocm_narrow_float_param_mask(params: list[KernelParam]) -> tuple[bool, ...]
 
 def _export_rocm_narrow_float_as_tvm_view(tensor: torch.Tensor, param: KernelParam):
     """Expose FP8/FP4 storage through DLPack without copying it."""
+    if not tensor.is_contiguous():
+        raise ValueError(
+            "The ROCm narrow-float TVM-FFI fallback requires a contiguous tensor; "
+            f"got shape={tuple(tensor.shape)} and stride={tensor.stride()}"
+        )
+
     storage_dtype = dtype(tensor.dtype)
     storage_bits = storage_dtype.bits * storage_dtype.lanes
     logical_bits = param.dtype.bits * param.dtype.lanes

--- a/tilelang/jit/adapter/tvm_ffi.py
+++ b/tilelang/jit/adapter/tvm_ffi.py
@@ -27,43 +27,6 @@ from tilelang.language.dtypes import dtype
 
 COMPILE_ARGS = {}
 
-
-def _rocm_narrow_float_param_mask(params: list[KernelParam]) -> tuple[bool, ...] | None:
-    """Return the FP8/FP4 parameters that need the ROCm DLPack fallback."""
-    if getattr(torch.version, "hip", None) is None:
-        return None
-
-    mask = tuple(bool(param.shape) and str(param.dtype).startswith(("float8", "float4")) for param in params)
-    return mask if any(mask) else None
-
-
-def _export_rocm_narrow_float_as_tvm_view(tensor: torch.Tensor, param: KernelParam):
-    """Expose FP8/FP4 storage through DLPack without copying it."""
-    if not tensor.is_contiguous():
-        raise ValueError(
-            "The ROCm narrow-float TVM-FFI fallback requires a contiguous tensor; "
-            f"got shape={tuple(tensor.shape)} and stride={tensor.stride()}"
-        )
-
-    storage_dtype = dtype(tensor.dtype)
-    storage_bits = storage_dtype.bits * storage_dtype.lanes
-    logical_bits = param.dtype.bits * param.dtype.lanes
-    if storage_bits % logical_bits != 0:
-        raise ValueError(
-            f"Cannot expose {tensor.dtype} storage as TileLang dtype {param.dtype}: "
-            f"{storage_bits} storage bits are not divisible by {logical_bits} logical bits"
-        )
-
-    # The Python DLPack fallback supports byte tensors, while FP8/FP4 are not
-    # portable DLPack dtypes. Reinterpret the same storage on both sides while
-    # retaining the Torch storage dtype and physical shape. In particular, the
-    # generated host wrapper expects packed FP4x2 as a subtype of scalar FP4;
-    # it validates the equivalent total bit count and physical strides.
-    byte_tensor = tensor.view(torch.int8)
-    tvm_tensor = runtime.from_dlpack(torch.utils.dlpack.to_dlpack(byte_tensor))
-    return tvm_tensor._create_view(list(tensor.shape), dtype=str(storage_dtype))
-
-
 if sys.platform == "darwin":
     from torch.utils import cpp_extension
 
@@ -241,8 +204,6 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
             param_shapes.append(native_shape)
 
         dynamic_symbolic_map = self._process_dynamic_symbolic()
-        rocm_narrow_float_mask = _rocm_narrow_float_param_mask(self.params)
-
         # Prepare helpers for friendly dtype error messages
         prim_func = self.prim_func
         buffer_map = prim_func.buffer_map
@@ -312,14 +273,7 @@ class TVMFFIKernelAdapter(BaseKernelAdapter):
                 tensor_list.append(tensor)
 
             executable = self._get_executable()
-            if rocm_narrow_float_mask is None:
-                executable(*tensor_list)
-            else:
-                runtime_args = [
-                    _export_rocm_narrow_float_as_tvm_view(tensor, self.params[i]) if rocm_narrow_float_mask[i] else tensor
-                    for i, tensor in enumerate(tensor_list)
-                ]
-                executable(*runtime_args)
+            executable(*tensor_list)
 
             # Return outputs in the requested form
             if len(self.result_idx) == 1:

--- a/tilelang/language/dtypes.py
+++ b/tilelang/language/dtypes.py
@@ -186,22 +186,13 @@ def __dtype_as_torch__(self: dtype) -> torch.dtype:
     dtype_str = str(self)
 
     if dtype_str == "float8_e4m3":
-        # Check if we're on HIP (AMD ROCm) or CUDA
-        if torch.version.hip is not None:
-            # HIP backend - use float8_e4m3fnuz
-            assert hasattr(torch, "float8_e4m3fnuz"), (
-                "torch.float8_e4m3fnuz is not supported in this version of torch. Please upgrade torch >= 2.2.0"
-            )
-            return torch.float8_e4m3fnuz
-        else:
-            # CUDA backend - use float8_e4m3fn
-            assert hasattr(torch, "float8_e4m3fn"), (
-                "torch.float8_e4m3fn is not supported in this version of torch. Please upgrade torch >= 2.1.0"
-            )
-            return torch.float8_e4m3fn
+        from tilelang.language.fp8 import determine_torch_fp8_type
+
+        return determine_torch_fp8_type("e4m3")
     elif dtype_str == "float8_e5m2":
-        assert hasattr(torch, "float8_e5m2"), "torch.float8_e5m2 is not supported in this version of torch. Please upgrade torch >= 2.1.0"
-        return torch.float8_e5m2
+        from tilelang.language.fp8 import determine_torch_fp8_type
+
+        return determine_torch_fp8_type("e5m2")
     elif dtype_str in ("float8_e4m3fnuz", "e4m3fnuz_float8"):
         assert hasattr(torch, "float8_e4m3fnuz"), (
             "torch.float8_e4m3fnuz is not supported in this version of torch. Please upgrade torch >= 2.2.0"

--- a/tilelang/language/fp8.py
+++ b/tilelang/language/fp8.py
@@ -10,7 +10,7 @@ def determine_fp8_type(fp8_format: Literal["e4m3", "e5m2"] = "e4m3") -> str:
     """
     Select the correct FP8 dtype string for the current platform.
     - CUDA defaults to FP8 E4M3FN / E5M2.
-    - ROCm uses FNUZ except gfx950 (OCP), which prefers non-FNUZ when available.
+    - ROCm gfx940/gfx941/gfx942 use FNUZ; other supported AMD targets use FN.
     """
     import torch
 
@@ -22,15 +22,12 @@ def determine_fp8_type(fp8_format: Literal["e4m3", "e5m2"] = "e4m3") -> str:
         return T.float8_e4m3fn if fp8_format == "e4m3" else T.float8_e5m2
     if not torch.cuda.is_available():
         return T.float8_e4m3fnuz if fp8_format == "e4m3" else T.float8_e5m2fnuz
-    props = torch.cuda.get_device_properties(0)
+    props = torch.cuda.get_device_properties(torch.cuda.current_device())
     gcn_arch = getattr(props, "gcnArchName", "")
+    uses_fnuz = gcn_arch.startswith(("gfx940", "gfx941", "gfx942"))
     if fp8_format == "e4m3":
-        if gcn_arch.startswith("gfx950"):
-            return T.float8_e4m3fn
-        return T.float8_e4m3fnuz
-    if gcn_arch.startswith("gfx950") and hasattr(T, "float8_e5m2"):
-        return T.float8_e5m2
-    return T.float8_e5m2fnuz
+        return T.float8_e4m3fnuz if uses_fnuz else T.float8_e4m3fn
+    return T.float8_e5m2fnuz if uses_fnuz else T.float8_e5m2
 
 
 def determine_torch_fp8_type(fp8_format: Literal["e4m3", "e5m2"] = "e4m3") -> torch.dtype:


### PR DESCRIPTION
## What this changes

This enables TileLang's existing `examples/deepseek_v4/act_quant.py` FP8 and
FP4 activation-quantization paths on ROCm without changing the example:

- require `apache-tvm-ffi>=0.1.12` and use its backend-aware native C-DLPack
  exchange for ROCm E4M3FN, E4M3FNUZ, and packed E2M1x2 tensors, while retaining
  TileLang's MPS-only C-DLPack disable;
- align Python FP8 dtype selection with `hip_fp8.h`: gfx940/gfx941/gfx942 use
  FNUZ, while gfx950/gfx11/gfx12 use FN, and derive the quantization bound from
  the selected dtype;
- make the existing software FP4 E2M1 helpers available to HIP targets beyond
  gfx950;
- correctly lower scalar FP4 conversion and packed vector FP4 loads/stores;
- emit exact hexadecimal HIP floating-point constants so quantization boundary
  values round identically to TIR;
- add unit coverage plus a ROCm DeepSeek V4 activation-quantization integration
  test.

## Why

On the original base (`6b81bb8735743f14e2ecc0bdfdeaa19f24661e13`), the
DeepSeek V4 example compiles its FP8 kernel on gfx1100 but cannot exchange the
narrow-float output through the configured FFI path. The generated kernel also
uses E4M3FN bytes while Python selects E4M3FNUZ. The FP4 path additionally needs
packed vector access and the existing software FP4 helpers outside the gfx950
guard.

Review identified that an adapter-side byte-view workaround was the wrong
layer. The final implementation removes that workaround, upgrades the tvm-ffi
lower bound to 0.1.12, keeps ROCm on the native C-DLPack path, and preserves the
common FFI adapter without AMD-specific argument rewriting.

HIP constants were also emitted with the default stream precision. For FP4
scaling, `1.0f / 6.0f` became `1.666667e-01f`, changing exact boundary cases
such as `amax == 3.0` from scale `0.5` to `1.0`. Hexadecimal literals preserve
the original TIR value.

## Real-device validation

Latest exact integration gate:

- PR head: `a2c3405de38baede7e6ad05080178a54fa4373c4`;
- official main tested: `14bac09d53455f30175aed039957ab3c16ee8407`;
- local and GitHub synthetic merge tree: `e721ba6cf99ab5423574640c056f3bb4febebed1`;
- machine: eight native Radeon PRO W7900D-class gfx1100 devices, no
  `HSA_OVERRIDE_GFX_VERSION` or FFI bypass variable;
- PyTorch `2.9.1+gitff65f5b`, HIP `7.2.53211-e1a6bc5663`, tvm-ffi 0.1.12.

The exact merge tree was configured with `USE_ROCM=ON`, `USE_CUDA=OFF` and
built from source (688 Ninja steps). Static FFI/language coverage passes
30/30, Ruff and clang-format pass, and the native gates report:

```text
native device / C-DLPack metadata: E4M3FN, E4M3FNUZ, E2M1x2 exact

$ python examples/deepseek_v4/act_quant.py
[PASS] test_fp8_act_quant M=256, N=1024, block_size=128
  (FP4 bit-exact match: 131072 bytes)
[PASS] test_fp4_act_quant M=256, N=1024, block_size=32
  FP8 round-trip MSE: 0.000706
  FP4 round-trip MSE: 0.013256
[PASS] test_round_trip_error

10/10 seeds: zero FP4 scale or packed-byte mismatch
31/31 passed: focused native FP8/FP4, FFI, and language suite
77/77 passed: HIP codegen and vector-Select suite
```

Since that gate, upstream main advanced five commits without touching any of
the PR's 16 paths. The public head remains mergeable and `CLEAN`; all 12 checks
succeed and two publish-only jobs are expected skips.

## Review follow-up

- `bae2102e` scopes FP4 vector-load SSA temporaries and added the then-relevant
  non-contiguous fallback boundary test.
- `9be6a1a2` absorbs the maintainer feedback: removes AMD-specific argument
  rewriting from the common FFI adapter, adopts tvm-ffi 0.1.12, keeps ROCm on
  native C-DLPack, retains only the MPS disable, derives FN/FNUZ bounds from the
  selected dtype, and documents the packed vector-store branch.
- later commits make FP4 header inclusion explicit for packed stores, preserve
  exact float constants, and extend the native regression matrix.

All current review threads are resolved. The latest real-device gate above is
on the exact current merge tree, not merely the original review commit.

## Scope

This adds a software FP4 activation-quantization/cast/copy foundation. It does
**not** claim or add gfx1100 hardware FP4 matrix instructions, an FP4 weight
GEMM, checkpoint-quality validation, or end-to-end model throughput.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Enables ROCm FP8 and software FP4 activation quantization for DeepSeek V4.
- Uses tvm-ffi 0.1.12 native C-DLPack exchange for ROCm narrow-float tensors.
- Updates ROCm FP8 dtype selection across AMD GPU targets.
- Adds portable FP4 E2M1 helpers and HIP lowering for scalar and packed vector conversions.
- Adds exact hexadecimal floating-point constant emission.
- Adds ROCm unit tests, DLPack metadata tests, environment tests, and a DeepSeek V4 integration test.

This PR does not add FP4 matrix instructions or an FP4 GEMM path.

## C++ style / lint notes

- The PR changes C++ code in `src/rocm/codegen`.
- It does not change `docs/developer_guide/cpp_style.md`.
- The **C++ API Style Audit (warning only)** runs in CI.
- TLCPP003/TLCPP004 findings are advisory. They should not block merge unless they identify a correctness, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
