### PR TITLE
[Lang][Reducer] Allow conditional reducer finalization

### DIFF
--- a/src/transform/verify_reducer_epoch.cc
+++ b/src/transform/verify_reducer_epoch.cc
@@ -6,13 +6,14 @@
  *   - every `local.reducer` allocation has exactly one reducer_init,
  *     zero or more reducer_update, and exactly one finalize_reducer
  *     (statically: one epoch site per allocation);
- *   - init and finalize share the exact same control-flow scope (the same
- *     stack of enclosing serial loops and conditional branches), so every
- *     dynamic execution of the init is closed by exactly one finalize in
- *     the same iteration. Neither may appear inside a `T.Parallel` loop.
- *     An epoch nested in a serial loop reopens once per iteration; the
- *     enclosing control flow must be thread-uniform, as with any other
- *     collective tile op;
+ *   - the finalize sits in the init's control-flow scope (the same stack of
+ *     enclosing serial loops and conditional branches) or in a conditional
+ *     refinement of it, so every dynamic execution of the init is closed by
+ *     at most one finalize in the same iteration (a finalize skipped by a
+ *     branch leaves the partials unread — harmless). Neither may appear
+ *     inside a `T.Parallel` loop. An epoch nested in a serial loop reopens
+ *     once per iteration; the enclosing control flow must be thread-uniform,
+ *     as with any other collective tile op;
  *   - updates appear only between init and finalize, and only inside a
  *     `T.Parallel` loop;
  *   - the reducer is opaque outside the three first-class ops: ordinary
@@ -209,12 +210,8 @@ private:
       Var dst_var = RegionArgBufferVar(op->args[1], "finalize_reducer");
       RequireReducer(var, "finalize_reducer");
       auto ctx_it = epoch_ctx_.find(var.get());
-      if (ctx_it != epoch_ctx_.end() && !(ctx_it->second == ctx_stack_)) {
-        LOG(FATAL) << "T.finalize_reducer on reducer `" << var
-                   << "` is not in the same loop/branch scope as its "
-                      "T.reducer_init: a reduction epoch must open and close "
-                      "within the same iteration of every enclosing loop and "
-                      "the same conditional branch.";
+      if (ctx_it != epoch_ctx_.end()) {
+        RequireConditionalRefinement(ctx_it->second, var);
       }
       if (info_.count(dst_var.get())) {
         LOG(FATAL) << "T.finalize_reducer destination `" << dst_var
@@ -265,6 +262,33 @@ private:
   }
 
   // ---- helpers ------------------------------------------------------------
+
+  /*! \brief T.finalize_reducer must sit in the init's scope or a conditional
+   *  refinement of it: the init context must be a prefix of the current
+   *  context, and every extra frame must be a conditional branch. A finalize
+   *  under extra conditionals runs 0 or 1 times per init (safe: a skipped
+   *  finalize leaves partials unread). Extra LOOP frames would run the
+   *  collective repeatedly on already-combined partials and are rejected, as
+   *  is a finalize outside the init's scope (it could run without any init).
+   */
+  void RequireConditionalRefinement(const std::vector<ContextFrame> &init_ctx,
+                                    const Var &var) const {
+    bool ok = init_ctx.size() <= ctx_stack_.size();
+    for (size_t i = 0; ok && i < ctx_stack_.size(); ++i) {
+      if (i < init_ctx.size()) {
+        ok = init_ctx[i] == ctx_stack_[i];
+      } else {
+        ok = ctx_stack_[i].node->IsInstance<IfThenElseNode>();
+      }
+    }
+    if (!ok) {
+      LOG(FATAL)
+          << "T.finalize_reducer on reducer `" << var
+          << "` is not in the scope of its T.reducer_init: the epoch must "
+             "close in the same loop iteration and branch it opened in, or "
+             "in a conditional branch nested inside that scope.";
+    }
+  }
 
   Var RegionArgBufferVar(const PrimExpr &arg, const char *who) const {
     if (auto call = arg.as<CallNode>()) {

--- a/testing/python/language/test_tilelang_language_reduce.py
+++ b/testing/python/language/test_tilelang_language_reduce.py
@@ -878,6 +878,41 @@ def test_finalize_reducer_default_alloc_v1_syntax():
     torch.testing.assert_close(O, ref, atol=1e-4, rtol=1e-4)
 
 
+def test_finalize_reducer_conditional_finalize():
+    """Legacy epoch opened at block scope, updated and finalized inside one
+    arm of a block-uniform conditional (the vllm sum_smaller_probs pattern):
+    the finalize runs 0 or 1 times per init, and skipped blocks never read
+    the reducer."""
+    extent, threads = 8, 128
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((extent,), T.float32),
+        S: T.Tensor((2,), T.int32),
+        B: T.Tensor((2,), T.float32),
+    ):
+        with T.Kernel(2, threads=threads) as bx:
+            src = T.alloc_fragment((extent,), T.float32)
+            T.copy(A, src)
+            total = T.alloc_reducer((1,), T.float32, replication="all")
+            T.fill(total, 0.0)
+            if S[bx] < 0:
+                if T.get_thread_binding() == 0:
+                    B[bx] = 0.0
+            else:
+                for i in T.Parallel(extent):
+                    total[0] += src[i]
+                T.finalize_reducer(total)
+                if T.get_thread_binding() == 0:
+                    B[bx] = total[0]
+
+    A = torch.arange(1, extent + 1, dtype=torch.float32, device="cuda")
+    S = torch.tensor([-1, 1], dtype=torch.int32, device="cuda")
+    B = tl.compile(kernel, out_idx=-1, pass_configs=_COMPILE_FLAGS)(A, S)
+    expected = torch.stack([torch.zeros((), device="cuda"), A.sum()])
+    torch.testing.assert_close(B, expected, atol=0, rtol=0)
+
+
 # (batch, exc_type, match)
 FINALIZE_REDUCER_INVALID_CASES = [
     (0, ValueError, "batch must be >= 1"),

--- a/testing/python/language/test_tilelang_language_reducer_v2.py
+++ b/testing/python/language/test_tilelang_language_reducer_v2.py
@@ -958,8 +958,8 @@ def test_seed_captured_at_init_site():
 
 
 def test_reject_finalize_in_different_scope():
-    """An epoch must open and close in the same control-flow scope: init
-    inside a serial loop with the finalize outside is rejected."""
+    """Init inside a serial loop with the finalize outside is rejected: the
+    finalize is not in the init's scope (nor a conditional refinement)."""
 
     def make():
         @T.prim_func
@@ -979,7 +979,68 @@ def test_reject_finalize_in_different_scope():
 
         return kernel
 
-    _compile_expect_error(make, "same loop/branch scope")
+    _compile_expect_error(make, "not in the scope of its T.reducer_init")
+
+
+def test_finalize_in_conditional_refinement():
+    """A finalize inside a block-uniform conditional nested in the init's
+    scope runs 0 or 1 times per init — legal. Blocks that skip the branch
+    leave the partials unread. (The sum_smaller_probs pattern.)"""
+    extent, threads = 8, 128
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((extent,), T.float32),
+        S: T.Tensor((2,), T.int32),
+        B: T.Tensor((2,), T.float32),
+    ):
+        with T.Kernel(2, threads=threads) as bx:
+            src = T.alloc_fragment((extent,), T.float32)
+            T.copy(A, src)
+            acc = T.alloc_reducer((1,), T.float32, op="sum")
+            T.reducer_init(acc)
+            if S[bx] < 0:
+                if T.get_thread_binding() == 0:
+                    B[bx] = 0.0
+            else:
+                for i in T.Parallel(extent):
+                    T.reducer_update(acc[0], src[i])
+                result = T.alloc_fragment((1,), T.float32)
+                T.finalize_reducer(acc, result)
+                if T.get_thread_binding() == 0:
+                    B[bx] = result[0]
+
+    A = torch.arange(1, extent + 1, dtype=torch.float32, device="cuda")
+    S = torch.tensor([-1, 1], dtype=torch.int32, device="cuda")
+    B = tl.compile(kernel, out_idx=-1)(A, S)
+    expected = torch.stack([torch.zeros((), device="cuda"), A.sum()])
+    torch.testing.assert_close(B, expected, atol=0, rtol=0)
+
+
+def test_reject_finalize_in_extra_loop():
+    """A finalize inside a loop the init is not in would rerun the collective
+    on already-combined partials — rejected even though the init context is
+    a prefix of the finalize context."""
+
+    def make():
+        @T.prim_func
+        def kernel(A: T.Tensor((8,), T.float32), B: T.Tensor((1,), T.float32)):
+            with T.Kernel(1, threads=128):
+                src = T.alloc_fragment((8,), T.float32)
+                T.copy(A, src)
+                acc = T.alloc_reducer((1,), T.float32, op="sum")
+                T.reducer_init(acc)
+                result = T.alloc_fragment((1,), T.float32)
+                for _ in T.serial(4):
+                    for i in T.Parallel(8):
+                        T.reducer_update(acc[0], src[i])
+                    T.finalize_reducer(acc, result)
+                if T.get_thread_binding() == 0:
+                    B[0] = result[0]
+
+        return kernel
+
+    _compile_expect_error(make, "not in the scope of its T.reducer_init")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Allow reducer finalization inside a conditional refinement of the reducer initialization scope.
- Preserve support for epochs that skip finalization when the guarded path leaves reducer partials unread.
- Keep unsafe loop and outward-scope finalization patterns rejected.

## Example

The reducer can be initialized at block scope and finalized only in the branch that consumes it:

```python
total = T.alloc_reducer((1,), T.float32, replication="all")
T.fill(total, 0.0)

if should_skip:
    if T.get_thread_binding() == 0:
        output[bx] = 0.0
else:
    for i in T.Parallel(extent):
        total[0] += values[i]
    T.finalize_reducer(total)
    if T.get_thread_binding() == 0:
        output[bx] = total[0]
```

Here the init context is a prefix of the finalize context, and the only additional frame is the conditional branch.

## Changes

- Replace strict reducer init/finalize context-stack equality with a prefix check.
- Permit only nested conditional frames beyond the init context, so a finalize executes zero or one time for each dynamic init.
- Reject additional `For` or `While` frames, mismatched branches, and finalization outside the init scope.
- Add v2 and legacy regression kernels that exercise both the finalized and skipped paths, plus a negative test for finalization in an extra loop.
- Update the existing scope-mismatch test for the refined diagnostic.

## Validation

- `./format.sh`
- `python -m pytest testing/python/language/test_tilelang_language_reduce.py testing/python/language/test_tilelang_language_reducer_v2.py -q` — 143 passed

## Risk

- The relaxation is deliberately limited to nested conditionals. A skipped finalize leaves the partials unread, while a newly nested loop remains invalid because it could reduce already-combined partials repeatedly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Allow reducer finalization in nested conditional refinements of the initialization scope.
- Reject finalization after additional `For` or `While` nesting, mismatched branches, or outside the initialization scope.
- Update diagnostics to describe valid conditional finalization and skipped paths.
- Add v2 and legacy regression tests for finalized, skipped, and invalid reducer paths.
- Validate with formatting, 143 language tests, and eight standalone vLLM `sum_smaller_probs` configurations.

## C++ style / lint notes

- The change touches C++ implementation code in `src/transform/verify_reducer_epoch.cc`.
- It does not change the documented rules in `docs/developer_guide/cpp_style.md`.
- No correctness or build issues are identified.
- Any C++ API Style Audit warnings are advisory only; this change adds no public API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->