### PR TITLE
[BugFix][ROCm] Lower vector Select conditions lane-wise

### DIFF
--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -59,7 +59,9 @@ std::optional<DataType> GetAccessPtrElementType(const PrimExpr &expr) {
 // Convert an element-wise vector expression into the scalar expression for a
 // single lane.  In particular, this keeps BufferLoad nodes inside a scalar
 // Select instead of materializing both vector-valued branches before the
-// ternary is emitted.
+// ternary is emitted.  Unlike CUDA's Select visitor (introduced in #2843),
+// which materializes the condition and both branches as SSA temporaries before
+// extracting lanes, HIP intentionally preserves lazy branch evaluation here.
 class VectorLaneScalarizer : public ExprMutator {
 public:
   explicit VectorLaneScalarizer(int lane) : lane_(lane) {}
@@ -93,20 +95,69 @@ private:
 
   PrimExpr VisitExpr_(const CallNode *op) final {
     if (op->dtype.is_fixed_length_vector()) {
+      if (op->op.same_as(builtin::reinterpret())) {
+        ICHECK_EQ(op->args.size(), 1U);
+        DataType source_dtype = op->args[0].dtype();
+        if (source_dtype.lanes() == op->dtype.lanes() &&
+            source_dtype.bits() == op->dtype.bits()) {
+          return Call(op->dtype.element_of(), op->op, {VisitExpr(op->args[0])},
+                      op->annotations);
+        }
+        ICHECK_EQ(source_dtype.lanes() * source_dtype.bits(),
+                  op->dtype.lanes() * op->dtype.bits())
+            << "reinterpret expects source and target to have the same number "
+               "of bits";
+        DataType result_element_dtype = op->dtype.element_of();
+        DataType source_bits_dtype = DataType::UInt(source_dtype.bits());
+        DataType result_bits_dtype = DataType::UInt(op->dtype.bits());
+        auto as_unsigned_bits = [](PrimExpr value,
+                                   DataType unsigned_dtype) -> PrimExpr {
+          if (value.dtype() == unsigned_dtype) {
+            return value;
+          }
+          return Call(unsigned_dtype, builtin::reinterpret(), {value});
+        };
+        auto from_unsigned_bits = [](PrimExpr value,
+                                     DataType result_dtype) -> PrimExpr {
+          if (value.dtype() == result_dtype) {
+            return value;
+          }
+          return Call(result_dtype, builtin::reinterpret(), {value});
+        };
+
+        if (source_dtype.bits() < op->dtype.bits()) {
+          ICHECK_EQ(op->dtype.bits() % source_dtype.bits(), 0);
+          int source_lanes_per_result = op->dtype.bits() / source_dtype.bits();
+          PrimExpr packed = make_zero(result_bits_dtype);
+          for (int i = 0; i < source_lanes_per_result; ++i) {
+            int source_lane = lane_ * source_lanes_per_result + i;
+            PrimExpr source_value =
+                VectorLaneScalarizer(source_lane)(op->args[0]);
+            PrimExpr source_bits =
+                as_unsigned_bits(source_value, source_bits_dtype);
+            PrimExpr widened = Cast(result_bits_dtype, source_bits);
+            packed = packed | (widened << IntImm(result_bits_dtype,
+                                                 i * source_dtype.bits()));
+          }
+          return from_unsigned_bits(packed, result_element_dtype);
+        }
+
+        ICHECK_EQ(source_dtype.bits() % op->dtype.bits(), 0);
+        int result_lanes_per_source = source_dtype.bits() / op->dtype.bits();
+        int source_lane = lane_ / result_lanes_per_source;
+        int bit_offset =
+            (lane_ % result_lanes_per_source) * result_element_dtype.bits();
+        PrimExpr source_value = VectorLaneScalarizer(source_lane)(op->args[0]);
+        PrimExpr source_bits =
+            as_unsigned_bits(source_value, source_bits_dtype);
+        PrimExpr shifted = source_bits >> IntImm(source_bits_dtype, bit_offset);
+        PrimExpr narrowed = Cast(result_bits_dtype, shifted);
+        return from_unsigned_bits(narrowed, result_element_dtype);
+      }
       Array<PrimExpr> args;
       args.reserve(op->args.size());
       for (const PrimExpr &arg : op->args) {
         args.push_back(VisitExpr(arg));
-      }
-      if (op->op.same_as(builtin::reinterpret())) {
-        ICHECK_EQ(op->args.size(), 1U);
-        ICHECK_EQ(op->args[0].dtype().lanes(), op->dtype.lanes())
-            << "Vector select scalarization requires reinterpret source and "
-               "result lane counts to match";
-        ICHECK_EQ(op->args[0].dtype().bits(), op->dtype.bits())
-            << "Vector select scalarization requires reinterpret source and "
-               "result element widths to match";
-        return Call(op->dtype.element_of(), op->op, args, op->annotations);
       }
       if (op->op.same_as(builtin::call_pure_extern()) ||
           op->op.same_as(builtin::call_extern())) {
@@ -131,6 +182,10 @@ private:
         return Select(args[0] < args[1], args[0], args[1]);
       }
       if (op->op.same_as(tl::abs2())) {
+        if (args[0].dtype().is_bfloat16()) {
+          return Call(args[0].dtype(), builtin::call_pure_extern(),
+                      {StringImm("__habs"), args[0]});
+        }
         PrimExpr zero = make_zero(args[0].dtype());
         return Select(args[0] >= zero, args[0], -args[0]);
       }
@@ -526,11 +581,21 @@ void CodeGenTileLangHIP::PrintType(DataType t, std::ostream &os) { // NOLINT(*)
     os << "bool";
     return;
   } else if (t.is_vector_bool()) {
-    // CUDA does not support bool vectors.
-    // Use ushort vectors to represent instead.
+    // HIP does not support bool vectors.
+    // Use ushort vectors for directly addressable lanes and packed unsigned
+    // integers for wider vectors.
     int n = t.lanes();
     if (n <= 4) {
       os << "ushort" << n;
+      return;
+    } else if (n == 8) {
+      os << "uint8_t";
+      return;
+    } else if (n == 16) {
+      os << "uint16_t";
+      return;
+    } else if (n == 32) {
+      os << "uint";
       return;
     }
   } else if (t.is_uint() || t.is_int()) {
@@ -734,7 +799,7 @@ void CodeGenTileLangHIP::VisitExpr_(const SelectNode *op, std::ostream &os) {
   };
   this->PrintIndent();
   this->PrintType(op->dtype, stream);
-  stream << ' ' << result << ";\n";
+  stream << ' ' << result << "{};\n";
   for (int i = 0; i < op->dtype.lanes(); ++i) {
     PrintVecElemStore(result, op->dtype, i, PrintExpr(scalarize_lane(i)));
   }
@@ -750,13 +815,23 @@ void CodeGenTileLangHIP::PrintVecElemLoad(const std::string &vec, DataType t,
   }
 
   static const char access[] = {'x', 'y', 'z', 'w'};
-  ICHECK(i >= 0 && i < (t.is_float4()                        ? 32
+  bool is_packed_bool = t.is_vector_bool() && t.lanes() >= 8;
+  bool is_packed_int4 = t.bits() == 4 && (t.is_int() || t.is_uint());
+  ICHECK(i >= 0 && i < (is_packed_bool                       ? t.lanes()
+                        : is_packed_int4                     ? t.lanes()
+                        : t.is_float4()                      ? 32
                         : t.bits() == 8                      ? 16
                         : (t.lanes() == 16)                  ? 16
                         : (t.lanes() == 32)                  ? 32
                         : (t.bits() == 16 || t.bits() == 32) ? 8
                                                              : 4));
-  if (t.bits() == 8 && (t.is_int() || t.is_uint())) {
+  if (is_packed_bool) {
+    std::ostringstream packed_byte;
+    packed_byte << "((const unsigned char*)(&(" << vec << ")))[" << i / 8
+                << "]";
+    os << "((static_cast<unsigned int>(" << packed_byte.str() << ") >> "
+       << i % 8 << ") & 0x01u)";
+  } else if (t.bits() == 8 && (t.is_int() || t.is_uint())) {
     std::string type_name = t.is_int() ? "char" : "unsigned char";
     if (t.lanes() == 2 || t.lanes() == 3) {
       os << vec << "." << access[i % t.lanes()];
@@ -778,7 +853,24 @@ void CodeGenTileLangHIP::PrintVecElemLoad(const std::string &vec, DataType t,
   } else if (t.is_bfloat16()) {
     os << "((bfloat16x2*)(&(" << vec << "." << access[i / 2] << ")))->"
        << access[i % 2];
+  } else if (is_packed_int4) {
+    std::ostringstream packed_byte;
+    packed_byte << "((const unsigned char*)(&(" << vec << ")))[" << i / 2
+                << "]";
+    int shift = i % 2 * 4;
+    if (t.is_uint()) {
+      os << "((static_cast<unsigned int>(" << packed_byte.str() << ") >> "
+         << shift << ") & 0x0fu)";
+    } else {
+      os << "((static_cast<int>((static_cast<unsigned int>("
+         << packed_byte.str() << ") >> " << shift << ") & 0x0fu) ^ 8) - 8)";
+    }
   } else if (t.is_float8() && !t.is_float8_e8m0fnu()) {
+    if (t.lanes() == 2) {
+      os << "tl_fp8x2_get_lane<" << GetFP8Type(t.element_of()) << ">(" << vec
+         << ", " << i << ")";
+      return;
+    }
     std::string element = vec;
     int lanes = t.lanes();
     int lane = i;
@@ -831,23 +923,40 @@ void CodeGenTileLangHIP::PrintVecElemStore(const std::string &vec, DataType t,
   this->PrintIndent();
   static const char access[] = {'x', 'y', 'z', 'w'};
 
-  ICHECK(i >= 0 && i < (t.bits() == 8                        ? 16
+  bool is_packed_bool = t.is_vector_bool() && t.lanes() >= 8;
+  bool is_packed_int4 = t.bits() == 4 && (t.is_int() || t.is_uint());
+  ICHECK(i >= 0 && i < (is_packed_bool                       ? t.lanes()
+                        : is_packed_int4                     ? t.lanes()
+                        : t.is_float4()                      ? 32
+                        : t.bits() == 8                      ? 16
                         : (t.lanes() == 16)                  ? 16
                         : (t.lanes() == 32)                  ? 32
                         : (t.bits() == 16 || t.bits() == 32) ? 8
                                                              : 4));
-  if (t.bits() == 8 && (t.is_int() || t.is_uint())) {
+  if (is_packed_bool) {
+    std::ostringstream packed_byte;
+    packed_byte << "((unsigned char*)(&(" << vec << ")))[" << i / 8 << "]";
+    stream << packed_byte.str() << " = ";
+    if (i % 8 != 0) {
+      stream << "(" << packed_byte.str() << " & ~(0x01u << " << i % 8
+             << ")) | ";
+    }
+    stream << "((static_cast<unsigned int>(" << value << ") & 0x01u) << "
+           << i % 8 << ");\n";
+  } else if (t.bits() == 8 && (t.is_int() || t.is_uint())) {
     if (t.lanes() == 2 || t.lanes() == 3) {
       stream << vec << '.' << access[i % t.lanes()] << "=" << "(" << value
              << ");\n";
     } else {
       std::string ac = t.lanes() == 4 ? vec : (vec + "." + access[i / 4]);
       stream << ac << "=";
-      // Do not read the first undef lane.
-      if (i != 0) {
-        stream << ac << " & ~(0x000000ff << " << i % 4 * 8 << ") |";
+      // Do not read the first lane of each carrier word.
+      if (i % 4 != 0) {
+        stream << "static_cast<unsigned int>(" << ac << ") & ~(0x000000ffu << "
+               << i % 4 * 8 << ") |";
       }
-      stream << "(" << value << " << " << i % 4 * 8 << ");\n";
+      stream << "(static_cast<unsigned int>(static_cast<unsigned char>("
+             << value << ")) << " << i % 4 * 8 << ");\n";
     }
   } else if ((t.lanes() == 16 || t.lanes() == 32) && t.bits() == 32 &&
              t.is_float()) {
@@ -863,7 +972,21 @@ void CodeGenTileLangHIP::PrintVecElemStore(const std::string &vec, DataType t,
   } else if (t.is_bfloat16()) {
     stream << "((bfloat16_t*)(&(" << vec << "." << access[i / 2] << ")))["
            << (i % 2) << "] = " << value << ";\n";
+  } else if (is_packed_int4) {
+    std::ostringstream packed_byte;
+    packed_byte << "((unsigned char*)(&(" << vec << ")))[" << i / 2 << "]";
+    stream << packed_byte.str() << " = ";
+    if (i % 2 != 0) {
+      stream << "(" << packed_byte.str() << " & 0x0fu) | ";
+    }
+    stream << "((static_cast<unsigned int>(" << value << ") & 0x0fu) << "
+           << i % 2 * 4 << ");\n";
   } else if (t.is_float8() && !t.is_float8_e8m0fnu()) {
+    if (t.lanes() == 2) {
+      stream << "tl_fp8x2_set_lane(" << vec << ", " << i << ", " << value
+             << ");\n";
+      return;
+    }
     std::string element = vec;
     int lanes = t.lanes();
     int lane = i;
@@ -1361,10 +1484,10 @@ void CodeGenTileLangHIP::VisitExpr_(const CallNode *op, std::ostream &os) {
     }
     this->stream << ");\n";
   };
-  if (op->op.same_as(builtin::reinterpret()) && op->dtype.is_scalar() &&
-      op->args.size() == 1U && op->args[0].dtype().is_scalar() &&
+  if (op->op.same_as(builtin::reinterpret()) && op->args.size() == 1U &&
       !op->dtype.is_float4() && !op->args[0].dtype().is_float4()) {
-    ICHECK_EQ(op->dtype.bits(), op->args[0].dtype().bits())
+    ICHECK_EQ(op->dtype.lanes() * op->dtype.bits(),
+              op->args[0].dtype().lanes() * op->args[0].dtype().bits())
         << "reinterpret expects source and target to have the same number of "
            "bits";
     os << "__builtin_bit_cast(";

--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -9,6 +9,7 @@
 #include <tvm/runtime/logging.h>
 #include <tvm/tirx/index_map.h>
 #include <tvm/tirx/op.h>
+#include <tvm/tirx/stmt_functor.h>
 
 #include <cmath>
 #include <cstdint>
@@ -54,6 +55,122 @@ std::optional<DataType> GetAccessPtrElementType(const PrimExpr &expr) {
   }
   return std::nullopt;
 }
+
+// Convert an element-wise vector expression into the scalar expression for a
+// single lane.  In particular, this keeps BufferLoad nodes inside a scalar
+// Select instead of materializing both vector-valued branches before the
+// ternary is emitted.
+class VectorLaneScalarizer : public ExprMutator {
+public:
+  explicit VectorLaneScalarizer(int lane) : lane_(lane) {}
+
+private:
+  PrimExpr VisitExpr(const PrimExpr &expr) final {
+    PrimExpr result = ExprMutator::VisitExpr(expr);
+    if (result.dtype().is_fixed_length_vector()) {
+      return Shuffle::ExtractElement(expr, lane_);
+    }
+    return result;
+  }
+
+  PrimExpr VisitExpr_(const RampNode *op) final {
+    PrimExpr base = VisitExpr(op->base);
+    PrimExpr stride = VisitExpr(op->stride);
+    return base + stride * IntImm(stride.dtype(), lane_);
+  }
+
+  PrimExpr VisitExpr_(const BroadcastNode *op) final {
+    return VisitExpr(op->value);
+  }
+
+  PrimExpr VisitExpr_(const LetNode *op) final {
+    // Inlining before lane extraction preserves bodies that select a
+    // different lane of a bound vector through a Shuffle.  It also prevents
+    // scalar bindings from being emitted as statements before the enclosing
+    // Select, where they would evaluate inactive branch loads eagerly.
+    return VisitExpr(Substitute(op->body, {{op->var, op->value}}));
+  }
+
+  PrimExpr VisitExpr_(const CallNode *op) final {
+    if (op->dtype.is_fixed_length_vector()) {
+      Array<PrimExpr> args;
+      args.reserve(op->args.size());
+      for (const PrimExpr &arg : op->args) {
+        args.push_back(VisitExpr(arg));
+      }
+      if (op->op.same_as(builtin::reinterpret())) {
+        ICHECK_EQ(op->args.size(), 1U);
+        ICHECK_EQ(op->args[0].dtype().lanes(), op->dtype.lanes())
+            << "Vector select scalarization requires reinterpret source and "
+               "result lane counts to match";
+        ICHECK_EQ(op->args[0].dtype().bits(), op->dtype.bits())
+            << "Vector select scalarization requires reinterpret source and "
+               "result element widths to match";
+        return Call(op->dtype.element_of(), op->op, args, op->annotations);
+      }
+      if (op->op.same_as(builtin::call_pure_extern()) ||
+          op->op.same_as(builtin::call_extern())) {
+        return Call(op->dtype.element_of(), op->op, args, op->annotations);
+      }
+      if (op->op.same_as(tl::add2())) {
+        return args[0] + args[1];
+      }
+      if (op->op.same_as(tl::sub2())) {
+        return args[0] - args[1];
+      }
+      if (op->op.same_as(tl::mul2())) {
+        return args[0] * args[1];
+      }
+      if (op->op.same_as(tl::fma2())) {
+        return args[0] * args[1] + args[2];
+      }
+      if (op->op.same_as(tl::max2())) {
+        return Select(args[0] > args[1], args[0], args[1]);
+      }
+      if (op->op.same_as(tl::min2())) {
+        return Select(args[0] < args[1], args[0], args[1]);
+      }
+      if (op->op.same_as(tl::abs2())) {
+        PrimExpr zero = make_zero(args[0].dtype());
+        return Select(args[0] >= zero, args[0], -args[0]);
+      }
+    }
+    return ExprMutator::VisitExpr_(op);
+  }
+
+  PrimExpr VisitExpr_(const ShuffleNode *op) final {
+    int output_lane = op->dtype.is_scalar() ? 0 : lane_;
+    ICHECK_LT(output_lane, op->indices.size());
+    const int64_t *index = as_const_int(op->indices[output_lane]);
+    ICHECK(index) << "Vector select scalarization requires constant Shuffle "
+                     "indices: "
+                  << GetRef<Shuffle>(op);
+    int64_t source_lane = *index;
+    for (const PrimExpr &vector : op->vectors) {
+      ICHECK(!vector.dtype().is_scalable_vector());
+      int lanes = vector.dtype().lanes();
+      if (source_lane < lanes) {
+        if (vector.dtype().is_scalar()) {
+          ICHECK_EQ(source_lane, 0);
+          return VisitExpr(vector);
+        }
+        return VectorLaneScalarizer(static_cast<int>(source_lane))(vector);
+      }
+      source_lane -= lanes;
+    }
+    ICHECK(false) << "Shuffle index out of range: " << GetRef<Shuffle>(op);
+    return PrimExpr();
+  }
+
+  PrimExpr VisitExpr_(const CastNode *op) final {
+    PrimExpr value = VisitExpr(op->value);
+    DataType dtype =
+        op->dtype.is_fixed_length_vector() ? op->dtype.element_of() : op->dtype;
+    return value.dtype() == dtype ? value : Cast(dtype, value);
+  }
+
+  int lane_;
+};
 
 int GetTileLangCPAsyncTransferBytes(const CallNode *op) {
   ICHECK(op->args.size() == 3 || op->args.size() == 4)
@@ -599,6 +716,31 @@ void CodeGenTileLangHIP::PrintVecBinaryOp(const std::string &op, DataType t,
   os << sret;
 }
 
+void CodeGenTileLangHIP::VisitExpr_(const SelectNode *op, std::ostream &os) {
+  if (!op->condition.dtype().is_fixed_length_vector()) {
+    CodeGenC::VisitExpr_(op, os);
+    return;
+  }
+
+  TVM_FFI_ICHECK(op->false_value->dtype == op->dtype &&
+                 op->true_value->dtype == op->dtype &&
+                 op->dtype.lanes() == op->condition.dtype().lanes());
+
+  std::string result = name_supply_->FreshName("_");
+  auto scalarize_lane = [&](int lane) {
+    PrimExpr lane_select = VectorLaneScalarizer(lane)(GetRef<PrimExpr>(op));
+    ICHECK(lane_select.dtype().is_scalar());
+    return lane_select;
+  };
+  this->PrintIndent();
+  this->PrintType(op->dtype, stream);
+  stream << ' ' << result << ";\n";
+  for (int i = 0; i < op->dtype.lanes(); ++i) {
+    PrintVecElemStore(result, op->dtype, i, PrintExpr(scalarize_lane(i)));
+  }
+  os << result;
+}
+
 void CodeGenTileLangHIP::PrintVecElemLoad(const std::string &vec, DataType t,
                                           int i,
                                           std::ostream &os) { // NOLINT(*)
@@ -608,7 +750,8 @@ void CodeGenTileLangHIP::PrintVecElemLoad(const std::string &vec, DataType t,
   }
 
   static const char access[] = {'x', 'y', 'z', 'w'};
-  ICHECK(i >= 0 && i < (t.bits() == 8                        ? 16
+  ICHECK(i >= 0 && i < (t.is_float4()                        ? 32
+                        : t.bits() == 8                      ? 16
                         : (t.lanes() == 16)                  ? 16
                         : (t.lanes() == 32)                  ? 32
                         : (t.bits() == 16 || t.bits() == 32) ? 8
@@ -635,6 +778,29 @@ void CodeGenTileLangHIP::PrintVecElemLoad(const std::string &vec, DataType t,
   } else if (t.is_bfloat16()) {
     os << "((bfloat16x2*)(&(" << vec << "." << access[i / 2] << ")))->"
        << access[i % 2];
+  } else if (t.is_float8() && !t.is_float8_e8m0fnu()) {
+    std::string element = vec;
+    int lanes = t.lanes();
+    int lane = i;
+    while (lanes > 4) {
+      int group_size = lanes / 2;
+      element += lane < group_size ? ".x" : ".y";
+      lane %= group_size;
+      lanes = group_size;
+    }
+    element += "." + std::string(1, access[lane]);
+    os << element;
+  } else if (t.is_float4()) {
+    std::string element = vec;
+    int lanes = t.lanes();
+    int lane = i;
+    while (lanes > 2) {
+      int group_size = lanes / 2;
+      element += lane < group_size ? ".x" : ".y";
+      lane %= group_size;
+      lanes = group_size;
+    }
+    os << element << (lane == 0 ? ".x()" : ".y()");
   } else if (t.lanes() > 4 && t.lanes() <= 8) {
     std::string type_name;
     if (t.bits() == 16) {
@@ -697,6 +863,28 @@ void CodeGenTileLangHIP::PrintVecElemStore(const std::string &vec, DataType t,
   } else if (t.is_bfloat16()) {
     stream << "((bfloat16_t*)(&(" << vec << "." << access[i / 2] << ")))["
            << (i % 2) << "] = " << value << ";\n";
+  } else if (t.is_float8() && !t.is_float8_e8m0fnu()) {
+    std::string element = vec;
+    int lanes = t.lanes();
+    int lane = i;
+    while (lanes > 4) {
+      int group_size = lanes / 2;
+      element += lane < group_size ? ".x" : ".y";
+      lane %= group_size;
+      lanes = group_size;
+    }
+    stream << element << "." << access[lane] << " = " << value << ";\n";
+  } else if (t.is_float4()) {
+    std::string element = vec;
+    int lanes = t.lanes();
+    int lane = i;
+    while (lanes > 2) {
+      int group_size = lanes / 2;
+      element += lane < group_size ? ".x" : ".y";
+      lane %= group_size;
+      lanes = group_size;
+    }
+    stream << element << (lane == 0 ? ".set_x(" : ".set_y(") << value << ");\n";
   } else if (t.lanes() > 4 && t.lanes() <= 8) {
     std::string type_name;
     if (t.bits() == 16) {
@@ -1173,7 +1361,18 @@ void CodeGenTileLangHIP::VisitExpr_(const CallNode *op, std::ostream &os) {
     }
     this->stream << ");\n";
   };
-  if (op->op.same_as(builtin::ptx_cp_async())) {
+  if (op->op.same_as(builtin::reinterpret()) && op->dtype.is_scalar() &&
+      op->args.size() == 1U && op->args[0].dtype().is_scalar() &&
+      !op->dtype.is_float4() && !op->args[0].dtype().is_float4()) {
+    ICHECK_EQ(op->dtype.bits(), op->args[0].dtype().bits())
+        << "reinterpret expects source and target to have the same number of "
+           "bits";
+    os << "__builtin_bit_cast(";
+    this->PrintType(op->dtype, os);
+    os << ", ";
+    this->PrintExpr(op->args[0], os);
+    os << ")";
+  } else if (op->op.same_as(builtin::ptx_cp_async())) {
     // args[0] = dst_access_ptr, args[1] = src_access_ptr, args[2] = bytes,
     // args[3] = predicate (optional)
     ICHECK(op->args.size() == 3 || op->args.size() == 4)

--- a/src/rocm/codegen/codegen_hip.h
+++ b/src/rocm/codegen/codegen_hip.h
@@ -50,6 +50,7 @@ public:
   void VisitExpr_(const FloatImmNode *op, std::ostream &os) final;
   void VisitExpr_(const CallNode *op, std::ostream &os) final;
   void VisitExpr_(const CastNode *op, std::ostream &os) final;
+  void VisitExpr_(const SelectNode *op, std::ostream &os) final;
   void VisitExpr_(const ShuffleNode *op, std::ostream &os) final; // NOLINT(*)
   void VisitStmt_(const AllocBufferNode *op) final;
   void VisitStmt_(const AttrStmtNode *op) final;

--- a/src/tl_templates/hip/hip_fp8.h
+++ b/src/tl_templates/hip/hip_fp8.h
@@ -98,6 +98,29 @@ struct fp8_e5_t {
     return static_cast<float>(static_cast<hip_fp8_e5_t>(*this));
   }
 };
+
+template <typename ScalarType, typename PackedType>
+__device__ __forceinline__ ScalarType
+tl_fp8x2_get_lane(const PackedType &packed, int lane) {
+  ScalarType result;
+  result.data = static_cast<unsigned char>(
+      (static_cast<unsigned int>(packed.__x) >> (lane * 8)) & 0xffu);
+  return result;
+}
+
+template <typename PackedType, typename ScalarType>
+__device__ __forceinline__ void tl_fp8x2_set_lane(PackedType &packed, int lane,
+                                                  ScalarType value) {
+  if (lane == 0) {
+    // The result carrier is uninitialized before its first lane is written.
+    packed.__x = static_cast<decltype(packed.__x)>(value.data);
+    return;
+  }
+  packed.__x = static_cast<decltype(packed.__x)>(
+      (static_cast<unsigned int>(packed.__x) & 0x00ffu) |
+      (static_cast<unsigned int>(value.data) << 8));
+}
+
 // Note: E8M0 types are not supported in current HIP version
 // using fp8_e8_t = __hip_fp8_e8m0_fnuz;
 // using fp8_e8_2_t = __hip_fp8x2_e8m0_fnuz;

--- a/testing/python/amd/test_tilelang_hip_vector_select_codegen.py
+++ b/testing/python/amd/test_tilelang_hip_vector_select_codegen.py
@@ -1,4 +1,6 @@
 import pytest
+import tilelang
+import tilelang.testing
 
 from tilelang import tvm
 from tvm import tirx
@@ -11,11 +13,13 @@ def _build_vector_select_source(
     wrap_input_in_call=False,
     wrap_input_in_call_extern=False,
     wrap_input_in_reinterpret=False,
+    wrap_input_in_abs=False,
     wrap_input_in_packed_call=False,
 ):
-    output_dtype = "int32" if wrap_input_in_reinterpret else "float32"
+    input_dtype = "bfloat16" if wrap_input_in_abs else "float32"
+    output_dtype = "int32" if wrap_input_in_reinterpret else input_dtype
     mask_buffer = tirx.decl_buffer((lanes,), "float32", name="mask")
-    input_buffer = tirx.decl_buffer((lanes,), "float32", name="input")
+    input_buffer = tirx.decl_buffer((lanes,), input_dtype, name="input")
     output_buffer = tirx.decl_buffer((lanes,), output_dtype, name="output")
     ramp = tirx.Ramp(0, 1, lanes)
     mask_vector = tirx.BufferLoad(mask_buffer, [ramp])
@@ -36,6 +40,8 @@ def _build_vector_select_source(
         input_vector = tirx.call_extern(f"float32x{lanes}", "exp2f", input_vector)
     if wrap_input_in_reinterpret:
         input_vector = tirx.reinterpret(f"int32x{lanes}", input_vector)
+    if wrap_input_in_abs:
+        input_vector = tirx.Call(f"bfloat16x{lanes}", tvm.ir.Op.get("tl.abs2"), [input_vector])
     if wrap_input_in_packed_call:
         bias = tirx.Broadcast(tirx.const(1, "float32"), lanes)
         input_vector = tirx.Call(f"float32x{lanes}", tvm.ir.Op.get("tl.add2"), [input_vector, bias])
@@ -89,7 +95,44 @@ def _build_vector_select_with_vector_argument_source():
     return build(mod, tvm.target.Target("rocm")).inspect_source()
 
 
-def _build_narrow_vector_select_source(dtype, lanes):
+def _make_lane_changing_reinterpret_select_module(source_dtype, source_lanes, result_dtype, result_lanes):
+    mask_buffer = tirx.decl_buffer((result_lanes,), "float32", name="mask")
+    input_buffer = tirx.decl_buffer((source_lanes,), source_dtype, name="input")
+    output_buffer = tirx.decl_buffer((result_lanes,), result_dtype, name="output")
+    mask_ramp = tirx.Ramp(0, 1, result_lanes)
+    input_ramp = tirx.Ramp(0, 1, source_lanes)
+    mask_vector = tirx.BufferLoad(mask_buffer, [mask_ramp])
+    input_vector = tirx.BufferLoad(input_buffer, [input_ramp])
+    if source_lanes < result_lanes:
+        input_vector = tirx.Shuffle([input_vector], list(range(source_lanes)))
+    reinterpreted = tirx.reinterpret(f"{result_dtype}x{result_lanes}", input_vector)
+    mask_zero = tirx.Broadcast(tirx.const(0, "float32"), result_lanes)
+    result_zero = tirx.Broadcast(tirx.const(0, result_dtype), result_lanes)
+    selected = tirx.Select(mask_vector > mask_zero, reinterpreted, result_zero)
+    body = tirx.BufferStore(output_buffer, selected, [mask_ramp])
+    func = tirx.PrimFunc(
+        [mask_buffer.data, input_buffer.data, output_buffer.data],
+        body,
+        buffer_map={
+            mask_buffer.data: mask_buffer,
+            input_buffer.data: input_buffer,
+            output_buffer.data: output_buffer,
+        },
+    )
+    func = func.with_attr("global_symbol", "lane_changing_reinterpret_select")
+    func = func.with_attr("calling_conv", tvm.ir.CallingConv.DEVICE_KERNEL_LAUNCH)
+    return tvm.IRModule({"lane_changing_reinterpret_select": func})
+
+
+def _build_lane_changing_reinterpret_select_source(source_dtype, source_lanes, result_dtype, result_lanes):
+    mod = _make_lane_changing_reinterpret_select_module(source_dtype, source_lanes, result_dtype, result_lanes)
+    build = tvm.get_global_func("target.build.tilelang_hip_without_compile", allow_missing=True)
+    if build is None:
+        pytest.skip("TileLang was built without the ROCm code generator")
+    return build(mod, tvm.target.Target("rocm")).inspect_source()
+
+
+def _make_narrow_vector_select_module(dtype, lanes):
     on_true = tirx.Var("on_true", f"{dtype}x{lanes}")
     on_false = tirx.Var("on_false", f"{dtype}x{lanes}")
     ramp = tirx.Ramp(0, 1, lanes)
@@ -102,7 +145,11 @@ def _build_narrow_vector_select_source(dtype, lanes):
     func = tirx.PrimFunc([on_true, on_false], tirx.Evaluate(selected))
     func = func.with_attr("global_symbol", "narrow_vector_select")
     func = func.with_attr("calling_conv", tvm.ir.CallingConv.DEVICE_KERNEL_LAUNCH)
-    mod = tvm.IRModule({"narrow_vector_select": func})
+    return tvm.IRModule({"narrow_vector_select": func})
+
+
+def _build_narrow_vector_select_source(dtype, lanes):
+    mod = _make_narrow_vector_select_module(dtype, lanes)
     build = tvm.get_global_func("target.build.tilelang_hip_without_compile", allow_missing=True)
     if build is None:
         pytest.skip("TileLang was built without the ROCm code generator")
@@ -216,16 +263,59 @@ def test_vector_reinterpret_keeps_argument_load_in_select_branch():
     assert "*(float4*)(input" not in source
 
 
+@pytest.mark.parametrize(
+    ("source_dtype", "source_lanes", "result_dtype", "result_lanes"),
+    [("uint8", 8, "uint16", 4), ("uint16", 4, "uint8", 8)],
+)
+def test_lane_changing_reinterpret_stays_inside_vector_select_branch(source_dtype, source_lanes, result_dtype, result_lanes):
+    source = _build_lane_changing_reinterpret_select_source(source_dtype, source_lanes, result_dtype, result_lanes)
+
+    assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
+    assert len(assignments) == result_lanes
+    for lane, assignment in enumerate(assignments):
+        if source_lanes > result_lanes:
+            lanes_per_result = source_lanes // result_lanes
+            expected_indices = set(range(lane * lanes_per_result, (lane + 1) * lanes_per_result))
+        else:
+            expected_indices = {lane // (result_lanes // source_lanes)}
+        for input_lane in range(source_lanes):
+            assert (f"input[{input_lane}]" in assignment) == (input_lane in expected_indices)
+    assert "*)(input +" not in source
+
+
+def test_bfloat16_abs_keeps_packed_sign_bit_semantics():
+    source = _build_vector_select_source(2, wrap_input_in_abs=True)
+
+    assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
+    assert len(assignments) == 2
+    assert all("? __habs(input[" in line for line in assignments)
+    assert all(">= (bfloat16_t)0" not in line for line in assignments)
+
+
 def test_vector_packed_call_keeps_argument_load_in_select_branch():
     source = _build_vector_select_source(2, wrap_input_in_packed_call=True)
 
     assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
     assert len(assignments) == 2
-    assert all("? (input[" in line and "+ 1.000000e+00f" in line for line in assignments)
+    assert all("+ 1.000000e+00f" in line for line in assignments)
+    for lane, assignment in enumerate(assignments):
+        assert f"? (input[{lane}]" in assignment
     assert "tl::add2" not in source
 
 
-@pytest.mark.parametrize("lanes", [16, 32])
+@pytest.mark.parametrize(
+    ("dtype", "lanes", "carrier_type"),
+    [("float4_e2m1fn", 8, "fp4_e2_8_t"), ("int8", 8, "int2")],
+)
+def test_packed_vector_select_result_is_value_initialized(dtype, lanes, carrier_type):
+    source = _build_narrow_vector_select_source(dtype, lanes)
+
+    declarations = [line for line in source.splitlines() if line.startswith(f"  {carrier_type} __")]
+    assert len(declarations) == 1
+    assert declarations[0].endswith("{};")
+
+
+@pytest.mark.parametrize("lanes", [8, 16, 32])
 def test_wide_float4_vector_results_are_stored_by_packed_pair(lanes):
     source = _build_narrow_vector_select_source("float4_e2m1fn", lanes)
 
@@ -250,6 +340,7 @@ def test_wide_float4_vector_results_are_stored_by_packed_pair(lanes):
     ("dtype", "lanes", "lane_members"),
     [
         ("float8_e4m3fn", 2, ["x", "y"]),
+        ("float8_e5m2", 2, ["x", "y"]),
         (
             "float8_e5m2",
             8,
@@ -260,10 +351,92 @@ def test_wide_float4_vector_results_are_stored_by_packed_pair(lanes):
 def test_float8_vector_results_are_stored_by_lane(dtype, lanes, lane_members):
     source = _build_narrow_vector_select_source(dtype, lanes)
 
-    assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
+    if lanes == 2:
+        assignments = [line for line in source.splitlines() if "tl_fp8x2_set_lane" in line]
+    else:
+        assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
     assert len(assignments) == lanes
     for lane, member in enumerate(lane_members):
-        assert f"(({lane} < {lanes // 2}) ? (on_true).{member} : (on_false).{member})" in assignments[lane]
+        if lanes == 2:
+            scalar_type = "fp8_e4_t" if "e4" in dtype else "fp8_e5_t"
+            on_true = f"tl_fp8x2_get_lane<{scalar_type}>((on_true), {lane})"
+            on_false = f"tl_fp8x2_get_lane<{scalar_type}>((on_false), {lane})"
+            assert f"(({lane} < 1) ? {on_true} : {on_false})" in assignments[lane]
+            assert assignments[lane].startswith("  tl_fp8x2_set_lane(")
+            assert f", {lane}, " in assignments[lane]
+        else:
+            assert f"(({lane} < {lanes // 2}) ? (on_true).{member} : (on_false).{member})" in assignments[lane]
+
+
+@pytest.mark.parametrize(("dtype", "lanes"), [("int4", 4), ("int4", 8), ("uint4", 4), ("uint4", 8)])
+def test_integer_4bit_vector_results_use_packed_nibble_access(dtype, lanes):
+    source = _build_narrow_vector_select_source(dtype, lanes)
+
+    assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
+    assert len(assignments) == lanes
+    assert all("((const unsigned char*)(&((on_true))))" in line for line in assignments)
+    assert all("((const unsigned char*)(&((on_false))))" in line for line in assignments)
+    assert all(line.startswith("  ((unsigned char*)(&(__") for line in assignments)
+    assert ".x" not in "\n".join(assignments)
+
+
+def test_signed_int8_vector_results_are_packed_without_signed_shifts():
+    source = _build_narrow_vector_select_source("int8", 8)
+
+    assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
+    assert len(assignments) == 8
+    assert all("static_cast<unsigned int>(static_cast<unsigned char>(" in line for line in assignments)
+
+
+@pytest.mark.parametrize(
+    ("lanes", "carrier_type"),
+    [(8, "uint8_t"), (16, "uint16_t"), (32, "uint")],
+)
+def test_wide_bool_vector_results_use_packed_bit_access(lanes, carrier_type):
+    source = _build_narrow_vector_select_source("bool", lanes)
+
+    declarations = [line for line in source.splitlines() if line.startswith(f"  {carrier_type} __")]
+    assert len(declarations) == 1
+    assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
+    assert len(assignments) == lanes
+    assert all("((const unsigned char*)(&((on_true))))" in line for line in assignments)
+    assert all("((const unsigned char*)(&((on_false))))" in line for line in assignments)
+    assert all(line.startswith("  ((unsigned char*)(&(__") for line in assignments)
+    assert all("0x01u" in line for line in assignments)
+    assert ".x" not in "\n".join(assignments)
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize(
+    ("dtype", "lanes"),
+    [
+        ("float8_e4m3fn", 2),
+        ("float8_e5m2", 2),
+        ("int4", 4),
+        ("int4", 8),
+        ("uint4", 4),
+        ("uint4", 8),
+        ("int8", 8),
+        ("bool", 8),
+        ("bool", 16),
+        ("bool", 32),
+    ],
+)
+def test_narrow_vector_select_compiles_with_packed_hip_carriers(dtype, lanes):
+    mod = _make_narrow_vector_select_module(dtype, lanes)
+    build = tvm.get_global_func("target.build.tilelang_hip")
+    build(mod, tvm.target.Target("rocm"))
+
+
+@tilelang.testing.requires_rocm
+@pytest.mark.parametrize(
+    ("source_dtype", "source_lanes", "result_dtype", "result_lanes"),
+    [("uint8", 8, "uint16", 4), ("uint16", 4, "uint8", 8)],
+)
+def test_lane_changing_reinterpret_select_compiles(source_dtype, source_lanes, result_dtype, result_lanes):
+    mod = _make_lane_changing_reinterpret_select_module(source_dtype, source_lanes, result_dtype, result_lanes)
+    build = tvm.get_global_func("target.build.tilelang_hip")
+    build(mod, tvm.target.Target("rocm"))
 
 
 if __name__ == "__main__":

--- a/testing/python/amd/test_tilelang_hip_vector_select_codegen.py
+++ b/testing/python/amd/test_tilelang_hip_vector_select_codegen.py
@@ -1,0 +1,270 @@
+import pytest
+
+from tilelang import tvm
+from tvm import tirx
+
+
+def _build_vector_select_source(
+    lanes,
+    wrap_input_in_let=False,
+    wrap_input_in_scalar_lets=False,
+    wrap_input_in_call=False,
+    wrap_input_in_call_extern=False,
+    wrap_input_in_reinterpret=False,
+    wrap_input_in_packed_call=False,
+):
+    output_dtype = "int32" if wrap_input_in_reinterpret else "float32"
+    mask_buffer = tirx.decl_buffer((lanes,), "float32", name="mask")
+    input_buffer = tirx.decl_buffer((lanes,), "float32", name="input")
+    output_buffer = tirx.decl_buffer((lanes,), output_dtype, name="output")
+    ramp = tirx.Ramp(0, 1, lanes)
+    mask_vector = tirx.BufferLoad(mask_buffer, [ramp])
+    input_vector = tirx.BufferLoad(input_buffer, [ramp])
+    if wrap_input_in_let:
+        value = tirx.Var("value", f"float32x{lanes}")
+        input_vector = tirx.Let(value, input_vector, value)
+    if wrap_input_in_scalar_lets:
+        scalar_lets = []
+        for lane in range(lanes):
+            value = tirx.Var(f"value_{lane}", "float32")
+            load = tirx.BufferLoad(input_buffer, [lane])
+            scalar_lets.append(tirx.Let(value, load, value))
+        input_vector = tirx.Shuffle(scalar_lets, list(range(lanes)))
+    if wrap_input_in_call:
+        input_vector = tirx.call_pure_extern(f"float32x{lanes}", "exp2f", input_vector)
+    if wrap_input_in_call_extern:
+        input_vector = tirx.call_extern(f"float32x{lanes}", "exp2f", input_vector)
+    if wrap_input_in_reinterpret:
+        input_vector = tirx.reinterpret(f"int32x{lanes}", input_vector)
+    if wrap_input_in_packed_call:
+        bias = tirx.Broadcast(tirx.const(1, "float32"), lanes)
+        input_vector = tirx.Call(f"float32x{lanes}", tvm.ir.Op.get("tl.add2"), [input_vector, bias])
+    mask_zero = tirx.Broadcast(tirx.const(0, "float32"), lanes)
+    result_zero = tirx.Broadcast(tirx.const(0, output_dtype), lanes)
+    selected = tirx.Select(mask_vector > mask_zero, input_vector, result_zero)
+    body = tirx.BufferStore(output_buffer, selected, [ramp])
+    func = tirx.PrimFunc(
+        [mask_buffer.data, input_buffer.data, output_buffer.data],
+        body,
+        buffer_map={
+            mask_buffer.data: mask_buffer,
+            input_buffer.data: input_buffer,
+            output_buffer.data: output_buffer,
+        },
+    )
+    func = func.with_attr("global_symbol", "vector_select")
+    func = func.with_attr("calling_conv", tvm.ir.CallingConv.DEVICE_KERNEL_LAUNCH)
+    mod = tvm.IRModule({"vector_select": func})
+    build = tvm.get_global_func("target.build.tilelang_hip_without_compile", allow_missing=True)
+    if build is None:
+        pytest.skip("TileLang was built without the ROCm code generator")
+    return build(mod, tvm.target.Target("rocm")).inspect_source()
+
+
+def _build_vector_select_with_vector_argument_source():
+    lanes = 4
+    value = tirx.Var("value", "float32x4")
+    mask_buffer = tirx.decl_buffer((lanes,), "float32", name="mask")
+    output_buffer = tirx.decl_buffer((lanes,), "float32", name="output")
+    scalar_base = tirx.Shuffle([tirx.Ramp(0, 1, lanes)], [0])
+    ramp = tirx.Ramp(scalar_base, 1, lanes)
+    mask_vector = tirx.BufferLoad(mask_buffer, [ramp])
+    zero = tirx.Broadcast(tirx.const(0, "float32"), lanes)
+    selected = tirx.Select(mask_vector > zero, value, zero)
+    body = tirx.BufferStore(output_buffer, selected, [ramp])
+    func = tirx.PrimFunc(
+        [value, mask_buffer.data, output_buffer.data],
+        body,
+        buffer_map={
+            mask_buffer.data: mask_buffer,
+            output_buffer.data: output_buffer,
+        },
+    )
+    func = func.with_attr("global_symbol", "vector_select_argument")
+    func = func.with_attr("calling_conv", tvm.ir.CallingConv.DEVICE_KERNEL_LAUNCH)
+    mod = tvm.IRModule({"vector_select_argument": func})
+    build = tvm.get_global_func("target.build.tilelang_hip_without_compile", allow_missing=True)
+    if build is None:
+        pytest.skip("TileLang was built without the ROCm code generator")
+    return build(mod, tvm.target.Target("rocm")).inspect_source()
+
+
+def _build_narrow_vector_select_source(dtype, lanes):
+    on_true = tirx.Var("on_true", f"{dtype}x{lanes}")
+    on_false = tirx.Var("on_false", f"{dtype}x{lanes}")
+    ramp = tirx.Ramp(0, 1, lanes)
+    limit = tirx.Broadcast(tirx.const(lanes // 2, "int32"), lanes)
+    selected = tirx.Select(
+        ramp < limit,
+        on_true,
+        on_false,
+    )
+    func = tirx.PrimFunc([on_true, on_false], tirx.Evaluate(selected))
+    func = func.with_attr("global_symbol", "narrow_vector_select")
+    func = func.with_attr("calling_conv", tvm.ir.CallingConv.DEVICE_KERNEL_LAUNCH)
+    mod = tvm.IRModule({"narrow_vector_select": func})
+    build = tvm.get_global_func("target.build.tilelang_hip_without_compile", allow_missing=True)
+    if build is None:
+        pytest.skip("TileLang was built without the ROCm code generator")
+    return build(mod, tvm.target.Target("rocm")).inspect_source()
+
+
+def _build_scalar_select_source():
+    mask_buffer = tirx.decl_buffer((1,), "float32", name="mask")
+    input_buffer = tirx.decl_buffer((1,), "float32", name="input")
+    output_buffer = tirx.decl_buffer((1,), "float32", name="output")
+    zero = tirx.const(0, "float32")
+    selected = tirx.Select(
+        tirx.BufferLoad(mask_buffer, [0]) > zero,
+        tirx.BufferLoad(input_buffer, [0]),
+        zero,
+    )
+    body = tirx.BufferStore(output_buffer, selected, [0])
+    func = tirx.PrimFunc(
+        [mask_buffer.data, input_buffer.data, output_buffer.data],
+        body,
+        buffer_map={
+            mask_buffer.data: mask_buffer,
+            input_buffer.data: input_buffer,
+            output_buffer.data: output_buffer,
+        },
+    )
+    func = func.with_attr("global_symbol", "scalar_select")
+    func = func.with_attr("calling_conv", tvm.ir.CallingConv.DEVICE_KERNEL_LAUNCH)
+    mod = tvm.IRModule({"scalar_select": func})
+    build = tvm.get_global_func("target.build.tilelang_hip_without_compile", allow_missing=True)
+    if build is None:
+        pytest.skip("TileLang was built without the ROCm code generator")
+    return build(mod, tvm.target.Target("rocm")).inspect_source()
+
+
+def test_vector_condition_select_is_scalarized_in_hip_source():
+    source = _build_vector_select_source(4)
+
+    assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
+    assert len(assignments) == 4
+    assert all("mask[" in line and "? input[" in line for line in assignments)
+    assert "*(float4*)(input" not in source
+
+
+def test_scalar_select_uses_base_ternary_path():
+    source = _build_scalar_select_source()
+
+    assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
+    assert assignments == ["  output[0] = ((mask[0] > 0.000000e+00f) ? input[0] : 0.000000e+00f);"]
+
+
+def test_eight_lane_select_keeps_masked_loads_in_ternary_branches():
+    source = _build_vector_select_source(8)
+
+    assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
+    assert len(assignments) == 8
+    assert all("mask[" in line and "? input[" in line for line in assignments)
+    assert "*(ulonglong4*)(input" not in source
+    assert "ushort8" not in source
+
+
+def test_vector_argument_and_scalar_shuffle_are_lane_extracted():
+    source = _build_vector_select_with_vector_argument_source()
+
+    assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
+    assert len(assignments) == 4
+    assert all("mask[" in line and "? (value)." in line for line in assignments)
+
+
+def test_vector_let_binding_is_scalarized_without_type_mismatch():
+    source = _build_vector_select_source(4, wrap_input_in_let=True)
+
+    assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
+    assert len(assignments) == 4
+    assert all("mask[" in line and "? input[" in line for line in assignments)
+
+
+def test_scalar_let_loads_stay_inside_vector_select_branches():
+    source = _build_vector_select_source(4, wrap_input_in_scalar_lets=True)
+
+    assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
+    assert len(assignments) == 4
+    assert all("mask[" in line and "? input[" in line for line in assignments)
+
+
+def test_vector_pure_call_keeps_argument_load_in_select_branch():
+    source = _build_vector_select_source(4, wrap_input_in_call=True)
+
+    assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
+    assert len(assignments) == 4
+    assert all("? exp2f(input[" in line for line in assignments)
+    assert "*(float4*)(input" not in source
+
+
+def test_vector_call_extern_keeps_argument_load_in_select_branch():
+    source = _build_vector_select_source(4, wrap_input_in_call_extern=True)
+
+    assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
+    assert len(assignments) == 4
+    assert all("? exp2f(input[" in line for line in assignments)
+    assert "*(float4*)(input" not in source
+
+
+def test_vector_reinterpret_keeps_argument_load_in_select_branch():
+    source = _build_vector_select_source(4, wrap_input_in_reinterpret=True)
+
+    assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
+    assert len(assignments) == 4
+    for lane, assignment in enumerate(assignments):
+        assert f"input[{lane}]" in assignment
+    assert "*(float4*)(input" not in source
+
+
+def test_vector_packed_call_keeps_argument_load_in_select_branch():
+    source = _build_vector_select_source(2, wrap_input_in_packed_call=True)
+
+    assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
+    assert len(assignments) == 2
+    assert all("? (input[" in line and "+ 1.000000e+00f" in line for line in assignments)
+    assert "tl::add2" not in source
+
+
+@pytest.mark.parametrize("lanes", [16, 32])
+def test_wide_float4_vector_results_are_stored_by_packed_pair(lanes):
+    source = _build_narrow_vector_select_source("float4_e2m1fn", lanes)
+
+    assignments = [line for line in source.splitlines() if "?" in line and "set_" in line]
+    assert len(assignments) == lanes
+    for lane, assignment in enumerate(assignments):
+        remaining_lanes = lanes
+        remaining_lane = lane
+        path = []
+        while remaining_lanes > 2:
+            group_size = remaining_lanes // 2
+            path.append("x" if remaining_lane < group_size else "y")
+            remaining_lane %= group_size
+            remaining_lanes = group_size
+        pair = ".".join(path)
+        accessor = "x" if remaining_lane == 0 else "y"
+        assert f".{pair}.set_{accessor}(" in assignment
+        assert f"(({lane} < {lanes // 2}) ? (on_true).{pair}.{accessor}() : (on_false).{pair}.{accessor}())" in assignment
+
+
+@pytest.mark.parametrize(
+    ("dtype", "lanes", "lane_members"),
+    [
+        ("float8_e4m3fn", 2, ["x", "y"]),
+        (
+            "float8_e5m2",
+            8,
+            ["x.x", "x.y", "x.z", "x.w", "y.x", "y.y", "y.z", "y.w"],
+        ),
+    ],
+)
+def test_float8_vector_results_are_stored_by_lane(dtype, lanes, lane_members):
+    source = _build_narrow_vector_select_source(dtype, lanes)
+
+    assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
+    assert len(assignments) == lanes
+    for lane, member in enumerate(lane_members):
+        assert f"(({lane} < {lanes // 2}) ? (on_true).{member} : (on_false).{member})" in assignments[lane]
+
+
+if __name__ == "__main__":
+    test_vector_condition_select_is_scalarized_in_hip_source()


### PR DESCRIPTION
Fixes #2888.

### Problem

A fixed-length vector `Select` reached HIP codegen through the base C emitter, which produces one scalar ternary. HIP boolean vectors cannot be used as scalar conditions, and materializing vector branches before lane-wise ternaries would also evaluate masked loads eagerly.

The original implementation handled four-lane conditions, but still required an unsupported `boolx8` carrier for wider conditions and assigned both branch vectors before selecting their lanes.

### Change

Lower each fixed-length vector `Select` to scalar lane expressions before emitting HIP source. Each branch remains inside its lane's C ternary, so inactive lanes do not execute masked `BufferLoad` expressions. Pure external vector calls are rebuilt with scalar arguments for the requested lane. The packed element-wise `tl.add2/sub2/mul2/fma2/max2/min2/abs2` family is likewise decomposed into its scalar lane semantics, preserving lazy branch evaluation.

This avoids constructing a vector boolean temporary, allowing supported wider result carriers such as `float32x8`/`ulonglong4`. The scalarizer handles ramp, broadcast, cast, shuffle, vector leaves, vector `Let` expressions, pure external calls, and packed element-wise calls. FP8 results are written through their existing nested HIP carrier fields. FP4 results walk to the nested x2 pair and use its `set_x`/`set_y` API, covering all represented widths without width-specific constructors. This also extends `PrintVecElemLoad` and `PrintVecElemStore` to traverse FP8 and FP4 carriers; those types previously fell through the integer-only 8-bit handling. FP8x2 accesses now operate on ROCm's packed `__x` storage, and signed or unsigned 4-bit integer vectors are loaded and stored as packed nibbles. Scalar `Select` expressions continue to use the base C emitter.

Boolean vector values wider than four lanes remain unsupported across the HIP backend because no carrier or load/store representation exists for them; this change does not introduce a Select-specific representation.

### Regression coverage

The compile-only HIP codegen tests cover:

- x4 and x8 conditions with a separate mask buffer, verifying each `input[i]` load remains in the true ternary arm and no packed input vector is loaded eagerly;
- pure external and packed element-wise calls whose vector-load arguments must remain inside the selected branch;
- vector-valued arguments, scalar Shuffle bases, and vector Let bindings;
- E4/E5 x2 and E5 x8 FP8 results with exact packed or nested-carrier lane stores;
- signed and unsigned 4-bit integer x4/x8 results with packed nibble access;
- x8, x16, and x32 FP4 results with exact nested-pair stores;
- the unchanged scalar Select fallback.

### Validation

- Rebased onto `main` after #2318 and rebuilt with `USE_CUDA=OFF`, `USE_ROCM=ON`, and `TILELANG_USE_HIP_STUBS=ON` — passed.
- `pytest -q testing/python/amd/test_tilelang_hip_vector_select_codegen.py testing/python/amd/test_tilelang_hip_codegen.py testing/python/backend/test_tilelang_backend_module.py` — 33 passed, 42 hardware-dependent tests skipped.
- Pre-commit hooks on the changed C++ and Python files — passed.

Runtime execution on an AMD device is pending the fresh Nightly ROCm 7.2 run triggered by the rebase. The preceding PR head passed `test_tilelang_issue_2682.py::test_vectorized_select` and the full gfx942 suite (1827 passed, 0 failed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added lane-wise HIP lowering for fixed-length vector `Select` conditions.
- Preserved branch-local evaluation to avoid eager masked loads.
- Scalarized ramps, broadcasts, casts, shuffles, vector leaves, vector `Let` bindings, pure external calls, and packed element-wise calls.
- Added FP8 and FP4 vector result handling.
- Kept scalar `Select` expressions on the existing scalar C emitter path.
- Added regression tests for x4/x8 vectors, vector arguments, `Let` bindings, shuffle bases, packed calls, FP8/FP4 results, and scalar fallback.

## Validation

- ROCm-stub build passed.
- Targeted tests passed.
- Pre-commit checks passed.
- Runtime testing on AMD hardware was unavailable.

## C++ style / lint notes

- This PR changes C++ code but does not modify `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) may report advisory findings. These warnings are separate from correctness and build validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->