### PR TITLE
[BugFix][CUDA] Advance tcgen05 ld/st segment pointers in b32 columns

### DIFF
--- a/src/tl_templates/cuda/copy_sm100.h
+++ b/src/tl_templates/cuda/copy_sm100.h
@@ -194,7 +194,8 @@ __device__ __forceinline__ void tcgen05_ld_core(uint32_t const &tmem_start_col,
   target_call_cls::copy<CUR_SEGMENT_LEN>(tmem_start_col, (uint32_t *)dst_ptr);
   if constexpr (N - CUR_SEGMENT_LEN > 0) {
     tcgen05_ld_core<target_call_cls, MAX_LOGN, N - CUR_SEGMENT_LEN>(
-        tmem_start_col + CUR_SEGMENT_LEN, dst_ptr + CUR_SEGMENT_LEN);
+        tmem_start_col + CUR_SEGMENT_LEN,
+        dst_ptr + CUR_SEGMENT_LEN * sizeof(uint32_t) / sizeof(dst_t));
   }
 }
 
@@ -323,7 +324,8 @@ __device__ __forceinline__ void tcgen05_st_core(uint32_t const &tmem_start_col,
                                                   (uint32_t const *)src_ptr);
   if constexpr (N - CUR_SEGMENT_LEN > 0) {
     tcgen05_st_core<target_call_cls, MAX_LOGN, N - CUR_SEGMENT_LEN>(
-        tmem_start_col + CUR_SEGMENT_LEN, src_ptr + CUR_SEGMENT_LEN);
+        tmem_start_col + CUR_SEGMENT_LEN,
+        src_ptr + CUR_SEGMENT_LEN * sizeof(uint32_t) / sizeof(src_t));
   }
 }
 

--- a/testing/python/language/test_tilelang_language_tmem_copy.py
+++ b/testing/python/language/test_tilelang_language_tmem_copy.py
@@ -205,6 +205,60 @@ def _make_16bit_roundtrip_kernel(shape, forward, dtype):
     return main
 
 
+def _make_16bit_split_kernel(shape, dtype, nsplit, split_store):
+    """One whole-buffer copy against sliced copies on the other side.
+
+    A 16-bit buffer whose b32-column count is not a power of two (e.g. 96
+    bf16 values = 48 columns) decomposes into multiple instruction segments
+    inside ONE tcgen05 call (x32 + x16); the segment recursion must advance
+    the register pointer in b32 columns, not in dst_t elements.  A symmetric
+    whole-store/whole-load roundtrip cancels a unit error, so exactly one
+    side is split into power-of-two (single-segment) slices.
+    """
+    last = shape[-1]
+    assert last % nsplit == 0
+    step = last // nsplit
+    rank = len(shape)
+
+    @T.prim_func
+    def main(
+        A: T.Tensor(shape, dtype),
+        D: T.Tensor(shape, dtype),
+    ):
+        with T.Kernel(1, threads=128):
+            A_shared = T.alloc_shared(shape, dtype)
+            A_frag = T.alloc_fragment(shape, dtype)
+            tmem = T.alloc_tmem(shape, dtype)
+            B_frag = T.alloc_fragment(shape, dtype)
+            B_shared = T.alloc_shared(shape, dtype)
+
+            T.annotate_layout({tmem: T.Layout(shape, lambda i, j: [i, j])})
+            T.copy(A, A_shared)
+            T.copy(A_shared, A_frag)
+            if split_store:
+                for s in range(nsplit):
+                    T.copy(
+                        _last_dim_slice(A_frag, rank, s * step, (s + 1) * step),
+                        _last_dim_slice(tmem, rank, s * step, (s + 1) * step),
+                    )
+            else:
+                T.copy(A_frag, tmem)
+            T.fill(A_frag, -1.0)
+            T.fill(B_frag, -2.0)
+            if split_store:
+                T.copy(tmem, B_frag)
+            else:
+                for s in range(nsplit):
+                    T.copy(
+                        _last_dim_slice(tmem, rank, s * step, (s + 1) * step),
+                        _last_dim_slice(B_frag, rank, s * step, (s + 1) * step),
+                    )
+            T.copy(B_frag, B_shared)
+            T.copy(B_shared, D)
+
+    return main
+
+
 def _make_shared_allocation_roundtrip_kernel(wide_cols, narrow_cols):
     """Roundtrip two TMEM buffers that share one physical tcgen05.alloc.
 
@@ -354,6 +408,26 @@ def test_tmem_copy_sliced_store_whole_load(name, shape, forward, threads):
 )
 def test_tmem_copy_roundtrip_sliced_batch(name, shape, forward, threads):
     _run_roundtrip(_make_batch_sliced_roundtrip_kernel(shape, forward, threads), shape)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
+@pytest.mark.parametrize("split_store", [True, False], ids=["whole_load", "whole_store"])
+def test_tmem_copy_16bit_multi_segment(split_store):
+    shape = (128, 96)
+    kernel = tilelang.compile(
+        _make_16bit_split_kernel(shape, T.bfloat16, nsplit=3, split_store=split_store),
+        target="cuda",
+        pass_configs=PASS_CONFIGS,
+    )
+    source = kernel.get_kernel_source()
+    # The whole-buffer side must be one multi-segment call (48 b32 columns).
+    assert "tcgen05_st_32dp32bNx<48," in source or "tcgen05_ld_32dp32bNx<48," in source
+    a = torch.randn(*shape, device="cuda", dtype=torch.bfloat16)
+    d = torch.empty(*shape, device="cuda", dtype=torch.bfloat16)
+    kernel(a, d)
+    torch.testing.assert_close(d, a, rtol=0.0, atol=0.0)
 
 
 @tilelang.testing.requires_cuda


### PR DESCRIPTION
The multi-segment recursion in tcgen05_{ld,st}_core advanced the register pointer in dst_t/src_t elements while segment lengths count b32 columns, so a 16-bit copy whose column count is not a power of two (e.g. 48 columns = one x32 + one x16 segment) accessed the tail segments' registers at half the intended offset -- a silent miscompilation. Advance the pointer in b32 units instead.

Add asymmetric whole-store/whole-load roundtrips at (128, 96) bf16: a symmetric roundtrip cancels the unit error, so exactly one side is split into power-of-two (single-segment) slices, catching each direction independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed CUDA `tcgen05_{ld,st}_core` multi-segment recursion.
- Advanced register pointers in b32-column units to calculate correct tail offsets.
- Added bf16 roundtrip tests for whole and split copies at `(128, 96)`.

## C++ style / lint notes

- The change touches `src/tl_templates/cuda/copy_sm100.h`.
- It does not change the rules in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit runs in warning-only mode. No new blocking correctness or build issues are identified.
- No public or exported declarations changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->