### PR TITLE
[CUDA] Remove `T.{reads,writes}` for `T.tma_{gather4,scatter4}`

### DIFF
--- a/src/tl_templates/cuda/copy_sm100.h
+++ b/src/tl_templates/cuda/copy_sm100.h
@@ -11,6 +11,7 @@
 #include "tcgen_05.h"
 #include "tcgen_05_ld.h"
 #include "tcgen_05_st.h"
+#include <cute/arch/config.hpp>
 
 namespace tl {
 
@@ -579,7 +580,8 @@ TL_DEVICE void tma_load_2sm(const CUtensorMap &descriptor,
 }
 
 // cp.async.bulk.tensor.2d.tile::{gather4,scatter4} (PTX 8.6).
-// The shared::cta gather4 form requires sm_100; scatter4 requires sm_100a.
+// The shared::cta gather4 form requires sm_100; scatter4 requires an
+// arch-/family-specific target, same set as CuTe's SM100 TMA atoms.
 // Five coordinate operands: {col, r0, r1, r2, r3}; the 4-row pack is implicit.
 // CacheHintSm90 reused from copy_sm90.h (always included alongside this file).
 #if (__CUDACC_VER_MAJOR__ > 12) ||                                             \
@@ -619,7 +621,7 @@ TL_DEVICE void
 tma_store_scatter4(const CUtensorMap &descriptor, void const *const smem_ptr,
                    int32_t const &col, int32_t const &r0, int32_t const &r1,
                    int32_t const &r2, int32_t const &r3) {
-#if defined(__CUDA_ARCH_FEAT_SM100_ALL)
+#if defined(CUTE_ARCH_TMA_SM100_ENABLED)
   uint64_t gmem_int_desc = reinterpret_cast<uint64_t>(&descriptor);
   uint32_t smem_int_ptr = smem_ptr_to_uint(smem_ptr);
   asm volatile(
@@ -630,7 +632,9 @@ tma_store_scatter4(const CUtensorMap &descriptor, void const *const smem_ptr,
         "r"(r2), "r"(r3), "l"(cache_hint)
       : "memory");
 #else
-  static_assert(kDependentFalse, "tl::tma_store_scatter4 requires sm_100a");
+  static_assert(kDependentFalse,
+                "tl::tma_store_scatter4 requires sm_100a or a compatible "
+                "architecture-specific target");
 #endif
 }
 #endif // CUDA 12.8+

--- a/testing/python/language/test_tilelang_language_tma_gather_scatter.py
+++ b/testing/python/language/test_tilelang_language_tma_gather_scatter.py
@@ -8,20 +8,6 @@ import tilelang.language as T
 import tilelang
 
 
-def _has_sm100():
-    try:
-        import torch
-    except ImportError:
-        return False
-    if not torch.cuda.is_available():
-        return False
-    major, _ = torch.cuda.get_device_capability(0)
-    return major >= 10
-
-
-requires_sm100 = pytest.mark.skipif(not _has_sm100(), reason="tile::gather4/scatter4 require sm_100a (Blackwell)")
-
-
 def gather_scatter_program(N: int, K: int, K_box: int, in_dtype: str = "float16"):
 
     @T.prim_func
@@ -31,9 +17,6 @@ def gather_scatter_program(N: int, K: int, K_box: int, in_dtype: str = "float16"
         Dst: T.Tensor((N, K), in_dtype),
     ):
         with T.Kernel(1, 1, threads=128) as (bx, by):
-            T.reads(Src[0:N, 0:K], Idx[0:4])
-            T.writes(Dst[0:N, 0:K])
-
             smem = T.alloc_shared((4, K_box), in_dtype)
             mbar = T.alloc_barrier(1)
 
@@ -87,7 +70,8 @@ def run_gather_scatter(N=64, K=64, K_box=64):
     torch.testing.assert_close(Dst, expected)
 
 
-@requires_sm100
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
 def test_gather_scatter_basic():
     run_gather_scatter(N=64, K=64, K_box=64)
 
@@ -118,9 +102,6 @@ def gather_scatter_swizzled_program(N: int, K: int, K_box: int, swizzle_kind: st
         Dst: T.Tensor((N, K), in_dtype),
     ):
         with T.Kernel(1, 1, threads=128) as (bx, by):
-            T.reads(Src[0:N, 0:K], Idx[0:4])
-            T.writes(Dst[0:N, 0:K])
-
             smem = T.alloc_shared((4, K_box), in_dtype)
             T.annotate_layout({smem: make_layout(smem)})
 
@@ -175,7 +156,8 @@ def run_gather_scatter_swizzled(N, K, K_box, swizzle_kind):
     torch.testing.assert_close(Dst, expected)
 
 
-@requires_sm100
+@tilelang.testing.requires_cuda_compute_version(10)
+@tilelang.testing.requires_cuda_compute_version_lt(11)
 @pytest.mark.parametrize(
     "K_box, swizzle_kind",
     [


### PR DESCRIPTION
This fixes a broken test for `T.tma_{gather4,scatter4}`, which has been broken since the TIRx refactor (#2216).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Removed `T.reads` and `T.writes` annotations from CUDA `T.tma_gather4` and `T.tma_scatter4` tests.
- Updated CUDA capability requirements for the gather/scatter tests.
- Updated SM100 TMA architecture guards and unsupported-target diagnostics.

## C++ style / lint notes

- The PR changes C++ header code but does not modify the rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) may report advisory findings. These findings are not merge blockers unless they introduce an API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->