### PR TITLE
[Testing] Run portable regression tests on auto targets

### DIFF
--- a/testing/python/autotune/test_tilelang_autotune.py
+++ b/testing/python/autotune/test_tilelang_autotune.py
@@ -199,7 +199,6 @@ def matmul(M, N, K):
     return autotuner.run(warmup=3, rep=20)
 
 
-@tilelang.testing.requires_cuda
 def test_autotune_get_configs():
     get_configs()
 

--- a/testing/python/issue/test_tilelang_issue_2883.py
+++ b/testing/python/issue/test_tilelang_issue_2883.py
@@ -7,10 +7,8 @@ when it exceeds the exact-enumeration limit and requires a stronger proof.
 import tilelang
 import tilelang.language as T
 import tilelang.testing
-from tilelang import tvm
 
 
-@tilelang.testing.requires_cuda
 def test_large_parallel_layout_is_injective():
     stride = T.dynamic("stride")
 
@@ -26,11 +24,8 @@ def test_large_parallel_layout_is_injective():
                 if token < 1:
                     dst[token, feature] = src[token, feature]
 
-    target = tvm.target.Target("cuda")
-    with target:
-        artifact = tilelang.lower(main, target=target, enable_device_compile=False)
-
-    assert artifact.kernel_source
+    kernel = tilelang.compile(main)
+    assert kernel.get_kernel_source()
 
 
 if __name__ == "__main__":

--- a/testing/python/language/test_tilelang_language_alloc.py
+++ b/testing/python/language/test_tilelang_language_alloc.py
@@ -116,8 +116,6 @@ def run_alloc_var_with_initializer(
     assert f"= {init_value};" in code
 
 
-# TODO(Gong): ROCm is not supported yet, disable for now
-@tilelang.testing.requires_cuda
 def test_alloc_var_with_initializer():
     run_alloc_var_with_initializer(256, 64, T.int32, 5)
 
@@ -157,8 +155,6 @@ def run_alloc_multi_vars_with_initializer(
     assert code.count("= 2;") == 1
 
 
-# TODO(Gong): ROCm is not supported yet, disable for now
-@tilelang.testing.requires_cuda
 def test_alloc_multi_vars_with_initializer():
     run_alloc_multi_vars_with_initializer(256, 64, T.int32)
 

--- a/testing/python/language/test_tilelang_language_atomic.py
+++ b/testing/python/language/test_tilelang_language_atomic.py
@@ -483,7 +483,6 @@ def run_atomic_add_complicated_parallel(K, M, N, block_M, block_N, dtype=T.float
     assert "AtomicAddx4" in kernel.get_kernel_source()
 
 
-@tilelang.testing.requires_cuda
 def test_atomic_memory_order():
     run_atomic_memory_order(4, 64, 64, 16, 16)
 
@@ -521,7 +520,6 @@ def test_atomic_addx4():
     run_atomic_addx4(16, 64, 4, 4)
 
 
-@tilelang.testing.requires_cuda
 def test_atomic_addx4_sliced_dst_compile():
     run_atomic_addx4_sliced_dst_compile(32, 8)
 
@@ -870,7 +868,6 @@ def test_atomic_min_scalar_bf16():
     run_atomic_min_scalar_literal("bfloat16")
 
 
-@tilelang.testing.requires_cuda
 def test_atomic_load_store():
     run_atomic_load_store(64, 64, 16, 16)
 
@@ -1062,7 +1059,6 @@ def test_atomic_addx2_return_prev_accepts_ramp():
     atomic_addx2_return_prev_ramp_program(T.float32)
 
 
-@tilelang.testing.requires_cuda
 def test_atomic_addx2_return_prev():
     kernel = tilelang.compile(atomic_addx2_return_prev_let_bound_program(T.float32))
     assert "AtomicAddx2Ret" in kernel.get_kernel_source()
@@ -1074,7 +1070,6 @@ def test_atomic_addx2_return_prev():
     torch.testing.assert_close(dst, torch.tensor([11.0, 22.0], device="cuda"))
 
 
-@tilelang.testing.requires_cuda
 def test_atomic_addx4_return_prev():
     kernel = tilelang.compile(atomic_addx4_return_prev_program(T.float32))
     assert "AtomicAddx4Ret" in kernel.get_kernel_source()
@@ -1166,13 +1161,12 @@ def atomic_add_return_prev_compaction_program(n, cap, block, dtype=T.float32):
     return compact_positive
 
 
-@tilelang.testing.requires_cuda
 def test_atomic_add_return_prev_materialized_once():
     n, cap, block = 4096, 4096, 256
     kernel = atomic_add_return_prev_compaction_program(n, cap, block)
 
     # Static check: the returned atomic must appear exactly once in the
-    # generated CUDA source (regression: duplicated AtomicAddRet calls).
+    # generated source (regression: duplicated AtomicAddRet calls).
     assert kernel.get_kernel_source().count("AtomicAddRet") == 1
 
     # Functional check: with all-positive input the counter must equal n and

--- a/testing/python/language/test_tilelang_language_frontend_v2.py
+++ b/testing/python/language/test_tilelang_language_frontend_v2.py
@@ -318,8 +318,6 @@ def test_swap_logic():
     torch.testing.assert_close(data, ref)
 
 
-# TODO(Gong): ROCm is not supported alloc_var with initializer
-@tilelang.testing.requires_cuda
 def test_while_loop():
     @tilelang.jit
     def while_loop():

--- a/testing/python/language/test_tilelang_language_reduce.py
+++ b/testing/python/language/test_tilelang_language_reduce.py
@@ -742,7 +742,6 @@ def test_finalize_reducer_correctness(op, dtype, block_M, block_N, batch):
     torch.testing.assert_close(B, _ref(A, op), atol=1e-2, rtol=1e-2)
 
 
-@tilelang.testing.requires_cuda
 def test_finalize_reducer_short_parallel_extent():
     extent = 8
     threads = 128
@@ -765,7 +764,6 @@ def test_finalize_reducer_short_parallel_extent():
     torch.testing.assert_close(B, A.sum().reshape(1), atol=0, rtol=0)
 
 
-@tilelang.testing.requires_cuda
 def test_finalize_reducer_mixed_parallel_extents():
     extent = 8
     threads = 128

--- a/testing/python/language/test_tilelang_language_var_init.py
+++ b/testing/python/language/test_tilelang_language_var_init.py
@@ -31,8 +31,6 @@ def test_alloc_var_rejects_unrepresentable_float32_initializer() -> None:
                 A[0] = value
 
 
-# TODO: var init is not supported on hip.
-@tilelang.testing.requires_cuda
 def test_var_assign() -> None:
     @tilelang.jit(out_idx=-1)
     def jit_kernel():


### PR DESCRIPTION
## Summary

- switch the issue #2883 regression from explicit CUDA lowering to `tilelang.compile`, allowing normal auto-target selection
- remove stale CUDA-only gates from portable autotune, reducer, atomic, and `alloc_var` tests
- remove outdated comments claiming HIP lacks `alloc_var` initialization

## Validation

- focused CUDA run: 14 passed
- Ruff and `git diff --check` passed
- all pre-commit hooks passed
- ROCm-only cross-build (`USE_CUDA=OFF`, `USE_ROCM=ON`, HIP stubs) collected all 13 newly ungated tests; representative HIP source-only lowering passed

Real ROCm runtime execution remains covered by the gfx942 CI leg.

Addresses #2903.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated portable regression tests to use automatic target selection.
- Replaced explicit CUDA lowering in issue `#2883` with `tilelang.compile`.
- Removed stale CUDA-only gates and HIP TODO comments from autotune, reducer, atomic, frontend, allocation, and variable initialization tests.
- Verified with 14 focused CUDA tests, Ruff, `git diff --check`, all pre-commit hooks, and a ROCm-only cross-build.
- Added 13 tests to the ROCm cross-build. Representative HIP source-only lowering passed.
- Runtime execution remains covered by the gfx942 CI leg.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->