### PR TITLE
[CodeGen] Emit #line directives from TIR spans

### DIFF
--- a/src/backend/common/codegen/codegen_c_line_directives.h
+++ b/src/backend/common/codegen/codegen_c_line_directives.h
@@ -1,22 +1,3 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 /*!
  * \file backend/common/codegen/codegen_c_line_directives.h
  * \brief CodeGenC base that optionally emits #line directives from Stmt spans.

--- a/src/backend/common/codegen/codegen_c_line_directives.h
+++ b/src/backend/common/codegen/codegen_c_line_directives.h
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*!
+ * \file backend/common/codegen/codegen_c_line_directives.h
+ * \brief CodeGenC base that optionally emits #line directives from Stmt spans.
+ */
+
+#ifndef TILELANG_BACKEND_COMMON_CODEGEN_CODEGEN_C_LINE_DIRECTIVES_H_
+#define TILELANG_BACKEND_COMMON_CODEGEN_CODEGEN_C_LINE_DIRECTIVES_H_
+
+#include <string>
+
+#include "target/source/codegen_c.h"
+
+namespace tvm {
+namespace codegen {
+
+/*!
+ * \brief Intermediate CodeGenC base that maps generated statements back to
+ * their Python source lines via `#line` directives (opt-in).
+ *
+ * `CodeGenC::PrintStmt` is non-virtual but forwards to the virtual
+ * `StmtFunctor::VisitStmt`, and every statement recursion in the vendored and
+ * TileLang codegen paths goes through it; overriding `VisitStmt` here
+ * therefore intercepts every printed statement without touching vendored TVM.
+ *
+ * A directive is emitted for every statement that carries a valid span — no
+ * deduplication: after `#line N`, each emitted line advances the logical line
+ * by one, so re-emitting is required to map a second statement from the same
+ * Python line back to N (dedup would drift). Statements without a span simply
+ * inherit the previous directive's mapping.
+ *
+ * Enabled via the `tl.emit_line_directives` pass config (default off), read by
+ * the backend builders before codegen.
+ */
+class CodeGenCWithLineDirectives : public CodeGenC {
+public:
+  void SetEmitLineDirectives(bool enable) { emit_line_directives_ = enable; }
+
+  // Intercept every statement visit. final: leaf codegen classes must not
+  // accidentally shadow the dispatch.
+  void VisitStmt(const Stmt &n) final {
+    if (emit_line_directives_ && n.defined() && n->span.defined()) {
+      EmitSpanDirective_(n->span);
+    }
+    // Qualified call: dispatch through StmtFunctor::VisitStmt to the matching
+    // VisitStmt_ callback without re-entering this override.
+    CodeGenC::VisitStmt(n);
+  }
+
+  // Called by AddFunction between the signature and the body; anchors the
+  // function entry to the PrimFunc's own span.
+  void PreFunctionBody(const PrimFunc &f) override {
+    if (emit_line_directives_ && f.defined() && f->span.defined()) {
+      EmitSpanDirective_(f->span);
+    }
+  }
+
+private:
+  void EmitSpanDirective_(const Span &span) {
+    if (!span->source_name.defined() || span->line <= 0) {
+      return;
+    }
+    const std::string file = static_cast<std::string>(span->source_name->name);
+    // Suppress a re-emission that immediately follows the same directive with
+    // no generated output in between: nothing advanced the logical line, so
+    // the mapping is unchanged and the extra directive would only be noise.
+    // Re-emission after real output still happens (no-dedup semantics).
+    if (span->line == last_line_ && file == last_file_ &&
+        stream.tellp() == last_directive_pos_) {
+      return;
+    }
+    stream << "#line " << span->line << " \"";
+    for (char c : file) {
+      if (c == '\\' || c == '"') {
+        stream << '\\';
+      }
+      stream << c;
+    }
+    stream << "\"\n";
+    last_line_ = span->line;
+    last_file_ = file;
+    last_directive_pos_ = stream.tellp();
+  }
+
+  /*! \brief Whether to emit #line directives (off by default). */
+  bool emit_line_directives_{false};
+  /*! \brief (line, file) of the last emitted directive, for noise
+   * suppression of immediately repeated directives. */
+  int64_t last_line_{0};
+  std::string last_file_;
+  /*! \brief Stream position right after the last emitted directive. */
+  std::streampos last_directive_pos_{};
+};
+
+} // namespace codegen
+} // namespace tvm
+
+#endif // TILELANG_BACKEND_COMMON_CODEGEN_CODEGEN_C_LINE_DIRECTIVES_H_

--- a/src/cpu/codegen/codegen_c.h
+++ b/src/cpu/codegen/codegen_c.h
@@ -31,14 +31,14 @@
 #include <utility>
 #include <vector>
 
-#include "target/source/codegen_c.h"
+#include "backend/common/codegen/codegen_c_line_directives.h"
 #include "tvm/target/codegen.h"
 #include <tvm/tirx/expr.h>
 
 namespace tvm {
 namespace codegen {
 
-class CodeGenTileLangC : public CodeGenC {
+class CodeGenTileLangC : public CodeGenCWithLineDirectives {
 public:
   CodeGenTileLangC();
   void Init(bool output_ssa, bool emit_asserts, bool emit_fwd_func_decl,

--- a/src/cpu/codegen/rt_mod_c.cc
+++ b/src/cpu/codegen/rt_mod_c.cc
@@ -1,7 +1,9 @@
 #include "codegen_c.h"
+#include "op/builtin.h"
 #include "support/check.h"
 #include <tvm/ffi/extra/module.h>
 #include <tvm/ir/cast.h>
+#include <tvm/ir/transform.h>
 
 namespace tvm {
 namespace codegen {
@@ -26,6 +28,10 @@ Module BuildTileLangC(IRModule mod, Target target) {
   cg.Init(output_ssa, emit_asserts, emit_fwd_func_decl, target->str(), devices);
   cg.SetConstantsByteAlignment(
       target->GetAttr<Integer>("constants-byte-alignment").value_or(16));
+  cg.SetEmitLineDirectives(
+      tvm::transform::PassContext::Current()
+          ->GetConfig<Bool>(tl::kEmitLineDirectives, Bool(false))
+          .value());
 
   auto is_aot_executor_fn = [](const PrimFunc &func) -> bool {
     return func->GetAttr<Bool>("runner_function", Bool(false)).value();

--- a/src/cuda/codegen/codegen_cuda.cc
+++ b/src/cuda/codegen/codegen_cuda.cc
@@ -6196,6 +6196,8 @@ void CodeGenTileLangCUDA::AddFunction(const GlobalVar &gvar,
   // Sync-insertion passes may split the block containing rng_init across
   // __syncthreads(), so a declaration emitted at the call site can go out
   // of scope before later rng_rand / rng_rand_float uses.
+  // Emit the function-entry #line before the pre-scan output below.
+  this->PreFunctionBody(f);
   rng_state_name_map_.clear();
   tirx::PostOrderVisit(f->body, [this](const ObjectRef &n) {
     const auto *call = n.as<CallNode>();
@@ -6208,7 +6210,6 @@ void CodeGenTileLangCUDA::AddFunction(const GlobalVar &gvar,
                  << name << ";\n";
     rng_state_name_map_.emplace(call, std::move(name));
   });
-  this->PreFunctionBody(f);
   int func_scope = this->BeginScope();
   this->PrintStmt(f->body);
   this->EndScope(func_scope);

--- a/src/cuda/codegen/codegen_cuda.h
+++ b/src/cuda/codegen/codegen_cuda.h
@@ -15,12 +15,12 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#include "target/source/codegen_c.h"
+#include "backend/common/codegen/codegen_c_line_directives.h"
 
 namespace tvm {
 namespace codegen {
 
-class CodeGenTileLangCUDA final : public CodeGenC {
+class CodeGenTileLangCUDA final : public CodeGenCWithLineDirectives {
 public:
   CodeGenTileLangCUDA();
   std::string Finish();

--- a/src/cuda/codegen/rt_mod_cuda.cc
+++ b/src/cuda/codegen/rt_mod_cuda.cc
@@ -1,4 +1,5 @@
 #include "codegen_cuda.h"
+#include "op/builtin.h"
 #include "runtime/pack_args.h"
 #include "runtime/thread_storage_scope.h"
 #include "support/check.h"
@@ -98,6 +99,10 @@ Module BuildTileLangCUDA(IRModule mod, Target target) {
   bool output_ssa = false;
   CodeGenTileLangCUDA cg;
   cg.Init(output_ssa);
+  cg.SetEmitLineDirectives(
+      tvm::transform::PassContext::Current()
+          ->GetConfig<Bool>(tl::kEmitLineDirectives, Bool(false))
+          .value());
 
   ValidateUniqueDeviceGlobalSymbols(mod);
   if (const auto f = Function::GetGlobal("tilelang_callback_cuda_validate")) {
@@ -141,6 +146,10 @@ Module BuildTileLangCUDAWithoutCompile(IRModule mod, Target target) {
   bool output_ssa = false;
   CodeGenTileLangCUDA cg;
   cg.Init(output_ssa);
+  cg.SetEmitLineDirectives(
+      tvm::transform::PassContext::Current()
+          ->GetConfig<Bool>(tl::kEmitLineDirectives, Bool(false))
+          .value());
 
   ValidateUniqueDeviceGlobalSymbols(mod);
   if (const auto f = Function::GetGlobal("tilelang_callback_cuda_validate")) {

--- a/src/op/builtin.cc
+++ b/src/op/builtin.cc
@@ -33,6 +33,7 @@ TVM_REGISTER_PASS_CONFIG_OPTION(kASTPrintEnable, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kLayoutVisualizationEnable, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kLayoutVisualizationFormats, ffi::String);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDeviceCompileFlags, ffi::Array<ffi::String>);
+TVM_REGISTER_PASS_CONFIG_OPTION(kEmitLineDirectives, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableDataRaceCheck, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableBufferInitCheck, Bool);
 TVM_REGISTER_PASS_CONFIG_OPTION(kDisableLoopUnswitching, Bool);

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -103,6 +103,10 @@ static constexpr const char *kLayoutVisualizationEnable =
 static constexpr const char *kLayoutVisualizationFormats =
     "tl.layout_visualization_formats";
 static constexpr const char *kDeviceCompileFlags = "tl.device_compile_flags";
+/*! \brief Emit #line directives in generated C-family source from TIR spans,
+ * mapping generated statements back to their Python source lines. Default:
+ * false. */
+static constexpr const char *kEmitLineDirectives = "tl.emit_line_directives";
 static constexpr const char *kDisableDataRaceCheck =
     "tl.disable_data_race_check";
 /*! \brief Disable the buffer-initialization check.

--- a/src/transform/split_host_device.cc
+++ b/src/transform/split_host_device.cc
@@ -81,6 +81,8 @@ public:
     host_buffer_map_ = func->buffer_map;
   }
 
+  void SetSourceSpan(const Span &span) { source_span_ = span; }
+
   tirx::Stmt VisitStmt_(const tirx::AttrStmtNode *op) final {
     if (op->attr_key == tvm::attr::kTarget) {
       found_device_region_ = true;
@@ -516,6 +518,9 @@ private:
     }
 
     tirx::PrimFunc device_func(params, body, kernel_ret_type);
+    if (source_span_.defined()) {
+      device_func.CopyOnWrite()->span = source_span_;
+    }
     Map<String, Any> device_attrs = {
         {tvm::attr::kTarget, device_target},
         {tirx::attr::kNoAlias, true},
@@ -563,6 +568,8 @@ private:
   IRModule *device_mod_;
   // Generate new GlobalVar for the kernel
   std::function<GlobalVar()> var_supply_;
+  // Source span of the host PrimFunc, carried onto split device kernels.
+  Span source_span_;
   // Collect assumes in host side
   Array<tirx::AttrStmt> host_assumes_;
 };
@@ -571,6 +578,7 @@ tirx::PrimFunc SplitHostDevice(tirx::PrimFunc func, IRModule *device_mod,
                                std::function<GlobalVar()> var_supply) {
   HostDeviceSplitter splitter(device_mod, std::move(var_supply));
   splitter.SetHostFuncSignature(func);
+  splitter.SetSourceSpan(func->span);
   // Propagate non-restrict parameter list from host func to device kernels
   if (auto opt =
           func->GetAttr<Array<tirx::Var>>(tl::attr::kNonRestrictParams)) {

--- a/testing/python/transform/test_tilelang_codegen_line_directives.py
+++ b/testing/python/transform/test_tilelang_codegen_line_directives.py
@@ -27,7 +27,7 @@ def vec_add(A: T.Tensor((N,), "float32"), B: T.Tensor((N,), "float32")):
 
 @T.prim_func
 def vec_add_cuda(A: T.Tensor((N,), "float32"), B: T.Tensor((N,), "float32")):
-    with T.kernel(1, threads=N) as bx:
+    with T.Kernel(1, threads=N) as bx:
         for i in T.Parallel(N):
             B[bx * N + i] = A[bx * N + i] + 1.0  # line_marker_store_cuda
 

--- a/testing/python/transform/test_tilelang_codegen_line_directives.py
+++ b/testing/python/transform/test_tilelang_codegen_line_directives.py
@@ -1,0 +1,116 @@
+"""Tests for opt-in ``#line`` directive emission in C-family codegen.
+
+With the ``tl.emit_line_directives`` pass config enabled, codegen maps every
+generated statement that carries a TIR span back to its Python source line via
+``#line N "file"``. These tests pin the emission on the CPU ``c`` target
+(no GPU / compiler toolchain needed) and lock the no-deduplication semantics:
+after ``#line N`` each emitted line advances the logical line, so a second
+statement from the same Python line must re-emit ``#line N`` (dedup would
+drift). See docs/issue_2913/codegen_final.md for the design.
+"""
+
+import re
+
+import tilelang
+import tilelang.language as T
+import tilelang.testing
+from tilelang import tvm
+
+N = 128
+
+
+@T.prim_func
+def vec_add(A: T.Tensor((N,), "float32"), B: T.Tensor((N,), "float32")):
+    for i in T.Parallel(N):
+        B[i] = A[i] + 1.0  # line_marker_store
+
+
+def _lowered_source(func, emit: bool) -> str:
+    # target is not passed to lower() explicitly: it resolves through
+    # determine_target("auto") reading the ambient Target("c") context.
+    config = {tilelang.PassConfigKey.TL_EMIT_LINE_DIRECTIVES: emit}
+    with tvm.target.Target("c"), tvm.transform.PassContext(opt_level=3, config=config):
+        artifact = tilelang.lower(func)
+    source = artifact.kernel_source
+    assert source is not None, "CPU C codegen produced no kernel source"
+    return source
+
+
+def _marker_line(marker: str) -> int:
+    with open(__file__) as f:
+        for i, line in enumerate(f, 1):
+            if marker in line:
+                return i
+    raise ValueError(f"marker not found: {marker}")
+
+
+def _line_directives(source: str) -> list[tuple[int, str]]:
+    return [(int(num), fname) for num, fname in re.findall(r'^#line (\d+) "(.*)"$', source, re.M)]
+
+
+def test_line_directives_emitted_when_enabled():
+    source = _lowered_source(vec_add, emit=True)
+    directives = _line_directives(source)
+    assert directives, f"no #line directives emitted:\n{source}"
+
+    # Directives must point back at this test file (span SourceName).
+    files = {fname for _, fname in directives}
+    assert __file__ in files, f"expected {__file__} among {files}:\n{source}"
+
+    # The function entry must be anchored to the user's def line, and the
+    # store statement to its actual source line.
+    def_line = _marker_line("def vec_add")
+    assert (def_line, __file__) in directives, (
+        f"function entry line {def_line} not mapped (PrimFunc span lost?); directives: {directives}\n{source}"
+    )
+    store_line = _marker_line("line_marker_store")
+    assert (store_line, __file__) in directives, f"store line {store_line} not mapped; directives: {directives}\n{source}"
+
+
+def test_line_directives_disabled_by_default():
+    source = _lowered_source(vec_add, emit=False)
+    assert "#line" not in source, source
+
+
+def test_line_directives_disabled_when_config_absent():
+    """The default path (config key entirely absent) must not emit either."""
+    with tvm.target.Target("c"), tvm.transform.PassContext(opt_level=3):
+        artifact = tilelang.lower(vec_add)
+    assert artifact.kernel_source is not None
+    assert "#line" not in artifact.kernel_source, artifact.kernel_source
+
+
+@tilelang.testing.requires_cuda
+def test_line_directives_cuda_source():
+    """CUDA source (compile-only path, no GPU/nvcc) also maps statements."""
+    target = {"kind": "cuda", "arch": "sm_80"}
+    config = {tilelang.PassConfigKey.TL_EMIT_LINE_DIRECTIVES: True}
+    with tvm.transform.PassContext(opt_level=3, config=config), tvm.target.Target(target):
+        artifact = tilelang.lower(vec_add, target=target)
+    source = artifact.kernel_source
+    assert source is not None, "CUDA codegen produced no kernel source"
+    directives = _line_directives(source)
+    store_line = _marker_line("line_marker_store")
+    assert (store_line, __file__) in directives, f"store line {store_line} not mapped; directives: {directives}\n{source}"
+
+
+def test_same_line_statements_reemit_directive():
+    """Statements lowered from one Python line must each re-emit ``#line N``.
+
+    The single store ``B[i] = A[i] + 1.0`` lowers to several statements that
+    share its span (the hoisted broadcast declaration plus the store itself),
+    so its line must appear as several directives. This locks the no-dedup
+    semantics: with (file, line) deduplication only the first would be emitted
+    and the following statements would drift to logical lines N+1, N+2, ...
+    """
+    source = _lowered_source(vec_add, emit=True)
+    directives = _line_directives(source)
+    store_line = _marker_line("line_marker_store")
+    same_line = [d for d in directives if d == (store_line, __file__)]
+    assert len(same_line) >= 2, (
+        f"expected >=2 re-emitted directives for line {store_line}, got {same_line}; all directives: {directives}\n{source}"
+    )
+
+
+if __name__ == "__main__":
+    tilelang.testing.main()

--- a/testing/python/transform/test_tilelang_codegen_line_directives.py
+++ b/testing/python/transform/test_tilelang_codegen_line_directives.py
@@ -25,6 +25,13 @@ def vec_add(A: T.Tensor((N,), "float32"), B: T.Tensor((N,), "float32")):
         B[i] = A[i] + 1.0  # line_marker_store
 
 
+@T.prim_func
+def vec_add_cuda(A: T.Tensor((N,), "float32"), B: T.Tensor((N,), "float32")):
+    with T.kernel(1, threads=N) as bx:
+        for i in T.Parallel(N):
+            B[bx * N + i] = A[bx * N + i] + 1.0  # line_marker_store_cuda
+
+
 def _lowered_source(func, emit: bool) -> str:
     # target is not passed to lower() explicitly: it resolves through
     # determine_target("auto") reading the ambient Target("c") context.
@@ -83,14 +90,14 @@ def test_line_directives_disabled_when_config_absent():
 @tilelang.testing.requires_cuda
 def test_line_directives_cuda_source():
     """CUDA source (compile-only path, no GPU/nvcc) also maps statements."""
-    target = {"kind": "cuda", "arch": "sm_80"}
+    target = {"kind": "cuda"}
     config = {tilelang.PassConfigKey.TL_EMIT_LINE_DIRECTIVES: True}
     with tvm.transform.PassContext(opt_level=3, config=config), tvm.target.Target(target):
-        artifact = tilelang.lower(vec_add, target=target)
+        artifact = tilelang.lower(vec_add_cuda, target=target)
     source = artifact.kernel_source
     assert source is not None, "CUDA codegen produced no kernel source"
     directives = _line_directives(source)
-    store_line = _marker_line("line_marker_store")
+    store_line = _marker_line("line_marker_store_cuda")
     assert (store_line, __file__) in directives, f"store line {store_line} not mapped; directives: {directives}\n{source}"
 
 

--- a/tilelang/metal/transform/mark_host_metal_context.py
+++ b/tilelang/metal/transform/mark_host_metal_context.py
@@ -51,7 +51,7 @@ def MarkHostMetalContext():
     def pass_fn(func, mod, ctx):
         mutator = _MarkHostMetalContextMutator()
         new_body = mutator.visit_stmt(func.body)
-        return func.with_body(new_body)
+        return func.with_body(new_body, span=func.span)
 
     return prim_func_pass(pass_fn, opt_level=0)
 

--- a/tilelang/metal/transform/metal_fragment_to_simdgroup.py
+++ b/tilelang/metal/transform/metal_fragment_to_simdgroup.py
@@ -162,7 +162,7 @@ def _metal_fragment_to_simdgroup(func: tir.PrimFunc, mod: IRModule, ctx) -> tir.
         new_ptr = PointerType(ptr_type.element_type, "metal.simdgroup")
         var_map[var] = tir.Var(var.name, new_ptr)
 
-    return func.with_body(_rewrite_scope(func.body, var_map, num_warps))
+    return func.with_body(_rewrite_scope(func.body, var_map, num_warps), span=func.span)
 
 
 MetalFragmentToSimdgroup = prim_func_pass(

--- a/tilelang/transform/add_bufstore_wrapper.py
+++ b/tilelang/transform/add_bufstore_wrapper.py
@@ -154,6 +154,6 @@ def AddWrapperForSingleBufStore():
 
         new_body = ir_transform(func.body, pre_visit, post_visit)
 
-        return func.with_body(new_body)
+        return func.with_body(new_body, span=func.span)
 
     return prim_func_pass(pass_fn, opt_level=0, name="tl.AddWrapperForSingleBufStore")

--- a/tilelang/transform/decouple_type_cast.py
+++ b/tilelang/transform/decouple_type_cast.py
@@ -658,6 +658,6 @@ def DecoupleTypeCast():
     def pass_fn(func: PrimFunc, mod, ctx) -> PrimFunc:
         mutator = DecoupleTypeCastMutator()
         new_body = mutator.visit_stmt(func.body)
-        return func.with_body(new_body)
+        return func.with_body(new_body, span=func.span)
 
     return prim_func_pass(pass_fn, opt_level=0, name="tl.DecoupleTypeCast")

--- a/tilelang/transform/hoist_broadcast_values.py
+++ b/tilelang/transform/hoist_broadcast_values.py
@@ -94,6 +94,6 @@ def HoistBroadcastValues():
     def pass_fn(func: PrimFunc, mod, ctx):
         mutator = HoistBroadcastValuesMutator()
         new_body = mutator.visit_stmt(func.body)
-        return func.with_body(new_body)
+        return func.with_body(new_body, span=func.span)
 
     return prim_func_pass(pass_fn, opt_level=0)

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -97,6 +97,13 @@ class PassConfigKey(str, Enum):
     CUDA compile callback. Default: None
     """
 
+    TL_EMIT_LINE_DIRECTIVES = "tl.emit_line_directives"
+    """Emit ``#line`` directives in generated C-family source from TIR spans,
+    mapping generated statements back to their Python source lines. Combined
+    with the always-on ``-lineinfo`` for nvcc, PTX ``.loc`` entries then point
+    at the Python source. Default: False
+    """
+
     TL_CONFIG_INDEX_BITWIDTH = "tl.config_index_bitwidth"
     """Bitwidth for configuration indices. Default: 32"""
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added opt-in `#line` directive emission for generated C and CUDA code.
- Mapped generated statements and function bodies to TIR source spans.
- Added the `tl.emit_line_directives` pass configuration with a default value of `false`.
- Preserved `PrimFunc` spans across host-device splitting and body-rewriting transforms.
- Added CPU and CUDA tests for source mapping, default behavior, and repeated source lines.

## C++ style / lint notes

- The PR changes C++ code and public C++ class inheritance.
- The changes may touch rules documented in `docs/developer_guide/cpp_style.md`, if the guide covers public API declarations and inheritance.
- The “C++ API Style Audit (warning only)” CI step is relevant.
- TLCPP003/TLCPP004 findings are advisory. They should not block merge unless they indicate a correctness, build, API, FFI, or maintainability risk.
- No correctness or build issue is identified in the provided summary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->