### PR TITLE
[TIR][Transform] Handle grid barriers and unbounded pointer ranges

### DIFF
--- a/src/transform/thread_storage_sync.cc
+++ b/src/transform/thread_storage_sync.cc
@@ -1253,6 +1253,16 @@ struct TileLangThreadSyncPlanner : public ConstrVisitor {
         e.scope = StorageScope::Create(s);
         curr_stmt_.access.emplace_back(std::move(e));
       }
+    } else if (op->op.same_as(tl::sync_grid())) {
+      // grid.sync() synchronizes every thread of every block and is a full
+      // memory fence, so it subsumes a block-level barrier for any storage
+      // scope planned here.
+      ICHECK(allow_append_);
+      AccessEntry e{.cset = {constr_stack_}};
+      e.threads = env_threads();
+      e.type = kSync;
+      e.scope = sync_scope_;
+      curr_stmt_.access.emplace_back(std::move(e));
     } else {
       ConstrVisitor::VisitExpr_(op);
     }
@@ -1520,6 +1530,16 @@ private:
     PrimExpr lhs_max = analyzer.Simplify(lhs.touched[0].max());
     PrimExpr rhs_min = analyzer.Simplify(rhs.touched[0].min());
     PrimExpr rhs_max = analyzer.Simplify(rhs.touched[0].max());
+    // A touched interval relaxed to (half-)unbounded carries TVM's symbolic
+    // infinity sentinels, which are handle-typed vars: comparing them against
+    // integer offsets throws a dtype mismatch inside tvm::less. An unbounded
+    // side can never prove disjointness anyway (e.g. an atomic whose index is
+    // a data-dependent load), so answer conservatively.
+    for (const PrimExpr &bound : {lhs_min, lhs_max, rhs_min, rhs_max}) {
+      if (!bound.dtype().is_int() && !bound.dtype().is_uint()) {
+        return false;
+      }
+    }
     Map<Var, PrimExpr> prev_sub, curr_sub;
     for (unsigned idx = 0; idx != 3; ++idx) {
       auto &info = thread_vars[idx];

--- a/testing/python/transform/test_tilelang_transform_thread_sync.py
+++ b/testing/python/transform/test_tilelang_transform_thread_sync.py
@@ -1285,5 +1285,89 @@ def test_sync_may_stay_inside_block_uniform_guard():
     assert 'T.tvm_storage_sync("shared")' in s, f"Expected a barrier for a cross-thread hazard:\n{s}"
 
 
+@tilelang.testing.requires_cuda
+def test_unbounded_atomic_touched_range_stays_conservative():
+    """Regression: an atomic whose address is data-dependent relaxes its
+    touched interval to (-inf, +inf), and those symbolic infinity sentinels
+    are handle-typed. Comparing them against a bounded pointer access inside
+    PointerAccessIsDisjoint threw `Cannot match type int32 vs handle`; the
+    planner must instead answer "not disjoint" and keep the sync."""
+
+    @T.prim_func(private=True)
+    def func():
+        A_shared = T.alloc_buffer((256,), dtype="float32", scope="shared")
+        idx = T.alloc_buffer((16,), dtype="int32", scope="shared")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        # Bounded pointer access covering the whole buffer (fill-style).
+        T.evaluate(
+            T.call_extern(
+                "handle",
+                "fake_fill",
+                T.tvm_access_ptr(T.type_annotation("float32"), A_shared.data, 0, 256, 2),
+            )
+        )
+        # Data-dependent atomic destination: the touched interval relaxes to
+        # everything once the enclosing loop is summarized.
+        for i in range(16):
+            T.evaluate(
+                T.call_intrin(
+                    "float32",
+                    tvm.tirx.op.Op.get("tl.atomic_add_elem_op"),
+                    T.address_of(A_shared[idx[i]]),
+                    T.float32(1),
+                    T.int32(0),
+                )
+            )
+
+    mod = tvm.IRModule({"main": func})
+    # Must not throw; the unprovable pair keeps its conservative barrier.
+    mod = tilelang.transform.ThreadSync("shared")(mod)
+    s = str(mod.script())
+    assert 'T.tvm_storage_sync("shared")' in s, f"Expected a conservative barrier:\n{s}"
+
+
+@tilelang.testing.requires_cuda
+def test_sync_grid_acts_as_shared_barrier():
+    """grid.sync() synchronizes every thread of every block, so the planner
+    must treat it as a block-level barrier too: accesses on the two sides of
+    a sync_grid need no extra __syncthreads(), and (regression) the
+    unprovable fill-vs-data-dependent-atomic pair is never even compared."""
+
+    @T.prim_func(private=True)
+    def func():
+        A_shared = T.alloc_buffer((256,), dtype="float32", scope="shared")
+        idx = T.alloc_buffer((16,), dtype="int32", scope="shared")
+        bx = T.launch_thread("blockIdx.x", 1)
+        tx = T.launch_thread("threadIdx.x", 128)
+        ty = T.launch_thread("threadIdx.y", 1)
+        tz = T.launch_thread("threadIdx.z", 1)
+        T.evaluate(
+            T.call_extern(
+                "handle",
+                "fake_fill",
+                T.tvm_access_ptr(T.type_annotation("float32"), A_shared.data, 0, 256, 2),
+            )
+        )
+        T.evaluate(T.call_intrin("handle", tvm.tirx.op.Op.get("tl.sync_grid")))
+        for i in range(16):
+            T.evaluate(
+                T.call_intrin(
+                    "float32",
+                    tvm.tirx.op.Op.get("tl.atomic_add_elem_op"),
+                    T.address_of(A_shared[idx[i]]),
+                    T.float32(1),
+                    T.int32(0),
+                )
+            )
+
+    mod = tvm.IRModule({"main": func})
+    mod = tilelang.transform.ThreadSync("shared")(mod)
+    s = str(mod.script())
+    assert 'T.tvm_storage_sync("shared")' not in s, f"sync_grid already covers the barrier:\n{s}"
+
+
 if __name__ == "__main__":
     tilelang.testing.main()


### PR DESCRIPTION
## Summary

- Recognize `tl.sync_grid` as an existing synchronization point during shared-memory thread-sync planning, avoiding redundant block barriers.
- Keep pointer-access conflict analysis conservative when touched ranges contain TVM's symbolic unbounded sentinels, preventing integer-versus-handle comparison failures.

## Changes

- Record grid-wide synchronization as a `kSync` access entry for the active storage scope.
- Stop disjointness proofs before ordering non-integer interval bounds.
- Cover both an unbounded data-dependent atomic range and a grid barrier separating the same hazard pattern.

## Validation

- `./format.sh`
- `cmake --build build -j16`
- `python -m pytest testing/python/transform/test_tilelang_transform_thread_sync.py -x` (41 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Recognize `tl.sync_grid` as a synchronization point for the active storage scope.
- Record grid synchronization as `kSync` access to avoid redundant block barriers.
- Handle symbolic unbounded pointer ranges conservatively.
- Add CUDA regression tests for atomic ranges and grid barriers.

## C++ style / lint notes

- The PR changes C++ code.
- No changes affect rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit remains warning-only.
- No correctness, build, or test issues are reported.
- No new blocking style issue is identified.

## Validation

- Formatting completed successfully.
- Build completed successfully.
- 41 thread-sync transform tests passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->