### PR TITLE
[ROCm] Resolve versioned device properties in HIP stub

### DIFF
--- a/src/rocm/stubs/hip.cc
+++ b/src/rocm/stubs/hip.cc
@@ -104,6 +104,8 @@ HIPDriverAPI CreateHIPDriverAPI() {
     return api;
   }
 
+#define TILELANG_STRINGIFY_IMPL(symbol) #symbol
+#define TILELANG_STRINGIFY(symbol) TILELANG_STRINGIFY_IMPL(symbol)
 #define LOOKUP(member, symbol)                                                 \
   api.member = GetSymbol<decltype(api.member)>(handle, symbol);                \
   if (api.member == nullptr) {                                                 \
@@ -118,7 +120,10 @@ HIPDriverAPI CreateHIPDriverAPI() {
   LOOKUP(hipGetDeviceCount_, "hipGetDeviceCount")
   LOOKUP(hipDeviceGetAttribute_, "hipDeviceGetAttribute")
   LOOKUP(hipDeviceGetName_, "hipDeviceGetName")
-  LOOKUP(hipGetDeviceProperties_, "hipGetDeviceProperties")
+  // ROCm 6+ maps this API to an ABI-versioned symbol such as
+  // hipGetDevicePropertiesR0600. Resolve the symbol selected by the build
+  // headers instead of casting the legacy entrypoint to the new struct type.
+  LOOKUP(hipGetDeviceProperties_, TILELANG_STRINGIFY(hipGetDeviceProperties))
   LOOKUP(hipMalloc_, "hipMalloc")
   LOOKUP(hipFree_, "hipFree")
   LOOKUP(hipHostMalloc_, "hipHostMalloc")
@@ -141,6 +146,8 @@ HIPDriverAPI CreateHIPDriverAPI() {
   LOOKUP(hipModuleLaunchKernel_, "hipModuleLaunchKernel")
   LOOKUP(hipModuleLaunchCooperativeKernel_, "hipModuleLaunchCooperativeKernel")
 #undef LOOKUP
+#undef TILELANG_STRINGIFY
+#undef TILELANG_STRINGIFY_IMPL
 
   return api;
 }


### PR DESCRIPTION
## Problem

ROCm 6+ headers map `hipGetDeviceProperties` to an ABI-versioned symbol such
as `hipGetDevicePropertiesR0600`. The HIP stub's function-pointer type follows
that mapping, but its `dlsym` lookup still requested the literal legacy symbol
`hipGetDeviceProperties`.

When TileLang is imported before another ROCm extension, the globally visible
stub can interpose that extension's HIP calls. The legacy function is then
called through the versioned structure type, corrupting returned device
properties and any launch geometry derived from them.

## Fix

Use two-stage macro stringification so the build headers select the matching
runtime symbol. With ROCm 6+ headers this resolves
`hipGetDevicePropertiesR0600`; the vendored fallback continues to resolve the
unversioned name.

## Validation

The change was tested on a physical AMD Radeon PRO W7900 (`gfx1100`) with
ROCm/HIP 7.2, without an architecture override.

- Strict `-Wall -Wextra -Werror` shared-library compilation passes.
- Direct properties change from corrupted values (empty architecture,
  `warpSize=1760000`, `multiProcessorCount=1`,
  `maxThreadsPerBlock=2147483647`) to `gfx1100`, wave32, 48 WGPs, and 1024
  threads/block.
- A fresh TileLang-first AITER BF16 top-k reproduction changes from an invalid
  `block=(1760000,1,1)` launch (`hipErrorInvalidConfiguration`) to
  `block=(256,1,1)` with HIP status 0. Top-k IDs match the reference exactly;
  maximum weight error is `2.98e-8`.
- Full integration: DeepSeek V4 Flash 0731 under SGLang, TP8, online
  blockwise-INT8 weights, and FP8 KV cache completes a fixed one-token request
  with HTTP 200. All 640 instrumented AITER top-k launches report HIP status 0,
  with zero failed launches and zero scheduler exceptions.

The full-model run used synchronous launch diagnostics and is execution
evidence, not a performance benchmark.

## Impact

This removes an import-order-dependent HIP ABI failure for applications that
combine TileLang with AITER or other ROCm extensions. The fix is selected by
the active HIP headers and is not specific to `gfx1100`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fix HIP stub symbol resolution for ROCm 6+ headers.
- Use two-stage macro stringification so `dlsym` resolves versioned symbols such as `hipGetDevicePropertiesR0600`.
- Preserve the unversioned symbol for the vendored HIP fallback.
- Prevent import-order-dependent HIP ABI corruption when TileLang loads before other ROCm extensions.
- Validate device properties, AITER top-k launch geometry, result matching, and DeepSeek V4 Flash integration on ROCm/HIP 7.2.

## C++ style / lint notes

- The change affects C++ code in `src/rocm/stubs/hip.cc`.
- It does not alter the documented rules in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step is relevant to C++ changes.
- No correctness, build, or test issues are reported.
- Any TLCPP003/TLCPP004 findings remain advisory unless the audit identifies a new API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->