### PR TITLE
[CodeGen][ROCm] Emit #line directives for HIP target

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -58,6 +58,18 @@ inline bool Vectorize256Disabled() {
       .value_or(Bool(false));
 }
 
+/*!
+ * \brief Check if ``#line`` directive emission from TIR source spans is
+ * enabled. When on, C-family codegen maps generated statements back to
+ * their Python source lines via ``#line N "file"`` (consumed by the
+ * CodeGenCWithLineDirectives builders).
+ */
+inline bool EmitLineDirectivesEnabled() {
+  auto ctxt = tvm::transform::PassContext::Current();
+  return ctxt->GetConfig("tl.emit_line_directives", ffi::Optional<Bool>())
+      .value_or(Bool(false));
+}
+
 } // namespace tl_config
 } // namespace tl
 } // namespace tvm

--- a/src/cpu/codegen/rt_mod_c.cc
+++ b/src/cpu/codegen/rt_mod_c.cc
@@ -1,9 +1,8 @@
 #include "codegen_c.h"
-#include "op/builtin.h"
+#include "config.h"
 #include "support/check.h"
 #include <tvm/ffi/extra/module.h>
 #include <tvm/ir/cast.h>
-#include <tvm/ir/transform.h>
 
 namespace tvm {
 namespace codegen {
@@ -28,10 +27,7 @@ Module BuildTileLangC(IRModule mod, Target target) {
   cg.Init(output_ssa, emit_asserts, emit_fwd_func_decl, target->str(), devices);
   cg.SetConstantsByteAlignment(
       target->GetAttr<Integer>("constants-byte-alignment").value_or(16));
-  cg.SetEmitLineDirectives(
-      tvm::transform::PassContext::Current()
-          ->GetConfig<Bool>(tl::kEmitLineDirectives, Bool(false))
-          .value());
+  cg.SetEmitLineDirectives(tl::tl_config::EmitLineDirectivesEnabled());
 
   auto is_aot_executor_fn = [](const PrimFunc &func) -> bool {
     return func->GetAttr<Bool>("runner_function", Bool(false)).value();

--- a/src/cuda/codegen/rt_mod_cuda.cc
+++ b/src/cuda/codegen/rt_mod_cuda.cc
@@ -1,4 +1,5 @@
 #include "codegen_cuda.h"
+#include "config.h"
 #include "op/builtin.h"
 #include "runtime/pack_args.h"
 #include "runtime/thread_storage_scope.h"
@@ -99,10 +100,7 @@ Module BuildTileLangCUDA(IRModule mod, Target target) {
   bool output_ssa = false;
   CodeGenTileLangCUDA cg;
   cg.Init(output_ssa);
-  cg.SetEmitLineDirectives(
-      tvm::transform::PassContext::Current()
-          ->GetConfig<Bool>(tl::kEmitLineDirectives, Bool(false))
-          .value());
+  cg.SetEmitLineDirectives(tl::tl_config::EmitLineDirectivesEnabled());
 
   ValidateUniqueDeviceGlobalSymbols(mod);
   if (const auto f = Function::GetGlobal("tilelang_callback_cuda_validate")) {
@@ -146,10 +144,7 @@ Module BuildTileLangCUDAWithoutCompile(IRModule mod, Target target) {
   bool output_ssa = false;
   CodeGenTileLangCUDA cg;
   cg.Init(output_ssa);
-  cg.SetEmitLineDirectives(
-      tvm::transform::PassContext::Current()
-          ->GetConfig<Bool>(tl::kEmitLineDirectives, Bool(false))
-          .value());
+  cg.SetEmitLineDirectives(tl::tl_config::EmitLineDirectivesEnabled());
 
   ValidateUniqueDeviceGlobalSymbols(mod);
   if (const auto f = Function::GetGlobal("tilelang_callback_cuda_validate")) {

--- a/src/rocm/codegen/codegen_hip.h
+++ b/src/rocm/codegen/codegen_hip.h
@@ -14,12 +14,12 @@
 #include <string>
 #include <unordered_map>
 
-#include "target/source/codegen_c.h"
+#include "backend/common/codegen/codegen_c_line_directives.h"
 
 namespace tvm {
 namespace codegen {
 
-class CodeGenTileLangHIP final : public CodeGenC {
+class CodeGenTileLangHIP final : public CodeGenCWithLineDirectives {
 public:
   CodeGenTileLangHIP();
   std::string Finish();

--- a/src/rocm/codegen/rt_mod_hip.cc
+++ b/src/rocm/codegen/rt_mod_hip.cc
@@ -7,6 +7,7 @@
 #include <hip/hip_runtime.h>
 
 #include "codegen_hip.h"
+#include "config.h"
 #include "runtime/pack_args.h"
 #include "target/rocm/rocm_fallback_module.h"
 
@@ -60,6 +61,7 @@ Module BuildTileLangHIP(IRModule mod, Target target) {
   CodeGenTileLangHIP cg;
   cg.Init(output_ssa);
   cg.SetTarget(target);
+  cg.SetEmitLineDirectives(tl::tl_config::EmitLineDirectivesEnabled());
 
   for (auto kv : mod->functions) {
     ICHECK(kv.second->IsInstance<PrimFuncNode>())
@@ -100,6 +102,7 @@ Module BuildTileLangHIPWithoutCompile(IRModule mod, Target target) {
   CodeGenTileLangHIP cg;
   cg.Init(output_ssa);
   cg.SetTarget(target);
+  cg.SetEmitLineDirectives(tl::tl_config::EmitLineDirectivesEnabled());
 
   for (auto kv : mod->functions) {
     ICHECK(kv.second->IsInstance<PrimFuncNode>())

--- a/testing/python/transform/test_tilelang_codegen_line_directives.py
+++ b/testing/python/transform/test_tilelang_codegen_line_directives.py
@@ -32,6 +32,13 @@ def vec_add_cuda(A: T.Tensor((N,), "float32"), B: T.Tensor((N,), "float32")):
             B[bx * N + i] = A[bx * N + i] + 1.0  # line_marker_store_cuda
 
 
+@T.prim_func
+def vec_add_hip(A: T.Tensor((N,), "float32"), B: T.Tensor((N,), "float32")):
+    with T.Kernel(1, threads=N) as bx:
+        for i in T.Parallel(N):
+            B[bx * N + i] = A[bx * N + i] + 1.0  # line_marker_store_hip
+
+
 def _lowered_source(func, emit: bool) -> str:
     # target is not passed to lower() explicitly: it resolves through
     # determine_target("auto") reading the ambient Target("c") context.
@@ -98,6 +105,20 @@ def test_line_directives_cuda_source():
     assert source is not None, "CUDA codegen produced no kernel source"
     directives = _line_directives(source)
     store_line = _marker_line("line_marker_store_cuda")
+    assert (store_line, __file__) in directives, f"store line {store_line} not mapped; directives: {directives}\n{source}"
+
+
+@tilelang.testing.requires_rocm
+def test_line_directives_hip_source():
+    """HIP source (compile-only path, no GPU/hipcc) also maps statements."""
+    target = {"kind": "hip"}
+    config = {tilelang.PassConfigKey.TL_EMIT_LINE_DIRECTIVES: True}
+    with tvm.transform.PassContext(opt_level=3, config=config), tvm.target.Target(target):
+        artifact = tilelang.lower(vec_add_hip, target=target)
+    source = artifact.kernel_source
+    assert source is not None, "HIP codegen produced no kernel source"
+    directives = _line_directives(source)
+    store_line = _marker_line("line_marker_store_hip")
     assert (store_line, __file__) in directives, f"store line {store_line} not mapped; directives: {directives}\n{source}"
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Added `tl::tl_config::EmitLineDirectivesEnabled()` to read `tl.emit_line_directives`, with a default value of `false`.
- Updated CPU, CUDA, and HIP code generation to use this configuration.
- Made HIP code generation inherit from `CodeGenCWithLineDirectives`.
- Added a ROCm-gated test that verifies HIP line directives map generated statements to Python source lines without requiring a GPU or `hipcc`.

## C++ style / lint notes

- This PR changes C++ code and adds a public inline function in `src/config.h`.
- The PR does not change `docs/developer_guide/cpp_style.md`.
- Review the “C++ API Style Audit (warning only)” CI step for advisory findings.
- Any TLCPP003/TLCPP004 findings are warning-only unless they indicate a clear API, FFI, or maintainability risk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->