### PR TITLE
[Enhancement] Expose cluster_mask on T.tma_copy

### DIFF
--- a/testing/python/language/test_tilelang_language_tma_copy.py
+++ b/testing/python/language/test_tilelang_language_tma_copy.py
@@ -635,9 +635,8 @@ def cluster_multicast_tma_copy_kernel(iters, slots, tile=64):
                 T.tma_copy(A[k, :, :], a_shared[slot, :, :], barrier=mbars[slot], cluster_mask=0b11)
                 T.mbarrier_arrive(mbarrier=mbars[slot])
                 T.mbarrier_wait_parity(mbarrier=mbars[slot], parity=parity)
+                # Plain T.copy already emits tma_store + arrive + wait.
                 T.copy(a_shared[slot, :, :], B[pid, k, :, :])
-                T.tma_store_arrive()
-                T.tma_store_wait(0)
 
     return main
 

--- a/testing/python/language/test_tilelang_language_tma_copy.py
+++ b/testing/python/language/test_tilelang_language_tma_copy.py
@@ -620,6 +620,50 @@ def test_tma_copy_store_pipeline_3_stages():
     run_gemm_tma_copy_store(num_stages=3)
 
 
+def cluster_multicast_tma_copy_kernel(iters, slots, tile=64):
+    @T.prim_func
+    def main(
+        A: T.Tensor((iters, tile, tile), T.float32),
+        B: T.Tensor((2, iters, tile, tile), T.float32),
+    ):
+        with T.ClusterKernel(2, threads=128, cluster_dims=(2, 1, 1)) as pid:
+            a_shared = T.alloc_shared((slots, tile, tile), dtype=T.float32)
+            mbars = T.alloc_barrier([128] * slots)
+            for k in T.serial(iters):
+                slot = k % slots
+                parity = (k // slots) % 2
+                T.tma_copy(A[k, :, :], a_shared[slot, :, :], barrier=mbars[slot], cluster_mask=0b11)
+                T.mbarrier_arrive(mbarrier=mbars[slot])
+                T.mbarrier_wait_parity(mbarrier=mbars[slot], parity=parity)
+                T.copy(a_shared[slot, :, :], B[pid, k, :, :])
+                T.tma_store_arrive()
+                T.tma_store_wait(0)
+
+    return main
+
+
+@tilelang.testing.requires_cuda_compute_version_ge(9, 0)
+def test_tma_copy_cluster_mask_multicast():
+    """cluster_mask multicasts while keeping tma_copy's split-phase contract.
+
+    The barrier ring is cycled more times than it has slots, so every slot is
+    reused under both parities. A fused wait, or a wait using the wrong parity,
+    would deadlock or return stale data here.
+    """
+    import torch
+
+    iters, slots = 8, 4
+    kernel = tilelang.compile(cluster_multicast_tma_copy_kernel(iters, slots), out_idx=[1])
+    assert "tma_load_multicast" in kernel.get_kernel_source()
+
+    torch.manual_seed(0)
+    A = torch.randn(iters, 64, 64, device="cuda", dtype=torch.float32)
+    B = kernel(A)
+    # Both CTAs of the cluster are in the mask, so both receive every tile.
+    for rank in range(2):
+        torch.testing.assert_close(B[rank], A)
+
+
 if __name__ == "__main__":
     tilelang.testing.main()
     # test_tma_copy_pipeline_2_stages()

--- a/tilelang/language/copy_op.py
+++ b/tilelang/language/copy_op.py
@@ -242,6 +242,7 @@ def tma_copy(
     dst: BufferLikeType,
     *,
     barrier=None,
+    cluster_mask: int | None = None,
     leader_scope_threads: int | None = None,
     eviction_policy: Literal["evict_normal", "evict_first", "evict_last"] | None = None,
     annotations: dict | None = None,
@@ -253,6 +254,13 @@ def tma_copy(
     T.tma_copy() emits only the producer part (expect_tx + tma_load).
     The user manages synchronization explicitly via T.barrier_arrive() and
     T.mbarrier_wait_parity(). ``barrier`` is required for loads.
+
+    ``cluster_mask`` turns a load into a TMA **multicast** within the thread-block
+    cluster while keeping that same split-phase contract, unlike T.copy_cluster()
+    whose multicast path also emits the wait. The lowest-ranked CTA in the mask
+    issues the multicast and the other in-mask CTAs issue nothing; a CTA *outside*
+    the mask falls back to its own unicast load. Every CTA runs its own expect_tx
+    against its local copy of ``barrier``, so each one waits on its own arrival.
 
     For **stores** (shared -> global): issues tma_store + tma_store_arrive (no wait).
     Unlike T.copy() which emits tma_store + tma_store_arrive + tma_store_wait,
@@ -269,6 +277,9 @@ def tma_copy(
             Required for loads (global -> shared). Not needed for stores.
             The TMA load will arrive at this barrier with expected byte count.
             The user must wait on the same barrier via T.mbarrier_wait_parity().
+        cluster_mask: Bitmask of the CTAs in the thread-block cluster that receive
+            a multicast load, e.g. ``0b11`` for the first two ranks. Loads only;
+            ``None`` issues an ordinary unicast load.
         leader_scope_threads: Number of threads in each TMA leader-election scope
             (e.g., 32 for per-warp). Defaults to the thread extend in the current context if not specified.
         eviction_policy: Cache eviction policy. Defaults to None.
@@ -300,6 +311,12 @@ def tma_copy(
         from .builtin import _mbar_to_buffer_load
 
         ann["barrier"] = _mbar_to_buffer_load(barrier)
+
+    if cluster_mask is not None:
+        if not isinstance(cluster_mask, int) or cluster_mask <= 0:
+            raise ValueError(f"cluster_mask must be a positive int bitmask, got {cluster_mask}")
+        if "cluster_mask" not in ann:
+            ann["cluster_mask"] = cluster_mask
 
     if leader_scope_threads is not None:
         if not isinstance(leader_scope_threads, int) or leader_scope_threads <= 0:


### PR DESCRIPTION
`T.tma_copy` has a split-phase contract: it issues the load and leaves `expect_tx` / arrive / wait-with-explicit-parity to the caller, which is what makes multi-stage pipelined mainloops expressible. `T.copy_cluster`'s multicast path is fused — it emits the wait too — so multicast has been unusable in exactly the place it pays off. That is #2929.

It turns out no new lowering is needed. In `LowerBulkCopy` (`src/cuda/op/copy.cc`) the two conditions are independent:

```cpp
bool use_multicast = is_load && (cluster_mask > 0);   // selects tma_load_multicast
...
if (GetIsTmaCopy(op)) { /* expect_tx only, no wait */ }
```

Neither excludes the other, and `tma_copy` forwards `annotations` verbatim, so `annotations={"cluster_mask": 0b11}` already produces an issue-only multicast today. The only thing missing was a documented parameter, so this PR adds one — same name and meaning as the `cluster_mask` that `copy_cluster` already exposes.

```python
T.tma_copy(A[k, :, :], a_shared[slot, :, :], barrier=mbars[slot], cluster_mask=0b11)
```

### Semantics recorded in the docstring

These are the existing lowering's behaviour, not new choices, and they were not written down anywhere:

- the lowest-ranked CTA in the mask issues the multicast; other in-mask CTAs issue nothing;
- a CTA **outside** the mask falls back to its own unicast load rather than being skipped;
- every CTA runs its own `expect_tx` against its local copy of `barrier`, so each waits on its own arrival.

`cluster_mask=0` raises rather than silently lowering to a plain unicast load. As with `leader_scope_threads` and `eviction_policy` in the same function, a value supplied through `annotations` keeps its documented precedence and is passed through unvalidated.

### Test

`test_tma_copy_cluster_mask_multicast` in `testing/python/language/test_tilelang_language_tma_copy.py` runs a 2-CTA cluster over a 4-slot barrier ring for 8 iterations, so every slot is reused under both parities — the structure a fused wait cannot express. It asserts `tma_load_multicast` is emitted and that both ranks receive every tile. A fused wait, or a wait on the wrong parity, would deadlock or return stale data.

Generated code, H200 (sm_90a), built from source at `main@5a9b2a54`:

```
mbars[(k & 3)].expect_transaction(16384);
mbars[(k & 3)].wait((k >> 2));
tl::tma_load_multicast(A_desc, mbars[(k & 3)], (&(a_shared[...])), (uint16_t)(3), ...);
```

Issue-only multicast, per-CTA `expect_transaction` on that CTA's own barrier slot, no internal wait, parity supplied by the caller.

`testing/python/language/test_tilelang_language_tma_copy.py`, `testing/python/cuda/test_tma_multicast_demo.py` and `testing/python/cuda/test_tma_dsmem.py` pass together on that build (21 passed, 2 skipped). `pre-commit` is clean.

Closes #2929


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added the `cluster_mask` argument to `T.tma_copy` for split-phase TMA multicast loads.
- Documented CTA leader selection, unicast behavior outside the mask, per-CTA `expect_tx`, zero-mask errors, and `annotations` precedence.
- Added a 2-CTA cluster test covering multicast code generation, barrier-ring parity reuse, and output correctness.

## Testing

- Compiles and executes a deterministic 2-CTA multicast kernel.
- Verifies both CTA outputs match the input tile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->