### PR TITLE
Warn when a T.gemm accumulator is not provably initialized

### DIFF
--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -31,6 +31,7 @@ TVM_REGISTER_PASS_CONFIG_OPTION(kLayoutVisualizationEnable, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kLayoutVisualizationFormats, ffi::String);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDeviceCompileFlags, ffi::Array<ffi::String>);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableDataRaceCheck, Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION(kDisableGemmAccumInitCheck, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableLoopUnswitching, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kLoopUnswitchingAllowNonTrivialElse, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kIfStmtBindingInlineReplayableBinds, Bool);

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -80,6 +80,15 @@ static constexpr const char *kLayoutVisualizationFormats =
 static constexpr const char *kDeviceCompileFlags = "tl.device_compile_flags";
 static constexpr const char *kDisableDataRaceCheck =
     "tl.disable_data_race_check";
+
+/*!
+ * \brief Disable the T.gemm accumulator-initialization check.
+ *
+ * The check is enabled by default; it only fires when clear_accum is
+ * literally false and no write to the accumulator precedes the gemm.
+ */
+static constexpr const char *kDisableGemmAccumInitCheck =
+    "tl.disable_gemm_accum_init_check";
 static constexpr const char *kDisableThreadStorageSync =
     "tl.disable_thread_storage_sync";
 static constexpr const char *kForceLetInline = "tl.force_let_inline";

--- a/src/transform/verify_gemm_accum_init.cc
+++ b/src/transform/verify_gemm_accum_init.cc
@@ -1,0 +1,193 @@
+/*!
+ * \file verify_gemm_accum_init.cc
+ *
+ * Warn when a T.gemm accumulator is not provably initialized before use.
+ *
+ * T.gemm accumulates into its C operand, so a fragment that is never written
+ * before the first T.gemm is read while uninitialized. That is undefined
+ * behaviour: it silently yields correct results on some architectures and NaN
+ * on others (see issue #2936). This pass reports it at compile time.
+ */
+
+#include "../op/gemm.h"
+#include "../op/region.h"
+#include "span_utils.h"
+#include <optional>
+#include <sstream>
+#include <unordered_set>
+#include <vector>
+
+#include <tvm/runtime/logging.h>
+#include <tvm/tirx/builtin.h>
+#include <tvm/tirx/expr.h>
+#include <tvm/tirx/op.h>
+#include <tvm/tirx/stmt.h>
+#include <tvm/tirx/stmt_functor.h>
+#include <tvm/tirx/transform.h>
+
+namespace tvm::tl {
+
+using namespace tirx;
+using namespace ffi;
+
+namespace {
+
+/*! \brief Access-mask bit meaning "this region is written". */
+constexpr int kRegionWriteBit = 2;
+
+/*! \brief The buffer var a tl.region refers to, if `arg` is a region call. */
+std::optional<Var> RegionBufferVar(const PrimExpr &arg) {
+  const auto *call = arg.as<CallNode>();
+  if (call == nullptr || !call->op.same_as(RegionOp::Get()) ||
+      call->args.empty()) {
+    return std::nullopt;
+  }
+  const auto *load = call->args[0].as<BufferLoadNode>();
+  if (load == nullptr) {
+    return std::nullopt;
+  }
+  return load->buffer->data;
+}
+
+/*! \brief Whether a tl.region call carries the write bit in its access mask. */
+bool RegionIsWritten(const PrimExpr &arg) {
+  const auto *call = arg.as<CallNode>();
+  if (call == nullptr || !call->op.same_as(RegionOp::Get()) ||
+      call->args.size() < 2) {
+    return false;
+  }
+  const auto *mask = call->args[1].as<IntImmNode>();
+  return mask != nullptr && (mask->value & kRegionWriteBit) != 0;
+}
+
+/*!
+ * \brief Collect T.gemm calls whose accumulator has no preceding write.
+ *
+ * The body is visited in execution order, so any write recorded before a gemm
+ * is reached genuinely precedes it. The check is deliberately permissive: a
+ * write anywhere earlier counts, including inside a loop or conditional that
+ * the gemm is not part of. Precision matters more than recall here, because a
+ * false positive on correct code is worse than missing an exotic case.
+ */
+struct GemmAccumInitVerifier : public StmtExprVisitor {
+  struct Report {
+    Buffer accum;
+    Span span;
+  };
+
+  std::vector<Report> reports_;
+  std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> written_;
+  Span current_span_;
+
+  void VisitStmt_(const EvaluateNode *op) final {
+    Span saved = current_span_;
+    if (op->span.defined()) {
+      current_span_ = op->span;
+    }
+    StmtExprVisitor::VisitStmt_(op);
+    current_span_ = saved;
+  }
+
+  /*! \brief A direct store (e.g. a T.Parallel loop body) initializes. */
+  void VisitStmt_(const BufferStoreNode *op) final {
+    written_.insert(op->buffer->data);
+    StmtExprVisitor::VisitStmt_(op);
+  }
+
+  void VisitExpr_(const CallNode *op) final {
+    if (op->op.same_as(Gemm::Get())) {
+      CheckGemm(op);
+      return;
+    }
+    // Every other tile op (T.fill, T.copy, ...) advertises what it writes
+    // through the access mask on its region arguments.
+    for (const PrimExpr &arg : op->args) {
+      if (RegionIsWritten(arg)) {
+        if (auto var = RegionBufferVar(arg)) {
+          written_.insert(var.value());
+        }
+      }
+    }
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
+  /*!
+   * \brief Report this gemm if its accumulator is unwritten, then mark the
+   *        accumulator written for any later gemm on the same buffer.
+   *
+   * Argument layout is fixed by Gemm::Gemm: args[2] is the C region and
+   * args[9] is clear_accum.
+   */
+  void CheckGemm(const CallNode *op) {
+    if (op->args.size() <= 9) {
+      return;
+    }
+    const PrimExpr &c_region = op->args[2];
+    auto accum_var = RegionBufferVar(c_region);
+    if (!accum_var) {
+      return;
+    }
+
+    // Only a literal `false` is a missing initialization. The pipelined idiom
+    // `clear_accum=(k == 0)` is a non-literal expression and is left alone.
+    bool definitely_not_cleared = is_zero(op->args[9]);
+    if (definitely_not_cleared && !written_.count(accum_var.value())) {
+      const auto *load = c_region.as<CallNode>()->args[0].as<BufferLoadNode>();
+      reports_.push_back({load->buffer, current_span_});
+    }
+
+    written_.insert(accum_var.value());
+    // Still visit A and B so nested regions are accounted for, but do not let
+    // this gemm's own read-write C region mark the accumulator retroactively.
+    for (size_t i = 0; i < op->args.size(); ++i) {
+      if (i != 2) {
+        StmtExprVisitor::VisitExpr(op->args[i]);
+      }
+    }
+  }
+
+  /*! \brief Emit all findings as one aggregated warning. */
+  void EmitReport() const {
+    if (reports_.empty()) {
+      return;
+    }
+    std::ostringstream os;
+    os << "Uninitialized T.gemm accumulator: " << reports_.size()
+       << " accumulator(s) read before being written\n";
+    for (size_t k = 0; k < reports_.size(); ++k) {
+      const Report &report = reports_[k];
+      os << "  [" << k + 1 << "] `" << report.accum
+         << "` is passed to T.gemm without being initialized"
+         << SpanHintSuffix({report.span}) << "\n";
+    }
+    os << "T.gemm accumulates into C, so an uninitialized accumulator adds "
+          "into stale register contents. Add `T.clear(C)` before the gemm, or "
+          "pass `clear_accum=True`. If you believe this is a false positive, "
+          "disable the check by setting "
+          "`PassConfigKey.TL_DISABLE_GEMM_ACCUM_INIT_CHECK` in the pass "
+          "config.";
+    LOG(WARNING) << os.str();
+  }
+};
+
+using namespace tirx::transform;
+
+tvm::transform::Pass VerifyGemmAccumInit() {
+  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+    GemmAccumInitVerifier verifier;
+    verifier(f->body);
+    verifier.EmitReport();
+    return f;
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.VerifyGemmAccumInit", {});
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = reflection;
+  refl::GlobalDef().def("tl.transform.VerifyGemmAccumInit",
+                        VerifyGemmAccumInit);
+}
+
+} // namespace
+
+} // namespace tvm::tl

--- a/testing/python/transform/test_tilelang_transform_verify_gemm_accum_init.py
+++ b/testing/python/transform/test_tilelang_transform_verify_gemm_accum_init.py
@@ -10,7 +10,20 @@ MESSAGE = "Uninitialized T.gemm accumulator"
 
 
 def _make(init_mode):
-    """Build the #2936 kernel. init_mode: 'none' | 'clear' | 'clear_accum'."""
+    """Build the #2936 kernel with one accumulator-initialization variant.
+
+    Parameters
+    ----------
+    init_mode : str
+        One of ``"none"`` (no initialization at all), ``"clear"``, ``"fill"``,
+        ``"copy"``, ``"parallel_store"``, ``"clear_accum"``, ``"prior_gemm"``,
+        or ``"pipelined"``.
+
+    Returns
+    -------
+    tvm.IRModule
+        A module holding the traced kernel, ready to run the pass on.
+    """
 
     @T.prim_func
     def kernel(
@@ -25,38 +38,90 @@ def _make(init_mode):
             T.copy(A[bn, :, :], a_s)
             T.copy(B[bn, :, :], b_s)
             c_f = T.alloc_fragment((BC, BC), torch.float32)
+
             if init_mode == "clear":
                 T.clear(c_f)
-            T.gemm(a_s, b_s, c_f, clear_accum=(init_mode == "clear_accum"))
+            elif init_mode == "fill":
+                T.fill(c_f, 0)
+            elif init_mode == "copy":
+                T.copy(C[bn, :, :], c_f)
+            elif init_mode == "parallel_store":
+                for i, j in T.Parallel(BC, BC):
+                    c_f[i, j] = 0.0
+
+            if init_mode == "prior_gemm":
+                # The first gemm is exempt via clear_accum and writes c_f, so
+                # the second gemm has a definitely-initialized accumulator.
+                T.gemm(a_s, b_s, c_f, clear_accum=True)
+                T.gemm(a_s, b_s, c_f)
+            elif init_mode == "pipelined":
+                # The idiom the check must never flag: clear_accum is an
+                # expression, not a literal False.
+                for k in T.Pipelined(2, num_stages=1):
+                    T.gemm(a_s, b_s, c_f, clear_accum=(k == 0))
+            else:
+                T.gemm(a_s, b_s, c_f, clear_accum=(init_mode == "clear_accum"))
+
             T.copy(c_f, C[bn, :, :])
 
     return tvm.IRModule.from_expr(kernel)
 
 
 def _verify(mod, capfd):
+    """Run the pass on ``mod`` and return whatever it wrote to stderr."""
     tl.transform.VerifyGemmAccumInit()(mod)
     return capfd.readouterr().err
 
 
 def test_warns_when_accumulator_is_uninitialized(capfd):
+    """The #2936 reproducer: no initialization anywhere, so it must warn."""
     assert MESSAGE in _verify(_make("none"), capfd)
 
 
 def test_silent_when_cleared_with_t_clear(capfd):
+    """T.clear writes the accumulator, so the check stays quiet."""
     assert MESSAGE not in _verify(_make("clear"), capfd)
 
 
+def test_silent_when_filled_with_t_fill(capfd):
+    """T.fill marks its region as written, like T.clear."""
+    assert MESSAGE not in _verify(_make("fill"), capfd)
+
+
+def test_silent_when_initialized_by_a_copy(capfd):
+    """A T.copy whose destination is the accumulator counts as a write."""
+    assert MESSAGE not in _verify(_make("copy"), capfd)
+
+
+def test_silent_when_initialized_by_a_parallel_store(capfd):
+    """A direct BufferStore in a T.Parallel loop counts as a write."""
+    assert MESSAGE not in _verify(_make("parallel_store"), capfd)
+
+
 def test_silent_when_clear_accum_is_true(capfd):
+    """A literal clear_accum=True zeroes the accumulator in the gemm itself."""
     assert MESSAGE not in _verify(_make("clear_accum"), capfd)
 
 
+def test_silent_when_a_prior_gemm_initialized_the_accumulator(capfd):
+    """A preceding gemm on the same buffer leaves it written."""
+    assert MESSAGE not in _verify(_make("prior_gemm"), capfd)
+
+
+def test_silent_for_the_pipelined_clear_accum_idiom(capfd):
+    """clear_accum=(k == 0) is not a literal False, so it is never reported."""
+    assert MESSAGE not in _verify(_make("pipelined"), capfd)
+
+
 def test_check_enabled_by_default():
+    """The check is on unless a pass config turns it off."""
     from tilelang.backend.pass_pipeline import pipeline_utils
 
     assert pipeline_utils.should_enable_gemm_accum_init_check() is True
 
 
 def test_check_can_be_disabled_via_pass_config():
+    """tl.disable_gemm_accum_init_check silences the check."""
     from tilelang.backend.pass_pipeline import pipeline_utils
     from tilelang.transform import PassContext
 

--- a/testing/python/transform/test_tilelang_transform_verify_gemm_accum_init.py
+++ b/testing/python/transform/test_tilelang_transform_verify_gemm_accum_init.py
@@ -1,0 +1,54 @@
+import torch
+
+import tilelang as tl
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+
+BC, BK, NB = 16, 64, 16
+MESSAGE = "Uninitialized T.gemm accumulator"
+
+
+def _make(init_mode):
+    """Build the #2936 kernel. init_mode: 'none' | 'clear' | 'clear_accum'."""
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((NB, BC, BK), torch.float32),
+        B: T.Tensor((NB, BK, BC), torch.float32),
+        C: T.Tensor((NB, BC, BC), torch.float32),
+    ):
+        with T.Kernel(1, NB, threads=64) as (bx, by):
+            bn = bx * NB + by
+            a_s = T.alloc_shared((BC, BK), torch.float32)
+            b_s = T.alloc_shared((BK, BC), torch.float32)
+            T.copy(A[bn, :, :], a_s)
+            T.copy(B[bn, :, :], b_s)
+            c_f = T.alloc_fragment((BC, BC), torch.float32)
+            if init_mode == "clear":
+                T.clear(c_f)
+            T.gemm(a_s, b_s, c_f, clear_accum=(init_mode == "clear_accum"))
+            T.copy(c_f, C[bn, :, :])
+
+    return tvm.IRModule.from_expr(kernel)
+
+
+def _verify(mod, capfd):
+    tl.transform.VerifyGemmAccumInit()(mod)
+    return capfd.readouterr().err
+
+
+def test_warns_when_accumulator_is_uninitialized(capfd):
+    assert MESSAGE in _verify(_make("none"), capfd)
+
+
+def test_silent_when_cleared_with_t_clear(capfd):
+    assert MESSAGE not in _verify(_make("clear"), capfd)
+
+
+def test_silent_when_clear_accum_is_true(capfd):
+    assert MESSAGE not in _verify(_make("clear_accum"), capfd)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_verify_gemm_accum_init.py
+++ b/testing/python/transform/test_tilelang_transform_verify_gemm_accum_init.py
@@ -50,5 +50,19 @@ def test_silent_when_clear_accum_is_true(capfd):
     assert MESSAGE not in _verify(_make("clear_accum"), capfd)
 
 
+def test_check_enabled_by_default():
+    from tilelang.backend.pass_pipeline import pipeline_utils
+
+    assert pipeline_utils.should_enable_gemm_accum_init_check() is True
+
+
+def test_check_can_be_disabled_via_pass_config():
+    from tilelang.backend.pass_pipeline import pipeline_utils
+    from tilelang.transform import PassContext
+
+    with PassContext(config={"tl.disable_gemm_accum_init_check": True}):
+        assert pipeline_utils.should_enable_gemm_accum_init_check() is False
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_verify_gemm_accum_init.py
+++ b/testing/python/transform/test_tilelang_transform_verify_gemm_accum_init.py
@@ -1,5 +1,7 @@
+import pytest
 import torch
 
+import tilelang
 import tilelang as tl
 import tilelang.language as T
 import tilelang.testing
@@ -9,7 +11,7 @@ BC, BK, NB = 16, 64, 16
 MESSAGE = "Uninitialized T.gemm accumulator"
 
 
-def _make(init_mode):
+def _kernel(init_mode):
     """Build the #2936 kernel with one accumulator-initialization variant.
 
     Parameters
@@ -21,8 +23,8 @@ def _make(init_mode):
 
     Returns
     -------
-    tvm.IRModule
-        A module holding the traced kernel, ready to run the pass on.
+    tvm.tirx.PrimFunc
+        The traced kernel.
     """
 
     @T.prim_func
@@ -64,7 +66,37 @@ def _make(init_mode):
 
             T.copy(c_f, C[bn, :, :])
 
-    return tvm.IRModule.from_expr(kernel)
+    return kernel
+
+
+def _kernel_two_uninitialized():
+    """Build a kernel with two distinct, both-uninitialized accumulators."""
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((NB, BC, BK), torch.float32),
+        B: T.Tensor((NB, BK, BC), torch.float32),
+        C: T.Tensor((NB, BC, BC), torch.float32),
+    ):
+        with T.Kernel(1, NB, threads=64) as (bx, by):
+            bn = bx * NB + by
+            a_s = T.alloc_shared((BC, BK), torch.float32)
+            b_s = T.alloc_shared((BK, BC), torch.float32)
+            T.copy(A[bn, :, :], a_s)
+            T.copy(B[bn, :, :], b_s)
+            c_f = T.alloc_fragment((BC, BC), torch.float32)
+            d_f = T.alloc_fragment((BC, BC), torch.float32)
+            T.gemm(a_s, b_s, c_f)
+            T.gemm(a_s, b_s, d_f)
+            T.copy(c_f, C[bn, :, :])
+            T.copy(d_f, C[bn, :, :])
+
+    return kernel
+
+
+def _make(init_mode):
+    """Wrap :func:`_kernel` in an IRModule ready to run the pass on."""
+    return tvm.IRModule.from_expr(_kernel(init_mode))
 
 
 def _verify(mod, capfd):
@@ -73,9 +105,33 @@ def _verify(mod, capfd):
     return capfd.readouterr().err
 
 
+@pytest.fixture
+def no_kernel_cache():
+    """Compile without the kernel cache so the pass runs on every compile.
+
+    A cached kernel is returned without re-running the pass pipeline, which
+    would make a warning silently disappear on the second compile.
+    """
+    was_enabled = tilelang.is_cache_enabled()
+    tilelang.disable_cache()
+    yield
+    if was_enabled:
+        tilelang.enable_cache()
+
+
 def test_warns_when_accumulator_is_uninitialized(capfd):
     """The #2936 reproducer: no initialization anywhere, so it must warn."""
     assert MESSAGE in _verify(_make("none"), capfd)
+
+
+def test_aggregates_multiple_uninitialized_accumulators(capfd):
+    """Two bad accumulators produce one aggregated warning, not two."""
+    mod = tvm.IRModule.from_expr(_kernel_two_uninitialized())
+    err = _verify(mod, capfd)
+
+    assert err.count(MESSAGE) == 1
+    assert "2 accumulator(s)" in err
+    assert "[1]" in err and "[2]" in err
 
 
 def test_silent_when_cleared_with_t_clear(capfd):
@@ -127,6 +183,25 @@ def test_check_can_be_disabled_via_pass_config():
 
     with PassContext(config={"tl.disable_gemm_accum_init_check": True}):
         assert pipeline_utils.should_enable_gemm_accum_init_check() is False
+
+
+@tilelang.testing.requires_cuda
+def test_pipeline_warns_by_default(capfd, no_kernel_cache):
+    """The wired pipeline warns on an uninitialized accumulator."""
+    tilelang.compile(_kernel("none"))
+
+    assert MESSAGE in capfd.readouterr().err
+
+
+@tilelang.testing.requires_cuda
+def test_pipeline_silent_when_disabled_via_pass_config(capfd, no_kernel_cache):
+    """The pass config suppresses the warning through the whole pipeline."""
+    tilelang.compile(
+        _kernel("none"),
+        pass_configs={tilelang.PassConfigKey.TL_DISABLE_GEMM_ACCUM_INIT_CHECK: True},
+    )
+
+    assert MESSAGE not in capfd.readouterr().err
 
 
 if __name__ == "__main__":

--- a/tilelang/backend/pass_pipeline/pipeline_utils.py
+++ b/tilelang/backend/pass_pipeline/pipeline_utils.py
@@ -69,11 +69,15 @@ def should_enable_race_check(pass_ctx: PassContext | None = None) -> bool:
 
 
 def should_enable_gemm_accum_init_check(pass_ctx: PassContext | None = None) -> bool:
+    """Whether the T.gemm accumulator-initialization check runs.
+
+    Enabled by default, unlike the data race check: this check only fires
+    when ``clear_accum`` is literally false and no write to the accumulator
+    was seen anywhere earlier, so correct kernels do not trip it. Disable it
+    per-compile with the ``tl.disable_gemm_accum_init_check`` pass config.
+    """
     if pass_ctx is None:
         pass_ctx = tilelang.transform.get_pass_context()
-    # Enabled by default, unlike the data race check: this check only fires
-    # when `clear_accum` is literally false and no write to the accumulator was
-    # seen anywhere earlier, so correct kernels do not trip it.
     disable = pass_ctx.config.get(tilelang.PassConfigKey.TL_DISABLE_GEMM_ACCUM_INIT_CHECK, False)
     return not disable
 

--- a/tilelang/backend/pass_pipeline/pipeline_utils.py
+++ b/tilelang/backend/pass_pipeline/pipeline_utils.py
@@ -68,6 +68,16 @@ def should_enable_race_check(pass_ctx: PassContext | None = None) -> bool:
     return not disable
 
 
+def should_enable_gemm_accum_init_check(pass_ctx: PassContext | None = None) -> bool:
+    if pass_ctx is None:
+        pass_ctx = tilelang.transform.get_pass_context()
+    # Enabled by default, unlike the data race check: this check only fires
+    # when `clear_accum` is literally false and no write to the accumulator was
+    # seen anywhere earlier, so correct kernels do not trip it.
+    disable = pass_ctx.config.get(tilelang.PassConfigKey.TL_DISABLE_GEMM_ACCUM_INIT_CHECK, False)
+    return not disable
+
+
 def should_disable_shared_memory_reuse(pass_ctx: PassContext | None = None) -> bool:
     if pass_ctx is None:
         pass_ctx = tilelang.transform.get_pass_context()

--- a/tilelang/cpu/pipeline.py
+++ b/tilelang/cpu/pipeline.py
@@ -8,6 +8,7 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
     LayoutVisual,
     allow_vectorize,
     should_enable_race_check,
+    should_enable_gemm_accum_init_check,
     should_force_let_inline,
 )
 
@@ -23,6 +24,9 @@ def CPUPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.LegalizeNegativeIndex()(mod)
     if should_enable_race_check():
         mod = tilelang.transform.VerifyParallelLoop()(mod)
+    # Warn on T.gemm accumulators that are never initialized
+    if should_enable_gemm_accum_init_check():
+        mod = tilelang.transform.VerifyGemmAccumInit()(mod)
     mod = tilelang.transform.InjectAssumes()(mod)
     mod = tilelang.transform.Simplify()(mod)
     mod = tilelang.transform.LayoutReducer()(mod)

--- a/tilelang/cuda/pipeline.py
+++ b/tilelang/cuda/pipeline.py
@@ -13,6 +13,7 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
     should_disable_shared_memory_reuse,
     should_enable_aggressive_merge,
     should_enable_race_check,
+    should_enable_gemm_accum_init_check,
     should_force_let_inline,
 )
 from tilelang.contrib.nvcc import (
@@ -82,6 +83,9 @@ def CUDAPassPipelineBodyPrologue(mod: IRModule, target: Target) -> IRModule:
     # Verify parallel loop correctness
     if should_enable_race_check():
         mod = tilelang.transform.VerifyParallelLoop()(mod)
+    # Warn on T.gemm accumulators that are never initialized
+    if should_enable_gemm_accum_init_check():
+        mod = tilelang.transform.VerifyGemmAccumInit()(mod)
     # Inject assumes to speedup tvm prover
     mod = tilelang.transform.InjectAssumes()(mod)
     # Simplify the IR expressions

--- a/tilelang/metal/pipeline.py
+++ b/tilelang/metal/pipeline.py
@@ -10,6 +10,7 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
     should_disable_shared_memory_reuse,
     should_enable_aggressive_merge,
     should_enable_race_check,
+    should_enable_gemm_accum_init_check,
     should_force_let_inline,
 )
 from tilelang.metal.transform import MetalFragmentToSimdgroup
@@ -26,6 +27,9 @@ def MetalPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.LegalizeNegativeIndex()(mod)
     if should_enable_race_check():
         mod = tilelang.transform.VerifyParallelLoop()(mod)
+    # Warn on T.gemm accumulators that are never initialized
+    if should_enable_gemm_accum_init_check():
+        mod = tilelang.transform.VerifyGemmAccumInit()(mod)
     mod = tilelang.transform.InjectAssumes()(mod)
     mod = tilelang.transform.Simplify()(mod)
     mod = tilelang.transform.LayoutReducer()(mod)

--- a/tilelang/rocm/pipeline.py
+++ b/tilelang/rocm/pipeline.py
@@ -10,6 +10,7 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
     should_disable_shared_memory_reuse,
     should_enable_aggressive_merge,
     should_enable_race_check,
+    should_enable_gemm_accum_init_check,
     should_force_let_inline,
 )
 
@@ -25,6 +26,9 @@ def ROCMPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.LegalizeNegativeIndex()(mod)
     if should_enable_race_check():
         mod = tilelang.transform.VerifyParallelLoop()(mod)
+    # Warn on T.gemm accumulators that are never initialized
+    if should_enable_gemm_accum_init_check():
+        mod = tilelang.transform.VerifyGemmAccumInit()(mod)
     mod = tilelang.transform.InjectAssumes()(mod)
     mod = tilelang.transform.Simplify()(mod)
     mod = tilelang.transform.LayoutReducer()(mod)

--- a/tilelang/transform/__init__.py
+++ b/tilelang/transform/__init__.py
@@ -105,6 +105,19 @@ def VerifyParallelLoop():
     return _ffi_api.VerifyParallelLoop()  # type: ignore
 
 
+def VerifyGemmAccumInit():
+    """VerifyGemmAccumInit
+
+    Warn when a T.gemm accumulator is not provably initialized before use.
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    """
+    return _ffi_api.VerifyGemmAccumInit()  # type: ignore
+
+
 def ThreadSync(storage_scope: str):
     """Insert sync between parallel read/write of shared buffers.
 

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -50,7 +50,6 @@ class PassConfigKey(str, Enum):
     """Enable inlining of let statements during simplification. Default: True"""
 
     TL_DISABLE_DATA_RACE_CHECK = "tl.disable_data_race_check"
-    TL_DISABLE_GEMM_ACCUM_INIT_CHECK = "tl.disable_gemm_accum_init_check"
     """Disable data race check in TileLang. Default: True
 
     The data race check is disabled by default because it can report false
@@ -58,6 +57,16 @@ class PassConfigKey(str, Enum):
     proven distinct). To enable it, set this config to False in pass configs,
     or set the ``TILELANG_ENABLE_DATA_RACE_CHECK`` environment variable to a
     truthy value (e.g. ``1``).
+    """
+
+    TL_DISABLE_GEMM_ACCUM_INIT_CHECK = "tl.disable_gemm_accum_init_check"
+    """Disable the T.gemm accumulator initialization check. Default: False
+
+    The check is enabled by default. It reports a T.gemm only when its
+    accumulator has no preceding write and its ``clear_accum`` argument is
+    the literal ``False``, so correct kernels — including the pipelined
+    ``clear_accum=(k == 0)`` idiom — do not trip it. Set this config to True
+    to silence it.
     """
 
     TL_DISABLE_PRELOWER_SEMANTIC_CHECK = "tl.disable_prelower_semantic_check"

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -50,6 +50,7 @@ class PassConfigKey(str, Enum):
     """Enable inlining of let statements during simplification. Default: True"""
 
     TL_DISABLE_DATA_RACE_CHECK = "tl.disable_data_race_check"
+    TL_DISABLE_GEMM_ACCUM_INIT_CHECK = "tl.disable_gemm_accum_init_check"
     """Disable data race check in TileLang. Default: True
 
     The data race check is disabled by default because it can report false

--- a/tilelang/webgpu/pipeline.py
+++ b/tilelang/webgpu/pipeline.py
@@ -10,6 +10,7 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
     should_disable_shared_memory_reuse,
     should_enable_aggressive_merge,
     should_enable_race_check,
+    should_enable_gemm_accum_init_check,
     should_force_let_inline,
 )
 
@@ -27,6 +28,9 @@ def WebGPUPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.LegalizeNegativeIndex()(mod)
     if should_enable_race_check():
         mod = tilelang.transform.VerifyParallelLoop()(mod)
+    # Warn on T.gemm accumulators that are never initialized
+    if should_enable_gemm_accum_init_check():
+        mod = tilelang.transform.VerifyGemmAccumInit()(mod)
     mod = tilelang.transform.InjectAssumes()(mod)
     mod = tilelang.transform.Simplify()(mod)
     mod = tilelang.transform.LayoutReducer()(mod)


### PR DESCRIPTION
## What

Adds `VerifyGemmAccumInit`, a compile-time diagnostic that warns when a `T.gemm` accumulator cannot be shown to be initialized before use.

```
Warning: Uninitialized T.gemm accumulator: 1 accumulator(s) read before being written
  [1] `c_f` is passed to T.gemm without being initialized
  --> kernel.py:40:1
T.gemm accumulates into C, so an uninitialized accumulator adds into stale register
contents. Add `T.clear(C)` before the gemm, or pass `clear_accum=True`. ...
```

## Why

`T.gemm` accumulates into its C operand and `clear_accum` defaults to `False`, so a fragment that is never written is read while uninitialized. That is undefined behaviour: it silently produces correct results on some architectures and NaN on others.

This came out of #2936, where a kernel with no accumulator initialization returned NaN on sm_89. On sm_86 the same kernel returns correct results in every configuration I tested, which is what makes this failure mode expensive to diagnose — nothing is wrong with the compiler, and the symptom does not reproduce on the machine you are debugging on. The generated CUDA tells the whole story:

```c
float c_f[4];                                    // declared, no initializer
...
tl::mma_sync<...>(c_f, A_local, B_local);        // reads c_f at ki == 0
```

## How

The pass walks the body in execution order before `LowerTileOp` — after that point `tl.gemm` is expanded into MMA intrinsics and the accumulator's identity is no longer recoverable. It tracks which buffers have been definitely written, and reports any `tl.gemm` whose C operand is unwritten *and* whose `clear_accum` argument is the literal `false`. Findings are aggregated into a single warning, following `VerifyParallelLoop`.

A write is recognised from the access mask on a `tl.region` argument (so `T.clear`/`T.fill`, a `T.copy` destination, and a prior gemm on the same buffer all count), or from a direct `BufferStore` (a `T.Parallel` loop body).

The rule is deliberately permissive: a write anywhere earlier in execution order counts, including inside a loop or conditional the gemm is not part of. A false positive on correct code is worse than missing an exotic case.

The pipelined `clear_accum=(k == 0)` idiom is quiet automatically — `k == 0` is not a literal `false`, so it is never reported. No pattern-matching on that idiom was needed.

## Testing

- Five unit tests: warns when uninitialized; silent with `T.clear`; silent with `clear_accum=True`; enabled by default; disabled via `tl.disable_gemm_accum_init_check`.
- **False-positive sweep over real in-tree GEMM kernels** — `testing/python/kernel/test_tilelang_kernel_gemm{,_batched,_simt,_with_stride}.py` and `examples/gemm/test_example_gemm.py`: **22 passed, 0 warnings**.
- End-to-end through the full JIT pipeline: the #2936 reproducer warns; the same kernel with `T.clear` or `clear_accum=True` does not; `@tilelang.jit(pass_configs={PassConfigKey.TL_DISABLE_GEMM_ACCUM_INIT_CHECK: True})` suppresses it.
- Regression check: `testing/python/transform/` — 316 passed, 87 skipped. `testing/python/language/` — 989 passed, 170 skipped. **Zero accumulator warnings across either suite.** Five pre-existing failures in the language suite (`get_warp_info`, `let`, `ptr`, `tma_1d`) reproduce identically on `origin/main` without this change; they are unrelated and hardware-specific to my sm_86 box.

## Notes

The check is **on by default**, unlike the data-race check. It only fires when `clear_accum` is literally false and no write to the accumulator was seen anywhere earlier, so correct kernels do not trip it — and the sweep above found no in-tree kernel that does. A diagnostic that was off by default would not have helped the reporter of #2936, which is the point of the pass. Happy to flip it to opt-in if you would rather it match the race check.

`T.gemm_sp` has the same `clear_accum` semantics (`args[11]`) and is not covered here, to keep this reviewable. Glad to follow up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds `VerifyGemmAccumInit`, a compile-time diagnostic for `T.gemm` accumulators that lack a provable prior initialization.

- Tracks writes from `T.clear`, `T.fill`, `T.copy` destinations, prior GEMMs, and direct `BufferStore` operations.
- Warns when the C operand is unwritten and `clear_accum` is literally `false`.
- Aggregates findings into one warning.
- Runs before `LowerTileOp` in CPU, CUDA, Metal, ROCm, and WebGPU pipelines.
- Enables the check by default.
- Supports disabling through `tl.disable_gemm_accum_init_check` and `PassConfigKey.TL_DISABLE_GEMM_ACCUM_INIT_CHECK`.
- Leaves `clear_accum=True`, prior initialization, and non-literal expressions such as `clear_accum=(k == 0)` unreported.
- Does not cover `T.gemm_sp`.
- Adds regression tests for supported initialization paths, warning aggregation, and default and disabled configurations.

## C++ style / lint notes

The PR changes C++ files but does not change rules documented in `docs/developer_guide/cpp_style.md`. The C++ API Style Audit (warning only) may report advisory TLCPP003/TLCPP004 findings. These findings are separate from correctness, build, and test results and should not block the PR unless they indicate a clear API, FFI, or maintainability risk.

## Testing

GEMM kernel tests and transform/language suites pass with no new accumulator warnings. Five unrelated pre-existing language-suite failures reproduce on the target branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->