### PR TITLE
[TIR][Transform] Preserve source spans across lowering passes

### DIFF
--- a/src/span_utils.cc
+++ b/src/span_utils.cc
@@ -6,6 +6,7 @@
 #include "span_utils.h"
 
 #include <tvm/ffi/reflection/registry.h>
+#include <tvm/tirx/stmt_functor.h>
 
 namespace tvm {
 namespace tl {
@@ -45,6 +46,19 @@ Span GetPrimFuncSpan(const PrimFunc &func) {
 
 String SpanToString(const Span &span) { return FormatSpan(span); }
 
+void StampSubtreeSpans(const Stmt &stmt, const Span &span) {
+  if (!stmt.defined() || !span.defined()) {
+    return;
+  }
+  PostOrderVisit(stmt, [&span](const ObjectRef &obj) {
+    if (const auto *node = obj.as<StmtNode>()) {
+      if (!node->span.defined()) {
+        const_cast<StmtNode *>(node)->span = span;
+      }
+    }
+  });
+}
+
 TVM_FFI_STATIC_INIT_BLOCK() {
   namespace refl = tvm::ffi::reflection;
   refl::GlobalDef()
@@ -54,6 +68,7 @@ TVM_FFI_STATIC_INIT_BLOCK() {
       .def("tl.ir.GetBufferSpan", &GetBufferSpan)
       .def("tl.ir.SetPrimFuncSpan", &SetPrimFuncSpan)
       .def("tl.ir.GetPrimFuncSpan", &GetPrimFuncSpan)
+      .def("tl.ir.StampSubtreeSpans", &StampSubtreeSpans)
       .def("tl.ir.SpanToString", &SpanToString);
 }
 

--- a/src/span_utils.h
+++ b/src/span_utils.h
@@ -39,6 +39,16 @@ inline std::string FormatSpan(const Span &span) {
 }
 
 /*!
+ * \brief Fill in the given span on every Stmt node in the subtree whose span
+ *        is undefined. Nodes that already carry a span are left untouched, so
+ *        lowered code inherits the source line of the statement it was
+ *        lowered from without overriding finer-grained spans.
+ * \note No-op when `span` is undefined. Spans never participate in structural
+ *       equality or hashing, so stamping does not change compilation results.
+ */
+void StampSubtreeSpans(const tirx::Stmt &stmt, const Span &span);
+
+/*!
  * \brief Suffix for error messages pointing at a source location, e.g.
  *        "\n  --> /path/to/kernel.py:21:1". Empty when no span is available.
  */

--- a/src/transform/if_stmt_binding.cc
+++ b/src/transform/if_stmt_binding.cc
@@ -135,9 +135,9 @@ private:
     Array<BufferRegion> writes_;
   };
 
-  static Stmt MakeSeq(Array<Stmt> seq) {
+  static Stmt MakeSeq(Array<Stmt> seq, Span span = Span()) {
     ICHECK(!seq.empty());
-    return seq.size() == 1 ? seq[0] : SeqStmt(std::move(seq));
+    return seq.size() == 1 ? seq[0] : SeqStmt(std::move(seq), span);
   }
 
   std::pair<Array<BufferRegion>, Array<BufferRegion>>
@@ -213,7 +213,7 @@ private:
     for (const Stmt &stmt : stmts) {
       guarded_stmts.push_back(GuardStmt(guard_condition, stmt, span));
     }
-    return MakeSeq(std::move(guarded_stmts));
+    return MakeSeq(std::move(guarded_stmts), span);
   }
 
   Stmt BindIfStmtLegacy(const Stmt &body, const PrimExpr &condition,
@@ -234,7 +234,7 @@ private:
         for (; i < n; ++i) {
           bind_scope.push_back(seq_stmt->seq[i]);
         }
-        guarded_bodies.push_back(MakeSeq(std::move(bind_scope)));
+        guarded_bodies.push_back(MakeSeq(std::move(bind_scope), span));
       }
       return GuardStmts(guarded_bodies, condition, span);
     }
@@ -279,7 +279,7 @@ private:
     }
 
     if (!bind_scope.empty()) {
-      guarded_bodies.push_back(MakeSeq(std::move(bind_scope)));
+      guarded_bodies.push_back(MakeSeq(std::move(bind_scope), span));
     }
     if (guarded_bodies.empty()) {
       return Evaluate(0, span);
@@ -328,7 +328,7 @@ private:
         buffer_data_to_buffer_.erase(it->first);
       }
     }
-    return SeqStmt(std::move(seq));
+    return SeqStmt(std::move(seq), op->span);
   }
 
   Stmt VisitStmt_(const SBlockNode *op) final {

--- a/src/transform/inject_pipeline.cc
+++ b/src/transform/inject_pipeline.cc
@@ -472,7 +472,9 @@ SBlock MakeBlock(const Stmt &body,
   }
   if (!block.defined()) {
     block = SBlock(/*iter_vars=*/{}, /*reads=*/{}, /*writes=*/{},
-                   /*name_hint=*/"", /*body*/ body);
+                   /*name_hint=*/"", /*body*/ body, /*init=*/std::nullopt,
+                   /*alloc_buffers=*/{}, /*match_buffers=*/{},
+                   /*annotations=*/{}, /*span=*/body->span);
   }
   Array<Array<BufferRegion>> access =
       GetSBlockReadWriteRegion(block, buffer_data_to_buffer);
@@ -3034,7 +3036,8 @@ private:
       }
       new_loop = For(Downcast<Var>(new_loop_var), pipeline_loop_->min, extent,
                      unroll_loop ? ForKind::kUnrolled : pipeline_loop_->kind,
-                     std::move(new_loop), std::nullopt, preserved_annotations);
+                     std::move(new_loop), std::nullopt, preserved_annotations,
+                     std::nullopt, pipeline_loop_->span);
     }
     Stmt result = SBlockRealize({}, Bool(true),
                                 MakeBlock(new_loop, buffer_data_to_buffer_));

--- a/src/transform/legalize_safe_memory_access.cc
+++ b/src/transform/legalize_safe_memory_access.cc
@@ -485,7 +485,8 @@ private:
     // If a store is out of bounds, we skip the corresponding stmt directly.
     Stmt store_with_conditions = store;
     for (auto cond : conditions) {
-      store_with_conditions = IfThenElse(cond, store_with_conditions);
+      store_with_conditions =
+          IfThenElse(cond, store_with_conditions, Stmt(), store->span);
     }
     return store_with_conditions;
   }
@@ -677,7 +678,7 @@ private:
 
     Stmt else_case = BufferStore(dst_info.base_load->buffer, safe_value,
                                  dst_info.base_load->indices);
-    return IfThenElse(combined, evaluate, else_case);
+    return IfThenElse(combined, evaluate, else_case, evaluate->span);
   }
 
   Stmt WrapEvaluateWithConditions(const Evaluate &evaluate,
@@ -687,7 +688,8 @@ private:
     }
     Stmt evaluate_with_conditions = evaluate;
     for (auto cond : conditions) {
-      evaluate_with_conditions = IfThenElse(cond, evaluate_with_conditions);
+      evaluate_with_conditions =
+          IfThenElse(cond, evaluate_with_conditions, Stmt(), evaluate->span);
     }
     return evaluate_with_conditions;
   }

--- a/src/transform/loop_partition.cc
+++ b/src/transform/loop_partition.cc
@@ -102,6 +102,9 @@ For PartitionLoop(For op, PrimExpr thread_index, arith::Analyzer *analyzer,
                   const Fragment &loop_layout, bool require_padding_guard) {
   ICHECK(loop_layout.defined());
   ICHECK(thread_index.defined());
+  // `op` is moved into `body` below; capture its span up front so reconstructed
+  // statements can still inherit the source location of the original loop.
+  const Span op_span = op->span;
   int old_loop_depth = loop_layout->InputDim();
   int new_loop_depth = loop_layout->OutputDim();
   // Create the new loop iter var
@@ -193,12 +196,12 @@ For PartitionLoop(For op, PrimExpr thread_index, arith::Analyzer *analyzer,
   }
   PrimExpr simplified_guard = analyzer->Simplify(guard);
   if (!analyzer->CanProve(simplified_guard)) {
-    body = IfThenElse(simplified_guard, body, Stmt());
+    body = IfThenElse(simplified_guard, body, Stmt(), op_span);
   }
 
   for (int i = new_loop_depth - 1; i >= 0; i--) {
     body = For(vars[i], make_zero(vars[i]->dtype), inv_loop->InputShape()[i],
-               ForKind::kSerial, body);
+               ForKind::kSerial, body, std::nullopt, {}, std::nullopt, op_span);
     analyzer->Bind(vars[i], Range(0, inv_loop->InputShape()[i]));
   }
 
@@ -345,7 +348,7 @@ Stmt LowerParallelLoop(For loop, const Fragment &loop_layout,
 
   // Step 3: Wrap with predicate if provided and this is a parallel loop
   if (predicate.defined() && parallel_loop) {
-    return IfThenElse(predicate.value(), result_loop);
+    return IfThenElse(predicate.value(), result_loop, Stmt(), loop->span);
   }
 
   return result_loop;

--- a/src/transform/loop_unswitching.cc
+++ b/src/transform/loop_unswitching.cc
@@ -553,7 +553,7 @@ public:
         result = GetRef<Stmt>(op);
       } else {
         result = For(op->loop_var, op->min, op->extent, op->kind, body,
-                     op->thread_binding, op->annotations, op->step);
+                     op->thread_binding, op->annotations, op->step, op->span);
       }
       if (pushed_thread_idx) {
         thread_idx_vars_in_scope_.erase(op->loop_var.get());
@@ -573,7 +573,7 @@ public:
         result = GetRef<Stmt>(op);
       } else {
         result = For(op->loop_var, op->min, op->extent, op->kind, body,
-                     op->thread_binding, op->annotations, op->step);
+                     op->thread_binding, op->annotations, op->step, op->span);
       }
       if (pushed_thread_idx) {
         thread_idx_vars_in_scope_.erase(op->loop_var.get());
@@ -596,7 +596,7 @@ public:
     // two versions.
     if (!allow_non_trivial_else_ && !IsSideEffectFreeStmt(else_body)) {
       result = For(op->loop_var, op->min, op->extent, op->kind, body,
-                   op->thread_binding, op->annotations, op->step);
+                   op->thread_binding, op->annotations, op->step, op->span);
       if (pushed_thread_idx) {
         thread_idx_vars_in_scope_.erase(op->loop_var.get());
       }
@@ -608,17 +608,18 @@ public:
     else_body = Substitute(else_body, {{op->loop_var, else_loop_var}});
 
     For then_loop(op->loop_var, op->min, op->extent, op->kind, then_body,
-                  op->thread_binding, op->annotations, op->step);
+                  op->thread_binding, op->annotations, op->step, op->span);
     For else_loop(else_loop_var, op->min, op->extent, op->kind, else_body,
-                  op->thread_binding, op->annotations, op->step);
+                  op->thread_binding, op->annotations, op->step, op->span);
 
-    result = IfThenElse(if_node->condition, then_loop, else_loop);
+    result =
+        IfThenElse(if_node->condition, then_loop, else_loop, if_node->span);
 
     // Wrap with hoisted Let bindings (in reverse order so first binding is
     // outermost)
     for (auto it = finder.hoisted_let_bindings.rbegin();
          it != finder.hoisted_let_bindings.rend(); ++it) {
-      result = SeqStmt({tirx::Bind(it->first, it->second), result});
+      result = SeqStmt({tirx::Bind(it->first, it->second), result}, op->span);
     }
 
     if (pushed_thread_idx) {

--- a/src/transform/lower_tile_op.cc
+++ b/src/transform/lower_tile_op.cc
@@ -23,6 +23,7 @@
 #include "../op/gemm_sp.h"
 #include "../op/operator.h"
 #include "../op/utils.h"
+#include "../span_utils.h"
 #include "cuda/op/builtin.h"
 #include "cuda/target_utils.h"
 #include "cuda/transform/ptx_async_copy_injector.h"
@@ -85,7 +86,7 @@ static Buffer makeBufferWithLayout(const Buffer &buffer, const Layout &layout,
   }
   return Buffer(new_var, buffer->dtype, output_shape, {}, buffer->elem_offset,
                 buffer->name, buffer->data_alignment, buffer->offset_factor,
-                buffer->buffer_type);
+                buffer->buffer_type, {}, buffer->span);
 }
 
 // The function `makeBufferWithLayout` creates a new Buffer object based on the
@@ -949,13 +950,16 @@ private:
       auto new_indices = layout_map_[buffer]->Forward(load->indices);
       auto new_buffer = buffer_remap_[load->buffer];
       layout_remap_.Set(new_buffer, layout_map_[load->buffer]);
-      return BufferLoad(new_buffer, new_indices);
+      return BufferLoad(new_buffer, new_indices, /*predicate=*/std::nullopt,
+                        load->span);
     } else if (var_remap_.count(buffer->data)) {
-      auto new_buffer = Buffer(
-          var_remap_[buffer->data], buffer->dtype, buffer->shape,
-          buffer->strides, buffer->elem_offset, buffer->name,
-          buffer->data_alignment, buffer->offset_factor, buffer->buffer_type);
-      return BufferLoad(new_buffer, load->indices);
+      auto new_buffer =
+          Buffer(var_remap_[buffer->data], buffer->dtype, buffer->shape,
+                 buffer->strides, buffer->elem_offset, buffer->name,
+                 buffer->data_alignment, buffer->offset_factor,
+                 buffer->buffer_type, {}, buffer->span);
+      return BufferLoad(new_buffer, load->indices, /*predicate=*/std::nullopt,
+                        load->span);
     }
     return load;
   }
@@ -967,13 +971,16 @@ private:
       auto new_indices = layout_map_[buffer]->Forward(store->indices);
       auto new_buffer = buffer_remap_[store->buffer];
       layout_remap_.Set(new_buffer, layout_map_[store->buffer]);
-      return BufferStore(new_buffer, store->value, new_indices);
+      return BufferStore(new_buffer, store->value, new_indices,
+                         /*predicate=*/std::nullopt, store->span);
     } else if (var_remap_.count(buffer->data)) {
-      auto new_buffer = Buffer(
-          var_remap_[buffer->data], buffer->dtype, buffer->shape,
-          buffer->strides, buffer->elem_offset, buffer->name,
-          buffer->data_alignment, buffer->offset_factor, buffer->buffer_type);
-      return BufferStore(new_buffer, store->value, store->indices);
+      auto new_buffer =
+          Buffer(var_remap_[buffer->data], buffer->dtype, buffer->shape,
+                 buffer->strides, buffer->elem_offset, buffer->name,
+                 buffer->data_alignment, buffer->offset_factor,
+                 buffer->buffer_type, {}, buffer->span);
+      return BufferStore(new_buffer, store->value, store->indices,
+                         /*predicate=*/std::nullopt, store->span);
     }
     return store;
   }
@@ -1053,7 +1060,8 @@ private:
       }
       Buffer new_buf(new_var, buffer->dtype, buffer->shape, buffer->strides,
                      buffer->elem_offset, buffer->name, buffer->data_alignment,
-                     buffer->offset_factor, buffer->buffer_type);
+                     buffer->offset_factor, buffer->buffer_type, {},
+                     buffer->span);
       buffer_remap_.Set(buffer, new_buf);
       auto node = Downcast<AllocBuffer>(IRMutatorWithAnalyzer::VisitStmt_(op));
       node.CopyOnWrite()->buffer = new_buf;
@@ -1141,6 +1149,9 @@ private:
     lower_args.require_smem_alignment = require_smem_alignment_callback;
 
     auto lowered = tile_op->Lower(lower_args, analyzer_);
+    // Let the whole lowered subtree inherit the source location of the tile
+    // op statement, keeping any finer-grained spans already present.
+    StampSubtreeSpans(lowered, op->span);
 
     return IRMutatorWithAnalyzer::VisitStmt(lowered);
   }
@@ -1422,6 +1433,8 @@ private:
         lowered = inject_result.stmt;
       }
     }
+    // Stamp after PTX async-copy injection so injected nodes are covered too.
+    StampSubtreeSpans(lowered, op->span);
     return lowered;
   }
 

--- a/src/transform/materialize_kernel_launch.cc
+++ b/src/transform/materialize_kernel_launch.cc
@@ -83,7 +83,7 @@ private:
       IterVar iter_var(Range::FromMinExtent(op->min, op->extent), op->loop_var,
                        IterVarType::kThreadIndex, tag);
       return AttrStmt(std::move(iter_var), tirx::attr::thread_extent,
-                      op->extent, std::move(body));
+                      op->extent, std::move(body), op->span);
     }
     // No SIMT: grid dims run as plain serial loops; thread dims are ignored
     // (a unit loop keeps the loop variable defined and pinned to 0).
@@ -92,7 +92,8 @@ private:
                           : op->extent;
     return For(op->loop_var, op->min, std::move(extent), ForKind::kSerial,
                std::move(body),
-               /*thread_binding=*/std::nullopt, op->annotations, op->step);
+               /*thread_binding=*/std::nullopt, op->annotations, op->step,
+               op->span);
   }
 
   bool lower_thread_binding_;

--- a/src/transform/merge_if_stmt.cc
+++ b/src/transform/merge_if_stmt.cc
@@ -59,6 +59,7 @@ private:
     // condition.
     Array<Stmt> new_seq;
     PrimExpr current_condition;
+    Span current_span;
     Array<Stmt> current_if_bodies;
 
     for (const Stmt &stmt : flat_seq) {
@@ -76,12 +77,13 @@ private:
                              current_if_bodies.size() == 1
                                  ? current_if_bodies[0]
                                  : this->VisitStmt(SeqStmt(current_if_bodies)),
-                             Stmt());
+                             Stmt(), current_span);
               new_seq.push_back(if_stmt);
               current_if_bodies.clear();
             }
 
             current_condition = if_node->condition;
+            current_span = if_node->span;
             current_if_bodies.push_back(if_node->then_case);
             continue;
           }
@@ -94,7 +96,7 @@ private:
                        current_if_bodies.size() == 1
                            ? current_if_bodies[0]
                            : this->VisitStmt(SeqStmt(current_if_bodies)),
-                       Stmt());
+                       Stmt(), current_span);
         new_seq.push_back(if_stmt);
         current_condition = PrimExpr();
         current_if_bodies.clear();
@@ -109,11 +111,11 @@ private:
                      current_if_bodies.size() == 1
                          ? current_if_bodies[0]
                          : this->VisitStmt(SeqStmt(current_if_bodies)),
-                     Stmt());
+                     Stmt(), current_span);
       new_seq.push_back(if_stmt);
     }
 
-    return new_seq.size() == 1 ? new_seq[0] : SeqStmt(new_seq);
+    return new_seq.size() == 1 ? new_seq[0] : SeqStmt(new_seq, op->span);
   }
 };
 

--- a/testing/python/transform/test_tilelang_transform_span_preservation.py
+++ b/testing/python/transform/test_tilelang_transform_span_preservation.py
@@ -1,0 +1,192 @@
+"""Tests that source spans survive the lowering pass chain.
+
+Span injection is validated by test_tilelang_language_span.py on freshly
+parsed IR. These tests cover the other half of the pipeline: lowering passes
+must not drop spans (StmtMutator copy-on-write preserves them; only explicit
+node reconstruction can lose them), so that codegen-time source mapping
+(`#line` emission) has something to work with.
+"""
+
+import pytest
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+from tilelang.ir import get_stmt_span, span_to_location
+from tvm.ir.instrument import pass_instrument
+from tvm.tirx.stmt_functor import post_order_visit
+
+
+def _count_spans(mod) -> tuple[int, int]:
+    """Return (stmts_with_span, total_stmts) over all PrimFuncs in the module."""
+    with_span = 0
+    total = 0
+    for _, func in mod.functions.items():
+        if not isinstance(func, tvm.tirx.PrimFunc):
+            continue
+
+        def visit(node):
+            nonlocal with_span, total
+            if isinstance(node, tvm.tirx.Stmt):
+                total += 1
+                if get_stmt_span(node) is not None:
+                    with_span += 1
+
+        post_order_visit(func.body, visit)
+    return with_span, total
+
+
+@pass_instrument
+class _SpanCoverageRecorder:
+    """Records (pass_name, with_span, total) after every pass."""
+
+    def __init__(self):
+        self.rows: list[tuple[str, int, int]] = []
+
+    def run_after_pass(self, mod, info):
+        self.rows.append((info.name, *_count_spans(mod)))
+
+
+def _marker_line(marker: str) -> int:
+    with open(__file__) as f:
+        for i, line in enumerate(f, 1):
+            if marker in line:
+                return i
+    raise ValueError(f"marker not found: {marker}")
+
+
+def _make_vector_add():
+    @T.prim_func
+    def main(A: T.Tensor((1024,), "float32"), B: T.Tensor((1024,), "float32")):
+        with T.Kernel(1024):
+            tid = T.get_thread_binding()
+            B[tid] = A[tid] + 1.0  # span_marker_vadd_store
+
+    return main
+
+
+def _make_gemm():
+    M = N = K = 128
+    block_M = block_N = block_K = 32
+
+    @T.prim_func
+    def main(
+        A: T.Tensor((M, K), "float16"),
+        B: T.Tensor((K, N), "float16"),
+        C: T.Tensor((M, N), "float32"),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=128) as (bx, by):
+            A_shared = T.alloc_shared((block_M, block_K), "float16", scope="shared")
+            B_shared = T.alloc_shared((block_K, block_N), "float16", scope="shared")
+            C_local = T.alloc_shared((block_M, block_N), "float32", scope="shared")
+            T.clear(C_local)  # span_marker_clear
+            for ko in T.Pipelined(T.ceildiv(K, block_K), num_stages=0):
+                T.copy(A[by * block_M, ko * block_K], A_shared)  # span_marker_copy_a
+                T.copy(B[ko * block_K, bx * block_N], B_shared)  # span_marker_copy_b
+                T.gemm(A_shared, B_shared, C_local)  # span_marker_gemm
+            T.copy(C_local, C[by * block_M, bx * block_N])  # span_marker_copy_out
+
+    return main
+
+
+def _lower_with_recorder(func, target: str) -> _SpanCoverageRecorder:
+    recorder = _SpanCoverageRecorder()
+    with tvm.target.Target(target), tvm.transform.PassContext(opt_level=3, instruments=[recorder]):
+        tilelang.lower(func, target=target)
+    return recorder
+
+
+# Passes whose span propagation was fixed; they must never drop a span
+# (statement *deletion* is fine — it also reduces the total).
+_SPAN_SAFE_PASSES = {
+    "tl.MaterializeKernelLaunch",
+    "tl.AddWrapperForSingleBufStore",
+    "tl.IfStmtBinding",
+    "tl.InjectSoftwarePipeline",
+    "tl.LowerTileOp",
+    "tl.DecoupleTypeCast",
+    "tl.LegalizeSafeMemoryAccess",
+    "tl.LoopUnswitching",
+    "tl.MergeIfStmt",
+}
+
+
+def _assert_no_span_loss(recorder: _SpanCoverageRecorder):
+    prev_w = None
+    for name, w, _t in recorder.rows:
+        if prev_w is not None and name in _SPAN_SAFE_PASSES:
+            assert w >= prev_w, f"pass {name} dropped spans: {prev_w} -> {w}"
+        prev_w = w
+
+
+def test_span_survives_lowering_cpu():
+    """Vector add on the CPU backend: fixed passes must not drop spans."""
+    func = _make_vector_add()
+    store_line = _marker_line("span_marker_vadd_store")
+
+    recorder = _lower_with_recorder(func, target="c")
+    assert recorder.rows, "no passes recorded"
+    _assert_no_span_loss(recorder)
+
+    # The final IR still contains a BufferStore pointing at the user store line.
+    # (Checked on the last pipeline row's module indirectly: re-lower and walk.)
+    with tvm.target.Target("c"):
+        artifact = tilelang.lower(_make_vector_add(), target="c")
+
+    found = False
+
+    def visit(node):
+        nonlocal found
+        if isinstance(node, tvm.tirx.BufferStore):
+            loc = span_to_location(get_stmt_span(node))
+            if loc is not None and loc[0] == __file__ and loc[1] == store_line:
+                found = True
+
+    for mod in (artifact.device_mod, artifact.host_mod):
+        if mod is not None:
+            for _, f in mod.functions.items():
+                if isinstance(f, tvm.tirx.PrimFunc):
+                    post_order_visit(f.body, visit)
+    assert found, "lowered IR lost the span of the user's BufferStore line"
+
+
+def test_span_survives_lowering_gemm_metal():
+    """GEMM on Metal: tile-op lowering must stamp the expanded subtree."""
+    pytest.importorskip("tilelang.metal")
+    copy_a_line = _marker_line("span_marker_copy_a")
+    copy_out_line = _marker_line("span_marker_copy_out")
+    clear_line = _marker_line("span_marker_clear")
+
+    recorder = _lower_with_recorder(_make_gemm(), target="metal")
+    _assert_no_span_loss(recorder)
+
+    with tvm.target.Target("metal"):
+        artifact = tilelang.lower(_make_gemm(), target="metal")
+
+    lines = set()
+
+    def visit(node):
+        if isinstance(node, tvm.tirx.Stmt):
+            loc = span_to_location(get_stmt_span(node))
+            if loc is not None and loc[0] == __file__:
+                lines.add(loc[1])
+
+    for mod in (artifact.device_mod, artifact.host_mod):
+        if mod is not None:
+            for _, f in mod.functions.items():
+                if isinstance(f, tvm.tirx.PrimFunc):
+                    post_order_visit(f.body, visit)
+
+    # The copy/clear user statements are lowered into loops; their source lines
+    # must still be present somewhere in the lowered IR.
+    # NOTE: T.gemm on Metal is expanded by a Python macro, so its leaves carry
+    # library-definition lines (eager-builder macro policy) rather than the
+    # user call-site line — that is intentional and asserted by the language
+    # span tests, so the gemm line itself is not checked here.
+    assert copy_a_line in lines, "T.copy(A) line lost during lowering"
+    assert copy_out_line in lines, "T.copy(C) line lost during lowering"
+    assert clear_line in lines, "T.clear line lost during lowering"
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/tilelang/ir.py
+++ b/tilelang/ir.py
@@ -120,6 +120,19 @@ def set_prim_func_span(func, span: Span) -> None:
     _span_ffi("SetPrimFuncSpan")(func, span)
 
 
+def stamp_stmt_spans(stmt, span: Span | None) -> None:
+    """Fill in `span` on every Stmt in the subtree whose span is undefined.
+
+    Nodes that already carry a span are left untouched. Intended for passes
+    that rebuild a user statement into a fresh subtree: stamping the result
+    with the original statement's span keeps source-line information alive
+    through lowering.
+    """
+    if span is None:
+        return
+    _span_ffi("StampSubtreeSpans")(stmt, span)
+
+
 def get_prim_func_span(func) -> Span | None:
     span = _span_ffi("GetPrimFuncSpan")(func)
     return span if span is not None and span.source_name is not None else None

--- a/tilelang/transform/add_bufstore_wrapper.py
+++ b/tilelang/transform/add_bufstore_wrapper.py
@@ -2,6 +2,8 @@ from tvm.tirx import BufferStore, For, AttrStmt, ForKind, Var, PrimFunc, BufferL
 from tvm.tirx.stmt_functor import ir_transform, post_order_visit
 from tvm.tirx.transform import prim_func_pass
 
+from tilelang.ir import get_stmt_span, stamp_stmt_spans
+
 
 def AddWrapperForSingleBufStore():
     """
@@ -143,7 +145,10 @@ def AddWrapperForSingleBufStore():
                                 )
 
                     # Wrap fragment[0] access with T.Parallel loop
-                    return For(Var("_", "int32"), 0, 1, ForKind.PARALLEL, statement)
+                    new_loop = For(Var("_", "int32"), 0, 1, ForKind.PARALLEL, statement)
+                    # The wrapper loop inherits the wrapped statement's source span.
+                    stamp_stmt_spans(new_loop, get_stmt_span(statement))
+                    return new_loop
 
             return statement
 

--- a/tilelang/transform/decouple_type_cast.py
+++ b/tilelang/transform/decouple_type_cast.py
@@ -75,6 +75,7 @@ from tvm.tirx.transform import prim_func_pass
 # Cache the Op for if_then_else to avoid repeated lookups
 _IF_THEN_ELSE_OP = Op.get("tirx.if_then_else")
 
+from tilelang.ir import get_stmt_span, stamp_stmt_spans
 from tilelang.utils.language import (
     is_fragment,
     is_global,
@@ -251,7 +252,9 @@ def _normalize_flat_binds(stmt: Stmt, env: BindEnv) -> Stmt | None:
                 result.append(normalized)
         if not result:
             return None
-        return SeqStmt(result) if len(result) > 1 else result[0]
+        normalized = SeqStmt(result) if len(result) > 1 else result[0]
+        stamp_stmt_spans(normalized, get_stmt_span(stmt))
+        return normalized
 
     if isinstance(stmt, IfThenElse):
         condition = _substitute_bind_env(stmt.condition, env)
@@ -260,15 +263,17 @@ def _normalize_flat_binds(stmt: Stmt, env: BindEnv) -> Stmt | None:
         normalized_else = None
         if stmt.else_case:
             normalized_else = else_case if else_case is not None else Evaluate(0)
-        return IfThenElse(
+        normalized_if = IfThenElse(
             condition,
             then_case if then_case is not None else Evaluate(0),
             normalized_else,
         )
+        stamp_stmt_spans(normalized_if, get_stmt_span(stmt))
+        return normalized_if
 
     if isinstance(stmt, For):
         body = _normalize_flat_binds(stmt.body, dict(env))
-        return For(
+        new_for = For(
             stmt.loop_var,
             _substitute_bind_env(stmt.min, env),
             _substitute_bind_env(stmt.extent, env),
@@ -278,8 +283,13 @@ def _normalize_flat_binds(stmt: Stmt, env: BindEnv) -> Stmt | None:
             stmt.annotations,
             _substitute_bind_env(stmt.step, env),
         )
+        stamp_stmt_spans(new_for, get_stmt_span(stmt))
+        return new_for
 
-    return _substitute_bind_env(stmt, env)
+    result = _substitute_bind_env(stmt, env)
+    # `substitute` rebuilds any node referencing a bind var, dropping its span.
+    stamp_stmt_spans(result, get_stmt_span(stmt))
+    return result
 
 
 def normalize_flat_binds(stmt: Stmt) -> Stmt:
@@ -359,7 +369,7 @@ class DecoupleTypeCastMutator(tirx.PyStmtExprMutator):
 
     def _make_for(self, original: For, new_body: Stmt) -> For:
         """Create a new For node with updated body, preserving other attributes."""
-        return For(
+        new_for = For(
             original.loop_var,
             original.min,
             original.extent,
@@ -369,6 +379,8 @@ class DecoupleTypeCastMutator(tirx.PyStmtExprMutator):
             original.annotations,
             original.step,
         )
+        stamp_stmt_spans(new_for, get_stmt_span(original))
+        return new_for
 
     # ----- entry point for each For loop -----
 
@@ -469,6 +481,10 @@ class DecoupleTypeCastMutator(tirx.PyStmtExprMutator):
         # Wrap with buffer declarations and allocations
         result = self._wrap_with_allocations(result, store_entries + load_entries)
 
+        # The replacement subtree inherits the original loop's span. Nodes
+        # already stamped above (compute loop, normalized body) keep their own
+        # spans; the staging copies and the alloc-scope wrapper get stamped too.
+        stamp_stmt_spans(result, get_stmt_span(op))
         return result
 
     # ----- helpers -----
@@ -498,7 +514,7 @@ class DecoupleTypeCastMutator(tirx.PyStmtExprMutator):
 
     def _make_vectorized_loop(self, original: For, body: Stmt) -> For:
         """Create a vectorized For loop based on the original."""
-        return For(
+        new_for = For(
             original.loop_var,
             original.min,
             original.extent,
@@ -508,6 +524,8 @@ class DecoupleTypeCastMutator(tirx.PyStmtExprMutator):
             original.annotations,
             original.step,
         )
+        stamp_stmt_spans(new_for, get_stmt_span(original))
+        return new_for
 
     def _create_copy_loops(
         self,

--- a/tilelang/transform/hoist_broadcast_values.py
+++ b/tilelang/transform/hoist_broadcast_values.py
@@ -10,6 +10,8 @@ from tvm.tirx import (
 from tvm.tirx.stmt import Bind
 from tvm.tirx.transform import prim_func_pass
 
+from tilelang.ir import get_stmt_span, stamp_stmt_spans
+
 
 @tirx.functor.mutator
 class HoistBroadcastValuesMutator(PyStmtExprMutator):
@@ -44,6 +46,7 @@ class HoistBroadcastValuesMutator(PyStmtExprMutator):
         self.hoist_enabled = saved_hoist_enabled
         self.pending_defs = saved_pending_defs
 
+        stamp_stmt_spans(new_stmt, get_stmt_span(op))
         return new_stmt
 
     def visit_bind_(self, op: Bind):
@@ -65,6 +68,7 @@ class HoistBroadcastValuesMutator(PyStmtExprMutator):
         self.hoist_enabled = saved_hoist_enabled
         self.pending_defs = saved_pending_defs
 
+        stamp_stmt_spans(new_stmt, get_stmt_span(op))
         return new_stmt
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Preserves source spans across C++ and Python TileLang lowering passes.

- Adds `StampSubtreeSpans` in C++ and `stamp_stmt_spans` in Python.
- Propagates spans through loop, sequence, conditional, pipeline, buffer, tile-operation, kernel-launch, and broadcast transformations.
- Preserves spans on generated nodes and fills only undefined statement spans.
- Adds tests for span preservation across vector-add and GEMM lowering on CPU and Metal targets.

## C++ style / lint notes

The PR changes C++ code but does not modify the documented rules in `docs/developer_guide/cpp_style.md`. The “C++ API Style Audit (warning only)” CI step is relevant. Any TLCPP003/TLCPP004 findings are advisory unless they identify a new API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->