### PR TITLE
[BugFix][ROCm] Reject sub-wavefront block sizes instead of crashing

### DIFF
--- a/src/rocm/op/gemm.cc
+++ b/src/rocm/op/gemm.cc
@@ -34,8 +34,8 @@ ComputeDefaultWarpPartition(const GemmWarpPolicyNode &policy, int M, int N,
 
   // Guard the callers that do not go through ComputeWarpPartition: a zero
   // warp count makes the modulo below divide by zero and kills the process.
-  ICHECK_GT(num_warps, 0)
-      << "num_warps must be positive, but got " << num_warps;
+  ICHECK_GT(num_warps, 0) << "num_warps must be positive, but got "
+                          << num_warps;
   ICHECK(M % kMPerWarp == 0)
       << "M must be divisible by " << kMPerWarp << ", but got " << M;
   ICHECK(N % kNPerWarp == 0)

--- a/src/rocm/op/gemm.cc
+++ b/src/rocm/op/gemm.cc
@@ -32,6 +32,10 @@ ComputeDefaultWarpPartition(const GemmWarpPolicyNode &policy, int M, int N,
   constexpr int kMPerWarp = 16;
   constexpr int kNPerWarp = 16;
 
+  // Guard the callers that do not go through ComputeWarpPartition: a zero
+  // warp count makes the modulo below divide by zero and kills the process.
+  ICHECK_GT(num_warps, 0)
+      << "num_warps must be positive, but got " << num_warps;
   ICHECK(M % kMPerWarp == 0)
       << "M must be divisible by " << kMPerWarp << ", but got " << M;
   ICHECK(N % kNPerWarp == 0)
@@ -118,7 +122,18 @@ struct Gemm {
   ComputeWarpPartition(const GemmWarpPolicyNode &policy, int M, int N,
                        int block_size, Target target, ffi::String gemm_inst) {
     (void)gemm_inst;
-    int num_warps = block_size / TargetRocmGetWarpSize(target);
+    const int warp_size = TargetRocmGetWarpSize(target);
+    // A block narrower than one wavefront yields zero warps, which used to
+    // reach ComputeDefaultWarpPartition and abort the process with SIGFPE on
+    // its `M % (m_warp * kMPerWarp)`. Thread counts tuned for NVIDIA's 32-lane
+    // warp hit this on CDNA, where the wavefront is 64 wide.
+    ICHECK_GE(block_size, warp_size)
+        << "T.gemm needs at least one full wavefront, but this block has only "
+        << block_size << " threads while the wavefront size for "
+        << target->str() << " is " << warp_size
+        << ". Raise the kernel's thread count to a multiple of " << warp_size
+        << ".";
+    int num_warps = block_size / warp_size;
     return ComputeDefaultWarpPartition(policy, M, N, num_warps);
   }
 

--- a/testing/python/amd/test_tilelang_hip_gemm_block_size.py
+++ b/testing/python/amd/test_tilelang_hip_gemm_block_size.py
@@ -26,12 +26,15 @@ def _gemm_kernel(threads):
     return main
 
 
-@tilelang.testing.requires_rocm
+@tilelang.testing.requires_cdna
 def test_sub_wavefront_block_size_raises_instead_of_crashing():
     """A block narrower than one wavefront used to abort the process with SIGFPE.
 
     `block_size / 64` floors to zero warps on CDNA, and the resulting
     `M % (m_warp * kMPerWarp)` divided by zero. It must be a normal error.
+
+    CDNA-only: 32 threads is a full wavefront on RDNA, so the guard correctly
+    does not fire there.
     """
     with pytest.raises(Exception, match="wavefront"):
         tilelang.compile(_gemm_kernel(32), target="hip")

--- a/testing/python/amd/test_tilelang_hip_gemm_block_size.py
+++ b/testing/python/amd/test_tilelang_hip_gemm_block_size.py
@@ -1,0 +1,46 @@
+import pytest
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+def _gemm_kernel(threads):
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((16, 32), "float16"),
+        B: T.Tensor((32, 32), "float16"),
+        C: T.Tensor((16, 32), "float32"),
+    ):
+        with T.Kernel(1, threads=threads):
+            A_shared = T.alloc_shared((16, 32), "float16")
+            B_shared = T.alloc_shared((32, 32), "float16")
+            C_local = T.alloc_fragment((16, 32), "float32")
+            T.copy(A, A_shared)
+            T.copy(B, B_shared)
+            T.clear(C_local)
+            T.gemm(A_shared, B_shared, C_local, policy=T.GemmWarpPolicy.FullRow)
+            T.copy(C_local, C)
+
+    return main
+
+
+@tilelang.testing.requires_rocm
+def test_sub_wavefront_block_size_raises_instead_of_crashing():
+    """A block narrower than one wavefront used to abort the process with SIGFPE.
+
+    `block_size / 64` floors to zero warps on CDNA, and the resulting
+    `M % (m_warp * kMPerWarp)` divided by zero. It must be a normal error.
+    """
+    with pytest.raises(Exception, match="wavefront"):
+        tilelang.compile(_gemm_kernel(32), target="hip")
+
+
+@tilelang.testing.requires_rocm
+def test_full_wavefront_block_size_still_compiles():
+    assert tilelang.compile(_gemm_kernel(64), target="hip") is not None
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()


### PR DESCRIPTION
A `T.gemm` inside a block narrower than one wavefront **aborts the whole process with SIGFPE during compilation** on ROCm. No exception, no diagnostic — the interpreter dies.

```
$ pytest examples/deepseek_nsa/test_example_tilelang_nsa.py
Fatal Python error: Floating point exception
...
  File "tilelang/rocm/op/gemm/gemm_mfma.py", line 22 in infer_layout
  File "tilelang/ir.py", line 32 in compute_warp_partition
exit 136
```

### Cause

`src/rocm/op/gemm.cc`:

```cpp
int num_warps = block_size / TargetRocmGetWarpSize(target);
return ComputeDefaultWarpPartition(policy, M, N, num_warps);
```

On CDNA the wavefront is 64 wide, so a 32-thread block floors to **zero** warps. `ComputeDefaultWarpPartition` then takes its `IsFullRow()` branch with `m_warp = num_warps = 0` and evaluates

```cpp
if (M % (m_warp * kMPerWarp) != 0)   // M % 0
```

Instrumented values from the failing kernel: `M=16 N=32 block_size=32`, target `thread_warp_size=64, mcpu=gfx942`.

This is easy to hit by accident, because a thread count tuned for NVIDIA's 32-lane warp is perfectly valid on CUDA and lands exactly here. All four `examples/deepseek_nsa` kernels hardcode `threads = 32`.

The damage is worse than one failing test: because it kills the process rather than raising, it takes down the pytest worker, and under xdist that produces collateral failures in unrelated tests (`wy_fast`, `fusedmoe` both pass in isolation).

### Fix

Check the block size against the wavefront before dividing, and report it. A second guard in `ComputeDefaultWarpPartition` covers callers that do not go through `ComputeWarpPartition`.

**No CUDA impact** — this is `src/rocm/op/gemm.cc` only. The CUDA implementation structures the same computation as `for (int m = num_warps; m >= 1; m--)`, which simply does not execute when `num_warps == 0`, so it never had this failure mode.

### Before / after

| | `examples/deepseek_nsa` |
| --- | --- |
| before | exit **136** (SIGFPE), core dumped, no diagnostic |
| after | exit **1**, `T.gemm needs at least one full wavefront, but this block has only 32 threads while the wavefront size for ... is 64. Raise the kernel's thread count to a multiple of 64.` |

### Verification on gfx942 (MI300X, ROCm 7.2)

- New regression test: 2 passed — asserts the error is raised for a 32-thread block and that a 64-thread block still compiles.
- Full ROCm suite: **1912 passed, 1237 skipped, 0 failed** (up 2 from the new tests, no regressions).

### Not addressed here

This makes the failure diagnosable; it does not make the NSA examples run. They still need a thread count that is valid on CDNA — `threads = 64` compiles, but whether that is the right value or should be derived from the target is a separate question for those examples. Filed separately if you'd prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Prevent ROCm `T.gemm` compilation crashes for blocks smaller than one wavefront.
- Validate warp counts before partition calculations.
- Add a guard in `ComputeDefaultWarpPartition`.
- Report a diagnostic requiring at least one full wavefront.
- Preserve CUDA behavior.
- Add CDNA regression tests for 32-thread and 64-thread blocks.
- ROCm tests passed: 1,912 passed, 1,237 skipped, and 0 failed.

## C++ style / lint notes

- The PR changes C++ code.
- It does not change rules documented in `docs/developer_guide/cpp_style.md`.
- The **C++ API Style Audit (warning only)** CI step remains applicable.
- No correctness or build issues are reported.
- No warning-only finding introduces a clear API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->