### PR TITLE
[BugFix] Skip DecoupleTypeCast on Evaluate roots to keep cp.async operands in their address spaces

### DIFF
--- a/testing/python/transform/test_tilelang_transform_decouple_type_cast.py
+++ b/testing/python/transform/test_tilelang_transform_decouple_type_cast.py
@@ -651,10 +651,13 @@ def test_codegen_pipelined_int64_index_cp_async_operands():
 
     source = kernel_fn().get_kernel_source()
 
-    assert "cp_async" in source, "Expected cp.async lowering for disable_tma copy"
-    for line in source.splitlines():
-        if "cp_async_gs" in line:
-            assert "_local_cast" not in line, f"cp_async operand points at local memory: {line.strip()}"
+    # Filter for the data-movement calls specifically: cp_async_commit/cp_async_wait
+    # also match a bare "cp_async" substring, so they alone would satisfy a laxer check
+    # while leaving the operand assertion below with nothing to inspect.
+    gs_lines = [line for line in source.splitlines() if "cp_async_gs" in line]
+    assert gs_lines, "Expected cp_async_gs (global->shared) calls for disable_tma copy"
+    for line in gs_lines:
+        assert "_local_cast" not in line, f"cp_async operand points at local memory: {line.strip()}"
 
 
 if __name__ == "__main__":

--- a/testing/python/transform/test_tilelang_transform_decouple_type_cast.py
+++ b/testing/python/transform/test_tilelang_transform_decouple_type_cast.py
@@ -570,5 +570,92 @@ def test_e2e_scalar_load_no_cast_buffer():
     assert "b_local_cast" not in source, "Scalar load b[0] should not get a cast buffer"
 
 
+def test_no_transform_evaluate_root_opaque_intrinsic():
+    """Test that a vectorized loop whose body is an opaque intrinsic is skipped.
+
+    Decoupling splits the value edge of a BufferStore to insert a staging
+    buffer. An Evaluate discards its result and stores nothing, so that edge
+    does not exist. Here the int64 index casts inside the ptx_cp_async
+    predicate previously made the pass treat the statement as mixed-precision
+    compute and rewrite both address operands to local staging buffers.
+
+    Regression test for issue #2497.
+    """
+
+    @T.prim_func
+    def before(a: T.Tensor[(256,), T.bfloat16], b: T.Tensor[(256,), T.bfloat16]):
+        for i in T.vectorized(8):
+            T.ptx_cp_async(
+                T.address_of(b[i]),
+                T.address_of(a[i]),
+                1,
+                T.cast(i, "int64") < T.int64(128),
+            )
+
+    @T.prim_func
+    def after(a: T.Tensor[(256,), T.bfloat16], b: T.Tensor[(256,), T.bfloat16]):
+        for i in T.vectorized(8):
+            T.ptx_cp_async(
+                T.address_of(b[i]),
+                T.address_of(a[i]),
+                1,
+                T.cast(i, "int64") < T.int64(128),
+            )
+
+    _check(before, after)
+
+
+@tilelang.testing.requires_cuda
+def test_codegen_pipelined_int64_index_cp_async_operands():
+    """Test that pipelined global→shared copies keep global/shared cp_async operands.
+
+    With int64 index arithmetic, DecoupleTypeCast used to rewrite the address
+    operands of ptx_cp_async to kernel-local register arrays, emitting
+    cp_async_gs_conditional(local, local). That violates the instruction's
+    address-space constraints (dst must be shared, src must be global) and
+    fails at launch with CUDA_ERROR_INVALID_ADDRESS_SPACE.
+
+    Regression test for issue #2497.
+    """
+    block_size, head_dim, num_stages = 128, 128, 2
+
+    @tilelang.jit
+    def kernel_fn():
+        total_len = T.dynamic("total_len", "int64")
+        num_blocks = T.dynamic("num_blocks")
+
+        @T.prim_func
+        def main(
+            Input: T.Tensor[(total_len, head_dim), T.bfloat16],
+            Output: T.Tensor[(total_len, head_dim), T.float32],
+            Offsets: T.Tensor[(num_blocks,), T.int64],
+        ):
+            with T.Kernel(num_blocks, threads=256) as bx:
+                shared_buf = T.alloc_shared((block_size, head_dim), T.bfloat16)
+                accum = T.alloc_fragment((block_size, head_dim), T.float32)
+
+                offset = Offsets[bx]
+                trip_count = T.ceildiv(T.cast(total_len - offset, "int32"), block_size)
+                for i in T.Pipelined(trip_count, num_stages=num_stages):
+                    start = T.cast(i, "int64") * block_size
+                    T.copy(
+                        Input[offset + start : offset + start + block_size, :],
+                        shared_buf,
+                        disable_tma=True,
+                    )
+                    for r, c in T.Parallel(block_size, head_dim):
+                        accum[r, c] = T.cast(shared_buf[r, c], T.float32)
+                        Output[offset + start + T.cast(r, "int64"), c] = accum[r, c]
+
+        return main
+
+    source = kernel_fn().get_kernel_source()
+
+    assert "cp_async" in source, "Expected cp.async lowering for disable_tma copy"
+    for line in source.splitlines():
+        if "cp_async_gs" in line:
+            assert "_local_cast" not in line, f"cp_async operand points at local memory: {line.strip()}"
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/tilelang/transform/decouple_type_cast.py
+++ b/tilelang/transform/decouple_type_cast.py
@@ -397,6 +397,17 @@ class DecoupleTypeCastMutator(tirx.PyStmtExprMutator):
         if _contains_seq_stmt(normalized_body):
             return self._make_for(op, new_body) if new_body is not op.body else op
 
+        # Skip Evaluate roots. Decoupling splits the value edge of a BufferStore
+        # to insert a staging buffer; an Evaluate discards its result and stores
+        # nothing, so that edge does not exist and the transform is undefined.
+        # Opaque intrinsic statements such as `tl.ptx_cp_async(...)` land here,
+        # and their operands are address arguments with address-space
+        # constraints (dst must be shared, src must be global) that rewriting to
+        # local staging buffers would violate.
+        _, root_stmt = extract_if_condition(normalized_body)
+        if isinstance(root_stmt, Evaluate):
+            return self._make_for(op, new_body) if new_body is not op.body else op
+
         # Collect all shared/global stores and loads
         collector = MemoryAccessCollector(op.loop_var)
         collector.visit_stmt(normalized_body)


### PR DESCRIPTION
## Summary

Fixes #2497.

`DecoupleTypeCast` was rewriting the address operands of `tl.ptx_cp_async` into
local staging buffers, so CUDA codegen emitted
`cp_async_gs_conditional<N>(local, local)` instead of the required
`global -> shared` form. The resulting kernel fails at launch with
`CUDA_ERROR_INVALID_ADDRESS_SPACE` (reported on H800 / sm_90).

The fix is a single guard: the pass now leaves `Evaluate` roots alone.
Decoupling works by splitting the value edge of a `BufferStore` to insert a
staging buffer; an `Evaluate` discards its result and stores nothing, so that
edge does not exist and the transform has nothing to act on.

## Root Cause

The pass detects "mixed-precision compute" by looking for `Cast` nodes in the
vectorized loop body (`_has_cast`). Two gates then decide the rewrite, and the
bug needs both.

**Gate 1 — misclassified trigger.** With int64 index arithmetic, `T.copy` lowers
to a `tl.ptx_cp_async(dst, src, num_elems, predicate)` whose guard predicate
carries explicit `T.Cast("int64", ...)` nodes:

```python
T.ptx_cp_async(
    T.access_ptr(shared_buf[0, ...], 1, 2),                 # arg0: dst, shared, write
    T.access_ptr(Input[... + offset, ...], 1, 1),            # arg1: src, global, read
    1,                                                       # arg2: num_elems
    offset + T.Cast("int64", ...) < total_len
    and offset + T.Cast("int64", ...) >= T.int64(0),         # arg3: guard predicate
)
```

The casts inside `arg0`/`arg1` sit in `BufferLoad.indices` and are correctly
skipped by the existing empty `visit_buffer_load_`. The ones in the predicate
(`arg3`) are not wrapped in any `BufferLoad`, so `_CastFinder` reports
`found=True` and the pass concludes a mixed-precision decouple is needed. With
int32 indices no explicit cast node is produced and the pass is a no-op — which
is why the bug is int64-specific.

**Gate 2 — address operand treated as data.** `MemoryAccessCollector.visit_call_`
recurses into all args of non-`if_then_else` calls, so it reaches
`tl.access_ptr(BufferLoad(Input, ...), ...)` and collects that `BufferLoad` as a
data access. Per `src/op/builtin.h`, the `BufferLoad` argument of
`tl.access_ptr` is an *address carrier* (kept in that shape so it can lower to
`tvm_access_ptr`), not a value to read. `AccessReplacer` then rewrites it to
`BufferLoad(Input_local_cast_1, [vec])`, pointing the operand at registers.

The result: the real address arithmetic is hoisted into two synchronous copy
loops, and the surviving `cp.async` is both redundant and illegal.

```python
# after the pass
shared_buf_local_cast = T.alloc_buffer((8,), "bfloat16", scope="local")
Input_local_cast_1    = T.alloc_buffer((8,), "bfloat16", scope="local")
for vec_copy in T.vectorized(8):
    shared_buf_local_cast[vec_copy] = shared_buf[0, ...]     # new sync copy
for vec_copy in T.vectorized(8):
    Input_local_cast_1[vec_copy] = Input[... + offset, ...]   # new sync copy
for vec in T.vectorized(8):
    T.ptx_cp_async(
        T.access_ptr(shared_buf_local_cast[vec], 1, 2),       # now local
        T.access_ptr(Input_local_cast_1[vec], 1, 1),          # now local
        1, <predicate unchanged>)                             # trigger cast untouched
```

Note the predicate is left byte-for-byte identical: the casts that triggered the
whole rewrite are never acted on, which is itself evidence the trigger is
spurious.

## Changes

`tilelang/transform/decouple_type_cast.py` (+11) — early return when the loop
body root, after inlining flat `Bind`s and stripping one `IfThenElse` layer, is
an `Evaluate`. Placed next to the existing `_contains_seq_stmt` guard and
*before* `MemoryAccessCollector` is constructed, so both gates are closed at
once. Reuses the `extract_if_condition` call that the function already needs.

Opaque intrinsic statements such as `tl.ptx_cp_async` land here, and their
operands are addresses with address-space constraints (dst shared, src global)
that staging buffers would violate.

The guard matches `Evaluate` specifically rather than "anything that is not a
`BufferStore`". The narrow form rests on a language-level invariant — an
`Evaluate` cannot store a value, so the edge decoupling needs cannot exist —
instead of on current test coverage, and it leaves every other statement shape
on its existing path.

`testing/python/transform/test_tilelang_transform_decouple_type_cast.py` (+87) —
two regression tests, one per layer.

## Tested

| Check | Result |
|---|---|
| Pass 19 status on the reproducer (`TL_LOWER_TRACE`) | `CHANGED` -> `NO-OP`, matching the int32 control |
| Reproducer codegen | 2 `cp_async` calls, 0 malformed (was 2/2); `dst=&shared_buf[...]`, `src=&Input[...]`; 92 -> 67 lines |
| Lowered TIR | no `decoupled_cast` block, no `_local_cast` buffer |
| `testing/python/transform/` | 320 passed, 57 skipped, 0 failed |
| Target test file | 17 passed, 4 skipped (skips require sm_90/sm_100) |
| Example codegen diff | 4 kernels byte-for-byte identical before/after (`diff -rq`, exit 0) |
| `format.sh` | all hooks pass |

**Regression tests are two-layered.** `test_no_transform_evaluate_root_opaque_intrinsic`
asserts at the transform layer that the pass is a no-op on an
`Evaluate(ptx_cp_async(...))` root via `structural_equal` — fast and precise.
`test_codegen_pipelined_int64_index_cp_async_operands` compiles the reproducer
shape (int64 indices + `T.Pipelined(num_stages=2)` + `disable_tma=True`) and
asserts no `cp_async` operand contains `_local_cast`. The second layer pins the
user-visible symptom, so the test still catches the bug if a future refactor
changes how correctness is enforced, or if malformed codegen reappears via a
different path.

**Negative check.** Neutering the guard (`if False:`) makes both new tests fail
with exactly the issue's shape,
`cp_async_gs_conditional<4>((&(shared_buf_local_cast[...])), (&(Input_local_cast_1[...])), ...)`,
confirming they fail for the intended reason.

**On "no behavior change".** The example codegen diff is the load-bearing
evidence here, not the unit tests: fp8 per-token cast (the pass's main use case),
mixed-precision elementwise, pipelined gemm with `num_stages=3`, and a pipelined
fp8 shared store all generate identical CUDA before and after. Across the 19
existing tests in the target file, every transforming site has a `BufferStore`
root after condition stripping (7 direct, 1 behind an `if`); an `Evaluate` root
never appears, so nothing previously transformed is now skipped.

`DecoupleTypeCast` runs in the cuda, cpu, rocm, metal and webgpu pipelines, so
the guard applies to all of them; the codegen-diff evidence covers cuda.

## Reproducer

```python
for i in T.Pipelined(trip_count, num_stages=2):
    start = T.cast(i, "int64") * block_size
    T.copy(Input[offset + start:offset + start + block_size, :], shared_buf, disable_tma=True)
    for r, c in T.Parallel(block_size, head_dim):
        accum[r, c] = T.cast(shared_buf[r, c], T.float32)
        Output[offset + start + T.cast(r, "int64"), c] = accum[r, c]
```

Needs int64 index arithmetic, `num_stages >= 2`, `disable_tma=True`, and a
consumer of the shared buffer. Gemm, varlen batching, dynamic shapes and
data-dependent trip counts are all irrelevant.

## Note for reviewers

Two adjacent items were deliberately left out of this PR.

`MemoryAccessCollector` treating the `tl.access_ptr` `BufferLoad` as a data
access (gate 2) is still there, but with the guard in place that code path is
unreachable in the current lowering pipeline: the collector only runs on
`BufferStore` roots, and `tl.access_ptr` appears only after lowering to
intrinsics, where the root is `Evaluate`. Adding a second filter there would be
untestable defensive code.

The collector skips `if_then_else` conditions but `_CastFinder` does not — a
real asymmetry, with no known input where it causes a wrong decision. Changing
the detection predicate to fix an unobservable difference seemed worse than
leaving it documented here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes issue `#2497` by preventing `DecoupleTypeCast` from rewriting address operands of `tl.ptx_cp_async` operations. The bug occurs when auto-`cp.async` lowering with int64 index arithmetic generates `cp_async_gs_conditional(local, local)` instead of the required global-to-shared form, causing `CUDA_ERROR_INVALID_ADDRESS_SPACE` at kernel launch on H800/sm_90 GPUs.

## Root Cause

Two gates trigger the bug:

**Gate 1**: With int64 index arithmetic, `T.copy` lowers to `tl.ptx_cp_async` with explicit `T.Cast("int64", ...)` nodes in the guard predicate. The `_CastFinder` detects these as mixed-precision compute, triggering the `DecoupleTypeCast` pass.

**Gate 2**: `MemoryAccessCollector.visit_call_` recurses into all non-`if_then_else` call arguments, treating the `tl.access_ptr(BufferLoad(...), ...)` address carrier as a data access. The `AccessReplacer` then rewrites it to use local staging buffers.

## Fix

The fix adds an early return when the loop body root (after inlining flat `Bind`s and stripping one `IfThenElse` layer) is an `Evaluate`. Since `Evaluate` discards its result and stores nothing, the value edge decoupling requires cannot exist. This preserves address-space constraints for opaque intrinsic statements like `tl.ptx_cp_async`.

### Changes to `tilelang/transform/decouple_type_cast.py`

Added guard logic (+11 lines) that checks if the normalized root statement is an `Evaluate`. When true, the pass returns the loop unchanged. This prevents rewriting of address operands in opaque intrinsic calls that have strict address-space constraints (destination must be shared memory, source must be global memory).

### Changes to `testing/python/transform/test_tilelang_transform_decouple_type_cast.py`

Added two regression tests (+87 lines):

- `test_no_transform_evaluate_root_opaque_intrinsic()`: Verifies that vectorized loops with `Evaluate` root statements containing opaque intrinsics remain unchanged after transformation.
- `test_codegen_pipelined_int64_index_cp_async_operands()`: Validates the end-to-end behavior for pipelined global-to-shared copies, confirming that generated `cp_async_gs` lines use correct global and shared memory addresses instead of local register casts.

The test refinement in the second commit improves test robustness by:
- Filtering for `cp_async_gs` lines specifically (global-to-shared async copies)
- Asserting the filtered collection is non-empty before checking operands
- Verifying each line does not contain illegal `_local_cast` operands

This ensures the test validates the intended user-visible symptom rather than passing vacuously when no global-to-shared calls exist.

## Validation

- The pass is a no-op on `Evaluate(ptx_cp_async(...))` loop roots
- Generated CUDA code is identical before and after for four kernel examples
- 320 existing tests pass with 0 failures
- The fix eliminates runtime `CUDA_ERROR_INVALID_ADDRESS_SPACE` on TileLang 0.1.9, including fully divisible KV-loop configurations with `num_stages=2` and automatic async-copy lowering enabled
<!-- end of auto-generated comment: release notes by coderabbit.ai -->