### PR TITLE
[Docs] Define backend architecture and integration skill

### DIFF
--- a/.agents/skills/tilelang-backend/SKILL.md
+++ b/.agents/skills/tilelang-backend/SKILL.md
@@ -1,18 +1,22 @@
 ---
 name: tilelang-backend
-description: Integrate or review a TileLang target backend, target-backend variant, or execution backend end to end across language dialects, target and BackendContext resolution, PassPipeline, host/device codegen, Build/JIT/Runtime, native CMake and packaging, tests, and documentation. Use when asked to add, port, scaffold, complete, or audit a TileLang backend or execution mode.
+description: Integrate or review a TileLang target backend, target-backend variant, or shared execution backend. Covers language dialects, target and BackendContext contributions, PassPipeline, host/device codegen, execution compatibility, native CMake and packaging, tests, and documentation; covers Build/JIT/Runtime implementation only when a genuinely new execution mode is requested. Use when asked to add, port, scaffold, complete, or audit a TileLang backend or execution mode.
 ---
 
 # TileLang Backend Integration
 
-Treat a target backend as one end-to-end vertical slice:
+Treat a target backend as four compiler-owned implementation areas connected to
+a separately reusable execution backend:
 
 ```text
 Language Dialect
-  -> BackendContext preparation
+  -> target/BackendContext contribution
   -> PassPipeline
   -> HostCodegen + DeviceCodegen
-  -> selected ExecutionBackend (Build -> Load -> Launch)
+  -> compatibility contract
+
+BackendContext selects a shared ExecutionBackend
+  -> Build -> Load -> Launch
 ```
 
 ## Required Reading
@@ -34,13 +38,15 @@ commands.
 
 Choose exactly one primary category:
 
-- **New target backend**: implement all five layers plus native/package
+- **New target backend**: implement the four target-backend areas, declare
+  compatibility with existing execution backends, and add native/package
   integration, tests, and user documentation.
 - **Target-backend variant**: add a distinct `BackendModule`; explicitly reuse
   or replace each component and make shared-target predicates unambiguous.
-- **New execution backend**: implement one Build/JIT/Runtime path and declare it
-  on compatible target backends; do not add a target pipeline unless target
-  semantics change.
+- **New execution backend**: only when no existing implementation can consume
+  the artifact or runtime API, implement one shared Build/JIT/Runtime path and
+  declare compatible target backends; do not add a target pipeline unless
+  target semantics change.
 
 Do not conflate a backend name, Python package name, TVM target kind, and
 execution backend name.
@@ -82,7 +88,8 @@ Follow the detailed checklist in order. Keep these boundaries non-negotiable:
 - Keep the complete pass order in `tilelang/<backend>/pipeline.py`.
 - Keep target dispatch out of `tilelang/engine/lower.py`.
 - Keep target codegen and toolchain helpers under target-backend ownership.
-- Keep Build inside the selected execution path.
+- Declare execution compatibility; do not implement target-local JIT/Runtime
+  when an existing shared execution backend satisfies the contract.
 - Add common helpers only after demonstrating a target-neutral shared use.
 - Fail unsupported features during target resolution or lowering with an
   actionable message.
@@ -94,6 +101,8 @@ Account for these current transitional details:
 - `BackendModule` is a compiler-facing manifest, not the entire backend.
 - `ExecutionBackendSpec` describes selection and capabilities; concrete
   adapters still live under `tilelang/jit/adapter/`.
+- For a new target backend, supplying compatible codegen outputs and metadata
+  is normally sufficient; a new adapter is not.
 - Execution-name dispatch still exists outside the spec. Search all JIT, cache,
   export, autotuning, diagnostic, and public typing sites when adding a mode.
 - Native `target.build.*` functions currently combine parts of CodeGen and
@@ -114,8 +123,9 @@ Run hardware-independent checks first:
 4. pipeline lowering and unsupported-feature diagnostics;
 5. source-only codegen and generated-source assertions;
 6. native build with the backend enabled;
-7. execution Build/load/launch and numerical tests on target hardware;
-8. cache/export/autotuning tests affected by a new execution mode;
+7. a compatibility smoke test through each declared shared execution path;
+8. full Build/load/launch, cache, export, and autotuning tests only for a new
+   execution mode;
 9. `git diff --check` and relevant documentation checks.
 
 After any native edit, rebuild before trusting Python results. Do not report a
@@ -126,8 +136,8 @@ backend complete when only registration or source generation passes.
 Use the Definition of Done in the integration checklist. In the final report,
 state:
 
-- which of the five layers changed;
+- which of the four target-backend areas changed;
 - which components were reused intentionally;
 - supported and explicitly unsupported capabilities;
-- execution paths tested;
+- compatible shared execution paths tested;
 - hardware/toolchain checks that could not be run.

--- a/.agents/skills/tilelang-backend/SKILL.md
+++ b/.agents/skills/tilelang-backend/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: tilelang-backend
+description: Integrate or review a TileLang target backend, target-backend variant, or execution backend end to end across language dialects, target and BackendContext resolution, PassPipeline, host/device codegen, Build/JIT/Runtime, native CMake and packaging, tests, and documentation. Use when asked to add, port, scaffold, complete, or audit a TileLang backend or execution mode.
+---
+
+# TileLang Backend Integration
+
+Treat a target backend as one end-to-end vertical slice:
+
+```text
+Language Dialect
+  -> BackendContext preparation
+  -> PassPipeline
+  -> HostCodegen + DeviceCodegen
+  -> selected ExecutionBackend (Build -> Load -> Launch)
+```
+
+## Required Reading
+
+Before editing code, read both files completely:
+
+1. [`../../../tilelang/backend/README.md`](../../../tilelang/backend/README.md)
+   for the architecture and ownership model.
+2. [`references/integration-checklist.md`](references/integration-checklist.md)
+   for concrete files, registration points, tests, and completion criteria.
+
+When native code, installation, or tests are involved, also read
+[`../tilelang-build/SKILL.md`](../tilelang-build/SKILL.md) before running build
+commands.
+
+## Workflow
+
+### 1. Classify the Request
+
+Choose exactly one primary category:
+
+- **New target backend**: implement all five layers plus native/package
+  integration, tests, and user documentation.
+- **Target-backend variant**: add a distinct `BackendModule`; explicitly reuse
+  or replace each component and make shared-target predicates unambiguous.
+- **New execution backend**: implement one Build/JIT/Runtime path and declare it
+  on compatible target backends; do not add a target pipeline unless target
+  semantics change.
+
+Do not conflate a backend name, Python package name, TVM target kind, and
+execution backend name.
+
+### 2. Define the Capability Contract
+
+Before implementation, record:
+
+- target kind, attributes, aliases, and variant predicate;
+- supported dialect extensions and tile operations;
+- launch/thread model and required pass behavior;
+- device output format and host targets;
+- execution backends in `auto` order;
+- eager versus deferred device compilation;
+- hardware-free and hardware-required validation boundaries.
+
+If TVM does not recognize the target kind, treat TVM target registration as a
+prerequisite. Do not emulate an unknown kind with scattered TileLang strings.
+
+### 3. Inspect Before Copying
+
+Use the closest existing backend as a reference:
+
+- CPU for serial/non-SIMT lowering;
+- ROCm, Metal, or WebGPU for a relatively direct SIMT backend;
+- CUDA only when CUDA-specific scheduling and memory behavior are relevant;
+- CuTeDSL for a predicate-selected variant sharing a target kind.
+
+Trace package initialization, target normalization, pipeline, codegen global
+functions, native source registration, execution adapter, CMake, and tests.
+Preserve unrelated worktree changes.
+
+### 4. Implement All Applicable Layers
+
+Follow the detailed checklist in order. Keep these boundaries non-negotiable:
+
+- Resolve target and execution state once into `BackendContext`.
+- Keep backend language extensions outside `tilelang.language.common`.
+- Keep the complete pass order in `tilelang/<backend>/pipeline.py`.
+- Keep target dispatch out of `tilelang/engine/lower.py`.
+- Keep target codegen and toolchain helpers under target-backend ownership.
+- Keep Build inside the selected execution path.
+- Add common helpers only after demonstrating a target-neutral shared use.
+- Fail unsupported features during target resolution or lowering with an
+  actionable message.
+
+### 5. Reconcile Current Implementation Constraints
+
+Account for these current transitional details:
+
+- `BackendModule` is a compiler-facing manifest, not the entire backend.
+- `ExecutionBackendSpec` describes selection and capabilities; concrete
+  adapters still live under `tilelang/jit/adapter/`.
+- Execution-name dispatch still exists outside the spec. Search all JIT, cache,
+  export, autotuning, diagnostic, and public typing sites when adding a mode.
+- Native `target.build.*` functions currently combine parts of CodeGen and
+  Build. Preserve source-only codegen when deferred Build needs it.
+- Backend Python packages are wheel-included automatically, but native sources
+  require explicit backend-local CMake integration.
+
+Do not deepen these transitional couplings. In particular, do not add
+target-kind branches to execution dispatch or execution-name checks to passes.
+
+### 6. Verify by Risk Layer
+
+Run hardware-independent checks first:
+
+1. package import and manifest registration;
+2. target normalization and context resolution;
+3. dialect exports and IR construction;
+4. pipeline lowering and unsupported-feature diagnostics;
+5. source-only codegen and generated-source assertions;
+6. native build with the backend enabled;
+7. execution Build/load/launch and numerical tests on target hardware;
+8. cache/export/autotuning tests affected by a new execution mode;
+9. `git diff --check` and relevant documentation checks.
+
+After any native edit, rebuild before trusting Python results. Do not report a
+backend complete when only registration or source generation passes.
+
+## Completion Standard
+
+Use the Definition of Done in the integration checklist. In the final report,
+state:
+
+- which of the five layers changed;
+- which components were reused intentionally;
+- supported and explicitly unsupported capabilities;
+- execution paths tested;
+- hardware/toolchain checks that could not be run.

--- a/.agents/skills/tilelang-backend/agents/openai.yaml
+++ b/.agents/skills/tilelang-backend/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "TileLang Backend Integration"
-  short_description: "Add TileLang backends end to end"
-  default_prompt: "Use $tilelang-backend to add a new TileLang target backend end to end."
+  short_description: "Integrate target and execution backends"
+  default_prompt: "Use $tilelang-backend to integrate a TileLang target backend and declare compatible execution paths."

--- a/.agents/skills/tilelang-backend/agents/openai.yaml
+++ b/.agents/skills/tilelang-backend/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TileLang Backend Integration"
+  short_description: "Add TileLang backends end to end"
+  default_prompt: "Use $tilelang-backend to add a new TileLang target backend end to end."

--- a/.agents/skills/tilelang-backend/references/integration-checklist.md
+++ b/.agents/skills/tilelang-backend/references/integration-checklist.md
@@ -10,7 +10,7 @@ Use this reference with the architecture in `tilelang/backend/README.md`.
 4. [Backend Context Preparation](#2-backend-context-preparation)
 5. [Pass Pipeline](#3-pass-pipeline)
 6. [Host and Device Codegen](#4-host-and-device-codegen)
-7. [Execution Backend](#5-execution-backend-build-jit-and-runtime)
+7. [Execution Backend Compatibility](#execution-backend-compatibility)
 8. [Native Compilation and Packaging](#native-compilation-and-packaging)
 9. [Tests and Documentation](#tests-and-documentation)
 10. [Definition of Done](#definition-of-done)
@@ -19,7 +19,7 @@ Use this reference with the architecture in `tilelang/backend/README.md`.
 
 | Change | Required integration |
 | --- | --- |
-| New target backend | All five layers, imports, native build, packaging, tests, and docs. |
+| New target backend | Four target-backend areas, execution compatibility declaration, imports, native compilation, packaging, tests, and docs. |
 | Variant sharing a target kind | Separate manifest and predicate; explicit component reuse; variant-resolution tests. |
 | New execution mode | Build/JIT/Runtime implementation, compatible manifests, shared dispatch bridge, cache/export/autotuning coverage. |
 
@@ -41,7 +41,7 @@ Record these choices in the implementation plan:
 - source or runtime-module format;
 - host targets and host preparation requirements;
 - execution paths and `auto` preference;
-- Build toolchain and eager/deferred compilation policy;
+- compatible execution implementations and eager/deferred compilation policy;
 - hardware-free source-generation coverage;
 - optional SDK/runtime and portable-wheel strategy.
 
@@ -233,45 +233,57 @@ Do not silently use another target's implementation. Reject unsupported
 operations during resolution/lowering with target and capability details, not
 through downstream source syntax or launch failures.
 
-## 5. Execution Backend: Build, JIT, and Runtime
+## Execution Backend Compatibility
 
-Declare execution paths in `tilelang/<backend>/execution_backend.py` using
-`ExecutionBackendSpec`.
+A new target backend normally reuses an existing execution implementation. In
+`tilelang/<backend>/execution_backend.py`, declare compatibility using
+`ExecutionBackendSpec` rather than implementing target-local JIT/Runtime code.
 
-For every path, define:
+For each compatible path, declare and verify:
 
-- name and `auto` order;
-- lazy availability check;
+- execution name and `auto` preference order;
+- lazy availability check, when dependencies are optional;
 - optional target predicate;
-- host-codegen requirement;
-- eager-device-compilation requirement;
-- artifact type and cache-key inputs;
-- loading and wrapper creation;
+- whether the shared implementation requests host codegen;
+- whether it requests eager device compilation;
+- the compiled or source-only codegen mode it consumes;
+- the source, artifact, global-symbol, argument, and launch-metadata contract.
+
+Declaring `tvm_ffi`, for example, means the target backend can produce the host
+and device runtime modules expected by the existing TVM FFI adapter. Declaring
+`nvrtc` means it can produce CUDA source and metadata expected by the existing
+NVRTC adapter. Do not declare an execution backend merely because its name is
+already available.
+
+The target backend provides target-specific source generation, validation,
+compiler callbacks, and toolchain helpers. The shared execution backend owns:
+
+- Build orchestration and cache policy;
+- wrapper creation and artifact loading;
 - argument, stream, and context binding;
-- launch, lifetime, and error behavior.
+- kernel launch, lifetime, and execution errors.
 
-Reuse an existing execution backend only when its artifact and launch contract
-match. Declaring `tvm_ffi`, for example, requires host/device runtime modules
-compatible with the TVM FFI adapter.
+An execution implementation may call target-owned compiler callbacks during
+Build. That compiler hook remains part of the target codegen/toolchain
+contract; it does not require a target-specific JIT adapter.
 
-Build is internal to the execution path:
+Add a compatibility smoke test through each declared path, but do not duplicate
+the shared adapter's generic unit tests in every target backend.
 
-```text
-generated code
-  -> Build: compile + link + package
-  -> JIT: cache + load + create callable
-  -> Runtime: bind + launch + manage lifetime
-```
+### When a new execution backend is required
 
-The target backend supplies reusable source generation, validation callbacks,
-and toolchain helpers. The execution backend selects them and decides whether
-Build is eager or deferred.
+Implement a new shared execution backend only when no existing adapter can
+consume the generated artifact or operate the target runtime API. Then define:
 
-### Current bridge
+- Build: compile, link, package, and artifact cache inputs;
+- JIT: cache lookup, load, wrapper creation, and callable construction;
+- Runtime: arguments, streams/contexts, launch, lifetime, and errors;
+- AOT/export behavior when artifacts can be produced without loading.
 
 `ExecutionBackendSpec` currently stores selection/capability metadata. Concrete
 adapters live in `tilelang/jit/adapter/`, and execution-name switches remain in
-shared JIT/cache/export/autotuning code. When adding a mode, find every site:
+shared JIT/cache/export/autotuning code. For a genuinely new mode, find every
+site:
 
 ```bash
 rg -n 'tvm_ffi|nvrtc|cython|torch|cutedsl' tilelang testing
@@ -280,9 +292,6 @@ rg -n 'tvm_ffi|nvrtc|cython|torch|cutedsl' tilelang testing
 Update JIT, cache, export, autotuning, diagnostics, environment validation, and
 public type annotations as applicable. Keep bridge dispatch based on execution
 name, never target kind. Do not place execution checks in compiler passes.
-
-For AOT/export, expose reusable artifact production within the execution path
-and test it without loading. Do not add Build as a sixth target-backend layer.
 
 ## Native Compilation and Packaging
 
@@ -313,13 +322,14 @@ Add hardware-independent coverage first:
 1. Package import and manifest registration.
 2. Target normalization and `create_backend_context()`.
 3. Auto-detection if declared.
-4. Execution order, explicit selection, and unavailable errors.
+4. Compatible execution order, explicit selection, and unavailable errors.
 5. Dialect exports and IR construction.
 6. Minimal pipeline lowering plus every backend-specific IR form.
 7. Source-only codegen without hardware when feasible.
 8. Generated-source syntax/structure.
-9. Compiled artifact creation for every Build path.
-10. Load/launch, streams, arguments, and numerical correctness.
+9. A smoke Build/load/launch through each declared shared execution path.
+10. Full cache, wrapper, stream, argument, and lifetime tests when adding a new
+    execution backend.
 11. Unsupported operations/architectures.
 12. Native build enabled and import when hardware/runtime is unavailable.
 
@@ -350,12 +360,14 @@ git diff --check
 ## Definition of Done
 
 - [ ] Explicit dialect imports and constructs common and backend-specific IR.
-- [ ] Target resolves to exactly one manifest and an intended execution path.
+- [ ] Target resolves to exactly one manifest and a compatible shared execution
+      backend.
 - [ ] Complete pass order lives in the backend package.
 - [ ] Supported dialect IR lowers without engine target dispatch.
 - [ ] Host/device codegen preserves source and launch metadata.
-- [ ] Every declared execution path can Build, load, and launch, or reports an
-      availability error.
+- [ ] Every declared shared execution backend can consume the generated output
+      in a smoke test or reports an availability error.
+- [ ] A target backend does not duplicate shared JIT/Runtime behavior.
 - [ ] Common tile operations are implemented or fail explicitly.
 - [ ] Native sources/toolchains are wired through local CMake and packaging.
 - [ ] Hardware-free import/source tests run where feasible.

--- a/.agents/skills/tilelang-backend/references/integration-checklist.md
+++ b/.agents/skills/tilelang-backend/references/integration-checklist.md
@@ -1,0 +1,366 @@
+# TileLang Backend Integration Checklist
+
+Use this reference with the architecture in `tilelang/backend/README.md`.
+
+## Contents
+
+1. [Scope Matrix](#scope-matrix)
+2. [Preflight Decisions](#preflight-decisions)
+3. [Language Dialect](#1-language-dialect)
+4. [Backend Context Preparation](#2-backend-context-preparation)
+5. [Pass Pipeline](#3-pass-pipeline)
+6. [Host and Device Codegen](#4-host-and-device-codegen)
+7. [Execution Backend](#5-execution-backend-build-jit-and-runtime)
+8. [Native Compilation and Packaging](#native-compilation-and-packaging)
+9. [Tests and Documentation](#tests-and-documentation)
+10. [Definition of Done](#definition-of-done)
+
+## Scope Matrix
+
+| Change | Required integration |
+| --- | --- |
+| New target backend | All five layers, imports, native build, packaging, tests, and docs. |
+| Variant sharing a target kind | Separate manifest and predicate; explicit component reuse; variant-resolution tests. |
+| New execution mode | Build/JIT/Runtime implementation, compatible manifests, shared dispatch bridge, cache/export/autotuning coverage. |
+
+A package name may differ from its target kind. For example, `rocm` owns
+`hip`. Decide the backend name, package name, target kind, and execution names
+before creating files.
+
+## Preflight Decisions
+
+Record these choices in the implementation plan:
+
+- TVM target kind and whether TVM already registers it;
+- required target attributes and accepted aliases;
+- auto-detection policy and architecture defaults;
+- variant-selection predicate if the target kind is shared;
+- common and backend-specific language surface;
+- initial supported tile operations and explicit exclusions;
+- SIMT, serial, or custom launch/thread model;
+- source or runtime-module format;
+- host targets and host preparation requirements;
+- execution paths and `auto` preference;
+- Build toolchain and eager/deferred compilation policy;
+- hardware-free source-generation coverage;
+- optional SDK/runtime and portable-wheel strategy.
+
+Do not begin by copying the CUDA backend wholesale. Select the closest backend
+for each layer; one backend may be the best pipeline reference while another is
+the best execution reference.
+
+## 1. Language Dialect
+
+Create `tilelang/<backend>/language/__init__.py`, including for a common-only
+initial dialect:
+
+```python
+from tilelang.language.common import *  # noqa: F401,F403
+from tilelang.language.common import __all__ as _COMMON_ALL
+
+__tilelang_dialect__ = "<backend>"
+__all__ = tuple(_COMMON_ALL)
+
+del _COMMON_ALL
+```
+
+For extensions:
+
+- place APIs under `tilelang/<backend>/language/`;
+- export a deterministic `__all__` and set `__tilelang_dialect__`;
+- construct IR operations, calls, or annotations instead of emitting source;
+- add pipeline lowering or legalization for every emitted form;
+- place Python intrinsic emitters in `tilelang/<backend>/intrinsics/` when used
+  by tile-op selection;
+- register native TIR builtins in `src/<backend>/op/` when required;
+- use `from tilelang.<backend> import language as T` in tests/examples.
+
+Do not add backend-only symbols to `tilelang.language.common` or the default
+CUDA-compatible `tilelang.language` facade. Test every extension from dialect
+construction through lowering.
+
+## 2. Backend Context Preparation
+
+### Target handling
+
+Add `tilelang/<backend>/target.py` when detection, normalization, aliases,
+architecture defaults, or predicates are needed.
+
+- Use `register_target_detector()` only for real auto-detection.
+- Use `register_target_normalizer()` for aliases and canonical attributes.
+- Return `None` for inputs belonging to another backend.
+- Preserve explicit user attributes unless documented canonicalization requires
+  a change.
+- Delay optional imports and hardware probes until the detector/normalizer is
+  called.
+- Make missing optional dependencies actionable.
+- Support explicit target resolution even if auto-detection is unavailable.
+
+Test strings, config dictionaries, `Target` objects, invalid attributes,
+aliases, canonical attributes, and auto-detection when declared.
+
+### Manifest
+
+Create `tilelang/<backend>/backend.py`:
+
+```python
+BACKEND = register_backend(
+    BackendModule(
+        name="<backend>",
+        target_kinds=("<target-kind>",),
+        supports_target=...,  # required for a shared target kind
+        pipelines={"<target-kind>": BACKEND_PIPELINE},
+        device_codegens={"<target-kind>": BACKEND_DEVICE_CODEGEN},
+        host_codegens=STANDARD_HOST_CODEGENS,
+        host_codegen_hooks={...},
+        execution_backends=EXECUTION_BACKENDS,
+        callbacks={...},
+    )
+)
+```
+
+Honor `BackendModule` validation:
+
+- `pipelines` and `device_codegens` contain exactly one entry per owned kind;
+- each pipeline name equals its TVM target kind;
+- at least one execution backend is declared;
+- execution names are unique and declaration order defines `auto`;
+- host codegens exist when an execution mode enables host codegen;
+- every manifest sharing a target kind has a mutually exclusive predicate;
+- FFI callback names are process-global and unique.
+
+Use callbacks for backend-owned validation or compiler/toolchain integration,
+not arbitrary engine dispatch.
+
+### Package initialization
+
+Create `tilelang/<backend>/__init__.py` with a cycle-safe order. Usually import:
+
+1. target registration;
+2. backend transforms;
+3. language dialect;
+4. intrinsics;
+5. tile-op implementations;
+6. backend manifest.
+
+Import the package from `tilelang/__init__.py` so built-in backends register
+during normal initialization. Test a fresh-process import without target
+hardware or SDK. Optional external plugins may use a different loading model,
+but must document and test it explicitly.
+
+## 3. Pass Pipeline
+
+Create `tilelang/<backend>/pipeline.py` with a complete ordered sequence after
+the shared `PreLowerSemanticCheck`. Wrap it in a `PassPipeline` named for the
+TVM target kind.
+
+Deliberately cover these boundaries where applicable:
+
+1. Bind the normalized target.
+2. Materialize the kernel launch model.
+3. Normalize and validate frontend IR.
+4. Run pre-layout target transformations whose annotations affect layout.
+5. Infer layouts and lower tile operations.
+6. Legalize memory, vectorization, types, and target intrinsics.
+7. Plan allocations and lower opaque blocks and buffers.
+8. Verify memory and lower supported reductions/synchronization.
+9. Split host and device functions.
+10. Apply post-split storage, synchronization, packed API, and launch lowering.
+
+Use shared helpers from `tilelang/backend/pass_pipeline` only for genuinely
+common behavior. Keep the complete ordered list visible in the backend package.
+Put Python backend-only passes in `tilelang/<backend>/transform/` and native
+passes in `src/<backend>/transform/`.
+
+Reference guidance:
+
+- CPU: serial/non-SIMT launch handling;
+- ROCm/Metal/WebGPU: comparatively direct SIMT pipelines;
+- CUDA: CUDA-specific async memory, specialization, and architecture passes;
+- CuTeDSL: explicit pipeline reuse by a target variant.
+
+Reuse a pipeline only when lowering is identical, and add an identity/reuse
+test. Never select a target-specific pipeline in `tilelang/engine/lower.py`.
+
+## 4. Host and Device Codegen
+
+### Device codegen
+
+Create `tilelang/<backend>/codegen.py` and a `DeviceCodegen`. Native backends
+usually register:
+
+```text
+target.build.tilelang_<backend>
+target.build.tilelang_<backend>_without_compile
+```
+
+The compiled path emits target code and returns a loadable runtime module. The
+source-only path emits the same source without invoking the target compiler.
+Implement both when any execution path defers Build. If a mode is unsupported,
+leave the callback absent and ensure no execution backend requests it.
+
+Preserve downstream metadata:
+
+- inspectable source;
+- global symbols;
+- argument types;
+- launch parameter tags;
+- target format;
+- runtime-module metadata needed to load and invoke kernels.
+
+Put native source generation and runtime-module integration under
+`src/<backend>/codegen/`. Keep Python wrappers thin and map them to
+backend-owned global functions.
+
+### Host codegen
+
+Reuse `STANDARD_HOST_CODEGENS` for `c`/`llvm` when compatible. Add a custom
+`HostCodegen` only for a genuinely different host representation. Use
+`HostCodegenHook` for device-backend preparation immediately before host
+codegen instead of adding engine branches.
+
+### Operations, intrinsics, and templates
+
+Inventory every operation used by the first supported kernels:
+
+- Python tile-op selectors: `tilelang/<backend>/op/`;
+- native op lowerers: `src/<backend>/op/` with target predicates;
+- Python intrinsic helpers: `tilelang/<backend>/intrinsics/`;
+- native builtins/lowering: `src/<backend>/op/` or backend transforms;
+- generated source templates: `src/tl_templates/<backend>/`.
+
+Do not silently use another target's implementation. Reject unsupported
+operations during resolution/lowering with target and capability details, not
+through downstream source syntax or launch failures.
+
+## 5. Execution Backend: Build, JIT, and Runtime
+
+Declare execution paths in `tilelang/<backend>/execution_backend.py` using
+`ExecutionBackendSpec`.
+
+For every path, define:
+
+- name and `auto` order;
+- lazy availability check;
+- optional target predicate;
+- host-codegen requirement;
+- eager-device-compilation requirement;
+- artifact type and cache-key inputs;
+- loading and wrapper creation;
+- argument, stream, and context binding;
+- launch, lifetime, and error behavior.
+
+Reuse an existing execution backend only when its artifact and launch contract
+match. Declaring `tvm_ffi`, for example, requires host/device runtime modules
+compatible with the TVM FFI adapter.
+
+Build is internal to the execution path:
+
+```text
+generated code
+  -> Build: compile + link + package
+  -> JIT: cache + load + create callable
+  -> Runtime: bind + launch + manage lifetime
+```
+
+The target backend supplies reusable source generation, validation callbacks,
+and toolchain helpers. The execution backend selects them and decides whether
+Build is eager or deferred.
+
+### Current bridge
+
+`ExecutionBackendSpec` currently stores selection/capability metadata. Concrete
+adapters live in `tilelang/jit/adapter/`, and execution-name switches remain in
+shared JIT/cache/export/autotuning code. When adding a mode, find every site:
+
+```bash
+rg -n 'tvm_ffi|nvrtc|cython|torch|cutedsl' tilelang testing
+```
+
+Update JIT, cache, export, autotuning, diagnostics, environment validation, and
+public type annotations as applicable. Keep bridge dispatch based on execution
+name, never target kind. Do not place execution checks in compiler passes.
+
+For AOT/export, expose reusable artifact production within the execution path
+and test it without loading. Do not add Build as a sixth target-backend layer.
+
+## Native Compilation and Packaging
+
+Create `src/<backend>/CMakeLists.txt` and make it own source selection,
+toolchain lookup, includes, definitions, stubs, and optional runtime libraries.
+
+- Separate always-safe codegen/registration from SDK-gated runtime sources.
+- Append sources/includes through existing `TILE_LANG_*` variables.
+- Include the backend-local file from the root CMake delegation block.
+- Add `USE_<BACKEND>` only when native compilation needs a gate; update
+  `TILELANG_BACKENDS`, option docs, environment handling, and defaults together.
+- Avoid hard runtime dependencies in wheels when codegen-only builds, lazy
+  loading, or stubs are practical.
+- Add link libraries, RPATH, install targets, and wheel-repair exclusions
+  deliberately.
+- Update `pyproject.toml` for dependencies, resources, or wheel behavior.
+
+Python packages under `tilelang/` are included by the current wheel mapping.
+Native sources are inactive until added through backend-local CMake.
+
+Do not edit `3rdparty/` to bypass a missing TileLang integration point. Isolate
+and justify any required upstream TVM target/runtime change.
+
+## Tests and Documentation
+
+Add hardware-independent coverage first:
+
+1. Package import and manifest registration.
+2. Target normalization and `create_backend_context()`.
+3. Auto-detection if declared.
+4. Execution order, explicit selection, and unavailable errors.
+5. Dialect exports and IR construction.
+6. Minimal pipeline lowering plus every backend-specific IR form.
+7. Source-only codegen without hardware when feasible.
+8. Generated-source syntax/structure.
+9. Compiled artifact creation for every Build path.
+10. Load/launch, streams, arguments, and numerical correctness.
+11. Unsupported operations/architectures.
+12. Native build enabled and import when hardware/runtime is unavailable.
+
+Update the builtin expectations in
+`testing/python/backend/test_tilelang_backend_module.py`. Put target tests under
+`testing/python/target/`, backend tests under `testing/python/<backend>/`, and
+execution tests under `testing/python/jit/` or the backend directory. Add a
+reusable marker under `tilelang/testing/` for hardware-gated tests.
+
+Update:
+
+- `tilelang/backend/README.md` registered-backend table;
+- `docs/get_started/targets.md`;
+- installation/build docs for SDKs and CMake flags;
+- an example using the explicit dialect and target.
+
+For exact build commands, use `.agents/skills/tilelang-build/SKILL.md`. Rebuild
+after native edits to avoid testing a stale shared library. Typical focused
+checks include:
+
+```bash
+python -m pytest testing/python/backend/test_tilelang_backend_module.py -x
+python -m pytest testing/python/target/ -x
+python -m pytest testing/python/foo/ -x  # Replace foo with the package name.
+git diff --check
+```
+
+## Definition of Done
+
+- [ ] Explicit dialect imports and constructs common and backend-specific IR.
+- [ ] Target resolves to exactly one manifest and an intended execution path.
+- [ ] Complete pass order lives in the backend package.
+- [ ] Supported dialect IR lowers without engine target dispatch.
+- [ ] Host/device codegen preserves source and launch metadata.
+- [ ] Every declared execution path can Build, load, and launch, or reports an
+      availability error.
+- [ ] Common tile operations are implemented or fail explicitly.
+- [ ] Native sources/toolchains are wired through local CMake and packaging.
+- [ ] Hardware-free import/source tests run where feasible.
+- [ ] Hardware tests cover launch and numerical correctness.
+- [ ] Cache/export/autotuning behavior is covered for new execution modes.
+- [ ] Registry, target docs, installation notes, and an example are updated.
+- [ ] No backend-only symbol, pass order, or target dispatch leaked into shared
+      code without demonstrated cross-backend need.

--- a/tilelang/backend/README.md
+++ b/tilelang/backend/README.md
@@ -1,38 +1,45 @@
 # TileLang Backend Architecture
 
-TileLang treats a backend as an end-to-end vertical slice, from its language
-dialect to the code that loads and launches the generated kernel. The goal is
-to make backend ownership explicit while keeping the common TileLang frontend
-and compiler entry points backend-neutral.
+TileLang treats a target backend as a compiler vertical slice, from its
+language dialect through target code generation. Generated code is handed to a
+separate, reusable execution backend for Build, loading, and launch. The goal
+is to make both ownership boundaries explicit while keeping the common
+TileLang frontend and compiler entry points backend-neutral.
 
 Coding agents implementing a new backend must use the
 [`tilelang-backend` skill](../../.agents/skills/tilelang-backend/SKILL.md).
 
 ## Design Model
 
-A backend owns five related parts:
+A target backend owns four implementation areas:
 
 | Part | Responsibility |
 | --- | --- |
 | Language dialect | Extends the common TileLang language with backend-specific operations and intrinsics. |
-| Context preparation | Normalizes the device and host targets, selects the target backend, and resolves an execution backend. |
+| Context contribution | Defines target detection/normalization, target ownership, and compatible execution backends used by shared context resolution. |
 | Pass pipeline | Lowers common and backend-specific IR through one explicit, backend-owned pass sequence. |
-| Host/device codegen | Converts lowered host and device IR into source or runtime modules. |
-| Execution backend | Owns the selected build, JIT, and runtime path: compiling artifacts, loading them, and launching kernels. |
+| Host/device codegen | Converts lowered host and device IR into source or runtime modules and provides target-specific toolchain hooks. |
+
+The target backend also declares which shared execution backends can consume
+its outputs. This is a compatibility declaration, not a fifth implementation
+area. A new target backend normally reuses `tvm_ffi`, `nvrtc`, `cython`,
+`torch`, or another existing execution implementation.
 
 The logical flow is:
 
 ```text
-backend language dialect
+target-backend language dialect
         |
         v
     frontend IR
         |
         v
-BackendContext preparation
+shared BackendContext resolution
+  - selects target backend
+  - selects compatible ExecutionBackend
         |
         v
-backend PassPipeline
+target-backend PassPipeline
         |
         v
 host/device split
@@ -42,21 +49,25 @@ host/device split
         +-----------> DeviceCodegen --+
                                       |
                                       v
-                         selected ExecutionBackend
+                       shared ExecutionBackend
                            Build -> Load -> Launch
 ```
 
 `BackendContext` is created once and accompanies the compilation through the
-pipeline and codegen stages into the selected execution backend. A later stage
-must not infer or resolve the backend again.
+pipeline and codegen stages. It also records the selected shared execution
+backend, which consumes the generated outputs. A later stage must not infer or
+resolve either backend again.
 
 ### Terminology
 
 - A **target backend**, such as CUDA, ROCm, CPU, Metal, or WebGPU, owns the
   dialect, lowering, codegen, and target-specific toolchain primitives.
 - An **execution backend**, such as `tvm_ffi`, `nvrtc`, `cython`, `torch`, or
-  `cutedsl`, selects and implements a build/JIT/runtime path for a target
-  backend.
+  `cutedsl`, is a reusable Build/JIT/Runtime implementation that may serve one
+  or more compatible target backends.
+- A target backend **declares execution compatibility** and satisfies the
+  selected implementation's source, artifact, and launch-metadata contract; it
+  does not normally implement another JIT adapter or runtime.
 - `BackendModule` is the compiler-facing registration manifest. It describes
   the components used by the current implementation, but it is not the whole
   backend implementation.
@@ -75,7 +86,7 @@ backend-owned packages:
   context resolution, and small shared helpers.
 - `tilelang/<backend>/` owns the dialect, target helpers, pipeline, codegen,
   toolchain hooks, operation implementations, intrinsics, and execution
-  policies for a target backend.
+  compatibility declarations for a target backend.
 - `tilelang/jit/` contains shared JIT infrastructure and the current execution
   adapters.
 
@@ -113,7 +124,7 @@ The manifest currently declares:
 - an optional target predicate used to distinguish variants;
 - one pass pipeline and one device-codegen entry for every owned target kind;
 - optional host-codegen entries and pre-codegen hooks;
-- the supported execution backends in `auto` preference order;
+- the compatible shared execution backends in `auto` preference order;
 - FFI callbacks used by backend validation or target-toolchain integration.
 
 `register_backend()` validates the complete declaration and publishes it once.
@@ -123,7 +134,7 @@ not maintain import paths, loading state, or synchronization.
 Several manifests may share one TVM target kind when predicates make the
 variants unambiguous. CUDA and CuTeDSL are separate manifests that both match
 the `cuda` target kind. They intentionally reuse the CUDA pipeline but declare
-different device codegen and execution policies. Pipeline reuse must be
+different device codegen and execution compatibility. Pipeline reuse must be
 explicit; it must not come from target-specific branching in the engine.
 
 ## Backend Context Preparation
@@ -149,7 +160,7 @@ BackendContext
   module             selected target-backend manifest
   target             normalized device target
   target_host        normalized host target
-  execution_backend  selected build/JIT/runtime policy
+  execution_backend  selected shared Build/JIT/Runtime implementation
 ```
 
 Cache, lowering, codegen, and JIT code pass the same context instance.
@@ -224,62 +235,51 @@ The engine must not contain a `target.kind.name` dispatch table for backend
 codegen. Backend variants, such as CUDA and CuTeDSL, declare their own codegen
 entries in their manifests.
 
-## Execution Backends: Build, JIT, and Runtime
+## Execution Backend Compatibility
 
-An execution backend owns the complete path from generated host/device code to
-a running kernel. Its implementation contains three related phases:
-
-- **Build** invokes the required compiler and linker, applies architecture and
-  toolchain options, and packages generated code into a loadable artifact such
-  as a cubin, HSACO, shared library, or runtime module.
-- **JIT** performs cache lookup, decides when to invoke Build, loads the
-  artifact, creates wrappers, and returns a callable kernel adapter.
-- **Runtime** owns the loaded module or kernel handle, binds arguments and
-  streams, launches the kernel, and manages execution-time lifetime and errors.
-
-Build is therefore an internal execution-backend stage rather than a separate
-top-level backend component. The target backend supplies reusable codegen,
-validation, compiler callbacks, and toolchain helpers; the execution backend
-decides which of them to use and whether compilation is eager or deferred. For
-example, `tvm_ffi` requests host codegen and eager device compilation, whereas
-`nvrtc` consumes generated CUDA source and compiles it later in its adapter.
-
-Conceptually, a target backend exposes a mapping such as:
+A target backend normally does not implement JIT or runtime behavior. It
+declares which shared execution backends can consume its generated outputs:
 
 ```text
 execution_backends:
-  tvm_ffi -> TVM FFI build/load/launch path
-  nvrtc   -> NVRTC compile + CUDA driver launch path
-  cython  -> generated Cython wrapper path
-  torch   -> framework-provided compile/load/launch path
+  tvm_ffi -> compatible with TVM FFI runtime modules
+  nvrtc   -> compatible with CUDA source + driver launch
+  cython  -> compatible with generated Cython wrappers
+  torch   -> compatible with framework-provided compile/launch
 ```
 
 `ExecutionBackendSpec` currently records the execution name, availability and
 target predicates, and whether host codegen or eager device compilation is
-required. The selected spec is stored in `BackendContext`.
+required. A compatible target backend must provide the codegen mode and output
+contract expected by the selected implementation:
 
-Parts of CodeGen and Build are currently combined behind native
-`target.build.*` functions and the historical `DeviceCodegen.build` name;
-`build_without_compile` exposes the source-only path. These names describe the
-current implementation, while the architectural ownership remains with the
-selected execution backend.
+- compiled or source-only device codegen as requested;
+- host codegen when requested;
+- source, artifact, global-symbol, argument, and launch metadata;
+- target-specific validation, compiler callbacks, and toolchain helpers.
 
-The concrete adapters currently live under `tilelang/jit/adapter`, and adapter
-dispatch still occurs in the shared JIT layer. Architecturally, however, the
-spec selects a concrete Build/JIT/Runtime implementation. New execution paths
-should move behavior behind that interface rather than add target-specific
-decisions to lowering or codegen.
+The shared execution backend owns cache orchestration, wrapper creation,
+artifact loading, argument/stream binding, launch, and runtime lifetime. It may
+invoke target-owned compiler callbacks during Build, but those callbacks do not
+make JIT/Runtime a target-backend implementation area.
 
-If TileLang adds a pure AOT/export workflow that produces artifacts without
-loading or executing them, it may expose Build as a reusable interface. That
-does not require Build to be a separate top-level component in the normal JIT
-architecture.
+Only add a new execution backend when no existing implementation can consume
+the target output or drive its runtime API. That is a separate integration
+task. Concrete adapters currently live under `tilelang/jit/adapter`, while
+adapter dispatch still occurs in the shared JIT layer; new execution behavior
+should move behind that shared interface rather than into target passes or
+codegen dispatch.
+
+Parts of CodeGen and Build remain combined behind native `target.build.*`
+functions and the historical `DeviceCodegen.build` name. Treat this as an
+implementation detail at the boundary: target codegen supplies the operation,
+and the selected execution backend decides whether and when it is invoked.
 
 ## Registered Target Backends
 
 | Python package | Target kind | Notes |
 | --- | --- | --- |
-| `tilelang/cuda/backend.py` | `cuda` | Plain CUDA codegen, compiler callbacks, and execution policies. |
+| `tilelang/cuda/backend.py` | `cuda` | Plain CUDA codegen, compiler callbacks, and execution compatibility. |
 | `tilelang/cuda/cutedsl_backend.py` | `cuda` | CuTeDSL variant explicitly reusing the CUDA pipeline. |
 | `tilelang/rocm` | `hip` | ROCm/HIP pipeline, codegen, compiler callback, and MFMA/WMMA extensions. |
 | `tilelang/cpu` | `c`, `llvm` | CPU pipeline, codegen, and scalar CPU tile-op implementations. |
@@ -325,7 +325,7 @@ tilelang/<backend>/
   __init__.py
   backend.py             manifest and backend toolchain callbacks
   target.py              target parsing and normalization helpers
-  execution_backend.py   supported Build/JIT/Runtime paths and auto preference
+  execution_backend.py   compatible execution paths and auto preference
   language/              backend language dialect
   pipeline.py            complete lowering sequence
   codegen.py             host/device codegen entries
@@ -376,9 +376,10 @@ Shared native helpers with no target-runtime dependency belong in
 - Keep host/device codegen dispatch, host preparation hooks, compiler
   callbacks, and target-specific toolchain helpers under target-backend
   ownership.
-- Treat execution-backend selection as the choice of a concrete
-  Build/JIT/Runtime path; do not spread execution-mode checks through compiler
-  passes.
+- Make target backends declare execution compatibility rather than reimplement
+  JIT/Runtime. Add a new execution backend only for a new artifact or runtime
+  contract.
+- Do not spread execution-mode checks through compiler passes.
 - Keep backend registration explicit. Do not infer target ownership from a
   directory name: `tilelang/rocm`, for example, owns the TVM `hip` target kind.
 - Register manifests during normal package initialization, without maintaining

--- a/tilelang/backend/README.md
+++ b/tilelang/backend/README.md
@@ -1,28 +1,92 @@
-# TileLang Backend Layout
+# TileLang Backend Architecture
 
-This is a short draft of the current multi-backend layout. The main goal of
-this refactor is to make backend ownership explicit while keeping the frontend
-TileLang language surface backend-neutral.
+TileLang treats a backend as an end-to-end vertical slice, from its language
+dialect to the code that loads and launches the generated kernel. The goal is
+to make backend ownership explicit while keeping the common TileLang frontend
+and compiler entry points backend-neutral.
 
-## Overview
+Coding agents implementing a new backend must use the
+[`tilelang-backend` skill](../../.agents/skills/tilelang-backend/SKILL.md).
 
-The Python backend layer is split into two parts:
+## Design Model
 
-- `tilelang/backend/`: common backend infrastructure, especially the
-  `BackendModule` registry, component interfaces, and shared pipeline
-  utilities.
-- `tilelang/<backend>/`: backend-owned Python implementation files, such as
-  a backend registration module, pass pipelines, codegen entries, tile-op
-  implementation registration, and backend intrinsics.
+A backend owns five related parts:
 
-The native side mirrors this split under `src/<backend>/`, where C++ op
-lowering, codegen, runtime modules, stubs, and backend-local CMake files live.
-`src/backend/` is reserved for shared native backend helpers.
+| Part | Responsibility |
+| --- | --- |
+| Language dialect | Extends the common TileLang language with backend-specific operations and intrinsics. |
+| Context preparation | Normalizes the device and host targets, selects the target backend, and resolves an execution backend. |
+| Pass pipeline | Lowers common and backend-specific IR through one explicit, backend-owned pass sequence. |
+| Host/device codegen | Converts lowered host and device IR into source or runtime modules. |
+| Execution backend | Owns the selected build, JIT, and runtime path: compiling artifacts, loading them, and launching kernels. |
 
-## Backend Module
+The logical flow is:
 
-`BackendModule` is the complete, typed manifest for a backend. Each backend's
-`backend.py` declares all compiler components in one place:
+```text
+backend language dialect
+        |
+        v
+    frontend IR
+        |
+        v
+BackendContext preparation
+        |
+        v
+backend PassPipeline
+        |
+        v
+host/device split
+        |
+        +-----------> HostCodegen ----+
+        |                             |
+        +-----------> DeviceCodegen --+
+                                      |
+                                      v
+                         selected ExecutionBackend
+                           Build -> Load -> Launch
+```
+
+`BackendContext` is created once and accompanies the compilation through the
+pipeline and codegen stages into the selected execution backend. A later stage
+must not infer or resolve the backend again.
+
+### Terminology
+
+- A **target backend**, such as CUDA, ROCm, CPU, Metal, or WebGPU, owns the
+  dialect, lowering, codegen, and target-specific toolchain primitives.
+- An **execution backend**, such as `tvm_ffi`, `nvrtc`, `cython`, `torch`, or
+  `cutedsl`, selects and implements a build/JIT/runtime path for a target
+  backend.
+- `BackendModule` is the compiler-facing registration manifest. It describes
+  the components used by the current implementation, but it is not the whole
+  backend implementation.
+- `BackendContext` is the resolved, immutable state for one compilation.
+
+Target backends and execution backends are deliberately separate. For example,
+CUDA can execute through `tvm_ffi`, `nvrtc`, or `cython`; selecting `nvrtc` does
+not select a different target architecture or pass pipeline.
+
+## Source Layout
+
+The Python implementation is split into common infrastructure and
+backend-owned packages:
+
+- `tilelang/backend/` contains the backend registry, component interfaces,
+  context resolution, and small shared helpers.
+- `tilelang/<backend>/` owns the dialect, target helpers, pipeline, codegen,
+  toolchain hooks, operation implementations, intrinsics, and execution
+  policies for a target backend.
+- `tilelang/jit/` contains shared JIT infrastructure and the current execution
+  adapters.
+
+The native side mirrors target-backend ownership under `src/<backend>/`, where
+C++ op lowering, codegen, runtime modules, toolchain stubs, and backend-local
+CMake files live. `src/backend/` is reserved for shared native backend helpers.
+
+## Backend Manifest
+
+Each backend's `backend.py` publishes a `BackendModule`, the typed manifest used
+by the compiler registry:
 
 ```python
 BACKEND = register_backend(
@@ -43,193 +107,236 @@ BACKEND = register_backend(
 )
 ```
 
-The central registry maps each target kind to candidate backend modules and
-uses `supports_target` to select exactly one. Backend packages are initialized
-once during TileLang import, so the registry needs no import paths, loading
-state, or synchronization.
+The manifest currently declares:
 
-The component objects remain focused extension interfaces, while
-`register_backend()` validates and publishes the complete manifest once.
+- its name and owned TVM target kinds;
+- an optional target predicate used to distinguish variants;
+- one pass pipeline and one device-codegen entry for every owned target kind;
+- optional host-codegen entries and pre-codegen hooks;
+- the supported execution backends in `auto` preference order;
+- FFI callbacks used by backend validation or target-toolchain integration.
 
-Execution modes are attached directly to `BackendModule` as one ordered list;
-list order defines the `auto` preference among matching modes.
+`register_backend()` validates the complete declaration and publishes it once.
+Backend packages are initialized during TileLang import, so the registry does
+not maintain import paths, loading state, or synchronization.
 
-Several backend modules may share one TVM target kind when predicates make the
-variants unambiguous. CUDA and CuTeDSL are separate manifests that both own the
-`cuda` kind and reference the same CUDA pipeline, while declaring different
-device codegen and execution policies.
+Several manifests may share one TVM target kind when predicates make the
+variants unambiguous. CUDA and CuTeDSL are separate manifests that both match
+the `cuda` target kind. They intentionally reuse the CUDA pipeline but declare
+different device codegen and execution policies. Pipeline reuse must be
+explicit; it must not come from target-specific branching in the engine.
 
-## Backend Context
+## Backend Context Preparation
 
-`BackendContext` is the immutable per-compilation object. The public compiler
-entry creates it once from user inputs:
+The public compiler or JIT entry creates one immutable `BackendContext`:
 
 ```python
 context = create_backend_context(target, target_host, execution_backend)
 ```
 
-It binds the selected `BackendModule`, concrete device/host targets, and
-`ExecutionBackendSpec`. Cache, JIT, lowering, and codegen pass the same context
-instance; internal stages never resolve backend state again.
+Context preparation performs three operations:
 
-## Lowering Entry
+1. Normalize the device target and host target.
+2. Select exactly one `BackendModule` using `target.kind.name` and, when
+   needed, `supports_target`.
+3. Resolve one available `ExecutionBackendSpec` from the user request or the
+   backend's ordered `auto` preference.
 
-`tilelang/engine/lower.py` owns the high-level lowering entry. It runs
-backend-independent semantic checks first, then resolves a pass pipeline from
-the TVM target kind:
+The resulting context binds:
 
 ```text
-PreLowerSemanticCheck(mod)
-mod = context.lower(mod)
+BackendContext
+  module             selected target-backend manifest
+  target             normalized device target
+  target_host        normalized host target
+  execution_backend  selected build/JIT/runtime policy
 ```
 
-The selected `BackendModule` owns the pipeline; the pipeline name must match
-`target.kind.name`.
+Cache, lowering, codegen, and JIT code pass the same context instance.
+Backend-specific target parsing and canonicalization belong in the backend
+package; backend selection itself stays in the shared context factory.
 
-Device codegen follows the same ownership model after host/device splitting:
+## Language Dialects
+
+`tilelang/language` defines the backend-neutral language surface. A backend may
+freely compose that surface with extensions under
+`tilelang/<backend>/language`:
+
+```python
+from tilelang import language as T       # common + CUDA compatibility facade
+from tilelang.cuda import language as T  # common + CUDA extensions
+from tilelang.rocm import language as T  # common + ROCm extensions
+```
+
+Dialect selection is static and follows the import path; it does not depend on
+a process-global mutable dialect registry. Backend-specific language APIs emit
+IR operations or annotations that the corresponding backend pipeline knows how
+to lower. The language layer should describe semantics and construct IR, not
+perform target code generation itself.
+
+For example, CUDA owns WGMMA and TCGEN05 language helpers and intrinsic
+emitters, while ROCm owns MFMA and WMMA helpers. Library code, tests, and
+examples using backend-specific symbols should prefer explicit backend
+language imports so static analysis and autocomplete can identify the dialect.
+
+The language dialect is part of the logical backend, even though it is not a
+field of the current `BackendModule` manifest.
+
+## Pass Pipeline
+
+Every target backend must explicitly own a complete lowering sequence after
+the shared semantic checks:
+
+```text
+PreLowerSemanticCheck(mod)  # shared frontend boundary
+mod = context.lower(mod)    # selected backend pipeline
+```
+
+The ordered pass list lives in `tilelang/<backend>/pipeline.py`. Backend-only
+passes must be called there rather than dispatched from
+`tilelang/engine/lower.py`. A backend pipeline may use small shared helpers from
+`tilelang/backend/pass_pipeline`, but its ordering and target-specific choices
+must remain visible in the backend package.
+
+A target variant may deliberately reference another backend's pipeline when
+their IR lowering is identical, as CuTeDSL currently does with CUDA. This is
+explicit pipeline composition, not implicit engine behavior.
+
+## Host and Device Codegen
+
+After the pipeline, the compiler splits the module into host and device IR.
+Both codegen paths are selected through `BackendContext`:
 
 ```text
 device_mod = context.codegen_device(device_mod, compile_device=...)
-```
 
-Each `BackendModule` declares one or more `DeviceCodegen` entries for its target.
-CUDA and CuTeDSL declare different codegen entries while sharing the CUDA
-pipeline; CPU owns the `c` and `llvm` entries. The engine-level lowering code
-should not keep backend-specific `target.kind.name` dispatch for device codegen.
-
-Host codegen is resolved from the host target in the same style:
-
-```text
 host_mod = context.preprocess_host_codegen(host_mod)
 host_mod = context.codegen_host(host_mod)
 ```
 
-Backends that enable host codegen explicitly reference the shared `c/llvm`
-host-codegen definitions. Device-specific host preparation remains on the same
-backend module; Metal uses this to mark functions requiring Metal runtime
-context.
+`DeviceCodegen` provides compiled and source-only entry points when the backend
+supports both. `HostCodegen` is selected from the concrete host target, usually
+`c` or `llvm`. `HostCodegenHook` lets a device backend prepare host IR without
+adding target checks to the shared engine; Metal uses such a hook to mark
+functions that require Metal runtime context.
 
-## Target Registration
+The engine must not contain a `target.kind.name` dispatch table for backend
+codegen. Backend variants, such as CUDA and CuTeDSL, declare their own codegen
+entries in their manifests.
+
+## Execution Backends: Build, JIT, and Runtime
+
+An execution backend owns the complete path from generated host/device code to
+a running kernel. Its implementation contains three related phases:
+
+- **Build** invokes the required compiler and linker, applies architecture and
+  toolchain options, and packages generated code into a loadable artifact such
+  as a cubin, HSACO, shared library, or runtime module.
+- **JIT** performs cache lookup, decides when to invoke Build, loads the
+  artifact, creates wrappers, and returns a callable kernel adapter.
+- **Runtime** owns the loaded module or kernel handle, binds arguments and
+  streams, launches the kernel, and manages execution-time lifetime and errors.
+
+Build is therefore an internal execution-backend stage rather than a separate
+top-level backend component. The target backend supplies reusable codegen,
+validation, compiler callbacks, and toolchain helpers; the execution backend
+decides which of them to use and whether compilation is eager or deferred. For
+example, `tvm_ffi` requests host codegen and eager device compilation, whereas
+`nvrtc` consumes generated CUDA source and compiles it later in its adapter.
+
+Conceptually, a target backend exposes a mapping such as:
+
+```text
+execution_backends:
+  tvm_ffi -> TVM FFI build/load/launch path
+  nvrtc   -> NVRTC compile + CUDA driver launch path
+  cython  -> generated Cython wrapper path
+  torch   -> framework-provided compile/load/launch path
+```
+
+`ExecutionBackendSpec` currently records the execution name, availability and
+target predicates, and whether host codegen or eager device compilation is
+required. The selected spec is stored in `BackendContext`.
+
+Parts of CodeGen and Build are currently combined behind native
+`target.build.*` functions and the historical `DeviceCodegen.build` name;
+`build_without_compile` exposes the source-only path. These names describe the
+current implementation, while the architectural ownership remains with the
+selected execution backend.
+
+The concrete adapters currently live under `tilelang/jit/adapter`, and adapter
+dispatch still occurs in the shared JIT layer. Architecturally, however, the
+spec selects a concrete Build/JIT/Runtime implementation. New execution paths
+should move behavior behind that interface rather than add target-specific
+decisions to lowering or codegen.
+
+If TileLang adds a pure AOT/export workflow that produces artifacts without
+loading or executing them, it may expose Build as a reusable interface. That
+does not require Build to be a separate top-level component in the normal JIT
+architecture.
+
+## Registered Target Backends
 
 | Python package | Target kind | Notes |
 | --- | --- | --- |
-| `tilelang/cuda/backend.py` | `cuda` | Plain CUDA codegen and execution policy. |
-| `tilelang/cuda/cutedsl_backend.py` | `cuda` | CuTeDSL variant sharing the CUDA pipeline. |
-| `tilelang/rocm` | `hip` | ROCm/HIP pass sequence and MFMA/WMMA tile-op implementations. |
-| `tilelang/cpu` | `c`, `llvm` | CPU pass sequence and scalar CPU tile-op implementations. |
-| `tilelang/metal` | `metal` | Metal pass sequence and Metal GEMM registration. |
+| `tilelang/cuda/backend.py` | `cuda` | Plain CUDA codegen, compiler callbacks, and execution policies. |
+| `tilelang/cuda/cutedsl_backend.py` | `cuda` | CuTeDSL variant explicitly reusing the CUDA pipeline. |
+| `tilelang/rocm` | `hip` | ROCm/HIP pipeline, codegen, compiler callback, and MFMA/WMMA extensions. |
+| `tilelang/cpu` | `c`, `llvm` | CPU pipeline, codegen, and scalar CPU tile-op implementations. |
+| `tilelang/metal` | `metal` | Metal pipeline, codegen, host hook, and Metal language extensions. |
 | `tilelang/webgpu/backend.py` | `webgpu` | WebGPU compiler component registration. |
 
-## `tilelang/backend`
+## Common Backend Infrastructure
 
-`tilelang/backend` should stay small. It contains shared backend plumbing, not
-backend-specific implementation details.
+`tilelang/backend` should stay small and contain shared interfaces and
+plumbing, not target-specific implementations:
 
 ```text
 tilelang/backend/
   __init__.py
   module.py
+  target.py
   device_codegen.py
   host_codegen.py
+  execution_backend.py
   pass_pipeline/
     __init__.py
     pipeline.py
     pipeline_utils.py
 ```
 
-- `module.py` defines `BackendModule`, its behavior methods, validation, and the
-  target-kind ownership registry.
+- `module.py` defines `BackendModule`, `BackendContext`, registration,
+  validation, and context resolution.
+- `target.py` provides common target detection and normalization plumbing.
 - `pass_pipeline/pipeline.py` defines `PassPipeline`.
-- `device_codegen.py` defines `DeviceCodegen` and global-function helpers.
-- `host_codegen.py` defines `HostCodegen`, host codegen hooks, and shared
-  `c/llvm` implementations.
+- `device_codegen.py` and `host_codegen.py` define codegen component types and
+  shared global-function helpers.
+- `execution_backend.py` defines the current execution-backend selection and
+  capability descriptor.
 - `pass_pipeline/pipeline_utils.py` contains small shared helpers for pass
-  configuration, layout visualization, vectorization gates, and shared-memory
-  reuse flags.
-Backend-specific pass lists should not live here. They should live in the
-backend package that owns the target.
+  configuration, visualization, vectorization gates, and shared-memory reuse.
 
-## Backend Packages
+## Backend Package Layout
 
-Each backend package owns the Python pieces needed to lower and register code
-for that backend.
+A typical target-backend package has the following shape:
 
 ```text
-tilelang/cuda/
-  backend.py
-  codegen.py
-  pipeline.py
-  transform/
-  op/
-  intrinsics/
-
-tilelang/rocm/
-  backend.py
-  codegen.py
-  pipeline.py
-  op/
-  intrinsics/
-
-tilelang/cpu/
-  backend.py
-  codegen.py
-  pipeline.py
-  op/
-
-tilelang/metal/
-  backend.py
-  codegen.py
-  pipeline.py
-  transform/
-  op/
-  intrinsics/
+tilelang/<backend>/
+  __init__.py
+  backend.py             manifest and backend toolchain callbacks
+  target.py              target parsing and normalization helpers
+  execution_backend.py   supported Build/JIT/Runtime paths and auto preference
+  language/              backend language dialect
+  pipeline.py            complete lowering sequence
+  codegen.py             host/device codegen entries
+  transform/             backend-only Python passes
+  op/                    tile-op implementations and registration
+  intrinsics/            backend intrinsic emitters and helpers
 ```
 
-The `backend.py` file contains one explicit `BackendModule`. Component files only
-define implementations and do not mutate global registries themselves.
-
-The `pipeline.py` file should expose one complete backend pass sequence after
-semantic checking. It may use shared helpers from `tilelang/backend`, but the
-ordered pass list should be visible in the backend-owned file. CUDA-only,
-ROCm-only, and Metal-only passes should be called from the corresponding
-backend pipeline rather than from engine-level code.
-
-The `codegen.py` file defines backend-owned host/device codegen functions,
-usually by mapping to native `target.build.*` global functions. The manifest
-wraps them in `DeviceCodegen`/`HostCodegen` values. Target variants should be
-represented by backend-owned predicates, not engine-level branching.
-
-The `op/` and `intrinsics/` folders contain Python implementation and helper
-code used by tile-op lowering. For example, CUDA owns MMA/WGMMA/TCGEN05
-intrinsic emitters, while ROCm owns MFMA/WMMA emitters. Backend-local
-transform passes, such as Metal's simdgroup lowering and host-context marking,
-should live under that backend's `transform/` package.
-
-## Language Dialects
-
-`tilelang/language/__init__.py` assembles the backend-neutral language surface,
-and `tilelang/language/common.py` exposes its stable common manifest.
-Backend-specific language modules compose that manifest with explicit backend
-extensions. After TileLang finishes initializing, `tilelang.language` is
-augmented as the CUDA-compatible facade.
-
-Backend-specific language surfaces live under the backend package:
-
-```python
-from tilelang import language as T       # common + CUDA compatibility facade
-from tilelang.cuda import language as T  # common + CUDA extension
-from tilelang.rocm import language as T  # common + ROCm extension
-```
-
-Each backend language module re-exports the common language and adds only the
-symbols owned by that backend. For example, CUDA exposes `T.tcgen05_mma`,
-WGMMA/TCGEN05 helpers, and CUDA intrinsic emitters; ROCm exposes MFMA/WMMA
-helpers. Dialect selection is static and follows the import path; there is no
-process-global dialect registry or mutable default.
-
-Library code, tests, and examples that rely on backend-specific symbols should
-prefer explicit imports such as `from tilelang.cuda import language as T` so
-static analysis and autocomplete can resolve the intended dialect.
+Not every backend needs every file. Component files define implementations;
+`backend.py` is the single place that assembles and registers the manifest.
+Import-time registration should remain deterministic and lightweight.
 
 ## Native Backend Layout
 
@@ -248,27 +355,31 @@ src/backend/
 
 Typical backend-local subdirectories are:
 
-- `op/`: native tile-op lowering helpers.
-- `codegen/`: backend codegen and runtime module integration.
-- `stubs/`: optional lazy-loading driver/runtime stubs for GPU backends.
+- `op/`: native tile-op lowering helpers;
+- `transform/`: native backend-only passes;
+- `codegen/`: target codegen, toolchain entry points, and runtime-module
+  integration;
+- `stubs/`: optional lazy-loading driver/runtime stubs;
 - `CMakeLists.txt`: backend-local source selection and toolchain setup.
 
-Shared native helpers that have no target runtime dependency belong in
+Shared native helpers with no target-runtime dependency belong in
 `src/backend/common`.
 
-## Guidelines
+## Ownership Rules
 
-- Keep `tilelang/language` and `tilelang/tileop` backend-neutral.
-- Keep backend-specific pass ordering in the backend package.
-- Keep backend-specific host-codegen dispatch and host preparation hooks in the
-  backend package.
-- Keep backend-specific device-codegen dispatch in the backend package.
-- Register backend implementations at import time, but keep import-time work
-  light.
-- Keep loading implicit in normal package initialization; backend registries
-  must not maintain import paths or loading state.
-- Prefer explicit target-kind registration over implicit folder-name matching,
-  because some names differ, such as `tilelang/rocm` registering target kind
-  `hip`.
-- When adding a backend-specific pass, put the call site in that backend's
-  `pipeline.py` and keep only small shared predicates in `pipeline_utils.py`.
+- Keep the common language surface and shared semantic checks backend-neutral.
+- Put backend language extensions under `tilelang/<backend>/language` and lower
+  them in that backend's pipeline.
+- Resolve target and execution state once when creating `BackendContext`.
+- Keep the complete backend-specific pass order in
+  `tilelang/<backend>/pipeline.py`.
+- Keep host/device codegen dispatch, host preparation hooks, compiler
+  callbacks, and target-specific toolchain helpers under target-backend
+  ownership.
+- Treat execution-backend selection as the choice of a concrete
+  Build/JIT/Runtime path; do not spread execution-mode checks through compiler
+  passes.
+- Keep backend registration explicit. Do not infer target ownership from a
+  directory name: `tilelang/rocm`, for example, owns the TVM `hip` target kind.
+- Register manifests during normal package initialization, without maintaining
+  a second lazy-loading registry.


### PR DESCRIPTION
## Summary

- document a target backend as four compiler-owned areas: dialect, context contribution, pipeline, and host/device codegen
- model execution support as a compatibility declaration against reusable execution backends rather than target-local JIT/Runtime implementation
- clarify that a new Build/JIT/Runtime adapter is needed only for a genuinely new artifact or runtime contract
- add a scoped `tilelang-backend` agent skill with concrete native build, packaging, testing, and completion checklists

## Validation

- `quick_validate.py .agents/skills/tilelang-backend`
- `codespell` for the changed Markdown files
- pre-commit hooks, including YAML and PyMarkdown checks
- `git diff --check`

Documentation-only change; runtime tests were not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Documented TileLang backend architecture as a five-part vertical slice: dialect, context, pipeline, code generation, and execution.
- Clarified target backends, execution backends, backend manifests, context preparation, and Build/JIT/Runtime paths.
- Added the scoped `tilelang-backend` agent skill with integration, native build, packaging, testing, and completion checklists.
- Added backend integration guidance for dialects, pipelines, code generation, execution, testing, and documentation.

## Validation

- Ran `quick_validate.py`, `codespell`, pre-commit hooks, YAML checks, PyMarkdown checks, and `git diff --check`.
- Runtime tests were not run because the changes are documentation-only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->