### PR TITLE
[Test] Add regression test for issue #2883

### DIFF
--- a/testing/python/issue/test_tilelang_issue_2883.py
+++ b/testing/python/issue/test_tilelang_issue_2883.py
@@ -1,0 +1,36 @@
+"""Regression test for GitHub issue #2883.
+
+Layout inference must accept a large injective ``T.Parallel`` domain even
+when it exceeds the exact-enumeration limit and requires a stronger proof.
+"""
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+
+
+def test_large_parallel_layout_is_injective():
+    stride = T.dynamic("stride")
+
+    @T.prim_func
+    def main(
+        dst: T.StridedTensor((1, 8192), (stride, 1), "uint8"),
+        src: T.StridedTensor((1, 8192), (stride, 1), "uint8"),
+    ):
+        T.assume(stride % 2 == 0)
+
+        with T.Kernel(1):
+            for token, feature in T.Parallel(64, 8192):
+                if token < 1:
+                    dst[token, feature] = src[token, feature]
+
+    target = tvm.target.Target("cuda")
+    with target:
+        artifact = tilelang.lower(main, target=target, enable_device_compile=False)
+
+    assert artifact.kernel_source
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

- add a standalone regression test for issue #2883
- cover layout inference for an injective `T.Parallel(64, 8192)` domain with dynamic strided tensors
- disable device compilation so the test isolates the layout-inference path

## Testing

- PASS: `bash format.sh --files testing/python/issue/test_tilelang_issue_2883.py`
- PASS: native CMake build
- BLOCKED: a focused pytest attempt of the same reproducer stopped before layout inference because the local shared TVM checkout does not expose `tvm.arith.Z3ContextScope`; after moving the test into the issue directory, it was not retried without approval to switch dependencies

Related to #2883.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added a standalone regression test for issue `#2883`.
- Covered layout inference for `T.Parallel(64, 8192)` with dynamic strided tensors.
- Disabled device compilation to isolate layout inference.
- Formatting and native CMake build passed.
- Pytest execution was blocked because `tvm.arith.Z3ContextScope` is unavailable in the shared TVM checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->