### PR TITLE
[BugFix] Reject layouts on shared buffers with non-constant extents

### DIFF
--- a/src/transform/layout_inference.cc
+++ b/src/transform/layout_inference.cc
@@ -749,6 +749,26 @@ private:
                         buffer->shape, &analyzer_, Integer(anchor_bits),
                         Integer(GetElementStorageBits(buffer->dtype)));
           if (IsSharedBuffer(buffer)) {
+            // A layout is an index map over a known extent, and buffer
+            // remapping later derives the replication factor as buffer_extent /
+            // layout_extent from IntImm values (makeBufferWithLayout in
+            // transform/lower_tile_op.cc). A symbolic extent supplies neither,
+            // so reject it here instead of dereferencing a null IntImmNode
+            // downstream. A shared buffer with a symbolic extent is otherwise
+            // supported; only carrying a layout on one is not.
+            for (size_t dimension_index = 0;
+                 dimension_index < buffer->shape.size(); ++dimension_index) {
+              if (!buffer->shape[dimension_index].as<IntImmNode>()) {
+                TVM_FFI_THROW(ValueError)
+                    << "Invalid layout for shared buffer `" << buffer->name
+                    << "`: its shape must be a compile-time constant to carry "
+                       "a "
+                    << "layout, but dimension " << dimension_index << " is `"
+                    << buffer->shape[dimension_index]
+                    << "`. Allocate the buffer with a static "
+                    << "tile extent, or drop the T.annotate_layout on it.";
+              }
+            }
             arith::IterMapResult injectivity =
                 resolved_layout->DetectInjective();
             if (!injectivity->errors.empty()) {

--- a/testing/python/issue/test_tilelang_issue_2906.py
+++ b/testing/python/issue/test_tilelang_issue_2906.py
@@ -1,0 +1,89 @@
+"""Regression test for GitHub issue #2906.
+
+A shared buffer whose extent is not a compile-time constant cannot carry a
+layout: the layout is an index map over a known extent, and buffer remapping
+derives a replication factor from ``IntImm`` values. Passing such a buffer to
+``T.annotate_layout`` previously dereferenced a null ``IntImmNode`` in
+``makeBufferWithLayout`` and killed the process with SIGSEGV, so the existing
+``ICHECK`` on the layout's own output shape could never fire.
+
+It must instead be rejected with a ``ValueError`` naming the buffer and the
+non-constant dimension. A symbolic shared extent *without* a layout annotation
+is supported and must keep working.
+"""
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.layout import Layout
+
+N = 256
+BM = 16
+
+REJECT_MATCH = r"shared buffer `[^`]*`.*compile-time constant.*dimension 0"
+
+
+def _kernel(shared_shape, layout_shape, annotate):
+    m = T.dynamic("m")
+
+    @T.prim_func
+    def main(A: T.Tensor((m, N), "float16"), B: T.Tensor((m, N), "float16")):
+        with T.Kernel(T.ceildiv(m, BM), threads=128) as bx:
+            s = T.alloc_shared(shared_shape, "float16")
+            if annotate:
+                T.annotate_layout({s: Layout(layout_shape, lambda i, j: [i, j])})
+            start = bx * BM
+            T.copy(A[start : start + BM, :], s)
+            T.copy(s, B[start : start + BM, :])
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+def test_symbolic_shared_extent_with_layout_is_rejected():
+    """The regression: symbolic extent + annotate_layout used to SIGSEGV."""
+    m = T.dynamic("m")
+
+    @T.prim_func
+    def main(A: T.Tensor((m, N), "float16"), B: T.Tensor((m, N), "float16")):
+        with T.Kernel(1, threads=128):
+            s = T.alloc_shared((m, N), "float16")
+            T.annotate_layout({s: Layout([m, N], lambda i, j: [i, j])})
+            T.copy(A[0:m, :], s)
+            T.copy(s, B[0:m, :])
+
+    with pytest.raises(ValueError, match=REJECT_MATCH):
+        tilelang.compile(main, out_idx=[1])
+
+
+@tilelang.testing.requires_cuda
+def test_symbolic_shared_extent_without_layout_still_works():
+    """A symbolic shared extent on its own is supported and must not regress."""
+    m = T.dynamic("m")
+
+    @T.prim_func
+    def main(A: T.Tensor((m, N), "float16"), B: T.Tensor((m, N), "float16")):
+        with T.Kernel(1, threads=128):
+            s = T.alloc_shared((m, N), "float16")
+            T.copy(A[0:m, :], s)
+            T.copy(s, B[0:m, :])
+
+    kernel = tilelang.compile(main, out_idx=[1])
+    a = torch.randn(64, N, dtype=torch.float16, device="cuda")
+    torch.testing.assert_close(kernel(a), a)
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("annotate", [True, False], ids=["with-layout", "without-layout"])
+def test_static_shared_tile_still_works(annotate):
+    """A static tile under a dynamic grid keeps working, with and without a layout."""
+    kernel = tilelang.compile(_kernel((BM, N), [BM, N], annotate), out_idx=[1])
+    a = torch.randn(64, N, dtype=torch.float16, device="cuda")
+    torch.testing.assert_close(kernel(a), a)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
## Summary

Fixes #2906.

`T.annotate_layout` on a shared buffer whose extent is not a compile-time constant crashed the compiler with SIGSEGV. `makeBufferWithLayout` derives the replication factor as `buffer_extent / layout_extent`, reading each dimension with `buffer_shape[i].as<IntImmNode>()->value`. A symbolic extent makes `.as<IntImmNode>()` return null, and the unguarded dereference kills the process. The `ICHECK` in the loop immediately below guards the identical condition for the layout output shape, but can never fire, because the unguarded loop runs first.

## Fix

Add the check in `layout_inference.cc` beside the injectivity check introduced by #2719, rather than in `makeBufferWithLayout`, so the failure surfaces during layout inference with a message naming the buffer and the offending dimension. The predicate is the same one the crashing code relies on (`.as<IntImmNode>()`), so passing the guard guarantees the downstream dereference is safe rather than approximating it.

Only the combination is rejected. The trigger is one cell of a 2×2, and the other three are left working:

| shared extent | `annotate_layout` | before | after |
|---|---|---|---|
| static `(BM, N)` | yes | builds + runs | unchanged |
| static `(BM, N)` | no | builds + runs | unchanged |
| symbolic `(m, N)` | no | builds + runs | unchanged |
| symbolic `(m, N)` | **yes** | **SIGSEGV** | `ValueError` |

A symbolic shared extent on its own is a supported construct — it lowers to CUDA dynamic shared memory (`extern __shared__`, size passed at launch, loop bounds computed from the symbol) and executes correctly. What cannot be expressed over a non-constant extent is a *layout*, since both the replication factor and the index map require a known extent. The fix is scoped to that.

## Tests

Added `testing/python/issue/test_tilelang_issue_2906.py`:

* the crash is rejected with a `ValueError` naming the buffer and dimension;
* a symbolic shared extent **without** a layout annotation still compiles, executes, and returns the expected result — this guards against over-rejecting a case that works today;
* a static tile under a dynamic grid is unaffected.

Verified locally against `main` (`af47530`, which contains #2719), built with CUDA on sm_89: the tests fail with SIGSEGV (`rc=139`) without the change and pass with it. `bash format.sh --files ...` is clean on both changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prevents a compiler SIGSEGV when `T.annotate_layout` targets a shared buffer with a non-constant extent.
- Raises `ValueError` with the buffer and offending dimension before unsafe dereferencing.
- Preserves symbolic shared buffers without layout annotations.
- Preserves static tiles under dynamic grids.

## Tests

- Added CUDA regression tests for invalid annotated symbolic shared buffers.
- Added coverage for symbolic shared buffers without layouts.
- Parameterized static shared-tile coverage for annotated and unannotated layouts.

## C++ style / lint notes

- The C++ change does not modify public APIs or documented rules in `docs/developer_guide/cpp_style.md`.
- No CI or lint tooling changes are included.
- The “C++ API Style Audit (warning only)” remains advisory. Warning-only findings do not affect correctness, build, or test validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->