### PR TITLE
[Testing] Gate CUDA-only tests so non-CUDA backends can run the suite

### DIFF
--- a/testing/python/components/test_storage_rewrite_detect_inplace.py
+++ b/testing/python/components/test_storage_rewrite_detect_inplace.py
@@ -51,6 +51,7 @@ def _get_device_kernel_script(detect_inplace: bool) -> str:
     return artifact.kernel_source
 
 
+@tilelang.testing.requires_cuda
 def test_storage_rewrite_detect_inplace_toggle():
     script_off = _get_device_kernel_script(detect_inplace=False)
     script_on = _get_device_kernel_script(detect_inplace=True)

--- a/testing/python/issue/test_tilelang_issue_2123.py
+++ b/testing/python/issue/test_tilelang_issue_2123.py
@@ -60,6 +60,7 @@ def test_issue_2123_atomic_load_lower_access_ptr_direct():
     _assert_access_ptr_lowered(lowered)
 
 
+@tilelang.testing.requires_cuda
 def test_issue_2123_atomic_load_lower_access_ptr_pipeline():
     target = tvm.target.Target("cuda", host="llvm")
     func = issue_2123_atomic_load_repro(4).with_attr("global_symbol", "main")

--- a/testing/python/issue/test_tilelang_issue_2529.py
+++ b/testing/python/issue/test_tilelang_issue_2529.py
@@ -33,6 +33,7 @@ def _lower_source(n, block, annotate_linear=False):
     return artifact.kernel_source
 
 
+@tilelang.testing.requires_cuda
 def test_tma_store_selection_uses_copy_bounds():
     full_tile_source = _lower_source(1024, 256)
     # The unannotated rank-1 tail exercises descriptor layout inference.

--- a/testing/python/issue/test_tilelang_issue_2554.py
+++ b/testing/python/issue/test_tilelang_issue_2554.py
@@ -5,6 +5,7 @@ import tilelang.language as T
 import tilelang.testing
 
 
+@tilelang.testing.requires_cuda
 def test_runtime_unknown_sign_vector_negative_index_load():
     @T.prim_func
     def main(A: T.Tensor((1024,), T.float32), B: T.Tensor((4, 4), T.float32)):
@@ -30,6 +31,7 @@ def test_runtime_unknown_sign_vector_negative_index_load():
     torch.testing.assert_close(b, expected)
 
 
+@tilelang.testing.requires_cuda
 def test_runtime_unknown_sign_vector_negative_index_store():
     @T.prim_func
     def main(B: T.Tensor((4, 4), T.float32), A: T.Tensor((1024,), T.float32)):

--- a/testing/python/jit/test_tilelang_jit_diagnostics.py
+++ b/testing/python/jit/test_tilelang_jit_diagnostics.py
@@ -206,6 +206,7 @@ def test_cuda_compile_callback_uses_fatbin_for_multiple_target_code(monkeypatch)
     assert captured["arch"] == ["-gencode", "arch=compute_100f,code=[sm_100a,sm_103a]"]
 
 
+@tilelang.testing.requires_cuda
 def test_jit_compile_reports_timeout_for_hanging_nvcc(monkeypatch, tmp_path, caplog, capture_tilelang_logs):
     import tilelang
     from tilelang.contrib import nvcc
@@ -306,6 +307,7 @@ def test_kernel_cache_miss_compile_logs_context(monkeypatch, tmp_path, caplog, c
     assert any("cache_diag_kernel" in message and "sm_120" in message for message in messages)
 
 
+@tilelang.testing.requires_cuda
 def test_explicit_cuda_arch_source_generation_probe():
     import tilelang
     from tilelang import tvm

--- a/testing/python/kernel/test_tilelang_kernel_gemm.py
+++ b/testing/python/kernel/test_tilelang_kernel_gemm.py
@@ -153,7 +153,8 @@ def test_gemm_bf16bf16f32_nn():
     )
 
 
-@tilelang.testing.requires_cuda_or_cdna
+# tfloat32 is an NVIDIA-only dtype and has no CDNA lowering.
+@tilelang.testing.requires_cuda
 def test_gemm_f32f32f32_nn():
     run_gemm(
         512,
@@ -221,7 +222,8 @@ def test_gemm_f64f64f64_nt():
     run_gemm(512, 512, 512, False, True, T.float64, T.float64, T.float64, 64, 32, 16)
 
 
-@tilelang.testing.requires_cuda_or_cdna
+# tfloat32 is an NVIDIA-only dtype and has no CDNA lowering.
+@tilelang.testing.requires_cuda
 def test_gemm_f32f32f32_nt():
     run_gemm(
         512,

--- a/testing/python/language/test_tilelang_cast_rounding.py
+++ b/testing/python/language/test_tilelang_cast_rounding.py
@@ -181,6 +181,7 @@ def _lower_rs_prim_func(target_dtype: str, arch: str, *, enable_device_compile: 
         )
 
 
+@tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
     "target_dtype,expected",
     [
@@ -194,6 +195,7 @@ def test_cast_rs_fp16_bf16_codegen(target_dtype, expected):
     assert expected in artifact.kernel_source
 
 
+@tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
     "target_dtype,expected",
     [
@@ -209,6 +211,7 @@ def test_cast_rs_fp16_bf16_packed_codegen(target_dtype, expected):
     assert expected in artifact.kernel_source
 
 
+@tilelang.testing.requires_cuda
 @pytest.mark.parametrize("target_dtype", ["float16", "bfloat16"])
 def test_cast_rs_fp16_bf16_rejects_sat_false(target_dtype):
     M = 256
@@ -231,6 +234,7 @@ def test_cast_rs_fp16_bf16_rejects_sat_false(target_dtype):
         tilelang.lower(main, target=target)
 
 
+@tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
     "target_dtype,expected",
     [

--- a/testing/python/language/test_tilelang_language_atomic.py
+++ b/testing/python/language/test_tilelang_language_atomic.py
@@ -380,6 +380,7 @@ def test_tma_atomic_add_32b_swizzle_runtime():
     torch.testing.assert_close(out, torch.ones_like(out), rtol=0, atol=0)
 
 
+@tilelang.testing.requires_cuda
 @pytest.mark.parametrize("dtype", [T.int16, T.int64, T.float64, T.float32x2])
 def test_tma_atomic_add_rejects_unsupported_dtype(dtype):
     with pytest.raises(
@@ -389,12 +390,14 @@ def test_tma_atomic_add_rejects_unsupported_dtype(dtype):
         lower_tma_atomic_add(dtype)
 
 
+@tilelang.testing.requires_cuda
 @pytest.mark.parametrize("dtype", [T.float16, T.bfloat16, T.float32, T.int32, T.uint32, T.uint64])
 def test_tma_atomic_add_accepts_ptx_dtype(dtype):
     artifact = lower_tma_atomic_add(dtype)
     assert "tma_store_add" in artifact.kernel_source
 
 
+@tilelang.testing.requires_cuda
 def test_tma_atomic_add_uint64_uses_linear_layout():
     artifact = lower_tma_atomic_add(T.uint64)
     descriptor_args = get_tma_atomic_add_descriptor_args(artifact)
@@ -404,6 +407,7 @@ def test_tma_atomic_add_uint64_uses_linear_layout():
     assert descriptor_args[-3].value == 0
 
 
+@tilelang.testing.requires_cuda
 def test_tma_atomic_add_splits_32b_swizzle_box():
     artifact = lower_tma_atomic_add(T.float32, shape=(16, 24))
     descriptor_args = get_tma_atomic_add_descriptor_args(artifact)
@@ -411,6 +415,7 @@ def test_tma_atomic_add_splits_32b_swizzle_box():
     assert artifact.kernel_source.count("tma_store_add") == 3
 
 
+@tilelang.testing.requires_cuda
 def test_tma_atomic_add_rejects_pre_hopper_target():
     with pytest.raises(
         tvm.error.InternalError,
@@ -419,6 +424,7 @@ def test_tma_atomic_add_rejects_pre_hopper_target():
         lower_tma_atomic_add(T.float32, arch="sm_80")
 
 
+@tilelang.testing.requires_cuda
 def test_tma_atomic_add_rejects_unencodable_explicit_layout():
     with pytest.raises(
         tvm.error.InternalError,

--- a/testing/python/language/test_tilelang_language_eager_jit.py
+++ b/testing/python/language/test_tilelang_language_eager_jit.py
@@ -44,6 +44,7 @@ def test_jit2_gemm():
     torch.testing.assert_close(C, C_ref, atol=1e-2, rtol=1e-2)
 
 
+@tilelang.testing.requires_cuda
 def test_jit2_gemm_ptr():
     @tilelang.jit
     def gemm_ptr(

--- a/testing/python/language/test_tilelang_language_float4_e2m1_unpacked_dtype.py
+++ b/testing/python/language/test_tilelang_language_float4_e2m1_unpacked_dtype.py
@@ -75,6 +75,7 @@ def _decode_tcgen05_formats(desc: int) -> tuple[int, int]:
     return (desc >> 7) & 0x7, (desc >> 10) & 0x7
 
 
+@tilelang.testing.requires_cuda
 def test_tcgen05_instr_desc_fp4_unpacked_x_fp8():
     fp4 = DataType("custom[float4_e2m1_unpacked]8")
     fp8 = DataType("float8_e4m3fn")
@@ -85,6 +86,7 @@ def test_tcgen05_instr_desc_fp4_unpacked_x_fp8():
     assert b_format == 0
 
 
+@tilelang.testing.requires_cuda
 def test_tcgen05_blockscaled_instr_desc_mxfp4_unpacked_x_mxfp8():
     fp4 = DataType("custom[float4_e2m1_unpacked]8")
     fp8 = DataType("float8_e4m3fn")

--- a/testing/python/language/test_tilelang_language_reduce.py
+++ b/testing/python/language/test_tilelang_language_reduce.py
@@ -502,6 +502,7 @@ def test_reduce(op, dtype, M, N, src_scope, dst_scope, threads, batch):
     torch.testing.assert_close(B, _ref(A, op), atol=tol, rtol=tol)
 
 
+@tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
     ("op", "packed_op"),
     [("sum", "add2"), ("max", "max2"), ("min", "min2")],
@@ -523,6 +524,7 @@ def test_reduce_local_packed_codegen(op, packed_op):
     assert f"tl::{packed_op}" in artifact.kernel_source
 
 
+@tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
     ("op", "packed_op"),
     [("sum", "add2"), ("max", "max2"), ("min", "min2")],
@@ -546,6 +548,7 @@ def test_reduce_local_noncontiguous_dim_packed_codegen(op, packed_op):
     assert f"tl::{packed_op}" in artifact.kernel_source
 
 
+@tilelang.testing.requires_cuda
 @pytest.mark.parametrize(
     ("op", "packed_op"),
     [("sum", "add2"), ("max", "max2"), ("min", "min2")],

--- a/testing/python/language/test_tilelang_language_tma_1d.py
+++ b/testing/python/language/test_tilelang_language_tma_1d.py
@@ -1,6 +1,7 @@
 import torch
 import tilelang
 import tilelang.language as T
+import tilelang.testing
 
 
 def ref_program(x, y):
@@ -54,6 +55,7 @@ def run_elementwise_add(M, N):
         assert "tma_load" in code and "CUtensorMap" in code
 
 
+@tilelang.testing.requires_cuda
 def test_tilelang_language_tma_1d():
     run_elementwise_add(128, 128)
     run_elementwise_add(256, 128)

--- a/testing/python/language/test_tilelang_language_tma_copy.py
+++ b/testing/python/language/test_tilelang_language_tma_copy.py
@@ -472,6 +472,7 @@ def run_fp4_tma_copy_roundtrip():
     assert torch.equal(b.view(torch.int8), a)
 
 
+@tilelang.testing.requires_cuda
 def test_fp4_unpacksmem_tma_descriptor_uses_align16b():
     program = fp4_tma_copy_unpacked_smem_load()
     artifact = tilelang.lower(
@@ -487,6 +488,7 @@ def test_fp4_unpacksmem_tma_descriptor_uses_align16b():
     assert 'T.call_packed("__tvm_tensormap_create_tiled", A_desc, 14,' in host_ir
 
 
+@tilelang.testing.requires_cuda
 def test_fp4_unpacksmem_tma_store_is_rejected():
     program = fp4_tma_copy_unpacked_smem_store()
     with pytest.raises(tvm.TVMError, match="only supports float4_e2m1_unpacked as an FP4 unpack load"):
@@ -497,6 +499,7 @@ def test_fp4_unpacksmem_tma_store_is_rejected():
         )
 
 
+@tilelang.testing.requires_cuda
 def test_copy_prefer_tma_lowers_as_synchronous_tma_load():
     @T.prim_func
     def main(x: T.Tensor((128, 32), T.float32)):
@@ -519,6 +522,7 @@ def test_copy_prefer_tma_lowers_as_synchronous_tma_load():
     assert ".wait(0)" in device_source
 
 
+@tilelang.testing.requires_cuda
 def test_device_bound_pointer_keeps_descriptorless_bulk1d():
     @T.prim_func
     def main(
@@ -544,6 +548,7 @@ def test_device_bound_pointer_keeps_descriptorless_bulk1d():
     assert "CUtensorMap" not in device_source
 
 
+@tilelang.testing.requires_cuda
 def test_device_bound_descriptor_tma_is_rejected_when_ws_disabled():
     @T.prim_func
     def main(src_ptrs: T.Tensor((1,), T.ptr)):

--- a/testing/python/target/test_tilelang_rocm_target.py
+++ b/testing/python/target/test_tilelang_rocm_target.py
@@ -114,17 +114,21 @@ def test_carver_rejects_unsupported_rdna_generations(monkeypatch):
     def fake_cdna(target):
         return ("cdna", target)
 
+    # gfx11 and gfx12 are the only generations `target_is_rdna` reports, so the
+    # unsupported-generation guard is unreachable without forcing the value.
     monkeypatch.setattr(arch_mod, "CDNA", fake_cdna)
-    with pytest.raises(ValueError, match="gfx11 targets only"):
+    monkeypatch.setattr(arch_mod, "target_get_rdna_generation", lambda target: 10)
+    with pytest.raises(ValueError, match="gfx11/gfx12 targets only"):
         arch_mod.get_arch(_hip_target("gfx1200"))
 
 
 @tilelang.testing.requires_rocm
-def test_rdna_device_model_rejects_gfx12_before_device_probe():
-    from tilelang.carver.arch.rdna import RDNA
+def test_rdna_device_model_rejects_unsupported_generation_before_device_probe(monkeypatch):
+    from tilelang.carver.arch import rdna as rdna_mod
 
-    with pytest.raises(ValueError, match="gfx11 targets only"):
-        RDNA(_hip_target("gfx1200"))
+    monkeypatch.setattr(rdna_mod, "target_get_rdna_generation", lambda target: 10)
+    with pytest.raises(ValueError, match="gfx11/gfx12 targets only"):
+        rdna_mod.RDNA(_hip_target("gfx1200"))
 
 
 @tilelang.testing.requires_rocm
@@ -132,11 +136,12 @@ def test_rdna_tensor_instruction_lookup_is_generation_aware():
     from tilelang.carver.arch.rdna import RDNA
 
     arch = RDNA.__new__(RDNA)
-    arch.rdna_generation = 11
-    assert arch.get_avaliable_tensorintrin_shapes() == [[16, 16]]
-    assert isinstance(arch.available_tensor_instructions, list)
+    for generation in (11, 12):
+        arch.rdna_generation = generation
+        assert arch.get_avaliable_tensorintrin_shapes() == [[16, 16]]
+        assert isinstance(arch.available_tensor_instructions, list)
 
-    arch.rdna_generation = 12
+    arch.rdna_generation = 10
     with pytest.raises(ValueError, match="Unsupported RDNA generation"):
         arch.get_avaliable_tensorintrin_shapes()
 

--- a/testing/python/tools/test_tilelang_tools_cuda_iket.py
+++ b/testing/python/tools/test_tilelang_tools_cuda_iket.py
@@ -11,6 +11,7 @@ from tilelang import tvm
 from tilelang.cache import _dispatch_map
 from tilelang.env import CacheState
 from tilelang.tools.cuda import iket
+import tilelang.testing
 
 
 _CUDA_POSTPROC = "tilelang_callback_cuda_postproc"
@@ -125,6 +126,7 @@ def test_iket_is_a_cuda_tool_not_a_language_namespace():
     assert iket.__name__ == "tilelang.tools.cuda.iket"
 
 
+@tilelang.testing.requires_cuda
 def test_event_metadata_is_preserved_in_tir_and_injected_source():
     with iket.session():
         kernel = _make_range_kernel()
@@ -140,6 +142,7 @@ def test_event_metadata_is_preserved_in_tir_and_injected_source():
     assert "__iket_range_decl_compute_phase" in source
 
 
+@tilelang.testing.requires_cuda
 def test_float_payload_macro_uses_distinct_temporaries():
     with iket.session(runtime_payloads=True):
         source = _lower_cuda_source(_make_float_payload_kernel())
@@ -161,6 +164,7 @@ def test_float_payload_macro_uses_distinct_temporaries():
     assert "TL_IKET_EVENT_PAYLOAD_F32" in source
 
 
+@tilelang.testing.requires_cuda
 def test_prebuilt_payload_primfunc_enables_runtime_payloads_during_lowering():
     assert not iket.runtime_payloads_enabled()
     kernel = _make_float_payload_kernel()
@@ -180,6 +184,7 @@ def test_prebuilt_payload_primfunc_enables_runtime_payloads_during_lowering():
     assert _event_metadata_bytes(source, "float_value")[12:16] == [13, 0, 0, 0]
 
 
+@tilelang.testing.requires_cuda
 @pytest.mark.parametrize("arch", ["sm_80", "sm_86", "sm_89"])
 def test_cluster_rank_register_is_gated_by_cuda_architecture(arch):
     with iket.session():
@@ -193,6 +198,7 @@ def test_cluster_rank_register_is_gated_by_cuda_architecture(arch):
     assert "%cluster_ctarank" in sm90_source
 
 
+@tilelang.testing.requires_cuda
 def test_prebuilt_primfunc_keeps_metadata_when_session_resets_registry():
     kernel = _make_mark_kernel("parsed_before_session")
     calls = _iket_calls(kernel)
@@ -217,6 +223,7 @@ def test_event_metadata_changes_kernel_cache_identity():
     assert _cache_key(first) != _cache_key(second)
 
 
+@tilelang.testing.requires_cuda
 def test_independently_built_primfuncs_get_module_wide_event_ids():
     first = _make_mark_kernel("module_first").with_attr("global_symbol", "first")
     iket.reset()
@@ -240,6 +247,7 @@ def test_event_name_limit_is_checked_during_primfunc_construction():
         _make_mark_kernel("界" * 11)
 
 
+@tilelang.testing.requires_cuda
 def test_nested_session_keeps_outer_callback_active():
     with iket.session():
         with iket.session():
@@ -309,6 +317,7 @@ def test_session_restores_an_absent_callback():
     tvm_ffi.register_global_func(_CUDA_POSTPROC, f=lambda code, _target: code, override=False)
 
 
+@tilelang.testing.requires_cuda
 def test_session_restores_a_previous_callback():
     def previous(code, _target):
         return "// previous callback\n" + code

--- a/testing/python/transform/test_readonly_param_const_codegen.py
+++ b/testing/python/transform/test_readonly_param_const_codegen.py
@@ -1,6 +1,7 @@
 import tilelang.language as T
 from tilelang.engine.lower import lower
 from tilelang.jit.adapter.utils import match_declare_kernel
+import tilelang.testing
 
 
 def _simple_add_kernel():
@@ -16,6 +17,7 @@ def _simple_add_kernel():
     return main
 
 
+@tilelang.testing.requires_cuda
 def test_codegen_emits_const_for_readonly_params():
     # Lower without device compilation to retrieve CUDA source reliably
     func = _simple_add_kernel()

--- a/testing/python/transform/test_tilelang_transform_fuse_mbarrier_arrive_expect_tx.py
+++ b/testing/python/transform/test_tilelang_transform_fuse_mbarrier_arrive_expect_tx.py
@@ -27,6 +27,7 @@ def _collect_calls(stmt, op_name: str):
     return calls
 
 
+@tilelang.testing.requires_cuda
 def test_fuse_simple_tma_expect_arrive():
     @T.prim_func
     def before(A_desc: T.handle("uint8x128", "grid_constant")):
@@ -52,6 +53,7 @@ def test_fuse_simple_tma_expect_arrive():
     assert len(_collect_calls(main.body, "tirx.ptx_arrive_barrier")) == 0
 
 
+@tilelang.testing.requires_cuda
 def test_fuse_requires_same_barrier():
     @T.prim_func
     def before(A_desc: T.handle("uint8x128", "grid_constant")):
@@ -77,6 +79,7 @@ def test_fuse_requires_same_barrier():
     assert len(_collect_calls(main.body, "tirx.ptx_arrive_barrier")) == 1
 
 
+@tilelang.testing.requires_cuda
 def test_fuse_inside_warp_specialization_scope():
     @T.prim_func
     def before(A_desc: T.handle("uint8x128", "grid_constant")):

--- a/testing/python/transform/test_tilelang_transform_inject_set_max_nreg.py
+++ b/testing/python/transform/test_tilelang_transform_inject_set_max_nreg.py
@@ -35,6 +35,7 @@ def _find_if_with_set_max_nreg(func, then_call, else_call):
     return matches[0]
 
 
+@tilelang.testing.requires_cuda
 def test_inject_set_max_nreg():
     """Test the InjectSetMaxNReg pass"""
 
@@ -94,6 +95,7 @@ def test_inject_set_max_nreg():
     _find_if_with_set_max_nreg(mod["main"], (24, 0), (240, 1))
 
 
+@tilelang.testing.requires_cuda
 def test_raw_set_max_nreg_keeps_legacy_behavior_with_simt_copy():
     """Raw T.set_max_nreg should stay in place instead of being treated as annotation."""
 
@@ -126,6 +128,7 @@ def test_raw_set_max_nreg_keeps_legacy_behavior_with_simt_copy():
     assert len(calls) == 2
 
 
+@tilelang.testing.requires_cuda
 def test_inject_set_max_nreg_no_set_max_nreg():
     """Test the InjectSetMaxNReg pass with no_set_max_nreg"""
 

--- a/testing/python/transform/test_tilelang_transform_layout_inference.py
+++ b/testing/python/transform/test_tilelang_transform_layout_inference.py
@@ -1,3 +1,5 @@
+import re
+
 from tilelang import tvm as tvm
 from tilelang.backend.target import determine_target
 import tilelang as tl
@@ -7,6 +9,11 @@ import pytest
 import torch
 
 auto_target = tvm.target.Target(determine_target("auto"))
+
+
+def _assert_launch_bounds(kernel_source: str, threads: int) -> None:
+    # CUDA emits `__launch_bounds__(N, 1)` while HIP emits `__launch_bounds__(N)`.
+    assert re.search(rf"__launch_bounds__\({threads}\b", kernel_source)
 
 
 @pytest.mark.parametrize(
@@ -119,7 +126,7 @@ def test_static_ragged_copy_minimizes_full_thread_padding():
         artifact = tl.lower(main, target=auto_target, enable_device_compile=False)
 
     kernel_source = str(artifact.kernel_source)
-    assert "__launch_bounds__(128, 1)" in kernel_source
+    _assert_launch_bounds(kernel_source, 128)
     assert "for (int i = 0; i < 5; ++i)" in kernel_source
     assert "threadIdx.x) >> 1)) < 257" in kernel_source
     assert "float2" not in kernel_source
@@ -142,7 +149,7 @@ def test_static_ragged_fp8_copy_minimizes_full_thread_padding():
         artifact = tl.lower(main, target=auto_target, enable_device_compile=False)
 
     kernel_source = str(artifact.kernel_source)
-    assert "__launch_bounds__(128, 1)" in kernel_source
+    _assert_launch_bounds(kernel_source, 128)
     assert "for (int i = 0; i < 3; ++i)" in kernel_source
     assert "fp8_e4_8_t" in kernel_source
     assert "fp8_e4_16_t" not in kernel_source
@@ -164,7 +171,7 @@ def test_static_ragged_copy_allows_1024_elements_384_threads():
         artifact = tl.lower(main, target=auto_target, enable_device_compile=False)
 
     kernel_source = str(artifact.kernel_source)
-    assert "__launch_bounds__(384, 1)" in kernel_source
+    _assert_launch_bounds(kernel_source, 384)
     assert "for (int i = 0; i < 3; ++i)" in kernel_source
     assert "B[((i * 384) + ((int)threadIdx.x))]" in kernel_source
     assert "(((int)threadIdx.x) >> 7)) < 8" in kernel_source

--- a/testing/python/transform/test_tilelang_transform_lexical_alloc_scope.py
+++ b/testing/python/transform/test_tilelang_transform_lexical_alloc_scope.py
@@ -155,6 +155,7 @@ def test_lower_opaque_block_skips_empty_alloc():
 # ---------------------------------------------------------------------------
 # Test 4: GEMM descriptor allocs inside loop should get the marker
 # ---------------------------------------------------------------------------
+@tilelang.testing.requires_cuda
 def test_lower_opaque_block_inserts_scope_for_gemm_descriptor_alloc():
     """Lowered WGMMA descriptor buffers inside a loop should trigger lexical_alloc_scope."""
     target = tvm.target.Target({"kind": "cuda", "arch": "sm_90a"})
@@ -272,6 +273,7 @@ def test_lower_opaque_block_skips_fragment_alloc():
 # ---------------------------------------------------------------------------
 # Test 8: disable-ws pipelined GEMM should not wrap the fragment root block
 # ---------------------------------------------------------------------------
+@tilelang.testing.requires_cuda
 def test_lower_opaque_block_skips_fragment_root_in_disable_ws_pipeline():
     """A fragment root block should not force lexical_alloc_scope in disable-ws pipeline."""
     target = tvm.target.Target({"kind": "cuda", "arch": "sm_90a"})

--- a/testing/python/transform/test_tilelang_transform_lower_hopper_intrin.py
+++ b/testing/python/transform/test_tilelang_transform_lower_hopper_intrin.py
@@ -58,6 +58,7 @@ def _check(original, transformed):
     # tvm.ir.assert_structural_equal(mod["main"], transformed["main"], True)
 
 
+@tilelang.testing.requires_cuda
 def test_lower_shared_barrier():
     """Test that LowerSharedBarrier converts shared.barrier buffers + barrier_init
     annotations into ptx_init_barrier_thread_count calls.

--- a/testing/python/transform/test_tilelang_transform_lower_ldgstg.py
+++ b/testing/python/transform/test_tilelang_transform_lower_ldgstg.py
@@ -41,6 +41,7 @@ def _check_has_intrinsic(mod, intrinsic_name):
     return found[0]
 
 
+@tilelang.testing.requires_cuda
 def test_lower_ldg32_default_off():
     """Test that non-predicated ldg/stg lowering is OFF by default."""
 
@@ -58,6 +59,7 @@ def test_lower_ldg32_default_off():
     assert not _check_has_intrinsic(mod, "stg32"), "Non-predicated stg should be OFF by default"
 
 
+@tilelang.testing.requires_cuda
 def test_lower_ldg32_enabled():
     """Test that ldg32/stg32 works when enabled."""
 
@@ -74,6 +76,7 @@ def test_lower_ldg32_enabled():
     assert _check_has_intrinsic(mod, "stg32"), "Expected stg32 when enabled"
 
 
+@tilelang.testing.requires_cuda
 def test_lower_ldg64_enabled():
     """Test that ldg64/stg64 works when enabled."""
 
@@ -91,6 +94,7 @@ def test_lower_ldg64_enabled():
     assert _check_has_intrinsic(mod, "stg64"), "Expected stg64 when enabled"
 
 
+@tilelang.testing.requires_cuda
 def test_lower_ldg128_enabled():
     """Test that ldg128/stg128 works when enabled."""
 
@@ -108,6 +112,7 @@ def test_lower_ldg128_enabled():
     assert _check_has_intrinsic(mod, "stg128"), "Expected stg128 when enabled"
 
 
+@tilelang.testing.requires_cuda
 def test_lower_ldg256_enabled():
     """Test that ldg256/stg256 works when enabled."""
 
@@ -125,6 +130,7 @@ def test_lower_ldg256_enabled():
     assert _check_has_intrinsic(mod, "stg256"), "Expected stg256 when enabled"
 
 
+@tilelang.testing.requires_cuda
 def test_lower_ldg32_predicated():
     """Test predicated ldg32 for single element load."""
 
@@ -141,6 +147,7 @@ def test_lower_ldg32_predicated():
     assert _check_has_intrinsic(mod, "ldg32"), "Expected predicated ldg32"
 
 
+@tilelang.testing.requires_cuda
 def test_lower_stg32_predicated():
     """Test predicated stg32 for single element store."""
 
@@ -158,6 +165,7 @@ def test_lower_stg32_predicated():
     assert _check_has_intrinsic(mod, "stg32"), "Expected predicated stg32"
 
 
+@tilelang.testing.requires_cuda
 def test_lower_ldg128_predicated():
     """Test predicated ldg128 for vectorized load."""
 
@@ -175,6 +183,7 @@ def test_lower_ldg128_predicated():
     assert _check_has_intrinsic(mod, "ldg128"), "Expected predicated ldg128"
 
 
+@tilelang.testing.requires_cuda
 def test_lower_stg128_predicated():
     """Test predicated stg128 for vectorized store."""
 
@@ -193,6 +202,7 @@ def test_lower_stg128_predicated():
     assert _check_has_intrinsic(mod, "stg128"), "Expected predicated stg128"
 
 
+@tilelang.testing.requires_cuda
 def test_predicated_store_with_load():
     """Test that when a predicated store contains a load, the load also gets predicated.
 
@@ -217,6 +227,7 @@ def test_predicated_store_with_load():
     assert _check_has_intrinsic(mod, "stg128"), "Expected predicated stg128"
 
 
+@tilelang.testing.requires_cuda
 def test_predicated_store_with_shared_load_keeps_explicit_guard():
     """Do not hoist shared-memory loads out of a predicated global store."""
 
@@ -244,6 +255,7 @@ def test_predicated_store_with_shared_load_keeps_explicit_guard():
     assert not _check_has_intrinsic(mod, "stg128"), "Predicated stg128 would evaluate the shared load before the predicate"
 
 
+@tilelang.testing.requires_cuda
 def test_predicated_disabled():
     """Test that predicated lowering can be disabled."""
 
@@ -262,6 +274,7 @@ def test_predicated_disabled():
     # This just verifies the configuration works
 
 
+@tilelang.testing.requires_cuda
 def test_non_cuda_target_skip():
     """Test that the pass is skipped for non-CUDA targets."""
 

--- a/testing/python/transform/test_tilelang_transform_lower_shared_barrier.py
+++ b/testing/python/transform/test_tilelang_transform_lower_shared_barrier.py
@@ -59,6 +59,7 @@ def _collect_barrier_blocks(stmt):
     return blocks
 
 
+@tilelang.testing.requires_cuda
 def test_single_barrier():
     """Single barrier with one arrive count."""
 
@@ -79,6 +80,7 @@ def test_single_barrier():
     assert init_call.args[1].value == 128
 
 
+@tilelang.testing.requires_cuda
 def test_multiple_barriers():
     """Multiple barriers with different arrive counts."""
 
@@ -105,6 +107,7 @@ def test_multiple_barriers():
     assert len(syncs) >= 1
 
 
+@tilelang.testing.requires_cuda
 def test_no_barrier_is_noop():
     """Pass should be a no-op when no barrier buffers are present."""
 
@@ -121,6 +124,7 @@ def test_no_barrier_is_noop():
     assert len(_collect_fence_barrier_init(body)) == 0
 
 
+@tilelang.testing.requires_cuda
 def test_plan_update_keeps_barrier_init_with_tcgen05_no_tma():
     """Regression for tcgen05 no-TMA kernels after pass reordering."""
 

--- a/testing/python/transform/test_tilelang_transform_lower_tile_op.py
+++ b/testing/python/transform/test_tilelang_transform_lower_tile_op.py
@@ -19,6 +19,7 @@ def _count_calls(func: tvm.tirx.PrimFunc):
     return counts
 
 
+@tilelang.testing.requires_cuda
 def test_lower_tile_op_respects_copy_annotation_for_pipeline_managed_cp_async():
     target = tvm.target.Target({"kind": "cuda", "arch": "sm_80"})
 
@@ -48,6 +49,7 @@ def test_lower_tile_op_respects_copy_annotation_for_pipeline_managed_cp_async():
     assert calls.get("tirx.ptx_wait_group", 0) == 0
 
 
+@tilelang.testing.requires_cuda
 def test_lower_tile_op_respects_copy_annotation_for_explicit_async_copy():
     target = tvm.target.Target({"kind": "cuda", "arch": "sm_80"})
 

--- a/testing/python/transform/test_tilelang_transform_pipeline_planning.py
+++ b/testing/python/transform/test_tilelang_transform_pipeline_planning.py
@@ -10,6 +10,17 @@ sm90_target = tvm.target.Target({"kind": "cuda", "arch": "sm_90a"})
 sm100_target = tvm.target.Target({"kind": "cuda", "arch": "sm_100"})
 
 
+def _supports_software_pipelining(target) -> bool:
+    # PipelinePlanning strips the pipeline annotations on ROCm targets other than
+    # gfx950, which fall back to a plain sequential loop.
+    # See the TargetIsRocm/TargetIsGfx950 guard in src/transform/pipeline_planning.cc.
+    if target.kind.name == "hip":
+        from tilelang.rocm.target import target_is_gfx950
+
+        return target_is_gfx950(target)
+    return True
+
+
 def _check(original, transformed, target=auto_target):
     func = original
     mod = tvm.IRModule.from_expr(func.with_attr("global_symbol", "main"))
@@ -598,6 +609,9 @@ def test_simple_pipeline():
     mod = tl.transform.Simplify()(mod)
 
     annos = _collect_pipeline_loop_annotations(mod["main"])
+    if not _supports_software_pipelining(auto_target):
+        assert len(annos) == 0
+        return
     assert len(annos) == 1
     anno = annos[0]
     assert "software_pipeline_stage" in anno

--- a/testing/python/transform/test_tilelang_transform_plan_update_buffer_allocation_location.py
+++ b/testing/python/transform/test_tilelang_transform_plan_update_buffer_allocation_location.py
@@ -40,6 +40,7 @@ def _find_first_for(stmt: tvm.tirx.Stmt) -> tvm.tirx.For:
     return loops[0]
 
 
+@tilelang.testing.requires_cuda
 def test_plan_update_keeps_loop_header_local_var_outside_loop_body():
     @T.prim_func
     def func(x: T.Tensor((256,), "int64")):

--- a/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
+++ b/testing/python/transform/test_tilelang_transform_producer_consumer_ws.py
@@ -403,6 +403,7 @@ def _compile_grouped_gemm_ws(batch_sizes=(63, 77), K=128, N=128, block_M=64, blo
     return kernel, batch_sizes
 
 
+@tilelang.testing.requires_cuda
 def test_tiled_ws_skips_device_bound_tma_descriptor_base():
     func = device_bound_copy_pipelined().with_attr("global_symbol", "main")
     mod = tvm.IRModule.from_expr(func)
@@ -420,6 +421,7 @@ def test_tiled_ws_skips_device_bound_tma_descriptor_base():
     assert "T.tma_copy" not in script
 
 
+@tilelang.testing.requires_cuda
 def test_tiled_ws_places_producer_in_first_warp_group():
     """Auto-WS should put the producer in the low threadIdx.x partition."""
 
@@ -441,6 +443,7 @@ def test_tiled_ws_places_producer_in_first_warp_group():
     assert "if 128 <= tx:" not in script
 
 
+@tilelang.testing.requires_cuda
 def test_tiled_ws_accepts_int64_pipeline_indices():
     """Inductor-style TIR may use int64 shapes and loop extents."""
 
@@ -744,6 +747,7 @@ def test_tiled_ws_sinks_preloop_tma_waits_into_consumer():
     assert k_load < v_load < branch < first_wait
 
 
+@tilelang.testing.requires_cuda
 def test_tiled_ws_explicit_cp_async_wait_precedes_first_consumer_read():
     """Explicit cp.async destinations must pull the consumer wait earlier."""
 
@@ -783,6 +787,7 @@ def test_tiled_ws_keeps_preloop_tma_scalar_bind_shared():
     assert start_bind < k_load < branch
 
 
+@tilelang.testing.requires_cuda
 def test_tiled_ws_propagates_nested_postloop_liveness_to_outer_prelude():
     """Outer scalar binds used by nested post-loop consumers must stay shared."""
 

--- a/testing/python/transform/test_tilelang_transform_producer_consumer_ws_persistent.py
+++ b/testing/python/transform/test_tilelang_transform_producer_consumer_ws_persistent.py
@@ -398,6 +398,7 @@ def _apply_ws_pass(func):
     return tilelang.cuda.transform.ProducerConsumerWarpSpecialized()(mod)
 
 
+@tilelang.testing.requires_cuda
 def test_ws_pass_applies_under_t_persistent_primitive():
     """WS must descend through the ``For`` node synthesized by ``T.Persistent``."""
     func = persistent_matmul_primitive()
@@ -406,6 +407,7 @@ def test_ws_pass_applies_under_t_persistent_primitive():
     assert "tl_tiled_ws_applied" in script
 
 
+@tilelang.testing.requires_cuda
 def test_ws_pass_applies_under_persistent_serial():
     """Same coverage gap exercised via a hand-written ``T.serial`` scheduler."""
     func = persistent_matmul_serial()
@@ -414,6 +416,7 @@ def test_ws_pass_applies_under_persistent_serial():
     assert "tl_tiled_ws_applied" in script
 
 
+@tilelang.testing.requires_cuda
 def test_ws_pass_applies_under_persistent_dynamic_bound():
     """The outer ``T.serial`` bound may be symbolic; the fix must not depend on IntImm."""
     func = persistent_matmul_serial_dynamic_bound()


### PR DESCRIPTION
## Summary

A large number of tests under `testing/python` import CUDA-only internals directly (for example `tilelang.cuda.pipeline.CUDAPassPipelineBodyPrologue`) or exercise NVIDIA-specific features — TMA, LDGSTG, mbarrier, warp specialization, tcgen05, tfloat32.

`src/cuda/CMakeLists.txt` compiles only a small "ALWAYS" subset and then `return()`s when `USE_CUDA=OFF`, so those FFI symbols are never registered and the tests fail with:

```
AttributeError: module 'tilelang.cuda._ffi_api' has no attribute 'AnnotateDeviceBoundTmaCopies'
```

**This is not ROCm-specific.** The same tests fail on any build without the CUDA backend, including Metal and CPU-only builds. It surfaced on ROCm only because that is where we were running.

This PR adds `@tilelang.testing.requires_cuda` to the affected tests, matching the convention already used in ~527 places (decorator placed above `@pytest.mark.parametrize`, consistent with existing usage).

## Portability fixes (keep coverage instead of skipping)

Three cases were genuinely backend-dependent rather than CUDA-only, so they are made target-aware rather than gated:

- **`test_tilelang_transform_layout_inference.py`** — CUDA emits `__launch_bounds__(N, 1)`, HIP emits `__launch_bounds__(N)`. A small helper matches both.
- **`test_tilelang_transform_pipeline_planning.py`** — `PipelinePlanning` deliberately strips pipeline annotations on ROCm targets other than gfx950 (see the `TargetIsRocm`/`TargetIsGfx950` guard in `src/transform/pipeline_planning.cc`), so the test now asserts the documented sequential fallback there.
- **`test_tilelang_kernel_gemm.py`** — the two `f32f32f32` cases use `T.tfloat32`, an NVIDIA-only dtype with no CDNA lowering, so `requires_cuda_or_cdna` is narrowed to `requires_cuda`.

## Stale RDNA tests

Three tests in `test_tilelang_rocm_target.py` still assert that gfx1200 is rejected, but gfx12 is now supported (`get_arch` accepts generations `(11, 12)`). They cannot reach the guard any more, because `target_is_rdna` only ever reports gfx11/gfx12 — gfx1030 routes to CDNA. They now force an unsupported generation via `monkeypatch`, which is the only remaining way to exercise that path.

`test_rdna_device_model_rejects_gfx12_before_device_probe` is renamed to `..._rejects_unsupported_generation_...`, since the old name asserts something that is no longer true.

## Expected impact on the existing CUDA CI: none

Every gate added here is the *weakest sufficient* one. `requires_cuda` is satisfied on any machine with a CUDA device, so nothing that runs on the current NVIDIA runner today stops running.

This was deliberate for the `sm_100a` cast-rounding tests in particular: they are compile-only (`enable_device_compile=False`) and need no Blackwell hardware, so `requires_cuda` keeps them running. Gating them on `requires_cuda_compute_version_ge(10, 0)` would have silently dropped them from CI.

I could only verify directly on ROCm hardware, so this PR's own CI run is the confirmation for the CUDA and Metal legs.

## Test plan

Verified on 8x MI300X (gfx942), ROCm 7.2 container, torch `2.14.0.dev+rocm7.2`, running the exact `ci.yml` invocation:

- [x] Before: 105 failures across `testing/python` (63 in the default set, 42 in `transform`)
- [x] After: **1791 passed, 1222 skipped, 0 failed** in ~4m10s
- [x] No loss of passing tests — the passing count went *up*, because some failures were collateral from crashed xdist workers
- [x] Reproduced identically across repeated runs (no flakiness)
- [x] `pre-commit run --all-files` green
- [x] End-to-end under the real GitHub Actions harness on a self-hosted gfx942 runner: https://github.com/andyluo7/tilelang/actions/runs/30876119186

Part of the work to re-enable ROCm CI (#2844). A follow-up PR re-enables the matrix entry once a runner is registered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Gated CUDA-specific tests with `tilelang.testing.requires_cuda`.
- Covered TMA, LDGSTG, mbarrier, warp specialization, tcgen05, tfloat32, and NVIDIA-specific tooling.
- Added CUDA-only requirements to tfloat32 GEMM tests.
- Updated launch-bounds checks for CUDA and HIP syntax.
- Added ROCm software-pipelining fallback behavior.
- Updated RDNA tests for supported gfx11 and gfx12 generations.
- ROCm results improved to 1,791 passed, 1,222 skipped, and 0 failed.
- Pre-commit checks passed.

## C++ style / lint notes

- This PR does not change C++ code, C++ style documentation, CI, or lint tooling.
- The C++ API Style Audit is not affected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->