### PR TITLE
[BugFix][ROCm] Emit a compiler barrier for tl.sync_warp on HIP

### DIFF
--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -1256,9 +1256,14 @@ void CodeGenTileLangHIP::VisitExpr_(const CallNode *op, std::ostream &os) {
     this->PrintIndent();
     this->stream << "cooperative_groups::this_grid().sync();\n";
   } else if (op->op.same_as(tl::sync_warp())) {
-    // AMD wavefronts execute in lockstep, so intra-wavefront convergence is
-    // guaranteed by the hardware. __syncwarp() has no HIP equivalent and is a
-    // no-op here. The mask argument (if present) is intentionally ignored.
+    // AMD wavefronts execute in lockstep, so no runtime barrier is needed for
+    // intra-wavefront convergence and the mask argument is ignored. A compiler
+    // barrier is still required: without one the backend may reorder the LDS
+    // accesses that a warp-synchronous reduction depends on.
+    // __builtin_amdgcn_wave_barrier() emits no instructions and only constrains
+    // scheduling.
+    this->PrintIndent();
+    this->stream << "__builtin_amdgcn_wave_barrier();\n";
   } else if (op->op.same_as(tl::any_sync())) {
     ICHECK_EQ(op->args.size(), 2U) << "tl.any_sync expects <mask, predicate>.";
     // HIP __any takes only the predicate; the mask is ignored because


### PR DESCRIPTION
## Summary

#2865 fixed the warp-synchronous allreduce corruption from #2628 by emitting `__syncwarp(mask)` around the in-warp reduction steps. On HIP that call lowers to nothing, so the fix never took effect on ROCm and the regression test added by that PR fails on gfx942:

```
testing/python/issue/test_tilelang_issue_2628.py::test_thread_allreduce_syncwarp_sum[float32-vals0]
E   AssertionError: Scalars are not close!
E   Expected 202.0 but got 90.0.
E   Absolute difference: 112.0 (up to 0.001 allowed)
```

The existing comment in `codegen_hip.cc` argues that AMD wavefronts execute in lockstep, so no barrier is needed:

```cpp
} else if (op->op.same_as(tl::sync_warp())) {
    // AMD wavefronts execute in lockstep, so intra-wavefront convergence is
    // guaranteed by the hardware. __syncwarp() has no HIP equivalent and is a
    // no-op here. The mask argument (if present) is intentionally ignored.
```

That is true of *runtime* convergence, but not of *compile-time* scheduling. With nothing marking the synchronization point, the backend is free to reorder or coalesce the LDS accesses that the warp-synchronous reduction depends on — which is exactly the corruption #2628 describes.

## Fix

Emit `__builtin_amdgcn_wave_barrier()`. It generates no instructions, so the lockstep reasoning still holds and there is no runtime cost; it only constrains the scheduler. The mask argument stays ignored, since a wavefront is always fully convergent.

## Test plan

No new test needed — `testing/python/issue/test_tilelang_issue_2628.py` from #2865 already covers this and currently fails on ROCm.

Verified on 8x MI300X (gfx942), ROCm 7.2, torch `2.14.0.dev+rocm7.2`:

- [x] Before: `test_tilelang_issue_2628.py` → **3 failed** (run aborted by `--maxfail=3`)
- [x] After: `test_tilelang_issue_2628.py` → **12 passed** (sum and mul across float32/int32/float16/bfloat16/int16/int8)
- [x] Full ROCm suite after the fix: **1809 passed, 1227 skipped, 0 failed**

## Notes

- The change is confined to `src/rocm/codegen/codegen_hip.cc`, so there is no CUDA or Metal impact.
- I could only verify on **gfx942**. `__builtin_amdgcn_wave_barrier()` is a standard AMDGCN builtin and should behave the same on gfx950 and RDNA, but I do not have that hardware to confirm.

This is also a concrete data point for #2844: the bug reached `main` today, in a PR whose purpose was fixing exactly this class of issue, and went unnoticed because ROCm CI has been disabled since May. A follow-up PR re-enables the ROCm matrix entry now that a gfx942 runner is registered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed `tl.sync_warp()` code generation on HIP/ROCm.
- Emit `__builtin_amdgcn_wave_barrier()` to prevent unsafe LDS access reordering.
- Keep the mask argument ignored because AMD wavefronts are fully convergent.
- CUDA and Metal code remain unchanged.

## Validation

- The gfx942 regression test for issue `#2628` passes.
- ROCm validation on 8 MI300X GPUs passed 12 regression tests.
- Full ROCm suite: 1,809 passed, 1,227 skipped, 0 failed.

## C++ style / lint notes

- The change does not modify rules in `docs/developer_guide/cpp_style.md`.
- The `C++ API Style Audit (warning only)` CI step applies.
- No correctness, build, or warning-only style issue is reported for this change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->