### PR TITLE
[Doc] ROCm CI is no longer disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ TileLang requires Python 3.10 or newer. The default `auto` target detects CUDA, 
 | Backend | Target | Platforms and hardware | Support level | Notes |
 | --- | --- | --- | --- | --- |
 | NVIDIA CUDA | `cuda` | Linux x86-64/AArch64, Windows x86-64; code paths from SM70 through SM120 | Primary | Release wheels and CI coverage; TMA, WGMMA, and TMEM features require the corresponding GPU architecture. |
-| AMD ROCm/HIP | `hip` | Linux; CDNA and RDNA GPUs, including gfx942/gfx950 paths | Supported | Included in Linux wheels; a ROCm runtime is required. ROCm CI is temporarily disabled. |
+| AMD ROCm/HIP | `hip` | Linux; CDNA and RDNA GPUs, including gfx942/gfx950 paths | Supported | Included in Linux wheels; a ROCm runtime is required. CI runs on a self-hosted gfx942 (MI300X) runner; gfx950 is not yet covered. |
 | Apple Metal | `metal` | macOS on Apple silicon | Supported | Release wheels and CI coverage; Metal 4 cooperative tensors are available on supported M5 systems. |
 | LLVM CPU | `llvm` | Host CPUs | Experimental | Build from source with `USE_LLVM=ON`; LLVM 15 or newer is required. |
 | NVIDIA CuTe DSL | `cutedsl` | NVIDIA GPUs | Experimental | Requires `nvidia-cutlass-dsl`. |


### PR DESCRIPTION
The backend support table still says *"ROCm CI is temporarily disabled."* That was accurate when the ROCm leg was commented out, but #2874 re-enabled it on a self-hosted gfx942 (MI300X) runner, so the note is now stale.

```diff
-... a ROCm runtime is required. ROCm CI is temporarily disabled.
+... a ROCm runtime is required. CI runs on a self-hosted gfx942 (MI300X) runner; gfx950 is not yet covered.
```

I added the gfx950 caveat deliberately rather than just deleting the stale sentence. The hardware column advertises "including gfx942/gfx950 paths", and the two architectures genuinely diverge in ways the test suite can observe — software pipelining annotations are stripped unless gfx950, fp8 `e4m3` maps to FNUZ on gfx942 but OCP FN on gfx950, and `__launch_bounds__` differs. Claiming unqualified "CI coverage" would overstate what the runner actually verifies.

Docs only, no code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated `README.md` to state that ROCm CI runs on a self-hosted gfx942 (MI300X) runner.
- Documented that gfx950 is not yet covered.
- No code, API, build, or test changes.

## C++ style / lint notes

- The PR does not touch rules in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step is unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->