### PR TITLE
[BugFix] Reject arch-less CUDA target instead of silent sm_50 (#1049)

### DIFF
--- a/testing/python/target/test_tilelang_target.py
+++ b/testing/python/target/test_tilelang_target.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import tilelang
+import tilelang.testing
 from tvm.target import Target
 import tilelang.backend.target as target_registry
 from tilelang.backend.execution_backend import (
@@ -21,6 +22,36 @@ from tilelang.backend.target import (
 
 def test_tilelang_does_not_export_target_wrapper():
     assert not hasattr(tilelang, "Target")
+
+
+def test_cuda_auto_without_gpu_rejects_instead_of_silent_sm50(monkeypatch):
+    # CUDA toolkit present but no GPU: auto detection must raise an actionable
+    # error, NOT return a bare "cuda" target (which TVM fills to sm_50).
+    from tilelang.cuda import target as cuda_target
+
+    monkeypatch.setattr(cuda_target, "check_cuda_availability", lambda: True)
+    monkeypatch.setattr(cuda_target, "_detect_torch_cuda_arch", lambda: None)
+    with pytest.raises(ValueError, match="arch"):
+        cuda_target._detect_cuda_target()
+
+
+def test_cuda_auto_with_gpu_returns_concrete_arch(monkeypatch):
+    from tilelang.cuda import target as cuda_target
+
+    monkeypatch.setattr(cuda_target, "check_cuda_availability", lambda: True)
+    monkeypatch.setattr(cuda_target, "_detect_torch_cuda_arch", lambda: "sm_90a")
+    target = cuda_target._detect_cuda_target()
+    assert isinstance(target, Target)
+    assert str(target.attrs["arch"]) == "sm_90a"
+
+
+def test_explicit_cuda_target_without_gpu_rejects(monkeypatch):
+    # Explicit target="cuda" without a GPU must also reject, not silently sm_50.
+    from tilelang.cuda import target as cuda_target
+
+    monkeypatch.setattr(cuda_target, "_detect_torch_cuda_arch", lambda: None)
+    with pytest.raises(ValueError, match="arch"):
+        determine_target("cuda", return_object=True)
 
 
 def test_default_target_env_accepts_json_string(monkeypatch):
@@ -152,3 +183,7 @@ def test_execution_backend_registry_rejects_removed_dlpack_backend():
 
     with pytest.raises(ValueError, match="Invalid execution backend 'dlpack'"):
         resolve_execution_backend("dlpack", target)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/target/test_tilelang_target.py
+++ b/testing/python/target/test_tilelang_target.py
@@ -18,6 +18,52 @@ def test_tilelang_does_not_export_target_wrapper():
     assert not hasattr(tilelang, "Target")
 
 
+@pytest.fixture
+def cuda_target_module(monkeypatch):
+    """``tilelang.cuda.target`` with the CUDA detection branch forced on.
+
+    ``_detect_cuda_target`` returns None up front when ``torch.version.hip`` is
+    set, so on a ROCm runner it never reaches the arch logic these tests cover.
+    Pinning hip to None keeps the assertions about that logic runner-independent.
+    """
+    import torch
+
+    from tilelang.cuda import target as cuda_target
+
+    monkeypatch.setattr(torch.version, "hip", None, raising=False)
+    return cuda_target
+
+
+def test_cuda_auto_without_gpu_rejects_instead_of_silent_sm50(monkeypatch, cuda_target_module):
+    # CUDA toolkit present but no GPU: auto detection must raise an actionable
+    # error, NOT return a bare "cuda" target (which TVM fills to sm_50).
+    cuda_target = cuda_target_module
+
+    monkeypatch.setattr(cuda_target, "check_cuda_availability", lambda: True)
+    monkeypatch.setattr(cuda_target, "_detect_torch_cuda_arch", lambda: None)
+    with pytest.raises(ValueError, match="arch"):
+        cuda_target._detect_cuda_target()
+
+
+def test_cuda_auto_with_gpu_returns_concrete_arch(monkeypatch, cuda_target_module):
+    cuda_target = cuda_target_module
+
+    monkeypatch.setattr(cuda_target, "check_cuda_availability", lambda: True)
+    monkeypatch.setattr(cuda_target, "_detect_torch_cuda_arch", lambda: "sm_90a")
+    target = cuda_target._detect_cuda_target()
+    assert isinstance(target, Target)
+    assert str(target.attrs["arch"]) == "sm_90a"
+
+
+def test_explicit_cuda_target_without_gpu_rejects(monkeypatch, cuda_target_module):
+    # Explicit target="cuda" without a GPU must also reject, not silently sm_50.
+    cuda_target = cuda_target_module
+
+    monkeypatch.setattr(cuda_target, "_detect_torch_cuda_arch", lambda: None)
+    with pytest.raises(ValueError, match="arch"):
+        determine_target("cuda", return_object=True)
+
+
 def test_default_target_env_accepts_json_string(monkeypatch):
     monkeypatch.setenv("TILELANG_DEFAULT_TARGET", '{"kind": "cuda", "arch": "sm_100f", "code": ["sm_100a", "sm_103a"]}')
 

--- a/tilelang/cuda/target.py
+++ b/tilelang/cuda/target.py
@@ -38,14 +38,21 @@ def _detect_torch_cuda_arch() -> str | None:
     return f"sm_{nvcc.get_target_arch(cap)}" if cap else None
 
 
-def _cuda_target_from_arch(arch: str | None) -> Target | str:
-    """Build a CUDA target while preserving the legacy bare string fallback."""
+def _cuda_target_from_arch(arch: str | None) -> Target:
+    """Build a concrete-arch CUDA target, refusing a bare "cuda" (TVM would
+    silently fill arch=sm_50 and mis-compile). Guards auto-detect and explicit
+    target="cuda" alike; an explicit arch compiles without a GPU."""
     if arch is None:
-        return "cuda"
+        raise ValueError(
+            "CUDA target has no arch and no GPU is available to detect one. "
+            "Pin the arch for your target GPU, e.g. "
+            "tilelang.compile(func, target={'kind': 'cuda', 'arch': 'sm_90a'}) or "
+            'TILELANG_DEFAULT_TARGET=\'{"kind": "cuda", "arch": "sm_90a"}\'.'
+        )
     return Target({"kind": "cuda", "arch": arch})
 
 
-def _detect_cuda_target() -> Target | str | None:
+def _detect_cuda_target() -> Target | None:
     import torch
 
     if torch.version.hip is not None:
@@ -53,15 +60,13 @@ def _detect_cuda_target() -> Target | str | None:
     if not check_cuda_availability():
         return None
 
-    arch = _detect_torch_cuda_arch()
-    return _cuda_target_from_arch(arch)
+    return _cuda_target_from_arch(_detect_torch_cuda_arch())
 
 
 def normalize_cuda_target(target: TargetLike) -> Target | None:
     if not isinstance(target, str) or target.strip() != "cuda":
         return None
-    normalized = _cuda_target_from_arch(_detect_torch_cuda_arch())
-    return normalized if isinstance(normalized, Target) else None
+    return _cuda_target_from_arch(_detect_torch_cuda_arch())
 
 
 def _with_cutedsl_key(target: Target | str) -> Target:


### PR DESCRIPTION
`tilelang/cuda/target.py:41` returned a bare `"cuda"` string when no arch could be
detected. TVM then fills `sm_50`, so a headless machine silently compiles for
Maxwell instead of failing.

Measured on an H20 box (same wheel, only `CUDA_VISIBLE_DEVICES` differs):

```
=== WITH GPU ===          === NO GPU (before) ===
auto -> arch=sm_90a       auto -> arch=sm_50
cuda -> arch=sm_90a       cuda -> arch=sm_50
```

`_cuda_target_from_arch(None)` now raises with the arch-pinning syntax instead.
An explicit arch still compiles with no GPU present, which is what #1049 asks for:

```
=== NO GPU (after) ===
auto     -> RAISED ValueError: CUDA target has no arch and no GPU is available to detect one...
cuda     -> RAISED ValueError: CUDA target has no arch and no GPU is available to detect one...
explicit -> cuda arch=sm_90a
```

Tests: 2 added in `testing/python/target/test_tilelang_target.py`, both fail before
the change. `testing/python/target` + `testing/python/tools` on H20: 8 failed /73
passed before, 6 failed /75 passed after, no new failures (the 6 are pre-existing
cutedsl cases).

Fixes #1049


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Require a concrete CUDA architecture for automatic detection and `target="cuda"`.
- Raise an actionable `ValueError` when no architecture is available.
- Preserve headless compilation when an explicit CUDA architecture is provided.
- Prevent TVM from silently defaulting to `sm_50`.
- Add tests for GPU detection, missing architectures, and explicit CUDA targets without a GPU.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->