### PR TITLE
[BugFix][CPU] Compute scalar GEMM products in accum dtype instead of input dtype

### DIFF
--- a/tilelang/cpu/op/gemm/gemm_scalar.py
+++ b/tilelang/cpu/op/gemm/gemm_scalar.py
@@ -47,8 +47,10 @@ class GemmScalar(GemmBase):
                 T.clear(C_buf)
             for i, j, k in T.grid(M, N, K):
                 C_buf[c0 + i, c1 + j] += T.cast(
-                    A_buf[a0 + (k if trans_A else i), a1 + (i if trans_A else k)]
-                    * B_buf[b0 + (j if trans_B else k), b1 + (k if trans_B else j)],
+                    A_buf[a0 + (k if trans_A else i), a1 + (i if trans_A else k)],
+                    accum_dtype,
+                ) * T.cast(
+                    B_buf[b0 + (j if trans_B else k), b1 + (k if trans_B else j)],
                     accum_dtype,
                 )
 


### PR DESCRIPTION
## Summary

`GemmScalar` — the CPU/LLVM fallback for `T.gemm` — evaluates each scalar multiply in the **input** dtype and only then widens the already-rounded product to the accumulator dtype:

```python
C_buf[c0 + i, c1 + j] += T.cast(
    A_buf[...] * B_buf[...],   # fp16 x fp16 -> fp16 (rounded)
    accum_dtype,
)
```

For fp16 inputs this diverges from CUDA/ROCm mma, which computes fp16 products exactly (the 22-bit result fits in fp32's 24-bit mantissa) and accumulates in fp32. It also diverges from TileLang's own CUDA FMA fallback (`tilelang/cuda/op/gemm/gemm_fma.py`), whose docstring documents the correct convention: *"Casts widen operands to `accum_dtype` before multiplication so narrow input dtypes stay numerically sound (e.g. BF16 to FP32 accumulation on Volta). This path favors correctness and coverage over peak throughput."*

## Problem

Rounding each product to fp16 before widening has two consequences:

1. **Accuracy.** Every product carries an extra ~2^-11 relative rounding (fp32 accumulation is ~2^-24), which dominates the error for realistic K. Measured on normal-range inputs: the fp16 GEMM deviates from exact-product accumulation by up to ~1e-2 absolute (K=256), whereas exact products are accurate to fp32-accumulation level (~1e-5).

2. **Overflow -> NaN/Inf.** Products with |a·b| > 65504 (fp16 max) overflow to ±inf; mixed-sign infs then produce NaN inside the fp32 accumulator. Measured with |a|,|b| ~ 600: 100% of outputs were NaN/Inf before the fix, while exact products stay finite (they fit in fp32).

## Fix

Cast both operands to `accum_dtype` before multiplying (exact for fp16/bf16/fp8 products, all of which fit exactly in fp32):

```python
C_buf[c0 + i, c1 + j] += T.cast(A_buf[...], accum_dtype) * T.cast(B_buf[...], accum_dtype)
```

This matches mma semantics and the convention already established in `gemm_fma.py`.

## Verification

fp16 `T.gemm` on `target="c"` (compiled and executed): normal-range inputs match an exact-product fp64 reference to fp32-accumulation level (max abs err 2e-5 vs ~1e-2 before); large-magnitude inputs (products > 65504) no longer produce NaN/Inf. Existing CPU GEMM tests (`test_tilelang_cpu_tgemm.py`, `test_tilelang_cpu_gemm.py`) pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed CPU/LLVM scalar `T.gemm` accumulation.
- Cast both operands to `accum_dtype` before multiplication.
- Prevented fp16 product rounding and fp16 overflow to `Inf` or `NaN`.
- Aligned CPU behavior with CUDA/ROCm MMA and existing CUDA FMA fallback semantics.
- Improved fp16 GEMM accuracy and preserved existing CPU GEMM test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->