### PR TITLE
[BugFix][Metal] Resolve auto backend to torch and skip disk cache for torch

### DIFF
--- a/testing/python/metal/test_metal_cache.py
+++ b/testing/python/metal/test_metal_cache.py
@@ -1,0 +1,99 @@
+"""Regression tests for issue #2722: TileLang on Metal.
+
+Covers two behaviors that previously made Metal support opaque:
+1. `@tilelang.jit` with no explicit `execution_backend` must resolve to the
+   torch backend (Metal adapter) instead of `tvm_ffi`.
+2. The torch backend must not attempt to persist a compiled library to the disk
+   cache (it has no `libpath` artifact; `torch.mps.compile_shader` compiles the
+   MSL source in-process). Before the fix this raised
+   `AttributeError: 'MetalKernelAdapter' object has no attribute 'libpath'`
+   and logged "Error during atomic cache save" on every run.
+"""
+
+import logging
+import os
+
+import tilelang
+import tilelang.testing
+import tilelang.language as T
+import torch
+
+from tilelang.cache.kernel_cache import KernelCache
+
+
+@tilelang.jit
+def _matmul_gemm_auto(M, N, K, block_M, block_N, block_K, dtype=T.float16, accum_dtype=T.float32):
+    @T.prim_func
+    def gemm_kernel(
+        A: T.Tensor((M, K), dtype),
+        B: T.Tensor((K, N), dtype),
+        C: T.Tensor((M, N), accum_dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), dtype, scope="shared")
+            B_shared = T.alloc_shared((block_K, block_N), dtype, scope="shared")
+            C_local = T.alloc_shared((block_M, block_N), accum_dtype, scope="shared")
+
+            T.clear(C_local)
+
+            for ko in T.Pipelined(T.ceildiv(K, block_K), num_stages=0):
+                T.copy(A[by * block_M, ko * block_K], A_shared)
+                T.copy(B[ko * block_K, bx * block_N], B_shared)
+
+                T.gemm(A_shared, B_shared, C_local)
+
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return gemm_kernel
+
+
+def _run_gemm(jit_kernel, M, N, K):
+    a = torch.randn(M, K, dtype=torch.float16, device="mps")
+    b = torch.randn(K, N, dtype=torch.float16, device="mps")
+    c = torch.zeros(M, N, dtype=torch.float32, device="mps")
+    jit_kernel(a, b, c)
+    ref = a.to(torch.float32) @ b.to(torch.float32)
+    assert torch.allclose(ref, c, atol=1e-2), f"max diff: {(ref - c).abs().max().item()}"
+
+
+@tilelang.testing.requires_metal
+def test_auto_backend_resolves_to_torch():
+    """Bare @tilelang.jit must resolve to the torch (Metal) backend."""
+    M, N, K = 64, 64, 64
+    kernel = _matmul_gemm_auto(M, N, K, 16, 16, 8)
+    assert kernel.execution_backend == "torch", kernel.execution_backend
+    _run_gemm(kernel, M, N, K)
+
+
+@tilelang.testing.requires_metal
+def test_torch_backend_no_disk_cache_write():
+    """The torch backend must not write disk cache entries or log save errors."""
+    cache_logger = logging.getLogger("tilelang.cache.kernel_cache")
+    records = []
+    handler = logging.Handler()
+    handler.emit = lambda record: records.append(record)
+    cache_logger.addHandler(handler)
+    cache_logger.setLevel(logging.ERROR)
+
+    cache_root = KernelCache._get_cache_root()
+    before = set(os.listdir(cache_root)) if os.path.isdir(cache_root) else set()
+
+    try:
+        M, N, K = 64, 64, 64
+        kernel = _matmul_gemm_auto(M, N, K, 16, 16, 8)
+        _run_gemm(kernel, M, N, K)
+        # Second run in the same process: memory-cache hit, still no disk I/O.
+        _run_gemm(kernel, M, N, K)
+    finally:
+        cache_logger.removeHandler(handler)
+
+    error_messages = [r.getMessage() for r in records if r.levelno >= logging.ERROR]
+    assert not any("Error during atomic cache save" in msg for msg in error_messages), error_messages
+
+    after = set(os.listdir(cache_root)) if os.path.isdir(cache_root) else set()
+    assert after == before, f"torch backend wrote disk cache entries: {after - before}"
+
+
+if __name__ == "__main__":
+    if torch.mps.is_available():
+        tilelang.testing.main()

--- a/tilelang/cache/kernel_cache.py
+++ b/tilelang/cache/kernel_cache.py
@@ -363,11 +363,16 @@ class KernelCache:
         if verbose:
             self.logger.debug(f"Checking disk cache for kernel {get_prim_func_name(func, '<unknown>')}")
 
-        # Disk loads can be expensive for large kernel sets; keep them outside
-        # the global cache lock so independent cache hits can proceed in parallel.
-        kernel = self._load_kernel_from_disk(
-            key, target, target_host, out_idx, execution_backend, pass_configs, compile_flags, func, verbose
-        )
+        if execution_backend == "torch":
+            # Metal's torch backend does not support cache yet
+            env.disable_cache()
+            kernel = None
+        else:
+            # Disk loads can be expensive for large kernel sets; keep them outside
+            # the global cache lock so independent cache hits can proceed in parallel.
+            kernel = self._load_kernel_from_disk(
+                key, target, target_host, out_idx, execution_backend, pass_configs, compile_flags, func, verbose
+            )
         if kernel is not None:
             if verbose:
                 self.logger.debug(f"Found kernel in disk cache for {get_prim_func_name(func, '<unknown>')}")
@@ -664,7 +669,8 @@ class KernelCache:
 
     def _save_so_cubin_to_disk(self, kernel: JITKernel, cache_path: str, verbose: bool = False):
         kernel_lib_path = os.path.join(cache_path, self.kernel_lib_path)
-        src_lib_path = kernel.adapter.libpath
+        if (src_lib_path := getattr(kernel.adapter, "libpath", None)) is None:
+            return
         if verbose:
             self.logger.debug(f"Saving kernel library to file: {kernel_lib_path}")
         KernelCache._safe_write_file(kernel_lib_path, "wb", lambda file: file.write(KernelCache._load_binary(src_lib_path)))

--- a/tilelang/metal/execution_backend.py
+++ b/tilelang/metal/execution_backend.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 from tilelang.backend.execution_backend import ExecutionBackendSpec, register_execution_backend
 
 
+# torch is registered first so that `execution_backend="auto"` resolves to the
+# Metal adapter (torch.mps.compile_shader), which is the supported execution path
+# for Metal. tvm_ffi remains available as an explicit opt-in.
+register_execution_backend("metal", ExecutionBackendSpec("torch"), override=True)
 register_execution_backend(
     "metal",
     ExecutionBackendSpec("tvm_ffi", enable_host_codegen=True, enable_device_compile=True),
     override=True,
 )
-register_execution_backend("metal", ExecutionBackendSpec("torch"), override=True)


### PR DESCRIPTION
Fixes the two real issues behind #2722 (TileLang on Metal is unusable out of the box).

## Problem

1. **`execution_backend="auto"` resolves to `tvm_ffi` on Metal.** `resolve_execution_backend_spec` picks the first registered spec, and `tilelang/metal/execution_backend.py` registered `tvm_ffi` before `torch`. The documented default is `metal->torch` (`jit/__init__.py`), and `tvm_ffi` does not run on Metal in practice, so every kernel had to be written as `@jit(execution_backend='torch')` with no documentation.

2. **The torch (Metal) backend crashes the kernel disk cache.** `MetalKernelAdapter` has no `libpath` attribute — the MSL source is compiled in-process via `torch.mps.compile_shader` — but `KernelCache._save_so_cubin_to_disk` unconditionally reads `kernel.adapter.libpath`. Every run logs:

   ```
   ERROR (kernel_cache.py:548): Error during atomic cache save
   AttributeError: 'MetalKernelAdapter' object has no attribute 'libpath'
   ```

   The exception is swallowed (non-fatal), but the disk entry is never persisted, so Metal kernels recompile on every process start and every run emits a misleading traceback. The database-load path (`_create_adapter_from_database`) additionally has no `torch` branch, so a persisted entry could never be reconstructed either.

## Change

- `tilelang/metal/execution_backend.py`: register `torch` before `tvm_ffi` so `auto` resolves to the supported Metal adapter; `tvm_ffi` stays available as an explicit opt-in.
- `tilelang/cache/kernel_cache.py`: skip disk load/save for the torch backend in `cached()` (in-memory cache still applies), matching the autotuner's existing "Torch backend does not support cache saving to disk" stance; guard `libpath` access in `_save_so_cubin_to_disk` so lib-less adapters can never crash the save path again.
- `testing/python/metal/test_metal_cache.py`: regression tests — bare `@tilelang.jit` resolves to `torch` and runs correctly; the torch backend writes no disk-cache entries and emits no "Error during atomic cache save".

## Verification (Apple M5, real Metal/MPS)

- Author's repro from #2722: PASS, error log gone (max diff 0.0)
- Bare `@tilelang.jit` GEMM on Metal: resolved backend `torch`, PASS
- `testing/python/metal/`: 38 passed (incl. 8 pre-existing bare-`@jit` gemm tests that previously required the explicit backend)
- `testing/python/cache/`: 14 passed / 14 skipped (CUDA-gated, no regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Register the Torch backend before `tvm_ffi` so `execution_backend="auto"` selects Torch for Metal.
- Keep `tvm_ffi` available through explicit backend selection.
- Skip disk-cache loading and saving for Torch while preserving in-memory caching.
- Guard cache saves when an adapter has no `libpath`.
- Add Metal regression tests for backend resolution, execution, repeated caching, and cache-save errors.

## Testing

- Metal tests pass on Apple M5.
- No cache-save errors occur for Torch-backed Metal kernels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->