### PR TITLE
[CPU] Support reduce ops on CPU

### DIFF
--- a/src/cpu/codegen/codegen_c.cc
+++ b/src/cpu/codegen/codegen_c.cc
@@ -36,6 +36,9 @@
 #include "target/build_common.h"
 #include "target/source/codegen_params.h"
 
+#include <cmath>
+#include <sstream>
+
 namespace tvm {
 namespace codegen {
 
@@ -477,6 +480,30 @@ void CodeGenTileLangC::VisitExpr_(const MinNode *op,
 void CodeGenTileLangC::VisitExpr_(const MaxNode *op,
                                   std::ostream &os) { // NOLINT(*)
   PrintTernaryCondExpr(op, ">", os);
+}
+
+void CodeGenTileLangC::VisitExpr_(const FloatImmNode *op,
+                                  std::ostream &os) { // NOLINT(*)
+  // The TVM base class emits `inff`/`nanf` which standard C compilers do not
+  // recognise. Use the C99 macros instead so reduce max/min identity values
+  // (-inf / +inf) lower correctly.
+  std::ostringstream temp;
+  if (std::isinf(op->value)) {
+    if (op->value < 0) {
+      temp << "-";
+    }
+    temp << "INFINITY";
+  } else if (std::isnan(op->value)) {
+    temp << "NAN";
+  } else {
+    temp << std::scientific << op->value;
+    if (op->dtype.bits() == 32)
+      temp << 'f';
+    else if (op->dtype.bits() == 16)
+      temp << 'h';
+  }
+  MarkConst(temp.str());
+  os << temp.str();
 }
 
 template <typename T>

--- a/src/cpu/codegen/codegen_c.cc
+++ b/src/cpu/codegen/codegen_c.cc
@@ -484,26 +484,32 @@ void CodeGenTileLangC::VisitExpr_(const MaxNode *op,
 
 void CodeGenTileLangC::VisitExpr_(const FloatImmNode *op,
                                   std::ostream &os) { // NOLINT(*)
-  // The TVM base class emits `inff`/`nanf` which standard C compilers do not
-  // recognise. Use the C99 macros instead so reduce max/min identity values
-  // (-inf / +inf) lower correctly.
-  std::ostringstream temp;
+  // Only intercept inf/nan: the TVM base class prints the IEEE text ("-inf")
+  // then appends the float suffix ('f'), producing "-inff" / "nanf", which
+  // C/C++ compilers reject (no inf/nan literal with a float suffix). Emit the
+  // C99 macros INFINITY / NAN for those two cases.
+  //
+  // Finite values delegate to the base class so its per-bit-width formatting
+  // is preserved. In particular fp16 keeps the legal cast form
+  // `(half)1.5e+00f`. The 'h' suffix copied from Metal (codegen_metal.cc)
+  // is MSL-only and invalid in C/C++ (g++: "no matching literal operator
+  // ... operator""h"), so it must not be replicated here. The base class
+  // default branch also throws InternalError on bad bit-widths, which a
+  // hand-rolled else would silently drop.
   if (std::isinf(op->value)) {
+    std::ostringstream temp;
     if (op->value < 0) {
       temp << "-";
     }
     temp << "INFINITY";
+    MarkConst(temp.str());
+    os << temp.str();
   } else if (std::isnan(op->value)) {
-    temp << "NAN";
+    MarkConst("NAN");
+    os << "NAN";
   } else {
-    temp << std::scientific << op->value;
-    if (op->dtype.bits() == 32)
-      temp << 'f';
-    else if (op->dtype.bits() == 16)
-      temp << 'h';
+    CodeGenC::VisitExpr_(op, os);
   }
-  MarkConst(temp.str());
-  os << temp.str();
 }
 
 template <typename T>

--- a/src/cpu/codegen/codegen_c.h
+++ b/src/cpu/codegen/codegen_c.h
@@ -68,8 +68,9 @@ public:
   void VisitExpr_(const CallNode *op, std::ostream &os) override;   // NOLINT(*)
   // overload min and max to use the ternary operator, so we don't rely on the
   // standard library implementations
-  void VisitExpr_(const MinNode *op, std::ostream &os) final; // NOLINT(*)
-  void VisitExpr_(const MaxNode *op, std::ostream &os) final; // NOLINT(*)
+  void VisitExpr_(const MinNode *op, std::ostream &os) final;      // NOLINT(*)
+  void VisitExpr_(const MaxNode *op, std::ostream &os) final;      // NOLINT(*)
+  void VisitExpr_(const FloatImmNode *op, std::ostream &os) final; // NOLINT(*)
 
   void VisitStmt_(const AssertStmtNode *op) final;  // NOLINT(*)
   void VisitStmt_(const AllocBufferNode *op) final; // NOLINT(*)

--- a/src/cpu/op/reduce.cc
+++ b/src/cpu/op/reduce.cc
@@ -1,0 +1,176 @@
+/*!
+ * \file tl/cpu/op/reduce.cc
+ * \brief CPU implementation for tl.reduce lowering (serial, local buffers).
+ *
+ * First version is purely serial: the reduce dimension is accumulated in a
+ * kSerial loop with no SIMD horizontal reduction and no thread-level
+ * parallelism. Correctness and test coverage first; performance work
+ * (SIMD / multi-thread reduce) is tracked in cpu_ops.md enhancement track.
+ *
+ * Scope is limited to local -> local/local.var buffers, which is the only
+ * path the frontend emits on CPU (reduce_op.py:69-81 emits ReduceOp directly
+ * only for local src with local/local.var dst; shared/fragment paths go
+ * through alloc_fragment, which CPU does not have).
+ */
+
+#include "op/reduce.h"
+
+#include <tvm/runtime/logging.h>
+
+#include "backend/common/op/reduce.h"
+#include "backend/common/target_utils.h"
+#include "op/utils.h"
+#include "support/check.h"
+#include "transform/loop_partition.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+
+namespace cpu {
+
+struct Reduce {
+  static Stmt Lower(const ReduceOpNode &op, const LowerArgs &lower_args,
+                    arith::Analyzer *analyzer) {
+    (void)analyzer;
+
+    // 1. nan_propagate guard: CPU codegen has no __hmax_nan/__hmin_nan
+    //    equivalent. Only meaningful for fp16/bf16 max/min/absmax; other
+    //    dtypes ignore the flag.
+    if (op.nan_propagate &&
+        (op.dst->dtype.is_float16() || op.dst->dtype.is_bfloat16())) {
+      LOG(FATAL) << "CPU reduce does not support nan_propagate=True for "
+                    "float16/bfloat16 max/min/absmax: the CPU codegen has no "
+                    "__hmax_nan/__hmin_nan equivalent intrinsics (CUDA-only). "
+                    "Target was: "
+                 << lower_args.target->str();
+    }
+
+    // 2. buffer_remap resolution (mirror backend/common/op/reduce.h:753-756).
+    auto get_buffer = [&](const Buffer &buffer) {
+      auto it = lower_args.buffer_remap.find(buffer);
+      return it == lower_args.buffer_remap.end() ? buffer : (*it).second;
+    };
+    Buffer src_buffer = get_buffer(op.src);
+    Buffer dst_buffer = get_buffer(op.dst);
+
+    // 3. Scope guard: only local src and local/local.var dst are accepted.
+    //    The frontend only emits this combination on CPU; give a readable
+    //    error for anything else instead of silently producing wrong code.
+    if (!IsLocalBuffer(op.src) || !IsLocalBuffer(op.dst, /*allow_var=*/true)) {
+      LOG(FATAL) << "CPU reduce only supports local src and "
+                    "local/local.var dst buffers, got src scope `"
+                 << op.src.scope() << "` and dst scope `" << op.dst.scope()
+                 << "`.";
+    }
+
+    // 4. Constraint checks.
+    //    batch is a GPU AllReduce barrier batching concept; CPU has no
+    //    thread-level reduction so batch > 1 is rejected.
+    ICHECK_EQ(op.batch, 1)
+        << "CPU reduce: batch > 1 is a GPU AllReduce barrier concept and "
+           "is not supported on CPU (no thread-level reduction).";
+    int src_dim = static_cast<int>(op.src->shape.size());
+    int dst_dim = static_cast<int>(op.dst->shape.size());
+    // dim should already be legalized to >= 0 by the frontend
+    // (_legalize_dim in reduce_op.py:12-15), but defend in depth.
+    ICHECK_GE(op.dim, 0) << "CPU reduce: dim must be non-negative";
+    ICHECK_LT(op.dim, src_dim) << "CPU reduce: dim " << op.dim
+                               << " out of range for src ndim " << src_dim;
+    ICHECK(dst_dim == src_dim - 1 || dst_dim == src_dim)
+        << "CPU reduce: dst ndim must be src_ndim-1 (no keepdim) or "
+           "src_ndim (keepdim), got src_ndim="
+        << src_dim << ", dst_ndim=" << dst_dim;
+    ICHECK(src_buffer->dtype == dst_buffer->dtype)
+        << "CPU reduce: src and dst dtypes must match, got "
+        << src_buffer->dtype << " vs " << dst_buffer->dtype;
+
+    // 5. Index construction (mirror backend LowerLocal reduce.h:651-671).
+    Array<Var> dst_vars;
+    Array<PrimExpr> dst_indices;
+    for (int i = 0; i < dst_dim; ++i) {
+      Var var("i" + std::to_string(i));
+      dst_vars.push_back(var);
+      dst_indices.push_back(var);
+    }
+
+    auto make_src_indices = [&](PrimExpr reduce_index) {
+      Array<PrimExpr> indices;
+      for (int i = 0; i < src_dim; ++i) {
+        if (i == op.dim) {
+          indices.push_back(reduce_index);
+        } else if (dst_dim == src_dim) {
+          // keepdim: dst has a size-1 axis at op.dim
+          indices.push_back(dst_vars[i]);
+        } else {
+          indices.push_back(dst_vars[i < op.dim ? i : i - 1]);
+        }
+      }
+      return indices;
+    };
+
+    Array<Stmt> stmts;
+
+    // 6. Optional init using the type/dtype-correct identity value
+    //    (backend::reduce::MakeInitValue covers all 8 types x dtype split).
+    if (op.clear) {
+      stmts.push_back(BufferStore(
+          dst_buffer, backend::reduce::MakeInitValue(op), dst_indices));
+    }
+
+    // 7. Inner reduce loop along op.dim. kSerial (NOT kUnrolled) to avoid
+    //    code-size blowup for large reduce extents compounded by JIT -O0.
+    //    clear=False accumulation falls out naturally: init is skipped and
+    //    MakeReduce reads the existing dst value as the accumulator.
+    Var rv("rv");
+    Stmt reduce_body =
+        BufferStore(dst_buffer,
+                    backend::reduce::MakeReduce(
+                        op, /*vsize=*/1, BufferLoad(dst_buffer, dst_indices),
+                        BufferLoad(src_buffer, make_src_indices(rv))),
+                    dst_indices);
+    stmts.push_back(For(rv, 0, op.src->shape[op.dim], ForKind::kSerial,
+                        reduce_body, std::nullopt));
+
+    // 8. Outer dst-dim loops. Built as kSerial then wrapped with
+    //    PragmaUnrollLoop to match the fill.cc/transpose.cc CPU op convention.
+    //    PragmaUnrollLoop (LoopPramaUnroller, loop_partition.cc:163-181)
+    //    only retags the outermost kSerial For it meets and returns without
+    //    recursing into the body, so the inner kSerial reduce loop above is
+    //    left untouched. Under the default UnrollLoopConfig
+    //    (explicit_unroll=false) this is a no-op (no loop body replication);
+    //    the tag is an intent marker consistent with other CPU ops.
+    Stmt body = SeqStmt::Flatten(stmts);
+    for (int i = dst_dim - 1; i >= 0; --i) {
+      body = For(dst_vars[i], 0, op.dst->shape[i], ForKind::kSerial, body,
+                 std::nullopt);
+    }
+    if (dst_dim >= 1) {
+      body = PragmaUnrollLoop(Downcast<For>(body));
+    }
+    return body;
+  }
+};
+
+} // namespace cpu
+
+namespace {
+
+bool MatchCPUReduceTarget(Target target) { return TargetIsCPU(target); }
+
+bool RegisterCPUReduce() {
+  RegisterReduceImpl(ReduceImpl{
+      "cpu.Reduce",
+      MatchCPUReduceTarget,
+      cpu::Reduce::Lower,
+  });
+  return true;
+}
+
+const bool cpu_reduce_registered = RegisterCPUReduce();
+
+} // namespace
+
+} // namespace tl
+} // namespace tvm

--- a/testing/python/cpu/test_tilelang_cpu_fp16_const.py
+++ b/testing/python/cpu/test_tilelang_cpu_fp16_const.py
@@ -1,0 +1,136 @@
+"""CPU codegen float literal regression tests.
+
+Covers two paths through CodeGenTileLangC::VisitExpr_(FloatImmNode*) that have
+broken before:
+
+1. Finite fp16 constants must lower to the cast form `(half)1.5e+00f`
+   (legal C/C++), NOT the `1.5e+00h` form copied from Metal — the `h`
+   suffix is MSL-only and g++ rejects it
+   ("no matching literal operator ... operator\"\"h").
+2. +/-inf and nan must lower to the C99 macros INFINITY / NAN, NOT the
+   base class's "-inff" / "nanf" output (IEEE text + 'f' suffix), which
+   g++ rejects ("use of undeclared identifier 'inff'"). This path is
+   exercised by reduce max/min identity init values.
+
+Both were latent because no prior c-target test emitted a finite fp16
+FloatImm or an inf identity. reduce max/min introduced the inf path; the
+fp16 finite-constant regression was introduced by copying Metal's FloatImm
+override verbatim and fixed by delegating finite values back to the base
+class.
+"""
+
+import re
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+from tilelang import tvm
+
+
+def _compile_c(func, out_idx):
+    with tvm.target.Target("c"):
+        return tilelang.compile(
+            func,
+            out_idx=out_idx,
+            target="c",
+            target_host="c",
+            execution_backend="cython",
+        )
+
+
+def _source(func) -> str:
+    with tvm.target.Target("c"):
+        artifact = tilelang.lower(func)
+    return artifact.kernel_source
+
+
+def test_fp16_finite_constant_arithmetic():
+    """Reproducer: T.float16(1.5) + T.float16(2.25) must compile and run.
+
+    Regression for the `1.5e+00h` literal bug: the Metal-derived override
+    appended an 'h' suffix for fp16, which is invalid in C/C++.
+    """
+
+    @T.prim_func
+    def main(A: T.Tensor((4,), "float16"), B: T.Tensor((4,), "float16")):
+        with T.Kernel(1):
+            for i in T.grid(4):
+                B[i] = A[i] + T.float16(1.5) + T.float16(2.25)
+
+    # Must compile cleanly (the bug failed at g++ compile step).
+    kernel = _compile_c(main, out_idx=[1])
+
+    # The generated source must use the legal cast form, not the 'h' suffix.
+    src = _source(main)
+    assert "(half)" in src, f"expected (half) cast form in source:\n{src}"
+    assert not re.search(r"[0-9]h\b", src), f"source must not contain an 'h' literal suffix (MSL-only):\n{src}"
+
+    a = torch.tensor([0.0, 1.0, 2.0, 3.0], dtype=torch.float16)
+    out = kernel(a)
+    expected = a + torch.tensor(3.75, dtype=torch.float16)
+    torch.testing.assert_close(out, expected)
+
+
+@pytest.mark.parametrize("op", ["max", "min"])
+def test_fp16_reduce_inf_identity(op):
+    """fp16 reduce_max/min identity (+/-inf) must lower to INFINITY, not inff.
+
+    The base class prints "-inf" + 'f' => "-inff", which g++ rejects.
+    """
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((4, 8), "float16"),
+        B: T.Tensor((4,), "float16"),
+    ):
+        with T.Kernel(1):
+            src = T.alloc_local((4, 8), "float16")
+            dst = T.alloc_local((4,), "float16")
+            for i, j in T.grid(4, 8):
+                src[i, j] = A[i, j]
+            if op == "max":
+                T.reduce_max(src, dst, dim=1, clear=True)
+            else:
+                T.reduce_min(src, dst, dim=1, clear=True)
+            for i in T.grid(4):
+                B[i] = dst[i]
+
+    # Source must use the C99 macro form, not the broken literal.
+    src = _source(main)
+    assert "INFINITY" in src, f"expected INFINITY macro for {op} identity in source:\n{src}"
+    assert "inff" not in src, f"source must not contain 'inff':\n{src}"
+
+    kernel = _compile_c(main, out_idx=[1])
+    a = torch.randn((4, 8), dtype=torch.float16)
+    out = kernel(a)
+    expected = a.amax(dim=1) if op == "max" else a.amin(dim=1)
+    torch.testing.assert_close(out, expected)
+
+
+def test_float32_finite_constant_sanity():
+    """float32 finite constants must keep the 'f' suffix after delegation.
+
+    Guards against over-narrowing the override: delegating finite values to
+    the base class must still produce `1.5e+00f` for float32. An input
+    tensor is threaded through so the torch wrapper can infer the CPU
+    device (a no-arg call defaults to CUDA).
+    """
+
+    @T.prim_func
+    def main(A: T.Tensor((1,), "float32"), B: T.Tensor((1,), "float32")):
+        with T.Kernel(1):
+            B[0] = A[0] + T.cast(1.5, "float32") + T.cast(2.25, "float32")
+
+    src = _source(main)
+    assert re.search(r"[0-9]f\b", src), f"expected a float32 'f' suffix literal in source:\n{src}"
+
+    kernel = _compile_c(main, out_idx=[1])
+    a = torch.tensor([0.0], dtype=torch.float32)
+    out = kernel(a)
+    torch.testing.assert_close(out, torch.tensor([3.75], dtype=torch.float32))
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/cpu/test_tilelang_cpu_reduce.py
+++ b/testing/python/cpu/test_tilelang_cpu_reduce.py
@@ -1,0 +1,235 @@
+"""CPU reduce op tests (target="c", execution_backend="cython").
+
+Covers the 8 reduce variants supported by src/cpu/op/reduce.cc on local
+buffers, which is the only path the frontend emits on CPU.
+"""
+
+import functools
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+from tilelang import tvm
+
+_FLOAT_OPS = ("sum", "max", "min", "abssum", "absmax")
+_BIT_OPS = ("bitand", "bitor", "bitxor")
+
+
+def _torch_dtype(dtype: str) -> torch.dtype:
+    return getattr(torch, dtype)
+
+
+def _ref_reduce(A: torch.Tensor, op: str, dim: int) -> torch.Tensor:
+    legal = dim if dim >= 0 else A.ndim + dim
+    if op == "sum":
+        return A.sum(dim=legal)
+    if op == "max":
+        return A.amax(dim=legal)
+    if op == "min":
+        return A.amin(dim=legal)
+    if op == "abssum":
+        return A.abs().sum(dim=legal)
+    if op == "absmax":
+        return A.abs().amax(dim=legal)
+    if op in _BIT_OPS:
+        binop = {
+            "bitand": torch.bitwise_and,
+            "bitor": torch.bitwise_or,
+            "bitxor": torch.bitwise_xor,
+        }[op]
+        return functools.reduce(
+            lambda acc, i: binop(acc, A.select(legal, i)),
+            range(1, A.shape[legal]),
+            A.select(legal, 0).clone(),
+        )
+    raise ValueError(op)
+
+
+def _emit_reduce(T, op: str, src, dst, dim: int, clear: bool):
+    if op == "sum":
+        T.reduce_sum(src, dst, dim=dim, clear=clear)
+    elif op == "max":
+        T.reduce_max(src, dst, dim=dim, clear=clear)
+    elif op == "min":
+        T.reduce_min(src, dst, dim=dim, clear=clear)
+    elif op == "abssum":
+        T.reduce_abssum(src, dst, dim=dim)
+    elif op == "absmax":
+        T.reduce_absmax(src, dst, dim=dim, clear=clear)
+    elif op == "bitand":
+        T.reduce_bitand(src, dst, dim=dim, clear=clear)
+    elif op == "bitor":
+        T.reduce_bitor(src, dst, dim=dim, clear=clear)
+    elif op == "bitxor":
+        T.reduce_bitxor(src, dst, dim=dim, clear=clear)
+    else:
+        raise ValueError(op)
+
+
+def _make_kernel_2d(op: str, M: int, N: int, dim: int, dtype: str, clear: bool):
+    legal = dim if dim >= 0 else 2 + dim
+    dst_shape = (N,) if legal == 0 else (M,)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        Init: T.Tensor(dst_shape, dtype),
+        B: T.Tensor(dst_shape, dtype),
+    ):
+        with T.Kernel(1):
+            src = T.alloc_local((M, N), dtype)
+            dst = T.alloc_local(dst_shape, dtype)
+            for i, j in T.grid(M, N):
+                src[i, j] = A[i, j]
+            for i in T.grid(dst_shape[0]):
+                dst[i] = Init[i]
+            _emit_reduce(T, op, src, dst, dim=legal, clear=clear)
+            for i in T.grid(dst_shape[0]):
+                B[i] = dst[i]
+
+    return main
+
+
+def _make_kernel_3d(op: str, P: int, Q: int, R: int, dim: int, dtype: str):
+    legal = dim if dim >= 0 else 3 + dim
+    if legal == 0:
+        dst_shape = (Q, R)
+    elif legal == 1:
+        dst_shape = (P, R)
+    else:
+        dst_shape = (P, Q)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((P, Q, R), dtype),
+        B: T.Tensor(dst_shape, dtype),
+    ):
+        with T.Kernel(1):
+            src = T.alloc_local((P, Q, R), dtype)
+            dst = T.alloc_local(dst_shape, dtype)
+            for p, q, r in T.grid(P, Q, R):
+                src[p, q, r] = A[p, q, r]
+            _emit_reduce(T, op, src, dst, dim=legal, clear=True)
+            if legal == 0:
+                for q, r in T.grid(Q, R):
+                    B[q, r] = dst[q, r]
+            elif legal == 1:
+                for p, r in T.grid(P, R):
+                    B[p, r] = dst[p, r]
+            else:
+                for p, q in T.grid(P, Q):
+                    B[p, q] = dst[p, q]
+
+    return main
+
+
+def _compile_c(func):
+    with tvm.target.Target("c"):
+        return tilelang.compile(
+            func,
+            out_idx=[2],
+            target="c",
+            target_host="c",
+            execution_backend="cython",
+        )
+
+
+def _make_input(shape, dtype, op):
+    tdtype = _torch_dtype(dtype)
+    gen = torch.Generator(device="cpu").manual_seed(7)
+    if op in _BIT_OPS:
+        return torch.randint(-50, 50, shape, dtype=tdtype, generator=gen)
+    return torch.randn(shape, dtype=tdtype, generator=gen)
+
+
+@pytest.mark.parametrize("op", _FLOAT_OPS)
+@pytest.mark.parametrize("dim", [0, 1, -1])
+def test_cpu_reduce_2d_float(op, dim):
+    M, N = 4, 8
+    dtype = "float32"
+    func = _make_kernel_2d(op, M, N, dim, dtype, clear=True)
+    kernel = _compile_c(func)
+
+    A = _make_input((M, N), dtype, op)
+    Init = torch.zeros((N if (dim if dim >= 0 else 2 + dim) == 0 else M,), dtype=_torch_dtype(dtype))
+    out = kernel(A, Init)
+    expected = _ref_reduce(A, op, dim)
+    torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("op", _BIT_OPS)
+@pytest.mark.parametrize("dim", [0, 1])
+def test_cpu_reduce_2d_bit(op, dim):
+    M, N = 4, 8
+    dtype = "int32"
+    func = _make_kernel_2d(op, M, N, dim, dtype, clear=True)
+    kernel = _compile_c(func)
+
+    A = _make_input((M, N), dtype, op)
+    dst_shape = (N,) if (dim if dim >= 0 else 2 + dim) == 0 else (M,)
+    Init = torch.zeros(dst_shape, dtype=_torch_dtype(dtype))
+    out = kernel(A, Init)
+    expected = _ref_reduce(A, op, dim)
+    torch.testing.assert_close(out, expected)
+
+
+@pytest.mark.parametrize("op", ["sum", "max", "bitand"])
+@pytest.mark.parametrize("dim", [0, 1, 2])
+def test_cpu_reduce_3d(op, dim):
+    P, Q, R = 2, 3, 4
+    dtype = "float32" if op != "bitand" else "int32"
+    func = _make_kernel_3d(op, P, Q, R, dim, dtype)
+    with tvm.target.Target("c"):
+        kernel = tilelang.compile(
+            func,
+            out_idx=[1],
+            target="c",
+            target_host="c",
+            execution_backend="cython",
+        )
+
+    A = _make_input((P, Q, R), dtype, op)
+    out = kernel(A)
+    expected = _ref_reduce(A, op, dim)
+    if op == "bitand":
+        torch.testing.assert_close(out, expected)
+    else:
+        torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("op", ["sum", "max", "min"])
+def test_cpu_reduce_clear_false_accumulates(op):
+    """clear=False must accumulate onto the pre-existing dst values."""
+    M, N = 4, 8
+    dtype = "float32"
+    func = _make_kernel_2d(op, M, N, dim=1, dtype=dtype, clear=False)
+    kernel = _compile_c(func)
+
+    A = _make_input((M, N), dtype, op)
+    Init = torch.full((M,), 1.0, dtype=_torch_dtype(dtype))
+    out = kernel(A, Init)
+
+    base = _ref_reduce(A, op, dim=1)
+    if op == "sum":
+        expected = base + Init
+    elif op == "max":
+        expected = torch.maximum(base, Init)
+    else:  # min
+        expected = torch.minimum(base, Init)
+    torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+
+
+def test_cpu_reduce_non_divisible_extent():
+    """Reduce extent of 17 (prime) exercises the kSerial loop tail."""
+    M, N = 3, 17
+    dtype = "float32"
+    func = _make_kernel_2d("sum", M, N, dim=1, dtype=dtype, clear=True)
+    kernel = _compile_c(func)
+
+    A = _make_input((M, N), dtype, "sum")
+    Init = torch.zeros((M,), dtype=_torch_dtype(dtype))
+    out = kernel(A, Init)
+    expected = _ref_reduce(A, "sum", dim=1)
+    torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)

--- a/testing/python/llvm/test_tilelang_llvm_reduce.py
+++ b/testing/python/llvm/test_tilelang_llvm_reduce.py
@@ -1,0 +1,150 @@
+"""LLVM reduce op tests (shares the cpu.Reduce registry with the `c` target).
+
+Lightweight mirror of testing/python/cpu/test_tilelang_cpu_reduce.py covering
+three representative ops (sum/max/bitand) + keepdim + clear=False, since the
+`llvm` and `c` targets share the same CPU ReduceImpl (TargetIsCPU matches
+kDLCPU). See src/cpu/op/reduce.cc.
+"""
+
+import functools
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+
+
+def _ref_reduce(A, op, dim):
+    legal = dim if dim >= 0 else A.ndim + dim
+    if op == "sum":
+        return A.sum(dim=legal)
+    if op == "max":
+        return A.amax(dim=legal)
+    if op == "bitand":
+        return functools.reduce(
+            lambda acc, i: torch.bitwise_and(acc, A.select(legal, i)),
+            range(1, A.shape[legal]),
+            A.select(legal, 0).clone(),
+        )
+    raise ValueError(op)
+
+
+def _emit(T, op, src, dst, dim, clear):
+    if op == "sum":
+        T.reduce_sum(src, dst, dim=dim, clear=clear)
+    elif op == "max":
+        T.reduce_max(src, dst, dim=dim, clear=clear)
+    elif op == "bitand":
+        T.reduce_bitand(src, dst, dim=dim, clear=clear)
+    else:
+        raise ValueError(op)
+
+
+@tilelang.testing.requires_llvm
+@pytest.mark.parametrize("op,dtype", [("sum", "float32"), ("max", "float32"), ("bitand", "int32")])
+def test_llvm_reduce_2d(op, dtype):
+    M, N = 4, 8
+    dim = 1
+    dst_shape = (M,)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        Init: T.Tensor(dst_shape, dtype),
+        B: T.Tensor(dst_shape, dtype),
+    ):
+        with T.Kernel(1):
+            src = T.alloc_local((M, N), dtype)
+            dst = T.alloc_local(dst_shape, dtype)
+            for i, j in T.grid(M, N):
+                src[i, j] = A[i, j]
+            for i in T.grid(M):
+                dst[i] = Init[i]
+            _emit(T, op, src, dst, dim=dim, clear=True)
+            for i in T.grid(M):
+                B[i] = dst[i]
+
+    with tvm.target.Target("llvm"):
+        kernel = tilelang.compile(main, out_idx=[2], target="llvm", execution_backend="tvm_ffi")
+
+    tdtype = getattr(torch, dtype)
+    gen = torch.Generator(device="cpu").manual_seed(11)
+    if op == "bitand":
+        A = torch.randint(-50, 50, (M, N), dtype=tdtype, generator=gen)
+    else:
+        A = torch.randn((M, N), dtype=tdtype, generator=gen)
+    Init = torch.zeros(dst_shape, dtype=tdtype)
+    out = kernel(A, Init)
+    expected = _ref_reduce(A, op, dim)
+    if op == "bitand":
+        torch.testing.assert_close(out, expected)
+    else:
+        torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+
+
+@tilelang.testing.requires_llvm
+def test_llvm_reduce_keepdim():
+    """keepdim dst shape [M, 1] along dim=1."""
+    M, N = 4, 8
+    dtype = "float32"
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        B: T.Tensor((M, 1), dtype),
+    ):
+        with T.Kernel(1):
+            src = T.alloc_local((M, N), dtype)
+            dst = T.alloc_local((M, 1), dtype)
+            for i, j in T.grid(M, N):
+                src[i, j] = A[i, j]
+            T.reduce_sum(src, dst, dim=1, clear=True)
+            for i in T.grid(M):
+                B[i, 0] = dst[i, 0]
+
+    with tvm.target.Target("llvm"):
+        kernel = tilelang.compile(main, out_idx=[1], target="llvm", execution_backend="tvm_ffi")
+
+    A = torch.randn((M, N), dtype=torch.float32)
+    out = kernel(A)
+    expected = A.sum(dim=1, keepdim=True)
+    torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+
+
+@tilelang.testing.requires_llvm
+def test_llvm_reduce_clear_false_accumulates():
+    M, N = 4, 8
+    dtype = "float32"
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, N), dtype),
+        Init: T.Tensor((M,), dtype),
+        B: T.Tensor((M,), dtype),
+    ):
+        with T.Kernel(1):
+            src = T.alloc_local((M, N), dtype)
+            dst = T.alloc_local((M,), dtype)
+            for i, j in T.grid(M, N):
+                src[i, j] = A[i, j]
+            for i in T.grid(M):
+                dst[i] = Init[i]
+            T.reduce_sum(src, dst, dim=1, clear=False)
+            for i in T.grid(M):
+                B[i] = dst[i]
+
+    with tvm.target.Target("llvm"):
+        kernel = tilelang.compile(main, out_idx=[2], target="llvm", execution_backend="tvm_ffi")
+
+    A = torch.randn((M, N), dtype=torch.float32)
+    Init = torch.full((M,), 1.0, dtype=torch.float32)
+    out = kernel(A, Init)
+    expected = A.sum(dim=1) + Init
+    torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added serial CPU lowering for `ReduceOp`.
- Supports floating-point and bitwise reductions with `keepdim`, batching, non-divisible extents, and `clear=False`.
- Added validation for supported scopes, data types, dimensions, and unsupported `nan_propagate` cases.
- Added C code generation for floating-point `INFINITY` and `NAN` constants.
- Added CPU and LLVM regression tests for reduction behavior and floating-point constants.

## C++ style / lint notes

- The PR changes C++ files but does not modify `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) may report advisory findings. These do not block merge unless they introduce a correctness, build, API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->