### PR TITLE
[Lang][Reducer] Support loop-scoped epochs and legacy default allocations

### DIFF
--- a/src/op/reducer.h
+++ b/src/op/reducer.h
@@ -70,8 +70,10 @@ inline bool IsReducerV2Buffer(const Buffer &buffer) {
 
 /// T.reducer_init(acc, init=None): open the epoch. The physical partials
 /// always start from the combine identity; the optional `init` value is a
-/// logical starting value, combined exactly once per logical output at
-/// finalize time (so physical replication can never multiply it).
+/// logical starting value, evaluated (captured) at the init site and
+/// combined exactly once per logical output at finalize time (so physical
+/// replication can never multiply it, and a loop-variant init expression
+/// keeps the value the epoch opened with).
 /// args[0] = tl.region(acc, "w"), optional args[1] = init value.
 class ReducerInitOpNode : public TileOperatorNode {
 public:

--- a/src/transform/canonicalize_legacy_reducer.cc
+++ b/src/transform/canonicalize_legacy_reducer.cc
@@ -9,6 +9,13 @@
  *   T.finalize_reducer(acc)           # in-place
  *   ... reads of acc ...
  *
+ * The same legacy syntax is also accepted on a v2 allocation
+ * (T.alloc_reducer without `replication`, the pre-v2 default): a
+ * `local.reducer` buffer that is never touched by any first-class v2 op
+ * is canonicalized under the same whitelist, keeping code written against
+ * the old default compiling. Mixing v2 ops and legacy syntax on one buffer
+ * is not canonicalized and fails in VerifyReducerEpoch.
+ *
  * Canonical v2 form produced by this pass:
  *   local.reducer allocation + reducer_info_v2 annotation
  *   tl.reducer_init(acc)
@@ -43,6 +50,7 @@
 
 #include <optional>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "../op/builtin.h"
 #include "../op/fill.h"
@@ -91,10 +99,44 @@ std::optional<double> TryConstValue(PrimExpr e) {
   return std::nullopt;
 }
 
+/*! \brief Collect the buffer vars referenced by any first-class v2 reducer
+ *  op. A v2-allocated reducer outside this set only ever appears in legacy
+ *  syntax and is eligible for canonicalization. */
+class ReducerV2OpUseCollector : public StmtExprVisitor {
+public:
+  static std::unordered_set<const VarNode *> Collect(const Stmt &body) {
+    ReducerV2OpUseCollector collector;
+    collector.VisitStmt(body);
+    return std::move(collector.used_);
+  }
+
+private:
+  void VisitExpr_(const CallNode *op) final {
+    if (op->op.same_as(ReducerInitOp::Get()) ||
+        op->op.same_as(FinalizeReducerV2Op::Get())) {
+      if (auto call = op->args[0].as<CallNode>()) {
+        if (call->op.same_as(region())) {
+          if (auto load = call->args[0].as<BufferLoadNode>()) {
+            used_.insert(load->buffer->data.get());
+          }
+        }
+      }
+    } else if (op->op.same_as(reducer_update())) {
+      if (auto load = op->args[0].as<BufferLoadNode>()) {
+        used_.insert(load->buffer->data.get());
+      }
+    }
+    StmtExprVisitor::VisitExpr_(op);
+  }
+
+  std::unordered_set<const VarNode *> used_;
+};
+
 class LegacyReducerCanonicalizer : public StmtExprMutator {
 public:
   static PrimFunc Substitute(PrimFunc f) {
     LegacyReducerCanonicalizer canonicalizer;
+    canonicalizer.v2_op_used_ = ReducerV2OpUseCollector::Collect(f->body);
     PrimFuncNode *fptr = f.CopyOnWrite();
     fptr->body = canonicalizer.VisitStmt(f->body);
     return f;
@@ -110,6 +152,7 @@ private:
     ReducerV2OpType op;
     Optional<PrimExpr> seed;
     Phase phase{Phase::kAllocated};
+    bool was_v2{false}; // v2 allocation used with legacy syntax only
   };
 
   // ---- allocation & annotation rewrite ------------------------------------
@@ -123,20 +166,45 @@ private:
                            ParseReducerV2OpType(info.Get("op").value()));
       }
     }
-    for (const auto &buffer : op->alloc_buffers) {
-      auto it = legacy_op_.find(buffer->data.get());
-      if (it == legacy_op_.end()) {
-        continue;
+    // A v2 allocation never touched by a first-class v2 op carries the old
+    // default of pre-v2 T.alloc_reducer: canonicalize its legacy syntax too.
+    if (auto anno = op->annotations.Get(attr::kReducerInfoV2)) {
+      auto map = anno.value().as<Map<Var, Map<String, Any>>>();
+      ICHECK(map) << "malformed reducer_info_v2 annotation";
+      for (const auto &[var, info] : map.value()) {
+        if (v2_op_used_.count(var.get())) {
+          continue;
+        }
+        auto op_str = info.Get("op");
+        ICHECK(op_str) << "reducer_info_v2 for `" << var
+                       << "` is missing the combine op";
+        legacy_v2_op_.emplace(
+            var.get(), ParseReducerV2OpType(op_str.value().cast<String>()));
       }
+    }
+    for (const auto &buffer : op->alloc_buffers) {
       LegacyReducer entry;
+      auto it = legacy_op_.find(buffer->data.get());
+      if (it != legacy_op_.end()) {
+        // v1 allocation: retype the handle into the local.reducer scope.
+        entry.op = it->second;
+        Var acc_var(buffer->data->name_hint,
+                    PointerType(PrimType(buffer->dtype), "local.reducer"));
+        entry.acc =
+            Buffer(acc_var, buffer->dtype, buffer->shape, buffer->strides,
+                   buffer->elem_offset, buffer->name, buffer->data_alignment,
+                   buffer->offset_factor, buffer->buffer_type);
+      } else {
+        auto v2_it = legacy_v2_op_.find(buffer->data.get());
+        if (v2_it == legacy_v2_op_.end()) {
+          continue;
+        }
+        // v2 allocation used with legacy syntax only: keep the buffer.
+        entry.op = v2_it->second;
+        entry.acc = buffer;
+        entry.was_v2 = true;
+      }
       entry.old_buffer = buffer;
-      entry.op = it->second;
-      Var acc_var(buffer->data->name_hint,
-                  PointerType(PrimType(buffer->dtype), "local.reducer"));
-      entry.acc =
-          Buffer(acc_var, buffer->dtype, buffer->shape, buffer->strides,
-                 buffer->elem_offset, buffer->name, buffer->data_alignment,
-                 buffer->offset_factor, buffer->buffer_type);
       Var dst_var(buffer->data->name_hint + "_result",
                   PointerType(PrimType(buffer->dtype), "local.fragment"));
       entry.dst = Buffer(dst_var, buffer->dtype, buffer->shape, buffer->strides,
@@ -169,6 +237,12 @@ private:
           << "` has no T.finalize_reducer; cannot canonicalize.";
       new_allocs.push_back(entry.acc);
       new_allocs.push_back(entry.dst);
+      changed = true;
+      if (entry.was_v2) {
+        // The allocation and its reducer_info_v2 entry are already correct;
+        // only the finalize destination is new.
+        continue;
+      }
       Map<String, Any> info;
       switch (entry.op) {
       case ReducerV2OpType::kSum:
@@ -184,7 +258,6 @@ private:
         LOG(FATAL) << "legacy (v1) reducers only support sum/max/min";
       }
       v2_info.Set(entry.acc->data, info);
-      changed = true;
     }
     if (changed) {
       p_result->alloc_buffers = new_allocs;
@@ -373,6 +446,8 @@ private:
   }
 
   std::unordered_map<const VarNode *, ReducerV2OpType> legacy_op_;
+  std::unordered_map<const VarNode *, ReducerV2OpType> legacy_v2_op_;
+  std::unordered_set<const VarNode *> v2_op_used_;
   std::unordered_map<const VarNode *, LegacyReducer> reducers_;
 };
 

--- a/src/transform/reducer_plan_materialize.cc
+++ b/src/transform/reducer_plan_materialize.cc
@@ -854,6 +854,12 @@ private:
     Fragment layout;
     ReducerV2OpType op;
     Optional<PrimExpr> seed;
+    // Per-thread register capturing the seed expression at the init site.
+    // The epoch may reopen once per iteration of an enclosing serial loop,
+    // and the seed expression (e.g. a running maximum) may be overwritten
+    // between init and finalize — the finalize-time combine must read the
+    // value the epoch opened with.
+    Buffer seed_buffer;
     bool narrow{false};
     std::vector<std::pair<int, int>> steps;
     // Packed accumulation: updates RMW `packed_buffer[slot, lane_var % 2]`;
@@ -911,6 +917,10 @@ private:
           new_allocs.push_back(it->second.packed_buffer);
           layout_map.Set(it->second.packed_buffer, it->second.packed_layout);
         }
+        if (it->second.seed_buffer.defined()) {
+          // Plain per-thread register; no fragment layout to publish.
+          new_allocs.push_back(it->second.seed_buffer);
+        }
         changed = true;
       } else {
         new_allocs.push_back(buffer);
@@ -964,18 +974,33 @@ private:
     const auto *var = old_buffer->data.get();
     ICHECK(reducer_info_.count(var))
         << "reducer_init on unknown reducer `" << old_buffer << "`";
-    ICHECK(!plans_.count(var))
-        << "double reducer_init on `" << old_buffer
-        << "` (should have been rejected by VerifyReducerEpoch)";
+    if (plans_.count(var)) {
+      // VerifyReducerEpoch guarantees one epoch site per allocation in the
+      // code the user wrote, but software pipelining / unrolling may have
+      // multi-versioned the enclosing loop since, duplicating the site.
+      // Every copy shares the allocation's plan; each emits its own
+      // capture+fill.
+      return EmitInitStmts(plans_.at(var), call);
+    }
 
     Plan plan;
     plan.old_buffer = old_buffer;
     const auto &info = reducer_info_.at(var);
     plan.op = ParseReducerV2OpType(info.Get("op").value().cast<String>());
     if (call->args.size() >= 2) {
-      // Logical starting value from T.reducer_init(acc, init): combined
-      // exactly once per logical output at finalize time.
-      plan.seed = call->args[1];
+      // Logical starting value from T.reducer_init(acc, init): captured
+      // into a per-thread register here at the init site, and combined
+      // exactly once per logical output at finalize time. Capturing (rather
+      // than re-evaluating at finalize) keeps a loop-variant seed correct
+      // when the epoch sits inside a serial loop.
+      Var seed_var(old_buffer->data->name_hint + "_seed",
+                   PointerType(PrimType(old_buffer->dtype), "local"));
+      plan.seed_buffer =
+          Buffer(seed_var, old_buffer->dtype, {IntImm(DataType::Int(32), 1)},
+                 /*strides=*/{}, old_buffer->elem_offset,
+                 old_buffer->name + "_seed", old_buffer->data_alignment,
+                 old_buffer->offset_factor, old_buffer->buffer_type);
+      plan.seed = BufferLoad(plan.seed_buffer, {make_zero(DataType::Int(32))});
     }
 
     auto narrow_it = narrow_decisions_.find(var);
@@ -1035,17 +1060,32 @@ private:
                  old_buffer->offset_factor, old_buffer->buffer_type);
     }
     plans_.emplace(var, plan);
-    const Plan &stored = plans_.at(var);
+    return EmitInitStmts(plans_.at(var), call);
+  }
 
+  /*! \brief The statements a reducer_init site lowers to: the identity fill
+   *  of the physical partials, preceded by the seed capture when the epoch
+   *  declares a starting value. */
+  Stmt EmitInitStmts(const Plan &stored, const CallNode *call) {
     // Every participant starts from the combine identity; the seed is
-    // combined exactly once at finalize. Packed plans accumulate into the
-    // lane buffer (`new_buffer` is fully written by the finalize fold).
+    // captured here and combined exactly once at finalize. Packed plans
+    // accumulate into the lane buffer (`new_buffer` is fully written by the
+    // finalize fold).
     const Buffer &init_target =
         stored.packed ? stored.packed_buffer : stored.new_buffer;
     PrimExpr identity = ReducerV2Identity(stored.op, init_target->dtype);
-    return Evaluate(
-        Call(DataType::Handle(), Fill::Get(),
-             {MakeFullRegion(init_target, kAccessWrite), identity}));
+    Stmt fill =
+        Evaluate(Call(DataType::Handle(), Fill::Get(),
+                      {MakeFullRegion(init_target, kAccessWrite), identity}));
+    if (stored.seed_buffer.defined()) {
+      ICHECK_GE(call->args.size(), 2)
+          << "reducer_init on `" << stored.old_buffer
+          << "`: duplicated epoch sites disagree about the seed";
+      Stmt capture = BufferStore(stored.seed_buffer, VisitExpr(call->args[1]),
+                                 {make_zero(DataType::Int(32))});
+      return SeqStmt({capture, fill});
+    }
+    return fill;
   }
 
   Stmt MaterializeUpdate(const CallNode *call) {

--- a/src/transform/verify_reducer_epoch.cc
+++ b/src/transform/verify_reducer_epoch.cc
@@ -4,9 +4,15 @@
  *
  * Enforced rules (first version):
  *   - every `local.reducer` allocation has exactly one reducer_init,
- *     zero or more reducer_update, and exactly one finalize_reducer;
- *   - init and finalize execute exactly once: they may not appear inside
- *     any loop or conditional;
+ *     zero or more reducer_update, and exactly one finalize_reducer
+ *     (statically: one epoch site per allocation);
+ *   - init and finalize share the exact same control-flow scope (the same
+ *     stack of enclosing serial loops and conditional branches), so every
+ *     dynamic execution of the init is closed by exactly one finalize in
+ *     the same iteration. Neither may appear inside a `T.Parallel` loop.
+ *     An epoch nested in a serial loop reopens once per iteration; the
+ *     enclosing control flow must be thread-uniform, as with any other
+ *     collective tile op;
  *   - updates appear only between init and finalize, and only inside a
  *     `T.Parallel` loop;
  *   - the reducer is opaque outside the three first-class ops: ordinary
@@ -28,6 +34,7 @@
 #include <sstream>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include "../op/builtin.h"
 #include "../op/reducer.h"
@@ -93,25 +100,45 @@ private:
 
   // ---- control-flow tracking ---------------------------------------------
 
+  // One frame per enclosing loop or conditional branch. `branch`
+  // distinguishes the then (0) and else (1) arms of a conditional: an epoch
+  // opened in one arm may not close in the other.
+  struct ContextFrame {
+    const Object *node;
+    int branch;
+    bool operator==(const ContextFrame &other) const {
+      return node == other.node && branch == other.branch;
+    }
+  };
+
   void VisitStmt_(const ForNode *op) final {
     bool is_parallel = op->kind == ForKind::kParallel;
     parallel_depth_ += is_parallel;
-    loop_depth_ += 1;
-    StmtExprVisitor::VisitStmt_(op);
-    loop_depth_ -= 1;
+    VisitExpr(op->min);
+    VisitExpr(op->extent);
+    ctx_stack_.push_back({op, 0});
+    VisitStmt(op->body);
+    ctx_stack_.pop_back();
     parallel_depth_ -= is_parallel;
   }
 
   void VisitStmt_(const IfThenElseNode *op) final {
-    if_depth_ += 1;
-    StmtExprVisitor::VisitStmt_(op);
-    if_depth_ -= 1;
+    VisitExpr(op->condition);
+    ctx_stack_.push_back({op, 0});
+    VisitStmt(op->then_case);
+    ctx_stack_.pop_back();
+    if (op->else_case) {
+      ctx_stack_.push_back({op, 1});
+      VisitStmt(op->else_case.value());
+      ctx_stack_.pop_back();
+    }
   }
 
   void VisitStmt_(const WhileNode *op) final {
-    loop_depth_ += 1;
-    StmtExprVisitor::VisitStmt_(op);
-    loop_depth_ -= 1;
+    VisitExpr(op->condition);
+    ctx_stack_.push_back({op, 0});
+    VisitStmt(op->body);
+    ctx_stack_.pop_back();
   }
 
   // ---- reducer op events / opaque-access enforcement ---------------------
@@ -120,7 +147,11 @@ private:
     if (op->op.same_as(ReducerInitOp::Get())) {
       Var var = RegionArgBufferVar(op->args[0], "reducer_init");
       RequireReducer(var, "reducer_init");
-      RequireStraightLine(var, "T.reducer_init");
+      if (parallel_depth_ > 0) {
+        LOG(FATAL) << "T.reducer_init on reducer `" << var
+                   << "` may not appear inside a T.Parallel loop.";
+      }
+      epoch_ctx_[var.get()] = ctx_stack_;
       if (op->args.size() >= 2) {
         const Buffer &buffer = var_to_buffer_.at(var.get());
         ICHECK(op->args[1].dtype() == buffer->dtype)
@@ -177,7 +208,14 @@ private:
       Var var = RegionArgBufferVar(op->args[0], "finalize_reducer");
       Var dst_var = RegionArgBufferVar(op->args[1], "finalize_reducer");
       RequireReducer(var, "finalize_reducer");
-      RequireStraightLine(var, "T.finalize_reducer");
+      auto ctx_it = epoch_ctx_.find(var.get());
+      if (ctx_it != epoch_ctx_.end() && !(ctx_it->second == ctx_stack_)) {
+        LOG(FATAL) << "T.finalize_reducer on reducer `" << var
+                   << "` is not in the same loop/branch scope as its "
+                      "T.reducer_init: a reduction epoch must open and close "
+                      "within the same iteration of every enclosing loop and "
+                      "the same conditional branch.";
+      }
       if (info_.count(dst_var.get())) {
         LOG(FATAL) << "T.finalize_reducer destination `" << dst_var
                    << "` must be an ordinary fragment, not a reducer.";
@@ -249,20 +287,12 @@ private:
     }
   }
 
-  void RequireStraightLine(const Var &var, const char *who) const {
-    if (loop_depth_ > 0 || if_depth_ > 0) {
-      LOG(FATAL) << who << " on reducer `" << var
-                 << "` must execute exactly once and may not appear inside "
-                    "a loop or conditional.";
-    }
-  }
-
   std::unordered_map<const VarNode *, Map<String, Any>> info_;
   std::unordered_map<const VarNode *, Buffer> var_to_buffer_;
   std::unordered_map<Var, EpochState, ObjectPtrHash, ObjectPtrEqual> state_;
+  std::unordered_map<const VarNode *, std::vector<ContextFrame>> epoch_ctx_;
+  std::vector<ContextFrame> ctx_stack_;
   int parallel_depth_ = 0;
-  int loop_depth_ = 0;
-  int if_depth_ = 0;
 };
 
 } // namespace

--- a/testing/python/language/test_tilelang_language_reduce.py
+++ b/testing/python/language/test_tilelang_language_reduce.py
@@ -802,6 +802,82 @@ def test_finalize_reducer_mixed_parallel_extents():
     torch.testing.assert_close(C, (A.sum() + B.sum()).reshape(1), atol=0, rtol=0)
 
 
+def test_finalize_reducer_epoch_inside_pipelined_loop():
+    """Legacy online-softmax: a full v1 epoch (fill / RMW updates / in-place
+    finalize / direct reads) reopens once per iteration of a T.Pipelined
+    tile loop, seeding the max from the running maximum."""
+    K, BLOCK_K, threads = 512, 128, 128
+
+    @T.prim_func
+    def kernel(A: T.Tensor((K,), T.float32), B: T.Tensor((1,), T.float32)):
+        with T.Kernel(1, threads=threads):
+            a_shared = T.alloc_shared((BLOCK_K,), T.float32)
+            a_frag = T.alloc_fragment((BLOCK_K,), T.float32)
+            running_max = T.alloc_fragment((1,), T.float32)
+            running_sum = T.alloc_fragment((1,), T.float32)
+            running_max[0] = -T.infinity(T.float32)
+            running_sum[0] = 0.0
+            for k_tile in T.Pipelined(T.ceildiv(K, BLOCK_K), num_stages=2):
+                T.copy(A[k_tile * BLOCK_K], a_shared)
+                T.copy(a_shared, a_frag)
+
+                new_max = T.alloc_reducer((1,), T.float32, op="max", replication="all")
+                T.fill(new_max, running_max[0])
+                for i in T.Parallel(BLOCK_K):
+                    new_max[0] = T.max(new_max[0], a_frag[i])
+                T.finalize_reducer(new_max)
+
+                new_sum = T.alloc_reducer((1,), T.float32, replication="all")
+                T.fill(new_sum, 0.0)
+                for i in T.Parallel(BLOCK_K):
+                    new_sum[0] += T.exp(a_frag[i] - new_max[0])
+                T.finalize_reducer(new_sum)
+
+                running_sum[0] = T.exp(running_max[0] - new_max[0]) * running_sum[0] + new_sum[0]
+                running_max[0] = new_max[0]
+            if T.get_thread_binding() == 0:
+                B[0] = T.log(running_sum[0]) + running_max[0]
+
+    A = torch.randn(K, dtype=torch.float32, device="cuda")
+    B = tl.compile(kernel, out_idx=-1, pass_configs=_COMPILE_FLAGS)(A)
+    torch.testing.assert_close(B, torch.logsumexp(A, dim=0).reshape(1), atol=1e-4, rtol=1e-4)
+
+
+def test_finalize_reducer_default_alloc_v1_syntax():
+    """Pre-v2 default: T.alloc_reducer without `replication` used with v1
+    syntax (T.clear / `acc[i] +=` / in-place finalize / direct reads) must
+    keep compiling — the buffer is v2-allocated but never touched by a v2
+    op, so the legacy shim canonicalizes it."""
+    BLOCK, K, threads = 64, 8, 128
+
+    @T.prim_func
+    def kernel(
+        G: T.Tensor((BLOCK, K), T.float32),
+        Y: T.Tensor((BLOCK, K), T.float32),
+        O: T.Tensor((BLOCK, K), T.float32),
+    ):
+        with T.Kernel(1, threads=threads):
+            g_frag = T.alloc_fragment((BLOCK, K), T.float32)
+            y_frag = T.alloc_fragment((BLOCK, K), T.float32)
+            out_frag = T.alloc_fragment((BLOCK, K), T.float32)
+            reducer = T.alloc_reducer((BLOCK,), T.float32)
+            T.copy(G, g_frag)
+            T.copy(Y, y_frag)
+            T.clear(reducer)
+            for i, j in T.Parallel(BLOCK, K):
+                reducer[i] += g_frag[i, j] * y_frag[i, j]
+            T.finalize_reducer(reducer)
+            for i, j in T.Parallel(BLOCK, K):
+                out_frag[i, j] = g_frag[i, j] - reducer[i]
+            T.copy(out_frag, O)
+
+    G = torch.randn(BLOCK, K, dtype=torch.float32, device="cuda")
+    Y = torch.randn(BLOCK, K, dtype=torch.float32, device="cuda")
+    O = tl.compile(kernel, out_idx=-1, pass_configs=_COMPILE_FLAGS)(G, Y)
+    ref = G - (G * Y).sum(dim=1, keepdim=True)
+    torch.testing.assert_close(O, ref, atol=1e-4, rtol=1e-4)
+
+
 # (batch, exc_type, match)
 FINALIZE_REDUCER_INVALID_CASES = [
     (0, ValueError, "batch must be >= 1"),

--- a/testing/python/language/test_tilelang_language_reducer_v2.py
+++ b/testing/python/language/test_tilelang_language_reducer_v2.py
@@ -822,5 +822,165 @@ def test_reject_double_init():
     _compile_expect_error(make, "double T.reducer_init")
 
 
+# ---------------------------------------------------------------------------
+# Epochs inside thread-uniform control flow (reopen once per iteration)
+# ---------------------------------------------------------------------------
+
+
+def test_epoch_inside_serial_loop_online_softmax():
+    """A full epoch (init/update/finalize) inside a serial tile loop reopens
+    once per iteration — the online-softmax rescale pattern. The max epoch
+    seeds from the running maximum, a loop-variant expression."""
+    K, BLOCK_K, threads = 512, 128, 128
+
+    @T.prim_func
+    def kernel(A: T.Tensor((K,), T.float32), B: T.Tensor((1,), T.float32)):
+        with T.Kernel(1, threads=threads):
+            a_frag = T.alloc_fragment((BLOCK_K,), T.float32)
+            running_max = T.alloc_fragment((1,), T.float32)
+            running_sum = T.alloc_fragment((1,), T.float32)
+            running_max[0] = -T.infinity(T.float32)
+            running_sum[0] = 0.0
+            for k_tile in T.serial(T.ceildiv(K, BLOCK_K)):
+                T.copy(A[k_tile * BLOCK_K], a_frag)
+                new_max = T.alloc_reducer((1,), T.float32, op="max")
+                T.reducer_init(new_max, running_max[0])
+                for i in T.Parallel(BLOCK_K):
+                    T.reducer_update(new_max[0], a_frag[i])
+                max_result = T.alloc_fragment((1,), T.float32)
+                T.finalize_reducer(new_max, max_result)
+
+                new_sum = T.alloc_reducer((1,), T.float32, op="sum")
+                T.reducer_init(new_sum)
+                for i in T.Parallel(BLOCK_K):
+                    T.reducer_update(new_sum[0], T.exp(a_frag[i] - max_result[0]))
+                sum_result = T.alloc_fragment((1,), T.float32)
+                T.finalize_reducer(new_sum, sum_result)
+
+                running_sum[0] = T.exp(running_max[0] - max_result[0]) * running_sum[0] + sum_result[0]
+                running_max[0] = max_result[0]
+            if T.get_thread_binding() == 0:
+                B[0] = T.log(running_sum[0]) + running_max[0]
+
+    A = torch.randn(K, dtype=torch.float32, device="cuda")
+    B = tl.compile(kernel, out_idx=-1)(A)
+    torch.testing.assert_close(B, torch.logsumexp(A, dim=0).reshape(1), atol=1e-4, rtol=1e-4)
+
+
+def test_epoch_inside_pipelined_loop():
+    """A full epoch inside a T.Pipelined body: the per-iteration collective
+    must survive software pipelining. Warp specialization is disabled, as
+    for every reducer-under-pipelining test."""
+    K, BLOCK_K, threads = 512, 128, 128
+
+    @T.prim_func
+    def kernel(A: T.Tensor((K,), T.float32), B: T.Tensor((1,), T.float32)):
+        with T.Kernel(1, threads=threads):
+            a_shared = T.alloc_shared((BLOCK_K,), T.float32)
+            a_frag = T.alloc_fragment((BLOCK_K,), T.float32)
+            running_max = T.alloc_fragment((1,), T.float32)
+            running_max[0] = -T.infinity(T.float32)
+            for k_tile in T.Pipelined(T.ceildiv(K, BLOCK_K), num_stages=2):
+                T.copy(A[k_tile * BLOCK_K], a_shared)
+                T.copy(a_shared, a_frag)
+                new_max = T.alloc_reducer((1,), T.float32, op="max")
+                T.reducer_init(new_max, running_max[0])
+                for i in T.Parallel(BLOCK_K):
+                    T.reducer_update(new_max[0], a_frag[i])
+                max_result = T.alloc_fragment((1,), T.float32)
+                T.finalize_reducer(new_max, max_result)
+                running_max[0] = max_result[0]
+            if T.get_thread_binding() == 0:
+                B[0] = running_max[0]
+
+    A = torch.randn(K, dtype=torch.float32, device="cuda")
+    B = tl.compile(
+        kernel,
+        out_idx=-1,
+        pass_configs={tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True},
+    )(A)
+    torch.testing.assert_close(B, A.max().reshape(1), atol=0, rtol=0)
+
+
+def test_epoch_inside_uniform_conditional():
+    """A full epoch inside a block-uniform conditional: every thread of the
+    block takes the same branch, so the collective stays barrier-uniform."""
+    extent, threads = 8, 128
+
+    @T.prim_func
+    def kernel(A: T.Tensor((extent,), T.float32), B: T.Tensor((2,), T.float32)):
+        with T.Kernel(2, threads=threads) as bx:
+            src = T.alloc_fragment((extent,), T.float32)
+            T.copy(A, src)
+            result = T.alloc_fragment((1,), T.float32)
+            result[0] = 0.0
+            if bx == 0:
+                acc = T.alloc_reducer((1,), T.float32, op="sum")
+                T.reducer_init(acc)
+                for i in T.Parallel(extent):
+                    T.reducer_update(acc[0], src[i])
+                T.finalize_reducer(acc, result)
+            if T.get_thread_binding() == 0:
+                B[bx] = result[0]
+
+    A = torch.arange(1, extent + 1, dtype=torch.float32, device="cuda")
+    B = tl.compile(kernel, out_idx=-1)(A)
+    expected = torch.stack([A.sum(), torch.zeros((), device="cuda")])
+    torch.testing.assert_close(B, expected, atol=0, rtol=0)
+
+
+def test_seed_captured_at_init_site():
+    """The T.reducer_init starting value is evaluated at the init site:
+    overwriting the expression's source before finalize must not change the
+    epoch's logical starting value."""
+    extent, threads = 8, 128
+
+    @T.prim_func
+    def kernel(A: T.Tensor((extent,), T.float32), B: T.Tensor((1,), T.float32)):
+        with T.Kernel(1, threads=threads):
+            src = T.alloc_fragment((extent,), T.float32)
+            T.copy(A, src)
+            seed = T.alloc_fragment((1,), T.float32)
+            seed[0] = 5.0
+            acc = T.alloc_reducer((1,), T.float32, op="sum")
+            T.reducer_init(acc, seed[0])
+            seed[0] = 100.0  # after init, before finalize: must not matter
+            for i in T.Parallel(extent):
+                T.reducer_update(acc[0], src[i])
+            result = T.alloc_fragment((1,), T.float32)
+            T.finalize_reducer(acc, result)
+            if T.get_thread_binding() == 0:
+                B[0] = result[0]
+
+    A = torch.arange(1, extent + 1, dtype=torch.float32, device="cuda")
+    B = tl.compile(kernel, out_idx=-1)(A)
+    torch.testing.assert_close(B, (A.sum() + 5.0).reshape(1), atol=0, rtol=0)
+
+
+def test_reject_finalize_in_different_scope():
+    """An epoch must open and close in the same control-flow scope: init
+    inside a serial loop with the finalize outside is rejected."""
+
+    def make():
+        @T.prim_func
+        def kernel(A: T.Tensor((8,), T.float32), B: T.Tensor((1,), T.float32)):
+            with T.Kernel(1, threads=128):
+                src = T.alloc_fragment((8,), T.float32)
+                T.copy(A, src)
+                acc = T.alloc_reducer((1,), T.float32, op="sum")
+                for _ in T.serial(4):
+                    T.reducer_init(acc)
+                    for i in T.Parallel(8):
+                        T.reducer_update(acc[0], src[i])
+                result = T.alloc_fragment((1,), T.float32)
+                T.finalize_reducer(acc, result)
+                if T.get_thread_binding() == 0:
+                    B[0] = result[0]
+
+        return kernel
+
+    _compile_expect_error(make, "same loop/branch scope")
+
+
 if __name__ == "__main__":
     tilelang.testing.main()

--- a/tilelang/language/reduce_op.py
+++ b/tilelang/language/reduce_op.py
@@ -351,16 +351,21 @@ def reduce_bitxor(
 def reducer_init(reducer: tirx.Buffer, init=None) -> tirx.PrimExpr:
     """Open a reducer epoch, optionally with a logical starting value.
 
-    Must be called exactly once per `T.alloc_reducer` allocation, before any
-    `T.reducer_update`. Without `init`, the reduction starts from the combine
-    identity (sum -> 0, max -> dtype lowest, min -> dtype highest, bitand ->
-    all ones, bitor/bitxor -> 0).
+    Must appear exactly once per `T.alloc_reducer` allocation, before any
+    `T.reducer_update`. The whole epoch (init, updates, finalize) may sit
+    inside thread-uniform serial loops or conditionals — the epoch then
+    reopens once per dynamic execution — but init and finalize must share
+    the same enclosing loop/branch scope. Without `init`, the reduction
+    starts from the combine identity (sum -> 0, max -> dtype lowest, min ->
+    dtype highest, bitand -> all ones, bitor/bitxor -> 0).
 
     `init` is a LOGICAL starting value: the result is as if one extra
     contribution `init` were combined into every logical output, exactly
     once. It is not a physical fill — physical partials always start from
-    the identity, and the compiler combines `init` once per logical output
-    at finalize time, so physical replication can never multiply it.
+    the identity, and the compiler captures `init` at the init site and
+    combines it once per logical output at finalize time, so physical
+    replication can never multiply it and later writes to buffers the
+    expression reads cannot change the epoch's starting value.
 
     Args:
         reducer (tirx.Buffer): Handle returned by `T.alloc_reducer`.


### PR DESCRIPTION
## Summary

- Allow reducer epochs to reopen in thread-uniform serial loops and conditional branches while requiring init and finalize to share the same structural scope.
- Preserve the value of loop-varying reducer seeds at the init site and keep legacy reducer syntax working with default `T.alloc_reducer` allocations.

## Changes

- Track enclosing loop and conditional-branch contexts in `VerifyReducerEpoch`, reject init inside `T.Parallel`, and diagnose epochs that close in a different scope.
- Capture optional init seeds in a per-thread buffer and reuse a reducer materialization plan when software pipelining duplicates an init site.
- Extend legacy canonicalization to v2-annotated reducer buffers that never use first-class v2 operations, while leaving mixed syntax to the verifier.
- Add coverage for online softmax in serial and pipelined loops, block-uniform conditionals, init-time seed capture, mismatched scopes, and default-allocation compatibility.

## Validation

- `./format.sh`
- `cmake --build build -j$(nproc)`
- `python -m pytest testing/python/language/test_tilelang_language_reduce.py testing/python/language/test_tilelang_language_reducer_v2.py -x`

## Notes

- Conditional and serial-loop scopes containing reducer epochs must be thread-uniform; the verifier enforces structural scope matching and excludes `T.Parallel` nesting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added reducer epoch support inside serial loops and conditional branches.
- Required reducer initialization and finalization to use the same structural scope.
- Kept reducer initialization prohibited inside `T.Parallel`.
- Captured loop-varying initialization seeds at the initialization site.
- Reused reducer materialization plans for duplicated initialization sites.
- Added legacy syntax support for compatible v2 reducer allocations.
- Added coverage for serial and pipelined loops, conditionals, seed capture, scope validation, and default reducer allocation.

## C++ style / lint notes

- The PR changes C++ files, but it does not modify rules documented in `docs/developer_guide/cpp_style.md`.
- The “C++ API Style Audit (warning only)” CI step is relevant to these changes.
- Any TLCPP003/TLCPP004 findings are advisory unless they identify a clear API, FFI, or maintainability risk.
- Formatting, compilation, and targeted reducer tests are included in validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->