### PR TITLE
[Layout] Support half-subpartition (M=64) TMEM tiles in tcgen05.ld/st

### DIFF
--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -3820,30 +3820,38 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     this->stream << "tl::tcgen05_sf_warp_transpose(reinterpret_cast<uint32_t*>("
                  << smem_ptr << "));\n";
   } else if (op->op.same_as(tl::tcgen05_ld())) {
-    ICHECK_EQ(op->args.size(), 7U) << "tcgen05_ld expects 7 arguments";
+    ICHECK(op->args.size() == 6U || op->args.size() == 7U)
+        << "tcgen05_ld expects 6 or 7 arguments";
     need_copy_sm100_h_ = true;
     int inst_bits = Downcast<IntImm>(op->args[0])->value;
     int chunks = Downcast<IntImm>(op->args[1])->value;
     bool pack16 = Downcast<Bool>(op->args[2])->value;
     std::string tmem_start_col = this->PrintExpr(op->args[3]);
     std::string col_offset = this->PrintExpr(op->args[4]);
-    int datapaths = Downcast<IntImm>(op->args[5])->value;
-    std::string dst_ptr = this->PrintExpr(op->args[6]);
+    // The datapath count is optional: a hand-written call from before it
+    // existed means the sub-partition-filling (32dp) wrappers.
+    bool has_datapaths = op->args.size() == 7U;
+    int datapaths = has_datapaths ? Downcast<IntImm>(op->args[5])->value : 32;
+    std::string dst_ptr = this->PrintExpr(op->args[has_datapaths ? 6 : 5]);
     this->PrintIndent();
     this->stream << "tl::tcgen05_ld_" << datapaths << "dp" << inst_bits
                  << "bNx<" << chunks << ", " << (pack16 ? "true" : "false")
                  << ">(" << tmem_start_col << ", " << col_offset << ", "
                  << dst_ptr << ");\n";
   } else if (op->op.same_as(tl::tcgen05_st())) {
-    ICHECK_EQ(op->args.size(), 7U) << "tcgen05_st expects 7 arguments";
+    ICHECK(op->args.size() == 6U || op->args.size() == 7U)
+        << "tcgen05_st expects 6 or 7 arguments";
     need_copy_sm100_h_ = true;
     int inst_bits = Downcast<IntImm>(op->args[0])->value;
     int chunks = Downcast<IntImm>(op->args[1])->value;
     bool unpack16 = Downcast<Bool>(op->args[2])->value;
     std::string tmem_start_col = this->PrintExpr(op->args[3]);
     std::string col_offset = this->PrintExpr(op->args[4]);
-    int datapaths = Downcast<IntImm>(op->args[5])->value;
-    std::string src_ptr = this->PrintExpr(op->args[6]);
+    // The datapath count is optional: a hand-written call from before it
+    // existed means the sub-partition-filling (32dp) wrappers.
+    bool has_datapaths = op->args.size() == 7U;
+    int datapaths = has_datapaths ? Downcast<IntImm>(op->args[5])->value : 32;
+    std::string src_ptr = this->PrintExpr(op->args[has_datapaths ? 6 : 5]);
     this->PrintIndent();
     this->stream << "tl::tcgen05_st_" << datapaths << "dp" << inst_bits
                  << "bNx<" << chunks << ", " << (unpack16 ? "true" : "false")

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -3820,33 +3820,35 @@ void CodeGenTileLangCUDA::VisitExpr_(const CallNode *op, std::ostream &os) {
     this->stream << "tl::tcgen05_sf_warp_transpose(reinterpret_cast<uint32_t*>("
                  << smem_ptr << "));\n";
   } else if (op->op.same_as(tl::tcgen05_ld())) {
-    ICHECK_EQ(op->args.size(), 6U) << "tcgen05_ld expects 6 arguments";
+    ICHECK_EQ(op->args.size(), 7U) << "tcgen05_ld expects 7 arguments";
     need_copy_sm100_h_ = true;
     int inst_bits = Downcast<IntImm>(op->args[0])->value;
     int chunks = Downcast<IntImm>(op->args[1])->value;
     bool pack16 = Downcast<Bool>(op->args[2])->value;
     std::string tmem_start_col = this->PrintExpr(op->args[3]);
     std::string col_offset = this->PrintExpr(op->args[4]);
-    std::string dst_ptr = this->PrintExpr(op->args[5]);
+    int datapaths = Downcast<IntImm>(op->args[5])->value;
+    std::string dst_ptr = this->PrintExpr(op->args[6]);
     this->PrintIndent();
-    this->stream << "tl::tcgen05_ld_32dp" << inst_bits << "bNx<" << chunks
-                 << ", " << (pack16 ? "true" : "false") << ">("
-                 << tmem_start_col << ", " << col_offset << ", " << dst_ptr
-                 << ");\n";
+    this->stream << "tl::tcgen05_ld_" << datapaths << "dp" << inst_bits
+                 << "bNx<" << chunks << ", " << (pack16 ? "true" : "false")
+                 << ">(" << tmem_start_col << ", " << col_offset << ", "
+                 << dst_ptr << ");\n";
   } else if (op->op.same_as(tl::tcgen05_st())) {
-    ICHECK_EQ(op->args.size(), 6U) << "tcgen05_st expects 6 arguments";
+    ICHECK_EQ(op->args.size(), 7U) << "tcgen05_st expects 7 arguments";
     need_copy_sm100_h_ = true;
     int inst_bits = Downcast<IntImm>(op->args[0])->value;
     int chunks = Downcast<IntImm>(op->args[1])->value;
     bool unpack16 = Downcast<Bool>(op->args[2])->value;
     std::string tmem_start_col = this->PrintExpr(op->args[3]);
     std::string col_offset = this->PrintExpr(op->args[4]);
-    std::string src_ptr = this->PrintExpr(op->args[5]);
+    int datapaths = Downcast<IntImm>(op->args[5])->value;
+    std::string src_ptr = this->PrintExpr(op->args[6]);
     this->PrintIndent();
-    this->stream << "tl::tcgen05_st_32dp" << inst_bits << "bNx<" << chunks
-                 << ", " << (unpack16 ? "true" : "false") << ">("
-                 << tmem_start_col << ", " << col_offset << ", " << src_ptr
-                 << ");\n";
+    this->stream << "tl::tcgen05_st_" << datapaths << "dp" << inst_bits
+                 << "bNx<" << chunks << ", " << (unpack16 ? "true" : "false")
+                 << ">(" << tmem_start_col << ", " << col_offset << ", "
+                 << src_ptr << ");\n";
   } else if (op->op.same_as(tl::tcgen05_mma_arrive())) {
     ICHECK_EQ(op->args.size(), 1U) << "tcgen05_mma_arrive expects 1 argument";
     need_tcgen05_common_h_ = true;

--- a/src/cuda/codegen/codegen_cutedsl.cc
+++ b/src/cuda/codegen/codegen_cutedsl.cc
@@ -1420,29 +1420,41 @@ void CodeGenTileLangCuTeDSL::VisitExpr_(const CallNode *op,
            << sfa_offset << ", " << sfb_ref << "[0] + " << sfb_offset
            << ", use_2cta=" << (enable_2cta ? "True" : "False") << ")\n";
   } else if (op->op.same_as(tl::tcgen05_ld())) {
-    ICHECK_EQ(op->args.size(), 6U) << "tcgen05_ld expects 6 arguments";
+    ICHECK(op->args.size() == 6U || op->args.size() == 7U)
+        << "tcgen05_ld expects 6 or 7 arguments";
     int inst_bits = Downcast<IntImm>(op->args[0])->value;
     int chunks = Downcast<IntImm>(op->args[1])->value;
     bool pack16 = Downcast<Bool>(op->args[2])->value;
     std::string tmem_start_col = PrintExpr_(op->args[3]);
     std::string col_offset = PrintExpr_(op->args[4]);
-    std::string dst_ptr = PrintExpr_(op->args[5]);
+    // The optional datapath count selects the half-subpartition (16dp)
+    // wrappers; a six-argument call from before it existed means the
+    // sub-partition-filling 32dp wrappers.
+    bool has_datapaths = op->args.size() == 7U;
+    int datapaths = has_datapaths ? Downcast<IntImm>(op->args[5])->value : 32;
+    std::string dst_ptr = PrintExpr_(op->args[has_datapaths ? 6 : 5]);
     PrintIndent();
-    stream << "tl.tcgen05_ld_32dp" << inst_bits << "bNx(" << chunks << ", "
-           << (pack16 ? "True" : "False") << ", " << tmem_start_col << ", "
-           << col_offset << ", " << dst_ptr << ")\n";
+    stream << "tl.tcgen05_ld_" << datapaths << "dp" << inst_bits << "bNx("
+           << chunks << ", " << (pack16 ? "True" : "False") << ", "
+           << tmem_start_col << ", " << col_offset << ", " << dst_ptr << ")\n";
   } else if (op->op.same_as(tl::tcgen05_st())) {
-    ICHECK_EQ(op->args.size(), 6U) << "tcgen05_st expects 6 arguments";
+    ICHECK(op->args.size() == 6U || op->args.size() == 7U)
+        << "tcgen05_st expects 6 or 7 arguments";
     int inst_bits = Downcast<IntImm>(op->args[0])->value;
     int chunks = Downcast<IntImm>(op->args[1])->value;
     bool unpack16 = Downcast<Bool>(op->args[2])->value;
     std::string tmem_start_col = PrintExpr_(op->args[3]);
     std::string col_offset = PrintExpr_(op->args[4]);
-    std::string src_ptr = PrintExpr_(op->args[5]);
+    // The optional datapath count selects the half-subpartition (16dp)
+    // wrappers; a six-argument call from before it existed means the
+    // sub-partition-filling 32dp wrappers.
+    bool has_datapaths = op->args.size() == 7U;
+    int datapaths = has_datapaths ? Downcast<IntImm>(op->args[5])->value : 32;
+    std::string src_ptr = PrintExpr_(op->args[has_datapaths ? 6 : 5]);
     PrintIndent();
-    stream << "tl.tcgen05_st_32dp" << inst_bits << "bNx(" << chunks << ", "
-           << (unpack16 ? "True" : "False") << ", " << tmem_start_col << ", "
-           << col_offset << ", " << src_ptr << ")\n";
+    stream << "tl.tcgen05_st_" << datapaths << "dp" << inst_bits << "bNx("
+           << chunks << ", " << (unpack16 ? "True" : "False") << ", "
+           << tmem_start_col << ", " << col_offset << ", " << src_ptr << ")\n";
   } else if (op->op.same_as(tl::tcgen05_mma_arrive())) {
     ICHECK_EQ(op->args.size(), 1U) << "tcgen05_mma_arrive expects 1 argument";
     PrintIndent();

--- a/src/cuda/op/builtin.cc
+++ b/src/cuda/op/builtin.cc
@@ -416,12 +416,12 @@ TIR_DEFINE_TL_BUILTIN(tcgen05_mma_arrive)
                                Integer(CallEffectKind::kOpaque));
 
 TIR_DEFINE_TL_BUILTIN(tcgen05_ld)
-    .set_num_inputs(6)
+    .set_num_inputs(7)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
 TIR_DEFINE_TL_BUILTIN(tcgen05_st)
-    .set_num_inputs(6)
+    .set_num_inputs(7)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 

--- a/src/cuda/op/builtin.cc
+++ b/src/cuda/op/builtin.cc
@@ -416,12 +416,12 @@ TIR_DEFINE_TL_BUILTIN(tcgen05_mma_arrive)
                                Integer(CallEffectKind::kOpaque));
 
 TIR_DEFINE_TL_BUILTIN(tcgen05_ld)
-    .set_num_inputs(7)
+    .set_num_inputs(-1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 
 TIR_DEFINE_TL_BUILTIN(tcgen05_st)
-    .set_num_inputs(7)
+    .set_num_inputs(-1)
     .set_attr<TCallEffectKind>("TCallEffectKind",
                                Integer(CallEffectKind::kOpaque));
 

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -395,9 +395,21 @@ cute::Layout TmemTileToB32Columns(const cute::Layout &tile,
 // of the buffer's layout, so it is decided on the WHOLE fragment -- a
 // Region slice of a batched buffer also leaves codomain gaps, but those
 // are batch gaps, not half-filled columns.
+// So ask exactly that, per datapath the fragment actually touches: a full
+// tile holds one value in each column of each of them.  Comparing size to
+// the whole codomain instead would also count gaps on the DATAPATH axis,
+// which a PTX Layout F fragment (1SM M=64, only the low 16 datapaths of
+// each sub-partition) has in abundance -- that would emit the modifier for
+// a tile whose columns are perfectly full.
 bool TmemFragmentNeedsPack16b(const cute::Layout &fragment) {
-  return cute::AsConst(cute::Size(fragment)) !=
-         cute::AsConst(cute::Cosize(fragment));
+  static const cute::Layout kDpOnly = cute::Layout::Parse("(1,1):(1,0)");
+  static const cute::Layout kColOnly = cute::Layout::Parse("(1,1):(0,1)");
+  // Filter drops the stride-0 modes, leaving the datapaths really occupied.
+  int64_t datapaths = cute::AsConst(
+      cute::Size(cute::Filter(cute::Composition(kDpOnly, fragment))));
+  int64_t columns =
+      cute::AsConst(cute::Cosize(cute::Composition(kColOnly, fragment)));
+  return cute::AsConst(cute::Size(fragment)) < datapaths * columns;
 }
 
 } // namespace
@@ -642,7 +654,9 @@ LayoutMap Copy::InferTMemLayout(const CopyNode &op,
     // its value-column planning: the plain instruction moves whole columns
     // of packed pairs.
     int64_t values_per_b32 = 32 / (tmem_buf->dtype.bits());
-    if (values_per_b32 > 1 && TmemFragmentNeedsPack16b(tmem_frag.value()))
+    bool pack16b_tile =
+        values_per_b32 > 1 && TmemFragmentNeedsPack16b(tmem_frag.value());
+    if (pack16b_tile)
       tile = TmemTileToB32Columns(tile, values_per_b32);
 
     // The register buffer is a grid of such slices (a split epilogue issues
@@ -676,8 +690,18 @@ LayoutMap Copy::InferTMemLayout(const CopyNode &op,
       // region-local coord -> (thread@0, value@1)
       // E.g., local_frag = (128,64):(1@0,1@1) for 32dp32b, 128 threads
       //       (thread = datapath, value = column within the slice).
-      Tcgen05CopyPlan expanded = ExpandTcgen05Layout(GetTcgen05MetaLd32Dp32B(),
-                                                     tile, num_useful_threads);
+      int64_t values_per_column = pack16b_tile ? 1 : values_per_b32;
+      Tcgen05CopyPlan expanded =
+          ExpandTcgen05Layout(GetTcgen05MetaLd32Dp32B(), tile,
+                              num_useful_threads, values_per_column);
+      // A PTX Layout F tile (1SM M=64) occupies only the low 16 datapaths of
+      // each sub-partition, so no full-width atom can tile it.  Fall back to
+      // the narrowest half-subpartition atom, which plays the same role there
+      // that 32dp32b plays above: LowerTmem searches its candidates for the
+      // one whose fragment matches whatever this picked.
+      if (!expanded.defined())
+        expanded = ExpandTcgen05Layout(GetTcgen05MetaLd16Dp64B(), tile,
+                                       num_useful_threads, values_per_column);
       if (!expanded.defined()) {
         continue;
       }
@@ -1539,8 +1563,8 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
          num_useful_wgs--) {
       int num_useful_threads = num_useful_wgs * WARPGROUP_SIZE;
       // region-local loop coord -> (thread@0, value@1)
-      Tcgen05CopyPlan plan =
-          ExpandTcgen05Layout(meta, tile, num_useful_threads);
+      Tcgen05CopyPlan plan = ExpandTcgen05Layout(meta, tile, num_useful_threads,
+                                                 pack16b ? 1 : values_per_b32);
       if (!plan.defined()) {
         continue;
       }
@@ -1638,6 +1662,8 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
         args.push_back(Bool(use_pack_unpack_modifier));
         args.push_back(BufferLoad(tmem_buf, issue_tmem_indices));
         args.push_back(col_offset);
+        args.push_back(IntImm(DataType::Int(32),
+                              static_cast<int>(plan->datapaths_per_warp)));
         args.push_back(reg_buf.access_ptr(
             /*access_mask=*/is_ld ? 2 : 1, DataType::Handle(),
             /*content_lanes=*/1, /*offset=*/issue_reg_offset,

--- a/src/cuda/op/copy.cc
+++ b/src/cuda/op/copy.cc
@@ -367,12 +367,9 @@ MakeTMARows(const Buffer &src, const Array<Range> &src_ranges,
   return std::make_pair(Array<Stmt>{for_loop}, extent * body_cnt);
 }
 
-// CuTe's make_tmem_copy works in the tensor's value width by upcasting the
-// atom's ValID (copy_traits_sm100.hpp:300).  Our tiles already address
-// (datapath@0, value-column@1), so the same unit change is one composition
-// with the value -> storage column map ((1),(vpb,1)):((1@0),(0,1@1)):
-// b32 column = value column / vpb, the sub-slot position dropping onto the
-// stride-0 mode (exactly CuTe upcast's shape-division, layout.hpp:1809).
+// Recast a (datapath, value-column) tile to b32 columns (CuTe upcast on the
+// column axis): b32 column = value column / values_per_b32, the sub-slot
+// position dropping onto a stride-0 mode.
 cute::Layout TmemTileToB32Columns(const cute::Layout &tile,
                                   int64_t values_per_b32) {
   cute::Layout value_to_b32 =
@@ -382,29 +379,14 @@ cute::Layout TmemTileToB32Columns(const cute::Layout &tile,
   return cute::Composition(value_to_b32, tile);
 }
 
-// A 16-bit fragment that needs the tcgen05.ld/st pack::16b / unpack::16b
-// modifiers does not cover its codomain: every value column is half-filled,
-// so size < cosize.  This is the accumulator format the MMA hardware writes
-// -- PTX ISA "Packing format for matrix D in Tensor Memory"
-// (9.7.17.10.4.1): a 16-bit matrix D element occupies the lower 16 bits of
-// its own 32-bit tensor-memory word (CUTLASS FrgTypeC's
-// StorageType=uint32_t / ValueType=half) -- and pack::16b is how tcgen05.ld
-// gathers those low halves (two adjacent words per register).  A fragment
-// with two values packed per b32 column is a bijection onto its footprint
-// and moves with the plain instruction.  The storage format is a property
-// of the buffer's layout, so it is decided on the WHOLE fragment -- a
-// Region slice of a batched buffer also leaves codomain gaps, but those
-// are batch gaps, not half-filled columns.
-// So ask exactly that, per datapath the fragment actually touches: a full
-// tile holds one value in each column of each of them.  Comparing size to
-// the whole codomain instead would also count gaps on the DATAPATH axis,
-// which a PTX Layout F fragment (1SM M=64, only the low 16 datapaths of
-// each sub-partition) has in abundance -- that would emit the modifier for
-// a tile whose columns are perfectly full.
+// Whether a 16-bit fragment stores one value per b32 word (the low half:
+// the MMA accumulator format, PTX "Packing format for matrix D in Tensor
+// Memory") and so needs the tcgen05 pack::16b/unpack::16b modifiers.  Its
+// columns are then half-filled: size < occupied datapaths * column cosize.
+// Decided on the WHOLE fragment (storage is a property of the buffer);
+// counting only occupied datapaths keeps Layout F's datapath gaps from
+// looking like holes.
 bool TmemFragmentNeedsPack16b(const cute::Layout &fragment) {
-  static const cute::Layout kDpOnly = cute::Layout::Parse("(1,1):(1,0)");
-  static const cute::Layout kColOnly = cute::Layout::Parse("(1,1):(0,1)");
-  // Filter drops the stride-0 modes, leaving the datapaths really occupied.
   int64_t datapaths = cute::AsConst(
       cute::Size(cute::Filter(cute::Composition(kDpOnly, fragment))));
   int64_t columns =
@@ -600,16 +582,14 @@ void Copy::CheckParallelLoopLayout(const CopyNode &op, CopyInst copy_inst) {
 }
 
 // Infer the register Fragment of a TMEM<->fragment copy from the TMEM
-// buffer's inferred layout, so that the copy later lowers to one
-// tcgen05.ld/st (LowerTmem below).
+// buffer's layout, so the copy lowers to tcgen05.ld/st (LowerTmem below).
 //
-// Running example used throughout (a split epilogue reading one accumulator
-// in two halves with 128 threads):
+// Running example (a split epilogue reading one accumulator in two halves,
+// 128 threads):
 //   C_tmem  = alloc_tmem((128, 128), f32), fragment (128,128):(1@0,1@1)
-//             (@0 = TMEM datapath axis, @1 = TMEM column axis)
 //   C_local = alloc_fragment((128, 128), f32)
 //   T.copy(C_tmem[:, 0:64],   C_local[:, 0:64])    <- this op
-//   T.copy(C_tmem[:, 64:128], C_local[:, 64:128])  <- a later op, same result
+//   T.copy(C_tmem[:, 64:128], C_local[:, 64:128])  <- later op, same result
 LayoutMap Copy::InferTMemLayout(const CopyNode &op,
                                 const LayoutInferArgs &layout_args,
                                 CopyInst copy_inst) {
@@ -623,36 +603,28 @@ LayoutMap Copy::InferTMemLayout(const CopyNode &op,
       layout_args.layout_map.count(tmem_buf)) {
     Layout tmem_layout = layout_args.layout_map[tmem_buf];
 
-    // logical buffer coord -> physical TMEM (datapath@0, column@1)
-    // E.g., tmem_frag = (128,128):(1@0,1@1)
+    // tmem_frag: logical buffer coord -> physical TMEM (datapath@0,
+    //   column@1).
+    //   E.g. (128,128):(1@0,1@1).
     Optional<cute::Layout> tmem_frag =
         cute::LayoutFromTileLangHierarchical(tmem_layout);
     ICHECK(tmem_frag.defined())
         << "TMEM layout of " << tmem_buf->name
         << " is not decodable by the CuTe analyzer: " << tmem_layout;
 
-    // As in CuTe's make_tmem_copy, the tiled copy is described relative to
-    // the Region origin: cute::Restrict splits the fragment into origin +
-    // tile, where the (possibly dynamic) origin only moves the tcgen05_ld/st
-    // base address and the static tile maps region-local coordinates to
-    // (datapath, column) steps.  Leading batch modes of a rank>2 buffer ride
-    // in the tile like any other mode (the fragment repeats them along
-    // columns).
-    // region-local coord -> (datapath, column) step from the origin
-    // E.g., origin = (0,0),  tile = (128,64):(1@0,1@1)
-    //       (the second copy differs only in origin = (0,64))
+    // cute::Restrict splits the fragment into Region origin + tile: the
+    // (possibly dynamic) origin only moves the base address.
+    // tile: region-local coord -> (datapath, column) step from the origin.
+    //   E.g. origin = (0,0), tile = (128,64):(1@0,1@1); the second copy
+    //   differs only in origin = (0,64).
     const Array<Range> &tmem_ranges =
         is_tmem_load ? op.src_range : op.dst_range;
     const Array<Range> &reg_ranges = is_tmem_load ? op.dst_range : op.src_range;
     cute::Layout tile = cute::Restrict(tmem_frag.value(), tmem_ranges).get<1>();
 
-    // A pack::16b tile (one value per b32 storage slot, CUTLASS FrgTypeC)
-    // is planned in b32 columns -- the CuTe upcast make_tmem_copy applies
-    // to ValID.  Shapes are untouched, so the fragment's logical
-    // coordinates and value order carry over unchanged (b32 column j holds
-    // exactly value j).  A 16-bit tile with two values per b32 column keeps
-    // its value-column planning: the plain instruction moves whole columns
-    // of packed pairs.
+    // A pack::16b tile is planned in b32 columns (shapes untouched: b32
+    // column j holds exactly value j); a packed-pair tile keeps value
+    // columns and moves whole columns with the plain instruction.
     int64_t values_per_b32 = 32 / (tmem_buf->dtype.bits());
     bool pack16b_tile =
         values_per_b32 > 1 && TmemFragmentNeedsPack16b(tmem_frag.value());
@@ -661,7 +633,7 @@ LayoutMap Copy::InferTMemLayout(const CopyNode &op,
 
     // The register buffer is a grid of such slices (a split epilogue issues
     // one copy per slice), each appending its own registers.
-    // E.g., nrep = (1, 2): two column halves.
+    // E.g. nrep = (1, 2): two column halves.
     size_t rank = reg_ranges.size();
     Array<int64_t> nrep;
     int64_t total_reps = 1;
@@ -687,18 +659,15 @@ LayoutMap Copy::InferTMemLayout(const CopyNode &op,
     for (int num_useful_wgs = num_threads / WARPGROUP_SIZE; num_useful_wgs >= 1;
          --num_useful_wgs) {
       int num_useful_threads = num_useful_wgs * WARPGROUP_SIZE;
-      // region-local coord -> (thread@0, value@1)
-      // E.g., local_frag = (128,64):(1@0,1@1) for 32dp32b, 128 threads
-      //       (thread = datapath, value = column within the slice).
+      // local_frag: region-local coord -> (thread@0, value@1).
+      //   E.g. (128,64):(1@0,1@1) for 32dp32b, 128 threads.
       int64_t values_per_column = pack16b_tile ? 1 : values_per_b32;
       Tcgen05CopyPlan expanded =
           ExpandTcgen05Layout(GetTcgen05MetaLd32Dp32B(), tile,
                               num_useful_threads, values_per_column);
-      // A PTX Layout F tile (1SM M=64) occupies only the low 16 datapaths of
-      // each sub-partition, so no full-width atom can tile it.  Fall back to
-      // the narrowest half-subpartition atom, which plays the same role there
-      // that 32dp32b plays above: LowerTmem searches its candidates for the
-      // one whose fragment matches whatever this picked.
+      // A Layout F tile occupies only the low 16 datapaths per
+      // sub-partition, which no full-width atom can tile; fall back to the
+      // narrowest half-subpartition atom.
       if (!expanded.defined())
         expanded = ExpandTcgen05Layout(GetTcgen05MetaLd16Dp64B(), tile,
                                        num_useful_threads, values_per_column);
@@ -710,18 +679,13 @@ LayoutMap Copy::InferTMemLayout(const CopyNode &op,
           cute::AsConst(cute::Size(local_frag)) / num_useful_threads;
 
       // Repeat the slice along the value vector to cover the whole register
-      // buffer: each further slice appends one slice's worth of registers
-      // per thread (row-major slice grid, matching the buffer's row-major
-      // element order), so every slice of a split copy lands in its own
-      // value range of one full-buffer Fragment.  Unit-extent region dims
-      // (dropped by Restrict) carry only their repetition mode.
-      // per-dim slice index -> value@1
-      // E.g., rep_grid = Composition(2:64@1, (1,2):(2,1)) = (1,2):(128@1,64@1)
-      //       full mode 1 pairs the slice's column mode with its repetition:
-      //       full = ((128,1),(64,2)):((1@0,128@1),(1@1,64@1))
-      //       so C_local[i, 64+j] -> thread i, value 64+j: the second copy's
-      //       64 registers per thread follow the first's, and the layout is
-      //       identical no matter which half inferred it.
+      // buffer (row-major slice grid): each further slice appends one
+      // slice's worth of registers per thread, so both halves of a split
+      // copy infer the same full-buffer Fragment.  Unit-extent region dims
+      // carry only their repetition mode.
+      // rep_grid: per-dim slice index -> value@1.
+      //   E.g. (1,2):(128@1,64@1) -- the second half's 64 registers per
+      //   thread follow the first's.
       cute::Layout rep_grid = cute::Composition(
           cute::Layout(total_reps, vals_per_slice * cute::E({1})),
           cute::MakeRowMajorLayout(nrep));
@@ -738,7 +702,7 @@ LayoutMap Copy::InferTMemLayout(const CopyNode &op,
       ICHECK_EQ(tile_idx, cute::Rank(tile))
           << "TMEM copy tile rank does not match the register loop rank";
 
-      // full buffer coord -> (thread@0, value@1)
+      // logical_coord2frag: full buffer coord -> (thread@0, value@1).
       Fragment logical_coord2frag = FragmentToTileLang(cute::MakeLayout(modes));
       results.Set(reg_buf, logical_coord2frag->BindThreadRange(
                                layout_args.thread_bounds));
@@ -1363,10 +1327,9 @@ Stmt Copy::LowerLDSM(const CopyNode &op, const LowerArgs &lower_args,
 
 namespace {
 
-// Unpack a (datapath, column) coordinate IntTuple produced by evaluating a
-// TMEM cute fragment into exactly two scalar expressions.  Adding the rank-2
-// zero ArithmeticTuple first normalizes the coordinate: an axis the layout
-// never touches materializes as a plain zero slot.
+// Unpack a (datapath, column) coordinate IntTuple into two scalar
+// expressions; adding the rank-2 zero first materializes an axis the layout
+// never touches as a plain zero.
 Array<PrimExpr> TmemCoordExprs(const cute::IntTuple &coord) {
   DataType dtype = DataType::Int(32);
   cute::IntTuple normalized = coord + cute::IntTupleTuple({0, 0});
@@ -1379,21 +1342,16 @@ Array<PrimExpr> TmemCoordExprs(const cute::IntTuple &coord) {
 
 } // namespace
 
-// Lower a TMEM<->fragment copy to one tcgen05.ld/st call.
+// Lower a TMEM<->fragment copy to tcgen05.ld/st calls.
 //
-// Running example (the same split epilogue as InferTMemLayout, lowering its
-// SECOND half so the Region origin is nonzero):
-//   C_tmem  = alloc_tmem((128, 128), f32), fragment (128,128):(1@0,1@1)
-//   C_local = alloc_fragment((128, 128), f32), 128 threads, whose inferred
-//             Fragment is full_tv = ((128,1),(64,2)):((1@0,128@1),(1@1,64@1))
+// Running example (the SECOND half of InferTMemLayout's split epilogue, so
+// the Region origin is nonzero):
 //   T.copy(C_tmem[:, 64:128], C_local[:, 64:128])
 //
-// The instruction pattern (which threads move which (datapath, column)) is
-// static and validated against the register Fragment; the Region origin only
-// selects WHERE: it becomes the tcgen05_ld/st base-address token
-// (LowerSharedTmem later encodes it as datapath<<16 | b32column), so a
-// dynamic origin -- e.g. a software-pipeline stage index -- just moves the
-// base address.
+// The instruction pattern is static and validated against the register
+// Fragment; the (possibly dynamic) Region origin only becomes the
+// tcgen05_ld/st base-address token (datapath<<16 | b32column in
+// LowerSharedTmem).
 Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
                      arith::Analyzer *analyzer) {
   const Buffer &src = op.src;
@@ -1471,21 +1429,16 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
   Array<PrimExpr> reg_logical_indices =
       op.MakeIndices(loop_vars, 1 - tmem_side);
 
-  // logical buffer coord -> physical TMEM (datapath@0, column@1)
+  // tmem_frag: logical buffer coord -> physical TMEM (datapath@0, column@1).
   Optional<cute::Layout> tmem_frag =
       cute::LayoutFromTileLangHierarchical(tmem_layout);
   ICHECK(tmem_frag.defined())
       << "TMEM layout of " << tmem_buf->name
       << " is not decodable by the CuTe analyzer: " << tmem_layout;
 
-  // As in CuTe's make_tmem_copy, describe the tiled copy relative to the
-  // Region origin: cute::Restrict splits the fragment into origin + tile,
-  // where the origin — which may be dynamic, for example a software-pipeline
-  // stage — only moves the base address carried by the tcgen05_ld/st address
-  // token, and the static tile maps the region-local loop coordinates to
-  // (datapath, column) steps.
-  // region-local coord -> (datapath, column) step from the origin
-  // E.g., phy_origin = (0, 64),  tile = (128,64):(1@0,1@1)
+  // As in InferTMemLayout, split the fragment into Region origin + tile.
+  // tile: region-local coord -> (datapath, column) step from the origin.
+  //   E.g. phy_origin = (0,64), tile = (128,64):(1@0,1@1).
   const Array<Range> &tmem_ranges =
       tmem_side == 0 ? op.src_range : op.dst_range;
   auto restricted = cute::Restrict(tmem_frag.value(), tmem_ranges);
@@ -1494,17 +1447,11 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
   ICHECK_EQ(cute::Rank(tile), static_cast<int64_t>(loop_vars.size()))
       << "TMEM copy tile rank does not match the copy loop rank";
 
-  // 16-bit values in 32-bit TMEM columns come in two layouts (see
-  // InferTMemLayout):
-  //  * pack::16b / unpack::16b (one value in the low half of each word,
-  //    CUTLASS FrgTypeC): plan on the b32-upcast tile; the modifier's
-  //    registers gather the low halves of two ADJACENT b32 columns
-  //    (Copy_Traits<*_16b> ValID) -- one register per two columns;
-  //  * two values packed per b32 column: plan in value columns and move
-  //    whole columns of packed pairs with the PLAIN instruction -- one
-  //    register per column, i.e. per two values.
-  // Either way one register covers two values, so the wrapper's N is half
-  // the planned chunk count.
+  // 16-bit values come in two layouts (TmemFragmentNeedsPack16b): pack::16b
+  // plans on the b32-upcast tile (one register gathers two adjacent
+  // columns' low halves); packed pairs plan in value columns (one register
+  // per column).  Either way one register covers two values, so the
+  // wrapper's N is half the planned chunk count.
   int64_t values_per_b32 = 32 / (tmem_buf->dtype.bits());
   bool pack16b =
       values_per_b32 > 1 && TmemFragmentNeedsPack16b(tmem_frag.value());
@@ -1522,10 +1469,8 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
 
   size_t tmem_rank = tmem_buf->shape.size();
 
-  // The address token below is the Region's logical origin across all buffer
-  // modes (leading batch modes are pinned by the Region).  LowerTileOp
-  // materializes the buffer's layout over it, so no separate origin
-  // adjustment is needed here.
+  // The address token below is the Region's logical origin; LowerTileOp
+  // materializes the buffer's layout over it.
   Map<Var, PrimExpr> loop_to_origin;
   for (const auto &iv : loop_vars) {
     loop_to_origin.Set(iv->var, iv->dom->min);
@@ -1562,7 +1507,7 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
     for (int num_useful_wgs = num_threads / WARPGROUP_SIZE; num_useful_wgs >= 1;
          num_useful_wgs--) {
       int num_useful_threads = num_useful_wgs * WARPGROUP_SIZE;
-      // region-local loop coord -> (thread@0, value@1)
+      // plan: region-local loop coord -> (thread@0, value@1).
       Tcgen05CopyPlan plan = ExpandTcgen05Layout(meta, tile, num_useful_threads,
                                                  pack16b ? 1 : values_per_b32);
       if (!plan.defined()) {
@@ -1570,20 +1515,15 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
       }
       int num_chunks_each_wg = static_cast<int>(plan->num_chunks_each_wg);
 
-      // The single conversion to a TileLang Fragment happens only on this
-      // final composed layout.
-      // E.g., fragment = (128,64):(1@0,1@1): loop (i, j) -> thread i,
-      //       value j.
+      // target_frag: loop coord -> (thread@0, value@1), the single
+      //   conversion to a TileLang Fragment.
+      //   E.g. (128,64):(1@0,1@1).
       Fragment target_frag = FragmentToTileLang(plan->fragment);
 
-      // The instruction's pattern must agree with the register buffer's
-      // Fragment on this Region, up to the Region's base register -- like
-      // the TMEM origin, that base may be dynamic (e.g. a serial slice
-      // loop) and only offsets the register pointer below.
-      // E.g., reg_layout maps C_local[i, 64+j] -> thread i, value 64+j, so
-      //       reg_thread == target_thread == i, and reg_val == 64+j with
-      //       reg_origin = 64: the instruction covers registers 64..127 of
-      //       each thread, and the access_ptr below starts at offset 64.
+      // The pattern must agree with the register Fragment up to the
+      // Region's (possibly dynamic) base register, which only offsets the
+      // register pointer below.
+      // E.g. reg_val == 64+j with reg_origin = 64: registers 64..127.
       PrimExpr target_thread =
           target_frag->ForwardThread(loop_exprs, std::nullopt);
       PrimExpr reg_thread =
@@ -1600,17 +1540,14 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
       }
 
       bool use_pack_unpack_modifier = pack16b;
-      // One register covers two 16-bit values -- pack::16b spans two b32
-      // columns, a packed pair shares one -- so the wrapper's N is half the
-      // planned chunk count (N is always a power of two).
+      // One register covers two 16-bit values, so N halves.
       int effective_chunks =
           needs_pack_unpack ? num_chunks_each_wg / 2 : num_chunks_each_wg;
       PrimExpr relative_wg_idx =
           FloorDiv(Sub(lower_args.thread_index, lower_args.thread_bounds->min),
                    WARPGROUP_SIZE);
-      // Column offsets are raw b32 columns: a pack::16b tile's chunk count
-      // already is b32 columns, a packed-pair tile's is halved (planned in
-      // value columns, two per b32).
+      // Column offsets are raw b32 columns: pack::16b already counts b32
+      // columns, a packed-pair count halves (two value columns per b32).
       int chunk_cols =
           pack16b ? num_chunks_each_wg * width : effective_chunks * width;
       PrimExpr col_offset = num_useful_threads == WARPGROUP_SIZE
@@ -1619,17 +1556,12 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
       int64_t vals_per_issue = plan->vals_per_issue;
       have_succeeded = true;
 
-      // One tcgen05 call per issue (rest coordinate): a gapped tile copies
-      // one contiguous chunk at a time.  Issue r starts at the region-local
-      // logical coords idx2crd(rest_domain(r)) -- decoded column-major over
-      // the loop extents -- and appends vals_per_issue registers per
-      // thread after the previous issues'.
-      // E.g., the running example (one issue) emits
+      // One tcgen05 call per issue: issue r starts at the region-local
+      // coords idx2crd(rest_domain(r)) and appends vals_per_issue registers
+      // per thread.
+      // E.g. the running example (one issue) emits
       //   tl::tcgen05_ld_32dp32bNx<64, false>(C_tmem[0, 64], 0,
       //                                       &C_local[64]);
-      // where the C_tmem[0, 64] token becomes base + (0<<16 | 64) in
-      // LowerSharedTmem, and &C_local[64] is the per-thread register slice
-      // at offset reg_origin.
       Array<Stmt> calls;
       Buffer orig_reg_buf = is_ld ? op.dst : op.src;
       for (int64_t issue = 0; issue < plan->num_issues; ++issue) {
@@ -1645,11 +1577,9 @@ Stmt Copy::LowerTmem(const CopyNode &op, const LowerArgs &lower_args,
             tmem_logical_indices.Map([&](const PrimExpr &index) {
               return analyzer->Simplify(Substitute(index, loop_to_issue));
             });
-        // The access_ptr offset is a LOGICAL linear offset: LowerTileOp's
-        // HandleAccessPtrAndOffset later decodes it over the register
-        // buffer's logical shape and maps it through the Fragment to the
-        // per-thread register index.  Linearize the issue's register origin
-        // row-major over the buffer shape.
+        // The access_ptr offset is a LOGICAL linear offset (row-major over
+        // the buffer shape); LowerTileOp later maps it through the Fragment
+        // to the per-thread register index.
         PrimExpr issue_reg_offset = IntImm(DataType::Int(32), 0);
         for (size_t d = 0; d < reg_logical_indices.size(); ++d) {
           issue_reg_offset = issue_reg_offset * orig_reg_buf->shape[d] +

--- a/src/layout/tcgen05_layout.cc
+++ b/src/layout/tcgen05_layout.cc
@@ -2,21 +2,17 @@
  * \file layout/tcgen05_layout.cc
  * \brief tcgen05.ld/st data-movement shapes as CuTe TV atoms.
  *
- * Each atom below is the CUTLASS ``Copy_Traits<SM100_TMEM_LOAD_*>`` TV
- * layout (cute/atom/copy_traits_sm100.hpp) written over (datapath, b32
- * column) coordinates, cross-checked against the PTX data-movement-shape
- * figures
+ * Each atom is the CUTLASS ``Copy_Traits<SM100_TMEM_LOAD_*>`` TV layout
+ * over (datapath, b32 column), matching the PTX data-movement shapes
  * (https://docs.nvidia.com/cuda/parallel-thread-execution/#tcgen05-memory-layout).
- * Loads and stores share one data-movement shape per width.
+ * Loads and stores share one shape per width.
  */
 
 #include "support/check.h"
 #include <algorithm>
-#include <array>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/tirx/op.h>
 #include <tvm/tirx/stmt_functor.h>
-#include <vector>
 
 #include "layout.h"
 #include "tcgen05_layout.h"
@@ -27,6 +23,9 @@ namespace tl {
 using namespace tirx;
 using tvm::ffi::Array;
 
+const cute::Layout kDpOnly = cute::Layout::Parse("(1,1):(1,0)");
+const cute::Layout kColOnly = cute::Layout::Parse("(1,1):(0,1)");
+
 namespace {
 
 IterVar MakeIterVar(std::string name, Range dom) {
@@ -34,19 +33,17 @@ IterVar MakeIterVar(std::string name, Range dom) {
   return IterVar(dom, var, IterVarType::kDataPar);
 }
 
-// The atoms are the CUTLASS ``Copy_Traits<...1x>`` TV layouts verbatim
-// (DstLayout over ValID, upcast to b32), written in CuTe spelling over the
-// physical coordinate axes, axis 0 = datapath ("@0"), axis 1 = b32 column
-// ("@1").  Each covers exactly one PTX issue of one warp: the 32x32b shape
-// fills the warp's whole 32-datapath sub-partition, the 16x shapes only its
-// low 16 datapaths.  ExpandTcgen05Layout replicates them over warps, the
-// high-datapath duplicate issue, .xN repetitions, and warpgroups purely by
-// layout algebra.
+// kSerialize: (datapath, column) -> serialized TMEM, the flat address
+// datapath + 128 * column.
+const cute::Layout kSerialize = cute::Layout::Parse("(1,1):(1,128)");
+
+// The atoms are the CUTLASS ``Copy_Traits<...1x>`` TV layouts, written over
+// axis 0 = datapath ("@0"), axis 1 = b32 column ("@1").  Each covers one
+// PTX issue of one warp.
 
 Tcgen05Meta MakeTcgen05Meta_32dp32b(bool is_store) {
-  // PTX 32x32b (Copy_Traits 32dp32b1x, ValID (32,32):(1,DP_b)): lane t ->
-  // datapath t; one register on one column per repetition, and the wrapper
-  // chaining extends repetitions exactly, so any N is legal.
+  // PTX 32x32b: lane t -> datapath t; one register on one column per
+  // repetition; wrapper chaining extends repetitions exactly, so any N.
   return Tcgen05Meta(is_store ? "tl::tcgen05_st_32dp32bNx"
                               : "tl::tcgen05_ld_32dp32bNx",
                      cute::Layout::Parse("(32,1):(1@0,0)"),
@@ -54,9 +51,8 @@ Tcgen05Meta MakeTcgen05Meta_32dp32b(bool is_store) {
 }
 
 Tcgen05Meta MakeTcgen05Meta_16dp64b(bool is_store) {
-  // PTX 16x64b (Copy_Traits 16dp64b1x, DstLayout ((2,2,8),32):((512,32,64),1)
-  // over ValID (64,16):(1,DP_b)): lane t -> datapath 8*(t%2) + t/4, column
-  // (t/2)%2; one register per issue.
+  // PTX 16x64b: lane t -> datapath 8*(t%2) + t/4, column (t/2)%2; one
+  // register per repetition.
   return Tcgen05Meta{is_store ? "tl::tcgen05_st_32dp64bNx"
                               : "tl::tcgen05_ld_32dp64bNx",
                      cute::Layout::Parse("((2,2,8),1):((8@0,1@1,1@0),0)"),
@@ -64,9 +60,8 @@ Tcgen05Meta MakeTcgen05Meta_16dp64b(bool is_store) {
 }
 
 Tcgen05Meta MakeTcgen05Meta_16dp128b(bool is_store) {
-  // PTX 16x128b (Copy_Traits 16dp128b1x, DstLayout ((4,8),(32,2)):
-  // ((32,128),(1,1024)) over ValID (128,16):(1,DP_b)): lane t -> column t%4,
-  // datapath t/4; two registers stepping the 8-datapath half.
+  // PTX 16x128b: lane t -> datapath t/4, column t%4; two registers stepping
+  // the 8-datapath half.
   return Tcgen05Meta{is_store ? "tl::tcgen05_st_32dp128bNx"
                               : "tl::tcgen05_ld_32dp128bNx",
                      cute::Layout::Parse("((4,8),2):((1@1,1@0),8@0)"),
@@ -74,9 +69,8 @@ Tcgen05Meta MakeTcgen05Meta_16dp128b(bool is_store) {
 }
 
 Tcgen05Meta MakeTcgen05Meta_16dp256b(bool is_store) {
-  // PTX 16x256b (Copy_Traits 16dp256b1x, DstLayout ((4,8),(64,2)):
-  // ((64,256),(1,2048)) over ValID (256,16):(1,DP_b)): lane t -> column
-  // 2*(t%4), datapath t/4; four registers as (adjacent column, 8-datapath).
+  // PTX 16x256b: lane t -> datapath t/4, column 2*(t%4); four registers as
+  // (adjacent column, 8-datapath half).
   return Tcgen05Meta{is_store ? "tl::tcgen05_st_32dp256bNx"
                               : "tl::tcgen05_ld_32dp256bNx",
                      cute::Layout::Parse("((4,8),(2,2)):((2@1,1@0),(1@1,8@0))"),
@@ -120,17 +114,11 @@ Tcgen05Meta GetTcgen05MetaSt16Dp256B() {
   return MakeTcgen05Meta_16dp256b(true);
 }
 
-// Project one physical axis through the TV atom (keep that axis's basis
-// strides, zero the other) and measure the footprint.  The datapath extent
-// determines the wrapper's duplication factor; the column extent is the
-// width of one .x1 repetition.
 int64_t Tcgen05AtomDatapaths(const Tcgen05Meta &meta) {
-  static const cute::Layout kDpOnly = cute::Layout::Parse("(1,1):(1,0)");
   return cute::AsConst(cute::Cosize(cute::Composition(kDpOnly, meta->tv)));
 }
 
 int64_t Tcgen05AtomWidth(const Tcgen05Meta &meta) {
-  static const cute::Layout kColOnly = cute::Layout::Parse("(1,1):(0,1)");
   return cute::AsConst(cute::Cosize(cute::Composition(kColOnly, meta->tv)));
 }
 
@@ -174,140 +162,73 @@ Tcgen05CopyPlan ExpandTcgen05Layout(const Tcgen05Meta &meta,
   ICHECK_GE(values_per_column, 1);
   int num_wgs = num_threads / WARPGROUP_SIZE;
 
-  // Serialize (datapath, column) into the flat address datapath + 128*column
-  // so everything below is algebra over one codomain.
-  // serialized_tmem_tile: logical tile -> serialized TMEM
-  // E.g., serialized_tmem_tile = (3,128,64):(16384,1,128)
-  static const cute::Layout kSerialize = cute::Layout::Parse("(1,1):(1,128)");
-
-  // How much of a warp's 32-lane sub-partition one warp covers is a property
-  // of the TILE.  On the datapath axis alone a dense fragment runs 128 before
-  // its first gap, a PTX Layout F fragment (1SM M=64) exactly 16.  A warp owns
-  // 32, so clamp there and let the atom divide what is left -- an atom too
-  // wide for the run (32dp32b against Layout F) falls out as a non-division.
-  // Projecting the columns away also makes this independent of whether they
-  // count values or b32 slots.
-  static const cute::Layout kDpOnly = cute::Layout::Parse("(1,1):(1,0)");
+  // The TILE decides the datapath split: its contiguous datapath run,
+  // clamped to one warp's 32 -- 32 for a dense tile, 16 for PTX Layout F
+  // (1SM M=64).  The atom must divide it; ndup duplicates the atom onto the
+  // high datapaths.
   const int64_t atom_datapaths = Tcgen05AtomDatapaths(meta);
   const int64_t dp_run = cute::AsConst(
       cute::Size(cute::RightInverse(cute::Composition(kDpOnly, tmem_tile))));
-  const int64_t dp_per_warp = dp_run < 32 ? dp_run : 32;
+  const int64_t dp_per_warp = std::min<int64_t>(dp_run, 32);
   if (dp_per_warp % atom_datapaths != 0)
     return Tcgen05CopyPlan(nullptr);
   const int64_t ndup = dp_per_warp / atom_datapaths;
   const int64_t dp_per_issue = 4 * dp_per_warp; // 128, or 64 for Layout F
   const bool partial_subpartition = dp_per_warp < 32;
 
+  // serialized_tmem_tile: logical tile -> (datapath, column) -> serialized
+  //   TMEM.
+  //   E.g. (3,128,64):(16384,1,128).
   cute::Layout serialized_tmem_tile = cute::Composition(kSerialize, tmem_tile);
-  int64_t size = cute::AsConst(cute::Size(serialized_tmem_tile));
+  const int64_t size = cute::AsConst(cute::Size(serialized_tmem_tile));
 
-  // One issue covers the tile's whole datapath footprint by one contiguous
-  // column run, so its logical footprint is read off the two projections
-  // separately -- a Layout F tile's gaps live on the datapath axis and never
-  // reach the column projection, so neither derivation needs a case split.
-  // Columns: the maximal contiguous run, inverted back into the flat logical
-  // domain.  inv_cols: column run -> flat logical tile.  E.g. 64:384.
-  static const cute::Layout kColOnly = cute::Layout::Parse("(1,1):(0,1)");
-  cute::Layout inv_cols =
-      cute::RightInverse(cute::Composition(kColOnly, tmem_tile));
-  int64_t cols_per_issue = cute::AsConst(cute::Size(inv_cols));
+  // One issue covers the whole datapath footprint by one contiguous column
+  // run, so the tile splits along the two projections.
+  // valid_dps:  datapath index -> datapath, Filter(kDpOnly o tmem_tile).
+  //   E.g. 128:1.
+  // valid_cols: column index -> column, Filter(kColOnly o tmem_tile).
+  //   E.g. (3,64):(128,1).
+  // issue_cols: per-issue column run -> column index,
+  //   RightInverse(valid_cols), the maximal contiguous run.
+  //   E.g. 64:3.
+  cute::Layout valid_dps = cute::Filter(cute::Composition(kDpOnly, tmem_tile));
+  cute::Layout valid_cols =
+      cute::Filter(cute::Composition(kColOnly, tmem_tile));
+  cute::Layout issue_cols = cute::RightInverse(valid_cols);
+  const int64_t num_dps = cute::AsConst(cute::Size(valid_dps));
+  const int64_t num_cols = cute::AsConst(cute::Size(valid_cols));
+  const int64_t cols_per_issue = cute::AsConst(cute::Size(issue_cols));
 
-  // Datapaths: collect the pure-datapath modes with their flat-domain
-  // weights, ascending by datapath stride so the footprint is enumerated in
-  // address order.  (dp stride, extent, weight) per mode.
-  cute::IntTuple flat_shape = cute::Flatten(tmem_tile->shape);
-  cute::IntTuple dp_strides =
-      cute::Flatten(cute::Composition(kDpOnly, tmem_tile)->stride);
-  cute::IntTuple col_strides =
-      cute::Flatten(cute::Composition(kColOnly, tmem_tile)->stride);
-  int64_t rank = cute::Rank(flat_shape);
-  std::vector<std::array<int64_t, 3>> dp_modes;
-  int64_t occupied_dps = 1;
-  for (int64_t i = 0, weight = 1; i < rank; ++i) {
-    if (!cute::IsConst(flat_shape[i]) || !cute::IsConst(dp_strides[i]) ||
-        !cute::IsConst(col_strides[i]))
-      return Tcgen05CopyPlan(nullptr);
-    int64_t extent = cute::AsConst(flat_shape[i]);
-    if (extent > 1 && cute::AsConst(dp_strides[i]) != 0) {
-      if (cute::AsConst(col_strides[i]) != 0) // a diagonal crosses both axes
-        return Tcgen05CopyPlan(nullptr);
-      dp_modes.push_back({cute::AsConst(dp_strides[i]), extent, weight});
-      occupied_dps *= extent;
-    }
-    weight *= extent;
-  }
-  // Four warps of dp_per_warp datapaths each must own the footprint exactly;
-  // a tile on fewer sub-partitions cannot drive a whole warpgroup.
-  if (occupied_dps != dp_per_issue)
+  // The four warps must own the datapath footprint exactly, the tile must
+  // be bijective onto (datapath, column), and the issues must tile the
+  // columns.
+  if (num_dps != dp_per_issue || num_dps * num_cols != size ||
+      num_cols % cols_per_issue != 0)
     return Tcgen05CopyPlan(nullptr);
-  std::stable_sort(dp_modes.begin(), dp_modes.end());
+  const int64_t num_issues = num_cols / cols_per_issue;
+  const int64_t elems_per_issue = dp_per_issue * cols_per_issue;
 
-  // chunk: issue-local (datapath footprint, column run) -> flat logical
-  // tile.  For a dense tile the footprint index IS the serialized address
-  // and this is exactly the maximal contiguous run right_inverse would
-  // find; for Layout F it also steps across the datapath gaps.
-  // E.g., chunk = 8192:3 (one whole batch entry).
-  Array<cute::IntTuple> chunk_shape, chunk_stride;
-  for (const auto &m : dp_modes) {
-    chunk_shape.push_back(cute::IntTuple(m[1]));
-    chunk_stride.push_back(cute::IntTuple(m[2]));
-  }
-  cute::IntTuple col_shape = cute::Flatten(inv_cols->shape);
-  cute::IntTuple col_stride = cute::Flatten(inv_cols->stride);
-  for (int64_t i = 0, r = cute::Rank(col_shape); i < r; ++i) {
-    chunk_shape.push_back(col_shape[i]);
-    chunk_stride.push_back(col_stride[i]);
-  }
-  cute::Layout chunk = cute::Coalesce(cute::Layout(chunk_shape, chunk_stride));
-
-  int64_t elems_per_issue = dp_per_issue * cols_per_issue;
-  if (size % elems_per_issue != 0)
-    return Tcgen05CopyPlan(nullptr);
-  int64_t num_issues = size / elems_per_issue;
-
-  // Divide the flat logical domain by the chunk; the rest mode locates each
-  // issue's origin (CuTe's tiled-copy rest iteration).
-  // rest_domain: issue -> flat logical tile origin
-  // E.g., rest_domain = 3:1 -> origins 0, 1, 2 (idx2crd: batch 0, 1, 2)
-  cute::Layout rest_domain =
-      num_issues == 1
-          ? cute::Layout(1, 0)
-          : cute::LogicalDivide(
-                cute::MakeColumnMajorLayout(cute::Size(tmem_tile)), chunk)[1];
-  if (cute::AsConst(cute::Size(rest_domain)) != num_issues)
-    return Tcgen05CopyPlan(nullptr);
-
-  // Instruction feasibility per issue.  The atom's column width and
-  // datapath extent come from its own algebra; a 16-datapath atom is issued
-  // twice per warp (low then high datapaths), so the whole per-warpgroup
-  // copy must stay one .xN issue for the wrapper's register order to hold.
-  // E.g., width = 1, ndup = 1, cols_per_issue = 64, num_chunks_each_wg = 64
-  int64_t width = Tcgen05AtomWidth(meta);
+  // Per-warpgroup instruction shape.
+  // E.g. width = 1, num_chunks_each_wg = 64.
+  const int64_t width = Tcgen05AtomWidth(meta);
   if (cols_per_issue % width != 0)
     return Tcgen05CopyPlan(nullptr);
-  int64_t total_chunks = cols_per_issue / width;
+  const int64_t total_chunks = cols_per_issue / width;
   if (total_chunks % num_wgs != 0)
     return Tcgen05CopyPlan(nullptr);
-  int num_chunks_each_wg = static_cast<int>(total_chunks / num_wgs);
+  const int64_t num_chunks_each_wg = total_chunks / num_wgs;
 
-  // The .xN the wrapper is actually handed: a partial sub-partition carries
-  // its sub-word packing as its own mode, so the repetitions are what remains.
-  // The full-datapath path plans in value columns and LowerTmem halves the
-  // count itself, so bound the planned count there -- never optimistic.
-  int64_t pack = partial_subpartition ? values_per_column : 1;
+  // The .xN the wrapper is handed: a partial sub-partition carries its
+  // sub-word packing as its own mode, so the repetitions are what remains
+  // (the full-datapath path plans in value columns; LowerTmem halves N).
+  const int64_t pack = partial_subpartition ? values_per_column : 1;
   if (num_chunks_each_wg % pack != 0)
     return Tcgen05CopyPlan(nullptr);
-  int64_t reps = num_chunks_each_wg / pack;
+  const int64_t reps = num_chunks_each_wg / pack;
 
-  // core chains a copy too big for one instruction by advancing ONE column
-  // and ONE register per repetition, exact only for an atom that is one of
-  // each -- 32dp32b, flagged by max_chunks == 0.  Every other atom must fit
-  // the per-warpgroup copy in a single .xN.  Lifting that needs the core
-  // parameterised by columns/registers per repetition AND the 32dp
-  // composites' nesting inverted so each half chains separately: fixing the
-  // strides alone still leaves a chained duplicate interleaved per segment
-  // instead of following all repetitions.  Until then a non-power-of-two .xN
-  // finds no plan (an M=64 bf16 operand at K = 96, 192 or 320).
+  // The wrapper chains an oversized copy one column and one register per
+  // repetition -- exact only for 32dp32b (max_chunks == 0).  Every other
+  // atom must fit one .xN: a power of two, at most max_chunks.
   if (meta->max_chunks != 0) {
     if (reps & (reps - 1)) // reps must be a power of two
       return Tcgen05CopyPlan(nullptr);
@@ -315,50 +236,68 @@ Tcgen05CopyPlan ExpandTcgen05Layout(const Tcgen05Meta &meta,
       return Tcgen05CopyPlan(nullptr);
   }
 
-  // The stamp: what ONE wrapper call covers.  Warps sit one sub-partition
-  // apart (32), a 16-datapath atom's duplicate issue on the high half of one
-  // (16), .xN repetitions a column group apart, warpgroups split the columns.
-  // The packed partner -- two sub-word values in one b32 column -- is the
-  // FASTEST value, one value column along, since a register's two halves are
-  // adjacent in the buffer; the atom addresses b32 columns, so its column step
-  // is `pack` value columns wide.  Spelled out rather than left to a blocked
-  // product's complement, whose fastest gap for Layout F is the *unoccupied*
-  // datapaths -- it would pack the warps in at stride 16.
-  // tiled: ((lane, (warp, wg)), (pack, reg, (rep, dup))) -> serialized TMEM
-  int64_t b32_col = 128 * pack;
+  // atom: (lane..., reg...) -> (datapath, column), the TV atom with its
+  //   column steps widened to `pack` value columns (the atom addresses b32
+  //   columns, the tile counts value columns).
+  //   E.g. (32,1):(1@0,0).
   cute::Layout atom = cute::Composition(
-      cute::Layout(Array<int64_t>{1, 1}, Array<int64_t>{1, b32_col}), meta->tv);
-  cute::Layout tiled = cute::MakeLayout(
-      {cute::MakeLayout(
-           {atom[0], cute::Layout(Array<int64_t>{4, num_wgs},
-                                  Array<int64_t>{32, b32_col * width * reps})}),
-       cute::MakeLayout(
-           {cute::Layout(Array<int64_t>{pack}, Array<int64_t>{128}), atom[1],
-            cute::Layout(Array<int64_t>{reps, ndup},
-                         Array<int64_t>{b32_col * width, 16})})});
+      cute::Layout(Array<int64_t>{1, 1},
+                   Array<cute::IntTuple>{cute::E({0}), pack * cute::E({1})}),
+      meta->tv);
 
-  // Physical -> logical.  For a full-datapath tile the chunk's domain is the
-  // serialized address within one issue (its footprint is the contiguous run
-  // [0,128) x columns), so the chunk itself is the map, and it stays valid
-  // where the tile is not injective (a pack::16b tile folds its unused
-  // sub-slot onto a stride-0 mode).  A Layout F issue's addresses skip the
-  // unoccupied datapaths, so its footprint index is NOT the address -- but
-  // such a tile IS injective, so left_inverse serves.  Either way the
-  // placement is derived from the tile, not assumed of it.
-  // tile_tv: (thread, value) -> flat logical tile
-  cute::Layout to_logical =
-      partial_subpartition ? cute::LeftInverse(serialized_tmem_tile) : chunk;
+  // full_t: (lane..., warp, warpgroup) -> (datapath, column); warps one
+  //   sub-partition apart, warpgroups splitting the columns.
+  //   E.g. ((32,1),4,1):((1@0,0),32@0,64@1).
+  cute::Layout full_t = cute::MakeLayout(
+      {atom[0], cute::Layout(4, 32 * cute::E({0})),
+       cute::Layout(num_wgs, num_chunks_each_wg * width * cute::E({1}))});
+
+  // full_v: (pack, reg..., rep, dup) -> (datapath, column), the wrapper's
+  //   register order: packed partner fastest, then the atom's registers,
+  //   then .xN repetitions, then the duplicate issue after ALL repetitions.
+  //   E.g. (1,1,64,1):(1@1,0,1@1,16@0).
+  cute::Layout full_v =
+      cute::MakeLayout({cute::Layout(pack, cute::E({1})), atom[1],
+                        cute::Layout(reps, width * pack * cute::E({1})),
+                        cute::Layout(ndup, atom_datapaths * cute::E({0}))});
+
+  // serialized_full_tv: (T, V) -> (datapath, column) -> serialized TMEM, one
+  //   issue's warpgroup-wide stamp.
+  cute::Layout serialized_full_tv =
+      cute::Composition(kSerialize, cute::MakeLayout({full_t, full_v}));
+
+  // to_logical: serialized TMEM -> flat logical tile,
+  //   LeftInverse(serialized_tmem_tile); gaps in the tile's image fold into
+  //   its modes and are never addressed.
+  //   E.g. (128,128,3):(3,384,1).
+  cute::Layout to_logical = cute::LeftInverse(serialized_tmem_tile);
+
+  // rest_cols: issue -> column origin,
+  //   LogicalDivide(valid_cols, issue_cols)[1].
+  //   E.g. 3:128.
+  // rest_domain: issue -> column origin -> serialized TMEM -> flat logical
+  //   tile origin, to_logical o (128 * rest_cols).
+  //   E.g. 3:1.
+  cute::Layout rest_cols = cute::LogicalDivide(valid_cols, issue_cols)[1];
+  cute::Layout rest_domain = cute::Composition(
+      to_logical, cute::Layout(rest_cols->shape, rest_cols->stride * 128));
+  if (cute::AsConst(cute::Size(rest_domain)) != num_issues)
+    return Tcgen05CopyPlan(nullptr);
+
+  // tile_tv: (T, V) -> (datapath, column) -> serialized TMEM -> flat logical
+  //   tile, with rest_domain appended as the slowest value mode.
+  //   E.g. ((32,4),(64,3)):((3,96),(384,1)).
   cute::Layout tile_tv = cute::MakeLayout(
-      {cute::Composition(to_logical, tiled[0]),
-       cute::MakeLayout(
-           {cute::Composition(to_logical, tiled[1]), rest_domain})});
-  int64_t num_vals = cute::AsConst(cute::Size(tile_tv[1]));
+      {cute::Composition(to_logical, serialized_full_tv[0]),
+       cute::MakeLayout({cute::Composition(to_logical, serialized_full_tv[1]),
+                         rest_domain})});
+  const int64_t num_vals = cute::AsConst(cute::Size(tile_tv[1]));
 
-  // Invert (the make_tiled_copy `right_inverse(...).with_shape(...)` idiom):
-  // the identity layout tags the (thread@0, value@1) axes, with_shape
-  // restores the tile's logical modes.
-  // fragment: logical tile -> (thread@0, value@1)
-  // E.g., fragment = (3,128,64):(64@1,1@0,1@1)
+  // fragment: logical tile -> (thread@0, value@1), RightInverse(tile_tv)
+  //   under the (thread, value) identity, reshaped to the tile's modes (the
+  //   make_tiled_copy right_inverse.with_shape idiom).  The size check
+  //   proves bijectivity.
+  //   E.g. (3,128,64):(64@1,1@0,1@1).
   cute::Layout inv_tv = cute::RightInverse(tile_tv);
   if (cute::AsConst(cute::Size(inv_tv)) != size)
     return Tcgen05CopyPlan(nullptr);

--- a/src/layout/tcgen05_layout.cc
+++ b/src/layout/tcgen05_layout.cc
@@ -255,7 +255,7 @@ Tcgen05CopyPlan ExpandTcgen05Layout(const Tcgen05Meta &meta,
   // instead of following all repetitions.  Until then a non-power-of-two .xN
   // finds no plan (an M=64 bf16 operand at K = 96, 192 or 320).
   if (meta->max_chunks != 0) {
-    if (reps & (reps - 1))  // reps must be a power of two
+    if (reps & (reps - 1)) // reps must be a power of two
       return Tcgen05CopyPlan(nullptr);
     if (reps > meta->max_chunks)
       return Tcgen05CopyPlan(nullptr);

--- a/src/layout/tcgen05_layout.cc
+++ b/src/layout/tcgen05_layout.cc
@@ -11,9 +11,12 @@
  */
 
 #include "support/check.h"
+#include <algorithm>
+#include <array>
 #include <tvm/ffi/reflection/registry.h>
 #include <tvm/tirx/op.h>
 #include <tvm/tirx/stmt_functor.h>
+#include <vector>
 
 #include "layout.h"
 #include "tcgen05_layout.h"
@@ -198,15 +201,67 @@ Tcgen05CopyPlan ExpandTcgen05Layout(const Tcgen05Meta &meta,
   cute::Layout serialized_tmem_tile = cute::Composition(kSerialize, tmem_tile);
   int64_t size = cute::AsConst(cute::Size(serialized_tmem_tile));
 
-  // A full-datapath issue is exactly the tile's maximal contiguous run, and
-  // the divide's rest mode iterates the issues after it.  A Layout F issue is
-  // not contiguous at all -- four datapath groups 32 apart -- so it is
-  // assembled explicitly below and always covers the tile in one go.
-  // inv_prefix: serialized chunk -> flat logical tile.  E.g. 8192:3.
-  cute::Layout inv_prefix = cute::RightInverse(serialized_tmem_tile);
-  int64_t elems_per_issue =
-      partial_subpartition ? size : cute::AsConst(cute::Size(inv_prefix));
-  if (elems_per_issue % dp_per_issue != 0 || size % elems_per_issue != 0)
+  // One issue covers the tile's whole datapath footprint by one contiguous
+  // column run, so its logical footprint is read off the two projections
+  // separately -- a Layout F tile's gaps live on the datapath axis and never
+  // reach the column projection, so neither derivation needs a case split.
+  // Columns: the maximal contiguous run, inverted back into the flat logical
+  // domain.  inv_cols: column run -> flat logical tile.  E.g. 64:384.
+  static const cute::Layout kColOnly = cute::Layout::Parse("(1,1):(0,1)");
+  cute::Layout inv_cols =
+      cute::RightInverse(cute::Composition(kColOnly, tmem_tile));
+  int64_t cols_per_issue = cute::AsConst(cute::Size(inv_cols));
+
+  // Datapaths: collect the pure-datapath modes with their flat-domain
+  // weights, ascending by datapath stride so the footprint is enumerated in
+  // address order.  (dp stride, extent, weight) per mode.
+  cute::IntTuple flat_shape = cute::Flatten(tmem_tile->shape);
+  cute::IntTuple dp_strides =
+      cute::Flatten(cute::Composition(kDpOnly, tmem_tile)->stride);
+  cute::IntTuple col_strides =
+      cute::Flatten(cute::Composition(kColOnly, tmem_tile)->stride);
+  int64_t rank = cute::Rank(flat_shape);
+  std::vector<std::array<int64_t, 3>> dp_modes;
+  int64_t occupied_dps = 1;
+  for (int64_t i = 0, weight = 1; i < rank; ++i) {
+    if (!cute::IsConst(flat_shape[i]) || !cute::IsConst(dp_strides[i]) ||
+        !cute::IsConst(col_strides[i]))
+      return Tcgen05CopyPlan(nullptr);
+    int64_t extent = cute::AsConst(flat_shape[i]);
+    if (extent > 1 && cute::AsConst(dp_strides[i]) != 0) {
+      if (cute::AsConst(col_strides[i]) != 0) // a diagonal crosses both axes
+        return Tcgen05CopyPlan(nullptr);
+      dp_modes.push_back({cute::AsConst(dp_strides[i]), extent, weight});
+      occupied_dps *= extent;
+    }
+    weight *= extent;
+  }
+  // Four warps of dp_per_warp datapaths each must own the footprint exactly;
+  // a tile on fewer sub-partitions cannot drive a whole warpgroup.
+  if (occupied_dps != dp_per_issue)
+    return Tcgen05CopyPlan(nullptr);
+  std::stable_sort(dp_modes.begin(), dp_modes.end());
+
+  // chunk: issue-local (datapath footprint, column run) -> flat logical
+  // tile.  For a dense tile the footprint index IS the serialized address
+  // and this is exactly the maximal contiguous run right_inverse would
+  // find; for Layout F it also steps across the datapath gaps.
+  // E.g., chunk = 8192:3 (one whole batch entry).
+  Array<cute::IntTuple> chunk_shape, chunk_stride;
+  for (const auto &m : dp_modes) {
+    chunk_shape.push_back(cute::IntTuple(m[1]));
+    chunk_stride.push_back(cute::IntTuple(m[2]));
+  }
+  cute::IntTuple col_shape = cute::Flatten(inv_cols->shape);
+  cute::IntTuple col_stride = cute::Flatten(inv_cols->stride);
+  for (int64_t i = 0, r = cute::Rank(col_shape); i < r; ++i) {
+    chunk_shape.push_back(col_shape[i]);
+    chunk_stride.push_back(col_stride[i]);
+  }
+  cute::Layout chunk = cute::Coalesce(cute::Layout(chunk_shape, chunk_stride));
+
+  int64_t elems_per_issue = dp_per_issue * cols_per_issue;
+  if (size % elems_per_issue != 0)
     return Tcgen05CopyPlan(nullptr);
   int64_t num_issues = size / elems_per_issue;
 
@@ -215,10 +270,10 @@ Tcgen05CopyPlan ExpandTcgen05Layout(const Tcgen05Meta &meta,
   // rest_domain: issue -> flat logical tile origin
   // E.g., rest_domain = 3:1 -> origins 0, 1, 2 (idx2crd: batch 0, 1, 2)
   cute::Layout rest_domain =
-      num_issues == 1 ? cute::Layout(1, 0)
-                      : cute::LogicalDivide(
-                            cute::MakeColumnMajorLayout(cute::Size(tmem_tile)),
-                            inv_prefix)[1];
+      num_issues == 1
+          ? cute::Layout(1, 0)
+          : cute::LogicalDivide(
+                cute::MakeColumnMajorLayout(cute::Size(tmem_tile)), chunk)[1];
   if (cute::AsConst(cute::Size(rest_domain)) != num_issues)
     return Tcgen05CopyPlan(nullptr);
 
@@ -228,7 +283,6 @@ Tcgen05CopyPlan ExpandTcgen05Layout(const Tcgen05Meta &meta,
   // copy must stay one .xN issue for the wrapper's register order to hold.
   // E.g., width = 1, ndup = 1, cols_per_issue = 64, num_chunks_each_wg = 64
   int64_t width = Tcgen05AtomWidth(meta);
-  int64_t cols_per_issue = elems_per_issue / dp_per_issue;
   if (cols_per_issue % width != 0)
     return Tcgen05CopyPlan(nullptr);
   int64_t total_chunks = cols_per_issue / width;
@@ -283,16 +337,17 @@ Tcgen05CopyPlan ExpandTcgen05Layout(const Tcgen05Meta &meta,
             cute::Layout(Array<int64_t>{reps, ndup},
                          Array<int64_t>{b32_col * width, 16})})});
 
-  // Physical -> logical.  inv_prefix spans the maximal contiguous chunk, one
-  // whole full-datapath issue, and stays valid where the tile is not injective
-  // (a pack::16b tile folds its unused sub-slot onto a stride-0 mode).  No
-  // contiguous prefix covers a Layout F issue's four groups, but such a tile
-  // IS injective, so left_inverse serves.  Either way the placement is derived
-  // from the tile, not assumed of it.
+  // Physical -> logical.  For a full-datapath tile the chunk's domain is the
+  // serialized address within one issue (its footprint is the contiguous run
+  // [0,128) x columns), so the chunk itself is the map, and it stays valid
+  // where the tile is not injective (a pack::16b tile folds its unused
+  // sub-slot onto a stride-0 mode).  A Layout F issue's addresses skip the
+  // unoccupied datapaths, so its footprint index is NOT the address -- but
+  // such a tile IS injective, so left_inverse serves.  Either way the
+  // placement is derived from the tile, not assumed of it.
   // tile_tv: (thread, value) -> flat logical tile
-  cute::Layout to_logical = partial_subpartition
-                                ? cute::LeftInverse(serialized_tmem_tile)
-                                : inv_prefix;
+  cute::Layout to_logical =
+      partial_subpartition ? cute::LeftInverse(serialized_tmem_tile) : chunk;
   cute::Layout tile_tv = cute::MakeLayout(
       {cute::Composition(to_logical, tiled[0]),
        cute::MakeLayout(

--- a/src/layout/tcgen05_layout.cc
+++ b/src/layout/tcgen05_layout.cc
@@ -134,13 +134,15 @@ int64_t Tcgen05AtomWidth(const Tcgen05Meta &meta) {
 Tcgen05CopyPlan::Tcgen05CopyPlan(cute::Layout fragment,
                                  int64_t num_chunks_each_wg,
                                  cute::Layout rest_domain, int64_t num_issues,
-                                 int64_t vals_per_issue) {
+                                 int64_t vals_per_issue,
+                                 int64_t datapaths_per_warp) {
   auto node = ffi::make_object<Tcgen05CopyPlanNode>();
   node->fragment = std::move(fragment);
   node->num_chunks_each_wg = num_chunks_each_wg;
   node->rest_domain = std::move(rest_domain);
   node->num_issues = num_issues;
   node->vals_per_issue = vals_per_issue;
+  node->datapaths_per_warp = datapaths_per_warp;
   data_ = std::move(node);
 }
 
@@ -151,7 +153,8 @@ void Tcgen05CopyPlanNode::RegisterReflection() {
       .def_ro("num_chunks_each_wg", &Tcgen05CopyPlanNode::num_chunks_each_wg)
       .def_ro("rest_domain", &Tcgen05CopyPlanNode::rest_domain)
       .def_ro("num_issues", &Tcgen05CopyPlanNode::num_issues)
-      .def_ro("vals_per_issue", &Tcgen05CopyPlanNode::vals_per_issue);
+      .def_ro("vals_per_issue", &Tcgen05CopyPlanNode::vals_per_issue)
+      .def_ro("datapaths_per_warp", &Tcgen05CopyPlanNode::datapaths_per_warp);
 }
 
 // Running example: 32dp32b, 128 threads, gapped tile from a column slice of
@@ -159,33 +162,53 @@ void Tcgen05CopyPlanNode::RegisterReflection() {
 //   tmem_tile = (3,128,64):(128@1,1@0,1@1)   (batch, datapath, column)
 Tcgen05CopyPlan ExpandTcgen05Layout(const Tcgen05Meta &meta,
                                     const cute::Layout &tmem_tile,
-                                    int num_threads) {
+                                    int num_threads,
+                                    int64_t values_per_column) {
   static constexpr int WARPGROUP_SIZE = 128;
   ICHECK(num_threads > 0 && num_threads % WARPGROUP_SIZE == 0)
       << "ExpandTcgen05Layout needs a positive multiple of " << WARPGROUP_SIZE
       << " threads, got " << num_threads;
+  ICHECK_GE(values_per_column, 1);
   int num_wgs = num_threads / WARPGROUP_SIZE;
 
   // Serialize (datapath, column) into the flat address datapath + 128*column
   // so everything below is algebra over one codomain.
-  // serialized_fragment: atom (lane/warp, reg) -> serialized TMEM
   // serialized_tmem_tile: logical tile -> serialized TMEM
   // E.g., serialized_tmem_tile = (3,128,64):(16384,1,128)
   static const cute::Layout kSerialize = cute::Layout::Parse("(1,1):(1,128)");
-  cute::Layout serialized_fragment = cute::Composition(kSerialize, meta->tv);
-  cute::Layout serialized_tmem_tile = cute::Composition(kSerialize, tmem_tile);
 
+  // How much of a warp's 32-lane sub-partition one warp covers is a property
+  // of the TILE.  On the datapath axis alone a dense fragment runs 128 before
+  // its first gap, a PTX Layout F fragment (1SM M=64) exactly 16.  A warp owns
+  // 32, so clamp there and let the atom divide what is left -- an atom too
+  // wide for the run (32dp32b against Layout F) falls out as a non-division.
+  // Projecting the columns away also makes this independent of whether they
+  // count values or b32 slots.
+  static const cute::Layout kDpOnly = cute::Layout::Parse("(1,1):(1,0)");
+  const int64_t atom_datapaths = Tcgen05AtomDatapaths(meta);
+  const int64_t dp_run = cute::AsConst(
+      cute::Size(cute::RightInverse(cute::Composition(kDpOnly, tmem_tile))));
+  const int64_t dp_per_warp = dp_run < 32 ? dp_run : 32;
+  if (dp_per_warp % atom_datapaths != 0)
+    return Tcgen05CopyPlan(nullptr);
+  const int64_t ndup = dp_per_warp / atom_datapaths;
+  const int64_t dp_per_issue = 4 * dp_per_warp; // 128, or 64 for Layout F
+  const bool partial_subpartition = dp_per_warp < 32;
+
+  cute::Layout serialized_tmem_tile = cute::Composition(kSerialize, tmem_tile);
   int64_t size = cute::AsConst(cute::Size(serialized_tmem_tile));
 
-  // right_inverse's stride chain stops at the tile's first serialized gap,
-  // so its size is the maximal contiguous chunk = one tcgen05 issue.
-  // inv_prefix: serialized chunk -> flat logical tile
-  // E.g., inv_prefix = 8192:3, chunk = 8192, num_issues = 3
+  // A full-datapath issue is exactly the tile's maximal contiguous run, and
+  // the divide's rest mode iterates the issues after it.  A Layout F issue is
+  // not contiguous at all -- four datapath groups 32 apart -- so it is
+  // assembled explicitly below and always covers the tile in one go.
+  // inv_prefix: serialized chunk -> flat logical tile.  E.g. 8192:3.
   cute::Layout inv_prefix = cute::RightInverse(serialized_tmem_tile);
-  int64_t chunk = cute::AsConst(cute::Size(inv_prefix));
-  if (chunk % 128 != 0 || size % chunk != 0)
+  int64_t elems_per_issue =
+      partial_subpartition ? size : cute::AsConst(cute::Size(inv_prefix));
+  if (elems_per_issue % dp_per_issue != 0 || size % elems_per_issue != 0)
     return Tcgen05CopyPlan(nullptr);
-  int64_t num_issues = size / chunk;
+  int64_t num_issues = size / elems_per_issue;
 
   // Divide the flat logical domain by the chunk; the rest mode locates each
   // issue's origin (CuTe's tiled-copy rest iteration).
@@ -205,52 +228,75 @@ Tcgen05CopyPlan ExpandTcgen05Layout(const Tcgen05Meta &meta,
   // copy must stay one .xN issue for the wrapper's register order to hold.
   // E.g., width = 1, ndup = 1, cols_per_issue = 64, num_chunks_each_wg = 64
   int64_t width = Tcgen05AtomWidth(meta);
-  int64_t ndup = 32 / Tcgen05AtomDatapaths(meta);
-  int64_t cols_per_issue = chunk / 128;
+  int64_t cols_per_issue = elems_per_issue / dp_per_issue;
   if (cols_per_issue % width != 0)
     return Tcgen05CopyPlan(nullptr);
   int64_t total_chunks = cols_per_issue / width;
   if (total_chunks % num_wgs != 0)
     return Tcgen05CopyPlan(nullptr);
   int num_chunks_each_wg = static_cast<int>(total_chunks / num_wgs);
-  if (ndup > 1) {
-    // The wrapper appends the duplicate issue's registers after ALL
-    // repetitions, so the per-warpgroup copy must be one .xN issue.
-    if (num_chunks_each_wg & (num_chunks_each_wg - 1))
+
+  // The .xN the wrapper is actually handed: a partial sub-partition carries
+  // its sub-word packing as its own mode, so the repetitions are what remains.
+  // The full-datapath path plans in value columns and LowerTmem halves the
+  // count itself, so bound the planned count there -- never optimistic.
+  int64_t pack = partial_subpartition ? values_per_column : 1;
+  if (num_chunks_each_wg % pack != 0)
+    return Tcgen05CopyPlan(nullptr);
+  int64_t reps = num_chunks_each_wg / pack;
+
+  // core chains a copy too big for one instruction by advancing ONE column
+  // and ONE register per repetition, exact only for an atom that is one of
+  // each -- 32dp32b, flagged by max_chunks == 0.  Every other atom must fit
+  // the per-warpgroup copy in a single .xN.  Lifting that needs the core
+  // parameterised by columns/registers per repetition AND the 32dp
+  // composites' nesting inverted so each half chains separately: fixing the
+  // strides alone still leaves a chained duplicate interleaved per segment
+  // instead of following all repetitions.  Until then a non-power-of-two .xN
+  // finds no plan (an M=64 bf16 operand at K = 96, 192 or 320).
+  if (meta->max_chunks != 0) {
+    if (reps & (reps - 1))  // reps must be a power of two
       return Tcgen05CopyPlan(nullptr);
-    if (num_chunks_each_wg > meta->max_chunks)
+    if (reps > meta->max_chunks)
       return Tcgen05CopyPlan(nullptr);
   }
 
-  // Replicate the atom with one blocked product over the wrapper's
-  // replication grid.  The blocked product's complement enumerates the
-  // serialized gaps around the atom in ascending-stride order -- the
-  // duplicate high-16-datapath issue first, then the warp sub-partitions,
-  // then the .xN column repetitions, then the warpgroup column split -- so
-  // the row-major (wg, rep, warp, dup) grid indexes exactly those slots.
-  // Zipped per atom mode: thread gets (warp, wg), value gets (rep, dup);
-  // the value replicas are FASTER than the thread replicas, so a thread's
-  // values stay contiguous in TMEM, and the duplicate issue lands after the
-  // repetitions exactly as the wrapper appends its registers.
-  // tiled: ((lane, (warp, wg)), (reg, (rep, dup))) -> serialized chunk
-  // E.g., tiled = ((32,(4,1)),(1,(64,1))):((1,(32,8192)),(0,(128,32)))
-  cute::Layout grid = cute::MakeRowMajorLayout(
-      Array<int64_t>{num_wgs, num_chunks_each_wg, 4, ndup});
-  cute::Layout tiler = cute::MakeLayout({cute::MakeLayout({grid[2], grid[0]}),
-                                         cute::MakeLayout({grid[1], grid[3]})});
-  cute::Layout tiled = cute::BlockedProduct(serialized_fragment, tiler);
-
-  // Map the copy back to flat logical indices piecewise, mirroring the
-  // (chunk, rest) split of the divide above: every replica of `tiled`
-  // addresses within one contiguous chunk, which inv_prefix inverts, and
-  // rest_domain already locates each issue's flat logical origin -- so the
-  // issue mode composes directly, without inverting the whole tile.
-  // tile_tv: (thread, value) -> flat logical tile
-  // E.g., tile_tv = ((32,(4,1)),((1,(64,1)),3)):((3,(96,1)),((0,(384,1)),1))
-  cute::Layout tile_tv = cute::MakeLayout(
-      {cute::Composition(inv_prefix, tiled[0]),
+  // The stamp: what ONE wrapper call covers.  Warps sit one sub-partition
+  // apart (32), a 16-datapath atom's duplicate issue on the high half of one
+  // (16), .xN repetitions a column group apart, warpgroups split the columns.
+  // The packed partner -- two sub-word values in one b32 column -- is the
+  // FASTEST value, one value column along, since a register's two halves are
+  // adjacent in the buffer; the atom addresses b32 columns, so its column step
+  // is `pack` value columns wide.  Spelled out rather than left to a blocked
+  // product's complement, whose fastest gap for Layout F is the *unoccupied*
+  // datapaths -- it would pack the warps in at stride 16.
+  // tiled: ((lane, (warp, wg)), (pack, reg, (rep, dup))) -> serialized TMEM
+  int64_t b32_col = 128 * pack;
+  cute::Layout atom = cute::Composition(
+      cute::Layout(Array<int64_t>{1, 1}, Array<int64_t>{1, b32_col}), meta->tv);
+  cute::Layout tiled = cute::MakeLayout(
+      {cute::MakeLayout(
+           {atom[0], cute::Layout(Array<int64_t>{4, num_wgs},
+                                  Array<int64_t>{32, b32_col * width * reps})}),
        cute::MakeLayout(
-           {cute::Composition(inv_prefix, tiled[1]), rest_domain})});
+           {cute::Layout(Array<int64_t>{pack}, Array<int64_t>{128}), atom[1],
+            cute::Layout(Array<int64_t>{reps, ndup},
+                         Array<int64_t>{b32_col * width, 16})})});
+
+  // Physical -> logical.  inv_prefix spans the maximal contiguous chunk, one
+  // whole full-datapath issue, and stays valid where the tile is not injective
+  // (a pack::16b tile folds its unused sub-slot onto a stride-0 mode).  No
+  // contiguous prefix covers a Layout F issue's four groups, but such a tile
+  // IS injective, so left_inverse serves.  Either way the placement is derived
+  // from the tile, not assumed of it.
+  // tile_tv: (thread, value) -> flat logical tile
+  cute::Layout to_logical = partial_subpartition
+                                ? cute::LeftInverse(serialized_tmem_tile)
+                                : inv_prefix;
+  cute::Layout tile_tv = cute::MakeLayout(
+      {cute::Composition(to_logical, tiled[0]),
+       cute::MakeLayout(
+           {cute::Composition(to_logical, tiled[1]), rest_domain})});
   int64_t num_vals = cute::AsConst(cute::Size(tile_tv[1]));
 
   // Invert (the make_tiled_copy `right_inverse(...).with_shape(...)` idiom):
@@ -271,7 +317,7 @@ Tcgen05CopyPlan ExpandTcgen05Layout(const Tcgen05Meta &meta,
           .WithShape(cute::IntTupleTuple(tile_shape));
 
   return Tcgen05CopyPlan(fragment, num_chunks_each_wg, rest_domain, num_issues,
-                         chunk / num_threads);
+                         elems_per_issue / num_threads, dp_per_warp);
 }
 
 Fragment FragmentToTileLang(const cute::Layout &layout) {

--- a/src/layout/tcgen05_layout.h
+++ b/src/layout/tcgen05_layout.h
@@ -10,19 +10,19 @@
 namespace tvm {
 namespace tl {
 
+// Projections of the physical TMEM coordinate (datapath@0, column@1) onto
+// one axis (the other axis's strides become 0).
+// E.g. Composition(kColOnly, (128,64):(1@0,1@1)) == (128,64):(0,1).
+TVM_DLL extern const cute::Layout kDpOnly;  // (datapath, column) -> datapath
+TVM_DLL extern const cute::Layout kColOnly; // (datapath, column) -> column
+
 // Metadata for one tcgen05.ld/st data-movement shape.
 //
-// `tv` is the CUTLASS ``Copy_Traits<SM100_TMEM_LOAD_*1x>`` TV atom verbatim
-// (DstLayout over ValID, upcast to b32): a rank-2 layout (lane modes,
-// register modes) whose ScaledBasis strides land in axis 0 = datapath and
-// axis 1 = b32 column.  It covers exactly what one PTX issue of the x1
-// shape covers -- one 32-lane warp and, for the 16-datapath shapes, only
-// the LOW 16 datapaths of the warp's sub-partition.  All replication is
-// applied algebraically by ExpandTcgen05Layout: the warp tiling
-// (make_tmem_copy's atom_t_layout), the wrapper's duplicate issue on the
-// high 16 datapaths, the .xN column repetitions, and the warpgroup split
-// enter as one blocked product over a replication grid, so the atom itself
-// stores none of them.
+// `tv` is the CUTLASS ``Copy_Traits<...1x>`` TV atom: (lane..., reg...) ->
+// (datapath@0, b32 column@1), covering one PTX issue of one warp (the
+// 16-datapath shapes only the LOW 16 datapaths of its sub-partition).  All
+// replication -- warps, the high-datapath duplicate issue, .xN repetitions,
+// warpgroups -- is applied by ExpandTcgen05Layout.
 class Tcgen05MetaNode : public ffi::Object {
 public:
   ffi::String intrinsics_name;
@@ -54,20 +54,15 @@ Tcgen05Meta GetTcgen05MetaSt16Dp64B();
 Tcgen05Meta GetTcgen05MetaSt16Dp128B();
 Tcgen05Meta GetTcgen05MetaSt16Dp256B();
 
-// The atom's extent along one physical axis, from the CuTe algebra: compose
-// an axis projection over the TV layout (keeping one axis's strides and
-// zeroing the other's) and take the cosize.  Datapaths determine the
-// wrapper's duplication factor (32 / datapaths issues fill a warp's
-// sub-partition); the width is the b32 columns of one .x1 repetition.
+// The atom's extent along one physical axis: Cosize of the axis projection
+// of `tv`.  Datapaths set the wrapper's duplication factor; the width is
+// the b32 columns of one .x1 repetition.
 int64_t Tcgen05AtomDatapaths(const Tcgen05Meta &meta);
 int64_t Tcgen05AtomWidth(const Tcgen05Meta &meta);
 
-// The tiled copy of one TMEM tile, built by ExpandTcgen05Layout.
-//
-// A tile whose serialized image is gapped (e.g. a column slice of a batched
-// accumulator, (3,128,64):(16384,1,128) serialized) cannot be one
-// instruction; the copy iterates its contiguous chunks instead, one issue
-// per rest coordinate (CuTe's tiled-copy rest modes).
+// The tiled copy of one TMEM tile, built by ExpandTcgen05Layout.  A tile
+// whose serialized image is gapped cannot be one instruction; the copy
+// issues once per contiguous chunk (CuTe's tiled-copy rest modes).
 class Tcgen05CopyPlanNode : public ffi::Object {
 public:
   cute::Layout fragment;      // logical tile coord -> (thread@0, value@1)
@@ -75,10 +70,8 @@ public:
   cute::Layout rest_domain;   // issue -> flat logical tile index of origin
   int64_t num_issues;         // size(rest_domain)
   int64_t vals_per_issue;     // registers per thread, per issue
-  // Datapaths of a warp's sub-partition the tile occupies -- 32, or 16 for a
-  // PTX Layout F fragment.  This is the number the wrapper is named after:
-  // 16 means the atom is issued once per warp instead of being duplicated
-  // onto the high datapaths.
+  // Datapaths of a warp's sub-partition the tile occupies: 32, or 16 for a
+  // PTX Layout F fragment (the atom is then issued once per warp).
   int64_t datapaths_per_warp;
 
   static void RegisterReflection();
@@ -95,23 +88,18 @@ public:
                                              Tcgen05CopyPlanNode);
 };
 
-// Build the copy plan for one TMEM tile, in CuTe algebra: serialize the
-// atom TV layout and `tmem_tile` (logical tile coords -> physical
-// (datapath@0, column@1)) into linear TMEM addressing via (1,1):(1,128);
-// right_inverse of the serialized tile finds its maximal contiguous chunk,
-// and logical_divide by that inverse splits the tile into (chunk, rest);
-// tile the serialized atom over (warpgroups, repetitions) with a blocked
-// product whose appended value mode is FASTER than the appended thread mode
-// (the values a thread holds stay contiguous in TMEM for the longest
-// vectors), and append the rest mode slowest of all (later issues append
-// registers); compose with the left inverse of the serialized tile
-// (register TV -> serialized TMEM -> logical tile); and invert once more.
+// Build the copy plan for one TMEM tile (logical tile coords -> physical
+// (datapath@0, column@1)).  One issue covers the tile's whole datapath
+// footprint by its maximal contiguous column run; the atom TV layout is
+// extended to that stamp and mapped back through the tile:
+//   tile_tv:     (thread, value) -> (datapath, column) -> serialized TMEM
+//                -> logical tile; its RightInverse is the fragment.
+//   rest_domain: issue -> column origin -> serialized TMEM -> logical tile.
 //
 // Returns a null ref when this instruction/warpgroup arrangement cannot
-// express the tile's chunks bijectively.
-// `values_per_column` is how many of the tile's columns share one b32 column
-// -- 1 for 32-bit values or a tile already stated in b32 columns.  It is the
-// one thing a value-column layout cannot say about itself.
+// express the tile bijectively.  `values_per_column` is how many of the
+// tile's columns share one b32 column (1 for 32-bit values or a tile
+// already stated in b32 columns).
 Tcgen05CopyPlan ExpandTcgen05Layout(const Tcgen05Meta &meta,
                                     const cute::Layout &tmem_tile,
                                     int num_threads,

--- a/src/layout/tcgen05_layout.h
+++ b/src/layout/tcgen05_layout.h
@@ -75,6 +75,11 @@ public:
   cute::Layout rest_domain;   // issue -> flat logical tile index of origin
   int64_t num_issues;         // size(rest_domain)
   int64_t vals_per_issue;     // registers per thread, per issue
+  // Datapaths of a warp's sub-partition the tile occupies -- 32, or 16 for a
+  // PTX Layout F fragment.  This is the number the wrapper is named after:
+  // 16 means the atom is issued once per warp instead of being duplicated
+  // onto the high datapaths.
+  int64_t datapaths_per_warp;
 
   static void RegisterReflection();
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.Tcgen05CopyPlan", Tcgen05CopyPlanNode,
@@ -85,7 +90,7 @@ class Tcgen05CopyPlan : public ffi::ObjectRef {
 public:
   TVM_DLL Tcgen05CopyPlan(cute::Layout fragment, int64_t num_chunks_each_wg,
                           cute::Layout rest_domain, int64_t num_issues,
-                          int64_t vals_per_issue);
+                          int64_t vals_per_issue, int64_t datapaths_per_warp);
   TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(Tcgen05CopyPlan, ffi::ObjectRef,
                                              Tcgen05CopyPlanNode);
 };
@@ -104,9 +109,13 @@ public:
 //
 // Returns a null ref when this instruction/warpgroup arrangement cannot
 // express the tile's chunks bijectively.
+// `values_per_column` is how many of the tile's columns share one b32 column
+// -- 1 for 32-bit values or a tile already stated in b32 columns.  It is the
+// one thing a value-column layout cannot say about itself.
 Tcgen05CopyPlan ExpandTcgen05Layout(const Tcgen05Meta &meta,
                                     const cute::Layout &tmem_tile,
-                                    int num_threads);
+                                    int num_threads,
+                                    int64_t values_per_column = 1);
 
 // Convert a fragment (logical coord -> (thread@0, value@1), like
 // Tcgen05CopyPlan::fragment) into a TileLang Fragment over its top-level

--- a/src/tl_templates/cuda/copy_sm100.h
+++ b/src/tl_templates/cuda/copy_sm100.h
@@ -258,6 +258,55 @@ tcgen05_ld_32dp256bNx(uint32_t const &tmem_start_col,
 #endif
 }
 
+// Half-subpartition (16 datapath) variants. The 32dp wrappers above
+// issue these twice, once per half; PTX Layout F (1SM M=64) occupies only
+// the low 16 datapaths of each sub-partition and needs a single issue.
+
+template <int N, bool pack16, typename dst_t, bool kDependentFalse = false>
+__device__ __forceinline__ void
+tcgen05_ld_16dp64bNx(uint32_t const &tmem_start_col,
+                     uint32_t const &tmem_col_offset, dst_t *dst_ptr) {
+#if defined(TL_CUDA_ARCH_TCGEN05_ENABLED)
+  tcgen05_ld_core<tl::tmem_ld_16dp64bNx<pack16>, 7, N>(
+      tmem_start_col + tmem_col_offset, dst_ptr);
+  tl::fence_view_async_tmem_load();
+#else
+  static_assert(kDependentFalse,
+                "tl::tcgen05_ld_16dp64bNx requires sm_100a or a compatible "
+                "architecture-specific target");
+#endif
+}
+
+template <int N, bool pack16, typename dst_t, bool kDependentFalse = false>
+__device__ __forceinline__ void
+tcgen05_ld_16dp128bNx(uint32_t const &tmem_start_col,
+                      uint32_t const &tmem_col_offset, dst_t *dst_ptr) {
+#if defined(TL_CUDA_ARCH_TCGEN05_ENABLED)
+  tcgen05_ld_core<tl::tmem_ld_16dp128bNx<pack16>, 6, N>(
+      tmem_start_col + tmem_col_offset, dst_ptr);
+  tl::fence_view_async_tmem_load();
+#else
+  static_assert(kDependentFalse,
+                "tl::tcgen05_ld_16dp128bNx requires sm_100a or a compatible "
+                "architecture-specific target");
+#endif
+}
+
+template <int N, bool pack16, typename dst_t, bool kDependentFalse = false>
+__device__ __forceinline__ void
+tcgen05_ld_16dp256bNx(uint32_t const &tmem_start_col,
+                      uint32_t const &tmem_col_offset, dst_t *dst_ptr) {
+#if defined(TL_CUDA_ARCH_TCGEN05_ENABLED)
+  tcgen05_ld_core<tl::tmem_ld_16dp256bNx<pack16>, 5, N>(
+      tmem_start_col + tmem_col_offset, dst_ptr);
+  tl::fence_view_async_tmem_load();
+#else
+  static_assert(kDependentFalse,
+                "tl::tcgen05_ld_16dp256bNx requires sm_100a or a compatible "
+                "architecture-specific target");
+#endif
+}
+
 // NOTE: The column offset increment (CUR_SEGMENT_LEN) assumes each register
 // maps to exactly one TMEM column (i.e. unpack::16b is NOT active). If
 // unpack::16b were used, each register would expand to 2 columns, requiring
@@ -334,6 +383,55 @@ tcgen05_st_32dp256bNx(uint32_t const &tmem_start_col,
 #else
   static_assert(kDependentFalse,
                 "tl::tcgen05_st_32dp256bNx requires sm_100a or a compatible "
+                "architecture-specific target");
+#endif
+}
+
+// Half-subpartition (16 datapath) variants. The 32dp wrappers above
+// issue these twice, once per half; PTX Layout F (1SM M=64) occupies only
+// the low 16 datapaths of each sub-partition and needs a single issue.
+
+template <int N, bool unpack16, typename src_t, bool kDependentFalse = false>
+__device__ __forceinline__ void
+tcgen05_st_16dp64bNx(uint32_t const &tmem_start_col,
+                     uint32_t const &tmem_col_offset, src_t const *src_ptr) {
+#if defined(TL_CUDA_ARCH_TCGEN05_ENABLED)
+  tcgen05_st_core<tl::tmem_st_16dp64bNx<unpack16>, 7, N>(
+      tmem_start_col + tmem_col_offset, src_ptr);
+  tl::fence_view_async_tmem_store();
+#else
+  static_assert(kDependentFalse,
+                "tl::tcgen05_st_16dp64bNx requires sm_100a or a compatible "
+                "architecture-specific target");
+#endif
+}
+
+template <int N, bool unpack16, typename src_t, bool kDependentFalse = false>
+__device__ __forceinline__ void
+tcgen05_st_16dp128bNx(uint32_t const &tmem_start_col,
+                      uint32_t const &tmem_col_offset, src_t const *src_ptr) {
+#if defined(TL_CUDA_ARCH_TCGEN05_ENABLED)
+  tcgen05_st_core<tl::tmem_st_16dp128bNx<unpack16>, 6, N>(
+      tmem_start_col + tmem_col_offset, src_ptr);
+  tl::fence_view_async_tmem_store();
+#else
+  static_assert(kDependentFalse,
+                "tl::tcgen05_st_16dp128bNx requires sm_100a or a compatible "
+                "architecture-specific target");
+#endif
+}
+
+template <int N, bool unpack16, typename src_t, bool kDependentFalse = false>
+__device__ __forceinline__ void
+tcgen05_st_16dp256bNx(uint32_t const &tmem_start_col,
+                      uint32_t const &tmem_col_offset, src_t const *src_ptr) {
+#if defined(TL_CUDA_ARCH_TCGEN05_ENABLED)
+  tcgen05_st_core<tl::tmem_st_16dp256bNx<unpack16>, 5, N>(
+      tmem_start_col + tmem_col_offset, src_ptr);
+  tl::fence_view_async_tmem_store();
+#else
+  static_assert(kDependentFalse,
+                "tl::tcgen05_st_16dp256bNx requires sm_100a or a compatible "
                 "architecture-specific target");
 #endif
 }

--- a/testing/python/language/test_tilelang_language_tcgen05_cutedsl.py
+++ b/testing/python/language/test_tilelang_language_tcgen05_cutedsl.py
@@ -1,0 +1,161 @@
+# TMEM copies (tcgen05.ld/st) through the CuTeDSL backend, exercising the
+# 32-datapath wrappers and the half-subpartition (16dp, PTX Layout F)
+# wrappers of tilelang/contrib/cutedsl/gemm_tcgen05.py.
+#
+# The roundtrips prove st and ld agree bit-exactly on every layout; the TS
+# GEMMs are the hardware ground truth: the MMA reads the A operand straight
+# from TMEM in the layout PTX prescribes, so a store that placed values on
+# the wrong datapaths shows up as a wrong product, not just a wrong readback.
+
+import pytest
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+def _is_cutedsl_available():
+    try:
+        from tilelang.jit.adapter.cutedsl.checks import check_cutedsl_available
+
+        check_cutedsl_available()
+        return True
+    except (ImportError, AssertionError):
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _is_cutedsl_available(), reason="CuTeDSL not installed")
+
+_PASS_CONFIGS = {tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True}
+
+# (name, shape, tmem forward fn, threads, wrapper the copies must use)
+LAYOUT_CASES = [
+    # (128,128):(1@0,1@1) -- the sub-partition-filling baseline.
+    ("std_2d", (128, 128), lambda i, j: [i, j], 128, "32dp32bNx"),
+    # ((16,4),128):((1@0,32@0),1@1) -- PTX Layout F, the 1SM M=64 fragment:
+    # only the LOW 16 datapaths of each 32-datapath sub-partition are
+    # occupied, so the atom is issued once per warp instead of duplicated
+    # onto the high 16.
+    ("layout_f_m64", (64, 128), lambda i, j: [i % 16 + 32 * (i // 16), j], 128, "16dp64bNx"),
+    ("layout_f_m64_2wg", (64, 256), lambda i, j: [i % 16 + 32 * (i // 16), j], 256, "16dp64bNx"),
+]
+
+
+def _make_roundtrip_kernel(shape, forward, threads):
+    @T.prim_func
+    def main(
+        A: T.Tensor(shape, T.float32),
+        D: T.Tensor(shape, T.float32),
+    ):
+        with T.Kernel(1, threads=threads):
+            A_shared = T.alloc_shared(shape, T.float32)
+            A_frag = T.alloc_fragment(shape, T.float32)
+            tmem = T.alloc_tmem(shape, T.float32)
+            B_frag = T.alloc_fragment(shape, T.float32)
+            B_shared = T.alloc_shared(shape, T.float32)
+
+            T.annotate_layout({tmem: T.Layout(shape, forward)})
+            T.copy(A, A_shared)
+            T.copy(A_shared, A_frag)
+            T.copy(A_frag, tmem)
+            T.copy(tmem, B_frag)
+            T.copy(B_frag, B_shared)
+            T.copy(B_shared, D)
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+@pytest.mark.parametrize(
+    ("name", "shape", "forward", "threads", "wrapper"),
+    LAYOUT_CASES,
+    ids=[case[0] for case in LAYOUT_CASES],
+)
+def test_tmem_copy_roundtrip_cutedsl(name, shape, forward, threads, wrapper):
+    import torch
+
+    kernel = tilelang.compile(
+        _make_roundtrip_kernel(shape, forward, threads),
+        target="cutedsl",
+        pass_configs=_PASS_CONFIGS,
+    )
+    source = kernel.get_kernel_source()
+    assert f"tl.tcgen05_st_{wrapper}" in source, f"{name} must store through {wrapper}"
+    assert f"tl.tcgen05_ld_{wrapper}" in source, f"{name} must load through {wrapper}"
+
+    a = torch.randn(*shape, device="cuda", dtype=torch.float32)
+    d = torch.zeros(*shape, device="cuda", dtype=torch.float32)
+    kernel(a, d)
+    torch.testing.assert_close(d, a, rtol=0, atol=0)
+
+
+def _make_ts_gemm_kernel(M, N, K):
+    """A TS GEMM whose A operand reaches TMEM through registers.
+
+    At M=64 the A fragment is PTX Layout F, so the register->TMEM store and
+    the MMA's read of it have to agree on a half-subpartition layout.
+    """
+    from tilelang.cuda.intrinsics import make_mma_swizzle_layout
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), T.bfloat16),
+        B: T.Tensor((N, K), T.bfloat16),
+        C: T.Tensor((M, N), T.float32),
+    ):
+        with T.Kernel(1, threads=128):
+            a_shared = T.alloc_shared((M, K), T.bfloat16)
+            b_shared = T.alloc_shared((N, K), T.bfloat16)
+            T.annotate_layout({a_shared: make_mma_swizzle_layout(a_shared)})
+            T.copy(A, a_shared)
+            T.copy(B, b_shared)
+            with T.sblock():
+                T.reads()
+                T.writes()
+                a_tmem = T.alloc_tmem((M, K), T.bfloat16)
+                c_tmem = T.alloc_tmem((M, N), T.float32)
+                a_frag = T.alloc_fragment((M, K), T.bfloat16)
+                c_frag = T.alloc_fragment((M, N), T.float32)
+                done = T.alloc_barrier(1)
+                T.copy(a_shared, a_frag)
+                T.copy(a_frag, a_tmem)
+                if T.get_warp_idx_sync() == 0:
+                    T.tcgen05_gemm(a_tmem, b_shared, c_tmem, transpose_B=True, clear_accum=True, mbar=done)
+                T.mbarrier_wait_parity(done, 0)
+                T.copy(c_tmem, c_frag)
+                T.copy(c_frag, C)
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+@pytest.mark.parametrize("M", [64, 128], ids=["m64", "m128"])
+def test_tcgen05_ts_gemm_tmem_a_correctness_cutedsl(M):
+    import torch
+
+    N, K = 128, 128
+    kernel = tilelang.compile(
+        _make_ts_gemm_kernel(M, N, K),
+        target="cutedsl",
+        pass_configs=_PASS_CONFIGS,
+    )
+    # M=64 must go through the half-subpartition wrappers, M=128 must not.
+    source = kernel.get_kernel_source()
+    want = "tl.tcgen05_st_16dp" if M == 64 else "tl.tcgen05_st_32dp"
+    assert want in source, f"M={M} expected {want} in the emitted source"
+
+    torch.manual_seed(0)
+    a = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(N, K, device="cuda", dtype=torch.bfloat16)
+    c = torch.empty(M, N, device="cuda", dtype=torch.float32)
+    kernel(a, b, c)
+    ref = a.float() @ b.float().T
+    torch.testing.assert_close(c, ref, rtol=2e-2, atol=2e-2)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/language/test_tilelang_language_tcgen05_gemm.py
+++ b/testing/python/language/test_tilelang_language_tcgen05_gemm.py
@@ -684,3 +684,77 @@ def test_tcgen05_gemm_batched_correctness():
     kernel(a, b, d)
     ref = (a.float() @ b.float().transpose(1, 2)).to(torch.bfloat16)
     torch.testing.assert_close(d, ref, rtol=1e-2, atol=1e-2)
+
+def _make_m64_ts_kernel(M, N, K):
+    """A TS GEMM whose A operand reaches TMEM through registers.
+
+    At M=64 the A fragment is PTX Layout F -- the low 16 datapaths of each
+    sub-partition -- so both the register->TMEM store and the MMA's read of it
+    have to agree on a half-subpartition layout.
+    """
+    from tilelang.cuda.intrinsics import make_mma_swizzle_layout
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), T.bfloat16),
+        B: T.Tensor((N, K), T.bfloat16),
+        C: T.Tensor((M, N), T.float32),
+    ):
+        with T.Kernel(1, threads=128):
+            a_shared = T.alloc_shared((M, K), T.bfloat16)
+            b_shared = T.alloc_shared((N, K), T.bfloat16)
+            T.annotate_layout({a_shared: make_mma_swizzle_layout(a_shared)})
+            T.copy(A, a_shared)
+            T.copy(B, b_shared)
+            with T.sblock():
+                T.reads()
+                T.writes()
+                a_tmem = T.alloc_tmem((M, K), T.bfloat16)
+                c_tmem = T.alloc_tmem((M, N), T.float32)
+                a_frag = T.alloc_fragment((M, K), T.bfloat16)
+                c_frag = T.alloc_fragment((M, N), T.float32)
+                done = T.alloc_barrier(1)
+                T.copy(a_shared, a_frag)
+                T.copy(a_frag, a_tmem)
+                if T.get_warp_idx_sync() == 0:
+                    T.tcgen05_gemm(
+                        a_tmem, b_shared, c_tmem, transpose_B=True, clear_accum=True, mbar=done
+                    )
+                T.mbarrier_wait_parity(done, 0)
+                T.copy(c_tmem, c_frag)
+                T.copy(c_frag, C)
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+@pytest.mark.parametrize(
+    ("M", "K"),
+    # K=512 puts the wrapper's .xN at 128, exactly 16dp64b's max_chunks.  M=128
+    # is the untouched path, so one shape guards it -- and it cannot reach
+    # K=512 anyway: two bf16 stagings would need 256 KB of shared memory.
+    [(64, 64), (64, 128), (64, 512), (128, 128)],
+    ids=["m64k64", "m64k128", "m64k512", "m128k128"],
+)
+def test_tcgen05_ts_gemm_tmem_a_correctness(M, K):
+    import torch
+
+    N = 128
+    kernel = tilelang.compile(
+        _make_m64_ts_kernel(M, N, K),
+        out_idx=[2],
+        target="cuda",
+        pass_configs={tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True},
+    )
+    # M=64 must go through the half-subpartition wrappers, M=128 must not.
+    source = kernel.get_kernel_source()
+    want = "tcgen05_st_16dp" if M == 64 else "tcgen05_st_32dp"
+    assert want in source, f"M={M} expected {want} in the emitted source"
+
+    torch.manual_seed(0)
+    a = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(N, K, device="cuda", dtype=torch.bfloat16)
+    ref = a.float() @ b.float().T
+    torch.testing.assert_close(kernel(a, b), ref, rtol=2e-2, atol=2e-2)

--- a/testing/python/language/test_tilelang_language_tcgen05_gemm.py
+++ b/testing/python/language/test_tilelang_language_tcgen05_gemm.py
@@ -685,6 +685,7 @@ def test_tcgen05_gemm_batched_correctness():
     ref = (a.float() @ b.float().transpose(1, 2)).to(torch.bfloat16)
     torch.testing.assert_close(d, ref, rtol=1e-2, atol=1e-2)
 
+
 def _make_m64_ts_kernel(M, N, K):
     """A TS GEMM whose A operand reaches TMEM through registers.
 
@@ -717,9 +718,7 @@ def _make_m64_ts_kernel(M, N, K):
                 T.copy(a_shared, a_frag)
                 T.copy(a_frag, a_tmem)
                 if T.get_warp_idx_sync() == 0:
-                    T.tcgen05_gemm(
-                        a_tmem, b_shared, c_tmem, transpose_B=True, clear_accum=True, mbar=done
-                    )
+                    T.tcgen05_gemm(a_tmem, b_shared, c_tmem, transpose_B=True, clear_accum=True, mbar=done)
                 T.mbarrier_wait_parity(done, 0)
                 T.copy(c_tmem, c_frag)
                 T.copy(c_frag, C)

--- a/testing/python/language/test_tilelang_language_tmem_copy.py
+++ b/testing/python/language/test_tilelang_language_tmem_copy.py
@@ -325,10 +325,7 @@ def test_tmem_copy_roundtrip_16bit(name, shape, forward, modifier):
     # A batched layout sliced along its column mode leaves per-batch column
     # gaps in TMEM; the copy iterates the contiguous chunks, one tcgen05
     # issue per batch entry (rest iteration).
-    [
-        case for case in LAYOUT_CASES
-        if case[0] in ("std_2d", "std_2d_2wg", "batched_3d", "layout_f_m64")
-    ],
+    [case for case in LAYOUT_CASES if case[0] in ("std_2d", "std_2d_2wg", "batched_3d", "layout_f_m64")],
     ids=["std_2d", "std_2d_2wg", "batched_3d", "layout_f_m64"],
 )
 def test_tmem_copy_roundtrip_sliced_last_dim(name, shape, forward, threads):

--- a/testing/python/language/test_tilelang_language_tmem_copy.py
+++ b/testing/python/language/test_tilelang_language_tmem_copy.py
@@ -32,6 +32,12 @@ LAYOUT_CASES = [
     ("interleaved_4d", (3, 32, 64, 4), lambda a, i, j, k: [i + 32 * k, a * 64 + j], 128),
     # (128,128):(1@0,1@1) spread across two warpgroups.
     ("std_2d_2wg", (128, 128), lambda i, j: [i, j], 256),
+    # ((16,4),128):((1@0,32@0),1@1) -- PTX Layout F, the 1SM M=64 fragment:
+    # only the LOW 16 datapaths of each 32-datapath sub-partition are
+    # occupied, so the four warps sit a whole sub-partition apart and the
+    # atom is issued once per warp instead of duplicated onto the high 16.
+    ("layout_f_m64", (64, 128), lambda i, j: [i % 16 + 32 * (i // 16), j], 128),
+    ("layout_f_m64_2wg", (64, 256), lambda i, j: [i % 16 + 32 * (i // 16), j], 256),
 ]
 
 
@@ -288,8 +294,13 @@ def test_tmem_copy_roundtrip(name, shape, forward, threads):
         # Two 16-bit values packed per b32 column move as whole columns with
         # the plain instruction.
         ("packed_pair", (128, 128), lambda i, j: [i, j], False),
+        # Layout F leaves gaps on the DATAPATH axis, not inside the columns:
+        # its columns are perfectly full, so it must move with the plain
+        # instruction too.  (Judging pack::16b by "does the fragment cover
+        # its codomain" reads those datapath gaps as half-filled columns.)
+        ("layout_f_packed_pair", (64, 128), lambda i, j: [i % 16 + 32 * (i // 16), j], False),
     ],
-    ids=["pack16b", "packed_pair"],
+    ids=["pack16b", "packed_pair", "layout_f_packed_pair"],
 )
 def test_tmem_copy_roundtrip_16bit(name, shape, forward, modifier):
     kernel = tilelang.compile(
@@ -314,8 +325,11 @@ def test_tmem_copy_roundtrip_16bit(name, shape, forward, modifier):
     # A batched layout sliced along its column mode leaves per-batch column
     # gaps in TMEM; the copy iterates the contiguous chunks, one tcgen05
     # issue per batch entry (rest iteration).
-    [case for case in LAYOUT_CASES if case[0] in ("std_2d", "std_2d_2wg", "batched_3d")],
-    ids=["std_2d", "std_2d_2wg", "batched_3d"],
+    [
+        case for case in LAYOUT_CASES
+        if case[0] in ("std_2d", "std_2d_2wg", "batched_3d", "layout_f_m64")
+    ],
+    ids=["std_2d", "std_2d_2wg", "batched_3d", "layout_f_m64"],
 )
 def test_tmem_copy_roundtrip_sliced_last_dim(name, shape, forward, threads):
     _run_roundtrip(_make_sliced_roundtrip_kernel(shape, forward, threads, nsplit=2), shape)
@@ -326,8 +340,8 @@ def test_tmem_copy_roundtrip_sliced_last_dim(name, shape, forward, threads):
 @tilelang.testing.requires_cuda_compute_version_lt(11)
 @pytest.mark.parametrize(
     ("name", "shape", "forward", "threads"),
-    [case for case in LAYOUT_CASES if case[0] in ("std_2d", "batched_3d")],
-    ids=["std_2d", "batched_3d"],
+    [case for case in LAYOUT_CASES if case[0] in ("std_2d", "batched_3d", "layout_f_m64")],
+    ids=["std_2d", "batched_3d", "layout_f_m64"],
 )
 def test_tmem_copy_sliced_store_whole_load(name, shape, forward, threads):
     _run_roundtrip(_make_asymmetric_roundtrip_kernel(shape, forward, threads, nsplit=2), shape)

--- a/testing/python/layout/test_tilelang_tcgen05_expand.py
+++ b/testing/python/layout/test_tilelang_tcgen05_expand.py
@@ -153,8 +153,7 @@ def _layout_f_tile(cols):
 def test_expand_half_matches_cutlass_dst_layout(meta, width, regs, ndup, num_wgs, chunks):
     num_threads = 128 * num_wgs
     cols = width * chunks * num_wgs
-    plan = _ffi_api.ExpandTcgen05Layout(
-        _get_meta("ld_" + meta), _layout_f_tile(cols), num_threads)
+    plan = _ffi_api.ExpandTcgen05Layout(_get_meta("ld_" + meta), _layout_f_tile(cols), num_threads)
     assert plan is not None, f"{meta} must expand a Layout F (64,{cols}) tile"
     assert plan.datapaths_per_warp == 16, f"{meta} must plan a Layout F tile single-issue"
     assert plan.num_chunks_each_wg == chunks
@@ -188,9 +187,7 @@ def test_expand_half_matches_cutlass_dst_layout(meta, width, regs, ndup, num_wgs
     assert ana.can_prove_equal(thread_got, thread_expect), (
         f"{meta} wgs={num_wgs} x{chunks}: fragment thread {thread_got} != {thread_expect}"
     )
-    assert ana.can_prove_equal(value_got, value_expect), (
-        f"{meta} wgs={num_wgs} x{chunks}: fragment value {value_got} != {value_expect}"
-    )
+    assert ana.can_prove_equal(value_got, value_expect), f"{meta} wgs={num_wgs} x{chunks}: fragment value {value_got} != {value_expect}"
 
 
 @pytest.mark.parametrize(("meta", "width", "regs", "ndup"), HALF_SPECS, ids=[s[0] for s in HALF_SPECS])
@@ -201,10 +198,8 @@ def test_expand_layout_f_requires_pow2_single_issue(meta, width, regs, ndup):
     # repetition still spans `width` columns, so it must stay a single .xN
     # issue just like the duplicated form -- Expand must refuse rather than
     # emit a chained copy that walks the columns at the wrong stride.
-    assert _ffi_api.ExpandTcgen05Layout(
-        _get_meta("ld_" + meta), _layout_f_tile(width * 3), 128) is None
-    assert _ffi_api.ExpandTcgen05Layout(
-        _get_meta("ld_" + meta), _layout_f_tile(width * 4), 128) is not None
+    assert _ffi_api.ExpandTcgen05Layout(_get_meta("ld_" + meta), _layout_f_tile(width * 3), 128) is None
+    assert _ffi_api.ExpandTcgen05Layout(_get_meta("ld_" + meta), _layout_f_tile(width * 4), 128) is not None
 
 
 def test_expand_32_datapath_atom_refuses_layout_f():

--- a/testing/python/layout/test_tilelang_tcgen05_expand.py
+++ b/testing/python/layout/test_tilelang_tcgen05_expand.py
@@ -202,6 +202,21 @@ def test_expand_layout_f_requires_pow2_single_issue(meta, width, regs, ndup):
     assert _ffi_api.ExpandTcgen05Layout(_get_meta("ld_" + meta), _layout_f_tile(width * 4), 128) is not None
 
 
+def test_expand_layout_f_issues_per_batch():
+    # A column slice of a batched M=64 accumulator stacks per-batch column
+    # gaps on top of Layout F's datapath gaps.  The gaps live on different
+    # axes, so the column projection still exposes the 64-column contiguous
+    # run and the plan issues once per batch entry (rest iteration), exactly
+    # like the dense gapped tile above.
+    tile = cute.Layout.parse("(3,(16,4),64):(128@1,(1@0,32@0),1@1)")
+    plan = _ffi_api.ExpandTcgen05Layout(_get_meta("st_16dp64b"), tile, 128)
+    assert plan is not None
+    assert plan.datapaths_per_warp == 16
+    assert (plan.num_chunks_each_wg, plan.num_issues, plan.vals_per_issue) == (32, 3, 32)
+    assert [plan.rest_domain(i) for i in range(3)] == [0, 1, 2]
+    assert str(plan.fragment) == "(3,(8,2,4),(2,32)):(32@1,(4@0,1@0,32@0),(2@0,1@1))"
+
+
 def test_expand_32_datapath_atom_refuses_layout_f():
     # A 32-datapath atom spans a whole sub-partition, so it cannot tile a
     # fragment that occupies only half of one however it is issued.

--- a/testing/python/layout/test_tilelang_tcgen05_expand.py
+++ b/testing/python/layout/test_tilelang_tcgen05_expand.py
@@ -3,8 +3,8 @@
 # The C++ side stores each tcgen05.ld/st atom as the per-warp, single-issue
 # CUTLASS ``Copy_Traits<...1x>`` TV layout and derives every replication --
 # warps, the high-datapath duplicate issue of the 16-datapath shapes, .xN
-# column repetitions, warpgroups -- by one blocked product over a row-major
-# replication grid.  These tests evaluate the resulting fragment at a
+# column repetitions, warpgroups -- as explicit replication modes of one
+# issue-wide TV layout.  These tests evaluate the resulting fragment at a
 # SYMBOLIC (datapath, column) coordinate built from the hand-evaluated
 # DstLayout formulas of cute/atom/copy_traits_sm100.hpp -- combined with the
 # register order of TileLang's tl::tcgen05_{ld,st}_32dpNNbNx wrappers (the

--- a/testing/python/layout/test_tilelang_tcgen05_expand.py
+++ b/testing/python/layout/test_tilelang_tcgen05_expand.py
@@ -130,5 +130,104 @@ def test_expand_gapped_tile_issues_per_batch():
     assert [plan.rest_domain(i) for i in range(3)] == [0, 1, 2]
 
 
+# ---------------------------------------------------------------------------
+# Half-subpartition tiles (PTX Layout F, the 1SM M=64 fragment).
+#
+# Layout F occupies only the LOW 16 datapaths of each 32-datapath
+# sub-partition, so the four warps sit a whole sub-partition apart and the
+# atom is issued once per warp instead of being duplicated onto the high 16.
+# There is no separate atom for this: it is a property of the TILE, and the
+# same meta plans either form.
+# ---------------------------------------------------------------------------
+
+HALF_SPECS = [s for s in ATOM_SPECS if s[0] != "32dp32b"]
+
+
+def _layout_f_tile(cols):
+    return cute.Layout.parse(f"((16,4),{cols}):((1@0,32@0),1@1)")
+
+
+@pytest.mark.parametrize(("meta", "width", "regs", "ndup"), HALF_SPECS, ids=[s[0] for s in HALF_SPECS])
+@pytest.mark.parametrize("num_wgs", [1, 2], ids=["1wg", "2wg"])
+@pytest.mark.parametrize("chunks", [1, 2, 4], ids=["x1", "x2", "x4"])
+def test_expand_half_matches_cutlass_dst_layout(meta, width, regs, ndup, num_wgs, chunks):
+    num_threads = 128 * num_wgs
+    cols = width * chunks * num_wgs
+    plan = _ffi_api.ExpandTcgen05Layout(
+        _get_meta("ld_" + meta), _layout_f_tile(cols), num_threads)
+    assert plan is not None, f"{meta} must expand a Layout F (64,{cols}) tile"
+    assert plan.datapaths_per_warp == 16, f"{meta} must plan a Layout F tile single-issue"
+    assert plan.num_chunks_each_wg == chunks
+    assert plan.num_issues == 1
+    # One issue per warp, so no duplicate registers: ndup drops out.
+    assert plan.vals_per_issue == regs * chunks
+
+    ana = tvm.arith.Analyzer()
+
+    def var(name, extent):
+        v = tvm.tirx.Var(name, "int32")
+        ana.bind(v, tvm.ir.Range(0, extent))
+        return v
+
+    t = var("t", 32)
+    j = var("j", regs)
+    n = var("n", chunks)
+    w = var("w", 4)
+    g = var("g", num_wgs)
+
+    # The same DstLayout formulas with the duplicate issue dropped (d = 0);
+    # physical datapath t + 32*w is Layout F's logical row t + 16*w.
+    dp, col = _dp_col(meta, t, j, n, 0, w)
+    row = dp - 16 * w
+    col = col + g * chunks * width
+
+    thread_expect = t + 32 * (w + 4 * g)
+    value_expect = j + regs * n
+
+    thread_got, value_got = cute.to_python(cute.from_python(plan.fragment((row, col))) + (0, 0))
+    assert ana.can_prove_equal(thread_got, thread_expect), (
+        f"{meta} wgs={num_wgs} x{chunks}: fragment thread {thread_got} != {thread_expect}"
+    )
+    assert ana.can_prove_equal(value_got, value_expect), (
+        f"{meta} wgs={num_wgs} x{chunks}: fragment value {value_got} != {value_expect}"
+    )
+
+
+@pytest.mark.parametrize(("meta", "width", "regs", "ndup"), HALF_SPECS, ids=[s[0] for s in HALF_SPECS])
+def test_expand_layout_f_requires_pow2_single_issue(meta, width, regs, ndup):
+    # tcgen05_{ld,st}_core chains a copy that does not fit one instruction by
+    # advancing one column and one register per repetition, which is only
+    # exact for 32dp32b.  A Layout F plan is issued once per warp, but its
+    # repetition still spans `width` columns, so it must stay a single .xN
+    # issue just like the duplicated form -- Expand must refuse rather than
+    # emit a chained copy that walks the columns at the wrong stride.
+    assert _ffi_api.ExpandTcgen05Layout(
+        _get_meta("ld_" + meta), _layout_f_tile(width * 3), 128) is None
+    assert _ffi_api.ExpandTcgen05Layout(
+        _get_meta("ld_" + meta), _layout_f_tile(width * 4), 128) is not None
+
+
+def test_expand_32_datapath_atom_refuses_layout_f():
+    # A 32-datapath atom spans a whole sub-partition, so it cannot tile a
+    # fragment that occupies only half of one however it is issued.
+    assert _ffi_api.ExpandTcgen05Layout(_get_meta("ld_32dp32b"), _layout_f_tile(16), 128) is None
+
+
+def test_expand_issue_count_follows_the_tile():
+    # One meta, two plans: a full-datapath tile duplicates the atom onto the
+    # high 16 datapaths, a Layout F tile issues it once.  Nothing about the
+    # instruction says which -- only the tile does.  The derivation does not
+    # depend on the atom, so one is enough here; the parametrized tests above
+    # pin the resulting fragments for all three.
+    meta, width, regs, ndup = "16dp64b", 2, 1, 2
+    full = _ffi_api.ExpandTcgen05Layout(_get_meta("ld_" + meta), _column_major_tile(128, width), 128)
+    assert full is not None and full.datapaths_per_warp == 32
+    assert full.vals_per_issue == regs * ndup
+
+    half = _ffi_api.ExpandTcgen05Layout(_get_meta("ld_" + meta), _layout_f_tile(width), 128)
+    assert half is not None and half.datapaths_per_warp == 16
+    assert half.vals_per_issue == regs
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/tilelang/contrib/cutedsl/gemm_tcgen05.py
+++ b/tilelang/contrib/cutedsl/gemm_tcgen05.py
@@ -24,6 +24,16 @@ __all__ = [
     "tcgen05_ld_32dp64bNx",
     "tcgen05_ld_32dp128bNx",
     "tcgen05_ld_32dp256bNx",
+    "tcgen05_ld_16dp64bNx",
+    "tcgen05_ld_16dp128bNx",
+    "tcgen05_ld_16dp256bNx",
+    "tcgen05_st_32dp32bNx",
+    "tcgen05_st_32dp64bNx",
+    "tcgen05_st_32dp128bNx",
+    "tcgen05_st_32dp256bNx",
+    "tcgen05_st_16dp64bNx",
+    "tcgen05_st_16dp128bNx",
+    "tcgen05_st_16dp256bNx",
     "tcgen05mma_blockscaled_ss",
     "tcgen05_cp_warpx4",
     "tcgen05_sf_warp_transpose",
@@ -450,7 +460,7 @@ def _emit_tmem_ld_segment(shape, seg_x, regs_per_x, addr):
     return [cutlass.Int32(result[i]) for i in range(total_regs)]
 
 
-def _emit_tmem_ld(n_x, max_log_n, ptx_type, regs_per_x, src_addr, dst_view, dst_offset=0, src_col_offset=0):
+def _emit_tmem_ld(n_x, max_log_n, ptx_type, regs_per_x, cols_per_x, src_addr, dst_view, dst_offset=0, src_col_offset=0):
     """Recursively split x-count into power-of-2 segments and emit TMEM loads.
 
     Called during @cute.jit compilation.
@@ -458,6 +468,7 @@ def _emit_tmem_ld(n_x, max_log_n, ptx_type, regs_per_x, src_addr, dst_view, dst_
     max_log_n:      max log2 of x-count per PTX instruction
     ptx_type:       TMEM load shape, e.g. "32x32b", "16x64b"
     regs_per_x:     i32 output registers per x-element
+    cols_per_x:     b32 columns covered per x-element (1/2/4/8 for 32/64/128/256b)
     src_addr:       CuTeDSL Int32 (runtime TMEM base address)
     dst_view:       CuTeDSL tensor view over destination registers
     dst_offset:     Python int — i32 offset into dst_view (compile-time constant)
@@ -481,7 +492,17 @@ def _emit_tmem_ld(n_x, max_log_n, ptx_type, regs_per_x, src_addr, dst_view, dst_
 
     # Recurse for remainder
     total_regs_emitted = seg_x * regs_per_x
-    _emit_tmem_ld(n_x - seg_x, max_log_n, ptx_type, regs_per_x, src_addr, dst_view, dst_offset + total_regs_emitted, src_col_offset + seg_x)
+    _emit_tmem_ld(
+        n_x - seg_x,
+        max_log_n,
+        ptx_type,
+        regs_per_x,
+        cols_per_x,
+        src_addr,
+        dst_view,
+        dst_offset + total_regs_emitted,
+        src_col_offset + seg_x * cols_per_x,
+    )
 
 
 def _emit_tmem_fence():
@@ -502,7 +523,7 @@ def tcgen05_ld_32dp32bNx(N: Constexpr[int], pack16: Constexpr[bool], tmem_start_
     """
     src_addr = cutlass.Int32(tmem_start_col) + cutlass.Int32(tmem_col_offset)
     dst_view = cute.make_tensor(cute.recast_ptr(dst_ptr, dtype=cute.Int32), (N,))
-    _emit_tmem_ld(N, _TMEM_LD_MAX_LOG_N, "32x32b", 1, src_addr, dst_view)
+    _emit_tmem_ld(N, _TMEM_LD_MAX_LOG_N, "32x32b", 1, 1, src_addr, dst_view)
     _emit_tmem_fence()
 
 
@@ -517,10 +538,10 @@ def tcgen05_ld_32dp64bNx(N: Constexpr[int], pack16: Constexpr[bool], tmem_start_
     src_addr = cutlass.Int32(tmem_start_col) + cutlass.Int32(tmem_col_offset)
     dst_view = cute.make_tensor(cute.recast_ptr(dst_ptr, dtype=cute.Int32), (total_regs,))
     # Lower 16 rows
-    _emit_tmem_ld(N, _TMEM_LD_MAX_LOG_N, "16x64b", 1, src_addr, dst_view, dst_offset=0, src_col_offset=0)
+    _emit_tmem_ld(N, _TMEM_LD_MAX_LOG_N, "16x64b", 1, 2, src_addr, dst_view, dst_offset=0, src_col_offset=0)
     # Upper 16 rows (TMEM row offset = 16 << 16)
     upper_addr = src_addr + cutlass.Int32(16 << 16)
-    _emit_tmem_ld(N, _TMEM_LD_MAX_LOG_N, "16x64b", 1, upper_addr, dst_view, dst_offset=N, src_col_offset=0)
+    _emit_tmem_ld(N, _TMEM_LD_MAX_LOG_N, "16x64b", 1, 2, upper_addr, dst_view, dst_offset=N, src_col_offset=0)
     _emit_tmem_fence()
 
 
@@ -537,10 +558,10 @@ def tcgen05_ld_32dp128bNx(N: Constexpr[int], pack16: Constexpr[bool], tmem_start
     src_addr = cutlass.Int32(tmem_start_col) + cutlass.Int32(tmem_col_offset)
     dst_view = cute.make_tensor(cute.recast_ptr(dst_ptr, dtype=cute.Int32), (total_regs,))
     # Lower 16 rows
-    _emit_tmem_ld(N, min(_TMEM_LD_MAX_LOG_N, 6), "16x128b", 2, src_addr, dst_view, dst_offset=0, src_col_offset=0)
+    _emit_tmem_ld(N, min(_TMEM_LD_MAX_LOG_N, 6), "16x128b", 2, 4, src_addr, dst_view, dst_offset=0, src_col_offset=0)
     # Upper 16 rows (TMEM row offset = 16 << 16)
     upper_addr = src_addr + cutlass.Int32(16 << 16)
-    _emit_tmem_ld(N, min(_TMEM_LD_MAX_LOG_N, 6), "16x128b", 2, upper_addr, dst_view, dst_offset=regs_per_half, src_col_offset=0)
+    _emit_tmem_ld(N, min(_TMEM_LD_MAX_LOG_N, 6), "16x128b", 2, 4, upper_addr, dst_view, dst_offset=regs_per_half, src_col_offset=0)
     _emit_tmem_fence()
 
 
@@ -557,8 +578,217 @@ def tcgen05_ld_32dp256bNx(N: Constexpr[int], pack16: Constexpr[bool], tmem_start
     src_addr = cutlass.Int32(tmem_start_col) + cutlass.Int32(tmem_col_offset)
     dst_view = cute.make_tensor(cute.recast_ptr(dst_ptr, dtype=cute.Int32), (total_regs,))
     # Lower 16 rows
-    _emit_tmem_ld(N, min(_TMEM_LD_MAX_LOG_N, 6), "16x256b", 4, src_addr, dst_view, dst_offset=0, src_col_offset=0)
+    _emit_tmem_ld(N, min(_TMEM_LD_MAX_LOG_N, 6), "16x256b", 4, 8, src_addr, dst_view, dst_offset=0, src_col_offset=0)
     # Upper 16 rows (TMEM row offset = 16 << 16)
     upper_addr = src_addr + cutlass.Int32(16 << 16)
-    _emit_tmem_ld(N, min(_TMEM_LD_MAX_LOG_N, 6), "16x256b", 4, upper_addr, dst_view, dst_offset=regs_per_half, src_col_offset=0)
+    _emit_tmem_ld(N, min(_TMEM_LD_MAX_LOG_N, 6), "16x256b", 4, 8, upper_addr, dst_view, dst_offset=regs_per_half, src_col_offset=0)
     _emit_tmem_fence()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Half-subpartition (16 datapath) TMEM loads.  The 32dp wrappers above
+# issue the 16x{64,128,256}b shape twice, once per half; a PTX Layout F
+# tile (1SM M=64) occupies only the low 16 datapaths of each
+# sub-partition and needs a single issue.  Matches
+# tl::tcgen05_ld_16dp{64,128,256}bNx from copy_sm100.h.
+# ──────────────────────────────────────────────────────────────────────
+
+
+@cute.jit
+def tcgen05_ld_16dp64bNx(N: Constexpr[int], pack16: Constexpr[bool], tmem_start_col: int, tmem_col_offset: int, dst_ptr: cute.Pointer):
+    """Load from TMEM using a single 16x64b issue (low 16 rows only).
+
+    N: x-count for the 16x64b instruction. Total output: N i32 regs.
+    """
+    src_addr = cutlass.Int32(tmem_start_col) + cutlass.Int32(tmem_col_offset)
+    dst_view = cute.make_tensor(cute.recast_ptr(dst_ptr, dtype=cute.Int32), (N,))
+    _emit_tmem_ld(N, _TMEM_LD_MAX_LOG_N, "16x64b", 1, 2, src_addr, dst_view)
+    _emit_tmem_fence()
+
+
+@cute.jit
+def tcgen05_ld_16dp128bNx(N: Constexpr[int], pack16: Constexpr[bool], tmem_start_col: int, tmem_col_offset: int, dst_ptr: cute.Pointer):
+    """Load from TMEM using a single 16x128b issue (low 16 rows only).
+
+    N: x-count for the 16x128b instruction. Total output: 2*N i32 regs.
+    """
+    src_addr = cutlass.Int32(tmem_start_col) + cutlass.Int32(tmem_col_offset)
+    dst_view = cute.make_tensor(cute.recast_ptr(dst_ptr, dtype=cute.Int32), (N * 2,))
+    _emit_tmem_ld(N, min(_TMEM_LD_MAX_LOG_N, 6), "16x128b", 2, 4, src_addr, dst_view)
+    _emit_tmem_fence()
+
+
+@cute.jit
+def tcgen05_ld_16dp256bNx(N: Constexpr[int], pack16: Constexpr[bool], tmem_start_col: int, tmem_col_offset: int, dst_ptr: cute.Pointer):
+    """Load from TMEM using a single 16x256b issue (low 16 rows only).
+
+    N: x-count for the 16x256b instruction. Total output: 4*N i32 regs.
+    """
+    src_addr = cutlass.Int32(tmem_start_col) + cutlass.Int32(tmem_col_offset)
+    dst_view = cute.make_tensor(cute.recast_ptr(dst_ptr, dtype=cute.Int32), (N * 4,))
+    _emit_tmem_ld(N, min(_TMEM_LD_MAX_LOG_N, 6), "16x256b", 4, 8, src_addr, dst_view)
+    _emit_tmem_fence()
+
+
+# ──────────────────────────────────────────────────────────────────────
+# TMEM stores (tcgen05.st) — register -> TMEM, mirroring the loads.
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _emit_tmem_st_segment(shape, seg_x, regs_per_x, addr, values):
+    """Emit one tcgen05.st wrapper call for a power-of-2 segment.
+
+    Called during @cute.jit compilation — emits MLIR ops directly.
+    values: list of (seg_x * regs_per_x) Int32 register values to store.
+    """
+    tmem_ptr = prims.make_tmem_ptr(cutlass.Int32(addr), cutlass.Int32)
+    if len(values) == 1:
+        prims.tcgen05_st(shape, tmem_ptr, values[0])
+    else:
+        prims.tcgen05_st(shape, tmem_ptr, Vector.from_elements(tuple(values), cutlass.Int32))
+
+
+def _emit_tmem_st(n_x, max_log_n, ptx_type, regs_per_x, cols_per_x, dst_addr, src_view, src_offset=0, dst_col_offset=0):
+    """Recursively split x-count into power-of-2 segments and emit TMEM stores.
+
+    Mirror image of _emit_tmem_ld: registers are read from src_view and the
+    TMEM address is the destination.
+    """
+    if n_x <= 0:
+        return
+
+    log_n = n_x.bit_length() - 1
+    seg_log = min(log_n, max_log_n)
+    seg_x = 1 << seg_log
+
+    if dst_col_offset == 0:
+        addr = dst_addr
+    else:
+        addr = dst_addr + cutlass.Int32(dst_col_offset)
+
+    total_regs = seg_x * regs_per_x
+    values = [cutlass.Int32(src_view[src_offset + j]) for j in range(total_regs)]
+    _emit_tmem_st_segment(ptx_type, seg_x, regs_per_x, addr, values)
+
+    _emit_tmem_st(
+        n_x - seg_x,
+        max_log_n,
+        ptx_type,
+        regs_per_x,
+        cols_per_x,
+        dst_addr,
+        src_view,
+        src_offset + total_regs,
+        dst_col_offset + seg_x * cols_per_x,
+    )
+
+
+def _emit_tmem_st_fence():
+    """Wait for pending tcgen05.st operations."""
+    prims.tcgen05_wait(prims.Tcgen05Wait.STORE)
+
+
+def _check_no_unpack16(name, unpack16):
+    if unpack16:
+        raise NotImplementedError(f"{name}: the unpack::16b modifier is not implemented in the cutedsl runtime")
+
+
+@cute.jit
+def tcgen05_st_32dp32bNx(N: Constexpr[int], unpack16: Constexpr[bool], tmem_start_col: int, tmem_col_offset: int, src_ptr: cute.Pointer):
+    """Store N uint32 values to TMEM using tcgen05.st.sync.aligned.32x32b.
+
+    Matches tl::tcgen05_st_32dp32bNx from copy_sm100.h.
+    """
+    _check_no_unpack16("tcgen05_st_32dp32bNx", unpack16)
+    dst_addr = cutlass.Int32(tmem_start_col) + cutlass.Int32(tmem_col_offset)
+    src_view = cute.make_tensor(cute.recast_ptr(src_ptr, dtype=cute.Int32), (N,))
+    _emit_tmem_st(N, _TMEM_LD_MAX_LOG_N, "32x32b", 1, 1, dst_addr, src_view)
+    _emit_tmem_st_fence()
+
+
+@cute.jit
+def tcgen05_st_32dp64bNx(N: Constexpr[int], unpack16: Constexpr[bool], tmem_start_col: int, tmem_col_offset: int, src_ptr: cute.Pointer):
+    """Store to TMEM using 32dp64b pattern (2x 16x64b for lower/upper 16 rows).
+
+    N: x-count for 16x64b instructions. Total input: 2*N i32 regs, the lower
+    half's registers first (the duplicate issue's registers follow all
+    repetitions, matching the C++ wrappers).
+    """
+    _check_no_unpack16("tcgen05_st_32dp64bNx", unpack16)
+    dst_addr = cutlass.Int32(tmem_start_col) + cutlass.Int32(tmem_col_offset)
+    src_view = cute.make_tensor(cute.recast_ptr(src_ptr, dtype=cute.Int32), (N * 2,))
+    _emit_tmem_st(N, _TMEM_LD_MAX_LOG_N, "16x64b", 1, 2, dst_addr, src_view, src_offset=0, dst_col_offset=0)
+    upper_addr = dst_addr + cutlass.Int32(16 << 16)
+    _emit_tmem_st(N, _TMEM_LD_MAX_LOG_N, "16x64b", 1, 2, upper_addr, src_view, src_offset=N, dst_col_offset=0)
+    _emit_tmem_st_fence()
+
+
+@cute.jit
+def tcgen05_st_32dp128bNx(N: Constexpr[int], unpack16: Constexpr[bool], tmem_start_col: int, tmem_col_offset: int, src_ptr: cute.Pointer):
+    """Store to TMEM using 32dp128b pattern (2x 16x128b for lower/upper 16 rows).
+
+    N: x-count for 16x128b instructions. Total input: 4*N i32 regs.
+    """
+    _check_no_unpack16("tcgen05_st_32dp128bNx", unpack16)
+    regs_per_half = N * 2
+    dst_addr = cutlass.Int32(tmem_start_col) + cutlass.Int32(tmem_col_offset)
+    src_view = cute.make_tensor(cute.recast_ptr(src_ptr, dtype=cute.Int32), (regs_per_half * 2,))
+    _emit_tmem_st(N, min(_TMEM_LD_MAX_LOG_N, 6), "16x128b", 2, 4, dst_addr, src_view, src_offset=0, dst_col_offset=0)
+    upper_addr = dst_addr + cutlass.Int32(16 << 16)
+    _emit_tmem_st(N, min(_TMEM_LD_MAX_LOG_N, 6), "16x128b", 2, 4, upper_addr, src_view, src_offset=regs_per_half, dst_col_offset=0)
+    _emit_tmem_st_fence()
+
+
+@cute.jit
+def tcgen05_st_32dp256bNx(N: Constexpr[int], unpack16: Constexpr[bool], tmem_start_col: int, tmem_col_offset: int, src_ptr: cute.Pointer):
+    """Store to TMEM using 32dp256b pattern (2x 16x256b for lower/upper 16 rows).
+
+    N: x-count for 16x256b instructions. Total input: 8*N i32 regs.
+    """
+    _check_no_unpack16("tcgen05_st_32dp256bNx", unpack16)
+    regs_per_half = N * 4
+    dst_addr = cutlass.Int32(tmem_start_col) + cutlass.Int32(tmem_col_offset)
+    src_view = cute.make_tensor(cute.recast_ptr(src_ptr, dtype=cute.Int32), (regs_per_half * 2,))
+    _emit_tmem_st(N, min(_TMEM_LD_MAX_LOG_N, 6), "16x256b", 4, 8, dst_addr, src_view, src_offset=0, dst_col_offset=0)
+    upper_addr = dst_addr + cutlass.Int32(16 << 16)
+    _emit_tmem_st(N, min(_TMEM_LD_MAX_LOG_N, 6), "16x256b", 4, 8, upper_addr, src_view, src_offset=regs_per_half, dst_col_offset=0)
+    _emit_tmem_st_fence()
+
+
+@cute.jit
+def tcgen05_st_16dp64bNx(N: Constexpr[int], unpack16: Constexpr[bool], tmem_start_col: int, tmem_col_offset: int, src_ptr: cute.Pointer):
+    """Store to TMEM using a single 16x64b issue (low 16 rows only).
+
+    N: x-count for the 16x64b instruction. Total input: N i32 regs.
+    """
+    _check_no_unpack16("tcgen05_st_16dp64bNx", unpack16)
+    dst_addr = cutlass.Int32(tmem_start_col) + cutlass.Int32(tmem_col_offset)
+    src_view = cute.make_tensor(cute.recast_ptr(src_ptr, dtype=cute.Int32), (N,))
+    _emit_tmem_st(N, _TMEM_LD_MAX_LOG_N, "16x64b", 1, 2, dst_addr, src_view)
+    _emit_tmem_st_fence()
+
+
+@cute.jit
+def tcgen05_st_16dp128bNx(N: Constexpr[int], unpack16: Constexpr[bool], tmem_start_col: int, tmem_col_offset: int, src_ptr: cute.Pointer):
+    """Store to TMEM using a single 16x128b issue (low 16 rows only).
+
+    N: x-count for the 16x128b instruction. Total input: 2*N i32 regs.
+    """
+    _check_no_unpack16("tcgen05_st_16dp128bNx", unpack16)
+    dst_addr = cutlass.Int32(tmem_start_col) + cutlass.Int32(tmem_col_offset)
+    src_view = cute.make_tensor(cute.recast_ptr(src_ptr, dtype=cute.Int32), (N * 2,))
+    _emit_tmem_st(N, min(_TMEM_LD_MAX_LOG_N, 6), "16x128b", 2, 4, dst_addr, src_view)
+    _emit_tmem_st_fence()
+
+
+@cute.jit
+def tcgen05_st_16dp256bNx(N: Constexpr[int], unpack16: Constexpr[bool], tmem_start_col: int, tmem_col_offset: int, src_ptr: cute.Pointer):
+    """Store to TMEM using a single 16x256b issue (low 16 rows only).
+
+    N: x-count for the 16x256b instruction. Total input: 4*N i32 regs.
+    """
+    _check_no_unpack16("tcgen05_st_16dp256bNx", unpack16)
+    dst_addr = cutlass.Int32(tmem_start_col) + cutlass.Int32(tmem_col_offset)
+    src_view = cute.make_tensor(cute.recast_ptr(src_ptr, dtype=cute.Int32), (N * 4,))
+    _emit_tmem_st(N, min(_TMEM_LD_MAX_LOG_N, 6), "16x256b", 4, 8, dst_addr, src_view)
+    _emit_tmem_st_fence()


### PR DESCRIPTION
A PTX Layout F fragment -- the 1SM M=64 shape make_tmem_frg_a/c selects -- occupies only the LOW 16 datapaths of each 32-datapath sub-partition, so its four warp groups sit 32 datapaths apart with nothing in between. ExpandTcgen05Layout assumed every tile covers 128 contiguous datapaths, so no instruction could be planned for one: an M=64 TS GEMM could not get its A operand into TMEM at all, dying with "Failed to find a suitable instruction for tcgen05.st". 
Tracks #2877.

No new PTX and no new atoms. The 32dp wrappers already issue the 16x{64,128,256}b shapes twice, once per half, so this adds wrappers that stop after the first issue -- and whether a tile wants one form or the other is a property of the TILE, so the planner derives it rather than the metas carrying a flag: right_inverse's maximal contiguous run is 128 when the fragment fills every datapath and exactly the atom's own extent when it is Layout F. One meta per width still covers both, and the plan reports the datapaths one warp ends up covering -- the number the wrapper is named after, which codegen prints straight into tcgen05_{ld,st}_NNdp*Nx.

### Solution

Replication is one explicit stamp -- what a single wrapper call covers -- rather than a blocked product whose complement happens to enumerate the gaps in the order the wrapper wants them. That coincidence holds only for a dense tile: for Layout F the complement's fastest gap is the unoccupied datapaths above the atom, so it would pack the warps in at stride 16 instead of one sub-partition apart. Spelling the stamp out costs a few lines and serves both.

Mapping it back to logical indices takes two inverses, because two kinds of tile arrive. inv_prefix spans the maximal contiguous chunk -- one whole issue for a full-datapath tile, and valid even where the tile is not injective, as a pack::16b tile is not. A Layout F issue reaches four datapath groups 32 apart so no contiguous prefix covers it, but such a tile IS injective, and left_inverse is then a genuine physical -> logical map with no contiguity requirement. Either way the placement is derived from the tile, not assumed of it.

Which datapaths of a sub-partition a warp covers is read off the tile too -- the run along the datapath axis alone, clamped to the 32 a warp owns -- so an atom too wide for it (32dp32b against Layout F) falls out as a non-division rather than needing a case of its own, and the answer does not depend on whether the tile's columns count values or b32 slots.

### Two things a 16-bit Layout F operand gets wrong if taken from the old code

`pack::16b` was judged by "does the fragment cover its codomain". Layout F leaves gaps on the datapath axis, not inside its columns, and was misread as half-filled -- emitting the modifier for a tile whose columns are full. TmemFragmentNeedsPack16b now asks the intended question directly: is every column of every occupied datapath full?

A partial sub-partition cannot be planned in value columns. Only the width-1 32dp32b atom is insensitive to the unit; the wider atoms pick their b32 column with a LANE bit, so stepping their columns by a value column splits each register's pair across two columns, transposing K with the column's low bit and silently permuting the A operand as [0,2,1,3] within every group of four. The stamp therefore steps the atom by a whole b32 column and carries the packed partner as its own fastest value axis. Only how many tile columns share a b32 column has to be passed in: a value-column layout cannot say that about itself.

Verified on B200: an M=64 TS GEMM with A staged through registers into TMEM now matches torch for K in {64,128,256,512} (and M=128 is unchanged); recovering the operand the MMA actually read is the identity, where it was the permutation above. Layout F register->TMEM->register round trips are bit-exact for fp32 and packed bf16 over one and two warpgroups; the fragments are proven against the CUTLASS Copy_Traits DstLayout formulas symbolically, for all lanes/registers/repetitions/warps at once; full-datapath tiles still lower to the identical 32dp instruction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Add half-subpartition (`M=64`) TMEM tile support for `tcgen05.ld/st`.
- Derive Layout F expansion, packing detection, datapath coverage, replication, issue planning, and inverse mappings from tile layouts.
- Add 16-datapath load and store wrappers for 64-, 128-, and 256-bit transfers.
- Add synchronization fences and correct chained-segment column advancement.
- Preserve full-datapath lowering and reject unsupported configurations.
- Keep legacy six-argument `tcgen05.ld/st` calls on 32-datapath behavior.

## Validation

- Add M=64 TS GEMM tests for K=64, 128, 256, and 512.
- Validate M=128 lowering, Layout F register-to-TMEM round trips, packed-pair handling, and CUTLASS `Copy_Traits` mappings.
- Test invalid atom, chunk, repetition, issue, and datapath configurations.
- Validate CuTeDSL TMEM copy and GEMM correctness.

## C++ style / lint notes

- The PR changes C++ APIs but does not change `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step applies.
- Treat TLCPP003/TLCPP004 findings as advisory unless they indicate a clear API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->