### PR TITLE
[CI] Use stable torch for the ROCm leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
             name: self-hosted-amd-gfx942
             # Format: [Nightly-]ROCm-<major>.<minor>[.<patch>]. E.g., "ROCm-6.4" or "Nightly-ROCm-7.0".
             # Use "Nightly-" prefix to use torch nightly builds.
-            toolkit: Nightly-ROCm-7.2
+            toolkit: ROCm-7.2
           - tags: [macos-latest]
             name: macos-latest
             toolkit: Metal # or Nightly-Metal


### PR DESCRIPTION
ROCm is currently the **only** leg in the test matrix running torch nightly — `CUDA-auto` and `Metal` both use stable. The practical effect is that an upstream PyTorch nightly regression turns the AMD leg red on unrelated PRs, and that reads to a reviewer as the self-hosted runner being flaky rather than as upstream churn. Since ROCm CI was only just re-enabled (#2874), protecting the credibility of that signal seems worth more than a day's head start on PyTorch regressions.

```diff
-            toolkit: Nightly-ROCm-7.2
+            toolkit: ROCm-7.2
```

### Verified on the gfx942 node

Built and ran the exact ci.yml ROCm invocation against `af475304` with the stable index:

| | nightly | stable |
| --- | --- | --- |
| torch | 2.14.0.dev+rocm7.2 | **2.13.0+rocm7.2** |
| result | 1868 passed | **1868 passed** |
| failures | 2 | 2 (same two) |

```
2 failed, 1868 passed, 1236 skipped in 274.24s (4:34)
```

Both failures are pre-existing on `main` and unrelated to the toolchain — `test_tilelang_issue_2682` (fixed by #2889) and `test_tilelang_issue_2883` (fixed by #2908). Pass count is identical to the nightly run, so this is not trading coverage for stability.

Stable is only one minor version behind nightly here, so the gap is small.

### Two details worth noting

`ROCm-7.2` parses correctly through the existing logic: `ROCM_VERSION="${TOOLKIT##*-}"` still yields `7.2`, and the `Nightly-` branch simply isn't taken, so `PIP_EXTRA_INDEX_URL` becomes `.../whl/rocm7.2`.

On the stable path the `Setup venv` step does not run its explicit `uv pip install torch` (that is nightly-only), so torch is resolved from the requirements files instead. That works because `torch` is unpinned in `requirements.txt` and the workflow already sets `UV_INDEX_STRATEGY: unsafe-best-match` at line 29 — without which resolution fails, since both PyTorch indexes ship only `cmake` 3.25.0 against a `cmake>=3.26` requirement. I confirmed both paths explicitly rather than assuming.

### Side benefit

Every new nightly pulled roughly 16G of fresh wheels into the runner's uv cache, which reached 48G within two days and needed a scheduled prune. Stable removes that churn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Changed the ROCm CI matrix from `Nightly-ROCm-7.2` to stable `ROCm-7.2`.
- Avoided unrelated failures from upstream PyTorch nightly regressions.
- Reduced recurring `uv` cache growth from nightly wheels.
- Verified matching stable and nightly results: 1,868 passed, 2 failed, and 1,236 skipped.
- Confirmed that the two failures were pre-existing and unrelated to the toolchain.
- Confirmed ROCm version parsing and stable dependency resolution.

## C++ style / lint notes

- This PR does not change C++ code or rules in `docs/developer_guide/cpp_style.md`.
- The `C++ API Style Audit (warning only)` CI step remains present.
- No correctness, build, test, or warning-only style issues were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->