### PR TITLE
[TIR][Python] Split backend-specific op proxies

### DIFF
--- a/testing/python/language/test_tilelang_language_dialect.py
+++ b/testing/python/language/test_tilelang_language_dialect.py
@@ -5,10 +5,13 @@ import pytest
 import tilelang
 import tilelang.language as T_default
 import tilelang.language.common as T_comm
+import tilelang.language.tir.op as common_tir_op
 from tilelang.language.tir.exports import (
+    BACKEND_ONLY_TIR_EXPORTS,
     CLASSIFIED_VENDOR_TIR_EXPORTS,
     CUDA_ONLY_TIR_EXPORTS,
     METAL_ONLY_TIR_EXPORTS,
+    ROCM_ONLY_TIR_EXPORTS,
     SHARED_LEGACY_TIR_EXPORTS,
 )
 
@@ -32,7 +35,9 @@ ROCM_ONLY_NAMES = {
     "mfma",
     "rdna_wmma",
     "tvm_mfma",
+    "tvm_mfma_store",
     "tvm_rdna_wmma",
+    "tvm_rdna_wmma_store",
 }
 
 
@@ -55,6 +60,12 @@ def test_common_language_preserves_special_dsl_exports():
     assert hasattr(T_comm, "__log")
     assert CUDA_ONLY_TIR_EXPORTS.isdisjoint(T_comm.__all__)
     assert METAL_ONLY_TIR_EXPORTS.isdisjoint(T_comm.__all__)
+    assert ROCM_ONLY_TIR_EXPORTS.isdisjoint(T_comm.__all__)
+
+
+def test_common_tir_op_module_contains_no_backend_owned_implementations():
+    for name in BACKEND_ONLY_TIR_EXPORTS:
+        assert not hasattr(common_tir_op, name)
 
 
 def test_cuda_language_composes_common_and_cuda_symbols():
@@ -80,6 +91,7 @@ def test_rocm_language_composes_common_and_rocm_symbols():
     assert T.mfma is T.tvm_mfma
     assert T.mfma_store is T.tvm_mfma_store
     assert set(T.__all__) >= ROCM_ONLY_NAMES
+    assert set(T.__all__) >= ROCM_ONLY_TIR_EXPORTS
     assert hasattr(T, "MatrixCoreIntrinEmitter")
     assert hasattr(T, "make_mfma_swizzle_layout")
     assert set(T.__all__) >= SHARED_LEGACY_TIR_EXPORTS
@@ -129,10 +141,22 @@ def test_metal_language_owns_simdgroup_tir_exports():
     assert set(T.__all__) >= METAL_ONLY_TIR_EXPORTS
 
 
+def test_backend_tir_modules_own_their_vendor_ops():
+    from tilelang.cuda.language import tir as cuda_tir
+    from tilelang.rocm.language import tir as rocm_tir
+
+    assert all(hasattr(cuda_tir, name) for name in CUDA_ONLY_TIR_EXPORTS)
+    assert all(hasattr(rocm_tir, name) for name in ROCM_ONLY_TIR_EXPORTS)
+    assert cuda_tir.ptx_wgmma_ss.__module__ == "tilelang.cuda.language.tir"
+    assert rocm_tir.tvm_mfma.__module__ == "tilelang.rocm.language.tir"
+
+
 def test_upstream_vendor_tir_exports_are_classified():
     import tvm.tirx.script.parser as upstream_tir_parser
 
-    vendor_exports = {name for name in upstream_tir_parser.__all__ if name.startswith("ptx_") or "simdgroup" in name}
+    vendor_exports = {
+        name for name in upstream_tir_parser.__all__ if name.startswith("ptx_") or "simdgroup" in name or name in {"mma_fill", "mma_store"}
+    }
     assert vendor_exports <= CLASSIFIED_VENDOR_TIR_EXPORTS
 
 
@@ -148,6 +172,7 @@ def test_upstream_vendor_tir_exports_are_classified():
 def test_non_cuda_dialects_do_not_export_cuda_symbols(module_name):
     module = importlib.import_module(module_name)
     assert CUDA_ONLY_NAMES.isdisjoint(module.__all__)
+    assert CUDA_ONLY_TIR_EXPORTS.isdisjoint(module.__all__)
 
 
 @pytest.mark.parametrize(
@@ -162,6 +187,7 @@ def test_non_cuda_dialects_do_not_export_cuda_symbols(module_name):
 def test_non_rocm_dialects_do_not_export_rocm_symbols(module_name):
     module = importlib.import_module(module_name)
     assert ROCM_ONLY_NAMES.isdisjoint(module.__all__)
+    assert ROCM_ONLY_TIR_EXPORTS.isdisjoint(module.__all__)
 
 
 def test_common_only_dialects_match_common_surface():

--- a/tilelang/cuda/language/tir.py
+++ b/tilelang/cuda/language/tir.py
@@ -1,6 +1,11 @@
 """CUDA-specific low-level TIR language operators."""
 
-import tilelang.language.tir.op as _tir_op
+from __future__ import annotations
+
+import tvm
+import tvm.tirx.op as _tvm_op
+from tvm.tirx.expr import IntImm
+
 from tilelang.language.tir.exports import CUDA_ONLY_TIR_EXPORTS, SHARED_LEGACY_TIR_EXPORTS
 from tilelang.language.tir.ir import (
     _dtype_forward,
@@ -13,20 +18,396 @@ from tilelang.language.tir.ir import (
     ptx_init_barrier_thread_count as ptx_init_barrier_thread_count,
     ptx_wait_group as ptx_wait_group,
 )
+from tilelang.language.tir.op import call_intrin as _call_intrin
 
-ptx_cp_async_bulk = _dtype_forward(_tir_op.ptx_cp_async_bulk)
-ptx_fence_barrier_init = _op_wrapper(_tir_op.ptx_fence_barrier_init)
-ptx_ldmatrix = _dtype_forward(_tir_op.ptx_ldmatrix)
-ptx_mma = _dtype_forward(_tir_op.ptx_mma)
-ptx_mma_block_scale = _dtype_forward(_tir_op.ptx_mma_block_scale)
-ptx_mma_sp = _dtype_forward(_tir_op.ptx_mma_sp)
-ptx_tcgen05_mma_blockscaled_ss = _dtype_forward(_tir_op.ptx_tcgen05_mma_blockscaled_ss)
-ptx_tcgen05_mma_ss = _dtype_forward(_tir_op.ptx_tcgen05_mma_ss)
-ptx_tcgen05_mma_ts = _dtype_forward(_tir_op.ptx_tcgen05_mma_ts)
-ptx_wait_barrier = _op_wrapper(_tir_op.ptx_wait_barrier)
-ptx_wgmma_rs = _dtype_forward(_tir_op.ptx_wgmma_rs)
-ptx_wgmma_sp_rs = _dtype_forward(_tir_op.ptx_wgmma_sp_rs)
-ptx_wgmma_sp_ss = _dtype_forward(_tir_op.ptx_wgmma_sp_ss)
-ptx_wgmma_ss = _dtype_forward(_tir_op.ptx_wgmma_ss)
+
+# Unchanged upstream CUDA operators are rebound directly in the CUDA dialect.
+mma_fill = _dtype_forward(_tvm_op.mma_fill)
+mma_store = _dtype_forward(_tvm_op.mma_store)
+ptx_cp_async_bulk = _dtype_forward(_tvm_op.ptx_cp_async_bulk)
+ptx_mma = _dtype_forward(_tvm_op.ptx_mma)
+ptx_mma_sp = _dtype_forward(_tvm_op.ptx_mma_sp)
+ptx_wait_barrier = _op_wrapper(_tvm_op.ptx_wait_barrier)
+
+
+@_dtype_forward
+def ptx_mma_block_scale(
+    accum_dtype,
+    shape,
+    A_layout,
+    B_layout,
+    kind,
+    scale_vec_size,
+    A_dtype,
+    B_dtype,
+    scale_type,
+    multiplicand_a,
+    a_index,
+    multiplicand_b,
+    b_index,
+    accumulator,
+    c_index,
+    scale_a,
+    scale_b,
+    scale_a_byte_id=0,
+    scale_a_thread_id=0,
+    scale_b_byte_id=0,
+    scale_b_thread_id=0,
+):
+    """Build an SM120a warp-level NVF4 block-scaled MMA call."""
+
+    def _selector_value(value):
+        return IntImm("int32", value) if isinstance(value, int) else value
+
+    return _call_intrin(
+        accum_dtype,
+        _tvm_op.Op.get("tl.ptx_mma_block_scale"),
+        tvm.tirx.StringImm(str(accum_dtype)),
+        tvm.tirx.StringImm(str(shape)),
+        tvm.tirx.StringImm(str(A_layout)),
+        tvm.tirx.StringImm(str(B_layout)),
+        tvm.tirx.StringImm(str(kind)),
+        IntImm("int32", scale_vec_size),
+        tvm.tirx.StringImm(str(A_dtype)),
+        tvm.tirx.StringImm(str(B_dtype)),
+        tvm.tirx.StringImm(str(scale_type)),
+        multiplicand_a,
+        a_index,
+        multiplicand_b,
+        b_index,
+        accumulator,
+        c_index,
+        scale_a,
+        scale_b,
+        _selector_value(scale_a_byte_id),
+        _selector_value(scale_a_thread_id),
+        _selector_value(scale_b_byte_id),
+        _selector_value(scale_b_thread_id),
+    )
+
+
+@_dtype_forward
+def ptx_wgmma_ss(
+    dtype,
+    wgmma_prefix,
+    a_is_k_major,
+    b_is_k_major,
+    a_dtype_abbrv,
+    b_dtype_abbrv,
+    accum_dtype_abbrv,
+    A_desc,
+    A_offset,
+    B_desc,
+    B_offset,
+    C_data,
+    C_offset,
+    scale_out,
+    scale_in_a,
+    scale_in_b,
+):
+    return _call_intrin(
+        dtype,
+        _tvm_op.Op.get("tl.ptx_wgmma_ss"),
+        wgmma_prefix,
+        a_is_k_major,
+        b_is_k_major,
+        a_dtype_abbrv,
+        b_dtype_abbrv,
+        accum_dtype_abbrv,
+        A_desc,
+        A_offset,
+        B_desc,
+        B_offset,
+        C_data,
+        C_offset,
+        scale_out,
+        scale_in_a,
+        scale_in_b,
+    )
+
+
+@_dtype_forward
+def ptx_wgmma_rs(
+    dtype,
+    wgmma_prefix,
+    b_is_k_major,
+    a_dtype_abbrv,
+    b_dtype_abbrv,
+    accum_dtype_abbrv,
+    A_buf,
+    A_offset,
+    B_desc,
+    B_offset,
+    C_data,
+    C_offset,
+    scale_out,
+    scale_in_a,
+    scale_in_b,
+):
+    return _call_intrin(
+        dtype,
+        _tvm_op.Op.get("tl.ptx_wgmma_rs"),
+        wgmma_prefix,
+        b_is_k_major,
+        a_dtype_abbrv,
+        b_dtype_abbrv,
+        accum_dtype_abbrv,
+        A_buf,
+        A_offset,
+        B_desc,
+        B_offset,
+        C_data,
+        C_offset,
+        scale_out,
+        scale_in_a,
+        scale_in_b,
+    )
+
+
+@_dtype_forward
+def ptx_wgmma_sp_ss(
+    dtype,
+    wgmma_prefix,
+    a_is_k_major,
+    b_is_k_major,
+    a_dtype_abbrv,
+    b_dtype_abbrv,
+    accum_dtype_abbrv,
+    A_desc,
+    A_offset,
+    E_data,
+    E_offset,
+    sparse_selector,
+    B_desc,
+    B_offset,
+    C_data,
+    C_offset,
+    scale_out,
+    scale_in_a,
+    scale_in_b,
+):
+    return _call_intrin(
+        dtype,
+        _tvm_op.Op.get("tl.ptx_wgmma_sp_ss"),
+        wgmma_prefix,
+        a_is_k_major,
+        b_is_k_major,
+        a_dtype_abbrv,
+        b_dtype_abbrv,
+        accum_dtype_abbrv,
+        A_desc,
+        A_offset,
+        E_data,
+        E_offset,
+        sparse_selector,
+        B_desc,
+        B_offset,
+        C_data,
+        C_offset,
+        scale_out,
+        scale_in_a,
+        scale_in_b,
+    )
+
+
+@_dtype_forward
+def ptx_wgmma_sp_rs(
+    dtype,
+    wgmma_prefix,
+    b_is_k_major,
+    a_dtype_abbrv,
+    b_dtype_abbrv,
+    accum_dtype_abbrv,
+    A_buf,
+    A_offset,
+    E_buf,
+    E_offset,
+    sparse_selector,
+    B_desc,
+    B_offset,
+    C_data,
+    C_offset,
+    scale_out,
+    scale_in_a,
+    scale_in_b,
+):
+    return _call_intrin(
+        dtype,
+        _tvm_op.Op.get("tl.ptx_wgmma_sp_rs"),
+        wgmma_prefix,
+        b_is_k_major,
+        a_dtype_abbrv,
+        b_dtype_abbrv,
+        accum_dtype_abbrv,
+        A_buf,
+        A_offset,
+        E_buf,
+        E_offset,
+        sparse_selector,
+        B_desc,
+        B_offset,
+        C_data,
+        C_offset,
+        scale_out,
+        scale_in_a,
+        scale_in_b,
+    )
+
+
+@_dtype_forward
+def ptx_tcgen05_mma_ss(
+    kind_dtype,
+    desc_a,
+    A_offset,
+    desc_b,
+    B_offset,
+    C_ptr,
+    C_offset,
+    desc_val,
+    scale_out,
+    mask0,
+    mask1,
+    mask2,
+    mask3,
+    enable_ws=False,
+    enable_2cta=False,
+    ws=None,
+    warp_specialized=None,
+    variant=None,
+):
+    """Build a TCGEN05 shared-memory x shared-memory MMA call."""
+    if ws is not None:
+        enable_ws = bool(ws)
+    if warp_specialized is not None:
+        enable_ws = bool(warp_specialized)
+    if variant is not None:
+        if isinstance(variant, str):
+            variant = variant.lower()
+            if variant in ("ws", "warp_specialized", "warp-specialized"):
+                enable_ws = True
+            elif variant in ("default", "std", "ss"):
+                enable_ws = False
+            else:
+                raise ValueError(f"ptx_tcgen05_mma_ss: unknown variant: {variant}")
+        else:
+            enable_ws = bool(variant)
+
+    return _call_intrin(
+        "handle",
+        _tvm_op.Op.get("tl.ptx_tcgen05_mma_ss"),
+        kind_dtype,
+        desc_a,
+        A_offset,
+        desc_b,
+        B_offset,
+        C_ptr,
+        C_offset,
+        desc_val,
+        scale_out,
+        mask0,
+        mask1,
+        mask2,
+        mask3,
+        enable_ws,
+        enable_2cta,
+    )
+
+
+@_dtype_forward
+def ptx_tcgen05_mma_ts(
+    kind_dtype,
+    A_ptr,
+    A_offset,
+    desc_b,
+    B_offset,
+    C_ptr,
+    C_offset,
+    desc_val,
+    scale_out,
+    mask0,
+    mask1,
+    mask2,
+    mask3,
+    enable_2cta=False,
+):
+    return _call_intrin(
+        "handle",
+        _tvm_op.Op.get("tl.ptx_tcgen05_mma_ts"),
+        kind_dtype,
+        A_ptr,
+        A_offset,
+        desc_b,
+        B_offset,
+        C_ptr,
+        C_offset,
+        desc_val,
+        scale_out,
+        mask0,
+        mask1,
+        mask2,
+        mask3,
+        enable_2cta,
+    )
+
+
+@_dtype_forward
+def ptx_tcgen05_mma_blockscaled_ss(
+    kind_dtype,
+    desc_a,
+    A_offset,
+    desc_b,
+    B_offset,
+    C_ptr,
+    C_offset,
+    desc_val,
+    scale_out,
+    sfa_ptr,
+    sfa_offset,
+    sfb_ptr,
+    sfb_offset,
+    reserved0=0,
+    reserved1=0,
+    enable_2cta=False,
+):
+    return _call_intrin(
+        "handle",
+        _tvm_op.Op.get("tl.ptx_tcgen05_mma_blockscaled_ss"),
+        kind_dtype,
+        desc_a,
+        A_offset,
+        desc_b,
+        B_offset,
+        C_ptr,
+        C_offset,
+        desc_val,
+        scale_out,
+        sfa_ptr,
+        sfa_offset,
+        sfb_ptr,
+        sfb_offset,
+        reserved0,
+        reserved1,
+        enable_2cta,
+    )
+
+
+@_dtype_forward
+def ptx_ldmatrix(trans, num, src_access_ptr, dst_access_ptr):
+    """Build a TileLang PTX ldmatrix call from source/destination access pointers."""
+    return tvm.tirx.call_intrin(
+        "handle",
+        tvm.tirx.op.Op.get("tl.ptx_ldmatrix"),
+        trans,
+        num,
+        src_access_ptr,
+        dst_access_ptr,
+    )
+
+
+@_op_wrapper
+def ptx_fence_barrier_init():
+    """Build a PTX fence for initialized mbarriers."""
+    return _call_intrin("handle", _tvm_op.Op.get("tl.ptx_fence_barrier_init"))
+
 
 __all__ = tuple(sorted(CUDA_ONLY_TIR_EXPORTS | SHARED_LEGACY_TIR_EXPORTS))

--- a/tilelang/cuda/language/tir.py
+++ b/tilelang/cuda/language/tir.py
@@ -22,12 +22,112 @@ from tilelang.language.tir.op import call_intrin as _call_intrin
 
 
 # Unchanged upstream CUDA operators are rebound directly in the CUDA dialect.
-mma_fill = _dtype_forward(_tvm_op.mma_fill)
 mma_store = _dtype_forward(_tvm_op.mma_store)
 ptx_cp_async_bulk = _dtype_forward(_tvm_op.ptx_cp_async_bulk)
 ptx_mma = _dtype_forward(_tvm_op.ptx_mma)
-ptx_mma_sp = _dtype_forward(_tvm_op.ptx_mma_sp)
 ptx_wait_barrier = _op_wrapper(_tvm_op.ptx_wait_barrier)
+
+
+@_dtype_forward
+def ptx_mma_sp(
+    dtype,
+    shape,
+    A_layout,
+    B_layout,
+    A_dtype,
+    B_dtype,
+    C_dtype,
+    multiplicand_a,
+    a_index,
+    multiplicand_b,
+    b_index,
+    accumulator,
+    c_index,
+    metadata,
+    meta_index,
+    sparse_selector,
+    saturate,
+):
+    """TVM intrinsic for sparse tensor core ptx instructions
+    https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-matrix-instructions-for-sparse-mma
+
+    Parameters
+    ----------
+    dtype : str
+        The data type of the result.
+
+    shape : str
+        The shape of mma fragment.
+
+    A_layout : Literal["row", "col"]
+        The layout of multiplicand fragment A.
+
+    B_layout : Literal["row", "col"]
+        The layout of multiplicand fragment B.
+
+    A_dtype : str
+        The data type of multiplicand fragment A.
+
+    B_dtype : str
+        The data type of multiplicand fragment B.
+
+    C_dtype : str
+        The data type of accumulator fragment C.
+
+    multiplicand_a : Var
+        The multiplicand fragment A variable.
+
+    a_index : Expr
+        The index of multiplicand fragment A.
+
+    multiplicand_b : Var
+        The multiplicand fragment B variable.
+
+    b_index : Expr
+        The index of multiplicand fragment B.
+
+    accumulator : Var
+        The accumulator fragment C variable.
+
+    c_index : Expr
+        The index of accumulator fragment C.
+
+    metadata : Expr
+        The metadata of operand.
+
+    meta_index : Expr
+        The metadata index of operand.
+
+    sparse_selector : Expr
+        The sparse selector indicating the thread that stores the metadata.
+
+    saturate : bool
+        The optional saturation at the output.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    return _tvm_op.ptx_mma_sp(
+        dtype,
+        shape,
+        A_layout,
+        B_layout,
+        A_dtype,
+        B_dtype,
+        C_dtype,
+        multiplicand_a,
+        a_index,
+        multiplicand_b,
+        b_index,
+        accumulator,
+        c_index,
+        metadata,
+        meta_index,
+        sparse_selector,
+        saturate,
+    )
 
 
 @_dtype_forward
@@ -54,7 +154,7 @@ def ptx_mma_block_scale(
     scale_b_byte_id=0,
     scale_b_thread_id=0,
 ):
-    """Build an SM120a warp-level NVF4 block-scaled MMA call."""
+    """TVM intrinsic for SM120a warp-level NVF4 block-scaled MMA."""
 
     def _selector_value(value):
         return IntImm("int32", value) if isinstance(value, int) else value
@@ -105,6 +205,9 @@ def ptx_wgmma_ss(
     scale_in_a,
     scale_in_b,
 ):
+    """TVM intrinsic for ptx tensor core wmma instructions
+    https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-matrix-instructions-for-wmma
+    """
     return _call_intrin(
         dtype,
         _tvm_op.Op.get("tl.ptx_wgmma_ss"),
@@ -275,21 +378,32 @@ def ptx_tcgen05_mma_ss(
     warp_specialized=None,
     variant=None,
 ):
-    """Build a TCGEN05 shared-memory x shared-memory MMA call."""
+    """TVM intrinsic for tcgen05.mma shared-memory x shared-memory instructions.
+
+    Expects 14 or 15 positional arguments:
+    (kind_dtype, desc_a, A_offset, desc_b, B_offset, C_ptr, C_offset,
+     desc_val, scale_out, mask0, mask1, mask2, mask3[, enable_ws]).
+    Aliases: you can also pass `ws` or `warp_specialized` (booleans) instead of `enable_ws`.
+    Alternatively, use `variant="ws"` (or "default").
+    - kind_dtype: instruction kind selector (e.g., T.float16 for kind::f16,
+      "tf32" for kind::tf32, "int8" for kind::i8, "float8_e4m3" for kind::f8f6f4).
+    """
+    # Aliases precedence: if either `ws` or `warp_specialized` is provided, they override enable_ws
     if ws is not None:
         enable_ws = bool(ws)
     if warp_specialized is not None:
         enable_ws = bool(warp_specialized)
     if variant is not None:
         if isinstance(variant, str):
-            variant = variant.lower()
-            if variant in ("ws", "warp_specialized", "warp-specialized"):
+            v = variant.lower()
+            if v in ("ws", "warp_specialized", "warp-specialized"):
                 enable_ws = True
-            elif variant in ("default", "std", "ss"):
+            elif v in ("default", "std", "ss"):
                 enable_ws = False
             else:
                 raise ValueError(f"ptx_tcgen05_mma_ss: unknown variant: {variant}")
         else:
+            # Treat non-string as truthy flag
             enable_ws = bool(variant)
 
     return _call_intrin(
@@ -330,6 +444,14 @@ def ptx_tcgen05_mma_ts(
     mask3,
     enable_2cta=False,
 ):
+    """TVM intrinsic for tcgen05.mma tensor-memory x shared-memory instructions.
+
+    Expects 13 positional arguments:
+    (kind_dtype, A_ptr, A_offset, desc_b, B_offset, C_ptr, C_offset,
+     desc_val, scale_out, mask0, mask1, mask2, mask3).
+    - kind_dtype: instruction kind selector (e.g., T.float16 for kind::f16,
+      "tf32" for kind::tf32, "int8" for kind::i8, "float8_e4m3" for kind::f8f6f4).
+    """
     return _call_intrin(
         "handle",
         _tvm_op.Op.get("tl.ptx_tcgen05_mma_ts"),
@@ -369,6 +491,18 @@ def ptx_tcgen05_mma_blockscaled_ss(
     reserved1=0,
     enable_2cta=False,
 ):
+    """TVM intrinsic for tcgen05.mma block-scaled (mxf8f6f4.block_scale) instructions.
+
+    Block-scaled TCGEN05 is explicit-async and carries an explicit ``enable_2cta``
+    flag, analogous to the regular SS/TS TCGEN05 intrinsics. There is no
+    fallback path if 2CTA is requested.
+
+    Positional args:
+    kind_dtype, desc_a, A_offset, desc_b, B_offset, C_ptr, C_offset,
+    desc_val, scale_out, sfa_ptr, sfa_offset, sfb_ptr, sfb_offset,
+    reserved0, reserved1, enable_2cta.
+    """
+
     return _call_intrin(
         "handle",
         _tvm_op.Op.get("tl.ptx_tcgen05_mma_blockscaled_ss"),
@@ -392,8 +526,59 @@ def ptx_tcgen05_mma_blockscaled_ss(
 
 
 @_dtype_forward
+def mma_fill(dtype, local_size, local_ptr, offset):
+    """TVM intrinsic for zero-initalizing an MMA accumulation register
+
+    Parameters
+    ----------
+    dtype : str
+        The data type of the result.
+
+    local_size : IntImm
+        The number of elements.
+
+    local_ptr : Var
+        The destination pointer variable.
+
+    offset : Expr
+        The destination offset.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    return _tvm_op.mma_fill(dtype, local_size, local_ptr, offset)
+
+
+@_dtype_forward
 def ptx_ldmatrix(trans, num, src_access_ptr, dst_access_ptr):
-    """Build a TileLang PTX ldmatrix call from source/destination access pointers."""
+    """TileLang intrinsic for ptx load matrix from shared memory
+
+    Uses `tl.ptx_ldmatrix` which expects access pointers created via
+    `T.access_ptr` (i.e. `tl.access_ptr` wrapping a `BufferLoad`).
+
+    https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-matrix-instructions-ldmatrix
+
+    Parameters
+    ----------
+    trans : bool
+        The matrix is loaded in column-major format.
+
+    num : IntImm
+        The number of matrices (2 or 4).
+
+    src_access_ptr : PrimExpr
+        A `tl.access_ptr` pointing to the source (shared memory) buffer.
+
+    dst_access_ptr : PrimExpr
+        A `tl.access_ptr` pointing to the destination (local/register) buffer.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression (handle-typed).
+    """
     return tvm.tirx.call_intrin(
         "handle",
         tvm.tirx.op.Op.get("tl.ptx_ldmatrix"),
@@ -406,7 +591,13 @@ def ptx_ldmatrix(trans, num, src_access_ptr, dst_access_ptr):
 
 @_op_wrapper
 def ptx_fence_barrier_init():
-    """Build a PTX fence for initialized mbarriers."""
+    """TVM intrinsic for ptx fence barrier initialization.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
     return _call_intrin("handle", _tvm_op.Op.get("tl.ptx_fence_barrier_init"))
 
 

--- a/tilelang/language/tir/exports.py
+++ b/tilelang/language/tir/exports.py
@@ -2,6 +2,8 @@
 
 CUDA_ONLY_TIR_EXPORTS = frozenset(
     {
+        "mma_fill",
+        "mma_store",
         "ptx_cp_async_bulk",
         "ptx_fence_barrier_init",
         "ptx_ldmatrix",
@@ -16,6 +18,15 @@ CUDA_ONLY_TIR_EXPORTS = frozenset(
         "ptx_wgmma_sp_rs",
         "ptx_wgmma_sp_ss",
         "ptx_wgmma_ss",
+    }
+)
+
+ROCM_ONLY_TIR_EXPORTS = frozenset(
+    {
+        "tvm_mfma",
+        "tvm_mfma_store",
+        "tvm_rdna_wmma",
+        "tvm_rdna_wmma_store",
     }
 )
 
@@ -42,7 +53,7 @@ SHARED_LEGACY_TIR_EXPORTS = frozenset(
     }
 )
 
-BACKEND_ONLY_TIR_EXPORTS = CUDA_ONLY_TIR_EXPORTS | METAL_ONLY_TIR_EXPORTS
+BACKEND_ONLY_TIR_EXPORTS = CUDA_ONLY_TIR_EXPORTS | METAL_ONLY_TIR_EXPORTS | ROCM_ONLY_TIR_EXPORTS
 CLASSIFIED_VENDOR_TIR_EXPORTS = BACKEND_ONLY_TIR_EXPORTS | SHARED_LEGACY_TIR_EXPORTS
 
 __all__ = [
@@ -50,5 +61,6 @@ __all__ = [
     "CLASSIFIED_VENDOR_TIR_EXPORTS",
     "CUDA_ONLY_TIR_EXPORTS",
     "METAL_ONLY_TIR_EXPORTS",
+    "ROCM_ONLY_TIR_EXPORTS",
     "SHARED_LEGACY_TIR_EXPORTS",
 ]

--- a/tilelang/language/tir/ir.py
+++ b/tilelang/language/tir/ir.py
@@ -312,8 +312,6 @@ call_llvm_intrin = _dtype_forward(_tir_op.call_llvm_intrin)
 call_llvm_pure_intrin = _dtype_forward(_tir_op.call_llvm_pure_intrin)
 call_pure_extern = _dtype_forward(_tir_op.call_pure_extern)
 ptx_cp_async = _dtype_forward(_tir_op.ptx_cp_async)
-mma_store = _dtype_forward(_tir_op.mma_store)
-mma_fill = _dtype_forward(_tir_op.mma_fill)
 vectorlow = _dtype_forward(_tir_op.vectorlow)
 vectorhigh = _dtype_forward(_tir_op.vectorhigh)
 vectorcombine = _dtype_forward(_tir_op.vectorcombine)
@@ -461,8 +459,6 @@ __all__ = (
     "max_value",
     "min",
     "min_value",
-    "mma_fill",
-    "mma_store",
     "nearbyint",
     "nextafter",
     "parallel",

--- a/tilelang/language/tir/op.py
+++ b/tilelang/language/tir/op.py
@@ -1,32 +1,33 @@
+"""Backend-neutral low-level TIR operator adapters."""
+
 from __future__ import annotations
 
 from numbers import Integral
 from typing import Any
 
 import tvm
+import tvm.tirx.op as _tvm_op
 from tvm.ir import PrimExpr
 from tvm.ir.base import Span
 from tvm.runtime import const
 from tvm.tirx import Buffer
 from tvm.tirx.expr import IntImm, Shuffle as Shuffle
-import tvm.tirx.op as _tvm_op
 
 from tilelang.language.dtypes import _is_any_dtype
 from tilelang.utils.deprecated import deprecated_warning
 
 
 def _buffer_data(value):
-    if isinstance(value, Buffer):
-        return value.data
-    return value
+    return value.data if isinstance(value, Buffer) else value
 
 
 def _normalize_primexpr_args(args):
     return tuple(_buffer_data(arg) for arg in args)
 
 
-# Re-export unchanged TVM operators without adding another Python call layer.
-# TileLang-specific adapters remain as functions below.
+# Re-export unchanged backend-neutral TVM operators without adding another
+# Python call layer. Backend-owned operators live in the corresponding
+# ``tilelang.<backend>.language.tir`` module.
 call_packed = _tvm_op.call_packed
 call_cpacked = _tvm_op.call_cpacked
 call_packed_lowered = _tvm_op.call_packed_lowered
@@ -58,15 +59,12 @@ tvm_mma_sync = _tvm_op.tvm_mma_sync
 tvm_bmma_sync = _tvm_op.tvm_bmma_sync
 tvm_fill_fragment = _tvm_op.tvm_fill_fragment
 tvm_store_matrix_sync = _tvm_op.tvm_store_matrix_sync
-ptx_mma = _tvm_op.ptx_mma
-mma_store = _tvm_op.mma_store
-ptx_cp_async_bulk = _tvm_op.ptx_cp_async_bulk
 ptx_commit_group = _tvm_op.ptx_commit_group
 ptx_wait_group = _tvm_op.ptx_wait_group
 ptx_cp_async_barrier = _tvm_op.ptx_cp_async_barrier
 ptx_init_barrier_thread_count = _tvm_op.ptx_init_barrier_thread_count
 ptx_arrive_barrier = _tvm_op.ptx_arrive_barrier
-ptx_wait_barrier = _tvm_op.ptx_wait_barrier
+ptx_arrive_barrier_expect_tx = _tvm_op.ptx_arrive_barrier_expect_tx
 create_barriers = _tvm_op.create_barriers
 vectorlow = _tvm_op.vectorlow
 vectorhigh = _tvm_op.vectorhigh
@@ -139,1082 +137,63 @@ vscale = _tvm_op.vscale
 
 
 def extract_lane(vector: PrimExpr, lane: int | IntImm, span: Span | None = None) -> PrimExpr:
-    """Extract one scalar lane from a fixed-width vector expression.
-
-    Parameters
-    ----------
-    vector : PrimExpr
-        The vector expression to extract from.
-
-    lane : int or IntImm
-        The zero-based lane index. The index must be known at compile time.
-
-    span : Optional[Span]
-        The location of this expression in the source code.
-
-    Returns
-    -------
-    result : PrimExpr
-        A scalar expression with the vector's element dtype.
-    """
+    """Extract one compile-time-selected lane from a fixed-width vector."""
     if not isinstance(vector, PrimExpr):
         raise TypeError(f"extract_lane expects a PrimExpr, but got {type(vector).__name__}")
-
     lanes = vector.dtype.lanes
     if lanes <= 1:
         raise ValueError(f"extract_lane expects a vector expression, but got dtype {vector.dtype}")
-
     if isinstance(lane, IntImm):
         lane = lane.value
     elif not isinstance(lane, Integral):
         raise TypeError(f"extract_lane expects a compile-time integer lane, but got {type(lane).__name__}")
-
     lane = int(lane)
     if lane < 0 or lane >= lanes:
         raise IndexError(f"Lane index {lane} is out of bounds for dtype {vector.dtype} with {lanes} lanes")
-
     return Shuffle([vector], [lane], span)
 
 
 def call_intrin(dtype, func_name, *args, annotations=None, span=None):
-    """Build expression by calling an intrinsic function.
-
-    Intrinsics can be overloaded with multiple data types via
-    the intrinsic translation rule.
-
-    Parameters
-    ----------
-    dtype : str
-        The data type of the result.
-
-    func_name: str
-        The intrinsic function name.
-
-    args : list
-        Positional arguments.
-
-    span : Optional[Span]
-        The location of this operator in the source code.
-
-    Returns
-    -------
-    call : PrimExpr
-        The call expression.
-    """
-    args = _normalize_primexpr_args(args)
-    return _tvm_op.call_intrin(dtype, func_name, *args, annotations=annotations, span=span)
+    """Build an intrinsic call, accepting Buffer arguments as their data vars."""
+    return _tvm_op.call_intrin(
+        dtype,
+        func_name,
+        *_normalize_primexpr_args(args),
+        annotations=annotations,
+        span=span,
+    )
 
 
 def call_pure_extern(dtype, func_name, *args, span=None):
-    """Build expression by calling a pure extern function.
-
-    Parameters
-    ----------
-    dtype : str
-        The data type of the result.
-
-    func_name: str
-        The extern function name.
-
-    args : list
-        Positional arguments.
-
-    span : Optional[Span]
-        The location of this operator in the source code.
-
-    Returns
-    -------
-    call : PrimExpr
-        The call expression.
-    """
-    args = _normalize_primexpr_args(args)
-    return _tvm_op.call_pure_extern(dtype, func_name, *args, span=span)
+    """Build a pure extern call, accepting Buffer arguments as their data vars."""
+    return _tvm_op.call_pure_extern(dtype, func_name, *_normalize_primexpr_args(args), span=span)
 
 
 def call_extern(dtype, func_name, *args, span=None):
-    """Build expression by calling a extern function.
-
-    Parameters
-    ----------
-    dtype : str
-        The data type of the result.
-
-    func_name: str
-        The extern function name.
-
-    args : list
-        Positional arguments.
-
-    span : Optional[Span]
-        The location of this operator in the source code.
-
-    Returns
-    -------
-    call : PrimExpr
-        The call expression.
-    """
-    args = _normalize_primexpr_args(args)
-    return _tvm_op.call_extern(dtype, func_name, *args, span=span)
+    """Build an extern call, accepting Buffer arguments as their data vars."""
+    return _tvm_op.call_extern(dtype, func_name, *_normalize_primexpr_args(args), span=span)
 
 
 def tvm_access_ptr(ptype, data, offset, extent, rw_mask):
-    """Get head access address with memory access pattern info
-
-    Parameters
-    ----------
-    ptype : Expr
-        The data type of pointer.
-
-    data : DType*
-        The data of pointer.
-
-    offset : int
-        The offset of pointer.
-
-    extent : int
-        The extent of pointer.
-
-    rw_mask : int
-        The read write mask.
-
-    Returns
-    -------
-    call : PrimExpr
-        The call expression.
-    """
-    data = _buffer_data(data)
-    return _tvm_op.tvm_access_ptr(ptype, data, offset, extent, rw_mask)
-
-
-def ptx_mma_sp(
-    dtype,
-    shape,
-    A_layout,
-    B_layout,
-    A_dtype,
-    B_dtype,
-    C_dtype,
-    multiplicand_a,
-    a_index,
-    multiplicand_b,
-    b_index,
-    accumulator,
-    c_index,
-    metadata,
-    meta_index,
-    sparse_selector,
-    saturate,
-):
-    """TVM intrinsic for sparse tensor core ptx instructions
-    https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-matrix-instructions-for-sparse-mma
-
-    Parameters
-    ----------
-    dtype : str
-        The data type of the result.
-
-    shape : str
-        The shape of mma fragment.
-
-    A_layout : Literal["row", "col"]
-        The layout of multiplicand fragment A.
-
-    B_layout : Literal["row", "col"]
-        The layout of multiplicand fragment B.
-
-    A_dtype : str
-        The data type of multiplicand fragment A.
-
-    B_dtype : str
-        The data type of multiplicand fragment B.
-
-    C_dtype : str
-        The data type of accumulator fragment C.
-
-    multiplicand_a : Var
-        The multiplicand fragment A variable.
-
-    a_index : Expr
-        The index of multiplicand fragment A.
-
-    multiplicand_b : Var
-        The multiplicand fragment B variable.
-
-    b_index : Expr
-        The index of multiplicand fragment B.
-
-    accumulator : Var
-        The accumulator fragment C variable.
-
-    c_index : Expr
-        The index of accumulator fragment C.
-
-    metadata : Expr
-        The metadata of operand.
-
-    meta_index : Expr
-        The metadata index of operand.
-
-    sparse_selector : Expr
-        The sparse selector indicating the thread that stores the metadata.
-
-    saturate : bool
-        The optional saturation at the output.
-
-    Returns
-    -------
-    call : PrimExpr
-        The call expression.
-    """
-    return _tvm_op.ptx_mma_sp(
-        dtype,
-        shape,
-        A_layout,
-        B_layout,
-        A_dtype,
-        B_dtype,
-        C_dtype,
-        multiplicand_a,
-        a_index,
-        multiplicand_b,
-        b_index,
-        accumulator,
-        c_index,
-        metadata,
-        meta_index,
-        sparse_selector,
-        saturate,
-    )
-
-
-def ptx_mma_block_scale(
-    accum_dtype,
-    shape,
-    A_layout,
-    B_layout,
-    kind,
-    scale_vec_size,
-    A_dtype,
-    B_dtype,
-    scale_type,
-    multiplicand_a,
-    a_index,
-    multiplicand_b,
-    b_index,
-    accumulator,
-    c_index,
-    scale_a,
-    scale_b,
-    scale_a_byte_id=0,
-    scale_a_thread_id=0,
-    scale_b_byte_id=0,
-    scale_b_thread_id=0,
-):
-    """TVM intrinsic for SM120a warp-level NVF4 block-scaled MMA."""
-
-    def _selector_value(value):
-        return IntImm("int32", value) if isinstance(value, int) else value
-
-    return call_intrin(
-        accum_dtype,
-        _tvm_op.Op.get("tl.ptx_mma_block_scale"),
-        tvm.tirx.StringImm(str(accum_dtype)),
-        tvm.tirx.StringImm(str(shape)),
-        tvm.tirx.StringImm(str(A_layout)),
-        tvm.tirx.StringImm(str(B_layout)),
-        tvm.tirx.StringImm(str(kind)),
-        IntImm("int32", scale_vec_size),
-        tvm.tirx.StringImm(str(A_dtype)),
-        tvm.tirx.StringImm(str(B_dtype)),
-        tvm.tirx.StringImm(str(scale_type)),
-        multiplicand_a,
-        a_index,
-        multiplicand_b,
-        b_index,
-        accumulator,
-        c_index,
-        scale_a,
-        scale_b,
-        _selector_value(scale_a_byte_id),
-        _selector_value(scale_a_thread_id),
-        _selector_value(scale_b_byte_id),
-        _selector_value(scale_b_thread_id),
-    )
-
-
-def ptx_wgmma_ss(
-    dtype,
-    wgmma_prefix,
-    a_is_k_major,
-    b_is_k_major,
-    a_dtype_abbrv,
-    b_dtype_abbrv,
-    accum_dtype_abbrv,
-    A_desc,
-    A_offset,
-    B_desc,
-    B_offset,
-    C_data,
-    C_offset,
-    scale_out,
-    scale_in_a,
-    scale_in_b,
-):
-    """TVM intrinsic for ptx tensor core wmma instructions
-    https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-matrix-instructions-for-wmma
-    """
-    return call_intrin(
-        dtype,
-        _tvm_op.Op.get("tl.ptx_wgmma_ss"),
-        wgmma_prefix,
-        a_is_k_major,
-        b_is_k_major,
-        a_dtype_abbrv,
-        b_dtype_abbrv,
-        accum_dtype_abbrv,
-        A_desc,
-        A_offset,
-        B_desc,
-        B_offset,
-        C_data,
-        C_offset,
-        scale_out,
-        scale_in_a,
-        scale_in_b,
-    )
-
-
-def ptx_wgmma_rs(
-    dtype,
-    wgmma_prefix,
-    b_is_k_major,
-    a_dtype_abbrv,
-    b_dtype_abbrv,
-    accum_dtype_abbrv,
-    A_buf,
-    A_offset,
-    B_desc,
-    B_offset,
-    C_data,
-    C_offset,
-    scale_out,
-    scale_in_a,
-    scale_in_b,
-):
-    return call_intrin(
-        dtype,
-        _tvm_op.Op.get("tl.ptx_wgmma_rs"),
-        wgmma_prefix,
-        b_is_k_major,
-        a_dtype_abbrv,
-        b_dtype_abbrv,
-        accum_dtype_abbrv,
-        A_buf,
-        A_offset,
-        B_desc,
-        B_offset,
-        C_data,
-        C_offset,
-        scale_out,
-        scale_in_a,
-        scale_in_b,
-    )
-
-
-def ptx_wgmma_sp_ss(
-    dtype,
-    wgmma_prefix,
-    a_is_k_major,
-    b_is_k_major,
-    a_dtype_abbrv,
-    b_dtype_abbrv,
-    accum_dtype_abbrv,
-    A_desc,
-    A_offset,
-    E_data,
-    E_offset,
-    sparse_selector,
-    B_desc,
-    B_offset,
-    C_data,
-    C_offset,
-    scale_out,
-    scale_in_a,
-    scale_in_b,
-):
-    return call_intrin(
-        dtype,
-        _tvm_op.Op.get("tl.ptx_wgmma_sp_ss"),
-        wgmma_prefix,
-        a_is_k_major,
-        b_is_k_major,
-        a_dtype_abbrv,
-        b_dtype_abbrv,
-        accum_dtype_abbrv,
-        A_desc,
-        A_offset,
-        E_data,
-        E_offset,
-        sparse_selector,
-        B_desc,
-        B_offset,
-        C_data,
-        C_offset,
-        scale_out,
-        scale_in_a,
-        scale_in_b,
-    )
-
-
-def ptx_wgmma_sp_rs(
-    dtype,
-    wgmma_prefix,
-    b_is_k_major,
-    a_dtype_abbrv,
-    b_dtype_abbrv,
-    accum_dtype_abbrv,
-    A_buf,
-    A_offset,
-    E_buf,
-    E_offset,
-    sparse_selector,
-    B_desc,
-    B_offset,
-    C_data,
-    C_offset,
-    scale_out,
-    scale_in_a,
-    scale_in_b,
-):
-    return call_intrin(
-        dtype,
-        _tvm_op.Op.get("tl.ptx_wgmma_sp_rs"),
-        wgmma_prefix,
-        b_is_k_major,
-        a_dtype_abbrv,
-        b_dtype_abbrv,
-        accum_dtype_abbrv,
-        A_buf,
-        A_offset,
-        E_buf,
-        E_offset,
-        sparse_selector,
-        B_desc,
-        B_offset,
-        C_data,
-        C_offset,
-        scale_out,
-        scale_in_a,
-        scale_in_b,
-    )
-
-
-def ptx_tcgen05_mma_ss(
-    kind_dtype,
-    desc_a,
-    A_offset,
-    desc_b,
-    B_offset,
-    C_ptr,
-    C_offset,
-    desc_val,
-    scale_out,
-    mask0,
-    mask1,
-    mask2,
-    mask3,
-    enable_ws=False,
-    enable_2cta=False,
-    ws=None,
-    warp_specialized=None,
-    variant=None,
-):
-    """TVM intrinsic for tcgen05.mma shared-memory x shared-memory instructions.
-
-    Expects 14 or 15 positional arguments:
-    (kind_dtype, desc_a, A_offset, desc_b, B_offset, C_ptr, C_offset,
-     desc_val, scale_out, mask0, mask1, mask2, mask3[, enable_ws]).
-    Aliases: you can also pass `ws` or `warp_specialized` (booleans) instead of `enable_ws`.
-    Alternatively, use `variant="ws"` (or "default").
-    - kind_dtype: instruction kind selector (e.g., T.float16 for kind::f16,
-      "tf32" for kind::tf32, "int8" for kind::i8, "float8_e4m3" for kind::f8f6f4).
-    """
-    # Aliases precedence: if either `ws` or `warp_specialized` is provided, they override enable_ws
-    if ws is not None:
-        enable_ws = bool(ws)
-    if warp_specialized is not None:
-        enable_ws = bool(warp_specialized)
-    if variant is not None:
-        if isinstance(variant, str):
-            v = variant.lower()
-            if v in ("ws", "warp_specialized", "warp-specialized"):
-                enable_ws = True
-            elif v in ("default", "std", "ss"):
-                enable_ws = False
-            else:
-                raise ValueError(f"ptx_tcgen05_mma_ss: unknown variant: {variant}")
-        else:
-            # Treat non-string as truthy flag
-            enable_ws = bool(variant)
-
-    return call_intrin(
-        "handle",
-        _tvm_op.Op.get("tl.ptx_tcgen05_mma_ss"),
-        kind_dtype,
-        desc_a,
-        A_offset,
-        desc_b,
-        B_offset,
-        C_ptr,
-        C_offset,
-        desc_val,
-        scale_out,
-        mask0,
-        mask1,
-        mask2,
-        mask3,
-        enable_ws,
-        enable_2cta,
-    )
-
-
-def ptx_tcgen05_mma_ts(
-    kind_dtype,
-    A_ptr,
-    A_offset,
-    desc_b,
-    B_offset,
-    C_ptr,
-    C_offset,
-    desc_val,
-    scale_out,
-    mask0,
-    mask1,
-    mask2,
-    mask3,
-    enable_2cta=False,
-):
-    """TVM intrinsic for tcgen05.mma tensor-memory x shared-memory instructions.
-
-    Expects 13 positional arguments:
-    (kind_dtype, A_ptr, A_offset, desc_b, B_offset, C_ptr, C_offset,
-     desc_val, scale_out, mask0, mask1, mask2, mask3).
-    - kind_dtype: instruction kind selector (e.g., T.float16 for kind::f16,
-      "tf32" for kind::tf32, "int8" for kind::i8, "float8_e4m3" for kind::f8f6f4).
-    """
-    return call_intrin(
-        "handle",
-        _tvm_op.Op.get("tl.ptx_tcgen05_mma_ts"),
-        kind_dtype,
-        A_ptr,
-        A_offset,
-        desc_b,
-        B_offset,
-        C_ptr,
-        C_offset,
-        desc_val,
-        scale_out,
-        mask0,
-        mask1,
-        mask2,
-        mask3,
-        enable_2cta,
-    )
-
-
-def ptx_tcgen05_mma_blockscaled_ss(
-    kind_dtype,
-    desc_a,
-    A_offset,
-    desc_b,
-    B_offset,
-    C_ptr,
-    C_offset,
-    desc_val,
-    scale_out,
-    sfa_ptr,
-    sfa_offset,
-    sfb_ptr,
-    sfb_offset,
-    reserved0=0,
-    reserved1=0,
-    enable_2cta=False,
-):
-    """TVM intrinsic for tcgen05.mma block-scaled (mxf8f6f4.block_scale) instructions.
-
-    Block-scaled TCGEN05 is explicit-async and carries an explicit ``enable_2cta``
-    flag, analogous to the regular SS/TS TCGEN05 intrinsics. There is no
-    fallback path if 2CTA is requested.
-
-    Positional args:
-    kind_dtype, desc_a, A_offset, desc_b, B_offset, C_ptr, C_offset,
-    desc_val, scale_out, sfa_ptr, sfa_offset, sfb_ptr, sfb_offset,
-    reserved0, reserved1, enable_2cta.
-    """
-
-    return call_intrin(
-        "handle",
-        _tvm_op.Op.get("tl.ptx_tcgen05_mma_blockscaled_ss"),
-        kind_dtype,
-        desc_a,
-        A_offset,
-        desc_b,
-        B_offset,
-        C_ptr,
-        C_offset,
-        desc_val,
-        scale_out,
-        sfa_ptr,
-        sfa_offset,
-        sfb_ptr,
-        sfb_offset,
-        reserved0,
-        reserved1,
-        enable_2cta,
-    )
-
-
-def mma_fill(dtype, local_size, local_ptr, offset):
-    """TVM intrinsic for zero-initalizing an MMA accumulation register
-
-    Parameters
-    ----------
-    dtype : str
-        The data type of the result.
-
-    local_size : IntImm
-        The number of elements.
-
-    local_ptr : Var
-        The destination pointer variable.
-
-    offset : Expr
-        The destination offset.
-
-    Returns
-    -------
-    call : PrimExpr
-        The call expression.
-    """
-    return _tvm_op.mma_fill(dtype, local_size, local_ptr, offset)
-
-
-def ptx_ldmatrix(trans, num, src_access_ptr, dst_access_ptr):
-    """TileLang intrinsic for ptx load matrix from shared memory
-
-    Uses `tl.ptx_ldmatrix` which expects access pointers created via
-    `T.access_ptr` (i.e. `tl.access_ptr` wrapping a `BufferLoad`).
-
-    https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-matrix-instructions-ldmatrix
-
-    Parameters
-    ----------
-    trans : bool
-        The matrix is loaded in column-major format.
-
-    num : IntImm
-        The number of matrices (2 or 4).
-
-    src_access_ptr : PrimExpr
-        A `tl.access_ptr` pointing to the source (shared memory) buffer.
-
-    dst_access_ptr : PrimExpr
-        A `tl.access_ptr` pointing to the destination (local/register) buffer.
-
-    Returns
-    -------
-    call : PrimExpr
-        The call expression (handle-typed).
-    """
-    return tvm.tirx.call_intrin(
-        "handle",
-        tvm.tirx.op.Op.get("tl.ptx_ldmatrix"),
-        trans,
-        num,
-        src_access_ptr,
-        dst_access_ptr,
-    )
+    """Build a TIR access pointer from a Buffer or data variable."""
+    return _tvm_op.tvm_access_ptr(ptype, _buffer_data(data), offset, extent, rw_mask)
 
 
 def ptx_cp_async(dst_access_ptr, src_access_ptr, num_elems, predicate=None):
-    """TVM intrinsic for ptx async copy from global to shared memory using cp.async
-    https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async
-
-    Parameters
-    ----------
-    dst_access_ptr : PrimExpr
-        The destination (shared memory) access pointer created by tvm_access_ptr.
-        Should include pointer, offset, extent, and write access flag (rw_mask=2).
-
-    src_access_ptr : PrimExpr
-        The source (global memory) access pointer created by tvm_access_ptr.
-        Should include pointer, offset, extent, and read access flag (rw_mask=1).
-
-    num_elems : int or PrimExpr
-        The number of logical elements to copy.
-
-        For TileLang's ``tl.ptx_cp_async`` frontend op, the final PTX byte width
-        is derived later from ``num_elems * element_bits(access_ptr)`` and must
-        eventually land on a legal ``cp.async`` width of 4, 8, or 16 bytes.
-
-    predicate : PrimExpr, optional
-        Optional predicate condition for conditional cp.async. When provided, the copy
-        will only be performed if the predicate evaluates to true. Otherwise, the
-        destination will be filled with zeros (default behavior of cp.async).
-
-    Returns
-    -------
-    call : PrimExpr
-        The call expression.
-
-    Examples
-    --------
-    >>> # Copy 16 uint8 elements (= 16 bytes) from global to shared memory
-    >>> T.ptx_cp_async(
-    ...     T.tvm_access_ptr(T.type_annotation(T.uint8), A_shared.data, 0, 16, 2),  # dst
-    ...     T.tvm_access_ptr(T.type_annotation(T.uint8), B_global.data, 0, 16, 1),  # src
-    ...     16  # num_elems
-    ... )
-    >>>
-    >>> # Predicated cp.async (only copy if condition is true)
-    >>> T.ptx_cp_async(
-    ...     T.tvm_access_ptr(T.type_annotation(T.uint8), A_shared.data, 0, 16, 2),
-    ...     T.tvm_access_ptr(T.type_annotation(T.uint8), B_global.data, 0, 16, 1),
-    ...     16,
-    ...     predicate=guard  # only copy if guard is true
-    ... )
-    """
-    if predicate is None:
-        return call_intrin("", _tvm_op.Op.get("tl.ptx_cp_async"), dst_access_ptr, src_access_ptr, num_elems)
-    else:
-        return call_intrin("", _tvm_op.Op.get("tl.ptx_cp_async"), dst_access_ptr, src_access_ptr, num_elems, predicate)
-
-
-def tvm_mfma(
-    dtype,
-    shape,
-    A_layout,
-    B_layout,
-    A_dtype,
-    B_dtype,
-    C_dtype,
-    multiplicand_a,
-    a_index,
-    multiplicand_b,
-    b_index,
-    accumulator,
-    c_index,
-):
-    """TVM intrinsic for amd matrix core mfma instructions
-    https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-matrix-instructions-for-mma
-
-    Parameters
-    ----------
-    dtype : str
-        The data type of the result.
-
-    shape : str
-        The shape of mma fragment.
-
-    A_layout : Literal["row", "col"]
-        The layout of multiplicand fragment A.
-
-    B_layout : Literal["row", "col"]
-        The layout of multiplicand fragment B.
-
-    A_dtype : str
-        The data type of multiplicand fragment A.
-
-    B_dtype : str
-        The data type of multiplicand fragment B.
-
-    C_dtype : str
-        The data type of accumulator fragment C.
-
-    multiplicand_a : Var
-        The multiplicand fragment A variable.
-
-    a_index : Expr
-        The index of multiplicand fragment A.
-
-    multiplicand_b : Var
-        The multiplicand fragment B variable.
-
-    b_index : Expr
-        The index of multiplicand fragment A.
-
-    accumulator : Var
-        The accumulator fragment C variable.
-
-    c_index : Expr
-        The index of accumulator fragment C.
-
-    Returns
-    -------
-    call : PrimExpr
-        The call expression.
-    """
-    return call_intrin(
-        dtype,
-        _tvm_op.Op.get("tl.tvm_mfma"),
-        shape,
-        A_layout,
-        B_layout,
-        A_dtype,
-        B_dtype,
-        C_dtype,
-        multiplicand_a,
-        a_index,
-        multiplicand_b,
-        b_index,
-        accumulator,
-        c_index,
-    )
-
-
-def tvm_mfma_store(dtype, m, n, dst_ptr, src_ptr, src_offset, dst_stride):
-    """TVM intrinsic for storing the result of PTX MMA into a destination pointer
-
-    Parameters
-    ----------
-    dtype : str
-        The data type of the result.
-
-    m : IntImm
-        The shape of mma fragment.
-
-    n : IntImm
-        The shape of mma fragment.
-
-    dst_ptr : Var
-        The destination pointer variable.
-
-    src_ptr : Var
-        The source pointer variable.
-
-    src_offset : Expr
-        The source offset.
-
-    dst_stride : Var
-        The destination stride.
-
-    Returns
-    -------
-    call : PrimExpr
-        The call expression.
-    """
-    return call_intrin(
-        dtype,
-        _tvm_op.Op.get("tl.tvm_mfma_store"),
-        m,
-        n,
-        dst_ptr,
-        src_ptr,
-        src_offset,
-        dst_stride,
-    )
-
-
-def tvm_rdna_wmma(
-    dtype,
-    shape,
-    A_layout,
-    B_layout,
-    A_dtype,
-    B_dtype,
-    C_dtype,
-    multiplicand_a,
-    a_index,
-    multiplicand_b,
-    b_index,
-    accumulator,
-    c_index,
-):
-    """TVM intrinsic for amd matrix core mfma instructions
-    https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-matrix-instructions-for-mma
-
-    Parameters
-    ----------
-    dtype : str
-        The data type of the result.
-
-    shape : str
-        The shape of mma fragment.
-
-    A_layout : Literal["row", "col"]
-        The layout of multiplicand fragment A.
-
-    B_layout : Literal["row", "col"]
-        The layout of multiplicand fragment B.
-
-    A_dtype : str
-        The data type of multiplicand fragment A.
-
-    B_dtype : str
-        The data type of multiplicand fragment B.
-
-    C_dtype : str
-        The data type of accumulator fragment C.
-
-    multiplicand_a : Var
-        The multiplicand fragment A variable.
-
-    a_index : Expr
-        The index of multiplicand fragment A.
-
-    multiplicand_b : Var
-        The multiplicand fragment B variable.
-
-    b_index : Expr
-        The index of multiplicand fragment A.
-
-    accumulator : Var
-        The accumulator fragment C variable.
-
-    c_index : Expr
-        The index of accumulator fragment C.
-
-    Returns
-    -------
-    call : PrimExpr
-        The call expression.
-    """
-    return call_intrin(
-        dtype,
-        _tvm_op.Op.get("tl.tvm_rdna_wmma"),
-        shape,
-        A_layout,
-        B_layout,
-        A_dtype,
-        B_dtype,
-        C_dtype,
-        multiplicand_a,
-        a_index,
-        multiplicand_b,
-        b_index,
-        accumulator,
-        c_index,
-    )
-
-
-def tvm_rdna_wmma_store(dtype, m, n, dst_ptr, src_ptr, src_offset, dst_stride):
-    """TVM intrinsic for storing the result of PTX MMA into a destination pointer
-
-    Parameters
-    ----------
-    dtype : str
-        The data type of the result.
-
-    m : IntImm
-        The shape of mma fragment.
-
-    n : IntImm
-        The shape of mma fragment.
-
-    dst_ptr : Var
-        The destination pointer variable.
-
-    src_ptr : Var
-        The source pointer variable.
-
-    src_offset : Expr
-        The source offset.
-
-    dst_stride : Var
-        The destination stride.
-
-    Returns
-    -------
-    call : PrimExpr
-        The call expression.
-    """
-    return call_intrin(
-        dtype,
-        _tvm_op.Op.get("tl.tvm_rdna_wmma_store"),
-        m,
-        n,
-        dst_ptr,
-        src_ptr,
-        src_offset,
-        dst_stride,
-    )
-
-
-def ptx_fence_barrier_init():
-    """TVM intrinsic for ptx fence barrier initialization.
-
-    Returns
-    -------
-    call : PrimExpr
-        The call expression.
-    """
-    return call_intrin("handle", _tvm_op.Op.get("tl.ptx_fence_barrier_init"))
-
-
-def ptx_arrive_barrier_expect_tx(barrier_id, byte_count):
-    """TVM intrinsic for ptx barrier arrival with expect tx using mbarrier.arrive.expect_tx
-    https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-mbarrier-arrive
-    https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-mbarrier-expect-tx-operation
-
-    Parameters
-    ----------
-    barrier_id : int
-        The ID of the barrier shared memory pointer.
-
-    byte_count : int
-        Increases the tx count of the mbarrier object to track completion of
-        additional async transactions.
-
-    Returns
-    -------
-    call : PrimExpr
-        The call expression.
-    """
-    return _tvm_op.ptx_arrive_barrier_expect_tx(barrier_id, byte_count)
+    """Build the legacy async-copy op shared by CUDA and HIP lowering."""
+    args = (dst_access_ptr, src_access_ptr, num_elems)
+    if predicate is not None:
+        args += (predicate,)
+    return call_intrin("", _tvm_op.Op.get("tl.ptx_cp_async"), *args)
 
 
 def infinity(dtype: str, span: Span | None = None) -> Any:
-    """infinity value of dtype
-
-    Parameters
-    ----------
-    dtype : str
-        The data type.
-
-    span : Optional[Span]
-        The location of this operator in the source code.
-
-    Returns
-    -------
-    value : tvm.Expr
-        The infinity value of dtype.
-    """
+    """Return positive infinity for ``dtype``."""
     return call_intrin(dtype, _tvm_op.Op.get("tl.infinity"), tvm.tirx.StringImm(str(dtype)), span=span)
 
 
-# NOTE(chaofan): Here we use the argument order (value, dtype, ...) instead of (dtype, value, ...) in TVM
-# to be consistent with T.cast.
 def reinterpret(value, dtype, span: Span | None = None) -> Any:
-    """Reinterpret cast a value to dtype.
-
-    Parameters
-    ----------
-    value : PrimExpr
-        The input value.
-
-    dtype : str
-        The data type.
-
-    span : Optional[Span]
-        The location of this operator in the source code.
-
-    Returns
-    -------
-    value : tvm.Expr
-        The reinterpret cast value of dtype.
-    """
-
-    # NOTE(chaofan): For compatibility, we allow the old API where dtype comes first
+    """Reinterpret ``value`` as ``dtype`` using TileLang's value-first API."""
     if _is_any_dtype(value):
         deprecated_warning("T.reinterpret(dtype, value)", "reinterpret(value, dtype)")
         value, dtype = dtype, value
@@ -1222,26 +201,7 @@ def reinterpret(value, dtype, span: Span | None = None) -> Any:
 
 
 def round(x, rounding_mode="ties-to-even", span=None):
-    """Round elements of the array to the nearest integer.
-
-    Parameters
-    ----------
-    x : PrimExpr
-        Input argument.
-
-    rounding_mode : str
-        Rounding mode to use. Supported values are ``"ties-to-even"`` and
-        ``"ties-away-from-zero"``. ``"ties-to-even"`` is the default and matches
-        the existing TileLang/TVM semantics.
-
-    span : Optional[Span]
-        The location of this operator in the source code.
-
-    Returns
-    -------
-    y : PrimExpr
-        The result.
-    """
+    """Round using ties-to-even or ties-away-from-zero semantics."""
     if rounding_mode is None:
         rounding_mode = "ties-to-even"
     elif not isinstance(rounding_mode, str):
@@ -1259,48 +219,17 @@ def round(x, rounding_mode="ties-to-even", span=None):
 
 
 def pow_of_int(x: PrimExpr, y: int) -> PrimExpr:
-    """Fast power operation than pow(float, float).
-
-    Args:
-        x (PrimExpr): Base value
-        y (int): Exponent value
-    """
-    return call_intrin(
-        x.dtype,
-        tvm.tirx.op.Op.get("tl.pow_of_int"),
-        x,
-        y,
-    )
+    """Build TileLang's integer-exponent power intrinsic."""
+    return call_intrin(x.dtype, _tvm_op.Op.get("tl.pow_of_int"), x, y)
 
 
 def pow(x, y, span=None):
-    """x power y
-
-    Parameters
-    ----------
-    x : PrimExpr
-        Input argument.
-
-    y : PrimExpr
-        The exponent
-
-    span : Optional[Span]
-        The location of this operator in the source code.
-
-    Returns
-    -------
-    z : PrimExpr
-        The result.
-    """
+    """Build ``x`` to the power ``y``, specializing positive integer exponents."""
     if isinstance(y, (int, IntImm)):
-        # pow_of_int's `for (i = 1; i < y; ...)` loop only computes x**y for y >= 1.
-        yv = int(y)
-        if yv == 0:
+        y_value = int(y)
+        if y_value == 0:
             return const(1, dtype=x.dtype)
-        if yv >= 1:
-            return pow_of_int(x, yv)
-        return _tvm_op.pow(x, yv, span)
+        if y_value >= 1:
+            return pow_of_int(x, y_value)
+        return _tvm_op.pow(x, y_value, span)
     return _tvm_op.pow(x, y, span)
-
-
-# pylint: disable=unnecessary-lambda

--- a/tilelang/language/tir/op.py
+++ b/tilelang/language/tir/op.py
@@ -1,33 +1,32 @@
-"""Backend-neutral low-level TIR operator adapters."""
-
 from __future__ import annotations
 
 from numbers import Integral
 from typing import Any
 
 import tvm
-import tvm.tirx.op as _tvm_op
 from tvm.ir import PrimExpr
 from tvm.ir.base import Span
 from tvm.runtime import const
 from tvm.tirx import Buffer
 from tvm.tirx.expr import IntImm, Shuffle as Shuffle
+import tvm.tirx.op as _tvm_op
 
 from tilelang.language.dtypes import _is_any_dtype
 from tilelang.utils.deprecated import deprecated_warning
 
 
 def _buffer_data(value):
-    return value.data if isinstance(value, Buffer) else value
+    if isinstance(value, Buffer):
+        return value.data
+    return value
 
 
 def _normalize_primexpr_args(args):
     return tuple(_buffer_data(arg) for arg in args)
 
 
-# Re-export unchanged backend-neutral TVM operators without adding another
-# Python call layer. Backend-owned operators live in the corresponding
-# ``tilelang.<backend>.language.tir`` module.
+# Re-export unchanged TVM operators without adding another Python call layer.
+# TileLang-specific adapters remain as functions below.
 call_packed = _tvm_op.call_packed
 call_cpacked = _tvm_op.call_cpacked
 call_packed_lowered = _tvm_op.call_packed_lowered
@@ -64,7 +63,6 @@ ptx_wait_group = _tvm_op.ptx_wait_group
 ptx_cp_async_barrier = _tvm_op.ptx_cp_async_barrier
 ptx_init_barrier_thread_count = _tvm_op.ptx_init_barrier_thread_count
 ptx_arrive_barrier = _tvm_op.ptx_arrive_barrier
-ptx_arrive_barrier_expect_tx = _tvm_op.ptx_arrive_barrier_expect_tx
 create_barriers = _tvm_op.create_barriers
 vectorlow = _tvm_op.vectorlow
 vectorhigh = _tvm_op.vectorhigh
@@ -137,63 +135,271 @@ vscale = _tvm_op.vscale
 
 
 def extract_lane(vector: PrimExpr, lane: int | IntImm, span: Span | None = None) -> PrimExpr:
-    """Extract one compile-time-selected lane from a fixed-width vector."""
+    """Extract one scalar lane from a fixed-width vector expression.
+
+    Parameters
+    ----------
+    vector : PrimExpr
+        The vector expression to extract from.
+
+    lane : int or IntImm
+        The zero-based lane index. The index must be known at compile time.
+
+    span : Optional[Span]
+        The location of this expression in the source code.
+
+    Returns
+    -------
+    result : PrimExpr
+        A scalar expression with the vector's element dtype.
+    """
     if not isinstance(vector, PrimExpr):
         raise TypeError(f"extract_lane expects a PrimExpr, but got {type(vector).__name__}")
+
     lanes = vector.dtype.lanes
     if lanes <= 1:
         raise ValueError(f"extract_lane expects a vector expression, but got dtype {vector.dtype}")
+
     if isinstance(lane, IntImm):
         lane = lane.value
     elif not isinstance(lane, Integral):
         raise TypeError(f"extract_lane expects a compile-time integer lane, but got {type(lane).__name__}")
+
     lane = int(lane)
     if lane < 0 or lane >= lanes:
         raise IndexError(f"Lane index {lane} is out of bounds for dtype {vector.dtype} with {lanes} lanes")
+
     return Shuffle([vector], [lane], span)
 
 
 def call_intrin(dtype, func_name, *args, annotations=None, span=None):
-    """Build an intrinsic call, accepting Buffer arguments as their data vars."""
-    return _tvm_op.call_intrin(
-        dtype,
-        func_name,
-        *_normalize_primexpr_args(args),
-        annotations=annotations,
-        span=span,
-    )
+    """Build expression by calling an intrinsic function.
+
+    Intrinsics can be overloaded with multiple data types via
+    the intrinsic translation rule.
+
+    Parameters
+    ----------
+    dtype : str
+        The data type of the result.
+
+    func_name: str
+        The intrinsic function name.
+
+    args : list
+        Positional arguments.
+
+    span : Optional[Span]
+        The location of this operator in the source code.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    args = _normalize_primexpr_args(args)
+    return _tvm_op.call_intrin(dtype, func_name, *args, annotations=annotations, span=span)
 
 
 def call_pure_extern(dtype, func_name, *args, span=None):
-    """Build a pure extern call, accepting Buffer arguments as their data vars."""
-    return _tvm_op.call_pure_extern(dtype, func_name, *_normalize_primexpr_args(args), span=span)
+    """Build expression by calling a pure extern function.
+
+    Parameters
+    ----------
+    dtype : str
+        The data type of the result.
+
+    func_name: str
+        The extern function name.
+
+    args : list
+        Positional arguments.
+
+    span : Optional[Span]
+        The location of this operator in the source code.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    args = _normalize_primexpr_args(args)
+    return _tvm_op.call_pure_extern(dtype, func_name, *args, span=span)
 
 
 def call_extern(dtype, func_name, *args, span=None):
-    """Build an extern call, accepting Buffer arguments as their data vars."""
-    return _tvm_op.call_extern(dtype, func_name, *_normalize_primexpr_args(args), span=span)
+    """Build expression by calling a extern function.
+
+    Parameters
+    ----------
+    dtype : str
+        The data type of the result.
+
+    func_name: str
+        The extern function name.
+
+    args : list
+        Positional arguments.
+
+    span : Optional[Span]
+        The location of this operator in the source code.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    args = _normalize_primexpr_args(args)
+    return _tvm_op.call_extern(dtype, func_name, *args, span=span)
 
 
 def tvm_access_ptr(ptype, data, offset, extent, rw_mask):
-    """Build a TIR access pointer from a Buffer or data variable."""
-    return _tvm_op.tvm_access_ptr(ptype, _buffer_data(data), offset, extent, rw_mask)
+    """Get head access address with memory access pattern info
+
+    Parameters
+    ----------
+    ptype : Expr
+        The data type of pointer.
+
+    data : DType*
+        The data of pointer.
+
+    offset : int
+        The offset of pointer.
+
+    extent : int
+        The extent of pointer.
+
+    rw_mask : int
+        The read write mask.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    data = _buffer_data(data)
+    return _tvm_op.tvm_access_ptr(ptype, data, offset, extent, rw_mask)
 
 
 def ptx_cp_async(dst_access_ptr, src_access_ptr, num_elems, predicate=None):
-    """Build the legacy async-copy op shared by CUDA and HIP lowering."""
-    args = (dst_access_ptr, src_access_ptr, num_elems)
-    if predicate is not None:
-        args += (predicate,)
-    return call_intrin("", _tvm_op.Op.get("tl.ptx_cp_async"), *args)
+    """TVM intrinsic for ptx async copy from global to shared memory using cp.async
+    https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async
+
+    Parameters
+    ----------
+    dst_access_ptr : PrimExpr
+        The destination (shared memory) access pointer created by tvm_access_ptr.
+        Should include pointer, offset, extent, and write access flag (rw_mask=2).
+
+    src_access_ptr : PrimExpr
+        The source (global memory) access pointer created by tvm_access_ptr.
+        Should include pointer, offset, extent, and read access flag (rw_mask=1).
+
+    num_elems : int or PrimExpr
+        The number of logical elements to copy.
+
+        For TileLang's ``tl.ptx_cp_async`` frontend op, the final PTX byte width
+        is derived later from ``num_elems * element_bits(access_ptr)`` and must
+        eventually land on a legal ``cp.async`` width of 4, 8, or 16 bytes.
+
+    predicate : PrimExpr, optional
+        Optional predicate condition for conditional cp.async. When provided, the copy
+        will only be performed if the predicate evaluates to true. Otherwise, the
+        destination will be filled with zeros (default behavior of cp.async).
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+
+    Examples
+    --------
+    >>> # Copy 16 uint8 elements (= 16 bytes) from global to shared memory
+    >>> T.ptx_cp_async(
+    ...     T.tvm_access_ptr(T.type_annotation(T.uint8), A_shared.data, 0, 16, 2),  # dst
+    ...     T.tvm_access_ptr(T.type_annotation(T.uint8), B_global.data, 0, 16, 1),  # src
+    ...     16  # num_elems
+    ... )
+    >>>
+    >>> # Predicated cp.async (only copy if condition is true)
+    >>> T.ptx_cp_async(
+    ...     T.tvm_access_ptr(T.type_annotation(T.uint8), A_shared.data, 0, 16, 2),
+    ...     T.tvm_access_ptr(T.type_annotation(T.uint8), B_global.data, 0, 16, 1),
+    ...     16,
+    ...     predicate=guard  # only copy if guard is true
+    ... )
+    """
+    if predicate is None:
+        return call_intrin("", _tvm_op.Op.get("tl.ptx_cp_async"), dst_access_ptr, src_access_ptr, num_elems)
+    else:
+        return call_intrin("", _tvm_op.Op.get("tl.ptx_cp_async"), dst_access_ptr, src_access_ptr, num_elems, predicate)
+
+
+def ptx_arrive_barrier_expect_tx(barrier_id, byte_count):
+    """TVM intrinsic for ptx barrier arrival with expect tx using mbarrier.arrive.expect_tx
+    https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-mbarrier-arrive
+    https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-mbarrier-expect-tx-operation
+
+    Parameters
+    ----------
+    barrier_id : int
+        The ID of the barrier shared memory pointer.
+
+    byte_count : int
+        Increases the tx count of the mbarrier object to track completion of
+        additional async transactions.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
+    return _tvm_op.ptx_arrive_barrier_expect_tx(barrier_id, byte_count)
 
 
 def infinity(dtype: str, span: Span | None = None) -> Any:
-    """Return positive infinity for ``dtype``."""
+    """infinity value of dtype
+
+    Parameters
+    ----------
+    dtype : str
+        The data type.
+
+    span : Optional[Span]
+        The location of this operator in the source code.
+
+    Returns
+    -------
+    value : tvm.Expr
+        The infinity value of dtype.
+    """
     return call_intrin(dtype, _tvm_op.Op.get("tl.infinity"), tvm.tirx.StringImm(str(dtype)), span=span)
 
 
+# NOTE(chaofan): Here we use the argument order (value, dtype, ...) instead of (dtype, value, ...) in TVM
+# to be consistent with T.cast.
 def reinterpret(value, dtype, span: Span | None = None) -> Any:
-    """Reinterpret ``value`` as ``dtype`` using TileLang's value-first API."""
+    """Reinterpret cast a value to dtype.
+
+    Parameters
+    ----------
+    value : PrimExpr
+        The input value.
+
+    dtype : str
+        The data type.
+
+    span : Optional[Span]
+        The location of this operator in the source code.
+
+    Returns
+    -------
+    value : tvm.Expr
+        The reinterpret cast value of dtype.
+    """
+
+    # NOTE(chaofan): For compatibility, we allow the old API where dtype comes first
     if _is_any_dtype(value):
         deprecated_warning("T.reinterpret(dtype, value)", "reinterpret(value, dtype)")
         value, dtype = dtype, value
@@ -201,7 +407,26 @@ def reinterpret(value, dtype, span: Span | None = None) -> Any:
 
 
 def round(x, rounding_mode="ties-to-even", span=None):
-    """Round using ties-to-even or ties-away-from-zero semantics."""
+    """Round elements of the array to the nearest integer.
+
+    Parameters
+    ----------
+    x : PrimExpr
+        Input argument.
+
+    rounding_mode : str
+        Rounding mode to use. Supported values are ``"ties-to-even"`` and
+        ``"ties-away-from-zero"``. ``"ties-to-even"`` is the default and matches
+        the existing TileLang/TVM semantics.
+
+    span : Optional[Span]
+        The location of this operator in the source code.
+
+    Returns
+    -------
+    y : PrimExpr
+        The result.
+    """
     if rounding_mode is None:
         rounding_mode = "ties-to-even"
     elif not isinstance(rounding_mode, str):
@@ -219,17 +444,48 @@ def round(x, rounding_mode="ties-to-even", span=None):
 
 
 def pow_of_int(x: PrimExpr, y: int) -> PrimExpr:
-    """Build TileLang's integer-exponent power intrinsic."""
-    return call_intrin(x.dtype, _tvm_op.Op.get("tl.pow_of_int"), x, y)
+    """Fast power operation than pow(float, float).
+
+    Args:
+        x (PrimExpr): Base value
+        y (int): Exponent value
+    """
+    return call_intrin(
+        x.dtype,
+        tvm.tirx.op.Op.get("tl.pow_of_int"),
+        x,
+        y,
+    )
 
 
 def pow(x, y, span=None):
-    """Build ``x`` to the power ``y``, specializing positive integer exponents."""
+    """x power y
+
+    Parameters
+    ----------
+    x : PrimExpr
+        Input argument.
+
+    y : PrimExpr
+        The exponent
+
+    span : Optional[Span]
+        The location of this operator in the source code.
+
+    Returns
+    -------
+    z : PrimExpr
+        The result.
+    """
     if isinstance(y, (int, IntImm)):
-        y_value = int(y)
-        if y_value == 0:
+        # pow_of_int's `for (i = 1; i < y; ...)` loop only computes x**y for y >= 1.
+        yv = int(y)
+        if yv == 0:
             return const(1, dtype=x.dtype)
-        if y_value >= 1:
-            return pow_of_int(x, y_value)
-        return _tvm_op.pow(x, y_value, span)
+        if yv >= 1:
+            return pow_of_int(x, yv)
+        return _tvm_op.pow(x, yv, span)
     return _tvm_op.pow(x, y, span)
+
+
+# pylint: disable=unnecessary-lambda

--- a/tilelang/rocm/language/tir.py
+++ b/tilelang/rocm/language/tir.py
@@ -1,7 +1,10 @@
 """ROCm-specific low-level TIR language operators."""
 
-import tilelang.language.tir.op as _tir_op
-from tilelang.language.tir.exports import SHARED_LEGACY_TIR_EXPORTS
+from __future__ import annotations
+
+import tvm.tirx.op as _tvm_op
+
+from tilelang.language.tir.exports import ROCM_ONLY_TIR_EXPORTS, SHARED_LEGACY_TIR_EXPORTS
 from tilelang.language.tir.ir import _dtype_forward
 from tilelang.language.tir.ir import (  # noqa: F401
     ptx_arrive_barrier,
@@ -12,20 +15,107 @@ from tilelang.language.tir.ir import (  # noqa: F401
     ptx_init_barrier_thread_count,
     ptx_wait_group,
 )
+from tilelang.language.tir.op import call_intrin as _call_intrin
 
-tvm_mfma = _dtype_forward(_tir_op.tvm_mfma)
-tvm_mfma_store = _dtype_forward(_tir_op.tvm_mfma_store)
-tvm_rdna_wmma = _dtype_forward(_tir_op.tvm_rdna_wmma)
-tvm_rdna_wmma_store = _dtype_forward(_tir_op.tvm_rdna_wmma_store)
 
-__all__ = tuple(
-    sorted(
-        (
-            *SHARED_LEGACY_TIR_EXPORTS,
-            "tvm_mfma",
-            "tvm_mfma_store",
-            "tvm_rdna_wmma",
-            "tvm_rdna_wmma_store",
-        )
+@_dtype_forward
+def tvm_mfma(
+    dtype,
+    shape,
+    A_layout,
+    B_layout,
+    A_dtype,
+    B_dtype,
+    C_dtype,
+    multiplicand_a,
+    a_index,
+    multiplicand_b,
+    b_index,
+    accumulator,
+    c_index,
+):
+    """Build an AMD MFMA matrix-core call."""
+    return _call_intrin(
+        dtype,
+        _tvm_op.Op.get("tl.tvm_mfma"),
+        shape,
+        A_layout,
+        B_layout,
+        A_dtype,
+        B_dtype,
+        C_dtype,
+        multiplicand_a,
+        a_index,
+        multiplicand_b,
+        b_index,
+        accumulator,
+        c_index,
     )
-)
+
+
+@_dtype_forward
+def tvm_mfma_store(dtype, m, n, dst_ptr, src_ptr, src_offset, dst_stride):
+    """Build an AMD MFMA accumulator store call."""
+    return _call_intrin(
+        dtype,
+        _tvm_op.Op.get("tl.tvm_mfma_store"),
+        m,
+        n,
+        dst_ptr,
+        src_ptr,
+        src_offset,
+        dst_stride,
+    )
+
+
+@_dtype_forward
+def tvm_rdna_wmma(
+    dtype,
+    shape,
+    A_layout,
+    B_layout,
+    A_dtype,
+    B_dtype,
+    C_dtype,
+    multiplicand_a,
+    a_index,
+    multiplicand_b,
+    b_index,
+    accumulator,
+    c_index,
+):
+    """Build an AMD RDNA WMMA matrix-core call."""
+    return _call_intrin(
+        dtype,
+        _tvm_op.Op.get("tl.tvm_rdna_wmma"),
+        shape,
+        A_layout,
+        B_layout,
+        A_dtype,
+        B_dtype,
+        C_dtype,
+        multiplicand_a,
+        a_index,
+        multiplicand_b,
+        b_index,
+        accumulator,
+        c_index,
+    )
+
+
+@_dtype_forward
+def tvm_rdna_wmma_store(dtype, m, n, dst_ptr, src_ptr, src_offset, dst_stride):
+    """Build an AMD RDNA WMMA accumulator store call."""
+    return _call_intrin(
+        dtype,
+        _tvm_op.Op.get("tl.tvm_rdna_wmma_store"),
+        m,
+        n,
+        dst_ptr,
+        src_ptr,
+        src_offset,
+        dst_stride,
+    )
+
+
+__all__ = tuple(sorted(ROCM_ONLY_TIR_EXPORTS | SHARED_LEGACY_TIR_EXPORTS))

--- a/tilelang/rocm/language/tir.py
+++ b/tilelang/rocm/language/tir.py
@@ -34,7 +34,55 @@ def tvm_mfma(
     accumulator,
     c_index,
 ):
-    """Build an AMD MFMA matrix-core call."""
+    """TVM intrinsic for amd matrix core mfma instructions
+    https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-matrix-instructions-for-mma
+
+    Parameters
+    ----------
+    dtype : str
+        The data type of the result.
+
+    shape : str
+        The shape of mma fragment.
+
+    A_layout : Literal["row", "col"]
+        The layout of multiplicand fragment A.
+
+    B_layout : Literal["row", "col"]
+        The layout of multiplicand fragment B.
+
+    A_dtype : str
+        The data type of multiplicand fragment A.
+
+    B_dtype : str
+        The data type of multiplicand fragment B.
+
+    C_dtype : str
+        The data type of accumulator fragment C.
+
+    multiplicand_a : Var
+        The multiplicand fragment A variable.
+
+    a_index : Expr
+        The index of multiplicand fragment A.
+
+    multiplicand_b : Var
+        The multiplicand fragment B variable.
+
+    b_index : Expr
+        The index of multiplicand fragment A.
+
+    accumulator : Var
+        The accumulator fragment C variable.
+
+    c_index : Expr
+        The index of accumulator fragment C.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
     return _call_intrin(
         dtype,
         _tvm_op.Op.get("tl.tvm_mfma"),
@@ -55,7 +103,36 @@ def tvm_mfma(
 
 @_dtype_forward
 def tvm_mfma_store(dtype, m, n, dst_ptr, src_ptr, src_offset, dst_stride):
-    """Build an AMD MFMA accumulator store call."""
+    """TVM intrinsic for storing the result of PTX MMA into a destination pointer
+
+    Parameters
+    ----------
+    dtype : str
+        The data type of the result.
+
+    m : IntImm
+        The shape of mma fragment.
+
+    n : IntImm
+        The shape of mma fragment.
+
+    dst_ptr : Var
+        The destination pointer variable.
+
+    src_ptr : Var
+        The source pointer variable.
+
+    src_offset : Expr
+        The source offset.
+
+    dst_stride : Var
+        The destination stride.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
     return _call_intrin(
         dtype,
         _tvm_op.Op.get("tl.tvm_mfma_store"),
@@ -84,7 +161,55 @@ def tvm_rdna_wmma(
     accumulator,
     c_index,
 ):
-    """Build an AMD RDNA WMMA matrix-core call."""
+    """TVM intrinsic for amd matrix core mfma instructions
+    https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-matrix-instructions-for-mma
+
+    Parameters
+    ----------
+    dtype : str
+        The data type of the result.
+
+    shape : str
+        The shape of mma fragment.
+
+    A_layout : Literal["row", "col"]
+        The layout of multiplicand fragment A.
+
+    B_layout : Literal["row", "col"]
+        The layout of multiplicand fragment B.
+
+    A_dtype : str
+        The data type of multiplicand fragment A.
+
+    B_dtype : str
+        The data type of multiplicand fragment B.
+
+    C_dtype : str
+        The data type of accumulator fragment C.
+
+    multiplicand_a : Var
+        The multiplicand fragment A variable.
+
+    a_index : Expr
+        The index of multiplicand fragment A.
+
+    multiplicand_b : Var
+        The multiplicand fragment B variable.
+
+    b_index : Expr
+        The index of multiplicand fragment A.
+
+    accumulator : Var
+        The accumulator fragment C variable.
+
+    c_index : Expr
+        The index of accumulator fragment C.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
     return _call_intrin(
         dtype,
         _tvm_op.Op.get("tl.tvm_rdna_wmma"),
@@ -105,7 +230,36 @@ def tvm_rdna_wmma(
 
 @_dtype_forward
 def tvm_rdna_wmma_store(dtype, m, n, dst_ptr, src_ptr, src_offset, dst_stride):
-    """Build an AMD RDNA WMMA accumulator store call."""
+    """TVM intrinsic for storing the result of PTX MMA into a destination pointer
+
+    Parameters
+    ----------
+    dtype : str
+        The data type of the result.
+
+    m : IntImm
+        The shape of mma fragment.
+
+    n : IntImm
+        The shape of mma fragment.
+
+    dst_ptr : Var
+        The destination pointer variable.
+
+    src_ptr : Var
+        The source pointer variable.
+
+    src_offset : Expr
+        The source offset.
+
+    dst_stride : Var
+        The destination stride.
+
+    Returns
+    -------
+    call : PrimExpr
+        The call expression.
+    """
     return _call_intrin(
         dtype,
         _tvm_op.Op.get("tl.tvm_rdna_wmma_store"),


### PR DESCRIPTION
## Summary

- move CUDA-owned PTX, WGMMA, TCGEN05, `mma_fill`, and `mma_store` proxies into the CUDA language dialect
- move MFMA and RDNA WMMA proxies into the ROCm language dialect while retaining the legacy CUDA/HIP shared ops in common TIR
- add explicit ROCm export ownership and strengthen dialect isolation/implementation ownership tests
- trim the common TIR op proxy down to backend-neutral adapters

## Testing

- `PIP_USER=no pre-commit run --files ...`
- `cmake --build build -j32` (698/698)
- dialect tests: 20 passed
- access_ptr, WGMMA, and TCGEN05 tests: 60 passed, 15 skipped
- CUDA MMA/TCGEN05 layout tests: 53 passed, 19 skipped
- NVF4 block-scale tests: 86 passed, 15 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Moved CUDA-specific TIR operation proxies into the CUDA dialect.
- Moved MFMA and RDNA WMMA proxies into the ROCm dialect.
- Kept shared CUDA/HIP operations in common TIR.
- Reduced common TIR to backend-neutral adapters using `tvm.tirx`.
- Added explicit ROCm export ownership and strengthened dialect isolation tests.
- Added CUDA wrappers for block-scaled MMA, WGMMA, TCGEN05, `ptx_ldmatrix`, and barrier initialization.
- Added ROCm wrappers for MFMA and RDNA WMMA operations.
- Removed backend-specific wrappers from common TIR.

## Testing

- Pre-commit checks passed.
- Build passed: 698/698.
- Dialect, access-pointer, WGMMA, TCGEN05, CUDA MMA/TCGEN05 layout, and NVF4 block-scale tests passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->