### PR TITLE
[CPU] Support atomic ops on CPU

### DIFF
--- a/src/cpu/CMakeLists.txt
+++ b/src/cpu/CMakeLists.txt
@@ -8,6 +8,7 @@ file(GLOB TILE_LANG_CPU_SRCS
   src/cpu/codegen/codegen_c.cc
   src/cpu/codegen/rt_mod_c.cc
   src/cpu/op/*.cc
+  src/cpu/transform/*.cc
   src/cpu/target_utils.cc
 )
 list(APPEND TILE_LANG_SRCS ${TILE_LANG_CPU_SRCS})

--- a/src/cpu/op/atomic_add.cc
+++ b/src/cpu/op/atomic_add.cc
@@ -1,0 +1,58 @@
+/*!
+ * \file tl/cpu/op/atomic_add.cc
+ * \brief CPU implementation for tl.atomicadd lowering (serial RMW).
+ *
+ * CPU execution is serial, so atomic_add degenerates to a plain
+ * read-modify-write (`dst = dst + value`) inside a kSerial loop nest built
+ * by cpu::LowerAtomicRMW. See atomic_rmw.h for the full contract
+ * (memory_order ignored, use_tma rejected).
+ */
+
+#include "op/atomic_add.h"
+
+#include "atomic_rmw.h"
+#include "backend/common/target_utils.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+
+namespace cpu {
+
+struct AtomicAdd {
+  static LayoutMap InferLayout(const AtomicAddNode &, const LayoutInferArgs &,
+                               InferLevel) {
+    // CPU has no fragment/shared layouts to infer.
+    return LayoutMap{};
+  }
+
+  static Stmt Lower(const AtomicAddNode &op, const LowerArgs &lower_args,
+                    arith::Analyzer *analyzer) {
+    (void)analyzer;
+    return LowerAtomicRMW(op, AtomicCombine::kAdd, lower_args, "atomic_add");
+  }
+};
+
+} // namespace cpu
+
+namespace {
+
+bool MatchCPUAtomicAddTarget(Target target) { return TargetIsCPU(target); }
+
+bool RegisterCPUAtomicAdd() {
+  RegisterAtomicAddImpl(AtomicAddImpl{
+      "cpu.AtomicAdd",
+      MatchCPUAtomicAddTarget,
+      cpu::AtomicAdd::InferLayout,
+      cpu::AtomicAdd::Lower,
+  });
+  return true;
+}
+
+const bool cpu_atomic_add_registered = RegisterCPUAtomicAdd();
+
+} // namespace
+
+} // namespace tl
+} // namespace tvm

--- a/src/cpu/op/atomic_reduce.cc
+++ b/src/cpu/op/atomic_reduce.cc
@@ -1,0 +1,70 @@
+/*!
+ * \file tl/cpu/op/atomic_reduce.cc
+ * \brief CPU implementation for tl.atomicmax/tl.atomicmin lowering
+ *        (serial RMW).
+ *
+ * CPU execution is serial, so atomic_max/atomic_min degenerate to a plain
+ * read-modify-write (`dst = max/min(dst, value)`) inside a kSerial loop nest
+ * built by cpu::LowerAtomicRMW. Both ops share the AtomicReduceImpl registry
+ * and are told apart via GetElemOp(). See atomic_rmw.h for the full contract
+ * (memory_order ignored, use_tma rejected).
+ */
+
+#include "op/atomic_reduce.h"
+
+#include "atomic_rmw.h"
+#include "backend/common/target_utils.h"
+#include "op/builtin.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+
+namespace cpu {
+
+struct AtomicReduce {
+  static LayoutMap InferLayout(const AtomicOpBaseNode &,
+                               const LayoutInferArgs &, InferLevel) {
+    // CPU has no fragment/shared layouts to infer.
+    return LayoutMap{};
+  }
+
+  static Stmt Lower(const AtomicOpBaseNode &op, const LowerArgs &lower_args,
+                    arith::Analyzer *analyzer) {
+    (void)analyzer;
+    AtomicCombine combine;
+    if (op.GetElemOp().same_as(atomic_max_elem_op())) {
+      combine = AtomicCombine::kMax;
+    } else {
+      ICHECK(op.GetElemOp().same_as(atomic_min_elem_op()))
+          << "CPU atomic_reduce: unexpected elem op " << op.GetElemOp()->name
+          << " (only atomic_max/atomic_min are registered).";
+      combine = AtomicCombine::kMin;
+    }
+    return LowerAtomicRMW(op, combine, lower_args, "atomic_reduce");
+  }
+};
+
+} // namespace cpu
+
+namespace {
+
+bool MatchCPUAtomicReduceTarget(Target target) { return TargetIsCPU(target); }
+
+bool RegisterCPUAtomicReduce() {
+  RegisterAtomicReduceImpl(AtomicReduceImpl{
+      "cpu.AtomicReduce",
+      MatchCPUAtomicReduceTarget,
+      cpu::AtomicReduce::InferLayout,
+      cpu::AtomicReduce::Lower,
+  });
+  return true;
+}
+
+const bool cpu_atomic_reduce_registered = RegisterCPUAtomicReduce();
+
+} // namespace
+
+} // namespace tl
+} // namespace tvm

--- a/src/cpu/op/atomic_rmw.h
+++ b/src/cpu/op/atomic_rmw.h
@@ -1,0 +1,160 @@
+/*!
+ * \file tl/cpu/op/atomic_rmw.h
+ * \brief Shared serial read-modify-write lowering for CPU atomic tile ops.
+ *
+ * CPU execution is serial, so an atomic update degenerates to a plain
+ * read-modify-write on the destination buffer. This helper builds a kSerial
+ * loop nest over the destination region whose body is a plain
+ * BufferLoad/combine/BufferStore, mirroring the src/cpu/op/reduce.cc
+ * conventions (no SIMD, no thread-level parallelism; correctness first).
+ *
+ * `memory_order` annotations are accepted but ignored: without concurrency
+ * there is no memory ordering semantics. When CPU gains thread-level
+ * parallelism this helper (and tl.transform.LowerCPUAtomics for the scalar
+ * path) is the single place to switch to `__atomic_*` / `std::atomic_ref`.
+ */
+
+#ifndef TVM_TL_CPU_OP_ATOMIC_RMW_H_
+#define TVM_TL_CPU_OP_ATOMIC_RMW_H_
+
+#include <tvm/runtime/logging.h>
+#include <tvm/tirx/op.h>
+
+#include <string>
+
+#include "op/atomic_reduce.h"
+#include "op/utils.h"
+#include "support/check.h"
+#include "transform/loop_partition.h"
+
+namespace tvm {
+namespace tl {
+namespace cpu {
+
+using namespace tirx;
+
+/// Combine operator of an atomic update: `dst = dst <combine> value`.
+enum class AtomicCombine { kAdd, kMax, kMin };
+
+inline PrimExpr MakeAtomicCombine(AtomicCombine combine, const PrimExpr &old,
+                                  const PrimExpr &value) {
+  switch (combine) {
+  case AtomicCombine::kAdd:
+    return old + value;
+  case AtomicCombine::kMax:
+    return Max(old, value);
+  case AtomicCombine::kMin:
+    return Min(old, value);
+  }
+  LOG(FATAL) << "Unreachable atomic combine kind";
+  return PrimExpr();
+}
+
+/*!
+ * \brief Lower an atomic tile op (add/max/min) to a serial RMW loop nest.
+ * \param op The atomic op (AtomicAddNode/AtomicMaxNode/AtomicMinNode).
+ * \param combine The combine operator matching `op.GetElemOp()`.
+ * \param lower_args Lowering context (target, buffer_remap).
+ * \param op_name Name used in diagnostics (e.g. "atomic_add").
+ */
+inline Stmt LowerAtomicRMW(const AtomicOpBaseNode &op, AtomicCombine combine,
+                           const LowerArgs &lower_args, const char *op_name) {
+  // TMA (cp.reduce) is a CUDA sm90+ feature with no CPU equivalent.
+  if (op.annotations.Get("use_tma")) {
+    LOG(FATAL) << "CPU " << op_name
+               << " does not support use_tma=True: TMA (cp.reduce) is a "
+                  "CUDA sm90+ feature. Target was: "
+               << lower_args.target->str();
+  }
+
+  // buffer_remap resolution (mirror src/cpu/op/reduce.cc).
+  auto get_buffer = [&](const Buffer &buffer) {
+    auto it = lower_args.buffer_remap.find(buffer);
+    return it == lower_args.buffer_remap.end() ? buffer : (*it).second;
+  };
+  Buffer dst_buffer = get_buffer(op.dst);
+
+  // The dst of a CPU atomic is a global output tensor or a local buffer;
+  // shared/fragment scopes do not exist on CPU.
+  if (!IsGlobalBuffer(op.dst) && !IsLocalBuffer(op.dst, /*allow_var=*/true)) {
+    LOG(FATAL) << "CPU " << op_name
+               << " only supports global/local dst buffers, got dst scope `"
+               << op.dst.scope() << "`.";
+  }
+
+  // One loop var per non-unit dst extent, in order; the k-th non-unit dst
+  // dim pairs with the k-th non-unit src dim. This is the same convention as
+  // the GPU MakeIterVars/MakeIndices (backend/common/op/atomic_reduce.h),
+  // and matches the frontend's legalize_pairwise_extents, which may leave
+  // src/dst ranges with different ndim but an equal count of non-unit dims.
+  Array<Var> loop_vars;
+  Array<PrimExpr> loop_extents;
+  Array<PrimExpr> dst_indices;
+  for (size_t k = 0; k < op.dst_range.size(); ++k) {
+    const Range &range = op.dst_range[k];
+    if (is_one(range->extent)) {
+      dst_indices.push_back(range->min);
+    } else {
+      Var var("i" + std::to_string(loop_vars.size()), range->extent->dtype);
+      loop_vars.push_back(var);
+      loop_extents.push_back(range->extent);
+      dst_indices.push_back(range->min + var);
+    }
+  }
+
+  PrimExpr value = op.src_value;
+  if (!op.src_value.defined()) {
+    Buffer src_buffer = get_buffer(op.src);
+    Array<PrimExpr> src_indices;
+    size_t var_idx = 0;
+    for (size_t k = 0; k < op.src_range.size(); ++k) {
+      const Range &range = op.src_range[k];
+      if (is_one(range->extent)) {
+        src_indices.push_back(range->min);
+      } else {
+        ICHECK_LT(var_idx, loop_vars.size())
+            << "CPU " << op_name
+            << ": src region has more non-unit extents than dst region "
+               "(src ndim="
+            << op.src_range.size() << ", dst ndim=" << op.dst_range.size()
+            << ").";
+        src_indices.push_back(range->min + loop_vars[var_idx]);
+        ++var_idx;
+      }
+    }
+    ICHECK_EQ(var_idx, loop_vars.size())
+        << "CPU " << op_name
+        << ": src and dst regions must have the same number of non-unit "
+           "extents after frontend extent legalization, got "
+        << var_idx << " vs " << loop_vars.size() << ".";
+    value = BufferLoad(src_buffer, src_indices);
+  }
+  if (value->dtype != dst_buffer->dtype) {
+    value = Cast(dst_buffer->dtype, value);
+  }
+
+  // Serial read-modify-write: plain BufferStore, no atomic intrinsic.
+  Stmt body = BufferStore(
+      dst_buffer,
+      MakeAtomicCombine(combine, BufferLoad(dst_buffer, dst_indices), value),
+      dst_indices);
+
+  // kSerial loops wrapped with PragmaUnrollLoop, matching the fill.cc /
+  // reduce.cc CPU op convention (transpose.cc does not use it); under the
+  // default UnrollLoopConfig (explicit_unroll=false) the tag is a no-op
+  // marker.
+  for (int i = static_cast<int>(loop_vars.size()) - 1; i >= 0; --i) {
+    body = For(loop_vars[i], 0, loop_extents[i], ForKind::kSerial, body,
+               std::nullopt);
+  }
+  if (!loop_vars.empty()) {
+    body = PragmaUnrollLoop(Downcast<For>(body));
+  }
+  return body;
+}
+
+} // namespace cpu
+} // namespace tl
+} // namespace tvm
+
+#endif // TVM_TL_CPU_OP_ATOMIC_RMW_H_

--- a/src/cpu/op/reduce.cc
+++ b/src/cpu/op/reduce.cc
@@ -134,8 +134,8 @@ struct Reduce {
                         reduce_body, std::nullopt));
 
     // 8. Outer dst-dim loops. Built as kSerial then wrapped with
-    //    PragmaUnrollLoop to match the fill.cc/transpose.cc CPU op convention.
-    //    PragmaUnrollLoop (LoopPramaUnroller, loop_partition.cc:163-181)
+    //    PragmaUnrollLoop to match the fill.cc CPU op convention.
+    //    PragmaUnrollLoop (LoopPramaUnroller, loop_partition.cc)
     //    only retags the outermost kSerial For it meets and returns without
     //    recursing into the body, so the inner kSerial reduce loop above is
     //    left untouched. Under the default UnrollLoopConfig

--- a/src/cpu/transform/lower_cpu_atomics.cc
+++ b/src/cpu/transform/lower_cpu_atomics.cc
@@ -1,0 +1,296 @@
+/*!
+ * \file lower_cpu_atomics.cc
+ * \brief Lower `tl.atomic_*_elem_op` intrinsics to plain serial
+ *        read-modify-write for CPU targets.
+ *
+ * CPU execution is serial, so an atomic update degenerates to a plain
+ * read-modify-write: `dst = dst <op> value`, with `return_prev` yielding the
+ * value stored before the update. `memory_order` arguments are accepted and
+ * ignored (there is no memory ordering semantics without concurrency); when
+ * CPU gains thread-level parallelism this pass (together with
+ * src/cpu/op/atomic_rmw.h for the tile-region path) is the single place to
+ * switch to `__atomic_*` / `std::atomic_ref`.
+ *
+ * The pass runs on the CPU pipeline right after LowerTileOp (tile-region
+ * atomics are already lowered to plain RMW loops by src/cpu/op/atomic_add.cc
+ * and atomic_reduce.cc) and before LegalizeVectorizedLoop /
+ * LegalizeSafeMemoryAccess / LowerAccessPtr, so every downstream pass and
+ * both CPU codegens only ever see plain BufferLoad/BufferStore. This is also
+ * why no CPU codegen changes are needed: the `c` codegen rejects unknown
+ * intrinsics at compile time with an `Unresolved call` InternalError
+ * (3rdparty/tvm/src/target/source/codegen_c.cc), and the `llvm` codegen
+ * (vendored TVM) rejects them as unknown intrinsics.
+ */
+
+#include "support/check.h"
+#include <tvm/ir/cast.h>
+#include <tvm/tirx/op.h>
+#include <tvm/tirx/stmt.h>
+#include <tvm/tirx/stmt_functor.h>
+#include <tvm/tirx/transform.h>
+
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "op/builtin.h"
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+using namespace ffi;
+
+namespace {
+
+/// Kind of an atomic read-modify-write elem op.
+enum class AtomicRMWKind { kAdd, kMax, kMin, kOr, kStore, kAddVec };
+
+struct AtomicRMWOp {
+  AtomicRMWKind kind;
+  int lanes;         ///< 1 for scalar ops, 2/4 for kAddVec
+  bool returns_prev; ///< `_ret` variants return the pre-update value
+};
+
+/// Match all 12 side-effect atomic elem ops (everything but atomic_load).
+std::optional<AtomicRMWOp> MatchAtomicRMWOp(const ObjectRef &op) {
+  if (op.same_as(atomic_add_elem_op()))
+    return AtomicRMWOp{AtomicRMWKind::kAdd, 1, false};
+  if (op.same_as(atomic_add_ret_elem_op()))
+    return AtomicRMWOp{AtomicRMWKind::kAdd, 1, true};
+  if (op.same_as(atomic_max_elem_op()))
+    return AtomicRMWOp{AtomicRMWKind::kMax, 1, false};
+  if (op.same_as(atomic_max_ret_elem_op()))
+    return AtomicRMWOp{AtomicRMWKind::kMax, 1, true};
+  if (op.same_as(atomic_min_elem_op()))
+    return AtomicRMWOp{AtomicRMWKind::kMin, 1, false};
+  if (op.same_as(atomic_min_ret_elem_op()))
+    return AtomicRMWOp{AtomicRMWKind::kMin, 1, true};
+  if (op.same_as(atomic_or_elem_op()))
+    return AtomicRMWOp{AtomicRMWKind::kOr, 1, false};
+  if (op.same_as(atomic_store_elem_op()))
+    return AtomicRMWOp{AtomicRMWKind::kStore, 1, false};
+  if (op.same_as(atomic_addx2_elem_op()))
+    return AtomicRMWOp{AtomicRMWKind::kAddVec, 2, false};
+  if (op.same_as(atomic_addx4_elem_op()))
+    return AtomicRMWOp{AtomicRMWKind::kAddVec, 4, false};
+  if (op.same_as(atomic_addx2_ret_elem_op()))
+    return AtomicRMWOp{AtomicRMWKind::kAddVec, 2, true};
+  if (op.same_as(atomic_addx4_ret_elem_op()))
+    return AtomicRMWOp{AtomicRMWKind::kAddVec, 4, true};
+  return std::nullopt;
+}
+
+/// Buffer and element indices recovered from a `tl.access_ptr` argument.
+struct AtomicAccess {
+  Buffer buffer;
+  Array<PrimExpr> indices;
+};
+
+PrimExpr MakeRMWCombine(AtomicRMWKind kind, const PrimExpr &old,
+                        const PrimExpr &value) {
+  switch (kind) {
+  case AtomicRMWKind::kAdd:
+  case AtomicRMWKind::kAddVec:
+    return old + value;
+  case AtomicRMWKind::kMax:
+    return Max(old, value);
+  case AtomicRMWKind::kMin:
+    return Min(old, value);
+  case AtomicRMWKind::kOr:
+    return old | value;
+  case AtomicRMWKind::kStore:
+    return value;
+  }
+  LOG(FATAL) << "Unreachable atomic RMW kind";
+  return PrimExpr();
+}
+
+PrimExpr CastIfNeeded(DataType dtype, const PrimExpr &value) {
+  return value->dtype == dtype ? value : Cast(dtype, value);
+}
+
+class CPUAtomicRewriter : public StmtExprMutator {
+public:
+  CPUAtomicRewriter() = default;
+
+  static PrimFunc Rewrite(PrimFunc func) {
+    if (!func.defined() || !func->body.defined()) {
+      return func;
+    }
+    CPUAtomicRewriter rewriter;
+    PrimFuncNode *n = func.CopyOnWrite();
+    n->body = rewriter(std::move(n->body));
+    return func;
+  }
+
+  // A `return_prev` rewrite records (Bind of the old value, RMW store) pairs
+  // while visiting expressions; each statement is wrapped so that the pairs
+  // execute before the original statement:
+  //   SeqStmt(Bind(old, BufferLoad(dst, idx)),
+  //           BufferStore(dst, old <op> v, idx),
+  //           <stmt using old>)
+  // Bind has no body: the variable is visible in the subsequent statements
+  // of the enclosing SeqStmt, so the old value is read before the store.
+  Stmt VisitStmt(const Stmt &stmt) final {
+    std::vector<Stmt> outer_prefix = std::move(pending_prefix_);
+    pending_prefix_.clear();
+
+    Stmt result = StmtExprMutator::VisitStmt(stmt);
+
+    if (!pending_prefix_.empty()) {
+      pending_prefix_.push_back(result);
+      result = SeqStmt::Flatten(pending_prefix_);
+    }
+
+    pending_prefix_ = std::move(outer_prefix);
+    return result;
+  }
+
+  Stmt VisitStmt_(const EvaluateNode *op) final {
+    // Statement position: the result (if any) is discarded, so `_ret`
+    // variants lower to the same plain RMW as their base op.
+    if (const auto *call = op->value.as<CallNode>()) {
+      if (std::optional<AtomicRMWOp> rmw = MatchAtomicRMWOp(call->op)) {
+        return LowerStmtAtomic(*call, *rmw);
+      }
+    }
+    return StmtExprMutator::VisitStmt_(op);
+  }
+
+  PrimExpr VisitExpr_(const CallNode *op) final {
+    if (op->op.same_as(atomic_load_elem_op())) {
+      // Pure read on a serial target.
+      AtomicAccess access = ParseAtomicAccessPtr(op->args[0], "atomic_load");
+      return BufferLoad(access.buffer, MutateIndices(access.indices));
+    }
+    if (std::optional<AtomicRMWOp> rmw = MatchAtomicRMWOp(op->op)) {
+      ICHECK(rmw->returns_prev)
+          << "CPU atomic lowering: " << op->op
+          << " has no return value and cannot appear in expression position; "
+             "use it as a standalone statement.";
+      ICHECK(rmw->lanes == 1)
+          << "CPU atomic lowering: atomic_addx" << rmw->lanes
+          << " with return_prev=True is not supported on CPU (the previous "
+             "vector value cannot be represented without TIR vector "
+             "construction); drop return_prev or use scalar atomic_add.";
+      return RewriteRetAtomic(*op, *rmw);
+    }
+    return StmtExprMutator::VisitExpr_(op);
+  }
+
+private:
+  AtomicAccess ParseAtomicAccessPtr(const PrimExpr &ptr, const char *role) {
+    const auto *call = ptr.as<CallNode>();
+    ICHECK(call != nullptr && call->op.same_as(tl::access_ptr()))
+        << "CPU atomic lowering expects the " << role
+        << " argument to be a tl.access_ptr call, but got: " << ptr;
+    const auto *load = call->args[0].as<BufferLoadNode>();
+    ICHECK(load != nullptr)
+        << "CPU atomic lowering expects the tl.access_ptr base of " << role
+        << " to be a BufferLoad, but got: " << call->args[0];
+    return {load->buffer, load->indices};
+  }
+
+  Array<PrimExpr> MutateIndices(const Array<PrimExpr> &indices) {
+    Array<PrimExpr> mutated;
+    mutated.reserve(indices.size());
+    for (const PrimExpr &index : indices) {
+      mutated.push_back(VisitExpr(index));
+    }
+    return mutated;
+  }
+
+  // Indices of the k-th element of a vectorized (x2/x4) access: the vector
+  // occupies consecutive elements along the last index (a slice `b[i, j:j+2]`
+  // reaches here as its scalar minimum `j`, so plain `+ k` is the expansion).
+  Array<PrimExpr> ElemIndices(Array<PrimExpr> indices, int k) {
+    if (k == 0) {
+      return indices;
+    }
+    PrimExpr last = indices.back();
+    if (const auto *ramp = last.as<RampNode>()) {
+      indices.Set(indices.size() - 1,
+                  ramp->base + make_const(ramp->base->dtype, k) * ramp->stride);
+    } else {
+      indices.Set(indices.size() - 1, last + make_const(last->dtype, k));
+    }
+    return indices;
+  }
+
+  // Expression position `_ret`: bind the pre-update value to a fresh var
+  // (executed first), perform the RMW store, and evaluate to the old value.
+  PrimExpr RewriteRetAtomic(const CallNode &call, const AtomicRMWOp &rmw) {
+    AtomicAccess dst = ParseAtomicAccessPtr(call.args[0], "atomic dst");
+    Array<PrimExpr> indices = MutateIndices(dst.indices);
+    PrimExpr value = CastIfNeeded(dst.buffer->dtype, VisitExpr(call.args[1]));
+
+    BufferLoad old_load(dst.buffer, indices);
+    Var old_var("atomic_old_" + std::to_string(atomic_old_counter_++),
+                old_load->dtype);
+    pending_prefix_.push_back(Bind(old_var, old_load));
+    pending_prefix_.push_back(BufferStore(
+        dst.buffer, MakeRMWCombine(rmw.kind, old_var, value), indices));
+    return old_var;
+  }
+
+  Stmt LowerStmtAtomic(const CallNode &call, const AtomicRMWOp &rmw) {
+    AtomicAccess dst = ParseAtomicAccessPtr(call.args[0], "atomic dst");
+
+    if (rmw.kind == AtomicRMWKind::kAddVec) {
+      // args = (dst access_ptr, value access_ptr): expand to per-element RMW.
+      AtomicAccess src = ParseAtomicAccessPtr(call.args[1], "atomic_addx");
+      std::vector<Stmt> stores;
+      for (int k = 0; k < rmw.lanes; ++k) {
+        Array<PrimExpr> dst_indices =
+            MutateIndices(ElemIndices(dst.indices, k));
+        Array<PrimExpr> src_indices =
+            MutateIndices(ElemIndices(src.indices, k));
+        PrimExpr elem = CastIfNeeded(dst.buffer->dtype,
+                                     BufferLoad(src.buffer, src_indices));
+        stores.push_back(BufferStore(dst.buffer,
+                                     BufferLoad(dst.buffer, dst_indices) + elem,
+                                     dst_indices));
+      }
+      return SeqStmt::Flatten(stores);
+    }
+
+    // Scalar forms: args = (ptr, value[, memory_order]); the optional
+    // trailing memory_order id is intentionally ignored on a serial target.
+    Array<PrimExpr> indices = MutateIndices(dst.indices);
+    PrimExpr value = CastIfNeeded(dst.buffer->dtype, VisitExpr(call.args[1]));
+    return BufferStore(
+        dst.buffer,
+        MakeRMWCombine(rmw.kind, BufferLoad(dst.buffer, indices), value),
+        indices);
+  }
+
+  int atomic_old_counter_ = 0;
+  // Bind/Store prefix statements recorded by `return_prev` rewrites, spliced
+  // before the enclosing statement by VisitStmt.
+  std::vector<Stmt> pending_prefix_;
+};
+
+} // namespace
+
+namespace transform {
+
+tvm::transform::Pass LowerCPUAtomics() {
+  auto pass_func = [](PrimFunc f, const IRModule &m,
+                      const tvm::transform::PassContext &ctx) {
+    return CPUAtomicRewriter::Rewrite(std::move(f));
+  };
+  return tvm::tirx::transform::CreatePrimFuncPass(pass_func, 0,
+                                                  "tl.LowerCPUAtomics", {});
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = reflection;
+  refl::GlobalDef().def("tl.cpu.transform.LowerCPUAtomics", LowerCPUAtomics);
+}
+
+} // namespace transform
+
+} // namespace tl
+} // namespace tvm

--- a/testing/python/cpu/test_tilelang_cpu_atomic.py
+++ b/testing/python/cpu/test_tilelang_cpu_atomic.py
@@ -1,0 +1,417 @@
+"""CPU atomic op tests (target="c", execution_backend="cython").
+
+Two lowering paths are covered:
+- tile-region: T.atomic_add/atomic_max/atomic_min on buffers/regions, lowered
+  by src/cpu/op/atomic_add.cc / atomic_reduce.cc to plain serial RMW loops;
+- scalar elem-op: T.atomic_add/max/min/or/load/store/addx2/addx4 on addressed
+  elements, rewritten by tl.transform.LowerCPUAtomics to plain RMW.
+
+On serial CPU, atomics degenerate to plain read-modify-write: memory_order is
+accepted but ignored, and return_prev yields the pre-update value.
+"""
+
+import functools
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+from tilelang import tvm
+
+
+def _compile_c(func, out_idx):
+    with tvm.target.Target("c"):
+        return tilelang.compile(
+            func,
+            out_idx=out_idx,
+            target="c",
+            target_host="c",
+            execution_backend="cython",
+        )
+
+
+def _make_input(shape, dtype, seed=7):
+    tdtype = getattr(torch, dtype)
+    gen = torch.Generator(device="cpu").manual_seed(seed)
+    if tdtype in (torch.int32, torch.int64):
+        return torch.randint(-50, 50, shape, dtype=tdtype, generator=gen)
+    return torch.randn(shape, dtype=tdtype, generator=gen)
+
+
+@pytest.mark.parametrize("dtype", ["float32", "int32", "float16"])
+def test_cpu_atomic_add_scalar_parallel(dtype):
+    """Scalar atomic_add into a global cell from a T.Parallel loop."""
+    N = 128
+
+    @T.prim_func
+    def main(A: T.Tensor((N,), dtype), Init: T.Tensor((1,), dtype), B: T.Tensor((1,), dtype)):
+        with T.Kernel(1):
+            B[0] = Init[0]
+            for i in T.Parallel(N):
+                T.atomic_add(B[0], A[i])
+
+    kernel = _compile_c(main, out_idx=[2])
+    A = _make_input((N,), dtype)
+    Init = torch.zeros((1,), dtype=getattr(torch, dtype))
+    out = kernel(A, Init)
+    expected = A.sum() + Init
+    if dtype == "float16":
+        torch.testing.assert_close(out, expected.reshape((1,)), rtol=1e-2, atol=1e-2)
+    else:
+        torch.testing.assert_close(out, expected.reshape((1,)))
+
+
+def test_cpu_atomic_add_scalar_serial_memory_order():
+    """Serial loop + memory_order (accepted, ignored) + codegen assertion."""
+    N = 64
+    dtype = "float32"
+
+    @T.prim_func
+    def main(A: T.Tensor((N,), dtype), Init: T.Tensor((1,), dtype), B: T.Tensor((1,), dtype)):
+        with T.Kernel(1):
+            B[0] = Init[0]
+            for i in T.serial(N):
+                T.atomic_add(B[0], A[i], memory_order="seq_cst")
+
+    kernel = _compile_c(main, out_idx=[2])
+    # The intrinsic must be gone from the generated source (plain RMW).
+    assert "atomic_add_elem_op" not in kernel.get_kernel_source()
+
+    A = _make_input((N,), dtype)
+    Init = torch.full((1,), 1.0, dtype=torch.float32)
+    out = kernel(A, Init)
+    torch.testing.assert_close(out, A.sum() + Init, rtol=1e-4, atol=1e-4)
+
+
+def test_cpu_atomic_add_scalar_return_prev():
+    """return_prev yields the pre-update value (exclusive prefix sum)."""
+    N = 8
+    dtype = "float32"
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), dtype),
+        Init: T.Tensor((1,), dtype),
+        B: T.Tensor((1,), dtype),
+        P: T.Tensor((N,), dtype),
+    ):
+        with T.Kernel(1):
+            B[0] = Init[0]
+            for i in T.serial(N):
+                P[i] = T.atomic_add(B[0], A[i], return_prev=True)
+
+    kernel = _compile_c(main, out_idx=[2, 3])
+    A = _make_input((N,), dtype)
+    Init = torch.full((1,), 1.0, dtype=torch.float32)
+    out_b, out_p = kernel(A, Init)
+    expected_p = Init + torch.cumsum(A, dim=0) - A
+    torch.testing.assert_close(out_p, expected_p, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(out_b, A.sum() + Init, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("op", ["max", "min"])
+def test_cpu_atomic_max_min_scalar_return_prev(op):
+    """return_prev with max/min combine: exclusive running prefix."""
+    N = 8
+    dtype = "float32"
+    emit = T.atomic_max if op == "max" else T.atomic_min
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), dtype),
+        Init: T.Tensor((1,), dtype),
+        B: T.Tensor((1,), dtype),
+        P: T.Tensor((N,), dtype),
+    ):
+        with T.Kernel(1):
+            B[0] = Init[0]
+            for i in T.serial(N):
+                P[i] = emit(B[0], A[i], return_prev=True)
+
+    kernel = _compile_c(main, out_idx=[2, 3])
+    A = _make_input((N,), dtype)
+    Init = torch.zeros((1,), dtype=torch.float32)
+    out_b, out_p = kernel(A, Init)
+
+    running = Init.clone()
+    expected_p = torch.empty_like(A)
+    combine = torch.maximum if op == "max" else torch.minimum
+    for i in range(N):
+        expected_p[i] = running[0]
+        running = combine(running, A[i : i + 1])
+    torch.testing.assert_close(out_p, expected_p, rtol=1e-4, atol=1e-4)
+    expected_b = combine(Init, A.max() if op == "max" else A.min())
+    torch.testing.assert_close(out_b, expected_b, rtol=1e-4, atol=1e-4)
+
+
+def test_cpu_atomic_add_scalar_int_value_cast():
+    """An int value added to a float buffer is cast to the dst dtype."""
+    dtype = "float32"
+
+    @T.prim_func
+    def main(Init: T.Tensor((1,), dtype), B: T.Tensor((1,), dtype)):
+        with T.Kernel(1):
+            B[0] = Init[0]
+            T.atomic_add(B[0], 3)
+
+    kernel = _compile_c(main, out_idx=[1])
+    Init = torch.full((1,), 1.5, dtype=torch.float32)
+    out = kernel(Init)
+    torch.testing.assert_close(out, Init + 3.0)
+
+
+@pytest.mark.parametrize(
+    "op,dtype",
+    [("max", "float32"), ("min", "float32"), ("max", "float16"), ("min", "int32")],
+)
+def test_cpu_atomic_max_min_scalar(op, dtype):
+    N = 64
+    emit = T.atomic_max if op == "max" else T.atomic_min
+
+    @T.prim_func
+    def main(A: T.Tensor((N,), dtype), Init: T.Tensor((1,), dtype), B: T.Tensor((1,), dtype)):
+        with T.Kernel(1):
+            B[0] = Init[0]
+            for i in T.Parallel(N):
+                emit(B[0], A[i])
+
+    kernel = _compile_c(main, out_idx=[2])
+    A = _make_input((N,), dtype)
+    base = A.max() if op == "max" else A.min()
+    Init = (base - 1).reshape((1,)) if op == "max" else (base + 1).reshape((1,))
+    out = kernel(A, Init)
+    expected = torch.maximum(A.max(), Init) if op == "max" else torch.minimum(A.min(), Init)
+    if dtype == "float16":
+        torch.testing.assert_close(out, expected.reshape((1,)), rtol=1e-2, atol=1e-2)
+    else:
+        torch.testing.assert_close(out, expected.reshape((1,)))
+
+
+def test_cpu_atomic_or_scalar():
+    N = 32
+    dtype = "int32"
+
+    @T.prim_func
+    def main(A: T.Tensor((N,), dtype), Init: T.Tensor((1,), dtype), B: T.Tensor((1,), dtype)):
+        with T.Kernel(1):
+            B[0] = Init[0]
+            for i in T.Parallel(N):
+                T.atomic_or(B[0], A[i])
+
+    kernel = _compile_c(main, out_idx=[2])
+    A = _make_input((N,), dtype)
+    Init = torch.zeros((1,), dtype=torch.int32)
+    out = kernel(A, Init)
+    expected = functools.reduce(torch.bitwise_or, list(A.unbind()), Init[0].clone())
+    torch.testing.assert_close(out, expected.reshape((1,)))
+
+
+def test_cpu_atomic_load_store():
+    dtype = "float32"
+
+    @T.prim_func
+    def main(A: T.Tensor((1,), dtype), B: T.Tensor((1,), dtype)):
+        with T.Kernel(1):
+            x = T.atomic_load(A[0], memory_order="acquire")
+            T.atomic_store(B[0], x + T.float32(1.0), memory_order="release")
+
+    kernel = _compile_c(main, out_idx=[1])
+    A = torch.full((1,), 2.5, dtype=torch.float32)
+    out = kernel(A)
+    torch.testing.assert_close(out, A + 1.0)
+
+
+def test_cpu_atomic_addx2_fp16():
+    """x2 vector atomic add, full-buffer form, expanded per element."""
+    dtype = "float16"
+
+    @T.prim_func
+    def main(Val: T.Tensor((2,), dtype), Init: T.Tensor((2,), dtype), Dst: T.Tensor((2,), dtype)):
+        with T.Kernel(1):
+            for i in T.serial(2):
+                Dst[i] = Init[i]
+            T.atomic_addx2(Dst, Val)
+
+    kernel = _compile_c(main, out_idx=[2])
+    Val = _make_input((2,), dtype)
+    Init = _make_input((2,), dtype, seed=11)
+    out = kernel(Val, Init)
+    torch.testing.assert_close(out, Init + Val, rtol=1e-2, atol=1e-2)
+
+
+def test_cpu_atomic_addx4_fp32_slice():
+    """x4 vector atomic add, slice form (region min offsets)."""
+    dtype = "float32"
+
+    @T.prim_func
+    def main(Val: T.Tensor((4,), dtype), Init: T.Tensor((4,), dtype), Dst: T.Tensor((4,), dtype)):
+        with T.Kernel(1):
+            for i in T.serial(4):
+                Dst[i] = Init[i]
+            T.atomic_addx4(Dst[0:4], Val[0:4])
+
+    kernel = _compile_c(main, out_idx=[2])
+    Val = _make_input((4,), dtype)
+    Init = _make_input((4,), dtype, seed=11)
+    out = kernel(Val, Init)
+    torch.testing.assert_close(out, Init + Val, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("dtype", ["float32", "int32"])
+def test_cpu_atomic_add_region_global(dtype):
+    """Tile-region atomic_add with a global dst buffer."""
+    M, N = 4, 8
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), Init: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
+        with T.Kernel(1):
+            for i, j in T.grid(M, N):
+                B[i, j] = Init[i, j]
+            T.atomic_add(B, A)
+
+    kernel = _compile_c(main, out_idx=[2])
+    A = _make_input((M, N), dtype)
+    Init = _make_input((M, N), dtype, seed=11)
+    out = kernel(A, Init)
+    torch.testing.assert_close(out, Init + A, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.parametrize("op", ["max", "min"])
+def test_cpu_atomic_max_min_region_local_dst(op):
+    """Tile-region atomic_max/atomic_min with a local dst buffer."""
+    M, N = 4, 8
+    dtype = "float32"
+    emit = T.atomic_max if op == "max" else T.atomic_min
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), Init: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
+        with T.Kernel(1):
+            dst = T.alloc_local((M, N), dtype)
+            for i, j in T.grid(M, N):
+                dst[i, j] = Init[i, j]
+            emit(dst, A)
+            for i, j in T.grid(M, N):
+                B[i, j] = dst[i, j]
+
+    kernel = _compile_c(main, out_idx=[2])
+    A = _make_input((M, N), dtype)
+    Init = _make_input((M, N), dtype, seed=11)
+    out = kernel(A, Init)
+    expected = torch.maximum(Init, A) if op == "max" else torch.minimum(Init, A)
+    torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+
+
+def test_cpu_atomic_add_region_scalar_value():
+    """Tile-region atomic_add with a scalar src value (src_value path)."""
+    M, N = 4, 8
+    dtype = "float32"
+
+    @T.prim_func
+    def main(Init: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
+        with T.Kernel(1):
+            for i, j in T.grid(M, N):
+                B[i, j] = Init[i, j]
+            T.atomic_add(B, 2)
+
+    kernel = _compile_c(main, out_idx=[1])
+    Init = _make_input((M, N), dtype)
+    out = kernel(Init)
+    torch.testing.assert_close(out, Init + 2.0, rtol=1e-4, atol=1e-4)
+
+
+def test_cpu_atomic_add_region_sliced_dst():
+    """Sliced dst region: dst_range carries a non-zero min offset."""
+    M, N = 4, 8
+    dtype = "float32"
+
+    @T.prim_func
+    def main(A: T.Tensor((M - 2, N), dtype), Init: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
+        with T.Kernel(1):
+            for i, j in T.grid(M, N):
+                B[i, j] = Init[i, j]
+            T.atomic_add(B[1 : M - 1, :], A)
+
+    kernel = _compile_c(main, out_idx=[2])
+    A = _make_input((M - 2, N), dtype)
+    Init = _make_input((M, N), dtype, seed=11)
+    out = kernel(A, Init)
+    expected = Init.clone()
+    expected[1 : M - 1, :] += A
+    torch.testing.assert_close(out, expected, rtol=1e-4, atol=1e-4)
+
+
+def test_cpu_atomic_add_region_memory_order():
+    """memory_order annotation on the tile-region path is accepted/ignored."""
+    M, N = 4, 8
+    dtype = "float32"
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
+        with T.Kernel(1):
+            for i, j in T.grid(M, N):
+                B[i, j] = 0.0
+            T.atomic_add(B, A, memory_order="acquire")
+
+    kernel = _compile_c(main, out_idx=[1])
+    A = _make_input((M, N), dtype)
+    out = kernel(A)
+    torch.testing.assert_close(out, A, rtol=1e-4, atol=1e-4)
+
+
+def test_cpu_atomic_add_use_tma_rejected():
+    M, N = 4, 8
+    dtype = "float32"
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
+        with T.Kernel(1):
+            T.atomic_add(B, A, use_tma=True)
+
+    with pytest.raises(Exception, match="use_tma"):
+        _compile_c(main, out_idx=[1])
+
+
+def test_cpu_atomic_addx2_return_prev_rejected():
+    """Vector return_prev is rejected with a readable error on CPU."""
+
+    @T.prim_func
+    def main(
+        Dst: T.Tensor((2,), "float16"),
+        Val: T.Tensor((2,), "float16"),
+        Prev: T.Tensor((2,), "float16"),
+    ):
+        with T.Kernel(1):
+            Prev[0:2] = T.atomic_addx2(Dst[0:2], Val[0:2], return_prev=True)
+
+    with pytest.raises(Exception, match="return_prev"):
+        _compile_c(main, out_idx=[2])
+
+
+def test_cpu_atomic_multiple_return_prev_one_statement():
+    """Two return_prev atomics in one statement: both Bind/Store prefixes are
+    spliced, in order, before the statement (pending_prefix_ isolation)."""
+    N = 8
+    dtype = "float32"
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), dtype),
+        B0: T.Tensor((1,), dtype),
+        B1: T.Tensor((1,), dtype),
+        P: T.Tensor((N,), dtype),
+    ):
+        with T.Kernel(1):
+            B0[0] = 0.0
+            B1[0] = 100.0
+            for i in T.serial(N):
+                P[i] = T.atomic_add(B0[0], A[i], return_prev=True) + T.atomic_add(B1[0], A[i], return_prev=True)
+
+    kernel = _compile_c(main, out_idx=[1, 2, 3])
+    A = _make_input((N,), dtype)
+    out_b0, out_b1, out_p = kernel(A)
+
+    prefix = torch.cumsum(A, dim=0) - A  # sum(A[:i])
+    torch.testing.assert_close(out_p, prefix + (100.0 + prefix), rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(out_b0, A.sum().reshape((1,)), rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(out_b1, 100.0 + A.sum().reshape((1,)), rtol=1e-4, atol=1e-4)

--- a/testing/python/llvm/test_tilelang_llvm_atomic.py
+++ b/testing/python/llvm/test_tilelang_llvm_atomic.py
@@ -1,0 +1,91 @@
+"""LLVM atomic op tests (shares the CPU atomic impls with the `c` target).
+
+Lightweight mirror of testing/python/cpu/test_tilelang_cpu_atomic.py covering
+one representative case per lowering path, since `llvm` and `c` share the same
+registries (TargetIsCPU matches kDLCPU) and the same LowerCPUAtomics pass:
+- scalar add + return_prev (tl.transform.LowerCPUAtomics),
+- tile-region max (src/cpu/op/atomic_reduce.cc),
+- addx4 vector expansion (tl.transform.LowerCPUAtomics).
+"""
+
+import torch
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+
+
+def _compile_llvm(func, out_idx):
+    with tvm.target.Target("llvm"):
+        return tilelang.compile(func, out_idx=out_idx, target="llvm", execution_backend="tvm_ffi")
+
+
+@tilelang.testing.requires_llvm
+def test_llvm_atomic_add_scalar_return_prev():
+    N = 8
+    dtype = "float32"
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), dtype),
+        Init: T.Tensor((1,), dtype),
+        B: T.Tensor((1,), dtype),
+        P: T.Tensor((N,), dtype),
+    ):
+        with T.Kernel(1):
+            B[0] = Init[0]
+            for i in T.serial(N):
+                P[i] = T.atomic_add(B[0], A[i], return_prev=True)
+
+    kernel = _compile_llvm(main, out_idx=[2, 3])
+    gen = torch.Generator(device="cpu").manual_seed(7)
+    A = torch.randn((N,), dtype=torch.float32, generator=gen)
+    Init = torch.full((1,), 1.0, dtype=torch.float32)
+    out_b, out_p = kernel(A, Init)
+    expected_p = Init + torch.cumsum(A, dim=0) - A
+    torch.testing.assert_close(out_p, expected_p, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(out_b, A.sum() + Init, rtol=1e-4, atol=1e-4)
+
+
+@tilelang.testing.requires_llvm
+def test_llvm_atomic_max_region():
+    M, N = 4, 8
+    dtype = "float32"
+
+    @T.prim_func
+    def main(A: T.Tensor((M, N), dtype), Init: T.Tensor((M, N), dtype), B: T.Tensor((M, N), dtype)):
+        with T.Kernel(1):
+            for i, j in T.grid(M, N):
+                B[i, j] = Init[i, j]
+            T.atomic_max(B, A)
+
+    kernel = _compile_llvm(main, out_idx=[2])
+    gen = torch.Generator(device="cpu").manual_seed(7)
+    A = torch.randn((M, N), dtype=torch.float32, generator=gen)
+    Init = torch.randn((M, N), dtype=torch.float32, generator=gen)
+    out = kernel(A, Init)
+    torch.testing.assert_close(out, torch.maximum(Init, A), rtol=1e-4, atol=1e-4)
+
+
+@tilelang.testing.requires_llvm
+def test_llvm_atomic_addx4():
+    dtype = "float32"
+
+    @T.prim_func
+    def main(Val: T.Tensor((4,), dtype), Init: T.Tensor((4,), dtype), Dst: T.Tensor((4,), dtype)):
+        with T.Kernel(1):
+            for i in T.serial(4):
+                Dst[i] = Init[i]
+            T.atomic_addx4(Dst[0:4], Val[0:4])
+
+    kernel = _compile_llvm(main, out_idx=[2])
+    gen = torch.Generator(device="cpu").manual_seed(7)
+    Val = torch.randn((4,), dtype=torch.float32, generator=gen)
+    Init = torch.randn((4,), dtype=torch.float32, generator=gen)
+    out = kernel(Val, Init)
+    torch.testing.assert_close(out, Init + Val, rtol=1e-4, atol=1e-4)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/cpu/__init__.py
+++ b/tilelang/cpu/__init__.py
@@ -1,2 +1,3 @@
 from . import op  # noqa: F401
+from . import transform  # noqa: F401
 from . import backend as backend  # noqa: F401

--- a/tilelang/cpu/_ffi_api.py
+++ b/tilelang/cpu/_ffi_api.py
@@ -1,0 +1,5 @@
+"""FFI APIs for CPU-specific TileLang transforms."""
+
+import tvm_ffi
+
+tvm_ffi.init_ffi_api("tl.cpu.transform", __name__)

--- a/tilelang/cpu/pipeline.py
+++ b/tilelang/cpu/pipeline.py
@@ -33,6 +33,10 @@ def CPUPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.LayoutInference()(mod)
     LayoutVisual(mod)
     mod = tilelang.transform.LowerTileOp()(mod)
+    # Scalar-path atomic intrinsics (tl.atomic_*_elem_op) survive LowerTileOp;
+    # rewrite them to plain serial RMW before vectorization/legalization so
+    # that both the `c` and `llvm` codegens only see BufferLoad/BufferStore.
+    mod = tilelang.cpu.transform.LowerCPUAtomics()(mod)
 
     mod = tilelang.transform.DecoupleTypeCast()(mod)
     mod = tilelang.transform.LegalizeVectorizedLoop()(mod)

--- a/tilelang/cpu/transform/__init__.py
+++ b/tilelang/cpu/transform/__init__.py
@@ -1,0 +1,19 @@
+"""CPU-specific transformation frontends."""
+
+from .. import _ffi_api
+
+
+def LowerCPUAtomics():
+    """Lower tl.atomic_*_elem_op intrinsics to serial read-modify-write.
+
+    CPU targets only: the pass rewrites scalar-path atomic intrinsics into
+    plain BufferLoad/BufferStore RMW so that both CPU codegens (`c` and
+    `llvm`) can consume them. Tile-region atomics are lowered separately by
+    the cpu.AtomicAdd/cpu.AtomicReduce impls inside LowerTileOp.
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The result pass
+    """
+    return _ffi_api.LowerCPUAtomics()  # type: ignore


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added CPU lowering for atomic add, max, and min operations.
- Added serial read-modify-write generation for CPU atomics.
- Added and registered the `LowerCPUAtomics` pass.
- Exposed the pass through the CPU Python API and pipeline.
- Added CPU and LLVM atomic operation tests.
- Added CPU transform sources to the CMake build.

## C++ style / lint notes

- The PR touches C++ API and FFI-related code covered by `docs/developer_guide/cpp_style.md`.
- CI includes the **C++ API Style Audit (warning only)** step.
- No audit output was provided. Any TLCPP003/TLCPP004 findings should remain advisory unless they indicate an API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->