### PR TITLE
[BugFix][Layout] Avoid thread-indexed wide reducer finalize readback

### DIFF
--- a/src/transform/reducer_plan_materialize.cc
+++ b/src/transform/reducer_plan_materialize.cc
@@ -384,6 +384,67 @@ bool CollectOverrideChain(const VarNode *root, const UseGraph &graph,
 
 bool IsPowerOfTwo(int64_t x) { return x > 0 && (x & (x - 1)) == 0; }
 
+/*! \brief Wide-plan destination override. The wide finalize publishes through
+ *  an `accumulator -> dst` copy. When LayoutInference gave dst a distributed
+ *  free-level layout (picked only to serve the later `dst -> global` copy),
+ *  that publication copy partitions by dst ownership and reads the fully
+ *  replicated accumulator registers at thread-dependent physical indices;
+ *  ptxas lowers the whole array to local memory. When the destination chain
+ *  is unconstrained (finalize-written, read only by copies to global or into
+ *  further unconstrained fragments), those free-level layouts were arbitrary
+ *  choices: replace them with participant-wide replication so every
+ *  fragment-to-fragment copy on the chain lowers to per-thread identity
+ *  slots and the final global publication takes the static-index
+ *  replica-zero path. Returns the layout entries to publish, or nothing when
+ *  the chain has other consumers (their inferred layouts then stand). */
+std::optional<std::vector<std::pair<Buffer, Fragment>>>
+TryWideFinalizeDstOverride(const EpochInfo &epoch,
+                           const Map<Buffer, Layout> &known_layouts,
+                           const UseGraph &use_graph) {
+  if (!epoch.dst.defined() || !IsFragmentBuffer(epoch.dst) ||
+      epoch.thread_extent <= 0) {
+    return std::nullopt;
+  }
+  // Without an inferred layout MaterializeFinalize already assigns
+  // participant-wide replication itself.
+  if (!known_layouts.count(epoch.dst)) {
+    return std::nullopt;
+  }
+  std::vector<Buffer> chain;
+  if (!CollectOverrideChain(epoch.dst->data.get(), use_graph, &chain)) {
+    return std::nullopt;
+  }
+  std::vector<std::pair<Buffer, Fragment>> entries;
+  auto add_entry = [&](const Buffer &buffer) -> bool {
+    for (const auto &dim : buffer->shape) {
+      if (!as_const_int(dim)) {
+        return false;
+      }
+    }
+    Fragment layout = Fragment::FullyReplicated(
+        buffer->shape, IntImm(DataType::Int(32), epoch.thread_extent));
+    if (epoch.thread_min != 0) {
+      // Copy loop layouts derived from these fragments carry the thread
+      // range; warp-specialized participants need the real one, not
+      // FullyReplicated's default [0, extent).
+      layout = layout->BindThreadRange(Range(
+          IntImm(DataType::Int(32), epoch.thread_min),
+          IntImm(DataType::Int(32), epoch.thread_min + epoch.thread_extent)));
+    }
+    entries.emplace_back(buffer, layout);
+    return true;
+  };
+  if (!add_entry(epoch.dst)) {
+    return std::nullopt;
+  }
+  for (const Buffer &staged : chain) {
+    if (!add_entry(staged)) {
+      return std::nullopt;
+    }
+  }
+  return entries;
+}
+
 /*! \brief A contribution is replica-safe when every physical execution of
  *  the same logical iteration computes the same value: pure expressions of
  *  loop vars plus loads from buffers whose replicas are value-equal by
@@ -827,9 +888,23 @@ public:
           }
         }
       } else {
+        // Same pre-traversal registration rationale as the narrow overrides
+        // above; per-buffer participant-wide replication instead of the
+        // induced layout.
+        auto wide_override =
+            TryWideFinalizeDstOverride(epoch, known_layouts, use_graph);
+        if (wide_override.has_value()) {
+          for (const auto &[buffer, layout] : *wide_override) {
+            rewriter.extra_layout_entries_.Set(buffer, layout);
+          }
+        }
         std::string msg =
             "[ReducerPlan] `" + std::string(epoch.buffer->name) +
             "`: wide plan (FullParticipant); narrow rejected: " + reason;
+        if (wide_override.has_value()) {
+          msg += "; unconstrained finalize destination re-layouted to "
+                 "participant-wide replication";
+        }
         if (verbose) {
           LOG(INFO) << msg;
         } else {

--- a/testing/python/language/test_tilelang_language_reducer_v2.py
+++ b/testing/python/language/test_tilelang_language_reducer_v2.py
@@ -10,6 +10,8 @@ Covers the FullParticipant wide baseline:
   - epoch lifecycle / illegal access diagnostics.
 """
 
+import re
+
 import pytest
 import tilelang
 import tilelang as tl
@@ -1041,6 +1043,202 @@ def test_reject_finalize_in_extra_loop():
         return kernel
 
     _compile_expect_error(make, "not in the scope of its T.reducer_init")
+
+
+# ---------------------------------------------------------------------------
+# Wide-plan finalize publication (thread-indexed readback regression)
+# ---------------------------------------------------------------------------
+#
+# Serial loop vars driving the update indices reject the narrow plan, so the
+# epoch takes the wide FullParticipant baseline. The finalize publishes
+# `accumulator -> result` with a tl.copy; under the free-level distributed
+# layout LayoutInference picked for `result` (serving only the later
+# `result -> global` copy), that copy reads the fully replicated accumulator
+# registers at thread-dependent physical indices and ptxas lowers the whole
+# array to local memory. The planner must re-layout the unconstrained
+# destination chain to participant-wide replication instead: static register
+# indices everywhere and a replica-zero guard on the global store.
+
+
+def _assert_static_wide_publication(source, local_arrays):
+    for name in local_arrays:
+        assert not re.search(rf"\b{name}\[[^\]\n]*threadIdx", source), source
+    assert "if (((int)threadIdx.x) == 0)" in source, source
+
+
+def _wide_plan_outer_product_kernel(K=256, threads=128):
+    """acc[i, j] += src[i, k] * src2[j, k] with serial i, j: wide plan."""
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((4, K), T.float32),
+        A2: T.Tensor((4, K), T.float32),
+        B: T.Tensor((4, 4), T.float32),
+    ):
+        with T.Kernel(1, threads=threads):
+            src = T.alloc_fragment((4, K), T.float32)
+            src2 = T.alloc_fragment((4, K), T.float32)
+            T.copy(A, src)
+            T.copy(A2, src2)
+            acc = T.alloc_reducer((4, 4), T.float32, op="sum")
+            T.reducer_init(acc)
+            for i in T.serial(4):
+                for j in T.serial(4):
+                    for k in T.Parallel(K):
+                        T.reducer_update(acc[i, j], src[i, k] * src2[j, k])
+            result = T.alloc_fragment((4, 4), T.float32)
+            T.finalize_reducer(acc, result)
+            T.copy(result, B)
+
+    return kernel
+
+
+def test_wide_plan_finalize_publication_static_indices_2d():
+    K = 256
+    kernel = tl.compile(_wide_plan_outer_product_kernel(K), out_idx=-1)
+    _assert_static_wide_publication(kernel.get_kernel_source(), ["acc", "result"])
+
+    A = torch.randn(4, K, dtype=torch.float32, device="cuda")
+    A2 = torch.randn(4, K, dtype=torch.float32, device="cuda")
+    B = kernel(A, A2)
+    torch.testing.assert_close(B, A @ A2.T, atol=1e-2, rtol=1e-2)
+
+
+def test_wide_plan_finalize_publication_static_indices_1d():
+    K, threads = 256, 128
+
+    @T.prim_func
+    def kernel(A: T.Tensor((4, K), T.float32), B: T.Tensor((4,), T.float32)):
+        with T.Kernel(1, threads=threads):
+            src = T.alloc_fragment((4, K), T.float32)
+            T.copy(A, src)
+            acc = T.alloc_reducer((4,), T.float32, op="sum")
+            T.reducer_init(acc)
+            for i in T.serial(4):
+                for k in T.Parallel(K):
+                    T.reducer_update(acc[i], src[i, k])
+            result = T.alloc_fragment((4,), T.float32)
+            T.finalize_reducer(acc, result)
+            T.copy(result, B)
+
+    compiled = tl.compile(kernel, out_idx=-1)
+    _assert_static_wide_publication(compiled.get_kernel_source(), ["acc", "result"])
+
+    A = torch.randn(4, K, dtype=torch.float32, device="cuda")
+    B = compiled(A)
+    torch.testing.assert_close(B, A.sum(dim=1), atol=1e-2, rtol=1e-2)
+
+
+def test_wide_plan_finalize_publication_legacy_entry():
+    """The legacy (v1) syntax reaches the same wide plan through
+    CanonicalizeLegacyReducer's fresh `acc_result` destination."""
+    K, threads = 256, 128
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((4, K), T.float32),
+        A2: T.Tensor((4, K), T.float32),
+        B: T.Tensor((4, 4), T.float32),
+    ):
+        with T.Kernel(1, threads=threads):
+            src = T.alloc_fragment((4, K), T.float32)
+            src2 = T.alloc_fragment((4, K), T.float32)
+            T.copy(A, src)
+            T.copy(A2, src2)
+            acc = T.alloc_reducer((4, 4), T.float32, replication="all")
+            T.clear(acc)
+            for i in T.serial(4):
+                for j in T.serial(4):
+                    for k in T.Parallel(K):
+                        acc[i, j] += src[i, k] * src2[j, k]
+            T.finalize_reducer(acc)
+            T.copy(acc, B)
+
+    compiled = tl.compile(kernel, out_idx=-1)
+    _assert_static_wide_publication(compiled.get_kernel_source(), ["acc", "acc_result"])
+
+    A = torch.randn(4, K, dtype=torch.float32, device="cuda")
+    A2 = torch.randn(4, K, dtype=torch.float32, device="cuda")
+    B = compiled(A, A2)
+    torch.testing.assert_close(B, A @ A2.T, atol=1e-2, rtol=1e-2)
+
+
+def test_wide_plan_finalize_staged_chain_override():
+    """`result` feeds a dtype-converting staging fragment before global: the
+    whole unconstrained chain is re-layouted together, so both hops keep
+    static register indices."""
+    K, threads = 256, 128
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((4, K), T.float32),
+        A2: T.Tensor((4, K), T.float32),
+        B: T.Tensor((4, 4), T.float16),
+    ):
+        with T.Kernel(1, threads=threads):
+            src = T.alloc_fragment((4, K), T.float32)
+            src2 = T.alloc_fragment((4, K), T.float32)
+            T.copy(A, src)
+            T.copy(A2, src2)
+            acc = T.alloc_reducer((4, 4), T.float32, op="sum")
+            T.reducer_init(acc)
+            for i in T.serial(4):
+                for j in T.serial(4):
+                    for k in T.Parallel(K):
+                        T.reducer_update(acc[i, j], src[i, k] * src2[j, k])
+            result = T.alloc_fragment((4, 4), T.float32)
+            T.finalize_reducer(acc, result)
+            staged = T.alloc_fragment((4, 4), T.float16)
+            T.copy(result, staged)
+            T.copy(staged, B)
+
+    compiled = tl.compile(kernel, out_idx=-1)
+    _assert_static_wide_publication(compiled.get_kernel_source(), ["acc", "result", "staged"])
+
+    A = torch.randn(4, K, dtype=torch.float32, device="cuda")
+    A2 = torch.randn(4, K, dtype=torch.float32, device="cuda")
+    B = compiled(A, A2)
+    torch.testing.assert_close(B, (A @ A2.T).to(torch.float16), atol=1e-1, rtol=1e-2)
+
+
+def test_wide_plan_dst_extra_consumer_not_overridden():
+    """A destination with a consumer beyond the copy chain must keep its
+    inferred layout (the override proof rejects it) and stay correct."""
+    K, threads = 256, 128
+
+    @T.prim_func
+    def kernel(
+        A: T.Tensor((4, K), T.float32),
+        A2: T.Tensor((4, K), T.float32),
+        B: T.Tensor((4, 4), T.float32),
+        C: T.Tensor((4, 4), T.float32),
+    ):
+        with T.Kernel(1, threads=threads):
+            src = T.alloc_fragment((4, K), T.float32)
+            src2 = T.alloc_fragment((4, K), T.float32)
+            T.copy(A, src)
+            T.copy(A2, src2)
+            acc = T.alloc_reducer((4, 4), T.float32, op="sum")
+            T.reducer_init(acc)
+            for i in T.serial(4):
+                for j in T.serial(4):
+                    for k in T.Parallel(K):
+                        T.reducer_update(acc[i, j], src[i, k] * src2[j, k])
+            result = T.alloc_fragment((4, 4), T.float32)
+            T.finalize_reducer(acc, result)
+            doubled = T.alloc_fragment((4, 4), T.float32)
+            for i, j in T.Parallel(4, 4):
+                doubled[i, j] = result[i, j] * T.float32(2.0)
+            T.copy(result, B)
+            T.copy(doubled, C)
+
+    compiled = tl.compile(kernel, out_idx=[-2, -1])
+    A = torch.randn(4, K, dtype=torch.float32, device="cuda")
+    A2 = torch.randn(4, K, dtype=torch.float32, device="cuda")
+    B, C = compiled(A, A2)
+    ref = A @ A2.T
+    torch.testing.assert_close(B, ref, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(C, ref * 2, atol=1e-2, rtol=1e-2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Publish unconstrained wide-plan finalize destinations with participant-wide replicated layouts.
- Prevent fully replicated reducer results from being lowered to local arrays with thread-dependent readback such as `reducer[threadIdx.x & 15]`.
- Keep the inferred layout unchanged when the destination copy chain has another consumer and cannot be overridden safely.

## Implementation

- Reuse the finalize-destination copy-chain census to prove that every overridden layout is confined to the reducer publication chain.
- Register the selected layouts before reducer materialization so downstream copies retain static register indices.
- Cover nonzero warp-specialized thread ranges and dtype-converting staging chains.

## Validation

- `./format.sh`
- `cmake --build build -j64` with both the default and CUDA-enabled configurations
- Focused reducer-v2 regression tests:

```bash
python -m pytest -q \
  testing/python/language/test_tilelang_language_reducer_v2.py::test_wide_plan_finalize_publication_static_indices_2d \
  testing/python/language/test_tilelang_language_reducer_v2.py::test_wide_plan_finalize_publication_static_indices_1d \
  testing/python/language/test_tilelang_language_reducer_v2.py::test_wide_plan_finalize_publication_legacy_entry \
  testing/python/language/test_tilelang_language_reducer_v2.py::test_wide_plan_finalize_staged_chain_override \
  testing/python/language/test_tilelang_language_reducer_v2.py::test_wide_plan_dst_extra_consumer_not_overridden
```

  Result: 5 passed.

- TileKernels MHC backward benchmark (`n=512`, `h=4096`): 15.68 us via CUPTI, with no thread-dependent reducer-result loads in the generated CUDA.

The full reducer-v2 file additionally reported 51 passed and one unrelated target-sensitive packed-narrow codegen assertion (`SumOp, 8` expected versus `SumOp, 4` on the auto-selected target). That test does not enter the modified wide-plan branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fix wide reducer finalize publication layouts.
- Use participant-wide replicated layouts for unconstrained wide-plan finalize destinations.
- Prevent fully replicated reducer results from lowering to thread-indexed local-array readbacks.
- Preserve inferred layouts when copy chains have additional consumers.
- Register selected layouts before reducer materialization.
- Add regression tests for 1D and 2D reductions, legacy syntax, dtype-converting staging chains, additional consumers, warp-specialized ranges, and dual outputs.
- Validate formatting, default and CUDA-enabled builds, five reducer-v2 tests, and the TileKernels MHC backward benchmark.

## C++ style / lint notes

- The PR changes C++ implementation code but does not change documented rules in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) remains applicable.
- No correctness or build issue is reported from style warnings. Advisory TLCPP003/TLCPP004 findings should not block merge unless they indicate a new API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->