### PR TITLE
[BugFix][CUDA] Provide htan overloads for fp16/bf16 tangent

### DIFF
--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -213,6 +213,17 @@ TL_PATCH TL_DEVICE bfloat16_t __hfma(const bfloat16_t x, const bfloat16_t y,
 #endif
 }
 
+// CUDA has no half-precision tangent intrinsic, but tangent lowering uses the
+// half-style `htan` name for 16-bit inputs. Evaluate in float32 and convert the
+// result back to the source type.
+TL_PATCH TL_DEVICE half_t htan(const half_t x) {
+  return half_t(tanf(float(x)));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t htan(const bfloat16_t x) {
+  return bfloat16_t(tanf(float(x)));
+}
+
 // TVM lowers T.exp(bfloat16) to the CUDA half-style `hexp` name. TileLang uses
 // cutlass::bfloat16_t for scalar bf16, while CUDA only overloads hexp for
 // __nv_bfloat16. Keep this narrow bridge in common.h so plain T.exp works

--- a/testing/python/math/test_math_fast_math.py
+++ b/testing/python/math/test_math_fast_math.py
@@ -362,5 +362,36 @@ def test_fastmath_versions(name, func):
     print(f"✓ {name} test passed")
 
 
+TAN_MATHOPS = [
+    ("tan", T.tan),
+    ("__tan", T.__tan),
+]
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize(("name", "func"), TAN_MATHOPS, ids=[name for name, _ in TAN_MATHOPS])
+@pytest.mark.parametrize("dtype", [T.float16, T.bfloat16], ids=["float16", "bfloat16"])
+def test_tan_16bit_compiles_and_runs(name, func, dtype):
+    """Test that 16-bit tan lowers to a callable htan and matches torch.tan"""
+    n = 32
+
+    @T.prim_func
+    def main(A: T.Tensor((n,), dtype), B: T.Tensor((n,), dtype)):
+        with T.Kernel(1, threads=32):
+            for i in T.Parallel(n):
+                B[i] = func(A[i])
+
+    kernel = tilelang.compile(main, out_idx=[1], target="cuda")
+    source = kernel.get_kernel_source()
+    assert "htan(" in source, f"expected htan in generated source for {name}"
+
+    inputs = torch.linspace(-1.0, 1.0, n, device="cuda", dtype=torch.float32).to(dtype.as_torch())
+    actual = kernel(inputs)
+    expected = torch.tan(inputs).to(dtype.as_torch())
+
+    torch.testing.assert_close(actual, expected, rtol=1e-2, atol=1e-2)
+    print(f"✓ {name} 16-bit test passed")
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Summary

`T.tan` and `T.__tan` on `float16`/`bfloat16` lower to `htan()`, but CUDA provides no half-precision tangent intrinsic, so every 16-bit tangent kernel fails to compile:

```
/tmp/.../tvm_kernels.cu(19): error: identifier "htan" is undefined
    B[((int)threadIdx.x)] = htan(A[((int)threadIdx.x)]);
                            ^
```

Reproducer (clear the JIT disk cache first, a stale cubin hides the error):

```bash
rm -rf ~/.tilelang/cache
```

```python
import tilelang as tl
import tilelang.language as T

@tl.jit(out_idx=[1])
def tan_fp16(n: int):
    @T.prim_func
    def main(A: T.Tensor((n,), "float16"), B: T.Tensor((n,), "float16")):
        with T.Kernel(1, threads=32):
            for i in T.Parallel(n):
                B[i] = T.tan(A[i])
    return main

tan_fp16(32)  # RuntimeError: identifier "htan" is undefined
```

Same failure for `bfloat16`, and for `T.__tan` on both dtypes.

## Fix

Add `TL_PATCH` device overloads in `src/tl_templates/cuda/common.h`, matching the existing bridges already there for `hexp` and other missing 16-bit intrinsics:

```cpp
TL_PATCH TL_DEVICE half_t htan(const half_t x) {
  return half_t(tanf(float(x)));
}

TL_PATCH TL_DEVICE bfloat16_t htan(const bfloat16_t x) {
  return bfloat16_t(tanf(float(x)));
}
```

Both evaluate in float32 with the accurate `tanf` (not `__tanf`) and convert back. No lowering rule changes, nothing under `3rdparty/` touched, no other dtype or operator affected.

## Test plan

Added `test_tan_16bit_compiles_and_runs` in `testing/python/math/test_math_fast_math.py`, covering `T.tan` and `T.__tan` across `float16` and `bfloat16`. Each case asserts the generated source contains `htan(` and that results match `torch.tan` within fp16 tolerance.

Verified on H200 (sm_90a), CUDA 13.0:

- [x] Before: 4 failed with `identifier "htan" is undefined`
- [x] After: 4 passed
- [x] Affected suites: `test_math_fast_math.py` + `test_mathops_fastmath.py` → 70 passed

## Related

Partial fix for #2879. This PR only addresses the fp16/bf16 compilation failure; the FP32 `T.__tan` accuracy issue reported in the same issue is handled in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added CUDA device overloads for `htan` with `half_t` and `bfloat16_t`.
- Implemented both overloads with float32 `tanf` evaluation and conversion back to the input type.
- Added tests for `T.tan` and `T.__tan` with both 16-bit types.
- Tests verify generated CUDA source and compare GPU results with `torch.tan`.
- No lowering rules or third-party code changed.

## C++ style / lint notes

- The change touches C++ code but does not modify documented style rules in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) may report advisory findings for the new overloads.
- No correctness or build issues are indicated. Advisory TLCPP003/TLCPP004 findings are not merge blockers without a clear API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->