### PR TITLE
[BugFix][CUDA] Restore cp.async for predicated zero-fill copies

### DIFF
--- a/src/transform/pipeline_planning.cc
+++ b/src/transform/pipeline_planning.cc
@@ -3,6 +3,7 @@
 #include <map>
 #include <numeric>
 #include <tvm/arith/analyzer.h>
+#include <tvm/ffi/extra/structural_equal.h>
 #include <tvm/ir/cast.h>
 #include <tvm/runtime/logging.h>
 #include <tvm/s_tir/stmt.h>
@@ -436,6 +437,7 @@ struct PipelineStageInfo {
   bool copy_stage = false;
   bool tma_copy = false; // true if this copy stage uses TMA (not cp.async)
   bool conditional_execution = false;
+  bool total_zero_fill_copy = false;
   bool producer_for_copy = false;
   int last_use_stmt_index =
       -1; // Initialized to -1, indicating no consumers found yet
@@ -498,13 +500,91 @@ public:
   }
 
   bool IsAsyncProducerCandidate(const PipelineStageInfo &pinfo) const {
-    if (pinfo.conditional_execution) {
+    // A guarded global-to-shared copy with an explicit zero-fill else branch
+    // defines the same shared location on every path.  It is therefore a
+    // total SIMT copy, unlike a generic conditionally executed producer.
+    if (pinfo.conditional_execution && !pinfo.total_zero_fill_copy) {
       return false;
     }
     if (pinfo.IsTmaCopy()) {
       return false;
     }
     return pinfo.IsCopyStage();
+  }
+
+  static bool IsZeroValue(const PrimExpr &expr) {
+    if (const auto *broadcast = expr.as<BroadcastNode>()) {
+      return IsZeroValue(broadcast->value);
+    }
+    if (const auto *float_imm = expr.as<FloatImmNode>()) {
+      return float_imm->value == 0.0;
+    }
+    if (const auto *int_imm = expr.as<IntImmNode>()) {
+      return int_imm->value == 0;
+    }
+    return false;
+  }
+
+  static const BufferLoadNode *MatchGlobalLoad(const PrimExpr &expr) {
+    if (const auto *load = expr.as<BufferLoadNode>()) {
+      return IsGlobalBuffer(load->buffer) ? load : nullptr;
+    }
+    return nullptr;
+  }
+
+  static const BufferStoreNode *MatchSingleBufferStore(const Stmt &stmt) {
+    if (const auto *store = stmt.as<BufferStoreNode>()) {
+      return store;
+    }
+    if (const auto *seq = stmt.as<SeqStmtNode>()) {
+      return seq->seq.size() == 1 ? MatchSingleBufferStore(seq->seq[0])
+                                  : nullptr;
+    }
+    return nullptr;
+  }
+
+  static bool ArePureExprs(const Array<PrimExpr> &exprs) {
+    return std::all_of(exprs.begin(), exprs.end(), [](const PrimExpr &expr) {
+      return SideEffect(expr) <= CallEffectKind::kPure;
+    });
+  }
+
+  bool IsTotalZeroFillCopyStmt(const Stmt &stmt,
+                               bool inside_parallel = false) const {
+    if (const auto *loop = stmt.as<ForNode>()) {
+      if (loop->kind != ForKind::kParallel ||
+          SideEffect(loop->min) > CallEffectKind::kPure ||
+          SideEffect(loop->extent) > CallEffectKind::kPure) {
+        return false;
+      }
+      return IsTotalZeroFillCopyStmt(loop->body, true);
+    }
+    if (const auto *seq = stmt.as<SeqStmtNode>()) {
+      return seq->seq.size() == 1
+                 ? IsTotalZeroFillCopyStmt(seq->seq[0], inside_parallel)
+                 : false;
+    }
+    const auto *conditional = stmt.as<IfThenElseNode>();
+    if (!inside_parallel || conditional == nullptr ||
+        !conditional->else_case.defined() ||
+        SideEffect(conditional->condition) > CallEffectKind::kPure) {
+      return false;
+    }
+    const BufferStoreNode *copy =
+        MatchSingleBufferStore(conditional->then_case);
+    const BufferStoreNode *zero_fill =
+        MatchSingleBufferStore(conditional->else_case.value());
+    if (copy == nullptr || zero_fill == nullptr ||
+        !copy->buffer.same_as(zero_fill->buffer) ||
+        !IsSharedBuffer(copy->buffer) ||
+        !StructuralEqual()(copy->indices, zero_fill->indices) ||
+        !ArePureExprs(copy->indices) || !ArePureExprs(zero_fill->indices) ||
+        copy->predicate.defined() || zero_fill->predicate.defined()) {
+      return false;
+    }
+    const BufferLoadNode *load = MatchGlobalLoad(copy->value);
+    return load != nullptr && ArePureExprs(load->indices) &&
+           !load->predicate.defined() && IsZeroValue(zero_fill->value);
   }
 
   bool IsPureCopyStmt(const Stmt &stmt) const {
@@ -994,9 +1074,11 @@ public:
     pinfo.scalar_uses = std::move(scalar_uses);
     pinfo.original_stmt_index = idx;
     pinfo.conditional_execution = MayBeConditionallyExecuted(block->body);
+    pinfo.total_zero_fill_copy = collector.GetGlobalCopyPattern() &&
+                                 IsTotalZeroFillCopyStmt(block->body);
     bool pure_copy_stage =
         collector.GetGlobalCopyPattern() && IsPureCopyStmt(block->body);
-    pinfo.copy_stage = pure_copy_stage;
+    pinfo.copy_stage = pure_copy_stage || pinfo.total_zero_fill_copy;
     pinfo.tma_copy = pure_copy_stage && !pinfo.conditional_execution &&
                      collector.GetTmaCopyPattern();
     ClassifyCopyLikeStage(block->body, &pinfo);

--- a/testing/python/issue/test_tilelang_issue_2759.py
+++ b/testing/python/issue/test_tilelang_issue_2759.py
@@ -1,0 +1,41 @@
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(8, 0)
+def test_predicated_pipeline_copy_uses_cp_async_and_zero_fills():
+    length = 514
+    tile_size = 512
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((length,), T.float16),
+        B: T.Tensor((2 * tile_size,), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((tile_size,), T.float16)
+            for tile in T.Pipelined(2, num_stages=1):
+                for i in T.Parallel(tile_size):
+                    if tile * tile_size + i < length:
+                        A_shared[i] = A[tile * tile_size + i]
+                    else:
+                        A_shared[i] = T.float16(0)
+                for i in T.Parallel(tile_size):
+                    B[tile * tile_size + i] = A_shared[i]
+
+    kernel = tilelang.compile(main, out_idx=[1], target="cuda")
+    assert "cp_async_gs" in kernel.get_kernel_source()
+
+    a = torch.arange(length, device="cuda", dtype=torch.float16)
+    b = kernel(a)
+    expected = torch.zeros(2 * tile_size, device="cuda", dtype=torch.float16)
+    expected[:length] = a
+    torch.testing.assert_close(b, expected, rtol=0, atol=0)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_pipeline_planning.py
+++ b/testing/python/transform/test_tilelang_transform_pipeline_planning.py
@@ -666,6 +666,124 @@ def test_pipeline_planning_recognizes_parallel_bufferstore_copy_stages():
     assert async_groups == [0, 0, -1]
 
 
+def test_pipeline_planning_recognizes_predicated_zero_fill_parallel_copy():
+    @T.prim_func
+    def before(
+        A: T.Tensor((130,), T.float16),
+        B: T.Tensor((2,), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((128,), T.float16)
+            for ko in T.Pipelined(2, num_stages=1):
+                for i in T.Parallel(128):
+                    if ko * 128 + i < 130:
+                        A_shared[i] = A[ko * 128 + i]
+                    else:
+                        A_shared[i] = T.float16(0)
+                B[ko] = A_shared[0]
+
+    mod = _run_pipeline_planning(before, sm80_target)
+    annos = _collect_pipeline_loop_annotations(mod["main"])
+    assert annos, "Expected at least one loop annotated by PipelinePlanning"
+    anno = annos[0]
+    stages = [int(v) for v in anno["software_pipeline_stage"]]
+    orders = [int(v) for v in anno["software_pipeline_order"]]
+    async_producers = [int(v) for v in anno["software_pipeline_async_producers"]]
+    async_groups = [int(v) for v in anno["software_pipeline_async_producer_groups"]]
+    assert stages == [0, 1]
+    assert orders == [1, 0]
+    assert async_producers == [1, 0]
+    assert async_groups == [0, -1]
+
+
+def test_pipeline_planning_keeps_nonzero_fallback_copy_synchronous():
+    @T.prim_func
+    def before(
+        A: T.Tensor((130,), T.float16),
+        B: T.Tensor((2,), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((128,), T.float16)
+            for ko in T.Pipelined(2, num_stages=1):
+                for i in T.Parallel(128):
+                    if ko * 128 + i < 130:
+                        A_shared[i] = A[ko * 128 + i]
+                    else:
+                        A_shared[i] = T.float16(1)
+                B[ko] = A_shared[0]
+
+    mod = _run_pipeline_planning(before, sm80_target)
+    annos = _collect_pipeline_loop_annotations(mod["main"])
+    assert annos, "Expected at least one loop annotated by PipelinePlanning"
+    assert "software_pipeline_async_producers" not in annos[0]
+
+
+def test_pipeline_planning_keeps_partial_guarded_copy_synchronous():
+    @T.prim_func
+    def before(
+        A: T.Tensor((130,), T.float16),
+        B: T.Tensor((2,), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((128,), T.float16)
+            for ko in T.Pipelined(2, num_stages=1):
+                for i in T.Parallel(128):
+                    if ko * 128 + i < 130:
+                        A_shared[i] = A[ko * 128 + i]
+                B[ko] = A_shared[0]
+
+    mod = _run_pipeline_planning(before, sm80_target)
+    annos = _collect_pipeline_loop_annotations(mod["main"])
+    assert annos, "Expected at least one loop annotated by PipelinePlanning"
+    assert "software_pipeline_async_producers" not in annos[0]
+
+
+def test_pipeline_planning_keeps_state_dependent_guarded_copy_synchronous():
+    @T.prim_func
+    def before(
+        A: T.Tensor((256,), T.float16),
+        Mask: T.Tensor((256,), T.int32),
+        B: T.Tensor((2,), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((128,), T.float16)
+            for ko in T.Pipelined(2, num_stages=1):
+                for i in T.Parallel(128):
+                    if Mask[ko * 128 + i] != 0:
+                        A_shared[i] = A[ko * 128 + i]
+                    else:
+                        A_shared[i] = T.float16(0)
+                B[ko] = A_shared[0]
+
+    mod = _run_pipeline_planning(before, sm80_target)
+    annos = _collect_pipeline_loop_annotations(mod["main"])
+    assert annos, "Expected at least one loop annotated by PipelinePlanning"
+    assert "software_pipeline_async_producers" not in annos[0]
+
+
+def test_pipeline_planning_keeps_state_dependent_index_copy_synchronous():
+    @T.prim_func
+    def before(
+        A: T.Tensor((256,), T.float16),
+        Indices: T.Tensor((256,), T.int32),
+        B: T.Tensor((2,), T.float16),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared((128,), T.float16)
+            for ko in T.Pipelined(2, num_stages=1):
+                for i in T.Parallel(128):
+                    if ko * 128 + i < 256:
+                        A_shared[i] = A[Indices[ko * 128 + i]]
+                    else:
+                        A_shared[i] = T.float16(0)
+                B[ko] = A_shared[0]
+
+    mod = _run_pipeline_planning(before, sm80_target)
+    annos = _collect_pipeline_loop_annotations(mod["main"])
+    assert annos, "Expected at least one loop annotated by PipelinePlanning"
+    assert "software_pipeline_async_producers" not in annos[0]
+
+
 def test_pipeline_planning_marks_async_producers_per_statement():
     @T.prim_func
     def before(A: T.Tensor((1024, 32), T.float32), B: T.Tensor((32, 1024), T.float32), C: T.Tensor((1024, 1024), T.float32)):


### PR DESCRIPTION
Fixes #2759.

A bounds-checked global-to-shared copy with a zero-fill else branch writes the same shared-memory location on every path, but PipelinePlanning currently rejects it as a conditional async producer.

This recognizes only that total-copy pattern. Loop bounds, the condition, and all source and destination indices must be pure; partial copies, nonzero fallbacks, and state-dependent guards or indices remain synchronous.

Tested:
- 48 passed, 3 skipped across the affected pipeline planning and lowering tests
- GB10 runtime check for cp.async emission and zero-filled tail values
- original sm90 reproducer emits 32 cp.async.cg.shared.global sites and 32 LDGSTS sites, matching v0.1.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Restores `cp.async` lowering for pure, predicated global-to-shared copies with total zero-fill fallbacks.
- Keeps partial copies, nonzero fallbacks, missing fallbacks, state-dependent guards, and state-dependent indices synchronous.
- Adds `total_zero_fill_copy` metadata to `PipelineStageInfo`.
- Adds pipeline-planning tests and a CUDA regression test for zero-filled tail elements.

## Validation

- 48 tests passed and 3 were skipped.
- GB10 runtime validation confirmed `cp.async` generation and correct zero-filled tail values.
- The sm90 reproducer emitted 32 `cp.async.cg.shared.global` instructions and 32 LDGSTS sites.

## C++ style / lint notes

- The PR changes C++ in `src/transform/pipeline_planning.cc`.
- The PR does not change `docs/developer_guide/cpp_style.md`.
- That guide documents the C++ API style audit.
- CI runs `C++ API Style Audit (warning only)`.
- No audit findings were provided. TLCPP003/TLCPP004 warnings are advisory and should not block merging without a clear API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->