### PR TITLE
[Layout][Inference] Restore register-count as the default cost model

### DIFF
--- a/.agents/skills/tilelang-layout/SKILL.md
+++ b/.agents/skills/tilelang-layout/SKILL.md
@@ -97,7 +97,7 @@ annotation contract.
 
 "Cheapest" is a pluggable policy (`layout_cost_model.{h,cc}`):
 
-- `tl.layout_cost_model="io-aware"` (default): every
+- `tl.layout_cost_model="io-aware"` (opt-in): every
   fragment<->global copy and global-touching parallel loop is charged
   `max(bandwidth bytes, issue bytes)` under the attempt's layouts, scored
   symbolically on the CuTe algebra (pack -> `LayoutFromTileLang` ->
@@ -105,7 +105,7 @@ annotation contract.
   segments counted at warp/step granularity). Registers are the tiebreak.
   Statements outside the model are charged a conservative worst case — an
   attempt must never profit from opacity.
-- `tl.layout_cost_model="register-count"`: legacy register-slots-only
+- `tl.layout_cost_model="register-count"` (default): register-slots-only
   ordering.
 - The scoring formulas are guarded by the Python parity check
   `maint/layout_inference/run.py --cute` (symbolic scorer vs an

--- a/maint/layout_inference/README.md
+++ b/maint/layout_inference/README.md
@@ -2,8 +2,8 @@
 
 Constructed IR cases with reviewed expected layouts, for validating the
 free-mode layout search — in particular the selection policy behind
-`tl.layout_cost_model` ("register-count" = the legacy ordering,
-"io-aware" = the default model in
+`tl.layout_cost_model` ("register-count" = the default ordering,
+"io-aware" = the opt-in global-memory model in
 `src/transform/layout_inference/layout_cost_model.cc`).
 
 Why this exists:
@@ -30,8 +30,8 @@ python run.py --cute         # compare symbolic scores with the exact oracle
 
 `--anchor` closes the loop between the model and the real vectorizer: the
 cost model scores a layout assuming a vector width, and the anchor reads
-back what the vectorizer actually emitted for the winning layout under the
-default config. Each case declares `VECTOR_ANCHOR = {variant: {buffer:
+back what the vectorizer actually emitted for the winning layout under an
+explicit `io-aware` config. Each case declares `VECTOR_ANCHOR = {variant: {buffer:
 lanes}}`; variants without one print observed widths for review. A
 mismatch means the model's width belief and codegen diverged — exactly the
 drift the shared MaxVectorLoadBits policy is supposed to prevent.

--- a/maint/layout_inference/cases/broadcast_read.py
+++ b/maint/layout_inference/cases/broadcast_read.py
@@ -51,7 +51,7 @@ def check(variant, model, result):
     assert loop["replicate"] == 1, f"loop layout must not replicate execution, got: {loop}"
 
 
-# Under the default (io-aware) config: S loads via the fully replicated
+# Under the explicit io-aware config: S loads via the fully replicated
 # fragment (vector = its slot count), Out streams 4-wide and coalesced —
 # the whole point of rejecting the #1729 thread-collapsed candidate.
 VECTOR_ANCHOR = {

--- a/maint/layout_inference/cases/elementwise_copy.py
+++ b/maint/layout_inference/cases/elementwise_copy.py
@@ -35,7 +35,7 @@ def check(variant, model, result):
 
 
 # Widest per-buffer vector access the lowered kernel must exhibit under the
-# default (io-aware) config — the width the winning layout was scored at.
+# explicit io-aware config — the width the winning layout was scored at.
 VECTOR_ANCHOR = {
     "fp16_128x128_t128": {"A": 8, "B": 8},
     "fp32_64x256_t256": {"A": 4, "B": 4},

--- a/maint/layout_inference/common.py
+++ b/maint/layout_inference/common.py
@@ -68,7 +68,7 @@ def run_layout_inference_objects(prim_func, cost_model: str, target=None):
 
 
 def lower_and_extract_vector_widths(prim_func, target=None) -> dict[str, int]:
-    """Fully lower under the DEFAULT pass config and report, per global
+    """Fully lower under the IO-AWARE pass config and report, per global
     buffer, the widest vectorized access (in lanes) the final device TIR
     performs.
 
@@ -79,7 +79,7 @@ def lower_and_extract_vector_widths(prim_func, target=None) -> dict[str, int]:
     """
     if target is None:
         target = tvm.target.Target(determine_target("auto"))
-    with tvm.target.Target(target):
+    with tvm.target.Target(target), tvm.transform.PassContext(config={"tl.layout_cost_model": "io-aware"}):
         artifact = tl.lower(prim_func, target=target, enable_device_compile=False)
     widths: dict[str, int] = {}
 

--- a/maint/layout_inference/run.py
+++ b/maint/layout_inference/run.py
@@ -15,7 +15,7 @@ Usage:
     python run.py --anchor        # lower fully and check that the widest
                                   # per-buffer vector access in device TIR
                                   # matches each case's VECTOR_ANCHOR (the
-                                  # width the cost model believed in);
+                                  # width the io-aware model believed in);
                                   # variants without an anchor print the
                                   # observed widths for review
     python run.py --cute          # compare the symbolic scorer with the
@@ -92,7 +92,7 @@ def format_layout(info: dict) -> str:
 
 
 def run_anchor(modules) -> int:
-    """Anchor mode: lower each variant under the DEFAULT pass config and
+    """Anchor mode: lower each variant under the IO-AWARE pass config and
     check the widest per-buffer vector access in the device TIR against the
     case's VECTOR_ANCHOR — the width the cost model's winning layout was
     scored to sustain. A mismatch means the model believed a width the

--- a/src/config.h
+++ b/src/config.h
@@ -29,14 +29,14 @@ inline bool ReducerPlanVerboseEnabled() {
 
 /*!
  * \brief The cost model that ranks free-mode layout attempts. Valid
- *  values: "io-aware" (default — bytes x vector-width/coalescing over
- *  fragment<->global traffic, registers as tiebreak) and "register-count"
- *  (the legacy total-register-slots ordering).
+ *  values: "register-count" (default — total fragment register slots) and
+ *  "io-aware" (bytes x vector-width/coalescing over fragment<->global
+ *  traffic, registers as tiebreak).
  */
 inline std::string LayoutCostModelName() {
   auto ctxt = tvm::transform::PassContext::Current();
   return ctxt->GetConfig("tl.layout_cost_model", ffi::Optional<ffi::String>())
-      .value_or(ffi::String("io-aware"));
+      .value_or(ffi::String("register-count"));
 }
 
 /*!

--- a/src/op/builtin.h
+++ b/src/op/builtin.h
@@ -82,10 +82,10 @@ static constexpr const char *kReducerForceBaseline =
 static constexpr const char *kEnableReducerPlanVerbose =
     "tl.enable_reducer_plan_verbose";
 // The cost model that ranks free-mode layout attempts, by name:
-// "io-aware" (default) scores estimated global-memory access cost —
-// vector width / coalescing of every fragment<->global copy, weighted by
-// bytes moved — with register count as the tiebreak; "register-count" is
-// the legacy total-register-slots-only ordering.
+// "register-count" (default) uses total fragment register slots;
+// "io-aware" scores estimated global-memory access cost — vector width /
+// coalescing of every fragment<->global copy, weighted by bytes moved —
+// with register count as the tiebreak.
 static constexpr const char *kLayoutCostModel = "tl.layout_cost_model";
 static constexpr const char *kEnableVectorizePlannerVerbose =
     "tl.enable_vectorize_planner_verbose";

--- a/src/transform/layout_inference/layout_cost_model.cc
+++ b/src/transform/layout_inference/layout_cost_model.cc
@@ -1106,7 +1106,7 @@ LayoutCostModel::Create(const std::string &name, Target target) {
   }
   LOG(FATAL) << "Unknown layout cost model \"" << name
              << "\" for pass config `tl.layout_cost_model`; valid values "
-                "are \"io-aware\" (default) and \"register-count\".";
+                "are \"register-count\" (default) and \"io-aware\".";
   return nullptr; // unreachable
 }
 

--- a/src/transform/layout_inference/layout_cost_model.h
+++ b/src/transform/layout_inference/layout_cost_model.h
@@ -6,15 +6,15 @@
  * connected component and keeps the cheapest complete layout assignment.
  * What "cheapest" means is a pluggable policy behind LayoutCostModel:
  *
- *  - RegisterCountCostModel (legacy): total fragment register slots,
- *    nothing else. Available through
- *    `tl.layout_cost_model="register-count"` for A/B comparisons.
+ *  - RegisterCountCostModel (default): total fragment register slots,
+ *    nothing else.
  *  - IOAwareCostModel (layout RFC, design B2): walks the component's
  *    global-memory-touching statements (fragment<->global copies and
  *    parallel loops with direct global accesses) and charges each one
  *    max(bandwidth bytes, issue-equivalent bytes) under the attempt's
- *    tentative layouts; registers remain the lexicographic tiebreak. This
- *    is the default policy.
+ *    tentative layouts; registers remain the lexicographic tiebreak.
+ *    Available through `tl.layout_cost_model="io-aware"` for opt-in use
+ *    and A/B comparisons.
  *
  * Concrete models live in the .cc; callers go through Create().
  */

--- a/testing/python/transform/test_tilelang_transform_layout_inference.py
+++ b/testing/python/transform/test_tilelang_transform_layout_inference.py
@@ -110,6 +110,36 @@ def test_loop_tail_split(block_M, block_N, block_K, threads, vec_load_b, dtype):
         # tvm.ir.assert_structural_equal(mod, ref_mod)
 
 
+def test_register_count_is_default_layout_cost_model():
+    @T.prim_func
+    def main(
+        S: T.Tensor((2,), T.float32),
+        Out: T.Tensor((2, 2560), T.float32),
+    ):
+        with T.Kernel(1, threads=256):
+            s_frag = T.alloc_fragment((2,), T.float32)
+            for i in T.Parallel(2):
+                s_frag[i] = S[i]
+            for i, j in T.Parallel(2, 2560):
+                Out[i, j] = s_frag[i] * 2.0
+
+    target = auto_target
+
+    def infer(pass_configs=None):
+        with target, tvm.transform.PassContext(config=pass_configs or {}):
+            mod = tvm.IRModule({"main": main})
+            mod = tvm.tirx.transform.BindTarget(target)(mod)
+            mod = tl.transform.MaterializeKernelLaunch()(mod)
+            return tl.transform.LayoutInference()(mod)
+
+    default = infer()
+    register_count = infer({"tl.layout_cost_model": "register-count"})
+    io_aware = infer({"tl.layout_cost_model": "io-aware"})
+
+    tvm.ir.assert_structural_equal(default, register_count)
+    assert not tvm.ir.structural_equal(default, io_aware)
+
+
 def test_static_ragged_copy_minimizes_full_thread_padding():
     n = 514
     threads = 128

--- a/tilelang/transform/pass_config.py
+++ b/tilelang/transform/pass_config.py
@@ -117,7 +117,7 @@ class PassConfigKey(str, Enum):
     "io-aware" scores estimated global-memory access cost (vector width /
     warp coalescing of every fragment<->global copy, weighted by bytes
     moved) with register count as the tiebreak; "register-count" is the
-    legacy total-register-slots-only ordering. Default: 'io-aware'"""
+    total-register-slots-only ordering. Default: 'register-count'"""
 
     TL_REDUCER_FORCE_BASELINE = "tl.reducer_force_baseline"
     """Force the canonical FullParticipant baseline for every reducer epoch,


### PR DESCRIPTION
## Summary

- Restore `register-count` as the default policy for free-mode layout inference.
- Keep `io-aware` available as an opt-in through `tl.layout_cost_model="io-aware"`.
- Make the vector-width anchor explicitly exercise IO-aware selection and add regression coverage for the default.

## Motivation

The IO-aware policy can choose wider layouts that increase register pressure and reduce occupancy in reduction-heavy normalization kernels. This returns the conservative register-count policy to the default while retaining IO-aware for explicit use and further evaluation.

## Validation

- `cmake --build build -j 32`
- `python -m pytest testing/python/transform/test_tilelang_transform_layout_inference.py -q -k register_count_is_default_layout_cost_model`
- Layout golden checks: 32/32 passed on an sm90 target
- IO-aware vector-width anchors: 16/16 passed on an sm90 target
- CuTe/oracle comparisons: 88/88 passed on an sm90 target
- `./format.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Restores `register-count` as the default free-mode layout cost model.
- Keeps `io-aware` available through `tl.layout_cost_model="io-aware"`.
- Updates documentation and error messages to reflect the default and opt-in models.
- Updates vector-width anchor checks to use the explicit `io-aware` configuration.
- Adds regression coverage for the default model.

## Validation

- Build passed.
- Targeted regression tests passed.
- Layout golden checks passed: 32/32.
- IO-aware vector-width checks passed: 16/16.
- CuTe/oracle comparisons passed on sm90: 88/88.
- Formatting checks passed.

## C++ style / lint notes

- The PR changes C++ documentation and configuration fallback behavior.
- No changes to C++ style rules are reported.
- The C++ API Style Audit remains warning-only.
- No correctness, build, or test issues are reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->