### PR TITLE
[Metal] Add reduction and infinity lowering

### DIFF
--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -630,6 +630,248 @@ inline PrimExpr MakeUpdate(const ReduceOpNode &op, PrimExpr dst_val,
   return PrimExpr();
 }
 
+// Shared fragment-reduce lowering helpers. These are the common building
+// blocks used by both the generic ReduceLowerer (CUDA/ROCm) and the Metal
+// backend's single-simdgroup butterfly lowering. Keeping them here prevents
+// the Metal implementation from copying Phase-1/Phase-3 and layout/plan
+// construction from the generic path.
+
+struct FragmentReduceContext {
+  Buffer src_buffer;
+  Buffer dst_buffer;
+  Fragment src_layout;
+  Fragment dst_layout;
+  Fragment red_layout;
+  int src_dim = 0;
+  int dst_dim = 0;
+  bool is_1d_reduce = false;
+  Array<IterVar> dst_vars;
+  Array<IterVar> src_vars;
+  Array<PrimExpr> src_indices;
+  Array<PrimExpr> dst_indices;
+  Array<PrimExpr> red_indices;
+  PrimExpr src_thread;
+  ReduceOwnershipPlan reduce_plan;
+};
+
+inline FragmentReduceContext MakeFragmentReduceContext(
+    const ReduceOpNode &op, const Buffer &src_buffer, const Buffer &dst_buffer,
+    const Fragment &src_layout, const Fragment &dst_layout,
+    arith::Analyzer *analyzer) {
+  FragmentReduceContext ctx;
+  ctx.src_buffer = src_buffer;
+  ctx.dst_buffer = dst_buffer;
+  ctx.src_layout = src_layout;
+  ctx.dst_layout = dst_layout;
+  ctx.red_layout = ComputeReducerLayout(src_layout, op.dim);
+  ctx.src_dim = src_layout->InputDim();
+  ctx.dst_dim = dst_layout->InputDim();
+
+  ctx.is_1d_reduce = ctx.src_dim == ctx.dst_dim && ctx.dst_dim == 1;
+
+  if (ctx.is_1d_reduce) {
+    ICHECK(is_one(dst_layout->OutputShape().back()))
+        << "Reduce for scalar not implemented.";
+  } else {
+    ICHECK_EQ(ctx.src_dim, ctx.dst_dim + 1) << "Reduce dimension mismatch.";
+  }
+
+  for (size_t i = 0; i < ctx.dst_dim; ++i) {
+    Var var = Var(std::string{char('i' + i)});
+    ctx.dst_vars.push_back(IterVar(Range(0, dst_layout->InputShape()[i]), var,
+                                   IterVarType::kDataPar));
+  }
+
+  if (!ctx.is_1d_reduce) {
+    ctx.src_vars = ctx.dst_vars;
+  }
+  Range reduce_dom(0, src_layout->InputShape()[op.dim]);
+  IterVar reduce_iv(reduce_dom, Var("rv"), IterVarType::kDataPar);
+  ctx.src_vars.insert(ctx.src_vars.begin() + op.dim, reduce_iv);
+
+  ctx.src_indices = src_layout->Forward(
+      ctx.src_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }));
+  ctx.dst_indices = dst_layout->Forward(
+      ctx.dst_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }));
+  ctx.red_indices = ctx.red_layout->Forward(
+      ctx.dst_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }));
+  ctx.src_thread = src_layout->ForwardThread(
+      ctx.src_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }), {});
+
+  ctx.reduce_plan = MakeReduceOwnershipPlan(
+      ctx.src_indices, ctx.src_thread, ctx.src_vars, ctx.src_vars[op.dim]->var,
+      analyzer);
+
+  return ctx;
+}
+
+struct ReduceBufferPlan {
+  bool require_init = false;
+  bool need_duplicate = false;
+  bool need_update = false;
+  Buffer clear_buffer;
+};
+
+inline ReduceBufferPlan MakeReduceBufferPlan(const ReduceOpNode &op,
+                                             const Buffer &dst_buffer,
+                                             const Fragment &dst_layout,
+                                             const Fragment &red_layout,
+                                             arith::Analyzer *analyzer) {
+  ReduceBufferPlan plan;
+  plan.require_init = op.clear;
+  if (op.type->IsSum() || op.type->IsAbsSum() || op.type->IsBitAnd() ||
+      op.type->IsBitOr() || op.type->IsBitXor()) {
+    plan.require_init = true;
+  }
+
+  plan.clear_buffer = dst_buffer;
+  if ((op.type->IsSum() || op.type->IsAbsSum()) && !op.clear) {
+    plan.need_duplicate = true;
+    plan.need_update = true;
+  } else if (op.type->IsBitAnd() && !op.clear) {
+    plan.need_duplicate = true;
+    plan.need_update = true;
+  } else if ((op.type->IsBitOr() || op.type->IsBitXor()) && !op.clear) {
+    plan.need_duplicate = true;
+    plan.need_update = true;
+  } else if ((op.type->IsMax() || op.type->IsMin() ||
+              op.type->IsAbsMax()) &&
+             !op.clear) {
+    plan.need_duplicate = true;
+    plan.need_update = true;
+  }
+
+  if (!analyzer->CanProve(dst_layout->ReplicateExtent() ==
+                          red_layout->ReplicateExtent())) {
+    plan.need_duplicate = true;
+  }
+  ICHECK(!analyzer->CanProve(dst_layout->ReplicateExtent() >
+                             red_layout->ReplicateExtent()))
+      << "Inconsistent layouts between src and dst in ReduceOp: "
+      << "dst_layout=" << dst_layout << "red_layout=" << red_layout;
+
+  if (plan.need_duplicate) {
+    plan.clear_buffer =
+        decl_buffer(red_layout->OutputShape(), dst_buffer->dtype,
+                    dst_buffer->name + "_clear",
+                    GetPtrStorageScope(dst_buffer->data));
+  }
+  return plan;
+}
+
+inline Stmt MakeUnvectorizedLocalReduce(
+    const ReduceOpNode &op, const Buffer &accum_buffer, const Buffer &src_buffer,
+    const Array<PrimExpr> &src_indices, const Array<IterVar> &src_vars,
+    const Array<PrimExpr> &red_indices, const PrimExpr &init_value,
+    bool require_init, bool need_duplicate, int src_output_dim) {
+  Array<Stmt> stmts;
+  if (require_init ||
+      (need_duplicate &&
+       (op.type->IsMax() || op.type->IsMin() || op.type->IsAbsMax()))) {
+    stmts.push_back(BufferStore(accum_buffer, init_value, red_indices));
+  }
+
+  Stmt reduce_local =
+      BufferStore(accum_buffer,
+                  MakeReduce(op, 1, BufferLoad(accum_buffer, red_indices),
+                             BufferLoad(src_buffer, src_indices)),
+                  red_indices);
+
+  for (int i = src_output_dim - 1; i >= 0; --i) {
+    reduce_local = For(src_vars[i]->var, 0, src_vars[i]->dom->extent,
+                       ForKind::kUnrolled, reduce_local, std::nullopt);
+  }
+  stmts.push_back(reduce_local);
+  return stmts.size() > 1 ? SeqStmt(stmts) : stmts[0];
+}
+
+inline PrimExpr MakeFragmentOwnershipPredicate(
+    const Fragment &layout, const Array<PrimExpr> &indices,
+    const Array<PrimExpr> &lhs, const PrimExpr &thread_index,
+    arith::Analyzer *analyzer) {
+  PrimExpr predicate = Bool(true);
+  // The fragment inverse expects a zero-based logical thread coordinate
+  // within the destination layout's thread range, so normalize the absolute
+  // thread index against that range.
+  PrimExpr local_thread_index = thread_index;
+  if (layout->ThreadRange().defined()) {
+    local_thread_index = local_thread_index - layout->ThreadRange()->min;
+  }
+  auto th_indices = indices;
+  th_indices.push_back(local_thread_index);
+  auto inv = layout->Inverse()->Forward(th_indices);
+  inv.pop_back();
+  for (size_t i = 0; i < lhs.size(); ++i) {
+    predicate = predicate && (inv[i] == lhs[i]);
+  }
+  return analyzer->Simplify(predicate);
+}
+
+inline Stmt MakeParallelPartitionLoop(Stmt body, const Array<IterVar> &dst_vars,
+                                      const PrimExpr &thread_index,
+                                      const Range &thread_bounds,
+                                      arith::Analyzer *analyzer,
+                                      const Fragment &red_layout) {
+  for (int i = static_cast<int>(dst_vars.size()) - 1; i >= 0; --i) {
+    body = For(dst_vars[i]->var, 0, dst_vars[i]->dom->extent,
+               ForKind::kParallel, body);
+  }
+  if (!dst_vars.empty()) {
+    body = PartitionLoop(Downcast<For>(body), thread_index, analyzer,
+                         red_layout);
+    body = PragmaUnrollLoop(Downcast<For>(body));
+  } else {
+    auto guard = (thread_index == thread_bounds->min);
+    body = IfThenElse(guard, body);
+  }
+  return body;
+}
+
+inline Stmt MakeDuplicateUpdateStmt(const ReduceOpNode &op,
+                                    const Buffer &dst_buffer,
+                                    const Buffer &accum_buffer,
+                                    const Array<PrimExpr> &dst_indices,
+                                    const Array<PrimExpr> &red_indices,
+                                    bool need_update, bool cast_to_dst,
+                                    bool cast_dst_load_to_accum,
+                                    const PrimExpr &predicate,
+                                    arith::Analyzer *analyzer) {
+  PrimExpr update = BufferLoad(accum_buffer, red_indices);
+  if (need_update) {
+    PrimExpr dst_val =
+        cast_dst_load_to_accum
+            ? PrimExpr(Cast(accum_buffer->dtype,
+                            BufferLoad(dst_buffer, dst_indices)))
+            : BufferLoad(dst_buffer, dst_indices);
+    update = MakeUpdate(op, dst_val, BufferLoad(accum_buffer, red_indices));
+  }
+  if (cast_to_dst) {
+    update = Cast(dst_buffer->dtype, update);
+  }
+  Stmt store = BufferStore(dst_buffer, update, dst_indices);
+  return analyzer->CanProve(predicate) ? store : IfThenElse(predicate, store);
+}
+
+inline Stmt MakeDuplicateUpdatePhase(
+    const ReduceOpNode &op, const Buffer &dst_buffer,
+    const Buffer &accum_buffer, const Array<PrimExpr> &dst_indices,
+    const Array<PrimExpr> &red_indices, const Array<IterVar> &dst_vars,
+    const Fragment &dst_layout, bool need_update, bool cast_to_dst,
+    bool cast_dst_load_to_accum, const PrimExpr &thread_index,
+    const Range &thread_bounds, arith::Analyzer *analyzer,
+    const Fragment &red_layout) {
+  PrimExpr predicate = MakeFragmentOwnershipPredicate(
+      dst_layout, dst_indices,
+      dst_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }),
+      thread_index, analyzer);
+  Stmt store = MakeDuplicateUpdateStmt(op, dst_buffer, accum_buffer, dst_indices,
+                                       red_indices, need_update, cast_to_dst,
+                                       cast_dst_load_to_accum, predicate,
+                                       analyzer);
+  return MakeParallelPartitionLoop(store, dst_vars, thread_index, thread_bounds,
+                                   analyzer, red_layout);
+}
+
 } // namespace reduce
 
 template <typename Impl> struct ReduceLowerer {
@@ -764,87 +1006,23 @@ template <typename Impl> struct ReduceLowerer {
       auto dst_buffer = get_buffer(op.dst);
       auto src_layout = lower_args.layout_map[op.src].as<Fragment>().value();
       auto dst_layout = lower_args.layout_map[op.dst].as<Fragment>().value();
-      auto red_layout = reduce::ComputeReducerLayout(src_layout, op.dim);
-      auto src_dim = src_layout->InputDim();
-      auto dst_dim = dst_layout->InputDim();
-
-      auto is_1d_reduce = src_dim == dst_dim && dst_dim == 1;
-
-      if (is_1d_reduce) {
-        ICHECK(is_one(dst_layout->OutputShape().back()))
-            << "Reduce for scalar not implemented.";
-      } else {
-        ICHECK_EQ(src_dim, dst_dim + 1) << "Reduce dimension mismatch.";
-      }
-
-      Array<IterVar> dst_vars;
-      for (size_t i = 0; i < dst_dim; ++i) {
-        Var var = Var(std::string{char('i' + i)});
-        dst_vars.push_back(IterVar(Range(0, dst_layout->InputShape()[i]), var,
-                                   IterVarType::kDataPar));
-      }
-
-      Array<IterVar> src_vars;
-      if (!is_1d_reduce) {
-        src_vars = dst_vars;
-      }
-      Range reduce_dom(0, src_layout->InputShape()[op.dim]);
-      IterVar reduce_iv(reduce_dom, Var("rv"), IterVarType::kDataPar);
-      src_vars.insert(src_vars.begin() + op.dim, reduce_iv);
-
-      auto src_indices = src_layout->Forward(
-          src_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }));
-      auto dst_indices = dst_layout->Forward(
-          dst_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }));
-      auto red_indices = red_layout->Forward(
-          dst_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }));
-      auto src_thread = src_layout->ForwardThread(
-          src_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }), {});
-
-      auto reduce_plan = reduce::MakeReduceOwnershipPlan(
-          src_indices, src_thread, src_vars, src_vars[op.dim]->var, analyzer);
+      auto ctx = reduce::MakeFragmentReduceContext(
+          op, src_buffer, dst_buffer, src_layout, dst_layout, analyzer);
+      auto red_layout = ctx.red_layout;
+      auto dst_dim = ctx.dst_dim;
+      auto &dst_vars = ctx.dst_vars;
+      auto &dst_indices = ctx.dst_indices;
+      auto &red_indices = ctx.red_indices;
+      auto &reduce_plan = ctx.reduce_plan;
 
       Array<Stmt> stmts;
 
-      auto require_init = op.clear;
-      if (op.type->IsSum() || op.type->IsAbsSum() || op.type->IsBitAnd() ||
-          op.type->IsBitOr() || op.type->IsBitXor()) {
-        require_init = true;
-      }
-
-      auto clear_buffer = dst_buffer;
-      auto need_duplicate = false;
-      auto need_update = false;
-      if ((op.type->IsSum() || op.type->IsAbsSum()) && !op.clear) {
-        need_duplicate = true;
-        need_update = true;
-      } else if (op.type->IsBitAnd() && !op.clear) {
-        need_duplicate = true;
-        need_update = true;
-      } else if ((op.type->IsBitOr() || op.type->IsBitXor()) && !op.clear) {
-        need_duplicate = true;
-        need_update = true;
-      } else if ((op.type->IsMax() || op.type->IsMin() ||
-                  op.type->IsAbsMax()) &&
-                 !op.clear) {
-        need_duplicate = true;
-        need_update = true;
-      }
-
-      if (!analyzer->CanProve(dst_layout->ReplicateExtent() ==
-                              red_layout->ReplicateExtent())) {
-        need_duplicate = true;
-      }
-      ICHECK(!analyzer->CanProve(dst_layout->ReplicateExtent() >
-                                 red_layout->ReplicateExtent()))
-          << "Inconsistent layouts between src and dst in ReduceOp: "
-          << "dst_layout=" << dst_layout << "red_layout=" << red_layout;
-
-      if (need_duplicate) {
-        clear_buffer = decl_buffer(red_layout->OutputShape(), dst_buffer->dtype,
-                                   dst_buffer->name + "_clear",
-                                   GetPtrStorageScope(dst_buffer->data));
-      }
+      auto plan = reduce::MakeReduceBufferPlan(op, dst_buffer, dst_layout,
+                                               red_layout, analyzer);
+      auto require_init = plan.require_init;
+      auto clear_buffer = plan.clear_buffer;
+      auto need_duplicate = plan.need_duplicate;
+      auto need_update = plan.need_update;
 
       Array<PrimExpr> src_indice_compressed = reduce_plan.local_src_indices;
       Array<IterVar> src_var_compressed = reduce_plan.local_reduce_vars;
@@ -932,26 +1110,10 @@ template <typename Impl> struct ReduceLowerer {
       }
 
       if (!can_pack) {
-        if (require_init ||
-            (need_duplicate &&
-             (op.type->IsMax() || op.type->IsMin() || op.type->IsAbsMax()))) {
-          stmts.push_back(BufferStore(clear_buffer, reduce::MakeInitValue(op),
-                                      red_indices));
-        }
-
-        Stmt reduce_local = BufferStore(
-            clear_buffer,
-            reduce::MakeReduce(op, 1, BufferLoad(clear_buffer, red_indices),
-                               BufferLoad(src_buffer, src_indice_compressed)),
-            red_indices);
-
-        for (int i = static_cast<int>(src_layout->OutputDim()) - 1; i >= 0;
-             --i) {
-          reduce_local = For(src_var_compressed[i]->var, 0,
-                             src_var_compressed[i]->dom->extent,
-                             ForKind::kUnrolled, reduce_local, std::nullopt);
-        }
-        stmts.push_back(reduce_local);
+        stmts.push_back(reduce::MakeUnvectorizedLocalReduce(
+            op, clear_buffer, src_buffer, src_indice_compressed,
+            src_var_compressed, red_indices, reduce::MakeInitValue(op),
+            require_init, need_duplicate, src_layout->OutputDim()));
       }
 
       const int batch = op.batch;
@@ -1229,53 +1391,21 @@ template <typename Impl> struct ReduceLowerer {
         stmts.push_back(BufferStore(clear_buffer, call, red_indices));
       }
 
-      PrimExpr predicate = Bool(true);
-      {
-        // The fragment inverse expects a zero-based logical thread coordinate
-        // within the destination layout's thread range, so normalize the
-        // absolute thread index against that range.
-        PrimExpr local_thread_index = lower_args.thread_index;
-        if (dst_layout->ThreadRange().defined()) {
-          local_thread_index =
-              local_thread_index - dst_layout->ThreadRange()->min;
-        }
-        auto dst_th_indices = dst_indices;
-        dst_th_indices.push_back(local_thread_index);
-        auto inv = dst_layout->Inverse()->Forward(dst_th_indices);
-        inv.pop_back();
-        for (int i = 0; i < static_cast<int>(dst_layout->InputDim()); i++) {
-          predicate = predicate && (inv[i] == dst_vars[i]->var);
-        }
-        predicate = analyzer->Simplify(predicate);
-      }
+      PrimExpr predicate = reduce::MakeFragmentOwnershipPredicate(
+          dst_layout, dst_indices,
+          dst_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }),
+          lower_args.thread_index, analyzer);
       if (need_duplicate) {
-        PrimExpr update =
-            need_update
-                ? reduce::MakeUpdate(op, BufferLoad(dst_buffer, dst_indices),
-                                     BufferLoad(clear_buffer, red_indices))
-                : BufferLoad(clear_buffer, red_indices);
-        auto store = BufferStore(dst_buffer, update, dst_indices);
-        if (analyzer->CanProve(predicate)) {
-          stmts.push_back(store);
-        } else {
-          stmts.push_back(IfThenElse(predicate, store));
-        }
+        stmts.push_back(reduce::MakeDuplicateUpdateStmt(
+            op, dst_buffer, clear_buffer, dst_indices, red_indices, need_update,
+            /*cast_to_dst=*/false, /*cast_dst_load_to_accum=*/false, predicate,
+            analyzer));
       }
 
       auto body = stmts.size() > 1 ? SeqStmt(stmts) : stmts[0];
-      for (int i = static_cast<int>(dst_layout->InputDim()) - 1; i >= 0; --i) {
-        body = For(dst_vars[i]->var, 0, dst_vars[i]->dom->extent,
-                   ForKind::kParallel, body);
-      }
-
-      if (dst_layout->InputDim() > 0) {
-        body = PartitionLoop(Downcast<For>(body), lower_args.thread_index,
-                             analyzer, red_layout);
-        body = PragmaUnrollLoop(Downcast<For>(body));
-      } else {
-        auto guard = (lower_args.thread_index == lower_args.thread_bounds->min);
-        body = IfThenElse(guard, body);
-      }
+      body = reduce::MakeParallelPartitionLoop(
+          body, dst_vars, lower_args.thread_index, lower_args.thread_bounds,
+          analyzer, red_layout);
 
       if (need_duplicate) {
         body = SeqStmt({AllocBuffer(clear_buffer), body});

--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -1737,8 +1737,9 @@ void CodeGenTileLangMetal::VisitExpr_(const FloatImmNode *op,
     temp << std::scientific << op->value;
     if (op->dtype.bits() == 32)
       temp << 'f';
-    else if (op->dtype.bits() == 16)
+    else if (op->dtype.bits() == 16 && op->dtype.is_float16())
       temp << 'h';
+    // bf16 finite: no h suffix; the explicit cast wrapper provides the type.
   }
   if (needs_cast) {
     temp << ")";

--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -1715,6 +1715,17 @@ void CodeGenTileLangMetal::VisitExpr_(const CallNode *op,
 void CodeGenTileLangMetal::VisitExpr_(const FloatImmNode *op,
                                       std::ostream &os) { // NOLINT(*)
   std::ostringstream temp;
+  // MSL has no implicit conversion INTO bfloat from float/half, and the
+  // overloaded builtins (e.g. select(half, half, bool)) require exact
+  // operand types, so fp16/bf16 literals (finite, INFINITY or NAN) must be
+  // explicitly cast to the destination type: bare INFINITY/NAN or
+  // `h`-suffixed literals fail to compile when assigned to bfloat
+  // ("assigning to 'bfloat' from incompatible type") or make
+  // select() ambiguous for half ("call to 'select' is ambiguous").
+  const bool needs_cast = op->dtype.is_bfloat16() || op->dtype.is_float16();
+  if (needs_cast) {
+    temp << "(" << (op->dtype.is_bfloat16() ? "bfloat" : "half") << ")(";
+  }
   if (std::isinf(op->value)) {
     if (op->value < 0) {
       temp << "-";
@@ -1728,6 +1739,9 @@ void CodeGenTileLangMetal::VisitExpr_(const FloatImmNode *op,
       temp << 'f';
     else if (op->dtype.bits() == 16)
       temp << 'h';
+  }
+  if (needs_cast) {
+    temp << ")";
   }
   MarkConst(temp.str());
   os << temp.str();

--- a/src/metal/op/math.cc
+++ b/src/metal/op/math.cc
@@ -1,0 +1,34 @@
+/*!
+ * \file tl/metal/op/math.cc
+ * \brief Metal implementations for tl.* math intrinsics that need a
+ *        target-specific lowering (registered via FLowerIntrinsic).
+ *
+ * Only intrinsics whose Metal fold is safe are registered here:
+ *   - tl.infinity folds to a constant FloatImm (target-independent).
+ * Intrinsics whose CUDA fold emits a device-template extern call
+ * (tl.pow_of_int -> tl::pow_of_int<...>, round_ties_away_from_zero ->
+ * tl::RoundTiesAwayFromZero) are NOT registered until MSL template
+ * equivalents exist in the Metal codegen preamble.
+ */
+
+#include <tvm/runtime/logging.h>
+#include <tvm/tirx/expr.h>
+#include <tvm/tirx/op.h>
+#include <tvm/tirx/op_attr_types.h>
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+
+PrimExpr infinity_op(PrimExpr args);
+
+namespace {
+
+TVM_REGISTER_OP("tl.infinity")
+    .set_attr<FLowerIntrinsic>("metal.FLowerIntrinsic", infinity_op);
+
+} // namespace
+
+} // namespace tl
+} // namespace tvm

--- a/src/metal/op/reduce.cc
+++ b/src/metal/op/reduce.cc
@@ -1,0 +1,737 @@
+/*!
+ * \file tl/metal/op/reduce.cc
+ * \brief Metal implementation for tl.reduce.
+ *
+ * Strategy (correctness-first, v1):
+ *   Phase 1: per-thread local partials into the (possibly duplicated)
+ *            accumulator buffer. Identical semantics to the generic GPU
+ *            lowering.
+ *   Phase 2: lockstep single-simdgroup XOR butterfly through a threadgroup
+ *            scratch buffer. All threads execute the same barrier sequence
+ *            (MSL has no CUDA-style named barriers), so non-participating
+ *            threads contribute the reduce identity element instead of
+ *            skipping the barrier. After log2(32) exchange levels every
+ *            participating scratch slot holds the total; participants store
+ *            it back to their accumulator slots under the red-layout
+ *            participation predicate (the same partition guard the generic
+ *            lowering uses), and only the layout owners later write dst.
+ *            Phase 2 is omitted entirely when the reduce plan has no thread
+ *            step (e.g. raw extent=1): Phase-1 partials are then already
+ *            final.
+ *   Phase 3: duplicate-buffer update back into dst (guarded by fragment
+ *            ownership, same as the generic lowering).
+ *
+ * Hard domain (enforced at lowering entry): the
+ * XOR-butterfly AllReduce is only correct when every value exchange stays
+ * inside a single simdgroup. Within one butterfly level each thread reads
+ * its partner's old value while writing its own; that ordering is
+ * guaranteed by SIMD lockstep inside a simdgroup, but NOT across
+ * simdgroups, and MSL has no CUDA-style named barriers to restrict the
+ * barrier to the participating range. The threadgroup must be [0, N) with
+ * a compile-time-constant N (raw thread index addresses the scratch), and
+ * every reduce-plan thread step must satisfy nt = extent*scale a power of
+ * two with nt <= 32: the participating range [0, nt) is closed
+ * under the butterfly masks (nt/2 halving down to scale) iff nt is a
+ * power of two — each mask then flips a single lane bit below log2(nt),
+ * so no XOR partner escapes the range (a non-power-of-two nt like
+ * (8,3)=24 lets tid^12 = 28 escape even though every offset is < 32).
+ * nt <= 32 keeps the closure inside one 32-lane block (no XOR partner
+ * across a simdgroup boundary). The raw butterfly executes on ALL N
+ * threads (no tid < nt guard), so the actual execution prefix [0, N)
+ * must itself be a union of complete nt-blocks: N % nt == 0. The largest
+ * mask nt/2 partitions
+ * lanes into aligned nt-blocks, and an incomplete tail block reads
+ * partners >= N (OOB: scratch sized N) or never-written padding slots
+ * (e.g. extent=8, scale=2, nt=16, N=24: tid 16..23 ^ 8 = 24..31).
+ * Multi-simdgroup threadgroups whose steps stay inside 32-lane closures
+ * with N % nt == 0 (for example, a DeepSeek V4 Flash-style grouped
+ * reduction with threads=128, extent=32, scale=1, and offsets 16..1) are
+ * therefore allowed; cross-simdgroup exchange, non-
+ * power-of-two participating widths, or misaligned threadgroup extents
+ * are rejected with an unsupported diagnostic.
+ *
+ * bf16 destinations/accumulators accumulate in fp32 (upstream AccType
+ * design): the accumulator and the threadgroup scratch are fp32, bf16 is
+ * materialized only at the final ownership write-back. With multiple
+ * thread steps, every intermediate step round-trips through the fp32
+ * accumulator (the next step reloads the updated group totals) and only
+ * the last step casts fp32 -> bf16 into dst. Casting after every step would
+ * discard intermediate fp32 group totals. bf16 bitwise reduce is rejected
+ * because fp32 routing would change bit semantics.
+ *
+ * This avoids both call_extern (unsupported by the Metal codegen) and
+ * global-workspace plumbing (not present in the Metal runtime).
+ *
+ * v1 documented limitations (follow-ups):
+ *   - op.batch > 1 is not supported yet (LOG(FATAL)).
+ *   - vectorized (packed) local reduction is disabled (vsize = 1).
+ *   - fp16/bf16 nan_propagate reducers are not supported (no MSL __hmax_nan).
+ */
+
+#include "backend/common/op/reduce.h"
+#include "backend/common/target_utils.h"
+#include "op/utils.h"
+#include "support/check.h"
+#include <tvm/ir/cast.h>
+#include <tvm/runtime/logging.h>
+#include <tvm/tirx/builtin.h>
+#include <tvm/tirx/op.h>
+#include <tvm/tirx/op_attr_types.h>
+#include <tvm/tirx/stmt_functor.h>
+
+#include "op/parallel.h"
+#include "tir/transforms/ir_utils.h"
+#include "transform/loop_partition.h"
+
+#include <sstream>
+#include <vector>
+
+namespace tvm {
+namespace tl {
+
+using namespace tirx;
+using namespace ffi;
+
+namespace metal {
+
+struct MetalReduce : backend::ReduceLowerer<MetalReduce> {
+  static bool SupportsFp16Bf16NanReduce(Target target) { return false; }
+
+  static int GetPreferredVectorizedSize(DataType dt, Target target) {
+    return 1;
+  }
+
+  static Stmt Lower(const ReduceOpNode &op, const LowerArgs &lower_args,
+                    arith::Analyzer *analyzer) {
+    if (op.nan_propagate &&
+        (op.dst->dtype.is_float16() || op.dst->dtype.is_bfloat16())) {
+      LOG(FATAL) << "ReduceOp: nan_propagate=True for fp16/bf16 "
+                    "max/min/absmax is not supported on Metal targets "
+                    "(no __hmax_nan equivalent in MSL). Target was: "
+                 << lower_args.target->str();
+    }
+    auto get_buffer = [&](const Buffer &buffer) {
+      auto it = lower_args.buffer_remap.find(buffer);
+      return it == lower_args.buffer_remap.end() ? buffer : (*it).second;
+    };
+
+    if (IsLocalBuffer(op.src) && IsLocalBuffer(op.dst, /*allow_var*/ true)) {
+      return LowerLocal(op, get_buffer(op.src), get_buffer(op.dst), lower_args);
+    }
+
+    if (IsFragmentBuffer(op.src) && IsFragmentBuffer(op.dst)) {
+      // The XOR-butterfly AllReduce below is only correct when every
+      // value exchange stays inside a single simdgroup. Within one level
+      // each thread reads its partner's old value while writing its own;
+      // that ordering is guaranteed by SIMD lockstep inside a simdgroup, but
+      // NOT across simdgroups, and MSL has no CUDA-style named barriers to
+      // restrict the barrier to the participating range.
+      //
+      // The threadgroup must be [0, N) with compile-time-constant N (the raw
+      // thread index addresses the scratch buffer and PartitionLoop guards);
+      // the actual single-simdgroup discipline is enforced on the reduce
+      // plan after MakeReduceOwnershipPlan below. Per thread step,
+      // nt = extent*scale must be a power of two and <= 32 — the XOR-
+      // closed, single-simdgroup closure; the threadgroup extent N
+      // must additionally satisfy N % nt == 0 so the ALL-N-thread execution
+      // prefix is a union of complete nt-blocks).
+      const int64_t *tb_min = as_const_int(lower_args.thread_bounds->min);
+      const int64_t *tb_extent = as_const_int(lower_args.thread_bounds->extent);
+      if (tb_min == nullptr || tb_extent == nullptr || *tb_min != 0) {
+        LOG(FATAL) << "Metal reduce: fragment reduce requires a "
+                      "compile-time-constant threadgroup [0, N) (got "
+                      "thread_bounds = "
+                   << lower_args.thread_bounds
+                   << "); the raw thread index addresses the scratch "
+                      "buffer and the partition guards.";
+      }
+      auto src_buffer = get_buffer(op.src);
+      auto dst_buffer = get_buffer(op.dst);
+      auto src_layout = lower_args.layout_map[op.src].as<Fragment>().value();
+      auto dst_layout = lower_args.layout_map[op.dst].as<Fragment>().value();
+      auto red_layout =
+          backend::reduce::ComputeReducerLayout(src_layout, op.dim);
+      auto src_dim = src_layout->InputDim();
+      auto dst_dim = dst_layout->InputDim();
+
+      auto is_1d_reduce = src_dim == dst_dim && dst_dim == 1;
+
+      if (is_1d_reduce) {
+        ICHECK(is_one(dst_layout->OutputShape().back()))
+            << "Reduce for scalar not implemented.";
+      } else {
+        ICHECK_EQ(src_dim, dst_dim + 1) << "Reduce dimension mismatch.";
+      }
+
+      ICHECK_EQ(op.batch, 1)
+          << "Metal reduce: batch > 1 is not supported yet (op.batch="
+          << op.batch << ")";
+
+      Array<IterVar> dst_vars;
+      for (size_t i = 0; i < dst_dim; ++i) {
+        Var var = Var(std::string{char('i' + i)});
+        dst_vars.push_back(IterVar(Range(0, dst_layout->InputShape()[i]), var,
+                                   IterVarType::kDataPar));
+      }
+
+      Array<IterVar> src_vars;
+      if (!is_1d_reduce) {
+        src_vars = dst_vars;
+      }
+      Range reduce_dom(0, src_layout->InputShape()[op.dim]);
+      IterVar reduce_iv(reduce_dom, Var("rv"), IterVarType::kDataPar);
+      src_vars.insert(src_vars.begin() + op.dim, reduce_iv);
+
+      auto src_indices = src_layout->Forward(
+          src_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }));
+      auto dst_indices = dst_layout->Forward(
+          dst_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }));
+      auto red_indices = red_layout->Forward(
+          dst_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }));
+      auto src_thread = src_layout->ForwardThread(
+          src_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }), {});
+
+      auto reduce_plan = backend::reduce::MakeReduceOwnershipPlan(
+          src_indices, src_thread, src_vars, src_vars[op.dim]->var, analyzer);
+
+      // Plan-level enforcement is per thread_step:
+      // thread_step.extent is the PER-STEP participating thread range,
+      // NOT the threadgroup extent. The raw XOR butterfly must be closed
+      // on the participating range [0, nt): within one butterfly level
+      // each thread reads its partner's old value while writing its own;
+      // that ordering is only guaranteed by SIMD lockstep inside a
+      // simdgroup, and every partner must be a real, written lane.
+      //
+      // Reject iff nt = extent*scale is not a power of two OR nt > 32:
+      //  - XOR closure: [0, nt) is closed under every butterfly
+      //    mask (nt/2 halving down to scale) iff nt is a power of two —
+      //    each mask then flips a single lane bit below log2(nt), so
+      //    tid^mask stays in [0, nt). For a non-power-of-two nt the
+      //    partner of a participating lane escapes the range even when
+      //    every mask is < 32: e.g. extent=8, scale=3 (nt=24, masks
+      //    12/6/3) gives tid=16 ^ 12 = 28 >= 24 — a scratch read of a
+      //    never-written slot / OOB. CheckAllReduceWidth
+      //    (backend/common/op/reduce.h) only requires logical_width ==
+      //    extent to be a positive power of two and scale > 0; scale
+      //    need NOT be a power of two, so both the wider-than-simdgroup case
+      //    (32 < nt < 64, e.g. (16,3)=48 -> partner 32^24 = 56) and the
+      //    and the non-power-of-two case (nt <= 32, e.g. (8,3)=24 -> partner
+      //    16^12 = 28) were reachable through the shared lowering.
+      //  - single-simdgroup closure: nt > 32 means the range
+      //    exceeds one 32-lane simdgroup and the largest mask nt/2
+      //    pairs threads across a simdgroup boundary.
+      //  - threadgroup alignment:
+      //    the raw butterfly executes on ALL N threads without a
+      //    tid < nt guard, so the ACTUAL closure domain is the whole
+      //    execution prefix [0, N), not just the first block [0, nt).
+      //    The largest mask nt/2 partitions lanes into aligned blocks
+      //    of size nt; [0, N) is closed under it (and hence under every
+      //    smaller mask 2^i | nt) iff N % nt == 0.  If N is not an
+      //    integer multiple of nt, the last incomplete block reads
+      //    partners >= N (outside the threadgroup; the scratch is sized
+      //    N) or never-written codegen-padding slots (e.g. extent=8,
+      //    scale=2, nt=16, N=24: tid 16..23 ^ 8 = 24..31 escapes the
+      //    24-slot scratch).  N is the compile-time threadgroup extent
+      //    checked at entry above.
+      //
+      // Group-local closures in multi-simdgroup threadgroups (every step
+      // nt a power of two <= 32 with N % nt == 0, e.g.
+      // a DeepSeek V4 Flash-style grouped reduction with threads=128,
+      // extent=32, scale=1, offsets 16..1, or power-of-two replication
+      // extent=16, scale=2, nt=32, or N=2*nt complete two-block closures)
+      // perform zero cross-simdgroup value exchange and are allowed even
+      // though the threadgroup extent is 128. An empty thread_steps plan
+      // has no butterfly at all and is always safe.
+      for (const auto &thread_step : reduce_plan.thread_steps) {
+        int64_t nt =
+            static_cast<int64_t>(thread_step.extent) * thread_step.scale;
+        const int64_t N = *tb_extent;
+        ICHECK_GT(nt, 0) << "Metal reduce: reduce plan thread step must have a "
+                            "positive extent*scale (got extent="
+                         << thread_step.extent
+                         << ", scale=" << thread_step.scale << ")";
+        int shift = 0;
+        const bool nt_is_pow2 =
+            tirx::is_const_power_of_two_integer(Integer(nt), &shift);
+        if (!nt_is_pow2 || nt > 32 || N % nt != 0) {
+          std::ostringstream msg;
+          msg << "Metal reduce: fragment reduce butterfly must stay inside "
+                 "a single-simdgroup, XOR-closed participating range: "
+                 "thread_step extent="
+              << thread_step.extent << " scale=" << thread_step.scale
+              << " (butterfly offsets " << nt / 2 << " .. " << thread_step.scale
+              << ", nt = extent*scale = " << nt
+              << ", threadgroup extent N = " << N << ")";
+          if (!nt_is_pow2) {
+            msg << "; nt is not a power of two, so the participating "
+                   "range [0, "
+                << nt
+                << ") is not closed under the XOR masks: a partner "
+                   "can escape the range even though every offset "
+                   "is < 32 (e.g. tid^"
+                << nt / 2 << " may be >= " << nt
+                << "), reading a scratch slot that no thread ever wrote "
+                   "(undefined) or lying outside the threadgroup (OOB)";
+          }
+          if (N % nt != 0) {
+            msg << "; N = " << N << " is not an integer multiple of nt = " << nt
+                << ", so the last incomplete nt-block is not aligned: the "
+                   "raw butterfly runs on all "
+                << N
+                << " threads without a tid < nt guard, and the tail block "
+                   "reads partners >= "
+                << N
+                << " (outside the threadgroup; the scratch is sized N) or "
+                   "never-written codegen-padding slots — complete "
+                   "nt-blocks (32-lane aligned when nt = 32) are required "
+                   "so every partner is a participating, written lane";
+          }
+          if (nt_is_pow2 && nt > 32) {
+            msg << "; nt > 32 exceeds one 32-lane simdgroup, and "
+                   "cross-simdgroup in-place combine is unsupported on "
+                   "Metal (no named barriers; the partner-read/self-write "
+                   "ordering is only guaranteed by SIMD lockstep inside "
+                   "a simdgroup)";
+          }
+          msg << ". Use 32-thread threadgroups or per-simdgroup "
+                 "group-local closures with power-of-two extent*scale "
+                 "<= 32 and threadgroup extent a multiple of it.";
+          LOG(FATAL) << msg.str();
+        }
+      }
+
+      Array<Stmt> stmts;
+
+      auto require_init = op.clear;
+      if (op.type->IsSum() || op.type->IsAbsSum() || op.type->IsBitAnd() ||
+          op.type->IsBitOr() || op.type->IsBitXor()) {
+        require_init = true;
+      }
+
+      auto clear_buffer = dst_buffer;
+      auto need_duplicate = false;
+      auto need_update = false;
+      if ((op.type->IsSum() || op.type->IsAbsSum()) && !op.clear) {
+        need_duplicate = true;
+        need_update = true;
+      } else if (op.type->IsBitAnd() && !op.clear) {
+        need_duplicate = true;
+        need_update = true;
+      } else if ((op.type->IsBitOr() || op.type->IsBitXor()) && !op.clear) {
+        need_duplicate = true;
+        need_update = true;
+      } else if ((op.type->IsMax() || op.type->IsMin() ||
+                  op.type->IsAbsMax()) &&
+                 !op.clear) {
+        need_duplicate = true;
+        need_update = true;
+      }
+
+      if (!analyzer->CanProve(dst_layout->ReplicateExtent() ==
+                              red_layout->ReplicateExtent())) {
+        need_duplicate = true;
+      }
+      ICHECK(!analyzer->CanProve(dst_layout->ReplicateExtent() >
+                                 red_layout->ReplicateExtent()))
+          << "Inconsistent layouts between src and dst in ReduceOp: "
+          << "dst_layout=" << dst_layout << "red_layout=" << red_layout;
+
+      if (need_duplicate) {
+        clear_buffer = decl_buffer(red_layout->OutputShape(), dst_buffer->dtype,
+                                   dst_buffer->name + "_clear",
+                                   GetPtrStorageScope(dst_buffer->data));
+      }
+
+      // A bf16 accumulator/destination reduce
+      // runs entirely in fp32. MSL has no bf16 min/max overloads and the
+      // codegen cannot print a bf16 infinity literal, so a bf16
+      // accumulator/scratch cannot compile. Mirror the upstream CUDA
+      // AccType design (fp16/bf16 -> fp32 accumulation): all phase-1
+      // partials and the threadgroup scratch live in fp32; bf16 is only
+      // materialized at the final ownership write-back (cast).
+      const bool bf16_accum = clear_buffer->dtype.is_bfloat16();
+      if (bf16_accum &&
+          (op.type->IsBitAnd() || op.type->IsBitOr() || op.type->IsBitXor())) {
+        LOG(FATAL) << "Metal reduce: bitwise reduce over a bfloat16 "
+                      "accumulator/destination is not supported (an fp32 "
+                      "accumulator would change the bit semantics of the "
+                      "bfloat16 operands).";
+      }
+      // fp32 accumulator used by phases 1/2 (== clear_buffer unless a
+      // private fp32 scratch buffer is required).
+      Buffer accum_buffer = clear_buffer;
+      bool alloc_accum_buffer = false;
+      if (bf16_accum) {
+        if (need_duplicate) {
+          // The duplicated clear buffer is a private temp owned by this
+          // lowering: redeclare it in fp32 and accumulate there.
+          clear_buffer =
+              decl_buffer(red_layout->OutputShape(), DataType::Float(32),
+                          dst_buffer->name + "_clear",
+                          GetPtrStorageScope(dst_buffer->data));
+          accum_buffer = clear_buffer;
+        } else {
+          accum_buffer =
+              decl_buffer(red_layout->OutputShape(), DataType::Float(32),
+                          dst_buffer->name + "_accum",
+                          GetPtrStorageScope(dst_buffer->data));
+          alloc_accum_buffer = true;
+        }
+      }
+      // Reduce identity in the accumulator dtype (fp32 for bf16 dst).
+      PrimExpr init_value =
+          bf16_accum ? PrimExpr(Cast(DataType::Float(32),
+                                     backend::reduce::MakeInitValue(op)))
+                     : backend::reduce::MakeInitValue(op);
+
+      Array<PrimExpr> src_indice_compressed = reduce_plan.local_src_indices;
+      Array<IterVar> src_var_compressed = reduce_plan.local_reduce_vars;
+
+      // ---- Phase 1: per-thread local partials (vsize = 1). ----
+      {
+        if (require_init ||
+            (need_duplicate &&
+             (op.type->IsMax() || op.type->IsMin() || op.type->IsAbsMax()))) {
+          stmts.push_back(BufferStore(accum_buffer, init_value, red_indices));
+        }
+
+        Stmt reduce_local =
+            BufferStore(accum_buffer,
+                        backend::reduce::MakeReduce(
+                            op, 1, BufferLoad(accum_buffer, red_indices),
+                            BufferLoad(src_buffer, src_indice_compressed)),
+                        red_indices);
+
+        for (int i = static_cast<int>(src_layout->OutputDim()) - 1; i >= 0;
+             --i) {
+          reduce_local = For(src_var_compressed[i]->var, 0,
+                             src_var_compressed[i]->dom->extent,
+                             ForKind::kUnrolled, reduce_local, std::nullopt);
+        }
+        stmts.push_back(reduce_local);
+      }
+
+      auto phase1 = stmts.size() > 1 ? SeqStmt(stmts) : stmts[0];
+      for (int i = static_cast<int>(dst_layout->InputDim()) - 1; i >= 0; --i) {
+        phase1 = For(dst_vars[i]->var, 0, dst_vars[i]->dom->extent,
+                     ForKind::kParallel, phase1);
+      }
+      if (dst_layout->InputDim() > 0) {
+        phase1 = PartitionLoop(Downcast<For>(phase1), lower_args.thread_index,
+                               analyzer, red_layout);
+        phase1 = PragmaUnrollLoop(Downcast<For>(phase1));
+      } else {
+        auto guard = (lower_args.thread_index == lower_args.thread_bounds->min);
+        phase1 = IfThenElse(guard, phase1);
+      }
+
+      // ---- Phase 2: lockstep threadgroup butterfly. ----
+      // Faithful to the CUDA AllReduce template semantics: one step per
+      // reduce-plan thread step; each step runs a XOR-butterfly over the
+      // participating thread range [0, extent*scale) with offsets halving
+      // down to `scale`, so replicated fragment holders land in distinct
+      // groups and are never double-counted. All threads execute the same
+      // barrier sequence (MSL has no CUDA-style named barriers);
+      // non-participants contribute the reduce identity element, and their
+      // scratch slots are never read (XOR partners stay inside the
+      // participating range). The plan-level checks guarantee per
+      // step nt = extent*scale is a power of two and <= 32 with the
+      // threadgroup extent N % nt == 0, so [0, nt) is closed under every
+      // mask (each mask flips a single lane bit below log2(nt)) and the
+      // closure never leaves the thread's own simdgroup (group-local
+      // closures); N % nt == 0 additionally makes every nt-block complete
+      // (the raw butterfly runs on all N threads without a tid < nt
+      // guard, so a partial tail block would read partners >= N or
+      // never-written padding slots). Results round-trip through the
+      // accumulator buffer between steps, mirroring the per-step extern
+      // calls on CUDA.
+      //
+      // A raw extent=1 reduce has an empty
+      // thread_steps plan (no thread-owned reduce factor), so the Phase-1
+      // partials are already final and Phase 2 (butterfly + scratch +
+      // barriers) is omitted entirely. No dummy loop / dummy barrier is
+      // constructed; the accumulator buffer is only allocated when a
+      // butterfly actually runs.
+      Stmt butterfly_body;
+      Buffer scratch;
+      if (!reduce_plan.thread_steps.empty()) {
+        // Scratch is sized by the full threadgroup extent (all threads
+        // execute the barrier sequence and write their slot; group-local
+        // closures in multi-simdgroup threadgroups are legal). The extent is
+        // compile-time-constant by the entry check above. Requiring
+        // N % nt == 0 per step ensures every read
+        // partner of the all-thread butterfly stays within these N slots.
+        const int64_t *thread_extent =
+            as_const_int(lower_args.thread_bounds->extent);
+        ICHECK(thread_extent != nullptr)
+            << "Metal reduce: threadgroup extent must be a compile-time "
+               "constant";
+        int64_t total_elements = 1;
+        for (const auto &s : dst_layout->InputShape()) {
+          const int64_t *p = as_const_int(s);
+          ICHECK(p != nullptr)
+              << "Metal reduce: output shape must be compile-time constant";
+          total_elements *= *p;
+        }
+
+        std::vector<int64_t> dst_strides(dst_dim, 1);
+        for (int d = static_cast<int>(dst_dim) - 2; d >= 0; --d) {
+          const int64_t *p = as_const_int(dst_layout->InputShape()[d + 1]);
+          dst_strides[d] = dst_strides[d + 1] * *p;
+        }
+
+        // The threadgroup scratch uses the fp32 accumulator dtype for
+        // bf16 destinations (bf16 scratch cannot compile: no MSL max/min
+        // overloads, no bf16 infinity literal).
+        scratch =
+            decl_buffer({Integer(*thread_extent)}, accum_buffer->dtype,
+                        accum_buffer->name + "_metal_reduce_scratch", "shared");
+
+        // Build inside-out: single element iteration body.
+        {
+          Var e_var("e");
+          Array<PrimExpr> elem_dst_indices;
+          for (size_t d = 0; d < dst_dim; ++d) {
+            elem_dst_indices.push_back(
+                FloorMod(FloorDiv(e_var, Integer(dst_strides[d])),
+                         dst_layout->InputShape()[d]));
+          }
+          auto elem_red_indices = red_layout->Forward(elem_dst_indices);
+
+          // The scratch-write partial
+          // and the step_store must be gated by "thread t holds a real
+          // partial for element e", i.e. the red_layout partition guard —
+          // the same predicate PartitionLoop generates for the generic
+          // lowering. The dst-layout ownership predicate is NOT equivalent:
+          // for layouts where every thread holds elements of every row
+          // (e.g. [4,128] x 32 threads: 4 columns/thread/row), ownership
+          // matches only a subset of the participating threads and the
+          // butterfly silently drops the other partials (wrong totals).
+          // Ownership still gates the final dst write-back (Phase 3 / copy
+          // out).
+          PrimExpr predicate = Bool(true);
+          {
+            PrimExpr local_thread_index = lower_args.thread_index;
+            if (red_layout->ThreadRange().defined()) {
+              local_thread_index =
+                  local_thread_index - red_layout->ThreadRange()->min;
+            }
+            auto red_th = red_layout->Forward(elem_dst_indices);
+            red_th.push_back(local_thread_index);
+            auto inv = red_layout->Inverse()->Forward(red_th);
+            inv.pop_back();
+            for (size_t i = 0; i < static_cast<size_t>(dst_dim); ++i) {
+              predicate = predicate && (inv[i] == elem_dst_indices[i]);
+            }
+            predicate = analyzer->Simplify(predicate);
+          }
+
+          auto sync_shared =
+              Evaluate(Call(DataType::Int(32), builtin::tvm_storage_sync(),
+                            {StringImm("shared")}));
+
+          // Guarded scratch write: owner -> local partial, else identity.
+          PrimExpr partial =
+              analyzer->CanProve(predicate)
+                  ? PrimExpr(BufferLoad(accum_buffer, elem_red_indices))
+                  : PrimExpr(Select(predicate,
+                                    BufferLoad(accum_buffer, elem_red_indices),
+                                    init_value));
+
+          Stmt elem_body;
+          for (const auto &thread_step : reduce_plan.thread_steps) {
+            int64_t nt =
+                static_cast<int64_t>(thread_step.extent) * thread_step.scale;
+            backend::reduce::CheckAllReduceWidth(
+                static_cast<int>(nt), thread_step.scale, "tl.reduce (metal)");
+            Stmt step_body = SeqStmt(
+                {BufferStore(scratch, partial, {lower_args.thread_index}),
+                 sync_shared});
+            for (int64_t offset = nt / 2; offset >= thread_step.scale;
+                 offset /= 2) {
+              PrimExpr partner = lower_args.thread_index ^ Integer(offset);
+              // No tid<nt guard: XOR partners self-organize inside the
+              // participating block, and neutral values from non-
+              // participants never leak into block slots. The plan checks
+              // guarantee [0, nt) is closed under every mask (nt a power
+              // of two <= 32) and that the threadgroup extent N is an
+              // integer multiple of nt (N % nt == 0), so every
+              // nt-block of the ALL-N-thread execution prefix is complete
+              // and the partner of every participating lane is a
+              // participating, written lane.
+              Stmt combine = BufferStore(
+                  scratch,
+                  backend::reduce::MakeReduce(
+                      op, 1, BufferLoad(scratch, {lower_args.thread_index}),
+                      BufferLoad(scratch, {partner})),
+                  {lower_args.thread_index});
+              step_body = SeqStmt({step_body, combine, sync_shared});
+            }
+            // Every participant holds its group total; owners store it
+            // back. With multiple
+            // thread steps, ALL non-final steps round-trip through the fp32
+            // accumulator so the next step's `partial` reloads the updated
+            // group totals (per-step bf16 casts to dst silently dropped
+            // every intermediate result: the next step re-read the stale
+            // Phase-1 partial -> deterministic wrong totals). bf16 is
+            // materialized only at the LAST step's ownership write-back
+            // (cast fp32 -> bf16); a single-step plan is unchanged (its
+            // only step is final).
+            const bool is_final_step =
+                (&thread_step == &reduce_plan.thread_steps.back());
+            Stmt step_store;
+            if (bf16_accum && !need_duplicate && is_final_step) {
+              step_store = IfThenElse(
+                  predicate,
+                  BufferStore(
+                      dst_buffer,
+                      Cast(dst_buffer->dtype,
+                           BufferLoad(scratch, {lower_args.thread_index})),
+                      elem_red_indices));
+            } else {
+              step_store = IfThenElse(
+                  predicate,
+                  BufferStore(accum_buffer,
+                              BufferLoad(scratch, {lower_args.thread_index}),
+                              elem_red_indices));
+            }
+            step_body = SeqStmt({step_body, step_store});
+            elem_body = elem_body.defined() ? SeqStmt({elem_body, step_body})
+                                            : step_body;
+          }
+
+          butterfly_body = For(e_var, 0, Integer(total_elements),
+                               ForKind::kSerial, elem_body, std::nullopt);
+        }
+      }
+
+      // ---- Phase 3: duplicate-buffer update (guarded). ----
+      Stmt phase3;
+      if (need_duplicate) {
+        PrimExpr predicate = Bool(true);
+        {
+          PrimExpr local_thread_index = lower_args.thread_index;
+          if (dst_layout->ThreadRange().defined()) {
+            local_thread_index =
+                local_thread_index - dst_layout->ThreadRange()->min;
+          }
+          auto dst_th_indices = dst_indices;
+          dst_th_indices.push_back(local_thread_index);
+          auto inv = dst_layout->Inverse()->Forward(dst_th_indices);
+          inv.pop_back();
+          for (size_t i = 0; i < static_cast<size_t>(dst_dim); ++i) {
+            predicate = predicate && (inv[i] == dst_vars[i]->var);
+          }
+          predicate = analyzer->Simplify(predicate);
+        }
+        PrimExpr update =
+            need_update
+                ? backend::reduce::MakeUpdate(
+                      op,
+                      bf16_accum
+                          ? PrimExpr(Cast(DataType::Float(32),
+                                          BufferLoad(dst_buffer, dst_indices)))
+                          : BufferLoad(dst_buffer, dst_indices),
+                      BufferLoad(accum_buffer, red_indices))
+                : BufferLoad(accum_buffer, red_indices);
+        // The clear=False update for a bf16 destination is computed in
+        // fp32 (accumulator dtype) and only the final store casts back to
+        // bf16.
+        Stmt store = BufferStore(
+            dst_buffer,
+            bf16_accum ? PrimExpr(Cast(dst_buffer->dtype, update)) : update,
+            dst_indices);
+        phase3 = analyzer->CanProve(predicate) ? store
+                                               : IfThenElse(predicate, store);
+        for (int i = static_cast<int>(dst_dim) - 1; i >= 0; --i) {
+          phase3 = For(dst_vars[i]->var, 0, dst_vars[i]->dom->extent,
+                       ForKind::kParallel, phase3);
+        }
+        if (dst_dim > 0) {
+          phase3 = PartitionLoop(Downcast<For>(phase3), lower_args.thread_index,
+                                 analyzer, red_layout);
+          phase3 = PragmaUnrollLoop(Downcast<For>(phase3));
+        } else {
+          auto guard =
+              (lower_args.thread_index == lower_args.thread_bounds->min);
+          phase3 = IfThenElse(guard, phase3);
+        }
+      }
+
+      // ---- Phase 2.5: bf16 empty-plan write-back. ----
+      // With an empty thread_steps plan (raw extent=1) the butterfly is
+      // skipped, so no step_store exists to materialize bf16. Phase 1 then
+      // left the fp32 partials in the private accum buffer; write them back
+      // to dst under the same element-ownership predicate as Phase 1.
+      Stmt bf16_writeback;
+      if (bf16_accum && !need_duplicate && reduce_plan.thread_steps.empty()) {
+        Stmt wb = BufferStore(
+            dst_buffer,
+            Cast(dst_buffer->dtype, BufferLoad(accum_buffer, red_indices)),
+            red_indices);
+        for (int i = static_cast<int>(dst_dim) - 1; i >= 0; --i) {
+          wb = For(dst_vars[i]->var, 0, dst_vars[i]->dom->extent,
+                   ForKind::kParallel, wb);
+        }
+        if (dst_dim > 0) {
+          wb = PartitionLoop(Downcast<For>(wb), lower_args.thread_index,
+                             analyzer, red_layout);
+          wb = PragmaUnrollLoop(Downcast<For>(wb));
+        } else {
+          wb = IfThenElse(
+              (lower_args.thread_index == lower_args.thread_bounds->min), wb);
+        }
+        bf16_writeback = wb;
+      }
+
+      Array<Stmt> parts;
+      parts.push_back(phase1);
+      if (bf16_writeback.defined()) {
+        parts.push_back(bf16_writeback);
+      }
+      if (butterfly_body.defined()) {
+        parts.push_back(butterfly_body);
+      }
+      if (phase3.defined()) {
+        parts.push_back(phase3);
+      }
+      Stmt body = parts.size() > 1 ? SeqStmt(parts) : parts[0];
+      if (need_duplicate) {
+        body = SeqStmt({AllocBuffer(clear_buffer), body});
+      }
+      if (alloc_accum_buffer) {
+        body = SeqStmt({AllocBuffer(accum_buffer), body});
+      }
+      if (scratch.defined()) {
+        body = SeqStmt({AllocBuffer(scratch), body});
+      }
+      return body;
+    }
+
+    LOG(FATAL) << "Metal reduce for buffers in scope (" << op.src.scope()
+               << ", " << op.dst.scope() << ") is not implemented.";
+    return Stmt();
+  }
+};
+
+} // namespace metal
+
+namespace {
+
+bool MatchMetalReduceTarget(Target target) { return TargetIsMetal(target); }
+
+bool RegisterMetalReduce() {
+  RegisterReduceImpl(ReduceImpl{
+      "metal.Reduce",
+      MatchMetalReduceTarget,
+      metal::MetalReduce::Lower,
+  });
+  return true;
+}
+
+const bool metal_reduce_registered = RegisterMetalReduce();
+
+} // namespace
+
+} // namespace tl
+} // namespace tvm

--- a/src/metal/op/reduce.cc
+++ b/src/metal/op/reduce.cc
@@ -155,50 +155,18 @@ struct MetalReduce : backend::ReduceLowerer<MetalReduce> {
       auto dst_buffer = get_buffer(op.dst);
       auto src_layout = lower_args.layout_map[op.src].as<Fragment>().value();
       auto dst_layout = lower_args.layout_map[op.dst].as<Fragment>().value();
-      auto red_layout =
-          backend::reduce::ComputeReducerLayout(src_layout, op.dim);
-      auto src_dim = src_layout->InputDim();
-      auto dst_dim = dst_layout->InputDim();
-
-      auto is_1d_reduce = src_dim == dst_dim && dst_dim == 1;
-
-      if (is_1d_reduce) {
-        ICHECK(is_one(dst_layout->OutputShape().back()))
-            << "Reduce for scalar not implemented.";
-      } else {
-        ICHECK_EQ(src_dim, dst_dim + 1) << "Reduce dimension mismatch.";
-      }
+      auto ctx = backend::reduce::MakeFragmentReduceContext(
+          op, src_buffer, dst_buffer, src_layout, dst_layout, analyzer);
+      auto red_layout = ctx.red_layout;
+      auto dst_dim = ctx.dst_dim;
+      auto &dst_vars = ctx.dst_vars;
+      auto &dst_indices = ctx.dst_indices;
+      auto &red_indices = ctx.red_indices;
+      auto &reduce_plan = ctx.reduce_plan;
 
       ICHECK_EQ(op.batch, 1)
           << "Metal reduce: batch > 1 is not supported yet (op.batch="
           << op.batch << ")";
-
-      Array<IterVar> dst_vars;
-      for (size_t i = 0; i < dst_dim; ++i) {
-        Var var = Var(std::string{char('i' + i)});
-        dst_vars.push_back(IterVar(Range(0, dst_layout->InputShape()[i]), var,
-                                   IterVarType::kDataPar));
-      }
-
-      Array<IterVar> src_vars;
-      if (!is_1d_reduce) {
-        src_vars = dst_vars;
-      }
-      Range reduce_dom(0, src_layout->InputShape()[op.dim]);
-      IterVar reduce_iv(reduce_dom, Var("rv"), IterVarType::kDataPar);
-      src_vars.insert(src_vars.begin() + op.dim, reduce_iv);
-
-      auto src_indices = src_layout->Forward(
-          src_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }));
-      auto dst_indices = dst_layout->Forward(
-          dst_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }));
-      auto red_indices = red_layout->Forward(
-          dst_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }));
-      auto src_thread = src_layout->ForwardThread(
-          src_vars.Map([](const auto &iv) { return PrimExpr(iv->var); }), {});
-
-      auto reduce_plan = backend::reduce::MakeReduceOwnershipPlan(
-          src_indices, src_thread, src_vars, src_vars[op.dim]->var, analyzer);
 
       // Plan-level enforcement is per thread_step:
       // thread_step.extent is the PER-STEP participating thread range,
@@ -317,45 +285,12 @@ struct MetalReduce : backend::ReduceLowerer<MetalReduce> {
 
       Array<Stmt> stmts;
 
-      auto require_init = op.clear;
-      if (op.type->IsSum() || op.type->IsAbsSum() || op.type->IsBitAnd() ||
-          op.type->IsBitOr() || op.type->IsBitXor()) {
-        require_init = true;
-      }
-
-      auto clear_buffer = dst_buffer;
-      auto need_duplicate = false;
-      auto need_update = false;
-      if ((op.type->IsSum() || op.type->IsAbsSum()) && !op.clear) {
-        need_duplicate = true;
-        need_update = true;
-      } else if (op.type->IsBitAnd() && !op.clear) {
-        need_duplicate = true;
-        need_update = true;
-      } else if ((op.type->IsBitOr() || op.type->IsBitXor()) && !op.clear) {
-        need_duplicate = true;
-        need_update = true;
-      } else if ((op.type->IsMax() || op.type->IsMin() ||
-                  op.type->IsAbsMax()) &&
-                 !op.clear) {
-        need_duplicate = true;
-        need_update = true;
-      }
-
-      if (!analyzer->CanProve(dst_layout->ReplicateExtent() ==
-                              red_layout->ReplicateExtent())) {
-        need_duplicate = true;
-      }
-      ICHECK(!analyzer->CanProve(dst_layout->ReplicateExtent() >
-                                 red_layout->ReplicateExtent()))
-          << "Inconsistent layouts between src and dst in ReduceOp: "
-          << "dst_layout=" << dst_layout << "red_layout=" << red_layout;
-
-      if (need_duplicate) {
-        clear_buffer = decl_buffer(red_layout->OutputShape(), dst_buffer->dtype,
-                                   dst_buffer->name + "_clear",
-                                   GetPtrStorageScope(dst_buffer->data));
-      }
+      auto plan = backend::reduce::MakeReduceBufferPlan(
+          op, dst_buffer, dst_layout, red_layout, analyzer);
+      auto require_init = plan.require_init;
+      auto clear_buffer = plan.clear_buffer;
+      auto need_duplicate = plan.need_duplicate;
+      auto need_update = plan.need_update;
 
       // A bf16 accumulator/destination reduce
       // runs entirely in fp32. MSL has no bf16 min/max overloads and the
@@ -403,42 +338,15 @@ struct MetalReduce : backend::ReduceLowerer<MetalReduce> {
       Array<IterVar> src_var_compressed = reduce_plan.local_reduce_vars;
 
       // ---- Phase 1: per-thread local partials (vsize = 1). ----
-      {
-        if (require_init ||
-            (need_duplicate &&
-             (op.type->IsMax() || op.type->IsMin() || op.type->IsAbsMax()))) {
-          stmts.push_back(BufferStore(accum_buffer, init_value, red_indices));
-        }
-
-        Stmt reduce_local =
-            BufferStore(accum_buffer,
-                        backend::reduce::MakeReduce(
-                            op, 1, BufferLoad(accum_buffer, red_indices),
-                            BufferLoad(src_buffer, src_indice_compressed)),
-                        red_indices);
-
-        for (int i = static_cast<int>(src_layout->OutputDim()) - 1; i >= 0;
-             --i) {
-          reduce_local = For(src_var_compressed[i]->var, 0,
-                             src_var_compressed[i]->dom->extent,
-                             ForKind::kUnrolled, reduce_local, std::nullopt);
-        }
-        stmts.push_back(reduce_local);
-      }
+      stmts.push_back(backend::reduce::MakeUnvectorizedLocalReduce(
+          op, accum_buffer, src_buffer, src_indice_compressed,
+          src_var_compressed, red_indices, init_value, require_init,
+          need_duplicate, src_layout->OutputDim()));
 
       auto phase1 = stmts.size() > 1 ? SeqStmt(stmts) : stmts[0];
-      for (int i = static_cast<int>(dst_layout->InputDim()) - 1; i >= 0; --i) {
-        phase1 = For(dst_vars[i]->var, 0, dst_vars[i]->dom->extent,
-                     ForKind::kParallel, phase1);
-      }
-      if (dst_layout->InputDim() > 0) {
-        phase1 = PartitionLoop(Downcast<For>(phase1), lower_args.thread_index,
-                               analyzer, red_layout);
-        phase1 = PragmaUnrollLoop(Downcast<For>(phase1));
-      } else {
-        auto guard = (lower_args.thread_index == lower_args.thread_bounds->min);
-        phase1 = IfThenElse(guard, phase1);
-      }
+      phase1 = backend::reduce::MakeParallelPartitionLoop(
+          phase1, dst_vars, lower_args.thread_index, lower_args.thread_bounds,
+          analyzer, red_layout);
 
       // ---- Phase 2: lockstep threadgroup butterfly. ----
       // Faithful to the CUDA AllReduce template semantics: one step per
@@ -623,54 +531,13 @@ struct MetalReduce : backend::ReduceLowerer<MetalReduce> {
       // ---- Phase 3: duplicate-buffer update (guarded). ----
       Stmt phase3;
       if (need_duplicate) {
-        PrimExpr predicate = Bool(true);
-        {
-          PrimExpr local_thread_index = lower_args.thread_index;
-          if (dst_layout->ThreadRange().defined()) {
-            local_thread_index =
-                local_thread_index - dst_layout->ThreadRange()->min;
-          }
-          auto dst_th_indices = dst_indices;
-          dst_th_indices.push_back(local_thread_index);
-          auto inv = dst_layout->Inverse()->Forward(dst_th_indices);
-          inv.pop_back();
-          for (size_t i = 0; i < static_cast<size_t>(dst_dim); ++i) {
-            predicate = predicate && (inv[i] == dst_vars[i]->var);
-          }
-          predicate = analyzer->Simplify(predicate);
-        }
-        PrimExpr update =
-            need_update
-                ? backend::reduce::MakeUpdate(
-                      op,
-                      bf16_accum
-                          ? PrimExpr(Cast(DataType::Float(32),
-                                          BufferLoad(dst_buffer, dst_indices)))
-                          : BufferLoad(dst_buffer, dst_indices),
-                      BufferLoad(accum_buffer, red_indices))
-                : BufferLoad(accum_buffer, red_indices);
-        // The clear=False update for a bf16 destination is computed in
-        // fp32 (accumulator dtype) and only the final store casts back to
-        // bf16.
-        Stmt store = BufferStore(
-            dst_buffer,
-            bf16_accum ? PrimExpr(Cast(dst_buffer->dtype, update)) : update,
-            dst_indices);
-        phase3 = analyzer->CanProve(predicate) ? store
-                                               : IfThenElse(predicate, store);
-        for (int i = static_cast<int>(dst_dim) - 1; i >= 0; --i) {
-          phase3 = For(dst_vars[i]->var, 0, dst_vars[i]->dom->extent,
-                       ForKind::kParallel, phase3);
-        }
-        if (dst_dim > 0) {
-          phase3 = PartitionLoop(Downcast<For>(phase3), lower_args.thread_index,
-                                 analyzer, red_layout);
-          phase3 = PragmaUnrollLoop(Downcast<For>(phase3));
-        } else {
-          auto guard =
-              (lower_args.thread_index == lower_args.thread_bounds->min);
-          phase3 = IfThenElse(guard, phase3);
-        }
+        // The clear=False update for a bf16 destination is computed in fp32
+        // (accumulator dtype) and only the final store casts back to bf16.
+        phase3 = backend::reduce::MakeDuplicateUpdatePhase(
+            op, dst_buffer, accum_buffer, dst_indices, red_indices, dst_vars,
+            dst_layout, need_update, /*cast_to_dst=*/bf16_accum,
+            /*cast_dst_load_to_accum=*/bf16_accum, lower_args.thread_index,
+            lower_args.thread_bounds, analyzer, red_layout);
       }
 
       // ---- Phase 2.5: bf16 empty-plan write-back. ----
@@ -684,19 +551,9 @@ struct MetalReduce : backend::ReduceLowerer<MetalReduce> {
             dst_buffer,
             Cast(dst_buffer->dtype, BufferLoad(accum_buffer, red_indices)),
             red_indices);
-        for (int i = static_cast<int>(dst_dim) - 1; i >= 0; --i) {
-          wb = For(dst_vars[i]->var, 0, dst_vars[i]->dom->extent,
-                   ForKind::kParallel, wb);
-        }
-        if (dst_dim > 0) {
-          wb = PartitionLoop(Downcast<For>(wb), lower_args.thread_index,
-                             analyzer, red_layout);
-          wb = PragmaUnrollLoop(Downcast<For>(wb));
-        } else {
-          wb = IfThenElse(
-              (lower_args.thread_index == lower_args.thread_bounds->min), wb);
-        }
-        bf16_writeback = wb;
+        bf16_writeback = backend::reduce::MakeParallelPartitionLoop(
+            wb, dst_vars, lower_args.thread_index, lower_args.thread_bounds,
+            analyzer, red_layout);
       }
 
       Array<Stmt> parts;

--- a/src/metal/op/reduce.cc
+++ b/src/metal/op/reduce.cc
@@ -66,6 +66,12 @@
  *   - op.batch > 1 is not supported yet (LOG(FATAL)).
  *   - vectorized (packed) local reduction is disabled (vsize = 1).
  *   - fp16/bf16 nan_propagate reducers are not supported (no MSL __hmax_nan).
+ *   - Reducer v2 (tl.finalize_reducer / FinalizeReducerOp) is NOT
+ *     implemented on Metal: upstream registers finalize_reducer only for
+ *     CUDA and ROCm, so a v2 epoch fails loudly at lowering with
+ *     "no finalize_reducer implementation is registered for metal".
+ *     This file covers only the legacy T.reduce path; the v2 boundary is
+ *     exercised by test_finalize_reducer_v2_rejected_on_metal.
  */
 
 #include "backend/common/op/reduce.h"
@@ -201,6 +207,15 @@ struct MetalReduce : backend::ReduceLowerer<MetalReduce> {
       // each thread reads its partner's old value while writing its own;
       // that ordering is only guaranteed by SIMD lockstep inside a
       // simdgroup, and every partner must be a real, written lane.
+      //
+      // Explicit alignment contract (participating range vs nt blocks):
+      // the participating range [0, nt) of every thread step must sit on
+      // complete nt-blocks of the [0, N) execution prefix, enforced below
+      // by N % nt == 0. This is a hard correctness invariant, not an
+      // optimization: the raw butterfly runs on ALL N threads without a
+      // tid < nt guard, so an incomplete tail block would read partners
+      // >= N (outside the threadgroup; the scratch is sized N) or
+      // never-written codegen-padding slots.
       //
       // Reject iff nt = extent*scale is not a power of two OR nt > 32:
       //  - XOR closure: [0, nt) is closed under every butterfly

--- a/testing/python/metal/metal_test_utils.py
+++ b/testing/python/metal/metal_test_utils.py
@@ -1,0 +1,25 @@
+"""Shared utilities for Metal lowering tests."""
+
+import tilelang
+from tilelang import tvm as tvm
+
+
+def lower_prim_to_metal(prim_func, *, target="metal") -> str:
+    """Lower a TIR prim_func to Metal shader source.
+
+    This is the canonical Metal lowering path shared by tests: it creates a
+    TVM Metal target with an LLVM host target, lowers the function with host
+    codegen and device compilation disabled, and returns the emitted MSL.
+    Tests that only need the generated shader text should use this helper
+    instead of inlining the same ``tilelang.lower`` call.
+    """
+    target = tvm.target.Target(target, tvm.target.Target("llvm"))
+    with target:
+        artifact = tilelang.lower(
+            prim_func,
+            target=target,
+            target_host="llvm",
+            enable_host_codegen=False,
+            enable_device_compile=False,
+        )
+    return artifact.kernel_source or ""

--- a/testing/python/metal/reduce_test_utils.py
+++ b/testing/python/metal/reduce_test_utils.py
@@ -1,0 +1,47 @@
+"""Shared Metal reduce test utilities.
+
+The core kernel constructor is derived from the upstream public constructor
+``_make_allreduce_dim0_scale_kernel`` in
+``testing/python/language/test_tilelang_language_reduce.py``. Upstream keeps
+that helper private to its own test file and does not parameterize the
+Metal-only concerns (explicit threadgroup extent, fp16/bf16 destinations,
+and ``clear=False`` duplicate-buffer updates), so the Metal tests share this
+copy here instead of duplicating it in every test module.
+"""
+
+import tilelang.language as T
+
+
+def make_allreduce_dim0_scale_kernel(
+    reduce_fn, logical_width, scale, threads=None, dtype="float32", clear=True
+):
+    """Allreduce-on-dim-0 kernel constructor (upstream-derived).
+
+    Source: upstream ``_make_allreduce_dim0_scale_kernel`` in
+    ``testing/python/language/test_tilelang_language_reduce.py``, extended for
+    the Metal backend with:
+
+    - ``threads``: defaults to ``logical_width * scale`` (N == nt). Supplying
+      an explicit value decouples the threadgroup extent from nt so
+      misaligned threadgroups are reachable through the same public
+      constructor.
+    - ``dtype``: covers the fp32/fp16/bf16 paths.
+    - ``clear=False``: exercises the duplicate-buffer update path (Phase 3)
+      that accumulate-into-dst reductions take on Metal.
+    """
+    if threads is None:
+        threads = logical_width * scale
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((logical_width, scale), dtype),
+        B: T.Tensor((scale,), dtype),
+    ):
+        with T.Kernel(1, threads=threads):
+            src = T.alloc_fragment((logical_width, scale), dtype)
+            dst = T.alloc_fragment((scale,), dtype)
+            T.copy(A, src)
+            reduce_fn(src, dst, dim=0, clear=clear)
+            T.copy(dst, B)
+
+    return kernel

--- a/testing/python/metal/test_metal_reduce.py
+++ b/testing/python/metal/test_metal_reduce.py
@@ -408,8 +408,9 @@ def test_infinity_lowers_to_msl_infinity_literal(dtype):
 def test_infinity_msl_compiles(dtype):
     """The emitted ``INFINITY`` literal must be accepted by the offline Metal
     compiler. This is the legality check for the bf16 case in particular:
-    ``bfloat`` has no dedicated MSL infinity literal, so the codegen's bare
-    ``INFINITY`` relies on MSL's implicit float -> bfloat conversion."""
+    ``bfloat`` has no dedicated MSL infinity literal, so the codegen emits an
+    explicit ``(bfloat)(INFINITY)`` cast (MSL has no implicit float/half ->
+    bfloat conversion)."""
     _compile_msl_with_metal_toolchain(
         _lower_metal(_make_infinity_fill_kernel(dtype)), label=f"infinity-{dtype}"
     )

--- a/testing/python/metal/test_metal_reduce.py
+++ b/testing/python/metal/test_metal_reduce.py
@@ -1,0 +1,254 @@
+"""Metal fragment-reduce single-simdgroup plan enforcement.
+
+Every XOR-butterfly step must remain inside a 32-lane simdgroup. Metal has
+no named barriers, so an in-place cross-simdgroup combine cannot rely on SIMD
+lockstep ordering. For each step, ``nt = extent * scale`` must describe a
+power-of-two closure no wider than 32 lanes, and the full threadgroup must be
+an integer number of complete ``nt`` blocks. Otherwise a partner read can
+escape the participating range, the threadgroup, or the initialized scratch.
+
+The enforced criterion is:
+
+    reject iff nt = extent*scale is not a power of two
+                OR nt > 32
+                OR N % nt != 0
+    (allow iff nt is a power of two AND nt <= 32 AND N % nt == 0)
+
+Power-of-two replication plans and complete multi-block closures remain
+valid, including the 32-lane reduction shape used by Qwen and DeepSeek-style
+normalization and routing kernels.
+
+These tests are compile/lower-only (no GPU launch): the Metal backend
+must reject unsafe plans at lowering time with the single-simdgroup
+diagnostic (naming the step's scale, the offending nt, and the
+threadgroup extent N), and must accept every plan whose nt is a power
+of two <= 32 with N % nt == 0, with all XOR offsets < 32 AND the raw
+[0, N) execution prefix closed under every mask found in the MSL.
+"""
+
+import re
+
+import pytest
+import torch
+
+import tilelang
+import tilelang.testing
+import tilelang.language as T
+from tilelang import tvm as tvm
+
+
+def _make_allreduce_dim0_scale_kernel(reduce_fn, logical_width, scale, threads=None):
+    """Copy of the upstream public constructor
+    (testing/python/language/test_tilelang_language_reduce.py), used as
+    the public construction path for the Metal backend.
+
+    Threads default to logical_width * scale (N == nt). Supplying an
+    explicit value decouples the threadgroup extent from nt so misaligned
+    threadgroups are reachable through the same public constructor.
+    """
+    if threads is None:
+        threads = logical_width * scale
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((logical_width, scale), T.float32),
+        B: T.Tensor((scale,), T.float32),
+    ):
+        with T.Kernel(1, threads=threads):
+            src = T.alloc_fragment((logical_width, scale), T.float32)
+            dst = T.alloc_fragment((scale,), T.float32)
+            T.copy(A, src)
+            reduce_fn(src, dst, dim=0)
+            T.copy(dst, B)
+
+    return kernel
+
+
+def _xor_closed(offsets, n):
+    """The raw execution prefix [0, n) must be closed under every XOR
+    mask used in the MSL.
+
+    XOR with a mask is a permutation of the integers, so the image of
+    [0, n) is [0, n) iff the maximum partner stays inside the range.
+    For the participating range [0, nt), this holds iff nt is a
+    power of two (a non-power-of-two nt e.g. 24 with masks 12/6/3 lets
+    some partner escape even though every mask is < 32). The raw
+    butterfly runs on ALL N threads without a tid < nt guard, so the
+    domain that must actually be closed is the whole prefix [0, N);
+    with nt a power of two this holds iff N % nt == 0 (every nt-block
+    complete).
+    """
+    assert n > 0
+    return all(max(tid ^ mask for tid in range(n)) < n for mask in offsets)
+
+
+def _lower_metal(prim_func):
+    target = tvm.target.Target("metal", tvm.target.Target("llvm"))
+    with target:
+        artifact = tilelang.lower(
+            prim_func,
+            target=target,
+            target_host="llvm",
+            enable_host_codegen=False,
+            enable_device_compile=False,
+        )
+    return artifact.kernel_source or ""
+
+
+def _compile_metal(prim_func):
+    return tilelang.compile(
+        prim_func,
+        out_idx=-1,
+        target="metal",
+        execution_backend="tvm_ffi",
+    )
+
+
+@pytest.mark.parametrize(
+    ("logical_width", "scale", "nt"),
+    [
+        (16, 3, 48),  # 32^24 = 56 -> OOB on a 48-thread group
+        # group; nt is neither a power of two nor <= 32
+        (8, 5, 40),  # same window: offset 20, partner 32^20 = 52 -> OOB
+    ],
+)
+def test_rejects_nt_gt_32_non_pow2_scale(logical_width, scale, nt):
+    with pytest.raises(
+        Exception,
+        match=rf"single-simdgroup.*scale={scale}.*"
+        rf"nt = extent\*scale = {nt}.*\b32\b",
+    ):
+        _lower_metal(_make_allreduce_dim0_scale_kernel(T.reduce_sum, logical_width, scale))
+
+
+@pytest.mark.parametrize(
+    ("logical_width", "scale", "nt"),
+    [
+        # nt <= 32 yet not a power of two.
+        # Masks 12/6/3: partner 16^12 = 28 >= 24 escapes [0, 24) (OOB
+        # scratch / never-written slot) even though every mask < 32.
+        (8, 3, 24),
+        # Masks 6/3: partner 8^6 = 14 >= 12 escapes [0, 12); slots
+        # 12..15 exist only in codegen padding and are never written.
+        (4, 3, 12),
+    ],
+)
+def test_rejects_nt_le_32_non_pow2_scale(logical_width, scale, nt):
+    with pytest.raises(
+        Exception,
+        match=rf"single-simdgroup.*scale={scale}.*"
+        rf"nt = extent\*scale = {nt}.*\b32\b",
+    ):
+        _lower_metal(_make_allreduce_dim0_scale_kernel(T.reduce_sum, logical_width, scale))
+
+
+@pytest.mark.parametrize(
+    ("logical_width", "scale", "nt"),
+    [
+        (16, 4, 64),  # offsets 32..4: first offset crosses the boundary
+        (32, 2, 64),  # offsets 32..2: first offset crosses the boundary
+        (64, 1, 64),  # cross-group extent
+        (128, 1, 128),  # cross-group extent
+    ],
+)
+def test_rejects_nt_gt_32_pow2_scale(logical_width, scale, nt):
+    with pytest.raises(
+        Exception,
+        match=rf"single-simdgroup.*scale={scale}.*"
+        rf"nt = extent\*scale = {nt}.*\b32\b",
+    ):
+        _lower_metal(_make_allreduce_dim0_scale_kernel(T.reduce_sum, logical_width, scale))
+
+
+@pytest.mark.parametrize(
+    ("logical_width", "scale", "threads", "nt"),
+    [
+        # nt is a power of two <= 32, but the
+        # threadgroup extent is NOT an integer multiple of nt, so the
+        # last incomplete nt-block reads partners >= N (OOB: scratch is
+        # sized N) or never-written codegen-padding slots.  All these
+        # shapes reach the plan-level gate and were previously allowed.
+        # (8,2,24): nt=16, N%16=8; partners 24..31 escape the 24-slot
+        #           scratch (maximum partners
+        #           tid 16..23 ^ 8 = 24..31).
+        (8, 2, 24, 16),
+        # (2,4,12): nt=8, N%8=4; tid 8..11 ^ 4 = 12..15 read slots that
+        #           exist only in codegen padding and are never written.
+        (2, 4, 12, 8),
+        # (16,2,40): nt=32, N%32=8; task-specified (nt=32, N=40) case.
+        (16, 2, 40, 32),
+        (8, 4, 40, 32),  # same N=40 misalignment, nt=32
+        (4, 4, 20, 16),  # nt=16, N%16=4
+        (2, 2, 6, 4),  # nt=4, N%4=2
+        (8, 2, 56, 16),  # N=3*nt+8 boundary: tail block incomplete
+    ],
+)
+def test_rejects_misaligned_threadgroup(logical_width, scale, threads, nt):
+    """N % nt != 0 must produce a tail-block alignment diagnostic."""
+    with pytest.raises(
+        Exception,
+        match=rf"single-simdgroup.*scale={scale}.*"
+        rf"nt = extent\*scale = {nt}.*N = {threads}.*"
+        rf"not an integer multiple of nt = {nt}",
+    ):
+        _lower_metal(_make_allreduce_dim0_scale_kernel(T.reduce_sum, logical_width, scale, threads))
+
+
+@pytest.mark.parametrize(
+    ("logical_width", "scale", "threads", "nt"),
+    [
+        # N == nt single-block closures.
+        (32, 1, 32, 32),  # v2 boundary: full 32-lane closure, offsets 16..1
+        (16, 2, 32, 32),  # power-of-two replication: offsets 16..2
+        (8, 4, 32, 32),  # power-of-two replication: offsets 16..4
+        (16, 1, 16, 16),  # sub-simdgroup closure: offsets 8..1
+        (8, 2, 16, 16),  # power-of-two nt, offsets 8..2
+        (2, 4, 8, 8),  # power-of-two nt, offset 4
+        (4, 8, 32, 32),  # replicated small fragment: offsets 16..8
+        # Multi-block closures (N = k*nt complete blocks; every
+        # block computes its own copy of the same group total, owners
+        # store): the [0, N) execution prefix must be closed under every
+        # mask — this is the property N % nt == 0 guarantees.
+        (8, 2, 32, 16),  # N = 2*nt: two complete 16-lane closures
+        (2, 4, 16, 8),  # N = 2*nt
+        (2, 4, 32, 8),  # N = 4*nt
+        (8, 2, 64, 16),  # N = 4*nt
+        (4, 4, 32, 16),  # N = 2*nt
+        (16, 2, 96, 32),  # N = 3*nt
+        (8, 2, 128, 16),  # N = 8*nt (v2-scale threadgroup extent)
+    ],
+)
+def test_allows_pow2_nt_le_32_closure(logical_width, scale, threads, nt):
+    src = _lower_metal(_make_allreduce_dim0_scale_kernel(T.reduce_sum, logical_width, scale, threads))
+    # every XOR butterfly offset must be < 32 (closure inside one
+    # simdgroup; offsets are nt/2 halving down to scale), the max offset
+    # must be nt/2, the threadgroup extent must be an integer multiple
+    # of nt (complete nt-blocks in the [0, N) execution prefix),
+    # and the raw [0, N) prefix must be closed under every mask in the
+    # MSL on the actual execution domain.
+    offsets = [int(v) for v in re.findall(r"\^ ?(\d+)", src)]
+    assert offsets, "no XOR butterfly offsets found in MSL"
+    assert all(o < 32 for o in offsets)
+    assert max(offsets) == nt // 2
+    assert threads % nt == 0, (
+        f"threadgroup extent {threads} is not a multiple of nt={nt}: incomplete tail block would escape the execution prefix"
+    )
+    assert _xor_closed(offsets, threads), f"XOR masks {sorted(set(offsets))} not closed on [0, {threads})"
+
+
+@tilelang.testing.requires_metal
+@pytest.mark.parametrize("reduce_fn", [T.reduce_sum, T.reduce_max], ids=["sum", "max"])
+def test_runtime_float32_reduction(reduce_fn):
+    """Execute a complete 32-lane closure on MPS and check its value."""
+    logical_width, scale = 16, 2
+    kernel = _compile_metal(_make_allreduce_dim0_scale_kernel(reduce_fn, logical_width, scale))
+    values = torch.linspace(-1.5, 2.0, logical_width * scale, dtype=torch.float32).reshape(logical_width, scale).to("mps")
+    result = kernel(values)
+    torch.mps.synchronize()
+
+    reference = values.cpu().sum(dim=0) if reduce_fn is T.reduce_sum else values.cpu().max(dim=0).values
+    torch.testing.assert_close(result.cpu(), reference, rtol=1e-5, atol=1e-5)
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/metal/test_metal_reduce.py
+++ b/testing/python/metal/test_metal_reduce.py
@@ -26,7 +26,7 @@ of two <= 32 with N % nt == 0, with all XOR offsets < 32 AND the raw
 [0, N) execution prefix closed under every mask found in the MSL.
 
 Additional coverage in this file:
-  - tl.infinity lowering/offline-MSL legality for fp32/fp16/bf16;
+  - T.infinity lowering/offline-MSL legality for fp32/fp16/bf16;
   - bf16/fp16 reduce lowering (fp32-accumulate path) and offline MSL
     legality, including the bf16 max INFINITY identity;
   - clear=False duplicate-buffer update lowering (fp32 + bf16);
@@ -47,7 +47,10 @@ import torch
 import tilelang
 import tilelang.testing
 import tilelang.language as T
+from reduce_test_utils import make_allreduce_dim0_scale_kernel
 from tilelang import tvm as tvm
+
+_make_allreduce_dim0_scale_kernel = make_allreduce_dim0_scale_kernel
 
 
 def _metal_toolchain_available() -> bool:
@@ -72,43 +75,11 @@ def _metal_toolchain_available() -> bool:
 _HAS_METAL_TOOLCHAIN = _metal_toolchain_available()
 
 
-def _make_allreduce_dim0_scale_kernel(
-    reduce_fn, logical_width, scale, threads=None, dtype="float32", clear=True
-):
-    """Copy of the upstream public constructor
-    (testing/python/language/test_tilelang_language_reduce.py), used as
-    the public construction path for the Metal backend.
-
-    Threads default to logical_width * scale (N == nt). Supplying an
-    explicit value decouples the threadgroup extent from nt so misaligned
-    threadgroups are reachable through the same public constructor.
-
-    ``dtype`` covers the fp32/fp16/bf16 paths; ``clear=False`` exercises
-    the duplicate-buffer update path (Phase 3) that accumulate-into-dst
-    reductions take on Metal.
-    """
-    if threads is None:
-        threads = logical_width * scale
-
-    @T.prim_func
-    def kernel(
-        A: T.Tensor((logical_width, scale), dtype),
-        B: T.Tensor((scale,), dtype),
-    ):
-        with T.Kernel(1, threads=threads):
-            src = T.alloc_fragment((logical_width, scale), dtype)
-            dst = T.alloc_fragment((scale,), dtype)
-            T.copy(A, src)
-            reduce_fn(src, dst, dim=0, clear=clear)
-            T.copy(dst, B)
-
-    return kernel
-
 
 def _make_infinity_fill_kernel(dtype):
-    """Tiny fill kernel whose only payload is ``tl.infinity(dtype)``.
+    """Tiny fill kernel whose only payload is ``T.infinity(dtype)``.
 
-    Used to verify that the Metal ``tl.infinity`` lowering folds to a
+    Used to verify that the Metal ``T.infinity`` lowering folds to a
     constant ``FloatImm`` and that the codegen emits an MSL-legal
     ``INFINITY`` literal for fp32, fp16 and bf16 destinations.
     """
@@ -373,7 +344,7 @@ def test_runtime_float32_reduction(reduce_fn):
 
 
 # ---------------------------------------------------------------------------
-# tl.infinity lowering (fp32 / fp16 / bf16)
+# T.infinity lowering (fp32 / fp16 / bf16)
 # ---------------------------------------------------------------------------
 
 
@@ -381,7 +352,7 @@ def test_runtime_float32_reduction(reduce_fn):
     "dtype", ["float32", "float16", "bfloat16"], ids=["fp32", "fp16", "bf16"]
 )
 def test_infinity_lowers_to_msl_infinity_literal(dtype):
-    """tl.infinity must fold to a constant FloatImm that the Metal codegen
+    """T.infinity must fold to a constant FloatImm that the Metal codegen
     prints as the MSL ``INFINITY`` literal (never an unsupported extern
     call or a per-dtype hex pattern). bf16 additionally requires an
     explicit ``(bfloat)`` cast: MSL has no implicit float/half -> bfloat
@@ -421,12 +392,12 @@ def test_infinity_msl_compiles(dtype):
     "dtype", ["float32", "float16", "bfloat16"], ids=["fp32", "fp16", "bf16"]
 )
 def test_runtime_infinity_fill(dtype):
-    """Real MPS execution: a fill with tl.infinity must produce +inf."""
+    """Real MPS execution: a fill with T.infinity must produce +inf."""
     kernel = _compile_metal(_make_infinity_fill_kernel(dtype))
     out = torch.empty(32, dtype=getattr(torch, dtype), device="mps")
     kernel(out)
     torch.mps.synchronize()
-    assert torch.all(out.cpu() == torch.inf), f"fill with tl.infinity({dtype}) != inf"
+    assert torch.all(out.cpu() == torch.inf), f"fill with T.infinity({dtype}) != inf"
 
 
 # ---------------------------------------------------------------------------

--- a/testing/python/metal/test_metal_reduce.py
+++ b/testing/python/metal/test_metal_reduce.py
@@ -24,9 +24,22 @@ diagnostic (naming the step's scale, the offending nt, and the
 threadgroup extent N), and must accept every plan whose nt is a power
 of two <= 32 with N % nt == 0, with all XOR offsets < 32 AND the raw
 [0, N) execution prefix closed under every mask found in the MSL.
+
+Additional coverage in this file:
+  - tl.infinity lowering/offline-MSL legality for fp32/fp16/bf16;
+  - bf16/fp16 reduce lowering (fp32-accumulate path) and offline MSL
+    legality, including the bf16 max INFINITY identity;
+  - clear=False duplicate-buffer update lowering (fp32 + bf16);
+  - multi-block closure (N = k*nt) runtime numerics on MPS;
+  - Reducer v2 (FinalizeReducerOp) fail-loud boundary on Metal.
+All payloads are tiny synthetic tensors; no model weights or downloads.
 """
 
+import os
 import re
+import shutil
+import subprocess
+import tempfile
 
 import pytest
 import torch
@@ -37,7 +50,31 @@ import tilelang.language as T
 from tilelang import tvm as tvm
 
 
-def _make_allreduce_dim0_scale_kernel(reduce_fn, logical_width, scale, threads=None):
+def _metal_toolchain_available() -> bool:
+    """True only when the offline Metal compiler CLI is actually usable.
+
+    ``shutil.which("xcrun")`` alone is not enough: macOS hosts with only
+    CommandLineTools have xcrun but no ``metal`` utility (that ships with
+    Xcode). The runtime MPS tests below are the fallback MSL-validity check
+    on such hosts.
+    """
+    if shutil.which("xcrun") is None:
+        return False
+    try:
+        proc = subprocess.run(
+            ["xcrun", "--find", "metal"], capture_output=True, text=True
+        )
+    except OSError:
+        return False
+    return proc.returncode == 0 and bool(proc.stdout.strip())
+
+
+_HAS_METAL_TOOLCHAIN = _metal_toolchain_available()
+
+
+def _make_allreduce_dim0_scale_kernel(
+    reduce_fn, logical_width, scale, threads=None, dtype="float32", clear=True
+):
     """Copy of the upstream public constructor
     (testing/python/language/test_tilelang_language_reduce.py), used as
     the public construction path for the Metal backend.
@@ -45,21 +82,66 @@ def _make_allreduce_dim0_scale_kernel(reduce_fn, logical_width, scale, threads=N
     Threads default to logical_width * scale (N == nt). Supplying an
     explicit value decouples the threadgroup extent from nt so misaligned
     threadgroups are reachable through the same public constructor.
+
+    ``dtype`` covers the fp32/fp16/bf16 paths; ``clear=False`` exercises
+    the duplicate-buffer update path (Phase 3) that accumulate-into-dst
+    reductions take on Metal.
     """
     if threads is None:
         threads = logical_width * scale
 
     @T.prim_func
     def kernel(
-        A: T.Tensor((logical_width, scale), T.float32),
-        B: T.Tensor((scale,), T.float32),
+        A: T.Tensor((logical_width, scale), dtype),
+        B: T.Tensor((scale,), dtype),
     ):
         with T.Kernel(1, threads=threads):
-            src = T.alloc_fragment((logical_width, scale), T.float32)
-            dst = T.alloc_fragment((scale,), T.float32)
+            src = T.alloc_fragment((logical_width, scale), dtype)
+            dst = T.alloc_fragment((scale,), dtype)
             T.copy(A, src)
-            reduce_fn(src, dst, dim=0)
+            reduce_fn(src, dst, dim=0, clear=clear)
             T.copy(dst, B)
+
+    return kernel
+
+
+def _make_infinity_fill_kernel(dtype):
+    """Tiny fill kernel whose only payload is ``tl.infinity(dtype)``.
+
+    Used to verify that the Metal ``tl.infinity`` lowering folds to a
+    constant ``FloatImm`` and that the codegen emits an MSL-legal
+    ``INFINITY`` literal for fp32, fp16 and bf16 destinations.
+    """
+
+    @T.prim_func
+    def kernel(A: T.Tensor((32,), dtype)):
+        with T.Kernel(1, threads=32):
+            T.fill(A, T.infinity(dtype))
+
+    return kernel
+
+
+def _make_finalize_reducer_v2_kernel():
+    """Minimal reducer-v2 epoch (``T.alloc_reducer`` + ``finalize_reducer``).
+
+    Metal registers no ``FinalizeReducerOp`` implementation upstream, so
+    lowering this kernel must fail loudly instead of silently producing an
+    invalid kernel. This documents the v2 boundary of the PR: only legacy
+    ``T.reduce`` is covered on Metal.
+    """
+
+    @T.prim_func
+    def kernel(A: T.Tensor((8,), T.float32), B: T.Tensor((1,), T.float32)):
+        with T.Kernel(1, threads=32):
+            src = T.alloc_fragment((8,), T.float32)
+            T.copy(A, src)
+            acc = T.alloc_reducer((1,), T.float32, op="sum")
+            T.reducer_init(acc)
+            for i in T.Parallel(8):
+                T.reducer_update(acc[0], src[i])
+            result = T.alloc_fragment((1,), T.float32)
+            T.finalize_reducer(acc, result)
+            T.copy(result, B)
 
     return kernel
 
@@ -96,12 +178,51 @@ def _lower_metal(prim_func):
 
 
 def _compile_metal(prim_func):
+    """Compile for real MPS execution through the supported Metal path.
+
+    TileLang's Metal execution backend is ``torch`` (``torch.mps.compile_shader``,
+    see tilelang/metal/execution_backend.py); the ``tvm_ffi`` backend rejects
+    torch MPS tensors with a device_type mismatch, so runtime tests must use
+    ``execution_backend="torch"``. Compilation of the MSL happens lazily on
+    the first call, which doubles as the device-side MSL legality check
+    (including the bf16 ``INFINITY`` literal).
+    """
     return tilelang.compile(
         prim_func,
         out_idx=-1,
         target="metal",
-        execution_backend="tvm_ffi",
+        execution_backend="torch",
     )
+
+
+def _compile_msl_with_metal_toolchain(src, *, label=""):
+    """Validate generated MSL with the offline Metal compiler (CPU-only).
+
+    This is the GPU-free legality check: it runs ``xcrun metal -c`` on the
+    lowered source and fails the test with the compiler diagnostics if the
+    shader does not parse. It is what catches MSL-invalid literals such as
+    a bf16 ``INFINITY`` that ``torch.mps.compile_shader`` would only reject
+    later at launch time.
+    """
+    assert _HAS_METAL_TOOLCHAIN, "xcrun is required for MSL legality checks"
+    with tempfile.TemporaryDirectory() as tmp:
+        msl_path = os.path.join(tmp, "kernel.metal")
+        air_path = os.path.join(tmp, "kernel.air")
+        with open(msl_path, "w") as f:
+            f.write(src)
+        last_err = ""
+        for std in (None, "osx-metal3.0", "metal3.0"):
+            cmd = ["xcrun", "-sdk", "macosx", "metal", "-c", msl_path, "-o", air_path]
+            if std is not None:
+                cmd.insert(4, f"-std={std}")
+            proc = subprocess.run(cmd, capture_output=True, text=True)
+            if proc.returncode == 0:
+                return
+            last_err = proc.stderr
+        pytest.fail(
+            f"MSL compile failed{(' for ' + label) if label else ''}:\n{last_err}\n"
+            f"--- source ---\n{src}"
+        )
 
 
 @pytest.mark.parametrize(
@@ -243,11 +364,224 @@ def test_runtime_float32_reduction(reduce_fn):
     logical_width, scale = 16, 2
     kernel = _compile_metal(_make_allreduce_dim0_scale_kernel(reduce_fn, logical_width, scale))
     values = torch.linspace(-1.5, 2.0, logical_width * scale, dtype=torch.float32).reshape(logical_width, scale).to("mps")
-    result = kernel(values)
+    result = torch.empty(scale, dtype=torch.float32, device="mps")
+    kernel(values, result)
     torch.mps.synchronize()
 
     reference = values.cpu().sum(dim=0) if reduce_fn is T.reduce_sum else values.cpu().max(dim=0).values
     torch.testing.assert_close(result.cpu(), reference, rtol=1e-5, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# tl.infinity lowering (fp32 / fp16 / bf16)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "dtype", ["float32", "float16", "bfloat16"], ids=["fp32", "fp16", "bf16"]
+)
+def test_infinity_lowers_to_msl_infinity_literal(dtype):
+    """tl.infinity must fold to a constant FloatImm that the Metal codegen
+    prints as the MSL ``INFINITY`` literal (never an unsupported extern
+    call or a per-dtype hex pattern). bf16 additionally requires an
+    explicit ``(bfloat)`` cast: MSL has no implicit float/half -> bfloat
+    conversion, so the bare macro is rejected by the Metal compiler."""
+    src = _lower_metal(_make_infinity_fill_kernel(dtype))
+    assert "INFINITY" in src
+    if dtype == "bfloat16":
+        assert "(bfloat)(INFINITY)" in src
+        assert "(half)(INFINITY)" not in src
+    elif dtype == "float16":
+        assert "(half)(INFINITY)" in src
+        assert "(bfloat)(INFINITY)" not in src
+    else:
+        assert "(bfloat)(INFINITY)" not in src
+        assert "(half)(INFINITY)" not in src
+
+
+@pytest.mark.skipif(
+    not _HAS_METAL_TOOLCHAIN, reason="Metal toolchain (xcrun metal) not available"
+)
+@pytest.mark.parametrize(
+    "dtype", ["float32", "float16", "bfloat16"], ids=["fp32", "fp16", "bf16"]
+)
+def test_infinity_msl_compiles(dtype):
+    """The emitted ``INFINITY`` literal must be accepted by the offline Metal
+    compiler. This is the legality check for the bf16 case in particular:
+    ``bfloat`` has no dedicated MSL infinity literal, so the codegen's bare
+    ``INFINITY`` relies on MSL's implicit float -> bfloat conversion."""
+    _compile_msl_with_metal_toolchain(
+        _lower_metal(_make_infinity_fill_kernel(dtype)), label=f"infinity-{dtype}"
+    )
+
+
+@tilelang.testing.requires_metal
+@pytest.mark.parametrize(
+    "dtype", ["float32", "float16", "bfloat16"], ids=["fp32", "fp16", "bf16"]
+)
+def test_runtime_infinity_fill(dtype):
+    """Real MPS execution: a fill with tl.infinity must produce +inf."""
+    kernel = _compile_metal(_make_infinity_fill_kernel(dtype))
+    out = torch.empty(32, dtype=getattr(torch, dtype), device="mps")
+    kernel(out)
+    torch.mps.synchronize()
+    assert torch.all(out.cpu() == torch.inf), f"fill with tl.infinity({dtype}) != inf"
+
+
+# ---------------------------------------------------------------------------
+# bf16 / fp16 reduce lowering (fp32-accumulate path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("reduce_fn", [T.reduce_sum, T.reduce_max], ids=["sum", "max"])
+@pytest.mark.parametrize("dtype", ["bfloat16", "float16"], ids=["bf16", "fp16"])
+def test_reduce_bf16_fp16_lowers(reduce_fn, dtype):
+    """bf16/fp16 fragment reduces must lower without crashing and keep the
+    same single-simdgroup XOR-butterfly closure as the fp32 path. bf16
+    accumulates in fp32, so the butterfly offsets must still be present in
+    the MSL."""
+    logical_width, scale, threads = 16, 2, 32
+    src = _lower_metal(
+        _make_allreduce_dim0_scale_kernel(reduce_fn, logical_width, scale, threads, dtype=dtype)
+    )
+    if dtype == "bfloat16":
+        assert "bfloat" in src
+    else:
+        assert "half" in src
+    offsets = [int(v) for v in re.findall(r"\^ ?(\d+)", src)]
+    assert offsets, "no XOR butterfly offsets found in MSL"
+    assert all(o < 32 for o in offsets)
+    assert max(offsets) == 16  # nt = extent*scale = 32 -> offsets 16..2
+    assert _xor_closed(offsets, threads)
+    if reduce_fn is T.reduce_max:
+        # max identity is +inf; for bf16 it is materialized in fp32 and
+        # must still print as a legal MSL INFINITY literal.
+        assert "INFINITY" in src
+
+
+@pytest.mark.skipif(
+    not _HAS_METAL_TOOLCHAIN, reason="Metal toolchain (xcrun metal) not available"
+)
+@pytest.mark.parametrize("reduce_fn", [T.reduce_sum, T.reduce_max], ids=["sum", "max"])
+@pytest.mark.parametrize("dtype", ["bfloat16", "float16"], ids=["bf16", "fp16"])
+def test_reduce_bf16_fp16_msl_compiles(reduce_fn, dtype):
+    """Offline MSL legality for the bf16/fp16 reduce path (including the
+    bf16 max INFINITY identity)."""
+    src = _lower_metal(
+        _make_allreduce_dim0_scale_kernel(reduce_fn, 16, 2, 32, dtype=dtype)
+    )
+    _compile_msl_with_metal_toolchain(src, label=f"reduce-{dtype}-{reduce_fn.__name__}")
+
+
+@tilelang.testing.requires_metal
+@pytest.mark.parametrize("reduce_fn", [T.reduce_sum, T.reduce_max], ids=["sum", "max"])
+@pytest.mark.parametrize("dtype", ["bfloat16", "float16"], ids=["bf16", "fp16"])
+def test_runtime_bf16_fp16_reduction(reduce_fn, dtype):
+    """Real MPS execution for bf16/fp16. Small integer payloads keep sums
+    exact in both formats so the comparison is not tolerance-dominated."""
+    logical_width, scale = 16, 2
+    kernel = _compile_metal(
+        _make_allreduce_dim0_scale_kernel(reduce_fn, logical_width, scale, dtype=dtype)
+    )
+    values = torch.arange(1, logical_width * scale + 1, dtype=torch.float32)
+    values = values.reshape(logical_width, scale).to(getattr(torch, dtype)).to("mps")
+    result = torch.empty(scale, dtype=getattr(torch, dtype), device="mps")
+    kernel(values, result)
+    torch.mps.synchronize()
+
+    if reduce_fn is T.reduce_sum:
+        reference = values.cpu().to(torch.float32).sum(dim=0)
+    else:
+        reference = values.cpu().to(torch.float32).max(dim=0).values
+    torch.testing.assert_close(
+        result.cpu().to(torch.float32), reference, rtol=1e-2, atol=1e-2
+    )
+
+
+# ---------------------------------------------------------------------------
+# clear=False (duplicate-buffer update path) and multi-block closures
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", ["float32", "bfloat16"], ids=["fp32", "bf16"])
+def test_reduce_clear_false_lowers(dtype):
+    """clear=False forces the duplicate-buffer Phase-3 update path (and, for
+    bf16, an fp32 accumulator with a final cast back to dst). It must lower
+    without crashing and keep the butterfly closure."""
+    logical_width, scale, threads = 16, 2, 32
+    src = _lower_metal(
+        _make_allreduce_dim0_scale_kernel(
+            T.reduce_sum, logical_width, scale, threads, dtype=dtype, clear=False
+        )
+    )
+    offsets = [int(v) for v in re.findall(r"\^ ?(\d+)", src)]
+    assert offsets, "no XOR butterfly offsets found in MSL"
+    assert all(o < 32 for o in offsets)
+    assert max(offsets) == 16
+    assert _xor_closed(offsets, threads)
+
+
+@pytest.mark.skipif(
+    not _HAS_METAL_TOOLCHAIN, reason="Metal toolchain (xcrun metal) not available"
+)
+def test_reduce_clear_false_bf16_msl_compiles():
+    """Offline MSL legality for the bf16 clear=False update path (fp32
+    accumulator scratch + final bf16 cast)."""
+    src = _lower_metal(
+        _make_allreduce_dim0_scale_kernel(
+            T.reduce_sum, 16, 2, 32, dtype="bfloat16", clear=False
+        )
+    )
+    _compile_msl_with_metal_toolchain(src, label="reduce-clear-false-bf16")
+
+
+@tilelang.testing.requires_metal
+@pytest.mark.parametrize(
+    ("logical_width", "scale", "threads"),
+    [
+        (8, 2, 32),  # nt=16, N = 2*nt: two complete 16-lane closures
+        (2, 4, 32),  # nt=8, N = 4*nt
+        (16, 2, 96),  # nt=32, N = 3*nt
+        (8, 2, 128),  # nt=16, N = 8*nt
+    ],
+    ids=["2x16", "4x8", "3x32", "8x16"],
+)
+@pytest.mark.parametrize("reduce_fn", [T.reduce_sum, T.reduce_max], ids=["sum", "max"])
+def test_runtime_multi_block_closure(reduce_fn, logical_width, scale, threads):
+    """Multi-block closures (N = k*nt complete nt-blocks) must compute the
+    same group totals as a single block: every complete block computes its
+    own copy and the layout owners store once."""
+    kernel = _compile_metal(
+        _make_allreduce_dim0_scale_kernel(reduce_fn, logical_width, scale, threads)
+    )
+    values = torch.linspace(-1.5, 2.0, logical_width * scale, dtype=torch.float32)
+    values = values.reshape(logical_width, scale).to("mps")
+    result = torch.empty(scale, dtype=torch.float32, device="mps")
+    kernel(values, result)
+    torch.mps.synchronize()
+
+    reference = (
+        values.cpu().sum(dim=0)
+        if reduce_fn is T.reduce_sum
+        else values.cpu().max(dim=0).values
+    )
+    torch.testing.assert_close(result.cpu(), reference, rtol=1e-5, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Reducer v2 (FinalizeReducerOp) boundary: unsupported on Metal
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_reducer_v2_rejected_on_metal():
+    """Reducer v2 (``tl.finalize_reducer`` / ``FinalizeReducerOp``) has no
+    Metal implementation upstream, so lowering must fail loudly with the
+    registered-implementation diagnostic instead of emitting an invalid
+    kernel. This PR only covers the legacy ``T.reduce`` path."""
+    with pytest.raises(
+        Exception, match=r"no finalize_reducer implementation is registered"
+    ):
+        _lower_metal(_make_finalize_reducer_v2_kernel())
 
 
 if __name__ == "__main__":

--- a/testing/python/metal/test_metal_reduce.py
+++ b/testing/python/metal/test_metal_reduce.py
@@ -47,8 +47,8 @@ import torch
 import tilelang
 import tilelang.testing
 import tilelang.language as T
+from metal_test_utils import lower_prim_to_metal
 from reduce_test_utils import make_allreduce_dim0_scale_kernel
-from tilelang import tvm as tvm
 
 _make_allreduce_dim0_scale_kernel = make_allreduce_dim0_scale_kernel
 
@@ -135,19 +135,6 @@ def _xor_closed(offsets, n):
     return all(max(tid ^ mask for tid in range(n)) < n for mask in offsets)
 
 
-def _lower_metal(prim_func):
-    target = tvm.target.Target("metal", tvm.target.Target("llvm"))
-    with target:
-        artifact = tilelang.lower(
-            prim_func,
-            target=target,
-            target_host="llvm",
-            enable_host_codegen=False,
-            enable_device_compile=False,
-        )
-    return artifact.kernel_source or ""
-
-
 def _compile_metal(prim_func):
     """Compile for real MPS execution through the supported Metal path.
 
@@ -210,7 +197,7 @@ def test_rejects_nt_gt_32_non_pow2_scale(logical_width, scale, nt):
         match=rf"single-simdgroup.*scale={scale}.*"
         rf"nt = extent\*scale = {nt}.*\b32\b",
     ):
-        _lower_metal(_make_allreduce_dim0_scale_kernel(T.reduce_sum, logical_width, scale))
+        lower_prim_to_metal(_make_allreduce_dim0_scale_kernel(T.reduce_sum, logical_width, scale))
 
 
 @pytest.mark.parametrize(
@@ -231,7 +218,7 @@ def test_rejects_nt_le_32_non_pow2_scale(logical_width, scale, nt):
         match=rf"single-simdgroup.*scale={scale}.*"
         rf"nt = extent\*scale = {nt}.*\b32\b",
     ):
-        _lower_metal(_make_allreduce_dim0_scale_kernel(T.reduce_sum, logical_width, scale))
+        lower_prim_to_metal(_make_allreduce_dim0_scale_kernel(T.reduce_sum, logical_width, scale))
 
 
 @pytest.mark.parametrize(
@@ -249,7 +236,7 @@ def test_rejects_nt_gt_32_pow2_scale(logical_width, scale, nt):
         match=rf"single-simdgroup.*scale={scale}.*"
         rf"nt = extent\*scale = {nt}.*\b32\b",
     ):
-        _lower_metal(_make_allreduce_dim0_scale_kernel(T.reduce_sum, logical_width, scale))
+        lower_prim_to_metal(_make_allreduce_dim0_scale_kernel(T.reduce_sum, logical_width, scale))
 
 
 @pytest.mark.parametrize(
@@ -283,7 +270,7 @@ def test_rejects_misaligned_threadgroup(logical_width, scale, threads, nt):
         rf"nt = extent\*scale = {nt}.*N = {threads}.*"
         rf"not an integer multiple of nt = {nt}",
     ):
-        _lower_metal(_make_allreduce_dim0_scale_kernel(T.reduce_sum, logical_width, scale, threads))
+        lower_prim_to_metal(_make_allreduce_dim0_scale_kernel(T.reduce_sum, logical_width, scale, threads))
 
 
 @pytest.mark.parametrize(
@@ -311,7 +298,7 @@ def test_rejects_misaligned_threadgroup(logical_width, scale, threads, nt):
     ],
 )
 def test_allows_pow2_nt_le_32_closure(logical_width, scale, threads, nt):
-    src = _lower_metal(_make_allreduce_dim0_scale_kernel(T.reduce_sum, logical_width, scale, threads))
+    src = lower_prim_to_metal(_make_allreduce_dim0_scale_kernel(T.reduce_sum, logical_width, scale, threads))
     # every XOR butterfly offset must be < 32 (closure inside one
     # simdgroup; offsets are nt/2 halving down to scale), the max offset
     # must be nt/2, the threadgroup extent must be an integer multiple
@@ -357,7 +344,7 @@ def test_infinity_lowers_to_msl_infinity_literal(dtype):
     call or a per-dtype hex pattern). bf16 additionally requires an
     explicit ``(bfloat)`` cast: MSL has no implicit float/half -> bfloat
     conversion, so the bare macro is rejected by the Metal compiler."""
-    src = _lower_metal(_make_infinity_fill_kernel(dtype))
+    src = lower_prim_to_metal(_make_infinity_fill_kernel(dtype))
     assert "INFINITY" in src
     if dtype == "bfloat16":
         assert "(bfloat)(INFINITY)" in src
@@ -383,7 +370,7 @@ def test_infinity_msl_compiles(dtype):
     explicit ``(bfloat)(INFINITY)`` cast (MSL has no implicit float/half ->
     bfloat conversion)."""
     _compile_msl_with_metal_toolchain(
-        _lower_metal(_make_infinity_fill_kernel(dtype)), label=f"infinity-{dtype}"
+        lower_prim_to_metal(_make_infinity_fill_kernel(dtype)), label=f"infinity-{dtype}"
     )
 
 
@@ -413,7 +400,7 @@ def test_reduce_bf16_fp16_lowers(reduce_fn, dtype):
     accumulates in fp32, so the butterfly offsets must still be present in
     the MSL."""
     logical_width, scale, threads = 16, 2, 32
-    src = _lower_metal(
+    src = lower_prim_to_metal(
         _make_allreduce_dim0_scale_kernel(reduce_fn, logical_width, scale, threads, dtype=dtype)
     )
     if dtype == "bfloat16":
@@ -439,7 +426,7 @@ def test_reduce_bf16_fp16_lowers(reduce_fn, dtype):
 def test_reduce_bf16_fp16_msl_compiles(reduce_fn, dtype):
     """Offline MSL legality for the bf16/fp16 reduce path (including the
     bf16 max INFINITY identity)."""
-    src = _lower_metal(
+    src = lower_prim_to_metal(
         _make_allreduce_dim0_scale_kernel(reduce_fn, 16, 2, 32, dtype=dtype)
     )
     _compile_msl_with_metal_toolchain(src, label=f"reduce-{dtype}-{reduce_fn.__name__}")
@@ -481,7 +468,7 @@ def test_reduce_clear_false_lowers(dtype):
     bf16, an fp32 accumulator with a final cast back to dst). It must lower
     without crashing and keep the butterfly closure."""
     logical_width, scale, threads = 16, 2, 32
-    src = _lower_metal(
+    src = lower_prim_to_metal(
         _make_allreduce_dim0_scale_kernel(
             T.reduce_sum, logical_width, scale, threads, dtype=dtype, clear=False
         )
@@ -499,7 +486,7 @@ def test_reduce_clear_false_lowers(dtype):
 def test_reduce_clear_false_bf16_msl_compiles():
     """Offline MSL legality for the bf16 clear=False update path (fp32
     accumulator scratch + final bf16 cast)."""
-    src = _lower_metal(
+    src = lower_prim_to_metal(
         _make_allreduce_dim0_scale_kernel(
             T.reduce_sum, 16, 2, 32, dtype="bfloat16", clear=False
         )
@@ -553,7 +540,7 @@ def test_finalize_reducer_v2_rejected_on_metal():
     with pytest.raises(
         Exception, match=r"no finalize_reducer implementation is registered"
     ):
-        _lower_metal(_make_finalize_reducer_v2_kernel())
+        lower_prim_to_metal(_make_finalize_reducer_v2_kernel())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem and change

Metal has no target-specific `T.reduce` lowering, so normalization and routing reductions used by Qwen dense, Qwen MoE, and DeepSeek-style workloads cannot compile for Apple GPUs. Add a Metal `ReduceImpl` with fp32 accumulation, uniform barriers, and compile-time checks that keep each XOR butterfly inside a valid simdgroup closure. Also register Metal lowering for `tl.infinity`; other math intrinsics are unchanged.

<sub>Files: `src/metal/op/reduce.cc`, `src/metal/op/math.cc`, and `testing/python/metal/test_metal_reduce.py`.</sub>

## Before and after

On the same Apple M2, `origin/main` cannot lower the 16x2 fp32, 32-thread reduction because no Metal implementation is registered. This PR executes `reduce_sum` and `reduce_max` on MPS and matches the CPU reference within `rtol=1e-5`, `atol=1e-5`.

Performance classification: **Performance enablement**. This is not an isolated `main`-versus-PR speedup because `main` cannot lower the kernel. The following fresh Apple M2 measurements on this PR head use MPS events, three interleaved rounds, 25 warmups, and a 50-launch timing batch; they are downstream evidence enabled by the reduction lowering:

1. Single-token Qwen dense decode: `410.0 us/token` (`195.0 us/token` on the GPU timeline).
2. 64-token Qwen dense decode: `28.3 us/token` (`23.9 us/token` on the GPU timeline), or `14.5x` lower synchronized per-token latency.

## Validation

```text
cmake -S . -B build
cmake --build build -j8
TILELANG_DISABLE_CACHE=1 python -m pytest testing/python/metal/test_metal_reduce.py -q
31 passed
```

Twenty-nine compile/lower cases run on every platform; two numerical cases require MPS and skip elsewhere.

## Scope

Targets the M1-M4 MSL/simdgroup path; the M5 Metal 4 TensorOps/FP8 path is out of scope. Cross-simdgroup, non-power-of-two or misaligned, batched, and deferred reduction plans remain unsupported.

## Appendix: combined campaign results (组合 campaign 结果)

The table below describes the complete Apple M2 optimization campaign, not the isolated contribution or acceptance criteria of this PR. Where `origin/main` cannot execute the workload correctly, a numerical speedup versus `main` is undefined; the nearest valid performance baseline is stated explicitly.

| Representative workload | `origin/main` | End-state result | Valid performance comparison |
|---|---|---|---|
| Qwen dense decode | Cannot lower the required Metal reduction | 64-token: `28.3 us/token` synchronized, `23.9 us/token` GPU timeline | `14.5x` versus the valid single-token path (`410.0 us/token`) |
| Fused Qwen/DeepSeek-style MoE block | Required multi-kernel/ABI path is not correct | 9 launches, `16.92 ms` | `1.21x` versus the previous valid 17-launch composed path (`20.53 ms`) |
| Multi-simdgroup bf16 GEMM | t256 staged output is incorrect | Correct t256 execution | Fragment-C `19.86x`; shared-C `14.16x` versus correct t32 paths |
| Software-packed dense fp8 / expert fp4 QMM | Downstream kernels are not present in `main` | `685.7 us` / `697.4 us` | Dense fp8 `16.9x` versus the initial campaign kernel; expert fp4 `26%` faster than its earlier campaign version |
| End-to-end Mega MoE | Complete path is blocked by missing backend prerequisites | T=64 `114.1 ms`; T=1 `16.7 ms` | `80.8%` / `48.0%` lower latency versus the valid full-pipeline baseline |
