### PR TITLE
[CUDA] Fix FP8 min/max codegen

### DIFF
--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -1136,6 +1136,26 @@ template <typename T> TL_DEVICE T fast_min(T a, T b) { return b < a ? b : a; }
 
 template <> TL_DEVICE float fast_min(float a, float b) { return fminf(a, b); }
 
+TL_DEVICE float_e4m3_t max(float_e4m3_t lhs, float_e4m3_t rhs) {
+  return float_e4m3_t(
+      ::fmaxf(static_cast<float>(lhs), static_cast<float>(rhs)));
+}
+
+TL_DEVICE float_e4m3_t min(float_e4m3_t lhs, float_e4m3_t rhs) {
+  return float_e4m3_t(
+      ::fminf(static_cast<float>(lhs), static_cast<float>(rhs)));
+}
+
+TL_DEVICE float_e5m2_t max(float_e5m2_t lhs, float_e5m2_t rhs) {
+  return float_e5m2_t(
+      ::fmaxf(static_cast<float>(lhs), static_cast<float>(rhs)));
+}
+
+TL_DEVICE float_e5m2_t min(float_e5m2_t lhs, float_e5m2_t rhs) {
+  return float_e5m2_t(
+      ::fminf(static_cast<float>(lhs), static_cast<float>(rhs)));
+}
+
 // --- max2 ----------------------------------------------------------------
 
 TL_DEVICE float2 max2(float2 a, float2 b) {

--- a/testing/python/language/test_tilelang_language_clamp.py
+++ b/testing/python/language/test_tilelang_language_clamp.py
@@ -1,3 +1,5 @@
+import pytest
+
 import tilelang.testing
 from tilelang import language as T
 
@@ -111,6 +113,89 @@ def test_clamp():
     run_clamp(1024, 128, T.float32, -0.06, 0.05)
     run_clamp_value_range(1024, 128, T.float16)
     run_clamp_value_range(1024, 128, T.float32)
+
+
+FP8_OPS = {
+    "max": lambda a, b, dtype: T.max(a, b),
+    "min": lambda a, b, dtype: T.min(a, b),
+    "clamp": lambda a, b, dtype: T.clamp(a, T.cast(-1.0, dtype), T.cast(1.0, dtype)),
+}
+
+
+def fp8_operand_kernel(N, block_N, dtype, op):
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), dtype),
+        B: T.Tensor((N,), dtype),
+        C: T.Tensor((N,), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), threads=block_N) as bx:
+            for i in T.Parallel(block_N):
+                C[bx * block_N + i] = FP8_OPS[op](A[bx * block_N + i], B[bx * block_N + i], dtype)
+
+    return main
+
+
+def run_fp8_min_max_clamp(N, block_N, dtype, op):
+    import torch
+
+    kernel = tilelang.compile(fp8_operand_kernel(N, block_N, dtype, op))
+    torch_dtype = dtype.as_torch()
+
+    # Integers are exactly representable in both float8 formats, so the
+    # reference comparison can be exact.
+    a = torch.randint(-4, 5, (N,), device="cuda").to(torch.float32)
+    b = torch.randint(-4, 5, (N,), device="cuda").to(torch.float32)
+    if op == "max":
+        ref = torch.maximum(a, b)
+    elif op == "min":
+        ref = torch.minimum(a, b)
+    else:
+        ref = a.clamp(-1.0, 1.0)
+
+    # Allocate the output here instead of using out_idx: rebuilding a torch
+    # tensor from an fp8 DLPack tensor is not supported on every torch version.
+    C = torch.empty(N, device="cuda", dtype=torch_dtype)
+    kernel(a.to(torch_dtype), b.to(torch_dtype), C)
+    torch.testing.assert_close(C.float(), ref.to(torch_dtype).float(), atol=0, rtol=0)
+
+
+def fp8_operand_vectorized_kernel(N, block_N, dtype, op, vec=4):
+    @T.prim_func
+    def main(
+        A: T.Tensor((N,), dtype),
+        B: T.Tensor((N,), dtype),
+        C: T.Tensor((N,), dtype),
+    ):
+        with T.Kernel(T.ceildiv(N, block_N), threads=block_N // vec) as bx:
+            for i in T.Parallel(block_N // vec):
+                for v in T.vectorized(vec):
+                    idx = bx * block_N + i * vec + v
+                    C[idx] = FP8_OPS[op](A[idx], B[idx], dtype)
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("dtype", [T.float8_e4m3, T.float8_e5m2])
+@pytest.mark.parametrize("op", list(FP8_OPS))
+def test_fp8_min_max_clamp(dtype, op):
+    run_fp8_min_max_clamp(1024, 128, dtype, op)
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("op", list(FP8_OPS))
+def test_fp8_vectorized_min_max(op):
+    # Vectorizing reaches the per-lane fallback, a separate overload-resolution
+    # context from the scalar expression.
+    tilelang.compile(fp8_operand_vectorized_kernel(1024, 128, T.float8_e4m3, op), out_idx=[2], target="cuda")
+
+
+@tilelang.testing.requires_cuda
+def test_fp8_e4m3fn_min_max():
+    # float8_e4m3fn shares the emitted CUDA type with float8_e4m3; clamp covers
+    # both min and max.
+    tilelang.compile(fp8_operand_kernel(1024, 128, T.float8_e4m3fn, "clamp"), out_idx=[2], target="cuda")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`T.max`, `T.min`, and `T.clamp` failed during nvcc compilation when applied to `float8_e4m3` or `float8_e5m2` operands:

```text
error: no operator "=" matches these operands
    operand types are: fp8_e4_t = float
```

## Root cause

CUDA codegen emits unqualified min/max calls for TIR `MinNode` and `MaxNode` expressions:

```cuda
C[i] = max(A[i], B[i]);
```

The FP8 wrappers promote to float, so the call returns float, but the result cannot be implicitly assigned back to the FP8 wrapper. `T.clamp` lowers to nested max and min operations and fails through the same path.

The per-lane vector fallback emits the same unqualified calls and has the same overload-resolution gap.

## Fix

Add `tl::min` and `tl::max` overloads alongside the FP8 wrapper types:

```cpp
TL_DEVICE float_e4m3_t max(float_e4m3_t lhs, float_e4m3_t rhs) {
  return float_e4m3_t(
      ::fmaxf(static_cast<float>(lhs), static_cast<float>(rhs)));
}
```

Equivalent overloads are provided for min and for `float_e5m2_t`.

The existing unqualified calls resolve these overloads through argument-dependent lookup, so scalar expressions, vector lanes, and nested clamp operations reuse the same implementation without adding FP8-specific branches to CUDA codegen.

`float8_e4m3fn` maps to the same emitted CUDA wrapper as `float8_e4m3` and therefore uses the same overloads.

## Tests

Added coverage for:

* exact runtime results for `T.max`, `T.min`, and `T.clamp` with `float8_e4m3` and `float8_e5m2`;
* vectorized max/min/clamp compilation through the per-lane fallback;
* `float8_e4m3fn` overload resolution.

Verified locally on a TITAN RTX (`sm_75`) with CUDA 12.4. The complete clamp test file passes 11 tests.

Fixes #2985

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fix CUDA code generation for `T.max`, `T.min`, and `T.clamp` with FP8 operands.
- Compute results with `fminf` and `fmaxf`, then convert them back to the FP8 type.
- Add overloads for `float_e4m3_t` and `float_e5m2_t`.
- Add scalar and vectorized tests for supported FP8 formats and operation combinations.

## C++ style / lint notes

- The PR does not change the rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit remains warning-only.
- No correctness or build issue is indicated by the reported style changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->