### PR TITLE
[Metal] Harden eager adapter execution and argument binding

### DIFF
--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -116,9 +116,12 @@ void CodeGenTileLangMetal::InitFuncState(const PrimFunc &f) {
 
 CodeGenTileLangMetal::CodeGenTileLangMetal(Target target) : target_(target) {
   restrict_keyword_ = "__restrict";
-  decl_stream << "union __TVMArgUnion {\n"
+  decl_stream << "#ifndef __TILELANG_ARGUNION_DEFINED\n"
+              << "#define __TILELANG_ARGUNION_DEFINED\n"
+              << "union __TVMArgUnion {\n"
               << " int v_int[2];\n"
-              << "};\n\n";
+              << "};\n"
+              << "#endif\n\n";
 }
 
 std::string CodeGenTileLangMetal::Finish() {

--- a/testing/python/metal/test_metal_adapter.py
+++ b/testing/python/metal/test_metal_adapter.py
@@ -1,0 +1,1866 @@
+"""Metal adapter and ABI regression coverage.
+
+Covers the runtime contracts required by local transformer workloads:
+
+- scalar binding: ``out_idx`` + scalar interleave (scalar first/middle/tail x
+  single/multi output) must not crash and must bind correctly on real MPS.
+- dynamic shape: dynamic ``out_idx`` shape resolution keyed by ``tirx.Var`` identity
+  (shared ``T.const``, expression dims like ``N + 1``, multiple outputs,
+  alias/non-alias inputs, undetermined symbol -> explicit error).
+- global buffer: compiler-generated buffers (``T.alloc_global``) bind from the lowered
+  host allocation semantics; ``T.const`` + ``T.empty`` + ``alloc_global``
+  compiles and runs on Metal.
+- launch order: multi-kernel launch plan follows host call-site order (producer ->
+  consumer, reversed function map, repeated same symbol).
+- keepalive: an exception after the first successful enqueue still establishes a
+  completion fence and keeps submitted buffers pinned.
+- completion: completed batches release their strong refs without a second launch
+  (background reaper), including the adapter destruction path.
+
+Every test executes on the real MPS device; failing = ABI/adapter regression.
+"""
+
+import gc
+import threading
+import time
+import weakref
+from unittest import mock
+
+import numpy as np
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+from tvm import tirx
+
+from tilelang import tvm as tvm
+from tilelang.jit.adapter.torch import metal as metal_mod
+from tilelang.jit.adapter.torch.metal import MetalKernelAdapter
+
+pytestmark = pytest.mark.skipif(
+    not torch.backends.mps.is_available(),
+    reason="PyTorch MPS device is required",
+)
+
+MPS = torch.device("mps")
+
+
+def _wait_keepalive_drained(timeout: float = 15.0) -> bool:
+    """Wait until the module-global keepalive queue is empty."""
+    deadline = time.time() + timeout
+    while metal_mod._pending_keepalive:
+        if time.time() > deadline:
+            return False
+        time.sleep(0.02)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# scalar binding: out_idx + scalar interleave — scalar first / middle / tail x
+# single / multi output. All six cases must bind and run on real MPS.
+# ---------------------------------------------------------------------------
+@T.prim_func
+def scalar_binding_scalar_first(S: T.int32, A: T.Tensor((64,), "float32"), OUT: T.Tensor((64,), "float32")):
+    with T.Kernel(64) as bx:
+        OUT[bx] = A[bx] * T.cast(S, T.float32)
+
+
+@T.prim_func
+def scalar_binding_scalar_middle(A: T.Tensor((64,), "float32"), S: T.int32, B: T.Tensor((64,), "float32"), OUT: T.Tensor((64,), "float32")):
+    with T.Kernel(64) as bx:
+        OUT[bx] = A[bx] * T.cast(S, T.float32) + B[bx]
+
+
+@T.prim_func
+def scalar_binding_scalar_tail(A: T.Tensor((64,), "float32"), B: T.Tensor((64,), "float32"), S: T.int32, OUT: T.Tensor((64,), "float32")):
+    with T.Kernel(64) as bx:
+        OUT[bx] = A[bx] + B[bx] + T.cast(S, T.float32)
+
+
+@T.prim_func
+def scalar_binding_multi_scalar_first(
+    S: T.int32,
+    X: T.Tensor((32,), "float32"),
+    Y: T.Tensor((32,), "float32"),
+    OUT1: T.Tensor((32,), "float32"),
+    OUT2: T.Tensor((32,), "float32"),
+):
+    with T.Kernel(32) as bx:
+        OUT1[bx] = X[bx] * T.cast(S, T.float32)
+        OUT2[bx] = Y[bx] / (T.cast(S, T.float32) + 1.0)
+
+
+@T.prim_func
+def scalar_binding_multi_scalar_middle(
+    X: T.Tensor((32,), "float32"),
+    S: T.int32,
+    Y: T.Tensor((32,), "float32"),
+    OUT1: T.Tensor((32,), "float32"),
+    OUT2: T.Tensor((32,), "float32"),
+):
+    with T.Kernel(32) as bx:
+        OUT1[bx] = X[bx] + T.cast(S, T.float32)
+        OUT2[bx] = X[bx] * Y[bx] - T.cast(S, T.float32)
+
+
+@T.prim_func
+def scalar_binding_multi_scalar_tail(
+    X: T.Tensor((32,), "float32"),
+    Y: T.Tensor((32,), "float32"),
+    S: T.int32,
+    OUT1: T.Tensor((32,), "float32"),
+    OUT2: T.Tensor((32,), "float32"),
+):
+    with T.Kernel(32) as bx:
+        OUT1[bx] = X[bx] * 2.0 + T.cast(S, T.float32)
+        OUT2[bx] = Y[bx] * 3.0 - T.cast(S, T.float32)
+
+
+def _scalar_binding_first(S, g):
+    A = g.normal(size=(64,)).astype(np.float32)
+    return (scalar_binding_scalar_first, [2], (S, torch.from_numpy(A).to(MPS)), (A * S,))
+
+
+def _scalar_binding_middle(S, g):
+    A = g.normal(size=(64,)).astype(np.float32)
+    B = g.normal(size=(64,)).astype(np.float32)
+    return (scalar_binding_scalar_middle, [3], (torch.from_numpy(A).to(MPS), S, torch.from_numpy(B).to(MPS)), (A * S + B,))
+
+
+def _scalar_binding_tail(S, g):
+    A = g.normal(size=(64,)).astype(np.float32)
+    B = g.normal(size=(64,)).astype(np.float32)
+    return (scalar_binding_scalar_tail, [3], (torch.from_numpy(A).to(MPS), torch.from_numpy(B).to(MPS), S), (A + B + S,))
+
+
+def _scalar_binding_multi_first(S, g):
+    X = g.normal(size=(32,)).astype(np.float32)
+    Y = g.normal(size=(32,)).astype(np.float32)
+    return (
+        scalar_binding_multi_scalar_first,
+        [3, 4],
+        (S, torch.from_numpy(X).to(MPS), torch.from_numpy(Y).to(MPS)),
+        (X * S, Y / (S + 1.0)),
+    )
+
+
+def _scalar_binding_multi_middle(S, g):
+    X = g.normal(size=(32,)).astype(np.float32)
+    Y = g.normal(size=(32,)).astype(np.float32)
+    return (scalar_binding_multi_scalar_middle, [3, 4], (torch.from_numpy(X).to(MPS), S, torch.from_numpy(Y).to(MPS)), (X + S, X * Y - S))
+
+
+def _scalar_binding_multi_tail(S, g):
+    X = g.normal(size=(32,)).astype(np.float32)
+    Y = g.normal(size=(32,)).astype(np.float32)
+    return (
+        scalar_binding_multi_scalar_tail,
+        [3, 4],
+        (torch.from_numpy(X).to(MPS), torch.from_numpy(Y).to(MPS), S),
+        (X * 2.0 + S, Y * 3.0 - S),
+    )
+
+
+SCALAR_BINDING_CASES = [
+    _scalar_binding_first,
+    _scalar_binding_middle,
+    _scalar_binding_tail,
+    _scalar_binding_multi_first,
+    _scalar_binding_multi_middle,
+    _scalar_binding_multi_tail,
+]
+
+
+@pytest.mark.parametrize("build", SCALAR_BINDING_CASES, ids=["first", "middle", "tail", "multi_first", "multi_middle", "multi_tail"])
+def test_scalar_binding_scalar_interleave_out_idx(build):
+    S = 3
+    g = np.random.default_rng(23)
+    prim, out_idx, call_args, expected = build(S, g)
+    kern = tilelang.compile(prim, out_idx=out_idx, execution_backend="torch", target="metal")
+    got = kern(*call_args)
+    if isinstance(got, (list, tuple)):
+        got = tuple(got)
+    else:
+        got = (got,)
+    torch.mps.synchronize()
+    for g_, e_ in zip(got, expected):
+        err = np.abs(g_.cpu().numpy() - e_).max()
+        assert err < 1e-4, f"[scalar binding {prim.attrs['global_symbol']}] binding mismatch: max_abs_err={err}"
+
+
+# ---------------------------------------------------------------------------
+# dynamic shape: dynamic out_idx shape resolution (Var identity, PrimExpr dims,
+# shared symbols, multiple outputs, alias/non-alias, explicit errors).
+# ---------------------------------------------------------------------------
+@tilelang.jit
+def dynamic_shape_shared_const(A, block: int = 128):
+    N = T.const("N")
+    A: T.Tensor[[N], T.float32]
+    OUT = T.empty([N], dtype=T.float32)
+    with T.Kernel(N, threads=block) as bx:
+        OUT[bx] = A[bx] * 2.0
+    return OUT
+
+
+@tilelang.jit
+def dynamic_shape_expr_dim(A, block: int = 128):
+    N = T.const("N")
+    A: T.Tensor[[N], T.float32]
+    OUT = T.empty([N + 1], dtype=T.float32)
+    with T.Kernel(N + 1, threads=block) as bx:
+        OUT[bx] = A[T.min(bx, N - 1)] * 2.0
+    return OUT
+
+
+@tilelang.jit
+def dynamic_shape_multi_output(X, Y, block: int = 128):
+    N = T.const("N")
+    X: T.Tensor[[N], T.float32]
+    Y: T.Tensor[[N], T.float32]
+    OUT1 = T.empty([N], dtype=T.float32)
+    OUT2 = T.empty([N + 1], dtype=T.float32)
+    with T.Kernel(N, threads=block) as bx:
+        OUT1[bx] = X[bx] + Y[bx]
+    with T.Kernel(N + 1, threads=block) as bx:
+        OUT2[bx] = X[T.min(bx, N - 1)] * Y[T.min(bx, N - 1)]
+    return (OUT1, OUT2)
+
+
+@tilelang.jit
+def dynamic_shape_alias_inputs(X, Y, block: int = 128):
+    N = T.const("N")
+    X: T.Tensor[[N], T.float32]
+    Y: T.Tensor[[N], T.float32]
+    OUT = T.empty([N], dtype=T.float32)
+    with T.Kernel(N, threads=block) as bx:
+        OUT[bx] = X[bx] * Y[bx] + X[bx]
+    return OUT
+
+
+def test_dynamic_shape_dynamic_out_idx_shared_const():
+    a = torch.randn(97, device=MPS)
+    out = dynamic_shape_shared_const(a)
+    torch.mps.synchronize()
+    assert out.shape == (97,)
+    assert torch.allclose(out, a * 2.0, atol=1e-5)
+
+
+def test_dynamic_shape_dynamic_out_idx_expr_dim():
+    a = torch.randn(97, device=MPS)
+    out = dynamic_shape_expr_dim(a)
+    torch.mps.synchronize()
+    assert out.shape == (98,), f"expected N+1=98, got {out.shape}"
+    assert torch.allclose(out[:97], a * 2.0, atol=1e-5)
+    assert out[97].item() == pytest.approx(a[96].item() * 2.0, abs=1e-5)
+
+
+def test_dynamic_shape_dynamic_out_idx_multi_output():
+    x = torch.randn(65, device=MPS)
+    y = torch.randn(65, device=MPS)
+    o1, o2 = dynamic_shape_multi_output(x, y)
+    torch.mps.synchronize()
+    assert o1.shape == (65,)
+    assert o2.shape == (66,)
+    assert torch.allclose(o1, x + y, atol=1e-5)
+    assert torch.allclose(o2[:65], x * y, atol=1e-5)
+
+
+def test_dynamic_shape_dynamic_out_idx_alias_and_non_alias():
+    x = torch.randn(73, device=MPS)
+    # alias: same tensor bound to both inputs
+    out = dynamic_shape_alias_inputs(x, x)
+    torch.mps.synchronize()
+    assert torch.allclose(out, x * x + x, atol=1e-5)
+    # non-alias: distinct tensors
+    y = torch.randn(73, device=MPS)
+    out = dynamic_shape_alias_inputs(x, y)
+    torch.mps.synchronize()
+    assert torch.allclose(out, x * y + x, atol=1e-5)
+
+
+def test_dynamic_shape_undetermined_symbol_raises():
+    # Lazy-style prim_func whose output dim M is not tied to any input:
+    # the launch must fail with an explicit error naming the symbol.
+    N = tirx.Var("N", "int32")
+    M = tirx.Var("M", "int32")
+
+    @T.prim_func
+    def f(A: T.Tensor((N,), "float32"), OUT: T.Tensor((M,), "float32")):
+        with T.Kernel(N) as bx:
+            OUT[bx] = A[bx] * 2.0
+
+    kern = tilelang.compile(f, out_idx=[1], execution_backend="torch", target="metal")
+    a = torch.randn(31, device=MPS)
+    with pytest.raises(RuntimeError, match="not determined by any caller-supplied tensor input shape"):
+        kern(a)
+    torch.mps.synchronize()
+
+
+def test_dynamic_shape_conflicting_symbol_bindings_raise():
+    # The same symbol bound to two inputs with different sizes must be
+    # rejected explicitly instead of silently resolving to one of them.
+    N = tirx.Var("N", "int32")
+
+    @T.prim_func
+    def f(A: T.Tensor((N,), "float32"), B: T.Tensor((N,), "float32"), OUT: T.Tensor((N,), "float32")):
+        with T.Kernel(N) as bx:
+            OUT[bx] = A[bx] + B[bx]
+
+    kern = tilelang.compile(f, out_idx=[2], execution_backend="torch", target="metal")
+    a = torch.randn(17, device=MPS)
+    b = torch.randn(19, device=MPS)
+    with pytest.raises(RuntimeError, match="conflicting sizes"):
+        kern(a, b)
+    torch.mps.synchronize()
+
+
+# ---------------------------------------------------------------------------
+# global buffer: compiler-generated buffers (T.alloc_global) — lazy + eagerjit.
+# ---------------------------------------------------------------------------
+@T.prim_func
+def global_buffer_alloc_global_lazy(A: T.Tensor((97,), "float32"), B: T.Tensor((97,), "float32")):
+    C = T.alloc_global((97,), "float32")
+    with T.Kernel(97) as bx:
+        C[bx] = A[bx] + 1.0
+        B[bx] = C[bx] * 2.0
+
+
+def test_global_buffer_alloc_global_lazy():
+    a = torch.randn(97, device=MPS)
+    kern = tilelang.compile(global_buffer_alloc_global_lazy, out_idx=[1], execution_backend="torch", target="metal")
+    b = kern(a)
+    torch.mps.synchronize()
+    assert torch.allclose(b, (a + 1.0) * 2.0, atol=1e-5)
+
+
+@tilelang.jit
+def global_buffer_alloc_global_eagerjit(A, block_N, dtype):
+    N = T.const("N")
+    A: T.Tensor[[N], dtype]
+    B = T.empty([N], dtype=dtype)
+    C = T.alloc_global([N], dtype)
+    with T.Kernel(T.ceildiv(N, block_N), threads=block_N) as bx:
+        T.copy(A[bx * block_N : (bx + 1) * block_N], C[bx * block_N : (bx + 1) * block_N])
+        T.copy(C[bx * block_N : (bx + 1) * block_N], B[bx * block_N : (bx + 1) * block_N])
+    return B
+
+
+def test_global_buffer_alloc_global_eagerjit():
+    a = torch.randn(1024, device=MPS, dtype=torch.float16)
+    b = global_buffer_alloc_global_eagerjit(a, 128, "float16")
+    torch.mps.synchronize()
+    assert torch.allclose(b, a, rtol=1e-2, atol=1e-2)
+
+
+# ---------------------------------------------------------------------------
+# launch order: launch plan follows host call-site order (producer -> consumer,
+# reversed function map, repeated same symbol).
+# ---------------------------------------------------------------------------
+@T.prim_func
+def launch_order_two_stage(A: T.Tensor((97,), "float32"), B: T.Tensor((97,), "float32"), C: T.Tensor((97,), "float32")):
+    with T.Kernel(97) as bx:
+        B[bx] = A[bx] + 1.0
+    with T.Kernel(97) as bx:
+        C[bx] = B[bx] * 2.0
+
+
+def test_launch_order_producer_consumer_order():
+    a = torch.randn(97, device=MPS)
+    kern = tilelang.compile(launch_order_two_stage, out_idx=[1, 2], execution_backend="torch", target="metal")
+    plan = kern.adapter._launch_plan()
+    assert [s.symbol for s in plan] == ["launch_order_two_stage_kernel", "launch_order_two_stage_kernel_1"]
+    b, c = kern(a)
+    torch.mps.synchronize()
+    assert torch.allclose(b, a + 1.0, atol=1e-5)
+    assert torch.allclose(c, (a + 1.0) * 2.0, atol=1e-5)
+
+
+def test_launch_order_reversed_function_map_still_host_order():
+    """device_mod function-map order reversed vs host call sites: the launch
+    plan must follow the HOST order; following the map would compute C from
+    uninitialized B (NaN) and fail."""
+    kern = tilelang.compile(launch_order_two_stage, out_idx=[1, 2], execution_backend="torch", target="metal")
+    art = kern.artifact
+    funcs = list(art.device_mod.functions.items())
+    assert len(funcs) == 2
+    assert [v.name_hint for v in art.device_mod.functions.keys()] == ["launch_order_two_stage_kernel", "launch_order_two_stage_kernel_1"]
+    rev = tvm.IRModule()
+    rev[funcs[1][0]] = funcs[1][1]  # insert kernel_1 FIRST -> reversed map
+    rev[funcs[0][0]] = funcs[0][1]
+    assert [v.name_hint for v in rev.functions.keys()] == ["launch_order_two_stage_kernel_1", "launch_order_two_stage_kernel"]
+
+    adapter = MetalKernelAdapter(
+        params=art.params,
+        result_idx=[1, 2],
+        func_or_mod=launch_order_two_stage,
+        host_mod=art.host_mod,
+        device_mod=rev,
+        kernel_global_source=art.kernel_source,
+    )
+    plan = adapter._launch_plan()
+    assert [s.symbol for s in plan] == ["launch_order_two_stage_kernel", "launch_order_two_stage_kernel_1"]
+
+    a = torch.randn(97, device=MPS)
+    b, c = adapter(a)
+    torch.mps.synchronize()
+    assert torch.allclose(b, a + 1.0, atol=1e-5)
+    assert torch.allclose(c, (a + 1.0) * 2.0, atol=1e-5)
+
+
+@T.prim_func
+def launch_order_repeated_symbol(A: T.Tensor((97,), "float32"), OUT: T.Tensor((97,), "float32")):
+    for _it in T.serial(2):
+        with T.Kernel(97) as bx:
+            OUT[bx] = A[bx] + 1.0
+
+
+def test_launch_order_repeated_same_symbol():
+    kern = tilelang.compile(launch_order_repeated_symbol, out_idx=[1], execution_backend="torch", target="metal")
+    plan = kern.adapter._launch_plan()
+    assert len(plan) == 2, "duplicate host call sites must be preserved"
+    assert plan[0].symbol == plan[1].symbol == "launch_order_repeated_symbol_kernel"
+    a = torch.randn(97, device=MPS)
+    out = kern(a)
+    torch.mps.synchronize()
+    assert torch.allclose(out, a + 1.0, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# keepalive: exception after the first successful enqueue still establishes a
+# completion fence and pins the submitted buffers.
+# ---------------------------------------------------------------------------
+def test_keepalive_aborted_launch_pins_submitted_buffers():
+    real_compile_shader = torch.mps.compile_shader
+    call_count = {"n": 0}
+
+    class _RaisingModule:
+        def __init__(self, mod):
+            self._mod = mod
+
+        def __getattr__(self, name):
+            fn = getattr(self._mod, name)
+
+            def _wrapped(*args, **kwargs):
+                call_count["n"] += 1
+                if call_count["n"] == 2:
+                    raise RuntimeError("injected second-launch failure")
+                return fn(*args, **kwargs)
+
+            return _wrapped
+
+    def _compile_wrapper(source):
+        return _RaisingModule(real_compile_shader(source))
+
+    with mock.patch("torch.mps.compile_shader", side_effect=_compile_wrapper):
+        kern = tilelang.compile(launch_order_two_stage, out_idx=[1, 2], execution_backend="torch", target="metal")
+
+    a = torch.randn(97, device=MPS)
+    with pytest.raises(RuntimeError, match="injected second-launch failure"):
+        kern(a)
+    # The first kernel was enqueued successfully: the batch must be pinned
+    # (fence + strong refs) even though the launcher raised.
+    assert metal_mod._pending_keepalive, "submitted buffers must stay pinned after an aborted launch"
+    assert _wait_keepalive_drained(), "completion fence must fire and release the pinned batch"
+    torch.mps.synchronize()
+
+
+def test_keepalive_temporary_output_stress():
+    """Caller-supplied outputs dropped immediately after launch:
+    every batch must stay pinned across many launches, with no caller strong
+    reference left behind."""
+    kern = tilelang.compile(completion_inplace, execution_backend="torch", target="metal")
+    a = torch.randn(64, device=MPS)
+    # Pause the reaper and neutralize the release helper so pinning is
+    # observable while batches are pending: no drain can release the current
+    # batch before the assertion runs.
+    orig_release = metal_mod._release_finished_work
+    orig_poll = metal_mod._KEEPALIVE_POLL_SECONDS
+    metal_mod._release_finished_work = lambda: None
+    metal_mod._KEEPALIVE_POLL_SECONDS = 3600.0
+    weaks = []
+    try:
+        for i in range(30):
+            # Vary the input to defeat allocator-caching aliasing.
+            a.mul_(1.0 + i * 1e-6)
+            a_i = a.clone()
+            out = torch.empty(64, device=MPS)
+            weaks.append(weakref.ref(out))
+            kern(a, out)
+            # No caller strong reference remains: the keepalive batch is the
+            # ONLY strong ref. While the batch is pending the temp must be
+            # alive (proves the allocator cannot reuse its memory), and it
+            # must be the *current* batch (the pre-launch drain released the
+            # previous one).
+            del out
+            assert metal_mod._pending_keepalive, f"iter {i}: batch must be pending"
+            assert weaks[-1]() is not None, f"iter {i}: temp dropped while pending"
+            assert torch.allclose(a, a_i, atol=0.0), f"iter {i}: input drift"
+    finally:
+        metal_mod._release_finished_work = orig_release
+        metal_mod._KEEPALIVE_POLL_SECONDS = orig_poll
+        metal_mod._reaper_wakeup.set()
+    # Restored reaper: every batch releases once its event fires, and the
+    # temps are freed without any second launch.
+    assert _wait_keepalive_drained(), "all batches must be released after completion"
+    torch.mps.synchronize()
+    gc.collect()
+    for i, w in enumerate(weaks):
+        assert w() is None, f"iter {i}: temp must be released after completion"
+    # The last output is still numerically correct end to end.
+    out_last = torch.empty(64, device=MPS)
+    kern(a, out_last)
+    torch.mps.synchronize()
+    assert torch.allclose(out_last, a + 1.0, atol=1e-5)
+    del weaks
+    gc.collect()
+
+
+# ---------------------------------------------------------------------------
+# completion: completed batches release strong refs without a second launch.
+# ---------------------------------------------------------------------------
+@T.prim_func
+def completion_inplace(A: T.Tensor((64,), "float32"), OUT: T.Tensor((64,), "float32")):
+    with T.Kernel(64) as bx:
+        OUT[bx] = A[bx] + 1.0
+
+
+def test_completion_releases_without_second_launch():
+    kern = tilelang.compile(completion_inplace, execution_backend="torch", target="metal")
+    a = torch.randn(64, device=MPS)
+    out = torch.zeros(64, device=MPS)
+    weak = weakref.ref(out)
+    kern(a, out)
+    torch.mps.synchronize()
+    del out
+    gc.collect()
+    # No second launch: the background reaper must release the batch.
+    assert _wait_keepalive_drained(), "batch must be released by the reaper, not by a next launch"
+    gc.collect()
+    assert weak() is None, "adapter must not hold the output tensor after completion"
+
+
+def test_completion_adapter_destruction_path():
+    kern = tilelang.compile(completion_inplace, execution_backend="torch", target="metal")
+    a = torch.randn(64, device=MPS)
+    out = torch.zeros(64, device=MPS)
+    weak = weakref.ref(out)
+    kern(a, out)
+    torch.mps.synchronize()
+    del out
+    del kern
+    gc.collect()
+    assert _wait_keepalive_drained(), "global queue must be reaped after adapter destruction"
+    gc.collect()
+    assert weak() is None
+
+
+def test_completion_sequential_launches_do_not_accumulate():
+    kern = tilelang.compile(completion_inplace, execution_backend="torch", target="metal")
+    a = torch.randn(64, device=MPS)
+    for i in range(5):
+        out = torch.zeros(64, device=MPS)
+        kern(a, out)
+        assert out[0].item() == pytest.approx(a[0].item() + 1.0, abs=1e-5)
+        del out
+        gc.collect()
+        assert _wait_keepalive_drained(), f"queue must drain after launch {i}"
+    torch.mps.synchronize()
+
+
+# ---------------------------------------------------------------------------
+# Host call-site args are consumed per site,
+# keepalive reaping is batch-atomic, host control flow is static-only, and
+# the destruction path has weakref/finalizer evidence.
+# ---------------------------------------------------------------------------
+@T.prim_func
+def host_plan_loop_carried(A: T.Tensor((97,), "float32"), OUT: T.Tensor((98,), "float32")):
+    for _it in T.serial(2):
+        with T.Kernel(96 + _it) as bx:
+            OUT[bx] = A[bx] + T.cast(_it, T.float32)
+
+
+def test_host_plan_loop_carried_args_and_geometry():
+    """A repeated symbol called with different loop-carried
+    scalar arguments and different per-site geometry. The loop variable must
+    be substituted into the call-site function args and launch args, and the
+    writes are non-idempotent (iter 1 overwrites iter 0 with +1.0)."""
+    # No out_idx: the caller supplies OUT explicitly, so the never-written
+    # tail element can be deterministically initialized.
+    kern = tilelang.compile(host_plan_loop_carried, execution_backend="torch", target="metal")
+    plan = kern.adapter._launch_plan()
+    assert len(plan) == 2, "constant loop must expand to two call sites"
+    assert plan[0].symbol == plan[1].symbol == "host_plan_loop_carried_kernel"
+    # Per-site geometry from the substituted launch args: 96 then 97
+    # (evaluated at launch time by the same resolver the launcher uses).
+    analyzer = tvm.arith.Analyzer()
+    assert metal_mod._resolve_int_value(plan[0].grid[0], {}, analyzer) == 96
+    assert metal_mod._resolve_int_value(plan[1].grid[0], {}, analyzer) == 97
+    # Per-site scalar args: the loop var becomes const 0 then const 1.
+    assert [b.value for b in plan[0].bindings if b.kind == "const"] == [0]
+    assert [b.value for b in plan[1].bindings if b.kind == "const"] == [1]
+    # Numeric: the second launch (grid 97) overwrites [0, 97) with A+1.
+    a = torch.randn(97, device=MPS)
+    # Deterministic tail element: the adapter-owned
+    # `torch.empty` output would leave out[97] uninitialized, so pass an
+    # explicitly zeroed OUT; the never-written element then has defined
+    # contents and the assertion cannot flake on allocator reuse.
+    out = torch.zeros(98, device=MPS)
+    kern(a, out)
+    torch.mps.synchronize()
+    assert torch.allclose(out[:97], a + 1.0, atol=1e-5)
+    assert out[97].item() == 0.0  # never written: defined by the caller init
+
+
+HOST_PLAN_N1 = tirx.Var("N", "int32")  # same name, first identity
+HOST_PLAN_N2 = tirx.Var("N", "int32")  # same name, second identity
+
+
+@T.prim_func
+def host_plan_same_name_vars(
+    A: T.Tensor((HOST_PLAN_N2,), "float32"),
+    B: T.Tensor((HOST_PLAN_N1,), "float32"),
+    OUT: T.Tensor((HOST_PLAN_N1,), "float32"),
+):
+    with T.Kernel(HOST_PLAN_N1) as bx:
+        OUT[bx] = B[bx] * 2.0
+
+
+def test_host_plan_same_name_distinct_identity_vars():
+    """Two tirx.Vars with the same name but different identity.
+    The symbol binding must use Var identity (grid + device scalar resolve to
+    HOST_PLAN_N1 = 5), not the first string match (which would pick HOST_PLAN_N2 = 9)."""
+    kern = tilelang.compile(host_plan_same_name_vars, out_idx=[2], execution_backend="torch", target="metal")
+    plan = kern.adapter._launch_plan()
+    site = plan[0]
+    sym_bindings = [b for b in site.bindings if b.kind == "symbol"]
+    assert len(sym_bindings) == 1
+    assert sym_bindings[0].symbol.same_as(HOST_PLAN_N1), "symbol must keep Var identity"
+    assert site.grid[0].same_as(HOST_PLAN_N1), "geometry must carry Var identity"
+
+    # Mocked launch: the geometry must be 5 (HOST_PLAN_N1), not 9 (HOST_PLAN_N2).
+    captured = {}
+
+    class _MockFn:
+        def __call__(self, *fn_args, **kwargs):
+            captured["args"] = fn_args
+            captured["threads"] = kwargs["threads"]
+            captured["group_size"] = kwargs["group_size"]
+
+    class _MockModule:
+        def __getattr__(self, name):
+            return _MockFn()
+
+    with mock.patch("torch.mps.compile_shader", return_value=_MockModule()):
+        kern_mock = tilelang.compile(host_plan_same_name_vars, out_idx=[2], execution_backend="torch", target="metal")
+    a9 = torch.randn(9, device=MPS)
+    b5 = torch.randn(5, device=MPS)
+    kern_mock(a9, b5)
+    assert captured["threads"] == [5 * 128, 1, 1], f"geometry must use HOST_PLAN_N1=5, got {captured['threads']}"
+    packed = [x for x in captured["args"] if isinstance(x, torch.Tensor) and x.dtype == torch.uint8]
+    assert len(packed) == 1, "exactly one packed args_t scalar buffer expected"
+    slot0 = int(packed[0].cpu().numpy().view("<i4")[0])
+    assert slot0 == 5, f"device scalar must be HOST_PLAN_N1=5, got {slot0}"
+
+    # Real MPS end to end: same geometry, correct values.
+    out = kern(a9, b5)
+    torch.mps.synchronize()
+    assert out.shape == (5,)
+    assert torch.allclose(out, b5 * 2.0, atol=1e-5)
+
+
+@T.prim_func
+def host_plan_cond_branch(A: T.Tensor((97,), "float32"), OUT: T.Tensor((97,), "float32")):
+    for _it in T.serial(2):
+        if _it == 0:
+            with T.Kernel(97) as bx:
+                OUT[bx] = A[bx] + 1.0
+        else:
+            with T.Kernel(97) as bx:
+                OUT[bx] = A[bx] * 2.0 + 1.0
+
+
+def test_host_plan_static_conditional_taken_branch_only():
+    """An IfThenElse whose condition is resolved by the substituted
+    loop variable must walk only its taken branch (2 sites, not 4)."""
+    kern = tilelang.compile(host_plan_cond_branch, out_idx=[1], execution_backend="torch", target="metal")
+    plan = kern.adapter._launch_plan()
+    assert len(plan) == 2, f"one branch per iteration expected, got {len(plan)} sites"
+    assert plan[0].symbol == "host_plan_cond_branch_kernel"  # iter 0: then (A+1)
+    assert plan[1].symbol == "host_plan_cond_branch_kernel_1"  # iter 1: else (A*2+1)
+    a = torch.randn(97, device=MPS)
+    out = kern(a)
+    torch.mps.synchronize()
+    assert torch.allclose(out, a * 2.0 + 1.0, atol=1e-5)
+
+
+def test_host_plan_runtime_conditional_plan_build_error():
+    """A conditional depending on a runtime value must be rejected
+    at plan build time, never silently executed as both branches."""
+    N = tirx.Var("N", "int32")
+
+    @T.prim_func
+    def f(A: T.Tensor((N,), "float32"), OUT: T.Tensor((N,), "float32")):
+        if N > 10:
+            with T.Kernel(N) as bx:
+                OUT[bx] = A[bx] + 1.0
+        else:
+            with T.Kernel(N) as bx:
+                OUT[bx] = A[bx] * 2.0
+
+    with pytest.raises(RuntimeError, match="cannot be resolved statically"):
+        tilelang.compile(f, out_idx=[1], execution_backend="torch", target="metal")
+
+
+def test_host_plan_runtime_loop_plan_build_error():
+    """A loop with runtime-dependent bounds must be rejected at
+    plan build time."""
+    N = tirx.Var("N", "int32")
+
+    @T.prim_func
+    def f(A: T.Tensor((N,), "float32"), OUT: T.Tensor((N,), "float32")):
+        for _i in T.serial(N):
+            with T.Kernel(N) as bx:
+                OUT[bx] = A[bx] + 1.0
+
+    with pytest.raises(RuntimeError, match="non-constant bounds"):
+        tilelang.compile(f, out_idx=[1], execution_backend="torch", target="metal")
+
+
+def test_host_plan_call_site_args_swapped_binding():
+    """The host calls the kernel with swapped buffer
+    arguments (OUT, A) while the device parameters are (A, OUT). The plan
+    must bind device param 0 to the call site's first actual argument (OUT,
+    slot 1) and device param 1 to A (slot 0) -- never by device-parameter
+    name."""
+    kern = tilelang.compile(completion_inplace, execution_backend="torch", target="metal")
+    art = kern.artifact
+    device_mod = art.device_mod
+    assert "completion_inplace_kernel" in device_mod
+
+    # Synthetic host module: FFI-style prologue binds handle Vars to args
+    # slots, then calls the kernel with swapped buffers (OUT first, A second).
+    struct_get = tvm.ir.Op.get("tirx.tvm_struct_get")
+    call_packed = tvm.ir.Op.get("tirx.tvm_call_packed")
+    args_var = tirx.Var("args", "handle")
+
+    def sg(struct, index, field, dtype="handle"):
+        index_e = index if isinstance(index, tirx.Var) else tirx.IntImm("int32", index)
+        return tirx.Call(
+            tvm.DataType(dtype),
+            struct_get,
+            [struct, index_e, tirx.IntImm("int32", field)],
+        )
+
+    a_h = tirx.Var("A_handle", "handle")
+    out_h = tirx.Var("OUT_handle", "handle")
+    a = tirx.Var("A", "handle")
+    out = tirx.Var("OUT", "handle")
+    call = tirx.Call(
+        tvm.DataType("int32"),
+        call_packed,
+        [
+            tirx.StringImm("completion_inplace_kernel"),
+            out,  # swapped: device param 0 (A) receives OUT's buffer
+            a,  # swapped: device param 1 (OUT) receives A's buffer
+            tirx.IntImm("int32", 64),
+            tirx.IntImm("int32", 128),
+            tirx.IntImm("int32", 1),
+            tirx.IntImm("int32", 1),
+        ],
+    )
+    host_func = tirx.PrimFunc(
+        [
+            tirx.Var("self_handle", "handle"),
+            args_var,
+            tirx.Var("num_args", "int32"),
+            tirx.Var("result", "handle"),
+        ],
+        tirx.SeqStmt(
+            [
+                tirx.Bind(a_h, sg(args_var, 0, 15)),
+                tirx.Bind(out_h, sg(args_var, 1, 15)),
+                tirx.Bind(a, sg(a_h, 0, 1)),
+                tirx.Bind(out, sg(out_h, 0, 1)),
+                tirx.Evaluate(call),
+            ]
+        ),
+    ).with_attr("tirx.is_entry_func", True)
+    host_mod = tvm.IRModule({tvm.ir.GlobalVar("completion_inplace_swapped"): host_func})
+
+    adapter = MetalKernelAdapter(
+        params=art.params,
+        result_idx=[1],
+        func_or_mod=completion_inplace,
+        host_mod=host_mod,
+        device_mod=device_mod,
+        kernel_global_source=art.kernel_source,
+    )
+    plan = adapter._launch_plan()
+    assert len(plan) == 1
+    bindings = plan[0].bindings
+    assert len(bindings) == 2, "device params (A, OUT)"
+    assert bindings[0].kind == "user" and bindings[0].param_index == 1, (
+        "device param A must bind the call site's first actual arg (OUT slot 1)"
+    )
+    assert bindings[1].kind == "user" and bindings[1].param_index == 0, (
+        "device param OUT must bind the call site's second actual arg (A slot 0)"
+    )
+
+
+class _RendezvousEvent:
+    """Fake event: query() blocks until two threads have both arrived, then
+    returns a fixed answer. Extra arrivals (e.g. a racing reaper) are
+    harmless."""
+
+    def __init__(self, done):
+        self._done = done
+        self._lock = threading.Lock()
+        self._arrived = 0
+        self._go = threading.Event()
+
+    def query(self):
+        with self._lock:
+            self._arrived += 1
+            if self._arrived >= 2:
+                self._go.set()
+        assert self._go.wait(timeout=10), "rendezvous timeout"
+        return self._done
+
+
+def test_host_plan_concurrent_release_race():
+    """Two threads release finished work concurrently. Both observe
+    the completed head batch before either removes it; the still-running next
+    batch must survive (never double-popleft)."""
+    orig_release = metal_mod._release_finished_work
+    orig_poll = metal_mod._KEEPALIVE_POLL_SECONDS
+    # Pause/neutralize the background reaper so only our two threads act.
+    metal_mod._release_finished_work = lambda: None
+    metal_mod._KEEPALIVE_POLL_SECONDS = 3600.0
+    saved = list(metal_mod._pending_keepalive)
+    try:
+        ev0 = _RendezvousEvent(True)  # head batch: finished
+        ev1 = _RendezvousEvent(False)  # next batch: still running
+        metal_mod._pending_keepalive.clear()
+        metal_mod._pending_keepalive.append(((object(),), ev0))
+        metal_mod._pending_keepalive.append(((object(),), ev1))
+
+        errors = []
+
+        def worker():
+            try:
+                orig_release()
+            except Exception as exc:  # pragma: no cover - failure path
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(2)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+        assert not errors, f"release threads raised: {errors}"
+        remaining = list(metal_mod._pending_keepalive)
+        assert len(remaining) == 1, f"exactly the unfinished batch must remain, got {len(remaining)}"
+        assert remaining[0][1] is ev1, "the unfinished batch was released early"
+    finally:
+        metal_mod._pending_keepalive.clear()
+        metal_mod._pending_keepalive.extend(saved)
+        metal_mod._release_finished_work = orig_release
+        metal_mod._KEEPALIVE_POLL_SECONDS = orig_poll
+
+
+class _RaisingEvent:
+    def query(self):
+        raise RuntimeError("injected query failure")
+
+
+def test_host_plan_query_error_sync_transition_drops_batch():
+    """A head-of-line query exception must not pin the queue
+    forever -- synchronize() proves completion and the batch is dropped."""
+    orig_release = metal_mod._release_finished_work
+    orig_poll = metal_mod._KEEPALIVE_POLL_SECONDS
+    metal_mod._release_finished_work = lambda: None
+    metal_mod._KEEPALIVE_POLL_SECONDS = 3600.0
+    saved = list(metal_mod._pending_keepalive)
+    try:
+        metal_mod._pending_keepalive.clear()
+        metal_mod._pending_keepalive.append(((object(),), _RaisingEvent()))
+        with mock.patch("torch.mps.synchronize", return_value=None):
+            orig_release()
+        assert not metal_mod._pending_keepalive, "query error + sync must drop the batch"
+        assert not metal_mod._stuck_keepalive
+    finally:
+        metal_mod._pending_keepalive.clear()
+        metal_mod._pending_keepalive.extend(saved)
+        metal_mod._release_finished_work = orig_release
+        metal_mod._KEEPALIVE_POLL_SECONDS = orig_poll
+
+
+class _FlakyEvent:
+    """query() fails twice (teardown-style), then reports completion."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def query(self):
+        self.calls += 1
+        if self.calls <= 2:
+            raise RuntimeError("transient query failure")
+        return True
+
+
+def test_host_plan_query_error_sync_failure_pins_stuck_then_retries():
+    """When both query() and synchronize() fail during MPS teardown,
+    the batch must stay pinned but leave the head-of-line path (stuck list);
+    a later successful query releases it."""
+    orig_release = metal_mod._release_finished_work
+    orig_poll = metal_mod._KEEPALIVE_POLL_SECONDS
+    metal_mod._release_finished_work = lambda: None
+    metal_mod._KEEPALIVE_POLL_SECONDS = 3600.0
+    saved = list(metal_mod._pending_keepalive)
+    try:
+        metal_mod._pending_keepalive.clear()
+        flaky = _FlakyEvent()
+        metal_mod._pending_keepalive.append(((object(),), flaky))
+        with mock.patch("torch.mps.synchronize", side_effect=RuntimeError("sync failed")):
+            orig_release()
+        assert not metal_mod._pending_keepalive, "stuck batch leaves the active queue"
+        assert len(metal_mod._stuck_keepalive) == 1, "batch stays pinned in the stuck list"
+        # Next drain: query now succeeds -> released from the stuck list.
+        orig_release()
+        assert not metal_mod._stuck_keepalive, "stuck batch must be released on retry"
+        assert flaky.calls >= 3
+    finally:
+        metal_mod._pending_keepalive.clear()
+        metal_mod._stuck_keepalive.clear()
+        metal_mod._pending_keepalive.extend(saved)
+        metal_mod._release_finished_work = orig_release
+        metal_mod._KEEPALIVE_POLL_SECONDS = orig_poll
+
+
+def test_host_plan_adapter_destruction_weakref_finalizer():
+    """The adapter's destruction path is provable: the object
+    must be collectable after `del kern` with weakref + finalizer evidence
+    (the launcher closure must not capture the adapter)."""
+    kern = tilelang.compile(completion_inplace, execution_backend="torch", target="metal")
+    adapter = kern.adapter
+    weak = weakref.ref(adapter)
+    fired = []
+    finalizer = weakref.finalize(adapter, lambda: fired.append(True))
+    del adapter
+    del kern
+    gc.collect()
+    assert weak() is None, "adapter must be collectable after kernel deletion"
+    assert fired == [True], "adapter finalizer must run (provable __del__ path)"
+    del finalizer
+    gc.collect()
+
+
+@tilelang.jit
+def host_plan_k1_broadcast(w, block: int = 64):
+    T_ = T.const("T_")
+    w: T.Tensor[[T_, 1], T.float32]
+    OUT = T.empty([T_], dtype=T.float32)
+    with T.Kernel(T_, threads=block) as bx:
+        OUT[bx] = w[bx, 0] * 2.0
+    return OUT
+
+
+def test_host_plan_rank1_fed_to_trailing_singleton_param():
+    """A flat (m,) tensor fed to a declared (T_, 1) param is valid (torch
+    right-aligned broadcasting; flat memory identical) and must not trip the
+    scalar binding rank check."""
+    w = torch.randn(7, device=MPS)
+    out = host_plan_k1_broadcast(w)
+    torch.mps.synchronize()
+    assert out.shape == (7,)
+    assert torch.allclose(out, w * 2.0, atol=1e-5)
+
+
+def test_host_plan_rank_mismatch_non_singleton_still_raises():
+    """The trailing-singleton relaxation must NOT accept a rank-1 tensor for
+    a declared (T_, 2) param."""
+    T_ = tirx.Var("T_", "int32")
+
+    @T.prim_func
+    def f(W: T.Tensor((T_, 2), "float32"), OUT: T.Tensor((T_,), "float32")):
+        with T.Kernel(T_) as bx:
+            OUT[bx] = W[bx, 0] * 2.0
+
+    kern = tilelang.compile(f, out_idx=[1], execution_backend="torch", target="metal")
+    w = torch.randn(7, device=MPS)
+    with pytest.raises(RuntimeError, match="declared rank 2"):
+        kern(w)
+    torch.mps.synchronize()
+
+
+# ---------------------------------------------------------------------------
+# Retained-prefix dimension validation for trailing-singleton rank relaxation,
+# nested static host loops, and deterministic output initialization.
+# ---------------------------------------------------------------------------
+def test_adapter_expr_rank_relax_rejects_retained_prefix_mismatch():
+    """A declared (7, 1) parameter fed a (3,) tensor must
+    be REJECTED.  The trailing 1 may be implicit, but the retained prefix (7)
+    must equal the actual extent (3); accepting it would launch static
+    geometry 7 over a three-element buffer (GPU out-of-bounds).  The
+    rejection happens BEFORE any kernel launch: the mocked module observes
+    zero calls (out-of-bounds guard)."""
+
+    @T.prim_func
+    def f(W: T.Tensor((7, 1), "float32"), OUT: T.Tensor((7,), "float32")):
+        with T.Kernel(7) as bx:
+            OUT[bx] = W[bx, 0] * 2.0
+
+    class _MockFn:
+        def __call__(self, *fn_args, **kwargs):
+            raise AssertionError("kernel must not be launched for a mismatched shape")
+
+    class _MockModule:
+        def __getattr__(self, name):
+            return _MockFn()
+
+    with mock.patch("torch.mps.compile_shader", return_value=_MockModule()):
+        kern = tilelang.compile(f, out_idx=[1], execution_backend="torch", target="metal")
+    w = torch.randn(3, device=MPS)
+    with pytest.raises(RuntimeError, match="declared dimension"):
+        kern(w)
+    torch.mps.synchronize()
+
+
+def test_adapter_expr_rank_matched_capacity_pattern_allowed():
+    """Qwen MoE scope guard: a rank-matched declared
+    capacity upper bound (64) fed a smaller actual tensor (15) is the legal
+    padded/masked pattern (the kernel's accesses are internally
+    masked/offset-guarded, so declared >= actual is safe and must NOT be
+    rejected). The capacity dim must be explicitly declared
+    (``T.annotate_capacity_dims``); without the declaration the same call
+    is rejected (see ``test_capacity_eager_scalar_param_dim_unmarked_rejected``).
+    Numerically: the masked kernel computes exactly the actual region and
+    never touches the rest."""
+
+    @tilelang.jit
+    def masked_kernel(a, cap, m, block: int = 32):
+        a: T.Tensor[[cap], T.float32]
+        OUT = T.empty([cap], dtype=T.float32)
+        T.annotate_capacity_dims({"a": (0,)})
+        with T.Kernel(cap, threads=block) as bx:
+            if bx < m:  # masked: only the actual m elements are accessed
+                OUT[bx] = a[bx] * 2.0
+        return OUT
+
+    a = torch.randn(15, device=MPS)
+    out = masked_kernel(a, 64, 15)  # declared (64,), actual (15,)
+    torch.mps.synchronize()
+    assert out.shape == (64,), "declared capacity shape is kept"
+    assert torch.allclose(out[:15], a * 2.0, atol=1e-5)
+    # No scalar-arg packing involved (all baked at compile time): the tail
+    # is never written, so a second call with the full capacity is also fine.
+    a64 = torch.randn(64, device=MPS)
+    out64 = masked_kernel(a64, 64, 64)
+    torch.mps.synchronize()
+    assert torch.allclose(out64, a64 * 2.0, atol=1e-5)
+
+
+def test_adapter_expr_rank_relax_expression_prefix_validation():
+    """A retained general-expression dimension (N + 1) must be
+    validated against the actual extent after N is bound by another input:
+    with A binding N=3, a (3,) tensor for W (declared N+1=4 != 3) is
+    rejected, and a (4,) tensor (N+1=4) is accepted end to end."""
+    N = tirx.Var("N", "int32")
+
+    @T.prim_func
+    def f(
+        A: T.Tensor((N,), "float32"),
+        W: T.Tensor((N + 1, 1), "float32"),
+        OUT: T.Tensor((N,), "float32"),
+    ):
+        with T.Kernel(N) as bx:
+            OUT[bx] = A[bx] + W[bx, 0]
+
+    kern = tilelang.compile(f, out_idx=[2], execution_backend="torch", target="metal")
+    a = torch.randn(3, device=MPS)  # binds N = 3 -> declared W prefix N+1 = 4
+    # Wrong extent: N+1 = 4 != 3 must be rejected.
+    w_bad = torch.randn(3, device=MPS)
+    with pytest.raises(RuntimeError, match="declared dimension"):
+        kern(a, w_bad)
+    torch.mps.synchronize()
+    # Legal: N=3 -> declared N+1=4 matches a (4,) tensor.
+    w_ok = torch.randn(4, device=MPS)
+    out = kern(a, w_ok)
+    torch.mps.synchronize()
+    assert out.shape == (3,)
+    assert torch.allclose(out, a + w_ok[:3], atol=1e-5)
+
+
+def test_adapter_expr_legal_broadcast_variants_pass():
+    """The legal torch right-aligned broadcast shapes
+    for a declared (T_, 1) param must all pass: (m,) and (m, 1)."""
+    w = torch.randn(7, device=MPS)
+    assert torch.allclose(host_plan_k1_broadcast(w), w * 2.0, atol=1e-5)
+    torch.mps.synchronize()
+    w2 = w.view(7, 1)
+    assert torch.allclose(host_plan_k1_broadcast(w2), w * 2.0, atol=1e-5)
+    torch.mps.synchronize()
+
+
+@T.prim_func
+def adapter_expr_nested_static_loops(A: T.Tensor((64,), "float32"), OUT: T.Tensor((64,), "float32")):
+    # Loop vars are carried through the LAUNCH GEOMETRY only (not as scalar
+    # kernel args): per-site grid = 8 + i + j.  (Runtime multi-scalar args
+    # are tested separately below; this kernel isolates static expansion and
+    # per-site substitution through launch geometry.)
+    for _i in T.serial(2, 4):  # outer: min=2 (nonzero), extent=2
+        for _j in T.serial(_i + 1):  # inner bound references the outer var
+            with T.Kernel(8 + _i + _j) as bx:
+                OUT[bx] = A[bx] + 1.0
+
+
+def test_adapter_expr_nested_static_host_loops_expand():
+    """A nested loop whose inner bound
+    references the outer constant iteration variable is statically
+    enumerable.  Outer min=2 (nonzero) x inner extents {3, 4} -> exactly 7
+    call sites, with BOTH loop variables substituted into the per-site
+    launch geometry (grid = 8 + i + j -> 10,11,12,11,12,13,14); the old
+    walker rejected this as a 'non-constant bounds' runtime loop."""
+    # No out_idx: the caller supplies OUT explicitly (deterministic init,
+    # deterministic caller initialization).
+    kern = tilelang.compile(adapter_expr_nested_static_loops, execution_backend="torch", target="metal")
+    plan = kern.adapter._launch_plan()
+    assert len(plan) == 7, f"nested static expansion expected 7 sites, got {len(plan)}"
+    analyzer = tvm.arith.Analyzer()
+    grids = [metal_mod._resolve_int_value(site.grid[0], {}, analyzer) for site in plan]
+    assert grids == [10, 11, 12, 11, 12, 13, 14], f"outer/inner loop vars must substitute into per-site geometry, got {grids}"
+    # Numeric end to end: every site writes A+1 over [0, 8+i+j); the last
+    # site (i=3, j=3, grid 14) wins, and out[14] stays caller-initialized
+    # (a wrong expansion or wrong grid would leave a different pattern).
+    a = torch.randn(64, device=MPS)
+    out = torch.zeros(64, device=MPS)
+    kern(a, out)
+    torch.mps.synchronize()
+    assert torch.allclose(out[:14], a[:14] + 1.0, atol=1e-5)
+    assert out[14:].abs().max().item() == 0.0, "sites must not write past grid 14"
+
+
+# ---------------------------------------------------------------------------
+# Exact-versus-capacity declaration discipline.
+# declaration discipline.  Rank matching is NO LONGER a validation
+# criterion: every declared dimension of every tensor input is validated
+# exactly (constants and general expressions must equal the caller's actual
+# extent; Var dims bind by identity) UNLESS the dimension is explicitly
+# declared as a capacity dimension in the compiled contract
+# (``tilelang_capacity_dims`` PrimFunc attr).
+#
+# Capacity marking is explicit opt-in only.
+# EXPLICIT opt-in ONLY.  The syntactic auto-inference from tensor
+# annotations (a dim that directly references a scalar function parameter
+# was auto-exempted) is removed: ``B_q(E, N, (K+1)//2)`` had its ordinary
+# exact dims E/N auto-exempted, which could let a smaller caller buffer
+# through.  Eager kernels declare capacity dims in the body via
+# ``T.annotate_capacity_dims({"A_q": (0,)})``; lazy kernels opt in via
+# ``func.with_attr("tilelang_capacity_dims", {"W": (0,)})``.  Everything
+# unmarked stays strictly validated.  Explicit capacity dims accept EITHER
+# mismatch direction at launch -- declared > actual (padded/masked, the
+# Qwen MoE QMM pattern) or declared < actual (active-prefix processing of a
+# larger allocation, the activation-quantization pattern) -- and the adapter runs an
+# advisory guard audit (warning when a marked dim's accesses show no
+# mask/offset guard evidence).
+# ---------------------------------------------------------------------------
+def test_strict_shape_rank_matched_constant_mismatch_rejected():
+    """A plain unmarked rank-matched declared
+    (7,) fed a (3,) tensor MUST be rejected BEFORE any kernel launch (mock
+    module observes zero calls).  Under adapter expression the rank-matched branch was
+    blanket-exempt, so this launched 7 elements over a three-element buffer
+    (GPU out-of-bounds)."""
+
+    @T.prim_func
+    def f(W: T.Tensor((7,), "float32"), OUT: T.Tensor((7,), "float32")):
+        with T.Kernel(7) as bx:
+            OUT[bx] = W[bx] * 2.0
+
+    class _MockFn:
+        def __call__(self, *fn_args, **kwargs):
+            raise AssertionError("kernel must not be launched for a mismatched shape")
+
+    class _MockModule:
+        def __getattr__(self, name):
+            return _MockFn()
+
+    with mock.patch("torch.mps.compile_shader", return_value=_MockModule()):
+        kern = tilelang.compile(f, out_idx=[1], execution_backend="torch", target="metal")
+        with pytest.raises(RuntimeError, match="declared dimension"):
+            kern(torch.randn(3))  # CPU tensor: rejection precedes any device use
+    torch.mps.synchronize()
+
+
+def test_strict_shape_rank_matched_rank1_constant_mismatch_rejected():
+    """Rank-matched (7, 1) fed (3, 1) must be rejected: no trailing-singleton
+    relaxation applies (ranks match), and the unmarked constant dim 7 != 3 is
+    a real out-of-bounds hazard."""
+
+    @T.prim_func
+    def f(W: T.Tensor((7, 1), "float32"), OUT: T.Tensor((7,), "float32")):
+        with T.Kernel(7) as bx:
+            OUT[bx] = W[bx, 0] * 2.0
+
+    class _MockFn:
+        def __call__(self, *fn_args, **kwargs):
+            raise AssertionError("kernel must not be launched for a mismatched shape")
+
+    class _MockModule:
+        def __getattr__(self, name):
+            return _MockFn()
+
+    with mock.patch("torch.mps.compile_shader", return_value=_MockModule()):
+        kern = tilelang.compile(f, out_idx=[1], execution_backend="torch", target="metal")
+        with pytest.raises(RuntimeError, match="declared dimension"):
+            kern(torch.randn(3, 1))
+    torch.mps.synchronize()
+
+
+def test_strict_shape_rank_matched_expression_mismatch_rejected():
+    """Rank-matched general-expression dim (N + 1) fed a (3,) tensor with
+    N=3 must be rejected (declared N+1=4 != 3), and the matching (4,) tensor
+    must pass end to end.  This is the rank-matched twin of the adapter expression
+    relaxed-prefix expression test: rank matching must NOT exempt it."""
+
+    N = tirx.Var("N", "int32")
+
+    @T.prim_func
+    def f(
+        A: T.Tensor((N,), "float32"),
+        W: T.Tensor((N + 1,), "float32"),
+        OUT: T.Tensor((N,), "float32"),
+    ):
+        with T.Kernel(N) as bx:
+            OUT[bx] = A[bx] + W[bx]
+
+    kern = tilelang.compile(f, out_idx=[2], execution_backend="torch", target="metal")
+    a = torch.randn(3, device=MPS)  # binds N = 3 -> declared W = N + 1 = 4
+    w_bad = torch.randn(3, device=MPS)
+    with pytest.raises(RuntimeError, match="declared dimension"):
+        kern(a, w_bad)
+    torch.mps.synchronize()
+    w_ok = torch.randn(4, device=MPS)
+    out = kern(a, w_ok)
+    torch.mps.synchronize()
+    assert out.shape == (3,)
+    assert torch.allclose(out, a + w_ok[:3], atol=1e-5)
+
+
+def test_strict_shape_eager_literal_dim_mismatch_rejected():
+    """An eagerjit tensor annotation with a LITERAL dim (7) is an exact
+    declaration (no scalar-parameter reference), so a (3,) tensor must be
+    rejected before launch.  (Two separate wrappers: the eagerjit kernel
+    cache keys on compile-time values only, so a kernel whose shader module
+    was built under the mock must not be reused for the real launch.)"""
+
+    @tilelang.jit
+    def lit_kernel_bad(a):
+        a: T.Tensor[[7], T.float32]
+        OUT = T.empty([7], dtype=T.float32)
+        with T.Kernel(7) as bx:
+            OUT[bx] = a[bx]
+        return OUT
+
+    @tilelang.jit
+    def lit_kernel_ok(a):
+        a: T.Tensor[[7], T.float32]
+        OUT = T.empty([7], dtype=T.float32)
+        with T.Kernel(7) as bx:
+            OUT[bx] = a[bx]
+        return OUT
+
+    class _MockFn:
+        def __call__(self, *fn_args, **kwargs):
+            raise AssertionError("kernel must not be launched for a mismatched shape")
+
+    class _MockModule:
+        def __getattr__(self, name):
+            return _MockFn()
+
+    with (
+        mock.patch("torch.mps.compile_shader", return_value=_MockModule()),
+        pytest.raises(RuntimeError, match="declared dimension"),
+    ):
+        lit_kernel_bad(torch.randn(3))  # CPU tensor: rejection precedes device use
+    torch.mps.synchronize()
+    # Real MPS launch with the matching literal extent.
+    a = torch.randn(7, device=MPS)
+    out = lit_kernel_ok(a)
+    torch.mps.synchronize()
+    assert out.shape == (7,)
+    assert torch.allclose(out, a, atol=1e-6)
+
+
+def test_strict_shape_eager_literal_rank1_mismatch_rejected():
+    """Round-2 HIGH guard in the eager path: an eagerjit (7, 1) literal
+    declaration fed a flat (3,) tensor is rank-relaxed but the retained
+    literal prefix 7 != 3 -> rejected (the relaxation must not weaken the
+    retained-prefix validation for eager kernels either)."""
+
+    @tilelang.jit
+    def lit_kernel2(w):
+        w: T.Tensor[[7, 1], T.float32]
+        OUT = T.empty([7], dtype=T.float32)
+        with T.Kernel(7) as bx:
+            OUT[bx] = w[bx, 0] * 2.0
+        return OUT
+
+    class _MockFn:
+        def __call__(self, *fn_args, **kwargs):
+            raise AssertionError("kernel must not be launched for a mismatched shape")
+
+    class _MockModule:
+        def __getattr__(self, name):
+            return _MockFn()
+
+    with (
+        mock.patch("torch.mps.compile_shader", return_value=_MockModule()),
+        pytest.raises(RuntimeError, match="declared dimension"),
+    ):
+        lit_kernel2(torch.randn(3))
+    torch.mps.synchronize()
+
+
+def test_strict_shape_eager_capacity_scalar_param_2d_allowed():
+    """The Qwen MoE capacity pattern in 2D: declared (cap, k) with cap/k direct
+    scalar-parameter references, actual (15, 8) -> accepted; the masked
+    kernel computes exactly the actual region and never touches the rest
+    (numeric verification on real MPS).  capacity: the capacity dims are
+    declared EXPLICITLY via ``T.annotate_capacity_dims`` (the annotation
+    alone no longer exempts anything -- see
+    ``test_capacity_eager_scalar_param_dim_unmarked_rejected``)."""
+
+    @tilelang.jit
+    def masked_kernel2d(a, out, cap, k, m, block: int = 32):
+        a: T.Tensor[[cap, k], T.float32]
+        out: T.Tensor[[cap, k], T.float32]
+        T.annotate_capacity_dims({"a": (0,), "out": (0,)})
+        with T.Kernel(cap, threads=block) as bx:
+            if bx < m:
+                for j in T.serial(k):
+                    out[bx, j] = a[bx, j] * 2.0
+
+    a = torch.randn(15, 8, device=MPS)
+    # Caller-supplied OUT keeps the masked tail deterministically initialized:
+    # the masked tail must stay caller-zeros.
+    out = torch.zeros(64, 8, device=MPS)
+    masked_kernel2d(a, out, 64, 8, 15)  # declared (64, 8), actual (15, 8)
+    torch.mps.synchronize()
+    assert out.shape == (64, 8), "declared capacity shape is kept"
+    assert torch.allclose(out[:15], a * 2.0, atol=1e-5)
+    assert out[15:].abs().max().item() == 0.0, "masked tail must never be written"
+
+
+def test_strict_shape_capacity_dim_scoped_other_dims_strict():
+    """Per-dim scoping: (cap, 8) declares dim0 as an EXPLICIT capacity dim
+    (``T.annotate_capacity_dims``, capacity) but dim1 as an exact literal.  A
+    mismatched dim1 is rejected even though dim0 is a legal capacity
+    mismatch; a matching dim1 (with any actual dim0 <= cap) is accepted."""
+
+    @tilelang.jit
+    def scope_kernel(a, cap, m, block: int = 32):
+        a: T.Tensor[[cap, 8], T.float32]
+        OUT = T.empty([cap, 8], dtype=T.float32)
+        T.annotate_capacity_dims({"a": (0,)})
+        with T.Kernel(cap, threads=block) as bx:
+            if bx < m:
+                for j in T.serial(8):
+                    OUT[bx, j] = a[bx, j] * 2.0
+        return OUT
+
+    out = scope_kernel(torch.randn(15, 8, device=MPS), 64, 15)
+    torch.mps.synchronize()
+    assert out.shape == (64, 8)
+    with pytest.raises(RuntimeError, match="declared dimension"):
+        scope_kernel(torch.randn(15, 4, device=MPS), 64, 15)
+    torch.mps.synchronize()
+    with pytest.raises(RuntimeError, match="declared dimension"):
+        scope_kernel(torch.randn(15, 16, device=MPS), 64, 15)
+    torch.mps.synchronize()
+
+
+def test_strict_shape_explicit_capacity_attr_lazy_allowed():
+    """Explicit opt-in channel for lazy @T.prim_func kernels: a param whose
+    dim is declared as a capacity dim via
+    ``func.with_attr("tilelang_capacity_dims", {"W": (0,)})`` accepts an
+    actual (3,) buffer (kernel internally masked to m=3); the identical
+    unmarked kernel rejects it."""
+
+    @T.prim_func
+    def fcap(W: T.Tensor((7,), "float32"), OUT: T.Tensor((7,), "float32")):
+        with T.Kernel(7) as bx:
+            if bx < 3:  # masked: only the actual 3 elements are accessed
+                OUT[bx] = W[bx] * 2.0
+
+    marked = fcap.with_attr("tilelang_capacity_dims", {"W": (0,)})
+    # No out_idx: the caller supplies OUT explicitly (deterministic init,
+    # the masked tail must stay caller-initialized to zero).
+    kern = tilelang.compile(marked, execution_backend="torch", target="metal")
+    w = torch.randn(3, device=MPS)
+    out = torch.zeros(7, device=MPS)
+    kern(w, out)
+    torch.mps.synchronize()
+    assert torch.allclose(out[:3], w * 2.0, atol=1e-5), "masked region must be computed"
+    assert out[3:].abs().max().item() == 0.0, "masked tail must never be written"
+    # The unmarked twin must reject the same call.
+    kern2 = tilelang.compile(fcap, execution_backend="torch", target="metal")
+    with pytest.raises(RuntimeError, match="declared dimension"):
+        kern2(torch.randn(3, device=MPS), torch.zeros(7, device=MPS))
+    torch.mps.synchronize()
+
+
+# ---------------------------------------------------------------------------
+# Capacity marking is explicit opt-in only.
+# EXPLICIT opt-in only.  The syntactic auto-inference (a tensor annotation
+# dim that directly references a scalar function parameter was auto-marked
+# as a capacity dim, exempting ordinary exact dims such as B_q.E/N from
+# validation) is removed.  Regression matrix:
+#   1. unmarked annotation dims that reference scalar params -> validated
+#      exactly (Qwen MoE A_q rows=64 vs actual 15 -> REJECT);
+#   2. explicitly declared capacity + mask/offset guard -> accepted (64 vs
+#      15, numeric, tail stays caller-zeros);
+#   3. explicit capacity WITHOUT guard evidence -> adapter warning;
+#   4. explicit capacity with actual > declared -> accepted (declared
+#      R=15 active prefix over a larger 64-row allocation; rows beyond
+#      declared are never touched, see
+#      test_capacity_eager_capacity_actual_larger_than_declared_allowed);
+#   5. lazy ``with_attr`` opt-in unchanged (test_strict_shape_explicit_capacity_attr_lazy_allowed).
+# ---------------------------------------------------------------------------
+def test_capacity_eager_scalar_param_dim_unmarked_rejected():
+    """An eager-JIT tensor annotation
+    whose dim references a scalar function parameter is an EXACT
+    declaration unless the author explicitly declares capacity.  Declared
+    (64, 8) fed an actual (15, 8) tensor MUST be rejected BEFORE any launch
+    (mock observes zero calls).  This is the exact Qwen MoE hazard: A_q's
+    ordinary rows dim (and B_q's E/N in the round-4 evidence dump) must be
+    validated per-dim."""
+
+    @tilelang.jit
+    def unmarked_kernel(a, out, cap, k, m, block: int = 32):
+        a: T.Tensor[[cap, k], T.float32]
+        out: T.Tensor[[cap, k], T.float32]
+        with T.Kernel(cap, threads=block) as bx:
+            if bx < m:
+                for j in T.serial(k):
+                    out[bx, j] = a[bx, j] * 2.0
+
+    class _MockFn:
+        def __call__(self, *fn_args, **kwargs):
+            raise AssertionError("kernel must not be launched for a mismatched shape")
+
+    class _MockModule:
+        def __getattr__(self, name):
+            return _MockFn()
+
+    with (
+        mock.patch("torch.mps.compile_shader", return_value=_MockModule()),
+        pytest.raises(RuntimeError, match="declared dimension"),
+    ):
+        unmarked_kernel(torch.randn(15, 8), torch.zeros(64, 8), 64, 8, 15)
+    torch.mps.synchronize()
+
+
+def test_capacity_eager_explicit_capacity_masked_allowed():
+    """The same kernel with an explicit
+    ``T.annotate_capacity_dims`` declaration accepts declared (64, 8) vs
+    actual (15, 8), computes exactly the masked region, and never touches
+    the caller-zeros tail (real MPS launch)."""
+
+    @tilelang.jit
+    def marked_kernel(a, out, cap, k, m, block: int = 32):
+        a: T.Tensor[[cap, k], T.float32]
+        out: T.Tensor[[cap, k], T.float32]
+        T.annotate_capacity_dims({"a": (0,), "out": (0,)})
+        with T.Kernel(cap, threads=block) as bx:
+            if bx < m:
+                for j in T.serial(k):
+                    out[bx, j] = a[bx, j] * 2.0
+
+    a = torch.randn(15, 8, device=MPS)
+    out = torch.zeros(64, 8, device=MPS)
+    marked_kernel(a, out, 64, 8, 15)  # declared (64, 8), actual (15, 8)
+    torch.mps.synchronize()
+    assert out.shape == (64, 8), "declared capacity shape is kept"
+    assert torch.allclose(out[:15], a * 2.0, atol=1e-5)
+    assert out[15:].abs().max().item() == 0.0, "masked tail must never be written"
+
+
+def test_capacity_qwen_moe_shape_probe():
+    """Qwen MoE representative shape: A_q declared with rows=64,
+    K=11) via scalar params, caller supplies (15, 11).  Unmarked -> REJECT
+    (per-dim validation, no exemption); explicitly marked (capacity dim 0)
+    -> ACCEPT with numeric verification.  Two separate wrappers: the
+    eagerjit kernel cache keys on compile-time values only, so the mock-
+    compiled (rejecting) wrapper must never be reused for the real launch."""
+
+    @tilelang.jit
+    def qwen_moe_unmarked(A_q, OUT, rows, K, m, block: int = 32):
+        A_q: T.Tensor[[rows, K], T.float32]
+        OUT: T.Tensor[[rows, K], T.float32]
+        with T.Kernel(rows, threads=block) as bx:
+            if bx < m:
+                for j in T.serial(K):
+                    OUT[bx, j] = A_q[bx, j] * 2.0
+
+    @tilelang.jit
+    def qwen_moe_marked(A_q, OUT, rows, K, m, block: int = 32):
+        A_q: T.Tensor[[rows, K], T.float32]
+        OUT: T.Tensor[[rows, K], T.float32]
+        T.annotate_capacity_dims({"A_q": (0,), "OUT": (0,)})
+        with T.Kernel(rows, threads=block) as bx:
+            if bx < m:
+                for j in T.serial(K):
+                    OUT[bx, j] = A_q[bx, j] * 2.0
+
+    class _MockFn:
+        def __call__(self, *fn_args, **kwargs):
+            raise AssertionError("kernel must not be launched for a mismatched shape")
+
+    class _MockModule:
+        def __getattr__(self, name):
+            return _MockFn()
+
+    with (
+        mock.patch("torch.mps.compile_shader", return_value=_MockModule()),
+        pytest.raises(RuntimeError, match="declared dimension"),
+    ):
+        qwen_moe_unmarked(torch.randn(15, 11), torch.zeros(64, 11), 64, 11, 15)
+    torch.mps.synchronize()
+    # Explicit capacity declaration -> 64 vs 15 is legal (masked access).
+    a = torch.randn(15, 11, device=MPS)
+    out = torch.zeros(64, 11, device=MPS)
+    qwen_moe_marked(a, out, 64, 11, 15)
+    torch.mps.synchronize()
+    assert torch.allclose(out[:15], a * 2.0, atol=1e-5)
+    assert out[15:].abs().max().item() == 0.0, "masked tail must never be written"
+
+
+def test_capacity_eager_capacity_actual_larger_than_declared_allowed():
+    """The activation-quantization pattern (declared < actual): a capacity dim whose
+    declared extent is the ACTIVE prefix (grid = declared, so every access
+    is bounded by declared) may receive a LARGER actual buffer (the padded
+    allocation) -- the rows beyond declared are simply never touched.
+    Real MPS launch: declared 15, actual 64-row buffer; out[:15] computed,
+    out[15:] stays caller-zeros.  (The guard audit is advisory and may warn
+    here: the accesses are bounded by the declared grid, not by an extra
+    mask.)"""
+
+    @tilelang.jit
+    def prefix_kernel(x, out, R, cap, block: int = 32):
+        x: T.Tensor[[R], T.float32]
+        out: T.Tensor[[R], T.float32]
+        T.annotate_capacity_dims({"x": (0,), "out": (0,)})
+        with T.Kernel(R, threads=block) as bx:
+            out[bx] = x[bx] * 2.0
+
+    # declared R=15 (active prefix): the kernel grid is R, so every access
+    # is bounded by declared; the caller passes LARGER 64-row allocations
+    # (rows >= 15 are garbage / caller-zeros and are never touched).
+    x = torch.randn(64, device=MPS)
+    out = torch.zeros(64, device=MPS)
+    prefix_kernel(x, out, 15, 64)
+    torch.mps.synchronize()
+    assert torch.allclose(out[:15], x[:15] * 2.0, atol=1e-5)
+    assert out[15:].abs().max().item() == 0.0, "rows beyond declared must stay untouched"
+
+
+def test_capacity_eager_capacity_guard_audit_warns_unguarded(caplog):
+    """An explicitly declared capacity dim whose accesses show no
+    mask/offset guard evidence (unconditional full sweep over the declared
+    extent) is a hazard: the adapter emits an advisory warning at
+    compilation time (the explicit declaration is the trust boundary, so
+    the audit warns rather than rejects)."""
+
+    @tilelang.jit
+    def unguarded_kernel(a, out, cap, m, block: int = 32):
+        a: T.Tensor[[cap], T.float32]
+        out: T.Tensor[[cap], T.float32]
+        T.annotate_capacity_dims({"a": (0,)})
+        with T.Kernel(cap, threads=block) as bx:
+            out[bx] = a[bx] * 2.0  # NO guard: sweeps the full declared extent
+
+    class _MockFn:
+        def __call__(self, *fn_args, **kwargs):
+            raise AssertionError("kernel must not be launched")
+
+    class _MockModule:
+        def __getattr__(self, name):
+            return _MockFn()
+
+    import logging
+
+    # Compile-only path: the audit runs at adapter construction (compile
+    # time), so no launch is attempted and the mock observes zero calls.
+    pf = unguarded_kernel.get_tir(torch.zeros(15), torch.zeros(64), 64, 15)
+    with (
+        mock.patch("torch.mps.compile_shader", return_value=_MockModule()),
+        caplog.at_level(logging.WARNING, logger="tilelang.jit.adapter.torch.metal"),
+    ):
+        tilelang.compile(pf, execution_backend="torch", target="metal")
+    assert any("no mask/offset guard evidence" in r.message and "'a'" in r.message for r in caplog.records), (
+        f"expected guard-audit warning, got {[r.message for r in caplog.records]}"
+    )
+
+
+def test_capacity_eager_capacity_guard_audit_silent_when_guarded(caplog):
+    """A masked access conditioned on a runtime
+    bound ``m``) is structural guard evidence, so no warning is emitted."""
+
+    @tilelang.jit
+    def guarded_kernel(a, out, cap, m, block: int = 32):
+        a: T.Tensor[[cap], T.float32]
+        out: T.Tensor[[cap], T.float32]
+        T.annotate_capacity_dims({"a": (0,), "out": (0,)})
+        with T.Kernel(cap, threads=block) as bx:
+            if bx < m:  # runtime-bounded mask
+                out[bx] = a[bx] * 2.0
+
+    class _MockFn:
+        def __call__(self, *fn_args, **kwargs):
+            raise AssertionError("kernel must not be launched")
+
+    class _MockModule:
+        def __getattr__(self, name):
+            return _MockFn()
+
+    import logging
+
+    pf = guarded_kernel.get_tir(torch.zeros(15), torch.zeros(64), 64, 15)
+    with (
+        mock.patch("torch.mps.compile_shader", return_value=_MockModule()),
+        caplog.at_level(logging.WARNING, logger="tilelang.jit.adapter.torch.metal"),
+    ):
+        tilelang.compile(pf, execution_backend="torch", target="metal")
+    assert not any("no mask/offset guard evidence" in r.message for r in caplog.records), (
+        f"unexpected guard-audit warning: {[r.message for r in caplog.records]}"
+    )
+
+
+def test_capacity_eager_capacity_guard_against_declared_extent_warns(caplog):
+    """Audit adversarial: a guard against the DECLARED extent itself (``bx
+    < cap``, i.e. a no-op for any smaller actual buffer) is not guard
+    evidence and must still warn.  Guards only count when their bound is
+    not the declared extent (a runtime bound or a smaller baked bound)."""
+
+    @tilelang.jit
+    def noop_guard_kernel(a, out, cap, m, block: int = 32):
+        a: T.Tensor[[cap], T.float32]
+        out: T.Tensor[[cap], T.float32]
+        T.annotate_capacity_dims({"a": (0,)})
+        with T.Kernel(cap, threads=block) as bx:
+            if bx < cap:  # bound == declared extent: no-op guard
+                out[bx] = a[bx] * 2.0
+
+    class _MockFn:
+        def __call__(self, *fn_args, **kwargs):
+            raise AssertionError("kernel must not be launched")
+
+    class _MockModule:
+        def __getattr__(self, name):
+            return _MockFn()
+
+    import logging
+
+    pf = noop_guard_kernel.get_tir(torch.zeros(15), torch.zeros(64), 64, 15)
+    with (
+        mock.patch("torch.mps.compile_shader", return_value=_MockModule()),
+        caplog.at_level(logging.WARNING, logger="tilelang.jit.adapter.torch.metal"),
+    ):
+        tilelang.compile(pf, execution_backend="torch", target="metal")
+    assert any("no mask/offset guard evidence" in r.message and "'a'" in r.message for r in caplog.records), (
+        f"expected guard-audit warning, got {[r.message for r in caplog.records]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# adapter expression §4: multi-runtime-scalar packing (≥2 runtime scalar kernel
+# arguments).  The Metal codegen packs every scalar parameter into a single
+# ``args_t`` struct at ``buffer(num_buffer)``, but the
+# ``torch.mps.compile_shader`` launcher binds each positional argument to
+# its own buffer slot, so pre-fix only the first scalar landed in the struct
+# and the rest silently read stale bytes (``kern(a, 5, 7)`` -> ``a + 5000``
+# instead of ``a + 5007``).  The adapter must pack all runtime scalars into
+# one buffer reproducing the struct layout.  All cases run on real MPS.
+# ---------------------------------------------------------------------------
+@T.prim_func
+def adapter_expr_two_scalar_middle(A: T.Tensor((64,), "float32"), scalar_i: T.int32, J: T.int32, OUT: T.Tensor((64,), "float32")):
+    with T.Kernel(64) as bx:
+        OUT[bx] = A[bx] + T.cast(scalar_i, T.float32) * 1000.0 + T.cast(J, T.float32)
+
+
+@T.prim_func
+def adapter_expr_two_scalar_first(scalar_i: T.int32, J: T.int32, A: T.Tensor((64,), "float32"), OUT: T.Tensor((64,), "float32")):
+    with T.Kernel(64) as bx:
+        OUT[bx] = A[bx] + T.cast(scalar_i, T.float32) * 1000.0 + T.cast(J, T.float32)
+
+
+@T.prim_func
+def adapter_expr_int_float_scalar_tail(A: T.Tensor((64,), "float32"), scalar_i: T.int32, F: T.float32, OUT: T.Tensor((64,), "float32")):
+    with T.Kernel(64) as bx:
+        OUT[bx] = A[bx] + T.cast(scalar_i, T.float32) * 1000.0 + F
+
+
+def _adapter_expr_run(prim, out_idx, call_args, expected):
+    kern = tilelang.compile(prim, out_idx=out_idx, execution_backend="torch", target="metal")
+    got = kern(*call_args)
+    torch.mps.synchronize()
+    err = np.abs(got.cpu().numpy() - expected).max()
+    assert err < 1e-4, f"[{prim.attrs['global_symbol']}] multi-runtime-scalar mismatch: max_abs_err={err}"
+
+
+def test_adapter_expr_two_runtime_scalars_middle():
+    """Two runtime scalars in middle positions must produce ``a + 5007``."""
+    a = torch.from_numpy(np.arange(64, dtype=np.float32)).to(MPS)
+    _adapter_expr_run(adapter_expr_two_scalar_middle, [3], (a, 5, 7), np.arange(64, dtype=np.float32) + 5007.0)
+
+
+def test_adapter_expr_two_runtime_scalars_first():
+    """Two runtime scalars in the leading public positions (FFI slot chain)."""
+    a = torch.from_numpy(np.arange(64, dtype=np.float32)).to(MPS)
+    _adapter_expr_run(adapter_expr_two_scalar_first, [3], (5, 7, a), np.arange(64, dtype=np.float32) + 5007.0)
+
+
+def test_adapter_expr_int_and_float_runtime_scalars_tail():
+    """int32 + float32 runtime scalars pack into their 8-byte slots."""
+    a = torch.from_numpy(np.arange(64, dtype=np.float32)).to(MPS)
+    _adapter_expr_run(adapter_expr_int_float_scalar_tail, [3], (a, 5, 7.5), np.arange(64, dtype=np.float32) + 5007.5)
+
+
+# ---------------------------------------------------------------------------
+# Adapter boundary-condition regressions
+# ---------------------------------------------------------------------------
+def test_loop_local_bind_snapshot():
+    """A tirx.Bind inside a static host loop must be snapshotted per call
+    site. The loop rebinds OUT to args slot 0 then
+    slot 1; without the snapshot both sites resolve the final (slot 1)
+    binding and the plan would enqueue two identical launches."""
+    kern = tilelang.compile(completion_inplace, execution_backend="torch", target="metal")
+    art = kern.artifact
+    device_mod = art.device_mod
+    assert "completion_inplace_kernel" in device_mod
+
+    struct_get = tvm.ir.Op.get("tirx.tvm_struct_get")
+    call_packed = tvm.ir.Op.get("tirx.tvm_call_packed")
+    args_var = tirx.Var("args", "handle")
+
+    def sg(struct, index, field, dtype="handle"):
+        index_e = index if isinstance(index, tirx.Var) else tirx.IntImm("int32", index)
+        return tirx.Call(
+            tvm.DataType(dtype),
+            struct_get,
+            [struct, index_e, tirx.IntImm("int32", field)],
+        )
+
+    a_h = tirx.Var("A_handle", "handle")
+    v_h = tirx.Var("V_handle", "handle")
+    a = tirx.Var("A", "handle")
+    out = tirx.Var("OUT", "handle")
+    it = tirx.Var("it", "int32")
+    call = tirx.Call(
+        tvm.DataType("int32"),
+        call_packed,
+        [
+            tirx.StringImm("completion_inplace_kernel"),
+            a,
+            out,
+            tirx.IntImm("int32", 64),
+            tirx.IntImm("int32", 128),
+            tirx.IntImm("int32", 1),
+            tirx.IntImm("int32", 1),
+        ],
+    )
+    host_func = tirx.PrimFunc(
+        [
+            tirx.Var("self_handle", "handle"),
+            args_var,
+            tirx.Var("num_args", "int32"),
+            tirx.Var("result", "handle"),
+        ],
+        tirx.SeqStmt(
+            [
+                tirx.Bind(a_h, sg(args_var, 0, 15)),
+                tirx.Bind(a, sg(a_h, 0, 1)),
+                tirx.For(
+                    it,
+                    0,
+                    2,
+                    tirx.ForKind.SERIAL,
+                    tirx.SeqStmt(
+                        [
+                            tirx.Bind(v_h, sg(args_var, it, 15)),
+                            tirx.Bind(out, sg(v_h, 0, 1)),
+                            tirx.Evaluate(call),
+                        ]
+                    ),
+                ),
+            ]
+        ),
+    ).with_attr("tirx.is_entry_func", True)
+    host_mod = tvm.IRModule({tvm.ir.GlobalVar("completion_inplace_loop_bind"): host_func})
+
+    adapter = MetalKernelAdapter(
+        params=art.params,
+        result_idx=[1],
+        func_or_mod=completion_inplace,
+        host_mod=host_mod,
+        device_mod=device_mod,
+        kernel_global_source=art.kernel_source,
+    )
+    plan = adapter._launch_plan()
+    assert len(plan) == 2, "static loop must expand to two call sites"
+    # Device params (A, OUT): OUT binds args slot 0 on iteration 0 and slot
+    # 1 on iteration 1; A is constant (slot 0) on both sites.
+    assert plan[0].bindings[0].param_index == 0
+    assert plan[1].bindings[0].param_index == 0
+    assert plan[0].bindings[1].kind == "user" and plan[0].bindings[1].param_index == 0
+    assert plan[1].bindings[1].kind == "user" and plan[1].bindings[1].param_index == 1
+
+
+def test_resolve_int_value_preserves_declared_dtype():
+    """General PrimExpr substitution must build each integer replacement
+    with the variable's declared dtype. Hardcoded int32
+    replacements made an int64 shape symbol fail with
+    InternalError: substituting n:int64 -> 41:int32 before
+    simplification."""
+    analyzer = tvm.arith.Analyzer()
+    n64 = tirx.Var("n", "int64")
+    assert metal_mod._resolve_int_value(n64 + tirx.IntImm("int64", 1), {n64: 41}, analyzer) == 42
+    s64 = tirx.Var("s", "int64")
+    assert metal_mod._resolve_int_value(s64 * 2, {}, analyzer, full=[5], scalar_vars={s64: 0}) == 10
+    u64 = tirx.Var("u", "uint64")
+    assert metal_mod._resolve_int_value(u64 + tirx.IntImm("uint64", 3), {u64: 7}, analyzer) == 10
+    i32 = tirx.Var("i", "int32")
+    assert metal_mod._resolve_int_value(i32 + 5, {i32: 3}, analyzer) == 8
+
+
+def test_annotate_capacity_dims_rejects_unknown_name():
+    """Unknown capacity-dimension names must raise at declaration time
+    instead of being silently dropped by the adapter (a
+    typo would otherwise leave the intended dim under strict validation and
+    fail later with a confusing declared-dimension mismatch)."""
+
+    @tilelang.jit
+    def bad_capacity(a, m):
+        a: T.Tensor((m, 8), "float32")
+        T.annotate_capacity_dims({"a_q": (0,)})  # typo: parameter is a
+
+    with pytest.raises(ValueError, match="unknown tensor parameter"):
+        bad_capacity(torch.randn(64, 8, device=MPS), 64)
+
+    with pytest.raises(ValueError, match="unknown tensor parameter"):
+
+        @T.prim_func
+        def bad_capacity_lazy(A: T.Tensor((64,), "float32"), OUT: T.Tensor((64,), "float32")):
+            T.annotate_capacity_dims({"B": (0,)})
+            for i in T.serial(64):
+                OUT[i] = A[i]
+
+    @T.prim_func
+    def valid_capacity_attr(A: T.Tensor((64,), "float32"), OUT: T.Tensor((64,), "float32")):
+        with T.Kernel(64) as i:
+            OUT[i] = A[i]
+
+    bad_attr = valid_capacity_attr.with_attr("tilelang_capacity_dims", {"B": (0,)})
+    with pytest.raises(ValueError, match="unknown tensor parameter"):
+        tilelang.compile(bad_attr, out_idx=[1], execution_backend="torch", target="metal")

--- a/testing/python/metal/test_metal_adapter.py
+++ b/testing/python/metal/test_metal_adapter.py
@@ -57,6 +57,35 @@ def _wait_keepalive_drained(timeout: float = 15.0) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# packed-slot -> public-parameter-index mapping for BOTH MakePackedAPI ABI
+# layouts (legacy slot == public index, and the callee-allocated output ABI
+# whose slots skip out_idx positions).  Non-trailing out_idx is the case that
+# distinguishes them: ``(A, OUT, B)`` with ``out_idx=[1]`` gives B packed
+# slot 2 in the legacy layout but slot 1 in the callee-allocated layout.
+# ---------------------------------------------------------------------------
+def test_packed_slot_to_param_index_both_layouts():
+    from tilelang.jit.adapter.torch.metal import _packed_slot_to_param_index
+
+    input_param_idx = [0, 2]  # public indices of (A, B) for params (A, OUT, B)
+    num_params = 3
+    # Legacy layout (Metal today): the packed slot IS the public index,
+    # including for the output parameter itself.
+    assert _packed_slot_to_param_index(0, input_param_idx, num_params, False) == 0  # A
+    assert _packed_slot_to_param_index(1, input_param_idx, num_params, False) == 1  # OUT
+    assert _packed_slot_to_param_index(2, input_param_idx, num_params, False) == 2  # B
+    # Callee-allocated output ABI: slots number only non-output parameters,
+    # so B (packed slot 1) must remap to public index 2 -- the exact
+    # silent-misbinding scenario this guards against.
+    assert _packed_slot_to_param_index(0, input_param_idx, num_params, True) == 0  # A
+    assert _packed_slot_to_param_index(1, input_param_idx, num_params, True) == 2  # B
+    # Out-of-range diagnostics instead of silent misbinding.
+    with pytest.raises(RuntimeError, match="packed slot 2"):
+        _packed_slot_to_param_index(2, input_param_idx, num_params, True)
+    with pytest.raises(RuntimeError, match="out of range"):
+        _packed_slot_to_param_index(3, input_param_idx, num_params, False)
+
+
+# ---------------------------------------------------------------------------
 # scalar binding: out_idx + scalar interleave — scalar first / middle / tail x
 # single / multi output. All six cases must bind and run on real MPS.
 # ---------------------------------------------------------------------------

--- a/testing/python/metal/test_metal_adapter.py
+++ b/testing/python/metal/test_metal_adapter.py
@@ -56,6 +56,16 @@ def _wait_keepalive_drained(timeout: float = 15.0) -> bool:
     return True
 
 
+def _compile(f, out_idx=None):
+    """Compile ``f`` through the Metal eager adapter (torch execution backend).
+
+    Every test in this module targets the MPS path via the torch execution
+    backend, so the boilerplate ``tilelang.compile(..., execution_backend="torch",
+    target="metal")`` lives here instead of at each call site.
+    """
+    return tilelang.compile(f, out_idx=out_idx, execution_backend="torch", target="metal")
+
+
 # ---------------------------------------------------------------------------
 # packed-slot -> public-parameter-index mapping for BOTH MakePackedAPI ABI
 # layouts (legacy slot == public index, and the callee-allocated output ABI
@@ -206,7 +216,7 @@ def test_scalar_binding_scalar_interleave_out_idx(build):
     S = 3
     g = np.random.default_rng(23)
     prim, out_idx, call_args, expected = build(S, g)
-    kern = tilelang.compile(prim, out_idx=out_idx, execution_backend="torch", target="metal")
+    kern = _compile(prim, out_idx=out_idx)
     got = kern(*call_args)
     if isinstance(got, (list, tuple)):
         got = tuple(got)
@@ -319,7 +329,7 @@ def test_dynamic_shape_undetermined_symbol_raises():
         with T.Kernel(N) as bx:
             OUT[bx] = A[bx] * 2.0
 
-    kern = tilelang.compile(f, out_idx=[1], execution_backend="torch", target="metal")
+    kern = _compile(f, out_idx=[1])
     a = torch.randn(31, device=MPS)
     with pytest.raises(RuntimeError, match="not determined by any caller-supplied tensor input shape"):
         kern(a)
@@ -336,7 +346,7 @@ def test_dynamic_shape_conflicting_symbol_bindings_raise():
         with T.Kernel(N) as bx:
             OUT[bx] = A[bx] + B[bx]
 
-    kern = tilelang.compile(f, out_idx=[2], execution_backend="torch", target="metal")
+    kern = _compile(f, out_idx=[2])
     a = torch.randn(17, device=MPS)
     b = torch.randn(19, device=MPS)
     with pytest.raises(RuntimeError, match="conflicting sizes"):
@@ -357,7 +367,7 @@ def global_buffer_alloc_global_lazy(A: T.Tensor((97,), "float32"), B: T.Tensor((
 
 def test_global_buffer_alloc_global_lazy():
     a = torch.randn(97, device=MPS)
-    kern = tilelang.compile(global_buffer_alloc_global_lazy, out_idx=[1], execution_backend="torch", target="metal")
+    kern = _compile(global_buffer_alloc_global_lazy, out_idx=[1])
     b = kern(a)
     torch.mps.synchronize()
     assert torch.allclose(b, (a + 1.0) * 2.0, atol=1e-5)
@@ -396,7 +406,7 @@ def launch_order_two_stage(A: T.Tensor((97,), "float32"), B: T.Tensor((97,), "fl
 
 def test_launch_order_producer_consumer_order():
     a = torch.randn(97, device=MPS)
-    kern = tilelang.compile(launch_order_two_stage, out_idx=[1, 2], execution_backend="torch", target="metal")
+    kern = _compile(launch_order_two_stage, out_idx=[1, 2])
     plan = kern.adapter._launch_plan()
     assert [s.symbol for s in plan] == ["launch_order_two_stage_kernel", "launch_order_two_stage_kernel_1"]
     b, c = kern(a)
@@ -409,7 +419,7 @@ def test_launch_order_reversed_function_map_still_host_order():
     """device_mod function-map order reversed vs host call sites: the launch
     plan must follow the HOST order; following the map would compute C from
     uninitialized B (NaN) and fail."""
-    kern = tilelang.compile(launch_order_two_stage, out_idx=[1, 2], execution_backend="torch", target="metal")
+    kern = _compile(launch_order_two_stage, out_idx=[1, 2])
     art = kern.artifact
     funcs = list(art.device_mod.functions.items())
     assert len(funcs) == 2
@@ -445,7 +455,7 @@ def launch_order_repeated_symbol(A: T.Tensor((97,), "float32"), OUT: T.Tensor((9
 
 
 def test_launch_order_repeated_same_symbol():
-    kern = tilelang.compile(launch_order_repeated_symbol, out_idx=[1], execution_backend="torch", target="metal")
+    kern = _compile(launch_order_repeated_symbol, out_idx=[1])
     plan = kern.adapter._launch_plan()
     assert len(plan) == 2, "duplicate host call sites must be preserved"
     assert plan[0].symbol == plan[1].symbol == "launch_order_repeated_symbol_kernel"
@@ -482,7 +492,7 @@ def test_keepalive_aborted_launch_pins_submitted_buffers():
         return _RaisingModule(real_compile_shader(source))
 
     with mock.patch("torch.mps.compile_shader", side_effect=_compile_wrapper):
-        kern = tilelang.compile(launch_order_two_stage, out_idx=[1, 2], execution_backend="torch", target="metal")
+        kern = _compile(launch_order_two_stage, out_idx=[1, 2])
 
     a = torch.randn(97, device=MPS)
     with pytest.raises(RuntimeError, match="injected second-launch failure"):
@@ -498,7 +508,7 @@ def test_keepalive_temporary_output_stress():
     """Caller-supplied outputs dropped immediately after launch:
     every batch must stay pinned across many launches, with no caller strong
     reference left behind."""
-    kern = tilelang.compile(completion_inplace, execution_backend="torch", target="metal")
+    kern = _compile(completion_inplace)
     a = torch.randn(64, device=MPS)
     # Pause the reaper and neutralize the release helper so pinning is
     # observable while batches are pending: no drain can release the current
@@ -555,7 +565,7 @@ def completion_inplace(A: T.Tensor((64,), "float32"), OUT: T.Tensor((64,), "floa
 
 
 def test_completion_releases_without_second_launch():
-    kern = tilelang.compile(completion_inplace, execution_backend="torch", target="metal")
+    kern = _compile(completion_inplace)
     a = torch.randn(64, device=MPS)
     out = torch.zeros(64, device=MPS)
     weak = weakref.ref(out)
@@ -570,7 +580,7 @@ def test_completion_releases_without_second_launch():
 
 
 def test_completion_adapter_destruction_path():
-    kern = tilelang.compile(completion_inplace, execution_backend="torch", target="metal")
+    kern = _compile(completion_inplace)
     a = torch.randn(64, device=MPS)
     out = torch.zeros(64, device=MPS)
     weak = weakref.ref(out)
@@ -585,7 +595,7 @@ def test_completion_adapter_destruction_path():
 
 
 def test_completion_sequential_launches_do_not_accumulate():
-    kern = tilelang.compile(completion_inplace, execution_backend="torch", target="metal")
+    kern = _compile(completion_inplace)
     a = torch.randn(64, device=MPS)
     for i in range(5):
         out = torch.zeros(64, device=MPS)
@@ -616,7 +626,7 @@ def test_host_plan_loop_carried_args_and_geometry():
     writes are non-idempotent (iter 1 overwrites iter 0 with +1.0)."""
     # No out_idx: the caller supplies OUT explicitly, so the never-written
     # tail element can be deterministically initialized.
-    kern = tilelang.compile(host_plan_loop_carried, execution_backend="torch", target="metal")
+    kern = _compile(host_plan_loop_carried)
     plan = kern.adapter._launch_plan()
     assert len(plan) == 2, "constant loop must expand to two call sites"
     assert plan[0].symbol == plan[1].symbol == "host_plan_loop_carried_kernel"
@@ -659,7 +669,7 @@ def test_host_plan_same_name_distinct_identity_vars():
     """Two tirx.Vars with the same name but different identity.
     The symbol binding must use Var identity (grid + device scalar resolve to
     HOST_PLAN_N1 = 5), not the first string match (which would pick HOST_PLAN_N2 = 9)."""
-    kern = tilelang.compile(host_plan_same_name_vars, out_idx=[2], execution_backend="torch", target="metal")
+    kern = _compile(host_plan_same_name_vars, out_idx=[2])
     plan = kern.adapter._launch_plan()
     site = plan[0]
     sym_bindings = [b for b in site.bindings if b.kind == "symbol"]
@@ -681,7 +691,7 @@ def test_host_plan_same_name_distinct_identity_vars():
             return _MockFn()
 
     with mock.patch("torch.mps.compile_shader", return_value=_MockModule()):
-        kern_mock = tilelang.compile(host_plan_same_name_vars, out_idx=[2], execution_backend="torch", target="metal")
+        kern_mock = _compile(host_plan_same_name_vars, out_idx=[2])
     a9 = torch.randn(9, device=MPS)
     b5 = torch.randn(5, device=MPS)
     kern_mock(a9, b5)
@@ -712,7 +722,7 @@ def host_plan_cond_branch(A: T.Tensor((97,), "float32"), OUT: T.Tensor((97,), "f
 def test_host_plan_static_conditional_taken_branch_only():
     """An IfThenElse whose condition is resolved by the substituted
     loop variable must walk only its taken branch (2 sites, not 4)."""
-    kern = tilelang.compile(host_plan_cond_branch, out_idx=[1], execution_backend="torch", target="metal")
+    kern = _compile(host_plan_cond_branch, out_idx=[1])
     plan = kern.adapter._launch_plan()
     assert len(plan) == 2, f"one branch per iteration expected, got {len(plan)} sites"
     assert plan[0].symbol == "host_plan_cond_branch_kernel"  # iter 0: then (A+1)
@@ -738,7 +748,7 @@ def test_host_plan_runtime_conditional_plan_build_error():
                 OUT[bx] = A[bx] * 2.0
 
     with pytest.raises(RuntimeError, match="cannot be resolved statically"):
-        tilelang.compile(f, out_idx=[1], execution_backend="torch", target="metal")
+        _compile(f, out_idx=[1])
 
 
 def test_host_plan_runtime_loop_plan_build_error():
@@ -753,7 +763,7 @@ def test_host_plan_runtime_loop_plan_build_error():
                 OUT[bx] = A[bx] + 1.0
 
     with pytest.raises(RuntimeError, match="non-constant bounds"):
-        tilelang.compile(f, out_idx=[1], execution_backend="torch", target="metal")
+        _compile(f, out_idx=[1])
 
 
 def test_host_plan_call_site_args_swapped_binding():
@@ -762,7 +772,7 @@ def test_host_plan_call_site_args_swapped_binding():
     must bind device param 0 to the call site's first actual argument (OUT,
     slot 1) and device param 1 to A (slot 0) -- never by device-parameter
     name."""
-    kern = tilelang.compile(completion_inplace, execution_backend="torch", target="metal")
+    kern = _compile(completion_inplace)
     art = kern.artifact
     device_mod = art.device_mod
     assert "completion_inplace_kernel" in device_mod
@@ -971,7 +981,7 @@ def test_host_plan_adapter_destruction_weakref_finalizer():
     """The adapter's destruction path is provable: the object
     must be collectable after `del kern` with weakref + finalizer evidence
     (the launcher closure must not capture the adapter)."""
-    kern = tilelang.compile(completion_inplace, execution_backend="torch", target="metal")
+    kern = _compile(completion_inplace)
     adapter = kern.adapter
     weak = weakref.ref(adapter)
     fired = []
@@ -1016,7 +1026,7 @@ def test_host_plan_rank_mismatch_non_singleton_still_raises():
         with T.Kernel(T_) as bx:
             OUT[bx] = W[bx, 0] * 2.0
 
-    kern = tilelang.compile(f, out_idx=[1], execution_backend="torch", target="metal")
+    kern = _compile(f, out_idx=[1])
     w = torch.randn(7, device=MPS)
     with pytest.raises(RuntimeError, match="declared rank 2"):
         kern(w)
@@ -1049,7 +1059,7 @@ def test_adapter_expr_rank_relax_rejects_retained_prefix_mismatch():
             return _MockFn()
 
     with mock.patch("torch.mps.compile_shader", return_value=_MockModule()):
-        kern = tilelang.compile(f, out_idx=[1], execution_backend="torch", target="metal")
+        kern = _compile(f, out_idx=[1])
     w = torch.randn(3, device=MPS)
     with pytest.raises(RuntimeError, match="declared dimension"):
         kern(w)
@@ -1106,7 +1116,7 @@ def test_adapter_expr_rank_relax_expression_prefix_validation():
         with T.Kernel(N) as bx:
             OUT[bx] = A[bx] + W[bx, 0]
 
-    kern = tilelang.compile(f, out_idx=[2], execution_backend="torch", target="metal")
+    kern = _compile(f, out_idx=[2])
     a = torch.randn(3, device=MPS)  # binds N = 3 -> declared W prefix N+1 = 4
     # Wrong extent: N+1 = 4 != 3 must be rejected.
     w_bad = torch.randn(3, device=MPS)
@@ -1153,7 +1163,7 @@ def test_adapter_expr_nested_static_host_loops_expand():
     walker rejected this as a 'non-constant bounds' runtime loop."""
     # No out_idx: the caller supplies OUT explicitly (deterministic init,
     # deterministic caller initialization).
-    kern = tilelang.compile(adapter_expr_nested_static_loops, execution_backend="torch", target="metal")
+    kern = _compile(adapter_expr_nested_static_loops)
     plan = kern.adapter._launch_plan()
     assert len(plan) == 7, f"nested static expansion expected 7 sites, got {len(plan)}"
     analyzer = tvm.arith.Analyzer()
@@ -1215,7 +1225,7 @@ def test_strict_shape_rank_matched_constant_mismatch_rejected():
             return _MockFn()
 
     with mock.patch("torch.mps.compile_shader", return_value=_MockModule()):
-        kern = tilelang.compile(f, out_idx=[1], execution_backend="torch", target="metal")
+        kern = _compile(f, out_idx=[1])
         with pytest.raises(RuntimeError, match="declared dimension"):
             kern(torch.randn(3))  # CPU tensor: rejection precedes any device use
     torch.mps.synchronize()
@@ -1240,7 +1250,7 @@ def test_strict_shape_rank_matched_rank1_constant_mismatch_rejected():
             return _MockFn()
 
     with mock.patch("torch.mps.compile_shader", return_value=_MockModule()):
-        kern = tilelang.compile(f, out_idx=[1], execution_backend="torch", target="metal")
+        kern = _compile(f, out_idx=[1])
         with pytest.raises(RuntimeError, match="declared dimension"):
             kern(torch.randn(3, 1))
     torch.mps.synchronize()
@@ -1263,7 +1273,7 @@ def test_strict_shape_rank_matched_expression_mismatch_rejected():
         with T.Kernel(N) as bx:
             OUT[bx] = A[bx] + W[bx]
 
-    kern = tilelang.compile(f, out_idx=[2], execution_backend="torch", target="metal")
+    kern = _compile(f, out_idx=[2])
     a = torch.randn(3, device=MPS)  # binds N = 3 -> declared W = N + 1 = 4
     w_bad = torch.randn(3, device=MPS)
     with pytest.raises(RuntimeError, match="declared dimension"):
@@ -1425,7 +1435,7 @@ def test_strict_shape_explicit_capacity_attr_lazy_allowed():
     marked = fcap.with_attr("tilelang_capacity_dims", {"W": (0,)})
     # No out_idx: the caller supplies OUT explicitly (deterministic init,
     # the masked tail must stay caller-initialized to zero).
-    kern = tilelang.compile(marked, execution_backend="torch", target="metal")
+    kern = _compile(marked)
     w = torch.randn(3, device=MPS)
     out = torch.zeros(7, device=MPS)
     kern(w, out)
@@ -1433,7 +1443,7 @@ def test_strict_shape_explicit_capacity_attr_lazy_allowed():
     assert torch.allclose(out[:3], w * 2.0, atol=1e-5), "masked region must be computed"
     assert out[3:].abs().max().item() == 0.0, "masked tail must never be written"
     # The unmarked twin must reject the same call.
-    kern2 = tilelang.compile(fcap, execution_backend="torch", target="metal")
+    kern2 = _compile(fcap)
     with pytest.raises(RuntimeError, match="declared dimension"):
         kern2(torch.randn(3, device=MPS), torch.zeros(7, device=MPS))
     torch.mps.synchronize()
@@ -1626,7 +1636,7 @@ def test_capacity_eager_capacity_guard_audit_warns_unguarded(caplog):
         mock.patch("torch.mps.compile_shader", return_value=_MockModule()),
         caplog.at_level(logging.WARNING, logger="tilelang.jit.adapter.torch.metal"),
     ):
-        tilelang.compile(pf, execution_backend="torch", target="metal")
+        _compile(pf)
     assert any("no mask/offset guard evidence" in r.message and "'a'" in r.message for r in caplog.records), (
         f"expected guard-audit warning, got {[r.message for r in caplog.records]}"
     )
@@ -1660,7 +1670,7 @@ def test_capacity_eager_capacity_guard_audit_silent_when_guarded(caplog):
         mock.patch("torch.mps.compile_shader", return_value=_MockModule()),
         caplog.at_level(logging.WARNING, logger="tilelang.jit.adapter.torch.metal"),
     ):
-        tilelang.compile(pf, execution_backend="torch", target="metal")
+        _compile(pf)
     assert not any("no mask/offset guard evidence" in r.message for r in caplog.records), (
         f"unexpected guard-audit warning: {[r.message for r in caplog.records]}"
     )
@@ -1696,7 +1706,7 @@ def test_capacity_eager_capacity_guard_against_declared_extent_warns(caplog):
         mock.patch("torch.mps.compile_shader", return_value=_MockModule()),
         caplog.at_level(logging.WARNING, logger="tilelang.jit.adapter.torch.metal"),
     ):
-        tilelang.compile(pf, execution_backend="torch", target="metal")
+        _compile(pf)
     assert any("no mask/offset guard evidence" in r.message and "'a'" in r.message for r in caplog.records), (
         f"expected guard-audit warning, got {[r.message for r in caplog.records]}"
     )
@@ -1731,7 +1741,7 @@ def adapter_expr_int_float_scalar_tail(A: T.Tensor((64,), "float32"), scalar_i: 
 
 
 def _adapter_expr_run(prim, out_idx, call_args, expected):
-    kern = tilelang.compile(prim, out_idx=out_idx, execution_backend="torch", target="metal")
+    kern = _compile(prim, out_idx=out_idx)
     got = kern(*call_args)
     torch.mps.synchronize()
     err = np.abs(got.cpu().numpy() - expected).max()
@@ -1764,7 +1774,7 @@ def test_loop_local_bind_snapshot():
     site. The loop rebinds OUT to args slot 0 then
     slot 1; without the snapshot both sites resolve the final (slot 1)
     binding and the plan would enqueue two identical launches."""
-    kern = tilelang.compile(completion_inplace, execution_backend="torch", target="metal")
+    kern = _compile(completion_inplace)
     art = kern.artifact
     device_mod = art.device_mod
     assert "completion_inplace_kernel" in device_mod
@@ -1892,4 +1902,4 @@ def test_annotate_capacity_dims_rejects_unknown_name():
 
     bad_attr = valid_capacity_attr.with_attr("tilelang_capacity_dims", {"B": (0,)})
     with pytest.raises(ValueError, match="unknown tensor parameter"):
-        tilelang.compile(bad_attr, out_idx=[1], execution_backend="torch", target="metal")
+        _compile(bad_attr, out_idx=[1])

--- a/testing/python/metal/test_metal_arg_binding.py
+++ b/testing/python/metal/test_metal_arg_binding.py
@@ -12,6 +12,9 @@ automatically:
   4. buffer + scalar interleave (A, S, B, OUT)
   5. odd/tail shapes (rows not multiple of 128, dim not multiple of 64)
   6. read-only alias (same tensor bound to two inputs)
+  7. non-trailing out_idx (A, OUT, B) with an input after the output
+  8. non-trailing out_idx + scalar (A, OUT, S, B)
+  9. non-trailing multiple outputs (A, OUT1, B, OUT2)
 
 Every case: fp64 oracle, NaN sentinel prefill, real GPU execution,
 torch.mps.synchronize(), exact error threshold. Failing = ABI regression.
@@ -243,3 +246,83 @@ def test_abi_readonly_alias():
         oracle,
         "alias(X==Y)",
     )
+
+
+# ---------------------------------------------------------------- 7. non-trailing out_idx (A, OUT, B)
+# Non-trailing outputs are the packed-ABI stress case: under the
+# callee-allocated output ABI (CUDA tilelang_out_idx path) MakePackedAPI
+# assigns packed FFI slots ONLY to non-output parameters (out_idx positions
+# are skipped and an allocator anchor is appended), so every input AFTER a
+# non-trailing output has a packed slot that differs from its public index;
+# the adapter must remap through the non-output parameter list or the later
+# input is silently bound to the launcher's freshly allocated output tensor.
+# Under the legacy layout (Metal today) the packed slot equals the public
+# index; these tests pin the contract for both.
+@T.prim_func
+def non_trailing_out_mid(
+    A: T.Tensor((64,), "float32"),
+    OUT: T.Tensor((64,), "float32"),
+    B: T.Tensor((64,), "float32"),
+):
+    with T.Kernel(64) as bx:
+        OUT[bx] = A[bx] * 2.0 + B[bx]
+
+
+def test_abi_non_trailing_out_idx_mid():
+    g = np.random.default_rng(29)
+    A = g.normal(size=(64,)).astype(np.float32)
+    B = g.normal(size=(64,)).astype(np.float32)
+    kern = tilelang.compile(non_trailing_out_mid, out_idx=[1], execution_backend="torch", target="metal")
+    out = kern(torch.from_numpy(A).to("mps"), torch.from_numpy(B).to("mps"))
+    torch.mps.synchronize()
+    err = np.abs(out.cpu().numpy() - (A * 2.0 + B)).max()
+    assert err < 1e-4, f"[non-trailing out_idx mid] binding mismatch: max_abs_err={err}"
+
+
+# ---------------------------------------------------------------- 8. non-trailing out_idx + scalar (A, OUT, S, B)
+@T.prim_func
+def non_trailing_out_scalar(
+    A: T.Tensor((64,), "float32"),
+    OUT: T.Tensor((64,), "float32"),
+    S: T.int32,
+    B: T.Tensor((64,), "float32"),
+):
+    with T.Kernel(64) as bx:
+        OUT[bx] = A[bx] * T.cast(S, T.float32) + B[bx]
+
+
+def test_abi_non_trailing_out_idx_scalar():
+    g = np.random.default_rng(31)
+    A = g.normal(size=(64,)).astype(np.float32)
+    B = g.normal(size=(64,)).astype(np.float32)
+    S = 3
+    kern = tilelang.compile(non_trailing_out_scalar, out_idx=[1], execution_backend="torch", target="metal")
+    out = kern(torch.from_numpy(A).to("mps"), S, torch.from_numpy(B).to("mps"))
+    torch.mps.synchronize()
+    err = np.abs(out.cpu().numpy() - (A * S + B)).max()
+    assert err < 1e-4, f"[non-trailing out_idx scalar] binding mismatch: max_abs_err={err}"
+
+
+# ---------------------------------------------------------------- 9. non-trailing multiple outputs (A, OUT1, B, OUT2)
+@T.prim_func
+def non_trailing_out_multi(
+    A: T.Tensor((64,), "float32"),
+    OUT1: T.Tensor((64,), "float32"),
+    B: T.Tensor((64,), "float32"),
+    OUT2: T.Tensor((64,), "float32"),
+):
+    with T.Kernel(64) as bx:
+        OUT1[bx] = A[bx] + B[bx]
+        OUT2[bx] = A[bx] * B[bx]
+
+
+def test_abi_non_trailing_out_idx_multi():
+    g = np.random.default_rng(37)
+    A = g.normal(size=(64,)).astype(np.float32)
+    B = g.normal(size=(64,)).astype(np.float32)
+    kern = tilelang.compile(non_trailing_out_multi, out_idx=[1, 3], execution_backend="torch", target="metal")
+    o1, o2 = kern(torch.from_numpy(A).to("mps"), torch.from_numpy(B).to("mps"))
+    torch.mps.synchronize()
+    e1 = np.abs(o1.cpu().numpy() - (A + B)).max()
+    e2 = np.abs(o2.cpu().numpy() - (A * B)).max()
+    assert e1 < 1e-4 and e2 < 1e-4, f"[non-trailing out_idx multi] OUT1 err={e1} OUT2 err={e2}"

--- a/testing/python/metal/test_metal_arg_binding.py
+++ b/testing/python/metal/test_metal_arg_binding.py
@@ -33,6 +33,11 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+def _compile(f, out_idx=None):
+    """Compile ``f`` through the Metal eager adapter (torch execution backend)."""
+    return tilelang.compile(f, out_idx=out_idx, execution_backend="torch", target="metal")
+
+
 def _check(kern, args, out, oracle, tag, atol=1e-4):
     """Sentinel + real GPU launch + sync + numerical assert."""
     out.fill_(float("nan"))
@@ -272,7 +277,7 @@ def test_abi_non_trailing_out_idx_mid():
     g = np.random.default_rng(29)
     A = g.normal(size=(64,)).astype(np.float32)
     B = g.normal(size=(64,)).astype(np.float32)
-    kern = tilelang.compile(non_trailing_out_mid, out_idx=[1], execution_backend="torch", target="metal")
+    kern = _compile(non_trailing_out_mid, out_idx=[1])
     out = kern(torch.from_numpy(A).to("mps"), torch.from_numpy(B).to("mps"))
     torch.mps.synchronize()
     err = np.abs(out.cpu().numpy() - (A * 2.0 + B)).max()
@@ -296,7 +301,7 @@ def test_abi_non_trailing_out_idx_scalar():
     A = g.normal(size=(64,)).astype(np.float32)
     B = g.normal(size=(64,)).astype(np.float32)
     S = 3
-    kern = tilelang.compile(non_trailing_out_scalar, out_idx=[1], execution_backend="torch", target="metal")
+    kern = _compile(non_trailing_out_scalar, out_idx=[1])
     out = kern(torch.from_numpy(A).to("mps"), S, torch.from_numpy(B).to("mps"))
     torch.mps.synchronize()
     err = np.abs(out.cpu().numpy() - (A * S + B)).max()
@@ -320,7 +325,7 @@ def test_abi_non_trailing_out_idx_multi():
     g = np.random.default_rng(37)
     A = g.normal(size=(64,)).astype(np.float32)
     B = g.normal(size=(64,)).astype(np.float32)
-    kern = tilelang.compile(non_trailing_out_multi, out_idx=[1, 3], execution_backend="torch", target="metal")
+    kern = _compile(non_trailing_out_multi, out_idx=[1, 3])
     o1, o2 = kern(torch.from_numpy(A).to("mps"), torch.from_numpy(B).to("mps"))
     torch.mps.synchronize()
     e1 = np.abs(o1.cpu().numpy() - (A + B)).max()

--- a/testing/python/metal/test_metal_arg_binding.py
+++ b/testing/python/metal/test_metal_arg_binding.py
@@ -1,0 +1,245 @@
+"""ABI/RUNTIME regression corpus: MetalKernelAdapter argument binding.
+
+SplitHostDevice sorts device parameters by handle class and name; the adapter
+must permute user arguments to the resulting order. The corpus is designed so
+that any future parameter
+reordering, host lowering change, or adapter modification is caught
+automatically:
+
+  1. non-alphabetical buffer names (Q, COS, SIN, Y)
+  2. strongly reversed names (Z, A, INPUT, OUT)
+  3. multiple outputs (X, Y, Z, OUT1, OUT2)
+  4. buffer + scalar interleave (A, S, B, OUT)
+  5. odd/tail shapes (rows not multiple of 128, dim not multiple of 64)
+  6. read-only alias (same tensor bound to two inputs)
+
+Every case: fp64 oracle, NaN sentinel prefill, real GPU execution,
+torch.mps.synchronize(), exact error threshold. Failing = ABI regression.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+import tilelang
+import tilelang.language as T
+
+pytestmark = pytest.mark.skipif(
+    not torch.backends.mps.is_available(),
+    reason="PyTorch MPS device is required",
+)
+
+
+def _check(kern, args, out, oracle, tag, atol=1e-4):
+    """Sentinel + real GPU launch + sync + numerical assert."""
+    out.fill_(float("nan"))
+    torch.mps.synchronize()
+    kern(*args, out)
+    torch.mps.synchronize()
+    assert not torch.isnan(out).any(), f"[{tag}] output not fully written (tail/region)"
+    err = np.abs(out.cpu().numpy() - oracle).max()
+    assert err < atol, f"[{tag}] binding mismatch: max_abs_err={err}"
+
+
+# ---------------------------------------------------------------- 1. rope (Q, COS, SIN, Y)
+@tilelang.jit
+def rope_kernel(R, D):
+    @T.prim_func
+    def rope(
+        Q: T.Tensor((R, D), "float32"),
+        COS: T.Tensor((R, D), "float32"),
+        SIN: T.Tensor((R, D), "float32"),
+        Y: T.Tensor((R, D), "float32"),
+    ):
+        with T.Kernel(R) as bx:
+            for d in T.serial(D // 2):
+                Y[bx, d] = Q[bx, d] * COS[bx, d] - Q[bx, d + D // 2] * SIN[bx, d]
+                Y[bx, d + D // 2] = Q[bx, d + D // 2] * COS[bx, d + D // 2] + Q[bx, d] * SIN[bx, d + D // 2]
+
+    return rope
+
+
+def test_abi_rope_non_alphabetical():
+    R, D = 64, 32
+    g = np.random.default_rng(7)
+    Q = g.normal(size=(R, D)).astype(np.float32)
+    C = g.normal(size=(R, D)).astype(np.float32)
+    S = g.normal(size=(R, D)).astype(np.float32)
+    d0 = np.arange(D // 2)
+    oracle = np.empty_like(Q)
+    oracle[:, d0] = Q[:, d0] * C[:, d0] - Q[:, d0 + D // 2] * S[:, d0]
+    oracle[:, d0 + D // 2] = Q[:, d0 + D // 2] * C[:, d0 + D // 2] + Q[:, d0] * S[:, d0 + D // 2]
+    _check(
+        rope_kernel(R, D),
+        [torch.from_numpy(Q).to("mps"), torch.from_numpy(C).to("mps"), torch.from_numpy(S).to("mps")],
+        torch.zeros(R, D, device="mps"),
+        oracle,
+        "rope(Q,COS,SIN,Y)",
+    )
+
+
+# ---------------------------------------------------------------- 2. reversed names (Z, A, INPUT, OUT)
+@tilelang.jit
+def mixed_kernel(R, D):
+    @T.prim_func
+    def mix(
+        Z: T.Tensor((R, D), "float32"),
+        A: T.Tensor((R, D), "float32"),
+        INPUT: T.Tensor((R, D), "float32"),
+        OUT: T.Tensor((R, D), "float32"),
+    ):
+        with T.Kernel(R) as bx:
+            for d in T.serial(D):
+                OUT[bx, d] = Z[bx, d] * A[bx, d] + INPUT[bx, d]
+
+    return mix
+
+
+def test_abi_reversed_names():
+    R, D = 32, 64
+    g = np.random.default_rng(11)
+    Z = g.normal(size=(R, D)).astype(np.float32)
+    A = g.normal(size=(R, D)).astype(np.float32)
+    I = g.normal(size=(R, D)).astype(np.float32)
+    oracle = Z * A + I
+    _check(
+        mixed_kernel(R, D),
+        [torch.from_numpy(Z).to("mps"), torch.from_numpy(A).to("mps"), torch.from_numpy(I).to("mps")],
+        torch.zeros(R, D, device="mps"),
+        oracle,
+        "mix(Z,A,INPUT,OUT)",
+    )
+
+
+# ---------------------------------------------------------------- 3. multiple outputs (X, Y, Z, OUT1, OUT2)
+@tilelang.jit
+def multiout_kernel(R, D):
+    @T.prim_func
+    def multi(
+        X: T.Tensor((R, D), "float32"),
+        Y: T.Tensor((R, D), "float32"),
+        Z: T.Tensor((R, D), "float32"),
+        OUT1: T.Tensor((R, D), "float32"),
+        OUT2: T.Tensor((R, D), "float32"),
+    ):
+        with T.Kernel(R) as bx:
+            for d in T.serial(D):
+                OUT1[bx, d] = X[bx, d] + Y[bx, d]
+                OUT2[bx, d] = X[bx, d] * Z[bx, d] - Y[bx, d]
+
+    return multi
+
+
+def test_abi_multiple_outputs():
+    R, D = 16, 32
+    g = np.random.default_rng(13)
+    X = g.normal(size=(R, D)).astype(np.float32)
+    Y = g.normal(size=(R, D)).astype(np.float32)
+    Z = g.normal(size=(R, D)).astype(np.float32)
+    o1, o2 = X + Y, X * Z - Y
+    kern = multiout_kernel(R, D)
+    out1 = torch.zeros(R, D, device="mps")
+    out2 = torch.zeros(R, D, device="mps")
+    kern(
+        torch.from_numpy(X).to("mps"),
+        torch.from_numpy(Y).to("mps"),
+        torch.from_numpy(Z).to("mps"),
+        out1,
+        out2,
+    )
+    torch.mps.synchronize()
+    # OUT1/OUT2 are both prefilled NaN; binding errors swap or garble them
+    e1 = np.abs(out1.cpu().numpy() - o1).max()
+    e2 = np.abs(out2.cpu().numpy() - o2).max()
+    assert e1 < 1e-4 and e2 < 1e-4, f"[multiout] OUT1 err={e1} OUT2 err={e2}"
+
+
+# ---------------------------------------------------------------- 4. buffer + scalar interleave (A, S, B, OUT)
+@tilelang.jit
+def saxpy_kernel(N):
+    @T.prim_func
+    def saxpy(
+        A: T.Tensor((N,), "float32"),
+        S: T.int32,
+        B: T.Tensor((N,), "float32"),
+        OUT: T.Tensor((N,), "float32"),
+    ):
+        with T.Kernel(N) as bx:
+            OUT[bx] = A[bx] * T.cast(S, T.float32) + B[bx]
+
+    return saxpy
+
+
+def test_abi_buffer_scalar_interleave():
+    N = 128
+    g = np.random.default_rng(17)
+    A = g.normal(size=(N,)).astype(np.float32)
+    B = g.normal(size=(N,)).astype(np.float32)
+    S = 3
+    oracle = A * S + B
+    _check(
+        saxpy_kernel(N),
+        [torch.from_numpy(A).to("mps"), S, torch.from_numpy(B).to("mps")],
+        torch.zeros(N, device="mps"),
+        oracle,
+        "saxpy(A,S,B,OUT)",
+    )
+
+
+# ---------------------------------------------------------------- 5. odd/tail shapes
+@tilelang.jit
+def tail_kernel(R, D):
+    @T.prim_func
+    def tail(
+        INPUT: T.Tensor((R, D), "float32"),
+        OUT: T.Tensor((R, D), "float32"),
+    ):
+        with T.Kernel(R) as bx:
+            for d in T.serial(D):
+                OUT[bx, d] = INPUT[bx, d] * 2.0
+
+    return tail
+
+
+def test_abi_odd_tail_shapes():
+    for R, D in [(31, 96), (127, 33), (1, 7), (257, 128)]:
+        g = np.random.default_rng(R + D)
+        X = g.normal(size=(R, D)).astype(np.float32)
+        _check(
+            tail_kernel(R, D),
+            [torch.from_numpy(X).to("mps")],
+            torch.zeros(R, D, device="mps"),
+            X * 2.0,
+            f"tail(R={R},D={D})",
+        )
+
+
+# ---------------------------------------------------------------- 6. read-only alias
+@tilelang.jit
+def alias_kernel(R, D):
+    @T.prim_func
+    def alias(
+        X: T.Tensor((R, D), "float32"),
+        Y: T.Tensor((R, D), "float32"),
+        OUT: T.Tensor((R, D), "float32"),
+    ):
+        with T.Kernel(R) as bx:
+            for d in T.serial(D):
+                OUT[bx, d] = X[bx, d] * Y[bx, d] + X[bx, d]
+
+    return alias
+
+
+def test_abi_readonly_alias():
+    R, D = 32, 16
+    g = np.random.default_rng(19)
+    X = g.normal(size=(R, D)).astype(np.float32)
+    oracle = X * X + X
+    x_t = torch.from_numpy(X).to("mps")
+    _check(
+        alias_kernel(R, D),
+        [x_t, x_t],  # same tensor bound to X and Y (read-only alias)
+        torch.zeros(R, D, device="mps"),
+        oracle,
+        "alias(X==Y)",
+    )

--- a/tilelang/jit/adapter/torch/metal.py
+++ b/tilelang/jit/adapter/torch/metal.py
@@ -1,6 +1,122 @@
+"""Metal eager adapter (torch.mps.compile_shader) with a host-call-site launch plan.
+
+This adapter is the supported Metal execution path for the torch backend. It
+launches every kernel of a (possibly multi-kernel) module in the exact order
+of the lowered host entry's ``tirx.tvm_call_packed`` call sites, binds every
+MSL buffer slot to either a public call-signature parameter, a compiler
+generated host allocation (``T.alloc_global`` workspace), or a runtime
+dynamic symbol (symbolic scalar such as ``N``), allocates ``out_idx`` outputs
+and compiler-generated buffers, and pins every buffer of a launch batch with
+a completion fence until the enqueued work finishes.
+
+Design notes:
+
+- Scalar interleave: shape resolution only ever consumes actual tensor
+  arguments; scalars stay in the positional ``full`` binding but never
+  contribute shapes.
+- Dynamic ``out_idx``: a runtime symbol table keyed by ``tirx.Var``
+  identity is built from caller-supplied tensor inputs only; output /
+  workspace dimensions (``IntImm``, ``Var``, or general ``PrimExpr`` such as
+  ``N + 1``) are evaluated against it, with an explicit error when a symbol
+  cannot be determined.
+- Compiler-generated buffers: binding information comes from the
+  lowered host call site / allocation semantics (``AllocBuffer`` nodes), not
+  from assuming every device parameter back-references a user parameter name.
+- Multi-kernel ordering: the launch plan follows the host call sites in
+  program order (duplicates preserved, constant-extent host loops expanded
+  with the loop variable substituted into call-site arguments and launch
+  geometry; statically resolvable conditionals follow their branch;
+  runtime-dependent control flow is rejected at plan build time).
+- Aborted launch batches: the keepalive fence is established from the
+  first successful enqueue via ``try/finally``; an exception mid-batch still
+  pins everything already submitted, and event-record failures fall back to
+  ``torch.mps.synchronize()``.
+- One-shot release: a background reaper thread drops each batch's
+  strong refs when its completion event fires, so a single launch does not
+  hold tensors until the next launch; the global queue also outlives the
+  adapter (destruction path). Reaping is batch-atomic (observation outside
+  the lock, removal under the lock with a head re-check), so concurrent
+  releasers can never pop a batch they did not observe finished; a query
+  exception transitions through ``torch.mps.synchronize()`` (drop) or moves
+  the batch to a pinned stuck list out of the head-of-line path.
+
+Call-site contract:
+
+- Every device parameter is bound from the *call site's* actual argument
+  (``args[1:1 + len(device_func.params)]``, the same slice the common
+  ``wrapper.py`` uses), resolved to public parameters through the FFI
+  ``args`` slot index (``tirx.tvm_struct_get(args, i, ...)`` chains) instead
+  of device-parameter names, to compiler-generated allocations through the
+  ``AllocBuffer`` data-handle ``tirx.Var`` identity, or to constants /
+  symbolic scalars / general expressions.
+- Grid/block geometry comes from the launch arguments appended after the
+  function arguments by ``LowerDeviceKernelLaunch`` (already substituted
+  into the caller's scope), mapped to axes by the device function's
+  ``tirx.kernel_launch_params`` attribute.
+- ``_BufferBinding.symbol`` stores the ``tirx.Var`` object (identity), not a
+  name string; the runtime symbol table is keyed by ``tirx.Var`` identity
+  with an unambiguous-name fallback only.
+
+Shape and host-loop validation:
+
+- Retained-prefix validation: the trailing-singleton rank relaxation drops
+  only trailing declared dims that are all constant 1, then EVERY retained
+  dimension of the relaxed param must equal the actual extent -- ``Var``
+  dims are bound by identity, constant / general-expression dims are
+  validated against the runtime symbol table.  A declared ``(7, 1)`` param
+  fed a ``(3,)`` tensor is rejected instead of launching static geometry 7
+  over a three-element buffer (GPU out-of-bounds).
+- Nested static host loops: ``For`` bounds are substituted with the outer
+  constant iterations and simplified before the constant check, so an inner
+  bound like ``_i + 1`` is statically enumerable and never mistaken for a
+  runtime loop.
+
+Strict extent validation:
+
+- Rank matching is no longer a validation criterion.  EVERY declared
+  dimension of EVERY tensor input is validated exactly (constants and
+  general expressions must equal the caller's actual extent; ``Var`` dims
+  bind by identity) UNLESS the dimension is explicitly declared as a
+  *capacity* dimension in the compiled contract (PrimFunc attr
+  ``tilelang_capacity_dims``).  Unmarked rank-matched constant dims that
+  differ from the actual extent (e.g. declared ``(7,)`` fed a ``(3,)``
+  tensor) are rejected before launch.
+
+Explicit capacity dimensions:
+
+- Capacity marking is EXPLICIT opt-in only.  The eager-jit pipeline no
+  longer infers capacity dims from tensor annotations that reference
+  scalar function parameters (the round-4 HIGH: ``B_q(E, N, (K+1)//2)``
+  had its ordinary exact dims ``E``/``N`` auto-exempted).  Eager kernels
+  declare capacity dims in the body via
+  ``T.annotate_capacity_dims({"A_q": (0,)})``; lazy kernels opt in via
+  ``func.with_attr("tilelang_capacity_dims", {"W": (0,)})``.  Everything
+  unmarked stays strictly validated.
+- The adapter runs an advisory guard audit on every explicitly declared
+  capacity dim: it collects structural evidence (condition comparisons
+  against non-declared bounds, runtime-bounded loops, min clamps) for
+  every access of the marked buffer along the marked dim and warns when a
+  dim has no accesses or ANY access lacks guard evidence.  The audit is
+  evidence, never a rejection: the explicit declaration is the trust
+  boundary. Both caller directions
+  are legal for a capacity dim -- declared > actual (padded/masked grouped
+  QMM) and declared < actual (active-prefix processing of a larger
+  allocation); safety for the former
+  rests on the kernel's masks, which the audit advises on.
+"""
+
 from __future__ import annotations
-from functools import wraps
+
+import contextlib
+import logging
+import numbers
+import os
+import struct
+import threading
+from collections import deque
 from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
 
 import torch
 from tvm import tirx
@@ -10,6 +126,765 @@ from tilelang import tvm as tvm
 from ..base import BaseKernelAdapter
 from tilelang.engine.param import KernelParam
 
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level keepalive reaper: batches live in a global queue so they
+# are reaped on completion regardless of the adapter's lifetime; the reaper
+# is a single lazily-started daemon thread.  Reaping is batch-atomic: the
+# completion observation happens outside the lock, the removal happens under
+# the lock and re-checks that the queue head is still the observed batch, so
+# concurrent releasers (reaper / launcher / destructor) can never pop a
+# batch they did not observe finished.
+# ---------------------------------------------------------------------------
+_KEEPALIVE_POLL_SECONDS = float(os.environ.get("TILELANG_METAL_KEEPALIVE_POLL_MS", "20")) / 1000.0
+
+_pending_keepalive: deque[tuple[tuple[torch.Tensor, ...], Any]] = deque()
+# Batches whose event query raised and whose synchronize fallback also
+# failed (MPS teardown): kept pinned (fail-safe) but out of the head-of-line
+# path, retried on later drains.
+_stuck_keepalive: list[tuple[tuple[torch.Tensor, ...], Any]] = []
+_keepalive_lock = threading.Lock()
+_reaper_lock = threading.Lock()
+_reaper_thread: threading.Thread | None = None
+# Wake event for the reaper: appended batches set it so the reaper drains
+# immediately instead of waiting out the poll interval; tests pause reaping
+# by setting ``_KEEPALIVE_POLL_SECONDS`` large and wake it by setting this.
+_reaper_wakeup = threading.Event()
+
+
+def _retry_stuck_keepalive() -> None:
+    """Release stuck batches once a later query proves them finished.
+
+    Batches in ``_stuck_keepalive`` stay strongly referenced (fail-safe
+    direction) until a query succeeds; removal is per batch identity (the
+    event object).
+    """
+    if not _stuck_keepalive:
+        return
+    for _batch, ev in list(_stuck_keepalive):
+        try:
+            done = bool(ev.query())
+        except Exception:
+            done = False
+        if done:
+            with _keepalive_lock:
+                _stuck_keepalive[:] = [e for e in _stuck_keepalive if e[1] is not ev]
+
+
+def _release_finished_work() -> None:
+    """Drop keepalive batches whose completion event has already fired.
+
+    Observation (``ev.query()``) happens *outside* the lock; removal happens
+    *under* the lock and re-checks that the queue head is still the observed
+    batch.  Two concurrent releasers therefore pop at most one batch each,
+    and a batch is only ever removed after it was observed finished (no
+    second ``popleft`` can steal the next, still-running batch).
+
+    A query exception is a state transition, not a stall: ``synchronize()``
+    proves all enqueued work completed, so the batch can be dropped; if the
+    synchronize itself fails (MPS teardown), the batch is moved to the stuck
+    list -- still pinned, but no longer blocking the queue head.
+    """
+    while True:
+        with _keepalive_lock:
+            if not _pending_keepalive:
+                break
+            batch, ev = _pending_keepalive[0]
+        try:
+            done = bool(ev.query())
+        except Exception:
+            done = None
+        if done is True:
+            with _keepalive_lock:
+                if _pending_keepalive and _pending_keepalive[0][1] is ev:
+                    _pending_keepalive.popleft()
+            continue
+        if done is False:
+            break
+        # Query error: transition through a full synchronize; the sync
+        # completes (or fails for) every enqueued batch.
+        try:
+            torch.mps.synchronize()
+        except Exception:
+            with _keepalive_lock:
+                if _pending_keepalive and _pending_keepalive[0][1] is ev:
+                    _pending_keepalive.popleft()
+                    _stuck_keepalive.append((batch, ev))
+            continue
+        with _keepalive_lock:
+            if _pending_keepalive and _pending_keepalive[0][1] is ev:
+                _pending_keepalive.popleft()
+        continue
+    _retry_stuck_keepalive()
+
+
+def _track_keepalive(refs: list[torch.Tensor]) -> None:
+    """Pin ``refs`` (deduplicated) until the enqueued work completes.
+
+    A completion event is recorded on the MPS stream after the batch was
+    enqueued; the background reaper drops the strong refs once the event
+    fires. If the event cannot be created/recorded, synchronize instead so
+    dropping the refs cannot dangle.
+    """
+    unique: list[torch.Tensor] = []
+    seen: set[int] = set()
+    for r in refs:
+        if isinstance(r, torch.Tensor) and id(r) not in seen:
+            seen.add(id(r))
+            unique.append(r)
+    if not unique:
+        return
+    try:
+        ev = torch.mps.Event()
+        ev.record()
+    except Exception:
+        # Fence unavailable (MPS teardown / allocation failure): block until
+        # the enqueued work finishes, then dropping the refs is safe.
+        torch.mps.synchronize()
+        return
+    _pending_keepalive.append((tuple(unique), ev))
+    _ensure_reaper()
+    # Wake the reaper immediately: it drains on the event instead of
+    # waiting out the whole poll interval (also makes test pause/resume
+    # deterministic).
+    _reaper_wakeup.set()
+
+
+def _reaper_loop() -> None:
+    while True:
+        with contextlib.suppress(Exception):
+            _release_finished_work()
+        # Interruptible sleep: ``_KEEPALIVE_POLL_SECONDS`` is read at call
+        # time (tests pause reaping by updating the module global) and a new
+        # batch wakes the reaper immediately via ``_reaper_wakeup``.
+        _reaper_wakeup.wait(timeout=_KEEPALIVE_POLL_SECONDS)
+        _reaper_wakeup.clear()
+
+
+def _ensure_reaper() -> None:
+    global _reaper_thread
+    with _reaper_lock:
+        if _reaper_thread is None or not _reaper_thread.is_alive():
+            _reaper_thread = threading.Thread(
+                target=_reaper_loop,
+                name="tilelang-metal-keepalive",
+                daemon=True,
+            )
+            _reaper_thread.start()
+
+
+# ---------------------------------------------------------------------------
+# Module-level launch-time resolvers.  These are plain functions (no ``self``)
+# so the launcher closure never captures the adapter, keeping the destruction
+# path deterministic with provable ``__del__`` cleanup.
+# ---------------------------------------------------------------------------
+def _symbol_value(var: Any, symtab: dict[Any, int]) -> int:
+    """Resolve a dynamic scalar symbol by ``tirx.Var`` identity.
+
+    The call-site symbol is normally the same ``tirx.Var`` object that
+    appears in the public parameter shapes (identity key).  When a lowering
+    step produced a distinct object, fall back to the name only if it is
+    unambiguous -- two same-named symbols of different identity are an error,
+    never a silent first match.
+    """
+    value = symtab.get(var)
+    if value is not None:
+        return value
+    name = str(var)
+    matches = [v for k, v in symtab.items() if str(k) == name]
+    if len(matches) == 1:
+        return matches[0]
+    raise RuntimeError(f"Metal adapter: dynamic scalar '{name}' is not determined by any caller-supplied tensor input shape")
+
+
+def _pack_scalar_args(scalar_slots: list[tuple[Any, Any]], device: Any) -> torch.Tensor:
+    """Pack runtime scalar kernel arguments into the Metal ``args_t`` buffer.
+
+    The Metal codegen emits every scalar function parameter inside a single
+    packed struct bound at ``buffer(num_buffer)``, with one 8-byte slot per
+    scalar (32-bit values in the low 4 bytes, 64-bit values in the full
+    slot), matching the TVM runtime's ``ArgUnion64`` packing.  The
+    ``torch.mps.compile_shader`` launcher, however, binds each positional
+    argument to its own buffer slot, so passing ``m`` separate Python
+    scalars only ever lands the first one inside the struct and silently
+    misreads the rest (for example, ``kern(a, 5, 7)`` can produce ``a + 5000``).
+    Packing every scalar into a single tensor reproduces the struct layout
+    exactly and binds it to the struct buffer slot.
+    """
+    if not scalar_slots:
+        raise RuntimeError("Metal adapter: internal error, no scalar slots to pack")
+    buf = bytearray(len(scalar_slots) * 8)
+    for i, (dtype, value) in enumerate(scalar_slots):
+        bits = int(dtype.bits)
+        if bits == 32:
+            if str(dtype) == "int32":
+                struct.pack_into("<i", buf, i * 8, int(value))
+            elif str(dtype) == "uint32":
+                struct.pack_into("<I", buf, i * 8, int(value))
+            elif str(dtype) == "float32":
+                struct.pack_into("<f", buf, i * 8, float(value))
+            else:
+                raise RuntimeError(f"Metal adapter: unsupported 32-bit scalar kernel parameter dtype '{dtype}'")
+        elif bits == 64:
+            if str(dtype) == "int64":
+                struct.pack_into("<q", buf, i * 8, int(value))
+            elif str(dtype) == "uint64":
+                struct.pack_into("<Q", buf, i * 8, int(value))
+            elif str(dtype) == "float64":
+                struct.pack_into("<d", buf, i * 8, float(value))
+            else:
+                raise RuntimeError(f"Metal adapter: unsupported 64-bit scalar kernel parameter dtype '{dtype}'")
+        else:
+            raise RuntimeError(
+                f"Metal adapter: unsupported scalar kernel parameter dtype "
+                f"'{dtype}' ({bits} bits); the Metal codegen can only "
+                "represent 32-bit and 64-bit scalar arguments in the packed "
+                "args struct"
+            )
+    return torch.frombuffer(buf, dtype=torch.uint8).to(device)
+
+
+def _resolve_int_value(
+    expr: Any,
+    symtab: dict[Any, int],
+    analyzer: Any,
+    full: list[Any] | None = None,
+    scalar_vars: dict[Any, int] | None = None,
+) -> int:
+    """Resolve an integer launch / dimension expression at call time.
+
+    ``IntImm`` / ``int`` pass through; a ``tirx.Var`` is resolved from the
+    identity-keyed symbol table, from a user scalar call-site argument (via
+    ``scalar_vars``/``full``), or from an unambiguous symbol name; general
+    ``PrimExpr`` expressions are evaluated by substituting the known values
+    and simplifying.
+    """
+    if isinstance(expr, tirx.IntImm):
+        return int(expr)
+    if isinstance(expr, int):
+        return expr
+    if isinstance(expr, tirx.Var):
+        if expr in symtab:
+            return symtab[expr]
+        if scalar_vars is not None and full is not None and expr in scalar_vars:
+            return int(full[scalar_vars[expr]])
+        name = str(expr)
+        matches = [val for k, val in symtab.items() if str(k) == name]
+        if len(matches) == 1:
+            return matches[0]
+        raise RuntimeError(f"Metal adapter: dynamic dimension symbol '{name}' is not determined by any caller-supplied tensor input shape")
+    if isinstance(expr, tirx.PrimExpr):
+        vmap: dict[Any, Any] = {}
+        for var, val in symtab.items():
+            vmap[var] = tirx.IntImm(str(var.dtype), int(val))
+        if scalar_vars is not None and full is not None:
+            for var, slot in scalar_vars.items():
+                value = full[slot]
+                if isinstance(value, numbers.Integral):
+                    vmap[var] = tirx.IntImm(str(var.dtype), int(value))
+        substituted = tvm.tirx.stmt_functor.substitute(expr, vmap) if vmap else expr
+        simplified = analyzer.simplify(substituted)
+        if isinstance(simplified, tirx.IntImm):
+            return int(simplified)
+        raise RuntimeError(f"Metal adapter: cannot resolve dynamic expression {expr} at launch time (unbound symbols remain)")
+    raise RuntimeError(f"Metal adapter: unsupported dimension {expr!r} ({type(expr).__name__})")
+
+
+def _build_symbol_table(
+    tensor_input_shapes: list[tuple[int, ...]],
+    params: list[KernelParam],
+    result_idx: list[int],
+    capacity_dims: dict[int, frozenset[int]] | None = None,
+) -> dict[Any, int]:
+    """Build a runtime symbol table keyed by ``tirx.Var`` identity.
+
+    Built from caller-supplied tensor inputs only: outputs never contribute,
+    shared symbols resolve from the input binding, and conflicting bindings
+    of the same symbol are rejected.
+
+    Shape discipline: every declared
+    dimension of every tensor input is validated against the caller's actual
+    extent -- constants and general expressions must evaluate to the exact
+    actual value, ``Var`` dimensions are bound into the symbol table by
+    identity (exact by construction).  The only accepted mismatches are:
+
+    - trailing declared dimensions that are all constant 1 (torch
+      right-aligned broadcasting, e.g. a ``(T_, 1)`` param fed a flat
+      ``(m,)`` tensor): those dimensions are dropped and the retained prefix
+      is validated as above -- a declared ``(7, 1)`` param fed a ``(3,)``
+      tensor has a 7-element kernel domain over a 3-element buffer and is
+      rejected instead of launching out of bounds;
+    - dimensions explicitly declared as *capacity* dimensions in the
+      compiled contract (``capacity_dims`` map; PrimFunc attr
+      ``tilelang_capacity_dims``, explicit opt-in only): the kernel
+      contract states the declared extent bounds every access the kernel
+      performs (internally masked/offset-guarded), so the caller's actual
+      extent may differ -- the legal padded/masked grouped-QMM pattern
+      (declared rows=64, actual per-expert slices of 15) and the
+      active-prefix pattern (declared active rows, larger allocation).
+      Both directions are legal; the guard audit
+      advises on mask evidence for the declared > actual direction.
+
+    ``capacity_dims`` maps public parameter positions to the shape-dim
+    indices that are contractually capacity declarations; everything else is
+    strict. Rank matching is not a criterion: an unmarked
+    rank-matched constant dim that differs from the actual extent is a real
+    out-of-bounds hazard and is rejected.
+    """
+    capacity_dims = capacity_dims or {}
+    symtab: dict[Any, int] = {}
+    tensor_params = [i for i in range(len(params)) if i not in result_idx and not params[i].is_scalar()]
+    if len(tensor_params) != len(tensor_input_shapes):
+        raise RuntimeError(f"Metal adapter: expected {len(tensor_params)} tensor input shapes, got {len(tensor_input_shapes)}")
+    # Phase 1: apply the trailing-singleton relaxation (dropping only
+    # trailing declared dims that are all constant 1) and bind ``Var`` dims
+    # by identity with conflict rejection.  The truncated declared dims are
+    # kept per param for phase-2 validation.
+    retained: list[tuple[int, list[Any], tuple[int, ...]]] = []
+    for param_idx, shape in zip(tensor_params, tensor_input_shapes):
+        param = params[param_idx]
+        declared = list(param.shape)
+        if len(shape) != len(declared):
+            # Allow trailing size-1 declared dims to be implicit (torch
+            # right-aligned broadcasting, e.g. a ``(T_, 1)`` param fed a flat
+            # ``(m,)`` tensor): the flat memory layout is identical, and the
+            # trailing dims are all constant 1.
+            if len(shape) < len(declared) and all(
+                (isinstance(d, tirx.IntImm) and int(d) == 1) or (isinstance(d, int) and d == 1) for d in declared[len(shape) :]
+            ):
+                declared = declared[: len(shape)]
+            else:
+                raise RuntimeError(
+                    f"Metal adapter: param {param_idx} declared rank {len(param.shape)} but caller supplied a rank-{len(shape)} tensor"
+                )
+        for dim, val in zip(declared, shape):
+            if isinstance(dim, tirx.Var):
+                prev = symtab.get(dim)
+                if prev is not None and prev != int(val):
+                    raise RuntimeError(
+                        f"Metal adapter: dynamic symbol '{dim}' bound to conflicting sizes {prev} and {int(val)} by caller-supplied tensors"
+                    )
+                symtab[dim] = int(val)
+        retained.append((param_idx, declared, tuple(shape)))
+    # Phase 2: validate EVERY retained declared dimension of EVERY tensor
+    # input (constants and general expressions, e.g. ``N + 1``) against the
+    # actual extent, EXCEPT dims explicitly declared as capacity dimensions
+    # (``capacity_dims``).  ``Var`` dims were bound in phase 1 (identity) and
+    # are exact by construction.  A mismatched extent would launch the
+    # static geometry over a buffer of a different size (GPU OOB).  Rank
+    # matching or relaxation is NOT a criterion: an unmarked rank-matched
+    # constant dim must still match exactly.
+    analyzer = tvm.arith.Analyzer()
+    for var, val in symtab.items():
+        analyzer.bind(var, val)
+    for param_idx, declared, shape in retained:
+        cap = capacity_dims.get(param_idx, ())
+        for dim_idx, (dim, val) in enumerate(zip(declared, shape)):
+            if dim_idx in cap:
+                # Explicit capacity declaration (PrimFunc attr
+                # ``tilelang_capacity_dims``, explicit opt-in): the
+                # kernel contract states the declared extent bounds every
+                # access (masked/offset-guarded), so the caller's actual
+                # extent may differ in EITHER direction -- declared >
+                # actual (padded/masked grouped QMM: declared rows=64,
+                # actual per-expert slices of 15) or declared < actual
+                # (active-prefix processing of a larger allocation).
+                # The guard audit advises on mask
+                # evidence; the explicit declaration is the trust
+                # boundary.
+                continue
+            if isinstance(dim, tirx.Var):
+                continue
+            actual = _resolve_int_value(dim, symtab, analyzer)
+            if actual != int(val):
+                raise RuntimeError(
+                    f"Metal adapter: param {param_idx} declared dimension "
+                    f"{dim} evaluates to {actual} but caller supplied "
+                    f"{int(val)}; declared and actual tensor extents must "
+                    "match exactly (a mismatched extent would launch the "
+                    "static geometry over a buffer of a different size) "
+                    "unless the dimension is explicitly declared as a "
+                    "capacity dimension"
+                )
+    return symtab
+
+
+def _eval_param_shape(symtab: dict[Any, int], param: Any) -> tuple[int, ...]:
+    """Resolve every dimension of ``param`` (KernelParam or tirx.Buffer)."""
+    analyzer = tvm.arith.Analyzer()
+    for var, val in symtab.items():
+        analyzer.bind(var, val)
+    return tuple(_resolve_int_value(d, symtab, analyzer) for d in param.shape)
+
+
+# ---------------------------------------------------------------------------
+# Capacity-dimension guard audit
+# ---------------------------------------------------------------------------
+# Capacity dims are exempt from strict extent validation ONLY when explicitly
+# declared (``T.annotate_capacity_dims`` in the eager DSL /
+# ``tilelang_capacity_dims`` attr for lazy kernels).  The exemption is a
+# contract: the kernel must bound its accesses along the marked dim by a
+# runtime mask/offset guard so that a smaller actual buffer is never
+# accessed out of bounds.  The audit below gathers STRUCTURAL evidence for
+# such guards from the compiled body (best-effort, advisory): it warns when
+# a marked dim has no accesses or no guard evidence at all, and never
+# rejects -- the explicit declaration is the trust boundary, and the audit
+# provides evidence for it.
+#
+# Evidence rules (an access is guarded when ANY holds):
+#   - condition: an enclosing ``Select`` / ``IfThenElse`` condition (only
+#     ``And`` conjuncts) UPPER-bounds a subexpression of the access index
+#     with a bound that is not the declared extent (not structurally
+#     equal to it and not derived from it) and not derived from the index
+#     itself. For a
+#     capacity dim the danger is an index that runs past the extent, so
+#     only comparisons that bound the index from above count (``idx < b``
+#     / ``idx <= b`` / ``b > idx`` / ``b >= idx``); lower-bound
+#     comparisons such as ``idx >= 0`` or ``idx > m`` do not protect that
+#     direction and are not evidence;
+#   - loop extent: an enclosing loop whose extent is not the declared
+#     extent and whose loop variable occurs in the access index (TIR loops
+#     bound their variable from above by construction);
+#   - clamp: the access index contains a ``Min`` that bounds it from above
+#     with operands all not derived from the declared extent (``Max``
+#     clamps from below -- it can only grow the index -- and is not
+#     evidence by itself; its children are still searched).
+#
+# Known limitations (documented): the eager-jit pipeline bakes scalar
+# parameters into constants before the adapter sees the PrimFunc, so a
+# guard whose bound is ``declared - 1`` (e.g. a clamp to ``rows - 1``) is
+# indistinguishable from a runtime bound after baking and counts as weak
+# evidence.  The audit is therefore advisory only.
+# ---------------------------------------------------------------------------
+
+
+def _expr_children(expr: Any) -> tuple[Any, ...]:
+    """Direct sub-expressions of a TIR expression (best-effort)."""
+    if isinstance(expr, tirx.Select):
+        return (expr.condition, expr.true_value, expr.false_value)
+    if isinstance(expr, tirx.Call):
+        return tuple(expr.args)
+    if isinstance(expr, tirx.BufferLoad):
+        return tuple(expr.indices)
+    if isinstance(expr, tirx.Cast):
+        return (expr.value,)
+    if isinstance(
+        expr,
+        (
+            tirx.Add,
+            tirx.Sub,
+            tirx.Mul,
+            tirx.Div,
+            tirx.FloorDiv,
+            tirx.FloorMod,
+            tirx.Mod,
+            tirx.Min,
+            tirx.Max,
+        ),
+    ):
+        return (expr.a, expr.b)
+    if isinstance(expr, (tirx.LT, tirx.LE, tirx.GT, tirx.GE, tirx.EQ, tirx.NE, tirx.And, tirx.Or)):
+        return (expr.a, expr.b)
+    if isinstance(expr, tirx.Not):
+        return (expr.a,)
+    if isinstance(expr, tirx.Let):
+        return (expr.value, expr.body)
+    if isinstance(expr, tirx.Ramp):
+        return (expr.base, expr.stride)
+    if isinstance(expr, tirx.Broadcast):
+        return (expr.value,)
+    return ()
+
+
+def _struct_eq(a: Any, b: Any) -> bool:
+    """Structural equality for the audit's comparisons.
+
+    Vars compare by name + dtype (NOT identity): the eager/lazy pipeline
+    redeclares buffers inside the body (``DeclBuffer``), so a symbolic
+    shape Var in the body is a different object than the ``buffer_map``
+    extent it came from -- a guard against the declared extent is a no-op
+    and must not count as evidence, and a runtime bound with a different
+    name must stay a runtime bound.  (``tvm.ir.structural_equal(...,
+    map_free_vars=True)`` cannot be used: it unifies ANY two free Vars,
+    making ``bx`` "contain" ``tx``.)
+    """
+    if isinstance(a, tirx.Var) and isinstance(b, tirx.Var):
+        return a.name == b.name and a.dtype == b.dtype
+    try:
+        return tvm.ir.structural_equal(a, b)
+    except Exception:
+        return False
+
+
+def _structural_contains(expr: Any, sub: Any) -> bool:
+    """True iff ``sub`` is structurally equal to ``expr`` or to a subtree
+    of ``expr`` (best-effort; analysis failures return False)."""
+    if _struct_eq(expr, sub):
+        return True
+    return any(_structural_contains(child, sub) for child in _expr_children(expr))
+
+
+def _condition_bounds_access(cond: Any, idx: Any, declared: Any) -> bool:
+    """Condition evidence: ``cond`` UPPER-bounds the access index ``idx``
+    using direction-aware comparisons. For a capacity dim
+    the danger is an index that runs past the extent, so only comparisons
+    that bound ``idx`` from above count -- ``idx < b`` / ``idx <= b``
+    (index on the left) and ``b > idx`` / ``b >= idx`` (index on the
+    right).  Lower-bound comparisons (``idx >= 0``, ``idx > m``,
+    ``b < idx``) do not protect that direction and are not evidence.
+    ``And`` conjuncts are walked; ``Or`` is not evidence (a disjunct does
+    not bound the access by itself)."""
+    if isinstance(cond, tirx.And):
+        return _condition_bounds_access(cond.a, idx, declared) or _condition_bounds_access(cond.b, idx, declared)
+    if isinstance(cond, (tirx.LT, tirx.LE)) and _structural_contains(idx, cond.a):
+        # ``a < b`` / ``a <= b``: an index on the left is bounded above.
+        return _upper_bound_is_valid(cond.b, idx, declared)
+    if isinstance(cond, (tirx.GT, tirx.GE)) and _structural_contains(idx, cond.b):
+        # ``a > b`` / ``a >= b``: an index on the right is bounded above.
+        return _upper_bound_is_valid(cond.a, idx, declared)
+    return False
+
+
+def _upper_bound_is_valid(bound: Any, idx: Any, declared: Any) -> bool:
+    """A comparison bound counts as capacity evidence only when it is not
+    the declared extent (``bx < cap`` is a no-op for any smaller actual
+    buffer) and not derived from the access index itself (``bx < bx + 1``
+    is vacuous)."""
+    return not _structural_contains(bound, declared) and not _structural_contains(bound, idx)
+
+
+def _clamp_evidence(idx: Any, declared: Any) -> bool:
+    """Clamp evidence: the access index contains a ``Min`` that bounds it
+    from above with operands all not derived from the declared extent
+    using direction-aware analysis. ``Max`` clamps from
+    below -- it can only grow the index -- so it is not evidence by
+    itself; its children are still searched for a genuine ``Min``."""
+    if isinstance(idx, tirx.Min):
+        if not _structural_contains(idx.a, declared) and not _structural_contains(idx.b, declared):
+            return True
+        return _clamp_evidence(idx.a, declared) or _clamp_evidence(idx.b, declared)
+    if isinstance(idx, tirx.Max):
+        return _clamp_evidence(idx.a, declared) or _clamp_evidence(idx.b, declared)
+    return any(_clamp_evidence(child, declared) for child in _expr_children(idx))
+
+
+def _access_guarded(idx: Any, conds: list[Any], loops: list[tuple[Any, Any]], declared: Any) -> bool:
+    """Guard evidence for one access index (see module comment)."""
+    if _clamp_evidence(idx, declared):
+        return True
+    for cond in conds:
+        if _condition_bounds_access(cond, idx, declared):
+            return True
+    for var, extent in loops:
+        if _structural_contains(extent, declared):
+            continue
+        if _structural_contains(idx, var):
+            return True
+    return False
+
+
+@tirx.functor.visitor
+class _CapacityGuardAuditor(tirx.PyStmtExprVisitor):
+    """Structural guard-evidence collector for one (buffer, dim) pair.
+
+    Records every access of the target buffer along the marked dim
+    (``BufferLoad`` / ``BufferStore`` / ``BufferRegion`` inside tile-op
+    calls) together with the enclosing condition / loop context, and
+    classifies each access as guarded or unguarded (see module comment for
+    the evidence rules).  Runs once per marked dim at adapter construction.
+
+    The hooked node types recurse MANUALLY (no ``super()``): the C++
+    ``PyStmtExprVisitor`` default double-traverses a subtree when a
+    registered Python hook calls the default for the same node, which would
+    double-count every access.  Non-hooked node types keep the C++ default
+    (single traversal).
+    """
+
+    def __init__(self, buffer_name: str, dim_idx: int, declared: Any):
+        super().__init__()
+        self._buffer_name = buffer_name
+        self._dim_idx = dim_idx
+        self._declared = declared
+        self._conds: list[Any] = []
+        self._loops: list[tuple[Any, Any]] = []
+        self.accesses = 0
+        self.guarded = 0
+
+    def _is_target(self, buf: Any) -> bool:
+        try:
+            return str(buf.name) == self._buffer_name
+        except Exception:
+            return False
+
+    def _record(self, idx: Any) -> None:
+        self.accesses += 1
+        if _access_guarded(idx, self._conds, self._loops, self._declared):
+            self.guarded += 1
+
+    # -- hooks (manual recursion; see class docstring) -------------------
+
+    def visit_if_then_else_(self, op: tirx.IfThenElse) -> None:
+        self.visit_expr(op.condition)
+        self._conds.append(op.condition)
+        try:
+            self.visit_stmt(op.then_case)
+            if op.else_case is not None:
+                self.visit_stmt(op.else_case)
+        finally:
+            self._conds.pop()
+
+    def visit_select_(self, op: tirx.Select) -> None:
+        self.visit_expr(op.condition)
+        self._conds.append(op.condition)
+        try:
+            self.visit_expr(op.true_value)
+            self.visit_expr(op.false_value)
+        finally:
+            self._conds.pop()
+
+    def visit_for_(self, op: tirx.For) -> None:
+        self.visit_expr(op.min)
+        self.visit_expr(op.extent)
+        self._loops.append((op.loop_var, op.extent))
+        try:
+            self.visit_stmt(op.body)
+        finally:
+            self._loops.pop()
+
+    def visit_buffer_load_(self, op: tirx.BufferLoad) -> None:
+        if self._is_target(op.buffer) and len(op.indices) > self._dim_idx:
+            self._record(op.indices[self._dim_idx])
+        for idx in op.indices:
+            self.visit_expr(idx)
+
+    def visit_buffer_store_(self, op: tirx.BufferStore) -> None:
+        if self._is_target(op.buffer) and len(op.indices) > self._dim_idx:
+            self._record(op.indices[self._dim_idx])
+        for idx in op.indices:
+            self.visit_expr(idx)
+        self.visit_expr(op.value)
+
+    def visit_call_(self, op: tirx.Call) -> None:
+        for arg in op.args:
+            if isinstance(arg, tirx.BufferRegion):
+                self._record_region(arg)
+            elif isinstance(arg, tirx.PrimExpr):
+                self.visit_expr(arg)
+
+    def _record_region(self, region: tirx.BufferRegion) -> None:
+        if not self._is_target(region.buffer):
+            return
+        try:
+            ranges = region.region
+            if len(ranges) > self._dim_idx:
+                self._record(ranges[self._dim_idx].min)
+            # Region bounds may themselves contain loads; audit them too.
+            for rng in ranges:
+                self.visit_expr(rng.min)
+                self.visit_expr(rng.extent)
+        except Exception:
+            pass
+
+
+def _audit_capacity_guards(
+    pf: tirx.PrimFunc,
+    capacity_dims: dict[int, frozenset[int]],
+    name_to_pos: dict[str, int],
+) -> None:
+    """Advisory guard audit for explicitly declared capacity dims.
+
+    Emits a warning when a marked (param, dim) has no accesses in the
+    kernel body or no guard evidence for any of its accesses.  Never
+    rejects: the explicit declaration is the trust boundary.
+    """
+    if not capacity_dims:
+        return
+    for _var, buf in pf.buffer_map.items():
+        bname = str(buf.name)
+        pos = name_to_pos.get(bname)
+        if pos is None:
+            continue
+        dims = capacity_dims.get(pos)
+        if not dims:
+            continue
+        for dim_idx in sorted(int(d) for d in dims):
+            if dim_idx >= len(buf.shape):
+                continue
+            auditor = _CapacityGuardAuditor(bname, dim_idx, buf.shape[dim_idx])
+            try:
+                auditor.visit_stmt(pf.body)
+            except Exception as exc:  # advisory: never break compilation
+                logger.warning(
+                    "Metal adapter: capacity guard audit failed for '%s' dim %d (%s); the declaration remains in effect",
+                    bname,
+                    dim_idx,
+                    exc,
+                )
+                continue
+            if auditor.accesses == 0:
+                logger.warning(
+                    "Metal adapter: capacity dim %d of '%s' has no accesses "
+                    "in the kernel body; the capacity declaration cannot be "
+                    "verified against mask/offset guards",
+                    dim_idx,
+                    bname,
+                )
+            elif auditor.guarded < auditor.accesses:
+                logger.warning(
+                    "Metal adapter: capacity dim %d of '%s': %d of %d "
+                    "access(es) have no mask/offset guard evidence; the "
+                    "declared extent is an upper bound only if every "
+                    "access is bounded by a runtime guard",
+                    dim_idx,
+                    bname,
+                    auditor.accesses - auditor.guarded,
+                    auditor.accesses,
+                )
+
+
+@dataclass(frozen=True)
+class _BufferBinding:
+    """One MSL buffer slot of one kernel call site.
+
+    ``kind`` is one of:
+      - "user": public call-signature parameter at ``param_index`` (tensor or
+        scalar value, both passed through positionally);
+      - "alloc": compiler-generated host allocation (``T.alloc_global``
+        workspace) described by ``buffer`` (tirx.Buffer with shape/dtype);
+      - "symbol": runtime dynamic scalar (e.g. the symbolic ``N`` threaded
+        through the device signature); ``symbol`` is the ``tirx.Var`` object
+        (identity), resolved from the runtime symbol table at launch time;
+      - "const": a constant integer known at plan build time (``value``);
+      - "expr": a general expression (``value``) evaluated against the
+        runtime symbol table / user scalar values at launch time.
+    """
+
+    kind: str
+    param_index: int = -1
+    buffer: Any = None
+    symbol: Any = None
+    value: Any = None
+    dtype: Any = None
+
+
+@dataclass(frozen=True)
+class _LaunchSite:
+    """One host call site: symbol + launch geometry + per-buffer bindings.
+
+    ``block`` / ``grid`` are expressions derived from the *call-site* launch
+    arguments (already substituted into the caller's scope by
+    ``LowerDeviceKernelLaunch``), evaluated per launch.  ``scalar_vars`` maps
+    call-site ``tirx.Var`` objects of user scalar parameters to their public
+    parameter index, for expression evaluation.
+    """
+
+    symbol: str
+    block: tuple[Any, Any, Any]
+    grid: tuple[Any, Any, Any]
+    bindings: tuple[_BufferBinding, ...]
+    scalar_vars: tuple[tuple[Any, int], ...] = ()
+
 
 class MetalKernelAdapter(BaseKernelAdapter):
     def __init__(
@@ -18,7 +893,7 @@ class MetalKernelAdapter(BaseKernelAdapter):
         result_idx: list[int],
         #  target: Union[str, Target],
         func_or_mod: tirx.PrimFunc | tvm.IRModule,
-        #  host_mod: Optional[tvm.IRModule] = None,
+        host_mod: tvm.IRModule | None = None,
         device_mod: tvm.IRModule | None = None,
         kernel_global_source: str | None = None,
         verbose: bool = False,
@@ -26,32 +901,64 @@ class MetalKernelAdapter(BaseKernelAdapter):
         #  compile_flags: Optional[List[str]] = None
     ):
         self.kernel_global_source = kernel_global_source
+        self.host_mod = host_mod
+        self.device_mod = device_mod
         if isinstance(func_or_mod, tirx.PrimFunc):
             func_name = func_or_mod.attrs["global_symbol"]
         else:
             func_name = func_or_mod.__name__
         self.kernel_name = func_name + "_kernel"
         self.verbose = verbose
-
-        self.block_info = [1, 1, 1]
-        self.grid_info = [1, 1, 1]
-
-        for var, func in device_mod.functions.items():
-            assert var.name_hint == self.kernel_name
-            thread_extent = func.attrs["thread_extent"]
-            for tag, extent in thread_extent.items():
-                if "threadIdx" in tag:
-                    self.block_info["xyz".index(tag[-1])] = extent
-                elif "blockIdx" in tag:
-                    self.grid_info["xyz".index(tag[-1])] = extent
-            break
-        else:
-            raise AssertionError(f"no kernel with name {func_name}")
-
-        # print(self.block_info, self.grid_info)
+        # Explicit capacity-dimension contract markers: capacity
+        # dims are exempt from strict extent validation ONLY when the kernel
+        # author explicitly declares them -- eager kernels via
+        # ``T.annotate_capacity_dims({"A_q": (0,)})`` in the body, lazy
+        # kernels via ``func.with_attr("tilelang_capacity_dims", {"W": (0,)})``.
+        # The syntactic auto-inference from tensor annotations was removed
+        # because ordinary exact dims that reference scalar parameters must
+        # not be auto-exempted.
+        # Keyed by public parameter position (the ``params``/call-site
+        # order).  Must be set BEFORE ``super().__init__``: the base
+        # ``_post_init`` builds the launcher closure, which captures this
+        # map.
+        self._capacity_dims: dict[int, frozenset[int]] = {}
+        attrs = getattr(func_or_mod, "attrs", None) or {}
+        cap_attr = attrs.get("tilelang_capacity_dims")
+        name_to_pos: dict[str, int] = {}
+        if isinstance(func_or_mod, tirx.PrimFunc):
+            # Public param names come from the BUFFER (``buffer_map`` value),
+            # not from ``params``: the lazy @T.prim_func path renames the FFI
+            # params to ``W_handle`` while the buffers keep the public name.
+            for i, var in enumerate(func_or_mod.params):
+                buf = func_or_mod.buffer_map.get(var)
+                if buf is not None:
+                    name_to_pos[str(buf.name)] = i
+        if cap_attr and isinstance(func_or_mod, tirx.PrimFunc):
+            unknown_names = sorted(str(pname) for pname in cap_attr if str(pname) not in name_to_pos)
+            if unknown_names:
+                raise ValueError(
+                    "Metal adapter: tilelang_capacity_dims contains unknown "
+                    f"tensor parameter name(s) {unknown_names}; declared "
+                    f"tensor parameters are {sorted(name_to_pos)}"
+                )
+            for pname, dims in cap_attr.items():
+                pos = name_to_pos.get(str(pname))
+                if pos is not None and not params[pos].is_scalar():
+                    self._capacity_dims[pos] = frozenset(int(d) for d in dims)
+            # Advisory guard audit: structural mask/offset-guard
+            # evidence for every explicitly declared capacity dim (warns on
+            # absence; never rejects).
+            _audit_capacity_guards(func_or_mod, self._capacity_dims, name_to_pos)
         super().__init__(func_or_mod, result_idx=result_idx, params=params)
 
     _kernel = None
+
+    def __del__(self) -> None:
+        # Best-effort: drop completed batches promptly at adapter destruction.
+        # Pending (in-flight) batches stay in the module-global queue and are
+        # reaped by the background thread on completion.
+        with contextlib.suppress(Exception):
+            _release_finished_work()
 
     def get_kernel_source(self, kernel_only: bool = True) -> str:
         if kernel_only:
@@ -62,18 +969,543 @@ class MetalKernelAdapter(BaseKernelAdapter):
                 return self.kernel_global_source[idx:]
         return self.kernel_global_source
 
+    # ------------------------------------------------------------------
+    # Host call-site analysis
+    # ------------------------------------------------------------------
+    def _host_entry_funcs(self) -> list[Any]:
+        """Lowered host functions whose bodies contain the kernel calls."""
+        if self.host_mod is None:
+            raise RuntimeError(
+                "Metal adapter: host_mod is required to build the launch plan (host call-site order); pass artifact.host_mod to the adapter"
+            )
+        funcs = list(self.host_mod.functions.values())
+        entries = [f for f in funcs if f.attrs.get("tirx.is_entry_func")]
+        return entries or funcs
+
+    @staticmethod
+    def _is_kernel_packed_call(call: Any) -> bool:
+        return getattr(call.op, "name", None) == "tirx.tvm_call_packed"
+
+    @staticmethod
+    def _const_int(expr: Any) -> int | None:
+        if isinstance(expr, tirx.IntImm):
+            return int(expr)
+        if isinstance(expr, int):
+            return expr
+        return None
+
+    @staticmethod
+    def _entry_args_var(entry: Any) -> Any:
+        """The FFI packed-``args`` handle of a host entry function, if any.
+
+        Call-site buffer/scalar arguments are resolved to public parameters
+        through the ``args`` slot index of the FFI entry (the packed-ABI
+        slot order is the public parameter order), so binding never depends
+        on parameter names.
+        """
+        for param in entry.params:
+            if str(param) == "args":
+                return param
+        return None
+
+    def _loop_substitute(self, expr: Any, loop_vmap: dict[Any, Any]) -> Any:
+        """Substitute constant host loop iterations into ``expr``."""
+        if not loop_vmap:
+            return expr
+        return tvm.tirx.stmt_functor.substitute(expr, loop_vmap)
+
+    def _static_condition(self, condition: Any, loop_vmap: dict[Any, Any]) -> bool:
+        """Statically resolve an ``IfThenElse`` condition.
+
+        Conditions that depend on runtime values cannot be represented in a
+        static launch plan: raise at plan build time instead of silently
+        emitting both branches.
+        """
+        cond = self._loop_substitute(condition, loop_vmap)
+        if isinstance(cond, tirx.IntImm):
+            return int(cond) != 0
+        simplified = tvm.arith.Analyzer().simplify(cond)
+        if isinstance(simplified, tirx.IntImm):
+            return int(simplified) != 0
+        raise RuntimeError(
+            f"Metal adapter: host conditional '{condition}' depends on "
+            "runtime values and cannot be resolved statically; the Metal "
+            "launch plan only supports statically resolvable control flow"
+        )
+
+    def _walk_host(
+        self,
+        node: Any,
+        call_sites: list[tuple[str, list[Any], Any, dict[Any, Any]]],
+        host_buffers: dict[Any, Any],
+        bind_map: dict[Any, Any],
+        args_var: Any,
+        loop_vmap: dict[Any, Any],
+    ) -> None:
+        """Collect kernel call sites in program order (duplicates preserved).
+
+        Constant-bounds host loops are expanded with the iteration value
+        substituted into every call-site argument and launch argument (the
+        ``min`` is honored); statically resolvable ``IfThenElse`` nodes walk
+        only their taken branch; runtime-dependent control flow raises.
+        ``Bind`` statements are recorded for FFI slot resolution and
+        ``AllocBuffer`` nodes for compiler-generated buffer binding.
+        """
+        if isinstance(node, tirx.Evaluate):
+            value = node.value
+            if isinstance(value, tirx.Call) and self._is_kernel_packed_call(value):
+                args = list(value.args)
+                if not args or not isinstance(args[0], tirx.StringImm):
+                    return
+                if loop_vmap:
+                    args = [self._loop_substitute(a, loop_vmap) for a in args]
+                # Snapshot the bindings at the call site: a tirx.Bind in a
+                # later static loop iteration must not overwrite the bindings
+                # used by earlier sites.
+                call_sites.append((str(args[0].value), args[1:], args_var, dict(bind_map)))
+            return
+        if isinstance(node, tirx.SeqStmt):
+            for stmt in node.seq:
+                self._walk_host(stmt, call_sites, host_buffers, bind_map, args_var, loop_vmap)
+            return
+        if isinstance(node, tirx.AttrStmt):
+            self._walk_host(node.body, call_sites, host_buffers, bind_map, args_var, loop_vmap)
+            return
+        if isinstance(node, tirx.Bind):
+            # Flat tirx Bind: record the value behind the local var (with the
+            # current loop iteration substituted, so loop-local bindings that
+            # reference the loop variable resolve per iteration).
+            bind_map[node.var] = self._loop_substitute(node.value, loop_vmap)
+            return
+        if isinstance(node, tirx.For):
+            # Substitute the outer constant iterations into the bounds and
+            # simplify BEFORE the constant check: a nested
+            # loop whose bound references the outer loop variable
+            # (``T.serial(_i + 1)`` inside ``T.serial(2, 4)``) is statically
+            # enumerable and must not be mistaken for a runtime loop.  Bounds
+            # that are still non-constant after substitution depend on
+            # runtime values and are rejected.
+            min_e = node.min if isinstance(node.min, int) else self._loop_substitute(node.min, loop_vmap)
+            extent_e = node.extent if isinstance(node.extent, int) else self._loop_substitute(node.extent, loop_vmap)
+            analyzer = tvm.arith.Analyzer()
+            min_v = self._const_int(analyzer.simplify(min_e))
+            extent = self._const_int(analyzer.simplify(extent_e))
+            if min_v is None or extent is None:
+                raise RuntimeError(
+                    f"Metal adapter: host loop with non-constant bounds "
+                    f"(min={node.min}, extent={node.extent}) around kernel "
+                    "call sites depends on runtime values and cannot be "
+                    "represented in the static launch plan; only "
+                    "constant-bounds loops are supported"
+                )
+            for i in range(min_v, min_v + extent):
+                inner = dict(loop_vmap)
+                inner[node.loop_var] = tirx.IntImm(str(node.loop_var.dtype), i)
+                self._walk_host(node.body, call_sites, host_buffers, bind_map, args_var, inner)
+            return
+        if isinstance(node, tirx.IfThenElse):
+            if self._static_condition(node.condition, loop_vmap):
+                self._walk_host(node.then_case, call_sites, host_buffers, bind_map, args_var, loop_vmap)
+            elif node.else_case is not None:
+                self._walk_host(node.else_case, call_sites, host_buffers, bind_map, args_var, loop_vmap)
+            return
+        # Leaf nodes in this tirx version (no body to descend into):
+        #   AllocBuffer (compiler-generated global buffer), DeclBuffer,
+        #   AssertStmt. AllocBuffer is recorded for binding resolution
+        #   keyed by its data-handle Var identity.
+        if isinstance(node, tirx.AllocBuffer):
+            host_buffers.setdefault(node.buffer.data, node.buffer)
+            return
+        if isinstance(node, (tirx.DeclBuffer, tirx.AssertStmt)):
+            return
+        raise RuntimeError(f"Metal adapter: unsupported host node {type(node).__name__} while collecting kernel call sites")
+
+    def _resolve_slot(self, expr: Any, bind_map: dict[Any, Any], args_var: Any, depth: int = 0) -> int | None:
+        """Map an FFI call-site argument back to its public-parameter slot.
+
+        Follows the host lowering's unpacking chain:
+        ``X = tvm_struct_get(X_handle, 0, 1, "handle")`` where
+        ``X_handle = Select(_, handle_add_byte_offset(tvm_struct_get(args, i, 15)), tvm_struct_get(args, i, 15))``
+        (and the scalar variant ``S = Cast(_, tvm_struct_get(args, i, 15))``)
+        -- the slot ``i`` is the packed-ABI argument index, i.e. the public
+        parameter index.  Returns ``None`` when the expression cannot be
+        traced to an ``args`` slot.
+        """
+        if depth > 24:
+            return None
+        if isinstance(expr, tirx.Var):
+            if args_var is not None and expr.same_as(args_var):
+                return None
+            value = bind_map.get(expr)
+            if value is None:
+                return None
+            return self._resolve_slot(value, bind_map, args_var, depth + 1)
+        if isinstance(expr, tirx.Cast):
+            return self._resolve_slot(expr.value, bind_map, args_var, depth + 1)
+        if isinstance(expr, tirx.Select):
+            then_slot = self._resolve_slot(expr.true_value, bind_map, args_var, depth + 1)
+            else_slot = self._resolve_slot(expr.false_value, bind_map, args_var, depth + 1)
+            if then_slot is not None and then_slot == else_slot:
+                return then_slot
+            return None
+        if isinstance(expr, tirx.Call):
+            name = expr.op.name
+            if name == "tirx.tvm_struct_get" and len(expr.args) == 3:
+                struct, index, field = expr.args
+                index_i = self._const_int(index)
+                field_i = self._const_int(field)
+                if index_i is None or field_i is None:
+                    return None
+                if args_var is not None and struct.same_as(args_var):
+                    # FFI value slot: field 15 is the union value member
+                    # (data handle or scalar int64).
+                    if field_i == 15:
+                        return index_i
+                    return None
+                # Data-pointer dereference: tvm_struct_get(handle, 0, 1).
+                if index_i == 0 and field_i == 1:
+                    return self._resolve_slot(struct, bind_map, args_var, depth + 1)
+                return None
+            if name == "tirx.handle_add_byte_offset" and len(expr.args) == 2:
+                return self._resolve_slot(expr.args[0], bind_map, args_var, depth + 1)
+        return None
+
+    def _bind_function_arg(
+        self,
+        kparam: Any,
+        call_arg: Any,
+        host_buffers: dict[Any, Any],
+        bind_map: dict[Any, Any],
+        args_var: Any,
+    ) -> tuple[_BufferBinding, Any | None]:
+        """Bind one device parameter from its per-call-site argument.
+
+        The device parameter order equals the MSL buffer order, and the host
+        call site passes its arguments in that same order (the
+        ``args[1:1+len(device_func.params)]`` contract of the common
+        wrapper).  Returns ``(binding, scalar_var)`` where ``scalar_var`` is
+        the call-site ``tirx.Var`` of a user scalar parameter (needed to
+        evaluate launch expressions at call time).
+        """
+        slot = self._resolve_slot(call_arg, bind_map, args_var)
+        if slot is not None:
+            scalar_var = call_arg if isinstance(call_arg, tirx.Var) and str(kparam.dtype) != "handle" else None
+            return (
+                _BufferBinding(
+                    kind="user",
+                    param_index=slot,
+                    dtype=None if str(kparam.dtype) == "handle" else kparam.dtype,
+                ),
+                scalar_var,
+            )
+        if isinstance(call_arg, tirx.Var):
+            buffer = host_buffers.get(call_arg)
+            if buffer is not None:
+                return _BufferBinding(kind="alloc", buffer=buffer), None
+            if str(kparam.dtype) != "handle":
+                # Runtime dynamic scalar (e.g. the symbolic N threaded through
+                # the device signature); resolved per launch by Var identity.
+                return (
+                    _BufferBinding(kind="symbol", symbol=call_arg, dtype=kparam.dtype),
+                    None,
+                )
+            raise RuntimeError(
+                f"Metal adapter: kernel parameter '{kparam}' receives buffer "
+                f"'{call_arg}' that is neither a public call-signature "
+                "argument nor a compiler-generated host allocation; cannot "
+                "bind it"
+            )
+        const = self._const_int(call_arg)
+        if const is not None:
+            return _BufferBinding(kind="const", value=const, dtype=kparam.dtype), None
+        if str(kparam.dtype) != "handle":
+            return _BufferBinding(kind="expr", value=call_arg, dtype=kparam.dtype), None
+        raise RuntimeError(
+            f"Metal adapter: kernel parameter '{kparam}' receives unsupported "
+            f"argument {call_arg!r} ({type(call_arg).__name__}); cannot bind it"
+        )
+
+    def _launch_plan(self) -> list[_LaunchSite]:
+        """Build a per-call-site launch plan from the lowered host module.
+
+        Every kernel is represented once per host call site, in program
+        order, with its DCE'd buffer signature (call-site args are in the
+        device-parameter order == MSL buffer order) and its own grid/block
+        derived from the call-site launch arguments.
+        """
+        if self.device_mod is None:
+            raise RuntimeError("Metal adapter: device_mod is required to build the launch plan")
+        host_buffers: dict[Any, Any] = {}
+        # Each call site records the entry context (FFI args handle + Bind
+        # map) it was collected under, so its arguments resolve against the
+        # right entry's slot chain.
+        call_sites: list[tuple[str, list[Any], Any, dict[Any, Any]]] = []
+        for entry in self._host_entry_funcs():
+            args_var = self._entry_args_var(entry)
+            bind_map: dict[Any, Any] = {}
+            self._walk_host(entry.body, call_sites, host_buffers, bind_map, args_var, {})
+        self._host_alloc_buffers = host_buffers
+
+        plan: list[_LaunchSite] = []
+        for symbol, call_args, args_var, entry_bind_map in call_sites:
+            if symbol not in self.device_mod:
+                # Non-kernel packed calls (e.g. __tvm_set_device).
+                continue
+            func = self.device_mod[symbol]
+            kparams = list(func.params)
+            if len(call_args) < len(kparams):
+                raise RuntimeError(
+                    f"Metal adapter: host call site '{symbol}' passes "
+                    f"{len(call_args)} buffers but the device function has "
+                    f"{len(kparams)} parameters"
+                )
+            function_args = call_args[: len(kparams)]
+            launch_args = call_args[len(kparams) :]
+            launch_tags = func.attrs.get("tirx.kernel_launch_params")
+            if launch_tags is None:
+                raise RuntimeError(
+                    f"Metal adapter: device function '{symbol}' has no "
+                    "'tirx.kernel_launch_params' attribute; cannot map the "
+                    "call-site launch arguments to grid/block geometry"
+                )
+            launch_tags = list(launch_tags)
+            if len(launch_args) != len(launch_tags):
+                raise RuntimeError(
+                    f"Metal adapter: host call site '{symbol}' passes "
+                    f"{len(launch_args)} launch arguments but the device "
+                    f"function declares {len(launch_tags)} launch parameters "
+                    f"{launch_tags}"
+                )
+
+            bindings: list[_BufferBinding] = []
+            scalar_vars: list[tuple[Any, int]] = []
+            for kp, ca in zip(kparams, function_args):
+                binding, scalar_var = self._bind_function_arg(kp, ca, host_buffers, entry_bind_map, args_var)
+                if scalar_var is not None:
+                    scalar_vars.append((scalar_var, binding.param_index))
+                bindings.append(binding)
+
+            # Geometry from the call-site launch arguments (already
+            # substituted into the caller's scope by
+            # LowerDeviceKernelLaunch), mapped to axes by the launch params.
+            # The dynamic-shared-memory tag is skipped exactly like the Metal
+            # codegen does (Metal has no dynamic shared memory; the size is
+            # baked into the MSL kernel's static threadgroup allocation).
+            block = [1, 1, 1]
+            grid = [1, 1, 1]
+            for tag, arg in zip(launch_tags, launch_args):
+                if tag == "tirx.use_dyn_shared_memory":
+                    continue
+                if tag == "blockIdx.x":
+                    grid[0] = arg
+                elif tag == "blockIdx.y":
+                    grid[1] = arg
+                elif tag == "blockIdx.z":
+                    grid[2] = arg
+                elif tag == "threadIdx.x":
+                    block[0] = arg
+                elif tag == "threadIdx.y":
+                    block[1] = arg
+                elif tag == "threadIdx.z":
+                    block[2] = arg
+                else:
+                    raise RuntimeError(f"Metal adapter: unsupported launch parameter tag '{tag}' on device function '{symbol}'")
+            plan.append(
+                _LaunchSite(
+                    symbol=symbol,
+                    block=tuple(block),
+                    grid=tuple(grid),
+                    bindings=tuple(bindings),
+                    scalar_vars=tuple(scalar_vars),
+                )
+            )
+        if not plan:
+            raise AssertionError(f"no kernel call sites with prefix {self.kernel_name} in host module")
+        return plan
+
+    # ------------------------------------------------------------------
+    # Dynamic shape resolution
+    # ------------------------------------------------------------------
+    def _symbol_table(self, tensor_input_shapes: list[tuple[int, ...]]) -> dict[Any, int]:
+        return _build_symbol_table(tensor_input_shapes, self.params, self.result_idx, self._capacity_dims)
+
+    def _eval_dim(self, dim: Any, symtab: dict[Any, int], analyzer: Any) -> int:
+        return _resolve_int_value(dim, symtab, analyzer)
+
+    def _eval_param_shape(self, symtab: dict[Any, int], param: Any) -> tuple[int, ...]:
+        return _eval_param_shape(symtab, param)
+
+    def _resolve_output_shapes(self, tensor_input_shapes: list[tuple[int, ...]]) -> list[tuple[int, ...]]:
+        """Resolve ``out_idx`` output tensor shapes."""
+        symtab = self._symbol_table(tensor_input_shapes)
+        return [self._eval_param_shape(symtab, self.params[idx]) for idx in self.result_idx]
+
+    # ------------------------------------------------------------------
+    # Launcher
+    # ------------------------------------------------------------------
     def _convert_torch_func(self) -> Callable:
         if self._kernel is None:
-            _kernel = getattr(torch.mps.compile_shader(self.kernel_global_source), self.kernel_name)
-            _threads = [x * y for (x, y) in zip(self.block_info, self.grid_info)]
+            _mps_module = torch.mps.compile_shader(self.kernel_global_source)
+            _launch_plan = self._launch_plan()
+            _symbol_table = _build_symbol_table
+            _eval_param_shape_fn = _eval_param_shape
+            _resolve_int_value_fn = _resolve_int_value
+            _symbol_value_fn = _symbol_value
+            _result_idx = list(self.result_idx)
+            _params = list(self.params)
+            _capacity_dims = dict(self._capacity_dims)
+            _input_param_idx = [i for i in range(len(_params)) if i not in _result_idx]
 
-            @wraps(_kernel)
-            def launcher(*args: torch.Tensor):
-                return _kernel(
-                    *args,
-                    threads=_threads,
-                    group_size=self.block_info,
+            def launcher(*args: Any) -> Any:
+                # `args` are the user-supplied non-output arguments in
+                # positional order and may mix tensors and scalars; only
+                # actual tensor arguments ever contribute shapes.
+                if len(args) != len(_input_param_idx):
+                    raise RuntimeError(f"Metal adapter: kernel expects {len(_input_param_idx)} non-output arguments, got {len(args)}")
+                tensor_args: list[torch.Tensor] = []
+                for i, arg in zip(_input_param_idx, args):
+                    if _params[i].is_scalar() == isinstance(arg, torch.Tensor):
+                        raise RuntimeError(
+                            f"Metal adapter: argument {i} for param "
+                            f"{_params[i]} must be a "
+                            f"{'tensor' if not _params[i].is_scalar() else 'scalar value'}, "
+                            f"got {type(arg).__name__}"
+                        )
+                    if isinstance(arg, torch.Tensor):
+                        tensor_args.append(arg)
+
+                _release_finished_work()
+
+                symtab = _symbol_table(
+                    [tuple(a.shape) for a in tensor_args],
+                    _params,
+                    _result_idx,
+                    _capacity_dims,
                 )
+                analyzer = tvm.arith.Analyzer()
+                for var, val in symtab.items():
+                    analyzer.bind(var, val)
+                out_device = tensor_args[0].device if tensor_args else torch.device("mps")
+                full: list[Any] = [None] * len(_params)
+                for i, arg in zip(_input_param_idx, args):
+                    full[i] = arg
+
+                # Allocate out_idx outputs (mirrors the TVMFFI adapter
+                # contract; shapes may be dynamic).
+                outputs: list[torch.Tensor] = []
+                for idx in _result_idx:
+                    shape = _eval_param_shape_fn(symtab, _params[idx])
+                    tensor = torch.empty(*shape, dtype=_params[idx].torch_dtype(), device=out_device)
+                    full[idx] = tensor
+                    outputs.append(tensor)
+
+                # Compiler-generated workspaces: one allocation per host
+                # AllocBuffer per launch, shared across call sites (keyed by
+                # the tirx.Buffer identity, not its name).
+                gen_buffers: dict[Any, torch.Tensor] = {}
+                launch_refs: list[torch.Tensor] = []
+                submitted = False
+                try:
+                    for site in _launch_plan:
+                        kfn = getattr(_mps_module, site.symbol)
+                        scalar_vars = dict(site.scalar_vars)
+                        # MSL buffer order is handles first, then a single
+                        # packed scalar-args struct at ``buffer(num_buffer)``.
+                        # ``torch.mps.compile_shader`` binds each positional
+                        # argument to its own buffer slot, so runtime scalars
+                        # must be packed into ONE tensor at the struct slot:
+                        # passing them individually only lands the first
+                        # scalar in the struct and silently misreads the rest
+                        # due to the multi-runtime-scalar ABI layout.
+                        tensor_kargs: list[torch.Tensor] = []
+                        scalar_slots: list[tuple[Any, Any]] = []
+                        seen_scalar = False
+                        for binding in site.bindings:
+                            if binding.kind == "user":
+                                value = full[binding.param_index]
+                                if binding.dtype is None:
+                                    if seen_scalar:
+                                        raise RuntimeError(
+                                            "Metal adapter: buffer kernel "
+                                            "parameter appears after a scalar "
+                                            "parameter; the Metal ABI "
+                                            "requires handles first"
+                                        )
+                                    tensor_kargs.append(value)
+                                else:
+                                    seen_scalar = True
+                                    scalar_slots.append((binding.dtype, value))
+                            elif binding.kind == "alloc":
+                                if seen_scalar:
+                                    raise RuntimeError(
+                                        "Metal adapter: buffer kernel "
+                                        "parameter appears after a scalar "
+                                        "parameter; the Metal ABI requires "
+                                        "handles first"
+                                    )
+                                tensor = gen_buffers.get(binding.buffer)
+                                if tensor is None:
+                                    shape = _eval_param_shape_fn(symtab, binding.buffer)
+                                    tensor = torch.empty(
+                                        *shape,
+                                        dtype=KernelParam(
+                                            binding.buffer.dtype,
+                                            list(binding.buffer.shape),
+                                        ).torch_dtype(),
+                                        device=out_device,
+                                    )
+                                    gen_buffers[binding.buffer] = tensor
+                                tensor_kargs.append(tensor)
+                            elif binding.kind == "symbol":
+                                seen_scalar = True
+                                scalar_slots.append(
+                                    (
+                                        binding.dtype,
+                                        _symbol_value_fn(binding.symbol, symtab),
+                                    )
+                                )
+                            elif binding.kind == "const":
+                                seen_scalar = True
+                                scalar_slots.append((binding.dtype, binding.value))
+                            elif binding.kind == "expr":
+                                seen_scalar = True
+                                scalar_slots.append(
+                                    (
+                                        binding.dtype,
+                                        _resolve_int_value_fn(
+                                            binding.value,
+                                            symtab,
+                                            analyzer,
+                                            full,
+                                            scalar_vars,
+                                        ),
+                                    )
+                                )
+                            else:
+                                raise RuntimeError(f"Metal adapter: unknown binding kind {binding.kind!r}")
+                        if scalar_slots:
+                            tensor_kargs.append(_pack_scalar_args(scalar_slots, out_device))
+                        launch_refs.extend(tensor_kargs)
+                        block = [_resolve_int_value_fn(b, symtab, analyzer, full, scalar_vars) for b in site.block]
+                        grid = [_resolve_int_value_fn(g, symtab, analyzer, full, scalar_vars) for g in site.grid]
+                        kfn(
+                            *tensor_kargs,
+                            threads=[a * b for a, b in zip(block, grid)],
+                            group_size=block,
+                        )
+                        submitted = True
+                finally:
+                    # From the first successful enqueue on, an exception
+                    # mid-batch still establishes the completion fence and
+                    # keeps every submitted buffer pinned.
+                    if submitted:
+                        _track_keepalive(launch_refs)
+
+                if len(outputs) == 1:
+                    return outputs[0]
+                if outputs:
+                    return outputs
+                return None
 
             self._kernel = launcher
 

--- a/tilelang/jit/adapter/torch/metal.py
+++ b/tilelang/jit/adapter/torch/metal.py
@@ -298,6 +298,47 @@ def _symbol_value(var: Any, symtab: dict[Any, int]) -> int:
     raise RuntimeError(f"Metal adapter: dynamic scalar '{name}' is not determined by any caller-supplied tensor input shape")
 
 
+def _packed_slot_to_param_index(
+    slot: int,
+    input_param_idx: list[int],
+    num_params: int,
+    skips_outputs: bool,
+    kparam: Any = None,
+) -> int:
+    """Map a packed-ABI slot to the public parameter index.
+
+    ``MakePackedAPI`` has two layouts:
+
+    - legacy (Metal today): every public parameter occupies a packed slot
+      equal to its public index, so the slot IS the public index;
+    - callee-allocated output ABI (``tilelang_out_idx``): output parameters
+      are skipped when numbering packed slots and an allocator anchor is
+      appended, so a non-output parameter's slot is its position in
+      ``input_param_idx`` (the public indices of the non-output parameters,
+      in public order).
+
+    ``skips_outputs`` selects the layout (detected from the lowered host
+    entry by the adapter).  ``kparam`` is only used for diagnostics.
+    """
+    if skips_outputs:
+        if slot < 0 or slot >= len(input_param_idx):
+            raise RuntimeError(
+                f"Metal adapter: FFI packed slot {slot} for kernel "
+                f"parameter '{kparam}' cannot be mapped to a public "
+                f"parameter (kernel has {len(input_param_idx)} "
+                "non-output parameters); the packed-API slot order skips "
+                "callee-allocated outputs"
+            )
+        return input_param_idx[slot]
+    if slot < 0 or slot >= num_params:
+        raise RuntimeError(
+            f"Metal adapter: FFI packed slot {slot} for kernel parameter "
+            f"'{kparam}' is out of range for a function with {num_params} "
+            "public parameters"
+        )
+    return slot
+
+
 def _pack_scalar_args(scalar_slots: list[tuple[Any, Any]], device: Any) -> torch.Tensor:
     """Pack runtime scalar kernel arguments into the Metal ``args_t`` buffer.
 
@@ -999,14 +1040,28 @@ class MetalKernelAdapter(BaseKernelAdapter):
         """The FFI packed-``args`` handle of a host entry function, if any.
 
         Call-site buffer/scalar arguments are resolved to public parameters
-        through the ``args`` slot index of the FFI entry (the packed-ABI
-        slot order is the public parameter order), so binding never depends
-        on parameter names.
+        through the ``args`` slot index of the FFI entry, so binding never
+        depends on parameter names.  The slot semantics depend on the packed
+        ABI layout: the legacy layout numbers every public parameter
+        (slot == public index); the callee-allocated output ABI skips
+        ``out_idx`` positions and appends an allocator anchor (slot == rank
+        in the non-output parameter list).  ``_bind_function_arg`` detects
+        the active layout from the lowered host entry and remaps via
+        ``_input_param_idx`` when needed.
         """
         for param in entry.params:
             if str(param) == "args":
                 return param
         return None
+
+    # NOTE: with the callee-allocated output ABI (CUDA ``tilelang_out_idx``
+    # path), the packed ``args`` slot order is the NON-OUTPUT parameter order
+    # (``out_idx`` positions are skipped and an allocator anchor is appended),
+    # NOT the public parameter order; ``_resolve_slot`` returns that packed
+    # slot and ``_bind_function_arg`` remaps it through ``_input_param_idx``.
+    # The legacy layout (Metal today) keeps slot == public index, and the
+    # active layout is detected from the lowered host entry (the
+    # ``allocator_anchor`` binding).
 
     def _loop_substitute(self, expr: Any, loop_vmap: dict[Any, Any]) -> Any:
         """Substitute constant host loop iterations into ``expr``."""
@@ -1074,7 +1129,12 @@ class MetalKernelAdapter(BaseKernelAdapter):
         if isinstance(node, tirx.Bind):
             # Flat tirx Bind: record the value behind the local var (with the
             # current loop iteration substituted, so loop-local bindings that
-            # reference the loop variable resolve per iteration).
+            # reference the loop variable resolve per iteration).  The
+            # callee-allocated output ABI's allocator anchor binds a
+            # ``<name>.allocator_anchor.*`` var in the entry; detecting it
+            # here marks the packed-ABI layout that skips output slots.
+            if "allocator_anchor" in str(node.var):
+                self._packed_api_skips_outputs = True
             bind_map[node.var] = self._loop_substitute(node.value, loop_vmap)
             return
         if isinstance(node, tirx.For):
@@ -1121,15 +1181,21 @@ class MetalKernelAdapter(BaseKernelAdapter):
         raise RuntimeError(f"Metal adapter: unsupported host node {type(node).__name__} while collecting kernel call sites")
 
     def _resolve_slot(self, expr: Any, bind_map: dict[Any, Any], args_var: Any, depth: int = 0) -> int | None:
-        """Map an FFI call-site argument back to its public-parameter slot.
+        """Map an FFI call-site argument back to its packed-ABI slot.
 
         Follows the host lowering's unpacking chain:
         ``X = tvm_struct_get(X_handle, 0, 1, "handle")`` where
         ``X_handle = Select(_, handle_add_byte_offset(tvm_struct_get(args, i, 15)), tvm_struct_get(args, i, 15))``
         (and the scalar variant ``S = Cast(_, tvm_struct_get(args, i, 15))``)
-        -- the slot ``i`` is the packed-ABI argument index, i.e. the public
-        parameter index.  Returns ``None`` when the expression cannot be
-        traced to an ``args`` slot.
+        -- the slot ``i`` is the packed-ABI argument index.  The packed slot
+        equals the public parameter index in the legacy layout (Metal
+        today); with the callee-allocated output ABI (``MakePackedAPI``,
+        gated to CUDA ``tilelang_out_idx``) the packed slots number only
+        non-output parameters and an allocator anchor is appended, so the
+        slot must be remapped through ``_input_param_idx`` before it can
+        index the launcher's ``full`` binding (see
+        ``_packed_slot_to_param_index``).  Returns ``None`` when the
+        expression cannot be traced to an ``args`` slot.
         """
         if depth > 24:
             return None
@@ -1189,11 +1255,34 @@ class MetalKernelAdapter(BaseKernelAdapter):
         """
         slot = self._resolve_slot(call_arg, bind_map, args_var)
         if slot is not None:
+            # ``MakePackedAPI`` has two packed-ABI layouts:
+            #
+            #  - legacy layout (Metal today): every public parameter keeps a
+            #    packed slot equal to its public index (``out_idx`` outputs
+            #    are ordinary arguments);
+            #  - callee-allocated layout (CUDA ``tilelang_out_idx`` ABI):
+            #    output parameters are skipped when numbering packed slots
+            #    and an allocator anchor is appended, so a non-output
+            #    parameter's packed slot is its position in
+            #    ``_input_param_idx``, NOT its public index.  The launcher's
+            #    ``full`` binding and scalar symbol resolution are keyed by
+            #    public parameter index, so remap before use.
+            #
+            # The active layout is detected from the lowered host entry (see
+            # ``_launch_plan``) so non-trailing ``out_idx`` stays correct
+            # under either ABI.
+            param_index = _packed_slot_to_param_index(
+                slot,
+                self._input_param_idx,
+                len(self.params),
+                self._packed_api_skips_outputs,
+                kparam,
+            )
             scalar_var = call_arg if isinstance(call_arg, tirx.Var) and str(kparam.dtype) != "handle" else None
             return (
                 _BufferBinding(
                     kind="user",
-                    param_index=slot,
+                    param_index=param_index,
                     dtype=None if str(kparam.dtype) == "handle" else kparam.dtype,
                 ),
                 scalar_var,
@@ -1233,6 +1322,23 @@ class MetalKernelAdapter(BaseKernelAdapter):
         device-parameter order == MSL buffer order) and its own grid/block
         derived from the call-site launch arguments.
         """
+        # Public indices of the non-output parameters, in public order.  In
+        # the callee-allocated output ABI (``MakePackedAPI`` skips
+        # ``out_idx`` positions when numbering packed slots and appends an
+        # allocator anchor) the packed-slot order equals this list, so it is
+        # the packed-slot -> public-parameter-index remap used by
+        # ``_bind_function_arg``.  In the legacy layout (Metal today) packed
+        # slots equal public parameter indices and this list is only used for
+        # the launcher's non-output argument contract.  Computed here so
+        # direct ``_launch_plan()`` callers (tests) get the same mapping as
+        # launcher construction.
+        self._input_param_idx = [i for i in range(len(self.params)) if i not in self.result_idx]
+        # Detect the packed-ABI layout from the lowered host entry: the
+        # callee-allocated output ABI materializes an ``allocator_anchor``
+        # binding in the entry body (CUDA ``tilelang_out_idx`` path); its
+        # absence means the legacy layout where every packed slot is a public
+        # parameter index.
+        self._packed_api_skips_outputs = False
         if self.device_mod is None:
             raise RuntimeError("Metal adapter: device_mod is required to build the launch plan")
         host_buffers: dict[Any, Any] = {}
@@ -1244,6 +1350,16 @@ class MetalKernelAdapter(BaseKernelAdapter):
             args_var = self._entry_args_var(entry)
             bind_map: dict[Any, Any] = {}
             self._walk_host(entry.body, call_sites, host_buffers, bind_map, args_var, {})
+        if not self._packed_api_skips_outputs:
+            # Fallback signal: the callee-allocated ABI also leaves its
+            # anchor's distinctive name/message in the serialized entry body
+            # (e.g. if a later pass renamed the Bind var but kept the assert
+            # message).  Host entry bodies are small, so the scan is cheap.
+            for entry in self._host_entry_funcs():
+                body = str(entry.body)
+                if "allocator_anchor" in body or "allocator anchor" in body:
+                    self._packed_api_skips_outputs = True
+                    break
         self._host_alloc_buffers = host_buffers
 
         plan: list[_LaunchSite] = []
@@ -1354,7 +1470,9 @@ class MetalKernelAdapter(BaseKernelAdapter):
             _result_idx = list(self.result_idx)
             _params = list(self.params)
             _capacity_dims = dict(self._capacity_dims)
-            _input_param_idx = [i for i in range(len(_params)) if i not in _result_idx]
+            # Established by ``_launch_plan`` above (single source of truth
+            # for the packed-slot -> public-parameter-index remap).
+            _input_param_idx = list(self._input_param_idx)
 
             def launcher(*args: Any) -> Any:
                 # `args` are the user-supplied non-output arguments in

--- a/tilelang/jit/adapter/torch/metal.py
+++ b/tilelang/jit/adapter/torch/metal.py
@@ -1442,19 +1442,16 @@ class MetalKernelAdapter(BaseKernelAdapter):
     # ------------------------------------------------------------------
     # Dynamic shape resolution
     # ------------------------------------------------------------------
-    def _symbol_table(self, tensor_input_shapes: list[tuple[int, ...]]) -> dict[Any, int]:
-        return _build_symbol_table(tensor_input_shapes, self.params, self.result_idx, self._capacity_dims)
-
-    def _eval_dim(self, dim: Any, symtab: dict[Any, int], analyzer: Any) -> int:
-        return _resolve_int_value(dim, symtab, analyzer)
-
-    def _eval_param_shape(self, symtab: dict[Any, int], param: Any) -> tuple[int, ...]:
-        return _eval_param_shape(symtab, param)
-
     def _resolve_output_shapes(self, tensor_input_shapes: list[tuple[int, ...]]) -> list[tuple[int, ...]]:
-        """Resolve ``out_idx`` output tensor shapes."""
-        symtab = self._symbol_table(tensor_input_shapes)
-        return [self._eval_param_shape(symtab, self.params[idx]) for idx in self.result_idx]
+        """Resolve ``out_idx`` output tensor shapes.
+
+        The module-level helpers ``_build_symbol_table``, ``_resolve_int_value``,
+        and ``_eval_param_shape`` are the single implementation; the launcher
+        closure binds them as plain functions too, so no thin per-method
+        forwarding wrappers are kept here.
+        """
+        symtab = _build_symbol_table(tensor_input_shapes, self.params, self.result_idx, self._capacity_dims)
+        return [_eval_param_shape(symtab, self.params[idx]) for idx in self.result_idx]
 
     # ------------------------------------------------------------------
     # Launcher

--- a/tilelang/jit/kernel.py
+++ b/tilelang/jit/kernel.py
@@ -373,7 +373,7 @@ class JITKernel(Generic[_P, _T]):
                 result_idx=out_idx,
                 # target=target,
                 func_or_mod=tilelang_func,
-                # host_mod=artifact.host_mod,
+                host_mod=artifact.host_mod,
                 device_mod=artifact.device_mod,
                 kernel_global_source=artifact.kernel_source,
                 verbose=self.verbose,

--- a/tilelang/language/eager/__init__.py
+++ b/tilelang/language/eager/__init__.py
@@ -1,4 +1,4 @@
-from .builder import prim_func, macro, PrimFunc, JITFunc, Ref, const, annotate_compile_flags, annotate_pass_configs  # noqa: F401
+from .builder import prim_func, macro, PrimFunc, JITFunc, Ref, const, annotate_compile_flags, annotate_pass_configs, annotate_capacity_dims  # noqa: F401
 from ..dtypes import *  # noqa: F401,F403
 from ..dtypes import __all__ as _dtypes_all
 
@@ -11,5 +11,6 @@ __all__ = (
     "const",
     "annotate_compile_flags",
     "annotate_pass_configs",
+    "annotate_capacity_dims",
     *_dtypes_all,
 )

--- a/tilelang/language/eager/ast.py
+++ b/tilelang/language/eager/ast.py
@@ -338,12 +338,23 @@ class DSLMutator(ast.NodeTransformer):
         node = self.generic_visit(node)
         return quote("if __tb.ctx_break(): break", span=node)
 
-    def _emit_assign_target(self, target: ast.expr, rval: ast.expr, annot: ast.expr | None = None) -> list[ast.stmt]:
+    def _emit_assign_target(
+        self,
+        target: ast.expr,
+        rval: ast.expr,
+        annot: ast.expr | None = None,
+    ) -> list[ast.stmt]:
         if isinstance(target, ast.Name):
             if annot is None:
                 return quote(f"name = __tb.bind('{target.id}', value)", name=target, value=rval, span=target)
             else:
-                return quote(f'name = __tb.bind("{target.id}", value, annot)', name=target, value=rval, annot=annot, span=target)
+                return quote(
+                    f'name = __tb.bind("{target.id}", value, annot)',
+                    name=target,
+                    value=rval,
+                    annot=annot,
+                    span=target,
+                )
         elif isinstance(target, ast.Attribute):
             s = ast.unparse(target)
             raise NotImplementedError(f"Attribute assignment not supported yet, `{s}`")
@@ -475,6 +486,12 @@ class DSLMutator(ast.NodeTransformer):
             return node
 
     def visit_AnnAssign(self, node: ast.AnnAssign):
+        # Tensor annotations are exact declarations. A shape
+        # dimension that happens to reference a scalar function parameter is
+        # still an exact declaration unless the author explicitly declares it
+        # as a capacity dimension via ``T.annotate_capacity_dims(...)`` in the
+        # kernel body; syntactic auto-inference could otherwise exempt ordinary
+        # exact dims from adapter validation.
         node = self.generic_visit(node)
         rval = node.value or quote_expr("__tb.empty", span=node, annot=node)
         return self._emit_assign_target(node.target, rval, annot=node.annotation)

--- a/tilelang/language/eager/builder.py
+++ b/tilelang/language/eager/builder.py
@@ -212,6 +212,13 @@ class Builder(BaseBuilder):
         self.eager_jit_subs: dict[str, PrimExpr] = {}
         self.func_pass_configs: dict[str, Any] | None = None
         self.func_compile_flags: list[str] | str | None = None
+        # Capacity-dim contract markers: populated ONLY by the
+        # explicit ``T.annotate_capacity_dims(...)`` opt-in (see below); the
+        # syntactic auto-inference from tensor annotations was removed
+        # because ordinary exact dimensions must remain strict. Attached to the PrimFunc as
+        # ``tilelang_capacity_dims`` so the Metal adapter can exempt exactly
+        # the explicitly declared dims from strict extent checks.
+        self._capacity_dims: dict[str, tuple[int, ...]] = {}
         self.current_file = "<unknown>"
         self.current_line = 0
         self.current_macro_name = "<unknown-macro>"
@@ -1111,6 +1118,46 @@ def annotate_compile_flags(flags: list[str] | str) -> None:
     builder.func_compile_flags = flags
 
 
+def annotate_capacity_dims(dims: dict[str, Sequence[int]]) -> None:
+    """Explicitly declare capacity dimensions of tensor parameters.
+
+    A *capacity* dimension is a shape dimension whose declared extent is an
+    upper bound for the accesses the kernel will perform: the kernel body
+    is expected to bound its accesses with a runtime mask/offset guard
+    (condition against a runtime bound, a runtime-bounded loop, or an
+    offset/clamp), so the caller may supply an actual buffer whose extent
+    differs from the declared one (the legal padded/masked grouped-QMM
+    pattern, e.g. declared rows=64, actual per-expert slices of 15).
+
+    Only dims listed here are exempted from the Metal adapter's strict
+    per-dimension extent validation; every other dim (including dims that
+    merely reference scalar function parameters in the tensor annotation)
+    is validated exactly.  The declaration is a compiled contract: it is
+    attached to the PrimFunc as ``tilelang_capacity_dims`` and the Metal
+    adapter audits the marked dims' accesses for mask/offset guard evidence
+    (warning when none is found).
+
+    Can be placed before or after tensor type annotations.  Lazy
+    ``@T.prim_func`` kernels can equivalently opt in per function via
+    ``func.with_attr("tilelang_capacity_dims", {"W": (0,)})``.
+
+    Example::
+
+        @tilelang.jit
+        def kernel(A_q, rows, m):
+            A_q: T.Tensor((rows, K), "uint8")
+            T.annotate_capacity_dims({"A_q": (0,)})
+            ...
+    """
+    builder = Builder.current()
+    if builder is None:
+        raise JITNoBuilderError("T.annotate_capacity_dims() can only be used inside @tilelang.jit or @T.prim_func")
+    if builder.eager_jit == "phase1":
+        return
+    for name, name_dims in dims.items():
+        builder._capacity_dims[str(name)] = tuple(int(d) for d in name_dims)
+
+
 def annotate_pass_configs(configs: dict[str, Any]) -> None:
     """
     Annotate pass configuration inside a function body.
@@ -1146,6 +1193,16 @@ def _patch_prim_func_attrs(pf: PrimFunc, builder: Builder) -> PrimFunc:
         if isinstance(flags, str):
             flags = [flags]
         pf = pf.with_attr("tilelang_compile_flags", flags)
+    if builder._capacity_dims:
+        tensor_param_names = {str(buf.name) for var in pf.params if (buf := pf.buffer_map.get(var)) is not None}
+        unknown_names = sorted(set(builder._capacity_dims) - tensor_param_names)
+        if unknown_names:
+            raise ValueError(
+                "T.annotate_capacity_dims: unknown tensor parameter name(s) "
+                f"{unknown_names}; declared tensor parameters are "
+                f"{sorted(tensor_param_names)}"
+            )
+        pf = pf.with_attr("tilelang_capacity_dims", dict(builder._capacity_dims))
     return pf
 
 


### PR DESCRIPTION
## Problem and change

The Metal eager adapter derives launches from the public signature rather than lowered host calls, which breaks multi-kernel order, generated workspaces, dynamic outputs, packed runtime scalars, and asynchronous tensor lifetime in fused Qwen dense, Qwen MoE, and DeepSeek-style workloads.

Build the launch plan from lowered host call sites, preserve program order, bind generated buffers and the packed `args_t` scalar ABI, resolve dynamic outputs/workspaces, and retain tensors until MPS completion. Multi-kernel MSL emits its shared argument union once. Capacity dimensions become an explicit contract through `T.annotate_capacity_dims(...)` or the equivalent PrimFunc attribute; unmarked dimensions remain strict shape matches.

<sub>Files: `src/metal/codegen/codegen_metal.cc`, `tilelang/jit/adapter/torch/metal.py`, `tilelang/jit/kernel.py`, `tilelang/language/eager/{__init__.py,ast.py,builder.py}`, `testing/python/metal/test_metal_adapter.py`, and `testing/python/metal/test_metal_arg_binding.py`.</sub>

## Before and after

On `origin/main`, the covered cases cannot reliably preserve repeated launch order, bind multiple packed scalars, allocate generated workspaces, or keep temporary tensors alive through asynchronous completion. This PR validates those behaviors with real-MPS ABI, launch-order, lifetime, dynamic-shape, and capacity-contract regressions.

Performance classification: **No performance claim**. No isolated speedup is claimed. The fused MoE benchmark also requires the separate Metal reduction lowering and downstream kernels, so campaign-level launch-count and latency numbers are intentionally excluded from this standalone PR and listed only in the appendix.

## Validation

```text
cmake -S . -B build
cmake --build build -j8
TILELANG_DISABLE_CACHE=1 python -m pytest \
  testing/python/metal/test_metal_adapter.py \
  testing/python/metal/test_metal_arg_binding.py -q
66 passed
```

Both runtime modules skip through `torch.backends.mps.is_available()` on non-MPS runners, including ROCm CI.

## Scope

Changes only the Metal torch execution path and explicit eager capacity contract. Targets the M1-M4 MSL/simdgroup path; the M5 Metal 4 TensorOps/FP8 path is out of scope.

## Appendix: combined campaign results (组合 campaign 结果)

The table below describes the complete Apple M2 optimization campaign, not the isolated contribution or acceptance criteria of this PR. Where `origin/main` cannot execute the workload correctly, a numerical speedup versus `main` is undefined; the nearest valid performance baseline is stated explicitly.

| Representative workload | `origin/main` | End-state result | Valid performance comparison |
|---|---|---|---|
| Qwen dense decode | Cannot lower the required Metal reduction | 64-token: `28.3 us/token` synchronized, `23.9 us/token` GPU timeline | `14.5x` versus the valid single-token path (`410.0 us/token`) |
| Fused Qwen/DeepSeek-style MoE block | Required multi-kernel/ABI path is not correct | 9 launches, `16.92 ms` | `1.21x` versus the previous valid 17-launch composed path (`20.53 ms`) |
| Multi-simdgroup bf16 GEMM | t256 staged output is incorrect | Correct t256 execution | Fragment-C `19.86x`; shared-C `14.16x` versus correct t32 paths |
| Software-packed dense fp8 / expert fp4 QMM | Downstream kernels are not present in `main` | `685.7 us` / `697.4 us` | Dense fp8 `16.9x` versus the initial campaign kernel; expert fp4 `26%` faster than its earlier campaign version |
| End-to-end Mega MoE | Complete path is blocked by missing backend prerequisites | T=64 `114.1 ms`; T=1 `16.7 ms` | `80.8%` / `48.0%` lower latency versus the valid full-pipeline baseline |
