### PR TITLE
[CUDA] Add __ldg overloads for 16-bit CUTLASS types

### DIFF
--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -543,9 +543,8 @@ TVM_DLL const Op &warp_reduce_bitor();
  * \brief tilelang intrinsic for CUDA/HIP read-only cache load (__ldg).
  *
  *  This op allows users to explicitly request a non-coherent cached load
- *  from global memory by emitting `__ldg(&ptr[idx])` for 32-bit
- *  element types on supported architectures. It provides a direct way to
- *  leverage the read-only data cache for performance-sensitive loads when
+ *  from global memory by emitting `__ldg(&ptr[idx])`. It provides a direct way
+ *  to leverage the read-only data cache for performance-sensitive loads when
  *  the compiler cannot infer `const __restrict__` automatically.
  *
  *  Usage from TVMScript:

--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -233,6 +233,16 @@ TL_PATCH TL_DEVICE bfloat16_t hexp(const bfloat16_t x) {
   return bfloat16_t(hexp(x.to_nv_bfloat16()));
 }
 
+// CUDA has no __ldg overloads for CUTLASS's 16-bit wrappers. Forward through
+// the bit-compatible native CUDA types.
+TL_PATCH TL_DEVICE half_t __ldg(const half_t *ptr) {
+  return half_t(__ldg(reinterpret_cast<const __half *>(ptr)));
+}
+
+TL_PATCH TL_DEVICE bfloat16_t __ldg(const bfloat16_t *ptr) {
+  return bfloat16_t(__ldg(reinterpret_cast<const __nv_bfloat16 *>(ptr)));
+}
+
 // Pack two half values.
 TL_DEVICE unsigned __pack_half2(const half x, const half y) {
   unsigned v0 = *((unsigned short *)&x);

--- a/testing/python/language/test_tilelang_language_intrinsics_codegen.py
+++ b/testing/python/language/test_tilelang_language_intrinsics_codegen.py
@@ -1,3 +1,6 @@
+import pytest
+import torch
+
 import tilelang
 import tilelang.language as T
 import tilelang.testing
@@ -24,6 +27,29 @@ def test_language_ldg_codegen():
     # We look for the intrinsic call with address-of argument
     assert "__ldg(" in src, "Expected __ldg call in generated CUDA source"
     assert "__ldg(&" in src or "__ldg(&(" in src, "Expected address-of form in __ldg call"
+
+
+def run_ldg_roundtrip(dtype, N=128):
+    @T.prim_func
+    def main(
+        x: T.Tensor((N,), dtype),
+        y: T.Tensor((N,), dtype),
+    ):
+        with T.Kernel(N, threads=32) as pid:
+            y[pid] = T.__ldg(x[pid])
+
+    kernel = tilelang.compile(main, out_idx=[1], target="cuda")
+    # Match the address-of form emitted by CUDA codegen.
+    assert "__ldg(&(" in kernel.get_kernel_source()
+
+    x = torch.randn(N, device="cuda").to(dtype.as_torch())
+    assert torch.equal(kernel(x), x)
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("dtype", [T.float16, T.bfloat16])
+def test_language_ldg_roundtrip(dtype):
+    run_ldg_roundtrip(dtype)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`T.__ldg` failed to compile for `float16` and `bfloat16` buffers. CUDA provides `__ldg` overloads for `__half` and `__nv_bfloat16`, while TileLang represents these scalar types with CUTLASS `half_t` and `bfloat16_t`.

`T.__ldg` already worked for 8-, 32- and 64-bit element types, so 16 bits was the only gap.

## Fix

Add forwarding overloads in `common.h` that reinterpret the bit-compatible wrapper pointers as the native CUDA types and wrap the loaded values back in the CUTLASS types.

The native 16-bit `__ldg` is available on SM60+, so no architecture-specific fallback is needed. Also remove the stale 32-bit-only wording from the intrinsic documentation, which never described the supported set.

## Tested

Added runtime coverage for both `float16` and `bfloat16`. Each kernel loads through `T.__ldg`, stores the result, and compares the output with the input exactly.

Verified locally on a TITAN RTX (`sm_75`) with CUDA 12.4, and cross-compiled for SM60, SM70, SM75, SM80, and SM90.

Fixes #2989

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added CUDA `__ldg` overloads for CUTLASS `half_t` and `bfloat16_t`.
- Reinterpreted pointers as native CUDA 16-bit types for loading, then converted results back to CUTLASS types.
- Updated `T.__ldg` documentation to remove the 32-bit element restriction.
- Added CUDA round-trip tests for `float16` and `bfloat16`.

## Validation

- Tested on a TITAN RTX with CUDA 12.4.
- Cross-compiled for SM60, SM70, SM75, SM80, and SM90.
- Verified exact round trips for both supported dtypes.

## C++ style / lint notes

- The PR changes C++ code but does not change the rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) CI step remains relevant.
- No correctness or build issue is indicated by the changes. Any TLCPP003/TLCPP004 findings are advisory only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->