### PR TITLE
[Analysis] Reject `T.Parallel` indexing of local buffers

### DIFF
--- a/examples/dequantize_gemm/example_dequant_gemm_bf16_mxfp4_cdna4.py
+++ b/examples/dequantize_gemm/example_dequant_gemm_bf16_mxfp4_cdna4.py
@@ -160,7 +160,7 @@ def matmul(
                     dtype=out_dtype,
                 )
 
-                for v in T.Parallel(local_size):
+                for v in T.vectorized(local_size):
                     B_dequantize_local_thread[v] *= Scale_local_thread_exponent[0]
 
                 for v in T.vectorized(0, local_size):

--- a/examples/dequantize_gemm/example_dequant_gemm_bf16_mxfp4_hopper.py
+++ b/examples/dequantize_gemm/example_dequant_gemm_bf16_mxfp4_hopper.py
@@ -253,7 +253,7 @@ def matmul(
                 )
 
                 # Finally, store the dequantized data to shared memory.
-                for v in T.Parallel(local_size):
+                for v in T.vectorized(local_size):
                     B_dequantize_local_thread[v] *= Scale_local_thread_exponent[0]
 
                 for v in T.vectorized(0, local_size):

--- a/testing/python/analysis/test_tilelang_parallel_local_index_checker.py
+++ b/testing/python/analysis/test_tilelang_parallel_local_index_checker.py
@@ -1,0 +1,88 @@
+import pytest
+
+import tilelang
+import tilelang.language as T
+
+
+@tilelang.jit
+def invalid_local_store():
+    @T.prim_func
+    def main():
+        with T.Kernel(1, threads=32):
+            local = T.alloc_local((32,), T.float32)
+            for i in T.Parallel(32):
+                local[i] = T.float32(1)
+
+    return main
+
+
+@tilelang.jit
+def invalid_local_load():
+    @T.prim_func
+    def main(out: T.Tensor((32,), T.float32)):
+        with T.Kernel(1, threads=32):
+            local = T.alloc_local((32,), T.float32)
+            for i in T.serial(32):
+                local[i] = T.float32(i)
+            for i in T.Parallel(32):
+                out[i] = local[i]
+
+    return main
+
+
+@tilelang.jit
+def invalid_nested_parallel_index():
+    @T.prim_func
+    def main():
+        with T.Kernel(1, threads=32):
+            local = T.alloc_local((32,), T.float32)
+            for i, j in T.Parallel(8, 4):
+                local[i * 4 + j] = T.float32(1)
+
+    return main
+
+
+@tilelang.jit
+def valid_constant_local_index():
+    @T.prim_func
+    def main(out: T.Tensor((32,), T.float32)):
+        with T.Kernel(1, threads=32):
+            scale_local = T.alloc_local((1,), T.float32)
+            scale_local[0] = T.float32(2)
+            for i in T.Parallel(32):
+                out[i] = scale_local[0]
+
+    return main
+
+
+@tilelang.jit
+def valid_inner_vectorized_local_index():
+    @T.prim_func
+    def main(out: T.Tensor((32,), T.float32)):
+        with T.Kernel(1, threads=32):
+            scratch = T.alloc_local((4,), T.float32)
+            for i in T.Parallel(32):
+                for lane in T.vectorized(4):
+                    scratch[lane] = T.float32(lane)
+                out[i] = scratch[0]
+
+    return main
+
+
+def test_parallel_local_index_rejected():
+    message = "Local buffer.*is indexed by T.Parallel loop variable"
+    with pytest.raises(ValueError, match=message):
+        invalid_local_store()
+    with pytest.raises(ValueError, match=message):
+        invalid_local_load()
+    with pytest.raises(ValueError, match=message):
+        invalid_nested_parallel_index()
+
+
+def test_parallel_independent_local_index_allowed():
+    valid_constant_local_index()
+    valid_inner_vectorized_local_index()
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/cpu/test_tilelang_cpu_gemm.py
+++ b/testing/python/cpu/test_tilelang_cpu_gemm.py
@@ -33,9 +33,7 @@ def matmul(M, N, K, block_M, block_N, block_K, dtype=T.float16, accum_dtype=T.fl
             for ko in T.Pipelined(K // block_K, num_stages=num_stages):
                 T.copy(A[by * block_M, ko * block_K], A_local)
 
-                # Or Copy with Parallel
-                for k, j in T.Parallel(block_K, block_N):
-                    B_local[k, j] = B[ko * block_K + k, by * block_N + j]
+                T.copy(B[ko * block_K, bx * block_N], B_local)
 
                 for i, j, k in T.grid(block_M, block_N, block_K):
                     C_local[i, j] += A_local[i, k] * B_local[k, j]

--- a/testing/python/llvm/test_tilelang_llvm_gemm.py
+++ b/testing/python/llvm/test_tilelang_llvm_gemm.py
@@ -33,9 +33,7 @@ def matmul(M, N, K, block_M, block_N, block_K, dtype=T.float16, accum_dtype=T.fl
             for ko in T.Pipelined(K // block_K, num_stages=num_stages):
                 T.copy(A[by * block_M, ko * block_K], A_local)
 
-                # Or Copy with Parallel
-                for k, j in T.Parallel(block_K, block_N):
-                    B_local[k, j] = B[ko * block_K + k, by * block_N + j]
+                T.copy(B[ko * block_K, bx * block_N], B_local)
 
                 for i, j, k in T.grid(block_M, block_N, block_K):
                     C_local[i, j] += A_local[i, k] * B_local[k, j]

--- a/tilelang/analysis/__init__.py
+++ b/tilelang/analysis/__init__.py
@@ -3,4 +3,5 @@
 from .ast_printer import ASTPrinter  # noqa: F401
 from .nested_loop_checker import NestedLoopChecker  # noqa: F401
 from .fragment_loop_checker import FragmentLoopChecker  # noqa: F401
+from .parallel_local_index_checker import ParallelLocalIndexChecker  # noqa: F401
 from .layout_visual import LayoutVisual  # noqa: F401

--- a/tilelang/analysis/parallel_local_index_checker.py
+++ b/tilelang/analysis/parallel_local_index_checker.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from tvm import tirx
+from tvm.tirx import Buffer, BufferLoad, BufferStore, For, ForKind, PrimFunc, PyStmtExprVisitor, Var
+from tvm.tirx.transform import prim_func_pass
+
+from tilelang.utils.language import is_local
+
+
+@tirx.functor.visitor
+class _LoopVarUseAnalyzer(PyStmtExprVisitor):
+    """Check whether an expression refers to a particular loop variable."""
+
+    def __init__(self, var: Var) -> None:
+        super().__init__()
+        self.var = var
+        self.used = False
+
+    def visit_var_(self, op: Var) -> None:
+        if op == self.var:
+            self.used = True
+
+
+@tirx.functor.visitor
+class _ParallelLocalIndexCheckVisitor(PyStmtExprVisitor):
+    """Reject local-buffer indices that depend on an enclosing parallel loop."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.parallel_loop_stack: list[For] = []
+
+    def visit_for_(self, op: For) -> None:
+        is_parallel = op.kind == ForKind.PARALLEL
+        if is_parallel:
+            self.parallel_loop_stack.append(op)
+        try:
+            super().visit_for_(op)
+        finally:
+            if is_parallel:
+                self.parallel_loop_stack.pop()
+
+    def _check_indices(self, buffer: Buffer, indices) -> None:
+        if not self.parallel_loop_stack or not is_local(buffer):
+            return
+
+        for loop in self.parallel_loop_stack:
+            analyzer = _LoopVarUseAnalyzer(loop.loop_var)
+            for index in indices:
+                analyzer.visit_expr(index)
+            if analyzer.used:
+                raise ValueError(
+                    "[Tilelang Semantic Check] "
+                    f"Local buffer `{buffer.name}` is indexed by T.Parallel loop variable `{loop.loop_var}`. "
+                    "Local buffers are thread-private and do not participate in parallel layout inference. "
+                    "Use T.serial/T.vectorized/T.unroll for per-thread local indexing, or T.alloc_fragment "
+                    "when the indexed dimension should be distributed across threads."
+                )
+
+    def visit_buffer_load_(self, op: BufferLoad) -> None:
+        self._check_indices(op.buffer, op.indices)
+        super().visit_buffer_load_(op)
+
+    def visit_buffer_store_(self, op: BufferStore) -> None:
+        self._check_indices(op.buffer, op.indices)
+        super().visit_buffer_store_(op)
+
+
+def ParallelLocalIndexChecker():
+    """Reject indexing a thread-private local buffer with a T.Parallel loop variable.
+
+    Local buffers have no cross-thread ownership layout. A local access may
+    appear inside a parallel loop when its index is independent of the parallel
+    loop variables, for example a replicated scalar ``scale_local[0]``. For an
+    indexed per-thread loop, use ``T.serial``, ``T.vectorized``, or ``T.unroll``;
+    for distributed ownership, allocate a fragment instead.
+    """
+
+    def pass_fn(func: PrimFunc, mod, ctx):
+        _ParallelLocalIndexCheckVisitor().visit_stmt(func.body)
+        return func
+
+    return prim_func_pass(pass_fn, opt_level=0)

--- a/tilelang/engine/semantic_check.py
+++ b/tilelang/engine/semantic_check.py
@@ -27,4 +27,5 @@ def PreLowerSemanticCheck(mod: IRModule) -> None:
     if should_enable_ast_print():
         tilelang.analysis.ASTPrinter()(mod)
     tilelang.analysis.NestedLoopChecker()(mod)
+    tilelang.analysis.ParallelLocalIndexChecker()(mod)
     tilelang.analysis.FragmentLoopChecker()(mod)


### PR DESCRIPTION
## Summary

- add a pre-lowering semantic checker that rejects local-buffer indices depending on enclosing T.Parallel loop variables
- keep parallel-independent local accesses valid and provide guidance to use serial/vectorized/unroll loops or fragment buffers
- migrate affected dequant GEMM examples and CPU/LLVM GEMM tests to valid indexing/copy patterns
- add regression coverage for local loads, stores, multidimensional parallel loops, constant indices, and inner vectorized loops

## Motivation

Local buffers are thread-private and do not participate in parallel layout inference. Indexing them with T.Parallel loop variables gives the loop a cross-thread ownership meaning that local storage cannot represent. Rejecting this pattern before backend lowering produces an actionable error instead of allowing undefined lowering behavior.

## Tests

- python -m pytest testing/python/analysis -q (10 passed)
- python -m pytest testing/python/cpu/test_tilelang_cpu_gemm.py::test_matmul_codegen -q (1 passed)
- Hopper MXFP4 dequant GEMM JIT compilation and numerical correctness on H100 (passed)
- pre-commit hooks, Ruff, and git diff --check (passed)

LLVM codegen was skipped because LLVM is not enabled in the local build. CDNA4 runtime validation requires a gfx950 environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `ParallelLocalIndexChecker` to pre-lowering semantic validation.
- Rejects local-buffer loads and stores indexed by enclosing `T.Parallel` variables.
- Allows constant indices, parallel-independent indices, non-local buffers, and inner vectorized loops.
- Updated dequantization examples to use `T.vectorized`.
- Updated CPU and LLVM GEMM tests to use `T.copy`.
- Added regression tests for valid and invalid indexing patterns.

## Validation

- Analysis tests passed.
- CPU GEMM code generation passed.
- Hopper MXFP4 dequantization compilation and numerical tests passed.
- Pre-commit hooks, Ruff, and diff checks passed.
- LLVM code generation and CDNA4 runtime validation were not run because of environment limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->