### PR TITLE
[CuTeDSL] Port backend intrinsics to CUTLASS DSL primitives

### DIFF
--- a/maint/host_checks/cutedsl_im2col_smoke.py
+++ b/maint/host_checks/cutedsl_im2col_smoke.py
@@ -1,0 +1,59 @@
+"""Small CuTeDSL im2col/TMA smoke test using the convolution example."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import torch
+import tilelang
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(repo_root / "examples" / "convolution"))
+
+    import example_convolution
+
+    n, c, h, w, f, k, s, d, p = 1, 128, 8, 8, 128, 3, 1, 1, 1
+    block_m, block_n, block_k, num_stages, threads = 64, 128, 32, 3, 256
+
+    prim_func = example_convolution.convolution.get_tir(
+        N=n,
+        C=c,
+        H=h,
+        W=w,
+        F=f,
+        K=k,
+        S=s,
+        D=d,
+        P=p,
+        block_M=block_m,
+        block_N=block_n,
+        block_K=block_k,
+        num_stages=num_stages,
+        threads=threads,
+    )
+    kernel = tilelang.compile(
+        prim_func,
+        target="cutedsl",
+        execution_backend="cutedsl",
+    )
+    print(f"adapter={type(kernel.adapter).__name__}")
+    pymodule = getattr(kernel.adapter, "pymodule", None)
+    print(f"has_tma_descs={getattr(pymodule, '_has_tma_descs', None)}")
+    print(f"cutlass_host_launcher_supported={getattr(pymodule, '_cutlass_host_launcher_supported', None)}")
+    print(f"cutlass_host_launcher_disabled_reason={getattr(pymodule, '_cutlass_host_launcher_disabled_reason', None)}")
+    source = kernel.get_kernel_source(kernel_only=False) or ""
+    print(f"source_has_im2col_offsets={'im2col_offsets' in source}")
+
+    a = torch.randn(n, h, w, c, device="cuda", dtype=torch.float16)
+    b = torch.randn(k, k, c, f, device="cuda", dtype=torch.float16)
+    out = kernel(a, b)
+    ref = example_convolution.ref_program(s, p, d)(a, b)
+    torch.testing.assert_close(out, ref, rtol=1e-2, atol=1e-2)
+    print("All checks passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/maint/host_checks/cutedsl_launcher_overhead.py
+++ b/maint/host_checks/cutedsl_launcher_overhead.py
@@ -1,0 +1,113 @@
+"""Compare CuTeDSL host launcher paths with a tiny non-TMA kernel.
+
+This script keeps the TileLang call surface fixed and switches only
+TILELANG_CUTEDSL_HOST_LAUNCHER between "cpp" and "cutlass". The CUTLASS path
+requires TVM-FFI by default so the comparison does not silently fall back to a
+Python callable. Use an external timeline profiler such as veloq/nsys around
+this process to inspect CPU/GPU bubbles; the script adds NVTX ranges around
+each measured loop.
+
+Example:
+  TILELANG_DISABLE_CACHE=1 python maint/host_checks/cutedsl_launcher_overhead.py --mode both
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+from contextlib import contextmanager
+
+import torch
+
+import tilelang
+import tilelang.language as T
+
+
+@contextmanager
+def nvtx_range(name: str):
+    torch.cuda.nvtx.range_push(name)
+    try:
+        yield
+    finally:
+        torch.cuda.nvtx.range_pop()
+
+
+def make_add_kernel(m: int, n: int, block_m: int, block_n: int, threads: int):
+    @T.prim_func
+    def add_kernel(
+        A: T.Tensor((m, n), T.float32),
+        B: T.Tensor((m, n), T.float32),
+        C: T.Tensor((m, n), T.float32),
+    ):
+        with T.Kernel(T.ceildiv(n, block_n), T.ceildiv(m, block_m), threads=threads) as (bx, by):
+            for local_y, local_x in T.Parallel(block_m, block_n):
+                y = by * block_m + local_y
+                x = bx * block_n + local_x
+                if y < m and x < n:
+                    C[y, x] = A[y, x] + B[y, x]
+
+    return add_kernel
+
+
+def run_mode(fn, args, mode: str, warmup: int, repeat: int) -> float:
+    os.environ["TILELANG_CUTEDSL_HOST_LAUNCHER"] = mode
+    for _ in range(warmup):
+        fn(*args)
+    torch.cuda.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    with nvtx_range(f"tilelang_cutedsl_launcher_{mode}"):
+        start.record()
+        for _ in range(repeat):
+            fn(*args)
+        end.record()
+    end.synchronize()
+    return start.elapsed_time(end) * 1000.0 / repeat
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("cpp", "cutlass", "both"), default="both")
+    parser.add_argument("--m", type=int, default=16)
+    parser.add_argument("--n", type=int, default=16)
+    parser.add_argument("--block-m", type=int, default=16)
+    parser.add_argument("--block-n", type=int, default=16)
+    parser.add_argument("--threads", type=int, default=256)
+    parser.add_argument("--warmup", type=int, default=100)
+    parser.add_argument("--repeat", type=int, default=10000)
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+
+    os.environ.setdefault("TILELANG_CUTEDSL_REQUIRE_TVMFFI", "1")
+
+    program = make_add_kernel(args.m, args.n, args.block_m, args.block_n, args.threads)
+    fn = tilelang.compile(program, target="cutedsl")
+
+    a = torch.randn((args.m, args.n), device="cuda", dtype=torch.float32)
+    b = torch.randn((args.m, args.n), device="cuda", dtype=torch.float32)
+    c = torch.empty((args.m, args.n), device="cuda", dtype=torch.float32)
+    fn(a, b, c)
+    torch.testing.assert_close(c, a + b)
+
+    modes = ("cpp", "cutlass") if args.mode == "both" else (args.mode,)
+    samples: dict[str, list[float]] = {}
+    for mode in modes:
+        samples[mode] = []
+        for _ in range(5):
+            samples[mode].append(run_mode(fn, (a, b, c), mode, args.warmup, args.repeat))
+
+    for mode in modes:
+        values = samples[mode]
+        print(
+            f"{mode}: mean={statistics.mean(values):.3f} us "
+            f"median={statistics.median(values):.3f} us "
+            f"min={min(values):.3f} us samples={values}"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/maint/host_checks/cutedsl_tma_launcher_overhead.py
+++ b/maint/host_checks/cutedsl_tma_launcher_overhead.py
@@ -1,0 +1,133 @@
+"""Compare CuTeDSL host launcher paths with a small tiled TMA copy kernel.
+
+This script switches only TILELANG_CUTEDSL_HOST_LAUNCHER between "cpp" and
+"cutlass". The CUTLASS path requires both direct CUTLASS host launch support
+and TVM-FFI conversion by default, so overhead measurements do not silently
+fall back to the generated C++ launcher or a Python callable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import statistics
+from contextlib import contextmanager
+
+import torch
+
+import tilelang
+import tilelang.language as T
+
+
+@contextmanager
+def nvtx_range(name: str):
+    torch.cuda.nvtx.range_push(name)
+    try:
+        yield
+    finally:
+        torch.cuda.nvtx.range_pop()
+
+
+def make_tma_copy_kernel(m: int, n: int, block_m: int, block_n: int, threads: int):
+    @T.prim_func
+    def tma_copy_kernel(
+        A: T.Tensor((m, n), T.float16),
+        B: T.Tensor((m, n), T.float16),
+    ):
+        with T.Kernel(T.ceildiv(n, block_n), T.ceildiv(m, block_m), threads=threads) as (bx, by):
+            A_shared = T.alloc_shared((block_m, block_n), T.float16)
+            loaded = T.alloc_barrier([32])
+            tx = T.get_thread_binding()
+
+            T.use_swizzle(8)
+
+            if tx < 32:
+                T.tma_copy(
+                    A[
+                        by * block_m : (by + 1) * block_m,
+                        bx * block_n : (bx + 1) * block_n,
+                    ],
+                    A_shared,
+                    barrier=loaded,
+                )
+                T.mbarrier_arrive(loaded)
+
+            T.mbarrier_wait_parity(loaded, 0)
+            for local_y, local_x in T.Parallel(block_m, block_n):
+                B[by * block_m + local_y, bx * block_n + local_x] = A_shared[local_y, local_x]
+
+    return tma_copy_kernel
+
+
+def run_mode(fn, args, mode: str, warmup: int, repeat: int) -> float:
+    os.environ["TILELANG_CUTEDSL_HOST_LAUNCHER"] = mode
+    for _ in range(warmup):
+        fn(*args)
+    torch.cuda.synchronize()
+
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    with nvtx_range(f"tilelang_cutedsl_tma_launcher_{mode}"):
+        start.record()
+        for _ in range(repeat):
+            fn(*args)
+        end.record()
+    end.synchronize()
+    return start.elapsed_time(end) * 1000.0 / repeat
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("cpp", "cutlass", "both"), default="both")
+    parser.add_argument("--m", type=int, default=16)
+    parser.add_argument("--n", type=int, default=128)
+    parser.add_argument("--block-m", type=int, default=4)
+    parser.add_argument("--block-n", type=int, default=32)
+    parser.add_argument("--threads", type=int, default=128)
+    parser.add_argument("--warmup", type=int, default=100)
+    parser.add_argument("--repeat", type=int, default=10000)
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if args.threads < 64:
+        raise ValueError("--threads must be at least 64 for the two-warp TMA copy kernel")
+
+    os.environ.setdefault("TILELANG_CUTEDSL_REQUIRE_TVMFFI", "1")
+    os.environ.setdefault("TILELANG_CUTEDSL_REQUIRE_CUTLASS_HOST", "1")
+
+    program = make_tma_copy_kernel(args.m, args.n, args.block_m, args.block_n, args.threads)
+    fn = tilelang.compile(
+        program,
+        target="cutedsl",
+        pass_configs={tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True},
+    )
+
+    a = torch.randn((args.m, args.n), device="cuda", dtype=torch.float16)
+    b = torch.empty((args.m, args.n), device="cuda", dtype=torch.float16)
+    fn(a, b)
+    torch.testing.assert_close(b, a, rtol=0, atol=0)
+
+    modes = ("cpp", "cutlass") if args.mode == "both" else (args.mode,)
+    samples: dict[str, list[float]] = {}
+    for mode in modes:
+        samples[mode] = []
+        for _ in range(5):
+            samples[mode].append(run_mode(fn, (a, b), mode, args.warmup, args.repeat))
+
+    for mode in modes:
+        values = samples[mode]
+        print(
+            f"{mode}: mean={statistics.mean(values):.3f} us "
+            f"median={statistics.median(values):.3f} us "
+            f"min={min(values):.3f} us samples={values}"
+        )
+
+    pymodule = fn.adapter.pymodule
+    print(f"has_tma_descs={getattr(pymodule, '_has_tma_descs', None)}")
+    print(f"cutlass_host_launcher_supported={getattr(pymodule, '_cutlass_host_launcher_supported', None)}")
+    print(f"cutlass_tvmffi_launcher={type(getattr(pymodule, '_cutlass_tvmffi_launcher', None)).__name__}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements-test-cuda.txt
+++ b/requirements-test-cuda.txt
@@ -8,4 +8,4 @@
 flash-attn==2.5.8
 cuda-python==13.0.3
 # Use the cu13 extra so CuTeDSL installs the CUDA 13 runtime package.
-nvidia-cutlass-dsl[cu13]==4.5.0
+nvidia-cutlass-dsl[cu13]==4.7.0

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -3441,8 +3441,8 @@ CodeGenTileLangCuTeDSL::GetSubByteBufferPtrAsByte_(const BufferNode *buffer,
     if (is_handle_type_match) {
       ptr_str = vid;
     } else {
-      ptr_str = "tl.recast_ptr(" + vid + ", dtype=" +
-                DTypeToString(byte_dtype) + ")";
+      ptr_str =
+          "tl.recast_ptr(" + vid + ", dtype=" + DTypeToString(byte_dtype) + ")";
     }
   } else if (scope == "shared.barrier" || scope == "shared.cluster_barrier") {
     ptr_str = vid;

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -173,6 +173,38 @@ int GetTileLangCPAsyncTransferBytes(const CallNode *op) {
   return static_cast<int>(total_bytes);
 }
 
+class ClusterInfoExtractor : public tirx::StmtVisitor {
+private:
+  void VisitStmt(const PrimFunc &f) {
+    if (f->GetAttr<Array<PrimExpr>>("cluster_dims").has_value()) {
+      launch_with_cluster = true;
+      auto cluster_dims = f->GetAttr<Array<PrimExpr>>("cluster_dims").value();
+      cluster_grid_x_ext = cluster_dims[0].as<IntImmNode>()->value;
+      cluster_grid_y_ext = cluster_dims[1].as<IntImmNode>()->value;
+      cluster_grid_z_ext = cluster_dims[2].as<IntImmNode>()->value;
+      ICHECK(cluster_grid_x_ext > 0 && cluster_grid_y_ext > 0 &&
+             cluster_grid_z_ext > 0);
+    }
+    StmtVisitor::VisitStmt(f->body);
+  }
+
+  bool launch_with_cluster = false;
+  int64_t cluster_grid_x_ext = 1;
+  int64_t cluster_grid_y_ext = 1;
+  int64_t cluster_grid_z_ext = 1;
+
+public:
+  std::optional<std::tuple<int64_t, int64_t, int64_t>>
+  extract(const PrimFunc &f) {
+    this->VisitStmt(f);
+    if (launch_with_cluster) {
+      return std::make_tuple(cluster_grid_x_ext, cluster_grid_y_ext,
+                             cluster_grid_z_ext);
+    }
+    return std::nullopt;
+  }
+};
+
 } // namespace
 
 CodeGenTileLangCuTeDSL::CodeGenTileLangCuTeDSL() {
@@ -187,6 +219,7 @@ CodeGenTileLangCuTeDSL::CodeGenTileLangCuTeDSL() {
 void CodeGenTileLangCuTeDSL::InitFuncState_(const PrimFunc &f) {
   raw_pointer_vars_.clear();
   zero_like_vars_.clear();
+  cluster_dims_ = ClusterInfoExtractor().extract(f);
   CodeGenTileLangPY::InitFuncState_(f);
 }
 
@@ -289,7 +322,9 @@ std::string DTypeToString(DataType t) {
       elem_type = "Float6E2M3FN";
     }
   } else if (t.is_float4()) {
-    if (t.is_float4_e2m1fn()) {
+    if (t.is_float4_e2m1_unpacked()) {
+      elem_type = "Float4E2M1FN_unpack";
+    } else if (t.is_float4_e2m1fn()) {
       elem_type = "Float4E2M1FN";
     }
   } else if (t.is_bool()) {
@@ -309,6 +344,9 @@ std::string DTypeToString(DataType t) {
     LOG(FATAL) << "Cannot convert type " << t << " to CuTeDSL type!";
   }
 
+  if (elem_type == "Float4E2M1FN_unpack") {
+    return "tl." + elem_type;
+  }
   return "cutlass." + elem_type;
 }
 } // namespace
@@ -883,13 +921,19 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
     PrintIndent();
     auto tmem_buffer = PrintExpr_(op->args[0]);
     auto num_cols = PrintExpr_(op->args[1]);
-    stream << "tl.tmem_allocate(" << tmem_buffer << ", " << num_cols << ")\n";
+    bool use_2cta = op->annotations.find("use_2cta") != op->annotations.end() &&
+                    Downcast<Bool>(op->annotations["use_2cta"])->value;
+    stream << "tl.tmem_allocate(" << tmem_buffer << ", " << num_cols
+           << ", use_2cta=" << (use_2cta ? "True" : "False") << ")\n";
   } else if (op->op.same_as(tl::ptx_deallocate_tensor_memory())) {
     ICHECK_EQ(op->args.size(), 2U);
     PrintIndent();
     auto tmem_buffer = PrintExpr_(op->args[0]);
     auto num_cols = PrintExpr_(op->args[1]);
-    stream << "tl.tmem_deallocate(" << tmem_buffer << ", " << num_cols << ")\n";
+    bool use_2cta = op->annotations.find("use_2cta") != op->annotations.end() &&
+                    Downcast<Bool>(op->annotations["use_2cta"])->value;
+    stream << "tl.tmem_deallocate(" << tmem_buffer << ", " << num_cols
+           << ", use_2cta=" << (use_2cta ? "True" : "False") << ")\n";
   } else if (op->op.same_as(tl::no_set_max_nreg())) {
     // do nothing
   } else if (op->op.same_as(tl::prefetch_tma_descriptor())) {
@@ -912,17 +956,54 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
     auto desc = op->args[0];
     ss << PrintExpr_(desc) << ", ";
     ss << PrintExpr_(op->args[1]) << ", ";
-    ss << PrintExpr_(op->args[2]) << ", (";
+    ss << PrintBytePointerExpr_(op->args[2]) << ", (";
     for (size_t i = 3; i < op->args.size() - 1; i++) {
       if (i > 3)
+        ss << ", ";
+      ss << PrintExpr_(op->args[i]);
+    }
+    ss << ")";
+    if (op->annotations.find("use_2cta") != op->annotations.end() &&
+        Downcast<Bool>(op->annotations["use_2cta"])->value) {
+      ss << ", use_2cta=True";
+    }
+    ss << ")\n";
+    PrintIndent();
+    stream << ss.str();
+  } else if (op->op.same_as(tl::tma_load_im2col())) {
+    std::ostringstream ss;
+    ICHECK_GE(op->args.size(), 6)
+        << "tma_load_im2col requires desc, mbar, smem, coordinates, "
+           "im2col offsets, and eviction policy";
+    auto pol = op->args[op->args.size() - 1].as<IntImmNode>();
+    ICHECK(pol) << "Eviction policy must be IntImm";
+    ICHECK_GE(pol->value, 0);
+    ICHECK_LT(static_cast<size_t>(pol->value), eviction_policy_names_.size());
+    auto eviction_policy = eviction_policy_names_[pol->value];
+    if (eviction_policy != "EVICT_NORMAL") {
+      LOG(FATAL) << "Eviction policy " << eviction_policy
+                 << " is not supported currently";
+    }
+
+    auto desc = op->args[0];
+    ss << "tl.tma_load(";
+    ss << PrintExpr_(desc) << ", ";
+    ss << PrintExpr_(op->args[1]) << ", ";
+    ss << PrintBytePointerExpr_(op->args[2]) << ", (";
+    for (size_t i = 3; i < op->args.size() - 3; i++) {
+      if (i > 3)
+        ss << ", ";
+      ss << PrintExpr_(op->args[i]);
+    }
+    ss << "), im2col_offsets=(";
+    for (size_t i = op->args.size() - 3; i < op->args.size() - 1; i++) {
+      if (i > op->args.size() - 3)
         ss << ", ";
       ss << PrintExpr_(op->args[i]);
     }
     ss << "))\n";
     PrintIndent();
     stream << ss.str();
-  } else if (op->op.same_as(tl::tma_load_im2col())) {
-    LOG(FATAL) << "Currently unsupported op: " << op->op;
   } else if (op->op.same_as(tl::tma_store())) {
     std::stringstream ss;
     // Check minimum argument count (desc, data, at least one coord,
@@ -1054,6 +1135,32 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
   } else if (op->op.same_as(tl::pdl_sync())) {
     PrintIndent();
     stream << "tl.griddepcontrol_wait()\n";
+  } else if (op->op.same_as(tl::cluster_arrive_relaxed())) {
+    PrintIndent();
+    stream << "tl.cluster_arrive_relaxed()\n";
+  } else if (op->op.same_as(tl::cluster_arrive())) {
+    PrintIndent();
+    stream << "tl.cluster_arrive()\n";
+  } else if (op->op.same_as(tl::cluster_wait())) {
+    PrintIndent();
+    stream << "tl.cluster_wait()\n";
+  } else if (op->op.same_as(tl::cluster_sync())) {
+    PrintIndent();
+    stream << "tl.cluster_sync()\n";
+  } else if (op->op.same_as(tl::block_rank_in_cluster())) {
+    os << "tl.block_rank_in_cluster()";
+  } else if (op->op.same_as(tl::clc_try_cancel())) {
+    print_extern_call_stmt("tl.clc_try_cancel");
+  } else if (op->op.same_as(tl::clc_try_cancel_multicast())) {
+    print_extern_call_stmt("tl.clc_try_cancel_multicast");
+  } else if (op->op.same_as(tl::clc_is_canceled())) {
+    os << "tl.clc_is_canceled(" << PrintExpr_(op->args[0]) << ")";
+  } else if (op->op.same_as(tl::clc_get_first_ctaid_x())) {
+    os << "tl.clc_get_first_ctaid_x(" << PrintExpr_(op->args[0]) << ")";
+  } else if (op->op.same_as(tl::clc_get_first_ctaid_y())) {
+    os << "tl.clc_get_first_ctaid_y(" << PrintExpr_(op->args[0]) << ")";
+  } else if (op->op.same_as(tl::clc_get_first_ctaid_z())) {
+    os << "tl.clc_get_first_ctaid_z(" << PrintExpr_(op->args[0]) << ")";
   } else if (op->op.same_as(tl::loop_break()) ||
              op->op.same_as(builtin::break_loop())) {
     if (in_break_loop_) {
@@ -1232,8 +1339,8 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
            << A_offset << ", (" << b_desc << " + " << B_offset << "), " << c_ref
            << " + " << c_offset << ", " << scale_out << ")\n";
   } else if (op->op.same_as(tl::ptx_tcgen05_mma_ss())) {
-    ICHECK_EQ(op->args.size(), 14U)
-        << "ptx_tcgen05_mma_ss expects 14 arguments";
+    ICHECK_EQ(op->args.size(), 15U)
+        << "ptx_tcgen05_mma_ss expects 15 arguments";
     std::string kind_dtype = Downcast<StringImm>(op->args[0])->value;
     std::string a_desc = PrintExpr_(op->args[1]);
     std::string A_offset = PrintExpr_(op->args[2]);
@@ -1248,8 +1355,11 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
     std::string mask2 = PrintExpr_(op->args[11]);
     std::string mask3 = PrintExpr_(op->args[12]);
     bool enable_ws = Downcast<Bool>(op->args[13])->value;
+    bool enable_2cta = Downcast<Bool>(op->args[14])->value;
     PrintIndent();
     if (enable_ws) {
+      ICHECK(!enable_2cta)
+          << "enable_ws and enable_2cta cannot be true at the same time";
       stream << "tl.tcgen05mma_ws_ss(\"" << kind_dtype << "\", (" << a_desc
              << " + " << A_offset << "), (" << b_desc << " + " << B_offset
              << "), " << c_ref << "[0] + " << c_offset << ", " << desc_val
@@ -1259,11 +1369,12 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
              << " + " << A_offset << "), (" << b_desc << " + " << B_offset
              << "), " << c_ref << "[0] + " << c_offset << ", " << desc_val
              << ", " << scale_out << ", " << mask0 << ", " << mask1 << ", "
-             << mask2 << ", " << mask3 << ")\n";
+             << mask2 << ", " << mask3
+             << ", use_2cta=" << (enable_2cta ? "True" : "False") << ")\n";
     }
   } else if (op->op.same_as(tl::ptx_tcgen05_mma_ts())) {
-    ICHECK_EQ(op->args.size(), 13U)
-        << "ptx_tcgen05_mma_ts expects 13 arguments";
+    ICHECK_EQ(op->args.size(), 14U)
+        << "ptx_tcgen05_mma_ts expects 14 arguments";
     std::string kind_dtype = Downcast<StringImm>(op->args[0])->value;
     std::string a_ref = PrintExpr_(op->args[1]);
     std::string A_offset = PrintExpr_(op->args[2]);
@@ -1277,12 +1388,37 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
     std::string mask1 = PrintExpr_(op->args[10]);
     std::string mask2 = PrintExpr_(op->args[11]);
     std::string mask3 = PrintExpr_(op->args[12]);
+    bool enable_2cta = Downcast<Bool>(op->args[13])->value;
     PrintIndent();
     stream << "tl.tcgen05mma_ts(\"" << kind_dtype << "\", " << a_ref << "[0] + "
            << A_offset << ", (" << b_desc << " + " << B_offset << "), " << c_ref
            << "[0] + " << c_offset << ", " << desc_val << ", " << scale_out
            << ", " << mask0 << ", " << mask1 << ", " << mask2 << ", " << mask3
-           << ")\n";
+           << ", use_2cta=" << (enable_2cta ? "True" : "False") << ")\n";
+  } else if (op->op.same_as(tl::ptx_tcgen05_mma_blockscaled_ss())) {
+    ICHECK_EQ(op->args.size(), 16U)
+        << "ptx_tcgen05_mma_blockscaled_ss expects 16 arguments";
+    std::string kind_dtype = Downcast<StringImm>(op->args[0])->value;
+    std::string a_desc = PrintExpr_(op->args[1]);
+    std::string A_offset = PrintExpr_(op->args[2]);
+    std::string b_desc = PrintExpr_(op->args[3]);
+    std::string B_offset = PrintExpr_(op->args[4]);
+    std::string c_ref = PrintExpr_(op->args[5]);
+    std::string c_offset = PrintExpr_(op->args[6]);
+    std::string desc_val = PrintExpr_(op->args[7]);
+    std::string scale_out = PrintExpr_(op->args[8]);
+    std::string sfa_ref = PrintExpr_(op->args[9]);
+    std::string sfa_offset = PrintExpr_(op->args[10]);
+    std::string sfb_ref = PrintExpr_(op->args[11]);
+    std::string sfb_offset = PrintExpr_(op->args[12]);
+    bool enable_2cta = Downcast<Bool>(op->args[15])->value;
+    PrintIndent();
+    stream << "tl.tcgen05mma_blockscaled_ss(\"" << kind_dtype << "\", ("
+           << a_desc << " + " << A_offset << "), (" << b_desc << " + "
+           << B_offset << "), " << c_ref << "[0] + " << c_offset << ", "
+           << desc_val << ", " << scale_out << ", " << sfa_ref << "[0] + "
+           << sfa_offset << ", " << sfb_ref << "[0] + " << sfb_offset
+           << ", use_2cta=" << (enable_2cta ? "True" : "False") << ")\n";
   } else if (op->op.same_as(tl::tcgen05_ld())) {
     ICHECK_EQ(op->args.size(), 6U) << "tcgen05_ld expects 6 arguments";
     int inst_bits = Downcast<IntImm>(op->args[0])->value;
@@ -1310,7 +1446,10 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
   } else if (op->op.same_as(tl::tcgen05_mma_arrive())) {
     ICHECK_EQ(op->args.size(), 1U) << "tcgen05_mma_arrive expects 1 argument";
     PrintIndent();
-    stream << "tl.tcgen05_mma_arrive(" << PrintExpr_(op->args[0]) << ")\n";
+    bool use_2cta = op->annotations.find("use_2cta") != op->annotations.end() &&
+                    Downcast<Bool>(op->annotations["use_2cta"])->value;
+    stream << "tl.tcgen05_mma_arrive(" << PrintExpr_(op->args[0])
+           << ", use_2cta=" << (use_2cta ? "True" : "False") << ")\n";
   } else if (op->op.same_as(tl::tcgen05_before_thread_sync())) {
     ICHECK_EQ(op->args.size(), 0U)
         << "tcgen05_before_thread_sync expects no arguments";
@@ -1321,6 +1460,26 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
         << "tcgen05_after_thread_sync expects no arguments";
     PrintIndent();
     stream << "tl.tcgen05_after_thread_sync()\n";
+  } else if (op->op.same_as(tl::ptx_tcgen05_cp_warpx4())) {
+    ICHECK_EQ(op->args.size(), 3U)
+        << "ptx_tcgen05_cp_warpx4 expects 3 arguments";
+    std::string smem_ptr = PrintExpr_(op->args[0]);
+    std::string tmem_ptr = PrintExpr_(op->args[1]);
+    std::string tmem_col_offset = PrintExpr_(op->args[2]);
+    bool use_2cta = false;
+    if (op->annotations.find("use_2cta") != op->annotations.end()) {
+      use_2cta = Downcast<Bool>(op->annotations["use_2cta"])->value;
+    }
+    PrintIndent();
+    stream << "tl.tcgen05_cp_warpx4(" << smem_ptr << ", " << tmem_ptr << ", "
+           << tmem_col_offset << ", use_2cta=" << (use_2cta ? "True" : "False")
+           << ")\n";
+  } else if (op->op.same_as(tl::ptx_tcgen05_sf_warp_transpose())) {
+    ICHECK_EQ(op->args.size(), 1U)
+        << "ptx_tcgen05_sf_warp_transpose expects 1 argument";
+    PrintIndent();
+    stream << "tl.tcgen05_sf_warp_transpose(" << PrintExpr_(op->args[0])
+           << ")\n";
   } else if (op->op.same_as(builtin::ptx_ldmatrix())) {
     // arg 0: whether the matrix is loaded in column major format or not.
     // arg 1: number of matrices to load.
@@ -1492,7 +1651,7 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
     ICHECK_EQ(op->args.size(), 7U)
         << "initialize_tcgen05_descriptor expects 7 arguments";
     std::string descriptor = PrintExpr_(op->args[0]);
-    std::string start_address = PrintExpr_(op->args[1]);
+    std::string start_address = PrintBytePointerExpr_(op->args[1]);
     std::string leading = PrintExpr_(op->args[2]);
     std::string stride = PrintExpr_(op->args[3]);
     std::string base_offset = PrintExpr_(op->args[4]);
@@ -2667,7 +2826,21 @@ void CodeGenTileLangCuTeDSL::VisitStmt_(const AttrStmtNode *op) {
     ICHECK(!func_name.empty() && panel_size > 0)
         << "threadblock_swizzle_pattern: failed to extract func_name and "
            "panel_size";
-    this->stream << "blockIdx = tl." << func_name << "(" << panel_size << ")\n";
+    if (cluster_dims_.has_value()) {
+      auto [cluster_grid_x_ext, cluster_grid_y_ext, cluster_grid_z_ext] =
+          cluster_dims_.value();
+      ICHECK(cluster_grid_y_ext == 1 && cluster_grid_z_ext == 1)
+          << "Only support annotate threadblock swizzle for cluster on X "
+             "dimension for now!";
+      ICHECK(panel_size % cluster_grid_x_ext == 0)
+          << "panel_size must be divisible by clusterDim.x";
+      this->stream << "blockIdx = tl." << func_name << "WithCluster("
+                   << panel_size / cluster_grid_x_ext << ", "
+                   << cluster_grid_x_ext << ")\n";
+    } else {
+      this->stream << "blockIdx = tl." << func_name << "(" << panel_size
+                   << ")\n";
+    }
     this->VisitStmt(op->body);
   } else if (op->attr_key == "pragma_unroll_factor") {
     const IntImmNode *factor = op->value.as<IntImmNode>();
@@ -3231,6 +3404,80 @@ std::string CodeGenTileLangCuTeDSL::GetBufferPtr_(const BufferNode *buffer,
   return "(" + ptr_str + " + " + index_str + ")";
 }
 
+std::string
+CodeGenTileLangCuTeDSL::GetSubByteBufferPtrAsByte_(const BufferNode *buffer,
+                                                   PrimExpr index) {
+  DataType buffer_element_dtype = buffer->dtype;
+  int elems_per_byte = 1;
+  if (buffer_element_dtype.is_float4_e2m1_unpacked()) {
+    // This dtype is a shared-memory storage/layout tag for tcgen05 blockscale
+    // operands.  CUDA codegen treats its buffer index as a byte offset after
+    // casting to uint8_t*, not as packed FP4 nibbles.
+    elems_per_byte = 1;
+  } else {
+    ICHECK_LT(buffer_element_dtype.bits(), 8)
+        << "GetSubByteBufferPtrAsByte_ expects a sub-byte buffer, got "
+        << buffer_element_dtype;
+    ICHECK_EQ(8 % buffer_element_dtype.bits(), 0)
+        << "Unsupported sub-byte width: " << buffer_element_dtype;
+    elems_per_byte = 8 / buffer_element_dtype.bits();
+  }
+
+  const VarNode *buffer_var = buffer->data.get();
+  const std::string vid = GetVarID(buffer_var);
+
+  std::string scope;
+  if (alloc_storage_scope_.count(buffer_var)) {
+    scope = alloc_storage_scope_.at(buffer_var);
+  }
+  if (scope.empty()) {
+    scope = GetPtrStorageScope(buffer->data);
+  }
+
+  std::string ptr_str;
+  DataType byte_dtype = DataType::UInt(8);
+  if (raw_pointer_vars_.count(buffer_var)) {
+    bool is_handle_type_match = HandleTypeMatch_(buffer_var, byte_dtype);
+    if (is_handle_type_match) {
+      ptr_str = vid;
+    } else {
+      ptr_str = "tl.recast_ptr(" + vid + ", dtype=" +
+                DTypeToString(byte_dtype) + ")";
+    }
+  } else if (scope == "shared.barrier" || scope == "shared.cluster_barrier") {
+    ptr_str = vid;
+  } else {
+    bool is_handle_type_match = HandleTypeMatch_(buffer_var, byte_dtype);
+    if (is_handle_type_match) {
+      ptr_str = vid + ".iterator";
+    } else {
+      ptr_str = "tl.recast_ptr(" + vid +
+                ".iterator, dtype=" + DTypeToString(byte_dtype) + ")";
+    }
+  }
+
+  std::string index_str = PrintExpr_(index);
+  if (elems_per_byte != 1) {
+    index_str = "(" + index_str + " // " + std::to_string(elems_per_byte) + ")";
+  }
+  return "(" + ptr_str + " + " + index_str + ")";
+}
+
+std::string
+CodeGenTileLangCuTeDSL::PrintBytePointerExpr_(const PrimExpr &expr) {
+  const CallNode *call = expr.as<CallNode>();
+  if (call && call->op.same_as(builtin::address_of())) {
+    ICHECK_EQ(call->args.size(), 1U);
+    const BufferLoadNode *load = call->args[0].as<BufferLoadNode>();
+    if (load && load->buffer->dtype.is_float4_e2m1_unpacked()) {
+      ICHECK_EQ(load->indices.size(), 1U)
+          << "CodeGenTileLangCuTeDSL only supports flat memory";
+      return GetSubByteBufferPtrAsByte_(load->buffer.get(), load->indices[0]);
+    }
+  }
+  return PrintExpr_(expr);
+}
+
 std::string CodeGenTileLangCuTeDSL::GetVarPtr_(const PrimExpr &expr) {
   // For local buffers (rmem tensors), we need to use .iterator to get the
   // pointer since local buffers in CuTeDSL are tensors, not raw pointers
@@ -3421,6 +3668,9 @@ void CodeGenTileLangCuTeDSL::PrintStorageSync_(const CallNode *op) {
       LOG(FATAL) << "Invalid number of arguments for storage sync: "
                  << args.size();
     }
+  } else if (sync == "cluster") {
+    PrintIndent();
+    stream << "tl.cluster_sync()\n";
   } else if (sync == "global") {
     LOG(FATAL) << "PrintStorageSync_ for global is not supported for now";
   } else {

--- a/src/cuda/codegen/codegen_cutedsl.h
+++ b/src/cuda/codegen/codegen_cutedsl.h
@@ -10,8 +10,8 @@
 #include <tvm/tirx/expr.h>
 #include <tvm/tirx/op.h>
 
-#include <string>
 #include <optional>
+#include <string>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>

--- a/src/cuda/codegen/codegen_cutedsl.h
+++ b/src/cuda/codegen/codegen_cutedsl.h
@@ -11,6 +11,8 @@
 #include <tvm/tirx/op.h>
 
 #include <string>
+#include <optional>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -80,6 +82,9 @@ protected:
                         std::ostream &os) override; // NOLINT(*)
 
   std::string GetBufferPtr_(const BufferNode *buffer, PrimExpr index);
+  std::string GetSubByteBufferPtrAsByte_(const BufferNode *buffer,
+                                         PrimExpr index);
+  std::string PrintBytePointerExpr_(const PrimExpr &expr);
   std::string GetBufferRef_(DataType t, const BufferNode *buffer,
                             PrimExpr index) override;
   PrimExpr LinearizeBufferIndices_(const BufferNode *buffer,
@@ -110,6 +115,8 @@ private:
 
   std::vector<std::string> eviction_policy_names_ = {
       "EVICT_NORMAL", "EVICT_FIRST", "EVICT_LAST"};
+
+  std::optional<std::tuple<int64_t, int64_t, int64_t>> cluster_dims_;
 
   // Fastmath configuration (read from PassContext)
   bool enable_fastmath_ = false;

--- a/src/cuda/codegen/rt_mod_cutedsl.cc
+++ b/src/cuda/codegen/rt_mod_cutedsl.cc
@@ -29,9 +29,18 @@ static Map<String, runtime::FunctionInfo> ExtractFuncInfo(const IRModule &mod) {
       arg_types.push_back(f->params[i].dtype());
     }
     Array<String> launch_param_tags;
+    if (f->GetAttr<Array<Integer>>("cluster_dims").defined()) {
+      launch_param_tags.push_back(runtime::launch_param::kClusterDimX);
+      launch_param_tags.push_back(runtime::launch_param::kClusterDimY);
+      launch_param_tags.push_back(runtime::launch_param::kClusterDimZ);
+    }
     if (auto opt = f->GetAttr<Array<String>>(tirx::attr::kKernelLaunchParams)) {
       for (const auto &tag : opt.value()) {
-        launch_param_tags.push_back(tag);
+        if (tag != runtime::launch_param::kClusterDimX &&
+            tag != runtime::launch_param::kClusterDimY &&
+            tag != runtime::launch_param::kClusterDimZ) {
+          launch_param_tags.push_back(tag);
+        }
       }
     }
     auto global_symbol = f->GetAttr<String>(tvm::attr::kGlobalSymbol);

--- a/testing/python/issue/test_tilelang_issue_2682.py
+++ b/testing/python/issue/test_tilelang_issue_2682.py
@@ -13,6 +13,7 @@ import tilelang.testing
 NUM_ELEMENTS = 4
 
 
+@tilelang.testing.requires_cuda
 def test_vectorized_select():
     @T.prim_func
     def kernel(

--- a/testing/python/issue/test_tilelang_issue_2883.py
+++ b/testing/python/issue/test_tilelang_issue_2883.py
@@ -10,6 +10,7 @@ import tilelang.testing
 from tilelang import tvm
 
 
+@tilelang.testing.requires_cuda
 def test_large_parallel_layout_is_injective():
     stride = T.dynamic("stride")
 

--- a/tilelang/contrib/cutedsl/__init__.py
+++ b/tilelang/contrib/cutedsl/__init__.py
@@ -37,6 +37,7 @@ from .gemm_v2 import *  # noqa: F401,F403
 from .gemm_tcgen05 import *  # noqa: F401,F403
 from .ieee_math import *  # noqa: F401,F403
 from .grid_sync import *  # noqa: F401,F403
+from .cluster import *  # noqa: F401,F403
 
 
 def thread_idx():

--- a/tilelang/contrib/cutedsl/atomic.py
+++ b/tilelang/contrib/cutedsl/atomic.py
@@ -78,18 +78,7 @@ def AtomicAdd(ptr: cute.Pointer, value: Numeric, *, loc=None, ip=None):
         # Bitcast i16 -> f16 for return
         result = llvm.bitcast(T.f16(), res_i16, loc=loc, ip=ip)
         return cutlass.Float16(result)
-    elif ptr.dtype == cutlass.Int32:
-        ret = prims.atomicrmw(
-            prims.AtomicOp.ADD,
-            _atomic_ptr(ptr),
-            ptr.dtype(value),
-            mem_order=prims.MemOrder.RELAXED,
-            syncscope=prims.MemScope.GPU,
-            loc=loc,
-            ip=ip,
-        )
-        return ptr.dtype(ret)
-    elif ptr.dtype == cutlass.Int64:
+    elif ptr.dtype == cutlass.Int32 or ptr.dtype == cutlass.Int64:
         ret = prims.atomicrmw(
             prims.AtomicOp.ADD,
             _atomic_ptr(ptr),

--- a/tilelang/contrib/cutedsl/atomic.py
+++ b/tilelang/contrib/cutedsl/atomic.py
@@ -20,63 +20,19 @@ __all__ = [
 import cutlass
 from cutlass import cute
 from cutlass._mlir.extras import types as T
-from cutlass._mlir.dialects import nvvm, llvm
-from cutlass._mlir.dialects._nvvm_enum_gen import (
-    AtomicOpKind,
-    MemOrderKind,
-    MemScopeKind,
-)
+from cutlass._mlir.dialects import llvm
+from cutlass.experimental import primitives as prims
 
 # Type alias for numeric values
 Numeric = cutlass.Float32 | cutlass.Float16 | cutlass.Int32 | cutlass.Int64 | int | float
 
 
-def _memory_order_to_llvm_load(memory_order: int):
-    """Convert TileLang memory order ID to LLVM atomic ordering for loads.
-
-    TileLang memory order mapping:
-        0: relaxed   -> monotonic
-        1: consume   -> acquire (consume is deprecated, use acquire)
-        2: acquire   -> acquire
-        3: release   -> acquire (release invalid for load)
-        4: acq_rel   -> acquire (acq_rel for load = acquire)
-        5: seq_cst   -> acquire (NVPTX llvm.load doesn't support seq_cst)
-
-    Note: NVPTX backend only supports monotonic/acquire for loads.
-    """
-    mapping = {
-        0: llvm.AtomicOrdering.monotonic,
-        1: llvm.AtomicOrdering.acquire,
-        2: llvm.AtomicOrdering.acquire,
-        3: llvm.AtomicOrdering.acquire,  # release invalid for load
-        4: llvm.AtomicOrdering.acquire,  # acq_rel -> acquire for load
-        5: llvm.AtomicOrdering.acquire,  # seq_cst -> acquire (NVPTX limitation)
-    }
-    return mapping.get(memory_order, llvm.AtomicOrdering.monotonic)
+def _atomic_ptr(ptr):
+    return ptr.llvm_ptr if hasattr(ptr, "llvm_ptr") else ptr
 
 
-def _memory_order_to_llvm_store(memory_order: int):
-    """Convert TileLang memory order ID to LLVM atomic ordering for stores.
-
-    TileLang memory order mapping:
-        0: relaxed   -> monotonic
-        1: consume   -> release (consume invalid for store)
-        2: acquire   -> release (acquire invalid for store)
-        3: release   -> release
-        4: acq_rel   -> release (acq_rel for store = release)
-        5: seq_cst   -> release (NVPTX llvm.store doesn't support seq_cst)
-
-    Note: NVPTX backend only supports monotonic/release for stores.
-    """
-    mapping = {
-        0: llvm.AtomicOrdering.monotonic,
-        1: llvm.AtomicOrdering.release,  # consume invalid for store
-        2: llvm.AtomicOrdering.release,  # acquire invalid for store
-        3: llvm.AtomicOrdering.release,
-        4: llvm.AtomicOrdering.release,  # acq_rel -> release for store
-        5: llvm.AtomicOrdering.release,  # seq_cst -> release (NVPTX limitation)
-    }
-    return mapping.get(memory_order, llvm.AtomicOrdering.monotonic)
+def _fence_sc_gpu(*, loc=None, ip=None) -> None:
+    prims.inline_ptx("fence.sc.gpu;", loc=loc, ip=ip)
 
 
 # =============================================================================
@@ -91,13 +47,12 @@ def AtomicAdd(ptr: cute.Pointer, value: Numeric, *, loc=None, ip=None):
     Returns the old value before addition (atomicrmw semantics).
     """
     if ptr.dtype == cutlass.Float32:
-        ret = nvvm.atomicrmw(
-            T.f32(),
-            AtomicOpKind.FADD,
-            ptr.llvm_ptr,
-            ptr.dtype(value).ir_value(loc=loc, ip=ip),
-            mem_order=MemOrderKind.RELAXED,
-            syncscope=MemScopeKind.GPU,
+        ret = prims.atomicrmw(
+            prims.AtomicOp.ADD,
+            _atomic_ptr(ptr),
+            ptr.dtype(value),
+            mem_order=prims.MemOrder.RELAXED,
+            syncscope=prims.MemScope.GPU,
             loc=loc,
             ip=ip,
         )
@@ -124,25 +79,23 @@ def AtomicAdd(ptr: cute.Pointer, value: Numeric, *, loc=None, ip=None):
         result = llvm.bitcast(T.f16(), res_i16, loc=loc, ip=ip)
         return cutlass.Float16(result)
     elif ptr.dtype == cutlass.Int32:
-        ret = nvvm.atomicrmw(
-            T.i32(),
-            AtomicOpKind.ADD,
-            ptr.llvm_ptr,
-            ptr.dtype(value).ir_value(loc=loc, ip=ip),
-            mem_order=MemOrderKind.RELAXED,
-            syncscope=MemScopeKind.GPU,
+        ret = prims.atomicrmw(
+            prims.AtomicOp.ADD,
+            _atomic_ptr(ptr),
+            ptr.dtype(value),
+            mem_order=prims.MemOrder.RELAXED,
+            syncscope=prims.MemScope.GPU,
             loc=loc,
             ip=ip,
         )
         return ptr.dtype(ret)
     elif ptr.dtype == cutlass.Int64:
-        ret = nvvm.atomicrmw(
-            T.i64(),
-            AtomicOpKind.ADD,
-            ptr.llvm_ptr,
-            ptr.dtype(value).ir_value(loc=loc, ip=ip),
-            mem_order=MemOrderKind.RELAXED,
-            syncscope=MemScopeKind.GPU,
+        ret = prims.atomicrmw(
+            prims.AtomicOp.ADD,
+            _atomic_ptr(ptr),
+            ptr.dtype(value),
+            mem_order=prims.MemOrder.RELAXED,
+            syncscope=prims.MemScope.GPU,
             loc=loc,
             ip=ip,
         )
@@ -154,7 +107,7 @@ def AtomicAdd(ptr: cute.Pointer, value: Numeric, *, loc=None, ip=None):
 def AtomicAddRet(ptr: cute.Pointer, value: Numeric, *, loc=None, ip=None):
     """Perform atomic addition and return the previous value.
 
-    This is the same as AtomicAdd since nvvm.atomicrmw always returns old value.
+    This is the same as AtomicAdd since prims.atomicrmw always returns old value.
     """
     return AtomicAdd(ptr, value, loc=loc, ip=ip)
 
@@ -282,17 +235,16 @@ def AtomicAddx4(dst_ptr: cute.Pointer, src_values, *, loc=None, ip=None):
 def AtomicMax(ptr: cute.Pointer, value: Numeric, *, loc=None, ip=None):
     """Perform atomic maximum operation.
 
-    For integers, uses nvvm.atomicrmw with MAX.
+    For integers, uses prims.atomicrmw with MAX.
     For floats, uses CAS loop since PTX doesn't have atomic max for float32.
     """
     if ptr.dtype == cutlass.Int32:
-        ret = nvvm.atomicrmw(
-            T.i32(),
-            AtomicOpKind.MAX,
-            ptr.llvm_ptr,
-            ptr.dtype(value).ir_value(loc=loc, ip=ip),
-            mem_order=MemOrderKind.RELAXED,
-            syncscope=MemScopeKind.GPU,
+        ret = prims.atomicrmw(
+            prims.AtomicOp.MAX,
+            _atomic_ptr(ptr),
+            ptr.dtype(value),
+            mem_order=prims.MemOrder.RELAXED,
+            syncscope=prims.MemScope.GPU,
             loc=loc,
             ip=ip,
         )
@@ -337,13 +289,12 @@ def AtomicMax(ptr: cute.Pointer, value: Numeric, *, loc=None, ip=None):
         )
         return cutlass.Float32(result)
     elif ptr.dtype == cutlass.Int64:
-        ret = nvvm.atomicrmw(
-            T.i64(),
-            AtomicOpKind.MAX,
-            ptr.llvm_ptr,
-            ptr.dtype(value).ir_value(loc=loc, ip=ip),
-            mem_order=MemOrderKind.RELAXED,
-            syncscope=MemScopeKind.GPU,
+        ret = prims.atomicrmw(
+            prims.AtomicOp.MAX,
+            _atomic_ptr(ptr),
+            ptr.dtype(value),
+            mem_order=prims.MemOrder.RELAXED,
+            syncscope=prims.MemScope.GPU,
             loc=loc,
             ip=ip,
         )
@@ -365,17 +316,16 @@ def AtomicMaxRet(ptr: cute.Pointer, value: Numeric, *, loc=None, ip=None):
 def AtomicMin(ptr: cute.Pointer, value: Numeric, *, loc=None, ip=None):
     """Perform atomic minimum operation.
 
-    For integers, uses nvvm.atomicrmw with MIN.
+    For integers, uses prims.atomicrmw with MIN.
     For floats, uses CAS loop since PTX doesn't have atomic min for float32.
     """
     if ptr.dtype == cutlass.Int32:
-        ret = nvvm.atomicrmw(
-            T.i32(),
-            AtomicOpKind.MIN,
-            ptr.llvm_ptr,
-            ptr.dtype(value).ir_value(loc=loc, ip=ip),
-            mem_order=MemOrderKind.RELAXED,
-            syncscope=MemScopeKind.GPU,
+        ret = prims.atomicrmw(
+            prims.AtomicOp.MIN,
+            _atomic_ptr(ptr),
+            ptr.dtype(value),
+            mem_order=prims.MemOrder.RELAXED,
+            syncscope=prims.MemScope.GPU,
             loc=loc,
             ip=ip,
         )
@@ -415,13 +365,12 @@ def AtomicMin(ptr: cute.Pointer, value: Numeric, *, loc=None, ip=None):
         )
         return cutlass.Float32(result)
     elif ptr.dtype == cutlass.Int64:
-        ret = nvvm.atomicrmw(
-            T.i64(),
-            AtomicOpKind.MIN,
-            ptr.llvm_ptr,
-            ptr.dtype(value).ir_value(loc=loc, ip=ip),
-            mem_order=MemOrderKind.RELAXED,
-            syncscope=MemScopeKind.GPU,
+        ret = prims.atomicrmw(
+            prims.AtomicOp.MIN,
+            _atomic_ptr(ptr),
+            ptr.dtype(value),
+            mem_order=prims.MemOrder.RELAXED,
+            syncscope=prims.MemScope.GPU,
             loc=loc,
             ip=ip,
         )
@@ -440,24 +389,23 @@ def AtomicMinRet(ptr: cute.Pointer, value: Numeric, *, loc=None, ip=None):
 # =============================================================================
 
 
-def _get_ptx_load_ordering(memory_order: int) -> str:
-    """Get PTX memory ordering modifier for load.
+def _get_load_ordering(memory_order: int) -> prims.MemOrder:
+    """Get primitive memory ordering for load.
 
     TileLang memory order:
-        0: relaxed -> .relaxed.gpu
-        1: consume -> .acquire.gpu (consume deprecated)
-        2: acquire -> .acquire.gpu
-        3: release -> .acquire.gpu (invalid for load)
-        4: acq_rel -> .acquire.gpu (load part)
-        5: seq_cst -> fence.sc + .relaxed.gpu
+        0: relaxed -> relaxed.gpu
+        1: consume -> acquire.gpu (consume deprecated)
+        2: acquire -> acquire.gpu
+        3: release -> acquire.gpu (invalid for load)
+        4: acq_rel -> acquire.gpu (load part)
+        5: seq_cst -> fence.sc.gpu + relaxed.gpu
     """
-    # For seq_cst, we need fence before load - handled separately
     if memory_order == 5:
-        return "relaxed.gpu"
+        return prims.MemOrder.RELAXED
     elif memory_order in (1, 2, 3, 4):
-        return "acquire.gpu"
+        return prims.MemOrder.ACQUIRE
     else:  # 0 or default
-        return "relaxed.gpu"
+        return prims.MemOrder.RELAXED
 
 
 def AtomicLoad(ptr: cute.Pointer, memory_order: int, *, loc=None, ip=None):
@@ -470,62 +418,40 @@ def AtomicLoad(ptr: cute.Pointer, memory_order: int, *, loc=None, ip=None):
     Returns:
         The loaded value
 
-    PTX mapping (per NVIDIA ABI):
-        relaxed: ld.relaxed.<scope>
-        acquire: ld.acquire.<scope>
-        seq_cst: fence.sc.<scope>; ld.relaxed.<scope>
+    NVVM mapping:
+        relaxed: relaxed.gpu
+        acquire: acquire.gpu
+        seq_cst: fence.sc.gpu + relaxed.gpu
     """
-    ordering = _get_ptx_load_ordering(memory_order)
-    is_seq_cst = memory_order == 5
+    if memory_order == 5:
+        _fence_sc_gpu(loc=loc, ip=ip)
 
     if ptr.dtype == cutlass.Int32:
-        if is_seq_cst:
-            # seq_cst requires fence before relaxed load
-            asm_str = "fence.sc.gpu; ld.relaxed.gpu.s32 $0, [$1];"
-        else:
-            asm_str = f"ld.{ordering}.s32 $0, [$1];"
-        result = llvm.inline_asm(
-            T.i32(),
-            [ptr.llvm_ptr],
-            asm_str,
-            "=r,l",
-            has_side_effects=True,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
+        result = prims.load_ext(
+            _atomic_ptr(ptr),
+            dtype=cutlass.Int32,
+            order=_get_load_ordering(memory_order),
+            scope=prims.MemScope.GPU,
             loc=loc,
             ip=ip,
         )
         return cutlass.Int32(result)
     elif ptr.dtype == cutlass.Float32:
-        if is_seq_cst:
-            asm_str = "fence.sc.gpu; ld.relaxed.gpu.f32 $0, [$1];"
-        else:
-            asm_str = f"ld.{ordering}.f32 $0, [$1];"
-        result = llvm.inline_asm(
-            T.f32(),
-            [ptr.llvm_ptr],
-            asm_str,
-            "=f,l",
-            has_side_effects=True,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
+        result = prims.load_ext(
+            _atomic_ptr(ptr),
+            dtype=cutlass.Float32,
+            order=_get_load_ordering(memory_order),
+            scope=prims.MemScope.GPU,
             loc=loc,
             ip=ip,
         )
         return cutlass.Float32(result)
     elif ptr.dtype == cutlass.Int64:
-        if is_seq_cst:
-            asm_str = "fence.sc.gpu; ld.relaxed.gpu.s64 $0, [$1];"
-        else:
-            asm_str = f"ld.{ordering}.s64 $0, [$1];"
-        result = llvm.inline_asm(
-            T.i64(),
-            [ptr.llvm_ptr],
-            asm_str,
-            "=l,l",
-            has_side_effects=True,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
+        result = prims.load_ext(
+            _atomic_ptr(ptr),
+            dtype=cutlass.Int64,
+            order=_get_load_ordering(memory_order),
+            scope=prims.MemScope.GPU,
             loc=loc,
             ip=ip,
         )
@@ -539,24 +465,23 @@ def AtomicLoad(ptr: cute.Pointer, memory_order: int, *, loc=None, ip=None):
 # =============================================================================
 
 
-def _get_ptx_store_ordering(memory_order: int) -> str:
-    """Get PTX memory ordering modifier for store.
+def _get_store_ordering(memory_order: int) -> prims.MemOrder:
+    """Get primitive memory ordering for store.
 
     TileLang memory order:
-        0: relaxed -> .relaxed.gpu
-        1: consume -> .release.gpu (invalid for store)
-        2: acquire -> .release.gpu (invalid for store)
-        3: release -> .release.gpu
-        4: acq_rel -> .release.gpu (store part)
-        5: seq_cst -> fence.sc + .relaxed.gpu
+        0: relaxed -> relaxed.gpu
+        1: consume -> release.gpu (invalid for store)
+        2: acquire -> release.gpu (invalid for store)
+        3: release -> release.gpu
+        4: acq_rel -> release.gpu (store part)
+        5: seq_cst -> fence.sc.gpu + relaxed.gpu
     """
-    # For seq_cst, we need fence before store - handled separately
     if memory_order == 5:
-        return "relaxed.gpu"
+        return prims.MemOrder.RELAXED
     elif memory_order in (1, 2, 3, 4):
-        return "release.gpu"
+        return prims.MemOrder.RELEASE
     else:  # 0 or default
-        return "relaxed.gpu"
+        return prims.MemOrder.RELAXED
 
 
 def AtomicStore(ptr: cute.Pointer, value: Numeric, memory_order: int, *, loc=None, ip=None):
@@ -567,62 +492,38 @@ def AtomicStore(ptr: cute.Pointer, value: Numeric, memory_order: int, *, loc=Non
         value: Value to store
         memory_order: TileLang memory order ID (0=relaxed, 3=release, 5=seq_cst, etc.)
 
-    PTX mapping (per NVIDIA ABI):
-        relaxed: st.relaxed.<scope>
-        release: st.release.<scope>
-        seq_cst: fence.sc.<scope>; st.relaxed.<scope>
+    NVVM mapping:
+        relaxed: relaxed.gpu
+        release: release.gpu
+        seq_cst: fence.sc.gpu + relaxed.gpu
     """
-    ordering = _get_ptx_store_ordering(memory_order)
-    is_seq_cst = memory_order == 5
+    if memory_order == 5:
+        _fence_sc_gpu(loc=loc, ip=ip)
 
     if ptr.dtype == cutlass.Int32:
-        val_ir = cutlass.Int32(value).ir_value(loc=loc, ip=ip)
-        if is_seq_cst:
-            asm_str = "fence.sc.gpu; st.relaxed.gpu.s32 [$0], $1;"
-        else:
-            asm_str = f"st.{ordering}.s32 [$0], $1;"
-        llvm.inline_asm(
-            None,
-            [ptr.llvm_ptr, val_ir],
-            asm_str,
-            "l,r",
-            has_side_effects=True,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
+        prims.store_ext(
+            cutlass.Int32(value).ir_value(loc=loc, ip=ip),
+            _atomic_ptr(ptr),
+            order=_get_store_ordering(memory_order),
+            scope=prims.MemScope.GPU,
             loc=loc,
             ip=ip,
         )
     elif ptr.dtype == cutlass.Float32:
-        val_ir = cutlass.Float32(value).ir_value(loc=loc, ip=ip)
-        if is_seq_cst:
-            asm_str = "fence.sc.gpu; st.relaxed.gpu.f32 [$0], $1;"
-        else:
-            asm_str = f"st.{ordering}.f32 [$0], $1;"
-        llvm.inline_asm(
-            None,
-            [ptr.llvm_ptr, val_ir],
-            asm_str,
-            "l,f",
-            has_side_effects=True,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
+        prims.store_ext(
+            cutlass.Float32(value).ir_value(loc=loc, ip=ip),
+            _atomic_ptr(ptr),
+            order=_get_store_ordering(memory_order),
+            scope=prims.MemScope.GPU,
             loc=loc,
             ip=ip,
         )
     elif ptr.dtype == cutlass.Int64:
-        val_ir = cutlass.Int64(value).ir_value(loc=loc, ip=ip)
-        if is_seq_cst:
-            asm_str = "fence.sc.gpu; st.relaxed.gpu.s64 [$0], $1;"
-        else:
-            asm_str = f"st.{ordering}.s64 [$0], $1;"
-        llvm.inline_asm(
-            None,
-            [ptr.llvm_ptr, val_ir],
-            asm_str,
-            "l,l",
-            has_side_effects=True,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
+        prims.store_ext(
+            cutlass.Int64(value).ir_value(loc=loc, ip=ip),
+            _atomic_ptr(ptr),
+            order=_get_store_ordering(memory_order),
+            scope=prims.MemScope.GPU,
             loc=loc,
             ip=ip,
         )

--- a/tilelang/contrib/cutedsl/cluster.py
+++ b/tilelang/contrib/cutedsl/cluster.py
@@ -1,0 +1,120 @@
+import cutlass
+from cutlass._mlir.dialects import arith
+from cutlass.cute.typing import Int32, Pointer
+from cutlass.cutlass_dsl import dsl_user_op
+from cutlass.experimental import primitives as prims
+
+__all__ = [
+    "cluster_arrive_relaxed",
+    "cluster_arrive",
+    "cluster_wait",
+    "cluster_sync",
+    "block_rank_in_cluster",
+    "clc_try_cancel",
+    "clc_try_cancel_multicast",
+    "clc_is_canceled",
+    "clc_get_first_ctaid_x",
+    "clc_get_first_ctaid_y",
+    "clc_get_first_ctaid_z",
+]
+
+
+def _smem_ptr(ptr: Pointer, dtype, *, loc=None, ip=None):
+    return cutlass.Pointer(
+        ptr,
+        dtype=dtype,
+        space=cutlass.AddressSpace.smem,
+        loc=loc,
+        ip=ip,
+    )
+
+
+@dsl_user_op
+def cluster_arrive_relaxed(*, loc=None, ip=None) -> None:
+    prims.barrier_cluster_arrive_relaxed_aligned(loc=loc, ip=ip)
+
+
+@dsl_user_op
+def cluster_arrive(*, loc=None, ip=None) -> None:
+    prims.barrier_cluster_arrive_aligned(loc=loc, ip=ip)
+
+
+@dsl_user_op
+def cluster_wait(*, loc=None, ip=None) -> None:
+    prims.barrier_cluster_wait_aligned(loc=loc, ip=ip)
+
+
+@dsl_user_op
+def cluster_sync(*, loc=None, ip=None) -> None:
+    prims.barrier_cluster_arrive_aligned(loc=loc, ip=ip)
+    prims.barrier_cluster_wait_aligned(loc=loc, ip=ip)
+
+
+@dsl_user_op
+def block_rank_in_cluster(*, loc=None, ip=None) -> Int32:
+    return prims.cluster_ctarank(loc=loc, ip=ip)
+
+
+@dsl_user_op
+def clc_try_cancel(result_ptr: Pointer, mbar_ptr: Pointer, *, loc=None, ip=None) -> None:
+    result = _smem_ptr(result_ptr, cutlass.Uint32, loc=loc, ip=ip)
+    mbar = _smem_ptr(mbar_ptr, cutlass.Uint64, loc=loc, ip=ip)
+    prims.clusterlaunchcontrol_try_cancel(result, mbar, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def clc_try_cancel_multicast(
+    result_ptr: Pointer, mbar_ptr: Pointer, *, loc=None, ip=None
+) -> None:
+    result = _smem_ptr(result_ptr, cutlass.Uint32, loc=loc, ip=ip)
+    mbar = _smem_ptr(mbar_ptr, cutlass.Uint64, loc=loc, ip=ip)
+    prims.clusterlaunchcontrol_try_cancel(result, mbar, multicast=0xFFFFFFFF, loc=loc, ip=ip)
+
+
+def _clc_response(result_ptr: Pointer, *, loc=None, ip=None):
+    result = _smem_ptr(result_ptr, cutlass.Int128, loc=loc, ip=ip)
+    response = result.load(alignment=16, loc=loc, ip=ip)
+    return response
+
+
+def _clc_query(query_type: prims.ClusterLaunchControlQueryType, result_ptr: Pointer, *, loc=None, ip=None):
+    response = _clc_response(result_ptr, loc=loc, ip=ip)
+    query = prims.clusterlaunchcontrol_query_cancel(query_type, response, loc=loc, ip=ip)
+    prims.fence_proxy("async_shared", space=prims.SharedSpace.shared_cta, loc=loc, ip=ip)
+    return query
+
+
+@dsl_user_op
+def clc_is_canceled(result_ptr: Pointer, *, loc=None, ip=None) -> Int32:
+    canceled = _clc_query(
+        prims.ClusterLaunchControlQueryType.IS_CANCELED, result_ptr, loc=loc, ip=ip
+    )
+    return Int32(
+        arith.extui(
+            Int32.mlir_type,
+            canceled.ir_value(loc=loc, ip=ip),
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def clc_get_first_ctaid_x(result_ptr: Pointer, *, loc=None, ip=None) -> Int32:
+    return _clc_query(
+        prims.ClusterLaunchControlQueryType.GET_FIRST_CTA_ID_X, result_ptr, loc=loc, ip=ip
+    )
+
+
+@dsl_user_op
+def clc_get_first_ctaid_y(result_ptr: Pointer, *, loc=None, ip=None) -> Int32:
+    return _clc_query(
+        prims.ClusterLaunchControlQueryType.GET_FIRST_CTA_ID_Y, result_ptr, loc=loc, ip=ip
+    )
+
+
+@dsl_user_op
+def clc_get_first_ctaid_z(result_ptr: Pointer, *, loc=None, ip=None) -> Int32:
+    return _clc_query(
+        prims.ClusterLaunchControlQueryType.GET_FIRST_CTA_ID_Z, result_ptr, loc=loc, ip=ip
+    )

--- a/tilelang/contrib/cutedsl/cluster.py
+++ b/tilelang/contrib/cutedsl/cluster.py
@@ -63,9 +63,7 @@ def clc_try_cancel(result_ptr: Pointer, mbar_ptr: Pointer, *, loc=None, ip=None)
 
 
 @dsl_user_op
-def clc_try_cancel_multicast(
-    result_ptr: Pointer, mbar_ptr: Pointer, *, loc=None, ip=None
-) -> None:
+def clc_try_cancel_multicast(result_ptr: Pointer, mbar_ptr: Pointer, *, loc=None, ip=None) -> None:
     result = _smem_ptr(result_ptr, cutlass.Uint32, loc=loc, ip=ip)
     mbar = _smem_ptr(mbar_ptr, cutlass.Uint64, loc=loc, ip=ip)
     prims.clusterlaunchcontrol_try_cancel(result, mbar, multicast=0xFFFFFFFF, loc=loc, ip=ip)
@@ -86,9 +84,7 @@ def _clc_query(query_type: prims.ClusterLaunchControlQueryType, result_ptr: Poin
 
 @dsl_user_op
 def clc_is_canceled(result_ptr: Pointer, *, loc=None, ip=None) -> Int32:
-    canceled = _clc_query(
-        prims.ClusterLaunchControlQueryType.IS_CANCELED, result_ptr, loc=loc, ip=ip
-    )
+    canceled = _clc_query(prims.ClusterLaunchControlQueryType.IS_CANCELED, result_ptr, loc=loc, ip=ip)
     return Int32(
         arith.extui(
             Int32.mlir_type,
@@ -101,20 +97,14 @@ def clc_is_canceled(result_ptr: Pointer, *, loc=None, ip=None) -> Int32:
 
 @dsl_user_op
 def clc_get_first_ctaid_x(result_ptr: Pointer, *, loc=None, ip=None) -> Int32:
-    return _clc_query(
-        prims.ClusterLaunchControlQueryType.GET_FIRST_CTA_ID_X, result_ptr, loc=loc, ip=ip
-    )
+    return _clc_query(prims.ClusterLaunchControlQueryType.GET_FIRST_CTA_ID_X, result_ptr, loc=loc, ip=ip)
 
 
 @dsl_user_op
 def clc_get_first_ctaid_y(result_ptr: Pointer, *, loc=None, ip=None) -> Int32:
-    return _clc_query(
-        prims.ClusterLaunchControlQueryType.GET_FIRST_CTA_ID_Y, result_ptr, loc=loc, ip=ip
-    )
+    return _clc_query(prims.ClusterLaunchControlQueryType.GET_FIRST_CTA_ID_Y, result_ptr, loc=loc, ip=ip)
 
 
 @dsl_user_op
 def clc_get_first_ctaid_z(result_ptr: Pointer, *, loc=None, ip=None) -> Int32:
-    return _clc_query(
-        prims.ClusterLaunchControlQueryType.GET_FIRST_CTA_ID_Z, result_ptr, loc=loc, ip=ip
-    )
+    return _clc_query(prims.ClusterLaunchControlQueryType.GET_FIRST_CTA_ID_Z, result_ptr, loc=loc, ip=ip)

--- a/tilelang/contrib/cutedsl/cpasync.py
+++ b/tilelang/contrib/cutedsl/cpasync.py
@@ -27,32 +27,86 @@ __all__ = [
     "fence_barrier_init",
 ]
 
-from cutlass.cutlass_dsl import CuTeDSL, T, if_generate, dsl_user_op  # noqa: F401
+from cutlass.cutlass_dsl import Constexpr, CuTeDSL, T, if_generate, dsl_user_op  # noqa: F401
 
-from cutlass._mlir.dialects import nvvm, cute_nvgpu  # noqa: F401
+from cutlass.experimental import primitives as prims
+import cutlass
 from cutlass._mlir import ir
 
 import cutlass._mlir.dialects.cute as _cute_ir
 import cutlass._mlir.dialects.cute_nvgpu as _cute_nvgpu_ir
 
 import cutlass.cute as cute
-from cutlass.cute.typing import Int, Boolean, Int32, Int16, Uint64, Pointer, Union  # noqa: F401
+from cutlass.cute.typing import Int, Int32, Int16, Uint64, Pointer, Union  # noqa: F401
 from cutlass.impl_utils import check_value_in
 
-from cutlass.cute.arch import cp_async_commit_group as cp_async_commit  # noqa: F401
-from cutlass.cute.arch import cp_async_wait_group as cp_async_wait  # noqa: F401
+_TMA_ARCHES = ["sm_90", "sm_90a", "sm_100a", "sm_110", "sm_120", "sm_120a"]
 
-# Mbarrier operations (merged from mbar.py)
-from cutlass.cute.arch import mbarrier_init, mbarrier_expect_tx, mbarrier_arrive  # noqa: F401
-from cutlass.cute.arch import mbarrier_arrive_and_expect_tx as arrive_and_expect_tx  # noqa: F401
-from cutlass.cute.arch import cp_async_mbarrier_arrive_noinc as mbarrier_cp_async_arrive_noinc  # noqa: F401
-import cutlass.cute.arch as arch
+
+class _MbarrierPointerAdapter:
+    """Expose a CuTe pointer as the Array-like mbarrier input shape."""
+
+    def __init__(self, ptr: cute.Pointer):
+        self._ptr = ptr
+
+    def data_ptr(self, idx=0, *, loc=None, ip=None):
+        ptr = cutlass.Pointer(
+            self._ptr,
+            dtype=cutlass.Uint64,
+            space=cutlass.AddressSpace.smem,
+            loc=loc,
+            ip=ip,
+        )
+        return ptr + idx if idx != 0 else ptr
+
+    def ir_value(self, *, loc=None, ip=None):
+        return self._ptr.ir_value(loc=loc, ip=ip)
+
+    def to_llvm_ptr(self, *, loc=None, ip=None):
+        return self._ptr.to_llvm_ptr(loc=loc, ip=ip)
+
+
+@dsl_user_op
+def cp_async_commit(*, loc=None, ip=None) -> None:
+    prims.cp_async_commit_group(loc=loc, ip=ip)
+
+
+@dsl_user_op
+def cp_async_wait(n: Int, *, loc=None, ip=None) -> None:
+    prims.cp_async_wait_group(n, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def mbarrier_init(mbar_ptr: Pointer, arrive_count: Int, *, loc=None, ip=None) -> None:
+    prims.mbarrier_init(mbar_ptr, Int32(arrive_count), loc=loc, ip=ip)
+
+
+@dsl_user_op
+def mbarrier_expect_tx(mbar_ptr: Pointer, tx_count: Int, *, loc=None, ip=None) -> None:
+    prims.mbarrier_expect_tx(mbar_ptr, Int32(tx_count), loc=loc, ip=ip)
+
+
+@dsl_user_op
+def arrive_and_expect_tx(mbar_ptr: Pointer, tx_count: Int, *, loc=None, ip=None) -> None:
+    prims.mbarrier_arrive_expect_tx(mbar_ptr, Int32(tx_count), loc=loc, ip=ip)
+
+
+@dsl_user_op
+def mbarrier_arrive(mbar_ptr: Pointer, cta_id: Int | None = None, *, loc=None, ip=None) -> None:
+    if cta_id is not None:
+        mbar_ptr = prims.mapa(mbar_ptr, Int32(cta_id), loc=loc, ip=ip)
+    prims.mbarrier_arrive(mbar_ptr, loc=loc, ip=ip)
+
+
+@dsl_user_op
+def mbarrier_cp_async_arrive_noinc(mbar_ptr: Pointer, *, loc=None, ip=None) -> None:
+    prims.cp_async_mbarrier_arrive(mbar_ptr, noinc=True, loc=loc, ip=ip)
 
 
 def cp_async_gs(size, dst, src):
     assert size in [16, 8, 4]
     # use CG (cache global) to by pass L1 when loading contiguous 128B.
-    mode = nvvm.LoadCacheModifierKind.CG if size == 16 else nvvm.LoadCacheModifierKind.CA
+    mode = prims.LoadCacheModifier.CG if size == 16 else prims.LoadCacheModifier.CA
     if isinstance(src, cute.Tensor):
         src_ptr = src.iterator
     elif isinstance(src, cute.Pointer):
@@ -87,8 +141,29 @@ def extract_tensormap_ptr(tma_atom: cute.CopyAtom, *, loc=None, ip=None) -> cute
     return tensormap_ptr
 
 
+def _as_tensormap_ptr(tma_desc, *, loc=None, ip=None):
+    """Return a pointer suitable for TensorMap NVVM primitives."""
+    if isinstance(tma_desc, cute.CopyAtom):
+        return extract_tensormap_ptr(tma_desc, loc=loc, ip=ip)
+    if isinstance(tma_desc, cute.Tensor):
+        return tma_desc.iterator
+    if hasattr(tma_desc, "get_ptr"):
+        return tma_desc.get_ptr(loc=loc, ip=ip)
+    return tma_desc
+
+
 @dsl_user_op
-def tma_load(tma_desc, mbar: cute.Pointer, smem_ptr: cute.Pointer, crd: Int | tuple[Int, ...], *, loc=None, ip=None) -> None:
+def tma_load(
+    tma_desc,
+    mbar: cute.Pointer,
+    smem_ptr: cute.Pointer,
+    crd: Int | tuple[Int, ...],
+    use_2cta: Constexpr[bool] = False,
+    im2col_offsets=None,
+    *,
+    loc=None,
+    ip=None,
+) -> None:
     """
     Load data from global memory to shared memory using TMA (Tensor Memory Access).
 
@@ -102,43 +177,54 @@ def tma_load(tma_desc, mbar: cute.Pointer, smem_ptr: cute.Pointer, crd: Int | tu
     :type crd:                       tuple[Int, ...]
     """
     arch = CuTeDSL._get_dsl().envar.arch
-    check_value_in(arch, ["sm_90", "sm_90a", "sm_100a"], "arch")
+    check_value_in(arch, _TMA_ARCHES, "arch")
 
     if not isinstance(crd, tuple) and isinstance(tma_desc, cute.Pointer):
         # Legacy signature: tma_load(smem_ptr, gmem_ptr, mbar, size)
         _smem_ptr = tma_desc
         _gmem_ptr = mbar
         _mbar = smem_ptr
-        nvvm.cp_async_bulk_shared_cluster_global(
-            dst_mem=_smem_ptr.llvm_ptr,
-            src_mem=_gmem_ptr.llvm_ptr,
-            mbar=_mbar.llvm_ptr,
-            size=Int32(crd).ir_value(loc=loc, ip=ip),
+        prims.cp_async_bulk_shared_cluster_global(
+            dst_mem=_smem_ptr,
+            src_mem=_gmem_ptr,
+            mbar=_mbar,
+            size=Int32(crd),
             loc=loc,
             ip=ip,
         )
     else:
-        if isinstance(tma_desc, cute.CopyAtom):
-            tma_desc_ptr = extract_tensormap_ptr(tma_desc)
-        elif isinstance(tma_desc, cute.Tensor):
-            tma_desc_ptr = tma_desc.iterator
-        else:
-            tma_desc_ptr = tma_desc
+        tma_desc_ptr = _as_tensormap_ptr(tma_desc, loc=loc, ip=ip)
         # Ensure crd is a tuple (handle single coordinate case)
         if not isinstance(crd, tuple):
             crd = (crd,)
-        nvvm.cp_async_bulk_tensor_shared_cluster_global(
-            dst_mem=smem_ptr.llvm_ptr,
-            tma_descriptor=tma_desc_ptr.llvm_ptr,
-            coordinates=[Int32(i).ir_value(loc=loc, ip=ip) for i in crd],
-            mbar=mbar.llvm_ptr,
-            im2col_offsets=[],
-            load_mode=nvvm.CpAsyncBulkTensorLoadMode.TILE,
-            group=nvvm.Tcgen05GroupKind.CTA_1,
-            use_intrinsic=False,  # set to True would lead to compile error
-            loc=loc,
-            ip=ip,
-        )
+        coordinates = [Int32(i) for i in crd]
+        im2col_offsets = [] if im2col_offsets is None else [Int16(i) for i in im2col_offsets]
+        mode = prims.TMALoadMode.IM2COL if im2col_offsets else None
+        if use_2cta:
+            prims.cp_async_bulk_tensor_shared_cluster_global(
+                dst_mem=smem_ptr,
+                tma_descriptor=tma_desc_ptr,
+                coordinates=coordinates,
+                mbar=_MbarrierPointerAdapter(mbar),
+                im2col_offsets=im2col_offsets,
+                l2_cache_hint=Uint64(0x1000000000000000),
+                mode=mode,
+                group=prims.CTAGroup.CTA_2,
+                loc=loc,
+                ip=ip,
+            )
+        else:
+            prims.cp_async_bulk_tensor_shared_cta_global(
+                dst_mem=smem_ptr,
+                tma_descriptor=tma_desc_ptr,
+                coordinates=coordinates,
+                mbar=mbar,
+                im2col_offsets=im2col_offsets,
+                l2_cache_hint=Uint64(0x1000000000000000),
+                mode=mode,
+                loc=loc,
+                ip=ip,
+            )
 
 
 @dsl_user_op
@@ -154,7 +240,7 @@ def tma_store(tma_desc, smem_ptr: cute.Pointer, crd: Int | tuple[Int, ...], *, l
     :type crd:                       tuple[Int, ...]
     """
     arch = CuTeDSL._get_dsl().envar.arch
-    check_value_in(arch, ["sm_90", "sm_90a", "sm_100a"], "arch")
+    check_value_in(arch, _TMA_ARCHES, "arch")
     if not isinstance(crd, tuple):
         if arch not in ("sm_90", "sm_90a"):
             raise NotImplementedError("tma_store(size) path is only implemented for sm_90/sm_90a")
@@ -167,17 +253,12 @@ def tma_store(tma_desc, smem_ptr: cute.Pointer, crd: Int | tuple[Int, ...], *, l
             ip=ip,
         )
     else:
-        if isinstance(tma_desc, cute.CopyAtom):
-            tma_desc_ptr = extract_tensormap_ptr(tma_desc)
-        elif isinstance(tma_desc, cute.Tensor):
-            tma_desc_ptr = tma_desc.iterator
-        else:
-            tma_desc_ptr = tma_desc
-        nvvm.cp_async_bulk_tensor_global_shared_cta(
-            tma_descriptor=tma_desc_ptr.llvm_ptr,
-            src_mem=smem_ptr.llvm_ptr,
-            coordinates=[Int32(i).ir_value(loc=loc, ip=ip) for i in crd],
-            predicate=None,
+        tma_desc_ptr = _as_tensormap_ptr(tma_desc, loc=loc, ip=ip)
+        prims.cp_async_bulk_tensor_global_shared_cta(
+            tma_descriptor=tma_desc_ptr,
+            src_mem=smem_ptr,
+            coordinates=[Int32(i) for i in crd],
+            mode=prims.TMAStoreMode.TILE,
             loc=loc,
             ip=ip,
         )
@@ -198,28 +279,21 @@ def tma_reduce(tma_desc, smem_ptr: cute.Pointer, crd: Int | tuple[Int, ...], *, 
     :param crd:                      Coordinates tuple for the tensor access
     :type crd:                       tuple[Int, ...]
     """
-    from cutlass._mlir.dialects._nvvm_enum_gen import TMAReduxKind, TMAStoreMode
-
     arch = CuTeDSL._get_dsl().envar.arch
-    check_value_in(arch, ["sm_90", "sm_90a", "sm_100a"], "arch")
+    check_value_in(arch, _TMA_ARCHES, "arch")
 
-    if isinstance(tma_desc, cute.CopyAtom):
-        tma_desc_ptr = extract_tensormap_ptr(tma_desc)
-    elif isinstance(tma_desc, cute.Tensor):
-        tma_desc_ptr = tma_desc.iterator
-    else:
-        tma_desc_ptr = tma_desc
+    tma_desc_ptr = _as_tensormap_ptr(tma_desc, loc=loc, ip=ip)
 
     # Ensure crd is a tuple
     if not isinstance(crd, tuple):
         crd = (crd,)
 
-    nvvm.cp_async_bulk_tensor_reduce(
-        tma_descriptor=tma_desc_ptr.llvm_ptr,
-        src_mem=smem_ptr.llvm_ptr,
-        red_kind=TMAReduxKind.ADD,
-        coordinates=[Int32(i).ir_value(loc=loc, ip=ip) for i in crd],
-        mode=TMAStoreMode.TILE,
+    prims.cp_async_bulk_tensor_reduce(
+        tma_descriptor=tma_desc_ptr,
+        src_mem=smem_ptr,
+        red_kind=prims.TMARedux.ADD,
+        coordinates=[Int32(i) for i in crd],
+        mode=prims.TMAStoreMode.TILE,
         loc=loc,
         ip=ip,
     )
@@ -231,7 +305,7 @@ def tma_store_arrive(*, loc=None, ip=None) -> None:
     Indicate arrival of warp issuing TMA_STORE.
     Corresponds to PTX instruction: cp.async.bulk.commit_group;
     """
-    nvvm.cp_async_bulk_commit_group(loc=loc, ip=ip)
+    prims.cp_async_bulk_commit_group(loc=loc, ip=ip)
 
 
 @dsl_user_op
@@ -245,12 +319,12 @@ def tma_store_wait(count: int, *, read=None, loc=None, ip=None) -> None:
     :param read: Whether to use the PTX .read modifier
     :type read: Optional[bool]
     """
-    nvvm.cp_async_bulk_wait_group(group=count, read=read, loc=loc, ip=ip)
+    prims.cp_async_bulk_wait_group(group=count, read=read, loc=loc, ip=ip)
 
 
 @dsl_user_op
 def cp_async_shared_global(
-    dst: cute.Pointer, src: cute.Pointer, cp_size: Int, modifier: nvvm.LoadCacheModifierKind, *, src_size: Int = None, loc=None, ip=None
+    dst: cute.Pointer, src: cute.Pointer, cp_size: Int, modifier: prims.LoadCacheModifier, *, src_size: Int = None, loc=None, ip=None
 ) -> None:
     """
     Asynchronously copy data from global memory to shared memory.
@@ -266,13 +340,12 @@ def cp_async_shared_global(
     :param cp_size: Optional copy size override
     :type cp_size: Int
     """
-    size = src_size if src_size else cp_size
-    nvvm.cp_async_shared_global(
-        dst=dst.llvm_ptr,
-        src=src.llvm_ptr,
-        size=ir.IntegerAttr.get(ir.IntegerType.get_signless(32), size),
+    prims.cp_async_shared_global(
+        dst=dst,
+        src=src,
+        size=cp_size,
         modifier=modifier,
-        cp_size=Int32(cp_size).ir_value(loc=loc, ip=ip),
+        cp_size=src_size,
         loc=loc,
         ip=ip,
     )
@@ -284,47 +357,24 @@ def prefetch_tma_descriptor(tma_desc, *, loc=None, ip=None) -> None:
     Prefetch a TMA descriptor.
     Corresponds to PTX instruction: prefetch.tensormap;
     """
-    if isinstance(tma_desc, cute.CopyAtom):
-        tma_desc_ptr = extract_tensormap_ptr(tma_desc)
-    elif isinstance(tma_desc, cute.Tensor):
-        tma_desc_ptr = tma_desc.iterator
-    else:
-        tma_desc_ptr = tma_desc
-    nvvm.prefetch_tensormap(tma_desc_ptr.llvm_ptr, loc=loc, ip=ip)
+    tma_desc_ptr = _as_tensormap_ptr(tma_desc, loc=loc, ip=ip)
+    prims.prefetch_tensormap(tma_desc_ptr, loc=loc, ip=ip)
 
 
-# ---------------------------------------------------------------------------
-# Mbarrier operations (merged from mbar.py)
-# ---------------------------------------------------------------------------
-
-from cutlass._mlir.dialects import llvm
-
-
-@dsl_user_op
-def mbarrier_wait(mbar_ptr: Pointer, phase: Int, timeout_ns: Int = 10000000, *, loc=None, ip=None) -> None:
+@cute.jit
+def mbarrier_wait(mbar_ptr: Pointer, phase: Int, timeout_ns: int = 10000000) -> None:
     """Waits on a mbarrier with a specified phase (blocking loop).
 
-    Uses inline PTX to loop until the try_wait succeeds.
-    The CUDA backend does: while (!mbar.try_wait(parity)) {}
+    Uses the primitive try-wait wrapper in a spin loop.
     """
-    llvm.inline_asm(
-        None,
-        [mbar_ptr.llvm_ptr, Int32(phase).ir_value(loc=loc, ip=ip), Int32(timeout_ns).ir_value(loc=loc, ip=ip)],
-        "{\n.reg .pred p;\nLAB_WAIT:\nmbarrier.try_wait.parity.shared::cta.b64 p, [$0], $1, $2;\n@!p bra LAB_WAIT;\n}",
-        "r,r,r",
-        has_side_effects=True,
-        is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
-        loc=loc,
-        ip=ip,
-    )
+    while not prims.mbarrier_try_wait_parity(mbar_ptr, Int32(phase), time_limit=Int32(timeout_ns)):
+        pass
 
 
 @dsl_user_op
 def mbarrier_cp_async_arrive(mbar_ptr: Pointer, *, loc=None, ip=None) -> None:
-    mbar_llvm_ptr = mbar_ptr.llvm_ptr
-    nvvm.cp_async_mbarrier_arrive_shared(
-        mbar_llvm_ptr,
+    prims.cp_async_mbarrier_arrive(
+        mbar_ptr,
         noinc=False,
         loc=loc,
         ip=ip,
@@ -332,8 +382,8 @@ def mbarrier_cp_async_arrive(mbar_ptr: Pointer, *, loc=None, ip=None) -> None:
 
 
 def fence_proxy_async():
-    arch.fence_proxy(arch.ProxyKind.async_shared, space=arch.SharedSpace.shared_cta)
+    prims.fence_proxy("async_shared", space=prims.SharedSpace.shared_cta)
 
 
 def fence_barrier_init():
-    arch.mbarrier_init_fence()
+    prims.fence_mbarrier_init()

--- a/tilelang/contrib/cutedsl/gemm_tcgen05.py
+++ b/tilelang/contrib/cutedsl/gemm_tcgen05.py
@@ -4,7 +4,7 @@ tcgen05 (SM100/Blackwell) MMA support for CuTeDSL backend.
 Provides:
   - Tcgen05SmemDescriptor: 64-bit SMEM descriptor for tcgen05 MMA
   - initialize_tcgen05_descriptor: bitfield packing matching common.h layout
-  - tcgen05mma_ss / tcgen05mma_ws_ss / tcgen05mma_ts: MMA PTX inline asm
+  - tcgen05mma_ss / tcgen05mma_ws_ss / tcgen05mma_ts: primitive MMA wrappers
   - tcgen05_mma_arrive: mbarrier arrive for MMA commit
   - tmem_allocate / tmem_deallocate: TMEM allocation/deallocation
 """
@@ -16,19 +16,25 @@ __all__ = [
     "tcgen05mma_ws_ss",
     "tcgen05mma_ts",
     "tcgen05_mma_arrive",
+    "tcgen05_before_thread_sync",
+    "tcgen05_after_thread_sync",
     "tmem_allocate",
     "tmem_deallocate",
     "tcgen05_ld_32dp32bNx",
     "tcgen05_ld_32dp64bNx",
     "tcgen05_ld_32dp128bNx",
     "tcgen05_ld_32dp256bNx",
+    "tcgen05mma_blockscaled_ss",
+    "tcgen05_cp_warpx4",
+    "tcgen05_sf_warp_transpose",
 ]
 
 import cutlass
 import cutlass.cute as cute
-from cutlass._mlir.dialects import llvm
-from cutlass._mlir import ir
+from cutlass._mlir_helpers.vector import Vector
 from cutlass.cutlass_dsl import Constexpr, dsl_user_op
+from cutlass.experimental import primitives as prims
+from cutlass.experimental.primitives import nvvm_wrapper as _nvvm_prims
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -90,25 +96,28 @@ def initialize_tcgen05_descriptor(desc, start_address, leading_byte_offset, stri
 
 
 # ──────────────────────────────────────────────────────────────────────
-# PTX kind mapping  (TIR dtype string  ->  PTX kind suffix)
+# tcgen05 kind mapping  (TIR dtype string  ->  primitive kind enum)
 # ──────────────────────────────────────────────────────────────────────
 
 _TCGEN05_KIND_MAP = {
-    "fp16": "f16",
-    "bf16": "f16",
-    "float16": "f16",
-    "bfloat16": "f16",
-    "tf32": "tf32",
-    "float32": "tf32",
-    "s8": "i8",
-    "u8": "i8",
-    "int8": "i8",
-    "uint8": "i8",
-    "e4m3": "f8f6f4",
-    "e5m2": "f8f6f4",
-    "float8_e4m3": "f8f6f4",
-    "float8_e4m3fn": "f8f6f4",
-    "float8_e5m2": "f8f6f4",
+    "fp16": prims.Tcgen05MMAKind.F16,
+    "bf16": prims.Tcgen05MMAKind.F16,
+    "float16": prims.Tcgen05MMAKind.F16,
+    "bfloat16": prims.Tcgen05MMAKind.F16,
+    "tf32": prims.Tcgen05MMAKind.TF32,
+    "float32": prims.Tcgen05MMAKind.TF32,
+    "s8": prims.Tcgen05MMAKind.INT8,
+    "u8": prims.Tcgen05MMAKind.INT8,
+    "int8": prims.Tcgen05MMAKind.INT8,
+    "uint8": prims.Tcgen05MMAKind.INT8,
+    "e4m3": prims.Tcgen05MMAKind.F8F6F4,
+    "e5m2": prims.Tcgen05MMAKind.F8F6F4,
+    "float8_e4m3": prims.Tcgen05MMAKind.F8F6F4,
+    "float8_e4m3fn": prims.Tcgen05MMAKind.F8F6F4,
+    "float8_e5m2": prims.Tcgen05MMAKind.F8F6F4,
+    "e2m1": prims.Tcgen05MMAKind.F8F6F4,
+    "float4_e2m1fn": prims.Tcgen05MMAKind.F8F6F4,
+    "float4_e2m1_unpacked": prims.Tcgen05MMAKind.F8F6F4,
 }
 
 
@@ -119,9 +128,47 @@ def _kind_for(dtype_str):
     return kind
 
 
-def _ir(val, loc=None, ip=None):
-    """Extract MLIR IR value from a CuTeDSL value."""
-    return val.ir_value(loc=loc, ip=ip) if hasattr(val, "ir_value") else val
+def _blockscaled_kind_for(dtype_str):
+    if dtype_str not in _TCGEN05_KIND_MAP:
+        raise ValueError(f"tcgen05mma blockscaled: unsupported dtype '{dtype_str}'")
+    return prims.MMABlockScaleKind.MXF8F6F4
+
+
+def _desc_value(desc):
+    return desc.desc_i64[0] if isinstance(desc, Tcgen05SmemDescriptor) else desc
+
+
+@dsl_user_op
+def _tcgen05_mma_ws(mma_kind, d, a, b, idesc, enable_input_d, *, loc=None, ip=None):
+    """Emit tcgen05.mma.ws while working around a CUTLASS 4.7 pre-release kw typo."""
+    _nvvm_prims._assert_tensor_mem(d, "tcgen05.mma.ws")
+    _nvvm_prims._nvvm.tcgen05_mma_ws(
+        _nvvm_prims._TCGEN05_MMA_KIND_TO_DIALECT[mma_kind],
+        d,
+        a,
+        cutlass.Int64(b),
+        cutlass.Int32(idesc),
+        cutlass.Boolean(enable_input_d),
+        col_b_zero_mask=None,
+        loc=loc,
+        ip=ip,
+    )
+
+
+def _tmem_ptr(tmem_addr):
+    return prims.make_tmem_ptr(cutlass.Int32(tmem_addr), cutlass.Int32)
+
+
+def _write_disable_mask(mask0, mask1, mask2, mask3):
+    return Vector.from_elements(
+        (
+            cutlass.Int32(mask0),
+            cutlass.Int32(mask1),
+            cutlass.Int32(mask2),
+            cutlass.Int32(mask3),
+        ),
+        cutlass.Int32,
+    )
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -141,63 +188,38 @@ def tcgen05mma_ss(
     mask1: int,
     mask2: int,
     mask3: int,
+    use_2cta: Constexpr[bool] = False,
 ):
-    """tcgen05.mma.cta_group::1.kind::{kind} [tmem_c], desc_a, desc_b, desc_val, {masks}, p;
+    """tcgen05.mma.cta_group::{1|2}.kind::{kind} [tmem_c], desc_a, desc_b, desc_val, ...;
 
     Guarded by elect_one_sync — only one thread in the warp issues the MMA.
     The TIR codegen also wraps calls in ``if (threadIdx.x >> 5) == 0``
     which selects warp 0.
     """
     kind = _kind_for(kind_dtype)
-
-    # elect.sync selects one thread in the warp to issue the MMA.
-    # The @q predicate goes on the MMA instruction itself (not the block scope).
-    asm_str = (
-        "{\n"
-        ".reg .pred p;\n"
-        ".reg .pred q;\n"
-        "elect.sync _|q, 0xFFFFFFFF;\n"
-        "setp.ne.b32 p, $4, 0;\n"
-        f"@q tcgen05.mma.cta_group::1.kind::{kind} "
-        "[$0], $1, $2, $3, {$5, $6, $7, $8}, p;\n"
-        "}"
-    )
-
-    @dsl_user_op
-    def _do_mma(c_val, da_val, db_val, dv_val, sc_val, m0_val, m1_val, m2_val, m3_val, *, loc=None, ip=None):
-        llvm.inline_asm(
-            None,
-            [
-                _ir(c_val, loc, ip),
-                _ir(da_val, loc, ip),
-                _ir(db_val, loc, ip),
-                _ir(dv_val, loc, ip),
-                _ir(sc_val, loc, ip),
-                _ir(m0_val, loc, ip),
-                _ir(m1_val, loc, ip),
-                _ir(m2_val, loc, ip),
-                _ir(m3_val, loc, ip),
-            ],
-            asm_str,
-            "r,l,l,r,r,r,r,r,r",
-            has_side_effects=True,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-
-    _do_mma(
-        cutlass.Int32(tmem_c),
-        desc_a.desc_i64[0],
-        desc_b.desc_i64[0],
-        cutlass.Int32(desc_val),
-        cutlass.Int32(scale_out),
-        cutlass.Int32(mask0),
-        cutlass.Int32(mask1),
-        cutlass.Int32(mask2),
-        cutlass.Int32(mask3),
-    )
+    if use_2cta:
+        if prims.elect_sync():
+            prims.tcgen05_mma(
+                kind,
+                prims.CTAGroup.CTA_2,
+                _tmem_ptr(tmem_c),
+                desc_a.desc_i64[0],
+                desc_b.desc_i64[0],
+                desc_val,
+                scale_out,
+            )
+    else:
+        if prims.elect_sync():
+            prims.tcgen05_mma(
+                kind,
+                prims.CTAGroup.CTA_1,
+                _tmem_ptr(tmem_c),
+                desc_a.desc_i64[0],
+                desc_b.desc_i64[0],
+                desc_val,
+                scale_out,
+                write_disable_mask=_write_disable_mask(mask0, mask1, mask2, mask3),
+            )
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -211,39 +233,15 @@ def tcgen05mma_ws_ss(
 ):
     """tcgen05.mma.ws.cta_group::1.kind::{kind} [tmem_c], desc_a, desc_b, desc_val, p, 0;"""
     kind = _kind_for(kind_dtype)
-
-    asm_str = (
-        "{\n"
-        ".reg .pred p;\n"
-        ".reg .pred q;\n"
-        "elect.sync _|q, 0xFFFFFFFF;\n"
-        "setp.ne.b32 p, $4, 0;\n"
-        f"@q tcgen05.mma.ws.cta_group::1.kind::{kind} "
-        "[$0], $1, $2, $3, p, 0;\n"
-        "}"
-    )
-
-    @dsl_user_op
-    def _do_mma_ws(c_val, da_val, db_val, dv_val, sc_val, *, loc=None, ip=None):
-        llvm.inline_asm(
-            None,
-            [_ir(c_val, loc, ip), _ir(da_val, loc, ip), _ir(db_val, loc, ip), _ir(dv_val, loc, ip), _ir(sc_val, loc, ip)],
-            asm_str,
-            "r,l,l,r,r",
-            has_side_effects=True,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
+    if prims.elect_sync():
+        _tcgen05_mma_ws(
+            kind,
+            _tmem_ptr(tmem_c),
+            desc_a.desc_i64[0],
+            desc_b.desc_i64[0],
+            desc_val,
+            scale_out,
         )
-
-    _do_mma_ws(
-        cutlass.Int32(tmem_c),
-        desc_a.desc_i64[0],
-        desc_b.desc_i64[0],
-        cutlass.Int32(desc_val),
-        cutlass.Int32(scale_out),
-    )
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -263,57 +261,33 @@ def tcgen05mma_ts(
     mask1: int,
     mask2: int,
     mask3: int,
+    use_2cta: Constexpr[bool] = False,
 ):
-    """tcgen05.mma.cta_group::1.kind::{kind} [tmem_c], [tmem_a], desc_b, desc_val, {masks}, p;"""
+    """tcgen05.mma.cta_group::{1|2}.kind::{kind} [tmem_c], [tmem_a], desc_b, desc_val, ...;"""
     kind = _kind_for(kind_dtype)
-
-    # A is [$1] (indirect via TMEM address), not $1 (direct descriptor)
-    asm_str = (
-        "{\n"
-        ".reg .pred p;\n"
-        ".reg .pred q;\n"
-        "elect.sync _|q, 0xFFFFFFFF;\n"
-        "setp.ne.b32 p, $4, 0;\n"
-        f"@q tcgen05.mma.cta_group::1.kind::{kind} "
-        "[$0], [$1], $2, $3, {$5, $6, $7, $8}, p;\n"
-        "}"
-    )
-
-    @dsl_user_op
-    def _do_mma_ts(c_val, a_val, db_val, dv_val, sc_val, m0_val, m1_val, m2_val, m3_val, *, loc=None, ip=None):
-        llvm.inline_asm(
-            None,
-            [
-                _ir(c_val, loc, ip),
-                _ir(a_val, loc, ip),
-                _ir(db_val, loc, ip),
-                _ir(dv_val, loc, ip),
-                _ir(sc_val, loc, ip),
-                _ir(m0_val, loc, ip),
-                _ir(m1_val, loc, ip),
-                _ir(m2_val, loc, ip),
-                _ir(m3_val, loc, ip),
-            ],
-            asm_str,
-            "r,r,l,r,r,r,r,r,r",
-            has_side_effects=True,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-
-    _do_mma_ts(
-        cutlass.Int32(tmem_c),
-        cutlass.Int32(tmem_a),
-        desc_b.desc_i64[0],
-        cutlass.Int32(desc_val),
-        cutlass.Int32(scale_out),
-        cutlass.Int32(mask0),
-        cutlass.Int32(mask1),
-        cutlass.Int32(mask2),
-        cutlass.Int32(mask3),
-    )
+    if use_2cta:
+        if prims.elect_sync():
+            prims.tcgen05_mma(
+                kind,
+                prims.CTAGroup.CTA_2,
+                _tmem_ptr(tmem_c),
+                _tmem_ptr(tmem_a),
+                desc_b.desc_i64[0],
+                desc_val,
+                scale_out,
+            )
+    else:
+        if prims.elect_sync():
+            prims.tcgen05_mma(
+                kind,
+                prims.CTAGroup.CTA_1,
+                _tmem_ptr(tmem_c),
+                _tmem_ptr(tmem_a),
+                desc_b.desc_i64[0],
+                desc_val,
+                scale_out,
+                write_disable_mask=_write_disable_mask(mask0, mask1, mask2, mask3),
+            )
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -322,32 +296,22 @@ def tcgen05mma_ts(
 
 
 @cute.jit
-def tcgen05_mma_arrive(mbar_ptr: cute.Pointer):
-    """tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64 [mbar];
+def tcgen05_mma_arrive(mbar_ptr: cute.Pointer, use_2cta: Constexpr[bool] = False):
+    """Commit prior tcgen05 work to an mbarrier."""
+    group = prims.CTAGroup.CTA_2 if use_2cta else prims.CTAGroup.CTA_1
+    multicast_mask = cutlass.Int16(3) if use_2cta else None
+    if prims.elect_sync():
+        prims.tcgen05_commit(mbar_ptr, multicast_mask=multicast_mask, group=group)
 
-    Guarded by elect_one_sync — only one thread in the warp issues the commit.
-    """
 
-    @dsl_user_op
-    def _do_arrive(bar_val, *, loc=None, ip=None):
-        llvm.inline_asm(
-            None,
-            [_ir(bar_val, loc, ip)],
-            "{\n"
-            ".reg .pred q;\n"
-            "elect.sync _|q, 0xFFFFFFFF;\n"
-            "@q tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64 [$0];\n"
-            "}",
-            "r",
-            has_side_effects=True,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
+@dsl_user_op
+def tcgen05_before_thread_sync(*, loc=None, ip=None) -> None:
+    prims.tcgen05_fence(prims.Tcgen05Fence.BEFORE_THREAD_SYNC, loc=loc, ip=ip)
 
-    bar_intptr = cutlass.Int32(mbar_ptr.toint())
-    _do_arrive(bar_intptr)
+
+@dsl_user_op
+def tcgen05_after_thread_sync(*, loc=None, ip=None) -> None:
+    prims.tcgen05_fence(prims.Tcgen05Fence.AFTER_THREAD_SYNC, loc=loc, ip=ip)
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -356,118 +320,134 @@ def tcgen05_mma_arrive(mbar_ptr: cute.Pointer):
 
 
 @cute.jit
-def tmem_allocate(tmem_buffer_ptr: cute.Pointer, num_cols: int):
-    """tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [dst], num_cols;
+def tmem_allocate(tmem_buffer_ptr: cute.Pointer, num_cols: int, use_2cta: Constexpr[bool] = False):
+    """Allocate TMEM columns for tcgen05 operations.
 
     tmem_buffer_ptr: SMEM pointer that receives the allocated TMEM address.
     num_cols: number of columns to allocate.
     """
-
-    @dsl_user_op
-    def _do_alloc(dst_val, ncols_val, *, loc=None, ip=None):
-        llvm.inline_asm(
-            None,
-            [_ir(dst_val, loc, ip), _ir(ncols_val, loc, ip)],
-            "tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [$0], $1;",
-            "r,r",
-            has_side_effects=True,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-
-    dst_intptr = cutlass.Int32(tmem_buffer_ptr.toint())
-    _do_alloc(dst_intptr, cutlass.Int32(num_cols))
+    group = prims.CTAGroup.CTA_2 if use_2cta else prims.CTAGroup.CTA_1
+    prims.tcgen05_alloc(tmem_buffer_ptr, cutlass.Int32(num_cols), group=group)
 
 
 @cute.jit
-def tmem_deallocate(tmem_ptr: cute.Pointer, num_cols: int):
-    """tcgen05.dealloc.cta_group::1.sync.aligned.b32 tmem_addr, num_cols;
+def tmem_deallocate(tmem_ptr: cute.Pointer, num_cols: int, use_2cta: Constexpr[bool] = False):
+    """Deallocate TMEM columns for tcgen05 operations.
 
     tmem_ptr: SMEM pointer to the uint32 holding the TMEM address.
     num_cols: number of columns to deallocate.
     """
-    # Read the TMEM address from the SMEM location
+    group = prims.CTAGroup.CTA_2 if use_2cta else prims.CTAGroup.CTA_1
     tmem_addr = cute.make_tensor(tmem_ptr, (1,))[0]
+    tmem_addr_ptr = prims.make_tmem_ptr(cutlass.Int32(tmem_addr), cutlass.Int32)
+    prims.tcgen05_dealloc(tmem_addr_ptr, cutlass.Int32(num_cols), group=group)
 
-    @dsl_user_op
-    def _do_dealloc(tptr_val, ncols_val, *, loc=None, ip=None):
-        llvm.inline_asm(
-            None,
-            [_ir(tptr_val, loc, ip), _ir(ncols_val, loc, ip)],
-            "tcgen05.dealloc.cta_group::1.sync.aligned.b32 $0, $1;",
-            "r,r",
-            has_side_effects=True,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
+
+# ──────────────────────────────────────────────────────────────────────
+# Block-scaled tcgen05 MMA
+# ──────────────────────────────────────────────────────────────────────
+
+
+@cute.jit
+def tcgen05mma_blockscaled_ss(
+    kind_dtype: str,
+    desc_a,
+    desc_b,
+    tmem_c: int,
+    desc_val: int,
+    scale_out: int,
+    tmem_sfa: int,
+    tmem_sfb: int,
+    use_2cta: Constexpr[bool] = False,
+):
+    """Block-scaled tcgen05.mma SS path with scale factors already in TMEM."""
+    group = prims.CTAGroup.CTA_2 if use_2cta else prims.CTAGroup.CTA_1
+    d_ptr = prims.make_tmem_ptr(cutlass.Int32(tmem_c), cutlass.Int32)
+    sfa_ptr = prims.make_tmem_ptr(cutlass.Int32(tmem_sfa), cutlass.Int32)
+    sfb_ptr = prims.make_tmem_ptr(cutlass.Int32(tmem_sfb), cutlass.Int32)
+    if prims.elect_sync():
+        prims.tcgen05_mma_block_scale(
+            _blockscaled_kind_for(kind_dtype),
+            group,
+            d_ptr,
+            _desc_value(desc_a),
+            _desc_value(desc_b),
+            desc_val,
+            enable_input_d=scale_out,
+            scale_a=sfa_ptr,
+            scale_b=sfb_ptr,
         )
 
-    _do_dealloc(cutlass.Int32(tmem_addr), cutlass.Int32(num_cols))
+
+# ──────────────────────────────────────────────────────────────────────
+# Scale-factor SMEM to TMEM helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+@cute.jit
+def tcgen05_cp_warpx4(smem_ptr: cute.Pointer, tmem_ptr: cute.Pointer, tmem_col_offset: int, use_2cta: Constexpr[bool] = False):
+    """Copy a 32x128b scale-factor tile from SMEM to TMEM with warpx4 multicast."""
+    smem_addr = smem_ptr.toint() if hasattr(smem_ptr, "toint") else smem_ptr
+    smem_desc = prims.Tcgen05SmemDesc.build(
+        start_address=smem_addr,
+        leading_byte_offset=0,
+        stride_byte_offset=128,
+        base_offset=0,
+        layout=prims.Tcgen05SmemSwizzle.NONE,
+    )
+    tmem_addr_tensor = tmem_ptr if isinstance(tmem_ptr, cute.Tensor) else cute.make_tensor(tmem_ptr, (1,))
+    tmem_addr = cutlass.Int32(tmem_addr_tensor[0]) + cutlass.Int32(tmem_col_offset)
+    tmem_dst = prims.make_tmem_ptr(tmem_addr, cutlass.Int32)
+    group = prims.CTAGroup.CTA_2 if use_2cta else prims.CTAGroup.CTA_1
+    shape, multicast = prims.S2TCopyMode.S2T_32x128b_WARPX4
+    if prims.elect_sync():
+        prims.tcgen05_cp(
+            shape,
+            tmem_dst,
+            smem_desc,
+            group=group,
+            multicast=multicast,
+        )
+
+
+@cute.jit
+def tcgen05_sf_warp_transpose(smem_ptr: cute.Pointer):
+    """In-place warp transpose for 128 uint32 scale-factor words in SMEM."""
+    smem = cute.make_tensor(cute.recast_ptr(smem_ptr, dtype=cutlass.Uint32), (128,))
+    tidx, _, _ = cute.arch.thread_idx()
+    lane = tidx % 32
+    lane_quad = lane >> 3
+    v0 = smem[(0 ^ lane_quad) * 32 + lane]
+    v1 = smem[(1 ^ lane_quad) * 32 + lane]
+    v2 = smem[(2 ^ lane_quad) * 32 + lane]
+    v3 = smem[(3 ^ lane_quad) * 32 + lane]
+    cute.arch.sync_warp()
+    smem[lane * 4 + (0 ^ lane_quad)] = v0
+    smem[lane * 4 + (1 ^ lane_quad)] = v1
+    smem[lane * 4 + (2 ^ lane_quad)] = v2
+    smem[lane * 4 + (3 ^ lane_quad)] = v3
 
 
 # ──────────────────────────────────────────────────────────────────────
-# TMEM load  —  tcgen05.ld.sync.aligned.32x32b.xN.b32
-#
-# Uses the same pattern as wgmma_rs: direct llvm.inline_asm calls from
-# within @cute.jit context (no @dsl_user_op wrapper).  The helper
-# functions below are called at Python / JIT-compile time and emit MLIR
-# operations directly into the surrounding @cute.jit function.
+# TMEM load helpers.
 # ──────────────────────────────────────────────────────────────────────
 
-# Max segment size for TMEM loads.  LLVM's NVPTX inline asm chokes on very
-# large operand counts (e.g. x128 = 129 operands), so we cap at x32 which
-# gives 33 operands — well within limits.  For N=128 this produces 4
-# sequential x32 loads.
 _TMEM_LD_MAX_LOG_N = 3  # 1 << 3 = 8  (keep small to avoid LLVM hangs with many operands)
 
 
-def _emit_tmem_ld_segment(ptx_type, seg_x, regs_per_x, addr_ir):
-    """Emit one tcgen05.ld inline asm for a power-of-2 segment.
+def _emit_tmem_ld_segment(shape, seg_x, regs_per_x, addr):
+    """Emit one tcgen05.ld wrapper call for a power-of-2 segment.
 
     Called during @cute.jit compilation — emits MLIR ops directly.
-    ptx_type:    PTX instruction type, e.g. "32x32b", "16x64b", "16x128b", "16x256b"
+    shape:       TMEM load shape, e.g. "32x32b", "16x64b", "16x128b", "16x256b"
     seg_x:       x-count in the PTX instruction (power of 2)
     regs_per_x:  number of i32 output registers per x-element
     Returns a list of (seg_x * regs_per_x) cutlass.Int32 values.
     """
-    i32_type = ir.IntegerType.get_signless(32)
     total_regs = seg_x * regs_per_x
-
-    if total_regs == 1:
-        result = llvm.inline_asm(
-            i32_type,
-            [addr_ir],
-            f"tcgen05.ld.sync.aligned.{ptx_type}.x{seg_x}.b32 $0, [$1];",
-            "=r,r",
-            has_side_effects=True,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-        )
-        return [cutlass.Int32(result)]
-
-    # Multi-output: struct of i32s
-    out_types = [i32_type] * total_regs
-    result_type = llvm.StructType.get_literal(out_types)
-
-    out_regs = ", ".join(f"${i}" for i in range(total_regs))
-    src_idx = total_regs  # source addr is the last operand
-    asm_str = f"tcgen05.ld.sync.aligned.{ptx_type}.x{seg_x}.b32 {{{out_regs}}}, [${src_idx}];"
-    constraints = ",".join(["=r"] * total_regs) + ",r"
-
-    result = llvm.inline_asm(
-        result_type,
-        [addr_ir],
-        asm_str,
-        constraints,
-        has_side_effects=True,
-        is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
-    )
-
-    return [cutlass.Int32(llvm.extractvalue(i32_type, result, [i])) for i in range(total_regs)]
+    tmem_ptr = prims.make_tmem_ptr(cutlass.Int32(addr), cutlass.Int32)
+    result = prims.tcgen05_ld(shape, tmem_ptr, num=seg_x)
+    return [cutlass.Int32(result[i]) for i in range(total_regs)]
 
 
 def _emit_tmem_ld(n_x, max_log_n, ptx_type, regs_per_x, src_addr, dst_view, dst_offset=0, src_col_offset=0):
@@ -476,7 +456,7 @@ def _emit_tmem_ld(n_x, max_log_n, ptx_type, regs_per_x, src_addr, dst_view, dst_
     Called during @cute.jit compilation.
     n_x:            remaining x-element count to load
     max_log_n:      max log2 of x-count per PTX instruction
-    ptx_type:       PTX instruction type, e.g. "32x32b", "16x64b"
+    ptx_type:       TMEM load shape, e.g. "32x32b", "16x64b"
     regs_per_x:     i32 output registers per x-element
     src_addr:       CuTeDSL Int32 (runtime TMEM base address)
     dst_view:       CuTeDSL tensor view over destination registers
@@ -490,14 +470,12 @@ def _emit_tmem_ld(n_x, max_log_n, ptx_type, regs_per_x, src_addr, dst_view, dst_
     seg_log = min(log_n, max_log_n)
     seg_x = 1 << seg_log
 
-    # Compute TMEM address for this segment
     if src_col_offset == 0:
-        addr_ir = src_addr.ir_value()
+        addr = src_addr
     else:
-        addr_ir = (src_addr + cutlass.Int32(src_col_offset)).ir_value()
+        addr = src_addr + cutlass.Int32(src_col_offset)
 
-    # Emit inline asm and store results
-    results = _emit_tmem_ld_segment(ptx_type, seg_x, regs_per_x, addr_ir)
+    results = _emit_tmem_ld_segment(ptx_type, seg_x, regs_per_x, addr)
     for j, val in enumerate(results):
         dst_view[dst_offset + j] = val
 
@@ -507,16 +485,8 @@ def _emit_tmem_ld(n_x, max_log_n, ptx_type, regs_per_x, src_addr, dst_view, dst_
 
 
 def _emit_tmem_fence():
-    """Emit tcgen05.wait fence.  Called during @cute.jit compilation."""
-    llvm.inline_asm(
-        None,
-        [],
-        "tcgen05.wait::ld.sync.aligned;",
-        "",
-        has_side_effects=True,
-        is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
-    )
+    """Wait for pending tcgen05.ld operations."""
+    prims.tcgen05_wait(prims.Tcgen05Wait.LOAD)
 
 
 @cute.jit

--- a/tilelang/contrib/cutedsl/ieee_math.py
+++ b/tilelang/contrib/cutedsl/ieee_math.py
@@ -3,10 +3,8 @@
 """
 IEEE-754 compliant floating-point operations with explicit rounding modes.
 
-These correspond to CUDA __fadd_rn, __fsub_rz, etc. Implemented via inline PTX
-to ensure exact rounding mode compliance.
-
-Rounding modes: rn (nearest), rz (toward zero), rm (toward -inf), rp (toward +inf)
+These correspond to CUDA __fadd_rn, __fsub_rz, etc.  TileLang keeps the
+public API names stable and delegates instruction emission to CUTLASS primitives.
 """
 
 __all__ = [
@@ -19,288 +17,184 @@ __all__ = [
     "ieee_fdiv",
 ]
 
-from cutlass._mlir.dialects import llvm
-from cutlass.base_dsl.typing import Float32, Float64
-from cutlass.cutlass_dsl import T, dsl_user_op
+import enum
+
+from cutlass.base_dsl.typing import Float32, Float64, Numeric
+from cutlass.experimental import primitives as prims
 
 
-# --- f32 binary ops ---
+class FPRound(str, enum.Enum):
+    RN = "rn"
+    RZ = "rz"
+    RM = "rm"
+    RP = "rp"
 
 
-@dsl_user_op
+def _rounding(rounding: str | FPRound) -> str:
+    if isinstance(rounding, FPRound):
+        return rounding.value
+    return FPRound(rounding).value
+
+
+def _scalar_arg_type(arg):
+    if isinstance(arg, Numeric):
+        return type(arg)
+    if hasattr(arg, "type"):
+        return Numeric.from_mlir_type(arg.type)
+    return None
+
+
+def _use_f64(*args) -> bool:
+    return any(_scalar_arg_type(arg) is Float64 for arg in args)
+
+
+def _ptx_dtype(dtype) -> str:
+    if dtype is Float32:
+        return "f32"
+    if dtype is Float64:
+        return "f64"
+    raise TypeError(f"Unsupported IEEE dtype: {dtype}")
+
+
+def _unary_fp_ptx(op: str, dtype, a, *, rounding: str = "rn", loc=None, ip=None):
+    rnd = _rounding(rounding)
+    return dtype(
+        prims.inline_ptx(
+            f"{op}.{rnd}.{_ptx_dtype(dtype)} {{$w0}}, {{$r0}};",
+            write_only_types=[dtype],
+            read_only_args=[dtype(a)],
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+def _binary_fp_ptx(op: str, dtype, a, b, *, rounding: str = "rn", loc=None, ip=None):
+    rnd = _rounding(rounding)
+    return dtype(
+        prims.inline_ptx(
+            f"{op}.{rnd}.{_ptx_dtype(dtype)} {{$w0}}, {{$r0}}, {{$r1}};",
+            write_only_types=[dtype],
+            read_only_args=[dtype(a), dtype(b)],
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+def _ternary_fp_ptx(op: str, dtype, a, b, c, *, rounding: str = "rn", loc=None, ip=None):
+    rnd = _rounding(rounding)
+    return dtype(
+        prims.inline_ptx(
+            f"{op}.{rnd}.{_ptx_dtype(dtype)} {{$w0}}, {{$r0}}, {{$r1}}, {{$r2}};",
+            write_only_types=[dtype],
+            read_only_args=[dtype(a), dtype(b), dtype(c)],
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
 def _fadd_f32(a: Float32, b: Float32, *, rounding: str = "rn", loc=None, ip=None) -> Float32:
-    return Float32(
-        llvm.inline_asm(
-            T.f32(),
-            [Float32(a).ir_value(), Float32(b).ir_value()],
-            f"add.{rounding}.f32 $0, $1, $2;",
-            "=f,f,f",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-    )
+    return _binary_fp_ptx("add", Float32, a, b, rounding=rounding, loc=loc, ip=ip)
 
 
-@dsl_user_op
 def _fsub_f32(a: Float32, b: Float32, *, rounding: str = "rn", loc=None, ip=None) -> Float32:
-    return Float32(
-        llvm.inline_asm(
-            T.f32(),
-            [Float32(a).ir_value(), Float32(b).ir_value()],
-            f"sub.{rounding}.f32 $0, $1, $2;",
-            "=f,f,f",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-    )
+    return _binary_fp_ptx("sub", Float32, a, b, rounding=rounding, loc=loc, ip=ip)
 
 
-@dsl_user_op
 def _fmul_f32(a: Float32, b: Float32, *, rounding: str = "rn", loc=None, ip=None) -> Float32:
-    return Float32(
-        llvm.inline_asm(
-            T.f32(),
-            [Float32(a).ir_value(), Float32(b).ir_value()],
-            f"mul.{rounding}.f32 $0, $1, $2;",
-            "=f,f,f",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-    )
+    return _binary_fp_ptx("mul", Float32, a, b, rounding=rounding, loc=loc, ip=ip)
 
 
-@dsl_user_op
 def _fmaf_f32(a: Float32, b: Float32, c: Float32, *, rounding: str = "rn", loc=None, ip=None) -> Float32:
-    return Float32(
-        llvm.inline_asm(
-            T.f32(),
-            [Float32(a).ir_value(), Float32(b).ir_value(), Float32(c).ir_value()],
-            f"fma.{rounding}.f32 $0, $1, $2, $3;",
-            "=f,f,f,f",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-    )
+    return _ternary_fp_ptx("fma", Float32, a, b, c, rounding=rounding, loc=loc, ip=ip)
 
 
-@dsl_user_op
 def _frcp_f32(a: Float32, *, rounding: str = "rn", loc=None, ip=None) -> Float32:
-    return Float32(
-        llvm.inline_asm(
-            T.f32(),
-            [Float32(a).ir_value()],
-            f"rcp.{rounding}.f32 $0, $1;",
-            "=f,f",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-    )
+    return _unary_fp_ptx("rcp", Float32, a, rounding=rounding, loc=loc, ip=ip)
 
 
-@dsl_user_op
 def _fsqrt_f32(a: Float32, *, rounding: str = "rn", loc=None, ip=None) -> Float32:
-    return Float32(
-        llvm.inline_asm(
-            T.f32(),
-            [Float32(a).ir_value()],
-            f"sqrt.{rounding}.f32 $0, $1;",
-            "=f,f",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-    )
+    return _unary_fp_ptx("sqrt", Float32, a, rounding=rounding, loc=loc, ip=ip)
 
 
-@dsl_user_op
 def _fdiv_f32(a: Float32, b: Float32, *, rounding: str = "rn", loc=None, ip=None) -> Float32:
-    return Float32(
-        llvm.inline_asm(
-            T.f32(),
-            [Float32(a).ir_value(), Float32(b).ir_value()],
-            f"div.{rounding}.f32 $0, $1, $2;",
-            "=f,f,f",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-    )
+    return _binary_fp_ptx("div", Float32, a, b, rounding=rounding, loc=loc, ip=ip)
 
 
-# --- f64 binary ops ---
-
-
-@dsl_user_op
 def _dadd_f64(a: Float64, b: Float64, *, rounding: str = "rn", loc=None, ip=None) -> Float64:
-    return Float64(
-        llvm.inline_asm(
-            T.f64(),
-            [Float64(a).ir_value(), Float64(b).ir_value()],
-            f"add.{rounding}.f64 $0, $1, $2;",
-            "=d,d,d",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-    )
+    return _binary_fp_ptx("add", Float64, a, b, rounding=rounding, loc=loc, ip=ip)
 
 
-@dsl_user_op
 def _dsub_f64(a: Float64, b: Float64, *, rounding: str = "rn", loc=None, ip=None) -> Float64:
-    return Float64(
-        llvm.inline_asm(
-            T.f64(),
-            [Float64(a).ir_value(), Float64(b).ir_value()],
-            f"sub.{rounding}.f64 $0, $1, $2;",
-            "=d,d,d",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-    )
+    return _binary_fp_ptx("sub", Float64, a, b, rounding=rounding, loc=loc, ip=ip)
 
 
-@dsl_user_op
 def _dmul_f64(a: Float64, b: Float64, *, rounding: str = "rn", loc=None, ip=None) -> Float64:
-    return Float64(
-        llvm.inline_asm(
-            T.f64(),
-            [Float64(a).ir_value(), Float64(b).ir_value()],
-            f"mul.{rounding}.f64 $0, $1, $2;",
-            "=d,d,d",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-    )
+    return _binary_fp_ptx("mul", Float64, a, b, rounding=rounding, loc=loc, ip=ip)
 
 
-@dsl_user_op
 def _dmaf_f64(a: Float64, b: Float64, c: Float64, *, rounding: str = "rn", loc=None, ip=None) -> Float64:
-    return Float64(
-        llvm.inline_asm(
-            T.f64(),
-            [Float64(a).ir_value(), Float64(b).ir_value(), Float64(c).ir_value()],
-            f"fma.{rounding}.f64 $0, $1, $2, $3;",
-            "=d,d,d,d",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-    )
+    return _ternary_fp_ptx("fma", Float64, a, b, c, rounding=rounding, loc=loc, ip=ip)
 
 
-@dsl_user_op
 def _drcp_f64(a: Float64, *, rounding: str = "rn", loc=None, ip=None) -> Float64:
-    return Float64(
-        llvm.inline_asm(
-            T.f64(),
-            [Float64(a).ir_value()],
-            f"rcp.{rounding}.f64 $0, $1;",
-            "=d,d",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-    )
+    return _unary_fp_ptx("rcp", Float64, a, rounding=rounding, loc=loc, ip=ip)
 
 
-@dsl_user_op
 def _dsqrt_f64(a: Float64, *, rounding: str = "rn", loc=None, ip=None) -> Float64:
-    return Float64(
-        llvm.inline_asm(
-            T.f64(),
-            [Float64(a).ir_value()],
-            f"sqrt.{rounding}.f64 $0, $1;",
-            "=d,d",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-    )
+    return _unary_fp_ptx("sqrt", Float64, a, rounding=rounding, loc=loc, ip=ip)
 
 
-@dsl_user_op
 def _ddiv_f64(a: Float64, b: Float64, *, rounding: str = "rn", loc=None, ip=None) -> Float64:
-    return Float64(
-        llvm.inline_asm(
-            T.f64(),
-            [Float64(a).ir_value(), Float64(b).ir_value()],
-            f"div.{rounding}.f64 $0, $1, $2;",
-            "=d,d,d",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-    )
-
-
-# --- Public API (dispatches by dtype) ---
+    return _binary_fp_ptx("div", Float64, a, b, rounding=rounding, loc=loc, ip=ip)
 
 
 def ieee_fadd(a, b, rounding="rn"):
     """IEEE-754 add with explicit rounding mode."""
+    if _use_f64(a, b):
+        return _dadd_f64(a, b, rounding=rounding)
     return _fadd_f32(a, b, rounding=rounding)
 
 
 def ieee_fsub(a, b, rounding="rn"):
     """IEEE-754 subtract with explicit rounding mode."""
+    if _use_f64(a, b):
+        return _dsub_f64(a, b, rounding=rounding)
     return _fsub_f32(a, b, rounding=rounding)
 
 
 def ieee_fmul(a, b, rounding="rn"):
     """IEEE-754 multiply with explicit rounding mode."""
+    if _use_f64(a, b):
+        return _dmul_f64(a, b, rounding=rounding)
     return _fmul_f32(a, b, rounding=rounding)
 
 
 def ieee_fmaf(a, b, c, rounding="rn"):
     """IEEE-754 fused multiply-add with explicit rounding mode."""
+    if _use_f64(a, b, c):
+        return _dmaf_f64(a, b, c, rounding=rounding)
     return _fmaf_f32(a, b, c, rounding=rounding)
 
 
 def ieee_frcp(a, rounding="rn"):
     """IEEE-754 reciprocal with explicit rounding mode."""
+    if _use_f64(a):
+        return _drcp_f64(a, rounding=rounding)
     return _frcp_f32(a, rounding=rounding)
 
 
 def ieee_fsqrt(a, rounding="rn"):
     """IEEE-754 square root with explicit rounding mode."""
+    if _use_f64(a):
+        return _dsqrt_f64(a, rounding=rounding)
     return _fsqrt_f32(a, rounding=rounding)
 
 
 def ieee_fdiv(a, b, rounding="rn"):
     """IEEE-754 divide with explicit rounding mode."""
+    if _use_f64(a, b):
+        return _ddiv_f64(a, b, rounding=rounding)
     return _fdiv_f32(a, b, rounding=rounding)

--- a/tilelang/contrib/cutedsl/ldsm.py
+++ b/tilelang/contrib/cutedsl/ldsm.py
@@ -2,11 +2,23 @@
 LDMATRIX and STMATRIX operations for CuTeDSL backend.
 Based on tl_templates/cuda/ldsm.h
 
-These functions provide wrappers around PTX ldmatrix/stmatrix instructions
+These functions provide wrappers around CUTLASS primitive ldmatrix/stmatrix operations
 for loading/storing 8x8 matrix fragments between shared memory and registers.
 """
 
 __all__ = [
+    "ldmatrix_x1",
+    "ldmatrix_x2",
+    "ldmatrix_x4",
+    "ldmatrix_x1_trans",
+    "ldmatrix_x2_trans",
+    "ldmatrix_x4_trans",
+    "stmatrix_x1",
+    "stmatrix_x2",
+    "stmatrix_x4",
+    "stmatrix_x1_trans",
+    "stmatrix_x2_trans",
+    "stmatrix_x4_trans",
     "ptx_ldmatrix_x1",
     "ptx_ldmatrix_x2",
     "ptx_ldmatrix_x4",
@@ -21,38 +33,34 @@ __all__ = [
     "ptx_stmatrix_x4_trans",
 ]
 
-from cutlass.cutlass_dsl import T, dsl_user_op
-from cutlass._mlir.dialects import nvvm, llvm
+from cutlass.cutlass_dsl import dsl_user_op
+from cutlass.experimental import primitives as prims
 from cutlass._mlir import ir  # noqa: F401
 from cutlass.cute.typing import Pointer, Int32  # noqa: F401
 import cutlass.cute as cute
 
 
-def _to_ir_value(v, loc=None, ip=None):
-    """Convert value to MLIR IR, handling both cutlass types and raw MLIR Values"""
-    if hasattr(v, "ir_value"):
-        return v.ir_value(loc=loc, ip=ip)
-    else:
-        # Already an MLIR Value
-        return v
-
-
 def _ldmatrix(smem_ptr, local_ptr, num, transpose, loc=None, ip=None):
     """Internal helper for ldmatrix operations"""
-    layout = nvvm.MMALayout.col if transpose else nvvm.MMALayout.row
-    assert num in [2, 4]
-    ret_type = llvm.StructType.get_literal([T.i32()] * num)
-    out_i32 = nvvm.ldmatrix(ret_type, smem_ptr.llvm_ptr, num=num, layout=layout, loc=loc, ip=ip)
+    layout = prims.MMALayout.COL if transpose else prims.MMALayout.ROW
+    assert num in [1, 2, 4]
+    ptr = smem_ptr.llvm_ptr if hasattr(smem_ptr, "llvm_ptr") else smem_ptr
+    out_i32 = prims.ldmatrix(ptr, num=num, layout=layout, loc=loc, ip=ip)
     out = cute.make_tensor(cute.recast_ptr(local_ptr, dtype=cute.Int32), num)
-    for i in range(num):
-        out[i] = cute.Int32(llvm.extractvalue(T.i32(), out_i32, [i], loc=loc, ip=ip))
+    if num == 1:
+        out[0] = cute.Int32(out_i32)
+    else:
+        for i in range(num):
+            out[i] = cute.Int32(out_i32[i])
 
 
 def _stmatrix(smem_ptr, values, transpose, loc=None, ip=None):
     """Internal helper for stmatrix operations"""
-    layout = nvvm.MMALayout.col if transpose else nvvm.MMALayout.row
-    ir_values = [_to_ir_value(v, loc, ip) for v in values]
-    nvvm.stmatrix(smem_ptr.llvm_ptr, ir_values, layout=layout, loc=loc, ip=ip)
+    layout = prims.MMALayout.COL if transpose else prims.MMALayout.ROW
+    ptr = smem_ptr.llvm_ptr if hasattr(smem_ptr, "llvm_ptr") else smem_ptr
+    num = len(values)
+    assert num in [1, 2, 4]
+    prims.stmatrix(ptr, values, layout, loc=loc, ip=ip)
 
 
 # ============================================================================
@@ -61,42 +69,37 @@ def _stmatrix(smem_ptr, values, transpose, loc=None, ip=None):
 
 
 @dsl_user_op
-def ptx_ldmatrix_x1(smem_ptr: Pointer, local_ptr: Pointer, *, loc=None, ip=None) -> None:
+def ldmatrix_x1(smem_ptr: Pointer, local_ptr: Pointer, *, loc=None, ip=None) -> None:
     """Load 1 matrix (8x8) from shared memory"""
-    # _ldmatrix(smem_ptr, local_ptr, 1, False, loc, ip)
-    out_i32 = nvvm.ldmatrix(T.i32(), smem_ptr.llvm_ptr, num=1, layout=nvvm.MMALayout.row, loc=loc, ip=ip)
-    out = cute.make_tensor(cute.recast_ptr(local_ptr, dtype=cute.Int32), 1)
-    out[0] = cute.Int32(out_i32)
+    _ldmatrix(smem_ptr, local_ptr, 1, False, loc, ip)
 
 
 @dsl_user_op
-def ptx_ldmatrix_x2(smem_ptr: Pointer, local_ptr: Pointer, *, loc=None, ip=None) -> None:
+def ldmatrix_x2(smem_ptr: Pointer, local_ptr: Pointer, *, loc=None, ip=None) -> None:
     """Load 2 matrices (8x8 each) from shared memory"""
     _ldmatrix(smem_ptr, local_ptr, 2, False, loc, ip)
 
 
 @dsl_user_op
-def ptx_ldmatrix_x4(smem_ptr: Pointer, local_ptr: Pointer, *, loc=None, ip=None) -> None:
+def ldmatrix_x4(smem_ptr: Pointer, local_ptr: Pointer, *, loc=None, ip=None) -> None:
     """Load 4 matrices (8x8 each) from shared memory"""
     _ldmatrix(smem_ptr, local_ptr, 4, False, loc, ip)
 
 
 @dsl_user_op
-def ptx_ldmatrix_x1_trans(smem_ptr: Pointer, local_ptr: Pointer, *, loc=None, ip=None) -> None:
+def ldmatrix_x1_trans(smem_ptr: Pointer, local_ptr: Pointer, *, loc=None, ip=None) -> None:
     """Load 1 matrix (8x8) with transpose from shared memory"""
-    out_i32 = nvvm.ldmatrix(T.i32(), smem_ptr.llvm_ptr, num=1, layout=nvvm.MMALayout.col, loc=loc, ip=ip)
-    out = cute.make_tensor(cute.recast_ptr(local_ptr, dtype=cute.Int32), 1)
-    out[0] = cute.Int32(out_i32)
+    _ldmatrix(smem_ptr, local_ptr, 1, True, loc, ip)
 
 
 @dsl_user_op
-def ptx_ldmatrix_x2_trans(smem_ptr: Pointer, local_ptr: Pointer, *, loc=None, ip=None) -> None:
+def ldmatrix_x2_trans(smem_ptr: Pointer, local_ptr: Pointer, *, loc=None, ip=None) -> None:
     """Load 2 matrices (8x8 each) with transpose from shared memory"""
     _ldmatrix(smem_ptr, local_ptr, 2, True, loc, ip)
 
 
 @dsl_user_op
-def ptx_ldmatrix_x4_trans(smem_ptr: Pointer, local_ptr: Pointer, *, loc=None, ip=None) -> None:
+def ldmatrix_x4_trans(smem_ptr: Pointer, local_ptr: Pointer, *, loc=None, ip=None) -> None:
     """Load 4 matrices (8x8 each) with transpose from shared memory"""
     _ldmatrix(smem_ptr, local_ptr, 4, True, loc, ip)
 
@@ -107,36 +110,50 @@ def ptx_ldmatrix_x4_trans(smem_ptr: Pointer, local_ptr: Pointer, *, loc=None, ip
 
 
 @dsl_user_op
-def ptx_stmatrix_x1(smem_ptr: Pointer, value0, *, loc=None, ip=None) -> None:
+def stmatrix_x1(smem_ptr: Pointer, value0, *, loc=None, ip=None) -> None:
     """Store 1 matrix (8x8) to shared memory"""
     _stmatrix(smem_ptr, [value0], False, loc, ip)
 
 
 @dsl_user_op
-def ptx_stmatrix_x2(smem_ptr: Pointer, value0, value1, *, loc=None, ip=None) -> None:
+def stmatrix_x2(smem_ptr: Pointer, value0, value1, *, loc=None, ip=None) -> None:
     """Store 2 matrices (8x8 each) to shared memory"""
     _stmatrix(smem_ptr, [value0, value1], False, loc, ip)
 
 
 @dsl_user_op
-def ptx_stmatrix_x4(smem_ptr: Pointer, value0, value1, value2, value3, *, loc=None, ip=None) -> None:
+def stmatrix_x4(smem_ptr: Pointer, value0, value1, value2, value3, *, loc=None, ip=None) -> None:
     """Store 4 matrices (8x8 each) to shared memory"""
     _stmatrix(smem_ptr, [value0, value1, value2, value3], False, loc, ip)
 
 
 @dsl_user_op
-def ptx_stmatrix_x1_trans(smem_ptr: Pointer, value0, *, loc=None, ip=None) -> None:
+def stmatrix_x1_trans(smem_ptr: Pointer, value0, *, loc=None, ip=None) -> None:
     """Store 1 matrix (8x8) with transpose to shared memory"""
     _stmatrix(smem_ptr, [value0], True, loc, ip)
 
 
 @dsl_user_op
-def ptx_stmatrix_x2_trans(smem_ptr: Pointer, value0, value1, *, loc=None, ip=None) -> None:
+def stmatrix_x2_trans(smem_ptr: Pointer, value0, value1, *, loc=None, ip=None) -> None:
     """Store 2 matrices (8x8 each) with transpose to shared memory"""
     _stmatrix(smem_ptr, [value0, value1], True, loc, ip)
 
 
 @dsl_user_op
-def ptx_stmatrix_x4_trans(smem_ptr: Pointer, value0, value1, value2, value3, *, loc=None, ip=None) -> None:
+def stmatrix_x4_trans(smem_ptr: Pointer, value0, value1, value2, value3, *, loc=None, ip=None) -> None:
     """Store 4 matrices (8x8 each) with transpose to shared memory"""
     _stmatrix(smem_ptr, [value0, value1, value2, value3], True, loc, ip)
+
+
+ptx_ldmatrix_x1 = ldmatrix_x1
+ptx_ldmatrix_x2 = ldmatrix_x2
+ptx_ldmatrix_x4 = ldmatrix_x4
+ptx_ldmatrix_x1_trans = ldmatrix_x1_trans
+ptx_ldmatrix_x2_trans = ldmatrix_x2_trans
+ptx_ldmatrix_x4_trans = ldmatrix_x4_trans
+ptx_stmatrix_x1 = stmatrix_x1
+ptx_stmatrix_x2 = stmatrix_x2
+ptx_stmatrix_x4 = stmatrix_x4
+ptx_stmatrix_x1_trans = stmatrix_x1_trans
+ptx_stmatrix_x2_trans = stmatrix_x2_trans
+ptx_stmatrix_x4_trans = stmatrix_x4_trans

--- a/tilelang/contrib/cutedsl/math.py
+++ b/tilelang/contrib/cutedsl/math.py
@@ -25,15 +25,14 @@ __all__ = [
 
 import cutlass
 import cutlass.cute as cute
+import cutlass.cute.math as cute_math
 
 from cutlass.cute.typing import Union, Numeric
 from cutlass.cute.tensor import TensorSSA
-from cutlass._mlir.dialects import arith, math
-from cutlass.cute.math import _math_op as _cute_math_op
 
-from cutlass._mlir.dialects import llvm
+from cutlass.experimental import primitives as prims
 from cutlass.base_dsl.typing import BFloat16, Float16, Float32, Uint16, Uint32
-from cutlass.cutlass_dsl import T, dsl_user_op
+from cutlass.cutlass_dsl import dsl_user_op
 
 
 def _scalar_arg_type(arg):
@@ -64,73 +63,51 @@ def _scalar_result_type(*args):
 
 
 def _tl_math_op(func, fastmath: bool, *args, **kwargs):
-    if any(isinstance(arg, TensorSSA) for arg in args):
-        return _cute_math_op(func, fastmath, *args, **kwargs)
-
-    result_type = _scalar_result_type(*args)
-    if not result_type.is_float:
-        raise TypeError(f"Expected scalar float inputs, but got {result_type}")
-
-    ir_args = []
-    for arg in args:
-        if isinstance(arg, Numeric):
-            if not type(arg).is_float:
-                raise TypeError(f"Expected scalar float inputs, but got {type(arg)}")
-            if type(arg) is result_type:
-                ir_args.append(arg.ir_value())
-            else:
-                ir_args.append(result_type(arg).ir_value())
-        elif hasattr(arg, "ir_value"):
-            ir_args.append(result_type(arg.ir_value()).ir_value())
-        else:
-            ir_args.append(result_type(arg).ir_value())
-
-    fastmath_flag = arith.FastMathFlags.fast if fastmath else arith.FastMathFlags.none
-    return result_type(func(*ir_args, fastmath=fastmath_flag, **kwargs))
+    return func(*args, fastmath=fastmath, **kwargs)
 
 
 def exp(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
-    return _tl_math_op(math.exp, fastmath, x, **kwargs)
+    return _tl_math_op(cute_math.exp, fastmath, x, **kwargs)
 
 
 def exp2(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
-    return _tl_math_op(math.exp2, fastmath, x, **kwargs)
+    return _tl_math_op(cute_math.exp2, fastmath, x, **kwargs)
 
 
 def log(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
-    return _tl_math_op(math.log, fastmath, x, **kwargs)
+    return _tl_math_op(cute_math.log, fastmath, x, **kwargs)
 
 
 def log1p(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
-    return _tl_math_op(math.log1p, fastmath, x, **kwargs)
+    return _tl_math_op(cute_math.log1p, fastmath, x, **kwargs)
 
 
 def log2(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
-    return _tl_math_op(math.log2, fastmath, x, **kwargs)
+    return _tl_math_op(cute_math.log2, fastmath, x, **kwargs)
 
 
 def log10(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
-    return _tl_math_op(math.log10, fastmath, x, **kwargs)
+    return _tl_math_op(cute_math.log10, fastmath, x, **kwargs)
 
 
 def tan(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
-    return _tl_math_op(math.tan, fastmath, x, **kwargs)
+    return _tl_math_op(cute_math.tan, fastmath, x, **kwargs)
 
 
 def cos(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
-    return _tl_math_op(math.cos, fastmath, x, **kwargs)
+    return _tl_math_op(cute_math.cos, fastmath, x, **kwargs)
 
 
 def sin(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
-    return _tl_math_op(math.sin, fastmath, x, **kwargs)
+    return _tl_math_op(cute_math.sin, fastmath, x, **kwargs)
 
 
 def sqrt(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
-    return _tl_math_op(math.sqrt, fastmath, x, **kwargs)
+    return _tl_math_op(cute_math.sqrt, fastmath, x, **kwargs)
 
 
 def rsqrt(x: Union[TensorSSA, Numeric], fastmath: bool = False, **kwargs) -> Union[TensorSSA, Numeric]:
-    return _tl_math_op(math.rsqrt, fastmath, x, **kwargs)
+    return _tl_math_op(cute_math.rsqrt, fastmath, x, **kwargs)
 
 
 def exp10(x: Union[TensorSSA, Numeric], fastmath: bool = False) -> Union[TensorSSA, Numeric]:
@@ -140,7 +117,7 @@ def exp10(x: Union[TensorSSA, Numeric], fastmath: bool = False) -> Union[TensorS
 
 
 def fabsf(x: Union[TensorSSA, Numeric], fastmath: bool = False) -> Union[TensorSSA, Numeric]:
-    return _tl_math_op(math.absf, fastmath, x)
+    return _tl_math_op(cute_math.absf, fastmath, x)
 
 
 def abs2(x: Union[TensorSSA, Numeric]) -> Union[TensorSSA, Numeric]:
@@ -161,7 +138,7 @@ def min2(x: Union[TensorSSA, Numeric], y: Union[TensorSSA, Numeric]) -> Union[Te
 
 def copysignf(x: Union[TensorSSA, Numeric], y: Union[TensorSSA, Numeric], fastmath: bool = False) -> Union[TensorSSA, Numeric]:
     if any(isinstance(arg, TensorSSA) for arg in (x, y)):
-        return _cute_math_op(math.copysign, fastmath, x, y)
+        return cute_math.copysign(x, y, fastmath=fastmath)
 
     result_type = _scalar_result_type(x, y)
     if result_type is not Float32:
@@ -175,13 +152,7 @@ def copysignf(x: Union[TensorSSA, Numeric], y: Union[TensorSSA, Numeric], fastma
 
 
 def isfinite(x: Numeric) -> cutlass.Boolean:
-    result_type = _scalar_result_type(x)
-    if not result_type.is_float:
-        raise TypeError(f"isfinite expects a scalar float input, but got {result_type}")
-
-    x_bits = Float32(x).bitcast(Uint32)
-    exponent = x_bits & Uint32(0x7F800000)
-    return exponent != Uint32(0x7F800000)
+    return cute_math.isfinite(x)
 
 
 def divf(
@@ -189,7 +160,7 @@ def divf(
     y: Union[TensorSSA, Numeric],
     fastmath: bool = False,
 ) -> Union[TensorSSA, Numeric]:
-    return _tl_math_op(arith.divf, fastmath, x, y)
+    return _tl_math_op(cute_math.div, fastmath, x, y)
 
 
 def __habs(x: Numeric) -> Numeric:
@@ -203,31 +174,24 @@ def __habs(x: Numeric) -> Numeric:
 
 @dsl_user_op
 def __float2half_rz(x: Union[float, Float32], *, loc=None, ip=None) -> Float16:
-    result_i16 = llvm.inline_asm(
-        T.i16(),
-        [Float32(x).ir_value(loc=loc, ip=ip)],
-        "cvt.rz.f16.f32 $0, $1;",
-        "=h,f",
-        has_side_effects=False,
-        is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
-        loc=loc,
-        ip=ip,
+    return Float16(
+        prims.inline_ptx(
+            "cvt.rz.f16.f32 {$w0}, {$r0};",
+            write_only_types=[Float16],
+            read_only_args=[Float32(x)],
+            loc=loc,
+            ip=ip,
+        )
     )
-    return Float16(llvm.bitcast(T.f16(), result_i16, loc=loc, ip=ip))
 
 
 @dsl_user_op
 def __tanhf(x: Union[float, Float32], *, fastmath, loc=None, ip=None) -> Float32:
     return Float32(
-        llvm.inline_asm(
-            T.f32(),
-            [Float32(x).ir_value()],
-            "tanh.approx.f32 $0, $1;",
-            "=f,f",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
+        prims.inline_ptx(
+            "tanh.approx.f32 {$w0}, {$r0};",
+            write_only_types=[Float32],
+            read_only_args=[Float32(x)],
             loc=loc,
             ip=ip,
         )
@@ -235,5 +199,4 @@ def __tanhf(x: Union[float, Float32], *, fastmath, loc=None, ip=None) -> Float32
 
 
 def tanh(x: Union[TensorSSA, Numeric], fastmath: bool = False) -> Union[TensorSSA, Numeric]:
-    tanh_op = __tanhf if fastmath else math.tanh
-    return _tl_math_op(tanh_op, False, x)
+    return cute_math.tanh(x, fastmath=fastmath)

--- a/tilelang/contrib/cutedsl/quantize.py
+++ b/tilelang/contrib/cutedsl/quantize.py
@@ -2,9 +2,8 @@
 # Licensed under the MIT License.
 """
 Quantization/dequantization functions for CuTeDSL backend.
-These implement the same functionality as the CUDA templates in
-examples/dequantize_gemm/quantize/lop3.py.
-using inline PTX via llvm.inline_asm.
+These implement the same functionality as the CUDA templates in tilelang/quantize/lop3.py
+using CUTLASS primitives where available, with local inline asm kept for FP4 twiddling.
 """
 
 __all__ = [
@@ -20,8 +19,9 @@ __all__ = [
 
 import cutlass
 import cutlass.cute as cute
+from cutlass.experimental import primitives as prims
 from cutlass._mlir.dialects import llvm, arith
-from cutlass.base_dsl.typing import Uint32
+from cutlass.base_dsl.typing import Int32, Uint32
 from cutlass.cutlass_dsl import T, dsl_user_op
 
 
@@ -31,6 +31,38 @@ FP16_TOP_MAGIC_NUM = 0x64006400
 IMMLUT = (0xF0 & 0xCC) | 0xAA  # = 0xea = 234
 MEDIAN_NUM_UNSIGNED = 0x64006400
 MEDIAN_NUM_SIGNED = 0x64086408
+
+
+@dsl_user_op
+def _lop3(a: Uint32, b: int, c: int, lut: int, *, loc=None, ip=None) -> Uint32:
+    if not isinstance(lut, int):
+        raise TypeError("lop3 lut must be an integer constant")
+    return Uint32(
+        prims.inline_ptx(
+            f"lop3.b32 {{$w0}}, {{$r0}}, {{$r1}}, {{$r2}}, {lut & 0xFF};",
+            write_only_types=[Uint32],
+            read_only_args=[Uint32(a), Uint32(b), Uint32(c)],
+            loc=loc,
+            ip=ip,
+        )
+    )
+
+
+@dsl_user_op
+def _sub_f16x2_i32(a: Int32, b: Int32, *, loc=None, ip=None) -> Int32:
+    return Int32(
+        llvm.inline_asm(
+            T.i32(),
+            [Int32(a).ir_value(loc=loc, ip=ip), Int32(b).ir_value(loc=loc, ip=ip)],
+            "sub.f16x2 $0, $1, $2;",
+            "=r,r,r",
+            has_side_effects=False,
+            is_align_stack=False,
+            asm_dialect=llvm.AsmDialect.AD_ATT,
+            loc=loc,
+            ip=ip,
+        )
+    )
 
 
 @dsl_user_op
@@ -49,26 +81,8 @@ def _lop3_sub_f16x2_unsigned(i4s: Uint32, shift: int, *, loc=None, ip=None) -> U
     # Shift right
     shifted = Uint32(arith.shrui(Uint32(i4s).ir_value(), Uint32(shift).ir_value()))
 
-    # LOP3 + sub in single asm block
-    # immLut=234 (0xea), BOTTOM_MASK=0x000f000f, FP16_TOP_MAGIC_NUM=0x64006400
-    # MEDIAN_NUM_UNSIGNED=0x64006400
-    result = Uint32(
-        llvm.inline_asm(
-            T.i32(),
-            [shifted.ir_value()],
-            "{ .reg .b32 tmp, median; "
-            "lop3.b32 tmp, $1, 0x000f000f, 0x64006400, 0xea; "
-            "mov.b32 median, 0x64006400; "
-            "sub.f16x2 $0, tmp, median; }",
-            "=r,r",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-    )
-    return result
+    tmp = _lop3(shifted, BOTTOM_MASK, FP16_TOP_MAGIC_NUM, IMMLUT, loc=loc, ip=ip)
+    return Uint32(_sub_f16x2_i32(Int32(tmp), Int32(MEDIAN_NUM_UNSIGNED), loc=loc, ip=ip))
 
 
 @dsl_user_op
@@ -76,24 +90,8 @@ def _lop3_sub_f16x2_signed(i4s: Uint32, shift: int, *, loc=None, ip=None) -> Uin
     """LOP3 + sub.f16x2 for signed i4 to f16x2 decode."""
     shifted = Uint32(arith.shrui(Uint32(i4s).ir_value(), Uint32(shift).ir_value()))
 
-    # MEDIAN_NUM_SIGNED=0x64086408
-    result = Uint32(
-        llvm.inline_asm(
-            T.i32(),
-            [shifted.ir_value()],
-            "{ .reg .b32 tmp, median; "
-            "lop3.b32 tmp, $1, 0x000f000f, 0x64006400, 0xea; "
-            "mov.b32 median, 0x64086408; "
-            "sub.f16x2 $0, tmp, median; }",
-            "=r,r",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-    )
-    return result
+    tmp = _lop3(shifted, BOTTOM_MASK, FP16_TOP_MAGIC_NUM, IMMLUT, loc=loc, ip=ip)
+    return Uint32(_sub_f16x2_i32(Int32(tmp), Int32(MEDIAN_NUM_SIGNED), loc=loc, ip=ip))
 
 
 def decode_i4u_to_f16(src_ptr, dst_ptr, N: int = 8):
@@ -243,14 +241,11 @@ def _pack_bf16_high(r0: Uint32, r1: Uint32, *, loc=None, ip=None) -> Uint32:
     """Pack high 16-bits of r0 and r1 into one uint32."""
     # r0[31:16] -> result[15:0], r1[31:16] -> result[31:16]
     return Uint32(
-        llvm.inline_asm(
-            T.i32(),
-            [Uint32(r0).ir_value(), Uint32(r1).ir_value()],
-            "prmt.b32 $0, $1, $2, 0x7632;",
-            "=r,r,r",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
+        prims.prmt(
+            Uint32(r0),
+            0x7632,
+            prims.PermuteMode.DEFAULT,
+            hi=Uint32(r1),
             loc=loc,
             ip=ip,
         )
@@ -262,14 +257,11 @@ def _pack_bf16_low(r0: Uint32, r1: Uint32, *, loc=None, ip=None) -> Uint32:
     """Pack low 16-bits of r0 and r1 into one uint32."""
     # r0[15:0] -> result[15:0], r1[15:0] -> result[31:16]
     return Uint32(
-        llvm.inline_asm(
-            T.i32(),
-            [Uint32(r0).ir_value(), Uint32(r1).ir_value()],
-            "prmt.b32 $0, $1, $2, 0x5410;",
-            "=r,r,r",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
+        prims.prmt(
+            Uint32(r0),
+            0x5410,
+            prims.PermuteMode.DEFAULT,
+            hi=Uint32(r1),
             loc=loc,
             ip=ip,
         )

--- a/tilelang/contrib/cutedsl/reduce.py
+++ b/tilelang/contrib/cutedsl/reduce.py
@@ -26,9 +26,7 @@ __all__ = [
 
 import cutlass
 import cutlass.cute as cute
-from cutlass.cute.typing import Int32
-from cutlass._mlir.dialects import nvvm
-from cutlass.cute.arch.nvvm_wrappers import shuffle_sync_op
+from cutlass.experimental import primitives as prims
 
 
 def min(a, b, c=None):
@@ -97,25 +95,15 @@ class BitXorOp:
 
 
 def bar_sync(barrier_id, number_of_threads):
-    cute.arch.barrier(barrier_id=barrier_id, number_of_threads=number_of_threads)
+    prims.barrier_cta_sync(barrier_id, thread_count=number_of_threads)
 
 
 def bar_sync_ptx(barrier_id, number_of_threads):
-    from cutlass._mlir.dialects import llvm
-
-    llvm.inline_asm(
-        None,
-        [Int32(barrier_id).ir_value(), Int32(number_of_threads).ir_value()],
-        "bar.sync $0, $1;",
-        "r,r",
-        has_side_effects=True,
-        is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
-    )
+    prims.barrier_cta_sync(barrier_id, thread_count=number_of_threads)
 
 
 # Import shuffle functions from warp module
-from .warp import __shfl_sync, __shfl_up_sync, __shfl_down_sync
+from .warp import __shfl_sync, __shfl_up_sync, __shfl_down_sync, _shfl_xor_sync
 
 
 def _warp_prefix_sum_forward(val, lane, MASK=0xFFFFFFFF):
@@ -509,10 +497,10 @@ def AllReduce(reducer, threads, scale, thread_offset, all_threads=None, batch_si
                 if self.batch_size > 1:
                     x_tensor = cute.make_tensor(x, (self.batch_size,))
                     for i in range(self.batch_size):
-                        other = shuffle_sync_op(x_tensor[i], offset, mask=0xFFFFFFFF, mask_and_clamp=0x1F, kind=nvvm.ShflKind.bfly)
+                        other = _shfl_xor_sync(x_tensor[i], offset)
                         x_tensor[i] = self.reducer()(x_tensor[i], other)
                 else:
-                    other = shuffle_sync_op(x, offset, mask=0xFFFFFFFF, mask_and_clamp=0x1F, kind=nvvm.ShflKind.bfly)
+                    other = _shfl_xor_sync(x, offset)
                     x = self.reducer()(x, other)
 
             if offset == self.scale:
@@ -550,10 +538,10 @@ def AllReduce(reducer, threads, scale, thread_offset, all_threads=None, batch_si
                 if self.batch_size > 1:
                     x_tensor = cute.make_tensor(x, (self.batch_size,))
                     for i in range(self.batch_size):
-                        other = shuffle_sync_op(x_tensor[i], offset, mask=0xFFFFFFFF, mask_and_clamp=0x1F, kind=nvvm.ShflKind.bfly)
+                        other = _shfl_xor_sync(x_tensor[i], offset)
                         x_tensor[i] = self.reducer()(x_tensor[i], other)
                 else:
-                    other = shuffle_sync_op(x, offset, mask=0xFFFFFFFF, mask_and_clamp=0x1F, kind=nvvm.ShflKind.bfly)
+                    other = _shfl_xor_sync(x, offset)
                     x = self.reducer()(x, other)
 
             if offset == self.scale:

--- a/tilelang/contrib/cutedsl/threadblock_swizzle.py
+++ b/tilelang/contrib/cutedsl/threadblock_swizzle.py
@@ -97,9 +97,7 @@ def rasterization2DRowWithCluster(panel_width: Constexpr[int], cluster_dim_x: Co
     panel_idx = cluster_idx // panel_size
     total_panel = cute.ceil_div(cluster_grid_size, panel_size)
     stride = panel_width if panel_idx + 1 < total_panel else (cluster_grid_size - panel_idx * panel_size) // num_cluster_x
-    swizzled_cluster_x = (
-        (num_cluster_x - 1 - panel_offset // stride) if (panel_idx & 1 != 0) else (panel_offset // stride)
-    )
+    swizzled_cluster_x = (num_cluster_x - 1 - panel_offset // stride) if (panel_idx & 1 != 0) else (panel_offset // stride)
     swizzled_cluster_y = panel_offset % stride + panel_idx * panel_width
     col_idx = swizzled_cluster_x * cluster_dim_x + intra_cluster_x
     return dim3(col_idx, swizzled_cluster_y, blockIdx.z)

--- a/tilelang/contrib/cutedsl/threadblock_swizzle.py
+++ b/tilelang/contrib/cutedsl/threadblock_swizzle.py
@@ -5,6 +5,8 @@ __all__ = [
     "GridDim",
     "rasterization2DRow",
     "rasterization2DColumn",
+    "rasterization2DRowWithCluster",
+    "rasterization2DColumnWithCluster",
 ]
 
 import cutlass.cute as cute
@@ -77,3 +79,49 @@ def rasterization2DColumn(panel_width: Constexpr[int]) -> dim3:
     row_idx = (gridDim.y - 1 - panel_offset // stride) if (panel_idx & 1 != 0) else (panel_offset // stride)
     col_idx = panel_offset % stride + panel_idx * panel_width
     return dim3(col_idx, row_idx, blockIdx.z)
+
+
+@cute.jit
+def rasterization2DRowWithCluster(panel_width: Constexpr[int], cluster_dim_x: Constexpr[int]) -> dim3:
+    """Row-major swizzle at cluster granularity while preserving intra-cluster x rank."""
+
+    blockIdx = BlockIdx()
+    gridDim = GridDim()
+    num_cluster_x = gridDim.x // cluster_dim_x
+    intra_cluster_x = blockIdx.x % cluster_dim_x
+    cluster_x = blockIdx.x // cluster_dim_x
+    cluster_idx = cluster_x + blockIdx.y * num_cluster_x
+    cluster_grid_size = num_cluster_x * gridDim.y
+    panel_size = panel_width * num_cluster_x
+    panel_offset = cluster_idx % panel_size
+    panel_idx = cluster_idx // panel_size
+    total_panel = cute.ceil_div(cluster_grid_size, panel_size)
+    stride = panel_width if panel_idx + 1 < total_panel else (cluster_grid_size - panel_idx * panel_size) // num_cluster_x
+    swizzled_cluster_x = (
+        (num_cluster_x - 1 - panel_offset // stride) if (panel_idx & 1 != 0) else (panel_offset // stride)
+    )
+    swizzled_cluster_y = panel_offset % stride + panel_idx * panel_width
+    col_idx = swizzled_cluster_x * cluster_dim_x + intra_cluster_x
+    return dim3(col_idx, swizzled_cluster_y, blockIdx.z)
+
+
+@cute.jit
+def rasterization2DColumnWithCluster(panel_width: Constexpr[int], cluster_dim_x: Constexpr[int]) -> dim3:
+    """Column-major swizzle at cluster granularity while preserving intra-cluster x rank."""
+
+    blockIdx = BlockIdx()
+    gridDim = GridDim()
+    num_cluster_x = gridDim.x // cluster_dim_x
+    intra_cluster_x = blockIdx.x % cluster_dim_x
+    cluster_x = blockIdx.x // cluster_dim_x
+    cluster_idx = cluster_x + blockIdx.y * num_cluster_x
+    cluster_grid_size = num_cluster_x * gridDim.y
+    panel_size = panel_width * gridDim.y
+    panel_offset = cluster_idx % panel_size
+    panel_idx = cluster_idx // panel_size
+    total_panel = cute.ceil_div(cluster_grid_size, panel_size)
+    stride = panel_width if panel_idx + 1 < total_panel else (cluster_grid_size - panel_idx * panel_size) // gridDim.y
+    swizzled_cluster_y = (gridDim.y - 1 - panel_offset // stride) if (panel_idx & 1 != 0) else (panel_offset // stride)
+    swizzled_cluster_x = panel_offset % stride + panel_idx * panel_width
+    col_idx = swizzled_cluster_x * cluster_dim_x + intra_cluster_x
+    return dim3(col_idx, swizzled_cluster_y, blockIdx.z)

--- a/tilelang/contrib/cutedsl/utils.py
+++ b/tilelang/contrib/cutedsl/utils.py
@@ -29,7 +29,7 @@ from cutlass.base_dsl.typing import (
 from cutlass.cutlass_dsl import T
 import cutlass._mlir.dialects.cute as _cute_ir
 from cutlass.cute.tensor import TensorSSA
-from cutlass._mlir.dialects import arith, builtin, llvm, nvgpu, nvvm, vector
+from cutlass._mlir.dialects import arith, builtin, llvm, nvgpu, vector
 from cutlass._mlir.extras import types as mlir_types
 from cutlass._mlir import ir as mlir_ir
 from cutlass.cutlass_dsl import dsl_user_op
@@ -60,6 +60,7 @@ BYTES_PER_POINTER = 8
 
 class Float4E2M1FN_unpack(Float, metaclass=FloatMeta, width=8, mlir_type=T.f4E2M1FN):
     pass
+
 
 # Map dtype to WGMMA types (moved from typing.py)
 type_map = {
@@ -110,10 +111,7 @@ def _recast_fp4_unpack_smem_ptr(ptr, swizzle_=None, *, loc=None, ip=None):
 
 
 def recast_ptr(ptr, swizzle_=None, dtype=None):
-    if (
-        dtype is Float4E2M1FN_unpack
-        and getattr(ptr, "memspace", None) == AddressSpace.smem
-    ):
+    if dtype is Float4E2M1FN_unpack and getattr(ptr, "memspace", None) == AddressSpace.smem:
         return _recast_fp4_unpack_smem_ptr(ptr, swizzle_)
     return cute.recast_ptr(ptr, swizzle_, dtype=dtype)
 
@@ -129,15 +127,11 @@ def _recast_type(src_type: mlir_ir.Type, res_elem_type: mlir_ir.Type) -> mlir_ir
             )
         return mlir_types.vector(*src_type.shape, res_elem_type)
     if isinstance(src_type, mlir_types.RankedTensorType):
-        return mlir_types.RankedTensorType.get(
-            element_type=res_elem_type, shape=src_type.shape, strides=src_type.strides
-        )
+        return mlir_types.RankedTensorType.get(element_type=res_elem_type, shape=src_type.shape, strides=src_type.strides)
     if isinstance(src_type, mlir_types.UnrankedTensorType):
         return mlir_types.UnrankedTensorType.get(element_type=res_elem_type)
     if isinstance(src_type, mlir_types.MemRefType):
-        return mlir_types.MemRefType.get(
-            element_type=res_elem_type, shape=src_type.shape, strides=src_type.strides
-        )
+        return mlir_types.MemRefType.get(element_type=res_elem_type, shape=src_type.shape, strides=src_type.strides)
     return res_elem_type
 
 

--- a/tilelang/contrib/cutedsl/utils.py
+++ b/tilelang/contrib/cutedsl/utils.py
@@ -7,11 +7,13 @@ bitcast, tensor construction, warp election, barrier sync, and FP16 packing.
 
 import cutlass
 import cutlass.cute as cute
+from cutlass import AddressSpace
+from cutlass.experimental import primitives as prims
 
-from cutlass.base_dsl._mlir_helpers import arith as arith_helper
 from cutlass.base_dsl.typing import (
     BFloat16,
     Float,
+    FloatMeta,
     Float16,
     Float32,
     Float4E2M1FN,
@@ -24,16 +26,21 @@ from cutlass.base_dsl.typing import (
     Uint16,
     Uint32,
 )
+from cutlass.cutlass_dsl import T
+import cutlass._mlir.dialects.cute as _cute_ir
 from cutlass.cute.tensor import TensorSSA
 from cutlass._mlir.dialects import arith, builtin, llvm, nvgpu, nvvm, vector
+from cutlass._mlir.extras import types as mlir_types
 from cutlass._mlir import ir as mlir_ir
 from cutlass.cutlass_dsl import dsl_user_op
 
 __all__ = [
     "BYTES_PER_TENSORMAP",
     "BYTES_PER_POINTER",
+    "Float4E2M1FN_unpack",
     "type_map",
     "bitcast",
+    "recast_ptr",
     "cast_tensor",
     "as_tensor_ssa",
     "as_rmem_tensor",
@@ -42,29 +49,35 @@ __all__ = [
     "handle_add_byte_offset",
     "shuffle_elect",
     "sync_thread_partial",
+    "warpgroup_reg_alloc",
+    "warpgroup_reg_dealloc",
     "pack_half2",
 ]
 
 BYTES_PER_TENSORMAP = 128
 BYTES_PER_POINTER = 8
 
+
+class Float4E2M1FN_unpack(Float, metaclass=FloatMeta, width=8, mlir_type=T.f4E2M1FN):
+    pass
+
 # Map dtype to WGMMA types (moved from typing.py)
 type_map = {
-    "int8": nvvm.WGMMATypes.s8,
-    "int32": nvvm.WGMMATypes.s32,
-    "uint8": nvvm.WGMMATypes.u8,
-    "float16": nvvm.WGMMATypes.f16,
-    "fp16": nvvm.WGMMATypes.f16,
-    "bfloat16": nvvm.WGMMATypes.bf16,
-    "bf16": nvvm.WGMMATypes.bf16,
-    "float32": nvvm.WGMMATypes.f32,
-    "fp32": nvvm.WGMMATypes.f32,
-    "tf32": nvvm.WGMMATypes.tf32,
-    "float8_e4m3": nvvm.WGMMATypes.e4m3,
-    "float8_e5m2": nvvm.WGMMATypes.e5m2,
-    "float8_e4m3fn": nvvm.WGMMATypes.e4m3,
-    "e4m3": nvvm.WGMMATypes.e4m3,
-    "e5m2": nvvm.WGMMATypes.e5m2,
+    "int8": prims.WGMMAType.S8,
+    "int32": prims.WGMMAType.S32,
+    "uint8": prims.WGMMAType.U8,
+    "float16": prims.WGMMAType.F16,
+    "fp16": prims.WGMMAType.F16,
+    "bfloat16": prims.WGMMAType.BF16,
+    "bf16": prims.WGMMAType.BF16,
+    "float32": prims.WGMMAType.F32,
+    "fp32": prims.WGMMAType.F32,
+    "tf32": prims.WGMMAType.TF32,
+    "float8_e4m3": prims.WGMMAType.E4M3,
+    "float8_e5m2": prims.WGMMAType.E5M2,
+    "float8_e4m3fn": prims.WGMMAType.E4M3,
+    "e4m3": prims.WGMMAType.E4M3,
+    "e5m2": prims.WGMMAType.E5M2,
 }
 
 # Map dtype to CuTeDSL type (internal)
@@ -79,6 +92,53 @@ _DTYPE_TO_CUTEDSL_TYPE = {
     "float32": Float32,
     "bfloat16": BFloat16,
 }
+
+
+@dsl_user_op
+def _recast_fp4_unpack_smem_ptr(ptr, swizzle_=None, *, loc=None, ip=None):
+    bit_layout = cute.make_layout((4, (16, 1)), stride=(1, (4, 128)))
+    swizzle_attr = swizzle_.type.attribute if swizzle_ is not None else None
+    res_ty = _cute_ir.PtrType.get(
+        Float4E2M1FN_unpack.mlir_type,
+        AddressSpace.smem,
+        ptr.alignment,
+        swizzle_attr,
+        None,
+        bit_layout.type.attribute,
+    )
+    return _cute_ir.recast_iter(res_ty, ptr.value, loc=loc, ip=ip)
+
+
+def recast_ptr(ptr, swizzle_=None, dtype=None):
+    if (
+        dtype is Float4E2M1FN_unpack
+        and getattr(ptr, "memspace", None) == AddressSpace.smem
+    ):
+        return _recast_fp4_unpack_smem_ptr(ptr, swizzle_)
+    return cute.recast_ptr(ptr, swizzle_, dtype=dtype)
+
+
+def _recast_type(src_type: mlir_ir.Type, res_elem_type: mlir_ir.Type) -> mlir_ir.Type:
+    if isinstance(src_type, mlir_types.VectorType):
+        if src_type.scalable:
+            return mlir_types.vector(
+                *src_type.shape,
+                res_elem_type,
+                scalable=src_type.scalable,
+                scalable_dims=src_type.scalable_dims,
+            )
+        return mlir_types.vector(*src_type.shape, res_elem_type)
+    if isinstance(src_type, mlir_types.RankedTensorType):
+        return mlir_types.RankedTensorType.get(
+            element_type=res_elem_type, shape=src_type.shape, strides=src_type.strides
+        )
+    if isinstance(src_type, mlir_types.UnrankedTensorType):
+        return mlir_types.UnrankedTensorType.get(element_type=res_elem_type)
+    if isinstance(src_type, mlir_types.MemRefType):
+        return mlir_types.MemRefType.get(
+            element_type=res_elem_type, shape=src_type.shape, strides=src_type.strides
+        )
+    return res_elem_type
 
 
 def bitcast(value, target_dtype):
@@ -116,7 +176,7 @@ def bitcast(value, target_dtype):
 @dsl_user_op
 def _narrow_to_float16_tensor(value, *, loc=None, ip=None):
     src = value.ir_value(loc=loc, ip=ip)
-    res_type = arith_helper.recast_type(src.type, Float16.mlir_type)
+    res_type = _recast_type(src.type, Float16.mlir_type)
     res = nvgpu.cvt_fpext(res_type, src, loc=loc, ip=ip)
     return TensorSSA(res, value.shape, Float16)
 
@@ -317,7 +377,17 @@ def shuffle_elect(thread_extent):
 def sync_thread_partial(barrier_id=None, thread_count=None):
     from .reduce import bar_sync_ptx
 
+    barrier_id = 0 if barrier_id is None else barrier_id
+    thread_count = 0 if thread_count is None else thread_count
     bar_sync_ptx(barrier_id, thread_count)
+
+
+def warpgroup_reg_alloc(reg_count):
+    prims.setmaxregister(reg_count, "increase")
+
+
+def warpgroup_reg_dealloc(reg_count):
+    prims.setmaxregister(reg_count, "decrease")
 
 
 def pack_half2(x, y):
@@ -340,17 +410,11 @@ def pack_half2(x, y):
         x_i16 = llvm.bitcast(i16_type, x_ir, loc=loc, ip=ip)
         y_i16 = llvm.bitcast(i16_type, y_ir, loc=loc, ip=ip)
 
-        packed_xy = llvm.inline_asm(
-            Int32.mlir_type,
-            [x_i16, y_i16],
-            "mov.b32 $0, {$1, $2};",
-            "=r,h,h",
-            has_side_effects=True,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
+        x_i32 = arith.extui(Int32.mlir_type, x_i16, loc=loc, ip=ip)
+        y_i32 = arith.extui(Int32.mlir_type, y_i16, loc=loc, ip=ip)
+        shift = arith.constant(Int32.mlir_type, 16, loc=loc, ip=ip)
+        y_shifted = arith.shli(y_i32, shift, loc=loc, ip=ip)
+        packed_xy = arith.ori(x_i32, y_shifted, loc=loc, ip=ip)
 
         return Int32(packed_xy)
 

--- a/tilelang/contrib/cutedsl/warp.py
+++ b/tilelang/contrib/cutedsl/warp.py
@@ -43,17 +43,9 @@ def _shfl_sync_typed(mask, val, offset, mask_and_clamp, kind, *, loc=None, ip=No
     val_type = type(val)
     if val_type in (Float16, BFloat16):
         val_i16 = val.bitcast(Int16, loc=loc, ip=ip)
-        val_i32 = Int32(
-            arith.extui(Int32.mlir_type, val_i16.ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
-        )
-        shuffled_i32 = prims.shfl_sync(
-            mask, val_i32, offset, mask_and_clamp, kind, loc=loc, ip=ip
-        )
-        shuffled_i16 = Int16(
-            arith.trunci(
-                Int16.mlir_type, shuffled_i32.ir_value(loc=loc, ip=ip), loc=loc, ip=ip
-            )
-        )
+        val_i32 = Int32(arith.extui(Int32.mlir_type, val_i16.ir_value(loc=loc, ip=ip), loc=loc, ip=ip))
+        shuffled_i32 = prims.shfl_sync(mask, val_i32, offset, mask_and_clamp, kind, loc=loc, ip=ip)
+        shuffled_i16 = Int16(arith.trunci(Int16.mlir_type, shuffled_i32.ir_value(loc=loc, ip=ip), loc=loc, ip=ip))
         return shuffled_i16.bitcast(val_type, loc=loc, ip=ip)
     return prims.shfl_sync(mask, val, offset, mask_and_clamp, kind, loc=loc, ip=ip)
 

--- a/tilelang/contrib/cutedsl/warp.py
+++ b/tilelang/contrib/cutedsl/warp.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 """
 Warp-level primitives for CuTeDSL backend.
-Re-exports from cutlass.cute.arch with TileLang naming conventions.
+TileLang-compatible wrappers over CUTLASS primitives.
 """
 
 __all__ = [
@@ -20,79 +20,97 @@ __all__ = [
     "warp_reduce_bitor",
 ]
 
-from cutlass._mlir.dialects import llvm, arith
-from cutlass.base_dsl.typing import Uint32, Int32
-from cutlass.cutlass_dsl import T, dsl_user_op
-from cutlass.cute.arch import shuffle_sync, shuffle_sync_down, shuffle_sync_up, shuffle_sync_bfly
+from cutlass.experimental import primitives as prims
+from cutlass._mlir.dialects import arith, math as _math
+from cutlass._mlir_helpers.arith import ArithValue
+from cutlass.base_dsl.typing import BFloat16, Float16, Int16, Int32, Numeric, Uint32
+from cutlass.cutlass_dsl import dsl_user_op
 
 
 FULL_MASK = 0xFFFFFFFF
 WARP_SIZE = 32
 
 
+def _as_shfl_value(val):
+    if isinstance(val, ArithValue):
+        return Numeric.from_mlir_type(val.type)(val)
+    return val
+
+
+@dsl_user_op
+def _shfl_sync_typed(mask, val, offset, mask_and_clamp, kind, *, loc=None, ip=None):
+    val = _as_shfl_value(val)
+    val_type = type(val)
+    if val_type in (Float16, BFloat16):
+        val_i16 = val.bitcast(Int16, loc=loc, ip=ip)
+        val_i32 = Int32(
+            arith.extui(Int32.mlir_type, val_i16.ir_value(loc=loc, ip=ip), loc=loc, ip=ip)
+        )
+        shuffled_i32 = prims.shfl_sync(
+            mask, val_i32, offset, mask_and_clamp, kind, loc=loc, ip=ip
+        )
+        shuffled_i16 = Int16(
+            arith.trunci(
+                Int16.mlir_type, shuffled_i32.ir_value(loc=loc, ip=ip), loc=loc, ip=ip
+            )
+        )
+        return shuffled_i16.bitcast(val_type, loc=loc, ip=ip)
+    return prims.shfl_sync(mask, val, offset, mask_and_clamp, kind, loc=loc, ip=ip)
+
+
 @dsl_user_op
 def __activemask(*, loc=None, ip=None) -> Uint32:
     """
     Returns a 32-bit integer mask of all currently active threads in the calling warp.
-
-    PTX: activemask.b32 %mask;
     """
-    result = llvm.inline_asm(
-        T.i32(),
-        [],
-        "activemask.b32 $0;",
-        "=r",
-        has_side_effects=False,
-        is_align_stack=False,
-        asm_dialect=llvm.AsmDialect.AD_ATT,
-        loc=loc,
-        ip=ip,
+    return Uint32(
+        prims.inline_ptx(
+            "activemask.b32 {$w0};",
+            write_only_types=[Uint32],
+            loc=loc,
+            ip=ip,
+        )
     )
-    return Uint32(result)
 
 
 def __shfl_down_sync(mask, val, delta, width=32):
     """
     Shuffle down within warp.
 
-    Uses CuTeDSL's shuffle_sync_down with proper mask_and_clamp calculation.
     Matches CUDA: c = ((warpSize - width) << 8) | 0x1f
     """
     mask_and_clamp = ((WARP_SIZE - width) << 8) | 0x1F
-    return shuffle_sync_down(val, offset=delta, mask=mask, mask_and_clamp=mask_and_clamp)
+    return _shfl_sync_typed(mask, val, delta, mask_and_clamp, "down")
 
 
 def __shfl_up_sync(mask, val, delta, width=32):
     """
     Shuffle up within warp.
 
-    Uses CuTeDSL's shuffle_sync_up with proper mask_and_clamp calculation.
     Matches CUDA: c = (warpSize - width) << 8
     """
     mask_and_clamp = (WARP_SIZE - width) << 8
-    return shuffle_sync_up(val, offset=delta, mask=mask, mask_and_clamp=mask_and_clamp)
+    return _shfl_sync_typed(mask, val, delta, mask_and_clamp, "up")
 
 
 def __shfl_sync(mask, val, srcLane, width=32):
     """
     Broadcast from a specific lane within warp.
 
-    Uses CuTeDSL's shuffle_sync (idx mode) with proper mask_and_clamp.
     Matches CUDA: c = ((warpSize - width) << 8) | (width - 1)
     """
     mask_and_clamp = ((WARP_SIZE - width) << 8) | ((width - 1) & 0x1F)
-    return shuffle_sync(val, offset=srcLane, mask=mask, mask_and_clamp=mask_and_clamp)
+    return _shfl_sync_typed(mask, val, srcLane, mask_and_clamp, "idx")
 
 
 def __shfl_xor_sync(mask, val, lane_mask, width=32):
     """
     Butterfly (XOR) shuffle within warp.
 
-    Uses CuTeDSL's shuffle_sync_bfly with the same clamp encoding as CUDA
-    __shfl_xor_sync.
+    Uses the same clamp encoding as CUDA __shfl_xor_sync.
     """
     mask_and_clamp = ((WARP_SIZE - width) << 8) | ((width - 1) & 0x1F)
-    return shuffle_sync_bfly(val, offset=lane_mask, mask=mask, mask_and_clamp=mask_and_clamp)
+    return _shfl_sync_typed(mask, val, lane_mask, mask_and_clamp, "bfly")
 
 
 @dsl_user_op
@@ -100,24 +118,9 @@ def __match_any_sync(mask, val, *, loc=None, ip=None) -> Uint32:
     """
     Return a bitmask of lanes whose value matches the calling lane.
 
-    PTX: match.any.sync.b32 d, a, membermask;
+    Uses the primitive match wrapper.
     """
-    return Uint32(
-        llvm.inline_asm(
-            T.i32(),
-            [
-                Int32(val).ir_value(loc=loc, ip=ip),
-                Int32(mask).ir_value(loc=loc, ip=ip),
-            ],
-            "match.any.sync.b32 $0, $1, $2;",
-            "=r,r,r",
-            has_side_effects=True,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-    )
+    return Uint32(prims.match_sync(mask, Int32(val), "any", loc=loc, ip=ip))
 
 
 @dsl_user_op
@@ -125,26 +128,14 @@ def __popc(val, *, loc=None, ip=None) -> Int32:
     """
     Count set bits in a 32-bit value.
 
-    PTX: popc.b32 d, a;
+    Uses MLIR math.ctpop; no inline PTX is needed for the unpredicated form.
     """
-    return Int32(
-        llvm.inline_asm(
-            T.i32(),
-            [Int32(val).ir_value(loc=loc, ip=ip)],
-            "popc.b32 $0, $1;",
-            "=r,r",
-            has_side_effects=False,
-            is_align_stack=False,
-            asm_dialect=llvm.AsmDialect.AD_ATT,
-            loc=loc,
-            ip=ip,
-        )
-    )
+    return Int32(_math.ctpop(Int32(val).ir_value(loc=loc, ip=ip), loc=loc, ip=ip))
 
 
 def _shfl_xor_sync(val, lane_mask):
     """Butterfly (XOR) shuffle within full warp."""
-    return shuffle_sync_bfly(val, offset=lane_mask, mask=FULL_MASK, mask_and_clamp=0x1F)
+    return _shfl_sync_typed(FULL_MASK, val, lane_mask, 0x1F, "bfly")
 
 
 def warp_reduce_sum(value):

--- a/tilelang/jit/adapter/cutedsl/checks.py
+++ b/tilelang/jit/adapter/cutedsl/checks.py
@@ -6,7 +6,7 @@ from importlib.util import find_spec as _find_spec
 import os
 
 _CUTEDSL_PUBLIC_DIST = "nvidia-cutlass-dsl"
-_CUTEDSL_MIN_VERSION = (4, 3, 1)
+_CUTEDSL_MIN_VERSION = (4, 7, 0)
 _CUTEDSL_BANNED_VERSIONS = {(4, 3, 4)}  # Known broken versions
 _VERSION_TRIPLE_RE = re.compile(r"(\d+)\.(\d+)\.(\d+)")
 
@@ -15,7 +15,7 @@ def _parse_version_triple(version_str: str) -> tuple[int, int, int] | None:
     """Parse a best-effort (major, minor, patch) triple from a version string.
 
     We intentionally avoid importing heavy/optional version parsers. For our
-    minimum requirement (>= 4.3.1), a numeric triple comparison is sufficient.
+    minimum requirement (>= 4.7.0), a numeric triple comparison is sufficient.
     """
     m = _VERSION_TRIPLE_RE.search(version_str)
     if not m:

--- a/tilelang/jit/adapter/cutedsl/wrapper.py
+++ b/tilelang/jit/adapter/cutedsl/wrapper.py
@@ -1022,8 +1022,8 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
     # =========================================================================
 
     def _pythonic_expr(self, expr: tvm.tirx.PrimExpr) -> str:
-        """Convert TVM expression to Python string."""
-        return pythonic_expr(expr, self._TYPE_MAP, floor_div_op="//")
+        """Convert TVM expression to Python string, ignoring casts."""
+        return pythonic_expr(expr, self._TYPE_MAP, ignore_cast=True, floor_div_op="//")
 
     def _generate_cubin_cluster_arg(self, cluster_dims: list[Any] | None) -> str:
         """Render the optional CuTeDSL launch cluster argument."""

--- a/tilelang/jit/adapter/cutedsl/wrapper.py
+++ b/tilelang/jit/adapter/cutedsl/wrapper.py
@@ -11,6 +11,7 @@ Key features:
 """
 
 from __future__ import annotations
+import re
 from typing import Any, ClassVar
 
 from tvm import IRModule
@@ -137,10 +138,9 @@ CPP_TMA_LAUNCH_INIT_TEMPLATE = """\
   // Declare stack-local TMA descriptor array (eliminates concurrency race)
   CUtensorMap tma_descs[{num_tma_descs}];
 
-  // Initialize TMA descriptors (HOST memory - passed via __grid_constant__)
-  // NOTE: We intentionally do NOT reuse/cached descriptors across launches.
-  // Pointer-only reuse is a correctness trap (shape/stride may change with same ptr),
-  // and correctness beats micro-optimizations.
+  // Initialize TMA descriptors (HOST memory - passed via __grid_constant__).
+  // B200 launch-overhead experiments showed safe descriptor cache-key checks cost
+  // more than re-encoding these descriptors for the current generated launcher.
   result = tma_init(tma_descs, {tma_tensor_args});
   if (result != CUDA_SUCCESS) {{
     std::cerr << "Failed to initialize TMA descriptors: " << result << "\\n";
@@ -172,6 +172,55 @@ CPP_KERNEL_LAUNCH_TEMPLATE = """\
     );
     if (result != CUDA_SUCCESS) {{
       std::cerr << "Failed to launch kernel {kernel_name} on device " << device_id << ": " << result << "\\n";
+      return result;
+    }}
+  }}
+"""
+
+# Clustered kernel launch template.
+CPP_CLUSTER_KERNEL_LAUNCH_TEMPLATE = """\
+  // Launch kernel {kernel_idx}: {kernel_name} (clustered)
+  {{
+    // Get the kernel for current device
+    auto kernels_it = g_device_kernels.find(device_id);
+    if (kernels_it == g_device_kernels.end()) {{
+      std::cerr << "Kernels not initialized for device " << device_id << "\\n";
+      return CUDA_ERROR_NOT_INITIALIZED;
+    }}
+    const std::vector<CUfunction>& kernels = kernels_it->second;
+
+    void* args[] = {{{kernel_args}}};
+    CUlaunchAttribute attrs[2];
+    attrs[0].id = CU_LAUNCH_ATTRIBUTE_CLUSTER_DIMENSION;
+    attrs[0].value.clusterDim.x = {cluster_x};
+    attrs[0].value.clusterDim.y = {cluster_y};
+    attrs[0].value.clusterDim.z = {cluster_z};
+    attrs[1].id = CU_LAUNCH_ATTRIBUTE_PROGRAMMATIC_STREAM_SERIALIZATION;
+    attrs[1].value.programmaticStreamSerializationAllowed = 1;
+
+    CUlaunchConfig config = {{}};
+    config.gridDimX = {grid_x};
+    config.gridDimY = {grid_y};
+    config.gridDimZ = {grid_z};
+    config.blockDimX = {block_x};
+    config.blockDimY = {block_y};
+    config.blockDimZ = {block_z};
+    config.sharedMemBytes = {smem_size};
+    config.hStream = stream;
+    config.attrs = attrs;
+    config.numAttrs = 2;
+
+    result = cuFuncSetAttribute(kernels[{kernel_idx}],
+                                CU_FUNC_ATTRIBUTE_NON_PORTABLE_CLUSTER_SIZE_ALLOWED,
+                                1);
+    if (result != CUDA_SUCCESS) {{
+      std::cerr << "Failed to set cluster attribute for {kernel_name} on device " << device_id << ": " << result << "\\n";
+      return result;
+    }}
+
+    result = cuLaunchKernelEx(&config, kernels[{kernel_idx}], args, nullptr);
+    if (result != CUDA_SUCCESS) {{
+      std::cerr << "Failed to launch clustered kernel {kernel_name} on device " << device_id << ": " << result << "\\n";
       return result;
     }}
   }}
@@ -548,16 +597,35 @@ TVM_FFI_DLL_EXPORT_TYPED_FUNC(cleanup_module, cleanup_module);
 # PYTHON CUBIN GENERATION TEMPLATES
 # =============================================================================
 
-# TMA descriptor atom initialization template
-CUBIN_TMA_ATOM_INIT_TEMPLATE = """\
-    {desc_name} = tl.Gemm_SM90.get_tma_atom(__fake_tensor__, (32, 32))"""
+# TensorMap initialization template for cubin generation. Tiled descriptors use
+# their real descriptor fields. Descriptor modes without a CUTLASS host-side
+# builder, such as im2col, use valid tiled fields only as a compile-time typed
+# TensorMap placeholder; the generated C++ launcher still encodes the real
+# runtime descriptor.
+CUBIN_TMA_DESC_INIT_TEMPLATE = """\
+    {desc_name}__dtype, {desc_name}__format = _tma_dtype_and_format({dtype})
+    {desc_name} = cuda.create_tensor_map_tiled(
+        global_address={tensor_name}_.iterator.toint(),
+        dtype={desc_name}__dtype,
+        global_dims=[{global_dim_values}],
+        global_strides=[{global_stride_values}],
+        box_dims=[{box_dim_values}],
+        traversal_strides=[{element_stride_values}],
+        interleave=_tma_interleave({interleave}),
+        swizzle=_tma_swizzle({swizzle}),
+        l2_promotion=_tma_l2_promotion({l2_promotion}),
+        oob_fill=_tma_oob_fill({oob_fill}),
+        tma_format={desc_name}__format,
+    )"""
 
 # Kernel launch call template
 CUBIN_KERNEL_LAUNCH_TEMPLATE = """\
     {function_name}({call_args}).launch(
       grid=[{grid_x}, {grid_y}, {grid_z}],
       block=[{block_x}, {block_y}, {block_z}],
+{cluster_arg}\
       smem={smem_size},
+      min_blocks_per_mp=1,
       stream=stream,
       use_pdl={use_pdl},
     )"""
@@ -594,6 +662,17 @@ CUBIN_GEN_CODE_TEMPLATE = """\
         {compile_args},
         options=f"--enable-tvm-ffi --keep-cubin --gpu-arch={target_arch} --dump-dir={{_staging_dir.as_posix()}}",
     )
+    engine = getattr(_kernel_wrapper, "engine", None)
+    if engine is not None and hasattr(engine, "initialize"):
+      engine.initialize()
+    _cutlass_launcher = _kernel_wrapper
+    try:
+      import tvm_ffi
+      _cutlass_tvmffi_launcher = tvm_ffi.convert(_kernel_wrapper)
+      _cutlass_tvmffi_error = None
+    except Exception as err:
+      _cutlass_tvmffi_launcher = None
+      _cutlass_tvmffi_error = repr(err)
 
     # CuTeDSL generates a long, mangled cubin filename that includes argument/type info,
     # e.g. "cutlass_kernel_wrapper_FakeTensor...sm_90a.cubin". We expect exactly one cubin.
@@ -620,6 +699,13 @@ import tvm.runtime as runtime
 _cpp_launcher = None
 _cpp_launcher_lib = None
 _cubin_generated = False
+_cutlass_launcher = None
+_cutlass_tvmffi_launcher = None
+_cutlass_tvmffi_error = None
+_cutlass_custream_cls = None
+_has_tma_descs = {has_tma_descs}
+_cutlass_host_launcher_supported = {cutlass_host_launcher_supported}
+_cutlass_host_launcher_disabled_reason = {cutlass_host_launcher_disabled_reason!r}
 
 # Pre-compute paths - cubin is stored alongside the launcher .so
 # Use module basename to avoid conflicts when multiple kernels run concurrently
@@ -631,17 +717,20 @@ _cubin_path_bytes = _cubin_path.as_posix().encode('utf-8')
 _cubin_needs_generation = not _cubin_path.exists()
 
 def _generate_cubin_if_needed({cubin_gen_params}):
-  \"\"\"Generate cubin file on first call.
+  \"\"\"Compile the CUTLASS host wrapper and keep the cubin artifact.
 
-  All CuTeDSL imports are inside this function to avoid slow
-  module-level initialization when loading from cache.
+  All CuTeDSL imports are inside this function to avoid slow module-level
+  initialization when loading from cache. The compiled handle is retained so
+  TILELANG_CUTEDSL_HOST_LAUNCHER=cutlass can launch through CUTLASS directly.
   \"\"\"
-  global _cubin_generated, _cubin_path
+  global _cubin_generated, _cubin_path, _cutlass_launcher
+  global _cutlass_tvmffi_launcher, _cutlass_tvmffi_error
 
   # Lazy import CuTeDSL only when cubin generation is needed
   from cuda.bindings.driver import CUstream
   import cutlass
   import cutlass.cute as cute
+  import cutlass.experimental.cuda as cuda
   from cutlass.cute.runtime import make_fake_stream, make_fake_compact_tensor
   import tilelang.contrib.cutedsl as tl
   # We rely on CuTeDSL's keep-cubin artifact rather than custom extraction.
@@ -667,12 +756,104 @@ def _generate_cubin_if_needed({cubin_gen_params}):
       "torch.uint16": cutlass.Uint16,
       "torch.uchar": cutlass.Uint8}}
 
+  _TMA_DTYPE_NAMES = {{
+      0: "Uint8",
+      1: "Uint16",
+      2: "Uint32",
+      3: "Int32",
+      4: "Uint64",
+      5: "Int64",
+      6: "Float16",
+      7: "Float32",
+      8: "Float64",
+      9: "BFloat16",
+      10: "Float32",
+      11: "TFloat32",
+      12: "TFloat32",
+      13: "Float4E2M1FN",
+      14: "Float4E2M1FN",
+      15: "Float6E3M2FN",
+  }}
+  _TMA_FORMAT_NAMES = {{
+      0: "BYTE",
+      1: "DEFAULT",
+      2: "DEFAULT",
+      3: "DEFAULT",
+      4: "DEFAULT",
+      5: "DEFAULT",
+      6: "DEFAULT",
+      7: "DEFAULT",
+      8: "DEFAULT",
+      9: "DEFAULT",
+      10: "F32_FTZ",
+      11: "DEFAULT",
+      12: "TF32_FTZ",
+      13: "B4X16",
+      14: "B4X16_P64",
+      15: "B6X16_P32",
+  }}
+
+  def _tma_dtype_and_format(value):
+    value = int(value)
+    dtype_name = _TMA_DTYPE_NAMES.get(value)
+    if dtype_name is None:
+      raise ValueError(f"Unsupported TMA TensorMap dtype enum: {{value}}")
+    dtype = getattr(cutlass, dtype_name, None)
+    if dtype is None:
+      raise ValueError(f"CUTLASS dtype {{dtype_name}} is unavailable")
+    return dtype, getattr(cuda.TensorMapDataFormat, _TMA_FORMAT_NAMES[value])
+
+  def _tma_interleave(value):
+    return cuda.TensorMapInterleave(int(value))
+
+  def _tma_swizzle(value):
+    return cuda.TensorMapSwizzle(int(value))
+
+  def _tma_l2_promotion(value):
+    return cuda.TensorMapL2Promotion(int(value))
+
+  def _tma_oob_fill(value):
+    return cuda.TensorMapFloatOOBFill(int(value))
+
   def _positive_fake_shape(shape):
     return tuple(max(int(dim), 1) for dim in tuple(shape))
 
 {cubin_gen_code}
 
   _cubin_generated = True
+
+def _host_launcher_mode():
+  mode = os.environ.get("TILELANG_CUTEDSL_HOST_LAUNCHER", "cpp").strip().lower()
+  if mode in ("", "cpp", "c++"):
+    return "cpp"
+  if mode in ("cutlass", "cute"):
+    return "cutlass"
+  raise ValueError(
+      "TILELANG_CUTEDSL_HOST_LAUNCHER must be one of: cpp, cutlass"
+  )
+
+def _as_cutlass_stream(stream):
+  global _cutlass_custream_cls
+  if _cutlass_custream_cls is None:
+    from cuda.bindings.driver import CUstream
+    _cutlass_custream_cls = CUstream
+  return _cutlass_custream_cls(stream)
+
+def _load_cutlass_launcher({cubin_gen_params}):
+  \"\"\"Return the compiled CUTLASS host launcher, compiling it if needed.\"\"\"
+  global _cubin_needs_generation
+  if _cutlass_launcher is None:
+    _generate_cubin_if_needed({cubin_gen_call_args})
+    _cubin_needs_generation = False
+  if _cutlass_tvmffi_launcher is not None:
+    return _cutlass_tvmffi_launcher
+  require_tvmffi = os.environ.get("TILELANG_CUTEDSL_REQUIRE_TVMFFI", "").strip().lower()
+  if require_tvmffi in ("1", "true", "yes", "on"):
+    raise RuntimeError(
+        "CUTLASS host launcher did not produce a TVM-FFI function"
+        + (f": {{_cutlass_tvmffi_error}}" if _cutlass_tvmffi_error else "")
+    )
+  return _cutlass_launcher
 
 def _load_cpp_launcher():
   \"\"\"Load C++ kernel launcher.\"\"\"
@@ -702,6 +883,20 @@ def call({call_func_params}, stream, device_id=0):
     _cubin_needs_generation = False
 
 {arg_prep_code}
+
+  host_launcher_mode = _host_launcher_mode()
+  if host_launcher_mode == "cutlass" and _cutlass_host_launcher_supported:
+    _cutlass_stream = _as_cutlass_stream(stream)
+    launcher = _cutlass_tvmffi_launcher
+    if launcher is None:
+      launcher = _load_cutlass_launcher({cubin_gen_call_args})
+    launcher({cutlass_launcher_call_args})
+    return
+
+  if host_launcher_mode == "cutlass":
+    require_cutlass_host = os.environ.get("TILELANG_CUTEDSL_REQUIRE_CUTLASS_HOST", "").strip().lower()
+    if require_cutlass_host in ("1", "true", "yes", "on"):
+      raise RuntimeError(_cutlass_host_launcher_disabled_reason)
 
   launcher = _load_cpp_launcher()
   result = launcher({launcher_call_args}, stream, device_id, _cubin_path_bytes)
@@ -829,6 +1024,13 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
     def _pythonic_expr(self, expr: tvm.tirx.PrimExpr) -> str:
         """Convert TVM expression to Python string."""
         return pythonic_expr(expr, self._TYPE_MAP, floor_div_op="//")
+
+    def _generate_cubin_cluster_arg(self, cluster_dims: list[Any] | None) -> str:
+        """Render the optional CuTeDSL launch cluster argument."""
+        if not cluster_dims or not any(int(dim) != 1 for dim in cluster_dims):
+            return ""
+        cluster = ", ".join(str(int(dim)) for dim in cluster_dims)
+        return f"      cluster=[{cluster}],\n"
 
     def _target_arch(self) -> str:
         """Return the CUDA SM architecture requested by the TileLang target."""
@@ -1190,13 +1392,19 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
         grid = function_info["grid_info"]
         block = function_info["block_info"]
         smem_size = function_info["dynamic_smem_buf"] or 0
+        cluster = function_info.get("cluster_dims")
+        use_cluster = bool(cluster and any(dim != 1 for dim in cluster))
 
         # Choose launch template based on cooperative groups / PDL requirements
         function_name = kernel_meta["function_name"]
         use_cooperative = self.use_cooperative_groups.get(function_name, False)
         use_pdl = function_name in self.pdl_sync_map
         if use_cooperative:
+            if use_cluster:
+                raise AssertionError("Cluster launch is not supported for cooperative groups")
             template = CPP_COOPERATIVE_KERNEL_LAUNCH_TEMPLATE
+        elif use_cluster:
+            template = CPP_CLUSTER_KERNEL_LAUNCH_TEMPLATE
         elif use_pdl:
             template = CPP_PDL_KERNEL_LAUNCH_TEMPLATE
         else:
@@ -1213,6 +1421,9 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
             block_y=self._cxx_expr(block[1]),
             block_z=self._cxx_expr(block[2]),
             smem_size=smem_size,
+            cluster_x=self._cxx_expr(cluster[0]) if cluster else 1,
+            cluster_y=self._cxx_expr(cluster[1]) if cluster else 1,
+            cluster_z=self._cxx_expr(cluster[2]) if cluster else 1,
         )
 
     # =========================================================================
@@ -1299,12 +1510,117 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
     # Python Wrapper Generation
     # =========================================================================
 
+    @staticmethod
+    def _collect_wrapper_params_union(kernel_metadata_list: list[dict]) -> list[str]:
+        """Collect parameters used by the generated CUTLASS host wrapper."""
+        wrapper_params_union = []
+        for kernel_meta in kernel_metadata_list:
+            for arg_name, _ in kernel_meta["call_args"]:
+                if arg_name not in wrapper_params_union:
+                    wrapper_params_union.append(arg_name)
+        return wrapper_params_union
+
+    def _collect_cutlass_host_args(
+        self,
+        kernel_metadata_list: list[dict],
+        all_desc_names: list[str],
+        all_tma_tensors: list[str],
+    ) -> list[str]:
+        """Collect runtime args needed by the generated CUTLASS host wrapper."""
+        host_args = []
+        for arg_name in self._collect_wrapper_params_union(kernel_metadata_list):
+            if arg_name in all_desc_names:
+                continue
+            if arg_name not in host_args:
+                host_args.append(arg_name)
+        for tensor_name in all_tma_tensors:
+            if tensor_name not in host_args:
+                host_args.append(tensor_name)
+        return host_args
+
+    def _supports_cutlass_tma_host_launcher(self, desc_names: list[str]) -> tuple[bool, str]:
+        """Return whether direct CUTLASS host launch can create all TMA descriptors."""
+        unsupported = []
+        for desc_name in desc_names:
+            info = getattr(self, "tma_desc_info", {}).get(desc_name, {})
+            if info.get("is_img2col", False):
+                unsupported.append(f"{desc_name}: im2col TensorMap creation is not exposed")
+        if unsupported:
+            return False, "; ".join(unsupported)
+        return True, ""
+
+    def _py_expr_list(self, values: list[Any]) -> str:
+        """Render a Python list body from TVM/Python scalar expressions."""
+        return ", ".join(value if isinstance(value, str) else self._pythonic_expr(value) for value in values)
+
+    def _py_expr_list_div(self, values: list[Any], divisor: int) -> str:
+        """Render a Python list body with integer division applied to each value."""
+        return ", ".join(f"({self._pythonic_expr(value)}) // {divisor}" for value in values)
+
+    def _generate_cubin_tma_desc_init(
+        self,
+        desc_name: str,
+        tensor_arg_map: dict[str, tuple[str, int]],
+    ) -> str:
+        """Generate CUTLASS TensorMap creation code for cubin generation."""
+        info = self.tma_desc_info[desc_name]
+        tensor_name, _ = tensor_arg_map[desc_name]
+        if info.get("is_img2col", False):
+            tensor_rank = int(info["tensor_rank"])
+            box_dims = [info["smem_box_channel"], info["smem_box_pixel"]] + [1] * max(tensor_rank - 2, 0)
+        else:
+            box_dims = info["box_dim"]
+        return CUBIN_TMA_DESC_INIT_TEMPLATE.format(
+            desc_name=desc_name,
+            tensor_name=tensor_name,
+            dtype=info["dtype"],
+            global_dim_values=self._py_expr_list(info["global_dim"]),
+            global_stride_values=self._py_expr_list_div(info["global_stride"][1:], 16),
+            box_dim_values=self._py_expr_list(box_dims),
+            element_stride_values=self._py_expr_list(info["element_strides"]),
+            interleave=info["interleave"],
+            swizzle=info["swizzle"],
+            l2_promotion=info["l2Promotion"],
+            oob_fill=info["oobFill"],
+        )
+
+    @staticmethod
+    def _annotate_tma_tensor_map_params(lib_code: str, desc_names: list[str]) -> str:
+        """Annotate generated kernel TMA params as grid-constant TensorMaps."""
+        if not lib_code or not desc_names:
+            return lib_code
+        desc_set = {str(desc_name) for desc_name in desc_names}
+
+        def annotate_param(param: str) -> str:
+            stripped = param.strip()
+            if not stripped:
+                return param
+            name = stripped.split(":", 1)[0].split("=", 1)[0].strip()
+            if name not in desc_set or ":" in stripped:
+                return param
+            leading = param[: len(param) - len(param.lstrip())]
+            trailing = param[len(param.rstrip()) :]
+            return f"{leading}{name}: cutlass.GridConstant[cuda.TensorMap]{trailing}"
+
+        def annotate_signature(match: re.Match) -> str:
+            params = ", ".join(annotate_param(param) for param in match.group("params").split(","))
+            return f"{match.group('prefix')}{params}{match.group('suffix')}"
+
+        return re.sub(
+            r"(?m)^(?P<prefix>\s*def\s+\w+\s*\()(?P<params>[^()\n]*)(?P<suffix>\)\s*:)",
+            annotate_signature,
+            lib_code,
+        )
+
     def _generate_cubin_gen_code(
         self,
         kernel_metadata_list: list[dict],
         function_args: list[dict],
         buffer_args: list[str],
         all_desc_names: list[str],
+        all_tma_tensors: list[str],
+        tensor_arg_map: dict[str, tuple[str, int]],
+        use_tensor_map_descs: bool,
         lib_code: str = "",
     ) -> str:
         """Generate cubin generation code for Python wrapper using templates.
@@ -1314,17 +1630,22 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
                       This will be embedded inside _generate_cubin_if_needed to enable
                       lazy loading of cutlass/cute modules.
         """
-        # Build unified wrapper parameters
-        wrapper_params_union = []
-        for kernel_meta in kernel_metadata_list:
-            for arg_name, _ in kernel_meta["call_args"]:
-                if arg_name not in wrapper_params_union:
-                    wrapper_params_union.append(arg_name)
+        if use_tensor_map_descs:
+            lib_code = self._annotate_tma_tensor_map_params(lib_code, all_desc_names)
+
+        # Build host wrapper parameters. TensorMap descriptors are created from
+        # backing tensors inside the generated CUTLASS wrapper.
+        wrapper_params_union = self._collect_wrapper_params_union(kernel_metadata_list)
+        host_arg_names = (
+            self._collect_cutlass_host_args(kernel_metadata_list, all_desc_names, all_tma_tensors)
+            if use_tensor_map_descs
+            else wrapper_params_union
+        )
 
         # Build inner args for cute.compile
         inner_args = []
         fake_inner_args = []
-        for arg_name in wrapper_params_union:
+        for arg_name in host_arg_names:
             if arg_name in buffer_args:
                 inner_args.append(f"{arg_name}_")
                 fake_inner_args.append(f"__fake_{arg_name}__")
@@ -1333,16 +1654,13 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
             else:
                 inner_args.append(arg_name)
                 fake_inner_args.append(arg_name)
-        if all_desc_names:
-            inner_args.append("__fake_tensor__")
-            fake_inner_args.append("__fake_tensor__")
         fake_inner_args.append("__fake_stream__")
 
         # Generate TMA init code
         tma_init_code = ""
         if all_desc_names:
-            tma_init_lines = ["    # Create dummy TMA atoms for compilation"]
-            tma_init_lines.extend(CUBIN_TMA_ATOM_INIT_TEMPLATE.format(desc_name=desc_name) for desc_name in all_desc_names)
+            tma_init_lines = ["    # Create typed TensorMap descriptors for cubin generation"]
+            tma_init_lines.extend(self._generate_cubin_tma_desc_init(desc_name, tensor_arg_map) for desc_name in all_desc_names)
             tma_init_code = "\n".join(tma_init_lines) + "\n"
 
         # Generate kernel launch calls
@@ -1356,6 +1674,7 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
                 block_x=self._pythonic_expr(km["function_info"]["block_info"][0]),
                 block_y=self._pythonic_expr(km["function_info"]["block_info"][1]),
                 block_z=self._pythonic_expr(km["function_info"]["block_info"][2]),
+                cluster_arg=self._generate_cubin_cluster_arg(km["function_info"].get("cluster_dims")),
                 smem_size=km["function_info"]["dynamic_smem_buf"] or 0,
                 use_pdl=str(km["function_name"] in self.pdl_sync_map),
             )
@@ -1377,18 +1696,11 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
                 arg_name=arg_name,
                 dtype_expr=buffer_arg_dtypes.get(arg_name) or f"_DTYPE_MAP[str({arg_name}.dtype)]",
             )
-            for arg_name in wrapper_params_union
+            for arg_name in host_arg_names
             if arg_name in buffer_args
         )
         if fake_tensor_code:
             fake_tensor_code += "\n"
-
-        # Generate fake TMA tensor code
-        fake_tma_tensor_code = ""
-        if all_desc_names:
-            fake_tma_tensor_code = (
-                "  __fake_tensor__ = make_fake_compact_tensor(cutlass.Int32, (32, 32), stride_order=(1, 0), assumed_align=16)\n"
-            )
 
         # Indent lib_code to be inside the function
         indented_lib_code = "\n".join("  " + line if line.strip() else line for line in lib_code.split("\n")) if lib_code else ""
@@ -1399,7 +1711,7 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
             tma_init_code=tma_init_code,
             kernel_launches=kernel_launches,
             fake_tensor_code=fake_tensor_code,
-            fake_tma_tensor_code=fake_tma_tensor_code,
+            fake_tma_tensor_code="",
             compile_args=", ".join(fake_inner_args),
             target_arch=self._target_arch(),
             primary_name=kernel_metadata_list[0]["function_name"],
@@ -1409,13 +1721,18 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
         self,
         function_args: list[dict],
         launcher_args: list[dict],
+        cutlass_launcher_args: list[str],
         cubin_gen_code: str,
         cubin_gen_params: str,
+        has_tma_descs: bool,
+        cutlass_host_launcher_supported: bool,
+        cutlass_host_launcher_disabled_reason: str,
     ) -> str:
         """Generate Python wrapper code."""
         # Build function parameters
         call_func_params = ", ".join(arg["name"] for arg in function_args)
         launcher_call_args = ", ".join(arg["name"] for arg in launcher_args)
+        cutlass_launcher_call_args = ", ".join(cutlass_launcher_args)
 
         return PYTHON_HOST_FUNC_TEMPLATE.format(
             cubin_gen_params=cubin_gen_params,
@@ -1425,6 +1742,10 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
             cubin_gen_call_args=cubin_gen_params,
             arg_prep_code="",
             launcher_call_args=launcher_call_args,
+            cutlass_launcher_call_args=cutlass_launcher_call_args,
+            has_tma_descs=str(bool(has_tma_descs)),
+            cutlass_host_launcher_supported=str(bool(cutlass_host_launcher_supported)),
+            cutlass_host_launcher_disabled_reason=cutlass_host_launcher_disabled_reason,
         )
 
     # =========================================================================
@@ -1619,12 +1940,18 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
         self._launcher_lib_name = "launcher_lib.so"
         self.launcher_lib_name = self._launcher_lib_name
 
+        tma_host_supported, tma_host_disabled_reason = self._supports_cutlass_tma_host_launcher(all_desc_names_union)
+        cutlass_host_launcher_supported = not all_desc_names_union or tma_host_supported
+
         # Generate cubin generation code (includes lib_code with @cute.kernel definitions)
         cubin_gen_code = self._generate_cubin_gen_code(
             kernel_metadata,
             function_args,
             buffer_args,
             all_desc_names_union,
+            all_tma_tensors,
+            tensor_arg_map,
+            use_tensor_map_descs=bool(all_desc_names_union),
             lib_code=getattr(self, "lib_code", ""),
         )
 
@@ -1635,8 +1962,19 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
         # `_generate_cubin_if_needed(...)` scope, so include them in its signature.
         scalar_names = [arg["name"] for arg in function_args if arg["type"] != "buffer"]
         cubin_gen_params = ", ".join(buffer_names + scalar_names)
+        cutlass_launcher_args = self._collect_cutlass_host_args(kernel_metadata, all_desc_names_union, all_tma_tensors)
+        cutlass_launcher_args.append("_cutlass_stream")
 
-        python_wrapper = self._generate_python_wrapper(function_args, launcher_args, cubin_gen_code, cubin_gen_params)
+        python_wrapper = self._generate_python_wrapper(
+            function_args,
+            launcher_args,
+            cutlass_launcher_args,
+            cubin_gen_code,
+            cubin_gen_params,
+            has_tma_descs=bool(all_desc_names_union),
+            cutlass_host_launcher_supported=cutlass_host_launcher_supported,
+            cutlass_host_launcher_disabled_reason=tma_host_disabled_reason,
+        )
 
         return python_wrapper
 
@@ -1669,6 +2007,7 @@ class TLCuTeDSLSourceWrapper(TLCUDASourceWrapper):
                     "block_info": self.block_info[function_name],
                     "grid_info": self.grid_info[function_name],
                     "dynamic_smem_buf": self.dynamic_smem_buf[function_name],
+                    "cluster_dims": self.cluster_dims.get(function_name, None),
                     "function_params": call_site["function_params"],
                 }
             )


### PR DESCRIPTION
## Summary

This ports the TileLang CuTeDSL backend from low-level PTX-oriented helper paths to CUTLASS DSL primitive APIs where available.

Main changes:
- Replace CuTeDSL backend intrinsic wrappers with `cutlass.experimental.primitives` semantic APIs for mbarrier, TMA, ldmatrix/stmatrix, atomics, reductions, math, quantization, warp ops, and tcgen05 paths.
- Enable the same primitives-backed CuTeDSL paths for SM120 where the underlying operation is supported, including TMA, mbarrier, CTA barriers, ldmatrix/stmatrix, atomics, and tcgen05 blockscaled flows.
- Add cluster helper support used by 2CTA/cluster TMA flows.
- Add TensorMap-aware CuTeDSL codegen and remove the dummy TMA atom fallback for cubin generation.
- Add an optional CUTLASS TVM-FFI host launcher path, while keeping the generated C++ launcher as fallback.
- Add maint smoke/benchmark scripts for CuTeDSL host launcher and im2col descriptor behavior.

## Dependency Note

This targets CUTLASS DSL 4.7 primitives. The corresponding CUTLASS release PR is NVIDIA/cutlass#3432.

The official `nvidia-cutlass-dsl==4.7.0` wheel set is not fully published yet, so validation was run with the latest matching 4.7.0a0 prerelease wheel set available in the internal index.

## Notes

- WGMMA and legacy MMA paths are intentionally left on the existing fallback implementation where CUTLASS primitives do not yet cover the needed combinations.
- Direct CUTLASS host launching remains disabled for im2col TensorMap descriptors until CUTLASS DSL exposes im2col TensorMap creation; the generated C++ launcher still encodes real im2col descriptors.

## Validation

- `git diff --check upstream/main..HEAD` passed.
- `just update` passed.
- B200 full examples with `TILELANG_TARGET=cutedsl`:
  `56 passed, 2 xpassed, 21 skipped, 3 failed`.
- The 3 B200 failures also reproduce with `TILELANG_TARGET=cuda`, so they are not CuTeDSL-specific regressions:
  - generated CUDA C++ `half_t` / `__half` mismatch in two cases
  - common reduce-lowering ICHECK in one GDN case
- H100 full example coverage was tested on SM90.
- SM120 full example coverage was tested on RTX PRO 6000. The primitives-backed CuTeDSL path is active for supported SM120 operations. The remaining SM120 failures match CUDA backend behavior and come from kernels requesting more dynamic shared memory than the device opt-in limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Ported the CuTeDSL backend from PTX and NVVM helpers to CUTLASS DSL 4.7 primitives.
- Updated mbarrier, TMA, async copy, ldmatrix/stmatrix, atomics, reductions, math, quantization, warp, and tcgen05 operations.
- Added SM120 support, cluster synchronization, 2CTA operations, cluster TMA flows, and cluster-aware launch configuration.
- Added TensorMap-aware cubin generation and removed dummy TMA atoms.
- Added optional CUTLASS TVM-FFI host launching with C++ launcher fallback.
- Added CuTeDSL launcher benchmarks and an im2col/TMA smoke test.
- Updated the CUDA test dependency to `nvidia-cutlass-dsl[cu13]==4.7.0`.
- Retained existing fallback implementations for WGMMA and legacy MMA paths.

## Validation

- Ran formatting and update checks.
- Validated B200, H100 SM90, and SM120 RTX PRO 6000 coverage.
- Reported failures reproduce with the CUDA backend or result from device dynamic shared-memory limits.
- Direct CUTLASS host launching remains disabled for im2col TensorMap descriptors.

## C++ style / lint notes

- The PR changes C++ code in the CuTeDSL code generator and runtime launcher.
- It does not change `docs/developer_guide/cpp_style.md`.
- It does not change the CI configuration or the “C++ API Style Audit (warning only)” step.
- Any TLCPP003/TLCPP004 findings remain advisory. Correctness, build, and test failures are separate from these warning-only style findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->