### PR TITLE
[CUDA] Fix warp shuffle for half, bfloat16, and FP8

### DIFF
--- a/src/tl_templates/cuda/common.h
+++ b/src/tl_templates/cuda/common.h
@@ -1260,6 +1260,49 @@ TL_DEVICE __half2 abs2(__half2 a) {
 
 using tl::tfloat32_t;
 
+// CUDA declares __shfl_*_sync only for its native arithmetic types, so
+// shuffling a CUTLASS sub-32-bit float wrapper either binds to the `float`
+// overload or is ambiguous, and fails to compile. Carry the raw bits through
+// the native 32-bit unsigned overload instead, as the tl::shfl_*_sync helpers
+// below do. The warpSize default also lets their three-argument generic
+// template resolve for these types.
+#define TL_DEFINE_SHFL_SYNC_OVERLOADS(TYPE, RAW)                               \
+  TL_PATCH TL_DEVICE TYPE __shfl_sync(unsigned mask, TYPE val, int src_lane,   \
+                                      int width = warpSize) {                  \
+    RAW raw = reinterpret_cast<RAW &>(val);                                    \
+    RAW ret = static_cast<RAW>(                                                \
+        __shfl_sync(mask, static_cast<uint32_t>(raw), src_lane, width));       \
+    return reinterpret_cast<TYPE &>(ret);                                      \
+  }                                                                            \
+  TL_PATCH TL_DEVICE TYPE __shfl_xor_sync(                                     \
+      unsigned mask, TYPE val, int lane_mask, int width = warpSize) {          \
+    RAW raw = reinterpret_cast<RAW &>(val);                                    \
+    RAW ret = static_cast<RAW>(                                                \
+        __shfl_xor_sync(mask, static_cast<uint32_t>(raw), lane_mask, width));  \
+    return reinterpret_cast<TYPE &>(ret);                                      \
+  }                                                                            \
+  TL_PATCH TL_DEVICE TYPE __shfl_down_sync(unsigned mask, TYPE val, int delta, \
+                                           int width = warpSize) {             \
+    RAW raw = reinterpret_cast<RAW &>(val);                                    \
+    RAW ret = static_cast<RAW>(                                                \
+        __shfl_down_sync(mask, static_cast<uint32_t>(raw), delta, width));     \
+    return reinterpret_cast<TYPE &>(ret);                                      \
+  }                                                                            \
+  TL_PATCH TL_DEVICE TYPE __shfl_up_sync(unsigned mask, TYPE val, int delta,   \
+                                         int width = warpSize) {               \
+    RAW raw = reinterpret_cast<RAW &>(val);                                    \
+    RAW ret = static_cast<RAW>(                                                \
+        __shfl_up_sync(mask, static_cast<uint32_t>(raw), delta, width));       \
+    return reinterpret_cast<TYPE &>(ret);                                      \
+  }
+
+TL_DEFINE_SHFL_SYNC_OVERLOADS(half_t, uint16_t)
+TL_DEFINE_SHFL_SYNC_OVERLOADS(bfloat16_t, uint16_t)
+TL_DEFINE_SHFL_SYNC_OVERLOADS(tl::float_e4m3_t, uint8_t)
+TL_DEFINE_SHFL_SYNC_OVERLOADS(tl::float_e5m2_t, uint8_t)
+
+#undef TL_DEFINE_SHFL_SYNC_OVERLOADS
+
 //
 // Optimized type-punned warp shuffle helpers for 16-bit types
 // Directly shuffle the underlying bits (as uint16/uint32) to avoid

--- a/testing/python/language/test_tilelang_language_warp_sync.py
+++ b/testing/python/language/test_tilelang_language_warp_sync.py
@@ -1,3 +1,5 @@
+import pytest
+
 import tilelang
 import tilelang.language as T
 import torch
@@ -56,6 +58,89 @@ def test_shfl_sync():
     assert "__shfl_sync" in kernel.get_kernel_source()
     kernel(a)
     assert torch.all(a == 310)
+
+
+def _shift(lane, delta):
+    """Return the source lane, or the current lane when the shift is out of range."""
+    shifted = lane + delta
+    return shifted if 0 <= shifted < 32 else lane
+
+
+# Builtin each shuffle lowers to and the lane its result comes from, in the row
+# order shfl_all_ops_kernel writes. The tables differ so the two shapes cannot fold.
+SHFL_TEMP_OPS = (
+    ("__shfl_sync", lambda lane: 31),
+    ("__shfl_xor_sync", lambda lane: lane ^ 1),
+    ("__shfl_down_sync", lambda lane: _shift(lane, 1)),
+    ("__shfl_up_sync", lambda lane: _shift(lane, -1)),
+)
+SHFL_INLINE_OPS = (
+    ("__shfl_sync", lambda lane: 0),
+    ("__shfl_xor_sync", lambda lane: lane ^ 2),
+    ("__shfl_down_sync", lambda lane: _shift(lane, 2)),
+    ("__shfl_up_sync", lambda lane: _shift(lane, -2)),
+)
+
+# One distinct value per lane so a wrong source lane cannot match by accident, on
+# float8_e5m2's coarse grid. Lane 0's negative zero needs the byte comparison.
+_MANTISSAS = (1.0, 1.25, 1.5, 1.75)
+_GRID = [sign * mant * 2.0**exp for exp in range(4) for mant in _MANTISSAS for sign in (1, -1)]
+LANE_VALUES = [-0.0, *_GRID[1:]]
+
+
+def shfl_all_ops_kernel(dtype):
+    @T.prim_func
+    def main(
+        A: T.Tensor((32,), dtype),
+        B: T.Tensor((len(SHFL_TEMP_OPS) + len(SHFL_INLINE_OPS), 32), dtype),
+    ):
+        with T.Kernel(1, threads=32):
+            tx = T.get_thread_binding()
+            # Rows 0-3 copy-initialize the result, rows 4-7 store it inline.
+            broadcast = T.shfl_sync(A[tx], 31)
+            swapped = T.shfl_xor(A[tx], 1)
+            shifted_down = T.shfl_down(A[tx], 1)
+            shifted_up = T.shfl_up(A[tx], 1)
+            B[0, tx] = broadcast
+            B[1, tx] = swapped
+            B[2, tx] = shifted_down
+            B[3, tx] = shifted_up
+            B[4, tx] = T.shfl_sync(A[tx], 0)
+            B[5, tx] = T.shfl_xor(A[tx], 2)
+            B[6, tx] = T.shfl_down(A[tx], 2)
+            B[7, tx] = T.shfl_up(A[tx], 2)
+
+    return main
+
+
+@tilelang.testing.requires_cuda
+@pytest.mark.parametrize("dtype", [T.float16, T.bfloat16, T.float8_e4m3, T.float8_e5m2])
+def test_shfl_narrow_float_dtypes(dtype):
+    kernel = tilelang.compile(shfl_all_ops_kernel(dtype))
+    source = kernel.get_kernel_source()
+
+    values = torch.tensor(LANE_VALUES, device="cuda", dtype=torch.float32)
+    torch_dtype = dtype.as_torch()
+    rows = len(SHFL_TEMP_OPS) + len(SHFL_INLINE_OPS)
+    # out_idx would rebuild a torch tensor from float8 DLPack, unsupported on some versions.
+    b = torch.empty(rows, 32, device="cuda", dtype=torch_dtype)
+    kernel(values.to(torch_dtype), b)
+
+    # Both shapes must still reach the raw builtin, or these overloads stop being
+    # covered. Count in the kernel body, not the preamble.
+    body = source[source.rindex("__global__") :]
+    for builtin, _ in SHFL_TEMP_OPS:
+        assert body.count(f"{builtin}(") == 2
+
+    for base, ops, form in ((0, SHFL_TEMP_OPS, "temporary"), (len(SHFL_TEMP_OPS), SHFL_INLINE_OPS, "inline")):
+        for offset, (builtin, src_lane) in enumerate(ops):
+            ref = values[[src_lane(lane) for lane in range(32)]].to(torch_dtype)
+            # Compare bytes: a float comparison would not separate -0.0 from +0.0.
+            got_bytes = b[base + offset].view(torch.uint8)
+            ref_bytes = ref.view(torch.uint8)
+            assert torch.equal(got_bytes, ref_bytes), (
+                f"{builtin} ({form} form) shuffled the wrong lane: got {got_bytes.tolist()}, expected {ref_bytes.tolist()}"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

`T.shfl_sync`, `T.shfl_xor`, `T.shfl_down`, and `T.shfl_up` failed to compile for narrow floating-point wrappers. `bfloat16` and FP8 failed in both temporary and inline forms; `float16` failed when the result was materialized in a temporary.

## Root cause

CUDA codegen emits raw `__shfl_*_sync` calls, but CUDA has no exact overloads for CUTLASS `half_t`/`bfloat16_t` or TileLang's FP8 wrappers.

The 16-bit wrappers resolved through the float overload and could not convert the result back in the failing code shape. `half_t` survives the inline form only because it has an assignment operator taking CUDA's `__half`, which `bfloat16_t` does not. FP8 calls were ambiguous between multiple native overloads.

## Fix

Add exact non-template overloads for all four shuffle builtins and these wrapper types:

- `half_t`
- `bfloat16_t`
- `float_e4m3_t`
- `float_e5m2_t`

Each overload carries the raw 8- or 16-bit value through CUDA's native `uint32_t` shuffle and restores the original wrapper type. A local macro generates the overloads and is undefined immediately after use.

Codegen remains unchanged. The `width = warpSize` default supports both codegen's four-argument calls and the existing three-argument `tl::shfl_*_sync` helpers.

## Tests

Added exact lane-permutation coverage for all four wrapper types and all four shuffle operations using materialized temporaries.

Verified locally on a TITAN RTX (`sm_75`) with CUDA 12.4:

- touched test file: 6 passed;
- negative control: 4 failed, 2 passed;
- the float, integer, and bool dtypes that already compiled still do, in both temporary and inline forms;
- related reduce, scan, and warp-reduce suites have no new failures.

Fixes #2569

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added CUDA warp-shuffle overloads for `half_t`, `bfloat16_t`, `tl::float_e4m3_t`, and `tl::float_e5m2_t`.
- Shuffled each type’s raw 8- or 16-bit representation through CUDA `uint32_t` intrinsics.
- Supported `T.shfl_sync`, `T.shfl_xor`, `T.shfl_down`, and `T.shfl_up`.
- Preserved existing code generation and wider-type behavior.
- Added parameterized CUDA tests for all four shuffle operations and narrow floating-point types.

## C++ style / lint notes

- The change adds C++ macro-generated overloads in `src/tl_templates/cuda/common.h`.
- It does not change rules documented in `docs/developer_guide/cpp_style.md`.
- The C++ API Style Audit (warning only) remains advisory.
- No correctness or build issue is identified from the reported changes. Any TLCPP003/TLCPP004 findings are advisory unless they indicate a clear API, FFI, or maintainability risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->