### PR TITLE
[BugFix][Carver] Parse lettered SM arch strings in check_sm_version

### DIFF
--- a/testing/python/carver/test_tilelang_carver_sm_version.py
+++ b/testing/python/carver/test_tilelang_carver_sm_version.py
@@ -1,0 +1,78 @@
+"""CPU regression test for SM arch string parsing in the carver.
+
+``check_sm_version`` gates every compute-capability decision the carver makes:
+``arch.sm_version`` feeds ``is_volta_arch`` / ``is_ampere_arch`` /
+``is_ada_arch`` / ``is_hopper_arch`` / ``has_mma_support``, and
+``matmul_analysis`` compares the same value against 70, 80 and 90 to pick the
+tensorcore path.
+
+nvcc and CUTLASS spell the arch-specific feature set of Hopper and newer with a
+trailing letter (``sm_90a``, ``sm_100a``, ``sm_103a``), and that is the value
+that reaches ``target.attrs["arch"]``. The old ``str.isdigit()`` guard rejected
+those strings and collapsed them to the -1 sentinel, so a real ``sm_90a``
+target read as older than sm_70 and silently lost its Hopper dispatch.
+
+No GPU is needed: the defect and the fix are pure string parsing.
+"""
+
+import tilelang.testing
+from tilelang.carver.arch import cuda as carver_cuda
+from tilelang.carver.arch.cuda import CUDA, check_sm_version, has_mma_support, is_ada_arch, is_ampere_arch, is_hopper_arch, is_volta_arch
+from tilelang.carver import matmul_analysis
+
+
+def test_check_sm_version_numeric_arch():
+    assert check_sm_version("sm_70") == 70
+    assert check_sm_version("sm_80") == 80
+    assert check_sm_version("sm_89") == 89
+    assert check_sm_version("sm_90") == 90
+    # The bare numeric form was already accepted and must stay accepted.
+    assert check_sm_version("90") == 90
+
+
+def test_check_sm_version_lettered_arch():
+    assert check_sm_version("sm_90a") == 90
+    assert check_sm_version("sm_100a") == 100
+    assert check_sm_version("sm_103a") == 103
+    assert check_sm_version("sm_120f") == 120
+
+
+def test_check_sm_version_rejects_non_cuda_arch():
+    # Not CUDA arches, so the -1 sentinel is the correct answer here.
+    assert check_sm_version("gfx942") == -1
+    assert check_sm_version("gfx90a") == -1
+    assert check_sm_version("sm_") == -1
+    assert check_sm_version("") == -1
+
+
+def _cuda_arch_with_sm_version(sm_version: int) -> CUDA:
+    """Build a CUDA arch carrying ``sm_version`` without touching a device.
+
+    ``CUDA.__init__`` queries cuda device 0, which no CPU runner has, but the
+    predicates below only read ``sm_version`` plus ``isinstance(arch, CUDA)``.
+    """
+    arch = CUDA.__new__(CUDA)
+    arch.sm_version = sm_version
+    return arch
+
+
+def test_lettered_arch_keeps_capability_dispatch():
+    hopper = _cuda_arch_with_sm_version(check_sm_version("sm_90a"))
+    assert is_hopper_arch(hopper)
+    assert has_mma_support(hopper)
+    assert not is_volta_arch(hopper)
+    assert not is_ampere_arch(hopper)
+    assert not is_ada_arch(hopper)
+
+    blackwell = _cuda_arch_with_sm_version(check_sm_version("sm_100a"))
+    assert has_mma_support(blackwell)
+
+
+def test_matmul_analysis_shares_one_parser():
+    # matmul_analysis used to carry its own copy of the same buggy body, so a
+    # fix in one place left the other wrong. Pin the single definition.
+    assert matmul_analysis.check_sm_version is carver_cuda.check_sm_version
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/carver/test_tilelang_carver_sm_version.py
+++ b/testing/python/carver/test_tilelang_carver_sm_version.py
@@ -45,6 +45,15 @@ def test_check_sm_version_rejects_non_cuda_arch():
     assert check_sm_version("") == -1
 
 
+def test_check_sm_version_rejects_malformed_prefix():
+    # Only one leading "sm_" is part of the grammar. Stripping every occurrence
+    # instead would let these read as valid compute capabilities.
+    assert check_sm_version("sm_sm_90") == -1
+    assert check_sm_version("xsm_90") == -1
+    assert check_sm_version("sm_90_sm_80") == -1
+    assert check_sm_version("90sm_") == -1
+
+
 def _cuda_arch_with_sm_version(sm_version: int) -> CUDA:
     """Build a CUDA arch carrying ``sm_version`` without touching a device.
 

--- a/tilelang/carver/arch/cuda.py
+++ b/tilelang/carver/arch/cuda.py
@@ -1,13 +1,26 @@
 from __future__ import annotations
+import re
 import tvm
 from tvm.target import Target
 from .arch_base import TileDevice
 from .driver import cuda_driver
 
+# Matches the numeric compute capability of an SM arch string, tolerating the
+# trailing feature-set letters nvcc and CUTLASS use for Hopper and newer
+# ("sm_90a", "sm_100a", "sm_103a").
+_SM_VERSION_PATTERN = re.compile(r"^(\d+)[a-zA-Z]*$")
+
 
 def check_sm_version(arch: str) -> int:
+    """Return the numeric compute capability of an SM arch string, or -1.
+
+    ``sm_90`` and ``sm_90a`` both describe compute capability 9.0, so both
+    parse to 90. Anything that does not start with digits, such as a HIP
+    ``gfx942`` target, is not a CUDA arch and returns -1.
+    """
     sm_version = arch.replace("sm_", "")
-    return int(sm_version) if sm_version.isdigit() else -1
+    match = _SM_VERSION_PATTERN.match(sm_version)
+    return int(match.group(1)) if match else -1
 
 
 def is_cuda_arch(arch: TileDevice) -> bool:

--- a/tilelang/carver/arch/cuda.py
+++ b/tilelang/carver/arch/cuda.py
@@ -5,21 +5,22 @@ from tvm.target import Target
 from .arch_base import TileDevice
 from .driver import cuda_driver
 
-# Matches the numeric compute capability of an SM arch string, tolerating the
-# trailing feature-set letters nvcc and CUTLASS use for Hopper and newer
-# ("sm_90a", "sm_100a", "sm_103a").
-_SM_VERSION_PATTERN = re.compile(r"^(\d+)[a-zA-Z]*$")
+# Matches an SM arch string in full: one optional "sm_" prefix, the numeric
+# compute capability, then the trailing feature-set letters nvcc and CUTLASS use
+# for Hopper and newer ("sm_90a", "sm_100a", "sm_103a"). Anchoring the prefix
+# here rather than stripping it first means a malformed value like "sm_sm_90"
+# has no way to slip through.
+_SM_VERSION_PATTERN = re.compile(r"^(?:sm_)?(\d+)[a-zA-Z]*$")
 
 
 def check_sm_version(arch: str) -> int:
     """Return the numeric compute capability of an SM arch string, or -1.
 
     ``sm_90`` and ``sm_90a`` both describe compute capability 9.0, so both
-    parse to 90. Anything that does not start with digits, such as a HIP
-    ``gfx942`` target, is not a CUDA arch and returns -1.
+    parse to 90. Anything that is not a well formed SM arch, such as a HIP
+    ``gfx942`` target, returns -1.
     """
-    sm_version = arch.replace("sm_", "")
-    match = _SM_VERSION_PATTERN.match(sm_version)
+    match = _SM_VERSION_PATTERN.match(arch)
     return int(match.group(1)) if match else -1
 
 

--- a/tilelang/carver/matmul_analysis.py
+++ b/tilelang/carver/matmul_analysis.py
@@ -18,6 +18,7 @@ from .analysis import (
 from tvm.target.target import Target
 from tvm.tirx.stmt_functor import pre_order_visit
 from .arch import get_arch, is_tensorcore_supported_precision
+from .arch.cuda import check_sm_version
 from .arch.rdna import _get_rdna_tuning_config
 from tilelang.rocm.target import target_get_mcpu, target_is_rdna
 import logging
@@ -539,10 +540,6 @@ def get_tensorized_func_and_tags(
         return all(conditions)
 
     # step2. transform function to tensorcore matmul (e.g. conv2d with im2col)
-    def check_sm_version(arch: str) -> int:
-        sm_version = arch.replace("sm_", "")
-        return int(sm_version) if sm_version.isdigit() else -1
-
     def is_cuda_tensorcore_target(target: Target) -> bool:
         return target.kind.name == "cuda" and check_sm_version(target.attrs.get("arch", "")) >= 70
 


### PR DESCRIPTION
`check_sm_version` gated on `str.isdigit()`, so any arch string carrying the trailing feature-set letter that nvcc and CUTLASS use for Hopper and newer, `sm_90a`, `sm_100a`, `sm_103a`, fell through to the `-1` sentinel instead of parsing to 90, 100 or 103.

Those lettered strings are the real value of `target.attrs["arch"]`, not a hypothetical one. `tilelang/contrib/nvcc.py` already does `.rstrip("af")` on that same attribute, `tilelang/contrib/nvrtc.py` documents `"90a"` as a valid arch, `tilelang/contrib/cutedsl/cpasync.py` validates against `["sm_90", "sm_90a", "sm_100a"]`, and `tilelang/carver/roller/policy/tensorcore.py` compares `compute_capability` against `"sm_90a"` directly. One path handled the suffix and this one did not.

The `-1` then silently corrupted capability dispatch. `CUDA.sm_version` is set from `check_sm_version` and feeds `is_volta_arch`, `is_ampere_arch`, `is_ada_arch`, `is_hopper_arch` and `has_mma_support`, and `matmul_analysis` compares the same value against 70, 80 and 90. With `-1` a real Hopper `sm_90a` target failed every one of those checks, so it was treated as pre-sm_70 and quietly lost its arch-specific pipeline, block-reduce and MMA dispatch. No error was raised, which is why no test caught it.

## Fix

Parse the leading digits instead of requiring an all-digit string, so `sm_90a` maps to 90 and `sm_100a` maps to 100. `-1` is kept only for genuinely non-CUDA input such as a HIP `gfx942` target, and the bare numeric form that the old code already accepted stays accepted.

`tilelang/carver/matmul_analysis.py` carried a second copy of the identical function body inside `get_tensorized_func_and_tags`, so fixing one place would have left the other wrong. It now imports the shared helper from `tilelang.carver.arch.cuda`. That module was already an import dependency of `matmul_analysis`, so no new import edge is added.

## Testing

New CPU regression test at `testing/python/carver/test_tilelang_carver_sm_version.py`. No GPU is needed, the defect and the fix are pure string parsing.

Verified fail-before and pass-after against the base ref rather than a stash:

```
git checkout upstream/main -- tilelang/carver/arch/cuda.py tilelang/carver/matmul_analysis.py
python -m pytest testing/python/carver/test_tilelang_carver_sm_version.py -q
# 3 failed, 2 passed
#   test_check_sm_version_lettered_arch
#   test_lettered_arch_keeps_capability_dispatch
#   test_matmul_analysis_shares_one_parser
```

With the fix applied, the same file reports 5 passed, and `testing/python/carver/test_tilelang_carver_hint.py` still passes alongside it.

The test covers four things: the numeric arches that already worked, the lettered arches that did not, the non-CUDA strings that must stay at `-1`, and the downstream consequence, that a `sm_90a` arch now satisfies `is_hopper_arch` and `has_mma_support` and none of the older-arch predicates. The last test pins the deduplication so a future re-copy of the parser fails.

Formatting checked with the pinned `ruff==0.14.14` from `requirements-lint.txt`: `ruff format --check` reports already formatted and `ruff check` passes on all three files.

Fixes #2852


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated `check_sm_version` to parse numeric and lettered CUDA architectures, including `sm_90a`, `sm_100a`, and `sm_103a`.
- Anchored the optional `sm_` prefix to reject malformed inputs such as `sm_sm_90`.
- Preserved `-1` for non-CUDA and unparseable inputs.
- Removed the duplicate parser in `matmul_analysis.py`.
- Added CPU-only regression tests for parsing, capability dispatch, invalid inputs, and parser deduplication.
- Formatting and lint checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->