### PR TITLE
[ROCm] Scalarize vectorizable calls in vector Select lowering

### DIFF
--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -9,6 +9,7 @@
 #include <tvm/runtime/logging.h>
 #include <tvm/tirx/index_map.h>
 #include <tvm/tirx/op.h>
+#include <tvm/tirx/op_attr_types.h>
 #include <tvm/tirx/stmt_functor.h>
 
 #include <cmath>
@@ -188,6 +189,12 @@ private:
         }
         PrimExpr zero = make_zero(args[0].dtype());
         return Select(args[0] >= zero, args[0], -args[0]);
+      }
+      static const OpAttrMap<TVectorizable> op_vectorizable =
+          Op::GetAttrMap<TVectorizable>("TVectorizable");
+      auto optional_op = op->op.as<Op>();
+      if (optional_op && op_vectorizable.get(optional_op.value(), false)) {
+        return Call(op->dtype.element_of(), op->op, args, op->annotations);
       }
     }
     return ExprMutator::VisitExpr_(op);

--- a/testing/python/amd/test_tilelang_hip_vector_select_codegen.py
+++ b/testing/python/amd/test_tilelang_hip_vector_select_codegen.py
@@ -186,16 +186,20 @@ def _build_scalar_select_source():
     return build(mod, tvm.target.Target("rocm")).inspect_source()
 
 
-def _build_integer_call_select_source(operation):
+def _build_integer_call_select_source(operation, dtype):
     @T.prim_func
     def integer_call_select(
-        source: T.Tensor[(4,), T.int32],
+        source: T.Tensor[(4,), dtype],
         mask: T.Tensor[(4,), T.int32],
-        destination: T.Tensor[(4,), T.int32],
+        destination: T.Tensor[(4,), dtype],
     ):
         with T.Kernel(1, threads=1):
             for index in T.vectorized(4):
-                destination[index] = T.Select(mask[index] != 0, operation(source[index]), 0)
+                destination[index] = T.Select(
+                    mask[index] != 0,
+                    operation(source[index]),
+                    T.cast(0, dtype),
+                )
 
     build = tvm.get_global_func("target.build.tilelang_hip_without_compile", allow_missing=True)
     if build is None:
@@ -226,15 +230,28 @@ def test_scalar_select_uses_base_ternary_path():
     assert assignments == ["  output[0] = ((mask[0] > 0.000000e+00f) ? input[0] : 0.000000e+00f);"]
 
 
-def test_integer_call_is_scalarized_per_select_lane():
-    source = _build_integer_call_select_source(lambda value: T.bitwise_and(value, 255))
+@pytest.mark.parametrize(
+    ("operation", "dtype", "source_pattern"),
+    [
+        pytest.param(lambda value: T.bitwise_and(value, 255), "int32", "&", id="bitwise_and"),
+        pytest.param(lambda value: T.bitwise_or(value, 255), "int32", "|", id="bitwise_or"),
+        pytest.param(lambda value: T.bitwise_xor(value, 255), "int32", "^", id="bitwise_xor"),
+        pytest.param(lambda value: T.bitwise_not(value), "int32", "~", id="bitwise_not"),
+        pytest.param(lambda value: T.shift_left(value, 2), "int32", "<<", id="shift_left"),
+        pytest.param(lambda value: T.shift_right(value, 2), "int32", ">>", id="shift_right"),
+        pytest.param(lambda value: T.popcount(value), "uint32", "__popc", id="popcount"),
+    ],
+)
+def test_integer_call_is_scalarized_per_select_lane(operation, dtype, source_pattern):
+    source = _build_integer_call_select_source(operation, dtype)
 
     assignments = [line for line in source.splitlines() if "?" in line and "source[" in line]
     assert len(assignments) == 4
     for lane, assignment in enumerate(assignments):
         assert f"source[{lane}]" in assignment
-        assert "&" in assignment
-    assert "*(int4*)(source" not in source
+        assert source_pattern in assignment
+    carrier = "uint4" if dtype == "uint32" else "int4"
+    assert f"*({carrier}*)(source" not in source
 
 
 def test_eight_lane_select_keeps_masked_loads_in_ternary_branches():

--- a/testing/python/amd/test_tilelang_hip_vector_select_codegen.py
+++ b/testing/python/amd/test_tilelang_hip_vector_select_codegen.py
@@ -1,5 +1,6 @@
 import pytest
 import tilelang
+import tilelang.language as T
 import tilelang.testing
 
 from tilelang import tvm
@@ -185,6 +186,30 @@ def _build_scalar_select_source():
     return build(mod, tvm.target.Target("rocm")).inspect_source()
 
 
+def _build_integer_call_select_source(operation):
+    @T.prim_func
+    def integer_call_select(
+        source: T.Tensor[(4,), T.int32],
+        mask: T.Tensor[(4,), T.int32],
+        destination: T.Tensor[(4,), T.int32],
+    ):
+        with T.Kernel(1, threads=1):
+            for index in T.vectorized(4):
+                destination[index] = T.Select(mask[index] != 0, operation(source[index]), 0)
+
+    build = tvm.get_global_func("target.build.tilelang_hip_without_compile", allow_missing=True)
+    if build is None:
+        pytest.skip("TileLang was built without the ROCm code generator")
+    target = tvm.target.Target("hip")
+    with target:
+        artifact = tilelang.lower(
+            integer_call_select,
+            target=target,
+            enable_device_compile=False,
+        )
+    return artifact.kernel_source
+
+
 def test_vector_condition_select_is_scalarized_in_hip_source():
     source = _build_vector_select_source(4)
 
@@ -199,6 +224,17 @@ def test_scalar_select_uses_base_ternary_path():
 
     assignments = [line for line in source.splitlines() if "?" in line and "=" in line]
     assert assignments == ["  output[0] = ((mask[0] > 0.000000e+00f) ? input[0] : 0.000000e+00f);"]
+
+
+def test_integer_call_is_scalarized_per_select_lane():
+    source = _build_integer_call_select_source(lambda value: T.bitwise_and(value, 255))
+
+    assignments = [line for line in source.splitlines() if "?" in line and "source[" in line]
+    assert len(assignments) == 4
+    for lane, assignment in enumerate(assignments):
+        assert f"source[{lane}]" in assignment
+        assert "&" in assignment
+    assert "*(int4*)(source" not in source
 
 
 def test_eight_lane_select_keeps_masked_loads_in_ternary_branches():


### PR DESCRIPTION
Follow-up to #2889.

### Problem

When a fixed-length vector `Select` branch contains a vectorizable call, the HIP lane scalarizer falls back to extracting a lane from the original vector expression. For a four-lane result, this can emit the complete vector load and operation four times, then select one different lane from each temporary.

For example, the base source generated for a fixed-size four-element bitwise input contains four separate `*(int4*)(source + 0)` loads, one before each lane assignment.

### Change

Use the existing `TVectorizable` operation attribute to rebuild vectorizable calls from their scalarized arguments. This is the same operation contract used by the TIR vectorizer, and avoids maintaining a separate HIP-specific list. Each `Select` assignment then computes only the requested lane instead of rematerializing the complete vector expression.

Target-specific intrinsic lowering still runs before HIP source generation. For example, supported popcount operations become `__popc` or `__popcll` pure-extern calls and continue through the existing pure-extern scalarization path.

This does not add a lazy-evaluation guarantee to TIR `Select`. The regression uses fixed-size source and mask buffers, so both branches are valid for every lane regardless of the condition.

### Regression coverage

The parameterized source-generation test lowers `bitwise_and`, `bitwise_or`, `bitwise_xor`, `bitwise_not`, `shift_left`, `shift_right`, and unsigned `popcount` through the full HIP pipeline. On the affected base the bitwise and shift expressions rematerialize packed source vectors. With this change, every generated assignment computes its corresponding scalar source lane and no packed source load is materialized. The popcount case also verifies the established `uint32` to `__popc` intrinsic-lowering path.

### Validation

- `cmake --build build -j$(nproc)` passed.
- `python -S -m pytest -q testing/python/amd/test_tilelang_hip_vector_select_codegen.py` passed: 36 passed, 12 hardware-gated tests skipped.
- `pre-commit run --files src/rocm/codegen/codegen_hip.cc testing/python/amd/test_tilelang_hip_vector_select_codegen.py` passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed HIP vector `Select` lowering for fixed-length vector branches with vectorizable calls.
- Rebuilds vectorizable calls from lane-scalarized arguments.
- Prevents repeated rematerialization of full vector loads and operations.
- Preserves target-specific intrinsic lowering.
- Added regression coverage for bitwise and shift operations across the HIP pipeline.
- Tests verify per-lane computation and reject packed `int4` source loads.

## Validation

- ROCm build passed.
- HIP vector `Select` tests passed: 35 passed, 12 hardware-gated skips.
- Pre-commit checks passed.
- Supported `uint32` and `uint64` `popcount` lowering remains handled by `hip.FLowerIntrinsic`.

## C++ style / lint notes

- The PR changes C++ code but does not change rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit is warning-only. No correctness or build issue is reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->