### PR TITLE
[Testing] Gate the issue #2883 regression test on CUDA

### DIFF
--- a/testing/python/issue/test_tilelang_issue_2883.py
+++ b/testing/python/issue/test_tilelang_issue_2883.py
@@ -10,6 +10,7 @@ import tilelang.testing
 from tilelang import tvm
 
 
+@tilelang.testing.requires_cuda
 def test_large_parallel_layout_is_injective():
     stride = T.dynamic("stride")
 


### PR DESCRIPTION
`testing/python/issue/test_tilelang_issue_2883.py`, added in #2899, currently fails on every ROCm CI run:

```
python/issue/test_tilelang_issue_2883.py::test_large_parallel_layout_is_injective
AttributeError: module 'tilelang.cuda._ffi_api' has no attribute 'AnnotateDeviceBoundTmaCopies'
```

The test lowers with an explicit `tvm.target.Target("cuda")`, which reaches `tilelang/cuda/transform/__init__.py`. With `USE_CUDA=OFF` only the "ALWAYS" CUDA sources are compiled, so that FFI symbol is never registered. Same pattern as #2863.

`requires_cuda` is the weakest sufficient gate here. The test is compile-only (`enable_device_compile=False`), so it needs no particular GPU generation and continues to run on the NVIDIA leg; a compute-version gate would have dropped it from CI entirely.

### Not a blanket sweep

I checked all 53 files in `testing/python/issue/` against the last full gfx942 run rather than grepping. This is the only one affected:

| Outcome on ROCm | Files |
| --- | --- |
| Failing | 1 (this one) |
| Passing | 21 |
| Correctly gated / skipped | 30 |

A naive grep flags `1115`, `814`, `96`, `2292` and `2624` as CUDA-only too, but all five pass on ROCm — `device="cuda"` is not a CUDA-only marker, since ROCm PyTorch maps it to HIP. Gating those would have removed working AMD coverage, so I left them alone.

The only other issue-directory failure on `main` right now is `test_tilelang_issue_2682.py::test_vectorized_select`, which #2889 already fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `requires_cuda` to `test_large_parallel_layout_is_injective`.
- Prevents ROCm failures caused by the missing `AnnotateDeviceBoundTmaCopies` FFI symbol.
- Preserves execution on NVIDIA CI because the test is compile-only.

## Testing

- Confirmed this is the only affected test among the 53 files in `testing/python/issue/`.
- Other tests using `device="cuda"` continue to pass on ROCm.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->