### PR TITLE
[Transform] Preserve conditional type-cast store semantics

### DIFF
--- a/testing/python/transform/test_tilelang_transform_decouple_type_cast.py
+++ b/testing/python/transform/test_tilelang_transform_decouple_type_cast.py
@@ -214,7 +214,13 @@ def test_local_to_memory_with_bind_chain():
 
 
 def test_local_to_memory_with_branch_local_bind():
-    """Test Bind definitions inside an IfThenElse branch do not escape."""
+    """Test Bind definitions inside an IfThenElse branch do not escape.
+
+    The guarded store gets a per-entry validity mask: the mask is
+    zeroed by an init loop, set to 1 at the compute store site (inside the
+    branch), and the copy-to loop is guarded by ``mask[i_copy] != 0`` instead
+    of re-evaluating the original branch condition.
+    """
 
     @T.prim_func
     def before(b: T.Tensor[(16,), T.float8_e4m3fn]):
@@ -234,11 +240,15 @@ def test_local_to_memory_with_branch_local_bind():
             T.reads()
             T.writes()
             b_local_cast = T.decl_buffer((16,), T.float8_e4m3fn, scope="local")
+            b_local_cast_mask = T.decl_buffer((16,), "int32", scope="local")
+            for i_mask in T.vectorized(16):
+                b_local_cast_mask[i_mask] = 0
             for i in T.vectorized(16):
                 if i < 8:
                     b_local_cast[i] = T.cast(a_frag[i] * scale[i], T.float8_e4m3fn)
+                    b_local_cast_mask[i] = 1
             for i_copy in T.vectorized(16):
-                if i_copy < 8:
+                if b_local_cast_mask[i_copy] != 0:
                     b[i_copy] = b_local_cast[i_copy]
 
     _check(before, after)
@@ -274,6 +284,225 @@ def test_cast_buffers_wrapped_in_lexical_alloc_scope():
     post_order_visit(mod["main"].body, _visit)
     assert annotated_blocks[0] == 1, f"Expected 1 lexical_alloc_scope block, got {annotated_blocks[0]}"
     assert allocs_inside[0] == 1, f"Expected the cast buffer alloc inside the scope, got {allocs_inside[0]}"
+
+
+def test_mask_guard_root_if_else_regression():
+    """Copy-to guards must NOT re-evaluate original
+    buffer conditions, because an earlier copy-to write-back can flip them.
+
+    Structure: root if/else where the then-branch stores to A (the buffer the
+    guard reads) and the else-branch stores to B. Re-evaluating ``A[i] > 0``
+    in B's copy-to loop after A's copy-to wrote back would flip the guard and
+    read an uninitialized cast local. The mask scheme records compute-time
+    truth at the store site, so B's copy-to fires exactly where the original
+    else-branch store fired.
+    """
+
+    @T.prim_func
+    def before(
+        A: T.Tensor[(8,), T.bfloat16],
+        src: T.Tensor[(8,), T.float32],
+        B: T.Tensor[(8,), T.bfloat16],
+    ):
+        for i in T.vectorized(8):
+            if A[i] > 0:
+                A[i] = T.cast(src[i], T.bfloat16)
+            else:
+                B[i] = T.cast(src[i], T.bfloat16)
+
+    @T.prim_func
+    def after(
+        A: T.Tensor[(8,), T.bfloat16],
+        src: T.Tensor[(8,), T.float32],
+        B: T.Tensor[(8,), T.bfloat16],
+    ):
+        with T.sblock("decoupled_cast"):
+            T.sblock_attr({"lexical_alloc_scope": 1})
+            T.reads()
+            T.writes()
+            A_local_cast = T.decl_buffer((8,), T.bfloat16, scope="local")
+            B_local_cast_1 = T.decl_buffer((8,), T.bfloat16, scope="local")
+            src_local_cast_2 = T.decl_buffer((8,), T.float32, scope="local")
+            A_local_cast_mask = T.decl_buffer((8,), "int32", scope="local")
+            B_local_cast_1_mask = T.decl_buffer((8,), "int32", scope="local")
+            for i_mask in T.vectorized(8):
+                A_local_cast_mask[i_mask] = 0
+            for i_mask in T.vectorized(8):
+                B_local_cast_1_mask[i_mask] = 0
+            for i_copy in T.vectorized(8):
+                src_local_cast_2[i_copy] = src[i_copy]
+            for i_copy in T.vectorized(8):
+                A_local_cast[i_copy] = A[i_copy]
+            for i in T.vectorized(8):
+                if A_local_cast[i] > T.bfloat16(0.0):
+                    A_local_cast[i] = T.cast(src_local_cast_2[i], T.bfloat16)
+                    A_local_cast_mask[i] = 1
+                else:
+                    B_local_cast_1[i] = T.cast(src_local_cast_2[i], T.bfloat16)
+                    B_local_cast_1_mask[i] = 1
+            for i_copy in T.vectorized(8):
+                if A_local_cast_mask[i_copy] != 0:
+                    A[i_copy] = A_local_cast[i_copy]
+            for i_copy in T.vectorized(8):
+                if B_local_cast_1_mask[i_copy] != 0:
+                    B[i_copy] = B_local_cast_1[i_copy]
+
+    _check(before, after)
+
+
+def _collect_guarded_copy_guards(mod, mask_name: str) -> list[str]:
+    """Return the guard expressions of every IfThenElse guarding a copy loop
+    whose condition references ``mask_name`` (as printed IR strings)."""
+    from tvm.tirx.stmt_functor import post_order_visit
+
+    guards: list[str] = []
+
+    def _visit(node):
+        if isinstance(node, tvm.tirx.IfThenElse) and mask_name in str(node.condition):
+            guards.append(str(node.condition))
+
+    post_order_visit(mod["main"].body, _visit)
+    return guards
+
+
+def test_mask_or_semantics_multi_branch_same_entry():
+    """OR/nested-branch semantics: several stores to the SAME (buffer, indices)
+    entry under different conditions map to ONE validity mask; the copy-to
+    fires iff any branch actually executed. No copy-to guard may reference the
+    original buffers (only the mask)."""
+
+    @T.prim_func
+    def before(
+        src: T.Tensor[(8,), T.float32],
+        B: T.Tensor[(8,), T.float8_e4m3fn],
+    ):
+        # Two branches kept separate so the OR-of-path-conditions semantics of
+        # the decoupled copy guard is exercised as written.
+        for i in T.vectorized(8):
+            if i < 4:  # noqa: SIM114
+                B[i] = T.cast(src[i], T.float8_e4m3fn)
+            elif i < 8:
+                B[i] = T.cast(src[i], T.float8_e4m3fn)
+
+    mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
+    mod = DecoupleTypeCast()(mod)
+
+    # Exactly one mask buffer, named after the single B entry's cast buffer.
+    from tvm.tirx.stmt_functor import post_order_visit
+
+    buffers = []
+
+    def _collect(node):
+        if isinstance(node, tvm.tirx.AllocBuffer):
+            buffers.append(node.buffer.name)
+
+    post_order_visit(mod["main"].body, _collect)
+    mask_buffers = [n for n in buffers if n.endswith("_mask")]
+    assert mask_buffers == ["B_local_cast_mask"], f"Unexpected mask buffers: {mask_buffers}"
+
+    # Every guarded copy loop reads ONLY the mask, never the original buffers.
+    guards = _collect_guarded_copy_guards(mod, "B_local_cast_mask")
+    assert guards, "Expected at least one mask-guarded copy-to loop"
+    for guard in guards:
+        assert "B[" not in guard, f"Copy-to guard re-reads original buffer: {guard}"
+        assert "src[" not in guard, f"Copy-to guard re-reads original buffer: {guard}"
+
+    # The mask is set inside both branches (OR semantics).
+    body_str = str(mod["main"].body)
+    assert body_str.count("B_local_cast_mask[i] = 1") == 2, body_str
+
+
+def test_unconditional_store_gets_no_mask():
+    """Anti-over-fix: an unconditional store needs no validity mask; the
+    copy-to loop stays unconditional and no mask buffer/init loop is emitted."""
+    from tvm.tirx.stmt_functor import post_order_visit
+
+    @T.prim_func
+    def before(b: T.Tensor[(16,), T.float4_e2m1fn]):
+        b_frag = T.alloc_local((16,), T.float32)
+        for i in T.vectorized(16):
+            b[i] = b_frag[i]
+
+    mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
+    mod = DecoupleTypeCast()(mod)
+
+    buffers = []
+
+    def _collect(node):
+        if isinstance(node, tvm.tirx.AllocBuffer):
+            buffers.append(node.buffer.name)
+
+    post_order_visit(mod["main"].body, _collect)
+    assert not any(n.endswith("_mask") for n in buffers), f"Unexpected masks: {buffers}"
+
+
+def test_guarded_copy_from_substitutes_loop_var():
+    """Guarded copy-from loops run under their own loop var: the collected
+    path condition (over the original loop var) must be substituted, otherwise
+    the original loop var is left free inside the copy loop ("used before
+    definition" in VarUseDefAnalysis). This catches a mask refactor that
+    drops the substitution for from-memory guards.
+    """
+
+    @T.prim_func
+    def before(src: T.Tensor[(8,), T.float32], B: T.Tensor[(8,), T.bfloat16]):
+        for i in T.vectorized(8):
+            if i < 4:
+                B[i] = T.cast(src[i], T.bfloat16)
+
+    @T.prim_func
+    def after(src: T.Tensor[(8,), T.float32], B: T.Tensor[(8,), T.bfloat16]):
+        with T.sblock("decoupled_cast"):
+            T.sblock_attr({"lexical_alloc_scope": 1})
+            T.reads()
+            T.writes()
+            B_local_cast = T.decl_buffer((8,), T.bfloat16, scope="local")
+            src_local_cast_1 = T.decl_buffer((8,), T.float32, scope="local")
+            B_local_cast_mask = T.decl_buffer((8,), "int32", scope="local")
+            for i_mask in T.vectorized(8):
+                B_local_cast_mask[i_mask] = 0
+            for i_copy in T.vectorized(8):
+                if i_copy < 4:
+                    src_local_cast_1[i_copy] = src[i_copy]
+            for i in T.vectorized(8):
+                if i < 4:
+                    B_local_cast[i] = T.cast(src_local_cast_1[i], T.bfloat16)
+                    B_local_cast_mask[i] = 1
+            for i_copy in T.vectorized(8):
+                if B_local_cast_mask[i_copy] != 0:
+                    B[i_copy] = B_local_cast[i_copy]
+
+    _check(before, after)
+
+
+def test_ternary_value_load_copy_from_is_unconditional():
+    """Both value branches of ``if_then_else`` are staged unconditionally.
+
+    DecoupleTypeCast must not apply the ternary condition to either copy-from:
+    the condition selects a value in the compute loop; it is not an enclosing
+    statement guard on either memory load.
+    """
+
+    @T.prim_func
+    def before(
+        src: T.Tensor[(16,), T.bfloat16],
+        out: T.Tensor[(8,), T.float32],
+    ):
+        for i in T.vectorized(8):
+            out[i] = T.if_then_else(
+                i < 4,
+                T.cast(src[i], T.float32),
+                T.cast(src[i + 8], T.float32) * T.float32(2),
+            )
+
+    mod = tvm.IRModule.from_expr(before.with_attr("global_symbol", "main"))
+    mod = DecoupleTypeCast()(mod)
+    text = mod["main"].script()
+
+    assert "src_local_cast_1[i_copy] = src[i_copy]" in text
+    assert "src_local_cast_2[i_copy] = src[i_copy + 8]" in text
+    assert "if i_copy < 4:" not in text
+    assert "if 4 <= i_copy:" not in text
 
 
 # =============================================================================

--- a/tilelang/transform/decouple_type_cast.py
+++ b/tilelang/transform/decouple_type_cast.py
@@ -41,6 +41,28 @@ The staging cast buffers together with the transformed loops are wrapped in
 an opaque block annotated with `lexical_alloc_scope`, so their allocations
 stay lexically scoped to the use site (see LowerOpaqueBlock / StorageRewrite)
 instead of being hoisted to the kernel entry.
+
+Conditional stores: copy-to guard semantics
+-------------------------------------------
+A store may sit under IfThenElse conditions (per-lane branches). The copy-to
+loop must write back exactly the lanes whose original store fired, otherwise
+an uninitialized cast local is written to memory. Re-evaluating the original
+path-condition *expression* in the copy-to loop is unsound: the expression is
+structurally identical to the compute-time condition, but earlier copy-to
+write-backs may have modified the buffers it reads, flipping its truth value
+between compute time and copy time.
+
+Instead, each store entry that has any enclosing condition gets a per-entry
+**validity mask** (a local int32 buffer, 0/1 per lane). The mask is set to 1
+inside the compute loop, at the exact statement position where the original
+store executed (inside the same branches), so it records the path the compute
+stage actually took; an init loop zeroes it first. The copy-to loop reads only
+``mask[i] != 0`` and never re-evaluates the original conditions, so OR/nested
+branch semantics reduce to "was this entry's cast local defined for this lane".
+Unconditional stores need no mask (their copy-to stays unconditional).
+Copy-from loops keep condition guards: they run before the compute loop and
+before any copy-to write-back, so original-buffer conditions are still stable
+at that point.
 """
 
 from __future__ import annotations
@@ -164,6 +186,41 @@ def _expr_depends_on_var(expr: tirx.PrimExpr, var: Var) -> bool:
     return found
 
 
+def _and_cond(path: tirx.PrimExpr | None, cond: tirx.PrimExpr) -> tirx.PrimExpr:
+    """Conjoin a path condition with a branch condition.
+
+    ``None`` encodes "always" (no enclosing condition), so it is the
+    neutral element for conjunction.
+    """
+    if path is None:
+        return cond
+    return tirx.And(path, cond)
+
+
+def _or_conditions(conds: list[tirx.PrimExpr | None]) -> tirx.PrimExpr | None:
+    """Disjunction of path conditions.
+
+    ``None`` encodes "always": an access without any enclosing condition
+    fires unconditionally, so the disjunction is unconditional. A tautology
+    ``c OR NOT(c)`` (either operand order, structural match) also folds to
+    ``None`` — the branch conditions of a root if/else are complementary, so
+    the OR of both branches' paths is always true.
+    """
+    result: tirx.PrimExpr | None = None
+    for cond in conds:
+        if cond is None:
+            return None
+        if result is None:
+            result = cond
+        else:
+            if (isinstance(cond, tirx.Not) and tvm_ir.structural_equal(cond.a, result)) or (
+                isinstance(result, tirx.Not) and tvm_ir.structural_equal(result.a, cond)
+            ):
+                return None
+            result = tirx.Or(result, cond)
+    return result
+
+
 # ---------------------------------------------------------------------------
 # Collection: gather all shared/global BufferStores and BufferLoads
 # ---------------------------------------------------------------------------
@@ -182,17 +239,38 @@ class MemoryAccessCollector(PyStmtExprVisitor):
     BufferLoads whose indices do not depend on ``loop_var`` are skipped
     because they are scalar accesses (e.g. ``b[0]``) that should remain
     in the compute loop as broadcasts.
+
+    Each collected access is paired with its path condition: the
+    conjunction of enclosing IfThenElse conditions (``None`` when the
+    access is unconditional). Load conditions still guard the copy-from
+    loops (safe: they are evaluated before the compute loop and before any
+    copy-to write-back). Store conditions are no longer re-evaluated in the
+    copy-to loops: each store entry gets a validity mask set at the compute
+    store site instead (see module docstring).
     """
 
     def __init__(self, loop_var: Var):
         super().__init__()
         self.loop_var = loop_var
-        self.stores: list[BufferStore] = []
-        self.loads: list[BufferLoad] = []
+        self.condition: tirx.PrimExpr | None = None
+        self.stores: list[tuple[BufferStore, tirx.PrimExpr | None]] = []
+        self.loads: list[tuple[BufferLoad, tirx.PrimExpr | None]] = []
+
+    def visit_if_then_else_(self, op: IfThenElse) -> None:
+        saved = self.condition
+        # Loads inside the condition itself fire whenever the statement is
+        # reached, i.e. under the enclosing (saved) condition only.
+        self.visit_expr(op.condition)
+        self.condition = _and_cond(saved, op.condition)
+        self.visit_stmt(op.then_case)
+        if op.else_case is not None:
+            self.condition = _and_cond(saved, tirx.Not(op.condition))
+            self.visit_stmt(op.else_case)
+        self.condition = saved
 
     def visit_buffer_store_(self, op: BufferStore) -> None:
         if is_global_or_shared_buffer(op.buffer):
-            self.stores.append(op)
+            self.stores.append((op, self.condition))
         # Visit value but skip indices
         self.visit_expr(op.value)
 
@@ -201,7 +279,7 @@ class MemoryAccessCollector(PyStmtExprVisitor):
         # Collect ALL qualifying loads (even from the same buffer with different
         # indices, e.g. a[i] and a[i+32]) so each gets its own cast buffer.
         if is_global_or_shared_buffer(op.buffer) and any(_expr_depends_on_var(idx, self.loop_var) for idx in op.indices):
-            self.loads.append(op)
+            self.loads.append((op, self.condition))
         # Skip indices traversal
 
     def visit_call_(self, op: Call) -> None:
@@ -331,6 +409,18 @@ def _find_cast_entry(
     return None
 
 
+def _find_cast_entry_index(
+    entries: list[CastEntry],
+    buffer: Buffer,
+    indices: list[tirx.PrimExpr],
+) -> int:
+    """Index of the entry matching a (buffer, indices) pair, or -1."""
+    for i, (orig_buf, orig_indices, _) in enumerate(entries):
+        if _buf_indices_match(orig_buf, orig_indices, buffer, indices):
+            return i
+    return -1
+
+
 # ---------------------------------------------------------------------------
 # Mutator
 # ---------------------------------------------------------------------------
@@ -408,39 +498,64 @@ class DecoupleTypeCastMutator(tirx.PyStmtExprMutator):
         if isinstance(root_stmt, Evaluate):
             return self._make_for(op, new_body) if new_body is not op.body else op
 
-        # Collect all shared/global stores and loads
+        # Collect all shared/global stores and loads, each with its path
+        # condition (conjunction of enclosing IfThenElse conditions).
         collector = MemoryAccessCollector(op.loop_var)
         collector.visit_stmt(normalized_body)
+        store_list = collector.stores
+        load_list = collector.loads
 
-        if not collector.stores and not collector.loads:
+        if not store_list and not load_list:
             # Cast exists but no memory access → nothing to decouple
             return self._make_for(op, new_body) if new_body is not op.body else op
 
         extent = op.extent.value
 
-        # Extract condition (from normalized body for correctness)
-        condition, _ = extract_if_condition(normalized_body)
-
         # Create cast entries for stores and loads
-        store_entries = self._create_cast_entries(collector.stores, extent)
+        store_entries = self._create_cast_entries([s for s, _ in store_list], extent)
         # For loads, skip those already covered by a store entry (read-modify-write)
         # by matching (buffer, indices). Loads with different indices from the same
         # buffer still get their own cast buffer.
-        uncovered_loads = [ld for ld in collector.loads if _find_cast_entry(store_entries, ld.buffer, list(ld.indices)) is None]
+        uncovered_loads = [ld for ld, _ in load_list if _find_cast_entry(store_entries, ld.buffer, list(ld.indices)) is None]
         load_entries = self._create_cast_entries(uncovered_loads, extent)
+
+        def _entry_conditions(
+            entries: list[CastEntry], accesses: list[tuple[BufferStore | BufferLoad, tirx.PrimExpr | None]]
+        ) -> list[tirx.PrimExpr | None]:
+            """OR of the path conditions of every access mapped to each entry."""
+            return [
+                _or_conditions([cond for acc, cond in accesses if _buf_indices_match(entry[0], entry[1], acc.buffer, list(acc.indices))])
+                for entry in entries
+            ]
+
+        # Copy-from loops are guarded by the load path conditions: they run
+        # before the compute loop and before any copy-to write-back, so the
+        # original buffers their conditions read are still in the state the
+        # compute loop will see. Copy-to loops must NOT re-evaluate the store
+        # path conditions (earlier write-backs could flip them); they are
+        # guarded by the per-entry validity masks set at the compute store
+        # sites instead. The store conditions are kept only to
+        # decide which entries are unconditional (mask=None).
+        load_conditions = _entry_conditions(load_entries, load_list)
+        store_conditions = _entry_conditions(store_entries, store_list)
+        store_masks = self._create_mask_buffers(store_entries, store_conditions)
+
+        # Zero the validity masks before the compute loop (per masked entry).
+        mask_init_loops = self._create_mask_init_loops(op, [m for m in store_masks if m is not None])
 
         # Build copy-from-memory loops (before compute)
         # For read-modify-write, reuse the store-side cast buffer for copy-from.
         rmw_entries = [
             entry
             for entry in store_entries
-            if any(_buf_indices_match(entry[0], entry[1], ld.buffer, list(ld.indices)) for ld in collector.loads)
+            if any(_buf_indices_match(entry[0], entry[1], ld.buffer, list(ld.indices)) for ld, _ in load_list)
         ]
+        rmw_conditions = _entry_conditions(rmw_entries, load_list)
         copy_from_loops = self._create_copy_loops(
             op,
             load_entries + rmw_entries,
+            load_conditions + rmw_conditions,
             direction="from_memory",
-            condition=condition,
         )
 
         # Build compute loop: replace stores and loads in the normalized body
@@ -451,23 +566,33 @@ class DecoupleTypeCastMutator(tirx.PyStmtExprMutator):
         load_replacement_entries = store_entries + load_entries
         compute_body = normalized_body
         if store_entries or load_entries:
-            compute_body = self._replace_access(compute_body, store_entries, load_replacement_entries, op.loop_var)
+            compute_body = self._replace_access(compute_body, store_entries, load_replacement_entries, op.loop_var, store_masks)
         compute_loop = self._make_vectorized_loop(op, compute_body)
 
-        # Build copy-to-memory loops (after compute)
+        # Build copy-to-memory loops (after compute). Guards are the per-entry
+        # validity masks (set at the compute store sites), never a re-evaluation
+        # of the original path conditions.
         copy_to_loops = self._create_copy_loops(
             op,
             store_entries,
+            [],
             direction="to_memory",
-            condition=condition,
+            masks=store_masks,
         )
 
-        # Combine: copy-from → compute → copy-to
-        all_stmts = copy_from_loops + [compute_loop] + copy_to_loops
+        # Combine: mask-init → copy-from → compute → copy-to. Mask init must
+        # precede the compute loop (which sets the masks) and the copy-to loops
+        # (which read them); placing it first keeps every original buffer in its
+        # initial state when the copy-from guards are evaluated.
+        all_stmts = mask_init_loops + copy_from_loops + [compute_loop] + copy_to_loops
         result: Stmt = SeqStmt(all_stmts) if len(all_stmts) > 1 else all_stmts[0]
 
         # Wrap with buffer declarations and allocations
-        result = self._wrap_with_allocations(result, store_entries + load_entries)
+        result = self._wrap_with_allocations(
+            result,
+            store_entries + load_entries,
+            [m for m in store_masks if m is not None],
+        )
 
         return result
 
@@ -509,20 +634,83 @@ class DecoupleTypeCastMutator(tirx.PyStmtExprMutator):
             original.step,
         )
 
+    def _create_mask_buffers(self, entries: list[CastEntry], conditions: list[tirx.PrimExpr | None]) -> list[Buffer | None]:
+        """Create a per-entry validity mask buffer (local int32, 0/1) for store entries.
+
+        ``None`` for entries whose copy-to loop is unconditional (no enclosing
+        condition, ``conditions[i] is None``): their cast local is defined on
+        every lane, so no mask is needed. Masked entries get
+        ``<cast_buffer>_mask`` with one int32 per lane; the compute loop sets
+        it to 1 exactly where the original store executed, and the copy-to
+        loop reads it instead of re-evaluating the original path conditions
+        directly.
+        """
+        return [
+            tirx.decl_buffer(
+                shape=(int(entry[2].shape[0]),),
+                dtype="int32",
+                name=f"{entry[2].name}_mask",
+                scope="local",
+            )
+            if condition is not None
+            else None
+            for entry, condition in zip(entries, conditions, strict=True)
+        ]
+
+    def _create_mask_init_loops(self, op: For, masks: list[Buffer]) -> list[For]:
+        """Zero every validity mask before the compute loop.
+
+        One vectorized loop per mask, mirroring the per-entry copy loop
+        structure. The masks are local buffers, so these loops vectorize at the
+        usual local-buffer width (int32x4 on Metal).
+        """
+        init_loops: list[For] = []
+        for mask in masks:
+            init_var = Var(f"{op.loop_var.name}_mask", op.loop_var.dtype)
+            init_store = BufferStore(mask, IntImm("int32", 0), [init_var])
+            init_loops.append(
+                For(
+                    init_var,
+                    op.min,
+                    op.extent,
+                    ForKind.VECTORIZED,
+                    init_store,
+                    op.thread_binding,
+                    op.annotations,
+                    op.step,
+                )
+            )
+        return init_loops
+
     def _create_copy_loops(
         self,
         op: For,
         entries: list[CastEntry],
+        conditions: list[tirx.PrimExpr | None],
         direction: str,
-        condition: tirx.PrimExpr | None = None,
+        masks: list[Buffer | None] | None = None,
     ) -> list[For]:
         """Create vectorized copy loops between memory and cast buffers.
 
         direction: "to_memory" (cast → memory) or "from_memory" (memory → cast).
+
+        ``to_memory`` guards come from ``masks`` (per-entry validity mask
+        buffers, parallel to ``entries``): the copy fires only where the
+        compute stage actually executed the original store (``mask[i] != 0``).
+        The original path conditions are deliberately NOT re-evaluated here —
+        earlier copy-to write-backs could flip their truth value between
+        compute time and copy time. ``None`` mask means the copy is
+        unconditional.
+
+        ``from_memory`` guards come from ``conditions`` (per-entry OR of load
+        path conditions, ``None`` = unconditional). These are safe to evaluate
+        here because copy-from runs before the compute loop and before any
+        copy-to write-back, so original buffers are still in the state the
+        compute loop will see.
         """
         copy_loops: list[For] = []
 
-        for orig_buffer, orig_indices, cast_buffer in entries:
+        for i, (orig_buffer, orig_indices, cast_buffer) in enumerate(entries):
             # vectorized loop only has one iteration variable,
             # so we use the same name for the copy variable
             copy_var = Var(f"{op.loop_var.name}_copy", op.loop_var.dtype)
@@ -536,17 +724,26 @@ class DecoupleTypeCastMutator(tirx.PyStmtExprMutator):
                     BufferLoad(cast_buffer, [copy_var]),
                     new_indices,
                 )
+                guard: tirx.PrimExpr | None = None
+                if masks is not None and masks[i] is not None:
+                    guard = tirx.NE(BufferLoad(masks[i], [copy_var]), IntImm("int32", 0))
             else:
                 copy_store = BufferStore(
                     cast_buffer,
                     BufferLoad(orig_buffer, new_indices),
                     [copy_var],
                 )
+                guard = conditions[i] if i < len(conditions) else None
+                if guard is not None:
+                    # The copy loop runs under ``copy_var``; the path condition
+                    # was collected over the original loop var, so substitute
+                    # before guarding (masks need no substitution: they are
+                    # indexed directly by ``copy_var``).
+                    guard = substitute(guard, {op.loop_var: copy_var})
 
             # Wrap with condition if present
-            if condition is not None:
-                new_condition = substitute(condition, {op.loop_var: copy_var})
-                copy_store = IfThenElse(new_condition, copy_store, None)
+            if guard is not None:
+                copy_store = IfThenElse(guard, copy_store, None)
 
             copy_loop = For(
                 copy_var,
@@ -562,18 +759,20 @@ class DecoupleTypeCastMutator(tirx.PyStmtExprMutator):
 
         return copy_loops
 
-    def _wrap_with_allocations(self, body: Stmt, entries: list[CastEntry]) -> Stmt:
+    def _wrap_with_allocations(self, body: Stmt, entries: list[CastEntry], mask_buffers: list[Buffer] = ()) -> Stmt:
         """Wrap statement with buffer allocations inside a lexical alloc scope.
 
-        The cast buffers are tiny per-site staging arrays. Placing them in an
-        opaque block annotated with `lexical_alloc_scope` makes LowerOpaqueBlock
-        materialize a scope boundary, so StorageRewrite keeps the allocations
-        next to their use site instead of hoisting them to the kernel entry,
-        and codegen emits a `{ ... }` scope with the declarations inside.
+        The cast buffers (and their validity masks) are tiny per-site staging
+        arrays. Placing them in an opaque block annotated with
+        `lexical_alloc_scope` makes LowerOpaqueBlock materialize a scope
+        boundary, so StorageRewrite keeps the allocations next to their use
+        site instead of hoisting them to the kernel entry, and codegen emits a
+        `{ ... }` scope with the declarations inside.
         """
-        if not entries:
+        buffers = [cast_buffer for _, _, cast_buffer in entries] + list(mask_buffers)
+        if not buffers:
             return body
-        alloc_stmts: list[Stmt] = [AllocBuffer(cast_buffer) for _, _, cast_buffer in entries]
+        alloc_stmts: list[Stmt] = [AllocBuffer(buf) for buf in buffers]
         alloc_stmts.append(body)
         block = SBlock(
             iter_vars=[],
@@ -585,9 +784,16 @@ class DecoupleTypeCastMutator(tirx.PyStmtExprMutator):
         )
         return SBlockRealize([], True, block)
 
-    def _replace_access(self, stmt: Stmt, store_entries: list[CastEntry], load_entries: list[CastEntry], loop_var: Var) -> Stmt:
+    def _replace_access(
+        self,
+        stmt: Stmt,
+        store_entries: list[CastEntry],
+        load_entries: list[CastEntry],
+        loop_var: Var,
+        store_masks: list[Buffer | None],
+    ) -> Stmt:
         """Replace memory accesses with cast buffer accesses."""
-        replacer = AccessReplacer(store_entries, load_entries, loop_var)
+        replacer = AccessReplacer(store_entries, load_entries, loop_var, store_masks)
         return replacer.visit_stmt(stmt)
 
 
@@ -599,17 +805,33 @@ class AccessReplacer(tirx.PyStmtExprMutator):
     like a[i] and a[i+32] from the same buffer map to different cast buffers.
     """
 
-    def __init__(self, store_entries: list[CastEntry], load_entries: list[CastEntry], loop_var: Var):
+    def __init__(
+        self,
+        store_entries: list[CastEntry],
+        load_entries: list[CastEntry],
+        loop_var: Var,
+        store_masks: list[Buffer | None],
+    ):
         super().__init__()
         self.store_entries = store_entries
         self.load_entries = load_entries
         self.loop_var = loop_var
+        self.store_masks = store_masks
 
     def visit_buffer_store_(self, op: BufferStore) -> Stmt:
         new_value = self.visit_expr(op.value)
         cast_buf = _find_cast_entry(self.store_entries, op.buffer, list(op.indices))
         if cast_buf is not None:
-            return BufferStore(cast_buf, new_value, [self.loop_var])
+            mask = self.store_masks[_find_cast_entry_index(self.store_entries, op.buffer, list(op.indices))]
+            cast_store = BufferStore(cast_buf, new_value, [self.loop_var])
+            if mask is not None:
+                # Record that this entry's cast local was actually defined on
+                # this lane using a validity mask. The mask store sits at
+                # the exact statement position of the original store, so it
+                # inherits every enclosing branch condition.
+                mask_store = BufferStore(mask, IntImm("int32", 1), [self.loop_var])
+                return SeqStmt([cast_store, mask_store])
+            return cast_store
         if new_value is not op.value:
             return BufferStore(op.buffer, new_value, list(op.indices))
         return op


### PR DESCRIPTION
## Problem and change

`DecoupleTypeCast` re-evaluates the original branch expression during conditional copy-to write-back. An earlier write-back can mutate an input to that expression, flip its value, and copy an uninitialized cast local.

Record compute-time store execution in a per-entry validity mask and make copy-to read that mask. Copy-from keeps its original guards, and unconditional stores remain mask-free.

<sub>Files: `tilelang/transform/decouple_type_cast.py` and `testing/python/transform/test_tilelang_transform_decouple_type_cast.py`.</sub>

## Before and after

On `origin/main`, copy-to may observe a different branch value from the compute stage. This PR preserves root if/else, nested-branch, and multiple-store OR semantics without re-reading mutable guard inputs.

Performance classification: **No performance claim**. This is a correctness fix, and no isolated latency benchmark exists. The mask is emitted only for conditional stores that require it, so unconditional paths keep their previous allocation and copy structure.

## Validation

```text
TILELANG_DISABLE_CACHE=1 python -m pytest \
  testing/python/transform/test_tilelang_transform_decouple_type_cast.py -q
16 passed, 10 skipped
```

The skipped cases are existing CUDA-only codegen/end-to-end tests; all backend-independent transform regressions pass.

## Scope

Backend-independent; does not change type-cast selection or vector-width policy.

## Appendix: combined campaign results (组合 campaign 结果)

The table below describes the complete Apple M2 optimization campaign, not the isolated contribution or acceptance criteria of this PR. Where `origin/main` cannot execute the workload correctly, a numerical speedup versus `main` is undefined; the nearest valid performance baseline is stated explicitly.

| Representative workload | `origin/main` | End-state result | Valid performance comparison |
|---|---|---|---|
| Qwen dense decode | Cannot lower the required Metal reduction | 64-token: `28.3 us/token` synchronized, `23.9 us/token` GPU timeline | `14.5x` versus the valid single-token path (`410.0 us/token`) |
| Fused Qwen/DeepSeek-style MoE block | Required multi-kernel/ABI path is not correct | 9 launches, `16.92 ms` | `1.21x` versus the previous valid 17-launch composed path (`20.53 ms`) |
| Multi-simdgroup bf16 GEMM | t256 staged output is incorrect | Correct t256 execution | Fragment-C `19.86x`; shared-C `14.16x` versus correct t32 paths |
| Software-packed dense fp8 / expert fp4 QMM | Downstream kernels are not present in `main` | `685.7 us` / `697.4 us` | Dense fp8 `16.9x` versus the initial campaign kernel; expert fp4 `26%` faster than its earlier campaign version |
| End-to-end Mega MoE | Complete path is blocked by missing backend prerequisites | T=64 `114.1 ms`; T=1 `16.7 ms` | `80.8%` / `48.0%` lower latency versus the valid full-pipeline baseline |
