### PR TITLE
[Examples] Gate CUDA-only and flash_attn-dependent example tests

### DIFF
--- a/examples/blocksparse_attention/test_example_blocksparse_attention.py
+++ b/examples/blocksparse_attention/test_example_blocksparse_attention.py
@@ -13,10 +13,12 @@ def test_example_tilelang_block_sparse_attn():
     example_tilelang_block_sparse_attn.main()
 
 
+@tilelang.testing.requires_package("flash_attn")
 def test_example_tilelang_sparse_gqa_decode_varlen_indice():
     example_tilelang_sparse_gqa_decode_varlen_indice.main(batch=1, max_cache_seqlen=2048)
 
 
+@tilelang.testing.requires_package("flash_attn")
 def test_example_tilelang_sparse_gqa_decode_varlen_mask():
     example_tilelang_sparse_gqa_decode_varlen_mask.main(batch=1, max_cache_seqlen=2048)
 

--- a/examples/gdn/test_example_gdn_compilation.py
+++ b/examples/gdn/test_example_gdn_compilation.py
@@ -1,4 +1,5 @@
 import torch
+import tilelang.testing
 from tilelang import language as T
 
 B = 1
@@ -277,6 +278,8 @@ def test_example_chunk_delta_h_compilation():
     h_tilelang, final_state_tilelang, V_new_tilelang = kernel(K, W, U, G, initial_state)  # noqa: F841
 
 
+# tfloat32 is an NVIDIA-only dtype and has no CDNA lowering.
+@tilelang.testing.requires_cuda
 def test_example_chunk_delta_bwd_compilation():
     from example_chunk_delta_bwd import tilelang_chunk_gated_delta_rule_bwd_dhu, prepare_input
 

--- a/examples/gemm/test_example_gemm.py
+++ b/examples/gemm/test_example_gemm.py
@@ -3,6 +3,8 @@ import example_gemm_intrinsics
 import example_gemm
 
 
+# Uses tl.ptx_ldmatrix, which is NVIDIA PTX-only.
+@tilelang.testing.requires_cuda
 def test_example_gemm_intrinsics():
     example_gemm_intrinsics.main(M=1024, N=1024, K=1024)
 


### PR DESCRIPTION
## Summary

Three example tests cannot run on non-CUDA backends and currently fail rather than skip:

| Test | Why it cannot run |
|---|---|
| `test_example_gemm_intrinsics` | lowers `tl.ptx_ldmatrix`, which is NVIDIA PTX-only (`Unresolved call ir.Op(... name="tl.ptx_ldmatrix")`) |
| `test_example_chunk_delta_bwd_compilation` | uses `T.tfloat32`, which has no CDNA lowering (`KeyError: dtype('custom[tfloat32]')`) |
| `test_example_tilelang_sparse_gqa_decode_varlen_{indice,mask}` | import `flash_attn`, installed by `requirements-test-cuda.txt` but with no equivalent in `requirements-test-rocm.txt` |

The first two get `@tilelang.testing.requires_cuda`; the blocksparse pair gets `@tilelang.testing.requires_package("flash_attn")`.

## Impact on the existing CUDA CI: none

All three keep running on the NVIDIA runner — `requires_cuda` is satisfied there, and `flash_attn` is installed via `requirements-test-cuda.txt`. This only changes behaviour on backends where they cannot run at all today.

## Note

`examples/` is not currently part of the ROCm CI invocation, so this is not required to re-enable ROCm CI (#2844) — it is groundwork toward running examples on ROCm too.

Worth flagging separately: with these three gated, six example failures remain on gfx942 that are **genuine ROCm bugs**, not gating problems. I have not touched them here since they need maintainer input:

- `examples/cast` — `float8_e4m3fn` is silently lowered to the **FNUZ** encoding on gfx942 (`src/tl_templates/hip/hip_fp8.h` selects FNUZ for gfx940/941/942, OCP elsewhere). The example requests OCP `e4m3fn` and compares against torch, which handles OCP correctly, so 100% of elements mismatch. This would pass on gfx950. Whether `T.float8_e4m3fn` should honour OCP semantics on CDNA3 or be rejected is a dtype-semantics decision.
- `examples/deepseek_nsa` — `test_example_tilelang_nsa_fwd{,_decode}` die with `Fatal Python error: Floating point exception` (SIGFPE, rc=136), reproducible in isolation. This also crashes xdist workers and produces false collateral failures in unrelated tests.
- `examples/flash_decoding` — `hipModuleLaunchKernel` InternalError, and `torch.AcceleratorError: CUDA error: invalid argument`.

Happy to open separate issues for these if useful.

## Test plan

- [x] Verified on 8x MI300X (gfx942), ROCm 7.2, torch `2.14.0.dev+rocm7.2`
- [x] The three gated tests now skip cleanly instead of failing
- [x] Confirmed by isolation runs that `wy_fast_compilation` and `fusedmoe_tilelang` were only failing as collateral from the nsa SIGFPE — both pass on their own
- [x] `pre-commit run --all-files` green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Gate `test_example_gemm_intrinsics` and `test_example_chunk_delta_bwd_compilation` with `requires_cuda`.
- Gate sparse GQA decode varlen tests with `requires_package("flash_attn")`.
- Unsupported backends and missing `flash_attn` now skip these tests cleanly.
- CUDA CI behavior remains unchanged.
- Pre-commit checks passed.
- Changes were verified on MI300X with ROCm 7.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->