### PR TITLE
[Skill] Add TileLang semantic validation skill

### DIFF
--- a/.agents/skills/tilelang-semantic/SKILL.md
+++ b/.agents/skills/tilelang-semantic/SKILL.md
@@ -154,8 +154,8 @@ ownership, replication, loop partitioning, or inferred loop layouts.
   disappear under optimized Python and usually produce poor diagnostics.
 - Do not infer source intent from `ForKind` alone when annotations define the
   construct.
-- Do not ban all nested `T.Pipelined` syntax; distinguish a bare serial-like
-  loop from two nested loops that both request software-pipeline lowering.
+- Do not treat nested pipeline requests as backend-independent invalidity;
+  hierarchical-pipeline support is a backend capability.
 - Do not require parallel extent to equal thread count or explicit layout
   shape; partitioning, replication, and guarded tails intentionally permit
   differences.
@@ -167,10 +167,11 @@ ownership, replication, loop partitioning, or inferred loop layouts.
 ## Resources
 
 - `references/loop-rules.md`: established loop contracts, representation
-  details, non-rules, and the pipeline-path rule under development.
+  details, non-rules, and backend-specific nested-pipeline guidance.
 - `references/memory-concurrency.md`: buffer bounds/initialization/ownership,
   aliasing, races, collective synchronization, barriers, and async lifetimes.
 - `references/operations-layout.md`: TileOp, pipeline, reducer, layout,
   kernel/target, and dtype contracts plus the implementation roadmap.
 - `scripts/scan_loop_nesting.py`: inventory lexical loop pairs and detect
-  nested software-pipeline requests in Python sources.
+  nested software-pipeline requests in Python sources without judging backend
+  support.

--- a/.agents/skills/tilelang-semantic/SKILL.md
+++ b/.agents/skills/tilelang-semantic/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tilelang-semantic
-description: Design, implement, debug, or review TileLang semantic rules and validation, especially loop nesting, T.Parallel/T.Pipelined/T.vectorized/T.Persistent contracts, buffer-scope legality, reducer lifecycle, data races, and actionable diagnostics. Use when changing tilelang/analysis checkers, early Verify* passes, language legality rules, or regression tests for invalid TileLang programs.
+description: Design, implement, debug, or review TileLang semantic rules and validation, including loop nesting, buffer bounds/initialization/ownership, data races, synchronization and async lifecycles, TileOp shape/dtype/scope contracts, software pipelines, reducers, layouts, kernel launch constraints, and actionable diagnostics. Use when changing tilelang/analysis checkers, early Verify* passes, language legality rules, or regression tests for invalid TileLang programs.
 ---
 
 # TileLang Semantic Validation
@@ -34,7 +34,16 @@ Before proposing or changing a rule:
 3. Trace the construct through the target pipelines and identify the first pass
    that assumes the proposed invariant.
 4. Search tests and examples for valid counterexamples.
-5. For loop-nesting work, read `references/loop-rules.md` completely and run:
+5. Load the relevant domain reference completely:
+
+   - loop nesting and loop/storage ownership:
+     `references/loop-rules.md`;
+   - bounds, initialization, scopes, races, synchronization, barriers, or
+     async operations: `references/memory-concurrency.md`;
+   - TileOps, software pipelines, reducers, layouts, kernel launch, or dtype
+     contracts: `references/operations-layout.md`.
+
+For loop-nesting work, also run:
 
 ```bash
 python .agents/skills/tilelang-semantic/scripts/scan_loop_nesting.py
@@ -98,9 +107,11 @@ Add, at minimum:
 
 1. one failing test for each violation shape;
 2. one near-neighbor valid test;
-3. nested and sibling cases for lexical-state rules;
-4. multidimensional cases for `T.Parallel`;
-5. a diagnostic assertion that checks the useful part of the message.
+3. a proof-boundary case that remains accepted when the analysis is
+   inconclusive;
+4. alternate control-flow paths for state/lifecycle rules;
+5. target-specific accepted and unsupported cases when capability matters;
+6. a diagnostic assertion that checks the useful part of the message.
 
 Also run affected backend codegen tests when a rule migrates existing kernels.
 Use `$tilelang-build` for repository test commands. For a Python pre-lower
@@ -119,6 +130,12 @@ git diff --check
   frontend diagnostics.
 - `src/transform/verify_*.cc`: native effect/dataflow verification such as
   reducer lifecycle, buffer initialization, and parallel races.
+- `src/transform/legalize_safe_memory_access.cc`: bounds proof, global guards,
+  and optional local/shared warnings.
+- `tilelang/language/*_op.py` and `tilelang/language/builtin.py`: source API
+  operand and annotation validation.
+- `src/transform/{pipeline_planning,inject_pipeline}.cc`: pipeline dependency,
+  ordering, replayability, and multi-versioning contracts.
 - `src/transform/layout_inference/parallel_loop_layout_validator.h`:
   post-inference parallel-layout annotation contract.
 - `tilelang/{cuda,rocm,cpu,metal,webgpu}/pipeline.py`: target pipeline order.
@@ -133,6 +150,8 @@ ownership, replication, loop partitioning, or inferred loop layouts.
   execution layers and use different lowering paths.
 - Do not reject every construct that falls back to serial execution.
 - Do not promote “cannot prove safe” to “proven unsafe.”
+- Do not use Python `assert` for new user-facing legality checks; assertions
+  disappear under optimized Python and usually produce poor diagnostics.
 - Do not infer source intent from `ForKind` alone when annotations define the
   construct.
 - Do not ban all nested `T.Pipelined` syntax; distinguish a bare serial-like
@@ -140,10 +159,18 @@ ownership, replication, loop partitioning, or inferred loop layouts.
 - Do not require parallel extent to equal thread count or explicit layout
   shape; partitioning, replication, and guarded tails intentionally permit
   differences.
+- Do not reject barriers merely because they occur inside `T.Parallel`;
+  validate participant sets, path uniformity, and execution counts.
+- Do not report a missing target feature or missed optimization as universal
+  semantic invalidity.
 
 ## Resources
 
 - `references/loop-rules.md`: established loop contracts, representation
   details, non-rules, and the pipeline-path rule under development.
+- `references/memory-concurrency.md`: buffer bounds/initialization/ownership,
+  aliasing, races, collective synchronization, barriers, and async lifetimes.
+- `references/operations-layout.md`: TileOp, pipeline, reducer, layout,
+  kernel/target, and dtype contracts plus the implementation roadmap.
 - `scripts/scan_loop_nesting.py`: inventory lexical loop pairs and detect
   nested software-pipeline requests in Python sources.

--- a/.agents/skills/tilelang-semantic/SKILL.md
+++ b/.agents/skills/tilelang-semantic/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: tilelang-semantic
+description: Design, implement, debug, or review TileLang semantic rules and validation, especially loop nesting, T.Parallel/T.Pipelined/T.vectorized/T.Persistent contracts, buffer-scope legality, reducer lifecycle, data races, and actionable diagnostics. Use when changing tilelang/analysis checkers, early Verify* passes, language legality rules, or regression tests for invalid TileLang programs.
+---
+
+# TileLang Semantic Validation
+
+## Core principle
+
+Reject a program only when the violated semantic invariant is established.
+Keep these outcomes distinct:
+
+| Finding | Treatment |
+|---|---|
+| Semantically invalid for every supported lowering | Default error |
+| Valid in principle but unsupported by the current lowering | Precise unsupported-case diagnostic or fallback |
+| Valid but an optimization does not apply | Warning or silent fallback, never a semantic error |
+| Potentially invalid but not provable | Warning, opt-in verifier, or no report |
+
+Do not turn an optimizer limitation into a language rule. For example,
+`T.vectorized` containing a loop-invariant `T.serial` is semantically valid even
+though the current vectorization planner may scalarize it.
+
+## Workflow
+
+### 1. Reconstruct the actual contract
+
+Before proposing or changing a rule:
+
+1. Locate the source API under `tilelang/language/`.
+2. Determine its source TIR representation. Do not infer semantics from the
+   Python spelling alone: `T.Pipelined` is a serial `For` with annotations, and
+   `T.Persistent` expands early into binds plus a serial loop.
+3. Trace the construct through the target pipelines and identify the first pass
+   that assumes the proposed invariant.
+4. Search tests and examples for valid counterexamples.
+5. For loop-nesting work, read `references/loop-rules.md` completely and run:
+
+```bash
+python .agents/skills/tilelang-semantic/scripts/scan_loop_nesting.py
+```
+
+Absence from the repository is not proof that a construct is invalid. Confirm
+the downstream assumption in code or with a minimal lowering test.
+Treat the scanner as an inventory aid, not a proof: inspect non-literal
+annotation dictionaries and generated TIR manually.
+
+### 2. Specify the rule before implementing it
+
+Write down all of the following:
+
+- **Scope:** the exact node, storage scope, or lexical region covered.
+- **Invariant:** what every valid program must satisfy.
+- **Proof criterion:** what the checker must establish before reporting.
+- **Exemptions:** atomics, reducers, generated IR, target-specific paths, etc.
+- **Near-neighbor valid case:** the smallest similar program that must remain
+  accepted.
+- **Diagnostic:** name the offending construct and give an actionable rewrite.
+- **Enforcement stage:** frontend, pre-lower, early native verification,
+  post-inference, or backend-specific lowering.
+
+For nesting rules, define a *path* as one lexical ancestor chain from the
+function body to a leaf statement. Sequential sibling loops are different
+paths.
+
+### 3. Choose the earliest reliable enforcement stage
+
+| Stage | Use it for |
+|---|---|
+| Frontend API | Invalid argument combinations or types known while constructing the loop/op |
+| `PreLowerSemanticCheck` | Backend-independent source-TIR structure with user-facing syntax still recognizable |
+| Early native `Verify*` pass | Analyzer-, effect-, region-, or dataflow-dependent checks shared by backends |
+| After `LayoutInference` | Contracts involving inferred `layout_map` or `parallel_loop_layout` |
+| Backend pipeline | Rules that genuinely depend on target instructions or execution geometry |
+
+Do not place a rule after a transform that erases the evidence needed to report
+it. If an early expansion erases identity, preserve an explicit annotation
+instead of pattern-matching incidental lowered shapes.
+
+### 4. Implement a validator, not a transform
+
+- Keep validation side-effect free.
+- Maintain lexical state with a stack and restore it on every exit path.
+- Use `For`, `Buffer`, `Var`, and other ObjectRef handles for retained identity;
+  follow `$tilelang-tvm-ir` for C++ TIR code.
+- Share traversal/variable-use utilities when rules need the same facts, but
+  keep diagnostics and rule ownership independent.
+- Include source spans when the IR carries them.
+- Use a stable prefix such as `[TileLang Semantic Check]` and describe a legal
+  replacement.
+- Honor the existing global pre-lower opt-out for compatibility. Do not add a
+  new per-rule opt-out for a proven-invalid rule unless compatibility requires
+  one; reserve fine-grained opt-outs for inconclusive analyses.
+
+### 5. Test the semantic boundary
+
+Add, at minimum:
+
+1. one failing test for each violation shape;
+2. one near-neighbor valid test;
+3. nested and sibling cases for lexical-state rules;
+4. multidimensional cases for `T.Parallel`;
+5. a diagnostic assertion that checks the useful part of the message.
+
+Also run affected backend codegen tests when a rule migrates existing kernels.
+Use `$tilelang-build` for repository test commands. For a Python pre-lower
+checker, start with:
+
+```bash
+python -m pytest testing/python/analysis -q
+python -m ruff check <changed-python-files>
+git diff --check
+```
+
+## Validation ownership map
+
+- `tilelang/engine/semantic_check.py`: shared pre-lowering entry point.
+- `tilelang/analysis/*checker.py`: source-TIR structural rules and actionable
+  frontend diagnostics.
+- `src/transform/verify_*.cc`: native effect/dataflow verification such as
+  reducer lifecycle, buffer initialization, and parallel races.
+- `src/transform/layout_inference/parallel_loop_layout_validator.h`:
+  post-inference parallel-layout annotation contract.
+- `tilelang/{cuda,rocm,cpu,metal,webgpu}/pipeline.py`: target pipeline order.
+- `tilelang/transform/pass_config.py`: opt-outs and strictness controls.
+
+Read `$tilelang-layout` before changing rules whose truth depends on fragment
+ownership, replication, loop partitioning, or inferred loop layouts.
+
+## Avoid
+
+- Do not equate `T.Parallel` with `T.vectorized`; they represent different
+  execution layers and use different lowering paths.
+- Do not reject every construct that falls back to serial execution.
+- Do not promote “cannot prove safe” to “proven unsafe.”
+- Do not infer source intent from `ForKind` alone when annotations define the
+  construct.
+- Do not ban all nested `T.Pipelined` syntax; distinguish a bare serial-like
+  loop from two nested loops that both request software-pipeline lowering.
+- Do not require parallel extent to equal thread count or explicit layout
+  shape; partitioning, replication, and guarded tails intentionally permit
+  differences.
+
+## Resources
+
+- `references/loop-rules.md`: established loop contracts, representation
+  details, non-rules, and the pipeline-path rule under development.
+- `scripts/scan_loop_nesting.py`: inventory lexical loop pairs and detect
+  nested software-pipeline requests in Python sources.

--- a/.agents/skills/tilelang-semantic/agents/openai.yaml
+++ b/.agents/skills/tilelang-semantic/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "TileLang Semantic Checks"
+  short_description: "Design and review TileLang semantic rules"
+  default_prompt: "Use $tilelang-semantic to design or review a TileLang semantic check with precise validity rules and regression tests."

--- a/.agents/skills/tilelang-semantic/agents/openai.yaml
+++ b/.agents/skills/tilelang-semantic/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "TileLang Semantic Checks"
-  short_description: "Design and review TileLang semantic rules"
-  default_prompt: "Use $tilelang-semantic to design or review a TileLang semantic check with precise validity rules and regression tests."
+  short_description: "Design TileLang semantic and safety contracts"
+  default_prompt: "Use $tilelang-semantic to design or review a TileLang semantic or safety rule and place its validation at the correct compiler stage."

--- a/.agents/skills/tilelang-semantic/references/loop-rules.md
+++ b/.agents/skills/tilelang-semantic/references/loop-rules.md
@@ -1,0 +1,226 @@
+# TileLang Loop Semantic Rules
+
+## Contents
+
+1. [Scope and terminology](#scope-and-terminology)
+2. [Source representation](#source-representation)
+3. [Established rules](#established-rules)
+4. [Pipeline requests on a lexical path](#pipeline-requests-on-a-lexical-path)
+5. [Vectorized loops are not required to be leaves](#vectorized-loops-are-not-required-to-be-leaves)
+6. [Non-rules](#non-rules)
+7. [Rule-design checklist](#rule-design-checklist)
+
+## Scope and terminology
+
+Apply a nesting rule to one lexical path: an ancestor chain from a function
+body to one leaf statement. Two sequential sibling loops are on different
+paths.
+
+Distinguish:
+
+- **semantic rule:** required for correctness on every supported lowering;
+- **implementation contract:** required by current passes but potentially
+  relaxable in the future;
+- **optimization condition:** determines whether an optimization applies and
+  must not be reported as semantic invalidity.
+
+Call a `T.Pipelined` loop **pipeline-requested** when source TIR carries
+`num_stages` or manual `tl_pipeline_order`/`tl_pipeline_stage` metadata. After
+planning, canonical markers also include `tl_pipelined_num_stages` and
+software-pipeline stage/order attrs. Auxiliary `group` or `sync` metadata does
+not request lowering by itself. A bare `T.Pipelined(n)` with none of these
+markers behaves structurally like a serial loop and is not
+pipeline-requested.
+
+## Source representation
+
+| Source construct | Source-TIR identity | Important consequence |
+|---|---|---|
+| `T.serial`, `T.grid` | serial `For` nest | Treat as ordinary sequential iteration |
+| `T.unroll` | `ForKind::kUnrolled` | Compile-time expansion intent; may contain lower-level loops |
+| `T.vectorized` | `ForKind::kVectorized` | SIMD intent; current planner selects only innermost loops |
+| `T.Parallel` | one or more `ForKind::kParallel` loops | Consecutive loops form one multidimensional parallel region |
+| `T.Pipelined` | serial `For` plus annotations | Detect through annotations, not `ForKind` |
+| `T.Persistent` | binds, guards, `loop_break`, and serial `For` | Preserve a marker before enforcing persistent-specific structure |
+| `while` | `While` | Often acts as a dynamic/persistent scheduler in real kernels |
+
+Always inspect the representation at the intended checker stage. A rule that
+looks obvious in Python may no longer be recognizable after frontend expansion.
+
+## Established rules
+
+These contracts are already enforced or covered by repository tests:
+
+### Consecutive parallel dimensions are one region
+
+Allow a strict chain:
+
+```python
+for i in T.Parallel(M):
+    for j in T.Parallel(N):
+        B[i, j] = A[i, j]
+```
+
+Reject re-entering `T.Parallel` after executable statements or another loop
+has broken the chain:
+
+```python
+for i in T.Parallel(M):
+    B[i, 0] = 0
+    for j in T.Parallel(N):
+        B[i, j] = A[i, j]
+```
+
+The current implementation is `tilelang/analysis/nested_loop_checker.py`.
+
+### Pipeline may contain parallel; parallel may not contain pipeline
+
+Allow the canonical tile loop:
+
+```python
+for k in T.Pipelined(K, num_stages=3):
+    for i in T.Parallel(M):
+        ...
+```
+
+Reject a pipeline-requested loop under a parallel region. Parallel lowering
+distributes elementwise work; software-pipeline planning owns a sequential
+producer/consumer timeline and cannot be introduced inside that region.
+
+### Tile operators do not belong inside a parallel region
+
+Reject `T.copy`, `T.gemm`, and other calls with `TLOpBuilder` inside
+`T.Parallel`. Allow per-element intrinsics such as supported atomics and
+reducer updates; do not classify every effectful call as a tile operator.
+
+### Parallel indexing follows storage ownership
+
+- Reject direct use of an enclosing parallel variable as an index into a
+  thread-private local buffer.
+- Allow parallel-independent local accesses such as replicated scalar reads.
+- Use fragment storage when the indexed logical dimension is distributed
+  across threads.
+- Retain the existing symbolic-range restriction for fragment indexing.
+
+These checks live in `parallel_local_index_checker.py` and
+`fragment_loop_checker.py`.
+
+## Pipeline requests on a lexical path
+
+Use this current implementation contract when adding the agreed nesting rule:
+
+> One lexical path may contain at most one pipeline-requested loop.
+
+Reject:
+
+```python
+for ko in T.Pipelined(K, num_stages=3):
+    for ki in T.Pipelined(BK, num_stages=2):
+        ...
+```
+
+Allow sibling pipelines because no statement is enclosed by both:
+
+```python
+for ko in T.Pipelined(K, num_stages=3):
+    ...
+for qo in T.Pipelined(Q, num_stages=2):
+    ...
+```
+
+Do not reject the existing serial-like nesting shape:
+
+```python
+for repeat in T.Pipelined(R):
+    for ko in T.Pipelined(K, num_stages=3):
+        ...
+```
+
+Only the inner loop requests pipeline lowering. Prefer `T.serial(R)` for the
+outer loop in new code because it expresses the intent directly.
+
+This is not a theoretical prohibition on hierarchical software pipelines. It
+is a current lowering contract: pipeline planning preserves an active marker
+for downstream multi-versioning and warp-specialization passes that do not
+support nested active pipelines. Keep the diagnostic explicit about current
+support so the rule can be relaxed when hierarchical lowering is implemented.
+
+Do not reuse `nested_loop_checker.is_pipelined_for()` unchanged for this rule.
+That helper intentionally uses a broader classification and currently treats
+`tl_pipeline_group` as pipelined. Define a narrower
+`is_pipeline_requested_for()` predicate for nested-active detection.
+
+For a source pre-lower checker:
+
+1. Maintain a stack or count of pipeline-requested ancestor loops.
+2. Report when entering another pipeline-requested loop while the count is
+   nonzero.
+3. Restore state before visiting sibling statements.
+4. Include both loop spans when available.
+5. Suggest replacing one loop with `T.serial` or removing one pipeline request.
+
+Cover this boundary matrix:
+
+- reject `num_stages` inside `num_stages`;
+- reject manual stage/order inside manual stage/order;
+- reject both mixed outer/inner combinations;
+- reject nesting hidden through serial, unroll, and conditional wrappers;
+- allow bare outer plus pipeline-requested inner;
+- allow pipeline-requested outer plus bare inner;
+- allow sequential pipeline-requested siblings;
+- do not count group/sync-only metadata as a pipeline request.
+
+## Vectorized loops are not required to be leaves
+
+Do not introduce a blanket rule that `T.vectorized` may not contain loops.
+This is semantically meaningful when the inner loop has lane-invariant bounds:
+
+```python
+for i in T.vectorized(M):
+    for k in T.serial(K):
+        C[i] += A[i, k] * B[k]
+```
+
+The serial loop executes for each SIMD lane. `T.unroll` is similarly possible.
+If the inner bound depends on `i`, lanes may have different trip counts and the
+construct needs predication or scalarization; treat that as a separate rule.
+
+Current implementation caveat: `VectorizePlanner` plans only innermost loops.
+An outer `T.vectorized` containing `T.serial` may therefore be lowered as
+serial with a warning. That is an optimization limitation, not semantic
+invalidity. Test both semantic acceptance and whether vectorization actually
+occurs before changing this behavior.
+
+## Non-rules
+
+Do not adopt these statements as general semantic rules:
+
+- “Every nested `T.Pipelined` is invalid.” Bare outer pipeline syntax is
+  currently serial-like, and existing tests use it.
+- “`T.vectorized` must be an AST leaf.” Sequential inner loops can be valid.
+- “`T.Parallel` extent must equal launched thread count.” Loop partitioning
+  and replication intentionally support different extents.
+- “Explicit loop-layout input shape must equal loop extent.” Guarded tails and
+  non-bijective layouts can be intentional.
+- “Every local access inside `T.Parallel` is invalid.” Only ownership-breaking
+  dependencies are forbidden; replicated or per-iteration scratch accesses can
+  be valid.
+- “No examples use this form, therefore it is invalid.” Confirm a downstream
+  correctness requirement.
+
+## Rule-design checklist
+
+Before approving a new loop rule, answer:
+
+1. Is this semantic invalidity, a current implementation contract, or an
+   optimization condition?
+2. What exact TIR shape identifies the construct at the checker stage?
+3. What is the smallest invalid example?
+4. What is the closest valid example?
+5. Do siblings differ from nested ancestors?
+6. Does a neutral wrapper (`serial`, `unroll`, `if`, `SeqStmt`) change the
+   answer?
+7. Does generated IR use the same shape and require an exemption?
+8. Can the checker prove the violation, or only fail to prove safety?
+9. Which pass first relies on the invariant?
+10. Does the diagnostic suggest the intended legal rewrite?

--- a/.agents/skills/tilelang-semantic/references/loop-rules.md
+++ b/.agents/skills/tilelang-semantic/references/loop-rules.md
@@ -5,7 +5,7 @@
 1. [Scope and terminology](#scope-and-terminology)
 2. [Source representation](#source-representation)
 3. [Established rules](#established-rules)
-4. [Pipeline requests on a lexical path](#pipeline-requests-on-a-lexical-path)
+4. [Nested pipelines are backend capabilities](#nested-pipelines-are-backend-capabilities)
 5. [Vectorized loops are not required to be leaves](#vectorized-loops-are-not-required-to-be-leaves)
 6. [Non-rules](#non-rules)
 7. [Rule-design checklist](#rule-design-checklist)
@@ -105,13 +105,31 @@ reducer updates; do not classify every effectful call as a tile operator.
 These checks live in `parallel_local_index_checker.py` and
 `fragment_loop_checker.py`.
 
-## Pipeline requests on a lexical path
+## Nested pipelines are backend capabilities
 
-Use this current implementation contract when adding the agreed nesting rule:
+Do not impose a language-wide limit on the number of pipeline-requested loops
+along one lexical path. Hierarchical software pipelines are semantically
+meaningful, and known Ascend kernels intentionally pipeline an outer tile loop
+and inner GEMM reduction loops at the same time.
 
-> One lexical path may contain at most one pipeline-requested loop.
+Comments in one backend's pipeline planning or multi-versioning passes establish
+only that backend's current implementation limit. They do not justify a
+backend-independent `PreLowerSemanticCheck`, which runs before the target
+pipeline has selected its lowering strategy.
 
-Reject:
+Use `pipeline-requested` classification for inventory and backend dispatch, not
+for global rejection. When reviewing nested pipelines:
+
+1. Resolve the selected target and backend pipeline.
+2. Determine whether that backend supports hierarchical pipeline planning,
+   buffer versioning, barriers, and warp/core specialization.
+3. Allow nesting when the backend contract supports it.
+4. If unsupported, diagnose it inside that backend after target resolution:
+   `Backend <name> does not support nested software pipelines`.
+5. Never silently discard one requested schedule if doing so can change async
+   or multi-buffer semantics.
+
+Keep the source scanner informational. It should report shapes such as:
 
 ```python
 for ko in T.Pipelined(K, num_stages=3):
@@ -119,56 +137,18 @@ for ko in T.Pipelined(K, num_stages=3):
         ...
 ```
 
-Allow sibling pipelines because no statement is enclosed by both:
-
-```python
-for ko in T.Pipelined(K, num_stages=3):
-    ...
-for qo in T.Pipelined(Q, num_stages=2):
-    ...
-```
-
-Do not reject the existing serial-like nesting shape:
-
-```python
-for repeat in T.Pipelined(R):
-    for ko in T.Pipelined(K, num_stages=3):
-        ...
-```
-
-Only the inner loop requests pipeline lowering. Prefer `T.serial(R)` for the
-outer loop in new code because it expresses the intent directly.
-
-This is not a theoretical prohibition on hierarchical software pipelines. It
-is a current lowering contract: pipeline planning preserves an active marker
-for downstream multi-versioning and warp-specialization passes that do not
-support nested active pipelines. Keep the diagnostic explicit about current
-support so the rule can be relaxed when hierarchical lowering is implemented.
-
-Do not reuse `nested_loop_checker.is_pipelined_for()` unchanged for this rule.
-That helper intentionally uses a broader classification and currently treats
-`tl_pipeline_group` as pipelined. Define a narrower
-`is_pipeline_requested_for()` predicate for nested-active detection.
-
-For a source pre-lower checker:
-
-1. Maintain a stack or count of pipeline-requested ancestor loops.
-2. Report when entering another pipeline-requested loop while the count is
-   nonzero.
-3. Restore state before visiting sibling statements.
-4. Include both loop spans when available.
-5. Suggest replacing one loop with `T.serial` or removing one pipeline request.
+but exit successfully without deciding whether the target can lower them.
 
 Cover this boundary matrix:
 
-- reject `num_stages` inside `num_stages`;
-- reject manual stage/order inside manual stage/order;
-- reject both mixed outer/inner combinations;
-- reject nesting hidden through serial, unroll, and conditional wrappers;
-- allow bare outer plus pipeline-requested inner;
-- allow pipeline-requested outer plus bare inner;
-- allow sequential pipeline-requested siblings;
-- do not count group/sync-only metadata as a pipeline request.
+- a supporting backend accepts nested `num_stages` and manual stage/order
+  schedules;
+- an unsupported backend rejects the same source with a target-specific
+  diagnostic;
+- target-agnostic pre-lower validation accepts both cases;
+- bare and pipeline-requested nested loops remain distinguishable for
+  analysis;
+- sequential sibling pipelines remain independent.
 
 ## Vectorized loops are not required to be leaves
 
@@ -195,8 +175,9 @@ occurs before changing this behavior.
 
 Do not adopt these statements as general semantic rules:
 
-- “Every nested `T.Pipelined` is invalid.” Bare outer pipeline syntax is
-  currently serial-like, and existing tests use it.
+- “Every nested `T.Pipelined` is invalid” or “one lexical path may contain at
+  most one pipeline-requested loop.” Nested pipeline support is a backend
+  capability; bare outer pipeline syntax is also serial-like.
 - “`T.vectorized` must be an AST leaf.” Sequential inner loops can be valid.
 - “`T.Parallel` extent must equal launched thread count.” Loop partitioning
   and replication intentionally support different extents.

--- a/.agents/skills/tilelang-semantic/references/memory-concurrency.md
+++ b/.agents/skills/tilelang-semantic/references/memory-concurrency.md
@@ -1,0 +1,205 @@
+# Memory and Concurrency Semantic Rules
+
+## Contents
+
+1. [Severity model](#severity-model)
+2. [Buffer rank and bounds](#buffer-rank-and-bounds)
+3. [Initialization](#initialization)
+4. [Storage ownership and aliasing](#storage-ownership-and-aliasing)
+5. [Parallel races and atomics](#parallel-races-and-atomics)
+6. [Collectives and barriers](#collectives-and-barriers)
+7. [Asynchronous operations](#asynchronous-operations)
+8. [Current coverage and priorities](#current-coverage-and-priorities)
+9. [Boundary tests](#boundary-tests)
+
+## Severity model
+
+Use a hard error only for a proven violation. Use a guard, warning, or opt-in
+analysis when validity cannot be established.
+
+| Result | Treatment |
+|---|---|
+| Proven rank mismatch, OOB, race, lifecycle violation, or invalid scope | Error |
+| Access may be unsafe but proof is inconclusive | Guard or warning |
+| Valid operation unsupported by one target | Target-specific unsupported diagnostic |
+| Safe operation that prevents vectorization or another optimization | Optimization warning at most |
+
+## Buffer rank and bounds
+
+Enforce these contracts for `BufferLoad`, `BufferStore`, buffer regions, and
+pointer-style accesses:
+
+- Require the number of indices to match the logical buffer rank unless the
+  operation explicitly defines flattened or region semantics.
+- Reject an access when analysis proves any scalar or vector lane is below
+  zero or at/above its dimension extent.
+- Preserve Python-style negative-index legalization when the language API
+  explicitly supports it; validate the normalized index instead.
+- Check every lane of `Ramp`, `Broadcast`, and `Shuffle` indices. Predicate
+  partially valid vector accesses instead of accepting one in-range lane as
+  proof for the whole vector.
+- Validate the base, extent, and read/write mask of `T.access_ptr` together;
+  checking only the base element is insufficient.
+- Require a buffer region to fit the source and destination shapes of the op
+  that consumes it.
+
+Current caveat: `SafeMemChecker` skips constant indices and treats local/shared
+OOB primarily as optional warnings. Do not rely on that behavior as the
+language contract. Add a default hard error for statically proven OOB while
+retaining guards/warnings for uncertain accesses.
+
+## Initialization
+
+Apply initialization semantics according to ownership:
+
+- Treat global buffers as caller-owned unless the API declares an output or
+  initialization obligation.
+- Require local and fragment values to be defined before use on every path that
+  reaches the read when that failure is provable.
+- Model read-modify-write as a read followed by a write; `x += y` does not
+  initialize `x`.
+- Account for tile operators and writable pointer escapes as potential writes,
+  but do not assume an opaque read-only call initialized a buffer.
+- Treat shared memory as cross-thread state. Source order alone does not prove
+  initialization under warp specialization; require a producer plus the
+  synchronization contract that makes it visible.
+- Distinguish “nothing ever writes this buffer” from path-sensitive partial
+  initialization. The former can be a low-noise default diagnostic; the latter
+  needs stronger control-flow and synchronization analysis.
+
+`VerifyBufferInit` currently implements the low-noise first tier. Extend it
+incrementally rather than claiming it proves definite assignment.
+
+## Storage ownership and aliasing
+
+Use storage scope as a semantic ownership contract:
+
+- `local`: private to one physical thread; do not infer cross-thread ownership
+  from a logical parallel index.
+- `local.fragment`: distributed or replicated according to a Fragment layout;
+  validate accesses against that ownership map.
+- `shared`: visible to participating threads in one CTA only after the required
+  synchronization.
+- cluster-shared scopes: visible only within the declared cluster and through
+  supported cluster operations.
+- `global`: visible across CTAs; cross-CTA coordination requires atomics or a
+  supported grid/cluster synchronization mechanism.
+
+For aliases and pointer escapes:
+
+- Preserve address space and storage scope through `address_of`, views, and
+  access-pointer lowering.
+- Require aliased regions to have compatible dtype, alignment, extent, and
+  access permissions.
+- Reject overlapping source/destination regions only when the operation does
+  not define overlap semantics.
+- Keep a buffer alive until every synchronous or asynchronous user has
+  completed.
+- Include writes through `access_ptr`, external calls, and TileOps in effect
+  analysis when their contracts permit mutation.
+
+## Parallel races and atomics
+
+For a non-atomic shared/global store inside logical parallel execution:
+
+- report a hard error when two distinct iterations are proven to write the
+  same location with conflicting values;
+- accept a proven injective address mapping;
+- follow the project's explicit same-value-write contract rather than silently
+  changing it;
+- exempt first-class reducers and supported atomics from ordinary-store race
+  rules, then validate their own contracts;
+- warn or require opt-in analysis when address disjointness is merely
+  unprovable.
+
+For atomic operations, validate:
+
+- supported operand and result dtype;
+- natural alignment and vector-lane contiguity;
+- memory scope and backend support;
+- legal memory-order values and preservation through lowering;
+- whether return-previous semantics are available for the selected operation;
+- address/region shape for vector atomics.
+
+Split the existing race verifier into a low-false-positive proven-race tier and
+an optional potential-race tier instead of enabling every solver failure as an
+error.
+
+## Collectives and barriers
+
+Treat each collective operation as declaring a participant set. Require every
+participant to execute compatible operations in a compatible order and count.
+
+- Validate `sync_threads` against CTA participants and `sync_grid` against a
+  cooperative grid launch.
+- Reject a collective when a condition is proven non-uniform across its
+  participants.
+- Reject unequal proven execution counts, including loop trip-count and early
+  exit differences.
+- Allow a barrier inside `T.Parallel` when loop partitioning/replication makes
+  the participant count and execution count uniform; placement alone is not a
+  violation.
+- Treat warp-group and cluster collectives according to their narrower
+  participant sets rather than requiring whole-CTA uniformity.
+
+For mbarriers, validate the lifecycle:
+
+1. initialize before arrive, expect-tx, or wait;
+2. keep the barrier in a supported shared scope;
+3. use a compatible expected-arrival/transaction count;
+4. pair wait phase/parity with the corresponding producer epoch;
+5. do not reuse or destroy an epoch before all required waits complete;
+6. keep producer and consumer references within the same ownership domain.
+
+Generated pipeline barriers may satisfy these rules by construction. Preserve
+annotations that distinguish generated ownership from user-managed barriers.
+
+## Asynchronous operations
+
+For `T.async_copy`, cp.async, TMA, and other async producers:
+
+- require a completion mechanism before the first consuming read;
+- prevent destination overwrite or buffer-version reuse before completion;
+- prevent source/destination lifetime end before completion;
+- pair commit/wait groups and enforce backend limits on outstanding groups;
+- validate barrier ownership, phase, transaction count, and pipeline version;
+- validate source/destination scopes, direction, alignment, and region shape;
+- account for conditional producers so a consumer never waits for work that
+  was not issued or consumes data whose producer was skipped.
+
+Prefer a unified async-dependency verifier over isolated instruction-specific
+checks. Run it while source TileOps and explicit waits are still recognizable,
+or preserve effect annotations through lowering.
+
+## Current coverage and priorities
+
+| Area | Current state | Next step |
+|---|---|---|
+| Buffer initialization | Default low-noise warning; not path-sensitive | Add proven local/fragment definite-assignment errors |
+| Global bounds | Runtime guards for uncertain accesses | Add proven constant/static OOB errors |
+| Local/shared bounds | Optional warning | Split proven violation from inconclusive warning |
+| Parallel race | Optional potential-race warning | Enable a proven-race tier by default |
+| Atomic contracts | Distributed across APIs/codegen | Centralize dtype/alignment/order checks |
+| Collective uniformity | Fragmented | Add participant/path/count analysis |
+| Barrier lifecycle | Mostly lowering-local | Add user-visible lifecycle verification |
+| Async dependencies | Pipeline/instruction-specific | Add wait/use/reuse verifier |
+
+Prioritize proven OOB/rank mismatch, collective/barrier correctness, async
+wait/use/reuse, and proven data races. These failures can produce silent memory
+corruption or deadlock.
+
+## Boundary tests
+
+For each rule, include both the violation and its nearest valid neighbor:
+
+- constant OOB versus a symbolic access protected by a valid predicate;
+- rank mismatch versus an explicitly flattened access API;
+- local read-before-write versus initialization on every branch;
+- shared producer/consumer with and without the required synchronization;
+- proven colliding store versus injective store and supported atomic update;
+- divergent collective versus a uniform collective inside `T.Parallel`;
+- wait-before-use versus async use-before-wait and overwrite-before-wait;
+- barrier phase match versus stale parity and mismatched ownership.
+
+Assert source spans and actionable diagnostics whenever the source IR carries
+them.

--- a/.agents/skills/tilelang-semantic/references/operations-layout.md
+++ b/.agents/skills/tilelang-semantic/references/operations-layout.md
@@ -50,7 +50,7 @@ the frontend.
 
 ## Software-pipeline contracts
 
-In addition to the loop-path rule in `loop-rules.md`, require:
+For each requested pipeline, require:
 
 - `order` and `stage` metadata to be present together and aligned with the
   schedulable statement list;
@@ -67,8 +67,9 @@ In addition to the loop-path rule in `loop-rules.md`, require:
 Classify failures carefully:
 
 - malformed metadata or an impossible dependency schedule is invalid;
-- nested pipeline-requested loops are currently unsupported, not theoretically
-  invalid;
+- nested pipeline-requested loops are legal at the language level; accept or
+  reject them according to the selected backend's hierarchical-pipeline
+  capability;
 - a requested pipeline with no profitable overlap is valid and may fall back
   to serial execution with a warning;
 - a backend without validated async pipelining should produce a target-specific
@@ -166,7 +167,7 @@ storage changes.
 | Area | Current state | Next step |
 |---|---|---|
 | TileOp operands/shapes | Many frontend checks, often `assert`; native builders also check | Normalize errors and define per-op contracts |
-| Pipeline dependencies | Strong late planning/injection checks | Add source-friendly metadata and nested-request diagnostics |
+| Pipeline dependencies | Strong late planning/injection checks | Add source-friendly metadata and backend capability diagnostics |
 | Reducer lifecycle | Strong early and post-consumption verification | Preserve and reuse this pattern |
 | Parallel layout annotations | Structural post-inference validation | Add thread-range and ownership compatibility checks |
 | Kernel launch arguments | Basic frontend validation | Add target capability diagnostics |
@@ -189,7 +190,8 @@ For pipelines:
 
 - malformed stage/order metadata and valid replayable-bind compatibility;
 - cyclic/conflicting dependencies versus a serial fallback;
-- nested pipeline requests versus bare nested `T.Pipelined` and siblings;
+- nested pipeline requests on supporting and unsupported backends, plus bare
+  nested `T.Pipelined` and siblings;
 - conditional async producer/consumer paths.
 
 For layouts and kernels:

--- a/.agents/skills/tilelang-semantic/references/operations-layout.md
+++ b/.agents/skills/tilelang-semantic/references/operations-layout.md
@@ -1,0 +1,206 @@
+# Operation, Pipeline, and Layout Semantic Rules
+
+## Contents
+
+1. [TileOp contracts](#tileop-contracts)
+2. [Software-pipeline contracts](#software-pipeline-contracts)
+3. [Reducer contracts](#reducer-contracts)
+4. [Layout and distribution contracts](#layout-and-distribution-contracts)
+5. [Kernel and target contracts](#kernel-and-target-contracts)
+6. [Type and value contracts](#type-and-value-contracts)
+7. [Current coverage and priorities](#current-coverage-and-priorities)
+8. [Boundary tests](#boundary-tests)
+
+## TileOp contracts
+
+Give every TileOp an explicit semantic contract covering:
+
+- accepted operand kinds (`Buffer`, `BufferLoad`, `BufferRegion`, pointer);
+- logical rank, shape, and region extents;
+- operand, accumulator, and result dtypes;
+- required storage scopes and address spaces;
+- read, write, and opaque effect regions;
+- legal source/destination aliasing and overlap;
+- initialization/accumulation behavior;
+- participant/uniformity requirements;
+- target-independent semantics and target-specific capabilities.
+
+Apply representative rules:
+
+- `T.copy`: require compatible regions unless the op explicitly defines
+  broadcast, padding, gather/scatter, or overlap behavior.
+- `T.gemm` and block-scaled variants: validate M/N/K, transpose interpretation,
+  batch dimensions, accumulator shape/dtype, operand scopes, scale layout, and
+  clear/accumulate semantics.
+- `T.clear`/`T.fill`: require a writable destination region and a convertible
+  value dtype.
+- reductions/scans: validate axis/rank, source/destination shape, identity,
+  dtype, and in-place support.
+- atomics: use the memory/concurrency contract for dtype, alignment, scope,
+  ordering, and return-value semantics.
+
+Do not use Python `assert` for new user-facing checks. Raise `TypeError` for an
+invalid operand kind and `ValueError` for an invalid value/shape combination;
+include operand names and expected versus actual values. Convert existing
+assertions opportunistically when touching an API.
+
+Run frontend checks when Python has exact shapes/types. Repeat critical
+invariants in native operator parsing when imported or generated TIR can bypass
+the frontend.
+
+## Software-pipeline contracts
+
+In addition to the loop-path rule in `loop-rules.md`, require:
+
+- `order` and `stage` metadata to be present together and aligned with the
+  schedulable statement list;
+- stage/order/group arrays to use valid values and consistent lengths;
+- replayable scalar binds to be pure and independent of buffers written by the
+  pipeline;
+- scalar and buffer dependencies to respect the proposed schedule;
+- no conflicting overlapping writes to one buffer version;
+- multi-versioned buffer allocation and stage indexing to agree;
+- explicit barriers and async groups to use the pipeline's depth and phase;
+- a conditional producer/consumer schedule to preserve definition and wait
+  semantics.
+
+Classify failures carefully:
+
+- malformed metadata or an impossible dependency schedule is invalid;
+- nested pipeline-requested loops are currently unsupported, not theoretically
+  invalid;
+- a requested pipeline with no profitable overlap is valid and may fall back
+  to serial execution with a warning;
+- a backend without validated async pipelining should produce a target-specific
+  fallback/unsupported diagnostic, not a universal semantic error.
+
+Move checks earlier only when source statement counting is stable. Replayable
+bind normalization changes the schedulable list, so preserve compatibility with
+both accepted annotation forms where the injector already does so.
+
+## Reducer contracts
+
+Preserve the existing first-class reducer lifecycle:
+
+1. allocate one reducer state;
+2. initialize exactly one static epoch site;
+3. perform zero or more updates between init and finalize;
+4. update only through `reducer_update` in `T.Parallel`;
+5. finalize exactly once in a compatible control-flow scope;
+6. use an ordinary destination buffer with a compatible dtype;
+7. forbid ordinary loads, stores, clear/fill/copy, aliasing, and pointer escape
+   of reducer state;
+8. reject reducer constructs that survive materialization.
+
+Keep init/finalize collective execution uniform. Distinguish a skipped finalize
+that leaves an unread partial from a path that reads an unfinalized or stale
+value.
+
+Treat `VerifyReducerEpoch` and `VerifyReducerConsumed` as the model for strong
+lifecycle diagnostics: validate early against user-written structure, then
+assert that no semantic marker survives its consuming lowering pass.
+
+## Layout and distribution contracts
+
+Validate layout structure without imposing false equality requirements:
+
+- require a parallel-loop layout annotation on the outermost consecutive
+  parallel loop after inference;
+- forbid independent layout annotations on inner loops of the same parallel
+  nest;
+- require layout input dimension to match the parallel-nest depth;
+- require buffer rank and layout logical rank to be compatible;
+- require Fragment thread extent/range to fit the kernel or
+  warp-specialization participant range selected for that use;
+- validate logical index domains against layout input domains and guarded tails;
+- require stores through replicated fragments to select one owner or use the
+  canonical replica-zero guard;
+- require injectivity only when the consumer contract needs unique ownership;
+  replication and reductions may intentionally be non-injective;
+- preserve address-space and swizzle semantics through layout conversion;
+- treat failed TileLang-to-CuTe conversion as unsupported input unless the
+  semantic contract itself is violated.
+
+Do not require loop extent to equal launched thread count or explicit layout
+shape. Loop partitioning, replication, thread ranges, and tail guards make
+those differences legal. Use `$tilelang-layout` and the layout verification
+harness before changing these rules.
+
+## Kernel and target contracts
+
+Separate target-independent kernel structure from target capability:
+
+- require integer, positive grid/block extents where statically known;
+- enforce dimensionality limits and prohibit malformed/nested launch regions;
+- require unique and compatible thread bindings per launch dimension;
+- validate cluster dimensions, masks, and cluster-shared operations together;
+- require cooperative launch support for grid-wide synchronization;
+- validate target limits such as threads per block, shared-memory capacity,
+  alignment, and instruction availability as target-specific support errors;
+- require warp/warp-group collectives to use compatible participant geometry;
+- preserve pointer address spaces through host/device split and codegen.
+
+Do not label a missing TMA, WGMMA, MFMA, cluster, or vector instruction as a
+language-semantic error when a legal fallback exists. Select the fallback or
+emit a precise target-support diagnostic.
+
+## Type and value contracts
+
+Require:
+
+- integer, nonnegative shape/region extents when statically known;
+- nonzero loop steps and legal annotation values;
+- BufferStore values convertible under the language's explicit cast rules;
+- vector lane counts and lane extraction indices to be valid;
+- reinterpret/view operations to preserve total storage size and alignment;
+- atomics, reducers, scans, and MMA operands to use supported dtypes;
+- stochastic rounding parameters only with the corresponding rounding mode;
+- memory-order and scope strings/enums to remain valid through lowering.
+
+Distinguish implicit numeric conversion permitted by TileLang from reinterpret
+casts that change storage interpretation. Reject silent address-space or packed
+storage changes.
+
+## Current coverage and priorities
+
+| Area | Current state | Next step |
+|---|---|---|
+| TileOp operands/shapes | Many frontend checks, often `assert`; native builders also check | Normalize errors and define per-op contracts |
+| Pipeline dependencies | Strong late planning/injection checks | Add source-friendly metadata and nested-request diagnostics |
+| Reducer lifecycle | Strong early and post-consumption verification | Preserve and reuse this pattern |
+| Parallel layout annotations | Structural post-inference validation | Add thread-range and ownership compatibility checks |
+| Kernel launch arguments | Basic frontend validation | Add target capability diagnostics |
+| Dtype/value checks | Distributed across APIs/codegen | Centralize reusable predicates and diagnostics |
+
+Prioritize consistent TileOp contracts and user diagnostics after the
+memory/concurrency safety work. Keep target support and optimization fallback
+separate from universal legality.
+
+## Boundary tests
+
+For TileOps:
+
+- wrong rank/shape/dtype/scope versus the nearest supported combination;
+- legal aliasing versus a proven forbidden overlap;
+- clear-accumulate and initialized-accumulator variants;
+- frontend construction and imported/generated TIR that bypasses it.
+
+For pipelines:
+
+- malformed stage/order metadata and valid replayable-bind compatibility;
+- cyclic/conflicting dependencies versus a serial fallback;
+- nested pipeline requests versus bare nested `T.Pipelined` and siblings;
+- conditional async producer/consumer paths.
+
+For layouts and kernels:
+
+- annotation rank mismatch versus legal guarded-tail shape differences;
+- replicated store with and without owner selection;
+- compatible versus out-of-range thread ranges under warp specialization;
+- target-independent valid kernel on supported and unsupported targets.
+
+For types:
+
+- legal numeric cast versus invalid reinterpret/packed-storage conversion;
+- supported atomic/reducer dtype versus unsupported dtype;
+- valid vector lane extraction versus compile-time out-of-range lane.

--- a/.agents/skills/tilelang-semantic/scripts/scan_loop_nesting.py
+++ b/.agents/skills/tilelang-semantic/scripts/scan_loop_nesting.py
@@ -109,7 +109,7 @@ class NestingVisitor(ast.NodeVisitor):
         self.stack: list[tuple[LoopInfo, int]] = []
         self.pairs: Counter[tuple[str, str]] = Counter()
         self.examples: dict[tuple[str, str], list[str]] = defaultdict(list)
-        self.pipeline_violations: list[str] = []
+        self.nested_pipeline_requests: list[str] = []
 
     def visit_For(self, node: ast.For) -> None:
         self._visit_loop(node)
@@ -133,7 +133,7 @@ class NestingVisitor(ast.NodeVisitor):
             ancestor = next((entry for entry in reversed(self.stack) if entry[0].pipeline_requested), None)
             if ancestor is not None:
                 ancestor_info, ancestor_line = ancestor
-                self.pipeline_violations.append(
+                self.nested_pipeline_requests.append(
                     f"{self.path}:{node.lineno}: {info.label} is nested under {ancestor_info.label} at line {ancestor_line}"
                 )
 
@@ -163,11 +163,6 @@ def parse_args() -> argparse.Namespace:
         help="Python files or directories to scan",
     )
     parser.add_argument("--examples", type=int, default=3, help="example locations to retain per pair")
-    parser.add_argument(
-        "--check-pipeline-paths",
-        action="store_true",
-        help="exit nonzero when two pipeline-requested loops share a lexical path",
-    )
     return parser.parse_args()
 
 
@@ -175,7 +170,7 @@ def main() -> int:
     args = parse_args()
     pair_counts: Counter[tuple[str, str]] = Counter()
     pair_examples: dict[tuple[str, str], list[str]] = defaultdict(list)
-    violations: list[str] = []
+    nested_pipeline_requests: list[str] = []
     parse_failures: list[str] = []
 
     for path in sorted(set(python_files(args.roots))):
@@ -187,7 +182,7 @@ def main() -> int:
         visitor = NestingVisitor(path, args.examples)
         visitor.visit(tree)
         pair_counts.update(visitor.pairs)
-        violations.extend(visitor.pipeline_violations)
+        nested_pipeline_requests.extend(visitor.nested_pipeline_requests)
         for pair, locations in visitor.examples.items():
             remaining = args.examples - len(pair_examples[pair])
             if remaining > 0:
@@ -198,10 +193,10 @@ def main() -> int:
         locations = ", ".join(pair_examples[pair])
         print(f"  {pair[0]:24s} -> {pair[1]:24s} {count:5d}  {locations}")
 
-    print("\nNested pipeline-requested paths:")
-    if violations:
-        for violation in violations:
-            print(f"  {violation}")
+    print("\nNested pipeline-requested paths (inventory only; backend support decides validity):")
+    if nested_pipeline_requests:
+        for request in nested_pipeline_requests:
+            print(f"  {request}")
     else:
         print("  none")
 
@@ -210,7 +205,7 @@ def main() -> int:
         for failure in parse_failures:
             print(f"  {failure}")
 
-    return 1 if args.check_pipeline_paths and violations else 0
+    return 0
 
 
 if __name__ == "__main__":

--- a/.agents/skills/tilelang-semantic/scripts/scan_loop_nesting.py
+++ b/.agents/skills/tilelang-semantic/scripts/scan_loop_nesting.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Inventory lexical TileLang loop nesting in Python source files."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+from collections import Counter, defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+
+LOOP_NAMES = {
+    "Parallel": "Parallel",
+    "parallel": "Parallel",
+    "Pipelined": "Pipelined",
+    "Persistent": "Persistent",
+    "serial": "Serial",
+    "Serial": "Serial",
+    "grid": "Grid",
+    "unroll": "Unroll",
+    "Unroll": "Unroll",
+    "vectorized": "Vectorized",
+    "Vectorized": "Vectorized",
+}
+
+PIPELINE_KEYWORDS = {"num_stages", "order", "stage"}
+PIPELINE_ANNOTATION_KEYS = {
+    "num_stages",
+    "tl_pipeline_order",
+    "tl_pipeline_stage",
+    "tl_pipelined_num_stages",
+}
+
+
+@dataclass(frozen=True)
+class LoopInfo:
+    kind: str
+    pipeline_requested: bool = False
+
+    @property
+    def label(self) -> str:
+        if self.kind != "Pipelined":
+            return self.kind
+        suffix = "requested" if self.pipeline_requested else "bare"
+        return f"Pipelined[{suffix}]"
+
+
+def _call_name(call: ast.Call) -> str | None:
+    func = call.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return None
+
+
+def _is_statically_empty(node: ast.expr) -> bool:
+    if isinstance(node, ast.Dict):
+        return not node.keys
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        return not node.elts
+    return False
+
+
+def _is_zero(node: ast.expr) -> bool:
+    return isinstance(node, ast.Constant) and isinstance(node.value, (int, bool)) and int(node.value) == 0
+
+
+def _annotations_request_pipeline(node: ast.expr) -> bool:
+    if not isinstance(node, ast.Dict):
+        return False
+    return any(isinstance(key, ast.Constant) and isinstance(key.value, str) and key.value in PIPELINE_ANNOTATION_KEYS for key in node.keys)
+
+
+def _pipeline_requested(call: ast.Call) -> bool:
+    for keyword in call.keywords:
+        if keyword.arg == "annotations":
+            if _annotations_request_pipeline(keyword.value):
+                return True
+            continue
+        if keyword.arg not in PIPELINE_KEYWORDS:
+            continue
+        if keyword.arg == "num_stages" and _is_zero(keyword.value):
+            continue
+        if _is_statically_empty(keyword.value):
+            continue
+        return True
+    return False
+
+
+def loop_info(node: ast.For | ast.While) -> LoopInfo | None:
+    if isinstance(node, ast.While):
+        return LoopInfo("While")
+    if not isinstance(node.iter, ast.Call):
+        return None
+    name = _call_name(node.iter)
+    if name not in LOOP_NAMES:
+        return None
+    kind = LOOP_NAMES[name]
+    return LoopInfo(kind, kind == "Pipelined" and _pipeline_requested(node.iter))
+
+
+class NestingVisitor(ast.NodeVisitor):
+    def __init__(self, path: Path, examples_per_pair: int) -> None:
+        self.path = path
+        self.examples_per_pair = examples_per_pair
+        self.stack: list[tuple[LoopInfo, int]] = []
+        self.pairs: Counter[tuple[str, str]] = Counter()
+        self.examples: dict[tuple[str, str], list[str]] = defaultdict(list)
+        self.pipeline_violations: list[str] = []
+
+    def visit_For(self, node: ast.For) -> None:
+        self._visit_loop(node)
+
+    def visit_While(self, node: ast.While) -> None:
+        self._visit_loop(node)
+
+    def _visit_loop(self, node: ast.For | ast.While) -> None:
+        info = loop_info(node)
+        if info is None:
+            self.generic_visit(node)
+            return
+
+        if self.stack:
+            pair = (self.stack[-1][0].label, info.label)
+            self.pairs[pair] += 1
+            if len(self.examples[pair]) < self.examples_per_pair:
+                self.examples[pair].append(f"{self.path}:{node.lineno}")
+
+        if info.pipeline_requested:
+            ancestor = next((entry for entry in reversed(self.stack) if entry[0].pipeline_requested), None)
+            if ancestor is not None:
+                ancestor_info, ancestor_line = ancestor
+                self.pipeline_violations.append(
+                    f"{self.path}:{node.lineno}: {info.label} is nested under {ancestor_info.label} at line {ancestor_line}"
+                )
+
+        self.stack.append((info, node.lineno))
+        for child in node.body:
+            self.visit(child)
+        for child in node.orelse:
+            self.visit(child)
+        self.stack.pop()
+
+
+def python_files(roots: Iterable[Path]) -> Iterable[Path]:
+    for root in roots:
+        if root.is_file() and root.suffix == ".py":
+            yield root
+        elif root.is_dir():
+            yield from root.rglob("*.py")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "roots",
+        nargs="*",
+        type=Path,
+        default=[Path("tilelang"), Path("testing/python"), Path("examples")],
+        help="Python files or directories to scan",
+    )
+    parser.add_argument("--examples", type=int, default=3, help="example locations to retain per pair")
+    parser.add_argument(
+        "--check-pipeline-paths",
+        action="store_true",
+        help="exit nonzero when two pipeline-requested loops share a lexical path",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    pair_counts: Counter[tuple[str, str]] = Counter()
+    pair_examples: dict[tuple[str, str], list[str]] = defaultdict(list)
+    violations: list[str] = []
+    parse_failures: list[str] = []
+
+    for path in sorted(set(python_files(args.roots))):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (OSError, SyntaxError, UnicodeDecodeError) as err:
+            parse_failures.append(f"{path}: {err}")
+            continue
+        visitor = NestingVisitor(path, args.examples)
+        visitor.visit(tree)
+        pair_counts.update(visitor.pairs)
+        violations.extend(visitor.pipeline_violations)
+        for pair, locations in visitor.examples.items():
+            remaining = args.examples - len(pair_examples[pair])
+            if remaining > 0:
+                pair_examples[pair].extend(locations[:remaining])
+
+    print("Lexical TileLang loop pairs:")
+    for pair, count in sorted(pair_counts.items()):
+        locations = ", ".join(pair_examples[pair])
+        print(f"  {pair[0]:24s} -> {pair[1]:24s} {count:5d}  {locations}")
+
+    print("\nNested pipeline-requested paths:")
+    if violations:
+        for violation in violations:
+            print(f"  {violation}")
+    else:
+        print("  none")
+
+    if parse_failures:
+        print("\nSkipped files:")
+        for failure in parse_failures:
+            print(f"  {failure}")
+
+    return 1 if args.check_pipeline_paths and violations else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a `tilelang-semantic` agent skill for designing and reviewing TileLang language-validity checks
- define a workflow that separates proven semantic errors, backend limitations, inconclusive safety analysis, and optimization fallbacks
- document loop, memory/ownership, race, synchronization, async, TileOp, pipeline, reducer, layout, kernel, and dtype contracts
- add a source scanner that inventories lexical loop nesting and nested pipeline requests

## Design notes

The skill routes detailed work into three progressive references:

- loop structure and storage ownership
- memory, concurrency, collectives, barriers, and async lifetimes
- TileOps, pipelines, reducers, layouts, kernel targets, and dtype/value contracts

A forward audit against the latest TileKernels Nightly corpus found intentional nested active pipelines in Ascend kernels. Accordingly, the skill treats hierarchical-pipeline support as a backend capability rather than a backend-independent semantic prohibition. The scanner reports nested requests for review but does not fail on them.

## Validation

- skill creator `quick_validate.py` (passed)
- repository pre-commit hooks (passed)
- Ruff check/format for the scanner (passed)
- scanner on TileLang sources (passed)
- scanner on latest TileKernels Nightly, including nested-pipeline inventory (passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Add the `tilelang-semantic` agent skill for designing and reviewing TileLang semantic checks.
- Document contracts for loops, memory, ownership, races, synchronization, async lifetimes, TileOps, pipelines, reducers, layouts, kernels, and dtypes.
- Define error classifications for semantic errors, backend limitations, inconclusive analysis, and optimization fallbacks.
- Add an AST-based scanner for loop nesting and nested pipeline requests.
- Report nested active pipelines for backend review without treating them as language-wide semantic errors.
- Add OpenAI agent metadata and reference documentation.

## Validation

- Skill creator validation passed.
- Repository pre-commit hooks, Ruff checks, and formatting passed.
- TileLang source scanning and TileKernels Nightly scanning passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->