### PR TITLE
[BugFix] Scalarize vectorized bool with more than 4 lanes

### DIFF
--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -206,8 +206,9 @@ inline void CheckAllReduceWidth(int reducing_threads, int scale,
 
 inline PrimExpr MakeInitValue(const ReduceOpNode &op, int vsize = 1) {
   auto dst_dtype = op.dst->dtype;
-  auto is_int = dst_dtype.is_int();
+  bool is_int = dst_dtype.is_int();
   bool is_uint = dst_dtype.is_uint();
+  bool is_bool = dst_dtype.is_bool();
   auto bits = dst_dtype.bits();
 
   PrimExpr scalar;
@@ -218,6 +219,8 @@ inline PrimExpr MakeInitValue(const ReduceOpNode &op, int vsize = 1) {
       scalar = make_const(op.dst->dtype, SignedMin(bits));
     } else if (is_uint) {
       scalar = make_const(op.dst->dtype, 0);
+    } else if (is_bool) {
+      scalar = make_const(op.dst->dtype, 0);
     } else {
       scalar = make_const(op.dst->dtype, -INFINITY);
     }
@@ -226,6 +229,8 @@ inline PrimExpr MakeInitValue(const ReduceOpNode &op, int vsize = 1) {
       scalar = make_const(op.dst->dtype, SignedMax(bits));
     } else if (is_uint) {
       scalar = make_const(op.dst->dtype, UnsignedMax(bits));
+    } else if (is_bool) {
+      scalar = make_const(op.dst->dtype, 1);
     } else {
       scalar = make_const(op.dst->dtype, INFINITY);
     }
@@ -236,6 +241,8 @@ inline PrimExpr MakeInitValue(const ReduceOpNode &op, int vsize = 1) {
       scalar = make_const(op.dst->dtype, -1);
     } else if (is_uint) {
       scalar = make_const(op.dst->dtype, UnsignedMax(bits));
+    } else if (is_bool) {
+      scalar = make_const(op.dst->dtype, 1);
     } else {
       scalar = make_const(op.dst->dtype, -INFINITY);
     }

--- a/src/transform/vectorize_loop.cc
+++ b/src/transform/vectorize_loop.cc
@@ -301,7 +301,17 @@ public:
   }
 
   PrimExpr VisitExpr(const PrimExpr &e) final {
-    return ExprFunctor::VisitExpr(e);
+    if (need_scalarize_) {
+      return e;
+    }
+    PrimExpr ret = ExprFunctor::VisitExpr(e);
+    // Vectorized boolean types with more than 4 lanes (e.g., boolx8)
+    // are not representable, scalarize for backend compatibility
+    if (ret.dtype().is_vector_bool() && ret.dtype().lanes() > 4) {
+      need_scalarize_ = true;
+      return e;
+    }
+    return ret;
   }
 
   PrimExpr VisitExpr_(const AddNode *op) final {

--- a/testing/python/issue/test_tilelang_issue_2568.py
+++ b/testing/python/issue/test_tilelang_issue_2568.py
@@ -1,0 +1,87 @@
+"""Regression tests for GitHub issue #2568.
+
+This test asserts that the bool reductions compile, run, and produce results
+identical to the equivalent logical reductions over the same data. The compile
+path also exercises the wide-bool-vector handling that used to abort codegen
+with ``Cannot convert type boolx8 to CUDA type``.
+"""
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+M, N = 32, 32
+THREADS = 128
+
+
+def _make_reduce_kernel(dtype, reduce_fn):
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), Out: T.Tensor((M,), dtype)):
+        with T.Kernel(1, 1, threads=THREADS) as (bx, by):
+            A_fr = T.alloc_fragment((M, N), dtype)
+            B_fr = T.alloc_fragment((M,), dtype)
+            T.copy(A, A_fr)
+            reduce_fn(A_fr, B_fr, dim=1)
+            T.copy(B_fr, Out)
+
+    return main
+
+
+def _make_logical_kernel(logical_op):
+    @T.prim_func
+    def main(A: T.Tensor((M, N), "bool"), Out: T.Tensor((M,), "bool")):
+        with T.Kernel(M, threads=THREADS) as bx:
+            A_sh = T.alloc_shared((N,), "bool")
+            for j in T.Parallel(N):
+                A_sh[j] = A[bx, j]
+            Out[bx] = logical_op(A_sh)
+
+    return main
+
+
+def _make_bool_tile():
+    torch.manual_seed(0)
+    a = torch.rand(M, N, device="cuda") < 0.5
+    # Deterministic rows so both outcomes of the logical reductions occur:
+    # row 0 is all-true (any_of/all_of -> True), row 1 is all-false (-> False).
+    a[0] = True
+    a[1] = False
+    return a
+
+
+@pytest.mark.parametrize(
+    ("reduce_fn", "logical_op", "torch_reduce"),
+    [
+        (T.reduce_max, T.any_of, lambda a: a.any(dim=1)),
+        (T.reduce_min, T.all_of, lambda a: a.all(dim=1)),
+        (T.reduce_bitand, T.all_of, lambda a: a.all(dim=1)),
+    ],
+    ids=["reduce_max==any_of", "reduce_min==all_of", "reduce_bitand==all_of"],
+)
+@tilelang.testing.requires_cuda
+def test_bool_reduce_matches_logical_reduction(reduce_fn, logical_op, torch_reduce):
+    a = _make_bool_tile()
+
+    out = tilelang.compile(_make_reduce_kernel("bool", reduce_fn), out_idx=[-1], target="cuda")(a)
+    logical_out = tilelang.compile(_make_logical_kernel(logical_op), out_idx=[-1], target="cuda")(a)
+    torch_ref = torch_reduce(a)
+
+    assert out.dtype == torch.bool
+    assert torch.equal(out, logical_out)
+    assert torch.equal(out, torch_ref)
+
+
+@pytest.mark.parametrize("dtype", ["int32", "float32"])
+@tilelang.testing.requires_cuda
+def test_non_bool_reduce_max_still_compiles(dtype):
+    # Compile-time control from the issue: the int/float reduce path must be
+    # unaffected by the bool identity fix.
+    tilelang.compile(_make_reduce_kernel(dtype, T.reduce_max), out_idx=[-1], target="cuda")
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
* Scalarize vectorized bool with more than 4 lanes to avoid ICE during downstream codegen
* Use dedicated init values for boolean reductions

Fixes #2568, fixes #2206 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Scalarize vectorized boolean values with more than four lanes to prevent CUDA codegen failures.
- Use boolean identity values for reductions:
  - `0` for `max` and logical OR.
  - `1` for `min`, bitwise AND, and logical AND.
- Preserve existing initialization behavior for integer and floating-point reductions.
- Add CUDA regression tests for boolean reductions and coverage for `int32` and `float32` reductions.

## C++ style / lint notes

- The PR changes C++ code in `reduce.h` and `vectorize_loop.cc`.
- No changes to the rules documented in `docs/developer_guide/cpp_style.md` are indicated.
- The “C++ API Style Audit (warning only)” CI step is relevant if configured for these files.
- No correctness or build issue is reported from style warnings. Advisory TLCPP003/TLCPP004 findings should not block merge unless they indicate a new API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->