### PR TITLE
[Tool] Add official compile-only CLI

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,7 @@ tutorials/logging
 :caption: TOOLS
 
 tools/index
+tools/compile_only
 tools/analyzer
 tools/layout_visualization
 tools/autodd

--- a/docs/tools/compile_only.md
+++ b/docs/tools/compile_only.md
@@ -1,0 +1,185 @@
+# Compile-Only Tool
+
+`python -m tilelang.tools.compile_only` lowers a TileLang program to
+inspectable kernel source without running it. No GPU, CUDA driver, or device
+compilation is required: the tool stops after
+`tilelang.lower(..., enable_device_compile=False)` and writes the generated
+kernel source to a file. It backs the TileLang integration in
+[Compiler Explorer](https://godbolt.org) and is equally useful for inspecting
+locally what `lower()` produces for a kernel.
+
+## Requirements
+
+The tool ships with the standard TileLang installation and has no optional
+dependencies. The default `c` target works on any machine, including CPU-only
+hosts. `--target cuda` requires a wheel whose CUDA codegen FFI is compiled in:
+Linux wheels include it and can emit CUDA source without a GPU present, while
+macOS Metal wheels do not and fail with a clear
+`CUDA codegen FFI missing` message instead of an `AttributeError`.
+
+## Quick Start
+
+Write a self-contained example that defines a kernel but never launches it:
+
+```python
+# example.py
+import tilelang
+import tilelang.language as T
+
+
+@tilelang.jit
+def add(A, B):
+    N = 64
+    A: T.Tensor((N,), T.float16)
+    B: T.Tensor((N,), T.float16)
+    C = T.empty((N,), T.float16)
+    with T.Kernel(1, threads=64):
+        for i in T.Parallel(N):
+            C[i] = A[i] + B[i]
+    return C
+```
+
+Compile it to CPU C source:
+
+```bash
+python -I -m tilelang.tools.compile_only --output_file out.c example.py
+```
+
+`out.c` then contains the generated kernel source:
+
+```c
+// tilelang target: {"kind":"c","tag":"","keys":["cpu"],"host":{"kind":"c","tag":"","keys":["cpu"]}}
+#include <tl_templates/cpp/common.h>
+
+#ifdef __cplusplus
+extern "C"
+#endif
+int32_t add_kernel(half* A, half* B, half* C);
+#ifdef __cplusplus
+extern "C"
+#endif
+int32_t add_kernel(half* A, half* B, half* C) {
+  for (int32_t i = 0; i < 8; ++i) {
+    *(half8*)(C + (i * 8)) = (*(half8*)(A + (i * 8)) + *(half8*)(B + (i * 8)));
+  }
+  return 0;
+}
+```
+
+CUDA source generation works the same way and still needs no GPU; the
+architecture is pinned instead of detected:
+
+```bash
+python -I -m tilelang.tools.compile_only --target cuda --output_file out.cu example.py
+```
+
+```cuda
+extern "C" __global__ void __launch_bounds__(64, 1) add_kernel(const half_t* __restrict__ A, const half_t* __restrict__ B, half_t* __restrict__ C) {
+  C[((int)threadIdx.x)] = (A[((int)threadIdx.x)] + B[((int)threadIdx.x)]);
+}
+```
+
+## How the Input Is Processed
+
+- The input file is imported as a regular Python module, so its top-level code
+  runs. Keep examples compile-only: define kernels, do not launch them or
+  allocate tensors at import time. Running the CLI with `python -I` (isolated
+  mode) is recommended, and is how Compiler Explorer invokes it.
+- The first `@tilelang.jit` function or `PrimFunc` in module order is selected.
+  Objects are inspected in definition order, so a `PrimFunc` defined before a
+  `@tilelang.jit` kernel wins.
+- The kernel is lowered but never device-compiled or executed, so no tensor
+  arguments are needed and no GPU is touched.
+
+## CLI Reference
+
+```text
+python -I -m tilelang.tools.compile_only [--target TARGET] --output_file OUTPUT input_file
+```
+
+| Argument | Meaning |
+| --- | --- |
+| `input_file` | Compile-only example file. Imported, never launched. |
+| `--output_file` | Required destination for the generated kernel source. Must not name the input file (symlinks to it are also rejected). |
+| `--target` | Explicit target. Defaults to `c`. |
+
+On success the CLI exits with `0` and writes the source to `--output_file`. On
+any failure it exits with `1`, prints a single
+`tilelang compile-only error: ...` line to stderr, and leaves no stale output
+behind: a previous artifact at `--output_file` is removed before compilation,
+so a failed rerun cannot leave an earlier run's source for a consumer such as
+Compiler Explorer to read.
+
+## Targets
+
+Targets must be explicit. `auto` performs device detection and is therefore
+rejected, as a plain string and in JSON form:
+
+```text
+$ python -I -m tilelang.tools.compile_only --target auto --output_file out.c example.py
+tilelang compile-only error: target must be explicit; do not use auto
+```
+
+| `--target` value | Behavior |
+| --- | --- |
+| `c` (default) | CPU C source. Works on every wheel, no GPU needed. |
+| `cuda` | CUDA source pinned to `sm_80`, so no device detection happens. |
+| `cuda -arch=sm_90` | CUDA source for the given architecture. Options must look like `-key=value`. |
+| `{"kind": "cuda", "arch": "sm_90"}` | JSON target. A bare `{"kind": "cuda"}` is pinned to `sm_80`; `{"kind": "auto"}` is rejected. |
+| `auto` | Rejected: `target must be explicit; do not use auto`. |
+
+On wheels without the CUDA codegen FFI (for example macOS Metal wheels), every
+CUDA target form fails softly with
+`tilelang compile-only error: CUDA codegen FFI missing (e.g. macOS Metal
+wheel); use default --target c`.
+
+## Error Reporting
+
+Compile problems are reported as diagnostics on stderr with exit code `1`, not
+as tracebacks about missing GPUs or drivers:
+
+```text
+$ python -I -m tilelang.tools.compile_only --output_file out.c broken.py
+tilelang compile-only error: no @tilelang.jit kernel or PrimFunc found
+```
+
+Syntax errors in the input, missing input files, and empty kernels are
+reported the same way.
+
+## Line Directives
+
+When the installed build registers the `tl.emit_line_directives` pass config
+(`PassConfigKey.TL_EMIT_LINE_DIRECTIVES`), the tool enables it automatically
+and the generated source carries `#line <n> "<input_file>"` directives that map
+each statement back to the originating line of the example. Compiler Explorer
+uses these to link generated source to the input pane. Older wheels without
+the config key simply produce source without `#line` directives; no flag is
+needed either way.
+
+## Programmatic API
+
+The same functionality is available in Python:
+
+```python
+from tilelang.tools.compile_only import compile_kernel_source
+
+source = compile_kernel_source(add.get_tir())              # default target "c"
+cuda_source = compile_kernel_source(add.get_tir(), "cuda")  # pinned to sm_80
+```
+
+- `compile_kernel_source(func, target="c")` lowers a `PrimFunc` (for example
+  from `JITImpl.get_tir()`) and returns the non-empty kernel source string.
+- `resolve_target(target)` maps a CLI-style target string to the explicit
+  target passed to `lower()`, applying the rules from the table above.
+- `cuda_codegen_available()` reports whether the installed wheel can lower
+  CUDA targets.
+
+## Limitations
+
+- Only the first `@tilelang.jit` kernel or `PrimFunc` in the module is
+  compiled; additional kernels in the same file are ignored.
+- The output is lowered kernel source, not a compiled binary: nothing is
+  passed to `nvcc`, and PTX/SASS is out of scope.
+- The input file is executed with the invoking Python interpreter. Treat it
+  like any script you run: `python -I` isolates it from your environment but
+  does not sandbox it.

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -7,6 +7,7 @@ or invoke only the tool needed for the current workflow.
 
 | Task | Tool | Entry point |
 | --- | --- | --- |
+| Emit kernel source without a GPU | [Compile-Only Tool](compile_only.md) | `python -m tilelang.tools.compile_only` |
 | Estimate compute and memory cost from TIR | [Performance Analyzer](analyzer.md) | `tilelang.tools.Analyzer` |
 | Inspect thread and data mappings | [Layout Visualization](layout_visualization.md) | `tilelang.tools.plot_layout` |
 | Reduce a failing program to a smaller reproducer | [AutoDD](autodd.md) | `python -m tilelang.autodd` |
@@ -16,6 +17,9 @@ or invoke only the tool needed for the current workflow.
 
 ## Choosing a Tool
 
+- Use the **Compile-Only Tool** to inspect the kernel source `lower()`
+  generates for an example file, on any machine and without launching
+  anything. It is the entry point behind the Compiler Explorer integration.
 - Use **Analyzer** before benchmarking when you need a rough roofline-style
   estimate from a `PrimFunc` or `IRModule`.
 - Use **Layout Visualization** to inspect how logical indices map to threads and

--- a/testing/python/tools/test_tilelang_tools_compile_only.py
+++ b/testing/python/tools/test_tilelang_tools_compile_only.py
@@ -127,6 +127,33 @@ def test_compile_only_cli_unlinks_stale_output_on_failure(tmp_path: Path):
     assert not output.is_file() or output.read_text() != stale
 
 
+def test_compile_only_cli_keeps_input_when_output_is_same_path(tmp_path: Path):
+    example = tmp_path / "example.py"
+    example.write_text(_COMPILE_ONLY_EXAMPLE)
+
+    result = _run_cli("--output_file", str(example), str(example))
+
+    assert result.returncode != 0
+    assert example.is_file()
+    assert example.read_text() == _COMPILE_ONLY_EXAMPLE
+    assert "output_file" in result.stderr
+    assert "input" in result.stderr.lower()
+
+
+def test_compile_only_cli_keeps_input_when_output_is_symlink(tmp_path: Path):
+    example = tmp_path / "example.py"
+    alias = tmp_path / "out.py"
+    example.write_text(_COMPILE_ONLY_EXAMPLE)
+    alias.symlink_to(example)
+
+    result = _run_cli("--output_file", str(alias), str(example))
+
+    assert result.returncode != 0
+    assert example.is_file()
+    assert example.read_text() == _COMPILE_ONLY_EXAMPLE
+    assert alias.is_symlink()
+
+
 def test_compile_only_cli_reports_syntax_error(tmp_path: Path):
     example = tmp_path / "bad.py"
     output = tmp_path / "out.s"

--- a/testing/python/tools/test_tilelang_tools_compile_only.py
+++ b/testing/python/tools/test_tilelang_tools_compile_only.py
@@ -47,7 +47,7 @@ def _add(A, B):
     C = T.empty((N,), T.float16)
     with T.Kernel(1, threads=64):
         for i in T.Parallel(N):
-            C[i] = A[i] + B[i]  # line_marker_store
+            C[i] = A[i] + B[i]  # line_marker_jit
     return C
 
 
@@ -110,6 +110,17 @@ def test_line_directive_parser_reads_file_and_line():
     assert _line_directives(source) == [(12, "/tmp/example.py")]
 
 
+def test_line_markers_do_not_collide():
+    # In-process lookup scans this file. First hit of each marker must differ
+    # or compile_kernel_source asserts the example-string line.
+    jit = _marker_line(Path(__file__), "line_marker_jit")
+    store = _marker_line(Path(__file__), "line_marker_store")
+    assert jit != store
+    lines = Path(__file__).read_text().splitlines()
+    assert lines[jit - 1].rstrip().endswith("# line_marker_jit")
+    assert "def _add" in "\n".join(lines[max(0, jit - 10) : jit])
+
+
 @pytest.mark.skipif(
     not _CAN_EMIT_LINE_DIRECTIVES,
     reason="tl.emit_line_directives is not in this wheel; CI merge with main has it",
@@ -118,7 +129,7 @@ def test_compile_kernel_source_emits_line_directives():
     source = compile_kernel_source(_add.get_tir())
     directives = _line_directives(source)
     assert directives, f"no #line directives:\n{source}"
-    store_line = _marker_line(Path(__file__), "line_marker_store")
+    store_line = _marker_line(Path(__file__), "line_marker_jit")
     files = {fname for _, fname in directives}
     assert any(Path(fname).name == Path(__file__).name for fname in files), files
     assert any(num == store_line and Path(fname).name == Path(__file__).name for num, fname in directives), (

--- a/testing/python/tools/test_tilelang_tools_compile_only.py
+++ b/testing/python/tools/test_tilelang_tools_compile_only.py
@@ -1,0 +1,159 @@
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang.tools.compile_only import compile_kernel_source, resolve_target
+
+_COMPILE_ONLY_EXAMPLE = """\
+import tilelang
+import tilelang.language as T
+
+
+@tilelang.jit
+def add(A, B):
+    N = 64
+    A: T.Tensor((N,), T.float16)
+    B: T.Tensor((N,), T.float16)
+    C = T.empty((N,), T.float16)
+    with T.Kernel(1, threads=64):
+        for i in T.Parallel(N):
+            C[i] = A[i] + B[i]
+    return C
+"""
+
+
+@tilelang.jit
+def _add(A, B):
+    N = 64
+    A: T.Tensor((N,), T.float16)
+    B: T.Tensor((N,), T.float16)
+    C = T.empty((N,), T.float16)
+    with T.Kernel(1, threads=64):
+        for i in T.Parallel(N):
+            C[i] = A[i] + B[i]
+    return C
+
+
+def _cuda_codegen_ffi_available() -> bool:
+    try:
+        from tilelang.cuda import _ffi_api
+
+        return hasattr(_ffi_api, "AnnotateDeviceBoundTmaCopies")
+    except Exception:
+        return False
+
+
+def _run_cli(*args):
+    return subprocess.run(
+        [sys.executable, "-I", "-m", "tilelang.tools.compile_only", *args],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=180,
+    )
+
+
+def _looks_like_generated_source(text: str) -> bool:
+    source = text.strip()
+    if not source:
+        return False
+    # Real lower() text: CPU C / HIP C / CUDA C / TIR. Do not require __global__.
+    markers = (
+        "#include",
+        'extern "C"',
+        "tilelang target",
+        "primfn",
+        "@T.prim_func",
+        "_kernel",
+    )
+    return any(marker in source for marker in markers)
+
+
+def test_compile_kernel_source_default_cpu_c():
+    source = compile_kernel_source(_add.get_tir())
+
+    assert source.strip()
+    assert _looks_like_generated_source(source)
+    assert "__global__" not in source
+    assert "AnnotateDeviceBoundTmaCopies" not in source
+
+
+def test_compile_only_cli_writes_kernel_source(tmp_path: Path):
+    example = tmp_path / "example.py"
+    output = tmp_path / "out.s"
+    example.write_text(_COMPILE_ONLY_EXAMPLE)
+
+    result = _run_cli("--output_file", str(output), str(example))
+
+    assert result.returncode == 0, result.stderr
+    assert output.is_file()
+    text = output.read_text()
+    assert text.strip()
+    assert _looks_like_generated_source(text)
+    assert "__global__" not in text
+
+
+def test_compile_only_cli_reports_compile_error(tmp_path: Path):
+    example = tmp_path / "broken.py"
+    output = tmp_path / "out.s"
+    example.write_text("x = 1\n")
+
+    result = _run_cli("--output_file", str(output), str(example))
+
+    assert result.returncode != 0
+    assert result.stderr.strip()
+    assert "no @tilelang.jit kernel or PrimFunc found" in result.stderr
+    assert "CUDA" not in result.stderr or "driver" not in result.stderr.lower()
+    assert not output.is_file() or not output.read_text().strip()
+
+
+def test_compile_only_cli_requires_output_file(tmp_path: Path):
+    example = tmp_path / "example.py"
+    example.write_text(_COMPILE_ONLY_EXAMPLE)
+
+    result = _run_cli(str(example))
+
+    assert result.returncode != 0
+    assert "output_file" in result.stderr
+
+
+def test_compile_only_cli_rejects_auto_target(tmp_path: Path):
+    example = tmp_path / "example.py"
+    output = tmp_path / "out.s"
+    example.write_text(_COMPILE_ONLY_EXAMPLE)
+
+    with pytest.raises(ValueError, match="auto"):
+        resolve_target("auto")
+
+    result = _run_cli("--target", "auto", "--output_file", str(output), str(example))
+
+    assert result.returncode != 0
+    assert "auto" in result.stderr
+    assert not output.is_file() or not output.read_text().strip()
+
+
+@pytest.mark.skipif(
+    not _cuda_codegen_ffi_available(),
+    reason="CUDA codegen FFI missing (e.g. macOS Metal wheel)",
+)
+def test_compile_only_cli_optional_cuda_target(tmp_path: Path):
+    example = tmp_path / "example.py"
+    output = tmp_path / "out.s"
+    example.write_text(_COMPILE_ONLY_EXAMPLE)
+
+    result = _run_cli("--target", "cuda", "--output_file", str(output), str(example))
+
+    assert result.returncode == 0, result.stderr
+    text = output.read_text()
+    assert text.strip()
+    assert _looks_like_generated_source(text)
+    assert "__global__" in text or "cuda" in text.lower()
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/tools/test_tilelang_tools_compile_only.py
+++ b/testing/python/tools/test_tilelang_tools_compile_only.py
@@ -8,13 +8,17 @@ import pytest
 import tilelang
 import tilelang.language as T
 import tilelang.testing
+from tilelang.transform import PassConfigKey
 from tilelang.tools.compile_only import (
     _is_cuda_target,
+    _pass_context_config,
     compile_kernel_source,
     cuda_codegen_available,
     discover_prim_func,
     resolve_target,
 )
+
+_CAN_EMIT_LINE_DIRECTIVES = hasattr(PassConfigKey, "TL_EMIT_LINE_DIRECTIVES")
 
 _COMPILE_ONLY_EXAMPLE = """\
 import tilelang
@@ -81,6 +85,23 @@ def test_compile_kernel_source_default_cpu_c():
     assert "AnnotateDeviceBoundTmaCopies" not in source
 
 
+def test_pass_context_config_enables_line_directives_when_supported():
+    config = _pass_context_config()
+    if _CAN_EMIT_LINE_DIRECTIVES:
+        assert config.get(PassConfigKey.TL_EMIT_LINE_DIRECTIVES) is True
+    else:
+        assert config == {}
+
+
+@pytest.mark.skipif(
+    not _CAN_EMIT_LINE_DIRECTIVES,
+    reason="tl.emit_line_directives is not in this wheel; CI merge with main has it",
+)
+def test_compile_kernel_source_emits_line_directives():
+    source = compile_kernel_source(_add.get_tir())
+    assert "#line" in source
+
+
 def test_compile_only_cli_writes_kernel_source(tmp_path: Path):
     example = tmp_path / "example.py"
     output = tmp_path / "out.s"
@@ -94,6 +115,21 @@ def test_compile_only_cli_writes_kernel_source(tmp_path: Path):
     assert text.strip()
     assert _looks_like_generated_source(text)
     assert "__global__" not in text
+
+
+@pytest.mark.skipif(
+    not _CAN_EMIT_LINE_DIRECTIVES,
+    reason="tl.emit_line_directives is not in this wheel; CI merge with main has it",
+)
+def test_compile_only_cli_emits_line_directives(tmp_path: Path):
+    example = tmp_path / "example.py"
+    output = tmp_path / "out.s"
+    example.write_text(_COMPILE_ONLY_EXAMPLE)
+
+    result = _run_cli("--output_file", str(output), str(example))
+
+    assert result.returncode == 0, result.stderr
+    assert "#line" in output.read_text()
 
 
 def test_compile_only_cli_reports_compile_error(tmp_path: Path):

--- a/testing/python/tools/test_tilelang_tools_compile_only.py
+++ b/testing/python/tools/test_tilelang_tools_compile_only.py
@@ -1,13 +1,20 @@
 import subprocess
 import sys
 from pathlib import Path
+from types import ModuleType
 
 import pytest
 
 import tilelang
 import tilelang.language as T
 import tilelang.testing
-from tilelang.tools.compile_only import compile_kernel_source, cuda_codegen_available, resolve_target
+from tilelang.tools.compile_only import (
+    _is_cuda_target,
+    compile_kernel_source,
+    cuda_codegen_available,
+    discover_prim_func,
+    resolve_target,
+)
 
 _COMPILE_ONLY_EXAMPLE = """\
 import tilelang
@@ -113,6 +120,41 @@ def test_compile_only_cli_requires_output_file(tmp_path: Path):
     assert "output_file" in result.stderr
 
 
+def test_discover_prim_func_respects_module_order():
+    # A later @tilelang.jit must not steal an earlier PrimFunc (module order).
+    prim = _add.get_tir()
+    module = ModuleType("tilelang_compile_only_order")
+    module.early_prim = prim
+    module.later_jit = _add
+
+    found = discover_prim_func(module)
+
+    assert found is prim
+
+
+def test_is_cuda_target_recognizes_option_strings():
+    assert _is_cuda_target("cuda")
+    assert _is_cuda_target("cuda -arch=sm_90")
+    assert _is_cuda_target("CUDA -arch=sm_80")
+    assert _is_cuda_target('{"kind": "cuda", "arch": "sm_90"}')
+    assert not _is_cuda_target("c")
+    assert not _is_cuda_target("llvm")
+    assert not _is_cuda_target('{"kind": "c"}')
+
+
+def test_resolve_target_parses_cuda_options():
+    pinned = resolve_target("cuda")
+    assert pinned == {"kind": "cuda", "arch": "sm_80"}
+
+    cli = resolve_target("cuda -arch=sm_90")
+    assert cli["kind"] == "cuda"
+    assert cli["arch"] == "sm_90"
+
+    json_target = resolve_target('{"kind": "cuda", "arch": "sm_90"}')
+    assert json_target["kind"] == "cuda"
+    assert json_target["arch"] == "sm_90"
+
+
 def test_compile_only_cli_rejects_auto_target(tmp_path: Path):
     example = tmp_path / "example.py"
     output = tmp_path / "out.s"
@@ -145,6 +187,18 @@ def test_compile_only_cli_cuda_soft_fails_without_ffi(tmp_path: Path):
     assert result.returncode != 0
     assert "CUDA codegen FFI missing" in result.stderr
     assert not output.is_file() or not output.read_text().strip()
+
+    with pytest.raises(RuntimeError, match="CUDA codegen FFI missing"):
+        compile_kernel_source(_add.get_tir(), "cuda -arch=sm_90")
+    with pytest.raises(RuntimeError, match="CUDA codegen FFI missing"):
+        compile_kernel_source(_add.get_tir(), '{"kind": "cuda", "arch": "sm_90"}')
+
+    optioned = tmp_path / "out_sm90.s"
+    result = _run_cli("--target", "cuda -arch=sm_90", "--output_file", str(optioned), str(example))
+
+    assert result.returncode != 0
+    assert "CUDA codegen FFI missing" in result.stderr
+    assert not optioned.is_file() or not optioned.read_text().strip()
 
 
 @pytest.mark.skipif(

--- a/testing/python/tools/test_tilelang_tools_compile_only.py
+++ b/testing/python/tools/test_tilelang_tools_compile_only.py
@@ -7,7 +7,7 @@ import pytest
 import tilelang
 import tilelang.language as T
 import tilelang.testing
-from tilelang.tools.compile_only import compile_kernel_source, resolve_target
+from tilelang.tools.compile_only import compile_kernel_source, cuda_codegen_available, resolve_target
 
 _COMPILE_ONLY_EXAMPLE = """\
 import tilelang
@@ -37,15 +37,6 @@ def _add(A, B):
         for i in T.Parallel(N):
             C[i] = A[i] + B[i]
     return C
-
-
-def _cuda_codegen_ffi_available() -> bool:
-    try:
-        from tilelang.cuda import _ffi_api
-
-        return hasattr(_ffi_api, "AnnotateDeviceBoundTmaCopies")
-    except Exception:
-        return False
 
 
 def _run_cli(*args):
@@ -138,7 +129,39 @@ def test_compile_only_cli_rejects_auto_target(tmp_path: Path):
 
 
 @pytest.mark.skipif(
-    not _cuda_codegen_ffi_available(),
+    cuda_codegen_available(),
+    reason="CUDA codegen FFI present; soft-fail path is for Metal-style wheels",
+)
+def test_compile_only_cli_cuda_soft_fails_without_ffi(tmp_path: Path):
+    example = tmp_path / "example.py"
+    output = tmp_path / "out.s"
+    example.write_text(_COMPILE_ONLY_EXAMPLE)
+
+    with pytest.raises(RuntimeError, match="CUDA codegen FFI missing"):
+        compile_kernel_source(_add.get_tir(), "cuda")
+
+    result = _run_cli("--target", "cuda", "--output_file", str(output), str(example))
+
+    assert result.returncode != 0
+    assert "CUDA codegen FFI missing" in result.stderr
+    assert not output.is_file() or not output.read_text().strip()
+
+
+@pytest.mark.skipif(
+    not cuda_codegen_available(),
+    reason="CUDA codegen FFI missing (e.g. macOS Metal wheel)",
+)
+def test_compile_kernel_source_optional_cuda():
+    source = compile_kernel_source(_add.get_tir(), "cuda")
+
+    assert source.strip()
+    assert _looks_like_generated_source(source)
+    assert "__global__" in source
+    assert "add_kernel" in source
+
+
+@pytest.mark.skipif(
+    not cuda_codegen_available(),
     reason="CUDA codegen FFI missing (e.g. macOS Metal wheel)",
 )
 def test_compile_only_cli_optional_cuda_target(tmp_path: Path):
@@ -152,7 +175,8 @@ def test_compile_only_cli_optional_cuda_target(tmp_path: Path):
     text = output.read_text()
     assert text.strip()
     assert _looks_like_generated_source(text)
-    assert "__global__" in text or "cuda" in text.lower()
+    assert "__global__" in text
+    assert "add_kernel" in text
 
 
 if __name__ == "__main__":

--- a/testing/python/tools/test_tilelang_tools_compile_only.py
+++ b/testing/python/tools/test_tilelang_tools_compile_only.py
@@ -1,3 +1,4 @@
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -33,7 +34,7 @@ def add(A, B):
     C = T.empty((N,), T.float16)
     with T.Kernel(1, threads=64):
         for i in T.Parallel(N):
-            C[i] = A[i] + B[i]
+            C[i] = A[i] + B[i]  # line_marker_store
     return C
 """
 
@@ -46,7 +47,7 @@ def _add(A, B):
     C = T.empty((N,), T.float16)
     with T.Kernel(1, threads=64):
         for i in T.Parallel(N):
-            C[i] = A[i] + B[i]
+            C[i] = A[i] + B[i]  # line_marker_store
     return C
 
 
@@ -58,6 +59,17 @@ def _run_cli(*args):
         check=False,
         timeout=180,
     )
+
+
+def _line_directives(source: str) -> list[tuple[int, str]]:
+    return [(int(num), fname) for num, fname in re.findall(r'^#line (\d+) "(.*)"$', source, re.M)]
+
+
+def _marker_line(path: Path, marker: str) -> int:
+    for i, line in enumerate(path.read_text().splitlines(), 1):
+        if marker in line:
+            return i
+    raise ValueError(f"marker not found: {marker}")
 
 
 def _looks_like_generated_source(text: str) -> bool:
@@ -93,13 +105,27 @@ def test_pass_context_config_enables_line_directives_when_supported():
         assert config == {}
 
 
+def test_line_directive_parser_reads_file_and_line():
+    source = '#line 12 "/tmp/example.py"\nint x;\n'
+    assert _line_directives(source) == [(12, "/tmp/example.py")]
+
+
 @pytest.mark.skipif(
     not _CAN_EMIT_LINE_DIRECTIVES,
     reason="tl.emit_line_directives is not in this wheel; CI merge with main has it",
 )
 def test_compile_kernel_source_emits_line_directives():
     source = compile_kernel_source(_add.get_tir())
-    assert "#line" in source
+    directives = _line_directives(source)
+    assert directives, f"no #line directives:\n{source}"
+    store_line = _marker_line(Path(__file__), "line_marker_store")
+    files = {fname for _, fname in directives}
+    assert any(Path(fname).name == Path(__file__).name for fname in files), files
+    assert any(num == store_line and Path(fname).name == Path(__file__).name for num, fname in directives), (
+        store_line,
+        directives,
+        source,
+    )
 
 
 def test_compile_only_cli_writes_kernel_source(tmp_path: Path):
@@ -129,7 +155,15 @@ def test_compile_only_cli_emits_line_directives(tmp_path: Path):
     result = _run_cli("--output_file", str(output), str(example))
 
     assert result.returncode == 0, result.stderr
-    assert "#line" in output.read_text()
+    text = output.read_text()
+    directives = _line_directives(text)
+    assert directives, f"no #line directives:\n{text}"
+    store_line = _marker_line(example, "line_marker_store")
+    assert any(num == store_line and Path(fname).name == example.name for num, fname in directives), (
+        store_line,
+        directives,
+        text,
+    )
 
 
 def test_compile_only_cli_reports_compile_error(tmp_path: Path):

--- a/testing/python/tools/test_tilelang_tools_compile_only.py
+++ b/testing/python/tools/test_tilelang_tools_compile_only.py
@@ -106,7 +106,60 @@ def test_compile_only_cli_reports_compile_error(tmp_path: Path):
     assert result.returncode != 0
     assert result.stderr.strip()
     assert "no @tilelang.jit kernel or PrimFunc found" in result.stderr
-    assert "CUDA" not in result.stderr or "driver" not in result.stderr.lower()
+    # A4: this is a compile diagnostic, not a missing-GPU / missing-driver abort.
+    assert "CUDA" not in result.stderr
+    assert "driver" not in result.stderr.lower()
+    assert not output.is_file() or not output.read_text().strip()
+
+
+def test_compile_only_cli_unlinks_stale_output_on_failure(tmp_path: Path):
+    # CE reuses --output_file. A failed compile must not leave yesterday's assembly.
+    example = tmp_path / "broken.py"
+    output = tmp_path / "out.s"
+    stale = "YESTERDAY_ASSEMBLY_MUST_NOT_SURVIVE\n"
+    output.write_text(stale)
+    example.write_text("x = 1\n")
+
+    result = _run_cli("--output_file", str(output), str(example))
+
+    assert result.returncode != 0
+    assert "no @tilelang.jit kernel or PrimFunc found" in result.stderr
+    assert not output.is_file() or output.read_text() != stale
+
+
+def test_compile_only_cli_reports_syntax_error(tmp_path: Path):
+    example = tmp_path / "bad.py"
+    output = tmp_path / "out.s"
+    example.write_text("def (\n")
+
+    result = _run_cli("--output_file", str(output), str(example))
+
+    assert result.returncode != 0
+    assert result.stderr.strip()
+    assert "SyntaxError" in result.stderr or "invalid syntax" in result.stderr.lower()
+    assert not output.is_file() or not output.read_text().strip()
+
+
+def test_compile_only_cli_reports_empty_file(tmp_path: Path):
+    example = tmp_path / "empty.py"
+    output = tmp_path / "out.s"
+    example.write_text("")
+
+    result = _run_cli("--output_file", str(output), str(example))
+
+    assert result.returncode != 0
+    assert "no @tilelang.jit kernel or PrimFunc found" in result.stderr
+    assert not output.is_file() or not output.read_text().strip()
+
+
+def test_compile_only_cli_reports_missing_input_file(tmp_path: Path):
+    missing = tmp_path / "no_such.py"
+    output = tmp_path / "out.s"
+
+    result = _run_cli("--output_file", str(output), str(missing))
+
+    assert result.returncode != 0
+    assert result.stderr.strip()
     assert not output.is_file() or not output.read_text().strip()
 
 

--- a/testing/python/tools/test_tilelang_tools_compile_only.py
+++ b/testing/python/tools/test_tilelang_tools_compile_only.py
@@ -208,6 +208,15 @@ def test_resolve_target_parses_cuda_options():
     assert json_target["arch"] == "sm_90"
 
 
+def test_resolve_target_rejects_json_auto():
+    with pytest.raises(ValueError, match="auto"):
+        resolve_target('{"kind": "auto"}')
+
+
+def test_resolve_target_pins_json_cuda_without_arch():
+    assert resolve_target('{"kind": "cuda"}') == {"kind": "cuda", "arch": "sm_80"}
+
+
 def test_compile_only_cli_rejects_auto_target(tmp_path: Path):
     example = tmp_path / "example.py"
     output = tmp_path / "out.s"
@@ -217,6 +226,18 @@ def test_compile_only_cli_rejects_auto_target(tmp_path: Path):
         resolve_target("auto")
 
     result = _run_cli("--target", "auto", "--output_file", str(output), str(example))
+
+    assert result.returncode != 0
+    assert "auto" in result.stderr
+    assert not output.is_file() or not output.read_text().strip()
+
+
+def test_compile_only_cli_rejects_json_auto_target(tmp_path: Path):
+    example = tmp_path / "example.py"
+    output = tmp_path / "out.s"
+    example.write_text(_COMPILE_ONLY_EXAMPLE)
+
+    result = _run_cli("--target", '{"kind": "auto"}', "--output_file", str(output), str(example))
 
     assert result.returncode != 0
     assert "auto" in result.stderr

--- a/tilelang/tools/compile_only.py
+++ b/tilelang/tools/compile_only.py
@@ -198,12 +198,16 @@ def _build_parser() -> argparse.ArgumentParser:
 def cli_main(argv: list[str] | None = None) -> int:
     """CE-shaped CLI (D2): ``--output_file`` + example.py. Default target ``c`` (D3)."""
     args = _build_parser().parse_args(argv)
+    output = Path(args.output_file)
+    # Match CuTe CE wrapper: drop a previous artifact before compile so a
+    # failed run cannot leave yesterday's assembly for CE to read.
+    output.unlink(missing_ok=True)
 
     try:
         module = load_example(args.input_file)
         func = discover_prim_func(module)
         source = compile_kernel_source(func, resolve_target(args.target))
-        Path(args.output_file).write_text(source)
+        output.write_text(source)
     except Exception as exc:
         print(f"{_ERROR_PREFIX}: {exc}", file=sys.stderr)
         return 1

--- a/tilelang/tools/compile_only.py
+++ b/tilelang/tools/compile_only.py
@@ -1,0 +1,151 @@
+"""Compile-only tool: emit inspectable ``lower()`` kernel source without a GPU.
+
+Usage::
+
+    python3 -I -m tilelang.tools.compile_only --output_file out.s example.py
+
+The default target is ``c`` (CPU C). CUDA is optional::
+
+    python3 -I -m tilelang.tools.compile_only --target cuda --output_file out.s example.py
+
+Programmatic API::
+
+    from tilelang.tools.compile_only import compile_kernel_source
+
+    source = compile_kernel_source(func)  # default target c
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+__all__ = [
+    "DEFAULT_TARGET",
+    "cli_main",
+    "compile_kernel_source",
+    "discover_prim_func",
+    "load_example",
+    "resolve_target",
+]
+
+# D3: explicit CPU C. Never "auto". Bare "cuda" still runs the CUDA normalizer
+# (torch.cuda probe); pin an arch so optional --target cuda does not device-detect.
+DEFAULT_TARGET = "c"
+_PINNED_CUDA_TARGET: dict[str, str] = {"kind": "cuda", "arch": "sm_80"}
+_ERROR_PREFIX = "tilelang compile-only error"
+
+
+def resolve_target(target: str) -> str | dict[str, str]:
+    """Map a CLI/library target string to an explicit lower() target.
+
+    Parameters
+    ----------
+    target : str
+        User-facing target. ``auto`` is rejected. ``cuda`` is pinned to sm_80.
+
+    Returns
+    -------
+    str or dict
+        A TVM target string, or a pinned CUDA target dict.
+    """
+    normalized = target.strip()
+    key = normalized.lower()
+    if not normalized or key == "auto":
+        raise ValueError("target must be explicit; do not use auto")
+    if key == "cuda":
+        return dict(_PINNED_CUDA_TARGET)
+    return normalized
+
+
+def load_example(path: str) -> ModuleType:
+    """Load ``example.py`` as a module (D2). Do not treat it as a launch script."""
+    spec = importlib.util.spec_from_file_location("tilelang_compile_only_input", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load input file: {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def discover_prim_func(module: ModuleType):
+    """Return the first ``@tilelang.jit`` / PrimFunc in module order (D2, 古法: one piece)."""
+    from tilelang.jit import JITImpl
+    from tilelang.language.eager import PrimFunc
+
+    for obj in vars(module).values():
+        if isinstance(obj, JITImpl):
+            return obj.get_tir()
+    for obj in vars(module).values():
+        if isinstance(obj, PrimFunc):
+            return obj
+    raise RuntimeError("no @tilelang.jit kernel or PrimFunc found")
+
+
+def compile_kernel_source(func, target: str | dict[str, str] = DEFAULT_TARGET) -> str:
+    """Lower ``func`` with ``enable_device_compile=False`` and return ``kernel_source`` (D1).
+
+    Parameters
+    ----------
+    func : PrimFunc or IRModule
+        Kernel from ``JITImpl.get_tir()`` or a PrimFunc. No tensor args.
+    target : str or dict, optional
+        Explicit target. Strings go through :func:`resolve_target`. Default ``c``.
+
+    Returns
+    -------
+    str
+        Non-empty ``CompiledArtifact.kernel_source`` from existing ``lower()``.
+    """
+    import tilelang
+    from tvm.target import Target
+
+    if isinstance(target, str):
+        target = resolve_target(target)
+    # Match JITKernel._compile_artifact: LayoutInference reads Target.current().
+    resolved = target if isinstance(target, Target) else Target(target)
+    with tilelang.transform.PassContext(opt_level=3), resolved:
+        artifact = tilelang.lower(func, target=resolved, enable_device_compile=False)
+    source = artifact.kernel_source
+    if not source or not str(source).strip():
+        raise RuntimeError("lower produced empty kernel_source")
+    return str(source)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="tilelang.tools.compile_only",
+        description="Compile a TileLang example to inspectable kernel source without a GPU.",
+    )
+    parser.add_argument("input_file", help="Compile-only example.py (no kernel launch)")
+    parser.add_argument("--output_file", required=True, help="Destination for generated kernel source")
+    parser.add_argument(
+        "--target",
+        default=DEFAULT_TARGET,
+        help="Explicit target (default: c). CUDA is optional: --target cuda",
+    )
+    return parser
+
+
+def cli_main(argv: list[str] | None = None) -> int:
+    """CE-shaped CLI (D2): ``--output_file`` + example.py. Default target ``c`` (D3)."""
+    args = _build_parser().parse_args(argv)
+
+    try:
+        module = load_example(args.input_file)
+        func = discover_prim_func(module)
+        source = compile_kernel_source(func, resolve_target(args.target))
+        Path(args.output_file).write_text(source)
+    except Exception as exc:
+        print(f"{_ERROR_PREFIX}: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(cli_main())

--- a/tilelang/tools/compile_only.py
+++ b/tilelang/tools/compile_only.py
@@ -151,6 +151,20 @@ def discover_prim_func(module: ModuleType):
     raise RuntimeError("no @tilelang.jit kernel or PrimFunc found")
 
 
+def _pass_context_config() -> dict:
+    """Enable ``#line`` when this build registered ``TL_EMIT_LINE_DIRECTIVES``.
+
+    Older wheels reject the unknown pass key. CI merge with main has the
+    option; CE can then map generated C back to the example.
+    """
+    from tilelang.transform import PassConfigKey
+
+    key = getattr(PassConfigKey, "TL_EMIT_LINE_DIRECTIVES", None)
+    if key is None:
+        return {}
+    return {key: True}
+
+
 def compile_kernel_source(func, target: str | dict[str, str] = DEFAULT_TARGET) -> str:
     """Lower ``func`` with ``enable_device_compile=False`` and return ``kernel_source`` (D1).
 
@@ -177,7 +191,7 @@ def compile_kernel_source(func, target: str | dict[str, str] = DEFAULT_TARGET) -
         raise RuntimeError(_CUDA_FFI_MISSING)
     # Match JITKernel._compile_artifact: LayoutInference reads Target.current().
     resolved = target if isinstance(target, Target) else Target(target)
-    with tilelang.transform.PassContext(opt_level=3), resolved:
+    with tilelang.transform.PassContext(opt_level=3, config=_pass_context_config()), resolved:
         artifact = tilelang.lower(func, target=resolved, enable_device_compile=False)
     source = artifact.kernel_source
     if not source or not str(source).strip():

--- a/tilelang/tools/compile_only.py
+++ b/tilelang/tools/compile_only.py
@@ -116,6 +116,11 @@ def resolve_target(target: str) -> str | dict[str, str]:
             raise ValueError(f"target JSON is invalid: {target}") from err
         if not isinstance(parsed, dict) or "kind" not in parsed:
             raise ValueError("target JSON must be an object with kind")
+        kind = _target_kind_name(parsed)
+        if kind == "auto":
+            raise ValueError("target must be explicit; do not use auto")
+        if kind == "cuda" and "arch" not in parsed:
+            return {**_PINNED_CUDA_TARGET, **parsed}
         return parsed
     if _target_kind_name(normalized) == "cuda":
         return _parse_cuda_cli_options(normalized)

--- a/tilelang/tools/compile_only.py
+++ b/tilelang/tools/compile_only.py
@@ -27,6 +27,7 @@ __all__ = [
     "DEFAULT_TARGET",
     "cli_main",
     "compile_kernel_source",
+    "cuda_codegen_available",
     "discover_prim_func",
     "load_example",
     "resolve_target",
@@ -37,6 +38,26 @@ __all__ = [
 DEFAULT_TARGET = "c"
 _PINNED_CUDA_TARGET: dict[str, str] = {"kind": "cuda", "arch": "sm_80"}
 _ERROR_PREFIX = "tilelang compile-only error"
+_CUDA_FFI_MISSING = "CUDA codegen FFI missing (e.g. macOS Metal wheel); use default --target c"
+
+
+def cuda_codegen_available() -> bool:
+    """Return whether this wheel can lower CUDA (``AnnotateDeviceBoundTmaCopies``)."""
+    try:
+        from tilelang.cuda import _ffi_api
+
+        return hasattr(_ffi_api, "AnnotateDeviceBoundTmaCopies")
+    except Exception:
+        return False
+
+
+def _is_cuda_target(target: object) -> bool:
+    if isinstance(target, str):
+        return target.strip().lower() == "cuda"
+    if isinstance(target, dict):
+        return str(target.get("kind", "")).lower() == "cuda"
+    kind = getattr(target, "kind", None)
+    return getattr(kind, "name", None) == "cuda"
 
 
 def resolve_target(target: str) -> str | dict[str, str]:
@@ -106,6 +127,10 @@ def compile_kernel_source(func, target: str | dict[str, str] = DEFAULT_TARGET) -
 
     if isinstance(target, str):
         target = resolve_target(target)
+    # Optional CUDA: Metal wheels lack the transform FFI. Fail clearly instead
+    # of leaking AttributeError from AnnotateDeviceBoundTmaCopies.
+    if _is_cuda_target(target) and not cuda_codegen_available():
+        raise RuntimeError(_CUDA_FFI_MISSING)
     # Match JITKernel._compile_artifact: LayoutInference reads Target.current().
     resolved = target if isinstance(target, Target) else Target(target)
     with tilelang.transform.PassContext(opt_level=3), resolved:

--- a/tilelang/tools/compile_only.py
+++ b/tilelang/tools/compile_only.py
@@ -74,6 +74,7 @@ def _target_kind_name(target: object) -> str:
 
 
 def _is_cuda_target(target: object) -> bool:
+    """Return whether ``target`` parses to the ``cuda`` kind, in any input form."""
     return _target_kind_name(target) == "cuda"
 
 
@@ -213,6 +214,7 @@ def _paths_are_same(left: Path, right: Path) -> bool:
 
 
 def _build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for the compile-only CLI."""
     parser = argparse.ArgumentParser(
         prog="tilelang.tools.compile_only",
         description="Compile a TileLang example to inspectable kernel source without a GPU.",

--- a/tilelang/tools/compile_only.py
+++ b/tilelang/tools/compile_only.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import json
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -51,13 +52,41 @@ def cuda_codegen_available() -> bool:
         return False
 
 
-def _is_cuda_target(target: object) -> bool:
-    if isinstance(target, str):
-        return target.strip().lower() == "cuda"
+def _target_kind_name(target: object) -> str:
+    """Return the TVM target kind after parsing a string, dict, or Target."""
     if isinstance(target, dict):
-        return str(target.get("kind", "")).lower() == "cuda"
+        return str(target.get("kind", "")).strip().lower()
+    if isinstance(target, str):
+        normalized = target.strip()
+        if not normalized:
+            return ""
+        if normalized.startswith("{"):
+            try:
+                parsed = json.loads(normalized)
+            except json.JSONDecodeError:
+                return ""
+            if isinstance(parsed, dict):
+                return str(parsed.get("kind", "")).strip().lower()
+            return ""
+        return normalized.split(None, 1)[0].lower()
     kind = getattr(target, "kind", None)
-    return getattr(kind, "name", None) == "cuda"
+    return str(getattr(kind, "name", "") or "").strip().lower()
+
+
+def _is_cuda_target(target: object) -> bool:
+    return _target_kind_name(target) == "cuda"
+
+
+def _parse_cuda_cli_options(target: str) -> dict[str, str]:
+    """Turn ``cuda -arch=sm_90`` into a TVM JSON-style dict (CLI form is gone)."""
+    parts = target.split()
+    spec = {"kind": "cuda"}
+    for part in parts[1:]:
+        if not part.startswith("-") or "=" not in part[1:]:
+            raise ValueError('CUDA target options must look like -arch=sm_90, or use JSON {"kind": "cuda", "arch": "sm_90"}')
+        key, value = part[1:].split("=", 1)
+        spec[key] = value
+    return spec
 
 
 def resolve_target(target: str) -> str | dict[str, str]:
@@ -67,11 +96,12 @@ def resolve_target(target: str) -> str | dict[str, str]:
     ----------
     target : str
         User-facing target. ``auto`` is rejected. ``cuda`` is pinned to sm_80.
+        Option-bearing CUDA strings (``cuda -arch=sm_90`` or JSON) keep their arch.
 
     Returns
     -------
     str or dict
-        A TVM target string, or a pinned CUDA target dict.
+        A TVM target string, or a CUDA target dict.
     """
     normalized = target.strip()
     key = normalized.lower()
@@ -79,6 +109,16 @@ def resolve_target(target: str) -> str | dict[str, str]:
         raise ValueError("target must be explicit; do not use auto")
     if key == "cuda":
         return dict(_PINNED_CUDA_TARGET)
+    if normalized.startswith("{"):
+        try:
+            parsed = json.loads(normalized)
+        except json.JSONDecodeError as err:
+            raise ValueError(f"target JSON is invalid: {target}") from err
+        if not isinstance(parsed, dict) or "kind" not in parsed:
+            raise ValueError("target JSON must be an object with kind")
+        return parsed
+    if _target_kind_name(normalized) == "cuda":
+        return _parse_cuda_cli_options(normalized)
     return normalized
 
 
@@ -101,7 +141,6 @@ def discover_prim_func(module: ModuleType):
     for obj in vars(module).values():
         if isinstance(obj, JITImpl):
             return obj.get_tir()
-    for obj in vars(module).values():
         if isinstance(obj, PrimFunc):
             return obj
     raise RuntimeError("no @tilelang.jit kernel or PrimFunc found")

--- a/tilelang/tools/compile_only.py
+++ b/tilelang/tools/compile_only.py
@@ -185,6 +185,19 @@ def compile_kernel_source(func, target: str | dict[str, str] = DEFAULT_TARGET) -
     return str(source)
 
 
+def _paths_are_same(left: Path, right: Path) -> bool:
+    """True if both paths name the same file, including via symlink."""
+    try:
+        if left.resolve() == right.resolve():
+            return True
+    except OSError:
+        pass
+    try:
+        return left.exists() and right.exists() and left.samefile(right)
+    except OSError:
+        return False
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="tilelang.tools.compile_only",
@@ -204,6 +217,10 @@ def cli_main(argv: list[str] | None = None) -> int:
     """CE-shaped CLI (D2): ``--output_file`` + example.py. Default target ``c`` (D3)."""
     args = _build_parser().parse_args(argv)
     output = Path(args.output_file)
+    source_path = Path(args.input_file)
+    if _paths_are_same(output, source_path):
+        print(f"{_ERROR_PREFIX}: --output_file must not be the input file", file=sys.stderr)
+        return 1
     # Match CuTe CE wrapper: drop a previous artifact before compile so a
     # failed run cannot leave yesterday's assembly for CE to read.
     output.unlink(missing_ok=True)


### PR DESCRIPTION
Fixes #2913.

`python -m tilelang.tools.compile_only` lowers a kernel to source without running it. Default `--target c`. `--target cuda` is optional and soft-fails on Metal-style wheels.

`auto` is rejected as a string or as JSON. Bare `{"kind":"cuda"}` is pinned to `sm_80`. `--output_file` is removed before compile so a failed CE rerun can't keep the previous dump.

```
python -I -m pytest testing/python/tools/test_tilelang_tools_compile_only.py -q
```

CE: https://github.com/compiler-explorer/compiler-explorer/pull/9029
infra: https://github.com/compiler-explorer/infra/pull/2307


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Adds the official `python -m tilelang.tools.compile_only` CLI.
- Lowers TileLang kernels to inspectable source without running them.
- Defaults to the CPU `c` target.
- Supports optional CUDA targets with validation and soft failure when CUDA FFI is unavailable.
- Rejects `auto` targets and pins bare CUDA targets to `sm_80`.
- Removes stale output before compilation while protecting the input file and symlinks.
- Enables `#line` directives when supported by the installed pass configuration.
- Adds comprehensive CLI, target-resolution, error-handling, line-directive, and optional CUDA tests.
- Supports TileLang integration with Compiler Explorer and related infrastructure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->