### PR TITLE
[BugFix] Keep loop-invariant stores during vectorize planning

### DIFF
--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -284,7 +284,7 @@ public:
           depends_on_loop_var = !IsExprInvariantInVectorBoundary(
               elem_offset, inner_for_->loop_var, vector_size_, analyzer_);
         }
-        if (depends_on_loop_var) {
+        if (depends_on_loop_var || info.is_store) {
           memory_min = arith::ZeroAwareGCD(memory_min, info.vector_size);
           has_global_or_shared_buffer = true;
         } else {

--- a/testing/python/language/test_tilelang_language_vectorize.py
+++ b/testing/python/language/test_tilelang_language_vectorize.py
@@ -114,6 +114,52 @@ def test_vectorize_invariant_index():
 
 
 @tilelang.jit
+def vectorize_invariant_store_accumulate(M, K):
+    @T.prim_func
+    def main(
+        A: T.Tensor[(M, K), T.float16],  # noqa: F821
+        Init: T.Tensor[(M,), T.float16],  # noqa: F821
+        B: T.Tensor[(M,), T.float16],  # noqa: F821
+    ):
+        with T.Kernel(M // 128, threads=128) as bx:
+            tx = T.get_thread_binding(0)
+            row = bx * 128 + tx
+            B[row] = Init[row]
+            # B[row] does not depend on the vectorized loop variable k, so
+            # vectorizing this loop turns the accumulate into a broadcast
+            # store: every lane reads the same old B[row], and the last
+            # lane's store wins, dropping all addends but A[row, K-1].
+            for k in T.vectorized(K):
+                B[row] = B[row] + A[row, k]
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+def test_vectorize_invariant_store_accumulate():
+    """A loop-invariant store address must keep the loop scalar.
+
+    Regression test for the VectorizePlanner bucketing in
+    src/transform/loop_vectorize.cc: a loop-invariant store computes
+    vector_size=1 in ComputeBufferVectorSize, but the entry was moved to the
+    local/fragment bucket which the simple-case strategy ignores, so the loop
+    was vectorized into a broadcast store. On CUDA this compiles and silently
+    produces wrong results (last lane wins); on the `c` target it fails to
+    compile (`vec_type` has no `.s0/.s1` accessors).
+    """
+    M, K = 128, 8
+    kernel = vectorize_invariant_store_accumulate(M, K)
+
+    a = torch.randn(M, K, device="cuda", dtype=torch.float16)
+    init = torch.randn(M, device="cuda", dtype=torch.float16)
+    b = init.clone()
+    kernel(a, init, b)
+
+    expected = init + a.sum(dim=1)
+    torch.testing.assert_close(b, expected, atol=1e-2, rtol=1e-2)
+
+
+@tilelang.jit
 def vectorize_test_all_dtypes(dtype, vec_num):
     @T.prim_func
     def main(A: T.Tensor[(64,), dtype]):


### PR DESCRIPTION
VectorizePlanner::ComputeBufferVectorSize returns vector_size=1 for stores whose address is invariant within the vector boundary, because vectorizing them produces a broadcast store: every lane reads the same old value and
stores to the same address, so the last lane silently wins (accumulation pattern).
However, Plan() then bucketed such entries by address invariance alone and moved them to the local/fragment bucket, which the simple-case strategy (GCD(memory_min, non_cast_call_node_min)) ignores — the constraint
was dropped and the loop was vectorized anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Fixed vectorization planning to preserve loop-invariant global and shared-buffer stores as memory constraints.
- Added a CUDA regression test for invariant-store accumulation.
- Verified results against `Init + a.sum(dim=1)` using float16 tensors and toleranced comparison.

## C++ style / lint notes

- The PR changes C++ code but does not modify the rules in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit is not relevant because the PR adds no public C++ API.
- No correctness or build issues are identified. Any audit findings would be warning-only.

## Tests

- Added `vectorize_invariant_store_accumulate(M, K)`.
- Added `test_vectorize_invariant_store_accumulate()`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->