### PR TITLE
[Doc] Fix wrong loop bound in FlashAttention README example

### DIFF
--- a/examples/flash_attention/README.md
+++ b/examples/flash_attention/README.md
@@ -66,7 +66,7 @@ def flash_attention(
 
             # Copy V block into shared memory
             T.copy(V[bz, k * block_N : (k + 1) * block_N, by, :], V_shared)
-            for i, j in T.Parallel(block_M, dim):
+            for i, j in T.Parallel(block_M, block_N):
                 acc_s[i, j] *= scale
 
             # Save old scores_max, then reset scores_max


### PR DESCRIPTION
    [Doc] Fix wrong loop bound in FlashAttention README example
    
    The scale multiplication loop for acc_s iterates over (block_M, dim),
    but acc_s is allocated as [block_M, block_N]. The `dim` variable refers
    to the head dimension of acc_o, not acc_s. Replace dim with block_N so
    the loop bound matches the actual buffer shape.
    
    Fixes #2867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the FlashAttention README example to iterate over `T.Parallel(block_M, block_N)` when scaling `acc_s`.
- The loop now matches `acc_s`’s `[block_M, block_N]` shape.
- Fixes `#2867`.

## C++ style / lint notes

- The change does not touch C++ source, C++ style documentation, CI, or lint tooling.
- The C++ API Style Audit does not apply.

## Testing

- Documentation-only change. No tests were added or changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->