### PR TITLE
[Typo] Correct source spelling errors

### DIFF
--- a/examples/flash_attention_sm100/gqa_bwd_bshd.py
+++ b/examples/flash_attention_sm100/gqa_bwd_bshd.py
@@ -17,7 +17,7 @@ PASS_CFG = {tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True, tilelang.PassConfi
 
 @tilelang.jit(out_idx=[3, 4], pass_configs=PASS_CFG)
 def flashattn_fwd(batch, heads, seq_len, dim, is_causal, block_M, block_N, groups=1):
-    """Forward for LSE; K/V indexed by by // groups."""
+    """Forward for LSE; K/V indexed by head // groups."""
     if groups <= 0 or heads % groups != 0:
         raise ValueError("groups must be a positive divisor of heads")
     head_kv = heads // groups

--- a/src/backend/common/codegen/codegen_c_host.h
+++ b/src/backend/common/codegen/codegen_c_host.h
@@ -98,7 +98,7 @@ private:
   Array<String> function_names_;
   /*! \brief whether to emit asserts in the resulting C code */
   bool emit_asserts_;
-  /*! \brief whether to emit forwared function declarations in the resulting C
+  /*! \brief whether to emit forwarded function declarations in the resulting C
    * code */
   bool emit_fwd_func_decl_;
   /*! \brief whether to generate the entry function if encountered */

--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -177,7 +177,7 @@ inline uint64_t UnsignedMax(int bits) {
   return (static_cast<uint64_t>(1) << bits) - 1;
 }
 
-inline int GetPreferedVectorizedSize(DataType dt,
+inline int GetPreferredVectorizedSize(DataType dt,
                                      bool supports_fp32x2 = false) {
   if (dt.is_bfloat16() || dt.is_float16() ||
       (supports_fp32x2 && dt.is_float() && dt.bits() == 32))
@@ -670,7 +670,7 @@ template <typename Impl> struct ReduceLowerer {
     };
 
     int vsize =
-        Impl::GetPreferedVectorizedSize(dst_buffer->dtype, lower_args.target);
+        Impl::GetPreferredVectorizedSize(dst_buffer->dtype, lower_args.target);
     const int64_t *reduce_extent = as_const_int(op.src->shape[op.dim]);
     bool can_pack = op.clear && vsize == 2 && reduce_extent &&
                     *reduce_extent >= vsize && *reduce_extent % vsize == 0 &&
@@ -857,7 +857,7 @@ template <typename Impl> struct ReduceLowerer {
       Buffer clear_buffer_packed;
       Buffer clear_batch_pack_buffer;
       {
-        int vsize = Impl::GetPreferedVectorizedSize(clear_buffer->dtype,
+        int vsize = Impl::GetPreferredVectorizedSize(clear_buffer->dtype,
                                                     lower_args.target);
         if (vsize > 1 && !src_var_compressed.empty()) {
           auto *ext = src_var_compressed.back()->dom->extent.as<IntImmNode>();
@@ -1019,7 +1019,7 @@ template <typename Impl> struct ReduceLowerer {
               static_cast<int>(*as_const_int(lower_args.thread_bounds->extent));
           auto thread_offset = lower_args.thread_bounds->min;
 
-          int vsize = Impl::GetPreferedVectorizedSize(clear_buffer->dtype,
+          int vsize = Impl::GetPreferredVectorizedSize(clear_buffer->dtype,
                                                       lower_args.target);
           bool can_batch_pack =
               vsize > 1 && batch >= vsize && batch % vsize == 0 &&

--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -178,7 +178,7 @@ inline uint64_t UnsignedMax(int bits) {
 }
 
 inline int GetPreferredVectorizedSize(DataType dt,
-                                     bool supports_fp32x2 = false) {
+                                      bool supports_fp32x2 = false) {
   if (dt.is_bfloat16() || dt.is_float16() ||
       (supports_fp32x2 && dt.is_float() && dt.bits() == 32))
     return 2;
@@ -858,7 +858,7 @@ template <typename Impl> struct ReduceLowerer {
       Buffer clear_batch_pack_buffer;
       {
         int vsize = Impl::GetPreferredVectorizedSize(clear_buffer->dtype,
-                                                    lower_args.target);
+                                                     lower_args.target);
         if (vsize > 1 && !src_var_compressed.empty()) {
           auto *ext = src_var_compressed.back()->dom->extent.as<IntImmNode>();
           if (ext && ext->value >= vsize && ext->value % vsize == 0 &&
@@ -1020,7 +1020,7 @@ template <typename Impl> struct ReduceLowerer {
           auto thread_offset = lower_args.thread_bounds->min;
 
           int vsize = Impl::GetPreferredVectorizedSize(clear_buffer->dtype,
-                                                      lower_args.target);
+                                                       lower_args.target);
           bool can_batch_pack =
               vsize > 1 && batch >= vsize && batch % vsize == 0 &&
               reduce::MakeCodegenReducer(op, vsize).has_value();

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -3069,7 +3069,7 @@ void CodeGenTileLangCuTeDSL::PrintCallExtern_(Type ret_type,
   if (global_symbol_str.substr(0, 2) == "__") {
     global_symbol_str = "tl." + global_symbol_str;
   }
-  // some optional template arguments might be ommited, so add names explicitly
+  // some optional template arguments might be omitted, so add names explicitly
   // for remain arguments
   if (global_symbol_str == "tl.gemm_ss" || global_symbol_str == "tl.gemm_rs" ||
       global_symbol_str == "tl.gemm_sr" || global_symbol_str == "tl.gemm_rr") {
@@ -3080,7 +3080,7 @@ void CodeGenTileLangCuTeDSL::PrintCallExtern_(Type ret_type,
   }
 
   if (ret_dtype.is_fixed_length_vector()) {
-    // maybe simplify this if TensorSSA suppports this OP
+    // maybe simplify this if TensorSSA supports this OP
     std::string sret = name_supply_->FreshName("_");
     PrintIndent();
     stream << sret << " = tl.make_rmem_tensor((" << ret_dtype.lanes() << ",), ";
@@ -3351,7 +3351,7 @@ std::string CodeGenTileLangCuTeDSL::GetBufferRef_(DataType t,
       std::ostringstream os;
       os << "tl.make_tensor_at_offset(" << ptr_str << ", " << index_str
          << ", (1,), div_by=" << scalarized_div_by << ")";
-      // for vector data types, ".load()" (added by BufferLoadNode) is neeed
+      // for vector data types, ".load()" (added by BufferLoadNode) is needed
       // instead of "[0]"
       if (buffer_element_dtype.is_scalar()) {
         os << "[0]";

--- a/src/cuda/codegen/codegen_py.h
+++ b/src/cuda/codegen/codegen_py.h
@@ -102,7 +102,7 @@ protected:
 
 protected:
   /*!
-   * \brief Print Type representation of type type.
+   * \brief Print the type representation.
    * \param t The type representation.
    * \param os The output stream
    */
@@ -161,7 +161,7 @@ protected:
   void VisitExpr_(const BufferLoadNode *op,
                   std::ostream &os) override; // NOLINT(*)
 
-  // statment
+  // statement
   void VisitStmt_(const BufferStoreNode *op) override;
   void VisitStmt_(const DeclBufferNode *op) override;
   void VisitStmt_(const BindNode *op) override;
@@ -188,7 +188,7 @@ protected:
   /*!
    * \brief Print external function call.
    * \param ret_type The return type.
-   * \param global_symbol The symbolc of the target function.
+   * \param global_symbol The symbolic name of the target function.
    * \param args The arguments to the function.
    * \param skip_first_arg Whether to skip the first arguments.
    * \param os The output stream.

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -2004,7 +2004,7 @@ Stmt Copy::LowerBulk(const CopyNode &op, const LowerArgs &lower_args,
     int64_t box_dim = cute::AsConst(tile_gbasis->shape[i]);
     if (box_dim > cap) {
       // This exceeds the hardware constraint. But we can make it work by
-      // spliting a mode.
+      // splitting a mode.
       // Only the slowest box mode has leftover the rest loop can absorb;
       // shrinking a faster mode would gap the contiguous shared prefix.
       int64_t inner = -1;

--- a/src/cuda/op/reduce.cc
+++ b/src/cuda/op/reduce.cc
@@ -21,12 +21,12 @@ struct Reduce : backend::ReduceLowerer<Reduce> {
     return TargetIsCuda(target);
   }
 
-  static int GetPreferedVectorizedSize(DataType dt, Target target) {
+  static int GetPreferredVectorizedSize(DataType dt, Target target) {
     if (!TargetIsCuda(target)) {
       return 1;
     }
     bool supports_fp32x2 = TargetHasSMVersionGE(target, 100);
-    return backend::reduce::GetPreferedVectorizedSize(dt, supports_fp32x2);
+    return backend::reduce::GetPreferredVectorizedSize(dt, supports_fp32x2);
   }
 
   static std::string MakeBatchAllReduce(std::string reducer,

--- a/src/rocm/op/reduce.cc
+++ b/src/rocm/op/reduce.cc
@@ -19,7 +19,7 @@ namespace rocm {
 struct Reduce : backend::ReduceLowerer<Reduce> {
   static bool SupportsFp16Bf16NanReduce(Target) { return false; }
 
-  static int GetPreferedVectorizedSize(DataType, Target) { return 1; }
+  static int GetPreferredVectorizedSize(DataType, Target) { return 1; }
 
   static std::string MakeBatchAllReduce(std::string reducer,
                                         int reducing_threads, int scale,

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -564,7 +564,7 @@ union GmmaDescriptor {
     uint16_t leading_byte_offset_ : 14, : 2; // 14 bits [0,14), 2 bits unused
     // stride dimension byte offset, bit [32,46), 4LSB not included
     // For N: This is the stride from the first 8 rows to the next 8 rows.
-    // For T: This is the stride fro mthe first 8 cols to the next 8 cols.
+    // For T: This is the stride from the first 8 cols to the next 8 cols.
     uint16_t stride_byte_offset_ : 14, : 2; // 14 bits [0,14), 2 bits unused
     // base_offset, bit [49,52)
     // Valid only for SWIZZLE_128B and SWIZZLE_64B

--- a/src/tl_templates/cuda/cuda_fp4.h
+++ b/src/tl_templates/cuda/cuda_fp4.h
@@ -174,7 +174,7 @@ TL_DEVICE fp4_e2_32_t make_fp4_e2_32_t(
 // ============================================================================
 // https://docs.nvidia.com/cuda/cuda-math-api/cuda_math_api/group__CUDA__MATH__FP4__MISC.html
 
-// Custom fp4_e2m1 -> half convertion for CUDA version < 13.0 to avoid using
+// Custom fp4_e2m1 -> half conversion for CUDA version < 13.0 to avoid using
 // `cvt.rn.relu.f16x2.e2m1x2`, as there are bugs in PTXAS related to
 // `cvt.rn.relu.f16x2.e2m1x2` between CUDA 12.6 and 12.9
 __device__ __half_raw __tl_cvt_fp4_to_halfraw_naive(
@@ -189,7 +189,7 @@ __device__ __half_raw __tl_cvt_fp4_to_halfraw_naive(
   return res;
 }
 
-// Custom fp4_e2m1 -> half convertion for CUDA version < 13.0 to avoid using
+// Custom fp4_e2m1 -> half conversion for CUDA version < 13.0 to avoid using
 // `cvt.rn.relu.f16x2.e2m1x2`, as there are bugs in PTXAS related to
 // `cvt.rn.relu.f16x2.e2m1x2` between CUDA 12.6 and 12.9
 __device__ __half2_raw __tl_cvt_fp4x2_to_halfraw2_naive(

--- a/src/transform/tvm_ffi_binder.h
+++ b/src/transform/tvm_ffi_binder.h
@@ -136,12 +136,12 @@ public:
    * bound.  For example, `binder.Bind(var, expr_1)` will produce an
    * entry mapping `var` to `expr_1` in the `binder.Defs()`.  If
    * `binder.Bind(var, expr_2)` is called later, then this will
-   * produce an assert statemtn that `expr_1 == expr_2`.
+   * produce an assert statement that `expr_1 == expr_2`.
    *
    * Note: Some assert statements produced by BindDLTensor are located
    * in `binder.InitNest()`, not within `binder.Asserts()`.  This is
    * deliberate, as some values may require checks prior to
-   * initialization.  (e.g. Intializing `m = dl_tensor->shape[3]`
+   * initialization.  (e.g. Initializing `m = dl_tensor->shape[3]`
    * requires first asserting that `3 < dl_tensor->ndim`.)
    */
   const std::vector<Stmt> &Asserts() const { return asserts_; }
@@ -194,7 +194,7 @@ private:
   std::vector<Var> defs_;
   /*! \brief Initialize nest */
   std::vector<Stmt> init_nest_;
-  /*! \brief handle data type in the defintiions */
+  /*! \brief handle data type in the definitions */
   ffi::Map<Var, PrimExpr> def_handle_dtype_;
   /*! \brief asserts generated */
   std::vector<Stmt> asserts_;

--- a/testing/python/language/test_tilelang_language_scan.py
+++ b/testing/python/language/test_tilelang_language_scan.py
@@ -689,7 +689,7 @@ def test_scan_offset_subregion():
         for dim in (0, 1):
             for reverse in (False, True):
                 # r0 == 64 is the regressing case (r0 == 0 is already covered by
-                # the full-region region tests above).
+                # the full-region tests above).
                 run_scan_offset_subregion(H, W, 64, 128, op=op, dim=dim, reverse=reverse)
 
 


### PR DESCRIPTION
## Summary

Correct confirmed spelling errors in TileLang-owned source and comments.

- Rename the internal reduction helper `GetPreferedVectorizedSize` to `GetPreferredVectorizedSize` across the shared, CUDA, and ROCm implementations.
- Correct misspelled words and duplicated words in C++ comments and Python documentation/comments.
- Keep runtime behavior unchanged apart from the internal symbol spelling.

## Validation

- `make -C build -j2` — completed successfully and built `lib/libtilelang.so`.
- `.venv/bin/ruff check examples/flash_attention_sm100/gqa_bwd_bshd.py testing/python/language/test_tilelang_language_scan.py` — passed.
- `.venv/bin/pre-commit run codespell --files ...` — passed.
- `git diff --check` — passed.
- Confirmed the old misspelled identifier and corrected typo patterns are absent outside vendor stubs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Renamed `GetPreferedVectorizedSize` to `GetPreferredVectorizedSize` across shared, CUDA, and ROCm reduction code.
- Corrected spelling errors in C++ comments, Python documentation, and test comments.
- Preserved runtime behavior.
- Validation passed with the build, Ruff, codespell, pre-commit, and `git diff --check`.

## C++ style / lint notes

- The PR touches the comments and documentation guidance in `docs/developer_guide/cpp_style.md`, but does not change the documented rules.
- The C++ API Style Audit runs in warning-only mode.
- No correctness, build, or test issues are reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->