### PR TITLE
[Enhancement] Disable data race check by default, opt-in via env var

### DIFF
--- a/src/transform/verify_parallel_loop.cc
+++ b/src/transform/verify_parallel_loop.cc
@@ -140,9 +140,10 @@ struct ParallelLoopVerifier : public ConstrVisitor {
         os << "\n";
       }
     }
-    os << "If you believe this is a false positive, pass "
-          "`PassKey.TL_DISABLE_DATA_RACE_CHECK` to pass key to "
-          "disable this check.";
+    os << "If you believe this is a false positive, disable the check by "
+          "setting `PassKey.TL_DISABLE_DATA_RACE_CHECK` in the pass config, "
+          "or by unsetting the `TILELANG_ENABLE_DATA_RACE_CHECK` environment "
+          "variable (the check is disabled by default).";
     LOG(WARNING) << os.str();
   }
 };

--- a/testing/python/transform/test_tilelang_transform_verify_parallel_loop.py
+++ b/testing/python/transform/test_tilelang_transform_verify_parallel_loop.py
@@ -68,5 +68,28 @@ def test_data_race_diagnostic_includes_span(capfd):
     assert "--> kernel.py:22:1" in err
 
 
+def test_race_check_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("TILELANG_ENABLE_DATA_RACE_CHECK", raising=False)
+    from tilelang.backend.pass_pipeline import pipeline_utils
+
+    assert pipeline_utils.should_enable_race_check() is False
+
+
+def test_race_check_enabled_via_env_var(monkeypatch):
+    monkeypatch.setenv("TILELANG_ENABLE_DATA_RACE_CHECK", "1")
+    from tilelang.backend.pass_pipeline import pipeline_utils
+
+    assert pipeline_utils.should_enable_race_check() is True
+
+
+def test_race_check_pass_config_overrides_env_var(monkeypatch):
+    monkeypatch.setenv("TILELANG_ENABLE_DATA_RACE_CHECK", "1")
+    from tilelang.backend.pass_pipeline import pipeline_utils
+    from tilelang.transform import PassContext
+
+    with PassContext(config={"tl.disable_data_race_check": True}):
+        assert pipeline_utils.should_enable_race_check() is False
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/tilelang/backend/pass_pipeline/pipeline_utils.py
+++ b/tilelang/backend/pass_pipeline/pipeline_utils.py
@@ -1,10 +1,25 @@
 from __future__ import annotations
 
+import os
+
 from tvm import IRModule
 from tvm.target import Target
 
 import tilelang
 from tilelang.transform import PassContext
+
+
+def _env_data_race_check_enabled() -> bool:
+    """Whether the data race check is enabled via the environment.
+
+    The check is disabled by default; users can opt in by setting the
+    ``TILELANG_ENABLE_DATA_RACE_CHECK`` environment variable to a truthy value
+    (e.g. ``1``, ``true``, ``yes``, ``on``).
+    """
+    value = os.environ.get("TILELANG_ENABLE_DATA_RACE_CHECK")
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
 def allow_vectorize(pass_ctx: PassContext | None = None) -> bool:
@@ -43,7 +58,14 @@ def should_enable_layout_visual(pass_ctx: PassContext | None = None) -> bool:
 def should_enable_race_check(pass_ctx: PassContext | None = None) -> bool:
     if pass_ctx is None:
         pass_ctx = tilelang.transform.get_pass_context()
-    return not pass_ctx.config.get(tilelang.PassConfigKey.TL_DISABLE_DATA_RACE_CHECK, False)
+    # The check is disabled by default because it can report false positives
+    # (e.g. shared buffer stores whose per-thread addresses cannot be proven
+    # distinct). Users can opt in via the TILELANG_ENABLE_DATA_RACE_CHECK
+    # environment variable, or override it per-compile through the
+    # `tl.disable_data_race_check` pass config.
+    default_disable = not _env_data_race_check_enabled()
+    disable = pass_ctx.config.get(tilelang.PassConfigKey.TL_DISABLE_DATA_RACE_CHECK, default_disable)
+    return not disable
 
 
 def should_disable_shared_memory_reuse(pass_ctx: PassContext | None = None) -> bool:

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -50,7 +50,14 @@ class PassConfigKey(str, Enum):
     """Enable inlining of let statements during simplification. Default: True"""
 
     TL_DISABLE_DATA_RACE_CHECK = "tl.disable_data_race_check"
-    """Disable data race check in TileLang. Default: False"""
+    """Disable data race check in TileLang. Default: True
+
+    The data race check is disabled by default because it can report false
+    positives (e.g. shared buffer stores whose per-thread addresses cannot be
+    proven distinct). To enable it, set this config to False in pass configs,
+    or set the ``TILELANG_ENABLE_DATA_RACE_CHECK`` environment variable to a
+    truthy value (e.g. ``1``).
+    """
 
     TL_DISABLE_PRELOWER_SEMANTIC_CHECK = "tl.disable_prelower_semantic_check"
     """Disable Python-side pre-lower semantic checks. Default: False"""


### PR DESCRIPTION
The `VerifyParallelLoop` data race check can report false positives on shared buffer stores whose per-thread addresses cannot be proven distinct (e.g. indices loaded from fragments). 

Now disabled it by default; users can opt in via the `TILELANG_ENABLE_DATA_RACE_CHECK` environment variable or by explicitly setting the `tl.disable_data_race_check` pass config to False.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Disabled `VerifyParallelLoop` data-race checking by default.
- Added `TILELANG_ENABLE_DATA_RACE_CHECK=1` to enable the check.
- Preserved `tl.disable_data_race_check` as a pass-context override.
- Documented false-positive cases involving shared buffer stores.
- Added tests for default, environment-variable, and pass-configuration behavior.

## C++ style / lint notes

- The PR changes C++ code, but it does not change rules documented in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step may report advisory findings. These findings do not affect correctness, build behavior, or test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->