### PR TITLE
[CUDA][Reduce] Add per-reduce control for FP32x2 accumulation

### DIFF
--- a/src/backend/common/op/reduce.h
+++ b/src/backend/common/op/reduce.h
@@ -670,8 +670,7 @@ template <typename Impl> struct ReduceLowerer {
       return indices;
     };
 
-    int vsize =
-        Impl::GetPreferredVectorizedSize(dst_buffer->dtype, lower_args.target);
+    int vsize = Impl::GetPreferredVectorizedSize(op, lower_args.target);
     const int64_t *reduce_extent = as_const_int(op.src->shape[op.dim]);
     bool can_pack = op.clear && vsize == 2 && reduce_extent &&
                     *reduce_extent >= vsize && *reduce_extent % vsize == 0 &&
@@ -855,8 +854,7 @@ template <typename Impl> struct ReduceLowerer {
       Buffer clear_buffer_packed;
       Buffer clear_batch_pack_buffer;
       {
-        int vsize = Impl::GetPreferredVectorizedSize(clear_buffer->dtype,
-                                                     lower_args.target);
+        int vsize = Impl::GetPreferredVectorizedSize(op, lower_args.target);
         if (vsize > 1 && !src_var_compressed.empty()) {
           auto *ext = src_var_compressed.back()->dom->extent.as<IntImmNode>();
           if (ext && ext->value >= vsize && ext->value % vsize == 0 &&
@@ -1013,8 +1011,7 @@ template <typename Impl> struct ReduceLowerer {
               static_cast<int>(*as_const_int(lower_args.thread_bounds->extent));
           auto thread_offset = lower_args.thread_bounds->min;
 
-          int vsize = Impl::GetPreferredVectorizedSize(clear_buffer->dtype,
-                                                       lower_args.target);
+          int vsize = Impl::GetPreferredVectorizedSize(op, lower_args.target);
           bool can_batch_pack =
               vsize > 1 && batch >= vsize && batch % vsize == 0 &&
               reduce::MakeCodegenReducer(op, vsize).has_value();

--- a/src/cuda/op/reduce.cc
+++ b/src/cuda/op/reduce.cc
@@ -17,16 +17,37 @@ using namespace tirx;
 namespace cuda {
 
 struct Reduce : backend::ReduceLowerer<Reduce> {
+  static bool IsFAdd2Enabled(const ReduceOpNode &op) {
+    constexpr const char *kEnableFAdd2 = "enable_fadd2";
+    if (auto value = op.annotations.Get(kEnableFAdd2)) {
+      if (auto enabled = value.value().as<Bool>()) {
+        return enabled.value();
+      }
+      if (auto enabled = value.value().as<IntImm>()) {
+        return enabled.value()->value != 0;
+      }
+      LOG(FATAL) << "CUDA ReduceOp annotation `" << kEnableFAdd2
+                 << "` must be a boolean";
+    }
+    return true;
+  }
+
   static bool SupportsFp16Bf16NanReduce(Target target) {
     return TargetIsCuda(target);
   }
 
-  static int GetPreferredVectorizedSize(DataType dt, Target target) {
+  static int GetPreferredVectorizedSize(const ReduceOpNode &op, Target target) {
     if (!TargetIsCuda(target)) {
       return 1;
     }
     bool supports_fp32x2 = TargetHasSMVersionGE(target, 100);
-    return backend::reduce::GetPreferredVectorizedSize(dt, supports_fp32x2);
+    int vsize = backend::reduce::GetPreferredVectorizedSize(op.dst->dtype,
+                                                            supports_fp32x2);
+    if (vsize == 2 && op.dst->dtype.is_float() && op.dst->dtype.bits() == 32 &&
+        (op.type->IsSum() || op.type->IsAbsSum()) && !IsFAdd2Enabled(op)) {
+      return 1;
+    }
+    return vsize;
   }
 
   static std::string MakeBatchAllReduce(std::string reducer,

--- a/src/op/reduce.cc
+++ b/src/op/reduce.cc
@@ -70,6 +70,7 @@ void RegisterReduceImpl(ReduceImpl impl) {
 
 ReduceOp::ReduceOp(Array<PrimExpr> args, Map<String, ObjectRef> annotations) {
   ObjectPtr<ReduceOpNode> node = make_object<ReduceOpNode>();
+  node->annotations = annotations;
   // Accept BufferRegion/BufferLoad for src/dst
   auto src_access = NormalizeToAccessRegion(args[0], kAccessRead);
   auto dst_access = NormalizeToAccessRegion(args[1], kAccessReadWrite);

--- a/src/op/reduce.h
+++ b/src/op/reduce.h
@@ -102,6 +102,7 @@ public:
                              ///< (use __hmax_nan/__hmin_nan) instead of the
                              ///< default __hmax/__hmin which return the
                              ///< non-NaN operand.
+  Map<String, ObjectRef> annotations; ///< Backend-specific lowering controls.
 
   TVM_FFI_DECLARE_OBJECT_INFO_FINAL("tl.ReduceOp", ReduceOpNode,
                                     TileOperatorNode);
@@ -117,7 +118,8 @@ public:
         .def_ro("type", &ReduceOpNode::type)
         .def_ro("clear", &ReduceOpNode::clear)
         .def_ro("batch", &ReduceOpNode::batch)
-        .def_ro("nan_propagate", &ReduceOpNode::nan_propagate);
+        .def_ro("nan_propagate", &ReduceOpNode::nan_propagate)
+        .def_ro("annotations", &ReduceOpNode::annotations);
   }
 
   /// Lower the operator to TIR statements

--- a/src/rocm/op/reduce.cc
+++ b/src/rocm/op/reduce.cc
@@ -19,7 +19,9 @@ namespace rocm {
 struct Reduce : backend::ReduceLowerer<Reduce> {
   static bool SupportsFp16Bf16NanReduce(Target) { return false; }
 
-  static int GetPreferredVectorizedSize(DataType, Target) { return 1; }
+  static int GetPreferredVectorizedSize(const ReduceOpNode &, Target) {
+    return 1;
+  }
 
   static std::string MakeBatchAllReduce(std::string reducer,
                                         int reducing_threads, int scale,

--- a/testing/python/cuda/test_cuda_f32x2_intrinsics.py
+++ b/testing/python/cuda/test_cuda_f32x2_intrinsics.py
@@ -140,7 +140,7 @@ def _make_auto_vec_fma_kernel(dtype_tl, width: int = 4):
     return main
 
 
-def _make_auto_vec_reduce_kernel(reduce_func, *, nan_propagate=False):
+def _make_auto_vec_reduce_kernel(reduce_func, *, nan_propagate=False, annotations=None):
     """Build a row reduction whose local fragment is contiguous per thread."""
 
     @T.prim_func
@@ -153,15 +153,15 @@ def _make_auto_vec_reduce_kernel(reduce_func, *, nan_propagate=False):
             dst = T.alloc_fragment((M,), T.float32)
             T.copy(A, src)
             if nan_propagate:
-                reduce_func(src, dst, dim=1, nan_propagate=True)
+                reduce_func(src, dst, dim=1, nan_propagate=True, annotations=annotations)
             else:
-                reduce_func(src, dst, dim=1)
+                reduce_func(src, dst, dim=1, annotations=annotations)
             T.copy(dst, C)
 
     return main
 
 
-def _make_auto_vec_batched_reduce_kernel(reduce_func, *, rows=M, width=64, threads=256):
+def _make_auto_vec_batched_reduce_kernel(reduce_func, *, rows=M, width=64, threads=256, annotations=None):
     """Build a reduction that shuffles packed values between threads."""
 
     @T.prim_func
@@ -173,7 +173,7 @@ def _make_auto_vec_batched_reduce_kernel(reduce_func, *, rows=M, width=64, threa
             src = T.alloc_shared((rows, width), T.float32)
             dst = T.alloc_fragment((rows,), T.float32)
             T.copy(A, src, disable_tma=True)
-            reduce_func(src, dst, dim=1, batch=2)
+            reduce_func(src, dst, dim=1, batch=2, annotations=annotations)
             T.copy(dst, C)
 
     return main
@@ -383,6 +383,29 @@ def test_codegen_auto_vec_reduce_f32_sm100(op_name, reduce_func, packed_ops):
 
 
 @tilelang.testing.requires_cuda
+@pytest.mark.parametrize("op_name,reduce_func", [("sum", T.reduce_sum), ("abssum", T.reduce_abssum)])
+def test_codegen_auto_vec_reduce_f32_disable_fadd2(op_name, reduce_func):
+    func = _make_auto_vec_reduce_kernel(reduce_func, annotations={"enable_fadd2": False})
+    src = _lower_to_cuda_source(func, target=SM100_TARGET)
+    assert "tl::add2" not in src, f"tl::add2 should be disabled for float32 {op_name} reduction"
+
+
+@tilelang.testing.requires_cuda
+def test_codegen_auto_vec_reduce_f32_disable_fadd2_does_not_disable_max2():
+    func = _make_auto_vec_reduce_kernel(T.reduce_max, annotations={"enable_fadd2": False})
+    src = _lower_to_cuda_source(func, target=SM100_TARGET)
+    assert "tl::max2" in src
+
+
+@tilelang.testing.requires_cuda
+def test_codegen_auto_vec_batched_reduce_f32_disable_fadd2():
+    func = _make_auto_vec_batched_reduce_kernel(T.reduce_sum, annotations={"enable_fadd2": False})
+    src = _lower_to_cuda_source(func, target=SM100_TARGET)
+    assert "tl::add2" not in src
+    assert "SumOp_f32x2" not in src
+
+
+@tilelang.testing.requires_cuda
 @pytest.mark.parametrize("op_name,reduce_func,packed_ops", _REDUCE_OPS, ids=[op[0] for op in _REDUCE_OPS])
 def test_codegen_auto_vec_reduce_f32_no_sm80(op_name, reduce_func, packed_ops):
     func = _make_auto_vec_reduce_kernel(reduce_func)
@@ -476,6 +499,18 @@ def test_correctness_fma2(dtype_name):
 @pytest.mark.parametrize("op_name,reduce_func", [(op_name, reduce_func) for op_name, reduce_func, _ in _REDUCE_OPS])
 def test_correctness_auto_vec_reduce_f32(op_name, reduce_func):
     func = _make_auto_vec_reduce_kernel(reduce_func)
+    kernel = tilelang.compile(func, out_idx=[1], target="cuda")
+    a = torch.randn((M, 128), device="cuda", dtype=torch.float32)
+    result = kernel(a)
+    reference = _torch_reduce(a, op_name)
+    torch.testing.assert_close(result, reference, atol=1e-5, rtol=1e-5)
+
+
+@tilelang.testing.requires_cuda
+@tilelang.testing.requires_cuda_compute_version(10)
+@pytest.mark.parametrize("op_name,reduce_func", [("sum", T.reduce_sum), ("abssum", T.reduce_abssum)])
+def test_correctness_auto_vec_reduce_f32_disable_fadd2(op_name, reduce_func):
+    func = _make_auto_vec_reduce_kernel(reduce_func, annotations={"enable_fadd2": False})
     kernel = tilelang.compile(func, out_idx=[1], target="cuda")
     a = torch.randn((M, 128), device="cuda", dtype=torch.float32)
     result = kernel(a)

--- a/tilelang/language/reduce_op.py
+++ b/tilelang/language/reduce_op.py
@@ -49,6 +49,10 @@ def reduce(
             float16/bfloat16. When True, lower to CUDA __hmax_nan/__hmin_nan so
             NaNs propagate through the reduction. When False (default), use
             __hmax/__hmin which return the non-NaN operand. CUDA-only.
+        annotations (dict, optional): Additional lowering controls. On CUDA
+            SM100+, FP32 sum/abssum reductions accept
+            ``{"enable_fadd2": False}`` to keep the reducer scalar. Packed
+            FP32x2 reduction remains enabled by default.
     """
     if batch < 1:
         raise ValueError(f"batch must be >= 1, got {batch}")
@@ -237,6 +241,9 @@ def reduce_sum(
                               If False, results will be accumulated on existing values.
                               Defaults to True.
         batch (int): Number of output elements per batched AllReduce call (default 1).
+        annotations (dict, optional): On CUDA SM100+, set
+            ``{"enable_fadd2": False}`` to disable packed FP32x2 accumulation
+            for this reduction. It is enabled by default.
     Note: When clear=True, reduce_sum will not compute directly on the output buffer. This is because
           during warp reduction, the same value would be accumulated multiple times (number of threads
           in the warp). Therefore, the implementation with clear=True follows these steps:
@@ -260,6 +267,9 @@ def reduce_abssum(buffer: tirx.Buffer, out: tirx.Buffer, dim: int = -1, batch: i
         out (tirx.Buffer): The output buffer
         dim (int): The dimension to perform reduce on
         batch (int): Number of output elements per batched AllReduce call (default 1).
+        annotations (dict, optional): On CUDA SM100+, set
+            ``{"enable_fadd2": False}`` to disable packed FP32x2 accumulation
+            for this reduction. It is enabled by default.
 
     Returns:
         tirx.Call: Handle to the reduction operation


### PR DESCRIPTION
## Summary

- Add a CUDA-only `enable_fadd2` reduce annotation so individual FP32 sum and absolute-sum reductions can opt out of packed FP32x2 accumulation.
- Keep packed accumulation enabled by default, preserving the existing behavior and its wins for issue-bound kernels.
- Keep the common reduce IR backend-neutral: it stores opaque annotations, while the CUDA reduce implementation interprets `enable_fadd2`.

## Motivation and observations

FP32x2 reducers on SM100+ can combine two independent FP32 additions into one packed instruction. This primarily reduces dynamic instruction and warp-scheduler issue pressure: two scalar FADD instructions need two issue opportunities, while the packed form can produce both lane results from one issued instruction. It does not reduce the number of scalar results being computed, the reduction synchronization, or memory traffic.

The optimization is therefore useful, but it is not universally profitable. During the regression investigation we observed the following:

- Restoring the register-count layout cost model removed the broader layout-related changes, but one representative RMSNorm backward kernel still ran at 20.1 us versus a 16.0 us baseline (1.26x slower).
- Comparing the earlier scalar code generation with the FP32x2 reducer path isolated the packed reduction as the important remaining difference.
- In that kernel, selecting packed FP32x2 accumulation increased register allocation from 64 to 72 registers per thread. That crossed an occupancy boundary and reduced the resident parallelism available to hide latency; the occupancy loss was larger than the issue-slot saving.
- Other kernels and focused instruction-throughput experiments showed the opposite result: when issue pressure is the bottleneck and register allocation does not cross an occupancy boundary, FADD2 can improve latency by roughly 15%.

This makes a global enable/disable policy undesirable. A `min_blocks_per_sm`/launch-bounds hint was also not a reliable fix: it constrains allocation but does not remove the extra packed temporaries or shorter live-range opportunities, and can lead to a different trade-off rather than restoring the scalar allocation. Rewriting application kernels or changing tile sizes can work case by case, but is too application-specific for this compiler behavior.

A fully automatic decision would need to account for reduction structure, register liveness/allocation granularity, occupancy thresholds, synchronization, and whether the kernel is issue-bound. Until that information is available in a sufficiently reliable profitability model, a per-reduction annotation provides a narrow escape hatch without giving up the default optimization.

## Changes

- Preserve reduce call annotations on `ReduceOpNode` as an opaque map.
- Pass the complete reduce op to backend vector-width selection instead of exposing a CUDA-specific flag in the common reducer.
- Parse `enable_fadd2` only in the CUDA reduce implementation.
- For SM100+ FP32 `sum` and `abssum`, select scalar width when the annotation is false.
- Apply the opt-out to both local packed accumulation and packed batched AllReduce lowering.
- Document the CUDA-specific control:

  ```python
  T.reduce_sum(
      src,
      dst,
      dim=1,
      annotations={"enable_fadd2": False},
  )
  ```

The annotation does not affect:

- FP16/BF16 packed reductions;
- FP32 `max`, `min`, or `absmax` packed reducers;
- explicit `T.add2` calls;
- ROCm or CPU lowering.

## Validation

- `./format.sh`
- `cmake --build build -j32`
- `python -m pytest testing/python/cuda/test_cuda_f32x2_intrinsics.py -q` (`94 passed`)
- `git diff --check`

The tests cover default packed code generation, scalar fallback for FP32 sum/abssum, batched reduction fallback, preservation of FP32 max2, and numerical correctness of the opt-out path.

## Risk

The default remains enabled, so existing kernels retain their current lowering. Opting out deliberately changes the local reduction association from packed pairwise accumulation to scalar accumulation, which can produce the usual small floating-point rounding differences. This change does not attempt to introduce an automatic FADD2 profitability model.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Adds the CUDA-only `enable_fadd2` annotation for individual FP32 `sum` and `abssum` reductions.

- Packed FP32x2 accumulation remains enabled by default.
- `annotations={"enable_fadd2": False}` selects scalar accumulation.
- The option affects local packed accumulation and packed batched AllReduce lowering on SM100+.
- Other data types, reducers, targets, and explicit `T.add2` remain unchanged.
- Common reduction IR preserves annotations without interpreting them.

## Testing

- Added CUDA code-generation tests for scalar accumulation.
- Added correctness tests for FP32 sum and absolute-sum reductions.
- Ran formatting, build checks, 94 CUDA intrinsic tests, and diff checks.
- Documented potential floating-point rounding differences.

## C++ style / lint notes

- The PR changes C++ reduction lowering, but it does not change rules documented in `docs/developer_guide/cpp_style.md`.
- The existing **C++ API Style Audit (warning only)** remains applicable.
- No correctness or build issues are identified. Advisory style warnings should not block merge unless they indicate a new API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->