### PR TITLE
[CI] Re-enable ROCm CI on a gfx942 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,12 +90,11 @@ jobs:
             # E.g., "CUDA-auto", "CUDA-13.0", or "Nightly-CUDA-13.0".
             # Use "Nightly-" prefix to use torch nightly builds.
             toolkit: CUDA-auto
-          # ROCm CI is temporarily disabled.
-          # - tags: [self-hosted, amd, gpu]
-          #   name: self-hosted-amd
-          #   # Format: [Nightly-]ROCm-<major>.<minor>[.<patch>]. E.g., "ROCm-6.4" or "Nightly-ROCm-7.0".
-          #   # Use "Nightly-" prefix to use torch nightly builds.
-          #   toolkit: Nightly-ROCm-7.2
+          - tags: [self-hosted, amd, gfx942]
+            name: self-hosted-amd-gfx942
+            # Format: [Nightly-]ROCm-<major>.<minor>[.<patch>]. E.g., "ROCm-6.4" or "Nightly-ROCm-7.0".
+            # Use "Nightly-" prefix to use torch nightly builds.
+            toolkit: Nightly-ROCm-7.2
           - tags: [macos-latest]
             name: macos-latest
             toolkit: Metal # or Nightly-Metal
@@ -390,7 +389,6 @@ jobs:
             ./python
 
       # AMD ROCm tests
-      # runtime and transform tests needs to repair, then rm it from ignore list
       - name: Run ROCm tests with Python ${{ matrix.python-version }} (${{ matrix.runner.toolkit }})
         id: rocm-tests
         if: contains(matrix.runner.toolkit, 'ROCm')
@@ -401,7 +399,6 @@ jobs:
             pytest --verbose --color=yes --durations=0 --showlocals --cache-clear
           )
           "${PYTEST[@]}" --maxfail=3 --numprocesses=8 \
-            --ignore=./python/runtime --ignore=./python/transform \
             ./python
 
       # Apple Metal tests


### PR DESCRIPTION
> **Draft — blocked on #2872.** Kept in draft deliberately: the `tests` job is
> skipped for draft PRs, so CI stays quiet until the blocker lands. Opening it
> now so it can be reviewed alongside #2872 rather than a day later.

## Summary

Reverts the temporary disable from #2241. An 8x MI300X (gfx942) runner is registered on this repository and runs the ROCm 7.2 toolchain in a container, so the existing `Nightly-ROCm-7.2` toolkit value applies unchanged.

Three changes, 7 lines total:

**1. Re-enable the matrix entry.**

**2. Drop `--ignore=./python/runtime`** — that directory passes (1 passed, 2 skipped). The ignore was stale.

**3. Drop `--ignore=./python/transform`** — its 42 failures were CUDA-only tests missing a `requires_cuda` gate, fixed in #2863. Ignoring the directory also discarded **215 passing tests**.

## On the runner label

The entry uses `[self-hosted, amd, gfx942]` rather than the previous `[self-hosted, amd, gpu]`.

A single `gpu` pool cannot distinguish CDNA generations, and several behaviours legitimately differ between them:

| Behaviour | gfx942 (CDNA3) | gfx950 (CDNA4) |
|---|---|---|
| Software pipelining | stripped (sequential fallback) | enabled |
| fp8 `e4m3` encoding | FNUZ | OCP |
| `__launch_bounds__` | `(N)` | `(N)` — differs from CUDA's `(N, 1)` |

With one shared label, results would vary depending on which machine picked up the job. An arch-specific label keeps that deterministic and leaves room for a gfx950 entry later.

**This is not load-bearing** — the runner is registered with `self-hosted, amd, gpu, gfx942`, so it matches either naming. Happy to keep `gpu` if you prefer; just say so and I'll change it.

## Blocked on #2872

#2872 fixes a ROCm allreduce correctness bug (`tl.sync_warp` lowers to nothing on HIP, so #2865's fix for #2628 never applied there). Without it the ROCm leg fails on 3 tests and `--maxfail=3` aborts the run.

**Merge order: #2872, then this.** I'll rebase, re-verify on the runner, and mark ready for review once that lands.

## Test plan

Verified on the registered runner (8x MI300X gfx942, ROCm 7.2, torch `2.14.0.dev+rocm7.2`) with the exact post-change invocation — no `--ignore` flags, `--maxfail=3`, `-n8`:

- [x] **1809 passed, 1227 skipped, 0 failed** in ~4m30s (120 min timeout)
- [x] Reproduced identically across repeated runs — no flakiness
- [x] Job total ~5 min warm / ~11 min cold, so this would be the fastest leg in the matrix
- [x] Full workflow exercised end-to-end (recursive checkout, `setup-uv`, ccache, `Set environment (ROCm)`, `uv pip install -v .`) on a self-hosted gfx942 runner

## Note for reviewers

This is a fork PR that modifies a workflow file, so it will need an explicit **"Approve and run"** when it comes out of draft. That run is also the first time the runner is exercised on this repository, so it effectively self-validates.

Closes #2844 once merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Re-enabled ROCm CI with the `self-hosted, amd, gfx942` runner labels.
- Restored the ROCm 7.2 nightly matrix entry.
- Removed stale `python/runtime` and `python/transform` exclusions.
- Validated 1811 passed, 1227 skipped, and 0 failed tests.

## C++ style / lint notes

- The PR changes CI but does not modify `docs/developer_guide/cpp_style.md`.
- The existing **C++ API Style Audit (warning only)** step remains unchanged.
- No new C++ style warnings or correctness issues were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->