### PR TITLE
[Enhancement] Show kernel name in pass timing report

### DIFF
--- a/testing/python/debug/test_pass_timing.py
+++ b/testing/python/debug/test_pass_timing.py
@@ -12,6 +12,7 @@ from tilelang import tvm
 from tilelang.utils.pass_timing import (
     PassTimingRecord,
     TileLangPassTimingInstrument,
+    _extract_kernel_label,
     build_pass_instruments,
     report_pass_timing_on_exit,
 )
@@ -176,3 +177,75 @@ def test_pass_timing_ignores_unmatched_after_callback(caplog):
     assert not timing.records
     assert not timing._stack
     assert "Ignoring unmatched pass timing callback" in caplog.text
+
+
+def test_pass_timing_captures_kernel_name_from_module():
+    timing = TileLangPassTimingInstrument()
+
+    with tvm.transform.PassContext(instruments=[timing.instrument]):
+        tvm.tirx.transform.Simplify()(_simple_module())
+
+    # The kernel name follows the PrimFunc's global_symbol attribute (which in
+    # the real compilation flow is also used as the IRModule key).
+    assert any(record.kernel == "program" for record in timing.records)
+    report = timing.report()
+    assert "Simplify(program)" in report
+
+
+def test_pass_timing_record_name_unaffected_by_kernel():
+    timing = TileLangPassTimingInstrument()
+
+    with tvm.transform.PassContext(instruments=[timing.instrument]):
+        tvm.tirx.transform.Simplify()(_simple_module())
+
+    record = timing.records[0]
+    assert record.name.endswith(".Simplify")
+    assert record.kernel == "program"
+
+
+def test_extract_kernel_label_none_or_empty():
+    assert _extract_kernel_label(None) == ""
+    assert _extract_kernel_label(tvm.IRModule()) == ""
+
+
+def test_extract_kernel_label_single_function():
+    assert _extract_kernel_label(_simple_module()) == "program"
+
+
+def test_extract_kernel_label_multiple_functions_shows_count():
+    @T.prim_func
+    def func_a(A: T.Tensor((16,), "float32"), B: T.Tensor((16,), "float32")):
+        with T.Kernel(threads=16):
+            tid = T.get_thread_binding()
+            B[tid] = A[tid] + 1.0
+
+    @T.prim_func
+    def func_b(A: T.Tensor((16,), "float32"), B: T.Tensor((16,), "float32")):
+        with T.Kernel(threads=16):
+            tid = T.get_thread_binding()
+            B[tid] = A[tid] + 2.0
+
+    mod = tvm.IRModule({"kernel_a": func_a, "kernel_b": func_b})
+
+    label = _extract_kernel_label(mod)
+
+    assert label == "func_a +1 more"
+
+
+def test_pass_timing_report_kernel_suffix_when_present():
+    timing = TileLangPassTimingInstrument()
+    timing._records.append(PassTimingRecord("tirx.Simplify", 0.001, 0, kernel="matmul"))
+
+    report = timing.report()
+
+    assert "tirx.Simplify(matmul)" in report
+
+
+def test_pass_timing_report_omits_suffix_when_kernel_empty():
+    timing = TileLangPassTimingInstrument()
+    timing._records.append(PassTimingRecord("tirx.Simplify", 0.001, 0, kernel=""))
+
+    report = timing.report()
+
+    assert "tirx.Simplify(matmul)" not in report
+    assert "tirx.Simplify" in report

--- a/tilelang/utils/pass_timing.py
+++ b/tilelang/utils/pass_timing.py
@@ -21,6 +21,42 @@ from tvm.ir import _ffi_instrument_api
 logger = logging.getLogger("tilelang.pass_timing")
 
 
+def _extract_kernel_label(mod) -> str:
+    """Derive a compact kernel label from the IRModule being compiled.
+
+    Returns the primary function's name (preferring ``global_symbol``,
+    falling back to the ``GlobalVar.name_hint``). When the module contains
+    multiple functions (e.g. grouped-device compilation), returns
+    ``"<first> +<N-1> more"``. Returns an empty string when no label can be
+    derived, so callers can simply omit the suffix.
+
+    This runs inside every pass callback and must never raise; any unexpected
+    error is swallowed and an empty string is returned.
+    """
+    try:
+        functions = getattr(mod, "functions", None) if mod is not None else None
+        if not functions:
+            return ""
+        names: list[str] = []
+        for gv, func in functions.items():
+            attrs = getattr(func, "attrs", None)
+            name = attrs.get("global_symbol") if attrs is not None else None
+            if name is None:
+                name = getattr(gv, "name_hint", None)
+            if name is None:
+                continue
+            name = str(name)
+            if name not in names:
+                names.append(name)
+        if not names:
+            return ""
+        if len(names) == 1:
+            return names[0]
+        return f"{names[0]} +{len(names) - 1} more"
+    except Exception:
+        return ""
+
+
 @dataclass
 class PassTimingRecord:
     """Single completed pass execution record."""
@@ -30,6 +66,7 @@ class PassTimingRecord:
     depth: int  # nesting depth (0 = top-level)
     self_duration_s: float = 0.0
     sequence: int = 0
+    kernel: str = ""
 
 
 @dataclass
@@ -39,6 +76,7 @@ class _ActivePass:
     depth: int
     sequence: int
     child_duration_s: float = 0.0
+    kernel: str = ""
 
 
 class _PassTimingState:
@@ -63,13 +101,14 @@ class _PassTimingState:
             )
             self.stack.clear()
 
-    def run_before_pass(self, _mod, info):
+    def run_before_pass(self, mod, info):
         self.stack.append(
             _ActivePass(
                 name=info.name,
                 start_time=time.monotonic(),
                 depth=len(self.stack),
                 sequence=self.next_sequence,
+                kernel=_extract_kernel_label(mod),
             )
         )
         self.next_sequence += 1
@@ -95,6 +134,7 @@ class _PassTimingState:
                 self_duration_s=self_duration_s,
                 depth=frame.depth,
                 sequence=frame.sequence,
+                kernel=frame.kernel,
             )
         )
         if self.stack:
@@ -128,8 +168,8 @@ class TileLangPassTimingInstrument:
     def _exit_pass_ctx(self):
         self._state.exit_pass_ctx()
 
-    def _run_before_pass(self, info):
-        self._state.run_before_pass(None, info)
+    def _run_before_pass(self, info, mod=None):
+        self._state.run_before_pass(mod, info)
 
     def _run_after_pass(self, info):
         self._state.run_after_pass(None, info)
@@ -168,34 +208,44 @@ class TileLangPassTimingInstrument:
 
         threshold_s = self._threshold_ms / 1000.0
         total = self.total_duration_s
+        records = self.records
         lines = []
 
-        lines.append("=" * 96)
+        def _display_name(record: PassTimingRecord) -> str:
+            return f"{record.name}({record.kernel})" if record.kernel else record.name
+
+        # Dynamic pass-name column width so the "(kernel)" suffix never breaks
+        # the table alignment. Only visible (post-threshold) rows are counted.
+        visible_names = [f"{'  ' * r.depth}{_display_name(r)}" for r in records if r.duration_s >= threshold_s]
+        name_col_width = max([43] + [len(n) for n in visible_names])
+        sep_width = name_col_width + 53
+
+        lines.append("=" * sep_width)
         lines.append("TileLang Pass Timing Report")
         if context:
             lines.append(f"Context: {context}")
-        lines.append("=" * 96)
+        lines.append("=" * sep_width)
         lines.append(f"Total: {total:.4f}s ({len(self._records)} passes)")
         if self._threshold_ms > 0:
             lines.append(f"(inclusive threshold: {self._threshold_ms:.1f}ms)")
-        lines.append("-" * 96)
-        lines.append(f"{'#':>3}  {'Pass Name':<43} {'Inclusive':>10} {'Self':>10}  {'Incl %':>7} {'Self %':>7}")
-        lines.append("-" * 96)
+        lines.append("-" * sep_width)
+        lines.append(f"{'#':>3}  {'Pass Name':<{name_col_width}} {'Inclusive':>10} {'Self':>10}  {'Incl %':>7} {'Self %':>7}")
+        lines.append("-" * sep_width)
 
         skipped = 0
-        for index, record in enumerate(self.records, 1):
+        for index, record in enumerate(records, 1):
             if record.duration_s < threshold_s:
                 skipped += 1
                 continue
             inclusive_pct = (record.duration_s / total * 100) if total > 0 else 0
             self_pct = (record.self_duration_s / total * 100) if total > 0 else 0
-            name_col = f"{'  ' * record.depth}{record.name}"
+            name_col = f"{'  ' * record.depth}{_display_name(record)}"
             lines.append(
-                f"{index:>3}  {name_col:<43} {record.duration_s:>9.4f}s "
+                f"{index:>3}  {name_col:<{name_col_width}} {record.duration_s:>9.4f}s "
                 f"{record.self_duration_s:>9.4f}s {inclusive_pct:>6.1f}% {self_pct:>6.1f}%"
             )
 
-        lines.append("-" * 96)
+        lines.append("-" * sep_width)
         sorted_records = sorted(
             (record for record in self._records if record.duration_s >= threshold_s),
             key=lambda record: record.duration_s,
@@ -206,12 +256,14 @@ class TileLangPassTimingInstrument:
             lines.append(f"Top {top_n} Slowest Passes by Inclusive Time:")
             for rank, record in enumerate(sorted_records[:top_n], 1):
                 inclusive_pct = (record.duration_s / total * 100) if total > 0 else 0
-                lines.append(f"  {rank:>2}. {record.name:<45} {record.duration_s:>9.4f}s {inclusive_pct:>5.1f}%")
+                lines.append(
+                    f"  {rank:>2}. {_display_name(record):<{name_col_width + 2}} {record.duration_s:>9.4f}s {inclusive_pct:>5.1f}%"
+                )
 
         if skipped > 0:
             lines.append(f"\n({skipped} passes skipped - under {self._threshold_ms:.1f}ms inclusive threshold)")
 
-        lines.append("=" * 96)
+        lines.append("=" * sep_width)
         return "\n".join(lines)
 
     def print_report(self, context: str | None = None):


### PR DESCRIPTION
Extend the pass timing instrument to capture the compiled kernel name alongside each pass.

Example:
```
Total: 3.3338s (68 passes)
---------------------------------------------------------------------------------------------------------
  #  Pass Name                                             Inclusive       Self   Incl %  Self %
---------------------------------------------------------------------------------------------------------
  1  pass_fn(matmul)                                         0.0006s    0.0006s    0.0%    0.0%
  2  pass_fn(matmul)                                         0.0010s    0.0010s    0.0%    0.0%
  3  tirx.BindTarget(matmul)                                 0.0013s    0.0013s    0.0%    0.0%
  4  tl.MaterializeKernelLaunch(matmul)                      0.0002s    0.0002s    0.0%    0.0%
  5  tl.AddWrapperForSingleBufStore(matmul)                  0.0009s    0.0009s    0.0%    0.0%
  6  tl.LegalizeNegativeIndex(matmul)                        0.0023s    0.0023s    0.1%    0.1%
  7  tl.InjectAssumes(matmul)                                0.0003s    0.0003s    0.0%    0.0%
  8  tl.Simplify(matmul)                                     0.0022s    0.0022s    0.1%    0.1%
  9  tl.LayoutReducer(matmul)                                0.0018s    0.0018s    0.1%    0.1%
 10  tl.IfStmtBinding(matmul)                                0.0001s    0.0001s    0.0%    0.0%
 11  tl.PipelinePlanning(matmul)                             0.0013s    0.0013s    0.0%    0.0%
 12  tl.InjectSoftwarePipeline(matmul)                       0.0391s    0.0391s    1.2%    1.2%
 13  tl.Simplify(matmul)                                     0.0066s    0.0066s    0.2%    0.2%
 14  tl.MetalFragmentToSimdgroup(matmul)                     0.0136s    0.0136s    0.4%    0.4%
 15  tl.LayoutInference(matmul)                              1.2855s    1.2855s   38.6%   38.6%
 16  tl.LowerTileOp(matmul)                                  0.7847s    0.7716s   23.5%   23.1%
 17    tl.LetInline(_gemm_ss_simdgroup)                      0.0002s    0.0002s    0.0%    0.0%
 18    tl.Simplify(_gemm_ss_simdgroup)                       0.0042s    0.0042s    0.1%    0.1%
 19    tl.LetInline(_gemm_ss_simdgroup)                      0.0002s    0.0002s    0.0%    0.0%
 20    tl.Simplify(_gemm_ss_simdgroup)                       0.0043s    0.0043s    0.1%    0.1%
 21    tl.LetInline(_gemm_ss_simdgroup)                      0.0002s    0.0002s    0.0%    0.0%
 22    tl.Simplify(_gemm_ss_simdgroup)                       0.0040s    0.0040s    0.1%    0.1%
 23  tl.DecoupleTypeCast(matmul)                             0.0088s    0.0088s    0.3%    0.3%
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Include the compiled kernel name in pass-timing records and reports.
- Display entries as `<pass name>(<kernel name>)`, including nested kernel-specific passes.
- Extract labels from `global_symbol` or `name_hint`.
- Support multi-function IRModules and omit empty kernel suffixes.
- Add tests for label extraction, propagation, formatting, and multi-function modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->