### PR TITLE
[BugFix] Use masked warpsync in in-warp allreduce

### DIFF
--- a/src/transform/lower_thread_allreduce.cc
+++ b/src/transform/lower_thread_allreduce.cc
@@ -21,6 +21,7 @@
  *  Lower allreduce to device implementable ir.
  * \file lower_thread_allreduce.cc
  */
+#include "op/builtin.h"
 #include "support/check.h"
 #include <tvm/arith/analyzer.h>
 #include <tvm/ir/cast.h>
@@ -752,6 +753,9 @@ private:
     if (reduce_align > 1) {
       PrimExpr in_warp_cond = reduce_index < (reduce_align >> 1);
 
+      Var active_mask("allreduce_active_mask", DataType::UInt(32));
+      Var participant_mask("allreduce_participant_mask", DataType::UInt(32));
+
       std::vector<Stmt> in_warp_seq;
 
       while (reduce_align > 1) {
@@ -776,10 +780,10 @@ private:
         }
 
         std::vector<Stmt> in_let_statement;
-        in_let_statement.emplace_back(SyncThread("warp"));
+        in_let_statement.emplace_back(SyncWarp(participant_mask));
         in_let_statement.emplace_back(
             fstore({in_warp_local_vars.begin(), in_warp_local_vars.end()}));
-        in_let_statement.emplace_back(SyncThread("warp"));
+        in_let_statement.emplace_back(SyncWarp(participant_mask));
 
         Stmt body = SeqStmt::Flatten(in_let_statement);
         for (size_t i = 0; i < size; i++) {
@@ -790,6 +794,15 @@ private:
 
       Stmt warp_body = SeqStmt::Flatten(in_warp_seq);
 
+      PrimExpr active_mask_value =
+          Call(DataType::UInt(64), tl::activemask(), {});
+      PrimExpr participant_mask_value = Call(
+          DataType::UInt(64), tl::ballot_sync(), {active_mask, in_warp_cond});
+
+      seq.emplace_back(
+          tirx::Bind(active_mask, Cast(DataType::UInt(32), active_mask_value)));
+      seq.emplace_back(tirx::Bind(
+          participant_mask, Cast(DataType::UInt(32), participant_mask_value)));
       seq.emplace_back(IfThenElse(in_warp_cond, warp_body));
       seq.emplace_back(SyncThread(shared_scope));
     }
@@ -826,10 +839,16 @@ private:
       return reduce_index;
     }
   }
+
   // sync thread op.
   static Stmt SyncThread(const std::string &sync) {
     return Evaluate(Call(DataType::Int(32), builtin::tvm_storage_sync(),
                          {StringImm(sync)}));
+  }
+
+  // sync warp op.
+  static Stmt SyncWarp(PrimExpr mask) {
+    return Evaluate(Call(DataType::Void(), tl::sync_warp(), {std::move(mask)}));
   }
 
   // Emit warp shuffle  calls.

--- a/testing/python/issue/test_tilelang_issue_2628.py
+++ b/testing/python/issue/test_tilelang_issue_2628.py
@@ -7,12 +7,13 @@ for such dtypes, and that the results are correct.
 """
 
 import torch
+import pytest
 import tilelang as tl
 import tilelang.language as T
 import tilelang.testing
 
 
-def make_kernel(reduce_threads, dtype):
+def make_kernel(reduce_threads, dtype, reduce_op, reduce_id):
     @tl.jit(pass_configs={tl.PassConfigKey.TL_DISABLE_TMA_LOWER: True, tl.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True})
     def kernel(A):
         K = T.const("K")
@@ -23,7 +24,7 @@ def make_kernel(reduce_threads, dtype):
             v = T.alloc_local((1,), dtype)
             v[0] = A[tk]
             Cr = T.alloc_local((1,), dtype)
-            with T.attr(T.comm_reducer(lambda x, y: x + y, [T.cast(0, dtype)]), "reduce_scope", T.reinterpret(T.uint64(0), dtype="handle")):
+            with T.attr(T.comm_reducer(reduce_op, [T.cast(reduce_id, dtype)]), "reduce_scope", T.reinterpret(T.uint64(0), dtype="handle")):
                 T.evaluate(T.tvm_thread_allreduce(T.uint32(1), v[0], True, Cr[0], tk, dtype="handle"))
             C[0] = Cr[0]
         return C
@@ -31,23 +32,46 @@ def make_kernel(reduce_threads, dtype):
     return kernel
 
 
-def test_thread_allreduce_syncwarp():
-    # Fixed exact-integer inputs so the reported values reproduce byte-for-byte.
-    INT_VALS = [10, 25, 40, 30, 15, 42, 20, 20]  # sum = 202 (-54 for int8)
-    BF16_VALS = [3.0, 8.0, 5.0, 2.0, 7.0, 6.0, 4.0, 6.0]  # sum = 41 (exact in bf16)
-    for dt, vals in [
+INT_VALS = [10, 25, 40, 30, 15, 42, 20, 20]  # sum = 202 (-54 for int8)
+BF16_VALS = [3.0, 8.0, 5.0, 2.0, 7.0, 6.0, 4.0, 6.0]  # sum = 41 (exact in bf16)
+
+
+@pytest.mark.parametrize(
+    "dt,vals",
+    [
         ("float32", INT_VALS),
         ("int32", INT_VALS),
         ("float16", INT_VALS),
         ("bfloat16", BF16_VALS),
         ("int16", INT_VALS),
         ("int8", INT_VALS),
-    ]:
-        dtype = getattr(torch, dt)
-        A = torch.tensor(vals, device="cuda").to(dtype)
-        got = make_kernel(8, dt)(A).to(dtype)[0].item()
-        ref = A.sum().to(dtype).item()
-        torch.testing.assert_close(got, ref, rtol=1e-3, atol=1e-3)
+    ],
+)
+def test_thread_allreduce_syncwarp_sum(dt, vals):
+    dtype = getattr(torch, dt)
+    A = torch.tensor(vals, device="cuda").to(dtype)
+    got = make_kernel(8, dt, lambda x, y: x + y, 0)(A).to(dtype)[0].item()
+    ref = A.sum().to(dtype).item()
+    torch.testing.assert_close(got, ref, rtol=1e-3, atol=1e-3)
+
+
+@pytest.mark.parametrize(
+    "dt,vals",
+    [
+        ("float32", INT_VALS),
+        ("int32", INT_VALS),
+        ("float16", INT_VALS),
+        ("bfloat16", BF16_VALS),
+        ("int16", INT_VALS),
+        ("int8", INT_VALS),
+    ],
+)
+def test_thread_allreduce_syncwarp_mul(dt, vals):
+    dtype = getattr(torch, dt)
+    A = torch.tensor(vals, device="cuda").to(dtype)
+    got = make_kernel(8, dt, lambda x, y: x * y, 1)(A).to(dtype)[0].item()
+    ref = torch.prod(A).to(dtype).item()
+    torch.testing.assert_close(got, ref, rtol=1e-3, atol=1e-3)
 
 
 if __name__ == "__main__":

--- a/testing/python/issue/test_tilelang_issue_2628.py
+++ b/testing/python/issue/test_tilelang_issue_2628.py
@@ -1,0 +1,54 @@
+"""Regression test for GitHub issue #2628.
+
+Allreduce with dtypes such as int8, int16, bfloat16 can produce incorrect
+results when the warp-synchronous reduction is not properly synchronized.
+This test ensures that the warp-synchronous reduction is properly synchronized
+for such dtypes, and that the results are correct.
+"""
+
+import torch
+import tilelang as tl
+import tilelang.language as T
+import tilelang.testing
+
+
+def make_kernel(reduce_threads, dtype):
+    @tl.jit(pass_configs={tl.PassConfigKey.TL_DISABLE_TMA_LOWER: True, tl.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True})
+    def kernel(A):
+        K = T.const("K")
+        A: T.Tensor((K,), dtype)
+        C = T.empty((1,), dtype)
+        with T.Kernel(1, threads=(reduce_threads,)):
+            tk = T.get_thread_binding(0)  # reduce dim = threadIdx.x, single warp
+            v = T.alloc_local((1,), dtype)
+            v[0] = A[tk]
+            Cr = T.alloc_local((1,), dtype)
+            with T.attr(T.comm_reducer(lambda x, y: x + y, [T.cast(0, dtype)]), "reduce_scope", T.reinterpret(T.uint64(0), dtype="handle")):
+                T.evaluate(T.tvm_thread_allreduce(T.uint32(1), v[0], True, Cr[0], tk, dtype="handle"))
+            C[0] = Cr[0]
+        return C
+
+    return kernel
+
+
+def test_thread_allreduce_syncwarp():
+    # Fixed exact-integer inputs so the reported values reproduce byte-for-byte.
+    INT_VALS = [10, 25, 40, 30, 15, 42, 20, 20]  # sum = 202 (-54 for int8)
+    BF16_VALS = [3.0, 8.0, 5.0, 2.0, 7.0, 6.0, 4.0, 6.0]  # sum = 41 (exact in bf16)
+    for dt, vals in [
+        ("float32", INT_VALS),
+        ("int32", INT_VALS),
+        ("float16", INT_VALS),
+        ("bfloat16", BF16_VALS),
+        ("int16", INT_VALS),
+        ("int8", INT_VALS),
+    ]:
+        dtype = getattr(torch, dt)
+        A = torch.tensor(vals, device="cuda").to(dtype)
+        got = make_kernel(8, dt)(A).to(dtype)[0].item()
+        ref = A.sum().to(dtype).item()
+        torch.testing.assert_close(got, ref, rtol=1e-3, atol=1e-3)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
The in-warp reduction loop separated each load/store pair with `SyncThread("warp")` -> `tvm_storage_sync("warp")`, which is a no-op in CUDA.
This leads to datarace and silently produces incorrect results.

Note that simply emitting `__syncthreads()` does not help as there might be a surrounding divergent `if` condition guarding the sync.
To fix this, we compute the participant mask via `__ballot_sync()` before entering the branch, and emit `__syncwarp(participant_mask)` (`tl::sync_warp`) between stages.

Fixes #2628 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed incorrect in-warp `tvm_thread_allreduce` results caused by unsynchronized shared-memory stages.
- Replaced warp-wide no-op barriers with masked `tl::sync_warp` calls.
- Computed participant masks with `__activemask()` and `__ballot_sync()`.
- Added regression coverage for float, integer, and `bfloat16` reductions.

## C++ style / lint notes

- The change does not modify `docs/developer_guide/cpp_style.md` or introduce a new public API.
- The C++ API Style Audit remains warning-only.
- No correctness or build issue is indicated by the style checks. Advisory `TLCPP003` or `TLCPP004` findings should not block this change without a clear API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->