### PR TITLE
[Compiler][Z3] Isolate analyzer contexts per kernel compilation

### DIFF
--- a/testing/python/arith/test_arith_hard.py
+++ b/testing/python/arith/test_arith_hard.py
@@ -1,6 +1,6 @@
 import tilelang.testing
 import tilelang.language as T
-from tvm.arith import Analyzer
+from tvm.arith import Analyzer, Z3ContextScope
 from tvm.ir.expr import Range
 from tvm.tirx.expr import Not, Or
 from tvm import tirx
@@ -8,6 +8,23 @@ from tvm import tirx
 
 def implies(x, y):
     return Or(Not(x), y)
+
+
+def test_z3_context_scope_clone_outlives_scope():
+    x = T.Var("x", T.int32)
+
+    with Z3ContextScope():
+        analyzer = Analyzer()
+        analyzer.bind(x, Range.from_min_extent(0, 16))
+
+    # Clone while a different compile scope is active. CopyFrom must retain
+    # the source Analyzer's context rather than mixing Z3 handles.
+    with Z3ContextScope():
+        cloned = analyzer.clone()
+
+    del analyzer
+    assert cloned.can_prove(x >= 0)
+    assert cloned.can_prove(x < 16)
 
 
 def test_hard_prove():

--- a/testing/python/layout/test_tilelang_layout_inference_z3_context.py
+++ b/testing/python/layout/test_tilelang_layout_inference_z3_context.py
@@ -1,0 +1,133 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+from tilelang.autotuner.grouped_compile import compile_grouped_unit_tvm_ffi
+from tilelang.autotuner.param import CompileArgs
+
+
+_STATE_CACHE_CASES = (
+    (266, 138, 44, 576),
+    (266, 138, 44, 8),
+    (145, 17, 21, 2048),
+    (145, 17, 21, 5120),
+)
+
+_STATE_CACHE_CONFIG_KEYS = (
+    "block_size_kvstore",
+    "block_size_inference",
+    "num_layers",
+    "feature_dim",
+)
+
+_STATE_CACHE_PASS_CONFIGS = {
+    tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+    tilelang.PassConfigKey.TL_DISABLE_DATA_RACE_CHECK: True,
+}
+
+
+def _make_state_cache_kernel(
+    block_size_kvstore: int,
+    block_size_inference: int,
+    num_layers: int,
+    feature_dim: int,
+):
+    cache_layer_stride = T.dynamic("cache_layer_stride")
+    cache_token_stride = T.dynamic("cache_token_stride")
+    tensor_layer_stride = T.dynamic("tensor_layer_stride")
+    tensor_token_stride = T.dynamic("tensor_token_stride")
+
+    block = 64
+    enable_pdl_sync = block_size_inference * feature_dim >= 65536
+
+    @T.prim_func
+    def kernel(
+        state_tensor: T.StridedTensor(
+            (num_layers, block_size_inference, feature_dim),
+            (tensor_layer_stride, tensor_token_stride, 1),
+            "uint8",
+        ),
+        state_cache: T.StridedTensor(
+            (num_layers, block_size_kvstore, feature_dim),
+            (cache_layer_stride, cache_token_stride, 1),
+            "uint8",
+        ),
+        last_hit_position: T.int32,
+    ):
+        T.assume(cache_layer_stride % 8 == 0)
+        T.assume(cache_token_stride % 8 == 0)
+        T.assume(tensor_layer_stride % 8 == 0)
+        T.assume(tensor_token_stride % 8 == 0)
+
+        start_pos = last_hit_position - block_size_inference
+
+        with T.Kernel(num_layers, T.ceildiv(block_size_inference, block)) as (bx, by):
+            if enable_pdl_sync:
+                T.pdl_sync()
+            for token_idx, feat_idx in T.Parallel(block, feature_dim):
+                actual_token_idx = by * block + token_idx
+                if actual_token_idx < block_size_inference:
+                    source_token_idx = (start_pos + actual_token_idx + block_size_kvstore) % block_size_kvstore
+                    target_token_idx = (start_pos + actual_token_idx + block_size_inference) % block_size_inference
+                    state_tensor[bx, target_token_idx, feat_idx] = state_cache[bx, source_token_idx, feat_idx]
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_layout_inference_isolated_from_previous_compile_z3_state():
+    cache_was_enabled = tilelang.is_cache_enabled()
+    tilelang.disable_cache()
+    try:
+        for config in _STATE_CACHE_CASES:
+            tilelang.compile(
+                _make_state_cache_kernel(*config),
+                target="cuda",
+                pass_configs=_STATE_CACHE_PASS_CONFIGS,
+            )
+    finally:
+        if cache_was_enabled:
+            tilelang.enable_cache()
+
+
+@tilelang.testing.requires_cuda
+def test_grouped_layout_inference_uses_fresh_z3_context_per_kernel():
+    unit_items = [(index, dict(zip(_STATE_CACHE_CONFIG_KEYS, config))) for index, config in enumerate(_STATE_CACHE_CASES)]
+    compile_args = CompileArgs(
+        execution_backend="tvm_ffi",
+        target=tvm.target.Target("cuda"),
+        pass_configs=_STATE_CACHE_PASS_CONFIGS,
+    )
+
+    results = compile_grouped_unit_tvm_ffi(
+        unit_items=unit_items,
+        compile_args=compile_args,
+        elaborate_func=_make_state_cache_kernel,
+    )
+
+    assert len(results) == len(unit_items)
+    for _, _, kernel, error in results:
+        if error is not None:
+            raise error
+        assert kernel is not None
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/autotuner/grouped_compile.py
+++ b/tilelang/autotuner/grouped_compile.py
@@ -34,9 +34,9 @@ def compile_grouped_unit_tvm_ffi(
 
     Flow:
     1. Elaborate each config into a PrimFunc.
-    2. Lower each PrimFunc into host/device IR modules.
-    3. Merge all device IR into one IRModule and compile device code once.
-    4. Build host runtime module per config and import shared device module.
+    2. Lower each PrimFunc and build its host module in a fresh Z3 context.
+    3. Merge all device IR and compile it once in a separate fresh Z3 context.
+    4. Import the shared device module into each host runtime module.
     5. Construct per-config JITKernel objects that share the grouped device module.
     """
 
@@ -69,31 +69,41 @@ def compile_grouped_unit_tvm_ffi(
             program = program.with_attr("global_symbol", unique_symbol)
 
             config_instruments, timing_inst = create_pass_instruments()
+            with tvm.arith.Z3ContextScope():
+                with (
+                    report_pass_timing_on_exit(
+                        timing_inst,
+                        context=f"stage=grouped-lower, config={idx}, kernel={unique_symbol}",
+                    ),
+                    tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=config_instruments),
+                    compile_args.target,
+                ):
+                    host_mod, device_mod, params, normalized_target, normalized_target_host = lower_to_host_device_ir(
+                        program,
+                        target=compile_args.target,
+                        target_host=compile_args.target_host,
+                    )
 
-            with (
-                report_pass_timing_on_exit(
-                    timing_inst,
-                    context=f"stage=grouped-lower, config={idx}, kernel={unique_symbol}",
-                ),
-                tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=config_instruments),
-                compile_args.target,
-            ):
-                host_mod, device_mod, params, normalized_target, normalized_target_host = lower_to_host_device_ir(
-                    program,
-                    target=compile_args.target,
-                    target_host=compile_args.target_host,
-                )
+                host_instruments, host_timing_inst = create_pass_instruments()
+                with (
+                    report_pass_timing_on_exit(
+                        host_timing_inst,
+                        context=f"stage=grouped-host, config={idx}, kernel={unique_symbol}",
+                    ),
+                    tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=host_instruments),
+                    normalized_target,
+                ):
+                    host_rt_mod = host_codegen(host_mod, normalized_target_host, target=normalized_target)
 
             lowered_items.append(
                 {
                     "idx": idx,
                     "config_arg": config_arg,
                     "program": program,
-                    "host_mod": host_mod,
+                    "host_rt_mod": host_rt_mod,
                     "device_mod": device_mod,
                     "params": params,
                     "target": normalized_target,
-                    "target_host": normalized_target_host,
                 }
             )
         except Exception as e:
@@ -124,6 +134,7 @@ def compile_grouped_unit_tvm_ffi(
         device_instruments, device_timing_inst = create_pass_instruments()
         grouped_config_indices = ",".join(str(item["idx"]) for item in lowered_items)
         with (
+            tvm.arith.Z3ContextScope(),
             report_pass_timing_on_exit(
                 device_timing_inst,
                 context=f"stage=grouped-device, configs=[{grouped_config_indices}]",
@@ -139,26 +150,15 @@ def compile_grouped_unit_tvm_ffi(
             idx = item["idx"]
             config_arg = item["config_arg"]
             try:
-                host_instruments, host_timing_inst = create_pass_instruments()
-                kernel_symbol = str(item["program"].attrs["global_symbol"])
-                with (
-                    report_pass_timing_on_exit(
-                        host_timing_inst,
-                        context=f"stage=grouped-host, config={idx}, kernel={kernel_symbol}",
-                    ),
-                    tvm.transform.PassContext(opt_level=3, config=pass_configs, instruments=host_instruments),
-                    item["target"],
-                ):
-                    grouped_host_rt_mod = host_codegen(item["host_mod"], item["target_host"], target=item["target"])
-
-                grouped_host_rt_mod.import_module(grouped_device_rt_mod)
+                host_rt_mod = item["host_rt_mod"]
+                host_rt_mod.import_module(grouped_device_rt_mod)
 
                 artifact = CompiledArtifact(
-                    host_mod=grouped_host_rt_mod,
+                    host_mod=host_rt_mod,
                     device_mod=item["device_mod"],
                     params=item["params"],
                     kernel_source=grouped_kernel_source,
-                    rt_mod=grouped_host_rt_mod,
+                    rt_mod=host_rt_mod,
                 )
 
                 adapter = TVMFFIKernelAdapter(

--- a/tilelang/engine/lower.py
+++ b/tilelang/engine/lower.py
@@ -309,6 +309,25 @@ def lower(
     own device codegen implementation in jit.
     """
 
+    with tvm.arith.Z3ContextScope():
+        return _lower_impl(
+            func_or_mod=func_or_mod,
+            target=target,
+            target_host=target_host,
+            runtime_only=runtime_only,
+            enable_host_codegen=enable_host_codegen,
+            enable_device_compile=enable_device_compile,
+        )
+
+
+def _lower_impl(
+    func_or_mod: tirx.PrimFunc | tvm.IRModule,
+    target: str | Target = "auto",
+    target_host: str | Target | None = None,
+    runtime_only=False,
+    enable_host_codegen=False,
+    enable_device_compile=False,
+) -> CompiledArtifact:
     host_mod, device_mod, params, target, target_host = lower_to_host_device_ir(
         func_or_mod=func_or_mod,
         target=target,


### PR DESCRIPTION
## Summary

- isolate each TileLang kernel compilation in a fresh Z3 context
- prevent Z3 resource limits and AST history from leaking across kernels and making layout inference order-dependent
- update the TVM submodule to the scoped-context support merged in [tile-ai/tvm#62](https://github.com/tile-ai/tvm/pull/62)

## Changes

- wrap the public lowering path in `tvm.arith.Z3ContextScope`, sharing one context within a kernel compilation while isolating independent compilations
- give each config in grouped TVM FFI compilation its own lowering and host-codegen context
- compile the merged grouped device module in a separate fresh context while preserving the shared device runtime module
- add a state-cache layout inference regression covering sequential and grouped compilation
- add coverage for analyzer clones that outlive their originating context scope

## Validation

- `cmake --build build -j64`
- `PYTHONPATH=. python -m pytest -q testing/python/arith/test_arith_hard.py testing/python/layout/test_tilelang_layout_inference_z3_context.py` (7 passed)
- `./format.sh`

## Notes

The regression sequence uses kernels that each compile successfully with a fresh context. Direct unscoped lowering reproduces the previous `no available layout found` failure on the fourth kernel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR isolates Z3 analyzer state per TileLang kernel compile.

It wraps public lowering in `tvm.arith.Z3ContextScope`. It also gives each grouped TVM FFI config its own lowering and host-codegen context.

Grouped compilation now builds host modules in fresh Z3 contexts. It still merges and compiles device modules once in a separate context. It keeps the shared device runtime module intact.

The TVM submodule moves to scoped-context support from `tile-ai/tvm#62`.

It also adds regression coverage for:
- sequential and grouped layout inference
- analyzer clones that survive the source Z3 context scope

Validation passed with the listed build checks, tests, and formatting checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->