### PR TITLE
[BugFix][JIT] Validate output parameter indices consistently

### DIFF
--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -794,6 +794,47 @@ void CodeGenTileLangHIP::VisitExpr_(const ShuffleNode *op,
   CodeGenC::VisitExpr_(op, os);
 }
 
+void CodeGenTileLangHIP::VisitExpr_(const SelectNode *op, std::ostream &os) {
+  // Non-vector cases.
+  if (!op->condition.dtype().is_fixed_length_vector()) {
+    CodeGenC::VisitExpr_(op, os);
+    return;
+  }
+
+  // Codegen vector condition case by serializing the select op.
+  TVM_FFI_ICHECK(op->false_value->dtype == op->dtype &&
+                 op->true_value->dtype == op->dtype &&
+                 op->dtype.lanes() == op->condition.dtype().lanes());
+
+  std::string r_var = name_supply_->FreshName("_");
+  this->PrintIndent();
+  this->PrintType(op->dtype, stream);
+  stream << ' ' << r_var << ";\n";
+  {
+    std::string c_var =
+        SSAGetID(PrintExpr(op->condition), op->condition.dtype());
+    std::string t_var = SSAGetID(PrintExpr(op->true_value), op->dtype);
+    std::string f_var = SSAGetID(PrintExpr(op->false_value), op->dtype);
+
+    // The condition is stored as an ushort vector.
+    int lanes = op->dtype.lanes();
+    DataType memory_ty(DataType::TypeCode::kUInt, 16, lanes);
+
+    for (int i = 0; i < lanes; ++i) {
+      std::ostringstream item;
+      item << "(bool(";
+      PrintVecElemLoad(c_var, memory_ty, i, item);
+      item << ")?";
+      PrintVecElemLoad(t_var, op->dtype, i, item);
+      item << ':';
+      PrintVecElemLoad(f_var, op->dtype, i, item);
+      item << ')';
+      PrintVecElemStore(r_var, op->dtype, i, item.str());
+    }
+  }
+  os << r_var;
+}
+
 void CodeGenTileLangHIP::VisitExpr_(const CastNode *op, std::ostream &os) {
   DataType from_ty = op->value.dtype();
   DataType target_ty = op->dtype;

--- a/src/rocm/codegen/codegen_hip.h
+++ b/src/rocm/codegen/codegen_hip.h
@@ -51,6 +51,7 @@ public:
   void VisitExpr_(const CallNode *op, std::ostream &os) final;
   void VisitExpr_(const CastNode *op, std::ostream &os) final;
   void VisitExpr_(const ShuffleNode *op, std::ostream &os) final; // NOLINT(*)
+  void VisitExpr_(const SelectNode *op, std::ostream &os) final;
   void VisitStmt_(const AllocBufferNode *op) final;
   void VisitStmt_(const AttrStmtNode *op) final;
   void VisitStmt_(const BufferStoreNode *op) final;

--- a/testing/python/amd/test_tilelang_hip_vector_select_codegen.py
+++ b/testing/python/amd/test_tilelang_hip_vector_select_codegen.py
@@ -1,0 +1,42 @@
+import pytest
+
+from tilelang import tvm
+from tvm import tirx
+
+
+def _build_vector_select_source():
+    lanes = 4
+    input_buffer = tirx.decl_buffer((lanes,), "float32", name="input")
+    output_buffer = tirx.decl_buffer((lanes,), "float32", name="output")
+    ramp = tirx.Ramp(0, 1, lanes)
+    input_vector = tirx.BufferLoad(input_buffer, [ramp])
+    zero = tirx.Broadcast(tirx.const(0, "float32"), lanes)
+    selected = tirx.Select(input_vector > zero, input_vector, zero)
+    body = tirx.BufferStore(output_buffer, selected, [ramp])
+    func = tirx.PrimFunc(
+        [input_buffer.data, output_buffer.data],
+        body,
+        buffer_map={
+            input_buffer.data: input_buffer,
+            output_buffer.data: output_buffer,
+        },
+    )
+    func = func.with_attr("global_symbol", "vector_select")
+    func = func.with_attr("calling_conv", tvm.ir.CallingConv.DEVICE_KERNEL_LAUNCH)
+    mod = tvm.IRModule({"vector_select": func})
+    build = tvm.get_global_func("target.build.tilelang_hip_without_compile", allow_missing=True)
+    if build is None:
+        pytest.skip("TileLang was built without the ROCm code generator")
+    return build(mod, tvm.target.Target("rocm")).inspect_source()
+
+
+def test_vector_condition_select_is_scalarized_in_hip_source():
+    source = _build_vector_select_source()
+
+    assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
+    assert len(assignments) == 4
+    assert all("bool(" in line for line in assignments)
+
+
+if __name__ == "__main__":
+    test_vector_condition_select_is_scalarized_in_hip_source()

--- a/testing/python/issue/test_tilelang_issue_2682.py
+++ b/testing/python/issue/test_tilelang_issue_2682.py
@@ -1,8 +1,8 @@
 """Regression test for issue #2682.
 
 T.vectorized with T.Select incorrectly generates scalar ternary expressions.
-CodeGenTileLangCUDA misses the handling of vectorized SelectNode, causing
-a fallback to CodeGenC in tvm that generates a scalar ternary expression.
+The CUDA and HIP code generators must lower vectorized SelectNode lane-wise;
+otherwise CodeGenC emits a scalar ternary expression for a vector condition.
 """
 
 import tilelang

--- a/testing/python/profiler/test_tilelang_result_idx_validation.py
+++ b/testing/python/profiler/test_tilelang_result_idx_validation.py
@@ -1,0 +1,62 @@
+import pytest
+
+from tilelang.jit.adapter import BaseKernelAdapter
+from tilelang.profiler import Profiler
+from tilelang.utils.tensor import TensorSupplyType
+
+
+class _TestAdapter(BaseKernelAdapter):
+    def _convert_torch_func(self):
+        return lambda: None
+
+
+_PARAMS = [object(), object(), object()]
+
+
+def _legalize_with_adapter(result_idx):
+    return _TestAdapter(None, _PARAMS, result_idx).result_idx
+
+
+def _legalize_with_profiler(result_idx):
+    return Profiler(_PARAMS, result_idx, TensorSupplyType.Integer).result_idx
+
+
+@pytest.mark.parametrize(
+    "legalize",
+    [_legalize_with_adapter, _legalize_with_profiler],
+    ids=["adapter", "profiler"],
+)
+@pytest.mark.parametrize("as_list", [False, True], ids=["int", "list"])
+@pytest.mark.parametrize(
+    ("index", "expected"),
+    [(-3, [0]), (-1, [2]), (0, [0]), (2, [2])],
+)
+def test_result_idx_accepts_valid_boundaries(legalize, as_list, index, expected):
+    result_idx = [index] if as_list else index
+
+    assert legalize(result_idx) == expected
+
+
+@pytest.mark.parametrize(
+    "legalize",
+    [_legalize_with_adapter, _legalize_with_profiler],
+    ids=["adapter", "profiler"],
+)
+@pytest.mark.parametrize("as_list", [False, True], ids=["int", "list"])
+@pytest.mark.parametrize("index", [-4, 3])
+def test_result_idx_rejects_out_of_range_boundaries(legalize, as_list, index):
+    result_idx = [index] if as_list else index
+
+    with pytest.raises(ValueError, match=r"between -3 and 2"):
+        legalize(result_idx)
+
+
+@pytest.mark.parametrize(
+    "legalize",
+    [_legalize_with_adapter, _legalize_with_profiler],
+    ids=["adapter", "profiler"],
+)
+@pytest.mark.parametrize("index", [0.5, "0"])
+def test_result_idx_rejects_non_integer_list_elements(legalize, index):
+    with pytest.raises(ValueError, match="list of integers"):
+        legalize([index])

--- a/tilelang/jit/adapter/base.py
+++ b/tilelang/jit/adapter/base.py
@@ -24,33 +24,31 @@ CachedTextSourceLike = CachedTextSource | str | None
 class BaseKernelAdapter(ABC):
     func: Callable | None = None
 
-    def __init__(self, mod, params: list[KernelParam], result_idx: list[int]) -> None:
+    def __init__(self, mod, params: list[KernelParam], result_idx: int | list[int] | None) -> None:
         self.mod = mod
         self.params = params
         self.result_idx = self._legalize_result_idx(result_idx)
         self._post_init()
 
-    def _legalize_result_idx(self, result_idx: list[int] | None) -> list[int]:
+    def _legalize_result_idx(self, result_idx: int | list[int] | None) -> list[int]:
         params = self.params
         # result_idx is a list of indices of the output tensors
         if result_idx is None:
-            result_idx = []
+            return []
         elif isinstance(result_idx, int):
-            if result_idx > len(params) or result_idx < -len(params):
-                raise ValueError(f"result_idx should be an integer between {-len(params) - 1} and {len(params) - 1}")
-            if result_idx < 0:
-                result_idx = len(params) + result_idx
             result_idx = [result_idx]
-        elif isinstance(result_idx, list):
-            for i, idx in enumerate(result_idx):
-                if idx >= len(params) or idx < -len(params):
-                    raise ValueError(f"result_idx should be an integer between {-len(params) - 1} and {len(params) - 1}")
-                if idx < 0:
-                    result_idx[i] = len(params) + idx
-        else:
+        elif not isinstance(result_idx, list):
             raise ValueError("result_idx should be a list of integers")
 
-        return result_idx
+        normalized_result_idx = []
+        for idx in result_idx:
+            if not isinstance(idx, int):
+                raise ValueError("result_idx should be a list of integers")
+            if idx >= len(params) or idx < -len(params):
+                raise ValueError(f"result_idx should be an integer between {-len(params)} and {len(params) - 1}")
+            normalized_result_idx.append(len(params) + idx if idx < 0 else idx)
+
+        return normalized_result_idx
 
     @abstractmethod
     def _convert_torch_func(self) -> callable:

--- a/tilelang/profiler/__init__.py
+++ b/tilelang/profiler/__init__.py
@@ -30,7 +30,7 @@ class Profiler:
     """
 
     params: list[KernelParam]
-    result_idx: list[int]
+    result_idx: int | list[int] | None
     supply_type: TensorSupplyType
     adapter: BaseKernelAdapter | None = None
 
@@ -39,21 +39,25 @@ class Profiler:
         self.result_idx = self._legalize_result_idx(self.result_idx)
         self.supply = get_tensor_supply(self.supply_type)
 
-    def _legalize_result_idx(self, result_idx: list[int] | None = None) -> list[int]:
+    def _legalize_result_idx(self, result_idx: int | list[int] | None = None) -> list[int]:
         params = self.params
         # result_idx is a list of indices of the output tensors
         if result_idx is None:
-            result_idx = []
+            return []
         elif isinstance(result_idx, int):
-            if result_idx > len(params) or result_idx < -len(params):
-                raise ValueError(f"result_idx should be an integer between {-len(params)} and {len(params) - 1}")
-            if result_idx < 0:
-                result_idx = len(params) + result_idx
             result_idx = [result_idx]
         elif not isinstance(result_idx, list):
             raise ValueError("result_idx should be a list of integers")
 
-        return result_idx
+        normalized_result_idx = []
+        for idx in result_idx:
+            if not isinstance(idx, int):
+                raise ValueError("result_idx should be a list of integers")
+            if idx >= len(params) or idx < -len(params):
+                raise ValueError(f"result_idx should be an integer between {-len(params)} and {len(params) - 1}")
+            normalized_result_idx.append(len(params) + idx if idx < 0 else idx)
+
+        return normalized_result_idx
 
     def with_default_adapter(self, adapter: BaseKernelAdapter) -> Profiler:
         self.adapter = adapter


### PR DESCRIPTION
Fixes #2884.

### Problem

Output parameter indices use Python indexing semantics, so the valid range is:

```text
-len(params) <= index < len(params)
```

The adapter and profiler had diverged from that contract. Both scalar paths accepted `len(params)`, the profiler did not validate list elements, and profiler lists containing negative indices were not normalized.

With three parameters, scalar `3` was accepted by both paths. The profiler also accepted `[3]` and `[-4]`, and preserved `[-1]` instead of normalizing it to `[2]`. Invalid values could therefore fail later during adapter wrapping or cause direct profiler use to classify parameters incorrectly.

### Change

Apply the same validation and normalization rules in both owners:

- Reject indices outside `[-len(params), len(params) - 1]`.
- Validate every list element as an integer.
- Normalize negative scalar and list indices.
- Report the correct bounds.
- Preserve support for `None`, scalar integers, and integer lists.

The change stays within the existing adapter and profiler ownership points rather than introducing a cross-package validation abstraction.

### Regression coverage

The new CPU-only tests exercise scalar and list forms at:

```text
-len-1, -len, -1, 0, len-1, len
```

They also verify rejection of non-integer list elements in both paths.

Against the affected base, these tests produced `13 failed, 15 passed`, covering the scalar upper-bound bug, profiler list bounds, incorrect adapter error text, and profiler negative-list normalization.

### Validation

- `pytest -q testing/python/profiler/test_tilelang_result_idx_validation.py testing/python/jit/test_tilelang_jit_nvrtc_host.py` — 32 passed
- `bash format.sh --files tilelang/jit/adapter/base.py tilelang/profiler/__init__.py testing/python/profiler/test_tilelang_result_idx_validation.py` — passed
- `git diff --check` — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Standardized `result_idx` handling in `BaseKernelAdapter` and `Profiler`.
- Accepted `None`, an integer, or a list of integers.
- Applied Python-style bounds: `-len(params) <= index < len(params)`.
- Normalized negative indices without mutating input lists.
- Rejected non-integer list elements and out-of-range indices.
- Added CPU-only regression tests for adapter and profiler paths.
- Added HIP code generation for vectorized `SelectNode` expressions.
- Added a HIP regression test for lane-wise vector select lowering.
- Updated vectorized select regression test documentation.

## C++ style / lint notes

This PR changes C++ code but does not change `docs/developer_guide/cpp_style.md` or CI lint tooling. The C++ API Style Audit (warning only) applies. Any TLCPP003/TLCPP004 findings are advisory unless they indicate a correctness, build, API, FFI, or maintainability issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->