### PR TITLE
[BugFix][Hopper] Select the widest legal WGMMA N instead of gcd

### DIFF
--- a/testing/python/issue/test_tilelang_issue_2928.py
+++ b/testing/python/issue/test_tilelang_issue_2928.py
@@ -64,8 +64,9 @@ def _matmul_nt(M, N, K, block_M, block_N, block_K):
     return main
 
 
-def _emitted_wgmma_shapes(kernel):
-    return sorted(set(re.findall(r"wgmma_ss<[^>]*?, (\d+, \d+, \d+),", kernel.get_kernel_source())))
+def _emitted_shapes(kernel, op):
+    """Distinct ``m, n, k`` operands emitted for ``op`` (``wgmma_ss``, ``wgmma_sp_ss``)."""
+    return sorted(set(re.findall(rf"{op}<[^>]*?, (\d+, \d+, \d+),", kernel.get_kernel_source())))
 
 
 @tilelang.testing.requires_cuda_compute_version_eq(9, 0)
@@ -75,7 +76,7 @@ def test_gemm_emits_single_wide_wgmma(block_N):
     N = block_N * 2
 
     kernel = tilelang.compile(_matmul_nt(M, N, K, block_M, block_N, block_K))
-    assert _emitted_wgmma_shapes(kernel) == [f"64, {block_N}, 16"]
+    assert _emitted_shapes(kernel, "wgmma_ss") == [f"64, {block_N}, 16"]
 
     torch.manual_seed(0)
     a = torch.randn(M, K, dtype=torch.float16, device="cuda")
@@ -83,6 +84,58 @@ def test_gemm_emits_single_wide_wgmma(block_N):
     c = torch.empty(M, N, dtype=torch.float16, device="cuda")
     kernel(a, b, c)
     torch.testing.assert_close(c, (a.float() @ b.float().T).half(), rtol=1e-2, atol=1e-2)
+
+
+def _matmul_sp_nt(M, N, K, block_M, block_N, block_K, e_factor):
+    dtype, accum_dtype, meta_dtype = "float16", "float", "int16"
+
+    @T.prim_func
+    def main(
+        A_sparse: T.Tensor((M, K // 2), dtype),
+        E: T.Tensor((M, K // e_factor), meta_dtype),
+        B: T.Tensor((N, K), dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K // 2), dtype)
+            E_shared = T.alloc_shared((block_M, block_K // e_factor), meta_dtype)
+            B_shared = T.alloc_shared((block_N, block_K), dtype)
+            C_frag = T.alloc_fragment((block_M, block_N), accum_dtype)
+            T.clear(C_frag)
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=2):
+                T.copy(E[by * block_M, k * block_K // e_factor], E_shared)
+                T.copy(A_sparse[by * block_M, k * block_K // 2], A_shared)
+                T.copy(B[bx * block_N, k * block_K], B_shared)
+                T.gemm_sp(A_shared, E_shared, B_shared, C_frag, False, False, True)
+            T.copy(C_frag, C[by * block_M, bx * block_N])
+
+    return main
+
+
+@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
+@pytest.mark.parametrize("block_N", [96, 112, 160])
+def test_gemm_sp_emits_single_wide_wgmma(block_N):
+    # Imported inside the sm_90 gate so collection never depends on examples/.
+    from examples.gemm_sp.sparse_utils import compress, get_e_factor, randn_semi_sparse
+
+    M, K, block_M, block_K = 128, 32, 128, 32
+    N = block_N * 2
+    e_factor = get_e_factor(T.float16, T.int16)
+
+    kernel = tilelang.compile(
+        _matmul_sp_nt(M, N, K, block_M, block_N, block_K, e_factor),
+        out_idx=[3],
+        pass_configs={tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True},
+    )
+    # Sparse WGMMA doubles K per instruction: 512 bits / 16 bits per element.
+    assert _emitted_shapes(kernel, "wgmma_sp_ss") == [f"64, {block_N}, 32"]
+
+    torch.manual_seed(0)
+    a = randn_semi_sparse(M, K, dtype=torch.float16, device="cuda")
+    b = torch.randn(N, K, dtype=torch.float16, device="cuda")
+    a_sparse, e = compress(a, meta_dtype=torch.int16)
+    c = kernel(a_sparse, e, b)
+    torch.testing.assert_close(c.float(), a.float() @ b.float().T, rtol=1e-2, atol=1e-2)
 
 
 if __name__ == "__main__":

--- a/testing/python/issue/test_tilelang_issue_2928.py
+++ b/testing/python/issue/test_tilelang_issue_2928.py
@@ -1,0 +1,89 @@
+"""Regression test for GitHub issue #2928.
+
+A ``block_N`` that is itself a legal Hopper WGMMA width (96, 112, 160, ...)
+must lower to a single ``m64nNk16`` instruction.  Deriving the instruction
+width from ``gcd(warp_col_tiles, 256)`` decomposed those extents into n32 / n16
+atoms and gave up most of the tensor-core throughput.
+"""
+
+import re
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.cuda.intrinsics.macro.wgmma_macro_generator import select_wgmma_inst_n
+
+
+@pytest.mark.parametrize(
+    "warp_col_tiles, expected",
+    [
+        # Legal single-instruction extents: keep the whole width.
+        (64, 64),
+        (96, 96),
+        (112, 112),
+        (160, 160),
+        (176, 176),
+        (256, 256),
+        # ``N % 16 == 8`` is a separately broken class (issue #2593); the width
+        # selection is left exactly as it was.
+        (24, 8),
+        (40, 8),
+        (88, 8),
+        # Past the 256 ceiling: widest legal divisor, which gcd cannot reach.
+        (384, 192),
+        (512, 256),
+    ],
+)
+def test_select_wgmma_inst_n(warp_col_tiles, expected):
+    assert select_wgmma_inst_n(warp_col_tiles) == expected
+
+
+def _matmul_nt(M, N, K, block_M, block_N, block_K):
+    dtype, accum_dtype = "float16", "float"
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), dtype),
+        B: T.Tensor((N, K), dtype),
+        C: T.Tensor((M, N), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), dtype)
+            B_shared = T.alloc_shared((block_N, block_K), dtype)
+            C_local = T.alloc_fragment((block_M, block_N), accum_dtype)
+            T.clear(C_local)
+            for k in T.Pipelined(T.ceildiv(K, block_K), num_stages=2):
+                T.copy(A[by * block_M, k * block_K], A_shared)
+                T.copy(B[bx * block_N, k * block_K], B_shared)
+                T.gemm(A_shared, B_shared, C_local, transpose_B=True)
+            T.copy(C_local, C[by * block_M, bx * block_N])
+
+    return main
+
+
+def _emitted_wgmma_shapes(kernel):
+    return sorted(set(re.findall(r"wgmma_ss<[^>]*?, (\d+, \d+, \d+),", kernel.get_kernel_source())))
+
+
+@tilelang.testing.requires_cuda_compute_version_eq(9, 0)
+@pytest.mark.parametrize("block_N", [96, 112, 160])
+def test_gemm_emits_single_wide_wgmma(block_N):
+    M, K, block_M, block_K = 128, 128, 64, 64
+    N = block_N * 2
+
+    kernel = tilelang.compile(_matmul_nt(M, N, K, block_M, block_N, block_K))
+    assert _emitted_wgmma_shapes(kernel) == [f"64, {block_N}, 16"]
+
+    torch.manual_seed(0)
+    a = torch.randn(M, K, dtype=torch.float16, device="cuda")
+    b = torch.randn(N, K, dtype=torch.float16, device="cuda")
+    c = torch.empty(M, N, dtype=torch.float16, device="cuda")
+    kernel(a, b, c)
+    torch.testing.assert_close(c, (a.float() @ b.float().T).half(), rtol=1e-2, atol=1e-2)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/cuda/intrinsics/macro/wgmma_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/wgmma_macro_generator.py
@@ -30,6 +30,30 @@ def _min_leaf_stride(stride) -> int:
     return int(stride)
 
 
+def select_wgmma_inst_n(warp_col_tiles: int) -> int:
+    """Widest legal WGMMA ``N`` that tiles ``warp_col_tiles`` exactly.
+
+    Hopper WGMMA accepts ``N`` in ``[8, 256]`` with ``N % 8 == 0``, so an extent
+    such as 96 or 160 is a single legal instruction.  Selecting
+    ``gcd(warp_col_tiles, 256)`` instead splits those into n32 / n16 atoms and
+    gives up most of the tensor-core throughput.
+
+    Widening is restricted to multiples of 16 for two independent reasons:
+    ``N % 16 == 8`` already miscomputes for ``warp_cols > 1`` (issue #2593), and
+    the integer instruction tables in ``wgmma.h`` / ``wgmma_sp.h`` only
+    instantiate multiples of 16 (plus 8 and 24), so a wider ``N % 16 == 8``
+    would not even compile for the s8 path.
+    """
+    # gcd is always a legal width, so it is the floor of the search.
+    fallback = gcd(warp_col_tiles, 256)
+    if warp_col_tiles % 16 != 0:
+        return fallback
+    for cand in range(256, fallback, -16):
+        if warp_col_tiles % cand == 0:
+            return cand
+    return fallback
+
+
 @dataclass(frozen=True)
 class WGMMADescriptorParams:
     """Pre-computed WGMMA descriptor parameters, produced by
@@ -243,7 +267,7 @@ class TensorCoreIntrinEmitter(MMAIntrinEmitter):
         return self
 
     def _initialize_wgmma_prefix(self, n_dim: int = 16):
-        inst_m, inst_n = 64, gcd(self.warp_col_tiles, 256)
+        inst_m, inst_n = 64, select_wgmma_inst_n(self.warp_col_tiles)
         assert inst_n % 8 == 0, (
             f"inst_n must be a multiple of 8, got {inst_n} (block_col_warps={self.block_col_warps}, warp_col_tiles={self.warp_col_tiles})"
         )

--- a/tilelang/cuda/intrinsics/macro/wgmma_sp_macro_generator.py
+++ b/tilelang/cuda/intrinsics/macro/wgmma_sp_macro_generator.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 from tilelang.cuda.intrinsics.macro.wgmma_macro_generator import (
     WGMMADescriptorParams,
     compute_gmma_descriptor,
-    gcd,
+    select_wgmma_inst_n,
 )
 from tilelang.cuda.intrinsics.macro.mma_sp_macro_generator import SparseTensorCoreIntrinEmitter
 import tilelang.language as T
@@ -85,7 +85,7 @@ class WGSparseTensorCoreIntrinEmitter(SparseTensorCoreIntrinEmitter):
         return self
 
     def _initialize_wgmma_prefix(self, n_dim: int = 16):
-        inst_m, inst_n = 64, gcd(self.warp_col_tiles, 256)
+        inst_m, inst_n = 64, select_wgmma_inst_n(self.warp_col_tiles)
         assert inst_n % 8 == 0, (
             f"inst_n must be a multiple of 8, got {inst_n} (block_col_warps={self.block_col_warps}, warp_col_tiles={self.warp_col_tiles})"
         )


### PR DESCRIPTION
On sm_90, a `T.gemm` whose N tile is a legal WGMMA width but not a power of two is decomposed into narrow instructions. `block_N = 96` lowers to `m64n32k16` and `block_N = 112` to `m64n16k16`, even though `m64n96k16` and `m64n112k16` are single legal instructions that `wgmma.h` already instantiates.

The practical effect is a non-monotonic performance cliff — a *larger* tile running *slower* than a smaller one. At `num_stages=4` below, `block_N=96` (228.0us) is slower than `block_N=64` (202.0us).

### Cause

`tilelang/cuda/intrinsics/macro/wgmma_macro_generator.py`:

```python
inst_m, inst_n = 64, gcd(self.warp_col_tiles, 256)
```

Hopper WGMMA accepts any `N` in `[8, 256]` with `N % 8 == 0`, but `gcd(_, 256)` can only ever return a power of two, so every extent with an odd factor collapses:

| `warp_col_tiles` | `gcd(_, 256)` | atoms | legal single instruction |
|---|---|---|---|
| 96 | 32 | 3 | `m64n96k16` |
| 112 | 16 | 7 | `m64n112k16` |
| 160 | 32 | 5 | `m64n160k16` |
| 176 | 16 | 11 | `m64n176k16` |

`src/tl_templates/cuda/instruction/wgmma.h` already instantiates every multiple of 8 from 8 to 256, so the templates were never the constraint — only the width selection was.

`wgmma_sp_macro_generator.py` carries the same line, so `T.gemm_sp` decomposes identically.

### Fix

Select the widest legal `N` that tiles `warp_col_tiles` exactly, falling back to the previous `gcd` value. Both generators now share one helper.

Widening is restricted to multiples of 16, for two independent reasons:

- `N % 16 == 8` already miscomputes for `warp_cols > 1` (#2593). This PR leaves that class on exactly its current width rather than changing the shape of a known-broken lowering.
- The **integer** instruction tables in `wgmma.h` and `wgmma_sp.h` only instantiate multiples of 16 (plus 8 and 24), so a wider `N % 16 == 8` would not compile on the s8 path.

The selected width is never narrower than the old `gcd` result, so no existing shape regresses.

### Validation

Built from source at `main@5a9b2a54`; H200 (sm_90a), CUDA 13.2. 4096x1920x4096 bf16 NT, warp-specialized mainloop, `block_M=64`, `block_K=128`. N is divisible by every `block_N` tested, so there is no tail-quantization confound. Median of 50 timed runs, same GPU for both columns.

| stages | `block_N` | inst before | us before | inst after | us after | speedup |
|---|---|---|---|---|---|---|
| 3 | 64 | `n64` | 232.6 | `n64` | 233.0 | — |
| 3 | 96 | `n32` | 222.2 | `n96` | 193.2 | **1.15x** |
| 3 | 128 | `n128` | 181.6 | `n128` | 182.2 | — |
| 3 | 160 | `n32` | 192.5 | `n160` | 159.3 | **1.21x** |
| 3 | 192 | `n64` | 152.4 | `n192` | 151.2 | — |
| 4 | 64 | `n64` | 202.0 | `n64` | 201.6 | — |
| 4 | 96 | `n32` | 228.0 | `n96` | 184.2 | **1.24x** |
| 4 | 128 | `n128` | 175.9 | `n128` | 176.4 | — |

Worth noting that `block_N=192` also changes instruction (`n64` -> `n192`) but does not get faster. The win is specifically about escaping the very narrow `n32` / `n16` instructions, not about reducing atom count in general. `block_N` 64 and 128 are unchanged because `gcd` already returned the whole extent for them.

### Tests

`testing/python/issue/test_tilelang_issue_2928.py`:

- `test_select_wgmma_inst_n` — pure Python, ungated, covers the widened extents, the untouched `N % 16 == 8` class, and the `> 256` path.
- `test_gemm_emits_single_wide_wgmma` — sm_90; asserts both the emitted instruction and numerical correctness for `block_N` in {96, 112, 160}.
- `test_gemm_sp_emits_single_wide_wgmma` — same, through `T.gemm_sp`, so the sparse generator's metadata and accumulator offsets are covered at the widened widths too.

Reverting only the selection line makes the sm_90 cases fail exactly as the table predicts — dense:

```
assert ['64, 32, 16'] == ['64, 96, 16']
assert ['64, 16, 16'] == ['64, 112, 16']
assert ['64, 32, 16'] == ['64, 160, 16']
```

and sparse, where WGMMA takes 512 bits of K per instruction:

```
assert ['64, 32, 32'] == ['64, 96, 32']
assert ['64, 16, 32'] == ['64, 112, 32']
assert ['64, 32, 32'] == ['64, 160, 32']
```

Existing suites pass on the same build (79 passed, 1 skipped): `test_tilelang_language_wgmma_gemm.py`, `test_tilelang_language_atom_mma.py`, `test_tilelang_tilelibrary_gemm_sp.py`. `pre-commit run --all-files` is clean.

`T.gemm_sp` is covered for correctness and emitted width but was not performance-tested; the change there is the same width selection.

Fixes #2928


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added shared `select_wgmma_inst_n` logic for dense and sparse Hopper WGMMA generators.
- Selects the widest legal N-width that divides `warp_col_tiles`.
- Restricts widened widths to multiples of 16.
- Preserves GCD-based selection as a fallback and retains existing behavior for `N % 16 == 8`.
- Added regression coverage for instruction selection, emitted WGMMA instructions, and numerical correctness.
- Enables wide instructions such as `m64n96k16`, `m64n112k16`, and `m64n160k16`.

## Testing

- Relevant test suites pass on compute capability 9.0 hardware.
- Ruff, formatting, and codespell checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->