### PR TITLE
[CI] Add gfx950 ROCm coverage on an MI350X runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,17 +86,26 @@ jobs:
         runner:
           - tags: [self-hosted, nvidia]
             name: self-hosted-nvidia
+            pytest-workers: 8
             # Format: CUDA-auto or [Nightly-]CUDA-<major>.<minor>[.<patch>].
             # E.g., "CUDA-auto", "CUDA-13.0", or "Nightly-CUDA-13.0".
             # Use "Nightly-" prefix to use torch nightly builds.
             toolkit: CUDA-auto
           - tags: [self-hosted, amd, gfx942]
             name: self-hosted-amd-gfx942
+            pytest-workers: 8
             # Format: [Nightly-]ROCm-<major>.<minor>[.<patch>]. E.g., "ROCm-6.4" or "Nightly-ROCm-7.0".
             # Use "Nightly-" prefix to use torch nightly builds.
             toolkit: ROCm-7.2
+          - tags: [self-hosted, amd, gfx950]
+            name: self-hosted-amd-gfx950
+            pytest-workers: 4
+            xdist-gpus: 4
+            # MI350X/CDNA4 support requires the ROCm 7.2 userspace image.
+            toolkit: ROCm-7.2
           - tags: [macos-latest]
             name: macos-latest
+            pytest-workers: 8
             toolkit: Metal # or Nightly-Metal
         python-version:
           - "3.12"
@@ -261,6 +270,19 @@ jobs:
             echo "::warning::hipcc not found in PATH!"
           fi
 
+      - name: Set ROCm xdist GPU affinity
+        if: ${{ matrix.runner.xdist-gpus }}
+        env:
+          EXPECTED_GPUS: ${{ matrix.runner.xdist-gpus }}
+        run: |
+          GPU_IDS=$(rocminfo | awk '/^  Uuid:[[:space:]]+GPU-/{print $2}' | paste -sd, -)
+          ACTUAL_GPUS=$(awk -F, '{print NF}' <<<"${GPU_IDS}")
+          if [[ -z "${GPU_IDS}" || "${ACTUAL_GPUS}" -ne "${EXPECTED_GPUS}" ]]; then
+            echo "::error::expected ${EXPECTED_GPUS} visible ROCm GPU UUIDs, found ${ACTUAL_GPUS}: ${GPU_IDS}"
+            exit 1
+          fi
+          echo "TILELANG_XDIST_GPU_IDS=${GPU_IDS}" | tee -a "${GITHUB_ENV}"
+
       - name: Set environment (Metal)
         if: contains(matrix.runner.toolkit, 'Metal')
         run: |
@@ -371,7 +393,7 @@ jobs:
             uv run --no-project -m --
             pytest --verbose --color=yes --durations=0 --showlocals --cache-clear
           )
-          "${PYTEST[@]}" --maxfail=3 --numprocesses=8 \
+          "${PYTEST[@]}" --maxfail=3 --numprocesses=${{ matrix.runner.pytest-workers }} \
             --ignore=../examples/grouped_gemm/test_example_grouped_gemm.py \
             ../examples
 
@@ -385,20 +407,22 @@ jobs:
             uv run --no-project -m --
             pytest --verbose --color=yes --durations=0 --showlocals --cache-clear
           )
-          "${PYTEST[@]}" --maxfail=3 --numprocesses=8 \
+          "${PYTEST[@]}" --maxfail=3 --numprocesses=${{ matrix.runner.pytest-workers }} \
             ./python
 
       # AMD ROCm tests
       - name: Run ROCm tests with Python ${{ matrix.python-version }} (${{ matrix.runner.toolkit }})
         id: rocm-tests
         if: contains(matrix.runner.toolkit, 'ROCm')
+        env:
+          TILELANG_XDIST_GPU_COUNT: ${{ matrix.runner.xdist-gpus || '' }}
         run: |
           cd testing
           PYTEST=(
             uv run --no-project -m --
             pytest --verbose --color=yes --durations=0 --showlocals --cache-clear
           )
-          "${PYTEST[@]}" --maxfail=3 --numprocesses=8 \
+          "${PYTEST[@]}" --maxfail=3 --numprocesses=${{ matrix.runner.pytest-workers }} \
             ./python
 
       # Apple Metal tests
@@ -411,7 +435,7 @@ jobs:
             uv run --no-project -m --
             pytest --verbose --color=yes --durations=0 --showlocals --cache-clear
           )
-          "${PYTEST[@]}" --maxfail=3 --numprocesses=8 \
+          "${PYTEST[@]}" --maxfail=3 --numprocesses=${{ matrix.runner.pytest-workers }} \
             -k metal \
             ./python
 

--- a/examples/dequantize_gemm/example_dequant_gemm_bf16_mxfp4_cdna4.py
+++ b/examples/dequantize_gemm/example_dequant_gemm_bf16_mxfp4_cdna4.py
@@ -43,7 +43,7 @@ def _tir_u8_to_f4_to_bf16(nbit: int, val: tirx.PrimExpr, pos: tirx.PrimExpr, sca
 
 def _get_target():
     """Return TVM hip target for gfx950."""
-    return tvm.target.Target("hip -mcpu=gfx950")
+    return tvm.target.Target({"kind": "hip", "mcpu": "gfx950"})
 
 
 def get_configs():
@@ -59,7 +59,7 @@ def get_configs():
 
 
 @tilelang.autotune(configs=get_configs())
-@tilelang.jit(out_idx=[-1], target="hip -mcpu=gfx950")
+@tilelang.jit(out_idx=[-1], target={"kind": "hip", "mcpu": "gfx950"})
 def matmul(
     M,
     N,

--- a/src/rocm/codegen/codegen_hip.cc
+++ b/src/rocm/codegen/codegen_hip.cc
@@ -1532,9 +1532,15 @@ void CodeGenTileLangHIP::VisitExpr_(const CallNode *op, std::ostream &os) {
   } else if (op->op.same_as(builtin::ptx_commit_group())) {
     print_extern_call_stmt("tl::cp_async_commit");
   } else if (op->op.same_as(builtin::ptx_wait_group())) {
-    int n = Downcast<IntImm>(op->args[0])->value;
-    std::string func_name = "tl::cp_async_wait<" + std::to_string(n) + ">";
-    print_extern_call_stmt(func_name, 1);
+    if (const auto *n = op->args[0].as<IntImmNode>()) {
+      std::string func_name =
+          "tl::cp_async_wait<" + std::to_string(n->value) + ">";
+      print_extern_call_stmt(func_name, 1);
+    } else {
+      this->PrintIndent();
+      this->stream << "tl::cp_async_wait_dynamic("
+                   << this->PrintExpr(op->args[0]) << ");\n";
+    }
   } else if (op->op.same_as(builtin::create_barriers())) {
     this->PrintIndent();
     int barrier_count = Downcast<IntImm>(op->args[0])->value;
@@ -2364,6 +2370,9 @@ inline void PrintConst(const FloatImmNode *op, std::ostream &os,
     FloatImm const_f32 = FloatImm(DataType::Float(32), op->value);
     PrintConst(const_f32.get(), os, p);
     os << ')';
+    return;
+  } else if (op->dtype.is_float4_e2m1fn()) {
+    os << "__tl_float_to_fp4(" << std::scientific << op->value << 'f' << ')';
     return;
   }
   // Type code is kFloat

--- a/src/tl_templates/hip/copy.h
+++ b/src/tl_templates/hip/copy.h
@@ -61,6 +61,63 @@ template <int N = 0> TL_DEVICE void cp_async_wait() {
   // async_gld_sld_fence(N);
 }
 
+// Software-pipeline prologues can produce a uniform runtime wait count (for
+// example, 1 - ko). s_waitcnt requires an immediate, so dispatch the common
+// range to template instantiations. Counts outside the pipeline range fall
+// back to wait-all, which is conservative and correct.
+TL_DEVICE void cp_async_wait_dynamic(int n) {
+  switch (n) {
+  case 1:
+    cp_async_wait<1>();
+    break;
+  case 2:
+    cp_async_wait<2>();
+    break;
+  case 3:
+    cp_async_wait<3>();
+    break;
+  case 4:
+    cp_async_wait<4>();
+    break;
+  case 5:
+    cp_async_wait<5>();
+    break;
+  case 6:
+    cp_async_wait<6>();
+    break;
+  case 7:
+    cp_async_wait<7>();
+    break;
+  case 8:
+    cp_async_wait<8>();
+    break;
+  case 9:
+    cp_async_wait<9>();
+    break;
+  case 10:
+    cp_async_wait<10>();
+    break;
+  case 11:
+    cp_async_wait<11>();
+    break;
+  case 12:
+    cp_async_wait<12>();
+    break;
+  case 13:
+    cp_async_wait<13>();
+    break;
+  case 14:
+    cp_async_wait<14>();
+    break;
+  case 15:
+    cp_async_wait<15>();
+    break;
+  default:
+    cp_async_wait<0>();
+    break;
+  }
+}
+
 template <bool pre_nop = false>
 CK_TILE_DEVICE void async_buffer_load_dword_v(void *smem, int32x4_t rsrc,
                                               index_t voffset) {

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -5,6 +5,32 @@ import pytest
 
 os.environ["PYTHONHASHSEED"] = "0"
 
+
+def _configure_xdist_gpu_affinity():
+    """Give each ROCm xdist worker one GPU when CI requests GPU affinity."""
+    count_text = os.environ.get("TILELANG_XDIST_GPU_COUNT", "")
+    device_ids = os.environ.get("TILELANG_XDIST_GPU_IDS", "")
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+    if not count_text or worker == "main":
+        return
+
+    try:
+        count = int(count_text)
+        worker_index = int(worker.removeprefix("gw"))
+    except ValueError as error:
+        raise RuntimeError(f"invalid xdist GPU affinity: count={count_text!r}, worker={worker!r}") from error
+    if count < 1 or not worker.startswith("gw"):
+        raise RuntimeError(f"invalid xdist GPU affinity: count={count_text!r}, worker={worker!r}")
+
+    devices = device_ids.split(",") if device_ids else []
+    if len(devices) != count or any(not device.startswith("GPU-") for device in devices):
+        raise RuntimeError(f"invalid ROCm GPU UUID list: expected {count}, got {device_ids!r}")
+    device = devices[worker_index % count]
+    os.environ["ROCR_VISIBLE_DEVICES"] = device
+
+
+_configure_xdist_gpu_affinity()
+
 # Ensure we import the in-tree `tilelang/` instead of any globally installed
 # versions that may appear earlier on PYTHONPATH.
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))

--- a/testing/python/amd/test_tilelang_mxfp4_gfx950.py
+++ b/testing/python/amd/test_tilelang_mxfp4_gfx950.py
@@ -24,7 +24,7 @@ from tilelang import tvm as tvm
 
 
 def _hip_target():
-    return "hip -mcpu=gfx950"
+    return {"kind": "hip", "mcpu": "gfx950"}
 
 
 def _fp4_encode(vals):
@@ -232,7 +232,7 @@ def test_get_mxfp_intrin_group_returns_hip_source():
     """get_mxfp_intrin_group() returns HIP C++ source (not CUDA PTX) for gfx950."""
     from examples.dequantize_gemm.quantize import get_mxfp_intrin_group
 
-    target = tvm.target.Target("hip -mcpu=gfx950")
+    target = tvm.target.Target({"kind": "hip", "mcpu": "gfx950"})
     info = get_mxfp_intrin_group(
         out_dtype=T.bfloat16,
         source_bit=4,

--- a/testing/python/jit/test_tilelang_jit_diagnostics.py
+++ b/testing/python/jit/test_tilelang_jit_diagnostics.py
@@ -189,6 +189,11 @@ def test_cuda_compile_callback_uses_fatbin_for_multiple_target_code(monkeypatch)
 
     captured = {}
 
+    # This test asserts that the compiler callback receives the fatbin target.
+    # A persistent self-hosted runner may already have this synthetic source in
+    # its disk cache, in which case the callback is intentionally bypassed.
+    monkeypatch.setattr(cuda_backend.env, "TILELANG_DISABLE_CACHE", "1")
+
     def fake_compile_cuda(code, target_format, arch, options=None, verbose=False):
         captured["target_format"] = target_format
         captured["arch"] = arch


### PR DESCRIPTION
## Summary

Add a ROCm `gfx950` CI leg for an MI350X self-hosted runner while preserving the existing CUDA, gfx942, and Metal behavior.

This draft:

- adds a `[self-hosted, amd, gfx950]` matrix entry using ROCm 7.2;
- configures gfx950-specific pytest parallelism and assigns each xdist worker a distinct ROCm GPU UUID;
- keeps the existing runners' parallelism unchanged;
- fixes gfx950 blockers discovered during MI350X validation: dynamic HIP `cp_async_wait` lowering, HIP float4 constant emission, structured gfx950 target construction, and a persistent-cache-sensitive diagnostics test; and
- retains the existing runner-owner guard and read-only workflow permissions.

The runner itself is staged but intentionally disabled and unregistered. This PR will remain a draft until maintainers approve the public-PR trust policy, provide or apply a short-lived registration token, and the complete workflow passes through GitHub Actions.

## Why

TileLang currently has automated ROCm coverage on gfx942 but no equivalent `gfx950` matrix entry. An MI350X runner allocation is available on a shared host. The existing default xdist parallelism can cause multiple workers to contend for the same devices, so the workflow needs an explicit runner-specific worker count and per-worker GPU affinity.

The source changes in this PR are failures exposed by running the current suite on gfx950, rather than unrelated feature work.

## Validation

The exact changed source files were staged on the MI350X validation environment. The ROCm Python suite completed with:

```text
1954 passed, 1199 skipped, 0 failed
```

Local repository checks:

```bash
bash format.sh --files \
  .github/workflows/ci.yml \
  examples/dequantize_gemm/example_dequant_gemm_bf16_mxfp4_cdna4.py \
  src/rocm/codegen/codegen_hip.cc \
  src/tl_templates/hip/copy.h \
  testing/conftest.py \
  testing/python/amd/test_tilelang_mxfp4_gfx950.py \
  testing/python/jit/test_tilelang_jit_diagnostics.py

git diff --check origin/main...HEAD
```

All applicable pre-commit hooks pass, including clang-format, Ruff, YAML validation, codespell, and private-key detection.

Still required before marking ready:

- register the repository runner as `amd-mi350x-gfx950-01` with custom labels `amd,gpu,gfx950,mi350x`;
- run the examples and Python suites through the actual GitHub Actions lifecycle;
- verify the preflight reports the expected set of visible gfx950 devices;
- confirm the runner exposes neither the Docker socket nor RDMA devices; and
- complete a short non-required burn-in before considering this check required.

## Runner security and resource boundary

The proposed persistent runner shares a physical MI350X host with a separate Mooncake allocation. Its container exposes only its assigned render devices plus `/dev/kfd`, is pinned to the matching NUMA CPU/memory partition, drops all Linux capabilities, and does not receive the Docker socket or `/dev/infiniband`.

Because this is still a public repository executing PR code on a persistent self-hosted runner, maintainer approval of the trigger policy is a prerequisite for activation. A maintainer-controlled label or equivalent approval gate is preferred over unconditional execution of every non-draft PR.

## Related work

PR #2326 contains broader AMD correctness fixes and touches three files also changed here. This draft does not intend to replace that work; maintainer guidance is requested on whether the overlapping gfx950 adjustments should be coordinated, rebased, or split before review.

## AI assistance

OpenAI Codex assisted with CI-gap analysis, runner isolation design, validation triage, and preparation of this draft. The human submitter remains responsible for reviewing and defending the changes before the PR is marked ready.
