### PR TITLE
[BugFix] Deduplicate replicated reducer updates

### DIFF
--- a/src/transform/loop_partition.cc
+++ b/src/transform/loop_partition.cc
@@ -92,7 +92,7 @@ private:
 // Rewrite the parallel loop into a common loop, which is mapped to threads
 For PartitionLoop(For op, PrimExpr thread_index, arith::Analyzer *analyzer,
                   const Fragment &loop_layout, bool require_padding_guard,
-                  const Array<Buffer> &canonical_reducer_buffers) {
+                  const Array<Buffer> &fully_replicated_reducer_buffers) {
   ICHECK(loop_layout.defined());
   ICHECK(thread_index.defined());
   int old_loop_depth = loop_layout->InputDim();
@@ -171,13 +171,17 @@ For PartitionLoop(For op, PrimExpr thread_index, arith::Analyzer *analyzer,
         analyzer->Simplify(replicate_index < replicate_extent);
     guard = And(guard, And(lower_bound, upper_bound));
   }
-  if (!canonical_reducer_buffers.empty()) {
+  if (!fully_replicated_reducer_buffers.empty()) {
     ICHECK_GT(indices.size(), static_cast<size_t>(old_loop_depth));
-    PrimExpr canonical_replica = analyzer->Simplify(EQ(
+    // InverseWithLevel appends REP after the original loop indices, so
+    // indices[old_loop_depth] is REP. Stores to buffers in this list execute
+    // only for REP=0.
+    PrimExpr is_replica_zero = analyzer->Simplify(EQ(
         indices[old_loop_depth], make_zero(indices[old_loop_depth].dtype())));
-    if (!analyzer->CanProve(canonical_replica)) {
+    if (!analyzer->CanProve(is_replica_zero)) {
+      // Rewrite with IfThenElse statement
       body = ReducerStoreGuarder::Rewrite(
-          std::move(body), canonical_reducer_buffers, canonical_replica);
+          std::move(body), fully_replicated_reducer_buffers, is_replica_zero);
     }
   }
   PrimExpr simplified_guard = analyzer->Simplify(guard);
@@ -304,7 +308,7 @@ Stmt LowerParallelLoop(For loop, const Fragment &loop_layout,
                        const LayoutMap &layout_map,
                        Optional<PrimExpr> predicate, bool parallel_loop,
                        bool should_vectorize, bool require_padding_guard,
-                       const Array<Buffer> &canonical_reducer_buffers) {
+                       const Array<Buffer> &fully_replicated_reducer_buffers) {
   // Save analyzer state to prevent conflicted bindings during vectorization
   auto saved_analyzer = analyzer->Clone();
 
@@ -324,7 +328,7 @@ Stmt LowerParallelLoop(For loop, const Fragment &loop_layout,
   if (parallel_loop) {
     result_loop =
         PartitionLoop(result_loop, thread_index, analyzer, loop_layout,
-                      require_padding_guard, canonical_reducer_buffers);
+                      require_padding_guard, fully_replicated_reducer_buffers);
   }
 
   // Step 2: Vectorize the loop (if requested)

--- a/src/transform/loop_partition.cc
+++ b/src/transform/loop_partition.cc
@@ -28,7 +28,6 @@
 
 #include <tvm/tirx/stmt_functor.h>
 
-#include <unordered_set>
 #include <utility>
 
 #include "../op/utils.h"
@@ -73,24 +72,20 @@ public:
   }
 
 private:
-  using BufferSet = std::unordered_set<Buffer, ObjectPtrHash, ObjectPtrEqual>;
-
   ReducerStoreGuarder(const Array<Buffer> &reducer_buffers, PrimExpr predicate)
-      : predicate_(std::move(predicate)) {
-    for (const Buffer &buffer : reducer_buffers) {
-      reducer_buffers_.insert(buffer);
-    }
-  }
+      : reducer_buffers_(reducer_buffers), predicate_(std::move(predicate)) {}
 
   Stmt VisitStmt_(const BufferStoreNode *op) final {
     BufferStore store = Downcast<BufferStore>(StmtExprMutator::VisitStmt_(op));
-    if (!reducer_buffers_.count(store->buffer)) {
-      return store;
+    for (const Buffer &buffer : reducer_buffers_) {
+      if (buffer.same_as(store->buffer)) {
+        return IfThenElse(predicate_, store);
+      }
     }
-    return IfThenElse(predicate_, store);
+    return store;
   }
 
-  BufferSet reducer_buffers_;
+  Array<Buffer> reducer_buffers_;
   PrimExpr predicate_;
 };
 

--- a/src/transform/loop_partition.cc
+++ b/src/transform/loop_partition.cc
@@ -28,6 +28,7 @@
 
 #include <tvm/tirx/stmt_functor.h>
 
+#include <unordered_set>
 #include <utility>
 
 #include "../op/utils.h"
@@ -63,9 +64,40 @@ private:
   arith::Analyzer *analyzer_;
 };
 
+class ReducerStoreGuarder : public StmtExprMutator {
+public:
+  static Stmt Rewrite(Stmt stmt, const Array<Buffer> &reducer_buffers,
+                      const PrimExpr &predicate) {
+    ReducerStoreGuarder guarder(reducer_buffers, predicate);
+    return guarder(std::move(stmt));
+  }
+
+private:
+  using BufferSet = std::unordered_set<Buffer, ObjectPtrHash, ObjectPtrEqual>;
+
+  ReducerStoreGuarder(const Array<Buffer> &reducer_buffers, PrimExpr predicate)
+      : predicate_(std::move(predicate)) {
+    for (const Buffer &buffer : reducer_buffers) {
+      reducer_buffers_.insert(buffer);
+    }
+  }
+
+  Stmt VisitStmt_(const BufferStoreNode *op) final {
+    BufferStore store = Downcast<BufferStore>(StmtExprMutator::VisitStmt_(op));
+    if (!reducer_buffers_.count(store->buffer)) {
+      return store;
+    }
+    return IfThenElse(predicate_, store);
+  }
+
+  BufferSet reducer_buffers_;
+  PrimExpr predicate_;
+};
+
 // Rewrite the parallel loop into a common loop, which is mapped to threads
 For PartitionLoop(For op, PrimExpr thread_index, arith::Analyzer *analyzer,
-                  const Fragment &loop_layout, bool require_padding_guard) {
+                  const Fragment &loop_layout, bool require_padding_guard,
+                  const Array<Buffer> &canonical_reducer_buffers) {
   ICHECK(loop_layout.defined());
   ICHECK(thread_index.defined());
   int old_loop_depth = loop_layout->InputDim();
@@ -143,6 +175,15 @@ For PartitionLoop(For op, PrimExpr thread_index, arith::Analyzer *analyzer,
     PrimExpr upper_bound =
         analyzer->Simplify(replicate_index < replicate_extent);
     guard = And(guard, And(lower_bound, upper_bound));
+  }
+  if (!canonical_reducer_buffers.empty()) {
+    ICHECK_GT(indices.size(), static_cast<size_t>(old_loop_depth));
+    PrimExpr canonical_replica = analyzer->Simplify(EQ(
+        indices[old_loop_depth], make_zero(indices[old_loop_depth].dtype())));
+    if (!analyzer->CanProve(canonical_replica)) {
+      body = ReducerStoreGuarder::Rewrite(
+          std::move(body), canonical_reducer_buffers, canonical_replica);
+    }
   }
   PrimExpr simplified_guard = analyzer->Simplify(guard);
   if (!analyzer->CanProve(simplified_guard)) {
@@ -267,7 +308,8 @@ Stmt LowerParallelLoop(For loop, const Fragment &loop_layout,
                        PrimExpr thread_index, arith::Analyzer *analyzer,
                        const LayoutMap &layout_map,
                        Optional<PrimExpr> predicate, bool parallel_loop,
-                       bool should_vectorize, bool require_padding_guard) {
+                       bool should_vectorize, bool require_padding_guard,
+                       const Array<Buffer> &canonical_reducer_buffers) {
   // Save analyzer state to prevent conflicted bindings during vectorization
   auto saved_analyzer = analyzer->Clone();
 
@@ -285,8 +327,9 @@ Stmt LowerParallelLoop(For loop, const Fragment &loop_layout,
 
   // Step 1: Partition the loop based on the layout (if this is a parallel loop)
   if (parallel_loop) {
-    result_loop = PartitionLoop(result_loop, thread_index, analyzer,
-                                loop_layout, require_padding_guard);
+    result_loop =
+        PartitionLoop(result_loop, thread_index, analyzer, loop_layout,
+                      require_padding_guard, canonical_reducer_buffers);
   }
 
   // Step 2: Vectorize the loop (if requested)

--- a/src/transform/loop_partition.h
+++ b/src/transform/loop_partition.h
@@ -39,7 +39,8 @@ using namespace tirx;
 
 For PartitionLoop(For op, PrimExpr thread_index, arith::Analyzer *analyzer,
                   const Fragment &loop_layout,
-                  bool require_padding_guard = false);
+                  bool require_padding_guard = false,
+                  const ffi::Array<Buffer> &canonical_reducer_buffers = {});
 
 Fragment PlanLoopPartition(const For &op, size_t num_thread,
                            int vectorize_size);
@@ -69,6 +70,8 @@ For PragmaUnrollLoop(For stmt);
  * \param should_vectorize Whether to vectorize the loop. False when reducers
  *        are present or when there are no non-local buffer accesses.
  *        (default true)
+ * \param canonical_reducer_buffers Fully replicated reducer buffers whose
+ *        stores must execute only on the canonical loop replica.
  * \return The lowered statement.
  */
 Stmt LowerParallelLoop(
@@ -76,7 +79,8 @@ Stmt LowerParallelLoop(
     arith::Analyzer *analyzer, const LayoutMap &layout_map = {},
     ffi::Optional<PrimExpr> predicate = ffi::Optional<PrimExpr>(),
     bool parallel_loop = true, bool should_vectorize = true,
-    bool require_padding_guard = false);
+    bool require_padding_guard = false,
+    const ffi::Array<Buffer> &canonical_reducer_buffers = {});
 
 } // namespace tl
 } // namespace tvm

--- a/src/transform/loop_partition.h
+++ b/src/transform/loop_partition.h
@@ -40,6 +40,8 @@ using namespace tirx;
 For PartitionLoop(
     For op, PrimExpr thread_index, arith::Analyzer *analyzer,
     const Fragment &loop_layout, bool require_padding_guard = false,
+    // TODO(lei): Remove this reducer-specific compatibility parameter after
+    // reducer lowering explicitly models update ownership.
     const ffi::Array<Buffer> &fully_replicated_reducer_buffers = {});
 
 Fragment PlanLoopPartition(const For &op, size_t num_thread,
@@ -70,8 +72,10 @@ For PragmaUnrollLoop(For stmt);
  * \param should_vectorize Whether to vectorize the loop. False when reducers
  *        are present or when there are no non-local buffer accesses.
  *        (default true)
- * \param fully_replicated_reducer_buffers Reducer buffers whose stores execute
- *        only for REP=0 of the current loop layout.
+ * \param fully_replicated_reducer_buffers Temporary compatibility hook for
+ *        restricting reducer stores to REP=0 of the current loop layout. It
+ *        should be removed after reducer lowering explicitly models update
+ *        ownership.
  * \return The lowered statement.
  */
 Stmt LowerParallelLoop(

--- a/src/transform/loop_partition.h
+++ b/src/transform/loop_partition.h
@@ -37,10 +37,10 @@ namespace tl {
 
 using namespace tirx;
 
-For PartitionLoop(For op, PrimExpr thread_index, arith::Analyzer *analyzer,
-                  const Fragment &loop_layout,
-                  bool require_padding_guard = false,
-                  const ffi::Array<Buffer> &canonical_reducer_buffers = {});
+For PartitionLoop(
+    For op, PrimExpr thread_index, arith::Analyzer *analyzer,
+    const Fragment &loop_layout, bool require_padding_guard = false,
+    const ffi::Array<Buffer> &fully_replicated_reducer_buffers = {});
 
 Fragment PlanLoopPartition(const For &op, size_t num_thread,
                            int vectorize_size);
@@ -70,8 +70,8 @@ For PragmaUnrollLoop(For stmt);
  * \param should_vectorize Whether to vectorize the loop. False when reducers
  *        are present or when there are no non-local buffer accesses.
  *        (default true)
- * \param canonical_reducer_buffers Fully replicated reducer buffers whose
- *        stores must execute only on the canonical loop replica.
+ * \param fully_replicated_reducer_buffers Reducer buffers whose stores execute
+ *        only for REP=0 of the current loop layout.
  * \return The lowered statement.
  */
 Stmt LowerParallelLoop(
@@ -80,7 +80,7 @@ Stmt LowerParallelLoop(
     ffi::Optional<PrimExpr> predicate = ffi::Optional<PrimExpr>(),
     bool parallel_loop = true, bool should_vectorize = true,
     bool require_padding_guard = false,
-    const ffi::Array<Buffer> &canonical_reducer_buffers = {});
+    const ffi::Array<Buffer> &fully_replicated_reducer_buffers = {});
 
 } // namespace tl
 } // namespace tvm

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -1387,20 +1387,24 @@ private:
     // the body, buffers may have been remapped via var_remap_. We need to find
     // the original var to check against reducer_info.
     bool has_reducer = false;
+    Array<Buffer> canonical_reducer_buffers;
     PostOrderVisit(for_node->body, [&](const ObjectRef &obj) {
-      if (!has_reducer) {
-        if (const auto *store = obj.as<BufferStoreNode>()) {
-          Var data_var = store->buffer->data;
-          // Find the original var if it was remapped
-          // var_remap_ maps old_var -> new_var, so we need reverse lookup
-          Var original_var = data_var;
-          for (const auto &[old_var, new_var] : var_remap_) {
-            if (new_var.same_as(data_var)) {
-              original_var = old_var;
-              break;
-            }
+      if (const auto *store = obj.as<BufferStoreNode>()) {
+        Var data_var = store->buffer->data;
+        // Find the original var if it was remapped
+        // var_remap_ maps old_var -> new_var, so we need reverse lookup
+        Var original_var = data_var;
+        for (const auto &[old_var, new_var] : var_remap_) {
+          if (new_var.same_as(data_var)) {
+            original_var = old_var;
+            break;
           }
-          has_reducer = reducer_info.count(original_var) != 0;
+        }
+        if (reducer_info.count(original_var)) {
+          has_reducer = true;
+          if (reducer_info[original_var]->rep == ReducerRepType::ALL) {
+            canonical_reducer_buffers.push_back(store->buffer);
+          }
         }
       }
     });
@@ -1426,7 +1430,8 @@ private:
     // Lower the parallel loop using the common function
     Stmt lowered = LowerParallelLoop(
         for_node, loop_layout, CurrentThreadIndex(), analyzer_, layout_map_,
-        predicate, parallel_loop, should_vectorize, require_padding_guard);
+        predicate, parallel_loop, should_vectorize, require_padding_guard,
+        canonical_reducer_buffers);
 
     // Only parallel-loop lowering needs PTX cp.async injection. Thread-level
     // lowering does not require converting eligible global->shared copies to

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -1387,7 +1387,9 @@ private:
     // the body, buffers may have been remapped via var_remap_. We need to find
     // the original var to check against reducer_info.
     bool has_reducer = false;
-    Array<Buffer> canonical_reducer_buffers;
+    // Stores to buffers in this list must execute only for REP=0 of the
+    // current T.Parallel loop layout.
+    Array<Buffer> fully_replicated_reducer_buffers;
     PostOrderVisit(for_node->body, [&](const ObjectRef &obj) {
       if (const auto *store = obj.as<BufferStoreNode>()) {
         Var data_var = store->buffer->data;
@@ -1403,7 +1405,7 @@ private:
         if (reducer_info.count(original_var)) {
           has_reducer = true;
           if (reducer_info[original_var]->rep == ReducerRepType::ALL) {
-            canonical_reducer_buffers.push_back(store->buffer);
+            fully_replicated_reducer_buffers.push_back(store->buffer);
           }
         }
       }
@@ -1431,7 +1433,7 @@ private:
     Stmt lowered = LowerParallelLoop(
         for_node, loop_layout, CurrentThreadIndex(), analyzer_, layout_map_,
         predicate, parallel_loop, should_vectorize, require_padding_guard,
-        canonical_reducer_buffers);
+        fully_replicated_reducer_buffers);
 
     // Only parallel-loop lowering needs PTX cp.async injection. Thread-level
     // lowering does not require converting eligible global->shared copies to

--- a/testing/python/language/test_tilelang_language_reduce.py
+++ b/testing/python/language/test_tilelang_language_reduce.py
@@ -742,6 +742,61 @@ def test_finalize_reducer_correctness(op, dtype, block_M, block_N, batch):
     torch.testing.assert_close(B, _ref(A, op), atol=1e-2, rtol=1e-2)
 
 
+@tilelang.testing.requires_cuda
+def test_finalize_reducer_short_parallel_extent():
+    extent = 8
+    threads = 128
+
+    @T.prim_func
+    def kernel(A: T.Tensor((extent,), T.float32), B: T.Tensor((1,), T.float32)):
+        with T.Kernel(1, threads=threads):
+            src = T.alloc_fragment((extent,), T.float32)
+            T.copy(A, src)
+            total = T.alloc_reducer((1,), T.float32, replication="all")
+            T.clear(total)
+            for i in T.Parallel(extent):
+                total[0] += src[i]
+            T.finalize_reducer(total)
+            if T.get_thread_binding() == 0:
+                B[0] = total[0]
+
+    A = torch.arange(1, extent + 1, dtype=torch.float32, device="cuda")
+    B = tl.compile(kernel, out_idx=-1, pass_configs=_COMPILE_FLAGS)(A)
+    torch.testing.assert_close(B, A.sum().reshape(1), atol=0, rtol=0)
+
+
+@tilelang.testing.requires_cuda
+def test_finalize_reducer_mixed_parallel_extents():
+    extent = 8
+    threads = 128
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((extent,), T.float32),
+        B: T.Tensor((2 * extent,), T.float32),
+        C: T.Tensor((1,), T.float32),
+    ):
+        with T.Kernel(1, threads=threads):
+            a_frag = T.alloc_fragment((extent,), T.float32)
+            b_frag = T.alloc_fragment((2 * extent,), T.float32)
+            T.copy(A, a_frag)
+            T.copy(B, b_frag)
+            total = T.alloc_reducer((1,), T.float32, replication="all")
+            T.clear(total)
+            for i in T.Parallel(extent):
+                total[0] += a_frag[i]
+            for j in T.Parallel(2 * extent):
+                total[0] += b_frag[j]
+            T.finalize_reducer(total)
+            if T.get_thread_binding() == 0:
+                C[0] = total[0]
+
+    A = torch.arange(1, extent + 1, dtype=torch.float32, device="cuda")
+    B = torch.arange(1, 2 * extent + 1, dtype=torch.float32, device="cuda")
+    C = tl.compile(kernel, out_idx=-1, pass_configs=_COMPILE_FLAGS)(A, B)
+    torch.testing.assert_close(C, (A.sum() + B.sum()).reshape(1), atol=0, rtol=0)
+
+
 # (batch, exc_type, match)
 FINALIZE_REDUCER_INVALID_CASES = [
     (0, ValueError, "batch must be >= 1"),


### PR DESCRIPTION
An issue with replicated reducer fragment buffers will occur when loaded with `T.Parallel`. This can be reproduced with:

```python
@tilelang.jit(
    out_idx=None,
    target="cuda",
    pass_configs=PASS_CONFIGS,
)
def reduce_with_finalize_reducer_tl():
    @T.prim_func
    def _reduce_with_finalize_reducer(
        x: T.Tensor((BD,), T.float32),
        out: T.Tensor((1,), T.float32),
    ) -> None:
        with T.Kernel(1, threads=THREADS):
            x_frag = T.alloc_fragment((BD,), T.float32)
            T.copy(x, x_frag)

            total = T.alloc_reducer((1,), T.float32, replication="all")
            T.fill(total, 0.0)
            for j in T.Parallel(BD):
                total[0] += x_frag[j]
            T.finalize_reducer(total)

            if T.get_thread_binding() == 0:
                out[0] = total[0]

    return _reduce_with_finalize_reducer
```

This produces cuda codes like:

```cuda
  float x_frag[1];
  float total[1];

  x_frag[0] = x[threadIdx.x & 7]; // !?
  total[0] = 0;
  total[0] += x_frag[0]; // !?
  AllReduce<SumOp, 128>(total[0]);
```

Reducer fragment buffers have long lifespan and can interact with multiple `T.Parallel`s and buffers, making its layout hard to analyze.

For conveneince and correctness, this issue is fixed by only enabling the first replicate (e.g. `rep == 0`) to write to reducer buffers. Now the following code will be generated, leaving sementics with `T.Parallel` unchanged:

```cuda
  float x_frag[1];
  float total[1];

  x_frag[0] = x[threadIdx.x & 7];
  total[0] = 0;
  if ((threadIdx.x >> 3) == 0) {
    total[0] += x_frag[0];
  }
  AllReduce<SumOp, 128>(total[0]);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Guard stores to fully replicated reducer buffers so only the canonical replica (`REP=0`) updates each buffer.
- Pass replicated reducer buffers through `PartitionLoop` and `LowerParallelLoop`.
- Preserve reducer buffer lookup order and verify buffer identity with `Buffer::same_as`.
- Add CUDA regressions for short and mixed parallel extents.
- Mark the reducer partition hook as temporary in the documentation.

## C++ style / lint notes

- The PR changes C++ implementation and public declarations but does not modify `docs/developer_guide/cpp_style.md`.
- The `C++ API Style Audit (warning only)` CI step may report advisory findings for the updated APIs.
- These findings are separate from correctness, build, and test results.
- No blocking style issue is identified from the provided changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->