### PR TITLE
[Test][CUDA] Gate issue 2883 regression on CUDA

### DIFF
--- a/testing/python/issue/test_tilelang_issue_2883.py
+++ b/testing/python/issue/test_tilelang_issue_2883.py
@@ -10,6 +10,7 @@ import tilelang.testing
 from tilelang import tvm
 
 
+@tilelang.testing.requires_cuda
 def test_large_parallel_layout_is_injective():
     stride = T.dynamic("stride")
 


### PR DESCRIPTION
Fixes #2903.

## Problem

`test_large_parallel_layout_is_injective` explicitly lowers with a CUDA target but is collected on ROCm-only builds. Since those builds do not register CUDA-specific C++ passes, the current main ROCm job fails with:

```text
AttributeError: module 'tilelang.cuda._ffi_api' has no attribute 'AnnotateDeviceBoundTmaCopies'
```

The failing gfx942 job completed with `1 failed, 1902 passed, 1236 skipped`: https://github.com/tile-ai/tilelang/actions/runs/31115687512/job/92665328476

## Change

Add `@tilelang.testing.requires_cuda` to the regression added in #2899. This keeps the test active on CUDA CI and skips it when TileLang is built without CUDA, following the convention established in #2863.

## Validation

- `pytest -q testing/python/issue/test_tilelang_issue_2883.py` on the existing ROCm build: `1 skipped`
- `pre-commit run --files testing/python/issue/test_tilelang_issue_2883.py`: passed
- `git diff --check`: passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added `@tilelang.testing.requires_cuda` to the Issue 2883 regression test.
- The test runs on CUDA-enabled builds and skips on ROCm-only builds.
- ROCm validation, pre-commit checks, and `git diff --check` passed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->