### PR TITLE
[Metal] Harden bf16 code generation and vectorization

### DIFF
--- a/src/backend/common/bf16_numeric_op.h
+++ b/src/backend/common/bf16_numeric_op.h
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file backend/common/bf16_numeric_op.h
+ * \brief Shared classification of bfloat16 numeric operations.
+ *
+ * Metal represents bf16x4/x8 vectors as packed uintN carriers that are only
+ * valid for pure memory copies.  The vectorizer and the Metal codegen both
+ * need the same notion of "bf16 numeric operation" (arithmetic, comparison,
+ * min/max, non-identity cast, numeric call) so the packed carriers are never
+ * fed into integer-typed MSL operations.
+ */
+#ifndef TVM_TL_BACKEND_COMMON_BF16_NUMERIC_OP_H_
+#define TVM_TL_BACKEND_COMMON_BF16_NUMERIC_OP_H_
+
+#include <tvm/runtime/data_type.h>
+
+namespace tvm {
+namespace tl {
+
+/*!
+ * \brief Whether a binary arithmetic/comparison/min/max node is a bf16
+ * numeric operation.
+ *
+ * An operation is classified as numeric when bfloat16 appears on either side
+ * or as the result dtype.
+ */
+inline bool IsBF16NumericBinaryOp(DataType lhs, DataType rhs, DataType result) {
+  return lhs.is_bfloat16() || rhs.is_bfloat16() || result.is_bfloat16();
+}
+
+/*!
+ * \brief Whether a cast is a bf16 numeric conversion.
+ *
+ * Identity casts are bit-level pass-throughs (pure copies) and are excluded.
+ */
+inline bool IsBF16NumericCastOp(DataType from, DataType to) {
+  return (from.is_bfloat16() || to.is_bfloat16()) && from != to;
+}
+
+/*!
+ * \brief Whether a call is a bf16 numeric operation based on its result dtype.
+ *
+ * if_then_else is a bit-level pick used by predicated pure copies and is not
+ * a numeric operation even when its result is bfloat16.
+ */
+inline bool IsBF16NumericCallOp(DataType result_dtype,
+                                bool is_bit_level_pure_copy) {
+  return result_dtype.is_bfloat16() && !is_bit_level_pure_copy;
+}
+
+/*!
+ * \brief Whether a call operand is a bf16 numeric operand.
+ *
+ * The codegen rejects packed bf16 carriers in call operands unless the call
+ * is a bit-level pure-copy call (if_then_else / reinterpret).
+ */
+inline bool IsBF16NumericCallArg(DataType arg_dtype,
+                                 bool is_bit_level_pure_copy) {
+  return arg_dtype.is_bfloat16() && !is_bit_level_pure_copy;
+}
+
+} // namespace tl
+} // namespace tvm
+
+#endif // TVM_TL_BACKEND_COMMON_BF16_NUMERIC_OP_H_

--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -1897,6 +1897,17 @@ void CodeGenTileLangMetal::VisitExpr_(const CallNode *op,
 void CodeGenTileLangMetal::VisitExpr_(const FloatImmNode *op,
                                       std::ostream &os) { // NOLINT(*)
   std::ostringstream temp;
+  // MSL has no implicit conversion INTO bfloat from float/half, and the
+  // overloaded builtins (e.g. select(half, half, bool)) require exact
+  // operand types, so fp16/bf16 literals (finite, INFINITY or NAN) must be
+  // explicitly cast to the destination type: bare INFINITY/NAN or
+  // `h`-suffixed literals fail to compile when assigned to bfloat
+  // ("assigning to 'bfloat' from incompatible type") or make
+  // select() ambiguous for half ("call to 'select' is ambiguous").
+  const bool needs_cast = op->dtype.is_bfloat16() || op->dtype.is_float16();
+  if (needs_cast) {
+    temp << "(" << (op->dtype.is_bfloat16() ? "bfloat" : "half") << ")(";
+  }
   if (std::isinf(op->value)) {
     if (op->value < 0) {
       temp << "-";
@@ -1910,16 +1921,13 @@ void CodeGenTileLangMetal::VisitExpr_(const FloatImmNode *op,
       temp << 'f';
     else if (op->dtype.bits() == 16 && op->dtype.is_float16())
       temp << 'h';
-    else if (op->dtype.is_bfloat16())
-      temp << ')';
+    // bf16 finite: no h suffix; the explicit cast wrapper provides the type.
+  }
+  if (needs_cast) {
+    temp << ")";
   }
   MarkConst(temp.str());
-  if (op->dtype.is_bfloat16() && !std::isinf(op->value) &&
-      !std::isnan(op->value)) {
-    os << "bfloat(" << temp.str();
-  } else {
-    os << temp.str();
-  }
+  os << temp.str();
 }
 
 ffi::Module BuildTileLangMetal(IRModule mod, Target target) {

--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -37,6 +37,7 @@
 #include <utility>
 #include <vector>
 
+#include "backend/common/bf16_numeric_op.h"
 #include "metal/op/builtin.h"
 #include "runtime/thread_storage_scope.h"
 #include "target/build_common.h"
@@ -946,38 +947,48 @@ void CodeGenTileLangMetal::CheckNoPackedBF16Carrier(DataType dtype,
   }
 }
 
+void CodeGenTileLangMetal::CheckNoPackedBF16CarrierForBinary(
+    DataType lhs, DataType rhs, DataType result, const char *ctx) const {
+  // Share the bf16-numeric-op classification with the vectorizer so both
+  // sides cannot drift apart (see backend/common/bf16_numeric_op.h).
+  if (tl::IsBF16NumericBinaryOp(lhs, rhs, result)) {
+    CheckNoPackedBF16Carrier(lhs, ctx);
+    CheckNoPackedBF16Carrier(rhs, ctx);
+  }
+}
+
 void CodeGenTileLangMetal::VisitExpr_(const SubNode *op,
                                       std::ostream &os) { // NOLINT(*)
-  CheckNoPackedBF16Carrier(op->a.dtype(), "subtract");
-  CheckNoPackedBF16Carrier(op->b.dtype(), "subtract");
+  CheckNoPackedBF16CarrierForBinary(op->a.dtype(), op->b.dtype(),
+                                    op->dtype, "subtract");
   CodeGenC::VisitExpr_(op, os);
 }
 
 void CodeGenTileLangMetal::VisitExpr_(const MulNode *op,
                                       std::ostream &os) { // NOLINT(*)
-  CheckNoPackedBF16Carrier(op->a.dtype(), "multiply");
-  CheckNoPackedBF16Carrier(op->b.dtype(), "multiply");
+  CheckNoPackedBF16CarrierForBinary(op->a.dtype(), op->b.dtype(),
+                                    op->dtype, "multiply");
   CodeGenC::VisitExpr_(op, os);
 }
 
 void CodeGenTileLangMetal::VisitExpr_(const DivNode *op,
                                       std::ostream &os) { // NOLINT(*)
-  CheckNoPackedBF16Carrier(op->a.dtype(), "divide");
-  CheckNoPackedBF16Carrier(op->b.dtype(), "divide");
+  CheckNoPackedBF16CarrierForBinary(op->a.dtype(), op->b.dtype(),
+                                    op->dtype, "divide");
   CodeGenC::VisitExpr_(op, os);
 }
 
 void CodeGenTileLangMetal::VisitExpr_(const ModNode *op,
                                       std::ostream &os) { // NOLINT(*)
-  CheckNoPackedBF16Carrier(op->a.dtype(), "modulo");
-  CheckNoPackedBF16Carrier(op->b.dtype(), "modulo");
+  CheckNoPackedBF16CarrierForBinary(op->a.dtype(), op->b.dtype(),
+                                    op->dtype, "modulo");
   CodeGenC::VisitExpr_(op, os);
 }
 
 void CodeGenTileLangMetal::VisitExpr_(const MinNode *op,
                                       std::ostream &os) { // NOLINT(*)
-  CheckNoPackedBF16Carrier(op->a.dtype(), "min");
-  CheckNoPackedBF16Carrier(op->b.dtype(), "min");
+  CheckNoPackedBF16CarrierForBinary(op->a.dtype(), op->b.dtype(),
+                                    op->dtype, "min");
   if (op->dtype.is_bfloat16()) {
     // MSL's standard library has no min() overload for bfloat/bfloat2
     // (bfloat16 support is limited to arithmetic/relational ops); emit the
@@ -991,8 +1002,8 @@ void CodeGenTileLangMetal::VisitExpr_(const MinNode *op,
 
 void CodeGenTileLangMetal::VisitExpr_(const MaxNode *op,
                                       std::ostream &os) { // NOLINT(*)
-  CheckNoPackedBF16Carrier(op->a.dtype(), "max");
-  CheckNoPackedBF16Carrier(op->b.dtype(), "max");
+  CheckNoPackedBF16CarrierForBinary(op->a.dtype(), op->b.dtype(),
+                                    op->dtype, "max");
   if (op->dtype.is_bfloat16()) {
     // See MinNode: no max() overload for bfloat/bfloat2; a > b ? a : b
     // (MSL select(false_value, true_value, condition)).
@@ -1005,50 +1016,50 @@ void CodeGenTileLangMetal::VisitExpr_(const MaxNode *op,
 
 void CodeGenTileLangMetal::VisitExpr_(const EQNode *op,
                                       std::ostream &os) { // NOLINT(*)
-  CheckNoPackedBF16Carrier(op->a.dtype(), "equality comparison");
-  CheckNoPackedBF16Carrier(op->b.dtype(), "equality comparison");
+  CheckNoPackedBF16CarrierForBinary(op->a.dtype(), op->b.dtype(),
+                                    op->dtype, "equality comparison");
   CodeGenC::VisitExpr_(op, os);
 }
 
 void CodeGenTileLangMetal::VisitExpr_(const NENode *op,
                                       std::ostream &os) { // NOLINT(*)
-  CheckNoPackedBF16Carrier(op->a.dtype(), "inequality comparison");
-  CheckNoPackedBF16Carrier(op->b.dtype(), "inequality comparison");
+  CheckNoPackedBF16CarrierForBinary(op->a.dtype(), op->b.dtype(),
+                                    op->dtype, "inequality comparison");
   CodeGenC::VisitExpr_(op, os);
 }
 
 void CodeGenTileLangMetal::VisitExpr_(const LTNode *op,
                                       std::ostream &os) { // NOLINT(*)
-  CheckNoPackedBF16Carrier(op->a.dtype(), "less-than comparison");
-  CheckNoPackedBF16Carrier(op->b.dtype(), "less-than comparison");
+  CheckNoPackedBF16CarrierForBinary(op->a.dtype(), op->b.dtype(),
+                                    op->dtype, "less-than comparison");
   CodeGenC::VisitExpr_(op, os);
 }
 
 void CodeGenTileLangMetal::VisitExpr_(const LENode *op,
                                       std::ostream &os) { // NOLINT(*)
-  CheckNoPackedBF16Carrier(op->a.dtype(), "less-equal comparison");
-  CheckNoPackedBF16Carrier(op->b.dtype(), "less-equal comparison");
+  CheckNoPackedBF16CarrierForBinary(op->a.dtype(), op->b.dtype(),
+                                    op->dtype, "less-equal comparison");
   CodeGenC::VisitExpr_(op, os);
 }
 
 void CodeGenTileLangMetal::VisitExpr_(const GTNode *op,
                                       std::ostream &os) { // NOLINT(*)
-  CheckNoPackedBF16Carrier(op->a.dtype(), "greater-than comparison");
-  CheckNoPackedBF16Carrier(op->b.dtype(), "greater-than comparison");
+  CheckNoPackedBF16CarrierForBinary(op->a.dtype(), op->b.dtype(),
+                                    op->dtype, "greater-than comparison");
   CodeGenC::VisitExpr_(op, os);
 }
 
 void CodeGenTileLangMetal::VisitExpr_(const GENode *op,
                                       std::ostream &os) { // NOLINT(*)
-  CheckNoPackedBF16Carrier(op->a.dtype(), "greater-equal comparison");
-  CheckNoPackedBF16Carrier(op->b.dtype(), "greater-equal comparison");
+  CheckNoPackedBF16CarrierForBinary(op->a.dtype(), op->b.dtype(),
+                                    op->dtype, "greater-equal comparison");
   CodeGenC::VisitExpr_(op, os);
 }
 
 void CodeGenTileLangMetal::VisitExpr_(const AddNode *op,
                                       std::ostream &os) { // NOLINT(*)
-  CheckNoPackedBF16Carrier(op->a.dtype(), "add");
-  CheckNoPackedBF16Carrier(op->b.dtype(), "add");
+  CheckNoPackedBF16CarrierForBinary(op->a.dtype(), op->b.dtype(),
+                                    op->dtype, "add");
   if (TryPrintMlxSwizzleExpr(ffi::GetRef<PrimExpr>(op), os)) {
     return;
   }
@@ -1060,7 +1071,7 @@ void CodeGenTileLangMetal::VisitExpr_(const CastNode *op,
   // Identity casts are bit-level pass-throughs (pure copy); any non-identity
   // cast touching a packed bf16 carrier is a numeric conversion and must be
   // rejected.
-  if (op->dtype != op->value.dtype()) {
+  if (tl::IsBF16NumericCastOp(op->value.dtype(), op->dtype)) {
     CheckNoPackedBF16Carrier(op->dtype, "cast");
     CheckNoPackedBF16Carrier(op->value.dtype(), "cast");
   }
@@ -1501,9 +1512,11 @@ void CodeGenTileLangMetal::VisitExpr_(const CallNode *op,
   // if_then_else (bit-level pick used by predicated copies) and reinterpret
   // (bit-level). Any other call consuming a packed carrier would compile to
   // integer-typed operands.
-  if (!op->op.same_as(builtin::if_then_else()) &&
-      !op->op.same_as(builtin::reinterpret())) {
-    for (const PrimExpr &arg : op->args) {
+  bool is_bit_level_pure_copy =
+      op->op.same_as(builtin::if_then_else()) ||
+      op->op.same_as(builtin::reinterpret());
+  for (const PrimExpr &arg : op->args) {
+    if (tl::IsBF16NumericCallArg(arg.dtype(), is_bit_level_pure_copy)) {
       CheckNoPackedBF16Carrier(arg.dtype(), "call");
     }
   }

--- a/src/metal/codegen/codegen_metal.cc
+++ b/src/metal/codegen/codegen_metal.cc
@@ -362,8 +362,17 @@ void CodeGenTileLangMetal::PrintType(DataType t,
     os << "bool";
     return;
   }
-  if ((t.is_float16() || t.is_bfloat16()) && lanes > 4 && lanes <= 8 &&
-      lanes % 2 == 0) {
+  if (t.is_float16() && lanes > 4 && lanes <= 8 && lanes % 2 == 0) {
+    os << "uint" << lanes / 2;
+    return;
+  }
+  // bf16 packed carriers are only legal for pure memory copies.
+  // Only widths whose packed size matches the logical size are representable:
+  // bf16x4 -> uint2 (8 bytes) and bf16x8 -> uint4 (16 bytes). bf16x6 would
+  // map to uint3 whose 16-byte array stride does NOT match the 12-byte
+  // logical size, silently misaddressing every element after the first, so it
+  // is rejected here (loud compile error) instead of miscompiled.
+  if (t.is_bfloat16() && (lanes == 4 || lanes == 8)) {
     os << "uint" << lanes / 2;
     return;
   }
@@ -420,6 +429,16 @@ void CodeGenTileLangMetal::PrintType(DataType t,
       return;
     }
   } else if (t.is_bfloat16()) {
+    // MSL has no 128-bit bfloat vectors: bfloat (1 lane) and bfloat2 are
+    // the only representable forms. Wider bfloat vectors are carried as
+    // packed uint2/uint4 elsewhere in the codegen.
+    if (t.lanes() == 2) {
+      os << "bfloat2";
+      return;
+    }
+    TVM_FFI_ICHECK_EQ(t.lanes(), 1)
+        << "Metal: bfloat16 vectors with " << t.lanes()
+        << " lanes are not representable in MSL (max 2 lanes: bfloat2)";
     os << "bfloat";
     return;
   }
@@ -763,8 +782,9 @@ void CodeGenTileLangMetal::VisitStmt_(const AllocBufferNode *op) {
     TVM_FFI_ICHECK(dtype == DataType::Float(16) ||
                    dtype == DataType::Float(32) ||
                    dtype == DataType::BFloat(16))
-        << "Only float16, float32, and bfloat16 are supported, but got "
-        << dtype;
+        << "Only float16, float32, and bfloat16 are supported for "
+           "metal.simdgroup, but got "
+        << dtype << " for buffer " << op->buffer->name;
     TVM_FFI_ICHECK(constant_size % 64 == 0)
         << "Only 8x8 matrix is supported, but got " << constant_size
         << " bytes\n";
@@ -862,25 +882,44 @@ void CodeGenTileLangMetal::EnsureFragmentLaneVars() {
 
 void CodeGenTileLangMetal::VisitExpr_(const SelectNode *op,
                                       std::ostream &os) { // NOLINT(*)
-  os << "select(" << PrintExpr(op->false_value) << ", "
-     << PrintExpr(op->true_value) << ", " << PrintExpr(op->condition) << ")";
+  // MSL's select() requires both operands to have identical types; untyped
+  // integer/float literals (e.g. INT32_MIN) make the overload ambiguous.
+  // Cast literal operands to the select result dtype explicitly.
+  auto print_operand = [&](const PrimExpr &operand) {
+    if (op->dtype.lanes() == 1 && (operand.as<IntImmNode>() != nullptr ||
+                                   operand.as<FloatImmNode>() != nullptr)) {
+      os << "(";
+      PrintType(op->dtype, os);
+      os << ")(" << PrintExpr(operand) << ")";
+    } else {
+      os << PrintExpr(operand);
+    }
+  };
+  os << "select(";
+  print_operand(op->false_value);
+  os << ", ";
+  print_operand(op->true_value);
+  os << ", " << PrintExpr(op->condition) << ")";
 }
 
 void CodeGenTileLangMetal::VisitExpr_(const BroadcastNode *op,
                                       std::ostream &os) { // NOLINT(*)
   std::string v = PrintExpr(op->value);
   int lanes = op->dtype.lanes();
-  if ((op->dtype.is_float16() || op->dtype.is_bfloat16()) && lanes > 4 &&
-      lanes % 2 == 0) {
+  if (op->dtype.is_float16() && lanes > 4 && lanes % 2 == 0) {
     os << "uint" << lanes / 2 << "(";
     for (int i = 0; i < lanes / 2; ++i) {
       if (i != 0)
         os << ", ";
-      if (op->dtype.is_float16()) {
-        os << "as_type<uint>(half2(" << v << ", " << v << "))";
-      } else if (op->dtype.is_bfloat16()) {
-        os << "as_type<uint>(bfloat2(" << v << ", " << v << "))";
-      }
+      os << "as_type<uint>(half2(" << v << ", " << v << "))";
+    }
+    os << ')';
+  } else if (op->dtype.is_bfloat16() && (lanes == 4 || lanes == 8)) {
+    os << "uint" << lanes / 2 << "(";
+    for (int i = 0; i < lanes / 2; ++i) {
+      if (i != 0)
+        os << ", ";
+      os << "as_type<uint>(bfloat2(" << v << ", " << v << "))";
     }
     os << ')';
   } else {
@@ -895,8 +934,121 @@ void CodeGenTileLangMetal::VisitExpr_(const BroadcastNode *op,
   }
 }
 
+void CodeGenTileLangMetal::CheckNoPackedBF16Carrier(DataType dtype,
+                                                    const char *ctx) const {
+  if (dtype.is_bfloat16() && dtype.lanes() >= 4) {
+    LOG(FATAL) << "Metal: packed bf16 carrier (bf16x" << dtype.lanes()
+               << " -> uint" << dtype.lanes() / 2
+               << ") must not enter a numeric " << ctx
+               << " expression. bf16 numeric operations are capped at 2 lanes "
+                  "(bfloat2) by the vectorizer; the packed uint path is only "
+                  "valid for pure memory copies.";
+  }
+}
+
+void CodeGenTileLangMetal::VisitExpr_(const SubNode *op,
+                                      std::ostream &os) { // NOLINT(*)
+  CheckNoPackedBF16Carrier(op->a.dtype(), "subtract");
+  CheckNoPackedBF16Carrier(op->b.dtype(), "subtract");
+  CodeGenC::VisitExpr_(op, os);
+}
+
+void CodeGenTileLangMetal::VisitExpr_(const MulNode *op,
+                                      std::ostream &os) { // NOLINT(*)
+  CheckNoPackedBF16Carrier(op->a.dtype(), "multiply");
+  CheckNoPackedBF16Carrier(op->b.dtype(), "multiply");
+  CodeGenC::VisitExpr_(op, os);
+}
+
+void CodeGenTileLangMetal::VisitExpr_(const DivNode *op,
+                                      std::ostream &os) { // NOLINT(*)
+  CheckNoPackedBF16Carrier(op->a.dtype(), "divide");
+  CheckNoPackedBF16Carrier(op->b.dtype(), "divide");
+  CodeGenC::VisitExpr_(op, os);
+}
+
+void CodeGenTileLangMetal::VisitExpr_(const ModNode *op,
+                                      std::ostream &os) { // NOLINT(*)
+  CheckNoPackedBF16Carrier(op->a.dtype(), "modulo");
+  CheckNoPackedBF16Carrier(op->b.dtype(), "modulo");
+  CodeGenC::VisitExpr_(op, os);
+}
+
+void CodeGenTileLangMetal::VisitExpr_(const MinNode *op,
+                                      std::ostream &os) { // NOLINT(*)
+  CheckNoPackedBF16Carrier(op->a.dtype(), "min");
+  CheckNoPackedBF16Carrier(op->b.dtype(), "min");
+  if (op->dtype.is_bfloat16()) {
+    // MSL's standard library has no min() overload for bfloat/bfloat2
+    // (bfloat16 support is limited to arithmetic/relational ops); emit the
+    // equivalent ternary select. TIR min semantics: a < b ? a : b.
+    os << "select(" << PrintExpr(op->b) << ", " << PrintExpr(op->a) << ", "
+       << PrintExpr(op->a) << " < " << PrintExpr(op->b) << ")";
+    return;
+  }
+  CodeGenC::VisitExpr_(op, os);
+}
+
+void CodeGenTileLangMetal::VisitExpr_(const MaxNode *op,
+                                      std::ostream &os) { // NOLINT(*)
+  CheckNoPackedBF16Carrier(op->a.dtype(), "max");
+  CheckNoPackedBF16Carrier(op->b.dtype(), "max");
+  if (op->dtype.is_bfloat16()) {
+    // See MinNode: no max() overload for bfloat/bfloat2; a > b ? a : b
+    // (MSL select(false_value, true_value, condition)).
+    os << "select(" << PrintExpr(op->b) << ", " << PrintExpr(op->a) << ", "
+       << PrintExpr(op->a) << " > " << PrintExpr(op->b) << ")";
+    return;
+  }
+  CodeGenC::VisitExpr_(op, os);
+}
+
+void CodeGenTileLangMetal::VisitExpr_(const EQNode *op,
+                                      std::ostream &os) { // NOLINT(*)
+  CheckNoPackedBF16Carrier(op->a.dtype(), "equality comparison");
+  CheckNoPackedBF16Carrier(op->b.dtype(), "equality comparison");
+  CodeGenC::VisitExpr_(op, os);
+}
+
+void CodeGenTileLangMetal::VisitExpr_(const NENode *op,
+                                      std::ostream &os) { // NOLINT(*)
+  CheckNoPackedBF16Carrier(op->a.dtype(), "inequality comparison");
+  CheckNoPackedBF16Carrier(op->b.dtype(), "inequality comparison");
+  CodeGenC::VisitExpr_(op, os);
+}
+
+void CodeGenTileLangMetal::VisitExpr_(const LTNode *op,
+                                      std::ostream &os) { // NOLINT(*)
+  CheckNoPackedBF16Carrier(op->a.dtype(), "less-than comparison");
+  CheckNoPackedBF16Carrier(op->b.dtype(), "less-than comparison");
+  CodeGenC::VisitExpr_(op, os);
+}
+
+void CodeGenTileLangMetal::VisitExpr_(const LENode *op,
+                                      std::ostream &os) { // NOLINT(*)
+  CheckNoPackedBF16Carrier(op->a.dtype(), "less-equal comparison");
+  CheckNoPackedBF16Carrier(op->b.dtype(), "less-equal comparison");
+  CodeGenC::VisitExpr_(op, os);
+}
+
+void CodeGenTileLangMetal::VisitExpr_(const GTNode *op,
+                                      std::ostream &os) { // NOLINT(*)
+  CheckNoPackedBF16Carrier(op->a.dtype(), "greater-than comparison");
+  CheckNoPackedBF16Carrier(op->b.dtype(), "greater-than comparison");
+  CodeGenC::VisitExpr_(op, os);
+}
+
+void CodeGenTileLangMetal::VisitExpr_(const GENode *op,
+                                      std::ostream &os) { // NOLINT(*)
+  CheckNoPackedBF16Carrier(op->a.dtype(), "greater-equal comparison");
+  CheckNoPackedBF16Carrier(op->b.dtype(), "greater-equal comparison");
+  CodeGenC::VisitExpr_(op, os);
+}
+
 void CodeGenTileLangMetal::VisitExpr_(const AddNode *op,
                                       std::ostream &os) { // NOLINT(*)
+  CheckNoPackedBF16Carrier(op->a.dtype(), "add");
+  CheckNoPackedBF16Carrier(op->b.dtype(), "add");
   if (TryPrintMlxSwizzleExpr(ffi::GetRef<PrimExpr>(op), os)) {
     return;
   }
@@ -905,6 +1057,13 @@ void CodeGenTileLangMetal::VisitExpr_(const AddNode *op,
 
 void CodeGenTileLangMetal::VisitExpr_(const CastNode *op,
                                       std::ostream &os) { // NOLINT(*)
+  // Identity casts are bit-level pass-throughs (pure copy); any non-identity
+  // cast touching a packed bf16 carrier is a numeric conversion and must be
+  // rejected.
+  if (op->dtype != op->value.dtype()) {
+    CheckNoPackedBF16Carrier(op->dtype, "cast");
+    CheckNoPackedBF16Carrier(op->value.dtype(), "cast");
+  }
   std::ostringstream value;
   if (TryPrintMlxSwizzleExpr(op->value, value)) {
     os << CastFromTo(value.str(), op->value.dtype(), op->dtype);
@@ -1338,6 +1497,16 @@ void CodeGenTileLangMetal::VisitExpr_(const CallNode *op,
       << "CodegenMetal does not support inter-function calls, "
       << "but expression " << ffi::GetRef<Call>(op) << " calls PrimFunc "
       << op->op;
+  // Packed bf16 carriers are only valid in pure-copy call contexts:
+  // if_then_else (bit-level pick used by predicated copies) and reinterpret
+  // (bit-level). Any other call consuming a packed carrier would compile to
+  // integer-typed operands.
+  if (!op->op.same_as(builtin::if_then_else()) &&
+      !op->op.same_as(builtin::reinterpret())) {
+    for (const PrimExpr &arg : op->args) {
+      CheckNoPackedBF16Carrier(arg.dtype(), "call");
+    }
+  }
   if (TryPrintSimdgroupIndexExpr(op, os)) {
     return;
   }
@@ -1707,6 +1876,19 @@ void CodeGenTileLangMetal::VisitExpr_(const CallNode *op,
     os << " + ";
     this->PrintExpr(op->args[1], os);
     os << "))";
+  } else if (op->op.same_as(builtin::if_then_else())) {
+    // CodeGenC's default if_then_else-expression printing emits a temp
+    // declaration into the current stream, which breaks when the expression
+    // is nested inside another expression (e.g. "x = if (...) ...").
+    // MSL accepts a plain C ternary for scalar/vector operands.
+    TVM_FFI_ICHECK_EQ(op->args.size(), 3U);
+    os << "(";
+    this->PrintExpr(op->args[0], os);
+    os << " ? ";
+    this->PrintExpr(op->args[1], os);
+    os << " : ";
+    this->PrintExpr(op->args[2], os);
+    os << ")";
   } else {
     CodeGenC::VisitExpr_(op, os);
   }
@@ -1726,11 +1908,18 @@ void CodeGenTileLangMetal::VisitExpr_(const FloatImmNode *op,
     temp << std::scientific << op->value;
     if (op->dtype.bits() == 32)
       temp << 'f';
-    else if (op->dtype.bits() == 16)
+    else if (op->dtype.bits() == 16 && op->dtype.is_float16())
       temp << 'h';
+    else if (op->dtype.is_bfloat16())
+      temp << ')';
   }
   MarkConst(temp.str());
-  os << temp.str();
+  if (op->dtype.is_bfloat16() && !std::isinf(op->value) &&
+      !std::isnan(op->value)) {
+    os << "bfloat(" << temp.str();
+  } else {
+    os << temp.str();
+  }
 }
 
 ffi::Module BuildTileLangMetal(IRModule mod, Target target) {

--- a/src/metal/codegen/codegen_metal.h
+++ b/src/metal/codegen/codegen_metal.h
@@ -65,6 +65,18 @@ public:
   void VisitExpr_(const SelectNode *op, std::ostream &os) final;    // NOLINT(*)
   void VisitExpr_(const BroadcastNode *op, std::ostream &os) final; // NOLINT(*)
   void VisitExpr_(const AddNode *op, std::ostream &os) final;       // NOLINT(*)
+  void VisitExpr_(const SubNode *op, std::ostream &os) final;       // NOLINT(*)
+  void VisitExpr_(const MulNode *op, std::ostream &os) final;       // NOLINT(*)
+  void VisitExpr_(const DivNode *op, std::ostream &os) final;       // NOLINT(*)
+  void VisitExpr_(const ModNode *op, std::ostream &os) final;       // NOLINT(*)
+  void VisitExpr_(const MinNode *op, std::ostream &os) final;       // NOLINT(*)
+  void VisitExpr_(const MaxNode *op, std::ostream &os) final;       // NOLINT(*)
+  void VisitExpr_(const EQNode *op, std::ostream &os) final;        // NOLINT(*)
+  void VisitExpr_(const NENode *op, std::ostream &os) final;        // NOLINT(*)
+  void VisitExpr_(const LTNode *op, std::ostream &os) final;        // NOLINT(*)
+  void VisitExpr_(const LENode *op, std::ostream &os) final;        // NOLINT(*)
+  void VisitExpr_(const GTNode *op, std::ostream &os) final;        // NOLINT(*)
+  void VisitExpr_(const GENode *op, std::ostream &os) final;        // NOLINT(*)
   void VisitExpr_(const CastNode *op, std::ostream &os) final;      // NOLINT(*)
   void VisitExpr_(const CallNode *op, std::ostream &os) final;      // NOLINT(*)
   void VisitExpr_(const FloatImmNode *op, std::ostream &os) final;  // NOLINT(*)
@@ -91,6 +103,12 @@ private:
                                std::ostream &os) const;
   void EnsureFragmentLaneVars();
   void EnsureCooperativeTensorBuffer(const Var &var);
+  // Reject packed bf16 carriers (bf16x4/x6/x8 -> uint2/uint3/uint4) inside
+  // numeric expressions: the packed uint path is only valid for pure memory
+  // copies (load/store/select/broadcast/identity cast). Any arithmetic,
+  // comparison, min/max or non-identity cast consuming a packed carrier would
+  // silently compile to integer operations.
+  void CheckNoPackedBF16Carrier(DataType dtype, const char *ctx) const;
 
   std::unordered_map<Var, std::string, ffi::ObjectPtrHash, ffi::ObjectPtrEqual>
       simdgroup_dtype_;

--- a/src/metal/codegen/codegen_metal.h
+++ b/src/metal/codegen/codegen_metal.h
@@ -109,6 +109,9 @@ private:
   // comparison, min/max or non-identity cast consuming a packed carrier would
   // silently compile to integer operations.
   void CheckNoPackedBF16Carrier(DataType dtype, const char *ctx) const;
+  void CheckNoPackedBF16CarrierForBinary(DataType lhs, DataType rhs,
+                                         DataType result,
+                                         const char *ctx) const;
 
   std::unordered_map<Var, std::string, ffi::ObjectPtrHash, ffi::ObjectPtrEqual>
       simdgroup_dtype_;

--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -236,6 +236,7 @@ public:
 
     // Clear previous buffer info and collect new ones
     buffer_vector_infos_.clear();
+    has_bf16_numeric_op_ = false;
     this->operator()(node);
 
     if (verbose) {
@@ -265,6 +266,40 @@ public:
 
     // GCD with loop extent to ensure vector_size divides the loop extent
     vector_size_ = arith::ZeroAwareGCD(loop_extent_vector_size_, vector_size_);
+
+    // Metal: bf16 accesses inside loops that touch local/fragment buffers
+    // must not exceed 2 lanes (MSL has no bf16 vectors beyond bfloat2 in the
+    // register path; the packed uint path is only valid for pure copy loops
+    // without fragment participation). Additionally, ANY bf16 numeric
+    // operation (arithmetic, comparison, min/max, numeric cast) caps the
+    // total lanes at 2: the packed uintN carrier must never enter a numeric
+    // expression, since the Metal codegen would silently emit integer
+    // arithmetic on it.
+    if (TargetIsMetal(Target::Current(false)) && vector_size_ > 2) {
+      bool has_fragment = false;
+      bool has_bf16 = false;
+      for (const auto &info : buffer_vector_infos_) {
+        if (!info.buffer.defined()) {
+          continue;
+        }
+        if (info.buffer->dtype.is_bfloat16()) {
+          has_bf16 = true;
+        }
+        // The legacy local/fragment bucket covered both local/fragment-scope
+        // buffers and loop-invariant non-local broadcast loads (upstream
+        // #2935 now classifies them as kLocal / kBroadcastLoad).
+        if (IsLocalBuffer(info.buffer, /*allow_var=*/true) ||
+            IsFragmentBuffer(info.buffer) || IsBroadcastLoad(info)) {
+          has_fragment = true;
+        }
+        if (has_fragment && has_bf16) {
+          break;
+        }
+      }
+      if (has_bf16_numeric_op_ || (has_fragment && has_bf16)) {
+        vector_size_ = 2;
+      }
+    }
 
     if (verbose) {
       std::cerr << "=== Final vector_size: " << vector_size_ << " ===" << "\n";
@@ -600,6 +635,12 @@ private:
   }
 
   PrimExpr VisitExpr_(const CallNode *node) final {
+    // A bf16-typed call (other than if_then_else, which is a bit-level pick
+    // used by predicated pure copies) is a numeric operation on bf16 vectors:
+    // packed carriers must never enter it.
+    if (node->dtype.is_bfloat16() && node->op != builtin::if_then_else()) {
+      has_bf16_numeric_op_ = true;
+    }
     if (node->op == builtin::if_then_else()) {
       CheckConditionVectorized(node->args[0]);
       return arith::IRMutatorWithAnalyzer::VisitExpr_(node);
@@ -862,11 +903,29 @@ private:
   }
 
   PrimExpr VisitExpr_(const CastNode *node) final {
+    // Any bf16 numeric cast (bf16 on either side, non-identity) is a numeric
+    // operation: packed carriers must not be produced/consumed by it.
+    // Identity casts are bit-level pass-throughs.
+    if ((node->dtype.is_bfloat16() || node->value.dtype().is_bfloat16()) &&
+        node->dtype != node->value.dtype()) {
+      has_bf16_numeric_op_ = true;
+    }
     // Consider both source and target types to ensure all intermediate
     // vector types can be represented. For example, casting int32 to
     // float8_e4m3fn: target allows 128/8=16 lanes but int32 only supports
     // up to 128/32=4 lanes in CUDA vector types.
     int target_lanes = vector_load_bits_max_ / node->dtype.bits();
+    // Metal: MSL vector types cap bfloat16 at 2 lanes (bfloat2) on EITHER
+    // side of the cast; other 16/32-bit element vectors cap at 4 lanes (no
+    // 128-bit vectors beyond float4). CUDA's 128-bit packing does not apply
+    // to MSL. Checking only the target dtype (previous behavior) let
+    // bf16->fp32 casts plan 4 lanes and emit an illegal uint2->float4 cast.
+    if (TargetIsMetal(Target::Current(false))) {
+      int metal_max_lanes =
+          (node->dtype.is_bfloat16() || node->value.dtype().is_bfloat16()) ? 2
+                                                                           : 4;
+      target_lanes = std::min(target_lanes, metal_max_lanes);
+    }
     int source_bits = node->value.dtype().bits();
     int max_lanes = target_lanes;
     if (source_bits > 0) {
@@ -924,6 +983,14 @@ private:
     int min_vec_size = arith::ZeroAwareGCD(
         buffer_vec_size,
         vector_load_bits_max_ / (buffer->dtype.bits() * buffer->dtype.lanes()));
+    // Metal: MSL has no bfloat16 vectors beyond bfloat2 (2 lanes) in the
+    // fragment/register path; global/shared buffers keep the packed uint
+    // path (bf16x8 via uint4). Cap bf16 at 2 lanes for local/fragment only.
+    if (TargetIsMetal(Target::Current(false)) && buffer->dtype.is_bfloat16() &&
+        (IsLocalBuffer(buffer, /*allow_var=*/true) ||
+         IsFragmentBuffer(buffer))) {
+      min_vec_size = std::min(min_vec_size, 2);
+    }
     bool is_invariant = false;
     int try_vec_size = buffer_vec_size;
     while (try_vec_size >= min_vec_size) {
@@ -938,6 +1005,12 @@ private:
     // If is_invariant is still false, use the fallback min_vec_size
     if (!is_invariant) {
       buffer_vec_size = min_vec_size;
+    }
+    if (TargetIsMetal(Target::Current(false)) && buffer->dtype.is_bfloat16() &&
+        (IsLocalBuffer(buffer, /*allow_var=*/true) ||
+         IsFragmentBuffer(buffer)) &&
+        buffer_vec_size > 2) {
+      buffer_vec_size = 2;
     }
 
     // 3. If element offset is independent with loop_var, ignore it.
@@ -995,12 +1068,44 @@ private:
     }
   }
 
+  // Mark the loop as containing a bf16 numeric operation (arithmetic,
+  // comparison, min/max) when either operand is bfloat16. The Metal codegen
+  // represents bf16x4/x8 as packed uintN carriers that are only valid for
+  // pure memory copies; any numeric use must cap the vector width at 2 lanes
+  // (bfloat2), otherwise the packed carrier would silently enter integer
+  // arithmetic.
+#define TL_MARK_BF16_NUMERIC_BINARY(NodeType)                                  \
+  PrimExpr VisitExpr_(const NodeType *node) final {                            \
+    if (node->a.dtype().is_bfloat16() || node->b.dtype().is_bfloat16() ||      \
+        node->dtype.is_bfloat16()) {                                           \
+      has_bf16_numeric_op_ = true;                                             \
+    }                                                                          \
+    return arith::IRMutatorWithAnalyzer::VisitExpr_(node);                     \
+  }
+
+  TL_MARK_BF16_NUMERIC_BINARY(AddNode)
+  TL_MARK_BF16_NUMERIC_BINARY(SubNode)
+  TL_MARK_BF16_NUMERIC_BINARY(MulNode)
+  TL_MARK_BF16_NUMERIC_BINARY(DivNode)
+  TL_MARK_BF16_NUMERIC_BINARY(ModNode)
+  TL_MARK_BF16_NUMERIC_BINARY(MinNode)
+  TL_MARK_BF16_NUMERIC_BINARY(MaxNode)
+  TL_MARK_BF16_NUMERIC_BINARY(EQNode)
+  TL_MARK_BF16_NUMERIC_BINARY(NENode)
+  TL_MARK_BF16_NUMERIC_BINARY(LTNode)
+  TL_MARK_BF16_NUMERIC_BINARY(LENode)
+  TL_MARK_BF16_NUMERIC_BINARY(GTNode)
+  TL_MARK_BF16_NUMERIC_BINARY(GENode)
+
+#undef TL_MARK_BF16_NUMERIC_BINARY
+
   int vector_load_bits_max_;
   int initial_vector_size_ = 128;
   int loop_extent_vector_size_ = 128;
 
   const ForNode *inner_for_{};
   bool has_nonlocal_memory_access_ = false;
+  bool has_bf16_numeric_op_ = false;
   int vector_size_ = 128;
   std::vector<BufferVectorInfo> buffer_vector_infos_;
   LayoutMap layout_map_;

--- a/src/transform/loop_vectorize.cc
+++ b/src/transform/loop_vectorize.cc
@@ -24,6 +24,7 @@
 
 #include "loop_vectorize.h"
 #include "../config.h"
+#include "backend/common/bf16_numeric_op.h"
 #include "../op/builtin.h"
 #include "../op/utils.h"
 #include "arith/int_operator.h"
@@ -638,7 +639,8 @@ private:
     // A bf16-typed call (other than if_then_else, which is a bit-level pick
     // used by predicated pure copies) is a numeric operation on bf16 vectors:
     // packed carriers must never enter it.
-    if (node->dtype.is_bfloat16() && node->op != builtin::if_then_else()) {
+    if (IsBF16NumericCallOp(node->dtype,
+                            node->op == builtin::if_then_else())) {
       has_bf16_numeric_op_ = true;
     }
     if (node->op == builtin::if_then_else()) {
@@ -906,8 +908,7 @@ private:
     // Any bf16 numeric cast (bf16 on either side, non-identity) is a numeric
     // operation: packed carriers must not be produced/consumed by it.
     // Identity casts are bit-level pass-throughs.
-    if ((node->dtype.is_bfloat16() || node->value.dtype().is_bfloat16()) &&
-        node->dtype != node->value.dtype()) {
+    if (IsBF16NumericCastOp(node->value.dtype(), node->dtype)) {
       has_bf16_numeric_op_ = true;
     }
     // Consider both source and target types to ensure all intermediate
@@ -1069,15 +1070,16 @@ private:
   }
 
   // Mark the loop as containing a bf16 numeric operation (arithmetic,
-  // comparison, min/max) when either operand is bfloat16. The Metal codegen
-  // represents bf16x4/x8 as packed uintN carriers that are only valid for
-  // pure memory copies; any numeric use must cap the vector width at 2 lanes
-  // (bfloat2), otherwise the packed carrier would silently enter integer
-  // arithmetic.
+  // comparison, min/max) when either operand or the result is bfloat16. The
+  // Metal codegen represents bf16x4/x8 as packed uintN carriers that are only
+  // valid for pure memory copies; any numeric use must cap the vector width
+  // at 2 lanes (bfloat2), otherwise the packed carrier would silently enter
+  // integer arithmetic. The classification is shared with the Metal codegen
+  // via backend/common/bf16_numeric_op.h.
 #define TL_MARK_BF16_NUMERIC_BINARY(NodeType)                                  \
   PrimExpr VisitExpr_(const NodeType *node) final {                            \
-    if (node->a.dtype().is_bfloat16() || node->b.dtype().is_bfloat16() ||      \
-        node->dtype.is_bfloat16()) {                                           \
+    if (IsBF16NumericBinaryOp(node->a.dtype(), node->b.dtype(),                \
+                              node->dtype)) {                                  \
       has_bf16_numeric_op_ = true;                                             \
     }                                                                          \
     return arith::IRMutatorWithAnalyzer::VisitExpr_(node);                     \

--- a/testing/python/metal/metal_test_utils.py
+++ b/testing/python/metal/metal_test_utils.py
@@ -1,0 +1,25 @@
+"""Shared utilities for Metal lowering tests."""
+
+import tilelang
+from tilelang import tvm as tvm
+
+
+def lower_prim_to_metal(prim_func, *, target="metal") -> str:
+    """Lower a TIR prim_func to Metal shader source.
+
+    This is the canonical Metal lowering path shared by tests: it creates a
+    TVM Metal target with an LLVM host target, lowers the function with host
+    codegen and device compilation disabled, and returns the emitted MSL.
+    Tests that only need the generated shader text should use this helper
+    instead of inlining the same ``tilelang.lower`` call.
+    """
+    target = tvm.target.Target(target, tvm.target.Target("llvm"))
+    with target:
+        artifact = tilelang.lower(
+            prim_func,
+            target=target,
+            target_host="llvm",
+            enable_host_codegen=False,
+            enable_device_compile=False,
+        )
+    return artifact.kernel_source or ""

--- a/testing/python/metal/test_metal_bf16_codegen.py
+++ b/testing/python/metal/test_metal_bf16_codegen.py
@@ -8,9 +8,9 @@ import pytest
 import torch
 
 import tilelang
-from tilelang import tvm as tvm
 import tilelang.testing
 import tilelang.language as T
+from metal_test_utils import lower_prim_to_metal
 
 
 @T.prim_func
@@ -78,29 +78,7 @@ def repro_gemm(dtype: str):
 
 def lower_to_metal(dtype: str) -> str:
     prim_func = repro_gemm.get_tir(dtype)
-    target = tvm.target.Target("metal", tvm.target.Target("llvm"))
-    with target:
-        artifact = tilelang.lower(
-            prim_func,
-            target=target,
-            target_host="llvm",
-            enable_host_codegen=False,
-            enable_device_compile=False,
-        )
-    return artifact.kernel_source or ""
-
-
-def lower_prim_to_metal(prim_func) -> str:
-    target = tvm.target.Target("metal", tvm.target.Target("llvm"))
-    with target:
-        artifact = tilelang.lower(
-            prim_func,
-            target=target,
-            target_host="llvm",
-            enable_host_codegen=False,
-            enable_device_compile=False,
-        )
-    return artifact.kernel_source or ""
+    return lower_prim_to_metal(prim_func)
 
 
 def test_metal_bf16_vectorized_copy_uses_packed_uint_type():

--- a/testing/python/metal/test_metal_bf16_codegen.py
+++ b/testing/python/metal/test_metal_bf16_codegen.py
@@ -33,6 +33,22 @@ def bf16_six_lane_copy(
         B[0] = A[0]
 
 
+@T.prim_func
+def bf16_fp16_literals(
+    A: T.Tensor((4,), "bfloat16"),
+    B: T.Tensor((4,), "bfloat16"),
+    C: T.Tensor((4,), "float16"),
+    D: T.Tensor((4,), "bfloat16"),
+    E: T.Tensor((4,), "float16"),
+):
+    with T.Kernel(1, threads=4):
+        for i in T.Parallel(4):
+            B[i] = A[i] + T.bfloat16(1.5)
+            C[i] = T.float16(2.5)
+            D[i] = T.bfloat16(float("inf"))
+            E[i] = T.float16(float("inf"))
+
+
 @tilelang.jit(out_idx=[2], target="metal", execution_backend="torch")
 def repro_gemm(dtype: str):
     M = 32
@@ -112,6 +128,22 @@ def test_metal_bf16_numeric_vector_uses_native_bfloat2():
 def test_metal_bf16_six_lane_packed_copy_is_rejected():
     with pytest.raises(Exception, match=r"bf16x6|6 lanes|not representable"):
         lower_prim_to_metal(bf16_six_lane_copy)
+
+
+def test_metal_fp16_bf16_literals_use_explicit_cast():
+    """fp16/bf16 FloatImm literals (finite and INFINITY) must be emitted with
+    an explicit ``(half)``/``(bfloat)`` cast: MSL has no implicit conversion
+    into bfloat from float/half, and bare INFINITY/NAN or `h`-suffixed
+    literals break bf16 assignments and half select() overloads. This also
+    pins the unified form shared with the reduce PR: no ``bfloat(...)``
+    wrapper and no ``h`` suffix on bf16 finite literals."""
+    src = lower_prim_to_metal(bf16_fp16_literals)
+    assert "(bfloat)(1.500000e+00)" in src
+    assert "1.500000e+00h" not in src
+    assert "bfloat(1.500000e+00)" not in src
+    assert "(half)(2.500000e+00h)" in src
+    assert "(bfloat)(INFINITY)" in src
+    assert "(half)(INFINITY)" in src
 
 
 @tilelang.testing.requires_metal

--- a/testing/python/metal/test_metal_bf16_codegen.py
+++ b/testing/python/metal/test_metal_bf16_codegen.py
@@ -4,10 +4,33 @@ These tests verify that TileLang can compile kernels down to Metal shader
 source code while correctly handling both float16 and bfloat16.
 """
 
+import pytest
+import torch
+
 import tilelang
 from tilelang import tvm as tvm
 import tilelang.testing
 import tilelang.language as T
+
+
+@T.prim_func
+def bf16_numeric_vector(
+    A: T.Tensor((8,), "bfloat16"),
+    B: T.Tensor((8,), "bfloat16"),
+    C: T.Tensor((8,), "bfloat16"),
+):
+    with T.Kernel(1, threads=1):
+        for i in T.vectorized(8):
+            C[i] = T.max(A[i] + B[i], T.bfloat16(0))
+
+
+@T.prim_func
+def bf16_six_lane_copy(
+    A: T.Tensor((1,), "bfloat16x6"),
+    B: T.Tensor((1,), "bfloat16x6"),
+):
+    with T.Kernel(1, threads=1):
+        B[0] = A[0]
 
 
 @tilelang.jit(out_idx=[2], target="metal", execution_backend="torch")
@@ -51,6 +74,19 @@ def lower_to_metal(dtype: str) -> str:
     return artifact.kernel_source or ""
 
 
+def lower_prim_to_metal(prim_func) -> str:
+    target = tvm.target.Target("metal", tvm.target.Target("llvm"))
+    with target:
+        artifact = tilelang.lower(
+            prim_func,
+            target=target,
+            target_host="llvm",
+            enable_host_codegen=False,
+            enable_device_compile=False,
+        )
+    return artifact.kernel_source or ""
+
+
 def test_metal_bf16_vectorized_copy_uses_packed_uint_type():
     src = lower_to_metal("bfloat16")
 
@@ -63,6 +99,36 @@ def test_metal_fp16_vectorized_copy_still_uses_packed_uint_type():
     src = lower_to_metal("float16")
 
     assert "*(threadgroup uint4*)" in src
+
+
+def test_metal_bf16_numeric_vector_uses_native_bfloat2():
+    src = lower_prim_to_metal(bf16_numeric_vector)
+
+    assert "bfloat2" in src
+    assert "uint4" not in src
+    assert "select(" in src
+
+
+def test_metal_bf16_six_lane_packed_copy_is_rejected():
+    with pytest.raises(Exception, match=r"bf16x6|6 lanes|not representable"):
+        lower_prim_to_metal(bf16_six_lane_copy)
+
+
+@tilelang.testing.requires_metal
+def test_metal_bf16_numeric_vector_runtime():
+    kernel = tilelang.compile(
+        bf16_numeric_vector,
+        target="metal",
+        execution_backend="torch",
+    )
+    a = torch.linspace(-2.0, 1.5, 8, dtype=torch.bfloat16, device="mps")
+    b = torch.linspace(0.5, 2.0, 8, dtype=torch.bfloat16, device="mps")
+    result = torch.empty_like(a)
+    kernel(a, b, result)
+    torch.mps.synchronize()
+
+    reference = torch.maximum(a.cpu() + b.cpu(), torch.zeros(8, dtype=torch.bfloat16))
+    torch.testing.assert_close(result.cpu(), reference, rtol=0, atol=0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem and change

Metal can use packed integers to carry wide bf16 copies, but numeric use of those carriers performs integer operations on bf16 bits. Register bf16 vectors also cannot exceed `bfloat2`.

Limit bf16 arithmetic, comparison, min/max, and numeric casts to `bfloat2`; keep wider packed carriers only for bit-preserving copies; lower bf16 min/max through legal MSL selection; and reject bf16x6 rather than emitting a padded `uint3`.

<sub>Files: `src/metal/codegen/codegen_metal.{cc,h}`, `src/transform/loop_vectorize.cc`, and `testing/python/metal/test_metal_bf16_codegen.py`.</sub>

## Before and after

On Apple M2, the same three regressions give 3 failures on `origin/main`: numeric bf16x8 becomes `uint4` arithmetic, bf16x6 is accepted, and the numeric shader fails MPS compilation. This PR emits `bfloat2`, rejects bf16x6 during lowering, and executes the numeric kernel through `torch.mps.compile_shader` bit-exactly against the CPU bf16 reference.

Performance classification: **No performance claim**. The campaign's fp8/fp4 QMM timings depend on separate quantized kernels and other split PRs, so they are intentionally excluded from this standalone bf16 correctness PR and listed only in the appendix.

## Validation

```text
cmake -S . -B build
cmake --build build -j8
TILELANG_DISABLE_CACHE=1 python -m pytest testing/python/metal -q
41 passed, 3 skipped
```

The module contains four codegen checks and one real-MPS numerical test; only the runtime case skips without Metal.

## Scope

Targets the M1-M4 MSL/simdgroup path while retaining legal software-packed copies; the M5 Metal 4 TensorOps/FP8 path is out of scope.

## Appendix: combined campaign results (组合 campaign 结果)

The table below describes the complete Apple M2 optimization campaign, not the isolated contribution or acceptance criteria of this PR. Where `origin/main` cannot execute the workload correctly, a numerical speedup versus `main` is undefined; the nearest valid performance baseline is stated explicitly.

| Representative workload | `origin/main` | End-state result | Valid performance comparison |
|---|---|---|---|
| Qwen dense decode | Cannot lower the required Metal reduction | 64-token: `28.3 us/token` synchronized, `23.9 us/token` GPU timeline | `14.5x` versus the valid single-token path (`410.0 us/token`) |
| Fused Qwen/DeepSeek-style MoE block | Required multi-kernel/ABI path is not correct | 9 launches, `16.92 ms` | `1.21x` versus the previous valid 17-launch composed path (`20.53 ms`) |
| Multi-simdgroup bf16 GEMM | t256 staged output is incorrect | Correct t256 execution | Fragment-C `19.86x`; shared-C `14.16x` versus correct t32 paths |
| Software-packed dense fp8 / expert fp4 QMM | Downstream kernels are not present in `main` | `685.7 us` / `697.4 us` | Dense fp8 `16.9x` versus the initial campaign kernel; expert fp4 `26%` faster than its earlier campaign version |
| End-to-end Mega MoE | Complete path is blocked by missing backend prerequisites | T=64 `114.1 ms`; T=1 `16.7 ms` | `80.8%` / `48.0%` lower latency versus the valid full-pipeline baseline |
