### PR TITLE
[Refactor] Recycle `T.unroll(explicit=True)` for early explicit unrolling

### DIFF
--- a/maint/gemm/gemm_sm120/benchmark_sm120_nvfp4_blockscaled_gemm.py
+++ b/maint/gemm/gemm_sm120/benchmark_sm120_nvfp4_blockscaled_gemm.py
@@ -159,7 +159,7 @@ def tilelang_nvfp4_blockscaled_gemm(
                         tile_m = tile_id // n_blocks
                         owner = stream & 1
                         owner_iter = stream // 2
-                        for ko in T.unroll(k_tiles, explicit=False, unroll_factor=1):
+                        for ko in T.unroll(k_tiles, unroll_factor=1):
                             stage = ko % num_stages
                             phase = ((owner_iter * k_tiles + ko) // num_stages) & 1
                             barrier_slot = owner * num_stages + stage
@@ -209,7 +209,7 @@ def tilelang_nvfp4_blockscaled_gemm(
                             T.barrier_wait(wg_order[0], (owner_iter - 1) & 1)
 
                         T.clear(C0_local)
-                        for ko in T.unroll(k_tiles, explicit=False, unroll_factor=1):
+                        for ko in T.unroll(k_tiles, unroll_factor=1):
                             stage = ko % num_stages
                             phase = ((owner_iter * k_tiles + ko) // num_stages) & 1
                             barrier_slot = stage
@@ -247,7 +247,7 @@ def tilelang_nvfp4_blockscaled_gemm(
                         T.barrier_wait(wg_order[1], owner_iter & 1)
 
                         T.clear(C1_local)
-                        for ko in T.unroll(k_tiles, explicit=False, unroll_factor=1):
+                        for ko in T.unroll(k_tiles, unroll_factor=1):
                             stage = ko % num_stages
                             phase = ((owner_iter * k_tiles + ko) // num_stages) & 1
                             barrier_slot = num_stages + stage

--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -707,8 +707,7 @@ template <typename Impl> struct ReduceLowerer {
                              src_value),
           dst_indices);
       stmts.push_back(For(rv, 0, Integer(*reduce_extent / vsize),
-                          ForKind::kUnrolled, reduce_body, std::nullopt,
-                          {{tirx::attr::pragma_unroll_explicit, Bool(false)}}));
+                          ForKind::kUnrolled, reduce_body, std::nullopt));
 
       PrimExpr packed = BufferLoad(packed_buffer, dst_indices);
       PrimExpr result =
@@ -727,15 +726,13 @@ template <typename Impl> struct ReduceLowerer {
                              BufferLoad(src_buffer, make_src_indices(rv))),
           dst_indices);
       stmts.push_back(For(rv, 0, op.src->shape[op.dim], ForKind::kUnrolled,
-                          reduce_body, std::nullopt,
-                          {{tirx::attr::pragma_unroll_explicit, Bool(false)}}));
+                          reduce_body, std::nullopt));
     }
 
     Stmt body = SeqStmt(stmts);
     for (int i = dst_dim - 1; i >= 0; --i) {
       body = For(dst_vars[i], 0, op.dst->shape[i], ForKind::kUnrolled, body,
-                 std::nullopt,
-                 {{tirx::attr::pragma_unroll_explicit, Bool(false)}});
+                 std::nullopt);
     }
     if (can_pack) {
       body = SeqStmt({AllocBuffer(packed_buffer), body});
@@ -910,18 +907,15 @@ template <typename Impl> struct ReduceLowerer {
                                    src_load),
                 red_indices);
 
-            reduce_local =
-                For(inner_var->var, 0, halved_extent, ForKind::kUnrolled,
-                    reduce_local, std::nullopt,
-                    {{tirx::attr::pragma_unroll_explicit, Bool(false)}});
+            reduce_local = For(inner_var->var, 0, halved_extent,
+                               ForKind::kUnrolled, reduce_local, std::nullopt);
 
             for (int i = static_cast<int>(src_layout->OutputDim()) - 2; i >= 0;
                  --i) {
               reduce_local =
                   For(src_var_compressed[i]->var, 0,
                       src_var_compressed[i]->dom->extent, ForKind::kUnrolled,
-                      reduce_local, std::nullopt,
-                      {{tirx::attr::pragma_unroll_explicit, Bool(false)}});
+                      reduce_local, std::nullopt);
             }
             local_body.push_back(reduce_local);
 
@@ -953,10 +947,9 @@ template <typename Impl> struct ReduceLowerer {
 
         for (int i = static_cast<int>(src_layout->OutputDim()) - 1; i >= 0;
              --i) {
-          reduce_local = For(
-              src_var_compressed[i]->var, 0, src_var_compressed[i]->dom->extent,
-              ForKind::kUnrolled, reduce_local, std::nullopt,
-              {{tirx::attr::pragma_unroll_explicit, Bool(false)}});
+          reduce_local = For(src_var_compressed[i]->var, 0,
+                             src_var_compressed[i]->dom->extent,
+                             ForKind::kUnrolled, reduce_local, std::nullopt);
         }
         stmts.push_back(reduce_local);
       }

--- a/src/transform/loop_partition.cc
+++ b/src/transform/loop_partition.cc
@@ -173,7 +173,6 @@ private:
       }
       For new_for = GetRef<For>(node);
       auto for_ptr = new_for.CopyOnWrite();
-      for_ptr->annotations.Set(tirx::attr::pragma_unroll_explicit, Bool(false));
       for_ptr->kind = ForKind::kUnrolled;
       return new_for;
     }

--- a/src/transform/unroll_loop.cc
+++ b/src/transform/unroll_loop.cc
@@ -66,7 +66,7 @@ struct UnrollLoopConfigNode
         .def_ro(
             "explicit_unroll", &UnrollLoopConfigNode::explicit_unroll,
             "Whether to explicitly unroll the loop instead of setting a pragma",
-            refl::DefaultValue(true))
+            refl::DefaultValue(false))
         .def_ro(
             "unroll_local_access", &UnrollLoopConfigNode::unroll_local_access,
             "Whether to always unroll local access", refl::DefaultValue(false));
@@ -178,6 +178,14 @@ public:
     Stmt stmt = StmtExprMutator::VisitStmt_(op);
     op = stmt.as<ForNode>();
     int value = GetTripCount(op);
+
+    // Whether to explicitly unroll.
+    bool explicit_unroll = explicit_unroll_;
+    if (auto attr = op->annotations.Get(tirx::attr::pragma_unroll_explicit)) {
+      explicit_unroll =
+          static_cast<bool>(Downcast<Integer>(attr.value())->value);
+    }
+
     // condition for auto unroll
     bool auto_unroll =
         (op->kind == ForKind::kSerial && value >= 0 &&
@@ -187,9 +195,9 @@ public:
                                   value <= auto_max_extent_);
 
     if (op->kind == ForKind::kUnrolled) {
-      if (explicit_unroll_) {
+      if (explicit_unroll) {
         ICHECK_GE(value, 0)
-            << "Cannot unroll non-constant loop " << explicit_unroll_;
+            << "Cannot unroll non-constant loop " << explicit_unroll;
       }
       auto_unroll = true;
     }
@@ -208,7 +216,7 @@ public:
       normal_loop_depth_ += 1;
     }
 
-    if ((auto_unroll && explicit_unroll_) ||
+    if ((auto_unroll && explicit_unroll) ||
         // unroll loops with extent = 1, no matter how many steps in body
         (0 <= value && value <= auto_max_extent_ && auto_max_extent_ == 1)) {
       return Unroll(op);

--- a/testing/python/language/test_tilelang_language_atomic.py
+++ b/testing/python/language/test_tilelang_language_atomic.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 import tilelang.testing
 import tilelang.layout
@@ -408,7 +410,10 @@ def test_tma_atomic_add_splits_32b_swizzle_box():
     artifact = lower_tma_atomic_add(T.float32, shape=(16, 24))
     descriptor_args = get_tma_atomic_add_descriptor_args(artifact)
     assert descriptor_args[-3].value == 1
-    assert artifact.kernel_source.count("tma_store_add") == 3
+    assert re.search(
+        r"for \(int \w+ = 0; \w+ < 3; \+\+\w+\) \{\n\s*tl::tma_store_add",
+        artifact.kernel_source,
+    )
 
 
 def test_tma_atomic_add_rejects_pre_hopper_target():

--- a/testing/python/layout/test_tilelang_cute.py
+++ b/testing/python/layout/test_tilelang_cute.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 import tilelang.testing
@@ -1008,7 +1010,7 @@ def test_decoder_preserves_input_shape():
 #   (j % 8) + ((i % 8) ^ ((j // 8) % 8)) * 8 + i * 64 + (j // 64) * 4096
 # ToCuteComposedLayout decodes it to Sw<3,4,3> and LowerBulk drives a swizzled
 # TMA load; the box truncates at the first non-contiguous global mode so the
-# rest replays as 8 unrolled tma_load calls.
+# rest replays as an 8-iteration tma_load loop.
 # ---------------------------------------------------------------------------
 @tilelang.testing.requires_cuda
 @tilelang.testing.requires_cuda_compute_version_ge(9, 0)
@@ -1039,7 +1041,7 @@ def test_tma_load_with_explicit_swizzled_layout():
 
     kernel = tilelang.compile(copy_swizzled, out_idx=[1])
     src = kernel.get_kernel_source()
-    assert src.count("tma_load(") == 8, "expected 8 (unrolled) TMA loads"
+    assert re.search(r"for \(int \w+ = 0; \w+ < 8; \+\+\w+\) \{\n\s*tl::tma_load\(", src), "expected an 8-iteration TMA load loop"
 
     ii = torch.arange(M, device="cuda").view(M, 1)
     jj = torch.arange(N, device="cuda").view(1, N)

--- a/testing/python/transform/test_tilelang_transform_unroll_loop.py
+++ b/testing/python/transform/test_tilelang_transform_unroll_loop.py
@@ -2,6 +2,7 @@ import tilelang
 from tilelang import tvm
 from tvm.script import ir as I
 from tvm.script import tirx as T
+from tvm.tirx.stmt_functor import post_order_visit
 
 
 def test_unroll_decl_buffer_defs_are_fresh():
@@ -9,7 +10,7 @@ def test_unroll_decl_buffer_defs_are_fresh():
     class Before:
         @T.prim_func
         def main(A: T.Buffer((16,), "float32")):
-            for i in T.unroll(2):
+            for i in T.unroll(2, annotations={"pragma_unroll_explicit": True}):
                 A_flat = T.decl_buffer((16,), "float32", data=A.data)
                 A_flat[0] = T.float32(i)
 
@@ -27,5 +28,51 @@ def test_unroll_decl_buffer_defs_are_fresh():
     assert stores[1].buffer.same_as(decls[1].buffer)
 
 
+def test_unroll_explicit_loops_only():
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def main(A: T.Buffer((4,), "int32")):
+            for i in T.unroll(2, annotations={"pragma_unroll_explicit": True}):
+                A[i] = i
+            for j in T.unroll(2, annotations={"pragma_unroll_explicit": False}):
+                A[j + 2] = j
+
+    after = tilelang.transform.UnrollLoop()(Before)
+    body = after["main"].body
+
+    assert isinstance(body, tvm.tirx.SeqStmt)
+    assert isinstance(body.seq[0], tvm.tirx.BufferStore)
+    assert isinstance(body.seq[1], tvm.tirx.BufferStore)
+    assert isinstance(body.seq[2], tvm.tirx.For)
+    assert body.seq[2].kind == tvm.tirx.ForKind.UNROLLED
+
+
+def test_unroll_explicit_loops_preserves_dynamic_and_factor_loops():
+    @I.ir_module
+    class Before:
+        @T.prim_func
+        def main(n: T.int32, A: T.Buffer((16,), "int32")):
+            for i in T.unroll(2, annotations={"pragma_unroll_explicit": True}):
+                A[i] = i
+            for j in T.unroll(n):
+                A[j] = j
+            for k in T.unroll(8, annotations={"pragma_unroll_factor": 4}):
+                A[k + 8] = k
+
+    after = tilelang.transform.UnrollLoop()(Before)
+    loops = []
+    post_order_visit(
+        after["main"].body,
+        lambda node: loops.append(node) if isinstance(node, tvm.tirx.For) else None,
+    )
+
+    assert [loop.loop_var.name for loop in loops] == ["j", "k"]
+    assert loops[0].kind == tvm.tirx.ForKind.UNROLLED
+    assert int(loops[1].annotations["pragma_unroll_factor"]) == 4
+
+
 if __name__ == "__main__":
     test_unroll_decl_buffer_defs_are_fresh()
+    test_unroll_explicit_loops_only()
+    test_unroll_explicit_loops_preserves_dynamic_and_factor_loops()

--- a/tilelang/cuda/pipeline.py
+++ b/tilelang/cuda/pipeline.py
@@ -107,6 +107,13 @@ def CUDAPassPipelineBodyPrologue(mod: IRModule, target: Target) -> IRModule:
     # pipeline body extraction focused on canonical SeqStmt bodies.
     mod = tilelang.transform.IfStmtBinding()(mod)
 
+    # Expand only explicitly requested unroll loops before pipeline planning
+    # and fold the constants exposed by substitution. This makes their
+    # copy/compute statements individual scheduling units.
+    mod = tilelang.transform.UnrollLoop()(mod)
+    # Simplify the unrolled loop bodies.
+    mod = tilelang.transform.Simplify()(mod)
+
     # Run pipeline planning and software-pipeline rewriting before layout
     # inference so inferred layouts see the final pipelined structure directly.
     mod = tilelang.transform.PipelinePlanning()(mod)

--- a/tilelang/language/loop.py
+++ b/tilelang/language/loop.py
@@ -277,19 +277,23 @@ def unroll(
         else:
             start = 0
 
-    # Ensure annotations has {"pragma_unroll_explicit": True} by default
     if annotations is None:
-        annotations = {"pragma_unroll_explicit": explicit}
+        annotations = dict()
     else:
-        # Add "pragma_unroll_explicit": True if not already present
         annotations = dict(annotations)
-        annotations.setdefault("pragma_unroll_explicit", explicit)
+
+    if explicit:
+        annotations["pragma_unroll_explicit"] = True
+    else:
+        explicit = annotations.get("pragma_unroll_explicit", False)
 
     if unroll_factor is not None:
-        # check pragma_unroll_explicit must be False
-        if annotations.get("pragma_unroll_explicit", True):
-            raise ValueError("pragma_unroll_explicit must be True when unroll_factor is not None")
-        annotations.update({"pragma_unroll_factor": unroll_factor})
+        annotations["pragma_unroll_factor"] = unroll_factor
+    else:
+        unroll_factor = annotations.get("pragma_unroll_factor")
+
+    if explicit and unroll_factor is not None:
+        raise ValueError("T.unroll's explicit and unroll_factor params are mutually exclusive.")
 
     if step is None or step_is_one:
         return tb_tir.unroll(start, stop, annotations=annotations)

--- a/tilelang/language/tir/ir.py
+++ b/tilelang/language/tir/ir.py
@@ -95,13 +95,10 @@ def unroll(start: PrimExpr, stop: PrimExpr = None, *, annotations: dict[str, Any
     res : frame.ForFrame
         The ForFrame.
     """
-    # Ensure annotations has {"pragma_unroll_explicit": True} by default
     if annotations is None:
-        annotations = {"pragma_unroll_explicit": False}
+        annotations = dict()
     else:
-        # Add "pragma_unroll_explicit": True if not already present
         annotations = dict(annotations)
-        annotations.setdefault("pragma_unroll_explicit", False)
     return _ir.unroll(start=start, stop=stop, annotations=annotations)
 
 

--- a/tilelang/tools/pass_visualizer/core.py
+++ b/tilelang/tools/pass_visualizer/core.py
@@ -98,7 +98,8 @@ def build_pass_stages(target: Target) -> list[tuple[str, object]]:
     object callable as ``transform(mod) -> mod``. Conditional passes are resolved
     here so the returned list reflects what actually runs for this target/config.
 
-    Matches CUDAPassPipelineBodyPrologue (tilelang/cuda/pipeline.py:68-137).
+    Matches CUDAPassPipelineBodyPrologue in tilelang/cuda/pipeline.py, except
+    for LayoutVisual, which only emits visualization side effects.
     """
     stages: list[tuple[str, object]] = []
 
@@ -122,15 +123,17 @@ def build_pass_stages(target: Target) -> list[tuple[str, object]]:
 
     stages.append(("LowerBlackwell2SM", tilelang.cuda.transform.LowerBlackwell2SM()))
     stages.append(("IfStmtBinding", tilelang.transform.IfStmtBinding()))
+    stages.append(("UnrollLoop", tilelang.transform.UnrollLoop()))
+    stages.append(("Simplify", tilelang.transform.Simplify()))
     stages.append(("PipelinePlanning", tilelang.transform.PipelinePlanning()))
     stages.append(("InjectSoftwarePipeline", tilelang.transform.InjectSoftwarePipeline()))
     stages.append(("Simplify", tilelang.transform.Simplify()))
 
-    # Infer memory layouts for fragments and shared memory (pipeline.py:113).
+    # Infer memory layouts for fragments and shared memory.
     stages.append(("LayoutInference", tilelang.transform.LayoutInference()))
 
-    # --- Post-LayoutInference lowering (pipeline.py:117-137) ---
-    # LayoutVisual (pipeline.py:115) is skipped: it only visualizes, not a transform.
+    # --- Post-LayoutInference lowering ---
+    # LayoutVisual is skipped: it only visualizes, not a transform.
     stages.append(("LowerTileOp", tilelang.transform.LowerTileOp()))
     stages.append(("LowerL2Persistent", tilelang.cuda.transform.LowerL2Persistent()))
     stages.append(("DecoupleTypeCast", tilelang.transform.DecoupleTypeCast()))


### PR DESCRIPTION
This PR refactors the `pragma_unroll_explicit` behavior: by default, it is off now. Nothing in the compiler needs explicit unrolling to function correctly. And cicc will unroll the code for you with `#pragma unroll`, which does not need explicit unrolling at all. So I decide to leverage `T.unroll(explicit=True)` for program pre-processing to facilitate pipeline planning: the software pipeliner and warp-specializer want to see IR nodes flattened for easier scheduling. So I added an UnrollLoop pass before the scheduling in the pass pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Disabled explicit unrolling by default.
- Reused `T.unroll(explicit=True)` during preprocessing.
- Added `UnrollLoop` before pipeline planning.
- Updated loop annotation handling and unroll validation.
- Updated CUDA pipeline and unroll tests.
- Adjusted TMA tests for emitted loops.

## C++ style / lint notes

- The PR does not modify rules in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) CI step remains relevant.
- No correctness or build issues are identified.
- TLCPP003/TLCPP004 findings remain advisory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->