### PR TITLE
[BugFix][Metal] Preserve pointer address spaces for byte offsets

### DIFF
--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -483,14 +483,17 @@ void CodeGenTileLangMetal::VisitStmt_(const BindNode *op) {
 
   const auto *pointer_type = op->var->type_annotation.as<PointerTypeNode>();
   TVM_FFI_ICHECK(pointer_type)
-      << "Metal handle binding requires a typed pointer: " << op->var;
+      << "Metal handle binding requires a typed pointer: " << op->var << " = "
+      << op->value;
   const auto *element_type = pointer_type->element_type.as<PrimTypeNode>();
   TVM_FFI_ICHECK(element_type)
-      << "Metal handle binding requires a primitive pointee type: " << op->var;
+      << "Metal handle binding requires a primitive pointee type: " << op->var
+      << " = " << op->value;
 
   const std::string &storage_scope = pointer_type->storage_scope;
   TVM_FFI_ICHECK(!storage_scope.empty())
-      << "Metal handle binding requires an explicit storage scope: " << op->var;
+      << "Metal handle binding requires an explicit storage scope: " << op->var
+      << " = " << op->value;
 
   alloc_storage_scope_[op->var.get()] = storage_scope;
   RegisterHandleType(op->var.get(), element_type->dtype);
@@ -912,6 +915,9 @@ void CodeGenTileLangMetal::VisitExpr_(const CastNode *op,
 
 std::string
 CodeGenTileLangMetal::GetStorageScopeOf(const PrimExpr &ptr_expr) const {
+  if (const auto *cast = ptr_expr.as<CastNode>()) {
+    return GetStorageScopeOf(cast->value);
+  }
   if (auto *var = ptr_expr.as<VarNode>()) {
     auto it = alloc_storage_scope_.find(var);
     if (it != alloc_storage_scope_.end()) {
@@ -987,7 +993,7 @@ CodeGenTileLangMetal::GetPointeeTypeOf(const PrimExpr &ptr_expr,
       return GetPointeeTypeOf(call->args[1], fallback);
     } else if (call->op.same_as(builtin::reinterpret())) {
       TVM_FFI_ICHECK_EQ(call->args.size(), 1U);
-      return GetPointeeTypeOf(call->args[0], fallback);
+      return fallback;
     }
   }
   return fallback;

--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -72,6 +72,21 @@ public:
   bool needs_fragment_lane_vars{false};
 };
 
+std::string MetalAddressSpaceForStorageScope(const std::string &scope) {
+  if (scope == "global") {
+    return "device";
+  }
+  if (scope == "shared" || scope == "shared.dyn" || scope == "threadgroup") {
+    return "threadgroup";
+  }
+  if (scope == "local" || scope == "local.var" || scope == "metal.simdgroup" ||
+      scope == "metal.cooperative_tensor") {
+    return "thread";
+  }
+  LOG(FATAL) << "Unknown Metal storage scope `" << scope << "`";
+  return "";
+}
+
 } // namespace
 
 void CodeGenTileLangMetal::InitFuncState(const PrimFunc &f) {
@@ -457,15 +472,43 @@ void CodeGenTileLangMetal::PrintVecElemStore(const std::string &vec, DataType t,
 
 void CodeGenTileLangMetal::PrintStorageScope(const std::string &scope,
                                              std::ostream &os) { // NOLINT(*)
-  if (scope == "global") {
-    os << "device ";
-  } else if (scope == "shared" || scope == "shared.dyn") {
-    os << "threadgroup ";
-  } else if (scope == "local" || scope == "local.var") {
-    os << "thread ";
-  } else {
-    LOG(FATAL) << "Unknown storage scope `" << scope << "`";
+  os << MetalAddressSpaceForStorageScope(scope) << " ";
+}
+
+void CodeGenTileLangMetal::VisitStmt_(const BindNode *op) {
+  if (!op->var.dtype().is_handle()) {
+    CodeGenC::VisitStmt_(op);
+    return;
   }
+
+  const auto *pointer_type = op->var->type_annotation.as<PointerTypeNode>();
+  TVM_FFI_ICHECK(pointer_type)
+      << "Metal handle binding requires a typed pointer: " << op->var;
+  const auto *element_type = pointer_type->element_type.as<PrimTypeNode>();
+  TVM_FFI_ICHECK(element_type)
+      << "Metal handle binding requires a primitive pointee type: " << op->var;
+
+  const std::string &storage_scope = pointer_type->storage_scope;
+  TVM_FFI_ICHECK(!storage_scope.empty())
+      << "Metal handle binding requires an explicit storage scope: " << op->var;
+
+  alloc_storage_scope_[op->var.get()] = storage_scope;
+  RegisterHandleType(op->var.get(), element_type->dtype);
+  std::string value = PrintExpr(op->value);
+
+  if (print_ssa_form_) {
+    TVM_FFI_ICHECK(!var_idmap_.count(op->var.get()));
+    var_idmap_[op->var.get()] = value;
+    return;
+  }
+
+  PrintIndent();
+  PrintStorageScope(storage_scope, stream);
+  PrintType(element_type->dtype, stream);
+  stream << "* " << AllocVarID(op->var.get()) << " = (";
+  PrintStorageScope(storage_scope, stream);
+  PrintType(element_type->dtype, stream);
+  stream << "*)" << value << ";\n";
 }
 
 void CodeGenTileLangMetal::VisitStmt_(const AttrStmtNode *op) {
@@ -868,74 +911,83 @@ void CodeGenTileLangMetal::VisitExpr_(const CastNode *op,
 }
 
 std::string
-CodeGenTileLangMetal::GetAddrSpaceOf(const PrimExpr &ptr_expr) const {
-  if (auto *call = ptr_expr.as<CallNode>()) {
-    if (call->op.same_as(builtin::address_of())) {
-      if (auto *load = call->args[0].as<BufferLoadNode>()) {
-        auto it = alloc_storage_scope_.find(load->buffer->data.get());
-        if (it != alloc_storage_scope_.end()) {
-          const std::string &scope = it->second;
-          if (scope == "shared" || scope == "shared.dyn") {
-            return "threadgroup";
-          }
-          if (scope == "local" || scope == "metal.cooperative_tensor") {
-            return "thread";
-          }
-          if (scope == "global") {
-            return "device";
-          }
-        }
-      }
-    }
-    for (const auto &arg : call->args) {
-      std::string result = GetAddrSpaceOf(arg);
-      if (!result.empty()) {
-        return result;
-      }
-    }
-  }
+CodeGenTileLangMetal::GetStorageScopeOf(const PrimExpr &ptr_expr) const {
   if (auto *var = ptr_expr.as<VarNode>()) {
     auto it = alloc_storage_scope_.find(var);
     if (it != alloc_storage_scope_.end()) {
-      const std::string &scope = it->second;
-      if (scope == "shared" || scope == "shared.dyn") {
-        return "threadgroup";
-      }
-      if (scope == "local" || scope == "metal.cooperative_tensor") {
-        return "thread";
-      }
-      if (scope == "global") {
-        return "device";
+      return it->second;
+    }
+    if (const auto *pointer_type = var->type_annotation.as<PointerTypeNode>()) {
+      if (!pointer_type->storage_scope.empty()) {
+        return pointer_type->storage_scope;
       }
     }
   }
-  return "thread";
+  if (auto *call = ptr_expr.as<CallNode>()) {
+    if (call->op.same_as(builtin::address_of())) {
+      TVM_FFI_ICHECK_EQ(call->args.size(), 1U);
+      if (auto *load = call->args[0].as<BufferLoadNode>()) {
+        return GetStorageScopeOf(load->buffer->data);
+      }
+    } else if (call->op.same_as(builtin::handle_add_byte_offset())) {
+      TVM_FFI_ICHECK_EQ(call->args.size(), 2U);
+      return GetStorageScopeOf(call->args[0]);
+    } else if (call->op.same_as(builtin::tvm_access_ptr())) {
+      TVM_FFI_ICHECK_GE(call->args.size(), 2U);
+      return GetStorageScopeOf(call->args[1]);
+    } else if (call->op.same_as(builtin::reinterpret())) {
+      TVM_FFI_ICHECK_EQ(call->args.size(), 1U);
+      return GetStorageScopeOf(call->args[0]);
+    }
+  }
+  return "";
+}
+
+std::string
+CodeGenTileLangMetal::GetAddrSpaceOf(const PrimExpr &ptr_expr) const {
+  std::string storage_scope = GetStorageScopeOf(ptr_expr);
+  TVM_FFI_ICHECK(!storage_scope.empty())
+      << "Cannot determine Metal storage scope for pointer expression "
+      << ptr_expr;
+  return MetalAddressSpaceForStorageScope(storage_scope);
 }
 
 std::string
 CodeGenTileLangMetal::GetPointeeTypeOf(const PrimExpr &ptr_expr,
                                        const std::string &fallback) {
-  if (auto *call = ptr_expr.as<CallNode>()) {
-    if (call->op.same_as(builtin::address_of())) {
-      if (auto *load = call->args[0].as<BufferLoadNode>()) {
-        std::ostringstream os;
-        PrintType(load->buffer->dtype, os);
-        return os.str();
-      }
-    }
-    for (const auto &arg : call->args) {
-      std::string result = GetPointeeTypeOf(arg, "");
-      if (!result.empty()) {
-        return result;
-      }
-    }
-  }
   if (auto *var = ptr_expr.as<VarNode>()) {
     auto it = handle_data_type_.find(var);
     if (it != handle_data_type_.end()) {
       std::ostringstream os;
       PrintType(it->second, os);
       return os.str();
+    }
+    if (const auto *pointer_type = var->type_annotation.as<PointerTypeNode>()) {
+      if (const auto *element_type =
+              pointer_type->element_type.as<PrimTypeNode>()) {
+        std::ostringstream os;
+        PrintType(element_type->dtype, os);
+        return os.str();
+      }
+    }
+  }
+  if (auto *call = ptr_expr.as<CallNode>()) {
+    if (call->op.same_as(builtin::address_of())) {
+      TVM_FFI_ICHECK_EQ(call->args.size(), 1U);
+      if (auto *load = call->args[0].as<BufferLoadNode>()) {
+        std::ostringstream os;
+        PrintType(load->buffer->dtype, os);
+        return os.str();
+      }
+    } else if (call->op.same_as(builtin::handle_add_byte_offset())) {
+      TVM_FFI_ICHECK_EQ(call->args.size(), 2U);
+      return GetPointeeTypeOf(call->args[0], fallback);
+    } else if (call->op.same_as(builtin::tvm_access_ptr())) {
+      TVM_FFI_ICHECK_GE(call->args.size(), 2U);
+      return GetPointeeTypeOf(call->args[1], fallback);
+    } else if (call->op.same_as(builtin::reinterpret())) {
+      TVM_FFI_ICHECK_EQ(call->args.size(), 1U);
+      return GetPointeeTypeOf(call->args[0], fallback);
     }
   }
   return fallback;
@@ -1642,11 +1694,9 @@ void CodeGenTileLangMetal::VisitExpr_(const CallNode *op,
     this->PrintExpr(op->args[0], os);
     os << "))";
   } else if (op->op.same_as(builtin::handle_add_byte_offset())) {
-    // Dynamic shared memory pointer arithmetic.
-    // Metal requires explicit address space qualifiers on all pointers.
-    // The base class emits ((void*)((char*)...)) which is invalid in MSL.
     TVM_FFI_ICHECK_EQ(op->args.size(), 2U);
-    os << "((threadgroup void*)((threadgroup char*)";
+    std::string addr_space = GetAddrSpaceOf(op->args[0]);
+    os << "((" << addr_space << " void*)((" << addr_space << " char*)";
     this->PrintExpr(op->args[0], os);
     os << " + ";
     this->PrintExpr(op->args[1], os);
@@ -1707,113 +1757,6 @@ ffi::Module BuildTileLangMetal(IRModule mod, Target target) {
     cg.AddFunction(kv.first, f);
 
     std::string fsource = cg.Finish();
-    // MSL requires explicit address space qualifiers on all pointers.
-    // The CUDA-oriented codegen emits void* for shared memory handles
-    // and pointer arithmetic casts, which is invalid in MSL. Fix them.
-    // 1) void* declarations for shared memory aliases
-    {
-      std::string from = "void* ";
-      std::string to = "threadgroup void* ";
-      for (size_t pos = 0;
-           (pos = fsource.find(from, pos)) != std::string::npos;) {
-        // Skip if already qualified (idempotent)
-        if (pos >= 12 && fsource.substr(pos - 12, 12) == "threadgroup ") {
-          pos += from.length();
-          continue;
-        }
-        fsource.replace(pos, from.length(), to);
-        pos += to.length();
-      }
-    }
-    // 2) void* casts in pointer arithmetic (handle_add_byte_offset)
-    {
-      std::string from = "((void*)((char*)";
-      std::string to = "((threadgroup void*)((threadgroup char*)";
-      for (size_t pos = 0;
-           (pos = fsource.find(from, pos)) != std::string::npos;) {
-        // Skip if already qualified
-        if (pos >= 2 && fsource.substr(pos - 2, 14) == "((threadgroup v") {
-          pos += from.length();
-          continue;
-        }
-        fsource.replace(pos, from.length(), to);
-        pos += to.length();
-      }
-    }
-    // 3) Pointer casts (TYPE*) on shared memory handles
-    {
-      std::string from = "((float2*)A_shared)";
-      std::string to = "((threadgroup float2*)A_shared)";
-      for (size_t pos = 0;
-           (pos = fsource.find(from, pos)) != std::string::npos;) {
-        if (pos >= 2 && fsource.substr(pos, 14) == "((threadgroup ") {
-          pos += from.length();
-          continue;
-        }
-        fsource.replace(pos, from.length(), to);
-        pos += to.length();
-      }
-    }
-    {
-      std::string from = "((float2*)B_shared)";
-      std::string to = "((threadgroup float2*)B_shared)";
-      for (size_t pos = 0;
-           (pos = fsource.find(from, pos)) != std::string::npos;) {
-        if (pos >= 2 && fsource.substr(pos, 14) == "((threadgroup ") {
-          pos += from.length();
-          continue;
-        }
-        fsource.replace(pos, from.length(), to);
-        pos += to.length();
-      }
-    }
-    // 4) Generalize: any ((TYPE*)_shared) pattern
-    {
-      size_t pos = 0;
-      while ((pos = fsource.find("*)_shared", pos)) != std::string::npos) {
-        size_t open = fsource.rfind("((", pos);
-        if (open != std::string::npos) {
-          // Skip if already has threadgroup qualifier
-          if (fsource.substr(open, 14) != "((threadgroup ") {
-            fsource.insert(open + 2, "threadgroup ");
-          }
-          pos = open + 2 + 12;
-        } else {
-          pos += 1;
-        }
-      }
-    }
-    // 5) Line-level: any line containing _shared → fix ALL pointer casts.
-    //    After passes 1-4, some casts still lack threadgroup because _shared
-    //    is nested inside the expression. This pass finds any (TYPE*) on a
-    //    _shared line and inserts the threadgroup qualifier if missing.
-    {
-      std::istringstream iss(fsource);
-      std::ostringstream oss;
-      std::string line;
-      while (std::getline(iss, line)) {
-        if (line.find("_shared") != std::string::npos) {
-          for (size_t i = 0; i + 3 < line.length(); i++) {
-            if (line[i] == '(') {
-              if (line.substr(i, 14) == "(threadgroup ") {
-                i += 13;
-                continue;
-              }
-              size_t j = i + 1;
-              while (j < line.length() && (isalnum(line[j]) || line[j] == '_'))
-                j++;
-              if (j < line.length() && line[j] == '*' &&
-                  j + 1 < line.length() && line[j + 1] == ')') {
-                line.insert(i + 1, "threadgroup ");
-                i += 12;
-              }
-            }
-          }
-        }
-        oss << line << "\n";
-      }
-      fsource = oss.str();
-    }
     source_maker << fsource << "\n";
     if (fmetal_postproc) {
       fsource = (*fmetal_postproc)(fsource, target).cast<std::string>();

--- a/src/metal/codegen/codegen_metal.h
+++ b/src/metal/codegen/codegen_metal.h
@@ -58,6 +58,7 @@ public:
   void PrintVecElemStore(const std::string &vec, DataType t, int i,
                          const std::string &value) final;
   // overload visitor
+  void VisitStmt_(const BindNode *op) final;                        // NOLINT(*)
   void VisitStmt_(const AllocBufferNode *op) final;                 // NOLINT(*)
   void VisitStmt_(const AttrStmtNode *op) final;                    // NOLINT(*)
   void VisitStmt_(const ForNode *op) final;                         // NOLINT(*)
@@ -72,6 +73,7 @@ public:
   using CodeGenC::PrintType;
 
 private:
+  std::string GetStorageScopeOf(const PrimExpr &ptr_expr) const;
   std::string GetAddrSpaceOf(const PrimExpr &ptr_expr) const;
   std::string GetPointeeTypeOf(const PrimExpr &ptr_expr,
                                const std::string &fallback);

--- a/testing/python/metal/test_metal_address_space.py
+++ b/testing/python/metal/test_metal_address_space.py
@@ -1,0 +1,96 @@
+"""Regression tests for type-driven Metal pointer address spaces."""
+
+import re
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+
+
+M = N = K = 128
+BLOCK_M = BLOCK_N = 16
+BLOCK_K = 8
+THREADS = 64
+
+
+def shared_alias_gemm():
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((M, K), T.float16),
+        B: T.Tensor((K, N), T.float16),
+        C: T.Tensor((M, N), T.float32),
+    ):
+        with T.Kernel(
+            T.ceildiv(N, BLOCK_N),
+            T.ceildiv(M, BLOCK_M),
+            threads=THREADS,
+        ) as (bx, by):
+            As = T.alloc_shared((BLOCK_M, BLOCK_K), T.float16)
+            Bs = T.alloc_shared((BLOCK_K, BLOCK_N), T.float16)
+            Cl = T.alloc_shared((BLOCK_M, BLOCK_N), T.float32)
+
+            T.clear(Cl)
+            for k in T.serial(T.ceildiv(K, BLOCK_K)):
+                T.copy(A[by * BLOCK_M, k * BLOCK_K], As)
+                T.copy(B[k * BLOCK_K, bx * BLOCK_N], Bs)
+                T.gemm(As, Bs, Cl)
+            T.copy(Cl, C[by * BLOCK_M, bx * BLOCK_N])
+
+    return kernel
+
+
+def lower_to_metal(enable_device_compile: bool) -> str:
+    target = tvm.target.Target("metal", tvm.target.Target("llvm"))
+    with target:
+        artifact = tilelang.lower(
+            shared_alias_gemm(),
+            target=target,
+            target_host="llvm",
+            enable_host_codegen=False,
+            enable_device_compile=enable_device_compile,
+        )
+    return artifact.kernel_source or ""
+
+
+def test_both_metal_build_paths_use_type_driven_shared_aliases(monkeypatch):
+    monkeypatch.setenv("TVM_COMPILE_FORCE_FALLBACK", "1")
+    compiled_source = lower_to_metal(enable_device_compile=True)
+    source_only = lower_to_metal(enable_device_compile=False)
+
+    assert compiled_source == source_only
+    aliases = re.findall(
+        r"threadgroup half\* (\w+) = \(threadgroup half\*\)",
+        compiled_source,
+    )
+    assert len(aliases) >= 2, compiled_source
+    for alias in aliases:
+        assert f"*(threadgroup half2*)({alias} +" in compiled_source
+        assert f"(half*){alias}" not in compiled_source
+
+
+@tilelang.testing.requires_metal
+@pytest.mark.parametrize("execution_backend", ["tvm_ffi", "torch"])
+def test_shared_alias_address_spaces_execute_on_metal(execution_backend):
+    kernel = tilelang.compile(
+        shared_alias_gemm(),
+        target="metal",
+        execution_backend=execution_backend,
+    )
+
+    a = torch.randn(M, K, dtype=torch.float16, device="mps")
+    b = torch.randn(K, N, dtype=torch.float16, device="mps")
+    c = torch.zeros(M, N, dtype=torch.float32, device="mps")
+
+    kernel(a, b, c)
+    torch.mps.synchronize()
+
+    expected = a.float() @ b.float()
+    assert torch.allclose(c, expected, atol=1e-2, rtol=1e-2)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/metal/test_metal_address_space.py
+++ b/testing/python/metal/test_metal_address_space.py
@@ -53,7 +53,9 @@ def lower_to_metal(enable_device_compile: bool) -> str:
             enable_host_codegen=False,
             enable_device_compile=enable_device_compile,
         )
-    return artifact.kernel_source or ""
+    source = artifact.kernel_source
+    assert source, f"empty Metal kernel source (enable_device_compile={enable_device_compile})"
+    return source
 
 
 def test_both_metal_build_paths_use_type_driven_shared_aliases(monkeypatch):
@@ -67,9 +69,11 @@ def test_both_metal_build_paths_use_type_driven_shared_aliases(monkeypatch):
         compiled_source,
     )
     assert len(aliases) >= 2, compiled_source
-    for alias in aliases:
-        assert f"*(threadgroup half2*)({alias} +" in compiled_source
-        assert f"(half*){alias}" not in compiled_source
+    unqualified_pointer_casts = re.findall(
+        r"\((?:half\d*|char|void)\*\)",
+        compiled_source,
+    )
+    assert not unqualified_pointer_casts, compiled_source
 
 
 @tilelang.testing.requires_metal
@@ -81,6 +85,7 @@ def test_shared_alias_address_spaces_execute_on_metal(execution_backend):
         execution_backend=execution_backend,
     )
 
+    torch.manual_seed(0)
     a = torch.randn(M, K, dtype=torch.float16, device="mps")
     b = torch.randn(K, N, dtype=torch.float16, device="mps")
     c = torch.zeros(M, N, dtype=torch.float32, device="mps")


### PR DESCRIPTION
## Problem

1. Metal requires pointer declarations and pointer casts to carry an explicit address-space qualifier.

2. Shared-memory aliases created through `BindNode` and `handle_add_byte_offset` could reach the MSL compiler as unqualified pointers. The current build path then tried to repair the generated source with five string-rewrite passes, including rules tied to names such as `A_shared`, `B_shared`, and `_shared`.

3. Equivalent kernels could therefore compile or fail depending on buffer names. A failing kernel is rejected before GPU execution with `pointer type must have explicit address space qualifier`.

## Root cause

1. The shared-memory merge pass preserves the pointee type and storage scope on the alias variable.

2. `CodeGenTileLangMetal` previously inherited generic C handling for pointer-valued `BindNode` statements, so that type information was not used when emitting the alias declaration.

3. `handle_add_byte_offset` was hard-coded to `threadgroup` instead of deriving its address space from the source pointer.

## Change

1. Emit pointer-valued `BindNode` declarations from their `PointerType`, including pointee dtype and storage scope.

2. Map TIR storage scopes to Metal `device`, `threadgroup`, and `thread` address spaces in one place.

3. Trace pointer storage scope and pointee type through variables, `address_of`, `handle_add_byte_offset`, `tvm_access_ptr`, and `reinterpret`.

4. Derive byte-offset casts from the source pointer and reject unresolved storage scopes.

5. Remove the five generated-source string rewrites. Both TileLang Metal build paths now consume the same type-correct codegen output.

## Upstream

1. The corresponding fix was accepted and merged as [Apache TVM #20101](https://github.com/apache/tvm/pull/20101).

2. This PR applies the same type-driven correction to TileLang own Metal codegen. It does not modify `3rdparty/tvm`.

## Validation

1. Hardware validation used a MacBook Air `Mac14,2` with Apple M2, macOS 15.6.1 `24G90`, Metal 3, Command Line Tools, and macOS SDK 15.5.

2. A full local `tilelang` build completed successfully from the current `main` base.

3. The focused regression passed through source-only codegen, compiled codegen, TVM FFI execution, and Torch execution on the M2 GPU:

```text
python -m pytest testing/python/metal/test_metal_address_space.py -q -ra
3 passed
```

4. The complete Metal test directory passed:

```text
python -m pytest testing/python/metal -q -ra
38 passed, 3 skipped
```

5. The three skips are the existing Metal 4 cooperative-tensor tests. They are not supported by the current M2 capability detector.

6. Repository checks passed:

```text
pre-commit run --all-files
All hooks passed
```

## Scope

1. The fix is independent of pointee dtype. The regression executes FP16 GEMM aliases, while address-space derivation is based on pointer storage scope.

2. The change is limited to TileLang Metal code generation and its regression coverage.

3. It does not change compilation pipelines, runtime dispatch, public APIs, serialized formats, or the `3rdparty/tvm` revision.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Preserve explicit Metal address-space qualifiers during pointer byte-offset code generation.
- Centralize TIR storage-scope to Metal address-space mapping.
- Propagate storage scopes and pointee types through pointer operations.
- Validate typed pointer bindings and reject unresolved address spaces.
- Remove five generated-source string-rewrite passes.
- Add regression tests for shared-memory pointer aliases across Metal compilation paths.

## Validation

- Focused regression tests: 3 passed.
- Full Metal tests: 38 passed, 3 skipped for unsupported Metal 4 cooperative tensors.
- Pre-commit hooks passed on Apple M2.

## C++ style / lint notes

- The PR changes C++ code and the `CodeGenTileLangMetal` declaration.
- The PR does not change the documented rules in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit remains warning-only.
- No correctness or build issues are identified. Advisory style warnings should not block this change unless they indicate a new API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->