### PR TITLE
[Refactor][BugFix] Refactor the loop vectorization plan with ConstraintKind

### DIFF
--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -249,11 +249,19 @@ public:
                 << "\n";
     }
 
-    // Classify before selecting a strategy so physical buffer scope is not
-    // overloaded with semantic properties such as broadcast or scalarization.
-    // SeqStmt bodies stay conservative; simple memory loops may defer
-    // local/fragment and cast constraints, while must-scalarize constraints
-    // always take precedence.
+    // Compute the final vector size from the classified constraints.
+    // Strategy:
+    // - A must-scalarize constraint always selects vector_size=1.
+    // - If the body contains SeqStmt, combine all constraints conservatively.
+    // - If there is no vector memory access, combine local, broadcast-load,
+    //   and call constraints.
+    // - Otherwise, select from memory and non-cast call constraints, then
+    //   revalidate deferred local and broadcast-load accesses.
+    // Rationale: local/fragment accesses are register-level and impose no
+    // memory alignment constraints. Invariant non-local loads become scalar
+    // broadcasts, while invariant stores carry ordering semantics and must
+    // remain scalar. Explicit classification keeps these semantic properties
+    // separate from physical buffer scope.
     VectorConstraintSummary constraints = SummarizeConstraints(verbose);
     vector_size_ = SelectVectorSize(constraints, has_seq_stmt, verbose);
 

--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -249,6 +249,11 @@ public:
                 << "\n";
     }
 
+    // Classify before selecting a strategy so physical buffer scope is not
+    // overloaded with semantic properties such as broadcast or scalarization.
+    // SeqStmt bodies stay conservative; simple memory loops may defer
+    // local/fragment and cast constraints, while must-scalarize constraints
+    // always take precedence.
     VectorConstraintSummary constraints = SummarizeConstraints(verbose);
     vector_size_ = SelectVectorSize(constraints, has_seq_stmt, verbose);
 
@@ -282,6 +287,11 @@ private:
   }
 
   bool IsBroadcastLoad(const BufferVectorInfo &info) const {
+    // A loop-invariant non-local load becomes one scalar load broadcast to all
+    // lanes, not a vector memory access. DecoupleTypeCast also does not create
+    // a cast buffer for it, so classify it separately from memory accesses.
+    // Stores are never broadcasts: same-address lane stores carry ordering
+    // semantics and are either marked must-scalarize or kept as memory access.
     if (info.is_store || info.indices.empty() || !inner_for_) {
       return false;
     }
@@ -323,7 +333,11 @@ private:
       std::cerr << "  [" << (info.is_cast ? "cast" : "call")
                 << "] -> vector_size=" << info.vector_size;
     }
-    std::cerr << " [" << ConstraintKindName(kind) << "]\n";
+    if (kind != VectorConstraintKind::kCall &&
+        kind != VectorConstraintKind::kCast) {
+      std::cerr << " [constraint=" << ConstraintKindName(kind) << "]";
+    }
+    std::cerr << "\n";
   }
 
   VectorConstraintSummary SummarizeConstraints(bool verbose) const {
@@ -365,12 +379,18 @@ private:
       }
     }
     if (verbose) {
-      std::cerr << "  Computed constraints: must_scalarize="
+      int legacy_local_fragment_min =
+          arith::ZeroAwareGCD(summary.local_min, summary.broadcast_load_min);
+      // Keep the established summary for log consumers. Historically,
+      // local_fragment_min also contained non-local broadcast loads.
+      std::cerr << "  Computed mins: local_fragment_min="
+                << legacy_local_fragment_min
+                << ", memory_min=" << summary.memory_min
+                << ", call_node_min=" << summary.call_min << "\n";
+      std::cerr << "  Classified constraints: must_scalarize="
                 << (summary.requires_scalarization ? "true" : "false")
-                << ", memory=" << summary.memory_min
                 << ", local=" << summary.local_min
-                << ", broadcast_load=" << summary.broadcast_load_min
-                << ", call=" << summary.call_min << "\n";
+                << ", broadcast_load=" << summary.broadcast_load_min << "\n";
     }
     return summary;
   }
@@ -378,6 +398,9 @@ private:
   int RevalidateDeferredAccesses(int vector_size,
                                  const std::vector<BufferVectorInfo> &accesses,
                                  bool verbose) const {
+    // The simple memory strategy may select a width larger than a deferred
+    // local/fragment or broadcast-load constraint. Re-check its indices at the
+    // selected boundary and fold the original width back in when needed.
     for (const BufferVectorInfo &info : accesses) {
       if (vector_size <= info.vector_size || info.indices.empty()) {
         continue;
@@ -392,7 +415,7 @@ private:
         int old_vector_size = vector_size;
         vector_size = arith::ZeroAwareGCD(vector_size, info.vector_size);
         if (verbose) {
-          std::cerr << "  [Re-validate] Deferred buffer '" << info.buffer->name
+          std::cerr << "  [Re-validate] Local buffer '" << info.buffer->name
                     << "' not invariant at vector_size=" << old_vector_size
                     << ", GCD with " << info.vector_size
                     << " -> vector_size=" << vector_size << "\n";
@@ -415,6 +438,8 @@ private:
         arith::ZeroAwareGCD(summary.local_min, summary.broadcast_load_min);
     int selected;
     if (has_seq_stmt) {
+      // Multiple statements may carry interactions not represented by the
+      // simple single-store optimization, so include every constraint.
       selected = arith::ZeroAwareGCD(
           arith::ZeroAwareGCD(deferred_min, summary.memory_min),
           summary.call_min);
@@ -423,24 +448,29 @@ private:
                   << " -> vector_size=" << selected << "\n";
       }
     } else if (summary.has_memory_access) {
+      // For a simple memory loop, local/fragment accesses do not impose memory
+      // alignment constraints. Cast constraints are also deferred because
+      // DecoupleTypeCast later splits mixed-type operations into separate
+      // loops, allowing memory copies to retain their wider vector width.
       selected =
           arith::ZeroAwareGCD(summary.memory_min, summary.non_cast_call_min);
       if (verbose) {
-        std::cerr << "  [Strategy] Has vector memory access, using memory="
-                  << summary.memory_min
-                  << ", non_cast_call=" << summary.non_cast_call_min
-                  << " (deferring local=" << summary.local_min
-                  << ", broadcast_load=" << summary.broadcast_load_min << ")"
+        std::cerr << "  [Strategy] Has memory buffers (simple case), using "
+                  << "memory_min=" << summary.memory_min
+                  << ", non_cast_call_node_min=" << summary.non_cast_call_min
+                  << " (ignoring local/fragment_min=" << deferred_min << ")"
                   << "\n";
       }
       selected = RevalidateDeferredAccesses(selected, summary.deferred_accesses,
                                             verbose);
     } else {
+      // With no vector memory access, local/fragment, broadcast-load, and call
+      // constraints jointly determine the available vector width.
       selected = arith::ZeroAwareGCD(deferred_min, summary.call_min);
       if (verbose) {
-        std::cerr << "  [Strategy] No vector memory access, using deferred="
-                  << deferred_min << ", call=" << summary.call_min
-                  << " -> vector_size=" << selected << "\n";
+        std::cerr << "  [Strategy] Only local/fragment buffers, using "
+                     "GCD(local_fragment_min, call_node_min)="
+                  << selected << "\n";
       }
     }
     return selected;

--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -84,12 +84,43 @@ struct VectorizePlanResult {
   PrimExpr condition;
 };
 
+enum class VectorConstraintKind {
+  kMustScalarize,
+  kCall,
+  kCast,
+  kLocal,
+  kMemory,
+  kBroadcastLoad,
+};
+
+struct VectorSizeConstraint {
+  int vector_size;
+  bool requires_scalarization;
+};
+
 struct BufferVectorInfo {
   Buffer buffer;
   int vector_size;
   bool is_store;
   Array<PrimExpr> indices;
   bool is_cast = false; // true for CastNode constraints (vs CallNode)
+  bool requires_scalarization = false;
+};
+
+struct VectorConstraintSummary {
+  explicit VectorConstraintSummary(int initial_vector_size)
+      : local_min(initial_vector_size), memory_min(initial_vector_size),
+        broadcast_load_min(initial_vector_size), call_min(initial_vector_size),
+        non_cast_call_min(initial_vector_size) {}
+
+  int local_min;
+  int memory_min;
+  int broadcast_load_min;
+  int call_min;
+  int non_cast_call_min;
+  bool requires_scalarization = false;
+  bool has_memory_access = false;
+  std::vector<BufferVectorInfo> deferred_accesses;
 };
 
 Array<PrimExpr> GetBufferStrides(const Buffer &buffer) {
@@ -209,16 +240,6 @@ public:
     buffer_vector_infos_.clear();
     this->operator()(node);
 
-    // Compute final vector size from collected buffer infos
-    // Strategy:
-    // - If For body contains SeqStmt: take min of all buffers (conservative)
-    // - Else if all buffers are local/fragment: take min of all
-    // - Else if there are global/shared buffers: ignore local/fragment
-    //   constraints and only take min of global/shared buffers
-    // Rationale: local/fragment are register-level, no memory alignment
-    // constraints. But for complex cases (SeqStmt), we stay conservative.
-    vector_size_ = initial_vector_size_;
-
     if (verbose) {
       std::cerr << "=== VectorizePlanner: Collected buffer vector sizes ==="
                 << "\n";
@@ -228,140 +249,8 @@ public:
                 << "\n";
     }
 
-    // Separate buffers into local/fragment vs memory (global/shared) vs
-    // call/cast
-    int local_fragment_min = initial_vector_size_;
-    int memory_min = initial_vector_size_;
-    int call_node_min = initial_vector_size_;
-    int non_cast_call_node_min = initial_vector_size_;
-    bool has_global_or_shared_buffer = false;
-
-    auto is_local_or_fragment = [](const Buffer &buf) {
-      return IsLocalBuffer(buf, /*allow_var=*/true) || IsFragmentBuffer(buf);
-    };
-
-    std::vector<BufferVectorInfo> local_fragment_buffers;
-
-    for (const auto &info : buffer_vector_infos_) {
-      auto buffer = info.buffer;
-      if (verbose) {
-        if (buffer.defined()) {
-          std::cerr << "  Buffer: " << buffer->name
-                    << " (scope=" << buffer.scope() << ")"
-                    << " -> vector_size=" << info.vector_size
-                    << (info.is_store ? " [store]" : " [load]") << "\n";
-        } else {
-          std::cerr << "  [" << (info.is_cast ? "cast" : "call")
-                    << "] -> vector_size=" << info.vector_size << "\n";
-        }
-      }
-      if (!buffer.defined()) {
-        call_node_min = arith::ZeroAwareGCD(call_node_min, info.vector_size);
-        if (!info.is_cast) {
-          non_cast_call_node_min =
-              arith::ZeroAwareGCD(non_cast_call_node_min, info.vector_size);
-        }
-      } else if (is_local_or_fragment(buffer)) {
-        local_fragment_min =
-            arith::ZeroAwareGCD(local_fragment_min, info.vector_size);
-        local_fragment_buffers.push_back(info);
-      } else {
-        // global, shared, shared.dyn
-        // If a *load*'s indices don't depend on loop var (e.g. b[0]), treat
-        // as local — it will become a scalar broadcast, not a vector memory
-        // access, and DecoupleTypeCast won't create a cast buffer for it.
-        // Stores must stay in the memory bucket: a loop-invariant store is a
-        // reduction-like pattern where ComputeBufferVectorSize has already
-        // returned 1 to disable vectorization, and that constraint must not
-        // be dropped (memory strategy ignores local_fragment_min).
-        bool depends_on_loop_var = true;
-        if (!info.indices.empty() && inner_for_) {
-          Array<PrimExpr> strides = GetBufferStrides(info.buffer);
-          PrimExpr elem_offset = 0;
-          for (size_t i = 0; i < info.indices.size(); ++i) {
-            elem_offset += info.indices[i] * strides[i];
-          }
-          depends_on_loop_var = !IsExprInvariantInVectorBoundary(
-              elem_offset, inner_for_->loop_var, vector_size_, analyzer_);
-        }
-        if (depends_on_loop_var) {
-          memory_min = arith::ZeroAwareGCD(memory_min, info.vector_size);
-          has_global_or_shared_buffer = true;
-        } else {
-          local_fragment_min =
-              arith::ZeroAwareGCD(local_fragment_min, info.vector_size);
-          local_fragment_buffers.push_back(info);
-        }
-      }
-    }
-
-    if (verbose) {
-      std::cerr << "  Computed mins: local_fragment_min=" << local_fragment_min
-                << ", memory_min=" << memory_min
-                << ", call_node_min=" << call_node_min << "\n";
-    }
-
-    if (has_seq_stmt) {
-      // For body contains SeqStmt (multiple statements).
-      // Use conservative strategy: take GCD of all buffers including local.
-      // The special local buffer optimization only applies to simple single
-      // BufferStore cases where we can be confident about the access pattern.
-      vector_size_ = arith::ZeroAwareGCD(
-          arith::ZeroAwareGCD(local_fragment_min, memory_min), call_node_min);
-      if (verbose) {
-        std::cerr << "  [Strategy] Has SeqStmt, using conservative GCD of all"
-                  << " -> vector_size=" << vector_size_ << "\n";
-      }
-    } else if (has_global_or_shared_buffer) {
-      // Has memory buffers and simple case (no SeqStmt):
-      // ignore local/fragment constraints AND cast constraints.
-      // Cast constraints are ignored because DecoupleTypeCast will later
-      // split mixed-type operations into separate loops, allowing memory
-      // copies to use wider vectors independently of cast width limits.
-      vector_size_ = arith::ZeroAwareGCD(memory_min, non_cast_call_node_min);
-      if (verbose) {
-        std::cerr << "  [Strategy] Has memory buffers (simple case), using "
-                  << "memory_min=" << memory_min
-                  << ", non_cast_call_node_min=" << non_cast_call_node_min
-                  << " (ignoring local/fragment_min=" << local_fragment_min
-                  << ")" << "\n";
-      }
-      // vector_size may be greater than local/fragment buffers' vector_size.
-      // In such case, we need to re-validate if the indices are vectorizable
-      // at the new vector_size boundary. If not, take GCD.
-      for (const auto &info : local_fragment_buffers) {
-        if (vector_size_ > info.vector_size && !info.indices.empty()) {
-          // Compute elem_offset from indices and strides
-          Array<PrimExpr> strides = GetBufferStrides(info.buffer);
-          PrimExpr elem_offset = 0;
-          for (size_t i = 0; i < info.indices.size(); ++i) {
-            elem_offset += info.indices[i] * strides[i];
-          }
-          if (!IndicesCanVectorize(elem_offset, inner_for_->loop_var,
-                                   inner_for_->extent, vector_size_,
-                                   analyzer_)) {
-            // Not invariant at this vector_size, need to take GCD
-            int old_vector_size = vector_size_;
-            vector_size_ = arith::ZeroAwareGCD(vector_size_, info.vector_size);
-            if (verbose) {
-              std::cerr << "  [Re-validate] Local buffer '" << info.buffer->name
-                        << "' not invariant at vector_size=" << old_vector_size
-                        << ", GCD with " << info.vector_size
-                        << " -> vector_size=" << vector_size_ << "\n";
-            }
-          }
-        }
-      }
-    } else {
-      // Only local/fragment buffers: use GCD of local_fragment_min and
-      // call_node_min
-      vector_size_ = arith::ZeroAwareGCD(local_fragment_min, call_node_min);
-      if (verbose) {
-        std::cerr << "  [Strategy] Only local/fragment buffers, using "
-                     "GCD(local_fragment_min, call_node_min)="
-                  << vector_size_ << "\n";
-      }
-    }
+    VectorConstraintSummary constraints = SummarizeConstraints(verbose);
+    vector_size_ = SelectVectorSize(constraints, has_seq_stmt, verbose);
 
     // GCD with loop extent to ensure vector_size divides the loop extent
     vector_size_ = arith::ZeroAwareGCD(loop_extent_vector_size_, vector_size_);
@@ -373,6 +262,190 @@ public:
   }
 
 private:
+  static const char *ConstraintKindName(VectorConstraintKind kind) {
+    switch (kind) {
+    case VectorConstraintKind::kMustScalarize:
+      return "must-scalarize";
+    case VectorConstraintKind::kCall:
+      return "call";
+    case VectorConstraintKind::kCast:
+      return "cast";
+    case VectorConstraintKind::kLocal:
+      return "local";
+    case VectorConstraintKind::kMemory:
+      return "memory";
+    case VectorConstraintKind::kBroadcastLoad:
+      return "broadcast-load";
+    }
+    LOG(FATAL) << "Unknown vector constraint kind";
+    return "unknown";
+  }
+
+  bool IsBroadcastLoad(const BufferVectorInfo &info) const {
+    if (info.is_store || info.indices.empty() || !inner_for_) {
+      return false;
+    }
+    Array<PrimExpr> strides = GetBufferStrides(info.buffer);
+    PrimExpr elem_offset = 0;
+    for (size_t i = 0; i < info.indices.size(); ++i) {
+      elem_offset += info.indices[i] * strides[i];
+    }
+    return IsExprInvariantInVectorBoundary(elem_offset, inner_for_->loop_var,
+                                           initial_vector_size_, analyzer_);
+  }
+
+  VectorConstraintKind ClassifyConstraint(const BufferVectorInfo &info) const {
+    if (info.requires_scalarization) {
+      return VectorConstraintKind::kMustScalarize;
+    }
+    if (!info.buffer.defined()) {
+      return info.is_cast ? VectorConstraintKind::kCast
+                          : VectorConstraintKind::kCall;
+    }
+    if (IsLocalBuffer(info.buffer, /*allow_var=*/true) ||
+        IsFragmentBuffer(info.buffer)) {
+      return VectorConstraintKind::kLocal;
+    }
+    if (IsBroadcastLoad(info)) {
+      return VectorConstraintKind::kBroadcastLoad;
+    }
+    return VectorConstraintKind::kMemory;
+  }
+
+  void LogConstraint(const BufferVectorInfo &info,
+                     VectorConstraintKind kind) const {
+    if (info.buffer.defined()) {
+      std::cerr << "  Buffer: " << info.buffer->name
+                << " (scope=" << info.buffer.scope() << ")"
+                << " -> vector_size=" << info.vector_size
+                << (info.is_store ? " [store]" : " [load]");
+    } else {
+      std::cerr << "  [" << (info.is_cast ? "cast" : "call")
+                << "] -> vector_size=" << info.vector_size;
+    }
+    std::cerr << " [" << ConstraintKindName(kind) << "]\n";
+  }
+
+  VectorConstraintSummary SummarizeConstraints(bool verbose) const {
+    VectorConstraintSummary summary(initial_vector_size_);
+    for (const BufferVectorInfo &info : buffer_vector_infos_) {
+      VectorConstraintKind kind = ClassifyConstraint(info);
+      if (verbose) {
+        LogConstraint(info, kind);
+      }
+      switch (kind) {
+      case VectorConstraintKind::kMustScalarize:
+        summary.requires_scalarization = true;
+        break;
+      case VectorConstraintKind::kCall:
+        summary.call_min =
+            arith::ZeroAwareGCD(summary.call_min, info.vector_size);
+        summary.non_cast_call_min =
+            arith::ZeroAwareGCD(summary.non_cast_call_min, info.vector_size);
+        break;
+      case VectorConstraintKind::kCast:
+        summary.call_min =
+            arith::ZeroAwareGCD(summary.call_min, info.vector_size);
+        break;
+      case VectorConstraintKind::kLocal:
+        summary.local_min =
+            arith::ZeroAwareGCD(summary.local_min, info.vector_size);
+        summary.deferred_accesses.push_back(info);
+        break;
+      case VectorConstraintKind::kMemory:
+        summary.memory_min =
+            arith::ZeroAwareGCD(summary.memory_min, info.vector_size);
+        summary.has_memory_access = true;
+        break;
+      case VectorConstraintKind::kBroadcastLoad:
+        summary.broadcast_load_min =
+            arith::ZeroAwareGCD(summary.broadcast_load_min, info.vector_size);
+        summary.deferred_accesses.push_back(info);
+        break;
+      }
+    }
+    if (verbose) {
+      std::cerr << "  Computed constraints: must_scalarize="
+                << (summary.requires_scalarization ? "true" : "false")
+                << ", memory=" << summary.memory_min
+                << ", local=" << summary.local_min
+                << ", broadcast_load=" << summary.broadcast_load_min
+                << ", call=" << summary.call_min << "\n";
+    }
+    return summary;
+  }
+
+  int RevalidateDeferredAccesses(int vector_size,
+                                 const std::vector<BufferVectorInfo> &accesses,
+                                 bool verbose) const {
+    for (const BufferVectorInfo &info : accesses) {
+      if (vector_size <= info.vector_size || info.indices.empty()) {
+        continue;
+      }
+      Array<PrimExpr> strides = GetBufferStrides(info.buffer);
+      PrimExpr elem_offset = 0;
+      for (size_t i = 0; i < info.indices.size(); ++i) {
+        elem_offset += info.indices[i] * strides[i];
+      }
+      if (!IndicesCanVectorize(elem_offset, inner_for_->loop_var,
+                               inner_for_->extent, vector_size, analyzer_)) {
+        int old_vector_size = vector_size;
+        vector_size = arith::ZeroAwareGCD(vector_size, info.vector_size);
+        if (verbose) {
+          std::cerr << "  [Re-validate] Deferred buffer '" << info.buffer->name
+                    << "' not invariant at vector_size=" << old_vector_size
+                    << ", GCD with " << info.vector_size
+                    << " -> vector_size=" << vector_size << "\n";
+        }
+      }
+    }
+    return vector_size;
+  }
+
+  int SelectVectorSize(const VectorConstraintSummary &summary,
+                       bool has_seq_stmt, bool verbose) const {
+    if (summary.requires_scalarization) {
+      if (verbose) {
+        std::cerr << "  [Strategy] Semantic constraint requires scalarization"
+                  << " -> vector_size=1\n";
+      }
+      return 1;
+    }
+    int deferred_min =
+        arith::ZeroAwareGCD(summary.local_min, summary.broadcast_load_min);
+    int selected;
+    if (has_seq_stmt) {
+      selected = arith::ZeroAwareGCD(
+          arith::ZeroAwareGCD(deferred_min, summary.memory_min),
+          summary.call_min);
+      if (verbose) {
+        std::cerr << "  [Strategy] Has SeqStmt, using conservative GCD of all"
+                  << " -> vector_size=" << selected << "\n";
+      }
+    } else if (summary.has_memory_access) {
+      selected =
+          arith::ZeroAwareGCD(summary.memory_min, summary.non_cast_call_min);
+      if (verbose) {
+        std::cerr << "  [Strategy] Has vector memory access, using memory="
+                  << summary.memory_min
+                  << ", non_cast_call=" << summary.non_cast_call_min
+                  << " (deferring local=" << summary.local_min
+                  << ", broadcast_load=" << summary.broadcast_load_min << ")"
+                  << "\n";
+      }
+      selected = RevalidateDeferredAccesses(selected, summary.deferred_accesses,
+                                            verbose);
+    } else {
+      selected = arith::ZeroAwareGCD(deferred_min, summary.call_min);
+      if (verbose) {
+        std::cerr << "  [Strategy] No vector memory access, using deferred="
+                  << deferred_min << ", call=" << summary.call_min
+                  << " -> vector_size=" << selected << "\n";
+      }
+    }
+    return selected;
+  }
+
   Stmt VisitStmt_(const ForNode *node) final {
     inner_for_ = node;
     bool contains_nested_for = false;
@@ -798,10 +871,11 @@ private:
     return arith::IRMutatorWithAnalyzer::VisitExpr_(node);
   }
 
-  int ComputeBufferVectorSize(const Array<PrimExpr> &indices,
-                              const Buffer &buffer, bool is_store) {
+  VectorSizeConstraint ComputeBufferVectorSize(const Array<PrimExpr> &indices,
+                                               const Buffer &buffer,
+                                               bool is_store) {
     if (!inner_for_)
-      return initial_vector_size_;
+      return {initial_vector_size_, /*requires_scalarization=*/false};
 
     int buffer_vec_size = loop_extent_vector_size_;
 
@@ -850,11 +924,11 @@ private:
     // not force the whole loop's vector size down to 1.
     if (is_store && (is_invariant || is_independent)) {
       if (!IsAllRepReducerBuffer(buffer)) {
-        return 1;
+        return {1, /*requires_scalarization=*/true};
       }
     }
     if (is_independent) {
-      return buffer_vec_size; // only limited constraint from this buffer
+      return {buffer_vec_size, /*requires_scalarization=*/false};
     }
     // 4. Try to find max vectorize size for this buffer
     while (buffer_vec_size > 1 &&
@@ -863,14 +937,16 @@ private:
                                 analyzer_)) {
       buffer_vec_size /= 2;
     }
-    return buffer_vec_size;
+    return {buffer_vec_size, /*requires_scalarization=*/false};
   }
 
   void UpdateVectorSize(const Array<PrimExpr> &indices, const Buffer &buffer,
                         bool is_store) {
-    int buffer_vec_size = ComputeBufferVectorSize(indices, buffer, is_store);
-    buffer_vector_infos_.push_back(
-        {buffer, buffer_vec_size, is_store, indices});
+    VectorSizeConstraint constraint =
+        ComputeBufferVectorSize(indices, buffer, is_store);
+    buffer_vector_infos_.push_back({buffer, constraint.vector_size, is_store,
+                                    indices, /*is_cast=*/false,
+                                    constraint.requires_scalarization});
   }
 
   // NOTE(wt): The base class IRMutatorWithAnalyzer::VisitStmt_(BindNode*)

--- a/testing/python/language/test_tilelang_language_vectorize.py
+++ b/testing/python/language/test_tilelang_language_vectorize.py
@@ -114,6 +114,61 @@ def test_vectorize_invariant_index():
 
 
 @tilelang.jit
+def vectorize_global_invariant_store_accumulate(M, K):
+    @T.prim_func
+    def main(
+        A: T.Tensor[(M, K), T.float32],  # noqa: F821
+        B: T.Tensor[(M,), T.float32],  # noqa: F821
+    ):
+        with T.Kernel(M // 128, threads=128) as bx:
+            row = bx * 128 + T.get_thread_binding(0)
+            B[row] = 0.0
+            for k in T.vectorized(K):
+                B[row] = B[row] + A[row, k]
+
+    return main
+
+
+@tilelang.jit
+def vectorize_local_invariant_store_accumulate(M, K):
+    @T.prim_func
+    def main(
+        A: T.Tensor[(M, K), T.float32],  # noqa: F821
+        B: T.Tensor[(M,), T.float32],  # noqa: F821
+    ):
+        with T.Kernel(M // 128, threads=128) as bx:
+            row = bx * 128 + T.get_thread_binding(0)
+            acc = T.alloc_local((1,), T.float32)
+            acc[0] = 0.0
+            for k in T.vectorized(K):
+                acc[0] = acc[0] + A[row, k]
+            B[row] = acc[0]
+
+    return main
+
+
+def run_vectorize_invariant_store_accumulate(kernel_factory):
+    M, K = 128, 4
+    kernel = kernel_factory(M, K)
+    a = torch.ones((M, K), device="cuda", dtype=torch.float32)
+    b = torch.empty((M,), device="cuda", dtype=torch.float32)
+
+    kernel(a, b)
+
+    torch.testing.assert_close(b, torch.full_like(b, float(K)), rtol=0, atol=0)
+
+
+@tilelang.testing.requires_cuda
+def test_vectorize_global_invariant_store_accumulate():
+    run_vectorize_invariant_store_accumulate(vectorize_global_invariant_store_accumulate)
+
+
+@tilelang.testing.requires_cuda
+def test_vectorize_local_invariant_store_accumulate():
+    run_vectorize_invariant_store_accumulate(vectorize_local_invariant_store_accumulate)
+
+
+@tilelang.jit
 def vectorize_test_all_dtypes(dtype, vec_num):
     @T.prim_func
     def main(A: T.Tensor[(64,), dtype]):


### PR DESCRIPTION
## Summary

- classify vectorization constraints explicitly as must-scalarize, call, cast, local, memory, or broadcast-load
- keep non-local invariant loads as scalar broadcasts without reusing the local/fragment category
- force ordinary loop-invariant stores to scalarize across global, shared, local, and fragment scopes while preserving the all-rep reducer exception
- add deterministic global and local accumulation regressions

## Motivation

`ComputeBufferVectorSize` already identifies ordinary invariant stores as requiring `vector_size=1`, but the old scope-based bucketing could discard that semantic requirement. The narrow fix in #2922 keeps global/shared stores in the memory bucket, while local/fragment stores can still lose the same constraint.

This change separates classification, aggregation, and strategy selection. `Plan()` now orchestrates those phases, broadcast loads have their own category, and a must-scalarize constraint returns width 1 before any memory/local strategy is selected.

Related: #2922

## ConstraintKind

| ConstraintKind | Classification condition | Typical example | Effect on vector size |
|---|---|---|---|
| `kMustScalarize` | `requires_scalarization=true`; an ordinary invariant/independent store, excluding all-rep reducers | `acc[0] += A[i]`, `B[row] += A[row, i]` | Takes precedence over every strategy and selects `vector_size=1` |
| `kCall` | Not associated with a concrete buffer and not produced by a cast | A regular `CallNode` or condition expression | Contributes to both `call_min` and `non_cast_call_min` |
| `kCast` | Not associated with a concrete buffer and produced by a `CastNode` | A conversion from `float32` to `float16` | Contributes to `call_min`; may be deferred by `DecoupleTypeCast` in the simple memory strategy |
| `kLocal` | Buffer scope is `local`, `local.var`, or fragment | `local[i] = value`, fragment load/store | Contributes to `local_min`; deferred and revalidated under the simple memory strategy |
| `kMemory` | A non-local buffer access that is neither a broadcast load nor a must-scalarize store | `B[row, i] = A[row, i]`, regular global/shared load/store | Contributes to `memory_min` and enables the memory vectorization strategy |
| `kBroadcastLoad` | A non-local load whose address is invariant within the candidate vector boundary | Reading `C[row]` inside a vectorized loop | Treated as scalar load + broadcast; excluded from `memory_min` and revalidated if necessary |

## Testing

- `bash format.sh --files src/transform/loop_vectorize.cc testing/python/language/test_tilelang_language_vectorize.py`
- `cmake --build build -j 32`
- `python -m pytest -q testing/python/language/test_tilelang_language_vectorize.py` — 36 passed
- `python -m pytest -q testing/python/transform/test_tilelang_transform_legalize_vectorized_loop.py::test_vectorize_access` — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Refactored loop-vectorization constraint handling into explicit constraint kinds and summaries.
- Preserved scalarization for loop-invariant stores across global, shared, local, and fragment buffers.
- Kept non-local invariant loads as scalar broadcasts.
- Preserved the all-rep reducer exception.
- Updated `Plan()` to classify constraints, aggregate them, select a strategy, revalidate deferred accesses, and enforce loop-extent divisibility.
- Added global and local invariant-store accumulation regression tests.

## Validation

- Formatting passed.
- Build passed.
- 36 language vectorization tests passed.
- Vectorized-loop access test passed.

## C++ style / lint notes

- The PR changes C++ code in `src/transform/loop_vectorize.cc`.
- No public or exported declarations changed.
- The PR does not change documented rules in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) is relevant to C++ changes. Any TLCPP003/TLCPP004 findings are advisory and do not block merging unless they indicate an API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->