### PR TITLE
[Metal] Make simdgroup synchronization tile-aware

### DIFF
--- a/src/metal/op/copy.cc
+++ b/src/metal/op/copy.cc
@@ -96,11 +96,15 @@ Stmt LowerSIMDGroupCopy(const CopyNode &op, const LowerArgs &lower_args,
           dst_col_base + warp_n * (warp_col_tiles * kNPerWarp) + j * kNPerWarp;
       PrimExpr ptr = Call(DataType::Handle(), builtin::address_of(),
                           {BufferLoad(op.dst, {row, col})});
+      // builtin::simdgroup_store(d, index, ptr, stride, col, row, transpose)
+      // expects the tile extents in (col, row) order. kMPerWarp is the row
+      // extent (M) and kNPerWarp is the column extent (N), so pass
+      // kNPerWarp as col and kMPerWarp as row.
       stmts.push_back(Evaluate(
           Call(DataType::Handle(), builtin::simdgroup_store(),
                {op.src->data, IntImm(DataType::Int(32), tile_idx), ptr,
-                dst_stride, IntImm(DataType::Int(32), kMPerWarp),
-                IntImm(DataType::Int(32), kNPerWarp),
+                dst_stride, IntImm(DataType::Int(32), kNPerWarp),
+                IntImm(DataType::Int(32), kMPerWarp),
                 Cast(DataType::Bool(), IntImm(DataType::Int(32), 0))})));
     }
   }

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -1140,8 +1140,8 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
     }
     if (op->op.same_as(builtin::simdgroup_store()) ||
         op->op.same_as(builtin::simdgroup_load())) {
-      // simdgroup_store(frag, tile_idx, ptr, stride, rows, cols, transpose)
-      // simdgroup_load(frag, tile_idx, ptr, stride, rows, cols, transpose)
+      // simdgroup_store(frag, tile_idx, ptr, stride, cols, rows, transpose)
+      // simdgroup_load(frag, tile_idx, ptr, stride, cols, rows, transpose)
       //
       // The pointer argument (args[2]) covers an entire rows x cols (8x8)
       // tile of shared (or global) memory. It comes in two official forms:
@@ -1159,16 +1159,19 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       //
       // The tile descriptor is propagated to the pointer argument (args[2])
       // only; the remaining six arguments (fragment, tile index, stride,
-      // rows, cols, transpose) are plain metadata and must not be tagged as
+      // cols, rows, transpose) are plain metadata and must not be tagged as
       // tile accesses.
       ICHECK_EQ(op->args.size(), 7U);
       bool is_store = op->op.same_as(builtin::simdgroup_store());
-      int tile_rows = 8, tile_cols = 8;
-      if (const auto *rows = op->args[4].as<IntImmNode>()) {
-        tile_rows = rows->value;
-      }
-      if (const auto *cols = op->args[5].as<IntImmNode>()) {
+      // The builtin signature is (d, index, ptr, stride, col, row, transpose)
+      // (see 3rdparty/tvm/include/tvm/tirx/builtin.h), so args[4] is the
+      // column extent and args[5] is the row extent.
+      int tile_cols = 8, tile_rows = 8;
+      if (const auto *cols = op->args[4].as<IntImmNode>()) {
         tile_cols = cols->value;
+      }
+      if (const auto *rows = op->args[5].as<IntImmNode>()) {
+        tile_rows = rows->value;
       }
       for (size_t i = 0; i < op->args.size(); ++i) {
         if (i == 2) {
@@ -1204,20 +1207,47 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
         bool is_tile_access = has_pending_tile_access_;
         AccessType tile_type = kRead;
         int tile_rows = 1, tile_cols = 1;
+        // For a flattened (post-FlattenBuffer) 1-D buffer the pointer
+        // argument is address_of(BufferLoad(flat, {row * stride + col})) and
+        // the tile covers a linear bounding box of
+        // (tile_rows - 1) * tile_stride + tile_cols elements starting at the
+        // base element (tile_stride is the row stride in elements). Record
+        // that extent so PointerAccessIsDisjoint (used by the tile-tile WAW
+        // branch of FindConflict) cannot prove overlapping tiles disjoint
+        // based on the row extent alone. Multi-dimensional buffers keep the
+        // per-dimension rows/cols expansion below.
+        PrimExpr flattened_tile_extent;
         if (is_tile_access) {
           tile_type = pending_tile_access_type_;
           tile_rows = pending_tile_rows_;
           tile_cols = pending_tile_cols_;
+          if (buffer->shape.size() == 1) {
+            ICHECK(pending_tile_stride_.defined());
+            PrimExpr tile_stride = pending_tile_stride_;
+            DataType index_dtype = load->indices[0].dtype();
+            if (tile_stride.dtype() != index_dtype) {
+              tile_stride = Cast(index_dtype, tile_stride);
+            }
+            flattened_tile_extent =
+                make_const(index_dtype, tile_rows - 1) * tile_stride +
+                make_const(index_dtype, tile_cols);
+          }
         }
         // Use buffer shape and indices to compute the buffer_ranges for each
         // dimension.
         for (size_t i = 0; i < buffer->shape.size(); ++i) {
           PrimExpr min = AddAliasElemOffset(GetRef<Var>(buffer_var),
                                             buffer->dtype, load->indices[i]);
-          int extent = is_tile_access
-                           ? ((i == 0) ? tile_rows : (i == 1 ? tile_cols : 1))
-                           : 1;
-          PrimExpr extent_expr = make_const(buffer->shape[i].dtype(), extent);
+          PrimExpr extent_expr;
+          if (flattened_tile_extent.defined()) {
+            extent_expr = flattened_tile_extent;
+          } else {
+            int extent = is_tile_access
+                             ? ((i == 0) ? tile_rows
+                                         : (i == 1 ? tile_cols : 1))
+                             : 1;
+            extent_expr = make_const(buffer->shape[i].dtype(), extent);
+          }
           buffer_ranges.push_back(Range::FromMinExtent(min, extent_expr));
         }
         if (Enabled(buffer_var, scope)) {
@@ -1233,16 +1263,25 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
             PrimExpr physical_index = AddAliasElemOffset(
                 GetRef<Var>(buffer_var), buffer->dtype, load->indices[i]);
             if (is_tile_access) {
-              // Cover the whole tile extent along this dimension. For a
-              // flattened (post-FlattenBuffer) 1-D buffer this is only an
-              // approximation of the 2-D footprint; the planner never relies
-              // on tile touched ranges for disjointness (see FindConflict),
-              // so the approximation is safe.
-              int extent = (i == 0) ? tile_rows : (i == 1 ? tile_cols : 1);
-              PrimExpr extent_minus_one =
-                  make_const(physical_index.dtype(), extent - 1);
-              e.touched.push_back(arith::IntSet::Interval(
-                  physical_index, physical_index + extent_minus_one));
+              if (flattened_tile_extent.defined()) {
+                // Flattened 1-D tile: the whole linear bounding box
+                // (rows x cols with the given row stride) is touched by every
+                // thread of the simdgroup. FindConflict's tile-tile WAW
+                // branch relies on these touched ranges (via
+                // PointerAccessIsDisjoint) to decide whether two stores can
+                // be left unordered, so the bounding box must cover the full
+                // tile footprint including the column extent and stride.
+                PrimExpr extent_minus_one = flattened_tile_extent - 1;
+                e.touched.push_back(arith::IntSet::Interval(
+                    physical_index, physical_index + extent_minus_one));
+              } else {
+                // Cover the whole tile extent along this dimension.
+                int extent = (i == 0) ? tile_rows : (i == 1 ? tile_cols : 1);
+                PrimExpr extent_minus_one =
+                    make_const(physical_index.dtype(), extent - 1);
+                e.touched.push_back(arith::IntSet::Interval(
+                    physical_index, physical_index + extent_minus_one));
+              }
             } else {
               e.touched.push_back(arith::IntSet::Vector(physical_index));
             }

--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -629,6 +629,19 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
      * return values).
      */
     bool is_atomic = false;
+    /*! \brief Whether this access originates from a simdgroup tile op
+     *         (simdgroup_store/simdgroup_load through address_of or
+     *         tvm_access_ptr).
+     *
+     * An 8x8 tile is produced/consumed cooperatively by every thread of
+     * the simdgroup: the per-thread element is lane-dependent and invisible
+     * in the base index expression, so the planner must treat the whole
+     * tile as touched and must not rely on single-element disjointness or
+     * same-index reasoning for ordering. Otherwise, multi-simdgroup staged
+     * epilogues can miss the barrier between simdgroup_store and cross-group
+     * reads.
+     */
+    bool is_tile_access = false;
   };
   /*! \brief Access pattern about a single statement */
   struct StmtEntry {
@@ -1125,6 +1138,53 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
       }
       return;
     }
+    if (op->op.same_as(builtin::simdgroup_store()) ||
+        op->op.same_as(builtin::simdgroup_load())) {
+      // simdgroup_store(frag, tile_idx, ptr, stride, rows, cols, transpose)
+      // simdgroup_load(frag, tile_idx, ptr, stride, rows, cols, transpose)
+      //
+      // The pointer argument (args[2]) covers an entire rows x cols (8x8)
+      // tile of shared (or global) memory. It comes in two official forms:
+      //   - address_of(BufferLoad): LowerSIMDGroupCopy staged path
+      //     (src/metal/op/copy.cc),
+      //   - tvm_access_ptr: Metal macro / tensor-intrin path (T.access_ptr
+      //     in metal_macro_generator.py and tensor_intrin/metal.py).
+      // The generic address_of / tvm_access_ptr handling records only the
+      // single base element and the address_of path always as kRead, which
+      // hides the write side of simdgroup_store (and the full tile
+      // footprint) from the sync planner. That left multi-simdgroup staged
+      // epilogues with no barrier between the staging stores and the
+      // cross-group epilogue reads. Record the pointer argument explicitly
+      // as a tile access with the full tile extent and correct access type.
+      //
+      // The tile descriptor is propagated to the pointer argument (args[2])
+      // only; the remaining six arguments (fragment, tile index, stride,
+      // rows, cols, transpose) are plain metadata and must not be tagged as
+      // tile accesses.
+      ICHECK_EQ(op->args.size(), 7U);
+      bool is_store = op->op.same_as(builtin::simdgroup_store());
+      int tile_rows = 8, tile_cols = 8;
+      if (const auto *rows = op->args[4].as<IntImmNode>()) {
+        tile_rows = rows->value;
+      }
+      if (const auto *cols = op->args[5].as<IntImmNode>()) {
+        tile_cols = cols->value;
+      }
+      for (size_t i = 0; i < op->args.size(); ++i) {
+        if (i == 2) {
+          has_pending_tile_access_ = true;
+          pending_tile_access_type_ = is_store ? kWrite : kRead;
+          pending_tile_rows_ = tile_rows;
+          pending_tile_cols_ = tile_cols;
+          pending_tile_stride_ = op->args[3];
+        } else {
+          has_pending_tile_access_ = false;
+        }
+        this->VisitExpr(op->args[i]);
+      }
+      has_pending_tile_access_ = false;
+      return;
+    }
     if (op->op.same_as(builtin::address_of())) {
       ICHECK_EQ(op->args.size(), 1U);
       if (auto load = op->args[0].as<BufferLoadNode>()) {
@@ -1136,13 +1196,29 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
         Array<Range> buffer_ranges;
         // from indices to buffer indices
         ICHECK(buffer->shape.size() == load->indices.size());
+        // Tile extents for an enclosing simdgroup_store/load (defaults to a
+        // single element for plain address_of uses). For a simdgroup tile
+        // access the touched extent along dimension i is the tile extent
+        // (rows for dim 0, cols for dim 1, 1 otherwise): the whole tile is
+        // touched by every thread of the simdgroup.
+        bool is_tile_access = has_pending_tile_access_;
+        AccessType tile_type = kRead;
+        int tile_rows = 1, tile_cols = 1;
+        if (is_tile_access) {
+          tile_type = pending_tile_access_type_;
+          tile_rows = pending_tile_rows_;
+          tile_cols = pending_tile_cols_;
+        }
         // Use buffer shape and indices to compute the buffer_ranges for each
         // dimension.
         for (size_t i = 0; i < buffer->shape.size(); ++i) {
           PrimExpr min = AddAliasElemOffset(GetRef<Var>(buffer_var),
                                             buffer->dtype, load->indices[i]);
-          PrimExpr extent = make_const(buffer->shape[i].dtype(), 1);
-          buffer_ranges.push_back(Range::FromMinExtent(min, extent));
+          int extent = is_tile_access
+                           ? ((i == 0) ? tile_rows : (i == 1 ? tile_cols : 1))
+                           : 1;
+          PrimExpr extent_expr = make_const(buffer->shape[i].dtype(), extent);
+          buffer_ranges.push_back(Range::FromMinExtent(min, extent_expr));
         }
         if (Enabled(buffer_var, scope)) {
           ICHECK(allow_append_);
@@ -1152,14 +1228,29 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
           e.buffer = Downcast<Var>(buffer->data);
           e.buffer_name = buffer;
           e.buffer_ranges = buffer_ranges;
-          for (const auto &index : load->indices) {
+          size_t n_indices = load->indices.size();
+          for (size_t i = 0; i < n_indices; ++i) {
             PrimExpr physical_index = AddAliasElemOffset(
-                GetRef<Var>(buffer_var), buffer->dtype, index);
-            e.touched.push_back(arith::IntSet::Vector(physical_index));
+                GetRef<Var>(buffer_var), buffer->dtype, load->indices[i]);
+            if (is_tile_access) {
+              // Cover the whole tile extent along this dimension. For a
+              // flattened (post-FlattenBuffer) 1-D buffer this is only an
+              // approximation of the 2-D footprint; the planner never relies
+              // on tile touched ranges for disjointness (see FindConflict),
+              // so the approximation is safe.
+              int extent = (i == 0) ? tile_rows : (i == 1 ? tile_cols : 1);
+              PrimExpr extent_minus_one =
+                  make_const(physical_index.dtype(), extent - 1);
+              e.touched.push_back(arith::IntSet::Interval(
+                  physical_index, physical_index + extent_minus_one));
+            } else {
+              e.touched.push_back(arith::IntSet::Vector(physical_index));
+            }
           }
           e.is_pointer_access = true;
+          e.is_tile_access = is_tile_access;
           e.is_atomic = (atomic_dst_ptr_depth_ > 0);
-          e.type = kRead;
+          e.type = is_tile_access ? tile_type : kRead;
           e.scope = scope;
           curr_stmt_.access.emplace_back(e);
         }
@@ -1227,8 +1318,36 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
         e.buffer_ranges = buffer_ranges;
         e.is_pointer_access = true;
         e.is_atomic = (atomic_dst_ptr_depth_ > 0);
-        e.touched = {
-            arith::IntSet::FromRange(Range::FromMinExtent(offset, extent))};
+        // The pointer argument of an enclosing simdgroup_store/load is a
+        // tvm_access_ptr with a single-element default extent (LowerAccessPtr
+        // for a BufferLoad base). Without special handling it would be
+        // recorded as a plain single-element pointer access, and FindConflict
+        // could prove it disjoint from other accesses via single-element
+        // PointerAccessIsDisjoint reasoning. For the Metal macro/tensor-intrin
+        // simdgroup path (T.access_ptr), tag it as a tile access and expand the
+        // touched range to a safe linear bounding box covering the whole
+        // rows x cols tile so the conservative tile rule in FindConflict
+        // applies. The rw_mask semantics are
+        // preserved below ("r" -> kRead tile, "w" -> kWrite tile; the Metal
+        // macros emit "w" for simdgroup_store and "r" for simdgroup_load,
+        // matching the pending tile type).
+        bool is_tile_access = has_pending_tile_access_;
+        e.is_tile_access = is_tile_access;
+        if (is_tile_access) {
+          ICHECK(pending_tile_stride_.defined());
+          PrimExpr tile_stride = pending_tile_stride_;
+          if (tile_stride.dtype() != extent.dtype()) {
+            tile_stride = Cast(extent.dtype(), tile_stride);
+          }
+          PrimExpr tile_extent =
+              make_const(extent.dtype(), pending_tile_rows_ - 1) * tile_stride +
+              make_const(extent.dtype(), pending_tile_cols_);
+          e.touched = {arith::IntSet::FromRange(
+              Range::FromMinExtent(offset, tile_extent))};
+        } else {
+          e.touched = {
+              arith::IntSet::FromRange(Range::FromMinExtent(offset, extent))};
+        }
         e.scope = scope;
         if (flag->value & 1) {
           e.type = kRead;
@@ -1480,6 +1599,15 @@ private:
   // (e.g., atomic_add/atomic_max/atomic_load). When > 0, accesses produced by
   // the pointer metadata ops are tagged as atomic.
   int atomic_dst_ptr_depth_{0};
+  // Enclosing simdgroup_store/simdgroup_load tile-access descriptor. While
+  // visiting the pointer argument of such a call, address_of(BufferLoad)
+  // records the access with the tile type (kWrite for store / kRead for
+  // load) and the full tile extent instead of a single-element kRead.
+  bool has_pending_tile_access_{false};
+  AccessType pending_tile_access_type_{kRead};
+  int pending_tile_rows_{1};
+  int pending_tile_cols_{1};
+  PrimExpr pending_tile_stride_;
   // the current free stmt entry.
   StmtEntry curr_stmt_;
   // The involving threads
@@ -1501,7 +1629,7 @@ private:
     syncs_inserted_.insert(obj);
   }
   bool PointerAccessIsDisjoint(const AccessEntry &lhs, const AccessEntry &rhs) {
-    if (lhs.touched.size() != 1 || rhs.touched.size() != 1) {
+    if (lhs.touched.empty() || lhs.touched.size() != rhs.touched.size()) {
       return false;
     }
     ConstrSet prev_cset{lhs.cset};
@@ -1516,10 +1644,6 @@ private:
         {"ty1", "ty2"},
         {"tz1", "tz2"},
     };
-    PrimExpr lhs_min = analyzer.Simplify(lhs.touched[0].min());
-    PrimExpr lhs_max = analyzer.Simplify(lhs.touched[0].max());
-    PrimExpr rhs_min = analyzer.Simplify(rhs.touched[0].min());
-    PrimExpr rhs_max = analyzer.Simplify(rhs.touched[0].max());
     Map<Var, PrimExpr> prev_sub, curr_sub;
     for (unsigned idx = 0; idx != 3; ++idx) {
       auto &info = thread_vars[idx];
@@ -1535,23 +1659,27 @@ private:
                                      /*rename_ranges=*/false);
     curr_cset = curr_cset.RenameFrom("<CURR>", curr_sub, std::nullopt,
                                      /*rename_ranges=*/false);
-    lhs_min = Substitute(lhs_min, prev_sub);
-    lhs_max = Substitute(lhs_max, prev_sub);
-    rhs_min = Substitute(rhs_min, curr_sub);
-    rhs_max = Substitute(rhs_max, curr_sub);
     // Lower to predicates before merging so that a variable bound to different
     // values on the two sides does not trip the analyzer's re-bind check.
     prev_cset.ToConstraints()
         .Merge(curr_cset.ToConstraints())
         .Populate(analyzer);
 
-    if (analyzer.CanProve(lhs_max < rhs_min,
-                          arith::ProofStrength::kSymbolicBound)) {
-      return true;
-    }
-    if (analyzer.CanProve(rhs_max < lhs_min,
-                          arith::ProofStrength::kSymbolicBound)) {
-      return true;
+    for (size_t i = 0; i < lhs.touched.size(); ++i) {
+      PrimExpr lhs_min =
+          Substitute(analyzer.Simplify(lhs.touched[i].min()), prev_sub);
+      PrimExpr lhs_max =
+          Substitute(analyzer.Simplify(lhs.touched[i].max()), prev_sub);
+      PrimExpr rhs_min =
+          Substitute(analyzer.Simplify(rhs.touched[i].min()), curr_sub);
+      PrimExpr rhs_max =
+          Substitute(analyzer.Simplify(rhs.touched[i].max()), curr_sub);
+      if (analyzer.CanProve(lhs_max < rhs_min,
+                            arith::ProofStrength::kSymbolicBound) ||
+          analyzer.CanProve(rhs_max < lhs_min,
+                            arith::ProofStrength::kSymbolicBound)) {
+        return true;
+      }
     }
     return false;
   }
@@ -1673,6 +1801,27 @@ private:
     // Access to different buffers does not conflict.
     if (!prev.buffer.same_as(curr.buffer)) {
       return false;
+    }
+
+    // simdgroup tile accesses (simdgroup_store/simdgroup_load through
+    // address_of): the whole tile is touched cooperatively by every thread
+    // of the simdgroup, and the per-thread element is lane-dependent
+    // (invisible in the base index). Any RAW/WAR ordering between a tile
+    // access and another access to the same buffer must therefore be
+    // enforced with a barrier — the single-element / same-index reasoning
+    // below cannot prove safety for multi-simdgroup staged epilogues.
+    //
+    // Write-after-write between two tile accesses needs no ordering only
+    // when their full tile footprints are provably disjoint. Overlapping
+    // cross-simdgroup stores are sequential program statements, so a barrier
+    // is required to make the later store deterministically win.
+    if (prev.is_tile_access || curr.is_tile_access) {
+      if (prev.is_tile_access && curr.is_tile_access && prev.type == kWrite &&
+          curr.type == kWrite) {
+        return !(prev.is_pointer_access && curr.is_pointer_access &&
+                 PointerAccessIsDisjoint(prev, curr));
+      }
+      return true;
     }
 
     // Atomic ops already provide correctness for concurrent access.

--- a/testing/python/metal/test_metal_threadsync_simdgroup_store.py
+++ b/testing/python/metal/test_metal_threadsync_simdgroup_store.py
@@ -1,0 +1,469 @@
+"""Test ThreadSync barriers for simdgroup_store / simdgroup_load tile accesses.
+
+Regression for the ThreadSyncPlanner gap fixed in
+src/transform/thread_storage_sync.cc: the pointer argument of
+simdgroup_store/simdgroup_load is an address_of(BufferLoad) which the
+planner used to record as a *single-element kRead* — hiding the write side
+of simdgroup_store and the full 8x8 tile footprint. Multi-simdgroup staged
+epilogues (fragment -> shared via simdgroup_store, then cross-simdgroup
+reads) therefore got 0 barriers between the staging stores and the reads
+(the 256-thread staged kernel failed 12/12 rounds, maxerr=5.969).
+
+The same gap exists for the second official pointer form, the Metal
+macro / tensor-intrin T.access_ptr (tvm_access_ptr) used by
+metal_macro_generator.py and tensor_intrin/metal.py: those accesses were
+recorded as plain single-element pointer accesses and FindConflict could
+prove them disjoint from other accesses via PointerAccessIsDisjoint —
+again skipping the barrier between overlapping cross-simdgroup tiles. The regression below
+covers both forms: the staged address_of path and the explicit
+T.access_ptr simdgroup_store/load path (normal + transpose + padded
+stride, cross-warp RAW and WAR).
+
+Acceptance criteria:
+  1. per-round max abs err vs fp32 CPU reference < 1e-2
+     (fp16 noise floor is far below 1e-2, which separates races like 5.969
+     from rounding noise),
+  2. run-to-run determinism: N rounds bit-identical (int32 bitview),
+  3. fresh output buffer allocated per round, all rounds must pass,
+  4. static MSL: a threadgroup_barrier must exist *after* the last
+     simdgroup_store of the staged epilogue (bar_after_store=True),
+  5. static MSL: for the T.access_ptr forms a threadgroup_barrier must
+     exist between the producer simdgroup op (store for RAW / load for
+     WAR) and the consumer simdgroup op of the other warp (pre-fix: no
+     such barrier, 8/8 configs),
+  6. the direct fragment-C -> global path (dense_gemm_frag
+     t256, zero-communication) must keep barriers==2 and stay bit-identical.
+
+The staged kernel below represents a DeepSeek V4 Flash-style gated-MoE
+epilogue (t256 = 8 simdgroups, block_M=8 -> each warp owns one row; the
+epilogue reads Cs_sh[i, 0], which is warp 0's column).
+"""
+
+import tilelang
+import tilelang.metal.language as T
+import tilelang.testing
+import pytest
+import torch
+
+pytestmark = pytest.mark.skipif(
+    not torch.backends.mps.is_available(),
+    reason="PyTorch MPS device is required",
+)
+
+# fp16 noise floor measured on M2 (maxerr of the correct t32 staged path).
+# 1e-2 separates the observed race failures (O(1), maxerr=5.969)
+# rounding noise is ~2.4e-04.
+MAX_ERR = 1e-2
+N_ROUNDS = 12
+STAGED_SHAPE = "64_512_2048"  # T_ x Is x H
+
+
+@tilelang.jit(execution_backend="tvm_ffi")
+def _staged_msg(x, Wg, Wu, Ws_g, mid, T_, Is, H, block_M=8, block_N=128, block_K=32, threads=256):
+    """DeepSeek V4 Flash-style t256 epilogue: fragment-to-shared
+    T.copy + cross-group epilogue read (Cs_sh[i,0] is warp-0's column)."""
+    x: T.Tensor((T_, H), "float16")
+    Wg: T.Tensor((Is, H), "float16")
+    Wu: T.Tensor((Is, H), "float16")
+    Ws_g: T.Tensor((1, H), "float16")
+    mid: T.Tensor((T_, Is), "float16")
+    with T.Kernel(T.ceildiv(T_, block_M), T.ceildiv(Is, block_N), threads=threads) as (bm, bn):
+        A_s = T.alloc_shared((block_M, block_K), "float16")
+        Bg_s = T.alloc_shared((block_N, block_K), "float16")
+        Bu_s = T.alloc_shared((block_N, block_K), "float16")
+        Bs_s = T.alloc_shared((block_N, block_K), "float16")
+        Cg = T.alloc_fragment((block_M, block_N), "float32")
+        Cu = T.alloc_fragment((block_M, block_N), "float32")
+        Cs = T.alloc_fragment((block_M, block_N), "float32")
+        Cg_sh = T.alloc_shared((block_M, block_N), "float32")
+        Cu_sh = T.alloc_shared((block_M, block_N), "float32")
+        Cs_sh = T.alloc_shared((block_M, block_N), "float32")
+        T.clear(Cg)
+        T.clear(Cu)
+        T.clear(Cs)
+        for kk in T.serial(T.ceildiv(H, block_K)):
+            for i, j in T.Parallel(block_M, block_K):
+                A_s[i, j] = T.if_then_else(
+                    (bm * block_M + i < T_) and (kk * block_K + j < H), x[bm * block_M + i, kk * block_K + j], T.cast(0, "float16")
+                )
+            for i, j in T.Parallel(block_N, block_K):
+                Bg_s[i, j] = T.if_then_else(
+                    (bn * block_N + i < Is) and (kk * block_K + j < H), Wg[bn * block_N + i, kk * block_K + j], T.cast(0, "float16")
+                )
+            for i, j in T.Parallel(block_N, block_K):
+                Bu_s[i, j] = T.if_then_else(
+                    (bn * block_N + i < Is) and (kk * block_K + j < H), Wu[bn * block_N + i, kk * block_K + j], T.cast(0, "float16")
+                )
+            for i, j in T.Parallel(block_N, block_K):
+                Bs_s[i, j] = T.if_then_else((i == 0) and (kk * block_K + j < H), Ws_g[0, kk * block_K + j], T.cast(0, "float16"))
+            T.gemm(A_s, Bg_s, Cg, transpose_B=True)
+            T.gemm(A_s, Bu_s, Cu, transpose_B=True)
+            T.gemm(A_s, Bs_s, Cs, transpose_B=True)
+        T.copy(Cg, Cg_sh)
+        T.copy(Cu, Cu_sh)
+        T.copy(Cs, Cs_sh)
+        for i, j in T.Parallel(block_M, block_N):
+            if bm * block_M + i < T_ and bn * block_N + j < Is:
+                gg = Cg_sh[i, j]
+                sig = 1.0 / (1.0 + T.exp(-Cs_sh[i, 0]))
+                mid[bm * block_M + i, bn * block_N + j] = T.cast((gg / (1 + T.exp(-gg))) * Cu_sh[i, j] * sig, "float16")
+
+
+@tilelang.jit(execution_backend="tvm_ffi")
+def _dense_gemm_frag(A, B, C, M, N, K, block_M, block_N, block_K, threads):
+    """Fragment-C direct simdgroup_store to global (zero
+    cross-warp communication; must stay unchanged by the fix)."""
+    A: T.Tensor((M, K), "float16")
+    B: T.Tensor((N, K), "float16")
+    C: T.Tensor((M, N), "float32")
+    with T.Kernel(T.ceildiv(N, block_N), T.ceildiv(M, block_M), threads=threads) as (bx, by):
+        A_s = T.alloc_shared((block_M, block_K), "float16")
+        B_s = T.alloc_shared((block_N, block_K), "float16")
+        C_l = T.alloc_fragment((block_M, block_N), "float32")
+        T.clear(C_l)
+        for kk in T.serial(T.ceildiv(K, block_K)):
+            for i, j in T.Parallel(block_M, block_K):
+                A_s[i, j] = T.if_then_else(
+                    (by * block_M + i < M) and (kk * block_K + j < K), A[by * block_M + i, kk * block_K + j], T.cast(0, "float16")
+                )
+            for i, j in T.Parallel(block_N, block_K):
+                B_s[i, j] = T.if_then_else(
+                    (bx * block_N + i < N) and (kk * block_K + j < K), B[bx * block_N + i, kk * block_K + j], T.cast(0, "float16")
+                )
+            T.gemm(A_s, B_s, C_l, transpose_B=True)
+        T.copy(C_l, C[by * block_M, bx * block_N])
+
+
+def _msl_facts(kernel):
+    src = kernel.get_kernel_source()
+    lines = src.splitlines()
+    last_bar = max((i for i, line in enumerate(lines) if "threadgroup_barrier" in line), default=-1)
+    last_store = max((i for i, line in enumerate(lines) if "simdgroup_store" in line), default=-1)
+    return dict(
+        src=src,
+        barriers=src.count("threadgroup_barrier"),
+        last_store=last_store,
+        last_bar=last_bar,
+        bar_after_store=(last_bar > last_store),
+    )
+
+
+def _staged_inputs(seed=11):
+    dev = "mps"
+    T_, Is, H = [int(v) for v in STAGED_SHAPE.split("_")]
+    torch.manual_seed(seed)
+    x = (torch.randn(T_, H) * 0.5).to(torch.float16).to(dev)
+    Wg = (torch.randn(Is, H) * 0.05).to(torch.float16).to(dev)
+    Wu = (torch.randn(Is, H) * 0.05).to(torch.float16).to(dev)
+    Ws = (torch.randn(1, H) * 0.05).to(torch.float16).to(dev)
+    xf = x.float().cpu()
+    ref = (torch.nn.functional.silu(xf @ Wg.float().cpu().T) * (xf @ Wu.float().cpu().T) * torch.sigmoid(xf @ Ws.float().cpu().T)).to(
+        torch.float16
+    )
+    return x, Wg, Wu, Ws, ref, T_, Is, H
+
+
+def _check_staged_threads(threads, n_rounds=N_ROUNDS, seed=11):
+    """Run the staged case with `threads` simdgroup threads and check the
+    full criterion (err per round, determinism, MSL barrier position)."""
+    x, Wg, Wu, Ws, ref, T_, Is, H = _staged_inputs(seed)
+    dev = "mps"
+    bn = 128 if threads > 32 else 64
+    k = _staged_msg.compile(x, Wg, Wu, Ws, torch.zeros(T_, Is, dtype=torch.float16, device=dev), T_, Is, H, 8, bn, 32, threads)
+    facts = _msl_facts(k)
+    fails = 0
+    maxerr = 0.0
+    det_ok = True
+    prev = None
+    for _ in range(n_rounds):
+        # Use a fresh output buffer every round.
+        mid = torch.empty(T_, Is, dtype=torch.float16, device=dev)
+        k(x, Wg, Wu, Ws, mid)
+        torch.mps.synchronize()
+        err = (mid.cpu() - ref).abs().max().item()
+        maxerr = max(maxerr, err)
+        if prev is not None:
+            det_ok = det_ok and torch.equal(mid.cpu(), prev)
+        prev = mid.cpu()
+        if err > MAX_ERR:
+            fails += 1
+    assert fails == 0, f"staged t{threads}: {fails}/{n_rounds} rounds wrong, maxerr={maxerr:.3e} (threshold {MAX_ERR})"
+    assert maxerr < MAX_ERR, f"staged t{threads}: maxerr={maxerr:.3e}"
+    assert det_ok, f"staged t{threads}: run-to-run divergence detected"
+    assert facts["bar_after_store"], (
+        f"staged t{threads}: no threadgroup_barrier after the last "
+        f"simdgroup_store (last_store={facts['last_store']}, "
+        f"last_bar={facts['last_bar']})"
+    )
+    return facts
+
+
+def test_codegen_staged_t256_barrier_after_store():
+    """Static MSL evidence (no GPU needed): t256 staged epilogue must have a
+    barrier after the last simdgroup_store (pre-fix: 2 barriers, none after
+    the stores at lines ~132-137; post-fix: 4, barrier at line 139)."""
+    x, Wg, Wu, Ws, _, T_, Is, H = _staged_inputs(seed=11)
+    k = _staged_msg.compile(x, Wg, Wu, Ws, torch.zeros(T_, Is, dtype=torch.float16, device="mps"), T_, Is, H, 8, 128, 32, 256)
+    facts = _msl_facts(k)
+    assert facts["bar_after_store"], (
+        f"bar_after_store={facts['bar_after_store']} (last_store={facts['last_store']}, last_bar={facts['last_bar']})"
+    )
+    assert facts["barriers"] >= 3, f"barriers={facts['barriers']}"
+
+
+def test_codegen_frag_t256_unchanged_barriers():
+    """The direct fragment-C -> global path must keep
+    the zero-communication barrier structure (2 barriers, all in the kk
+    loop, none added around the final simdgroup_store)."""
+    dev = "mps"
+    M, N, K = 64, 2048, 512
+    A = torch.zeros(M, K, dtype=torch.float16, device=dev)
+    B = torch.zeros(N, K, dtype=torch.float16, device=dev)
+    C = torch.zeros(M, N, dtype=torch.float32, device=dev)
+    k = _dense_gemm_frag.compile(A, B, C, M, N, K, 8, 128, 32, 256)
+    facts = _msl_facts(k)
+    assert facts["barriers"] == 2, f"frag t256 barriers={facts['barriers']}"
+
+
+@tilelang.testing.requires_metal
+def test_correctness_staged_t256():
+    """Dynamic: t256 staged epilogue, 12 rounds fresh buffer, all rounds must
+    be < 1e-2 vs fp32 ref and run-to-run bit-identical. Pre-fix: 12/12 wrong
+    (maxerr=5.969)."""
+    facts = _check_staged_threads(256)
+    assert facts["barriers"] >= 3
+
+
+@tilelang.testing.requires_metal
+def test_correctness_staged_t32():
+    """Dynamic: t32 (single simdgroup) staged epilogue must stay correct
+    (pre-fix baseline remains below the race-detection threshold)."""
+    _check_staged_threads(32)
+
+
+@tilelang.testing.requires_metal
+def test_correctness_frag_t256_bit_identical():
+    """dense_gemm_frag t256 direct-to-global must
+    stay bit-identical to the fp32 reference and keep barriers==2."""
+    dev = "mps"
+    M, N, K = 64, 2048, 512
+    torch.manual_seed(7)
+    A = (torch.randn(M, K) * 0.5).to(torch.float16).to(dev)
+    B = (torch.randn(N, K) * 0.05).to(torch.float16).to(dev)
+    C = torch.empty(M, N, dtype=torch.float32, device=dev)
+    k = _dense_gemm_frag.compile(A, B, C, M, N, K, 8, 128, 32, 256)
+    k(A, B, C)
+    torch.mps.synchronize()
+    ref = (A.float() @ B.float().T).cpu()
+    assert torch.equal(C.cpu(), ref), f"frag t256 diverged from fp32 reference (maxerr={(C.cpu() - ref).abs().max().item():.3e})"
+    assert _msl_facts(k)["barriers"] == 2
+
+
+# ---------------------------------------------------------------------------
+# T.access_ptr (tvm_access_ptr) pointer-form coverage
+# ---------------------------------------------------------------------------
+# The Metal macro / tensor-intrin path builds simdgroup_store/load pointer
+# arguments as T.access_ptr(...) (lowered to tvm_access_ptr with a
+# single-element default extent). Previously these were recorded as
+# plain single-element pointer accesses and PointerAccessIsDisjoint could
+# prove two *base elements* disjoint while the 8x8 tile footprints overlap
+# (here: warp 0 stores the tile at sh[1, 0] covering rows 1..8; warp 1
+# loads the tile at sh[8, 0] covering rows 8..15; the tiles overlap at
+# row 8 while the base offsets 1*stride and 8*stride are disjoint).
+#
+# Kernel layout (threads=64, 2 simdgroups): each warp owns one 8x8
+# simdgroup matrix in a per-warp metal.simdgroup local buffer. The shared
+# buffer is seeded with zeros, warp 0 produces/consumes the sh[1, 0] tile
+# and warp 1 consumes/produces the sh[8, 0] tile; results are read back to
+# global with a per-warp base (out[0, warp*8]).
+#
+# - RAW kernel: warp 0 simdgroup_store (access_ptr "w") then warp 1
+#   simdgroup_load (access_ptr "r") -> barrier must separate them, and
+#   out[0, 8:16] must equal x[7, 0:8] (the overlap row of the stored tile).
+# - WAR kernel: warp 0 simdgroup_load (access_ptr "r") then warp 1
+#   simdgroup_store (access_ptr "w") -> barrier must separate them, and
+#   out[:, 0:8] must stay all-zero (the load sees the seed).
+#
+# Variants: transpose in {False, True} x shared stride in {8, 16}
+# (padded stride: row stride 16 with an 8-column tile footprint).
+
+AP_CONFIGS = ((0, 8), (0, 16), (1, 8), (1, 16))  # (transpose, stride)
+
+
+@tilelang.jit(execution_backend="tvm_ffi")
+def _access_ptr_raw(x, out, transpose, stride, threads=64):
+    """Cross-warp RAW through the T.access_ptr pointer form: warp 0 stores
+    the tile at sh[1, 0] (rows 1..8), warp 1 loads the tile at sh[8, 0]
+    (rows 8..15). The footprints overlap at row 8 while the base elements
+    are disjoint, so the pre-fix single-element disjointness proof skipped
+    the RAW barrier."""
+    x: T.Tensor((8, 16), "float32")
+    out: T.Tensor((8, 16), "float32")
+    with T.Kernel(1, threads=threads) as (_bx,):
+        sh = T.alloc_shared((16, stride), "float32")
+        C_l = T.alloc_local((64,), "float32", scope="metal.simdgroup")
+        C2 = T.alloc_local((64,), "float32", scope="metal.simdgroup")
+        for i, j in T.Parallel(16, stride):
+            sh[i, j] = 0.0
+        T.simdgroup_load(C_l.data, 0, T.access_ptr(x[0, T.get_thread_binding() // 32 * 8], "r"), 16, 8, 8, T.bool(transpose))
+        T.make_filled_simdgroup_matrix(C2.data, 0, T.cast(0.0, "float32"))
+        if T.get_thread_binding() < 32:
+            T.simdgroup_store(C_l.data, 0, T.access_ptr(sh[1, 0], "w"), stride, 8, 8, T.bool(transpose))
+        if T.get_thread_binding() >= 32:
+            T.simdgroup_load(C2.data, 0, T.access_ptr(sh[8, 0], "r"), stride, 8, 8, T.bool(transpose))
+        T.simdgroup_store(C2.data, 0, T.access_ptr(out[0, T.get_thread_binding() // 32 * 8], "w"), 16, 8, 8, T.bool(transpose))
+
+
+@tilelang.jit(execution_backend="tvm_ffi")
+def _access_ptr_war(x, out, transpose, stride, threads=64):
+    """Cross-warp WAR through the T.access_ptr pointer form: warp 0 loads
+    the tile at sh[1, 0] (rows 1..8), warp 1 stores the tile at sh[8, 0]
+    (rows 8..15). The footprints overlap at row 8; a barrier must separate
+    the load from the store."""
+    x: T.Tensor((8, 16), "float32")
+    out: T.Tensor((8, 16), "float32")
+    with T.Kernel(1, threads=threads) as (bx,):
+        sh = T.alloc_shared((16, stride), "float32")
+        C_l = T.alloc_local((64,), "float32", scope="metal.simdgroup")
+        C2 = T.alloc_local((64,), "float32", scope="metal.simdgroup")
+        for i, j in T.Parallel(16, stride):
+            sh[i, j] = 0.0
+        T.simdgroup_load(C_l.data, 0, T.access_ptr(x[0, T.get_thread_binding() // 32 * 8], "r"), 16, 8, 8, T.bool(transpose))
+        T.make_filled_simdgroup_matrix(C2.data, 0, T.cast(0.0, "float32"))
+        if T.get_thread_binding() < 32:
+            T.simdgroup_load(C2.data, 0, T.access_ptr(sh[1, 0], "r"), stride, 8, 8, T.bool(transpose))
+        if T.get_thread_binding() >= 32:
+            T.simdgroup_store(C_l.data, 0, T.access_ptr(sh[8, 0], "w"), stride, 8, 8, T.bool(transpose))
+        T.simdgroup_store(C2.data, 0, T.access_ptr(out[0, T.get_thread_binding() // 32 * 8], "w"), 16, 8, 8, T.bool(transpose))
+
+
+@tilelang.jit(execution_backend="tvm_ffi")
+def _access_ptr_waw(out, stride, threads=64):
+    """Two sequential simdgroups store overlapping 8x8 shared tiles.
+
+    The first tile covers rows 1..8 and the second covers rows 8..15, so
+    row 8 requires a barrier between the stores. The final load keeps the
+    shared-memory writes observable in generated code.
+    """
+    out: T.Tensor((8, 16), "float32")
+    with T.Kernel(1, threads=threads) as (bx,):
+        sh = T.alloc_shared((16, stride), "float32")
+        first = T.alloc_local((64,), "float32", scope="metal.simdgroup")
+        second = T.alloc_local((64,), "float32", scope="metal.simdgroup")
+        loaded = T.alloc_local((64,), "float32", scope="metal.simdgroup")
+        T.make_filled_simdgroup_matrix(first.data, 0, T.cast(1.0, "float32"))
+        T.make_filled_simdgroup_matrix(second.data, 0, T.cast(2.0, "float32"))
+        if T.get_thread_binding() < 32:
+            T.simdgroup_store(first.data, 0, T.access_ptr(sh[1, 0], "w"), stride, 8, 8, T.bool(False))
+        if T.get_thread_binding() >= 32:
+            T.simdgroup_store(second.data, 0, T.access_ptr(sh[8, 0], "w"), stride, 8, 8, T.bool(False))
+        T.simdgroup_load(loaded.data, 0, T.access_ptr(sh[8, 0], "r"), stride, 8, 8, T.bool(False))
+        T.simdgroup_store(loaded.data, 0, T.access_ptr(out[0, T.get_thread_binding() // 32 * 8], "w"), 16, 8, 8, T.bool(False))
+
+
+def _msl_barrier_between(src, first_marker, second_marker):
+    """True if a threadgroup_barrier line exists between the last
+    first_marker line that precedes some second_marker line and the first
+    second_marker line after it."""
+    lines = src.splitlines()
+    bars = [i for i, line in enumerate(lines) if "threadgroup_barrier" in line]
+    first = [i for i, line in enumerate(lines) if first_marker in line]
+    second = [i for i, line in enumerate(lines) if second_marker in line]
+    first_before = [i for i in first if any(j > i for j in second)]
+    if not first_before:
+        return False
+    last_first = max(first_before)
+    second_after = [i for i in second if i > last_first]
+    if not second_after:
+        return False
+    return any(last_first < b < min(second_after) for b in bars)
+
+
+def _msl_barrier_between_first_two(src, marker):
+    lines = src.splitlines()
+    positions = [i for i, line in enumerate(lines) if marker in line]
+    assert len(positions) >= 2, f"expected at least two {marker} occurrences"
+    return any("threadgroup_barrier" in line for line in lines[positions[0] + 1 : positions[1]])
+
+
+def _access_ptr_inputs(seed=3):
+    dev = "mps"
+    torch.manual_seed(seed)
+    x = (torch.randn(8, 16) * 0.5).to(torch.float32).to(dev)
+    exp_raw = torch.zeros(8, 16, dtype=torch.float32, device=dev)
+    # overlap row: warp 1's loaded tile row 0 = sh[8, 0:8] = the stored
+    # tile's last row = x[7, 0:8] (identical for both transpose layouts:
+    # the transpose chain maps the overlap row to out[0, 8:16] the same
+    # way). warp 0's half is the initialized zero matrix.
+    exp_raw[0, 8:16] = x[7, 0:8]
+    exp_war = torch.zeros(8, 16, dtype=torch.float32, device=dev)
+    return x, exp_raw, exp_war
+
+
+def test_codegen_access_ptr_raw_barrier():
+    """Static: a threadgroup_barrier must separate the access_ptr-form
+    simdgroup_store (warp 0) from the overlapping simdgroup_load (warp 1)
+    for normal/transpose x stride 8/16. The single-element disjointness
+    proof must not hide the full tile footprint."""
+    dev = "mps"
+    x = torch.randn(8, 16, dtype=torch.float32, device=dev)
+    out = torch.empty(8, 16, dtype=torch.float32, device=dev)
+    for transpose, stride in AP_CONFIGS:
+        k = _access_ptr_raw.compile(x, out, transpose, stride, 64)
+        assert _msl_barrier_between(k.get_kernel_source(), "simdgroup_store", "simdgroup_load"), (
+            f"RAW access_ptr t{transpose} s{stride}: no barrier between simdgroup_store and simdgroup_load"
+        )
+
+
+def test_codegen_access_ptr_war_barrier():
+    """Static: a threadgroup_barrier must separate the access_ptr-form
+    simdgroup_load (warp 0) from the overlapping simdgroup_store (warp 1)
+    for normal/transpose x stride 8/16."""
+    dev = "mps"
+    x = torch.randn(8, 16, dtype=torch.float32, device=dev)
+    out = torch.empty(8, 16, dtype=torch.float32, device=dev)
+    for transpose, stride in AP_CONFIGS:
+        k = _access_ptr_war.compile(x, out, transpose, stride, 64)
+        assert _msl_barrier_between(k.get_kernel_source(), "simdgroup_load", "simdgroup_store"), (
+            f"WAR access_ptr t{transpose} s{stride}: no barrier between simdgroup_load and simdgroup_store"
+        )
+
+
+@pytest.mark.parametrize("stride", (8, 16))
+def test_codegen_access_ptr_overlapping_waw_barrier(stride):
+    """Overlapping tile stores must be ordered for compact and padded rows."""
+    out = torch.empty(8, 16, dtype=torch.float32, device="mps")
+    kernel = _access_ptr_waw.compile(out, stride, 64)
+    assert _msl_barrier_between_first_two(kernel.get_kernel_source(), "simdgroup_store"), (
+        f"overlapping WAW access_ptr stride={stride}: no barrier between tile stores"
+    )
+
+
+@tilelang.testing.requires_metal
+def test_correctness_access_ptr_raw_war():
+    """Dynamic: all 8 access_ptr configs x N_ROUNDS, fresh output buffers
+    per round, bit-identical vs the exact fp32 reference and run-to-run
+    deterministic. RAW: out[0, 8:16] == x[7, 0:8]; WAR: all zeros."""
+    x, exp_raw, exp_war = _access_ptr_inputs()
+    for transpose, stride in AP_CONFIGS:
+        for kind, kern, exp in (("raw", _access_ptr_raw, exp_raw), ("war", _access_ptr_war, exp_war)):
+            initial_out = torch.empty(8, 16, dtype=torch.float32, device="mps")
+            compiled = kern.compile(x, initial_out, transpose, stride, 64)
+            prev = None
+            for _ in range(N_ROUNDS):
+                out = torch.empty(8, 16, dtype=torch.float32, device="mps")
+                compiled(x, out)
+                torch.mps.synchronize()
+                got = out.cpu()
+                ref = exp.cpu()
+                assert torch.equal(got, ref), (
+                    f"access_ptr {kind} t{transpose} s{stride} diverged (maxerr={(got - ref).abs().max().item():.3e})"
+                )
+                if prev is not None:
+                    assert torch.equal(got, prev), f"access_ptr {kind} t{transpose} s{stride}: run-to-run divergence"
+                prev = got
+
+
+if __name__ == "__main__":
+    if torch.mps.is_available():
+        tilelang.testing.main()

--- a/testing/python/metal/test_metal_threadsync_simdgroup_store.py
+++ b/testing/python/metal/test_metal_threadsync_simdgroup_store.py
@@ -361,6 +361,38 @@ def _access_ptr_waw(out, stride, threads=64):
         T.simdgroup_store(loaded.data, 0, T.access_ptr(out[0, T.get_thread_binding() // 32 * 8], "w"), 16, 8, 8, T.bool(False))
 
 
+@tilelang.jit(execution_backend="tvm_ffi")
+def _address_of_waw(out, stride, threads=64):
+    """Two sequential simdgroups store overlapping 8x8 shared tiles through
+    the address_of(BufferLoad) pointer form.
+
+    This is the LowerSIMDGroupCopy staged form (src/metal/op/copy.cc): the
+    pointer argument is address_of(BufferLoad(dst, {row, col})) and the Metal
+    pipeline runs FlattenBuffer before ThreadSync, so ThreadSync sees a
+    flattened 1-D buffer with a single linear index. The first tile covers
+    rows 1..8 and the second covers rows 8..15, so row 8 requires a barrier
+    between the stores; the base elements (1 * stride and 8 * stride) are
+    disjoint, so the pre-fix row-only touched range let
+    PointerAccessIsDisjoint prove the two stores disjoint and skip the
+    barrier. The final load keeps the shared-memory writes observable in
+    generated code.
+    """
+    out: T.Tensor((8, 16), "float32")
+    with T.Kernel(1, threads=threads) as (bx,):
+        sh = T.alloc_shared((16, stride), "float32")
+        first = T.alloc_local((64,), "float32", scope="metal.simdgroup")
+        second = T.alloc_local((64,), "float32", scope="metal.simdgroup")
+        loaded = T.alloc_local((64,), "float32", scope="metal.simdgroup")
+        T.make_filled_simdgroup_matrix(first.data, 0, T.cast(1.0, "float32"))
+        T.make_filled_simdgroup_matrix(second.data, 0, T.cast(2.0, "float32"))
+        if T.get_thread_binding() < 32:
+            T.simdgroup_store(first.data, 0, T.address_of(sh[1, 0]), stride, 8, 8, T.bool(False))
+        if T.get_thread_binding() >= 32:
+            T.simdgroup_store(second.data, 0, T.address_of(sh[8, 0]), stride, 8, 8, T.bool(False))
+        T.simdgroup_load(loaded.data, 0, T.address_of(sh[8, 0]), stride, 8, 8, T.bool(False))
+        T.simdgroup_store(loaded.data, 0, T.address_of(out[0, T.get_thread_binding() // 32 * 8]), 16, 8, 8, T.bool(False))
+
+
 def _msl_barrier_between(src, first_marker, second_marker):
     """True if a threadgroup_barrier line exists between the last
     first_marker line that precedes some second_marker line and the first
@@ -437,6 +469,50 @@ def test_codegen_access_ptr_overlapping_waw_barrier(stride):
     assert _msl_barrier_between_first_two(kernel.get_kernel_source(), "simdgroup_store"), (
         f"overlapping WAW access_ptr stride={stride}: no barrier between tile stores"
     )
+
+
+@pytest.mark.parametrize("stride", (8, 16))
+def test_codegen_address_of_overlapping_waw_barrier(stride):
+    """Overlapping tile stores through the flattened address_of form must be
+    ordered for compact and padded rows.
+
+    Pre-fix the flattened 1-D touched range only covered tile_rows elements
+    (e.g. stride=8: intervals [8, 15] and [64, 71] are disjoint), so the
+    tile-tile WAW disjointness proof skipped the barrier even though the
+    tiles overlap at row 8. Post-fix the touched range is the full linear
+    bounding box (tile_rows - 1) * stride + tile_cols, so the intervals
+    overlap and ThreadSync inserts the barrier.
+    """
+    out = torch.empty(8, 16, dtype=torch.float32, device="mps")
+    kernel = _address_of_waw.compile(out, stride, 64)
+    assert _msl_barrier_between_first_two(kernel.get_kernel_source(), "simdgroup_store"), (
+        f"overlapping WAW address_of stride={stride}: no barrier between tile stores"
+    )
+
+
+@tilelang.testing.requires_metal
+def test_correctness_address_of_overlapping_waw():
+    """Dynamic: with the barrier the second store deterministically wins the
+    overlap row (row 8 = 2.0), and the final load of rows 8..15 reads all 2.0
+    for compact and padded rows. Without the barrier the overlap row races
+    between 1.0 and 2.0."""
+    for stride in (8, 16):
+        out = torch.empty(8, 16, dtype=torch.float32, device="mps")
+        kernel = _address_of_waw.compile(out, stride, 64)
+        exp = torch.full((8, 16), 2.0, dtype=torch.float32)
+        prev = None
+        for _ in range(N_ROUNDS):
+            out = torch.empty(8, 16, dtype=torch.float32, device="mps")
+            kernel(out)
+            torch.mps.synchronize()
+            got = out.cpu()
+            assert torch.equal(got, exp), (
+                f"address_of WAW stride={stride} diverged "
+                f"(maxerr={(got - exp).abs().max().item():.3e})"
+            )
+            if prev is not None:
+                assert torch.equal(got, prev), f"address_of WAW stride={stride}: run-to-run divergence"
+            prev = got
 
 
 @tilelang.testing.requires_metal


### PR DESCRIPTION
## Problem and change

`ThreadSyncPlanner` treats `simdgroup_store` and `simdgroup_load` pointers as single-element accesses, hiding access direction, stride, and the full tile footprint. It can therefore omit a barrier between overlapping cross-simdgroup operations in staged MoE epilogues such as the DeepSeek-style regression.

Track simdgroup operations as stride-aware tile accesses and omit tile write ordering only when complete pointer footprints are provably disjoint.

<sub>Files: `src/transform/thread_storage_sync.cc` and `testing/python/metal/test_metal_threadsync_simdgroup_store.py`.</sub>

## Before and after

On the same Apple M2 staged t256 workload, `origin/main` emits no barrier after the final `simdgroup_store`; 12/12 fresh-buffer rounds are wrong, with maximum absolute error `5.969`. This PR inserts the required barrier, keeps every round below `1e-2`, and produces bit-identical repeated outputs. The direct fragment-to-global path remains bit-identical with its original two barriers.

Performance classification: **Performance enablement**. Incorrect `main` output is not a valid speed baseline. Fresh Apple M2 GPU-timeline measurements on this PR head used three rounds, 25 warmups, and 100 launches per round for an `8x5120x17408` bf16 GEMM:

1. Fragment-C: t32 `39,778.1 us`, correct t256 `2,003.3 us` (`19.86x`).
2. Shared-C: t32 `36,530.9 us`, correct t256 `2,580.0 us` (`14.16x`).

The speedup comes from the multi-simdgroup kernel configuration; this PR supplies the synchronization correctness required to use that t256 path safely.

## Validation

The fp16 `tvm_ffi` regression is independent of the bf16-codegen and torch-adapter PRs.

```text
cmake -S . -B build
cmake --build build -j8
TILELANG_DISABLE_CACHE=1 python -m pytest \
  testing/python/metal/test_metal_threadsync_simdgroup_store.py -q
10 passed
```

The module skips when `torch.backends.mps.is_available()` is false.

## Scope

Targets M1-M4 MSL simdgroup synchronization without changing CUDA or ROCm behavior; the M5 Metal 4 TensorOps/FP8 path is out of scope.

## Appendix: combined campaign results (组合 campaign 结果)

The table below describes the complete Apple M2 optimization campaign, not the isolated contribution or acceptance criteria of this PR. Where `origin/main` cannot execute the workload correctly, a numerical speedup versus `main` is undefined; the nearest valid performance baseline is stated explicitly.

| Representative workload | `origin/main` | End-state result | Valid performance comparison |
|---|---|---|---|
| Qwen dense decode | Cannot lower the required Metal reduction | 64-token: `28.3 us/token` synchronized, `23.9 us/token` GPU timeline | `14.5x` versus the valid single-token path (`410.0 us/token`) |
| Fused Qwen/DeepSeek-style MoE block | Required multi-kernel/ABI path is not correct | 9 launches, `16.92 ms` | `1.21x` versus the previous valid 17-launch composed path (`20.53 ms`) |
| Multi-simdgroup bf16 GEMM | t256 staged output is incorrect | Correct t256 execution | Fragment-C `19.86x`; shared-C `14.16x` versus correct t32 paths |
| Software-packed dense fp8 / expert fp4 QMM | Downstream kernels are not present in `main` | `685.7 us` / `697.4 us` | Dense fp8 `16.9x` versus the initial campaign kernel; expert fp4 `26%` faster than its earlier campaign version |
| End-to-end Mega MoE | Complete path is blocked by missing backend prerequisites | T=64 `114.1 ms`; T=1 `16.7 ms` | `80.8%` / `48.0%` lower latency versus the valid full-pipeline baseline |
