### PR TITLE
[Feature] Warp specialization schedules and materialization

### DIFF
--- a/examples/aws/flash_attention.py
+++ b/examples/aws/flash_attention.py
@@ -1,0 +1,769 @@
+import argparse
+
+import torch
+import torch.nn.functional as F
+import tilelang
+import tilelang.language as T
+from tilelang.carver.arch import driver
+from tilelang.profiler import do_bench
+
+
+PASS_CFG = {
+    tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+}
+
+
+@T.macro
+def get_num_waves(block_id, num_blocks, sm_num):
+    return T.ceildiv(num_blocks - block_id, sm_num)
+
+
+# The FA4 static persistent scheduler's tile order: the q block index is the
+# minor dimension, then head, then batch (flash_attn/cute/tile_scheduler.py,
+# StaticPersistentTileScheduler.get_current_work).
+@T.macro
+def get_attn_tile(block_id, wave_id, sm_num, q_blocks, heads):
+    tile_id = block_id + wave_id * sm_num
+    bx = tile_id % q_blocks
+    hn = tile_id // q_blocks
+    by = hn % heads
+    bz = hn // heads
+    return bx, by, bz
+
+
+@tilelang.jit(pass_configs=PASS_CFG)
+def flash_attention(
+    Q,
+    K,
+    V,
+    block_M,
+    block_N,
+    store_block_N,
+    dim,
+    dtype,
+    accum_dtype,
+    num_stages,
+    num_persistent_stages,
+):
+    batch, seq_len, heads = T.const("batch, seq_len, heads")
+
+    Q: T.Tensor((batch, seq_len, heads, dim), dtype)
+    K: T.Tensor((batch, seq_len, heads, dim), dtype)
+    V: T.Tensor((batch, seq_len, heads, dim), dtype)
+    Output = T.empty((batch, seq_len, heads, dim), dtype)
+
+    q_blocks = T.ceildiv(seq_len, block_M)
+    loop_range = T.ceildiv(seq_len, block_N)
+    num_blocks = q_blocks * heads * batch
+    sm_num = driver.get_num_sms()
+    scale = (1.0 / dim) ** 0.5 * 1.44269504
+    assert dim == 128
+    assert block_M == 128
+    assert block_N == 128
+    assert seq_len % block_M == 0
+    assert seq_len % block_N == 0
+    assert dim % store_block_N == 0
+
+    with T.Kernel(sm_num, threads=128) as block_id:
+        Q_shared = T.alloc_shared((block_M, dim), dtype)
+        K_shared = T.alloc_shared((block_N, dim), dtype)
+        V_shared = T.alloc_shared((block_N, dim), dtype)
+        O_shared = T.alloc_shared((block_M, dim), dtype)
+        scale_shared = T.alloc_shared((block_M,), accum_dtype)
+        logsum_shared = T.alloc_shared((block_M,), accum_dtype)
+
+        S_tmem = T.alloc_tmem((block_M, block_N), accum_dtype)
+        P_tmem = T.alloc_tmem((block_M, block_N), dtype)
+        O_tmem = T.alloc_tmem((block_M, dim), accum_dtype)
+
+        tid = T.get_thread_binding()
+
+        S_reg = T.alloc_fragment((block_M, block_N), accum_dtype)
+        P_cast = T.alloc_fragment((block_M, block_N), dtype)
+        scores_max = T.alloc_fragment((block_M,), accum_dtype)
+        scores_max_prev = T.alloc_fragment((block_M,), accum_dtype)
+        scores_rescale = T.alloc_fragment((block_M,), accum_dtype)
+        scores_sum = T.alloc_fragment((block_M,), accum_dtype)
+        logsum = T.alloc_fragment((block_M,), accum_dtype)
+        O_local = T.alloc_fragment((block_M, store_block_N), accum_dtype)
+        inv_sum = T.alloc_fragment((block_M,), accum_dtype)
+
+        # The schedulable task is the tile op; instructions reference the
+        # stable ids attached in the kernel body (a T.WSID entry in the
+        # annotations= of tile ops and loops — every statement of a
+        # scope carries its own id). The pass derives read/write sets
+        # itself; the schedule carries no metadata.
+        #
+        # Four roles (an FA4-style split, minus 2-CTA):
+        #  - Softmax owns the S -> P transform and the running statistics.
+        #    It hands the per-row rescale factor to Correction through the
+        #    "scale" pipeline immediately after row-max, and publishes P
+        #    before the row-sum, so neither O correction nor the reduction
+        #    sits on the tensor-core critical path.
+        #  - Correction owns the O accumulator: the per-iteration rescale
+        #    (skipped entirely on the stale-max fast path) and the final
+        #    normalize + store, in store_block_N-column TMEM slices.
+        #  - TMA feeds Q/K/V; MMA issues both GEMMs.
+        #
+        # The kernel is persistent, following FA4's static persistent
+        # scheduler: one CTA per SM, each looping over its q tiles (block
+        # minor, then head, then batch). The q pipeline has
+        # num_persistent_stages versions so the next wave's Q load overlaps
+        # the current wave.
+        #
+        # Sync stages express intra-role software pipelining: acquire/commit
+        # (and wait/release) of a pipeline pair up at one stage, and the
+        # instructions between them run at that stage's iteration offset.
+        # MMA's PV-side spans sit at stage 1, one iteration behind its QK
+        # span: the materialized MMA loop runs an extra iteration and issues
+        # QK(i) before PV(i-1), so the tensor core computes S(i) while
+        # Softmax is still turning S(i-1) into P(i-1).
+        #
+        # The acc pipeline cycles loop_range + 1 times per wave on both
+        # sides: Correction's per-iteration rescales plus its final
+        # normalize, matched by MMA's PV consumes plus one wave-level
+        # consume pairing the normalize commit. Without the extra consume
+        # the full/empty parity would diverge from the second wave on. Both
+        # roles touch acc at two loop depths, so the pass tracks their acc
+        # phases with runtime counters.
+        T.annotate_ws_schedule(
+            T.WSSchedule(
+                num_warps=12,
+                roles=[
+                    T.WSRole("Softmax", warps_lo=0, warps_hi=4, max_nreg=224),
+                    T.WSRole("Correction", warps_lo=4, warps_hi=8, max_nreg=80),
+                    T.WSRole("TMA", warps_lo=8, warps_hi=9, max_nreg=40),
+                    T.WSRole("MMA", warps_lo=9, warps_hi=10, max_nreg=40),
+                    # Warps 10-11 are unassigned register donors.
+                ],
+                pipelines=[
+                    T.WSPipeline("q", [Q_shared], depth=num_persistent_stages),
+                    T.WSPipeline("k", [K_shared], depth=num_stages),
+                    T.WSPipeline("v", [V_shared], depth=num_stages),
+                    T.WSPipeline("score", [S_tmem], depth=1),
+                    T.WSPipeline("prob", [P_tmem], depth=1),
+                    T.WSPipeline("acc", [O_tmem], depth=1),
+                    # Softmax -> Correction rescale handoff.
+                    T.WSPipeline("scale", [scale_shared], depth=num_stages),
+                    # Softmax -> Correction logsum handoff for the epilogue.
+                    T.WSPipeline("stats", [logsum_shared], depth=1),
+                ],
+                scopes=[
+                    T.WSScope(
+                        "loop_kv",
+                        {
+                            "TMA": [
+                                T.WSSync.producer_acquire("k"),
+                                "copy_K_g2s",
+                                T.WSSync.producer_commit("k"),
+                                T.WSSync.producer_acquire("v"),
+                                "copy_V_g2s",
+                                T.WSSync.producer_commit("v"),
+                            ],
+                            "MMA": [
+                                T.WSSync.consumer_wait("k", stage=0),
+                                T.WSSync.producer_acquire("score", stage=0),
+                                "gemm_QK",
+                                T.WSSync.producer_commit("score", stage=0),
+                                T.WSSync.consumer_release("k", stage=0),
+                                # The PV spans run at stage 1: this loop
+                                # iteration issues PV of the PREVIOUS kv
+                                # step, after QK of the current one.
+                                T.WSSync.consumer_wait("prob", stage=1),
+                                T.WSSync.consumer_wait("v", stage=1),
+                                T.WSSync.consumer_wait("acc", stage=1),
+                                "gemm_PV",
+                                T.WSSync.consumer_release("prob", stage=1),
+                                T.WSSync.consumer_release("v", stage=1),
+                                T.WSSync.consumer_release("acc", stage=1),
+                            ],
+                            "Softmax": [
+                                T.WSSync.consumer_wait("score"),
+                                "copy_S_t2r",
+                                T.WSSync.consumer_release("score"),
+                                "copy_max_prev",
+                                "reduce_max",
+                                "stale_max",
+                                # Publish the rescale right after row-max so
+                                # Correction overlaps with exp below.
+                                T.WSSync.producer_acquire("scale"),
+                                "copy_scale_s",
+                                T.WSSync.producer_commit("scale"),
+                                "exp_scale",
+                                "softmax_exp",
+                                # Publish P before row-sum: the reduction is
+                                # not a PV dependency.
+                                T.WSSync.producer_acquire("prob"),
+                                "copy_P_cast",
+                                "copy_P_r2t",
+                                T.WSSync.producer_commit("prob"),
+                                "reduce_sum",
+                                "update_logsum",
+                            ],
+                            "Correction": [
+                                T.WSSync.consumer_wait("scale"),
+                                "rescale_vote",
+                                # Correction produces the rescaled O that
+                                # MMA's PV then accumulates onto.
+                                T.WSSync.producer_acquire("acc"),
+                                "rescale_O",
+                                T.WSSync.producer_commit("acc"),
+                                T.WSSync.consumer_release("scale"),
+                            ],
+                        },
+                    ),
+                    # The persistent loop over this CTA's q tiles.
+                    T.WSScope(
+                        "loop_wave_id",
+                        {
+                            "TMA": [
+                                T.WSSync.producer_acquire("q"),
+                                "copy_Q_g2s",
+                                T.WSSync.producer_commit("q"),
+                                "loop_kv",
+                            ],
+                            "MMA": [
+                                T.WSSync.consumer_wait("q"),
+                                "loop_kv",
+                                T.WSSync.consumer_release("q"),
+                                # Consume the version produced by
+                                # Correction's normalize commit, keeping
+                                # acc's per-wave cycle counts equal.
+                                T.WSSync.consumer_wait("acc"),
+                                T.WSSync.consumer_release("acc"),
+                            ],
+                            "Softmax": [
+                                "init_max",
+                                "init_logsum",
+                                "loop_kv",
+                                T.WSSync.producer_acquire("stats"),
+                                "copy_logsum_s",
+                                T.WSSync.producer_commit("stats"),
+                            ],
+                            "Correction": [
+                                "loop_kv",
+                                T.WSSync.consumer_wait("stats"),
+                                "copy_inv_sum",
+                                "recip_sum",
+                                T.WSSync.producer_acquire("acc"),
+                                "normalize_O",
+                                T.WSSync.producer_commit("acc"),
+                                T.WSSync.consumer_release("stats"),
+                                "copy_O_s2g",
+                            ],
+                        },
+                    ),
+                    T.WSScope(
+                        T.WSScope.ROOT,
+                        {
+                            "TMA": ["loop_wave_id"],
+                            "MMA": ["loop_wave_id"],
+                            "Softmax": ["loop_wave_id"],
+                            "Correction": ["loop_wave_id"],
+                        },
+                    ),
+                ],
+            )
+        )
+
+        num_waves = get_num_waves(block_id, num_blocks, sm_num)
+
+        for wave_id in T.Pipelined(
+            num_waves,
+            num_stages=num_persistent_stages,
+            annotations={T.WSID: "loop_wave_id"},
+        ):
+            bx, by, bz = get_attn_tile(block_id, wave_id, sm_num, q_blocks, heads)
+
+            T.copy(
+                Q[bz, bx * block_M : (bx + 1) * block_M, by, :],
+                Q_shared,
+                annotations={T.WSID: "copy_Q_g2s"},
+            )
+            T.fill(scores_max, -T.infinity(accum_dtype), annotations={T.WSID: "init_max"})
+            T.fill(logsum, 0, annotations={T.WSID: "init_logsum"})
+
+            for k in T.Pipelined(loop_range, num_stages=1, annotations={T.WSID: "loop_kv"}):
+                T.copy(
+                    K[bz, k * block_N : (k + 1) * block_N, by, :],
+                    K_shared,
+                    annotations={T.WSID: "copy_K_g2s"},
+                )
+                T.copy(
+                    V[bz, k * block_N : (k + 1) * block_N, by, :],
+                    V_shared,
+                    annotations={T.WSID: "copy_V_g2s"},
+                )
+
+                T.gemm(
+                    Q_shared,
+                    K_shared,
+                    S_tmem,
+                    transpose_B=True,
+                    clear_accum=True,
+                    annotations={T.WSID: "gemm_QK"},
+                )
+
+                T.copy(S_tmem, S_reg, annotations={T.WSID: "copy_S_t2r"})
+                T.copy(scores_max, scores_max_prev, annotations={T.WSID: "copy_max_prev"})
+                T.reduce_max(S_reg, scores_max, dim=1, clear=False, annotations={T.WSID: "reduce_max"})
+                for i in T.Parallel(block_M, annotations={T.WSID: "stale_max"}):
+                    # Stale-max fast path: when the max moves by less
+                    # than 8 exponent steps, keep the previous max so
+                    # the rescale factor is exactly 1 and Correction can
+                    # skip the whole O read-modify-write.
+                    scores_rescale[i] = T.if_then_else(
+                        (scores_max_prev[i] - scores_max[i]) * scale >= -8.0,
+                        1.0,
+                        T.exp2(scores_max_prev[i] * scale - scores_max[i] * scale),
+                    )
+                    scores_max[i] = T.if_then_else(
+                        (scores_max_prev[i] - scores_max[i]) * scale >= -8.0,
+                        scores_max_prev[i],
+                        scores_max[i],
+                    )
+
+                T.copy(scores_rescale, scale_shared, annotations={T.WSID: "copy_scale_s"})
+
+                # Warp-local vote: each warp owns 32 rows of O, so it
+                # can skip its own read-modify-write when all its
+                # rescale factors are 1. At k == 0 the factor is 0 and
+                # O_tmem is garbage, but PV(0) clears the accumulator
+                # anyway. The vote binds a scalar consumed only by the
+                # rescale guard; it guards the op body alone — the
+                # schedule's acc/scale sync entries stay unconditional.
+                with T.ws_op("rescale_vote"):
+                    should_rescale = T.any_sync(scale_shared[tid % block_M] < 1.0)
+                if should_rescale != 0:
+                    for s in T.unroll(T.ceildiv(dim, store_block_N), annotations={T.WSID: "rescale_O"}):
+                        T.copy(
+                            O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
+                            O_local,
+                        )
+                        for i, j in T.Parallel(block_M, store_block_N):
+                            O_local[i, j] *= scale_shared[i]
+                        T.copy(
+                            O_local,
+                            O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
+                        )
+
+                # Affine first (packed f32x2 FMA), exp2 separately.
+                for i in T.Parallel(block_M, annotations={T.WSID: "exp_scale"}):
+                    for j in T.vectorized(block_N):
+                        S_reg[i, j] = S_reg[i, j] * scale + (-scores_max[i] * scale)
+                for i, j in T.Parallel(block_M, block_N, annotations={T.WSID: "softmax_exp"}):
+                    S_reg[i, j] = T.exp2(S_reg[i, j])
+
+                T.copy(S_reg, P_cast, annotations={T.WSID: "copy_P_cast"})
+                T.copy(P_cast, P_tmem, annotations={T.WSID: "copy_P_r2t"})
+
+                T.reduce_sum(S_reg, scores_sum, dim=1, annotations={T.WSID: "reduce_sum"})
+                for i in T.Parallel(block_M, annotations={T.WSID: "update_logsum"}):
+                    logsum[i] = logsum[i] * scores_rescale[i] + scores_sum[i]
+
+                T.gemm(
+                    P_tmem,
+                    V_shared,
+                    O_tmem,
+                    clear_accum=k == 0,
+                    annotations={T.WSID: "gemm_PV"},
+                )
+
+            T.copy(logsum, logsum_shared, annotations={T.WSID: "copy_logsum_s"})
+            T.copy(logsum_shared, inv_sum, annotations={T.WSID: "copy_inv_sum"})
+            # One reciprocal per row, reused across all output slices.
+            for i in T.Parallel(block_M, annotations={T.WSID: "recip_sum"}):
+                inv_sum[i] = 1.0 / inv_sum[i]
+            for s in T.unroll(T.ceildiv(dim, store_block_N), annotations={T.WSID: "normalize_O"}):
+                T.copy(
+                    O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
+                    O_local,
+                )
+                for i, j in T.Parallel(block_M, store_block_N):
+                    O_local[i, j] *= inv_sum[i]
+                T.copy(
+                    O_local,
+                    O_shared[:, s * store_block_N : (s + 1) * store_block_N],
+                )
+            T.copy(
+                O_shared,
+                Output[bz, bx * block_M : (bx + 1) * block_M, by, :],
+                annotations={T.WSID: "copy_O_s2g"},
+            )
+
+    return Output
+
+
+@tilelang.jit(pass_configs=PASS_CFG)
+def flash_attention_ws(
+    Q,
+    K,
+    V,
+    block_M,
+    block_N,
+    store_block_N,
+    dim,
+    dtype,
+    accum_dtype,
+    num_stages,
+    num_persistent_stages,
+):
+    batch, seq_len, heads = T.const("batch, seq_len, heads")
+
+    Q: T.Tensor((batch, seq_len, heads, dim), dtype)
+    K: T.Tensor((batch, seq_len, heads, dim), dtype)
+    V: T.Tensor((batch, seq_len, heads, dim), dtype)
+    Output = T.empty((batch, seq_len, heads, dim), dtype)
+
+    q_blocks = T.ceildiv(seq_len, block_M)
+    loop_range = T.ceildiv(seq_len, block_N)
+    num_blocks = q_blocks * heads * batch
+    sm_num = driver.get_num_sms()
+    scale = (1.0 / dim) ** 0.5 * 1.44269504
+    assert dim == 128
+    assert block_M == 128
+    assert block_N == 128
+    assert seq_len % block_M == 0
+    assert seq_len % block_N == 0
+    assert dim % store_block_N == 0
+
+    with T.Kernel(sm_num, threads=384) as block_id:
+        Q_shared = T.alloc_shared((num_persistent_stages, block_M, dim), dtype)
+        K_shared = T.alloc_shared((num_stages, block_N, dim), dtype)
+        V_shared = T.alloc_shared((num_stages, block_N, dim), dtype)
+        O_shared = T.alloc_shared((block_M, dim), dtype)
+        scale_shared = T.alloc_shared((num_stages, block_M), accum_dtype)
+        logsum_shared = T.alloc_shared((block_M,), accum_dtype)
+
+        S_tmem = T.alloc_tmem((block_M, block_N), accum_dtype)
+        P_tmem = T.alloc_tmem((block_M, block_N), dtype)
+        O_tmem = T.alloc_tmem((block_M, dim), accum_dtype)
+
+        q_full = T.alloc_barrier([32] * num_persistent_stages)
+        q_empty = T.alloc_barrier([1] * num_persistent_stages)
+        k_full = T.alloc_barrier([32] * num_stages)
+        k_empty = T.alloc_barrier([1] * num_stages)
+        v_full = T.alloc_barrier([32] * num_stages)
+        v_empty = T.alloc_barrier([1] * num_stages)
+        s_full = T.alloc_barrier([1])
+        s_empty = T.alloc_barrier([128])
+        prob_full = T.alloc_barrier([128])
+        prob_empty = T.alloc_barrier([1])
+        acc_full = T.alloc_barrier([128])
+        acc_empty = T.alloc_barrier([1])
+        scale_full = T.alloc_barrier([128] * num_stages)
+        scale_empty = T.alloc_barrier([128] * num_stages)
+        stats_full = T.alloc_barrier([128])
+        stats_empty = T.alloc_barrier([128])
+
+        tid = T.get_thread_binding()
+
+        S_reg = T.alloc_fragment((block_M, block_N), accum_dtype)
+        P_cast = T.alloc_fragment((block_M, block_N), dtype)
+        scores_max = T.alloc_fragment((block_M,), accum_dtype)
+        scores_max_prev = T.alloc_fragment((block_M,), accum_dtype)
+        scores_rescale = T.alloc_fragment((block_M,), accum_dtype)
+        scores_sum = T.alloc_fragment((block_M,), accum_dtype)
+        logsum = T.alloc_fragment((block_M,), accum_dtype)
+        O_local = T.alloc_fragment((block_M, store_block_N), accum_dtype)
+        inv_sum = T.alloc_fragment((block_M,), accum_dtype)
+
+        if tid < 128:  # warps 0-3: online softmax
+            T.set_max_nreg(224, 1)
+            num_waves = get_num_waves(block_id, num_blocks, sm_num)
+            for wave_id in T.serial(num_waves):
+                T.fill(scores_max, -T.infinity(accum_dtype))
+                T.fill(logsum, 0)
+
+                for k in T.serial(loop_range):
+                    g = wave_id * loop_range + k
+
+                    T.mbarrier_wait_parity(s_full[0], g & 1)
+                    T.copy(S_tmem, S_reg)
+                    T.mbarrier_arrive(s_empty[0])
+
+                    T.copy(scores_max, scores_max_prev)
+                    T.reduce_max(S_reg, scores_max, dim=1, clear=False)
+                    for i in T.Parallel(block_M):
+                        # Stale-max fast path: keep the previous max when it
+                        # moves by less than 8 exponent steps, so the
+                        # rescale factor is exactly 1.
+                        scores_rescale[i] = T.if_then_else(
+                            (scores_max_prev[i] - scores_max[i]) * scale >= -8.0,
+                            1.0,
+                            T.exp2(scores_max_prev[i] * scale - scores_max[i] * scale),
+                        )
+                        scores_max[i] = T.if_then_else(
+                            (scores_max_prev[i] - scores_max[i]) * scale >= -8.0,
+                            scores_max_prev[i],
+                            scores_max[i],
+                        )
+
+                    # Publish the rescale immediately after row-max so the
+                    # correction warps overlap with exp / P production.
+                    T.mbarrier_wait_parity(scale_empty[g % num_stages], ((g // num_stages) & 1) ^ 1)
+                    T.copy(scores_rescale, scale_shared[g % num_stages, :])
+                    T.mbarrier_arrive(scale_full[g % num_stages])
+
+                    # Affine first (packed f32x2 FMA), exp2 separately.
+                    for i in T.Parallel(block_M):
+                        for j in T.vectorized(block_N):
+                            S_reg[i, j] = S_reg[i, j] * scale + (-scores_max[i] * scale)
+                    for i, j in T.Parallel(block_M, block_N):
+                        S_reg[i, j] = T.exp2(S_reg[i, j])
+
+                    # Publish P before row-sum: the reduction is not a PV
+                    # dependency.
+                    T.mbarrier_wait_parity(prob_empty[0], (g & 1) ^ 1)
+                    T.copy(S_reg, P_cast)
+                    T.copy(P_cast, P_tmem)
+                    T.mbarrier_arrive(prob_full[0])
+
+                    T.reduce_sum(S_reg, scores_sum, dim=1)
+                    for i in T.Parallel(block_M):
+                        logsum[i] = logsum[i] * scores_rescale[i] + scores_sum[i]
+
+                T.mbarrier_wait_parity(stats_empty[0], (wave_id & 1) ^ 1)
+                T.copy(logsum, logsum_shared)
+                T.mbarrier_arrive(stats_full[0])
+
+        elif tid < 256:  # warps 4-7: O correction + epilogue
+            T.set_max_nreg(80, 0)
+            num_waves = get_num_waves(block_id, num_blocks, sm_num)
+            for wave_id in T.serial(num_waves):
+                bx, by, bz = get_attn_tile(block_id, wave_id, sm_num, q_blocks, heads)
+
+                for k in T.serial(loop_range):
+                    g = wave_id * loop_range + k
+                    # acc cycles loop_range + 1 times per wave (the final
+                    # normalize is one more producer cycle).
+                    c = wave_id * (loop_range + 1) + k
+
+                    T.mbarrier_wait_parity(scale_full[g % num_stages], (g // num_stages) & 1)
+                    T.mbarrier_wait_parity(acc_empty[0], (c & 1) ^ 1)
+                    # Common case: every rescale factor is exactly 1
+                    # (stale-max fast path), and each warp can skip the O
+                    # read-modify-write for its own rows. At k == 0 the
+                    # factor is 0 and O_tmem is garbage, but PV(0) clears
+                    # the accumulator anyway.
+                    should_rescale = T.any_sync(scale_shared[g % num_stages, tid % block_M] < 1.0)
+                    if should_rescale != 0:
+                        for s in T.unroll(T.ceildiv(dim, store_block_N)):
+                            T.copy(
+                                O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
+                                O_local,
+                            )
+                            for i, j in T.Parallel(block_M, store_block_N):
+                                O_local[i, j] *= scale_shared[g % num_stages, i]
+                            T.copy(
+                                O_local,
+                                O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
+                            )
+                    T.mbarrier_arrive(scale_empty[g % num_stages])
+                    T.mbarrier_arrive(acc_full[0])
+
+                c_last = wave_id * (loop_range + 1) + loop_range
+                T.mbarrier_wait_parity(stats_full[0], wave_id & 1)
+                T.mbarrier_wait_parity(acc_empty[0], (c_last & 1) ^ 1)
+                T.copy(logsum_shared, inv_sum)
+                # One reciprocal per row, reused across all output slices.
+                for i in T.Parallel(block_M):
+                    inv_sum[i] = 1.0 / inv_sum[i]
+                for s in T.unroll(T.ceildiv(dim, store_block_N)):
+                    T.copy(
+                        O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
+                        O_local,
+                    )
+                    for i, j in T.Parallel(block_M, store_block_N):
+                        O_local[i, j] *= inv_sum[i]
+                    T.copy(
+                        O_local,
+                        O_shared[:, s * store_block_N : (s + 1) * store_block_N],
+                    )
+                T.mbarrier_arrive(stats_empty[0])
+                T.mbarrier_arrive(acc_full[0])
+                T.copy(O_shared, Output[bz, bx * block_M : (bx + 1) * block_M, by, :])
+
+        elif tid < 288:  # warp 8: TMA
+            T.set_max_nreg(40, 0)
+            num_waves = get_num_waves(block_id, num_blocks, sm_num)
+            for wave_id in T.serial(num_waves):
+                bx, by, bz = get_attn_tile(block_id, wave_id, sm_num, q_blocks, heads)
+
+                q_stage = wave_id % num_persistent_stages
+                T.mbarrier_wait_parity(q_empty[q_stage], ((wave_id // num_persistent_stages) & 1) ^ 1)
+                T.tma_copy(
+                    Q[bz, bx * block_M : (bx + 1) * block_M, by, :],
+                    Q_shared[q_stage, :, :],
+                    barrier=q_full[q_stage],
+                )
+                T.mbarrier_arrive(q_full[q_stage])
+
+                for k in T.serial(loop_range):
+                    g = wave_id * loop_range + k
+                    stage = g % num_stages
+                    parity_inv = ((g // num_stages) & 1) ^ 1
+                    T.mbarrier_wait_parity(k_empty[stage], parity_inv)
+                    T.tma_copy(
+                        K[bz, k * block_N : (k + 1) * block_N, by, :],
+                        K_shared[stage, :, :],
+                        barrier=k_full[stage],
+                    )
+                    T.mbarrier_arrive(k_full[stage])
+                    T.mbarrier_wait_parity(v_empty[stage], parity_inv)
+                    T.tma_copy(
+                        V[bz, k * block_N : (k + 1) * block_N, by, :],
+                        V_shared[stage, :, :],
+                        barrier=v_full[stage],
+                    )
+                    T.mbarrier_arrive(v_full[stage])
+
+        elif tid < 320:  # warp 9: tensor-core issue
+            T.set_max_nreg(40, 0)
+            num_waves = get_num_waves(block_id, num_blocks, sm_num)
+            for wave_id in T.serial(num_waves):
+                q_stage = wave_id % num_persistent_stages
+                T.mbarrier_wait_parity(q_full[q_stage], (wave_id // num_persistent_stages) & 1)
+                # PV runs one software-pipeline stage behind QK: QK(i) is
+                # issued before PV(i-1), so the tensor core computes S(i)
+                # while softmax is still turning S(i-1) into P(i-1).
+                for i in T.serial(loop_range + 1):
+                    if i < loop_range:
+                        g = wave_id * loop_range + i
+                        T.mbarrier_wait_parity(k_full[g % num_stages], (g // num_stages) & 1)
+                        T.mbarrier_wait_parity(s_empty[0], (g & 1) ^ 1)
+                        T.tcgen05_gemm(
+                            Q_shared[q_stage, :, :],
+                            K_shared[g % num_stages, :, :],
+                            S_tmem,
+                            transpose_B=True,
+                            mbar=None,
+                            clear_accum=True,
+                        )
+                        T.tcgen05_mma_arrive(s_full[0])
+                        T.tcgen05_mma_arrive(k_empty[g % num_stages])
+                    if i >= 1:
+                        gp = wave_id * loop_range + i - 1
+                        cp = wave_id * (loop_range + 1) + i - 1
+                        T.mbarrier_wait_parity(prob_full[0], gp & 1)
+                        T.mbarrier_wait_parity(v_full[gp % num_stages], (gp // num_stages) & 1)
+                        T.mbarrier_wait_parity(acc_full[0], cp & 1)
+                        T.tcgen05_gemm(
+                            P_tmem,
+                            V_shared[gp % num_stages, :, :],
+                            O_tmem,
+                            mbar=None,
+                            clear_accum=(i - 1) == 0,
+                        )
+                        T.tcgen05_mma_arrive(prob_empty[0])
+                        T.tcgen05_mma_arrive(v_empty[gp % num_stages])
+                        T.tcgen05_mma_arrive(acc_empty[0])
+                T.tcgen05_mma_arrive(q_empty[q_stage])
+                # Consume the version produced by the normalize commit,
+                # keeping acc's per-wave cycle counts equal on both sides.
+                c_last = wave_id * (loop_range + 1) + loop_range
+                T.mbarrier_wait_parity(acc_full[0], c_last & 1)
+                T.tcgen05_mma_arrive(acc_empty[0])
+
+        else:  # warps 10-11: idle register donors
+            T.set_max_nreg(40, 0)
+
+    return Output
+
+
+KERNELS = {
+    "flash_attention": flash_attention,
+    "flash_attention_ws": flash_attention_ws,
+}
+
+
+def reference_attention(q, k, v):
+    q_cpu = q.cpu().float()
+    k_cpu = k.cpu().float()
+    v_cpu = v.cpu().float()
+    scores = torch.einsum("bqhd,bkhd->bhqk", q_cpu, k_cpu)
+    scores /= q.shape[-1] ** 0.5
+    probabilities = torch.softmax(scores, dim=-1)
+    return torch.einsum("bhqk,bkhd->bqhd", probabilities, v_cpu).to(torch.bfloat16)
+
+
+def main(
+    kernel="flash_attention",
+    batch=1,
+    heads=16,
+    seq_len=16384,
+    dim=128,
+    block_M=128,
+    block_N=128,
+    store_block_N=16,
+    num_stages=2,
+    num_persistent_stages=2,
+):
+    if dim != 128:
+        raise ValueError("this example requires head dimension 128")
+
+    dtype, accum_dtype = T.bfloat16, T.float32
+    kernel_fn = KERNELS[kernel]
+    kwargs = {
+        "block_M": block_M,
+        "block_N": block_N,
+        "store_block_N": store_block_N,
+        "dim": dim,
+        "dtype": dtype,
+        "accum_dtype": accum_dtype,
+        "num_stages": num_stages,
+        "num_persistent_stages": num_persistent_stages,
+    }
+
+    shape = (batch, seq_len, heads, dim)
+    q = torch.randn(shape, device="cuda", dtype=torch.bfloat16)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    output = kernel_fn(q, k, v, **kwargs)
+
+    expected = reference_attention(q, k, v).to(output.device)
+    torch.testing.assert_close(output, expected, rtol=1e-2, atol=1e-2)
+    print("All checks passed. ✅")
+
+    tl_latency = do_bench(lambda: kernel_fn(q, k, v, **kwargs), backend="cupti")
+    q4 = q.permute(0, 2, 1, 3)
+    k4 = k.permute(0, 2, 1, 3)
+    v4 = v.permute(0, 2, 1, 3)
+    torch_latency = do_bench(lambda: F.scaled_dot_product_attention(q4, k4, v4), backend="cupti")
+    total_flops = 4 * batch * heads * seq_len * seq_len * dim
+    print(f"Tilelang latency: {tl_latency} ms")
+    print(f"Flops: {total_flops / (tl_latency / 1e3) / 1e12} TFLOPS")
+    print(f"Torch latency: {torch_latency} ms")
+    print(f"Flops: {total_flops / (torch_latency / 1e3) / 1e12} TFLOPS")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--kernel", choices=sorted(KERNELS), default="flash_attention")
+    p.add_argument("--batch", type=int, default=1)
+    p.add_argument("--heads", type=int, default=16)
+    p.add_argument("--seq_len", type=int, default=16384)
+    p.add_argument("--dim", type=int, default=128)
+    p.add_argument("--block_m", type=int, default=128)
+    p.add_argument("--block_n", type=int, default=128)
+    p.add_argument(
+        "--store_block_n",
+        type=int,
+        default=16,
+        help="epilogue store slice width",
+    )
+    p.add_argument("--num_stages", type=int, default=2)
+    p.add_argument("--num_persistent_stages", type=int, default=2)
+    args = p.parse_args()
+    main(
+        kernel=args.kernel,
+        batch=args.batch,
+        heads=args.heads,
+        seq_len=args.seq_len,
+        dim=args.dim,
+        block_M=args.block_m,
+        block_N=args.block_n,
+        store_block_N=args.store_block_n,
+        num_stages=args.num_stages,
+        num_persistent_stages=args.num_persistent_stages,
+    )

--- a/examples/aws/flash_attention.py
+++ b/examples/aws/flash_attention.py
@@ -13,24 +13,6 @@ PASS_CFG = {
 }
 
 
-@T.macro
-def get_num_waves(block_id, num_blocks, sm_num):
-    return T.ceildiv(num_blocks - block_id, sm_num)
-
-
-# The FA4 static persistent scheduler's tile order: the q block index is the
-# minor dimension, then head, then batch (flash_attn/cute/tile_scheduler.py,
-# StaticPersistentTileScheduler.get_current_work).
-@T.macro
-def get_attn_tile(block_id, wave_id, sm_num, q_blocks, heads):
-    tile_id = block_id + wave_id * sm_num
-    bx = tile_id % q_blocks
-    hn = tile_id // q_blocks
-    by = hn % heads
-    bz = hn // heads
-    return bx, by, bz
-
-
 @tilelang.jit(pass_configs=PASS_CFG)
 def flash_attention(
     Q,
@@ -54,7 +36,6 @@ def flash_attention(
 
     q_blocks = T.ceildiv(seq_len, block_M)
     loop_range = T.ceildiv(seq_len, block_N)
-    num_blocks = q_blocks * heads * batch
     sm_num = driver.get_num_sms()
     scale = (1.0 / dim) ** 0.5 * 1.44269504
     assert dim == 128
@@ -88,44 +69,30 @@ def flash_attention(
         O_local = T.alloc_fragment((block_M, store_block_N), accum_dtype)
         inv_sum = T.alloc_fragment((block_M,), accum_dtype)
 
-        # The schedulable task is the tile op; instructions reference the
-        # stable ids attached in the kernel body (a T.WSID entry in the
-        # annotations= of tile ops and loops — every statement of a
-        # scope carries its own id). The pass derives read/write sets
-        # itself; the schedule carries no metadata.
-        #
+        # The persistent tile scheduler, in FA4's static tile order: the q
+        # block index is the minor dimension, then head, then batch
+        # (m = q block, n = head-batch). State is per thread; every role
+        # runs its own copy of the init / advance ops.
+        sched = T.PersistentTileScheduler(q_blocks, heads * batch, name="sched")
+
         # Four roles (an FA4-style split, minus 2-CTA):
-        #  - Softmax owns the S -> P transform and the running statistics.
-        #    It hands the per-row rescale factor to Correction through the
-        #    "scale" pipeline immediately after row-max, and publishes P
-        #    before the row-sum, so neither O correction nor the reduction
-        #    sits on the tensor-core critical path.
+        #  - Softmax owns the S -> P transform and the running
+        #    statistics, handing the rescale factor to Correction right
+        #    after row-max and publishing P before the row-sum.
         #  - Correction owns the O accumulator: the per-iteration rescale
-        #    (skipped entirely on the stale-max fast path) and the final
-        #    normalize + store, in store_block_N-column TMEM slices.
+        #    (skipped on the stale-max fast path) and the final
+        #    normalize + store.
         #  - TMA feeds Q/K/V; MMA issues both GEMMs.
         #
-        # The kernel is persistent, following FA4's static persistent
-        # scheduler: one CTA per SM, each looping over its q tiles (block
-        # minor, then head, then batch). The q pipeline has
-        # num_persistent_stages versions so the next wave's Q load overlaps
-        # the current wave.
-        #
-        # Sync stages express intra-role software pipelining: acquire/commit
-        # (and wait/release) of a pipeline pair up at one stage, and the
-        # instructions between them run at that stage's iteration offset.
-        # MMA's PV-side spans sit at stage 1, one iteration behind its QK
-        # span: the materialized MMA loop runs an extra iteration and issues
-        # QK(i) before PV(i-1), so the tensor core computes S(i) while
-        # Softmax is still turning S(i-1) into P(i-1).
+        # MMA's PV spans sit at stage 1, one iteration behind QK: the
+        # tensor core computes S(i) while Softmax turns S(i-1) into
+        # P(i-1).
         #
         # The acc pipeline cycles loop_range + 1 times per wave on both
-        # sides: Correction's per-iteration rescales plus its final
-        # normalize, matched by MMA's PV consumes plus one wave-level
-        # consume pairing the normalize commit. Without the extra consume
-        # the full/empty parity would diverge from the second wave on. Both
-        # roles touch acc at two loop depths, so the pass tracks their acc
-        # phases with runtime counters.
+        # sides (Correction's rescales + normalize vs MMA's PV consumes
+        # + one wave-level consume), keeping the parity aligned. Both
+        # roles touch acc at two loop depths, so their acc phases use
+        # runtime counters.
         T.annotate_ws_schedule(
             T.WSSchedule(
                 num_warps=12,
@@ -166,9 +133,8 @@ def flash_attention(
                                 "gemm_QK",
                                 T.WSSync.producer_commit("score", stage=0),
                                 T.WSSync.consumer_release("k", stage=0),
-                                # The PV spans run at stage 1: this loop
-                                # iteration issues PV of the PREVIOUS kv
-                                # step, after QK of the current one.
+                                # Stage 1: PV of the PREVIOUS kv step,
+                                # after QK of the current one.
                                 T.WSSync.consumer_wait("prob", stage=1),
                                 T.WSSync.consumer_wait("v", stage=1),
                                 T.WSSync.consumer_wait("acc", stage=1),
@@ -212,25 +178,31 @@ def flash_attention(
                             ],
                         },
                     ),
-                    # The persistent loop over this CTA's q tiles.
+                    # The persistent loop: a while scope. It has no
+                    # iteration expression, so pipelines synced under it
+                    # use runtime phase counters. tile_idx / sched_next
+                    # touch no pipeline buffers, so several roles place
+                    # them — each runs its own copy.
                     T.WSScope(
-                        "loop_wave_id",
+                        "loop_wave",
                         {
                             "TMA": [
+                                "tile_idx",
                                 T.WSSync.producer_acquire("q"),
                                 "copy_Q_g2s",
                                 T.WSSync.producer_commit("q"),
                                 "loop_kv",
+                                "sched_next",
                             ],
                             "MMA": [
                                 T.WSSync.consumer_wait("q"),
                                 "loop_kv",
                                 T.WSSync.consumer_release("q"),
-                                # Consume the version produced by
-                                # Correction's normalize commit, keeping
+                                # Pairs the normalize commit, keeping
                                 # acc's per-wave cycle counts equal.
                                 T.WSSync.consumer_wait("acc"),
                                 T.WSSync.consumer_release("acc"),
+                                "sched_next",
                             ],
                             "Softmax": [
                                 "init_max",
@@ -239,8 +211,10 @@ def flash_attention(
                                 T.WSSync.producer_acquire("stats"),
                                 "copy_logsum_s",
                                 T.WSSync.producer_commit("stats"),
+                                "sched_next",
                             ],
                             "Correction": [
+                                "tile_idx",
                                 "loop_kv",
                                 T.WSSync.consumer_wait("stats"),
                                 "copy_inv_sum",
@@ -250,146 +224,150 @@ def flash_attention(
                                 T.WSSync.producer_commit("acc"),
                                 T.WSSync.consumer_release("stats"),
                                 "copy_O_s2g",
+                                "sched_next",
                             ],
                         },
                     ),
                     T.WSScope(
                         T.WSScope.ROOT,
                         {
-                            "TMA": ["loop_wave_id"],
-                            "MMA": ["loop_wave_id"],
-                            "Softmax": ["loop_wave_id"],
-                            "Correction": ["loop_wave_id"],
+                            "TMA": ["sched_init", "loop_wave"],
+                            "MMA": ["sched_init", "loop_wave"],
+                            "Softmax": ["sched_init", "loop_wave"],
+                            "Correction": ["sched_init", "loop_wave"],
                         },
                     ),
                 ],
             )
         )
 
-        num_waves = get_num_waves(block_id, num_blocks, sm_num)
+        with T.ws_op("sched_init"):
+            sched.init(block_id)
 
-        for wave_id in T.Pipelined(
-            num_waves,
-            num_stages=num_persistent_stages,
-            annotations={T.WSID: "loop_wave_id"},
-        ):
-            bx, by, bz = get_attn_tile(block_id, wave_id, sm_num, q_blocks, heads)
+        with T.ws_op("loop_wave"):
+            while sched.valid():
+                with T.ws_op("tile_idx"):
+                    bx = sched.m_idx
+                    hn = sched.n_idx
+                    by = hn % heads
+                    bz = hn // heads
 
-            T.copy(
-                Q[bz, bx * block_M : (bx + 1) * block_M, by, :],
-                Q_shared,
-                annotations={T.WSID: "copy_Q_g2s"},
-            )
-            T.fill(scores_max, -T.infinity(accum_dtype), annotations={T.WSID: "init_max"})
-            T.fill(logsum, 0, annotations={T.WSID: "init_logsum"})
-
-            for k in T.Pipelined(loop_range, num_stages=1, annotations={T.WSID: "loop_kv"}):
                 T.copy(
-                    K[bz, k * block_N : (k + 1) * block_N, by, :],
-                    K_shared,
-                    annotations={T.WSID: "copy_K_g2s"},
-                )
-                T.copy(
-                    V[bz, k * block_N : (k + 1) * block_N, by, :],
-                    V_shared,
-                    annotations={T.WSID: "copy_V_g2s"},
-                )
-
-                T.gemm(
+                    Q[bz, bx * block_M : (bx + 1) * block_M, by, :],
                     Q_shared,
-                    K_shared,
-                    S_tmem,
-                    transpose_B=True,
-                    clear_accum=True,
-                    annotations={T.WSID: "gemm_QK"},
+                    annotations={T.WSID: "copy_Q_g2s"},
                 )
+                T.fill(scores_max, -T.infinity(accum_dtype), annotations={T.WSID: "init_max"})
+                T.fill(logsum, 0, annotations={T.WSID: "init_logsum"})
 
-                T.copy(S_tmem, S_reg, annotations={T.WSID: "copy_S_t2r"})
-                T.copy(scores_max, scores_max_prev, annotations={T.WSID: "copy_max_prev"})
-                T.reduce_max(S_reg, scores_max, dim=1, clear=False, annotations={T.WSID: "reduce_max"})
-                for i in T.Parallel(block_M, annotations={T.WSID: "stale_max"}):
-                    # Stale-max fast path: when the max moves by less
-                    # than 8 exponent steps, keep the previous max so
-                    # the rescale factor is exactly 1 and Correction can
-                    # skip the whole O read-modify-write.
-                    scores_rescale[i] = T.if_then_else(
-                        (scores_max_prev[i] - scores_max[i]) * scale >= -8.0,
-                        1.0,
-                        T.exp2(scores_max_prev[i] * scale - scores_max[i] * scale),
+                for k in T.Pipelined(loop_range, num_stages=1, annotations={T.WSID: "loop_kv"}):
+                    T.copy(
+                        K[bz, k * block_N : (k + 1) * block_N, by, :],
+                        K_shared,
+                        annotations={T.WSID: "copy_K_g2s"},
                     )
-                    scores_max[i] = T.if_then_else(
-                        (scores_max_prev[i] - scores_max[i]) * scale >= -8.0,
-                        scores_max_prev[i],
-                        scores_max[i],
+                    T.copy(
+                        V[bz, k * block_N : (k + 1) * block_N, by, :],
+                        V_shared,
+                        annotations={T.WSID: "copy_V_g2s"},
                     )
 
-                T.copy(scores_rescale, scale_shared, annotations={T.WSID: "copy_scale_s"})
+                    T.gemm(
+                        Q_shared,
+                        K_shared,
+                        S_tmem,
+                        transpose_B=True,
+                        clear_accum=True,
+                        annotations={T.WSID: "gemm_QK"},
+                    )
 
-                # Warp-local vote: each warp owns 32 rows of O, so it
-                # can skip its own read-modify-write when all its
-                # rescale factors are 1. At k == 0 the factor is 0 and
-                # O_tmem is garbage, but PV(0) clears the accumulator
-                # anyway. The vote binds a scalar consumed only by the
-                # rescale guard; it guards the op body alone — the
-                # schedule's acc/scale sync entries stay unconditional.
-                with T.ws_op("rescale_vote"):
-                    should_rescale = T.any_sync(scale_shared[tid % block_M] < 1.0)
-                if should_rescale != 0:
-                    for s in T.unroll(T.ceildiv(dim, store_block_N), annotations={T.WSID: "rescale_O"}):
-                        T.copy(
-                            O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
-                            O_local,
+                    T.copy(S_tmem, S_reg, annotations={T.WSID: "copy_S_t2r"})
+                    T.copy(scores_max, scores_max_prev, annotations={T.WSID: "copy_max_prev"})
+                    T.reduce_max(S_reg, scores_max, dim=1, clear=False, annotations={T.WSID: "reduce_max"})
+                    for i in T.Parallel(block_M, annotations={T.WSID: "stale_max"}):
+                        # Stale-max fast path: when the max moves by less
+                        # than 8 exponent steps, keep the previous max so
+                        # the rescale factor is exactly 1 and Correction can
+                        # skip the whole O read-modify-write.
+                        scores_rescale[i] = T.if_then_else(
+                            (scores_max_prev[i] - scores_max[i]) * scale >= -8.0,
+                            1.0,
+                            T.exp2(scores_max_prev[i] * scale - scores_max[i] * scale),
                         )
-                        for i, j in T.Parallel(block_M, store_block_N):
-                            O_local[i, j] *= scale_shared[i]
-                        T.copy(
-                            O_local,
-                            O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
+                        scores_max[i] = T.if_then_else(
+                            (scores_max_prev[i] - scores_max[i]) * scale >= -8.0,
+                            scores_max_prev[i],
+                            scores_max[i],
                         )
 
-                # Affine first (packed f32x2 FMA), exp2 separately.
-                for i in T.Parallel(block_M, annotations={T.WSID: "exp_scale"}):
-                    for j in T.vectorized(block_N):
-                        S_reg[i, j] = S_reg[i, j] * scale + (-scores_max[i] * scale)
-                for i, j in T.Parallel(block_M, block_N, annotations={T.WSID: "softmax_exp"}):
-                    S_reg[i, j] = T.exp2(S_reg[i, j])
+                    T.copy(scores_rescale, scale_shared, annotations={T.WSID: "copy_scale_s"})
 
-                T.copy(S_reg, P_cast, annotations={T.WSID: "copy_P_cast"})
-                T.copy(P_cast, P_tmem, annotations={T.WSID: "copy_P_r2t"})
+                    # Warp-local vote: each warp owns 32 rows of O and
+                    # skips its read-modify-write when all its rescale
+                    # factors are 1 (at k == 0 PV clears the accumulator
+                    # anyway). The guard covers the op body alone; sync
+                    # entries stay unconditional.
+                    with T.ws_op("rescale_vote"):
+                        should_rescale = T.any_sync(scale_shared[tid % block_M] < 1.0)
+                    if should_rescale != 0:
+                        for s in T.unroll(T.ceildiv(dim, store_block_N), annotations={T.WSID: "rescale_O"}):
+                            T.copy(
+                                O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
+                                O_local,
+                            )
+                            for i, j in T.Parallel(block_M, store_block_N):
+                                O_local[i, j] *= scale_shared[i]
+                            T.copy(
+                                O_local,
+                                O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
+                            )
 
-                T.reduce_sum(S_reg, scores_sum, dim=1, annotations={T.WSID: "reduce_sum"})
-                for i in T.Parallel(block_M, annotations={T.WSID: "update_logsum"}):
-                    logsum[i] = logsum[i] * scores_rescale[i] + scores_sum[i]
+                    # Affine first (packed f32x2 FMA), exp2 separately.
+                    for i in T.Parallel(block_M, annotations={T.WSID: "exp_scale"}):
+                        for j in T.vectorized(block_N):
+                            S_reg[i, j] = S_reg[i, j] * scale + (-scores_max[i] * scale)
+                    for i, j in T.Parallel(block_M, block_N, annotations={T.WSID: "softmax_exp"}):
+                        S_reg[i, j] = T.exp2(S_reg[i, j])
 
-                T.gemm(
-                    P_tmem,
-                    V_shared,
-                    O_tmem,
-                    clear_accum=k == 0,
-                    annotations={T.WSID: "gemm_PV"},
-                )
+                    T.copy(S_reg, P_cast, annotations={T.WSID: "copy_P_cast"})
+                    T.copy(P_cast, P_tmem, annotations={T.WSID: "copy_P_r2t"})
 
-            T.copy(logsum, logsum_shared, annotations={T.WSID: "copy_logsum_s"})
-            T.copy(logsum_shared, inv_sum, annotations={T.WSID: "copy_inv_sum"})
-            # One reciprocal per row, reused across all output slices.
-            for i in T.Parallel(block_M, annotations={T.WSID: "recip_sum"}):
-                inv_sum[i] = 1.0 / inv_sum[i]
-            for s in T.unroll(T.ceildiv(dim, store_block_N), annotations={T.WSID: "normalize_O"}):
+                    T.reduce_sum(S_reg, scores_sum, dim=1, annotations={T.WSID: "reduce_sum"})
+                    for i in T.Parallel(block_M, annotations={T.WSID: "update_logsum"}):
+                        logsum[i] = logsum[i] * scores_rescale[i] + scores_sum[i]
+
+                    T.gemm(
+                        P_tmem,
+                        V_shared,
+                        O_tmem,
+                        clear_accum=k == 0,
+                        annotations={T.WSID: "gemm_PV"},
+                    )
+
+                T.copy(logsum, logsum_shared, annotations={T.WSID: "copy_logsum_s"})
+                T.copy(logsum_shared, inv_sum, annotations={T.WSID: "copy_inv_sum"})
+                # One reciprocal per row, reused across all output slices.
+                for i in T.Parallel(block_M, annotations={T.WSID: "recip_sum"}):
+                    inv_sum[i] = 1.0 / inv_sum[i]
+                for s in T.unroll(T.ceildiv(dim, store_block_N), annotations={T.WSID: "normalize_O"}):
+                    T.copy(
+                        O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
+                        O_local,
+                    )
+                    for i, j in T.Parallel(block_M, store_block_N):
+                        O_local[i, j] *= inv_sum[i]
+                    T.copy(
+                        O_local,
+                        O_shared[:, s * store_block_N : (s + 1) * store_block_N],
+                    )
                 T.copy(
-                    O_tmem[:, s * store_block_N : (s + 1) * store_block_N],
-                    O_local,
+                    O_shared,
+                    Output[bz, bx * block_M : (bx + 1) * block_M, by, :],
+                    annotations={T.WSID: "copy_O_s2g"},
                 )
-                for i, j in T.Parallel(block_M, store_block_N):
-                    O_local[i, j] *= inv_sum[i]
-                T.copy(
-                    O_local,
-                    O_shared[:, s * store_block_N : (s + 1) * store_block_N],
-                )
-            T.copy(
-                O_shared,
-                Output[bz, bx * block_M : (bx + 1) * block_M, by, :],
-                annotations={T.WSID: "copy_O_s2g"},
-            )
+
+                with T.ws_op("sched_next"):
+                    sched.next_tile()
 
     return Output
 
@@ -417,7 +395,6 @@ def flash_attention_ws(
 
     q_blocks = T.ceildiv(seq_len, block_M)
     loop_range = T.ceildiv(seq_len, block_N)
-    num_blocks = q_blocks * heads * batch
     sm_num = driver.get_num_sms()
     scale = (1.0 / dim) ** 0.5 * 1.44269504
     assert dim == 128
@@ -468,10 +445,17 @@ def flash_attention_ws(
         O_local = T.alloc_fragment((block_M, store_block_N), accum_dtype)
         inv_sum = T.alloc_fragment((block_M,), accum_dtype)
 
+        # Scheduler state is per thread (FA4's static tile order: q block
+        # minor, then head, then batch): init once, then every role runs
+        # its own `while sched.valid()` loop at its own pace, reading
+        # sched.current_iter as the wave clock.
+        sched = T.PersistentTileScheduler(q_blocks, heads * batch, name="sched")
+        sched.init(block_id)
+
         if tid < 128:  # warps 0-3: online softmax
             T.set_max_nreg(224, 1)
-            num_waves = get_num_waves(block_id, num_blocks, sm_num)
-            for wave_id in T.serial(num_waves):
+            while sched.valid():
+                wave_id = sched.current_iter
                 T.fill(scores_max, -T.infinity(accum_dtype))
                 T.fill(logsum, 0)
 
@@ -526,12 +510,15 @@ def flash_attention_ws(
                 T.mbarrier_wait_parity(stats_empty[0], (wave_id & 1) ^ 1)
                 T.copy(logsum, logsum_shared)
                 T.mbarrier_arrive(stats_full[0])
+                sched.next_tile()
 
         elif tid < 256:  # warps 4-7: O correction + epilogue
             T.set_max_nreg(80, 0)
-            num_waves = get_num_waves(block_id, num_blocks, sm_num)
-            for wave_id in T.serial(num_waves):
-                bx, by, bz = get_attn_tile(block_id, wave_id, sm_num, q_blocks, heads)
+            while sched.valid():
+                wave_id = sched.current_iter
+                bx = sched.m_idx
+                by = sched.n_idx % heads
+                bz = sched.n_idx // heads
 
                 for k in T.serial(loop_range):
                     g = wave_id * loop_range + k
@@ -583,12 +570,15 @@ def flash_attention_ws(
                 T.mbarrier_arrive(stats_empty[0])
                 T.mbarrier_arrive(acc_full[0])
                 T.copy(O_shared, Output[bz, bx * block_M : (bx + 1) * block_M, by, :])
+                sched.next_tile()
 
         elif tid < 288:  # warp 8: TMA
             T.set_max_nreg(40, 0)
-            num_waves = get_num_waves(block_id, num_blocks, sm_num)
-            for wave_id in T.serial(num_waves):
-                bx, by, bz = get_attn_tile(block_id, wave_id, sm_num, q_blocks, heads)
+            while sched.valid():
+                wave_id = sched.current_iter
+                bx = sched.m_idx
+                by = sched.n_idx % heads
+                bz = sched.n_idx // heads
 
                 q_stage = wave_id % num_persistent_stages
                 T.mbarrier_wait_parity(q_empty[q_stage], ((wave_id // num_persistent_stages) & 1) ^ 1)
@@ -617,11 +607,12 @@ def flash_attention_ws(
                         barrier=v_full[stage],
                     )
                     T.mbarrier_arrive(v_full[stage])
+                sched.next_tile()
 
         elif tid < 320:  # warp 9: tensor-core issue
             T.set_max_nreg(40, 0)
-            num_waves = get_num_waves(block_id, num_blocks, sm_num)
-            for wave_id in T.serial(num_waves):
+            while sched.valid():
+                wave_id = sched.current_iter
                 q_stage = wave_id % num_persistent_stages
                 T.mbarrier_wait_parity(q_full[q_stage], (wave_id // num_persistent_stages) & 1)
                 # PV runs one software-pipeline stage behind QK: QK(i) is
@@ -664,6 +655,7 @@ def flash_attention_ws(
                 c_last = wave_id * (loop_range + 1) + loop_range
                 T.mbarrier_wait_parity(acc_full[0], c_last & 1)
                 T.tcgen05_mma_arrive(acc_empty[0])
+                sched.next_tile()
 
         else:  # warps 10-11: idle register donors
             T.set_max_nreg(40, 0)

--- a/examples/aws/gemm.py
+++ b/examples/aws/gemm.py
@@ -1,0 +1,434 @@
+import argparse
+
+import torch
+import tilelang
+import tilelang.language as T
+from tilelang.carver.arch import driver
+from tilelang.profiler import do_bench
+
+
+@T.macro
+def get_num_waves(block_id, num_blocks, sm_num):
+    return T.ceildiv(num_blocks - block_id, sm_num)
+
+
+@T.macro
+def get_tile_id(block_id, wave_id, sm_num, group_size, m_blocks):
+    tile_id = block_id + wave_id * sm_num
+    bx = (tile_id // group_size) % m_blocks
+    by = (tile_id % group_size) + (tile_id // group_size) // m_blocks * group_size
+    return bx, by
+
+
+@tilelang.jit
+def gemm(
+    A,
+    B,
+    block_M,
+    block_N,
+    store_block_N,
+    block_K,
+    dtype,
+    accum_dtype,
+    num_stages,
+    num_persistent_stages,
+):
+    M, N, K = T.const("M, N, K")
+
+    A: T.Tensor((M, K), dtype)
+    B: T.Tensor((N, K), dtype)
+    C = T.empty((M, N), dtype)
+
+    m_blocks = T.ceildiv(M, block_M)
+    n_blocks = T.ceildiv(N, block_N)
+    k_blocks = T.ceildiv(K, block_K)
+    num_blocks = m_blocks * n_blocks
+    sm_num = driver.get_num_sms()
+    group_size = 8
+    assert n_blocks % (2 * group_size) == 0
+    assert K % (2 * block_K) == 0
+
+    with T.Kernel(sm_num, threads=128) as block_id:
+        A_shared = T.alloc_shared((block_M, block_K), dtype)
+        B_shared = T.alloc_shared((block_N, block_K), dtype)
+        C_tmem = T.alloc_tmem([block_M, block_N], accum_dtype)
+        # mbar = T.alloc_barrier(1)
+        C_local = T.alloc_fragment((block_M, store_block_N), accum_dtype)
+        C_shared = T.alloc_shared((block_M, store_block_N), dtype)
+
+        # The complete, unambiguous schedule to transform `gemm` to `gemm_ws`.
+        #
+        # The schedulable task is the tile op. Every scheduled op / loop in
+        # the kernel body carries a stable id (a T.WSID entry in its
+        # annotations), and the schedule refers to those ids. Scalar lets
+        # are not schedulable tasks: they are re-evaluated privately by each
+        # role. Data dependencies are not part of the schedule either; the
+        # pass queries the reads/writes of each tile op itself.
+        #
+        # Each pipeline is a full/empty barrier pair protecting `depth`
+        # versions of its buffers: the producer waits for empty and signals
+        # full, the consumer waits for full and signals empty. Sync
+        # instructions carry a software-pipeline stage; within one role's
+        # scope body, acquire/commit (and wait/release) of a pipeline pair
+        # up at one stage, and instructions between them run at that stage's
+        # iteration offset (stages that agree across the body cancel out, as
+        # they do everywhere here).
+        T.annotate_ws_schedule(
+            T.WSSchedule(
+                # This overrides the number of threads.
+                num_warps=8,
+                # The partition of warps, each with a distinct role.
+                roles=[
+                    T.WSRole("TMA", warps_lo=0, warps_hi=1, max_nreg=40),
+                    T.WSRole("MMA", warps_lo=1, warps_hi=2, max_nreg=40),
+                    T.WSRole("Epilogue", warps_lo=4, warps_hi=8, max_nreg=224),
+                ],
+                # Each pipeline has 2 sets of barriers: full and empty.
+                # The producer waits for the empty barrier and signals the full barrier.
+                # The consumer waits for the full barrier and signals the empty barrier.
+                # The pipeline depth is the number of versions of the buffers.
+                # Multiple buffers can share one pipeline.
+                pipelines=[
+                    # This pipeline synchronizes between the TMA warp and the MMA warp, protecting the multi-versioned A_shared and B_shared buffers.
+                    T.WSPipeline("smem", [A_shared, B_shared], depth=num_stages),
+                    # This pipeline synchronizes between the MMA warp and the Epilogue warps, protecting the multi-versioned C_tmem buffer.
+                    T.WSPipeline("tmem", [C_tmem], depth=num_persistent_stages),
+                ],
+                # Every T.Pipelined loop is a scope, named by its ws op id;
+                # they are exactly the loops this schedule specializes. The
+                # root scope is implicit in the kernel, named T.WSScope.ROOT.
+                # A loop is also a large operation that can be scheduled in
+                # its parent scope; other loop kinds (T.serial, T.unroll,
+                # T.Parallel) are always single ops. Plain strings are
+                # shorthand for T.WSOpRef.
+                #
+                # Each scope body gives one sequence of ops per role. The
+                # prologue and epilogue of the software pipeline are
+                # generated automatically (as boundary guards, when a role's
+                # sync stages do not cancel out).
+                scopes=[
+                    T.WSScope(
+                        "loop_k",
+                        {
+                            "TMA": [
+                                # Wait for the smem_empty barrier.
+                                # Before this, A_shared and B_shared are not usable, because there are multiple versions of them, and the buffers are protected by the pipeline.
+                                # After this, the buffers are visible, and the acquired version is bound to each buffer.
+                                T.WSSync.producer_acquire("smem", stage=0),
+                                # Now A_shared will refer to the acquired version of A_shared, for every op.
+                                # Here, copy_A_g2s will write to that version of A_shared.
+                                # During schedule materialization, TileLang will first find that the operand A_shared being written to is bound to pipeline smem, so it will bind an smem_full barrier to the op. It will be eventually lowered to a cp.async.bulk.tensor.mbarrier::complete_tx::bytes, decrementing the transaction count of the barrier.
+                                "copy_A_g2s",
+                                # Similarly, copy_B_g2s will write to the acquired version of B_shared.
+                                "copy_B_g2s",
+                                # Signal the smem_full barrier.
+                                # After this, the buffers are not usable, and again protected by the pipeline.
+                                T.WSSync.producer_commit("smem", stage=0),
+                            ],
+                            "MMA": [
+                                # Wait for the smem_full barrier at stage num_stages - 1.
+                                # After this, the corresponding version of A_shared and B_shared is bound to the variables.
+                                T.WSSync.consumer_wait("smem", stage=num_stages - 1),
+                                # During schedule materialization, TileLang will first find that the operands A_shared and B_shared being read from are bound to pipeline smem, so it will bind an smem_empty barrier to the op. It will be eventually lowered to a tcgen05.commit.mbarrier::arrive::one, incrementing the arrival count of the barrier.
+                                "gemm_C",
+                                # Signal the smem_empty barrier.
+                                # After this, the buffers are not usable, and again protected by the pipeline.
+                                T.WSSync.consumer_release("smem", stage=num_stages - 1),
+                                # After materialization, the loop would look like:
+                                #   for k in range(k_blocks):
+                                #       if k >= num_stages - 1:
+                                #           ...body(k - num_stages + 1)
+                                #   body(k_blocks - num_stages + 1)
+                                #   ...
+                                #   body(k_blocks - 1)
+                                # But that is exactly equivalent to
+                                #   for k in range(k_blocks):
+                                #       body(k)
+                                # So that is the loop we see: this role's
+                                # stages agree, so the offsets cancel.
+                            ],
+                            "Epilogue": [],
+                        },
+                    ),
+                    # This is the persistent loop.
+                    T.WSScope(
+                        "loop_wave_id",
+                        {
+                            "TMA": [
+                                "loop_k",
+                            ],
+                            "MMA": [
+                                T.WSSync.producer_acquire("tmem", stage=0),
+                                # Here, C_tmem will refer to the acquired version of C_tmem.
+                                "loop_k",
+                                T.WSSync.producer_commit("tmem", stage=0),
+                            ],
+                            "Epilogue": [
+                                "loop_k",
+                                T.WSSync.consumer_wait("tmem", stage=num_persistent_stages - 1),
+                                # This unrolled loop is seen as a single node for scheduling. It reads C_tmem, which is protected by pipeline tmem, so C_tmem inside refers to the acquired version.
+                                # Since C_local and C_shared are not multi-versioned, they will refer to the original buffers.
+                                "loop_i",
+                                T.WSSync.consumer_release("tmem", stage=num_persistent_stages - 1),
+                            ],
+                        },
+                    ),
+                    # The root scope is implicit. Nonetheless, the ops inside
+                    # can still be scheduled.
+                    T.WSScope(
+                        T.WSScope.ROOT,
+                        {
+                            "TMA": ["loop_wave_id"],
+                            "MMA": ["loop_wave_id"],
+                            "Epilogue": ["loop_wave_id"],
+                        },
+                    ),
+                ],
+            )
+        )
+
+        num_waves = get_num_waves(block_id, num_blocks, sm_num)
+
+        for wave_id in T.Pipelined(
+            num_waves,
+            num_stages=num_persistent_stages,
+            annotations={T.WSID: "loop_wave_id"},
+        ):
+            bx, by = get_tile_id(block_id, wave_id, sm_num, group_size, m_blocks)
+
+            for k in T.Pipelined(
+                k_blocks,
+                num_stages=num_stages,
+                annotations={T.WSID: "loop_k"},
+            ):
+                T.copy(
+                    A[bx * block_M, k * block_K],
+                    A_shared,
+                    annotations={T.WSID: "copy_A_g2s"},
+                )
+                T.copy(
+                    B[by * block_N, k * block_K],
+                    B_shared,
+                    annotations={T.WSID: "copy_B_g2s"},
+                )
+                T.gemm(
+                    A_shared,
+                    B_shared,
+                    C_tmem,
+                    transpose_B=True,
+                    clear_accum=k == 0,
+                    # mbar=mbar,
+                    annotations={T.WSID: "gemm_C"},
+                )
+                # T.mbarrier_wait_parity(mbar, k % 2)
+
+            for i in T.unroll(
+                T.ceildiv(block_N, store_block_N),
+                annotations={T.WSID: "loop_i"},
+            ):
+                T.copy(C_tmem[:, i * store_block_N : (i + 1) * store_block_N], C_local)
+                T.copy(C_local, C_shared)
+                T.copy(C_shared, C[bx * block_M, by * block_N + i * store_block_N])
+
+    return C
+
+
+@tilelang.jit
+def gemm_ws(
+    A,
+    B,
+    block_M,
+    block_N,
+    store_block_N,
+    block_K,
+    dtype,
+    accum_dtype,
+    num_stages,
+    num_persistent_stages,
+):
+    M, N, K = T.const("M, N, K")
+
+    A: T.Tensor((M, K), dtype)
+    B: T.Tensor((N, K), dtype)
+    C = T.empty((M, N), dtype)
+
+    m_blocks = T.ceildiv(M, block_M)
+    n_blocks = T.ceildiv(N, block_N)
+    k_blocks = T.ceildiv(K, block_K)
+    num_blocks = m_blocks * n_blocks
+    sm_num = driver.get_num_sms()
+    group_size = 8
+    assert n_blocks % (2 * group_size) == 0
+    assert K % (2 * block_K) == 0
+
+    with T.Kernel(sm_num, threads=256) as block_id:
+        A_shared = T.alloc_shared((num_stages, block_M, block_K), dtype)
+        B_shared = T.alloc_shared((num_stages, block_N, block_K), dtype)
+        C_tmem = T.alloc_tmem([num_persistent_stages, block_M, block_N], accum_dtype)
+        C_local = T.alloc_fragment((block_M, store_block_N), accum_dtype)
+        C_shared = T.alloc_shared((block_M, store_block_N), dtype)
+        smem_full = T.alloc_barrier([32] * num_stages)
+        smem_empty = T.alloc_barrier([1] * num_stages)
+        tmem_full = T.alloc_barrier([1] * num_persistent_stages)
+        tmem_empty = T.alloc_barrier([128] * num_persistent_stages)
+
+        tx = T.get_thread_binding()
+
+        if tx < 32:  # warp 0: TMA
+            T.set_max_nreg(40, 0)
+            num_waves = get_num_waves(block_id, num_blocks, sm_num)
+            for wave_id in T.serial(num_waves):
+                bx, by = get_tile_id(block_id, wave_id, sm_num, group_size, m_blocks)
+
+                for k in T.serial(k_blocks):
+                    phase = wave_id * k_blocks + k
+
+                    T.mbarrier_wait_parity(smem_empty[phase % num_stages], ((phase // num_stages) & 1) ^ 1)
+                    T.tma_copy(
+                        A[
+                            bx * block_M : (bx + 1) * block_M,
+                            k * block_K : (k + 1) * block_K,
+                        ],
+                        A_shared[phase % num_stages, :, :],
+                        barrier=smem_full[phase % num_stages],
+                    )
+                    T.tma_copy(
+                        B[
+                            by * block_N : (by + 1) * block_N,
+                            k * block_K : (k + 1) * block_K,
+                        ],
+                        B_shared[phase % num_stages, :, :],
+                        barrier=smem_full[phase % num_stages],
+                    )
+                    T.mbarrier_arrive(smem_full[phase % num_stages])
+        elif tx < 64:  # warp 1: MMA
+            T.set_max_nreg(40, 0)
+            num_waves = get_num_waves(block_id, num_blocks, sm_num)
+            for wave_id in T.serial(num_waves):
+                bx, by = get_tile_id(block_id, wave_id, sm_num, group_size, m_blocks)
+
+                T.mbarrier_wait_parity(
+                    tmem_empty[wave_id % num_persistent_stages],
+                    ((wave_id // num_persistent_stages) & 1) ^ 1,
+                )
+
+                for k in T.serial(k_blocks):
+                    phase = wave_id * k_blocks + k
+
+                    T.mbarrier_wait_parity(smem_full[phase % num_stages], (phase // num_stages) & 1)
+                    T.tcgen05_gemm(
+                        A_shared[phase % num_stages, :, :],
+                        B_shared[phase % num_stages, :, :],
+                        C_tmem[wave_id % num_persistent_stages, :, :],
+                        transpose_B=True,
+                        mbar=None,
+                        clear_accum=k == 0,
+                    )
+
+                    T.tcgen05_mma_arrive(smem_empty[phase % num_stages])
+
+                T.tcgen05_mma_arrive(tmem_full[wave_id % num_persistent_stages])
+        elif tx < 128:  # warps 2-3: idle register donors
+            T.set_max_nreg(40, 0)
+        elif 128 <= tx < 256:  # warps 4-7: epilogue
+            T.set_max_nreg(224, 1)
+            num_waves = get_num_waves(block_id, num_blocks, sm_num)
+            for wave_id in T.serial(num_waves):
+                bx, by = get_tile_id(block_id, wave_id, sm_num, group_size, m_blocks)
+
+                T.mbarrier_wait_parity(
+                    tmem_full[wave_id % num_persistent_stages],
+                    (wave_id // num_persistent_stages) & 1,
+                )
+
+                for i in T.unroll(T.ceildiv(block_N, store_block_N)):
+                    T.copy(
+                        C_tmem[
+                            wave_id % num_persistent_stages,
+                            :,
+                            i * store_block_N : (i + 1) * store_block_N,
+                        ],
+                        C_local,
+                    )
+                    T.copy(C_local, C_shared)
+                    T.copy(C_shared, C[bx * block_M, by * block_N + i * store_block_N])
+
+                T.mbarrier_arrive(tmem_empty[wave_id % num_persistent_stages])
+
+    return C
+
+
+KERNELS = {"gemm": gemm, "gemm_ws": gemm_ws}
+
+
+def main(
+    kernel="gemm",
+    M=8192,
+    N=8192,
+    K=8192,
+    block_M=128,
+    block_N=256,
+    store_block_N=64,
+    block_K=64,
+    num_stages=4,
+    num_persistent_stages=2,
+):
+    dtype, accum_dtype = T.bfloat16, T.float
+    kernel_fn = KERNELS[kernel]
+    kwargs = {
+        "block_M": block_M,
+        "block_N": block_N,
+        "store_block_N": store_block_N,
+        "block_K": block_K,
+        "dtype": dtype,
+        "accum_dtype": accum_dtype,
+        "num_stages": num_stages,
+        "num_persistent_stages": num_persistent_stages,
+    }
+
+    a = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
+    b = torch.randn(N, K, device="cuda", dtype=torch.bfloat16)
+    c = kernel_fn(a, b, **kwargs)
+
+    ref_c = (a.to(torch.float) @ b.to(torch.float).T).to(torch.bfloat16)
+    torch.testing.assert_close(c, ref_c, rtol=1e-2, atol=1e-2)
+    print("All checks passed. ✅")
+
+    tl_latency = do_bench(lambda: kernel_fn(a, b, **kwargs), backend="cupti")
+    torch_latency = do_bench(lambda: a @ b.T, backend="cupti")
+    print(f"Tilelang latency: {tl_latency} ms")
+    print(f"Flops: {2 * M * N * K / (tl_latency / 1e3) / 1e12} TFLOPS")
+    print(f"Torch latency: {torch_latency} ms")
+    print(f"Flops: {2 * M * N * K / (torch_latency / 1e3) / 1e12} TFLOPS")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--kernel", choices=sorted(KERNELS), default="gemm")
+    p.add_argument("--m", type=int, default=8192)
+    p.add_argument("--n", type=int, default=8192)
+    p.add_argument("--k", type=int, default=8192)
+    p.add_argument("--block_m", type=int, default=128)
+    p.add_argument("--block_n", type=int, default=256)
+    p.add_argument(
+        "--store_block_n",
+        type=int,
+        default=64,
+        help="epilogue store slice width",
+    )
+    p.add_argument("--block_k", type=int, default=64)
+    p.add_argument("--num_stages", type=int, default=4)
+    p.add_argument("--num_persistent_stages", type=int, default=2)
+    args = p.parse_args()
+    main(
+        kernel=args.kernel,
+        M=args.m,
+        N=args.n,
+        K=args.k,
+        block_M=args.block_m,
+        block_N=args.block_n,
+        store_block_N=args.store_block_n,
+        block_K=args.block_k,
+        num_stages=args.num_stages,
+        num_persistent_stages=args.num_persistent_stages,
+    )

--- a/examples/aws/gemm.py
+++ b/examples/aws/gemm.py
@@ -88,36 +88,46 @@ def gemm(
                         "loop_k",
                         {
                             "TMA": [
-                                # Wait for smem_empty; inside the span every
-                                # op refers to the acquired version of
-                                # A_shared / B_shared.
+                                # Wait for the smem_empty barrier.
+                                # Before this, A_shared and B_shared are not usable, because there are multiple versions of them, and the buffers are protected by the pipeline.
+                                # After this, the buffers are visible, and the acquired version is bound to each buffer.
                                 T.WSSync.producer_acquire("smem", stage=0),
-                                # The copies write buffers of pipeline smem,
-                                # so their TMA transactions complete the
-                                # smem_full barrier.
+                                # Now A_shared will refer to the acquired version of A_shared, for every op.
+                                # Here, copy_A_g2s will write to that version of A_shared.
+                                # During schedule materialization, TileLang will first find that the operand A_shared being written to is bound to pipeline smem, so it will bind an smem_full barrier to the op. It will be eventually lowered to a cp.async.bulk.tensor.mbarrier::complete_tx::bytes, decrementing the transaction count of the barrier.
                                 "copy_A_g2s",
+                                # Similarly, copy_B_g2s will write to the acquired version of B_shared.
                                 "copy_B_g2s",
+                                # Signal the smem_full barrier.
+                                # After this, the buffers are not usable, and again protected by the pipeline.
                                 T.WSSync.producer_commit("smem", stage=0),
                             ],
                             "MMA": [
-                                # This role runs num_stages - 1 iterations
-                                # behind TMA. Its two stages agree, so the
-                                # offsets cancel and its own loop is emitted
-                                # unshifted.
+                                # Wait for the smem_full barrier at stage num_stages - 1.
+                                # After this, the corresponding version of A_shared and B_shared is bound to the variables.
                                 T.WSSync.consumer_wait("smem", stage=num_stages - 1),
-                                # gemm_C reads buffers of pipeline smem, so
-                                # its tcgen05.commit arrives on smem_empty.
+                                # During schedule materialization, TileLang will first find that the operands A_shared and B_shared being read from are bound to pipeline smem, so it will bind an smem_empty barrier to the op. It will be eventually lowered to a tcgen05.commit.mbarrier::arrive::one, incrementing the arrival count of the barrier.
                                 "gemm_C",
+                                # Signal the smem_empty barrier.
+                                # After this, the buffers are not usable, and again protected by the pipeline.
                                 T.WSSync.consumer_release("smem", stage=num_stages - 1),
+                                # After materialization, the loop would look like:
+                                #   for k in range(k_blocks):
+                                #       if k >= num_stages - 1:
+                                #           ...body(k - num_stages + 1)
+                                #   body(k_blocks - num_stages + 1)
+                                #   ...
+                                #   body(k_blocks - 1)
+                                # But that is exactly equivalent to
+                                #   for k in range(k_blocks):
+                                #       body(k)
+                                # So that is the loop we see: this role's
+                                # stages agree, so the offsets cancel.
                             ],
                             "Epilogue": [],
                         },
                     ),
-                    # The persistent loop: a while scope. It has no
-                    # iteration expression, so pipelines synced under it
-                    # use runtime phase counters. tile_idx / sched_next
-                    # touch no pipeline buffers, so several roles place
-                    # them — each runs its own copy.
+                    # This is the persistent loop.
                     T.WSScope(
                         "loop_wave",
                         {
@@ -143,7 +153,8 @@ def gemm(
                             ],
                         },
                     ),
-                    # The implicit root scope: ops outside any loop.
+                    # The root scope is implicit. Nonetheless, the ops inside
+                    # can still be scheduled.
                     T.WSScope(
                         T.WSScope.ROOT,
                         {

--- a/examples/aws/gemm.py
+++ b/examples/aws/gemm.py
@@ -7,19 +7,6 @@ from tilelang.carver.arch import driver
 from tilelang.profiler import do_bench
 
 
-@T.macro
-def get_num_waves(block_id, num_blocks, sm_num):
-    return T.ceildiv(num_blocks - block_id, sm_num)
-
-
-@T.macro
-def get_tile_id(block_id, wave_id, sm_num, group_size, m_blocks):
-    tile_id = block_id + wave_id * sm_num
-    bx = (tile_id // group_size) % m_blocks
-    by = (tile_id % group_size) + (tile_id // group_size) // m_blocks * group_size
-    return bx, by
-
-
 @tilelang.jit
 def gemm(
     A,
@@ -42,7 +29,6 @@ def gemm(
     m_blocks = T.ceildiv(M, block_M)
     n_blocks = T.ceildiv(N, block_N)
     k_blocks = T.ceildiv(K, block_K)
-    num_blocks = m_blocks * n_blocks
     sm_num = driver.get_num_sms()
     group_size = 8
     assert n_blocks % (2 * group_size) == 0
@@ -56,23 +42,20 @@ def gemm(
         C_local = T.alloc_fragment((block_M, store_block_N), accum_dtype)
         C_shared = T.alloc_shared((block_M, store_block_N), dtype)
 
+        sched = T.PersistentTileScheduler(m_blocks, n_blocks, swizzle_size=group_size, name="sched")
+
         # The complete, unambiguous schedule to transform `gemm` to `gemm_ws`.
         #
-        # The schedulable task is the tile op. Every scheduled op / loop in
-        # the kernel body carries a stable id (a T.WSID entry in its
-        # annotations), and the schedule refers to those ids. Scalar lets
-        # are not schedulable tasks: they are re-evaluated privately by each
-        # role. Data dependencies are not part of the schedule either; the
-        # pass queries the reads/writes of each tile op itself.
+        # Ops and loops carry stable ids (a T.WSID entry in their
+        # annotations); the schedule refers to those ids. Data
+        # dependencies are not declared — the pass queries each tile
+        # op's reads/writes itself.
         #
         # Each pipeline is a full/empty barrier pair protecting `depth`
-        # versions of its buffers: the producer waits for empty and signals
-        # full, the consumer waits for full and signals empty. Sync
-        # instructions carry a software-pipeline stage; within one role's
-        # scope body, acquire/commit (and wait/release) of a pipeline pair
-        # up at one stage, and instructions between them run at that stage's
-        # iteration offset (stages that agree across the body cancel out, as
-        # they do everywhere here).
+        # versions of its buffers. Sync instructions carry a
+        # software-pipeline stage; instructions between an
+        # acquire/commit (or wait/release) pair run at that stage's
+        # iteration offset.
         T.annotate_ws_schedule(
             T.WSSchedule(
                 # This overrides the number of threads.
@@ -94,141 +77,130 @@ def gemm(
                     # This pipeline synchronizes between the MMA warp and the Epilogue warps, protecting the multi-versioned C_tmem buffer.
                     T.WSPipeline("tmem", [C_tmem], depth=num_persistent_stages),
                 ],
-                # Every T.Pipelined loop is a scope, named by its ws op id;
-                # they are exactly the loops this schedule specializes. The
-                # root scope is implicit in the kernel, named T.WSScope.ROOT.
-                # A loop is also a large operation that can be scheduled in
-                # its parent scope; other loop kinds (T.serial, T.unroll,
-                # T.Parallel) are always single ops. Plain strings are
-                # shorthand for T.WSOpRef.
-                #
-                # Each scope body gives one sequence of ops per role. The
-                # prologue and epilogue of the software pipeline are
-                # generated automatically (as boundary guards, when a role's
-                # sync stages do not cancel out).
+                # A scope is a scheduled loop: a serial loop named by its
+                # ws op id, or a T.ws_op-wrapped while loop (the persistent
+                # loop below); the root scope is implicit. Each scope body
+                # gives one sequence of ops per role. When a role's sync
+                # stages do not cancel out, the software pipeline's
+                # prologue and epilogue are unrolled automatically.
                 scopes=[
                     T.WSScope(
                         "loop_k",
                         {
                             "TMA": [
-                                # Wait for the smem_empty barrier.
-                                # Before this, A_shared and B_shared are not usable, because there are multiple versions of them, and the buffers are protected by the pipeline.
-                                # After this, the buffers are visible, and the acquired version is bound to each buffer.
+                                # Wait for smem_empty; inside the span every
+                                # op refers to the acquired version of
+                                # A_shared / B_shared.
                                 T.WSSync.producer_acquire("smem", stage=0),
-                                # Now A_shared will refer to the acquired version of A_shared, for every op.
-                                # Here, copy_A_g2s will write to that version of A_shared.
-                                # During schedule materialization, TileLang will first find that the operand A_shared being written to is bound to pipeline smem, so it will bind an smem_full barrier to the op. It will be eventually lowered to a cp.async.bulk.tensor.mbarrier::complete_tx::bytes, decrementing the transaction count of the barrier.
+                                # The copies write buffers of pipeline smem,
+                                # so their TMA transactions complete the
+                                # smem_full barrier.
                                 "copy_A_g2s",
-                                # Similarly, copy_B_g2s will write to the acquired version of B_shared.
                                 "copy_B_g2s",
-                                # Signal the smem_full barrier.
-                                # After this, the buffers are not usable, and again protected by the pipeline.
                                 T.WSSync.producer_commit("smem", stage=0),
                             ],
                             "MMA": [
-                                # Wait for the smem_full barrier at stage num_stages - 1.
-                                # After this, the corresponding version of A_shared and B_shared is bound to the variables.
+                                # This role runs num_stages - 1 iterations
+                                # behind TMA. Its two stages agree, so the
+                                # offsets cancel and its own loop is emitted
+                                # unshifted.
                                 T.WSSync.consumer_wait("smem", stage=num_stages - 1),
-                                # During schedule materialization, TileLang will first find that the operands A_shared and B_shared being read from are bound to pipeline smem, so it will bind an smem_empty barrier to the op. It will be eventually lowered to a tcgen05.commit.mbarrier::arrive::one, incrementing the arrival count of the barrier.
+                                # gemm_C reads buffers of pipeline smem, so
+                                # its tcgen05.commit arrives on smem_empty.
                                 "gemm_C",
-                                # Signal the smem_empty barrier.
-                                # After this, the buffers are not usable, and again protected by the pipeline.
                                 T.WSSync.consumer_release("smem", stage=num_stages - 1),
-                                # After materialization, the loop would look like:
-                                #   for k in range(k_blocks):
-                                #       if k >= num_stages - 1:
-                                #           ...body(k - num_stages + 1)
-                                #   body(k_blocks - num_stages + 1)
-                                #   ...
-                                #   body(k_blocks - 1)
-                                # But that is exactly equivalent to
-                                #   for k in range(k_blocks):
-                                #       body(k)
-                                # So that is the loop we see: this role's
-                                # stages agree, so the offsets cancel.
                             ],
                             "Epilogue": [],
                         },
                     ),
-                    # This is the persistent loop.
+                    # The persistent loop: a while scope. It has no
+                    # iteration expression, so pipelines synced under it
+                    # use runtime phase counters. tile_idx / sched_next
+                    # touch no pipeline buffers, so several roles place
+                    # them — each runs its own copy.
                     T.WSScope(
-                        "loop_wave_id",
+                        "loop_wave",
                         {
                             "TMA": [
+                                "tile_idx",
                                 "loop_k",
+                                "sched_next",
                             ],
                             "MMA": [
                                 T.WSSync.producer_acquire("tmem", stage=0),
-                                # Here, C_tmem will refer to the acquired version of C_tmem.
                                 "loop_k",
                                 T.WSSync.producer_commit("tmem", stage=0),
+                                "sched_next",
                             ],
                             "Epilogue": [
-                                "loop_k",
-                                T.WSSync.consumer_wait("tmem", stage=num_persistent_stages - 1),
-                                # This unrolled loop is seen as a single node for scheduling. It reads C_tmem, which is protected by pipeline tmem, so C_tmem inside refers to the acquired version.
-                                # Since C_local and C_shared are not multi-versioned, they will refer to the original buffers.
+                                "tile_idx",
+                                T.WSSync.consumer_wait("tmem", stage=0),
+                                # The unrolled loop is one op; it reads the
+                                # acquired version of C_tmem.
                                 "loop_i",
-                                T.WSSync.consumer_release("tmem", stage=num_persistent_stages - 1),
+                                T.WSSync.consumer_release("tmem", stage=0),
+                                "sched_next",
                             ],
                         },
                     ),
-                    # The root scope is implicit. Nonetheless, the ops inside
-                    # can still be scheduled.
+                    # The implicit root scope: ops outside any loop.
                     T.WSScope(
                         T.WSScope.ROOT,
                         {
-                            "TMA": ["loop_wave_id"],
-                            "MMA": ["loop_wave_id"],
-                            "Epilogue": ["loop_wave_id"],
+                            "TMA": ["sched_init", "loop_wave"],
+                            "MMA": ["sched_init", "loop_wave"],
+                            "Epilogue": ["sched_init", "loop_wave"],
                         },
                     ),
                 ],
             )
         )
 
-        num_waves = get_num_waves(block_id, num_blocks, sm_num)
+        with T.ws_op("sched_init"):
+            sched.init(block_id)
 
-        for wave_id in T.Pipelined(
-            num_waves,
-            num_stages=num_persistent_stages,
-            annotations={T.WSID: "loop_wave_id"},
-        ):
-            bx, by = get_tile_id(block_id, wave_id, sm_num, group_size, m_blocks)
+        with T.ws_op("loop_wave"):
+            while sched.valid():
+                with T.ws_op("tile_idx"):
+                    bx = sched.m_idx
+                    by = sched.n_idx
 
-            for k in T.Pipelined(
-                k_blocks,
-                num_stages=num_stages,
-                annotations={T.WSID: "loop_k"},
-            ):
-                T.copy(
-                    A[bx * block_M, k * block_K],
-                    A_shared,
-                    annotations={T.WSID: "copy_A_g2s"},
-                )
-                T.copy(
-                    B[by * block_N, k * block_K],
-                    B_shared,
-                    annotations={T.WSID: "copy_B_g2s"},
-                )
-                T.gemm(
-                    A_shared,
-                    B_shared,
-                    C_tmem,
-                    transpose_B=True,
-                    clear_accum=k == 0,
-                    # mbar=mbar,
-                    annotations={T.WSID: "gemm_C"},
-                )
-                # T.mbarrier_wait_parity(mbar, k % 2)
+                for k in T.Pipelined(
+                    k_blocks,
+                    num_stages=num_stages,
+                    annotations={T.WSID: "loop_k"},
+                ):
+                    T.copy(
+                        A[bx * block_M, k * block_K],
+                        A_shared,
+                        annotations={T.WSID: "copy_A_g2s"},
+                    )
+                    T.copy(
+                        B[by * block_N, k * block_K],
+                        B_shared,
+                        annotations={T.WSID: "copy_B_g2s"},
+                    )
+                    T.gemm(
+                        A_shared,
+                        B_shared,
+                        C_tmem,
+                        transpose_B=True,
+                        clear_accum=k == 0,
+                        # mbar=mbar,
+                        annotations={T.WSID: "gemm_C"},
+                    )
+                    # T.mbarrier_wait_parity(mbar, k % 2)
 
-            for i in T.unroll(
-                T.ceildiv(block_N, store_block_N),
-                annotations={T.WSID: "loop_i"},
-            ):
-                T.copy(C_tmem[:, i * store_block_N : (i + 1) * store_block_N], C_local)
-                T.copy(C_local, C_shared)
-                T.copy(C_shared, C[bx * block_M, by * block_N + i * store_block_N])
+                for i in T.unroll(
+                    T.ceildiv(block_N, store_block_N),
+                    annotations={T.WSID: "loop_i"},
+                ):
+                    T.copy(C_tmem[:, i * store_block_N : (i + 1) * store_block_N], C_local)
+                    T.copy(C_local, C_shared)
+                    T.copy(C_shared, C[bx * block_M, by * block_N + i * store_block_N])
+
+                with T.ws_op("sched_next"):
+                    sched.next_tile()
 
     return C
 
@@ -255,7 +227,6 @@ def gemm_ws(
     m_blocks = T.ceildiv(M, block_M)
     n_blocks = T.ceildiv(N, block_N)
     k_blocks = T.ceildiv(K, block_K)
-    num_blocks = m_blocks * n_blocks
     sm_num = driver.get_num_sms()
     group_size = 8
     assert n_blocks % (2 * group_size) == 0
@@ -272,16 +243,22 @@ def gemm_ws(
         tmem_full = T.alloc_barrier([1] * num_persistent_stages)
         tmem_empty = T.alloc_barrier([128] * num_persistent_stages)
 
+        # Scheduler state is per thread: init once, then every role runs
+        # its own `while sched.valid()` loop at its own pace, reading
+        # sched.current_iter as the wave clock.
+        sched = T.PersistentTileScheduler(m_blocks, n_blocks, swizzle_size=group_size, name="sched")
+        sched.init(block_id)
+
         tx = T.get_thread_binding()
 
         if tx < 32:  # warp 0: TMA
             T.set_max_nreg(40, 0)
-            num_waves = get_num_waves(block_id, num_blocks, sm_num)
-            for wave_id in T.serial(num_waves):
-                bx, by = get_tile_id(block_id, wave_id, sm_num, group_size, m_blocks)
+            while sched.valid():
+                bx = sched.m_idx
+                by = sched.n_idx
 
                 for k in T.serial(k_blocks):
-                    phase = wave_id * k_blocks + k
+                    phase = sched.current_iter * k_blocks + k
 
                     T.mbarrier_wait_parity(smem_empty[phase % num_stages], ((phase // num_stages) & 1) ^ 1)
                     T.tma_copy(
@@ -301,12 +278,11 @@ def gemm_ws(
                         barrier=smem_full[phase % num_stages],
                     )
                     T.mbarrier_arrive(smem_full[phase % num_stages])
+                sched.next_tile()
         elif tx < 64:  # warp 1: MMA
             T.set_max_nreg(40, 0)
-            num_waves = get_num_waves(block_id, num_blocks, sm_num)
-            for wave_id in T.serial(num_waves):
-                bx, by = get_tile_id(block_id, wave_id, sm_num, group_size, m_blocks)
-
+            while sched.valid():
+                wave_id = sched.current_iter
                 T.mbarrier_wait_parity(
                     tmem_empty[wave_id % num_persistent_stages],
                     ((wave_id // num_persistent_stages) & 1) ^ 1,
@@ -328,13 +304,15 @@ def gemm_ws(
                     T.tcgen05_mma_arrive(smem_empty[phase % num_stages])
 
                 T.tcgen05_mma_arrive(tmem_full[wave_id % num_persistent_stages])
+                sched.next_tile()
         elif tx < 128:  # warps 2-3: idle register donors
             T.set_max_nreg(40, 0)
         elif 128 <= tx < 256:  # warps 4-7: epilogue
             T.set_max_nreg(224, 1)
-            num_waves = get_num_waves(block_id, num_blocks, sm_num)
-            for wave_id in T.serial(num_waves):
-                bx, by = get_tile_id(block_id, wave_id, sm_num, group_size, m_blocks)
+            while sched.valid():
+                bx = sched.m_idx
+                by = sched.n_idx
+                wave_id = sched.current_iter
 
                 T.mbarrier_wait_parity(
                     tmem_full[wave_id % num_persistent_stages],
@@ -354,6 +332,7 @@ def gemm_ws(
                     T.copy(C_shared, C[bx * block_M, by * block_N + i * store_block_N])
 
                 T.mbarrier_arrive(tmem_empty[wave_id % num_persistent_stages])
+                sched.next_tile()
 
     return C
 

--- a/examples/aws/gemm.py
+++ b/examples/aws/gemm.py
@@ -33,6 +33,7 @@ def gemm(
     group_size = 8
     assert n_blocks % (2 * group_size) == 0
     assert K % (2 * block_K) == 0
+    assert block_N % store_block_N == 0
 
     with T.Kernel(sm_num, threads=128) as block_id:
         A_shared = T.alloc_shared((block_M, block_K), dtype)
@@ -242,6 +243,7 @@ def gemm_ws(
     group_size = 8
     assert n_blocks % (2 * group_size) == 0
     assert K % (2 * block_K) == 0
+    assert block_N % store_block_N == 0
 
     with T.Kernel(sm_num, threads=256) as block_id:
         A_shared = T.alloc_shared((num_stages, block_M, block_K), dtype)

--- a/examples/aws/test_example_aws.py
+++ b/examples/aws/test_example_aws.py
@@ -1,0 +1,37 @@
+import tilelang.testing
+
+import flash_attention
+import gemm
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_example_gemm():
+    # N must be a multiple of 2 * group_size * block_N, K of 2 * block_K.
+    gemm.main(kernel="gemm", M=512, N=4096, K=512)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_example_gemm_ws():
+    gemm.main(kernel="gemm_ws", M=512, N=4096, K=512)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_example_flash_attention():
+    flash_attention.main(kernel="flash_attention", batch=1, heads=4, seq_len=1024)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+def test_example_flash_attention_ws():
+    flash_attention.main(kernel="flash_attention_ws", batch=1, heads=4, seq_len=1024)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/src/cuda/op/copy_analysis.cc
+++ b/src/cuda/op/copy_analysis.cc
@@ -832,6 +832,44 @@ CopyInstSelection ClassifyWarpSpecializedProducerCopy(const CopyNode &op,
                               : Unsupported(facts.async_unavailable_reason);
   }
 
+  // Honor prefer_instruction like SelectCopyInstForLowering, restricted to
+  // producer-side loads.
+  if (facts.prefer_instruction == PreferredCopyInstruction::kTMA) {
+    if (facts.disable_tma) {
+      return Unsupported("T.copy prefer_instruction=\"tma\" conflicts with "
+                         "disable_tma=true.");
+    }
+    if (facts.pass_context_disables_tma) {
+      return Unsupported("T.copy prefer_instruction=\"tma\" conflicts with "
+                         "pass config tl.disable_tma_lower=true.");
+    }
+    CopyInst inst =
+        SelectTmaInst(facts, /*allow_load=*/true, /*allow_store=*/false,
+                      /*check_last_dim=*/true);
+    return inst == CopyInst::kInvalid
+               ? Unsupported("T.copy prefer_instruction=\"tma\" could not be "
+                             "honored: " +
+                             facts.tma_unavailable_reason)
+               : Supported(inst);
+  }
+
+  if (facts.prefer_instruction == PreferredCopyInstruction::kCPAsync) {
+    if (!IsAutoAsyncCopyEnabled(/*default_enabled=*/true)) {
+      return Unsupported(
+          "T.copy prefer_instruction=\"cp_async\" conflicts with "
+          "pass config tl.enable_async_copy=false.");
+    }
+    return facts.can_cp_async
+               ? Supported(CopyInst::kCPAsync)
+               : Unsupported("T.copy prefer_instruction="
+                             "\"cp_async\" could not be honored: " +
+                             facts.async_unavailable_reason);
+  }
+
+  if (facts.prefer_instruction == PreferredCopyInstruction::kSync) {
+    return Supported(SelectSyncLikeInst(facts));
+  }
+
   if (!facts.disable_tma) {
     CopyInst inst =
         SelectTmaInst(facts, /*allow_load=*/true, /*allow_store=*/false,

--- a/src/cuda/transform/materialize_ws_schedule.cc
+++ b/src/cuda/transform/materialize_ws_schedule.cc
@@ -1,0 +1,1959 @@
+/*!
+ * \file materialize_ws_schedule.cc
+ * \brief Materialize a user-provided warp-specialization schedule.
+ *
+ * A warp-specialized kernel partitions its warps into roles that run
+ * different code and hand data to each other through multi-buffered
+ * staging buffers. The schedule — a T.WSSchedule annotation on the
+ * kernel's block (see T.annotate_ws_schedule) — declares:
+ *  - roles: named warp ranges, each with an optional register budget;
+ *  - pipelines: one producer/consumer handshake each — a "full" and an
+ *    "empty" mbarrier array protecting a set of buffers, which this pass
+ *    replicates into `depth` versions;
+ *  - scopes: the scheduled serial loops plus an implicit root. A scope
+ *    gives each participating role a body: the sequence of ops, child
+ *    scopes, and sync points that role executes per iteration.
+ *
+ * The pass rewrites the kernel into explicit form — `if (tx < ...)` role
+ * branches, versioned buffers, mbarrier waits/arrives with correct
+ * parity, TMA copies completing through barriers, asynchronous tcgen05
+ * MMAs — before PipelinePlanning / LayoutInference / LowerTileOp, so
+ * downstream passes see the same tile-op IR a hand-written
+ * warp-specialized kernel would produce.
+ *
+ * Ids. The schedulable task is a single statement, named by a stable id:
+ * a "tl.ws_op_id" entry in a tile op's call annotations or a loop's
+ * annotations, or a `with T.ws_op(id):` wrapper for a scalar Bind (the
+ * one statement form without annotations). Scope loops are serial
+ * (T.Pipelined or T.serial; the pass consumes num_stages — the software
+ * pipelining happens here). A T.unroll / T.Parallel loop is one opaque
+ * op; statements inside it need no ids. Every statement of a scheduled
+ * kernel must be placed by the schedule — anything unplaced is a fatal
+ * error. A function may hold several kernels, each with its own
+ * schedule; a function without any is returned untouched, and a
+ * scheduled kernel's id markers are consumed during matching and
+ * emission.
+ *
+ * Dependencies are computed, not declared: QueryAccess derives each op's
+ * operands from the tile ops' own access regions. An operand's def is
+ * the pipeline protecting its buffer; a pipeline's producer / consumer
+ * uses are the ops writing / reading its buffers.
+ *
+ * Synchronization. producer_acquire / producer_commit and consumer_wait
+ * / consumer_release bracket a role's work on a pipeline: the acquire or
+ * wait opens a span, the matching commit or release closes it in the
+ * same scope body. An op must run inside an open span of every pipeline
+ * protecting one of its operands, and its accesses are rebound to buffer
+ * version (phase % depth), where the role's phase counts its completed
+ * sync cycles on that pipeline — an expression of the loop iteration, or
+ * a runtime counter when cycles repeat within one body or span several
+ * loops. Sync entries carry a software-pipeline stage: within one body,
+ * an entry at stage s runs (s - s_min) iterations behind, the loop gains
+ * that many extra steps, and boundary guards cover the ramp-up/drain.
+ *
+ * Arrive counts are derived from what each signaling op lowers to (its
+ * atom): TMA data rides the barrier's transaction count, a tcgen05
+ * commit arrives once for all outstanding MMAs, and synchronous compute
+ * arrives per thread.
+ *
+ * Source `if`s around statements become per-op guards, folded together
+ * with the stage boundary guard into one condition. Sync entries are
+ * never guarded: a role that skips work skips only the op bodies, so
+ * pipeline cycles stay unconditional in every role.
+ *
+ * VerifySchedule rejects broken schedules at compile time:
+ *  - span coverage: brackets pair up, a role is the producer or the
+ *    consumer of a pipeline (never both), and ops run inside the spans
+ *    their operands need;
+ *  - cycle balance: within every loop scope, a pipeline's producer and
+ *    consumer sides cycle equally often per iteration;
+ *  - deadlock freedom: the roles' sync events are executed under the
+ *    mbarrier parity model, each loop modeled at two iterations (enough,
+ *    because balanced iterations leave the barrier state unchanged).
+ *
+ * TODO: cluster launch control, while loops, 2-CTA GEMM, epilogue
+ * sub-tiling, stage shifts on counter-tracked pipelines,
+ * try_acquire/try_wait split sync entries, shared-barrier pipeline
+ * groups.
+ */
+
+#include <tvm/arith/analyzer.h>
+#include <tvm/ffi/extra/structural_equal.h>
+#include <tvm/runtime/logging.h>
+#include <tvm/target/target.h>
+#include <tvm/tirx/buffer.h>
+#include <tvm/tirx/builtin.h>
+#include <tvm/tirx/op.h>
+#include <tvm/tirx/stmt.h>
+#include <tvm/tirx/stmt_functor.h>
+#include <tvm/tirx/transform.h>
+
+#include <algorithm>
+#include <array>
+#include <functional>
+#include <limits>
+#include <map>
+#include <optional>
+#include <set>
+#include <sstream>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "cuda/op/builtin.h"
+#include "cuda/op/copy.h"
+#include "op/builtin.h"
+#include "op/copy.h"
+#include "op/gemm.h"
+#include "op/operator.h"
+#include "transform/common/mbarrier.h"
+#include "transform/common/warp_specialize.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+using namespace ffi;
+
+namespace {
+
+// Below this register budget a role donates registers (setmaxnreg.dec);
+// at or above it the role receives (setmaxnreg.inc).
+constexpr int kNregIncThreshold = 128;
+
+// Positions in the materializer's roles_ / pipelines_ / scopes_ vectors,
+// resolved once from schedule names at the parse boundary; -1 = none.
+// Quantities that are not indices (stages, depths, warp counts) stay int.
+using RoleIndex = int;
+using PipelineIndex = int;
+using ScopeIndex = int;
+
+// Identity-keyed maps on Buffer handles. Iteration order is hash order
+// and never observable: consumers renormalize into ordered containers.
+using BufferDefMap =
+    std::unordered_map<Buffer, PipelineIndex, ObjectPtrHash, ObjectPtrEqual>;
+using BufferVersionMap =
+    std::unordered_map<Buffer, Buffer, ObjectPtrHash, ObjectPtrEqual>;
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+// An id value arrives as an ffi String (loop annotations) or as a
+// StringImm (call annotations, whose values must be objects).
+String ExtractWSOpId(const Any &a) {
+  if (auto v = a.try_cast<String>())
+    return *std::move(v);
+  if (const auto *s = a.as<StringImmNode>())
+    return s->value;
+  LOG(FATAL) << "ws_schedule: expected string for " << kWSOpIdKey << ", got "
+             << a.GetTypeKey();
+  return "";
+}
+
+// Rebuild an annotations map, keeping only the keys `keep` accepts. The
+// value type is templated because For/SBlock annotations are Any-valued
+// while Call annotations are ObjectRef-valued.
+template <typename V, typename Pred>
+Map<String, V> FilterAnnotations(const Map<String, V> &ann, Pred keep) {
+  Map<String, V> result;
+  for (const auto &[k, v] : ann) {
+    if (keep(k))
+      result.Set(k, v);
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Tile op helpers
+// ---------------------------------------------------------------------------
+const Op &RegionOp() {
+  static const Op &op = Op::Get("tl.tileop.region");
+  return op;
+}
+const Op &TmaCopyOp() {
+  static const Op &op = Op::Get("tl.tileop.tma_copy");
+  return op;
+}
+const Op &Tcgen05GemmOp() {
+  static const Op &op = Op::Get("tl.tileop.tcgen05_gemm");
+  return op;
+}
+
+// ---------------------------------------------------------------------------
+// QueryAccess: the buffers a statement reads and writes — the pass's
+// dependency oracle. Schedules declare no dataflow; pipeline membership,
+// arrive styles, and arrive counts are all derived from these operands.
+//
+// Tile ops report their own access regions (a gemm reads its accumulator
+// only when it does not clear it, say); granularity is the whole buffer
+// for now. Plain loads and stores count directly, except the
+// address-only root load inside a region argument, which would surface
+// write-only operands as reads. Global buffers are operands too — they
+// simply never resolve to a pipeline.
+// ---------------------------------------------------------------------------
+struct AccessSet {
+  // Operand buffer -> defining pipeline: the pipeline protecting the
+  // buffer, or -1 while unresolved / unprotected. QueryAccess records
+  // the operands; BuildUseChains resolves the defs.
+  BufferDefMap reads, writes;
+
+  // The defs of all operands, unprotected operands excluded.
+  std::set<PipelineIndex> Defs() const {
+    std::set<PipelineIndex> defs;
+    for (const auto *operands : {&reads, &writes})
+      for (const auto &[buf, def] : *operands)
+        if (def >= 0)
+          defs.insert(def);
+    return defs;
+  }
+
+  bool HasDef(PipelineIndex pipeline_idx) const {
+    for (const auto *operands : {&reads, &writes})
+      for (const auto &[buf, def] : *operands)
+        if (def == pipeline_idx)
+          return true;
+    return false;
+  }
+};
+
+// Unions the statement's accesses into *acc. Region calls appear only as
+// tile-op arguments and are skipped: the owning op reports their
+// accesses, and their root loads are excluded from the plain-load pass.
+void QueryAccess(const Stmt &stmt, AccessSet *acc) {
+  std::unordered_set<BufferLoad, ObjectPtrHash, ObjectPtrEqual> region_roots;
+  PostOrderVisit(stmt, [&](const ObjectRef &node) {
+    const auto *call = node.as<CallNode>();
+    if (!call)
+      return;
+    if (call->op.same_as(RegionOp())) {
+      const auto *load = call->args[0].as<BufferLoadNode>();
+      ICHECK(load) << "ws_schedule: region arg0 must be a BufferLoad";
+      region_roots.insert(GetRef<BufferLoad>(load));
+      return;
+    }
+    TileOperator tile_op = ParseOperator(GetRef<Call>(call));
+    if (!tile_op.defined())
+      return; // a non-tile-op intrinsic (exp2, any_sync, ...)
+    AccessRegions access = tile_op->GetAccessRegions();
+    for (const BufferRegion &r : access.reads)
+      acc->reads.emplace(r->buffer, -1);
+    for (const BufferRegion &r : access.writes)
+      acc->writes.emplace(r->buffer, -1);
+  });
+  PostOrderVisit(stmt, [&](const ObjectRef &node) {
+    if (const auto *load = node.as<BufferLoadNode>()) {
+      if (!region_roots.count(GetRef<BufferLoad>(load)))
+        acc->reads.emplace(load->buffer, -1);
+    } else if (const auto *store = node.as<BufferStoreNode>()) {
+      acc->writes.emplace(store->buffer, -1);
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Op atoms: which asynchronous instruction (if any) an op lowers to.
+// Classified once per op and consumed twice — arrive-count planning reads
+// each barrier side's completion signal off the atoms, and emission
+// converts the call — so planner and emitter cannot disagree.
+//  - kSync: synchronous compute; only the executing threads witness its
+//    completion, so they arrive per thread.
+//  - kTmaCopy: bulk-async copy; the data rides the barrier's transaction
+//    count. It only writes its destination, so it holds producer uses.
+//  - kTcgen05Gemm: asynchronous tensor core; one tcgen05.commit performs
+//    a single mbarrier arrive covering all outstanding MMAs.
+// ---------------------------------------------------------------------------
+enum class OpAtom : uint8_t {
+  kSync = 0,
+  kTmaCopy = 1,
+  kTcgen05Gemm = 2,
+};
+
+// Classify one call with the same instruction-selection helpers the
+// lowering uses: ClassifyWarpSpecializedProducerCopy applies the real
+// TMA legality rules (scope, swizzle, stride, dtype), and a gemm
+// accumulating in tensor memory lowers to the asynchronous tcgen05 path.
+OpAtom ClassifyCall(const Call &call, const Target &target) {
+  TileOperator tile_op = ParseOperator(call);
+  if (!tile_op.defined())
+    return OpAtom::kSync; // a non-tile-op intrinsic
+  if (const auto *copy = tile_op.as<CopyNode>()) {
+    cuda::CopyInstSelection sel =
+        cuda::ClassifyWarpSpecializedProducerCopy(*copy, target);
+    return cuda::CopyInstIsTMA(sel.inst) ? OpAtom::kTmaCopy : OpAtom::kSync;
+  }
+  if (const auto *gemm = tile_op.as<GemmNode>()) {
+    return gemm->cRegion_->buffer.scope() == "shared.tmem"
+               ? OpAtom::kTcgen05Gemm
+               : OpAtom::kSync;
+  }
+  return OpAtom::kSync;
+}
+
+// ---------------------------------------------------------------------------
+// Parsed schedule structures
+// ---------------------------------------------------------------------------
+struct RoleSpec {
+  String name;
+  int warp_lo = 0, warp_hi = 0; // [lo, hi) in warps
+  int nreg = 0;                 // 0 = absent
+  int NumThreads() const { return (warp_hi - warp_lo) * 32; }
+  int NregAction() const { return nreg >= kNregIncThreshold ? 1 : 0; }
+};
+
+// One schedulable op: declared by ParseSchedule (placed by exactly one
+// role in exactly one scope body), completed by RecordOpStmt with the
+// matched statement and its guard; later phases fill in the rest.
+struct OpInfo {
+  String id;
+  Stmt stmt;                    // the single matched original statement
+  Optional<PrimExpr> guard;     // original guard, if any
+  AccessSet access;             // operands (whole buffers) and their defs
+  OpAtom atom = OpAtom::kSync;  // classified once by BuildOpAtoms
+  PipelineIndex write_def = -1; // the written operands' single def
+  RoleIndex role_idx = -1;      // the single owning role
+  ScopeIndex sched_scope = -1;  // scope whose body references this op
+};
+
+// Orders a pipeline's uses by op id: deterministic (pointer order varies
+// run to run), and one entry per op — an op signals a pipeline once no
+// matter how many of its operands the pipeline protects.
+struct OpIdLess {
+  bool operator()(const OpInfo *a, const OpInfo *b) const {
+    return a->id < b->id;
+  }
+};
+using UseSet = std::set<const OpInfo *, OpIdLess>;
+
+// How one side (full or empty) of a pipeline's barrier pair is signaled.
+// An mbarrier phase completes only when the pending arrival count AND
+// the transaction count both reach zero, and the init count must be
+// >= 1. So:
+//  1. Collect the atoms of the signaling role's uses of the side
+//     (producer uses signal full, consumer uses signal empty) into the
+//     three flags below.
+//  2. Transactions alone cannot close the arrival side, so a
+//     transaction-only side falls back to the per-thread arrive. Then
+//       count = has_async_arrival + has_thread_arrive * role threads.
+// The commit/release entry emits exactly these arrivals: at most one
+// tcgen05.commit (covering all outstanding MMAs) plus at most one
+// per-thread ptx_arrive_barrier.
+struct BarrierSidePlan {
+  bool has_transaction = false;   // TMA transactions ride the tx-count
+  bool has_async_arrival = false; // one tcgen05.commit arrive::one covers all
+  bool has_thread_arrive = false; // per-thread arrive at the sync entry
+  RoleIndex signal_role_idx = -1; // the signaling role
+  int64_t count = 0;              // resulting mbarrier.init arrival count
+};
+
+struct PipelineSpec {
+  String name;
+  int depth = 1;
+  std::vector<Buffer> buffers; // original buffers
+  Buffer full, empty;          // materialized barrier buffers
+  // Ops whose operands this pipeline protects: producers write them,
+  // consumers read them.
+  UseSet producers, consumers;
+  const UseSet &Uses(bool producer_side) const {
+    return producer_side ? producers : consumers;
+  }
+  // Derived from the signaling ops' atoms (never user-specified).
+  BarrierSidePlan full_plan, empty_plan;
+};
+
+struct SyncEntry {
+  WSSyncKind kind; // set at parse time; never null afterwards
+  PipelineIndex pipeline_idx = -1;
+  int stage = 0;
+};
+
+struct BodyEntry {
+  enum Kind { kOp, kScope, kSync };
+  Kind kind = kOp;
+  String id; // op id or scope id
+  SyncEntry sync;
+};
+
+struct ScopeSpec {
+  String id;
+  For orig_loop; // undefined for the root scope (until matched, for others)
+  // The scope whose bodies reference this one (-1 for the root); unique,
+  // and checked against the loop's lexical parent during matching.
+  ScopeIndex parent = -1;
+  // Per-role instruction sequence, indexed by role index (position in the
+  // warp-sorted roles_ vector); empty when the role has no body here.
+  std::vector<std::vector<BodyEntry>> bodies;
+
+  // The kernel's implicit root is the only scope without a loop:
+  // MatchKernel requires every other scope to match one.
+  bool IsRoot() const { return !orig_loop.defined(); }
+};
+
+// ---------------------------------------------------------------------------
+// The materializer
+// ---------------------------------------------------------------------------
+class WSScheduleMaterializer {
+public:
+  WSScheduleMaterializer(SBlock block, Var thread_var, Target target)
+      : block_(std::move(block)), thread_var_(std::move(thread_var)),
+        target_(std::move(target)) {}
+
+  int NumThreads() const { return num_warps_ * 32; }
+
+  SBlock Run() {
+    ParseSchedule();
+    MatchKernel();
+    PlanVersionedBuffers();
+    BuildUseChains();
+    BuildOpAtoms();
+    PlanArriveCounts();
+    VerifySchedule();
+    return RebuildBlock(EmitRoleBranches());
+  }
+
+private:
+  // ---- schedule parsing ---------------------------------------------------
+
+  // Resolve a schedule-referenced buffer to the block's own allocation. The
+  // schedule holds the buffer object captured at trace time; match by
+  // identity first, then by data var, then by name.
+  Buffer FindBlockBuffer(const Buffer &ref) {
+    for (const Buffer &b : block_->alloc_buffers) {
+      if (b.same_as(ref) || b->data.same_as(ref->data))
+        return b;
+    }
+    for (const Buffer &b : block_->alloc_buffers) {
+      if (b->name == ref->name)
+        return b;
+    }
+    LOG(FATAL) << "ws_schedule: pipeline buffer '" << ref->name
+               << "' is not allocated in this kernel";
+    return Buffer();
+  }
+
+  void ParseSchedule() {
+    auto ann = block_->annotations.Get(kWSScheduleKey);
+    ICHECK(ann.has_value());
+    auto sched_opt = ann.value().try_cast<WSSchedule>();
+    ICHECK(sched_opt.has_value())
+        << "ws_schedule: annotation must be a tl.WSSchedule object, got "
+        << ann.value().GetTypeKey();
+    WSSchedule sched = *std::move(sched_opt);
+
+    num_warps_ = static_cast<int>(sched->num_warps);
+    ICHECK_GT(num_warps_, 0) << "ws_schedule: num_warps must be positive";
+    ICHECK_EQ(num_warps_ % 4, 0)
+        << "ws_schedule: num_warps must be a multiple of 4 (setmaxnreg acts "
+           "on whole warpgroups), got "
+        << num_warps_;
+
+    // Roles.
+    for (const WSRole &r : sched->roles) {
+      RoleSpec role;
+      role.name = r->name;
+      role.warp_lo = static_cast<int>(r->warp_lo);
+      role.warp_hi = static_cast<int>(r->warp_hi);
+      role.nreg = static_cast<int>(r->max_nreg);
+      ICHECK_GE(role.warp_lo, 0) << "ws_schedule: role " << role.name
+                                 << " has a negative warp range start";
+      ICHECK_LT(role.warp_lo, role.warp_hi)
+          << "ws_schedule: role " << role.name << " has an empty warp range";
+      ICHECK_LE(role.warp_hi, num_warps_)
+          << "ws_schedule: role " << role.name << " exceeds num_warps";
+      roles_.push_back(std::move(role));
+    }
+    std::stable_sort(roles_.begin(), roles_.end(),
+                     [](const RoleSpec &a, const RoleSpec &b) {
+                       return a.warp_lo < b.warp_lo;
+                     });
+    for (size_t i = 1; i < roles_.size(); ++i) {
+      ICHECK_LE(roles_[i - 1].warp_hi, roles_[i].warp_lo)
+          << "ws_schedule: roles " << roles_[i - 1].name << " ["
+          << roles_[i - 1].warp_lo << ", " << roles_[i - 1].warp_hi << ") and "
+          << roles_[i].name << " [" << roles_[i].warp_lo << ", "
+          << roles_[i].warp_hi << ") have overlapping warp ranges";
+    }
+
+    // setmaxnreg allocates registers for the whole warpgroup: all four
+    // warps 4g..4g+3 must request the same budget (or none of them any).
+    // Roles sharing a warpgroup must therefore agree on max_nreg; idle
+    // warps adopt their warpgroup's request, and a fully idle warpgroup
+    // donates down to the smallest donor budget.
+    warpgroup_nreg_.assign(num_warps_ / 4, -1); // -1 = no covering role
+    for (const RoleSpec &r : roles_) {
+      for (int w = r.warp_lo; w < r.warp_hi; ++w) {
+        int &wg = warpgroup_nreg_[w / 4];
+        if (wg == -1) {
+          wg = r.nreg;
+        } else {
+          ICHECK_EQ(wg, r.nreg)
+              << "ws_schedule: role " << r.name << " requests max_nreg "
+              << r.nreg << " but another role of warpgroup " << w / 4
+              << " (warps " << w / 4 * 4 << ".." << w / 4 * 4 + 3
+              << ") requests " << wg << " (0 = none); setmaxnreg "
+              << "allocates per warpgroup, so all four warps must "
+              << "allocate or deallocate the same number of registers";
+        }
+      }
+    }
+    int donor = 0;
+    for (const RoleSpec &r : roles_) {
+      if (r.nreg > 0 && r.NregAction() == 0)
+        donor = donor == 0 ? r.nreg : std::min(donor, r.nreg);
+    }
+    for (int &v : warpgroup_nreg_) {
+      if (v == -1)
+        v = donor;
+    }
+
+    // Pipelines. Buffers are typed references; match them to the block's
+    // allocations by data var (the schedule may hold the pre-trace proxy of
+    // the same allocation).
+    for (const WSPipeline &p : sched->pipelines) {
+      PipelineSpec pipeline;
+      pipeline.name = p->name;
+      pipeline.depth = static_cast<int>(p->depth);
+      ICHECK_GE(pipeline.depth, 1);
+      for (const tirx::Buffer &b : p->buffers)
+        pipeline.buffers.push_back(FindBlockBuffer(b));
+      pipelines_.push_back(std::move(pipeline));
+    }
+
+    // Scopes.
+    for (const WSScope &s : sched->scopes) {
+      ScopeSpec scope;
+      scope.id = s->id;
+      scope.bodies.resize(roles_.size());
+      for (const auto &[role_name, instrs] : s->bodies) {
+        RoleIndex role_idx = RoleIndexOf(role_name);
+        ICHECK_GE(role_idx, 0)
+            << "ws_schedule: scope " << scope.id
+            << " has a body for unknown role '" << role_name << "'";
+        std::vector<BodyEntry> entries;
+        for (const WSInstr &instr : instrs) {
+          BodyEntry entry;
+          if (const auto *op_ref = instr.as<WSOpRefNode>()) {
+            entry.kind = BodyEntry::kOp; // refined to kScope below
+            entry.id = op_ref->id;
+          } else if (const auto *sync = instr.as<WSSyncNode>()) {
+            entry.kind = BodyEntry::kSync;
+            entry.sync.kind = sync->kind;
+            entry.sync.stage = static_cast<int>(sync->stage);
+            entry.sync.pipeline_idx = PipelineIndexOf(sync->pipeline);
+            ICHECK_GE(entry.sync.pipeline_idx, 0)
+                << "ws_schedule: unknown pipeline '" << sync->pipeline
+                << "' in scope " << scope.id;
+          } else {
+            LOG(FATAL) << "ws_schedule: unknown instruction type "
+                       << instr->GetTypeKey();
+          }
+          entries.push_back(std::move(entry));
+        }
+        scope.bodies[role_idx] = std::move(entries);
+      }
+      scopes_.push_back(std::move(scope));
+    }
+
+    // Classify body entries as op or child-scope references and validate
+    // the reference graph: an op is placed exactly once (its statement is
+    // cloned verbatim, so repetition would duplicate work); a child scope
+    // has exactly one parent scope, is entered at most once per role, and
+    // is never the root.
+    std::set<std::pair<ScopeIndex, RoleIndex>> scope_refs;
+    for (size_t si = 0; si < scopes_.size(); ++si) {
+      ScopeSpec &scope = scopes_[si];
+      for (size_t ri = 0; ri < scope.bodies.size(); ++ri) {
+        for (BodyEntry &e : scope.bodies[ri]) {
+          if (e.kind != BodyEntry::kOp)
+            continue;
+          ScopeIndex child_idx = ScopeIndexOf(e.id);
+          if (child_idx >= 0) {
+            e.kind = BodyEntry::kScope;
+            ICHECK(e.id != kWSRootScopeId)
+                << "ws_schedule: the root scope cannot be referenced from a "
+                   "scope body";
+            ScopeSpec &child = scopes_[child_idx];
+            if (child.parent < 0) {
+              child.parent = static_cast<ScopeIndex>(si);
+            } else {
+              ICHECK_EQ(child.parent, static_cast<ScopeIndex>(si))
+                  << "ws_schedule: scope '" << e.id
+                  << "' is referenced from multiple parent scopes ('"
+                  << scopes_[child.parent].id << "' and '" << scope.id << "')";
+            }
+            ICHECK(scope_refs.insert({child_idx, static_cast<RoleIndex>(ri)})
+                       .second)
+                << "ws_schedule: scope '" << e.id
+                << "' is referenced more than once by role " << roles_[ri].name
+                << "; each participating role enters a scope exactly once "
+                   "per parent iteration";
+            continue;
+          }
+          auto it = ops_.find(e.id);
+          if (it == ops_.end()) {
+            OpInfo op;
+            op.id = e.id;
+            op.role_idx = static_cast<RoleIndex>(ri);
+            op.sched_scope = static_cast<ScopeIndex>(si);
+            ops_.emplace(e.id, std::move(op));
+          } else {
+            ICHECK_EQ(it->second.role_idx, static_cast<RoleIndex>(ri))
+                << "ws_schedule: op '" << e.id
+                << "' is scheduled by multiple roles";
+            ICHECK_EQ(it->second.sched_scope, static_cast<ScopeIndex>(si))
+                << "ws_schedule: op '" << e.id
+                << "' is scheduled in multiple scopes";
+            LOG(FATAL) << "ws_schedule: op '" << e.id
+                       << "' is referenced more than once in the body of "
+                          "scope '"
+                       << scope.id << "'; an op is placed exactly once";
+          }
+        }
+      }
+    }
+    // An unreferenced scope would never be emitted, silently dropping the
+    // work its bodies schedule.
+    for (const ScopeSpec &scope : scopes_) {
+      ICHECK(scope.parent >= 0 || scope.id == kWSRootScopeId)
+          << "ws_schedule: scope '" << scope.id
+          << "' is never referenced from a parent scope body";
+    }
+  }
+
+  ScopeIndex ScopeIndexOf(const String &id) const {
+    for (size_t i = 0; i < scopes_.size(); ++i)
+      if (scopes_[i].id == id)
+        return static_cast<ScopeIndex>(i);
+    return -1;
+  }
+
+  RoleIndex RoleIndexOf(const String &name) const {
+    for (size_t i = 0; i < roles_.size(); ++i)
+      if (roles_[i].name == name)
+        return static_cast<RoleIndex>(i);
+    return -1;
+  }
+
+  PipelineIndex PipelineIndexOf(const String &name) const {
+    for (size_t i = 0; i < pipelines_.size(); ++i)
+      if (pipelines_[i].name == name)
+        return static_cast<PipelineIndex>(i);
+    return -1;
+  }
+
+  // ---- op matching --------------------------------------------------------
+
+  // Walk the kernel body against the schedule. Coverage is two-sided:
+  // every declared op must match exactly one statement in its scheduling
+  // scope, every scope must find its loop, and — enforced in MatchTask —
+  // every kernel statement must carry an id, except inside op-node loops,
+  // which their loop's id covers.
+  void MatchKernel() {
+    ScopeIndex root = ScopeIndexOf(kWSRootScopeId);
+    ICHECK_GE(root, 0) << "ws_schedule: missing root scope";
+    MatchScopeBody(root, block_->body);
+    for (auto &[id, op] : ops_) {
+      ICHECK(op.stmt.defined())
+          << "ws_schedule: op '" << id
+          << "' is scheduled but no statement in the kernel carries this id";
+      QueryAccess(op.stmt, &op.access);
+      // A buffer read only by the op's guard is an operand too: it needs
+      // span protection and version rebinding like the body.
+      if (op.guard.defined())
+        QueryAccess(Evaluate(op.guard.value()), &op.access);
+    }
+    for (const ScopeSpec &scope : scopes_) {
+      ICHECK(scope.orig_loop.defined() || scope.id == kWSRootScopeId)
+          << "ws_schedule: scope '" << scope.id
+          << "' has no matching loop in the kernel";
+    }
+  }
+
+  void MatchScopeBody(ScopeIndex scope_idx, const Stmt &body) {
+    for (const Stmt &task : BodyStmts(body))
+      MatchTask(scope_idx, task, Optional<PrimExpr>());
+  }
+
+  // The statements of a body: a SeqStmt's list, or the single statement
+  // itself. Not recursive — traced TIR does not nest SeqStmts.
+  static Array<Stmt> BodyStmts(const Stmt &s) {
+    if (const auto *seq = s.as<SeqStmtNode>())
+      return seq->seq;
+    return {s};
+  }
+
+  void RecordScopeLoop(ScopeIndex scope_idx, const For &loop) {
+    ICHECK(!scopes_[scope_idx].orig_loop.defined())
+        << "ws_schedule: scope " << scopes_[scope_idx].id << " matched twice";
+    // Any serial loop can be a scope (T.Pipelined is just a serial loop
+    // with a num_stages annotation, which this pass consumes — the
+    // software pipelining happens here). T.unroll / T.Parallel loops are
+    // single op nodes.
+    ICHECK(loop->kind == ForKind::kSerial)
+        << "ws_schedule: scope '" << scopes_[scope_idx].id
+        << "' must be a serial loop (T.Pipelined or T.serial); T.unroll / "
+           "T.Parallel loops are scheduled as single ops";
+    // Phases count iterations as (loop_var - min); a non-unit step would
+    // break version indices and parities. TODO: divide by the step.
+    ICHECK(loop->HasTrivialStep())
+        << "ws_schedule: scope '" << scopes_[scope_idx].id
+        << "' has a non-unit loop step; write the loop with unit step and "
+           "scale the indices in the body instead";
+    scopes_[scope_idx].orig_loop = loop;
+    MatchScopeBody(scope_idx, loop->body);
+  }
+
+  // Consume the id marker as the statement is recorded, so the emitted
+  // clones never leak scheduling metadata downstream. Ids live in tile-op
+  // call annotations or loop annotations; the T.ws_op wrapper was already
+  // consumed by the matcher, so a recorded Bind carries nothing.
+  static Stmt StripOpId(const Stmt &stmt) {
+    if (const auto *ev = stmt.as<EvaluateNode>()) {
+      const auto *call = ev->value.as<CallNode>();
+      if (call && call->annotations.count(kWSOpIdKey)) {
+        Map<String, ObjectRef> ann =
+            FilterAnnotations(call->annotations, [](const String &key) {
+              return key != kWSOpIdKey;
+            });
+        return Evaluate(Call(call->dtype, call->op, call->args, std::move(ann),
+                             call->span));
+      }
+      return stmt;
+    }
+    if (stmt.as<ForNode>()) {
+      For loop = Downcast<For>(stmt);
+      if (loop->annotations.count(kWSOpIdKey)) {
+        loop.CopyOnWrite()->annotations =
+            FilterAnnotations(loop->annotations, [](const String &key) {
+              return key != kWSOpIdKey;
+            });
+      }
+      return loop;
+    }
+    return stmt;
+  }
+
+  void RecordOpStmt(ScopeIndex scope_idx, const String &id, const Stmt &stmt,
+                    const Optional<PrimExpr> &guard) {
+    auto it = ops_.find(id);
+    ICHECK(it != ops_.end()) << "ws_schedule: statement carries ws op id '"
+                             << id << "' but the schedule never places it:\n"
+                             << stmt;
+    OpInfo &op = it->second;
+    ICHECK(!op.stmt.defined())
+        << "ws_schedule: two statements carry ws op id '" << id
+        << "'; every scheduled statement needs its own id";
+    ICHECK_EQ(scope_idx, op.sched_scope)
+        << "ws_schedule: op '" << id << "' lives in scope '"
+        << scopes_[scope_idx].id << "' of the kernel but is scheduled by "
+        << "scope '" << scopes_[op.sched_scope].id << "'";
+    op.stmt = StripOpId(stmt);
+    if (guard.defined())
+      op.guard = guard;
+  }
+
+  void MatchTask(ScopeIndex scope_idx, const Stmt &task,
+                 Optional<PrimExpr> guard) {
+    ScopeSpec &scope = scopes_[scope_idx];
+
+    // A manual annotation (`with T.ws_op(id):`) for the one statement kind
+    // that cannot carry annotations= itself — the scalar Bind. The wrapper
+    // is consumed here; the op records the wrapped statement.
+    if (const auto *attr = task.as<AttrStmtNode>()) {
+      if (attr->attr_key == kWSOpIdKey) {
+        String id = ExtractWSOpId(Any(attr->value));
+        ICHECK(!attr->body.as<SeqStmtNode>())
+            << "ws_schedule: T.ws_op('" << id << "') must annotate exactly "
+            << "one statement; every scheduled statement needs its own id";
+        ICHECK_LT(ScopeIndexOf(id), 0)
+            << "ws_schedule: scope id '" << id << "' belongs on the loop's "
+            << "own annotations, not on a T.ws_op wrapper";
+        RecordOpStmt(scope_idx, id, attr->body, guard);
+        return;
+      }
+      LOG(FATAL) << "ws_schedule: unexpected AttrStmt '" << attr->attr_key
+                 << "' in kernel body";
+    }
+
+    // Loop with a ws op id annotation. A serial loop whose id names a
+    // schedule scope opens that scope; any other annotated loop (T.unroll,
+    // T.Parallel) is one opaque op node — its body is cloned wholesale and
+    // statements inside it need no ids of their own.
+    if (const auto *loop = task.as<ForNode>()) {
+      if (auto id_ann = loop->annotations.Get(kWSOpIdKey)) {
+        String id = ExtractWSOpId(id_ann.value());
+        ScopeIndex child = ScopeIndexOf(id);
+        if (child >= 0) {
+          ICHECK(!guard.defined())
+              << "ws_schedule: guarded scope loops are not supported";
+          ICHECK_EQ(scopes_[child].parent, scope_idx)
+              << "ws_schedule: scope '" << id << "' lives in scope '"
+              << scope.id << "' of the kernel but is referenced from scope '"
+              << scopes_[scopes_[child].parent].id << "'";
+          RecordScopeLoop(child, GetRef<For>(loop));
+          return;
+        }
+        RecordOpStmt(scope_idx, id, task, guard);
+        return;
+      }
+    }
+
+    // A single tile-op statement carrying its id in the call annotations
+    // is an op, treated as an opaque node.
+    if (const auto *ev = task.as<EvaluateNode>()) {
+      if (const auto *call = ev->value.as<CallNode>()) {
+        if (auto id = call->annotations.Get(kWSOpIdKey)) {
+          RecordOpStmt(scope_idx, ExtractWSOpId(id.value()), task, guard);
+          return;
+        }
+      }
+    }
+
+    // Dig through source guards: an op inside an IfThenElse records the
+    // accumulated condition, which emission folds into its entry guard.
+    if (const auto *ite = task.as<IfThenElseNode>()) {
+      ICHECK(!ite->else_case.defined())
+          << "ws_schedule: else branches are not supported yet";
+      PrimExpr cond =
+          guard.defined() ? (guard.value() && ite->condition) : ite->condition;
+      for (const Stmt &sub : BodyStmts(ite->then_case))
+        MatchTask(scope_idx, sub, cond);
+      return;
+    }
+
+    // Nothing is silently dropped or implicitly replicated: every
+    // statement of a scheduled kernel must be placed by the schedule.
+    LOG(FATAL) << "ws_schedule: statement in scope '" << scope.id
+               << "' carries no ws op id; tile ops and loops take "
+                  "annotations={\"tl.ws_op_id\": ...}, other statements "
+                  "(a scalar Bind) are wrapped in T.ws_op(...):\n"
+               << task;
+  }
+
+  // ---- planning -----------------------------------------------------------
+
+  void PlanVersionedBuffers() {
+    for (PipelineIndex i = 0; i < static_cast<PipelineIndex>(pipelines_.size());
+         ++i) {
+      PipelineSpec &pipeline = pipelines_[i];
+      for (const Buffer &buf : pipeline.buffers) {
+        ICHECK(!buffer_pipeline_.count(buf))
+            << "ws_schedule: buffer " << buf->name
+            << " belongs to multiple pipelines";
+        buffer_pipeline_[buf] = i;
+        if (pipeline.depth > 1) {
+          ObjectPtr<BufferNode> n = make_object<BufferNode>(*buf.get());
+          n->shape.insert(n->shape.begin(),
+                          IntImm(DataType::Int(32), pipeline.depth));
+          if (!n->strides.empty()) {
+            PrimExpr stride0 = n->strides[0] * n->shape[1];
+            n->strides.insert(n->strides.begin(), std::move(stride0));
+          }
+          versioned_[buf] = Buffer(std::move(n));
+        }
+      }
+      pipeline.full =
+          CreateMBarrierBuffer(pipeline.name + "_full", pipeline.depth);
+      pipeline.empty =
+          CreateMBarrierBuffer(pipeline.name + "_empty", pipeline.depth);
+    }
+  }
+
+  // ---- def/use chains -------------------------------------------------------
+
+  // Resolve each operand's defining pipeline and build the pipelines'
+  // reverse use sets. An op's written operands must all resolve to ONE
+  // pipeline: the completion signal behind a producer commit (a TMA
+  // transaction in particular is bound to a single mbarrier at issue
+  // time) can only trigger one. Read operands are unconstrained — one
+  // asynchronous commit may back releases of several pipelines.
+  void BuildUseChains() {
+    for (auto &[id, op] : ops_) {
+      Buffer write_buf;
+      for (auto &[buf, def] : op.access.writes) {
+        auto it = buffer_pipeline_.find(buf);
+        if (it == buffer_pipeline_.end())
+          continue;
+        def = it->second;
+        pipelines_[def].producers.insert(&op);
+        if (op.write_def < 0) {
+          op.write_def = def;
+          write_buf = buf;
+        } else {
+          ICHECK_EQ(op.write_def, def)
+              << "ws_schedule: op '" << id << "' writes " << write_buf->name
+              << " of pipeline '" << pipelines_[op.write_def].name << "' and "
+              << buf->name << " of pipeline '" << pipelines_[def].name
+              << "'; an op's synchronization can only trigger one pipeline, "
+                 "so split the op";
+        }
+      }
+      for (auto &[buf, def] : op.access.reads) {
+        auto it = buffer_pipeline_.find(buf);
+        if (it == buffer_pipeline_.end())
+          continue;
+        def = it->second;
+        pipelines_[def].consumers.insert(&op);
+      }
+    }
+  }
+
+  // ---- op atoms -------------------------------------------------------------
+
+  void BuildOpAtoms() {
+    for (auto &[id, op] : ops_) {
+      const auto *ev = op.stmt.as<EvaluateNode>();
+      if (ev && ev->value.as<CallNode>()) {
+        op.atom = ClassifyCall(Downcast<Call>(ev->value), target_);
+        continue;
+      }
+      // A compound statement (an op-node loop) stays synchronous; an
+      // asynchronous instruction nested inside one could not be wired to
+      // its barrier, so it is rejected. Plain reference locals: C++17
+      // lambdas cannot capture structured bindings.
+      const String &op_id = id;
+      const Stmt &stmt = op.stmt;
+      PostOrderVisit(stmt, [&](const ObjectRef &node) {
+        const auto *call = node.as<CallNode>();
+        if (!call || call->op.same_as(RegionOp()))
+          return;
+        ICHECK(ClassifyCall(GetRef<Call>(call), target_) == OpAtom::kSync)
+            << "ws_schedule: op '" << op_id << "' nests an asynchronous "
+            << "instruction inside a compound statement; make it a "
+            << "directly scheduled op so its barrier can be wired:\n"
+            << stmt;
+      });
+    }
+  }
+
+  // Fill each pipeline's two BarrierSidePlans (see the struct comment):
+  // find the unique signaling role of each side, collect the atoms of
+  // its uses, and derive the arrival count.
+  void PlanArriveCounts() {
+    // The signaling role of a side is the role holding its commit /
+    // release entries; it must be unique.
+    for (const ScopeSpec &scope : scopes_) {
+      for (size_t ri = 0; ri < scope.bodies.size(); ++ri) {
+        for (const BodyEntry &e : scope.bodies[ri]) {
+          if (e.kind != BodyEntry::kSync)
+            continue;
+          if (e.sync.kind.IsWait())
+            continue;
+          PipelineSpec &pipeline = pipelines_[e.sync.pipeline_idx];
+          bool producer_side = e.sync.kind.IsProducerCommit();
+          BarrierSidePlan &plan =
+              producer_side ? pipeline.full_plan : pipeline.empty_plan;
+          if (plan.signal_role_idx < 0) {
+            plan.signal_role_idx = static_cast<RoleIndex>(ri);
+          } else {
+            ICHECK_EQ(plan.signal_role_idx, static_cast<RoleIndex>(ri))
+                << "ws_schedule: pipeline " << pipeline.name
+                << " is committed/released by multiple roles";
+          }
+        }
+      }
+    }
+    for (PipelineIndex p = 0; p < static_cast<PipelineIndex>(pipelines_.size());
+         ++p) {
+      PipelineSpec &pipeline = pipelines_[p];
+      for (bool producer_side : {true, false}) {
+        BarrierSidePlan &plan =
+            producer_side ? pipeline.full_plan : pipeline.empty_plan;
+        if (plan.signal_role_idx < 0)
+          continue; // reported below
+        for (const OpInfo *op : pipeline.Uses(producer_side)) {
+          if (op->role_idx != plan.signal_role_idx)
+            continue;
+          switch (op->atom) {
+          case OpAtom::kTmaCopy:
+            plan.has_transaction = true;
+            break;
+          case OpAtom::kTcgen05Gemm:
+            plan.has_async_arrival = true;
+            break;
+          case OpAtom::kSync:
+            plan.has_thread_arrive = true;
+            break;
+          }
+        }
+        // Transactions cannot close the arrival side by themselves;
+        // without any other arrival, fall back to the per-thread arrive.
+        if (plan.has_transaction && !plan.has_async_arrival &&
+            !plan.has_thread_arrive) {
+          plan.has_thread_arrive = true;
+        }
+        const RoleSpec &role = roles_[plan.signal_role_idx];
+        plan.count = (plan.has_async_arrival ? 1 : 0) +
+                     (plan.has_thread_arrive ? role.NumThreads() : 0);
+      }
+    }
+    for (PipelineSpec &pipeline : pipelines_) {
+      ICHECK_GT(pipeline.full_plan.count, 0)
+          << "ws_schedule: pipeline " << pipeline.name << " has no producer";
+      ICHECK_GT(pipeline.empty_plan.count, 0)
+          << "ws_schedule: pipeline " << pipeline.name << " has no consumer";
+    }
+  }
+
+  // ---- schedule verification ------------------------------------------------
+  //
+  // A broken schedule would hang or race on the GPU; these checks reject
+  // it at compile time instead.
+
+  // Per role: sync brackets must pair up (an acquire/wait opens a span,
+  // the matching commit/release closes it in the same scope body), a
+  // role is the producer or the consumer of a pipeline but never both (a
+  // role handing data to itself would need no pipeline), and every op
+  // must run inside an open span of each pipeline protecting one of its
+  // operands — an access outside the span races with the other side of
+  // the handshake, before the wait or after the release alike.
+  //
+  // A span covers reads and writes both: the flavor is the role's
+  // handshake direction, not the op's access direction (a consumer may
+  // write what it waited on, a producer may read what it acquired).
+  // Spans opened in an enclosing scope cover ops in child scopes.
+  void VerifySpanCoverage() const {
+    for (RoleIndex ri = 0; ri < static_cast<RoleIndex>(roles_.size()); ++ri) {
+      std::map<PipelineIndex, bool> flavor; // pipeline -> role is producer
+      std::set<PipelineIndex> open; // union of all enclosing bodies' spans
+      std::function<void(ScopeIndex)> walk = [&](ScopeIndex scope_idx) {
+        const ScopeSpec &scope = scopes_[scope_idx];
+        std::set<PipelineIndex> local; // spans opened in THIS body
+        for (const BodyEntry &e : scope.bodies[ri]) {
+          if (e.kind == BodyEntry::kSync) {
+            PipelineIndex p = e.sync.pipeline_idx;
+            const String &pname = pipelines_[p].name;
+            auto [fit, first] = flavor.emplace(p, e.sync.kind.IsProducer());
+            ICHECK(first || fit->second == e.sync.kind.IsProducer())
+                << "ws_schedule: role " << roles_[ri].name
+                << " is both a producer and a consumer of pipeline '" << pname
+                << "'; the flavors are the two parties of the handshake, and "
+                   "a role handing data to itself needs no pipeline";
+            if (e.sync.kind.IsWait()) {
+              ICHECK(!open.count(p))
+                  << "ws_schedule: pipeline '" << pname << "' acquired twice "
+                  << "without an intervening commit/release in role "
+                  << roles_[ri].name;
+              open.insert(p);
+              local.insert(p);
+            } else {
+              ICHECK(local.count(p))
+                  << "ws_schedule: commit/release of pipeline '" << pname
+                  << "' in role " << roles_[ri].name
+                  << " has no matching acquire/wait in the same scope body";
+              open.erase(p);
+              local.erase(p);
+            }
+            continue;
+          }
+          if (e.kind == BodyEntry::kScope) {
+            walk(ScopeIndexOf(e.id));
+            continue;
+          }
+          const OpInfo &op = ops_.at(e.id);
+          auto check_operand = [&](const Buffer &buf, PipelineIndex def,
+                                   const char *how) {
+            if (def < 0)
+              return;
+            ICHECK(open.count(def))
+                << "ws_schedule: op '" << op.id << "' in role "
+                << roles_[ri].name << " " << how << " " << buf->name
+                << " outside an open span of pipeline '" << pipelines_[def].name
+                << "'; bracket the op with producer_acquire/producer_commit "
+                << "or consumer_wait/consumer_release (the stage may be "
+                << "concurrently overwritten or still read by an "
+                << "asynchronous task)";
+          };
+          for (const auto &[buf, def] : op.access.writes)
+            check_operand(buf, def, "writes");
+          for (const auto &[buf, def] : op.access.reads)
+            check_operand(buf, def, "reads");
+        }
+        ICHECK(local.empty())
+            << "ws_schedule: role " << roles_[ri].name << " leaves pipeline '"
+            << pipelines_[*local.begin()].name
+            << "' acquired at the end of a scope body; every acquire/wait "
+               "must be paired with a commit/release in the same body";
+      };
+      walk(ScopeIndexOf(kWSRootScopeId));
+    }
+  }
+
+  // Within every loop scope, a pipeline's producer and consumer sides
+  // must cycle equally often per iteration: an imbalance drifts the
+  // full/empty parity further apart every trip, and a side whose
+  // counterpart cycles in a different loop diverges with the extents.
+  // Balance also makes each iteration leave the barrier state unchanged,
+  // which is what lets the deadlock model run every loop for just two
+  // iterations. Deliberately strict: schedules balanced only through
+  // particular loop extents are rejected too.
+  void VerifyCycleBalance() const {
+    for (size_t si = 0; si < scopes_.size(); ++si) {
+      const ScopeSpec &scope = scopes_[si];
+      if (scope.IsRoot())
+        continue; // the root runs once; the deadlock model covers it exactly
+      std::map<PipelineIndex, std::array<int, 2>>
+          cycles; // [consumer, producer]
+      for (RoleIndex ri = 0; ri < static_cast<RoleIndex>(roles_.size()); ++ri) {
+        for (const BodyEntry &e : scope.bodies[ri]) {
+          if (e.kind == BodyEntry::kSync && e.sync.kind.IsCommit())
+            cycles[e.sync.pipeline_idx][e.sync.kind.IsProducer() ? 1 : 0]++;
+        }
+      }
+      for (const auto &[pipeline_idx, sides] : cycles) {
+        ICHECK_EQ(sides[1], sides[0])
+            << "ws_schedule: pipeline '" << pipelines_[pipeline_idx].name
+            << "' cycles " << sides[1] << " time(s) on the producer side but "
+            << sides[0] << " time(s) on the consumer side per iteration of "
+            << "scope '" << scope.id << "'; the full/empty parity diverges "
+            << "as the loop advances — cycle both sides equally often "
+            << "within the scope";
+      }
+    }
+  }
+
+  // Flatten one role's sync entries into the order the emitted code
+  // executes them. Every loop is modeled for two iterations — warm-up
+  // plus one steady-state trip; VerifyCycleBalance makes further
+  // iterations replay the steady state — and the stage deltas reproduce
+  // the software-pipelined reordering rather than the textual order (an
+  // entry at delta d executes at steps d .. d + trips - 1). Sync entries
+  // are unconditional in the emitted code, so the model needs no
+  // conditional events.
+  std::vector<SyncEntry> FlattenRoleEvents(RoleIndex role_idx) const {
+    std::vector<SyncEntry> events;
+    std::function<void(ScopeIndex)> emit = [&](ScopeIndex scope_idx) {
+      const ScopeSpec &scope = scopes_[scope_idx];
+      const std::vector<BodyEntry> &entries = scope.bodies[role_idx];
+      if (entries.empty())
+        return;
+      StagePlan plan = PlanStages(role_idx, entries);
+      int trips = scope.IsRoot() ? 1 : 2;
+      int steps = scope.IsRoot() ? 1 : trips + plan.shift;
+      for (int t = 0; t < steps; ++t) {
+        for (size_t i = 0; i < entries.size(); ++i) {
+          if (!scope.IsRoot() &&
+              (t < plan.delta[i] || t >= plan.delta[i] + trips))
+            continue; // outside this entry's boundary guards
+          const BodyEntry &e = entries[i];
+          if (e.kind == BodyEntry::kScope)
+            emit(ScopeIndexOf(e.id));
+          else if (e.kind == BodyEntry::kSync)
+            events.push_back(e.sync);
+        }
+      }
+    };
+    emit(ScopeIndexOf(kWSRootScopeId));
+    return events;
+  }
+
+  // Execute all roles' sync events under the mbarrier parity model:
+  //  - a role's (k+1)-th wait on a pipeline is enabled once total commits
+  //    reach k+1 (the (k+1)-th full phase completed);
+  //  - its (k+1)-th acquire is enabled once depth + total releases reach
+  //    k+1 (the first `depth` acquires pass on the initial parity);
+  //  - commits and releases never block.
+  // Parity waits consume nothing and the totals only grow, so an enabled
+  // event can never become disabled: one greedy execution reaches the
+  // same end state as every interleaving, and a role still blocked at
+  // quiescence is a real hang, reported with its blocking event.
+  void VerifyDeadlockFree() const {
+    int n_roles = static_cast<int>(roles_.size());
+    std::vector<std::vector<SyncEntry>> events(n_roles);
+    for (RoleIndex r = 0; r < n_roles; ++r)
+      events[r] = FlattenRoleEvents(r);
+
+    std::vector<int> cursors(n_roles, 0);
+    // commits[p] / releases[p]: totals across all roles so far; waits and
+    // acquires are counted per (role, pipeline) observer.
+    std::map<PipelineIndex, int> commits, releases;
+    std::vector<std::map<PipelineIndex, int>> waits(n_roles), acquires(n_roles);
+
+    auto enabled = [&](int r) {
+      const SyncEntry &e = events[r][cursors[r]];
+      if (e.kind.IsConsumerWait())
+        return waits[r][e.pipeline_idx] < commits[e.pipeline_idx];
+      if (e.kind.IsProducerAcquire())
+        return acquires[r][e.pipeline_idx] <
+               static_cast<int>(pipelines_[e.pipeline_idx].depth) +
+                   releases[e.pipeline_idx];
+      return true; // commit / release never block
+    };
+
+    bool progressed = true;
+    while (progressed) {
+      progressed = false;
+      for (int r = 0; r < n_roles; ++r) {
+        while (cursors[r] < static_cast<int>(events[r].size()) && enabled(r)) {
+          const SyncEntry &e = events[r][cursors[r]];
+          if (e.kind.IsProducerAcquire())
+            acquires[r][e.pipeline_idx] += 1;
+          else if (e.kind.IsProducerCommit())
+            commits[e.pipeline_idx] += 1;
+          else if (e.kind.IsConsumerWait())
+            waits[r][e.pipeline_idx] += 1;
+          else
+            releases[e.pipeline_idx] += 1;
+          cursors[r] += 1;
+          progressed = true;
+        }
+      }
+    }
+
+    std::ostringstream blocked;
+    bool deadlocked = false;
+    for (int r = 0; r < n_roles; ++r) {
+      if (cursors[r] >= static_cast<int>(events[r].size()))
+        continue;
+      deadlocked = true;
+      const SyncEntry &e = events[r][cursors[r]];
+      blocked << "\n  role " << roles_[r].name << " blocked at " << e.kind
+              << "(\"" << pipelines_[e.pipeline_idx].name << "\") after "
+              << cursors[r] << " of " << events[r].size() << " sync events";
+    }
+    ICHECK(!deadlocked)
+        << "ws_schedule: schedule deadlocks: the roles' sync events reach a "
+           "state where every unfinished role is blocked (mbarrier parity "
+           "model; loops modeled at two iterations):"
+        << blocked.str();
+  }
+
+  void VerifySchedule() {
+    VerifySpanCoverage();
+    VerifyCycleBalance();
+    VerifyDeadlockFree();
+  }
+
+  // ---- stage analysis -------------------------------------------------------
+
+  // Pipelines transitively touched by a role's entries under a scope.
+  std::set<PipelineIndex> ScopePipelines(RoleIndex role_idx,
+                                         ScopeIndex scope_idx) const {
+    std::set<PipelineIndex> result;
+    const ScopeSpec &scope = scopes_[scope_idx];
+    for (const BodyEntry &e : scope.bodies[role_idx]) {
+      if (e.kind == BodyEntry::kOp) {
+        std::set<PipelineIndex> defs = ops_.at(e.id).access.Defs();
+        result.insert(defs.begin(), defs.end());
+      } else if (e.kind == BodyEntry::kScope) {
+        std::set<PipelineIndex> pipelines =
+            ScopePipelines(role_idx, ScopeIndexOf(e.id));
+        result.insert(pipelines.begin(), pipelines.end());
+      }
+    }
+    return result;
+  }
+
+  // Per-entry stage offsets for one (role, scope) body. delta = stage -
+  // s_min: an entry at delta d executes logical iteration (i - d) at
+  // loop step i, so the loop gains `shift` extra steps and per-entry
+  // boundary guards. A sync entry uses its own stage; an op or child
+  // scope takes the stage of the open spans covering the pipelines it
+  // touches, which must agree (a mix would make the loop-var
+  // substitution ambiguous); entries under no open span run at delta 0.
+  struct StagePlan {
+    std::vector<int> delta; // per entry
+    int shift = 0;          // max delta; loop extent grows by this much
+  };
+
+  StagePlan PlanStages(RoleIndex role_idx,
+                       const std::vector<BodyEntry> &entries) const {
+    StagePlan plan;
+    plan.delta.assign(entries.size(), 0);
+
+    int s_min = std::numeric_limits<int>::max();
+    for (const BodyEntry &e : entries) {
+      if (e.kind == BodyEntry::kSync)
+        s_min = std::min(s_min, e.sync.stage);
+    }
+    if (s_min == std::numeric_limits<int>::max())
+      return plan; // no syncs in this body
+
+    // pipeline -> stage of its open span. Bracket pairing and role
+    // flavor exclusivity were verified (VerifySpanCoverage); only the
+    // pair's stage agreement is checked here, where stages live.
+    std::map<PipelineIndex, int> pipeline_stage;
+    auto span_delta = [&](const std::set<PipelineIndex> &touched_pipelines,
+                          const String &what) -> int {
+      int stage = std::numeric_limits<int>::min();
+      for (const auto &[pipeline_idx, open_stage] : pipeline_stage) {
+        if (!touched_pipelines.count(pipeline_idx))
+          continue;
+        if (stage == std::numeric_limits<int>::min()) {
+          stage = open_stage;
+        } else {
+          ICHECK_EQ(stage, open_stage)
+              << "ws_schedule: " << what << " in role " << roles_[role_idx].name
+              << " touches pipelines whose open spans sit at different "
+                 "stages; split the op or align the stages";
+        }
+      }
+      return stage == std::numeric_limits<int>::min() ? s_min : stage;
+    };
+
+    for (size_t i = 0; i < entries.size(); ++i) {
+      const BodyEntry &e = entries[i];
+      if (e.kind == BodyEntry::kSync) {
+        plan.delta[i] = e.sync.stage - s_min;
+        if (e.sync.kind.IsWait()) {
+          pipeline_stage[e.sync.pipeline_idx] = e.sync.stage;
+        } else {
+          // Bracket verified: the matching open exists in this body.
+          auto oit = pipeline_stage.find(e.sync.pipeline_idx);
+          ICHECK_EQ(oit->second, e.sync.stage)
+              << "ws_schedule: acquire/wait of pipeline '"
+              << pipelines_[e.sync.pipeline_idx].name << "' in role "
+              << roles_[role_idx].name << " is at stage " << oit->second
+              << " but its commit/release is at stage " << e.sync.stage
+              << "; pairs must share one stage";
+          pipeline_stage.erase(oit);
+        }
+      } else if (e.kind == BodyEntry::kOp) {
+        plan.delta[i] = span_delta(ops_.at(e.id).access.Defs(), e.id) - s_min;
+      } else { // kScope
+        plan.delta[i] =
+            span_delta(ScopePipelines(role_idx, ScopeIndexOf(e.id)), e.id) -
+            s_min;
+      }
+    }
+    // Bracket verified: every span opened in this body has closed.
+
+    for (int d : plan.delta)
+      plan.shift = std::max(plan.shift, d);
+    return plan;
+  }
+
+  // ---- emission -----------------------------------------------------------
+
+  struct LoopLevel {
+    PrimExpr iter;   // logical iteration of the current entry at this level
+    PrimExpr extent; // ORIGINAL loop extent (cycles per outer iteration)
+    PrimExpr min;    // ORIGINAL loop min (phase counts iterations from it)
+  };
+
+  struct RoleCtx {
+    const RoleSpec *role = nullptr;
+    RoleIndex role_idx = -1;
+    Map<Var, PrimExpr> subs;      // orig vars -> per-role expressions
+    std::vector<LoopLevel> chain; // enclosing loops, outer->inner
+    // Pipeline -> phase at acquire/wait / runtime phase counter.
+    std::map<PipelineIndex, PrimExpr> pipeline_phase;
+    std::map<PipelineIndex, Buffer> counters;
+  };
+
+  static PrimExpr LinearPhase(const RoleCtx &ctx) {
+    PrimExpr phase;
+    for (const LoopLevel &lvl : ctx.chain) {
+      // The phase counts completed iterations, so a non-zero loop min is
+      // subtracted (T.Pipelined(3, 7) starts at phase 0, not 3).
+      PrimExpr iter = is_zero(lvl.min) ? lvl.iter : lvl.iter - lvl.min;
+      phase = phase.defined() ? phase * lvl.extent + iter : iter;
+    }
+    return phase.defined() ? phase : PrimExpr(IntImm(DataType::Int(32), 0));
+  }
+
+  // A (role, pipeline) pair needs a runtime phase counter when its
+  // cycles are not one-per-iteration of a single loop: sync points at
+  // several loop depths, or several cycles in one body — the loop-based
+  // phase would give such cycles the same version and parity. Counters
+  // are per (role, pipeline): sharing one between pipelines would
+  // require them to cycle in lockstep, since every read of the counter
+  // must see that pipeline's own completed-cycle count.
+  bool NeedsCounter(RoleIndex role_idx, PipelineIndex pipeline_idx) const {
+    std::set<ScopeIndex> sync_scopes;
+    bool multi_cycle = false;
+    std::function<void(ScopeIndex)> scan = [&](ScopeIndex scope_idx) {
+      int closes_here = 0;
+      for (const BodyEntry &e : scopes_[scope_idx].bodies[role_idx]) {
+        if (e.kind == BodyEntry::kScope) {
+          scan(ScopeIndexOf(e.id));
+        } else if (e.kind == BodyEntry::kSync &&
+                   e.sync.pipeline_idx == pipeline_idx) {
+          sync_scopes.insert(scope_idx);
+          if (e.sync.kind.IsCommit())
+            closes_here += 1;
+        }
+      }
+      if (closes_here > 1)
+        multi_cycle = true;
+    };
+    scan(ScopeIndexOf(kWSRootScopeId));
+    return multi_cycle || sync_scopes.size() > 1;
+  }
+
+  PrimExpr PipelinePhase(const RoleCtx &ctx, PipelineIndex pipeline_idx) const {
+    auto cit = ctx.counters.find(pipeline_idx);
+    if (cit != ctx.counters.end())
+      return BufferLoad(cit->second, {IntImm(DataType::Int(32), 0)});
+    return LinearPhase(ctx);
+  }
+
+  static Stmt MakeWait(const Buffer &bar, PrimExpr idx, PrimExpr parity) {
+    return Evaluate(
+        Call(DataType::Handle(), mbarrier_wait_parity(),
+             {BufferLoad(bar, {std::move(idx)}), std::move(parity)}));
+  }
+
+  // Arrivals for one commit/release entry, per its side plan: at most
+  // one tcgen05.commit (covering all outstanding MMAs) plus at most one
+  // per-thread arrive — exactly plan.count arrivals per phase.
+  void MakeArrive(const PipelineSpec &pipeline, bool full, PrimExpr idx,
+                  Array<Stmt> *out) const {
+    const Buffer &bar = full ? pipeline.full : pipeline.empty;
+    const BarrierSidePlan &plan =
+        full ? pipeline.full_plan : pipeline.empty_plan;
+    if (plan.has_async_arrival) {
+      PrimExpr ptr = bar.access_ptr(3, DataType::Handle(), 1, idx);
+      out->push_back(
+          Evaluate(Call(DataType::Void(), tcgen05_mma_arrive(), {ptr})));
+    }
+    if (plan.has_thread_arrive) {
+      out->push_back(
+          Evaluate(Call(DataType::Void(), builtin::ptx_arrive_barrier(),
+                        {BufferLoad(bar, {std::move(idx)})})));
+    }
+  }
+
+  void EmitSync(RoleCtx &ctx, const SyncEntry &sync, Array<Stmt> *out) {
+    PipelineSpec &pipeline = pipelines_[sync.pipeline_idx];
+    PrimExpr depth = IntImm(DataType::Int(32), pipeline.depth);
+    PrimExpr phase = PipelinePhase(ctx, sync.pipeline_idx);
+    PrimExpr idx = floormod(phase, depth);
+    PrimExpr parity =
+        bitwise_and(floordiv(phase, depth), IntImm(DataType::Int(32), 1));
+
+    if (sync.kind.IsProducerAcquire()) {
+      ctx.pipeline_phase[sync.pipeline_idx] = std::move(phase);
+      out->push_back(MakeWait(
+          pipeline.empty, std::move(idx),
+          bitwise_xor(std::move(parity), IntImm(DataType::Int(32), 1))));
+    } else if (sync.kind.IsConsumerWait()) {
+      ctx.pipeline_phase[sync.pipeline_idx] = std::move(phase);
+      out->push_back(
+          MakeWait(pipeline.full, std::move(idx), std::move(parity)));
+    } else if (sync.kind.IsProducerCommit()) {
+      MakeArrive(pipeline, /*full=*/true, std::move(idx), out);
+    } else { // consumer release
+      MakeArrive(pipeline, /*full=*/false, std::move(idx), out);
+    }
+    if (sync.kind.IsCommit() && ctx.counters.count(sync.pipeline_idx)) {
+      Buffer cnt = ctx.counters.at(sync.pipeline_idx);
+      PrimExpr zero = IntImm(DataType::Int(32), 0);
+      out->push_back(BufferStore(cnt, BufferLoad(cnt, {zero}) + 1, {zero}));
+    }
+  }
+
+  // Rebind every access of a multi-versioned buffer to the acquired
+  // version. Buffer versioning only; call conversion is EmitOp's job.
+  struct OpRewriter : public StmtExprMutator {
+    const WSScheduleMaterializer &self;
+    const RoleCtx &ctx;
+    OpRewriter(const WSScheduleMaterializer &self, const RoleCtx &ctx)
+        : self(self), ctx(ctx) {}
+
+    PrimExpr VersionIndex(const Buffer &orig) {
+      // versioned_ keys are pipeline buffers (PlanVersionedBuffers), and
+      // span coverage verified the op runs inside an open span, so the
+      // pipeline and its phase are always present.
+      PipelineIndex p = self.buffer_pipeline_.at(orig);
+      return floormod(ctx.pipeline_phase.at(p),
+                      IntImm(DataType::Int(32), self.pipelines_[p].depth));
+    }
+
+    // The BufferLoad path below prepends the version index to a
+    // versioned region's root load; detect the extra index here and
+    // insert the matching unit extent to keep the region's
+    // indices-per-extent invariant.
+    PrimExpr VisitExpr_(const CallNode *op) final {
+      Call call = Downcast<Call>(StmtExprMutator::VisitExpr_(op));
+      if (call->op.same_as(RegionOp()) && call->args.size() >= 2) {
+        if (const auto *load = call->args[0].as<BufferLoadNode>()) {
+          size_t num_extents = call->args.size() - 2;
+          if (load->indices.size() == num_extents + 1) {
+            Array<PrimExpr> args;
+            args.push_back(call->args[0]);
+            args.push_back(call->args[1]);
+            // The region is the op's footprint: origin = the root load's
+            // indices, size = the extents. The op touches exactly the ONE
+            // acquired version (origin phase % depth), so the version
+            // dimension's extent is 1 — the depth lives in the versioned
+            // buffer's shape, not here.
+            args.push_back(IntImm(DataType::Int(32), 1));
+            for (size_t i = 2; i < call->args.size(); ++i)
+              args.push_back(call->args[i]);
+            return Call(call->dtype, call->op, std::move(args),
+                        call->annotations, call->span);
+          }
+        }
+      }
+      return call;
+    }
+
+    PrimExpr VisitExpr_(const BufferLoadNode *op) final {
+      BufferLoad load = Downcast<BufferLoad>(StmtExprMutator::VisitExpr_(op));
+      auto vit = self.versioned_.find(load->buffer);
+      if (vit == self.versioned_.end())
+        return load;
+      Array<PrimExpr> indices;
+      indices.push_back(VersionIndex(load->buffer));
+      for (const PrimExpr &i : load->indices)
+        indices.push_back(i);
+      return BufferLoad(vit->second, std::move(indices));
+    }
+
+    Stmt VisitStmt_(const BufferStoreNode *op) final {
+      BufferStore store =
+          Downcast<BufferStore>(StmtExprMutator::VisitStmt_(op));
+      auto vit = self.versioned_.find(store->buffer);
+      if (vit == self.versioned_.end())
+        return store;
+      Array<PrimExpr> indices;
+      indices.push_back(VersionIndex(store->buffer));
+      for (const PrimExpr &i : store->indices)
+        indices.push_back(i);
+      return BufferStore(vit->second, store->value, std::move(indices));
+    }
+  };
+
+  Stmt RewriteOpStmt(const RoleCtx &ctx, Stmt stmt) const {
+    OpRewriter rewriter(*this, ctx);
+    return rewriter(std::move(stmt));
+  }
+
+  PrimExpr RewriteOpExpr(const RoleCtx &ctx, PrimExpr expr) const {
+    OpRewriter rewriter(*this, ctx);
+    return rewriter(std::move(expr));
+  }
+
+  // Swap an asynchronous atom's call to its explicit async op. The
+  // statement shape — a direct Evaluate of the call — was enforced by
+  // BuildOpAtoms.
+  Stmt ConvertAtomCall(const RoleCtx &ctx, const OpInfo &op, Stmt stmt) const {
+    const auto *ev = stmt.as<EvaluateNode>();
+    ICHECK(ev);
+    Call call = Downcast<Call>(ev->value);
+    auto ann = call->annotations;
+    if (op.atom == OpAtom::kTmaCopy) {
+      // The TMA transaction completes the full barrier of the pipeline
+      // protecting the destination: the op's single write def. A TMA copy
+      // into an unprotected buffer has no barrier to wire and stays a
+      // plain copy for the generic lowering.
+      if (op.write_def < 0)
+        return stmt;
+      const PipelineSpec &pipeline = pipelines_[op.write_def];
+      // Span coverage verified: the pipeline was acquired.
+      PrimExpr idx = floormod(ctx.pipeline_phase.at(op.write_def),
+                              IntImm(DataType::Int(32), pipeline.depth));
+      ann.Set("barrier", BufferLoad(pipeline.full, {std::move(idx)}));
+      ann.Set("is_tma_copy", IntImm(DataType::Int(32), 1));
+      return Evaluate(Call(call->dtype, TmaCopyOp(), call->args, std::move(ann),
+                           call->span));
+    } else if (op.atom == OpAtom::kTcgen05Gemm) {
+      ann.Set("is_tcgen05", IntImm(DataType::Int(32), 1));
+      return Evaluate(Call(call->dtype, Tcgen05GemmOp(), call->args,
+                           std::move(ann), call->span));
+    }
+    LOG(FATAL) << "ws_schedule: unknown async atom "
+               << static_cast<int>(op.atom);
+  }
+
+  // The op's source guard is NOT applied here: EmitScopeBody folds it into
+  // the entry's guard, combined with any stage boundary guard.
+  Stmt EmitOp(const RoleCtx &ctx, const OpInfo &op) const {
+    Stmt body = RewriteOpStmt(ctx, Substitute(op.stmt, ctx.subs));
+    if (op.atom != OpAtom::kSync)
+      body = ConvertAtomCall(ctx, op, std::move(body));
+    return body;
+  }
+
+  // Emit one (role, scope) body as a flat statement list for the caller
+  // to splice; a SeqStmt is built only where an IfThenElse needs a single
+  // body. `plan` holds the per-entry stage deltas; `loop_var` /
+  // `orig_extent` describe the enclosing loop (undefined for the root),
+  // whose chain level the caller has already pushed.
+  Array<Stmt> EmitScopeBody(RoleCtx &ctx, ScopeIndex scope_idx,
+                            const StagePlan &plan,
+                            const Optional<Var> &loop_var,
+                            const Optional<PrimExpr> &orig_extent,
+                            const Var &orig_loop_var) {
+    ScopeSpec &scope = scopes_[scope_idx];
+    const std::vector<BodyEntry> &entries = scope.bodies[ctx.role_idx];
+    if (entries.empty())
+      return {};
+    if (plan.shift > 0) {
+      ICHECK(loop_var.defined())
+          << "ws_schedule: stage offsets require a loop scope, but scope "
+          << scope.id << " is the root";
+    }
+
+    Array<Stmt> stmts;
+
+    // Point the substitution and phase chain at entry i's logical
+    // iteration and return its guard: the stage boundary condition
+    // combined with the op's own source guard (substituted with the
+    // shifted iteration and version-rebound like the body). Sync entries
+    // have no source guard.
+    auto focus_entry = [&](size_t i) -> Optional<PrimExpr> {
+      Optional<PrimExpr> guard;
+      if (loop_var.defined()) {
+        int delta = plan.delta[i];
+        PrimExpr iter =
+            delta == 0 ? PrimExpr(loop_var.value())
+                       : loop_var.value() - IntImm(DataType::Int(32), delta);
+        ctx.subs.Set(orig_loop_var, iter);
+        ctx.chain.back().iter = std::move(iter);
+        if (delta > 0)
+          guard = loop_var.value() >= IntImm(DataType::Int(32), delta);
+        if (delta < plan.shift) {
+          PrimExpr upper =
+              loop_var.value() <
+              orig_extent.value() + IntImm(DataType::Int(32), delta);
+          guard = guard.defined() ? guard.value() && upper : upper;
+        }
+      }
+      const BodyEntry &e = entries[i];
+      if (e.kind == BodyEntry::kOp) {
+        const OpInfo &op = ops_.at(e.id);
+        if (op.guard.defined()) {
+          PrimExpr src =
+              RewriteOpExpr(ctx, Substitute(op.guard.value(), ctx.subs));
+          guard = guard.defined() ? guard.value() && src : src;
+        }
+      }
+      return guard;
+    };
+    // Unguarded entries append straight to `stmts`; guarded entries keep
+    // emitting into `guarded` while the guard stays structurally
+    // identical, and the run closes as one IfThenElse when it changes.
+    Optional<PrimExpr> cur_guard;
+    Array<Stmt> guarded;
+    StructuralEqual structural_equal;
+    auto close_guard = [&]() {
+      if (cur_guard.defined() && !guarded.empty()) {
+        stmts.push_back(IfThenElse(
+            cur_guard.value(),
+            guarded.size() == 1 ? guarded[0] : SeqStmt(std::move(guarded))));
+      }
+      cur_guard = Optional<PrimExpr>();
+      guarded = Array<Stmt>();
+    };
+
+    for (size_t i = 0; i < entries.size(); ++i) {
+      const BodyEntry &e = entries[i];
+      Optional<PrimExpr> guard = focus_entry(i);
+      bool reuse = guard.defined() == cur_guard.defined() &&
+                   (!guard.defined() ||
+                    structural_equal(guard.value(), cur_guard.value()));
+      if (!reuse) {
+        close_guard();
+        cur_guard = guard;
+      }
+      Array<Stmt> *out = cur_guard.defined() ? &guarded : &stmts;
+      if (e.kind == BodyEntry::kScope) {
+        Stmt child = EmitChildScope(ctx, ScopeIndexOf(e.id));
+        if (child.defined())
+          out->push_back(std::move(child));
+      } else if (e.kind == BodyEntry::kSync) {
+        EmitSync(ctx, e.sync, out);
+      } else {
+        out->push_back(EmitOp(ctx, ops_.at(e.id)));
+      }
+    }
+    close_guard();
+    // Restore the unshifted iteration for any parent-level use.
+    if (loop_var.defined()) {
+      ctx.subs.Set(orig_loop_var, loop_var.value());
+      ctx.chain.back().iter = loop_var.value();
+    }
+    return stmts;
+  }
+
+  Stmt EmitChildScope(RoleCtx &ctx, ScopeIndex scope_idx) {
+    ScopeSpec &scope = scopes_[scope_idx];
+    // Matched (MatchKernel): every non-root scope has its kernel loop.
+    const For &orig = scope.orig_loop;
+
+    if (scope.bodies[ctx.role_idx].empty())
+      return Stmt();
+
+    // The loop extent may need to grow by the scope's stage shift.
+    StagePlan plan = PlanStages(ctx.role_idx, scope.bodies[ctx.role_idx]);
+
+    Var fresh(orig->loop_var->name_hint, orig->loop_var->dtype);
+    ctx.subs.Set(orig->loop_var, fresh);
+    PrimExpr extent = Substitute(orig->extent, ctx.subs);
+    PrimExpr min = Substitute(orig->min, ctx.subs);
+    if (plan.shift > 0) {
+      ICHECK(is_zero(orig->min))
+          << "ws_schedule: stage offsets require 0-based loops";
+    }
+    ctx.chain.push_back({fresh, extent, min});
+    Array<Stmt> body =
+        EmitScopeBody(ctx, scope_idx, plan, fresh, extent, orig->loop_var);
+    ctx.chain.pop_back();
+    if (body.empty())
+      return Stmt(); // role does not participate in this scope
+    PrimExpr emit_extent = plan.shift > 0
+                               ? extent + IntImm(DataType::Int(32), plan.shift)
+                               : extent;
+    // Preserve the source loop kind (e.g. an unrolled epilogue subtile loop)
+    // and its annotations, minus the consumed scheduling markers.
+    Map<String, Any> ann =
+        FilterAnnotations(orig->annotations, [](const String &key) {
+          return key != kWSOpIdKey && key != "num_stages" &&
+                 key.find("tl_pipeline_") != 0;
+        });
+    return For(fresh, Substitute(orig->min, ctx.subs), std::move(emit_extent),
+               orig->kind,
+               body.size() == 1 ? body[0] : SeqStmt(std::move(body)),
+               std::nullopt, std::move(ann));
+  }
+
+  Stmt EmitRole(RoleIndex role_idx) {
+    const RoleSpec &role = roles_[role_idx];
+    RoleCtx ctx;
+    ctx.role = &role;
+    ctx.role_idx = role_idx;
+
+    Array<Stmt> stmts;
+    if (role.nreg > 0) {
+      stmts.push_back(
+          Evaluate(Call(DataType::Handle(), set_max_nreg(),
+                        {IntImm(DataType::Int(32), role.nreg),
+                         IntImm(DataType::Int(32), role.NregAction())})));
+    }
+
+    // Materialize runtime phase counters where linearization is unsound.
+    for (PipelineIndex p = 0; p < static_cast<PipelineIndex>(pipelines_.size());
+         ++p) {
+      bool used = false;
+      for (const ScopeSpec &scope : scopes_) {
+        for (const BodyEntry &e : scope.bodies[role_idx])
+          if (e.kind == BodyEntry::kSync && e.sync.pipeline_idx == p)
+            used = true;
+      }
+      if (used && NeedsCounter(role_idx, p)) {
+        Buffer cnt =
+            decl_buffer({IntImm(DataType::Int(32), 1)}, DataType::Int(32),
+                        pipelines_[p].name + "_phase", "local");
+        ctx.counters[p] = cnt;
+        stmts.push_back(AllocBuffer(cnt));
+        stmts.push_back(BufferStore(cnt, IntImm(DataType::Int(32), 0),
+                                    {IntImm(DataType::Int(32), 0)}));
+      }
+    }
+
+    ScopeIndex root = ScopeIndexOf(kWSRootScopeId);
+    StagePlan plan = PlanStages(role_idx, scopes_[root].bodies[role_idx]);
+    Array<Stmt> body = EmitScopeBody(ctx, root, plan, Optional<Var>(),
+                                     Optional<PrimExpr>(), Var());
+    ICHECK(!body.empty()) << "ws_schedule: role " << role.name
+                          << " has an empty root body";
+    for (const Stmt &s : body)
+      stmts.push_back(s);
+    // The role branch is one arm of an IfThenElse: inline seq-wrap.
+    return stmts.size() == 1 ? stmts[0] : SeqStmt(std::move(stmts));
+  }
+
+  // Idle warps execute their warpgroup's register request
+  // (warpgroup_nreg_); a no-op when the warpgroup requests nothing.
+  Stmt EmitIdle(int nreg) const {
+    if (nreg == 0)
+      return Evaluate(IntImm(DataType::Int(32), 0));
+    return Evaluate(
+        Call(DataType::Handle(), set_max_nreg(),
+             {IntImm(DataType::Int(32), nreg),
+              IntImm(DataType::Int(32), nreg >= kNregIncThreshold ? 1 : 0)}));
+  }
+
+  // Emit the `if (tx < ...)` role branches ordered by warp range, filling
+  // gaps with idle branches — split where the warpgroup register request
+  // changes, so every idle warp executes exactly its warpgroup's request.
+  Stmt EmitRoleBranches() {
+    Array<Stmt> branches;
+    Array<PrimExpr> conds;
+    auto fill_idle = [&](int lo, int hi) {
+      for (int w = lo; w < hi;) {
+        int nreg = warpgroup_nreg_[w / 4];
+        int seg = w;
+        while (seg < hi && warpgroup_nreg_[seg / 4] == nreg)
+          ++seg;
+        conds.push_back(thread_var_ < IntImm(DataType::Int(32), seg * 32));
+        branches.push_back(EmitIdle(nreg));
+        w = seg;
+      }
+    };
+    int cursor = 0;
+    for (size_t ri = 0; ri < roles_.size(); ++ri) {
+      const RoleSpec &role = roles_[ri];
+      ICHECK_GE(role.warp_lo, cursor)
+          << "ws_schedule: overlapping role warp ranges";
+      fill_idle(cursor, role.warp_lo);
+      conds.push_back(thread_var_ <
+                      IntImm(DataType::Int(32), role.warp_hi * 32));
+      branches.push_back(EmitRole(static_cast<RoleIndex>(ri)));
+      cursor = role.warp_hi;
+    }
+    fill_idle(cursor, num_warps_);
+    Stmt body = branches[branches.size() - 1];
+    for (int i = static_cast<int>(branches.size()) - 2; i >= 0; --i)
+      body = IfThenElse(conds[i], branches[i], std::move(body));
+    return body;
+  }
+
+  // Rebuild the block around the emitted body: versioned buffer
+  // replacements, barrier allocations with their derived init counts, and
+  // the consumed schedule annotation removed.
+  SBlock RebuildBlock(Stmt body) {
+    Array<Buffer> allocs;
+    for (const Buffer &buf : block_->alloc_buffers) {
+      auto vit = versioned_.find(buf);
+      allocs.push_back(vit == versioned_.end() ? buf : vit->second);
+    }
+    Map<Var, Array<PrimExpr>> barrier_init;
+    for (const PipelineSpec &pipeline : pipelines_) {
+      allocs.push_back(pipeline.full);
+      allocs.push_back(pipeline.empty);
+      Array<PrimExpr> full_counts, empty_counts;
+      for (int i = 0; i < pipeline.depth; ++i) {
+        full_counts.push_back(
+            IntImm(DataType::Int(32), pipeline.full_plan.count));
+        empty_counts.push_back(
+            IntImm(DataType::Int(32), pipeline.empty_plan.count));
+      }
+      barrier_init.Set(pipeline.full->data, std::move(full_counts));
+      barrier_init.Set(pipeline.empty->data, std::move(empty_counts));
+    }
+
+    SBlock new_block = block_;
+    auto *n = new_block.CopyOnWrite();
+    n->body = std::move(body);
+    n->alloc_buffers = std::move(allocs);
+    Map<String, Any> ann =
+        FilterAnnotations(n->annotations, [](const String &key) {
+          return key != kWSScheduleKey;
+        });
+    if (auto existing = ann.Get("barrier_init")) {
+      auto prev = Downcast<Map<Var, Array<PrimExpr>>>(existing.value());
+      for (const auto &[var, counts] : prev)
+        barrier_init.Set(var, counts);
+    }
+    ann.Set("barrier_init", std::move(barrier_init));
+    n->annotations = std::move(ann);
+    return new_block;
+  }
+
+  // ---- state ---------------------------------------------------------------
+
+  SBlock block_;
+  Var thread_var_;
+  Target target_;
+  int num_warps_ = 0;
+  std::vector<RoleSpec> roles_;
+  std::vector<PipelineSpec> pipelines_;
+  std::vector<ScopeSpec> scopes_;
+  std::map<String, OpInfo> ops_;
+  // Per-warpgroup register request (index = warp / 4, 0 = none), agreed
+  // on by every covering role; idle warps execute it too.
+  std::vector<int> warpgroup_nreg_;
+  BufferDefMap buffer_pipeline_;
+  BufferVersionMap versioned_;
+};
+
+// Rewrite every schedule-annotated SBlock in place — a function may hold
+// several kernels, each with its own schedule. Tracking the threadIdx.x
+// binding on the way down hands each materializer the binding that
+// actually encloses its block, and exactly that binding is widened to
+// that schedule's warp count on the way back up.
+class WSScheduleRewriter : public StmtMutator {
+public:
+  explicit WSScheduleRewriter(Optional<Target> target)
+      : target_(std::move(target)) {}
+
+  Stmt VisitStmt_(const AttrStmtNode *op) final {
+    if (op->attr_key == tirx::attr::thread_extent) {
+      IterVar iv = Downcast<IterVar>(op->node);
+      if (iv->thread_tag == "threadIdx.x") {
+        thread_iv_ = iv;
+        new_extent_ = -1;
+        AttrStmt attr = Downcast<AttrStmt>(StmtMutator::VisitStmt_(op));
+        if (new_extent_ >= 0) {
+          PrimExpr nt = IntImm(DataType::Int(32), new_extent_);
+          thread_iv_.CopyOnWrite()->dom = {0, nt};
+          attr.CopyOnWrite()->node = thread_iv_;
+          attr.CopyOnWrite()->value = nt;
+        }
+        thread_iv_ = {};
+        return attr;
+      }
+      // Warp roles partition threadIdx.x only: a scheduled block under a
+      // multi-dimensional thread launch would mis-assign warps.
+      if (iv->thread_tag == "threadIdx.y" || iv->thread_tag == "threadIdx.z") {
+        bool saved = multi_dim_threads_;
+        multi_dim_threads_ = multi_dim_threads_ || !is_one(op->value);
+        Stmt stmt = StmtMutator::VisitStmt_(op);
+        multi_dim_threads_ = saved;
+        return stmt;
+      }
+    }
+    return StmtMutator::VisitStmt_(op);
+  }
+
+  Stmt VisitStmt_(const SBlockNode *op) final {
+    if (!op->annotations.count(kWSScheduleKey))
+      return StmtMutator::VisitStmt_(op);
+    ICHECK(thread_iv_.defined())
+        << "ws_schedule: threadIdx.x binding not found around the scheduled "
+           "block";
+    ICHECK(!multi_dim_threads_)
+        << "ws_schedule: the scheduled kernel must launch threads in one "
+           "dimension (threadIdx.x only); warp roles partition threadIdx.x";
+    ICHECK(target_.defined())
+        << "ws_schedule: PrimFunc has no bound target (BindTarget must run "
+           "before MaterializeWSSchedule)";
+    WSScheduleMaterializer materializer(GetRef<SBlock>(op), thread_iv_->var,
+                                        target_.value());
+    SBlock block = materializer.Run();
+    new_extent_ = materializer.NumThreads();
+    return block;
+  }
+
+private:
+  Optional<Target> target_;
+  IterVar thread_iv_;
+  bool multi_dim_threads_ = false;
+  int new_extent_ = -1;
+};
+
+// Schedule and op ids come together (both present or neither): a function
+// without the schedule annotation is returned untouched, and the
+// materializer consumes the ids of a scheduled kernel as it clones the
+// statements.
+PrimFunc MaterializeWSScheduleImpl(PrimFunc f) {
+  WSScheduleRewriter rewriter(f->GetAttr<Target>(tvm::attr::kTarget));
+  Stmt body = rewriter(f->body);
+  if (body.same_as(f->body))
+    return f;
+  f.CopyOnWrite()->body = std::move(body);
+  return f;
+}
+
+} // namespace
+
+tvm::transform::Pass MaterializeWSSchedule() {
+  using namespace tirx::transform;
+  auto pass_func = [](PrimFunc f, const IRModule &m,
+                      tvm::transform::PassContext ctx) {
+    return MaterializeWSScheduleImpl(std::move(f));
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.MaterializeWSSchedule", {});
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = reflection;
+  refl::GlobalDef().def("tl.cuda.transform.MaterializeWSSchedule",
+                        MaterializeWSSchedule);
+}
+
+} // namespace tl
+} // namespace tvm

--- a/src/cuda/transform/materialize_ws_schedule.cc
+++ b/src/cuda/transform/materialize_ws_schedule.cc
@@ -2,79 +2,61 @@
  * \file materialize_ws_schedule.cc
  * \brief Materialize a user-provided warp-specialization schedule.
  *
- * A warp-specialized kernel partitions its warps into roles that run
- * different code and hand data to each other through multi-buffered
- * staging buffers. The schedule — a T.WSSchedule annotation on the
- * kernel's block (see T.annotate_ws_schedule) — declares:
+ * The schedule — a T.WSSchedule annotation on the kernel's block (see
+ * T.annotate_ws_schedule) — declares:
  *  - roles: named warp ranges, each with an optional register budget;
  *  - pipelines: one producer/consumer handshake each — a "full" and an
- *    "empty" mbarrier array protecting a set of buffers, which this pass
- *    replicates into `depth` versions;
- *  - scopes: the scheduled serial loops plus an implicit root. A scope
- *    gives each participating role a body: the sequence of ops, child
- *    scopes, and sync points that role executes per iteration.
+ *    "empty" mbarrier array protecting a set of buffers, which this
+ *    pass replicates into `depth` versions;
+ *  - scopes: the scheduled loops plus an implicit root. A scope gives
+ *    each participating role a body: the ops, child scopes, and sync
+ *    points that role executes per iteration.
  *
- * The pass rewrites the kernel into explicit form — `if (tx < ...)` role
- * branches, versioned buffers, mbarrier waits/arrives with correct
- * parity, TMA copies completing through barriers, asynchronous tcgen05
- * MMAs — before PipelinePlanning / LayoutInference / LowerTileOp, so
- * downstream passes see the same tile-op IR a hand-written
- * warp-specialized kernel would produce.
+ * The pass rewrites the kernel into explicit form — role branches,
+ * versioned buffers, mbarrier waits/arrives, TMA copies completing
+ * through barriers, asynchronous tcgen05 MMAs — before
+ * PipelinePlanning / LayoutInference / LowerTileOp, so downstream
+ * passes see the same tile-op IR a hand-written kernel would produce.
  *
- * Ids. The schedulable task is a single statement, named by a stable id:
- * a "tl.ws_op_id" entry in a tile op's call annotations or a loop's
- * annotations, or a `with T.ws_op(id):` wrapper for a scalar Bind (the
- * one statement form without annotations). Scope loops are serial
- * (T.Pipelined or T.serial; the pass consumes num_stages — the software
- * pipelining happens here). A T.unroll / T.Parallel loop is one opaque
- * op; statements inside it need no ids. Every statement of a scheduled
- * kernel must be placed by the schedule — anything unplaced is a fatal
- * error. A function may hold several kernels, each with its own
- * schedule; a function without any is returned untouched, and a
- * scheduled kernel's id markers are consumed during matching and
- * emission.
+ * Ids. The schedulable op is one statement, named by a "tl.ws_op_id"
+ * annotation on a tile op or loop, or a `with T.ws_op(id):` wrapper
+ * for anything else (possibly several plain statements, which become
+ * ONE opaque op). Scope loops are serial loops (the pass consumes
+ * num_stages) or T.ws_op-wrapped while loops (phases under them use
+ * runtime counters; the condition must be role-uniform). A T.unroll /
+ * T.Parallel loop is one opaque op. Every statement must be placed by
+ * the schedule — anything unplaced is a fatal error. Several roles may
+ * place the same op only when it touches no pipeline buffers; each
+ * role then runs its own copy.
  *
- * Dependencies are computed, not declared: QueryAccess derives each op's
- * operands from the tile ops' own access regions. An operand's def is
- * the pipeline protecting its buffer; a pipeline's producer / consumer
- * uses are the ops writing / reading its buffers.
+ * Dependencies are computed, not declared: QueryAccess derives each
+ * op's operands; an operand's def is the pipeline protecting its
+ * buffer.
  *
- * Synchronization. producer_acquire / producer_commit and consumer_wait
- * / consumer_release bracket a role's work on a pipeline: the acquire or
- * wait opens a span, the matching commit or release closes it in the
- * same scope body. An op must run inside an open span of every pipeline
- * protecting one of its operands, and its accesses are rebound to buffer
- * version (phase % depth), where the role's phase counts its completed
- * sync cycles on that pipeline — an expression of the loop iteration, or
- * a runtime counter when cycles repeat within one body or span several
- * loops. Sync entries carry a software-pipeline stage: within one body,
- * an entry at stage s runs (s - s_min) iterations behind, the loop gains
- * that many extra steps, and boundary guards cover the ramp-up/drain.
+ * Synchronization. producer_acquire / producer_commit and
+ * consumer_wait / consumer_release bracket a role's work on a
+ * pipeline. An op must run inside an open span of every pipeline
+ * protecting one of its operands; its accesses are rebound to buffer
+ * version (phase % depth). Sync entries carry a software-pipeline
+ * stage: an entry at stage s runs (s - s_min) iterations behind,
+ * emitted as unrolled prologue/epilogue steps around a steady-state
+ * loop with no per-iteration boundary checks.
  *
- * Arrive counts are derived from what each signaling op lowers to (its
- * atom): TMA data rides the barrier's transaction count, a tcgen05
- * commit arrives once for all outstanding MMAs, and synchronous compute
- * arrives per thread.
+ * Arrive counts derive from each signaling op's atom (see OpAtom and
+ * BarrierSidePlan).
  *
- * Source `if`s around statements become per-op guards, folded together
- * with the stage boundary guard into one condition. Sync entries are
- * never guarded: a role that skips work skips only the op bodies, so
- * pipeline cycles stay unconditional in every role.
+ * Source `if`s around statements become per-op guards; sync entries
+ * stay unconditional in every role. An `if` around a scope loop guards
+ * the whole scope; its condition must be uniform across roles.
  *
- * VerifySchedule rejects broken schedules at compile time:
- *  - span coverage: brackets pair up, a role is the producer or the
- *    consumer of a pipeline (never both), and ops run inside the spans
- *    their operands need;
- *  - cycle balance: within every loop scope, a pipeline's producer and
- *    consumer sides cycle equally often per iteration;
- *  - deadlock freedom: the roles' sync events are executed under the
- *    mbarrier parity model, each loop modeled at two iterations (enough,
- *    because balanced iterations leave the barrier state unchanged).
+ * VerifySchedule rejects broken schedules at compile time: span
+ * coverage, cycle balance, and deadlock freedom under the mbarrier
+ * parity model.
  *
- * TODO: cluster launch control, while loops, 2-CTA GEMM, epilogue
- * sub-tiling, stage shifts on counter-tracked pipelines,
- * try_acquire/try_wait split sync entries, shared-barrier pipeline
- * groups.
+ * TODO: cluster launch control; data-dependent synchronization; 2-CTA
+ * GEMM; epilogue sub-tiling; stage shifts on counter-tracked
+ * pipelines; try_acquire/try_wait split sync entries; shared-barrier
+ * pipeline groups; else branches around ops and scope loops.
  */
 
 #include <tvm/arith/analyzer.h>
@@ -103,6 +85,7 @@
 
 #include "cuda/op/builtin.h"
 #include "cuda/op/copy.h"
+#include "layout/layout.h"
 #include "op/builtin.h"
 #include "op/copy.h"
 #include "op/gemm.h"
@@ -182,15 +165,10 @@ const Op &Tcgen05GemmOp() {
 
 // ---------------------------------------------------------------------------
 // QueryAccess: the buffers a statement reads and writes — the pass's
-// dependency oracle. Schedules declare no dataflow; pipeline membership,
-// arrive styles, and arrive counts are all derived from these operands.
-//
-// Tile ops report their own access regions (a gemm reads its accumulator
-// only when it does not clear it, say); granularity is the whole buffer
-// for now. Plain loads and stores count directly, except the
-// address-only root load inside a region argument, which would surface
-// write-only operands as reads. Global buffers are operands too — they
-// simply never resolve to a pipeline.
+// dependency oracle. Tile ops report their own access regions;
+// granularity is the whole buffer. Plain loads and stores count
+// directly, except address-only root loads (region / access_ptr
+// arguments), which are not data reads.
 // ---------------------------------------------------------------------------
 struct AccessSet {
   // Operand buffer -> defining pipeline: the pipeline protecting the
@@ -217,11 +195,11 @@ struct AccessSet {
   }
 };
 
-// Unions the statement's accesses into *acc. Region calls appear only as
-// tile-op arguments and are skipped: the owning op reports their
-// accesses, and their root loads are excluded from the plain-load pass.
+// Unions the statement's accesses into *acc. The owning tile op reports
+// a region argument's accesses; an access_ptr's rw mask says how the
+// intrinsic accesses its buffer.
 void QueryAccess(const Stmt &stmt, AccessSet *acc) {
-  std::unordered_set<BufferLoad, ObjectPtrHash, ObjectPtrEqual> region_roots;
+  std::unordered_set<BufferLoad, ObjectPtrHash, ObjectPtrEqual> address_roots;
   PostOrderVisit(stmt, [&](const ObjectRef &node) {
     const auto *call = node.as<CallNode>();
     if (!call)
@@ -229,7 +207,21 @@ void QueryAccess(const Stmt &stmt, AccessSet *acc) {
     if (call->op.same_as(RegionOp())) {
       const auto *load = call->args[0].as<BufferLoadNode>();
       ICHECK(load) << "ws_schedule: region arg0 must be a BufferLoad";
-      region_roots.insert(GetRef<BufferLoad>(load));
+      address_roots.insert(GetRef<BufferLoad>(load));
+      return;
+    }
+    if (call->op.same_as(access_ptr())) {
+      // access_ptr(base_load, extent, rw_mask)
+      const auto *load = call->args[0].as<BufferLoadNode>();
+      ICHECK(load) << "ws_schedule: access_ptr arg0 must be a BufferLoad";
+      address_roots.insert(GetRef<BufferLoad>(load));
+      const auto *mask = call->args[2].as<IntImmNode>();
+      ICHECK(mask) << "ws_schedule: access_ptr rw mask must be constant:\n"
+                   << GetRef<Call>(call);
+      if (mask->value & 1)
+        acc->reads.emplace(load->buffer, -1);
+      if (mask->value & 2)
+        acc->writes.emplace(load->buffer, -1);
       return;
     }
     TileOperator tile_op = ParseOperator(GetRef<Call>(call));
@@ -243,7 +235,7 @@ void QueryAccess(const Stmt &stmt, AccessSet *acc) {
   });
   PostOrderVisit(stmt, [&](const ObjectRef &node) {
     if (const auto *load = node.as<BufferLoadNode>()) {
-      if (!region_roots.count(GetRef<BufferLoad>(load)))
+      if (!address_roots.count(GetRef<BufferLoad>(load)))
         acc->reads.emplace(load->buffer, -1);
     } else if (const auto *store = node.as<BufferStoreNode>()) {
       acc->writes.emplace(store->buffer, -1);
@@ -253,26 +245,26 @@ void QueryAccess(const Stmt &stmt, AccessSet *acc) {
 
 // ---------------------------------------------------------------------------
 // Op atoms: which asynchronous instruction (if any) an op lowers to.
-// Classified once per op and consumed twice — arrive-count planning reads
-// each barrier side's completion signal off the atoms, and emission
-// converts the call — so planner and emitter cannot disagree.
-//  - kSync: synchronous compute; only the executing threads witness its
-//    completion, so they arrive per thread.
-//  - kTmaCopy: bulk-async copy; the data rides the barrier's transaction
-//    count. It only writes its destination, so it holds producer uses.
-//  - kTcgen05Gemm: asynchronous tensor core; one tcgen05.commit performs
-//    a single mbarrier arrive covering all outstanding MMAs.
+// Classified once and consumed by both arrive-count planning and call
+// conversion, so planner and emitter cannot disagree.
+//  - kSync: synchronous compute; arrives per thread.
+//  - kTmaCopy: bulk-async copy; the data rides the barrier's
+//    transaction count.
+//  - kTcgen05Gemm: one tcgen05.commit arrives once for all outstanding
+//    MMAs.
+//  - kCpAsyncCopy: a cp.async copy (T.async_copy or
+//    prefer_instruction="cp_async"); completion rides the commit
+//    entry's deferred per-thread cp.async.mbarrier.arrive.
 // ---------------------------------------------------------------------------
 enum class OpAtom : uint8_t {
   kSync = 0,
   kTmaCopy = 1,
   kTcgen05Gemm = 2,
+  kCpAsyncCopy = 3,
 };
 
 // Classify one call with the same instruction-selection helpers the
-// lowering uses: ClassifyWarpSpecializedProducerCopy applies the real
-// TMA legality rules (scope, swizzle, stride, dtype), and a gemm
-// accumulating in tensor memory lowers to the asynchronous tcgen05 path.
+// lowering uses, so the atom matches what the op actually lowers to.
 OpAtom ClassifyCall(const Call &call, const Target &target) {
   TileOperator tile_op = ParseOperator(call);
   if (!tile_op.defined())
@@ -280,7 +272,11 @@ OpAtom ClassifyCall(const Call &call, const Target &target) {
   if (const auto *copy = tile_op.as<CopyNode>()) {
     cuda::CopyInstSelection sel =
         cuda::ClassifyWarpSpecializedProducerCopy(*copy, target);
-    return cuda::CopyInstIsTMA(sel.inst) ? OpAtom::kTmaCopy : OpAtom::kSync;
+    if (cuda::CopyInstIsTMA(sel.inst))
+      return OpAtom::kTmaCopy;
+    if (cuda::CopyInstIsCPAsync(sel.inst))
+      return OpAtom::kCpAsyncCopy;
+    return OpAtom::kSync;
   }
   if (const auto *gemm = tile_op.as<GemmNode>()) {
     return gemm->cRegion_->buffer.scope() == "shared.tmem"
@@ -301,23 +297,20 @@ struct RoleSpec {
   int NregAction() const { return nreg >= kNregIncThreshold ? 1 : 0; }
 };
 
-// One schedulable op: declared by ParseSchedule (placed by exactly one
-// role in exactly one scope body), completed by RecordOpStmt with the
-// matched statement and its guard; later phases fill in the rest.
+// One schedulable op: declared by ParseSchedule, completed by
+// RecordOpStmt with the matched statement, filled in by later phases.
 struct OpInfo {
   String id;
-  Stmt stmt;                    // the single matched original statement
-  Optional<PrimExpr> guard;     // original guard, if any
-  AccessSet access;             // operands (whole buffers) and their defs
-  OpAtom atom = OpAtom::kSync;  // classified once by BuildOpAtoms
-  PipelineIndex write_def = -1; // the written operands' single def
-  RoleIndex role_idx = -1;      // the single owning role
-  ScopeIndex sched_scope = -1;  // scope whose body references this op
+  Stmt stmt;                     // the single matched original statement
+  Optional<PrimExpr> guard;      // original guard, if any
+  AccessSet access;              // operands (whole buffers) and their defs
+  OpAtom atom = OpAtom::kSync;   // classified once by BuildOpAtoms
+  PipelineIndex write_def = -1;  // the written operands' single def
+  std::set<RoleIndex> role_idxs; // the placing roles
+  ScopeIndex sched_scope = -1;   // scope whose body references this op
 };
 
-// Orders a pipeline's uses by op id: deterministic (pointer order varies
-// run to run), and one entry per op — an op signals a pipeline once no
-// matter how many of its operands the pipeline protects.
+// Orders a pipeline's uses by op id: deterministic, one entry per op.
 struct OpIdLess {
   bool operator()(const OpInfo *a, const OpInfo *b) const {
     return a->id < b->id;
@@ -325,25 +318,20 @@ struct OpIdLess {
 };
 using UseSet = std::set<const OpInfo *, OpIdLess>;
 
-// How one side (full or empty) of a pipeline's barrier pair is signaled.
-// An mbarrier phase completes only when the pending arrival count AND
-// the transaction count both reach zero, and the init count must be
-// >= 1. So:
-//  1. Collect the atoms of the signaling role's uses of the side
-//     (producer uses signal full, consumer uses signal empty) into the
-//     three flags below.
-//  2. Transactions alone cannot close the arrival side, so a
-//     transaction-only side falls back to the per-thread arrive. Then
-//       count = has_async_arrival + has_thread_arrive * role threads.
-// The commit/release entry emits exactly these arrivals: at most one
-// tcgen05.commit (covering all outstanding MMAs) plus at most one
-// per-thread ptx_arrive_barrier.
+// How one side (full or empty) of a pipeline's barrier pair is
+// signaled, derived from the atoms of the signaling role's uses:
+//   count = has_tcgen05_arrival
+//         + (has_cpasync_arrival + has_thread_arrive) * role threads.
+// The deferred cp.async arrive orders only the thread's prior cp.async
+// ops (PTX memory model, Program Order - Async Operations), so it never
+// replaces the plain per-thread arrive of synchronous work.
 struct BarrierSidePlan {
-  bool has_transaction = false;   // TMA transactions ride the tx-count
-  bool has_async_arrival = false; // one tcgen05.commit arrive::one covers all
-  bool has_thread_arrive = false; // per-thread arrive at the sync entry
-  RoleIndex signal_role_idx = -1; // the signaling role
-  int64_t count = 0;              // resulting mbarrier.init arrival count
+  bool has_transaction = false;     // TMA transactions ride the tx-count
+  bool has_tcgen05_arrival = false; // one tcgen05.commit covers all MMAs
+  bool has_cpasync_arrival = false; // per-thread deferred cp.async arrive
+  bool has_thread_arrive = false;   // per-thread arrive at the sync entry
+  RoleIndex signal_role_idx = -1;   // the signaling role
+  int64_t count = 0;                // resulting mbarrier.init arrival count
 };
 
 struct PipelineSpec {
@@ -377,16 +365,19 @@ struct BodyEntry {
 struct ScopeSpec {
   String id;
   For orig_loop; // undefined for the root scope (until matched, for others)
-  // The scope whose bodies reference this one (-1 for the root); unique,
-  // and checked against the loop's lexical parent during matching.
+  // Set when the scope is a T.ws_op-wrapped while loop: phases under it
+  // use runtime counters, and the condition must be role-uniform.
+  While orig_while;
+  // Source guard around the scope loop; must be role-uniform, so a
+  // false guard skips the scope's sync entries in all roles together.
+  Optional<PrimExpr> guard;
+  // The scope whose bodies reference this one (-1 for the root).
   ScopeIndex parent = -1;
-  // Per-role instruction sequence, indexed by role index (position in the
-  // warp-sorted roles_ vector); empty when the role has no body here.
+  // Per-role instruction sequence; empty when the role has no body here.
   std::vector<std::vector<BodyEntry>> bodies;
 
-  // The kernel's implicit root is the only scope without a loop:
-  // MatchKernel requires every other scope to match one.
-  bool IsRoot() const { return !orig_loop.defined(); }
+  // The implicit root is the only scope without a loop.
+  bool IsRoot() const { return !orig_loop.defined() && !orig_while.defined(); }
 };
 
 // ---------------------------------------------------------------------------
@@ -414,9 +405,8 @@ public:
 private:
   // ---- schedule parsing ---------------------------------------------------
 
-  // Resolve a schedule-referenced buffer to the block's own allocation. The
-  // schedule holds the buffer object captured at trace time; match by
-  // identity first, then by data var, then by name.
+  // Resolve a schedule-referenced buffer to the block's own
+  // allocation: by identity, then data var, then name.
   Buffer FindBlockBuffer(const Buffer &ref) {
     for (const Buffer &b : block_->alloc_buffers) {
       if (b.same_as(ref) || b->data.same_as(ref->data))
@@ -443,8 +433,8 @@ private:
     num_warps_ = static_cast<int>(sched->num_warps);
     ICHECK_GT(num_warps_, 0) << "ws_schedule: num_warps must be positive";
     ICHECK_EQ(num_warps_ % 4, 0)
-        << "ws_schedule: num_warps must be a multiple of 4 (setmaxnreg acts "
-           "on whole warpgroups), got "
+        << "ws_schedule: num_warps must be a multiple of 4 (warps are "
+           "managed in warpgroups of 4), got "
         << num_warps_;
 
     // Roles.
@@ -474,11 +464,9 @@ private:
           << roles_[i].warp_hi << ") have overlapping warp ranges";
     }
 
-    // setmaxnreg allocates registers for the whole warpgroup: all four
-    // warps 4g..4g+3 must request the same budget (or none of them any).
-    // Roles sharing a warpgroup must therefore agree on max_nreg; idle
-    // warps adopt their warpgroup's request, and a fully idle warpgroup
-    // donates down to the smallest donor budget.
+    // setmaxnreg allocates per warpgroup: roles sharing one must agree
+    // on max_nreg. Idle warps adopt their warpgroup's request; a fully
+    // idle warpgroup donates down to the smallest donor budget.
     warpgroup_nreg_.assign(num_warps_ / 4, -1); // -1 = no covering role
     for (const RoleSpec &r : roles_) {
       for (int w = r.warp_lo; w < r.warp_hi; ++w) {
@@ -506,9 +494,7 @@ private:
         v = donor;
     }
 
-    // Pipelines. Buffers are typed references; match them to the block's
-    // allocations by data var (the schedule may hold the pre-trace proxy of
-    // the same allocation).
+    // Pipelines.
     for (const WSPipeline &p : sched->pipelines) {
       PipelineSpec pipeline;
       pipeline.name = p->name;
@@ -554,11 +540,10 @@ private:
       scopes_.push_back(std::move(scope));
     }
 
-    // Classify body entries as op or child-scope references and validate
-    // the reference graph: an op is placed exactly once (its statement is
-    // cloned verbatim, so repetition would duplicate work); a child scope
-    // has exactly one parent scope, is entered at most once per role, and
-    // is never the root.
+    // Classify body entries as op or child-scope references and
+    // validate the reference graph: an op is placed in one scope, at
+    // most once per role; a child scope has one parent, is entered at
+    // most once per role, and is never the root.
     std::set<std::pair<ScopeIndex, RoleIndex>> scope_refs;
     for (size_t si = 0; si < scopes_.size(); ++si) {
       ScopeSpec &scope = scopes_[si];
@@ -593,26 +578,24 @@ private:
           if (it == ops_.end()) {
             OpInfo op;
             op.id = e.id;
-            op.role_idx = static_cast<RoleIndex>(ri);
+            op.role_idxs.insert(static_cast<RoleIndex>(ri));
             op.sched_scope = static_cast<ScopeIndex>(si);
             ops_.emplace(e.id, std::move(op));
           } else {
-            ICHECK_EQ(it->second.role_idx, static_cast<RoleIndex>(ri))
-                << "ws_schedule: op '" << e.id
-                << "' is scheduled by multiple roles";
             ICHECK_EQ(it->second.sched_scope, static_cast<ScopeIndex>(si))
                 << "ws_schedule: op '" << e.id
                 << "' is scheduled in multiple scopes";
-            LOG(FATAL) << "ws_schedule: op '" << e.id
-                       << "' is referenced more than once in the body of "
-                          "scope '"
-                       << scope.id << "'; an op is placed exactly once";
+            ICHECK(
+                it->second.role_idxs.insert(static_cast<RoleIndex>(ri)).second)
+                << "ws_schedule: op '" << e.id
+                << "' is referenced more than once in the body of scope '"
+                << scope.id << "' by role " << roles_[ri].name
+                << "; a role places an op at most once";
           }
         }
       }
     }
-    // An unreferenced scope would never be emitted, silently dropping the
-    // work its bodies schedule.
+    // An unreferenced scope would silently drop its scheduled work.
     for (const ScopeSpec &scope : scopes_) {
       ICHECK(scope.parent >= 0 || scope.id == kWSRootScopeId)
           << "ws_schedule: scope '" << scope.id
@@ -644,10 +627,8 @@ private:
   // ---- op matching --------------------------------------------------------
 
   // Walk the kernel body against the schedule. Coverage is two-sided:
-  // every declared op must match exactly one statement in its scheduling
-  // scope, every scope must find its loop, and — enforced in MatchTask —
-  // every kernel statement must carry an id, except inside op-node loops,
-  // which their loop's id covers.
+  // every declared op and scope must match a statement, and (enforced in
+  // MatchOp) every kernel statement must carry an id.
   void MatchKernel() {
     ScopeIndex root = ScopeIndexOf(kWSRootScopeId);
     ICHECK_GE(root, 0) << "ws_schedule: missing root scope";
@@ -657,21 +638,20 @@ private:
           << "ws_schedule: op '" << id
           << "' is scheduled but no statement in the kernel carries this id";
       QueryAccess(op.stmt, &op.access);
-      // A buffer read only by the op's guard is an operand too: it needs
-      // span protection and version rebinding like the body.
+      // Buffers read by the op's guard are operands too.
       if (op.guard.defined())
         QueryAccess(Evaluate(op.guard.value()), &op.access);
     }
     for (const ScopeSpec &scope : scopes_) {
-      ICHECK(scope.orig_loop.defined() || scope.id == kWSRootScopeId)
+      ICHECK(!scope.IsRoot() || scope.id == kWSRootScopeId)
           << "ws_schedule: scope '" << scope.id
           << "' has no matching loop in the kernel";
     }
   }
 
   void MatchScopeBody(ScopeIndex scope_idx, const Stmt &body) {
-    for (const Stmt &task : BodyStmts(body))
-      MatchTask(scope_idx, task, Optional<PrimExpr>());
+    for (const Stmt &stmt : BodyStmts(body))
+      MatchOp(scope_idx, stmt, Optional<PrimExpr>());
   }
 
   // The statements of a body: a SeqStmt's list, or the single statement
@@ -682,19 +662,25 @@ private:
     return {s};
   }
 
-  void RecordScopeLoop(ScopeIndex scope_idx, const For &loop) {
-    ICHECK(!scopes_[scope_idx].orig_loop.defined())
+  // A while scope has no extent: phases under it use runtime counters.
+  void RecordScopeWhileLoop(ScopeIndex scope_idx, const While &loop) {
+    ICHECK(scopes_[scope_idx].IsRoot())
         << "ws_schedule: scope " << scopes_[scope_idx].id << " matched twice";
-    // Any serial loop can be a scope (T.Pipelined is just a serial loop
-    // with a num_stages annotation, which this pass consumes — the
-    // software pipelining happens here). T.unroll / T.Parallel loops are
-    // single op nodes.
+    scopes_[scope_idx].orig_while = loop;
+    MatchScopeBody(scope_idx, loop->body);
+  }
+
+  void RecordScopeForLoop(ScopeIndex scope_idx, const For &loop) {
+    ICHECK(scopes_[scope_idx].IsRoot())
+        << "ws_schedule: scope " << scopes_[scope_idx].id << " matched twice";
+    // Any serial loop can be a scope (T.Pipelined is a serial loop with
+    // a num_stages annotation).
     ICHECK(loop->kind == ForKind::kSerial)
         << "ws_schedule: scope '" << scopes_[scope_idx].id
         << "' must be a serial loop (T.Pipelined or T.serial); T.unroll / "
            "T.Parallel loops are scheduled as single ops";
-    // Phases count iterations as (loop_var - min); a non-unit step would
-    // break version indices and parities. TODO: divide by the step.
+    // Phases count iterations as (loop_var - min); a non-unit step
+    // would break them. TODO: divide by the step.
     ICHECK(loop->HasTrivialStep())
         << "ws_schedule: scope '" << scopes_[scope_idx].id
         << "' has a non-unit loop step; write the loop with unit step and "
@@ -704,9 +690,7 @@ private:
   }
 
   // Consume the id marker as the statement is recorded, so the emitted
-  // clones never leak scheduling metadata downstream. Ids live in tile-op
-  // call annotations or loop annotations; the T.ws_op wrapper was already
-  // consumed by the matcher, so a recorded Bind carries nothing.
+  // clones never leak scheduling metadata downstream.
   static Stmt StripOpId(const Stmt &stmt) {
     if (const auto *ev = stmt.as<EvaluateNode>()) {
       const auto *call = ev->value.as<CallNode>();
@@ -752,22 +736,31 @@ private:
       op.guard = guard;
   }
 
-  void MatchTask(ScopeIndex scope_idx, const Stmt &task,
-                 Optional<PrimExpr> guard) {
+  void MatchOp(ScopeIndex scope_idx, const Stmt &stmt,
+               Optional<PrimExpr> guard) {
     ScopeSpec &scope = scopes_[scope_idx];
 
-    // A manual annotation (`with T.ws_op(id):`) for the one statement kind
-    // that cannot carry annotations= itself — the scalar Bind. The wrapper
-    // is consumed here; the op records the wrapped statement.
-    if (const auto *attr = task.as<AttrStmtNode>()) {
+    // A `with T.ws_op(id):` wrapper. With a scope id it wraps a while
+    // loop and opens that scope; otherwise the wrapped statements become
+    // ONE opaque op. The wrapper is consumed here.
+    if (const auto *attr = stmt.as<AttrStmtNode>()) {
       if (attr->attr_key == kWSOpIdKey) {
         String id = ExtractWSOpId(Any(attr->value));
-        ICHECK(!attr->body.as<SeqStmtNode>())
-            << "ws_schedule: T.ws_op('" << id << "') must annotate exactly "
-            << "one statement; every scheduled statement needs its own id";
-        ICHECK_LT(ScopeIndexOf(id), 0)
-            << "ws_schedule: scope id '" << id << "' belongs on the loop's "
-            << "own annotations, not on a T.ws_op wrapper";
+        ScopeIndex child = ScopeIndexOf(id);
+        if (child >= 0) {
+          const auto *wl = attr->body.as<WhileNode>();
+          ICHECK(wl) << "ws_schedule: scope id '" << id << "' on a T.ws_op "
+                     << "wrapper must wrap a while loop; serial loops carry "
+                     << "the id in their own annotations";
+          ICHECK_EQ(scopes_[child].parent, scope_idx)
+              << "ws_schedule: scope '" << id << "' lives in scope '"
+              << scope.id << "' of the kernel but is referenced from scope '"
+              << scopes_[scopes_[child].parent].id << "'";
+          if (guard.defined())
+            scopes_[child].guard = guard;
+          RecordScopeWhileLoop(child, GetRef<While>(wl));
+          return;
+        }
         RecordOpStmt(scope_idx, id, attr->body, guard);
         return;
       }
@@ -775,59 +768,56 @@ private:
                  << "' in kernel body";
     }
 
-    // Loop with a ws op id annotation. A serial loop whose id names a
-    // schedule scope opens that scope; any other annotated loop (T.unroll,
-    // T.Parallel) is one opaque op node — its body is cloned wholesale and
-    // statements inside it need no ids of their own.
-    if (const auto *loop = task.as<ForNode>()) {
+    // An annotated loop: a serial loop whose id names a scope opens
+    // that scope; any other annotated loop is one opaque op.
+    if (const auto *loop = stmt.as<ForNode>()) {
       if (auto id_ann = loop->annotations.Get(kWSOpIdKey)) {
         String id = ExtractWSOpId(id_ann.value());
         ScopeIndex child = ScopeIndexOf(id);
         if (child >= 0) {
-          ICHECK(!guard.defined())
-              << "ws_schedule: guarded scope loops are not supported";
           ICHECK_EQ(scopes_[child].parent, scope_idx)
               << "ws_schedule: scope '" << id << "' lives in scope '"
               << scope.id << "' of the kernel but is referenced from scope '"
               << scopes_[scopes_[child].parent].id << "'";
-          RecordScopeLoop(child, GetRef<For>(loop));
+          if (guard.defined())
+            scopes_[child].guard = guard;
+          RecordScopeForLoop(child, GetRef<For>(loop));
           return;
         }
-        RecordOpStmt(scope_idx, id, task, guard);
+        RecordOpStmt(scope_idx, id, stmt, guard);
         return;
       }
     }
 
-    // A single tile-op statement carrying its id in the call annotations
-    // is an op, treated as an opaque node.
-    if (const auto *ev = task.as<EvaluateNode>()) {
+    // A tile op carrying its id in the call annotations.
+    if (const auto *ev = stmt.as<EvaluateNode>()) {
       if (const auto *call = ev->value.as<CallNode>()) {
         if (auto id = call->annotations.Get(kWSOpIdKey)) {
-          RecordOpStmt(scope_idx, ExtractWSOpId(id.value()), task, guard);
+          RecordOpStmt(scope_idx, ExtractWSOpId(id.value()), stmt, guard);
           return;
         }
       }
     }
 
-    // Dig through source guards: an op inside an IfThenElse records the
-    // accumulated condition, which emission folds into its entry guard.
-    if (const auto *ite = task.as<IfThenElseNode>()) {
+    // An op inside an IfThenElse records the accumulated condition as
+    // its guard.
+    if (const auto *ite = stmt.as<IfThenElseNode>()) {
       ICHECK(!ite->else_case.defined())
           << "ws_schedule: else branches are not supported yet";
       PrimExpr cond =
           guard.defined() ? (guard.value() && ite->condition) : ite->condition;
       for (const Stmt &sub : BodyStmts(ite->then_case))
-        MatchTask(scope_idx, sub, cond);
+        MatchOp(scope_idx, sub, cond);
       return;
     }
 
-    // Nothing is silently dropped or implicitly replicated: every
-    // statement of a scheduled kernel must be placed by the schedule.
+    // Every statement of a scheduled kernel must be placed by the
+    // schedule; nothing is silently dropped or replicated.
     LOG(FATAL) << "ws_schedule: statement in scope '" << scope.id
                << "' carries no ws op id; tile ops and loops take "
                   "annotations={\"tl.ws_op_id\": ...}, other statements "
                   "(a scalar Bind) are wrapped in T.ws_op(...):\n"
-               << task;
+               << stmt;
   }
 
   // ---- planning -----------------------------------------------------------
@@ -862,11 +852,10 @@ private:
   // ---- def/use chains -------------------------------------------------------
 
   // Resolve each operand's defining pipeline and build the pipelines'
-  // reverse use sets. An op's written operands must all resolve to ONE
-  // pipeline: the completion signal behind a producer commit (a TMA
-  // transaction in particular is bound to a single mbarrier at issue
-  // time) can only trigger one. Read operands are unconstrained — one
-  // asynchronous commit may back releases of several pipelines.
+  // use sets. An op's written operands must all resolve to ONE pipeline
+  // (its completion signal can only trigger one); reads are
+  // unconstrained. An op placed by several roles must have NO
+  // pipeline-protected operands — duplicated accesses would race.
   void BuildUseChains() {
     for (auto &[id, op] : ops_) {
       Buffer write_buf;
@@ -895,6 +884,35 @@ private:
         def = it->second;
         pipelines_[def].consumers.insert(&op);
       }
+      if (op.role_idxs.size() > 1) {
+        std::set<PipelineIndex> defs = op.access.Defs();
+        ICHECK(defs.empty())
+            << "ws_schedule: op '" << id << "' is placed by "
+            << op.role_idxs.size() << " roles but touches buffer(s) of "
+            << "pipeline '" << pipelines_[*defs.begin()].name
+            << "'; only ops touching no pipeline buffers may be duplicated "
+               "across roles";
+      }
+    }
+    // A scope guard or while condition must not read pipeline buffers:
+    // it has to be uniform across roles.
+    for (const ScopeSpec &scope : scopes_) {
+      auto check_uniform = [&](const PrimExpr &expr, const char *what) {
+        AccessSet access;
+        QueryAccess(Evaluate(expr), &access);
+        for (const auto *operands : {&access.reads, &access.writes}) {
+          for (const auto &[buf, def] : *operands) {
+            ICHECK(!buffer_pipeline_.count(buf))
+                << "ws_schedule: the " << what << " of scope '" << scope.id
+                << "' touches pipeline buffer " << buf->name << "; it must "
+                << "be uniform across roles";
+          }
+        }
+      };
+      if (scope.guard.defined())
+        check_uniform(scope.guard.value(), "guard");
+      if (scope.orig_while.defined())
+        check_uniform(scope.orig_while->condition, "condition");
     }
   }
 
@@ -907,10 +925,10 @@ private:
         op.atom = ClassifyCall(Downcast<Call>(ev->value), target_);
         continue;
       }
-      // A compound statement (an op-node loop) stays synchronous; an
-      // asynchronous instruction nested inside one could not be wired to
-      // its barrier, so it is rejected. Plain reference locals: C++17
-      // lambdas cannot capture structured bindings.
+      // A compound statement (an op-node loop, a T.ws_op group) stays
+      // synchronous; a nested asynchronous instruction could not be
+      // wired to its barrier, so it is rejected. (Locals because C++17
+      // lambdas cannot capture structured bindings.)
       const String &op_id = id;
       const Stmt &stmt = op.stmt;
       PostOrderVisit(stmt, [&](const ObjectRef &node) {
@@ -926,9 +944,8 @@ private:
     }
   }
 
-  // Fill each pipeline's two BarrierSidePlans (see the struct comment):
-  // find the unique signaling role of each side, collect the atoms of
-  // its uses, and derive the arrival count.
+  // Fill each pipeline's two BarrierSidePlans: find the unique
+  // signaling role of each side and derive the count from its uses.
   void PlanArriveCounts() {
     // The signaling role of a side is the role holding its commit /
     // release entries; it must be unique.
@@ -961,30 +978,35 @@ private:
             producer_side ? pipeline.full_plan : pipeline.empty_plan;
         if (plan.signal_role_idx < 0)
           continue; // reported below
+        // Selects the signaling role's uses (such ops have exactly one
+        // placing role).
         for (const OpInfo *op : pipeline.Uses(producer_side)) {
-          if (op->role_idx != plan.signal_role_idx)
+          if (!op->role_idxs.count(plan.signal_role_idx))
             continue;
           switch (op->atom) {
           case OpAtom::kTmaCopy:
             plan.has_transaction = true;
             break;
           case OpAtom::kTcgen05Gemm:
-            plan.has_async_arrival = true;
+            plan.has_tcgen05_arrival = true;
+            break;
+          case OpAtom::kCpAsyncCopy:
+            plan.has_cpasync_arrival = true;
             break;
           case OpAtom::kSync:
             plan.has_thread_arrive = true;
             break;
           }
         }
-        // Transactions cannot close the arrival side by themselves;
-        // without any other arrival, fall back to the per-thread arrive.
-        if (plan.has_transaction && !plan.has_async_arrival &&
-            !plan.has_thread_arrive) {
+        // Transactions alone cannot complete a phase: a side with TMA
+        // copies keeps the per-thread arrive.
+        if (plan.has_transaction)
           plan.has_thread_arrive = true;
-        }
         const RoleSpec &role = roles_[plan.signal_role_idx];
-        plan.count = (plan.has_async_arrival ? 1 : 0) +
-                     (plan.has_thread_arrive ? role.NumThreads() : 0);
+        plan.count = (plan.has_tcgen05_arrival ? 1 : 0) +
+                     ((plan.has_cpasync_arrival ? 1 : 0) +
+                      (plan.has_thread_arrive ? 1 : 0)) *
+                         static_cast<int64_t>(role.NumThreads());
       }
     }
     for (PipelineSpec &pipeline : pipelines_) {
@@ -1000,18 +1022,11 @@ private:
   // A broken schedule would hang or race on the GPU; these checks reject
   // it at compile time instead.
 
-  // Per role: sync brackets must pair up (an acquire/wait opens a span,
-  // the matching commit/release closes it in the same scope body), a
-  // role is the producer or the consumer of a pipeline but never both (a
-  // role handing data to itself would need no pipeline), and every op
-  // must run inside an open span of each pipeline protecting one of its
-  // operands — an access outside the span races with the other side of
-  // the handshake, before the wait or after the release alike.
-  //
-  // A span covers reads and writes both: the flavor is the role's
-  // handshake direction, not the op's access direction (a consumer may
-  // write what it waited on, a producer may read what it acquired).
-  // Spans opened in an enclosing scope cover ops in child scopes.
+  // Per role: sync brackets must pair up within one scope body, a role
+  // is the producer or the consumer of a pipeline but never both, and
+  // every op must run inside an open span of each pipeline protecting
+  // one of its operands. Spans opened in an enclosing scope cover ops
+  // in child scopes.
   void VerifySpanCoverage() const {
     for (RoleIndex ri = 0; ri < static_cast<RoleIndex>(roles_.size()); ++ri) {
       std::map<PipelineIndex, bool> flavor; // pipeline -> role is producer
@@ -1062,7 +1077,7 @@ private:
                 << "'; bracket the op with producer_acquire/producer_commit "
                 << "or consumer_wait/consumer_release (the stage may be "
                 << "concurrently overwritten or still read by an "
-                << "asynchronous task)";
+                << "asynchronous op)";
           };
           for (const auto &[buf, def] : op.access.writes)
             check_operand(buf, def, "writes");
@@ -1080,13 +1095,9 @@ private:
   }
 
   // Within every loop scope, a pipeline's producer and consumer sides
-  // must cycle equally often per iteration: an imbalance drifts the
-  // full/empty parity further apart every trip, and a side whose
-  // counterpart cycles in a different loop diverges with the extents.
-  // Balance also makes each iteration leave the barrier state unchanged,
-  // which is what lets the deadlock model run every loop for just two
-  // iterations. Deliberately strict: schedules balanced only through
-  // particular loop extents are rejected too.
+  // must cycle equally often per iteration; an imbalance drifts the
+  // full/empty parity apart every trip. Balance also lets the deadlock
+  // model run every loop for just two iterations.
   void VerifyCycleBalance() const {
     for (size_t si = 0; si < scopes_.size(); ++si) {
       const ScopeSpec &scope = scopes_[si];
@@ -1112,14 +1123,10 @@ private:
     }
   }
 
-  // Flatten one role's sync entries into the order the emitted code
-  // executes them. Every loop is modeled for two iterations — warm-up
-  // plus one steady-state trip; VerifyCycleBalance makes further
-  // iterations replay the steady state — and the stage deltas reproduce
-  // the software-pipelined reordering rather than the textual order (an
-  // entry at delta d executes at steps d .. d + trips - 1). Sync entries
-  // are unconditional in the emitted code, so the model needs no
-  // conditional events.
+  // Flatten one role's sync entries into emitted-code order: loops are
+  // modeled for two iterations, and the stage deltas reproduce the
+  // software-pipelined reordering (an entry at delta d executes at
+  // steps d .. d + trips - 1).
   std::vector<SyncEntry> FlattenRoleEvents(RoleIndex role_idx) const {
     std::vector<SyncEntry> events;
     std::function<void(ScopeIndex)> emit = [&](ScopeIndex scope_idx) {
@@ -1134,7 +1141,7 @@ private:
         for (size_t i = 0; i < entries.size(); ++i) {
           if (!scope.IsRoot() &&
               (t < plan.delta[i] || t >= plan.delta[i] + trips))
-            continue; // outside this entry's boundary guards
+            continue; // outside this entry's step window
           const BodyEntry &e = entries[i];
           if (e.kind == BodyEntry::kScope)
             emit(ScopeIndexOf(e.id));
@@ -1147,16 +1154,11 @@ private:
     return events;
   }
 
-  // Execute all roles' sync events under the mbarrier parity model:
-  //  - a role's (k+1)-th wait on a pipeline is enabled once total commits
-  //    reach k+1 (the (k+1)-th full phase completed);
-  //  - its (k+1)-th acquire is enabled once depth + total releases reach
-  //    k+1 (the first `depth` acquires pass on the initial parity);
-  //  - commits and releases never block.
-  // Parity waits consume nothing and the totals only grow, so an enabled
-  // event can never become disabled: one greedy execution reaches the
-  // same end state as every interleaving, and a role still blocked at
-  // quiescence is a real hang, reported with its blocking event.
+  // Execute all roles' sync events under the mbarrier parity model: a
+  // role's (k+1)-th wait needs k+1 total commits, its (k+1)-th acquire
+  // needs depth + total releases >= k+1, commits/releases never block.
+  // Enabled events never become disabled, so one greedy execution
+  // suffices; a role still blocked at quiescence is a real hang.
   void VerifyDeadlockFree() const {
     int n_roles = static_cast<int>(roles_.size());
     std::vector<std::vector<SyncEntry>> events(n_roles);
@@ -1246,14 +1248,12 @@ private:
 
   // Per-entry stage offsets for one (role, scope) body. delta = stage -
   // s_min: an entry at delta d executes logical iteration (i - d) at
-  // loop step i, so the loop gains `shift` extra steps and per-entry
-  // boundary guards. A sync entry uses its own stage; an op or child
-  // scope takes the stage of the open spans covering the pipelines it
-  // touches, which must agree (a mix would make the loop-var
-  // substitution ambiguous); entries under no open span run at delta 0.
+  // step i. A sync entry uses its own stage; an op or child scope takes
+  // the stage of the open spans covering its pipelines (which must
+  // agree); entries under no open span run at delta 0.
   struct StagePlan {
     std::vector<int> delta; // per entry
-    int shift = 0;          // max delta; loop extent grows by this much
+    int shift = 0;          // max delta; unrolled steps on each side
   };
 
   StagePlan PlanStages(RoleIndex role_idx,
@@ -1269,9 +1269,8 @@ private:
     if (s_min == std::numeric_limits<int>::max())
       return plan; // no syncs in this body
 
-    // pipeline -> stage of its open span. Bracket pairing and role
-    // flavor exclusivity were verified (VerifySpanCoverage); only the
-    // pair's stage agreement is checked here, where stages live.
+    // pipeline -> stage of its open span; only the pair's stage
+    // agreement still needs checking here.
     std::map<PipelineIndex, int> pipeline_stage;
     auto span_delta = [&](const std::set<PipelineIndex> &touched_pipelines,
                           const String &what) -> int {
@@ -1352,13 +1351,20 @@ private:
     return phase.defined() ? phase : PrimExpr(IntImm(DataType::Int(32), 0));
   }
 
+  // Whether a scope or any of its ancestors is a while scope: no
+  // iteration expression exists there to linearize a phase against.
+  bool UnderWhileScope(ScopeIndex scope_idx) const {
+    for (ScopeIndex s = scope_idx; s >= 0; s = scopes_[s].parent) {
+      if (scopes_[s].orig_while.defined())
+        return true;
+    }
+    return false;
+  }
+
   // A (role, pipeline) pair needs a runtime phase counter when its
-  // cycles are not one-per-iteration of a single loop: sync points at
-  // several loop depths, or several cycles in one body — the loop-based
-  // phase would give such cycles the same version and parity. Counters
-  // are per (role, pipeline): sharing one between pipelines would
-  // require them to cycle in lockstep, since every read of the counter
-  // must see that pipeline's own completed-cycle count.
+  // cycles are not one-per-iteration of a single for loop: several
+  // cycles in one body, sync points at several loop depths, or any
+  // sync under a while scope.
   bool NeedsCounter(RoleIndex role_idx, PipelineIndex pipeline_idx) const {
     std::set<ScopeIndex> sync_scopes;
     bool multi_cycle = false;
@@ -1378,7 +1384,13 @@ private:
         multi_cycle = true;
     };
     scan(ScopeIndexOf(kWSRootScopeId));
-    return multi_cycle || sync_scopes.size() > 1;
+    if (multi_cycle || sync_scopes.size() > 1)
+      return true;
+    for (ScopeIndex s : sync_scopes) {
+      if (UnderWhileScope(s))
+        return true;
+    }
+    return false;
   }
 
   PrimExpr PipelinePhase(const RoleCtx &ctx, PipelineIndex pipeline_idx) const {
@@ -1394,18 +1406,26 @@ private:
              {BufferLoad(bar, {std::move(idx)}), std::move(parity)}));
   }
 
-  // Arrivals for one commit/release entry, per its side plan: at most
-  // one tcgen05.commit (covering all outstanding MMAs) plus at most one
-  // per-thread arrive — exactly plan.count arrivals per phase.
+  // Arrivals for one commit/release entry — exactly plan.count arrivals
+  // per phase.
   void MakeArrive(const PipelineSpec &pipeline, bool full, PrimExpr idx,
                   Array<Stmt> *out) const {
     const Buffer &bar = full ? pipeline.full : pipeline.empty;
     const BarrierSidePlan &plan =
         full ? pipeline.full_plan : pipeline.empty_plan;
-    if (plan.has_async_arrival) {
+    if (plan.has_tcgen05_arrival) {
       PrimExpr ptr = bar.access_ptr(3, DataType::Handle(), 1, idx);
       out->push_back(
           Evaluate(Call(DataType::Void(), tcgen05_mma_arrive(), {ptr})));
+    }
+    if (plan.has_cpasync_arrival) {
+      // Group the thread's outstanding cp.asyncs, then arrive deferred:
+      // the arrive fires once they complete.
+      out->push_back(
+          Evaluate(Call(DataType::Handle(), builtin::ptx_commit_group(), {})));
+      out->push_back(
+          Evaluate(Call(DataType::Handle(), ptx_cp_async_barrier_noinc(),
+                        {BufferLoad(bar, {idx})})));
     }
     if (plan.has_thread_arrive) {
       out->push_back(
@@ -1452,18 +1472,16 @@ private:
         : self(self), ctx(ctx) {}
 
     PrimExpr VersionIndex(const Buffer &orig) {
-      // versioned_ keys are pipeline buffers (PlanVersionedBuffers), and
-      // span coverage verified the op runs inside an open span, so the
-      // pipeline and its phase are always present.
+      // The pipeline and its phase are always present: versioned_ keys
+      // are pipeline buffers, and span coverage was verified.
       PipelineIndex p = self.buffer_pipeline_.at(orig);
       return floormod(ctx.pipeline_phase.at(p),
                       IntImm(DataType::Int(32), self.pipelines_[p].depth));
     }
 
     // The BufferLoad path below prepends the version index to a
-    // versioned region's root load; detect the extra index here and
-    // insert the matching unit extent to keep the region's
-    // indices-per-extent invariant.
+    // versioned region's root load; insert the matching unit extent to
+    // keep the region's indices-per-extent invariant.
     PrimExpr VisitExpr_(const CallNode *op) final {
       Call call = Downcast<Call>(StmtExprMutator::VisitExpr_(op));
       if (call->op.same_as(RegionOp()) && call->args.size() >= 2) {
@@ -1473,11 +1491,8 @@ private:
             Array<PrimExpr> args;
             args.push_back(call->args[0]);
             args.push_back(call->args[1]);
-            // The region is the op's footprint: origin = the root load's
-            // indices, size = the extents. The op touches exactly the ONE
-            // acquired version (origin phase % depth), so the version
-            // dimension's extent is 1 — the depth lives in the versioned
-            // buffer's shape, not here.
+            // The op touches exactly the one acquired version, so the
+            // version dimension's extent is 1.
             args.push_back(IntImm(DataType::Int(32), 1));
             for (size_t i = 2; i < call->args.size(); ++i)
               args.push_back(call->args[i]);
@@ -1525,19 +1540,17 @@ private:
     return rewriter(std::move(expr));
   }
 
-  // Swap an asynchronous atom's call to its explicit async op. The
-  // statement shape — a direct Evaluate of the call — was enforced by
-  // BuildOpAtoms.
+  // Rewrite an asynchronous atom's call: swap it to its explicit async
+  // op (TMA, tcgen05) or annotate it (cp.async).
   Stmt ConvertAtomCall(const RoleCtx &ctx, const OpInfo &op, Stmt stmt) const {
     const auto *ev = stmt.as<EvaluateNode>();
     ICHECK(ev);
     Call call = Downcast<Call>(ev->value);
     auto ann = call->annotations;
     if (op.atom == OpAtom::kTmaCopy) {
-      // The TMA transaction completes the full barrier of the pipeline
-      // protecting the destination: the op's single write def. A TMA copy
-      // into an unprotected buffer has no barrier to wire and stays a
-      // plain copy for the generic lowering.
+      // The transaction completes the full barrier of the pipeline
+      // protecting the destination. A copy into an unprotected buffer
+      // has no barrier to wire and stays a plain copy.
       if (op.write_def < 0)
         return stmt;
       const PipelineSpec &pipeline = pipelines_[op.write_def];
@@ -1548,6 +1561,13 @@ private:
       ann.Set("is_tma_copy", IntImm(DataType::Int(32), 1));
       return Evaluate(Call(call->dtype, TmaCopyOp(), call->args, std::move(ann),
                            call->span));
+    } else if (op.atom == OpAtom::kCpAsyncCopy) {
+      // Skip the copy's implicit commit_group + wait_group(0):
+      // completion rides the commit entry's deferred arrive instead.
+      ann.Set(attr::kAsyncCopyNoImplicitCommitWait,
+              IntImm(DataType::Int(32), 1));
+      return Evaluate(
+          Call(call->dtype, call->op, call->args, std::move(ann), call->span));
     } else if (op.atom == OpAtom::kTcgen05Gemm) {
       ann.Set("is_tcgen05", IntImm(DataType::Int(32), 1));
       return Evaluate(Call(call->dtype, Tcgen05GemmOp(), call->args,
@@ -1557,8 +1577,8 @@ private:
                << static_cast<int>(op.atom);
   }
 
-  // The op's source guard is NOT applied here: EmitScopeBody folds it into
-  // the entry's guard, combined with any stage boundary guard.
+  // The op's source guard is NOT applied here: EmitScopeBody folds it
+  // into the entry's guard.
   Stmt EmitOp(const RoleCtx &ctx, const OpInfo &op) const {
     Stmt body = RewriteOpStmt(ctx, Substitute(op.stmt, ctx.subs));
     if (op.atom != OpAtom::kSync)
@@ -1566,50 +1586,39 @@ private:
     return body;
   }
 
-  // Emit one (role, scope) body as a flat statement list for the caller
-  // to splice; a SeqStmt is built only where an IfThenElse needs a single
-  // body. `plan` holds the per-entry stage deltas; `loop_var` /
-  // `orig_extent` describe the enclosing loop (undefined for the root),
-  // whose chain level the caller has already pushed.
+  // Emit one (role, scope) body, keeping only entries with stage delta
+  // in [delta_lo, delta_hi] — prologue/epilogue steps select their
+  // slice of the software pipeline this way. `base` is the step
+  // expression of a for scope (an entry at delta d runs iteration
+  // base - d); undefined for the root and for while scopes.
   Array<Stmt> EmitScopeBody(RoleCtx &ctx, ScopeIndex scope_idx,
                             const StagePlan &plan,
-                            const Optional<Var> &loop_var,
-                            const Optional<PrimExpr> &orig_extent,
-                            const Var &orig_loop_var) {
+                            const Optional<PrimExpr> &base,
+                            const Var &orig_loop_var, int delta_lo,
+                            int delta_hi) {
     ScopeSpec &scope = scopes_[scope_idx];
     const std::vector<BodyEntry> &entries = scope.bodies[ctx.role_idx];
     if (entries.empty())
       return {};
-    if (plan.shift > 0) {
-      ICHECK(loop_var.defined())
-          << "ws_schedule: stage offsets require a loop scope, but scope "
-          << scope.id << " is the root";
-    }
 
     Array<Stmt> stmts;
 
-    // Point the substitution and phase chain at entry i's logical
-    // iteration and return its guard: the stage boundary condition
-    // combined with the op's own source guard (substituted with the
-    // shifted iteration and version-rebound like the body). Sync entries
-    // have no source guard.
+    // Point the substitution and phase chain at entry i's iteration
+    // and return its guard (iteration bound + the op's source guard).
     auto focus_entry = [&](size_t i) -> Optional<PrimExpr> {
       Optional<PrimExpr> guard;
-      if (loop_var.defined()) {
+      if (base.defined()) {
         int delta = plan.delta[i];
-        PrimExpr iter =
-            delta == 0 ? PrimExpr(loop_var.value())
-                       : loop_var.value() - IntImm(DataType::Int(32), delta);
+        PrimExpr iter = delta == 0
+                            ? base.value()
+                            : base.value() - IntImm(DataType::Int(32), delta);
         ctx.subs.Set(orig_loop_var, iter);
-        ctx.chain.back().iter = std::move(iter);
-        if (delta > 0)
-          guard = loop_var.value() >= IntImm(DataType::Int(32), delta);
-        if (delta < plan.shift) {
-          PrimExpr upper =
-              loop_var.value() <
-              orig_extent.value() + IntImm(DataType::Int(32), delta);
-          guard = guard.defined() ? guard.value() && upper : upper;
-        }
+        ctx.chain.back().iter = iter;
+        // A prologue step (finite delta window) bounds every entry by
+        // the loop extent, covering loops shorter than their shift;
+        // static bounds fold to constant guards the simplifier removes.
+        if (delta_hi < plan.shift)
+          guard = iter < ctx.chain.back().extent;
       }
       const BodyEntry &e = entries[i];
       if (e.kind == BodyEntry::kOp) {
@@ -1622,17 +1631,15 @@ private:
       }
       return guard;
     };
-    // Unguarded entries append straight to `stmts`; guarded entries keep
-    // emitting into `guarded` while the guard stays structurally
-    // identical, and the run closes as one IfThenElse when it changes.
+    // Runs of entries under a structurally identical guard close as one
+    // IfThenElse.
     Optional<PrimExpr> cur_guard;
     Array<Stmt> guarded;
     StructuralEqual structural_equal;
     auto close_guard = [&]() {
       if (cur_guard.defined() && !guarded.empty()) {
-        stmts.push_back(IfThenElse(
-            cur_guard.value(),
-            guarded.size() == 1 ? guarded[0] : SeqStmt(std::move(guarded))));
+        stmts.push_back(
+            IfThenElse(cur_guard.value(), SeqOrSingle(std::move(guarded))));
       }
       cur_guard = Optional<PrimExpr>();
       guarded = Array<Stmt>();
@@ -1640,6 +1647,8 @@ private:
 
     for (size_t i = 0; i < entries.size(); ++i) {
       const BodyEntry &e = entries[i];
+      if (plan.delta[i] < delta_lo || plan.delta[i] > delta_hi)
+        continue;
       Optional<PrimExpr> guard = focus_entry(i);
       bool reuse = guard.defined() == cur_guard.defined() &&
                    (!guard.defined() ||
@@ -1660,53 +1669,151 @@ private:
       }
     }
     close_guard();
-    // Restore the unshifted iteration for any parent-level use.
-    if (loop_var.defined()) {
-      ctx.subs.Set(orig_loop_var, loop_var.value());
-      ctx.chain.back().iter = loop_var.value();
+    // Restore the steady-state iteration for any parent-level use.
+    if (base.defined()) {
+      ctx.subs.Set(orig_loop_var, base.value());
+      ctx.chain.back().iter = base.value();
     }
     return stmts;
   }
 
+  static Stmt SeqOrSingle(Array<Stmt> stmts) {
+    return stmts.size() == 1 ? stmts[0] : SeqStmt(std::move(stmts));
+  }
+
+  // Emit one child scope for the current role. A stage shift is
+  // unrolled explicitly, so no per-iteration boundary check remains in
+  // the steady-state loop:
+  //   prologue step t (t = 0 .. shift-1): the entries at delta <= t;
+  //   steady state:                       every entry, unguarded;
+  //   epilogue step t (t = 1 .. shift):   the entries at delta >= t.
   Stmt EmitChildScope(RoleCtx &ctx, ScopeIndex scope_idx) {
     ScopeSpec &scope = scopes_[scope_idx];
-    // Matched (MatchKernel): every non-root scope has its kernel loop.
-    const For &orig = scope.orig_loop;
-
     if (scope.bodies[ctx.role_idx].empty())
-      return Stmt();
-
-    // The loop extent may need to grow by the scope's stage shift.
+      return Stmt(); // role does not participate in this scope
     StagePlan plan = PlanStages(ctx.role_idx, scope.bodies[ctx.role_idx]);
+    Stmt out = scope.orig_while.defined()
+                   ? EmitChildScopeWhileLoop(ctx, scope_idx, plan)
+                   : EmitChildScopeForLoop(ctx, scope_idx, plan);
+    // The uniform source guard: false skips the scope in all roles
+    // together.
+    if (scope.guard.defined()) {
+      out = IfThenElse(
+          RewriteOpExpr(ctx, Substitute(scope.guard.value(), ctx.subs)),
+          std::move(out));
+    }
+    return out;
+  }
 
-    Var fresh(orig->loop_var->name_hint, orig->loop_var->dtype);
-    ctx.subs.Set(orig->loop_var, fresh);
+  // For scope: prologue step t runs iterations t - delta, the steady
+  // state covers [shift, extent), and epilogue step t runs iterations
+  // extent + t - 1 - delta iff extent > shift - t. Short and dynamic
+  // extents are handled by the emitted bounds alone; the simplifier
+  // folds the static cases.
+  Stmt EmitChildScopeForLoop(RoleCtx &ctx, ScopeIndex scope_idx,
+                             const StagePlan &plan) {
+    ScopeSpec &scope = scopes_[scope_idx];
+    constexpr int kMaxDelta = std::numeric_limits<int>::max();
+    PrimExpr zero = IntImm(DataType::Int(32), 0);
+
+    const For &orig = scope.orig_loop;
+    const Var &orig_var = orig->loop_var;
+    Var fresh(orig_var->name_hint, orig_var->dtype);
+    ctx.subs.Set(orig_var, fresh);
     PrimExpr extent = Substitute(orig->extent, ctx.subs);
     PrimExpr min = Substitute(orig->min, ctx.subs);
     if (plan.shift > 0) {
-      ICHECK(is_zero(orig->min))
+      ICHECK(is_zero(min))
           << "ws_schedule: stage offsets require 0-based loops";
     }
     ctx.chain.push_back({fresh, extent, min});
+
+    Array<Stmt> result;
+    for (int t = 0; t < plan.shift; ++t) {
+      Array<Stmt> step = EmitScopeBody(
+          ctx, scope_idx, plan, IntImm(DataType::Int(32), t), orig_var, 0, t);
+      for (const Stmt &stmt : step)
+        result.push_back(stmt);
+    }
+
     Array<Stmt> body =
-        EmitScopeBody(ctx, scope_idx, plan, fresh, extent, orig->loop_var);
-    ctx.chain.pop_back();
-    if (body.empty())
-      return Stmt(); // role does not participate in this scope
-    PrimExpr emit_extent = plan.shift > 0
-                               ? extent + IntImm(DataType::Int(32), plan.shift)
-                               : extent;
-    // Preserve the source loop kind (e.g. an unrolled epilogue subtile loop)
-    // and its annotations, minus the consumed scheduling markers.
+        EmitScopeBody(ctx, scope_idx, plan, fresh, orig_var, 0, kMaxDelta);
+    // The steady state covers iterations [shift, extent). Preserve the
+    // source loop kind and annotations, minus the consumed markers.
     Map<String, Any> ann =
-        FilterAnnotations(orig->annotations, [](const String &key) {
-          return key != kWSOpIdKey && key != "num_stages" &&
-                 key.find("tl_pipeline_") != 0;
+        FilterAnnotations(scope.orig_loop->annotations, [](const String &k) {
+          return k != kWSOpIdKey && k != "num_stages" &&
+                 k.find("tl_pipeline_") != 0;
         });
-    return For(fresh, Substitute(orig->min, ctx.subs), std::move(emit_extent),
-               orig->kind,
-               body.size() == 1 ? body[0] : SeqStmt(std::move(body)),
-               std::nullopt, std::move(ann));
+    PrimExpr loop_min =
+        plan.shift > 0 ? PrimExpr(IntImm(DataType::Int(32), plan.shift)) : min;
+    PrimExpr loop_extent =
+        plan.shift > 0 ? max(extent - plan.shift, zero) : extent;
+    result.push_back(For(fresh, std::move(loop_min), std::move(loop_extent),
+                         scope.orig_loop->kind, SeqOrSingle(std::move(body)),
+                         std::nullopt, std::move(ann)));
+
+    for (int t = 1; t <= plan.shift; ++t) {
+      Array<Stmt> step = EmitScopeBody(
+          ctx, scope_idx, plan, extent + IntImm(DataType::Int(32), t - 1),
+          orig_var, t, kMaxDelta);
+      // The step runs iff extent > shift - t.
+      result.push_back(
+          IfThenElse(IntImm(DataType::Int(32), plan.shift - t) < extent,
+                     SeqOrSingle(std::move(step))));
+    }
+    ctx.chain.pop_back();
+    return SeqOrSingle(std::move(result));
+  }
+
+  // While scope: no iteration expression (phases under it are runtime
+  // counters). Prologue steps run under the loop condition and bump a
+  // completed-trip counter; epilogue step t runs iff t <= trips, which
+  // drains exactly what a short loop started.
+  Stmt EmitChildScopeWhileLoop(RoleCtx &ctx, ScopeIndex scope_idx,
+                               const StagePlan &plan) {
+    ScopeSpec &scope = scopes_[scope_idx];
+    constexpr int kMaxDelta = std::numeric_limits<int>::max();
+    PrimExpr zero = IntImm(DataType::Int(32), 0);
+    // The condition is re-evaluated at every use.
+    auto cond = [&]() {
+      return RewriteOpExpr(ctx,
+                           Substitute(scope.orig_while->condition, ctx.subs));
+    };
+
+    Array<Stmt> result;
+    Buffer trips;
+    if (plan.shift > 0) {
+      trips = decl_buffer({IntImm(DataType::Int(32), 1)}, DataType::Int(32),
+                          scope.id + "_trips", "local");
+      result.push_back(AllocBuffer(trips));
+      result.push_back(BufferStore(trips, zero, {zero}));
+    }
+    auto bump_trips = [&]() {
+      return BufferStore(trips, BufferLoad(trips, {zero}) + 1, {zero});
+    };
+
+    for (int t = 0; t < plan.shift; ++t) {
+      Array<Stmt> step = EmitScopeBody(ctx, scope_idx, plan,
+                                       Optional<PrimExpr>(), Var(), 0, t);
+      step.push_back(bump_trips());
+      result.push_back(IfThenElse(cond(), SeqOrSingle(std::move(step))));
+    }
+
+    Array<Stmt> body = EmitScopeBody(ctx, scope_idx, plan, Optional<PrimExpr>(),
+                                     Var(), 0, kMaxDelta);
+    if (plan.shift > 0)
+      body.push_back(bump_trips());
+    result.push_back(While(cond(), SeqOrSingle(std::move(body))));
+
+    for (int t = 1; t <= plan.shift; ++t) {
+      Array<Stmt> step = EmitScopeBody(
+          ctx, scope_idx, plan, Optional<PrimExpr>(), Var(), t, kMaxDelta);
+      result.push_back(
+          IfThenElse(IntImm(DataType::Int(32), t) <= BufferLoad(trips, {zero}),
+                     SeqOrSingle(std::move(step))));
+    }
+    return SeqOrSingle(std::move(result));
   }
 
   Stmt EmitRole(RoleIndex role_idx) {
@@ -1723,7 +1830,7 @@ private:
                          IntImm(DataType::Int(32), role.NregAction())})));
     }
 
-    // Materialize runtime phase counters where linearization is unsound.
+    // Runtime phase counters where linearization is unsound.
     for (PipelineIndex p = 0; p < static_cast<PipelineIndex>(pipelines_.size());
          ++p) {
       bool used = false;
@@ -1745,18 +1852,20 @@ private:
 
     ScopeIndex root = ScopeIndexOf(kWSRootScopeId);
     StagePlan plan = PlanStages(role_idx, scopes_[root].bodies[role_idx]);
-    Array<Stmt> body = EmitScopeBody(ctx, root, plan, Optional<Var>(),
-                                     Optional<PrimExpr>(), Var());
+    ICHECK_EQ(plan.shift, 0)
+        << "ws_schedule: stage offsets require a loop scope; role " << role.name
+        << " has offset sync stages in its root body";
+    Array<Stmt> body = EmitScopeBody(ctx, root, plan, Optional<PrimExpr>(),
+                                     Var(), 0, std::numeric_limits<int>::max());
     ICHECK(!body.empty()) << "ws_schedule: role " << role.name
                           << " has an empty root body";
     for (const Stmt &s : body)
       stmts.push_back(s);
-    // The role branch is one arm of an IfThenElse: inline seq-wrap.
-    return stmts.size() == 1 ? stmts[0] : SeqStmt(std::move(stmts));
+    return SeqOrSingle(std::move(stmts));
   }
 
-  // Idle warps execute their warpgroup's register request
-  // (warpgroup_nreg_); a no-op when the warpgroup requests nothing.
+  // Idle warps execute their warpgroup's register request; a no-op
+  // when it requests nothing.
   Stmt EmitIdle(int nreg) const {
     if (nreg == 0)
       return Evaluate(IntImm(DataType::Int(32), 0));
@@ -1766,9 +1875,9 @@ private:
               IntImm(DataType::Int(32), nreg >= kNregIncThreshold ? 1 : 0)}));
   }
 
-  // Emit the `if (tx < ...)` role branches ordered by warp range, filling
-  // gaps with idle branches — split where the warpgroup register request
-  // changes, so every idle warp executes exactly its warpgroup's request.
+  // Emit the `if (tx < ...)` role branches ordered by warp range,
+  // filling gaps with idle branches split by warpgroup register
+  // request.
   Stmt EmitRoleBranches() {
     Array<Stmt> branches;
     Array<PrimExpr> conds;
@@ -1801,9 +1910,8 @@ private:
     return body;
   }
 
-  // Rebuild the block around the emitted body: versioned buffer
-  // replacements, barrier allocations with their derived init counts, and
-  // the consumed schedule annotation removed.
+  // Rebuild the block: versioned buffers, barrier allocations with
+  // their init counts, the consumed schedule annotation removed.
   SBlock RebuildBlock(Stmt body) {
     Array<Buffer> allocs;
     for (const Buffer &buf : block_->alloc_buffers) {
@@ -1839,6 +1947,24 @@ private:
         barrier_init.Set(var, counts);
     }
     ann.Set("barrier_init", std::move(barrier_init));
+    // Annotated layouts of versioned buffers gain the version
+    // dimension too.
+    if (auto lm_ref = ann.Get(attr::kLayoutMap)) {
+      if (auto lm_opt = lm_ref.value().as<Map<Var, Layout>>()) {
+        Map<Var, Layout> layout_map = lm_opt.value();
+        bool changed = false;
+        for (const auto &[orig, versioned] : versioned_) {
+          auto entry = layout_map.Get(orig->data);
+          if (!entry.has_value())
+            continue;
+          layout_map.Set(orig->data,
+                         entry.value()->Expand({versioned->shape[0]}));
+          changed = true;
+        }
+        if (changed)
+          ann.Set(attr::kLayoutMap, layout_map);
+      }
+    }
     n->annotations = std::move(ann);
     return new_block;
   }
@@ -1853,18 +1979,15 @@ private:
   std::vector<PipelineSpec> pipelines_;
   std::vector<ScopeSpec> scopes_;
   std::map<String, OpInfo> ops_;
-  // Per-warpgroup register request (index = warp / 4, 0 = none), agreed
-  // on by every covering role; idle warps execute it too.
+  // Per-warpgroup register request (index = warp / 4, 0 = none).
   std::vector<int> warpgroup_nreg_;
   BufferDefMap buffer_pipeline_;
   BufferVersionMap versioned_;
 };
 
-// Rewrite every schedule-annotated SBlock in place — a function may hold
-// several kernels, each with its own schedule. Tracking the threadIdx.x
-// binding on the way down hands each materializer the binding that
-// actually encloses its block, and exactly that binding is widened to
-// that schedule's warp count on the way back up.
+// Rewrite every schedule-annotated SBlock in place — a function may
+// hold several kernels, each with its own schedule. The enclosing
+// threadIdx.x binding is widened to each schedule's warp count.
 class WSScheduleRewriter : public StmtMutator {
 public:
   explicit WSScheduleRewriter(Optional<Target> target)
@@ -1886,8 +2009,7 @@ public:
         thread_iv_ = {};
         return attr;
       }
-      // Warp roles partition threadIdx.x only: a scheduled block under a
-      // multi-dimensional thread launch would mis-assign warps.
+      // Warp roles partition threadIdx.x only.
       if (iv->thread_tag == "threadIdx.y" || iv->thread_tag == "threadIdx.z") {
         bool saved = multi_dim_threads_;
         multi_dim_threads_ = multi_dim_threads_ || !is_one(op->value);
@@ -1925,10 +2047,7 @@ private:
   int new_extent_ = -1;
 };
 
-// Schedule and op ids come together (both present or neither): a function
-// without the schedule annotation is returned untouched, and the
-// materializer consumes the ids of a scheduled kernel as it clones the
-// statements.
+// A function without a schedule annotation is returned untouched.
 PrimFunc MaterializeWSScheduleImpl(PrimFunc f) {
   WSScheduleRewriter rewriter(f->GetAttr<Target>(tvm::attr::kTarget));
   Stmt body = rewriter(f->body);

--- a/src/cuda/transform/materialize_ws_schedule.cc
+++ b/src/cuda/transform/materialize_ws_schedule.cc
@@ -767,8 +767,18 @@ private:
         RecordOpStmt(scope_idx, id, attr->body, guard);
         return;
       }
-      LOG(FATAL) << "ws_schedule: unexpected AttrStmt '" << attr->attr_key
-                 << "' in kernel body";
+      // Kernel-level metadata (T.use_swizzle,
+      // T.annotate_min_blocks_per_sm, ...) wraps the statements that
+      // follow it. Record the wrapper, keep matching inside it, and
+      // re-wrap the rebuilt kernel body (RebuildBlock).
+      ICHECK(scope.id == kWSRootScopeId && !guard.defined())
+          << "ws_schedule: AttrStmt '" << attr->attr_key
+          << "' must be at the top level of the kernel:\n"
+          << stmt;
+      metadata_attrs_.push_back(GetRef<AttrStmt>(attr));
+      for (const Stmt &sub : BodyStmts(attr->body))
+        MatchOp(scope_idx, sub, guard);
+      return;
     }
 
     // An annotated loop: a serial loop whose id names a scope opens
@@ -1916,6 +1926,13 @@ private:
   // Rebuild the block: versioned buffers, barrier allocations with
   // their init counts, the consumed schedule annotation removed.
   SBlock RebuildBlock(Stmt body) {
+    // Re-wrap the kernel-level metadata attrs consumed during matching.
+    for (auto it = metadata_attrs_.rbegin(); it != metadata_attrs_.rend();
+         ++it) {
+      AttrStmt attr = *it;
+      attr.CopyOnWrite()->body = std::move(body);
+      body = attr;
+    }
     Array<Buffer> allocs;
     for (const Buffer &buf : block_->alloc_buffers) {
       auto vit = versioned_.find(buf);
@@ -1982,6 +1999,8 @@ private:
   std::vector<PipelineSpec> pipelines_;
   std::vector<ScopeSpec> scopes_;
   std::map<String, OpInfo> ops_;
+  // Kernel-level metadata AttrStmts, re-wrapped around the rebuilt body.
+  std::vector<AttrStmt> metadata_attrs_;
   // Per-warpgroup register request (index = warp / 4, 0 = none).
   std::vector<int> warpgroup_nreg_;
   BufferDefMap buffer_pipeline_;

--- a/src/cuda/transform/materialize_ws_schedule.cc
+++ b/src/cuda/transform/materialize_ws_schedule.cc
@@ -272,6 +272,9 @@ OpAtom ClassifyCall(const Call &call, const Target &target) {
   if (const auto *copy = tile_op.as<CopyNode>()) {
     cuda::CopyInstSelection sel =
         cuda::ClassifyWarpSpecializedProducerCopy(*copy, target);
+    ICHECK(sel.supported)
+        << "ws_schedule: producer copy instruction selection failed: "
+        << sel.reason;
     if (cuda::CopyInstIsTMA(sel.inst))
       return OpAtom::kTmaCopy;
     if (cuda::CopyInstIsCPAsync(sel.inst))

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -5,8 +5,11 @@
  */
 
 #include "./transform/common/attr.h"
+#include "./transform/common/warp_specialize.h"
 #include "op/builtin.h"
 #include "support/check.h"
+#include <tvm/ffi/reflection/creator.h>
+#include <tvm/ffi/reflection/enum_def.h>
 #include <tvm/ir/cast.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/tirx/stmt.h>
@@ -100,7 +103,8 @@ ForFrame PipelinedFor(PrimExpr start, const PrimExpr &stop, int num_stages,
                       const Array<PrimExpr> &order,
                       const Array<PrimExpr> &stages,
                       const Array<Array<PrimExpr>> &sync,
-                      const Array<Array<PrimExpr>> &groups) {
+                      const Array<Array<PrimExpr>> &groups,
+                      const Map<String, Any> &annotations) {
   using namespace tvm::tirx;
   ObjectPtr<ForFrameNode> n = make_object<ForFrameNode>();
   DataType dtype = stop.dtype();
@@ -112,7 +116,7 @@ ForFrame PipelinedFor(PrimExpr start, const PrimExpr &stop, int num_stages,
     ICHECK_EQ(vars.size(), doms.size());
     int n = vars.size();
     ICHECK(n == 1);
-    Map<String, Any> anno;
+    Map<String, Any> anno = annotations;
     if (num_stages > 0)
       anno.Set("num_stages", PrimExpr(num_stages));
     if (!order.empty())
@@ -392,6 +396,165 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def("tl.SideEffect", tirx::SideEffect);
   KernelLaunchFrameNode::RegisterReflection();
   WarpSpecializeFrameNode::RegisterReflection();
+}
+
+// ---------------------------------------------------------------------------
+// Warp-specialization schedule objects (transform/common/warp_specialize.h).
+// These are frontend IR constructs, not transformations: T.WSSchedule and
+// friends are built by the tracer and attached as a block annotation for the
+// MaterializeWSSchedule pass to consume.
+// ---------------------------------------------------------------------------
+
+WSRole::WSRole(String name, int64_t warp_lo, int64_t warp_hi,
+               int64_t max_nreg) {
+  auto n = make_object<WSRoleNode>();
+  n->name = std::move(name);
+  n->warp_lo = warp_lo;
+  n->warp_hi = warp_hi;
+  n->max_nreg = max_nreg;
+  data_ = std::move(n);
+}
+
+void WSRoleNode::RegisterReflection() {
+  namespace refl = reflection;
+  refl::ObjectDef<WSRoleNode>()
+      .def_ro("name", &WSRoleNode::name)
+      .def_ro("warp_lo", &WSRoleNode::warp_lo)
+      .def_ro("warp_hi", &WSRoleNode::warp_hi)
+      .def_ro("max_nreg", &WSRoleNode::max_nreg);
+}
+
+WSPipeline::WSPipeline(String name, Array<tirx::Buffer> buffers,
+                       int64_t depth) {
+  auto n = make_object<WSPipelineNode>();
+  n->name = std::move(name);
+  n->buffers = std::move(buffers);
+  n->depth = depth;
+  data_ = std::move(n);
+}
+
+void WSPipelineNode::RegisterReflection() {
+  namespace refl = reflection;
+  refl::ObjectDef<WSPipelineNode>()
+      .def_ro("name", &WSPipelineNode::name)
+      .def_ro("buffers", &WSPipelineNode::buffers)
+      .def_ro("depth", &WSPipelineNode::depth);
+}
+
+void WSInstrNode::RegisterReflection() {
+  namespace refl = reflection;
+  refl::ObjectDef<WSInstrNode>();
+}
+
+WSOpRef::WSOpRef(String id) {
+  auto n = make_object<WSOpRefNode>();
+  n->id = std::move(id);
+  data_ = std::move(n);
+}
+
+void WSOpRefNode::RegisterReflection() {
+  namespace refl = reflection;
+  refl::ObjectDef<WSOpRefNode>().def_ro("id", &WSOpRefNode::id);
+}
+
+WSSync::WSSync(WSSyncKind kind, String pipeline, int64_t stage) {
+  auto n = make_object<WSSyncNode>();
+  n->kind = std::move(kind);
+  n->pipeline = std::move(pipeline);
+  n->stage = stage;
+  data_ = std::move(n);
+}
+
+void WSSyncNode::RegisterReflection() {
+  namespace refl = reflection;
+  refl::ObjectDef<WSSyncNode>()
+      .def_ro("kind", &WSSyncNode::kind)
+      .def_ro("pipeline", &WSSyncNode::pipeline)
+      .def_ro("stage", &WSSyncNode::stage);
+}
+
+WSScope::WSScope(String id, Map<String, Array<WSInstr>> bodies) {
+  auto n = make_object<WSScopeNode>();
+  n->id = std::move(id);
+  n->bodies = std::move(bodies);
+  data_ = std::move(n);
+}
+
+void WSScopeNode::RegisterReflection() {
+  namespace refl = reflection;
+  refl::ObjectDef<WSScopeNode>()
+      .def_ro("id", &WSScopeNode::id)
+      .def_ro("bodies", &WSScopeNode::bodies);
+}
+
+WSSchedule::WSSchedule(int64_t num_warps, Array<WSRole> roles,
+                       Array<WSPipeline> pipelines, Array<WSScope> scopes) {
+  auto n = make_object<WSScheduleNode>();
+  n->num_warps = num_warps;
+  n->roles = std::move(roles);
+  n->pipelines = std::move(pipelines);
+  n->scopes = std::move(scopes);
+  data_ = std::move(n);
+}
+
+void WSScheduleNode::RegisterReflection() {
+  namespace refl = reflection;
+  refl::ObjectDef<WSScheduleNode>()
+      .def_ro("num_warps", &WSScheduleNode::num_warps)
+      .def_ro("roles", &WSScheduleNode::roles)
+      .def_ro("pipelines", &WSScheduleNode::pipelines)
+      .def_ro("scopes", &WSScheduleNode::scopes);
+}
+
+// Register the sync-kind enum and its variants. Declaration order fixes the
+// dense ordinals (0..3) consumed by WSSyncKind::CanonicalOrdinal().
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = reflection;
+  // EnumObj subclasses have no __ffi_init__; allocate via init(false).
+  refl::ObjectDef<WSSyncKindObj>(
+      refl::init(false)); // NOLINT(bugprone-unused-raii)
+  refl::TypeAttrDef<WSSyncKindObj>().def(
+      refl::type_attr::kConvert,
+      &refl::details::FFIConvertFromAnyViewToObjectRef<WSSyncKind>);
+  refl::EnumDef<WSSyncKindObj>("PRODUCER_ACQUIRE"); // ordinal 0
+  refl::EnumDef<WSSyncKindObj>("PRODUCER_COMMIT");  // ordinal 1
+  refl::EnumDef<WSSyncKindObj>("CONSUMER_WAIT");    // ordinal 2
+  refl::EnumDef<WSSyncKindObj>("CONSUMER_RELEASE"); // ordinal 3
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = reflection;
+  WSRoleNode::RegisterReflection();
+  WSPipelineNode::RegisterReflection();
+  WSInstrNode::RegisterReflection();
+  WSOpRefNode::RegisterReflection();
+  WSSyncNode::RegisterReflection();
+  WSScopeNode::RegisterReflection();
+  WSScheduleNode::RegisterReflection();
+  refl::GlobalDef()
+      .def("tl.WSRole",
+           [](String name, int64_t warp_lo, int64_t warp_hi, int64_t max_nreg) {
+             return WSRole(std::move(name), warp_lo, warp_hi, max_nreg);
+           })
+      .def("tl.WSPipeline",
+           [](String name, Array<tirx::Buffer> buffers, int64_t depth) {
+             return WSPipeline(std::move(name), std::move(buffers), depth);
+           })
+      .def("tl.WSOpRef", [](String id) { return WSOpRef(std::move(id)); })
+      .def("tl.WSSync",
+           [](WSSyncKind kind, String pipeline, int64_t stage) {
+             return WSSync(std::move(kind), std::move(pipeline), stage);
+           })
+      .def("tl.WSScope",
+           [](String id, Map<String, Array<WSInstr>> bodies) {
+             return WSScope(std::move(id), std::move(bodies));
+           })
+      .def("tl.WSSchedule",
+           [](int64_t num_warps, Array<WSRole> roles,
+              Array<WSPipeline> pipelines, Array<WSScope> scopes) {
+             return WSSchedule(num_warps, std::move(roles),
+                               std::move(pipelines), std::move(scopes));
+           });
 }
 
 } // namespace tl

--- a/src/transform/common/warp_specialize.h
+++ b/src/transform/common/warp_specialize.h
@@ -1,0 +1,245 @@
+/*!
+ * \file warp_specialize.h
+ * \brief Typed warp-specialization schedule, exposed via TVM-FFI.
+ *
+ * A WSSchedule is the complete description of how to transform a
+ * straight-line kernel into a warp-specialized one. These are frontend IR
+ * constructs (implemented in src/ir.cc): they are
+ * built on the Python side (T.WSSchedule / T.WSRole / T.WSPipeline /
+ * T.WSScope), attached to the tilelang_root block by
+ * T.annotate_ws_schedule, and consumed by the MaterializeWSSchedule pass.
+ *
+ * Structure:
+ *  - WSRole: a contiguous warp range [warp_lo, warp_hi) with one duty and an
+ *    optional register budget.
+ *  - WSPipeline: a full/empty mbarrier pair protecting a set of buffers with
+ *    `depth` versions. Buffers are referenced directly (matched to block
+ *    allocations by their data var).
+ *  - WSInstr: one step of a role's program. Either a WSOpRef, naming a tile
+ *    op or child scope by its stable `tl.ws_op_id`, or a WSSync, a pipeline
+ *    synchronization point (producer_acquire / producer_commit /
+ *    consumer_wait / consumer_release) with a software-pipeline stage.
+ *  - WSScope: a loop (or the kWSRootScopeId root scope) with one
+ *    instruction sequence per role.
+ *  - WSSchedule: warp count, roles, pipelines, scopes.
+ *
+ * Dependencies (which ops touch which pipeline buffers) are intentionally
+ * not part of the schedule: the pass infers them from the kernel.
+ */
+
+#ifndef TVM_TL_TRANSFORM_COMMON_WARP_SPECIALIZE_H_
+#define TVM_TL_TRANSFORM_COMMON_WARP_SPECIALIZE_H_
+
+#include <tvm/ffi/container/array.h>
+#include <tvm/ffi/container/map.h>
+#include <tvm/ffi/enum.h>
+#include <tvm/ffi/string.h>
+#include <tvm/tirx/buffer.h>
+
+#include "support/check.h"
+
+namespace tvm {
+namespace tl {
+
+/*!
+ * \brief Block annotation key carrying the WSSchedule object.
+ *
+ * Set on the tilelang_root block by T.annotate_ws_schedule.
+ */
+static constexpr const char *kWSScheduleKey = "tl.ws_schedule";
+
+/*!
+ * \brief Annotation key carrying a stable op / scope id.
+ *
+ * Appears in tile-op call annotations
+ * (T.copy(..., annotations={"tl.ws_op_id": ...})), loop annotations
+ * (T.Pipelined / T.serial / T.unroll / T.Parallel), and AttrStmt wrappers
+ * around statement groups (with T.ws_op(...)).
+ */
+static constexpr const char *kWSOpIdKey = "tl.ws_op_id";
+
+/*! \brief Scope id of the kernel's implicit root scope (T.WSScope.ROOT). */
+static constexpr const char *kWSRootScopeId = "tl.ws_scope_root";
+
+/*! \brief A contiguous warp range with a single duty. */
+class WSRoleNode : public ffi::Object {
+public:
+  /*! \brief Role name; keys the per-role bodies of every scope. */
+  ffi::String name;
+  /*! \brief Warp range [warp_lo, warp_hi). */
+  int64_t warp_lo;
+  int64_t warp_hi;
+  /*! \brief setmaxnreg budget; 0 = unset. */
+  int64_t max_nreg;
+
+  static void RegisterReflection();
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.WSRole", WSRoleNode, ffi::Object);
+};
+
+class WSRole : public ffi::ObjectRef {
+public:
+  TVM_DLL WSRole(ffi::String name, int64_t warp_lo, int64_t warp_hi,
+                 int64_t max_nreg);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(WSRole, ffi::ObjectRef,
+                                             WSRoleNode);
+};
+
+/*! \brief A full/empty barrier pair protecting multi-versioned buffers. */
+class WSPipelineNode : public ffi::Object {
+public:
+  /*! \brief Pipeline name; referenced by WSSync instructions. */
+  ffi::String name;
+  /*! \brief The buffers this pipeline protects (and multi-versions). */
+  ffi::Array<tirx::Buffer> buffers;
+  /*! \brief Number of buffer versions. */
+  int64_t depth;
+
+  static void RegisterReflection();
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.WSPipeline", WSPipelineNode,
+                                    ffi::Object);
+};
+
+class WSPipeline : public ffi::ObjectRef {
+public:
+  TVM_DLL WSPipeline(ffi::String name, ffi::Array<tirx::Buffer> buffers,
+                     int64_t depth);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(WSPipeline, ffi::ObjectRef,
+                                             WSPipelineNode);
+};
+
+/*! \brief Base class of one step in a role's program. */
+class WSInstrNode : public ffi::Object {
+public:
+  static void RegisterReflection();
+  TVM_FFI_DECLARE_OBJECT_INFO("tl.WSInstr", WSInstrNode, ffi::Object);
+};
+
+class WSInstr : public ffi::ObjectRef {
+public:
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(WSInstr, ffi::ObjectRef,
+                                             WSInstrNode);
+};
+
+/*! \brief Reference to a tile op or child scope by its `tl.ws_op_id`. */
+class WSOpRefNode : public WSInstrNode {
+public:
+  ffi::String id;
+
+  static void RegisterReflection();
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.WSOpRef", WSOpRefNode, WSInstrNode);
+};
+
+class WSOpRef : public WSInstr {
+public:
+  TVM_DLL explicit WSOpRef(ffi::String id);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(WSOpRef, WSInstr, WSOpRefNode);
+};
+
+/*! \brief Pipeline synchronization kind, in TVM FFI enum convention. */
+class WSSyncKindObj : public ffi::EnumObj {
+public:
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.WSSyncKind", WSSyncKindObj,
+                                    ffi::EnumObj);
+};
+
+class WSSyncKind : public ffi::Enum {
+public:
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(WSSyncKind, ffi::Enum,
+                                             WSSyncKindObj);
+
+  static WSSyncKind ProducerAcquire() { return Get("PRODUCER_ACQUIRE"); }
+  static WSSyncKind ProducerCommit() { return Get("PRODUCER_COMMIT"); }
+  static WSSyncKind ConsumerWait() { return Get("CONSUMER_WAIT"); }
+  static WSSyncKind ConsumerRelease() { return Get("CONSUMER_RELEASE"); }
+
+  int CanonicalOrdinal() const {
+    return static_cast<int>(operator->()->_value);
+  }
+
+  bool IsProducerAcquire() const { return CanonicalOrdinal() == 0; }
+  bool IsProducerCommit() const { return CanonicalOrdinal() == 1; }
+  bool IsConsumerWait() const { return CanonicalOrdinal() == 2; }
+  bool IsConsumerRelease() const { return CanonicalOrdinal() == 3; }
+  /*! \brief Waits (acquire / consumer-wait) open a span and block. */
+  bool IsWait() const { return IsProducerAcquire() || IsConsumerWait(); }
+  /*! \brief Commits (commit / release) close a span and signal a barrier. */
+  bool IsCommit() const { return IsProducerCommit() || IsConsumerRelease(); }
+  /*! \brief Producer-side syncs use the empty->full barrier direction. */
+  bool IsProducer() const { return IsProducerAcquire() || IsProducerCommit(); }
+
+private:
+  static WSSyncKind Get(const ffi::String &name) {
+    ffi::Enum e = ffi::EnumObj::Get<WSSyncKindObj>(name);
+    const auto *node = e.as<WSSyncKindObj>();
+    ICHECK(node != nullptr)
+        << "WSSyncKind entry `" << name << "` is not a WSSyncKindObj";
+    return ffi::GetRef<WSSyncKind>(node);
+  }
+};
+
+/*! \brief A pipeline synchronization point. */
+class WSSyncNode : public WSInstrNode {
+public:
+  WSSyncKind kind;
+  /*! \brief Name of the pipeline being synchronized. */
+  ffi::String pipeline;
+  /*! \brief Software-pipeline stage of this sync point. */
+  int64_t stage;
+
+  static void RegisterReflection();
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.WSSync", WSSyncNode, WSInstrNode);
+};
+
+class WSSync : public WSInstr {
+public:
+  TVM_DLL WSSync(WSSyncKind kind, ffi::String pipeline, int64_t stage);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(WSSync, WSInstr, WSSyncNode);
+};
+
+/*! \brief A loop (or the root scope) with per-role instruction lists. */
+class WSScopeNode : public ffi::Object {
+public:
+  /*! \brief The `tl.ws_op_id` of the loop, or kWSRootScopeId. */
+  ffi::String id;
+  /*! \brief Role name -> instruction sequence. */
+  ffi::Map<ffi::String, ffi::Array<WSInstr>> bodies;
+
+  static void RegisterReflection();
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.WSScope", WSScopeNode, ffi::Object);
+};
+
+class WSScope : public ffi::ObjectRef {
+public:
+  TVM_DLL WSScope(ffi::String id,
+                  ffi::Map<ffi::String, ffi::Array<WSInstr>> bodies);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(WSScope, ffi::ObjectRef,
+                                             WSScopeNode);
+};
+
+/*! \brief The complete warp-specialization schedule of one kernel. */
+class WSScheduleNode : public ffi::Object {
+public:
+  /*! \brief Total warp count; overrides the kernel's thread extent. */
+  int64_t num_warps;
+  ffi::Array<WSRole> roles;
+  ffi::Array<WSPipeline> pipelines;
+  ffi::Array<WSScope> scopes;
+
+  static void RegisterReflection();
+  TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.WSSchedule", WSScheduleNode,
+                                    ffi::Object);
+};
+
+class WSSchedule : public ffi::ObjectRef {
+public:
+  TVM_DLL WSSchedule(int64_t num_warps, ffi::Array<WSRole> roles,
+                     ffi::Array<WSPipeline> pipelines,
+                     ffi::Array<WSScope> scopes);
+  TVM_FFI_DEFINE_OBJECT_REF_METHODS_NULLABLE(WSSchedule, ffi::ObjectRef,
+                                             WSScheduleNode);
+};
+
+} // namespace tl
+} // namespace tvm
+
+#endif // TVM_TL_TRANSFORM_COMMON_WARP_SPECIALIZE_H_

--- a/testing/python/language/test_tilelang_language_copy.py
+++ b/testing/python/language/test_tilelang_language_copy.py
@@ -46,6 +46,20 @@ def test_tilelang_copy():
     run_tilelang_copy(M=1024, N=576, block_M=32, block_N=576, dtype=T.float32)
 
 
+def test_scalar_copy_annotations_preserved():
+    @T.prim_func
+    def main(A: T.Tensor((1,), T.float32), B: T.Tensor((1,), T.float32)):
+        with T.Kernel(1, threads=32):
+            A_shared = T.alloc_shared((1,), T.float32)
+            T.copy(A[0], B[0], annotations={"test.copy": "sync"})
+            T.async_copy(A[0], A_shared[0], annotations={"test.copy": "async"})
+
+    script = main.script()
+    assert script.count("test.copy") == 2
+    assert "T.copy(" in script
+    assert "T.async_copy(" in script
+
+
 def run_tilelang_copy_cross_dtype(M=256, N=256, block_M=128, block_N=128, src_dtype=T.float16, dst_dtype=T.bfloat16):
     program = tilelang_copy(M, N, block_M, block_N, src_dtype=src_dtype, dst_dtype=dst_dtype)
     kernel = tilelang.compile(program, out_idx=[1])

--- a/testing/python/language/test_tilelang_language_copy.py
+++ b/testing/python/language/test_tilelang_language_copy.py
@@ -54,10 +54,11 @@ def test_scalar_copy_annotations_preserved():
             T.copy(A[0], B[0], annotations={"test.copy": "sync"})
             T.async_copy(A[0], A_shared[0], annotations={"test.copy": "async"})
 
-    script = main.script()
-    assert script.count("test.copy") == 2
-    assert "T.copy(" in script
-    assert "T.async_copy(" in script
+    lines = main.script().splitlines()
+    copy_line = next(line for line in lines if "T.copy(" in line)
+    async_line = next(line for line in lines if "T.async_copy(" in line)
+    assert 'test.copy="sync"' in copy_line
+    assert 'test.copy="async"' in async_line
 
 
 def run_tilelang_copy_cross_dtype(M=256, N=256, block_M=128, block_N=128, src_dtype=T.float16, dst_dtype=T.bfloat16):

--- a/testing/python/language/test_tilelang_language_scan.py
+++ b/testing/python/language/test_tilelang_language_scan.py
@@ -60,10 +60,11 @@ def test_fragment_scan_annotations_preserved():
             T.cumsum(sum_frag, annotations={"test.scan": "cumsum"})
             T.cummax(max_frag, annotations={"test.scan": "cummax"})
 
-    script = scan.script()
-    assert script.count("test.scan") == 2
-    assert '"cumsum"' in script
-    assert '"cummax"' in script
+    lines = scan.script().splitlines()
+    cumsum_line = next(line for line in lines if "T.cumsum(" in line)
+    cummax_line = next(line for line in lines if "T.cummax(" in line)
+    assert 'test.scan="cumsum"' in cumsum_line
+    assert 'test.scan="cummax"' in cummax_line
 
 
 def run_cumsum(M, N, block_M, block_N, dim=0, reverse=False, dtype=T.float32, scope="smem"):

--- a/testing/python/language/test_tilelang_language_scan.py
+++ b/testing/python/language/test_tilelang_language_scan.py
@@ -49,6 +49,23 @@ def cumsum_fragment_test(M, N, block_M, block_N, dim=0, reverse=False, dtype=T.f
     return cumsum
 
 
+def test_fragment_scan_annotations_preserved():
+    @T.prim_func
+    def scan(A: T.Tensor((32,), T.float32)):
+        with T.Kernel(1, threads=32):
+            sum_frag = T.alloc_fragment((32,), T.float32)
+            max_frag = T.alloc_fragment((32,), T.float32)
+            T.copy(A, sum_frag)
+            T.copy(A, max_frag)
+            T.cumsum(sum_frag, annotations={"test.scan": "cumsum"})
+            T.cummax(max_frag, annotations={"test.scan": "cummax"})
+
+    script = scan.script()
+    assert script.count("test.scan") == 2
+    assert '"cumsum"' in script
+    assert '"cummax"' in script
+
+
 def run_cumsum(M, N, block_M, block_N, dim=0, reverse=False, dtype=T.float32, scope="smem"):
     if scope == "smem":
         program = cumsum_smem_test(M, N, block_M, block_N, dim, reverse, dtype)

--- a/testing/python/transform/test_tilelang_transform_materialize_ws_schedule.py
+++ b/testing/python/transform/test_tilelang_transform_materialize_ws_schedule.py
@@ -91,7 +91,16 @@ def _smem_pipeline_kernel(
             )
 
             for i in T.Pipelined(4, num_stages=depth, annotations={T.WSID: "loop_k"}):
-                T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                if kernel_edit == "unsupported_tma_preference":
+                    T.copy(
+                        A[i * 64, 0],
+                        A_shared,
+                        disable_tma=True,
+                        prefer_instruction="tma",
+                        annotations={T.WSID: "copy_in"},
+                    )
+                else:
+                    T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
                 if kernel_edit == "unannotated_consumer":
                     T.copy(A_shared, A_frag)
                 else:
@@ -119,13 +128,49 @@ def test_basic_two_role_transform():
 
 
 @tilelang.testing.requires_cuda
+def test_scalar_op_annotations_preserved():
+    @T.prim_func
+    def kernel(A: T.Tensor((1,), T.float32), B: T.Tensor((1,), T.float32)):
+        with T.Kernel(1, threads=128):
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=4,
+                    roles=[T.WSRole("Worker", warps_lo=0, warps_hi=4, max_nreg=224)],
+                    pipelines=[],
+                    scopes=[
+                        T.WSScope(
+                            T.WSScope.ROOT,
+                            {
+                                "Worker": [
+                                    "copy",
+                                    "atomic_max",
+                                    "atomic_min",
+                                    "atomic_add",
+                                ]
+                            },
+                        )
+                    ],
+                )
+            )
+            T.copy(A[0], B[0], annotations={T.WSID: "copy"})
+            T.atomic_max(B[0], A[0], annotations={T.WSID: "atomic_max"})
+            T.atomic_min(B[0], A[0], annotations={T.WSID: "atomic_min"})
+            T.atomic_add(B[0], A[0], annotations={T.WSID: "atomic_add"})
+
+    script = str(_materialize(kernel))
+    assert "T.copy(" in script
+    assert script.count("atomic_") >= 3
+    assert "ws_schedule" not in script and "ws_op_id" not in script
+
+
+@tilelang.testing.requires_cuda
 def test_buffer_multi_versioning():
     func = _materialize(_smem_pipeline_kernel(depth=3))
     script = str(func)
     # The pipeline buffer gains a leading version dimension of `depth`.
     assert "A_shared = T.sblock_alloc_buffer((3, 64, 64)" in script
     # Accesses index the acquired version (phase % depth).
-    assert "A_shared[i % 3" in script or "A_shared[(i" in script
+    assert re.search(r"A_shared\[\(?i(?:_\d+)? % 3\)?, 0, 0\]", script), script
 
 
 @tilelang.testing.requires_cuda
@@ -320,6 +365,12 @@ def test_prefer_instruction_cp_async_selects_cp_async_atom():
 
 
 @tilelang.testing.requires_cuda
+def test_unsupported_preferred_copy_rejected():
+    with pytest.raises(Exception, match='prefer_instruction="tma" conflicts with disable_tma=true'):
+        _materialize(_smem_pipeline_kernel(kernel_edit="unsupported_tma_preference"))
+
+
+@tilelang.testing.requires_cuda
 def test_consumer_wait_parity():
     func = _materialize(_smem_pipeline_kernel(depth=2))
     script = str(func)
@@ -409,12 +460,12 @@ def test_stage_offset_unrolls_prologue_epilogue():
     # boundary checks; the stage-1 entries address the previous logical
     # iteration.
     assert "for i in range(1, 4):" in script
-    assert "i - 1" in script
     assert "i >= 1" not in script and "1 <= i" not in script
     assert "if i < 4" not in script
     # Prologue (the stage-0 entries at iteration 0) precedes the loop;
     # epilogue (the stage-1 entries at iteration 3) follows it.
     producer = script[script.find("T.set_max_nreg(40, 0)") :]
+    assert "T.region(C_shared[(i - 1) % 2, 0, 0]" in producer, producer
     prologue = producer.find("T.mbarrier_wait_parity(a_empty_1[0], 1)")
     loop = producer.find("for i in range(1, 4):")
     epilogue = producer.find("T.mbarrier_wait_parity(c_empty_1[1], 0)")
@@ -1027,8 +1078,9 @@ def test_ws_op_wrapper_groups_statements():
     script = str(func)
     # Both statements of the group emitted once, in the consumer branch,
     # with the pipeline read version-rebound.
-    assert script.count("A_frag") >= 2
-    assert "A_shared[i % 2" in script
+    consumer = script[script.find("T.set_max_nreg(224, 1)") :]
+    assert consumer.count("T.copy(T.region(A_shared[i % 2") == 1, consumer
+    assert consumer.count("T.copy(T.region(A_frag[") == 1, consumer
     assert "ws_op_id" not in script
 
 

--- a/testing/python/transform/test_tilelang_transform_materialize_ws_schedule.py
+++ b/testing/python/transform/test_tilelang_transform_materialize_ws_schedule.py
@@ -53,6 +53,9 @@ def _smem_pipeline_kernel(
         with T.Kernel(1, threads=128) as _:
             A_shared = T.alloc_shared((64, 64), T.float16)
             A_frag = T.alloc_fragment((64, 64), T.float16)
+            if kernel_edit == "metadata_attrs":
+                T.use_swizzle(10)
+                T.annotate_min_blocks_per_sm(2)
 
             bodies = {
                 "Producer": [
@@ -1091,6 +1094,20 @@ def test_unannotated_global_store_rejected():
     from every role body."""
     with pytest.raises(Exception, match="carries no ws op id"):
         _materialize(_smem_pipeline_kernel(kernel_edit="unannotated_global_store"))
+
+
+@tilelang.testing.requires_cuda
+def test_kernel_metadata_attrs_preserved():
+    """Kernel-level metadata AttrStmts (T.use_swizzle,
+    T.annotate_min_blocks_per_sm) wrap the statements that follow them:
+    the pass schedules through them and re-wraps the rebuilt body."""
+    func = _materialize(_smem_pipeline_kernel(kernel_edit="metadata_attrs"))
+    script = str(func)
+    swizzle = script.find('"threadblock_swizzle_pattern"')
+    min_blocks = script.find('"tl.min_blocks_per_sm"')
+    branch = script.find("if tx < 32:")
+    assert 0 <= swizzle < min_blocks < branch
+    assert "T.tma_copy(" in script
 
 
 @tilelang.testing.requires_cuda

--- a/testing/python/transform/test_tilelang_transform_materialize_ws_schedule.py
+++ b/testing/python/transform/test_tilelang_transform_materialize_ws_schedule.py
@@ -1,0 +1,1373 @@
+"""Unit tests for the MaterializeWSSchedule transform.
+
+Each test builds its input in the form the pass consumes directly: a
+static-shape ``@T.prim_func`` kernel (traced at decoration — no torch, no
+GPU) prepared with exactly the two passes that define the input contract,
+BindTarget and MaterializeKernelLaunch. The target is pinned so the tests
+are independent of the machine and of the production pipeline.
+"""
+
+import re
+
+import pytest
+
+import tilelang
+import tilelang.testing
+from tilelang import language as T
+from tilelang import tvm
+
+_TARGET = tvm.target.Target({"kind": "cuda", "arch": "sm_100a"})
+
+
+def _materialize(func):
+    """Prepare `func` (BindTarget + MaterializeKernelLaunch — the pass's
+    input contract) and apply MaterializeWSSchedule; returns the
+    transformed PrimFunc."""
+    mod = tvm.IRModule.from_expr(func.with_attr("global_symbol", "main"))
+    mod = tvm.tirx.transform.BindTarget(_TARGET)(mod)
+    mod = tilelang.transform.MaterializeKernelLaunch()(mod)
+    mod = tilelang.cuda.transform.MaterializeWSSchedule()(mod)["main"]
+    return mod
+
+
+def _smem_pipeline_kernel(
+    *,
+    depth=2,
+    producer_stage=0,
+    consumer_wait_stage=0,
+    consumer_release_stage=0,
+    schedule_edit=None,
+    kernel_edit=None,
+):
+    """A minimal two-role smem pipeline: one TMA warp copies A tile-by-tile
+    into a multi-versioned shared buffer; one consumer warpgroup copies it
+    back out to global memory through a fragment.
+
+    ``schedule_edit(bodies)`` may rewrite the per-role instruction lists and
+    ``kernel_edit`` selects alternative kernel-body variants used by the
+    error-path tests.
+    """
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+
+            bodies = {
+                "Producer": [
+                    T.WSSync.producer_acquire("buf", stage=producer_stage),
+                    "copy_in",
+                    T.WSSync.producer_commit("buf", stage=producer_stage),
+                ],
+                "Consumer": [
+                    T.WSSync.consumer_wait("buf", stage=consumer_wait_stage),
+                    "copy_frag",
+                    T.WSSync.consumer_release("buf", stage=consumer_release_stage),
+                    "copy_out",
+                ],
+            }
+            if schedule_edit is not None:
+                schedule_edit(bodies)
+
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[
+                        T.WSPipeline("buf", [A_shared], depth=depth),
+                    ],
+                    scopes=[
+                        T.WSScope("loop_k", bodies),
+                        T.WSScope(
+                            T.WSScope.ROOT,
+                            {"Producer": ["loop_k"], "Consumer": ["loop_k"]},
+                        ),
+                    ],
+                )
+            )
+
+            for i in T.Pipelined(4, num_stages=depth, annotations={T.WSID: "loop_k"}):
+                T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                if kernel_edit == "unannotated_consumer":
+                    T.copy(A_shared, A_frag)
+                else:
+                    T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
+                if kernel_edit == "unannotated_global_store":
+                    B[0, 0] = T.float16(0.0)
+
+    return kernel
+
+
+def test_basic_two_role_transform():
+    func = _materialize(_smem_pipeline_kernel())
+    script = str(func)
+    # Warp-specialized branches on the thread var, in warp order.
+    assert 'T.launch_thread("threadIdx.x", 256)' in script
+    assert "if tx < 32:" in script
+    assert "T.set_max_nreg(40, 0)" in script
+    assert "T.set_max_nreg(224, 1)" in script
+    # The schedule annotation is consumed.
+    assert "ws_schedule" not in script
+    # Every scheduling marker is stripped.
+    assert "ws_op_id" not in script
+
+
+def test_buffer_multi_versioning():
+    func = _materialize(_smem_pipeline_kernel(depth=3))
+    script = str(func)
+    # The pipeline buffer gains a leading version dimension of `depth`.
+    assert "A_shared = T.sblock_alloc_buffer((3, 64, 64)" in script
+    # Accesses index the acquired version (phase % depth).
+    assert "A_shared[i % 3" in script or "A_shared[(i" in script
+
+
+def test_barrier_counts_tma_fallback_and_threads():
+    func = _materialize(_smem_pipeline_kernel())
+    script = str(func)
+    # Producer side: the TMA copy rides the tx-count; with no other arrival
+    # the per-thread fallback arrives with the producer warp (32 threads).
+    assert "buf_full: [32, 32]" in script
+    # Consumer side: synchronous fragment reads -> all 128 consumer threads.
+    assert "buf_empty: [128, 128]" in script
+
+
+def test_tma_copy_conversion_carries_barrier():
+    func = _materialize(_smem_pipeline_kernel())
+    script = str(func)
+    # The producer copy is converted to tma_copy with the full barrier
+    # attached; no emit_arrive is used.
+    assert "T.tma_copy(" in script
+    assert "barrier=buf_full" in script
+    assert "emit_arrive" not in script
+    # The commit is a plain per-thread arrive (transaction fallback).
+    assert "T.ptx_arrive_barrier(buf_full" in script
+
+
+def test_consumer_wait_parity():
+    func = _materialize(_smem_pipeline_kernel(depth=2))
+    script = str(func)
+    # Producer waits for empty with inverted parity; consumer waits for full
+    # with plain parity.
+    assert "T.mbarrier_wait_parity(buf_empty" in script
+    assert "T.mbarrier_wait_parity(buf_full" in script
+
+
+def test_uniform_stages_cancel():
+    # When ALL of a role's sync stages agree, the offsets cancel and the
+    # loop is emitted unshifted (the documented loop-equivalence).
+    func = _materialize(_smem_pipeline_kernel(consumer_wait_stage=1, consumer_release_stage=1))
+    script = str(func)
+    assert "for i in range(4):" in script  # original extent, no guards
+
+
+def test_stage_offset_shifts_and_guards():
+    """Two pipelines synced at different stages within one role: the body
+    at the later stage runs one logical iteration behind, the loop gains an
+    extra step, and boundary guards appear."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((32, 64), T.float16)
+            C_shared = T.alloc_shared((32, 64), T.float16)
+            A_frag = T.alloc_fragment((32, 64), T.float16)
+            C_frag = T.alloc_fragment((32, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[
+                        T.WSPipeline("a", [A_shared], depth=2),
+                        T.WSPipeline("c", [C_shared], depth=2),
+                    ],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("a", stage=0),
+                                    "copy_a",
+                                    T.WSSync.producer_commit("a", stage=0),
+                                    # The second copy runs one iteration
+                                    # behind the first.
+                                    T.WSSync.producer_acquire("c", stage=1),
+                                    "copy_c",
+                                    T.WSSync.producer_commit("c", stage=1),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("a", stage=0),
+                                    "read_a",
+                                    T.WSSync.consumer_release("a", stage=0),
+                                    T.WSSync.consumer_wait("c", stage=0),
+                                    "read_c",
+                                    T.WSSync.consumer_release("c", stage=0),
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
+                    ],
+                )
+            )
+
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                T.copy(A[i * 32, 0], A_shared, annotations={T.WSID: "copy_a"})
+                T.copy(A[i * 32, 0], C_shared, annotations={T.WSID: "copy_c"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "read_a"})
+                T.copy(C_shared, C_frag, annotations={T.WSID: "read_c"})
+
+    func = _materialize(kernel)
+    script = str(func)
+    # Producer loop lengthened by the stage shift with boundary guards: the
+    # 4-step loop runs 5 steps.
+    assert "range(5)" in script
+    assert "i < 4" in script  # stage-0 upper guard
+    assert "i >= 1" in script or "1 <= i" in script  # stage-1 lower guard
+    # The stage-1 copy addresses the previous logical iteration.
+    assert "i - 1" in script
+    # Consecutive entries at one stage share ONE merged guard block each
+    # (acquire/copy/commit runs of the producer), not a run of equal ifs.
+    assert script.count("if i < 4") == 1
+    assert len(re.findall(r"if (?:i >= 1|1 <= i)", script)) == 1
+
+
+def test_mismatched_pair_stages_rejected():
+    with pytest.raises(Exception, match="pairs must share one stage"):
+        _materialize(_smem_pipeline_kernel(consumer_wait_stage=0, consumer_release_stage=1))
+
+
+def test_missing_commit_rejected():
+    # A pipeline whose producer never commits has no full-side signal.
+    def drop_commit(bodies):
+        bodies["Producer"] = [e for e in bodies["Producer"] if not isinstance(e, T.WSSync) or e.kind.same_as(T.WSSyncKind.PRODUCER_ACQUIRE)]
+
+    with pytest.raises(Exception, match="has no producer"):
+        _materialize(_smem_pipeline_kernel(schedule_edit=drop_commit))
+
+
+def test_unclosed_span_rejected():
+    # An extra trailing acquire leaves the span open at the end of the body.
+    def extra_acquire(bodies):
+        bodies["Producer"].append(T.WSSync.producer_acquire("buf"))
+
+    with pytest.raises(Exception, match="acquired at the end of a scope body"):
+        _materialize(_smem_pipeline_kernel(schedule_edit=extra_acquire))
+
+
+def test_double_acquire_rejected():
+    # Two acquires without an intervening commit are a double-open.
+    def double_acquire(bodies):
+        bodies["Producer"].insert(1, T.WSSync.producer_acquire("buf"))
+        bodies["Producer"].append(T.WSSync.producer_commit("buf"))
+
+    with pytest.raises(Exception, match="acquired twice"):
+        _materialize(_smem_pipeline_kernel(schedule_edit=double_acquire))
+
+
+def test_role_both_producer_and_consumer_rejected():
+    # The flavors are the two parties of the handshake: a role handing data
+    # to itself needs no pipeline, so one role must not hold both flavors.
+    def self_handshake(bodies):
+        bodies["Producer"] = [
+            T.WSSync.producer_acquire("buf"),
+            "copy_in",
+            T.WSSync.producer_commit("buf"),
+            T.WSSync.consumer_wait("buf"),
+            "copy_frag",
+            T.WSSync.consumer_release("buf"),
+        ]
+        bodies["Consumer"] = ["copy_out"]
+
+    with pytest.raises(Exception, match="both a producer and a consumer"):
+        _materialize(_smem_pipeline_kernel(schedule_edit=self_handshake))
+
+
+def test_unknown_pipeline_rejected():
+    def rename_pipeline(bodies):
+        bodies["Producer"][0] = T.WSSync.producer_acquire("nonexistent")
+
+    with pytest.raises(Exception, match="unknown pipeline"):
+        _materialize(_smem_pipeline_kernel(schedule_edit=rename_pipeline))
+
+
+def test_missing_op_rejected():
+    def add_ghost_op(bodies):
+        bodies["Producer"].append("ghost_op")
+
+    with pytest.raises(Exception, match="no statement in the kernel carries this id"):
+        _materialize(_smem_pipeline_kernel(schedule_edit=add_ghost_op))
+
+
+def test_unscheduled_statement_rejected():
+    def drop_consumer_op(bodies):
+        bodies["Consumer"] = [e for e in bodies["Consumer"] if e != "copy_frag"]
+
+    with pytest.raises(Exception, match="carries no ws op id|never places it"):
+        _materialize(_smem_pipeline_kernel(schedule_edit=drop_consumer_op, kernel_edit="unannotated_consumer"))
+
+
+def test_op_scheduled_by_multiple_roles_rejected():
+    def share_op(bodies):
+        bodies["Producer"].append("copy_frag")
+
+    with pytest.raises(Exception, match="scheduled by multiple roles"):
+        _materialize(_smem_pipeline_kernel(schedule_edit=share_op))
+
+
+def test_distinct_guards_stay_distinct():
+    """Consecutive guarded ops with structurally different guards keep
+    their own conditions."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag_lo",
+                                    "copy_frag_hi",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out",
+                                ],
+                            },
+                        ),
+                        T.WSScope(
+                            T.WSScope.ROOT,
+                            {"Producer": ["loop_k"], "Consumer": ["loop_k"]},
+                        ),
+                    ],
+                )
+            )
+
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                if i < 1:
+                    T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag_lo"})
+                if i < 2:
+                    T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag_hi"})
+                T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
+
+    func = _materialize(kernel)
+    script = str(func)
+    # Both source conditions survive; merging under one guard would delete
+    # the `< 1` condition.
+    assert "< 1" in script
+    assert "< 2" in script
+
+
+def test_ws_op_wrapper_single_statement_only():
+    """T.ws_op manually annotates exactly one statement (the escape hatch
+    for statement forms without annotations=); wrapping several statements
+    is rejected — every scheduled statement needs its own id."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out",
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
+                    ],
+                )
+            )
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                with T.ws_op("copy_frag"):
+                    T.copy(A_shared, A_frag)
+                    T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
+
+    with pytest.raises(Exception, match="exactly one statement"):
+        _materialize(kernel)
+
+
+def test_unannotated_global_store_rejected():
+    """A statement whose only effect is a global write must be placed by
+    the schedule like any other op; unannotated it would silently vanish
+    from every role body."""
+    with pytest.raises(Exception, match="carries no ws op id"):
+        _materialize(_smem_pipeline_kernel(kernel_edit="unannotated_global_store"))
+
+
+def test_nonzero_loop_base_phase():
+    """A scope loop starting at a non-zero base counts pipeline phases from
+    the base: iteration `base` is phase 0, so barrier indices and parities
+    come from (i - base), not the raw loop var."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out",
+                                ],
+                            },
+                        ),
+                        T.WSScope(
+                            T.WSScope.ROOT,
+                            {"Producer": ["loop_k"], "Consumer": ["loop_k"]},
+                        ),
+                    ],
+                )
+            )
+
+            for i in T.Pipelined(3, 7, num_stages=2, annotations={T.WSID: "loop_k"}):
+                T.copy(A[(i - 3) * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                T.copy(A_frag, B[(i - 3) * 64, 0], annotations={T.WSID: "copy_out"})
+
+    func = _materialize(kernel)
+    script = str(func)
+    # The phase is (i - 3): version indices and parities derive from it, so
+    # the raw loop var must never reach a barrier index / parity position.
+    assert "- 3) % 2" in script
+    assert re.search(r"\bi(_\d+)? % 2", script) is None
+
+
+def test_release_before_use_rejected():
+    """Work on a pipeline's buffers after the span closed races with the
+    next producer of the stage; the span-coverage check rejects it."""
+
+    def release_early(bodies):
+        # consumer: wait, release, then read -- copy_frag lands outside.
+        bodies["Consumer"] = [
+            T.WSSync.consumer_wait("buf"),
+            T.WSSync.consumer_release("buf"),
+            "copy_frag",
+            "copy_out",
+        ]
+
+    with pytest.raises(Exception, match="outside an open span"):
+        _materialize(_smem_pipeline_kernel(schedule_edit=release_early))
+
+
+def test_unbracketed_producer_rejected():
+    """A producer op scheduled outside its pipeline's acquire/commit
+    bracket is rejected by the span-coverage check even though the bracket
+    itself is present."""
+
+    def op_outside_bracket(bodies):
+        bodies["Producer"] = [
+            "copy_in",
+            T.WSSync.producer_acquire("buf"),
+            T.WSSync.producer_commit("buf"),
+        ]
+
+    with pytest.raises(Exception, match="outside an open span"):
+        _materialize(_smem_pipeline_kernel(schedule_edit=op_outside_bracket))
+
+
+def test_cycle_imbalance_rejected():
+    """A pipeline cycling twice on the producer side but once on the
+    consumer side per loop iteration diverges parity every trip."""
+
+    def double_producer_cycle(bodies):
+        bodies["Producer"] = [
+            T.WSSync.producer_acquire("buf"),
+            "copy_in",
+            T.WSSync.producer_commit("buf"),
+            T.WSSync.producer_acquire("buf"),
+            T.WSSync.producer_commit("buf"),
+        ]
+
+    with pytest.raises(Exception, match="parity diverges"):
+        _materialize(_smem_pipeline_kernel(schedule_edit=double_producer_cycle))
+
+
+def test_cross_pipeline_deadlock_rejected():
+    """Two roles waiting on each other's pipelines before producing their
+    own deadlock immediately; the parity-model execution catches it."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            X_shared = T.alloc_shared((64, 64), T.float16)
+            Y_shared = T.alloc_shared((64, 64), T.float16)
+            X_frag = T.alloc_fragment((64, 64), T.float16)
+
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("RoleX", warps_lo=0, warps_hi=4, max_nreg=224),
+                        T.WSRole("RoleY", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[
+                        T.WSPipeline("x", [X_shared], depth=1),
+                        T.WSPipeline("y", [Y_shared], depth=1),
+                    ],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                # RoleX produces x but first waits on y;
+                                # RoleY produces y but first waits on x.
+                                "RoleX": [
+                                    T.WSSync.consumer_wait("y"),
+                                    T.WSSync.producer_acquire("x"),
+                                    "copy_x",
+                                    T.WSSync.producer_commit("x"),
+                                    "read_y",
+                                    T.WSSync.consumer_release("y"),
+                                    "copy_out_x",
+                                ],
+                                "RoleY": [
+                                    T.WSSync.consumer_wait("x"),
+                                    T.WSSync.producer_acquire("y"),
+                                    "copy_y",
+                                    T.WSSync.producer_commit("y"),
+                                    T.WSSync.consumer_release("x"),
+                                ],
+                            },
+                        ),
+                        T.WSScope(
+                            T.WSScope.ROOT,
+                            {"RoleX": ["loop_k"], "RoleY": ["loop_k"]},
+                        ),
+                    ],
+                )
+            )
+
+            for i in T.Pipelined(4, num_stages=1, annotations={T.WSID: "loop_k"}):
+                T.copy(A[i * 64, 0], X_shared, annotations={T.WSID: "copy_x"})
+                T.copy(X_shared, Y_shared, annotations={T.WSID: "copy_y"})
+                T.copy(Y_shared, X_frag, annotations={T.WSID: "read_y"})
+                T.copy(X_frag, B[i * 64, 0], annotations={T.WSID: "copy_out_x"})
+
+    with pytest.raises(Exception, match="deadlock"):
+        _materialize(kernel)
+
+
+def test_op_writing_two_pipelines_rejected():
+    """An op's synchronization can only trigger one pipeline: a single op
+    statement (here a T.Parallel op node) writing buffers of two pipelines
+    is rejected."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            X_shared = T.alloc_shared((64, 64), T.float16)
+            Y_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[
+                        T.WSPipeline("x", [X_shared], depth=2),
+                        T.WSPipeline("y", [Y_shared], depth=2),
+                    ],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("x"),
+                                    T.WSSync.producer_acquire("y"),
+                                    "copy_both",
+                                    T.WSSync.producer_commit("x"),
+                                    T.WSSync.producer_commit("y"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("x"),
+                                    T.WSSync.consumer_wait("y"),
+                                    "copy_frag_x",
+                                    "copy_frag_y",
+                                    T.WSSync.consumer_release("x"),
+                                    T.WSSync.consumer_release("y"),
+                                    "copy_out",
+                                ],
+                            },
+                        ),
+                        T.WSScope(
+                            T.WSScope.ROOT,
+                            {"Producer": ["loop_k"], "Consumer": ["loop_k"]},
+                        ),
+                    ],
+                )
+            )
+
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                # One statement (a T.Parallel op node) writing buffers of
+                # two different pipelines.
+                for u, v in T.Parallel(64, 64, annotations={T.WSID: "copy_both"}):
+                    X_shared[u, v] = A[i * 64 + u, v]
+                    Y_shared[u, v] = A[i * 64 + u, v]
+                T.copy(X_shared, A_frag, annotations={T.WSID: "copy_frag_x"})
+                T.copy(Y_shared, A_frag, annotations={T.WSID: "copy_frag_y"})
+                T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
+
+    with pytest.raises(Exception, match="can only trigger one pipeline"):
+        _materialize(kernel)
+
+
+def test_unknown_role_body_rejected():
+    def add_role_body(bodies):
+        bodies["Ghost"] = []
+
+    with pytest.raises(Exception, match="unknown role"):
+        _materialize(_smem_pipeline_kernel(schedule_edit=add_role_body))
+
+
+def test_num_warps_must_be_warpgroup_aligned():
+    with pytest.raises(AssertionError, match="multiple of 4"):
+        T.WSSchedule(num_warps=6, roles=[], pipelines=[], scopes=[])
+
+
+def test_ws_scope_root_constant():
+    assert T.WSScope.ROOT == "tl.ws_scope_root"
+
+
+def test_ws_sync_kind_enum_round_trip():
+    sync = T.WSSync.consumer_release("p", stage=3)
+    assert sync.kind.same_as(T.WSSyncKind.CONSUMER_RELEASE)
+    assert str(sync.pipeline) == "p"
+    assert int(sync.stage) == 3
+
+
+def test_ws_role_requires_keyword_range():
+    role = T.WSRole("R", warps_lo=4, warps_hi=8, max_nreg=224)
+    assert int(role.warp_lo) == 4 and int(role.warp_hi) == 8
+    with pytest.raises(TypeError):
+        T.WSRole("R", (4, 8))  # positional tuples are not accepted
+
+
+def _scope_kind_kernel(loop_ctor):
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out",
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
+                    ],
+                )
+            )
+            for i in loop_ctor(4, annotations={T.WSID: "loop_k"}):
+                T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
+
+    return kernel
+
+
+def test_serial_scope_loop_and_unrolled_rejected():
+    """Any serial loop can be a schedule scope (T.Pipelined is a serial
+    loop whose num_stages this pass consumes); T.unroll / T.Parallel loops
+    cannot."""
+    # A plain T.serial scope materializes like a T.Pipelined one.
+    func = _materialize(_scope_kind_kernel(T.serial))
+    script = str(func)
+    assert "T.mbarrier_wait_parity(" in script
+    assert '"num_stages"' not in script
+
+    # T.unroll cannot be a scope.
+    with pytest.raises(Exception, match="must be a serial loop"):
+        _materialize(_scope_kind_kernel(T.unroll))
+
+
+def test_op_node_loop():
+    """A T.unroll loop with an id is one op node: inner statements need no
+    ids, the loop keeps its kind, and its pipeline reads rebind to the
+    acquired version."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "store_loop",
+                                    T.WSSync.consumer_release("buf"),
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
+                    ],
+                )
+            )
+
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                # The unrolled loop is one op node; its statements are
+                # unannotated and its A_shared read binds it to the pipeline.
+                for s in T.unroll(2, annotations={T.WSID: "store_loop"}):
+                    T.copy(A_shared[:, s * 32 : (s + 1) * 32], A_frag[:, s * 32 : (s + 1) * 32])
+                    T.copy(A_frag[:, s * 32 : (s + 1) * 32], B[i * 64, s * 32])
+
+    func = _materialize(kernel)
+    script = str(func)
+    # The unroll survives as a loop inside the consumer branch (op-node
+    # loops keep their kind), with the pipeline version index applied to
+    # A_shared inside it -- statements inside op-node loops need no ids.
+    assert "T.unroll(2)" in script
+    assert "A_shared[i % 2, 0, s * 32]" in script
+
+
+def test_idle_donor_branch():
+    # Roles cover warps [0,1) and [4,8) of 8: warps 1-4 form a gap branch
+    # and warps beyond the last role donate registers too.
+    func = _materialize(_smem_pipeline_kernel())
+    script = str(func)
+    # The gap branch donates registers down to the smallest donor budget.
+    assert script.count("T.set_max_nreg(40, 0)") >= 2
+
+
+def test_unscheduled_kernel_untouched():
+    """Schedule and op ids come together (both or neither): a kernel
+    without the schedule annotation is returned exactly as it came in —
+    no transformation, no stripping."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            T.copy(A[0, 0], A_shared, annotations={T.WSID: "copy_in"})
+            T.copy(A_shared, B[0, 0], annotations={T.WSID: "copy_out"})
+
+    mod = tvm.IRModule.from_expr(kernel.with_attr("global_symbol", "main"))
+    mod = tvm.tirx.transform.BindTarget(_TARGET)(mod)
+    mod = tilelang.transform.MaterializeKernelLaunch()(mod)
+    out = tilelang.cuda.transform.MaterializeWSSchedule()(mod)["main"]
+    assert tvm.ir.structural_equal(out, mod["main"])
+
+
+def test_tcgen05_async_arrive_count():
+    """A gemm accumulating into TMEM signals with tcgen05.commit: the full
+    barrier of the accumulator pipeline gets arrive count 1, and the smem
+    release below the gemm becomes a tcgen05_mma_arrive."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            C_tmem = T.alloc_tmem((64, 64), T.float32)
+            C_frag = T.alloc_fragment((64, 64), T.float32)
+
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("MMA", warps_lo=1, warps_hi=2, max_nreg=40),
+                        T.WSRole("Epilogue", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[
+                        T.WSPipeline("smem", [A_shared], depth=2),
+                        T.WSPipeline("acc", [C_tmem], depth=1),
+                    ],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("smem"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("smem"),
+                                ],
+                                "MMA": [
+                                    T.WSSync.consumer_wait("smem"),
+                                    "gemm_C",
+                                    T.WSSync.consumer_release("smem"),
+                                ],
+                                "Epilogue": [],
+                            },
+                        ),
+                        T.WSScope(
+                            T.WSScope.ROOT,
+                            {
+                                "Producer": ["loop_k"],
+                                "MMA": [
+                                    T.WSSync.producer_acquire("acc"),
+                                    "loop_k",
+                                    T.WSSync.producer_commit("acc"),
+                                ],
+                                "Epilogue": [
+                                    "loop_k",
+                                    T.WSSync.consumer_wait("acc"),
+                                    "copy_C",
+                                    T.WSSync.consumer_release("acc"),
+                                    "copy_out",
+                                ],
+                            },
+                        ),
+                    ],
+                )
+            )
+
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                T.gemm(
+                    A_shared,
+                    A_shared,
+                    C_tmem,
+                    transpose_B=True,
+                    clear_accum=i == 0,
+                    annotations={T.WSID: "gemm_C"},
+                )
+            T.copy(C_tmem, C_frag, annotations={T.WSID: "copy_C"})
+            T.copy(C_frag, B[0, 0], annotations={T.WSID: "copy_out"})
+
+    func = _materialize(kernel)
+    script = str(func)
+    # The gemm is converted to the async tcgen05 form.
+    assert "T.tcgen05_gemm(" in script
+    # smem_empty and acc_full are signaled by the tensor core: count 1 each.
+    assert "smem_empty: [1, 1]" in script
+    assert "acc_full: [1]" in script
+    # Synchronous epilogue reads release acc with all 128 threads.
+    assert "acc_empty: [128]" in script
+    # The MMA-side releases are tcgen05 commits.
+    assert "T.tcgen05_mma_arrive(" in script
+
+
+def test_runtime_phase_counter_for_multi_depth_spans():
+    """A pipeline synchronized at two loop depths by one role needs a
+    runtime phase counter instead of the linearized iteration."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out",
+                                ],
+                            },
+                        ),
+                        T.WSScope(
+                            T.WSScope.ROOT,
+                            {
+                                "Producer": [
+                                    # An extra root-level cycle: the producer
+                                    # now syncs buf at two loop depths.
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_head",
+                                    T.WSSync.producer_commit("buf"),
+                                    "loop_k",
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_head_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_head_out",
+                                    "loop_k",
+                                ],
+                            },
+                        ),
+                    ],
+                )
+            )
+
+            T.copy(A[0, 0], A_shared, annotations={T.WSID: "copy_head"})
+            T.copy(A_shared, A_frag, annotations={T.WSID: "copy_head_frag"})
+            T.copy(A_frag, B[0, 0], annotations={T.WSID: "copy_head_out"})
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
+
+    func = _materialize(kernel)
+    script = str(func)
+    # Both roles track their buf phase with a local counter.
+    assert "buf_phase" in script
+
+
+def test_op_referenced_twice_rejected():
+    # An op's statement is cloned verbatim; referencing it twice would
+    # duplicate the work.
+    def duplicate_ref(bodies):
+        bodies["Producer"].insert(2, "copy_in")
+
+    with pytest.raises(Exception, match="referenced more than once in the body"):
+        _materialize(_smem_pipeline_kernel(schedule_edit=duplicate_ref))
+
+
+def test_scope_loop_nonunit_step_rejected():
+    """Phases count iterations as (loop_var - min), which a non-unit step
+    breaks. The eager frontend desugars T.serial(..., step) into a
+    unit-step loop plus a Bind, so stamp the For node's step field
+    directly to pin the IR-level rejection."""
+    func = _smem_pipeline_kernel()
+
+    def add_step(stmt):
+        if isinstance(stmt, tvm.tirx.For) and T.WSID in stmt.annotations:
+            return tvm.tirx.For(
+                stmt.loop_var,
+                stmt.min,
+                stmt.extent,
+                stmt.kind,
+                stmt.body,
+                stmt.thread_binding,
+                stmt.annotations,
+                step=tvm.tirx.IntImm("int32", 2),
+            )
+        return None
+
+    stepped = func.with_body(tvm.tirx.stmt_functor.ir_transform(func.body, None, add_step, ["tirx.For"]))
+    with pytest.raises(Exception, match="non-unit loop step"):
+        _materialize(stepped)
+
+
+def test_guard_read_outside_span_rejected():
+    """A buffer read only by an op's if-condition is an operand too: a
+    guard reading a pipeline buffer after the role released it is
+    rejected by the span-coverage check."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out",
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
+                    ],
+                )
+            )
+
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                if A_shared[0, 0] > T.float16(0.0):
+                    T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
+
+    with pytest.raises(Exception, match="outside an open span"):
+        _materialize(kernel)
+
+
+def test_one_sided_scope_cycles_rejected():
+    """A pipeline cycling on one side only inside a loop scope (its
+    counterpart cycles in the root here) diverges with the loop extent;
+    every pipeline must cycle both sides equally often per iteration."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                            },
+                        ),
+                        T.WSScope(
+                            T.WSScope.ROOT,
+                            {
+                                "Producer": ["loop_k"],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out",
+                                ],
+                            },
+                        ),
+                    ],
+                )
+            )
+
+            for _i in T.serial(4, annotations={T.WSID: "loop_k"}):
+                T.copy(A[0, 0], A_shared, annotations={T.WSID: "copy_in"})
+            T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+            T.copy(A_frag, B[0, 0], annotations={T.WSID: "copy_out"})
+
+    with pytest.raises(Exception, match="parity diverges"):
+        _materialize(kernel)
+
+
+def test_source_guard_combines_with_boundary_guard():
+    """An op carrying both a stage boundary guard and its own source guard
+    gets ONE combined condition, not nested ifs; the source guard is
+    substituted with the shifted iteration."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((32, 64), T.float16)
+            C_shared = T.alloc_shared((32, 64), T.float16)
+            A_frag = T.alloc_fragment((32, 64), T.float16)
+            C_frag = T.alloc_fragment((32, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[
+                        T.WSPipeline("a", [A_shared], depth=2),
+                        T.WSPipeline("c", [C_shared], depth=2),
+                    ],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("a", stage=0),
+                                    "copy_a",
+                                    T.WSSync.producer_commit("a", stage=0),
+                                    T.WSSync.producer_acquire("c", stage=1),
+                                    "copy_c",
+                                    T.WSSync.producer_commit("c", stage=1),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("a", stage=0),
+                                    "read_a",
+                                    T.WSSync.consumer_release("a", stage=0),
+                                    T.WSSync.consumer_wait("c", stage=0),
+                                    "read_c",
+                                    T.WSSync.consumer_release("c", stage=0),
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
+                    ],
+                )
+            )
+
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                T.copy(A[i * 32, 0], A_shared, annotations={T.WSID: "copy_a"})
+                if i < 3:
+                    T.copy(A[i * 32, 0], C_shared, annotations={T.WSID: "copy_c"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "read_a"})
+                T.copy(C_shared, C_frag, annotations={T.WSID: "read_c"})
+
+    func = _materialize(kernel)
+    script = str(func)
+    # copy_c runs at stage 1: its boundary guard (i >= 1) and its source
+    # guard (i < 3, on the shifted iteration i - 1) meet in one condition.
+    assert re.search(r"if i >= 1 and i - 1 < 3", script) or re.search(r"if 1 <= i and i - 1 < 3", script), script
+    # The acquire/commit around it keep their unconditional boundary-only
+    # guard: the source guard never covers sync entries.
+    assert len(re.findall(r"if (?:i >= 1|1 <= i):", script)) >= 1
+
+
+def test_warpgroup_nreg_conflict_rejected():
+    """setmaxnreg allocates per warpgroup: two roles inside one warpgroup
+    (warps 4g..4g+3) must request the same max_nreg."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((64, 64), T.float16), B: T.Tensor((64, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=4,
+                    roles=[
+                        T.WSRole("R0", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("R1", warps_lo=1, warps_hi=2, max_nreg=224),
+                    ],
+                    pipelines=[],
+                    scopes=[T.WSScope(T.WSScope.ROOT, {"R0": ["cp"], "R1": []})],
+                )
+            )
+            T.copy(A, B, annotations={T.WSID: "cp"})
+
+    with pytest.raises(Exception, match="allocates per warpgroup"):
+        _materialize(kernel)
+
+
+def test_idle_warps_adopt_warpgroup_nreg():
+    """Idle warps sharing a warpgroup with a role execute that warpgroup's
+    request — not the globally smallest donor budget (here the consumer's
+    40 would break warpgroup 0's uniform 80)."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=80),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=40),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out",
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
+                    ],
+                )
+            )
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
+
+    func = _materialize(kernel)
+    script = str(func)
+    # Producer branch + idle warps 1..3 of warpgroup 0: both request 80.
+    assert script.count("T.set_max_nreg(80, 0)") == 2
+    assert script.count("T.set_max_nreg(40, 0)") == 1  # consumer warpgroup
+
+
+def test_two_scheduled_kernels_in_one_function():
+    """A function may hold several kernels, each with its own schedule;
+    each is materialized under its own threadIdx.x binding, widened to
+    that schedule's warp count."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((64, 64), T.float16), B: T.Tensor((64, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=4,
+                    roles=[T.WSRole("R", warps_lo=0, warps_hi=4, max_nreg=224)],
+                    pipelines=[],
+                    scopes=[T.WSScope(T.WSScope.ROOT, {"R": ["cp"]})],
+                )
+            )
+            T.copy(A, B, annotations={T.WSID: "cp"})
+        with T.Kernel(1, threads=128) as _:
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[T.WSRole("S", warps_lo=0, warps_hi=8, max_nreg=224)],
+                    pipelines=[],
+                    scopes=[T.WSScope(T.WSScope.ROOT, {"S": ["cp2"]})],
+                )
+            )
+            T.copy(B, A, annotations={T.WSID: "cp2"})
+
+    func = _materialize(kernel)
+    script = str(func)
+    # Each kernel's own binding is widened to its own schedule's warps.
+    assert 'T.launch_thread("threadIdx.x", 128)' in script
+    assert 'T.launch_thread("threadIdx.x", 256)' in script
+    assert script.count("T.set_max_nreg(224, 1)") == 2
+    assert "ws_schedule" not in script and "ws_op_id" not in script
+
+
+def test_multi_dim_thread_launch_rejected():
+    """Warp roles partition threadIdx.x only: a scheduled kernel under a
+    2-D thread launch would mis-assign warps."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((64, 64), T.float16), B: T.Tensor((64, 64), T.float16)):
+        with T.Kernel(1, threads=(64, 2)) as _:
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=4,
+                    roles=[T.WSRole("R", warps_lo=0, warps_hi=4, max_nreg=224)],
+                    pipelines=[],
+                    scopes=[T.WSScope(T.WSScope.ROOT, {"R": ["cp"]})],
+                )
+            )
+            T.copy(A, B, annotations={T.WSID: "cp"})
+
+    with pytest.raises(Exception, match="one\\s+dimension"):
+        _materialize(kernel)
+
+
+def test_negative_warp_range_rejected():
+    @T.prim_func
+    def kernel(A: T.Tensor((64, 64), T.float16), B: T.Tensor((64, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=4,
+                    roles=[T.WSRole("R", warps_lo=-1, warps_hi=1, max_nreg=224)],
+                    pipelines=[],
+                    scopes=[T.WSScope(T.WSScope.ROOT, {"R": ["cp"]})],
+                )
+            )
+            T.copy(A, B, annotations={T.WSID: "cp"})
+
+    with pytest.raises(Exception, match="negative warp range"):
+        _materialize(kernel)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_materialize_ws_schedule.py
+++ b/testing/python/transform/test_tilelang_transform_materialize_ws_schedule.py
@@ -103,6 +103,7 @@ def _smem_pipeline_kernel(
     return kernel
 
 
+@tilelang.testing.requires_cuda
 def test_basic_two_role_transform():
     func = _materialize(_smem_pipeline_kernel())
     script = str(func)
@@ -117,6 +118,7 @@ def test_basic_two_role_transform():
     assert "ws_op_id" not in script
 
 
+@tilelang.testing.requires_cuda
 def test_buffer_multi_versioning():
     func = _materialize(_smem_pipeline_kernel(depth=3))
     script = str(func)
@@ -126,28 +128,198 @@ def test_buffer_multi_versioning():
     assert "A_shared[i % 3" in script or "A_shared[(i" in script
 
 
-def test_barrier_counts_tma_fallback_and_threads():
+@tilelang.testing.requires_cuda
+def test_barrier_counts_tma_and_threads():
     func = _materialize(_smem_pipeline_kernel())
     script = str(func)
-    # Producer side: the TMA copy rides the tx-count; with no other arrival
-    # the per-thread fallback arrives with the producer warp (32 threads).
+    # Producer side: the TMA data rides the tx-count; the per-thread
+    # arrive of the producer warp (32 threads) closes the arrival count.
     assert "buf_full: [32, 32]" in script
     # Consumer side: synchronous fragment reads -> all 128 consumer threads.
     assert "buf_empty: [128, 128]" in script
 
 
+@tilelang.testing.requires_cuda
 def test_tma_copy_conversion_carries_barrier():
     func = _materialize(_smem_pipeline_kernel())
     script = str(func)
     # The producer copy is converted to tma_copy with the full barrier
-    # attached; no emit_arrive is used.
+    # attached; the commit is a plain per-thread arrive.
     assert "T.tma_copy(" in script
     assert "barrier=buf_full" in script
     assert "emit_arrive" not in script
-    # The commit is a plain per-thread arrive (transaction fallback).
     assert "T.ptx_arrive_barrier(buf_full" in script
 
 
+@tilelang.testing.requires_cuda
+def test_guarded_tma_copy_keeps_unconditional_syncs():
+    """A source-guarded TMA copy skips only the copy itself: the
+    acquire/commit and the per-thread arrives stay unconditional, so the
+    pipeline cycles every iteration (a skipped copy simply contributes no
+    transaction bytes)."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out",
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
+                    ],
+                )
+            )
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                if i < 3:
+                    T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
+
+    func = _materialize(kernel)
+    script = str(func)
+    assert "buf_full: [32, 32]" in script
+    assert "emit_arrive" not in script
+    assert "T.ptx_arrive_barrier(buf_full" in script
+
+
+@tilelang.testing.requires_cuda
+def test_cp_async_with_sync_work_keeps_both_arrives():
+    """The deferred cp.async arrive publishes only the thread's own
+    cp.async data, so synchronous work on the same side keeps its plain
+    release arrive — both are emitted and both are counted."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "pad_in",
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out",
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
+                    ],
+                )
+            )
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                T.fill(A_shared, 0, annotations={T.WSID: "pad_in"})
+                T.async_copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
+
+    func = _materialize(kernel)
+    script = str(func)
+    assert "cp_async_barrier_noinc(buf_full" in script
+    assert "T.ptx_arrive_barrier(buf_full" in script
+    # One deferred + one plain arrive per producer thread (32 + 32).
+    assert "buf_full: [64, 64]" in script
+
+
+@tilelang.testing.requires_cuda
+def test_prefer_instruction_cp_async_selects_cp_async_atom():
+    """``T.copy(..., prefer_instruction="cp_async")`` classifies as a
+    cp.async op like ``T.async_copy``: the copy loses its implicit
+    commit/wait and the commit entry carries the deferred arrive."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out",
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
+                    ],
+                )
+            )
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                T.copy(
+                    A[i * 64, 0],
+                    A_shared,
+                    prefer_instruction="cp_async",
+                    annotations={T.WSID: "copy_in"},
+                )
+                T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
+
+    func = _materialize(kernel)
+    script = str(func)
+    assert "no_implicit_async_commit_wait" in script
+    assert "cp_async_barrier_noinc(buf_full" in script
+    # The deferred arrive is the only producer arrive (32 threads).
+    assert "buf_full: [32, 32]" in script
+    assert "T.ptx_arrive_barrier(buf_full" not in script
+
+
+@tilelang.testing.requires_cuda
 def test_consumer_wait_parity():
     func = _materialize(_smem_pipeline_kernel(depth=2))
     script = str(func)
@@ -157,6 +329,7 @@ def test_consumer_wait_parity():
     assert "T.mbarrier_wait_parity(buf_full" in script
 
 
+@tilelang.testing.requires_cuda
 def test_uniform_stages_cancel():
     # When ALL of a role's sync stages agree, the offsets cancel and the
     # loop is emitted unshifted (the documented loop-equivalence).
@@ -165,10 +338,9 @@ def test_uniform_stages_cancel():
     assert "for i in range(4):" in script  # original extent, no guards
 
 
-def test_stage_offset_shifts_and_guards():
-    """Two pipelines synced at different stages within one role: the body
-    at the later stage runs one logical iteration behind, the loop gains an
-    extra step, and boundary guards appear."""
+def _stage_offset_kernel(extent):
+    """Two pipelines synced at different stages within one role: the
+    entries at the later stage run one logical iteration behind."""
 
     @T.prim_func
     def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
@@ -217,32 +389,62 @@ def test_stage_offset_shifts_and_guards():
                 )
             )
 
-            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+            for i in T.Pipelined(extent, num_stages=2, annotations={T.WSID: "loop_k"}):
                 T.copy(A[i * 32, 0], A_shared, annotations={T.WSID: "copy_a"})
                 T.copy(A[i * 32, 0], C_shared, annotations={T.WSID: "copy_c"})
                 T.copy(A_shared, A_frag, annotations={T.WSID: "read_a"})
                 T.copy(C_shared, C_frag, annotations={T.WSID: "read_c"})
 
-    func = _materialize(kernel)
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_stage_offset_unrolls_prologue_epilogue():
+    """The shifted body unrolls into an explicit prologue step, a
+    steady-state loop with no per-iteration boundary checks, and an
+    explicit epilogue step."""
+    func = _materialize(_stage_offset_kernel(4))
     script = str(func)
-    # Producer loop lengthened by the stage shift with boundary guards: the
-    # 4-step loop runs 5 steps.
-    assert "range(5)" in script
-    assert "i < 4" in script  # stage-0 upper guard
-    assert "i >= 1" in script or "1 <= i" in script  # stage-1 lower guard
-    # The stage-1 copy addresses the previous logical iteration.
+    # The producer's steady state covers iterations [1, 4) and carries no
+    # boundary checks; the stage-1 entries address the previous logical
+    # iteration.
+    assert "for i in range(1, 4):" in script
     assert "i - 1" in script
-    # Consecutive entries at one stage share ONE merged guard block each
-    # (acquire/copy/commit runs of the producer), not a run of equal ifs.
-    assert script.count("if i < 4") == 1
-    assert len(re.findall(r"if (?:i >= 1|1 <= i)", script)) == 1
+    assert "i >= 1" not in script and "1 <= i" not in script
+    assert "if i < 4" not in script
+    # Prologue (the stage-0 entries at iteration 0) precedes the loop;
+    # epilogue (the stage-1 entries at iteration 3) follows it.
+    producer = script[script.find("T.set_max_nreg(40, 0)") :]
+    prologue = producer.find("T.mbarrier_wait_parity(a_empty_1[0], 1)")
+    loop = producer.find("for i in range(1, 4):")
+    epilogue = producer.find("T.mbarrier_wait_parity(c_empty_1[1], 0)")
+    assert 0 <= prologue < loop < epilogue
 
 
+@tilelang.testing.requires_cuda
+def test_short_static_loop_folds_to_prologue_epilogue():
+    """A loop shorter than its stage shift: the unrolled prologue and
+    epilogue steps cover every iteration under constant bounds, and the
+    pipeline's Simplify pass folds them away together with the empty
+    steady-state loop."""
+    func = _materialize(_stage_offset_kernel(1))
+    mod = tilelang.transform.Simplify()(tvm.IRModule.from_expr(func))
+    script = str(mod["main"])
+    producer = script[script.find("T.set_max_nreg(40, 0)") : script.find("T.set_max_nreg(224, 1)")]
+    # One cycle of each pipeline, no loop, no residual constant guards.
+    assert producer.count("T.mbarrier_wait_parity(a_empty") == 1
+    assert producer.count("T.mbarrier_wait_parity(c_empty") == 1
+    assert "for " not in producer
+    assert "T.bool(True)" not in producer
+
+
+@tilelang.testing.requires_cuda
 def test_mismatched_pair_stages_rejected():
     with pytest.raises(Exception, match="pairs must share one stage"):
         _materialize(_smem_pipeline_kernel(consumer_wait_stage=0, consumer_release_stage=1))
 
 
+@tilelang.testing.requires_cuda
 def test_missing_commit_rejected():
     # A pipeline whose producer never commits has no full-side signal.
     def drop_commit(bodies):
@@ -252,6 +454,7 @@ def test_missing_commit_rejected():
         _materialize(_smem_pipeline_kernel(schedule_edit=drop_commit))
 
 
+@tilelang.testing.requires_cuda
 def test_unclosed_span_rejected():
     # An extra trailing acquire leaves the span open at the end of the body.
     def extra_acquire(bodies):
@@ -261,6 +464,7 @@ def test_unclosed_span_rejected():
         _materialize(_smem_pipeline_kernel(schedule_edit=extra_acquire))
 
 
+@tilelang.testing.requires_cuda
 def test_double_acquire_rejected():
     # Two acquires without an intervening commit are a double-open.
     def double_acquire(bodies):
@@ -271,6 +475,7 @@ def test_double_acquire_rejected():
         _materialize(_smem_pipeline_kernel(schedule_edit=double_acquire))
 
 
+@tilelang.testing.requires_cuda
 def test_role_both_producer_and_consumer_rejected():
     # The flavors are the two parties of the handshake: a role handing data
     # to itself needs no pipeline, so one role must not hold both flavors.
@@ -289,6 +494,7 @@ def test_role_both_producer_and_consumer_rejected():
         _materialize(_smem_pipeline_kernel(schedule_edit=self_handshake))
 
 
+@tilelang.testing.requires_cuda
 def test_unknown_pipeline_rejected():
     def rename_pipeline(bodies):
         bodies["Producer"][0] = T.WSSync.producer_acquire("nonexistent")
@@ -297,6 +503,7 @@ def test_unknown_pipeline_rejected():
         _materialize(_smem_pipeline_kernel(schedule_edit=rename_pipeline))
 
 
+@tilelang.testing.requires_cuda
 def test_missing_op_rejected():
     def add_ghost_op(bodies):
         bodies["Producer"].append("ghost_op")
@@ -305,6 +512,7 @@ def test_missing_op_rejected():
         _materialize(_smem_pipeline_kernel(schedule_edit=add_ghost_op))
 
 
+@tilelang.testing.requires_cuda
 def test_unscheduled_statement_rejected():
     def drop_consumer_op(bodies):
         bodies["Consumer"] = [e for e in bodies["Consumer"] if e != "copy_frag"]
@@ -313,14 +521,403 @@ def test_unscheduled_statement_rejected():
         _materialize(_smem_pipeline_kernel(schedule_edit=drop_consumer_op, kernel_edit="unannotated_consumer"))
 
 
-def test_op_scheduled_by_multiple_roles_rejected():
+@tilelang.testing.requires_cuda
+def test_op_with_pipeline_operand_duplicated_across_roles_rejected():
+    # copy_frag reads A_shared, a pipeline buffer: duplicating it across
+    # roles would have both parties of the handshake access the buffer.
     def share_op(bodies):
         bodies["Producer"].append("copy_frag")
 
-    with pytest.raises(Exception, match="scheduled by multiple roles"):
+    with pytest.raises(Exception, match="duplicated across roles"):
         _materialize(_smem_pipeline_kernel(schedule_edit=share_op))
 
 
+@tilelang.testing.requires_cuda
+def test_empty_defs_op_duplicated_across_roles():
+    """An op touching no pipeline buffers may be placed by several roles;
+    each role branch runs its own copy of the statement."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                    "step_frag",
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "step_frag",
+                                ],
+                            },
+                        ),
+                        T.WSScope(
+                            T.WSScope.ROOT,
+                            {
+                                "Producer": ["init_frag", "loop_k"],
+                                "Consumer": ["init_frag", "loop_k", "copy_out"],
+                            },
+                        ),
+                    ],
+                )
+            )
+
+            T.fill(A_frag, 0, annotations={T.WSID: "init_frag"})
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                for r, c in T.Parallel(64, 64, annotations={T.WSID: "step_frag"}):
+                    A_frag[r, c] = A_frag[r, c] + T.float16(1.0)
+            T.copy(A_frag, B[0, 0], annotations={T.WSID: "copy_out"})
+
+    func = _materialize(kernel)
+    script = str(func)
+    # Both roles run their own copy: once in the producer branch, once in
+    # the consumer branch — at the root and inside the loop scope alike.
+    assert script.count("T.fill(") == 2
+    assert script.count("A_frag[r, c] + T.float16(1.0)") == 2
+    # Scheduling metadata is fully consumed.
+    assert "ws_op_id" not in script
+
+
+@tilelang.testing.requires_cuda
+def test_raw_ptx_cp_async_is_opaque():
+    """A raw ptx_cp_async gets no special handling: with its own
+    commit_group + wait_group(0) it is a synchronous unit like any other
+    op — its access_ptr operands bind it to the pipeline (the write-side
+    base load), the version dimension joins the base load's indices, and
+    the producer commit is the plain per-thread arrive."""
+
+    @T.prim_func
+    def kernel(B: T.Tensor((4, 8), T.float16), B_out: T.Tensor((4, 8), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            B_shared = T.alloc_shared((8,), T.float16)
+            B_frag = T.alloc_fragment((8,), T.float16)
+
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [B_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "cp_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out",
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
+                    ],
+                )
+            )
+
+            for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                with T.ws_op("cp_in"):
+                    T.ptx_cp_async(
+                        T.access_ptr(B_shared[0], "w", 8),
+                        T.access_ptr(B[i, 0], "r", 8),
+                        8,
+                    )
+                    T.ptx_commit_group()
+                    T.ptx_wait_group(0)
+                T.copy(B_shared, B_frag, annotations={T.WSID: "copy_frag"})
+                T.copy(B_frag, B_out[i, 0], annotations={T.WSID: "copy_out"})
+
+    func = _materialize(kernel)
+    script = str(func)
+    # The op is cloned as-is (its own group sync included); the commit is
+    # the plain per-thread arrive of the producer warp.
+    assert "cp_async_barrier_noinc" not in script
+    assert "T.ptx_commit_group()" in script
+    assert "T.ptx_wait_group(0)" in script
+    assert "T.ptx_arrive_barrier(buf_full" in script
+    assert "buf_full: [32, 32]" in script
+    assert "buf_empty: [128, 128]" in script
+    # The version dimension joins the access_ptr base load.
+    assert "B_shared[i % 2, 0]" in script
+
+
+def _guarded_scope_kernel(guard_on_pipeline_buffer=False):
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((256, 64), T.float16),
+        B: T.Tensor((256, 64), T.float16),
+        flag: T.Tensor((1,), T.int32),
+    ):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_k",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out",
+                                ],
+                            },
+                        ),
+                        T.WSScope(T.WSScope.ROOT, {"Producer": ["loop_k"], "Consumer": ["loop_k"]}),
+                    ],
+                )
+            )
+
+            if guard_on_pipeline_buffer:
+                if A_shared[0, 0] > T.float16(0):
+                    for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                        T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                        T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                        T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
+            else:
+                if flag[0] > 0:
+                    for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
+                        T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                        T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                        T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_guarded_scope_loop():
+    """A source guard around a scope loop is emitted in every role: all
+    roles evaluate the same uniform condition, so a false guard skips the
+    scope's sync entries together and the pipeline phases stay aligned."""
+    func = _materialize(_guarded_scope_kernel())
+    script = str(func)
+    # One guarded loop per role branch.
+    assert script.count("if flag[0] > 0:") == 2
+    assert "ws_op_id" not in script
+
+
+@tilelang.testing.requires_cuda
+def test_guarded_scope_loop_pipeline_buffer_rejected():
+    # A guard reading a pipeline buffer cannot be uniform across roles.
+    with pytest.raises(Exception, match="uniform across roles"):
+        _materialize(_guarded_scope_kernel(guard_on_pipeline_buffer=True))
+
+
+def _while_scope_kernel(shifted=False):
+    """A persistent-scheduler-style while scope: per-role duplicated
+    scheduler state and a smem pipeline synced under the while (forcing a
+    runtime phase counter). With ``shifted``, a second producer pipeline
+    is consumed at stage 1, so the consumer's while body carries a stage
+    shift (forcing an unrolled prologue/epilogue)."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(4, threads=128) as block_id:
+            A_shared = T.alloc_shared((32, 64), T.float16)
+            C_shared = T.alloc_shared((32, 64), T.float16)
+            A_frag = T.alloc_fragment((32, 64), T.float16)
+            C_frag = T.alloc_fragment((32, 64), T.float16)
+            sched = T.PersistentTileScheduler(4, 1, num_workers=4, name="sched")
+
+            producer = [
+                T.WSSync.producer_acquire("buf"),
+                "copy_in",
+                T.WSSync.producer_commit("buf"),
+            ]
+            consumer = [
+                T.WSSync.consumer_wait("buf", stage=0),
+                "copy_frag",
+                T.WSSync.consumer_release("buf", stage=0),
+            ]
+            pipelines = [T.WSPipeline("buf", [A_shared], depth=2)]
+            if shifted:
+                pipelines.append(T.WSPipeline("cbuf", [C_shared], depth=2))
+                producer += [
+                    T.WSSync.producer_acquire("cbuf"),
+                    "copy_in_c",
+                    T.WSSync.producer_commit("cbuf"),
+                ]
+                consumer += [
+                    T.WSSync.consumer_wait("cbuf", stage=1),
+                    "copy_frag_c",
+                    T.WSSync.consumer_release("cbuf", stage=1),
+                ]
+            consumer.append("copy_out")
+
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=pipelines,
+                    scopes=[
+                        T.WSScope(
+                            "loop_wave",
+                            {
+                                "Producer": producer + ["sched_next"],
+                                "Consumer": consumer + ["sched_next"],
+                            },
+                        ),
+                        T.WSScope(
+                            T.WSScope.ROOT,
+                            {
+                                "Producer": ["sched_init", "loop_wave"],
+                                "Consumer": ["sched_init", "loop_wave"],
+                            },
+                        ),
+                    ],
+                )
+            )
+
+            with T.ws_op("sched_init"):
+                sched.init(block_id)
+            with T.ws_op("loop_wave"):
+                while sched.valid():
+                    T.copy(A[sched.m_idx * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
+                    T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                    if shifted:
+                        T.copy(A[sched.m_idx * 64 + 32, 0], C_shared, annotations={T.WSID: "copy_in_c"})
+                        T.copy(C_shared, C_frag, annotations={T.WSID: "copy_frag_c"})
+                        T.copy(C_frag, B[sched.m_idx * 64 + 32, 0], annotations={T.WSID: "copy_out"})
+                    else:
+                        T.copy(A_frag, B[sched.m_idx * 64, 0], annotations={T.WSID: "copy_out"})
+                    with T.ws_op("sched_next"):
+                        sched.next_tile()
+
+    return kernel
+
+
+@tilelang.testing.requires_cuda
+def test_while_scope_counter_phases():
+    """A while scope has no iteration expression: the pipeline synced
+    under it takes a runtime phase counter in both roles, the scheduler
+    state ops are duplicated per role, and each role re-evaluates the
+    uniform condition."""
+    func = _materialize(_while_scope_kernel())
+    script = str(func)
+    # One while per role, both on the scheduler state.
+    assert script.count("while sched_linear_idx[0] < 4:") == 2
+    # The scheduler init/advance runs in both roles.
+    assert script.count("sched_current_iter[0] = 0") == 2
+    assert script.count("sched_current_iter[0] = sched_current_iter[0] + 1") == 2
+    # Phases are runtime counters, bumped at the commit/release entries.
+    assert "buf_phase" in script
+    assert script.count("buf_phase[0] = buf_phase[0] + 1") == 2
+    assert "ws_op_id" not in script
+
+
+@tilelang.testing.requires_cuda
+def test_while_scope_stage_offset_prologue_epilogue():
+    """A stage shift under a while scope unrolls into an explicit
+    prologue step (the early-stage entries under the loop condition) and
+    an epilogue step (the late-stage entries, guarded by the completed
+    trip count) instead of per-iteration boundary guards."""
+    func = _materialize(_while_scope_kernel(shifted=True))
+    script = str(func)
+    # The consumer's shifted body: prologue `if cond`, then the while,
+    # then the trip-guarded drain step.
+    consumer = script[script.find("T.set_max_nreg(224, 1)") :]
+    prologue = consumer.find("if sched_linear_idx[0] < 4:")
+    kernel_loop = consumer.find("while sched_linear_idx[0] < 4:")
+    drain = consumer.find("if 1 <= loop_wave_trips[0]:")
+    assert 0 <= prologue < kernel_loop < drain
+    assert "loop_wave_trips[0] = loop_wave_trips[0] + 1" in consumer
+
+
+@tilelang.testing.requires_cuda
+def test_while_condition_pipeline_buffer_rejected():
+    # A while condition reading a pipeline buffer cannot be uniform.
+    @T.prim_func
+    def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
+        with T.Kernel(1, threads=128) as _:
+            A_shared = T.alloc_shared((64, 64), T.float16)
+            A_frag = T.alloc_fragment((64, 64), T.float16)
+            T.annotate_ws_schedule(
+                T.WSSchedule(
+                    num_warps=8,
+                    roles=[
+                        T.WSRole("Producer", warps_lo=0, warps_hi=1, max_nreg=40),
+                        T.WSRole("Consumer", warps_lo=4, warps_hi=8, max_nreg=224),
+                    ],
+                    pipelines=[T.WSPipeline("buf", [A_shared], depth=2)],
+                    scopes=[
+                        T.WSScope(
+                            "loop_wave",
+                            {
+                                "Producer": [
+                                    T.WSSync.producer_acquire("buf"),
+                                    "copy_in",
+                                    T.WSSync.producer_commit("buf"),
+                                ],
+                                "Consumer": [
+                                    T.WSSync.consumer_wait("buf"),
+                                    "copy_frag",
+                                    T.WSSync.consumer_release("buf"),
+                                    "copy_out",
+                                ],
+                            },
+                        ),
+                        T.WSScope(
+                            T.WSScope.ROOT,
+                            {"Producer": ["loop_wave"], "Consumer": ["loop_wave"]},
+                        ),
+                    ],
+                )
+            )
+            with T.ws_op("loop_wave"):
+                while A_shared[0, 0] > T.float16(0):
+                    T.copy(A[0, 0], A_shared, annotations={T.WSID: "copy_in"})
+                    T.copy(A_shared, A_frag, annotations={T.WSID: "copy_frag"})
+                    T.copy(A_frag, B[0, 0], annotations={T.WSID: "copy_out"})
+
+    with pytest.raises(Exception, match="uniform across roles"):
+        _materialize(kernel)
+
+
+@tilelang.testing.requires_cuda
 def test_distinct_guards_stay_distinct():
     """Consecutive guarded ops with structurally different guards keep
     their own conditions."""
@@ -381,10 +978,11 @@ def test_distinct_guards_stay_distinct():
     assert "< 2" in script
 
 
-def test_ws_op_wrapper_single_statement_only():
-    """T.ws_op manually annotates exactly one statement (the escape hatch
-    for statement forms without annotations=); wrapping several statements
-    is rejected — every scheduled statement needs its own id."""
+@tilelang.testing.requires_cuda
+def test_ws_op_wrapper_groups_statements():
+    """T.ws_op wrapping several statements (an inlined scheduler method,
+    say) forms ONE opaque op: the accesses union, and the whole group is
+    cloned into its role."""
 
     @T.prim_func
     def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
@@ -410,9 +1008,8 @@ def test_ws_op_wrapper_single_statement_only():
                                 ],
                                 "Consumer": [
                                     T.WSSync.consumer_wait("buf"),
-                                    "copy_frag",
+                                    "copy_frag_out",
                                     T.WSSync.consumer_release("buf"),
-                                    "copy_out",
                                 ],
                             },
                         ),
@@ -422,14 +1019,20 @@ def test_ws_op_wrapper_single_statement_only():
             )
             for i in T.Pipelined(4, num_stages=2, annotations={T.WSID: "loop_k"}):
                 T.copy(A[i * 64, 0], A_shared, annotations={T.WSID: "copy_in"})
-                with T.ws_op("copy_frag"):
+                with T.ws_op("copy_frag_out"):
                     T.copy(A_shared, A_frag)
-                    T.copy(A_frag, B[i * 64, 0], annotations={T.WSID: "copy_out"})
+                    T.copy(A_frag, B[i * 64, 0])
 
-    with pytest.raises(Exception, match="exactly one statement"):
-        _materialize(kernel)
+    func = _materialize(kernel)
+    script = str(func)
+    # Both statements of the group emitted once, in the consumer branch,
+    # with the pipeline read version-rebound.
+    assert script.count("A_frag") >= 2
+    assert "A_shared[i % 2" in script
+    assert "ws_op_id" not in script
 
 
+@tilelang.testing.requires_cuda
 def test_unannotated_global_store_rejected():
     """A statement whose only effect is a global write must be placed by
     the schedule like any other op; unannotated it would silently vanish
@@ -438,6 +1041,7 @@ def test_unannotated_global_store_rejected():
         _materialize(_smem_pipeline_kernel(kernel_edit="unannotated_global_store"))
 
 
+@tilelang.testing.requires_cuda
 def test_nonzero_loop_base_phase():
     """A scope loop starting at a non-zero base counts pipeline phases from
     the base: iteration `base` is phase 0, so barrier indices and parities
@@ -494,6 +1098,7 @@ def test_nonzero_loop_base_phase():
     assert re.search(r"\bi(_\d+)? % 2", script) is None
 
 
+@tilelang.testing.requires_cuda
 def test_release_before_use_rejected():
     """Work on a pipeline's buffers after the span closed races with the
     next producer of the stage; the span-coverage check rejects it."""
@@ -511,6 +1116,7 @@ def test_release_before_use_rejected():
         _materialize(_smem_pipeline_kernel(schedule_edit=release_early))
 
 
+@tilelang.testing.requires_cuda
 def test_unbracketed_producer_rejected():
     """A producer op scheduled outside its pipeline's acquire/commit
     bracket is rejected by the span-coverage check even though the bracket
@@ -527,6 +1133,7 @@ def test_unbracketed_producer_rejected():
         _materialize(_smem_pipeline_kernel(schedule_edit=op_outside_bracket))
 
 
+@tilelang.testing.requires_cuda
 def test_cycle_imbalance_rejected():
     """A pipeline cycling twice on the producer side but once on the
     consumer side per loop iteration diverges parity every trip."""
@@ -544,6 +1151,7 @@ def test_cycle_imbalance_rejected():
         _materialize(_smem_pipeline_kernel(schedule_edit=double_producer_cycle))
 
 
+@tilelang.testing.requires_cuda
 def test_cross_pipeline_deadlock_rejected():
     """Two roles waiting on each other's pipelines before producing their
     own deadlock immediately; the parity-model execution catches it."""
@@ -608,6 +1216,7 @@ def test_cross_pipeline_deadlock_rejected():
         _materialize(kernel)
 
 
+@tilelang.testing.requires_cuda
 def test_op_writing_two_pipelines_rejected():
     """An op's synchronization can only trigger one pipeline: a single op
     statement (here a T.Parallel op node) writing buffers of two pipelines
@@ -675,6 +1284,7 @@ def test_op_writing_two_pipelines_rejected():
         _materialize(kernel)
 
 
+@tilelang.testing.requires_cuda
 def test_unknown_role_body_rejected():
     def add_role_body(bodies):
         bodies["Ghost"] = []
@@ -683,15 +1293,24 @@ def test_unknown_role_body_rejected():
         _materialize(_smem_pipeline_kernel(schedule_edit=add_role_body))
 
 
+@tilelang.testing.requires_cuda
 def test_num_warps_must_be_warpgroup_aligned():
+    # Warps are managed in warpgroups of 4.
     with pytest.raises(AssertionError, match="multiple of 4"):
-        T.WSSchedule(num_warps=6, roles=[], pipelines=[], scopes=[])
+        T.WSSchedule(
+            num_warps=6,
+            roles=[T.WSRole("R", warps_lo=0, warps_hi=6)],
+            pipelines=[],
+            scopes=[],
+        )
 
 
+@tilelang.testing.requires_cuda
 def test_ws_scope_root_constant():
     assert T.WSScope.ROOT == "tl.ws_scope_root"
 
 
+@tilelang.testing.requires_cuda
 def test_ws_sync_kind_enum_round_trip():
     sync = T.WSSync.consumer_release("p", stage=3)
     assert sync.kind.same_as(T.WSSyncKind.CONSUMER_RELEASE)
@@ -699,6 +1318,7 @@ def test_ws_sync_kind_enum_round_trip():
     assert int(sync.stage) == 3
 
 
+@tilelang.testing.requires_cuda
 def test_ws_role_requires_keyword_range():
     role = T.WSRole("R", warps_lo=4, warps_hi=8, max_nreg=224)
     assert int(role.warp_lo) == 4 and int(role.warp_hi) == 8
@@ -749,6 +1369,7 @@ def _scope_kind_kernel(loop_ctor):
     return kernel
 
 
+@tilelang.testing.requires_cuda
 def test_serial_scope_loop_and_unrolled_rejected():
     """Any serial loop can be a schedule scope (T.Pipelined is a serial
     loop whose num_stages this pass consumes); T.unroll / T.Parallel loops
@@ -764,6 +1385,7 @@ def test_serial_scope_loop_and_unrolled_rejected():
         _materialize(_scope_kind_kernel(T.unroll))
 
 
+@tilelang.testing.requires_cuda
 def test_op_node_loop():
     """A T.unroll loop with an id is one op node: inner statements need no
     ids, the loop keeps its kind, and its pipeline reads rebind to the
@@ -820,6 +1442,7 @@ def test_op_node_loop():
     assert "A_shared[i % 2, 0, s * 32]" in script
 
 
+@tilelang.testing.requires_cuda
 def test_idle_donor_branch():
     # Roles cover warps [0,1) and [4,8) of 8: warps 1-4 form a gap branch
     # and warps beyond the last role donate registers too.
@@ -829,6 +1452,7 @@ def test_idle_donor_branch():
     assert script.count("T.set_max_nreg(40, 0)") >= 2
 
 
+@tilelang.testing.requires_cuda
 def test_unscheduled_kernel_untouched():
     """Schedule and op ids come together (both or neither): a kernel
     without the schedule annotation is returned exactly as it came in —
@@ -848,6 +1472,7 @@ def test_unscheduled_kernel_untouched():
     assert tvm.ir.structural_equal(out, mod["main"])
 
 
+@tilelang.testing.requires_cuda
 def test_tcgen05_async_arrive_count():
     """A gemm accumulating into TMEM signals with tcgen05.commit: the full
     barrier of the accumulator pipeline gets arrive count 1, and the smem
@@ -937,6 +1562,7 @@ def test_tcgen05_async_arrive_count():
     assert "T.tcgen05_mma_arrive(" in script
 
 
+@tilelang.testing.requires_cuda
 def test_runtime_phase_counter_for_multi_depth_spans():
     """A pipeline synchronized at two loop depths by one role needs a
     runtime phase counter instead of the linearized iteration."""
@@ -1009,6 +1635,7 @@ def test_runtime_phase_counter_for_multi_depth_spans():
     assert "buf_phase" in script
 
 
+@tilelang.testing.requires_cuda
 def test_op_referenced_twice_rejected():
     # An op's statement is cloned verbatim; referencing it twice would
     # duplicate the work.
@@ -1019,6 +1646,7 @@ def test_op_referenced_twice_rejected():
         _materialize(_smem_pipeline_kernel(schedule_edit=duplicate_ref))
 
 
+@tilelang.testing.requires_cuda
 def test_scope_loop_nonunit_step_rejected():
     """Phases count iterations as (loop_var - min), which a non-unit step
     breaks. The eager frontend desugars T.serial(..., step) into a
@@ -1045,6 +1673,7 @@ def test_scope_loop_nonunit_step_rejected():
         _materialize(stepped)
 
 
+@tilelang.testing.requires_cuda
 def test_guard_read_outside_span_rejected():
     """A buffer read only by an op's if-condition is an operand too: a
     guard reading a pipeline buffer after the role released it is
@@ -1096,6 +1725,7 @@ def test_guard_read_outside_span_rejected():
         _materialize(kernel)
 
 
+@tilelang.testing.requires_cuda
 def test_one_sided_scope_cycles_rejected():
     """A pipeline cycling on one side only inside a loop scope (its
     counterpart cycles in the root here) diverges with the loop extent;
@@ -1151,10 +1781,11 @@ def test_one_sided_scope_cycles_rejected():
         _materialize(kernel)
 
 
-def test_source_guard_combines_with_boundary_guard():
-    """An op carrying both a stage boundary guard and its own source guard
-    gets ONE combined condition, not nested ifs; the source guard is
-    substituted with the shifted iteration."""
+@tilelang.testing.requires_cuda
+def test_source_guard_follows_shifted_iteration():
+    """The source guard of an op at a later stage is substituted with the
+    op's shifted iteration — it is the only condition inside the
+    steady-state loop, which carries no boundary checks of its own."""
 
     @T.prim_func
     def kernel(A: T.Tensor((256, 64), T.float16), B: T.Tensor((256, 64), T.float16)):
@@ -1210,14 +1841,13 @@ def test_source_guard_combines_with_boundary_guard():
 
     func = _materialize(kernel)
     script = str(func)
-    # copy_c runs at stage 1: its boundary guard (i >= 1) and its source
-    # guard (i < 3, on the shifted iteration i - 1) meet in one condition.
-    assert re.search(r"if i >= 1 and i - 1 < 3", script) or re.search(r"if 1 <= i and i - 1 < 3", script), script
-    # The acquire/commit around it keep their unconditional boundary-only
-    # guard: the source guard never covers sync entries.
-    assert len(re.findall(r"if (?:i >= 1|1 <= i):", script)) >= 1
+    # copy_c runs at stage 1: inside the loop its source guard (i < 3)
+    # follows the shifted iteration, and no boundary guard joins it.
+    assert re.search(r"if i - 1 < 3", script), script
+    assert "i >= 1" not in script and "1 <= i" not in script
 
 
+@tilelang.testing.requires_cuda
 def test_warpgroup_nreg_conflict_rejected():
     """setmaxnreg allocates per warpgroup: two roles inside one warpgroup
     (warps 4g..4g+3) must request the same max_nreg."""
@@ -1242,6 +1872,7 @@ def test_warpgroup_nreg_conflict_rejected():
         _materialize(kernel)
 
 
+@tilelang.testing.requires_cuda
 def test_idle_warps_adopt_warpgroup_nreg():
     """Idle warps sharing a warpgroup with a role execute that warpgroup's
     request — not the globally smallest donor budget (here the consumer's
@@ -1293,6 +1924,7 @@ def test_idle_warps_adopt_warpgroup_nreg():
     assert script.count("T.set_max_nreg(40, 0)") == 1  # consumer warpgroup
 
 
+@tilelang.testing.requires_cuda
 def test_two_scheduled_kernels_in_one_function():
     """A function may hold several kernels, each with its own schedule;
     each is materialized under its own threadIdx.x binding, widened to
@@ -1330,6 +1962,7 @@ def test_two_scheduled_kernels_in_one_function():
     assert "ws_schedule" not in script and "ws_op_id" not in script
 
 
+@tilelang.testing.requires_cuda
 def test_multi_dim_thread_launch_rejected():
     """Warp roles partition threadIdx.x only: a scheduled kernel under a
     2-D thread launch would mis-assign warps."""
@@ -1351,6 +1984,7 @@ def test_multi_dim_thread_launch_rejected():
         _materialize(kernel)
 
 
+@tilelang.testing.requires_cuda
 def test_negative_warp_range_rejected():
     @T.prim_func
     def kernel(A: T.Tensor((64, 64), T.float16), B: T.Tensor((64, 64), T.float16)):

--- a/tilelang/cuda/pipeline.py
+++ b/tilelang/cuda/pipeline.py
@@ -92,10 +92,10 @@ def CUDAPassPipelineBodyPrologue(mod: IRModule, target: Target) -> IRModule:
     # @CUDA-specific
     # Tile-level warp specialization: runs before layout inference so that
     # producer/consumer split happens at the high-level tile-op IR.
-    # The pass classifies copy ops as TMA/cp.async/sync inline. Shared buffers
-    # are multi-versioned internally only for functions where the WS
-    # transformation actually applies.
+    # MaterializeWSSchedule: Materialize a user-provided warp-specialization schedule (T.annotate_ws_schedule).
+    # ProducerConsumerWarpSpecialized: The pass classifies copy ops as TMA/cp.async/sync inline. Shared buffers are multi-versioned internally only for functions where the WS transformation actually applies.
     if allow_warp_specialized(target=target):
+        mod = tilelang.cuda.transform.MaterializeWSSchedule()(mod)
         mod = tilelang.cuda.transform.ProducerConsumerWarpSpecialized()(mod)
 
     # @CUDA / Blackwell specific

--- a/tilelang/cuda/transform/__init__.py
+++ b/tilelang/cuda/transform/__init__.py
@@ -137,6 +137,22 @@ def AnnotateWarpGroupRegAlloc():
     return _ffi_api.AnnotateWarpGroupRegAlloc()  # type: ignore
 
 
+def MaterializeWSSchedule():
+    """Materialize a user-provided warp-specialization schedule.
+
+    Consumes the ``ws_schedule`` block annotation attached by
+    ``T.annotate_ws_schedule`` and rewrites the kernel into explicit
+    warp-specialized form (role branches, multi-versioned buffers,
+    mbarrier synchronization, TMA copies, async tcgen05 MMA).
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    """
+    return _ffi_api.MaterializeWSSchedule()  # type: ignore
+
+
 def PersistThreadblock():
     """PersistThreadblock"""
     return _ffi_api.PersistThreadblock()  # type: ignore
@@ -155,6 +171,7 @@ __all__ = [
     "LowerSharedBarrier",
     "LowerSharedTmem",
     "MarkCudaSyncCalls",
+    "MaterializeWSSchedule",
     "PersistThreadblock",
     "ProducerConsumerWarpSpecialized",
 ]

--- a/tilelang/language/annotations.py
+++ b/tilelang/language/annotations.py
@@ -141,20 +141,29 @@ def annotate_ws_schedule(schedule):
 
 
 def ws_op(op_id: str):
-    """Manually annotate the single enclosed statement with a stable
-    warp-specialization op id.
+    """Manually annotate the enclosed statement(s) with a stable
+    warp-specialization op or scope id.
 
-    Wraps the statement in an ``AttrStmt`` with key :data:`WSID`. This is
-    the annotation of last resort, for statements whose form cannot carry
-    ``annotations=`` — a scalar Bind in particular:
+    Wraps the body in an ``AttrStmt`` with key :data:`WSID`. This is the
+    annotation of last resort, for statement forms that cannot carry
+    ``annotations=`` themselves. The enclosed statements — a scalar Bind,
+    or several statements such as an inlined scheduler method — become
+    ONE opaque op:
 
     >>> with T.ws_op("rescale_vote"):
     ...     should_rescale = T.any_sync(scale_shared[tid] < 1.0)
+    >>> with T.ws_op("sched_next"):
+    ...     sched.next_tile()
+
+    With a scope id the wrapper encloses a ``while`` loop and opens that
+    scope (serial scope loops carry the id in their own annotations):
+
+    >>> with T.ws_op("loop_wave"):
+    ...     while sched.valid():
+    ...         ...
 
     Tile ops and loops pass ``annotations={T.WSID: ...}`` directly
-    instead. The wrapper must enclose exactly one statement; the
-    ``MaterializeWSSchedule`` pass rejects multi-statement bodies (every
-    scheduled statement needs its own id).
+    instead.
     """
     assert isinstance(op_id, str) and op_id, "ws_op id must be a non-empty string"
     return attr(None, WSID, op_id)

--- a/tilelang/language/annotations.py
+++ b/tilelang/language/annotations.py
@@ -9,13 +9,21 @@ from tvm.tirx.script.builder.ir import sblock_attr
 from tvm.tirx import FloatImm, tvm_tuple
 
 __all__ = [
+    "WSID",
     "use_swizzle",
     "annotate_layout",
     "annotate_safe_value",
     "annotate_l2_hit_ratio",
     "annotate_restrict_buffers",
     "annotate_min_blocks_per_sm",
+    "annotate_ws_schedule",
+    "ws_op",
 ]
+
+# Annotation key carrying a statement's stable warp-specialization op id
+# (kWSOpIdKey in src/transform/common/warp_specialize.h). Shorthand so kernels
+# write ``annotations={T.WSID: "copy_A"}`` on tile ops and loops.
+WSID = "tl.ws_op_id"
 
 
 def use_swizzle(panel_size: int, order: str = "row", enable: bool = True):
@@ -114,3 +122,39 @@ def annotate_restrict_buffers(*buffers):
             raise TypeError(f"annotate_restrict_buffers expects Buffer arguments, got {type(buf)}") from e
     # Also return as block attribute (root block exists by default) for readability/tools.
     return sblock_attr({"tl.non_restrict_params": data_vars})
+
+
+def annotate_ws_schedule(schedule):
+    """Attach a warp-specialization schedule to the kernel.
+
+    ``schedule`` is a typed :class:`~tilelang.language.ws_schedule.WSSchedule`
+    object describing how to transform the straight-line kernel into a
+    warp-specialized one: warp roles, pipelines (full/empty barrier pairs
+    protecting multi-versioned buffers), and per-role instruction sequences
+    per loop scope. It is materialized by the ``MaterializeWSSchedule`` pass;
+    see ``examples/aws/gemm.py`` for a complete example.
+    """
+    from tilelang.language.ws_schedule import WSSchedule
+
+    assert isinstance(schedule, WSSchedule), f"annotate_ws_schedule expects a T.WSSchedule object, got {type(schedule)}"
+    return sblock_attr({"tl.ws_schedule": schedule})
+
+
+def ws_op(op_id: str):
+    """Manually annotate the single enclosed statement with a stable
+    warp-specialization op id.
+
+    Wraps the statement in an ``AttrStmt`` with key :data:`WSID`. This is
+    the annotation of last resort, for statements whose form cannot carry
+    ``annotations=`` — a scalar Bind in particular:
+
+    >>> with T.ws_op("rescale_vote"):
+    ...     should_rescale = T.any_sync(scale_shared[tid] < 1.0)
+
+    Tile ops and loops pass ``annotations={T.WSID: ...}`` directly
+    instead. The wrapper must enclose exactly one statement; the
+    ``MaterializeWSSchedule`` pass rejects multi-statement bodies (every
+    scheduled statement needs its own id).
+    """
+    assert isinstance(op_id, str) and op_id, "ws_op id must be a non-empty string"
+    return attr(None, WSID, op_id)

--- a/tilelang/language/atomic.py
+++ b/tilelang/language/atomic.py
@@ -6,6 +6,7 @@ import tilelang.language as T
 from tilelang._typing import BufferLikeType
 from tvm import DataType, ir
 from tvm.tirx import PrimExpr, Buffer, Var, op
+from tilelang.language.utils import _normalize_annotations
 from tilelang.utils.language import to_buffer_region, legalize_pairwise_extents
 from tilelang.language.utils import get_extent
 
@@ -35,7 +36,9 @@ def _get_memory_order_id(operation: str, memory_order: str, valid_orders: frozen
     return _MEMORY_ORDER_ID_MAP[memory_order]
 
 
-def atomic_max(dst: Buffer, value: PrimExpr, memory_order: str | None = None, return_prev: bool = False) -> PrimExpr:
+def atomic_max(
+    dst: Buffer, value: PrimExpr, memory_order: str | None = None, return_prev: bool = False, annotations: dict | None = None
+) -> PrimExpr:
     """
     Perform an atomic maximum on the value stored at dst with an optional memory-order.
 
@@ -111,14 +114,16 @@ def atomic_max(dst: Buffer, value: PrimExpr, memory_order: str | None = None, re
     if return_prev:
         raise NotImplementedError("return_prev is not supported for tile-region-based atomic operations")
 
-    ann = {}
+    ann = _normalize_annotations(annotations)
     if memory_order is not None:
         ann["memory_order"] = _MEMORY_ORDER_ID_MAP[memory_order]
 
-    return T.call_intrin("handle", op.Op.get("tl.tileop.atomicmax"), value, dst, annotations=ann if ann else None)
+    return T.call_intrin("handle", op.Op.get("tl.tileop.atomicmax"), value, dst, annotations=ann)
 
 
-def atomic_min(dst: Buffer, value: PrimExpr, memory_order: str | None = None, return_prev: bool = False) -> PrimExpr:
+def atomic_min(
+    dst: Buffer, value: PrimExpr, memory_order: str | None = None, return_prev: bool = False, annotations: dict | None = None
+) -> PrimExpr:
     """
     Atomically update the value at dst to the minimum of its current value and value.
 
@@ -194,14 +199,21 @@ def atomic_min(dst: Buffer, value: PrimExpr, memory_order: str | None = None, re
     if return_prev:
         raise NotImplementedError("return_prev is not supported for tile-region-based atomic operations")
 
-    ann = {}
+    ann = _normalize_annotations(annotations)
     if memory_order is not None:
         ann["memory_order"] = _MEMORY_ORDER_ID_MAP[memory_order]
 
-    return T.call_intrin("handle", op.Op.get("tl.tileop.atomicmin"), value, dst, annotations=ann if ann else None)
+    return T.call_intrin("handle", op.Op.get("tl.tileop.atomicmin"), value, dst, annotations=ann)
 
 
-def atomic_add(dst: Buffer, value: PrimExpr, memory_order: str | None = None, return_prev: bool = False, use_tma: bool = False) -> PrimExpr:
+def atomic_add(
+    dst: Buffer,
+    value: PrimExpr,
+    memory_order: str | None = None,
+    return_prev: bool = False,
+    use_tma: bool = False,
+    annotations: dict | None = None,
+) -> PrimExpr:
     """
     Atomically add `value` into `dst`, returning a handle to the operation.
 
@@ -288,13 +300,13 @@ def atomic_add(dst: Buffer, value: PrimExpr, memory_order: str | None = None, re
         raise NotImplementedError("return_prev is not supported for tile-region-based atomic operations")
 
     # Build annotations dict
-    ann = {}
+    ann = _normalize_annotations(annotations)
     if use_tma:
         ann["use_tma"] = 1
     if memory_order is not None:
         ann["memory_order"] = _MEMORY_ORDER_ID_MAP[memory_order]
 
-    return T.call_intrin("handle", op.Op.get("tl.tileop.atomicadd"), value, dst, annotations=ann if ann else None)
+    return T.call_intrin("handle", op.Op.get("tl.tileop.atomicadd"), value, dst, annotations=ann)
 
 
 def atomic_addx2(dst: BufferLikeType, value: BufferLikeType, return_prev: bool = False) -> PrimExpr:

--- a/tilelang/language/atomic.py
+++ b/tilelang/language/atomic.py
@@ -80,6 +80,7 @@ def atomic_max(
 
     src_extent = get_extent(value)
     dst_extent = get_extent(dst)
+    ann = _normalize_annotations(annotations)
 
     if dst_extent is None and src_extent is None:
         # Scalar path: use atomicmax_elem_op intrinsic
@@ -93,6 +94,7 @@ def atomic_max(
             T.access_ptr(dst, "rw"),
             value,
             memory_order_id,
+            annotations=ann,
         )
 
     # When both arguments are Buffer, we can check whether they are structural equal.
@@ -114,7 +116,6 @@ def atomic_max(
     if return_prev:
         raise NotImplementedError("return_prev is not supported for tile-region-based atomic operations")
 
-    ann = _normalize_annotations(annotations)
     if memory_order is not None:
         ann["memory_order"] = _MEMORY_ORDER_ID_MAP[memory_order]
 
@@ -165,6 +166,7 @@ def atomic_min(
 
     src_extent = get_extent(value)
     dst_extent = get_extent(dst)
+    ann = _normalize_annotations(annotations)
 
     if dst_extent is None and src_extent is None:
         # Scalar path: use atomicmin_elem_op intrinsic
@@ -178,6 +180,7 @@ def atomic_min(
             T.access_ptr(dst, "rw"),
             value,
             memory_order_id,
+            annotations=ann,
         )
 
     # When both arguments are Buffer, we can check whether they are structural equal.
@@ -199,7 +202,6 @@ def atomic_min(
     if return_prev:
         raise NotImplementedError("return_prev is not supported for tile-region-based atomic operations")
 
-    ann = _normalize_annotations(annotations)
     if memory_order is not None:
         ann["memory_order"] = _MEMORY_ORDER_ID_MAP[memory_order]
 
@@ -260,6 +262,7 @@ def atomic_add(
 
     src_extent = get_extent(value)
     dst_extent = get_extent(dst)
+    ann = _normalize_annotations(annotations)
 
     # Thread-level atomic add, where both extent can't be inferred
     if dst_extent is None and src_extent is None:
@@ -268,7 +271,7 @@ def atomic_add(
 
         # Pass destination by pointer to match device signature
         if memory_order is None:
-            return T.call_intrin(return_type, atomic_add_op, T.access_ptr(dst, "rw"), value)
+            return T.call_intrin(return_type, atomic_add_op, T.access_ptr(dst, "rw"), value, annotations=ann)
         else:
             return T.call_intrin(
                 return_type,
@@ -276,6 +279,7 @@ def atomic_add(
                 T.access_ptr(dst, "rw"),
                 value,
                 _MEMORY_ORDER_ID_MAP[memory_order],
+                annotations=ann,
             )
 
     # When both arguments are Buffer, we can check whether they are structural equal.
@@ -300,7 +304,6 @@ def atomic_add(
         raise NotImplementedError("return_prev is not supported for tile-region-based atomic operations")
 
     # Build annotations dict
-    ann = _normalize_annotations(annotations)
     if use_tma:
         ann["use_tma"] = 1
     if memory_order is not None:

--- a/tilelang/language/common.py
+++ b/tilelang/language/common.py
@@ -137,10 +137,24 @@ from .utils import index_to_coordinates  # noqa: F401
 
 from .symbolics import dynamic, symbolic  # noqa: F401
 from .annotations import (  # noqa: F401
+    WSID,
     use_swizzle,
     annotate_layout,
     annotate_safe_value,
     annotate_restrict_buffers,
+    annotate_ws_schedule,
+    ws_op,
+)
+
+from .ws_schedule import (  # noqa: F401
+    WSRole,
+    WSPipeline,
+    WSInstr,
+    WSOpRef,
+    WSSync,
+    WSSyncKind,
+    WSScope,
+    WSSchedule,
 )
 
 from .meta import (
@@ -187,6 +201,15 @@ _LOCAL_EXPORTS = (
     "Tensor",
     "Unroll",
     "Vectorized",
+    "WSID",
+    "WSInstr",
+    "WSOpRef",
+    "WSPipeline",
+    "WSRole",
+    "WSSchedule",
+    "WSScope",
+    "WSSync",
+    "WSSyncKind",
     "access_ptr",
     "activemask",
     "all_of",
@@ -202,6 +225,8 @@ _LOCAL_EXPORTS = (
     "annotate_layout",
     "annotate_restrict_buffers",
     "annotate_safe_value",
+    "annotate_ws_schedule",
+    "ws_op",
     "any_of",
     "any_sync",
     "async_copy",

--- a/tilelang/language/copy_op.py
+++ b/tilelang/language/copy_op.py
@@ -108,16 +108,9 @@ def copy(
       scope-specific decisions happen during lowering.
     """
     src, dst = _normalize_copy_regions(src, dst)
-    if isinstance(src, tirx.BufferLoad) and isinstance(dst, tirx.BufferLoad):
-        # Scalar fast path. Mirror the dtype conversion the region path applies
-        # in copy.cc; cast to the load dtype, which is what BufferStore checks
-        # once index lanes are folded in.
-        value = src
-        if src.dtype != dst.dtype:
-            value = tirx.Cast(dst.dtype, src)
-        return tirx.BufferStore(dst.buffer, value, dst.indices)
 
-    # Build annotations dict
+    # Build annotations dict before selecting the scalar fast path: a scalar
+    # copy with metadata must remain a tile op so the metadata is preserved.
     ann = _normalize_annotations(annotations)
 
     # Individual arguments take lower precedence than annotations
@@ -134,6 +127,15 @@ def copy(
     # Parallel loop layout hint (Fragment). Mirrors T.Parallel(loop_layout=...)
     if loop_layout is not None and "parallel_loop_layout" not in ann:
         ann["parallel_loop_layout"] = loop_layout
+
+    if isinstance(src, tirx.BufferLoad) and isinstance(dst, tirx.BufferLoad) and not ann:
+        # Scalar fast path. Mirror the dtype conversion the region path applies
+        # in copy.cc; cast to the load dtype, which is what BufferStore checks
+        # once index lanes are folded in.
+        value = src
+        if src.dtype != dst.dtype:
+            value = tirx.Cast(dst.dtype, src)
+        return tirx.BufferStore(dst.buffer, value, dst.indices)
 
     return tirx.call_intrin("handle", tirx.op.Op.get("tl.tileop.copy"), src, dst, annotations=ann)
 
@@ -220,14 +222,14 @@ def async_copy(
         tirx.Call: A handle to the async copy operation
     """
     src, dst = _normalize_copy_regions(src, dst)
-    if isinstance(src, tirx.BufferLoad) and isinstance(dst, tirx.BufferLoad):
-        return tirx.BufferStore(dst.buffer, src, dst.indices)
-
     ann = _normalize_annotations(annotations)
     if "coalesced_width" not in ann and coalesced_width is not None:
         ann["coalesced_width"] = coalesced_width
     if loop_layout is not None and "parallel_loop_layout" not in ann:
         ann["parallel_loop_layout"] = loop_layout
+
+    if isinstance(src, tirx.BufferLoad) and isinstance(dst, tirx.BufferLoad) and not ann:
+        return tirx.BufferStore(dst.buffer, src, dst.indices)
 
     return tirx.call_intrin(
         "handle",

--- a/tilelang/language/copy_op.py
+++ b/tilelang/language/copy_op.py
@@ -9,7 +9,7 @@ from tilelang.utils.language import (
     legalize_pairwise_extents,
 )
 from tilelang.utils.deprecated import deprecated
-from tilelang.language.utils import get_extent, buffer_region_to_tile_region
+from tilelang.language.utils import get_extent, buffer_region_to_tile_region, _normalize_annotations
 import tvm
 from tvm import ir, tirx
 
@@ -118,7 +118,7 @@ def copy(
         return tirx.BufferStore(dst.buffer, value, dst.indices)
 
     # Build annotations dict
-    ann = annotations.copy() if annotations else {}
+    ann = _normalize_annotations(annotations)
 
     # Individual arguments take lower precedence than annotations
     if "coalesced_width" not in ann and coalesced_width is not None:
@@ -129,15 +129,13 @@ def copy(
         eviction_policy_map = {"evict_normal": 0, "evict_first": 1, "evict_last": 2}
         ann["eviction_policy"] = eviction_policy_map[eviction_policy]
     if "prefer_instruction" not in ann and prefer_instruction is not None:
-        ann["prefer_instruction"] = prefer_instruction
-    if isinstance(ann.get("prefer_instruction"), str):
-        ann["prefer_instruction"] = tirx.StringImm(ann["prefer_instruction"])
+        ann["prefer_instruction"] = tirx.StringImm(prefer_instruction)
 
     # Parallel loop layout hint (Fragment). Mirrors T.Parallel(loop_layout=...)
     if loop_layout is not None and "parallel_loop_layout" not in ann:
         ann["parallel_loop_layout"] = loop_layout
 
-    return tirx.call_intrin("handle", tirx.op.Op.get("tl.tileop.copy"), src, dst, annotations=ann if ann else None)
+    return tirx.call_intrin("handle", tirx.op.Op.get("tl.tileop.copy"), src, dst, annotations=ann)
 
 
 def copy_cluster(
@@ -149,6 +147,7 @@ def copy_cluster(
     remote_barrier: tirx.BufferLoad | None = None,
     eviction_policy: Literal["evict_normal", "evict_first", "evict_last"] | None = None,
     coalesced_width: int | None = None,
+    annotations: dict | None = None,
     loop_layout: Any | None = None,
 ) -> tirx.PrimExpr | tirx.Stmt:
     """Cluster-aware copy for TMA multicast or SM-to-SM shared-memory copy.
@@ -166,6 +165,8 @@ def copy_cluster(
         coalesced_width: Vectorization width (in elements) for the SIMT loop
             used on the SM-to-SM fallback path (``dst_block`` set, no fast
             bulk-async route available).
+        annotations: Additional annotations dict. Values in annotations take
+            precedence over individual arguments.
         loop_layout: Parallel loop layout hint (Fragment) for the SIMT loop on
             the SM-to-SM fallback path. Incompatible with the TMA multicast
             path (``cluster_mask`` set).
@@ -175,22 +176,22 @@ def copy_cluster(
     """
     src, dst = _normalize_copy_regions(src, dst)
 
-    ann: dict = {}
-    if dst_block is not None:
+    ann = _normalize_annotations(annotations)
+    if "dst_block" not in ann and dst_block is not None:
         ann["dst_block"] = dst_block
-    if cluster_mask is not None:
+    if "cluster_mask" not in ann and cluster_mask is not None:
         ann["cluster_mask"] = cluster_mask
-    if remote_barrier is not None:
+    if "barrier" not in ann and remote_barrier is not None:
         ann["barrier"] = remote_barrier
-    if eviction_policy is not None:
+    if "eviction_policy" not in ann and eviction_policy is not None:
         eviction_policy_map = {"evict_normal": 0, "evict_first": 1, "evict_last": 2}
         ann["eviction_policy"] = eviction_policy_map[eviction_policy]
-    if coalesced_width is not None:
+    if "coalesced_width" not in ann and coalesced_width is not None:
         ann["coalesced_width"] = coalesced_width
-    if loop_layout is not None:
+    if loop_layout is not None and "parallel_loop_layout" not in ann:
         ann["parallel_loop_layout"] = loop_layout
 
-    return tirx.call_intrin("handle", tirx.op.Op.get("tl.tileop.copy"), src, dst, annotations=ann if ann else None)
+    return tirx.call_intrin("handle", tirx.op.Op.get("tl.tileop.copy"), src, dst, annotations=ann)
 
 
 def async_copy(
@@ -222,7 +223,7 @@ def async_copy(
     if isinstance(src, tirx.BufferLoad) and isinstance(dst, tirx.BufferLoad):
         return tirx.BufferStore(dst.buffer, src, dst.indices)
 
-    ann = annotations.copy() if annotations else {}
+    ann = _normalize_annotations(annotations)
     if "coalesced_width" not in ann and coalesced_width is not None:
         ann["coalesced_width"] = coalesced_width
     if loop_layout is not None and "parallel_loop_layout" not in ann:
@@ -233,7 +234,7 @@ def async_copy(
         tirx.op.Op.get("tl.tileop.async_copy"),
         src,
         dst,
-        annotations=ann if ann else None,
+        annotations=ann,
     )
 
 
@@ -294,7 +295,7 @@ def tma_copy(
     src = to_buffer_region(src, access_type="r", extents=src_extent)
     dst = to_buffer_region(dst, access_type="w", extents=dst_extent)
 
-    ann = annotations.copy() if annotations else {}
+    ann = _normalize_annotations(annotations)
 
     if barrier is not None:
         from .builtin import _mbar_to_buffer_load
@@ -313,7 +314,7 @@ def tma_copy(
         eviction_policy_map = {"evict_normal": 0, "evict_first": 1, "evict_last": 2}
         ann["eviction_policy"] = eviction_policy_map[eviction_policy]
 
-    return tirx.call_intrin("handle", tirx.op.Op.get("tl.tileop.tma_copy"), src, dst, annotations=ann if ann else None)
+    return tirx.call_intrin("handle", tirx.op.Op.get("tl.tileop.tma_copy"), src, dst, annotations=ann)
 
 
 _TMA_SUPPORTED_DTYPES = frozenset(
@@ -341,6 +342,7 @@ def tma_gather4(
     barrier,
     swizzle=None,
     eviction_policy: Literal["evict_normal", "evict_first", "evict_last"] | None = None,
+    annotations: dict | None = None,
 ):
     """Issue a TMA tile::gather4 load (sm_100a, Blackwell).
 
@@ -354,6 +356,9 @@ def tma_gather4(
 
     The ``swizzle`` kwarg is deprecated; mark the shared tile via
     ``T.annotate_layout`` for non-default swizzle.
+
+    ``annotations`` is an additional annotations dict, merged before the
+    internal gather4 encoding keys.
     """
     if not isinstance(src, tirx.Buffer):
         raise TypeError("tma_gather4 src must be a tirx.Buffer (global)")
@@ -400,13 +405,16 @@ def tma_gather4(
     src_region = to_buffer_region(src, access_type="r", extents=[4, K_box])
     dst_region = to_buffer_region(dst, access_type="w", extents=[4, K_box])
 
-    ann = {
-        "is_gather4": True,
-        "gather4_rows": rows,
-        "gather4_col": col,
-        "barrier": bar_load,
-        "eviction_policy": ep,
-    }
+    ann = _normalize_annotations(annotations)
+    ann.update(
+        {
+            "is_gather4": True,
+            "gather4_rows": rows,
+            "gather4_col": col,
+            "barrier": bar_load,
+            "eviction_policy": ep,
+        }
+    )
     return tirx.call_intrin(
         "handle",
         tirx.op.Op.get("tl.tileop.copy"),
@@ -438,6 +446,7 @@ def tma_scatter4(
     *,
     swizzle=None,
     eviction_policy: Literal["evict_normal", "evict_first", "evict_last"] | None = None,
+    annotations: dict | None = None,
 ):
     """Issue a TMA tile::scatter4 store (sm_100a, Blackwell).
 
@@ -445,6 +454,9 @@ def tma_scatter4(
     a 2D global tensor ``dst``. Caller is responsible for ``tma_store_arrive``
     / ``tma_store_wait`` and the ``T.shuffle_elect`` guard. See
     :func:`tma_gather4` for descriptor / swizzle inference details.
+
+    ``annotations`` is an additional annotations dict, merged before the
+    internal scatter4 encoding keys.
     """
     if not isinstance(src, tirx.Buffer):
         raise TypeError("tma_scatter4 src must be a tirx.Buffer (shared)")
@@ -485,12 +497,15 @@ def tma_scatter4(
     src_region = to_buffer_region(src, access_type="r", extents=[4, K_box])
     dst_region = to_buffer_region(dst, access_type="w", extents=[4, K_box])
 
-    ann = {
-        "is_scatter4": True,
-        "gather4_rows": rows,
-        "gather4_col": col,
-        "eviction_policy": ep,
-    }
+    ann = _normalize_annotations(annotations)
+    ann.update(
+        {
+            "is_scatter4": True,
+            "gather4_rows": rows,
+            "gather4_col": col,
+            "eviction_policy": ep,
+        }
+    )
     return tirx.call_intrin(
         "handle",
         tirx.op.Op.get("tl.tileop.copy"),
@@ -503,6 +518,7 @@ def tma_scatter4(
 def transpose(
     src: BufferLikeType,
     dst: BufferLikeType,
+    annotations: dict | None = None,
 ) -> tirx.PrimExpr:
     """Transpose a 2D buffer in shared memory: dst[j, i] = src[i, j].
 
@@ -512,6 +528,7 @@ def transpose(
     Args:
         src: Source buffer or region of shape (..., M, N).
         dst: Destination buffer or region of shape (..., N, M).
+        annotations: Optional annotations to attach to the call.
 
     Returns:
         tirx.Call: A handle to the transpose operation.
@@ -534,6 +551,7 @@ def transpose(
         tirx.op.Op.get("tl.tileop.transpose"),
         src,
         dst,
+        annotations=_normalize_annotations(annotations),
     )
 
 
@@ -547,6 +565,7 @@ def im2col(
     dilation: int,
     pad: int,
     eviction_policy: Literal["evict_normal", "evict_first", "evict_last"] | None = None,
+    annotations: dict | None = None,
 ) -> tirx.PrimExpr:
     """Perform im2col transformation for 2D convolution.
 
@@ -559,6 +578,7 @@ def im2col(
         stride (int): Stride of the convolution
         dilation (int): Dilation rate
         pad (int): Padding size
+        annotations: Optional annotations to attach to the call
 
     Returns:
         tirx.Call: A handle to the im2col operation
@@ -585,6 +605,7 @@ def im2col(
         dilation,
         pad,
         eviction_policy,
+        annotations=_normalize_annotations(annotations),
     )
 
 
@@ -599,6 +620,7 @@ def c2d_im2col(
     dilation: int,
     pad: int,
     eviction_policy: Literal["evict_normal", "evict_first", "evict_last"] | None = None,
+    annotations: dict | None = None,
 ) -> tirx.PrimExpr:
     """Deprecated alias for :func:`im2col`.
 
@@ -616,4 +638,5 @@ def c2d_im2col(
         dilation,
         pad,
         eviction_policy,
+        annotations=annotations,
     )

--- a/tilelang/language/experimental/gemm_sp_op.py
+++ b/tilelang/language/experimental/gemm_sp_op.py
@@ -12,6 +12,7 @@ from tilelang.utils.language import (
     prim_expr_equal,
 )
 from tilelang.language.utils import (
+    _normalize_annotations,
     buffer_region_to_tile_region,
 )
 from tilelang._typing import BufferLikeType
@@ -30,6 +31,7 @@ def _gemm_sp_impl(
     clear_accum: bool = False,
     k_pack: int = 1,
     wg_wait: int = 0,
+    annotations: dict | None = None,
 ) -> tirx.Call:
     """Shared sparse GEMM implementation.
 
@@ -40,6 +42,8 @@ def _gemm_sp_impl(
         if isinstance(arg, tirx.Var) and T.has_let_value(arg):
             return T.get_let_value(arg).buffer
         return arg
+
+    annotations = _normalize_annotations(annotations)
 
     A_sparse = legalize_arguments(A_sparse)
     E = legalize_arguments(E)
@@ -113,6 +117,7 @@ def _gemm_sp_impl(
         offset_b,
         k_pack,
         wg_wait,
+        annotations=annotations,
     )
 
 
@@ -128,6 +133,7 @@ def gemm_sp(
     clear_accum: bool = False,
     k_pack: int = 1,
     wg_wait: int = 0,
+    annotations: dict | None = None,
 ) -> tirx.Call:
     """TileLang sparse GEMM operator.
 
@@ -150,6 +156,7 @@ def gemm_sp(
         clear_accum: Whether to zero the accumulator before computation. Defaults to False.
         k_pack: Number of K dimensions packed per warp. Defaults to 1.
         wg_wait: Warp group wait count. Defaults to 0.
+        annotations: Additional annotations.
 
     Returns:
         tirx.Call: A handle to the sparse GEMM operation.
@@ -167,6 +174,7 @@ def gemm_sp(
         clear_accum,
         k_pack,
         wg_wait,
+        annotations=annotations,
     )
 
 
@@ -180,6 +188,7 @@ def wgmma_gemm_sp(
     transpose_B: bool = False,
     policy: GemmWarpPolicy = GemmWarpPolicy.Square,
     clear_accum: bool = False,
+    annotations: dict | None = None,
 ) -> tirx.Call:
     """Explicit Hopper WGMMA sparse GEMM without an implicit wait.
 
@@ -201,6 +210,7 @@ def wgmma_gemm_sp(
         transpose_B: Whether to transpose B. Defaults to False.
         policy: Warp partition policy. Defaults to GemmSPWarpPolicy.Square.
         clear_accum: Whether to zero the accumulator before computation. Defaults to False.
+        annotations: Additional annotations.
 
     Returns:
         tirx.Call: A handle to the sparse GEMM operation.
@@ -218,6 +228,7 @@ def wgmma_gemm_sp(
         clear_accum,
         1,
         -1,
+        annotations=annotations,
     )
 
 
@@ -231,6 +242,7 @@ def tcgen05_gemm_sp(
     transpose_B: bool = False,
     policy: GemmWarpPolicy = GemmWarpPolicy.Square,
     clear_accum: bool = False,
+    annotations: dict | None = None,
 ) -> tirx.Call:
     """Explicit Blackwell TCGEN05 sparse GEMM without an implicit wait.
 
@@ -254,6 +266,7 @@ def tcgen05_gemm_sp(
         transpose_B: Whether to transpose B. Defaults to False.
         policy: Warp partition policy. Defaults to GemmSPWarpPolicy.Square.
         clear_accum: Whether to zero the accumulator before computation. Defaults to False.
+        annotations: Additional annotations.
 
     Returns:
         tirx.Call: A handle to the sparse GEMM operation.
@@ -271,4 +284,5 @@ def tcgen05_gemm_sp(
         clear_accum,
         1,
         0,
+        annotations=annotations,
     )

--- a/tilelang/language/fill_op.py
+++ b/tilelang/language/fill_op.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 from tilelang._typing import BufferLikeType
 from tvm import tirx
 from tilelang.language.common import has_let_value, get_let_value
+from tilelang.language.utils import _normalize_annotations
 from tilelang.utils.language import get_buffer_region_from_load, to_buffer_region
 
 
-def fill(buffer: BufferLikeType, value: tirx.PrimExpr) -> tirx.PrimExpr:
+def fill(buffer: BufferLikeType, value: tirx.PrimExpr, annotations: dict | None = None) -> tirx.PrimExpr:
     """Fill a buffer or buffer region with a specified value.
 
     Args:
         buffer: Either a TVM buffer or buffer region to be filled
         value: The value to fill the buffer with
+        annotations: Optional annotations to attach to the fill call
 
     Returns:
         A TVM intrinsic call that performs the fill operation
@@ -34,14 +36,21 @@ def fill(buffer: BufferLikeType, value: tirx.PrimExpr) -> tirx.PrimExpr:
             extents = [tirx.IntImm("int32", 1) for _ in buffer.indices]
     else:
         extents = []
-    return tirx.call_intrin("handle", tirx.op.Op.get("tl.tileop.fill"), to_buffer_region(buffer, access_type="w", extents=extents), value)
+    return tirx.call_intrin(
+        "handle",
+        tirx.op.Op.get("tl.tileop.fill"),
+        to_buffer_region(buffer, access_type="w", extents=extents),
+        value,
+        annotations=_normalize_annotations(annotations),
+    )
 
 
-def clear(buffer: BufferLikeType) -> tirx.PrimExpr:
+def clear(buffer: BufferLikeType, annotations: dict | None = None) -> tirx.PrimExpr:
     """Clear a buffer by filling it with zeros.
 
     Args:
         buffer: Either a TVM buffer or a variable that contains a buffer region
+        annotations: Optional annotations forwarded to the underlying fill
 
     Returns:
         A fill operation that sets the buffer contents to zero
@@ -52,12 +61,12 @@ def clear(buffer: BufferLikeType) -> tirx.PrimExpr:
     if isinstance(buffer, tirx.Var) and has_let_value(buffer):
         buffer_region = get_let_value(buffer)  # Get the actual buffer region from variable
         if isinstance(buffer_region, tirx.BufferRegion):
-            return fill(buffer_region, 0)
+            return fill(buffer_region, 0, annotations=annotations)
         elif isinstance(buffer_region, tirx.BufferLoad):
             region = get_buffer_region_from_load(buffer_region)
             if region is None:
                 raise ValueError(f"Invalid buffer region: {buffer_region}, type: {type(buffer_region)}")
-            return fill(region, 0)
+            return fill(region, 0, annotations=annotations)
         else:
             raise ValueError(f"Invalid buffer region: {buffer_region}, type: {type(buffer_region)}")
-    return fill(buffer, 0)
+    return fill(buffer, 0, annotations=annotations)

--- a/tilelang/language/gemm_op.py
+++ b/tilelang/language/gemm_op.py
@@ -15,6 +15,7 @@ from tilelang.utils.language import (
     prim_expr_equal,
 )
 from tilelang.language.utils import (
+    _normalize_annotations,
     buffer_region_to_tile_region,
 )
 
@@ -51,6 +52,8 @@ def _gemm_impl(
             return T.get_let_value(arg).buffer
         return arg
 
+    annotations = _normalize_annotations(annotations)
+
     A = legalize_arguments(A)
     B = legalize_arguments(B)
     C = legalize_arguments(C)
@@ -81,7 +84,7 @@ def _gemm_impl(
     K_B = B_shape[-1] if transpose_B else B_shape[-2]
     assert prim_expr_equal(M_A, M), f"T.gemm M shape check failed: M_A = {M_A}, M_C = {M}"
     assert prim_expr_equal(K, K_B), f"T.gemm K shape check failed: K_A = {K}, K_B = {K_B}"
-    use_2cta = annotations is not None and annotations.get("use_2cta", 0)
+    use_2cta = annotations.get("use_2cta", 0)
     if use_2cta:
         # In 2CTA mode each CTA holds half of B along N, so N_B should be N // 2
         assert prim_expr_equal(N_B * 2, N), f"T.gemm N shape check failed for 2CTA: N_B = {N_B}, expected N_C / 2 = {N} / 2"
@@ -152,6 +155,7 @@ def gemm(
     clear_accum: bool = False,
     k_pack: int = 1,
     mbar: BarrierType | None = None,
+    annotations: dict | None = None,
 ) -> tirx.PrimExpr:
     """TileLang GEMM operator.
 
@@ -175,6 +179,7 @@ def gemm(
         k_pack (int): Numbers of packed matrix cores, for ROCm only. Defaults to 1.
         mbar (BarrierType, i.e. Buffer | BufferLoad, or Var, optional): Mbarrier in Blackwell.
             Required when this GEMM lowers to TCGEN5MMA. Defaults to None.
+        annotations (Optional[dict]): Additional annotations.
 
     Returns:
         tirx.Call: A handle to the GEMM operation.
@@ -191,6 +196,7 @@ def gemm(
         k_pack,
         0,
         mbar,
+        annotations=annotations,
     )
 
 
@@ -202,6 +208,7 @@ def wgmma_gemm(
     transpose_B: bool = False,
     policy: GemmWarpPolicy = GemmWarpPolicy.Square,
     clear_accum: bool = False,
+    annotations: dict | None = None,
 ) -> tirx.PrimExpr:
     """Explicit Hopper WGMMA GEMM without an implicit wait.
 
@@ -226,6 +233,7 @@ def wgmma_gemm(
         1,
         -1,
         None,
+        annotations=annotations,
     )
 
 
@@ -240,6 +248,7 @@ def tcgen05_gemm(
     *,
     mbar: BarrierType | None,
     use_2cta: bool = False,
+    annotations: dict | None = None,
 ) -> tirx.PrimExpr:
     """Explicit Blackwell TCGEN05 GEMM without an implicit wait.
 
@@ -259,7 +268,8 @@ def tcgen05_gemm(
     compilation fails instead of silently falling back to another GEMM path.
     """
 
-    ann = {"is_tcgen05": 1}
+    ann = _normalize_annotations(annotations)
+    ann["is_tcgen05"] = 1
     if use_2cta:
         ann["use_2cta"] = 1
     return _gemm_impl(

--- a/tilelang/language/loop.py
+++ b/tilelang/language/loop.py
@@ -117,6 +117,7 @@ def Pipelined(
     stage: list[int] | None = None,
     sync: list[list[int]] | None = None,
     group: list[list[int]] | None = None,
+    annotations: dict[str, Any] | None = None,
 ) -> frame.ForFrame:
     """Tools to construct pipelined for loop.
 
@@ -144,6 +145,8 @@ def Pipelined(
         Optional synchronization metadata for manual pipeline lowering.
     group : Optional[List[List[int]]]
         Optional producer grouping metadata for manual pipeline lowering.
+    annotations : Optional[Dict[str, Any]]
+        Additional loop annotations.
 
     Notes
     -----
@@ -187,8 +190,10 @@ def Pipelined(
         sync = []
     if group is None:
         group = []
+    if annotations is None:
+        annotations = {}
     # type: ignore[attr-defined] # pylint: disable=no-member
-    return _ffi_api.Pipelined(start, stop, num_stages, order, stage, sync, group)
+    return _ffi_api.Pipelined(start, stop, num_stages, order, stage, sync, group, annotations)
 
 
 def serial(

--- a/tilelang/language/reduce_op.py
+++ b/tilelang/language/reduce_op.py
@@ -7,6 +7,7 @@ from tilelang.language.common import copy, macro, alloc_fragment, evaluate
 from tilelang.utils.language import to_buffer_region, to_tile_region
 from tilelang.utils.language import is_shared, is_fragment, is_local
 from tvm.script.ir_builder import IRBuilder
+from tilelang.language.utils import _normalize_annotations
 
 
 def _legalize_dim(buffer: tirx.Buffer, dim: int):
@@ -22,7 +23,14 @@ ReduceKind = Literal["sum", "abssum", "max", "absmax", "min", "bitand", "bitor",
 
 # NOTE(chaofan): T.reduce is implemented as a macro, so no return
 def reduce(
-    buffer: tirx.Buffer, out: tirx.Buffer, reduce_type: ReduceKind, dim: int, clear: bool, batch: int = 1, nan_propagate: bool = False
+    buffer: tirx.Buffer,
+    out: tirx.Buffer,
+    reduce_type: ReduceKind,
+    dim: int,
+    clear: bool,
+    batch: int = 1,
+    nan_propagate: bool = False,
+    annotations: dict | None = None,
 ) -> None:
     """Perform a reduction operation on a buffer along a specified dimension.
 
@@ -56,13 +64,11 @@ def reduce(
             f"output shape is {out_buffer.shape}, expected shapes are {expected_shapes_str}"
         )
 
-    annotations = {}
+    annotations = _normalize_annotations(annotations)
     if batch > 1:
         annotations["batch"] = batch
     if nan_propagate:
         annotations["nan_propagate"] = True
-    if not annotations:
-        annotations = None
 
     # Emit local reductions before macro expansion so alloc_var retains its
     # underlying Buffer rather than becoming a scalar expression.
@@ -156,7 +162,13 @@ def reduce(
 
 
 def reduce_max(
-    buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1, clear: bool = True, batch: int = 1, nan_propagate: bool = False
+    buffer: tirx.Buffer,
+    out: tirx.Buffer,
+    dim: int = -1,
+    clear: bool = True,
+    batch: int = 1,
+    nan_propagate: bool = False,
+    annotations: dict | None = None,
 ) -> None:
     """Perform reduce max on input buffer, store the result to output buffer
 
@@ -181,11 +193,17 @@ def reduce_max(
     handle : PrimExpr
     """
     dim = _legalize_dim(buffer, dim)
-    reduce(buffer, out, "max", dim, clear, batch=batch, nan_propagate=nan_propagate)
+    reduce(buffer, out, "max", dim, clear, batch=batch, nan_propagate=nan_propagate, annotations=annotations)
 
 
 def reduce_min(
-    buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1, clear: bool = True, batch: int = 1, nan_propagate: bool = False
+    buffer: tirx.Buffer,
+    out: tirx.Buffer,
+    dim: int = -1,
+    clear: bool = True,
+    batch: int = 1,
+    nan_propagate: bool = False,
+    annotations: dict | None = None,
 ) -> None:
     """Perform reduce min on input buffer, store the result to output buffer.
 
@@ -203,10 +221,12 @@ def reduce_min(
         tirx.Call: Handle to the reduction operation
     """
     dim = _legalize_dim(buffer, dim)
-    reduce(buffer, out, "min", dim, clear, batch=batch, nan_propagate=nan_propagate)
+    reduce(buffer, out, "min", dim, clear, batch=batch, nan_propagate=nan_propagate, annotations=annotations)
 
 
-def reduce_sum(buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1, clear: bool = True, batch: int = 1) -> None:
+def reduce_sum(
+    buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1, clear: bool = True, batch: int = 1, annotations: dict | None = None
+) -> None:
     """Perform reduce sum on input buffer, store the result to output buffer.
 
     Args:
@@ -229,10 +249,10 @@ def reduce_sum(buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1, clear: bool
         tirx.Call: Handle to the reduction operation
     """
     dim = _legalize_dim(buffer, dim)
-    reduce(buffer, out, "sum", dim, clear, batch=batch)
+    reduce(buffer, out, "sum", dim, clear, batch=batch, annotations=annotations)
 
 
-def reduce_abssum(buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1, batch: int = 1) -> None:
+def reduce_abssum(buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1, batch: int = 1, annotations: dict | None = None) -> None:
     """Perform reduce absolute sum on input buffer, store the result to output buffer.
 
     Args:
@@ -245,11 +265,17 @@ def reduce_abssum(buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1, batch: i
         tirx.Call: Handle to the reduction operation
     """
     dim = _legalize_dim(buffer, dim)
-    reduce(buffer, out, "abssum", dim, True, batch=batch)
+    reduce(buffer, out, "abssum", dim, True, batch=batch, annotations=annotations)
 
 
 def reduce_absmax(
-    buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1, clear: bool = True, batch: int = 1, nan_propagate: bool = False
+    buffer: tirx.Buffer,
+    out: tirx.Buffer,
+    dim: int = -1,
+    clear: bool = True,
+    batch: int = 1,
+    nan_propagate: bool = False,
+    annotations: dict | None = None,
 ) -> None:
     """Perform reduce absolute max on input buffer, store the result to output buffer.
 
@@ -266,10 +292,12 @@ def reduce_absmax(
         tirx.Call: Handle to the reduction operation
     """
     dim = _legalize_dim(buffer, dim)
-    reduce(buffer, out, "absmax", dim, clear, batch=batch, nan_propagate=nan_propagate)
+    reduce(buffer, out, "absmax", dim, clear, batch=batch, nan_propagate=nan_propagate, annotations=annotations)
 
 
-def reduce_bitand(buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1, clear: bool = True, batch: int = 1) -> None:
+def reduce_bitand(
+    buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1, clear: bool = True, batch: int = 1, annotations: dict | None = None
+) -> None:
     """Perform reduce bitwise-and on input buffer, store the result to output buffer.
 
     Args:
@@ -282,10 +310,12 @@ def reduce_bitand(buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1, clear: b
         tirx.Call: Handle to the reduction operation
     """
     dim = _legalize_dim(buffer, dim)
-    reduce(buffer, out, "bitand", dim, clear, batch=batch)
+    reduce(buffer, out, "bitand", dim, clear, batch=batch, annotations=annotations)
 
 
-def reduce_bitor(buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1, clear: bool = True, batch: int = 1) -> None:
+def reduce_bitor(
+    buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1, clear: bool = True, batch: int = 1, annotations: dict | None = None
+) -> None:
     """Perform reduce bitwise-or on input buffer, store the result to output buffer.
 
     Args:
@@ -298,10 +328,12 @@ def reduce_bitor(buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1, clear: bo
         tirx.Call: Handle to the reduction operation
     """
     dim = _legalize_dim(buffer, dim)
-    reduce(buffer, out, "bitor", dim, clear, batch=batch)
+    reduce(buffer, out, "bitor", dim, clear, batch=batch, annotations=annotations)
 
 
-def reduce_bitxor(buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1, clear: bool = True, batch: int = 1) -> None:
+def reduce_bitxor(
+    buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1, clear: bool = True, batch: int = 1, annotations: dict | None = None
+) -> None:
     """Perform reduce bitwise-xor on input buffer, store the result to output buffer.
 
     Args:
@@ -313,10 +345,10 @@ def reduce_bitxor(buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1, clear: b
         tirx.Call: Handle to the reduction operation
     """
     dim = _legalize_dim(buffer, dim)
-    reduce(buffer, out, "bitxor", dim, clear, batch=batch)
+    reduce(buffer, out, "bitxor", dim, clear, batch=batch, annotations=annotations)
 
 
-def finalize_reducer(reducer: tirx.Buffer, batch: int = 1) -> tirx.PrimExpr:
+def finalize_reducer(reducer: tirx.Buffer, batch: int = 1, annotations: dict | None = None) -> tirx.PrimExpr:
     """
     Finalize a reducer buffer by emitting the `tl.tileop.finalize_reducer` intrinsic.
 
@@ -336,14 +368,14 @@ def finalize_reducer(reducer: tirx.Buffer, batch: int = 1) -> tirx.PrimExpr:
     """
     if batch < 1:
         raise ValueError(f"finalize_reducer: batch must be >= 1, got {batch}")
-    annotations = {}
+    annotations = _normalize_annotations(annotations)
     if batch > 1:
         annotations["batch"] = batch
     return tirx.call_intrin(
         "handle",
         tirx.op.Op.get("tl.tileop.finalize_reducer"),
         to_tile_region(reducer, access_type="w"),
-        annotations=annotations if annotations else None,
+        annotations=annotations,
     )
 
 

--- a/tilelang/language/scan_op.py
+++ b/tilelang/language/scan_op.py
@@ -19,6 +19,7 @@ def _scan_fragment(
     dim: int,
     reverse: bool,
     op_key: str,
+    annotations: dict | None = None,
 ) -> None:
     src_shape = retrieve_shape(src)
     src_buffer = _get_buffer(src)
@@ -35,6 +36,7 @@ def _scan_fragment(
         to_tile_region(scan_smem, access_type="w"),
         dim,
         reverse,
+        annotations=_normalize_annotations(annotations),
     )
     copy(scan_smem, dst)
 
@@ -45,6 +47,7 @@ def cumsum_fragment(
     dst: BufferLikeType,
     dim: int,
     reverse: bool,
+    annotations: dict | None = None,
 ) -> None:
     """
     Compute cumulative sum for fragment buffers by copying to shared memory first.
@@ -58,7 +61,7 @@ def cumsum_fragment(
         dim: Dimension along which to compute cumulative sum.
         reverse: If True, compute cumulative sum in reverse order.
     """
-    _scan_fragment(src, dst, dim, reverse, _CUMSUM_OP_KEY)
+    _scan_fragment(src, dst, dim, reverse, _CUMSUM_OP_KEY, annotations)
 
 
 def _prepare_scan_args(src: BufferLikeType, dst: BufferLikeType | None, dim: int, op_name: str) -> tuple[BufferLikeType, int]:
@@ -135,7 +138,7 @@ def cumsum(
     dst, dim = _prepare_scan_args(src, dst, dim, "cumsum")
 
     if is_fragment(src):
-        cumsum_fragment(src, dst, dim, reverse)
+        cumsum_fragment(src, dst, dim, reverse, annotations)
         return
 
     return tirx.call_intrin(
@@ -155,6 +158,7 @@ def cummax_fragment(
     dst: BufferLikeType,
     dim: int,
     reverse: bool,
+    annotations: dict | None = None,
 ) -> None:
     """
     Compute cumulative maximum for fragment buffers by staging through shared memory.
@@ -165,7 +169,7 @@ def cummax_fragment(
         dim: Dimension along which to compute cumulative maximum.
         reverse: If True, compute cumulative maximum in reverse order.
     """
-    _scan_fragment(src, dst, dim, reverse, _CUMMAX_OP_KEY)
+    _scan_fragment(src, dst, dim, reverse, _CUMMAX_OP_KEY, annotations)
 
 
 def cummax(
@@ -187,7 +191,7 @@ def cummax(
     dst, dim = _prepare_scan_args(src, dst, dim, "cummax")
 
     if is_fragment(src):
-        cummax_fragment(src, dst, dim, reverse)
+        cummax_fragment(src, dst, dim, reverse, annotations)
         return
 
     return tirx.call_intrin(

--- a/tilelang/language/scan_op.py
+++ b/tilelang/language/scan_op.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from tilelang._typing import BufferLikeType
 from tilelang.language.common import alloc_shared, copy, macro
+from tilelang.language.utils import _normalize_annotations
 from tilelang.utils.language import _get_buffer, is_fragment, retrieve_shape, to_tile_region
 from tvm import tirx
 
@@ -86,6 +87,7 @@ def cumsum(
     dst: BufferLikeType | None = None,
     dim: int = 0,
     reverse: bool = False,
+    annotations: dict | None = None,
 ) -> tirx.PrimExpr | None:
     """
     Compute the cumulative sum of `src` along `dim`, writing results to `dst`.
@@ -143,6 +145,7 @@ def cumsum(
         to_tile_region(dst, access_type="w"),
         dim,
         reverse,
+        annotations=_normalize_annotations(annotations),
     )
 
 
@@ -170,6 +173,7 @@ def cummax(
     dst: BufferLikeType | None = None,
     dim: int = 0,
     reverse: bool = False,
+    annotations: dict | None = None,
 ) -> tirx.PrimExpr | None:
     """
     Compute the cumulative maximum of `src` along `dim`, writing results to `dst`.
@@ -193,4 +197,5 @@ def cummax(
         to_tile_region(dst, access_type="w"),
         dim,
         reverse,
+        annotations=_normalize_annotations(annotations),
     )

--- a/tilelang/language/utils.py
+++ b/tilelang/language/utils.py
@@ -9,6 +9,17 @@ from tilelang import language as T
 from tilelang._typing import BufferLikeType, ShapeType
 
 
+def _normalize_annotations(annotations: dict | None) -> dict:
+    """Copy a tile-op annotations dict, lifting plain str values to StringImm.
+
+    ``Call::annotations`` is ``Map<String, ObjectRef>``: unlike For/SBlock
+    annotations (``Any``-valued, where raw Python strings pass through as
+    ffi String), a bare str is rejected at the Call constructor, so it must
+    be wrapped in a TIR StringImm. Other values pass through unchanged.
+    """
+    return {k: tirx.StringImm(v) if isinstance(v, str) else v for k, v in (annotations or {}).items()}
+
+
 def region(buffer: BufferLoad, access_type: str, *args: PrimExpr) -> PrimExpr:
     """Create a tl.region call for a BufferLoad and extents."""
     access_type = {"r": 1, "w": 2, "rw": 3}[access_type]

--- a/tilelang/language/ws_schedule.py
+++ b/tilelang/language/ws_schedule.py
@@ -1,0 +1,190 @@
+"""Typed warp-specialization schedule objects.
+
+A :class:`WSSchedule` is the complete description of how to transform a
+straight-line kernel into a warp-specialized one. It is built inside the
+kernel (after buffer allocations, so pipelines can reference the buffers
+directly), attached with ``T.annotate_ws_schedule``, and consumed by the
+``MaterializeWSSchedule`` pass.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import tvm_ffi
+from tvm.ir import Node
+from tvm import tirx
+from tvm_ffi.dataclasses import Enum
+
+from tilelang import _ffi_api
+
+__all__ = [
+    "WSRole",
+    "WSPipeline",
+    "WSInstr",
+    "WSOpRef",
+    "WSSync",
+    "WSSyncKind",
+    "WSScope",
+    "WSSchedule",
+]
+
+
+class WSSyncKind(Enum, type_key="tl.WSSyncKind"):
+    """Pipeline synchronization kind.
+
+    The producer waits for the empty barrier (ACQUIRE) and signals the full
+    barrier (COMMIT); the consumer waits for the full barrier (WAIT) and
+    signals the empty barrier (RELEASE).
+    """
+
+    # Bare ClassVar binders attach to the C++-registered variants.
+    PRODUCER_ACQUIRE: ClassVar[WSSyncKind]
+    PRODUCER_COMMIT: ClassVar[WSSyncKind]
+    CONSUMER_WAIT: ClassVar[WSSyncKind]
+    CONSUMER_RELEASE: ClassVar[WSSyncKind]
+
+
+@tvm_ffi.register_object("tl.WSRole")
+class WSRole(Node):
+    """A contiguous warp range with a single duty.
+
+    Parameters
+    ----------
+    name : str
+        Role name; keys the per-role bodies of every scope.
+    warps_lo : int
+        First warp of the role's range.
+    warps_hi : int
+        One past the last warp: the role covers warps lo..hi-1.
+    max_nreg : int
+        setmaxnreg budget for the role's warps; 0 leaves registers untouched.
+    """
+
+    def __init__(self, name: str, *, warps_lo: int, warps_hi: int, max_nreg: int = 0):
+        self.__init_handle_by_constructor__(_ffi_api.WSRole, name, int(warps_lo), int(warps_hi), max_nreg)
+
+
+@tvm_ffi.register_object("tl.WSPipeline")
+class WSPipeline(Node):
+    """A full/empty mbarrier pair protecting multi-versioned buffers.
+
+    The producer waits for the empty barrier and signals the full barrier;
+    the consumer waits for the full barrier and signals the empty barrier.
+    ``depth`` is the number of buffer versions; multiple buffers can share
+    one pipeline.
+
+    Parameters
+    ----------
+    name : str
+        Pipeline name; referenced by :class:`WSSync` instructions.
+    buffers : list[tirx.Buffer]
+        The on-chip buffers this pipeline protects (and multi-versions).
+    depth : int
+        The number of versions of each buffer.
+    """
+
+    def __init__(self, name: str, buffers: list[tirx.Buffer], depth: int):
+        self.__init_handle_by_constructor__(_ffi_api.WSPipeline, name, list(buffers), depth)
+
+
+@tvm_ffi.register_object("tl.WSInstr")
+class WSInstr(Node):
+    """Base class of one step in a role's program."""
+
+
+@tvm_ffi.register_object("tl.WSOpRef")
+class WSOpRef(WSInstr):
+    """Reference to a tile op or child scope by its stable ``tl.ws_op_id``."""
+
+    def __init__(self, id: str):  # noqa: A002
+        self.__init_handle_by_constructor__(_ffi_api.WSOpRef, id)
+
+
+@tvm_ffi.register_object("tl.WSSync")
+class WSSync(WSInstr):
+    """A pipeline synchronization point.
+
+    Prefer the classmethod constructors::
+
+        WSSync.producer_acquire("smem", stage=0)
+        WSSync.producer_commit("smem", stage=0)
+        WSSync.consumer_wait("smem", stage=num_stages - 1)
+        WSSync.consumer_release("smem", stage=num_stages - 1)
+
+    Within one role's scope body, acquire/commit (and wait/release) of a
+    pipeline must pair up at the same stage; entries between them execute at
+    that stage's iteration offset.
+    """
+
+    def __init__(self, kind: WSSyncKind, pipeline: str, stage: int = 0):
+        self.__init_handle_by_constructor__(_ffi_api.WSSync, kind, pipeline, stage)
+
+    @classmethod
+    def producer_acquire(cls, pipeline: str, stage: int = 0) -> WSSync:
+        """Wait for the empty barrier; binds the stage's buffer versions."""
+        return cls(WSSyncKind.PRODUCER_ACQUIRE, pipeline, stage)
+
+    @classmethod
+    def producer_commit(cls, pipeline: str, stage: int = 0) -> WSSync:
+        """Signal the full barrier; ends the producer's span."""
+        return cls(WSSyncKind.PRODUCER_COMMIT, pipeline, stage)
+
+    @classmethod
+    def consumer_wait(cls, pipeline: str, stage: int = 0) -> WSSync:
+        """Wait for the full barrier; binds the stage's buffer versions."""
+        return cls(WSSyncKind.CONSUMER_WAIT, pipeline, stage)
+
+    @classmethod
+    def consumer_release(cls, pipeline: str, stage: int = 0) -> WSSync:
+        """Signal the empty barrier; ends the consumer's span."""
+        return cls(WSSyncKind.CONSUMER_RELEASE, pipeline, stage)
+
+
+@tvm_ffi.register_object("tl.WSScope")
+class WSScope(Node):
+    """A loop (or the root scope) with per-role instruction lists.
+
+    Parameters
+    ----------
+    id : str
+        The ``tl.ws_op_id`` of the loop this scope schedules, or
+        :data:`WSScope.ROOT` for the kernel's implicit root scope.
+    bodies : dict[str, list[WSInstr | str]]
+        Role name -> instruction sequence. Plain strings are shorthand for
+        :class:`WSOpRef`.
+    """
+
+    ROOT = "tl.ws_scope_root"
+    """The id of the kernel's implicit root scope."""
+
+    def __init__(self, id: str, bodies: dict[str, list]):  # noqa: A002
+        typed_bodies = {}
+        for role, instrs in bodies.items():
+            typed_bodies[role] = [WSOpRef(i) if isinstance(i, str) else i for i in instrs]
+        self.__init_handle_by_constructor__(_ffi_api.WSScope, id, typed_bodies)
+
+
+@tvm_ffi.register_object("tl.WSSchedule")
+class WSSchedule(Node):
+    """The complete warp-specialization schedule of one kernel.
+
+    Parameters
+    ----------
+    num_warps : int
+        Total warp count; overrides the kernel's thread extent.
+    roles : list[WSRole]
+    pipelines : list[WSPipeline]
+    scopes : list[WSScope]
+    """
+
+    def __init__(
+        self,
+        num_warps: int,
+        roles: list[WSRole],
+        pipelines: list[WSPipeline],
+        scopes: list[WSScope],
+    ):
+        assert num_warps > 0, f"num_warps must be positive, got {num_warps}"
+        assert num_warps % 4 == 0, f"num_warps must be a multiple of 4 (setmaxnreg acts on whole warpgroups), got {num_warps}"
+        self.__init_handle_by_constructor__(_ffi_api.WSSchedule, num_warps, list(roles), list(pipelines), list(scopes))


### PR DESCRIPTION
This PR adds a new set of annotations for describing arbitrary warp specialization scheme, with the abstraction of pipelines. A pipeline supports 4 kinds of operations: `producer_acquire`, `producer_commit`, `consumer_wait`, and `consumer_release`. Behind the scenes, mbarriers are created to implement the synchronization between warps.

This PR introduces a new pass, MaterializeWSSchedule, that transforms an annotated kernel to a warp-specialized kernel. 

The set of infrastructure enables further development of fully automatic warp specialization in TileLang. I am working on this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added warp-specialization schedule objects, annotations, synchronization primitives, and public Python APIs.
- Added `MaterializeWSSchedule` to lower annotated kernels into warp-specialized CUDA kernels.
- Extended pipeline, loop, copy, GEMM, reduction, atomic, scan, and fill operations to preserve annotations.
- Added warp-specialized GEMM and FlashAttention examples with validation and benchmarks.
- Added comprehensive positive and negative tests for schedule materialization and AWS examples.

## C++ style / lint notes

- The PR changes C++ code covered by `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step applies.
- Warning-only TLCPP003/TLCPP004 findings should not block merging unless they indicate an API, FFI, or maintainability risk.
- Correctness, build, and test failures remain separate from advisory style warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->