### PR TITLE
[Transform] Add VerifyBufferInit, a general buffer-initialization check

### DIFF
--- a/examples/flash_decoding/example_mha_inference.py
+++ b/examples/flash_decoding/example_mha_inference.py
@@ -134,7 +134,7 @@ def flashattn(batch, heads, seqlen_q, seqlen_kv, dim, is_causal, block_M, block_
                 ],
                 lse_local,
             )
-            T.reduce_max(lse_local, lse_max_local, dim=0, clear=False)
+            T.reduce_max(lse_local, lse_max_local, dim=0, clear=True)
             for k in T.Pipelined(num_split):
                 T.copy(lse_local[k, :], lse_local_split)
                 for i in T.Parallel(block_M):

--- a/examples/grouped_gemm/example_grouped_gemm_bwd.py
+++ b/examples/grouped_gemm/example_grouped_gemm_bwd.py
@@ -33,6 +33,7 @@ def grouped_gemm_fwd(
 
         m_start_padded = bx * block_M
 
+        cur_batch_idx = 0
         for i in range(batch_count):
             in_cur_batch_idx = m_start_padded >= batch_padded_offsets[i]
             cur_batch_idx = T.if_then_else(in_cur_batch_idx, i, cur_batch_idx)

--- a/examples/grouped_gemm/example_grouped_gemm_fwd.py
+++ b/examples/grouped_gemm/example_grouped_gemm_fwd.py
@@ -82,6 +82,7 @@ def grouped_gemm(
 
         m_start_padded = bx * block_M
 
+        cur_batch_idx = 0
         for i in range(batch_count):
             in_cur_batch_idx = m_start_padded >= batch_padded_offsets[i]
             cur_batch_idx = T.if_then_else(in_cur_batch_idx, i, cur_batch_idx)

--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -33,6 +33,7 @@ TVM_REGISTER_PASS_CONFIG_OPTION(kLayoutVisualizationEnable, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kLayoutVisualizationFormats, ffi::String);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDeviceCompileFlags, ffi::Array<ffi::String>);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableDataRaceCheck, Bool);
+TVM_REGISTER_PASS_CONFIG_OPTION(kDisableBufferInitCheck, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableLoopUnswitching, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kLoopUnswitchingAllowNonTrivialElse, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kIfStmtBindingInlineReplayableBinds, Bool);

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -99,6 +99,13 @@ static constexpr const char *kLayoutVisualizationFormats =
 static constexpr const char *kDeviceCompileFlags = "tl.device_compile_flags";
 static constexpr const char *kDisableDataRaceCheck =
     "tl.disable_data_race_check";
+/*! \brief Disable the buffer-initialization check.
+ *
+ * The check warns when a non-global-scope buffer is read before anything
+ * writes it. It is enabled by default.
+ */
+static constexpr const char *kDisableBufferInitCheck =
+    "tl.disable_buffer_init_check";
 static constexpr const char *kDisableThreadStorageSync =
     "tl.disable_thread_storage_sync";
 static constexpr const char *kForceLetInline = "tl.force_let_inline";

--- a/src/op/gemm.cc
+++ b/src/op/gemm.cc
@@ -159,6 +159,27 @@ AccessRegions GemmNode::GetAccessRegions() const {
   return result;
 }
 
+ffi::Array<BufferRegion> GemmNode::GetReadBeforeWriteRegions() const {
+  ffi::Array<BufferRegion> result;
+  result.push_back(aRegion_);
+  result.push_back(bRegion_);
+  if (sfaRegion_.defined()) {
+    result.push_back(sfaRegion_);
+  }
+  if (sfbRegion_.defined()) {
+    result.push_back(sfbRegion_);
+  }
+  // The accumulator's old contents are consumed only when the clear is
+  // provably absent. GetAccessRegions() uses !is_one() because a clear that
+  // cannot be proven still creates a read dependency for pipelining; here the
+  // question is whether the op definitely reads, so the pipelined idiom
+  // `clear_accum=(k == 0)` must not count.
+  if (is_zero(clearAccum_)) {
+    result.push_back(cRegion_);
+  }
+  return result;
+}
+
 TileOperator GemmNode::Clone() const {
   auto op = make_object<GemmNode>(*this);
   return Gemm(op);

--- a/src/op/gemm.h
+++ b/src/op/gemm.h
@@ -163,6 +163,7 @@ public:
   LayoutMap InferLayout(const LayoutInferArgs &layout_args,
                         InferLevel level) const override;
   AccessRegions GetAccessRegions() const override;
+  ffi::Array<tirx::BufferRegion> GetReadBeforeWriteRegions() const override;
 
   TileOperator Clone() const;
 

--- a/src/op/gemm_sp.cc
+++ b/src/op/gemm_sp.cc
@@ -151,6 +151,19 @@ AccessRegions GemmSPNode::GetAccessRegions() const {
   return result;
 }
 
+ffi::Array<BufferRegion> GemmSPNode::GetReadBeforeWriteRegions() const {
+  ffi::Array<BufferRegion> result;
+  result.push_back(aRegion_);
+  result.push_back(eRegion_);
+  result.push_back(bRegion_);
+  // See GemmNode::GetReadBeforeWriteRegions: only a provable absence of the
+  // clear makes the accumulator's old contents a definite read.
+  if (is_zero(clear_accum)) {
+    result.push_back(cRegion_);
+  }
+  return result;
+}
+
 TileOperator GemmSPNode::Clone() const {
   auto op = make_object<GemmSPNode>(*this);
   return GemmSP(op);

--- a/src/op/gemm_sp.h
+++ b/src/op/gemm_sp.h
@@ -131,6 +131,7 @@ public:
   LayoutMap InferLayout(const LayoutInferArgs &layout_args,
                         InferLevel level) const override;
   AccessRegions GetAccessRegions() const override;
+  ffi::Array<tirx::BufferRegion> GetReadBeforeWriteRegions() const override;
 
   TileOperator Clone() const;
 

--- a/src/op/operator.h
+++ b/src/op/operator.h
@@ -176,6 +176,19 @@ public:
     return result;
   }
 
+  /*!
+   * \brief Regions whose preexisting contents this op consumes before
+   *        establishing a value of its own.
+   *
+   * A subset of GetAccessRegions().reads, which answers the weaker may-read
+   * question ("could this op read this region?") and is deliberately
+   * conservative for dependency analysis. Ops whose read set depends on an
+   * argument value narrow it here; the default reports every read.
+   */
+  virtual ffi::Array<tirx::BufferRegion> GetReadBeforeWriteRegions() const {
+    return GetAccessRegions().reads;
+  }
+
   void SetAccessRegions(std::vector<AccessRegion> access_regions) {
     access_regions_ = std::move(access_regions);
   }

--- a/src/transform/verify_buffer_init.cc
+++ b/src/transform/verify_buffer_init.cc
@@ -226,6 +226,8 @@ struct BufferInitVerifier : public StmtExprVisitor {
   std::unordered_map<const VarNode *, std::vector<const Object *>>
       potential_writers_;
   Span current_span_;
+  /*! \brief The store whose subexpressions are being visited, if any. */
+  const Object *active_store_ = nullptr;
 
   /*! \brief Treat every parameter buffer as written by the caller. */
   void SeedParams(const PrimFunc &f) {
@@ -291,16 +293,24 @@ struct BufferInitVerifier : public StmtExprVisitor {
    *
    * The destination is recorded last, so `x[i] = x[i] + 1` reports x when
    * nothing wrote it earlier: a store reads its own right-hand side before it
-   * establishes anything. Cross-thread scopes are unaffected, since they
-   * ignore source order and ask only whether another node writes the buffer.
+   * establishes anything. The store is also published as the reader of every
+   * subexpression it contains, so a cross-thread scope discounts this store
+   * when asking whether another node writes the buffer. Without that, a store
+   * that reads its own destination would vouch for itself and the same code
+   * would report under a per-thread scope but not a shared one.
    */
   void VisitStmt_(const BufferStoreNode *op) final {
+    const Object *saved = active_store_;
+    active_store_ = op;
     StmtExprVisitor::VisitStmt_(op);
+    active_store_ = saved;
     written_.insert(op->buffer->data);
   }
 
   void VisitExpr_(const BufferLoadNode *op) final {
-    CheckRead(op->buffer);
+    // Discounting the enclosing store only affects loads of its own
+    // destination; it is recorded as a writer of nothing else.
+    CheckRead(op->buffer, Kind::kGeneric, active_store_);
     StmtExprVisitor::VisitExpr_(op);
   }
 

--- a/src/transform/verify_buffer_init.cc
+++ b/src/transform/verify_buffer_init.cc
@@ -1,0 +1,399 @@
+/*!
+ * \file verify_buffer_init.cc
+ *
+ * Warn when a non-global-scope buffer is read before anything writes it.
+ *
+ * Reading a shared-memory or register buffer that nothing has written yields
+ * whatever those locations last held. That is undefined behaviour: it can
+ * silently produce correct results on one architecture and NaN on another
+ * (see issue #2936). This pass reports it at compile time.
+ *
+ * The analysis is deliberately imprecise in one direction: a write anywhere
+ * earlier in execution order counts, even under a conditional the read is not
+ * guarded by. It detects "nothing writes this buffer at all", and nothing
+ * finer. That keeps false positives rare enough for the check to be on by
+ * default.
+ */
+
+#include "../op/builtin.h"
+#include "../op/gemm.h"
+#include "../op/gemm_sp.h"
+#include "../op/operator.h"
+#include "span_utils.h"
+#include <sstream>
+#include <unordered_map>
+#include <unordered_set>
+#include <string>
+#include <vector>
+
+#include <tvm/runtime/logging.h>
+#include <tvm/tirx/builtin.h>
+#include <tvm/tirx/expr.h>
+#include <tvm/tirx/op.h>
+#include <tvm/tirx/op_attr_types.h>
+#include <tvm/tirx/stmt.h>
+#include <tvm/tirx/stmt_functor.h>
+#include <tvm/tirx/transform.h>
+
+namespace tvm::tl {
+
+using namespace tirx;
+using namespace ffi;
+
+namespace {
+
+/*!
+ * \brief Scopes this check does not report.
+ *
+ * Global memory is the caller's responsibility. Barrier scopes hold mbarrier
+ * state established by intrinsics the pass does not model, and reading them
+ * before any visible write is normal (cf. inject_pipeline.cc).
+ */
+bool IsExemptScope(const String &scope) {
+  return scope == "global" || scope == "shared.barrier" ||
+         scope == "shared.cluster_barrier";
+}
+
+/*!
+ * \brief Whether reads of this scope must ignore source order.
+ *
+ * Shared memory is written by one group of threads and read by another, with
+ * correctness established by barriers rather than by program order. A
+ * warp-specialized kernel routinely places the producer branch after the
+ * consumer branch in the body, so "written earlier in the body" says nothing
+ * about what has run. Per-thread storage has no such excuse: source order is
+ * that thread's execution order.
+ */
+bool IsCrossThreadScope(const String &scope) {
+  const std::string s = scope;
+  return s.rfind("shared", 0) == 0;
+}
+
+/*! \brief Collects every buffer a function potentially writes.
+ *
+ * Records which node performed each write so that a read can discount the
+ * reading operation's own write: a gemm that accumulates into an otherwise
+ * untouched buffer must still be reported.
+ */
+struct PotentialWriteCollector : public StmtExprVisitor {
+  std::unordered_map<const VarNode *, std::vector<const Object *>> writers;
+
+  void Record(const Var &var, const Object *writer) {
+    writers[var.get()].push_back(writer);
+  }
+
+  void VisitStmt_(const BufferStoreNode *op) final {
+    Record(op->buffer->data, op);
+    StmtExprVisitor::VisitStmt_(op);
+  }
+
+  void VisitExpr_(const CallNode *op) final {
+    TileOperator tile_op;
+    try {
+      tile_op = ParseOperator(GetRef<Call>(op));
+    } catch (const tvm::ffi::Error &) {
+      tile_op = TileOperator();
+    }
+    if (tile_op.defined()) {
+      for (const BufferRegion &region : tile_op->GetAccessRegions().writes) {
+        Record(region->buffer->data, op);
+      }
+      return;
+    }
+    // Anything the pass cannot interpret may write through its arguments; see
+    // BufferInitVerifier::MarkOpaqueEscapes for the same reasoning.
+    for (const PrimExpr &arg : op->args) {
+      if (const auto *load = arg.as<BufferLoadNode>()) {
+        Record(load->buffer->data, op);
+      }
+    }
+    StmtExprVisitor::VisitExpr_(op);
+  }
+};
+
+struct BufferInitVerifier : public StmtExprVisitor {
+  /*! \brief Which remedy the warning should suggest. */
+  enum class Kind { kGeneric, kGemmAccum };
+
+  struct Report {
+    Buffer buffer;
+    Span span;
+    Kind kind;
+  };
+
+  std::vector<Report> reports_;
+  std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> written_;
+  std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> reported_;
+  std::unordered_map<const VarNode *, std::vector<const Object *>>
+      potential_writers_;
+  Span current_span_;
+
+  /*! \brief Treat every parameter buffer as written by the caller. */
+  void SeedParams(const PrimFunc &f) {
+    for (const auto &kv : f->buffer_map) {
+      written_.insert(kv.second->data);
+    }
+  }
+
+  /*! \brief Record what the whole function potentially writes. */
+  void CollectPotentialWrites(const PrimFunc &f) {
+    PotentialWriteCollector collector;
+    collector(f->body);
+    potential_writers_ = std::move(collector.writers);
+  }
+
+  /*! \brief Whether some node other than \p reader writes \p var. */
+  bool WrittenByAnotherNode(const Var &var, const Object *reader) const {
+    auto it = potential_writers_.find(var.get());
+    if (it == potential_writers_.end()) {
+      return false;
+    }
+    for (const Object *writer : it->second) {
+      if (writer != reader) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /*! \brief Record a read, reporting it if nothing has written the buffer.
+   *
+   * Each buffer is reported at most once, however many times it is read.
+   */
+  void CheckRead(const Buffer &buffer, Kind kind = Kind::kGeneric,
+                 const Object *reader = nullptr) {
+    if (IsExemptScope(buffer.scope())) {
+      return;
+    }
+    const Var &var = buffer->data;
+    if (reported_.count(var)) {
+      return;
+    }
+    const bool satisfied = IsCrossThreadScope(buffer.scope())
+                               ? WrittenByAnotherNode(var, reader)
+                               : written_.count(var) > 0;
+    if (satisfied) {
+      return;
+    }
+    reported_.insert(var);
+    reports_.push_back({buffer, current_span_, kind});
+  }
+
+  void VisitStmt_(const EvaluateNode *op) final {
+    Span saved = current_span_;
+    if (op->span.defined()) {
+      current_span_ = op->span;
+    }
+    StmtExprVisitor::VisitStmt_(op);
+    current_span_ = saved;
+  }
+
+  /*! \brief A direct store initializes.
+   *
+   * Recorded before visiting the stored value. Reading `x = f(..., x)` as a
+   * read-before-write would make this a definite-assignment analysis over
+   * scalars, which reports idioms like
+   * `idx = T.if_then_else(cond, i, idx)` that are conventional and benign.
+   */
+  void VisitStmt_(const BufferStoreNode *op) final {
+    written_.insert(op->buffer->data);
+    StmtExprVisitor::VisitStmt_(op);
+  }
+
+  void VisitExpr_(const BufferLoadNode *op) final {
+    CheckRead(op->buffer);
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
+  /*! \brief Parse a call as a tile op, or return null if it cannot be.
+   *
+   * A tile op call is not always in its final form at this point in the
+   * pipeline, and an op builder that indexes an argument it has not been
+   * given throws. This pass only warns, so a call it cannot interpret must
+   * degrade to the opaque-escape treatment rather than abort the build.
+   */
+  static TileOperator TryParseOperator(const Call &call) {
+    try {
+      return ParseOperator(call);
+    } catch (const tvm::ffi::Error &) {
+      return TileOperator();
+    }
+  }
+
+  void VisitExpr_(const CallNode *op) final {
+    if (auto tile_op = TryParseOperator(GetRef<Call>(op)); tile_op.defined()) {
+      VisitTileOp(tile_op, op);
+      // Do not recurse. A tl.region argument wraps a BufferLoad that marks the
+      // region, not a real read; visiting it would double-count and ignore the
+      // op's own semantics.
+      return;
+    }
+    if (op->op.same_as(builtin::address_of()) ||
+        op->op.same_as(builtin::tvm_access_ptr()) ||
+        op->op.same_as(tl::access_ptr()) ||
+        op->op.same_as(builtin::call_extern()) || IsTileOpCall(op) ||
+        MayWriteThroughArgs(op)) {
+      MarkOpaqueEscapes(op);
+      return;
+    }
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
+  /*! \brief Whether this call may write through one of its arguments.
+   *
+   * A pure op only reads what it is given, so its BufferLoad arguments are
+   * ordinary reads. Anything at kUpdateState (== kOpaque) or beyond may write,
+   * as may an op that never registered an effect kind, or a call to something
+   * other than an Op at all.
+   */
+  static bool MayWriteThroughArgs(const CallNode *op) {
+    static const auto effect_map =
+        Op::GetAttrMap<TCallEffectKind>("TCallEffectKind");
+    auto opt_op = op->op.as<Op>();
+    if (!opt_op.has_value()) {
+      return true;
+    }
+    Op call_op = opt_op.value();
+    if (!effect_map.count(call_op)) {
+      return true;
+    }
+    return effect_map[call_op]->value >=
+           static_cast<int>(CallEffectKind::kUpdateState);
+  }
+
+  /*! \brief Whether this call is a tile op, however well-formed. */
+  static bool IsTileOpCall(const CallNode *op) {
+    auto opt_op = op->op.as<Op>();
+    if (!opt_op.has_value()) {
+      return false;
+    }
+    const std::string &name = opt_op.value()->name;
+    return name.rfind("tl.tileop.", 0) == 0;
+  }
+
+  /*!
+   * \brief Conservatively record writes for calls the pass cannot interpret.
+   *
+   * A buffer whose pointer escapes into an opaque call may be written by it.
+   * Assuming it is written trades recall for precision, which is the trade
+   * this check is built on.
+   */
+  void MarkOpaqueEscapes(const CallNode *op) {
+    if (op->op.same_as(builtin::address_of())) {
+      if (!op->args.empty()) {
+        if (const auto *load = op->args[0].as<BufferLoadNode>()) {
+          written_.insert(load->buffer->data);
+        }
+      }
+      return;
+    }
+    if (op->op.same_as(tl::access_ptr())) {
+      // access_ptr(base_load, extent, rw_mask)
+      if (op->args.size() >= 3) {
+        if (GetConservativeAccessMask(op->args[2]) & kAccessWrite) {
+          if (const auto *load = op->args[0].as<BufferLoadNode>()) {
+            written_.insert(load->buffer->data);
+          }
+        }
+      }
+      return;
+    }
+    if (op->op.same_as(builtin::tvm_access_ptr())) {
+      // args: [type_hint, data_var, offset, extent, rw_mask]
+      if (op->args.size() >= 5) {
+        if (GetConservativeAccessMask(op->args[4]) & kAccessWrite) {
+          if (const auto *var = op->args[1].as<VarNode>()) {
+            written_.insert(GetRef<Var>(var));
+          }
+        }
+      }
+      return;
+    }
+    for (const PrimExpr &arg : op->args) {
+      if (const auto *var = arg.as<VarNode>()) {
+        if (var->dtype.is_handle()) {
+          written_.insert(GetRef<Var>(var));
+        }
+      } else if (const auto *load = arg.as<BufferLoadNode>()) {
+        written_.insert(load->buffer->data);
+      } else if (const auto *call = arg.as<CallNode>()) {
+        // Nested address_of / tvm_access_ptr inside an extern argument list.
+        MarkOpaqueEscapes(call);
+      }
+    }
+  }
+
+  /*! \brief Check an op's definite reads, then apply its writes.
+   *
+   * Reads before writes, so a read-modify-write region (a gemm accumulating
+   * into C) is reported when nothing wrote it earlier.
+   */
+  void VisitTileOp(const TileOperator &tile_op, const Object *reader) {
+    // The analysis below is op-agnostic; this lookup only selects which remedy
+    // the warning suggests.
+    Buffer accum;
+    if (const auto *gemm = tile_op.as<GemmNode>()) {
+      accum = gemm->cRegion_->buffer;
+    } else if (const auto *gemm_sp = tile_op.as<GemmSPNode>()) {
+      accum = gemm_sp->cRegion_->buffer;
+    }
+    for (const BufferRegion &region : tile_op->GetReadBeforeWriteRegions()) {
+      Kind kind = (accum.defined() && region->buffer.same_as(accum))
+                      ? Kind::kGemmAccum
+                      : Kind::kGeneric;
+      CheckRead(region->buffer, kind, reader);
+    }
+    for (const BufferRegion &region : tile_op->GetAccessRegions().writes) {
+      written_.insert(region->buffer->data);
+    }
+  }
+
+  /*! \brief Emit all findings as one aggregated warning. */
+  void EmitReport() const {
+    if (reports_.empty()) {
+      return;
+    }
+    std::ostringstream os;
+    os << "Buffer read before initialization: " << reports_.size()
+       << " buffer(s) read before anything writes them\n";
+    for (size_t k = 0; k < reports_.size(); ++k) {
+      const Report &report = reports_[k];
+      os << "  [" << k + 1 << "] `" << report.buffer
+         << "` is read before anything writes it"
+         << SpanHintSuffix({report.span}) << "\n";
+      if (report.kind == Kind::kGemmAccum) {
+        os << "      T.gemm accumulates into C, so an uninitialized "
+              "accumulator adds into stale contents. Add `T.clear(C)` before "
+              "the gemm, or pass `clear_accum=True`.\n";
+      }
+    }
+    os << "Initialize the buffer before its first read (for example with "
+          "`T.clear`, `T.fill`, or a `T.copy` into it). If you believe this "
+          "is a false positive, disable the check by setting "
+          "`PassConfigKey.TL_DISABLE_BUFFER_INIT_CHECK` in the pass config.";
+    LOG(WARNING) << os.str();
+  }
+};
+
+using namespace tirx::transform;
+
+tvm::transform::Pass VerifyBufferInit() {
+  auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+    BufferInitVerifier verifier;
+    verifier.SeedParams(f);
+    verifier.CollectPotentialWrites(f);
+    verifier(f->body);
+    verifier.EmitReport();
+    return f;
+  };
+  return CreatePrimFuncPass(pass_func, 0, "tl.VerifyBufferInit", {});
+}
+
+TVM_FFI_STATIC_INIT_BLOCK() {
+  namespace refl = reflection;
+  refl::GlobalDef().def("tl.transform.VerifyBufferInit", VerifyBufferInit);
+}
+
+} // namespace
+
+} // namespace tvm::tl

--- a/src/transform/verify_buffer_init.cc
+++ b/src/transform/verify_buffer_init.cc
@@ -20,6 +20,7 @@
 #include "../op/gemm_sp.h"
 #include "../op/operator.h"
 #include "span_utils.h"
+#include <exception>
 #include <sstream>
 #include <string>
 #include <unordered_map>
@@ -74,12 +75,14 @@ bool IsCrossThreadScope(const String &scope) {
  * A tile op call is not always in its final form at this point in the
  * pipeline, and an op builder that indexes an argument it has not been given
  * throws. This pass only warns, so a call it cannot interpret must degrade to
- * the opaque-escape treatment rather than abort the build.
+ * the opaque-escape treatment rather than abort the build. Every builder
+ * failure seen so far raises tvm::ffi::Error, which derives from
+ * std::exception; catching the base covers the rest by the same rule.
  */
 TileOperator TryParseOperator(const Call &call) {
   try {
     return ParseOperator(call);
-  } catch (const tvm::ffi::Error &) {
+  } catch (const std::exception &) {
     return TileOperator();
   }
 }
@@ -375,7 +378,7 @@ struct BufferInitVerifier : public StmtExprVisitor {
        << " buffer(s) read before anything writes them\n";
     for (size_t k = 0; k < reports_.size(); ++k) {
       const Report &report = reports_[k];
-      os << "  [" << k + 1 << "] `" << report.buffer
+      os << "  [" << k + 1 << "] `" << report.buffer->name
          << "` is read before anything writes it"
          << SpanHintSuffix({report.span}) << "\n";
       if (report.kind == Kind::kGemmAccum) {

--- a/src/transform/verify_buffer_init.cc
+++ b/src/transform/verify_buffer_init.cc
@@ -287,17 +287,16 @@ struct BufferInitVerifier : public StmtExprVisitor {
     current_span_ = saved;
   }
 
-  /*! \brief A direct store initializes.
+  /*! \brief A direct store initializes, but only after it has been evaluated.
    *
-   * Recorded before visiting the stored value. Reading `x = f(..., x)` as a
-   * read-before-write would make this a definite-assignment analysis over
-   * scalars, which reports idioms like
-   * `idx = T.if_then_else(cond, i, idx)` that are conventional and benign.
-   * Every other buffer the value and the indices read is still visited below.
+   * The destination is recorded last, so `x[i] = x[i] + 1` reports x when
+   * nothing wrote it earlier: a store reads its own right-hand side before it
+   * establishes anything. Cross-thread scopes are unaffected, since they
+   * ignore source order and ask only whether another node writes the buffer.
    */
   void VisitStmt_(const BufferStoreNode *op) final {
-    written_.insert(op->buffer->data);
     StmtExprVisitor::VisitStmt_(op);
+    written_.insert(op->buffer->data);
   }
 
   void VisitExpr_(const BufferLoadNode *op) final {

--- a/src/transform/verify_buffer_init.cc
+++ b/src/transform/verify_buffer_init.cc
@@ -222,6 +222,8 @@ struct BufferInitVerifier : public StmtExprVisitor {
 
   std::vector<Report> reports_;
   std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> written_;
+  /*! \brief Buffers the caller established, written by no node here. */
+  std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> params_;
   std::unordered_set<Var, ObjectPtrHash, ObjectPtrEqual> reported_;
   std::unordered_map<const VarNode *, std::vector<const Object *>>
       potential_writers_;
@@ -229,10 +231,15 @@ struct BufferInitVerifier : public StmtExprVisitor {
   /*! \brief The store whose subexpressions are being visited, if any. */
   const Object *active_store_ = nullptr;
 
-  /*! \brief Treat every parameter buffer as written by the caller. */
+  /*! \brief Treat every parameter buffer as written by the caller.
+   *
+   * Recorded separately as well: the caller is not a node in this body, so a
+   * cross-thread scope asking who else writes the buffer would never find it.
+   */
   void SeedParams(const PrimFunc &f) {
     for (const auto &kv : f->buffer_map) {
       written_.insert(kv.second->data);
+      params_.insert(kv.second->data);
     }
   }
 
@@ -270,9 +277,12 @@ struct BufferInitVerifier : public StmtExprVisitor {
     if (reported_.count(var)) {
       return;
     }
-    const bool satisfied = IsCrossThreadScope(buffer.scope())
-                               ? WrittenByAnotherNode(var, reader)
-                               : written_.count(var) > 0;
+    // A parameter arrives written whatever its scope; only buffers the body
+    // has to establish itself go through the scope-dependent question.
+    const bool satisfied =
+        params_.count(var) > 0 ||
+        (IsCrossThreadScope(buffer.scope()) ? WrittenByAnotherNode(var, reader)
+                                            : written_.count(var) > 0);
     if (satisfied) {
       return;
     }

--- a/src/transform/verify_buffer_init.cc
+++ b/src/transform/verify_buffer_init.cc
@@ -399,6 +399,13 @@ using namespace tirx::transform;
 
 tvm::transform::Pass VerifyBufferInit() {
   auto pass_func = [=](PrimFunc f, IRModule m, PassContext ctx) {
+    // Enabled by default. The analysis reports buffers that nothing writes at
+    // all, plus order-sensitive cases in per-thread storage where the only
+    // write comes after the read, which keeps false positives rare enough to
+    // warrant it; users can opt out through this pass config.
+    if (ctx->GetConfig(kDisableBufferInitCheck, Bool(false)).value()->value) {
+      return f;
+    }
     BufferInitVerifier verifier;
     verifier.SeedParams(f);
     verifier.CollectPotentialWrites(f);

--- a/src/transform/verify_buffer_init.cc
+++ b/src/transform/verify_buffer_init.cc
@@ -21,9 +21,9 @@
 #include "../op/operator.h"
 #include "span_utils.h"
 #include <sstream>
+#include <string>
 #include <unordered_map>
 #include <unordered_set>
-#include <string>
 #include <vector>
 
 #include <tvm/runtime/logging.h>
@@ -69,6 +69,114 @@ bool IsCrossThreadScope(const String &scope) {
   return s.rfind("shared", 0) == 0;
 }
 
+/*! \brief Parse a call as a tile op, or return null if it cannot be.
+ *
+ * A tile op call is not always in its final form at this point in the
+ * pipeline, and an op builder that indexes an argument it has not been given
+ * throws. This pass only warns, so a call it cannot interpret must degrade to
+ * the opaque-escape treatment rather than abort the build.
+ */
+TileOperator TryParseOperator(const Call &call) {
+  try {
+    return ParseOperator(call);
+  } catch (const tvm::ffi::Error &) {
+    return TileOperator();
+  }
+}
+
+/*! \brief Whether this call is a tile op, however well-formed. */
+bool IsTileOpCall(const CallNode *op) {
+  auto opt_op = op->op.as<Op>();
+  if (!opt_op.has_value()) {
+    return false;
+  }
+  const std::string &name = opt_op.value()->name;
+  return name.rfind("tl.tileop.", 0) == 0;
+}
+
+/*! \brief Whether this call may write through one of its arguments.
+ *
+ * A pure op only reads what it is given, so its BufferLoad arguments are
+ * ordinary reads. Anything at kUpdateState (== kOpaque) or beyond may write,
+ * as may an op that never registered an effect kind, or a call to something
+ * other than an Op at all.
+ */
+bool MayWriteThroughArgs(const CallNode *op) {
+  static const auto effect_map =
+      Op::GetAttrMap<TCallEffectKind>("TCallEffectKind");
+  auto opt_op = op->op.as<Op>();
+  if (!opt_op.has_value()) {
+    return true;
+  }
+  Op call_op = opt_op.value();
+  if (!effect_map.count(call_op)) {
+    return true;
+  }
+  return effect_map[call_op]->value >=
+         static_cast<int>(CallEffectKind::kUpdateState);
+}
+
+/*! \brief Whether a buffer reaching this call may be written by it. */
+bool EscapesThroughArgs(const CallNode *op) {
+  return op->op.same_as(builtin::address_of()) ||
+         op->op.same_as(builtin::tvm_access_ptr()) ||
+         op->op.same_as(tl::access_ptr()) ||
+         op->op.same_as(builtin::call_extern()) || IsTileOpCall(op) ||
+         MayWriteThroughArgs(op);
+}
+
+/*!
+ * \brief Report every buffer variable an uninterpretable call may write.
+ *
+ * A buffer whose pointer escapes into an opaque call may be written by it.
+ * Assuming it is written trades recall for precision, which is the trade this
+ * check is built on. The two walks below both route through here, so their
+ * notions of what a call may write cannot drift apart.
+ */
+template <typename F>
+void ForEachOpaqueWrite(const CallNode *op, const F &record) {
+  if (op->op.same_as(builtin::address_of())) {
+    if (!op->args.empty()) {
+      if (const auto *load = op->args[0].as<BufferLoadNode>()) {
+        record(load->buffer->data);
+      }
+    }
+    return;
+  }
+  if (op->op.same_as(tl::access_ptr())) {
+    // access_ptr(base_load, extent, rw_mask)
+    if (op->args.size() >= 3 &&
+        (GetConservativeAccessMask(op->args[2]) & kAccessWrite)) {
+      if (const auto *load = op->args[0].as<BufferLoadNode>()) {
+        record(load->buffer->data);
+      }
+    }
+    return;
+  }
+  if (op->op.same_as(builtin::tvm_access_ptr())) {
+    // args: [type_hint, data_var, offset, extent, rw_mask]
+    if (op->args.size() >= 5 &&
+        (GetConservativeAccessMask(op->args[4]) & kAccessWrite)) {
+      if (const auto *var = op->args[1].as<VarNode>()) {
+        record(GetRef<Var>(var));
+      }
+    }
+    return;
+  }
+  for (const PrimExpr &arg : op->args) {
+    if (const auto *var = arg.as<VarNode>()) {
+      if (var->dtype.is_handle()) {
+        record(GetRef<Var>(var));
+      }
+    } else if (const auto *load = arg.as<BufferLoadNode>()) {
+      record(load->buffer->data);
+    } else if (const auto *call = arg.as<CallNode>()) {
+      // Nested address_of / tvm_access_ptr inside an extern argument list.
+      ForEachOpaqueWrite(call, record);
+    }
+  }
+}
+
 /*! \brief Collects every buffer a function potentially writes.
  *
  * Records which node performed each write so that a read can discount the
@@ -88,24 +196,15 @@ struct PotentialWriteCollector : public StmtExprVisitor {
   }
 
   void VisitExpr_(const CallNode *op) final {
-    TileOperator tile_op;
-    try {
-      tile_op = ParseOperator(GetRef<Call>(op));
-    } catch (const tvm::ffi::Error &) {
-      tile_op = TileOperator();
-    }
-    if (tile_op.defined()) {
+    if (TileOperator tile_op = TryParseOperator(GetRef<Call>(op));
+        tile_op.defined()) {
       for (const BufferRegion &region : tile_op->GetAccessRegions().writes) {
         Record(region->buffer->data, op);
       }
       return;
     }
-    // Anything the pass cannot interpret may write through its arguments; see
-    // BufferInitVerifier::MarkOpaqueEscapes for the same reasoning.
-    for (const PrimExpr &arg : op->args) {
-      if (const auto *load = arg.as<BufferLoadNode>()) {
-        Record(load->buffer->data, op);
-      }
+    if (EscapesThroughArgs(op)) {
+      ForEachOpaqueWrite(op, [&](const Var &var) { Record(var, op); });
     }
     StmtExprVisitor::VisitExpr_(op);
   }
@@ -194,6 +293,7 @@ struct BufferInitVerifier : public StmtExprVisitor {
    * read-before-write would make this a definite-assignment analysis over
    * scalars, which reports idioms like
    * `idx = T.if_then_else(cond, i, idx)` that are conventional and benign.
+   * Every other buffer the value and the indices read is still visited below.
    */
   void VisitStmt_(const BufferStoreNode *op) final {
     written_.insert(op->buffer->data);
@@ -205,122 +305,20 @@ struct BufferInitVerifier : public StmtExprVisitor {
     StmtExprVisitor::VisitExpr_(op);
   }
 
-  /*! \brief Parse a call as a tile op, or return null if it cannot be.
-   *
-   * A tile op call is not always in its final form at this point in the
-   * pipeline, and an op builder that indexes an argument it has not been
-   * given throws. This pass only warns, so a call it cannot interpret must
-   * degrade to the opaque-escape treatment rather than abort the build.
-   */
-  static TileOperator TryParseOperator(const Call &call) {
-    try {
-      return ParseOperator(call);
-    } catch (const tvm::ffi::Error &) {
-      return TileOperator();
-    }
-  }
-
   void VisitExpr_(const CallNode *op) final {
-    if (auto tile_op = TryParseOperator(GetRef<Call>(op)); tile_op.defined()) {
+    if (TileOperator tile_op = TryParseOperator(GetRef<Call>(op));
+        tile_op.defined()) {
       VisitTileOp(tile_op, op);
       // Do not recurse. A tl.region argument wraps a BufferLoad that marks the
       // region, not a real read; visiting it would double-count and ignore the
       // op's own semantics.
       return;
     }
-    if (op->op.same_as(builtin::address_of()) ||
-        op->op.same_as(builtin::tvm_access_ptr()) ||
-        op->op.same_as(tl::access_ptr()) ||
-        op->op.same_as(builtin::call_extern()) || IsTileOpCall(op) ||
-        MayWriteThroughArgs(op)) {
-      MarkOpaqueEscapes(op);
+    if (EscapesThroughArgs(op)) {
+      ForEachOpaqueWrite(op, [&](const Var &var) { written_.insert(var); });
       return;
     }
     StmtExprVisitor::VisitExpr_(op);
-  }
-
-  /*! \brief Whether this call may write through one of its arguments.
-   *
-   * A pure op only reads what it is given, so its BufferLoad arguments are
-   * ordinary reads. Anything at kUpdateState (== kOpaque) or beyond may write,
-   * as may an op that never registered an effect kind, or a call to something
-   * other than an Op at all.
-   */
-  static bool MayWriteThroughArgs(const CallNode *op) {
-    static const auto effect_map =
-        Op::GetAttrMap<TCallEffectKind>("TCallEffectKind");
-    auto opt_op = op->op.as<Op>();
-    if (!opt_op.has_value()) {
-      return true;
-    }
-    Op call_op = opt_op.value();
-    if (!effect_map.count(call_op)) {
-      return true;
-    }
-    return effect_map[call_op]->value >=
-           static_cast<int>(CallEffectKind::kUpdateState);
-  }
-
-  /*! \brief Whether this call is a tile op, however well-formed. */
-  static bool IsTileOpCall(const CallNode *op) {
-    auto opt_op = op->op.as<Op>();
-    if (!opt_op.has_value()) {
-      return false;
-    }
-    const std::string &name = opt_op.value()->name;
-    return name.rfind("tl.tileop.", 0) == 0;
-  }
-
-  /*!
-   * \brief Conservatively record writes for calls the pass cannot interpret.
-   *
-   * A buffer whose pointer escapes into an opaque call may be written by it.
-   * Assuming it is written trades recall for precision, which is the trade
-   * this check is built on.
-   */
-  void MarkOpaqueEscapes(const CallNode *op) {
-    if (op->op.same_as(builtin::address_of())) {
-      if (!op->args.empty()) {
-        if (const auto *load = op->args[0].as<BufferLoadNode>()) {
-          written_.insert(load->buffer->data);
-        }
-      }
-      return;
-    }
-    if (op->op.same_as(tl::access_ptr())) {
-      // access_ptr(base_load, extent, rw_mask)
-      if (op->args.size() >= 3) {
-        if (GetConservativeAccessMask(op->args[2]) & kAccessWrite) {
-          if (const auto *load = op->args[0].as<BufferLoadNode>()) {
-            written_.insert(load->buffer->data);
-          }
-        }
-      }
-      return;
-    }
-    if (op->op.same_as(builtin::tvm_access_ptr())) {
-      // args: [type_hint, data_var, offset, extent, rw_mask]
-      if (op->args.size() >= 5) {
-        if (GetConservativeAccessMask(op->args[4]) & kAccessWrite) {
-          if (const auto *var = op->args[1].as<VarNode>()) {
-            written_.insert(GetRef<Var>(var));
-          }
-        }
-      }
-      return;
-    }
-    for (const PrimExpr &arg : op->args) {
-      if (const auto *var = arg.as<VarNode>()) {
-        if (var->dtype.is_handle()) {
-          written_.insert(GetRef<Var>(var));
-        }
-      } else if (const auto *load = arg.as<BufferLoadNode>()) {
-        written_.insert(load->buffer->data);
-      } else if (const auto *call = arg.as<CallNode>()) {
-        // Nested address_of / tvm_access_ptr inside an extern argument list.
-        MarkOpaqueEscapes(call);
-      }
-    }
   }
 
   /*! \brief Check an op's definite reads, then apply its writes.

--- a/testing/python/transform/test_tilelang_transform_verify_buffer_init.py
+++ b/testing/python/transform/test_tilelang_transform_verify_buffer_init.py
@@ -159,18 +159,34 @@ def test_reports_an_uninitialized_local_buffer(capfd):
     assert MESSAGE in _verify(kernel, capfd)
 
 
-def test_silent_for_scalar_self_referential_assignment(capfd):
-    """`idx = T.if_then_else(cond, i, idx)` is conventional, not a finding.
+def test_reports_a_store_that_reads_its_own_destination(capfd):
+    """A store evaluates its right-hand side before it establishes anything.
 
-    Reading the destination on the right-hand side does not make this a
-    read-before-write in the sense the pass reports; treating it as one turns
-    the pass into a definite-assignment analysis over scalars.
+    `idx = T.if_then_else(cond, i, idx)` carries the previous value forward, so
+    with nothing written beforehand the first pass reads whatever the slot
+    held. examples/grouped_gemm/example_grouped_gemm_fwd_ptr.py writes the
+    initializer that its sibling files omit.
     """
 
     @T.prim_func
     def kernel(A: T.Tensor((NB,), torch.int32), C: T.Tensor((NB,), torch.int32)):
         with T.Kernel(NB, threads=64) as bx:
             idx = T.alloc_local((1,), torch.int32)
+            for i in T.serial(NB):
+                idx[0] = T.if_then_else(A[i] > 0, i, idx[0])
+            C[bx] = idx[0]
+
+    assert MESSAGE in _verify(kernel, capfd)
+
+
+def test_silent_when_the_destination_is_initialized_first(capfd):
+    """The same carry-forward is fine once something establishes a value."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((NB,), torch.int32), C: T.Tensor((NB,), torch.int32)):
+        with T.Kernel(NB, threads=64) as bx:
+            idx = T.alloc_local((1,), torch.int32)
+            idx[0] = 0
             for i in T.serial(NB):
                 idx[0] = T.if_then_else(A[i] > 0, i, idx[0])
             C[bx] = idx[0]

--- a/testing/python/transform/test_tilelang_transform_verify_buffer_init.py
+++ b/testing/python/transform/test_tilelang_transform_verify_buffer_init.py
@@ -450,20 +450,18 @@ def test_reducer_kernel_compiles(no_kernel_cache):
     tilelang.compile(_reducer_kernel())
 
 
-def test_check_enabled_by_default():
+def test_check_enabled_by_default(capfd):
     """The check is on unless a pass config turns it off."""
-    from tilelang.backend.pass_pipeline import pipeline_utils
-
-    assert pipeline_utils.should_enable_buffer_init_check() is True
+    assert MESSAGE in _verify(_gemm_kernel("none"), capfd)
 
 
-def test_check_can_be_disabled_via_pass_config():
-    """tl.disable_buffer_init_check silences the check."""
-    from tilelang.backend.pass_pipeline import pipeline_utils
+def test_check_can_be_disabled_via_pass_config(capfd):
+    """tl.disable_buffer_init_check silences the pass itself, not just the
+    pipeline that schedules it."""
     from tilelang.transform import PassContext
 
     with PassContext(config={"tl.disable_buffer_init_check": True}):
-        assert pipeline_utils.should_enable_buffer_init_check() is False
+        assert MESSAGE not in _verify(_gemm_kernel("none"), capfd)
 
 
 @tilelang.testing.requires_cuda

--- a/testing/python/transform/test_tilelang_transform_verify_buffer_init.py
+++ b/testing/python/transform/test_tilelang_transform_verify_buffer_init.py
@@ -1,0 +1,369 @@
+import pytest
+import torch
+
+import tilelang
+import tilelang as tl
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+
+BC, BK, NB = 16, 64, 16
+MESSAGE = "Buffer read before initialization"
+GEMM_HINT = "clear_accum=True"
+
+
+def _gemm_kernel(init_mode):
+    """Build the #2936 kernel with one accumulator-initialization variant.
+
+    Parameters
+    ----------
+    init_mode : str
+        One of ``"none"``, ``"clear"``, ``"clear_accum"``, or ``"pipelined"``.
+    """
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((NB, BC, BK), torch.float32),
+        B: T.Tensor((NB, BK, BC), torch.float32),
+        C: T.Tensor((NB, BC, BC), torch.float32),
+    ):
+        with T.Kernel(1, NB, threads=64) as (bx, by):
+            bn = bx * NB + by
+            a_s = T.alloc_shared((BC, BK), torch.float32)
+            b_s = T.alloc_shared((BK, BC), torch.float32)
+            T.copy(A[bn, :, :], a_s)
+            T.copy(B[bn, :, :], b_s)
+            c_f = T.alloc_fragment((BC, BC), torch.float32)
+
+            if init_mode == "clear":
+                T.clear(c_f)
+
+            if init_mode == "pipelined":
+                # The idiom the check must never flag: clear_accum is an
+                # expression, not a literal False.
+                for k in T.Pipelined(2, num_stages=1):
+                    T.gemm(a_s, b_s, c_f, clear_accum=(k == 0))
+            else:
+                T.gemm(a_s, b_s, c_f, clear_accum=(init_mode == "clear_accum"))
+
+            T.copy(c_f, C[bn, :, :])
+
+    return kernel
+
+
+def _verify(func, capfd):
+    """Run the pass on ``func`` and return whatever it wrote to stderr."""
+    mod = tvm.IRModule.from_expr(func)
+    tl.transform.VerifyBufferInit()(mod)
+    return capfd.readouterr().err
+
+
+# --------------------------------------------------------------- gemm cases
+
+
+def test_warns_when_accumulator_is_uninitialized(capfd):
+    """The #2936 reproducer: nothing writes c_f before the gemm reads it."""
+    assert MESSAGE in _verify(_gemm_kernel("none"), capfd)
+
+
+def test_silent_when_cleared_with_t_clear(capfd):
+    """T.clear writes the accumulator, so the check stays quiet."""
+    assert MESSAGE not in _verify(_gemm_kernel("clear"), capfd)
+
+
+def test_silent_when_clear_accum_is_true(capfd):
+    """A literal clear_accum=True means the gemm establishes C itself."""
+    assert MESSAGE not in _verify(_gemm_kernel("clear_accum"), capfd)
+
+
+def test_silent_for_the_pipelined_clear_accum_idiom(capfd):
+    """clear_accum=(k == 0) is not a definite read of C.
+
+    This is the regression guard on GetReadBeforeWriteRegions. Consuming
+    GetAccessRegions().reads instead would flag this kernel, because its
+    !is_one() predicate keeps C in the read set for a non-literal clear.
+    """
+    assert MESSAGE not in _verify(_gemm_kernel("pipelined"), capfd)
+
+
+# ------------------------------------------------------------ general cases
+
+
+def _extern_filled_kernel():
+    """A shared buffer whose contents come from an opaque extern call."""
+
+    @T.prim_func
+    def kernel(C: T.Tensor((NB, BC), torch.float32)):
+        with T.Kernel(NB, threads=64) as bx:
+            s = T.alloc_shared((BC,), torch.float32)
+            T.call_extern("handle", "fill_it", T.address_of(s[0]))
+            for i in T.Parallel(BC):
+                C[bx, i] = s[i]
+
+    return kernel
+
+
+def test_silent_when_filled_by_an_extern_call(capfd):
+    """A buffer handed to an opaque call is conservatively treated as written."""
+    assert MESSAGE not in _verify(_extern_filled_kernel(), capfd)
+
+
+def test_silent_for_global_scope_buffers(capfd):
+    """Global buffers are the caller's responsibility, never reported."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((NB, BC), torch.float32), C: T.Tensor((NB, BC), torch.float32)):
+        with T.Kernel(NB, threads=64) as bx:
+            for i in T.Parallel(BC):
+                C[bx, i] = A[bx, i]
+
+    assert MESSAGE not in _verify(kernel, capfd)
+
+
+def test_reports_a_shared_buffer_read_before_any_copy(capfd):
+    """The general case the gemm-specific check could not see."""
+
+    @T.prim_func
+    def kernel(C: T.Tensor((NB, BC), torch.float32)):
+        with T.Kernel(NB, threads=64) as bx:
+            s = T.alloc_shared((BC,), torch.float32)
+            for i in T.Parallel(BC):
+                C[bx, i] = s[i]
+
+    assert MESSAGE in _verify(kernel, capfd)
+
+
+def test_silent_when_shared_buffer_is_copied_first(capfd):
+    """The same buffer read after a T.copy into it is fine."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((NB, BC), torch.float32), C: T.Tensor((NB, BC), torch.float32)):
+        with T.Kernel(NB, threads=64) as bx:
+            s = T.alloc_shared((BC,), torch.float32)
+            T.copy(A[bx, :], s)
+            for i in T.Parallel(BC):
+                C[bx, i] = s[i]
+
+    assert MESSAGE not in _verify(kernel, capfd)
+
+
+def test_reports_an_uninitialized_local_buffer(capfd):
+    """Register-scope buffers are covered too, not just shared memory."""
+
+    @T.prim_func
+    def kernel(C: T.Tensor((NB,), torch.float32)):
+        with T.Kernel(NB, threads=64) as bx:
+            acc = T.alloc_local((1,), torch.float32)
+            C[bx] = acc[0]
+
+    assert MESSAGE in _verify(kernel, capfd)
+
+
+def test_silent_for_scalar_self_referential_assignment(capfd):
+    """`idx = T.if_then_else(cond, i, idx)` is conventional, not a finding.
+
+    Reading the destination on the right-hand side does not make this a
+    read-before-write in the sense the pass reports; treating it as one turns
+    the pass into a definite-assignment analysis over scalars.
+    """
+
+    @T.prim_func
+    def kernel(A: T.Tensor((NB,), torch.int32), C: T.Tensor((NB,), torch.int32)):
+        with T.Kernel(NB, threads=64) as bx:
+            idx = T.alloc_local((1,), torch.int32)
+            for i in T.serial(NB):
+                idx[0] = T.if_then_else(A[i] > 0, i, idx[0])
+            C[bx] = idx[0]
+
+    assert MESSAGE not in _verify(kernel, capfd)
+
+
+def test_silent_when_shared_buffer_is_written_by_a_later_branch(capfd):
+    """Warp specialization puts the producer after the consumer in the body.
+
+    Both branches run concurrently and coordinate through barriers, so source
+    order says nothing about what has executed. For shared scopes the question
+    is whether any other operation writes the buffer at all.
+    """
+
+    @T.prim_func
+    def kernel(A: T.Tensor((NB, BC), torch.float32), C: T.Tensor((NB, BC), torch.float32)):
+        with T.Kernel(NB, threads=128) as bx:
+            s = T.alloc_shared((BC,), torch.float32)
+            tx = T.get_thread_binding()
+            if tx < 64:
+                for i in T.Parallel(BC):
+                    C[bx, i] = s[i]
+            else:
+                T.copy(A[bx, :], s)
+
+    assert MESSAGE not in _verify(kernel, capfd)
+
+
+def test_reports_a_fragment_written_only_after_its_read(capfd):
+    """Per-thread storage keeps order-sensitive tracking.
+
+    Unlike shared memory, a fragment has no cross-thread producer, so source
+    order is this thread's execution order and a write that comes afterwards
+    does not excuse the read.
+    """
+
+    @T.prim_func
+    def kernel(C: T.Tensor((NB, BC), torch.float32)):
+        with T.Kernel(NB, threads=64) as bx:
+            f = T.alloc_fragment((BC,), torch.float32)
+            for i in T.Parallel(BC):
+                C[bx, i] = f[i]
+            T.clear(f)
+
+    assert MESSAGE in _verify(kernel, capfd)
+
+
+# ---------------------------------------------------------- reporting cases
+
+
+def _two_uninitialized_kernel():
+    """Two distinct buffers, both read before anything writes them."""
+
+    @T.prim_func
+    def kernel(C: T.Tensor((NB, BC), torch.float32)):
+        with T.Kernel(NB, threads=64) as bx:
+            s = T.alloc_shared((BC,), torch.float32)
+            t = T.alloc_shared((BC,), torch.float32)
+            for i in T.Parallel(BC):
+                C[bx, i] = s[i] + t[i]
+
+    return kernel
+
+
+def test_gemm_accumulator_gets_the_clear_accum_hint(capfd):
+    """An uninitialized gemm C operand names the fix that applies to it."""
+    err = _verify(_gemm_kernel("none"), capfd)
+
+    assert MESSAGE in err
+    assert GEMM_HINT in err
+
+
+def test_non_gemm_report_omits_the_gemm_hint(capfd):
+    """A plain shared-buffer read gets the generic advice, not clear_accum."""
+    err = _verify(_two_uninitialized_kernel(), capfd)
+
+    assert MESSAGE in err
+    assert GEMM_HINT not in err
+
+
+def test_aggregates_multiple_uninitialized_buffers(capfd):
+    """Two bad buffers produce one aggregated warning, not two."""
+    err = _verify(_two_uninitialized_kernel(), capfd)
+
+    assert err.count(MESSAGE) == 1
+    assert "2 buffer(s)" in err
+    assert "[1]" in err and "[2]" in err
+
+
+def test_reports_each_buffer_once_however_many_reads(capfd):
+    """A buffer read repeatedly still produces a single entry."""
+
+    @T.prim_func
+    def kernel(C: T.Tensor((NB, BC), torch.float32)):
+        with T.Kernel(NB, threads=64) as bx:
+            s = T.alloc_shared((BC,), torch.float32)
+            for i in T.Parallel(BC):
+                C[bx, i] = s[i] + s[(i + 1) % BC] + s[(i + 2) % BC]
+
+    err = _verify(kernel, capfd)
+
+    assert "1 buffer(s)" in err
+    assert "[2]" not in err
+
+
+# ------------------------------------------------------------------ wiring
+
+
+@pytest.fixture
+def no_kernel_cache():
+    """Compile without the kernel cache so the pass runs on every compile.
+
+    A cached kernel is returned without re-running the pass pipeline, which
+    would make the warning silently disappear on the second compile.
+    """
+    was_enabled = tilelang.is_cache_enabled()
+    tilelang.disable_cache()
+    yield
+    if was_enabled:
+        tilelang.enable_cache()
+
+
+def _reducer_kernel():
+    """A kernel using T.alloc_reducer / T.finalize_reducer.
+
+    Before LayoutReducer runs, the tl.tileop.finalize_reducer call carries a
+    single argument while the op's builder reads args[1]. Parsing it there
+    throws, which must never take a compile down.
+    """
+
+    @T.prim_func
+    def kernel(A: T.Tensor((BC, BK), torch.float32), B: T.Tensor((BC,), torch.float32)):
+        with T.Kernel(1, threads=64) as _:
+            a_f = T.alloc_fragment((BC, BK), torch.float32)
+            r_f = T.alloc_reducer((BC,), torch.float32, op="sum", replication="all")
+            T.clear(r_f)
+            T.copy(A, a_f)
+            for i, j in T.Parallel(BC, BK):
+                r_f[i] += a_f[i, j]
+            T.finalize_reducer(r_f)
+            T.copy(r_f, B)
+
+    return kernel
+
+
+def test_reducer_kernel_does_not_raise(capfd):
+    """An unparseable tile op degrades to opaque, it does not throw."""
+    err = _verify(_reducer_kernel(), capfd)
+
+    assert MESSAGE not in err
+
+
+@tilelang.testing.requires_cuda
+def test_reducer_kernel_compiles(no_kernel_cache):
+    """End-to-end: the check must not break reducer kernels."""
+    tilelang.compile(_reducer_kernel())
+
+
+def test_check_enabled_by_default():
+    """The check is on unless a pass config turns it off."""
+    from tilelang.backend.pass_pipeline import pipeline_utils
+
+    assert pipeline_utils.should_enable_buffer_init_check() is True
+
+
+def test_check_can_be_disabled_via_pass_config():
+    """tl.disable_buffer_init_check silences the check."""
+    from tilelang.backend.pass_pipeline import pipeline_utils
+    from tilelang.transform import PassContext
+
+    with PassContext(config={"tl.disable_buffer_init_check": True}):
+        assert pipeline_utils.should_enable_buffer_init_check() is False
+
+
+@tilelang.testing.requires_cuda
+def test_pipeline_warns_by_default(capfd, no_kernel_cache):
+    """The wired pipeline warns on an uninitialized accumulator."""
+    tilelang.compile(_gemm_kernel("none"))
+
+    assert MESSAGE in capfd.readouterr().err
+
+
+@tilelang.testing.requires_cuda
+def test_pipeline_silent_when_disabled_via_pass_config(capfd, no_kernel_cache):
+    """The pass config suppresses the warning through the whole pipeline."""
+    tilelang.compile(
+        _gemm_kernel("none"),
+        pass_configs={tilelang.PassConfigKey.TL_DISABLE_BUFFER_INIT_CHECK: True},
+    )
+
+    assert MESSAGE not in capfd.readouterr().err
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_transform_verify_buffer_init.py
+++ b/testing/python/transform/test_tilelang_transform_verify_buffer_init.py
@@ -216,6 +216,43 @@ def test_silent_when_shared_buffer_is_written_by_a_later_branch(capfd):
     assert MESSAGE not in _verify(kernel, capfd)
 
 
+def test_reports_a_shared_store_that_reads_its_own_destination(capfd):
+    """Ignoring source order must not let a store vouch for itself.
+
+    A shared buffer is satisfied when some *other* node writes it, so the
+    reading node's own write has to be discounted here exactly as it is for a
+    gemm accumulating into an untouched accumulator. The store below is the
+    only writer of `s` and reads the destination it is about to establish.
+    """
+
+    @T.prim_func
+    def kernel(A: T.Tensor((NB, BC), torch.float32), C: T.Tensor((NB, BC), torch.float32)):
+        with T.Kernel(NB, threads=128) as bx:
+            s = T.alloc_shared((BC,), torch.float32)
+            for i in T.Parallel(BC):
+                s[i] = s[i] + A[bx, i]
+            for i in T.Parallel(BC):
+                C[bx, i] = s[i]
+
+    assert MESSAGE in _verify(kernel, capfd)
+
+
+def test_silent_when_another_node_writes_the_shared_destination(capfd):
+    """The same accumulation is fine once anything else establishes a value."""
+
+    @T.prim_func
+    def kernel(A: T.Tensor((NB, BC), torch.float32), C: T.Tensor((NB, BC), torch.float32)):
+        with T.Kernel(NB, threads=128) as bx:
+            s = T.alloc_shared((BC,), torch.float32)
+            T.clear(s)
+            for i in T.Parallel(BC):
+                s[i] = s[i] + A[bx, i]
+            for i in T.Parallel(BC):
+                C[bx, i] = s[i]
+
+    assert MESSAGE not in _verify(kernel, capfd)
+
+
 def test_reports_a_fragment_written_only_after_its_read(capfd):
     """Per-thread storage keeps order-sensitive tracking.
 
@@ -331,9 +368,9 @@ def no_kernel_cache():
 
 
 def _reducer_kernel():
-    """A kernel using T.alloc_reducer / T.finalize_reducer.
+    """A kernel using the legacy T.alloc_reducer / T.finalize_reducer form.
 
-    Before LayoutReducer runs, the tl.tileop.finalize_reducer call carries a
+    At the point this pass runs, the tl.tileop.finalize_reducer call carries a
     single argument while the op's builder reads args[1]. Parsing it there
     throws, which must never take a compile down.
     """
@@ -351,6 +388,32 @@ def _reducer_kernel():
             T.copy(r_f, B)
 
     return kernel
+
+
+def test_silent_for_the_reducer_v2_idiom(capfd):
+    """The first-class reducer ops inherit the default read-before-write set.
+
+    `T.reducer_init` establishes the accumulator, `T.reducer_update` reads and
+    writes it, and `T.finalize_reducer` reads it into a destination it writes.
+    None of these ops overrides GetReadBeforeWriteRegions, so this pins that
+    the op-agnostic default is already right for them.
+    """
+
+    @T.prim_func
+    def kernel(A: T.Tensor((BC,), torch.float32), B: T.Tensor((1,), torch.float32)):
+        with T.Kernel(1, threads=64) as _:
+            src = T.alloc_fragment((BC,), torch.float32)
+            T.copy(A, src)
+            acc = T.alloc_reducer((1,), torch.float32, op="sum")
+            T.reducer_init(acc)
+            for i in T.Parallel(BC):
+                T.reducer_update(acc[0], src[i])
+            result = T.alloc_fragment((1,), torch.float32)
+            T.finalize_reducer(acc, result)
+            if T.get_thread_binding() == 0:
+                B[0] = result[0]
+
+    assert MESSAGE not in _verify(kernel, capfd)
 
 
 def test_reducer_kernel_does_not_raise(capfd):

--- a/testing/python/transform/test_tilelang_transform_verify_buffer_init.py
+++ b/testing/python/transform/test_tilelang_transform_verify_buffer_init.py
@@ -219,6 +219,26 @@ def test_reports_a_fragment_written_only_after_its_read(capfd):
     assert MESSAGE in _verify(kernel, capfd)
 
 
+def test_reports_an_unguarded_loop_carried_read(capfd):
+    """An unguarded loop-carried read is a real finding, not an artifact.
+
+    The write at the bottom of the body reaches the read only on iterations
+    after the first, so iteration zero reads whatever the fragment happened to
+    hold. Source-order tracking gets this case right. A read guarded so it
+    cannot run on the first iteration is the case it does not.
+    """
+
+    @T.prim_func
+    def kernel(A: T.Tensor((BC,), torch.float32), C: T.Tensor((BC,), torch.float32)):
+        with T.Kernel(1, threads=64) as _:
+            f = T.alloc_fragment((1,), torch.float32)
+            for k in T.serial(BC):
+                C[k] = f[0]
+                f[0] = A[k]
+
+    assert MESSAGE in _verify(kernel, capfd)
+
+
 # ---------------------------------------------------------- reporting cases
 
 
@@ -318,7 +338,7 @@ def _reducer_kernel():
 
 
 def test_reducer_kernel_does_not_raise(capfd):
-    """An unparseable tile op degrades to opaque, it does not throw."""
+    """A tile op the pass cannot parse degrades to opaque, it does not throw."""
     err = _verify(_reducer_kernel(), capfd)
 
     assert MESSAGE not in err

--- a/testing/python/transform/test_tilelang_transform_verify_buffer_init.py
+++ b/testing/python/transform/test_tilelang_transform_verify_buffer_init.py
@@ -120,6 +120,27 @@ def test_silent_for_global_scope_buffers(capfd):
     assert MESSAGE not in _verify(kernel, capfd)
 
 
+def test_silent_for_a_scoped_parameter_buffer(capfd):
+    """A parameter is the caller's to fill, whatever storage scope it carries.
+
+    Cross-thread scopes ask whether some other *node in this body* writes the
+    buffer, and the caller is not one. A shared-scope parameter therefore has
+    to be admitted on the strength of being a parameter, or it reports while
+    an identical local-scope parameter stays silent.
+    """
+
+    @T.prim_func
+    def kernel(
+        S: T.Tensor((BC,), torch.float32, scope="shared.dyn"),
+        C: T.Tensor((BC,), torch.float32),
+    ):
+        with T.Kernel(1, threads=64) as _:
+            for i in T.Parallel(BC):
+                C[i] = S[i]
+
+    assert MESSAGE not in _verify(kernel, capfd)
+
+
 def test_reports_a_shared_buffer_read_before_any_copy(capfd):
     """The general case the gemm-specific check could not see."""
 

--- a/tilelang/backend/pass_pipeline/pipeline_utils.py
+++ b/tilelang/backend/pass_pipeline/pipeline_utils.py
@@ -68,18 +68,6 @@ def should_enable_race_check(pass_ctx: PassContext | None = None) -> bool:
     return not disable
 
 
-def should_enable_buffer_init_check(pass_ctx: PassContext | None = None) -> bool:
-    if pass_ctx is None:
-        pass_ctx = tilelang.transform.get_pass_context()
-    # Enabled by default. The analysis reports buffers that nothing writes at
-    # all, plus order-sensitive cases in per-thread storage where the only
-    # write comes after the read, which keeps false positives rare enough to
-    # warrant it; users can opt out through the `tl.disable_buffer_init_check`
-    # pass config.
-    disable = pass_ctx.config.get(tilelang.PassConfigKey.TL_DISABLE_BUFFER_INIT_CHECK, False)
-    return not disable
-
-
 def should_disable_shared_memory_reuse(pass_ctx: PassContext | None = None) -> bool:
     if pass_ctx is None:
         pass_ctx = tilelang.transform.get_pass_context()

--- a/tilelang/backend/pass_pipeline/pipeline_utils.py
+++ b/tilelang/backend/pass_pipeline/pipeline_utils.py
@@ -68,6 +68,16 @@ def should_enable_race_check(pass_ctx: PassContext | None = None) -> bool:
     return not disable
 
 
+def should_enable_buffer_init_check(pass_ctx: PassContext | None = None) -> bool:
+    if pass_ctx is None:
+        pass_ctx = tilelang.transform.get_pass_context()
+    # Enabled by default. The analysis only reports buffers that nothing writes
+    # at all, which keeps false positives rare enough to warrant it; users can
+    # opt out through the `tl.disable_buffer_init_check` pass config.
+    disable = pass_ctx.config.get(tilelang.PassConfigKey.TL_DISABLE_BUFFER_INIT_CHECK, False)
+    return not disable
+
+
 def should_disable_shared_memory_reuse(pass_ctx: PassContext | None = None) -> bool:
     if pass_ctx is None:
         pass_ctx = tilelang.transform.get_pass_context()

--- a/tilelang/backend/pass_pipeline/pipeline_utils.py
+++ b/tilelang/backend/pass_pipeline/pipeline_utils.py
@@ -71,9 +71,11 @@ def should_enable_race_check(pass_ctx: PassContext | None = None) -> bool:
 def should_enable_buffer_init_check(pass_ctx: PassContext | None = None) -> bool:
     if pass_ctx is None:
         pass_ctx = tilelang.transform.get_pass_context()
-    # Enabled by default. The analysis only reports buffers that nothing writes
-    # at all, which keeps false positives rare enough to warrant it; users can
-    # opt out through the `tl.disable_buffer_init_check` pass config.
+    # Enabled by default. The analysis reports buffers that nothing writes at
+    # all, plus order-sensitive cases in per-thread storage where the only
+    # write comes after the read, which keeps false positives rare enough to
+    # warrant it; users can opt out through the `tl.disable_buffer_init_check`
+    # pass config.
     disable = pass_ctx.config.get(tilelang.PassConfigKey.TL_DISABLE_BUFFER_INIT_CHECK, False)
     return not disable
 

--- a/tilelang/cpu/pipeline.py
+++ b/tilelang/cpu/pipeline.py
@@ -7,6 +7,7 @@ import tilelang
 from tilelang.backend.pass_pipeline.pipeline_utils import (
     LayoutVisual,
     allow_vectorize,
+    should_enable_buffer_init_check,
     should_enable_race_check,
     should_force_let_inline,
 )
@@ -27,6 +28,13 @@ def CPUPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.Simplify()(mod)
     mod = tilelang.transform.CanonicalizeLegacyReducer()(mod)
     mod = tilelang.transform.VerifyReducerEpoch()(mod)
+    # Warn on buffers that are read before anything writes them.
+    # Runs after the reducer passes above, so legacy reducers have been
+    # canonicalized, and before PipelinePlanning and LowerTileOp, while
+    # loop bodies are still in source order and tile ops still declare
+    # their access regions.
+    if should_enable_buffer_init_check():
+        mod = tilelang.transform.VerifyBufferInit()(mod)
 
     mod = tilelang.transform.IfStmtBinding()(mod)
     mod = tilelang.transform.Simplify()(mod)

--- a/tilelang/cpu/pipeline.py
+++ b/tilelang/cpu/pipeline.py
@@ -7,7 +7,6 @@ import tilelang
 from tilelang.backend.pass_pipeline.pipeline_utils import (
     LayoutVisual,
     allow_vectorize,
-    should_enable_buffer_init_check,
     should_enable_race_check,
     should_force_let_inline,
 )
@@ -33,8 +32,7 @@ def CPUPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     # canonicalized, and before PipelinePlanning and LowerTileOp, while
     # loop bodies are still in source order and tile ops still declare
     # their access regions.
-    if should_enable_buffer_init_check():
-        mod = tilelang.transform.VerifyBufferInit()(mod)
+    mod = tilelang.transform.VerifyBufferInit()(mod)
 
     mod = tilelang.transform.IfStmtBinding()(mod)
     mod = tilelang.transform.Simplify()(mod)

--- a/tilelang/cuda/pipeline.py
+++ b/tilelang/cuda/pipeline.py
@@ -12,6 +12,7 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
     allow_vectorize,
     should_disable_shared_memory_reuse,
     should_enable_aggressive_merge,
+    should_enable_buffer_init_check,
     should_enable_race_check,
     should_force_let_inline,
 )
@@ -90,6 +91,13 @@ def CUDAPassPipelineBodyPrologue(mod: IRModule, target: Target) -> IRModule:
     # diagnostics point at user-written code)
     mod = tilelang.transform.CanonicalizeLegacyReducer()(mod)
     mod = tilelang.transform.VerifyReducerEpoch()(mod)
+    # Warn on buffers that are read before anything writes them.
+    # Runs after the reducer passes above, so legacy reducers have been
+    # canonicalized, and before PipelinePlanning and LowerTileOp, while
+    # loop bodies are still in source order and tile ops still declare
+    # their access regions.
+    if should_enable_buffer_init_check():
+        mod = tilelang.transform.VerifyBufferInit()(mod)
 
     # @CUDA-specific
     # Tile-level warp specialization: runs before layout inference so that

--- a/tilelang/cuda/pipeline.py
+++ b/tilelang/cuda/pipeline.py
@@ -12,7 +12,6 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
     allow_vectorize,
     should_disable_shared_memory_reuse,
     should_enable_aggressive_merge,
-    should_enable_buffer_init_check,
     should_enable_race_check,
     should_force_let_inline,
 )
@@ -96,8 +95,7 @@ def CUDAPassPipelineBodyPrologue(mod: IRModule, target: Target) -> IRModule:
     # canonicalized, and before PipelinePlanning and LowerTileOp, while
     # loop bodies are still in source order and tile ops still declare
     # their access regions.
-    if should_enable_buffer_init_check():
-        mod = tilelang.transform.VerifyBufferInit()(mod)
+    mod = tilelang.transform.VerifyBufferInit()(mod)
 
     # @CUDA-specific
     # Tile-level warp specialization: runs before layout inference so that

--- a/tilelang/metal/pipeline.py
+++ b/tilelang/metal/pipeline.py
@@ -9,7 +9,6 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
     allow_vectorize,
     should_disable_shared_memory_reuse,
     should_enable_aggressive_merge,
-    should_enable_buffer_init_check,
     should_enable_race_check,
     should_force_let_inline,
 )
@@ -36,8 +35,7 @@ def MetalPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     # canonicalized, and before PipelinePlanning and LowerTileOp, while
     # loop bodies are still in source order and tile ops still declare
     # their access regions.
-    if should_enable_buffer_init_check():
-        mod = tilelang.transform.VerifyBufferInit()(mod)
+    mod = tilelang.transform.VerifyBufferInit()(mod)
 
     mod = tilelang.transform.IfStmtBinding()(mod)
     mod = tilelang.transform.PipelinePlanning()(mod)

--- a/tilelang/metal/pipeline.py
+++ b/tilelang/metal/pipeline.py
@@ -9,6 +9,7 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
     allow_vectorize,
     should_disable_shared_memory_reuse,
     should_enable_aggressive_merge,
+    should_enable_buffer_init_check,
     should_enable_race_check,
     should_force_let_inline,
 )
@@ -30,6 +31,13 @@ def MetalPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.Simplify()(mod)
     mod = tilelang.transform.CanonicalizeLegacyReducer()(mod)
     mod = tilelang.transform.VerifyReducerEpoch()(mod)
+    # Warn on buffers that are read before anything writes them.
+    # Runs after the reducer passes above, so legacy reducers have been
+    # canonicalized, and before PipelinePlanning and LowerTileOp, while
+    # loop bodies are still in source order and tile ops still declare
+    # their access regions.
+    if should_enable_buffer_init_check():
+        mod = tilelang.transform.VerifyBufferInit()(mod)
 
     mod = tilelang.transform.IfStmtBinding()(mod)
     mod = tilelang.transform.PipelinePlanning()(mod)

--- a/tilelang/rocm/pipeline.py
+++ b/tilelang/rocm/pipeline.py
@@ -9,6 +9,7 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
     allow_vectorize,
     should_disable_shared_memory_reuse,
     should_enable_aggressive_merge,
+    should_enable_buffer_init_check,
     should_enable_race_check,
     should_force_let_inline,
 )
@@ -29,6 +30,13 @@ def ROCMPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.Simplify()(mod)
     mod = tilelang.transform.CanonicalizeLegacyReducer()(mod)
     mod = tilelang.transform.VerifyReducerEpoch()(mod)
+    # Warn on buffers that are read before anything writes them.
+    # Runs after the reducer passes above, so legacy reducers have been
+    # canonicalized, and before PipelinePlanning and LowerTileOp, while
+    # loop bodies are still in source order and tile ops still declare
+    # their access regions.
+    if should_enable_buffer_init_check():
+        mod = tilelang.transform.VerifyBufferInit()(mod)
 
     mod = tilelang.transform.IfStmtBinding()(mod)
     mod = tilelang.transform.PipelinePlanning()(mod)

--- a/tilelang/rocm/pipeline.py
+++ b/tilelang/rocm/pipeline.py
@@ -9,7 +9,6 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
     allow_vectorize,
     should_disable_shared_memory_reuse,
     should_enable_aggressive_merge,
-    should_enable_buffer_init_check,
     should_enable_race_check,
     should_force_let_inline,
 )
@@ -35,8 +34,7 @@ def ROCMPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     # canonicalized, and before PipelinePlanning and LowerTileOp, while
     # loop bodies are still in source order and tile ops still declare
     # their access regions.
-    if should_enable_buffer_init_check():
-        mod = tilelang.transform.VerifyBufferInit()(mod)
+    mod = tilelang.transform.VerifyBufferInit()(mod)
 
     mod = tilelang.transform.IfStmtBinding()(mod)
     mod = tilelang.transform.PipelinePlanning()(mod)

--- a/tilelang/transform/__init__.py
+++ b/tilelang/transform/__init__.py
@@ -105,6 +105,17 @@ def VerifyParallelLoop():
     return _ffi_api.VerifyParallelLoop()  # type: ignore
 
 
+def VerifyBufferInit():
+    """Warn when a non-global-scope buffer is read before anything writes it.
+
+    Returns
+    -------
+    fpass : tvm.transform.Pass
+        The registered pass. It inspects the IR and returns it unchanged.
+    """
+    return _ffi_api.VerifyBufferInit()  # type: ignore
+
+
 def ThreadSync(storage_scope: str):
     """Insert sync between parallel read/write of shared buffers.
 

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -49,6 +49,14 @@ class PassConfigKey(str, Enum):
     TL_SIMPLIFY_ENABLE_LET_INLINE = "enable_simplify_let_inline"
     """Enable inlining of let statements during simplification. Default: True"""
 
+    TL_DISABLE_BUFFER_INIT_CHECK = "tl.disable_buffer_init_check"
+    """Disable the buffer-initialization check. Default: False
+
+    The check warns when a non-global-scope buffer is read before anything
+    writes it. It is enabled by default; set this config to True to silence
+    it.
+    """
+
     TL_DISABLE_DATA_RACE_CHECK = "tl.disable_data_race_check"
     """Disable data race check in TileLang. Default: True
 

--- a/tilelang/webgpu/pipeline.py
+++ b/tilelang/webgpu/pipeline.py
@@ -9,6 +9,7 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
     allow_vectorize,
     should_disable_shared_memory_reuse,
     should_enable_aggressive_merge,
+    should_enable_buffer_init_check,
     should_enable_race_check,
     should_force_let_inline,
 )
@@ -31,6 +32,13 @@ def WebGPUPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     mod = tilelang.transform.Simplify()(mod)
     mod = tilelang.transform.CanonicalizeLegacyReducer()(mod)
     mod = tilelang.transform.VerifyReducerEpoch()(mod)
+    # Warn on buffers that are read before anything writes them.
+    # Runs after the reducer passes above, so legacy reducers have been
+    # canonicalized, and before PipelinePlanning and LowerTileOp, while
+    # loop bodies are still in source order and tile ops still declare
+    # their access regions.
+    if should_enable_buffer_init_check():
+        mod = tilelang.transform.VerifyBufferInit()(mod)
 
     mod = tilelang.transform.IfStmtBinding()(mod)
     mod = tilelang.transform.PipelinePlanning()(mod)

--- a/tilelang/webgpu/pipeline.py
+++ b/tilelang/webgpu/pipeline.py
@@ -9,7 +9,6 @@ from tilelang.backend.pass_pipeline.pipeline_utils import (
     allow_vectorize,
     should_disable_shared_memory_reuse,
     should_enable_aggressive_merge,
-    should_enable_buffer_init_check,
     should_enable_race_check,
     should_force_let_inline,
 )
@@ -37,8 +36,7 @@ def WebGPUPassPipelineBody(mod: IRModule, target: Target) -> IRModule:
     # canonicalized, and before PipelinePlanning and LowerTileOp, while
     # loop bodies are still in source order and tile ops still declare
     # their access regions.
-    if should_enable_buffer_init_check():
-        mod = tilelang.transform.VerifyBufferInit()(mod)
+    mod = tilelang.transform.VerifyBufferInit()(mod)
 
     mod = tilelang.transform.IfStmtBinding()(mod)
     mod = tilelang.transform.PipelinePlanning()(mod)


### PR DESCRIPTION
# [Transform] Warn when a buffer is read before anything writes it

Follow-up to #2939, closed as too gemm-specific. This is the general check
suggested there: a non-global-scope buffer read at a point where nothing has
written it. Motivating case is #2936 — a `T.gemm` accumulator nothing
initializes, correct on one machine and NaN on another.

`VerifyBufferInit` walks each `PrimFunc` in execution order, warns, and returns
the function unchanged. It never fails a build.

It runs after `CanonicalizeLegacyReducer` / `VerifyReducerEpoch` and before
`PipelinePlanning` and `LowerTileOp`. That slot matters: tile operators still
carry their access regions, so writes from `T.copy`, `T.clear` and `T.fill` are
visible rather than opaque, and loop bodies are still in source order rather
than rotated across pipeline stages. Rebased onto #2940 — same point in the
sequence that `LayoutReducer` used to occupy.

## Why `GetReadBeforeWriteRegions()`

The one new piece of op-level API is a virtual on `TileOperatorNode` defaulting
to `GetAccessRegions().reads`, overridden only by `GemmNode` / `GemmSPNode`.

`GetAccessRegions()` answers **may-read** and is correctly conservative for the
dependency analysis it was built for. This check needs **must-read**: does the
op consume the region's prior contents before establishing a value of its own?

Gemm is where the two diverge. `GemmNode::GetAccessRegions()` keeps C in the
read set unless the clear is *proven* (`if (!is_one(clearAccum_))`), which is
right for pipelining but means the common `clear_accum=(k == 0)` idiom — neither
literal true nor false — reports C as read with nothing writing it beforehand.
That idiom is all over `examples/`, so a check consuming
`GetAccessRegions().reads` would false-positive on much of the tree.
`test_silent_for_the_pipelined_clear_accum_idiom` is the regression guard:
swapping the verifier back fails that test and only that test.

The override lives in the gemm ops, where the knowledge already lives, so the
verifier stays op-agnostic. Existing consumers of `GetAccessRegions()` are
untouched. The reducer v2 ops from #2940 are a useful check on that claim since
they landed after this was written: they inherit the default, need no override,
and are silent.

(Not to be confused with the `kAccessReadWrite` mask in `GemmNode::Gemm` —
`GemmNode` overrides `GetAccessRegions()` and never consults it.)

## Deliberate imprecision

The pass detects "nothing writes this buffer at all" and nothing finer — no
index-level or path-sensitive reasoning, so it will not catch partial
initialization. Four rules follow:

- **Scope-dependent ordering.** For per-thread storage a write counts if it
  appears earlier in the body — source order is that thread's execution order.
  Shared memory ignores order and asks only whether some *other* operation
  writes the buffer, because a warp-specialized kernel routinely places the
  producer branch after the consumer branch and coordinates through barriers.
  Excluding the reading operator's own write is what keeps #2936 reported.
- **Calls that may write are assumed to**, via `TCallEffectKind`; an op with no
  registered effect kind is assumed to write.
- **Exempt scopes.** `global` is the caller's responsibility; `shared.barrier`
  and `shared.cluster_barrier` hold mbarrier state the pass does not model.
  Parameters are exempt at any scope for the same reason as `global`.
- **A store establishes nothing until its value is evaluated**, so
  `x[i] = x[i] + 1` and the carry-forward `idx = T.if_then_else(cond, i, idx)`
  are findings. The store is also discounted as its own writer, so shared and
  per-thread scopes reach that conclusion alike.

**Known limitation**: a read the loop *guards* out of its own first iteration
(`if k > 0: C[k] = f[0]`) is reported though it never reads uninitialized
storage. Clearing it needs path sensitivity the pass does not attempt. An
*unguarded* loop-carried read is reported and correctly so. No guarded case
appears anywhere in `examples/`.

## Default-on, and the evidence for it

Enabled by default, with `tl.disable_buffer_init_check` to opt out.
`VerifyParallelLoop` is the precedent that had to default off, so the default
here is backed by measurement:

- **`testing/python/language`** (997 passing): zero warnings, pass/fail counts
  identical to the same tree without this change.
- **All 285 `.py` under `examples/`** (104 are `example_*.py`): **three warnings
  in two places**, both real read-before-writes, no known false positive. The
  last commit fixes all three; afterwards, zero warnings and zero import
  failures, re-measured on top of #2940.

Neither finding is new — `lse_max_local` dates to #46 (Jan 2025),
`cur_batch_idx` to #515 (May 2025) — and **no runtime failure is claimed for
either.**

**`example_mha_inference.py`** never initializes `lse_max_local` and passes it
to `T.reduce_max(..., clear=False)`, which marks the destination as a read. It
is visible in the generated CUDA. On an RTX 3060 Ti the current form is
bit-identical to both fixes across five launches; seeding `+inf` instead turns
all 524288 outputs into NaN. Benign here is a property of the machine, not the
code. Note the pass found this through the *default* interface — reduce needs no
override, and the check is not gemm-shaped.

**`example_grouped_gemm_fwd.py`** and its `_bwd` counterpart carry
`cur_batch_idx` forward through itself with no initializer. The third file in
that directory, `example_grouped_gemm_fwd_ptr.py`, writes `cur_batch_idx = 0`
before the same loop and is silent — a second author, writing the same loop ten
months later (#1923), initialized it unprompted, which is the best evidence
this is an oversight rather than an idiom. One red herring worth naming: both
files fail their own `torch.allclose`, and that is **not** caused by this.
Adding the initializer leaves an unchanged 0.25 max abs error over ~3.4k of
1572864 elements, so the mismatch is pre-existing and untouched here.

The fix commit is three lines and is deliberately last — drop it without
touching anything else if you would rather those files go through their own
review.

## Tests

`testing/python/transform/test_tilelang_transform_verify_buffer_init.py`, 28
tests: the #2936 gemm kernel and its three silent variants; shared, `local` and
extern-filled buffers; global-scope and scoped-parameter reads; legacy and v2
reducer idioms; stores that read their own destination in both scope classes.
Two tests pin the scope-ordering rule from opposite sides — a shared buffer
written only by a later branch is silent, a fragment written only after its read
still warns — and the first fails under uniform order-sensitivity while the
second fails under uniform whole-function suppression. The rest cover
aggregated reporting and the config wiring end-to-end through `tilelang.compile`.

## Open questions

1. **Default-on** — one-line change to `should_enable_buffer_init_check` if you
   would rather see the check land quietly first.
2. **The gemm hint.** The analysis is op-agnostic, but the *wording* of a report
   checks for `GemmNode` to suggest `T.clear(C)` / `clear_accum=True`. If that
   reads as too gemm-aware, dropping to the generic message costs nothing
   structurally.

Closes the thread from #2939. Related: #2936.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added `VerifyBufferInit`, a warning-only transform that detects reads from non-global buffers before writes reach them.
- Added scope-aware analysis for must-read and may-read regions, calls, opaque pointer escapes, shared memory, loops, and source spans.
- Added `GetReadBeforeWriteRegions()` with GEMM and GEMM-SP overrides.
- Enabled the pass across CPU, CUDA, Metal, ROCm, and WebGPU pipelines.
- Added `tl.disable_buffer_init_check` for opt-out control.
- Added 28 tests covering analysis, reporting, configuration, and pipeline behavior.
- Initialized buffers in three examples. All 285 example scripts now produce zero warnings.

## C++ style / lint notes

- The PR changes C++ files and adds a public C++ API.
- Review `docs/developer_guide/cpp_style.md` for applicable API and maintainability guidance.
- The “C++ API Style Audit (warning only)” CI step applies.
- Any TLCPP003/TLCPP004 findings are advisory unless they indicate a clear API, FFI, or maintainability risk.
- No correctness, build, or test issue is identified in the supplied summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
