### PR TITLE
[CUDA] Add pre-SM80 fallback for bf16 atomic add

### DIFF
--- a/src/tl_templates/cuda/atomic.h
+++ b/src/tl_templates/cuda/atomic.h
@@ -49,6 +49,30 @@ template <> TL_DEVICE __nv_bfloat16 cuda_cast<__nv_bfloat16, float>(float val) {
 }
 #endif
 
+// CUDA only provides bf16 atomicAdd on SM80+. Use 16-bit CAS on SM70–79,
+// relying on CUTLASS's fp32 fallback for bfloat16_t addition. Gate this
+// non-template definition because 16-bit atomicCAS is unavailable below SM70.
+#if !defined(__CUDA_ARCH__) || (__CUDA_ARCH__ >= 700)
+TL_DEVICE bfloat16_t atomicAdd(bfloat16_t *address, bfloat16_t val) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+  return bfloat16_t(atomicAdd(reinterpret_cast<__nv_bfloat16 *>(address),
+                              val.to_nv_bfloat16()));
+#else
+  unsigned short *address_as_ushort =
+      reinterpret_cast<unsigned short *>(address);
+  unsigned short old_bits = *address_as_ushort;
+  unsigned short assumed_bits;
+  do {
+    assumed_bits = old_bits;
+    bfloat16_t sum = *reinterpret_cast<bfloat16_t *>(&assumed_bits) + val;
+    old_bits = atomicCAS(address_as_ushort, assumed_bits,
+                         *reinterpret_cast<unsigned short *>(&sum));
+  } while (assumed_bits != old_bits);
+  return *reinterpret_cast<bfloat16_t *>(&old_bits);
+#endif
+}
+#endif
+
 // Helpers for atomic operations
 
 namespace tl_atomic_detail {
@@ -492,8 +516,14 @@ template <typename T1, typename T2>
 TL_DEVICE T1 AtomicAddRet(T1 *address, T2 val,
                           int memory_order = int(cuda::memory_order_relaxed)) {
   using NT1 = typename normalize_atomic_type<T1>::type;
-  if constexpr (std::is_same_v<NT1, half> ||
-                std::is_same_v<NT1, __nv_bfloat16>) {
+  if constexpr (std::is_same_v<NT1, bfloat16_t>) {
+    // Pre-SM80 only: cuda::atomic_ref has no fetch_add for bfloat16_t, so use
+    // the atomicAdd overload above. Memory order is dropped, as in AtomicAdd.
+    (void)memory_order;
+    return static_cast<T1>(
+        atomicAdd(reinterpret_cast<NT1 *>(address), cuda_cast<NT1>(val)));
+  } else if constexpr (std::is_same_v<NT1, half> ||
+                       std::is_same_v<NT1, __nv_bfloat16>) {
     if (tl_atomic_detail::IsRelaxedMemoryOrder(memory_order)) {
       return static_cast<T1>(
           atomicAdd(reinterpret_cast<NT1 *>(address), static_cast<NT1>(val)));
@@ -616,7 +646,7 @@ AtomicAddx4Ret(half_t *ref, SrcType *val,
   return ret;
 }
 
-#if (defined(__CUDA_ARCH_LIST__) && (__CUDA_ARCH_LIST__ > 750))
+// Conversion only; the packed bf16 atomics below are what need SM80.
 template <typename T> TL_DEVICE __nv_bfloat162 ToBfloat162(T *val) {
   return *reinterpret_cast<const __nv_bfloat162 *>(val);
 }
@@ -639,6 +669,7 @@ TL_DEVICE __nv_bfloat162 ToBfloat162(float *val) {
   return ToBfloat162(static_cast<const float *>(val));
 }
 
+#if (defined(__CUDA_ARCH_LIST__) && (__CUDA_ARCH_LIST__ > 750))
 template <typename ValType>
 TL_DEVICE void AtomicAddx2(bfloat16_t *ref, ValType val,
                            int memory_order = int(cuda::memory_order_relaxed)) {
@@ -681,6 +712,31 @@ AtomicAddx2Ret(bfloat16_t *ref, src_type *val,
   }
 }
 
+#else
+// Pre-SM80 has no packed bf16 atomicAdd and no `atom.*.v2.bf16`: fall back to
+// scalar adds like the fp32 helpers below. Atomicity is per element and the
+// memory order is dropped.
+template <typename ValType>
+TL_DEVICE void AtomicAddx2(bfloat16_t *ref, ValType val,
+                           int memory_order = int(cuda::memory_order_relaxed)) {
+  (void)memory_order;
+  __nv_bfloat162 add_val = ToBfloat162(val);
+  tl_atomic_detail::AtomicAddx2Scalar(ref, bfloat16_t(add_val.x),
+                                      bfloat16_t(add_val.y));
+}
+
+template <typename src_type>
+TL_DEVICE __nv_bfloat162
+AtomicAddx2Ret(bfloat16_t *ref, src_type *val,
+               int memory_order = int(cuda::memory_order_relaxed)) {
+  (void)memory_order;
+  __nv_bfloat162 add_val = ToBfloat162(val);
+  bfloat16_t prev_x = atomicAdd(ref + 0, bfloat16_t(add_val.x));
+  bfloat16_t prev_y = atomicAdd(ref + 1, bfloat16_t(add_val.y));
+  return __nv_bfloat162(prev_x.to_nv_bfloat16(), prev_y.to_nv_bfloat16());
+}
+#endif
+
 // bf16 counterpart of the fp16 AtomicAddx4Ret above.
 template <typename SrcType>
 TL_DEVICE uint2
@@ -693,7 +749,6 @@ AtomicAddx4Ret(bfloat16_t *ref, SrcType *val,
   ret.y = *reinterpret_cast<const unsigned int *>(&prev_hi);
   return ret;
 }
-#endif
 
 #if (defined(__CUDA_ARCH_LIST__) && (__CUDA_ARCH_LIST__ >= 900))
 template <typename SrcType>
@@ -724,7 +779,6 @@ TL_DEVICE void AtomicAddx4(half_t *ref, SrcType *val,
 }
 #endif
 
-#if (defined(__CUDA_ARCH_LIST__) && (__CUDA_ARCH_LIST__ > 750))
 #if (defined(__CUDA_ARCH_LIST__) && (__CUDA_ARCH_LIST__ >= 900))
 template <typename SrcType>
 TL_DEVICE void AtomicAddx4(bfloat16_t *ref, SrcType *val,
@@ -752,7 +806,6 @@ TL_DEVICE void AtomicAddx4(bfloat16_t *ref, SrcType *val,
   AtomicAddx2(ref, val, memory_order);
   AtomicAddx2(ref + 2, val + 2, memory_order);
 }
-#endif
 #endif
 
 template <typename T> TL_DEVICE float2 ToFloat2(T *val) {

--- a/testing/python/language/test_tilelang_language_atomic.py
+++ b/testing/python/language/test_tilelang_language_atomic.py
@@ -503,7 +503,7 @@ def test_atomic_add_mixed_dtype_fp16():
 
 
 @tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_ge(8, 0)
+@tilelang.testing.requires_cuda_compute_version_ge(7, 0)
 def test_atomic_add_mixed_dtype_bf16():
     run_atomic_add_mixed_dtype(8, T.float32, T.bfloat16)
     run_atomic_addx2_mixed_dtype(32, 64, 8, 16, T.float32, T.bfloat16)
@@ -525,7 +525,7 @@ def test_atomic_addx4_sliced_dst_compile():
 
 
 @tilelang.testing.requires_cuda
-@tilelang.testing.requires_cuda_compute_version_ge(8, 0)
+@tilelang.testing.requires_cuda_compute_version_ge(7, 0)
 def test_atomic_addx4_16bit():
     for dtype in (T.float16, T.bfloat16):
         for offset in (0, 4):
@@ -534,6 +534,13 @@ def test_atomic_addx4_16bit():
 
 def test_atomic_return_prev():
     run_atomic_return_prev(32, 32, 8, 8)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(7, 0)
+@pytest.mark.parametrize("dtype", [T.float16, T.bfloat16])
+def test_atomic_return_prev_16bit(dtype):
+    run_atomic_return_prev(32, 32, 8, 8, dtype=dtype)
 
 
 def test_atomic_add():
@@ -1180,6 +1187,80 @@ def test_atomic_add_return_prev_materialized_once():
     assert counter.item() == n, f"atomic executed {counter.item()} times, expected {n}"
     assert (out < 0).sum().item() == 0, "unwritten slots: atomic return value was re-evaluated"
     assert torch.equal(out.sort().values.long(), torch.arange(n).cuda())
+
+
+# ======================= Contended scalar atomic add =======================
+
+
+@tilelang.jit
+def atomic_add_contended_program(N, threads, dtype):
+    @T.prim_func
+    def atomic_add_contended(A: T.Tensor((N,), dtype), Out: T.Tensor((1,), dtype)):
+        with T.Kernel(1, threads=threads) as _:
+            for i in T.Parallel(N):
+                T.atomic_add(Out[0], A[i])
+
+    return atomic_add_contended
+
+
+def run_atomic_add_contended(N, threads, dtype):
+    kernel = atomic_add_contended_program(N, threads, dtype)
+
+    # Every thread targets the same cell, so a non-atomic read-modify-write
+    # loses updates. Ones keep every partial sum exactly representable.
+    a = torch.ones(N, dtype=getattr(torch, dtype)).cuda()
+    out = torch.zeros(1, dtype=getattr(torch, dtype)).cuda()
+
+    kernel(a, out)
+
+    assert float(out[0]) == float(N), f"lost updates: got {float(out[0])}, expected {N}"
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version_ge(7, 0)
+def test_atomic_add_contended_bf16():
+    # bf16 is the dtype whose pre-SM80 add is a CAS loop; float32 contention is
+    # already covered by the multi-block test_atomic_add above.
+    run_atomic_add_contended(128, 128, T.bfloat16)
+
+
+@tilelang.jit(target={"kind": "cuda", "arch": "sm_75"})
+def atomic_add_bf16_sm75_program(N):
+    @T.prim_func
+    def atomic_add_bf16_sm75(A: T.Tensor((N,), T.bfloat16), B: T.Tensor((N,), T.bfloat16), Prev: T.Tensor((N,), T.bfloat16)):
+        with T.Kernel(1, threads=32) as _:
+            # Outside a parallel loop, so it stays scalar instead of packed.
+            T.atomic_add(B[1], A[1])
+            for i in T.Parallel(N // 2):
+                T.atomic_addx2(B[i * 2], A[i * 2])
+            for i in T.Parallel(N // 4):
+                T.atomic_addx4(B[i * 4], A[i * 4])
+            Prev[0] = T.atomic_add(B[0], A[0], return_prev=True)
+            Prev[0:2] = T.atomic_addx2(B[0:2], A[0:2], return_prev=True)
+            Prev[0:4] = T.atomic_addx4(B[0:4], A[0:4], return_prev=True)
+
+    return atomic_add_bf16_sm75
+
+
+@tilelang.testing.requires_cuda
+def test_atomic_add_bf16_compiles_for_sm75():
+    """The native __nv_bfloat16 atomicAdd and `atom.*.v2.bf16` are SM80+, and
+    atomic.h reaches every generated kernel, so the pre-SM80 fallbacks must keep
+    compiling. Pinned with an explicit sm_75 target because the tests above use
+    the runner's native target and would miss this fallback on a modern GPU."""
+    source = atomic_add_bf16_sm75_program(64).get_kernel_source()
+
+    # Auto-vectorization rewrites scalar adds into packed ones, so check the
+    # kernel above still reaches each fallback.
+    for helper in (
+        "AtomicAdd(",
+        "AtomicAddx2(",
+        "AtomicAddx4(",
+        "AtomicAddRet(",
+        "AtomicAddx2Ret(",
+        "AtomicAddx4Ret(",
+    ):
+        assert helper in source, f"{helper} not exercised by the sm_75 kernel"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

On SM70–79, all bf16 forms of `T.atomic_add` fail to compile:

* **scalar**: no `atomicAdd(bfloat16_t*)` overload
* **return_prev**: no `cuda::atomic_ref<bfloat16_t>::fetch_add`
* **x2**: no matching bf16 `AtomicAddx2` helper
* **x4**: falls into an incompatible generic scalar decomposition

On an SM75 GPU, this causes three failures in `test_tilelang_language_atomic.py`. Two additional bf16 tests were hidden behind unnecessary SM80 gates.

## Root cause

`normalize_atomic_type<bfloat16_t>` maps to CUDA's `__nv_bfloat16` only on SM80+, where native bf16 atomic add is available. On SM70–79 the type remains `cutlass::bfloat16_t`, for which no `atomicAdd` overload exists.

The bf16 x2 helpers and their conversion utilities were also guarded by SM80. `AtomicAddRet` consequently fell through to `cuda::atomic_ref<bfloat16_t>::fetch_add`, which CUDA does not provide.

## Fix

Add an `atomicAdd(bfloat16_t*)` overload:

* SM80+ forwards to native `__nv_bfloat16` atomic add.
* SM70–79 uses a 16-bit CAS loop, with CUTLASS's existing pre-SM80 bf16 arithmetic for the accumulate step.

Route `AtomicAddRet` through this overload, make the bf16 conversion helpers available below SM80, and add a per-element scalar fallback for x2. The existing x4 path composes two x2 operations.

The overload definition is gated to SM70+ because 16-bit `atomicCAS` is not available on older targets; unrelated SM60 kernels therefore remain unaffected.

The fallback provides per-element atomicity, not whole-vector atomicity, and does not add memory-order semantics beyond the existing pre-SM80 behavior.

## Tests

* Added a contended bf16 regression in which 128 threads add into one cell and must produce exactly 128.
* Added an explicit `sm_75` compile-only regression covering scalar, x2/x4, and their return-prev helpers, so modern CUDA runners still compile the pre-SM80 paths.
* Lowered the existing mixed-dtype and x4 bf16 test gates from SM80 to SM70, and added gated scalar return-prev coverage.
* `test_tilelang_language_atomic.py`: 66 passed, 8 skipped on a TITAN RTX (`sm_75`) with CUDA 12.4.
* Cross-compiled the bf16 family for SM70, SM75, SM80, and SM90, and confirmed that an unrelated fp32 atomic kernel still compiles for SM60.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `atomicAdd(bfloat16_t*)` support for SM70–79 with a 16-bit CAS loop.
- Kept native bf16 atomics for SM80+.
- Routed return-prev operations through the new overload.
- Added pre-SM80 scalar fallbacks for x2 operations. x4 operations still use two x2 operations.
- Enabled bf16 conversion helpers on SM70+.
- Added contended bf16 numerical tests and SM75 compile-only coverage.
- Lowered applicable test gates from SM80 to SM70.
- Preserved SM60 compatibility for unrelated fp32 atomic kernels.

## Validation

- Passed on an SM75 TITAN RTX with CUDA 12.4.
- Cross-compiled bf16 kernels for SM70, SM75, SM80, and SM90.
- Confirmed continued compilation of an fp32 atomic kernel for SM60.

## C++ style / lint notes

- This PR changes C++ code in `src/tl_templates/cuda/atomic.h`.
- The change does not modify the rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) CI step may report advisory findings. These warnings are separate from correctness, build, and test validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->