### PR TITLE
[BugFix] Fix failed ties-away-from-zero round compile on bfloat16/float8

### DIFF
--- a/src/op/math.cc
+++ b/src/op/math.cc
@@ -76,10 +76,9 @@ PrimExpr round_ties_away_from_zero_op(PrimExpr args) {
   if (dtype.is_int() || dtype.is_uint() || dtype.is_bool()) {
     return call->args[0];
   }
-  ffi::String func_name =
-      dtype.is_float() && dtype.bits() == 64 ? "round" : "roundf";
   return tirx::Call(dtype, tirx::builtin::call_pure_extern(),
-                    {StringImm(func_name), call->args[0]}, call->annotations);
+                    {StringImm("tl::RoundTiesAwayFromZero"), call->args[0]},
+                    call->annotations);
 }
 
 TVM_REGISTER_OP("tl.round_ties_away_from_zero")

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -1371,4 +1371,24 @@ template <> TL_DEVICE float2 shfl_sync(unsigned mask, float2 val, int srcLane) {
   return reinterpret_cast<float2 const &>(raw);
 }
 
+TL_DEVICE half_t RoundTiesAwayFromZero(half_t x) {
+  return half_t(roundf(float(x)));
+}
+
+TL_DEVICE float RoundTiesAwayFromZero(float x) { return roundf(x); }
+
+TL_DEVICE double RoundTiesAwayFromZero(double x) { return round(x); }
+
+TL_DEVICE bfloat16_t RoundTiesAwayFromZero(bfloat16_t x) {
+  return bfloat16_t(roundf(float(x)));
+}
+
+TL_DEVICE float_e4m3_t RoundTiesAwayFromZero(float_e4m3_t x) {
+  return float_e4m3_t(cutlass::float_e4m3_t(roundf(float(x))));
+}
+
+TL_DEVICE float_e5m2_t RoundTiesAwayFromZero(float_e5m2_t x) {
+  return float_e5m2_t(cutlass::float_e5m2_t(roundf(float(x))));
+}
+
 } // namespace tl

--- a/src/tl_templates/hip/common.h
+++ b/src/tl_templates/hip/common.h
@@ -379,4 +379,16 @@ template <> TL_DEVICE bfloat16_t shfl(bfloat16_t val, int srcLane) {
   return bfloat16_t(r);
 }
 
+TL_DEVICE half_t RoundTiesAwayFromZero(half_t x) {
+  return half_t(roundf(static_cast<float>(x)));
+}
+
+TL_DEVICE float RoundTiesAwayFromZero(float x) { return roundf(x); }
+
+TL_DEVICE double RoundTiesAwayFromZero(double x) { return round(x); }
+
+TL_DEVICE bfloat16_t RoundTiesAwayFromZero(bfloat16_t x) {
+  return bfloat16_t(roundf(static_cast<float>(x)));
+}
+
 } // namespace tl

--- a/testing/python/fastmath/test_mathops_fastmath.py
+++ b/testing/python/fastmath/test_mathops_fastmath.py
@@ -285,12 +285,12 @@ def test_mathops_generate_no_fastmath(name, func):
 
 
 @tilelang.testing.requires_cuda
-def test_round_ties_away_from_zero_uses_roundf():
+def test_round_ties_away_from_zero_uses_helper():
     run_single_arg_mathop_test(
         "round",
         lambda x: T.round(x, "ties-away-from-zero"),
         dtype=T.float32,
-        cuda_mathop_name="round",
+        cuda_mathop_name="RoundTiesAwayFromZero",
     )
 
 

--- a/testing/python/issue/test_tilelang_issue_2635.py
+++ b/testing/python/issue/test_tilelang_issue_2635.py
@@ -1,0 +1,30 @@
+import tilelang
+import tilelang.testing
+import tilelang.language as T
+
+
+def _make_round_kernel(dtype):
+    @T.prim_func
+    def main(A: T.Tensor((16,), dtype), B: T.Tensor((16,), dtype)):
+        with T.Kernel(1, threads=16):
+            for i in T.Parallel(16):
+                B[i] = T.round(A[i], "ties-away-from-zero")
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(8, 0)
+def test_round_ties_away_from_zero_compiles_for_bfloat16():
+    tilelang.compile(_make_round_kernel("bfloat16"), target="cuda")
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(8, 9)
+def test_round_ties_away_from_zero_compiles_for_float8():
+    for dtype in ("float8_e4m3", "float8_e5m2"):
+        tilelang.compile(_make_round_kernel(dtype), target="cuda")
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/math/test_math_fast_math.py
+++ b/testing/python/math/test_math_fast_math.py
@@ -328,7 +328,11 @@ def test_mathops_generate_no_fastmath(name, func):
     ("rounding_mode", "func", "cuda_mathop_name"),
     [
         ("ties-to-even", lambda x: T.round(x), "nearbyint"),
-        ("ties-away-from-zero", lambda x: T.round(x, "ties-away-from-zero"), "round"),
+        (
+            "ties-away-from-zero",
+            lambda x: T.round(x, "ties-away-from-zero"),
+            "RoundTiesAwayFromZero",
+        ),
     ],
     ids=["ties-to-even", "ties-away-from-zero"],
 )


### PR DESCRIPTION
Add helper functions for dtype rounding.
Simplify the code by using the helper function call.
Also add a regression test.
Fixes #2635 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added dtype-specific `tl::RoundTiesAwayFromZero` overloads for supported floating-point types.
- Updated `round_ties_away_from_zero_op` to use the helper for floating-point values.
- Preserved existing behavior for integer, unsigned, and boolean types.
- Added CUDA regression tests for `bfloat16`, `float8_e4m3`, and `float8_e5m2`.
- Fixed compilation failures caused by incompatible `nvcc` assignments.

## C++ style / lint notes

- The PR changes C++ code.
- Check the changes against `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit is warning-only. Treat TLCPP003/TLCPP004 findings as advisory unless they introduce a clear API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->