### PR TITLE
[Debug][TIR] Drive Pass Visualizer with PassInstrument

### DIFF
--- a/docs/tutorials/debug_tools_for_tilelang.md
+++ b/docs/tutorials/debug_tools_for_tilelang.md
@@ -212,7 +212,7 @@ which is retained only for backward compatibility. New users should use
 
 ## Pass Visualizer: Structure-Tree View Across Passes
 
-The **Pass Visualizer** is a complement to Pass Diff. Where Pass Diff shows a line-level diff of the **TVMScript text**, the Pass Visualizer renders the IR as a **structure tree** (the `SBlock` nesting, with `reads` / `writes` / `alloc_buffers` / `annotations` fields) and expands every tile op by field name. It produces a single self-contained, interactive HTML file that steps through each CUDA lowering pass.
+The **Pass Visualizer** is a complement to Pass Diff. Where Pass Diff shows a line-level diff of the **TVMScript text**, the Pass Visualizer renders the IR as a **structure tree** (the `SBlock` nesting, with `reads` / `writes` / `alloc_buffers` / `annotations` fields) and expands every tile op by field name. A TVM `PassInstrument` observes the canonical CUDA lowering prologue, so the report follows the conditional passes and order that actually execute. It produces a single self-contained, interactive HTML file that steps through those passes.
 
 This view is most useful when debugging **structural** passes — layout inference, warp specialization, pipelining — where you care about how the IR's block structure and operator semantics change, not just which text lines moved.
 
@@ -223,7 +223,7 @@ This view is most useful when debugging **structural** passes — layout inferen
 | Compared object | TVMScript text lines | `SBlock` structure tree |
 | Operator display | Raw one-liner, positional args | Expanded **by field name** (`M=64`, `K=32`, `policy=0`) |
 | Highlighting | Generic `+` / `-` | Per-class: tile op / sync primitive / lowered hardware intrinsic |
-| Trigger | Environment-variable hook, captures the real full pipeline | Explicit CLI, runs the focused lowering prologue |
+| Trigger | Environment-variable hook, captures the real full pipeline | Explicit CLI, instruments the real focused lowering prologue |
 
 ### Quick Start (CLI)
 
@@ -252,6 +252,7 @@ This writes `gemm_relu_passes.html` (the interactive browser) and a sibling `gem
 - **Left pane**: the ordered pass list, each tagged `changed` / `no-op` with an added/removed line count. Click a pass — or use the <kbd>↑</kbd>/<kbd>↓</kbd> keys — to step through the pipeline.
 - **Right pane**: the structure tree for the selected pass, with lines **added** by that pass highlighted green and lines it **removed** shown ghosted red.
 - **Operator highlighting**: tile ops (e.g. `T.gemm`, `T.copy`), synchronization primitives, and lowered hardware intrinsics (`ptx_mma`, `tma_load`, …) are each colored distinctly, so you can follow a `T.copy` as it lowers into TMA/PTX intrinsics.
+- **Real pass metadata**: stage names and ordering come from `PassInstrument`; nested implementation passes are folded into their top-level pipeline stage to keep the browser timeline linear.
 
 ### Programmatic API
 

--- a/docs/tutorials/debug_tools_for_tilelang.md
+++ b/docs/tutorials/debug_tools_for_tilelang.md
@@ -212,7 +212,7 @@ which is retained only for backward compatibility. New users should use
 
 ## Pass Visualizer: Structure-Tree View Across Passes
 
-The **Pass Visualizer** is a complement to Pass Diff. Where Pass Diff shows a line-level diff of the **TVMScript text**, the Pass Visualizer renders the IR as a **structure tree** (the `SBlock` nesting, with `reads` / `writes` / `alloc_buffers` / `annotations` fields) and expands every tile op by field name. A TVM `PassInstrument` observes the canonical CUDA lowering prologue, so the report follows the conditional passes and order that actually execute. It produces a single self-contained, interactive HTML file that steps through those passes.
+The **Pass Visualizer** is a complement to Pass Diff. Where Pass Diff shows a line-level diff of the **TVMScript text**, the Pass Visualizer renders the IR as a **structure tree** (the `SBlock` nesting, with `reads` / `writes` / `alloc_buffers` / `annotations` fields) and expands every tile op by field name. A TVM `PassInstrument` observes the canonical CUDA lowering prologue, so the report follows the conditional passes and order that actually execute. It produces a single self-contained, interactive HTML file that steps through those passes. The CLI currently supports CUDA targets only; backend-specific pipeline dispatch can be added separately for other targets.
 
 This view is most useful when debugging **structural** passes — layout inference, warp specialization, pipelining — where you care about how the IR's block structure and operator semantics change, not just which text lines moved.
 

--- a/testing/python/debug/test_pass_visualizer.py
+++ b/testing/python/debug/test_pass_visualizer.py
@@ -19,11 +19,12 @@ from tilelang import tvm
 
 from tilelang.tools.pass_visualizer import (
     build_module,
+    capture_structure,
     inspect_structure,
+    PassStructureRecord,
     StructureTreePassInstrument,
 )
 from tilelang.tools.pass_visualizer.viewer import (
-    _capture_tree,
     build_pass_data,
     emit_html,
     emit_txt,
@@ -113,6 +114,25 @@ def test_structure_tree_instrument_ignores_nested_passes():
     assert [record.name for record in records] == ["test.Outer"]
 
 
+def test_pass_structure_record_changed_uses_structure_snapshot():
+    """The changed flag describes the structure-tree diff shown by the viewer."""
+    unchanged = PassStructureRecord(
+        name="test.Unchanged",
+        sequence=0,
+        before_lines=["PrimFunc", "  body"],
+        after_lines=["PrimFunc", "  body"],
+    )
+    changed = PassStructureRecord(
+        name="test.Changed",
+        sequence=1,
+        before_lines=["PrimFunc", "  body"],
+        after_lines=["PrimFunc", "  changed body"],
+    )
+
+    assert not unchanged.changed
+    assert changed.changed
+
+
 def test_structure_tree_instrument_cleans_up_after_failure():
     """A missing after-pass callback is retained as a diagnostic, not stale state."""
     mod, _target = _build_small_module()
@@ -150,10 +170,10 @@ def test_inspect_structure_renders_tree(capsys):
 
 
 @tilelang.testing.requires_cuda
-def test_capture_tree_returns_lines():
-    """_capture_tree turns inspect_structure output into a list of text lines."""
+def test_capture_structure_returns_lines():
+    """capture_structure turns inspect_structure output into text lines."""
     mod, _target = _build_small_module()
-    lines = _capture_tree(mod)
+    lines = capture_structure(mod)
 
     assert isinstance(lines, list)
     assert len(lines) > 0
@@ -203,6 +223,23 @@ def test_build_pass_data_and_emit(tmp_path):
     txt = emit_txt(name, stages)
     assert "kernel: gemm_relu" in txt
     assert "T.gemm" in txt
+
+
+def test_build_pass_data_rejects_non_cuda_target():
+    """The focused viewer rejects backends whose pass pipeline it cannot dispatch."""
+    import os
+
+    kernel_path = os.path.join(
+        os.path.dirname(tilelang.tools.pass_visualizer.__file__),
+        "examples",
+        "gemm_relu.py",
+    )
+    with open(kernel_path) as f:
+        source = f.read()
+
+    kwargs = {"M": 128, "N": 128, "K": 128, "block_M": 64, "block_N": 64, "block_K": 32}
+    with pytest.raises(ValueError, match="currently supports only CUDA targets"):
+        build_pass_data(kernel_path, None, "llvm", kwargs, source)
 
 
 @tilelang.testing.requires_cuda

--- a/testing/python/debug/test_pass_visualizer.py
+++ b/testing/python/debug/test_pass_visualizer.py
@@ -2,13 +2,15 @@
 """Tests for the pass_visualizer debugging tool.
 
 Covers:
-- Core helpers: build_module, build_pass_stages, inspect_structure
-- Structure-tree capture and per-pass diffing (build_pass_data via viewer)
+- Core helpers: build_module, inspect_structure, StructureTreePassInstrument
+- Real-pipeline structure capture and per-pass diffing (build_pass_data via viewer)
 - HTML / text emission (emit_html, emit_txt)
 
 These run the CUDA lowering prologue on a small kernel. An explicit cuda target
 is passed so the pipeline does not depend on auto target detection.
 """
+
+import pytest
 
 import tilelang
 import tilelang.testing
@@ -17,8 +19,8 @@ from tilelang import tvm
 
 from tilelang.tools.pass_visualizer import (
     build_module,
-    build_pass_stages,
     inspect_structure,
+    StructureTreePassInstrument,
 )
 from tilelang.tools.pass_visualizer.viewer import (
     _capture_tree,
@@ -38,7 +40,6 @@ def _gemm_relu_kernel():
 
     @tilelang.jit(out_idx=[-1])
     def gemm_relu(M, N, K, block_M, block_N, block_K, dtype="float16", accum_dtype="float32"):
-
         @T.prim_func
         def main(
             A: T.Tensor((M, K), dtype),
@@ -81,19 +82,57 @@ def _build_small_module():
 
 
 @tilelang.testing.requires_cuda
-def test_build_pass_stages_nonempty():
-    """build_pass_stages returns an ordered list of (name, transform) pairs."""
-    _mod, target = _build_small_module()
-    stages = build_pass_stages(target)
+def test_structure_tree_instrument_records_real_passes():
+    """The instrument records top-level passes using their PassInfo names."""
+    mod, target = _build_small_module()
+    instrument = StructureTreePassInstrument()
 
-    assert len(stages) > 0
-    names = [name for name, _ in stages]
-    # The prologue must run LayoutInference and LowerTileOp.
-    assert "LayoutInference" in names
-    assert "LowerTileOp" in names
-    for name, transform in stages:
-        assert isinstance(name, str)
-        assert callable(transform)
+    with tvm.transform.PassContext(instruments=[instrument]), target:
+        mod = tvm.tirx.transform.BindTarget(target)(mod)
+        tilelang.transform.MaterializeKernelLaunch()(mod)
+
+    records = instrument.ordered_records()
+    assert [record.name for record in records] == ["tirx.BindTarget", "tl.MaterializeKernelLaunch"]
+    assert instrument.input_lines
+    assert any("PrimFunc" in line for line in instrument.input_lines)
+
+
+def test_structure_tree_instrument_ignores_nested_passes():
+    """Nested implementation passes do not duplicate linear browser stages."""
+    mod, _target = _build_small_module()
+    instrument = StructureTreePassInstrument()
+
+    @tvm.transform.module_pass(opt_level=0, name="test.Outer")
+    def outer_pass(mod, _ctx):
+        return tvm.tirx.transform.Simplify()(mod)
+
+    with tvm.transform.PassContext(instruments=[instrument]):
+        outer_pass(mod)
+
+    records = instrument.ordered_records()
+    assert [record.name for record in records] == ["test.Outer"]
+
+
+def test_structure_tree_instrument_cleans_up_after_failure():
+    """A missing after-pass callback is retained as a diagnostic, not stale state."""
+    mod, _target = _build_small_module()
+    instrument = StructureTreePassInstrument()
+
+    @tvm.transform.module_pass(opt_level=0, name="test.Fail")
+    def failing_pass(_mod, _ctx):
+        raise RuntimeError("expected failure")
+
+    with pytest.raises(RuntimeError, match="expected failure"), tvm.transform.PassContext(instruments=[instrument]):
+        failing_pass(mod)
+
+    assert instrument.records == []
+    assert instrument.incomplete_passes == ["test.Fail"]
+
+    # Entering a new context resets the incomplete frame and records normally.
+    with tvm.transform.PassContext(instruments=[instrument]):
+        tvm.tirx.transform.Simplify()(mod)
+    assert [record.name for record in instrument.ordered_records()] == ["tirx.Simplify"]
+    assert instrument.incomplete_passes == []
 
 
 @tilelang.testing.requires_cuda
@@ -128,7 +167,7 @@ def test_capture_tree_returns_lines():
 
 @tilelang.testing.requires_cuda
 def test_build_pass_data_and_emit(tmp_path):
-    """End-to-end: run the example kernel through the pipeline and emit HTML/txt."""
+    """End-to-end: observe the real prologue and emit HTML/txt."""
     import os
 
     kernel_path = os.path.join(
@@ -150,6 +189,12 @@ def test_build_pass_data_and_emit(tmp_path):
     flags = {st["flag"] for st in stages}
     assert "source" in flags
     assert "input" in flags
+    stage_names = [st["name"].split("] ", 1)[-1] for st in stages[2:]]
+    assert "LayoutInference" in stage_names
+    assert "LowerTileOp" in stage_names
+    assert "AddWrapperForSingleBufStore" in stage_names
+    assert "DecoupleTypeCast" in stage_names
+    assert "pass_fn" not in stage_names
 
     html = emit_html(name, stages)
     assert "Pass browser" in html
@@ -158,6 +203,59 @@ def test_build_pass_data_and_emit(tmp_path):
     txt = emit_txt(name, stages)
     assert "kernel: gemm_relu" in txt
     assert "T.gemm" in txt
+
+
+@tilelang.testing.requires_cuda
+def test_build_pass_data_observes_canonical_prologue(monkeypatch):
+    """A newly introduced real pipeline pass appears without a viewer pass list."""
+    import os
+
+    kernel_path = os.path.join(
+        os.path.dirname(tilelang.tools.pass_visualizer.__file__),
+        "examples",
+        "gemm_relu.py",
+    )
+    with open(kernel_path) as f:
+        source = f.read()
+
+    @tvm.transform.module_pass(opt_level=0, name="test.InjectedPipelinePass")
+    def injected_pass(mod, _ctx):
+        return mod
+
+    def injected_prologue(mod, _target):
+        return injected_pass(mod)
+
+    monkeypatch.setattr("tilelang.tools.pass_visualizer.viewer.CUDAPassPipelineBodyPrologue", injected_prologue)
+    kwargs = {"M": 128, "N": 128, "K": 128, "block_M": 64, "block_N": 64, "block_K": 32}
+    _name, stages = build_pass_data(kernel_path, None, "cuda", kwargs, source)
+
+    assert [stage["name"] for stage in stages] == ["source code", "(input)", "[01] InjectedPipelinePass"]
+
+
+@tilelang.testing.requires_cuda
+def test_build_pass_data_respects_jit_pass_configs(tmp_path):
+    """Conditional stages use the analyzed JITImpl's real PassContext config."""
+    import os
+
+    kernel_path = os.path.join(
+        os.path.dirname(tilelang.tools.pass_visualizer.__file__),
+        "examples",
+        "gemm_relu.py",
+    )
+    with open(kernel_path) as f:
+        source = f.read()
+    source = source.replace(
+        "@tilelang.jit(out_idx=[-1])",
+        '@tilelang.jit(out_idx=[-1], pass_configs={"tl.disable_warp_specialized": True})',
+    )
+    configured_path = tmp_path / "gemm_relu_no_ws.py"
+    configured_path.write_text(source)
+
+    kwargs = {"M": 128, "N": 128, "K": 128, "block_M": 64, "block_N": 64, "block_K": 32}
+    _name, stages = build_pass_data(str(configured_path), None, "cuda", kwargs, source)
+
+    stage_names = [st["name"] for st in stages]
+    assert not any("ProducerConsumerWarpSpecialized" in name for name in stage_names)
 
 
 if __name__ == "__main__":

--- a/tilelang/analysis/layout_visual.py
+++ b/tilelang/analysis/layout_visual.py
@@ -105,4 +105,4 @@ def LayoutVisual(formats: str | Sequence[str] = ""):
         _LayoutVisualVisitor(formats=formats).visit_stmt(func.body)
         return func
 
-    return prim_func_pass(pass_fn, opt_level=0)
+    return prim_func_pass(pass_fn, opt_level=0, name="tl.LayoutVisual")

--- a/tilelang/tools/pass_visualizer/README.md
+++ b/tilelang/tools/pass_visualizer/README.md
@@ -11,6 +11,10 @@ lowering prologue, so conditional passes and their order match the pipeline that
 actually executes. The tool emits a single self-contained, interactive HTML
 file that steps through those passes.
 
+The Pass Visualizer currently supports CUDA targets only. Other backends can
+use the structure-tree instrument once they provide a backend-specific pipeline
+entry point, but they are not dispatched by this CLI yet.
+
 Use it when debugging **structural** passes (layout inference, warp
 specialization, pipelining), where what matters is how the IR's block structure
 and operator semantics change, not just which text lines moved.
@@ -41,7 +45,7 @@ This writes `gemm_relu_passes.html` (the interactive browser) and a sibling
 |----------|-------------|
 | `path` | Python file containing a `@tilelang.jit` kernel (positional) |
 | `--factory` | Name of the kernel to analyze (default: first discovered) |
-| `--target` | Compilation target (default: `auto`) |
+| `--target` | CUDA compilation target (default: `auto`) |
 | `--set K=V` | Argument forwarded to the kernel factory (repeatable) |
 | `--out` | Output HTML path (default: `<kernel>_passes.html` next to the source) |
 

--- a/tilelang/tools/pass_visualizer/README.md
+++ b/tilelang/tools/pass_visualizer/README.md
@@ -6,8 +6,10 @@ This is a debugging complement to [`tilelang.utils.pass_diff`](../pass_diff.py).
 Where `pass_diff` shows a line-level diff of the **TVMScript text**, this tool
 renders the IR as an **`SBlock` structure tree** — the block nesting plus
 `reads` / `writes` / `alloc_buffers` / `annotations` fields — and expands every
-tile op by field name. It emits a single self-contained, interactive HTML file
-that steps through each CUDA lowering pass.
+tile op by field name. A TVM `PassInstrument` observes the canonical CUDA
+lowering prologue, so conditional passes and their order match the pipeline that
+actually executes. The tool emits a single self-contained, interactive HTML
+file that steps through those passes.
 
 Use it when debugging **structural** passes (layout inference, warp
 specialization, pipelining), where what matters is how the IR's block structure
@@ -20,7 +22,7 @@ and operator semantics change, not just which text lines moved.
 | Compared object | TVMScript text lines | `SBlock` structure tree |
 | Operator display | Raw one-liner, positional args | Expanded **by field name** (`M=64`, `K=32`, `policy=0`) |
 | Highlighting | Generic `+` / `-` | Per-class: tile op / sync primitive / lowered hardware intrinsic |
-| Trigger | Environment-variable hook, captures the real full pipeline | Explicit CLI, runs the focused lowering prologue |
+| Trigger | Environment-variable hook, captures the real full pipeline | Explicit CLI, instruments the real focused lowering prologue |
 
 ## Usage
 
@@ -54,6 +56,9 @@ This writes `gemm_relu_passes.html` (the interactive browser) and a sibling
   primitives, and lowered hardware intrinsics (`ptx_mma`, `tma_load`, …) are
   each colored distinctly, so you can follow a `T.copy` as it lowers into
   TMA/PTX intrinsics.
+- **Real pass metadata**: stage names and ordering come from `PassInstrument`;
+  nested implementation passes are folded into their top-level pipeline stage
+  to keep the browser timeline linear.
 
 ## Programmatic API
 
@@ -72,5 +77,5 @@ html = emit_html(name, stages)
 ## Files
 
 - `viewer.py` — CLI entry point; per-pass capture, diffing, and HTML/text emission.
-- `core.py` — kernel loading, the CUDA lowering pass pipeline, and the structure-tree renderer.
+- `core.py` — kernel loading, the structure-tree `PassInstrument`, and the renderer.
 - `examples/gemm_relu.py` — a small fused GEMM + bias + ReLU kernel used as demo input.

--- a/tilelang/tools/pass_visualizer/__init__.py
+++ b/tilelang/tools/pass_visualizer/__init__.py
@@ -7,12 +7,14 @@ expands tile ops by field name, with per-class operator highlighting.
 """
 
 from .core import (
-    build_pass_stages,  # noqa: F401
     build_module,  # noqa: F401
+    capture_structure,  # noqa: F401
     inspect_structure,  # noqa: F401
     load_user_module,  # noqa: F401
     discover_jit_kernels,  # noqa: F401
     kernel_to_tir,  # noqa: F401
+    PassStructureRecord,  # noqa: F401
+    StructureTreePassInstrument,  # noqa: F401
 )
 
 # NOTE: viewer (build_pass_data / emit_html / emit_txt) is intentionally NOT

--- a/tilelang/tools/pass_visualizer/core.py
+++ b/tilelang/tools/pass_visualizer/core.py
@@ -355,14 +355,12 @@ class PassStructureRecord:
 
     name: str
     sequence: int
-    before_ir: str
-    after_ir: str
     before_lines: list[str]
     after_lines: list[str]
 
     @property
     def changed(self) -> bool:
-        return self.before_ir != self.after_ir
+        return self.before_lines != self.after_lines
 
 
 @dataclass
@@ -371,7 +369,6 @@ class _ActivePass:
 
     name: str
     sequence: int | None
-    before_ir: str | None
     before_lines: list[str] | None
 
 
@@ -417,12 +414,11 @@ class StructureTreePassInstrument:
             frame = _ActivePass(
                 name=name,
                 sequence=self._next_sequence,
-                before_ir=str(mod),
                 before_lines=before_lines,
             )
             self._next_sequence += 1
         else:
-            frame = _ActivePass(name=name, sequence=None, before_ir=None, before_lines=None)
+            frame = _ActivePass(name=name, sequence=None, before_lines=None)
         self._stack.append(frame)
 
     def run_after_pass(self, mod: tvm.IRModule, info):
@@ -440,14 +436,11 @@ class StructureTreePassInstrument:
         if frame.sequence is None:
             return
 
-        assert frame.before_ir is not None
         assert frame.before_lines is not None
         self.records.append(
             PassStructureRecord(
                 name=name,
                 sequence=frame.sequence,
-                before_ir=frame.before_ir,
-                after_ir=str(mod),
                 before_lines=frame.before_lines,
                 after_lines=capture_structure(mod),
             )

--- a/tilelang/tools/pass_visualizer/core.py
+++ b/tilelang/tools/pass_visualizer/core.py
@@ -1,9 +1,9 @@
-"""Core helpers for the pass visualizer: load a user TileLang kernel, build the
-CUDA lowering pass pipeline, and render a PrimFunc's SBlock structure tree.
+"""Core helpers for the pass visualizer: load a user TileLang kernel, capture
+real compiler-pass executions, and render a PrimFunc's SBlock structure tree.
 
-This mirrors ``CUDAPassPipelineBodyPrologue`` in ``tilelang/cuda/pipeline.py``,
-running each prologue pass (through LayoutInference and the post-LayoutInference
-lowering passes) so the structure tree can be captured before/after every stage.
+``StructureTreePassInstrument`` observes the canonical CUDA lowering prologue
+through TVM's ``PassInstrument`` API.  The visualizer therefore follows the
+passes that actually execute instead of maintaining a duplicate pass list.
 
 The kernel file is taken as input; any ``@tilelang.jit`` kernel in the file is
 auto-discovered. These helpers are consumed by ``viewer.py`` to emit an
@@ -13,9 +13,12 @@ interactive HTML pass browser.
 from __future__ import annotations
 
 import ast
+import contextlib
 import importlib.util
+import io
+import logging
+from dataclasses import dataclass
 
-import tilelang
 from tilelang import tvm as tvm
 from tvm import tirx
 from tvm.tirx import PrimFunc, SBlock
@@ -28,11 +31,8 @@ try:
 except ImportError:  # installed package (0.1.x) exposes it here
     from tilelang.utils.target import determine_target
 from tilelang.engine.lower import canon_target_host
-from tilelang.cuda.pipeline import allow_warp_specialized
-from tilelang.backend.pass_pipeline.pipeline_utils import (
-    should_enable_race_check,
-    should_force_let_inline,
-)
+
+logger = logging.getLogger("tilelang.pass_visualizer")
 
 
 def load_user_module(path: str):
@@ -89,58 +89,6 @@ def build_module(func: tirx.PrimFunc, target: str | Target = "auto"):
     target_host = tvm.target.Target(target_host)
     target = tvm.target.Target(target, target_host)
     return mod, target
-
-
-def build_pass_stages(target: Target) -> list[tuple[str, object]]:
-    """Build the ordered CUDA prologue pass list, through the full Prologue.
-
-    Each stage is a ``(name, transform)`` pair where ``transform`` is a TVM pass
-    object callable as ``transform(mod) -> mod``. Conditional passes are resolved
-    here so the returned list reflects what actually runs for this target/config.
-
-    Matches CUDAPassPipelineBodyPrologue (tilelang/cuda/pipeline.py:68-137).
-    """
-    stages: list[tuple[str, object]] = []
-
-    stages.append(("BindTarget", tirx.transform.BindTarget(target)))
-    stages.append(("MaterializeKernelLaunch", tilelang.transform.MaterializeKernelLaunch()))
-    stages.append(("AnnotateDeviceBoundTmaCopies", tilelang.cuda.transform.AnnotateDeviceBoundTmaCopies()))
-
-    if should_force_let_inline():
-        stages.append(("LetInline", tilelang.transform.LetInline()))
-    stages.append(("AddWrapperForSingleBufStore", tilelang.transform.AddWrapperForSingleBufStore()))
-    stages.append(("LegalizeNegativeIndex", tilelang.transform.LegalizeNegativeIndex()))
-
-    if should_enable_race_check():
-        stages.append(("VerifyParallelLoop", tilelang.transform.VerifyParallelLoop()))
-    stages.append(("InjectAssumes", tilelang.transform.InjectAssumes()))
-    stages.append(("Simplify", tilelang.transform.Simplify()))
-    stages.append(("LayoutReducer", tilelang.transform.LayoutReducer()))
-
-    if allow_warp_specialized(target=target):
-        stages.append(("ProducerConsumerWarpSpecialized", tilelang.cuda.transform.ProducerConsumerWarpSpecialized()))
-
-    stages.append(("LowerBlackwell2SM", tilelang.cuda.transform.LowerBlackwell2SM()))
-    stages.append(("IfStmtBinding", tilelang.transform.IfStmtBinding()))
-    stages.append(("PipelinePlanning", tilelang.transform.PipelinePlanning()))
-    stages.append(("InjectSoftwarePipeline", tilelang.transform.InjectSoftwarePipeline()))
-    stages.append(("Simplify", tilelang.transform.Simplify()))
-
-    # Infer memory layouts for fragments and shared memory (pipeline.py:113).
-    stages.append(("LayoutInference", tilelang.transform.LayoutInference()))
-
-    # --- Post-LayoutInference lowering (pipeline.py:117-137) ---
-    # LayoutVisual (pipeline.py:115) is skipped: it only visualizes, not a transform.
-    stages.append(("LowerTileOp", tilelang.transform.LowerTileOp()))
-    stages.append(("LowerL2Persistent", tilelang.cuda.transform.LowerL2Persistent()))
-    stages.append(("DecoupleTypeCast", tilelang.transform.DecoupleTypeCast()))
-    stages.append(("LegalizeVectorizedLoop", tilelang.transform.LegalizeVectorizedLoop()))
-    stages.append(("LegalizeSafeMemoryAccess", tilelang.transform.LegalizeSafeMemoryAccess()))
-    stages.append(("LowerAccessPtr", tilelang.transform.LowerAccessPtr()))
-    stages.append(("Simplify", tilelang.transform.Simplify()))
-    stages.append(("HoistNonRestrictParams", tilelang.transform.HoistNonRestrictParams()))
-
-    return stages
 
 
 def _fmt_shape(shape) -> list:
@@ -391,6 +339,123 @@ def inspect_structure(mod: tvm.IRModule) -> None:
         print("└─ body")
         _walk_stmt(func.body, "       ")
         print()
+
+
+def capture_structure(mod: tvm.IRModule) -> list[str]:
+    """Render ``inspect_structure`` into stable text lines for diffing."""
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        inspect_structure(mod)
+    return buf.getvalue().splitlines()
+
+
+@dataclass
+class PassStructureRecord:
+    """Before/after structure snapshots for one top-level compiler pass."""
+
+    name: str
+    sequence: int
+    before_ir: str
+    after_ir: str
+    before_lines: list[str]
+    after_lines: list[str]
+
+    @property
+    def changed(self) -> bool:
+        return self.before_ir != self.after_ir
+
+
+@dataclass
+class _ActivePass:
+    """One active PassInstrument callback frame, including nested passes."""
+
+    name: str
+    sequence: int | None
+    before_ir: str | None
+    before_lines: list[str] | None
+
+
+@tvm.ir.instrument.pass_instrument
+class StructureTreePassInstrument:
+    """Capture structure trees around the real top-level passes in a pipeline.
+
+    Some top-level TileLang passes invoke nested TVM passes internally.  Those
+    callbacks are tracked so before/after events remain correctly paired, but
+    only depth-zero passes become browser stages.  This preserves the viewer's
+    linear pipeline semantics instead of duplicating a parent's changes in its
+    nested implementation details.
+    """
+
+    def __init__(self):
+        self.records: list[PassStructureRecord] = []
+        self.input_lines: list[str] | None = None
+        self.incomplete_passes: list[str] = []
+        self._stack: list[_ActivePass] = []
+        self._next_sequence = 0
+
+    def enter_pass_ctx(self):
+        self.records.clear()
+        self.input_lines = None
+        self.incomplete_passes.clear()
+        self._stack.clear()
+        self._next_sequence = 0
+
+    def exit_pass_ctx(self):
+        # A failing pass has no run_after_pass callback. Preserve its name for
+        # diagnostics, then clear the stack so this instrument can be reused.
+        if self._stack:
+            self.incomplete_passes.extend(frame.name for frame in self._stack)
+            self._stack.clear()
+
+    def run_before_pass(self, mod: tvm.IRModule, info):
+        name = str(info.name)
+        is_top_level = not self._stack
+        if is_top_level:
+            before_lines = capture_structure(mod)
+            if self.input_lines is None:
+                self.input_lines = before_lines
+            frame = _ActivePass(
+                name=name,
+                sequence=self._next_sequence,
+                before_ir=str(mod),
+                before_lines=before_lines,
+            )
+            self._next_sequence += 1
+        else:
+            frame = _ActivePass(name=name, sequence=None, before_ir=None, before_lines=None)
+        self._stack.append(frame)
+
+    def run_after_pass(self, mod: tvm.IRModule, info):
+        name = str(info.name)
+        if not self._stack:
+            logger.warning("Ignoring unmatched after-pass callback for %s", name)
+            return
+
+        frame = self._stack.pop()
+        if frame.name != name:
+            logger.warning("Ignoring mismatched after-pass callback for %s (expected %s)", name, frame.name)
+            self._stack.clear()
+            return
+
+        if frame.sequence is None:
+            return
+
+        assert frame.before_ir is not None
+        assert frame.before_lines is not None
+        self.records.append(
+            PassStructureRecord(
+                name=name,
+                sequence=frame.sequence,
+                before_ir=frame.before_ir,
+                after_ir=str(mod),
+                before_lines=frame.before_lines,
+                after_lines=capture_structure(mod),
+            )
+        )
+
+    def ordered_records(self) -> list[PassStructureRecord]:
+        """Return completed top-level pass records in execution order."""
+        return sorted(self.records, key=lambda record: record.sequence)
 
 
 def _parse_kv(pairs: list[str]) -> dict[str, object]:

--- a/tilelang/tools/pass_visualizer/viewer.py
+++ b/tilelang/tools/pass_visualizer/viewer.py
@@ -116,11 +116,6 @@ def _highlight(line: str) -> str:
     return s
 
 
-def _capture_tree(mod) -> list[str]:
-    """Compatibility wrapper around the core structure renderer."""
-    return M.capture_structure(mod)
-
-
 def _diff_rows(prev: list[str], cur: list[str]) -> list[dict]:
     """Merge prev->cur into display rows tagged equal / add / del.
 
@@ -176,6 +171,8 @@ def build_pass_data(path: str, factory: str | None, target: str, kwargs: dict[st
     name, kernel = next(iter(kernels.items()))
     func = M.kernel_to_tir(kernel, **kwargs)
     mod, resolved_target = M.build_module(func, target=target)
+    if resolved_target.kind.name != "cuda":
+        raise ValueError(f"Pass Visualizer currently supports only CUDA targets, got {resolved_target.kind.name!r}.")
 
     # Match JIT compilation's pass-config precedence: PrimFunc-level configs
     # first, then explicit @tilelang.jit configs. Normalize enum keys before
@@ -203,7 +200,7 @@ def build_pass_data(path: str, factory: str | None, target: str, kwargs: dict[st
     src_rows = [{"t": "equal", "s": ln, "h": _highlight(ln), "op": bool(_TILEOP_RE.search(ln))} for ln in source.split("\n")]
     captured.append({"name": "source code", "flag": "source", "rows": src_rows})
 
-    input_lines = instrument.input_lines if instrument.input_lines is not None else _capture_tree(mod)
+    input_lines = instrument.input_lines if instrument.input_lines is not None else M.capture_structure(mod)
     captured.append(
         {
             "name": "(input)",
@@ -445,10 +442,10 @@ def _write_outputs(name: str, stages: list[dict], html_path: str) -> str:
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Build an interactive HTML pass browser for a TileLang kernel.")
+    parser = argparse.ArgumentParser(description="Build an interactive HTML CUDA-pass browser for a TileLang kernel.")
     parser.add_argument("path", help="Path to a Python file containing a @tilelang.jit kernel.")
     parser.add_argument("--factory", default=None, help="Name of the kernel to analyze (default: first discovered).")
-    parser.add_argument("--target", default="auto", help="Compilation target (default: auto).")
+    parser.add_argument("--target", default="auto", help="CUDA compilation target (default: auto).")
     parser.add_argument(
         "--set",
         dest="kwargs",

--- a/tilelang/tools/pass_visualizer/viewer.py
+++ b/tilelang/tools/pass_visualizer/viewer.py
@@ -6,8 +6,8 @@ structure tree for the selected pass, with lines added by that pass highlighted
 green and lines it removed shown ghosted red — so switching between passes makes
 "what this pass changed" obvious.
 
-Reuses the tree-rendering logic from core.py verbatim; this file only adds
-per-pass capture, line-level diffing (difflib), and HTML emission.
+The canonical CUDA prologue runs under a ``PassInstrument`` from ``core.py``;
+this file converts its before/after snapshots into line diffs and emits HTML.
 
 Run with::
 
@@ -21,15 +21,17 @@ Run with::
 from __future__ import annotations
 
 import argparse
-import contextlib
 import difflib
 import html
-import io
 import json
 import os
 import re
 
+from tilelang import tvm
+from tilelang.cuda.pipeline import CUDAPassPipelineBodyPrologue
 from tilelang.engine.semantic_check import PreLowerSemanticCheck
+from tilelang.jit import JITImpl
+from tilelang.transform.pass_config import normalize_pass_configs
 
 from . import core as M
 
@@ -115,11 +117,8 @@ def _highlight(line: str) -> str:
 
 
 def _capture_tree(mod) -> list[str]:
-    """Render core.inspect_structure(mod) into a list of text lines."""
-    buf = io.StringIO()
-    with contextlib.redirect_stdout(buf):
-        M.inspect_structure(mod)
-    return buf.getvalue().splitlines()
+    """Compatibility wrapper around the core structure renderer."""
+    return M.capture_structure(mod)
 
 
 def _diff_rows(prev: list[str], cur: list[str]) -> list[dict]:
@@ -155,7 +154,7 @@ def _diff_rows(prev: list[str], cur: list[str]) -> list[dict]:
 
 
 def build_pass_data(path: str, factory: str | None, target: str, kwargs: dict[str, object], source: str) -> tuple[str, list[dict]]:
-    """Run the pipeline pass-by-pass, capturing a tree + diff for each stage.
+    """Observe the real CUDA prologue, capturing a tree + diff for each pass.
 
     Returns (kernel_name, stages) where each stage is:
         {name, flag, rows}
@@ -178,8 +177,24 @@ def build_pass_data(path: str, factory: str | None, target: str, kwargs: dict[st
     func = M.kernel_to_tir(kernel, **kwargs)
     mod, resolved_target = M.build_module(func, target=target)
 
-    PreLowerSemanticCheck(mod)
-    stages = M.build_pass_stages(resolved_target)
+    # Match JIT compilation's pass-config precedence: PrimFunc-level configs
+    # first, then explicit @tilelang.jit configs. Normalize enum keys before
+    # handing them to TVM's PassContext.
+    pass_configs = {}
+    if func.attrs and "tilelang_pass_configs" in func.attrs:
+        pass_configs.update(dict(func.attrs["tilelang_pass_configs"]))
+    if isinstance(kernel, JITImpl) and kernel.pass_configs:
+        pass_configs.update(kernel.pass_configs)
+    pass_configs = normalize_pass_configs(pass_configs)
+
+    # Semantic checks are part of the real pre-lower path but are not lowering
+    # stages. Run them under the same config without adding them to the browser.
+    with tvm.transform.PassContext(opt_level=3, config=pass_configs), resolved_target:
+        PreLowerSemanticCheck(mod)
+
+    instrument = M.StructureTreePassInstrument()
+    with tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=[instrument]), resolved_target:
+        mod = CUDAPassPipelineBodyPrologue(mod, resolved_target)
 
     captured: list[dict] = []
 
@@ -188,8 +203,7 @@ def build_pass_data(path: str, factory: str | None, target: str, kwargs: dict[st
     src_rows = [{"t": "equal", "s": ln, "h": _highlight(ln), "op": bool(_TILEOP_RE.search(ln))} for ln in source.split("\n")]
     captured.append({"name": "source code", "flag": "source", "rows": src_rows})
 
-    prev_lines: list[str] = []
-    input_lines = _capture_tree(mod)
+    input_lines = instrument.input_lines if instrument.input_lines is not None else _capture_tree(mod)
     captured.append(
         {
             "name": "(input)",
@@ -197,24 +211,18 @@ def build_pass_data(path: str, factory: str | None, target: str, kwargs: dict[st
             "rows": _diff_rows([], input_lines),
         }
     )
-    prev_lines = input_lines
 
-    for idx, (pname, transform) in enumerate(stages, start=1):
-        before = str(mod)
-        with resolved_target:  # post-LayoutInference passes need Target.Current()
-            mod = transform(mod)
-        after = str(mod)
-        changed = before != after
-
-        cur_lines = _capture_tree(mod)
+    for idx, record in enumerate(instrument.ordered_records(), start=1):
+        # PassInfo names carry a namespace (tirx.BindTarget, tl.LowerTileOp).
+        # Keep the compact names used by the existing browser UI.
+        pname = record.name.rsplit(".", 1)[-1]
         captured.append(
             {
                 "name": f"[{idx:02d}] {pname}",
-                "flag": "changed" if changed else "no-op",
-                "rows": _diff_rows(prev_lines, cur_lines),
+                "flag": "changed" if record.changed else "no-op",
+                "rows": _diff_rows(record.before_lines, record.after_lines),
             }
         )
-        prev_lines = cur_lines
 
     return name, captured
 

--- a/tilelang/transform/add_bufstore_wrapper.py
+++ b/tilelang/transform/add_bufstore_wrapper.py
@@ -151,4 +151,4 @@ def AddWrapperForSingleBufStore():
 
         return func.with_body(new_body)
 
-    return prim_func_pass(pass_fn, opt_level=0)
+    return prim_func_pass(pass_fn, opt_level=0, name="tl.AddWrapperForSingleBufStore")

--- a/tilelang/transform/decouple_type_cast.py
+++ b/tilelang/transform/decouple_type_cast.py
@@ -631,4 +631,4 @@ def DecoupleTypeCast():
         new_body = mutator.visit_stmt(func.body)
         return func.with_body(new_body)
 
-    return prim_func_pass(pass_fn, opt_level=0)
+    return prim_func_pass(pass_fn, opt_level=0, name="tl.DecoupleTypeCast")


### PR DESCRIPTION
## Summary

- Replace the Pass Visualizer duplicate CUDA prologue list with a TVM `PassInstrument` attached to the canonical prologue.
- Keep structure-tree reports synchronized with target-dependent and pass-config-dependent compilation behavior.

## Changes

- Capture before/after structure trees for each top-level pass while folding nested implementation passes into their parent stage.
- Run semantic checks and the canonical CUDA prologue with normalized PrimFunc and JIT pass configurations from the analyzed kernel.
- Add stable `PassInfo` names for Python-defined passes visible in the instrumented report.
- Remove the fixed `build_pass_stages` helper and update the public exports, documentation, and regression coverage.
- Cover real pipeline observation, conditional pass configuration, nested callbacks, failure cleanup, and HTML/text emission.

## Validation

- `./format.sh`
- `python -m pytest testing/python/debug/test_pass_visualizer.py testing/python/transform/test_tilelang_transform_decouple_type_cast.py -x -q` (26 passed, 1 skipped)
- `python -m pytest testing/python/debug/test_lower_trace.py testing/python/debug/test_pass_diff.py -x -q` (76 passed)

## Notes

- The viewer remains focused on `CUDAPassPipelineBodyPrologue`; full-pipeline tracing remains available through `TL_LOWER_TRACE`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Refactored the Pass Visualizer to use `StructureTreePassInstrument` on the canonical `CUDAPassPipelineBodyPrologue`.
- Captured before/after structure trees for top-level passes.
- Grouped nested implementation passes under their parent stages.
- Applied normalized JIT and `PrimFunc` pass configurations from the analyzed kernel.
- Added stable names for Python-defined passes.
- Removed `build_pass_stages`.
- Added `capture_structure`, `PassStructureRecord`, and `StructureTreePassInstrument` exports.
- Added explicit names for several TileLang passes.
- Updated documentation and CLI descriptions to identify CUDA support and canonical pipeline tracing.
- Added regression coverage for conditional ordering, nested callbacks, change detection, failure cleanup, dynamic passes, and pass configurations.

## Validation

- 26 tests passed, 1 skipped.
- 76 tests passed.
- Formatting and targeted test suites completed successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->