### PR TITLE
[Bugfix] Carry memory_order through vectorized atomic_add

### DIFF
--- a/src/tl_templates/cuda/atomic.h
+++ b/src/tl_templates/cuda/atomic.h
@@ -143,29 +143,27 @@ TL_DEVICE void tl_atomic_add_bf16(unsigned short &ret, unsigned long long addr,
   }
 }
 
-TL_DEVICE void tl_atomic_add_v2_f16(unsigned short &ret_x,
-                                    unsigned short &ret_y,
-                                    unsigned long long addr,
-                                    unsigned short val_x, unsigned short val_y,
-                                    int memory_order) {
+// Packed f16x2 rather than `.v2.f16`: both encode the same pairwise add, but
+// `atom` with vector operands requires sm_90 while the packed 32-bit form is
+// available from sm_60, so this keeps ordered fp16 wide atomics working on
+// every supported target.
+TL_DEVICE void tl_atomic_add_f16x2(unsigned int &ret, unsigned long long addr,
+                                   unsigned int val, int memory_order) {
   if (IsReleaseMemoryOrder(memory_order)) {
-    asm volatile(
-        "atom.release.gpu.global.add.noftz.v2.f16 {%0,%1}, [%2], {%3,%4};"
-        : "=h"(ret_x), "=h"(ret_y)
-        : "l"(addr), "h"(val_x), "h"(val_y)
-        : "memory");
+    asm volatile("atom.release.gpu.global.add.noftz.f16x2 %0, [%1], %2;"
+                 : "=r"(ret)
+                 : "l"(addr), "r"(val)
+                 : "memory");
   } else if (IsAcquireLikeMemoryOrder(memory_order)) {
-    asm volatile(
-        "atom.acquire.gpu.global.add.noftz.v2.f16 {%0,%1}, [%2], {%3,%4};"
-        : "=h"(ret_x), "=h"(ret_y)
-        : "l"(addr), "h"(val_x), "h"(val_y)
-        : "memory");
+    asm volatile("atom.acquire.gpu.global.add.noftz.f16x2 %0, [%1], %2;"
+                 : "=r"(ret)
+                 : "l"(addr), "r"(val)
+                 : "memory");
   } else if (IsAcqRelLikeMemoryOrder(memory_order)) {
-    asm volatile(
-        "atom.acq_rel.gpu.global.add.noftz.v2.f16 {%0,%1}, [%2], {%3,%4};"
-        : "=h"(ret_x), "=h"(ret_y)
-        : "l"(addr), "h"(val_x), "h"(val_y)
-        : "memory");
+    asm volatile("atom.acq_rel.gpu.global.add.noftz.f16x2 %0, [%1], %2;"
+                 : "=r"(ret)
+                 : "l"(addr), "r"(val)
+                 : "memory");
   }
 }
 
@@ -175,20 +173,23 @@ TL_DEVICE void tl_atomic_add_v2_bf16(unsigned short &ret_x,
                                      unsigned short val_x, unsigned short val_y,
                                      int memory_order) {
   if (IsReleaseMemoryOrder(memory_order)) {
-    asm volatile("atom.release.gpu.global.add.v2.bf16 {%0,%1}, [%2], {%3,%4};"
-                 : "=h"(ret_x), "=h"(ret_y)
-                 : "l"(addr), "h"(val_x), "h"(val_y)
-                 : "memory");
+    asm volatile(
+        "atom.release.gpu.global.add.noftz.v2.bf16 {%0,%1}, [%2], {%3,%4};"
+        : "=h"(ret_x), "=h"(ret_y)
+        : "l"(addr), "h"(val_x), "h"(val_y)
+        : "memory");
   } else if (IsAcquireLikeMemoryOrder(memory_order)) {
-    asm volatile("atom.acquire.gpu.global.add.v2.bf16 {%0,%1}, [%2], {%3,%4};"
-                 : "=h"(ret_x), "=h"(ret_y)
-                 : "l"(addr), "h"(val_x), "h"(val_y)
-                 : "memory");
+    asm volatile(
+        "atom.acquire.gpu.global.add.noftz.v2.bf16 {%0,%1}, [%2], {%3,%4};"
+        : "=h"(ret_x), "=h"(ret_y)
+        : "l"(addr), "h"(val_x), "h"(val_y)
+        : "memory");
   } else if (IsAcqRelLikeMemoryOrder(memory_order)) {
-    asm volatile("atom.acq_rel.gpu.global.add.v2.bf16 {%0,%1}, [%2], {%3,%4};"
-                 : "=h"(ret_x), "=h"(ret_y)
-                 : "l"(addr), "h"(val_x), "h"(val_y)
-                 : "memory");
+    asm volatile(
+        "atom.acq_rel.gpu.global.add.noftz.v2.bf16 {%0,%1}, [%2], {%3,%4};"
+        : "=h"(ret_x), "=h"(ret_y)
+        : "l"(addr), "h"(val_x), "h"(val_y)
+        : "memory");
   }
 }
 
@@ -597,16 +598,10 @@ TL_DEVICE void AtomicAddx2(half_t *ref, ValType val,
     // Since atomicAdd does not support memory order, atomic_ref does not
     // support vectorized atomic operation we can only inline ptx code here
     // Note: Vectorized atomic operations only support global space
-    // Note: for 16-bit value, we need to reinterpret_cast the value to unsigned
-    // short and use "h" register in assembly
-    unsigned short add_val_x_cast = tl_atomic_detail::PackBits16(add_val.x);
-    unsigned short add_val_y_cast = tl_atomic_detail::PackBits16(add_val.y);
-    unsigned long long ref_addr = reinterpret_cast<unsigned long long>(ref);
-    unsigned short ret_val_x_cast;
-    unsigned short ret_val_y_cast;
-    tl_atomic_detail::tl_atomic_add_v2_f16(ret_val_x_cast, ret_val_y_cast,
-                                           ref_addr, add_val_x_cast,
-                                           add_val_y_cast, memory_order);
+    unsigned int ret_val;
+    tl_atomic_detail::tl_atomic_add_f16x2(
+        ret_val, reinterpret_cast<unsigned long long>(ref),
+        *reinterpret_cast<const unsigned int *>(&add_val), memory_order);
   }
 }
 
@@ -618,16 +613,11 @@ AtomicAddx2Ret(half_t *ref, ValType val,
   if (tl_atomic_detail::IsRelaxedMemoryOrder(memory_order)) {
     return atomicAdd(reinterpret_cast<half2 *>(ref), add_val);
   } else {
-    unsigned short add_val_x_cast = tl_atomic_detail::PackBits16(add_val.x);
-    unsigned short add_val_y_cast = tl_atomic_detail::PackBits16(add_val.y);
-    unsigned long long ref_addr = reinterpret_cast<unsigned long long>(ref);
-    unsigned short ret_val_x_cast;
-    unsigned short ret_val_y_cast;
-    tl_atomic_detail::tl_atomic_add_v2_f16(ret_val_x_cast, ret_val_y_cast,
-                                           ref_addr, add_val_x_cast,
-                                           add_val_y_cast, memory_order);
-    return half2(tl_atomic_detail::UnpackBits16<__half>(ret_val_x_cast),
-                 tl_atomic_detail::UnpackBits16<__half>(ret_val_y_cast));
+    unsigned int ret_val;
+    tl_atomic_detail::tl_atomic_add_f16x2(
+        ret_val, reinterpret_cast<unsigned long long>(ref),
+        *reinterpret_cast<const unsigned int *>(&add_val), memory_order);
+    return *reinterpret_cast<const half2 *>(&ret_val);
   }
 }
 
@@ -670,6 +660,35 @@ TL_DEVICE __nv_bfloat162 ToBfloat162(float *val) {
 }
 
 #if (defined(__CUDA_ARCH_LIST__) && (__CUDA_ARCH_LIST__ > 750))
+namespace tl_atomic_detail {
+// Below sm_90 there is no ordered bf16 atomic add in any width: `atom` with
+// vector types requires sm_90, and so does `atom.add.bf16` itself, so the
+// pair cannot be decomposed into ordered scalar atomics the way the fp16 path
+// does. Emulate the ordering with fences around a relaxed bf16x2 atomicAdd
+// instead. `__threadfence()` lowers to `fence.sc.gpu` (MEMBAR.SC.GPU), i.e.
+// device scope -- the same scope as the `.gpu` qualifier on the ordered PTX
+// above -- and is a two-way barrier, strictly stronger than the one-way
+// barrier release/acquire require. So this is conservative rather than lossy:
+// it just costs more than the sm_90+ instruction would. One consequence worth
+// knowing: for seq_cst this fallback is *stronger* than the sm_90 path, which
+// maps seq_cst onto `atom.acq_rel` like the rest of this file does.
+TL_DEVICE __nv_bfloat162 tl_atomic_add_v2_bf16_fenced(__nv_bfloat162 *addr,
+                                                      __nv_bfloat162 val,
+                                                      int memory_order) {
+  const bool acq_rel = IsAcqRelLikeMemoryOrder(memory_order);
+  if (acq_rel || IsReleaseMemoryOrder(memory_order)) {
+    // Prior writes become visible before the add does.
+    __threadfence();
+  }
+  __nv_bfloat162 prev = atomicAdd(addr, val);
+  if (acq_rel || IsAcquireLikeMemoryOrder(memory_order)) {
+    // Later reads cannot be hoisted above the add.
+    __threadfence();
+  }
+  return prev;
+}
+} // namespace tl_atomic_detail
+
 template <typename ValType>
 TL_DEVICE void AtomicAddx2(bfloat16_t *ref, ValType val,
                            int memory_order = int(cuda::memory_order_relaxed)) {
@@ -677,6 +696,7 @@ TL_DEVICE void AtomicAddx2(bfloat16_t *ref, ValType val,
   if (tl_atomic_detail::IsRelaxedMemoryOrder(memory_order)) {
     atomicAdd(reinterpret_cast<__nv_bfloat162 *>(ref), add_val);
   } else {
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     unsigned short add_val_x_cast = tl_atomic_detail::PackBits16(add_val.x);
     unsigned short add_val_y_cast = tl_atomic_detail::PackBits16(add_val.y);
     unsigned long long ref_addr = reinterpret_cast<unsigned long long>(ref);
@@ -685,6 +705,10 @@ TL_DEVICE void AtomicAddx2(bfloat16_t *ref, ValType val,
     tl_atomic_detail::tl_atomic_add_v2_bf16(ret_val_x_cast, ret_val_y_cast,
                                             ref_addr, add_val_x_cast,
                                             add_val_y_cast, memory_order);
+#else
+    tl_atomic_detail::tl_atomic_add_v2_bf16_fenced(
+        reinterpret_cast<__nv_bfloat162 *>(ref), add_val, memory_order);
+#endif
   }
 }
 
@@ -698,6 +722,7 @@ AtomicAddx2Ret(bfloat16_t *ref, src_type *val,
                          *reinterpret_cast<const __nv_bfloat162 *>(val)));
   } else {
     __nv_bfloat162 add_val = *reinterpret_cast<const __nv_bfloat162 *>(val);
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
     unsigned short add_val_x_cast = tl_atomic_detail::PackBits16(add_val.x);
     unsigned short add_val_y_cast = tl_atomic_detail::PackBits16(add_val.y);
     unsigned long long ref_addr = reinterpret_cast<unsigned long long>(ref);
@@ -709,6 +734,10 @@ AtomicAddx2Ret(bfloat16_t *ref, src_type *val,
     return __nv_bfloat162(
         tl_atomic_detail::UnpackBits16<__nv_bfloat16>(ret_val_x_cast),
         tl_atomic_detail::UnpackBits16<__nv_bfloat16>(ret_val_y_cast));
+#else
+    return tl_atomic_detail::tl_atomic_add_v2_bf16_fenced(
+        reinterpret_cast<__nv_bfloat162 *>(ref), add_val, memory_order);
+#endif
   }
 }
 

--- a/src/transform/vectorize_loop.cc
+++ b/src/transform/vectorize_loop.cc
@@ -660,8 +660,15 @@ public:
       return GetRef<PrimExpr>(op);
     }
 
-    // Return the vectorized atomic op
-    return Call(op->dtype, GetVectorizedAtomicOp(vector_size), {dst, src});
+    // Return the vectorized atomic op, carrying the trailing operands
+    // (memory_order) so the wide atomic honors the requested ordering just like
+    // the scalar path does. Copied as-is: the order is a scalar constant and
+    // must not be broadcast to the vector lanes.
+    Array<PrimExpr> new_args{dst, src};
+    for (size_t i = 2; i < op->args.size(); ++i) {
+      new_args.push_back(op->args[i]);
+    }
+    return Call(op->dtype, GetVectorizedAtomicOp(vector_size), new_args);
   }
 
   static std::optional<int> GetAccessPtrElementBits(const PrimExpr &expr) {

--- a/testing/python/language/test_tilelang_language_atomic.py
+++ b/testing/python/language/test_tilelang_language_atomic.py
@@ -462,6 +462,41 @@ def run_atomic_add_auto_vectorized_unit_test(vec_size: int, dtype=T.float32):
 
 
 @tilelang.jit
+def atomic_add_vectorized_memory_order_program(N, threads, memory_order, dtype=T.float16):
+    @T.prim_func
+    def atomic_add(X: T.Tensor((N,), dtype), Out: T.Tensor((N,), dtype)):
+        with T.Kernel(1, threads=threads):
+            T.atomic_add(Out[0:N], X[0:N], memory_order=memory_order)
+
+    return atomic_add
+
+
+def run_atomic_add_vectorized_memory_order(N, threads, memory_order, memory_order_id, dtype=T.float16):
+    # A vectorized atomic add must carry the requested memory order, just like
+    # the scalar lowering of the same call does. Cache disabled because the key
+    # does not cover the native library by default, so a stale pre-fix kernel
+    # source would otherwise be served here.
+    tilelang.disable_cache()
+    try:
+        kernel = atomic_add_vectorized_memory_order_program(N, threads, memory_order, dtype=dtype)
+
+        wide_calls = re.findall(r"AtomicAddx\d\([^;]*\);", kernel.get_kernel_source())
+        assert wide_calls, f"expected a vectorized atomic add, got:\n{kernel.get_kernel_source()}"
+        for call in wide_calls:
+            assert call.endswith(f", {memory_order_id});"), f"{memory_order} dropped from vectorized atomic add: {call}"
+
+        # Each order takes a separately spelled asm string in the device helpers,
+        # so run the kernel to check this one actually computes the sum.
+        torch_dtype = getattr(torch, dtype)
+        X = torch.randn(N, dtype=torch_dtype).cuda()
+        Out = torch.zeros(N, dtype=torch_dtype).cuda()
+        kernel(X, Out)
+        torch.testing.assert_close(Out, X, atol=1e-2, rtol=1e-2)
+    finally:
+        tilelang.enable_cache()
+
+
+@tilelang.jit
 def atomic_add_complicated_parallel_program(K, M, N, block_M, block_N, dtype=T.float32):
     @T.prim_func
     def atomic_add(A: T.Tensor((K, M, N), dtype), B: T.Tensor((M, N), dtype)):
@@ -514,6 +549,28 @@ def test_atomic_different_memory_orders():
     run_atomic_different_memory_orders(32, 32, 8, 8, dtype=T.float32)
     run_atomic_different_memory_orders(32, 32, 8, 8, dtype=T.float16)
     run_atomic_different_memory_orders(32, 32, 8, 8, dtype=T.bfloat16)
+
+
+# ids match cuda::memory_order. Each one is a separately spelled asm string in
+# the device helpers, so all three ordered spellings need exercising.
+_ORDERED_MEMORY_ORDERS = [("acquire", 2), ("release", 3), ("acq_rel", 4)]
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("memory_order, memory_order_id", _ORDERED_MEMORY_ORDERS)
+def test_atomic_add_vectorized_preserves_memory_order(memory_order, memory_order_id):
+    run_atomic_add_vectorized_memory_order(64, 32, memory_order, memory_order_id, dtype=T.float16)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(8, 0)
+@pytest.mark.parametrize("memory_order, memory_order_id", _ORDERED_MEMORY_ORDERS)
+def test_atomic_add_vectorized_preserves_memory_order_bf16(memory_order, memory_order_id):
+    # bf16 takes a different device path depending on the target: below sm_90
+    # there is no ordered bf16 atomic in any width, so AtomicAddx2 falls back to
+    # fences around a relaxed add, while sm_90 uses the ordered instruction. A
+    # given run covers whichever side the test GPU selects.
+    run_atomic_add_vectorized_memory_order(64, 32, memory_order, memory_order_id, dtype=T.bfloat16)
 
 
 def test_atomic_addx4():

--- a/tilelang/language/atomic.py
+++ b/tilelang/language/atomic.py
@@ -42,7 +42,7 @@ def atomic_max(
     """
     Perform an atomic maximum on the value stored at dst with an optional memory-order.
 
-    Supports scalar/addressed extern atomic max when neither argument exposes extents, or tile-region-based atomic max for Buffer/BufferRegion/BufferLoad inputs. If both arguments are plain Buffers their shapes must be structurally equal. If at least one side exposes extents, extents are aligned (missing dimensions are treated as size 1); an assertion is raised if extents cannot be deduced. The optional `memory_order` (one of "relaxed","consume","acquire","release","acq_rel","seq_cst") is used only for the direct extern `AtomicMax` path when no extents are available — otherwise the tile-region path ignores `memory_order`.
+    Supports scalar/addressed extern atomic max when neither argument exposes extents, or tile-region-based atomic max for Buffer/BufferRegion/BufferLoad inputs. If both arguments are plain Buffers their shapes must be structurally equal. If at least one side exposes extents, extents are aligned (missing dimensions are treated as size 1); an assertion is raised if extents cannot be deduced. The optional `memory_order` (one of "relaxed","consume","acquire","release","acq_rel","seq_cst") is honored on CUDA targets by both the direct extern `AtomicMax` path and the tile-region path. HIP and CuteDSL codegen currently ignore it.
 
     Parameters:
         dst (Buffer): Destination buffer/address to apply the atomic max.
@@ -128,7 +128,7 @@ def atomic_min(
     """
     Atomically update the value at dst to the minimum of its current value and value.
 
-    Supports scalar/addressed extern atomic min when neither argument exposes extents, or tile-region-based atomic min for Buffer/BufferRegion/BufferLoad inputs. If both arguments are plain Buffers their shapes must be structurally equal. If at least one side exposes extents, extents are aligned (missing dimensions are treated as size 1); an assertion is raised if extents cannot be deduced. The optional `memory_order` (one of "relaxed","consume","acquire","release","acq_rel","seq_cst") is used only for the direct extern `AtomicMin` path when no extents are available — otherwise the tile-region path ignores `memory_order`.
+    Supports scalar/addressed extern atomic min when neither argument exposes extents, or tile-region-based atomic min for Buffer/BufferRegion/BufferLoad inputs. If both arguments are plain Buffers their shapes must be structurally equal. If at least one side exposes extents, extents are aligned (missing dimensions are treated as size 1); an assertion is raised if extents cannot be deduced. The optional `memory_order` (one of "relaxed","consume","acquire","release","acq_rel","seq_cst") is honored on CUDA targets by both the direct extern `AtomicMin` path and the tile-region path. HIP and CuteDSL codegen currently ignore it.
 
     Parameters:
         dst (Buffer): Destination buffer/address to apply the atomic min.
@@ -219,7 +219,7 @@ def atomic_add(
     """
     Atomically add `value` into `dst`, returning a handle to the operation.
 
-    Supports scalar/addressed extern atomic add when neither argument exposes extents, or tile-region-based atomic add for Buffer/BufferRegion/BufferLoad inputs. If both arguments are plain Buffers their shapes must be structurally equal. If at least one side exposes extents, extents are aligned (missing dimensions are treated as size 1); an assertion is raised if extents cannot be deduced. The optional `memory_order` (one of "relaxed","consume","acquire","release","acq_rel","seq_cst") is used only for the direct extern `AtomicAdd` path when no extents are available — otherwise the tile-region path ignores `memory_order`.
+    Supports scalar/addressed extern atomic add when neither argument exposes extents, or tile-region-based atomic add for Buffer/BufferRegion/BufferLoad inputs. If both arguments are plain Buffers their shapes must be structurally equal. If at least one side exposes extents, extents are aligned (missing dimensions are treated as size 1); an assertion is raised if extents cannot be deduced. The optional `memory_order` (one of "relaxed","consume","acquire","release","acq_rel","seq_cst") is honored on CUDA targets by both paths: the direct extern `AtomicAdd` path when no extents are available, and the tile-region path (including when it auto-vectorizes to `AtomicAddx2`/`AtomicAddx4`). HIP and CuteDSL codegen currently ignore it.
 
     Parameters:
         dst (Buffer): Destination buffer/address to apply the atomic add.


### PR DESCRIPTION
Fixes #2688.

## Cause

`vectorize_loop.cc` rebuilt the wide atomic from two operands:

```cpp
return Call(op->dtype, GetVectorizedAtomicOp(vector_size), {dst, src});
```

The region lowering puts `memory_order` in `args[2]`. Codegen appends it only under
`if (op->args.size() > 2)`, so the emitted `AtomicAddx2(dst, src)` picks up the
`= memory_order_relaxed` default on the device function. Legal C++, no diagnostic anywhere.
Everything downstream already accepted the operand, including `num_inputs = 3`; the vectorizer
was under-filling it.

The fix carries the trailing operands through, starting at index 2 because the two-argument form
is legal, and copying rather than visiting because the order is lane-invariant.

## Why atomic.h changes too

Carrying the order makes inline PTX reachable that had never been assembled: the non-relaxed
branches were constant-folded away while the order always defaulted to relaxed. Three of them do
not build.

1. **fp16 used `.v2.f16`**, whose vector operands require sm_90, and fp16 vectorizes to x2 on
   every target. Now uses packed `f16x2`, available from sm_60 and emitting identical SASS on
   sm_90, so fp16 needs no arch guard at all and the per-half pack/unpack goes away.
2. **bf16 was missing `.noftz`**, which ptxas requires for `.bf16`. Syntax error on every target,
   sm_90 included.
3. **bf16 has no ordered atomic below sm_90 at any width**, so unlike fp16 there is nothing to
   fall back to. The sm_90 path is guarded, with `__threadfence()` around a relaxed bf16x2
   atomicAdd below it: two-way where release and acquire need one-way, so conservative rather
   than lossy.

New guards use `__CUDA_ARCH__` rather than the `__CUDA_ARCH_LIST__` spelling elsewhere in this
file, which fails a `-gencode` multi-arch build with `C1012`. The remaining uses guard
declarations, where `__CUDA_ARCH__` is undefined in the host pass, so those stay as they are.

Docstrings for `atomic_add`, `atomic_max` and `atomic_min` claimed the region path ignores
`memory_order`, which is no longer true.

## Testing

Six cases covering acquire, release and acq_rel on fp16 and bf16, since each ordering is a
separately spelled asm string. Each asserts on the generated CUDA, then runs the kernel.

RTX 2000 Ada (sm_89), CUDA 13.3: **56 passed, 3 skipped, 1 failed**. The failure is
`test_tma_atomic_add`, which fails identically on unmodified `main` (TMA needs sm_90 and that
test has no arch guard) and uses no `memory_order`.

Negative control: reverting only the two source files, keeping the new tests, and rebuilding
makes them fail with `AtomicAddx2((&(Out[...])), *(uint1*)(X + ...));`. Restoring and rebuilding
makes them pass.

Every PTX spelling was checked against sm_75 through sm_90 with ptxas. There is no sm_90
hardware here, so those branches are verified to assemble rather than to run.

## One untested path

`AtomicAddx2Ret(bfloat16_t*)` takes the same guard through the shared helper, and
`AtomicAddx4Ret` routes through it. This is the only part with no test, and it cannot have one:
nothing reachable instantiates the bf16 Ret overloads with a non-relaxed order, since
`GetVectorizedAtomicOp` returns only the non-ret ops, `T.atomic_addx2` / `T.atomic_addx4` take no
`memory_order`, and region-form `return_prev=True` raises `NotImplementedError`. Guarded anyway
so the file stays consistent and the path is already correct when `return_prev` is implemented.
Verified by instantiating the template directly: without the guard it fails on sm_80/86/89 with
`Instruction 'atom.add.bf16.global' requires .target sm_90 or higher`, and passes on all four
targets with it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Preserve trailing operands, including `memory_order`, when vectorizing `T.atomic_add` to `AtomicAddx2` or `AtomicAddx4`.
- Use packed `f16x2` PTX for vector fp16 atomics.
- Add `.noftz` to vector bf16 PTX.
- Add fenced bf16 atomics for architectures below sm_90.
- Update `atomic_add`, `atomic_max`, and `atomic_min` documentation.
- Add six CUDA tests for acquire, release, and acq_rel ordering on fp16 and bf16.

## C++ style / lint notes

- The PR changes C++ code in `src/tl_templates/cuda/atomic.h` and `src/transform/vectorize_loop.cc`.
- The available summary does not identify changes to rules in `docs/developer_guide/cpp_style.md`.
- Review the “C++ API Style Audit (warning only)” CI step for advisory findings.
- Treat TLCPP003/TLCPP004 findings as warning-only unless they indicate a new API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->