### PR TITLE
[BugFix] Isolate NVRTC kernel handles per adapter

### DIFF
--- a/testing/python/cache/test_tilelang_kernel_cache.py
+++ b/testing/python/cache/test_tilelang_kernel_cache.py
@@ -192,6 +192,8 @@ def test_disk_cache_with_postproc(clean_cache_env, backend):
     )
 
     assert counter.count == 1, f"Cache hit: postproc should not be called again, got {counter.count} calls"
+    if backend == "nvrtc":
+        assert kernel1.adapter.kernels is not kernel2.adapter.kernels
 
     source2 = kernel2.get_kernel_source()
     assert counter.marker in source2, f"Expected cached marker '{counter.marker}' in source"

--- a/testing/python/jit/test_tilelang_jit_nvrtc.py
+++ b/testing/python/jit/test_tilelang_jit_nvrtc.py
@@ -173,6 +173,30 @@ def test_gemm_jit_kernel():
     )
 
 
+def _make_add_constant_kernel(value):
+    @T.prim_func
+    def main(A: T.Tensor((128,), T.float32), B: T.Tensor((128,), T.float32)):
+        with T.Kernel(1, threads=128) as bx:
+            for tx in T.Parallel(128):
+                B[bx * 128 + tx] = A[bx * 128 + tx] + value
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+def test_nvrtc_kernel_handles_are_isolated_between_adapters():
+    first_kernel = tilelang.compile(_make_add_constant_kernel(1.0), out_idx=-1, execution_backend="nvrtc")
+    x = torch.zeros(128, device="cuda", dtype=torch.float32)
+
+    first_result_before = first_kernel(x)
+    second_kernel = tilelang.compile(_make_add_constant_kernel(5.0), out_idx=-1, execution_backend="nvrtc")
+
+    assert first_kernel.adapter.kernels is not second_kernel.adapter.kernels
+    torch.testing.assert_close(first_result_before, torch.ones_like(x))
+    torch.testing.assert_close(first_kernel(x), torch.ones_like(x))
+    torch.testing.assert_close(second_kernel(x), torch.full_like(x, 5.0))
+
+
 def run_nvrtc_kernel_do_bench(
     M, N, K, trans_A, trans_B, in_dtype, out_dtype, dtypeAccum, block_M, block_N, block_K, num_stages=3, num_threads=128
 ):

--- a/tilelang/jit/adapter/nvrtc/adapter.py
+++ b/tilelang/jit/adapter/nvrtc/adapter.py
@@ -26,7 +26,7 @@ if is_nvrtc_available:
 
 class NVRTCKernelAdapter(BaseKernelAdapter):
     pymodule = None
-    kernels = {}
+    kernels: dict[str, Any]
 
     def __init__(
         self,
@@ -89,6 +89,7 @@ class NVRTCKernelAdapter(BaseKernelAdapter):
         self.lib_generator.load_lib()
         self.libpath = self.lib_generator.libpath
         self.pymodule = self.lib_generator.pymodule
+        self.kernels = {}
         culib = self.lib_generator.culib
         for name in self.function_names:
             result, self.kernels[name] = cuda.cuLibraryGetKernel(culib, bytes(name, "utf-8"))
@@ -148,6 +149,7 @@ class NVRTCKernelAdapter(BaseKernelAdapter):
         adapter.pymodule = adapter.lib_generator.pymodule
         adapter.function_names = adapter.pymodule._function_names
 
+        adapter.kernels = {}
         culib = adapter.lib_generator.culib
         for name in adapter.function_names:
             result, adapter.kernels[name] = cuda.cuLibraryGetKernel(culib, bytes(name, "utf-8"))


### PR DESCRIPTION
## Summary

- keep NVRTC kernel handle maps on each adapter instance instead of sharing a class-level dictionary
- initialize isolated maps for both fresh compilation and disk-cache restoration
- add regression coverage for same-named kernels and cached adapter restoration

## Testing

- `cmake -S . -B build -G Ninja` and `cmake --build build -j8`
- `python -m pytest testing/python/jit/test_tilelang_jit_nvrtc.py::test_nvrtc_kernel_handles_are_isolated_between_adapters testing/python/jit/test_tilelang_jit_nvrtc_host.py -q` (5 passed)
- `TILELANG_DISABLE_CACHE=0 python -m pytest testing/python/cache/test_tilelang_kernel_cache.py::test_disk_cache_with_postproc[nvrtc] -q` (1 passed)
- `bash format.sh --files` on all changed files

Fixes #2949

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Isolate NVRTC kernel handle maps per `NVRTCKernelAdapter` instance.
- Initialize isolated maps for fresh compilation and disk-cache restoration.
- Add regression coverage for same-named kernels and cached adapter restoration.

## Testing

- CMake configuration and build.
- NVRTC and host JIT tests.
- NVRTC disk-cache test.
- Formatting checks for changed files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->