### PR TITLE
[CUDA][ROCm][Metal] Split backend-specific builtin ops

### DIFF
--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -12,9 +12,9 @@
 #include <tvm/ir/cast.h>
 #include <tvm/runtime/logging.h>
 
+#include "cuda/op/builtin.h"
 #include "layout/layout.h"
 #include "layout/utils.h"
-#include "op/builtin.h"
 #include "op/utils.h"
 #include "tir/transforms/ir_utils.h"
 #include "transform/loop_partition.h"

--- a/src/cuda/CMakeLists.txt
+++ b/src/cuda/CMakeLists.txt
@@ -5,6 +5,7 @@
 # backend CMake file, but outside the USE_CUDA block.
 file(GLOB TILE_LANG_CUDA_ALWAYS_SRCS
   src/cuda/codegen/intrin_rule_cuda.cc
+  src/cuda/op/builtin.cc
   src/cuda/op/copy_analysis.cc
   src/cuda/target_utils.cc
   src/cuda/transform/lower_ptx_async_copy.cc
@@ -164,6 +165,7 @@ file(GLOB TILE_LANG_CUDA_ACTIVE_SRCS
   src/cuda/transform/*.cc
 )
 list(REMOVE_ITEM TILE_LANG_CUDA_ACTIVE_SRCS
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/cuda/op/builtin.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/cuda/op/copy_analysis.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/cuda/transform/ptx_async_copy_injector.cc"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/cuda/transform/lower_ptx_async_copy.cc")

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -23,7 +23,8 @@
 #include "arith/pattern_match.h"
 #include "backend/common/target_utils.h"
 #include "cuda/codegen/ptx.h"
-#include "op/builtin.h"
+#include "cuda/op/builtin.h"
+#include "cuda/target_utils.h"
 #include "transform/common/attr.h"
 
 namespace tvm {

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -23,7 +23,6 @@
 
 #include "arith/pattern_match.h"
 #include "cuda/op/builtin.h"
-#include "cuda/target_utils.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -22,7 +22,8 @@
 #include <vector>
 
 #include "arith/pattern_match.h"
-#include "op/builtin.h"
+#include "cuda/op/builtin.h"
+#include "cuda/target_utils.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/cuda/op/atomic_add.cc
+++ b/src/cuda/op/atomic_add.cc
@@ -10,10 +10,10 @@
 #include <tvm/runtime/logging.h>
 
 #include "backend/common/target_utils.h"
+#include "cuda/op/builtin.h"
 #include "cuda/op/copy.h"
 #include "cuda/op/tma_layout.h"
 #include "layout/layout.h"
-#include "op/builtin.h"
 #include "op/utils.h"
 #include "span_utils.h"
 #include "transform/common/loop_fusion_utils.h"

--- a/src/cuda/op/builtin.cc
+++ b/src/cuda/op/builtin.cc
@@ -23,6 +23,8 @@ TVM_REGISTER_PASS_CONFIG_OPTION(kDisableShuffleElect, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kEnableLowerLDGSTG, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kEnableLowerLDGSTGPredicated, Bool);
 
+DataType CuTensorMapType() { return DataType::UInt(8, 128); }
+
 TIR_DEFINE_TL_BUILTIN(__exp).set_num_inputs(1).set_attr<TCallEffectKind>(
     "TCallEffectKind", Integer(CallEffectKind::kOpaque));
 

--- a/src/cuda/op/builtin.cc
+++ b/src/cuda/op/builtin.cc
@@ -1,0 +1,492 @@
+/*!
+ * \file tl/cuda/op/builtin.cc
+ * \brief Registration of CUDA-specific TileLang intrinsic Ops.
+ */
+
+#include "builtin.h"
+
+#include <tvm/ir/transform.h>
+
+#include "op/builtin_registry.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+
+TVM_REGISTER_PASS_CONFIG_OPTION(kDisableWarpSpecialized, Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION(kDisableTMALower, Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION(kPtxasRegisterUsageLevel, Integer);
+TVM_REGISTER_PASS_CONFIG_OPTION(kDisableVectorize256, Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION(kDisableWGMMA, Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION(kDisableShuffleElect, Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION(kEnableLowerLDGSTG, Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION(kEnableLowerLDGSTGPredicated, Bool);
+
+TIR_DEFINE_TL_BUILTIN(__exp).set_num_inputs(1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(__exp10).set_num_inputs(1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(__log).set_num_inputs(1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(__log2).set_num_inputs(1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(__log10).set_num_inputs(1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(__tan).set_num_inputs(1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(__cos).set_num_inputs(1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(__sin).set_num_inputs(1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(fast_rcp).set_num_inputs(1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(max_nan).set_num_inputs(2).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(min_nan).set_num_inputs(2).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(ieee_add).set_num_inputs(3).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(ieee_sub).set_num_inputs(3).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(ieee_mul).set_num_inputs(3).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(ieee_fmaf).set_num_inputs(4).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(ieee_frcp).set_num_inputs(2).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(ieee_fsqrt)
+    .set_num_inputs(2)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(ieee_frsqrt)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(ieee_fdiv).set_num_inputs(3).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(max2_nan).set_num_inputs(2).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(min2_nan).set_num_inputs(2).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(rng_init).set_num_inputs(4).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(rng_rand).set_num_inputs(0).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(rng_rand_float)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(create_tma_descriptor)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(create_tma_im2col_descriptor)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(prefetch_tma_descriptor)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(tma_load).set_num_inputs(-1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(tma_load_im2col)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(tma_load_multicast)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(tma_store).set_num_inputs(-1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(tma_load_gather4)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(tma_store_scatter4)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ptx_fence_barrier_init)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ptx_arrive_cluster_barrier)
+    .set_num_inputs(2)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ptx_wgmma_ss)
+    .set_num_inputs(15)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ptx_wgmma_rs)
+    .set_num_inputs(15)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ptx_wgmma_sp_ss)
+    .set_num_inputs(18)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ptx_wgmma_sp_rs)
+    .set_num_inputs(17)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ptx_mma_block_scale)
+    .set_num_inputs(21)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ptx_tcgen05_mma_ss)
+    .set_num_inputs(14)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ptx_tcgen05_mma_ts)
+    .set_num_inputs(13)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ptx_tcgen05_mma_blockscaled_ss)
+    .set_num_inputs(16)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ptx_tcgen05_cp_warpx4)
+    .set_num_inputs(3)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ptx_tcgen05_sf_warp_transpose)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(deallocate_tmem)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ptx_init_tensor_memory)
+    .set_num_inputs(2)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ptx_deallocate_tensor_memory)
+    .set_num_inputs(2)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ptx_mma_sm70)
+    .set_num_inputs(13)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ptx_ldmatrix)
+    .set_num_inputs(4)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ptx_cp_async_barrier_noinc)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ptx_st_bulk_shared)
+    .set_num_inputs(3)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(fence_proxy_async)
+    .set_num_inputs(0)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(tcgen05_before_thread_sync)
+    .set_num_inputs(0)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(tcgen05_after_thread_sync)
+    .set_num_inputs(0)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(tma_store_arrive)
+    .set_num_inputs(0)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(tma_store_wait)
+    .set_num_inputs(2)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(set_max_nreg)
+    .set_num_inputs(2)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(warpgroup_arrive)
+    .set_num_inputs(0)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(warpgroup_commit_batch)
+    .set_num_inputs(0)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(warpgroup_wait)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(warpgroup_fence_operand)
+    .set_num_inputs(4)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(get_lane_idx)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(get_warp_idx_sync)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(get_warp_idx)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(get_warp_group_idx)
+    .set_num_inputs(-1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(pack_b8x4).set_num_inputs(4).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(cluster_arrive_relaxed)
+    .set_num_inputs(0)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(cluster_arrive)
+    .set_num_inputs(0)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(cluster_wait)
+    .set_num_inputs(0)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(cluster_sync)
+    .set_num_inputs(0)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(block_rank_in_cluster)
+    .set_num_inputs(0)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(clc_try_cancel)
+    .set_num_inputs(2)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(clc_try_cancel_multicast)
+    .set_num_inputs(2)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(clc_is_canceled)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(clc_get_first_ctaid_x)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(clc_get_first_ctaid_y)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(clc_get_first_ctaid_z)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(named_barrier_arrive)
+    .set_num_inputs(2)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(pdl_trigger)
+    .set_num_inputs(0)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(pdl_sync).set_num_inputs(0).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(tl_shuffle_elect)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(initialize_wgmma_descriptor)
+    .set_num_inputs(5)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(initialize_tcgen05_descriptor)
+    .set_num_inputs(7)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(increase_descriptor_offset)
+    .set_num_inputs(2)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(device_assert)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(device_assert_with_msg)
+    .set_num_inputs(2)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(tcgen05_mma_arrive)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(tcgen05_ld)
+    .set_num_inputs(6)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(tcgen05_st)
+    .set_num_inputs(6)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(__ffs).set_num_inputs(1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(__fns).set_num_inputs(3).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(ldg32).set_num_inputs(-1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(ldg64).set_num_inputs(-1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(ldg128).set_num_inputs(-1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(lds32).set_num_inputs(1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(lds64).set_num_inputs(1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(lds128).set_num_inputs(1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(ldg256).set_num_inputs(-1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(stg32).set_num_inputs(-1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(stg64).set_num_inputs(-1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(stg128).set_num_inputs(-1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(sts32).set_num_inputs(2).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(sts64).set_num_inputs(2).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(sts128).set_num_inputs(2).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(stg256).set_num_inputs(-1).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(ptx_cluster_store)
+    .set_num_inputs(4)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(tma_store_cluster)
+    .set_num_inputs(5)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(mvb_stage_index)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
+} // namespace tl
+} // namespace tvm
+
+#undef TIR_DEFINE_TL_BUILTIN

--- a/src/cuda/op/builtin.h
+++ b/src/cuda/op/builtin.h
@@ -95,6 +95,11 @@ TVM_DLL const Op &rng_rand();
 TVM_DLL const Op &rng_rand_float();
 
 /*!
+ * \brief Return the sentinel dtype used for CUDA tensor-map parameters.
+ */
+DataType CuTensorMapType();
+
+/*!
  * \brief tvm intrinsics for TMADescriptor creation for tiled load
  *
  * CuTensorMap* create_tma_descriptor(data_type, rank, global_addr,

--- a/src/cuda/op/builtin.h
+++ b/src/cuda/op/builtin.h
@@ -1,0 +1,815 @@
+/*!
+ * \file tl/cuda/op/builtin.h
+ * \brief CUDA-specific TileLang intrinsic Ops and compiler attributes.
+ */
+
+#ifndef TVM_TL_CUDA_OP_BUILTIN_H_
+#define TVM_TL_CUDA_OP_BUILTIN_H_
+
+#include "op/builtin.h"
+
+namespace tvm {
+namespace tl {
+
+namespace attr {
+
+// Warp-specialization annotations consumed only by CUDA lowering.
+static constexpr const char *kWarpSpecializationScope =
+    "kWarpSpecializationScope";
+static constexpr const char *kCustomWarpSpecialization =
+    "kCustomWarpSpecialization";
+
+// A CUDA TMA descriptor cannot encode a pointer bound inside device code.
+static constexpr const char *kTmaDescriptorBaseIsDeviceBound =
+    "tma_descriptor_base_is_device_bound";
+
+// Minimum CUDA thread blocks per SM for __launch_bounds__ emission.
+static constexpr const char *kMinBlocksPerSM = "tl.min_blocks_per_sm";
+
+} // namespace attr
+
+// PrimFunc attribute set when CUDA TMA operations are generated.
+static constexpr const char *kHasTMA = "tl.has_tma";
+
+// CUDA-specific pass configuration keys. Their string values remain stable
+// because they are part of the Python PassContext interface.
+static constexpr const char *kDisableWarpSpecialized =
+    "tl.disable_warp_specialized";
+static constexpr const char *kDisableTMALower = "tl.disable_tma_lower";
+static constexpr const char *kPtxasRegisterUsageLevel =
+    "tl.ptxas_register_usage_level";
+static constexpr const char *kDisableVectorize256 = "tl.disable_vectorize_256";
+static constexpr const char *kDisableWGMMA = "tl.disable_wgmma";
+static constexpr const char *kDisableShuffleElect = "tl.disable_shuffle_elect";
+static constexpr const char *kEnableLowerLDGSTG = "tl.enable_lower_ldgstg";
+static constexpr const char *kEnableLowerLDGSTGPredicated =
+    "tl.enable_lower_ldgstg_predicated";
+
+// fast math related op
+// __exp(x) - fast exponential
+TVM_DLL const Op &__exp();
+// __exp10(x) - fast base-10 exponential
+TVM_DLL const Op &__exp10();
+// __log(x) - fast natural logarithm
+TVM_DLL const Op &__log();
+// __log2(x) - fast base-2 logarithm
+TVM_DLL const Op &__log2();
+// __log10(x) - fast base-10 logarithm
+TVM_DLL const Op &__log10();
+// __tan(x) - fast tangent
+TVM_DLL const Op &__tan();
+// __cos(x) - fast cosine
+TVM_DLL const Op &__cos();
+// __sin(x) - fast sine
+TVM_DLL const Op &__sin();
+// fast_rcp(x) - approximate reciprocal
+TVM_DLL const Op &fast_rcp();
+// max_nan(x, y) - max with CUDA __hmax_nan semantics for fp16/bf16
+TVM_DLL const Op &max_nan();
+// min_nan(x, y) - min with CUDA __hmin_nan semantics for fp16/bf16
+TVM_DLL const Op &min_nan();
+
+// high precision with IEEE-compliant.
+// ieee_add(x, y, rounding_mode) - IEEE-compliant addition
+TVM_DLL const Op &ieee_add();
+// ieee_sub(x, y, rounding_mode) - IEEE-compliant subtraction
+TVM_DLL const Op &ieee_sub();
+// ieee_mul(x, y, rounding_mode) - IEEE-compliant multiplication
+TVM_DLL const Op &ieee_mul();
+// ieee_fmaf(x, y, z, rounding_mode) - IEEE-compliant fused multiply-add
+TVM_DLL const Op &ieee_fmaf();
+// ieee_frcp(x, rounding_mode) - IEEE-compliant reciprocal
+TVM_DLL const Op &ieee_frcp();
+// ieee_fsqrt(x, rounding_mode) - IEEE-compliant square root
+TVM_DLL const Op &ieee_fsqrt();
+// ieee_frsqrt(x) - IEEE-compliant reciprocal square root (rn only)
+TVM_DLL const Op &ieee_frsqrt();
+// ieee_fdiv(x, y, rounding_mode) - IEEE-compliant division
+TVM_DLL const Op &ieee_fdiv();
+TVM_DLL const Op &max2_nan();
+TVM_DLL const Op &min2_nan();
+
+// random op
+TVM_DLL const Op &rng_init();
+TVM_DLL const Op &rng_rand();
+TVM_DLL const Op &rng_rand_float();
+
+/*!
+ * \brief tvm intrinsics for TMADescriptor creation for tiled load
+ *
+ * CuTensorMap* create_tma_descriptor(data_type, rank, global_addr,
+ * global_shape..., global_stride..., smem_box..., smem_stride..., interleave,
+ * swizzle, l2_promotion, oob_fill)
+ *
+ */
+TVM_DLL const Op &create_tma_descriptor();
+
+/*!
+ * \brief tvm intrinsics for TMADescriptor creation for image to column load
+ *
+ * CuTensorMap* create_tma_im2col_descriptor(data_type, rank, global_addr,
+ * global_shape..., global_stride..., elem_stride..., lower_corner...,
+ * upper_corner..., smme_box_pixel, smem_box_channel, interleave, swizzle,
+ * l2_promotion, oob_fill)
+ *
+ */
+TVM_DLL const Op &create_tma_im2col_descriptor();
+
+/*!
+ * \brief tvm intrinsic for prefetching a TMA descriptor on Hopper.
+ *
+ * prefetch_tma_descriptor(descriptor)
+ *
+ */
+TVM_DLL const Op &prefetch_tma_descriptor();
+
+/*!
+ * \brief tvm intrinsics for loading data from global tensor descriptor to
+ * shared memory
+ *
+ * tma_load(descriptor, mbarrier, smem_data, coord_0, coord_1, ...)
+ *
+ */
+TVM_DLL const Op &tma_load();
+
+/*!
+ * \brief tvm intrinsics for loading image from global tensor to columns in
+ * shared memory
+ *
+ * tma_load(descriptor, mbarrier, smem_data, coord_0, coord_1, ...,
+ * image_offset, ...)
+ *
+ */
+TVM_DLL const Op &tma_load_im2col();
+
+/*!
+ * \brief TMA multicast load from a tensor descriptor to cluster shared memory.
+ *
+ * tma_load_multicast(descriptor, mbarrier, smem_data, multicast_mask,
+ *                    coord_0, coord_1, ..., eviction_policy)
+ */
+TVM_DLL const Op &tma_load_multicast();
+
+/*!
+ * \brief tvm intrinsics for storing data from shared memory to global tensor
+ * descriptor
+ *
+ * tma_store(descriptor, smem_data, coord_0, coord_1, ...)
+ *
+ */
+TVM_DLL const Op &tma_store();
+
+/*!
+ * \brief tvm intrinsics for tile::gather4 TMA load (sm_90+).
+ *
+ * Loads four rows from a 2D global tensor (described by a tiled CUtensorMap)
+ * into a shared memory tile. The four rows can be at arbitrary indices.
+ *
+ *   tma_load_gather4(descriptor, mbarrier, smem_data, col,
+ *                    row0, row1, row2, row3, eviction_policy)
+ *
+ * The descriptor must be encoded with rank=2 and box dim along axis 1 = 1
+ * (the four-row pack is implicit in the gather4 PTX mode).
+ */
+TVM_DLL const Op &tma_load_gather4();
+
+/*!
+ * \brief tvm intrinsics for tile::scatter4 TMA store (sm_90+).
+ *
+ * Stores four shared-memory rows back to four arbitrary rows of a 2D global
+ * tensor (described by a tiled CUtensorMap).
+ *
+ *   tma_store_scatter4(descriptor, smem_data, col,
+ *                      row0, row1, row2, row3, eviction_policy)
+ */
+TVM_DLL const Op &tma_store_scatter4();
+
+/*!
+ * \brief tvm intrinsics for barrier initialization fence
+ *
+ * ptx_fence_barrier_init()
+ *
+ */
+const Op &ptx_fence_barrier_init();
+
+/*
+ * \brief tvm intrinsics for cluster barrier arrive
+ *
+ * ptx_arrive_cluster_barrier(mbarrier, cta_id)
+ *
+ */
+TVM_DLL const Op &ptx_arrive_cluster_barrier();
+
+/*!
+ * \brief tvm intrinsic for ptx tensor core wgmma instructions.
+ *
+ *  void ptx_wgmma_ss(StringImm accum_dtype, StringImm wgmma_prefix, bool
+ * a_is_k_major, bool b_is_k_major, StringImm a_dtype_abbrv, StringImm
+ * b_dtype_abbrv, StringImm accum_dtype_abbrv, Var A_descriptor, PrimExpr
+ * A_offset, Var B_descriptor, Var B_offset, Var C_data, Var C_offset, bool
+ * scale_out, bool scale_in_a, bool scale_in_b);
+ */
+TVM_DLL const Op &ptx_wgmma_ss();
+
+/*!
+ * \brief tvm intrinsics for ptx tensor core wgmma instructions.
+ *
+ *  void ptx_wgmma_rs(StringImm accum_dtype, StringImm wgmma_prefix,
+ * bool b_is_k_major, StringImm a_dtype_abbrv, StringImm b_dtype_abbrv,
+ * StringImm accum_dtype_abbrv, Var A_descriptor, PrimExpr A_offset, Var
+ * B_descriptor, Var B_offset, Var C_data, Var C_offset, bool scale_out,
+ * bool scale_in_a, bool scale_in_b);
+ */
+TVM_DLL const Op &ptx_wgmma_rs();
+
+/*!
+ * \brief tvm intrinsic for sparse ptx wgmma shared-shared instructions.
+ */
+TVM_DLL const Op &ptx_wgmma_sp_ss();
+
+/*!
+ * \brief tvm intrinsic for sparse ptx wgmma register-shared instructions.
+ */
+TVM_DLL const Op &ptx_wgmma_sp_rs();
+
+/*!
+ * \brief tvm intrinsic for ptx tensor core mma with block scaling on SM120a.
+ */
+TVM_DLL const Op &ptx_mma_block_scale();
+
+/*!
+ * \brief tvm intrinsic for tcgen05 mma shared-shared instructions.
+ */
+TVM_DLL const Op &ptx_tcgen05_mma_ss();
+
+/*!
+ * \brief tvm intrinsic for tcgen05 mma tensor-shared instructions.
+ */
+TVM_DLL const Op &ptx_tcgen05_mma_ts();
+
+/*!
+ * \brief tvm intrinsic for tcgen05 block-scaled mma shared-shared instructions.
+ */
+TVM_DLL const Op &ptx_tcgen05_mma_blockscaled_ss();
+
+/*!
+ * \brief tvm intrinsic for tcgen05 copy warpx4 (smem to tmem).
+ */
+TVM_DLL const Op &ptx_tcgen05_cp_warpx4();
+
+/*!
+ * \brief tvm intrinsic for scale factor warp transpose in shared memory.
+ */
+TVM_DLL const Op &ptx_tcgen05_sf_warp_transpose();
+
+/*!
+ * \brief Frontend TMEM deallocation marker.
+ *
+ * deallocate_tmem(tmem_buffer_data)
+ *
+ * This op is produced by the TileLang Python frontend and must be lowered by
+ * LowerSharedTmem into ptx_deallocate_tensor_memory(access_ptr, num_cols).
+ */
+TVM_DLL const Op &deallocate_tmem();
+
+/*!
+ * \brief tvm intrinsics for initializing tensor memory
+ *
+ * ptx_init_tensor_memory(tmem_buffer, num_cols)
+ *
+ */
+TVM_DLL const Op &ptx_init_tensor_memory();
+
+/*!
+ * \brief tvm intrinsics for deallocating tensor memory
+ *
+ * tmem_deallocate(tmem_buffer)
+ *
+ */
+TVM_DLL const Op &ptx_deallocate_tensor_memory();
+
+/*!
+ * \brief tvm intrinsic for ptx tensor core mma instructions on SM70.
+ *
+ *  void ptx_mma_sm70(StringImm shape, StringImm A_layout, StringImm B_layout,
+ *                    StringImm A_dtype, StringImm B_dtype, StringImm C_dtype,
+ *                    Var multiplicand_a, Expr a_index,
+ *                    Var multiplicand_b, Expr b_index,
+ *                    Var accumulator, Expr c_index, bool saturate);
+ */
+TVM_DLL const Op &ptx_mma_sm70();
+
+/*!
+ * \brief tvm intrinsics for ldmatrix
+ *
+ * ptx_ldmatrix(transposed, num, shared_addr, local_addr)
+ *
+ */
+TVM_DLL const Op &ptx_ldmatrix();
+
+/*!
+ * \brief tvm intrinsic for ptx async copy barrier using
+ * cp.async.mbarrier.arrive.noinc
+ *
+ *  This op is used to represent a ptx async copy barrier operation in tilelang.
+ */
+TVM_DLL const Op &ptx_cp_async_barrier_noinc();
+
+/*!
+ * \brief TileLang intrinsic for zeroing shared memory with st.bulk.
+ *
+ * ptx_st_bulk_shared(smem_data, bytes, init_val)
+ *
+ */
+TVM_DLL const Op &ptx_st_bulk_shared();
+
+/*!
+ * \brief Pack four b8 value into a b32 value
+ *
+ * int32 pack_b8x4(b8_value, b8_value, b8_value, b8_value)
+ *
+ */
+TVM_DLL const Op &pack_b8x4();
+
+/*!
+ * \brief Issue a shared memory fence for async operations
+ *
+ * FenceProxyAsync()
+ *
+ */
+TVM_DLL const Op &fence_proxy_async();
+
+/*!
+ * \brief Indicate arrival of warp issuing TMA_STORE
+ *
+ * tma_store_arrive()
+ *
+ */
+TVM_DLL const Op &tma_store_arrive();
+
+/*!
+ * \brief Wait for TMA_STORE to finish
+ *
+ * tma_store_wait()
+ *
+ */
+TVM_DLL const Op &tma_store_wait();
+
+/*!
+ * \brief Set reg hint for warp-specialized branched
+ *
+ * SetMaxNRegInc(num_reg, is_inc)
+ *
+ */
+TVM_DLL const Op &set_max_nreg();
+
+/*!
+ * \brief Arrive at a warpgroup fence for WGMMA sequences
+ *
+ * warpgroup_arrive()
+ *
+ */
+TVM_DLL const Op &warpgroup_arrive();
+
+/*!
+ * \brief Commit the current warpgroup batch for WGMMA sequences
+ *
+ * warpgroup_commit_batch()
+ *
+ */
+TVM_DLL const Op &warpgroup_commit_batch();
+
+/*!
+ * \brief Wait for the warpgroup batch identified by num_mma
+ *
+ * warpgroup_wait(num_mma)
+ *
+ */
+TVM_DLL const Op &warpgroup_wait();
+
+/*!
+ * \brief Fence accumulator operand registers for upcoming WGMMA operations
+ *
+ * warpgroup_fence_operand(dtype, ptr, offset, num_regs)
+ *
+ */
+TVM_DLL const Op &warpgroup_fence_operand();
+
+/*!
+ * \brief Return the canonical lane index for the calling thread.
+ *
+ * get_lane_idx([warp_size])
+ *
+ */
+TVM_DLL const Op &get_lane_idx();
+
+/*!
+ * \brief Return the canonical warp index, assuming converged threads.
+ *
+ * get_warp_idx_sync([warp_size])
+ *
+ */
+TVM_DLL const Op &get_warp_idx_sync();
+
+/*!
+ * \brief Return the canonical warp index without synchronizing the warp.
+ *
+ * get_warp_idx([warp_size])
+ *
+ */
+TVM_DLL const Op &get_warp_idx();
+
+/*!
+ * \brief Return the canonical warp group index for converged threads.
+ *
+ * get_warp_group_idx([warp_size, warps_per_group])
+ *
+ */
+TVM_DLL const Op &get_warp_group_idx();
+
+/*!
+ * \brief Cluster barrier arrive with relaxed ordering
+ *
+ * cluster_arrive_relaxed()
+ *
+ */
+TVM_DLL const Op &cluster_arrive_relaxed();
+
+/*!
+ * \brief Cluster barrier arrive
+ *
+ * cluster_arrive()
+ *
+ */
+TVM_DLL const Op &cluster_arrive();
+
+/*!
+ * \brief Cluster barrier wait
+ *
+ * cluster_wait()
+ *
+ */
+TVM_DLL const Op &cluster_wait();
+
+/*!
+ * \brief Cluster barrier arrive + wait (full sync)
+ *
+ * cluster_sync()
+ *
+ */
+TVM_DLL const Op &cluster_sync();
+
+/*!
+ * \brief Return the 1-D rank of the calling CTA within its cluster
+ *
+ * int block_rank_in_cluster()
+ *
+ */
+TVM_DLL const Op &block_rank_in_cluster();
+
+/*!
+ * \brief Issue a Blackwell cluster launch control query that writes a 16-byte
+ * response into shared memory and signals completion on the given mbarrier.
+ *
+ * clc_try_cancel(result_ptr, mbar_ptr)
+ *
+ */
+TVM_DLL const Op &clc_try_cancel();
+
+/*!
+ * \brief Cluster-wide multicast variant of cluster launch control query.
+ *
+ * clc_try_cancel_multicast(result_ptr, mbar_ptr)
+ *
+ */
+TVM_DLL const Op &clc_try_cancel_multicast();
+
+/*!
+ * \brief Return 1 when a CLC response represents a successful cancellation.
+ *
+ * int32 clc_is_canceled(result_ptr)
+ *
+ */
+TVM_DLL const Op &clc_is_canceled();
+
+/*!
+ * \brief Return the x coordinate of the first CTA in a successful CLC response.
+ *
+ * uint32 clc_get_first_ctaid_x(result_ptr)
+ *
+ */
+TVM_DLL const Op &clc_get_first_ctaid_x();
+
+/*!
+ * \brief Return the y coordinate of the first CTA in a successful CLC response.
+ *
+ * uint32 clc_get_first_ctaid_y(result_ptr)
+ *
+ */
+TVM_DLL const Op &clc_get_first_ctaid_y();
+
+/*!
+ * \brief Return the z coordinate of the first CTA in a successful CLC response.
+ *
+ * uint32 clc_get_first_ctaid_z(result_ptr)
+ *
+ */
+TVM_DLL const Op &clc_get_first_ctaid_z();
+
+/*!
+ * \brief CTA named barrier one-sided arrive (bar.arrive).
+ *
+ * Signals that the calling threads have arrived at the named barrier without
+ * waiting for other participants.  Useful in warp-specialized producer/consumer
+ * pipelines where one side must signal readiness/free-buffer state without
+ * blocking, while the other side waits with bar.sync / T.sync_threads().
+ *
+ * named_barrier_arrive(barrier_id, thread_count)
+ *   barrier_id   - named barrier index (0-15)
+ *   thread_count - total number of participating threads
+ *
+ * Lowers to: asm volatile("bar.arrive %0, %1;" : : "r"(id), "r"(cnt));
+ */
+TVM_DLL const Op &named_barrier_arrive();
+
+/*!
+ * \brief Programmatic dependency trigger.
+ *
+ * pdl_trigger()
+ *
+ */
+TVM_DLL const Op &pdl_trigger();
+
+/*!
+ * \brief Programmatic grid dependency synchronization.
+ *
+ * pdl_sync()
+ *
+ */
+TVM_DLL const Op &pdl_sync();
+
+/*!
+ * \brief tilelang intrinsic for shuffle elect.
+ *
+ *  This op is used to represent a shuffle elect operation in tilelang.
+ */
+TVM_DLL const Op &tl_shuffle_elect();
+
+/*!
+ * \brief tilelang intrinsic for initializing a descriptor buffer for
+ * wgmma/utcmma.
+ *
+ *  This op is used to represent a descriptor initialization operation in
+ * tilelang.
+ */
+TVM_DLL const Op &initialize_wgmma_descriptor();
+
+/*!
+ * \brief tilelang intrinsic for initializing a descriptor buffer for
+ * tcgen05 mma.
+ */
+TVM_DLL const Op &initialize_tcgen05_descriptor();
+
+/*!
+ * \brief tilelang intrinsic for committing UMMA (TCGEN05) barrier arrive.
+ *
+ *  This op wraps the device-side arrive used to signal completion of MMA work
+ *  to a shared-memory mbarrier. It mirrors CUTLASS's umma_arrive.
+ */
+TVM_DLL const Op &tcgen05_mma_arrive();
+
+/*!
+ * \brief tilelang intrinsic for lowered TCGEN05 tensor-memory load.
+ *
+ *  Internal lowering op used by LowerTmemCopy to represent
+ *  `tl::tcgen05_ld_*` calls without routing through `call_extern`.
+ */
+TVM_DLL const Op &tcgen05_ld();
+
+/*!
+ * \brief tilelang intrinsic for lowered TCGEN05 tensor-memory store.
+ *
+ *  Internal lowering op used by LowerTmemCopy to represent
+ *  `tl::tcgen05_st_*` calls without routing through `call_extern`.
+ */
+TVM_DLL const Op &tcgen05_st();
+
+/*!
+ * \brief TCGEN05 fence before a thread-block-wide sync (__syncthreads /
+ * bar.sync). Matches PTX \c tcgen05.fence::before_thread_sync (DeepGEMM /
+ * Blackwell UMMA sequencing).
+ */
+TVM_DLL const Op &tcgen05_before_thread_sync();
+
+/*!
+ * \brief TCGEN05 fence after a thread-block-wide sync. Matches PTX \c
+ * tcgen05.fence::after_thread_sync.
+ */
+TVM_DLL const Op &tcgen05_after_thread_sync();
+
+/*!
+ * \brief tilelang intrinsic for setting the start address of a descriptor
+ * buffer for wgmma/utcmma.
+ *
+ *  This op is used to represent a descriptor start address setting operation in
+ * tilelang.
+ */
+
+TVM_DLL const Op &increase_descriptor_offset();
+
+/*!
+ * \brief tilelang intrinsic for assert on device.
+ *
+ *  This op is used to represent an assert on device
+ */
+TVM_DLL const Op &device_assert();
+
+/*!
+ * \brief tilelang intrinsic for assert on device with additional message.
+ *
+ *  This op is used to represent an assert on device with additional message.
+ */
+TVM_DLL const Op &device_assert_with_msg();
+
+/*!
+ * \brief tilelang intrinsic for CUDA find-first-set bit (__ffs / __ffsll).
+ *
+ *  Returns the one-based position of the least significant set bit, or 0 when
+ *  the input is zero. CUDA codegen emits `__ffs` for 32-bit integer inputs and
+ *  `__ffsll` for 64-bit integer inputs.
+ *
+ *  Usage from TVMScript:
+ *    lane = T.__ffs(mask) - 1
+ */
+TVM_DLL const Op &__ffs();
+
+/*!
+ * \brief tilelang intrinsic for CUDA find-nth-set bit (__fns).
+ *
+ *  Returns the zero-based position of the offset-th set bit in mask starting
+ *  from base, or 0xFFFFFFFF when not found. CUDA codegen emits `__fns`.
+ *
+ *  Usage from TVMScript:
+ *    lane = T.__fns(mask, 0, k + 1)
+ */
+TVM_DLL const Op &__fns();
+
+/*!
+ * \brief tilelang intrinsic for global memory load with 32-bit vector width.
+ *
+ *  This op loads 32 bits (4 bytes) from global memory using explicit
+ *  PTX ld.global instructions for performance-sensitive loads.
+ *
+ *  Usage from TVMScript:
+ *    y[i] = T.ldg32(x, i)
+ */
+TVM_DLL const Op &ldg32();
+
+/*!
+ * \brief tilelang intrinsic for global memory load with 64-bit vector width.
+ *
+ *  This op loads 64 bits (8 bytes) from global memory using explicit
+ *  PTX ld.global.v2 instructions for vectorized loads.
+ *
+ *  Usage from TVMScript:
+ *    y[i] = T.ldg64(x, i)
+ */
+TVM_DLL const Op &ldg64();
+
+/*!
+ * \brief tilelang intrinsic for global memory load with 128-bit vector width.
+ *
+ *  This op loads 128 bits (16 bytes) from global memory using explicit
+ *  PTX ld.global.v4 or ld.global.v2.s64 instructions for wide vectorized loads.
+ *
+ *  Usage from TVMScript:
+ *    y[i] = T.ldg128(x, i)
+ */
+TVM_DLL const Op &ldg128();
+
+/*!
+ * \brief tilelang intrinsic for shared memory load with 32-bit vector width.
+ *
+ * This op loads 32 bits (4 bytes) from shared memory and returns uint32.
+ */
+TVM_DLL const Op &lds32();
+
+/*!
+ * \brief tilelang intrinsic for shared memory load with 64-bit vector width.
+ *
+ * This op loads 64 bits (8 bytes) from shared memory and returns uint32x2.
+ */
+TVM_DLL const Op &lds64();
+
+/*!
+ * \brief tilelang intrinsic for shared memory load with 128-bit vector width.
+ *
+ * This op loads 128 bits (16 bytes) from shared memory and returns uint32x4.
+ */
+TVM_DLL const Op &lds128();
+
+/*!
+ * \brief tilelang intrinsic for global memory load with 256-bit vector width.
+ *
+ *  This op loads 256 bits (32 bytes) from global memory using explicit
+ *  PTX ld.global.v4.s64 instructions for maximum vectorized loads.
+ *  Requires CUDA 12.9+ for native support; older versions use two 128-bit
+ * loads.
+ *
+ *  Usage from TVMScript:
+ *    y[i] = T.ldg256(x, i)
+ */
+TVM_DLL const Op &ldg256();
+
+/*!
+ * \brief tilelang intrinsic for global memory store with 32-bit vector width.
+ *
+ *  This op stores 32 bits (4 bytes) to global memory using explicit
+ *  PTX st.global instructions for performance-sensitive stores.
+ *
+ *  Usage from TVMScript:
+ *    T.stg32(y, i, value)
+ */
+TVM_DLL const Op &stg32();
+
+/*!
+ * \brief tilelang intrinsic for global memory store with 64-bit vector width.
+ *
+ *  This op stores 64 bits (8 bytes) to global memory using explicit
+ *  PTX st.global.v2 instructions for vectorized stores.
+ *
+ *  Usage from TVMScript:
+ *    T.stg64(y, i, value)
+ */
+TVM_DLL const Op &stg64();
+
+/*!
+ * \brief tilelang intrinsic for global memory store with 128-bit vector width.
+ *
+ *  This op stores 128 bits (16 bytes) to global memory using explicit
+ *  PTX st.global.v4 instructions for wide vectorized stores.
+ *
+ *  Usage from TVMScript:
+ *    T.stg128(y, i, value)
+ */
+TVM_DLL const Op &stg128();
+
+/*!
+ * \brief tilelang intrinsic for shared memory store with 32-bit vector width.
+ *
+ * This op stores a uint32 value to shared memory.
+ */
+TVM_DLL const Op &sts32();
+
+/*!
+ * \brief tilelang intrinsic for shared memory store with 64-bit vector width.
+ *
+ * This op stores a uint32x2 value to shared memory.
+ */
+TVM_DLL const Op &sts64();
+
+/*!
+ * \brief tilelang intrinsic for shared memory store with 128-bit vector width.
+ *
+ * This op stores a uint32x4 value to shared memory.
+ */
+TVM_DLL const Op &sts128();
+
+/*!
+ * \brief tilelang intrinsic for global memory store with 256-bit vector width.
+ *
+ *  This op stores 256 bits (32 bytes) to global memory using explicit
+ *  PTX st.global.v4.s64 instructions for maximum vectorized stores.
+ *  Requires CUDA 12.9+ for native support; older versions use two 128-bit
+ * stores.
+ *
+ *  Usage from TVMScript:
+ *    T.stg256(y, i, value)
+ */
+TVM_DLL const Op &stg256();
+
+/*!
+ * \brief Elementwise shared::cluster store via cooperative groups.
+ */
+TVM_DLL const Op &ptx_cluster_store();
+
+/*!
+ * \brief Bulk async shared::cluster store to another CTA.
+ *
+ * tma_store_cluster(dst_ptr, src_ptr, dst_cta, size_bytes, bar_ref)
+ */
+TVM_DLL const Op &tma_store_cluster();
+
+/*!
+ * \brief Mark a buffer version index generated by MultiVersionBufferRewriter.
+ *
+ * This compiler-internal intrinsic preserves the provenance of synthetic
+ * pipeline stage indices until warp specialization assigns branch-local
+ * transaction counters. It must be removed before code generation.
+ */
+TVM_DLL const Op &mvb_stage_index();
+
+} // namespace tl
+} // namespace tvm
+
+#endif // TVM_TL_CUDA_OP_BUILTIN_H_

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -9,13 +9,13 @@
 #include <tvm/ir/cast.h>
 #include <tvm/runtime/logging.h>
 
+#include "cuda/op/builtin.h"
 #include "cuda/op/copy.h"
 #include "cuda/op/tma_layout.h"
 #include "cuda/target_utils.h"
 #include "cuda/transform/ptx_async_copy_injector.h"
 #include "layout/cute_layout.h"
 #include "layout/tcgen05_layout.h"
-#include "op/builtin.h"
 #include "op/utils.h"
 #include "span_utils.h"
 #include "transform/common/loop_fusion_utils.h"

--- a/src/cuda/op/copy_analysis.cc
+++ b/src/cuda/op/copy_analysis.cc
@@ -7,8 +7,8 @@
 #include "support/check.h"
 #include <tvm/runtime/logging.h>
 
+#include "cuda/op/builtin.h"
 #include "cuda/target_utils.h"
-#include "op/builtin.h"
 #include "op/utils.h"
 
 #include <tvm/tirx/transform.h>

--- a/src/cuda/op/fill.cc
+++ b/src/cuda/op/fill.cc
@@ -6,7 +6,7 @@
 #include "backend/common/op/fill.h"
 
 #include "backend/common/target_utils.h"
-#include "op/builtin.h"
+#include "cuda/op/builtin.h"
 #include "op/utils.h"
 #include <tvm/arith/analyzer.h>
 #include <tvm/tirx/op.h>

--- a/src/cuda/op/gemm.cc
+++ b/src/cuda/op/gemm.cc
@@ -7,8 +7,8 @@
 #include "support/check.h"
 #include <tvm/runtime/logging.h>
 
+#include "cuda/op/builtin.h"
 #include "cuda/target_utils.h"
-#include "op/builtin.h"
 #include "op/tcgen5_meta.h"
 #include "op/utils.h"
 #include "span_utils.h"

--- a/src/cuda/op/gemm_sp.cc
+++ b/src/cuda/op/gemm_sp.cc
@@ -6,8 +6,8 @@
 #include "op/gemm.h"
 #include "support/check.h"
 
+#include "cuda/op/builtin.h"
 #include "cuda/target_utils.h"
-#include "op/builtin.h"
 #include "op/tcgen5_meta.h"
 #include "op/utils.h"
 #include "span_utils.h"

--- a/src/cuda/target_utils.cc
+++ b/src/cuda/target_utils.cc
@@ -28,6 +28,8 @@ int GetCudaArchInt(Target target) {
 
 } // namespace
 
+DataType CuTensorMapType() { return DataType::UInt(8, 128); }
+
 bool TargetIsCuda(Target target) {
   return target->GetTargetDeviceType() == kDLCUDA;
 }

--- a/src/cuda/target_utils.cc
+++ b/src/cuda/target_utils.cc
@@ -28,8 +28,6 @@ int GetCudaArchInt(Target target) {
 
 } // namespace
 
-DataType CuTensorMapType() { return DataType::UInt(8, 128); }
-
 bool TargetIsCuda(Target target) {
   return target->GetTargetDeviceType() == kDLCUDA;
 }

--- a/src/cuda/target_utils.h
+++ b/src/cuda/target_utils.h
@@ -12,11 +12,6 @@
 namespace tvm {
 namespace tl {
 
-/*!
- * \brief Return the sentinel dtype used for CUDA tensor-map parameters.
- */
-DataType CuTensorMapType();
-
 bool TargetIsCuda(Target target);
 bool TargetIsCuTeDSL(Target target);
 

--- a/src/cuda/target_utils.h
+++ b/src/cuda/target_utils.h
@@ -12,6 +12,11 @@
 namespace tvm {
 namespace tl {
 
+/*!
+ * \brief Return the sentinel dtype used for CUDA tensor-map parameters.
+ */
+DataType CuTensorMapType();
+
 bool TargetIsCuda(Target target);
 bool TargetIsCuTeDSL(Target target);
 

--- a/src/cuda/transform/annotate_device_bound_tma_copies.cc
+++ b/src/cuda/transform/annotate_device_bound_tma_copies.cc
@@ -10,7 +10,7 @@
 #include <unordered_set>
 #include <utility>
 
-#include "op/builtin.h"
+#include "cuda/op/builtin.h"
 #include "op/copy.h"
 #include "op/operator.h"
 #include "op/utils.h"

--- a/src/cuda/transform/annotate_warp_group_reg_alloc.cc
+++ b/src/cuda/transform/annotate_warp_group_reg_alloc.cc
@@ -11,7 +11,7 @@
 #include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/transform.h>
 
-#include "op/builtin.h"
+#include "cuda/op/builtin.h"
 #include "runtime/thread_storage_scope.h"
 #include "tir/transforms/ir_utils.h"
 #include <functional>

--- a/src/cuda/transform/fuse_mbarrier_arrive_expect_tx.cc
+++ b/src/cuda/transform/fuse_mbarrier_arrive_expect_tx.cc
@@ -11,7 +11,7 @@
 #include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/transform.h>
 
-#include "op/builtin.h"
+#include "cuda/op/builtin.h"
 #include "transform/merge_if_stmt.h"
 
 namespace tvm {

--- a/src/cuda/transform/inject_fence_proxy.cc
+++ b/src/cuda/transform/inject_fence_proxy.cc
@@ -21,7 +21,7 @@
 #include "tir/transforms/ir_utils.h"
 
 #include "backend/common/target_utils.h"
-#include "op/builtin.h"
+#include "cuda/op/builtin.h"
 
 namespace tvm {
 namespace tl {

--- a/src/cuda/transform/inject_tcgen05_fence.cc
+++ b/src/cuda/transform/inject_tcgen05_fence.cc
@@ -39,7 +39,7 @@
 #include <utility>
 
 #include "backend/common/target_utils.h"
-#include "op/builtin.h"
+#include "cuda/op/builtin.h"
 
 namespace tvm {
 namespace tl {

--- a/src/cuda/transform/lower_hopper_intrin.cc
+++ b/src/cuda/transform/lower_hopper_intrin.cc
@@ -18,7 +18,6 @@
 
 #include "cuda/op/builtin.h"
 #include "cuda/runtime.h"
-#include "cuda/target_utils.h"
 
 namespace tvm {
 namespace tl {

--- a/src/cuda/transform/lower_hopper_intrin.cc
+++ b/src/cuda/transform/lower_hopper_intrin.cc
@@ -16,8 +16,9 @@
 #include <unordered_map>
 #include <vector>
 
+#include "cuda/op/builtin.h"
 #include "cuda/runtime.h"
-#include "op/builtin.h"
+#include "cuda/target_utils.h"
 
 namespace tvm {
 namespace tl {

--- a/src/cuda/transform/lower_l2_persistent_annotation.cc
+++ b/src/cuda/transform/lower_l2_persistent_annotation.cc
@@ -11,7 +11,7 @@
 #include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/transform.h>
 
-#include "op/builtin.h"
+#include "cuda/op/builtin.h"
 
 namespace tvm {
 namespace tl {

--- a/src/cuda/transform/lower_ldg_stg.cc
+++ b/src/cuda/transform/lower_ldg_stg.cc
@@ -30,7 +30,7 @@
 #include <tvm/tirx/transform.h>
 
 #include "backend/common/target_utils.h"
-#include "op/builtin.h"
+#include "cuda/op/builtin.h"
 #include "op/utils.h"
 #include "tir/ir/buffer_common.h"
 

--- a/src/cuda/transform/lower_pdl.cc
+++ b/src/cuda/transform/lower_pdl.cc
@@ -4,7 +4,7 @@
  */
 
 #include "backend/common/target_utils.h"
-#include "op/builtin.h"
+#include "cuda/op/builtin.h"
 #include "support/check.h"
 #include "transform/common/attr.h"
 #include "tvm/ir/type.h"

--- a/src/cuda/transform/lower_shared_barrier.cc
+++ b/src/cuda/transform/lower_shared_barrier.cc
@@ -2,7 +2,7 @@
  *  \file lower_shared_barrier.cc
  *  \brief Convert shared.barrier buffers to plain shared + ptx init.
  */
-#include "op/builtin.h"
+#include "cuda/op/builtin.h"
 #include "support/check.h"
 #include "tvm/ir/type.h"
 #include <tvm/arith/analyzer.h>

--- a/src/cuda/transform/lower_shared_tmem.cc
+++ b/src/cuda/transform/lower_shared_tmem.cc
@@ -7,8 +7,8 @@
  *  packs several into one allocation when that saves columns, and shifts every
  *  address a packed buffer forms by where it starts in the allocation.
  */
+#include "cuda/op/builtin.h"
 #include "cuda/target_utils.h"
-#include "op/builtin.h"
 #include "support/check.h"
 #include "tvm/ir/type.h"
 #include <algorithm>

--- a/src/cuda/transform/multi_version_buffer_rewriter.cc
+++ b/src/cuda/transform/multi_version_buffer_rewriter.cc
@@ -18,9 +18,9 @@
 #include <utility>
 #include <vector>
 
+#include "cuda/op/builtin.h"
 #include "layout/layout.h"
 #include "multi_version_buffer_rewriter.h"
-#include "op/builtin.h"
 #include "op/operator.h"
 #include "op/region.h"
 #include "op/utils.h"

--- a/src/cuda/transform/persist_threadblock.cc
+++ b/src/cuda/transform/persist_threadblock.cc
@@ -9,7 +9,7 @@
 #include <tvm/tirx/stmt_functor.h>
 #include <tvm/tirx/transform.h>
 
-#include "op/builtin.h"
+#include "cuda/op/builtin.h"
 
 namespace tvm {
 namespace tl {

--- a/src/cuda/transform/producer_consumer_ws.cc
+++ b/src/cuda/transform/producer_consumer_ws.cc
@@ -35,10 +35,10 @@
 #include <utility>
 
 #include "backend/common/target_utils.h"
+#include "cuda/op/builtin.h"
 #include "cuda/op/copy.h"
 #include "layout/cute_layout.h"
 #include "multi_version_buffer_rewriter.h"
-#include "op/builtin.h"
 #include "op/copy.h"
 #include "op/fill.h"
 #include "op/gemm.h"

--- a/src/cuda/transform/ptx_async_copy_injector.cc
+++ b/src/cuda/transform/ptx_async_copy_injector.cc
@@ -17,8 +17,8 @@
 #include <optional>
 #include <vector>
 
+#include "cuda/op/builtin.h"
 #include "cuda/transform/ptx_async_copy_injector.h"
-#include "op/builtin.h"
 #include "op/utils.h"
 #include "tir/ir/buffer_common.h"
 

--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -37,7 +37,7 @@
 #include <utility>
 #include <vector>
 
-#include "op/builtin.h"
+#include "metal/op/builtin.h"
 #include "runtime/thread_storage_scope.h"
 #include "target/build_common.h"
 #include "target/metal/metal_fallback_module.h"

--- a/src/metal/op/builtin.cc
+++ b/src/metal/op/builtin.cc
@@ -1,0 +1,38 @@
+/*!
+ * \file tl/metal/op/builtin.cc
+ * \brief Registration of Metal-specific TileLang intrinsic Ops.
+ */
+
+#include "builtin.h"
+
+#include "op/builtin_registry.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+
+TIR_DEFINE_TL_BUILTIN(cooperative_tensor_fill)
+    .set_num_inputs(5)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(cooperative_tensor_load)
+    .set_num_inputs(11)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(cooperative_tensor_store)
+    .set_num_inputs(11)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(cooperative_tensor_multiply_accumulate)
+    .set_num_inputs(13)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+} // namespace tl
+} // namespace tvm
+
+#undef TIR_DEFINE_TL_BUILTIN

--- a/src/metal/op/builtin.h
+++ b/src/metal/op/builtin.h
@@ -1,0 +1,24 @@
+/*!
+ * \file tl/metal/op/builtin.h
+ * \brief Metal-specific TileLang intrinsic Ops.
+ */
+
+#ifndef TVM_TL_METAL_OP_BUILTIN_H_
+#define TVM_TL_METAL_OP_BUILTIN_H_
+
+#include "op/builtin.h"
+
+namespace tvm {
+namespace tl {
+
+// Metal cooperative tensor operations.
+
+TVM_DLL const Op &cooperative_tensor_fill();
+TVM_DLL const Op &cooperative_tensor_load();
+TVM_DLL const Op &cooperative_tensor_store();
+TVM_DLL const Op &cooperative_tensor_multiply_accumulate();
+
+} // namespace tl
+} // namespace tvm
+
+#endif // TVM_TL_METAL_OP_BUILTIN_H_

--- a/src/metal/op/copy.cc
+++ b/src/metal/op/copy.cc
@@ -5,9 +5,9 @@
 
 #include "op/copy.h"
 
+#include "metal/op/builtin.h"
 #include "metal/op/utils.h"
 #include "metal/target_utils.h"
-#include "op/builtin.h"
 #include "op/utils.h"
 
 #include <tvm/tirx/builtin.h>

--- a/src/metal/op/fill.cc
+++ b/src/metal/op/fill.cc
@@ -7,8 +7,8 @@
 #include <tvm/runtime/logging.h>
 
 #include "backend/common/target_utils.h"
+#include "metal/op/builtin.h"
 #include "metal/op/utils.h"
-#include "op/builtin.h"
 #include "op/utils.h"
 #include "transform/loop_partition.h"
 #include "transform/loop_vectorize.h"

--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -1,18 +1,13 @@
 /*!
  * \file tl/op/builtin.cc
- * \brief Builtin intrinsics.
- *
+ * \brief Registration of backend-neutral TileLang intrinsic Ops.
  */
 
 #include "builtin.h"
-#include "support/check.h"
 
-#include <tvm/tirx/builtin.h>
-#include <tvm/tirx/op.h>
-#include <tvm/tirx/op_attr_types.h>
+#include <tvm/ir/transform.h>
 
-#include "backend/common/target_utils.h"
-#include "cuda/stubs/cuda.h"
+#include "builtin_registry.h"
 
 namespace tvm {
 namespace tl {
@@ -21,29 +16,21 @@ using namespace tirx;
 
 TVM_REGISTER_PASS_CONFIG_OPTION(kDebugMergeSharedMemoryAllocations, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableSafeMemoryLegalize, Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION(kDisableWarpSpecialized, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableThreadStorageSync, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kConfigIndexBitwidth, Integer);
-TVM_REGISTER_PASS_CONFIG_OPTION(kDisableTMALower, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kEnableAggressiveSharedMemoryMerge, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableSharedMemoryReuse, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kForceLetInline, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableFastMath, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kEnableFastMath, Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION(kPtxasRegisterUsageLevel, Integer);
-TVM_REGISTER_PASS_CONFIG_OPTION(kDisableVectorize256, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kEnableAsyncCopy, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kEnableVectorizePlannerVerbose, Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION(kDisableWGMMA, Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION(kDisableShuffleElect, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kStorageRewriteDetectInplace, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kASTPrintEnable, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kLayoutVisualizationEnable, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kLayoutVisualizationFormats, ffi::String);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDeviceCompileFlags, ffi::Array<ffi::String>);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableDataRaceCheck, Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION(kEnableLowerLDGSTG, Bool);
-TVM_REGISTER_PASS_CONFIG_OPTION(kEnableLowerLDGSTGPredicated, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableLoopUnswitching, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kLoopUnswitchingAllowNonTrivialElse, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kIfStmtBindingInlineReplayableBinds, Bool);
@@ -53,86 +40,11 @@ TVM_REGISTER_PASS_CONFIG_OPTION(kDumpIRDir, ffi::String);
 TVM_REGISTER_PASS_CONFIG_OPTION(kPassProfile, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kPassProfileThresholdMs, FloatImm);
 
-DataType CuTensorMapType() { return DataType::UInt(8, 128); }
-
-#define TIR_DEFINE_TL_BUILTIN(OpName)                                          \
-  const Op &OpName() {                                                         \
-    static const Op &op = Op::Get("tl." #OpName);                              \
-    return op;                                                                 \
-  }                                                                            \
-  TVM_REGISTER_OP("tl." #OpName)                                               \
-      .set_attr<TScriptPrinterName>("TScriptPrinterName", #OpName)
-
-// Pointer access metadata op (frontend-only, lowered later).
 TIR_DEFINE_TL_BUILTIN(access_ptr)
     .set_num_inputs(3)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kPure));
 
-// fast math related op
-TIR_DEFINE_TL_BUILTIN(__exp).set_num_inputs(1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(__exp10).set_num_inputs(1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(__log).set_num_inputs(1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(__log2).set_num_inputs(1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(__log10).set_num_inputs(1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(__tan).set_num_inputs(1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(__cos).set_num_inputs(1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(__sin).set_num_inputs(1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(fast_rcp).set_num_inputs(1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(max_nan).set_num_inputs(2).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(min_nan).set_num_inputs(2).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-// high precision with IEEE-compliant
-TIR_DEFINE_TL_BUILTIN(ieee_add).set_num_inputs(3).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(ieee_sub).set_num_inputs(3).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(ieee_mul).set_num_inputs(3).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(ieee_fmaf).set_num_inputs(4).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(ieee_frcp).set_num_inputs(2).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(ieee_fsqrt)
-    .set_num_inputs(2)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(ieee_frsqrt)
-    .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(ieee_fdiv).set_num_inputs(3).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-// Packed x2 element-wise math intrinsics (float32x2, bfloat16x2, float16x2)
 TIR_DEFINE_TL_BUILTIN(add2).set_num_inputs(2).set_attr<TCallEffectKind>(
     "TCallEffectKind", Integer(CallEffectKind::kPure));
 
@@ -154,94 +66,6 @@ TIR_DEFINE_TL_BUILTIN(min2).set_num_inputs(2).set_attr<TCallEffectKind>(
 TIR_DEFINE_TL_BUILTIN(abs2).set_num_inputs(1).set_attr<TCallEffectKind>(
     "TCallEffectKind", Integer(CallEffectKind::kPure));
 
-TIR_DEFINE_TL_BUILTIN(max2_nan).set_num_inputs(2).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(min2_nan).set_num_inputs(2).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(rng_init).set_num_inputs(4).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(rng_rand).set_num_inputs(0).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(rng_rand_float)
-    .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(create_tma_descriptor)
-    .set_num_inputs(-1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(create_tma_im2col_descriptor)
-    .set_num_inputs(-1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(prefetch_tma_descriptor)
-    .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(tma_load).set_num_inputs(-1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(tma_load_im2col)
-    .set_num_inputs(-1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(tma_load_multicast)
-    .set_num_inputs(-1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(tma_store).set_num_inputs(-1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(tma_load_gather4)
-    .set_num_inputs(-1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(tma_store_scatter4)
-    .set_num_inputs(-1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(cooperative_tensor_fill)
-    .set_num_inputs(5)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(cooperative_tensor_load)
-    .set_num_inputs(11)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(cooperative_tensor_store)
-    .set_num_inputs(11)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(cooperative_tensor_multiply_accumulate)
-    .set_num_inputs(13)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ptx_fence_barrier_init)
-    .set_num_inputs(-1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ptx_arrive_cluster_barrier)
-    .set_num_inputs(2)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
 TIR_DEFINE_TL_BUILTIN(mbarrier_wait_parity)
     .set_num_inputs(2)
     .set_attr<TCallEffectKind>("TCallEffectKind",
@@ -252,127 +76,13 @@ TIR_DEFINE_TL_BUILTIN(mbarrier_expect_tx)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(ptx_wgmma_ss)
-    .set_num_inputs(15)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ptx_wgmma_rs)
-    .set_num_inputs(15)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ptx_wgmma_sp_ss)
-    .set_num_inputs(18)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ptx_wgmma_sp_rs)
-    .set_num_inputs(17)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ptx_mma_block_scale)
-    .set_num_inputs(21)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ptx_tcgen05_mma_ss)
-    .set_num_inputs(14)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ptx_tcgen05_mma_ts)
-    .set_num_inputs(13)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ptx_tcgen05_mma_blockscaled_ss)
-    .set_num_inputs(16)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ptx_tcgen05_cp_warpx4)
-    .set_num_inputs(3)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ptx_tcgen05_sf_warp_transpose)
-    .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(deallocate_tmem)
-    .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ptx_init_tensor_memory)
-    .set_num_inputs(2)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ptx_deallocate_tensor_memory)
-    .set_num_inputs(2)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ptx_mma_sm70)
-    .set_num_inputs(13)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ptx_ldmatrix)
-    .set_num_inputs(4)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
 TIR_DEFINE_TL_BUILTIN(ptx_stmatrix)
     .set_num_inputs(-1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(ptx_cp_async_barrier_noinc)
-    .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
 TIR_DEFINE_TL_BUILTIN(ptx_cp_async)
     .set_num_inputs(-1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ptx_st_bulk_shared)
-    .set_num_inputs(3)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(fence_proxy_async)
-    .set_num_inputs(0)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(tcgen05_before_thread_sync)
-    .set_num_inputs(0)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(tcgen05_after_thread_sync)
-    .set_num_inputs(0)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(tma_store_arrive)
-    .set_num_inputs(0)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(tma_store_wait)
-    .set_num_inputs(2)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-TIR_DEFINE_TL_BUILTIN(set_max_nreg)
-    .set_num_inputs(2)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
@@ -391,46 +101,6 @@ TIR_DEFINE_TL_BUILTIN(no_set_max_nreg)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(warpgroup_arrive)
-    .set_num_inputs(0)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(warpgroup_commit_batch)
-    .set_num_inputs(0)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(warpgroup_wait)
-    .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(warpgroup_fence_operand)
-    .set_num_inputs(4)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(get_lane_idx)
-    .set_num_inputs(-1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(get_warp_idx_sync)
-    .set_num_inputs(-1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(get_warp_idx)
-    .set_num_inputs(-1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(get_warp_group_idx)
-    .set_num_inputs(-1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kPure));
-
 TIR_DEFINE_TL_BUILTIN(wait_wgmma)
     .set_num_inputs(1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
@@ -439,85 +109,12 @@ TIR_DEFINE_TL_BUILTIN(wait_wgmma)
 TIR_DEFINE_TL_BUILTIN(pack_b16).set_num_inputs(2).set_attr<TCallEffectKind>(
     "TCallEffectKind", Integer(CallEffectKind::kPure));
 
-TIR_DEFINE_TL_BUILTIN(pack_b8x4).set_num_inputs(4).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(cluster_arrive_relaxed)
-    .set_num_inputs(0)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(cluster_arrive)
-    .set_num_inputs(0)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(cluster_wait)
-    .set_num_inputs(0)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(cluster_sync)
-    .set_num_inputs(0)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(block_rank_in_cluster)
-    .set_num_inputs(0)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(clc_try_cancel)
-    .set_num_inputs(2)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(clc_try_cancel_multicast)
-    .set_num_inputs(2)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(clc_is_canceled)
-    .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(clc_get_first_ctaid_x)
-    .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(clc_get_first_ctaid_y)
-    .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(clc_get_first_ctaid_z)
-    .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kPure));
-
 TIR_DEFINE_TL_BUILTIN(sync_grid).set_num_inputs(0).set_attr<TCallEffectKind>(
     "TCallEffectKind", Integer(CallEffectKind::kOpaque));
 
 TIR_DEFINE_TL_BUILTIN(sync_warp).set_num_inputs(-1).set_attr<TCallEffectKind>(
     "TCallEffectKind", Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(named_barrier_arrive)
-    .set_num_inputs(2)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(pdl_trigger)
-    .set_num_inputs(0)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(pdl_sync).set_num_inputs(0).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-// Warp-vote / warp-ballot intrinsics. These synchronize the warp, so they are
-// marked opaque to prevent reordering across divergent control flow.
 TIR_DEFINE_TL_BUILTIN(any_sync).set_num_inputs(2).set_attr<TCallEffectKind>(
     "TCallEffectKind", Integer(CallEffectKind::kOpaque));
 
@@ -537,7 +134,6 @@ TIR_DEFINE_TL_BUILTIN(activemask)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-// Block-wide predicated barriers.
 TIR_DEFINE_TL_BUILTIN(syncthreads_count)
     .set_num_inputs(1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
@@ -553,8 +149,6 @@ TIR_DEFINE_TL_BUILTIN(syncthreads_or)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-// Warp-shuffle intrinsics. All four accept (mask, value, lane_or_offset,
-// width) and are opaque because they involve inter-lane communication.
 TIR_DEFINE_TL_BUILTIN(shfl_sync).set_num_inputs(4).set_attr<TCallEffectKind>(
     "TCallEffectKind", Integer(CallEffectKind::kOpaque));
 
@@ -573,7 +167,6 @@ TIR_DEFINE_TL_BUILTIN(shfl_up_sync)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-// Warp match-any/match-all intrinsics (CUDA sm_70+). HIP lowering errors.
 TIR_DEFINE_TL_BUILTIN(match_any_sync)
     .set_num_inputs(2)
     .set_attr<TCallEffectKind>("TCallEffectKind",
@@ -586,44 +179,6 @@ TIR_DEFINE_TL_BUILTIN(match_all_sync)
 
 TIR_DEFINE_TL_BUILTIN(loop_break)
     .set_num_inputs(0)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(tvm_mfma).set_num_inputs(12).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(tvm_mfma_store)
-    .set_num_inputs(6)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(tvm_rdna_wmma)
-    .set_num_inputs(12)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(tvm_rdna_wmma_store)
-    .set_num_inputs(6)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(tl_shuffle_elect)
-    .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kPure));
-
-TIR_DEFINE_TL_BUILTIN(initialize_wgmma_descriptor)
-    .set_num_inputs(5)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(initialize_tcgen05_descriptor)
-    .set_num_inputs(7)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(increase_descriptor_offset)
-    .set_num_inputs(2)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
@@ -692,31 +247,6 @@ TIR_DEFINE_TL_BUILTIN(atomic_min_ret_elem_op)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-TIR_DEFINE_TL_BUILTIN(device_assert)
-    .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(device_assert_with_msg)
-    .set_num_inputs(2)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(tcgen05_mma_arrive)
-    .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(tcgen05_ld)
-    .set_num_inputs(6)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(tcgen05_st)
-    .set_num_inputs(6)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
 TIR_DEFINE_TL_BUILTIN(warp_reduce_sum)
     .set_num_inputs(1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
@@ -742,118 +272,10 @@ TIR_DEFINE_TL_BUILTIN(warp_reduce_bitor)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
-// ds_read_tr16_b64(smem_ptr) -> uint32x2
-// gfx950 LDS transpose read: 64-bit, 16-element transpose (FP16/BF16 MFMA)
-TIR_DEFINE_TL_BUILTIN(ds_read_tr16_b64)
-    .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kPure));
-
-// ds_read_tr8_b64(smem_ptr) -> uint32x2
-// gfx950 LDS transpose read: 64-bit, 8-element transpose (FP32 MFMA)
-TIR_DEFINE_TL_BUILTIN(ds_read_tr8_b64)
-    .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kPure));
-
-// __ldg(BufferLoad | Buffer, idx?) -> value
-// Treat as a pure call that returns the loaded value.
 TIR_DEFINE_TL_BUILTIN(__ldg).set_num_inputs(-1).set_attr<TCallEffectKind>(
     "TCallEffectKind", Integer(CallEffectKind::kPure));
 
-// __ffs(value) -> one-based least-significant set-bit position, or 0.
-TIR_DEFINE_TL_BUILTIN(__ffs).set_num_inputs(1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-// __fns(mask, base, offset) -> zero-based nth set-bit position, or 0xFFFFFFFF.
-TIR_DEFINE_TL_BUILTIN(__fns).set_num_inputs(3).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-// ldg32(address, predicate(optional)) -> 32-bit value
-// Global memory load with 32-bit vector width
-TIR_DEFINE_TL_BUILTIN(ldg32).set_num_inputs(-1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-// ldg64(address, predicate(optional)) -> 64-bit value
-// Global memory load with 64-bit vector width
-TIR_DEFINE_TL_BUILTIN(ldg64).set_num_inputs(-1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-// ldg128(address, predicate(optional)) -> 128-bit value
-// Global memory load with 128-bit vector width
-TIR_DEFINE_TL_BUILTIN(ldg128).set_num_inputs(-1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-// lds32(address) -> 32-bit value
-// Shared memory load with 32-bit vector width
-TIR_DEFINE_TL_BUILTIN(lds32).set_num_inputs(1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-// lds64(address) -> 64-bit value
-// Shared memory load with 64-bit vector width
-TIR_DEFINE_TL_BUILTIN(lds64).set_num_inputs(1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-// lds128(address) -> 128-bit value
-// Shared memory load with 128-bit vector width
-TIR_DEFINE_TL_BUILTIN(lds128).set_num_inputs(1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-// ldg256(address, predicate(optional)) -> 256-bit value
-// Global memory load with 256-bit vector width
-TIR_DEFINE_TL_BUILTIN(ldg256).set_num_inputs(-1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kPure));
-
-// stg32(Buffer, idx, value) -> void
-// Global memory store with 32-bit vector width
-TIR_DEFINE_TL_BUILTIN(stg32).set_num_inputs(-1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-// stg64(Buffer, idx, value) -> void
-// Global memory store with 64-bit vector width
-TIR_DEFINE_TL_BUILTIN(stg64).set_num_inputs(-1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-// stg128(Buffer, idx, value) -> void
-// Global memory store with 128-bit vector width
-TIR_DEFINE_TL_BUILTIN(stg128).set_num_inputs(-1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-// sts32(Buffer, idx, value) -> void
-// Shared memory store with 32-bit vector width
-TIR_DEFINE_TL_BUILTIN(sts32).set_num_inputs(2).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-// sts64(Buffer, idx, value) -> void
-// Shared memory store with 64-bit vector width
-TIR_DEFINE_TL_BUILTIN(sts64).set_num_inputs(2).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-// sts128(Buffer, idx, value) -> void
-// Shared memory store with 128-bit vector width
-TIR_DEFINE_TL_BUILTIN(sts128).set_num_inputs(2).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-// stg256(Buffer, idx, value) -> void
-// Global memory store with 256-bit vector width
-TIR_DEFINE_TL_BUILTIN(stg256).set_num_inputs(-1).set_attr<TCallEffectKind>(
-    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(ptx_cluster_store)
-    .set_num_inputs(4)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-TIR_DEFINE_TL_BUILTIN(tma_store_cluster)
-    .set_num_inputs(5)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kOpaque));
-
-// Compiler-internal marker for MVB-generated pipeline stage indices.
-TIR_DEFINE_TL_BUILTIN(mvb_stage_index)
-    .set_num_inputs(1)
-    .set_attr<TCallEffectKind>("TCallEffectKind",
-                               Integer(CallEffectKind::kPure));
-
 } // namespace tl
 } // namespace tvm
+
+#undef TIR_DEFINE_TL_BUILTIN

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -1,76 +1,38 @@
 /*!
  * \file tl/op/builtin.h
- * \brief Builtin intrinsics.
- *
+ * \brief Backend-neutral and cross-backend TileLang intrinsic Ops.
  */
 
 #ifndef TVM_TL_OP_BUILTIN_H_
 #define TVM_TL_OP_BUILTIN_H_
 
 #include "operator.h"
-#include "support/check.h"
+
 #include <tvm/ir/cast.h>
-#include <tvm/ir/transform.h>
 #include <tvm/runtime/logging.h>
 
 namespace tvm {
-/*!
- * \brief Create the TVM intrinsic that initializes a PTX fence barrier.
- *
- * Initializes a PTX fence-style barrier used to coordinate asynchronous memory
- * operations (for example, TMA/TMA_STORE). Returns the Op representing this
- * intrinsic for use in TIR lowering and code generation.
- *
- */
 namespace tl {
 
 namespace attr {
+
 static constexpr const char *kSafeValueMap = "safe_value_map";
-static constexpr const char *kWarpSpecializationScope =
-    "kWarpSpecializationScope";
-static constexpr const char *kCustomWarpSpecialization =
-    "kCustomWarpSpecialization";
-// Loop annotation key controlling whether PTX async-copy rewriting is enabled
-// in the annotated loop subtree. Value should be Bool (False/True).
+
+// Async-copy annotations shared by CUDA and ROCm lowering.
 static constexpr const char *kLoopPreferAsync = "parallel_prefer_async";
-// Loop annotation key controlling whether async commit/wait should be omitted
-// for injected cp.async in this parallel loop subtree. Value should be Bool.
 static constexpr const char *kParallelAsyncWithoutAsyncCommitWait =
     "parallel_async_without_async_commit_wait";
-// Copy-op annotation key controlling whether cp.async commit/wait are managed
-// by an enclosing transform (e.g. software pipeline / warp specialization).
-// Value should be IntImm/Bool-like truthy scalar.
 static constexpr const char *kAsyncCopyNoImplicitCommitWait =
     "no_implicit_async_commit_wait";
-// Copy-op annotation marking that a global endpoint's base pointer is a
-// handle Var defined by Bind inside the function body. Descriptor-based TMA
-// cannot encode such a pointer on the host, while descriptorless Bulk1D
-// remains valid. Value should be IntImm/Bool-like truthy scalar.
-static constexpr const char *kTmaDescriptorBaseIsDeviceBound =
-    "tma_descriptor_base_is_device_bound";
-// Tile-op annotation key carrying an explicit mbarrier parity expression.
-// Pipeline transforms set this on ops whose lowering would otherwise infer
-// parity from surrounding loop context.
+
+// Pipeline annotation carrying an explicit mbarrier parity expression.
 static constexpr const char *kPipelineMbarPhaseExpr =
     "tl.pipeline_mbar_phase_expr";
+
 static constexpr const char *kLocalVarInit = "tl.local_var_init";
-// A PrimFunc-level attribute carrying a list of handle Vars
-// that must NOT be marked with the restrict qualifier in codegen.
-// Type: ffi::Array<tirx::Var>
 static constexpr const char *kNonRestrictParams = "tl.non_restrict_params";
-// A PrimFunc-level attribute carrying the minimum number of thread blocks
-// per SM (multiprocessor).  When present it is emitted as the second
-// argument of __launch_bounds__(maxThreads, minBlocksPerMultiprocessor).
-// Type: Integer
-static constexpr const char *kMinBlocksPerSM = "tl.min_blocks_per_sm";
-// lexical_alloc_scope may first appear as a Block annotation, requesting that
-// LowerOpaqueBlock materialize a lexical scope boundary for that block subtree.
-// After LowerOpaqueBlock, the same key appears as an AttrStmt marker that
-// generates a C/CUDA lexical scope `{ ... }` in codegen. Allocations nested
-// inside this scope cannot be hoisted past the boundary by StorageRewrite,
-// giving the underlying compiler accurate variable lifetime information for
-// register allocation.
 static constexpr const char *kLexicalAllocScope = "lexical_alloc_scope";
+
 } // namespace attr
 
 inline ffi::Optional<PrimExpr> GetAnnotatedMbarPhaseExpr(
@@ -86,73 +48,28 @@ inline ffi::Optional<PrimExpr> GetAnnotatedMbarPhaseExpr(
   return ffi::Optional<PrimExpr>();
 }
 
+// Backend-neutral pass configuration and PrimFunc attribute keys.
 static constexpr const char *kDebugMergeSharedMemoryAllocations =
     "tl.debug_merge_shared_memory_allocations";
-// PrimFunc attribute: set by LowerTileOp to indicate TMA operations were
-// actually generated.  Read by OptimizeForTarget to pick the right pipeline.
-static constexpr const char *kHasTMA = "tl.has_tma";
-// PrimFunc attribute: Map<String, IntImm> from a shared buffer's data Var
-// name to the minimum base alignment (bytes) required by swizzle-sensitive
-// instructions that consume it (TMA bulk copy, wgmma/tcgen05 descriptors).
-// Keyed by name rather than Var so the attribute does not hold references
-// into the function body (which would perturb printing and SSA passes); a
-// name collision can only over-align, never under-align. Written by
-// LowerTileOp, consumed by MergeSharedMemoryAllocations.
 static constexpr const char *kSmemAlignmentMap = "tl.smem_alignment_map";
 static constexpr const char *kDisableSafeMemoryLegalize =
     "tl.disable_safe_memory_legalize";
-static constexpr const char *kDisableWarpSpecialized =
-    "tl.disable_warp_specialized";
 static constexpr const char *kConfigIndexBitwidth = "tl.config_index_bitwidth";
-// Deprecated pass config, temporarily re-enabled. Prevents plain T.copy()
-// from auto-lowering to TMA store. Will be removed in v0.1.10.
-static constexpr const char *kDisableTMALower = "tl.disable_tma_lower";
 static constexpr const char *kEnableAggressiveSharedMemoryMerge =
     "tl.enable_aggressive_shared_memory_merge";
 static constexpr const char *kDisableSharedMemoryReuse =
     "tl.disable_shared_memory_reuse";
 static constexpr const char *kDisableFastMath = "tl.disable_fast_math";
 static constexpr const char *kEnableFastMath = "tl.enable_fast_math";
-static constexpr const char *kPtxasRegisterUsageLevel =
-    "tl.ptxas_register_usage_level";
-static constexpr const char *kDisableVectorize256 = "tl.disable_vectorize_256";
 static constexpr const char *kEnableAsyncCopy = "tl.enable_async_copy";
 static constexpr const char *kEnableVectorizePlannerVerbose =
     "tl.enable_vectorize_planner_verbose";
-static constexpr const char *kDisableWGMMA = "tl.disable_wgmma";
-static constexpr const char *kDisableShuffleElect = "tl.disable_shuffle_elect";
 static constexpr const char *kDisableLoopUnswitching =
     "tl.disable_loop_unswitching";
-// Allow loop unswitching even when the else-version of the loop body is
-// non-trivial (has side effects). Default: false (conservative).
 static constexpr const char *kLoopUnswitchingAllowNonTrivialElse =
     "tl.loop_unswitching_allow_non_trivial_else";
 static constexpr const char *kIfStmtBindingInlineReplayableBinds =
     "tl.if_stmt_binding_inline_replayable_binds";
-
-/*!
- * \brief Enable lowering non-predicated global load/store to ldg/stg intrinsics
- *
- * When enabled, transforms regular (non-predicated) global memory loads and
- * stores to explicit ldg/stg intrinsics for potentially better performance.
- * Default: OFF (disabled)
- *
- * kEnableLowerLDGSTG = "tl.enable_lower_ldgstg"
- */
-static constexpr const char *kEnableLowerLDGSTG = "tl.enable_lower_ldgstg";
-
-/*!
- * \brief Enable lowering predicated global load/store to ldg/stg intrinsics
- *
- * When enabled (set to true), predicated loads (if_then_else with else=0) and
- * predicated stores (IfThenElse with store in then case) will be lowered
- * to predicated ldg/stg intrinsics.
- * Default: OFF (predicated lowering is disabled by default)
- *
- * kEnableLowerLDGSTGPredicated = "tl.enable_lower_ldgstg_predicated"
- */
-static constexpr const char *kEnableLowerLDGSTGPredicated =
-    "tl.enable_lower_ldgstg_predicated";
 static constexpr const char *kStorageRewriteDetectInplace =
     "tl.storage_rewrite_detect_inplace";
 static constexpr const char *kASTPrintEnable = "tl.ast_print_enable";
@@ -163,58 +80,16 @@ static constexpr const char *kLayoutVisualizationFormats =
 static constexpr const char *kDeviceCompileFlags = "tl.device_compile_flags";
 static constexpr const char *kDisableDataRaceCheck =
     "tl.disable_data_race_check";
-
-/*!
- * \brief Whether to disable thread storage synchronization
- *
- * When enabled, disables the automatic insertion of thread synchronization
- * barriers (e.g., __syncthreads()) for shared memory access coordination.
- * This can be useful for performance optimization in cases where manual
- * synchronization is preferred or when synchronization is not needed.
- *
- * kDisableThreadStorageSync = "tl.disable_thread_storage_sync"
- *
- */
 static constexpr const char *kDisableThreadStorageSync =
     "tl.disable_thread_storage_sync";
-
-/*!
- * \brief Force inline Let bindings during simplification.
- *
- * kForceLetInline = "tl.force_let_inline"
- *
- */
 static constexpr const char *kForceLetInline = "tl.force_let_inline";
-
-/*!
- * \brief Disable out of bound warning in LegalizeSafeMemoryAccess pass.
- *
- * kDisableOutOfBoundWarning = "tl.disable_out_of_bound_warning"
- *
- */
 static constexpr const char *kDisableOutOfBoundWarning =
     "tl.disable_out_of_bound_warning";
-
-/*!
- * \brief Enable dumping IR during lowering between passes.
- *
- * kEnableDumpIR = "tl.enable_dump_ir"
- *
- */
 static constexpr const char *kEnableDumpIR = "tl.enable_dump_ir";
 static constexpr const char *kDumpIRDir = "tl.dump_ir_path";
-
 static constexpr const char *kPassProfile = "tl.pass_profile";
 static constexpr const char *kPassProfileThresholdMs =
     "tl.pass_profile_threshold_ms";
-
-/*!
- * \brief Get the type of the CUDA tensor map
- *
- * DataType CuTensorMapType()
- *
- */
-DataType CuTensorMapType();
 
 /*!
  * \brief TileLang intrinsic for carrying pointer access metadata in frontend.
@@ -235,48 +110,6 @@ DataType CuTensorMapType();
  */
 TVM_DLL const Op &access_ptr();
 
-// fast math related op
-// __exp(x) - fast exponential
-TVM_DLL const Op &__exp();
-// __exp10(x) - fast base-10 exponential
-TVM_DLL const Op &__exp10();
-// __log(x) - fast natural logarithm
-TVM_DLL const Op &__log();
-// __log2(x) - fast base-2 logarithm
-TVM_DLL const Op &__log2();
-// __log10(x) - fast base-10 logarithm
-TVM_DLL const Op &__log10();
-// __tan(x) - fast tangent
-TVM_DLL const Op &__tan();
-// __cos(x) - fast cosine
-TVM_DLL const Op &__cos();
-// __sin(x) - fast sine
-TVM_DLL const Op &__sin();
-// fast_rcp(x) - approximate reciprocal
-TVM_DLL const Op &fast_rcp();
-// max_nan(x, y) - max with CUDA __hmax_nan semantics for fp16/bf16
-TVM_DLL const Op &max_nan();
-// min_nan(x, y) - min with CUDA __hmin_nan semantics for fp16/bf16
-TVM_DLL const Op &min_nan();
-
-// high precision with IEEE-compliant.
-// ieee_add(x, y, rounding_mode) - IEEE-compliant addition
-TVM_DLL const Op &ieee_add();
-// ieee_sub(x, y, rounding_mode) - IEEE-compliant subtraction
-TVM_DLL const Op &ieee_sub();
-// ieee_mul(x, y, rounding_mode) - IEEE-compliant multiplication
-TVM_DLL const Op &ieee_mul();
-// ieee_fmaf(x, y, z, rounding_mode) - IEEE-compliant fused multiply-add
-TVM_DLL const Op &ieee_fmaf();
-// ieee_frcp(x, rounding_mode) - IEEE-compliant reciprocal
-TVM_DLL const Op &ieee_frcp();
-// ieee_fsqrt(x, rounding_mode) - IEEE-compliant square root
-TVM_DLL const Op &ieee_fsqrt();
-// ieee_frsqrt(x) - IEEE-compliant reciprocal square root (rn only)
-TVM_DLL const Op &ieee_frsqrt();
-// ieee_fdiv(x, y, rounding_mode) - IEEE-compliant division
-TVM_DLL const Op &ieee_fdiv();
-
 // Packed x2 element-wise math (float32x2, bfloat16x2, float16x2)
 TVM_DLL const Op &add2();
 TVM_DLL const Op &sub2();
@@ -285,124 +118,9 @@ TVM_DLL const Op &fma2();
 TVM_DLL const Op &max2();
 TVM_DLL const Op &min2();
 TVM_DLL const Op &abs2();
-TVM_DLL const Op &max2_nan();
-TVM_DLL const Op &min2_nan();
 
-// random op
-TVM_DLL const Op &rng_init();
-TVM_DLL const Op &rng_rand();
-TVM_DLL const Op &rng_rand_float();
-
-/*!
- * \brief tvm intrinsics for TMADescriptor creation for tiled load
- *
- * CuTensorMap* create_tma_descriptor(data_type, rank, global_addr,
- * global_shape..., global_stride..., smem_box..., smem_stride..., interleave,
- * swizzle, l2_promotion, oob_fill)
- *
- */
-TVM_DLL const Op &create_tma_descriptor();
-
-/*!
- * \brief tvm intrinsics for TMADescriptor creation for image to column load
- *
- * CuTensorMap* create_tma_im2col_descriptor(data_type, rank, global_addr,
- * global_shape..., global_stride..., elem_stride..., lower_corner...,
- * upper_corner..., smme_box_pixel, smem_box_channel, interleave, swizzle,
- * l2_promotion, oob_fill)
- *
- */
-TVM_DLL const Op &create_tma_im2col_descriptor();
-
-/*!
- * \brief tvm intrinsic for prefetching a TMA descriptor on Hopper.
- *
- * prefetch_tma_descriptor(descriptor)
- *
- */
-TVM_DLL const Op &prefetch_tma_descriptor();
-
-/*!
- * \brief tvm intrinsics for loading data from global tensor descriptor to
- * shared memory
- *
- * tma_load(descriptor, mbarrier, smem_data, coord_0, coord_1, ...)
- *
- */
-TVM_DLL const Op &tma_load();
-
-/*!
- * \brief tvm intrinsics for loading image from global tensor to columns in
- * shared memory
- *
- * tma_load(descriptor, mbarrier, smem_data, coord_0, coord_1, ...,
- * image_offset, ...)
- *
- */
-TVM_DLL const Op &tma_load_im2col();
-
-/*!
- * \brief TMA multicast load from a tensor descriptor to cluster shared memory.
- *
- * tma_load_multicast(descriptor, mbarrier, smem_data, multicast_mask,
- *                    coord_0, coord_1, ..., eviction_policy)
- */
-TVM_DLL const Op &tma_load_multicast();
-
-/*!
- * \brief tvm intrinsics for storing data from shared memory to global tensor
- * descriptor
- *
- * tma_store(descriptor, smem_data, coord_0, coord_1, ...)
- *
- */
-TVM_DLL const Op &tma_store();
-
-/*!
- * \brief tvm intrinsics for tile::gather4 TMA load (sm_90+).
- *
- * Loads four rows from a 2D global tensor (described by a tiled CUtensorMap)
- * into a shared memory tile. The four rows can be at arbitrary indices.
- *
- *   tma_load_gather4(descriptor, mbarrier, smem_data, col,
- *                    row0, row1, row2, row3, eviction_policy)
- *
- * The descriptor must be encoded with rank=2 and box dim along axis 1 = 1
- * (the four-row pack is implicit in the gather4 PTX mode).
- */
-TVM_DLL const Op &tma_load_gather4();
-
-/*!
- * \brief tvm intrinsics for tile::scatter4 TMA store (sm_90+).
- *
- * Stores four shared-memory rows back to four arbitrary rows of a 2D global
- * tensor (described by a tiled CUtensorMap).
- *
- *   tma_store_scatter4(descriptor, smem_data, col,
- *                      row0, row1, row2, row3, eviction_policy)
- */
-TVM_DLL const Op &tma_store_scatter4();
-
-TVM_DLL const Op &cooperative_tensor_fill();
-TVM_DLL const Op &cooperative_tensor_load();
-TVM_DLL const Op &cooperative_tensor_store();
-TVM_DLL const Op &cooperative_tensor_multiply_accumulate();
-
-/*!
- * \brief tvm intrinsics for barrier initialization fence
- *
- * ptx_fence_barrier_init()
- *
- */
-const Op &ptx_fence_barrier_init();
-
-/*
- * \brief tvm intrinsics for cluster barrier arrive
- *
- * ptx_arrive_cluster_barrier(mbarrier, cta_id)
- *
- */
-TVM_DLL const Op &ptx_arrive_cluster_barrier();
+// These historical PTX-named IR markers are shared by CUDA and ROCm
+// lowerings. Keep their registered names stable for frontend compatibility.
 
 /*!
  * \brief tvm intrinsics for mbarrier wait with parity bit
@@ -421,127 +139,12 @@ TVM_DLL const Op &mbarrier_wait_parity();
 TVM_DLL const Op &mbarrier_expect_tx();
 
 /*!
- * \brief tvm intrinsic for ptx tensor core wgmma instructions.
- *
- *  void ptx_wgmma_ss(StringImm accum_dtype, StringImm wgmma_prefix, bool
- * a_is_k_major, bool b_is_k_major, StringImm a_dtype_abbrv, StringImm
- * b_dtype_abbrv, StringImm accum_dtype_abbrv, Var A_descriptor, PrimExpr
- * A_offset, Var B_descriptor, Var B_offset, Var C_data, Var C_offset, bool
- * scale_out, bool scale_in_a, bool scale_in_b);
- */
-TVM_DLL const Op &ptx_wgmma_ss();
-
-/*!
- * \brief tvm intrinsics for ptx tensor core wgmma instructions.
- *
- *  void ptx_wgmma_rs(StringImm accum_dtype, StringImm wgmma_prefix,
- * bool b_is_k_major, StringImm a_dtype_abbrv, StringImm b_dtype_abbrv,
- * StringImm accum_dtype_abbrv, Var A_descriptor, PrimExpr A_offset, Var
- * B_descriptor, Var B_offset, Var C_data, Var C_offset, bool scale_out,
- * bool scale_in_a, bool scale_in_b);
- */
-TVM_DLL const Op &ptx_wgmma_rs();
-
-/*!
- * \brief tvm intrinsic for sparse ptx wgmma shared-shared instructions.
- */
-TVM_DLL const Op &ptx_wgmma_sp_ss();
-
-/*!
- * \brief tvm intrinsic for sparse ptx wgmma register-shared instructions.
- */
-TVM_DLL const Op &ptx_wgmma_sp_rs();
-
-/*!
- * \brief tvm intrinsic for ptx tensor core mma with block scaling on SM120a.
- */
-TVM_DLL const Op &ptx_mma_block_scale();
-
-/*!
- * \brief tvm intrinsic for tcgen05 mma shared-shared instructions.
- */
-TVM_DLL const Op &ptx_tcgen05_mma_ss();
-
-/*!
- * \brief tvm intrinsic for tcgen05 mma tensor-shared instructions.
- */
-TVM_DLL const Op &ptx_tcgen05_mma_ts();
-
-/*!
- * \brief tvm intrinsic for tcgen05 block-scaled mma shared-shared instructions.
- */
-TVM_DLL const Op &ptx_tcgen05_mma_blockscaled_ss();
-
-/*!
- * \brief tvm intrinsic for tcgen05 copy warpx4 (smem to tmem).
- */
-TVM_DLL const Op &ptx_tcgen05_cp_warpx4();
-
-/*!
- * \brief tvm intrinsic for scale factor warp transpose in shared memory.
- */
-TVM_DLL const Op &ptx_tcgen05_sf_warp_transpose();
-
-/*!
- * \brief Frontend TMEM deallocation marker.
- *
- * deallocate_tmem(tmem_buffer_data)
- *
- * This op is produced by the TileLang Python frontend and must be lowered by
- * LowerSharedTmem into ptx_deallocate_tensor_memory(access_ptr, num_cols).
- */
-TVM_DLL const Op &deallocate_tmem();
-
-/*!
- * \brief tvm intrinsics for initializing tensor memory
- *
- * ptx_init_tensor_memory(tmem_buffer, num_cols)
- *
- */
-TVM_DLL const Op &ptx_init_tensor_memory();
-
-/*!
- * \brief tvm intrinsics for deallocating tensor memory
- *
- * tmem_deallocate(tmem_buffer)
- *
- */
-TVM_DLL const Op &ptx_deallocate_tensor_memory();
-
-/*!
- * \brief tvm intrinsic for ptx tensor core mma instructions on SM70.
- *
- *  void ptx_mma_sm70(StringImm shape, StringImm A_layout, StringImm B_layout,
- *                    StringImm A_dtype, StringImm B_dtype, StringImm C_dtype,
- *                    Var multiplicand_a, Expr a_index,
- *                    Var multiplicand_b, Expr b_index,
- *                    Var accumulator, Expr c_index, bool saturate);
- */
-TVM_DLL const Op &ptx_mma_sm70();
-
-/*!
- * \brief tvm intrinsics for ldmatrix
- *
- * ptx_ldmatrix(transposed, num, shared_addr, local_addr)
- *
- */
-TVM_DLL const Op &ptx_ldmatrix();
-
-/*!
  * \brief tvm intrinsics for stmatrix
  *
  * ptx_ldmatrix(transposed, num, shared_addr, int32_values...)
  *
  */
 TVM_DLL const Op &ptx_stmatrix();
-
-/*!
- * \brief tvm intrinsic for ptx async copy barrier using
- * cp.async.mbarrier.arrive.noinc
- *
- *  This op is used to represent a ptx async copy barrier operation in tilelang.
- */
-TVM_DLL const Op &ptx_cp_async_barrier_noinc();
 
 /*!
  * \brief TileLang intrinsic for PTX async copy from global to shared memory
@@ -553,60 +156,12 @@ TVM_DLL const Op &ptx_cp_async_barrier_noinc();
 TVM_DLL const Op &ptx_cp_async();
 
 /*!
- * \brief TileLang intrinsic for zeroing shared memory with st.bulk.
- *
- * ptx_st_bulk_shared(smem_data, bytes, init_val)
- *
- */
-TVM_DLL const Op &ptx_st_bulk_shared();
-
-/*!
  * \brief Pack two b16 value into a b32 value
  *
  * int32 pack_b16(b16_value, b16_value)
  *
  */
 TVM_DLL const Op &pack_b16();
-
-/*!
- * \brief Pack four b8 value into a b32 value
- *
- * int32 pack_b8x4(b8_value, b8_value, b8_value, b8_value)
- *
- */
-TVM_DLL const Op &pack_b8x4();
-
-/*!
- * \brief Issue a shared memory fence for async operations
- *
- * FenceProxyAsync()
- *
- */
-TVM_DLL const Op &fence_proxy_async();
-
-/*!
- * \brief Indicate arrival of warp issuing TMA_STORE
- *
- * tma_store_arrive()
- *
- */
-TVM_DLL const Op &tma_store_arrive();
-
-/*!
- * \brief Wait for TMA_STORE to finish
- *
- * tma_store_wait()
- *
- */
-TVM_DLL const Op &tma_store_wait();
-
-/*!
- * \brief Set reg hint for warp-specialized branched
- *
- * SetMaxNRegInc(num_reg, is_inc)
- *
- */
-TVM_DLL const Op &set_max_nreg();
 
 /*!
  * \brief Annotation-only producer reg dealloc hint for warp specialization
@@ -633,165 +188,12 @@ TVM_DLL const Op &annotate_consumer_reg_alloc();
 TVM_DLL const Op &no_set_max_nreg();
 
 /*!
- * \brief Arrive at a warpgroup fence for WGMMA sequences
- *
- * warpgroup_arrive()
- *
- */
-TVM_DLL const Op &warpgroup_arrive();
-
-/*!
- * \brief Commit the current warpgroup batch for WGMMA sequences
- *
- * warpgroup_commit_batch()
- *
- */
-TVM_DLL const Op &warpgroup_commit_batch();
-
-/*!
- * \brief Wait for the warpgroup batch identified by num_mma
- *
- * warpgroup_wait(num_mma)
- *
- */
-TVM_DLL const Op &warpgroup_wait();
-
-/*!
- * \brief Fence accumulator operand registers for upcoming WGMMA operations
- *
- * warpgroup_fence_operand(dtype, ptr, offset, num_regs)
- *
- */
-TVM_DLL const Op &warpgroup_fence_operand();
-
-/*!
- * \brief Return the canonical lane index for the calling thread.
- *
- * get_lane_idx([warp_size])
- *
- */
-TVM_DLL const Op &get_lane_idx();
-
-/*!
- * \brief Return the canonical warp index, assuming converged threads.
- *
- * get_warp_idx_sync([warp_size])
- *
- */
-TVM_DLL const Op &get_warp_idx_sync();
-
-/*!
- * \brief Return the canonical warp index without synchronizing the warp.
- *
- * get_warp_idx([warp_size])
- *
- */
-TVM_DLL const Op &get_warp_idx();
-
-/*!
- * \brief Return the canonical warp group index for converged threads.
- *
- * get_warp_group_idx([warp_size, warps_per_group])
- *
- */
-TVM_DLL const Op &get_warp_group_idx();
-
-/*!
  * \brief Wait the previous wgmma to finish
  *
  * wait_wgmma(num_mma)
  *
  */
 TVM_DLL const Op &wait_wgmma();
-
-/*!
- * \brief Cluster barrier arrive with relaxed ordering
- *
- * cluster_arrive_relaxed()
- *
- */
-TVM_DLL const Op &cluster_arrive_relaxed();
-
-/*!
- * \brief Cluster barrier arrive
- *
- * cluster_arrive()
- *
- */
-TVM_DLL const Op &cluster_arrive();
-
-/*!
- * \brief Cluster barrier wait
- *
- * cluster_wait()
- *
- */
-TVM_DLL const Op &cluster_wait();
-
-/*!
- * \brief Cluster barrier arrive + wait (full sync)
- *
- * cluster_sync()
- *
- */
-TVM_DLL const Op &cluster_sync();
-
-/*!
- * \brief Return the 1-D rank of the calling CTA within its cluster
- *
- * int block_rank_in_cluster()
- *
- */
-TVM_DLL const Op &block_rank_in_cluster();
-
-/*!
- * \brief Issue a Blackwell cluster launch control query that writes a 16-byte
- * response into shared memory and signals completion on the given mbarrier.
- *
- * clc_try_cancel(result_ptr, mbar_ptr)
- *
- */
-TVM_DLL const Op &clc_try_cancel();
-
-/*!
- * \brief Cluster-wide multicast variant of cluster launch control query.
- *
- * clc_try_cancel_multicast(result_ptr, mbar_ptr)
- *
- */
-TVM_DLL const Op &clc_try_cancel_multicast();
-
-/*!
- * \brief Return 1 when a CLC response represents a successful cancellation.
- *
- * int32 clc_is_canceled(result_ptr)
- *
- */
-TVM_DLL const Op &clc_is_canceled();
-
-/*!
- * \brief Return the x coordinate of the first CTA in a successful CLC response.
- *
- * uint32 clc_get_first_ctaid_x(result_ptr)
- *
- */
-TVM_DLL const Op &clc_get_first_ctaid_x();
-
-/*!
- * \brief Return the y coordinate of the first CTA in a successful CLC response.
- *
- * uint32 clc_get_first_ctaid_y(result_ptr)
- *
- */
-TVM_DLL const Op &clc_get_first_ctaid_y();
-
-/*!
- * \brief Return the z coordinate of the first CTA in a successful CLC response.
- *
- * uint32 clc_get_first_ctaid_z(result_ptr)
- *
- */
-TVM_DLL const Op &clc_get_first_ctaid_z();
 
 /*!
  * \brief Synchronize all threads in a grid
@@ -808,38 +210,6 @@ TVM_DLL const Op &sync_grid();
  *
  */
 TVM_DLL const Op &sync_warp();
-
-/*!
- * \brief CTA named barrier one-sided arrive (bar.arrive).
- *
- * Signals that the calling threads have arrived at the named barrier without
- * waiting for other participants.  Useful in warp-specialized producer/consumer
- * pipelines where one side must signal readiness/free-buffer state without
- * blocking, while the other side waits with bar.sync / T.sync_threads().
- *
- * named_barrier_arrive(barrier_id, thread_count)
- *   barrier_id   - named barrier index (0-15)
- *   thread_count - total number of participating threads
- *
- * Lowers to: asm volatile("bar.arrive %0, %1;" : : "r"(id), "r"(cnt));
- */
-TVM_DLL const Op &named_barrier_arrive();
-
-/*!
- * \brief Programmatic dependency trigger.
- *
- * pdl_trigger()
- *
- */
-TVM_DLL const Op &pdl_trigger();
-
-/*!
- * \brief Programmatic grid dependency synchronization.
- *
- * pdl_sync()
- *
- */
-TVM_DLL const Op &pdl_sync();
 
 /*!
  * \brief Warp-vote: non-zero if ANY active lane in the mask has a non-zero
@@ -976,143 +346,6 @@ TVM_DLL const Op &match_all_sync();
 TVM_DLL const Op &loop_break();
 
 /*!
- * \brief tilelang intrinsic for gfx950 LDS transpose read, 64-bit, 16-element.
- *
- * Reads 8 bytes from LDS with a 16-element transpose (FP16/BF16 MFMA B-load).
- * Only available on gfx950 (MI350/MI355X).
- *
- * uint32x2 ds_read_tr16_b64(smem_access_ptr)
- */
-TVM_DLL const Op &ds_read_tr16_b64();
-
-/*!
- * \brief tilelang intrinsic for gfx950 LDS transpose read, 64-bit, 8-element.
- *
- * Reads 8 bytes from LDS with an 8-element transpose (FP32 MFMA B-load).
- * Only available on gfx950 (MI350/MI355X).
- *
- * uint32x2 ds_read_tr8_b64(smem_access_ptr)
- */
-TVM_DLL const Op &ds_read_tr8_b64();
-
-/*!
- * \brief tvm intrinsic for amd matrix core mfma instructions.
- *
- *  void tvm_mfma(StringImm shape, StringImm A_layout, StringImm B_layout,
- *               StringImm A_dtype, StringImm B_dtype, StringImm C_dtype,
- *               Var multiplicand_a, Expr a_index,
- *               Var multiplicand_b, Expr b_index,
- *               Var accumulator, Expr c_index);
- */
-TVM_DLL const Op &tvm_mfma();
-
-/*!
- * \brief tvm intrinsic for storing the result of AMD MFMA into a destination
- * pointer.
- *
- *        There is no real instruction that does that, but we want to hide
- * details of complex index manipulation behind this intrinsic to simplify TIR
- * lowering passes (e.g. LowerWarpMemory) like cuda ptx backend does.
- *
- * void tvm_mfma_store(IntImm m, IntImm n, Var dst_ptr, Var src_ptr, Expr
- * src_offset, Var dst_stride);
- */
-TVM_DLL const Op &tvm_mfma_store();
-
-/*!
- * \brief tvm intrinsic for amd rdna matrix core instructions.
- *
- *  void tvm_rdna_wmma(StringImm shape, StringImm A_layout, StringImm B_layout,
- *               StringImm A_dtype, StringImm B_dtype, StringImm C_dtype,
- *               Var multiplicand_a, Expr a_index,
- *               Var multiplicand_b, Expr b_index,
- *               Var accumulator, Expr c_index);
- */
-TVM_DLL const Op &tvm_rdna_wmma();
-
-/*!
- * \brief tvm intrinsic for storing the result of AMD RDNA WMMA into a
- * destination pointer.
- *
- *        There is no real instruction that does that, but we want to hide
- * details of complex index manipulation behind this intrinsic to simplify TIR
- * lowering passes (e.g. LowerWarpMemory) like cuda ptx backend does.
- *
- * void tvm_rdna_wmma_store(IntImm m, IntImm n, Var dst_ptr, Var src_ptr, Expr
- * src_offset, Var dst_stride);
- */
-TVM_DLL const Op &tvm_rdna_wmma_store();
-
-/*!
- * \brief tilelang intrinsic for shuffle elect.
- *
- *  This op is used to represent a shuffle elect operation in tilelang.
- */
-TVM_DLL const Op &tl_shuffle_elect();
-
-/*!
- * \brief tilelang intrinsic for initializing a descriptor buffer for
- * wgmma/utcmma.
- *
- *  This op is used to represent a descriptor initialization operation in
- * tilelang.
- */
-TVM_DLL const Op &initialize_wgmma_descriptor();
-
-/*!
- * \brief tilelang intrinsic for initializing a descriptor buffer for
- * tcgen05 mma.
- */
-TVM_DLL const Op &initialize_tcgen05_descriptor();
-
-/*!
- * \brief tilelang intrinsic for committing UMMA (TCGEN05) barrier arrive.
- *
- *  This op wraps the device-side arrive used to signal completion of MMA work
- *  to a shared-memory mbarrier. It mirrors CUTLASS's umma_arrive.
- */
-TVM_DLL const Op &tcgen05_mma_arrive();
-
-/*!
- * \brief tilelang intrinsic for lowered TCGEN05 tensor-memory load.
- *
- *  Internal lowering op used by LowerTmemCopy to represent
- *  `tl::tcgen05_ld_*` calls without routing through `call_extern`.
- */
-TVM_DLL const Op &tcgen05_ld();
-
-/*!
- * \brief tilelang intrinsic for lowered TCGEN05 tensor-memory store.
- *
- *  Internal lowering op used by LowerTmemCopy to represent
- *  `tl::tcgen05_st_*` calls without routing through `call_extern`.
- */
-TVM_DLL const Op &tcgen05_st();
-
-/*!
- * \brief TCGEN05 fence before a thread-block-wide sync (__syncthreads /
- * bar.sync). Matches PTX \c tcgen05.fence::before_thread_sync (DeepGEMM /
- * Blackwell UMMA sequencing).
- */
-TVM_DLL const Op &tcgen05_before_thread_sync();
-
-/*!
- * \brief TCGEN05 fence after a thread-block-wide sync. Matches PTX \c
- * tcgen05.fence::after_thread_sync.
- */
-TVM_DLL const Op &tcgen05_after_thread_sync();
-
-/*!
- * \brief tilelang intrinsic for setting the start address of a descriptor
- * buffer for wgmma/utcmma.
- *
- *  This op is used to represent a descriptor start address setting operation in
- * tilelang.
- */
-
-TVM_DLL const Op &increase_descriptor_offset();
-
-/*!
  * \brief tilelang intrinsic for element-wise atomic addition.
  *
  *  This op is used to represent an element-wise atomic add operation in
@@ -1217,20 +450,6 @@ TVM_DLL const Op &atomic_min_elem_op();
 TVM_DLL const Op &atomic_min_ret_elem_op();
 
 /*!
- * \brief tilelang intrinsic for assert on device.
- *
- *  This op is used to represent an assert on device
- */
-TVM_DLL const Op &device_assert();
-
-/*!
- * \brief tilelang intrinsic for assert on device with additional message.
- *
- *  This op is used to represent an assert on device with additional message.
- */
-TVM_DLL const Op &device_assert_with_msg();
-
-/*!
  * \brief tilelang intrinsic for warp reduction sum.
  */
 TVM_DLL const Op &warp_reduce_sum();
@@ -1256,10 +475,10 @@ TVM_DLL const Op &warp_reduce_bitand();
 TVM_DLL const Op &warp_reduce_bitor();
 
 /*!
- * \brief tilelang intrinsic for CUDA read-only cache load (__ldg).
+ * \brief tilelang intrinsic for CUDA/HIP read-only cache load (__ldg).
  *
  *  This op allows users to explicitly request a non-coherent cached load
- *  from global memory on CUDA by emitting `__ldg(&ptr[idx])` for 32-bit
+ *  from global memory by emitting `__ldg(&ptr[idx])` for 32-bit
  *  element types on supported architectures. It provides a direct way to
  *  leverage the read-only data cache for performance-sensitive loads when
  *  the compiler cannot infer `const __restrict__` automatically.
@@ -1273,185 +492,7 @@ TVM_DLL const Op &warp_reduce_bitor();
  */
 TVM_DLL const Op &__ldg();
 
-/*!
- * \brief tilelang intrinsic for CUDA find-first-set bit (__ffs / __ffsll).
- *
- *  Returns the one-based position of the least significant set bit, or 0 when
- *  the input is zero. CUDA codegen emits `__ffs` for 32-bit integer inputs and
- *  `__ffsll` for 64-bit integer inputs.
- *
- *  Usage from TVMScript:
- *    lane = T.__ffs(mask) - 1
- */
-TVM_DLL const Op &__ffs();
-
-/*!
- * \brief tilelang intrinsic for CUDA find-nth-set bit (__fns).
- *
- *  Returns the zero-based position of the offset-th set bit in mask starting
- *  from base, or 0xFFFFFFFF when not found. CUDA codegen emits `__fns`.
- *
- *  Usage from TVMScript:
- *    lane = T.__fns(mask, 0, k + 1)
- */
-TVM_DLL const Op &__fns();
-
-/*!
- * \brief tilelang intrinsic for global memory load with 32-bit vector width.
- *
- *  This op loads 32 bits (4 bytes) from global memory using explicit
- *  PTX ld.global instructions for performance-sensitive loads.
- *
- *  Usage from TVMScript:
- *    y[i] = T.ldg32(x, i)
- */
-TVM_DLL const Op &ldg32();
-
-/*!
- * \brief tilelang intrinsic for global memory load with 64-bit vector width.
- *
- *  This op loads 64 bits (8 bytes) from global memory using explicit
- *  PTX ld.global.v2 instructions for vectorized loads.
- *
- *  Usage from TVMScript:
- *    y[i] = T.ldg64(x, i)
- */
-TVM_DLL const Op &ldg64();
-
-/*!
- * \brief tilelang intrinsic for global memory load with 128-bit vector width.
- *
- *  This op loads 128 bits (16 bytes) from global memory using explicit
- *  PTX ld.global.v4 or ld.global.v2.s64 instructions for wide vectorized loads.
- *
- *  Usage from TVMScript:
- *    y[i] = T.ldg128(x, i)
- */
-TVM_DLL const Op &ldg128();
-
-/*!
- * \brief tilelang intrinsic for shared memory load with 32-bit vector width.
- *
- * This op loads 32 bits (4 bytes) from shared memory and returns uint32.
- */
-TVM_DLL const Op &lds32();
-
-/*!
- * \brief tilelang intrinsic for shared memory load with 64-bit vector width.
- *
- * This op loads 64 bits (8 bytes) from shared memory and returns uint32x2.
- */
-TVM_DLL const Op &lds64();
-
-/*!
- * \brief tilelang intrinsic for shared memory load with 128-bit vector width.
- *
- * This op loads 128 bits (16 bytes) from shared memory and returns uint32x4.
- */
-TVM_DLL const Op &lds128();
-
-/*!
- * \brief tilelang intrinsic for global memory load with 256-bit vector width.
- *
- *  This op loads 256 bits (32 bytes) from global memory using explicit
- *  PTX ld.global.v4.s64 instructions for maximum vectorized loads.
- *  Requires CUDA 12.9+ for native support; older versions use two 128-bit
- * loads.
- *
- *  Usage from TVMScript:
- *    y[i] = T.ldg256(x, i)
- */
-TVM_DLL const Op &ldg256();
-
-/*!
- * \brief tilelang intrinsic for global memory store with 32-bit vector width.
- *
- *  This op stores 32 bits (4 bytes) to global memory using explicit
- *  PTX st.global instructions for performance-sensitive stores.
- *
- *  Usage from TVMScript:
- *    T.stg32(y, i, value)
- */
-TVM_DLL const Op &stg32();
-
-/*!
- * \brief tilelang intrinsic for global memory store with 64-bit vector width.
- *
- *  This op stores 64 bits (8 bytes) to global memory using explicit
- *  PTX st.global.v2 instructions for vectorized stores.
- *
- *  Usage from TVMScript:
- *    T.stg64(y, i, value)
- */
-TVM_DLL const Op &stg64();
-
-/*!
- * \brief tilelang intrinsic for global memory store with 128-bit vector width.
- *
- *  This op stores 128 bits (16 bytes) to global memory using explicit
- *  PTX st.global.v4 instructions for wide vectorized stores.
- *
- *  Usage from TVMScript:
- *    T.stg128(y, i, value)
- */
-TVM_DLL const Op &stg128();
-
-/*!
- * \brief tilelang intrinsic for shared memory store with 32-bit vector width.
- *
- * This op stores a uint32 value to shared memory.
- */
-TVM_DLL const Op &sts32();
-
-/*!
- * \brief tilelang intrinsic for shared memory store with 64-bit vector width.
- *
- * This op stores a uint32x2 value to shared memory.
- */
-TVM_DLL const Op &sts64();
-
-/*!
- * \brief tilelang intrinsic for shared memory store with 128-bit vector width.
- *
- * This op stores a uint32x4 value to shared memory.
- */
-TVM_DLL const Op &sts128();
-
-/*!
- * \brief tilelang intrinsic for global memory store with 256-bit vector width.
- *
- *  This op stores 256 bits (32 bytes) to global memory using explicit
- *  PTX st.global.v4.s64 instructions for maximum vectorized stores.
- *  Requires CUDA 12.9+ for native support; older versions use two 128-bit
- * stores.
- *
- *  Usage from TVMScript:
- *    T.stg256(y, i, value)
- */
-TVM_DLL const Op &stg256();
-
-/*!
- * \brief Elementwise shared::cluster store via cooperative groups.
- */
-TVM_DLL const Op &ptx_cluster_store();
-
-/*!
- * \brief Bulk async shared::cluster store to another CTA.
- *
- * tma_store_cluster(dst_ptr, src_ptr, dst_cta, size_bytes, bar_ref)
- */
-TVM_DLL const Op &tma_store_cluster();
-
-/*!
- * \brief Mark a buffer version index generated by MultiVersionBufferRewriter.
- *
- * This compiler-internal intrinsic preserves the provenance of synthetic
- * pipeline stage indices until warp specialization assigns branch-local
- * transaction counters. It must be removed before code generation.
- */
-TVM_DLL const Op &mvb_stage_index();
-
 } // namespace tl
 } // namespace tvm
 
-#endif //  TVM_TL_OP_BUILTIN_H_
+#endif // TVM_TL_OP_BUILTIN_H_

--- a/src/op/builtin_registry.h
+++ b/src/op/builtin_registry.h
@@ -1,0 +1,20 @@
+/*!
+ * \file tl/op/builtin_registry.h
+ * \brief Internal registration helper for TileLang intrinsic Ops.
+ */
+
+#ifndef TVM_TL_OP_BUILTIN_REGISTRY_H_
+#define TVM_TL_OP_BUILTIN_REGISTRY_H_
+
+#include <tvm/tirx/op.h>
+#include <tvm/tirx/op_attr_types.h>
+
+#define TIR_DEFINE_TL_BUILTIN(OpName)                                          \
+  const Op &OpName() {                                                         \
+    static const Op &op = Op::Get("tl." #OpName);                              \
+    return op;                                                                 \
+  }                                                                            \
+  TVM_REGISTER_OP("tl." #OpName)                                               \
+      .set_attr<tirx::TScriptPrinterName>("TScriptPrinterName", #OpName)
+
+#endif // TVM_TL_OP_BUILTIN_REGISTRY_H_

--- a/src/rocm/CMakeLists.txt
+++ b/src/rocm/CMakeLists.txt
@@ -4,6 +4,7 @@
 # common code and source generation. Compile them regardless of USE_ROCM.
 file(GLOB TILE_LANG_ROCM_ALWAYS_SRCS
   src/rocm/codegen/intrin_rule_hip.cc
+  src/rocm/op/builtin.cc
   src/rocm/target_utils.cc
 )
 list(APPEND TILE_LANG_SRCS ${TILE_LANG_ROCM_ALWAYS_SRCS})
@@ -135,6 +136,8 @@ file(GLOB TILE_LANG_ROCM_ACTIVE_SRCS
   src/rocm/op/*.cc
   src/rocm/transform/*.cc
 )
+list(REMOVE_ITEM TILE_LANG_ROCM_ACTIVE_SRCS
+  "${CMAKE_CURRENT_SOURCE_DIR}/src/rocm/op/builtin.cc")
 list(APPEND TILE_LANG_SRCS ${TILE_LANG_ROCM_ACTIVE_SRCS})
 list(APPEND TILE_LANG_INCLUDES ${ROCM_INCLUDE_DIRS})
 

--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include "backend/common/target_utils.h"
-#include "cuda/target_utils.h"
 #include "rocm/op/builtin.h"
 
 namespace tvm {
@@ -308,11 +307,6 @@ void CodeGenTileLangHIP::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
 
   if (t.is_void()) {
     os << "void";
-    return;
-  }
-
-  if (t == tl::CuTensorMapType()) {
-    os << "CUtensorMap";
     return;
   }
 

--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -18,7 +18,8 @@
 #include <vector>
 
 #include "backend/common/target_utils.h"
-#include "op/builtin.h"
+#include "cuda/target_utils.h"
+#include "rocm/op/builtin.h"
 
 namespace tvm {
 namespace codegen {

--- a/src/rocm/op/atomic_add.cc
+++ b/src/rocm/op/atomic_add.cc
@@ -10,8 +10,8 @@
 
 #include "backend/common/target_utils.h"
 #include "layout/layout.h"
-#include "op/builtin.h"
 #include "op/utils.h"
+#include "rocm/op/builtin.h"
 #include "transform/common/loop_fusion_utils.h"
 #include "transform/loop_partition.h"
 

--- a/src/rocm/op/builtin.cc
+++ b/src/rocm/op/builtin.cc
@@ -1,0 +1,46 @@
+/*!
+ * \file tl/rocm/op/builtin.cc
+ * \brief Registration of ROCm-specific TileLang intrinsic Ops.
+ */
+
+#include "builtin.h"
+
+#include "op/builtin_registry.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+
+TIR_DEFINE_TL_BUILTIN(ds_read_tr16_b64)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(ds_read_tr8_b64)
+    .set_num_inputs(1)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kPure));
+
+TIR_DEFINE_TL_BUILTIN(tvm_mfma).set_num_inputs(12).set_attr<TCallEffectKind>(
+    "TCallEffectKind", Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(tvm_mfma_store)
+    .set_num_inputs(6)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(tvm_rdna_wmma)
+    .set_num_inputs(12)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+TIR_DEFINE_TL_BUILTIN(tvm_rdna_wmma_store)
+    .set_num_inputs(6)
+    .set_attr<TCallEffectKind>("TCallEffectKind",
+                               Integer(CallEffectKind::kOpaque));
+
+} // namespace tl
+} // namespace tvm
+
+#undef TIR_DEFINE_TL_BUILTIN

--- a/src/rocm/op/builtin.h
+++ b/src/rocm/op/builtin.h
@@ -1,0 +1,85 @@
+/*!
+ * \file tl/rocm/op/builtin.h
+ * \brief ROCm-specific TileLang intrinsic Ops.
+ */
+
+#ifndef TVM_TL_ROCM_OP_BUILTIN_H_
+#define TVM_TL_ROCM_OP_BUILTIN_H_
+
+#include "op/builtin.h"
+
+namespace tvm {
+namespace tl {
+
+/*!
+ * \brief tilelang intrinsic for gfx950 LDS transpose read, 64-bit, 16-element.
+ *
+ * Reads 8 bytes from LDS with a 16-element transpose (FP16/BF16 MFMA B-load).
+ * Only available on gfx950 (MI350/MI355X).
+ *
+ * uint32x2 ds_read_tr16_b64(smem_access_ptr)
+ */
+TVM_DLL const Op &ds_read_tr16_b64();
+
+/*!
+ * \brief tilelang intrinsic for gfx950 LDS transpose read, 64-bit, 8-element.
+ *
+ * Reads 8 bytes from LDS with an 8-element transpose (FP32 MFMA B-load).
+ * Only available on gfx950 (MI350/MI355X).
+ *
+ * uint32x2 ds_read_tr8_b64(smem_access_ptr)
+ */
+TVM_DLL const Op &ds_read_tr8_b64();
+
+/*!
+ * \brief tvm intrinsic for amd matrix core mfma instructions.
+ *
+ *  void tvm_mfma(StringImm shape, StringImm A_layout, StringImm B_layout,
+ *               StringImm A_dtype, StringImm B_dtype, StringImm C_dtype,
+ *               Var multiplicand_a, Expr a_index,
+ *               Var multiplicand_b, Expr b_index,
+ *               Var accumulator, Expr c_index);
+ */
+TVM_DLL const Op &tvm_mfma();
+
+/*!
+ * \brief tvm intrinsic for storing the result of AMD MFMA into a destination
+ * pointer.
+ *
+ *        There is no real instruction that does that, but we want to hide
+ * details of complex index manipulation behind this intrinsic to simplify TIR
+ * lowering passes (e.g. LowerWarpMemory) like cuda ptx backend does.
+ *
+ * void tvm_mfma_store(IntImm m, IntImm n, Var dst_ptr, Var src_ptr, Expr
+ * src_offset, Var dst_stride);
+ */
+TVM_DLL const Op &tvm_mfma_store();
+
+/*!
+ * \brief tvm intrinsic for amd rdna matrix core instructions.
+ *
+ *  void tvm_rdna_wmma(StringImm shape, StringImm A_layout, StringImm B_layout,
+ *               StringImm A_dtype, StringImm B_dtype, StringImm C_dtype,
+ *               Var multiplicand_a, Expr a_index,
+ *               Var multiplicand_b, Expr b_index,
+ *               Var accumulator, Expr c_index);
+ */
+TVM_DLL const Op &tvm_rdna_wmma();
+
+/*!
+ * \brief tvm intrinsic for storing the result of AMD RDNA WMMA into a
+ * destination pointer.
+ *
+ *        There is no real instruction that does that, but we want to hide
+ * details of complex index manipulation behind this intrinsic to simplify TIR
+ * lowering passes (e.g. LowerWarpMemory) like cuda ptx backend does.
+ *
+ * void tvm_rdna_wmma_store(IntImm m, IntImm n, Var dst_ptr, Var src_ptr, Expr
+ * src_offset, Var dst_stride);
+ */
+TVM_DLL const Op &tvm_rdna_wmma_store();
+
+} // namespace tl
+} // namespace tvm
+
+#endif // TVM_TL_ROCM_OP_BUILTIN_H_

--- a/src/rocm/op/copy.cc
+++ b/src/rocm/op/copy.cc
@@ -8,8 +8,8 @@
 #include <tvm/ir/cast.h>
 #include <tvm/runtime/logging.h>
 
-#include "op/builtin.h"
 #include "op/utils.h"
+#include "rocm/op/builtin.h"
 #include "rocm/target_utils.h"
 #include "rocm/transform/async_copy_injector.h"
 #include "transform/common/loop_fusion_utils.h"

--- a/src/rocm/transform/async_copy_injector.cc
+++ b/src/rocm/transform/async_copy_injector.cc
@@ -17,8 +17,8 @@
 #include <optional>
 #include <vector>
 
-#include "op/builtin.h"
 #include "op/utils.h"
+#include "rocm/op/builtin.h"
 #include "rocm/transform/async_copy_injector.h"
 #include "tir/ir/buffer_common.h"
 

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -18,11 +18,11 @@
 
 #include "../layout/layout.h"
 #include "../layout/utils.h"
-#include "../op/builtin.h"
 #include "../op/gemm.h"
 #include "../op/gemm_sp.h"
 #include "../op/operator.h"
 #include "../op/utils.h"
+#include "cuda/op/builtin.h"
 #include "cuda/target_utils.h"
 #include "cuda/transform/ptx_async_copy_injector.h"
 

--- a/src/transform/merge_shared_memory_allocations.cc
+++ b/src/transform/merge_shared_memory_allocations.cc
@@ -43,8 +43,8 @@
 #include <unordered_set>
 #include <utility>
 
-#include "../op/builtin.h"
 #include "common/storage_size.h"
+#include "cuda/op/builtin.h"
 #include "runtime/thread_storage_scope.h"
 #include "tir/transforms/ir_utils.h"
 #include <tvm/tirx/function.h>

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -20,11 +20,11 @@
 /*!
  * \file thread_storage_sync.cc
  */
-#include "../op/builtin.h"
 #include "./common/constr_visitor.h"
 #include "./common/thread_sync_types.h"
 #include "arith/ir_mutator_with_analyzer.h"
 #include "common/attr.h"
+#include "cuda/op/builtin.h"
 #include "runtime/thread_storage_scope.h"
 #include "support/check.h"
 #include "tir/transforms/ir_utils.h"


### PR DESCRIPTION
## Summary

- Move backend-specific TileLang builtin declarations and registrations out of the shared `src/op/builtin.*` files into backend-owned modules.
- Keep cross-backend IR contracts in the common layer while preserving existing Op names, argument metadata, side-effect attributes, and PassContext keys.
- Make backend ownership explicit without changing frontend or runtime behavior.

## Changes

- Add `src/{cuda,rocm,metal}/op/builtin.{h,cc}` and a shared internal registration helper.
- Move CUDA-only fast math, IEEE rounding, TMA, WGMMA/TCGEN05, warp and cluster operations, explicit load/store operations, and related configuration declarations into the CUDA module.
- Move AMD MFMA, RDNA, and LDS operations and Metal cooperative tensor operations into their respective modules.
- Relocate the CUDA tensor-map sentinel type to CUDA target utilities.
- Update backend consumers and CMake source lists. Backend registration units remain available in backend-disabled builds so existing frontend lookups continue to resolve.
- Preserve the existing intrinsic documentation alongside the moved declarations.

## Validation

- `./format.sh`
- `cmake -S . -B build -DUSE_CUDA=OFF -DUSE_ROCM=OFF -DUSE_METAL=OFF`
- `cmake --build build -j32`
- `cmake -S . -B build-backends -DUSE_CUDA=ON -DUSE_ROCM=ON -DUSE_METAL=OFF -DTILELANG_HIP_INCLUDE_DIR=$PWD/3rdparty/hip-headers/include`
- `cmake --build build-backends --target tilelang -j32`
- `python3 -m pytest testing/python/components/test_tilelang_pass_config_disable_tma_lower.py -q`
- Runtime registry audit for all 172 TileLang builtin Ops
- Declaration, registration attribute, and PassConfig compatibility audit
- `git diff --check origin/main...HEAD`

## Notes

- Historical PTX-named IR markers consumed by both CUDA and ROCm remain in the common module.
- Backend builtin registration units are deliberately part of the always-built source sets; backend lowering and code generation remain gated by their build options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Moved CUDA, ROCm, and Metal builtin declarations and registrations into backend-owned modules.
- Added shared builtin registration support.
- Kept backend-neutral intrinsics, attributes, pass options, and IR contracts in `src/op/builtin.*`.
- Moved CUDA tensor-map utilities to CUDA-specific code.
- Updated backend consumers and CMake source lists.
- Preserved operation names, metadata, side effects, frontend behavior, and runtime behavior.
- Kept backend registration units available in backend-disabled builds.

## Validation

- Ran formatting, whitespace, build, targeted test, registry, and compatibility checks.
- Covered backend-enabled and backend-disabled builds.

## C++ style / lint notes

- This PR changes C++ source, headers, and CMake files.
- It does not change the rules documented in `docs/developer_guide/cpp_style.md`.
- The `C++ API Style Audit (warning only)` CI step applies.
- TLCPP003/TLCPP004 findings are advisory and do not block merging unless they indicate a clear API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->